### PR TITLE
ci: 문서 후속 기록의 직전 green PR head 재사용

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,15 @@ jobs:
               return parents.length === 2 && parents.some((parent) => parent.sha === baseSha);
             }
 
+            async function isCurrentBaseAncestor(candidateSha, baseSha) {
+              const { data: comparison } = await github.rest.repos.compareCommitsWithBasehead({
+                owner,
+                repo,
+                basehead: `${baseSha}...${candidateSha}`,
+              });
+              return comparison.status === 'ahead' || comparison.status === 'identical';
+            }
+
             function latestRun(runs) {
               return runs
                 .slice()
@@ -132,6 +141,74 @@ jobs:
                   const aTime = Date.parse(a.completed_at || a.started_at || a.created_at || 0);
                   return bTime - aTime;
                 })[0];
+            }
+
+            async function buildResult(candidateSha, pr) {
+              const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+                owner,
+                repo,
+                ref: candidateSha,
+                per_page: 100,
+              });
+              let source = 'check-run';
+              let buildRun = latestRun(checkRuns.filter((run) => (
+                run.name === 'Build & Test'
+                && run.app?.slug === 'github-actions'
+              )));
+
+              if (!buildRun) {
+                // Fork PRs can expose the aggregate only through Actions jobs. Keep the
+                // branch and exact candidate SHA identity guard for that fallback.
+                const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                  owner,
+                  repo,
+                  workflow_id: 'ci.yml',
+                  event: 'pull_request',
+                  branch: pr.head.ref,
+                  per_page: 100,
+                });
+                const workflowRun = latestRun(workflowRuns.filter((run) => (
+                  run.path === '.github/workflows/ci.yml'
+                  && run.event === 'pull_request'
+                  && run.head_sha === candidateSha
+                )));
+
+                if (!workflowRun) {
+                  return { state: 'missing', reason: `missing-build-and-test:${candidateSha}` };
+                }
+                if (workflowRun.status !== 'completed') {
+                  return {
+                    state: 'pending',
+                    reason: `build-and-test-workflow-not-completed:${workflowRun.status}`,
+                  };
+                }
+
+                const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                  owner,
+                  repo,
+                  run_id: workflowRun.id,
+                  filter: 'latest',
+                  per_page: 100,
+                });
+                buildRun = latestRun(jobs.filter((job) => job.name === 'Build & Test'));
+                if (!buildRun) {
+                  return { state: 'missing', reason: `missing-build-and-test-job:${candidateSha}` };
+                }
+                source = 'actions-job';
+              }
+              if (buildRun.status !== 'completed') {
+                return {
+                  state: 'pending',
+                  reason: `build-and-test-not-completed:${buildRun.status}`,
+                };
+              }
+              if (!allowedConclusions.has(buildRun.conclusion)) {
+                return {
+                  state: 'failed',
+                  reason: `build-and-test-not-green:${buildRun.conclusion}`,
+                };
+              }
+              return { state: 'green', source, conclusion: buildRun.conclusion };
             }
 
             try {
@@ -165,8 +242,8 @@ jobs:
                 return;
               }
 
-              let trailingReviewOnlyCommits = 0;
-              let candidateSha = '';
+              const reviewOnlyCandidates = [];
+              let codeCandidateSha = '';
 
               for (let index = commits.length - 1; index >= 0; index -= 1) {
                 const sha = commits[index].sha;
@@ -187,109 +264,55 @@ jobs:
                 if (reviewOnly) {
                   const parents = commit.parents || [];
                   if (parents.length === 1) {
-                    trailingReviewOnlyCommits += 1;
+                    reviewOnlyCandidates.push(sha);
                     continue;
                   }
-                  // #3233: a docs-only Update branch merge can be the already-verified
-                  // candidate after one or more trailing review-record commits. It must
-                  // be exactly a merge of the current PR base; all other merge shapes
-                  // retain the conservative full-CI fallback.
-                  if (trailingReviewOnlyCommits > 0
+                  // #3233: a docs-only Update branch merge can be an eligible green
+                  // candidate only after a trailing review-only record. Other merge
+                  // shapes may hide code outside the review-only diff.
+                  if (reviewOnlyCandidates.length > 0
                     && isCurrentBaseReviewMerge(commit, pr.base.sha)) {
-                    candidateSha = sha;
-                    core.info(`using current-base ${reviewOnlyLabel(files)} merge as candidate SHA ${candidateSha}`);
+                    reviewOnlyCandidates.push(sha);
+                    core.info(`including current-base ${reviewOnlyLabel(files)} merge candidate ${sha}`);
                     break;
                   }
                   setResult(false, `${reviewOnlyLabel(files)}-merge-not-reusable:${sha}`);
                   return;
                 }
 
-                candidateSha = sha;
+                codeCandidateSha = sha;
                 break;
               }
 
-              if (trailingReviewOnlyCommits === 0) {
+              if (reviewOnlyCandidates.length === 0) {
                 setResult(false, 'no-trailing-review-only-commits');
                 return;
               }
-              if (!candidateSha) {
-                candidateSha = pr.base.sha;
-                core.info(`all PR commits are review-only; using base SHA ${candidateSha}`);
-                setResult(true, 'all-review-only-no-code-impact', candidateSha);
-                return;
+              if (codeCandidateSha) {
+                reviewOnlyCandidates.push(codeCandidateSha);
               }
 
-              const checkRuns = await github.paginate(github.rest.checks.listForRef, {
-                owner,
-                repo,
-                ref: candidateSha,
-                per_page: 100,
-              });
-              let buildSource = 'check-run';
-              let buildRun = latestRun(checkRuns.filter((run) => (
-                run.name === 'Build & Test'
-                && run.app?.slug === 'github-actions'
-              )));
-
-              if (!buildRun) {
-                // Fork pull_request runs may expose the head SHA through Actions jobs while
-                // returning no check-runs for that same SHA. The Actions head_sha server filter
-                // can omit fork runs too, so narrow by the PR branch and compare head_sha locally.
-                // Still require the exact CI workflow, head SHA, and aggregate job.
-                const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
-                  owner,
-                  repo,
-                  workflow_id: 'ci.yml',
-                  event: 'pull_request',
-                  branch: pr.head.ref,
-                  per_page: 100,
-                });
-                const workflowRun = latestRun(workflowRuns.filter((run) => (
-                  run.path === '.github/workflows/ci.yml'
-                  && run.event === 'pull_request'
-                  && run.head_sha === candidateSha
-                )));
-
-                if (!workflowRun) {
-                  setResult(false, `missing-build-and-test:${candidateSha}`, candidateSha);
+              for (const candidateSha of reviewOnlyCandidates) {
+                if (!(await isCurrentBaseAncestor(candidateSha, pr.base.sha))) {
+                  core.info(`candidate does not include current base: ${candidateSha}`);
+                  continue;
+                }
+                const result = await buildResult(candidateSha, pr);
+                if (result.state === 'green') {
+                  const successReason = result.source === 'check-run'
+                    ? `build-and-test-green:${result.conclusion}`
+                    : `build-and-test-job-green:${result.conclusion}`;
+                  setResult(true, successReason, candidateSha);
                   return;
                 }
-                if (workflowRun.status !== 'completed') {
-                  setResult(
-                    false,
-                    `build-and-test-workflow-not-completed:${workflowRun.status}`,
-                    candidateSha,
-                  );
+                if (result.state === 'failed') {
+                  setResult(false, result.reason, candidateSha);
                   return;
                 }
-
-                const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
-                  owner,
-                  repo,
-                  run_id: workflowRun.id,
-                  filter: 'latest',
-                  per_page: 100,
-                });
-                buildRun = latestRun(jobs.filter((job) => job.name === 'Build & Test'));
-                if (!buildRun) {
-                  setResult(false, `missing-build-and-test-job:${candidateSha}`, candidateSha);
-                  return;
-                }
-                buildSource = 'actions-job';
-              }
-              if (buildRun.status !== 'completed') {
-                setResult(false, `build-and-test-not-completed:${buildRun.status}`, candidateSha);
-                return;
-              }
-              if (!allowedConclusions.has(buildRun.conclusion)) {
-                setResult(false, `build-and-test-not-green:${buildRun.conclusion}`, candidateSha);
-                return;
+                core.info(`candidate not reusable yet: ${candidateSha} (${result.reason})`);
               }
 
-              const successReason = buildSource === 'check-run'
-                ? `build-and-test-green:${buildRun.conclusion}`
-                : `build-and-test-job-green:${buildRun.conclusion}`;
-              setResult(true, successReason, candidateSha);
+              setResult(false, 'no-green-current-base-build-candidate');
             } catch (error) {
               core.warning(`CI preflight failed; running full CI. ${error.message}`);
               setResult(false, 'preflight-error');

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -118,6 +118,15 @@ jobs:
               return parents.length === 2 && parents.some((parent) => parent.sha === baseSha);
             }
 
+            async function isCurrentBaseAncestor(candidateSha, baseSha) {
+              const { data: comparison } = await github.rest.repos.compareCommitsWithBasehead({
+                owner,
+                repo,
+                basehead: `${baseSha}...${candidateSha}`,
+              });
+              return comparison.status === 'ahead' || comparison.status === 'identical';
+            }
+
             function latestRun(runs) {
               return runs
                 .slice()
@@ -126,6 +135,38 @@ jobs:
                   const aTime = Date.parse(a.completed_at || a.started_at || a.created_at || 0);
                   return bTime - aTime;
                 })[0];
+            }
+
+            async function codeqlResult(candidateSha) {
+              const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+                owner,
+                repo,
+                ref: candidateSha,
+                per_page: 100,
+              });
+
+              for (const checkName of requiredChecks) {
+                const checkRun = latestRun(checkRuns.filter((run) => (
+                  run.name === checkName
+                  && run.app?.slug === 'github-actions'
+                )));
+                if (!checkRun) {
+                  return { state: 'missing', reason: `missing-check:${checkName}:${candidateSha}` };
+                }
+                if (checkRun.status !== 'completed') {
+                  return {
+                    state: 'pending',
+                    reason: `check-not-completed:${checkName}:${checkRun.status}`,
+                  };
+                }
+                if (!allowedConclusions.has(checkRun.conclusion)) {
+                  return {
+                    state: 'failed',
+                    reason: `check-not-green:${checkName}:${checkRun.conclusion}`,
+                  };
+                }
+              }
+              return { state: 'green' };
             }
 
             try {
@@ -159,8 +200,8 @@ jobs:
                 return;
               }
 
-              let trailingReviewOnlyCommits = 0;
-              let candidateSha = '';
+              const reviewOnlyCandidates = [];
+              let codeCandidateSha = '';
 
               for (let index = commits.length - 1; index >= 0; index -= 1) {
                 const sha = commits[index].sha;
@@ -181,66 +222,51 @@ jobs:
                 if (reviewOnly) {
                   const parents = commit.parents || [];
                   if (parents.length === 1) {
-                    trailingReviewOnlyCommits += 1;
+                    reviewOnlyCandidates.push(sha);
                     continue;
                   }
-                  // #3233: a docs-only Update branch merge can be the already-verified
-                  // candidate after one or more trailing review-record commits. It must
-                  // be exactly a merge of the current PR base; all other merge shapes
-                  // retain the conservative full-CodeQL fallback.
-                  if (trailingReviewOnlyCommits > 0
+                  // #3233 keeps the narrow Update branch merge topology. Its green
+                  // workflow can be reused after one or more review-only records.
+                  if (reviewOnlyCandidates.length > 0
                     && isCurrentBaseReviewMerge(commit, pr.base.sha)) {
-                    candidateSha = sha;
-                    core.info(`using current-base ${reviewOnlyLabel(files)} merge as candidate SHA ${candidateSha}`);
+                    reviewOnlyCandidates.push(sha);
+                    core.info(`including current-base ${reviewOnlyLabel(files)} merge candidate ${sha}`);
                     break;
                   }
                   setResult(false, `${reviewOnlyLabel(files)}-merge-not-reusable:${sha}`);
                   return;
                 }
 
-                candidateSha = sha;
+                codeCandidateSha = sha;
                 break;
               }
 
-              if (trailingReviewOnlyCommits === 0) {
+              if (reviewOnlyCandidates.length === 0) {
                 setResult(false, 'no-trailing-review-only-commits');
                 return;
               }
-              if (!candidateSha) {
-                candidateSha = pr.base.sha;
-                core.info(`all PR commits are review-only; using base SHA ${candidateSha}`);
-                setResult(true, 'all-review-only-no-code-impact', candidateSha);
-                return;
+              if (codeCandidateSha) {
+                reviewOnlyCandidates.push(codeCandidateSha);
               }
 
-              const checkRuns = await github.paginate(github.rest.checks.listForRef, {
-                owner,
-                repo,
-                ref: candidateSha,
-                per_page: 100,
-              });
-
-              for (const checkName of requiredChecks) {
-                const checkRun = latestRun(checkRuns.filter((run) => (
-                  run.name === checkName
-                  && run.app?.slug === 'github-actions'
-                )));
-
-                if (!checkRun) {
-                  setResult(false, `missing-check:${checkName}:${candidateSha}`, candidateSha);
+              for (const candidateSha of reviewOnlyCandidates) {
+                if (!(await isCurrentBaseAncestor(candidateSha, pr.base.sha))) {
+                  core.info(`candidate does not include current base: ${candidateSha}`);
+                  continue;
+                }
+                const result = await codeqlResult(candidateSha);
+                if (result.state === 'green') {
+                  setResult(true, 'codeql-checks-green', candidateSha);
                   return;
                 }
-                if (checkRun.status !== 'completed') {
-                  setResult(false, `check-not-completed:${checkName}:${checkRun.status}`, candidateSha);
+                if (result.state === 'failed') {
+                  setResult(false, result.reason, candidateSha);
                   return;
                 }
-                if (!allowedConclusions.has(checkRun.conclusion)) {
-                  setResult(false, `check-not-green:${checkName}:${checkRun.conclusion}`, candidateSha);
-                  return;
-                }
+                core.info(`candidate not reusable yet: ${candidateSha} (${result.reason})`);
               }
 
-              setResult(true, 'codeql-checks-green', candidateSha);
+              setResult(false, 'no-green-current-base-codeql-candidate');
             } catch (error) {
               core.warning(`CodeQL preflight failed; running full CodeQL. ${error.message}`);
               setResult(false, 'preflight-error');

--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -128,6 +128,15 @@ jobs:
               return parents.length === 2 && parents.some((parent) => parent.sha === baseSha);
             }
 
+            async function isCurrentBaseAncestor(candidateSha, baseSha) {
+              const { data: comparison } = await github.rest.repos.compareCommitsWithBasehead({
+                owner,
+                repo,
+                basehead: `${baseSha}...${candidateSha}`,
+              });
+              return comparison.status === 'ahead' || comparison.status === 'identical';
+            }
+
             function latestRun(runs) {
               return runs
                 .slice()
@@ -136,6 +145,87 @@ jobs:
                   const aTime = Date.parse(a.completed_at || a.started_at || a.created_at || 0);
                   return bTime - aTime;
                 })[0];
+            }
+
+            async function renderDiffResult(candidateSha, pr) {
+              const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                owner,
+                repo,
+                workflow_id: 'render-diff.yml',
+                event: 'pull_request',
+                head_sha: candidateSha,
+                per_page: 100,
+              });
+              const renderDiffRun = latestRun(workflowRuns.filter((run) => (
+                run.path === '.github/workflows/render-diff.yml'
+                && run.event === 'pull_request'
+                && run.head_sha === candidateSha
+              )));
+
+              if (!renderDiffRun) {
+                return {
+                  state: 'missing',
+                  reason: `missing-render-diff-workflow:${candidateSha}`,
+                };
+              }
+              if (renderDiffRun.status !== 'completed') {
+                return {
+                  state: 'pending',
+                  reason: `render-diff-workflow-not-completed:${renderDiffRun.status}`,
+                };
+              }
+              if (renderDiffRun.conclusion !== 'success') {
+                return {
+                  state: 'failed',
+                  reason: `latest-render-diff-workflow-not-success:${renderDiffRun.conclusion}`,
+                };
+              }
+              const runCreatedAt = Date.parse(renderDiffRun.created_at);
+              const pullCreatedAt = Date.parse(pr.created_at);
+              if (!Number.isFinite(runCreatedAt)
+                || !Number.isFinite(pullCreatedAt)
+                || renderDiffRun.head_branch !== pr.head.ref
+                || renderDiffRun.head_repository?.id !== pr.head.repo?.id
+                || runCreatedAt < pullCreatedAt) {
+                return { state: 'failed', reason: 'render-diff-workflow-pr-identity-mismatch' };
+              }
+
+              const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                owner,
+                repo,
+                run_id: renderDiffRun.id,
+                filter: 'latest',
+                per_page: 100,
+              });
+              const renderDiffJob = latestRun(jobs.filter((job) => (
+                job.name === 'Canvas visual diff'
+              )));
+              if (!renderDiffJob) {
+                return {
+                  state: 'failed',
+                  reason: `missing-canvas-visual-diff-job:${candidateSha}`,
+                };
+              }
+              if (renderDiffJob.status !== 'completed') {
+                return {
+                  state: 'pending',
+                  reason: `canvas-visual-diff-not-completed:${renderDiffJob.status}`,
+                };
+              }
+              if (renderDiffJob.conclusion !== 'success') {
+                return {
+                  state: 'failed',
+                  reason: `canvas-visual-diff-not-success:${renderDiffJob.conclusion}`,
+                };
+              }
+              const expectedIdentityStep = `Render Diff identity PR #${pr.number} base ${pr.base.sha}`;
+              const identityStep = (renderDiffJob.steps || []).find((step) => (
+                step.name === expectedIdentityStep
+              ));
+              if (identityStep?.status !== 'completed' || identityStep.conclusion !== 'success') {
+                return { state: 'failed', reason: 'canvas-visual-diff-identity-mismatch' };
+              }
+              return { state: 'green' };
             }
 
             try {
@@ -169,8 +259,8 @@ jobs:
                 return;
               }
 
-              let trailingReviewOnlyCommits = 0;
-              let candidateSha = '';
+              const reviewOnlyCandidates = [];
+              let codeCandidateSha = '';
 
               for (let index = commits.length - 1; index >= 0; index -= 1) {
                 const sha = commits[index].sha;
@@ -191,108 +281,51 @@ jobs:
                 if (reviewOnly) {
                   const parents = commit.parents || [];
                   if (parents.length === 1) {
-                    trailingReviewOnlyCommits += 1;
+                    reviewOnlyCandidates.push(sha);
                     continue;
                   }
-                  // #3233: a docs-only Update branch merge can be the already-verified
-                  // candidate after one or more trailing review-record commits. It must
-                  // be exactly a merge of the current PR base; all other merge shapes
-                  // retain the conservative full-render fallback.
-                  if (trailingReviewOnlyCommits > 0
+                  // #3233 keeps the narrow Update branch merge topology. Its green
+                  // workflow can be reused after one or more review-only records.
+                  if (reviewOnlyCandidates.length > 0
                     && isCurrentBaseReviewMerge(commit, pr.base.sha)) {
-                    candidateSha = sha;
-                    core.info(`using current-base ${reviewOnlyLabel(files)} merge as candidate SHA ${candidateSha}`);
+                    reviewOnlyCandidates.push(sha);
+                    core.info(`including current-base ${reviewOnlyLabel(files)} merge candidate ${sha}`);
                     break;
                   }
                   setResult(false, `${reviewOnlyLabel(files)}-merge-not-reusable:${sha}`);
                   return;
                 }
 
-                candidateSha = sha;
+                codeCandidateSha = sha;
                 break;
               }
 
-              if (trailingReviewOnlyCommits === 0) {
+              if (reviewOnlyCandidates.length === 0) {
                 setResult(false, 'no-trailing-review-only-commits');
                 return;
               }
-              if (!candidateSha) {
-                candidateSha = pr.base.sha;
-                core.info(`all PR commits are review-only; using base SHA ${candidateSha}`);
-                setResult(true, 'all-review-only-no-render-impact', candidateSha);
-                return;
+              if (codeCandidateSha) {
+                reviewOnlyCandidates.push(codeCandidateSha);
               }
 
-              const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
-                owner,
-                repo,
-                workflow_id: 'render-diff.yml',
-                event: 'pull_request',
-                status: 'completed',
-                head_sha: candidateSha,
-                per_page: 100,
-              });
-              const renderDiffRun = latestRun(workflowRuns.filter((run) => (
-                run.path === '.github/workflows/render-diff.yml'
-                && run.event === 'pull_request'
-                && run.head_sha === candidateSha
-              )));
-
-              if (!renderDiffRun) {
-                setResult(false, `missing-completed-render-diff-workflow:${candidateSha}`, candidateSha);
-                return;
-              }
-              if (renderDiffRun.conclusion !== 'success') {
-                setResult(
-                  false,
-                  `latest-render-diff-workflow-not-success:${renderDiffRun.conclusion}`,
-                  candidateSha,
-                );
-                return;
-              }
-              const runCreatedAt = Date.parse(renderDiffRun.created_at);
-              const pullCreatedAt = Date.parse(pr.created_at);
-              if (!Number.isFinite(runCreatedAt)
-                || !Number.isFinite(pullCreatedAt)
-                || renderDiffRun.head_branch !== pr.head.ref
-                || renderDiffRun.head_repository?.id !== pr.head.repo?.id
-                || runCreatedAt < pullCreatedAt) {
-                setResult(false, 'render-diff-workflow-pr-identity-mismatch', candidateSha);
-                return;
+              for (const candidateSha of reviewOnlyCandidates) {
+                if (!(await isCurrentBaseAncestor(candidateSha, pr.base.sha))) {
+                  core.info(`candidate does not include current base: ${candidateSha}`);
+                  continue;
+                }
+                const result = await renderDiffResult(candidateSha, pr);
+                if (result.state === 'green') {
+                  setResult(true, 'canvas-visual-diff-success', candidateSha);
+                  return;
+                }
+                if (result.state === 'failed') {
+                  setResult(false, result.reason, candidateSha);
+                  return;
+                }
+                core.info(`candidate not reusable yet: ${candidateSha} (${result.reason})`);
               }
 
-              const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
-                owner,
-                repo,
-                run_id: renderDiffRun.id,
-                filter: 'latest',
-                per_page: 100,
-              });
-              const renderDiffJob = latestRun(jobs.filter((job) => (
-                job.name === 'Canvas visual diff'
-              )));
-              if (!renderDiffJob) {
-                setResult(false, `missing-canvas-visual-diff-job:${candidateSha}`, candidateSha);
-                return;
-              }
-              if (renderDiffJob.status !== 'completed' || renderDiffJob.conclusion !== 'success') {
-                setResult(
-                  false,
-                  `canvas-visual-diff-not-success:${renderDiffJob.status}:${renderDiffJob.conclusion}`,
-                  candidateSha,
-                );
-                return;
-              }
-              const expectedIdentityStep = `Render Diff identity PR #${pr.number} base ${pr.base.sha}`;
-              const identityStep = (renderDiffJob.steps || []).find((step) => (
-                step.name === expectedIdentityStep
-              ));
-              if (identityStep?.status !== 'completed' || identityStep.conclusion !== 'success') {
-                setResult(false, 'canvas-visual-diff-identity-mismatch', candidateSha);
-                return;
-              }
-
-              setResult(true, 'canvas-visual-diff-success', candidateSha);
+              setResult(false, 'no-green-current-base-render-candidate');
             } catch (error) {
               core.warning(`Render Diff preflight failed; running full Render Diff. ${error.message}`);
               setResult(false, 'preflight-error');

--- a/mydocs/manual/pr_review/multi_pr_update_branch.md
+++ b/mydocs/manual/pr_review/multi_pr_update_branch.md
@@ -32,14 +32,15 @@ contributor 또는 maintainer가 Update branch를 수행해 PR head가 바뀌면
 
 1. 최신 head SHA를 확인한다.
 2. 이전 SHA에서 시작한 run을 확인한다.
-3. queued, pending, in_progress run만 force-cancel API로 취소한다.
+3. queued, pending, in_progress run만 **일반 `gh run cancel`을 먼저 시도하지 않고** force-cancel API로
+   즉시 취소한다.
 4. 완료 상태와 cancelled 결론을 재확인한다.
 
 러너 구성 전환 등으로 배정 가능한 label이 사라진 run은 `queued`에 고착될 수 있다. 이 run은 일반 cancel이
 끝나지 않고 같은 concurrency group을 계속 점유해, 후속 run이 job을 하나도 시작하지 못한 `pending`으로
 연쇄 고착될 수 있다. 새 run이 `pending`이면 최신 run만 재실행하지 말고 같은 PR·workflow의 이전
-`queued`/`pending`/`in_progress` run부터 확인한다. 일반 cancel 뒤에도 상태가 유지되면 아래 force-cancel
-API를 사용하고, 이전 run이 실제 `completed/cancelled`가 된 뒤 후속 run 상태를 다시 확인한다.
+`queued`/`pending`/`in_progress` run부터 확인한다. 정확한 stale SHA를 확인한 직후 아래 force-cancel API를
+사용하고, 이전 run이 실제 `completed/cancelled`가 된 뒤 후속 run 상태를 다시 확인한다.
 
 ~~~bash
 gh pr view N --repo edwardkim/rhwp --json headRefOid

--- a/mydocs/manual/pr_review/review_only_fast_pass.md
+++ b/mydocs/manual/pr_review/review_only_fast_pass.md
@@ -12,7 +12,8 @@ review-only인 경우에 적용하는 공용 modifier다. maintainer·collaborat
 
 [CI workflow](../../../.github/workflows/ci.yml)의 preflight는 다음 허용 범위를 사용한다.
 
-- mydocs 아래 모든 파일
+- mydocs 아래 모든 파일 — 파일 상태와 확장자를 제한하지 않는다. 따라서 `mydocs/pr/assets` 등에
+  올리는 PDF, HWP/HWPX, PNG 등 검토 증적도 문서-only PR과 같은 허용 범위다.
 - added 상태의 samples 아래 hwp, hwpx, pdf, png
 - added 상태의 pdf 아래 PDF
 
@@ -21,21 +22,28 @@ review-only인 경우에 적용하는 공용 modifier다. maintainer·collaborat
 
 ## A. code PR 뒤의 trailing review-only commit
 
-contributor code PR의 뒤에 review 문서·오늘할일·허용된 신규 기준 자료를 추가하면 workflow는 trailing
-review-only commit을 제외한 직전 candidate SHA의 Build & Test 결과를 재사용한다.
+contributor code PR의 뒤에 review 문서·오늘할일·허용된 신규 기준 자료를 추가하면 workflow는 현재 head에서
+거꾸로 확인해, **현재 base를 포함하고 이후 변경이 모두 review-only인 가장 최근 green PR head**의 결과를
+재사용한다. 따라서 직전 green PR head 자체가 review-only commit이어도, 그 commit의 full CI가 성공했고 그 뒤에
+허용된 기록만 추가됐다면 candidate가 될 수 있다.
 
 다음 조건을 모두 만족해야 한다.
 
-1. 뒤에 추가한 review-only commit은 single-parent다.
-2. 직전 candidate가 review-only Update branch merge이면 현재 PR base를 parent로 포함한 2-parent merge이고,
-   그 뒤에 적어도 하나의 single-parent review-only commit이 있어야 한다.
-3. candidate SHA의 Build & Test check 또는 같은 SHA의 CI workflow 집계 job이 completed이고
-   conclusion이 success, skipped, neutral 중 하나다.
-4. push 뒤 최신 head의 preflight와 branch protection이 요구하는 Build & Test aggregate를 확인한다.
+1. candidate 이후 current head까지의 review-only commit은 single-parent다.
+2. review-only Update branch merge를 candidate로 쓰는 경우에는 현재 PR base를 parent로 포함한 정확히
+   2-parent merge이고, 그 뒤에 적어도 하나의 single-parent review-only commit이 있어야 한다.
+3. candidate SHA는 현재 base를 ancestor로 포함한다. base가 바뀐 뒤 update branch를 하지 않은 옛 run은
+   재사용하지 않는다.
+4. 후보는 최신순으로 조회한다. check/workflow가 없거나 진행 중인 후보는 더 이전 후보를 계속 확인하되,
+   가장 최근 완료 후보가 failed이면 full CI로 fallback한다.
+5. 채택한 candidate SHA의 Build & Test check 또는 같은 SHA의 CI workflow 집계 job이 completed이고
+   conclusion이 success, skipped, neutral 중 하나여야 한다.
+6. push 뒤 최신 head의 preflight와 branch protection이 요구하는 Build & Test aggregate를 확인한다.
    heavy worker가 skipped인 것은 정상이나 aggregate가 pending 또는 failing이면 merge하지 않는다.
 
-local Cargo 성공만으로 candidate의 GitHub Actions를 대체하지 않는다. check 조회 실패, missing, failed,
-허용되지 않은 merge 형태이면 workflow는 full CI로 fallback한다.
+local Cargo 성공만으로 candidate의 GitHub Actions를 대체하지 않는다. current base 불일치, 가장 최근 완료
+candidate check의 failed, 허용되지 않은 merge 형태, 허용 경로 밖 변경은 full CI fallback이다. 후보가 전부
+missing 또는 진행 중이면 green 검증을 찾지 못한 것이므로 역시 full CI를 실행한다.
 
 collaborator가 contributor code를 local에서 검증한 뒤 review·오늘할일만 같은 source head에 추가하는 경우도
 이 A 경로다. local 검증 결과와 candidate SHA, 재사용한 Build & Test URL을 review 문서에 기록한다.

--- a/mydocs/orders/20260725.md
+++ b/mydocs/orders/20260725.md
@@ -1,5 +1,21 @@
 # 오늘 할일 - 2026년 7월 25일
 
+## #3309 — 문서-only 후속 기록의 green PR head 재사용
+
+[#3309](https://github.com/edwardkim/rhwp/issues/3309)의 #3304 재현을 보정한다. 같은 PR에서 구현 commit의
+full CI가 성공한 뒤 `mydocs/**` review·오늘할일 기록만 후속 push했을 때, CI·CodeQL·Render Diff preflight가
+현재 base를 포함하는 직전 green head를 재사용해야 한다.
+
+- 구현 PR: [#3312](https://github.com/edwardkim/rhwp/pull/3312), branch `task_m100_3309`.
+- 구현 범위: 세 workflow의 candidate 최신순 탐색·current-base ancestor 확인·missing/pending 후보의 이전
+  candidate 재탐색을 통일하고, 최신 완료 후보 실패·base 불일치·비허용 merge는 full CI fallback으로 유지한다.
+  Update branch 뒤 stale run은 일반 cancel 없이 force-cancel API를 바로 사용하도록 절차를 맞춘다.
+- 증적 정책: `mydocs/**`의 PDF, HWP/HWPX, PNG 등은 파일 상태와 확장자에 관계없이 문서-only 허용 범위다.
+- 검증: 구현 SHA `7fed99fd2`의 full CI·CodeQL·Render Diff가 성공했다. 이 후속 문서 commit push 뒤 최신 head의
+  preflight, `Build & Test` aggregate, CodeQL, Render Diff가 직전 green SHA를 재사용해 통과하는지 확인한다.
+- merge 전 조건: 최신 head CI 성공, mergeable 재확인, 작업지시자 merge 승인. merge 후 #3309 close와
+  `upstream/devel` 동기화·작업 branch 정리를 수행한다.
+
 ## kevin9327 CLI JSON 8건 — v2 통합 PR
 
 `kevin9327`의 CLI JSON 기능 PR 8건을 최신 `upstream/devel` 위

--- a/mydocs/plans/task_m100_3309.md
+++ b/mydocs/plans/task_m100_3309.md
@@ -1,0 +1,42 @@
+# 수행계획서 — #3309 문서-only 후속 기록의 직전 green PR head 재사용
+
+- 이슈: [#3309](https://github.com/edwardkim/rhwp/issues/3309)
+- 브랜치: `task_m100_3309`
+- 기준: `upstream/devel` `f68aa8be5`
+- 실제 재현: [#3304](https://github.com/edwardkim/rhwp/pull/3304)의 green head `bcff621` 뒤
+  review-only `2042ee0` push
+
+## 문제
+
+현재 CI·CodeQL·Render Diff preflight는 trailing review-only commit을 모두 건너뛴 뒤 마지막 비문서
+commit만 candidate로 조회한다. #3304에서는 그 code commit `a60ae32`에 독립 CI가 없어 full CI로
+fallback했으며, 실제로 성공한 직전 PR head `bcff621`는 review-only commit이라는 이유로 후보에서
+제외됐다.
+
+[#3233](https://github.com/edwardkim/rhwp/issues/3233)은 현재 base를 parent로 둔 문서-only Update branch
+merge를 한정해 재사용한다. 일반 single-parent review-only 후속 기록의 green head 선택은 남아 있다.
+
+## 범위
+
+1. CI·CodeQL·Render Diff의 preflight가 trailing review-only 구간 안의 가장 최근 green PR head도
+   candidate로 조회한다.
+2. candidate는 현재 PR commit이고 current base가 ancestor여야 한다. 문서-only merge는 기존처럼 정확히
+   2-parent이며 current base를 parent로 포함하는 경우만 인정한다.
+3. candidate 이후 current head까지의 모든 commit은 허용 review-only 경로여야 하며, check/workflow
+   missing·미완료·실패, base 불일치, 허용되지 않은 merge는 full CI fallback을 유지한다.
+4. `review_only_fast_pass.md`의 candidate 정의와 `multi_pr_update_branch.md`의 stale run 정리 기본 명령을
+   구현과 일치시킨다. stale run은 일반 cancel을 먼저 시도하지 않고 force-cancel API를 사용한다.
+
+## 검증
+
+- `actionlint`, Ruby YAML parse, inline GitHub Script의 `node --check`, `git diff --check`
+- #3304의 실제 SHA 관계(`bcff621 → 2042ee0`)와 Build & Test·CodeQL·Render Diff success 기록을
+  candidate 조건으로 재확인
+- 구현 PR의 full CI가 성공한 뒤 review-only 후속 기록 commit을 추가해 최신 head의 heavy job skip을
+  GitHub Actions에서 확인
+
+## 범위 제외
+
+- Native Skia의 renderer 영향 경로 판정
+- branch protection required check 이름 또는 정책 변경
+- 코드·fixture·golden·baseline 변경

--- a/mydocs/plans/task_m100_3309_impl.md
+++ b/mydocs/plans/task_m100_3309_impl.md
@@ -1,0 +1,34 @@
+# 구현계획서 — #3309 공통 green candidate 탐색
+
+## candidate 구간
+
+PR commit을 최신순으로 읽는다. 허용된 trailing review-only single-parent commit은 후보 목록에 넣는다.
+그 뒤 current base를 parent로 포함한 2-parent review-only Update branch merge가 나오면 그것도 후보에 넣고
+중단한다. 다른 merge 형태는 기존처럼 full CI fallback이다. review-only 구간 뒤 비문서 commit이 있으면
+그 commit도 종전 호환 candidate로 목록 끝에 넣는다.
+
+candidate 목록은 최신순이다. 각 SHA에 대해 다음을 확인한다.
+
+| 조건 | 처리 |
+| --- | --- |
+| current base가 candidate의 ancestor | 해당 SHA의 기존 PR workflow/check 조회 |
+| workflow/check가 아직 없거나 진행 중 | 더 이전 candidate를 계속 탐색 |
+| 가장 최근 완료 candidate가 실패 | full CI fallback |
+| green aggregate 및 workflow identity 충족 | fast-pass candidate로 채택 |
+| 허용 경로 밖 변경·base 불일치·비허용 merge | 즉시 full CI fallback |
+
+이 규칙으로 #3304의 `bcff621`은 `2042ee0`보다 한 단계 이전이지만, 이후 변경이 review-only이고
+current base를 포함한 가장 최근 green head이므로 재사용된다. 반면 code 변경, stale base, 실패한 required
+check는 우회하지 않는다.
+
+## 파일별 변경
+
+- `.github/workflows/ci.yml`: Build & Test check와 fork fallback workflow job을 후보별로 탐색한다.
+- `.github/workflows/codeql.yml`: 세 analysis check를 같은 후보별 규칙으로 검증한다.
+- `.github/workflows/render-diff.yml`: Canvas visual diff, PR/head/base identity를 후보별로 검증한다.
+- `mydocs/manual/pr_review/review_only_fast_pass.md`: 일반 green PR head 재사용 및 fallback 조건을 갱신한다.
+- `mydocs/manual/pr_review/multi_pr_update_branch.md`: stale run 확인 직후 force-cancel API를 쓰도록 기본 절차를
+  명확히 한다.
+
+세 workflow의 허용 경로·merge topology·candidate 순서는 동일하게 유지한다. workflow inline JavaScript를
+각 파일의 기존 verification 방식에 맞게 최소한으로 확장한다.

--- a/mydocs/pr/archives/pr_3312_review.md
+++ b/mydocs/pr/archives/pr_3312_review.md
@@ -1,0 +1,61 @@
+# PR #3312 검토 기록
+
+## 라우팅
+
+```text
+base route: collaborator_self_merge
+modifiers: intake_and_review, local_validation, review_only_fast_pass
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+  collaborator_self_merge.md, intake_and_review.md, local_validation.md,
+  review_only_fast_pass.md
+current head: 문서 trailing commit push 전 참고값 7fed99fd2c0e294d41ef2d868e67cd26c54f9290
+```
+
+## PR metadata
+
+| 항목 | 문서 작성 시점 참고값 |
+| --- | --- |
+| PR | [#3312](https://github.com/edwardkim/rhwp/pull/3312) |
+| 제목 | `ci: 문서 후속 기록의 직전 green PR head 재사용` |
+| 작성자 | `jangster77` |
+| base / head | `devel` / `task_m100_3309` |
+| 관련 이슈 | [#3309](https://github.com/edwardkim/rhwp/issues/3309) |
+| 구현 SHA | `7fed99fd2c0e294d41ef2d868e67cd26c54f9290` |
+| 규모 | 8 files, +422/-218 (문서 trailing commit 전) |
+| 상태 | `MERGEABLE`, `CLEAN`; 최종 판단 전 최신 head 재확인 필요 |
+
+## 변경 범위와 판단
+
+- CI·CodeQL·Render Diff의 preflight가 trailing review-only commit을 최신순으로 candidate로 탐색한다.
+  current base를 포함하는 가장 최근 green candidate를 선택하고, check/workflow가 missing·pending이면 더 이전
+  후보를 확인한다.
+- 최신 완료 후보의 실패, current-base 불일치, 비허용 merge 형태, 허용 경로 밖 변경은 fast-pass하지 않고 full
+  CI fallback한다. branch protection과 aggregate 이름은 변경하지 않는다.
+- #3304의 `bcff621 → 2042ee0`를 재현 근거로 삼았다. 기존에는 마지막 비문서 SHA `a60ae32`만 조회해 full CI가
+  재실행됐고, 수정 뒤에는 직전 green PR head도 candidate가 된다.
+- `multi_pr_update_branch.md`는 Update branch 뒤 stale SHA의 queued/pending/in-progress run을 일반 cancel 없이
+  force-cancel API로 즉시 정리하도록 명확히 했다.
+- renderer, Rust source/test, fixture, golden/baseline은 변경하지 않았다. 시각 검증과 Cargo 재실행은 대상이
+  아니며, workflow 자체가 바뀌므로 GitHub full CI가 구현 SHA에서 필수다.
+
+## 구현 SHA 검증
+
+- `git diff --check`, workflow YAML parse, 각 inline GitHub Script의 `node --check`,
+  `actionlint -ignore SC2086`를 통과했다. Render Diff의 SC2086은 변경 범위 밖 기존 경고다.
+- candidate mock으로 최신 문서 후보가 미완료이면 이전 green 후보를 선택하고, 최신 완료 후보 실패와
+  current-base 불일치에서는 full CI로 fallback하는 것을 세 workflow에서 확인했다.
+- `7fed99fd2`의 CI Build & Test, CodeQL, Render Diff가 모두 성공했다. CI heavy job과 8개 default-feature
+  shard도 성공했다.
+- `mydocs/**`는 세 preflight에서 파일 상태·확장자 검사보다 먼저 허용한다. 따라서 `mydocs/pr/assets`의 PDF,
+  HWP/HWPX, PNG 증적도 문서-only 범위다.
+
+## 문서 trailing commit 검증 계획
+
+이 문서·implementation 기록·오늘할일만 포함하는 후속 commit을 push한다. 최신 head에서는 구현 SHA
+`7fed99fd2`를 candidate로 재사용해 CI·CodeQL·Render Diff heavy job이 skip되고, required aggregate는
+success여야 한다. base가 바뀌거나 최신 required check가 실패하면 fast-pass하지 않고 full CI 결과를 따른다.
+
+## 최종 권고
+
+문서 trailing commit의 최신 head CI 성공, mergeable 재확인, `edwardkim` review와 작업지시자 merge 승인을
+조건으로 merge를 권고한다. merge 뒤 #3309를 close하고 `upstream/devel` 동기화와 task branch 정리를 수행한다.

--- a/mydocs/pr/archives/pr_3312_review_impl.md
+++ b/mydocs/pr/archives/pr_3312_review_impl.md
@@ -1,0 +1,26 @@
+# PR #3312 구현·통합 계획
+
+## 대상과 rollback 경계
+
+- 대상: [#3312](https://github.com/edwardkim/rhwp/pull/3312), [#3309](https://github.com/edwardkim/rhwp/issues/3309)
+- 구현 SHA: `7fed99fd2c0e294d41ef2d868e67cd26c54f9290`
+- 문서 trailing commit: 이 파일, `pr_3312_review.md`, `20260725.md`
+
+workflow 세 파일은 같은 candidate 안전 규칙을 가져야 한다. fast-pass가 예상과 다르거나 최신 aggregate가
+실패하면 merge하지 않고 해당 PR에서 원인을 보정한다. merge 뒤 문제를 발견하면 `devel` 직접 수정이 아니라
+별도 후속 PR로 revert 또는 보정한다.
+
+## 단계
+
+1. 구현 SHA의 full CI, CodeQL, Render Diff 성공과 current-base 관계를 확인한다. 완료: `7fed99fd2`.
+2. review·implementation·오늘할일만 추가한 문서 trailing commit을 push한다.
+3. 새 head의 세 preflight가 `7fed99fd2`를 candidate로 선택하고 Build & Test aggregate, CodeQL, Render Diff가
+   통과하는지 확인한다. heavy worker의 skipped는 이 경로에서 정상이다.
+4. 최신 head SHA·mergeable·required check를 재확인한 뒤 작업지시자 merge 승인과 reviewer 판단을 기다린다.
+5. merge 뒤 #3309 close, `upstream/devel` fast-forward, remote/local `task_m100_3309` branch 정리를 수행한다.
+
+## 증적 파일 원칙
+
+후속 기록에 `mydocs/**` 아래 PDF, HWP/HWPX, PNG 같은 증적 파일이 포함되어도 파일 상태·확장자 제한 없이
+문서-only 허용 범위다. 반면 `samples/`·`pdf/`의 새 기준 자료와 source/test/workflow/Cargo.lock 변경은 각각
+workflow allowlist와 full-CI fallback 규칙을 따른다.

--- a/mydocs/working/task_m100_3309_stage1.md
+++ b/mydocs/working/task_m100_3309_stage1.md
@@ -1,0 +1,37 @@
+# #3309 단계 1 완료 — green head 재사용 fast-pass 구현·정적 검증
+
+- 이슈: [#3309](https://github.com/edwardkim/rhwp/issues/3309)
+- 브랜치: `task_m100_3309`
+- 기준: `upstream/devel` `f68aa8be5`
+
+## 완료 내용
+
+CI, CodeQL, Render Diff preflight가 trailing review-only commit을 최신순으로 후보화하고, 현재 base를
+포함하는 가장 최근 green candidate를 재사용하도록 보정했다. 최신 후보의 check/workflow가 아직 없거나
+진행 중이면 더 이전 후보를 확인하고, 가장 최근 완료 후보의 실패·base 불일치·비허용 merge·비허용 경로는
+기존처럼 full CI fallback으로 처리한다.
+
+`#3304`의 `bcff621` 뒤 `2042ee0` 사례를 기준으로, 이전에는 비문서 commit만 조회해 full CI가 재실행됐던
+경로가 이제 직전 green PR head를 선택한다. Update branch 뒤 이전 SHA의 stale run은 일반 cancel을 먼저
+시도하지 않고 force-cancel API를 즉시 사용하도록 절차도 맞췄다.
+
+## mydocs 증적 허용 확인
+
+세 workflow의 `isAllowedReviewPath`는 `mydocs/` 경로를 파일 상태·확장자 검사보다 먼저 허용한다. 따라서
+`mydocs/pr/assets` 등에 추가·수정·이동하는 PDF, HWP/HWPX, PNG를 포함한 증적 자료는 문서-only PR의
+fast-pass 대상이다. 이 보장을 `review_only_fast_pass.md` 허용 범위에도 명시했다.
+
+## 정적 검증
+
+- `git diff --check` 성공
+- `actionlint -ignore 'SC2086' .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/render-diff.yml`
+  성공. Render Diff의 기존 SC2086 경고는 변경 범위 밖이다.
+- Ruby YAML parse 성공: CI, CodeQL, Render Diff
+- 각 inline GitHub Script `node --check` 성공
+- #3304의 `bcff621 → 2042ee0` current-base 관계와 기존 Build & Test·CodeQL·Render Diff success를 재확인
+- mock으로 최신 문서 후보가 미완료일 때 이전 green 후보를 선택하는 경우, 최신 완료 후보 실패와 current-base
+  불일치에서는 full CI fallback하는 경우를 세 workflow에서 확인
+- `mydocs/` 허용 조건이 `file.status !== 'added'` 검사보다 앞서는지 세 workflow에서 확인
+
+Rust 소스·테스트·fixture는 변경하지 않았으므로 Cargo 테스트는 이 단계의 변경 범위에 해당하지 않는다. workflow
+변경 PR의 GitHub full CI와 그 뒤의 review-only 증적 commit fast-pass 실증은 PR 단계에서 수행한다.


### PR DESCRIPTION
## 요약

- trailing review-only commit의 후보를 최신순으로 탐색해 current base를 포함하는 가장 최근 green PR head를 재사용합니다.
- CI, CodeQL, Render Diff의 candidate 검증과 full-CI fallback 조건을 일치시킵니다.
- Update branch 뒤 stale run은 일반 cancel 없이 force-cancel API를 즉시 사용하도록 절차를 명확히 합니다.

## 검증

- `git diff --check`
- workflow YAML parse, inline GitHub Script `node --check`
- `actionlint -ignore SC2086`
- #3304 SHA/green run 관계 및 candidate mock 검증

Closes #3309