### PR TITLE
fix(parser/#3524): HWP3 책갈피를 공통 Control::Bookmark 로 — 저장하면 통째로 사라지던 축

### DIFF
--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -1650,13 +1650,16 @@ fn parse_hwp3_object_dispatch(
         let name = crate::parser::hwp3::encoding::decode_hwp3_string(name_buf)
             .trim_end_matches('\0')
             .to_string();
-        let bookmark_type = (&bookmark_extra[32..34])
-            .read_u16::<LittleEndian>()
-            .unwrap_or(0);
-        let mut field = crate::model::control::Field::default();
-        field.field_type = crate::model::control::FieldType::Unknown;
-        field.command = format!("Bookmark:{}:type={}", name, bookmark_type);
-        controls.push(crate::model::control::Control::Field(field));
+        // 책갈피 종류(offset 40..42)는 공통 IR 의 `Bookmark` 에 자리가 없어 싣지 않는다.
+        // 이름이 책갈피의 정체이고, 그것만 있으면 HWP5 로 온전히 저장된다.
+        //
+        // 종전에는 `Control::Field(command="Bookmark:<이름>:type=N")` 라는 HWP3 전용
+        // 합성 표현을 공통 IR 에 넣었다. 읽는 곳이 없는 잔재였고, HWP5 저장기가 표현할 수
+        // 없어 저장하면 통째로 사라졌다 (hwp3-sample16.hwp 10건, `convert --verify` exit 3).
+        // IR 에는 이미 `Control::Bookmark` 가 있고 저장기도 CTRL_BOOKMARK 로 완비돼 있다.
+        controls.push(crate::model::control::Control::Bookmark(
+            crate::model::control::Bookmark { name },
+        ));
         ctrl_data_records.push(None);
     } else if ch == 7 {
         // [Task #877] 날짜 형식 (spec §10.3, 표 37): 84 bytes total.

--- a/tests/issue_hwp3_bookmark_native.rs
+++ b/tests/issue_hwp3_bookmark_native.rs
@@ -1,0 +1,119 @@
+//! HWP3 책갈피가 저장하면 통째로 사라진다 (#3505 스윕에서 발견).
+//!
+//! `convert --verify` 가 `hwp3-sample16.hwp` 에서 exit 3 을 냈다.
+//!
+//! ```text
+//! paragraph[70] controls: expected=[field,newNum,pageNumPos] actual=[newNum,pageNumPos]
+//! paragraph[73] controls: expected=[field] actual=[]
+//! ```
+//!
+//! ## 근인
+//!
+//! HWP3 파서가 책갈피를 **HWP3 전용 합성 표현**으로 만들었다.
+//!
+//! ```text
+//! Control::Field { field_type: Unknown, command: "Bookmark:<이름>:type=0" }
+//! ```
+//!
+//! 이 `command` 문자열을 읽는 곳은 저장소 어디에도 없다 — 순수 잔재다. 그런데 HWP5
+//! 저장기에는 `FieldType::Unknown` 필드를 쓸 방법이 없어 저장하면 컨트롤이 통째로 사라졌다.
+//!
+//! 공통 IR 에는 이미 `Control::Bookmark` 가 있고 저장기도 `CTRL_BOOKMARK` 로 완비돼 있다.
+//! HWP3 전용 해석을 `src/parser/hwp3/` 안에서 끝내고 공통 표현을 내보내면 그대로 왕복한다.
+//! **#3492(개요번호 마커 IR 유출)와 같은 계열**이다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::model::control::Control;
+
+/// 책갈피 10개가 든 HWP 3.0 문서.
+const SAMPLE: &str = "samples/hwp3-sample16.hwp";
+const BOOKMARK_COUNT: usize = 10;
+
+fn sample_path() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn load(path: &std::path::Path) -> rhwp::model::document::Document {
+    let data = std::fs::read(path).expect("파일 읽기");
+    rhwp::parser::parse_document(&data).expect("파싱")
+}
+
+fn bookmark_names(doc: &rhwp::model::document::Document) -> Vec<String> {
+    doc.sections
+        .iter()
+        .flat_map(|s| s.paragraphs.iter())
+        .flat_map(|p| p.controls.iter())
+        .filter_map(|c| match c {
+            Control::Bookmark(b) => Some(b.name.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn convert_roundtrip() -> std::path::PathBuf {
+    let out = std::env::temp_dir().join(format!(
+        "rhwp-hwp3bm-{}-{}.hwp",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos()
+    ));
+    let res = std::process::Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("convert")
+        .arg(sample_path())
+        .arg(&out)
+        .arg("--verify")
+        .output()
+        .expect("rhwp 실행");
+    assert_eq!(
+        res.status.code(),
+        Some(0),
+        "convert --verify 가 IR 손실을 보고했다:\n{}",
+        String::from_utf8_lossy(&res.stdout)
+    );
+    out
+}
+
+/// 책갈피는 공통 표현(`Control::Bookmark`)으로 나온다 — HWP3 전용 합성 필드가 아니다.
+#[test]
+fn hwp3_bookmarks_use_the_common_control() {
+    let doc = load(&sample_path());
+    assert_eq!(
+        bookmark_names(&doc).len(),
+        BOOKMARK_COUNT,
+        "책갈피가 공통 표현으로 나오지 않았다"
+    );
+
+    // 합성 표현이 남아 있으면 안 된다.
+    let leaked: Vec<String> = doc
+        .sections
+        .iter()
+        .flat_map(|s| s.paragraphs.iter())
+        .flat_map(|p| p.controls.iter())
+        .filter_map(|c| match c {
+            Control::Field(f) if f.command.starts_with("Bookmark:") => Some(f.command.clone()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "HWP3 전용 책갈피 합성 필드가 IR 에 남았다: {leaked:?}"
+    );
+}
+
+/// 저장해도 책갈피가 이름까지 그대로 살아남는다.
+#[test]
+fn bookmarks_survive_saving_to_hwp5() {
+    let before = bookmark_names(&load(&sample_path()));
+    assert_eq!(before.len(), BOOKMARK_COUNT);
+
+    let out = convert_roundtrip();
+    let after = bookmark_names(&load(&out));
+    let _ = std::fs::remove_file(&out);
+
+    assert_eq!(
+        after, before,
+        "저장 후 책갈피가 달라졌다 (수정 전에는 통째로 사라졌다)"
+    );
+}


### PR DESCRIPTION
## 요약

HWP 3.0 문서를 저장하면 **책갈피가 통째로 사라집니다.** `convert --verify` 가 exit 3 으로
컨트롤 소실 10건을 보고합니다 (`hwp3-sample16.hwp` 의 책갈피 **전부**).

## 근인 — HWP3 전용 합성 표현이 공통 IR 로 유출

```rust
// 종전 (src/parser/hwp3/mod.rs)
field.field_type = FieldType::Unknown;
field.command = format!("Bookmark:{}:type={}", name, bookmark_type);
controls.push(Control::Field(field));
```

- 이 `"Bookmark:…"` 문자열을 읽는 곳은 **저장소 어디에도 없습니다** — 순수 잔재입니다.
- HWP5 저장기에는 `FieldType::Unknown` 필드를 쓸 방법이 없어 **컨트롤이 통째로 사라집니다.**

그런데 필요한 것은 **이미 다 있었습니다.**

- 공통 IR: `Control::Bookmark { name }`
- HWP5 저장기: `CTRL_BOOKMARK` + `serialize_bookmark_ctrl_data`
- 컨트롤 문자: `Control::Bookmark => (0x0016, tags::CTRL_BOOKMARK)`

파서만 공통 표현을 내보내면 그대로 왕복합니다.

## 변경

`CLAUDE.md` 의 "HWP3 전용 해석은 `src/parser/hwp3/` 안에서 끝낸다" 규칙에 맞춰 파서 안에서
닫습니다. **#3492(개요번호 마커 IR 유출)와 같은 계열**입니다 — 그때는 정보가 이미
`ParaShape` 로 옮겨져 있어 마커를 걷어내는 것이 답이었고, 이번엔 공통 표현이 이미 있어
그것으로 바꾸는 것이 답입니다.

## 실측

| 지표 | 수정 전 | 수정 후 |
|---|---|---|
| `convert --verify` | **exit 3** (차이 10건) | **exit 0** |
| 책갈피 왕복 | 10 → **0** | 10 → **10** (이름 수열 동일) |
| 페이지 수 | 64 | 64 — 불변 |

## 검증

- 회귀 테스트 2건 (`tests/issue_hwp3_bookmark_native.rs`) — 공통 표현 사용(+합성 필드 미유출)
  / 저장 후 이름까지 보존. **수정을 되돌리면 둘 다 red.**
- `cargo nextest run --no-fail-fast` **4,256건 전건 통과**
- `cargo clippy --all-targets -- -D warnings` 통과, 변경 파일 rustfmt 클린
- 최신 `devel` 위로 리베이스 후 재확인

## 범위 밖으로 남긴 것

책갈피 **종류**(spec §10.2 offset 40..42)는 공통 IR 의 `Bookmark` 에 자리가 없어 싣지
않았습니다. 이름이 책갈피의 정체이고 그것만으로 HWP5 에 온전히 저장됩니다. 종류까지
보존하려면 `Bookmark` 구조체 확장이 필요해 별도 판단 대상으로 두었습니다.

## 발견 경위

#3505(샘플 346건 전수 `convert --verify`)의 다섯 축 중 **실제 소실이 확인된 유일한 축**을
추적한 결과입니다. 나머지 넷은 확인 결과 손실이 아니거나 판정 유보로 정정했습니다.

Refs #3524
