### PR TITLE
fix(render/#3375): 빈 누름틀 안내문을 인쇄 등가 프로필에서 미출력 — 프로필 계약에 누름틀 축 편입

### DIFF
--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -5514,6 +5514,11 @@ impl LayoutEngine {
                             }),
                             BoundingBox::new(guide_x, y, guide_width, line_height),
                         );
+                        // [#3375] 안내문은 한컴 편집 화면에서만 보이고 인쇄·PDF 에는 나가지
+                        // 않는다. 그림 미지정 placeholder(#2225)와 같은 계약이라 같은
+                        // `editor_only` 표시를 쓴다 — 흐름 폭에는 영향이 없으므로(별도 마커
+                        // 노드) 쪽수·줄바꿈은 프로필과 무관하게 동일하다.
+                        let guide_node = guide_node.with_editor_only();
                         markers.push(MarkerInsert {
                             marker_x: guide_x,
                             marker_w: guide_width,

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -85,6 +85,15 @@ pub struct SvgRenderer {
     pub debug_overlay: bool,
     /// 편집 화면 전용 missing-picture placeholder 표시 여부.
     pub show_missing_picture_placeholder: bool,
+    /// [#3375] `editor_only` 노드(빈 누름틀 안내문 등) 표시 여부.
+    ///
+    /// 한컴은 편집 화면에서만 보여 주는 요소를 인쇄·PDF 에서는 내보내지 않는다. paint
+    /// LayerBuilder 는 이미 `editor_only` 를 프로필로 걸러내지만 SVG 렌더러는 렌더 트리를
+    /// 직접 순회해 그 계약 밖에 있었다.
+    ///
+    /// 기본값은 **표시(true)** 다 — 프로필 개념이 없는 legacy 경로(편집 화면 렌더)는 종전대로
+    /// 트리를 그대로 그린다. 프로필을 아는 layer 경로만 `shows_editor_visuals()` 로 내린다.
+    pub show_editor_only_nodes: bool,
     /// 디버그 오버레이용: 문단별 경계 수집 (pi → bbox)
     overlay_para_bounds: std::collections::HashMap<usize, OverlayBounds>,
     /// 디버그 오버레이용: 표 경계 수집
@@ -167,6 +176,7 @@ impl SvgRenderer {
             show_control_codes: false,
             debug_overlay: false,
             show_missing_picture_placeholder: false,
+            show_editor_only_nodes: true,
             overlay_para_bounds: std::collections::HashMap::new(),
             overlay_table_bounds: Vec::new(),
             overlay_image_bounds: Vec::new(),
@@ -253,6 +263,11 @@ impl SvgRenderer {
     /// 개별 노드를 SVG로 렌더링
     fn render_node(&mut self, node: &RenderNode) {
         if !node.visible {
+            return;
+        }
+        // [#3375] 편집 화면 전용 요소는 인쇄 등가 profile 에서 내보내지 않는다
+        // (paint LayerBuilder 의 `editor_only` 계약과 동형).
+        if node.editor_only && !self.show_editor_only_nodes {
             return;
         }
 

--- a/src/renderer/svg_layer.rs
+++ b/src/renderer/svg_layer.rs
@@ -242,6 +242,7 @@ impl LayerRenderer for SvgLayerRenderer {
         self.renderer.show_control_codes = tree.output_options.show_control_codes;
         self.renderer.debug_overlay = tree.output_options.debug_overlay;
         self.renderer.show_missing_picture_placeholder = tree.profile.shows_editor_visuals();
+        self.renderer.show_editor_only_nodes = tree.profile.shows_editor_visuals();
         let render_tree = self.build_render_tree(tree);
         self.renderer.render_tree(&render_tree);
         Ok(())

--- a/tests/issue_3375_field_guide_print_profile.rs
+++ b/tests/issue_3375_field_guide_print_profile.rs
@@ -1,0 +1,78 @@
+//! Issue #3375: 빈 누름틀 안내문이 인쇄 등가 프로필에서도 출력되던 문제.
+//!
+//! 한컴은 안내문(빨간 이탤릭)을 편집 화면에서만 보여 주고 인쇄·PDF 에는 내보내지 않는다.
+//! 그림 미지정 placeholder(#2225/#2297)에는 이미 프로필 계약이 있었지만 누름틀 안내문 축에는
+//! 적용돼 있지 않았다.
+//!
+//! 렌더 노드의 `editor_only` 표시는 paint LayerBuilder 가 이미 프로필로 걸러내지만, SVG
+//! 렌더러는 렌더 트리를 직접 순회해 그 계약 밖에 있었다 — 두 곳을 함께 맞춘다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+const SAMPLE: &str = "samples/field-01.hwp";
+/// `samples/field-01.hwp` 의 빈 누름틀 안내문.
+const GUIDE: &str = "여기에 입력";
+
+fn svg_text(profile: &str) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"));
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse");
+    let svg = doc
+        .render_page_svg_with_profile(0, profile)
+        .unwrap_or_else(|e| panic!("render {profile}: {e:?}"));
+    // `<text>` 안 내용만 이어 붙여 공백을 지운다 — SVG 는 글자를 여러 요소로 쪼갠다.
+    let mut out = String::new();
+    let mut rest = svg.as_str();
+    while let Some(open) = rest.find("<text") {
+        let after = &rest[open..];
+        let Some(gt) = after.find('>') else {
+            break;
+        };
+        let body = &after[gt + 1..];
+        let Some(close) = body.find("</text>") else {
+            break;
+        };
+        out.push_str(&body[..close]);
+        rest = &body[close + "</text>".len()..];
+    }
+    out.chars().filter(|c| !c.is_whitespace()).collect()
+}
+
+fn guide_needle() -> String {
+    GUIDE.chars().filter(|c| !c.is_whitespace()).collect()
+}
+
+/// 편집 화면 프로필에서는 안내문이 보여야 한다(종전 동작 보존).
+#[test]
+fn screen_profile_keeps_field_guide() {
+    let text = svg_text("screen");
+    assert!(
+        text.contains(&guide_needle()),
+        "편집 화면에서는 안내문이 보여야 한다"
+    );
+}
+
+/// 인쇄 등가 프로필에서는 안내문이 나가지 않아야 한다.
+#[test]
+fn print_profile_suppresses_field_guide() {
+    let text = svg_text("print");
+    assert!(
+        !text.contains(&guide_needle()),
+        "인쇄 프로필에 안내문이 남았다: {text}"
+    );
+}
+
+/// 안내문 억제는 **표시**만 바꾼다 — 본문 텍스트는 두 프로필에서 같아야 한다.
+/// (안내문은 별도 마커 노드라 흐름 폭에 영향이 없어 쪽수·줄바꿈이 갈리지 않는다.)
+#[test]
+fn suppression_only_removes_guide_text() {
+    let screen = svg_text("screen");
+    let print = svg_text("print");
+    let needle = guide_needle();
+    let screen_without_guides = screen.replace(&needle, "");
+    assert_eq!(
+        screen_without_guides, print,
+        "안내문 외의 본문이 프로필에 따라 달라졌다"
+    );
+}


### PR DESCRIPTION
## 요약

한컴은 빈 누름틀 안내문(빨간 이탤릭)을 편집 화면에서만 보여 주고 인쇄·PDF 에는 내보내지
않는다. 그림 미지정 placeholder(#2225/#2297)에는 이미 프로필 계약이 있었지만 **누름틀 안내문
축에는 적용돼 있지 않아** `export-svg --profile print` 와 `export-pdf`(기본 print)에서 안내문이
그대로 출력됐다.

## 근인

안내문은 레이아웃 단계에서 별도 마커 노드로 주입되는데, 프로필 계약에 연결돼 있지 않았다.
필요한 인프라는 이미 있었다.

- 렌더 노드의 **`editor_only`** 표시 + `RenderProfile::shows_editor_visuals()` 술어
- paint `LayerBuilder` 는 이 계약으로 이미 걸러낸다(`builder.rs`)
- 그런데 **SVG 렌더러는 렌더 트리를 직접 순회**해 그 계약 밖에 있었다

## 변경

1. 레이아웃에서 만드는 안내문 노드에 `with_editor_only()` 표시
2. SVG 순회 진입에서 `editor_only` 노드를 프로필에 따라 건너뛰기 — 그림 placeholder 처리와 동형
3. 억제는 **profile 을 아는 layer 경로에서만** 발동. 원시 `SvgRenderer` 기본값은 표시(true)라
   profile 개념이 없는 legacy 편집 렌더는 종전 그대로다

## 실측

| 프로필 | 수정 전 | 수정 후 |
|---|---|---|
| screen | 안내문 출력 (56자) | 안내문 출력 (56자) — 불변 |
| **print** | **안내문 출력 (56자)** | **억제 (31자)** |

`export-pdf` 는 기본이 `RenderProfile::Print` 라 같은 계약을 탄다.

**설계상 중요한 점**: 안내문은 별도 마커 노드라 흐름 폭에 기여하지 않는다 — 억제해도
**쪽수·줄바꿈이 프로필에 따라 갈리지 않는다.** 이 불변식을 세 번째 테스트로 고정했다.

## 검증

- 회귀 테스트 3건 추가 (`tests/issue_3375_field_guide_print_profile.rs`)
  - 편집 프로필 유지 / 인쇄 프로필 억제 / **본문 동일성**(두 프로필의 차이가 안내문뿐)
- `cargo nextest run --no-fail-fast`: **4,229건 전건 통과**
- `cargo clippy -- -D warnings` 통과, 변경 파일 rustfmt 클린
- 최신 `devel` 워크트리에서 빌드·테스트

### 게이트가 잡아 준 것

첫 시도에서 억제 기본값을 `false` 로 두었더니 **profile 개념이 없는 legacy SVG 경로(편집 화면
렌더)에서도 안내문이 사라졌고**, `test_task229_field_svg_guide_text` 가 이를 검출했다. 기본값을
표시로 되돌려 변화를 인쇄 등가 프로필에만 한정했다.

## 범위 밖으로 남긴 것

이슈의 부수 관찰(빈 안내문이 레이아웃에서 폭 0 취급되어 같은 줄 뒤 텍스트와 겹침)은 **편집 화면
레이아웃 축**이라 넣지 않았다. 한컴 편집 화면 동작과의 정합 확인이 별도로 필요하고, 인쇄 계약과는
독립이다. 필요하시면 별도 조각으로 다루겠다.

Refs #3375
