### PR TITLE
ci: devel PR stale run 자동 force-cancel (#3406)

### DIFF
--- a/.github/workflows/cancel-stale-pr-runs.yml
+++ b/.github/workflows/cancel-stale-pr-runs.yml
@@ -1,0 +1,96 @@
+name: Cancel stale PR runs
+
+# Update branch(synchronize) 뒤 같은 devel PR의 이전 SHA run을 force-cancel한다.
+# PR source를 checkout하거나 PR이 제공한 script를 실행하지 않는다. 외부 fork PR은 GitHub가
+# pull_request token을 읽기 전용으로 낮추므로 job을 skip하고 review 절차의 수동 처리로 남긴다.
+on:
+  pull_request:
+    branches: [devel]
+    types: [synchronize]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+# 연속 synchronize에서는 최신 reaper만 유지한다. reaper 안에서도 live head를 재확인하므로
+# 취소 요청 직전 최신 SHA를 보호한다.
+concurrency:
+  group: cancel-stale-pr-runs-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  cancel-stale-runs:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Force-cancel older pull-request runs for this PR
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pullNumber = context.payload.pull_request.number;
+            const activeStatuses = new Set([
+              'queued', 'in_progress', 'pending', 'requested', 'waiting',
+            ]);
+
+            async function getLivePull() {
+              const { data } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: pullNumber,
+              });
+              return data;
+            }
+
+            const pull = await getLivePull();
+            if (pull.state !== 'open') {
+              core.info(`PR #${pullNumber} is ${pull.state}; nothing to cancel.`);
+              return;
+            }
+
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRunsForRepo,
+              {
+                owner,
+                repo,
+                branch: pull.head.ref,
+                event: 'pull_request',
+                per_page: 100,
+              },
+            );
+            const staleRuns = runs.filter((run) => (
+              run.head_sha !== pull.head.sha
+              && activeStatuses.has(run.status)
+              && (run.pull_requests || []).some((runPull) => runPull.number === pullNumber)
+            ));
+
+            let cancelled = 0;
+            for (const run of staleRuns) {
+              // 새 synchronize가 이 reaper보다 먼저 반영됐을 수 있다. 요청 직전 live head를
+              // 재확인해 최신 SHA의 run은 절대 취소하지 않는다.
+              const livePull = await getLivePull();
+              if (livePull.state !== 'open') {
+                core.info(`PR #${pullNumber} is ${livePull.state}; stop cancelling.`);
+                break;
+              }
+              if (run.head_sha === livePull.head.sha) {
+                core.info(`Keep current run ${run.id} (${run.name}, ${run.head_sha}).`);
+                continue;
+              }
+
+              await github.request(
+                'POST /repos/{owner}/{repo}/actions/runs/{run_id}/force-cancel',
+                {
+                  owner,
+                  repo,
+                  run_id: run.id,
+                },
+              );
+              cancelled += 1;
+              core.info(`Force-cancelled stale run ${run.id} (${run.name}, ${run.head_sha}).`);
+            }
+
+            core.info(
+              `Current head ${pull.head.sha}; force-cancelled ${cancelled} stale run(s).`,
+            );

--- a/mydocs/manual/pr_review/multi_pr_update_branch.md
+++ b/mydocs/manual/pr_review/multi_pr_update_branch.md
@@ -30,11 +30,14 @@ scripts/pr_triage.sh <author> --list
 contributor 또는 maintainer가 Update branch를 수행해 PR head가 바뀌면, 이전 SHA run이 최신 required check와
 섞여 보일 수 있다. 최신 head의 CI는 절대 취소하지 않는다.
 
-1. 최신 head SHA를 확인한다.
-2. 이전 SHA에서 시작한 run을 확인한다.
-3. queued, pending, in_progress run만 **일반 `gh run cancel`을 먼저 시도하지 않고** force-cancel API로
-   즉시 취소한다.
-4. 완료 상태와 cancelled 결론을 재확인한다.
+1. `devel` 대상이고 head가 같은 저장소인 PR에서는 `Cancel stale PR runs` reaper가 `synchronize` event로
+   시작했는지, 최신 head SHA와 함께 확인한다. 이 workflow는 PR source를 checkout·실행하지 않고, 같은
+   PR의 이전 SHA `pull_request` run만 force-cancel한다.
+2. reaper가 성공했다면 이전 SHA run이 `completed/cancelled`가 되었고 최신 head run이 시작됐는지 확인한다.
+3. external fork PR은 GitHub가 `pull_request` token의 write 권한을 읽기 전용으로 낮추므로 reaper가
+   의도적으로 skip한다. 이 경우와 reaper 실패·미실행 시에는 이전 SHA에서 시작한 active run만 **일반
+   `gh run cancel`을 먼저 시도하지 않고** force-cancel API로 즉시 취소한다.
+4. 수동 취소 뒤에도 완료 상태와 `cancelled` 결론을 재확인한다.
 
 러너 구성 전환 등으로 배정 가능한 label이 사라진 run은 `queued`에 고착될 수 있다. 이 run은 일반 cancel이
 끝나지 않고 같은 concurrency group을 계속 점유해, 후속 run이 job을 하나도 시작하지 못한 `pending`으로
@@ -49,8 +52,9 @@ gh run list --repo edwardkim/rhwp --commit <old-sha> \
 gh api --method POST repos/edwardkim/rhwp/actions/runs/<run-id>/force-cancel
 ~~~
 
-force-cancel 대상 SHA, run URL, 완료 상태를 review 문서 또는 작업 기록에 남긴다. stale run 정리는 최신
-head의 새 CI를 기다리는 일과 병렬로 할 수 있지만, 대상 SHA 검증과 force-cancel API 호출은 순차로 한다.
+자동·수동 어느 경로든 force-cancel 대상 SHA, run URL, 완료 상태를 review 문서 또는 작업 기록에 남긴다.
+stale run 정리는 최신 head의 새 CI를 기다리는 일과 병렬로 할 수 있지만, 대상 SHA 검증과 force-cancel
+API 호출은 순차로 한다.
 
 PR close/reopen만으로는 GitHub의 merge ref가 항상 재계산된다고 가정하지 않는다. 고착 run을 정리한 뒤에도
 merge ref 또는 required check가 갱신되지 않으면, head SHA가 바뀌는 push의 `synchronize` 이벤트로

--- a/mydocs/orders/20260726.md
+++ b/mydocs/orders/20260726.md
@@ -216,3 +216,18 @@ v0.8.0 이후 `devel` 누적분을 0.8.1 PATCH 로 릴리즈한다. 신규 기�
 - 미추적 파일 정리: `rhwp-firefox-0.8.0.zip`, `rhwp-studio/e2e/tmp-*.mjs` 6종 제거(재생성 가능).
 - **#3319 상태 정정**: 문서에 merge 대기로 남아 있었으나 실제로는 2026-07-25에 `61b13fad4`로
   병합·close 완료였다. 위 섹션을 실제 상태로 갱신했다.
+
+## #3406 — Update branch 뒤 stale CI run 자동 force-cancel
+
+- 이슈 [#3406](https://github.com/edwardkim/rhwp/issues/3406), 브랜치
+  `task/3406-ci-force-cancel`.
+- `devel` 대상이며 head가 `edwardkim/rhwp` 안에 있는 PR의 `synchronize`에서, 같은 PR의 이전 SHA
+  active run만 force-cancel하는 `Cancel stale PR runs` workflow를 추가했다. live head를 취소 직전에
+  다시 확인하고 PR source checkout·shell·PR 제공 script 실행은 하지 않는다.
+- external fork PR은 GitHub가 `pull_request` token write 권한을 읽기 전용으로 낮추므로 자동 처리를
+  우회하지 않고, `multi_pr_update_branch.md`의 수동 force-cancel 절차를 fallback으로 유지한다.
+- 격리 fork PR [jangster77/rhwp#9](https://github.com/jangster77/rhwp/pull/9)에서 이전 SHA
+  `db82b24`의 CI·CodeQL·Render Diff 3개가 `cancelled`되고, Update branch 새 SHA `4a049c8`의
+  세 run이 다시 시작됨을 확인했다. reaper 증적: [run 30198335771](https://github.com/jangster77/rhwp/actions/runs/30198335771).
+- 정적 검증: `actionlint`, Ruby YAML parse, embedded Script `node --check`, Markdown 링크 검사,
+  `git diff --check` 통과. Rust·WASM·frontend·fixture 변경은 없어 해당 빌드·시각 검증은 대상이 아니다.

--- a/mydocs/plans/task_m100_3406.md
+++ b/mydocs/plans/task_m100_3406.md
@@ -1,0 +1,50 @@
+# 수행계획서 — #3406 Update branch 뒤 stale CI 자동 강제 취소
+
+- 이슈: [#3406](https://github.com/edwardkim/rhwp/issues/3406)
+- 작업 브랜치: `task/3406-ci-force-cancel`
+- 기준: `upstream/devel` `91bd61758`
+
+## 문제와 근거
+
+PR의 **Update branch**는 새 head SHA의 workflow run을 시작하지만, 기존 SHA에서 이미 실행 중인
+CI·CodeQL·Render Diff run을 보장해 취소하지 않는다. 기존 각 workflow의 `concurrency`는 유지하되,
+GitHub의 취소 순서와 runner 종료 지연만으로는 stale run을 즉시 정리할 수 없었다.
+
+격리 fork PR에서 `pull_request_target` reaper와 Actions force-cancel API를 검증했다. Update branch 뒤
+이전 SHA `2f8258e`의 CI·CodeQL·Render Diff run 3개가 `cancelled`가 되었고, 새 SHA `102d67c`의 세
+workflow가 다시 시작됐다. 증적은 [reaper run](https://github.com/jangster77/rhwp/actions/runs/30198059264)에
+남아 있다.
+
+## 범위
+
+1. `devel` 대상이며 head가 `edwardkim/rhwp` 안에 있는 PR의 `synchronize` 이벤트에서 stale PR run을 자동
+   force-cancel하는 전용 workflow를 추가한다.
+2. workflow는 `pull_request`에서 실행하되, PR source를 checkout하거나 PR 제공 script를 실행하지 않는다.
+   권한은 `actions: write`, `contents: read`, `pull-requests: read`로 한정한다.
+3. 같은 PR 번호·head branch의 `pull_request` run만 대상으로 하며, live PR head SHA와 같은 run은 절대
+   취소하지 않는다. 대상 상태는 `queued`, `in_progress`, `pending`, `requested`, `waiting`으로 제한한다.
+4. update가 연속으로 발생해도 오래된 reaper가 최신 SHA를 취소하지 않도록 cancel 직전 live PR head를
+   다시 확인한다.
+5. 외부 fork PR은 GitHub가 `pull_request` token의 write 권한을 읽기 전용으로 낮추므로 reaper를 명시적으로
+   skip하고, 운영 가이드의 수동 force-cancel 절차를 유지한다.
+
+## 배포 경로
+
+`main`은 메인터너 전용 릴리즈 브랜치이므로 변경하지 않는다. 이 변경은 `devel`에만 통합한다. `devel`
+대상의 동일 저장소 PR은 자동 처리하고, external fork PR은 workflow가 skip한 뒤 review 절차의 수동
+force-cancel로 처리한다.
+
+## 검증
+
+- `actionlint .github/workflows/cancel-stale-pr-runs.yml`
+- workflow YAML parse 및 embedded GitHub Script의 `node --check`
+- `git diff --check`
+- 이미 수행한 격리 fork의 실제 Update branch 재검증 결과와 source/base·권한·checkout 부재를 대조
+- PR 생성 뒤에는 `devel` 대상 동일 저장소 PR에서 실제 Update branch를 재검증한다.
+
+## 범위 제외
+
+- 기존 CI·CodeQL·Render Diff의 job 구성, required check, runner label 변경
+- 임의의 push·schedule·workflow_dispatch run 취소
+- external fork PR의 Actions token write 권한 우회
+- `main` 또는 release/main-sync 변경

--- a/mydocs/plans/task_m100_3406_impl.md
+++ b/mydocs/plans/task_m100_3406_impl.md
@@ -1,0 +1,29 @@
+# 구현계획서 — #3406 stale PR run reaper
+
+## workflow 계약
+
+새 `.github/workflows/cancel-stale-pr-runs.yml`은 `pull_request`의 `synchronize`에서만 실행한다. `devel`
+대상의 동일 저장소 head PR만 허용하며 source checkout 단계·shell 단계가 없다. `actions/github-script`
+안에서 GitHub API만 호출한다. 외부 fork PR은 GitHub Actions가 write token을 읽기 전용으로 낮추므로 job을
+명시적으로 skip한다.
+
+| 단계 | 처리 | 안전 장치 |
+| --- | --- | --- |
+| 1 | live PR 정보를 조회 | closed PR이면 종료하고 event payload의 낡은 SHA를 그대로 신뢰하지 않음 |
+| 2 | 같은 head branch의 `pull_request` run 열거 | `pull_requests[].number`가 현재 PR 번호인 run만 남김 |
+| 3 | active + stale SHA를 선별 | current head SHA run과 완료 run은 제외 |
+| 4 | 각 force-cancel 직전 live PR head 재확인 | 그 run SHA가 최신이면 건너뜀 |
+| 5 | REST force-cancel 호출 및 로그 | workflow 이름을 하드코딩하지 않고 대상 run ID·SHA를 남김 |
+
+top-level concurrency는 PR 번호별로 이전 reaper를 취소한다. 실제 CI run의 기존 concurrency 정의는
+바꾸지 않는다.
+
+## 문서 변경
+
+`mydocs/manual/pr_review/multi_pr_update_branch.md`는 Update branch 직후 자동 reaper 완료와 stale run
+상태를 먼저 확인하도록 바꾼다. reaper가 없거나 실패했을 때만 기존 force-cancel API 수동 절차를 쓴다.
+
+## 배포
+
+workflow는 `devel` 변경 PR로만 반영한다. `main`은 메인터너 전용 릴리즈 경로이므로 이 이슈의 변경 대상이
+아니다. devel 외부 fork PR의 stale run은 기존 수동 force-cancel 절차를 적용한다.

--- a/mydocs/pr/archives/pr_3409_review.md
+++ b/mydocs/pr/archives/pr_3409_review.md
@@ -1,0 +1,60 @@
+# PR #3409 검토 기록 — devel PR stale run 자동 force-cancel
+
+| 항목 | 내용 |
+| --- | --- |
+| PR | [#3409](https://github.com/edwardkim/rhwp/pull/3409) — `ci: devel PR stale run 자동 force-cancel (#3406)` |
+| 작성자·준비자 | `@jangster77` (collaborator self-merge) |
+| base / head | `devel` / `task/3406-ci-force-cancel` |
+| 관련 이슈 | [#3406](https://github.com/edwardkim/rhwp/issues/3406) |
+| 작성 시점 참고 head | `c06a4c398387daf1367291b47fda1abc97aefa2f` |
+| 작성 시점 규모 | 7 files, +264 / -7, 4 commits; 이 문서 추가 뒤 최신 head·CI를 다시 확인해야 함 |
+| 라우팅 | base: collaborator self-merge; modifiers: intake/review, local validation, post-merge |
+
+## 변경 범위와 판정
+
+새 `Cancel stale PR runs` workflow는 `devel` 대상이며 head가 같은 저장소인 PR의 `synchronize`
+event에서 실행된다. 같은 PR 번호의 `pull_request` run 중 현재 live head SHA와 다른 active
+(`queued`, `in_progress`, `pending`, `requested`, `waiting`) run만 Actions force-cancel API로 취소한다.
+
+각 취소 직전에 PR live head를 다시 읽는다. 따라서 연속 Update branch에서 먼저 시작한 reaper가 이후
+최신 SHA의 run을 취소하지 않는다. 기존 CI·CodeQL·Render Diff의 concurrency/job/required check는 바꾸지
+않는다.
+
+workflow에는 PR source checkout, shell step, PR 제공 script 실행이 없다. 권한은 `actions: write`,
+`contents: read`, `pull-requests: read`로 한정했다. GitHub가 `pull_request` token을 읽기 전용으로
+낮추는 external fork PR은 job을 의도적으로 skip하고, [다수 PR과 update branch 처리](../../manual/pr_review/multi_pr_update_branch.md#25-update-branch-뒤-이전-sha-ci-강제-취소)의
+수동 force-cancel 절차를 적용한다.
+
+renderer·layout·Rust·WASM·frontend·fixture·golden/baseline 변경이 없으므로 시각 검증, Cargo, WASM
+검증은 대상이 아니다. CI workflow 변경이므로 workflow 구문·권한·조건과 최신 GitHub Actions를 검증
+대상으로 한다.
+
+## 로컬·격리 검증
+
+- `actionlint .github/workflows/cancel-stale-pr-runs.yml` 통과
+- Ruby YAML parse 통과
+- embedded GitHub Script `node --check` 통과
+- `python3 scripts/check_markdown_links.py --changed-from upstream/devel` 통과
+- `git diff --check` 통과
+- 격리 동일 저장소 PR [jangster77/rhwp#9](https://github.com/jangster77/rhwp/pull/9)에서 base를 전진시킨
+  뒤 Update branch를 수행했다.
+  - 이전 `db82b24`의 CI `30198327109`, CodeQL `30198327121`, Render Diff `30198327120`은 모두
+    `completed/cancelled`가 됐다.
+  - 새 `4a049c8`의 CI `30198335775`, CodeQL `30198335764`, Render Diff `30198335768`은 자동으로
+    다시 시작됐다.
+  - [reaper run 30198335771](https://github.com/jangster77/rhwp/actions/runs/30198335771)은 success이며
+    세 stale run의 force-cancel 로그를 남겼다. 기존 `pull_request_target` test reaper는
+    [run 30198334829](https://github.com/jangster77/rhwp/actions/runs/30198334829)에서 `skipped`여서
+    결과에 개입하지 않았다.
+
+## 위험과 후속 처리
+
+- external fork PR은 자동 취소 범위 밖이며, 이 권한 경계를 넓히지 않는다.
+- `main`은 메인터너 고유 릴리즈 브랜치이므로 변경하지 않는다.
+- merge 뒤 #3406의 close 상태를 확인한다. default branch가 `main`이므로 `Closes #3406`만으로
+  auto-close되지 않으면 devel sync 뒤 승인된 수동 close/comment 경로를 적용한다.
+
+## 최종 권고
+
+**merge 권고**. 최종 조건은 이 문서 추가 뒤의 최신 PR head에서 CI, CodeQL, Render Diff가 모두 통과하고,
+`MERGEABLE`/비차단 상태를 재확인하며, 작업지시자의 merge 승인을 받는 것이다.

--- a/mydocs/working/task_m100_3406_stage1.md
+++ b/mydocs/working/task_m100_3406_stage1.md
@@ -1,0 +1,29 @@
+# #3406 단계 1 완료 — devel 동일 저장소 PR stale run reaper 구현
+
+- 이슈: [#3406](https://github.com/edwardkim/rhwp/issues/3406)
+- 브랜치: `task/3406-ci-force-cancel`
+- 기준: `upstream/devel` `91bd61758`
+
+## 완료 내용
+
+`devel` 대상의 동일 저장소 PR에서 Update branch가 `synchronize` event를 만들면, 전용 reaper가 같은
+PR 번호의 active `pull_request` run 중 live head SHA와 다른 run을 force-cancel하도록 구현했다. workflow는
+PR source를 checkout하거나 shell·PR 제공 script를 실행하지 않으며 GitHub API만 사용한다.
+
+취소 직전 live PR head를 다시 읽으므로, 연속 Update branch에서 먼저 시작된 reaper가 이후 최신 SHA run을
+취소하지 않는다. 기존 CI·CodeQL·Render Diff의 concurrency 설정과 job 구성은 변경하지 않았다.
+
+`main`은 메인터너 전용 릴리즈 브랜치이므로 변경하지 않는다. GitHub가 external fork의 `pull_request` token
+write 권한을 읽기 전용으로 낮추는 경우에는 job을 의도적으로 skip하며, 이 경우 review 절차의 수동
+force-cancel API를 사용한다.
+
+## 정적 검증
+
+- `actionlint .github/workflows/cancel-stale-pr-runs.yml` 성공
+- Ruby YAML parse 성공
+- embedded GitHub Script `node --check` 성공
+- `git diff --check` 성공
+
+Rust·WASM·frontend·fixture 변경은 없으므로 Cargo·WASM·시각 검증은 이 단계 범위에 해당하지 않는다. 다음
+단계에서 `jangster77/rhwp`의 동일 저장소 head 격리 PR로 실제 `pull_request` write-token reaper를
+Update branch와 함께 재검증한다.

--- a/mydocs/working/task_m100_3406_stage2.md
+++ b/mydocs/working/task_m100_3406_stage2.md
@@ -1,0 +1,34 @@
+# #3406 단계 2 완료 — 동일 저장소 `pull_request` 실제 Update branch 검증
+
+- 이슈: [#3406](https://github.com/edwardkim/rhwp/issues/3406)
+- 구현 브랜치: `task/3406-ci-force-cancel`
+- 격리 검증 PR: [jangster77/rhwp#9](https://github.com/jangster77/rhwp/pull/9)
+
+## 검증 방법
+
+`jangster77/rhwp` 안의 서로 다른 test base/head branch로 PR을 만들었다. production workflow와 같은
+`pull_request` API reaper를 source에 두고, 기존 CI·CodeQL·Render Diff가 실제로 시작된 상태에서 base를
+한 commit 전진시킨 뒤 GitHub **Update branch**를 실행했다.
+
+기존 `pull_request_target` 검증 workflow는 이 test base와 다른 branch 조건이라 job이 `skipped`되었다.
+따라서 결과는 이번 `pull_request` reaper만의 결과다.
+
+## 결과
+
+| 구분 | SHA / run | 결과 |
+| --- | --- | --- |
+| 이전 head | `db82b24` | CI `30198327109`, CodeQL `30198327121`, Render Diff `30198327120` 모두 `completed/cancelled` |
+| Update branch head | `4a049c8` | CI `30198335775`, CodeQL `30198335764`, Render Diff `30198335768` 자동 재시작 |
+| reaper | [run 30198335771](https://github.com/jangster77/rhwp/actions/runs/30198335771) | success; 이전 run 3개 force-cancel 로그 확인 |
+| 비개입 확인 | [run 30198334829](https://github.com/jangster77/rhwp/actions/runs/30198334829) | 기존 `pull_request_target` reaper job `skipped` |
+
+reaper 로그는 `Current head 4a049c8…; force-cancelled 3 stale run(s).`을 기록했다. 이로써 `devel` 대상
+동일 저장소 PR에서 필요한 `actions: write` 권한과 live head 재확인·force-cancel 경로가 실제로 동작함을
+확인했다.
+
+## 경계 확인
+
+- production `main`은 변경하지 않았다.
+- external fork PR은 GitHub의 read-only token 제약을 우회하지 않는다. workflow job이 skip되고
+  `multi_pr_update_branch.md`의 수동 force-cancel 절차가 fallback이다.
+- PR source checkout, shell step, PR 제공 script 실행은 없다.


### PR DESCRIPTION
Closes #3406

## 변경

- `devel` 대상의 동일 저장소 PR에서 Update branch(`synchronize`) 뒤 이전 SHA의 active `pull_request` run을 자동 force-cancel하는 `Cancel stale PR runs` workflow를 추가했습니다.
- 같은 PR 번호만 대상으로 하고, 각 취소 직전에 live head를 다시 확인해 최신 SHA run은 취소하지 않습니다.
- PR source checkout·shell·PR 제공 script 실행 없이 GitHub API만 호출하며, 권한은 `actions: write`, `contents: read`, `pull-requests: read`로 제한했습니다.
- external fork PR은 GitHub의 read-only token 제약을 우회하지 않고 reaper를 skip하며, 기존 수동 force-cancel 절차를 fallback으로 문서화했습니다.

## 검증

- 격리 fork PR [#9](https://github.com/jangster77/rhwp/pull/9): 이전 SHA의 CI·CodeQL·Render Diff 3개가 `cancelled`, Update branch 새 SHA의 세 run이 자동 재시작. [reaper 증적](https://github.com/jangster77/rhwp/actions/runs/30198335771)
- `actionlint .github/workflows/cancel-stale-pr-runs.yml`
- Ruby YAML parse 및 embedded GitHub Script `node --check`
- `python3 scripts/check_markdown_links.py --changed-from upstream/devel`
- `git diff --check`

Rust·WASM·frontend·fixture 변경은 없어 Cargo·WASM·시각 검증 대상이 아닙니다.