### PR TITLE
fix(hwp3): footnote_between_margin IR 배선 — 각주 전용 ×4, 한컴 변환 실측 근거 (#3032)

### DIFF
--- a/mydocs/report/task_m100_3032_report.md
+++ b/mydocs/report/task_m100_3032_report.md
@@ -1,0 +1,54 @@
+# Task #3032 — HWP3 footnote_between_margin IR 배선 (PR #3036 인수·보완 보고서)
+
+`Closes #3032`. kevin9327의 PR #3036 발견을 메인테이너가 인수해 적용처·스케일을 정정한 기록.
+
+## 경위
+
+- PR #3036: `doc_info` offset 108 "각주와 각주 사이의 간격"(`footnote_between_margin`)이
+  파싱만 되고 IR 미배선임을 발견, **미주(endnote_shape)** `raw_unknown` 에 raw 값 배선.
+- CI 실패: `issue_1692` PDF 쪽범위 골든(43쪽 마지막 미주 58→53). 메인테이너 시각 대조로
+  미주 간격이 벌어진 것을 확인. 기여자는 스펙·바이트·소비처 추적 코멘트 회신(성실 조사,
+  단 ×4 누락·적용처 판단이 실측과 상이).
+- 현 devel(#3225 시그니처 통일)과 CONFLICTING 상태이기도 하여 close+통합 경로로 인수.
+
+## 판정 근거 — 한컴 자체 변환이 정답지
+
+작업지시자 확인: `samples/SO-SUEOP.hwpx` 는 같은 .hwp 를 **한컴 편집기에서 열어 HWPX 로
+저장**한 파일 — 한컴 암묵지가 명시된 1차 권위 자료다. 실측:
+
+| HWPX | betweenNotes | aboveLine | belowLine |
+|---|---:|---:|---:|
+| footNotePr(각주) | **284** (=71×4) | 852 (=213×4) | 568 (=142×4) |
+| endNotePr(미주) | **0** | 864(기본) | 576(기본) |
+
+- **×4 확정**: HWP3 hunit → HWPUNIT 은 이웃 필드(#2772/#3054)와 동일한 ×4.
+- **적용처 확정**: offset 108 은 **각주 전용**. 미주는 0 — 원 PR 의 endnote 배선이 골든을
+  깬 이유가 이것이며, 실제로 endnote ×4(284) 배선 실험도 골든 red 를 재현했다.
+
+## 구현
+
+- `fixup` 의 section_def 조립부에서 `footnote_shape.raw_unknown =
+  footnote_between_margin.saturating_mul(4)` 배선 (`src/parser/hwp3/mod.rs`).
+- `hwp3_default_endnote_shape()` 는 raw_unknown 배선 없이 0 유지(사유 주석).
+- 단위 테스트 `issue_3032_footnote_between_margin_wires_footnote_shape_only`:
+  SO-SUEOP 실파싱으로 각주 284·미주 0 동시 검증.
+- 커밋 authorship 은 kevin9327 유지(인수 크레딧).
+
+## 검증
+
+- 단위 테스트 + `issue_1692` 골든 11/11 (HWP3·HWPX 양 포맷).
+- 전체 release-test **4005/4005**, fmt clean, Docker wasm 빌드 성공.
+- **시각 판정(작업지시자, 2026-07-25) 통과**: devel↔적용판 42·43쪽 픽셀 diff **0**
+  (2,005,644px 전수, native-skia scale 1.5 동일 폰트셋) — 미주 정답지 보존 증명.
+  각주 경로는 저장소 HWP3 샘플에 각주 문서가 없어 잠복(발화 시 한컴 오라클 값과 일치).
+
+## 파생 효과·발견
+
+- HWP↔HWPX 동일 문서의 studio 렌더 차이 한 축 해소(footnote betweenNotes 284=284 정합).
+- 시각 판정 중 별도 결함 2건 발견·등록: #3302(1쪽 그림 미표시), #3303(문단 테두리
+  '없음' 오렌더 — bde926e4b 연관 점검 필요).
+
+## 후속
+
+- PR #3036 은 본 통합 merge 후 검토 결과·크레딧 코멘트와 함께 close.
+- HWP3 각주 실문서 확보 시 각주 간격 시각 실측(작업지시자 한컴 제작 제안 유지).

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -544,6 +544,9 @@ fn hwp3_default_endnote_shape(doc_info: &Hwp3DocInfo) -> crate::model::footnote:
         separator_color: 0x00000000,
         numbering: FootnoteNumbering::Continue,
         placement: FootnotePlacement::EachColumn,
+        // doc_info offset 108(footnote_between_margin)은 미주에 배선하지 않는다 —
+        // 한컴 HWP3→HWPX 변환 실측(SO-SUEOP: endNotePr betweenNotes=0)과
+        // PDF 쪽범위 골든(issue_1692) 모두 미주 간격 0 을 요구한다 (#3032).
         ..Default::default()
     };
     shape.attr = shape.encode_attr();
@@ -3381,6 +3384,12 @@ pub fn parse_hwp3(data: &[u8]) -> Result<Document, Hwp3Error> {
         1
     };
     section_def.footnote_shape.separator_line_width = 1;
+    // [#3032] doc_info offset 108 "각주와 각주 사이의 간격"(footnote_between_margin)을
+    // footnote_shape.raw_unknown("주석 사이")에 hunit ×4 = HWPUNIT 변환으로 배선한다.
+    // 적용처·스케일 근거는 한컴 자체 HWP3→HWPX 변환 실측(SO-SUEOP.hwpx:
+    // footNotePr betweenNotes=284=71×4 / endNotePr betweenNotes=0) — 각주 전용이며
+    // 미주(endnote_shape)는 0 을 유지한다 (PR #3036 검토에서 적용처 정정).
+    section_def.footnote_shape.raw_unknown = doc_info.footnote_between_margin.saturating_mul(4);
 
     // [Task #877 Stage 4] HWP3 doc_info.border_type / border_margin → SectionDef.page_border_fill
     // 변환. HWP3 spec §3.2 (문서 정보) offset 112-121 의 페이지 테두리 정보. type=0 이면 없음,
@@ -4098,6 +4107,31 @@ mod tests {
             (ps.attr1 >> 28) & 1,
             1,
             "border_connection이 attr1 bit 28로 배선되어야 함"
+        );
+    }
+
+    #[test]
+    fn issue_3032_footnote_between_margin_wires_footnote_shape_only() {
+        // doc_info offset 108 "각주와 각주 사이의 간격"(footnote_between_margin)이 파싱만
+        // 되고 IR 에 배선되지 않던 문제 (#3032, PR #3036 kevin9327 발견). 적용처·스케일은
+        // 한컴 자체 HWP3→HWPX 변환 실측(SO-SUEOP.hwpx)이 정답지다:
+        //   footNotePr betweenNotes=284(=71×4) / endNotePr betweenNotes=0.
+        // 따라서 footnote_shape 에만 hunit ×4 로 배선하고 endnote_shape 는 0 을 유지한다.
+        let doc = crate::parser::hwp3::parse_hwp3(
+            &std::fs::read(concat!(env!("CARGO_MANIFEST_DIR"), "/samples/SO-SUEOP.hwp"))
+                .expect("SO-SUEOP.hwp 읽기"),
+        )
+        .expect("SO-SUEOP.hwp 파싱");
+        let section_def = &doc.sections[0].section_def;
+        assert_eq!(
+            section_def.footnote_shape.between_notes_margin_hu(),
+            284,
+            "각주 raw_unknown 은 71(hunit)×4 = 284(HWPUNIT) 이어야 한다"
+        );
+        assert_eq!(
+            section_def.endnote_shape.between_notes_margin_hu(),
+            0,
+            "미주 raw_unknown 은 한컴 endNotePr 실측대로 0 을 유지해야 한다"
         );
     }
 


### PR DESCRIPTION
## 요약

kevin9327의 PR #3036 발견을 인수·보완했습니다 (커밋 authorship 보존). `doc_info` offset 108 "각주와 각주 사이의 간격"(`footnote_between_margin`)이 파싱만 되고 IR에 배선되지 않던 문제의 정정판입니다.

## 원 PR 대비 정정 2가지 — 근거는 한컴 자체 변환 실측

작업지시자 확인대로 `samples/SO-SUEOP.hwpx`는 같은 .hwp를 한컴 편집기에서 열어 HWPX로 저장한 파일이라, 한컴 암묵지가 명시된 1차 권위 자료입니다:

| HWPX | betweenNotes | aboveLine | belowLine |
|---|---:|---:|---:|
| footNotePr(각주) | **284** (=71×4) | 852 (=213×4) | 568 (=142×4) |
| endNotePr(미주) | **0** | 864(기본) | 576(기본) |

1. **스케일**: HWP3 hunit → HWPUNIT **×4** (이웃 필드 #2772/#3054 관례와 동일; 원 PR은 raw 배선)
2. **적용처**: **각주(footnote_shape) 전용**, 미주는 0 유지 (원 PR의 endnote 배선은 PDF 쪽범위 골든 issue_1692를 깨는 것을 실측 재현 — 한컴 endNotePr=0과 정합)

## 검증

- 단위 테스트: SO-SUEOP 실파싱으로 각주 284·미주 0 동시 검증
- `issue_1692` 골든 11/11 (HWP3·HWPX 양 포맷), 전체 release-test **4005/4005**, fmt clean, Docker wasm 빌드 성공
- **작업지시자 시각 판정 통과**: devel↔적용판 42·43쪽 픽셀 diff **0** (2,005,644px 전수, native-skia scale 1.5 동일 폰트셋)
- 각주 경로는 저장소 HWP3 샘플에 각주 문서가 없어 시각 잠복 — 발화 시 한컴 오라클 값과 일치

## 파생

- 같은 문서의 HWP↔HWPX studio 렌더 차이 한 축 해소 (footnote betweenNotes 284=284)
- 시각 판정 중 별도 결함 2건 발견·등록: #3302(1쪽 그림 — skia 1bpp BMP placeholder 진단 완료), #3303(문단 테두리 '없음' 오렌더)

상세: `mydocs/report/task_m100_3032_report.md`

Closes #3032. merge 후 #3036은 검토 요약·크레딧과 함께 close 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)