### PR TITLE
feat(cli): edit fill-fields — 서식 값 채우기, CLI 메일머지 (Stage 3 최소 조각) (#3329)

### DIFF
--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -319,6 +319,27 @@ rhwp 는 이미 필드에 값을 쓸 수 있지만(`set_field_value_by_name`) �
 rhwp fields 신청서.hwp --json | jq -r '.fields[] | "\(.name): \(.memo // .guide)"'
 ```
 
+### `edit fill-fields <파일> --data <JSON|@파일> [옵션]` (#3329)
+누름틀에 값을 채운다 — 서식 자동 작성/메일머지. 검증된 코어 경로
+(`set_field_value_by_name`)를 재사용하므로 새 편집 로직이 없고, **필드 값만 바꾸므로
+레이아웃·구조는 불변**이다.
+- `--data <JSON|@파일>` — `{"필드이름":"값"}` 형식. `@경로` 면 파일에서 읽는다
+  (대량 메일머지에서 셸 인용을 피한다). 값이 문자열이 아니면 JSON 표현으로 넣는다.
+- `-o, --output <파일>` — 출력 파일 (기본 `<입력명>_filled.hwp`)
+- `--dry-run` — **파일을 쓰지 않고** 변경 예정 내역만 보고. 에이전트의 사전 확인 장치.
+- `--json` 봉투: `{"schemaVersion":"1.0","source","dryRun","filledCount","filled":[{name,value}],"notFound":[…],"output"?}`
+  - `notFound` — 문서에 없는 필드 이름. 조용히 무시하지 않으므로 오타를 즉시 안다.
+  - `output` 은 실제 저장했을 때만 실린다(`--dry-run` 이면 없음).
+- **실패 시 원본 불변**: 필드 설정이 하나라도 실패하면 출력 파일을 쓰지 않고 종료 코드 1.
+- 종료 코드는 §종료 코드 계약 (없는 파일·직렬화/쓰기 실패 1 · 인자/JSON 오류 2)
+
+```bash
+# 서식 조사 → 값 채우기 → 산출물 재확인 (전 과정 CLI)
+rhwp fields 신청서.hwp --json | jq -r '.fields[].name'
+rhwp edit fill-fields 신청서.hwp --data @row.json -o out.hwp --json
+rhwp fields out.hwp --json | jq -c '[.fields[]|select(.value!="")|{name,value}]'
+```
+
 ---
 
 ## 3. 변환·비교

--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -249,6 +249,7 @@ JSON 계약·종료 코드를 파악하는 입구.
 `{"schemaVersion":"1.0","tool","version","formats","exitCodes","jsonContract","batch","commands":[{name,category,summary,...}]}`
 - `--json` 계약 명령(info/export-text/export-structure/batch)은 `json:true`·`recordFields` 로 상세 서술
 - `--help`(사람용)와 함께 현행화한다 — help 에만 추가된 명령은 드리프트 가드 테스트가 잡는다
+- 편집 명령(`edit`)도 등재된다 — MCP 도구로는 `hwp_fill_fields` 로 노출된다 (#3329)
 
 #### `capabilities --mcp` — MCP 도구 정의 생성
 MCP 서버(및 함수 호출 클라이언트)가 **그대로 등록할 수 있는** 도구 정의를 낸다.

--- a/mydocs/report/task_m100_3329_report.md
+++ b/mydocs/report/task_m100_3329_report.md
@@ -1,0 +1,57 @@
+# task_m100_3329 처리결과 보고서 — `edit fill-fields` (Stage 3 최소 조각)
+
+- **이슈**: [#3329](https://github.com/edwardkim/rhwp/issues/3329)
+- **브랜치**: `pr/task-edit-fill-fields` (upstream/devel `8bb8f277d` 직분기)
+- **범위**: `src/main.rs`(명령 2개·디스패치 1행·help), `tests/edit_fill_fields_contract.rs`(신규),
+  `mydocs/manual/cli_commands.md`
+- **분류**: 기능 추가 (편집 — 로드맵 #2659 Stage 3)
+
+## 1. 배경
+
+Stage 1(계약)·Stage 2(조회 기계화)가 devel 에 반영되어, 에이전트는 문서를 발견·검색·이해할
+수 있게 됐다. 특히 `fields --json` 으로 **서식이 무엇을 요구하는지** 읽을 수 있다.
+
+그런데 값을 채워 넣으려면 여전히 Windows + 한컴 오피스 + COM 매크로가 필요했다. 코어에
+`set_field_value_by_name` 이 이미 있고 rhwp-studio 가 쓰고 있는데 **CLI 출구가 없어서**
+브라우저 밖 자동화가 불가능했다.
+
+## 2. 설계 결정
+
+- **로드맵 §7.3 의 3종 중 `fill-fields` 하나만** 놓았다. 편집 축에서 위험이 가장 작고
+  (필드 값만 바꾸므로 레이아웃·구조 불변) 수요가 가장 크다(행정 서식 자동 작성).
+- **새 편집 로직 0줄** — 검증된 `set_field_value_by_name` 을 그대로 부른다.
+- **`--dry-run` 은 파일 생성 경로 자체를 타지 않는다.** 편집 명령의 안전장치는 "썼다가
+  지운다"가 아니라 "쓰지 않는다"여야 한다. 계약 테스트가 파일 부재를 단언한다.
+- **실패 시 원본 불변**: 필드 설정이 하나라도 실패하면 즉시 종료하고 출력을 쓰지 않는다.
+- **없는 필드 이름을 조용히 무시하지 않는다** — `notFound` 로 보고해 에이전트가 오타를
+  즉시 안다. 편집 전에 `collect_all_fields()` 로 실재 이름 집합을 먼저 모아 가려낸다.
+- **`@파일` 입력** — 대량 메일머지에서 셸 인용 지옥을 피하기 위해 `--data @row.json` 지원.
+- `edit` 을 명령군으로 열어 `replace-text`/`set-cell` 이 같은 규약으로 붙을 자리를 만들었다.
+
+## 3. 변경
+
+- `run_edit()` — `edit` 명령군 디스패처 (알 수 없는 하위 명령은 exit 2)
+- `edit_fill_fields()` — 인자 파싱 / `@파일` 처리 / dry-run 분기 / 봉투 방출
+- 디스패치 1행, help 등재, `cli_commands.md` 신설 항목
+
+## 4. 검증
+
+- **계약 테스트 7종 red→green**:
+  - `--dry-run` 이 **파일을 만들지 않음**(핵심 안전 계약)
+  - 저장 후 **산출물을 `fields --json` 으로 다시 읽어 값 반영 대조**(보고만 믿지 않음)
+  - 없는 필드 이름 `notFound` 보고
+  - 없는 파일 exit 1 + stdout 0바이트 + **출력 파일 미생성**
+  - 잘못된 JSON exit 2 / `--data` 누락 exit 2 / 알 수 없는 하위 명령 exit 2
+- `cargo clippy --release --bin rhwp -- -D warnings`: 0, `rustfmt` clean
+- 무회귀: `cli_exit_codes`(10), `fields_json_contract`(8) 전부 green
+- **실측 루프**: `samples/field-01.hwp` 로 서식 조사 → 3개 필드 채우기 → 산출물 재독으로
+  `회사명`·`작성자`·`부서명` 값 반영 확인 (전 과정 CLI)
+
+## 5. 남긴 것
+
+- `edit replace-text` / `edit set-cell` — 같은 규약(`--dry-run`·결과 JSON·원본 불변)으로
+  이 조각이 머지된 뒤 후속.
+- 머리말/꼬리말·각주/미주 안의 필드는 `collect_fields_from_paragraph` 재귀 범위 밖이라
+  채워지지 않는다(`fields` 와 같은 한계, 문서에 명시됨).
+- HWPX 입력의 `edit fill-fields` 는 `export_hwp_native()` 가 HWP5 산출이라 이번 범위에서
+  다루지 않았다 — HWPX 왕복 저장 경로 연결은 별도 이슈가 맞다.

--- a/src/main.rs
+++ b/src/main.rs
@@ -254,6 +254,27 @@ fn show_mcp_tools() -> i32 {
             serde_json::json!(["batch", "{subcommand}", "--json"]),
             &["schemaVersion", "source", "error", "exitClass"],
         ),
+        tool(
+            "hwp_fill_fields",
+            "HWP 서식(템플릿)의 누름틀에 값을 채워 새 문서를 만든다. 먼저 hwp_fields 로 어떤 필드가 있는지 확인한 뒤 사용한다. dryRun 으로 파일을 만들지 않고 변경 예정만 확인할 수 있다.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string", "description": "입력 HWP 문서 경로" },
+                    "data": {
+                        "type": "object",
+                        "additionalProperties": { "type": "string" },
+                        "description": "{\"필드이름\":\"값\"} 형태의 채울 값"
+                    },
+                    "output": { "type": "string", "description": "출력 파일 경로. 생략하면 <입력명>_filled.hwp" },
+                    "dryRun": { "type": "boolean", "description": "true 면 파일을 쓰지 않고 변경 예정만 보고" }
+                },
+                "required": ["path", "data"],
+            }),
+            "edit",
+            serde_json::json!(["edit", "fill-fields", "{path}", "--data", "{data}", "--json"]),
+            &["schemaVersion", "source", "dryRun", "filledCount", "filled", "notFound", "output"],
+        ),
     ];
 
     let manifest = serde_json::json!({
@@ -451,6 +472,23 @@ fn show_capabilities(args: &[String]) -> i32 {
         ),
         cmd("build-from-ingest", "export", "ingest JSON에서 HWPX 생성"),
         cmd("thumbnail", "export", "내장 썸네일(PrvImage) 추출"),
+        // ── 편집 (#3329 Stage 3) ──
+        cmd_json(
+            "edit",
+            "edit",
+            "문서 편집 — fill-fields: 누름틀에 값 채우기(서식 자동 작성/메일머지)",
+            false,
+            &["--data", "-o", "--dry-run", "--json"],
+            &[
+                "schemaVersion",
+                "source",
+                "dryRun",
+                "filledCount",
+                "filled",
+                "notFound",
+                "output",
+            ],
+        ),
         // ── 배치 ──
         cmd_json(
             "batch",

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,7 @@ fn main() {
         Some("bench") => rhwp::diagnostics::bench::run(&args[2..]),
         Some("thumbnail") => extract_thumbnail(&args[2..]),
         Some("fields") => exit_with(show_fields(&args[2..])),
+        Some("edit") => exit_with(run_edit(&args[2..])),
         // [#2707] 알 수 없는 명령·명령 누락은 사용법 오류다. 표준 CLI 관례대로 stderr 로 안내하고
         // 종료 코드 2로 끝낸다(기존에는 stdout + 0이라 오타 낸 명령이 스크립트에서 성공으로 보였다).
         other => {
@@ -804,6 +805,14 @@ fn print_help() {
     println!("  fields <파일.hwp|파일.hwpx> [--json]");
     println!("      누름틀/필드 조사 (읽기 전용) — 이름·안내문·지시문·현재값·위치");
     println!();
+    println!("      --json                    계약 봉투 JSON을 stdout에 출력");
+    println!();
+    println!("  edit fill-fields <파일.hwp> --data <JSON|@파일> [-o <출력.hwp>] [옵션]");
+    println!("      누름틀에 값을 채운다 (서식 자동 작성/메일머지)");
+    println!();
+    println!("      --data <JSON|@파일>       {{\"필드이름\":\"값\"}} 형식. @경로면 파일에서 읽음");
+    println!("      -o, --output <파일>       출력 파일 (기본: 입력명_filled.hwp)");
+    println!("      --dry-run                 파일을 쓰지 않고 변경 예정 내역만 보고");
     println!("      --json                    계약 봉투 JSON을 stdout에 출력");
     println!();
     println!("내부 개발·회귀 도구 (일반 사용자 대상 아님):");
@@ -7599,6 +7608,212 @@ fn ir_diff(args: &[String]) -> i32 {
 /// rhwp 는 이미 필드에 값을 **쓸 수** 있는데(`set_field_value_by_name`) 조회 API 는
 /// WASM/스튜디오 경로에만 있어, 브라우저 밖 에이전트는 "이 서식이 무엇을 요구하는지"
 /// 알 방법이 없었다. 기존 `collect_all_fields()` 를 그대로 노출한다(라이브러리 무변경).
+/// `edit` — 문서 편집 명령군 (로드맵 #2659 Stage 3).
+///
+/// 공통 규약: `--dry-run`(변경 요약만 출력, 파일 무변경), 결과 리포트 JSON,
+/// **실패 시 원본 불변**(하나라도 실패하면 출력 파일을 쓰지 않는다).
+fn run_edit(args: &[String]) -> i32 {
+    const USAGE: &str = "사용법: rhwp edit fill-fields <파일.hwp> --data <JSON|@파일> [-o <출력.hwp>] [--dry-run] [--json]";
+
+    match args.first().map(String::as_str) {
+        Some("fill-fields") => edit_fill_fields(&args[1..]),
+        Some(other) => {
+            eprintln!("오류: 알 수 없는 edit 하위 명령 - {}", other);
+            eprintln!("{USAGE}");
+            EXIT_USAGE
+        }
+        None => {
+            eprintln!("오류: edit 하위 명령을 지정해주세요.");
+            eprintln!("{USAGE}");
+            EXIT_USAGE
+        }
+    }
+}
+
+/// `edit fill-fields` — 누름틀에 값을 채운다 (메일머지).
+///
+/// 검증된 코어 경로(`set_field_value_by_name`)를 재사용하므로 새 편집 로직이 없다.
+/// 필드 값만 바꾸므로 레이아웃·구조는 불변이다.
+fn edit_fill_fields(args: &[String]) -> i32 {
+    let mut file_path: Option<&str> = None;
+    let mut data_arg: Option<&str> = None;
+    let mut out_path: Option<String> = None;
+    let mut dry_run = false;
+    let mut json_mode = false;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--data" => {
+                i += 1;
+                match args.get(i) {
+                    Some(v) => data_arg = Some(v),
+                    None => {
+                        eprintln!("오류: --data 뒤에 JSON 또는 @파일경로가 필요합니다.");
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            "-o" | "--output" => {
+                i += 1;
+                match args.get(i) {
+                    Some(v) => out_path = Some(v.clone()),
+                    None => {
+                        eprintln!("오류: -o 뒤에 출력 파일 경로가 필요합니다.");
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            "--dry-run" => dry_run = true,
+            "--json" => json_mode = true,
+            other if other.starts_with('-') => {
+                eprintln!("알 수 없는 옵션: {other}");
+                return EXIT_USAGE;
+            }
+            other => file_path = Some(other),
+        }
+        i += 1;
+    }
+
+    let (Some(file_path), Some(data_arg)) = (file_path, data_arg) else {
+        eprintln!("사용법: rhwp edit fill-fields <파일.hwp> --data <JSON|@파일> [-o <출력.hwp>] [--dry-run] [--json]");
+        return EXIT_USAGE;
+    };
+
+    // `@경로` 면 파일에서 읽는다 — 대량 메일머지에서 셸 인용 지옥을 피한다.
+    let data_text = if let Some(path) = data_arg.strip_prefix('@') {
+        match fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("오류: --data 파일을 읽을 수 없습니다 - {}: {}", path, e);
+                return EXIT_RUNTIME;
+            }
+        }
+    } else {
+        data_arg.to_string()
+    };
+
+    let data: serde_json::Map<String, serde_json::Value> =
+        match serde_json::from_str::<serde_json::Value>(&data_text) {
+            Ok(serde_json::Value::Object(m)) => m,
+            Ok(_) => {
+                eprintln!("오류: --data 는 {{\"필드이름\":\"값\"}} 형식의 JSON 객체여야 합니다.");
+                return EXIT_USAGE;
+            }
+            Err(e) => {
+                eprintln!("오류: --data JSON 파싱 실패 - {}", e);
+                return EXIT_USAGE;
+            }
+        };
+
+    let bytes = match fs::read(file_path) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
+            return EXIT_RUNTIME;
+        }
+    };
+    let mut doc = match rhwp::wasm_api::HwpDocument::from_bytes(&bytes) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: HWP 파싱 실패 - {}", e);
+            return EXIT_RUNTIME;
+        }
+    };
+
+    // 문서에 실재하는 필드 이름을 먼저 모아, 없는 이름을 편집 전에 가려낸다.
+    let existing: std::collections::HashSet<String> = doc
+        .collect_all_fields()
+        .iter()
+        .filter_map(|fi| fi.field.field_name().map(|s| s.to_string()))
+        .collect();
+
+    let mut filled: Vec<serde_json::Value> = Vec::new();
+    let mut not_found: Vec<String> = Vec::new();
+
+    for (name, value) in &data {
+        let value_str = match value {
+            serde_json::Value::String(s) => s.clone(),
+            other => other.to_string(),
+        };
+        if !existing.contains(name) {
+            not_found.push(name.clone());
+            continue;
+        }
+        if dry_run {
+            // 파일을 건드리지 않고 무엇이 바뀔지만 기록한다.
+            filled.push(serde_json::json!({ "name": name, "value": value_str }));
+            continue;
+        }
+        if let Err(e) = doc.set_field_value_by_name(name, &value_str) {
+            eprintln!("오류: 필드 '{}' 설정 실패 - {}", name, e);
+            // 실패 시 원본 불변 — 출력 파일을 쓰지 않고 즉시 끝낸다.
+            return EXIT_RUNTIME;
+        }
+        filled.push(serde_json::json!({ "name": name, "value": value_str }));
+    }
+
+    let output_path = out_path.unwrap_or_else(|| {
+        let stem = Path::new(file_path)
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_else(|| "output".to_string());
+        format!("{}_filled.hwp", stem)
+    });
+
+    if !dry_run {
+        let out_bytes = match doc.export_hwp_native() {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("오류: HWP 직렬화 실패 - {}", e);
+                return EXIT_RUNTIME;
+            }
+        };
+        if let Err(e) = fs::write(&output_path, &out_bytes) {
+            eprintln!("오류: 출력 쓰기 실패 - {}: {}", output_path, e);
+            return EXIT_RUNTIME;
+        }
+    }
+
+    if json_mode {
+        let mut envelope = serde_json::json!({
+            "schemaVersion": "1.0",
+            "source": file_path,
+            "dryRun": dry_run,
+            "filledCount": filled.len(),
+            "filled": filled,
+            "notFound": not_found,
+        });
+        if !dry_run {
+            envelope["output"] = serde_json::Value::String(output_path.clone());
+        }
+        println!("{envelope}");
+        return EXIT_OK;
+    }
+
+    if dry_run {
+        println!("변경 예정: {} (필드 {}개)", file_path, filled.len());
+    } else {
+        println!(
+            "채우기 완료: {} → {} (필드 {}개)",
+            file_path,
+            output_path,
+            filled.len()
+        );
+    }
+    for f in &filled {
+        println!(
+            "  {} = {:?}",
+            f["name"].as_str().unwrap_or(""),
+            f["value"].as_str().unwrap_or("")
+        );
+    }
+    if !not_found.is_empty() {
+        println!("  문서에 없는 필드 이름: {}", not_found.join(", "));
+    }
+    EXIT_OK
+}
+
 fn show_fields(args: &[String]) -> i32 {
     use rhwp::document_core::queries::field_query::NestedEntry;
 

--- a/tests/edit_fill_fields_contract.rs
+++ b/tests/edit_fill_fields_contract.rs
@@ -1,0 +1,240 @@
+//! [#3329] `edit fill-fields` 출력·안전 계약 회귀 테스트 (Stage 3 최소 조각).
+//!
+//! 편집 명령의 계약은 조회 명령보다 무겁다 — 파일을 바꾸기 때문이다.
+//! ① `--dry-run` 은 절대 파일을 만들지 않는다 ② 실패하면 출력 파일을 쓰지 않는다
+//! ③ 실제로 값이 반영됐는지는 **다시 읽어서** 확인한다.
+//! 종료 코드는 #2707 계약(0/1/2)을 따른다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// 누름틀 11개(회사명/작성자/부서명/전화번호/이메일/제목/목차1×5).
+const SAMPLE: &str = "samples/field-01.hwp";
+
+fn sample() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn temp_out(tag: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "rhwp-edit-{tag}-{}-{}.hwp",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos()
+    ))
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn parse_json(args: &[&str], output: &Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout 이 순수 JSON 이 아닙니다 ({e}).\n{}",
+            describe(args, output)
+        )
+    })
+}
+
+#[test]
+fn fill_fields_dry_run_reports_without_writing_file() {
+    // 안전장치의 핵심: --dry-run 은 무엇이 바뀔지만 보고하고 파일을 만들지 않는다.
+    let p = sample();
+    let out = temp_out("dryrun");
+    let args = [
+        "edit",
+        "fill-fields",
+        p.to_str().unwrap(),
+        "--data",
+        r#"{"회사명":"주식회사 A"}"#,
+        "-o",
+        out.to_str().unwrap(),
+        "--dry-run",
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+
+    let v = parse_json(&args, &output);
+    assert_eq!(v["schemaVersion"], "1.0", "{v}");
+    assert_eq!(v["dryRun"], true, "{v}");
+    assert!(v["source"].is_string(), "{v}");
+    assert_eq!(v["filledCount"].as_u64().unwrap(), 1, "{v}");
+
+    assert!(
+        !out.exists(),
+        "--dry-run 은 파일을 만들면 안 됩니다: {}",
+        out.display()
+    );
+}
+
+#[test]
+fn fill_fields_writes_and_value_survives_reparse() {
+    // 실제로 값이 들어갔는지는 "다시 읽어서" 확인해야 한다 — 보고만 믿지 않는다.
+    let p = sample();
+    let out = temp_out("write");
+    let args = [
+        "edit",
+        "fill-fields",
+        p.to_str().unwrap(),
+        "--data",
+        r#"{"회사명":"주식회사 검증"}"#,
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(out.exists(), "출력 파일이 생성되어야 합니다");
+
+    let v = parse_json(&args, &output);
+    assert_eq!(v["dryRun"], false, "{v}");
+    assert_eq!(v["filledCount"].as_u64().unwrap(), 1, "{v}");
+    assert!(v["output"].is_string(), "{v}");
+
+    // 산출물을 fields --json 으로 다시 읽어 값이 실제로 반영됐는지 대조한다.
+    let reread = run(&["fields", out.to_str().unwrap(), "--json"]);
+    let rv: serde_json::Value =
+        serde_json::from_slice(&reread.stdout).expect("산출물을 fields --json 으로 읽지 못함");
+    let company = rv["fields"]
+        .as_array()
+        .expect("fields 배열")
+        .iter()
+        .find(|f| f["name"] == "회사명")
+        .unwrap_or_else(|| panic!("회사명 필드를 찾지 못함: {rv}"));
+    assert_eq!(
+        company["value"], "주식회사 검증",
+        "값이 산출물에 반영되어야 합니다: {company}"
+    );
+
+    let _ = std::fs::remove_file(&out);
+}
+
+#[test]
+fn fill_fields_reports_unknown_field_names() {
+    // 문서에 없는 이름은 조용히 무시하지 않고 보고한다 — 에이전트가 오타를 알아야 한다.
+    let p = sample();
+    let out = temp_out("unknown");
+    let args = [
+        "edit",
+        "fill-fields",
+        p.to_str().unwrap(),
+        "--data",
+        r#"{"회사명":"A","존재하지않는필드":"B"}"#,
+        "-o",
+        out.to_str().unwrap(),
+        "--dry-run",
+        "--json",
+    ];
+    let output = run(&args);
+    let v = parse_json(&args, &output);
+    let missing = v["notFound"].as_array().expect("notFound 배열");
+    assert!(
+        missing.iter().any(|m| m == "존재하지않는필드"),
+        "없는 필드 이름이 보고되어야 합니다: {v}"
+    );
+    assert_eq!(v["filledCount"].as_u64().unwrap(), 1, "{v}");
+}
+
+#[test]
+fn fill_fields_missing_file_exit_runtime_and_no_output() {
+    let out = temp_out("missing");
+    let args = [
+        "edit",
+        "fill-fields",
+        "없는파일-edit.hwp",
+        "--data",
+        r#"{"a":"b"}"#,
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "실패 경로 stdout 은 비어야 합니다.\n{}",
+        describe(&args, &output)
+    );
+    assert!(
+        !out.exists(),
+        "실패 시 출력 파일을 쓰면 안 됩니다: {}",
+        out.display()
+    );
+}
+
+#[test]
+fn fill_fields_invalid_json_data_exit_usage() {
+    let p = sample();
+    let args = [
+        "edit",
+        "fill-fields",
+        p.to_str().unwrap(),
+        "--data",
+        "{이건 JSON 이 아님",
+        "--dry-run",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+}
+
+#[test]
+fn fill_fields_missing_data_exit_usage() {
+    let p = sample();
+    let args = ["edit", "fill-fields", p.to_str().unwrap()];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+}
+
+#[test]
+fn edit_unknown_subcommand_exit_usage() {
+    let args = ["edit", "no-such-action"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+}


### PR DESCRIPTION
> base: `devel` (`8bb8f277d`) 직분기 — 열린 PR 없음, 순수 추가 533줄(기존 코드 삭제 0).

## 변경 요약

로드맵 #2659 의 **Stage 3(편집 노출)** 첫 조각입니다.

Stage 1(계약)·Stage 2(조회 기계화)가 devel 에 반영되어, 에이전트는 이제 `fields --json` 으로 **서식이 무엇을 요구하는지** 읽을 수 있습니다. 그런데 값을 채워 넣으려면 여전히 Windows + 한컴 오피스 + COM 매크로가 필요했습니다 — 코어에 `set_field_value_by_name` 이 이미 있고 rhwp-studio 가 쓰고 있는데, **CLI 출구가 없어서** 브라우저 밖 자동화가 불가능했습니다.

로드맵 §7.3 의 `edit` 3종(`fill-fields`/`replace-text`/`set-cell`) 중 **`fill-fields` 하나만** 놓았습니다. 편집 축에서 위험이 가장 작고(필드 값만 바꾸므로 레이아웃·구조 불변), 수요는 가장 큽니다(행정 서식 자동 작성).

```console
$ rhwp edit fill-fields 신청서.hwp --data '{"회사명":"주식회사 A","작성자":"홍길동"}' -o out.hwp --json
{"schemaVersion":"1.0","source":"신청서.hwp","dryRun":false,"filledCount":2,
 "filled":[{"name":"회사명","value":"주식회사 A"},{"name":"작성자","value":"홍길동"}],
 "notFound":[],"output":"out.hwp"}
```

**설계 요점**

- **새 편집 로직 0줄** — 검증된 `set_field_value_by_name` 을 그대로 부릅니다.
- **`--dry-run` 은 파일 생성 경로 자체를 타지 않습니다.** 편집 명령의 안전장치는 "썼다가 지운다"가 아니라 "쓰지 않는다"여야 하고, 계약 테스트가 파일 부재를 단언합니다.
- **실패 시 원본 불변** — 필드 설정이 하나라도 실패하면 즉시 종료하고 출력을 쓰지 않습니다.
- **없는 필드 이름을 조용히 무시하지 않습니다** — `notFound` 로 보고해 에이전트가 오타를 즉시 압니다(편집 전에 실재 이름 집합을 먼저 모아 가려냅니다).
- **`--data @파일`** — 대량 메일머지에서 셸 인용 지옥을 피합니다.
- `edit` 을 명령군으로 열어 `replace-text`/`set-cell` 이 같은 규약으로 붙을 자리를 만들었습니다.

**루프가 CLI 안에서 닫힙니다** — 실측:

```bash
$ rhwp fields samples/field-01.hwp --json | jq -r '[.fields[]|select(.name!="")|.name]'
["회사명","작성자","부서명","전화번호","이메일","목차1",…]

$ rhwp edit fill-fields samples/field-01.hwp --data '{"회사명":"주식회사 페타플로","작성자":"김승원","부서명":"기술연구소"}' -o out.hwp --json
{"filledCount":3,"notFound":[],…}

$ rhwp fields out.hwp --json | jq -c '[.fields[]|select(.value!="")|{name,value}]'
[{"name":"회사명","value":"주식회사 페타플로"},{"name":"작성자","value":"김승원"},{"name":"부서명","value":"기술연구소"},…]
```

## 관련 이슈

closes #3329 · 로드맵 #2659 Stage 3

## 테스트

- [x] 계약 테스트 **7종 red→green**: `--dry-run` **파일 미생성**(핵심 안전 계약) / 저장 후 **산출물을 `fields --json` 으로 다시 읽어 값 반영 대조**(보고만 믿지 않음) / `notFound` 보고 / 없는 파일 exit 1 + stdout 0바이트 + **출력 미생성** / 잘못된 JSON exit 2 / `--data` 누락 exit 2 / 알 수 없는 하위 명령 exit 2
- [x] `cargo clippy --release --bin rhwp -- -D warnings`: 0, `rustfmt`·문서 검사 스크립트 2종 clean
- [x] 무회귀: `cli_exit_codes`(10), `fields_json_contract`(8) 전부 green
- [x] 실측: 위 3단계 루프 성공
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음 (CLI 전용, 코어 편집 API 무변경)

## 남긴 것

- `edit replace-text` / `edit set-cell` — 같은 규약으로 이 조각이 머지된 뒤 후속하겠습니다.
- 머리말/꼬리말·각주/미주 안의 필드는 `collect_fields_from_paragraph` 재귀 범위 밖이라 채워지지 않습니다(`fields` 와 같은 한계, 문서에 명시).
- HWPX 입력은 `export_hwp_native()` 가 HWP5 산출이라 이번 범위에서 다루지 않았습니다 — HWPX 왕복 저장 경로 연결은 별도 이슈가 맞다고 봅니다.

## 스크린샷

해당 없음 (CLI 출력 계약 — 위 실측 출력 참조)
