### PR TITLE
fix(renderer): 미주 번호 prepend 가 autoNum 갭을 없애 인라인 수식이 문단 끝으로 밀리는 문제

### DIFF
--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -445,6 +445,18 @@ fn prepend_endnote_marker_text(para: &mut Paragraph, endnote: &crate::model::foo
     if leading_spaces > 0 {
         para.delete_text_at(0, leading_spaces);
     }
+    // === D1-FIX-A: 번호 텍스트가 autoNum 을 실체화했으므로 그 컨트롤을 제거한다.
+    // 남겨두면 placeholder 갭이 사라진 뒤에도 controls[] 에 남아, 뒤따르는
+    // 인라인 개체(수식)의 갭을 대신 소비해 어순이 한 칸 밀린다.
+    if leading_spaces > 0
+        && matches!(
+            para.controls.first(),
+            Some(crate::model::control::Control::AutoNumber(an))
+                if an.number_type == crate::model::control::AutoNumberType::Endnote
+        )
+    {
+        para.controls.remove(0);
+    }
     let prefix = format!("{} ", format_endnote_marker_text(endnote));
     let prefix_len = prefix.chars().count();
     para.insert_text_at(0, &prefix);
@@ -18570,6 +18582,64 @@ mod tests {
             margin_gutter: 0,
             ..Default::default()
         }
+    }
+
+    /// 미주 번호를 앞에 붙일 때 autoNum 의 placeholder 글자를 지우면서도
+    /// `controls[]` 에 AutoNumber 를 남기면, 갭 분배가 한 칸 밀려 뒤따르는
+    /// 인라인 수식이 자기 갭을 빼앗기고 문단 끝으로 떨어진다.
+    #[test]
+    fn endnote_marker_prepend_keeps_inline_equation_in_place() {
+        use crate::model::control::{AutoNumber, AutoNumberType, Control, Equation};
+        use crate::model::footnote::Endnote;
+
+        // 원본 run 순서: <autoNum/> " (1)" <equation/> " Z"
+        // AUTO_NUMBER 는 8 code unit 을 점유하면서 가시 placeholder ' ' 를 남긴다.
+        let mut equation = Box::<Equation>::default();
+        equation.common.treat_as_char = true;
+        let mut para = Paragraph {
+            text: "  (1) Z".to_string(),
+            char_offsets: vec![0, 8, 9, 10, 11, 20, 21],
+            // 파서 규약: char_count = 마지막 stream 위치 + 글자폭 + 끝 마커 1
+            char_count: 23,
+            controls: vec![
+                Control::AutoNumber(AutoNumber {
+                    number_type: AutoNumberType::Endnote,
+                    ..Default::default()
+                }),
+                Control::Equation(equation),
+            ],
+            ..Default::default()
+        };
+        let endnote = Endnote {
+            number: 1,
+            ..Default::default()
+        };
+
+        prepend_endnote_marker_text(&mut para, &endnote);
+
+        // 번호 표기는 그대로여야 한다 (공백이 늘거나 줄지 않는다).
+        assert_eq!(para.text, "1) (1) Z", "미주 번호 표기가 바뀌었다");
+
+        let positions = para.control_text_positions();
+        let eq_idx = para
+            .controls
+            .iter()
+            .position(|c| matches!(c, Control::Equation(_)))
+            .expect("수식 컨트롤은 남아 있어야 한다");
+        let eq_pos = positions[eq_idx];
+        let text_len = para.text.chars().count();
+
+        assert_ne!(
+            eq_pos, text_len,
+            "수식이 문단 끝 폴백으로 밀렸다 (text={:?}, positions={:?})",
+            para.text, positions
+        );
+        // "1) (1)" 바로 뒤 = 6
+        assert_eq!(
+            eq_pos, 6,
+            "수식 위치가 원본 run 순서와 다르다 (text={:?}, positions={:?})",
+            para.text, positions
+        );
     }
 
     fn make_paragraph_with_height(line_height: i32) -> Paragraph {


### PR DESCRIPTION
> PR base 브랜치: **`devel`**

## 변경 요약

미주 본문 첫 문단에 번호(`25) `)를 붙이는 `prepend_endnote_marker_text()` 가 **선행 공백을 지울 때 `autoNum` 의 placeholder 글자까지 함께 지웁니다.** 그런데 그 placeholder 는 HWP stream 에서 **8 code unit** 을 점유하는 반면 `Paragraph::delete_text_at()` 의 `utf16_delta` 는 공백을 **1 unit** 으로 셉니다.

그래서 삭제 직후:

- `char_offsets` 에서 **AutoNumber 를 붙들고 있던 8 unit 갭이 사라지고**,
- `controls[]` 에는 **AutoNumber 가 그대로 남습니다.**

`control_text_positions()` 는 갭을 `controls[]` 순서대로 분배하므로 **컨트롤 N+1 : 갭 N** 이 되어, AutoNumber 가 **뒤따르는 인라인 수식의 갭을 대신 가져가고** 수식은 `paragraph.rs` 의 폴백(`chars.len()`)으로 **문단 끝**에 그려집니다.

번호 텍스트가 이미 autoNum 을 시각적으로 실체화했으므로, **그 컨트롤을 `controls[]` 에서 제거**해 갭과 컨트롤 수를 맞춥니다.

```rust
if leading_spaces > 0
    && matches!(
        para.controls.first(),
        Some(Control::AutoNumber(an)) if an.number_type == AutoNumberType::Endnote
    )
{
    para.controls.remove(0);
}
```

### 증상

미주 본문의 문장 중간 인라인 수식이 뒤로 밀려 **읽는 뜻이 달라집니다**(표시 흔들림이 아니라 내용 오류).

```
원본 run 순서 : <autoNum/> " (1)" <equation A/> " (2)마름모"
기대          : 25) (1) [A] (2)마름모
실제 v0.8.2   : 25) (1) (2)마름모 [A]      ← 수식이 문단 끝으로
```

## 관련 이슈

refs #3466

⚠️ **이슈 #3466 본문에 제가 적어 둔 수정안(`control_text_positions()` 의 jump-8 placeholder 인식)은 철회합니다.** 그 방향은 같은 코퍼스에서 27문단 중 11개만 고쳤고, 고쳐진 11개도 **우연**이었습니다 — 마커의 trailing space 가 마침 stride 16 이라 `stride % 8 == 0` 휴리스틱이 거기 걸린 것이었습니다. 본 PR 의 수정과 **함께 넣으면 과잉 발화해 오히려 깨집니다**(수식이 앞머리에 중복 배치). 이슈 본문도 정리하겠습니다.

## 테스트

- [x] `cargo test --lib` 통과 (**2,956 passed / 0 failed**)
- [x] `cargo clippy --all-targets -- -D warnings` 통과
- [x] `cargo fmt --all -- --check` 통과
- [x] 관련 샘플 파일로 render tree 내보내기 확인

**수정 전 실패 증명** — 추가한 회귀 테스트는 본 수정 없이 다음과 같이 실패합니다:

```
assertion `left != right` failed: 수식이 문단 끝 폴백으로 밀렸다
  (text="1) (1) Z", positions=[6, 8])
  left: 8      ← 수식 위치
 right: 8      ← chars.len() (문단 끝 폴백)
```

`positions=[6, 8]` 에서 보이듯 **AutoNumber 가 6(수식의 갭)을 가져갑니다.**

### 코퍼스 실측

한컴 PDF 를 판정에 쓰지 않았습니다 (CONTRIBUTING §"한컴 PDF 와의 일치 검증에 대해"). **HWPX 원본 XML ↔ `export-render-tree` JSON** 의 인라인 요소 순서를 문자열로 대조했습니다. HWPX 25개 문서 / 짝지어 판정한 수식 포함 문단 7,228개:

| 문단이 `autoNum` 을 가짐 | 정상 | **한 칸 밀림** | 법칙으로 설명 안 됨 |
|---|---|---|---|
| 예 — **수정 전** | 144 | **243** | 6 |
| 예 — **수정 후** | **382** | **5** | 6 |
| 아니오 (수정 전/후 동일) | 6,779 | 0 | 56 |

- **243 → 5** (238문단 해소). 행 합 393 불변 — 문단이 사라지거나 새로 생기지 않았습니다.
- **"설명 안 됨" 6 → 6**, `autoNum` 없는 행 **완전 불변** ⇒ 다른 곳으로 옮겨간 결함이 없습니다.
- 번호 표기 자체는 불변입니다(`'25) '` 유지, 공백이 늘거나 줄지 않음).

### 남은 5건 (이 PR 범위 밖)

한 문단에 `autoNum` 이 **여러 개**인 병합 미주입니다. `prepend_endnote_marker_text` 는 `ep_idx == 0` 에서 첫 컨트롤 하나만 실체화하므로 본 수정도 하나만 제거합니다.

```
원본: [정답]<eq>[정답]⑤        실제: [정답][정답]⑤<eq>
```

같은 근인의 하위 케이스로 보이나 따로 확인이 필요해 이 PR 에는 넣지 않았습니다.

## 스크린샷

해당 없음 (인라인 요소 **순서** 변경이라 render tree 의 자식 배열/bbox 순서로 검증했습니다).
