### PR TITLE
feat(cli/#3480): 값이 칸을 넘치면 봉투에 신호 — 렌더 트리 직독으로 침묵 제거

### DIFF
--- a/src/document_core/queries/cell_fit.rs
+++ b/src/document_core/queries/cell_fit.rs
@@ -1,0 +1,165 @@
+//! [#3480] 셀 맞춤 측정 — "이 값이 이 칸에 들어가는가"를 **렌더 트리에서 직독**한다.
+//!
+//! `edit set-cell`·`edit fill-fields` 는 값이 칸을 넘쳐도 성공만 보고했다. 에이전트는
+//! 렌더 결과를 보지 않으므로, 사람이라면 제출하지 않을 문서를 완성본으로 넘긴다.
+//!
+//! 이 질의는 **조판 엔진이 있어야만 가능한 답**이다. 폭을 따로 추정하지 않고 실제 렌더
+//! 트리의 셀 상자와 그 안의 텍스트 줄을 읽는다 — 측정 경로와 렌더 경로가 갈라지는
+//! 알려진 함정(#2237)을 피하기 위해서다.
+
+use crate::document_core::DocumentCore;
+use crate::error::HwpError;
+use crate::renderer::render_tree::{RenderNode, RenderNodeType};
+
+/// 한 셀의 렌더 실측치.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CellFit {
+    /// 셀 상자 폭 (px)
+    pub cell_width_px: f64,
+    /// 셀 상자 높이 (px)
+    pub cell_height_px: f64,
+    /// 셀 안에서 가장 넓은 렌더 줄의 폭 (px)
+    pub text_width_px: f64,
+    /// 셀 안 렌더 줄 수
+    pub lines: usize,
+    /// 렌더 줄이 셀 상자 오른쪽을 넘었는가
+    pub clipped_horizontally: bool,
+}
+
+impl CellFit {
+    /// 값이 이 칸에 한 줄로 들어갔는가.
+    pub fn fits_on_one_line(&self) -> bool {
+        self.lines <= 1 && !self.clipped_horizontally
+    }
+}
+
+/// 셀을 가리키는 방법 — 격자 좌표 또는 모델 셀 인덱스.
+#[derive(Debug, Clone, Copy)]
+pub enum CellSelector {
+    /// `set-cell` 의 격자 주소
+    RowCol { row: u16, col: u16 },
+    /// 필드 위치(`NestedEntry::TableCell`)가 주는 모델 셀 인덱스
+    ModelIndex(usize),
+}
+
+impl DocumentCore {
+    /// [#3480] 표 셀의 렌더 실측치를 돌려준다.
+    ///
+    /// `section_index`/`para_index`/`control_index` 는 표 컨트롤의 위치다
+    /// (`table_extract::extract_tables` 가 주는 좌표와 같다).
+    ///
+    /// 표를 찾지 못하면 `Ok(None)` — 측정 실패는 편집 실패가 아니므로 오류로 올리지 않는다.
+    pub fn measure_cell_fit(
+        &self,
+        section_index: usize,
+        para_index: usize,
+        control_index: usize,
+        selector: CellSelector,
+    ) -> Result<Option<CellFit>, HwpError> {
+        let total_pages = self.page_count() as usize;
+        for page in 0..total_pages {
+            let tree = self.build_page_tree_cached(page as u32)?;
+            if let Some(fit) = find_cell_fit(
+                &tree.root,
+                section_index,
+                para_index,
+                control_index,
+                selector,
+            ) {
+                return Ok(Some(fit));
+            }
+        }
+        Ok(None)
+    }
+}
+
+fn selector_matches(node: &crate::renderer::render_tree::TableCellNode, s: CellSelector) -> bool {
+    match s {
+        CellSelector::RowCol { row, col } => node.row == row && node.col == col,
+        CellSelector::ModelIndex(idx) => node.model_cell_index == Some(idx as u32),
+    }
+}
+
+fn find_cell_fit(
+    node: &RenderNode,
+    sec: usize,
+    para: usize,
+    ctrl: usize,
+    selector: CellSelector,
+) -> Option<CellFit> {
+    if let RenderNodeType::Table(ref table) = node.node_type {
+        if table.section_index == Some(sec)
+            && table.para_index == Some(para)
+            && table.control_index == Some(ctrl)
+        {
+            for child in &node.children {
+                let RenderNodeType::TableCell(ref cell) = child.node_type else {
+                    continue;
+                };
+                if !selector_matches(cell, selector) {
+                    continue;
+                }
+                return Some(measure(child));
+            }
+            // 표는 찾았으나 그 셀이 이 쪽에 없다 — 분할 표의 다음 쪽을 계속 본다.
+            return None;
+        }
+    }
+    for child in &node.children {
+        if let Some(found) = find_cell_fit(child, sec, para, ctrl, selector) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// 셀 노드 아래의 텍스트 줄을 모아 실측치를 만든다.
+fn measure(cell_node: &RenderNode) -> CellFit {
+    let mut lines = 0usize;
+    let mut widest = 0.0f64;
+    let mut rightmost = f64::NEG_INFINITY;
+    collect_lines(cell_node, &mut lines, &mut widest, &mut rightmost);
+
+    let cell_right = cell_node.bbox.x + cell_node.bbox.width;
+    CellFit {
+        cell_width_px: cell_node.bbox.width,
+        cell_height_px: cell_node.bbox.height,
+        text_width_px: if widest.is_finite() { widest } else { 0.0 },
+        lines,
+        // 0.5px 는 렌더 반올림 여유 — 이보다 작은 초과는 넘침으로 보지 않는다.
+        clipped_horizontally: rightmost.is_finite() && rightmost > cell_right + 0.5,
+    }
+}
+
+fn collect_lines(node: &RenderNode, lines: &mut usize, widest: &mut f64, rightmost: &mut f64) {
+    for child in &node.children {
+        match child.node_type {
+            RenderNodeType::TextLine(_) => {
+                *lines += 1;
+                // 줄 상자는 흐름 폭을 담을 뿐이라, 실제 글자가 놓인 오른쪽 끝은
+                // 자식 런에서 구한다.
+                let mut run_right = f64::NEG_INFINITY;
+                let mut run_left = f64::INFINITY;
+                collect_run_extent(child, &mut run_left, &mut run_right);
+                if run_right.is_finite() && run_left.is_finite() {
+                    *widest = widest.max(run_right - run_left);
+                    *rightmost = rightmost.max(run_right);
+                }
+                // 줄 안에 중첩 표가 있을 수 있으므로 더 내려가지 않는다.
+            }
+            // 중첩 표의 줄까지 세면 이 셀의 줄 수가 아니게 된다.
+            RenderNodeType::Table(_) => {}
+            _ => collect_lines(child, lines, widest, rightmost),
+        }
+    }
+}
+
+fn collect_run_extent(node: &RenderNode, left: &mut f64, right: &mut f64) {
+    for child in &node.children {
+        if matches!(child.node_type, RenderNodeType::TextRun(_)) {
+            *left = left.min(child.bbox.x);
+            *right = right.max(child.bbox.x + child.bbox.width);
+        }
+        collect_run_extent(child, left, right);
+    }
+}

--- a/src/document_core/queries/mod.rs
+++ b/src/document_core/queries/mod.rs
@@ -1,4 +1,6 @@
 mod bookmark_query;
+// [#3480] "이 값이 이 칸에 들어가는가" 는 조판 엔진이 있어야만 답할 수 있는 질의다.
+pub mod cell_fit;
 mod cursor_nav;
 mod cursor_rect;
 pub(crate) mod doc_tree_nav;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use rhwp::document_core::queries::cell_fit::{CellFit, CellSelector};
 use std::env;
 use std::fs;
 use std::path::Path;
@@ -8268,6 +8269,37 @@ fn run_edit(args: &[String]) -> i32 {
 ///
 /// 검증된 코어 경로(`set_field_value_by_name`)를 재사용하므로 새 편집 로직이 없다.
 /// 필드 값만 바꾸므로 레이아웃·구조는 불변이다.
+/// [#3480] 이름 있는 필드 중 **본문 최상위 표 셀** 안에 있는 것의 좌표를 모은다.
+///
+/// 중첩 표·글상자 안(깊이 2 이상)은 렌더 트리 조회 좌표가 달라 신호를 만들지 않는다 —
+/// 없는 사실을 지어내느니 침묵이 낫다(이 경우는 봉투에 아무 항목도 넣지 않는다).
+fn field_cell_targets(
+    doc: &rhwp::wasm_api::HwpDocument,
+) -> Vec<(String, usize, usize, usize, usize)> {
+    use rhwp::document_core::queries::field_query::NestedEntry;
+    let mut out = Vec::new();
+    for fi in doc.collect_all_fields() {
+        let Some(name) = fi.field.field_name() else {
+            continue;
+        };
+        let [NestedEntry::TableCell {
+            control_index,
+            cell_index,
+            ..
+        }] = fi.location.nested_path.as_slice()
+        else {
+            continue;
+        };
+        out.push((
+            name.to_string(),
+            fi.location.section_index,
+            fi.location.para_index,
+            *control_index,
+            *cell_index,
+        ));
+    }
+    out
+}
 fn edit_fill_fields(args: &[String]) -> i32 {
     let mut file_path: Option<&str> = None;
     let mut data_arg: Option<&str> = None;
@@ -8362,6 +8394,22 @@ fn edit_fill_fields(args: &[String]) -> i32 {
         .filter_map(|fi| fi.field.field_name().map(|s| s.to_string()))
         .collect();
 
+    // [#3480] 편집 전 셀 맞춤을 먼저 재 둔다 — 값이 칸을 넘쳤는지는 전후 비교로만 말할 수 있다.
+    // 요청된 이름만 잰다 — 문서 전체를 재면 대형 서식(누름틀 1,000개대)에서 비용이 폭발한다.
+    let requested: std::collections::HashSet<&str> = data.keys().map(|k| k.as_str()).collect();
+    let cell_targets: Vec<(String, usize, usize, usize, usize)> = field_cell_targets(&doc)
+        .into_iter()
+        .filter(|(name, ..)| requested.contains(name.as_str()))
+        .collect();
+    let fits_before: Vec<Option<CellFit>> = cell_targets
+        .iter()
+        .map(|(_, sec, para, ctrl, cell)| {
+            doc.measure_cell_fit(*sec, *para, *ctrl, CellSelector::ModelIndex(*cell))
+                .ok()
+                .flatten()
+        })
+        .collect();
+
     let mut filled: Vec<serde_json::Value> = Vec::new();
     let mut not_found: Vec<String> = Vec::new();
 
@@ -8374,17 +8422,31 @@ fn edit_fill_fields(args: &[String]) -> i32 {
             not_found.push(name.clone());
             continue;
         }
-        if dry_run {
-            // 파일을 건드리지 않고 무엇이 바뀔지만 기록한다.
-            filled.push(serde_json::json!({ "name": name, "value": value_str }));
-            continue;
-        }
+        // [#3480] --dry-run 도 같은 넘침 보고를 하려면 메모리 상 문서에는 적용해야 한다.
+        // 출력 파일은 아래에서 dry_run 일 때 쓰지 않는다.
         if let Err(e) = doc.set_field_value_by_name(name, &value_str) {
             eprintln!("오류: 필드 '{}' 설정 실패 - {}", name, e);
             // 실패 시 원본 불변 — 출력 파일을 쓰지 않고 즉시 끝낸다.
             return EXIT_RUNTIME;
         }
         filled.push(serde_json::json!({ "name": name, "value": value_str }));
+    }
+
+    // [#3480] 채운 이름에 대해서만 전후를 비교한다.
+    let filled_names: std::collections::HashSet<&str> =
+        filled.iter().filter_map(|f| f["name"].as_str()).collect();
+    let mut overflow: Vec<serde_json::Value> = Vec::new();
+    for ((name, sec, para, ctrl, cell), before) in cell_targets.iter().zip(fits_before) {
+        if !filled_names.contains(name.as_str()) {
+            continue;
+        }
+        let after = doc
+            .measure_cell_fit(*sec, *para, *ctrl, CellSelector::ModelIndex(*cell))
+            .ok()
+            .flatten();
+        if let Some(entry) = cell_overflow_entry(format!("field:{name}"), before, after) {
+            overflow.push(entry);
+        }
     }
 
     let output_path = out_path.unwrap_or_else(|| {
@@ -8417,6 +8479,8 @@ fn edit_fill_fields(args: &[String]) -> i32 {
             "filledCount": filled.len(),
             "filled": filled,
             "notFound": not_found,
+            // [#3480] 값이 칸에 들어갔는지 — 비어 있으면 문제 없음.
+            "overflow": overflow,
         });
         if !dry_run {
             envelope["output"] = serde_json::Value::String(output_path.clone());
@@ -8711,6 +8775,33 @@ fn recolor_cell_text_black(
     true
 }
 
+/// [#3480] 편집 전후 셀 맞춤에서 "넘침" 신호를 만든다.
+///
+/// 여러 줄이 정상인 칸도 있으므로 **줄 수 자체가 아니라 편집이 늘린 줄**을 신호로 삼는다.
+/// 가로로 셀 상자를 벗어난 경우(잘림)는 줄 수와 무관하게 신호다.
+/// 채우기를 막지는 않는다 — 판단은 소비자 몫이고, 여기서는 침묵만 없앤다.
+fn cell_overflow_entry(
+    target: String,
+    before: Option<CellFit>,
+    after: Option<CellFit>,
+) -> Option<serde_json::Value> {
+    let after = after?;
+    // 측정 실패(표를 못 찾음)는 신호를 만들지 않는다 — 없는 사실을 지어내지 않는다.
+    let lines_before = before.map(|f| f.lines).unwrap_or(1).max(1);
+    let grew = after.lines > lines_before;
+    if !grew && !after.clipped_horizontally {
+        return None;
+    }
+    Some(serde_json::json!({
+        "target": target,
+        "cellWidthPx": (after.cell_width_px * 10.0).round() / 10.0,
+        "textWidthPx": (after.text_width_px * 10.0).round() / 10.0,
+        "lines": after.lines,
+        "linesBefore": lines_before,
+        "clipped": after.clipped_horizontally,
+    }))
+}
+
 fn edit_set_cell(args: &[String]) -> i32 {
     let mut file_path: Option<&str> = None;
     let mut table_arg: Option<usize> = None;
@@ -8924,7 +9015,14 @@ fn edit_set_cell(args: &[String]) -> i32 {
         Located::Fail(code) => return code,
     };
 
-    if !dry_run {
+    // [#3480] 편집 전 셀 맞춤을 먼저 잰다 — "값이 칸을 넘쳤는가" 는 전후 비교로만 말할 수 있다.
+    let fit_before = doc
+        .measure_cell_fit(sec, para, ctrl, CellSelector::ModelIndex(cell_idx))
+        .ok()
+        .flatten();
+
+    // --dry-run 도 같은 보고를 하려면 메모리 상 문서에는 적용해야 한다. 파일은 쓰지 않는다.
+    {
         // 셀의 모든 문단 텍스트를 비운다 (다문단 셀 — 빈 문단 골격은 유지된다).
         for (pi, len) in para_lens.iter().enumerate() {
             if *len == 0 {
@@ -8967,6 +9065,16 @@ fn edit_set_cell(args: &[String]) -> i32 {
         }
     }
 
+    let fit_after = doc
+        .measure_cell_fit(sec, para, ctrl, CellSelector::ModelIndex(cell_idx))
+        .ok()
+        .flatten();
+    let overflow = cell_overflow_entry(
+        format!("table{}[{},{}]", table_no, row, col),
+        fit_before,
+        fit_after,
+    );
+
     let output_path = out_path.unwrap_or_else(|| {
         let stem = Path::new(file_path)
             .file_stem()
@@ -9000,12 +9108,25 @@ fn edit_set_cell(args: &[String]) -> i32 {
             "newText": new_text,
             "dryRun": dry_run,
             "keepStyle": keep_style,
+            // [#3480] 값이 칸에 들어갔는지 — 비어 있으면 문제 없음.
+            "overflow": overflow.clone().map(|v| vec![v]).unwrap_or_default(),
         });
         if !dry_run {
             envelope["output"] = serde_json::Value::String(output_path.clone());
         }
         println!("{envelope}");
         return EXIT_OK;
+    }
+
+    if let Some(o) = &overflow {
+        // JSON 을 안 보는 사람에게도 알린다 — 막지는 않는다.
+        eprintln!(
+            "경고: 값이 칸에 한 줄로 들어가지 않습니다 — {} 줄 {} (칸 폭 {}px, 글 폭 {}px)",
+            o["target"].as_str().unwrap_or(""),
+            o["lines"],
+            o["cellWidthPx"],
+            o["textWidthPx"],
+        );
     }
 
     if dry_run {

--- a/tests/issue_3480_cell_overflow_signal.rs
+++ b/tests/issue_3480_cell_overflow_signal.rs
@@ -1,0 +1,182 @@
+//! Issue #3480: 채운 값이 칸을 넘쳐도 경고 없이 성공을 보고한다.
+//!
+//! `edit set-cell`·`edit fill-fields` 는 값이 셀을 넘쳐 여러 줄로 밀리거나 셀 경계를
+//! 벗어나도 `exit 0` 에 경고 하나 없었다. 에이전트는 렌더 결과를 보지 않으므로,
+//! 사람이라면 제출하지 않을 문서를 완성본으로 넘긴다.
+//!
+//! 신호는 **조판 엔진의 실제 렌더 트리**에서 읽는다 — 폭을 따로 추정하면 측정 경로와
+//! 렌더 경로가 갈라지는 알려진 함정(#2237)을 밟는다.
+//!
+//! 계약:
+//!   1) 편집이 줄 수를 늘렸거나 글이 셀 상자를 가로로 넘으면 `overflow` 에 보고
+//!   2) 들어가는 값이면 `overflow` 는 비어 있음 (무회귀)
+//!   3) 채우기를 막지 않는다 — 종료코드는 그대로 0, 판단은 소비자 몫
+//!   4) `--dry-run` 도 같은 보고를 한다 (파일을 만들기 전에 알 수 있어야 한다)
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// 한 줄짜리 기입 칸(성명)이 있는 실물 서식.
+const FORM: &str = "samples/복학원서.hwp";
+/// 누름틀이 표 셀 안에 있는 대형 법정 서식.
+const FIELD_FORM: &str = "samples/80168_regulatory_analysis.hwp";
+
+fn sample(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn temp_path(tag: &str, ext: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "rhwp-issue3480-{tag}-{}-{}.{ext}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos()
+    ))
+}
+
+fn run(args: &[&str]) -> (serde_json::Value, i32) {
+    let out = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let last = stdout.lines().last().unwrap_or("{}").to_string();
+    let json = serde_json::from_str(&last).unwrap_or_else(|e| {
+        panic!(
+            "JSON 파싱 실패({e}): {last}\nstderr={}",
+            String::from_utf8_lossy(&out.stderr)
+        )
+    });
+    (json, out.status.code().unwrap_or(-1))
+}
+
+fn set_cell(text: &str, out: &Path, extra: &[&str]) -> (serde_json::Value, i32) {
+    let input = sample(FORM);
+    let mut args = vec![
+        "edit",
+        "set-cell",
+        input.to_str().unwrap(),
+        "--table",
+        "0",
+        "--row",
+        "2",
+        "--col",
+        "3",
+        "--text",
+        text,
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    args.extend_from_slice(extra);
+    run(&args)
+}
+
+fn overflow_of(json: &serde_json::Value) -> &Vec<serde_json::Value> {
+    json["overflow"]
+        .as_array()
+        .unwrap_or_else(|| panic!("overflow 배열이 없다: {json}"))
+}
+
+/// 칸을 넘치는 값은 보고된다 — 그래도 채우기는 막지 않는다.
+#[test]
+fn long_value_reports_overflow_without_failing() {
+    let out = temp_path("long", "hwp");
+    let (json, code) = set_cell(
+        "홍가상홍가상홍가상홍가상홍가상홍가상홍가상홍가상홍가상홍가상",
+        &out,
+        &[],
+    );
+    assert_eq!(code, 0, "넘침은 실패가 아니다 — 신호만 준다: {json}");
+
+    let overflow = overflow_of(&json);
+    assert_eq!(overflow.len(), 1, "넘침이 보고되지 않았다: {json}");
+    let entry = &overflow[0];
+    assert_eq!(entry["target"], "table0[2,3]");
+    let lines = entry["lines"].as_u64().expect("lines");
+    let lines_before = entry["linesBefore"].as_u64().expect("linesBefore");
+    assert!(
+        lines > lines_before,
+        "편집이 줄을 늘렸을 때만 신호여야 한다: {entry}"
+    );
+    assert!(
+        entry["cellWidthPx"].as_f64().is_some_and(|w| w > 0.0),
+        "칸 폭이 실측값이어야 한다: {entry}"
+    );
+    let _ = std::fs::remove_file(&out);
+}
+
+/// 들어가는 값은 조용하다 — 무회귀.
+#[test]
+fn fitting_value_reports_no_overflow() {
+    let out = temp_path("fit", "hwp");
+    let (json, code) = set_cell("홍길동", &out, &[]);
+    assert_eq!(code, 0);
+    assert!(
+        overflow_of(&json).is_empty(),
+        "들어가는 값에 넘침을 보고했다: {json}"
+    );
+    let _ = std::fs::remove_file(&out);
+}
+
+/// `--dry-run` 도 같은 보고를 한다 — 파일을 만들기 전에 알 수 있어야 한다.
+#[test]
+fn dry_run_reports_the_same_overflow() {
+    let out = temp_path("dry", "hwp");
+    let (json, code) = set_cell(
+        "홍가상홍가상홍가상홍가상홍가상홍가상홍가상홍가상홍가상홍가상",
+        &out,
+        &["--dry-run"],
+    );
+    assert_eq!(code, 0);
+    assert_eq!(
+        overflow_of(&json).len(),
+        1,
+        "--dry-run 이 넘침을 보고하지 않았다: {json}"
+    );
+    assert!(!out.exists(), "--dry-run 은 출력 파일을 쓰지 않아야 한다");
+}
+
+/// 누름틀 경로도 같은 신호를 준다 — 셀 폭을 가로로 넘으면 `clipped`.
+#[test]
+fn fill_fields_reports_overflowing_cell_field() {
+    let data_path = temp_path("data", "json");
+    std::fs::write(
+        &data_path,
+        serde_json::to_string(&serde_json::json!({ "직급": "가상직급".repeat(30) }))
+            .expect("직렬화"),
+    )
+    .expect("data.json 쓰기");
+    let out = temp_path("fill", "hwp");
+    let input = sample(FIELD_FORM);
+    let data_arg = format!("@{}", data_path.to_str().unwrap());
+    let (json, code) = run(&[
+        "edit",
+        "fill-fields",
+        input.to_str().unwrap(),
+        "--data",
+        &data_arg,
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ]);
+    let _ = std::fs::remove_file(&data_path);
+    assert_eq!(code, 0, "넘침은 실패가 아니다: {json}");
+    assert_eq!(json["filledCount"].as_u64(), Some(1));
+
+    let overflow = overflow_of(&json);
+    assert_eq!(overflow.len(), 1, "누름틀 넘침이 보고되지 않았다: {json}");
+    let entry = &overflow[0];
+    assert_eq!(entry["target"], "field:직급");
+    assert_eq!(
+        entry["clipped"], true,
+        "셀 폭을 크게 넘는 값인데 clipped 가 아니다: {entry}"
+    );
+    let cell = entry["cellWidthPx"].as_f64().expect("cellWidthPx");
+    let text = entry["textWidthPx"].as_f64().expect("textWidthPx");
+    assert!(text > cell, "글 폭이 칸 폭을 넘어야 한다: {entry}");
+    let _ = std::fs::remove_file(&out);
+}


### PR DESCRIPTION
## 요약

`edit set-cell`·`edit fill-fields` 는 값이 칸을 넘쳐도 **경고 하나 없이 exit 0** 이었다.
에이전트·스크립트는 렌더 결과를 보지 않으므로, 사람이라면 제출하지 않을 문서를 완성본으로
넘긴다. 봉투에 `overflow` 신호를 추가해 침묵을 없앤다.

## 왜 rhwp 만 할 수 있는 검사인가

"이 글자열이 이 칸에 들어가는가"는 조판 엔진이 있어야 답할 수 있다. 그래서 폭을 따로
추정하지 않고 **실제 렌더 트리의 셀 상자와 그 안의 텍스트 줄을 직독**한다 — 측정 경로와
렌더 경로가 갈라지는 알려진 함정(#2237)을 밟지 않기 위해서다.

## 변경

1. **새 질의** `document_core/queries/cell_fit.rs`
   ```rust
   pub struct CellFit { cell_width_px, cell_height_px, text_width_px, lines, clipped_horizontally }
   pub fn measure_cell_fit(&self, sec, para, ctrl, selector) -> Result<Option<CellFit>, HwpError>
   ```
   표를 못 찾으면 `Ok(None)` — 측정 실패는 편집 실패가 아니고, **없는 사실을 지어내지 않는다.**
2. **`set-cell`** — 편집 전후로 재서 `overflow` 를 봉투에 싣는다.
3. **`fill-fields`** — 같은 신호. 루프 밖에서 전후 1회씩만 재고, **요청된 이름만** 잰다
   (문서 전체를 재면 누름틀 1,000개대 서식에서 비용이 폭발한다 — 실측 2초).

### 신호 기준

**줄 수 자체가 아니라 편집이 늘린 줄**을 신호로 삼는다. 여러 줄이 정상인 칸이 있기 때문이다
(이슈의 지적 그대로). 가로로 셀 상자를 벗어난 경우(`clipped`)는 줄 수와 무관하게 신호다.

**채우기를 막지 않는다** — 종료코드는 그대로 0이고 판단은 소비자 몫이다. JSON 을 안 보는
사람을 위해 stderr 에 경고 한 줄도 낸다.

## 실측

**`set-cell`** — `samples/복학원서.hwp` 성명 칸에 30자

```json
"overflow":[{"target":"table0[2,3]","cellWidthPx":218.4,"textWidthPx":215.0,
             "lines":3,"linesBefore":1,"clipped":false}]
```

SVG 실렌더의 줄(y=220.4 · 235.1 · 249.8)과 **줄 수가 일치**한다 — 질의가 렌더와 같은 답을 준다.

**`fill-fields`** — `samples/80168_regulatory_analysis.hwp` 의 `직급` 에 120자

```json
"overflow":[{"target":"field:직급","cellWidthPx":143.8,"textWidthPx":2080.0,
             "lines":1,"linesBefore":1,"clipped":true}]
```

줄로 감기지 않고 한 줄에 밀어 넣어 셀 폭의 14배가 된 경우 — 줄 수만 봤으면 놓쳤을 축이다.

들어가는 값(`홍길동`)은 `overflow: []`. `--dry-run` 도 같은 보고를 한다.

## 검증

- 회귀 테스트 4건 (`tests/issue_3480_cell_overflow_signal.rs`)
  — 넘침 보고 / 맞는 값 무회귀 / `--dry-run` 동일 보고 / 누름틀 가로 넘침
- `cargo nextest run --no-fail-fast` 전건 통과
- `cargo clippy --all-targets -- -D warnings` 통과, 변경 파일 rustfmt 클린

## 알아두실 점

- `--dry-run` 이 같은 보고를 하려면 **메모리 상 문서에는 적용**해야 해서 그렇게 바꿨습니다.
  출력 파일은 종전대로 쓰지 않습니다.
- 깊이 2 이상(중첩 표·글상자 안)의 누름틀은 렌더 트리 조회 좌표가 달라 **신호를 만들지
  않습니다.** 틀린 신호보다 침묵이 낫다는 판단입니다 — 필요하면 후속으로 넓히겠습니다.
- `edit_fill_fields` 를 건드리므로 **PR #3491(#3476 반복 필드)와 같은 함수에서 충돌**할 수
  있습니다. 이 PR 은 루프 본문을 거의 건드리지 않도록(전후 측정을 루프 밖에 둠) 짰습니다.
  머지 순서에 따라 제가 리베이스해 드리겠습니다.

Refs #3480
