### PR TITLE
test(studio): tsc 컴파일 스텝을 npm bin 대신 node 로 실행 — Windows 에서 스위트 2종이 중단되던 문제

### DIFF
--- a/rhwp-studio/tests/cell-flow-boundary.test.ts
+++ b/rhwp-studio/tests/cell-flow-boundary.test.ts
@@ -11,8 +11,16 @@ import { fileURLToPath } from 'node:url';
 // 실제 production 모듈을 임시 CommonJS로 변환해 source 복제 없이 동작을 검증한다.
 const studioRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const runtimeRoot = mkdtempSync(path.join(tmpdir(), 'rhwp-cell-flow-boundary-'));
-const compiler = path.join(studioRoot, 'node_modules', '.bin', 'tsc');
+// npm bin 을 직접 spawn 하지 않는다: Windows 의 `.bin/tsc` 는 확장자 없는 shell 스크립트라
+// 실행되지 않고, `.cmd` 는 Node 가 shell 없는 spawn 을 막는다(CVE-2024-27980 완화). 어느
+// 쪽이든 status=null 로 죽어 테스트가 통째로 중단된다. typescript 의 JS 진입점을 현재
+// node 로 실행하면 셸 없이도 모든 OS 에서 동일하게 동작한다.
+const compiler = process.env.RHWP_STUDIO_TSC ?? process.execPath;
+const compilerArgs = process.env.RHWP_STUDIO_TSC
+  ? []
+  : [path.join(studioRoot, 'node_modules', 'typescript', 'bin', 'tsc')];
 const compilation = spawnSync(compiler, [
+  ...compilerArgs,
   '--ignoreConfig',
   'src/engine/command.ts',
   'src/engine/history.ts',

--- a/rhwp-studio/tests/deferred-pagination-runner.test.ts
+++ b/rhwp-studio/tests/deferred-pagination-runner.test.ts
@@ -9,9 +9,16 @@ import { fileURLToPath } from 'node:url';
 
 const studioRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const runtimeRoot = mkdtempSync(path.join(tmpdir(), 'rhwp-deferred-pagination-runner-'));
-const compiler = process.env.RHWP_STUDIO_TSC
-  ?? path.join(studioRoot, 'node_modules', '.bin', 'tsc');
+// npm bin 을 직접 spawn 하지 않는다: Windows 의 `.bin/tsc` 는 확장자 없는 shell 스크립트라
+// 실행되지 않고, `.cmd` 는 Node 가 shell 없는 spawn 을 막는다(CVE-2024-27980 완화). 어느
+// 쪽이든 status=null 로 죽어 테스트가 통째로 중단된다. typescript 의 JS 진입점을 현재
+// node 로 실행하면 셸 없이도 모든 OS 에서 동일하게 동작한다.
+const compiler = process.env.RHWP_STUDIO_TSC ?? process.execPath;
+const compilerArgs = process.env.RHWP_STUDIO_TSC
+  ? []
+  : [path.join(studioRoot, 'node_modules', 'typescript', 'bin', 'tsc')];
 const compilation = spawnSync(compiler, [
+  ...compilerArgs,
   '--ignoreConfig',
   'src/engine/deferred-pagination-runner.ts',
   '--target', 'ES2022',


### PR DESCRIPTION
## 문제

`tests/cell-flow-boundary.test.ts` 와 `tests/deferred-pagination-runner.test.ts` 는 production
모듈을 임시 CommonJS 로 변환하려고 `node_modules/.bin/tsc` 를 `spawnSync` 한다. **Windows 에서는
이 spawn 이 반드시 실패한다.**

- 확장자 없는 `.bin/tsc` 는 shell 스크립트라 CreateProcess 로 실행되지 않는다.
- `.bin/tsc.cmd` 는 Node 가 shell 없는 spawn 을 막는다(CVE-2024-27980 완화, Node 18.20+/20.12+).

두 파일 모두 `assert.equal(compilation.status, 0, ...)` 가 **top-level** 이라 실패 시 테스트
파일이 통째로 중단되고 `npm test` 가 exit 1 로 끝난다:

```
AssertionError [ERR_ASSERTION]: cell-flow test runtime compile failed:
undefinedundefined
null !== 0
```

(`status: null` + stdout/stderr `undefined` = 프로세스가 뜨지도 못한 신호다.)

## 수정

typescript 의 JS 진입점을 현재 node(`process.execPath`)로 실행한다. 셸을 쓰지 않으므로 경로에
공백이 있어도 인용 문제가 없고, 플랫폼 분기도 필요 없다.

```ts
const compiler = process.env.RHWP_STUDIO_TSC ?? process.execPath;
const compilerArgs = process.env.RHWP_STUDIO_TSC
  ? []
  : [path.join(studioRoot, 'node_modules', 'typescript', 'bin', 'tsc')];
```

기존 `RHWP_STUDIO_TSC` 오버라이드는 그대로 두고, 없던 `cell-flow-boundary` 에도 같은 오버라이드를
추가해 두 파일의 계약을 맞췄다.

## 검증

| | 수정 전 | 수정 후 |
|---|---|---|
| Windows `npm test` | 실행 실패 (두 파일 중단) | **641 tests / 641 pass / 0 fail** |
| 대상 2개 스위트 단독 | 실행 실패 | 17 pass / 0 fail |

641 은 Linux CI 에서 통과하던 개수와 같다 — 즉 이 수정으로 Windows 가 CI 와 같은 커버리지를
갖게 된다. Linux 동작은 바뀌지 않는다(같은 컴파일러를 다른 진입점으로 부를 뿐).
