### PR TITLE
fix(core/#3380): 채운 값이 안내문과 같아도 보존 — 적재 정규화가 실값을 잔재로 오인

### DIFF
--- a/src/document_core/queries/field_query.rs
+++ b/src/document_core/queries/field_query.rs
@@ -548,6 +548,20 @@ impl DocumentCore {
             .ok_or_else(|| HwpError::InvalidField("field_range 인덱스 초과".into()))?;
         current_fr.start_char_idx = start_idx;
         current_fr.end_char_idx = new_end;
+        let control_idx = current_fr.control_idx;
+
+        // [#3380] 값을 채운 필드는 더 이상 "초기 상태"가 아니다 — properties 비트 15를 세운다.
+        //
+        // 적재 시 `clear_initial_field_texts` 는 비트 15가 0 인 ClickHere 필드의 텍스트가
+        // 안내문과 같으면 "한컴이 남긴 안내문 잔재"로 보고 지운다. 그래서 채운 값이 하필
+        // 안내문과 같으면(행정 서식의 "주무관"·"공개"·"해당없음" 등 흔한 실값) 저장·재적재
+        // 후 그 칸만 소리 없이 비었다. 쓰기 시점에 상태를 표시해 두면 정규화가 값을 잔재로
+        // 오인하지 않는다. 비트 15 는 이 정규화와 Memo 직렬화에서만 쓰여 렌더에 영향이 없다.
+        if !value.is_empty() {
+            if let Some(Control::Field(field)) = para.controls.get_mut(control_idx) {
+                field.properties |= 1 << 15;
+            }
+        }
 
         // char_offsets 재생성: FIELD_BEGIN/END 갭, 탭 폭, UTF-16 code unit 크기 반영
         rebuild_char_offsets(para);

--- a/tests/issue_3380_field_value_equals_guide.rs
+++ b/tests/issue_3380_field_value_equals_guide.rs
@@ -1,0 +1,91 @@
+//! Issue #3380: 채울 값이 누름틀 안내문과 같으면 저장 후 조용히 유실된다.
+//!
+//! 적재 시 `clear_initial_field_texts` 는 **properties 비트 15 == 0**(초기 상태)인 ClickHere
+//! 필드의 텍스트가 안내문과 같으면 "한컴이 남긴 안내문 잔재"로 보고 지운다. 그런데 값을
+//! 채우는 경로가 그 비트를 세우지 않아, 하필 안내문과 같은 값(행정 서식의 "주무관"·"공개"·
+//! "해당없음" 등 흔한 실값)을 넣으면 저장·재적재 후 그 칸만 비었다. `fill-fields` 는 성공으로
+//! 보고하므로 재독 대조 없이는 드러나지 않는다.
+//!
+//! 트리거는 길이가 아니라 **안내문과의 문자열 일치**다 — 같은 길이의 다른 값은 살아남는다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+const SAMPLE: &str = "samples/field-01.hwp";
+const FIELD: &str = "회사명";
+/// `samples/field-01.hwp` 의 `회사명` 안내문.
+const GUIDE: &str = "여기에 입력";
+
+fn load() -> rhwp::wasm_api::HwpDocument {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"));
+    rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse")
+}
+
+fn field_value(doc: &rhwp::wasm_api::HwpDocument, name: &str) -> String {
+    let json = doc.get_field_list();
+    let v: serde_json::Value = serde_json::from_str(&json).expect("field list JSON");
+    let fields = v["fields"]
+        .as_array()
+        .or_else(|| v.as_array())
+        .expect("fields 배열");
+    fields
+        .iter()
+        .find(|f| f["name"] == name)
+        .map(|f| f["value"].as_str().unwrap_or("").to_string())
+        .unwrap_or_else(|| panic!("필드 {name} 없음"))
+}
+
+/// 값을 채우고 저장·재적재한 뒤의 값을 돌려준다.
+fn fill_and_roundtrip(value: &str) -> String {
+    let mut doc = load();
+    doc.set_field_value_by_name_api(FIELD, value)
+        .expect("set_field_value_by_name");
+    assert_eq!(
+        field_value(&doc, FIELD),
+        value,
+        "메모리 반영은 종전에도 정상이었다"
+    );
+    let saved = doc.export_hwp().expect("export_hwp");
+    let reloaded = rhwp::wasm_api::HwpDocument::from_bytes(&saved).expect("재적재");
+    field_value(&reloaded, FIELD)
+}
+
+/// 안내문과 **같은** 값도 저장 후 살아남아야 한다.
+#[test]
+fn value_equal_to_guide_survives_roundtrip() {
+    assert_eq!(
+        fill_and_roundtrip(GUIDE),
+        GUIDE,
+        "안내문과 같은 값이 저장·재적재에서 유실됐다"
+    );
+}
+
+/// 안내문과 다른 값은 종전대로 보존된다(무회귀). 같은 길이도 함께 확인해, 트리거가 길이가
+/// 아니라 문자열 일치임을 계약으로 남긴다.
+#[test]
+fn other_values_survive_roundtrip() {
+    for value in ["주식회사 가나다", "가나다라마바", "가나"] {
+        assert_eq!(
+            fill_and_roundtrip(value),
+            value,
+            "안내문과 다른 값 {value:?} 이 유실됐다"
+        );
+    }
+}
+
+/// 빈 값으로 되돌리면 안내문 상태(빈 값)로 남아야 한다 — 채움 표시가 굳어버리지 않는다.
+#[test]
+fn clearing_value_returns_to_empty() {
+    let mut doc = load();
+    doc.set_field_value_by_name_api(FIELD, "주식회사 가나다")
+        .expect("채우기");
+    doc.set_field_value_by_name_api(FIELD, "").expect("비우기");
+    let saved = doc.export_hwp().expect("export_hwp");
+    let reloaded = rhwp::wasm_api::HwpDocument::from_bytes(&saved).expect("재적재");
+    assert_eq!(
+        field_value(&reloaded, FIELD),
+        "",
+        "비운 필드는 빈 값이어야 함"
+    );
+}


### PR DESCRIPTION
## 요약

값이 누름틀 안내문과 같으면 `fill-fields` 는 성공으로 보고하는데 저장 후 재독하면 그 칸만
비어 있었다. 행정 서식의 안내문은 흔한 실값과 자주 겹친다("주무관"·"공개"·"해당없음").
재독 대조 없이는 드러나지 않는 무언 유실이다.

## 근인 — 이슈의 추정과 다른 지점

이슈는 "setter 의 dirty-check" 를 추정했지만, **메모리 반영은 종전에도 정상**이었다. 손실은
**저장 후 재적재**에서만 일어난다.

적재 시 도는 `clear_initial_field_texts` 는 한컴이 안내문을 필드 값으로 넣어버린 경우
(메모 추가 등)를 빈 필드로 정규화한다. 그 판별이 **"properties 비트 15(수정됨) == 0 이고
텍스트가 안내문과 같음"** 인데, 값을 채우는 경로가 그 비트를 세우지 않았다. 그래서 채운
실값이 하필 안내문과 같으면 정규화가 잔재로 오인해 지웠다.

## 트리거를 실측으로 좁혔다

같은 길이의 다른 값으로 대조해, 트리거가 **길이가 아니라 안내문과의 문자열 일치**임을 확인했다.

| 채운 값 | 수정 전 (저장·재적재) | 수정 후 |
|---|---|---|
| `주식회사 가나다` (8자) | 보존 | 보존 |
| **`여기에 입력` (안내문, 6자)** | **유실** | **보존** |
| `가나다라마바` (6자, 같은 길이) | 보존 | 보존 |
| `가나` (2자) | 보존 | 보존 |

## 변경

- `set_field_text_at`(ClickHere 쓰기의 단일 지점)에서 비어 있지 않은 값을 쓰면
  `properties |= 1 << 15` 로 "초기 상태 아님"을 표시한다.
- **빈 값으로 되돌리는 경로는 비트를 세우지 않아** 안내문 상태로 정상 복귀한다(테스트로 고정).
- 비트 15 는 이 정규화(`document.rs`)와 Memo 직렬화(`serializer/control.rs`)에서만 참조되어
  렌더·조판에 영향이 없음을 전수 확인했다.

## 검증

- 회귀 테스트 3건 추가 (`tests/issue_3380_field_value_equals_guide.rs`)
  - 안내문과 같은 값의 라운드트립 보존
  - 다른 값 무회귀 — 같은 길이 값을 포함해 "트리거는 문자열 일치" 를 계약으로 남김
  - 비우기 후 빈 값 복귀
- `cargo nextest run --no-fail-fast`: **4,223건 전건 통과**
- `cargo clippy -- -D warnings` 통과, 변경 파일 rustfmt 클린
- 최신 `devel` 워크트리에서 빌드·테스트해 확인

## 이슈 제안 중 남긴 것

제안 2번(“fill-fields 가 기록 후 재독으로 filled/notApplied 를 구분해 보고”)은 넣지 않았다.
이번 수정으로 무언 유실 자체가 사라졌고, 재독 보고는 CLI 계약 변경이라 별도 조각이 맞다고
봤다. 필요하시면 이어서 다루겠다.

Refs #3380
