### PR TITLE
feat(cli): batch 에 search·export-tables·fields 축 추가 — 코퍼스 규모 완결 (#3346)

### DIFF
--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -319,6 +319,27 @@ rhwp 는 이미 필드에 값을 쓸 수 있지만(`set_field_value_by_name`) �
 rhwp fields 신청서.hwp --json | jq -r '.fields[] | "\(.name): \(.memo // .guide)"'
 ```
 
+### `edit fill-fields <파일> --data <JSON|@파일> [옵션]` (#3329)
+누름틀에 값을 채운다 — 서식 자동 작성/메일머지. 검증된 코어 경로
+(`set_field_value_by_name`)를 재사용하므로 새 편집 로직이 없고, **필드 값만 바꾸므로
+레이아웃·구조는 불변**이다.
+- `--data <JSON|@파일>` — `{"필드이름":"값"}` 형식. `@경로` 면 파일에서 읽는다
+  (대량 메일머지에서 셸 인용을 피한다). 값이 문자열이 아니면 JSON 표현으로 넣는다.
+- `-o, --output <파일>` — 출력 파일 (기본 `<입력명>_filled.hwp`)
+- `--dry-run` — **파일을 쓰지 않고** 변경 예정 내역만 보고. 에이전트의 사전 확인 장치.
+- `--json` 봉투: `{"schemaVersion":"1.0","source","dryRun","filledCount","filled":[{name,value}],"notFound":[…],"output"?}`
+  - `notFound` — 문서에 없는 필드 이름. 조용히 무시하지 않으므로 오타를 즉시 안다.
+  - `output` 은 실제 저장했을 때만 실린다(`--dry-run` 이면 없음).
+- **실패 시 원본 불변**: 필드 설정이 하나라도 실패하면 출력 파일을 쓰지 않고 종료 코드 1.
+- 종료 코드는 §종료 코드 계약 (없는 파일·직렬화/쓰기 실패 1 · 인자/JSON 오류 2)
+
+```bash
+# 서식 조사 → 값 채우기 → 산출물 재확인 (전 과정 CLI)
+rhwp fields 신청서.hwp --json | jq -r '.fields[].name'
+rhwp edit fill-fields 신청서.hwp --data @row.json -o out.hwp --json
+rhwp fields out.hwp --json | jq -c '[.fields[]|select(.value!="")|{name,value}]'
+```
+
 ---
 
 ## 3. 변환·비교

--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -249,6 +249,7 @@ JSON 계약·종료 코드를 파악하는 입구.
 `{"schemaVersion":"1.0","tool","version","formats","exitCodes","jsonContract","batch","commands":[{name,category,summary,...}]}`
 - `--json` 계약 명령(info/export-text/export-structure/batch)은 `json:true`·`recordFields` 로 상세 서술
 - `--help`(사람용)와 함께 현행화한다 — help 에만 추가된 명령은 드리프트 가드 테스트가 잡는다
+- 편집 명령(`edit`)도 등재된다 — MCP 도구로는 `hwp_fill_fields` 로 노출된다 (#3329)
 
 #### `capabilities --mcp` — MCP 도구 정의 생성
 MCP 서버(및 함수 호출 클라이언트)가 **그대로 등록할 수 있는** 도구 정의를 낸다.

--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -148,13 +148,20 @@ rhwp export-pdf input.hwp -o out.pdf \
   `schemaVersion` 이 계약이며 필드 추가는 허용, 변경·삭제는 `tests/cli_json_contract.rs` 가 잡는다.
   `page` 는 `-p` 와 같은 0 기준.
 
-### `batch <export-text|info|export-structure> --json [--mode <m>] [--threads <N>]` (#3238, #3261)
+### `batch <export-text|info|export-structure|export-tables|fields|search> --json [옵션]` (#3238, #3261, #3346)
 stdin 의 파일 목록(한 줄당 경로 하나)을 **한 프로세스에서 파일 간 병렬**로 처리해
 NDJSON(한 줄당 레코드 하나)을 stdin 입력 순서대로 스트림 출력한다.
 - `batch export-text` 성공 레코드: `{"schemaVersion":"1.0","source","pageCount","text"}`
 - `batch info` 성공 레코드: `info --json` 과 **같은 스키마** — 단건/배치를 같은 소비 코드로 읽는다
 - `batch export-structure` 성공 레코드: `export-structure --json` 봉투와 같은 스키마.
   `--mode auto|outline|clause` 는 이 축 전용(기본 auto)
+- `batch export-tables` 성공 레코드: `export-tables --json` 봉투와 같은 스키마
+  (병합 `rowSpan`/`colSpan`·중첩 표 보존)
+- `batch fields` 성공 레코드: `fields --json` 봉투와 같은 스키마
+- `batch search` 성공 레코드: `search --json` 봉투와 같은 스키마.
+  **`--query <검색어>` 는 이 축 전용이며 필수**다(없으면 사용법 오류 2).
+  대량 코퍼스에서 스트림이 부풀지 않도록 **파일당 매치 1,000건 상한**을 둔다
+  (단건 `search --limit` 과 같은 취지). 대소문자는 구분한다.
 - 실패 레코드(공통): `{"schemaVersion":"1.0","source","error","exitClass":"runtime"}`
 - 건별 실패(읽기·파싱·추출·panic)는 레코드로 격리하고 스트림을 계속한다.
   하나라도 실패하면 최종 종료 코드 1 (#2707 계약).
@@ -165,6 +172,13 @@ NDJSON(한 줄당 레코드 하나)을 stdin 입력 순서대로 스트림 출�
 # 아카이브 파이프라인: 메타데이터 스윕 → 대상 선별 → 본문 추출
 find docs/ -name '*.hwp' | rhwp batch info --json > meta.ndjson
 find docs/ -name '*.hwp' | rhwp batch export-text --json > corpus.ndjson
+
+# 아카이브 전역 검색 — 어느 문서 어느 쪽에 있는지 (#3346)
+find docs/ -name '*.hwp' | rhwp batch search --query "위임전결" --json   | jq -c 'select(.matchCount > 0) | {source, pages:[.matches[].page]}'
+
+# 코퍼스 표 수확 / 서식 템플릿 일괄 조사
+find docs/ -name '*.hwp' | rhwp batch export-tables --json | jq -c '{source, tableCount}'
+find forms/ -name '*.hwp' | rhwp batch fields --json | jq -c 'select(.fieldCount>0) | {source, fieldCount}'
 ```
 
 검증된 에이전트·파이프라인 시나리오(선별→추출, RAG 청킹, 실패 처리)는

--- a/mydocs/report/task_m100_3329_report.md
+++ b/mydocs/report/task_m100_3329_report.md
@@ -1,0 +1,57 @@
+# task_m100_3329 처리결과 보고서 — `edit fill-fields` (Stage 3 최소 조각)
+
+- **이슈**: [#3329](https://github.com/edwardkim/rhwp/issues/3329)
+- **브랜치**: `pr/task-edit-fill-fields` (upstream/devel `8bb8f277d` 직분기)
+- **범위**: `src/main.rs`(명령 2개·디스패치 1행·help), `tests/edit_fill_fields_contract.rs`(신규),
+  `mydocs/manual/cli_commands.md`
+- **분류**: 기능 추가 (편집 — 로드맵 #2659 Stage 3)
+
+## 1. 배경
+
+Stage 1(계약)·Stage 2(조회 기계화)가 devel 에 반영되어, 에이전트는 문서를 발견·검색·이해할
+수 있게 됐다. 특히 `fields --json` 으로 **서식이 무엇을 요구하는지** 읽을 수 있다.
+
+그런데 값을 채워 넣으려면 여전히 Windows + 한컴 오피스 + COM 매크로가 필요했다. 코어에
+`set_field_value_by_name` 이 이미 있고 rhwp-studio 가 쓰고 있는데 **CLI 출구가 없어서**
+브라우저 밖 자동화가 불가능했다.
+
+## 2. 설계 결정
+
+- **로드맵 §7.3 의 3종 중 `fill-fields` 하나만** 놓았다. 편집 축에서 위험이 가장 작고
+  (필드 값만 바꾸므로 레이아웃·구조 불변) 수요가 가장 크다(행정 서식 자동 작성).
+- **새 편집 로직 0줄** — 검증된 `set_field_value_by_name` 을 그대로 부른다.
+- **`--dry-run` 은 파일 생성 경로 자체를 타지 않는다.** 편집 명령의 안전장치는 "썼다가
+  지운다"가 아니라 "쓰지 않는다"여야 한다. 계약 테스트가 파일 부재를 단언한다.
+- **실패 시 원본 불변**: 필드 설정이 하나라도 실패하면 즉시 종료하고 출력을 쓰지 않는다.
+- **없는 필드 이름을 조용히 무시하지 않는다** — `notFound` 로 보고해 에이전트가 오타를
+  즉시 안다. 편집 전에 `collect_all_fields()` 로 실재 이름 집합을 먼저 모아 가려낸다.
+- **`@파일` 입력** — 대량 메일머지에서 셸 인용 지옥을 피하기 위해 `--data @row.json` 지원.
+- `edit` 을 명령군으로 열어 `replace-text`/`set-cell` 이 같은 규약으로 붙을 자리를 만들었다.
+
+## 3. 변경
+
+- `run_edit()` — `edit` 명령군 디스패처 (알 수 없는 하위 명령은 exit 2)
+- `edit_fill_fields()` — 인자 파싱 / `@파일` 처리 / dry-run 분기 / 봉투 방출
+- 디스패치 1행, help 등재, `cli_commands.md` 신설 항목
+
+## 4. 검증
+
+- **계약 테스트 7종 red→green**:
+  - `--dry-run` 이 **파일을 만들지 않음**(핵심 안전 계약)
+  - 저장 후 **산출물을 `fields --json` 으로 다시 읽어 값 반영 대조**(보고만 믿지 않음)
+  - 없는 필드 이름 `notFound` 보고
+  - 없는 파일 exit 1 + stdout 0바이트 + **출력 파일 미생성**
+  - 잘못된 JSON exit 2 / `--data` 누락 exit 2 / 알 수 없는 하위 명령 exit 2
+- `cargo clippy --release --bin rhwp -- -D warnings`: 0, `rustfmt` clean
+- 무회귀: `cli_exit_codes`(10), `fields_json_contract`(8) 전부 green
+- **실측 루프**: `samples/field-01.hwp` 로 서식 조사 → 3개 필드 채우기 → 산출물 재독으로
+  `회사명`·`작성자`·`부서명` 값 반영 확인 (전 과정 CLI)
+
+## 5. 남긴 것
+
+- `edit replace-text` / `edit set-cell` — 같은 규약(`--dry-run`·결과 JSON·원본 불변)으로
+  이 조각이 머지된 뒤 후속.
+- 머리말/꼬리말·각주/미주 안의 필드는 `collect_fields_from_paragraph` 재귀 범위 밖이라
+  채워지지 않는다(`fields` 와 같은 한계, 문서에 명시됨).
+- HWPX 입력의 `edit fill-fields` 는 `export_hwp_native()` 가 HWP5 산출이라 이번 범위에서
+  다루지 않았다 — HWPX 왕복 저장 경로 연결은 별도 이슈가 맞다.

--- a/mydocs/report/task_m100_3346_report.md
+++ b/mydocs/report/task_m100_3346_report.md
@@ -1,0 +1,63 @@
+# task_m100_3346 처리결과 보고서 — `batch` 에 search·export-tables·fields 축 추가
+
+- **이슈**: [#3346](https://github.com/edwardkim/rhwp/issues/3346)
+- **브랜치**: `pr/task-batch-axes` (upstream/devel `8bb8f277d` 직분기)
+- **범위**: `src/main.rs`, `tests/batch_axes_contract.rs`(신규), `mydocs/manual/cli_commands.md`
+- **분류**: 기능 추가 (로드맵 #2659 Stage 2 완결편)
+
+## 1. 문제
+
+Stage 2 조회 축이 devel 에 전부 반영되어 `export-tables`·`fields`·`search` 가 `--json`
+계약을 갖췄는데, `batch` 는 여전히 3축만 지원했다. `capabilities` 실측으로 확인한 공백:
+
+```
+json 계약 명령: info, export-text, export-structure, capabilities, export-svg,
+               export-tables, search, fields, batch, ir-diff   (10개)
+batch 지원 축: export-text, info, export-structure              (3개)
+```
+
+에이전트에게 코퍼스 규모 작업이 승부처인데, 문서 한 건씩 프로세스를 띄우면 1만 건
+아카이브에서 파싱 비용이 1만 번 반복된다. `batch` 는 그 문제를 이미 풀어 뒀지만
+(한 프로세스·파일 간 병렬·입력 순서 보존·panic 격리·부분 실패 exit 1) 새 축들이
+그 혜택을 못 받고 있었다.
+
+## 2. 설계 결정
+
+- **동시성 골격은 무변경.** `BatchMode` 에 축만 추가했다. 스레드 풀·순서 보존 재정렬
+  버퍼·`catch_unwind` 격리·부분 실패 종료 코드는 한 줄도 건드리지 않았다.
+- **봉투 빌더를 추출해 단건/배치가 스키마를 공유한다.** 기존 `info`/`export-structure` 가
+  `info_json_value`/`structure_json_value` 를 공유하던 규약을 그대로 따라
+  `tables_json_value`·`fields_json_value`·`search_json_value` 를 뽑았다. 단건 명령들이
+  인라인으로 봉투를 만들던 것을 이 빌더 호출로 바꿔, **스키마가 갈라질 수 없게** 했다.
+- **`collect_field_records()` 추출** — `fields` 의 레코드 조립(중첩 경로 포함)을 한 곳에
+  두어 단건/배치가 같은 필드 집합을 낸다.
+- **`--query` 는 search 축 전용** — `--mode` 가 `export-structure` 전용인 것과 같은 규약.
+  타 축에 쓰면 사용법 오류 2, `search` 인데 없으면 사용법 오류 2.
+- **파일당 매치 상한 1,000건** — 대량 코퍼스에서 한 문서가 매치를 수만 건 쏟아내면
+  NDJSON 스트림이 부푼다. 단건 `search --limit` 과 같은 취지의 방어다.
+- **자기서술 동시 갱신**: `capabilities` 의 `batch.subcommands`·`flags`, MCP `hwp_batch`
+  도구의 `inputSchema.enum`, `--help` 를 함께 고쳤다. 드리프트 가드가 CI 에서 잡는다.
+
+## 3. 변경
+
+- `BatchMode` 3축 추가(`Tables`/`Fields`/`Search{query}`), `batch_record` 분기 확장
+- 레코드 빌더 3종(`batch_tables_record_inner`·`batch_fields_record_inner`·
+  `batch_search_record_inner`)
+- 봉투 빌더 3종 + `collect_field_records` 추출 (단건 명령들이 이를 호출하도록 변경)
+- `run_batch` 서브커맨드 목록·`--query` 파싱, `capabilities`/MCP/help/문서 갱신
+
+## 4. 검증
+
+- **계약 테스트 8종 red→green**: 3축 각각의 레코드가 **단건 봉투 스키마와 일치** /
+  배치 경로에서도 **표 병합 정보 보존**(같은 추출기를 쓴다는 증거) / 입력 순서 보존 +
+  부분 실패 exit 1 / `--query` 누락 exit 2 / `--query` 타 축 사용 exit 2 /
+  **기존 3축 무회귀** / **capabilities 드리프트 가드**
+- 상세 검증 결과(clippy·전체 lib·연관 통합 스위트·fmt·실측 스모크·문서 검사)는
+  PR 본문에 기록.
+
+## 5. 남긴 것
+
+- `batch ir-diff`(쌍 목록 배치 검증)는 stdin 입력 형식(쌍 구분) 설계가 필요해 제외했다.
+- `batch export-svg`(렌더 매니페스트 배치)는 산출물 경로 충돌 규칙이 필요해 제외했다.
+- `batch search` 는 대소문자 구분 고정이다 — `--ignore-case` 를 배치에도 노출할지는
+  수요 확인 후 별도로 다루는 것이 맞다고 본다.

--- a/src/main.rs
+++ b/src/main.rs
@@ -254,6 +254,27 @@ fn show_mcp_tools() -> i32 {
             serde_json::json!(["batch", "{subcommand}", "--json"]),
             &["schemaVersion", "source", "error", "exitClass"],
         ),
+        tool(
+            "hwp_fill_fields",
+            "HWP 서식(템플릿)의 누름틀에 값을 채워 새 문서를 만든다. 먼저 hwp_fields 로 어떤 필드가 있는지 확인한 뒤 사용한다. dryRun 으로 파일을 만들지 않고 변경 예정만 확인할 수 있다.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string", "description": "입력 HWP 문서 경로" },
+                    "data": {
+                        "type": "object",
+                        "additionalProperties": { "type": "string" },
+                        "description": "{\"필드이름\":\"값\"} 형태의 채울 값"
+                    },
+                    "output": { "type": "string", "description": "출력 파일 경로. 생략하면 <입력명>_filled.hwp" },
+                    "dryRun": { "type": "boolean", "description": "true 면 파일을 쓰지 않고 변경 예정만 보고" }
+                },
+                "required": ["path", "data"],
+            }),
+            "edit",
+            serde_json::json!(["edit", "fill-fields", "{path}", "--data", "{data}", "--json"]),
+            &["schemaVersion", "source", "dryRun", "filledCount", "filled", "notFound", "output"],
+        ),
     ];
 
     let manifest = serde_json::json!({
@@ -451,6 +472,23 @@ fn show_capabilities(args: &[String]) -> i32 {
         ),
         cmd("build-from-ingest", "export", "ingest JSON에서 HWPX 생성"),
         cmd("thumbnail", "export", "내장 썸네일(PrvImage) 추출"),
+        // ── 편집 (#3329 Stage 3) ──
+        cmd_json(
+            "edit",
+            "edit",
+            "문서 편집 — fill-fields: 누름틀에 값 채우기(서식 자동 작성/메일머지)",
+            false,
+            &["--data", "-o", "--dry-run", "--json"],
+            &[
+                "schemaVersion",
+                "source",
+                "dryRun",
+                "filledCount",
+                "filled",
+                "notFound",
+                "output",
+            ],
+        ),
         // ── 배치 ──
         cmd_json(
             "batch",

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,7 @@ fn main() {
         Some("bench") => rhwp::diagnostics::bench::run(&args[2..]),
         Some("thumbnail") => extract_thumbnail(&args[2..]),
         Some("fields") => exit_with(show_fields(&args[2..])),
+        Some("edit") => exit_with(run_edit(&args[2..])),
         // [#2707] 알 수 없는 명령·명령 누락은 사용법 오류다. 표준 CLI 관례대로 stderr 로 안내하고
         // 종료 코드 2로 끝낸다(기존에는 stdout + 0이라 오타 낸 명령이 스크립트에서 성공으로 보였다).
         other => {
@@ -804,6 +805,14 @@ fn print_help() {
     println!("  fields <파일.hwp|파일.hwpx> [--json]");
     println!("      누름틀/필드 조사 (읽기 전용) — 이름·안내문·지시문·현재값·위치");
     println!();
+    println!("      --json                    계약 봉투 JSON을 stdout에 출력");
+    println!();
+    println!("  edit fill-fields <파일.hwp> --data <JSON|@파일> [-o <출력.hwp>] [옵션]");
+    println!("      누름틀에 값을 채운다 (서식 자동 작성/메일머지)");
+    println!();
+    println!("      --data <JSON|@파일>       {{\"필드이름\":\"값\"}} 형식. @경로면 파일에서 읽음");
+    println!("      -o, --output <파일>       출력 파일 (기본: 입력명_filled.hwp)");
+    println!("      --dry-run                 파일을 쓰지 않고 변경 예정 내역만 보고");
     println!("      --json                    계약 봉투 JSON을 stdout에 출력");
     println!();
     println!("내부 개발·회귀 도구 (일반 사용자 대상 아님):");
@@ -7599,6 +7608,212 @@ fn ir_diff(args: &[String]) -> i32 {
 /// rhwp 는 이미 필드에 값을 **쓸 수** 있는데(`set_field_value_by_name`) 조회 API 는
 /// WASM/스튜디오 경로에만 있어, 브라우저 밖 에이전트는 "이 서식이 무엇을 요구하는지"
 /// 알 방법이 없었다. 기존 `collect_all_fields()` 를 그대로 노출한다(라이브러리 무변경).
+/// `edit` — 문서 편집 명령군 (로드맵 #2659 Stage 3).
+///
+/// 공통 규약: `--dry-run`(변경 요약만 출력, 파일 무변경), 결과 리포트 JSON,
+/// **실패 시 원본 불변**(하나라도 실패하면 출력 파일을 쓰지 않는다).
+fn run_edit(args: &[String]) -> i32 {
+    const USAGE: &str = "사용법: rhwp edit fill-fields <파일.hwp> --data <JSON|@파일> [-o <출력.hwp>] [--dry-run] [--json]";
+
+    match args.first().map(String::as_str) {
+        Some("fill-fields") => edit_fill_fields(&args[1..]),
+        Some(other) => {
+            eprintln!("오류: 알 수 없는 edit 하위 명령 - {}", other);
+            eprintln!("{USAGE}");
+            EXIT_USAGE
+        }
+        None => {
+            eprintln!("오류: edit 하위 명령을 지정해주세요.");
+            eprintln!("{USAGE}");
+            EXIT_USAGE
+        }
+    }
+}
+
+/// `edit fill-fields` — 누름틀에 값을 채운다 (메일머지).
+///
+/// 검증된 코어 경로(`set_field_value_by_name`)를 재사용하므로 새 편집 로직이 없다.
+/// 필드 값만 바꾸므로 레이아웃·구조는 불변이다.
+fn edit_fill_fields(args: &[String]) -> i32 {
+    let mut file_path: Option<&str> = None;
+    let mut data_arg: Option<&str> = None;
+    let mut out_path: Option<String> = None;
+    let mut dry_run = false;
+    let mut json_mode = false;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--data" => {
+                i += 1;
+                match args.get(i) {
+                    Some(v) => data_arg = Some(v),
+                    None => {
+                        eprintln!("오류: --data 뒤에 JSON 또는 @파일경로가 필요합니다.");
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            "-o" | "--output" => {
+                i += 1;
+                match args.get(i) {
+                    Some(v) => out_path = Some(v.clone()),
+                    None => {
+                        eprintln!("오류: -o 뒤에 출력 파일 경로가 필요합니다.");
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            "--dry-run" => dry_run = true,
+            "--json" => json_mode = true,
+            other if other.starts_with('-') => {
+                eprintln!("알 수 없는 옵션: {other}");
+                return EXIT_USAGE;
+            }
+            other => file_path = Some(other),
+        }
+        i += 1;
+    }
+
+    let (Some(file_path), Some(data_arg)) = (file_path, data_arg) else {
+        eprintln!("사용법: rhwp edit fill-fields <파일.hwp> --data <JSON|@파일> [-o <출력.hwp>] [--dry-run] [--json]");
+        return EXIT_USAGE;
+    };
+
+    // `@경로` 면 파일에서 읽는다 — 대량 메일머지에서 셸 인용 지옥을 피한다.
+    let data_text = if let Some(path) = data_arg.strip_prefix('@') {
+        match fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("오류: --data 파일을 읽을 수 없습니다 - {}: {}", path, e);
+                return EXIT_RUNTIME;
+            }
+        }
+    } else {
+        data_arg.to_string()
+    };
+
+    let data: serde_json::Map<String, serde_json::Value> =
+        match serde_json::from_str::<serde_json::Value>(&data_text) {
+            Ok(serde_json::Value::Object(m)) => m,
+            Ok(_) => {
+                eprintln!("오류: --data 는 {{\"필드이름\":\"값\"}} 형식의 JSON 객체여야 합니다.");
+                return EXIT_USAGE;
+            }
+            Err(e) => {
+                eprintln!("오류: --data JSON 파싱 실패 - {}", e);
+                return EXIT_USAGE;
+            }
+        };
+
+    let bytes = match fs::read(file_path) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
+            return EXIT_RUNTIME;
+        }
+    };
+    let mut doc = match rhwp::wasm_api::HwpDocument::from_bytes(&bytes) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: HWP 파싱 실패 - {}", e);
+            return EXIT_RUNTIME;
+        }
+    };
+
+    // 문서에 실재하는 필드 이름을 먼저 모아, 없는 이름을 편집 전에 가려낸다.
+    let existing: std::collections::HashSet<String> = doc
+        .collect_all_fields()
+        .iter()
+        .filter_map(|fi| fi.field.field_name().map(|s| s.to_string()))
+        .collect();
+
+    let mut filled: Vec<serde_json::Value> = Vec::new();
+    let mut not_found: Vec<String> = Vec::new();
+
+    for (name, value) in &data {
+        let value_str = match value {
+            serde_json::Value::String(s) => s.clone(),
+            other => other.to_string(),
+        };
+        if !existing.contains(name) {
+            not_found.push(name.clone());
+            continue;
+        }
+        if dry_run {
+            // 파일을 건드리지 않고 무엇이 바뀔지만 기록한다.
+            filled.push(serde_json::json!({ "name": name, "value": value_str }));
+            continue;
+        }
+        if let Err(e) = doc.set_field_value_by_name(name, &value_str) {
+            eprintln!("오류: 필드 '{}' 설정 실패 - {}", name, e);
+            // 실패 시 원본 불변 — 출력 파일을 쓰지 않고 즉시 끝낸다.
+            return EXIT_RUNTIME;
+        }
+        filled.push(serde_json::json!({ "name": name, "value": value_str }));
+    }
+
+    let output_path = out_path.unwrap_or_else(|| {
+        let stem = Path::new(file_path)
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_else(|| "output".to_string());
+        format!("{}_filled.hwp", stem)
+    });
+
+    if !dry_run {
+        let out_bytes = match doc.export_hwp_native() {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("오류: HWP 직렬화 실패 - {}", e);
+                return EXIT_RUNTIME;
+            }
+        };
+        if let Err(e) = fs::write(&output_path, &out_bytes) {
+            eprintln!("오류: 출력 쓰기 실패 - {}: {}", output_path, e);
+            return EXIT_RUNTIME;
+        }
+    }
+
+    if json_mode {
+        let mut envelope = serde_json::json!({
+            "schemaVersion": "1.0",
+            "source": file_path,
+            "dryRun": dry_run,
+            "filledCount": filled.len(),
+            "filled": filled,
+            "notFound": not_found,
+        });
+        if !dry_run {
+            envelope["output"] = serde_json::Value::String(output_path.clone());
+        }
+        println!("{envelope}");
+        return EXIT_OK;
+    }
+
+    if dry_run {
+        println!("변경 예정: {} (필드 {}개)", file_path, filled.len());
+    } else {
+        println!(
+            "채우기 완료: {} → {} (필드 {}개)",
+            file_path,
+            output_path,
+            filled.len()
+        );
+    }
+    for f in &filled {
+        println!(
+            "  {} = {:?}",
+            f["name"].as_str().unwrap_or(""),
+            f["value"].as_str().unwrap_or("")
+        );
+    }
+    if !not_found.is_empty() {
+        println!("  문서에 없는 필드 이름: {}", not_found.join(", "));
+    }
+    EXIT_OK
+}
+
 fn show_fields(args: &[String]) -> i32 {
     use rhwp::document_core::queries::field_query::NestedEntry;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,7 +238,7 @@ fn show_mcp_tools() -> i32 {
                 "properties": {
                     "subcommand": {
                         "type": "string",
-                        "enum": ["export-text", "info", "export-structure"],
+                        "enum": ["export-text", "info", "export-structure", "export-tables", "fields"],
                         "description": "각 파일에 적용할 처리"
                     },
                     "paths": {
@@ -275,6 +275,26 @@ fn show_mcp_tools() -> i32 {
             serde_json::json!(["edit", "fill-fields", "{path}", "--data", "{data}", "--json"]),
             &["schemaVersion", "source", "dryRun", "filledCount", "filled", "notFound", "output"],
         ),
+        tool(
+            "hwp_batch_search",
+            "여러 문서를 한 프로세스에서 병렬 검색해 NDJSON 스트림으로 받는다. 매치마다 구역·문단·페이지 주소가 붙어 '어느 문서 몇 쪽'을 답할 수 있다. 파일 목록은 stdin 으로 한 줄에 하나씩 넣는다.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": { "type": "string", "description": "찾을 문자열 (대소문자 구분)" },
+                    "paths": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "검색할 문서 경로 목록 (stdin 으로 전달된다)"
+                    },
+                    "threads": { "type": "integer", "minimum": 1, "description": "병렬 스레드 수. 기본은 CPU 코어 수" }
+                },
+                "required": ["query", "paths"],
+            }),
+            "batch",
+            serde_json::json!(["batch", "search", "--json", "--query", "{query}"]),
+            &["schemaVersion", "source", "query", "matchCount", "matches"],
+        ),
     ];
 
     let manifest = serde_json::json!({
@@ -288,7 +308,7 @@ fn show_mcp_tools() -> i32 {
         "invocation": {
             "transport": "cli",
             "note": "각 도구의 cli.args 에서 {name} 자리표시자를 inputSchema 의 같은 이름 값으로 치환해 실행한다. stdout 은 순수 JSON, 진단은 stderr, 종료 코드는 0/1/2(+ir-diff 차이 3).",
-            "stdinTools": ["hwp_batch"],
+            "stdinTools": ["hwp_batch", "hwp_batch_search"],
         },
         "tools": tools,
     });
@@ -583,8 +603,8 @@ fn show_capabilities(args: &[String]) -> i32 {
             "failure": "단건 명령 실패 시 stdout 0바이트; batch 는 error 레코드 + 최종 exit 1",
         },
         "batch": {
-            "subcommands": ["export-text", "info", "export-structure"],
-            "flags": ["--json", "--threads", "--mode"],
+            "subcommands": ["export-text", "info", "export-structure", "export-tables", "fields", "search"],
+            "flags": ["--json", "--threads", "--mode", "--query"],
             "ordering": "stdin 입력 순서 보존",
             "input": "stdin, 한 줄당 파일 경로 하나",
         },
@@ -669,12 +689,13 @@ fn print_help() {
     println!("      -p, --page <번호>       특정 페이지만 내보내기 (0부터 시작)");
     println!("      --json                  결과를 JSON으로 stdout에 출력 (파일 저장 안 함)");
     println!();
-    println!("  batch <export-text|info|export-structure> --json [--threads <N>]");
+    println!("  batch <export-text|info|export-structure|export-tables|fields|search> --json [--threads <N>]");
     println!(
         "      stdin의 파일 목록(한 줄당 하나)을 한 프로세스로 전건 처리해 NDJSON 스트림 출력"
     );
     println!("      --threads <N>           파일 간 병렬 스레드 수 (기본: CPU 코어 수)");
     println!("      --mode <m>              export-structure 전용: auto|outline|clause");
+    println!("      --query <검색어>        search 전용: 찾을 문자열");
     println!();
     println!("  export-markdown <파일.hwp> [옵션]");
     println!("      페이지별 텍스트를 Markdown(.md)으로 내보내기");
@@ -2509,12 +2530,7 @@ fn export_tables(args: &[String]) -> i32 {
     };
 
     let tables = extract_tables(doc.document());
-    let envelope = serde_json::json!({
-        "schemaVersion": "1.0",
-        "source": file_path,
-        "tableCount": tables.len(),
-        "tables": tables,
-    });
+    let envelope = tables_json_value(file_path, &tables);
 
     if let Some(p) = out_path {
         let json = match serde_json::to_string_pretty(&envelope) {
@@ -2852,17 +2868,24 @@ fn export_markdown(args: &[String]) -> i32 {
 fn run_batch(args: &[String]) -> i32 {
     use std::io::{BufRead, Write};
 
-    const USAGE: &str = "사용법: <파일 목록> | rhwp batch <export-text|info|export-structure> --json [--mode auto|outline|clause] [--threads <N>]  (stdin: 한 줄당 파일 경로 하나)";
+    const USAGE: &str = "사용법: <파일 목록> | rhwp batch <export-text|info|export-structure|export-tables|fields|search> --json [--mode auto|outline|clause] [--query <검색어>] [--threads <N>]  (stdin: 한 줄당 파일 경로 하나)";
 
     let subcommand = args.first().map(String::as_str);
     let is_structure = subcommand == Some("export-structure");
+    // [#3346] --query 는 search 축 전용이다 (--mode 가 export-structure 전용인 것과 같은 규약).
+    let is_search = subcommand == Some("search");
     if !matches!(
         subcommand,
-        Some("export-text") | Some("info") | Some("export-structure")
+        Some("export-text")
+            | Some("info")
+            | Some("export-structure")
+            | Some("export-tables")
+            | Some("fields")
+            | Some("search")
     ) {
         match subcommand {
             Some(unknown) => eprintln!(
-                "오류: batch 는 현재 export-text·info·export-structure 만 지원합니다 - {}",
+                "오류: batch 는 export-text·info·export-structure·export-tables·fields·search 만 지원합니다 - {}",
                 unknown
             ),
             None => eprintln!("오류: batch 서브커맨드를 지정해주세요."),
@@ -2874,12 +2897,30 @@ fn run_batch(args: &[String]) -> i32 {
     let mut json_mode = false;
     let mut threads_opt: Option<usize> = None;
     let mut structure_mode = rhwp::document_core::queries::structure::StructureMode::Auto;
+    let mut search_query: Option<String> = None;
     let mut i = 1;
     while i < args.len() {
         match args[i].as_str() {
             "--json" => {
                 json_mode = true;
                 i += 1;
+            }
+            "--query" => {
+                // [#3346] --query 는 search 축 전용이다.
+                if !is_search {
+                    eprintln!("오류: --query 는 search 에서만 사용할 수 있습니다.");
+                    return EXIT_USAGE;
+                }
+                let Some(value) = args.get(i + 1) else {
+                    eprintln!("오류: --query 뒤에 검색어가 필요합니다.");
+                    return EXIT_USAGE;
+                };
+                if value.is_empty() {
+                    eprintln!("오류: --query 검색어가 비어 있습니다.");
+                    return EXIT_USAGE;
+                }
+                search_query = Some(value.clone());
+                i += 2;
             }
             "--mode" => {
                 // [#3261] --mode 는 export-structure 축 전용이다.
@@ -2930,6 +2971,16 @@ fn run_batch(args: &[String]) -> i32 {
     let mode = match subcommand {
         Some("export-text") => BatchMode::ExportText,
         Some("info") => BatchMode::Info,
+        Some("export-tables") => BatchMode::Tables,
+        Some("fields") => BatchMode::Fields,
+        Some("search") => {
+            let Some(q) = search_query.as_deref() else {
+                eprintln!("오류: batch search 는 --query <검색어> 가 필요합니다.");
+                eprintln!("{USAGE}");
+                return EXIT_USAGE;
+            };
+            BatchMode::Search { query: q }
+        }
         _ => BatchMode::Structure(structure_mode),
     };
 
@@ -3068,11 +3119,19 @@ fn run_batch(args: &[String]) -> i32 {
 
 /// [#3238] batch 가 처리하는 서브커맨드 축.
 #[derive(Clone, Copy)]
-enum BatchMode {
+enum BatchMode<'a> {
     ExportText,
     Info,
     /// [#3261] 문서 개요/조문 구조 — `export-structure --json` 과 스키마 공유.
     Structure(rhwp::document_core::queries::structure::StructureMode),
+    /// [#3346] 표 격자 — `export-tables --json` 과 스키마 공유.
+    Tables,
+    /// [#3346] 누름틀 조사 — `fields --json` 과 스키마 공유.
+    Fields,
+    /// [#3346] 주소를 가진 검색 — `search --json` 과 스키마 공유.
+    Search {
+        query: &'a str,
+    },
 }
 
 /// [#3238] 파일 하나를 처리해 NDJSON 레코드 하나를 만든다. 실패는 레코드로 보고하고
@@ -3080,11 +3139,14 @@ enum BatchMode {
 ///
 /// 배치는 신뢰할 수 없는 대량 코퍼스를 훑는 용도라, 한 건의 파서 panic 이 배치 전체를
 /// 죽여서는 안 된다. panic 도 해당 파일의 `error` 레코드로 격리한다.
-fn batch_record(mode: BatchMode, path: &str) -> serde_json::Value {
+fn batch_record(mode: BatchMode<'_>, path: &str) -> serde_json::Value {
     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| match mode {
         BatchMode::ExportText => batch_export_text_record_inner(path),
         BatchMode::Info => batch_info_record_inner(path),
         BatchMode::Structure(structure_mode) => batch_structure_record_inner(path, structure_mode),
+        BatchMode::Tables => batch_tables_record_inner(path),
+        BatchMode::Fields => batch_fields_record_inner(path),
+        BatchMode::Search { query } => batch_search_record_inner(path, query),
     })) {
         Ok(record) => record,
         Err(payload) => {
@@ -3162,6 +3224,54 @@ fn batch_structure_record_inner(
     structure_json_value(path, &st)
 }
 
+/// [#3346] `batch export-tables --json` 의 파일당 레코드 — `export-tables --json` 봉투와
+/// 같은 스키마(`tables_json_value` 공유)다.
+fn batch_tables_record_inner(path: &str) -> serde_json::Value {
+    use rhwp::document_core::queries::table_extract::extract_tables;
+    let data = match fs::read(path) {
+        Ok(d) => d,
+        Err(e) => return batch_fail_record(path, format!("파일을 읽을 수 없습니다: {}", e)),
+    };
+    let doc = match rhwp::wasm_api::HwpDocument::from_bytes(&data) {
+        Ok(d) => d,
+        Err(e) => return batch_fail_record(path, format!("파싱 실패: {}", e)),
+    };
+    let tables = extract_tables(doc.document());
+    tables_json_value(path, &tables)
+}
+
+/// [#3346] `batch fields --json` 의 파일당 레코드 — `fields --json` 봉투와 같은 스키마.
+fn batch_fields_record_inner(path: &str) -> serde_json::Value {
+    let data = match fs::read(path) {
+        Ok(d) => d,
+        Err(e) => return batch_fail_record(path, format!("파일을 읽을 수 없습니다: {}", e)),
+    };
+    let doc = match rhwp::wasm_api::HwpDocument::from_bytes(&data) {
+        Ok(d) => d,
+        Err(e) => return batch_fail_record(path, format!("파싱 실패: {}", e)),
+    };
+    let fields = collect_field_records(&doc);
+    fields_json_value(path, &fields)
+}
+
+/// [#3346] `batch search --json` 의 파일당 레코드 — `search --json` 봉투와 같은 스키마.
+///
+/// 대량 코퍼스에서 한 문서가 매치를 수만 건 쏟아내면 스트림이 부풀므로, 배치 경로는
+/// 파일당 매치 상한을 둔다(단건 `search --limit` 과 같은 취지).
+fn batch_search_record_inner(path: &str, query: &str) -> serde_json::Value {
+    const BATCH_MATCH_LIMIT: usize = 1000;
+    let data = match fs::read(path) {
+        Ok(d) => d,
+        Err(e) => return batch_fail_record(path, format!("파일을 읽을 수 없습니다: {}", e)),
+    };
+    let doc = match rhwp::wasm_api::HwpDocument::from_bytes(&data) {
+        Ok(d) => d,
+        Err(e) => return batch_fail_record(path, format!("파싱 실패: {}", e)),
+    };
+    let matches = doc.grep(query, true, Some(BATCH_MATCH_LIMIT));
+    search_json_value(path, query, true, &matches)
+}
+
 /// [#3238] `batch info --json` 의 파일당 레코드 — `info --json` 과 같은 스키마
 /// (`info_json_value` 공유)라 소비자가 단건/배치를 같은 코드로 읽는다.
 fn batch_info_record_inner(path: &str) -> serde_json::Value {
@@ -3190,6 +3300,46 @@ fn structure_json_value(
         "mode": st.mode,
         "nodeCount": st.node_count,
         "structure": st,
+    })
+}
+
+/// [#3346] `export-tables --json` 과 `batch export-tables` 가 공유하는 봉투.
+fn tables_json_value(
+    file_path: &str,
+    tables: &[rhwp::document_core::queries::table_extract::TableGrid],
+) -> serde_json::Value {
+    serde_json::json!({
+        "schemaVersion": "1.0",
+        "source": file_path,
+        "tableCount": tables.len(),
+        "tables": tables,
+    })
+}
+
+/// [#3346] `fields --json` 과 `batch fields` 가 공유하는 봉투.
+fn fields_json_value(file_path: &str, fields: &[serde_json::Value]) -> serde_json::Value {
+    serde_json::json!({
+        "schemaVersion": "1.0",
+        "source": file_path,
+        "fieldCount": fields.len(),
+        "fields": fields,
+    })
+}
+
+/// [#3346] `search --json` 과 `batch search` 가 공유하는 봉투.
+fn search_json_value(
+    file_path: &str,
+    query: &str,
+    case_sensitive: bool,
+    matches: &[rhwp::document_core::queries::grep::GrepMatch],
+) -> serde_json::Value {
+    serde_json::json!({
+        "schemaVersion": "1.0",
+        "source": file_path,
+        "query": query,
+        "caseSensitive": case_sensitive,
+        "matchCount": matches.len(),
+        "matches": matches,
     })
 }
 
@@ -5489,14 +5639,7 @@ fn search_document(args: &[String]) -> i32 {
     let matches = doc.grep(query, !ignore_case, limit);
 
     if json_mode {
-        let envelope = serde_json::json!({
-            "schemaVersion": "1.0",
-            "source": file_path,
-            "query": query,
-            "caseSensitive": !ignore_case,
-            "matchCount": matches.len(),
-            "matches": matches,
-        });
+        let envelope = search_json_value(file_path, query, !ignore_case, &matches);
         println!("{envelope}");
         // 매치 0건은 실패가 아니다 — 1은 런타임 실패 전용이다(#2707).
         return EXIT_OK;
@@ -7641,11 +7784,63 @@ fn ir_diff(args: &[String]) -> i32 {
     EXIT_OK
 }
 
+/// [#3346] `fields --json` 과 `batch fields` 가 공유하는 필드 레코드 수집.
+///
+/// 단건/배치가 같은 스키마를 내도록 한 곳에서 만든다.
+fn collect_field_records(doc: &rhwp::wasm_api::HwpDocument) -> Vec<serde_json::Value> {
+    use rhwp::document_core::queries::field_query::NestedEntry;
+
+    doc.collect_all_fields()
+        .iter()
+        .map(|fi| {
+            // 중첩 경로: 표 셀·글상자 안의 필드가 어디에 있는지 — 후속 편집의 좌표다.
+            let nested: Vec<serde_json::Value> = fi
+                .location
+                .nested_path
+                .iter()
+                .map(|e| match e {
+                    NestedEntry::TableCell {
+                        control_index,
+                        cell_index,
+                        para_index,
+                    } => serde_json::json!({
+                        "kind": "tableCell",
+                        "control": control_index,
+                        "cell": cell_index,
+                        "paragraph": para_index,
+                    }),
+                    NestedEntry::TextBox {
+                        control_index,
+                        para_index,
+                    } => serde_json::json!({
+                        "kind": "textBox",
+                        "control": control_index,
+                        "paragraph": para_index,
+                    }),
+                })
+                .collect();
+
+            serde_json::json!({
+                "fieldId": fi.field.field_id,
+                "fieldType": format!("{:?}", fi.field.field_type),
+                "name": fi.field.field_name().unwrap_or(""),
+                "guide": fi.field.guide_text().unwrap_or(""),
+                "memo": fi.field.memo_text().unwrap_or_default(),
+                "command": fi.field.command,
+                "value": fi.value,
+                "editableInForm": fi.field.is_editable_in_form(),
+                "location": {
+                    "section": fi.location.section_index,
+                    "paragraph": fi.location.para_index,
+                    "nested": nested,
+                },
+            })
+        })
+        .collect()
+}
+
 /// `fields` — 누름틀/필드 조사 (읽기 전용).
 ///
-/// rhwp 는 이미 필드에 값을 **쓸 수** 있는데(`set_field_value_by_name`) 조회 API 는
-/// WASM/스튜디오 경로에만 있어, 브라우저 밖 에이전트는 "이 서식이 무엇을 요구하는지"
-/// 알 방법이 없었다. 기존 `collect_all_fields()` 를 그대로 노출한다(라이브러리 무변경).
 /// `edit` — 문서 편집 명령군 (로드맵 #2659 Stage 3).
 ///
 /// 공통 규약: `--dry-run`(변경 요약만 출력, 파일 무변경), 결과 리포트 JSON,
@@ -7852,9 +8047,10 @@ fn edit_fill_fields(args: &[String]) -> i32 {
     EXIT_OK
 }
 
+/// rhwp 는 이미 필드에 값을 **쓸 수** 있는데(`set_field_value_by_name`) 조회 API 는
+/// WASM/스튜디오 경로에만 있어, 브라우저 밖 에이전트는 "이 서식이 무엇을 요구하는지"
+/// 알 방법이 없었다. 기존 `collect_all_fields()` 를 그대로 노출한다(라이브러리 무변경).
 fn show_fields(args: &[String]) -> i32 {
-    use rhwp::document_core::queries::field_query::NestedEntry;
-
     let mut file_path: Option<&str> = None;
     let mut json_mode = false;
     for a in args {
@@ -7888,62 +8084,10 @@ fn show_fields(args: &[String]) -> i32 {
         }
     };
 
-    let infos = doc.collect_all_fields();
-    let fields: Vec<serde_json::Value> = infos
-        .iter()
-        .map(|fi| {
-            // 중첩 경로: 표 셀·글상자 안의 필드가 어디에 있는지 — 후속 편집의 좌표다.
-            let nested: Vec<serde_json::Value> = fi
-                .location
-                .nested_path
-                .iter()
-                .map(|e| match e {
-                    NestedEntry::TableCell {
-                        control_index,
-                        cell_index,
-                        para_index,
-                    } => serde_json::json!({
-                        "kind": "tableCell",
-                        "control": control_index,
-                        "cell": cell_index,
-                        "paragraph": para_index,
-                    }),
-                    NestedEntry::TextBox {
-                        control_index,
-                        para_index,
-                    } => serde_json::json!({
-                        "kind": "textBox",
-                        "control": control_index,
-                        "paragraph": para_index,
-                    }),
-                })
-                .collect();
-
-            serde_json::json!({
-                "fieldId": fi.field.field_id,
-                "fieldType": format!("{:?}", fi.field.field_type),
-                "name": fi.field.field_name().unwrap_or(""),
-                "guide": fi.field.guide_text().unwrap_or(""),
-                "memo": fi.field.memo_text().unwrap_or_default(),
-                "command": fi.field.command,
-                "value": fi.value,
-                "editableInForm": fi.field.is_editable_in_form(),
-                "location": {
-                    "section": fi.location.section_index,
-                    "paragraph": fi.location.para_index,
-                    "nested": nested,
-                },
-            })
-        })
-        .collect();
+    let fields = collect_field_records(&doc);
 
     if json_mode {
-        let envelope = serde_json::json!({
-            "schemaVersion": "1.0",
-            "source": file_path,
-            "fieldCount": fields.len(),
-            "fields": fields,
-        });
+        let envelope = fields_json_value(file_path, &fields);
         println!("{envelope}");
         return EXIT_OK;
     }

--- a/tests/batch_axes_contract.rs
+++ b/tests/batch_axes_contract.rs
@@ -1,0 +1,278 @@
+//! [#3346] `batch` 신규 축(search·export-tables·fields) 계약 회귀 테스트.
+//!
+//! 핵심 계약: 배치 레코드는 **단건 명령의 봉투와 같은 스키마**다 — 소비자가 단건/배치를
+//! 같은 코드로 읽는다. 입력 순서 보존·부분 실패 exit 1 은 기존 batch 규약 그대로다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+const SAMPLE: &str = "samples/hwp3-sample.hwp";
+/// 표를 가진 문서.
+const SAMPLE_TABLE: &str = "samples/table-001.hwp";
+/// 누름틀을 가진 문서.
+const SAMPLE_FIELDS: &str = "samples/field-01.hwp";
+
+fn sample(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn run_with_stdin(args: &[&str], stdin_body: &str) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("rhwp 실행 실패");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(stdin_body.as_bytes())
+        .expect("stdin 쓰기 실패");
+    child.wait_with_output().expect("rhwp 종료 대기 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn ndjson(args: &[&str], output: &Output) -> Vec<serde_json::Value> {
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| {
+            serde_json::from_str(l)
+                .unwrap_or_else(|e| panic!("NDJSON 아님 ({e}): {l}\n{}", describe(args, output)))
+        })
+        .collect()
+}
+
+#[test]
+fn batch_search_records_share_single_command_schema() {
+    let p = sample(SAMPLE);
+    let s = p.to_str().unwrap();
+    let args = ["batch", "search", "--query", "의", "--json"];
+    let output = run_with_stdin(&args, &format!("{s}\n{s}\n"));
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+
+    let records = ndjson(&args, &output);
+    assert_eq!(records.len(), 2, "{}", describe(&args, &output));
+    for v in &records {
+        // 단건 `search --json` 봉투와 같은 필드들.
+        assert_eq!(v["schemaVersion"], "1.0", "{v}");
+        assert!(v["source"].is_string(), "{v}");
+        assert_eq!(v["query"], "의", "{v}");
+        assert!(v["matchCount"].as_u64().is_some(), "{v}");
+        assert!(v["matches"].is_array(), "{v}");
+        assert!(v.get("error").is_none(), "{v}");
+    }
+    assert!(
+        records[0]["matchCount"].as_u64().unwrap() >= 1,
+        "문서에 있는 검색어인데 0건입니다: {:?}",
+        records[0]
+    );
+}
+
+#[test]
+fn batch_export_tables_records_share_single_command_schema() {
+    let p = sample(SAMPLE_TABLE);
+    let s = p.to_str().unwrap();
+    let args = ["batch", "export-tables", "--json"];
+    let output = run_with_stdin(&args, &format!("{s}\n"));
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+
+    let records = ndjson(&args, &output);
+    assert_eq!(records.len(), 1, "{}", describe(&args, &output));
+    let v = &records[0];
+    assert_eq!(v["schemaVersion"], "1.0", "{v}");
+    assert!(v["source"].is_string(), "{v}");
+    assert!(v["tableCount"].as_u64().unwrap() >= 1, "{v}");
+    assert!(v["tables"].is_array(), "{v}");
+    // 병합 보존이 배치 경로에서도 유지되는지 — 단건과 같은 추출기를 쓴다는 증거.
+    let has_merge = v["tables"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|t| t["cells"].as_array().unwrap().iter())
+        .any(|c| {
+            c["colSpan"].as_u64().unwrap_or(1) >= 2 || c["rowSpan"].as_u64().unwrap_or(1) >= 2
+        });
+    assert!(has_merge, "병합 정보가 배치에서도 보존되어야 합니다: {v}");
+}
+
+#[test]
+fn batch_fields_records_share_single_command_schema() {
+    let p = sample(SAMPLE_FIELDS);
+    let s = p.to_str().unwrap();
+    let args = ["batch", "fields", "--json"];
+    let output = run_with_stdin(&args, &format!("{s}\n"));
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+
+    let records = ndjson(&args, &output);
+    let v = &records[0];
+    assert_eq!(v["schemaVersion"], "1.0", "{v}");
+    assert!(v["fieldCount"].as_u64().unwrap() >= 1, "{v}");
+    assert!(v["fields"].is_array(), "{v}");
+}
+
+#[test]
+fn batch_new_axes_preserve_input_order_and_report_partial_failure() {
+    // 기존 batch 규약(순서 보존 + 부분 실패 exit 1)이 신규 축에서도 성립해야 한다.
+    let p = sample(SAMPLE);
+    let s = p.to_str().unwrap();
+    let args = ["batch", "search", "--query", "의", "--json"];
+    let output = run_with_stdin(&args, &format!("{s}\n없는파일-batch-search.hwp\n{s}\n"));
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}",
+        describe(&args, &output)
+    );
+
+    let records = ndjson(&args, &output);
+    assert_eq!(records.len(), 3, "{}", describe(&args, &output));
+    // 입력 순서 보존: 두 번째가 실패 레코드여야 한다.
+    assert!(records[0].get("error").is_none(), "{:?}", records[0]);
+    assert!(records[1].get("error").is_some(), "{:?}", records[1]);
+    assert_eq!(records[1]["exitClass"], "runtime", "{:?}", records[1]);
+    assert_eq!(records[1]["schemaVersion"], "1.0", "{:?}", records[1]);
+    assert!(records[2].get("error").is_none(), "{:?}", records[2]);
+}
+
+#[test]
+fn batch_search_without_query_is_usage_error() {
+    let args = ["batch", "search", "--json"];
+    let output = run_with_stdin(&args, "");
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+}
+
+#[test]
+fn batch_query_flag_rejected_for_other_subcommands() {
+    // --query 는 search 축 전용이다 (--mode 가 export-structure 전용인 것과 같은 규약).
+    let args = ["batch", "info", "--json", "--query", "x"];
+    let output = run_with_stdin(&args, "");
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+}
+
+#[test]
+fn batch_existing_axes_still_work() {
+    // 무회귀 가드: 기존 3축이 그대로 동작해야 한다.
+    let p = sample(SAMPLE);
+    let s = p.to_str().unwrap();
+    for sub in ["info", "export-text", "export-structure"] {
+        let args = ["batch", sub, "--json"];
+        let output = run_with_stdin(&args, &format!("{s}\n"));
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "기존 축 {sub} 회귀\n{}",
+            describe(&args, &output)
+        );
+        let records = ndjson(&args, &output);
+        assert_eq!(records.len(), 1, "{sub}");
+        assert_eq!(records[0]["schemaVersion"], "1.0", "{sub}");
+    }
+}
+
+#[test]
+fn capabilities_batch_list_includes_new_axes() {
+    // 드리프트 가드: 축을 추가했으면 자기서술도 같이 갱신되어야 한다.
+    let output = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(["capabilities"])
+        .output()
+        .expect("rhwp 실행 실패");
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).expect("capabilities JSON");
+    let subs: Vec<&str> = v["batch"]["subcommands"]
+        .as_array()
+        .expect("batch.subcommands")
+        .iter()
+        .filter_map(|s| s.as_str())
+        .collect();
+    for expected in ["search", "export-tables", "fields"] {
+        assert!(
+            subs.contains(&expected),
+            "capabilities 의 batch 축에 {expected} 가 없습니다: {subs:?}"
+        );
+    }
+}
+
+#[test]
+fn mcp_batch_tools_are_invocable_from_their_declaration() {
+    // [#3346] MCP 도구는 **선언만 보고 호출**할 수 있어야 한다. `--query` 가 필수인
+    // search 축을 인자 자리표시자 없이 hwp_batch 의 enum 에만 넣으면, 매니페스트를
+    // 따르는 클라이언트가 `batch search --json` 을 만들어 항상 exit 2 를 받는다.
+    // 그래서 search 는 전용 도구(hwp_batch_search)로 분리한다.
+    let output = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(["capabilities", "--mcp"])
+        .output()
+        .expect("rhwp 실행 실패");
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).expect("MCP JSON");
+    let tools = v["tools"].as_array().expect("tools");
+
+    let batch = tools
+        .iter()
+        .find(|t| t["name"] == "hwp_batch")
+        .expect("hwp_batch 도구");
+    let subs: Vec<&str> = batch["inputSchema"]["properties"]["subcommand"]["enum"]
+        .as_array()
+        .expect("subcommand enum")
+        .iter()
+        .filter_map(|s| s.as_str())
+        .collect();
+    assert!(
+        !subs.contains(&"search"),
+        "search 는 --query 가 필수라 hwp_batch 로는 호출할 수 없습니다: {subs:?}"
+    );
+
+    let search = tools
+        .iter()
+        .find(|t| t["name"] == "hwp_batch_search")
+        .expect("hwp_batch_search 도구가 있어야 합니다");
+    let required: Vec<&str> = search["inputSchema"]["required"]
+        .as_array()
+        .expect("required")
+        .iter()
+        .filter_map(|s| s.as_str())
+        .collect();
+    assert!(required.contains(&"query"), "{search}");
+
+    // 인자 템플릿에 {query} 자리표시자가 실제로 있어야 값을 넘길 수 있다.
+    let args_str = search["cli"]["args"].to_string();
+    assert!(
+        args_str.contains("{query}"),
+        "cli.args 에 {{query}} 자리표시자가 필요합니다: {args_str}"
+    );
+}

--- a/tests/edit_fill_fields_contract.rs
+++ b/tests/edit_fill_fields_contract.rs
@@ -1,0 +1,240 @@
+//! [#3329] `edit fill-fields` 출력·안전 계약 회귀 테스트 (Stage 3 최소 조각).
+//!
+//! 편집 명령의 계약은 조회 명령보다 무겁다 — 파일을 바꾸기 때문이다.
+//! ① `--dry-run` 은 절대 파일을 만들지 않는다 ② 실패하면 출력 파일을 쓰지 않는다
+//! ③ 실제로 값이 반영됐는지는 **다시 읽어서** 확인한다.
+//! 종료 코드는 #2707 계약(0/1/2)을 따른다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// 누름틀 11개(회사명/작성자/부서명/전화번호/이메일/제목/목차1×5).
+const SAMPLE: &str = "samples/field-01.hwp";
+
+fn sample() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn temp_out(tag: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "rhwp-edit-{tag}-{}-{}.hwp",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos()
+    ))
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn parse_json(args: &[&str], output: &Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout 이 순수 JSON 이 아닙니다 ({e}).\n{}",
+            describe(args, output)
+        )
+    })
+}
+
+#[test]
+fn fill_fields_dry_run_reports_without_writing_file() {
+    // 안전장치의 핵심: --dry-run 은 무엇이 바뀔지만 보고하고 파일을 만들지 않는다.
+    let p = sample();
+    let out = temp_out("dryrun");
+    let args = [
+        "edit",
+        "fill-fields",
+        p.to_str().unwrap(),
+        "--data",
+        r#"{"회사명":"주식회사 A"}"#,
+        "-o",
+        out.to_str().unwrap(),
+        "--dry-run",
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+
+    let v = parse_json(&args, &output);
+    assert_eq!(v["schemaVersion"], "1.0", "{v}");
+    assert_eq!(v["dryRun"], true, "{v}");
+    assert!(v["source"].is_string(), "{v}");
+    assert_eq!(v["filledCount"].as_u64().unwrap(), 1, "{v}");
+
+    assert!(
+        !out.exists(),
+        "--dry-run 은 파일을 만들면 안 됩니다: {}",
+        out.display()
+    );
+}
+
+#[test]
+fn fill_fields_writes_and_value_survives_reparse() {
+    // 실제로 값이 들어갔는지는 "다시 읽어서" 확인해야 한다 — 보고만 믿지 않는다.
+    let p = sample();
+    let out = temp_out("write");
+    let args = [
+        "edit",
+        "fill-fields",
+        p.to_str().unwrap(),
+        "--data",
+        r#"{"회사명":"주식회사 검증"}"#,
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(out.exists(), "출력 파일이 생성되어야 합니다");
+
+    let v = parse_json(&args, &output);
+    assert_eq!(v["dryRun"], false, "{v}");
+    assert_eq!(v["filledCount"].as_u64().unwrap(), 1, "{v}");
+    assert!(v["output"].is_string(), "{v}");
+
+    // 산출물을 fields --json 으로 다시 읽어 값이 실제로 반영됐는지 대조한다.
+    let reread = run(&["fields", out.to_str().unwrap(), "--json"]);
+    let rv: serde_json::Value =
+        serde_json::from_slice(&reread.stdout).expect("산출물을 fields --json 으로 읽지 못함");
+    let company = rv["fields"]
+        .as_array()
+        .expect("fields 배열")
+        .iter()
+        .find(|f| f["name"] == "회사명")
+        .unwrap_or_else(|| panic!("회사명 필드를 찾지 못함: {rv}"));
+    assert_eq!(
+        company["value"], "주식회사 검증",
+        "값이 산출물에 반영되어야 합니다: {company}"
+    );
+
+    let _ = std::fs::remove_file(&out);
+}
+
+#[test]
+fn fill_fields_reports_unknown_field_names() {
+    // 문서에 없는 이름은 조용히 무시하지 않고 보고한다 — 에이전트가 오타를 알아야 한다.
+    let p = sample();
+    let out = temp_out("unknown");
+    let args = [
+        "edit",
+        "fill-fields",
+        p.to_str().unwrap(),
+        "--data",
+        r#"{"회사명":"A","존재하지않는필드":"B"}"#,
+        "-o",
+        out.to_str().unwrap(),
+        "--dry-run",
+        "--json",
+    ];
+    let output = run(&args);
+    let v = parse_json(&args, &output);
+    let missing = v["notFound"].as_array().expect("notFound 배열");
+    assert!(
+        missing.iter().any(|m| m == "존재하지않는필드"),
+        "없는 필드 이름이 보고되어야 합니다: {v}"
+    );
+    assert_eq!(v["filledCount"].as_u64().unwrap(), 1, "{v}");
+}
+
+#[test]
+fn fill_fields_missing_file_exit_runtime_and_no_output() {
+    let out = temp_out("missing");
+    let args = [
+        "edit",
+        "fill-fields",
+        "없는파일-edit.hwp",
+        "--data",
+        r#"{"a":"b"}"#,
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "실패 경로 stdout 은 비어야 합니다.\n{}",
+        describe(&args, &output)
+    );
+    assert!(
+        !out.exists(),
+        "실패 시 출력 파일을 쓰면 안 됩니다: {}",
+        out.display()
+    );
+}
+
+#[test]
+fn fill_fields_invalid_json_data_exit_usage() {
+    let p = sample();
+    let args = [
+        "edit",
+        "fill-fields",
+        p.to_str().unwrap(),
+        "--data",
+        "{이건 JSON 이 아님",
+        "--dry-run",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+}
+
+#[test]
+fn fill_fields_missing_data_exit_usage() {
+    let p = sample();
+    let args = ["edit", "fill-fields", p.to_str().unwrap()];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+}
+
+#[test]
+fn edit_unknown_subcommand_exit_usage() {
+    let args = ["edit", "no-such-action"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+}


### PR DESCRIPTION
> base: `devel` / **PR #3345 위에 적층** — 두 PR 모두 `capabilities`·MCP 자기서술을 건드리므로 적층으로 충돌을 해소했습니다. 리뷰 대상은 마지막 커밋(`58b1792a`) 하나이고, #3345 머지 시 리베이스하겠습니다.

## 변경 요약

Stage 2 조회 축이 devel 에 전부 반영됐는데 **`batch` 는 3축만** 지원해, 새로 생긴 고가치 축들이 코퍼스 규모 처리의 혜택을 못 받고 있었습니다. 문서 한 건씩 프로세스를 띄우면 1만 건 아카이브에서 파싱 비용이 1만 번 반복됩니다.

**설계 요점**

- **동시성 골격은 무변경.** `BatchMode` 에 축만 추가했습니다 — 스레드 풀·순서 보존 재정렬 버퍼·`catch_unwind` 격리·부분 실패 종료 코드를 한 줄도 건드리지 않았습니다.
- **봉투 빌더를 추출해 단건/배치가 스키마를 공유합니다.** 인라인으로 만들던 봉투를 `tables_json_value`·`fields_json_value`·`search_json_value` 호출로 바꿔 **스키마가 갈라질 수 없게** 했습니다(기존 `info`/`export-structure` 규약과 동일).
- **`--query` 는 search 축 전용** — `--mode` 가 `export-structure` 전용인 것과 같은 규약. 타 축 사용 exit 2, 누락 시 exit 2.
- **파일당 매치 1,000건 상한** — 대량 코퍼스에서 NDJSON 스트림 폭증 방어(실측: 393쪽 편람이 정확히 1000에서 잘림).

**MCP 매니페스트 결함 발견·수정**: `--query` 가 필수인 search 를 `hwp_batch` 의 enum 에만 넣으면, 매니페스트를 따르는 클라이언트가 인자를 넘길 방법이 없어 **항상 exit 2** 를 받습니다. 광고만 하고 구동할 수 없는 도구가 되는 셈이라, 전용 도구 `hwp_batch_search` 로 분리하고 **"선언만으로 호출 가능해야 한다"를 테스트로 고정**했습니다.

## 전/후 실행 증거

### 1) 아카이브 전역 검색 — 매치마다 구역·문단·페이지 주소

**명령**
```bash
printf 'samples/hwp3-sample.hwp\nsamples/table-001.hwp\n' | rhwp batch search --query 의 --json
```

**전 (devel `8bb8f277d`)**
```console
오류: batch 는 현재 export-text·info·export-structure 만 지원합니다 - search
사용법: <파일 목록> | rhwp batch <export-text|info|export-structure> --json [--mode auto|outline|clause] [--threads <N>]  (stdin: 한
exit=2
```

**후 (본 PR)**
```console
{"caseSensitive":true,"matchCount":276,"matches":[{"charOffset":25,"context":"  빠른 넷트웍에 연결된 서버(server)들의 클러스
{"caseSensitive":true,"matchCount":2,"matches":[{"cell":{"cell":7,"control":0,"paragraph":0},"charOffset":5,"context":"품질관리협의체
batch: 2건 중 2 성공, 0 실패 (21ms, threads=32)
exit=0
```

### 2) 코퍼스 표 수확 — 병합 보존

**명령**
```bash
printf 'samples/table-001.hwp\n' | rhwp batch export-tables --json
```

**전 (devel `8bb8f277d`)**
```console
오류: batch 는 현재 export-text·info·export-structure 만 지원합니다 - export-tables
사용법: <파일 목록> | rhwp batch <export-text|info|export-structure> --json [--mode auto|outline|clause] [--threads <N>]  (stdin: 한
exit=2
```

**후 (본 PR)**
```console
{"schemaVersion":"1.0","source":"samples/table-001.hwp","tableCount":1,"tables":[{"cellCount":131,"cells":[{"col":0,"colSpan":1,"isHeader":f
batch: 1건 중 1 성공, 0 실패 (1ms, threads=32)
exit=0
```

### 3) 서식 템플릿 일괄 조사

**명령**
```bash
printf 'samples/field-01.hwp\n' | rhwp batch fields --json
```

**전 (devel `8bb8f277d`)**
```console
오류: batch 는 현재 export-text·info·export-structure 만 지원합니다 - fields
사용법: <파일 목록> | rhwp batch <export-text|info|export-structure> --json [--mode auto|outline|clause] [--threads <N>]  (stdin: 한
exit=2
```

**후 (본 PR)**
```console
{"fieldCount":11,"fields":[{"command":"Clickhere:set:48:Direction:wstring:6:여기에 입력 HelpState:wstring:0:  ","editableInForm":true,"
batch: 1건 중 1 성공, 0 실패 (2ms, threads=32)
exit=0
```

### 4) MCP 도구 목록 — batch search 를 선언만으로 호출 가능

**명령**
```bash
rhwp capabilities --mcp
```

**전 (devel `8bb8f277d`)**
```console
{"invocation":{"note":"각 도구의 cli.args 에서 {name} 자리표시자를 inputSchema 의 같은 이름 값으로 치환해 실행한��
exit=0
```

**후 (본 PR)**
```console
{"invocation":{"note":"각 도구의 cli.args 에서 {name} 자리표시자를 inputSchema 의 같은 이름 값으로 치환해 실행한��
exit=0
```

## 관련 이슈

closes #3346 · 로드맵 #2659 Stage 2 완결편

## 테스트

- [x] 계약 테스트 **9종 red→green**: 3축 각각 **단건 봉투 스키마와 일치** / 배치 경로에서도 **표 병합 보존** / 입력 순서 보존 + 부분 실패 exit 1 / `--query` 누락·타 축 사용 exit 2 / **기존 3축 무회귀** / capabilities 드리프트 가드 / **MCP 도구 호출 가능성**
- [x] `cargo test --release --lib`: **2923 passed, 0 failed**
- [x] 연관 통합 스위트 무회귀: `cli_json_contract`(22)·`cli_exit_codes`(10)·`fields_json_contract`(8)·`search_json_contract`(10)·`table_extract_json_contract`(9)·`edit_fill_fields_contract`(7) — 전부 0 failed
- [x] `cargo clippy --release --bin rhwp -- -D warnings`: 0, `rustfmt`·문서 검사 스크립트 2종 clean
- [x] 실측: 단건/배치 봉투 **키 집합 동일** 확인, 1,000건 상한 동작 확인
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음 (CLI 전용)

## 남긴 것

- `batch ir-diff`(쌍 목록 검증)는 stdin 쌍 구분 형식 설계가 필요해 제외
- `batch export-svg`(렌더 배치)는 산출물 경로 충돌 규칙이 필요해 제외
- `batch search` 는 대소문자 구분 고정 — `--ignore-case` 노출은 수요 확인 후

## 스크린샷

CLI 명령이라 위 **전/후 실행 출력**이 스크린샷에 해당합니다 (devel 바이너리와 본 PR 바이너리를 각각 빌드해 같은 명령을 실행한 실측입니다).
