### PR TITLE
fix(cli): export 계열 위치 인자 파싱 통일 2차 조각 — svg/png/pdf/markdown/render-tree/doclang (#3359)

### DIFF
--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -24,6 +24,8 @@ rhwp --version     # 버전
 - `-p, --page <번호>` — 특정 페이지만 (0부터). 생략 시 전체
 - `--profile <프로필>` — 출력 프로필: `screen` | `print` | `high-quality` | `fast-preview`
   (export-svg / export-png / export-pdf 지원, #2297)
+- 옵션은 파일 앞뒤 어디에 와도 된다 (#3359 — export-svg/png/pdf/markdown/render-tree/
+  doclang, export-structure/export-tables 와 동일 규약). 파일 positional 을 두 번 주면 exit 2.
 
 **프로필 의미론** — 편집 시각 요소(#2225 그림 미지정 placeholder 등)의 표시 여부를 가른다:
 

--- a/mydocs/report/task_m100_3359_report.md
+++ b/mydocs/report/task_m100_3359_report.md
@@ -1,0 +1,49 @@
+# task_m100_3359 처리결과 보고서 — export 계열 위치 인자 파싱 통일 (2차 조각)
+
+- **이슈**: [#3359](https://github.com/edwardkim/rhwp/issues/3359) (#3349 후속)
+- **브랜치**: `pr/fix-issue-3359-export-family-option-order` (upstream/devel `4a39f7cc0` 직분기)
+- **범위**: `src/main.rs`(export_svg/export_render_tree/export_png/export_pdf/
+  export_markdown/export_doclang 파싱부만), `tests/issue_3359_export_family_option_order.rs`(신규),
+  `mydocs/manual/cli_commands.md`(공통 옵션 1항목)
+- **분류**: 버그 수정 (CLI 파싱 — #3349 명단의 export 계열 잔여분)
+
+## 1. 배경
+
+#3349 에서 확인한 파일-선행 강제 파싱(`args[0]` 무조건 파일 가정)의 export 계열 잔여
+6곳이다. 실측(v0.8.0): `rhwp export-svg -p 0 FILE` → `알 수 없는 옵션: 0` exit 2.
+1차 조각(#3352, export-text)과 같은 레시피를 기계적으로 적용했다.
+
+## 2. 설계 결정
+
+- **1차 조각과 동일 규약** — 첫 비플래그 토큰 = 파일, 옵션 위치 무관, 중복 positional
+  즉시 exit 2 (`입력 파일은 하나만 지정할 수 있습니다`), 파일 미지정 시 기존 사용법
+  메시지 그대로 exit 2. 각 명령의 옵션 처리 암은 무변경 — 기본 암(`_`)만
+  `starts_with('-')` 분기 + positional 수집으로 교체했다.
+- **export-pdf 의 `--help` 특례 보존** — 첫 인자 `--help|-h` 는 종전대로 사용법 출력
+  exit 0. (다른 위치의 `--help` 는 종전에도 지금도 알 수 없는 옵션 exit 2.)
+- **export-png 도 같은 레시피 적용** — 단 native-skia feature 빌드에서만 실행되므로
+  통합 테스트는 non-feature 빌드에서 가능한 5종만 다룬다. 내부 도구(dump-*, diag)는
+  '일반 사용자 대상 아님' 구분에 따라 범위 제외(#3359 본문에 기록).
+
+## 3. 변경
+
+- 6개 함수 파싱부: `args[0]` 가정 제거 → 위치 무관 수집. 파싱 이후 로직 무변경.
+- `cli_commands.md` 공통 옵션에 위치 무관 규약 1항목.
+
+## 4. 검증
+
+- **회귀 테스트 8종** (`tests/issue_3359_export_family_option_order.rs`, red→green):
+  svg/markdown/render-tree/pdf/doclang 옵션 선행 성공(산출물 확인 포함) /
+  중복 positional exit 2 / 옵션만 주고 파일 없음 exit 2 (5종 일괄) /
+  알 수 없는 플래그 즉시 exit 2 유지
+- **무회귀**: `cli_exit_codes`(export-svg `--fontpath` 오타 즉시 exit 2 + 산출물 미생성
+  계약 포함), `cli_json_contract` 전부 green (release-test 프로필)
+- `cargo fmt --all -- --check` clean, clippy `--bin rhwp -- -D warnings` 0건
+- **실측 전/후**: 전 = v0.8.0 릴리스(export-svg `-p 0` 선행 exit 2), 후 = 본 브랜치
+  빌드(동작) — PR 본문 수록
+
+## 5. 남긴 것
+
+- 내부 도구(dump-pages/dump-note-shape/dump-endnote-lines/dump/diag)의 같은 패턴 5곳 —
+  필요해지면 같은 레시피로.
+- `search` 의 2-positional(파일+검색어) 확장은 #3349 때와 같은 이유로 범위 밖.

--- a/src/main.rs
+++ b/src/main.rs
@@ -824,15 +824,9 @@ fn allows_implicit_sibling_resources(format: rhwp::parser::FileFormat) -> bool {
 }
 
 fn export_svg(args: &[String]) -> i32 {
-    if args.is_empty() {
-        eprintln!("오류: 문서 파일 경로를 지정해주세요.");
-        eprintln!(
-            "사용법: rhwp export-svg <파일.hwp|파일.hwpx|파일.hml> [옵션] (rhwp --help 참조)"
-        );
-        return EXIT_USAGE;
-    }
-
-    let file_path = &args[0];
+    // [#3359] 위치 인자 파싱은 export-structure/export-text(#3349) 규약과 동일 —
+    // 첫 비플래그 토큰이 파일이고 옵션은 위치 무관이다.
+    let mut file_path: Option<&str> = None;
     let mut output_dir = "output".to_string();
     let mut target_page: Option<u32> = None;
     let mut show_para_marks = false;
@@ -846,7 +840,7 @@ fn export_svg(args: &[String]) -> i32 {
     let mut render_profile: Option<rhwp::paint::RenderProfile> = None;
     let mut json_mode = false;
 
-    let mut i = 1;
+    let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
             "--output" | "-o" => {
@@ -980,12 +974,27 @@ fn export_svg(args: &[String]) -> i32 {
                 json_mode = true;
                 i += 1;
             }
-            _ => {
-                eprintln!("알 수 없는 옵션: {}", args[i]);
+            other if other.starts_with('-') => {
+                eprintln!("알 수 없는 옵션: {other}");
                 return EXIT_USAGE;
+            }
+            other => {
+                if file_path.replace(other).is_some() {
+                    eprintln!("오류: 입력 파일은 하나만 지정할 수 있습니다: {other}");
+                    return EXIT_USAGE;
+                }
+                i += 1;
             }
         }
     }
+
+    let Some(file_path) = file_path else {
+        eprintln!("오류: 문서 파일 경로를 지정해주세요.");
+        eprintln!(
+            "사용법: rhwp export-svg <파일.hwp|파일.hwpx|파일.hml> [옵션] (rhwp --help 참조)"
+        );
+        return EXIT_USAGE;
+    };
 
     if render_profile.is_some() && font_embed_mode != rhwp::renderer::svg::FontEmbedMode::None {
         eprintln!("오류: --profile은 --font-style/--embed-fonts와 함께 사용할 수 없습니다.");
@@ -1162,20 +1171,15 @@ fn export_svg(args: &[String]) -> i32 {
 }
 
 fn export_render_tree(args: &[String]) -> i32 {
-    if args.is_empty() {
-        eprintln!("오류: HWP 파일 경로를 지정해주세요.");
-        eprintln!("사용법: rhwp export-render-tree <파일.hwp> [옵션] (rhwp --help 참조)");
-        return EXIT_USAGE;
-    }
-
-    let file_path = &args[0];
+    // [#3359] 위치 인자 파싱은 export-structure/export-text(#3349) 규약과 동일.
+    let mut file_path: Option<&str> = None;
     let mut output_dir = "output".to_string();
     let mut target_page: Option<u32> = None;
     let mut show_para_marks = false;
     let mut show_control_codes = false;
     let mut respect_vpos_reset = false;
 
-    let mut i = 1;
+    let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
             "--output" | "-o" => {
@@ -1214,12 +1218,25 @@ fn export_render_tree(args: &[String]) -> i32 {
                 respect_vpos_reset = true;
                 i += 1;
             }
-            _ => {
-                eprintln!("알 수 없는 옵션: {}", args[i]);
+            other if other.starts_with('-') => {
+                eprintln!("알 수 없는 옵션: {other}");
                 return EXIT_USAGE;
+            }
+            other => {
+                if file_path.replace(other).is_some() {
+                    eprintln!("오류: 입력 파일은 하나만 지정할 수 있습니다: {other}");
+                    return EXIT_USAGE;
+                }
+                i += 1;
             }
         }
     }
+
+    let Some(file_path) = file_path else {
+        eprintln!("오류: HWP 파일 경로를 지정해주세요.");
+        eprintln!("사용법: rhwp export-render-tree <파일.hwp> [옵션] (rhwp --help 참조)");
+        return EXIT_USAGE;
+    };
 
     let data = match fs::read(file_path) {
         Ok(d) => d,
@@ -1572,13 +1589,8 @@ fn export_png(_args: &[String]) -> i32 {
 fn export_png(args: &[String]) -> i32 {
     use rhwp::document_core::queries::rendering::{PngExportOptions, VlmTarget};
 
-    if args.is_empty() {
-        eprintln!("오류: HWP 파일 경로를 지정해주세요.");
-        eprintln!("사용법: rhwp export-png <파일.hwp> [옵션] (rhwp --help 참조)");
-        return EXIT_USAGE;
-    }
-
-    let file_path = &args[0];
+    // [#3359] 위치 인자 파싱은 export-structure/export-text(#3349) 규약과 동일.
+    let mut file_path: Option<&str> = None;
     let mut output_dir = "output".to_string();
     let mut target_page: Option<u32> = None;
     let mut font_paths: Vec<std::path::PathBuf> = Vec::new();
@@ -1589,7 +1601,7 @@ fn export_png(args: &[String]) -> i32 {
     // PNG export is print-equivalent output. Editor visuals require an explicit screen profile.
     let mut render_profile = rhwp::paint::RenderProfile::HighQuality;
 
-    let mut i = 1;
+    let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
             "--output" | "-o" => {
@@ -1705,12 +1717,25 @@ fn export_png(args: &[String]) -> i32 {
                     return EXIT_USAGE;
                 }
             }
-            _ => {
-                eprintln!("알 수 없는 옵션: {}", args[i]);
+            other if other.starts_with('-') => {
+                eprintln!("알 수 없는 옵션: {other}");
                 return EXIT_USAGE;
+            }
+            other => {
+                if file_path.replace(other).is_some() {
+                    eprintln!("오류: 입력 파일은 하나만 지정할 수 있습니다: {other}");
+                    return EXIT_USAGE;
+                }
+                i += 1;
             }
         }
     }
+
+    let Some(file_path) = file_path else {
+        eprintln!("오류: HWP 파일 경로를 지정해주세요.");
+        eprintln!("사용법: rhwp export-png <파일.hwp> [옵션] (rhwp --help 참조)");
+        return EXIT_USAGE;
+    };
 
     let png_options = PngExportOptions {
         scale,
@@ -1836,12 +1861,7 @@ fn export_png(args: &[String]) -> i32 {
 }
 
 fn export_pdf(args: &[String]) -> i32 {
-    if args.is_empty() {
-        eprintln!("오류: 문서 파일 경로를 지정해주세요.");
-        print_export_pdf_usage();
-        return 2;
-    }
-    if args[0] == "--help" || args[0] == "-h" {
+    if args.first().is_some_and(|a| a == "--help" || a == "-h") {
         print_export_pdf_usage();
         return 0;
     }
@@ -1854,7 +1874,8 @@ fn export_pdf(args: &[String]) -> i32 {
 
     #[cfg(not(target_arch = "wasm32"))]
     {
-        let file_path = &args[0];
+        // [#3359] 위치 인자 파싱은 export-structure/export-text(#3349) 규약과 동일.
+        let mut file_path: Option<&str> = None;
         let mut output_file = String::new();
         let mut target_page: Option<u32> = None;
         let mut pdf_backend = rhwp::renderer::pdf::PdfBackend::default();
@@ -1864,7 +1885,7 @@ fn export_pdf(args: &[String]) -> i32 {
         let mut compatibility_only_options = Vec::new();
         let mut direct_raster_dpi_was_set = false;
 
-        let mut i = 1;
+        let mut i = 0;
         while i < args.len() {
             match args[i].as_str() {
                 "--output" | "-o" => {
@@ -2061,13 +2082,26 @@ fn export_pdf(args: &[String]) -> i32 {
                     );
                     i += 1;
                 }
-                _ => {
-                    eprintln!("알 수 없는 옵션: {}", args[i]);
+                other if other.starts_with('-') => {
+                    eprintln!("알 수 없는 옵션: {other}");
                     print_export_pdf_usage();
                     return 2;
                 }
+                other => {
+                    if file_path.replace(other).is_some() {
+                        eprintln!("오류: 입력 파일은 하나만 지정할 수 있습니다: {other}");
+                        return 2;
+                    }
+                    i += 1;
+                }
             }
         }
+
+        let Some(file_path) = file_path else {
+            eprintln!("오류: 문서 파일 경로를 지정해주세요.");
+            print_export_pdf_usage();
+            return 2;
+        };
 
         compatibility_only_options.sort_unstable();
         compatibility_only_options.dedup();
@@ -2512,17 +2546,12 @@ fn export_tables(args: &[String]) -> i32 {
 }
 
 fn export_markdown(args: &[String]) -> i32 {
-    if args.is_empty() {
-        eprintln!("오류: HWP 파일 경로를 지정해주세요.");
-        eprintln!("사용법: rhwp export-markdown <파일.hwp> [옵션] (rhwp --help 참조)");
-        return EXIT_USAGE;
-    }
-
-    let file_path = &args[0];
+    // [#3359] 위치 인자 파싱은 export-structure/export-text(#3349) 규약과 동일.
+    let mut file_path: Option<&str> = None;
     let mut output_dir = "output".to_string();
     let mut target_page: Option<u32> = None;
 
-    let mut i = 1;
+    let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
             "--output" | "-o" => {
@@ -2549,12 +2578,25 @@ fn export_markdown(args: &[String]) -> i32 {
                     return EXIT_USAGE;
                 }
             }
-            _ => {
-                eprintln!("알 수 없는 옵션: {}", args[i]);
+            other if other.starts_with('-') => {
+                eprintln!("알 수 없는 옵션: {other}");
                 return EXIT_USAGE;
+            }
+            other => {
+                if file_path.replace(other).is_some() {
+                    eprintln!("오류: 입력 파일은 하나만 지정할 수 있습니다: {other}");
+                    return EXIT_USAGE;
+                }
+                i += 1;
             }
         }
     }
+
+    let Some(file_path) = file_path else {
+        eprintln!("오류: HWP 파일 경로를 지정해주세요.");
+        eprintln!("사용법: rhwp export-markdown <파일.hwp> [옵션] (rhwp --help 참조)");
+        return EXIT_USAGE;
+    };
 
     let data = match fs::read(file_path) {
         Ok(d) => d,
@@ -5774,19 +5816,12 @@ fn convert_hwp(args: &[String]) -> i32 {
 /// `export_hwpx_native()` 로 HWPX(ZIP) 직렬화한다. `convert`(배포용 해제 → .hwp 출력)와
 /// 별개의 포맷 변환 명령. 출력 생략 시 입력과 같은 폴더에 `<stem>.hwpx`.
 fn export_doclang(args: &[String]) -> i32 {
-    if args.is_empty() {
-        eprintln!("오류: 문서 파일 경로를 지정해주세요.");
-        eprintln!(
-            "사용법: rhwp export-doclang <파일.hwp|파일.hwpx> [-o <출력.xml>] [--assets-dir <디렉터리>] (rhwp --help 참조)"
-        );
-        return EXIT_USAGE;
-    }
-
-    let file_path = &args[0];
+    // [#3359] 위치 인자 파싱은 export-structure/export-text(#3349) 규약과 동일.
+    let mut file_path: Option<&str> = None;
     let mut output_override: Option<std::path::PathBuf> = None;
     let mut assets_dir: Option<std::path::PathBuf> = None;
 
-    let mut i = 1;
+    let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
             "--output" | "-o" => {
@@ -5807,12 +5842,27 @@ fn export_doclang(args: &[String]) -> i32 {
                     return EXIT_USAGE;
                 }
             }
-            _ => {
-                eprintln!("알 수 없는 옵션: {}", args[i]);
+            other if other.starts_with('-') => {
+                eprintln!("알 수 없는 옵션: {other}");
                 return EXIT_USAGE;
+            }
+            other => {
+                if file_path.replace(other).is_some() {
+                    eprintln!("오류: 입력 파일은 하나만 지정할 수 있습니다: {other}");
+                    return EXIT_USAGE;
+                }
+                i += 1;
             }
         }
     }
+
+    let Some(file_path) = file_path else {
+        eprintln!("오류: 문서 파일 경로를 지정해주세요.");
+        eprintln!(
+            "사용법: rhwp export-doclang <파일.hwp|파일.hwpx> [-o <출력.xml>] [--assets-dir <디렉터리>] (rhwp --help 참조)"
+        );
+        return EXIT_USAGE;
+    };
 
     // 기본 출력 경로: 입력 stem + `.dclg.xml` (입력 파일 옆).
     let input_path = std::path::Path::new(file_path);

--- a/tests/issue_3359_export_family_option_order.rs
+++ b/tests/issue_3359_export_family_option_order.rs
@@ -1,0 +1,199 @@
+//! [#3359] export 계열 위치 인자 파싱 회귀 테스트 (#3349 2차 조각).
+//!
+//! 계약: export-svg/render-tree/pdf/markdown/doclang 은 옵션이 파일 앞에 와도
+//! 동작한다 (export-structure/export-text 와 동일 규약). 파일 선행을 강제하던
+//! 시절에는 `-p 0 파일` 에서 `-p` 가 파일로 잡혀 "알 수 없는 옵션: 0" 으로 죽었다.
+//! export-png 은 같은 레시피를 적용했으나 native-skia feature 빌드에서만 실행
+//! 가능하므로 여기서는 다루지 않는다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const SAMPLE: &str = "samples/hwp3-sample.hwp";
+
+fn sample_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}
+
+fn unique_temp_path(label: &str) -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock")
+        .as_nanos();
+    std::env::temp_dir().join(format!("rhwp-3359-{label}-{}-{nonce}", std::process::id()))
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(rhwp_bin())
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn assert_code(args: &[&str], expected: i32) -> Output {
+    let output = run(args);
+    assert_eq!(
+        output.status.code(),
+        Some(expected),
+        "{}",
+        describe(args, &output)
+    );
+    output
+}
+
+/// 버그 재현 형태 그대로 — 옵션 전부가 파일 앞에 와도 산출물이 나온다.
+#[test]
+fn export_svg_options_before_file_succeeds() {
+    let sample = sample_path();
+    let out = unique_temp_path("svg");
+    let out_s = out.to_str().expect("utf-8 경로");
+    let args = [
+        "export-svg",
+        "-p",
+        "0",
+        "-o",
+        out_s,
+        sample.to_str().unwrap(),
+    ];
+    assert_code(&args, 0);
+    let produced = std::fs::read_dir(&out)
+        .expect("출력 폴더")
+        .filter_map(Result::ok)
+        .any(|e| e.path().extension().is_some_and(|x| x == "svg"));
+    assert!(produced, "SVG 산출물이 있어야 합니다");
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+#[test]
+fn export_markdown_options_before_file_succeeds() {
+    let sample = sample_path();
+    let out = unique_temp_path("md");
+    let out_s = out.to_str().expect("utf-8 경로");
+    let args = [
+        "export-markdown",
+        "-p",
+        "0",
+        "-o",
+        out_s,
+        sample.to_str().unwrap(),
+    ];
+    assert_code(&args, 0);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+#[test]
+fn export_render_tree_options_before_file_succeeds() {
+    let sample = sample_path();
+    let out = unique_temp_path("rt");
+    let out_s = out.to_str().expect("utf-8 경로");
+    let args = [
+        "export-render-tree",
+        "-p",
+        "0",
+        "-o",
+        out_s,
+        sample.to_str().unwrap(),
+    ];
+    assert_code(&args, 0);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+#[test]
+fn export_pdf_options_before_file_succeeds() {
+    let sample = sample_path();
+    let out = unique_temp_path("pdf");
+    std::fs::create_dir_all(&out).expect("임시 폴더");
+    let out_file = out.join("out.pdf");
+    let out_file_s = out_file.to_str().expect("utf-8 경로");
+    let args = [
+        "export-pdf",
+        "-o",
+        out_file_s,
+        "-p",
+        "0",
+        sample.to_str().unwrap(),
+    ];
+    assert_code(&args, 0);
+    assert!(out_file.exists(), "PDF 산출물이 있어야 합니다");
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+#[test]
+fn export_doclang_options_before_file_succeeds() {
+    // doclang 은 HWP5/HWPX 입력 전용이라 HWP3 공용 샘플 대신 HWP5 샘플을 쓴다.
+    let sample = Path::new(env!("CARGO_MANIFEST_DIR")).join("samples/field-01.hwp");
+    let out = unique_temp_path("dclg");
+    std::fs::create_dir_all(&out).expect("임시 폴더");
+    let out_file = out.join("out.dclg.xml");
+    let out_file_s = out_file.to_str().expect("utf-8 경로");
+    let args = ["export-doclang", "-o", out_file_s, sample.to_str().unwrap()];
+    assert_code(&args, 0);
+    assert!(out_file.exists(), "DocLang 산출물이 있어야 합니다");
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+/// 파일을 두 번 주면 조용히 덮어쓰지 않고 즉시 사용법 오류다 (대표: export-svg).
+#[test]
+fn duplicate_file_is_usage_error() {
+    let sample = sample_path();
+    let s = sample.to_str().unwrap();
+    let args = ["export-svg", s, s];
+    let output = assert_code(&args, 2);
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("입력 파일은 하나만"),
+        "{}",
+        describe(&args, &output)
+    );
+}
+
+/// 파일 없이 옵션만 주면 사용법 오류다 (no-args 케이스는 cli_exit_codes 가 커버).
+#[test]
+fn options_without_file_is_usage_error() {
+    for args in [
+        vec!["export-svg", "-p", "0"],
+        vec!["export-markdown", "-p", "0"],
+        vec!["export-render-tree", "-p", "0"],
+        vec!["export-pdf", "-p", "0"],
+        vec!["export-doclang", "--assets-dir", "x"],
+    ] {
+        let output = run(&args);
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "{}",
+            describe(&args, &output)
+        );
+    }
+}
+
+/// 알 수 없는 플래그는 여전히 즉시 사용법 오류로 잡는다 (기존 계약 유지).
+#[test]
+fn unknown_flag_is_still_usage_error() {
+    let sample = sample_path();
+    let args = [
+        "export-svg",
+        "--fontpath",
+        "./ttfs",
+        sample.to_str().unwrap(),
+    ];
+    let output = assert_code(&args, 2);
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("알 수 없는 옵션: --fontpath"),
+        "{}",
+        describe(&args, &output)
+    );
+}


### PR DESCRIPTION
> base: `devel` (`4a39f7cc0`) 직분기. 열린 PR #3352(1차 조각, export-text)와 **같은
> 레시피의 다른 함수들**이라 파일은 겹치되(main.rs) hunk 는 겹치지 않습니다.

## 변경 요약

#3359 수정입니다 — #3349 에서 명단을 남긴 export 계열 잔여 6곳
(`export-svg`/`export-png`/`export-pdf`/`export-markdown`/`export-render-tree`/`export-doclang`)에
1차 조각(#3352)과 같은 레시피를 적용했습니다. 실측(v0.8.0):

```console
$ rhwp export-svg -p 0 "samples/2022년 국립국어원 업무계획.hwp"
알 수 없는 옵션: 0
exit=2
```

**설계 요점**

- **각 명령의 옵션 처리 암은 무변경** — 기본 암(`_`)만 `starts_with('-')` 분기 +
  positional 수집으로 교체. 파싱 이후 로직 무변경, 파일 선행 호출 전부 보존(순수 확장).
- **중복 positional 은 조용히 덮지 않습니다** — `입력 파일은 하나만 지정할 수 있습니다`
  즉시 exit 2 (export-structure/#3352 와 동일 문구).
- **export-pdf 의 `--help` 특례 보존** — 첫 인자 `--help|-h` 는 종전대로 사용법 + exit 0.
- **export-png 도 같은 레시피** — 단 native-skia 빌드에서만 실행되므로 통합 테스트는
  non-feature 빌드에서 가능한 5종을 다룹니다. 내부 도구(dump-*, diag)는 도움말의
  '일반 사용자 대상 아님' 구분에 따라 범위 제외.

## 전/후 실행 증거

전 = **v0.8.0 공식 릴리스 바이너리**, 후 = 본 브랜치 빌드.

```console
# 전 — 옵션 선행이 전 명령에서 즉사
$ rhwp export-svg -p 0 FILE                    → 알 수 없는 옵션: 0 (exit 2)
$ rhwp export-markdown -p 0 -o out FILE        → 알 수 없는 옵션: 0 (exit 2)
$ rhwp export-pdf -o out.pdf -p 0 FILE         → 알 수 없는 옵션: 0 (exit 2)

# 후 — 동작 + 산출물 생성 (파일 선행 호출도 종전대로)
$ rhwp export-svg -p 0 -o out FILE             → exit 0, out/…_001.svg
$ rhwp export-markdown -p 0 -o out FILE        → exit 0
$ rhwp export-pdf -o out/out.pdf -p 0 FILE     → exit 0, out/out.pdf

# 새 오류 계약 — 중복 positional
$ rhwp export-svg A.hwp B.hwp                  → 오류: 입력 파일은 하나만 지정할 수 있습니다: B.hwp (exit 2)
```

## 검증

- **회귀 테스트 8종** (`tests/issue_3359_export_family_option_order.rs`, red→green):
  svg/markdown/render-tree/pdf/doclang 옵션 선행 성공(산출물 존재 확인) /
  중복 positional exit 2 / 옵션만 있고 파일 없음 exit 2 (5종 일괄) /
  알 수 없는 플래그 즉시 exit 2 유지
- **무회귀**: `cli_exit_codes` — 특히 `--fontpath` 오타 시 **즉시 exit 2 + 산출물
  미생성** 계약이 그대로 통과합니다. `cli_json_contract` 전부 green (release-test).
- `cargo fmt --all -- --check` clean, clippy `--bin rhwp -- -D warnings` 0건
- 문서: `cli_commands.md` 공통 옵션에 위치 무관 규약 1항목.
  처리 기록: `mydocs/report/task_m100_3359_report.md`
