### PR TITLE
ci: rust-cache를 hosted 전용으로 게이트 — 공유 ~/.cargo/bin 파괴 사고 정정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,7 +468,11 @@ jobs:
 
       # [#2393] 수동 restore/save 캐시 → rust-cache (적중률·정리 자동화).
       # 저장 정책은 종전과 동일하게 devel/main push 로 한정.
+      # [#3289] self-hosted 는 공유 ~/.cargo + 러너별 _work target 이 자연 캐시라 제외.
+      # rust-cache 의 save 전 정리가 공유 ~/.cargo/bin 의 cargo-nextest 를 삭제하는
+      # 사고 실측 (devel push run 30145509799, "Cleaning cargo/bin").
       - name: Rust build cache
+        if: runner.environment == 'github-hosted'
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: test-archive
@@ -653,7 +657,9 @@ jobs:
           components: clippy, rustfmt
           targets: wasm32-unknown-unknown
 
+      # [#3289] self-hosted 제외 — 공유 ~/.cargo/bin 파괴 사고 (build-test-archive 주석 참조)
       - name: Rust build cache
+        if: runner.environment == 'github-hosted'
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: lint
@@ -719,7 +725,9 @@ jobs:
       # [#2431 C] 기본 test job 의 rust-cache 이행 후 writer가 사라진
       # Linux-cargo-* namespace 대신 Native Skia 전용 shared key를 사용한다.
       # PR은 restore-only, devel/main push만 save하는 신뢰 경계를 유지한다.
+      # [#3289] self-hosted 제외 — 공유 ~/.cargo/bin 파괴 사고 (build-test-archive 주석 참조)
       - name: Rust build cache
+        if: runner.environment == 'github-hosted'
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: native-skia

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -264,10 +264,15 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # [#3289] CodeQL 은 가용 RAM 대부분을 힙으로 잡는다 — 공유 self-hosted 호스트에서
+      # 분석 2개 동시 실행 시 JVM 이 각각 40~55GB 를 점유해 호스트 100GB 를 포화시킨
+      # 사고 실측(2026-07-25 htop). 호스티드(16GB VM)와 동급으로 캡한다.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+          ram: 12288
+          threads: 16
 
       - name: Install Rust toolchain
         if: matrix.language == 'rust'

--- a/mydocs/report/task_m100_3289_report.md
+++ b/mydocs/report/task_m100_3289_report.md
@@ -57,6 +57,11 @@
 
 - **공유 홈 원칙**: 잡 단위 툴 설치 액션 금지(레이스). 툴은 호스트에 1회 설치가 정본.
   현재 상주: rustup/cargo(1.93.1), cargo-nextest 0.9.140, node v24.18.0(nvm).
+- **공유 홈을 변형하는 캐시 액션 금지**: Swatinem/rust-cache 는 save 전 정리로 공유
+  `~/.cargo/bin` 의 상주 툴(cargo-nextest)을 삭제하고 registry 를 prune 한다 — devel push
+  첫 save 에서 실측(run 30145509799, "Cleaning cargo/bin"). rust-cache 는
+  `runner.environment == 'github-hosted'` 게이트 필수. 캐시 저장 쿼터도 read-only 상태라
+  self-hosted 에선 이득이 없다.
 - **Rust 툴체인 버전 범프 절차**: CI 의 toolchain 값을 올리기 전에 호스트에서
   `rustup toolchain install <ver>` 선행 — 동시 잡의 자동 설치 레이스 방지.
 - **러너 설정 파일**: `.path` 는 한 줄 콜론 결합(nvm bin + 시스템 + `/home/app/.cargo/bin`),

--- a/mydocs/report/task_m100_3289_report.md
+++ b/mydocs/report/task_m100_3289_report.md
@@ -62,6 +62,10 @@
   첫 save 에서 실측(run 30145509799, "Cleaning cargo/bin"). rust-cache 는
   `runner.environment == 'github-hosted'` 게이트 필수. 캐시 저장 쿼터도 read-only 상태라
   self-hosted 에선 이득이 없다.
+- **RAM 자동 감지 도구는 캡 필수**: CodeQL 은 가용 RAM 대부분을 힙으로 잡아, 분석 2개
+  동시 실행 시 JVM 각각 40~55GB → 호스트 100GB 포화·스톨 실측(2026-07-25, swap 512M).
+  호스티드에서 무해했던 건 16GB VM 이라 힙이 작게 잡혔기 때문. codeql-action init 에
+  `ram: 12288`/`threads: 16` 캡. 같은 유형(가용 자원 전체를 잡는 도구) 도입 시 동일 점검.
 - **Rust 툴체인 버전 범프 절차**: CI 의 toolchain 값을 올리기 전에 호스트에서
   `rustup toolchain install <ver>` 선행 — 동시 잡의 자동 설치 레이스 방지.
 - **러너 설정 파일**: `.path` 는 한 줄 콜론 결합(nvm bin + 시스템 + `/home/app/.cargo/bin`),


### PR DESCRIPTION
## 배경

#3286 merge 후 첫 devel push run(30145509799)에서 `Build test archive`가 `no such command: nextest`로 실패했다. Lint 잡의 rust-cache post 스텝(devel push라 처음으로 save 경로 진입)이 **'Cleaning cargo/bin'으로 공유 홈 `~/.cargo/bin`의 cargo-nextest를 삭제**한 것이 원인이다 (05:20:02 삭제 → 05:21:03 시작한 archive 잡 실패, 로그 실측). 캐시 저장 자체도 쿼터 초과(read-only)로 실패해 이득 없이 파괴만 일어났다. PR run은 restore-only라 이 경로가 잠복해 있었다.

## 변경

- ci.yml rust-cache 3곳(lint·build-test-archive·native-skia)에 `if: runner.environment == 'github-hosted'` 게이트 — self-hosted는 공유 `~/.cargo` + 러너별 `_work` target이 자연 캐시라 rust-cache가 불필요하다
- 거버넌스 보고서(task_m100_3289_report.md)에 '공유 홈을 변형하는 캐시 액션 금지' 규칙 추가

## 조치 완료 (인프라)

- 호스트에 cargo-nextest 0.9.140 재설치 완료

## 검증 계획

- 이 PR CI green 확인 → squash merge → devel 실패 run 재실행으로 green 복구 확인

관련: #3289 (거버넌스), run 30145509799 (사고 실측)

🤖 Generated with [Claude Code](https://claude.com/claude-code)