### PR TITLE
fix(studio/#3412): idle 전체 pagination flush 를 작은 문서로 한정 — 대형 문서 839ms 프리즈·#2214 계약 파손 해소

### DIFF
--- a/rhwp-studio/e2e/issue-2214-page-local-repaint.test.mjs
+++ b/rhwp-studio/e2e/issue-2214-page-local-repaint.test.mjs
@@ -344,6 +344,22 @@ async function installTrace(page) {
       paginationDeferred: result?.paginationDeferred ?? null,
       cellFlowChanged: result?.cellFlowChanged ?? null,
     }));
+    // [#3412] #3254 가 도입한 단일 호출 치환 경로. IME 조합 갱신은 이제 delete+insert 가
+    // 아니라 이 한 번의 replace 로 처리된다 — 계측하지 않으면 흐름이 통째로 안 보인다.
+    wrap(wasm, 'replaceTextInCellDeferredPagination', 'wasm.replaceTextInCellDeferredPagination', (args) => ({
+      sectionIndex: args[0],
+      parentParaIndex: args[1],
+      controlIndex: args[2],
+      cellIndex: args[3],
+      cellParaIndex: args[4],
+      charOffset: args[5],
+      deleteCount: args[6],
+      textLength: String(args[7] ?? '').length,
+    }), (result) => ({
+      resultCharOffset: result?.charOffset ?? null,
+      paginationDeferred: result?.paginationDeferred ?? null,
+      cellFlowChanged: result?.cellFlowChanged ?? null,
+    }));
     wrap(wasm, 'deleteTextInCellDeferredPagination', 'wasm.deleteTextInCellDeferredPagination', (args) => ({
       sectionIndex: args[0],
       parentParaIndex: args[1],
@@ -362,6 +378,12 @@ async function installTrace(page) {
     wrap(wasm, 'exportHwp', 'wasm.exportHwp');
     wrap(wasm, 'exportHwpx', 'wasm.exportHwpx');
     wrap(wasm, 'renderPageSvg', 'wasm.renderPageSvg', (args) => ({ pageIndex: args[0] }));
+    // [#3412] 인쇄/PDF 경로는 b7234ed07 부터 profile 인자를 받는 변형을 쓴다.
+    // 옛 이름만 계측하면 인쇄 barrier 가 렌더 이벤트를 하나도 못 본다.
+    wrap(wasm, 'renderPageSvgWithProfile', 'wasm.renderPageSvgWithProfile', (args) => ({
+      pageIndex: args[0],
+      profile: args[1],
+    }));
     wrap(wasm, 'getCursorRectByPathNear', 'wasm.getCursorRectByPathNear', (args) => ({
       sectionIndex: args[0],
       parentParaIndex: args[1],
@@ -450,11 +472,12 @@ async function collectTrace(page) {
         refreshNow: count('CanvasView.refreshInvalidatedPageNow'),
         deferredInsert: count('wasm.insertTextInCellDeferredPagination'),
         deferredDelete: count('wasm.deleteTextInCellDeferredPagination'),
+        deferredReplace: count('wasm.replaceTextInCellDeferredPagination'),
         immediateDelete: count('wasm.deleteTextInCell'),
         pathDelete: count('wasm.deleteTextInCellByPath'),
         exportHwp: count('wasm.exportHwp'),
         exportHwpx: count('wasm.exportHwpx'),
-        renderPageSvg: count('wasm.renderPageSvg'),
+        renderPageSvg: count('wasm.renderPageSvg') + count('wasm.renderPageSvgWithProfile'),
         cursorRectNear: count('wasm.getCursorRectByPathNear'),
         cursorRect: count('wasm.getCursorRectByPath'),
         cursorRectInCell: count('wasm.getCursorRectInCell'),
@@ -1457,18 +1480,25 @@ async function runMultiUpdateImeSmoke(page, format, bytes) {
   assert.equal(snapshot.pagination.pending, true, `${format} IME deferred hold`);
 
   const trace = await collectTrace(page);
-  const deletes = trace.events.filter((event) => event.type === 'wasm.deleteTextInCellDeferredPagination');
-  assert.equal(trace.counts.deferredInsert, 3, `${format} IME deferred insert count`);
-  assert.equal(trace.counts.deferredDelete, 2, `${format} IME replacement delete count`);
+  // [#3412] #3254 이후 조합 갱신은 delete+insert 가 아니라 단일 replace 를 쓴다.
+  // 첫 갱신(삭제 0)만 insert 로 남고, 2·3번째가 replace 두 번이 된다.
+  const replacements = trace.events.filter(
+    (event) => event.type === 'wasm.replaceTextInCellDeferredPagination',
+  );
+  assert.equal(trace.counts.deferredInsert, 1, `${format} IME deferred insert count`);
+  assert.equal(trace.counts.deferredReplace, 2, `${format} IME deferred replacement count`);
+  assert.equal(trace.counts.deferredDelete, 0, `${format} IME standalone delete count`);
   assert.equal(trace.counts.immediateDelete, 0, `${format} IME synchronous flat delete count`);
   assert.equal(trace.counts.pathDelete, 0, `${format} IME path delete count`);
   assert.equal(trace.counts.cursorRectInCell, 0, `${format} IME anchor cursor lookup count`);
   assert.equal(trace.counts.prepareTextMutation, 3, `${format} IME effect consumption count`);
   assert.equal(trace.counts.wasmFlush, 0, `${format} IME synchronous flush count`);
-  assert.deepEqual(deletes.map((event) => event.charOffset), [
+  // 두 치환 모두 조합 anchor 에서 직전 조합 글자 1개를 지우고 새 글자로 바꾼다.
+  assert.deepEqual(replacements.map((event) => event.charOffset), [
     TARGET.charOffset,
     TARGET.charOffset,
   ]);
+  assert.deepEqual(replacements.map((event) => event.deleteCount), [1, 1]);
   for (const [index, durationMs] of durationsMs.entries()) {
     assert.ok(durationMs < 250, `${format} IME update ${index + 1} blocked ${durationMs.toFixed(2)}ms`);
   }
@@ -1808,11 +1838,29 @@ async function runSaveBarrierSmoke(page, format, bytes) {
 async function runPrintBarrierSmoke(page, format, bytes) {
   const before = await preparePendingBoundary(page, format, bytes);
   await page.evaluate(() => {
+    // [#3412] 인쇄 미리보기는 별도 창(print.html surface)을 열고 load 이벤트·origin·rAF 를
+    // 사용한다. 가짜 창이 document/print/close 만 갖고 있으면 createPrintPreviewSurface 가
+    // addEventListener 에서 죽어 페이지가 한 장도 안 그려진다.
     const printDocument = document.implementation.createHTMLDocument('issue-2424-print');
+    try {
+      Object.defineProperty(printDocument, 'readyState', { value: 'complete', configurable: true });
+    } catch {
+      // readyState 를 덮어쓸 수 없으면 load 이벤트 경로로 넘어간다.
+    }
+    const surfaceUrl = new URL('print.html', document.baseURI).href;
     window.__issue2424PrintWindow = {
       document: printDocument,
+      location: { href: surfaceUrl, origin: window.location.origin },
+      closed: false,
+      addEventListener() {},
+      removeEventListener() {},
+      requestAnimationFrame(callback) {
+        return window.requestAnimationFrame(callback);
+      },
       print() {},
-      close() {},
+      close() {
+        this.closed = true;
+      },
     };
     window.open = () => window.__issue2424PrintWindow;
   });
@@ -1826,7 +1874,9 @@ async function runPrintBarrierSmoke(page, format, bytes) {
   );
   const trace = await collectTrace(page);
   const flush = trace.events.find((event) => event.type === 'wasm.flushDeferredPagination');
-  const firstRender = trace.events.find((event) => event.type === 'wasm.renderPageSvg');
+  const firstRender = trace.events.find(
+    (event) => event.type === 'wasm.renderPageSvg' || event.type === 'wasm.renderPageSvgWithProfile',
+  );
   assert.ok(flush, `${format} print flush event`);
   assert.ok(firstRender, `${format} print render event`);
   assert.ok(flush.sequence < firstRender.sequence, `${format} print must flush before first page render`);
@@ -1835,11 +1885,14 @@ async function runPrintBarrierSmoke(page, format, bytes) {
 
   const output = await page.evaluate(() => ({
     pageCount: window.__issue2424PrintWindow.document.querySelectorAll('.page').length,
-    printBarLabel: window.__issue2424PrintWindow.document.querySelector('.print-bar span')?.textContent ?? '',
+    // [#3412] 402d6342c 에서 미리보기 바가 print-preview-bar/print-preview-title 로 바뀌고
+    // 라벨도 `파일명 — N쪽` 형식이 됐다.
+    printBarLabel: window.__issue2424PrintWindow.document
+      .querySelector('.print-preview-bar .print-preview-title')?.textContent ?? '',
     pending: window.__inputHandler.hasDeferredPaginationPending(),
   }));
   assert.equal(output.pageCount, before.pagination.pageCount, `${format} print final page count`);
-  assert.match(output.printBarLabel, /115페이지/, `${format} print bar page count`);
+  assert.match(output.printBarLabel, /115쪽/, `${format} print bar page count`);
   assert.equal(output.pending, false, `${format} print pending state`);
   await restoreTrace(page);
   console.log(`  print barrier: GREEN, flush→render ${output.pageCount} pages`);

--- a/rhwp-studio/e2e/issue-2214-page-local-repaint.test.mjs
+++ b/rhwp-studio/e2e/issue-2214-page-local-repaint.test.mjs
@@ -390,9 +390,12 @@ async function installTrace(page) {
       kind: args[0]?.kind,
       commandType: args[0]?.command?.type,
     }));
+    // [#3412] TextMutationEffects 의 필드는 documentPaginationPending/flowChanged 다.
+    // 예전 이름(deferredPagination/cellFlowChanged)으로 읽으면 항상 undefined→null 이
+    // 기록돼, 아래 단언들이 실제 값과 무관하게 null 로 비교된다.
     wrap(input, 'prepareTextMutationBeforeCursor', 'InputHandler.prepareTextMutationBeforeCursor', (args) => ({
-      deferredPagination: args[0]?.deferredPagination ?? null,
-      cellFlowChanged: args[0]?.cellFlowChanged ?? null,
+      deferredPagination: args[0]?.documentPaginationPending ?? null,
+      cellFlowChanged: args[0]?.flowChanged ?? null,
       paginationCompleted: args[0]?.paginationCompleted ?? null,
     }), (result) => ({ result }));
     wrap(input, 'refreshAfterOperation', 'InputHandler.refreshAfterOperation', (args) => ({

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -48,6 +48,16 @@ const DRAG_SCROLL_MAX_STEP_PX = 20;
 const PX_TO_RAW_2X = 150;
 const PX_TO_HWPUNIT = 75;
 const DOCUMENT_PAGINATION_IDLE_FLUSH_DELAY_MS = 120;
+/**
+ * [#3412] idle 자동 flush 대상 문서 크기 상한.
+ *
+ * #3248 이 idle 병합을 도입하면서 이 게이트(#2010 의 30쪽 상한)를 함께 지워 모든 문서가
+ * 120ms 정지마다 동기 전체 pagination 을 하게 됐다. 대형 문서에서는 그 flush 자체가
+ * 결함이다 — 115쪽 문서 실측으로 메인 스레드를 839ms 막고, #2214 의 재개형 러너를
+ * 취소해 페이지-로컬 리페인트 계약(flush 0)을 깬다. 큰 문서는 러너와 명시 boundary
+ * flush(undo/redo/navigation/blur/저장·인쇄)로 마감한다.
+ */
+const DOCUMENT_PAGINATION_IDLE_FLUSH_PAGE_LIMIT = 30;
 
 type FormatCopyState = {
   charProps: Partial<CharProperties>;
@@ -2464,9 +2474,21 @@ export class InputHandler {
   private scheduleDeferredPaginationFlush(): void {
     this.cancelDeferredPaginationFlush();
     this.deferredPaginationPending = true;
+    if (!this.shouldAutoFlushDeferredPagination()) return;
     this.deferredPaginationFlushTimer = setTimeout(() => {
       this.flushDeferredPaginationIfNeeded('idle-auto');
     }, DOCUMENT_PAGINATION_IDLE_FLUSH_DELAY_MS);
+  }
+
+  /**
+   * [#3412] idle 자동 flush 대상 여부.
+   *
+   * 전진 중인 재개형 잡이 있으면 idle flush 는 그 잡을 취소하고 같은 일을 동기로 다시
+   * 하는 셈이라 예약하지 않는다. 문서 크기 상한은 위 상수 주석 참조.
+   */
+  private shouldAutoFlushDeferredPagination(): boolean {
+    if (this.deferredPaginationRunner.isActive()) return false;
+    return this.wasm.pageCount <= DOCUMENT_PAGINATION_IDLE_FLUSH_PAGE_LIMIT;
   }
 
   private cancelDeferredPaginationFlush(): void {

--- a/rhwp-studio/tests/input-edit-invalidation.test.ts
+++ b/rhwp-studio/tests/input-edit-invalidation.test.ts
@@ -209,7 +209,7 @@ test('deferred pending이 실제로 있을 때만 page-local idle flush를 예�
   );
 });
 
-test('document pagination은 120ms idle과 명시 boundary에서 flush된다', () => {
+test('document pagination은 작은 문서의 120ms idle과 명시 boundary에서 flush된다', () => {
   const inputHandlerSource = readFileSync(new URL('../src/engine/input-handler.ts', import.meta.url), 'utf8');
   const keyboardSource = readFileSync(new URL('../src/engine/input-handler-keyboard.ts', import.meta.url), 'utf8');
   const textSource = readFileSync(new URL('../src/engine/input-handler-text.ts', import.meta.url), 'utf8');
@@ -219,8 +219,23 @@ test('document pagination은 120ms idle과 명시 boundary에서 flush된다', (
     inputHandlerSource,
     /const DOCUMENT_PAGINATION_IDLE_FLUSH_DELAY_MS = 120;/,
   );
-  assert.doesNotMatch(inputHandlerSource, /DEFERRED_PAGINATION_AUTO_FLUSH_PAGE_LIMIT/);
-  assert.doesNotMatch(inputHandlerSource, /shouldAutoFlushDeferredPagination/);
+  // [#3412] #3248 은 idle 병합을 도입하며 문서 크기 게이트를 지우고 그 부재를 여기서
+  // 가드로 고정했다. 그러나 대형 문서에서는 그 flush 자체가 결함이다 — 115쪽 문서에서
+  // 타이핑을 120ms 만 멈추면 동기 전체 pagination 이 839ms 동안 메인 스레드를 막고,
+  // #2214 의 재개형 러너를 취소해 페이지-로컬 리페인트 계약(flush 0)을 깬다.
+  // 그래서 idle 병합은 유지하되 대상은 작은 문서로 되돌린다. 큰 문서는 재개형 러너와
+  // 명시 boundary flush(undo/redo/navigation/blur/저장·인쇄)로 마감한다.
+  assert.match(inputHandlerSource, /const DOCUMENT_PAGINATION_IDLE_FLUSH_PAGE_LIMIT = 30;/);
+  assert.match(
+    inputHandlerSource,
+    /if \(!this\.shouldAutoFlushDeferredPagination\(\)\) return;/,
+    'idle flush 예약은 대상 판정을 통과한 문서에만 걸려야 한다',
+  );
+  assert.match(
+    inputHandlerSource,
+    /private shouldAutoFlushDeferredPagination\(\): boolean \{\s*if \(this\.deferredPaginationRunner\.isActive\(\)\) return false;\s*return this\.wasm\.pageCount <= DOCUMENT_PAGINATION_IDLE_FLUSH_PAGE_LIMIT;\s*\}/,
+    '전진 중인 resumable job 이 있으면 idle flush 는 같은 일을 동기로 되풀이하므로 예약하지 않는다',
+  );
 
   const undoStart = inputHandlerSource.indexOf('private handleUndo(): void {');
   const redoStart = inputHandlerSource.indexOf('private handleRedo(): void {');


### PR DESCRIPTION
﻿## 요약

#3412 의 `after-56-sync: cumulative flush count 2 !== 0` 은 테스트 문제가 아니라 **#3248 이
들여온 회귀**다. idle 병합을 도입하면서 문서 크기 게이트를 함께 지운 탓에, 대형 문서에서
타이핑을 120ms 만 멈추면 동기 전체 pagination 이 돌아 **메인 스레드를 839ms 막고** #2214 의
재개형 러너를 취소한다. 게이트를 복원해 idle 병합은 유지하되 대상을 작은 문서로 되돌린다.

## 근인

`141299fd7` (#3248, 2026-07-24):

```diff
-const DEFERRED_PAGINATION_AUTO_FLUSH_DELAY_MS = 10_000;
-const DEFERRED_PAGINATION_AUTO_FLUSH_PAGE_LIMIT = 30;
+const DOCUMENT_PAGINATION_IDLE_FLUSH_DELAY_MS = 120;

 private scheduleDeferredPaginationFlush(): void {
   ...
-  if (!this.shouldAutoFlushDeferredPagination()) {
-    return;
-  }
```

계측(트레이스에 호출 시작시각·소요시간·러너 호출 추가):

| 이벤트 | 시작 | 소요 |
|---|---:|---:|
| 55번째 입력 삽입 | 4306.5ms | 0.3ms |
| `afterPageLocalEdit` → 120ms 타이머 재무장 | 4356.4ms | — |
| `runner.cancel` (타이머 발화) | 4478.6ms | — |
| **`wasm.flushDeferredPagination`** | 4478.7ms | **839.3ms** |
| 56번째(경계) 입력 삽입 | 5404.5ms | 0.3ms |

flush 는 경계 입력이 아니라 **55번째 뒤 122ms 정지**에서 났고, 경계 입력은 839ms 동기 flush 가
끝난 뒤에야 들어간다. `141299fd7` 은 v0.8.1 기준선 `6814bf431` 의 조상이므로 회귀 시점도 확정된다.

## 변경

1. **`shouldAutoFlushDeferredPagination()` 복원** — 30쪽 이하 문서만 idle flush 를 예약하고,
   **전진 중인 재개형 잡이 있으면 예약하지 않는다**(같은 일을 동기로 되풀이하는 것이므로).
   큰 문서는 러너와 명시 boundary flush(undo/redo/navigation/blur/저장·인쇄)로 마감한다 —
   그 경로들은 그대로 둔다.
2. **소스 가드 갱신** — #3248 은 게이트 부재를 `tests/input-edit-invalidation.test.ts` 의
   `doesNotMatch` 로 고정해 뒀다. 그 계약을 뒤집는 변경이므로 **가드를 반대 방향으로 다시 쓰고
   근거(839ms·#2214 계약)를 주석으로 남겼다.** 이름만 바꿔 우회하지 않았다.
3. **E2E 트레이스 필드명 정정** — `installTrace` 가 `deferredPagination`/`cellFlowChanged` 를
   읽는데 실제 `TextMutationEffects` 필드는 `documentPaginationPending`/`flowChanged` 라
   항상 `null` 이 기록됐다. 1번을 고쳐도 `input 1 consumed deferred effect` 에서 즉시 실패하므로
   함께 정정했다.

## 검증

**issue-2214 E2E** (`--mode=headless`, vite dev, 115쪽 문서):

```
[HWP] focused GREEN (3 runs)
  run 1: GREEN, flush=0, steps=115, boundary=94.60ms, begin=42.70ms, stableP95=53.30ms
  run 2: GREEN, flush=0, steps=115, boundary=105.30ms, begin=47.70ms, stableP95=65.70ms
  run 3: GREEN, flush=0, steps=115, boundary=96.60ms, begin=42.80ms, stableP95=66.90ms
  ime raw stable smoke: GREEN, flush=0
  ios raw stable smoke: GREEN, flush=0
  ime raw smoke: GREEN, flush=0, steps=115
  ios raw smoke: GREEN, flush=0, steps=115
```

수정 전에는 첫 run 의 `after-56-sync` 에서 `flush=2` 로 실패했다. 계약값(flush 0 / begin 1 /
steps 115)이 그대로 복원됐다.

- studio 단위 테스트 **600 pass / 0 fail**, `tsc --noEmit` 통과
- `cell-flow-boundary`·`deferred-pagination-runner` 2종은 `node_modules/.bin/tsc` 를 `shell`
  없이 `spawnSync` 해 Windows 에서 실행 자체가 실패한다(status `null`). **이 변경 전에도 동일하게
  실패**함을 확인했다 — 별개 하니스 이슈다.

## 남은 실패 (이 PR 범위 밖, 무관 확인)

같은 스위트 뒤쪽 multi-update IME 단계가 `deferredInsert 1 !== 3` 으로 실패한다. 게이트 없이
**예전 10초 지연만 적용한 A/B 에서도 동일하게 실패**하므로 이 변경과 무관한 별개 결함이다
(종전에는 앞선 flush 단언에서 중단돼 드러나지 않았다). #3412 에 별도로 기록했다.

Refs #3412

---

## 추가 커밋 — 스위트 전 단계 완주 (0672b982)

flush 회귀를 고치자, 그동안 중단 지점 뒤에 가려져 있던 **낡은 계약 4건**이 차례로 드러났다.
모두 구현이 바뀐 뒤 테스트가 따라오지 못한 경우이고 제품 동작은 정상이다.

| 드러난 실패 | 원인 | 조치 |
|---|---|---|
| `IME deferred insert count 1 !== 3` | #3254 가 조합 갱신을 delete+insert → 단일 `replaceTextInCellDeferredPagination` 으로 바꿈 | 치환 호출 계측 추가, 기대값 insert 1 / replace 2 / delete 0 |
| 인쇄 barrier 120s 타임아웃 | 가짜 미리보기 창에 `addEventListener`·`location`·rAF 가 없어 `createPrintPreviewSurface` 가 죽음 | 실제 경로가 쓰는 창 API 를 갖춘 스텁으로 교체 |
| `print render event` 없음 | 인쇄 경로는 b7234ed07 부터 `renderPageSvgWithProfile` 사용 | profile 변형까지 계측·합산 |
| `print bar page count` 불일치 | 402d6342c 에서 `print-preview-bar`/`print-preview-title`·`N쪽` 로 변경 | 선택자·기대 문자열 현행화 |

### 최종 검증

```
[HWP]  focused GREEN (3 runs): flush=0, steps=115
       raw smoke 4종 GREEN / Backspace·Delete GREEN
       multi-update IME GREEN / IME pagination-commit GREEN
       save barrier GREEN / print barrier GREEN (flush→115쪽 렌더)
[HWPX] 동일하게 전 단계 GREEN
exit code 0
```

스위트가 **HWP·HWPX 양쪽 전 단계를 완주**한다.

### 알려진 위생 문제 (별개)

이 스위트는 브라우저 프로필 상태에 민감하다. 누적된 프로필로 재실행하면 Backspace 단계가
간헐 실패한다(같은 제품 코드로 새 프로필에서는 통과). 이 PR 범위 밖으로 남긴다.
