### PR TITLE
fix(vscode): integrate TypeScript 7 and webpack updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,3 +81,12 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    # engines.vscode ^1.82.0 계약은 VS Code API 1.82와 Node 18.15를 기준으로 한다.
+    # 최소 지원 버전을 올리기 전에는 더 최신 API/runtime 타입을 노출하지 않는다.
+    ignore:
+      - dependency-name: "@types/vscode"
+        versions:
+          - ">=1.83.0"
+      - dependency-name: "@types/node"
+        versions:
+          - ">=18.16.0"

--- a/mydocs/pr/archives/pr_3334_report.md
+++ b/mydocs/pr/archives/pr_3334_report.md
@@ -1,17 +1,17 @@
-# PR #3334 umbrella 사전 판단 보고서 — VS Code 의존성 예외 3건
+# PR #3334 umbrella 사전 판단 보고서 — VS Code 의존성 6건
 
-> 이 문서는 PR #3334/#3337/#3344를 보정한 Route B integration candidate의 pre-merge 판단이다.
-> integration PR 생성·CI 성공·merge·원 PR close는 아직 완료되지 않았다.
+> 이 문서는 PR #3334/#3337/#3339/#3341/#3342/#3344를 보정·통합한 Route B candidate의
+> pre-merge 판단이다. Draft #3388은 생성됐지만 확장 head CI 성공·merge·원 PR close는 완료되지 않았다.
 
 ## 판단 요약
 
 | 항목 | 내용 |
 |---|---|
-| 대상 | [#3334](https://github.com/edwardkim/rhwp/pull/3334), [#3337](https://github.com/edwardkim/rhwp/pull/3337), [#3344](https://github.com/edwardkim/rhwp/pull/3344) |
+| 대상 | [#3334](https://github.com/edwardkim/rhwp/pull/3334), [#3337](https://github.com/edwardkim/rhwp/pull/3337), [#3339](https://github.com/edwardkim/rhwp/pull/3339), [#3341](https://github.com/edwardkim/rhwp/pull/3341), [#3342](https://github.com/edwardkim/rhwp/pull/3342), [#3344](https://github.com/edwardkim/rhwp/pull/3344) |
 | 작성자 / base | `dependabot[bot]` / `devel` |
 | route | Route B — source commit cherry-pick + collaborator fix integration PR |
 | 기준선 | `upstream/devel@e7dffced399e45685ae746bd2ea21d37542ea95e` |
-| local candidate | `fdc0af5b5c2d8b266990419fbc87cc0543589717` |
+| local code candidate | `9ef89e64ea5b701407d1b7bebfe67913ceaf10c2` |
 | 권고 | 원 PR 직접 merge는 보류하고 보정 integration candidate를 수용 |
 | 최종 조건 | 최신 integration PR head full CI 성공과 작업지시자 merge 승인 |
 
@@ -33,6 +33,13 @@ TypeScript 7은 기존 programmatic compiler API를 제공하지 않는다. 원 
 VS Code 1.82 Extension Host는 Node 18.15를 기준으로 하는데 Node 26 type으로 compile하면 더 최신 runtime
 API가 노출된다. Node 18.15 type으로 고정하고 같은 범위를 Dependabot 정책에 반영했다.
 
+### #3339/#3341/#3342 webpack build tooling
+
+webpack-cli 7.2.1, webpack 5.109.0, ts-loader 9.6.2를 #3388의 보정 tree 위에 통합했다.
+#3339는 자동 적용됐지만 #3341과 #3342는 같은 `devDependencies`와 lockfile 문맥에서 충돌했다.
+각 원 version bump를 채택하면서 TypeScript 7 CLI/TypeScript 6 compiler API alias, VS Code 1.82 type,
+Node 18.15 type을 유지하고 최종 manifest 기준으로 lockfile을 다시 계산했다.
+
 ## 변경 파일
 
 | 파일 | collaborator 보정 |
@@ -52,9 +59,12 @@ review 문서는 이 source/config 보정과 분리된 docs commit으로 추가�
 |---|---|---|
 | #3334 | `9a77d8362d5bd86701c68a4799d434736742c62e` | `3039b4d8e08d4c2a847a601554cf6d6fe508ba02` |
 | #3337 | `ea5580b77378d685193aed76c880bb5732af2f79` | `beba924eb4f4e8f64fec55e8f1d6927c9b6d8676` |
+| #3339 | `ca9a87e540f159aaa2adcaca9662c935d4b2662e` | `d0ab718ab28b963f318852a043c781e06007550b` |
+| #3341 | `5d94473495e20079e1a90c268d4717b263a94030` | `9b17a601c21d3fc13e43f1b08d253b3b13b335e6` |
+| #3342 | `5e70de300180d0e1c1c7326bb28d172f254c1516` | `9ef89e64ea5b701407d1b7bebfe67913ceaf10c2` |
 | #3344 | `568d7d2932ec98e769175f8bbdf236832b59b7e7` | `22222092feab59ee67fc6784ce0b6ce72f8caf23` |
 
-세 commit은 `git cherry-pick -x`로 적용해 `dependabot[bot]` author, `Signed-off-by`, source SHA를 보존했다.
+여섯 commit은 `git cherry-pick -x`로 적용해 `dependabot[bot]` author, `Signed-off-by`, source SHA를 보존했다.
 collaborator fix `fdc0af5b5c2d8b266990419fbc87cc0543589717`은 별도 commit이다.
 
 ## 로컬 검증
@@ -62,10 +72,11 @@ collaborator fix `fdc0af5b5c2d8b266990419fbc87cc0543589717`은 별도 commit이�
 | 검증 | 결과 |
 |---|---|
 | fresh WASM `wasm-pack build --target web --dev` | 성공 |
-| 보정 lockfile `npm ci` | 성공, audit 취약점 0건 |
+| 확장 lockfile clean `npm ci` | 성공, audit 취약점 0건 |
 | TypeScript compiler 선택 | CLI 7.0.2 / API 6.0.3 |
-| `npm run typecheck` | extension/webview 성공 |
-| `npm run compile` | extension/webview webpack 성공 |
+| build tooling 선택 | webpack-cli 7.2.1 / webpack 5.109.0 / ts-loader 9.6.2 |
+| `npm run typecheck` | TypeScript 7 extension/webview 성공 |
+| `npm run compile` | TypeScript 6 API 기반 extension/webview webpack 성공 |
 | VS Code font/license contract | 3/3 성공 |
 | VSIX package | 성공, 35 files / 17.35 MB |
 | Dependabot YAML parse | 성공 |
@@ -86,6 +97,8 @@ Studio/browser distribution 1건이 prerequisite 실패했다. VS Code 관련 3�
 - #3344 run
   [#30177250840](https://github.com/edwardkim/rhwp/actions/runs/30177250840):
   `Frontend package gates`, `Build & Test`, CodeQL 성공.
+- #3339, #3341, #3342 최신 source head:
+  `Frontend package gates`, `Build & Test`, CodeQL 성공.
 
 이 값은 2026-07-26 원 PR head 기준 참고값이다. Route B의 authoritative CI는 향후 integration PR의
 최신 head 결과다.
@@ -99,11 +112,12 @@ Studio/browser distribution 1건이 prerequisite 실패했다. VS Code 관련 3�
 ## 문서와 remote 반영 계획
 
 - 원 PR별 review:
-  [#3334](pr_3334_review.md), [#3337](pr_3337_review.md), [#3344](pr_3344_review.md)
+  [#3334](pr_3334_review.md), [#3337](pr_3337_review.md), [#3339](pr_3339_review.md),
+  [#3341](pr_3341_review.md), [#3342](pr_3342_review.md), [#3344](pr_3344_review.md)
 - 실행 순서와 승인 gate: [umbrella implementation 계획](pr_3334_review_impl.md)
 - 원 PR은 `maintainerCanModify=false`이므로 review/code/docs를 source head에 push하지 않는다.
-- 사용자 승인 뒤 현재 integration branch를 `origin`에 push하고 `devel` 대상 PR을 생성한다.
-- PR body는 세 원 PR을 `Supersedes`로 표시하고 source/integration mapping과 contributor credit을 기록한다.
+- 작업지시자 승인에 따라 확장 branch를 `origin`에 push하고 기존 Draft #3388 metadata를 갱신한다.
+- PR body는 여섯 원 PR을 `Supersedes`로 표시하고 source/integration mapping과 contributor credit을 기록한다.
 
 ## Merge 전 조건
 
@@ -120,16 +134,18 @@ code/config 보정이 포함되므로 review-only fast-pass를 적용하지 않�
 - integration PR의 merge commit과 merge 시각을 GitHub에서 다시 읽는다.
 - 별도 승인 뒤 각 원 PR에 integration PR 번호, merge commit, source/integration mapping,
   CI 요약, Dependabot credit 보존을 설명하고 superseded 상태로 close한다.
-- 세 원 PR에는 linked issue가 없다. merge 뒤에도 상태를 재확인하되 수동 close할 issue는 현재 없다.
+- 여섯 원 PR에는 linked issue가 없다. merge 뒤에도 상태를 재확인하되 수동 close할 issue는 현재 없다.
 - `upstream/devel` 반영을 확인한 뒤 local branch, fetch branch, 생성물 정리는 별도 종료 gate에서 수행한다.
 
 ## 잔여 리스크와 결론
 
 - 로컬 검증은 Node 24에서 수행했으므로 저장소 CI Node 22 결과가 필요하다.
+- webpack-cli 7.2.1의 build-time Node 하한은 20.9.0이다. 저장소 CI Node 22는 충족하지만 Node 18
+  개발 환경에서 package/compile 명령을 실행할 수 없다.
 - 실제 VS Code 1.82 Extension Host 설치 smoke는 수행하지 않았다. minimum API/runtime type compile과
   VSIX package를 이번 local 근거로 사용한다.
 - 전체 frontend aggregate는 integration PR에서 아직 실행되지 않았다.
 
-**사전 권고**: 보정된 Route B integration candidate는 PR 생성 후보로 수용한다. 원 PR 세 건은 직접
-merge하지 않는다. remote push와 integration PR 생성, CI 후 review, merge, 원 PR close는 각 승인
-게이트를 통과한 뒤 수행한다.
+**사전 권고**: 보정·확장된 Route B integration candidate를 Draft #3388의 최신 후보로 수용한다.
+원 PR 여섯 건은 직접 merge하지 않는다. 확장 head CI 후 review, merge, 원 PR close는 각 승인 게이트를
+통과한 뒤 수행한다.

--- a/mydocs/pr/archives/pr_3334_report.md
+++ b/mydocs/pr/archives/pr_3334_report.md
@@ -1,0 +1,135 @@
+# PR #3334 umbrella 사전 판단 보고서 — VS Code 의존성 예외 3건
+
+> 이 문서는 PR #3334/#3337/#3344를 보정한 Route B integration candidate의 pre-merge 판단이다.
+> integration PR 생성·CI 성공·merge·원 PR close는 아직 완료되지 않았다.
+
+## 판단 요약
+
+| 항목 | 내용 |
+|---|---|
+| 대상 | [#3334](https://github.com/edwardkim/rhwp/pull/3334), [#3337](https://github.com/edwardkim/rhwp/pull/3337), [#3344](https://github.com/edwardkim/rhwp/pull/3344) |
+| 작성자 / base | `dependabot[bot]` / `devel` |
+| route | Route B — source commit cherry-pick + collaborator fix integration PR |
+| 기준선 | `upstream/devel@e7dffced399e45685ae746bd2ea21d37542ea95e` |
+| local candidate | `fdc0af5b5c2d8b266990419fbc87cc0543589717` |
+| 권고 | 원 PR 직접 merge는 보류하고 보정 integration candidate를 수용 |
+| 최종 조건 | 최신 integration PR head full CI 성공과 작업지시자 merge 승인 |
+
+## 원인과 사전 판단
+
+### #3334 TypeScript 7
+
+TypeScript 7은 기존 programmatic compiler API를 제공하지 않는다. 원 PR은 `ts-loader`가 import하는
+`typescript`를 곧바로 7.0.2로 바꿔 `fileExists` 접근에서 CI가 실패했다. TypeScript 7 CLI와
+`@typescript/typescript6` API alias를 병행하는 공식 migration 형태로 보정했다.
+
+### #3337 VS Code API type
+
+`engines.vscode ^1.82.0`을 유지하면서 `@types/vscode ^1.125.0`으로 compile하면 최소 지원 버전에 없는 API
+사용을 build가 허용할 수 있다. 원 PR CI는 성공했지만 지원 계약을 보증하지 않으므로 1.82 type으로 고정했다.
+
+### #3344 Node type
+
+VS Code 1.82 Extension Host는 Node 18.15를 기준으로 하는데 Node 26 type으로 compile하면 더 최신 runtime
+API가 노출된다. Node 18.15 type으로 고정하고 같은 범위를 Dependabot 정책에 반영했다.
+
+## 변경 파일
+
+| 파일 | collaborator 보정 |
+|---|---|
+| `.github/dependabot.yml` | VS Code 1.82/Node 18.15보다 새로운 type update 제한 |
+| `rhwp-vscode/package.json` | TypeScript 7 CLI + TypeScript 6 API alias, typecheck gate, runtime type 고정 |
+| `rhwp-vscode/package-lock.json` | alias/type 해소 및 `fast-uri` 3.1.4 보안 patch |
+| `rhwp-vscode/tsconfig.json` | Node type 명시 |
+| `rhwp-vscode/tsconfig.webview.json` | TypeScript 7 config 호환과 공유 source root 명시 |
+| `rhwp-vscode/src/webview/viewer.ts` | 최신 DOM `hidden` type의 boolean 정규화 |
+
+review 문서는 이 source/config 보정과 분리된 docs commit으로 추가한다.
+
+## source provenance와 credit
+
+| 원 PR | source commit | integration commit |
+|---|---|---|
+| #3334 | `9a77d8362d5bd86701c68a4799d434736742c62e` | `3039b4d8e08d4c2a847a601554cf6d6fe508ba02` |
+| #3337 | `ea5580b77378d685193aed76c880bb5732af2f79` | `beba924eb4f4e8f64fec55e8f1d6927c9b6d8676` |
+| #3344 | `568d7d2932ec98e769175f8bbdf236832b59b7e7` | `22222092feab59ee67fc6784ce0b6ce72f8caf23` |
+
+세 commit은 `git cherry-pick -x`로 적용해 `dependabot[bot]` author, `Signed-off-by`, source SHA를 보존했다.
+collaborator fix `fdc0af5b5c2d8b266990419fbc87cc0543589717`은 별도 commit이다.
+
+## 로컬 검증
+
+| 검증 | 결과 |
+|---|---|
+| fresh WASM `wasm-pack build --target web --dev` | 성공 |
+| 보정 lockfile `npm ci` | 성공, audit 취약점 0건 |
+| TypeScript compiler 선택 | CLI 7.0.2 / API 6.0.3 |
+| `npm run typecheck` | extension/webview 성공 |
+| `npm run compile` | extension/webview webpack 성공 |
+| VS Code font/license contract | 3/3 성공 |
+| VSIX package | 성공, 35 files / 17.35 MB |
+| Dependabot YAML parse | 성공 |
+| `git diff --check` | 성공 |
+
+전체 font contract 실행에서는 이번 검토가 생성하지 않은 `rhwp-studio/dist/fonts`가 없어
+Studio/browser distribution 1건이 prerequisite 실패했다. VS Code 관련 3건은 같은 실행 산출물에서 모두
+성공했다. full frontend aggregate는 integration PR CI에서 다시 확인해야 한다.
+
+## 원 PR CI 스냅샷
+
+- #3334 run
+  [#30177235189](https://github.com/edwardkim/rhwp/actions/runs/30177235189):
+  `Frontend package gates`, `Build & Test` 실패.
+- #3337 run
+  [#30177238171](https://github.com/edwardkim/rhwp/actions/runs/30177238171):
+  `Frontend package gates`, `Build & Test`, CodeQL 성공.
+- #3344 run
+  [#30177250840](https://github.com/edwardkim/rhwp/actions/runs/30177250840):
+  `Frontend package gates`, `Build & Test`, CodeQL 성공.
+
+이 값은 2026-07-26 원 PR head 기준 참고값이다. Route B의 authoritative CI는 향후 integration PR의
+최신 head 결과다.
+
+## 렌더·시각 검증
+
+- renderer/layout/paint/WASM API/fixture/font asset 변경이 없다.
+- webview source 1줄은 메뉴 open 상태를 boolean으로 정규화하며 페이지 조판·렌더 출력과 무관하다.
+- visual sweep과 기준 asset은 필요하지 않다고 판정했다.
+
+## 문서와 remote 반영 계획
+
+- 원 PR별 review:
+  [#3334](pr_3334_review.md), [#3337](pr_3337_review.md), [#3344](pr_3344_review.md)
+- 실행 순서와 승인 gate: [umbrella implementation 계획](pr_3334_review_impl.md)
+- 원 PR은 `maintainerCanModify=false`이므로 review/code/docs를 source head에 push하지 않는다.
+- 사용자 승인 뒤 현재 integration branch를 `origin`에 push하고 `devel` 대상 PR을 생성한다.
+- PR body는 세 원 PR을 `Supersedes`로 표시하고 source/integration mapping과 contributor credit을 기록한다.
+
+## Merge 전 조건
+
+1. docs commit까지 포함한 integration PR 최신 head SHA를 확인한다.
+2. `Frontend package gates`, `Build & Test`, CodeQL 등 관련 최신 full CI가 성공해야 한다.
+3. review 문서가 integration PR diff에 포함되어야 한다.
+4. integration PR이 mergeable 상태여야 한다.
+5. 작업지시자가 GitHub review/merge를 별도로 승인해야 한다.
+
+code/config 보정이 포함되므로 review-only fast-pass를 적용하지 않는다.
+
+## Merge 뒤 확인 계획
+
+- integration PR의 merge commit과 merge 시각을 GitHub에서 다시 읽는다.
+- 별도 승인 뒤 각 원 PR에 integration PR 번호, merge commit, source/integration mapping,
+  CI 요약, Dependabot credit 보존을 설명하고 superseded 상태로 close한다.
+- 세 원 PR에는 linked issue가 없다. merge 뒤에도 상태를 재확인하되 수동 close할 issue는 현재 없다.
+- `upstream/devel` 반영을 확인한 뒤 local branch, fetch branch, 생성물 정리는 별도 종료 gate에서 수행한다.
+
+## 잔여 리스크와 결론
+
+- 로컬 검증은 Node 24에서 수행했으므로 저장소 CI Node 22 결과가 필요하다.
+- 실제 VS Code 1.82 Extension Host 설치 smoke는 수행하지 않았다. minimum API/runtime type compile과
+  VSIX package를 이번 local 근거로 사용한다.
+- 전체 frontend aggregate는 integration PR에서 아직 실행되지 않았다.
+
+**사전 권고**: 보정된 Route B integration candidate는 PR 생성 후보로 수용한다. 원 PR 세 건은 직접
+merge하지 않는다. remote push와 integration PR 생성, CI 후 review, merge, 원 PR close는 각 승인
+게이트를 통과한 뒤 수행한다.

--- a/mydocs/pr/archives/pr_3334_review.md
+++ b/mydocs/pr/archives/pr_3334_review.md
@@ -1,0 +1,102 @@
+# PR #3334 검토 기록 — rhwp-vscode TypeScript 7 전환
+
+## 라우팅
+
+```text
+base route: collaborator 매개 외부 PR (Route B: 통합 PR)
+modifiers: 접수·리뷰 기록, 로컬 검증, 다수 PR·update branch, 재작업·예외(Dependabot)
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+  collaborator_external_pr.md, intake_and_review.md, local_validation.md,
+  multi_pr_update_branch.md, rework_and_exceptions.md
+current head: 9a77d8362d5bd86701c68a4799d434736742c62e
+```
+
+## PR metadata
+
+| 항목 | 내용 |
+|---|---|
+| 원 PR | [#3334](https://github.com/edwardkim/rhwp/pull/3334) |
+| 작성자 / base | `dependabot[bot]` / `devel` |
+| 검토자 | `@postmelee` (local fetch 전 review request) |
+| labels / milestone | `dependencies`, `javascript` / 없음 |
+| assignee | 없음 — GitHub이 Dependabot bot을 assignable actor로 허용하지 않음 |
+| 규모 | 2026-07-26 조회: +373/-12, 2 files, 1 commit |
+| head | `9a77d8362d5bd86701c68a4799d434736742c62e` |
+| 상태 스냅샷 | `MERGEABLE`, `BEHIND`, draft 아님, review decision 없음 |
+| 권한 / 관련 issue | `maintainerCanModify=false` / 자동 close 대상 issue 없음 |
+| 판단 | 원 PR 직접 merge 보류, 보정된 Route B 통합에 수용 |
+
+metadata와 CI는 문서 작성 시점 참고값이다. 최종 판단 전 최신 integration PR head에서 다시 확인한다.
+
+## 변경 범위
+
+- `rhwp-vscode/package.json`의 `typescript`를 5.9.3에서 7.0.2로 올린다.
+- `rhwp-vscode/package-lock.json`에 TypeScript 7 네이티브 배포물과 플랫폼별 optional package를 반영한다.
+- 원 PR에는 source, test, runtime asset 변경이 없다.
+
+## 발견한 차단 문제
+
+원 PR의 CI run
+[#30177235189](https://github.com/edwardkim/rhwp/actions/runs/30177235189)에서
+`Frontend package gates`가 실패했다. `npm --prefix rhwp-vscode run compile` 중 `ts-loader`가
+TypeScript compiler API의 `fileExists`를 읽으려다 다음 오류를 냈다.
+
+```text
+TypeError: Cannot read properties of undefined (reading 'fileExists')
+```
+
+[TypeScript 7 공식 발표](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/)에 따르면
+7.0은 programmatic API를 제공하지 않으며, API가 필요한 도구는
+`@typescript/typescript6` compatibility package를 npm alias로 함께 사용해야 한다. 따라서
+`ts-loader`가 `typescript` 7.0.2를 직접 import하는 원 PR 상태는 source 수정 없이 해소되지 않는다.
+
+## Route B 통합과 collaborator 보정
+
+| 구분 | SHA | 내용 |
+|---|---|---|
+| 원 commit | `9a77d8362` | Dependabot TypeScript 7.0.2 bump |
+| 통합 commit | `3039b4d8e` | `-x` cherry-pick, 원 저자와 `Signed-off-by` 보존 |
+| 보정 commit | `fdc0af5b5` | TypeScript 7 CLI와 TypeScript 6 API 병행, 설정·검증 gate 보완 |
+
+보정 결과는 다음과 같다.
+
+- `@typescript/native: npm:typescript@^7.0.2`로 TypeScript 7 CLI를 유지한다.
+- `typescript: npm:@typescript/typescript6@^6.0.2`로 `ts-loader`가 사용할 compiler API를 제공한다.
+- `typecheck` script에서 TypeScript 7 CLI로 extension/webview 두 config를 검사한 뒤 webpack을 실행한다.
+- TypeScript 7 설정 계약에 맞게 Node type을 명시하고 webview의 제거된 `baseUrl` 의존을 없앤다.
+- 최신 DOM type에서 `HTMLElement.hidden`이 `"until-found"`를 포함할 수 있으므로 메뉴 토글 입력을
+  명시적 boolean으로 정규화한다.
+
+여러 PR의 실행 순서와 전체 보정은 [통합 implementation 계획](pr_3334_review_impl.md), 사전 수용 판단은
+[통합 사전 보고서](pr_3334_report.md)에 기록한다.
+
+## 렌더 영향 판정
+
+- renderer, layout, paint, WASM API, fixture, font asset은 변경하지 않는다.
+- `viewer.ts` 변경은 메뉴 open/close 입력의 타입 정규화이며 기존 boolean 값에서 동작이 같다.
+- 페이지 수·배치·SVG/PDF 산출 주장이 없으므로 visual sweep 대상이 아니다.
+
+## 검증
+
+보정된 통합 branch `codex/review-dependabot-vscode-20260726`에서 다음을 확인했다.
+
+- `CARGO_INCREMENTAL=0 wasm-pack build --target web --dev`: 성공.
+- `npm ci`: 성공, 최종 audit 취약점 0건.
+- TypeScript 선택 확인: `tsc` 7.0.2, `require("typescript")` compiler API 6.0.3.
+- `npm run typecheck`: extension/webview config 모두 성공.
+- `npm run compile`: extension/webview webpack bundle 모두 성공.
+- `node --test --test-name-pattern='VS Code' scripts/frontend-font-assets.test.mjs`: 3/3 성공.
+- `npx --yes @vscode/vsce package`: 35 files, 17.35 MB VSIX 생성 성공.
+- `.github/dependabot.yml` YAML parse와 `git diff --check`: 성공.
+
+전체 font contract 스크립트도 실행했으나 이번 범위에서 생성하지 않은 `rhwp-studio/dist/fonts`가 없어
+Studio/browser distribution 1건이 prerequisite 실패했다. 같은 스크립트의 VS Code 3건은 모두 성공했으며,
+통합 PR의 full CI에서는 Studio build를 포함한 전체 `Frontend package gates`가 성공해야 한다.
+
+## 리스크와 권고
+
+- 원 PR head의 `Build & Test`는 실패 상태이므로 직접 merge할 수 없다.
+- 로컬 검증은 Node 24에서 수행했다. 저장소 CI의 Node 22 결과가 authoritative gate다.
+- **권고**: 원 PR은 merge하지 않고, 보정 commit을 포함한 Route B integration PR의 최신 head CI가
+  성공하고 작업지시자가 승인한 뒤 통합한다. 통합 PR merge 뒤 별도 승인으로 원 PR에 supersede 설명을
+  남기고 close한다.

--- a/mydocs/pr/archives/pr_3334_review.md
+++ b/mydocs/pr/archives/pr_3334_review.md
@@ -78,7 +78,7 @@ TypeError: Cannot read properties of undefined (reading 'fileExists')
 
 ## 검증
 
-보정된 통합 branch `codex/review-dependabot-vscode-20260726`에서 다음을 확인했다.
+보정된 통합 branch `review/dependabot-vscode-20260726`에서 다음을 확인했다.
 
 - `CARGO_INCREMENTAL=0 wasm-pack build --target web --dev`: 성공.
 - `npm ci`: 성공, 최종 audit 취약점 0건.

--- a/mydocs/pr/archives/pr_3334_review_impl.md
+++ b/mydocs/pr/archives/pr_3334_review_impl.md
@@ -15,7 +15,7 @@
 ```text
 base route: collaborator 매개 외부 PR (Route B: 통합 PR)
 modifiers: 접수·리뷰 기록, 로컬 검증, 다수 PR·update branch, 재작업·예외(Dependabot)
-integration branch: codex/review-dependabot-vscode-20260726
+integration branch: review/dependabot-vscode-20260726
 base: upstream/devel@e7dffced399e45685ae746bd2ea21d37542ea95e
 verified local code head: fdc0af5b5c2d8b266990419fbc87cc0543589717
 ```

--- a/mydocs/pr/archives/pr_3334_review_impl.md
+++ b/mydocs/pr/archives/pr_3334_review_impl.md
@@ -1,13 +1,17 @@
-# PR #3334 umbrella implementation 계획 — VS Code 의존성 예외 3건
+# PR #3334 umbrella implementation 계획 — VS Code 의존성 6건
 
 ## 목적과 상태
 
 - 대상: Dependabot PR [#3334](https://github.com/edwardkim/rhwp/pull/3334),
   [#3337](https://github.com/edwardkim/rhwp/pull/3337),
+  [#3339](https://github.com/edwardkim/rhwp/pull/3339),
+  [#3341](https://github.com/edwardkim/rhwp/pull/3341),
+  [#3342](https://github.com/edwardkim/rhwp/pull/3342),
   [#3344](https://github.com/edwardkim/rhwp/pull/3344)
-- 역할: 세 원 PR을 직접 merge하지 않고 최신 `upstream/devel` 기반 Route B integration PR로 대체한다.
-- 현재 상태: source cherry-pick, collaborator 보정, local verification 완료. review 문서 작성 단계.
-- 이 문서는 integration PR merge 전 실행 계획이다. push, PR 생성, CI 성공, merge, 원 PR close를
+- 역할: 여섯 원 PR을 직접 merge하지 않고 최신 `upstream/devel` 기반 Route B integration PR로 대체한다.
+- 현재 상태: Draft [#3388](https://github.com/edwardkim/rhwp/pull/3388)에 source cherry-pick,
+  collaborator 보정, 확장 local verification을 완료하고 review 문서를 갱신하는 단계다.
+- 이 문서는 integration PR merge 전 실행 계획이다. 확장 head push, 최신 CI 성공, merge, 원 PR close를
   완료 사실로 기록하지 않는다.
 
 ## 라우팅과 기준선
@@ -17,10 +21,10 @@ base route: collaborator 매개 외부 PR (Route B: 통합 PR)
 modifiers: 접수·리뷰 기록, 로컬 검증, 다수 PR·update branch, 재작업·예외(Dependabot)
 integration branch: review/dependabot-vscode-20260726
 base: upstream/devel@e7dffced399e45685ae746bd2ea21d37542ea95e
-verified local code head: fdc0af5b5c2d8b266990419fbc87cc0543589717
+verified local code head: 9ef89e64ea5b701407d1b7bebfe67913ceaf10c2
 ```
 
-세 원 PR은 모두 `maintainerCanModify=false`이므로 contributor/Dependabot head에는 commit을 push하지 않는다.
+여섯 원 PR은 모두 `maintainerCanModify=false`이므로 contributor/Dependabot head에는 commit을 push하지 않는다.
 원 PR별 reviewer는 local fetch 전에 `@postmelee`로 지정했다. labels는 기존
 `dependencies`, `javascript`를 유지하고 milestone은 만들지 않았다. Dependabot bot은 assignable actor가
 아니어서 assignee는 비워 두었다.
@@ -33,6 +37,9 @@ verified local code head: fdc0af5b5c2d8b266990419fbc87cc0543589717
 | 2 | #3337 | `ea5580b77378d685193aed76c880bb5732af2f79` | `beba924eb4f4e8f64fec55e8f1d6927c9b6d8676` | 1.125 type은 제거하고 VS Code 1.82 type으로 계약 고정 |
 | 3 | #3344 | `568d7d2932ec98e769175f8bbdf236832b59b7e7` | `22222092feab59ee67fc6784ce0b6ce72f8caf23` | Node 26 type은 제거하고 Node 18.15 type으로 계약 고정 |
 | 4 | collaborator fix | 해당 없음 | `fdc0af5b5c2d8b266990419fbc87cc0543589717` | build bridge, TS config, type policy, lockfile 보안 patch |
+| 5 | #3339 | `ca9a87e540f159aaa2adcaca9662c935d4b2662e` | `d0ab718ab28b963f318852a043c781e06007550b` | webpack-cli 7.2.1, 자동 적용 |
+| 6 | #3341 | `5d94473495e20079e1a90c268d4717b263a94030` | `9b17a601c21d3fc13e43f1b08d253b3b13b335e6` | webpack 5.109.0, TypeScript/webpack-cli 조합 충돌 해소 |
+| 7 | #3342 | `5e70de300180d0e1c1c7326bb28d172f254c1516` | `9ef89e64ea5b701407d1b7bebfe67913ceaf10c2` | ts-loader 9.6.2, TypeScript API alias/lockfile 충돌 해소 |
 
 모든 source commit은 `git cherry-pick -x`로 적용했다. author는 `dependabot[bot]`으로 유지되고
 `Signed-off-by`와 source SHA provenance가 commit message에 보존된다. collaborator fix는 별도 commit이다.
@@ -46,6 +53,11 @@ verified local code head: fdc0af5b5c2d8b266990419fbc87cc0543589717
   `@types/node`/`@types/vscode` root dependency 문맥에 content conflict가 발생했다.
 - conflict 해소 commit에는 두 원 bump를 모두 유지했다. 지원 계약 변경은 이후 collaborator fix로
   분리해 원 commit의 의미와 보정 책임을 섞지 않았다.
+- #3339는 기존 #3388 tree에 자동 적용됐다.
+- #3341은 `typescript`, `webpack`, `webpack-cli`가 인접한 manifest/lockfile 문맥에서 충돌했다.
+  webpack 5.109.0을 채택하고 TypeScript 6 API alias와 webpack-cli 7.2.1을 유지했다.
+- #3342는 `ts-loader`, `typescript`와 전이 lockfile 문맥에서 충돌했다. ts-loader 9.6.2를 채택하고
+  TypeScript 7 CLI/TypeScript 6 API 분리를 보존한 뒤 npm으로 lockfile을 다시 계산했다.
 
 ### Collaborator fix
 
@@ -71,26 +83,26 @@ verified local code head: fdc0af5b5c2d8b266990419fbc87cc0543589717
 
 | 단계 | 상태 | 작업 |
 |---|---|---|
-| 0. metadata 정렬 | 완료 | 세 원 PR reviewer 지정, labels/milestone 확인, assignee 제한 기록 |
+| 0. metadata 정렬 | 완료 | 여섯 원 PR reviewer 지정, labels/milestone 확인, assignee 제한 기록 |
 | 1. Route B branch | 완료 | 최신 `upstream/devel`에서 visibility/integration branch 생성 |
-| 2. source 통합 | 완료 | 세 source commit을 `-x` cherry-pick하고 #3344 conflict 해소 |
+| 2. source 통합 | 완료 | 여섯 source commit을 `-x` cherry-pick하고 #3344/#3341/#3342 conflict 해소 |
 | 3. collaborator 보정 | 완료 | build bridge, type/runtime 계약, Dependabot 정책을 별도 commit |
-| 4. local verification | 완료 | fresh WASM, clean npm install, typecheck, webpack, contract, VSIX, audit |
-| 5. review 문서 | 현재 단계 | 원 PR별 review와 umbrella report를 별도 docs commit으로 작성 |
-| 6. remote integration PR | 승인 대기 | origin push와 `devel` 대상 integration PR 생성 |
+| 4. local verification | 완료 | clean npm install, typecheck, webpack 5.109, contract, VSIX, audit |
+| 5. review 문서 | 현재 단계 | 원 PR별 review와 umbrella report를 별도 docs commit으로 갱신 |
+| 6. remote integration PR | 승인됨·미반영 | 확장 head를 origin에 push하고 Draft #3388 metadata 갱신 |
 | 7. authoritative CI/review | 미실행 | 최신 integration head의 full CI 확인 후 GitHub review 판단 |
 | 8. merge/후속 | 별도 승인 필요 | integration PR merge, 원 PR 설명 comment/close, issue 상태 확인 |
 
 ## 검증 순서와 결과
 
-1. `CARGO_INCREMENTAL=0 wasm-pack build --target web --dev`: 성공.
-2. 보정 lockfile `npm ci`: 성공, 159 package audit 취약점 0건.
+1. 선행 #3388 검증의 `CARGO_INCREMENTAL=0 wasm-pack build --target web --dev`: 성공.
+2. 확장 lockfile clean `npm ci`: 성공, `npm audit` 취약점 0건.
 3. compiler selection: TypeScript 7 CLI 7.0.2, `typescript` compiler API 6.0.3.
-4. `npm run typecheck`: extension/webview 모두 성공.
-5. `npm run compile`: 두 webpack config 모두 성공.
-6. VS Code font/license contract: 3/3 성공.
-7. VSIX package: 35 files, 17.35 MB, 성공.
-8. Dependabot YAML parse와 `git diff --check`: 성공.
+4. dependency selection: webpack-cli 7.2.1, webpack 5.109.0, ts-loader 9.6.2.
+5. `npm run typecheck`: extension/webview 모두 성공.
+6. `npm run compile`: 두 webpack config 모두 성공.
+7. VS Code font/license contract: 3/3 성공.
+8. VSIX package: 35 files, 17.35 MB, 성공.
 
 전체 font contract의 Studio/browser distribution 1건은 `rhwp-studio/dist/fonts` prerequisite가 없어
 실패했다. integration PR CI는 Studio build를 선행하므로 latest full `Frontend package gates` 성공을
@@ -98,13 +110,14 @@ verified local code head: fdc0af5b5c2d8b266990419fbc87cc0543589717
 
 ## Remote PR 계획
 
-사용자 승인 뒤에만 현재 branch를 `origin`에 push하고 `devel` 대상 integration PR을 만든다.
+작업지시자는 기존 Draft #3388 확장과 remote push를 승인했다. docs commit 뒤 현재 branch를 `origin`에
+push하고 #3388의 title/body를 여섯 원 PR 범위로 갱신한다.
 PR body에는 다음을 포함한다.
 
-- `Supersedes #3334`, `Supersedes #3337`, `Supersedes #3344`
+- `Supersedes #3334`, `#3337`, `#3339`, `#3341`, `#3342`, `#3344`
 - source PR/commit과 integration commit mapping
 - Dependabot author 및 `Signed-off-by` 보존
-- TypeScript 7/6 bridge와 VS Code 1.82/Node 18.15 지원 계약
+- TypeScript 7/6 bridge, VS Code 1.82/Node 18.15 지원 계약, webpack build tooling 조합
 - local verification과 원 PR CI 스냅샷
 - integration PR이 merge된 뒤 원 PR을 close한다는 명시
 
@@ -113,7 +126,7 @@ review-only fast-pass를 적용하지 않는다.
 
 ## 승인·rollback 경계
 
-- docs commit 뒤 사용자 검토와 remote push/PR 생성 승인을 다시 받는다.
+- #3388 확장 push와 metadata 갱신은 이번 작업지시로 승인됐다.
 - integration PR CI가 실패하면 원 source commit을 rewrite하지 않고 collaborator fix를 별도 commit으로
   보완한다.
 - merge, 원 PR comment/close, issue close는 각각 해당 단계의 명시 승인을 받는다.

--- a/mydocs/pr/archives/pr_3334_review_impl.md
+++ b/mydocs/pr/archives/pr_3334_review_impl.md
@@ -1,0 +1,120 @@
+# PR #3334 umbrella implementation 계획 — VS Code 의존성 예외 3건
+
+## 목적과 상태
+
+- 대상: Dependabot PR [#3334](https://github.com/edwardkim/rhwp/pull/3334),
+  [#3337](https://github.com/edwardkim/rhwp/pull/3337),
+  [#3344](https://github.com/edwardkim/rhwp/pull/3344)
+- 역할: 세 원 PR을 직접 merge하지 않고 최신 `upstream/devel` 기반 Route B integration PR로 대체한다.
+- 현재 상태: source cherry-pick, collaborator 보정, local verification 완료. review 문서 작성 단계.
+- 이 문서는 integration PR merge 전 실행 계획이다. push, PR 생성, CI 성공, merge, 원 PR close를
+  완료 사실로 기록하지 않는다.
+
+## 라우팅과 기준선
+
+```text
+base route: collaborator 매개 외부 PR (Route B: 통합 PR)
+modifiers: 접수·리뷰 기록, 로컬 검증, 다수 PR·update branch, 재작업·예외(Dependabot)
+integration branch: codex/review-dependabot-vscode-20260726
+base: upstream/devel@e7dffced399e45685ae746bd2ea21d37542ea95e
+verified local code head: fdc0af5b5c2d8b266990419fbc87cc0543589717
+```
+
+세 원 PR은 모두 `maintainerCanModify=false`이므로 contributor/Dependabot head에는 commit을 push하지 않는다.
+원 PR별 reviewer는 local fetch 전에 `@postmelee`로 지정했다. labels는 기존
+`dependencies`, `javascript`를 유지하고 milestone은 만들지 않았다. Dependabot bot은 assignable actor가
+아니어서 assignee는 비워 두었다.
+
+## source와 integration commit
+
+| 순서 | 원 PR | source commit | integration commit | 최종 처리 |
+|---|---|---|---|---|
+| 1 | #3334 | `9a77d8362d5bd86701c68a4799d434736742c62e` | `3039b4d8e08d4c2a847a601554cf6d6fe508ba02` | TypeScript 7 CLI 유지, compiler API는 TypeScript 6 alias로 보정 |
+| 2 | #3337 | `ea5580b77378d685193aed76c880bb5732af2f79` | `beba924eb4f4e8f64fec55e8f1d6927c9b6d8676` | 1.125 type은 제거하고 VS Code 1.82 type으로 계약 고정 |
+| 3 | #3344 | `568d7d2932ec98e769175f8bbdf236832b59b7e7` | `22222092feab59ee67fc6784ce0b6ce72f8caf23` | Node 26 type은 제거하고 Node 18.15 type으로 계약 고정 |
+| 4 | collaborator fix | 해당 없음 | `fdc0af5b5c2d8b266990419fbc87cc0543589717` | build bridge, TS config, type policy, lockfile 보안 patch |
+
+모든 source commit은 `git cherry-pick -x`로 적용했다. author는 `dependabot[bot]`으로 유지되고
+`Signed-off-by`와 source SHA provenance가 commit message에 보존된다. collaborator fix는 별도 commit이다.
+
+## 충돌과 보정 범위
+
+### Cherry-pick 충돌
+
+- #3334와 #3337은 순서대로 자동 적용됐다.
+- #3344는 세 PR이 같은 manifest/lockfile 기준선에서 갈라져
+  `@types/node`/`@types/vscode` root dependency 문맥에 content conflict가 발생했다.
+- conflict 해소 commit에는 두 원 bump를 모두 유지했다. 지원 계약 변경은 이후 collaborator fix로
+  분리해 원 commit의 의미와 보정 책임을 섞지 않았다.
+
+### Collaborator fix
+
+- `rhwp-vscode/package.json`
+  - TypeScript 7 CLI를 `@typescript/native` alias로 설치한다.
+  - `typescript` import는 `@typescript/typescript6` API alias로 제공한다.
+  - extension/webview TypeScript 7 `typecheck` 뒤 webpack을 실행한다.
+  - VS Code/Node type을 각각 1.82/18.15 line에 고정한다.
+- `rhwp-vscode/package-lock.json`
+  - alias와 runtime type 해소를 반영한다.
+  - `fast-uri`를 취약한 3.1.3에서 compatible patch 3.1.4로 갱신한다.
+- `rhwp-vscode/tsconfig.json`
+  - Extension Host의 Node type을 명시한다.
+- `rhwp-vscode/tsconfig.webview.json`
+  - TypeScript 7에서 제거된 `baseUrl`을 없애고 paths를 명시적 상대 경로로 바꾼다.
+  - 공유하는 `rhwp-studio` source를 포함하도록 `rootDir`을 명시한다.
+- `rhwp-vscode/src/webview/viewer.ts`
+  - 최신 DOM `hidden` type을 boolean으로 정규화한다.
+- `.github/dependabot.yml`
+  - `engines.vscode ^1.82.0`을 올리기 전 newer VS Code/Node type PR 생성을 막는다.
+
+## 단계
+
+| 단계 | 상태 | 작업 |
+|---|---|---|
+| 0. metadata 정렬 | 완료 | 세 원 PR reviewer 지정, labels/milestone 확인, assignee 제한 기록 |
+| 1. Route B branch | 완료 | 최신 `upstream/devel`에서 visibility/integration branch 생성 |
+| 2. source 통합 | 완료 | 세 source commit을 `-x` cherry-pick하고 #3344 conflict 해소 |
+| 3. collaborator 보정 | 완료 | build bridge, type/runtime 계약, Dependabot 정책을 별도 commit |
+| 4. local verification | 완료 | fresh WASM, clean npm install, typecheck, webpack, contract, VSIX, audit |
+| 5. review 문서 | 현재 단계 | 원 PR별 review와 umbrella report를 별도 docs commit으로 작성 |
+| 6. remote integration PR | 승인 대기 | origin push와 `devel` 대상 integration PR 생성 |
+| 7. authoritative CI/review | 미실행 | 최신 integration head의 full CI 확인 후 GitHub review 판단 |
+| 8. merge/후속 | 별도 승인 필요 | integration PR merge, 원 PR 설명 comment/close, issue 상태 확인 |
+
+## 검증 순서와 결과
+
+1. `CARGO_INCREMENTAL=0 wasm-pack build --target web --dev`: 성공.
+2. 보정 lockfile `npm ci`: 성공, 159 package audit 취약점 0건.
+3. compiler selection: TypeScript 7 CLI 7.0.2, `typescript` compiler API 6.0.3.
+4. `npm run typecheck`: extension/webview 모두 성공.
+5. `npm run compile`: 두 webpack config 모두 성공.
+6. VS Code font/license contract: 3/3 성공.
+7. VSIX package: 35 files, 17.35 MB, 성공.
+8. Dependabot YAML parse와 `git diff --check`: 성공.
+
+전체 font contract의 Studio/browser distribution 1건은 `rhwp-studio/dist/fonts` prerequisite가 없어
+실패했다. integration PR CI는 Studio build를 선행하므로 latest full `Frontend package gates` 성공을
+필수 조건으로 둔다.
+
+## Remote PR 계획
+
+사용자 승인 뒤에만 현재 branch를 `origin`에 push하고 `devel` 대상 integration PR을 만든다.
+PR body에는 다음을 포함한다.
+
+- `Supersedes #3334`, `Supersedes #3337`, `Supersedes #3344`
+- source PR/commit과 integration commit mapping
+- Dependabot author 및 `Signed-off-by` 보존
+- TypeScript 7/6 bridge와 VS Code 1.82/Node 18.15 지원 계약
+- local verification과 원 PR CI 스냅샷
+- integration PR이 merge된 뒤 원 PR을 close한다는 명시
+
+연결된 issue가 없으므로 `Closes #...`는 넣지 않는다. full CI가 필요한 code/config 변경이므로
+review-only fast-pass를 적용하지 않는다.
+
+## 승인·rollback 경계
+
+- docs commit 뒤 사용자 검토와 remote push/PR 생성 승인을 다시 받는다.
+- integration PR CI가 실패하면 원 source commit을 rewrite하지 않고 collaborator fix를 별도 commit으로
+  보완한다.
+- merge, 원 PR comment/close, issue close는 각각 해당 단계의 명시 승인을 받는다.
+- remote push 전 rollback은 local branch를 보존하거나 삭제하는 것으로 끝나며 원 PR에는 영향이 없다.

--- a/mydocs/pr/archives/pr_3337_review.md
+++ b/mydocs/pr/archives/pr_3337_review.md
@@ -1,0 +1,76 @@
+# PR #3337 검토 기록 — VS Code API type 지원 범위
+
+## 라우팅
+
+```text
+base route: collaborator 매개 외부 PR (Route B: 통합 PR)
+modifiers: 접수·리뷰 기록, 로컬 검증, 다수 PR·update branch, 재작업·예외(Dependabot)
+current head: ea5580b77378d685193aed76c880bb5732af2f79
+```
+
+## PR metadata
+
+| 항목 | 내용 |
+|---|---|
+| 원 PR | [#3337](https://github.com/edwardkim/rhwp/pull/3337) |
+| 작성자 / base | `dependabot[bot]` / `devel` |
+| 검토자 | `@postmelee` (local fetch 전 review request) |
+| labels / milestone | `dependencies`, `javascript` / 없음 |
+| assignee | 없음 — GitHub이 Dependabot bot을 assignable actor로 허용하지 않음 |
+| 규모 | 2026-07-26 조회: +7/-7, 2 files, 1 commit |
+| head | `ea5580b77378d685193aed76c880bb5732af2f79` |
+| 상태 스냅샷 | `MERGEABLE`, `BEHIND`, draft 아님, review decision 없음 |
+| 권한 / 관련 issue | `maintainerCanModify=false` / 자동 close 대상 issue 없음 |
+| 판단 | 원 PR 직접 merge 보류, 지원 계약을 보정한 Route B 통합으로 대체 |
+
+metadata와 CI는 문서 작성 시점 참고값이다. 최종 판단 전 최신 integration PR head에서 다시 확인한다.
+
+## 변경 범위와 문제
+
+- 원 PR은 `@types/vscode`를 1.110.0에서 1.125.0으로 올리고 manifest 하한도 `^1.125.0`으로 바꾼다.
+- 확장 manifest의 `engines.vscode`는 계속 `^1.82.0`이다.
+- [VS Code extension manifest 문서](https://code.visualstudio.com/api/references/extension-manifest)는
+  `engines.vscode`를 확장이 호환되는 VS Code 버전 범위로 정의한다.
+- 1.125 type으로 compile하면서 1.82 설치를 허용하면 1.82에 없는 API 사용을 build가 차단하지 못한다.
+  원 PR CI가 성공한 사실은 이 최소 지원 계약을 검증하지 않는다.
+- 원 PR 전에도 caret 범위 때문에 lockfile이 1.110.0까지 올라가 있어 선언된 최소 버전과 실제 compile
+  type이 이미 어긋나 있었다. 이번 검토는 해당 drift도 함께 닫는다.
+
+## Route B 통합과 collaborator 보정
+
+| 구분 | SHA | 내용 |
+|---|---|---|
+| 원 commit | `ea5580b77` | Dependabot `@types/vscode` 1.125.0 bump |
+| 통합 commit | `beba924eb` | `-x` cherry-pick, 원 저자와 `Signed-off-by` 보존 |
+| 보정 commit | `fdc0af5b5` | 최소 지원 API type과 Dependabot 정책 정렬 |
+
+최종 통합 tree에서는 `@types/vscode`를 `~1.82.0`, lockfile을 1.82.0으로 고정한다.
+`.github/dependabot.yml`은 `engines.vscode`를 올리기 전 `>=1.83.0` type update를 생성하지 않도록 제한한다.
+따라서 원 PR이 요청한 1.125.0 자체는 최종 tree에 남기지 않으며, 원 commit provenance만 보존한 뒤
+지원 계약 보정으로 supersede한다.
+
+## 렌더 영향 판정
+
+- API declaration과 lockfile만 바꾸며 renderer·layout·paint·asset을 변경하지 않는다.
+- visual sweep 대상이 아니다.
+
+## 검증
+
+- 원 PR CI run
+  [#30177238171](https://github.com/edwardkim/rhwp/actions/runs/30177238171)의
+  `Build & Test`, `Frontend package gates`, CodeQL은 문서 작성 시점 성공이다.
+- 통합 tree에서 `@types/vscode` 1.82.0 해소를 확인했다.
+- fresh WASM 뒤 TypeScript 7 extension/webview typecheck와 TypeScript 6 API 기반 webpack compile이
+  모두 성공했다.
+- VS Code font/license contract 3/3, VSIX package, YAML parse, `git diff --check`가 성공했다.
+
+전체 font contract의 Studio/browser 항목 1건은 `rhwp-studio/dist/fonts` 미생성으로 prerequisite 실패했다.
+통합 PR full CI에서 전체 frontend aggregate를 다시 확인한다.
+
+## 리스크와 권고
+
+- 1.82 type으로 compile이 성공했으므로 현재 source가 더 최신 VS Code API를 요구하지 않는 것은 확인했다.
+- 실제 VS Code 1.82 Extension Host 설치 smoke는 수행하지 않았다. 이 변경은 type/build 계약 보정이며,
+  integration PR의 Node 22 full CI를 merge gate로 둔다.
+- **권고**: #3337은 직접 merge하지 않고 보정된 integration PR로 대체한다. integration PR merge 뒤
+  별도 승인으로 원 PR에 supersede 설명을 남기고 close한다.

--- a/mydocs/pr/archives/pr_3339_review.md
+++ b/mydocs/pr/archives/pr_3339_review.md
@@ -1,0 +1,58 @@
+# PR #3339 검토 기록 — rhwp-vscode webpack-cli 7
+
+## 라우팅
+
+```text
+base route: collaborator 매개 외부 PR (Route B: 통합 PR)
+modifiers: 접수·리뷰 기록, 로컬 검증, 다수 PR·update branch, 재작업·예외(Dependabot)
+current head: ca9a87e540f159aaa2adcaca9662c935d4b2662e
+```
+
+## PR metadata
+
+| 항목 | 내용 |
+|---|---|
+| 원 PR | [#3339](https://github.com/edwardkim/rhwp/pull/3339) |
+| 작성자 / base | `dependabot[bot]` / `devel` |
+| 검토자 | `@postmelee` (source 통합 전 review request) |
+| labels / milestone | `dependencies`, `javascript` / 없음 |
+| assignee | 없음 — GitHub이 Dependabot bot을 assignable actor로 허용하지 않음 |
+| 규모 | 2026-07-26 조회: +35/-90, 2 files, 1 commit |
+| head | `ca9a87e540f159aaa2adcaca9662c935d4b2662e` |
+| 상태 스냅샷 | `MERGEABLE`, `BEHIND`, draft 아님, review decision 없음 |
+| 권한 / 관련 issue | `maintainerCanModify=false` / 자동 close 대상 issue 없음 |
+| 판단 | 원 PR 직접 merge 대신 VS Code Route B 통합에 수용 |
+
+metadata와 CI는 문서 작성 시점 참고값이다. 최종 판단 전 최신 integration PR head에서 다시 확인한다.
+
+## 변경 범위와 통합
+
+- 원 PR은 `rhwp-vscode`의 `webpack-cli`를 6.0.1에서 7.2.1로 올린다.
+- source commit `ca9a87e540f159aaa2adcaca9662c935d4b2662e`를 `git cherry-pick -x`로 적용해
+  integration commit `d0ab718ab28b963f318852a043c781e06007550b`을 만들었다.
+- 원 저자 `dependabot[bot]`, `Signed-off-by`, source SHA provenance를 보존했다.
+- #3388의 TypeScript 7 CLI/TypeScript 6 compiler API alias 위에 충돌 없이 적용됐다.
+- 설치된 webpack-cli 7.2.1은 build-time Node `>=20.9.0`을 요구한다. 저장소 CI Node 22와
+  로컬 검증 Node 24는 이 조건을 충족하며, dev dependency라 VS Code 1.82 Extension Host에는 포함되지 않는다.
+
+## 렌더 영향 판정
+
+- package manifest와 lockfile만 바꾸며 renderer, layout, paint, WASM API, fixture, font asset을
+  변경하지 않는다.
+- visual sweep 대상이 아니다.
+
+## 검증
+
+- 원 PR 최신 head의 `Frontend package gates`, `Build & Test`, CodeQL은 문서 작성 시점 성공이다.
+- 통합 tree에서 `webpack-cli 7.2.1`, `webpack 5.109.0`, `ts-loader 9.6.2` 해소를 확인했다.
+- clean `npm ci`, TypeScript 7 extension/webview `npm run typecheck`, webpack `npm run compile`이 성공했다.
+- VS Code font/license contract 3/3과 VSIX package 35 files, 17.35 MB가 성공했다.
+- `npm audit`은 취약점 0건이다.
+
+## 리스크와 권고
+
+- release/package 명령의 build-time Node 하한이 올라가므로 Node 18 개발 환경에서는 webpack-cli 7을
+  직접 실행할 수 없다. 저장소 CI 계약은 Node 22이며 최신 integration PR CI를 authoritative gate로 둔다.
+- **권고**: #3339는 직접 merge하지 않고 확장된 Draft
+  [#3388](https://github.com/edwardkim/rhwp/pull/3388)로 대체한다. #3388 merge 뒤 별도 승인으로
+  source/integration mapping을 설명하고 원 PR을 close한다.

--- a/mydocs/pr/archives/pr_3341_review.md
+++ b/mydocs/pr/archives/pr_3341_review.md
@@ -1,0 +1,59 @@
+# PR #3341 검토 기록 — rhwp-vscode webpack 5.109
+
+## 라우팅
+
+```text
+base route: collaborator 매개 외부 PR (Route B: 통합 PR)
+modifiers: 접수·리뷰 기록, 로컬 검증, 다수 PR·update branch, 재작업·예외(Dependabot)
+current head: 5d94473495e20079e1a90c268d4717b263a94030
+```
+
+## PR metadata
+
+| 항목 | 내용 |
+|---|---|
+| 원 PR | [#3341](https://github.com/edwardkim/rhwp/pull/3341) |
+| 작성자 / base | `dependabot[bot]` / `devel` |
+| 검토자 | `@postmelee` (source 통합 전 review request) |
+| labels / milestone | `dependencies`, `javascript` / 없음 |
+| assignee | 없음 — GitHub이 Dependabot bot을 assignable actor로 허용하지 않음 |
+| 규모 | 2026-07-26 조회: +95/-150, 2 files, 1 commit |
+| head | `5d94473495e20079e1a90c268d4717b263a94030` |
+| 상태 스냅샷 | `MERGEABLE`, `BEHIND`, draft 아님, review decision 없음 |
+| 권한 / 관련 issue | `maintainerCanModify=false` / 자동 close 대상 issue 없음 |
+| 판단 | 충돌을 해소한 VS Code Route B 통합에 수용 |
+
+metadata와 CI는 문서 작성 시점 참고값이다. 최종 판단 전 최신 integration PR head에서 다시 확인한다.
+
+## 변경 범위와 충돌 해소
+
+- 원 PR은 `rhwp-vscode`의 `webpack`을 5.105.4에서 5.109.0으로 올린다.
+- source commit `5d94473495e20079e1a90c268d4717b263a94030`을 `git cherry-pick -x`로 적용해
+  integration commit `9b17a601c21d3fc13e43f1b08d253b3b13b335e6`을 만들었다.
+- 원 저자 `dependabot[bot]`, `Signed-off-by`, source SHA provenance를 보존했다.
+- 원 PR과 #3388이 같은 `devDependencies`와 lockfile을 바꿔 content conflict가 발생했다.
+- 충돌 해소에서는 #3341의 `webpack ^5.109.0`을 채택하면서 #3388의
+  `typescript: npm:@typescript/typescript6` API alias와 #3339의 `webpack-cli ^7.2.1`을 유지했다.
+- 최종 manifest를 기준으로 npm lockfile을 다시 계산했다.
+
+## 렌더 영향 판정
+
+- build tooling manifest와 lockfile만 바꾸며 runtime renderer/layout/paint, fixture, font asset을
+  변경하지 않는다.
+- visual sweep 대상이 아니다.
+
+## 검증
+
+- 원 PR 최신 head의 `Frontend package gates`, `Build & Test`, CodeQL은 문서 작성 시점 성공이다.
+- 통합 tree의 clean `npm ci`와 `npm audit` 취약점 0건을 확인했다.
+- TypeScript 7.0.2 CLI typecheck와 TypeScript 6.0.3 compiler API 기반 webpack build가 성공했다.
+- extension/webview 두 bundle은 webpack 5.109.0으로 성공했다.
+- VS Code font/license contract 3/3과 VSIX package 35 files, 17.35 MB가 성공했다.
+
+## 리스크와 권고
+
+- 원 PR의 녹색 CI는 #3388의 TypeScript alias와 결합된 lockfile을 검증하지 않는다. 최신 #3388 head의
+  full `Frontend package gates`와 `Build & Test`가 authoritative gate다.
+- **권고**: #3341은 직접 merge하지 않고 충돌 해소 commit을 포함한 Draft
+  [#3388](https://github.com/edwardkim/rhwp/pull/3388)로 대체한다. #3388 merge 뒤 별도 승인으로
+  원 PR을 close한다.

--- a/mydocs/pr/archives/pr_3342_review.md
+++ b/mydocs/pr/archives/pr_3342_review.md
@@ -1,0 +1,59 @@
+# PR #3342 검토 기록 — rhwp-vscode ts-loader 9.6
+
+## 라우팅
+
+```text
+base route: collaborator 매개 외부 PR (Route B: 통합 PR)
+modifiers: 접수·리뷰 기록, 로컬 검증, 다수 PR·update branch, 재작업·예외(Dependabot)
+current head: 5e70de300180d0e1c1c7326bb28d172f254c1516
+```
+
+## PR metadata
+
+| 항목 | 내용 |
+|---|---|
+| 원 PR | [#3342](https://github.com/edwardkim/rhwp/pull/3342) |
+| 작성자 / base | `dependabot[bot]` / `devel` |
+| 검토자 | `@postmelee` (source 통합 전 review request) |
+| labels / milestone | `dependencies`, `javascript` / 없음 |
+| assignee | 없음 — GitHub이 Dependabot bot을 assignable actor로 허용하지 않음 |
+| 규모 | 2026-07-26 조회: +19/-104, 2 files, 1 commit |
+| head | `5e70de300180d0e1c1c7326bb28d172f254c1516` |
+| 상태 스냅샷 | `MERGEABLE`, `BEHIND`, draft 아님, review decision 없음 |
+| 권한 / 관련 issue | `maintainerCanModify=false` / 자동 close 대상 issue 없음 |
+| 판단 | TypeScript API bridge를 보존한 VS Code Route B 통합에 수용 |
+
+metadata와 CI는 문서 작성 시점 참고값이다. 최종 판단 전 최신 integration PR head에서 다시 확인한다.
+
+## 변경 범위와 충돌 해소
+
+- 원 PR은 `rhwp-vscode`의 `ts-loader`를 9.5.4에서 9.6.2로 올린다.
+- source commit `5e70de300180d0e1c1c7326bb28d172f254c1516`을 `git cherry-pick -x`로 적용해
+  integration commit `9ef89e64ea5b701407d1b7bebfe67913ceaf10c2`을 만들었다.
+- 원 저자 `dependabot[bot]`, `Signed-off-by`, source SHA provenance를 보존했다.
+- 원 PR과 #3388이 같은 `devDependencies`와 lockfile 전이 항목을 바꿔 content conflict가 발생했다.
+- 충돌 해소에서는 #3342의 `ts-loader ^9.6.2`를 채택하되, `ts-loader`가 import하는
+  `typescript`는 기존 `npm:@typescript/typescript6@^6.0.2` compiler API alias로 유지했다.
+- TypeScript 7 CLI, webpack 5.109.0, webpack-cli 7.2.1과 함께 최종 lockfile을 다시 계산했다.
+
+## 렌더 영향 판정
+
+- build tooling manifest와 lockfile만 바꾸며 runtime renderer/layout/paint, fixture, font asset을
+  변경하지 않는다.
+- visual sweep 대상이 아니다.
+
+## 검증
+
+- 원 PR 최신 head의 `Frontend package gates`, `Build & Test`, CodeQL은 문서 작성 시점 성공이다.
+- 통합 tree에서 `ts-loader 9.6.2`가 TypeScript 6.0.3 compiler API와 함께 설치됨을 확인했다.
+- TypeScript 7.0.2 CLI의 extension/webview typecheck와 webpack 5.109.0 compile이 성공했다.
+- clean `npm ci`, VS Code font/license contract 3/3, VSIX 35 files, 17.35 MB가 성공했다.
+- `npm audit`은 취약점 0건이다.
+
+## 리스크와 권고
+
+- TypeScript 7은 programmatic compiler API를 제공하지 않으므로 `typescript` alias를 다시 7.x로
+  되돌리면 `ts-loader` build가 재차 실패한다. 이 통합은 CLI와 API package 분리를 merge 조건으로 둔다.
+- **권고**: #3342는 직접 merge하지 않고 충돌 해소 commit을 포함한 Draft
+  [#3388](https://github.com/edwardkim/rhwp/pull/3388)로 대체한다. #3388 merge 뒤 별도 승인으로
+  원 PR을 close한다.

--- a/mydocs/pr/archives/pr_3344_review.md
+++ b/mydocs/pr/archives/pr_3344_review.md
@@ -1,0 +1,80 @@
+# PR #3344 검토 기록 — VS Code Extension Host Node type 지원 범위
+
+## 라우팅
+
+```text
+base route: collaborator 매개 외부 PR (Route B: 통합 PR)
+modifiers: 접수·리뷰 기록, 로컬 검증, 다수 PR·update branch, 재작업·예외(Dependabot)
+current head: 568d7d2932ec98e769175f8bbdf236832b59b7e7
+```
+
+## PR metadata
+
+| 항목 | 내용 |
+|---|---|
+| 원 PR | [#3344](https://github.com/edwardkim/rhwp/pull/3344) |
+| 작성자 / base | `dependabot[bot]` / `devel` |
+| 검토자 | `@postmelee` (local fetch 전 review request) |
+| labels / milestone | `dependencies`, `javascript` / 없음 |
+| assignee | 없음 — GitHub이 Dependabot bot을 assignable actor로 허용하지 않음 |
+| 규모 | 2026-07-26 조회: +11/-11, 2 files, 1 commit |
+| head | `568d7d2932ec98e769175f8bbdf236832b59b7e7` |
+| 상태 스냅샷 | `MERGEABLE`, `BEHIND`, draft 아님, review decision 없음 |
+| 권한 / 관련 issue | `maintainerCanModify=false` / 자동 close 대상 issue 없음 |
+| 판단 | 원 PR 직접 merge 보류, runtime type 계약을 보정한 Route B 통합으로 대체 |
+
+metadata와 CI는 문서 작성 시점 참고값이다. 최종 판단 전 최신 integration PR head에서 다시 확인한다.
+
+## 변경 범위와 문제
+
+- 원 PR은 `@types/node`를 20.19.37에서 26.1.1로 올리고 manifest 하한을 `^26.1.1`로 바꾼다.
+- 확장은 `engines.vscode: ^1.82.0`을 선언한다.
+- [VS Code 1.82 release notes](https://code.visualstudio.com/updates/v1_82)는 Extension Host가 포함된
+  Electron 25의 Node.js를 18.15.0으로 갱신했다고 기록한다.
+- Node 26 type으로 compile하면서 VS Code 1.82 설치를 허용하면 런타임에 없는 Node API 사용을 build가
+  차단하지 못한다. 원 PR의 녹색 CI는 Node 26 type compilation이 성공했다는 뜻이지 1.82 runtime
+  호환성을 보증하지 않는다.
+- 원 PR 전의 `@types/node ^20.0.0`도 최소 runtime보다 높았으므로 이번 검토에서 함께 정렬한다.
+
+## Route B 통합과 collaborator 보정
+
+| 구분 | SHA | 내용 |
+|---|---|---|
+| 원 commit | `568d7d293` | Dependabot `@types/node` 26.1.1 bump |
+| 통합 commit | `22222092f` | `-x` cherry-pick, 원 저자와 `Signed-off-by` 보존 |
+| 보정 commit | `fdc0af5b5` | Node 18.15 type과 Dependabot 정책 정렬 |
+
+#3334와 #3337을 먼저 적용한 상태에서 #3344를 cherry-pick하자 두 manifest의 같은
+`devDependencies` 문맥에서 충돌했다. 충돌 해소 단계에서는 `@types/node 26.1.1`과
+`@types/vscode 1.125.0` 원 bump를 모두 보존해 원 commit을 완료한 뒤, collaborator 보정 commit에서
+지원 계약을 별도로 적용했다.
+
+최종 통합 tree는 `@types/node ~18.15.0`, lockfile 18.15.13을 사용한다.
+`.github/dependabot.yml`은 minimum Extension Host를 올리기 전 `>=18.16.0` type update를 생성하지 않도록
+제한한다. 원 PR이 요청한 26.1.1은 최종 tree에 남기지 않는다.
+
+## 렌더 영향 판정
+
+- Node declaration과 lockfile만 바꾸며 renderer·layout·paint·asset을 변경하지 않는다.
+- visual sweep 대상이 아니다.
+
+## 검증
+
+- 원 PR CI run
+  [#30177250840](https://github.com/edwardkim/rhwp/actions/runs/30177250840)의
+  `Build & Test`, `Frontend package gates`, CodeQL은 문서 작성 시점 성공이다.
+- 통합 tree에서 `@types/node` 18.15.13 해소를 확인했다.
+- `types: ["node"]`를 명시한 TypeScript 7 extension typecheck와 TypeScript 6 API 기반 webpack
+  extension bundle이 성공했다.
+- fresh WASM, webview typecheck/bundle, VS Code font/license contract 3/3, VSIX package,
+  YAML parse, `git diff --check`가 성공했다.
+
+전체 font contract의 Studio/browser 항목 1건은 `rhwp-studio/dist/fonts` 미생성으로 prerequisite 실패했다.
+통합 PR full CI에서 전체 frontend aggregate를 다시 확인한다.
+
+## 리스크와 권고
+
+- 실제 VS Code 1.82 Extension Host 설치 smoke는 수행하지 않았다. compile type을 최소 runtime에 맞춘
+  것이 이번 변경의 핵심 보증이다.
+- **권고**: #3344는 직접 merge하지 않고 보정된 integration PR로 대체한다. integration PR의 Node 22
+  full CI와 작업지시자 승인을 merge 조건으로 두며, merge 뒤 별도 승인으로 원 PR을 close한다.

--- a/rhwp-vscode/package-lock.json
+++ b/rhwp-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rhwp-vscode",
-  "version": "0.7.19",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rhwp-vscode",
-      "version": "0.7.19",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
@@ -18,7 +18,7 @@
         "copy-webpack-plugin": "^14.0.0",
         "null-loader": "^4.0.1",
         "ts-loader": "^9.5.0",
-        "typescript": "^5.7.0",
+        "typescript": "^7.0.2",
         "webpack": "^5.98.0",
         "webpack-cli": "^6.0.0"
       },
@@ -150,6 +150,346 @@
       "integrity": "sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -1770,17 +2110,38 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "tsc": "bin/tsc"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/undici-types": {

--- a/rhwp-vscode/package-lock.json
+++ b/rhwp-vscode/package-lock.json
@@ -20,7 +20,7 @@
         "null-loader": "^4.0.1",
         "ts-loader": "^9.5.0",
         "typescript": "npm:@typescript/typescript6@^6.0.2",
-        "webpack": "^5.98.0",
+        "webpack": "^5.109.0",
         "webpack-cli": "^7.2.1"
       },
       "engines": {
@@ -99,32 +99,10 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
-    },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -722,9 +700,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -732,19 +710,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-import-phases": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "peerDependencies": {
-        "acorn": "^8.14.0"
       }
     },
     "node_modules/ajv": {
@@ -1044,14 +1009,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
-      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "version": "5.24.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
+      "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -1071,9 +1036,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1234,13 +1199,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true,
-      "license": "BSD-2-Clause"
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
@@ -1412,13 +1370,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -1447,20 +1398,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/loader-runner": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
-      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.11.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/loader-utils": {
@@ -1513,26 +1450,74 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+    "node_modules/minimizer-webpack-plugin": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mime-db": "1.52.0"
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
       }
     },
     "node_modules/neo-async": {
@@ -1946,9 +1931,9 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
-      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1960,9 +1945,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
-      "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -1976,40 +1961,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/terser-webpack-plugin": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
-      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "jest-worker": "^27.4.5",
-        "schema-utils": "^4.3.0",
-        "terser": "^5.31.1"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "uglify-js": {
-          "optional": true
-        }
       }
     },
     "node_modules/tinyglobby": {
@@ -2150,13 +2101,12 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
-      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+      "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       },
       "engines": {
@@ -2164,37 +2114,32 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.105.4",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
-      "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
+      "version": "5.109.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.0.tgz",
+      "integrity": "sha512-vomrngskVVXEZF9sMZfYAd4pXZUnfaWdJGlF+BTNF+gJBCKYCQBnOeVPlrh39Ewl7nlCsirDplMy6o5g9xJHBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.16.0",
-        "acorn-import-phases": "^1.0.3",
         "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.20.0",
-        "es-module-lexer": "^2.0.0",
+        "enhanced-resolve": "^5.24.2",
+        "es-module-lexer": "^2.1.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.3.1",
-        "mime-types": "^2.1.27",
+        "mime-db": "^1.54.0",
+        "minimizer-webpack-plugin": "^5.6.1",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.3.17",
-        "watchpack": "^2.5.1",
-        "webpack-sources": "^3.3.4"
+        "watchpack": "^2.5.2",
+        "webpack-sources": "^3.5.1"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -2290,9 +2235,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
-      "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+      "integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/rhwp-vscode/package-lock.json
+++ b/rhwp-vscode/package-lock.json
@@ -13,7 +13,7 @@
         "canvaskit-wasm": "^0.41.1"
       },
       "devDependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": "^26.1.1",
         "@types/vscode": "^1.125.0",
         "copy-webpack-plugin": "^14.0.0",
         "null-loader": "^4.0.1",
@@ -135,13 +135,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/vscode": {
@@ -2145,9 +2145,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/rhwp-vscode/package-lock.json
+++ b/rhwp-vscode/package-lock.json
@@ -13,12 +13,13 @@
         "canvaskit-wasm": "^0.41.1"
       },
       "devDependencies": {
-        "@types/node": "^26.1.1",
-        "@types/vscode": "^1.125.0",
+        "@types/node": "~18.15.0",
+        "@types/vscode": "~1.82.0",
+        "@typescript/native": "npm:typescript@^7.0.2",
         "copy-webpack-plugin": "^14.0.0",
         "null-loader": "^4.0.1",
         "ts-loader": "^9.5.0",
-        "typescript": "^7.0.2",
+        "typescript": "npm:@typescript/typescript6@^6.0.2",
         "webpack": "^5.98.0",
         "webpack-cli": "^6.0.0"
       },
@@ -135,21 +136,69 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~8.3.0"
-      }
-    },
-    "node_modules/@types/vscode": {
-      "version": "1.125.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
-      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
+      "integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript/native": {
+      "name": "typescript",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/@typescript/old": {
+      "name": "typescript",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
       "version": "7.0.2",
@@ -1164,9 +1213,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -2110,46 +2159,18 @@
       }
     },
     "node_modules/typescript": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "name": "@typescript/typescript6",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript6/-/typescript6-6.0.2.tgz",
+      "integrity": "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@typescript/old": "npm:typescript@^6"
+      },
       "bin": {
-        "tsc": "bin/tsc"
-      },
-      "engines": {
-        "node": ">=16.20.0"
-      },
-      "optionalDependencies": {
-        "@typescript/typescript-aix-ppc64": "7.0.2",
-        "@typescript/typescript-darwin-arm64": "7.0.2",
-        "@typescript/typescript-darwin-x64": "7.0.2",
-        "@typescript/typescript-freebsd-arm64": "7.0.2",
-        "@typescript/typescript-freebsd-x64": "7.0.2",
-        "@typescript/typescript-linux-arm": "7.0.2",
-        "@typescript/typescript-linux-arm64": "7.0.2",
-        "@typescript/typescript-linux-loong64": "7.0.2",
-        "@typescript/typescript-linux-mips64el": "7.0.2",
-        "@typescript/typescript-linux-ppc64": "7.0.2",
-        "@typescript/typescript-linux-riscv64": "7.0.2",
-        "@typescript/typescript-linux-s390x": "7.0.2",
-        "@typescript/typescript-linux-x64": "7.0.2",
-        "@typescript/typescript-netbsd-arm64": "7.0.2",
-        "@typescript/typescript-netbsd-x64": "7.0.2",
-        "@typescript/typescript-openbsd-arm64": "7.0.2",
-        "@typescript/typescript-openbsd-x64": "7.0.2",
-        "@typescript/typescript-sunos-x64": "7.0.2",
-        "@typescript/typescript-win32-arm64": "7.0.2",
-        "@typescript/typescript-win32-x64": "7.0.2"
+        "tsc6": "bin/tsc6"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/rhwp-vscode/package-lock.json
+++ b/rhwp-vscode/package-lock.json
@@ -21,16 +21,16 @@
         "ts-loader": "^9.5.0",
         "typescript": "npm:@typescript/typescript6@^6.0.2",
         "webpack": "^5.98.0",
-        "webpack-cli": "^6.0.0"
+        "webpack-cli": "^7.2.1"
       },
       "engines": {
         "vscode": "^1.82.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
-      "integrity": "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-1.1.0.tgz",
+      "integrity": "sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -707,53 +707,6 @@
       "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@webpack-cli/configtest": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-3.0.1.tgz",
-      "integrity": "sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/info": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-3.0.1.tgz",
-      "integrity": "sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/serve": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-3.0.1.tgz",
-      "integrity": "sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      },
-      "peerDependenciesMeta": {
-        "webpack-dev-server": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -1027,13 +980,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -1228,16 +1174,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fastest-levenshtein": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
-      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.9.1"
-      }
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -2277,22 +2213,17 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
-      "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.2.1.tgz",
+      "integrity": "sha512-YwSGbcZdfz12DM8JIseVPr3oBb09IgVCVc4vY3oDvZnI/mALTGPAP1QiqOi4/bBLSJrRHaqDIXeHcNA0+G38aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@discoveryjs/json-ext": "^0.6.1",
-        "@webpack-cli/configtest": "^3.0.1",
-        "@webpack-cli/info": "^3.0.1",
-        "@webpack-cli/serve": "^3.0.1",
-        "colorette": "^2.0.14",
-        "commander": "^12.1.0",
-        "cross-spawn": "^7.0.3",
-        "envinfo": "^7.14.0",
-        "fastest-levenshtein": "^1.0.12",
-        "import-local": "^3.0.2",
+        "@discoveryjs/json-ext": "^1.1.0",
+        "commander": "^14.0.3",
+        "cross-spawn": "^7.0.6",
+        "envinfo": "^7.21.0",
+        "import-local": "^3.2.0",
         "interpret": "^3.1.1",
         "rechoir": "^0.8.0",
         "webpack-merge": "^6.0.1"
@@ -2301,16 +2232,30 @@
         "webpack-cli": "bin/cli.js"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^5.82.0"
+        "js-yaml": "^4.0.0 || ^5.0.0",
+        "json5": "^2.2.3",
+        "toml": "^3.0.0 || ^4.0.0",
+        "webpack": "^5.101.0",
+        "webpack-bundle-analyzer": "^4.0.0 || ^5.0.0",
+        "webpack-dev-server": "^5.0.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
+        "js-yaml": {
+          "optional": true
+        },
+        "json5": {
+          "optional": true
+        },
+        "toml": {
+          "optional": true
+        },
         "webpack-bundle-analyzer": {
           "optional": true
         },
@@ -2320,13 +2265,13 @@
       }
     },
     "node_modules/webpack-cli/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/webpack-merge": {

--- a/rhwp-vscode/package-lock.json
+++ b/rhwp-vscode/package-lock.json
@@ -18,7 +18,7 @@
         "@typescript/native": "npm:typescript@^7.0.2",
         "copy-webpack-plugin": "^14.0.0",
         "null-loader": "^4.0.1",
-        "ts-loader": "^9.5.0",
+        "ts-loader": "^9.6.2",
         "typescript": "npm:@typescript/typescript6@^6.0.2",
         "webpack": "^5.109.0",
         "webpack-cli": "^7.2.1"
@@ -799,19 +799,6 @@
         "node": "*"
       }
     },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -1140,19 +1127,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -1299,16 +1273,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -1434,20 +1398,6 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
@@ -1692,13 +1642,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -1812,19 +1762,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/serialize-javascript": {
@@ -1998,51 +1935,29 @@
         }
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/ts-loader": {
-      "version": "9.5.4",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.4.tgz",
-      "integrity": "sha512-nCz0rEwunlTZiy6rXFByQU1kVVpCIgUpc/psFiKVrUwrizdnIbRFu8w7bxhUF0X613DYwT4XzrZHpVyMe758hQ==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.6.2.tgz",
+      "integrity": "sha512-R4iuczmtgxvtuI556s+hTZ6/7Ee03VCAk/l/M8LY1OAsUgB7YydsCxkgq9D9pKRaD7GJqUi2u8fp9zZP/ufjKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
-        "enhanced-resolve": "^5.0.0",
-        "micromatch": "^4.0.0",
-        "semver": "^7.3.4",
+        "picomatch": "^4.0.0",
         "source-map": "^0.7.4"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "peerDependencies": {
+        "loader-utils": "*",
         "typescript": "*",
-        "webpack": "^5.0.0"
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "loader-utils": {
+          "optional": true
+        }
       }
     },
     "node_modules/typescript": {

--- a/rhwp-vscode/package-lock.json
+++ b/rhwp-vscode/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
-        "@types/vscode": "^1.82.0",
+        "@types/vscode": "^1.125.0",
         "copy-webpack-plugin": "^14.0.0",
         "null-loader": "^4.0.1",
         "ts-loader": "^9.5.0",
@@ -145,9 +145,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.110.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.110.0.tgz",
-      "integrity": "sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==",
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
+      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
       "dev": true,
       "license": "MIT"
     },

--- a/rhwp-vscode/package.json
+++ b/rhwp-vscode/package.json
@@ -120,7 +120,7 @@
     "null-loader": "^4.0.1",
     "ts-loader": "^9.5.0",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
-    "webpack": "^5.98.0",
+    "webpack": "^5.109.0",
     "webpack-cli": "^7.2.1"
   }
 }

--- a/rhwp-vscode/package.json
+++ b/rhwp-vscode/package.json
@@ -121,6 +121,6 @@
     "ts-loader": "^9.5.0",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "webpack": "^5.98.0",
-    "webpack-cli": "^6.0.0"
+    "webpack-cli": "^7.2.1"
   }
 }

--- a/rhwp-vscode/package.json
+++ b/rhwp-vscode/package.json
@@ -118,7 +118,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "copy-webpack-plugin": "^14.0.0",
     "null-loader": "^4.0.1",
-    "ts-loader": "^9.5.0",
+    "ts-loader": "^9.6.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "webpack": "^5.109.0",
     "webpack-cli": "^7.2.1"

--- a/rhwp-vscode/package.json
+++ b/rhwp-vscode/package.json
@@ -102,7 +102,8 @@
     }
   },
   "scripts": {
-    "compile": "webpack --mode production",
+    "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.webview.json",
+    "compile": "npm run typecheck && webpack --mode production",
     "watch": "webpack --mode development --watch",
     "vscode:prepublish": "npm run compile",
     "package": "vsce package"
@@ -112,12 +113,13 @@
     "canvaskit-wasm": "^0.41.1"
   },
   "devDependencies": {
-    "@types/node": "^26.1.1",
-    "@types/vscode": "^1.125.0",
+    "@types/node": "~18.15.0",
+    "@types/vscode": "~1.82.0",
+    "@typescript/native": "npm:typescript@^7.0.2",
     "copy-webpack-plugin": "^14.0.0",
     "null-loader": "^4.0.1",
     "ts-loader": "^9.5.0",
-    "typescript": "^7.0.2",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
     "webpack": "^5.98.0",
     "webpack-cli": "^6.0.0"
   }

--- a/rhwp-vscode/package.json
+++ b/rhwp-vscode/package.json
@@ -117,7 +117,7 @@
     "copy-webpack-plugin": "^14.0.0",
     "null-loader": "^4.0.1",
     "ts-loader": "^9.5.0",
-    "typescript": "^5.7.0",
+    "typescript": "^7.0.2",
     "webpack": "^5.98.0",
     "webpack-cli": "^6.0.0"
   }

--- a/rhwp-vscode/package.json
+++ b/rhwp-vscode/package.json
@@ -113,7 +113,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "@types/vscode": "^1.82.0",
+    "@types/vscode": "^1.125.0",
     "copy-webpack-plugin": "^14.0.0",
     "null-loader": "^4.0.1",
     "ts-loader": "^9.5.0",

--- a/rhwp-vscode/package.json
+++ b/rhwp-vscode/package.json
@@ -112,7 +112,7 @@
     "canvaskit-wasm": "^0.41.1"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
+    "@types/node": "^26.1.1",
     "@types/vscode": "^1.125.0",
     "copy-webpack-plugin": "^14.0.0",
     "null-loader": "^4.0.1",

--- a/rhwp-vscode/src/webview/viewer.ts
+++ b/rhwp-vscode/src/webview/viewer.ts
@@ -323,7 +323,7 @@ function setZoomMenuOpen(open: boolean): void {
 
 stbZoomMenu.addEventListener("click", (e) => {
   e.stopPropagation();
-  setZoomMenuOpen(stbZoomPopup.hidden);
+  setZoomMenuOpen(stbZoomPopup.hidden !== false);
 });
 
 document.addEventListener("click", () => setZoomMenuOpen(false));

--- a/rhwp-vscode/tsconfig.json
+++ b/rhwp-vscode/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "commonjs",
     "lib": ["ES2022"],
+    "types": ["node"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,

--- a/rhwp-vscode/tsconfig.webview.json
+++ b/rhwp-vscode/tsconfig.webview.json
@@ -6,18 +6,18 @@
     "allowImportingTsExtensions": true,
     "rewriteRelativeImportExtensions": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "rootDir": "..",
     "outDir": "./dist/webview",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true,
-    "baseUrl": ".",
     "paths": {
       "@rhwp-wasm/*": ["../pkg/*"],
       "@/*": ["../rhwp-studio/src/*"],
-      "canvaskit-wasm": ["node_modules/canvaskit-wasm/types/index.d.ts"],
-      "@noble/hashes/*": ["node_modules/@noble/hashes/*"]
+      "canvaskit-wasm": ["./node_modules/canvaskit-wasm/types/index.d.ts"],
+      "@noble/hashes/*": ["./node_modules/@noble/hashes/*"]
     }
   },
   "include": ["src/webview/**/*.ts"]


### PR DESCRIPTION
## 요약

- Dependabot PR #3334, #3337, #3339, #3341, #3342, #3344의 원 commit을
  `git cherry-pick -x`로 통합했습니다.
- TypeScript 7 CLI는 유지하면서 compiler API가 필요한 `ts-loader`에는 공식 TypeScript 6
  compatibility alias를 제공합니다.
- `engines.vscode ^1.82.0`에 맞춰 VS Code API type은 1.82, Node type은 18.15 line으로 고정했습니다.
- webpack-cli 7.2.1, webpack 5.109.0, ts-loader 9.6.2를 같은 최종 lockfile에서 검증했습니다.
- TypeScript 7 설정 호환, DOM `hidden` type 정규화, Dependabot 재발 방지 정책과 review 문서를 포함합니다.

Supersedes #3334

Supersedes #3337

Supersedes #3339

Supersedes #3341

Supersedes #3342

Supersedes #3344

## 원인과 보정

- #3334: TypeScript 7에는 기존 programmatic compiler API가 없어 `ts-loader`가 `fileExists` 접근에서
  실패했습니다.
- #3337: `@types/vscode` 1.125는 확장의 최소 지원 버전 VS Code 1.82보다 높은 API를 노출합니다.
- #3344: `@types/node` 26은 VS Code 1.82 Extension Host의 Node 18.15 runtime과 맞지 않습니다.
- #3339는 기존 보정 tree에 자동 적용됐습니다.
- #3341/#3342는 같은 `devDependencies`와 lockfile을 바꿔 충돌했으며, webpack 5.109.0과
  ts-loader 9.6.2를 채택하면서 TypeScript 7 CLI/TypeScript 6 API alias 및 webpack-cli 7.2.1을
  보존했습니다.
- 전이 dev dependency `fast-uri`는 취약한 3.1.3에서 compatible patch 3.1.4로 갱신했습니다.

## Source provenance

| 원 PR | source commit | integration commit |
|---|---|---|
| #3334 | `9a77d8362d5bd86701c68a4799d434736742c62e` | `3039b4d8e08d4c2a847a601554cf6d6fe508ba02` |
| #3337 | `ea5580b77378d685193aed76c880bb5732af2f79` | `beba924eb4f4e8f64fec55e8f1d6927c9b6d8676` |
| #3339 | `ca9a87e540f159aaa2adcaca9662c935d4b2662e` | `d0ab718ab28b963f318852a043c781e06007550b` |
| #3341 | `5d94473495e20079e1a90c268d4717b263a94030` | `9b17a601c21d3fc13e43f1b08d253b3b13b335e6` |
| #3342 | `5e70de300180d0e1c1c7326bb28d172f254c1516` | `9ef89e64ea5b701407d1b7bebfe67913ceaf10c2` |
| #3344 | `568d7d2932ec98e769175f8bbdf236832b59b7e7` | `22222092feab59ee67fc6784ce0b6ce72f8caf23` |

여섯 integration commit은 `dependabot[bot]` author, `Signed-off-by`, source SHA를 보존합니다.
collaborator 보정은 별도 commit `fdc0af5b5c2d8b266990419fbc87cc0543589717`입니다.

## 검증

- 선행 fresh `CARGO_INCREMENTAL=0 wasm-pack build --target web --dev`
- 확장 lockfile clean `npm ci`
- `npm audit` — 취약점 0건
- TypeScript 7.0.2 extension/webview `npm run typecheck`
- TypeScript 6.0.3 API 기반 `npm run compile`
- webpack-cli 7.2.1 / webpack 5.109.0 / ts-loader 9.6.2 설치 확인
- VS Code font/license contract 3/3
- `npx --yes @vscode/vsce package` — 35 files, 17.35 MB
- `git diff --check upstream/devel...HEAD`

전체 font contract의 Studio/browser 항목 1건은 local에서 `rhwp-studio/dist/fonts` prerequisite가 없어
실패했습니다. VS Code 관련 3건은 성공했으며, 이 PR의 full `Frontend package gates`를 merge 조건으로 둡니다.

## Review 기록

- `mydocs/pr/archives/pr_3334_review.md`
- `mydocs/pr/archives/pr_3337_review.md`
- `mydocs/pr/archives/pr_3339_review.md`
- `mydocs/pr/archives/pr_3341_review.md`
- `mydocs/pr/archives/pr_3342_review.md`
- `mydocs/pr/archives/pr_3344_review.md`
- `mydocs/pr/archives/pr_3334_review_impl.md`
- `mydocs/pr/archives/pr_3334_report.md`

## Merge gate

- code/config와 conflict resolution이 있으므로 review-only fast-pass를 적용하지 않습니다.
- 최신 PR head의 `Frontend package gates`, `Build & Test`, CodeQL 성공이 필요합니다.
- 이 integration PR이 merge된 뒤 별도 승인으로 원 Dependabot PR에 source mapping과 credit 보존을
  설명하고 close합니다.
- 여섯 원 PR에는 linked issue가 없어 `Closes #...`는 포함하지 않았습니다.
