### PR TITLE
fix(query/#3403): 분할 표 셀 매치가 실제 렌더 쪽을 보고 — RAG 인용 1쪽 어긋남

### DIFF
--- a/src/document_core/queries/grep.rs
+++ b/src/document_core/queries/grep.rs
@@ -123,6 +123,57 @@ impl DocumentCore {
         index
     }
 
+    /// `(구역, 문단, 컨트롤) → [(시작 행, 끝 행, 글로벌 페이지)]` 인덱스.
+    ///
+    /// [#3403] 표가 쪽을 넘겨 이어지면 뒤쪽 행의 셀은 다음 쪽에 렌더되는데, 문단 단위
+    /// 페이지 인덱스는 표 호스트 문단의 **첫 쪽**만 알고 있다. 그래서 분할 표 셀 매치가
+    /// 한 쪽 앞을 가리켰다(RAG 인용이 엉뚱한 쪽을 렌더). 행 범위를 함께 들고 있으면
+    /// 셀의 행 번호로 실제 렌더 쪽을 고를 수 있다.
+    ///
+    /// 분할되지 않은 표(`PageItem::Table`)도 전 행 범위로 함께 넣어, 셀 경로가 항상 같은
+    /// 조회를 쓰도록 한다.
+    fn build_table_row_page_index(
+        &self,
+    ) -> HashMap<(usize, usize, usize), Vec<(usize, usize, u32)>> {
+        let mut index: HashMap<(usize, usize, usize), Vec<(usize, usize, u32)>> = HashMap::new();
+        let mut global_offset = 0u32;
+        for (sec_idx, pr) in self.pagination.iter().enumerate() {
+            for (local_i, page) in pr.pages.iter().enumerate() {
+                let global_page = global_offset + local_i as u32;
+                for col in &page.column_contents {
+                    for item in &col.items {
+                        match item {
+                            PageItem::Table {
+                                para_index,
+                                control_index,
+                            } => {
+                                index
+                                    .entry((sec_idx, *para_index, *control_index))
+                                    .or_default()
+                                    .push((0, usize::MAX, global_page));
+                            }
+                            PageItem::PartialTable {
+                                para_index,
+                                control_index,
+                                start_row,
+                                end_row,
+                                ..
+                            } => {
+                                index
+                                    .entry((sec_idx, *para_index, *control_index))
+                                    .or_default()
+                                    .push((*start_row, *end_row, global_page));
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+            global_offset += pr.pages.len() as u32;
+        }
+        index
+    }
+
     /// 문서를 검색해 주소가 붙은 매치 목록을 돌려준다.
     ///
     /// 본문·표 셀·글상자를 순회한다(`search_all` 과 같은 범위). `limit` 이 `Some` 이면
@@ -132,6 +183,7 @@ impl DocumentCore {
             return Vec::new();
         }
         let page_index = self.build_paragraph_page_index();
+        let table_row_pages = self.build_table_row_page_index();
         let qlen = query.chars().count();
         let mut out: Vec<GrepMatch> = Vec::new();
 
@@ -139,21 +191,43 @@ impl DocumentCore {
             for (para_idx, para) in section.paragraphs.iter().enumerate() {
                 let page = page_index.get(&(sec_idx, para_idx)).copied();
 
+                let make_at =
+                    |page: Option<u32>,
+                     text: &str,
+                     offset: usize,
+                     cell: Option<CellRef>,
+                     textbox: Option<TextBoxRef>,
+                     equation: Option<EquationRef>| GrepMatch {
+                        section: sec_idx,
+                        paragraph: para_idx,
+                        page,
+                        char_offset: offset,
+                        length: qlen,
+                        text: text.to_string(),
+                        context: make_context(text, offset, qlen),
+                        cell,
+                        textbox,
+                        equation,
+                    };
                 let make = |text: &str,
                             offset: usize,
                             cell: Option<CellRef>,
                             textbox: Option<TextBoxRef>,
-                            equation: Option<EquationRef>| GrepMatch {
-                    section: sec_idx,
-                    paragraph: para_idx,
-                    page,
-                    char_offset: offset,
-                    length: qlen,
-                    text: text.to_string(),
-                    context: make_context(text, offset, qlen),
-                    cell,
-                    textbox,
-                    equation,
+                            equation: Option<EquationRef>| {
+                    make_at(page, text, offset, cell, textbox, equation)
+                };
+                // [#3403] 분할 표 셀은 호스트 문단의 첫 쪽이 아니라 그 행이 실제로 렌더되는
+                // 쪽을 쓴다. 행 범위를 못 찾으면 종전 문단 쪽으로 물러선다.
+                let cell_page = |ctrl_idx: usize, row: usize| -> Option<u32> {
+                    table_row_pages
+                        .get(&(sec_idx, para_idx, ctrl_idx))
+                        .and_then(|ranges| {
+                            ranges
+                                .iter()
+                                .find(|(start, end, _)| row >= *start && row < *end)
+                                .map(|(_, _, page)| *page)
+                        })
+                        .or(page)
                 };
 
                 for offset in super::search_query::find_matches(&para.text, query, case_sensitive) {
@@ -173,7 +247,8 @@ impl DocumentCore {
                                         query,
                                         case_sensitive,
                                     ) {
-                                        out.push(make(
+                                        out.push(make_at(
+                                            cell_page(ctrl_idx, cell.row as usize),
                                             &cp.text,
                                             offset,
                                             Some(CellRef {
@@ -197,7 +272,8 @@ impl DocumentCore {
                                                 query,
                                                 case_sensitive,
                                             ) {
-                                                out.push(make(
+                                                out.push(make_at(
+                                                    cell_page(ctrl_idx, cell.row as usize),
                                                     &equation.script,
                                                     offset,
                                                     Some(CellRef {

--- a/tests/issue_3403_split_table_cell_page.rs
+++ b/tests/issue_3403_split_table_cell_page.rs
@@ -1,0 +1,88 @@
+//! Issue #3403: 페이지 분할된 표 안 셀 매치가 표 시작 페이지로 보고되던 문제.
+//!
+//! `grep()` 은 `(구역, 문단) → 첫 페이지` 인덱스 하나로 모든 매치의 페이지를 채웠다. 표가
+//! 쪽을 넘겨 이어지면 뒤쪽 행의 셀은 다음 쪽에 렌더되는데도 호스트 문단의 첫 쪽이 보고돼,
+//! "그 쪽만 렌더해 근거 인용"하는 RAG 루프가 한 쪽 앞을 가리켰다.
+//!
+//! 재현 문서: `samples/2022년 국립국어원 업무계획.hwp` — `Ⅳ. 역점 추진과제` 표(para 586)가
+//! 30–31쪽(0기준)에 걸친다.
+//!
+//! 정답지는 실제 렌더다. `export-svg` 로 뽑은 30쪽에는 "통합사전", 31쪽에는 "내실화"·
+//! "수요조사"·"양성기관" 이 있음을 확인하고 이 계약을 고정했다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const SAMPLE: &str = "samples/2022년 국립국어원 업무계획.hwp";
+const HOST_PARAGRAPH: u64 = 586;
+
+fn sample() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn search_json(query: &str) -> serde_json::Value {
+    let out = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(["search", sample().to_str().unwrap(), query, "--json"])
+        .output()
+        .expect("rhwp 실행 실패");
+    assert!(
+        out.status.success(),
+        "search 실패: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_slice(&out.stdout).expect("search JSON 파싱")
+}
+
+/// 분할 표 안 매치는 호스트 문단의 첫 쪽이 아니라 **그 행이 렌더되는 쪽**으로 보고돼야 한다.
+#[test]
+fn split_table_cell_matches_report_rendered_page() {
+    let json = search_json("한국어");
+    let matches = json["matches"].as_array().expect("matches 배열");
+    let host: Vec<&serde_json::Value> = matches
+        .iter()
+        .filter(|m| m["paragraph"].as_u64() == Some(HOST_PARAGRAPH))
+        .collect();
+    assert!(
+        !host.is_empty(),
+        "재현 문서의 분할 표 문단 {HOST_PARAGRAPH} 매치가 없다"
+    );
+
+    let pages: std::collections::BTreeSet<u64> =
+        host.iter().filter_map(|m| m["page"].as_u64()).collect();
+    assert!(
+        pages.len() > 1,
+        "분할 표인데 매치가 한 쪽으로만 보고됐다: {:?}",
+        pages
+    );
+
+    // 실제 렌더(export-svg) 기준: 30쪽=통합사전, 31쪽=내실화·수요조사·양성기관.
+    for (needle, expected_page) in [
+        ("통합사전 시스템", 30u64),
+        ("내실화", 31),
+        ("수요조사", 31),
+        ("양성기관", 31),
+    ] {
+        let hit = host
+            .iter()
+            .find(|m| m["text"].as_str().is_some_and(|t| t.contains(needle)))
+            .unwrap_or_else(|| panic!("{needle:?} 매치를 찾지 못했다"));
+        assert_eq!(
+            hit["page"].as_u64(),
+            Some(expected_page),
+            "{needle:?} 는 {expected_page}쪽에 렌더된다, got={}",
+            hit["page"]
+        );
+    }
+}
+
+/// 페이지 보정이 매치 자체를 늘리거나 줄이지 않아야 한다(무회귀).
+#[test]
+fn page_attribution_does_not_change_match_count() {
+    let json = search_json("한국어");
+    assert_eq!(
+        json["matchCount"].as_u64(),
+        Some(123),
+        "매치 수가 달라졌다 — 페이지 보정은 개수에 영향을 주지 않아야 한다"
+    );
+}


### PR DESCRIPTION
## 요약

`grep()` 은 `(구역, 문단) → 첫 페이지` 인덱스 하나로 **모든** 매치의 페이지를 채웠다
(`or_insert`). 표가 쪽을 넘겨 이어지면 뒤쪽 행의 셀은 다음 쪽에 렌더되는데도 호스트 문단의
첫 쪽이 보고돼, "그 쪽만 렌더해 근거 인용"하는 RAG 루프가 한 쪽 앞을 가리켰다. 이슈 지적대로
**값이 없는 것보다 있는데 틀린 쪽이 위험하다.**

## 정답지 — 실제 렌더로 독립 확인

이슈 표를 그대로 믿지 않고 `export-svg` 로 두 쪽을 렌더해 텍스트를 뽑아 대조했다.

| 렌더 쪽 | 포함 텍스트 |
|---|---|
| 30쪽 (`_031.svg`) | 통합사전 |
| 31쪽 (`_032.svg`) | 내실화 · 수요조사 · 양성기관 |

## 실측 red→green

`samples/2022년 국립국어원 업무계획.hwp`, para 586 = 30~31쪽에 걸친 표:

| | 수정 전 | 수정 후 |
|---|---|---|
| para 586 매치 25건 | **page 30 × 25** | **page 30 × 5, page 31 × 20** |
| cell 13 (통합사전) | 30 | 30 ✅ |
| cell 28 (내실화) | 30 ❌ | **31** ✅ |
| cell 29 (수요조사·양성기관) | 30 ❌ | **31** ✅ |
| 전체 매치 | 123 | 123 (불변) |

이슈가 낸 정량("25건 중 5건 정확, 20건 틀림")과 정확히 일치한다.

## 변경

- `PageItem::Table` / `PageItem::PartialTable` 에서
  `(구역, 문단, 컨트롤) → [(시작 행, 끝 행, 페이지)]` 인덱스를 만든다.
- **셀 매치만** 셀의 행 번호로 실제 렌더 쪽을 고른다. 범위를 못 찾으면 종전 문단 쪽으로
  물러선다(폴백 보존).
- 분할되지 않은 표도 전 행 범위(`0..usize::MAX`)로 함께 넣어, 셀 경로가 항상 같은 조회를 쓴다.
- 본문 문단·글상자 경로는 **무변경**이다.

이슈 제안 (1)(본문 분할 문단의 char offset 기반 정밀 매핑)은 이번 범위에 넣지 않았다 —
관측된 오보고는 전부 분할 표 셀에서 나왔고(전체 123건 중 어긋난 20건 모두), 본문 문단은
"인용은 시작 위치 기준" 규약과도 어긋나지 않는다. 필요해지면 별도 축으로 다룰 수 있다.

## 검증

- 회귀 테스트 2건 추가 (`tests/issue_3403_split_table_cell_page.rs`): 렌더 쪽 계약 /
  매치 수 무회귀
- `cargo nextest run --no-fail-fast`: **4,196건 전건 통과**
- `cargo clippy -- -D warnings` 통과, 변경 파일 rustfmt 클린
- 최신 `devel` 워크트리에서 빌드·테스트해 확인했다

Refs #3403
