### PR TITLE
fix(cli/#3476): 반복 누름틀을 색인으로 지목 + 중복 침묵 제거 — 서식 절반이 빈 채 완성본으로 나가던 경로

### DIFF
--- a/src/document_core/queries/field_query.rs
+++ b/src/document_core/queries/field_query.rs
@@ -330,11 +330,39 @@ impl DocumentCore {
 
     /// setFieldValueByName: 필드 이름으로 값 설정
     pub fn set_field_value_by_name(&mut self, name: &str, value: &str) -> Result<String, HwpError> {
+        self.set_field_value_by_name_at(name, 0, value)
+    }
+
+    /// [#3476] 같은 이름이 반복되는 서식에서 **N번째(0 기준)** 필드를 지정해 값을 넣는다.
+    ///
+    /// 실제 제출 서식(규제영향분석서·사업계획서·평가표)은 같은 항목 묶음을 여러 번 요구해
+    /// 한 이름이 십수 번 반복된다. 이름만으로는 첫 매치밖에 지목할 수 없어 나머지를 채울
+    /// 방법이 없었다. 열거 순서는 `fields` 조회 순서(`collect_all_fields`)와 같다.
+    pub fn set_field_value_by_name_at(
+        &mut self,
+        name: &str,
+        occurrence: usize,
+        value: &str,
+    ) -> Result<String, HwpError> {
         let fields = self.collect_all_fields();
         let fi = fields
             .iter()
-            .find(|f| f.field.field_name().map(|n| n == name).unwrap_or(false))
-            .ok_or_else(|| HwpError::InvalidField(format!("필드 이름 '{}' 없음", name)))?;
+            .filter(|f| f.field.field_name().map(|n| n == name).unwrap_or(false))
+            .nth(occurrence)
+            .ok_or_else(|| {
+                let total = fields
+                    .iter()
+                    .filter(|f| f.field.field_name().map(|n| n == name).unwrap_or(false))
+                    .count();
+                if total == 0 {
+                    HwpError::InvalidField(format!("필드 이름 '{}' 없음", name))
+                } else {
+                    HwpError::InvalidField(format!(
+                        "필드 이름 '{}' 의 {} 번째 항목 없음 (총 {}개)",
+                        name, occurrence, total
+                    ))
+                }
+            })?;
 
         let field_id = fi.field.field_id;
         let location = fi.location.clone();
@@ -364,6 +392,18 @@ impl DocumentCore {
             json_escape(&old_value),
             json_escape(value),
         ))
+    }
+
+    /// [#3476] 필드 이름별 개수. 같은 이름이 여러 번 나오는 서식에서 "몇 개 중 몇 개를
+    /// 채웠는지" 를 호출자가 보고할 수 있게 한다.
+    pub fn field_name_counts(&self) -> std::collections::HashMap<String, usize> {
+        let mut counts = std::collections::HashMap::new();
+        for fi in self.collect_all_fields() {
+            if let Some(name) = fi.field.field_name() {
+                *counts.entry(name.to_string()).or_insert(0) += 1;
+            }
+        }
+        counts
     }
 
     /// 셀 필드의 텍스트를 교체한다 (셀의 첫 문단 텍스트를 value로 대체).

--- a/src/main.rs
+++ b/src/main.rs
@@ -1090,6 +1090,7 @@ fn print_help() {
     println!("      누름틀에 값을 채운다 (서식 자동 작성/메일머지)");
     println!();
     println!("      --data <JSON|@파일>       {{\"필드이름\":\"값\"}} 형식. @경로면 파일에서 읽음");
+    println!("                                반복 이름은 \"이름[N]\"(0 기준)로 지목");
     println!("      -o, --output <파일>       출력 파일 (기본: 입력명_filled.hwp)");
     println!("      --dry-run                 파일을 쓰지 않고 변경 예정 내역만 보고");
     println!("      --json                    계약 봉투 JSON을 stdout에 출력");
@@ -8264,10 +8265,25 @@ fn run_edit(args: &[String]) -> i32 {
     }
 }
 
+/// [#3476] `이름[N]` 형태의 `--data` 키에서 (이름, 0 기준 색인)을 뽑는다.
+///
+/// 반복 필드를 지목하기 위한 문법이다. 대괄호가 없거나 숫자가 아니면 `None` — 이름 자체에
+/// 대괄호가 들어간 필드를 깨뜨리지 않도록 **숫자 색인일 때만** 분해한다.
+fn parse_field_occurrence_key(key: &str) -> Option<(&str, usize)> {
+    let rest = key.strip_suffix(']')?;
+    let open = rest.rfind('[')?;
+    let (name, digits) = rest.split_at(open);
+    let idx: usize = digits[1..].parse().ok()?;
+    if name.is_empty() {
+        return None;
+    }
+    Some((name, idx))
+}
+
 /// `edit fill-fields` — 누름틀에 값을 채운다 (메일머지).
 ///
 /// 검증된 코어 경로(`set_field_value_by_name`)를 재사용하므로 새 편집 로직이 없다.
-/// 필드 값만 바꾸므로 레이아웃·구조는 불변이다.
+/// 필드 값만 바꾸므로 레이아웃·구조는 불변이다. [#3476] 반복 이름은 `이름[N]` 으로 지목한다.
 fn edit_fill_fields(args: &[String]) -> i32 {
     let mut file_path: Option<&str> = None;
     let mut data_arg: Option<&str> = None;
@@ -8355,36 +8371,57 @@ fn edit_fill_fields(args: &[String]) -> i32 {
         }
     };
 
-    // 문서에 실재하는 필드 이름을 먼저 모아, 없는 이름을 편집 전에 가려낸다.
-    let existing: std::collections::HashSet<String> = doc
-        .collect_all_fields()
-        .iter()
-        .filter_map(|fi| fi.field.field_name().map(|s| s.to_string()))
-        .collect();
+    // 문서에 실재하는 필드 이름과 **개수**를 먼저 모은다. 없는 이름은 편집 전에 가려내고,
+    // [#3476] 같은 이름이 여러 번 나오면 그 사실을 봉투에 실어 침묵을 없앤다.
+    let name_counts = doc.field_name_counts();
 
     let mut filled: Vec<serde_json::Value> = Vec::new();
     let mut not_found: Vec<String> = Vec::new();
+    let mut ambiguous: Vec<serde_json::Value> = Vec::new();
 
-    for (name, value) in &data {
+    for (key, value) in &data {
         let value_str = match value {
             serde_json::Value::String(s) => s.clone(),
             other => other.to_string(),
         };
-        if !existing.contains(name) {
-            not_found.push(name.clone());
+        // [#3476] `이름[N]` 은 0 기준 occurrence 지정. 색인이 없으면 종전대로 첫 매치다.
+        let (name, occurrence) = match parse_field_occurrence_key(key) {
+            Some((base, idx)) => (base, Some(idx)),
+            None => (key.as_str(), None),
+        };
+        let total = name_counts.get(name).copied().unwrap_or(0);
+        if total == 0 {
+            not_found.push(key.clone());
             continue;
+        }
+        if let Some(idx) = occurrence {
+            if idx >= total {
+                // 범위를 벗어난 색인은 오타와 같은 취급 — 조용히 넘기지 않는다.
+                not_found.push(key.clone());
+                continue;
+            }
+        } else if total > 1 {
+            ambiguous.push(serde_json::json!({
+                "name": name,
+                "matched": 1,
+                "total": total,
+            }));
         }
         if dry_run {
             // 파일을 건드리지 않고 무엇이 바뀔지만 기록한다.
-            filled.push(serde_json::json!({ "name": name, "value": value_str }));
+            filled.push(serde_json::json!({ "name": key, "value": value_str }));
             continue;
         }
-        if let Err(e) = doc.set_field_value_by_name(name, &value_str) {
-            eprintln!("오류: 필드 '{}' 설정 실패 - {}", name, e);
+        let result = match occurrence {
+            Some(idx) => doc.set_field_value_by_name_at(name, idx, &value_str),
+            None => doc.set_field_value_by_name(name, &value_str),
+        };
+        if let Err(e) = result {
+            eprintln!("오류: 필드 '{}' 설정 실패 - {}", key, e);
             // 실패 시 원본 불변 — 출력 파일을 쓰지 않고 즉시 끝낸다.
             return EXIT_RUNTIME;
         }
-        filled.push(serde_json::json!({ "name": name, "value": value_str }));
+        filled.push(serde_json::json!({ "name": key, "value": value_str }));
     }
 
     let output_path = out_path.unwrap_or_else(|| {
@@ -8417,6 +8454,9 @@ fn edit_fill_fields(args: &[String]) -> i32 {
             "filledCount": filled.len(),
             "filled": filled,
             "notFound": not_found,
+            // [#3476] 색인 없이 지정한 이름이 문서에 여러 번 있으면 몇 개 중 몇 개를 채웠는지
+            // 알린다 — 침묵하면 에이전트가 불완전한 산출물을 완성본으로 오해한다.
+            "ambiguous": ambiguous,
         });
         if !dry_run {
             envelope["output"] = serde_json::Value::String(output_path.clone());

--- a/tests/issue_2724_passthrough_invalidation_guard.rs
+++ b/tests/issue_2724_passthrough_invalidation_guard.rs
@@ -207,6 +207,12 @@ const EXEMPT: &[(&str, &str, Exempt, &str)] = &[
         Exempt::SessionState,
         "활성 필드 해제 + 렌더 캐시 무효화. 직렬화 비대상.",
     ),
+    (
+        "queries/field_query.rs",
+        "set_field_value_by_name",
+        Exempt::DelegatesTo("set_field_value_by_name_at"),
+        "[#3476] occurrence 지정판(0번째)에 위임 — 무효화는 위임 대상 본문에서 수행한다.",
+    ),
     // ── 문서 전체 교체·생성 ────────────────────────────────────────────────
     (
         "commands/document.rs",

--- a/tests/issue_3476_fill_fields_repeated_names.rs
+++ b/tests/issue_3476_fill_fields_repeated_names.rs
@@ -1,0 +1,166 @@
+//! Issue #3476: `edit fill-fields` 가 같은 이름의 반복 필드 중 첫 번째만 채우고 침묵한다.
+//!
+//! 실제 제출 서식(규제영향분석서·사업계획서·평가표)은 같은 항목 묶음을 여러 번 요구한다.
+//! `samples/80168_regulatory_analysis.hwp` 는 누름틀 1,070개 중 고유 이름이 151개뿐이고,
+//! `피규제집단명` 은 규제 대상 집단 14개에 대응해 14번 반복된다.
+//!
+//! 종전에는 `{"피규제집단명": "..."}` 가 첫 번째만 채우면서 `filledCount:1`·`notFound:[]` 로
+//! **요청대로 다 됐다** 처럼 보고했다. 에이전트는 13칸이 빈 문서를 완성본으로 제출한다.
+//!
+//! 계약 두 가지를 고정한다.
+//!   1) 색인 없는 키가 반복 이름을 가리키면 `ambiguous` 로 몇 개 중 몇 개인지 보고
+//!   2) `이름[N]`(0 기준)으로 N번째를 지목 — 범위 밖은 `notFound`
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const REPEATED: &str = "samples/80168_regulatory_analysis.hwp";
+/// 14회 반복되는 필드 이름.
+const REPEATED_FIELD: &str = "피규제집단명";
+const REPEAT_COUNT: u64 = 14;
+/// 이름이 겹치지 않는 서식 — 무회귀 확인용.
+const UNIQUE: &str = "samples/field-01.hwp";
+
+fn sample(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn temp_path(tag: &str, ext: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "rhwp-issue3476-{tag}-{}-{}.{ext}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos()
+    ))
+}
+
+fn run(args: &[&str]) -> (serde_json::Value, i32) {
+    let out = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let last = stdout.lines().last().unwrap_or("{}").to_string();
+    let json = serde_json::from_str(&last).unwrap_or_else(|e| {
+        panic!(
+            "JSON 파싱 실패({e}): {last}\nstderr={}",
+            String::from_utf8_lossy(&out.stderr)
+        )
+    });
+    (json, out.status.code().unwrap_or(-1))
+}
+
+fn fill(input: &str, data: &str, out: &Path, extra: &[&str]) -> serde_json::Value {
+    let data_path = temp_path("data", "json");
+    std::fs::write(&data_path, data).expect("data.json 쓰기");
+    let data_arg = format!("@{}", data_path.to_str().unwrap());
+    let input_path = sample(input);
+    let input_arg = input_path.to_str().unwrap().to_string();
+    let out_arg = out.to_str().unwrap().to_string();
+    let mut args = vec![
+        "edit",
+        "fill-fields",
+        input_arg.as_str(),
+        "--data",
+        data_arg.as_str(),
+        "-o",
+        out_arg.as_str(),
+        "--json",
+    ];
+    args.extend_from_slice(extra);
+    let (json, _) = run(&args);
+    let _ = std::fs::remove_file(&data_path);
+    json
+}
+
+fn field_values(path: &Path, name: &str) -> Vec<String> {
+    let (json, _) = run(&["fields", path.to_str().unwrap(), "--json"]);
+    json["fields"]
+        .as_array()
+        .expect("fields 배열")
+        .iter()
+        .filter(|f| f["name"] == name)
+        .map(|f| f["value"].as_str().unwrap_or("").to_string())
+        .collect()
+}
+
+/// 색인 없는 키가 반복 이름을 가리키면 몇 개 중 몇 개인지 보고해야 한다.
+#[test]
+fn plain_key_on_repeated_name_reports_ambiguous() {
+    let out = temp_path("plain", "hwp");
+    let json = fill(REPEATED, r#"{"피규제집단명":"가상협회 회원사"}"#, &out, &[]);
+    assert_eq!(json["filledCount"].as_u64(), Some(1));
+    let ambiguous = json["ambiguous"].as_array().expect("ambiguous 배열");
+    let hit = ambiguous
+        .iter()
+        .find(|a| a["name"] == REPEATED_FIELD)
+        .unwrap_or_else(|| panic!("반복 이름이 보고되지 않았다: {json}"));
+    assert_eq!(hit["matched"].as_u64(), Some(1));
+    assert_eq!(hit["total"].as_u64(), Some(REPEAT_COUNT));
+
+    // 실제로도 첫 번째만 바뀐다(종전 동작 유지 — 무회귀).
+    let values = field_values(&out, REPEATED_FIELD);
+    assert_eq!(values.len() as u64, REPEAT_COUNT);
+    assert_eq!(values[0], "가상협회 회원사");
+    let _ = std::fs::remove_file(&out);
+}
+
+/// `이름[N]` 으로 N번째를 지목할 수 있어야 하고, 범위 밖은 `notFound` 로 드러나야 한다.
+#[test]
+fn indexed_keys_target_each_occurrence() {
+    let out = temp_path("indexed", "hwp");
+    let json = fill(
+        REPEATED,
+        r#"{"피규제집단명[0]":"첫번째집단","피규제집단명[1]":"두번째집단","피규제집단명[13]":"열네번째집단","피규제집단명[14]":"범위초과"}"#,
+        &out,
+        &[],
+    );
+    assert_eq!(
+        json["filledCount"].as_u64(),
+        Some(3),
+        "유효 색인 3개, {json}"
+    );
+    let not_found: Vec<&str> = json["notFound"]
+        .as_array()
+        .expect("notFound 배열")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+    assert_eq!(
+        not_found,
+        vec!["피규제집단명[14]"],
+        "범위 밖 색인은 notFound 로 보고돼야 한다"
+    );
+    assert!(
+        json["ambiguous"].as_array().is_some_and(|a| a.is_empty()),
+        "색인을 지정했으면 모호하지 않다: {json}"
+    );
+
+    let values = field_values(&out, REPEATED_FIELD);
+    assert_eq!(values[0], "첫번째집단");
+    assert_eq!(values[1], "두번째집단");
+    assert_eq!(values[13], "열네번째집단");
+    assert_ne!(values[12], "열네번째집단", "지목하지 않은 항목은 불변");
+    let _ = std::fs::remove_file(&out);
+}
+
+/// 이름이 유일하면 `ambiguous` 는 비어 있어야 한다(무회귀). `--dry-run` 도 같은 보고를 한다.
+#[test]
+fn unique_names_are_not_ambiguous_and_dry_run_matches() {
+    let out = temp_path("unique", "hwp");
+    let json = fill(
+        UNIQUE,
+        r#"{"회사명":"주식회사 가나다"}"#,
+        &out,
+        &["--dry-run"],
+    );
+    assert_eq!(json["filledCount"].as_u64(), Some(1));
+    assert!(
+        json["ambiguous"].as_array().is_some_and(|a| a.is_empty()),
+        "유일한 이름은 모호하지 않다: {json}"
+    );
+    assert!(!out.exists(), "--dry-run 은 출력 파일을 쓰지 않아야 한다");
+}


### PR DESCRIPTION
## 요약

`edit fill-fields` 는 같은 이름이 반복되는 누름틀에서 **첫 번째 하나만 채우고, 다 됐다고
보고**했다. 실제 제출 서식은 같은 항목 묶음을 여러 번 요구한다 —
`samples/80168_regulatory_analysis.hwp` 는 누름틀 1,070개 중 고유 이름이 151개뿐이고
`피규제집단명` 은 규제 대상 집단 14개에 대응해 **14번** 반복된다.

```
{"피규제집단명": "..."}   →   filledCount: 1,  notFound: [],  exit 0
```

`notFound` 가 비어 있고 종료 코드가 0이라, 호출자(특히 에이전트)는 **13칸이 빈 문서를
완성본으로** 넘긴다. "죽지 않았지만 틀렸다" 계열이다.

## 근인

`set_field_value_by_name` 이 `find()` 로 **첫 매치만** 집는다. 나머지 13개를 지목할 수단이
API 에도 CLI 에도 없었고, CLI 는 "이름이 존재하는가" 만 검사(`HashSet`)해 **몇 개인지**를
아예 보지 않았다.

## 변경

1. **코어** — `set_field_value_by_name_at(name, occurrence, value)` 추가. 0 기준 N번째를
   지목한다. 열거 순서는 `fields` 조회 순서(`collect_all_fields`)와 같다. 기존
   `set_field_value_by_name` 은 `occurrence=0` 위임으로 남겨 **동작 불변**.
   범위 밖 색인은 `'이름' 의 N 번째 항목 없음 (총 M개)` 로 개수를 밝힌다.
2. **코어** — `field_name_counts()` 추가(이름별 개수).
3. **CLI** — `--data` 키에 `"이름[N]"` 문법. 색인 없는 키가 반복 이름을 가리키면 봉투에
   `ambiguous: [{name, matched, total}]` 로 **몇 개 중 몇 개를 채웠는지** 싣는다.
   범위 밖 색인은 오타와 같은 취급으로 `notFound`.

`이름[N]` 분해는 **대괄호 안이 숫자일 때만** 한다 — 이름 자체에 대괄호가 든 필드를 깨지
않기 위해서다.

## 실측 (`samples/80168_regulatory_analysis.hwp`, `피규제집단명` ×14)

| 입력 | 수정 전 | 수정 후 |
|---|---|---|
| `{"피규제집단명":"…"}` | `filledCount:1`, `notFound:[]` — **침묵** | `filledCount:1` + `ambiguous:{matched:1, total:14}` |
| `{"…[0]":…,"…[1]":…,"…[13]":…}` | 지목 불가 | `filledCount:3`, 되읽기로 0·1·13번만 변경·나머지 12개 불변 확인 |
| `{"…[14]":…}` | 지목 불가 | `notFound:["피규제집단명[14]"]` |

## 검증

- 회귀 테스트 3건 추가 (`tests/issue_3476_fill_fields_repeated_names.rs`)
  — 모호 보고 / 색인 지목·범위 밖 / 유일 이름 무회귀 + `--dry-run` 동일 보고
- `cargo nextest run --no-fail-fast`: **전건 통과**
- `cargo clippy --all-targets -- -D warnings` 통과, 변경 파일 rustfmt 클린
- 최신 `devel`(cef2363c9) 워크트리에서 빌드·테스트

### #2724 패스스루 가드 등재

`set_field_value_by_name` 이 위임 래퍼가 되면서 자기 본문에 무효화가 없어져
`classification_drift_is_blocked` 가 잡았다. 가드가 지시한 대로 이름 변경으로 회피하지 않고
`Exempt::DelegatesTo("set_field_value_by_name_at")` 로 **분류와 근거를 적어 등재**했다
(위임 대상이 실제로 무효화하는지는 가드의 검사 3이 검증한다). 무효화 밀도 원장은 손대지
않았다 — 사이트 수는 그대로다.

Refs #3476
