### PR TITLE
fix(serializer/#3495): 미주 앞 진짜 공백을 자동번호 placeholder 로 오인해 먹던 저장 경로

### DIFF
--- a/src/serializer/body_text.rs
+++ b/src/serializer/body_text.rs
@@ -515,10 +515,13 @@ fn serialize_para_text(para: &Paragraph) -> Vec<u8> {
         let is_autonum_placeholder = *ch == ' '
             && offset == prev_end
             && ctrl_idx < para.controls.len()
-            && matches!(
-                control_char_code_and_id(&para.controls[ctrl_idx]).0,
-                0x0011 | 0x0012
-            )
+            // [#3495] 0x0012(자동번호)만 placeholder 공백을 만든다. 두 파서 모두
+            // 그렇다 — parser/body_text.rs 는 ch == 0x0012 일 때만, HWPX section.rs 는
+            // 0x0012 파트일 때만 text 에 공백을 push 한다. 각주·미주(0x0011)는
+            // placeholder 를 만들지 않으므로, 여기 포함하면 미주 앞의 진짜 공백을
+            // placeholder 로 오인해 컨트롤로 덮어쓴다 (SO-SUEOP.hwp 문단 238:
+            // 공백 12개 -> 11개, 뒤 텍스트가 한 칸 당겨짐).
+            && matches!(control_char_code_and_id(&para.controls[ctrl_idx]).0, 0x0012)
             && next_offset.map_or(is_last_text_char, |n| n >= offset + 8);
         if is_autonum_placeholder {
             let (ctrl_code, ctrl_id) = control_char_code_and_id(&para.controls[ctrl_idx]);

--- a/tests/issue_3495_endnote_space_eaten.rs
+++ b/tests/issue_3495_endnote_space_eaten.rs
@@ -1,0 +1,119 @@
+//! Issue #3495: 저장하면 미주 **앞의 공백 한 칸이 사라진다**.
+//!
+//! `convert` 로 HWP5 를 쓰면 미주가 있는 문단에서 공백이 하나 줄고, 그 뒤 텍스트가 통째로
+//! 한 칸 당겨진다. `--verify` 는 exit 0 이라 종료코드로는 드러나지 않는다.
+//!
+//! ## 근인
+//!
+//! PARA_TEXT 저장기의 **자동번호 placeholder 휴리스틱**이 각주·미주까지 받고 있었다.
+//!
+//! ```text
+//! ch == ' ' && offset == prev_end && 다음 컨트롤 코드 ∈ {0x0011, 0x0012} && next_offset >= offset + 8
+//! ```
+//!
+//! placeholder 공백을 만드는 것은 **0x0012(자동번호)뿐이다** — `parser/body_text.rs` 는
+//! `ch == 0x0012` 일 때만, HWPX `section.rs` 는 `\u{0012}` 파트일 때만 text 에 공백을
+//! push 한다. 각주·미주(0x0011)는 placeholder 를 만들지 않으므로, 그 앞에 놓인 공백은
+//! **진짜 공백**인데 휴리스틱이 이를 컨트롤로 덮어썼다.
+//!
+//! 조건의 나머지(`offset == prev_end`, `next_offset >= offset + 8`)는 연속 텍스트 뒤에
+//! 컨트롤이 오면 자연히 성립해서 판별력이 없다. 실제 판별자는 컨트롤 코드뿐이다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::model::control::Control;
+
+/// 미주가 본문 중간에 앵커된 HWP 3.0 문서.
+const SAMPLE: &str = "samples/SO-SUEOP.hwp";
+
+fn load(path: &std::path::Path) -> rhwp::model::document::Document {
+    let data = std::fs::read(path).expect("파일 읽기");
+    rhwp::parser::parse_document(&data).expect("파싱")
+}
+
+fn sample_path() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+/// 미주를 가진 문단의 (텍스트, 미주 위치) 목록.
+fn endnote_paragraphs(doc: &rhwp::model::document::Document) -> Vec<(String, Vec<usize>)> {
+    doc.sections
+        .iter()
+        .flat_map(|s| s.paragraphs.iter())
+        .filter(|p| {
+            p.controls
+                .iter()
+                .any(|c| matches!(c, Control::Endnote(_) | Control::Footnote(_)))
+        })
+        .map(|p| (p.text.clone(), p.control_text_positions()))
+        .collect()
+}
+
+fn convert_roundtrip() -> std::path::PathBuf {
+    let out = std::env::temp_dir().join(format!(
+        "rhwp-issue3495-{}-{}.hwp",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos()
+    ));
+    let status = std::process::Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("convert")
+        .arg(sample_path())
+        .arg(&out)
+        .output()
+        .expect("rhwp 실행");
+    assert!(
+        status.status.success(),
+        "convert 실패: {}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+    out
+}
+
+/// 미주가 있는 문단의 텍스트가 저장으로 바뀌지 않는다.
+#[test]
+fn saving_keeps_the_space_before_an_endnote() {
+    let before = endnote_paragraphs(&load(&sample_path()));
+    assert!(
+        !before.is_empty(),
+        "미주 문단을 찾지 못했다 — 표본이 바뀌었는지 확인하라"
+    );
+
+    let out = convert_roundtrip();
+    let after = endnote_paragraphs(&load(&out));
+    let _ = std::fs::remove_file(&out);
+
+    assert_eq!(after.len(), before.len(), "저장 후 미주 문단 수가 달라졌다");
+    for (i, ((text_a, _), (text_b, _))) in before.iter().zip(after.iter()).enumerate() {
+        assert_eq!(
+            text_a.chars().count(),
+            text_b.chars().count(),
+            "미주 문단 {i} 의 글자 수가 달라졌다 (공백이 먹혔는지 확인):\n  전: {text_a:?}\n  후: {text_b:?}"
+        );
+        assert_eq!(text_a, text_b, "미주 문단 {i} 의 텍스트가 달라졌다");
+    }
+}
+
+/// 미주 표시 위치도 그대로다 — 앞 문자가 사라지면 위치가 당겨진다.
+#[test]
+fn endnote_marker_position_survives_saving() {
+    let before = endnote_paragraphs(&load(&sample_path()));
+    let out = convert_roundtrip();
+    let after = endnote_paragraphs(&load(&out));
+    let _ = std::fs::remove_file(&out);
+
+    let mut checked = 0usize;
+    for (i, ((_, pos_a), (_, pos_b))) in before.iter().zip(after.iter()).enumerate() {
+        // 본문 중간 앵커(위치가 0 이 아닌 것)만 — 문단 첫머리는 밀릴 여지가 없다.
+        if pos_a.iter().all(|p| *p == 0) {
+            continue;
+        }
+        assert_eq!(
+            pos_a, pos_b,
+            "미주 표시 위치가 저장으로 이동했다 (문단 {i})"
+        );
+        checked += 1;
+    }
+    assert!(checked > 0, "본문 중간 앵커 미주를 찾지 못했다");
+}


### PR DESCRIPTION
## 요약

HWP5 로 저장하면 미주가 있는 문단에서 **공백이 한 칸 사라지고** 뒤 텍스트가 통째로 당겨진다.
`convert --verify` 는 exit 0 이라 종료코드로 드러나지 않는다.

```
SO-SUEOP.hwp 문단 238
  원본  text="나:이인화 동경유학생 (            )시점"  (28자)  미주 위치 18
  저장  text="나:이인화 동경유학생 (           )시점"   (27자)  미주 위치 17
                                    ↑ 공백 12개 → 11개
```

이슈에는 "미주 표시가 밀린다"로 적었는데, **실체는 표시 이동이 아니라 앞 문자 소실**이었다.

## 근인

PARA_TEXT 저장기의 **자동번호 placeholder 휴리스틱**이 각주·미주까지 받고 있었다.

```rust
ch == ' ' && offset == prev_end
          && 컨트롤코드 ∈ {0x0011, 0x0012}
          && next_offset >= offset + 8
```

placeholder 공백을 만드는 것은 **0x0012(자동번호)뿐**이다.

- `parser/body_text.rs:335` — `if ch == 0x0012 { text.push(' ') }`
- `parser/hwpx/section.rs:681` — `"\u{0012}"` 파트에서만 `visual_text.push(' ')`

각주·미주(0x0011)는 placeholder 를 만들지 않는다. 그러니 그 앞에 놓인 공백은 **진짜 공백**인데
휴리스틱이 이를 컨트롤로 덮어썼다.

조건의 나머지도 판별력이 없다 — 연속 텍스트 뒤에 컨트롤이 오면 `offset == prev_end` 와
`next_offset >= offset + 8` 은 자연히 성립한다. **실제 판별자는 컨트롤 코드뿐**이라
`0x0012` 로 좁혔다.

## 실측 (`samples/SO-SUEOP.hwp`)

| 지표 | 수정 전 | 수정 후 |
|---|---|---|
| 문단 238 텍스트 | 27자 (공백 11) | **28자 (공백 12) — 원본과 완전 일치** |
| 문단 238 미주 위치 | 17 | **18 (원본과 동일)** |
| `export-text` 대조 hunk | 131 | **123** |

남은 123 hunk 는 **말미 공백 계열**로, 수정 전에도 209건 있던 별개의 선행 축이다
(이 PR 로 생긴 것이 아니다).

## 검증

- 회귀 테스트 2건 (`tests/issue_3495_endnote_space_eaten.rs`) — 미주 문단 텍스트 보존 /
  미주 표시 위치 보존. **수정을 되돌리면 둘 다 red.**
- `0x0011` 은 Task #1050(HWPX → HWP 각주 저장 한컴 호환)에서 들어온 값이라, 그 계약
  테스트를 포함한 **전체 게이트로 확인**했습니다 — `cargo nextest run --no-fail-fast`
  **4,231건 전건 통과**.
- `cargo clippy --all-targets -- -D warnings` 통과, 변경 파일 rustfmt 클린
- 최신 `devel`(ad16eb457, 연작 7건 통합 반영) 위로 리베이스 후 재확인

Refs #3495
