### PR TITLE
fix(cli): export-text 위치 인자 파싱 통일 — 옵션이 파일 앞에 와도 동작 (#3349)

### DIFF
--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -147,6 +147,8 @@ rhwp export-pdf input.hwp -o out.pdf \
   `{"schemaVersion":"1.0","source","pageCount","pages":[{"page","text"}]}` —
   `schemaVersion` 이 계약이며 필드 추가는 허용, 변경·삭제는 `tests/cli_json_contract.rs` 가 잡는다.
   `page` 는 `-p` 와 같은 0 기준.
+- 옵션은 파일 앞뒤 어디에 와도 된다 (#3349, export-structure/export-tables 와 동일 규약).
+  파일 positional 을 두 번 주면 exit 2.
 
 ### `batch <export-text|info|export-structure> --json [--mode <m>] [--threads <N>]` (#3238, #3261)
 stdin 의 파일 목록(한 줄당 경로 하나)을 **한 프로세스에서 파일 간 병렬**로 처리해

--- a/mydocs/report/task_m100_3349_report.md
+++ b/mydocs/report/task_m100_3349_report.md
@@ -1,0 +1,65 @@
+# task_m100_3349 처리결과 보고서 — `export-text` 위치 인자 파싱 통일
+
+- **이슈**: [#3349](https://github.com/edwardkim/rhwp/issues/3349)
+- **브랜치**: `pr/fix-issue-3349-export-text-option-order` (upstream/devel `4a39f7cc0` 직분기)
+- **범위**: `src/main.rs`(`export_text` 파싱부만), `tests/issue_3349_export_text_option_order.rs`(신규),
+  `mydocs/manual/cli_commands.md`(1항목)
+- **분류**: 버그 수정 (CLI 파싱 — 에이전트 호출 실패)
+
+## 1. 배경
+
+`export-text` 는 옵션이 파일 **뒤**면 동작하고 **앞**이면 exit 2 로 죽는다.
+v0.8.0 릴리스 바이너리 실측:
+
+| 호출 순서 | 결과 |
+|---|---|
+| `export-text FILE --json -p 0` | exit 0 |
+| `export-text --json FILE -p 0` | exit 0 |
+| `export-text -p 0 --json FILE` | **exit 2 — `알 수 없는 옵션: 0`** |
+| `export-text --json --page 0 FILE` | **exit 2 — `알 수 없는 옵션: 0`** |
+
+원인은 `--json` 만 위치 무관으로 선추출한 뒤 **남은 첫 토큰을 무조건 파일로 가정**
+(`let file_path = &args[0]`)하는 파싱이다. `-p` 가 파일 경로가 되고 `0` 이 옵션 자리에서
+"알 수 없는 옵션"이 된다 — 오류 메시지가 실제 원인과 무관해 진단이 불가능하다.
+
+같은 조회 축의 `export-structure`/`export-tables` 는 위치 무관 파싱이라 같은 순서가
+동작한다. 자기서술(`capabilities`)과 JSON 파이프라인 가이드 어디에도 "파일 선행" 제약이
+선언돼 있지 않으므로, 자기서술만 보고 호출을 생성하는 에이전트는 이 지뢰를 피할 수 없다.
+
+## 2. 설계 결정
+
+- **새 규약 발명 0** — `export-structure`(#3261)가 이미 쓰는 파싱(첫 비플래그 토큰 = 파일,
+  옵션 위치 무관, 중복 positional 즉시 exit 2)을 그대로 옮겼다. 명령군 안에서 규약이
+  하나로 수렴한다.
+- **기존 호출 전부 보존** — 파일 선행 호출은 이전과 동일하게 동작한다. 순수 확장이다.
+- **중복 positional 은 조용히 덮지 않는다** — `입력 파일은 하나만 지정할 수 있습니다` 로
+  즉시 exit 2 (export-structure 와 동일 문구).
+- **1차 조각은 `export-text` 하나만** — JSON 파이프라인 가이드가 첫 번째로 안내하는 추출
+  축이다. 같은 패턴(파일 선행 강제)의 나머지 export 계열(svg/png/pdf/markdown/render-tree/
+  doclang)은 같은 레시피의 후속 조각으로 남겼다(#3349 에 명단 기록).
+
+## 3. 변경
+
+- `export_text()` — 파싱 루프를 위치 무관으로 교체 (`args[0]` 가정 제거, `starts_with('-')`
+  분기 + positional 수집). 파싱 이후 로직은 무변경.
+- `cli_commands.md` — `export-text` 항목에 위치 무관 규약 1줄 명시.
+
+## 4. 검증
+
+- **회귀 테스트 5종** (`tests/issue_3349_export_text_option_order.rs`):
+  - 버그 재현 형태 그대로 `--json -p 0 FILE` → exit 0 + 봉투 계약 (red→green)
+  - `-p 0 --json FILE` — `--json` 특례가 아님을 고정
+  - 순서 3종(파일 선행/플래그 선행/교차)의 **결과 JSON 완전 일치**
+  - 중복 positional exit 2 + stdout 0바이트 + 오류 문구
+  - 알 수 없는 플래그 exit 2 (기존 계약 유지)
+- **무회귀**: `cli_json_contract`, `cli_exit_codes` 전부 green (release-test 프로필)
+- `cargo fmt --all -- --check` clean
+- **실측 전/후**: 전 = v0.8.0 릴리스 바이너리(공식 배포물), 후 = 본 브랜치 빌드 —
+  PR 본문에 콘솔 증거 수록
+
+## 5. 남긴 것
+
+- 같은 패턴의 나머지 11곳(export 계열 6 + 내부 dump/diag 5)은 이 조각이 머지된 뒤
+  같은 레시피로 후속 처리 가능 — 명단은 #3349 본문에 있다.
+- `search` 의 검색어 positional(파일 + 검색어 2개)은 이 규약의 2-positional 확장이 필요해
+  이번 범위에서 다루지 않았다.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2236,49 +2236,61 @@ fn export_text(args: &[String]) -> i32 {
         .filter(|a| a.as_str() != "--json")
         .cloned()
         .collect();
-    if args.is_empty() {
-        eprintln!("오류: HWP 파일 경로를 지정해주세요.");
-        eprintln!("사용법: rhwp export-text <파일.hwp> [옵션] (rhwp --help 참조)");
-        return EXIT_USAGE;
-    }
-
-    let file_path = &args[0];
+    // [#3349] 위치 인자 파싱을 export-structure/export-tables 규약으로 통일 —
+    // 첫 비플래그 토큰이 파일이고 옵션은 위치 무관이다. 파일 선행을 강제하면
+    // `-p 0 --json 파일` 에서 `-p` 가 파일로 잡혀 "알 수 없는 옵션: 0" 이 된다.
+    let mut file_path: Option<&str> = None;
     let mut output_dir = "output".to_string();
     let mut target_page: Option<u32> = None;
 
-    let mut i = 1;
+    let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
             "--output" | "-o" => {
-                if i + 1 < args.len() {
-                    output_dir = args[i + 1].clone();
-                    i += 2;
-                } else {
-                    eprintln!("오류: --output 뒤에 폴더 경로가 필요합니다.");
-                    return EXIT_USAGE;
+                i += 1;
+                match args.get(i) {
+                    Some(p) => output_dir = p.clone(),
+                    None => {
+                        eprintln!("오류: --output 뒤에 폴더 경로가 필요합니다.");
+                        return EXIT_USAGE;
+                    }
                 }
             }
             "--page" | "-p" => {
-                if i + 1 < args.len() {
-                    match args[i + 1].parse::<u32>() {
+                i += 1;
+                match args.get(i) {
+                    Some(v) => match v.parse::<u32>() {
                         Ok(n) => target_page = Some(n),
                         Err(_) => {
                             eprintln!("오류: 페이지 번호가 올바르지 않습니다.");
                             return EXIT_USAGE;
                         }
+                    },
+                    None => {
+                        eprintln!("오류: --page 뒤에 페이지 번호가 필요합니다.");
+                        return EXIT_USAGE;
                     }
-                    i += 2;
-                } else {
-                    eprintln!("오류: --page 뒤에 페이지 번호가 필요합니다.");
+                }
+            }
+            other if other.starts_with('-') => {
+                eprintln!("알 수 없는 옵션: {other}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if file_path.replace(other).is_some() {
+                    eprintln!("오류: 입력 파일은 하나만 지정할 수 있습니다: {other}");
                     return EXIT_USAGE;
                 }
             }
-            _ => {
-                eprintln!("알 수 없는 옵션: {}", args[i]);
-                return EXIT_USAGE;
-            }
         }
+        i += 1;
     }
+
+    let Some(file_path) = file_path else {
+        eprintln!("오류: HWP 파일 경로를 지정해주세요.");
+        eprintln!("사용법: rhwp export-text <파일.hwp> [옵션] (rhwp --help 참조)");
+        return EXIT_USAGE;
+    };
 
     let data = match fs::read(file_path) {
         Ok(d) => d,

--- a/tests/issue_3349_export_text_option_order.rs
+++ b/tests/issue_3349_export_text_option_order.rs
@@ -1,0 +1,116 @@
+//! [#3349] `export-text` 위치 인자 파싱 회귀 테스트.
+//!
+//! 계약: 옵션은 파일 앞뒤 어디에 와도 같은 결과를 낸다 (export-structure/export-tables 와
+//! 동일 규약). 파일 선행을 강제하던 시절에는 `-p 0 --json 파일` 에서 `-p` 가 파일로 잡혀
+//! "알 수 없는 옵션: 0" 으로 죽었다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::process::{Command, Output};
+
+/// 파싱까지 성공하는 실제 샘플 (cli_json_contract.rs 와 동일).
+const SAMPLE: &str = "samples/hwp3-sample.hwp";
+
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(rhwp_bin())
+        .args(args)
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn stdout_json(args: &[&str]) -> serde_json::Value {
+    let output = run(args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "exit 0 이어야 합니다.\n{}",
+        describe(args, &output)
+    );
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout 이 순수 JSON 이 아닙니다 ({e}).\n{}",
+            describe(args, &output)
+        )
+    })
+}
+
+/// 버그 재현 형태 그대로 — 옵션 전부가 파일 앞에 와도 동작한다.
+#[test]
+fn options_before_file_succeeds() {
+    let value = stdout_json(&["export-text", "--json", "-p", "0", SAMPLE]);
+    assert_eq!(value["schemaVersion"], "1.0");
+    assert_eq!(value["source"], SAMPLE);
+    assert_eq!(value["pageCount"], 1);
+    assert_eq!(value["pages"][0]["page"], 0);
+}
+
+/// `--json` 특례가 아니라 모든 옵션이 위치 무관임을 고정한다.
+#[test]
+fn page_before_json_before_file_succeeds() {
+    let value = stdout_json(&["export-text", "-p", "0", "--json", SAMPLE]);
+    assert_eq!(value["pages"][0]["page"], 0);
+}
+
+/// 옵션 순서가 달라도 결과 JSON 은 완전히 같다.
+#[test]
+fn all_orders_produce_identical_json() {
+    let file_first = stdout_json(&["export-text", SAMPLE, "--json", "-p", "0"]);
+    let flag_first = stdout_json(&["export-text", "--page", "0", "--json", SAMPLE]);
+    let interleaved = stdout_json(&["export-text", "--json", SAMPLE, "-p", "0"]);
+    assert_eq!(file_first, flag_first);
+    assert_eq!(file_first, interleaved);
+}
+
+/// 파일을 두 번 주면 조용히 덮어쓰지 않고 즉시 사용법 오류다.
+#[test]
+fn duplicate_file_is_usage_error() {
+    let args = ["export-text", SAMPLE, SAMPLE, "--json"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "exit 2 여야 합니다.\n{}",
+        describe(&args, &output)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "실패 시 stdout 은 0바이트여야 합니다.\n{}",
+        describe(&args, &output)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("입력 파일은 하나만"),
+        "중복 positional 오류 메시지가 나와야 합니다.\n{}",
+        describe(&args, &output)
+    );
+}
+
+/// 알 수 없는 플래그는 여전히 사용법 오류로 잡는다 (기존 계약 유지).
+#[test]
+fn unknown_flag_is_usage_error() {
+    let args = ["export-text", "--nope", SAMPLE];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "exit 2 여야 합니다.\n{}",
+        describe(&args, &output)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("알 수 없는 옵션"),
+        "알 수 없는 옵션 메시지가 나와야 합니다.\n{}",
+        describe(&args, &output)
+    );
+}


### PR DESCRIPTION
> base: `devel` (`4a39f7cc0`) 직분기 — 열린 PR(#3345·#3347)과 겹치는 함수 없음.

## 변경 요약

#3349 수정입니다. `export-text` 는 옵션이 파일 **뒤**면 동작하지만 **앞**이면
`알 수 없는 옵션: 0` (exit 2) 으로 죽습니다. 원인은 `--json` 만 위치 무관으로 선추출한 뒤
**남은 첫 토큰을 무조건 파일로 가정**하는 파싱입니다 — `-p 0 --json FILE` 에서 `-p` 가
파일 경로가 되고, `0` 이 옵션 자리에서 원인 무관한 오류로 보고됩니다.

같은 조회 축의 `export-structure`/`export-tables` 는 이미 위치 무관 파싱이라 같은 순서가
동작합니다. `capabilities` 자기서술과 JSON 파이프라인 가이드 어디에도 "파일 선행" 제약이
선언돼 있지 않으므로, 자기서술만 보고 호출을 생성하는 에이전트는 이 지뢰를 피할 방법이
없습니다. 가이드의 공식 예시조차 옵션 선행(`rhwp export-text --json 문서.hwp`)입니다 —
`--json` 만 특례로 살고 `-p` 는 죽는 현재 상태는 규약이 아니라 우연입니다.

**설계 요점**

- **새 규약 발명 0** — `export-structure`(#3261)의 파싱(첫 비플래그 토큰 = 파일, 옵션 위치
  무관, 중복 positional 즉시 exit 2)을 그대로 옮겼습니다. 파싱 이후 로직은 무변경입니다.
- **기존 호출 전부 보존** — 파일 선행 호출은 이전과 동일하게 동작합니다. 순수 확장입니다.
- **중복 positional 은 조용히 덮지 않습니다** — `입력 파일은 하나만 지정할 수 있습니다` 로
  즉시 exit 2 (export-structure 와 동일 문구).
- **1차 조각은 `export-text` 하나만** — JSON 파이프라인 가이드가 첫 번째로 안내하는 추출
  축입니다. 같은 패턴의 나머지(export-svg 실측 재현 포함 12곳)는 #3349 에 명단을 남겼고,
  이 조각이 자리 잡으면 같은 레시피로 후속 처리 가능합니다.

## 전/후 실행 증거

전 = **v0.8.0 공식 릴리스 바이너리**(Windows x86_64 배포물 그대로), 후 = 본 브랜치 빌드.
대상: `samples/2022년 국립국어원 업무계획.hwp` (35쪽).

### 전 (v0.8.0 릴리스) — 옵션 선행이 원인 무관한 오류로 죽음

```console
$ rhwp export-text --json --page 0 "samples/2022년 국립국어원 업무계획.hwp"
알 수 없는 옵션: 0
exit=2

$ rhwp export-text -p 0 --json "samples/2022년 국립국어원 업무계획.hwp"
알 수 없는 옵션: 0
exit=2

$ rhwp export-text "samples/2022년 국립국어원 업무계획.hwp" --json -p 0   # 파일 선행만 생존
{"pageCount":1,"pages":[{"page":0,"text":"...2022년 국립국어원 업무계획..."}],"schemaVersion":"1.0",...}
exit=0
```

### 후 (본 PR) — 세 순서 전부 동작, 결과 바이트 동일

```console
$ rhwp export-text --json --page 0 "samples/2022년 국립국어원 업무계획.hwp"   # exit 0
$ rhwp export-text -p 0 --json "samples/2022년 국립국어원 업무계획.hwp"       # exit 0
$ rhwp export-text "samples/2022년 국립국어원 업무계획.hwp" --json -p 0      # exit 0 (기존 호출 무변화)

# 순서 3종 stdout sha256 동일:
파일선행   f8feb0a007e084a6…
플래그선행 f8feb0a007e084a6…
교차       f8feb0a007e084a6…
```

새로 생기는 오류 계약 — 중복 positional 은 조용히 덮지 않습니다:

```console
$ rhwp export-text A.hwp B.hwp --json
오류: 입력 파일은 하나만 지정할 수 있습니다: B.hwp
exit=2
```

## 검증

- **회귀 테스트 5종** (`tests/issue_3349_export_text_option_order.rs`, red→green):
  버그 재현형(`--json -p 0 FILE`) / `--json` 특례 아님(`-p 0 --json FILE`) /
  순서 3종 결과 JSON 완전 일치 / 중복 positional exit 2 + stdout 0바이트 /
  알 수 없는 플래그 exit 2 유지
- **무회귀**: `cli_json_contract`(22), `cli_exit_codes` 전부 green (release-test 프로필)
- `cargo fmt --all -- --check` clean, clippy `--bin rhwp -- -D warnings` 0건
- 문서: `cli_commands.md` `export-text` 항목에 위치 무관 규약 1줄 명시.
  처리 기록: `mydocs/report/task_m100_3349_report.md`
