### PR TITLE
fix(cli): search --limit 절단 가시화 — totalMatchCount·truncated 추가-전용 필드 (#3353)

### DIFF
--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -275,14 +275,16 @@ HWP 파일 정보 표시(버전/구역 수/암호화 등).
 문서를 검색해 매치마다 **구역·문단·페이지·문자 오프셋**을 함께 돌려준다.
 평문을 뽑아 외부에서 찾으면 주소가 소멸해 근거 제시가 불가능한데, rhwp 는 조판 엔진이
 있어 "몇 쪽"에 답할 수 있다. 파서/렌더 무변경 읽기 질의.
-- `--json` 봉투: `{"schemaVersion":"1.0","source","query","caseSensitive","matchCount","matches":[…]}`
+- `--json` 봉투: `{"schemaVersion":"1.0","source","query","caseSensitive","matchCount","totalMatchCount","truncated","matches":[…]}`
 - 매치: `{section,paragraph,page?,charOffset,length,text,context,cell?}`
   - `page` 는 0부터 시작하는 글로벌 페이지. 조판에 배치되지 않은 문단이면 생략된다.
   - `cell` 은 표 셀 안의 매치일 때 `{control,cell,paragraph}` 좌표
   - `context` 는 매치 앞뒤 발췌(각 40자)
 - 검색 범위는 본문 + 표 셀 + 글상자 (`search_query::search_all` 과 동일)
 - **매치 0건은 오류가 아니다** — `matchCount:0`, 종료 코드 0 (1은 런타임 실패 전용)
-- `--limit N` 은 대형 문서에서 컨텍스트를 아끼기 위한 상한
+- `--limit N` 은 대형 문서에서 컨텍스트를 아끼기 위한 상한. 절단돼도
+  `totalMatchCount`(문서 전체 매치 수)와 `truncated:true` 로 총량이 보인다 (#3353) —
+  `matchCount` 는 종전대로 반환된 매치 수(= `matches` 길이)다.
 - 성능: 페이지 매핑 비용은 0이다(로드 시 조판 완료). `(구역,문단)→페이지` 인덱스를
   한 번만 만들어 재사용한다. 실측 393쪽·10MB 문서에서 19건 검색 **215ms**(파싱 포함).
 

--- a/mydocs/report/task_m100_3353_report.md
+++ b/mydocs/report/task_m100_3353_report.md
@@ -1,0 +1,52 @@
+# task_m100_3353 처리결과 보고서 — `search --limit` 절단 가시성
+
+- **이슈**: [#3353](https://github.com/edwardkim/rhwp/issues/3353)
+- **브랜치**: `pr/fix-issue-3353-search-limit-truncation` (upstream/devel `4a39f7cc0` 직분기)
+- **범위**: `src/main.rs`(`search_document` 결과 집계부 + capabilities recordFields),
+  `tests/issue_3353_search_limit_truncation.rs`(신규), `mydocs/manual/cli_commands.md`(2줄)
+- **분류**: 버그 수정 (CLI JSON 계약 — 절단 은폐)
+
+## 1. 배경
+
+`search --limit N` 은 도움말이 "컨텍스트 절약용"으로 권하는 옵션인데, 이걸 쓰면
+`matchCount` 가 절단된 수를 보고하고 절단 표시가 없어 **문서 전체 매치 수를 알 수 없다.**
+v0.8.0 실측: 316건 문서에서 `--limit 3` → `{"matchCount":3}` — "정확히 3건"과
+"3건만 표시(실제 316건)"를 에이전트가 구별할 방법이 없다. 컨텍스트를 아끼려는
+에이전트일수록 `--limit` 을 쓰므로, 신중한 소비자가 더 크게 속는 구조다.
+
+## 2. 설계 결정
+
+- **`matchCount` 의미 보존** — 종전대로 반환된 매치 수(= `matches.len()`)다. 스키마
+  정책(필드 추가만 허용, 변경·삭제 금지)과 기존 소비자(`matchCount > 0` 게이트,
+  `search_limit_caps_result_count` 계약 테스트)를 깨지 않는다.
+- **추가-전용 2필드** — `totalMatchCount`(문서 전체 매치 수), `truncated`(절단 여부).
+  에이전트 재질의 판단 근거가 봉투 안에 생긴다.
+- **전수 grep 후 표시만 절단** — 총량 보고에는 전수 스캔이 불가피하다. `--limit` 의
+  목적은 스캔 시간이 아니라 **출력 컨텍스트** 절약이므로 목적을 해치지 않는다
+  (스캔 비용은 limit 유무와 무관하게 문서 크기에 비례. 코어 `grep` 시그니처 무변경).
+- **비-JSON 출력도 동일 원칙** — 절단 시 `— 316건 중 3건 표시 (--limit)`.
+- **`capabilities` recordFields 동기화** — 자기서술만 보고 소비하는 에이전트가 새 필드를
+  발견할 수 있게 등재.
+
+## 3. 변경
+
+- `search_document()` — `grep(…, limit)` → `grep(…, None)` 전수 스캔 후 `take(n)` 절단,
+  `totalMatchCount`·`truncated` 봉투 추가, 절단 시 사람용 출력 문구 변경.
+- capabilities 의 search `recordFields` 에 `totalMatchCount`·`truncated` 등재.
+- `cli_commands.md` — search 봉투·`--limit` 항목 갱신.
+
+## 4. 검증
+
+- **회귀 테스트 4종** (`tests/issue_3353_search_limit_truncation.rs`, red→green):
+  절단 시 totalMatchCount=전체·truncated=true / 미절단 시 totalMatchCount==matchCount·
+  truncated=false / limit ≥ 전체면 truncated=false / 비-JSON 절단 안내 문구
+- **무회귀**: `search_json_contract`(기존 계약 — `matchCount ≤ limit` 포함),
+  `cli_json_contract` 전부 green (release-test 프로필)
+- `cargo fmt --all -- --check` clean, clippy `--bin rhwp -- -D warnings` 0건
+- **실측 전/후**: 전 = v0.8.0 릴리스 바이너리, 후 = 본 브랜치 빌드 — PR 본문 수록
+
+## 5. 남긴 것
+
+- #3347 의 `batch search` 는 파일당 1,000건 상한을 두므로 같은 가시성이 필요하다.
+  #3347 이 봉투 빌더(`search_json_value`)를 추출하므로, 머지 순서에 따라 이 필드들을
+  빌더로 옮기는 리베이스(또는 빌더 위 얹기)로 정리한다 — #3353 본문에 기록됨.

--- a/src/main.rs
+++ b/src/main.rs
@@ -427,6 +427,8 @@ fn show_capabilities(args: &[String]) -> i32 {
                 "query",
                 "caseSensitive",
                 "matchCount",
+                "totalMatchCount",
+                "truncated",
                 "matches",
             ],
         ),
@@ -5439,15 +5441,28 @@ fn search_document(args: &[String]) -> i32 {
         }
     };
 
-    let matches = doc.grep(query, !ignore_case, limit);
+    // [#3353] 총량을 보고하려면 전수 스캔이 불가피하다 — `--limit` 의 목적은 스캔 시간이
+    // 아니라 출력 컨텍스트 절약이므로, 전수 grep 후 표시만 절단한다. 절단 사실을 숨기면
+    // 에이전트가 "정확히 N건"과 "N건만 표시(실제 그 이상)"를 구별할 수 없다.
+    let all_matches = doc.grep(query, !ignore_case, None);
+    let total_match_count = all_matches.len();
+    let matches: Vec<_> = match limit {
+        Some(n) => all_matches.into_iter().take(n).collect(),
+        None => all_matches,
+    };
+    let truncated = matches.len() < total_match_count;
 
     if json_mode {
+        // [#3353] matchCount 는 종전대로 반환된 매치 수(= matches.len())다.
+        // totalMatchCount·truncated 는 추가-전용 필드(스키마 정책: 변경·삭제 금지).
         let envelope = serde_json::json!({
             "schemaVersion": "1.0",
             "source": file_path,
             "query": query,
             "caseSensitive": !ignore_case,
             "matchCount": matches.len(),
+            "totalMatchCount": total_match_count,
+            "truncated": truncated,
             "matches": matches,
         });
         println!("{envelope}");
@@ -5455,7 +5470,17 @@ fn search_document(args: &[String]) -> i32 {
         return EXIT_OK;
     }
 
-    println!("검색: {:?} in {} — {}건", query, file_path, matches.len());
+    if truncated {
+        println!(
+            "검색: {:?} in {} — {}건 중 {}건 표시 (--limit)",
+            query,
+            file_path,
+            total_match_count,
+            matches.len()
+        );
+    } else {
+        println!("검색: {:?} in {} — {}건", query, file_path, matches.len());
+    }
     for m in &matches {
         let page = m
             .page

--- a/tests/issue_3353_search_limit_truncation.rs
+++ b/tests/issue_3353_search_limit_truncation.rs
@@ -1,0 +1,118 @@
+//! [#3353] `search --limit` 절단 가시성 회귀 테스트.
+//!
+//! 계약: `matchCount` 는 반환된 매치 수(= `matches.len()`)이고, `totalMatchCount` 는
+//! 문서 전체 매치 수, `truncated` 는 절단 여부다. `--limit` 을 써도 에이전트가
+//! "정확히 N건"과 "N건만 표시(실제 그 이상)"를 구별할 수 있어야 한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// search_json_contract.rs 와 같은 샘플·검색어 — 매치가 여러 건 실재한다.
+const SAMPLE: &str = "samples/hwp3-sample.hwp";
+const QUERY: &str = "의";
+
+fn sample(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(rhwp_bin())
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn search_json(extra: &[&str]) -> serde_json::Value {
+    let p = sample(SAMPLE);
+    let mut args = vec!["search", p.to_str().unwrap(), QUERY, "--json"];
+    args.extend_from_slice(extra);
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout 이 순수 JSON 이 아닙니다 ({e}).\n{}",
+            describe(&args, &output)
+        )
+    })
+}
+
+/// 절단 시: matchCount 는 limit, totalMatchCount 는 전체, truncated=true.
+#[test]
+fn limit_reports_total_and_truncated() {
+    let full = search_json(&[]);
+    let total = full["matchCount"].as_u64().expect("matchCount");
+    assert!(total >= 2, "샘플에 매치가 2건 이상이어야 합니다: {full}");
+
+    let limited = search_json(&["--limit", "1"]);
+    assert_eq!(limited["matchCount"], 1, "{limited}");
+    assert_eq!(
+        limited["matches"].as_array().map(Vec::len),
+        Some(1),
+        "{limited}"
+    );
+    assert_eq!(
+        limited["totalMatchCount"].as_u64(),
+        Some(total),
+        "절단돼도 문서 전체 매치 수를 보고해야 합니다: {limited}"
+    );
+    assert_eq!(limited["truncated"], true, "{limited}");
+}
+
+/// 미절단 시: totalMatchCount == matchCount, truncated=false.
+#[test]
+fn no_limit_reports_not_truncated() {
+    let v = search_json(&[]);
+    assert_eq!(v["totalMatchCount"], v["matchCount"], "{v}");
+    assert_eq!(v["truncated"], false, "{v}");
+}
+
+/// limit 이 전체 이상이면 절단이 아니다.
+#[test]
+fn limit_at_or_above_total_is_not_truncated() {
+    let full = search_json(&[]);
+    let total = full["matchCount"].as_u64().expect("matchCount");
+    let big = (total + 10).to_string();
+    let v = search_json(&["--limit", &big]);
+    assert_eq!(v["matchCount"].as_u64(), Some(total), "{v}");
+    assert_eq!(v["totalMatchCount"].as_u64(), Some(total), "{v}");
+    assert_eq!(v["truncated"], false, "{v}");
+}
+
+/// 비-JSON 출력도 절단 시 전체 건수를 알린다.
+#[test]
+fn human_output_reports_total_when_truncated() {
+    let p = sample(SAMPLE);
+    let args = ["search", p.to_str().unwrap(), QUERY, "--limit", "1"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("건 중 1건 표시"),
+        "절단 시 '전체 N건 중 1건 표시' 안내가 나와야 합니다.\n{}",
+        describe(&args, &output)
+    );
+}


### PR DESCRIPTION
> base: `devel` (`4a39f7cc0`) 직분기. 열린 PR 중 #3347(batch search)과 주제가 인접하나
> 겹치는 코드는 없습니다 — 조율 계획은 마지막 절 참조.

## 변경 요약

#3353 수정입니다. `search --limit N` 은 도움말이 "컨텍스트 절약용"으로 권하는 옵션인데,
정작 이걸 쓰면 `matchCount` 가 절단된 수를 보고하고 절단 표시가 없어 **문서 전체 매치
수를 알 수 없게 됩니다.** 316건 문서에서 `--limit 3` → `{"matchCount":3}` — 에이전트는
"정확히 3건"과 "3건만 표시(실제 316건)"를 구별할 방법이 없습니다. 컨텍스트를 아끼려는
에이전트일수록 `--limit` 을 쓰므로, **신중한 소비자가 더 크게 속는** 구조입니다.

**설계 요점**

- **`matchCount` 의미 보존** — 종전대로 반환된 매치 수(= `matches.len()`)입니다. 스키마
  정책(필드 추가만 허용)과 기존 소비자(`matchCount > 0` 게이트, 기존 계약 테스트
  `search_limit_caps_result_count`)를 깨지 않습니다.
- **추가-전용 2필드** — `totalMatchCount`(문서 전체 매치 수)·`truncated`(절단 여부).
  에이전트가 "더 있는가"를 봉투 안에서 판단합니다.
- **전수 grep 후 표시만 절단** — 총량 보고에는 전수 스캔이 불가피합니다. `--limit` 의
  목적은 스캔 시간이 아니라 **출력 컨텍스트** 절약이므로 목적을 해치지 않습니다
  (스캔 비용은 limit 유무와 무관하게 문서 크기에 비례, 코어 `grep` 시그니처 무변경).
- **비-JSON 출력도 동일 원칙** — 절단 시 `— 316건 중 3건 표시 (--limit)`.
- **`capabilities` recordFields 동기화** — 자기서술만 보고 소비하는 에이전트가 새 필드를
  발견할 수 있습니다.

## 전/후 실행 증거

전 = **v0.8.0 공식 릴리스 바이너리**, 후 = 본 브랜치 빌드.
대상: `samples/2022년 국립국어원 업무계획.hwp` (35쪽, "국어" 316건).

### 전 (v0.8.0 릴리스) — 절단이 보이지 않음

```console
$ rhwp search FILE 국어 --json | jq '{matchCount, totalMatchCount, truncated}'
{"matchCount":316, "totalMatchCount":null, "truncated":null}

$ rhwp search FILE 국어 --json --limit 3 | jq '{matchCount, totalMatchCount, truncated}'
{"matchCount":3, "totalMatchCount":null, "truncated":null}     # ← 316건인데 3건으로 보임

$ rhwp search FILE 국어 --limit 3
검색: "국어" in samples/2022년 국립국어원 업무계획.hwp — 3건
```

### 후 (본 PR) — 총량·절단이 봉투 안에 있음

```console
$ rhwp search FILE 국어 --json | jq '{matchCount, totalMatchCount, truncated}'
{"matchCount":316, "totalMatchCount":316, "truncated":false}

$ rhwp search FILE 국어 --json --limit 3 | jq '{matchCount, totalMatchCount, truncated}'
{"matchCount":3, "totalMatchCount":316, "truncated":true}

$ rhwp search FILE 국어 --limit 3
검색: "국어" in samples/2022년 국립국어원 업무계획.hwp — 316건 중 3건 표시 (--limit)
```

## 검증

- **회귀 테스트 4종** (`tests/issue_3353_search_limit_truncation.rs`, red→green):
  절단 시 `totalMatchCount`=전체·`truncated:true` / 미절단 시 두 값 일치·`false` /
  `--limit ≥ 전체` 는 절단 아님 / 비-JSON 절단 안내 문구
- **무회귀**: `search_json_contract`(기존 `matchCount ≤ limit` 계약 포함),
  `cli_json_contract` 전부 green (release-test 프로필)
- `cargo fmt --all -- --check` clean, clippy `--bin rhwp -- -D warnings` 0건
- 문서: `cli_commands.md` search 봉투·`--limit` 항목 갱신.
  처리 기록: `mydocs/report/task_m100_3353_report.md`

## #3347 과의 조율

#3347 의 `batch search` 는 파일당 1,000건 상한을 두므로 같은 절단 가시성이 필요합니다.
#3347 이 봉투 빌더(`search_json_value`)를 추출하므로:
- 본 PR 이 먼저 머지되면 — #3347 리베이스 때 두 필드를 빌더로 함께 옮기겠습니다.
- #3347 이 먼저 머지되면 — 본 PR 을 빌더 위에 리베이스해 batch 축까지 같이 해소하겠습니다.
