### PR TITLE
fix(text/#3385): 텍스트 추출이 렌더의 글리프 치환 표를 쓰도록 — PUA 유출 156,762자 → 207자

### DIFF
--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -2532,7 +2532,23 @@ fn text_surface_replacement(ch: char) -> Option<String> {
         return char::from_u32(0x2460 + n).map(|c| c.to_string());
     }
     // 렌더가 이미 표시 문자열을 갖고 있는 대역은 같은 답을 쓴다.
-    pua_to_display_text(ch)
+    if let Some(replacement) = pua_to_display_text(ch) {
+        return Some(replacement);
+    }
+    // 렌더의 글리프 치환 표(`map_pua_bullet_char`)를 텍스트 표면에도 적용한다.
+    //
+    // 새 매핑을 지어내지 않고 **렌더가 이미 쓰는 표를 재사용**한다 — 근거(한컴 정답지
+    // 실측)가 그 표에 붙어 있고, 렌더 동작은 바뀌지 않는다. 사각 안 숫자(U+F02B1~F02C4)는
+    // 그 표에서 의도적으로 원문 유지라 위 분기가 계속 담당한다.
+    //
+    // 규모: 저장소 샘플 346건 중 50건이 추출 텍스트에 PUA 를 흘렸고, 그중 U+F080F
+    // (굵은 가로선 ━)만 155,709자다. hwp3-sample11.hwp 는 한 쪽 1,398자 중 181자가
+    // 이 문자이고 최장 96자 연속 — 머리말/꼬리말 가로선이 본문 텍스트로 나갔다.
+    let mapped = super::layout::map_pua_bullet_char(ch);
+    if mapped != ch {
+        return Some(mapped.to_string());
+    }
+    None
 }
 /// 조합된 텍스트 런에서 PUA 테두리 숫자 문자를 찾아 CharOverlap 런으로 변환한다.
 ///

--- a/tests/issue_3385b_text_surface_full_pua.rs
+++ b/tests/issue_3385b_text_surface_full_pua.rs
@@ -1,0 +1,128 @@
+//! Issue #3385 후속: 텍스트 추출이 **렌더의 글리프 치환 표를 쓰지 않아** PUA 가 그대로 나간다.
+//!
+//! #3499 는 사각 안 숫자(U+F02B1~F02C4) 한 대역만 막았다. 저장소 샘플 346건을 전수
+//! 측정하니 추출 텍스트에 PUA 가 남는 문서가 **50건, 156,762자**였고, 그중 U+F080F
+//! (한컴 굵은 가로선)만 **155,709자**였다. `hwp3-sample11.hwp` 는 한 쪽 1,398자 중
+//! 181자가 이 문자이고 최장 96자 연속 — 머리말/꼬리말 가로선이 본문 텍스트로 나갔다.
+//!
+//! 정체는 저장소 안에 이미 있었다. `map_pua_bullet_char` 가 한컴 정답지 실측 근거와 함께
+//! 표시 문자를 정의한다(`0xF080F => '━'`, `0xF0854 => '《'` 등). **렌더는 그 표를 쓰는데
+//! 텍스트 추출은 쓰지 않았다.**
+//!
+//! 계약 두 가지를 고정한다.
+//!   1) 추출 텍스트에는 표에 있는 PUA 가 남지 않는다
+//!   2) 렌더는 건드리지 않는다 — `pua_to_text_surface` 는 추출 경로에서만 불린다
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// 머리말·꼬리말 가로선이 PUA 로 조판된 HWP 3.0 문서.
+const LINE_SAMPLE: &str = "samples/hwp3-sample11.hwp";
+/// 책괄호(《》)가 PUA 로 조판된 문서.
+const BRACKET_SAMPLE: &str = "samples/exam_kor.hwp";
+
+fn sample(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn out_dir(tag: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "rhwp-issue3385b-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos()
+    ))
+}
+
+fn export(kind: &str, rel: &str, dir: &Path) -> String {
+    let out = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg(kind)
+        .arg(sample(rel))
+        .arg("-o")
+        .arg(dir)
+        .output()
+        .expect("rhwp 실행 실패");
+    assert!(
+        out.status.success(),
+        "{kind} 실패: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let mut all = String::new();
+    for entry in std::fs::read_dir(dir).expect("출력 디렉터리") {
+        let path = entry.expect("항목").path();
+        if path.is_file() {
+            all.push_str(&std::fs::read_to_string(&path).unwrap_or_default());
+        }
+    }
+    all
+}
+
+fn pua_chars(text: &str) -> Vec<char> {
+    text.chars()
+        .filter(|c| {
+            let cp = *c as u32;
+            (0xE000..=0xF8FF).contains(&cp) || (0xF0000..=0xFFFFD).contains(&cp)
+        })
+        .collect()
+}
+
+/// 가로선 PUA 가 추출 텍스트에서 사라지고 읽을 수 있는 괘선으로 바뀐다.
+#[test]
+fn heavy_horizontal_line_pua_is_readable_in_extracted_text() {
+    let dir = out_dir("line");
+    let text = export("export-text", LINE_SAMPLE, &dir);
+    let leaked = pua_chars(&text);
+    assert!(
+        leaked.is_empty(),
+        "추출 텍스트에 PUA 가 남았다 ({}건): {:?}",
+        leaked.len(),
+        &leaked[..leaked.len().min(3)]
+    );
+    assert!(
+        text.contains('\u{2501}'),
+        "굵은 가로선(━)으로 바뀐 흔적이 없다 — 매핑이 적용되지 않았을 수 있다"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// 책괄호 PUA(U+F0854·F0855)도 《 》 로 나온다.
+#[test]
+fn book_bracket_pua_becomes_angle_brackets() {
+    let dir = out_dir("bracket");
+    let text = export("export-text", BRACKET_SAMPLE, &dir);
+    let leaked = pua_chars(&text);
+    assert!(
+        leaked.is_empty(),
+        "추출 텍스트에 PUA 가 남았다 ({}건): {:?}",
+        leaked.len(),
+        &leaked[..leaked.len().min(3)]
+    );
+    assert!(
+        text.contains('\u{300A}') && text.contains('\u{300B}'),
+        "책괄호 《 》 로 바뀌지 않았다"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// 렌더는 그대로다 — 텍스트 표면 변환이 렌더까지 번지면 안 된다.
+///
+/// `map_pua_bullet_char` 는 원래 렌더 경로의 표이므로 SVG 에는 이미 치환된 글자가 나온다.
+/// 여기서 고정하는 것은 **텍스트 전용 변환이 렌더 출력을 바꾸지 않는다**는 점이다 —
+/// 사각 안 숫자는 렌더에서 원문 유지(캡스톤 F-1 결정)여야 한다.
+#[test]
+fn render_keeps_the_boxed_number_passthrough() {
+    let dir = out_dir("svg");
+    let svg = export("export-svg", "samples/2022년 국립국어원 업무계획.hwp", &dir);
+    let boxed = svg
+        .chars()
+        .filter(|c| (0xF02B1..=0xF02C4).contains(&(*c as u32)))
+        .count();
+    assert!(
+        boxed > 0,
+        "렌더에서 사각 안 숫자 원문이 사라졌다 — 텍스트 표면 변환이 렌더까지 번졌다"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## 요약

`export-text` 산출물에 한컴 PUA 가 그대로 남아, 폰트가 없는 소비자(RAG·LLM·grep)에게
**읽을 수 없는 코드포인트**가 흘러갔습니다.

저장소 샘플 **346건 전수** 측정: **50개 문서 · 156,762자**. 그중 `U+F080F`(한컴 굵은
가로선)만 **155,709자**입니다.

```
hwp3-sample11.hwp — 한 쪽 1,398자 중 181자(13%)가 U+F080F, 최장 96자 연속
→ 머리말/꼬리말 가로선이 본문 텍스트로 나갔다
```

## 근인 — 표는 이미 있었는데 텍스트만 안 썼다

`map_pua_bullet_char`(paragraph_layout.rs)가 한컴 정답지 실측 근거와 함께 표시 문자를
정의합니다.

```rust
0xF080F => '\u{2501}', // ━ (Task #826, sample11 머리말/꼬리말 가로선 시각 정합)
0xF0854 => '\u{300A}', // 《 (Task #528, exam_kor p17 실측 각 33회)
0xF0855 => '\u{300B}', // 》
0xF081A => '\u{2500}', // ─
0xF0827 => '\u{25A0}', // ■
```

**렌더는 이 표를 쓰는데 텍스트 추출은 쓰지 않았습니다.** 앞선 수정(PR #3499)은
`pua_to_display_text` 가 보는 **작은 표**만 참조해 사각 안 숫자 한 대역만 막았습니다.

## 변경

`text_surface_replacement` 가 `map_pua_bullet_char` 를 함께 참조하도록 한 줄기 확장입니다.

- **새 매핑을 지어내지 않습니다** — 근거가 붙은 기존 렌더 표를 재사용합니다.
- **렌더는 바뀌지 않습니다** — `pua_to_text_surface` 의 호출처는 `extract_page_text_native`
  하나뿐입니다(코드 수준으로 확인).
- 사각 안 숫자(U+F02B1~F02C4)는 그 표에서 **의도적으로 원문 유지**(캡스톤 F-1)라 #3499 가
  넣은 텍스트 전용 매핑이 계속 담당합니다.

## 실측 (샘플 346건 전수, 최신 `devel` 기준)

| | 수정 전 | 수정 후 |
|---|---|---|
| PUA 유출 문서 | 50 | **22** |
| PUA 유출 글자 | 156,762 | **207** (99.9% 감소) |
| `hwp3-sample11.hwp` | 27,195 | **0** |

## 검증

- 회귀 테스트 3건 — 가로선 `━` / 책괄호 `《》` / **렌더의 사각 안 숫자 원문 유지**(번짐 방지 가드).
  수정을 되돌리면 앞 2건 red, 가드는 양쪽 green.
- `cargo nextest run --no-fail-fast` **4,252건 전건 통과**
- `cargo clippy --all-targets -- -D warnings` 통과, 변경 파일 rustfmt 클린
- 최신 `devel` 위로 리베이스 후 재확인

## 남은 것 — 매핑을 지어내지 않았습니다

잔여 207자는 `map_pua_bullet_char` 에 **없는** 코드포인트입니다. 한컴 표시 모양을 아시는
분이 알려 주시면 표에 넣겠습니다.

| 코드포인트 | 잔여 | 비고 |
|---|---|---|
| U+F0810 | 42 | |
| U+F0848 | 34 | |
| U+F0808 | 21 | |
| U+F080E | 19 | |
| U+F0040 | 16 | |
| U+F080C | 13 | |
| U+E04D | 8 | BMP 사설영역 |
| U+F0289 | 7 | 글자겹침 2자리 숫자 계열(십의자리 1) |
| U+F0806 | 7 | |
| U+F081C | 4 | HWP TAC filler (Issue #677 — 시각 폭 0, 텍스트에서 제거 검토 대상) |

<sub>정정: PR #3499 에서 U+F0854·F0855 를 "의미 미확인"으로 남겼는데 틀렸습니다 —
`map_pua_bullet_char` 에 책괄호로 이미 매핑돼 있었고, 제가 작은 표만 보고 단정했습니다.
이슈 #3385 에 정정해 두었습니다.</sub>

Refs #3385
