### PR TITLE
fix(renderer): planet6897 폰트 폴백 PR 통합 (#3300, #3314)

### DIFF
--- a/mydocs/orders/20260726.md
+++ b/mydocs/orders/20260726.md
@@ -12,3 +12,15 @@
 - 증적: `mydocs/report/assets/task_m100_3319/so_sueop_hwpx_ole_selected.png`의 실제 선택 테두리·
   회전 핸들.
 - 다음: merge 승인 뒤 #3319 자동 close, `devel` 동기화, 작업 branch와 검토 전용 target 정리.
+
+## planet6897 #3310·#3318 — 폰트 fallback 통합 검토
+
+- `review/planet6897-font-20260726`은 최신 `upstream/devel` `61b13fad4` 위에서
+  #3310 `dc2f505` → #3318 `2e60b06`을 누적 cherry-pick한 검토 branch다.
+- 메인터너 보정 `678494aa0`은 Web Canvas의 빠진 base-family fallback 네 경로와,
+  headless form caption의 bundled Noto 최후 폴백을 보완한다. 원 contributor head에는 push하지 않는다.
+- 검증: focused 폰트 tests, Native Skia 공식 3종(57·2·4 tests), release-test 전수 실행,
+  fmt·clippy·diff check 통과. WASM build는 작업지시자가 수동 실행한다.
+- #3300의 `156467716`, #3314의 `1.hwpx` 및 기준 PDF는 PR·issue·저장소에 없어 independent visual
+  sweep은 보류로 기록했다. 자료가 제공되면 실제 PDF/PNG 대조를 추가한다.
+- 다음: 작업지시자 승인 뒤 통합 branch를 upstream 임시 head로 push하고 `devel` 대상 PR을 생성한다.

--- a/mydocs/pr/archives/pr_3310_review.md
+++ b/mydocs/pr/archives/pr_3310_review.md
@@ -1,0 +1,67 @@
+# PR #3310 검토 기록
+
+## 라우팅
+
+```text
+base route: collaborator_external_pr
+modifiers: intake_and_review, local_validation, multi_pr_update_branch,
+  visual_fixture_evidence
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+  collaborator_external_pr.md, intake_and_review.md, local_validation.md,
+  multi_pr_update_branch.md, visual_fixture_evidence.md
+current head: 작성 시점 참고값 dc2f505ae5cbc468b26e692153b63b1ea596e4d4
+```
+
+## PR metadata
+
+| 항목 | 작성 시점 참고값 |
+| --- | --- |
+| PR | [#3310](https://github.com/edwardkim/rhwp/pull/3310) |
+| 제목 | `fix(#3300): skia 폰트 조달을 custom/번들로 분리` |
+| 작성자 / base | `planet6897` / `devel` |
+| 원 head / commit | `fix/3300-skia-custom-font-dirs` / `dc2f505ae5cbc468b26e692153b63b1ea596e4d4` |
+| 관련 이슈 | [#3300](https://github.com/edwardkim/rhwp/issues/3300) |
+| 규모 | 3 files, +99/-8, 1 commit |
+| 원 PR 상태 | `MERGEABLE`, `BEHIND`; maintainer 수정 허용, reviewer `jangster77` 요청 완료 |
+| 통합 branch | `review/planet6897-font-20260726` (`upstream/devel` `61b13fad4` 기준) |
+
+위 상태와 SHA는 작성 시점 참고값이다. 원 PR은 최신 `devel`보다 뒤에 있으므로 직접 merge하지 않고
+#3318과 함께 최신 devel 위 누적 검토한다.
+
+## 변경과 누적 적용
+
+- 원 commit `dc2f505`를 통합 branch에 `2c640c46`으로 충돌 없이 cherry-pick했다.
+- `custom_font_dirs()`를 호출자 지정·환경변수로 한정하고, `bundled_font_dirs()`의
+  `ttfs/opensource`를 별도 typeface map으로 적재한다. 따라서 시스템 family의 스타일 매칭은
+  `FontMgr::match_family_style`에 남고, 번들은 custom·system 뒤 최후 폴백이 된다.
+- 통합 검토에서 form caption 경로가 분리한 bundle map을 보지 않는 누락을 발견했다. 보정 commit
+  `678494aa0`은 form 후보 끝에 bundled `Noto Sans KR ExtraLight`와 `Noto Sans KR`를 넣고,
+  custom → system → bundled → legacy 순서를 유지한다.
+
+원 contributor head는 rewrite·push하지 않는다. 보정은 통합 branch에만 있다.
+
+## 검증
+
+- `custom_font_dirs_excludes_system_and_bundled`, `bundled_font_dirs_is_repo_asset_only`: 통과
+- `issue_3300_form_family_chain_includes_bundled_noto_fallbacks`: Native Skia에서 통과
+- `cargo test --profile release-test --features native-skia skia --lib`: 57 passed
+- `issue_2225_missing_picture_placeholder`: 2 passed
+- `render_p37_direct_pdf_export`: 4 passed
+- `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests`: 전수 실행 완료
+  (IR field sweep 포함; 신규·이동 fixture가 없으므로 baseline TSV 변경 없음)
+- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `git diff --check`: 통과
+- WASM build는 작업지시자가 수동 실행하는 범위라 이 review에서 재실행하지 않았다.
+
+## 시각·fixture 판정
+
+#3300 이슈와 PR에는 재현 문서 `156467716`의 HWP/HWPX 원본·기준 PDF가 첨부되지 않았고, 저장소에도
+동일 이름의 fixture가 없다. 따라서 원본 대 기준 PDF의 독립 visual sweep·대표 PNG는 만들 수 없다.
+이는 실제 sweep 통과로 대체하지 않는다. Skia typeface 우선순위와 form fallback은 위 Native Skia 단위
+검증으로 확인했고, 재현 파일이 제공되면 PDF/PNG 대조를 후속 검증으로 수행한다.
+
+## 최종 권고
+
+[#3318](https://github.com/edwardkim/rhwp/pull/3318)과 함께 통합 branch의 새 `devel` 대상 PR로
+준비하는 것을 권고한다. 최신 통합 head의 full CI와 작업지시자 push·PR 생성 승인이 선행 조건이다.
+통합 PR merge 뒤에는 #3310 원 PR close와 #3300 close 상태를 확인하고, contributor에게 통합 결과를
+한 번만 알린다.

--- a/mydocs/pr/archives/pr_3310_review_impl.md
+++ b/mydocs/pr/archives/pr_3310_review_impl.md
@@ -1,0 +1,23 @@
+# PR #3310 통합 검토·보정 계획
+
+## 적용 기준
+
+- 검토 branch: `review/planet6897-font-20260726`
+- 기준 devel: `61b13fad4fc022b0c00f99dbe995dfe8a923ab45`
+- contributor 원 commit: `dc2f505ae5cbc468b26e692153b63b1ea596e4d4`
+- 누적 cherry-pick: `2c640c46e`
+
+## 단계
+
+1. #3310 원 head를 SHA 고정·fetch하고 최신 devel 기반 검토 branch에 cherry-pick한다.
+2. #3318을 뒤이어 적용해 공통 `text_replay.rs`의 폴백 순서가 충돌 없이 합쳐지는지 확인한다.
+3. form caption이 `bundled_typefaces`를 사용하지 않는 누락을 `678494aa0`으로 보정하고 Native Skia
+   회귀 test를 추가한다. 원 contributor branch에는 push하지 않는다.
+4. #3310·#3318별 archive review, 오늘할일을 같은 통합 PR diff에 넣고 최신 code head의 full CI를 확인한다.
+5. 작업지시자 승인 뒤 upstream의 새 통합 head branch로 push·PR을 만든다. 원 PR은 통합 PR이 merge된 뒤에만
+   close와 완료 comment를 처리한다.
+
+## rollback
+
+통합 PR merge 전에는 `678494aa0` 또는 해당 cherry-pick commit만 되돌려 원인별로 재검증한다. contributor
+원 commit과 fork head는 rebase·amend·force-push하지 않는다.

--- a/mydocs/pr/archives/pr_3318_review.md
+++ b/mydocs/pr/archives/pr_3318_review.md
@@ -1,0 +1,60 @@
+# PR #3318 검토 기록
+
+## 라우팅
+
+```text
+base route: collaborator_external_pr
+modifiers: intake_and_review, local_validation, multi_pr_update_branch,
+  visual_fixture_evidence
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+  collaborator_external_pr.md, intake_and_review.md, local_validation.md,
+  multi_pr_update_branch.md, visual_fixture_evidence.md
+current head: 작성 시점 참고값 2e60b0645b99d748f2abe858da81cbf20ec4dd1b
+```
+
+## PR metadata
+
+| 항목 | 작성 시점 참고값 |
+| --- | --- |
+| PR | [#3318](https://github.com/edwardkim/rhwp/pull/3318) |
+| 제목 | `fix(#3314): 굵기 접미사 face 폴백에 base family 삽입` |
+| 작성자 / base | `planet6897` / `devel` |
+| 원 head / commit | `fix/3314-base-family-fallback` / `2e60b0645b99d748f2abe858da81cbf20ec4dd1b` |
+| 관련 이슈 | [#3314](https://github.com/edwardkim/rhwp/issues/3314) |
+| 규모 | 4 files, +112/-9, 1 commit |
+| 원 PR 상태 | `MERGEABLE`, `BEHIND`; maintainer 수정 허용, reviewer `jangster77` 요청 완료 |
+| 통합 branch | `review/planet6897-font-20260726` (`upstream/devel` `61b13fad4` 기준) |
+
+## 변경과 누적 적용
+
+- 원 commit `2e60b06`을 #3310 뒤에 `7da56d169`으로 cherry-pick했다. `text_replay.rs` 자동 병합은
+  충돌 없이 두 변경의 순서를 보존했다.
+- 원 변경은 SVG 네 경로, HTML, Native Skia가 요청 face → base family → generic fallback을 사용하도록
+  하고 text measurement는 그대로 둔다.
+- 같은 폴백 계약을 쓰는 Web Canvas 2D의 회전 text, 일반 text, char overlap, text control mark 네 경로가
+  빠진 것을 발견했다. 보정 commit `678494aa0`은 공용 `canvas_font_family_chain()`으로 네 경로를 통일해
+  Canvas에서도 base family가 generic 앞에 오도록 했다.
+
+## 검증
+
+- `test_base_family_without_weight_suffix`: 요청 face, base family, SVG·Canvas 인용 chain을 함께 검증해 통과
+- `cargo test --profile release-test --features native-skia skia --lib`: 57 passed
+- `issue_2225_missing_picture_placeholder`: 2 passed
+- `render_p37_direct_pdf_export`: 4 passed
+- `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests`: 전수 실행 완료
+  (IR field sweep 포함; fixture 변경 없음)
+- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `git diff --check`: 통과
+- WASM build는 작업지시자가 수동 실행하는 범위라 이 review에서 재실행하지 않았다.
+
+## 시각·fixture 판정
+
+#3314가 언급한 `1.hwpx`와 한컴 기준 PDF가 PR·issue에 첨부되지 않았고 저장소에도 없다. 따라서
+실제 page PNG·PDF 비교를 수행하거나 대표 visual asset을 만들 수 없다. 이는 visual sweep 통과가 아니라
+재현 자료 부재다. 새 unit test는 모든 Canvas 조립점과 SVG/Skia helper의 순서를 고정하며, 원본이 제공되면
+독립 시각 대조를 추가해야 한다.
+
+## 최종 권고
+
+#3310과 분리 merge하지 말고 통합 branch의 새 PR로 준비한다. 최신 통합 head의 full CI와 작업지시자
+push·PR 생성 승인이 충족되면 merge를 권고한다. merge 뒤 #3318 원 PR과 #3314의 close 상태를 확인하고
+동일 내용의 contributor comment를 중복 게시하지 않는다.

--- a/mydocs/pr/archives/pr_3318_review_impl.md
+++ b/mydocs/pr/archives/pr_3318_review_impl.md
@@ -1,0 +1,22 @@
+# PR #3318 통합 검토·보정 계획
+
+## 적용 기준
+
+- 검토 branch: `review/planet6897-font-20260726`
+- 기준 devel: `61b13fad4fc022b0c00f99dbe995dfe8a923ab45`
+- contributor 원 commit: `2e60b0645b99d748f2abe858da81cbf20ec4dd1b`
+- 누적 cherry-pick: `7da56d169`
+- 통합 보정: `678494aa0`
+
+## 단계
+
+1. #3310을 먼저 누적해 Skia custom·system·bundle typeface 우선순위를 확정한다.
+2. #3318을 적용해 Native Skia의 family list에 base family가 들어가는지 확인한다.
+3. Canvas 2D의 네 font-family 조립점을 공용 helper로 보정하고 native release-test에서 회귀를 고정한다.
+4. 시각 fixture/PDF 부재를 review에 기록하고, 원본이 제공될 때의 PDF/PNG 대조를 후속 조건으로 남긴다.
+5. #3310과 하나의 integration PR로 검증·제출한다. 원 contributor PR에는 보정 commit을 push하지 않는다.
+
+## rollback
+
+통합 PR merge 전 `678494aa0`을 되돌리면 원 #3318의 SVG·HTML·Skia 변경만 남는다. 다만 Canvas 경로가
+동일 계약에서 이탈하므로 이 상태는 merge 후보가 아니다.

--- a/src/renderer/font_paths.rs
+++ b/src/renderer/font_paths.rs
@@ -95,6 +95,31 @@ pub fn search_dirs(extra: &[PathBuf]) -> Vec<PathBuf> {
     dirs
 }
 
+/// custom typeface 로더(skia `with_font_paths`)용 디렉터리 — **시스템·번들 제외**.
+///
+/// skia 의 custom 로더는 family 당 typeface 1개만 담아 굵기(스타일) 변형을
+/// 표현하지 못하고, 해석 체인에서 시스템 매칭보다 앞선다(#2864 이전 필드
+/// 검증 의미론). 그래서 여기에는 사용자가 의도한 폰트(호출자 지정 → 환경
+/// 변수)만 담는다:
+/// - 시스템 디렉터리를 넣으면 regular 파일이 family 를 선점해 bold run 이
+///   전부 regular 로 렌더된다(#3300) — 시스템 폰트는
+///   `FontMgr::match_family_style`(정상 스타일 매칭)이 담당한다.
+/// - 번들 opensource 를 넣으면 깊은 폴백(Noto Sans KR)이 시스템 1순위를
+///   제치고 선점된다(#3300, r23 발산 −6.9pp) — 번들은 별도 최후-폴백 로더
+///   (`bundled_font_dirs`)로 체인 말미에만 선다.
+pub fn custom_font_dirs(extra: &[PathBuf]) -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = extra.to_vec();
+    dirs.extend(env_font_paths());
+    dirs
+}
+
+/// 번들 최후-폴백 로더용 디렉터리 — 폰트 미설치 환경(CI headless·컨테이너)
+/// 에서 한국어 드롭을 막는 저장소 자산(#2293). 해석 체인에서는 custom·시스템
+/// 뒤(최후)에만 선다(#3300).
+pub fn bundled_font_dirs() -> Vec<PathBuf> {
+    vec![PathBuf::from(BUNDLED_OPENSOURCE_DIR)]
+}
+
 /// `fontdb` 에 조달 순서대로 폰트를 적재한다.
 ///
 /// 시스템 폰트는 `load_system_fonts()` 가 담당하므로 여기서는 호출자 지정 →
@@ -203,5 +228,41 @@ mod tests {
                  폰트가 필요하면 --font-path 또는 {FONT_PATH_ENV} 로 지정한다."
             );
         }
+    }
+
+    /// [#3300] custom 로더 목록은 시스템·번들을 포함하면 안 된다.
+    /// - 시스템: family 당 1 typeface 라 굵기 변형 소실(regular 선점)
+    /// - 번들: 깊은 폴백(Noto)이 시스템 1순위를 제치고 본문을 렌더(r23 −6.9pp)
+    #[test]
+    fn custom_font_dirs_excludes_system_and_bundled() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::set_var(FONT_PATH_ENV, "/tmp/env-fonts");
+        let extra = vec![PathBuf::from("/tmp/caller")];
+        let dirs = custom_font_dirs(&extra);
+        assert_eq!(
+            dirs,
+            vec![
+                PathBuf::from("/tmp/caller"),
+                PathBuf::from("/tmp/env-fonts")
+            ],
+            "custom 로더는 호출자 지정 → 환경변수만 담는다"
+        );
+        for sys in system_font_dirs() {
+            assert!(!dirs.contains(&sys), "시스템 디렉터리 포함 금지: {sys:?}");
+        }
+        assert!(
+            !dirs.contains(&PathBuf::from(BUNDLED_OPENSOURCE_DIR)),
+            "번들은 custom 이 아니라 최후-폴백 로더로 간다"
+        );
+        std::env::remove_var(FONT_PATH_ENV);
+    }
+
+    /// [#3300] 번들 최후-폴백 로더는 저장소 자산만 담는다(#2293 한국어 드롭 방지).
+    #[test]
+    fn bundled_font_dirs_is_repo_asset_only() {
+        assert_eq!(
+            bundled_font_dirs(),
+            vec![PathBuf::from(BUNDLED_OPENSOURCE_DIR)]
+        );
     }
 }

--- a/src/renderer/html.rs
+++ b/src/renderer/html.rs
@@ -292,7 +292,16 @@ impl Renderer for HtmlRenderer {
             "sans-serif".to_string()
         } else {
             let fallback = super::generic_fallback(&style.font_family);
-            format!("'{}', {}", escape_html(&style.font_family), fallback)
+            // [#3314] 접미사 face 미설치 시 base family 가 generic 보다 먼저 구제.
+            match super::base_family_without_weight_suffix(&style.font_family) {
+                Some(base) => format!(
+                    "'{}', '{}', {}",
+                    escape_html(&style.font_family),
+                    escape_html(&base),
+                    fallback
+                ),
+                None => format!("'{}', {}", escape_html(&style.font_family), fallback),
+            }
         };
 
         // 위첨자/아래첨자: y좌표·font_size 직접 조정 (absolute 위치이므로 vertical-align 불가)

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1025,6 +1025,23 @@ pub fn render_font_family_chain(font_family: &str) -> String {
     }
 }
 
+/// Canvas 2D 렌더용 인용 font-family 체인.
+///
+/// [#3314] Canvas API가 요구하는 인용 형식을 유지하면서, 굵기 접미사 face
+/// 바로 뒤에 base family를 넣어 generic 폴백보다 먼저 선택되게 한다.
+/// 측정 경로에는 사용하지 않는다.
+pub fn canvas_font_family_chain(font_family: &str) -> String {
+    if font_family.is_empty() {
+        return "sans-serif".to_string();
+    }
+
+    let fallback = generic_fallback(font_family);
+    match base_family_without_weight_suffix(font_family) {
+        Some(base) => format!("\"{}\", \"{}\", {}", font_family, base, fallback),
+        None => format!("\"{}\", {}", font_family, fallback),
+    }
+}
+
 /// CSS generic fallback 반환 (serif 또는 sans-serif)
 ///
 /// 폰트 이름에 명조/바탕/궁서 등 세리프 계열 키워드가 포함되면 "serif",
@@ -1724,6 +1741,18 @@ mod tests {
         assert!(chain.starts_with("Noto Serif KR Black,'Noto Serif KR',"));
         let plain = render_font_family_chain("맑은 고딕");
         assert!(plain.starts_with("맑은 고딕,'Malgun Gothic'"));
+
+        assert_eq!(
+            canvas_font_family_chain("Noto Serif KR Black"),
+            format!(
+                "\"Noto Serif KR Black\", \"Noto Serif KR\", {}",
+                generic_fallback("Noto Serif KR Black")
+            )
+        );
+        assert_eq!(
+            canvas_font_family_chain("맑은 고딕"),
+            format!("\"맑은 고딕\", {}", generic_fallback("맑은 고딕"))
+        );
     }
 
     #[test]

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -971,6 +971,60 @@ pub(crate) fn text_anchor_square_table_strip(
     (strip_cs > 0 && strip_sw > 0).then_some((strip_cs, strip_sw))
 }
 
+/// [#3314] 요청 face 의 굵기/폭 접미사를 벗긴 base family.
+///
+/// `"Noto Serif KR Black"` → `Some("Noto Serif KR")`, 접미사가 없으면 `None`.
+/// 폴백 체인은 요청 face 바로 뒤에 이 base 를 끼워 넣는다 — 접미사 face 가
+/// 미설치일 때 같은 family 의 base face 가 generic 체인(Batang 등)보다 먼저
+/// 구제한다(1.hwpx: 한컴 NotoSerifKR vs rhwp Batang, 제목 잉크 −31%).
+/// 요청 face 가 실존하면 체인 선두라 무영향. **렌더 경로 전용** — 측정 경로
+/// (`text_measurement`)는 쓰지 않아 조판(쪽수)이 불변이다.
+pub fn base_family_without_weight_suffix(font_family: &str) -> Option<String> {
+    // 뒤에서부터 제거되는 토큰들. "Extra Bold" 처럼 두 토큰으로 쪼개진 경우를
+    // 위해 수식 접두 토큰(extra/ultra/semi/demi)도 포함한다.
+    const WEIGHT_TOKENS: &[&str] = &[
+        "black",
+        "heavy",
+        "extrabold",
+        "ultrabold",
+        "semibold",
+        "demibold",
+        "bold",
+        "medium",
+        "regular",
+        "normal",
+        "extralight",
+        "ultralight",
+        "demilight",
+        "light",
+        "thin",
+        "extra",
+        "ultra",
+        "semi",
+        "demi",
+    ];
+    let mut tokens: Vec<&str> = font_family.split_whitespace().collect();
+    let original_len = tokens.len();
+    while tokens.len() > 1 {
+        let last = tokens.last().expect("len > 1").to_ascii_lowercase();
+        if WEIGHT_TOKENS.contains(&last.as_str()) {
+            tokens.pop();
+        } else {
+            break;
+        }
+    }
+    (tokens.len() < original_len).then(|| tokens.join(" "))
+}
+
+/// [#3314] 렌더용 폴백 체인 문자열: `요청 face → (base family) → generic 체인`.
+pub fn render_font_family_chain(font_family: &str) -> String {
+    let fb = generic_fallback(font_family);
+    match base_family_without_weight_suffix(font_family) {
+        Some(base) => format!("{},'{}',{}", font_family, base, fb),
+        None => format!("{},{}", font_family, fb),
+    }
+}
+
 /// CSS generic fallback 반환 (serif 또는 sans-serif)
 ///
 /// 폰트 이름에 명조/바탕/궁서 등 세리프 계열 키워드가 포함되면 "serif",
@@ -1637,6 +1691,39 @@ mod tests {
         assert_eq!(format_number(26, NumberFormat::LatinUpper), "Z");
         assert_eq!(format_number(27, NumberFormat::LatinUpper), "AA");
         assert_eq!(format_number(1, NumberFormat::LatinLower), "a");
+    }
+
+    /// [#3314] 굵기 접미사 face 의 base family 추출과 렌더 체인 삽입.
+    #[test]
+    fn test_base_family_without_weight_suffix() {
+        assert_eq!(
+            base_family_without_weight_suffix("Noto Serif KR Black").as_deref(),
+            Some("Noto Serif KR")
+        );
+        assert_eq!(
+            base_family_without_weight_suffix("나눔고딕 Bold").as_deref(),
+            Some("나눔고딕")
+        );
+        assert_eq!(
+            base_family_without_weight_suffix("경기천년제목 Light").as_deref(),
+            Some("경기천년제목")
+        );
+        // 두 토큰 접미사 ("Extra Bold")
+        assert_eq!(
+            base_family_without_weight_suffix("Noto Sans KR Extra Bold").as_deref(),
+            Some("Noto Sans KR")
+        );
+        // 접미사 없음 → None (체인 불변)
+        assert_eq!(base_family_without_weight_suffix("맑은 고딕"), None);
+        assert_eq!(base_family_without_weight_suffix("HY헤드라인M"), None);
+        assert_eq!(base_family_without_weight_suffix("휴먼명조"), None);
+        // 전체가 접미사 토큰뿐이면 벗기지 않는다
+        assert_eq!(base_family_without_weight_suffix("Light"), None);
+        // 렌더 체인: 요청 face → base → generic
+        let chain = render_font_family_chain("Noto Serif KR Black");
+        assert!(chain.starts_with("Noto Serif KR Black,'Noto Serif KR',"));
+        let plain = render_font_family_chain("맑은 고딕");
+        assert!(plain.starts_with("맑은 고딕,'Malgun Gothic'"));
     }
 
     #[test]

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -275,6 +275,17 @@ fn font_digest_matches_resource_bytes(digest: &crate::paint::FontDigest, actual:
     digest.algorithm == crate::paint::RESOURCE_KEY_ALGORITHM && digest.value == actual
 }
 
+const FORM_CJK_FAMILIES: &[&str] = &[
+    "Malgun Gothic",
+    "맑은 고딕",
+    "NanumGothic",
+    "나눔고딕",
+    "AppleGothic",
+    // #3300: 시스템 부재 headless 환경에서는 bundled_typefaces가 이 두 family를 제공한다.
+    "Noto Sans KR ExtraLight",
+    "Noto Sans KR",
+];
+
 pub struct SkiaLayerRenderer {
     font_mgr: FontMgr,
     /// 사용자 지정 폰트 디렉토리에서 미리 로드한 폰트 캐시.
@@ -1245,20 +1256,18 @@ impl LayerRasterRenderer for SkiaLayerRenderer {
 impl SkiaLayerRenderer {
     fn make_form_font(&self, size: f32) -> Font {
         let style = FontStyle::default();
-        let cjk_families = [
-            "Malgun Gothic",
-            "맑은 고딕",
-            "NanumGothic",
-            "나눔고딕",
-            "AppleGothic",
-        ];
-        for family in &cjk_families {
+        for family in FORM_CJK_FAMILIES {
             if let Some(tf) = self.custom_typefaces.get(*family).cloned() {
                 return Font::new(tf, size);
             }
             if let Some(tf) =
                 match_system_family_style(&self.font_mgr, &self.system_families, family, style)
             {
+                return Font::new(tf, size);
+            }
+            // [#3300] 시스템 폰트가 없는 headless 환경에서는 번들 폰트가
+            // custom·system 뒤의 최후 폴백으로 form caption의 한국어를 구제한다.
+            if let Some(tf) = self.bundled_typefaces.get(*family).cloned() {
                 return Font::new(tf, size);
             }
         }
@@ -1540,6 +1549,15 @@ mod tests {
         image::load_from_memory(bytes)
             .expect("decode png")
             .to_rgba8()
+    }
+
+    #[test]
+    fn issue_3300_form_family_chain_includes_bundled_noto_fallbacks() {
+        assert_eq!(
+            &FORM_CJK_FAMILIES[FORM_CJK_FAMILIES.len() - 2..],
+            &["Noto Sans KR ExtraLight", "Noto Sans KR"],
+            "form caption은 system 후보 뒤에 bundled Noto 최후 폴백까지 탐색해야 한다"
+        );
     }
 
     fn assert_channel(pixel: image::Rgba<u8>, channel: usize, min: u8, max: u8) {

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -281,6 +281,11 @@ pub struct SkiaLayerRenderer {
     /// key = primary face name (Typeface::family_name), value = Typeface.
     /// SVG 의 `--font-path` 와 같은 패턴으로 ttfs 디렉토리의 한컴 전용 폰트 (HY견명조 등) 도 사용 가능.
     custom_typefaces: HashMap<String, Typeface>,
+    /// [#3300] 번들 최후-폴백 폰트(ttfs/opensource). custom 과 분리해 해석
+    /// 체인에서 custom·시스템 매칭 **뒤**에만 선다 — custom 에 섞으면 깊은
+    /// 폴백(Noto Sans KR)이 시스템 1순위(문서 지정 맑은 고딕 등)를 제치고
+    /// 본문 전체를 폴백 서체로 렌더한다(r23 발산 −6.9pp).
+    bundled_typefaces: HashMap<String, Typeface>,
     /// 시스템에 실제 존재하는 font family 목록.
     /// headless macOS 에서 missing family 를 CoreText 에 넘기면 downloadable font
     /// lookup IPC가 영구 대기할 수 있어, match_family_style 호출 전 사전 필터로 사용한다.
@@ -304,16 +309,17 @@ impl SkiaLayerRenderer {
         SKIA_FONT_BASE.with(|(font_mgr, system_families)| Self {
             font_mgr: font_mgr.clone(),
             custom_typefaces: HashMap::new(),
+            bundled_typefaces: HashMap::new(),
             system_families: system_families.clone(),
         })
     }
 
-    /// 사용자 지정 폰트 디렉토리 (ttfs 등) 의 폰트를 로드하여 Skia 가 직접 사용 가능하게 한다.
-    /// SVG 의 `--font-path` 와 동일한 패턴.
-    pub fn with_font_paths(mut self, font_paths: &[std::path::PathBuf]) -> Self {
-        // [#2864] 조달 순서는 renderer::font_paths 가 단일 정의한다.
-        let search_dirs = crate::renderer::font_paths::search_dirs(font_paths);
-        for dir in &search_dirs {
+    fn load_typefaces_from_dirs(
+        font_mgr: &FontMgr,
+        dirs: &[std::path::PathBuf],
+        into: &mut HashMap<String, Typeface>,
+    ) {
+        for dir in dirs {
             if !dir.exists() {
                 continue;
             }
@@ -329,14 +335,26 @@ impl SkiaLayerRenderer {
                     }
                     if let Ok(data) = std::fs::read(&path) {
                         let skia_data = skia_safe::Data::new_copy(&data);
-                        if let Some(typeface) = self.font_mgr.new_from_data(&skia_data, None) {
+                        if let Some(typeface) = font_mgr.new_from_data(&skia_data, None) {
                             let family = typeface.family_name();
-                            self.custom_typefaces.entry(family).or_insert(typeface);
+                            into.entry(family).or_insert(typeface);
                         }
                     }
                 }
             }
         }
+    }
+
+    /// 사용자 지정 폰트 디렉토리 (ttfs 등) 의 폰트를 로드하여 Skia 가 직접 사용 가능하게 한다.
+    /// SVG 의 `--font-path` 와 동일한 패턴.
+    pub fn with_font_paths(mut self, font_paths: &[std::path::PathBuf]) -> Self {
+        // [#2864] 조달 순서는 renderer::font_paths 가 단일 정의한다.
+        // [#3300] custom(호출자+환경변수)과 번들 최후-폴백을 분리 적재한다 —
+        // 시스템 디렉터리는 어느 쪽에도 넣지 않는다(스타일 매칭은 FontMgr 담당).
+        let custom_dirs = crate::renderer::font_paths::custom_font_dirs(font_paths);
+        Self::load_typefaces_from_dirs(&self.font_mgr, &custom_dirs, &mut self.custom_typefaces);
+        let bundled_dirs = crate::renderer::font_paths::bundled_font_dirs();
+        Self::load_typefaces_from_dirs(&self.font_mgr, &bundled_dirs, &mut self.bundled_typefaces);
         self
     }
 
@@ -615,6 +633,7 @@ impl SkiaLayerRenderer {
             canvas,
             font_mgr: &self.font_mgr,
             custom_typefaces: &self.custom_typefaces,
+            bundled_typefaces: &self.bundled_typefaces,
             system_families: &self.system_families,
             output_options,
         };

--- a/src/renderer/skia/text_replay.rs
+++ b/src/renderer/skia/text_replay.rs
@@ -22,6 +22,7 @@ pub(super) struct SkiaTextReplay<'a> {
     pub(super) canvas: &'a Canvas,
     pub(super) font_mgr: &'a FontMgr,
     pub(super) custom_typefaces: &'a HashMap<String, Typeface>,
+    pub(super) bundled_typefaces: &'a HashMap<String, Typeface>,
     pub(super) system_families: &'a SystemFontFamilies,
     pub(super) output_options: &'a LayerOutputOptions,
 }
@@ -114,6 +115,16 @@ impl SkiaTextReplay<'_> {
                             family,
                             font_style,
                         ) {
+                            push(&mut chain, &mut seen, tf);
+                        }
+                    }
+                    // [#3300] 번들 최후-폴백(ttfs/opensource)은 custom·시스템
+                    // 뒤에만 선다. #2864 가 번들을 custom 에 섞은 뒤 깊은 폴백
+                    // (Noto Sans KR)이 시스템 1순위를 제치고 본문 전체를 폴백
+                    // 서체로 렌더했다(r23 발산 −6.9pp). 폰트 미설치 환경(#2293)
+                    // 에서는 앞 단계가 비므로 종전대로 번들이 한국어를 구제한다.
+                    for family in &families {
+                        if let Some(tf) = self.bundled_typefaces.get(*family).cloned() {
                             push(&mut chain, &mut seen, tf);
                         }
                     }

--- a/src/renderer/skia/text_replay.rs
+++ b/src/renderer/skia/text_replay.rs
@@ -66,8 +66,15 @@ impl SkiaTextReplay<'_> {
                     (false, false) => FontStyle::normal(),
                 };
                 let mut families = Vec::new();
+                // [#3314] 접미사 face("Noto Serif KR Black") 미설치 시 base
+                // family 가 아래 generic 폴백보다 먼저 구제 — SVG 체인과 정합.
+                let base_family =
+                    crate::renderer::base_family_without_weight_suffix(&style.font_family);
                 if !style.font_family.trim().is_empty() {
                     families.push(style.font_family.as_str());
+                }
+                if let Some(base) = base_family.as_deref() {
+                    families.push(base);
                 }
                 // 한글 fallback (CJK glyph 미보유 폰트로 fallback 시 사각형 방지).
                 // SVG 경로의 CSS font chain 과 동일한 한글 폴백 폰트 순서.

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -320,8 +320,8 @@ impl SvgRenderer {
                     let font_family = if run.style.font_family.is_empty() {
                         "sans-serif".to_string()
                     } else {
-                        let fb = super::generic_fallback(&run.style.font_family);
-                        format!("{},{}", run.style.font_family, fb)
+                        // [#3314] 요청 face → base family → generic 체인.
+                        super::render_font_family_chain(&run.style.font_family)
                     };
                     let mut attrs = format!("font-family=\"{}\" font-size=\"{}\" fill=\"{}\" text-anchor=\"middle\" dominant-baseline=\"central\"",
                         escape_xml(&font_family), font_size, color);
@@ -1979,8 +1979,8 @@ impl SvgRenderer {
         let font_family_str = if style.font_family.is_empty() {
             "sans-serif".to_string()
         } else {
-            let fb = super::generic_fallback(&style.font_family);
-            format!("{},{}", style.font_family, fb)
+            // [#3314] 요청 face → base family → generic 체인.
+            super::render_font_family_chain(&style.font_family)
         };
         let mut font_attrs = format!(
             "font-family=\"{}\" font-size=\"{:.2}\"",
@@ -2123,8 +2123,8 @@ impl SvgRenderer {
         let font_family_str = if style.font_family.is_empty() {
             "sans-serif".to_string()
         } else {
-            let fb = super::generic_fallback(&style.font_family);
-            format!("{},{}", style.font_family, fb)
+            // [#3314] 요청 face → base family → generic 체인.
+            super::render_font_family_chain(&style.font_family)
         };
         let mut font_attrs = format!(
             "font-family=\"{}\" font-size=\"{:.2}\"",
@@ -2698,8 +2698,8 @@ impl Renderer for SvgRenderer {
         let font_family = if style.font_family.is_empty() {
             "sans-serif".to_string()
         } else {
-            let fb = super::generic_fallback(&style.font_family);
-            format!("{},{}", style.font_family, fb)
+            // [#3314] 요청 face → base family → generic 체인.
+            super::render_font_family_chain(&style.font_family)
         };
         let old_hangul_font_family = format!("'Source Han Serif K Old Hangul',{}", font_family);
 

--- a/src/renderer/web_canvas.rs
+++ b/src/renderer/web_canvas.rs
@@ -729,12 +729,7 @@ impl WebCanvasRenderer {
             } else {
                 12.0
             };
-            let font_family = if run.style.font_family.is_empty() {
-                "sans-serif".to_string()
-            } else {
-                let fallback = super::generic_fallback(&run.style.font_family);
-                format!("\"{}\" , {}", run.style.font_family, fallback)
-            };
+            let font_family = super::canvas_font_family_chain(&run.style.font_family);
             let font = format!(
                 "{}{}{:.3}px {}",
                 font_style_str, font_weight, font_size, font_family
@@ -2168,12 +2163,7 @@ impl Renderer for WebCanvasRenderer {
             (base_font_size, y)
         };
 
-        let font_family = if style.font_family.is_empty() {
-            "sans-serif".to_string()
-        } else {
-            let fallback = super::generic_fallback(&style.font_family);
-            format!("\"{}\", {}", style.font_family, fallback)
-        };
+        let font_family = super::canvas_font_family_chain(&style.font_family);
 
         let font = format!(
             "{}{}{:.3}px {}",
@@ -3003,12 +2993,7 @@ impl WebCanvasRenderer {
             glyph_color.clone()
         };
 
-        let font_family = if style.font_family.is_empty() {
-            "sans-serif".to_string()
-        } else {
-            let fallback = super::generic_fallback(&style.font_family);
-            format!("\"{}\" , {}", style.font_family, fallback)
-        };
+        let font_family = super::canvas_font_family_chain(&style.font_family);
         let font_weight = if style.bold { "bold " } else { "" };
         let font_style_str = if style.italic { "italic " } else { "" };
         let font = format!(
@@ -3169,12 +3154,7 @@ impl WebCanvasRenderer {
             glyph_color.clone()
         };
 
-        let font_family = if style.font_family.is_empty() {
-            "sans-serif".to_string()
-        } else {
-            let fallback = super::generic_fallback(&style.font_family);
-            format!("\"{}\" , {}", style.font_family, fallback)
-        };
+        let font_family = super::canvas_font_family_chain(&style.font_family);
 
         let cx = bbox_x + box_size / 2.0;
         let cy = bbox_y + bbox_h - box_size / 2.0;


### PR DESCRIPTION
## 통합 범위

- [#3310](https://github.com/edwardkim/rhwp/pull/3310): Skia custom·system·bundled typeface 조달 분리
- [#3318](https://github.com/edwardkim/rhwp/pull/3318): 굵기 접미사 face 뒤 base family 폴백
- 메인터너 보정: Web Canvas 2D 네 font-family 조립점과 headless form caption의 bundled Noto 최후 폴백

Closes #3300
Closes #3314

## 검증

- focused 폰트 fallback tests
- Native Skia: `skia --lib` 57 passed, 공식 integration 2 passed·4 passed
- `cargo test --profile release-test --tests` 전수 실행
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `git diff --check`
- WASM build는 작업지시자가 수동 실행하는 범위라 이 PR에서 재실행하지 않았습니다.

## 시각 검증

#3300의 `156467716`, #3314의 `1.hwpx`와 기준 PDF는 PR·issue·저장소에 없어 독립 PDF/PNG visual sweep을 수행할 수 없었습니다. 이를 통과로 간주하지 않으며, 재현 자료가 제공되면 실제 대조를 추가합니다.

## 검토 기록

- `mydocs/pr/archives/pr_3310_review.md`
- `mydocs/pr/archives/pr_3310_review_impl.md`
- `mydocs/pr/archives/pr_3318_review.md`
- `mydocs/pr/archives/pr_3318_review_impl.md`

통합 PR merge 후 원 PR #3310·#3318의 close 상태와 contributor 완료 코멘트를 확인합니다.