### PR TITLE
test(studio/#3450): PDF 안내 모달 E2E 를 프로필 상태에 무관하게 멱등화

### DIFF
--- a/rhwp-studio/e2e/print-pdf-issue3126.test.mjs
+++ b/rhwp-studio/e2e/print-pdf-issue3126.test.mjs
@@ -12,9 +12,31 @@
  */
 import { execFileSync } from 'child_process';
 import { mkdirSync } from 'fs';
-import { runTest, loadHwpFile, assert } from './helpers.mjs';
+import { runTest, loadApp, loadHwpFile, assert } from './helpers.mjs';
 
 const OUTPUT_DIR = '../output/e2e/issue-3126';
+
+/**
+ * PDF 안내 표시 설정을 localStorage 에 직접 심는다 (앱 재초기화 없음).
+ *
+ * [#3450] 이 설정은 `rhwp-settings` 에 영속되고 UserSettingsService 는 앱 초기화
+ * 시점에 한 번만 읽는다. 안내 숨김 케이스가 값을 false 로 남기면 **다음 실행**의
+ * 앞선 케이스들이 안내 없는 흐름(즉시 준비 모달)으로 시작해, 안내 모달 관련 단언만
+ * 실패한다. host 모드는 사용자 Chrome 프로필에 붙으므로 그 값이 실행 사이에 남는다.
+ */
+async function writePdfGuidancePreference(page, show) {
+  await page.evaluate((shouldShow) => {
+    const raw = JSON.parse(localStorage.getItem('rhwp-settings') || '{}');
+    raw.dialog = { ...(raw.dialog || {}), showPdfPrintGuidance: shouldShow };
+    localStorage.setItem('rhwp-settings', JSON.stringify(raw));
+  }, show);
+}
+
+/** 안내 표시 설정을 심고 앱을 다시 초기화해 그 값으로 시작하게 한다. */
+async function applyPdfGuidancePreference(page, show) {
+  await writePdfGuidancePreference(page, show);
+  await loadApp(page);
+}
 
 async function installPrintCapture(page) {
   await page.evaluate(() => {
@@ -267,6 +289,7 @@ function assertSharedPdfContract(menu, dialog, result) {
 }
 
 await runTest('#3126 PDF 경로 — #2524 embedded bitmap/SVG font 회귀', async ({ page, browser }) => {
+  await applyPdfGuidancePreference(page, true);
   const load = await loadHwpFile(page, 'render-p35-font-native-bitmap.hwpx');
   await installPrintCapture(page);
   const menu = await clickPdfMenuItem(page);
@@ -299,6 +322,7 @@ await runTest('#3126 PDF 경로 — #2524 embedded bitmap/SVG font 회귀', asyn
 });
 
 await runTest('#3126 PDF 경로 — #2525 다중 페이지/검색 텍스트 회귀', async ({ page, browser }) => {
+  await applyPdfGuidancePreference(page, true);
   const load = await loadHwpFile(page, 'hwpx/hwpx-02.hwpx');
   assert(load.pageCount > 1, '#2525 fixture는 다중 페이지');
   await installPrintCapture(page);
@@ -324,6 +348,7 @@ await runTest('#3126 PDF 경로 — #2525 다중 페이지/검색 텍스트 회�
 });
 
 await runTest('#3126 PDF 경로 — 안내 숨김 저장과 복원 가능한 직접 준비 흐름', async ({ page }) => {
+  await applyPdfGuidancePreference(page, true);
   await loadHwpFile(page, 'render-p35-font-native-bitmap.hwpx');
   await installPrintCapture(page);
   const firstMenu = await clickPdfMenuItem(page);
@@ -350,6 +375,11 @@ await runTest('#3126 PDF 경로 — 안내 숨김 저장과 복원 가능한 직
   );
   assert(!secondResult.capture.pdfDialogVisibleAtPrint, 'print() 전에 직접 준비 모달 제거');
   assert(secondResult.after.surfaceRemoved, '두 번째 실행 뒤 iframe 정리');
+
+  // [#3450] 이 케이스가 남긴 안내 숨김 설정을 프로필에서 원복한다. 각 케이스가
+  // 시작 시 값을 심으므로 이중 안전장치지만, 실행 뒤 프로필을 처음 상태로 돌려
+  // 다른 스위트·수동 확인이 이 실행에 오염되지 않게 한다.
+  await writePdfGuidancePreference(page, true);
 });
 
 async function clickPrintMenuItem(page) {


### PR DESCRIPTION
﻿## 요약

#3450 의 `print-pdf-issue3126` E2E 실패 4건은 **제품 결함이 아니라 스위트가 멱등하지 않아서**다.
같은 Chrome 프로필로 두 번째 실행부터 결정적으로 실패한다. 원인을 실증하고 스위트를 고쳤다.

## 근인

1. 세 번째 케이스(`안내 숨김 저장과 복원 가능한 직접 준비 흐름`)가 `hideFutureGuidance: true` 로
   실행해 `localStorage.rhwp-settings.dialog.showPdfPrintGuidance = false` 를 저장한다.
   테스트는 저장 사실을 단언까지 하지만(`안내 숨김 설정을 rhwp-settings에 저장`) **원복하지 않는다.**
2. `UserSettingsService` 는 싱글턴이고 이 값을 **앱 초기화 때 한 번만** 읽는다
   (`src/core/user-settings.ts` — 생성자에서 `load()`).
3. `showGuidance=false` 면 `PdfPrintDialog.showAsync()` 가 곧바로 `beginPreparing()` 을 호출한다
   (`src/ui/pdf-print-dialog.ts:159`). 그 결과 `.dialog-pdf-guidance` 가
   `.dialog-pdf-preparing` CSS 로 숨겨지고, 확인 버튼 라벨이 `인쇄 창 열기` 로 세팅된 직후
   `준비 중…` 으로 덮인다.
4. `helpers.mjs` 에는 localStorage 초기화가 없고, host 모드는 사용자 Chrome 프로필에 그대로
   붙는다 → 값이 실행 사이에 살아남는다.

그래서 **안내 모달에 의존하는 단언 2개**(`sawPdfConfirmDialog`, `primaryLabel`)만
**케이스 2개**에서 실패해 정확히 **4 FAIL** 이 된다. 인쇄 surface·진행률·print() 호출 등
나머지 계약은 영향을 받지 않아 그대로 통과한다 — 이슈에 기록된 증상과 일치한다.

## 실증

headless + 고정 `--user-data-dir` 로 프로필을 유지하며 연속 실행했다.

| 실행 | 수정 전 | 수정 후 |
|---|---|---|
| 1회차 (새 프로필) | 116 PASS, 단언 실패 0 | 116 PASS, 단언 실패 0 |
| 2회차 (같은 프로필) | **4 FAIL** — `PDF 안내 모달 표시` ×2, `PDF 모달의 명시적 확인 버튼` ×2 | 116 PASS, 단언 실패 0 |

수정 후에는 **오염된(안내 숨김이 남은) 프로필에서 시작해도** 연속 2회 모두 무실패다.

## 변경

- 케이스마다 안내 표시 설정을 localStorage 에 심고 앱을 다시 초기화해 시작 상태를 결정적으로 고정
- 안내 숨김 케이스는 끝에서 값을 원복 (다른 스위트·수동 확인 오염 방지)

제품 코드는 건드리지 않았다. `showGuidance=false` 경로 자체는 의도된 동작이고 세 번째 케이스가
이미 그 계약을 검증한다.

## 곁가지 관찰 (이 PR 범위 밖)

- `inspectPdf()` 의 `pdfinfo` 는 없으면 예외로 케이스 전체를 중단시킨다. 같은 함수의
  `pdftotext` 는 없으면 DOM 계약만 검증하고 넘어가도록 처리돼 있어 둘의 취급이 어긋난다.

Refs #3450

