### PR TITLE
ci: CodeQL·Render Diff 호스티드 재배치 — CI만 self-hosted 유지

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ concurrency:
 jobs:
   preflight:
     name: CodeQL preflight
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read
@@ -248,7 +248,7 @@ jobs:
 
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     needs: preflight
     if: ${{ always() && needs.preflight.outputs.fast_pass != 'true' }}
@@ -264,15 +264,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # [#3289] CodeQL 은 가용 RAM 대부분을 힙으로 잡는다 — 공유 self-hosted 호스트에서
-      # 분석 2개 동시 실행 시 JVM 이 각각 40~55GB 를 점유해 호스트 100GB 를 포화시킨
-      # 사고 실측(2026-07-25 htop). 호스티드(16GB VM)와 동급으로 캡한다.
+      # [#3290] 호스티드 16GB VM 은 CodeQL 자동 감지 값이 적정하다. self-hosted 로
+      # 되돌릴 경우 ram/threads 캡 필수 — #3289 사고(무캡 JVM 40~55GB×2 로 호스트
+      # 포화·스톨) 및 task_m100_3289_report.md 거버넌스 절 참조.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          ram: 12288
-          threads: 16
 
       - name: Install Rust toolchain
         if: matrix.language == 'rust'

--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -61,7 +61,7 @@ concurrency:
 jobs:
   preflight:
     name: Render Diff preflight
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       actions: read
@@ -300,7 +300,7 @@ jobs:
 
   canvas-visual-diff:
     name: Canvas visual diff
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     needs: preflight
     if: ${{ always() && needs.preflight.outputs.fast_pass != 'true' }}


### PR DESCRIPTION
Closes #3290

## 변경

- `codeql.yml`(preflight·analyze)·`render-diff.yml`(preflight·canvas-visual-diff) 4개 job을 `ubuntu-latest`로 복귀 — CI(ci.yml 13 job)와 full-renderer-sweep만 self-hosted 플릿 유지
- CodeQL `ram: 12288/threads: 16` 캡 제거 — 호스티드 16GB VM은 자동 감지가 적정값. self-hosted 복귀 시 캡 필수를 주석으로 남김(#3289 사고 실측 참조)
- `runner.environment` 분기는 그대로 유지해 양방향 이식성 보존

## 배경

작업지시자 지시: 호스트(70코어·회선 1개) 동시 부하 분산 — PR 하나가 CI+CodeQL+RD를 전부 한 호스트에서 소화하던 것을 분리. #3289 메모리 포화 사고(무캡 CodeQL JVM 2개×40~55GB)의 구조적 재발 방지이기도 하다.

## 검증

- 이 PR의 CodeQL·Render Diff가 호스티드에서, CI가 self-hosted에서 각각 green인지 확인 후 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)