### PR TITLE
ci: shard nextest 스레드 self-hosted 8 캡 — 다중 run CPU 기아 flake 정정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,6 +612,13 @@ jobs:
       - name: Run shard ${{ matrix.shard }}/8
         run: |
           set -o pipefail
+          # [#3289] self-hosted 20 러너는 70코어 한 호스트를 공유한다. nextest 기본
+          # 스레드(=코어 수 70)로는 다중 run 폭주 시 20잡×70=1400 스레드가 경쟁해
+          # 벽시계 상한 테스트가 CPU 기아로 flake 한다 (PR #3288 shard 8 실측:
+          # issue_2833 상한 초과). 8 스레드 캡 — 단일 run 8shard×8=64≈70코어 정합.
+          if [[ "${RUNNER_ENVIRONMENT}" != "github-hosted" ]]; then
+            export NEXTEST_TEST_THREADS=8
+          fi
           # --extract-to . : CLI 테스트의 env!("CARGO_BIN_EXE_rhwp") 는 빌드
           # 러너 절대 경로가 컴파일 타임에 박힌다. GitHub 러너는 job 간
           # workspace 경로가 동일하므로 워크스페이스에 풀어 target/ 경로를

--- a/mydocs/report/task_m100_3289_report.md
+++ b/mydocs/report/task_m100_3289_report.md
@@ -102,6 +102,11 @@ self-hosted 워크플로(ci.yml·full-renderer-sweep.yml)의 공유 상태 쓰�
   "Unable to clean → repository will be recreated" 로 자가 복구한다(재클론 ~30s). 조치 불요.
 - **네트워크**: 20 러너가 회선 1개 공유 — 대용량 아티팩트를 다수 잡이 동시 소비하는 설계는
   호스트 캐시 공유를 먼저 검토한다.
+- **CPU 공유와 시간 상한 테스트**: nextest 기본 스레드는 코어 수(70)라, 다중 run 폭주 시
+  20잡×70=1400 스레드가 70코어를 경쟁해 벽시계 상한 테스트가 CPU 기아로 flake 한다
+  (PR #3288 shard 실측: issue_2833 상한 초과). shard 잡은 self-hosted 에서
+  `NEXTEST_TEST_THREADS=8` 캡(단일 run 8shard×8=64≈70코어 정합, 폭주 시 ~2.3배 상한).
+  벽시계 상한을 단정하는 테스트 신설은 공유 CPU 환경의 간섭을 감안해 여유 배수를 둔다.
 
 ## 후속 후보
 


### PR DESCRIPTION
## 배경

kevin9327 PR 8개를 동시 재검증하자 shard 잡 최대 20개가 각각 nextest 기본 스레드(=코어 수 70)로 실행되어, 70코어 호스트에서 최대 1,400 스레드가 경쟁했다. 이 CPU 기아로 벽시계 상한 테스트 `issue_2833_hml_adapter_row_sizes`(row_sizes O(n) 회귀 가드)가 532ms로 상한을 넘겨 flake (PR #3288 run 30149513930 shard 8 실측). 호스티드는 shard마다 전용 4코어 VM이라 없던 간섭이다.

## 변경

- shard 잡 실행 시 self-hosted 에서만 `NEXTEST_TEST_THREADS=8` — 단일 run이면 8shard×8=64≈70코어로 정합, 다중 run 폭주 시에도 20잡×8=160(~2.3배)으로 상한. 호스티드는 기본값 유지.
- 거버넌스 보고서에 'CPU 공유와 시간 상한 테스트' 규칙 추가 (신설 시간 상한 테스트는 여유 배수 권고).

## 검증

- 이 PR CI green + shard 소요 시간 비교(단일 run 기준 저하 없어야 함) 후 merge.

관련: #3289

🤖 Generated with [Claude Code](https://claude.com/claude-code)