### PR TITLE
ci(#3508): reaper 이중 트리거 핫픽스 — same-repo 즉시 복원 + fork 는 main 반영 후 개시

### DIFF
--- a/.github/workflows/cancel-stale-pr-runs.yml
+++ b/.github/workflows/cancel-stale-pr-runs.yml
@@ -2,16 +2,24 @@ name: Cancel stale PR runs
 
 # Update branch(synchronize) 뒤 같은 devel PR의 이전 SHA run을 force-cancel한다.
 #
-# [#3508] pull_request_target 전환 — fork PR도 자동 cancel 대상이다.
-# - pull_request 이벤트는 fork PR에서 토큰이 읽기 전용으로 강등돼 actions API를 못 부른다.
-#   pull_request_target은 base 저장소 write 토큰을 유지하고, PR base 브랜치(devel)의 이
-#   파일로 평가되므로 main 반영을 기다릴 필요가 없다(#3406 원안의 설계).
+# [#3508] 이중 트리거 — pull_request(same-repo 즉시) + pull_request_target(fork, main 반영 후).
+# - 실측(#3503, 2026-07-28): pull_request_target 트리거는 **default 브랜치(main)의 워크플로
+#   파일 기준으로 등록**된다. devel에만 있는 pull_request_target 정의는 발동하지 않는다.
+#   또한 트리거를 pull_request_target 단독으로 바꾸면 pull_request run은 PR merge-ref의
+#   파일을 쓰므로 same-repo 자동 cancel까지 함께 죽는다 — 그래서 두 이벤트를 모두 선언한다.
+# - pull_request: same-repo PR 전용(가드). fork PR은 토큰이 읽기 전용으로 강등돼 actions
+#   API를 못 부른다.
+# - pull_request_target: fork PR 전용(가드). 이 파일이 다음 릴리즈로 main에 실린 뒤부터
+#   발동한다. same-repo는 pull_request 경로와 중복되지 않게 skip한다.
 # - 안전 경계: 이 워크플로는 PR source를 checkout하지 않고, PR이 제공한 어떤 코드도
 #   실행하지 않는다. 순수 GitHub API 호출뿐이다. pull_request_target의 알려진 위험은
 #   PR 코드 실행에서 나오므로 이 경계를 바꾸는 수정은 보안 리뷰 없이 금지한다.
 # - fork run은 run.pull_requests 배열이 비는 GitHub quirk가 있어 PR 번호 매치 대신
 #   head_repository + head_branch + head_sha 대조로 stale을 판정한다.
 on:
+  pull_request:
+    branches: [devel]
+    types: [synchronize]
   pull_request_target:
     branches: [devel]
     types: [synchronize]
@@ -21,14 +29,22 @@ permissions:
   contents: read
   pull-requests: read
 
-# 연속 synchronize에서는 최신 reaper만 유지한다. reaper 안에서도 live head를 재확인하므로
-# 취소 요청 직전 최신 SHA를 보호한다.
+# 연속 synchronize에서는 최신 reaper만 유지한다. 이벤트별로 group을 분리한다 — 같은
+# synchronize에 두 이벤트가 다 뜨는 경우(main 반영 후 same-repo), group을 공유하면
+# skip될 run이 실제 동작할 run을 cancel-in-progress로 죽일 수 있다.
 concurrency:
-  group: cancel-stale-pr-runs-${{ github.event.pull_request.number }}
+  group: cancel-stale-pr-runs-${{ github.event_name }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   cancel-stale-runs:
+    # same-repo는 pull_request 경로로, fork는 pull_request_target 경로로만 실행해
+    # 이중 발동을 막는다.
+    if: >-
+      (github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name == github.repository)
+      || (github.event_name == 'pull_request_target'
+        && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     steps:
       - name: Force-cancel older pull-request runs for this PR

--- a/mydocs/manual/pr_review/multi_pr_update_branch.md
+++ b/mydocs/manual/pr_review/multi_pr_update_branch.md
@@ -30,10 +30,13 @@ scripts/pr_triage.sh <author> --list
 contributor 또는 maintainer가 Update branch를 수행해 PR head가 바뀌면, 이전 SHA run이 최신 required check와
 섞여 보일 수 있다. 최신 head의 CI는 절대 취소하지 않는다.
 
-1. `devel` 대상 PR(fork 포함, #3508)에서는 `Cancel stale PR runs` reaper가 `synchronize` event로
-   시작했는지, 최신 head SHA와 함께 확인한다. 이 workflow는 `pull_request_target`으로 base
-   브랜치(devel)의 정의를 실행하되 PR source를 checkout·실행하지 않고, 같은 PR head
-   (head_repository+head_branch)의 이전 SHA `pull_request` run만 force-cancel한다.
+1. `devel` 대상 PR에서는 `Cancel stale PR runs` reaper가 `synchronize` event로 시작했는지,
+   최신 head SHA와 함께 확인한다. 이 workflow는 PR source를 checkout·실행하지 않고, 같은
+   PR head(head_repository+head_branch)의 이전 SHA `pull_request` run만 force-cancel한다.
+   이중 트리거(#3508)다 — same-repo PR은 `pull_request` 경로로 즉시, **fork PR은
+   `pull_request_target` 경로인데 이 트리거는 default 브랜치(main)의 파일 기준으로
+   등록되므로(#3503 실측) 워크플로가 릴리즈로 main에 실린 뒤부터 발동한다.** 그 전의
+   fork PR은 아래 3의 script 폴백을 쓴다.
 2. reaper가 성공했다면 이전 SHA run이 `completed/cancelled`가 되었고 최신 head run이 시작됐는지 확인한다.
 3. reaper 실패·미실행 시에는 `scripts/cancel_stale_pr_runs.sh <PR번호>`로 정리한다(#3508 —
    현재 head 확인 → 이전 SHA active run 나열 → force-cancel → 완료 재확인을 한 명령으로,

--- a/mydocs/orders/20260728.md
+++ b/mydocs/orders/20260728.md
@@ -116,7 +116,7 @@ playbook 편입 등 개선 5건을 PR 코멘트로 게시했다
   편집기 실측이 선행돼야 한다. 시행 산출물은 세션 스크래치패드에 있어 이슈 등록이 결정되면
   증적을 안정 경로로 옮긴다.
 
-## #3508 — stale run 자동 cancel 을 fork PR 로 확장 (merge 완료·실증 대기)
+## #3508 — stale run 자동 cancel 을 fork PR 로 확장 (핫픽스 진행)
 
 collaborator 실불만("내 PR 은 자동 cancel 되는데 fork PR 처리 땐 main 머지 제약으로 못
 쓴다, 하나씩 처리할 때 너무 귀찮다")에서 출발. 진단: #3409 출하본이 원안(#3406 의
@@ -132,9 +132,15 @@ collaborator 실불만("내 PR 은 자동 cancel 되는데 fork PR 처리 땐 ma
   스크립트 실검증(fork 2건·닫힘 1건)과 jq 필터 필드 실데이터 확인까지 통과.
 - **PR [#3509](https://github.com/edwardkim/rhwp/pull/3509) squash merge (`8ce70526d`)**,
   CI SUCCESS 20. PR 본문에 jangster77 격리 저장소 사전 검증 요청을 선택지로 남김.
-- **잔여: reaper 실증** — `pull_request_target` 은 base 브랜치 파일로 동작하므로 merge 후
-  첫 fork PR update branch 에서만 발동 확인 가능. 실증 후 승인 받아 #3508 close.
-  이슈는 의도적으로 OPEN 유지(`Closes` 미사용).
+- **실증 실패(12:02 UTC, #3503 수동 update branch)** — reaper run 0건. 실측 확정:
+  `pull_request_target` 트리거는 **default 브랜치(main) 파일 기준으로 등록**된다.
+  "base 브랜치로 충분" 은 내 오판이었고 collaborator 의 "main 에 머지되어야" 가 옳았다.
+  2차 피해로 #3509 는 same-repo 자동 cancel 까지 끊었다(merge-ref 가 새 파일을 담아
+  `pull_request` run 미발동).
+- **핫픽스(작업지시자 승인)**: 이중 트리거 — `pull_request`(same-repo, 즉시 복원) +
+  `pull_request_target`(fork, 릴리즈로 main 반영 후 개시). concurrency group 에 event_name
+  포함(상호 cancel 방지), 2.5 문서 정정, stage2 보고서에 교훈 3건 기록.
+- 잔여: 핫픽스 PR merge → same-repo 복원 실증 → 다음 릴리즈 후 fork 실증 → #3508 close.
 
 ## PR #3516 — 암호 HWPX 기본 복호화·열기와 HWP3 아래아 보존
 

--- a/mydocs/working/task_m100_3508_stage2.md
+++ b/mydocs/working/task_m100_3508_stage2.md
@@ -1,0 +1,63 @@
+# #3508 2단계 후속 — 실증 실패, 원인 확정, 이중 트리거 핫픽스
+
+Issue: #3508
+브랜치: `task/3508-reaper-dual-trigger` (핫픽스)
+
+## 실증 시도와 실패 (2026-07-28 12:02 UTC)
+
+작업지시자가 fork PR #3503 에 수동 Update branch 를 실행해 실증을 시도했다.
+
+| 관찰 | 결과 |
+|---|---|
+| synchronize 이벤트 | 발생 — 새 head `963940ee1` 의 CI·CodeQL 정상 시작(12:02:40Z) |
+| reaper run | **0건** — 저장소 전체에서 `pull_request_target` 이벤트 run 역대 0건 |
+| main 의 reaper 파일 | 구버전(`pull_request` 트리거) 그대로 |
+
+이전 SHA(`1a1a39bd1`) run 이 이미 completed 라 취소 대상이 없던 것과 별개로, **run 자체가
+뜨지 않았다.**
+
+## 원인 — 실측으로 확정
+
+**`pull_request_target` 트리거는 default 브랜치(main)의 워크플로 파일 기준으로 등록된다.**
+devel 에만 있는 정의는 발동하지 않는다.
+
+- 계획서와 #3509 는 "base 브랜치(devel) 파일로 동작하므로 main 불필요" 를 전제로 했는데,
+  이는 "base 컨텍스트에서 실행된다" 는 문서 서술을 트리거 등록까지 확장 해석한 **오판**이다.
+  collaborator 의 원 불만("main 에 머지되어야 한다") 이 실측으로 옳았다.
+- 2차 피해: 트리거를 `pull_request_target` 단독으로 바꾼 #3509 merge 는 **same-repo 자동
+  cancel 까지 끊었다.** `pull_request` run 은 PR merge-ref 의 파일을 쓰는데, update branch
+  후 merge-ref 가 devel 의 새 파일(트리거에 `pull_request` 없음)을 담아 run 이 안 뜬다.
+  #3503 에서 reaper run 이 어느 이벤트로도 0건인 것이 그 증거다(완료 조건 4 위반 상태).
+
+## 핫픽스 — 이중 트리거
+
+`on:` 에 `pull_request` 와 `pull_request_target` 을 모두 선언하고 job 가드로 이중 발동을
+막는다.
+
+| 이벤트 | 대상 | 발동 시점 |
+|---|---|---|
+| `pull_request` | same-repo 만 (가드) | **즉시** — merge-ref 파일로 동작, #3509 이전 동작 복원 |
+| `pull_request_target` | fork 만 (가드) | 이 파일이 **릴리즈로 main 에 실린 뒤** |
+
+- concurrency group 에 `event_name` 을 포함해 이벤트별로 분리 — main 반영 후 same-repo
+  synchronize 에 두 이벤트가 다 뜰 때, group 을 공유하면 skip 될 pull_request_target run 이
+  실동작 중인 pull_request run 을 cancel-in-progress 로 죽일 수 있다.
+- 스크립트 본문·안전 경계·최소 권한은 #3509 그대로.
+- `multi_pr_update_branch.md` 2.5 의 "fork 포함" 서술을 "main 반영 후 개시" 로 정정.
+
+## 교훈
+
+- **워크플로 트리거 변경은 merge-ref 를 통해 열린 PR 전체에 소급 적용된다** — 구 트리거를
+  제거하면 그 이벤트의 run 이 즉시 전면 중단된다. 트리거 교체는 이중 선언 → main 반영 확인
+  → 구 트리거 제거의 2단계로 해야 한다.
+- `pull_request_target`·`schedule`·`workflow_run` 류의 등록형 트리거는 default 브랜치
+  기준이다. base 브랜치 서술("runs in the context of the base")과 혼동하지 말 것.
+- 격리 저장소 사전 검증(#3406 전례)을 생략한 대가를 클릭 한 번으로 배웠다 — 워크플로 트리거
+  변경은 사전 격리 검증을 기본 게이트로 삼는다.
+
+## 검증·잔여
+
+- YAML 파싱, 문서 게이트 (아래 커밋 전 실행).
+- same-repo 복원 실증: merge 후 same-repo PR synchronize 에서 `pull_request` reaper run 확인.
+- fork 커버 실증: **다음 릴리즈로 main 반영 후** fork PR update branch 에서 확인. #3508 은
+  그때까지 OPEN 유지.


### PR DESCRIPTION
## 배경 — #3509 실증 실패

작업지시자가 fork PR #3503 에 수동 Update branch 를 실행한 실증(12:02 UTC)에서 **reaper run
이 0건**이었다. 실측으로 확정된 사실:

1. **`pull_request_target` 트리거는 default 브랜치(main)의 워크플로 파일 기준으로
   등록된다.** devel 에만 있는 정의는 발동하지 않는다 — #3509 의 "base 브랜치로 충분" 전제는
   오판이었고, collaborator 의 원 불만("main 에 머지되어야 한다")이 옳았다.
2. **#3509 는 same-repo 자동 cancel 까지 끊었다.** `pull_request` run 은 PR merge-ref 의
   파일을 쓰는데, 트리거를 단독 교체한 새 파일에는 `pull_request` 가 없어 run 이 안 뜬다.
   저장소 전체에서 reaper run 이 어느 이벤트로도 0건인 것이 증거다.

## 변경

`on:` 에 두 이벤트를 모두 선언하고 job 가드로 이중 발동을 막는다.

| 이벤트 | 대상(가드) | 발동 |
|---|---|---|
| `pull_request` | same-repo 만 | **즉시** — merge-ref 파일로 동작, #3509 이전 동작 복원 |
| `pull_request_target` | fork 만 | 이 파일이 **릴리즈로 main 에 실린 뒤** |

- concurrency group 에 `event_name` 포함 — main 반영 후 same-repo synchronize 에 두 이벤트가
  같이 뜰 때 skip 될 run 이 실동작 run 을 cancel-in-progress 로 죽이는 것을 방지.
- 스크립트 본문·안전 경계(PR 코드 미checkout·미실행)·최소 권한은 #3509 그대로.
- `multi_pr_update_branch.md` 2.5 의 "fork 포함" 을 "main 반영 후 개시" 로 정정.
- stage2 보고서에 실증 실패 경위와 교훈 3건 기록 — 트리거 교체는 이중 선언 → main 반영 →
  구 트리거 제거의 2단계로, 등록형 트리거(pull_request_target·schedule·workflow_run)는
  default 브랜치 기준, 워크플로 트리거 변경은 격리 사전 검증(#3406 전례)을 기본 게이트로.

## 검증

- YAML 파싱 OK (트리거 2종 확인), 문서 링크 게이트 이상 없음.
- same-repo 복원 실증: merge 후 same-repo PR synchronize 에서 `pull_request` reaper run 확인
  예정. fork 실증: 다음 릴리즈로 main 반영 후. #3508 은 그때까지 OPEN.

관련: #3508