### PR TITLE
fix(hwp3): 문단 테두리 선 종류를 한컴 실측대로 '선 없음'으로 배선 — 42쪽 상자·음영 좌우선 오렌더 정정 (#3303)

### DIFF
--- a/mydocs/report/task_m100_3303_report.md
+++ b/mydocs/report/task_m100_3303_report.md
@@ -1,0 +1,65 @@
+# Task #3303 — HWP3 문단 테두리 '없음' 오렌더 정정 (최종 보고서)
+
+- Issue: [#3303](https://github.com/edwardkim/rhwp/issues/3303)
+- Branch: `task/3303-para-border-none-render`
+- 계획서: `mydocs/working/task_m100_3303_stage1.md` / `_stage2.md`
+
+## 결론
+
+SO-SUEOP.hwp 42쪽 지문 문단에 그려지던 테두리 상자(v0.8.0 시각 회귀)와
+hwp3-sample4 음영 문단 좌우의 검은 세로선은 **같은 뿌리** — #2995(bde926e4b)가
+HWP3 `border=1`을 4방향 Solid로 합성했고, `BorderLineType`의 Rust 기본값이 Solid라
+음영 경로의 BorderFill까지 Solid 선을 갖게 된 것이다. 파서에서 4방향 선을 명시적
+`None`으로 배선해 정정했다(렌더러 무수정 — `para_border_is_visible`이 None을 걸러줌).
+
+## 권위 근거 (3중 교차검증)
+
+| 층위 | 실측 |
+|---|---|
+| 원시 바이트 | 42쪽 지문 셰이프 `shade_ratio=0, border=1, border_connection=1` |
+| 스펙 정독 | 표 13(187B)에 테두리 선 종류/굵기/색 필드 부재 — offset 181은 on/off 뿐 |
+| 한컴 UI | 문단 모양 대화상자: 종류 "선 없음"·0.1mm·검정, 문단 테두리 연결 ON |
+| 한컴 변환 HWPX | `samples/SO-SUEOP.hwpx` `paraPr 38 → border borderFillIDRef="1" connect="1"`, `borderFill 1` 4방향 `type="NONE"` |
+| 코퍼스 스윕 | HWP3 271개 전수에서 `border=1`은 SO-SUEOP 유일 — Solid 합성의 양성 증거 전무 |
+
+부수 확정: 스펙 표 13 offset 182 "1=선 연결 안 함"은 실측과 **극성 반대**
+(`border_connection=1 → connect="1"` 연결 ON). rhwp 배선(#2976, attr1 bit28)은 실측과
+일치해 무변경. 두 사항 모두 `mydocs/tech/한글문서파일구조3.0.md` 표 13 아래 보완
+주석으로 기록(#1129 보완 주석 관례를 따름 — hwp_spec_errata.md는 HWP5 전용 정오표라
+위치 변경).
+
+## 수정
+
+- `src/parser/hwp3/mod.rs` `hwp3_para_shape_border_fill()`: 4방향 선을 명시적
+  `BorderLineType::None`으로 채우고 has_border Solid 합성 블록 삭제. bf 생성
+  조건(`shade>0 || border=1`)·참조·연결 배선 무변경 — 한컴 변환 HWPX와 동형 구조.
+- 테스트 3케이스 교체/추가: border만 → None 선 / 음영만 → None 선+Solid fill /
+  둘 다 없음 → None 반환.
+
+## 검증 결과
+
+| 항목 | 결과 |
+|---|---|
+| 단위(hwp3 파서 36건, 신규 3건 포함) | 통과 |
+| 전체 `cargo test --tests --profile release-test` | 323 스위트 전부 ok, 실패 0 |
+| `cargo fmt --check` | 통과 |
+| IR 덤프 | ps 947 `border_fill_id=5` 참조 구조 보존 |
+| SVG | 42쪽 stroke 6→2(소멸 4 = 지문·222번 좌우 세로선, 잔여 2 = 머리말 구분선·본문 밑줄), sample4 stroke 4→0 + 음영 rect 2 보존 |
+| render-tree JSON | 테두리 Line 노드 소멸(잔여 1 = 머리말 구분선) |
+| skia (`--features native-skia` export-png) | 42쪽에서 지문 높이 80%+ 관통 세로 열 0개 (수정 전 우측 세로선 실측 지점) |
+| canvas2d (wasm 재빌드, studio) | **작업지시자 시각 판정 통과** (2026-07-26) |
+
+수정 영향 파일은 코퍼스 스윕상 SO-SUEOP·hwp3-sample4 2개뿐 — 그 외 HWP3 문서
+무영향은 구조적으로 보장된다.
+
+## 후속 (범위 밖)
+
+- **ir-diff 확장 제안**: ParaShape 비교 항목에 `border_fill_id` + 참조 BorderFill
+  4방향 선 종류 요약 추가. 이번 발산(HWPX NONE vs HWP3 Solid)은 현행 ir-diff
+  비교 항목(ml/mr/indent/tab_def/sb/sa/ls) 밖이라 자동 검출되지 않았다.
+- 한컴이 문단 테두리를 실제로 그리는 HWP3 양성 샘플(한글 97 형식 저장 대비 실험)이
+  확보되면 선 합성 재도입을 그 실측 근거로 판단한다.
+
+## 릴리즈
+
+0.8.1 PATCH 대상 (#3348과 함께).

--- a/mydocs/tech/한글문서파일구조3.0.md
+++ b/mydocs/tech/한글문서파일구조3.0.md
@@ -411,6 +411,20 @@ last_verified: 2026-07-17
 
 **표 13 문단 모양**
 
+> **rhwp Task #3303 보완 주석 (2026-07-26):** offset 181 "문단 테두리 1=있음"은 테두리
+> **구조**의 존재이지 선을 그린다는 뜻이 아니다. 문단 모양에는 테두리 선 종류/굵기/색
+> 필드가 없으며, 한컴 2022는 `border=1`을 **선 없음**(NONE, 0.1mm, 검정 기본값)으로
+> 매핑한다 — 근거: `samples/SO-SUEOP.hwp`(원시 바이트 border=1) → 한컴 UI "선 없음"
+> 표시 + 한컴 자체 변환 `samples/SO-SUEOP.hwpx`의 `paraPr/border → borderFill` 4방향
+> `type="NONE"` 실측 3중 교차검증. 파서는 BorderFill 구조를 유지하되 선 종류를 항상
+> None 으로 배선한다(Solid 합성 금지 — #2995 의 Solid 합성이 42쪽 지문 상자 오렌더의
+> 원인이었다). 음영(offset 180) 경로 역시 배경 채움만 배선하고 선은 None 이다.
+>
+> **offset 182 "선 연결" 극성 반대:** 스펙 문구 "1=테두리 선 연결 안 함"은 실측과
+> 반대다. 같은 문서의 한컴 변환 HWPX 에서 `border_connection=1` 문단이
+> `<hh:border ... connect="1"/>`(연결 ON)로 매핑됨을 확인했다. rhwp 배선(#2976,
+> ParaShape attr1 bit 28 set)은 실측과 일치한다.
+
 ---
 
 ## 6. 글자 모양 자료 구조

--- a/mydocs/working/task_m100_3303_stage1.md
+++ b/mydocs/working/task_m100_3303_stage1.md
@@ -1,0 +1,88 @@
+# Task #3303 Stage 1 — 문단 테두리 '없음' 오렌더 (수행계획서)
+
+## 증상 (이슈 + 오늘 실측)
+
+`samples/SO-SUEOP.hwp` 42쪽 지문 문단들에 rhwp가 테두리 상자를 그린다. 한컴 편집기
+문단 모양 대화상자의 테두리 종류는 **"없음"**(작업지시자 실측, 2026-07-25). v0.7.x에는
+없다가 v0.8.0에서 나타난 시각 회귀로, 용의 커밋은 bde926e4b(#2995)다.
+
+## 조사 결과 (2026-07-26)
+
+1. **원시 바이트 실측**: 42쪽 지문 문단 셰이프(ps_id=947 계열)는
+   `shade_ratio=0, border=1, border_connection=1`. 파일에는 스펙(표 13, offset 181
+   "문단 테두리 0=없음, 1=있음")상 "있음"이 기록되어 있다.
+2. **원인 확정**: bde926e4b가 `has_border()`(=`border==1`)만으로 4방향
+   `BorderLineType::Solid` 테두리를 IR에 배선 → 렌더러가 그대로 그림. 즉 이슈의
+   가설 (a) "파서가 '없음' 테두리를 border_fill 참조로 잘못 배선"이 맞다. 렌더러는
+   선이 있으니 그리는 것뿐이므로 수정은 **파서 안**에서 끝낸다(CLAUDE.md: HWP3 전용
+   해석은 `src/parser/hwp3/` 안에서).
+3. **스펙 한계**: HWP3 문단 모양에는 테두리 **선 종류/굵기/색 필드가 없다**(on/off
+   1바이트뿐). #2995는 스펙 문구("1=있음")만 근거로 Solid 4방향을 합성했고, red→green
+   테스트도 합성 struct 입력뿐 — **한컴 확인 양성 샘플이 없었다**.
+4. **코퍼스 스윕(271개 HWP3 전수)**: `border=1`인 파일은 SO-SUEOP.hwp **단 1개**
+   (셰이프 2건)이고, 그 파일에 대한 한컴 판정이 "없음"이다. 나머지 border_fill 생성은
+   전부 `shade_ratio>0, border=0`(hwp3-sample4, 음영 경로 77건). 즉 **"border=1 →
+   한컴이 테두리를 그린다"는 양성 증거가 코퍼스에 전무**하고, 유일한 실측 증거는
+   그 반대다.
+5. **한컴 자체 변환 HWPX 대조(권위 확정)**: `samples/SO-SUEOP.hwpx`(한컴 편집기가
+   같은 V3 문서를 HWPX로 변환한 것)에서 해당 지문 문단 `paraPr id="38"`은
+   `<hh:border borderFillIDRef="1" ... connect="1"/>`를 갖고, `borderFill id="1"`은
+   **4방향 전부 `type="NONE"` `width="0.1 mm"` `color="#000000"`, 채움 없음**이다.
+   한컴 UI 대화상자 실측(종류: 선 없음, 굵기 0.1mm, 색 검정, 연결 ON)과 XML이
+   완전 일치 — V3 `border=1`의 목표 매핑이 구조 레벨로 확정됐다.
+
+## 방침 (한컴 UI 실측 반영 — 2026-07-26 작업지시자 제공)
+
+한컴 2022 문단 모양 대화상자 실측으로 V3 → 한컴 매핑이 확정됐다:
+
+| V3 바이트 | 한컴 2022 매핑 |
+|---|---|
+| `border=1` | 테두리 **종류: 선 없음**(굵기 0.1mm·색 검정 기본값) → 선을 그리지 않음 |
+| `border_connection=1` | 문단 테두리 **연결: ON** |
+| `shade_ratio=0` | 배경 면 색: 색 없음 |
+
+이에 따라 `hwp3_para_shape_border_fill()`의 **has_border 기반 `Solid` 4방향 합성을
+제거하고, 한컴과 동일하게 "선 없음" 매핑으로 정정**한다(#2995의 Solid 합성 철회).
+BorderFill 생성·참조 자체는 유지(한컴도 테두리 구조는 유지한 채 선 종류만 없음) —
+시각 결과는 "그리지 않음", 왕복 보존 구조는 한컴과 동형. 음영(`shade_ratio>0`)
+경로는 무변경.
+
+- 근거: 시각 판정 권위(한컴 2022) UI 실측 + 스펙 정독(표 13에 선 종류 필드 부재)
+  교차검증. 스펙 문구("1=있음")는 "테두리 구조 존재"이지 "선을 그린다"가 아님이
+  실측으로 확정.
+- `hwp_spec_errata.md`에 2건 기록해 재발 방지:
+  (1) 표 13 offset 181 — border=1이어도 선 종류 필드가 없어 한컴은 "선 없음"으로
+  매핑(Solid 합성 금지). (2) offset 182 — 스펙 "1=연결 안 함"은 실측과 **극성 반대**
+  (한컴: border_connection=1 → 연결 ON). rhwp 현행 배선(#2976, attr1 bit28)은 실측과
+  일치하므로 무변경.
+
+## 수정 범위
+
+- `src/parser/hwp3/mod.rs` — `hwp3_para_shape_border_fill()`: has_border 시
+  `BorderLineType::Solid` 합성을 제거하고 선 종류를 기본값(없음)으로 유지(BorderFill
+  생성·참조는 유지). 함수 주석을 #3303 한컴 실측 근거로 갱신. #2995 합성 테스트
+  (`test_hwp3_para_shape_border_fill_wires_has_border_flag`)를 "border=1 → BorderFill은
+  생성되되 4방향 선 종류는 없음(Solid 합성 금지)" 기대로 교체.
+- `mydocs/tech/hwp_spec_errata.md` — 표 13 offset 181(선 없음 매핑)·182(연결 극성
+  반대) 실측 불일치 2건 추가.
+- 렌더러 무수정 — 단, 검증에서 "선 없음 BorderFill 참조(border_fill_id≠0)일 때
+  아무 백엔드도 선을 그리지 않음"을 실측으로 확인(이슈 가설 (b) 기각 확정).
+
+## 검증
+
+1. 단위: 갱신 테스트 (border=1·shade=0 → None / shade>0 → Some+선 없음+음영 유지).
+2. IR: `dump samples/SO-SUEOP.hwp`에서 ps_id=947 `border_fill_id=0` 확인.
+3. 시각: `export-png -p 41`(42쪽) before/after + **4-backend 대조**(svg/canvas/paint/json
+   — 오늘할일 이월 기록의 "수정 시 4-backend 대조 필수") + skia(p42 우측 세로선 소멸).
+   after 자산은 작업지시자 시각 판정 게이트.
+4. 회귀: hwp3-sample4(음영 77건) before/after 픽셀 diff 0 확인(음영 경로 무영향 증명).
+5. push 전: `cargo test --tests --profile release-test` + `fmt --check`.
+
+## PR
+
+- 브랜치 `task/3303-para-border-none-render`, base devel, `Closes #3303`.
+- 0.8.1 PATCH 대상. PR 생성은 별도 승인 후.
+
+## 다음 단계
+
+승인 시 Stage 2(구현계획서 — 코드/테스트/errata 문안 확정) 후 구현.

--- a/mydocs/working/task_m100_3303_stage2.md
+++ b/mydocs/working/task_m100_3303_stage2.md
@@ -1,0 +1,88 @@
+# Task #3303 Stage 2 — 구현계획서
+
+## Stage 1 이후 추가 실증 (구현 직전 조사)
+
+1. **렌더러는 `line_type == None`이면 그리지 않는다** (`para_border_is_visible`,
+   `layout.rs:94`; `border_rendering.rs` 전반). 이슈 가설 (b)(renderer가 id≠0이면
+   무조건 그림)는 기각 — 파서에서 선 종류를 None으로 주면 충분하다.
+2. **`BorderLineType`의 `#[default]`가 `Solid`** (`model/style.rs:559`). 따라서
+   `BorderFill::default()`로 만든 bf의 4방향 선이 이미 Solid이고, bde926e4b의 명시적
+   Solid 설정은 사실상 no-op — **bf를 생성한 것 자체가 테두리를 그리게 했다**.
+3. **음영 경로도 같은 뿌리로 오염**: hwp3-sample4 4쪽 SVG 실측에서 음영 rect 2개의
+   좌·우 모서리에 검은 세로선(#000000, 0.4px) 4개가 그려진다. V3에는 선 종류 필드가
+   없으므로 이 선들도 합성 아티팩트다. (#3303의 "skia 우측 세로선"·42쪽 좌우
+   세로선과 동일 기전 — 상하선은 연결/스킵 로직으로 생략되어 좌우만 보임)
+
+## 수정 — `src/parser/hwp3/mod.rs` `hwp3_para_shape_border_fill()`
+
+```rust
+// [#3303] V3 문단 모양(표 13)에는 테두리 선 종류/굵기/색 필드가 없다(181 offset
+// on/off 뿐). 한컴 2022는 border=1을 "선 없음(NONE, 0.1mm, 검정)"으로 매핑한다
+// (한컴 자체 변환 SO-SUEOP.hwpx: paraPr/border→borderFill 4방향 type="NONE").
+// BorderLineType의 Rust default는 Solid이므로 명시적으로 None을 채워야 하며,
+// 음영(shade_ratio) 경로도 같은 이유로 선은 항상 None이다.
+fn hwp3_para_shape_border_fill(
+    hwp3_ps: &crate::parser::hwp3::records::Hwp3ParaShape,
+) -> Option<crate::model::style::BorderFill> {
+    if hwp3_ps.shade_ratio == 0 && !hwp3_ps.has_border() {
+        return None;
+    }
+    let mut bf = crate::model::style::BorderFill::default();
+    for b in bf.borders.iter_mut() {
+        b.line_type = crate::model::style::BorderLineType::None;
+    }
+    if hwp3_ps.shade_ratio > 0 {
+        ...기존 음영 로직 무변경...
+    }
+    Some(bf)
+}
+```
+
+- has_border Solid 합성 블록 삭제. bf 생성 조건(`shade>0 || has_border`)·참조 배선·
+  `border_connection`(attr1 bit28) 배선은 무변경.
+- 함수 위 주석을 #2986 → #3303 근거로 교체.
+
+## 테스트 — `src/parser/hwp3/mod.rs` tests
+
+`test_hwp3_para_shape_border_fill_wires_has_border_flag` 교체:
+
+1. `border=1, shade=0` → `Some(bf)`, **4방향 전부 `line_type == None`**, fill 없음
+   (한컴 SO-SUEOP.hwpx 변환 구조와 동형).
+2. `border=0, shade=20` → `Some(bf)`, 4방향 None, fill Solid(회색) — 음영 경로에서도
+   Solid 선 아티팩트가 없음을 고정.
+3. `border=0, shade=0` → `None` (기존 동작 유지).
+
+## errata — `mydocs/tech/hwp_spec_errata.md` 2건 추가
+
+1. 표 13 offset 181 "문단 테두리 0=없음, 1=있음": "있음"은 테두리 **구조** 존재이지
+   선을 그린다는 뜻이 아님. V3에는 선 종류 필드가 없고, 한컴 2022는 선 없음
+   (NONE/0.1mm/검정)으로 매핑 — Solid 합성 금지. 근거: SO-SUEOP.hwp 원시 바이트 +
+   한컴 UI + 한컴 변환 SO-SUEOP.hwpx XML 3중 실측 (#3303).
+2. 표 13 offset 182 "선 연결 1=테두리 선 연결 안 함": **극성 반대**. 실측(한컴 변환
+   HWPX)은 `border_connection=1 → connect="1"`(연결 ON). rhwp 배선(#2976)은 실측과
+   일치하므로 무변경.
+
+## 검증 절차
+
+1. 단위: 위 테스트 3케이스 + `cargo test --lib parser::hwp3`.
+2. IR: `rhwp dump samples/SO-SUEOP.hwp -p 1005` → border_fill_id=5 유지 확인(구조 보존).
+3. **SVG 백엔드 (정량)**: 수정 전/후 `export-svg`로
+   - SO-SUEOP p41: 지문 테두리 stroke 라인 소멸 (전 4+? → 0)
+   - hwp3-sample4 p3: 음영 rect 2개 유지 + 좌우 세로선 4개 → 0
+4. **4-backend 대조**: svg(3) / canvas2d(studio headless 42쪽 스크린샷 — 상자 소멸) /
+   render-tree JSON(`export-render-tree` 테두리 LineNode 소멸) / skia(`cargo build
+   --release --features native-skia` 후 `export-png` p41 — 우측 세로선 소멸).
+5. 회귀: HWP3 코퍼스에서 이 경로 소비 파일은 SO-SUEOP·sample4 2개뿐(Stage 1 스윕)
+   — 그 외 파일 무영향은 구조적으로 보장. `cargo test --tests --profile release-test`
+   + `fmt --check` (push 전).
+6. **시각 판정 게이트(작업지시자)**: SO-SUEOP 42쪽 + sample4 음영 페이지 after 렌더.
+
+## PR
+
+- 커밋 1개(코드+테스트+errata+working/report 문서), `Closes #3303`, 본문 한국어.
+- PR 생성은 별도 승인 후. 0.8.1 PATCH 대상.
+
+## 후속 제안 (범위 밖, 이슈 등록 후보)
+
+- ir-diff ParaShape 비교에 `border_fill_id` + 참조 BorderFill 4방향 선 종류 요약 추가
+  — 이번 발산(HWPX NONE vs HWP3 Solid)은 현행 ir-diff 사각지대(비교 항목에 없음).

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -412,8 +412,13 @@ pub(crate) fn convert_para_shape(
     ps
 }
 
-// [#2986] HWP3 ParaShape.border(has_border()) 플래그가 shade_ratio 처럼 border_fill_id로
-// 배선되지 않아, 문단 테두리가 켜져 있어도(음영 없이) 항상 소실되던 결함 수정.
+// [#3303] V3 문단 모양(표 13)에는 테두리 선 종류/굵기/색 필드가 없다(offset 181은
+// on/off 뿐). 한컴 2022는 border=1을 "선 없음"으로 매핑한다 — 한컴 자체 변환
+// SO-SUEOP.hwpx에서 paraPr/border → borderFill 4방향 type="NONE" 실측. 따라서
+// BorderFill 구조(참조·연결 속성)는 유지하되 선은 그리지 않는다. BorderLineType의
+// Rust default가 Solid라서 명시적으로 None을 채워야 하며(#2995의 Solid 합성이
+// 42쪽 지문 상자·음영 문단 좌우 세로선 오렌더의 뿌리였다), 음영(shade_ratio)
+// 경로도 같은 이유로 선은 항상 None이다.
 fn hwp3_para_shape_border_fill(
     hwp3_ps: &crate::parser::hwp3::records::Hwp3ParaShape,
 ) -> Option<crate::model::style::BorderFill> {
@@ -421,6 +426,9 @@ fn hwp3_para_shape_border_fill(
         return None;
     }
     let mut bf = crate::model::style::BorderFill::default();
+    for b in bf.borders.iter_mut() {
+        b.line_type = crate::model::style::BorderLineType::None;
+    }
     if hwp3_ps.shade_ratio > 0 {
         let ratio = hwp3_ps.shade_ratio.min(100) as u32;
         let gray = (255 * (100 - ratio) / 100) as u8;
@@ -431,11 +439,6 @@ fn hwp3_para_shape_border_fill(
             pattern_color: 0,
             pattern_type: 0,
         });
-    }
-    if hwp3_ps.has_border() {
-        for b in bf.borders.iter_mut() {
-            b.line_type = crate::model::style::BorderLineType::Solid;
-        }
     }
     Some(bf)
 }
@@ -4161,16 +4164,42 @@ mod tests {
     }
 
     #[test]
-    fn test_hwp3_para_shape_border_fill_wires_has_border_flag() {
-        // [#2986] border=1, shade_ratio=0 인 경우에도 border_fill 이 생성되고
-        // 4방향 테두리선이 Solid 로 설정되어야 한다 (기존에는 None 이 반환되어 소실됨).
+    fn test_hwp3_para_shape_border_fill_maps_border_flag_to_no_lines() {
+        // [#3303] V3 문단 모양에는 선 종류 필드가 없어, 한컴 2022는 border=1 을
+        // "선 없음"으로 매핑한다(한컴 변환 SO-SUEOP.hwpx: borderFill 4방향 NONE).
+        // BorderFill 구조는 생성·참조하되 4방향 선은 None 이어야 한다 —
+        // #2995 의 Solid 합성은 42쪽 지문 상자 오렌더의 원인이었다.
         let mut hwp3_ps = crate::parser::hwp3::records::Hwp3ParaShape::default();
         hwp3_ps.border = 1;
         let bf = hwp3_para_shape_border_fill(&hwp3_ps).expect("border_fill 이 생성되어야 함");
         assert!(bf
             .borders
             .iter()
-            .all(|b| b.line_type == crate::model::style::BorderLineType::Solid));
+            .all(|b| b.line_type == crate::model::style::BorderLineType::None));
+        assert!(bf.fill.solid.is_none());
+    }
+
+    #[test]
+    fn test_hwp3_para_shape_border_fill_shade_has_fill_without_lines() {
+        // [#3303] 음영 경로도 BorderLineType 의 Rust default(Solid) 아티팩트 없이
+        // 배경 채움만 배선돼야 한다 — 종전엔 음영 문단 좌우에 세로선이 오렌더됐다
+        // (hwp3-sample4 실측).
+        let mut hwp3_ps = crate::parser::hwp3::records::Hwp3ParaShape::default();
+        hwp3_ps.shade_ratio = 20;
+        let bf = hwp3_para_shape_border_fill(&hwp3_ps).expect("border_fill 이 생성되어야 함");
+        assert!(bf
+            .borders
+            .iter()
+            .all(|b| b.line_type == crate::model::style::BorderLineType::None));
+        assert_eq!(bf.fill.fill_type, crate::model::style::FillType::Solid);
+        assert!(bf.fill.solid.is_some());
+    }
+
+    #[test]
+    fn test_hwp3_para_shape_border_fill_absent_returns_none() {
+        // border=0, shade_ratio=0 이면 border_fill 을 만들지 않는다 (기존 동작 유지).
+        let hwp3_ps = crate::parser::hwp3::records::Hwp3ParaShape::default();
+        assert!(hwp3_para_shape_border_fill(&hwp3_ps).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## 요약

SO-SUEOP.hwp 42쪽 지문 문단에 그려지던 테두리 상자(v0.8.0 시각 회귀)와 hwp3-sample4 음영 문단 좌우의 검은 세로선을 정정합니다. 두 증상 모두 #2995(bde926e4b)가 HWP3 `border=1`을 4방향 Solid로 합성한 것 + `BorderLineType`의 Rust 기본값이 Solid인 것이 뿌리였습니다.

## 권위 근거 (3중 교차검증)

| 층위 | 실측 |
|---|---|
| 원시 바이트 | 42쪽 지문 셰이프 `border=1, shade_ratio=0, border_connection=1` |
| 스펙 | 표 13(187B)에 테두리 선 종류/굵기/색 필드 부재 — offset 181은 on/off 뿐 |
| 한컴 UI | 문단 모양 대화상자: 종류 "선 없음"·0.1mm·검정, 연결 ON (작업지시자 실측) |
| 한컴 변환 HWPX | `samples/SO-SUEOP.hwpx` `paraPr 38 → border borderFillIDRef=1 connect=1`, `borderFill 1` 4방향 `type=NONE` |
| 코퍼스 | HWP3 271개 전수에서 `border=1`은 SO-SUEOP 유일 — Solid 합성의 양성 증거 전무 |

## 수정

- `hwp3_para_shape_border_fill()`: 4방향 선을 명시적 `BorderLineType::None`으로 배선, Solid 합성 삭제. bf 생성 조건·참조·연결(attr1 bit28) 무변경 — 한컴 변환 HWPX와 동형 구조
- 음영 경로도 같은 수정으로 정정(default Solid 오염)
- 스펙 보완 주석 2건(한글문서파일구조3.0.md 표 13): offset 181 선없음 매핑, offset 182 연결 극성 반대(스펙 문구가 실측과 반대, rhwp 배선은 일치)
- 렌더러 무수정 — `para_border_is_visible`이 None을 걸러줌

## 검증

- 단위 3케이스(border만→None 선 / 음영만→None 선+fill / 없음→None)
- 전체 `cargo test --tests --profile release-test` 323 스위트 ok, 실패 0 + `fmt --check`
- SVG: 42쪽 stroke 6→2(소멸 4 = 지문·222번 좌우 세로선, 잔여 2 = 머리말 구분선·본문 밑줄), sample4 stroke 4→0 + 음영 rect 보존
- render-tree JSON: 테두리 Line 노드 소멸 / skia export-png: 세로 관통 열 0개
- canvas2d(wasm): **작업지시자 시각 판정 통과** (2026-07-26)

영향 파일은 코퍼스 스윕상 2개뿐(SO-SUEOP·sample4) — 그 외 무영향 구조 보장.

## 후속

- ir-diff ParaShape 비교에 border_fill_id/선 종류 추가(이번 발산의 자동 검출 공백) — 별도 이슈 예정

Closes #3303

🤖 Generated with [Claude Code](https://claude.com/claude-code)