### PR TITLE
fix(parser/#3528): 표 캡션 경계를 직계 레벨로 판정 — 캡션 속 표가 경계를 가로채던 문제

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6158,6 +6158,8 @@ fn convert_hwp(args: &[String]) -> i32 {
             return EXIT_RUNTIME;
         }
     };
+    // [#3505] --verify 비교 강도를 정하려면 원본 포맷을 알아야 한다 (대상은 항상 HWP5).
+    let source_format = rhwp::parser::detect_format(&data);
 
     // 문서 로드
     let mut doc = match load_document(&data) {
@@ -6219,6 +6221,13 @@ fn convert_hwp(args: &[String]) -> i32 {
                             doc.document(),
                             reloaded.document(),
                         );
+                        // [#3505] 포맷을 넘는 변환이면 대상 포맷에 자리가 없는 항목을
+                        // 걷어낸다. 같은 포맷(HWP5→HWP5) 왕복은 엄격 비교 그대로.
+                        let diff = if source_format == rhwp::parser::FileFormat::Hwp {
+                            diff
+                        } else {
+                            rhwp::serializer::hwpx::roundtrip::strip_cross_format_noise(diff)
+                        };
                         if !diff.is_empty() {
                             print_ir_verify_failure(&diff, output_path);
                             process::exit(3);

--- a/src/parser/control.rs
+++ b/src/parser/control.rs
@@ -165,9 +165,18 @@ fn parse_table_control(ctrl_data: &[u8], child_records: &[Record]) -> Control {
     }
 
     // HWPTAG_TABLE 레코드 위치 찾기
+    //
+    // [#3528] **직계 자식 레벨**의 것만 본다. 종전에는 첫 HWPTAG_TABLE 을 그냥 집었는데,
+    // 캡션 문단 안에 표가 들어 있으면 그 표가 자기 HWPTAG_TABLE 을 더 앞에 방출한다
+    // (저장 순서: CTRL_TABLE → 캡션 → HWPTAG_TABLE → 셀). 그러면 캡션 범위가 거기서
+    // 끊겨 캡션 문단이 잘리고, 그 안의 표도 얕게 읽힌다.
+    //
+    // 직계 자식은 모두 CTRL_HEADER 바로 아래 레벨이므로(캡션 LIST_HEADER·HWPTAG_TABLE·
+    // 셀 LIST_HEADER 가 같은 레벨), 자식 레코드의 최소 레벨이 곧 직계 레벨이다.
+    let direct_level = child_records.iter().map(|r| r.level).min();
     let table_record_idx = child_records
         .iter()
-        .position(|r| r.tag_id == tags::HWPTAG_TABLE);
+        .position(|r| r.tag_id == tags::HWPTAG_TABLE && Some(r.level) == direct_level);
 
     // HWPTAG_TABLE 이전에 LIST_HEADER가 있으면 캡션
     if let Some(table_idx) = table_record_idx {

--- a/src/serializer/hwpx/roundtrip.rs
+++ b/src/serializer/hwpx/roundtrip.rs
@@ -502,6 +502,45 @@ pub fn roundtrip_ir_diff(hwpx_bytes: &[u8]) -> Result<IrDiff, SerializeError> {
 ///
 /// Stage 1~5에서 비교 대상 필드를 누적 확장한다 (문단 텍스트, 표·그림 속성 등).
 /// `hwpx-roundtrip` 배치 진단(Task #1315)에서도 사용한다.
+/// [#3505] 포맷을 넘는 변환에서 **비교할 수 없는 항목**을 걷어낸다.
+///
+/// `diff_documents` 는 HWPX 왕복(같은 포맷) 보존 가드로 만들어졌다. `convert` 처럼 포맷을
+/// 넘는 변환에 그대로 쓰면 **대상 포맷에 자리가 없는 필드**가 차이로 잡혀, 진짜 손실이
+/// 그 잡음에 묻힌다. 샘플 346건 실측에서 차이 224건 중 180건이 이 부류였다.
+///
+/// 걷어내는 것은 둘뿐이고, 각각 "내용이 보존됨"을 실측으로 확인한 것만 넣었다.
+///
+/// 1. **HWPX `<hp:parameters>` 원문**(`raw_parameters_xml`) — HWPX 전용 verbatim 필드(#1391)로
+///    HWP5 에는 대응 표현이 없다. 하이퍼링크·Clickhere 의 실제 payload 는 `command` 와
+///    필드 이름으로 보존된다(issue1893 fixture 11개 전수 확인: `command` 달라진 필드 0건).
+/// 2. **원본이 값을 안 가진 `imgDim`** — 원본 `(0, 0)` 에 왕복본이 실제 치수를 채우는
+///    방향이다. 잃은 것이 아니라 채운 것이라 손실이 아니다.
+///
+/// 같은 포맷 왕복(HWPX→HWPX, HWP5→HWP5)에는 **쓰지 않는다** — 그쪽에서는 두 필드 모두
+/// 보존돼야 할 진짜 계약이다.
+pub fn strip_cross_format_noise(diff: IrDiff) -> IrDiff {
+    IrDiff {
+        differences: diff
+            .differences
+            .into_iter()
+            .filter(|d| !is_cross_format_incomparable(d))
+            .collect(),
+    }
+}
+
+fn is_cross_format_incomparable(d: &IrDifference) -> bool {
+    match d {
+        // HWPX verbatim parameters 소실 — 대상 포맷에 자리가 없다.
+        IrDifference::FieldContent { detail, .. } => {
+            detail.contains("parameters:") && detail.contains("actual=None")
+        }
+        // 원본이 값을 안 가진 imgDim 만 — 다른 크기 필드가 섞여 있으면 남긴다.
+        IrDifference::PictureSize { detail, .. } => {
+            detail.starts_with("imgDim: expected=(0, 0)") && !detail.contains(';')
+        }
+        _ => false,
+    }
+}
 pub fn diff_documents(a: &Document, b: &Document) -> IrDiff {
     let mut diff = IrDiff::default();
 
@@ -595,10 +634,20 @@ pub fn diff_documents(a: &Document, b: &Document) -> IrDiff {
     }
 
     // BinData
-    if a.bin_data_content.len() != b.bin_data_content.len() {
+    //
+    // [#3505] 바이트가 0인 항목은 세지 않는다. HWP3 파서는 그림 컨트롤마다 id·확장자·
+    // 바이트가 모두 빈 placeholder 를 만드는데(hwp3-sample10.hwp 3건), 저장기가 그것을
+    // 쓰지 않는 것은 손실이 아니다. 실제 이미지는 컨트롤 내부 경로로 실려 렌더된다.
+    let non_empty = |d: &Document| -> usize {
+        d.bin_data_content
+            .iter()
+            .filter(|c| !c.data.load().is_empty())
+            .count()
+    };
+    if non_empty(a) != non_empty(b) {
         diff.push(IrDifference::BinDataContentCount {
-            expected: a.bin_data_content.len(),
-            actual: b.bin_data_content.len(),
+            expected: non_empty(a),
+            actual: non_empty(b),
         });
     }
 

--- a/tests/convert_verify_corpus_ratchet.rs
+++ b/tests/convert_verify_corpus_ratchet.rs
@@ -1,0 +1,229 @@
+//! [#3505] `convert --verify` 코퍼스 래칫 — 저장 손실이 새로 들어오는 것을 막는다.
+//!
+//! 이 세션에서 고친 저장 손실 두 건(#3492 개요번호 마커, #3524 책갈피)은 **둘 다
+//! `convert --verify` 가 이미 종료코드로 판정할 수 있었는데** 아무도 돌리지 않아 남아
+//! 있었다. 개별 결함을 더 찾는 것보다 이 계열이 다시 들어오지 못하게 막는 쪽이 낫다.
+//!
+//! ## 왜 지금 걸 수 있게 됐나
+//!
+//! 종전에는 샘플 346건 중 **22건**이 exit 3 였다. 그중 대부분은 손실이 아니라 **포맷 간
+//! 비교가 무의미한 항목**이었다 — `diff_documents` 는 HWPX 왕복(같은 포맷) 가드로 만들어졌기
+//! 때문이다. 그 항목들을 `strip_cross_format_noise` 로 걷어내고 빈 BinData placeholder 를
+//! 세지 않게 하니 **6건**만 남았다. 그 6건은 아래에 근거와 함께 등재한다.
+//!
+//! ## 이 테스트가 하는 일
+//!
+//! 샘플 전수를 변환·재파싱해 `--verify` 와 같은 비교를 돌리고, **실패하는 문서 집합이
+//! 등재 목록과 정확히 같은지** 본다.
+//!
+//! - 새 문서가 실패하면 → 저장 손실이 새로 들어왔다. 고치거나, 근거를 적어 등재하라.
+//! - 등재된 문서가 통과하면 → 고쳐졌다. **목록에서 지워라** (래칫을 조인다).
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::parser::FileFormat;
+use rhwp::serializer::hwpx::roundtrip::{diff_documents, strip_cross_format_noise};
+
+/// 현재 저장 손실이 남아 있는 문서 — 각 항목은 **왜 아직 열려 있는지**를 밝힌다.
+///
+/// 고치면 여기서 지운다. 새로 추가할 때는 반드시 근거를 함께 적는다.
+const EXPECTED_FAILURES: &[(&str, &str)] = &[
+    (
+        "hwp3-sample16.hwp",
+        "HWP3 책갈피 소실 (#3524) — PR #3525 로 수정 제출, 머지되면 이 줄을 지운다",
+    ),
+    (
+        "2025년 기부·답례품 실적 지자체 보고서_양식.hwpx",
+        "표 flowWithText 가 false→true 로 뒤집힘 20건 (#3505). rhwp 렌더 영향은 0으로 \
+         확인(쪽수·텍스트·SVG 괘선 좌표 동일), 한글 해석은 오라클 필요",
+    ),
+    (
+        "2025 행정업무운영 편람(최종).hwpx",
+        "같은 flowWithText 축 12건 (#3505)",
+    ),
+    (
+        "issue1853_caption_precedes_body_split.hwpx",
+        "같은 flowWithText 축 1건 (#3505)",
+    ),
+    ("hwpx_sample2.hwpx", "같은 flowWithText 축 1건 (#3505)"),
+    (
+        "issue1891_external_bindata_link.hwpx",
+        "깊이 3 중첩 표의 캡션 소실 — 캡션 문단 3→1, page_break RowBreak→None. \
+         flowWithText 와 다른 축이며 아직 조사 전",
+    ),
+];
+
+/// 게이트에서 제외하는 문서 — 크기에 비해 변환이 지나치게 오래 걸린다(각 2분+).
+///
+/// 제외는 **결함이 없다는 뜻이 아니다.** 별도 스윕으로 확인한다.
+const TOO_SLOW: &[&str] = &[
+    "[2027] 온새미로 1 본교재.hwp",
+    "[2027] 온새미로 1 본교재.hwpx",
+];
+
+/// 크기 상한 — 이보다 큰 문서는 게이트에서 제외한다(등재 문서는 예외로 항상 검사).
+///
+/// 코퍼스 346건 중 287건이 이 상한 안이고 바이트로는 37MB / 280MB 다. 비용은 대형
+/// 50여 건이 지배하므로, 상한을 두면 **문서 수 83%를 유지하면서 실행 시간을 크게 줄인다.**
+/// 상한을 넘는 문서의 저장 손실은 이 게이트가 잡지 못한다 — 별도 스윕 대상이다.
+const SIZE_CAP_BYTES: u64 = 1024 * 1024;
+
+/// 코퍼스를 나눌 조각 수 — nextest 가 조각마다 프로세스를 병렬로 띄운다.
+const PARTITIONS: usize = 4;
+
+fn samples_dir() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("samples")
+}
+
+/// `convert --verify` 와 같은 판정: 변환 → 재파싱 → IR 비교.
+///
+/// 비교 강도는 CLI 와 같다 — 포맷을 넘으면 대상 포맷에 자리가 없는 항목을 걷어낸다.
+fn verify_roundtrip(data: &[u8]) -> Option<usize> {
+    let source_format = rhwp::parser::detect_format(data);
+    let mut doc = rhwp::wasm_api::HwpDocument::from_bytes(data).ok()?;
+    doc.convert_to_editable_native().ok()?;
+    let bytes = doc.export_hwp_with_adapter().ok()?;
+    let reloaded = rhwp::wasm_api::HwpDocument::from_bytes(&bytes).ok()?;
+
+    let diff = diff_documents(doc.document(), reloaded.document());
+    let diff = if source_format == FileFormat::Hwp {
+        diff
+    } else {
+        strip_cross_format_noise(diff)
+    };
+    Some(diff.differences.len())
+}
+
+/// 코퍼스를 `PARTITIONS` 조각으로 나눠 검사한다.
+///
+/// 전수를 한 테스트로 돌리면 415초가 걸려 CI 샤드 하나가 그만큼 길어진다. nextest 는
+/// `#[test]` 단위로 프로세스를 병렬 스케줄하므로, 조각으로 나누면 **같은 커버리지에
+/// 벽시계만 1/N** 이 된다. 나눔 기준은 정렬된 파일 목록의 인덱스라 결정적이다.
+fn run_partition(part: usize) {
+    let expected: std::collections::BTreeMap<&str, &str> =
+        EXPECTED_FAILURES.iter().copied().collect();
+    let skip: std::collections::BTreeSet<&str> = TOO_SLOW.iter().copied().collect();
+
+    let mut failed: std::collections::BTreeMap<String, usize> = Default::default();
+    let mut checked = 0usize;
+    let mut unreadable = 0usize;
+    let mut oversized = 0usize;
+    let mut seen: std::collections::BTreeSet<String> = Default::default();
+
+    let mut entries: Vec<std::path::PathBuf> = std::fs::read_dir(samples_dir())
+        .expect("samples 디렉터리")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| {
+            matches!(
+                p.extension().and_then(|s| s.to_str()),
+                Some("hwp") | Some("hwpx")
+            )
+        })
+        .collect();
+    // 크기 내림차순으로 정렬한 뒤 인덱스로 나눈다 — 큰 문서가 한 조각에 몰리면 그 조각이
+    // 전체 벽시계를 지배한다(실측: 이름순 분배 시 42/50/134/191초로 4.5배 편차).
+    // 이름을 2차 키로 둬서 크기가 같아도 순서가 결정적이다.
+    entries.sort_by_key(|p| {
+        let size = std::fs::metadata(p).map(|m| m.len()).unwrap_or(0);
+        (std::cmp::Reverse(size), p.clone())
+    });
+
+    for (index, path) in entries.into_iter().enumerate() {
+        if index % PARTITIONS != part {
+            continue;
+        }
+        let name = path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or_default()
+            .to_string();
+        if skip.contains(name.as_str()) {
+            continue;
+        }
+        // 등재된 문서는 크기와 무관하게 항상 검사한다 — 그래야 고쳐졌을 때 래칫을 조일 수
+        // 있고, 다시 나빠졌을 때도 잡힌다.
+        let pinned_doc = expected.contains_key(name.as_str());
+        if !pinned_doc {
+            let too_big = std::fs::metadata(&path)
+                .map(|m| m.len() > SIZE_CAP_BYTES)
+                .unwrap_or(false);
+            if too_big {
+                oversized += 1;
+                continue;
+            }
+        }
+        let Ok(data) = std::fs::read(&path) else {
+            continue;
+        };
+        // 암호 문서 등 열 수 없는 표본은 이 게이트의 대상이 아니다.
+        let Some(count) = verify_roundtrip(&data) else {
+            unreadable += 1;
+            continue;
+        };
+        checked += 1;
+        seen.insert(name.clone());
+        if count > 0 {
+            failed.insert(name, count);
+        }
+    }
+
+    assert!(
+        checked > 40,
+        "조각 {part} 이 검사한 문서가 너무 적다({checked}건) — 표본 수집이 깨졌는지 확인하라"
+    );
+
+    let now: std::collections::BTreeSet<&str> = failed.keys().map(|s| s.as_str()).collect();
+    // 이 조각이 실제로 검사한 문서만 비교 대상이다 — 다른 조각의 등재 문서를 여기서
+    // "고쳐졌다" 로 오판하면 안 된다.
+    let pinned: std::collections::BTreeSet<&str> = expected
+        .keys()
+        .copied()
+        .filter(|n| seen.contains(*n))
+        .collect();
+
+    let regressions: Vec<String> = now
+        .difference(&pinned)
+        .map(|n| format!("  + {n} (차이 {}건)", failed[*n]))
+        .collect();
+    let fixed: Vec<String> = pinned
+        .difference(&now)
+        .map(|n| format!("  - {n}"))
+        .collect();
+
+    assert!(
+        regressions.is_empty(),
+        "저장 손실이 새로 들어왔다 ({}건):\n{}\n\
+         고치거나, 근거를 적어 EXPECTED_FAILURES 에 등재하라.\n\
+         상세: rhwp convert <파일> /tmp/out.hwp --verify\n\
+         (검사 {checked}건 / 열 수 없음 {unreadable}건 / 크기 상한 초과 {oversized}건)",
+        regressions.len(),
+        regressions.join("\n")
+    );
+
+    assert!(
+        fixed.is_empty(),
+        "등재된 문서가 이제 통과한다 ({}건):\n{}\n\
+         EXPECTED_FAILURES 에서 지워 래칫을 조여라.",
+        fixed.len(),
+        fixed.join("\n")
+    );
+}
+
+#[test]
+fn ratchet_partition_0() {
+    run_partition(0);
+}
+
+#[test]
+fn ratchet_partition_1() {
+    run_partition(1);
+}
+
+#[test]
+fn ratchet_partition_2() {
+    run_partition(2);
+}
+
+#[test]
+fn ratchet_partition_3() {
+    run_partition(3);
+}

--- a/tests/convert_verify_corpus_ratchet.rs
+++ b/tests/convert_verify_corpus_ratchet.rs
@@ -45,11 +45,7 @@ const EXPECTED_FAILURES: &[(&str, &str)] = &[
         "같은 flowWithText 축 1건 (#3505)",
     ),
     ("hwpx_sample2.hwpx", "같은 flowWithText 축 1건 (#3505)"),
-    (
-        "issue1891_external_bindata_link.hwpx",
-        "표 캡션 안에 표가 있을 때 캡션 문단이 3→1 로 잘림 (#3528). 저장기는 문단 3개를 \
-         모두 쓰므로 재파싱 쪽 종료 판정이 유력하나 미확인",
-    ),
+    // issue1891_external_bindata_link.hwpx 는 #3528 수정으로 통과한다 — 래칫을 한 칸 조였다.
 ];
 
 /// 게이트에서 제외하는 문서 — 크기에 비해 변환이 지나치게 오래 걸린다(각 2분+).

--- a/tests/convert_verify_corpus_ratchet.rs
+++ b/tests/convert_verify_corpus_ratchet.rs
@@ -47,8 +47,8 @@ const EXPECTED_FAILURES: &[(&str, &str)] = &[
     ("hwpx_sample2.hwpx", "같은 flowWithText 축 1건 (#3505)"),
     (
         "issue1891_external_bindata_link.hwpx",
-        "깊이 3 중첩 표의 캡션 소실 — 캡션 문단 3→1, page_break RowBreak→None. \
-         flowWithText 와 다른 축이며 아직 조사 전",
+        "표 캡션 안에 표가 있을 때 캡션 문단이 3→1 로 잘림 (#3528). 저장기는 문단 3개를 \
+         모두 쓰므로 재파싱 쪽 종료 판정이 유력하나 미확인",
     ),
 ];
 

--- a/tests/issue_3528_nested_caption_boundary.rs
+++ b/tests/issue_3528_nested_caption_boundary.rs
@@ -1,0 +1,102 @@
+//! Issue #3528: 표 캡션 안에 표가 있으면 저장 시 캡션 문단이 잘린다.
+//!
+//! ## 근인
+//!
+//! HWP5 저장 순서는 `CTRL_TABLE → 캡션(LIST_HEADER + 문단) → HWPTAG_TABLE → 셀` 이다.
+//! 파서는 그 순서를 이용해 **첫 `HWPTAG_TABLE` 앞까지**를 캡션으로 잘랐다.
+//!
+//! 그런데 캡션 문단 **안에 표가 들어 있으면** 그 표가 자기 `HWPTAG_TABLE` 을 더 앞에
+//! 방출한다. 그러면 경계 판정이 바깥 표의 것이 아니라 **캡션 속 표의 것**을 집어, 캡션
+//! 문단이 잘리고 그 안의 표도 얕게 읽힌다.
+//!
+//! 해법은 **직계 자식 레벨의 `HWPTAG_TABLE` 만** 경계로 삼는 것이다. 캡션 LIST_HEADER ·
+//! HWPTAG_TABLE · 셀 LIST_HEADER 가 모두 같은 레벨이므로, 자식 레코드의 최소 레벨이 곧
+//! 직계 레벨이다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::model::control::Control;
+use rhwp::model::paragraph::Paragraph;
+
+/// 캡션 안에 표가 든 문서 (깊이 3 중첩).
+const SAMPLE: &str = "samples/issue1891_external_bindata_link.hwpx";
+
+fn sample_path() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+/// 문서 전체에서 "캡션 문단 안에 표를 가진" 표를 찾아 (캡션 문단 수) 목록을 만든다.
+fn captions_holding_tables(doc: &rhwp::model::document::Document) -> Vec<usize> {
+    fn walk(paras: &[Paragraph], out: &mut Vec<usize>) {
+        for p in paras {
+            for c in &p.controls {
+                let Control::Table(t) = c else { continue };
+                if let Some(caption) = &t.caption {
+                    let holds_table = caption
+                        .paragraphs
+                        .iter()
+                        .any(|cp| cp.controls.iter().any(|cc| matches!(cc, Control::Table(_))));
+                    if holds_table {
+                        out.push(caption.paragraphs.len());
+                    }
+                    walk(&caption.paragraphs, out);
+                }
+                for cell in &t.cells {
+                    walk(&cell.paragraphs, out);
+                }
+            }
+        }
+    }
+    let mut out = Vec::new();
+    for s in &doc.sections {
+        walk(&s.paragraphs, &mut out);
+    }
+    out
+}
+
+fn load(path: &std::path::Path) -> rhwp::model::document::Document {
+    let data = std::fs::read(path).expect("파일 읽기");
+    rhwp::parser::parse_document(&data).expect("파싱")
+}
+
+/// 표를 품은 캡션이 저장 후에도 문단 수를 유지한다.
+#[test]
+fn caption_holding_a_table_keeps_its_paragraphs() {
+    let before = captions_holding_tables(&load(&sample_path()));
+    assert!(
+        !before.is_empty(),
+        "캡션 안에 표를 가진 표를 찾지 못했다 — 표본이 바뀌었는지 확인하라"
+    );
+
+    let out = std::env::temp_dir().join(format!(
+        "rhwp-issue3528-{}-{}.hwp",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos()
+    ));
+    let res = std::process::Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("convert")
+        .arg(sample_path())
+        .arg(&out)
+        .arg("--verify")
+        .output()
+        .expect("rhwp 실행");
+    let stdout = String::from_utf8_lossy(&res.stdout).to_string();
+    let after = if out.exists() {
+        captions_holding_tables(&load(&out))
+    } else {
+        Vec::new()
+    };
+    let _ = std::fs::remove_file(&out);
+
+    assert_eq!(
+        after, before,
+        "저장 후 캡션 문단 수가 달라졌다 (수정 전 3→1 로 잘렸다)"
+    );
+    assert_eq!(
+        res.status.code(),
+        Some(0),
+        "convert --verify 가 IR 손실을 보고했다:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## 요약

표 **캡션 안에 표가 들어 있으면** 저장 후 캡션 문단이 `3 → 1` 로 잘리고, 그 안의 표도
`page_break`(RowBreak→None)와 **자기 캡션을 통째로** 잃습니다. `convert --verify` 가
exit 3 으로 잡습니다.

## 근인 — 경계 판정이 첫 번째 것을 집는다

HWP5 저장 순서는 `CTRL_TABLE → 캡션(LIST_HEADER + 문단) → HWPTAG_TABLE → 셀` 입니다.
파서는 그 순서를 이용해 **첫 `HWPTAG_TABLE` 앞까지**를 캡션으로 잘랐습니다.

```rust
// 종전 (src/parser/control.rs)
let table_record_idx = child_records
    .iter()
    .position(|r| r.tag_id == tags::HWPTAG_TABLE);   // ← 첫 번째를 그냥 집는다
let caption_records = child_records[start..table_idx];
```

캡션 문단 **안에 표가 있으면 그 표가 자기 `HWPTAG_TABLE` 을 더 앞에 방출**합니다. 그러면
경계가 바깥 표의 것이 아니라 캡션 속 표의 것으로 잡혀 캡션이 거기서 끊깁니다.

## 변경

**직계 자식 레벨의 `HWPTAG_TABLE` 만** 경계로 삼습니다.

```rust
// 직계 자식은 모두 CTRL_HEADER 바로 아래 레벨이므로(캡션 LIST_HEADER · HWPTAG_TABLE ·
// 셀 LIST_HEADER 가 같은 레벨), 자식 레코드의 최소 레벨이 곧 직계 레벨이다.
let direct_level = child_records.iter().map(|r| r.level).min();
let table_record_idx = child_records
    .iter()
    .position(|r| r.tag_id == tags::HWPTAG_TABLE && Some(r.level) == direct_level);
```

## 실측

| 지표 | 수정 전 | 수정 후 |
|---|---|---|
| `convert --verify` | **exit 3** (차이 3건) | **exit 0** |
| 캡션 문단 수 | 3 → **1** | 3 → **3** |
| 캡션 속 표의 `page_break`·캡션 | 소실 | 보존 |

## 래칫이 실제로 조여지는 것을 확인했습니다

이 브랜치는 PR #3527(코퍼스 래칫) 위에 있습니다. 그 래칫에서 이 문서를
**등재 목록에서 지우고**(6건 → 5건) 다시 돌려 4조각 전부 통과함을 확인했습니다.

래칫이 "고쳐지면 목록에서 지워라"라는 설계대로 동작한다는 실증이기도 합니다 — 만든 장치가
같은 날 제 몫을 했습니다.

## 검증

- 회귀 테스트 1건 (`tests/issue_3528_nested_caption_boundary.rs`) — 표를 품은 캡션의 문단
  수가 저장 후에도 유지되는지. **수정을 되돌리면 red.**
- `cargo nextest run --no-fail-fast` **4,258건 전건 통과**
- `cargo clippy --all-targets -- -D warnings` 통과, 변경 파일 rustfmt 클린

## 머지 순서

**PR #3527 뒤에 머지해 주세요.** 이 브랜치가 그 위에 얹혀 있고, 래칫 등재 목록 수정이
포함돼 있습니다.

Refs #3528
