### PR TITLE
fix(extension): 인쇄 surface print.html 을 확장 빌드에 복사 (#3433)

### DIFF
--- a/mydocs/orders/20260726.md
+++ b/mydocs/orders/20260726.md
@@ -1,5 +1,25 @@
 # 오늘 할일 - 2026년 7월 26일
 
+## #3433 — 확장 인쇄 실패: print.html 빌드 복사 누락 (진행중)
+
+작업지시자가 v0.8.1 배포 확인 중 Firefox·Chrome 양쪽에서 인쇄 실패를 보고했다.
+
+- 현상: `moz-extension://<id>/print.html` 을 찾을 수 없음. Chrome 도 동일(번들 원문 노출,
+  스택 `assets/viewer-CruV-ONE.js:66`).
+- 원인: `rhwp-studio/public/print.html` 이 확장 dist 에 복사되지 않는다. 확장은
+  `vite publicDir:false` 라 `build.mjs` 가 개별 복사해야 하는데 `theme-init.js`·
+  `favicon.ico`·아이콘 SVG 만 대상이고 `print.html` 이 빠졌다. 실측: 0.8.1 zip 양쪽 모두
+  `print.html` 0건.
+- `print.html` 은 인라인 CSS 만 쓰는 자족 파일(1.4KB)이라 추가 의존 자산이 없다.
+- `public/` 전수 대조 결과 진짜 누락은 `print.html` 하나다. WASM 계열은 `dist/wasm/` 으로
+  별도 복사되고 `samples/` 는 의도된 제외다.
+- `web_accessible_resources` 등재는 불필요 — 뷰어와 `print.html` 이 같은 확장 origin 이다
+  (그 목록은 외부 웹페이지 접근용).
+- 영향: `print.html`·`print-surface.ts` 가 같은 커밋 `b7234ed07`(2026-07-23)에서 도입됐고
+  이후 `build.mjs` 는 폰트·theme-init 만 수정됐다. **v0.8.0 부터 미동작으로 추정**하나
+  v0.8.0 zip 실물 대조는 하지 않아 미확정이다.
+- 후속: 수정 후 **0.8.2 핫픽스** 필요(0.8.1 은 이미 3개 스토어 제출됨).
+
 ## #3326 — v0.8.0 릴리즈 main 통합 (완료)
 
 - 릴리즈 준비 PR [#3327](https://github.com/edwardkim/rhwp/pull/3327) CI 전 항목 green으로

--- a/rhwp-chrome/build.mjs
+++ b/rhwp-chrome/build.mjs
@@ -94,6 +94,11 @@ copy(resolve(__dirname, '_locales'), resolve(DIST, '_locales'));
 // 확장 CSP('self')는 인라인을 금지하므로 인라인 대신 이 외부 파일을 쓴다.
 copy(resolve(ROOT, 'rhwp-studio', 'public', 'theme-init.js'), resolve(DIST, 'theme-init.js'));
 
+// [#3433] 인쇄 surface. print-surface.ts 가 'print.html' 을 확장 루트 기준 상대 경로로
+// 열므로(new URL(surfacePath, baseUrl)) dist 최상위에 있어야 한다. 같은 확장 origin 이라
+// web_accessible_resources 등재는 불필요하다.
+copy(resolve(ROOT, 'rhwp-studio', 'public', 'print.html'), resolve(DIST, 'print.html'));
+
 // rhwp-studio 리소스 (CSS에서 참조)
 mkdirSync(resolve(DIST, 'images'), { recursive: true });
 copy(resolve(ROOT, 'rhwp-studio', 'public', 'images', 'icon_small_ko.svg'), resolve(DIST, 'images', 'icon_small_ko.svg'));
@@ -120,6 +125,24 @@ for (const font of fontFiles) {
   copy(resolve(fontDir, font), resolve(DIST, 'fonts', font));
 }
 console.log(`  woff2 ${fontFiles.length}개 복사`);
+
+// [#3433] 필수 산출물 게이트. copy() 는 원본이 없으면 SKIP 경고만 내고 넘어가므로,
+// public/ 자산 누락이 빌드 성공으로 위장된다(print.html 이 v0.8.0~0.8.1 에서 이렇게 빠졌다).
+// 런타임이 반드시 요구하는 파일만 여기서 확인하고, 없으면 빌드를 실패시킨다.
+const REQUIRED_DIST_FILES = [
+  'manifest.json',
+  'viewer.html',
+  'print.html', // print-surface.ts 가 확장 루트 기준으로 연다
+  'theme-init.js',
+  'wasm/rhwp.js',
+  'wasm/rhwp_bg.wasm',
+];
+const missing = REQUIRED_DIST_FILES.filter((f) => !existsSync(resolve(DIST, f)));
+if (missing.length > 0) {
+  console.error('\n=== 빌드 실패: 필수 산출물 누락 ===');
+  for (const f of missing) console.error(`  MISSING: ${f}`);
+  process.exit(1);
+}
 
 console.log('\n=== 빌드 완료 ===');
 console.log(`출력: ${DIST}`);

--- a/rhwp-firefox/build.mjs
+++ b/rhwp-firefox/build.mjs
@@ -90,6 +90,10 @@ mkdirSync(resolve(DIST, 'images'), { recursive: true });
 // [#1444] 다크테마 FOUC 방지 스크립트 (vite publicDir:false 라 개별 복사). 확장 CSP('self')
 // 가 인라인을 금지하므로 viewer.html 의 <script src="/theme-init.js"> 대상 파일을 둔다.
 copy(resolve(ROOT, 'rhwp-studio', 'public', 'theme-init.js'), resolve(DIST, 'theme-init.js'));
+// [#3433] 인쇄 surface. print-surface.ts 가 'print.html' 을 확장 루트 기준 상대 경로로
+// 열므로(new URL(surfacePath, baseUrl)) dist 최상위에 있어야 한다. 같은 확장 origin 이라
+// web_accessible_resources 등재는 불필요하다.
+copy(resolve(ROOT, 'rhwp-studio', 'public', 'print.html'), resolve(DIST, 'print.html'));
 copy(resolve(ROOT, 'rhwp-studio', 'public', 'images', 'icon_small_ko.svg'), resolve(DIST, 'images', 'icon_small_ko.svg'));
 // [#1444] 다크 모드 아이콘 스프라이트 (base.css 다크 테마에서 참조). 누락 시 viewer 404.
 copy(resolve(ROOT, 'rhwp-studio', 'public', 'images', 'icon_small_ko_dark.svg'), resolve(DIST, 'images', 'icon_small_ko_dark.svg'));
@@ -114,6 +118,24 @@ for (const font of fontFiles) {
   copy(resolve(fontDir, font), resolve(DIST, 'fonts', font));
 }
 console.log(`  woff2 ${fontFiles.length}개 복사`);
+
+// [#3433] 필수 산출물 게이트. copy() 는 원본이 없으면 SKIP 경고만 내고 넘어가므로,
+// public/ 자산 누락이 빌드 성공으로 위장된다(print.html 이 v0.8.0~0.8.1 에서 이렇게 빠졌다).
+// 런타임이 반드시 요구하는 파일만 여기서 확인하고, 없으면 빌드를 실패시킨다.
+const REQUIRED_DIST_FILES = [
+  'manifest.json',
+  'viewer.html',
+  'print.html', // print-surface.ts 가 확장 루트 기준으로 연다
+  'theme-init.js',
+  'wasm/rhwp.js',
+  'wasm/rhwp_bg.wasm',
+];
+const missing = REQUIRED_DIST_FILES.filter((f) => !existsSync(resolve(DIST, f)));
+if (missing.length > 0) {
+  console.error('\n=== 빌드 실패: 필수 산출물 누락 ===');
+  for (const f of missing) console.error(`  MISSING: ${f}`);
+  process.exit(1);
+}
 
 console.log('\n=== 빌드 완료 ===');
 console.log(`출력: ${DIST}`);


### PR DESCRIPTION
## 문제

Chrome·Firefox 양쪽 확장에서 인쇄(Ctrl+P)가 실패한다.

```
파일을 찾을 수 없음
Firefox가 moz-extension://<id>/print.html 에서 파일을 찾을 수 없습니다.
```

Closes #3433

## 원인

`print-surface.ts` 가 `print.html` 을 확장 루트 기준 상대 경로로 열지만
(`new URL(surfacePath, baseUrl)`), `build.mjs` 가 그 파일을 `dist` 에 복사하지 않았다.

확장은 `vite publicDir:false` 라 `rhwp-studio/public/` 자산을 `build.mjs` 가 개별 복사해야
하는데, 대상이 `theme-init.js`·`favicon.ico`·아이콘 SVG 뿐이고 `print.html` 이 빠져 있었다.

실측:

```bash
unzip -l rhwp-chrome/rhwp-chrome-0.8.1.zip | grep -i print   # 0건
unzip -l rhwp-firefox/rhwp-firefox-0.8.1.zip | grep -i print # 0건
```

웹 버전(GitHub Pages)은 vite 가 `public/` 을 서빙하므로 정상이다.

## 변경

**1. `print.html` 복사 추가** — `rhwp-chrome/build.mjs`, `rhwp-firefox/build.mjs`

`web_accessible_resources` 등재는 하지 않는다. 뷰어와 `print.html` 이 같은 확장 origin 이라
iframe 로드에 필요하지 않다(그 목록은 외부 웹페이지 접근용).

**2. 필수 산출물 게이트 추가**

`copy()` 는 원본이 없으면 `SKIP (not found)` 경고만 내고 넘어가므로 **누락이 빌드 성공으로
위장된다.** `print.html` 이 v0.8.0 도입(`b7234ed07`) 이래 이렇게 빠져 있었다. 빌드 말미에
런타임 필수 6종(`manifest.json`, `viewer.html`, `print.html`, `theme-init.js`,
`wasm/rhwp.js`, `wasm/rhwp_bg.wasm`)의 존재를 확인하고 없으면 `exit 1` 로 실패시킨다.

기존 print 테스트 15개는 URL 계산·명령 계약만 검증해 산출물 누락을 잡지 못했다. 이 게이트가
그 빈틈을 메운다.

## 검증

| 항목 | 결과 |
|---|---|
| chrome/firefox dist | `print.html` 1436 bytes 복사 확인 |
| **게이트 동작 실증** | 원본 임시 제거 후 빌드 → `MISSING: print.html`, exit 1 |
| studio `npm test` | **641 pass / 0 fail** |
| print 단위 테스트 | 15 pass |
| E2E `print-pdf-issue3126` | **10항목 PASS** ("인쇄 미리보기 전용 print.html" 포함) |
| **확장 실기 인쇄** | 빌드된 dist 를 브라우저에 로드해 **정상 동작 확인**(작업지시자) |

게이트는 추가에 그치지 않고 실제로 누락을 잡는지 실증했다.

## 영향 범위

`print.html` 과 `print-surface.ts` 가 같은 커밋에서 도입된 뒤 `build.mjs` 는 폰트·theme-init
관련만 수정됐다. **v0.8.0~0.8.1 확장에서 인쇄가 동작하지 않았다.** 다만 v0.8.0 zip 실물
대조는 하지 않았다.

Rust 소스 무변경이라 cargo 검증은 대상이 아니다.

## 후속

v0.8.2 핫픽스([#3445](https://github.com/edwardkim/rhwp/issues/3445))로 배포한다.