### PR TITLE
fix(text/#3385): 한컴 PUA 사각 안 숫자를 텍스트 표면에서만 읽을 수 있게 — 렌더 결정은 불변

### DIFF
--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -5349,7 +5349,11 @@ impl DocumentCore {
                 RenderNodeType::TextRun(tr) => {
                     // 사람이 읽을 문자열이므로 표시 텍스트를 쓴다 — 머리말 필드는
                     // 모델에 제어문자 1자라 그대로 내보내면 값이 사라진다 (Task #3216).
-                    out.push_str(tr.display_or_text());
+                    // [#3385] 렌더가 폰트 정합을 위해 원문으로 흘리는 PUA 는 텍스트
+                    // 표면에서만 읽을 수 있는 문자로 바꾼다 (렌더 결정은 불변).
+                    out.push_str(&crate::renderer::composer::pua_to_text_surface(
+                        tr.display_or_text(),
+                    ));
                     *has_token = true;
                 }
                 RenderNodeType::FootnoteMarker(marker) => {

--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -2507,6 +2507,46 @@ pub fn pua_to_display_text(ch: char) -> Option<String> {
     None
 }
 
+/// [#3385] **텍스트 추출 전용** PUA 표시 변환.
+///
+/// 렌더 경로는 U+F02B1~F02C4(사각 안 숫자)를 **일부러 원문 그대로 흘린다** — 표준
+/// ①~⑳ 로 매핑하면 1순위 폰트의 *원 안* 글리프가 즉시 잡혀 한컴 정답지의 *사각 안*
+/// 글리프와 멀어지기 때문이다(Task #509 → 캡스톤 F-1 에서 표준 매핑을 되돌린 근거가
+/// `map_pua_bullet_char` 에 남아 있다).
+///
+/// 그러나 **텍스트 표면은 사정이 다르다.** 추출 결과는 폰트가 없는 소비자(RAG·LLM·grep)
+/// 에게 가므로 원문 PUA 는 읽을 수 없는 코드포인트일 뿐이다. 그래서 렌더 결정은 그대로
+/// 두고 텍스트 표면에서만 읽을 수 있는 문자로 바꾼다.
+///
+/// 의미를 모르는 PUA 는 **매핑을 지어내지 않고 그대로 둔다.**
+pub fn pua_to_text_surface(text: &str) -> std::borrow::Cow<'_, str> {
+    if !text
+        .chars()
+        .any(|ch| text_surface_replacement(ch).is_some())
+    {
+        return std::borrow::Cow::Borrowed(text);
+    }
+    let mut out = String::with_capacity(text.len());
+    for ch in text.chars() {
+        match text_surface_replacement(ch) {
+            Some(rep) => out.push_str(&rep),
+            None => out.push(ch),
+        }
+    }
+    std::borrow::Cow::Owned(out)
+}
+
+fn text_surface_replacement(ch: char) -> Option<String> {
+    let cp = ch as u32;
+    // 사각 안 숫자 1~20 — 렌더는 사각 글리프를 위해 원문을 유지하지만, 텍스트에서는
+    // 둘러싸인 숫자라는 뜻이 전달되면 충분하다.
+    if (0xF02B1..=0xF02C4).contains(&cp) {
+        let n = cp - 0xF02B1; // 0-based
+        return char::from_u32(0x2460 + n).map(|c| c.to_string());
+    }
+    // 렌더가 이미 표시 문자열을 갖고 있는 대역은 같은 답을 쓴다.
+    pua_to_display_text(ch)
+}
 /// 조합된 텍스트 런에서 PUA 테두리 숫자 문자를 찾아 CharOverlap 런으로 변환한다.
 ///
 /// PUA 문자는 원본 그대로 유지하되 CharOverlapInfo만 부착한다.

--- a/tests/issue_3385_text_surface_pua.rs
+++ b/tests/issue_3385_text_surface_pua.rs
@@ -1,0 +1,92 @@
+//! Issue #3385: 한컴 PUA 사각 안 숫자가 텍스트 추출에 원문 그대로 남는다.
+//!
+//! `export-text` 는 표시 문자열 변환을 하지 않아 U+F02B1~F02C4 를 그대로 내보냈다.
+//! 추출 결과는 폰트가 없는 소비자(RAG·LLM·grep)에게 가므로 **읽을 수 없는 코드포인트**다.
+//!
+//! 중요한 경계: **렌더는 원문 유지가 맞다.** Task #509 → 캡스톤 F-1 에서 표준 ①~⑳ 매핑을
+//! 일부러 되돌렸다 — 매핑하면 1순위 폰트의 *원 안* 글리프가 즉시 잡혀 한컴 정답지의
+//! *사각 안* 글리프와 멀어지기 때문이다. 그래서 이 수정은 **텍스트 표면에만** 적용하고
+//! 렌더 출력은 건드리지 않는다. 두 계약을 함께 고정한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// 섹션 헤딩 번호가 사각 안 숫자 PUA 로 조판된 실물 문서.
+const SAMPLE: &str = "samples/2022년 국립국어원 업무계획.hwp";
+
+fn sample_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn out_dir(tag: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "rhwp-issue3385-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos()
+    ))
+}
+
+fn run_export(kind: &str, dir: &Path) -> String {
+    let out = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg(kind)
+        .arg(sample_path())
+        .arg("-o")
+        .arg(dir)
+        .output()
+        .expect("rhwp 실행 실패");
+    assert!(
+        out.status.success(),
+        "{kind} 실패: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let mut all = String::new();
+    for entry in std::fs::read_dir(dir).expect("출력 디렉터리") {
+        let path = entry.expect("항목").path();
+        if path.is_file() {
+            all.push_str(&std::fs::read_to_string(&path).unwrap_or_default());
+        }
+    }
+    all
+}
+
+/// 사각 안 숫자 PUA 대역.
+fn boxed_number_pua(ch: char) -> bool {
+    (0xF02B1..=0xF02C4).contains(&(ch as u32))
+}
+
+/// 텍스트 추출은 읽을 수 있는 문자를 준다.
+#[test]
+fn extracted_text_has_no_boxed_number_pua() {
+    let dir = out_dir("text");
+    let text = run_export("export-text", &dir);
+    let leaked: Vec<char> = text.chars().filter(|c| boxed_number_pua(*c)).collect();
+    assert!(
+        leaked.is_empty(),
+        "추출 텍스트에 사각 안 숫자 PUA 가 남았다 ({}건): {:?}",
+        leaked.len(),
+        &leaked[..leaked.len().min(3)]
+    );
+    // 읽을 수 있는 둘러싸인 숫자로 바뀌어야 한다.
+    assert!(
+        text.contains('\u{2460}'),
+        "① 로 바뀐 흔적이 없다 — 매핑이 적용되지 않았을 수 있다"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// 렌더는 원문 PUA 를 그대로 흘린다 — 폰트 정합 결정(Task #509)을 깨지 않는다.
+#[test]
+fn rendered_svg_keeps_the_raw_pua() {
+    let dir = out_dir("svg");
+    let svg = run_export("export-svg", &dir);
+    let kept = svg.chars().filter(|c| boxed_number_pua(*c)).count();
+    assert!(
+        kept > 0,
+        "렌더에서 원문 PUA 가 사라졌다 — 텍스트 표면 변환이 렌더까지 번졌다"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## 요약

`export-text` 가 한컴 PUA **사각 안 숫자**(U+F02B1~F02C4)를 원문 그대로 내보냈다. 추출
결과는 폰트가 없는 소비자(RAG·LLM·grep)에게 가므로 읽을 수 없는 코드포인트일 뿐이다.
`samples/2022년 국립국어원 업무계획.hwp` 35쪽에서 5건 유출.

## 경계 — 렌더는 원문 유지가 맞다

이슈는 "미매핑이라 tofu"로 보았지만, **렌더의 raw PUA passthrough 는 의도된 결정**이다.
Task #509 → 캡스톤 F-1(2026-05-16)에서 표준 ①~⑳(U+2460~) 매핑을 **일부러 되돌린** 근거가
`map_pua_bullet_char` 에 남아 있다.

> 매핑 결과 표준 ① 가 1순위 폰트(맑은 고딕 등)의 **원 안** 글리프로 즉시 렌더링 …
> raw PUA passthrough + `generic_fallback()` 의 함초롬바탕 확장B 가 PUA 영역 글리프
> (**사각 안**)를 매칭

한컴 정답지 글리프가 사각 안 숫자라, 매핑하면 오히려 정답지와 멀어진다. 그래서 기존 변환
표(`pua_plain_text_display`)를 넓히지 않았다 — 그 표는 렌더 경로와 공유되기 때문이다.

## 변경

**텍스트 표면 전용** 매핑을 따로 뒀다.

- `composer::pua_to_text_surface` — 사각 안 숫자는 둘러싸인 숫자(U+2460~)로, 그 밖 대역은
  렌더가 이미 쓰는 표시 문자열과 **같은 답**을 쓴다.
- `extract_page_text_native` 에서 적용.

의미를 모르는 PUA(U+F0854·U+F0855)는 **매핑을 지어내지 않고 그대로 둔다** — 문서화된
공백으로 남기고 이슈에서 한컴 표시 모양을 여쭤 뒀다.

## 실측

| 경로 | 수정 전 | 수정 후 |
|---|---|---|
| `export-text` | U+F02B1 ×2 · F02B2 ×2 · F02B3 ×1 | **0건** — `① 국민의 국어능력`, `② 국어사전 개편` |
| `export-svg` | U+F02B1 ×2 · F02B2 ×2 · F02B3 ×1 | **동일 (불변)** |

## 검증

- 회귀 테스트 2건 (`tests/issue_3385_text_surface_pua.rs`) — **두 계약을 함께 고정**한다:
  텍스트에 PUA 없음(수정 제거 시 red) + 렌더는 원문 유지(양쪽 green, 번짐 방지 가드)
- `cargo nextest run --no-fail-fast`: 4,228건 전건 통과
- `cargo clippy --all-targets -- -D warnings` 통과, 변경 파일 rustfmt 클린
- 최신 `devel`(ead4300d2) 위로 리베이스

Refs #3385
