### PR TITLE
chore: 기여 PR 게이트 누적 cleanup (2026-07-27 회차)

### DIFF
--- a/.github/actions/install-wasm-pack/action.yml
+++ b/.github/actions/install-wasm-pack/action.yml
@@ -25,7 +25,12 @@ runs:
           # [#3289] 고정 /tmp 경로는 동시 잡 간 전개 충돌 — mktemp 로 격리하고,
           # 설치는 같은 디렉터리 임시명 → rename(원자적 교체)으로 부분 바이너리 노출을 막는다.
           tmpdir="$(mktemp -d)"
-          curl -sSfL "$URL" | tar -xzf - -C "$tmpdir"
+          # [#3431] 파이프가 아니라 파일로 먼저 받는다 — curl 이 전송 중 끊겨 재시도하면
+          # 스트림을 처음부터 다시 흘리므로, tar 가 이미 읽고 있던 파이프에는 앞선 조각이
+          # 남아 gzip 이 깨진다. 파일로 받으면 재시도가 실제로 이득이 된다.
+          curl -sSfL --retry 5 --retry-delay 2 --retry-connrefused \
+            -o "$tmpdir/wasm-pack.tar.gz" "$URL"
+          tar -xzf "$tmpdir/wasm-pack.tar.gz" -C "$tmpdir"
           # [#3284] sudo 없이 사용자 경로(~/.cargo/bin)에 배치 — self-hosted 러너의
           # 제한된 sudo(apt 한정)와 호스티드 러너 양쪽에서 동일하게 동작한다.
           mkdir -p "$install_dir"


### PR DESCRIPTION
기여 PR 자체 게이트에서 나온 **P2 미만** findings 를 원인별로 모아 두는 누적 draft 입니다. feature PR 을 최소로 유지하려고 소스 PR 에는 넣지 않고 여기 쌓습니다. 묶음이 익으면 개별 PR 로 승격하고 이 draft 는 완결 배너와 함께 닫습니다.

대상 게이트 회차: #3423 · #3444 · #3452 · #3455 (2026-07-27)

## 클러스터 A — 다운로드·재시도 견고화

- [x] **`curl --retry` 를 파이프에 물리면 재시도가 실효를 못 낸다** — 전송 중 끊김에서 curl 은 스트림을 처음부터 다시 흘리는데, 파이프 건너편 `tar` 는 이미 앞선 조각을 읽은 상태라 gzip 이 깨진다. 파일로 받은 뒤 풀도록 고침 (이 draft 의 첫 커밋).
  - 출처: #3444 리뷰. #3444 가 먼저 병합되면 이 커밋을 그 위로 rebase 해 파일 방식만 남긴다.

## 클러스터 B — 문서 포인터 정확도

- [ ] **CLAUDE.md 의 검증 게이트 링크에 앵커가 없다** — 본문은 "`local_validation.md` 의 4.3" 이라고 안내하면서 링크는 파일 최상단으로 간다. `#43-변경-범위별-기본-검증` 앵커를 붙여야 안내한 절로 바로 간다.
  - 출처: #3423 리뷰. **#3423 병합 후 적용 가능** — 해당 줄이 아직 devel 에 없다.

## 저자 판단이 필요한 항목

없음.

## 이 회차에서 P2 로 올라가 소스 PR 에 게시한 것

- #3455 — 그림 prefetch 서명이 문서 로드에서 비워지지 않아, 문서를 갈아 열면 같은 `bin_data_id` 를 쓰는 다른 그림의 prefetch 가 건너뛰어진다. 인라인 스레드에 근거와 수정 방향을 남겼습니다.

## 게이트에서 기각된 후보

- `write_json_base64` 가 `document_core::helpers` 에 있고 `paint::json` 이 쓰는 것 — 층위 문제로 잡았다가 철회. 같은 모듈의 `json_escape` 가 이미 같은 방식으로 쓰이고 있어 선례와 일치하며, JSON 쓰기 헬퍼가 그 자리에 있는 것은 일관적이다. `source_image_key` 를 `paint/resources.rs` 로 옮긴 것과는 성격이 다르다(그쪽은 키 = 신원 개념).
