### PR TITLE
ci: dtolnay rust-toolchain hosted 게이트 — 공유 ~/.rustup settings.toml 레이스 정정

### DIFF
--- a/.github/actions/install-wasm-pack/action.yml
+++ b/.github/actions/install-wasm-pack/action.yml
@@ -13,14 +13,25 @@ runs:
         set -euo pipefail
         # [#2233] 버전 변경은 여기 한 곳 + Dockerfile 만 갱신한다.
         WASM_PACK_VERSION=0.15.0
-        TARBALL="wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl"
-        URL="https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/${TARBALL}.tar.gz"
-        curl -sSfL "$URL" | tar -xzf - -C /tmp
-        # [#3284] sudo 없이 사용자 경로(~/.cargo/bin)에 배치 — self-hosted 러너의
-        # 제한된 sudo(apt 한정)와 호스티드 러너 양쪽에서 동일하게 동작한다.
-        # dtolnay/rust-toolchain 이 이미 PATH 에 넣지만 self-hosted 안전을 위해 명시 추가.
         install_dir="${HOME}/.cargo/bin"
-        mkdir -p "$install_dir"
-        mv "/tmp/${TARBALL}/wasm-pack" "$install_dir/wasm-pack"
+        # [#3289] self-hosted 20 러너는 ~/.cargo/bin 을 공유한다 — 매 잡 무조건 설치는
+        # 동시 잡의 mv 교체 레이스가 되므로, 핀 버전이 이미 있으면 건너뛴다.
+        if command -v wasm-pack >/dev/null 2>&1 \
+          && [[ "$(wasm-pack --version)" == "wasm-pack ${WASM_PACK_VERSION}" ]]; then
+          echo "wasm-pack ${WASM_PACK_VERSION} already installed — skip"
+        else
+          TARBALL="wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl"
+          URL="https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/${TARBALL}.tar.gz"
+          # [#3289] 고정 /tmp 경로는 동시 잡 간 전개 충돌 — mktemp 로 격리하고,
+          # 설치는 같은 디렉터리 임시명 → rename(원자적 교체)으로 부분 바이너리 노출을 막는다.
+          tmpdir="$(mktemp -d)"
+          curl -sSfL "$URL" | tar -xzf - -C "$tmpdir"
+          # [#3284] sudo 없이 사용자 경로(~/.cargo/bin)에 배치 — self-hosted 러너의
+          # 제한된 sudo(apt 한정)와 호스티드 러너 양쪽에서 동일하게 동작한다.
+          mkdir -p "$install_dir"
+          mv "$tmpdir/${TARBALL}/wasm-pack" "$install_dir/wasm-pack.tmp.$$"
+          mv -f "$install_dir/wasm-pack.tmp.$$" "$install_dir/wasm-pack"
+          rm -rf "$tmpdir"
+        fi
         echo "$install_dir" >> "$GITHUB_PATH"
         "$install_dir/wasm-pack" --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -743,7 +743,10 @@ jobs:
           shared-key: native-skia
           save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/main') }}
 
+      # [#3289] self-hosted 는 호스트에 선설치됨 — 동시 잡의 apt/dpkg 락 경합 방지.
+      # 신규 시스템 패키지는 호스트 선설치가 정본 (거버넌스 보고서 참조).
       - name: Install native Skia runtime packages
+        if: runner.environment == 'github-hosted'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -791,8 +794,11 @@ jobs:
       - name: Install wasm-pack
         uses: ./.github/actions/install-wasm-pack
 
+      # [#3289] self-hosted 제외 — restore 의 tar 전개가 공유 ~/.cargo/registry 를
+      # 락 없이 덮어써 동시 cargo 빌드와 충돌한다. 상주 registry + _work target 이 자연 캐시.
       - name: Restore frontend WASM cargo cache
         id: frontend_wasm_cargo_cache_restore
+        if: runner.environment == 'github-hosted'
         uses: actions/cache/restore@v5
         with:
           path: |
@@ -856,8 +862,9 @@ jobs:
       - name: Verify font asset contracts
         run: node --test scripts/frontend-font-assets.test.mjs
 
+      # [#3289] self-hosted 제외 — 공유 ~/.cargo tar 저장은 무익(쿼터 read-only)하고 거대하다.
       - name: Save frontend WASM cargo cache
-        if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/main') && steps.frontend_wasm_cargo_cache_restore.outputs.cache-hit != 'true' }}
+        if: ${{ runner.environment == 'github-hosted' && github.event_name == 'push' && (github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/main') && steps.frontend_wasm_cargo_cache_restore.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v5
         with:
           path: |
@@ -1017,7 +1024,9 @@ jobs:
       - name: Install wasm-pack
         uses: ./.github/actions/install-wasm-pack
 
+      # [#3289] self-hosted 제외 — 공유 ~/.cargo 락 없는 tar 전개/저장 금지 (frontend 주석 참조).
       - name: Cache cargo registry & build
+        if: runner.environment == 'github-hosted'
         uses: actions/cache@v5
         with:
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,6 +453,10 @@ jobs:
           df -h
 
       - name: Install Rust toolchain
+        # [#3289] dtolnay 액션의 rustup default 가 매 잡마다 공유 ~/.rustup/settings.toml 을
+        # 다시 써 동시 잡 레이스로 파일이 깨진다(실측: version 필드 소실). self-hosted 는
+        # 호스트 rustup + rust-toolchain.toml 디렉터리 override 로 충분하므로 hosted 전용.
+        if: runner.environment == 'github-hosted'
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.93.1
@@ -566,6 +570,8 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
+        # [#3289] 공유 ~/.rustup settings.toml 레이스 방지 — 첫 사용처 주석 참조.
+        if: runner.environment == 'github-hosted'
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.93.1
@@ -651,6 +657,8 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
+        # [#3289] 공유 ~/.rustup settings.toml 레이스 방지 — 첫 사용처 주석 참조.
+        if: runner.environment == 'github-hosted'
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.93.1
@@ -718,6 +726,8 @@ jobs:
           df -h
 
       - name: Install Rust toolchain
+        # [#3289] 공유 ~/.rustup settings.toml 레이스 방지 — 첫 사용처 주석 참조.
+        if: runner.environment == 'github-hosted'
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.93.1
@@ -771,6 +781,8 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
+        # [#3289] 공유 ~/.rustup settings.toml 레이스 방지 — 첫 사용처 주석 참조.
+        if: runner.environment == 'github-hosted'
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.93.1
@@ -995,6 +1007,8 @@ jobs:
           df -h
 
       - name: Install Rust toolchain
+        # [#3289] 공유 ~/.rustup settings.toml 레이스 방지 — 첫 사용처 주석 참조.
+        if: runner.environment == 'github-hosted'
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.93.1

--- a/.github/workflows/full-renderer-sweep.yml
+++ b/.github/workflows/full-renderer-sweep.yml
@@ -39,7 +39,9 @@ jobs:
       - name: Install wasm-pack
         uses: ./.github/actions/install-wasm-pack
 
+      # [#3289] self-hosted 제외 — 공유 ~/.cargo 락 없는 tar 전개/저장 금지 (ci.yml 주석 참조).
       - name: Cache cargo registry & build
+        if: runner.environment == 'github-hosted'
         uses: actions/cache@v5
         with:
           path: |
@@ -58,7 +60,9 @@ jobs:
           cache: npm
           cache-dependency-path: rhwp-studio/package-lock.json
 
+      # [#3289] self-hosted 는 호스트에 선설치됨(2026-07-25) — apt/dpkg 락 경합 방지.
       - name: Install font packages
+        if: runner.environment == 'github-hosted'
         run: |
           sudo apt-get update
           sudo apt-get install -y fonts-noto-cjk fonts-noto-core fonts-noto-mono fonts-nanum libfontconfig1-dev libfreetype6-dev

--- a/.github/workflows/full-renderer-sweep.yml
+++ b/.github/workflows/full-renderer-sweep.yml
@@ -27,6 +27,10 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
+        # [#3289] dtolnay 액션의 rustup default 가 매 잡마다 공유 ~/.rustup/settings.toml 을
+        # 다시 써 동시 잡 레이스로 파일이 깨진다(실측: version 필드 소실). self-hosted 는
+        # 호스트 rustup + rust-toolchain.toml 디렉터리 override 로 충분하므로 hosted 전용.
+        if: runner.environment == 'github-hosted'
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt

--- a/mydocs/report/task_m100_3289_report.md
+++ b/mydocs/report/task_m100_3289_report.md
@@ -66,6 +66,31 @@
   동시 실행 시 JVM 각각 40~55GB → 호스트 100GB 포화·스톨 실측(2026-07-25, swap 512M).
   호스티드에서 무해했던 건 16GB VM 이라 힙이 작게 잡혔기 때문. codeql-action init 에
   `ram: 12288`/`threads: 16` 캡. 같은 유형(가용 자원 전체를 잡는 도구) 도입 시 동일 점검.
+  (이후 #3290 으로 CodeQL·Render Diff 가 호스티드 복귀 — self-hosted 재배치 시 캡 필수.)
+
+## 동시 쓰기 레이스 전수 점검 (2026-07-25, 작업지시자 지시)
+
+self-hosted 워크플로(ci.yml·full-renderer-sweep.yml)의 공유 상태 쓰기 경로 전수 점검 결과.
+
+**정정한 잡 단위 쓰기 (전부 hosted 게이트 또는 무해화):**
+
+| 쓰기 경로 | 결함 | 정정 |
+|---|---|---|
+| dtolnay rust-toolchain 7곳 | `rustup default` 가 매 잡 `~/.rustup/settings.toml` 재작성 → 동시 잡에 파일 파손 실측 | hosted 게이트, self-hosted 는 rust-toolchain.toml override |
+| taiki-e nextest 2곳 | 공유 `~/.cargo/bin` 동시 mv 교체 실측 | hosted 게이트 + 호스트 상주 설치 |
+| Swatinem/rust-cache 3곳 | save 전 정리가 공유 bin·registry 파괴 실측 | hosted 게이트 |
+| install-wasm-pack composite | 고정 /tmp 전개 충돌 + 공유 bin 무조건 mv | 핀 버전 존재 시 skip + mktemp + 동일 디렉터리 rename(원자 교체) |
+| actions/cache 3곳 (frontend·release wasm·sweep) | restore 의 tar 전개가 공유 `~/.cargo/registry` 를 락 없이 덮어씀 | hosted 게이트 |
+| apt-get 2곳 (native-skia·sweep 폰트) | 동시 잡 dpkg 락 경합 | hosted 게이트, 패키지는 호스트 선설치(sweep 폰트 포함, 2026-07-25) |
+
+**점검 후 안전 판정 (설계상 동시성 안전):**
+
+- cargo 자체의 `~/.cargo/registry`·`git` 접근 — cargo 내장 flock 으로 직렬화
+- npm 의 `~/.npm` — cacache 가 동시 접근 안전 설계
+- `artifact-cache` 호스트 캐시 — tmp+mv 원자 쓰기, prune 은 24h 경과 dir 만 + 오류 무시
+- setup-node 툴 캐시 — 러너별 `_work/_tool` (공유 아님)
+- `GITHUB_OUTPUT`/`GITHUB_PATH`/`GITHUB_ENV` — 잡별 임시 파일
+- rustup 툴체인 자동 설치 — 평상시 no-op, 버전 범프 시 호스트 선설치 절차로 회피(위 규칙)
 - **Rust 툴체인 버전 범프 절차**: CI 의 toolchain 값을 올리기 전에 호스트에서
   `rustup toolchain install <ver>` 선행 — 동시 잡의 자동 설치 레이스 방지.
 - **러너 설정 파일**: `.path` 는 한 줄 콜론 결합(nvm bin + 시스템 + `/home/app/.cargo/bin`),


### PR DESCRIPTION
## 배경

fix/2813 PR CI(run 30147842082, runner-lxc-06)에서 `could not parse settings file: ~/.rustup/settings.toml` 실패. dtolnay/rust-toolchain이 매 잡마다 실행하는 `rustup default 1.93.1`이 **공유 `~/.rustup/settings.toml`을 매번 재작성**하므로, 동시 잡이 겹치면 파일이 잘린다(실측: `version` 필드 소실, 잔여 102바이트). #3289 공유 홈 레이스 계열의 마지막 쓰기 경로다.

## 변경

- dtolnay/rust-toolchain 스텝 7곳(ci.yml 6 + full-renderer-sweep.yml 1)에 `if: runner.environment == 'github-hosted'` 게이트
- self-hosted는 호스트 rustup + `rust-toolchain.toml`(1.93.1 + clippy/rustfmt + wasm32 target 핀) 디렉터리 override로 툴체인이 해석되고, `.path`에 `~/.cargo/bin`이 있어 PATH도 확보됨 — 잡 단위 rustup 상태 쓰기가 사라진다

## 조치 완료 (인프라)

- 호스트 `settings.toml` 복구(version 필드 복원), `rustup show active-toolchain` 정상 확인

## 검증

- 이 PR CI green 확인 후 merge. merge 후 fix/2813 PR은 CI 재실행으로 정상화(pull_request merge ref가 갱신된 devel 워크플로를 사용).

관련: #3289 거버넌스(task_m100_3289_report.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)