### PR TITLE
fix(#3314): 굵기 접미사 face 폴백에 base family 삽입 — Batang 낙하 방지

### DIFF
--- a/src/renderer/html.rs
+++ b/src/renderer/html.rs
@@ -292,7 +292,16 @@ impl Renderer for HtmlRenderer {
             "sans-serif".to_string()
         } else {
             let fallback = super::generic_fallback(&style.font_family);
-            format!("'{}', {}", escape_html(&style.font_family), fallback)
+            // [#3314] 접미사 face 미설치 시 base family 가 generic 보다 먼저 구제.
+            match super::base_family_without_weight_suffix(&style.font_family) {
+                Some(base) => format!(
+                    "'{}', '{}', {}",
+                    escape_html(&style.font_family),
+                    escape_html(&base),
+                    fallback
+                ),
+                None => format!("'{}', {}", escape_html(&style.font_family), fallback),
+            }
         };
 
         // 위첨자/아래첨자: y좌표·font_size 직접 조정 (absolute 위치이므로 vertical-align 불가)

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -971,6 +971,60 @@ pub(crate) fn text_anchor_square_table_strip(
     (strip_cs > 0 && strip_sw > 0).then_some((strip_cs, strip_sw))
 }
 
+/// [#3314] 요청 face 의 굵기/폭 접미사를 벗긴 base family.
+///
+/// `"Noto Serif KR Black"` → `Some("Noto Serif KR")`, 접미사가 없으면 `None`.
+/// 폴백 체인은 요청 face 바로 뒤에 이 base 를 끼워 넣는다 — 접미사 face 가
+/// 미설치일 때 같은 family 의 base face 가 generic 체인(Batang 등)보다 먼저
+/// 구제한다(1.hwpx: 한컴 NotoSerifKR vs rhwp Batang, 제목 잉크 −31%).
+/// 요청 face 가 실존하면 체인 선두라 무영향. **렌더 경로 전용** — 측정 경로
+/// (`text_measurement`)는 쓰지 않아 조판(쪽수)이 불변이다.
+pub fn base_family_without_weight_suffix(font_family: &str) -> Option<String> {
+    // 뒤에서부터 제거되는 토큰들. "Extra Bold" 처럼 두 토큰으로 쪼개진 경우를
+    // 위해 수식 접두 토큰(extra/ultra/semi/demi)도 포함한다.
+    const WEIGHT_TOKENS: &[&str] = &[
+        "black",
+        "heavy",
+        "extrabold",
+        "ultrabold",
+        "semibold",
+        "demibold",
+        "bold",
+        "medium",
+        "regular",
+        "normal",
+        "extralight",
+        "ultralight",
+        "demilight",
+        "light",
+        "thin",
+        "extra",
+        "ultra",
+        "semi",
+        "demi",
+    ];
+    let mut tokens: Vec<&str> = font_family.split_whitespace().collect();
+    let original_len = tokens.len();
+    while tokens.len() > 1 {
+        let last = tokens.last().expect("len > 1").to_ascii_lowercase();
+        if WEIGHT_TOKENS.contains(&last.as_str()) {
+            tokens.pop();
+        } else {
+            break;
+        }
+    }
+    (tokens.len() < original_len).then(|| tokens.join(" "))
+}
+
+/// [#3314] 렌더용 폴백 체인 문자열: `요청 face → (base family) → generic 체인`.
+pub fn render_font_family_chain(font_family: &str) -> String {
+    let fb = generic_fallback(font_family);
+    match base_family_without_weight_suffix(font_family) {
+        Some(base) => format!("{},'{}',{}", font_family, base, fb),
+        None => format!("{},{}", font_family, fb),
+    }
+}
+
 /// CSS generic fallback 반환 (serif 또는 sans-serif)
 ///
 /// 폰트 이름에 명조/바탕/궁서 등 세리프 계열 키워드가 포함되면 "serif",
@@ -1637,6 +1691,39 @@ mod tests {
         assert_eq!(format_number(26, NumberFormat::LatinUpper), "Z");
         assert_eq!(format_number(27, NumberFormat::LatinUpper), "AA");
         assert_eq!(format_number(1, NumberFormat::LatinLower), "a");
+    }
+
+    /// [#3314] 굵기 접미사 face 의 base family 추출과 렌더 체인 삽입.
+    #[test]
+    fn test_base_family_without_weight_suffix() {
+        assert_eq!(
+            base_family_without_weight_suffix("Noto Serif KR Black").as_deref(),
+            Some("Noto Serif KR")
+        );
+        assert_eq!(
+            base_family_without_weight_suffix("나눔고딕 Bold").as_deref(),
+            Some("나눔고딕")
+        );
+        assert_eq!(
+            base_family_without_weight_suffix("경기천년제목 Light").as_deref(),
+            Some("경기천년제목")
+        );
+        // 두 토큰 접미사 ("Extra Bold")
+        assert_eq!(
+            base_family_without_weight_suffix("Noto Sans KR Extra Bold").as_deref(),
+            Some("Noto Sans KR")
+        );
+        // 접미사 없음 → None (체인 불변)
+        assert_eq!(base_family_without_weight_suffix("맑은 고딕"), None);
+        assert_eq!(base_family_without_weight_suffix("HY헤드라인M"), None);
+        assert_eq!(base_family_without_weight_suffix("휴먼명조"), None);
+        // 전체가 접미사 토큰뿐이면 벗기지 않는다
+        assert_eq!(base_family_without_weight_suffix("Light"), None);
+        // 렌더 체인: 요청 face → base → generic
+        let chain = render_font_family_chain("Noto Serif KR Black");
+        assert!(chain.starts_with("Noto Serif KR Black,'Noto Serif KR',"));
+        let plain = render_font_family_chain("맑은 고딕");
+        assert!(plain.starts_with("맑은 고딕,'Malgun Gothic'"));
     }
 
     #[test]

--- a/src/renderer/skia/text_replay.rs
+++ b/src/renderer/skia/text_replay.rs
@@ -65,8 +65,15 @@ impl SkiaTextReplay<'_> {
                     (false, false) => FontStyle::normal(),
                 };
                 let mut families = Vec::new();
+                // [#3314] 접미사 face("Noto Serif KR Black") 미설치 시 base
+                // family 가 아래 generic 폴백보다 먼저 구제 — SVG 체인과 정합.
+                let base_family =
+                    crate::renderer::base_family_without_weight_suffix(&style.font_family);
                 if !style.font_family.trim().is_empty() {
                     families.push(style.font_family.as_str());
+                }
+                if let Some(base) = base_family.as_deref() {
+                    families.push(base);
                 }
                 // 한글 fallback (CJK glyph 미보유 폰트로 fallback 시 사각형 방지).
                 // SVG 경로의 CSS font chain 과 동일한 한글 폴백 폰트 순서.

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -320,8 +320,8 @@ impl SvgRenderer {
                     let font_family = if run.style.font_family.is_empty() {
                         "sans-serif".to_string()
                     } else {
-                        let fb = super::generic_fallback(&run.style.font_family);
-                        format!("{},{}", run.style.font_family, fb)
+                        // [#3314] 요청 face → base family → generic 체인.
+                        super::render_font_family_chain(&run.style.font_family)
                     };
                     let mut attrs = format!("font-family=\"{}\" font-size=\"{}\" fill=\"{}\" text-anchor=\"middle\" dominant-baseline=\"central\"",
                         escape_xml(&font_family), font_size, color);
@@ -1979,8 +1979,8 @@ impl SvgRenderer {
         let font_family_str = if style.font_family.is_empty() {
             "sans-serif".to_string()
         } else {
-            let fb = super::generic_fallback(&style.font_family);
-            format!("{},{}", style.font_family, fb)
+            // [#3314] 요청 face → base family → generic 체인.
+            super::render_font_family_chain(&style.font_family)
         };
         let mut font_attrs = format!(
             "font-family=\"{}\" font-size=\"{:.2}\"",
@@ -2123,8 +2123,8 @@ impl SvgRenderer {
         let font_family_str = if style.font_family.is_empty() {
             "sans-serif".to_string()
         } else {
-            let fb = super::generic_fallback(&style.font_family);
-            format!("{},{}", style.font_family, fb)
+            // [#3314] 요청 face → base family → generic 체인.
+            super::render_font_family_chain(&style.font_family)
         };
         let mut font_attrs = format!(
             "font-family=\"{}\" font-size=\"{:.2}\"",
@@ -2698,8 +2698,8 @@ impl Renderer for SvgRenderer {
         let font_family = if style.font_family.is_empty() {
             "sans-serif".to_string()
         } else {
-            let fb = super::generic_fallback(&style.font_family);
-            format!("{},{}", style.font_family, fb)
+            // [#3314] 요청 face → base family → generic 체인.
+            super::render_font_family_chain(&style.font_family)
         };
         let old_hangul_font_family = format!("'Source Han Serif K Old Hangul',{}", font_family);
 


### PR DESCRIPTION
## 요약

이슈 #3314 수정입니다. 문서가 굵기 접미사가 붙은 face(`Noto Serif KR Black`,
`경기천년제목 Light`, `나눔고딕 Bold` 등)를 지정하고 해당 face 가 미설치면,
폴백 체인이 **같은 family 의 base face 를 건너뛰고** generic 체인 선두(세리프의
경우 Batang)로 낙하했습니다 — 1.hwpx 한글 오라클 PDF span 대조에서 제목 잉크
−31%·ASCII 줄 폭 −25%(514→385px)의 원인으로 확정된 결함입니다.

## 수정

- `base_family_without_weight_suffix()` — 요청 face 의 굵기/폭 토큰(Black·Bold·
  Light·ExtraLight 등, "Extra Bold" 2-토큰형 포함)을 후방에서 벗긴 base family.
- 렌더 체인 4경로에 `요청 face → base family → generic 체인` 순으로 삽입:
  svg 4개소(`render_font_family_chain` 헬퍼), html, skia `families` 리스트.
- **측정 경로(`text_measurement`)는 불변** — 조판(쪽수) 비접촉을 구조로 보장
  (접미사 제거 A/B 기실측: ASCII advance +0.00%, stored lineseg 지배).
- 요청 face 가 실존하면 체인 선두이므로 무영향 — 미설치일 때만 base 가 구제.

## 검증

- 체인 실측: `경기천년제목 Light,'경기천년제목','Malgun Gothic',…` (base 삽입 확인)
- **영향 반경 A/B** (무작위 1,000건 p1, 수정 전후 release): 변경 **3건(0.3%),
  최대 0.66%** — 전건 한글 COM 오라클 재판정 **중립(±0.02pp), 회귀 0**
- 92셋 페이지 게이트 92/92 (100%), svg_snapshot 골든 8/8 재갱신 불필요
- nextest 전체 4,127/4,127 통과, clippy -D warnings 클린, fmt 클린
- 단위 테스트 추가(접미사 추출 6형 + 체인 조립 2형)

r23 서베이 분석에서 도출한 폰트 축 수정 2건 중 두 번째로, skia 폰트 조달 분리
(#3300, PR #3310)와 독립적으로 적용 가능합니다.

Closes #3314

🤖 Generated with [Claude Code](https://claude.com/claude-code)
