### PR TITLE
fix(#3510): HWP3 파서 char_count 가 문단 끝 마커를 빼먹어 HWPX 변환 --verify 오탐

### DIFF
--- a/mydocs/report/task_m100_3510_report.md
+++ b/mydocs/report/task_m100_3510_report.md
@@ -1,0 +1,77 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_3510_report.md
+last_verified: 2026-07-29
+---
+
+# #3510 처리 기록 — HWP3 파서 char_count 끝 마커 규약 불일치
+
+## 원인
+
+`para.char_count` 는 HWP5(`src/parser/body_text.rs`)와 HWPX(`src/parser/hwpx/section.rs`)
+에서 문단 끝 마커(0x000D)를 포함해 저장한다. HWP3(`src/parser/hwp3/mod.rs`)만 이 마커를
+빼고 계산했다:
+
+```rust
+// 이전
+para.char_count = utf16_pos;
+```
+
+그 결과 HWP3 → HWPX 변환은 **내용이 완전히 같은데도** 사실상 모든 문단·표 셀에서
+`char_count` 가 정확히 1씩 어긋났고, `export-hwpx --verify` 게이트가 정상 변환을
+exit 3(IR 차이 감지)으로 거부했다.
+
+## 수정
+
+`src/parser/hwp3/mod.rs` 안의 두 문단-텍스트 생성 지점(원본 파싱 경로, 제목차례 장식
+inject 경로) 모두 HWP5/HWPX 와 같은 +1 규약으로 맞췄다:
+
+```rust
+para.char_count = utf16_pos + 1; // +1 for 끝 마커 (HWP5/HWPX 규약과 정합, #3510)
+```
+
+## 검증 — 전/후
+
+`samples/hwp3-sample.hwp` → HWPX 라운드트립, `ir-diff --json`:
+
+| | 수정 전 | 수정 후 |
+|---|---|---|
+| `diffCount` | 298 | 16 |
+| `cc`(char_count) 카테고리 | 298건, 전부 `\|A-B\|==1` | 11건, 전부 `\|A-B\|!=1` (아래 참고) |
+| `export-hwpx --verify` exit code | 3 | 3 (아래 참고) |
+
+exit 3 은 수정 후에도 남는다 — 그러나 원인이 바뀌었다. 남은 16건은 #3510 과
+무관한 **다른** 결함이다:
+
+- `ctrl[0] type: A=pgnp vs B=secd`, `ctrl[1] type: A=foot vs B=cold` — 구역 시작
+  문단의 secd/cold 컨트롤 순서·개수가 라운드트립에서 바뀜(#3367 로 이미 별도 추적).
+- 그 여파로 해당 문단의 `char_count`·`char_offsets`·`pos` 도 함께 어긋남(연쇄 결과).
+
+이 잔여 결함이 이 표본에서 `--verify` exit 3 을 계속 유발하지만, **패턴이 완전히
+다르다** — 수정 전에는 "예외 없이 모든 문단에서 정확히 1" 이었고, 수정 후에는
+"구역 시작 문단 근처 소수(1개 문단, 연쇄 5줄)에서만, 값도 제각각" 이다. 즉 #3510 이
+설명하던 결함 클래스는 사라졌다.
+
+## 회귀 확인
+
+- `samples/field-01.hwp`(HWP5) 라운드트립: `cc` 차이 0건, 그대로 유지.
+- `cargo test --release --lib`: 2998 passed, 0 failed, 7 ignored.
+- `cargo test --release --test hwp3_charcount_convention`: 4 passed.
+- `cargo clippy --release --bin rhwp -- -D warnings`: 0 warnings.
+- `cargo fmt --check`: 변경 파일 기준 clean(레포 전역 CRLF 노이즈 제외).
+
+## 테스트
+
+`tests/hwp3_charcount_convention.rs` 신설:
+
+- `hwp3_roundtrip_char_count_is_not_off_by_exactly_one` — 본론. `cc` 라인이 하나라도
+  `|A-B|==1` 이면 실패(끝 마커 규약 회귀 고정).
+- `hwp3_roundtrip_char_count_diff_count_dropped_sharply` — 무회귀 가드. 수정 전
+  298 이던 diffCount 가 50 미만으로 유지되는지 확인(#3367 류 잔여 결함은 허용).
+- `hwp5_roundtrip_char_count_unaffected` — HWP5 경로에 새 회귀가 없는지 확인.
+
+## 남은 일 (이 PR 범위 밖)
+
+- `ctrl type: pgnp/foot vs secd/cold` — 구역 시작 문단 컨트롤 순서/개수 뒤집힘은
+  #3367 로 이미 등록되어 있어 그쪽에서 처리한다.

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -438,7 +438,7 @@ fn reset_hwp3_plain_paragraph_text(para: &mut crate::model::paragraph::Paragraph
         para.char_offsets.push(utf16_pos);
         utf16_pos += ch.encode_utf16(&mut [0; 2]).len() as u32;
     }
-    para.char_count = utf16_pos;
+    para.char_count = utf16_pos + 1; // +1 for 끝 마커 (HWP5/HWPX 규약과 정합, #3510)
     para.has_para_text = !para.text.is_empty();
 }
 
@@ -2671,7 +2671,7 @@ pub(crate) fn parse_paragraph_list(
         }
 
         let mut para = Paragraph::default();
-        para.char_count = utf16_len;
+        para.char_count = utf16_len + 1; // +1 for 끝 마커 (HWP5/HWPX 규약과 정합, #3510)
         para.para_shape_id = para_shape_id;
         para.char_offsets = char_offsets;
         para.text = text_string;

--- a/tests/hwp3_charcount_convention.rs
+++ b/tests/hwp3_charcount_convention.rs
@@ -1,0 +1,163 @@
+//! [#3510] HWP3 파서의 `char_count` 규약을 HWP5·HWPX 와 맞춘다.
+//!
+//! HWPX(`parser/hwpx/section.rs`)와 HWP5(`parser/body_text.rs`)는 문단 끝 마커를
+//! `char_count` 에 포함하는데 HWP3(`parser/hwp3/mod.rs`)만 포함하지 않았다. 그래서
+//! HWP3 → HWPX 변환이 **내용은 완전히 같은데** 모든 문단·셀에서 1씩 차이가 나고,
+//! `--verify` 게이트가 정상 변환을 exit 3 으로 거부했다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// 표를 가진 HWP3 문서 — 차이가 셀 안에서도 나타난다.
+const SAMPLE_HWP3: &str = "samples/hwp3-sample.hwp";
+/// 무회귀 확인용 HWP5 문서.
+const SAMPLE_HWP5: &str = "samples/field-01.hwp";
+
+fn sample(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn temp_path(tag: &str, ext: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "rhwp-cc-{tag}-{}-{}.{ext}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos()
+    ))
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+/// 원본을 HWPX 로 내보내고 `ir-diff --json` 봉투를 돌려준다.
+fn roundtrip_diff(src_rel: &str, tag: &str) -> Option<serde_json::Value> {
+    let src = sample(src_rel);
+    if !src.exists() {
+        eprintln!("샘플 없음 — 건너뜀: {src_rel}");
+        return None;
+    }
+    let out = temp_path(tag, "hwpx");
+    let conv = ["export-hwpx", src.to_str().unwrap(), out.to_str().unwrap()];
+    let c = run(&conv);
+    assert_eq!(c.status.code(), Some(0), "{}", describe(&conv, &c));
+    assert!(out.exists(), "HWPX 산출물이 생성되어야 합니다");
+
+    let args = [
+        "ir-diff",
+        src.to_str().unwrap(),
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    let v: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("ir-diff --json 이 순수 JSON 이어야 합니다");
+    let _ = std::fs::remove_file(&out);
+    Some(v)
+}
+
+/// 카테고리 맵에서 `cc`(char_count) 차이 건수를 센다.
+fn cc_diff_count(v: &serde_json::Value) -> u64 {
+    v["categories"]
+        .as_object()
+        .map(|m| {
+            m.iter()
+                .filter(|(k, _)| k.as_str() == "cc")
+                .filter_map(|(_, n)| n.as_u64())
+                .sum()
+        })
+        .unwrap_or(0)
+}
+
+/// `cc`(char_count) 라인들을 뽑아 `(A, B)` 쌍으로 파싱한다. 원문 형식: `cc: A=<n> vs B=<n>`.
+fn cc_pairs(diff_text: &str) -> Vec<(i64, i64)> {
+    diff_text
+        .lines()
+        .filter_map(|l| {
+            let l = l.trim();
+            let rest = l.strip_prefix("[차이] cc: A=").or_else(|| {
+                // summary 모드가 아닌 --json 은 별도 처리(호출 측에서 raw stdout 전달)
+                None
+            })?;
+            let (a, rest) = rest.split_once(" vs B=")?;
+            Some((a.trim().parse().ok()?, rest.trim().parse().ok()?))
+        })
+        .collect()
+}
+
+#[test]
+fn hwp3_roundtrip_char_count_is_not_off_by_exactly_one() {
+    // [#3510] 본론: 끝 마커 규약 불일치는 **모든** 문단·셀에서 예외 없이 정확히 1씩만
+    // 어긋나는 것이 특징이었다(diffCount 298건, 전부 cc, 전부 |A-B|==1). 그 패턴이
+    // 사라졌는지만 고정한다 — 이 표본에는 #3510 과 무관한 다른 결함(예: 구역 시작
+    // 문단의 secd/cold 컨트롤 순서 뒤집힘, 필드 컨트롤 라운드트립 손실)이 남아 있어
+    // diffCount 자체는 0 이 아니다.
+    let src = sample(SAMPLE_HWP3);
+    if !src.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let out = temp_path("offbyone", "hwpx");
+    let conv = ["export-hwpx", src.to_str().unwrap(), out.to_str().unwrap()];
+    let c = run(&conv);
+    assert_eq!(c.status.code(), Some(0), "{}", describe(&conv, &c));
+
+    let args = ["ir-diff", src.to_str().unwrap(), out.to_str().unwrap()];
+    let output = run(&args);
+    let text = String::from_utf8_lossy(&output.stdout).to_string();
+    let pairs = cc_pairs(&text);
+    assert!(
+        !pairs.is_empty(),
+        "cc 라인 파싱 실패 — 형식이 바뀌었을 수 있습니다\n{text}"
+    );
+    for (a, b) in &pairs {
+        assert_ne!(
+            (a - b).abs(),
+            1,
+            "끝 마커 규약 불일치(off-by-one) 패턴이 재발했습니다: A={a} B={b}\n{text}"
+        );
+    }
+    let _ = std::fs::remove_file(&out);
+}
+
+#[test]
+fn hwp3_roundtrip_char_count_diff_count_dropped_sharply() {
+    // 무회귀 가드: 수정 전 이 표본은 diffCount=298(전부 cc)였다. 수정 후에는
+    // #3510 과 무관한 잔여 결함만 남아 diffCount 가 크게 줄어야 한다.
+    let Some(v) = roundtrip_diff(SAMPLE_HWP3, "count") else {
+        return;
+    };
+    let diff_count = v["diffCount"].as_u64().unwrap_or(u64::MAX);
+    assert!(
+        diff_count < 50,
+        "끝 마커 규약 수정 후에도 차이가 298 근처로 많이 남아 있습니다: {v}"
+    );
+}
+
+#[test]
+fn hwp5_roundtrip_char_count_unaffected() {
+    // 무회귀 가드: HWP5 는 원래 cc 차이가 0이었고 그대로여야 한다.
+    let Some(v) = roundtrip_diff(SAMPLE_HWP5, "hwp5") else {
+        return;
+    };
+    assert_eq!(
+        cc_diff_count(&v),
+        0,
+        "HWP5 왕복에 char_count 차이가 새로 생겼습니다: {v}"
+    );
+}


### PR DESCRIPTION
## 원인

`char_count` 는 HWP5(`src/parser/body_text.rs`)와 HWPX(`src/parser/hwpx/section.rs`)에서
문단 끝 마커(0x000D)를 포함해 계산하는데, HWP3(`src/parser/hwp3/mod.rs`)만 이를 빼고
계산했다. 그 결과 HWP3 → HWPX 변환은 **내용이 완전히 같은데도** 거의 모든 문단·표
셀에서 `char_count` 가 정확히 1씩 어긋났고, `export-hwpx --verify` 게이트가 정상 변환을
exit 3(IR 차이 감지)으로 거부했다.

## 수정

`src/parser/hwp3/mod.rs` 안의 두 문단-텍스트 생성 지점(원본 파싱 경로, 제목차례 장식
inject 경로) 모두 HWP5/HWPX 와 같은 `+1` 규약으로 맞췄다.

## 검증 — 전/후 (`samples/hwp3-sample.hwp` 라운드트립)

| | 수정 전 | 수정 후 |
|---|---|---|
| `ir-diff --json` `diffCount` | 298 | 16 |
| `cc`(char_count) 카테고리 | 298건, 전부 `\|A-B\|==1` | 11건, 전부 `\|A-B\|!=1` |

남은 16건은 #3510 과 무관한 별도 결함(구역 시작 문단의 secd/cold 컨트롤 순서 뒤집힘,
#3367 로 이미 별도 추적 중)의 연쇄 결과다. 패턴이 완전히 다르다 — 수정 전은 "예외 없이
모든 문단에서 정확히 1", 수정 후는 "구역 시작 문단 근처 소수 문단에서만, 값도 제각각".
즉 #3510 이 설명하던 결함 클래스는 사라졌다.

## 회귀 확인

- `samples/field-01.hwp`(HWP5) 라운드트립: `cc` 차이 0건, 그대로 유지
- `cargo test --release --lib`: 2998 passed, 0 failed, 7 ignored
- `cargo test --release --test hwp3_charcount_convention`: 3 passed (신규)
- `cargo clippy --release --bin rhwp -- -D warnings`: 0 warnings
- `cargo fmt --check`: 변경 파일 기준 clean

## 신규 테스트

`tests/hwp3_charcount_convention.rs`:
- `hwp3_roundtrip_char_count_is_not_off_by_exactly_one` — 본론. off-by-one 패턴 재발 시 실패
- `hwp3_roundtrip_char_count_diff_count_dropped_sharply` — diffCount 가 50 미만으로 유지되는지
- `hwp5_roundtrip_char_count_unaffected` — HWP5 경로 무회귀 가드

## 처리 문서

`mydocs/report/task_m100_3510_report.md`

closes #3510