### PR TITLE
fix(hwpx): 왕복 무손실 결함 3건 — memoShapeIDRef·각주 place, BinData 등록 구멍, ParaShape 여백 (#2779, #3526, #3368)

### DIFF
--- a/src/model/document.rs
+++ b/src/model/document.rs
@@ -260,6 +260,9 @@ pub struct SectionDef {
     pub text_direction: u8,
     /// 개요 번호 ID (SectionDef 바이트 14-15, Numbering 테이블 참조, 1-based)
     pub outline_numbering_id: u16,
+    /// [#2779] 메모 모양 ID (HWPX `secPr@memoShapeIDRef`, header.xml `hh:memoPr@id` 참조).
+    /// HWP5 SECTION_DEF 고정 필드에는 대응 슬롯이 없어 HWPX 경로 전용 보존 필드다.
+    pub memo_shape_id: u16,
     /// CTRL_HEADER 데이터의 파싱된 필드 이후 추가 바이트 (라운드트립 보존용)
     pub raw_ctrl_extra: Vec<u8>,
     /// 추가 쪽 테두리/배경 (2번째, 3번째 등)

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -1198,6 +1198,13 @@ fn parse_para_shape_switch(
     let mut def_next: Option<i32> = None;
     let mut def_line_spacing_type: Option<LineSpacingType> = None;
     let mut def_line_spacing: Option<i32> = None;
+    // case 원본 값(1× 스케일)을 임시 저장 ([#3368] default 채택 판정용)
+    let mut case_margin_left: Option<i32> = None;
+    let mut case_margin_right: Option<i32> = None;
+    let mut case_indent: Option<i32> = None;
+    let mut case_prev: Option<i32> = None;
+    let mut case_next: Option<i32> = None;
+    let mut case_line_spacing: Option<i32> = None;
 
     loop {
         match reader.read_event_into(&mut buf) {
@@ -1240,11 +1247,26 @@ fn parse_para_shape_switch(
                                         // 일반 HWPX 문단 흐름과 기준 HWP3 변환본이 함께 밀린다.
                                         let val2x = val * 2;
                                         match tag_name {
-                                            b"left" => ps.margin_left = val2x,
-                                            b"right" => ps.margin_right = val2x,
-                                            b"intent" => ps.indent = val2x,
-                                            b"prev" => ps.spacing_before = val2x,
-                                            b"next" => ps.spacing_after = val2x,
+                                            b"left" => {
+                                                ps.margin_left = val2x;
+                                                case_margin_left = Some(val);
+                                            }
+                                            b"right" => {
+                                                ps.margin_right = val2x;
+                                                case_margin_right = Some(val);
+                                            }
+                                            b"intent" => {
+                                                ps.indent = val2x;
+                                                case_indent = Some(val);
+                                            }
+                                            b"prev" => {
+                                                ps.spacing_before = val2x;
+                                                case_prev = Some(val);
+                                            }
+                                            b"next" => {
+                                                ps.spacing_after = val2x;
+                                                case_next = Some(val);
+                                            }
                                             _ => {}
                                         }
                                         found_case = true;
@@ -1294,6 +1316,7 @@ fn parse_para_shape_switch(
                                         LineSpacingType::Percent => v,
                                         _ => v * 2,
                                     };
+                                    case_line_spacing = Some(v);
                                 }
                                 found_case = true;
                             } else if in_default {
@@ -1349,9 +1372,64 @@ fn parse_para_shape_switch(
         if let Some(v) = def_line_spacing {
             ps.line_spacing = v;
         }
+    } else {
+        // [#3368] case 와 default 가 반감 관계면 default 의 원본값을 채택한다.
+        // (홀수 값은 case 인코딩으로 표현되지 않아 case×2 로는 1 만큼 어긋난다.)
+        if let Some(v) = exact_value_from_default(case_margin_left, def_margin_left) {
+            ps.margin_left = v;
+        }
+        if let Some(v) = exact_value_from_default(case_margin_right, def_margin_right) {
+            ps.margin_right = v;
+        }
+        if let Some(v) = exact_value_from_default(case_indent, def_indent) {
+            ps.indent = v;
+        }
+        if let Some(v) = exact_value_from_default(case_prev, def_prev) {
+            ps.spacing_before = v;
+        }
+        if let Some(v) = exact_value_from_default(case_next, def_next) {
+            ps.spacing_after = v;
+        }
+        let ls_exact = match ps.line_spacing_type {
+            // PERCENT 는 비율이라 반감 대상이 아니다(방출측도 양쪽에 같은 값을 쓴다).
+            LineSpacingType::Percent => None,
+            _ => exact_value_from_default(case_line_spacing, def_line_spacing),
+        };
+        if let Some(v) = ls_exact {
+            ps.line_spacing = v;
+        }
     }
 
     Ok(())
+}
+
+/// `<switch>` 의 `case`(HwpUnitChar, 1× 스케일) 와 `default`(IR 과 같은 2× 스케일) 가
+/// 반감 관계일 때 `default` 에 남아 있는 원본값을 돌려준다. 그 외에는 `None`.
+///
+/// [#3368] 홀수 2× 값은 `case` 인코딩(정수 나눗셈)으로 표현할 수 없어, `case × 2` 로만
+/// 되읽으면 1 만큼 어긋난다 (`ml 101 → case 50 → 100`). 원본값은 `default` 에 그대로
+/// 남으므로 반감 관계가 확인되면 그쪽을 채택해 왕복을 고정점으로 만든다.
+///
+/// 판정식은 `|default − case × 2| ≤ 1` 이다. 음수 반내림 방향이 한컴(내림:
+/// `default -519 → case -260`) 과 우리 writer(0 방향 절단: `default -2621 → case -1310`)
+/// 에서 서로 달라 양쪽을 함께 받아야 한다. `default == case × 2` 인 짝수 값은 기존
+/// 결과와 같으므로 실제로 값이 바뀌는 것은 홀수 `default` 뿐이다.
+///
+/// 두 분기에 **같은 값**을 쓴 문서(반감 없음)는 `case != default` 조건으로 제외해
+/// 기존 `case × 2` 해석을 그대로 유지한다. 한컴 원본 표본 262개 실측 기준 margin 쌍
+/// 분포는 반감 16,248(그중 홀수 default 37) · 동일값 21 · 그 외 0 이며, lineSpacing 은
+/// PERCENT 가 동일값, FIXED/AT_LEAST 가 반감으로 같은 규칙을 따른다. 즉 이 정정으로
+/// 값이 바뀌는 한컴 원본 필드는 37개뿐이고, 모두 한컴이 `default` 에 적어 둔 값으로
+/// 되돌아간다.
+fn exact_value_from_default(case: Option<i32>, default: Option<i32>) -> Option<i32> {
+    let (case, default) = (case?, default?);
+    // i64 승격은 오버플로 없이 gap 을 계산하기 위한 것이다.
+    let gap = i64::from(default) - i64::from(case) * 2;
+    if case != default && gap.abs() <= 1 {
+        Some(default)
+    } else {
+        None
+    }
 }
 
 // ─── Style ───
@@ -2556,6 +2634,85 @@ mod tests {
         assert_eq!(ps.indent, -4520);
         assert_eq!(ps.spacing_before, 568);
         assert_eq!(ps.spacing_after, 1136);
+    }
+
+    #[test]
+    fn odd_para_margin_survives_hwpx_serialize_parse_roundtrip() {
+        // [#3368] 홀수 여백(ml=101)은 <hp:case>(HwpUnitChar) 의 정수 나눗셈으로
+        // 표현할 수 없어 case×2 로만 되읽으면 101 → 50 → 100 으로 1 만큼 줄었다
+        // (ir-diff "PS[64] ml: 100vs101", exit 3). writer 가 <hp:default> 에 원본값을
+        // 같이 쓰므로 되읽기가 이를 채택해 왕복이 고정점이 되어야 한다.
+        use crate::serializer::hwpx::{context::SerializeContext, header::write_header};
+
+        let mut ps = ParaShape::default();
+        ps.margin_left = 101;
+        ps.margin_right = -101; // 음수 홀수(0 방향 절단)도 함께 고정
+        ps.indent = 2621;
+        ps.spacing_before = 7;
+        ps.spacing_after = 9;
+        ps.line_spacing = 333;
+        ps.line_spacing_type = LineSpacingType::Fixed;
+
+        let mut doc = crate::model::document::Document::default();
+        doc.doc_info.para_shapes = vec![ps];
+        let ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_header(&doc, &ctx).expect("write_header"))
+            .expect("header.xml 은 UTF-8");
+
+        let (doc_info, _) = parse_hwpx_header(&xml).expect("parse header");
+        let back = &doc_info.para_shapes[0];
+
+        assert_eq!(back.margin_left, 101, "홀수 좌측여백 왕복: {xml}");
+        assert_eq!(back.margin_right, -101, "음수 홀수 우측여백 왕복: {xml}");
+        assert_eq!(back.indent, 2621, "홀수 들여쓰기 왕복: {xml}");
+        assert_eq!(back.spacing_before, 7, "홀수 문단위 간격 왕복: {xml}");
+        assert_eq!(back.spacing_after, 9, "홀수 문단아래 간격 왕복: {xml}");
+        assert_eq!(back.line_spacing, 333, "홀수 고정 줄간격 왕복: {xml}");
+    }
+
+    #[test]
+    fn hancom_equal_case_default_switch_keeps_hwpunitchar_scale() {
+        // [#3368] default 채택은 반감 관계(case = default/2)일 때로 한정한다.
+        // 한컴 산출물 중 두 분기에 같은 값을 쓰는 문서(반감 없음)까지 default 를
+        // 채택하면 모든 여백이 절반으로 접힌다. case×2 해석이 유지돼야 한다.
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head"
+  xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core"
+  xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph">
+  <hh:refList>
+    <hh:paraProperties itemCnt="1">
+      <hh:paraPr id="1">
+        <hp:switch>
+          <hp:case hp:required-namespace="http://www.hancom.co.kr/hwpml/2016/HwpUnitChar">
+            <hh:margin>
+              <hc:intent value="-700" unit="HWPUNIT"/>
+              <hc:left value="1400" unit="HWPUNIT"/>
+              <hc:right value="0" unit="HWPUNIT"/>
+              <hc:prev value="0" unit="HWPUNIT"/>
+              <hc:next value="120" unit="HWPUNIT"/>
+            </hh:margin>
+          </hp:case>
+          <hp:default>
+            <hh:margin>
+              <hc:intent value="-700" unit="HWPUNIT"/>
+              <hc:left value="1400" unit="HWPUNIT"/>
+              <hc:right value="0" unit="HWPUNIT"/>
+              <hc:prev value="0" unit="HWPUNIT"/>
+              <hc:next value="120" unit="HWPUNIT"/>
+            </hh:margin>
+          </hp:default>
+        </hp:switch>
+      </hh:paraPr>
+    </hh:paraProperties>
+  </hh:refList>
+</hh:head>"##;
+
+        let (doc_info, _) = parse_hwpx_header(xml).unwrap();
+        let ps = &doc_info.para_shapes[1];
+
+        assert_eq!(ps.margin_left, 2800, "동일값 switch 는 case×2 유지");
+        assert_eq!(ps.indent, -1400, "동일값 switch 는 case×2 유지");
+        assert_eq!(ps.spacing_after, 240, "동일값 switch 는 case×2 유지");
     }
 
     #[test]

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -297,6 +297,11 @@ fn parse_section_def_start(e: &quick_xml::events::BytesStart, sec_def: &mut Sect
             b"outlineShapeIDRef" => {
                 sec_def.outline_numbering_id = parse_u16(&attr);
             }
+            // [#2779] memoShapeIDRef → memo_shape_id (UINT16, header.xml `hh:memoPr@id` 참조).
+            // 종전엔 수집하지 않아 저장 시 템플릿 상수 "0" 으로 리셋됐다(실측 14 secPr/9 파일).
+            b"memoShapeIDRef" => {
+                sec_def.memo_shape_id = parse_u16(&attr);
+            }
             _ => {}
         }
     }
@@ -1078,12 +1083,22 @@ fn parse_note_pr_children(
                             match attr.key.as_ref() {
                                 b"place" => {
                                     if let Ok(s) = std::str::from_utf8(&attr.value) {
+                                        // [#2779] OWPML 스키마(ParaList placement@place)의 정식
+                                        // 토큰은 컨텍스트마다 다르지만 HWP5 attr bits 8-9 코드
+                                        // 공간은 공유한다:
+                                        //   각주 EACH_COLUMN(0)·MERGED_COLUMN(1)·RIGHT_MOST_COLUMN(2)
+                                        //   미주 END_OF_DOCUMENT(0)·END_OF_SECTION(1)
+                                        // 종전엔 MERGED_COLUMN/RIGHT_MOST_COLUMN 이 표에 없어
+                                        // `_ => continue` 로 떨어져, 통단·오른쪽단 각주가 파싱
+                                        // 단계에서 기본값(각 단마다)으로 소실됐다.
+                                        // (BELOW_TEXT/RIGHT_COLUMN 은 스키마 밖 관용 표기 — 수용 유지.)
                                         let placement = match s {
-                                            "END_OF_SECTION" | "BELOW_TEXT" | "sectionEnd"
-                                            | "belowText" => {
+                                            "END_OF_SECTION" | "MERGED_COLUMN" | "BELOW_TEXT"
+                                            | "sectionEnd" | "belowText" => {
                                                 crate::model::footnote::FootnotePlacement::BelowText
                                             }
-                                            "RIGHT_COLUMN" | "rightColumn" => {
+                                            "RIGHT_MOST_COLUMN" | "RIGHT_COLUMN"
+                                            | "rightColumn" => {
                                                 crate::model::footnote::FootnotePlacement::RightColumn
                                             }
                                             "END_OF_DOCUMENT" | "EACH_COLUMN" | "documentEnd"
@@ -6615,6 +6630,77 @@ mod tests {
         );
         assert_eq!((section.section_def.endnote_shape.attr >> 8) & 0x03, 1);
         assert_eq!((section.section_def.endnote_shape.attr >> 10) & 0x03, 0);
+    }
+
+    /// [#2779] 각주 placement 의 OWPML 정식 토큰 MERGED_COLUMN(통단)·
+    /// RIGHT_MOST_COLUMN(가장 오른쪽 단)을 파서가 수용해야 한다. 종전엔 토큰 표에
+    /// 없어 `_ => continue` 로 떨어져, 통단/오른쪽단 각주가 파싱 단계에서 기본값
+    /// (각 단마다, 코드 0)으로 소실됐다.
+    #[test]
+    fn issue2779_footnote_placement_accepts_schema_column_tokens() {
+        // (placement, attr bits 8-9 코드) 를 돌려준다.
+        fn parse_place(place: &str) -> (crate::model::footnote::FootnotePlacement, u32) {
+            let xml = format!(
+                r##"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:secPr textDirection="HORIZONTAL" spaceColumns="1134" tabStop="8000" outlineShapeIDRef="1" masterPageCnt="0">
+        <hp:footNotePr>
+          <hp:autoNumFormat type="DIGIT" userChar="" prefixChar="" suffixChar=")" supscript="0"/>
+          <hp:noteLine length="-1" type="SOLID" width="0.12 mm" color="#000000"/>
+          <hp:noteSpacing betweenNotes="283" belowLine="567" aboveLine="850"/>
+          <hp:numbering type="CONTINUOUS" newNum="1"/>
+          <hp:placement place="{place}" beneathText="0"/>
+        </hp:footNotePr>
+      </hp:secPr>
+    </hp:run>
+  </hp:p>
+</hs:sec>"##
+            );
+            let section = parse_hwpx_section(&xml).unwrap();
+            let shape = &section.section_def.footnote_shape;
+            (shape.placement, (shape.attr >> 8) & 0x03)
+        }
+
+        use crate::model::footnote::FootnotePlacement;
+        assert_eq!(
+            parse_place("MERGED_COLUMN"),
+            (FootnotePlacement::BelowText, 1),
+            "MERGED_COLUMN(통단으로 배열) = attr bits 8-9 코드 1"
+        );
+        assert_eq!(
+            parse_place("RIGHT_MOST_COLUMN"),
+            (FootnotePlacement::RightColumn, 2),
+            "RIGHT_MOST_COLUMN(가장 오른쪽 단에 배열) = attr bits 8-9 코드 2"
+        );
+        // 기본 토큰은 종전대로 코드 0.
+        assert_eq!(
+            parse_place("EACH_COLUMN"),
+            (FootnotePlacement::EachColumn, 0),
+            "EACH_COLUMN(각 단마다 따로 배열) = attr bits 8-9 코드 0"
+        );
+    }
+
+    /// [#2779] secPr@memoShapeIDRef 가 SectionDef.memo_shape_id 로 수집돼야 한다.
+    /// 종전엔 파서가 속성을 읽지 않아 저장 시 템플릿 상수 "0" 으로 리셋됐다.
+    #[test]
+    fn issue2779_secpr_memo_shape_id_ref_parsed() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:secPr id="" textDirection="HORIZONTAL" spaceColumns="1134" tabStop="8000" tabStopVal="4000" tabStopUnit="HWPUNIT" outlineShapeIDRef="1" memoShapeIDRef="2" textVerticalWidthHead="0" masterPageCnt="0">
+      </hp:secPr>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        assert_eq!(section.section_def.memo_shape_id, 2);
     }
 
     #[test]

--- a/src/serializer/hwpx/context.rs
+++ b/src/serializer/hwpx/context.rs
@@ -75,7 +75,8 @@ pub struct BinDataEntry {
     pub media_type: String,
     /// IR 상의 bin_data_id (storage_id) — 매핑 역추적용
     pub bin_data_id: u16,
-    /// content.hpf `isEmbeded` — false 면 외부 파일 참조(ZIP 엔트리 없음, #1891).
+    /// content.hpf `isEmbeded` — false 면 ZIP 엔트리가 없는 항목이다:
+    /// 외부 파일 참조(#1891) 또는 스트림 부재로 콘텐츠가 없는 항목(#3526).
     pub is_embedded: bool,
 }
 
@@ -190,15 +191,21 @@ impl SerializeContext {
             );
         }
 
-        // 외부 참조(Link) BinData: 콘텐츠가 없어도 manifest 항목과 참조는 보존해야
-        // 한다 (#1891 — 미등록이면 해당 <hp:pic> 직렬화가 실패해 그림 컨트롤이
-        // 통째로 드롭되고 레이아웃 앵커가 사라져 렌더가 갈라진다). ZIP 엔트리는
-        // 만들지 않고 content.hpf 에 isEmbeded="0" + 원본 href 로만 방출한다.
+        // 콘텐츠 없는 BinData: 바이트가 없어도 manifest 항목과 참조는 보존해야
+        // 한다 (미등록이면 `write_img` 가 Err 를 반환해(picture.rs) 해당 <hp:pic>
+        // 이 통째로 드롭되고 레이아웃 앵커까지 사라져 렌더가 갈라진다).
+        //
+        // [#1891] 은 외부 참조(Link)만 이 구멍을 막았으나, Embedding/Storage 도
+        // 스트림이 없으면(parser/mod.rs 가 "BinData 스트림 없음" 경고 후 skip)
+        // bin_data_content 가 비어 위 루프에 걸리지 않는다. 그 결과 두 루프를
+        // 모두 빠져나가 같은 드롭이 재현됐다(#3526 hwpspec.hwp bin_data_id=37).
+        // 따라서 data_type 을 가리지 않고 "아직 등록되지 않은 모든 항목"으로 넓힌다.
+        //
+        // ZIP 엔트리는 만들지 않고 content.hpf 에 isEmbeded="0" + href(외부 경로,
+        // 없으면 빈 문자열)로만 방출한다 — mod.rs 가 ZIP 쓰기와 3-way 단언에서,
+        // package_check 가 엔트리 실재 검사에서 각각 제외하므로 패키지는 정합하다.
         // 명명은 위와 같은 숫자 불변식(`image{storage_id}`)을 따른다.
         for bd in &doc.doc_info.bin_data_list {
-            if !matches!(bd.data_type, crate::model::bin_data::BinDataType::Link) {
-                continue;
-            }
             // storage_id=0 은 "참조 없는 placeholder pic" 센티널(#1567)과 겹치므로
             // 등록하지 않는다 (HWP5 Link 항목은 storage_id 미부여일 수 있음).
             if bd.storage_id == 0 || ctx.bin_data_map.contains_key(&bd.storage_id) {
@@ -385,6 +392,71 @@ mod tests {
         assert_eq!(e6.media_type, "application/octet-stream");
         let e7 = &ctx.bin_data_map[&7];
         assert_eq!(e7.href, "BinData/image7.bmp");
+    }
+
+    #[test]
+    fn issue3526_contentless_embedding_bindata_is_registered() {
+        // [#3526] 스트림이 없어 `bin_data_content` 가 비는 Embedding/Storage 항목도
+        // manifest 에 등록돼야 한다. 미등록이면 picture.rs `write_img` 가 Err 를
+        // 반환해 <hp:pic> 이 통째로 드롭되고 앵커·레이아웃까지 사라진다
+        // (hwpspec.hwp bin_data_id=37). [#1891] 은 Link 만 막아서 Embedding/Storage
+        // 는 두 등록 루프를 모두 빠져나갔다.
+        use crate::model::bin_data::{BinData, BinDataContent, BinDataType};
+        let mut doc = Document::default();
+        // 정상 항목(콘텐츠 보유) — 넓힌 루프가 이걸 덮어쓰면 안 된다.
+        doc.bin_data_content.push(BinDataContent {
+            id: 1,
+            data: vec![0, 1, 2].into(),
+            extension: "png".to_string(),
+        });
+        doc.doc_info.bin_data_list.push(BinData {
+            data_type: BinDataType::Embedding,
+            storage_id: 1,
+            extension: Some("png".to_string()),
+            ..Default::default()
+        });
+        // 스트림 부재 재현: 목록에는 있으나 콘텐츠가 없는 Embedding / Storage.
+        doc.doc_info.bin_data_list.push(BinData {
+            data_type: BinDataType::Embedding,
+            storage_id: 37,
+            extension: Some("jpg".to_string()),
+            ..Default::default()
+        });
+        doc.doc_info.bin_data_list.push(BinData {
+            data_type: BinDataType::Storage,
+            storage_id: 38,
+            extension: Some("OLE".to_string()),
+            ..Default::default()
+        });
+
+        let ctx = SerializeContext::collect_from_document(&doc);
+
+        // `write_img`(picture.rs) 의 분기 조건 그 자체 — Some 이어야 pic 이 산다.
+        assert_eq!(
+            ctx.resolve_bin_id(37),
+            Some("image37"),
+            "콘텐츠 없는 Embedding 도 등록돼야 <hp:pic> 이 드롭되지 않는다"
+        );
+        assert_eq!(
+            ctx.resolve_bin_id(38),
+            Some("image38"),
+            "콘텐츠 없는 Storage 도 동일하게 등록"
+        );
+
+        let e37 = &ctx.bin_data_map[&37];
+        assert!(
+            !e37.is_embedded,
+            "ZIP 엔트리가 없으므로 isEmbeded=0 (mod.rs 3-way 단언 제외 대상)"
+        );
+        assert_eq!(e37.media_type, "image/jpeg");
+        // abs_path 없는 Embedding 은 빈 href — populate_link_image_paths 가 빈
+        // 경로를 걸러내므로(parser/mod.rs) 허위 external_path 가 생기지 않는다.
+        assert_eq!(e37.href, "", "존재하지 않는 ZIP 경로를 가리키면 안 된다");
+
+        // 콘텐츠 보유 항목은 그대로 임베드로 남아야 한다(덮어쓰기 회귀 가드).
+        let e1 = &ctx.bin_data_map[&1];
+        assert!(e1.is_embedded, "콘텐츠 보유 항목은 isEmbeded=1 유지");
+        assert_eq!(e1.href, "BinData/image1.png");
     }
 
     #[test]

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -95,7 +95,8 @@ fn replace_visibility(xml: &str, sd: &SectionDef) -> String {
     xml.replacen(TEMPLATE_VISIBILITY, &render_visibility(sd), 1)
 }
 
-/// [#1987] 템플릿 secPr 의 하드코딩 스칼라(spaceColumns, outlineShapeIDRef)를 IR 값으로 치환.
+/// [#1987] 템플릿 secPr 의 하드코딩 스칼라(spaceColumns, outlineShapeIDRef, memoShapeIDRef 등)를
+/// IR 값으로 치환.
 /// 각 속성은 템플릿 secPr 여는 태그에 정확히 1회 등장하므로 replacen(1)로 안전하다.
 fn replace_secpr_scalars(xml: &str, sd: &SectionDef) -> String {
     let out = xml.replacen(
@@ -119,6 +120,16 @@ fn replace_secpr_scalars(xml: &str, sd: &SectionDef) -> String {
     let out = out.replacen(
         r#"outlineShapeIDRef="1""#,
         &format!(r#"outlineShapeIDRef="{}""#, sd.outline_numbering_id),
+        1,
+    );
+
+    // [#2779] 메모 모양 참조. 파서가 secPr@memoShapeIDRef 를 memo_shape_id 로 읽지만
+    // 직렬화가 템플릿 상수 "0" 만 방출해, 메모 모양이 지정된 구역이 저장마다 0 으로
+    // 리셋됐다(실측 14 secPr/9 파일). 템플릿 secPr 여는 태그에 정확히 1회 등장하고
+    // 기본 SectionDef 도 0 이라 기본 문서 출력은 바이트 동일하다.
+    let out = out.replacen(
+        r#"memoShapeIDRef="0""#,
+        &format!(r#"memoShapeIDRef="{}""#, sd.memo_shape_id),
         1,
     );
 
@@ -233,6 +244,54 @@ fn render_note_numbering(shape: &crate::model::footnote::FootnoteShape) -> Strin
         r#"<hp:numbering type="{}" newNum="{}"/>"#,
         note_numbering_str(shape.numbering),
         shape.start_number,
+    )
+}
+
+/// [#2779] FootnotePlacement → HWPX `placement/@place` 토큰 (컨텍스트 키 역매핑).
+///
+/// OWPML 스키마(ParaList: footNotePr/endNotePr 의 placement@place)는 각주와 미주에
+/// 서로 다른 열거를 두지만, 두 열거는 HWP5 `attr` bits 8-9 의 같은 코드 공간을 쓴다
+/// (모델 주석 「각 단마다 따로 배열 / 문서의 마지막」과 동일한 대응):
+///
+/// | 코드 | FootnotePlacement | 각주 토큰          | 미주 토큰       |
+/// |------|-------------------|--------------------|-----------------|
+/// | 0    | EachColumn        | EACH_COLUMN        | END_OF_DOCUMENT |
+/// | 1    | BelowText         | MERGED_COLUMN      | END_OF_SECTION  |
+/// | 2    | RightColumn       | RIGHT_MOST_COLUMN  | (없음)          |
+///
+/// 즉 코드↔토큰은 컨텍스트를 아는 한 각 컨텍스트 안에서 전단사이므로, 호출자가
+/// 자기가 각주/미주 중 무엇을 렌더하는지 알려주면 무손실 역매핑이 된다.
+/// 미주에 코드 2(RightColumn)가 들어오는 비정상 IR 은 스키마에 대응 토큰이 없어
+/// 기본값 `END_OF_DOCUMENT` 로 강등한다.
+fn note_place_str(
+    placement: crate::model::footnote::FootnotePlacement,
+    is_end_note: bool,
+) -> &'static str {
+    use crate::model::footnote::FootnotePlacement::*;
+    if is_end_note {
+        match placement {
+            BelowText => "END_OF_SECTION",
+            // EachColumn 및 스키마 밖 RightColumn → 기본값.
+            _ => "END_OF_DOCUMENT",
+        }
+    } else {
+        match placement {
+            BelowText => "MERGED_COLUMN",
+            RightColumn => "RIGHT_MOST_COLUMN",
+            EachColumn => "EACH_COLUMN",
+        }
+    }
+}
+
+/// [#2779] FootnoteShape → `<hp:placement .../>` (place + beneathText).
+fn render_note_placement(
+    shape: &crate::model::footnote::FootnoteShape,
+    is_end_note: bool,
+) -> String {
+    format!(
+        r#"<hp:placement place="{}" beneathText="{}"/>"#,
+        note_place_str(shape.placement, is_end_note),
+        u8::from(shape.print_inline_after_text),
     )
 }
 
@@ -370,26 +429,25 @@ fn replace_footnote_shape(xml: &str, sd: &SectionDef) -> String {
         &render_note_numbering(&sd.endnote_shape),
     );
 
-    // beneathText(본문 아래 바로 이어 출력). placement 의 `place` 열거형은 각주/
-    // 미주 의미를 conflate 해 무손실 역매핑이 어렵지만, beneathText 는 같은 요소의
-    // 독립 bool 이라 역매핑이 명확하다. 파서는 이 값을
-    // FootnoteShape.print_inline_after_text(HWP 바이너리 attr bit13)로 읽는데
-    // 템플릿이 "0" 으로 고정돼 저장 때마다 꺼졌다.
-    // 각주/미주 앵커의 place 값이 서로 달라 replacen(1) 충돌이 없다.
+    // placement — 배치 방법(place)과 beneathText(본문 아래 바로 이어 출력).
+    //
+    // beneathText 는 같은 요소의 독립 bool 이라 종전에도 IR 반영됐다(템플릿 "0" 고정
+    // 이라 저장 때마다 꺼지던 결함). [#2779] place 는 종전에 템플릿 상수
+    // (EACH_COLUMN/END_OF_DOCUMENT)를 그대로 방출해, 통단·오른쪽단 각주와 구역끝
+    // 미주가 저장마다 기본 배치로 되돌아갔다. 컨텍스트 키 역매핑(note_place_str)으로
+    // 각주/미주 각각의 스키마 토큰을 방출한다.
+    //
+    // 각주 슬롯의 방출 토큰은 EACH_COLUMN/MERGED_COLUMN/RIGHT_MOST_COLUMN 셋 뿐이라
+    // 미주 앵커(END_OF_DOCUMENT)를 새로 만들어내지 않는다 — 연쇄 replacen(1) 이
+    // 서로의 슬롯을 훔칠 수 없다(기존 코드와 동일 근거).
     out.replacen(
         r#"<hp:placement place="EACH_COLUMN" beneathText="0"/>"#,
-        &format!(
-            r#"<hp:placement place="EACH_COLUMN" beneathText="{}"/>"#,
-            u8::from(sd.footnote_shape.print_inline_after_text)
-        ),
+        &render_note_placement(&sd.footnote_shape, false),
         1,
     )
     .replacen(
         r#"<hp:placement place="END_OF_DOCUMENT" beneathText="0"/>"#,
-        &format!(
-            r#"<hp:placement place="END_OF_DOCUMENT" beneathText="{}"/>"#,
-            u8::from(sd.endnote_shape.print_inline_after_text)
-        ),
+        &render_note_placement(&sd.endnote_shape, true),
         1,
     )
 }
@@ -2856,6 +2914,100 @@ mod tests {
         );
     }
 
+    /// [#2779] placement 의 `place`(배치 방법)가 템플릿 상수가 아니라 IR 값으로
+    /// 방출돼야 한다. 각주/미주는 같은 코드 공간(attr bits 8-9)을 쓰지만 OWPML 토큰이
+    /// 서로 달라, 컨텍스트 키 역매핑이 필요하다:
+    ///   각주 1=MERGED_COLUMN(통단) / 2=RIGHT_MOST_COLUMN, 미주 1=END_OF_SECTION.
+    /// 재파싱까지 확인해 rhwp 자기 왕복이 무손실인지 본다.
+    #[test]
+    fn issue2779_note_place_reflects_ir() {
+        use crate::model::footnote::FootnotePlacement;
+        use crate::parser::hwpx::section::parse_hwpx_section;
+
+        let mut para = Paragraph::default();
+        para.text = "x".to_string();
+        let (mut doc, mut section) = make_doc_with_paragraph(para);
+        section.section_def.footnote_shape.placement = FootnotePlacement::BelowText;
+        section.section_def.endnote_shape.placement = FootnotePlacement::BelowText;
+        doc.sections = vec![section.clone()];
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+
+        assert!(
+            xml.contains(r#"<hp:placement place="MERGED_COLUMN" beneathText="0"/>"#),
+            "각주 통단 배치가 IR 값으로 방출돼야 함"
+        );
+        assert!(
+            xml.contains(r#"<hp:placement place="END_OF_SECTION" beneathText="0"/>"#),
+            "미주 구역끝 배치가 IR 값으로 방출돼야 함"
+        );
+        assert!(
+            !xml.contains(r#"place="EACH_COLUMN""#),
+            "템플릿 상수 EACH_COLUMN 잔존 금지"
+        );
+        assert!(
+            !xml.contains(r#"place="END_OF_DOCUMENT""#),
+            "템플릿 상수 END_OF_DOCUMENT 잔존 금지"
+        );
+
+        let reparsed = parse_hwpx_section(&xml).unwrap();
+        assert_eq!(
+            reparsed.section_def.footnote_shape.placement,
+            FootnotePlacement::BelowText,
+            "각주 배치가 재파싱에서 보존돼야 함"
+        );
+        assert_eq!(
+            reparsed.section_def.endnote_shape.placement,
+            FootnotePlacement::BelowText,
+            "미주 배치가 재파싱에서 보존돼야 함"
+        );
+    }
+
+    /// [#2779] 각주 코드 2(가장 오른쪽 단)는 각주 전용 토큰이 있으나, 미주에는 스키마상
+    /// 대응 토큰이 없어 기본값 END_OF_DOCUMENT 로 강등한다(주석 참조).
+    #[test]
+    fn issue2779_note_place_right_column_footnote_only() {
+        use crate::model::footnote::FootnotePlacement;
+
+        let mut para = Paragraph::default();
+        para.text = "x".to_string();
+        let (mut doc, mut section) = make_doc_with_paragraph(para);
+        section.section_def.footnote_shape.placement = FootnotePlacement::RightColumn;
+        section.section_def.endnote_shape.placement = FootnotePlacement::RightColumn;
+        doc.sections = vec![section.clone()];
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+
+        assert!(
+            xml.contains(r#"<hp:placement place="RIGHT_MOST_COLUMN" beneathText="0"/>"#),
+            "각주 오른쪽단 배치가 IR 값으로 방출돼야 함"
+        );
+        assert!(
+            xml.contains(r#"<hp:placement place="END_OF_DOCUMENT" beneathText="0"/>"#),
+            "미주는 스키마 밖 코드 2 를 기본값으로 강등해야 함"
+        );
+    }
+
+    /// [#2779] 기본 SectionDef(placement=EachColumn, beneathText=0)의 출력은 템플릿과
+    /// 동일해야 한다 — 무변경 가드.
+    #[test]
+    fn issue2779_note_place_keeps_template_defaults() {
+        let mut para = Paragraph::default();
+        para.text = "x".to_string();
+        let (doc, section) = make_doc_with_paragraph(para);
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+
+        assert!(
+            xml.contains(r#"<hp:placement place="EACH_COLUMN" beneathText="0"/>"#),
+            "각주 기본 배치는 템플릿과 동일해야 함"
+        );
+        assert!(
+            xml.contains(r#"<hp:placement place="END_OF_DOCUMENT" beneathText="0"/>"#),
+            "미주 기본 배치는 템플릿과 동일해야 함"
+        );
+    }
+
     #[test]
     fn issue1984_footnote_shape_reflects_ir() {
         // [#1984] footNotePr 의 noteLine/noteSpacing 이 템플릿 기본값(aboveLine=850,
@@ -3178,6 +3330,54 @@ mod tests {
         assert!(
             !xml.contains(r#"spaceColumns="1134""#),
             "템플릿 1134 잔존 금지"
+        );
+    }
+
+    /// [#2779] secPr@memoShapeIDRef 가 템플릿 상수 "0" 이 아니라 IR 값으로 방출되고
+    /// 재파싱까지 살아남아야 한다. 종전엔 3계층(모델/파서/직렬화기) 모두 결손이라
+    /// 메모 모양 참조가 저장마다 0 으로 리셋됐다(실측 14 secPr/9 파일).
+    #[test]
+    fn issue2779_secpr_memo_shape_id_reflects_ir() {
+        use crate::parser::hwpx::section::parse_hwpx_section;
+
+        let mut para = Paragraph::default();
+        para.text = "x".to_string();
+        let (mut doc, mut section) = make_doc_with_paragraph(para);
+        section.section_def.memo_shape_id = 3;
+        doc.sections = vec![section.clone()];
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+
+        assert!(
+            xml.contains(r#"memoShapeIDRef="3""#),
+            "memoShapeIDRef 가 IR 값이어야 함: {}",
+            &xml[..600.min(xml.len())]
+        );
+        assert!(
+            !xml.contains(r#"memoShapeIDRef="0""#),
+            "템플릿 상수 memoShapeIDRef=0 잔존 금지"
+        );
+
+        let reparsed = parse_hwpx_section(&xml).unwrap();
+        assert_eq!(
+            reparsed.section_def.memo_shape_id, 3,
+            "memoShapeIDRef 가 재파싱에서 보존돼야 함"
+        );
+    }
+
+    /// [#2779] 기본 SectionDef(memo_shape_id=0)의 출력은 템플릿과 동일해야 한다 —
+    /// 무변경 가드.
+    #[test]
+    fn issue2779_secpr_memo_shape_id_keeps_template_default() {
+        let mut para = Paragraph::default();
+        para.text = "x".to_string();
+        let (doc, section) = make_doc_with_paragraph(para);
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+        assert!(
+            xml.contains(r#"outlineShapeIDRef="0" memoShapeIDRef="0""#),
+            "기본 문서는 템플릿 그대로여야 함: {}",
+            &xml[..600.min(xml.len())]
         );
     }
 


### PR DESCRIPTION
**이 PR 로 닫히는 이슈**: #2779 · #3526 · #3368

(포크에서 올린 PR 이라 `Closes` 키워드가 자동 연결되지 않습니다 — 머지 후 수동으로 닫아 주시거나,
말씀 주시면 제가 닫겠습니다.)

## 배경

#3534 에 이은 두 번째 조각입니다. 제가 열어 둔 이슈를 devel `2f281d67f` 로 재검증하면서
**코드가 확실히 틀렸고 수정 범위가 좁은 것만** 골랐습니다. 설계 판단이 필요한 건은 넣지 않았습니다.

원래 #3518(HWP3 페이지 수 64→65)도 함께 올릴 계획이었는데, **구현해 보니 증상이 해소되지 않아
뺐습니다.** 경위와 실제 원인은 이슈에 남겼습니다(요약: 원인은 provenance 가드가 아니라
`char_shapes` 시작 위치가 −2 로 밀리는 HWP3 위치 공간 불일치 — #3532 (c) 와 같은 뿌리).

## 포함 변경

### 1. `secPr@memoShapeIDRef` 3계층 미보존 + 각주/미주 `place` 하드코딩 (#2779)

메모 모양 참조가 모델·파서·저장 **세 곳 모두**에서 유실됐습니다. `SectionDef.memo_shape_id` 추가,
파싱 arm 추가, `replace_secpr_scalars` 치환 추가로 왕복을 닫습니다. 기본값 0 이면 출력이 템플릿과
바이트 동일합니다.

각주/미주 배치도 같은 자리에서 유실됩니다 — 파서에 스키마 토큰 `MERGED_COLUMN` /
`RIGHT_MOST_COLUMN` 이 없어 `_ => continue` 로 떨어지고, 저장은 `place` 를 하드코딩했습니다.

**역매핑은 문맥 키가 필수**입니다. 코드 0 이 각주에서는 `EACH_COLUMN`, 미주에서는
`END_OF_DOCUMENT` 인데 파서가 두 토큰을 `EachColumn` 하나로 접습니다. 추측하지 않고 세 출처가
일치하는지 확인한 뒤 `note_place_str(placement, is_end_note)` 로 구현했습니다:

- OWPML `ParaList XML schema.xml` 의 footNotePr / endNotePr 열거 순서
- `src/model/footnote.rs:276-285` 의 이중 의미 주석
- `src/document_core/commands/object_ops/note.rs:158-179` 의 API 명칭

각주 슬롯은 미주 앵커 `place="END_OF_DOCUMENT"` 를 합성할 수 없도록 막았습니다.

**범위 밖**: 헤더 `hh:memoProperties` 방출은 이슈 §4 에서 스코프 밖으로 선언돼 있어 넣지
않았습니다. 복원된 참조는 그것이 반영되기 전까지 저장된 헤더에 대상이 없습니다.

### 2. 스트림 없는 Embedding BinData 미등록 → 그림이 통째로 드롭 (#3526)

`parser/mod.rs:1774-1778` 이 스트림 없는 BinData 를 건너뛰어 content 가 없는데,
`context.rs` 의 1차 등록은 content 기준, 2차 등록은 `Link` 만 받습니다. **content 없고 Link 도
아닌 Embedding/Storage 항목이 두 루프를 모두 빠져나가** `resolve_bin_id` 가 `None` 을 돌려주고,
`picture.rs:282-291` 이 `Err` 로 `<hp:pic>` 를 통째로 버립니다 — 그림과 앵커·레이아웃이 함께
사라집니다. #1891 이 Link 에 대해 막은 구멍이 Embedding/Storage 에 남아 있던 형태입니다.

매니페스트 전용 항목(`is_embedded=false`)이 유효한 패키지 형태임을 **4개 경로에서 확인**했습니다 —
ZIP 기록 스킵(`serializer/hwpx/mod.rs:129`), 3자 검증 필터(`:233`), href 검사 제외
(`package_check.rs:328-340`), 재읽기 시 항목 유지(`parser/hwpx/content.rs:136`). 마지막 것 덕분에
**매니페스트 인덱스가 밀려 그림 참조 전체가 어긋나는 사고를 오히려 막습니다.**

### 3. ParaShape 여백 왕복이 고정점이 아님 (#3368)

writer 는 `case` 에 `x/2`, `default` 에 원값을 쓰는데 파서가 `case×2` 만 읽습니다. 홀수 HWPUNIT 은
`case` 로 표현 불가라 101 → 50 → 100 으로 내려앉습니다. **정확한 값은 이미 `<hp:default>` 에
있는데 파서가 버리고 있었습니다.**

`case != default && |default − case×2| <= 1` 일 때 `default` 원값을 채택합니다. 짝수에서는
무동작이고, 실제로 바뀌는 것은 `case` 로 표현 불가능한 홀수 집합뿐입니다.

**계약은 한컴 실물로 확정했습니다.** samples 의 한컴 저장 `.hwpx` 262개 전량에서 paraPr `switch` 쌍:

| 관계 | 쌍 수 |
|---|---|
| 양쪽 0 | 53,206 |
| 반감 관계 (`\|default − case×2\| ≤ 1`) | 16,248 |
| case == default (0 아님) | 21 |
| 그 외 | **0** |

즉 한컴도 같은 halving 계약을 쓰고 `default` 에 원값을 적습니다(편람 `paraPr=1458`
left `case=100` / `default=201`). 종전 조사 노트의 "한컴은 halving 을 하지 않는다" 는 한 파일
(`svg_picture_repro.hwpx`)의 21쌍을 일반화한 **제 오독이라 #3368 에 정정 코멘트를 남겼습니다.**
그 동일-값 패턴은 조건에서 배제해 종전 `case×2` 해석을 지킵니다.

코퍼스 영향 범위는 **정확히 37개 필드**이고, 각각 한컴이 `default` 에 직접 쓴 값으로 ±1
되돌아갑니다. 직렬화기의 ×2/÷2 스케일 계약 자체는 건드리지 않았습니다.

## 열린 PR 과의 충돌 여부

**파일·라인 모두 겹치지 않습니다.**

| PR | 건드리는 파일 | 이 PR 과 겹침 |
|---|---|---|
| #3534 | `serializer/hwpx/section.rs` :2010~:2645, `parser/hwpx/section.rs`, `parser/hwp3/mod.rs` | 같은 파일 2개이나 **라인 무관** (이 PR 은 secPr/place 경로 :100~:394) |
| #3478 · #3482 | `src/main.rs`, `field_query.rs` | 없음 |
| #3457 · #3490 | `mydocs/report/**` | 없음 |
| #3533 | `parser/hwp3/mod.rs` :438, :2671 | 없음 |

## 검증

```
cargo fmt --all -- --check                                          # clean
cargo clippy --profile release-test --all-targets -- -D warnings    # clean
cargo test --profile release-test --lib                             # 3008 passed / 0 failed
cargo test --profile release-test --tests                           # 354 바이너리 / 4288 passed / 0 failed
```

신규 회귀 테스트 10종 (각 이슈별 왕복 검증 + 무변경 가드):

| 테스트 | 대상 |
|---|---|
| `issue2779_secpr_memo_shape_id_ref_parsed` / `_reflects_ir` / `_keeps_template_default` | #2779 memoShapeIDRef |
| `issue2779_footnote_placement_accepts_schema_column_tokens` | #2779 파서 토큰 |
| `issue2779_note_place_reflects_ir` / `_right_column_footnote_only` / `_keeps_template_defaults` | #2779 place 역매핑 |
| `issue3526_contentless_embedding_bindata_is_registered` | #3526 |
| `odd_para_margin_survives_hwpx_serialize_parse_roundtrip` | #3368 |
| `hancom_equal_case_default_switch_keeps_hwpunitchar_scale` | #3368 한컴 패턴 보호 |
