### PR TITLE
fix(studio): 외부 연결 그림 dev 전용 fetch를 프로덕션·확장 환경에서 가드 (#3348)

### DIFF
--- a/mydocs/report/task_m100_3348_report.md
+++ b/mydocs/report/task_m100_3348_report.md
@@ -1,0 +1,42 @@
+# Task #3348 — 외부 연결 그림 dev 전용 fetch 가드 (최종 보고서)
+
+- Issue: [#3348](https://github.com/edwardkim/rhwp/issues/3348) (#3313 서브 이슈)
+- Branch: `task/3348-external-image-fetch-guard`
+- 계획서: `mydocs/working/task_m100_3348_stage1.md` / `_stage2.md`
+
+## 배경
+
+v0.8.0 배포 점검(2026-07-26)에서 크롬 확장 Errors 패널에
+`[WasmBridge] 외부 image ...: 00000000.OOO TypeError: Failed to fetch`
+(`populateExternalImagesFromDevServer`)가 기록됨을 작업지시자가 발견했다. GitHub Pages
+배포 사이트에서도 동일 fetch가 404로 실패한다(headless 실측, 콘솔 error 1건).
+
+원인: 외부 연결 그림(HWP3 pic_type=0)의 `/samples/{basename}` fetch는 vite dev 서버
+전용 경로(`server.fs.allow`)인데, 프로덕션 빌드(Pages)·확장(chrome-extension://)에서도
+무조건 시도되어 문서를 열 때마다 실패 요청과 로그가 쌓였다.
+
+## 수정
+
+`rhwp-studio/src/core/wasm-bridge.ts` — `populateExternalImagesFromDevServer()` 진입부에
+`if (!import.meta.env.DEV) return;` 가드 1줄(+근거 주석). dev 서버의 기존 동작
+(#3313 1차 정정의 주입 + 뷰 갱신 배선)은 무변경.
+
+## 검증 결과
+
+| 단계 | 결과 |
+|---|---|
+| `tsc --noEmit` | 통과 |
+| studio 단위 테스트 | 637 pass / 0 fail |
+| dev 보존 (headless, `tmp-3313-sosueop-image.check.mjs`) | 주입 1건 발생·1쪽 이미지 시각 표시 확인. 스크립트의 "유채색 비율" FAIL은 대상 이미지가 흑백(붓글씨)이라 채도 휴리스틱이 0%를 내는 검사 자체의 한계 — 가드 유무 A/B 재실행으로 본 수정과 무관한 사전 존재 현상임을 실증 |
+| 프로덕션 제거 (vite build + preview, headless) | `/samples/` 네트워크 요청 0건·`외부 image` 콘솔 로그 0건·문서 로드 정상. 대조군(가드 없는 현 배포 사이트)은 동일 절차에서 404 error 1건 |
+| 확장 dist 로드 | 작업지시자 수동 게이트 (재빌드 제공) |
+
+## 비범위 (유지)
+
+프로덕션/확장의 사이드카 공급 UX(폴더 열기·다중 파일 드롭 → `inject_external_image`)는
+부모 이슈 #3313 잔여 범위로 남는다. SO-SUEOP.hwp 1쪽 이미지가 배포판에서 보이게 하는
+것은 그 설계 없이는 불가하며 본 가드의 목표가 아니다.
+
+## 릴리즈
+
+0.8.1 PATCH 대상.

--- a/mydocs/working/task_m100_3348_stage1.md
+++ b/mydocs/working/task_m100_3348_stage1.md
@@ -1,0 +1,57 @@
+# Task #3348 Stage 1 — 외부 연결 그림 dev 전용 fetch 가드 (수행계획서)
+
+## 배경
+
+v0.8.0 배포 점검(2026-07-26)에서 크롬 확장 Errors 패널에
+`[WasmBridge] 외부 image ...: 00000000.OOO TypeError: Failed to fetch`가 기록되는 것을
+작업지시자가 발견했다. GitHub Pages 배포 사이트에서도 같은 fetch가 404로 실패한다
+(headless 실측 완료 — 콘솔 error 1건).
+
+`WasmBridge.populateExternalImagesFromDevServer()`는 외부 연결 그림(HWP3 pic_type=0)의
+basename을 `/samples/{name}`에서 fetch해 주입하는 **vite dev 서버 전용 경로**다
+(vite `server.fs.allow`가 samples/ 를 서빙하는 것에 의존). 프로덕션 빌드(Pages)와
+확장(chrome-extension://)에는 이 경로가 없어, 외부 연결 그림이 있는 문서를 열 때마다
+문서당 그림 개수만큼 무의미한 네트워크 요청 + 실패 로그가 쌓인다.
+
+## 방침
+
+**dev 환경이 아니면 fetch를 시도하지 않는다.** 판별은 vite 표준 `import.meta.env.DEV`.
+
+- dev 서버(`vite`/`vite --port 7700`): `DEV=true` → 기존 동작 유지
+  (#3313 1차 정정의 주입 + `onExternalImagesInjected` 뷰 갱신 배선 그대로).
+- 프로덕션 빌드(Pages `vite build`, 확장 `build.mjs`): `DEV=false` → 호출 자체 스킵.
+  외부 연결 그림은 지금과 동일하게 placeholder 표시(회귀 아님 — 현재도 fetch가 전부
+  실패해 placeholder로 귀결되며, 달라지는 것은 소음 제거뿐).
+
+대안으로 "fetch는 시도하되 실패를 조용히 삼키기"를 검토했으나, 프로덕션에서 성공할 수
+없는 요청을 문서마다 반복하는 것 자체가 낭비라 가드 방식을 택한다.
+
+## 수정 범위
+
+- `rhwp-studio/src/core/wasm-bridge.ts` — `populateExternalImagesFromDevServer()` 진입부
+  1곳에 가드 추가 (호출부 유지, 함수 이름의 "DevServer" 의미와 일치).
+
+## 비범위
+
+- 프로덕션/확장의 사이드카 공급 UX(폴더 열기·다중 파일 드롭 → `inject_external_image`)
+  — #3313 잔여 범위로 유지 (이 이슈는 #3313의 서브 이슈).
+- SO-SUEOP.hwp 1쪽 이미지가 배포판에서 보이게 만드는 것 — 위 UX 설계 없이는 불가능,
+  본 가드의 목표가 아니다.
+
+## 검증
+
+1. `tsc` + rhwp-studio 단위 테스트 전체.
+2. dev 서버 headless e2e — SO-SUEOP.hwp 외부 그림 주입이 여전히 동작(유채색 픽셀 비율,
+   기존 tmp-3313 체크 재사용).
+3. 프로덕션 확인 — `vite build` 산출물(preview 서빙)에서 SO-SUEOP.hwp 로드 시
+   `/samples/` fetch 요청·실패 로그 0건.
+4. 확장 재빌드(`rhwp-chrome npm run build`) 후 dist 로드 확인은 작업지시자 수동 게이트.
+
+## PR
+
+- 브랜치 `task/3348-external-image-fetch-guard`, base `devel`, `Closes #3348`.
+- 이 정정은 0.8.1 릴리즈 대상. PR 생성은 별도 승인 후 진행.
+
+## 다음 단계
+
+승인 시 Stage 2(구현계획서 — 가드 코드·검증 커맨드 확정) 후 구현.

--- a/mydocs/working/task_m100_3348_stage2.md
+++ b/mydocs/working/task_m100_3348_stage2.md
@@ -1,0 +1,39 @@
+# Task #3348 Stage 2 — 구현계획서
+
+## 수정 1곳 — `rhwp-studio/src/core/wasm-bridge.ts`
+
+`populateExternalImagesFromDevServer()` 진입부(현재 `if (!this.doc) return;` 직후)에
+가드 1줄 + 근거 주석:
+
+```ts
+private async populateExternalImagesFromDevServer(): Promise<void> {
+  if (!this.doc) return;
+  // [#3348] /samples/ fetch는 vite dev 서버 전용(server.fs.allow). 프로덕션 빌드
+  // (Pages·확장)에는 경로가 없어 실패 로그만 쌓이므로 dev 외에는 시도하지 않는다.
+  // 프로덕션 사이드카 공급 UX는 #3313 잔여 범위.
+  if (!import.meta.env.DEV) return;
+  ...
+```
+
+- 호출부(`loadDocument` 내 `void this.populateExternalImagesFromDevServer();`)는 무변경.
+- `import.meta.env.DEV`는 vite 정적 치환 — 프로덕션 번들에서는 `if (true) return;` 꼴로
+  상수 접힘되어 dead code 제거까지 기대 가능. wasm-bridge.ts 는 이미 vite 전용 모듈
+  경로라 타입(`vite/client`) 문제 없음(주변 코드가 동일 관용구 사용, tsc 로 확정).
+
+## 검증 절차 (순서대로)
+
+1. `cd rhwp-studio && npx tsc --noEmit` — 타입 게이트.
+2. `npm test` — 단위 테스트 전체(변경이 순수 가드라 회귀 없음 확인).
+3. **dev 보존 실측**: dev 서버 기동 후 기존 `tmp-3313-sosueop-image.check.mjs`
+   (headless) — 주입 후 유채색 픽셀 비율이 여전히 상승(≈18%)하는지.
+4. **프로덕션 제거 실측**: `npx vite build` + `npx vite preview` 로 산출물 서빙,
+   headless로 SO-SUEOP.hwp 업로드 → 네트워크에서 `/samples/` 요청 0건·해당 콘솔
+   경고 0건 확인(요청 감시는 puppeteer request 이벤트).
+5. 확장 재빌드(`rhwp-chrome npm run build`) 후 dist 로드 오류 소멸 확인 —
+   작업지시자 수동 게이트.
+
+## 커밋·PR
+
+- 커밋 1개: `fix(studio): 외부 연결 그림 dev 전용 fetch를 프로덕션·확장에서 가드 (#3348)`
+- working 문서(stage1/2) 동일 브랜치 커밋(보고서는 report/ 에 최종 1건).
+- PR: base devel, `Closes #3348`, 본문 한국어 — 생성은 별도 승인 후.

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -298,6 +298,10 @@ export class WasmBridge {
   /** [Task #741 후속] 외부 file path 그림 영역 영역 dev 서버 영역 영역 fetch + inject. */
   private async populateExternalImagesFromDevServer(): Promise<void> {
     if (!this.doc) return;
+    // [#3348] /samples/ fetch는 vite dev 서버 전용(server.fs.allow). 프로덕션 빌드
+    // (Pages·확장)에는 경로가 없어 실패 로그만 쌓이므로 dev 외에는 시도하지 않는다.
+    // 프로덕션 사이드카 공급 UX는 #3313 잔여 범위.
+    if (!import.meta.env.DEV) return;
     try {
       const basenamesJson = this.doc.getExternalImageBasenames();
       const basenames: string[] = JSON.parse(basenamesJson);


### PR DESCRIPTION
## 요약

크롬 확장 Errors 패널에 기록되던 `[WasmBridge] 외부 image ...: 00000000.OOO TypeError: Failed to fetch` 오류와 GitHub Pages 배포 사이트의 동일 404 실패를 제거합니다.

`populateExternalImagesFromDevServer()`의 `/samples/{basename}` fetch는 vite dev 서버 전용 경로(`server.fs.allow`)인데 프로덕션 빌드(Pages)·확장(chrome-extension://)에서도 무조건 시도되어, 문서를 열 때마다 실패 요청과 오류 로그가 쌓였습니다.

## 수정

- 진입부에 `if (!import.meta.env.DEV) return;` 가드 1줄 + 근거 주석. vite 정적 치환으로 프로덕션 번들에서는 dead code 제거
- dev 서버의 기존 동작(#3313 1차 정정의 주입 + 뷰 갱신 배선)은 무변경

## 검증

- `tsc --noEmit` + studio 단위 테스트 **637/637**
- dev 보존: headless e2e에서 주입 1건 발생 + 1쪽 이미지 시각 표시 확인 (가드 유무 A/B 동일 — 검사 스크립트의 유채색 휴리스틱 FAIL은 흑백 이미지에 대한 사전 존재 한계로 실증)
- 프로덕션 제거: `vite build` + `preview` headless에서 `/samples/` 네트워크 요청 **0건**·외부 image 로그 **0건** (대조군인 가드 없는 배포 사이트는 동일 절차에서 404 error 1건)
- 확장 dist 재빌드 후 Errors 패널 오류 소멸 — **작업지시자 확인 완료** (2026-07-26)

## 참고

- 이후 재조사(#3363)에서 SO-SUEOP의 1쪽 이미지는 외부 연결이 아니라 내장 글맵시 OLE로 확정 — 본 가드는 그와 무관하게 유효한 프로덕션 소음 제거이며, 진짜 pic_type=0 문서의 사이드카 공급 UX는 별도 과제로 남습니다.

Closes #3348

🤖 Generated with [Claude Code](https://claude.com/claude-code)