### PR TITLE
fix(parser/#3492): HWP3 개요번호 마커를 소비 직후 IR 에서 걷어냄 — 저장 손실과 미주 위치 이탈의 공통 뿌리

### DIFF
--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -3758,6 +3758,38 @@ fn fixup_hwp3_outline_fields(doc: &mut crate::model::document::Document) {
             doc.doc_info.para_shapes.push(outline_shape);
             paragraph.para_shape_id = (doc.doc_info.para_shapes.len() - 1) as u16;
         }
+
+        // [#3492] 번호 정보를 ParaShape 로 옮겼으니 HWP3 전용 마커는 공통 IR 에서 걷어낸다.
+        for paragraph in &mut section.paragraphs {
+            strip_hwp3_outline_marker_controls(paragraph);
+        }
+    }
+}
+
+/// [#3492] 소비를 마친 HWP3 개요번호 마커 컨트롤을 문단에서 제거한다.
+///
+/// 이 마커는 HWP3 전용 표현이고 **텍스트 앵커가 없다** — 오브젝트 문자를 남기지 않아
+/// `char_offsets` 어디에도 대응 위치가 없다. 번호는 이미 `ParaShape::head_type`·`para_level`
+/// 과 `Numbering` 으로 옮겨졌으므로 마커 자체는 잔재다.
+///
+/// 공통 IR 에 남겨 두면 HWP5 저장기가 자리 없는 컨트롤에 필드 begin/end(각 8 코드 유닛)를
+/// 지어내 문자 수를 부풀리고, 재파싱하면 필드로 복원되지 않아 `convert --verify` 가 손실로
+/// 판정한다(SO-SUEOP.hwp 93건).
+fn strip_hwp3_outline_marker_controls(paragraph: &mut crate::model::paragraph::Paragraph) {
+    use crate::model::control::Control;
+
+    for i in (0..paragraph.controls.len()).rev() {
+        let Control::Field(field) = &paragraph.controls[i] else {
+            continue;
+        };
+        if !field.command.starts_with("Outline:") {
+            continue;
+        }
+        paragraph.controls.remove(i);
+        // ctrl_data_records 는 controls 와 인덱스가 1:1 이므로 같이 지워 정렬을 유지한다.
+        if i < paragraph.ctrl_data_records.len() {
+            paragraph.ctrl_data_records.remove(i);
+        }
     }
 }
 

--- a/tests/issue_3492_hwp3_outline_marker_leak.rs
+++ b/tests/issue_3492_hwp3_outline_marker_leak.rs
@@ -1,0 +1,155 @@
+//! Issue #3492: HWP3 문서를 저장하면 재파싱한 IR 이 달라진다 — `convert --verify` 가 exit 3.
+//!
+//! `samples/SO-SUEOP.hwp`(HWP 3.0, 46쪽)를 HWP5 로 저장하고 되읽으면 컨트롤 93개가
+//! 사라진 것으로 보고됐다. 정체는 **HWP3 개요번호 마커**다.
+//!
+//! HWP3 파서는 이 마커를 `Control::Field("Outline:kind=..:level=..")` 로 만든 뒤
+//! `fixup_hwp3_outline_fields` 에서 읽어 `ParaShape::head_type`·`para_level` 과
+//! `Numbering` 으로 옮긴다. 옮긴 뒤에는 아무도 읽지 않는데 공통 IR 에는 그대로 남았다.
+//!
+//! 이 잔재는 **텍스트 앵커가 없다** — 오브젝트 문자를 남기지 않아 `char_offsets` 어디에도
+//! 대응 위치가 없다. 그래서 두 가지가 동시에 깨졌다.
+//!
+//!   1) HWP5 저장기가 자리 없는 컨트롤에 필드 begin/end(각 8 코드 유닛)를 지어내
+//!      문자 수를 부풀리고, 재파싱하면 필드로 복원되지 않아 `--verify` 가 손실로 판정
+//!   2) 앵커가 없으면서도 `controls` 앞자리를 차지해, 같은 문단의 **미주 참조 표시가
+//!      제 오프셋을 빼앗기고** 줄 끝으로 밀렸다
+//!
+//! 계약: 마커는 소비 직후 공통 IR 에서 걷어낸다. 번호 정보는 `ParaShape` 에 남는다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::model::control::Control;
+use rhwp::model::style::HeadType;
+
+const SAMPLE: &str = "samples/SO-SUEOP.hwp";
+/// 개요번호가 붙는 문단 수 — 마커를 걷어내도 번호는 남아야 한다.
+const OUTLINE_PARAGRAPHS: usize = 92;
+
+fn sample_path() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn parse_sample() -> rhwp::model::document::Document {
+    let data = std::fs::read(sample_path()).expect("샘플 읽기");
+    rhwp::parser::parse_document(&data).expect("HWP3 파싱")
+}
+
+fn is_outline_marker(control: &Control) -> bool {
+    matches!(control, Control::Field(f) if f.command.starts_with("Outline:"))
+}
+
+/// HWP3 전용 개요번호 마커는 공통 IR 로 새어 나오지 않는다.
+#[test]
+fn outline_markers_do_not_leak_into_the_common_ir() {
+    let doc = parse_sample();
+    let leaked: Vec<String> = doc
+        .sections
+        .iter()
+        .flat_map(|s| s.paragraphs.iter())
+        .flat_map(|p| p.controls.iter())
+        .filter_map(|c| match c {
+            Control::Field(f) if f.command.starts_with("Outline:") => Some(f.command.clone()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "HWP3 개요번호 마커가 공통 IR 에 남았다 ({}건): {:?}",
+        leaked.len(),
+        &leaked[..leaked.len().min(3)]
+    );
+}
+
+/// 마커를 걷어내도 번호 정보(`head_type`·`Numbering`)는 그대로다 — 정보 손실이 아니다.
+#[test]
+fn outline_numbering_survives_the_marker_removal() {
+    let doc = parse_sample();
+    let numbered = doc
+        .sections
+        .iter()
+        .flat_map(|s| s.paragraphs.iter())
+        .filter(|p| {
+            doc.doc_info
+                .para_shapes
+                .get(p.para_shape_id as usize)
+                .is_some_and(|s| s.head_type == HeadType::Number)
+        })
+        .count();
+    assert_eq!(
+        numbered, OUTLINE_PARAGRAPHS,
+        "개요번호 문단 수가 달라졌다 — 마커 제거가 번호까지 지웠는지 확인하라"
+    );
+    assert!(
+        !doc.doc_info.numberings.is_empty(),
+        "개요번호 정의(Numbering)가 사라졌다"
+    );
+}
+
+/// 앵커 없는 마커가 앞자리를 차지하면 뒤 컨트롤이 제 오프셋을 잃는다.
+///
+/// `char_offsets` 의 8 코드 유닛 공백은 미주 것인데, 마커가 `controls[0]` 이라 그 자리를
+/// 가져가고 미주 표시가 줄 끝으로 밀렸다. 마커를 걷어내면 미주가 제 위치로 돌아온다.
+#[test]
+fn endnote_marks_keep_their_recorded_offset() {
+    let doc = parse_sample();
+    let mut checked = 0usize;
+    for section in &doc.sections {
+        for paragraph in &section.paragraphs {
+            let Some(endnote_idx) = paragraph
+                .controls
+                .iter()
+                .position(|c| matches!(c, Control::Endnote(_)))
+            else {
+                continue;
+            };
+            // 오프셋에 공백이 있는 문단만 — 미주가 본문 중간에 앵커된 경우다.
+            let gap = paragraph
+                .char_offsets
+                .windows(2)
+                .position(|w| w[1] - w[0] > 1);
+            let Some(gap) = gap else { continue };
+            let positions = paragraph.control_text_positions();
+            assert_eq!(
+                positions.get(endnote_idx).copied(),
+                Some(gap + 1),
+                "미주 표시가 기록된 오프셋을 벗어났다: controls={} text={:?} offsets={:?} positions={:?}",
+                paragraph.controls.len(),
+                paragraph.text,
+                paragraph.char_offsets,
+                positions
+            );
+            checked += 1;
+        }
+    }
+    assert!(
+        checked > 0,
+        "미주 앵커 문단을 찾지 못했다 — 표본이 바뀌었는지 확인하라"
+    );
+}
+
+/// 보고된 계약 그대로: `convert --verify` 가 exit 0.
+#[test]
+fn convert_verify_reports_no_ir_loss() {
+    let out = std::env::temp_dir().join(format!(
+        "rhwp-issue3492-{}-{}.hwp",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos()
+    ));
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("convert")
+        .arg(sample_path())
+        .arg(&out)
+        .arg("--verify")
+        .output()
+        .expect("rhwp 실행");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let _ = std::fs::remove_file(&out);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "convert --verify 가 IR 손실을 보고했다:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## 요약

`convert --verify` 가 `samples/SO-SUEOP.hwp`(HWP 3.0, 46쪽)에서 재파싱 IR 차이 92건을
보고하고 exit 3 로 끝났다. 정체는 **HWP3 개요번호 마커가 공통 IR 로 새어 나온 것**이다.

## 근인

HWP3 파서는 마커를 `Control::Field("Outline:kind=..:level=..")` 로 만든 뒤
`fixup_hwp3_outline_fields` 에서 읽어 `ParaShape::head_type`·`para_level` 과 `Numbering` 으로
옮긴다. **옮긴 뒤에는 읽는 곳이 없는데** 공통 IR 에는 그대로 남았다 — 문서 내 field 컨트롤
93건이 전부 이 종류였다(다른 종류 0건).

이 잔재는 **텍스트 앵커가 없다**. 오브젝트 문자를 남기지 않아 `char_offsets` 어디에도 대응
위치가 없다. 그래서 두 가지가 동시에 깨졌다.

**① 저장 손실** — HWP5 저장기가 자리 없는 컨트롤에 필드 begin/end(각 8 코드 유닛)를
지어낸다. 문단 54 의 `cc 6 → 23` 이 `6 + 8 + 8 + 1`(문단 종결자)과 정확히 일치한다.
재파싱하면 필드로 복원되지 않아 `--verify` 가 손실로 판정한다.

**② 미주 위치 이탈** — 앵커가 없으면서 `controls` 앞자리를 차지해, 같은 문단의 **미주 참조
표시가 제 오프셋을 빼앗기고 줄 끝으로 밀렸다**.

```
문단 523  text="금수회의록   안국선"  offsets=[0,1,2,3,4,13,14,15,16,17,18]
          controls=[Field(Outline:…), Endnote(96)]
          control_text_positions() = [5, 11]
                                      ↑ 5 는 미주 것이었다 (offsets 의 8 코드 유닛 공백)
```

`export-text` 에서 `금수회의록   안국선96)` 로 나오던 것이 `금수회의록96)   안국선` 로
바로잡힌다. 컨트롤이 뒤 컨트롤의 자리를 훔치는 **#3466 과 같은 계열**이다.

## 변경

`CLAUDE.md` 의 "HWP3 전용 해석은 `src/parser/hwp3/` 안에서 끝낸다"에 맞춰 파서 안에서 닫는다.
소비 직후 마커 컨트롤을 제거하고, `ctrl_data_records` 의 짝도 같이 지워 인덱스 정렬을 유지한다.

## 실측

| 지표 | 수정 전 | 수정 후 |
|---|---|---|
| `convert --verify` | **exit 3** (IR 차이 92건) | **exit 0** (IR 차이 없음) |
| `ir-diff` 컨트롤 차이 | 96 | **3** |
| 개요번호 문단 / `Numbering` | 92 / 있음 | 92 / 있음 — **불변** |
| 페이지 수 | 46 | 46 — **불변** |
| 미주 표시 위치 | 줄 끝(11) | **기록된 오프셋(5)** |

번호 정보는 `ParaShape` 에 남으므로 **정보 손실이 아니다**. 마커만 걷어낸다.

## 검증

- 회귀 테스트 4건 추가 (`tests/issue_3492_hwp3_outline_marker_leak.rs`)
  — 마커 미유출 / 번호 보존 / 미주 오프셋 / `convert --verify` exit 0
  — **수정을 되돌리면 3건이 red** (번호 보존은 양쪽 green — 의도한 무회귀 축)
- `cargo nextest run --no-fail-fast`: **4,230건 전건 통과**
- `cargo clippy --all-targets -- -D warnings` 통과, 변경 파일 rustfmt 클린
- 최신 `devel`(cef2363c9) 워크트리에서 빌드·테스트

## 범위 밖으로 남긴 것 (별개 축, 이 PR 로 바뀌지 않음)

조사 중 확인했으나 보고된 결함과 뿌리가 다르고, 함께 고치면 변경이 번져 따로 둔다.

1. **`cc` 규약 어긋남 (928문단)** — HWP3 파싱은 `char_count` = 본문 길이, HWP5 파싱은
   본문 길이 + 1(문단 종결자). `--verify` 는 `cc` 를 비교하지 않아 이번 판정에는 안 걸렸다.
2. **미주 표시 왕복 ±1** — HWP3 원본과 HWP5 왕복본의 `export-text` 가 여전히 131 hunk
   차이(수정 전 132). 마커와 무관한 선행 결함이다.

필요하시면 각각 이슈로 올리고 별도 조각으로 다루겠다.

Refs #3492
