### PR TITLE
fix(search): search/grep 가 수식(Equation) 스크립트 텍스트를 검색 대상에서 빠뜨리던 결함 수정

### DIFF
--- a/src/document_core/queries/grep.rs
+++ b/src/document_core/queries/grep.rs
@@ -42,6 +42,9 @@ pub struct GrepMatch {
     /// 글상자 안의 매치면 글상자 좌표. 본문·표 셀 매치면 생략된다.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub textbox: Option<TextBoxRef>,
+    /// 수식 스크립트 안의 매치면 수식 좌표. 본문·표 셀·글상자 매치면 생략된다.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub equation: Option<EquationRef>,
 }
 
 /// 표 셀 매치의 좌표.
@@ -62,6 +65,13 @@ pub struct TextBoxRef {
     pub control: usize,
     /// 글상자 안의 문단 인덱스.
     pub paragraph: usize,
+}
+
+/// 수식 매치의 좌표.
+#[derive(Debug, Clone, Serialize)]
+pub struct EquationRef {
+    /// 수식을 담은 본문 문단의 컨트롤 인덱스.
+    pub control: usize,
 }
 
 /// 매치 주변 발췌를 만든다 (앞뒤 `WINDOW` 문자).
@@ -131,7 +141,8 @@ impl DocumentCore {
                 let make = |text: &str,
                             offset: usize,
                             cell: Option<CellRef>,
-                            textbox: Option<TextBoxRef>| GrepMatch {
+                            textbox: Option<TextBoxRef>,
+                            equation: Option<EquationRef>| GrepMatch {
                     section: sec_idx,
                     paragraph: para_idx,
                     page,
@@ -141,10 +152,11 @@ impl DocumentCore {
                     context: make_context(text, offset, qlen),
                     cell,
                     textbox,
+                    equation,
                 };
 
                 for offset in super::search_query::find_matches(&para.text, query, case_sensitive) {
-                    out.push(make(&para.text, offset, None, None));
+                    out.push(make(&para.text, offset, None, None, None));
                     if limit.is_some_and(|n| out.len() >= n) {
                         return out;
                     }
@@ -168,6 +180,7 @@ impl DocumentCore {
                                                 cell: cell_idx,
                                                 paragraph: cp_idx,
                                             }),
+                                            None,
                                             None,
                                         ));
                                         if limit.is_some_and(|n| out.len() >= n) {
@@ -195,11 +208,31 @@ impl DocumentCore {
                                                 control: ctrl_idx,
                                                 paragraph: tp_idx,
                                             }),
+                                            None,
                                         ));
                                         if limit.is_some_and(|n| out.len() >= n) {
                                             return out;
                                         }
                                     }
+                                }
+                            }
+                        }
+                        // 수식 스크립트 — 렌더 트리(EquationNode)가 아니라 IR을 직접 순회하므로
+                        // #3419(export-text/markdown 쪽 수식 텍스트화)와는 별개 경로였다.
+                        // 표 셀·글상자와 동일하게 본문 문단 순회 중 함께 검색한다.
+                        Control::Equation(eq) => {
+                            for offset in
+                                super::search_query::find_matches(&eq.script, query, case_sensitive)
+                            {
+                                out.push(make(
+                                    &eq.script,
+                                    offset,
+                                    None,
+                                    None,
+                                    Some(EquationRef { control: ctrl_idx }),
+                                ));
+                                if limit.is_some_and(|n| out.len() >= n) {
+                                    return out;
                                 }
                             }
                         }
@@ -209,5 +242,28 @@ impl DocumentCore {
             }
         }
         out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// [#3413] CLI `rhwp search` 는 `DocumentCore::grep` 을 호출한다(`wasm_api::HwpDocument::grep`
+    /// 경유). 이 경로가 본문/표 셀/글상자만 순회하고 수식(Equation) 컨트롤의 script 텍스트를
+    /// 빠뜨려 `search exam_math.hwp "lim" --json` 이 matchCount=0 을 반환하던 버그의 회귀 테스트.
+    #[test]
+    fn grep_finds_equation_script() {
+        let data = std::fs::read("samples/exam_math.hwp").expect("샘플 파일 읽기 실패");
+        let doc = DocumentCore::from_bytes(&data).expect("샘플 파일 파싱 실패");
+        let matches = doc.grep("lim", true, None);
+        assert!(
+            !matches.is_empty(),
+            "수식 스크립트 안의 'lim' 매치를 찾지 못함"
+        );
+        assert!(
+            matches.iter().any(|m| m.equation.is_some()),
+            "매치 중 equation 컨텍스트가 있는 항목이 없음: {matches:?}"
+        );
     }
 }

--- a/src/document_core/queries/search_query.rs
+++ b/src/document_core/queries/search_query.rs
@@ -150,6 +150,20 @@ fn search_all(doc: &DocumentCore, query: &str, case_sensitive: bool) -> Vec<Sear
                             }
                         }
                     }
+                    // 수식 스크립트 — 렌더 트리(EquationNode)가 아니라 IR을 직접 순회하므로
+                    // #3419(export-text/markdown 쪽 수식 텍스트화)와는 별개 경로. 셀/글상자와
+                    // 동일하게 cell_context 로 표시해 커서 이동 대상에서는 제외한다.
+                    Control::Equation(eq) => {
+                        for offset in find_in_text(&eq.script, query, case_sensitive) {
+                            results.push(SearchHit {
+                                sec: sec_idx,
+                                para: para_idx,
+                                char_offset: offset,
+                                length: qlen,
+                                cell_context: Some((para_idx, ctrl_idx, 0, 0)),
+                            });
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -524,5 +538,22 @@ mod tests {
     fn find_in_text_korean() {
         assert_eq!(find_in_text("안녕하세요 세계", "세계", true), vec![6]);
         assert_eq!(find_in_text("가나가나", "가나", true), vec![0, 2]);
+    }
+
+    /// [#3413] `search` 가 수식(Equation) 컨트롤의 script 텍스트를 검색 대상에서
+    /// 빠뜨리던 버그 회귀 테스트. 실제 표본(`samples/exam_math.hwp`)의 수식에는
+    /// `lim` 이 포함돼 있는데도 이전 코드는 matchCount=0 을 반환했다.
+    #[test]
+    fn search_all_text_finds_equation_script() {
+        let data = std::fs::read("samples/exam_math.hwp").expect("샘플 파일 읽기 실패");
+        let doc = DocumentCore::from_bytes(&data).expect("샘플 파일 파싱 실패");
+        let json = doc
+            .search_all_text_native("lim", true, true)
+            .expect("검색 실패");
+        assert!(
+            json.contains("\"charOffset\""),
+            "수식 스크립트 내 'lim' 매치를 찾지 못함: {json}"
+        );
+        assert_ne!(json, "[]", "수식 스크립트 내 'lim' 매치가 비어있음");
     }
 }


### PR DESCRIPTION
## 증상

\`rhwp search exam_math.hwp "lim" --json\` 이 \`matchCount:0\` 을 반환한다.
\`dump --section 0\` 으로 확인하면 수식 컨트롤 script 에 텍스트가 실제로
존재하는데도 검색되지 않는다.

```
$ rhwp dump samples/exam_math.hwp --section 0 | grep -i 수식
  [1] 수식: script=" lim _{h ``rarrow`` 0} {f left(2+h  right)-f left(2  right)} over {h}`" ...
  [1] 수식: script=" lim _{x ``rarrow``  alpha} {f left(2 x+1  right)} over {f left(x  right)}`" ...
```

## 근본 원인

CLI \`search\` 커맨드는 \`DocumentCore::grep\`(\`src/document_core/queries/grep.rs\`)을
호출하는데, 이 함수는 문서 IR을 직접 순회하면서 본문 문단·표 셀
(\`Control::Table\`)·글상자(\`Control::Shape\`) 만 검색하고 수식
(\`Control::Equation\`)의 \`script\` 필드는 아예 건드리지 않았다.

#3419 는 렌더 트리(\`EquationNode.script\`, \`export-text\`/markdown 경로)의
수식 텍스트화만 고쳤을 뿐, **IR을 직접 순회하는 이 검색 경로는 손대지
않아** 별개로 남아있던 버그다. \`search_query.rs::search_all\`
(치환/커서 이동에 쓰이는 별도 진입점)도 동일한 누락이 있어 함께 수정했다.

## 수정

두 순회 루프(\`grep.rs\`, \`search_query.rs\`)에 \`Control::Equation\` 분기를
추가해 \`eq.script\` 를 표 셀/글상자와 동일한 패턴으로 검색 대상에
포함시켰다. \`grep.rs\` 에는 \`EquationRef { control }\` 좌표를
\`GrepMatch.equation\` 필드로 추가해 JSON 응답에서 어떤 수식 컨트롤에서
매치됐는지 식별 가능하게 했다.

## 검증 (실제 CLI 출력, samples/exam_math.hwp)

**수정 전:**
```json
{"caseSensitive":true,"matchCount":0,"matches":[],"query":"lim","schemaVersion":"1.0","source":"samples/exam_math.hwp"}
```

**수정 후:**
```json
{"caseSensitive":true,"matchCount":6,"matches":[{"charOffset":1,"context":" lim _{h \`\`rarrow\`\` 0} {f left(2+h  right)-f…","equation":{"control":1},"length":3,"page":0,"paragraph":18,"section":0,"text":" lim _{h \`\`rarrow\`\` 0} {f left(2+h  right)-f left(2  right)} over {h}\`"}, ... 총 6건]}
```

\`samples/equation-lim.hwp\` 도 동일 패턴으로 \`matchCount:0 → 1\` 확인.

## 테스트

- \`grep.rs::tests::grep_finds_equation_script\` (신규) — CLI가 실제로 타는 경로
- \`search_query.rs::tests::search_all_text_finds_equation_script\` (신규) — 치환/커서
  이동에 쓰이는 별도 진입점
- \`cargo test --profile release-test --lib\` 통과 확인

관련 #3413 (해당 이슈의 일부 범위만 다룸 — 이슈는 닫지 않음)