### PR TITLE
fix: XML 1.0 방어와 컨트롤 삽입 정합 보완 (#3382, #3214)

### DIFF
--- a/mydocs/orders/20260727.md
+++ b/mydocs/orders/20260727.md
@@ -1,5 +1,25 @@
 # 오늘 할일 - 2026년 7월 27일
 
+## chrisryugj PR 2건 — 체리픽 통합 검토·HWPX XML 보정
+
+`@chrisryugj`의 열린 [#3421](https://github.com/edwardkim/rhwp/pull/3421)과
+[#3425](https://github.com/edwardkim/rhwp/pull/3425)를 최신 `upstream/devel`
+`2d7303c5bea13eaf072e782cd7f7b4a6db59b35e` 위 가시 branch
+`review/chrisryugj-20260727`에 기능 commit만 체리픽했다. source branch에는 push하지 않았다.
+
+- #3421은 XML 1.0 비허용 scalar가 SVG·PDF·HWPX 방출 경로에 남지 않게 하는 변경이고, #3425는 HWPX의
+  정상적인 `controls`/`ctrl_data_records` 길이 불일치에서 인라인 control 삽입이 패닉하지 않게 한다.
+- #3421 정적 검토에서 공용 HWPX event writer의 text·attribute 경로가 빠진 것을 찾아
+  `ad7ce8ca6`으로 보정했다. 해당 helper와 field 수동 attribute가 같은 XML 1.0 filter를 사용하고,
+  실제 writer 출력 회귀 시험이 `U+0003` 제거와 markup escape 보존을 고정한다.
+- #3382에는 재현 HWPX·한글 기준 PDF가 없어 시각 sweep을 꾸미지 않았다. 정상 문서 배치를 바꾸지 않는
+  XML 유효성 변경이므로 실제 writer 출력·serializer 회귀를 증적으로 기록했다. 새 fixture가 없어
+  IR field-sweep baseline TSV 변경도 없다.
+- 전용 Cargo target에서 release-test 전체 **2,962/0**, Native Skia 공식 3종 **57/0·2/0·4/0**,
+  fmt·diff check·clippy·WASM lib check를 통과했다. source CI도 두 PR 모두 전체 성공·`CLEAN`이다.
+- 개별 review 2개와 통합 구현 기록을 같은 통합 PR에 넣는다. remote push·PR 생성은 승인 뒤에만 하고,
+  통합 head CI·mergeable 성공 뒤 실제 merge 및 원 PR/issue 후속 처리를 진행한다.
+
 ## v0.8.2 핫픽스 릴리즈 (#3445) — 완료
 
 v0.8.1 배포 직후 발견된 **브라우저 확장 인쇄 전면 실패**를 복구하는 핫픽스다.

--- a/mydocs/pr/archives/pr_3421_3425_chrisryugj_review_impl.md
+++ b/mydocs/pr/archives/pr_3421_3425_chrisryugj_review_impl.md
@@ -1,0 +1,46 @@
+# chrisryugj PR 2건 통합 검토 구현 기록 — 2026-07-27
+
+## 통합 범위
+
+사용자 가시 primary worktree의 `review/chrisryugj-20260727`을 최신 `upstream/devel`
+`2d7303c5bea13eaf072e782cd7f7b4a6db59b35e`에서 만들고, contributor source head의 기능 commit만
+fetch·누적했다. source branch의 devel merge commit과 source branch 자체에는 손대지 않았다.
+
+| PR | source head / 기능 commit | 통합 commit | 판정 |
+| --- | --- | --- | --- |
+| #3421 | `539920af` / `23d94ac6` | `e656e0381` | 메인터너 보정 후 수용 가능 |
+| #3425 | `3984f2a8` / `683c14e0` | `597dabf07` | 수용 가능 |
+| maintainer | 공용 HWPX event writer XML 1.0 보완 | `ad7ce8ca6` | #3421의 미포함 저장 경로 보정 |
+
+두 source PR은 작성 시점에 `MERGEABLE` / `CLEAN`이고 CI, CodeQL, Render Diff, Native Skia 및
+default-feature 8 shard가 모두 성공했다. maintainer hold·review comment는 없었다.
+
+## 보정 사유
+
+#3421의 XML 1.0 filter는 수동 string serializer를 보호하지만, HWPX의 `quick-xml` event writer는
+invalid scalar를 직접 검증하지 않아 text·attribute 경로가 남는다. `ad7ce8ca6`은 공용 helper 하나로
+`text()`, `start_tag_attrs()`, `empty_tag()`와 field 수동 attribute를 함께 보정하고 실제 writer
+출력 회귀 시험을 추가했다. #3425는 control 축과 `ctrl_data_records` 축의 index 정합만 다루므로
+이 보정과 독립적이며 충돌하지 않는다.
+
+## 검증 묶음
+
+전용 target `CARGO_TARGET_DIR=target/review-chrisryugj-20260727`, `CARGO_INCREMENTAL=0`에서 Cargo
+작업을 순차 실행했다.
+
+- #3214 focused 2건과 #3382 filter·event writer focused tests 성공.
+- Rust `cargo test --profile release-test --tests`: **2,962 passed / 0 failed**, IR field sweep 포함.
+- Native Skia 공식 3종: **57/0**, **2/0**, **4/0**.
+- `cargo fmt --all -- --check`, `git diff --check`, `cargo clippy -- -D warnings`,
+  `cargo check --target wasm32-unknown-unknown --lib`: 성공.
+
+#3382 이슈에는 실제 재현 HWPX·한글 기준 PDF가 첨부되지 않았고 변경 자체도 정상 문서의 화면 배치를
+바꾸지 않는 XML 유효성 계약이다. 따라서 임의의 PNG visual sweep은 수행하지 않았고, 이 한계와
+공용 writer 실출력 회귀 검증을 #3421 개별 기록에 남겼다. 새 fixture가 없으므로 IR baseline TSV 변경도
+없다.
+
+## 통합 PR과 후속 조건
+
+두 PR과 `ad7ce8ca6`을 하나의 통합 PR 후보로 유지한다. PR 생성, remote push, source PR comment/close/
+merge는 작업지시자의 별도 승인 뒤에만 수행한다. 그 뒤 통합 head의 CI와 mergeable을 다시 확인하고,
+실제 merge 뒤에만 원 PR·관련 issue 상태와 감사 comment를 처리한다.

--- a/mydocs/pr/archives/pr_3421_review.md
+++ b/mydocs/pr/archives/pr_3421_review.md
@@ -1,0 +1,59 @@
+# PR #3421 검토 기록 — XML 1.0 비허용 문자 방어 확대
+
+| 항목 | 내용 |
+| --- | --- |
+| 원 PR | [#3421](https://github.com/edwardkim/rhwp/pull/3421) — `fix(xml): XML 1.0 비허용 문자 방어를 전 방출 경로로 확대 — SVG·PDF·HWPX 저장 (#3382)` |
+| 작성자·검토자 | `@chrisryugj` (external contributor) · `@jangster77` (collaborator) |
+| base / source head | `devel` / `539920af94c369896b849752b05f7e26058f891e` (`chrisryugj/rhwp_fork`) |
+| 원 변경 규모 | 10 files, +166 / -10; 기능 commit `23d94ac6fef1c1263f3503df17ea71aa853168b1` (source의 devel merge commit은 미적용) |
+| 통합 검토 | `review/chrisryugj-20260727`, 기준 `upstream/devel` `2d7303c5bea13eaf072e782cd7f7b4a6db59b35e`; `23d94ac6…` → `e656e0381` |
+| 메인터너 보정 | `ad7ce8ca6` — 공용 HWPX event writer의 text·attribute 경로까지 XML 1.0 필터 적용 |
+| 관련 이슈 | [#3382](https://github.com/edwardkim/rhwp/issues/3382) |
+| 작성 시점 source 상태 | `MERGEABLE` / `CLEAN`; CI·CodeQL·Render Diff·Native Skia·8개 default-feature shard 모두 성공 |
+| 라우팅 | base: `collaborator_external_pr`; modifiers: `intake_and_review`, `local_validation`, `visual_fixture_evidence`, `multi_pr_update_branch` |
+
+Loaded documents: `pr_review_workflow.md`, `pr_review/README.md`,
+`collaborator_external_pr.md`, `intake_and_review.md`, `local_validation.md`,
+`visual_fixture_evidence.md`, `multi_pr_update_branch.md`.
+
+## 원 변경과 메인터너 보정
+
+원 PR은 XML 1.0 `Char` 집합(`#x9 | #xA | #xD | #x20..#xD7FF | #xE000..#xFFFD |
+#x10000..#x10FFFF`)만 통과시키도록 DocLang, EMF/WMF·OLE/OOXML chart SVG, 수식 SVG, PDF XMP,
+HWPX section 재조립과 field attribute 경로를 보완한다. 허용 범위·기존 `& < >` 이스케이프 순서는
+각 방출기에서 일관되고, 탭·개행·CR·한글·non-BMP의 보존 시험도 포함한다.
+
+정적 검토 중 HWPX의 공용 `text()` 및 `start_tag_attrs()`/`empty_tag()`가 `quick-xml`의 마크업
+이스케이프만 이용하고 XML 1.0 scalar 범위를 검사하지 않는 경로를 발견했다. 이 경로는 폼 텍스트·도형
+설명·hyperlink URL과 bookmark·폼 속성에서 실제 사용된다. 따라서 원 PR의 `xml_escape()`만으로는
+저장한 패키지에 제어문자가 남을 수 있었다.
+
+`ad7ce8ca6`은 공용 `filter_xml_1_0_chars()`를 추가해 event writer의 텍스트와 속성 전체에 적용하고,
+수동 `field_begin_open_tag()`도 같은 helper를 재사용하게 했다. 새 회귀 시험은 `U+0003`이 text와
+attribute 모두에서 제거되고 `&` 이스케이프가 유지됨을 실제 writer 출력으로 고정한다. 이 보정은
+원 contributor commit의 XML 방어 의도를 확장할 뿐, 정상 XML의 출력 형식·레이아웃은 바꾸지 않는다.
+
+## Fixture·시각 증적 판단
+
+#3382에는 재현에 사용한 HWPX, 한글 기준 PDF, 페이지 번호 또는 첨부 파일이 남아 있지 않다. 또한 이
+변경은 불법 scalar를 제거해 XML parser/브라우저의 중단을 막는 저장·방출 유효성 변경으로, 정상 문서의
+기하·글리프·페이지 배치를 바꾸지 않는다. 따라서 기준 PDF 없는 임의 PNG를 시각 증적으로 만들면 이
+결함의 수용 근거가 되지 않는다.
+
+시각 sweep은 **원본 fixture 부재 및 비시각 XML 유효성 변경**으로 적용하지 않았다. 대신 위 공용 writer
+출력 회귀 시험과 HWPX serializer 전체 회귀로 방출 바이트에 금지 문자가 남지 않는 경로를 검증했다.
+새 HWP/HWPX fixture를 추가하지 않았으므로 IR field-sweep baseline TSV 등록 trigger도 없다.
+
+## 검증
+
+- #3382 XML filter focused tests와 보정의 `event_writers_drop_xml_invalid_chars_from_text_and_attributes`: 성공.
+- 통합 후보 `cargo test --profile release-test --tests`: **2,962 passed / 0 failed**, IR field sweep 포함.
+- Native Skia 공식 3종: **57/0**, **2/0**, **4/0**.
+- `cargo fmt --all -- --check`, `git diff --check`, `cargo clippy -- -D warnings`,
+  `cargo check --target wasm32-unknown-unknown --lib`: 성공.
+
+## 최종 권고
+
+**메인터너 보정 후 기술적으로 수용 가능**. 통합 PR의 최신 head CI·mergeable과 작업지시자 승인을
+최종 merge 조건으로 둔다. #3382의 실제 HWPX와 한글 기준 PDF가 후속 제공되면 별도 재현·시각 대조를
+추가할 수 있지만, 현재 수용을 막을 근거는 아니다.

--- a/mydocs/pr/archives/pr_3425_review.md
+++ b/mydocs/pr/archives/pr_3425_review.md
@@ -1,0 +1,49 @@
+# PR #3425 검토 기록 — 컨트롤 삽입 시 `ctrl_data_records` 정합
+
+| 항목 | 내용 |
+| --- | --- |
+| 원 PR | [#3425](https://github.com/edwardkim/rhwp/pull/3425) — `fix(edit): 컨트롤 삽입이 ctrl_data_records 길이 불일치에서 패닉 (#3214)` |
+| 작성자·검토자 | `@chrisryugj` (external contributor) · `@jangster77` (collaborator) |
+| base / source head | `devel` / `3984f2a8398359ed0c8bd0b93d99bb648f2ab0b5` (`chrisryugj/rhwp_fork`) |
+| 원 변경 규모 | 6 files, +89 / -0; 기능 commit `683c14e090a1f713b09d61248d873962d6f93742` (source의 devel merge commit은 미적용) |
+| 통합 검토 | `review/chrisryugj-20260727`, 기준 `upstream/devel` `2d7303c5bea13eaf072e782cd7f7b4a6db59b35e`; `683c14e0…` → `597dabf07` |
+| 관련 이슈 | [#3214](https://github.com/edwardkim/rhwp/issues/3214) |
+| 작성 시점 source 상태 | `MERGEABLE` / `CLEAN`; CI·CodeQL·Render Diff·Native Skia·8개 default-feature shard 모두 성공 |
+| 라우팅 | base: `collaborator_external_pr`; modifiers: `intake_and_review`, `local_validation`, `multi_pr_update_branch` |
+
+Loaded documents: `pr_review_workflow.md`, `pr_review/README.md`,
+`collaborator_external_pr.md`, `intake_and_review.md`, `local_validation.md`,
+`multi_pr_update_branch.md`.
+
+## 원 변경과 판정
+
+`controls`의 삽입 위치는 control 축에서 계산하는데 HWPX 파서는 HWP5 전용 `CTRL_DATA` 레코드를
+채우지 않아 `ctrl_data_records.len() < controls.len()`이 정상일 수 있다. 기존 코드는 그 control
+인덱스로 더 짧은 vector에 `insert()`해 각주·미주·수식·도형·새 번호 삽입에서 범위 초과 패닉을 낼 수
+있었다.
+
+PR은 `Paragraph::align_ctrl_data_records()`를 추가해 부족한 슬롯만 `None`으로 채우고, header/footer
+생성 및 모든 해당 인라인 control 삽입 경로에서 control/record 양쪽 insert 전에 호출한다. 더 긴 record
+vector를 자르지 않아 기존 HWP5의 추가 원본 정보도 보존한다. 두 회귀 시험은 (1) header 생성 뒤 record
+길이 정합과 각주 삽입, (2) HWPX와 같은 의도적 불일치 상태에서의 각주 삽입을 검증한다. 코드상
+차단점은 발견하지 못했다.
+
+## Fixture·시각 증적 판단
+
+배열 인덱스 정합과 패닉 방지가 전부이며 renderer·serialization 형식·페이지 배치는 바꾸지 않는다.
+새 HWP/HWPX fixture도 추가하지 않았다. 그러므로 visual sweep 및 PNG 증적은 적용 대상이 아니며,
+IR field-sweep baseline TSV 등록 trigger도 없다.
+
+## 검증
+
+- `issue3214_header_creation_keeps_ctrl_data_records_aligned`,
+  `issue3214_insert_survives_unaligned_ctrl_data_records`: 성공.
+- 통합 후보 `cargo test --profile release-test --tests`: **2,962 passed / 0 failed**, IR field sweep 포함.
+- Native Skia 공식 3종: **57/0**, **2/0**, **4/0**.
+- `cargo fmt --all -- --check`, `git diff --check`, `cargo clippy -- -D warnings`,
+  `cargo check --target wasm32-unknown-unknown --lib`: 성공.
+
+## 최종 권고
+
+**기술적으로 수용 가능**. #3421의 공용 HWPX XML 보정과 함께 같은 통합 PR에 넣어도 충돌이나
+행동 중첩이 없다. 최신 통합 head CI·mergeable 및 작업지시자 승인을 최종 merge 조건으로 둔다.

--- a/src/doclang/writer/escape.rs
+++ b/src/doclang/writer/escape.rs
@@ -28,7 +28,14 @@ pub fn escape_text(s: &str) -> String {
             '&' => out.push_str("&amp;"),
             '<' => out.push_str("&lt;"),
             '>' => out.push_str("&gt;"),
-            _ => out.push(c),
+            // XML 1.0 legal characters: #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] |
+            // [#x10000-#x10FFFF].  Anything else (control characters, U+FFFE/U+FFFF) is dropped
+            // so the emitted document stays well-formed XML (#3382 class).
+            '\u{09}' | '\u{0A}' | '\u{0D}' => out.push(c),
+            '\u{20}'..='\u{D7FF}' | '\u{E000}'..='\u{FFFD}' | '\u{10000}'..='\u{10FFFF}' => {
+                out.push(c)
+            }
+            _ => {} // XML-invalid character
         }
     }
     out
@@ -48,7 +55,12 @@ pub fn escape_attr(s: &str) -> String {
             '>' => out.push_str("&gt;"),
             '"' => out.push_str("&quot;"),
             '\'' => out.push_str("&apos;"),
-            _ => out.push(c),
+            // See `escape_text`: XML 1.0 legal characters only (#3382 class).
+            '\u{09}' | '\u{0A}' | '\u{0D}' => out.push(c),
+            '\u{20}'..='\u{D7FF}' | '\u{E000}'..='\u{FFFD}' | '\u{10000}'..='\u{10FFFF}' => {
+                out.push(c)
+            }
+            _ => {} // XML-invalid character
         }
     }
     out
@@ -71,6 +83,28 @@ mod tests {
             escape_attr("a&b<c>\"d\"'e'"),
             "a&amp;b&lt;c&gt;&quot;d&quot;&apos;e&apos;"
         );
+    }
+
+    #[test]
+    fn drops_xml_invalid_control_chars() {
+        // #3382 class: XML 1.0 forbids most C0 controls outright — emitting them verbatim
+        // produces a document that no conforming parser can read ("PCDATA invalid Char value 3").
+        assert_eq!(escape_text("a\u{03}b"), "ab");
+        assert_eq!(escape_attr("a\u{03}b"), "ab");
+        for c in ['\u{00}', '\u{08}', '\u{0B}', '\u{0C}', '\u{0E}', '\u{1F}'] {
+            assert_eq!(
+                escape_text(&format!("x{c}y")),
+                "xy",
+                "control {:#04x}",
+                c as u32
+            );
+        }
+        // U+FFFE / U+FFFF are not XML characters either.
+        assert_eq!(escape_text("a\u{FFFE}\u{FFFF}b"), "ab");
+        // Tab / LF / CR stay — they are legal XML characters.
+        assert_eq!(escape_text("a\tb\nc\rd"), "a\tb\nc\rd");
+        // Ordinary text (incl. non-BMP) is untouched.
+        assert_eq!(escape_text("한글 A\u{1F600}"), "한글 A\u{1F600}");
     }
 
     #[test]

--- a/src/document_core/commands/header_footer_ops.rs
+++ b/src/document_core/commands/header_footer_ops.rs
@@ -166,6 +166,9 @@ impl DocumentCore {
             return Err(HwpError::RenderError("구역에 문단이 없습니다".to_string()));
         }
         section.paragraphs[0].controls.push(ctrl);
+        // [#3214] controls 만 늘리면 ctrl_data_records 와의 인덱스 대응이 깨져, 이후 같은
+        // 문단에 각주·미주·수식을 삽입할 때 ctrl_data_records.insert 가 범위를 넘어 패닉한다.
+        section.paragraphs[0].align_ctrl_data_records();
         // 컨트롤 1개 = UTF-16 8 code units → char_count 갱신
         section.paragraphs[0].char_count += 8;
         section.raw_stream = None;
@@ -1586,6 +1589,58 @@ mod tests {
         assert!(
             format!("{:?}", tree).contains("가나다"),
             "렌더 트리에 본문 텍스트 없음"
+        );
+    }
+
+    /// [#3214] 머리말 생성이 `controls` 만 늘려 `ctrl_data_records` 와 어긋나면, 같은 문단에
+    /// 각주를 삽입할 때 `ctrl_data_records.insert` 가 범위를 넘어 패닉한다.
+    /// (WASM 에서는 패닉이 객체 borrow 를 오염시켜 이후 모든 호출이 실패한다.)
+    #[test]
+    fn issue3214_header_creation_keeps_ctrl_data_records_aligned() {
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+        core.insert_text_native(0, 0, 0, "ab").unwrap();
+
+        core.create_header_footer_native(0, true, 0).unwrap();
+
+        let para = &core.document.sections[0].paragraphs[0];
+        assert_eq!(
+            para.controls.len(),
+            para.ctrl_data_records.len(),
+            "머리말 생성 후 controls/ctrl_data_records 길이가 어긋났다"
+        );
+
+        // 머리말 컨트롤 "뒤"(텍스트 끝)에 각주를 삽입해야 insert_idx == controls.len() 이 되어
+        // ctrl_data_records(짧음)에 대한 범위 초과가 드러난다 — 수정 전에는 여기서 패닉했다.
+        core.insert_footnote_native(0, 0, 2).unwrap();
+        let para = &core.document.sections[0].paragraphs[0];
+        assert_eq!(para.controls.len(), para.ctrl_data_records.len());
+    }
+
+    /// [#3214] HWPX 파서는 CTRL_DATA(HWP5 전용 레코드) 개념이 없어 `ctrl_data_records` 를
+    /// 채우지 않는다. 즉 `ctrl_data_records.len() < controls.len()` 은 HWPX 문서의 정상
+    /// 상태이며, 컨트롤 삽입 경로는 이를 견뎌야 한다.
+    #[test]
+    fn issue3214_insert_survives_unaligned_ctrl_data_records() {
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+        core.insert_text_native(0, 0, 0, "ab").unwrap();
+
+        // HWPX 파서가 남기는 어긋난 상태를 재현한다(컨트롤은 있고 CTRL_DATA 는 없음).
+        core.create_header_footer_native(0, true, 0).unwrap();
+        {
+            let para = &mut core.document.sections[0].paragraphs[0];
+            para.ctrl_data_records.clear();
+            assert!(!para.controls.is_empty());
+        }
+
+        core.insert_footnote_native(0, 0, 2).unwrap();
+
+        let para = &core.document.sections[0].paragraphs[0];
+        assert_eq!(
+            para.controls.len(),
+            para.ctrl_data_records.len(),
+            "삽입 후 두 배열 길이가 정합해야 한다"
         );
     }
 }

--- a/src/document_core/commands/object_ops/common.rs
+++ b/src/document_core/commands/object_ops/common.rs
@@ -382,6 +382,8 @@ impl crate::document_core::DocumentCore {
             idx
         };
 
+        // [#3214] controls 기준 인덱스를 ctrl_data_records 에 그대로 쓰기 전에 정렬한다.
+        paragraph.align_ctrl_data_records();
         paragraph
             .controls
             .insert(insert_idx, Control::NewNumber(new_number));

--- a/src/document_core/commands/object_ops/equation.rs
+++ b/src/document_core/commands/object_ops/equation.rs
@@ -422,6 +422,8 @@ impl DocumentCore {
             idx
         };
 
+        // [#3214] controls 기준 인덱스를 ctrl_data_records 에 그대로 쓰기 전에 정렬한다.
+        paragraph.align_ctrl_data_records();
         paragraph
             .controls
             .insert(insert_idx, Control::Equation(Box::new(equation)));

--- a/src/document_core/commands/object_ops/note.rs
+++ b/src/document_core/commands/object_ops/note.rs
@@ -512,6 +512,10 @@ impl DocumentCore {
             idx
         };
 
+        // [#3214] insert_idx 는 controls 기준이다. HWPX 문서는 ctrl_data_records 가 controls
+        // 보다 짧은 상태가 정상이므로(파서가 채우지 않음), 정렬 없이 같은 인덱스로 insert 하면
+        // 범위 초과로 패닉한다.
+        paragraph.align_ctrl_data_records();
         paragraph
             .controls
             .insert(insert_idx, Control::Footnote(Box::new(footnote)));
@@ -758,6 +762,8 @@ impl DocumentCore {
             idx
         };
 
+        // [#3214] 각주 경로와 동일 — controls 기준 인덱스를 쓰기 전에 정렬한다.
+        paragraph.align_ctrl_data_records();
         paragraph
             .controls
             .insert(insert_idx, Control::Endnote(Box::new(endnote)));

--- a/src/document_core/commands/object_ops/shape.rs
+++ b/src/document_core/commands/object_ops/shape.rs
@@ -1511,6 +1511,8 @@ impl DocumentCore {
             };
 
             // 컨트롤 추가
+            // [#3214] controls 기준 인덱스를 ctrl_data_records 에 그대로 쓰기 전에 정렬한다.
+            paragraph.align_ctrl_data_records();
             paragraph
                 .controls
                 .insert(insert_idx, Control::Shape(Box::new(shape_obj)));
@@ -2326,6 +2328,8 @@ impl DocumentCore {
             }
 
             // 문단에 삽입
+            // [#3214] controls 기준 인덱스를 ctrl_data_records 에 그대로 쓰기 전에 정렬한다.
+            para.align_ctrl_data_records();
             para.controls
                 .insert(insert_idx, Control::Shape(Box::new(child)));
             para.ctrl_data_records.insert(insert_idx, None);

--- a/src/emf/converter/svg.rs
+++ b/src/emf/converter/svg.rs
@@ -62,7 +62,13 @@ pub fn escape_xml(s: &str) -> String {
             '&' => out.push_str("&amp;"),
             '"' => out.push_str("&quot;"),
             '\'' => out.push_str("&apos;"),
-            _ => out.push(ch),
+            // XML 1.0 허용 문자: #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+            // 그 외(제어문자, U+FFFE, U+FFFF 등)는 제거 — 방출된 SVG 가 불법 XML 이 되지 않도록 (#3382)
+            '\u{09}' | '\u{0A}' | '\u{0D}' => out.push(ch),
+            '\u{20}'..='\u{D7FF}' | '\u{E000}'..='\u{FFFD}' | '\u{10000}'..='\u{10FFFF}' => {
+                out.push(ch)
+            }
+            _ => {} // XML 무효 문자 제거
         }
     }
     out

--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -322,6 +322,26 @@ pub struct OrphanFieldEnd {
 }
 
 impl Paragraph {
+    /// `ctrl_data_records` 를 `controls` 길이에 맞춰 `None` 으로 패딩한다.
+    ///
+    /// [#3214] `ctrl_data_records[i]` 는 `controls[i]` 대응이지만, **두 배열의 길이가 항상
+    /// 같지는 않다**. CTRL_DATA 는 HWP5 바이너리 전용 레코드라 HWPX 파서는 이 배열을 채우지
+    /// 않고(`parser/hwpx` 에 적재 지점이 없다), HWP3 파서와 편집 커맨드만 쌍으로 관리한다.
+    /// 즉 HWPX 로 연 문서는 `ctrl_data_records.len() < controls.len()` 이 정상 상태다.
+    ///
+    /// 그런데 컨트롤 삽입 경로는 삽입 위치를 `controls` 기준으로 계산한 뒤 그 인덱스를 그대로
+    /// `ctrl_data_records.insert(idx, None)` 에 넘긴다. 두 길이가 어긋나 있으면
+    /// `insertion index (is N) should be <= len (is M)` 로 패닉하고, WASM 에서는 패닉이
+    /// 객체 borrow 를 오염시켜 이후 모든 호출이 `recursive use of an object` 로 실패한다.
+    ///
+    /// 인덱스 대응에 기대는 쓰기를 하기 전에 이 함수로 정렬한다. 삽입 **전에** 호출하면
+    /// `insert_idx <= ctrl_data_records.len()` 이 보장된다.
+    pub fn align_ctrl_data_records(&mut self) {
+        while self.ctrl_data_records.len() < self.controls.len() {
+            self.ctrl_data_records.push(None);
+        }
+    }
+
     pub(crate) fn is_split_movable_control(ctrl: &Control) -> bool {
         matches!(
             ctrl,

--- a/src/ole_chart/svg_renderer.rs
+++ b/src/ole_chart/svg_renderer.rs
@@ -267,7 +267,13 @@ fn escape_xml_text(value: &str) -> String {
             '>' => escaped.push_str("&gt;"),
             '"' => escaped.push_str("&quot;"),
             '\'' => escaped.push_str("&apos;"),
-            _ => escaped.push(ch),
+            // XML 1.0 허용 문자: #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+            // 그 외(제어문자, U+FFFE, U+FFFF 등)는 제거 — 방출된 SVG 가 불법 XML 이 되지 않도록 (#3382)
+            '\u{09}' | '\u{0A}' | '\u{0D}' => escaped.push(ch),
+            '\u{20}'..='\u{D7FF}' | '\u{E000}'..='\u{FFFD}' | '\u{10000}'..='\u{10FFFF}' => {
+                escaped.push(ch)
+            }
+            _ => {} // XML 무효 문자 제거
         }
     }
     escaped

--- a/src/ooxml_chart/renderer.rs
+++ b/src/ooxml_chart/renderer.rs
@@ -133,7 +133,13 @@ fn xml_escape(s: &str) -> String {
             '&' => out.push_str("&amp;"),
             '"' => out.push_str("&quot;"),
             '\'' => out.push_str("&apos;"),
-            _ => out.push(ch),
+            // XML 1.0 허용 문자: #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+            // 그 외(제어문자, U+FFFE, U+FFFF 등)는 제거 — 방출된 SVG 가 불법 XML 이 되지 않도록 (#3382)
+            '\u{09}' | '\u{0A}' | '\u{0D}' => out.push(ch),
+            '\u{20}'..='\u{D7FF}' | '\u{E000}'..='\u{FFFD}' | '\u{10000}'..='\u{10FFFF}' => {
+                out.push(ch)
+            }
+            _ => {} // XML 무효 문자 제거
         }
     }
     out

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -4960,7 +4960,13 @@ fn escape_xml_text(s: &str) -> String {
             '<' => out.push_str("&lt;"),
             '>' => out.push_str("&gt;"),
             '"' => out.push_str("&quot;"),
-            _ => out.push(c),
+            // XML 1.0 허용 문자: #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+            // 그 외(제어문자 등)는 제거 — 재조립된 문자열이 그대로 저장돼 불법 XML 이 되지 않도록 (#3382 계열)
+            '\u{09}' | '\u{0A}' | '\u{0D}' => out.push(c),
+            '\u{20}'..='\u{D7FF}' | '\u{E000}'..='\u{FFFD}' | '\u{10000}'..='\u{10FFFF}' => {
+                out.push(c)
+            }
+            _ => {} // XML 무효 문자 제거
         }
     }
     out

--- a/src/renderer/equation/svg_render.rs
+++ b/src/renderer/equation/svg_render.rs
@@ -666,7 +666,13 @@ fn escape_xml(text: &str) -> String {
             '>' => result.push_str("&gt;"),
             '"' => result.push_str("&quot;"),
             '\'' => result.push_str("&apos;"),
-            _ => result.push(ch),
+            // XML 1.0 허용 문자: #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+            // 그 외(제어문자, U+FFFE, U+FFFF 등)는 제거 — 방출된 SVG 가 불법 XML 이 되지 않도록 (#3382)
+            '\u{09}' | '\u{0A}' | '\u{0D}' => result.push(ch),
+            '\u{20}'..='\u{D7FF}' | '\u{E000}'..='\u{FFFD}' | '\u{10000}'..='\u{10FFFF}' => {
+                result.push(ch)
+            }
+            _ => {} // XML 무효 문자 제거
         }
     }
     result
@@ -692,6 +698,27 @@ mod tests {
         let ast = EqParser::new(tokens).parse();
         let layout = EqLayout::new(20.0).layout(&ast);
         render_equation_svg(&layout, "#000000", 20.0)
+    }
+
+    #[test]
+    fn escape_xml_drops_xml_invalid_control_chars() {
+        // #3382: 수식 SVG 는 본문 SVG(renderer/svg.rs)와 달리 XML 1.0 문자 필터가 없어,
+        // IR 텍스트에 섞인 제어문자를 그대로 방출하면 산출 SVG 가 불법 XML 이 된다
+        // ("PCDATA invalid Char value 3") — 뷰어가 해당 페이지 렌더를 중단한다.
+        assert_eq!(escape_xml("a\u{03}b"), "ab");
+        for c in ['\u{00}', '\u{08}', '\u{0B}', '\u{0C}', '\u{0E}', '\u{1F}'] {
+            assert_eq!(
+                escape_xml(&format!("x{c}y")),
+                "xy",
+                "control {:#04x}",
+                c as u32
+            );
+        }
+        assert_eq!(escape_xml("a\u{FFFE}\u{FFFF}b"), "ab");
+        // 탭·개행·복귀는 XML 1.0 허용 문자이므로 유지
+        assert_eq!(escape_xml("a\tb\nc\rd"), "a\tb\nc\rd");
+        // 기존 마크업 이스케이프는 무회귀
+        assert_eq!(escape_xml("<a & b>\"'"), "&lt;a &amp; b&gt;&quot;&apos;");
     }
 
     #[test]

--- a/src/renderer/pdf.rs
+++ b/src/renderer/pdf.rs
@@ -653,7 +653,13 @@ fn escape_xml_attr(value: &str) -> String {
             '>' => escaped.push_str("&gt;"),
             '"' => escaped.push_str("&quot;"),
             '\'' => escaped.push_str("&apos;"),
-            _ => escaped.push(ch),
+            // XML 1.0 허용 문자: #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+            // 그 외(제어문자 등)는 제거 — PDF 에 심는 XMP 메타데이터가 불법 XML 이 되지 않도록 (#3382 계열)
+            '\u{09}' | '\u{0A}' | '\u{0D}' => escaped.push(ch),
+            '\u{20}'..='\u{D7FF}' | '\u{E000}'..='\u{FFFD}' | '\u{10000}'..='\u{10FFFF}' => {
+                escaped.push(ch)
+            }
+            _ => {} // XML 무효 문자 제거
         }
     }
     escaped

--- a/src/serializer/hwpx/field.rs
+++ b/src/serializer/hwpx/field.rs
@@ -15,7 +15,7 @@ use quick_xml::Writer;
 
 use crate::model::control::{Bookmark, Field, FieldType, Hyperlink};
 
-use super::utils::{empty_tag, end_tag, start_tag, start_tag_attrs, text};
+use super::utils::{empty_tag, end_tag, filter_xml_1_0_chars, start_tag, start_tag_attrs, text};
 use super::SerializeError;
 
 // =====================================================================
@@ -62,19 +62,7 @@ pub fn field_begin_open_tag(field: &Field) -> String {
 fn xml_escape_attr(s: &str) -> String {
     // XML 1.0 이 담을 수 없는 문자(제어문자 등)를 먼저 제거한다 — 남겨 두면 저장된 HWPX 안의
     // XML 이 불법이 되어 한컴·뷰어가 파일 자체를 열지 못한다 (#3382 계열).
-    s.chars()
-        .filter(|c| {
-            matches!(
-                c,
-                '\u{09}'
-                    | '\u{0A}'
-                    | '\u{0D}'
-                    | '\u{20}'..='\u{D7FF}'
-                    | '\u{E000}'..='\u{FFFD}'
-                    | '\u{10000}'..='\u{10FFFF}'
-            )
-        })
-        .collect::<String>()
+    filter_xml_1_0_chars(s)
         .replace('&', "&amp;")
         .replace('<', "&lt;")
         .replace('>', "&gt;")

--- a/src/serializer/hwpx/field.rs
+++ b/src/serializer/hwpx/field.rs
@@ -60,7 +60,22 @@ pub fn field_begin_open_tag(field: &Field) -> String {
 }
 
 fn xml_escape_attr(s: &str) -> String {
-    s.replace('&', "&amp;")
+    // XML 1.0 이 담을 수 없는 문자(제어문자 등)를 먼저 제거한다 — 남겨 두면 저장된 HWPX 안의
+    // XML 이 불법이 되어 한컴·뷰어가 파일 자체를 열지 못한다 (#3382 계열).
+    s.chars()
+        .filter(|c| {
+            matches!(
+                c,
+                '\u{09}'
+                    | '\u{0A}'
+                    | '\u{0D}'
+                    | '\u{20}'..='\u{D7FF}'
+                    | '\u{E000}'..='\u{FFFD}'
+                    | '\u{10000}'..='\u{10FFFF}'
+            )
+        })
+        .collect::<String>()
+        .replace('&', "&amp;")
         .replace('<', "&lt;")
         .replace('>', "&gt;")
         .replace('"', "&quot;")

--- a/src/serializer/hwpx/utils.rs
+++ b/src/serializer/hwpx/utils.rs
@@ -33,7 +33,8 @@ pub fn start_tag_attrs<W: Write>(
 ) -> Result<(), SerializeError> {
     let mut el = BytesStart::new(name);
     for (k, v) in attrs {
-        el.push_attribute((*k, *v));
+        let value = filter_xml_1_0_chars(v);
+        el.push_attribute((*k, value.as_str()));
     }
     w.write_event(Event::Start(el))
         .map_err(|e| SerializeError::XmlError(e.to_string()))?;
@@ -55,7 +56,8 @@ pub fn empty_tag<W: Write>(
 ) -> Result<(), SerializeError> {
     let mut el = BytesStart::new(name);
     for (k, v) in attrs {
-        el.push_attribute((*k, *v));
+        let value = filter_xml_1_0_chars(v);
+        el.push_attribute((*k, value.as_str()));
     }
     w.write_event(Event::Empty(el))
         .map_err(|e| SerializeError::XmlError(e.to_string()))?;
@@ -64,9 +66,31 @@ pub fn empty_tag<W: Write>(
 
 /// 텍스트 노드 (자동 이스케이프)
 pub fn text<W: Write>(w: &mut Writer<W>, content: &str) -> Result<(), SerializeError> {
-    w.write_event(Event::Text(BytesText::new(content)))
+    let content = filter_xml_1_0_chars(content);
+    w.write_event(Event::Text(BytesText::new(&content)))
         .map_err(|e| SerializeError::XmlError(e.to_string()))?;
     Ok(())
+}
+
+/// XML 1.0이 허용하는 문자만 남긴다.
+///
+/// `quick-xml`의 event writer는 `&` 등의 마크업 문자는 이스케이프하지만 XML 1.0 문자
+/// 범위까지 검증하지 않는다. HWPX의 텍스트와 속성 모두 이 helper를 거쳐야 저장한 패키지가
+/// 불법 XML이 되지 않는다 (#3382).
+pub fn filter_xml_1_0_chars(s: &str) -> String {
+    s.chars()
+        .filter(|c| {
+            matches!(
+                c,
+                '\u{09}'
+                    | '\u{0A}'
+                    | '\u{0D}'
+                    | '\u{20}'..='\u{D7FF}'
+                    | '\u{E000}'..='\u{FFFD}'
+                    | '\u{10000}'..='\u{10FFFF}'
+            )
+        })
+        .collect()
 }
 
 /// XML 속성·텍스트 이스케이프 (&, <, >, ", ')
@@ -74,20 +98,16 @@ pub fn text<W: Write>(w: &mut Writer<W>, content: &str) -> Result<(), SerializeE
 /// XML 1.0 이 문서에 담을 수 없는 문자(제어문자 등)는 제거한다 — 남겨 두면 저장된
 /// HWPX 안의 XML 이 불법이 되어 한컴·뷰어가 파일 자체를 열지 못한다 (#3382 계열).
 pub fn xml_escape(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
+    let filtered = filter_xml_1_0_chars(s);
+    let mut out = String::with_capacity(filtered.len());
+    for c in filtered.chars() {
         match c {
             '&' => out.push_str("&amp;"),
             '<' => out.push_str("&lt;"),
             '>' => out.push_str("&gt;"),
             '"' => out.push_str("&quot;"),
             '\'' => out.push_str("&apos;"),
-            // XML 1.0 허용 문자: #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
-            '\u{09}' | '\u{0A}' | '\u{0D}' => out.push(c),
-            '\u{20}'..='\u{D7FF}' | '\u{E000}'..='\u{FFFD}' | '\u{10000}'..='\u{10FFFF}' => {
-                out.push(c)
-            }
-            _ => {} // XML 무효 문자 제거
+            _ => out.push(c),
         }
     }
     out
@@ -116,5 +136,22 @@ mod tests {
         // 기존 마크업 이스케이프·한글·non-BMP 는 무회귀
         assert_eq!(xml_escape("<a & b>\"'"), "&lt;a &amp; b&gt;&quot;&apos;");
         assert_eq!(xml_escape("한글 A\u{1F600}"), "한글 A\u{1F600}");
+    }
+
+    #[test]
+    fn event_writers_drop_xml_invalid_chars_from_text_and_attributes() {
+        let mut bytes = Vec::new();
+        let mut writer = Writer::new(&mut bytes);
+        start_tag_attrs(&mut writer, "hp:test", &[("name", "a\u{03}b")]).unwrap();
+        text(&mut writer, "x\u{03}y & z").unwrap();
+        end_tag(&mut writer, "hp:test").unwrap();
+        empty_tag(&mut writer, "hp:empty", &[("value", "c\u{03}d")]).unwrap();
+
+        let xml = String::from_utf8(bytes).unwrap();
+        assert_eq!(
+            xml,
+            r#"<hp:test name="ab">xy &amp; z</hp:test><hp:empty value="cd"/>"#
+        );
+        assert!(!xml.contains('\u{03}'));
     }
 }

--- a/src/serializer/hwpx/utils.rs
+++ b/src/serializer/hwpx/utils.rs
@@ -70,6 +70,9 @@ pub fn text<W: Write>(w: &mut Writer<W>, content: &str) -> Result<(), SerializeE
 }
 
 /// XML 속성·텍스트 이스케이프 (&, <, >, ", ')
+///
+/// XML 1.0 이 문서에 담을 수 없는 문자(제어문자 등)는 제거한다 — 남겨 두면 저장된
+/// HWPX 안의 XML 이 불법이 되어 한컴·뷰어가 파일 자체를 열지 못한다 (#3382 계열).
 pub fn xml_escape(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {
@@ -79,8 +82,39 @@ pub fn xml_escape(s: &str) -> String {
             '>' => out.push_str("&gt;"),
             '"' => out.push_str("&quot;"),
             '\'' => out.push_str("&apos;"),
-            _ => out.push(c),
+            // XML 1.0 허용 문자: #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+            '\u{09}' | '\u{0A}' | '\u{0D}' => out.push(c),
+            '\u{20}'..='\u{D7FF}' | '\u{E000}'..='\u{FFFD}' | '\u{10000}'..='\u{10FFFF}' => {
+                out.push(c)
+            }
+            _ => {} // XML 무효 문자 제거
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn xml_escape_drops_xml_invalid_control_chars() {
+        // #3382 계열: 저장 경로에서 제어문자를 그대로 흘리면 section0.xml 이 불법 XML 이 되어
+        // 한컴·뷰어가 파일 자체를 열지 못한다. (HWPX→HWP5 변환 등으로 IR 에 0x03 이 유입된 실측 사례)
+        assert_eq!(xml_escape("a\u{03}b"), "ab");
+        for c in ['\u{00}', '\u{08}', '\u{0B}', '\u{0C}', '\u{0E}', '\u{1F}'] {
+            assert_eq!(
+                xml_escape(&format!("x{c}y")),
+                "xy",
+                "control {:#04x}",
+                c as u32
+            );
+        }
+        assert_eq!(xml_escape("a\u{FFFE}\u{FFFF}b"), "ab");
+        // 탭·개행·복귀는 XML 1.0 허용 문자이므로 유지
+        assert_eq!(xml_escape("a\tb\nc\rd"), "a\tb\nc\rd");
+        // 기존 마크업 이스케이프·한글·non-BMP 는 무회귀
+        assert_eq!(xml_escape("<a & b>\"'"), "&lt;a &amp; b&gt;&quot;&apos;");
+        assert_eq!(xml_escape("한글 A\u{1F600}"), "한글 A\u{1F600}");
+    }
 }

--- a/src/wmf/converter/svg/node.rs
+++ b/src/wmf/converter/svg/node.rs
@@ -50,6 +50,22 @@ impl Node {
     fn escape_text(value: impl ToString) -> String {
         value
             .to_string()
+            .chars()
+            // XML 1.0 허용 문자만 남긴다: #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] |
+            // [#x10000-#x10FFFF]. 제어문자를 그대로 흘리면 방출된 SVG 가 불법 XML 이 되어
+            // 뷰어가 렌더를 중단한다 (#3382).
+            .filter(|c| {
+                matches!(
+                    c,
+                    '\u{09}'
+                        | '\u{0A}'
+                        | '\u{0D}'
+                        | '\u{20}'..='\u{D7FF}'
+                        | '\u{E000}'..='\u{FFFD}'
+                        | '\u{10000}'..='\u{10FFFF}'
+                )
+            })
+            .collect::<String>()
             .replace('&', "&amp;")
             .replace('<', "&lt;")
             .replace('>', "&gt;")


### PR DESCRIPTION
## 통합 범위

- [#3421](https://github.com/edwardkim/rhwp/pull/3421): SVG·PDF·HWPX 방출 경로의 XML 1.0 비허용 문자 방어
- [#3425](https://github.com/edwardkim/rhwp/pull/3425): HWPX `controls`/`ctrl_data_records` 길이 불일치에서 인라인 컨트롤 삽입 패닉 방지

## 메인터너 보정

정적 검토에서 #3421의 HWPX 공용 `quick-xml` event writer가 text·attribute의 XML 1.0 scalar를 별도로 검증하지 않는 경로를 확인했습니다. `ad7ce8ca6`에서 공용 필터를 `text()`·시작/빈 태그 속성 writer와 field 수동 attribute에 적용하고, 실제 writer 출력 회귀 시험을 추가했습니다.

## 검증

- `cargo test --profile release-test --tests`: 2,962 passed / 0 failed (IR field sweep 포함)
- Native Skia 공식 3종: 57/0, 2/0, 4/0
- fmt, diff check, clippy (`-D warnings`), wasm32 library check 성공
- 원 PR #3421·#3425의 최신 CI·CodeQL·Render Diff도 모두 성공

## Fixture·시각 근거

#3382에는 실제 재현 HWPX와 한글 기준 PDF가 첨부되지 않았고, 변경은 정상 문서의 배치를 바꾸지 않는 XML 유효성 계약입니다. 임의 PNG visual sweep 대신 공용 writer의 실제 출력 회귀를 추가했으며, 새 fixture는 없어 IR baseline TSV 변경이 없습니다.

개별 검토와 통합 기록은 `mydocs/pr/archives/`, 오늘할일은 `mydocs/orders/20260727.md`에 포함했습니다.

Closes #3382
Closes #3214