### PR TITLE
ci(#3508): stale run 자동 cancel 을 fork PR 로 확장 — pull_request_target 전환 + 원커맨드 폴백

### DIFF
--- a/.github/workflows/cancel-stale-pr-runs.yml
+++ b/.github/workflows/cancel-stale-pr-runs.yml
@@ -1,10 +1,18 @@
 name: Cancel stale PR runs
 
 # Update branch(synchronize) 뒤 같은 devel PR의 이전 SHA run을 force-cancel한다.
-# PR source를 checkout하거나 PR이 제공한 script를 실행하지 않는다. 외부 fork PR은 GitHub가
-# pull_request token을 읽기 전용으로 낮추므로 job을 skip하고 review 절차의 수동 처리로 남긴다.
+#
+# [#3508] pull_request_target 전환 — fork PR도 자동 cancel 대상이다.
+# - pull_request 이벤트는 fork PR에서 토큰이 읽기 전용으로 강등돼 actions API를 못 부른다.
+#   pull_request_target은 base 저장소 write 토큰을 유지하고, PR base 브랜치(devel)의 이
+#   파일로 평가되므로 main 반영을 기다릴 필요가 없다(#3406 원안의 설계).
+# - 안전 경계: 이 워크플로는 PR source를 checkout하지 않고, PR이 제공한 어떤 코드도
+#   실행하지 않는다. 순수 GitHub API 호출뿐이다. pull_request_target의 알려진 위험은
+#   PR 코드 실행에서 나오므로 이 경계를 바꾸는 수정은 보안 리뷰 없이 금지한다.
+# - fork run은 run.pull_requests 배열이 비는 GitHub quirk가 있어 PR 번호 매치 대신
+#   head_repository + head_branch + head_sha 대조로 stale을 판정한다.
 on:
-  pull_request:
+  pull_request_target:
     branches: [devel]
     types: [synchronize]
 
@@ -21,7 +29,6 @@ concurrency:
 
 jobs:
   cancel-stale-runs:
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Force-cancel older pull-request runs for this PR
@@ -48,7 +55,14 @@ jobs:
               core.info(`PR #${pullNumber} is ${pull.state}; nothing to cancel.`);
               return;
             }
+            const headRepo = pull.head.repo ? pull.head.repo.full_name : null;
+            if (!headRepo) {
+              core.info(`PR #${pullNumber} head repository is gone; nothing to cancel.`);
+              return;
+            }
 
+            // branch 필터는 head_branch 문자열 기준이라 fork run도 잡힌다. 다른 fork의
+            // 동명 branch와 섞이지 않도록 아래 filter에서 head_repository를 반드시 대조한다.
             const runs = await github.paginate(
               github.rest.actions.listWorkflowRunsForRepo,
               {
@@ -59,10 +73,14 @@ jobs:
                 per_page: 100,
               },
             );
+            // [#3508] fork run은 run.pull_requests가 빈 배열인 경우가 있어 PR 번호 매치를
+            // 쓰지 않는다. head_repository+head_branch가 이 PR의 head를 유일하게 식별한다.
             const staleRuns = runs.filter((run) => (
               run.head_sha !== pull.head.sha
               && activeStatuses.has(run.status)
-              && (run.pull_requests || []).some((runPull) => runPull.number === pullNumber)
+              && run.head_branch === pull.head.ref
+              && run.head_repository
+              && run.head_repository.full_name === headRepo
             ));
 
             let cancelled = 0;

--- a/mydocs/manual/pr_review/multi_pr_update_branch.md
+++ b/mydocs/manual/pr_review/multi_pr_update_branch.md
@@ -30,13 +30,15 @@ scripts/pr_triage.sh <author> --list
 contributor 또는 maintainer가 Update branch를 수행해 PR head가 바뀌면, 이전 SHA run이 최신 required check와
 섞여 보일 수 있다. 최신 head의 CI는 절대 취소하지 않는다.
 
-1. `devel` 대상이고 head가 같은 저장소인 PR에서는 `Cancel stale PR runs` reaper가 `synchronize` event로
-   시작했는지, 최신 head SHA와 함께 확인한다. 이 workflow는 PR source를 checkout·실행하지 않고, 같은
-   PR의 이전 SHA `pull_request` run만 force-cancel한다.
+1. `devel` 대상 PR(fork 포함, #3508)에서는 `Cancel stale PR runs` reaper가 `synchronize` event로
+   시작했는지, 최신 head SHA와 함께 확인한다. 이 workflow는 `pull_request_target`으로 base
+   브랜치(devel)의 정의를 실행하되 PR source를 checkout·실행하지 않고, 같은 PR head
+   (head_repository+head_branch)의 이전 SHA `pull_request` run만 force-cancel한다.
 2. reaper가 성공했다면 이전 SHA run이 `completed/cancelled`가 되었고 최신 head run이 시작됐는지 확인한다.
-3. external fork PR은 GitHub가 `pull_request` token의 write 권한을 읽기 전용으로 낮추므로 reaper가
-   의도적으로 skip한다. 이 경우와 reaper 실패·미실행 시에는 이전 SHA에서 시작한 active run만 **일반
-   `gh run cancel`을 먼저 시도하지 않고** force-cancel API로 즉시 취소한다.
+3. reaper 실패·미실행 시에는 `scripts/cancel_stale_pr_runs.sh <PR번호>`로 정리한다(#3508 —
+   현재 head 확인 → 이전 SHA active run 나열 → force-cancel → 완료 재확인을 한 명령으로,
+   `--dry-run`은 목록만). 이 경로도 **일반 `gh run cancel`을 먼저 시도하지 않고** force-cancel
+   API를 쓴다. script를 쓸 수 없는 환경에서만 아래 수동 API 절차를 따른다.
 4. 수동 취소 뒤에도 완료 상태와 `cancelled` 결론을 재확인한다.
 
 러너 구성 전환 등으로 배정 가능한 label이 사라진 run은 `queued`에 고착될 수 있다. 이 run은 일반 cancel이

--- a/mydocs/orders/20260728.md
+++ b/mydocs/orders/20260728.md
@@ -115,3 +115,16 @@ playbook 편입 등 개선 5건을 PR 코멘트로 게시했다
 - 격차 후보 4건의 이슈 등록은 작업지시자 판단 대기 — 후보 3 은 교차검증, 후보 4 는 한컴
   편집기 실측이 선행돼야 한다. 시행 산출물은 세션 스크래치패드에 있어 이슈 등록이 결정되면
   증적을 안정 경로로 옮긴다.
+
+## #3508 — stale run 자동 cancel 을 fork PR 로 확장 (진행중)
+
+collaborator 실불만("내 PR 은 자동 cancel 되는데 fork PR 처리 땐 main 머지 제약으로 못
+쓴다, 하나씩 처리할 때 너무 귀찮다")에서 출발. 진단: #3409 출하본이 원안(#3406 의
+`pull_request_target`)보다 보수적인 `pull_request` 이벤트라 fork PR 토큰 강등 → skip.
+"main 제약"은 `workflow_run` 대안에만 해당하고 `pull_request_target` 은 base 브랜치(devel)
+파일로 동작해 main 불필요.
+
+- 방침(작업지시자): 우리가 이슈 등록해 처리. A(reaper `pull_request_target` 전환, fork run
+  의 `pull_requests` 배열 공백 quirk 대응) + B(수동 2.5 절차 원커맨드 스크립트) 병행.
+- 이슈 #3508 등록, assignee edwardkim, 브랜치 `task/3508-fork-pr-stale-cancel`.
+- 다음: 수행계획서 → 작업지시자 승인 → 구현.

--- a/mydocs/plans/task_m100_3508.md
+++ b/mydocs/plans/task_m100_3508.md
@@ -1,0 +1,78 @@
+# stale run 자동 cancel 의 fork PR 확장 수행계획서
+
+Issue: #3508
+브랜치: `task/3508-fork-pr-stale-cancel`
+배경: collaborator 실불만 — fork PR 을 하나씩 처리할 때 update branch 마다 stale run 수동
+정리가 반복된다. 관련 #3406(원 reaper 설계), #3409(출하 구현).
+
+## 1. 목표
+
+fork PR 에서도 update branch 직후 이전 SHA run 이 자동 force-cancel 되게 하고, 자동화가
+못 미치는 경우를 위한 원커맨드 폴백을 제공한다.
+
+## 2. 변경 설계
+
+### A. `cancel-stale-pr-runs.yml` — `pull_request_target` 전환
+
+| 항목 | 현행 | 변경 |
+|---|---|---|
+| 트리거 | `pull_request` (fork 토큰 강등) | `pull_request_target` (base 브랜치 평가, write 토큰 유지) |
+| fork 가드 | `if: head.repo == github.repository` 로 skip | 제거 — fork PR 도 대상 |
+| stale 판정 | `branch: head.ref` 목록 + `run.pull_requests[].number` 매치 | **`head_repository.full_name` + `head_branch` + `head_sha != live head`** 대조 — fork run 은 `pull_requests` 배열이 비는 GitHub quirk 가 있어 현행 필터가 fork run 을 못 잡는다 |
+| 안전 경계 | PR 코드 미checkout·미실행 | **동일 유지** — 순수 API 호출만. `pull_request_target` 위험(PR 코드 실행)에 해당 없음을 주석으로 명시 |
+| 최신 head 보호 | 취소 직전 live head 재확인 | 동일 유지 |
+| 권한 | `actions: write, contents: read, pull-requests: read` | 동일 (필요 최소) |
+
+주의: `listWorkflowRunsForRepo` 의 `branch:` 필터는 base 저장소 기준이라 fork run 조회에
+부적합할 수 있다 — branch 필터를 빼고 `event: pull_request` + `head_sha`/`head_repository`
+후처리로 좁히거나, `per_page` 페이지네이션 상한을 확인해 과도 조회를 막는다(구현 시 실측).
+
+### B. `scripts/cancel_stale_pr_runs.sh <PR번호>` — 수동 2.5 절차 원커맨드화
+
+multi_pr_update_branch 2.5 의 절차를 그대로 감싼다.
+
+1. `gh pr view` 로 현재 head SHA 확인
+2. 같은 PR 의 이전 SHA active run(`queued/in_progress/pending/requested/waiting`) 나열
+3. 각 run 에 force-cancel API 호출 (일반 `gh run cancel` 은 시도하지 않음 — 2.5 규정)
+4. `completed/cancelled` 재확인 루프
+5. 대상 SHA·run URL·완료 상태를 stdout 으로 — review 문서 기록 요건을 그대로 채움
+
+fork/same-repo 모두 동작(로컬 `gh` 인증은 maintainer 토큰). 오조작 방지로 최신 head run 은
+어떤 경우에도 대상에서 제외한다.
+
+### C. 문서 정합
+
+`multi_pr_update_branch.md` 2.5 를 갱신 — reaper 가 fork PR 도 커버함, 수동 폴백은 B
+스크립트 사용. 정보구조 변경이 아니므로 링크·메타데이터 검사는 변경 파일 범위로 한정.
+
+## 3. 검증 계획
+
+- **워크플로 정적 검증**: `actionlint` 또는 YAML 파싱 + 구문 검사. 트리거·권한·가드 diff 리뷰.
+- **B 스크립트 실검증**: 열린 fork PR 하나에서 (a) stale run 이 없는 상태 → "대상 없음" 정상
+  종료, (b) 가능하면 update branch 실발생 시점에 실행해 실제 cancel 확인. 실발생이 어려우면
+  드라이런 출력(대상 목록만)과 API 경로 검증으로 대체하고 한계를 보고서에 명시.
+- **A 실검증의 한계**: `pull_request_target` 은 base 브랜치의 파일로 동작하므로 **PR 단계에서는
+  새 reaper 가 발동하지 않는다**(merge 후 첫 fork PR synchronize 에서 실증 가능). 이 한계와
+  merge 후 실증 계획을 PR 본문에 명시한다 — #3406 이 격리 fork 로 사전 검증한 전례를 따라
+  가능하면 jangster77 의 격리 저장소 검증을 요청한다.
+- 기존 same-repo 경로 무회귀: 트리거 전환 후에도 same-repo PR 이 대상에 포함됨을 필터
+  로직으로 확인.
+
+## 4. 단계
+
+| 단계 | 내용 | 게이트 |
+|---|---|---|
+| 1 | A 워크플로 전환 + B 스크립트 + C 문서 | 구현 |
+| 2 | 정적 검증 + B 실검증 + 보고서 | 검증 통과 |
+| 3 | PR 생성 (**별도 승인**) → CI → merge (**별도 승인**) | 승인 게이트 |
+| 4 | merge 후 첫 fork PR update branch 에서 A 실증 → 이슈 close (**승인**) | 실증 게이트 |
+
+## 5. 위험
+
+- `pull_request_target` 전환의 보안 리뷰 부담 — 이 워크플로는 checkout 이 없어 실위험이
+  낮지만, 리뷰어가 한눈에 확인할 수 있게 "PR 코드를 절대 checkout·실행하지 않는다" 주석과
+  pinned action 버전을 유지한다.
+- fork run 조회 API 의 페이지네이션 비용 — run 목록이 큰 저장소라 필터 설계를 실측으로
+  확정한다.
+- merge 전 실증 불가(위 3절) — 완료 조건 1 은 merge 후 실증으로만 닫힌다. 이슈 close 를
+  그 시점까지 미룬다.

--- a/mydocs/working/task_m100_3508_stage1.md
+++ b/mydocs/working/task_m100_3508_stage1.md
@@ -1,0 +1,55 @@
+# #3508 1·2단계 — 구현과 검증
+
+Issue: #3508
+브랜치: `task/3508-fork-pr-stale-cancel`
+
+## 구현
+
+### A. `cancel-stale-pr-runs.yml` — `pull_request_target` 전환
+
+- 트리거 `pull_request` → `pull_request_target` (base 브랜치 devel 의 정의로 실행, fork PR
+  에서도 write 토큰 유지 — main 반영 불필요).
+- same-repo 가드(`if: head.repo == github.repository`) 제거.
+- stale 판정을 `run.pull_requests[].number` 매치에서 **`head_repository.full_name` +
+  `head_branch` + `head_sha != live head`** 대조로 교체 — fork run 은 `pull_requests` 배열이
+  비는 GitHub quirk 로 종전 필터가 fork run 을 잡지 못한다. 다른 fork 의 동명 branch 와
+  섞이지 않도록 head_repository 대조를 필수로 한다.
+- head repo 가 삭제된 PR(`pull.head.repo == null`) 조기 종료 분기 추가.
+- **안전 경계 불변**: PR source checkout 없음, PR 제공 코드 실행 없음, 순수 API 호출.
+  "이 경계를 바꾸는 수정은 보안 리뷰 없이 금지" 를 워크플로 주석으로 명시.
+- 최신 head 보호(취소 직전 live 재확인)·concurrency·최소 권한은 종전 그대로.
+
+### B. `scripts/cancel_stale_pr_runs.sh <PR번호> [--dry-run]`
+
+multi_pr 2.5 수동 절차의 원커맨드화. 현재 head 확인 → 같은 PR head 의 이전 SHA active run
+나열 → force-cancel(일반 `gh run cancel` 미시도, 2.5 규정) → `completed/cancelled` 재확인
+(6회×10초) → run URL·SHA 출력(review 기록 요건). 취소 직전 live head 재이동 감지 시 중단.
+
+### C. `multi_pr_update_branch.md` 2.5 갱신
+
+reaper 가 fork PR 을 커버함을 반영하고, 수동 폴백 1순위를 B 스크립트로, script 불가 환경만
+종전 수동 API 절차로 남겼다.
+
+## 검증
+
+| 항목 | 결과 |
+|---|---|
+| 워크플로 YAML 파싱 | OK (actionlint 미설치 — 파싱 검증만) |
+| `bash -n` | OK (shellcheck 미설치) |
+| 문서 링크·메타데이터 게이트 | 변경 5파일 이상 없음 / 메타데이터 이상 없음 |
+| B 실검증 — fork PR 열림(#2529, #3456) | head repo/branch 정확 해석, "active run 없음" exit 0 |
+| B 실검증 — 닫힌 PR(#3499) | "OPEN 아님 — 중단" exit 1 |
+| **jq 필터 필드 실데이터 검증** | #3456 branch 의 실제 run 이 `head_repository.full_name`·`head_branch` 를 기대 형태로 반환, completed run 정확 제외 |
+
+### 검증 한계 (계획서 3절 그대로)
+
+- **stale run 실취소 경로는 미실증** — 실제 update branch 경합 없이 안전하게 만들 수 없다.
+  필터 로직은 reaper 와 동일 구조이고 필드명은 실데이터로 확인했다.
+- **A 는 merge 전 발동 불가** — `pull_request_target` 은 base 브랜치 파일로 동작한다.
+  merge 후 첫 fork PR update branch 에서 실증하고, 그때까지 이슈 #3508 을 닫지 않는다.
+  #3406 전례에 따라 jangster77 격리 저장소 사전 검증 요청을 PR 본문에 선택지로 남긴다.
+
+## 다음
+
+3단계 — PR 생성(**별도 승인**) → CI → merge(**별도 승인**). 4단계 — merge 후 fork PR
+update branch 실증 → 이슈 close(**승인**).

--- a/scripts/cancel_stale_pr_runs.sh
+++ b/scripts/cancel_stale_pr_runs.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# [#3508] multi_pr_update_branch.md 2.5의 stale run 수동 정리를 원커맨드로 감싼다.
+#
+#   사용법: scripts/cancel_stale_pr_runs.sh <PR번호> [--dry-run]
+#
+# - 현재 head SHA를 확인하고, 같은 PR head(head_repository+head_branch)의 이전 SHA
+#   active run만 force-cancel API로 취소한다. 일반 `gh run cancel`은 시도하지 않는다(2.5 규정).
+# - 최신 head SHA run은 어떤 경우에도 대상에서 제외한다.
+# - 대상 SHA·run URL·완료 상태를 출력한다 — review 문서 기록 요건을 그대로 채운다.
+# - fork PR·same-repo PR 모두 동작한다(로컬 gh 인증 토큰 권한 기준).
+set -euo pipefail
+
+REPO="${RHWP_REPO:-edwardkim/rhwp}"
+PR="${1:?사용법: $0 <PR번호> [--dry-run]}"
+DRY="${2:-}"
+
+pr_json=$(gh pr view "$PR" --repo "$REPO" \
+  --json state,headRefOid,headRefName,headRepositoryOwner,headRepository)
+state=$(jq -r '.state' <<<"$pr_json")
+head_sha=$(jq -r '.headRefOid' <<<"$pr_json")
+head_ref=$(jq -r '.headRefName' <<<"$pr_json")
+head_repo=$(jq -r '"\(.headRepositoryOwner.login)/\(.headRepository.name)"' <<<"$pr_json")
+
+echo "PR #$PR (${REPO})  state=$state"
+echo "  head: $head_sha  ($head_repo:$head_ref)"
+if [ "$state" != "OPEN" ]; then
+  echo "  OPEN 상태가 아니므로 중단합니다."
+  exit 1
+fi
+
+# 같은 head branch의 pull_request run을 나열하고, 이 PR head(저장소+브랜치)로 좁힌 뒤
+# 최신 head SHA를 제외한 active run만 고른다.
+stale=$(gh api --paginate \
+  "repos/$REPO/actions/runs?event=pull_request&branch=$head_ref&per_page=100" \
+  --jq '.workflow_runs[]' 2>/dev/null | jq -s \
+  --arg sha "$head_sha" --arg ref "$head_ref" --arg repo "$head_repo" '
+    [ .[]
+      | select(.head_branch == $ref)
+      | select(.head_repository.full_name == $repo)
+      | select(.head_sha != $sha)
+      | select(.status == "queued" or .status == "in_progress"
+               or .status == "pending" or .status == "requested"
+               or .status == "waiting")
+      | {id, name: (.name // .display_title), head_sha, status, url: .html_url}
+    ]')
+
+count=$(jq 'length' <<<"$stale")
+if [ "$count" -eq 0 ]; then
+  echo "  이전 SHA의 active run 없음 — 정리할 대상이 없습니다."
+  exit 0
+fi
+
+echo "  이전 SHA active run ${count}건:"
+jq -r '.[] | "    [\(.status)] \(.name)  \(.head_sha[0:9])  \(.url)"' <<<"$stale"
+
+if [ "$DRY" = "--dry-run" ]; then
+  echo "  --dry-run: 취소하지 않고 종료합니다."
+  exit 0
+fi
+
+# 취소 직전 live head 재확인 — update가 또 있었으면 새 head run을 건드리지 않는다.
+live_sha=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid)
+if [ "$live_sha" != "$head_sha" ]; then
+  echo "  head가 $live_sha 로 이동했습니다. 목록을 다시 만드세요 — 중단."
+  exit 1
+fi
+
+echo "$stale" | jq -r '.[].id' | while read -r run_id; do
+  gh api --method POST "repos/$REPO/actions/runs/$run_id/force-cancel" >/dev/null
+  echo "  force-cancel 요청: run $run_id"
+done
+
+# completed/cancelled 재확인 (최대 6회 × 10초)
+echo "  완료 상태 재확인:"
+for run_id in $(jq -r '.[].id' <<<"$stale"); do
+  ok=""
+  for _ in 1 2 3 4 5 6; do
+    rs=$(gh api "repos/$REPO/actions/runs/$run_id" --jq '"\(.status)/\(.conclusion // "-")"')
+    if [[ "$rs" == completed/* ]]; then ok="$rs"; break; fi
+    sleep 10
+  done
+  if [ -n "$ok" ]; then
+    echo "    run $run_id → $ok"
+  else
+    echo "    run $run_id → 아직 미완료 (마지막 상태: $rs) — 재확인 필요"
+  fi
+done
+echo "완료. 위 run URL·SHA를 review 문서에 기록하세요."


### PR DESCRIPTION
## 배경

collaborator 실불만에서 출발한다 — 본인 PR(same-repo)은 update branch 시 자동 cancel 되는데,
컨트리뷰터 fork PR 을 하나씩 처리할 때는 stale run 수동 정리가 반복된다.

관련: #3508 (merge 후 실증까지 이슈를 닫지 않으므로 `Closes` 를 쓰지 않는다)

## 진단

#3409 출하본 reaper 는 원안(#3406 의 `pull_request_target`)보다 보수적인 `pull_request`
이벤트다. fork PR 에서 토큰이 읽기 전용으로 강등돼 same-repo 가드로 skip 했다. "main 에
머지돼야 한다"는 제약은 `workflow_run` 대안에만 해당하고, `pull_request_target` 은 **PR base
브랜치(devel)의 워크플로 정의로 실행**되므로 main 반영이 필요 없다.

## 변경

1. **reaper `pull_request_target` 전환** — fork 가드 제거, write 토큰 유지.
   - stale 판정을 `run.pull_requests[].number` 매치 → **`head_repository.full_name` +
     `head_branch` + `head_sha != live head`** 대조로 교체. fork run 은 `pull_requests`
     배열이 비는 GitHub quirk 로 종전 필터가 fork run 을 잡지 못한다.
   - head repo 가 삭제된 PR 조기 종료 분기 추가.
   - **안전 경계 불변**: PR source 를 checkout 하지 않고 PR 이 제공한 어떤 코드도 실행하지
     않는다 — 순수 API 호출뿐. `pull_request_target` 의 알려진 위험은 PR 코드 실행에서
     나오므로, "이 경계를 바꾸는 수정은 보안 리뷰 없이 금지" 를 워크플로 주석으로 명시했다.
   - 최신 head 보호(취소 직전 live 재확인)·concurrency·최소 권한(`actions: write`,
     `contents: read`, `pull-requests: read`)은 종전 그대로.
2. **`scripts/cancel_stale_pr_runs.sh <PR번호> [--dry-run]`** — multi_pr 2.5 수동 절차의
   원커맨드화. force-cancel 전용(일반 `gh run cancel` 미시도), `completed/cancelled` 재확인
   루프, review 기록용 run URL·SHA 출력. reaper 실패·미실행 시 폴백으로도 남는다.
3. **`multi_pr_update_branch.md` 2.5 갱신** — fork 커버 반영, 수동 폴백 1순위를 스크립트로.

## 검증

| 항목 | 결과 |
|---|---|
| 워크플로 YAML 파싱 | OK |
| `bash -n` | OK |
| 문서 링크·메타데이터 게이트 | 변경 5파일 이상 없음 |
| 스크립트 실검증 — 열린 fork PR(#2529·#3456) | head repo/branch 정확 해석, "active run 없음" exit 0 |
| 스크립트 실검증 — 닫힌 PR(#3499) | "OPEN 아님 — 중단" exit 1 |
| jq 필터 필드 실데이터 검증 | #3456 branch 실제 run 이 `head_repository.full_name`·`head_branch` 기대 형태, completed 정확 제외 |

### 검증 한계 (정직 고지)

- stale run **실취소 경로는 미실증** — 실제 update branch 경합 없이 안전하게 만들 수 없다.
  필터 로직은 reaper 와 동일 구조이고 필드명은 실데이터로 확인했다.
- **reaper 는 merge 전 발동 불가** — `pull_request_target` 은 base 브랜치 파일로 동작한다.
  merge 후 첫 fork PR update branch 에서 실증하며, 그때까지 #3508 을 닫지 않는다.

## @jangster77 님께 — 격리 저장소 사전 검증 요청 (선택)

#3406 때 격리 fork 로 reaper 를 사전 실증하신 전례가 있습니다. 가능하시면 이 branch 의
워크플로를 격리 저장소 base 브랜치에 두고 fork PR update branch 시나리오로 사전 검증해
주시면 merge 확신이 높아집니다. 어려우면 merge 후 첫 fork PR 처리에서 함께 확인해도 됩니다.
이 변경이 닫으려는 불편이 바로 그 fork PR 처리 마찰입니다.