### PR TITLE
fix(hml/renderer): IR 에 있는데 무시되던 속성 2건 — HML 셀 세로정렬, 위/아래첨자 (#3189, #2771)

### DIFF
--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -1540,13 +1540,7 @@ fn effective_text_font_size_and_baseline(run: &TextRunNode) -> (f64, f64) {
     } else {
         12.0
     };
-    if run.style.superscript {
-        (base_font_size * 0.7, run.baseline - base_font_size * 0.3)
-    } else if run.style.subscript {
-        (base_font_size * 0.7, run.baseline + base_font_size * 0.15)
-    } else {
-        (base_font_size, run.baseline)
-    }
+    run.style.script_draw_metrics(base_font_size, run.baseline)
 }
 
 fn write_tab_leaders(buf: &mut String, leaders: &[TabLeaderInfo]) {

--- a/src/parser/hml/adapter.rs
+++ b/src/parser/hml/adapter.rs
@@ -237,7 +237,10 @@ fn into_table(source: HmlTable) -> Result<Control, HmlError> {
             border_fill_id: source_cell.border_fill_id,
             paragraphs,
             apply_inner_margin: true,
-            vertical_align: VerticalAlign::Center,
+            // [#3189] 종전엔 Center 하드코딩이라 원본의 Top/Bottom 이 유실됐다.
+            // reader 가 PARALIST@VertAlign 을 읽어 넣은 값을 그대로 옮긴다
+            // (속성이 없으면 reader 가 Center 로 접으므로 기존 동작과 같다).
+            vertical_align: source_cell.vertical_align,
             ..Default::default()
         });
     }

--- a/src/parser/hml/reader.rs
+++ b/src/parser/hml/reader.rs
@@ -10,6 +10,7 @@ use crate::model::style::{
     border_width_index, Alignment, BorderFill, BorderLineType, CharShape, Fill, FillType, Font,
     LineSpacingType, ParaShape, ShapeBorderLine, SolidFill, Style, TabDef,
 };
+use crate::model::table::VerticalAlign;
 use crate::model::Padding;
 
 use super::envelope::PreservedFragment;
@@ -168,6 +169,12 @@ pub(crate) struct HmlCell {
     pub height: u32,
     pub padding: Padding,
     pub border_fill_id: u16,
+    /// [#3189] `<PARALIST VertAlign="...">` 의 셀 세로 정렬.
+    /// `VerticalAlign::default()` 는 `Top` 이지만 HML 경로의 실효 기본값은 `Center`
+    /// 다(종전 adapter 가 모든 셀을 Center 로 하드코딩했다). 그래서 `start_cell` 이
+    /// `..Default::default()` 에 맡기지 않고 Center 를 명시로 넣는다 — 이 필드를
+    /// 파생 기본값으로 두면 PARALIST 가 없는 기존 문서의 정렬이 통째로 바뀐다.
+    pub vertical_align: VerticalAlign,
     pub paragraphs: Vec<HmlParagraph>,
 }
 
@@ -442,6 +449,7 @@ impl<'a> ReadState<'a> {
             "TEXTMARGIN" => self.capture_text_margin(element),
             "TABLE" => self.start_table(element),
             "CELL" => self.start_cell(element),
+            "PARALIST" => self.capture_paralist(element),
             "SIZE" => self.capture_object_size(element),
             "POSITION" => self.capture_object_position(element),
             "INSIDEMARGIN" => self.capture_table_padding(element),
@@ -900,8 +908,27 @@ impl<'a> ReadState<'a> {
             width: parse_attribute(element, b"Width")?.unwrap_or(0),
             height: parse_attribute(element, b"Height")?.unwrap_or(0),
             border_fill_id: parse_attribute(element, b"BorderFill")?.unwrap_or(0),
+            // [#3189] PARALIST 가 아예 없는 셀도 종전 동작(Center)을 유지해야 한다.
+            vertical_align: VerticalAlign::Center,
             ..Default::default()
         });
+        Ok(())
+    }
+
+    /// [#3189] `<PARALIST VertAlign="...">` 의 셀 세로 정렬을 가장 안쪽 셀에 귀속한다.
+    ///
+    /// PARALIST 는 셀뿐 아니라 글상자(`DRAWTEXT`) 아래에도 나오므로, 셀 안 글상자의
+    /// PARALIST 가 바깥 셀 값을 덮어쓰지 않도록 문단 귀속과 같은
+    /// `nearest_paragraph_owner_is_cell` 판정을 재사용한다(#2723 과 동일한 규칙).
+    fn capture_paralist(&mut self, element: &BytesStart<'_>) -> Result<(), HmlError> {
+        if !self.nearest_paragraph_owner_is_cell() {
+            return Ok(());
+        }
+        let vertical_align =
+            parse_cell_vertical_align(attribute(element, b"VertAlign")?.as_deref());
+        if let Some(cell) = self.cells.last_mut() {
+            cell.vertical_align = vertical_align;
+        }
         Ok(())
     }
 
@@ -1583,6 +1610,16 @@ fn parse_vert_align(value: Option<&str>) -> VertAlign {
         Some("Inside") => VertAlign::Inside,
         Some("Outside") => VertAlign::Outside,
         _ => VertAlign::Top,
+    }
+}
+
+/// [#3189] 셀 세로 정렬(`PARALIST@VertAlign`). 개체 위치용 `parse_vert_align` 과 달리
+/// 속성이 없으면 `Top` 이 아니라 `Center` 로 접는다 — HML 경로의 실효 기본값이다.
+fn parse_cell_vertical_align(value: Option<&str>) -> VerticalAlign {
+    match value {
+        Some("Top") => VerticalAlign::Top,
+        Some("Bottom") => VerticalAlign::Bottom,
+        _ => VerticalAlign::Center,
     }
 }
 

--- a/src/renderer/html.rs
+++ b/src/renderer/html.rs
@@ -305,13 +305,7 @@ impl Renderer for HtmlRenderer {
         };
 
         // 위첨자/아래첨자: y좌표·font_size 직접 조정 (absolute 위치이므로 vertical-align 불가)
-        let (draw_y, draw_size) = if style.superscript {
-            (y - font_size * 0.3, font_size * 0.7)
-        } else if style.subscript {
-            (y + font_size * 0.15, font_size * 0.7)
-        } else {
-            (y, font_size)
-        };
+        let (draw_size, draw_y) = style.script_draw_metrics(font_size, y);
 
         let mut css = format!(
             "position:absolute;left:{}px;top:{}px;font-family:{};font-size:{}px;color:{};",

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -203,7 +203,54 @@ pub struct TextStyle {
     pub shade_color: ColorRef,
 }
 
+/// 위첨자/아래첨자 글리프를 그릴 때 적용하는 본문 대비 글꼴 크기 배율.
+pub const SCRIPT_FONT_SCALE: f64 = 0.7;
+/// 위첨자 baseline 상향 이동량 (본문 글꼴 크기 대비 em).
+pub const SUPERSCRIPT_RISE_EM: f64 = 0.3;
+/// 아래첨자 baseline 하향 이동량 (본문 글꼴 크기 대비 em).
+pub const SUBSCRIPT_DROP_EM: f64 = 0.15;
+
 impl TextStyle {
+    /// 위첨자/아래첨자 run 의 **그리기** 글꼴 크기와 baseline 을 계산한다.
+    ///
+    /// SVG·Canvas·HTML·Skia·paint JSON 이 각자 하드코딩하던 동일 상수를 한곳으로
+    /// 모은 것이다 (#2771). 레이아웃 advance 는 본문 run 기준을 유지하고 실제
+    /// 글리프 크기와 baseline 만 조정한다는 계약은 종전과 같다.
+    ///
+    /// 비첨자 run 은 인자를 그대로 돌려주므로 기존 출력이 비트 단위로 보존된다.
+    pub fn script_draw_metrics(&self, base_font_size: f64, baseline_y: f64) -> (f64, f64) {
+        if self.superscript {
+            (
+                base_font_size * SCRIPT_FONT_SCALE,
+                baseline_y - base_font_size * SUPERSCRIPT_RISE_EM,
+            )
+        } else if self.subscript {
+            (
+                base_font_size * SCRIPT_FONT_SCALE,
+                baseline_y + base_font_size * SUBSCRIPT_DROP_EM,
+            )
+        } else {
+            (base_font_size, baseline_y)
+        }
+    }
+
+    /// 글자폭 맞춤(fit) 대상 advance 에 적용할 배율 (#2771).
+    ///
+    /// SVG `textLength` 와 Canvas `fit_scale` 은 "레이아웃 advance 에 글리프 폭을
+    /// 맞춘다". 그런데 첨자 글리프는 `script_draw_metrics` 로 0.7 배 축소되어
+    /// 그려지므로, 대상 advance 를 같은 배율로 줄이지 않으면 브라우저가 축소된
+    /// 글리프를 본문 폭까지 되늘려 1/0.7 ≈ 1.43 배 가로 확대가 발생한다.
+    ///
+    /// 비첨자는 **정확히 1.0** 을 돌려준다. `advance * 1.0` 은 IEEE-754 상
+    /// 반올림이 없는 항등 연산이라 기존 `textLength` 값이 비트 단위로 불변이다.
+    pub fn script_advance_scale(&self) -> f64 {
+        if self.superscript || self.subscript {
+            SCRIPT_FONT_SCALE
+        } else {
+            1.0
+        }
+    }
+
     /// 시각적 bold 여부.
     ///
     /// CharShape.bold=true 외에도 HY헤드라인M 같은 heavy display face 를
@@ -1451,6 +1498,83 @@ mod tests {
         // 1인치 = 7200 HWPUNIT, 96 DPI → 96px
         let px = hwpunit_to_px(7200, 96.0);
         assert!((px - 96.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_script_draw_metrics_matches_shared_contract() {
+        // [#2771] SVG/Canvas/HTML/Skia/paint JSON 이 공유하는 첨자 계약:
+        // 글꼴 0.7 배 + baseline 위 0.3em / 아래 0.15em.
+        let base = TextStyle {
+            font_size: 20.0,
+            ..Default::default()
+        };
+
+        let sup = TextStyle {
+            superscript: true,
+            ..base.clone()
+        };
+        let (sup_size, sup_y) = sup.script_draw_metrics(20.0, 100.0);
+        assert!(
+            (sup_size - 14.0).abs() < 1e-9,
+            "위첨자 글꼴은 0.7 배여야 함: {sup_size}"
+        );
+        assert!(
+            (sup_y - 94.0).abs() < 1e-9,
+            "위첨자 baseline 은 0.3em 위여야 함: {sup_y}"
+        );
+
+        let sub = TextStyle {
+            subscript: true,
+            ..base.clone()
+        };
+        let (sub_size, sub_y) = sub.script_draw_metrics(20.0, 100.0);
+        assert!(
+            (sub_size - 14.0).abs() < 1e-9,
+            "아래첨자 글꼴은 0.7 배여야 함: {sub_size}"
+        );
+        assert!(
+            (sub_y - 103.0).abs() < 1e-9,
+            "아래첨자 baseline 은 0.15em 아래여야 함: {sub_y}"
+        );
+
+        // 비첨자는 인자를 그대로 돌려준다.
+        assert_eq!(base.script_draw_metrics(20.0, 100.0), (20.0, 100.0));
+    }
+
+    #[test]
+    fn test_script_advance_scale_is_exact_identity_for_non_script() {
+        // [#2771] 비첨자 배율이 **정확히 1.0** 이어야 기존 golden SVG 의
+        // textLength 값이 비트 단위로 보존된다 (`x * 1.0` 은 IEEE-754 상
+        // 반올림이 없는 항등 연산).
+        let base = TextStyle {
+            font_size: 20.0,
+            ..Default::default()
+        };
+        assert_eq!(base.script_advance_scale(), 1.0);
+        for advance in [0.0_f64, 6.2133, 1e-300, 1e300, f64::MIN_POSITIVE] {
+            assert_eq!(
+                (advance * base.script_advance_scale()).to_bits(),
+                advance.to_bits(),
+                "비첨자 advance 는 비트 단위로 불변이어야 함: {advance}"
+            );
+        }
+
+        // 첨자 배율은 그리기 글꼴 축소율과 반드시 같은 값이어야 한다.
+        // (다르면 글리프가 textLength 로 되늘어나는 #2771 결함이 재발한다.)
+        let sup = TextStyle {
+            superscript: true,
+            ..base.clone()
+        };
+        let sub = TextStyle {
+            subscript: true,
+            ..base.clone()
+        };
+        for style in [&sup, &sub] {
+            assert_eq!(
+                style.script_draw_metrics(20.0, 0.0).0,
+                20.0 * style.script_advance_scale()
+            );
+        }
     }
 
     // [#2287] 저장 LINE_SEG 없는 빈 anchor 문단의 TAC 그림 줄 메트릭 합성.

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -1591,6 +1591,19 @@ mod tests {
         image.pixels().filter(|pixel| pixel[3] > 0).count()
     }
 
+    /// 잉크 픽셀의 세로 범위 `(min_y, max_y)`. 잉크가 없으면 `None`.
+    fn ink_y_range(image: &image::RgbaImage) -> Option<(u32, u32)> {
+        let mut min_y: Option<u32> = None;
+        let mut max_y = 0_u32;
+        for (_, y, pixel) in image.enumerate_pixels() {
+            if pixel[3] > 0 {
+                min_y = Some(min_y.map_or(y, |m| m.min(y)));
+                max_y = max_y.max(y);
+            }
+        }
+        min_y.map(|min| (min, max_y))
+    }
+
     fn portable_font_resources() -> ResourceArena {
         let mut resources = ResourceArena::default();
         let font_bytes = [0_u8, 1, 2, 3];
@@ -3018,6 +3031,80 @@ mod tests {
         let image = decode_rgba(&output.bytes);
 
         assert!(count_ink(&image) > 0);
+    }
+
+    #[test]
+    fn issue_2771_script_run_shrinks_glyph_and_shifts_baseline() {
+        // [#2771] skia 경로에는 첨자 분기가 아예 없어 위첨자/아래첨자를 본문과
+        // 같은 크기·같은 baseline 으로 그렸다. SVG/Canvas/HTML 과 동일한
+        // 계약(0.7 배 글꼴 + baseline 이동)을 따라야 한다.
+        let render_script = |superscript: bool, subscript: bool| {
+            let run = TextRunNode {
+                text: "A".to_string(),
+                style: TextStyle {
+                    font_size: 24.0,
+                    color: 0x00000000,
+                    superscript,
+                    subscript,
+                    ..Default::default()
+                },
+                char_shape_id: None,
+                para_shape_id: None,
+                section_index: None,
+                para_index: None,
+                char_start: None,
+                cell_context: None,
+                is_para_end: false,
+                is_line_break_end: false,
+                rotation: 0.0,
+                is_vertical: false,
+                char_overlap: None,
+                border_fill_id: 0,
+                baseline: 32.0,
+                field_marker: Default::default(),
+                display_text: None,
+            };
+            let tree = PageLayerTree::new(
+                64.0,
+                64.0,
+                LayerNode::leaf(
+                    BoundingBox::new(0.0, 0.0, 64.0, 64.0),
+                    None,
+                    vec![PaintOp::text_run(
+                        BoundingBox::new(4.0, 0.0, 56.0, 64.0),
+                        run,
+                    )],
+                ),
+            );
+            let output = SkiaLayerRenderer::new()
+                .render_raster_with_options(&tree, RasterRenderOptions::default())
+                .expect("render script text");
+            ink_y_range(&decode_rgba(&output.bytes)).expect("글리프 잉크가 있어야 함")
+        };
+
+        let (base_top, base_bottom) = render_script(false, false);
+        let (sup_top, sup_bottom) = render_script(true, false);
+        let (sub_top, sub_bottom) = render_script(false, true);
+
+        assert!(
+            sup_bottom < base_bottom,
+            "위첨자는 본문보다 위 baseline 이어야 함: sup={sup_bottom}, base={base_bottom}"
+        );
+        assert!(
+            sub_bottom > base_bottom,
+            "아래첨자는 본문보다 아래 baseline 이어야 함: sub={sub_bottom}, base={base_bottom}"
+        );
+        let base_height = base_bottom - base_top;
+        assert!(
+            sup_bottom - sup_top < base_height,
+            "위첨자 글리프는 0.7 배로 작아야 함: sup={}, base={base_height}",
+            sup_bottom - sup_top
+        );
+        assert!(
+            sub_bottom - sub_top < base_height,
+            "아래첨자 글리프는 0.7 배로 작아야 함: sub={}, base={base_height}",
+            sub_bottom - sub_top
+        );
     }
 
     #[test]

--- a/src/renderer/skia/text_replay.rs
+++ b/src/renderer/skia/text_replay.rs
@@ -54,11 +54,17 @@ impl SkiaTextReplay<'_> {
                 if text.is_empty() && style.tab_leaders.is_empty() {
                     return;
                 }
-                let font_size = if style.font_size > 0.0 {
-                    style.font_size as f32
+                let base_font_size = if style.font_size > 0.0 {
+                    style.font_size
                 } else {
                     12.0
                 };
+                // [#2771] 위첨자/아래첨자를 SVG/Canvas/HTML 과 동일한 계약(0.7 배
+                // 글꼴 + baseline 이동)으로 그린다. 종전 skia 경로는 첨자 분기가
+                // 아예 없어 본문과 같은 크기·같은 baseline 으로 그렸다.
+                // baseline 이동은 아래 `y` 계산에서 함께 적용한다.
+                let (draw_font_size, _) = style.script_draw_metrics(base_font_size, 0.0);
+                let font_size = draw_font_size as f32;
                 let font_style = match (style.bold, style.italic) {
                     (true, true) => FontStyle::bold_italic(),
                     (true, false) => FontStyle::bold(),
@@ -167,11 +173,13 @@ impl SkiaTextReplay<'_> {
                         Some(font)
                     }
                 };
-                let y = if baseline > 0.0 {
+                let baseline_y = if baseline > 0.0 {
                     bbox.y + baseline
                 } else {
                     bbox.y + bbox.height
                 };
+                // [#2771] 첨자 baseline 이동 (위 0.3em / 아래 0.15em). 비첨자는 항등.
+                let (_, y) = style.script_draw_metrics(base_font_size, baseline_y);
                 let effective_rotation = if is_vertical {
                     rotation + 90.0
                 } else {

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -2696,13 +2696,12 @@ impl Renderer for SvgRenderer {
         };
         // 위첨자/아래첨자는 레이아웃 advance 는 원래 run 기준으로 유지하고,
         // 실제 SVG glyph 크기와 baseline 만 Canvas/HTML 출력과 동일하게 조정한다.
-        let (font_size, y) = if style.superscript {
-            (base_font_size * 0.7, y - base_font_size * 0.3)
-        } else if style.subscript {
-            (base_font_size * 0.7, y + base_font_size * 0.15)
-        } else {
-            (base_font_size, y)
-        };
+        let (font_size, y) = style.script_draw_metrics(base_font_size, y);
+        // [#2771] `textLength` 는 **실제로 그려지는** 글리프 폭에 맞춰야 한다.
+        // char_positions 의 advance 는 본문(base) 크기 기준이므로, 0.7 배로 그려지는
+        // 첨자에 그대로 넘기면 lengthAdjust="spacingAndGlyphs" 가 글리프를 1/0.7 배
+        // 가로로 늘린다. 비첨자는 정확히 1.0 이라 기존 textLength 값이 불변이다.
+        let script_advance_scale = style.script_advance_scale();
         let font_family = if style.font_family.is_empty() {
             "sans-serif".to_string()
         } else {
@@ -2863,7 +2862,7 @@ impl Renderer for SvgRenderer {
                 let char_y = y + dy;
                 let length_attrs = svg_text_length_attrs(
                     cluster_str,
-                    cluster_advance(*char_idx, cluster_str),
+                    cluster_advance(*char_idx, cluster_str) * script_advance_scale,
                     ratio,
                 );
                 let shadow_attrs = attrs_for_cluster(cluster_str, &shadow_color);
@@ -2926,14 +2925,17 @@ impl Renderer for SvgRenderer {
                     y,
                     font_size,
                     color,
-                    svg_text_length_attrs(cluster_str, adv, ratio),
+                    svg_text_length_attrs(cluster_str, adv * script_advance_scale, ratio),
                     escape_xml(cluster_str),
                 ));
                 continue;
             }
             let char_x = x + char_positions[*char_idx];
-            let length_attrs =
-                svg_text_length_attrs(cluster_str, cluster_advance(*char_idx, cluster_str), ratio);
+            let length_attrs = svg_text_length_attrs(
+                cluster_str,
+                cluster_advance(*char_idx, cluster_str) * script_advance_scale,
+                ratio,
+            );
             let common_attrs = attrs_for_cluster(cluster_str, &color);
 
             if has_ratio {

--- a/src/renderer/svg/tests.rs
+++ b/src/renderer/svg/tests.rs
@@ -72,6 +72,83 @@ fn test_svg_draw_text_superscript_adjusts_baseline_and_size() {
     assert!(output.contains("y=\"94\""));
 }
 
+/// 주어진 글리프를 담은 `<text>` 줄에서 `textLength` 값을 뽑아낸다.
+fn text_length_of(output: &str, glyph: &str) -> f64 {
+    let needle = format!(">{glyph}</text>");
+    let line = output
+        .lines()
+        .find(|line| line.contains(needle.as_str()))
+        .unwrap_or_else(|| panic!("SVG 에 `{glyph}` <text> 가 있어야 함"));
+    let value = line
+        .split("textLength=\"")
+        .nth(1)
+        .unwrap_or_else(|| panic!("`{glyph}` 는 textLength 를 가져야 함: {line}"))
+        .split('"')
+        .next()
+        .unwrap_or_else(|| panic!("textLength 값이 닫히지 않음: {line}"));
+    value
+        .parse()
+        .unwrap_or_else(|_| panic!("textLength 는 수치여야 함: {line}"))
+}
+
+#[test]
+fn test_svg_draw_text_script_scales_text_length_by_glyph_size() {
+    // [#2771] 첨자 글리프는 본문의 0.7 배 크기로 그려진다. 그런데 폭 맞춤에 쓰는
+    // textLength 가 본문(base) advance 그대로면 lengthAdjust="spacingAndGlyphs"
+    // 가 0.7 배 글리프를 본문 폭까지 되늘려 1/0.7 ≈ 1.43 배 가로 확대가 난다.
+    // → textLength 도 0.7 배여야 한다.
+    let base_style = TextStyle {
+        font_size: 20.0,
+        font_family: "돋움".to_string(),
+        ..Default::default()
+    };
+    let mut base_renderer = SvgRenderer::new();
+    base_renderer.begin_page(800.0, 600.0);
+    base_renderer.draw_text("1", 10.0, 100.0, &base_style);
+    let base_length = text_length_of(base_renderer.output(), "1");
+    assert!(base_length > 0.0, "본문 숫자는 textLength 를 가져야 함");
+
+    for style in [
+        TextStyle {
+            superscript: true,
+            ..base_style.clone()
+        },
+        TextStyle {
+            subscript: true,
+            ..base_style.clone()
+        },
+    ] {
+        let mut renderer = SvgRenderer::new();
+        renderer.begin_page(800.0, 600.0);
+        renderer.draw_text("1", 10.0, 100.0, &style);
+        let script_length = text_length_of(renderer.output(), "1");
+        assert!(
+            (script_length - base_length * 0.7).abs() < 0.001,
+            "첨자 textLength 는 본문의 0.7 배여야 함: base={base_length}, script={script_length}"
+        );
+    }
+}
+
+#[test]
+fn test_svg_draw_text_non_script_text_length_is_unchanged() {
+    // [#2771] 배율 인자는 비첨자에서 **정확히 1.0** 이라 기존 golden textLength
+    // 값이 비트 단위로 보존된다. 레이아웃 advance 자체는 첨자에서도 본문 기준을
+    // 유지하므로(그리기 크기만 축소) 두 run 의 char_positions 는 동일하다.
+    let style = TextStyle {
+        font_size: 20.0,
+        font_family: "돋움".to_string(),
+        ..Default::default()
+    };
+    assert_eq!(style.script_advance_scale(), 1.0);
+
+    let mut renderer = SvgRenderer::new();
+    renderer.begin_page(800.0, 600.0);
+    renderer.draw_text("1", 10.0, 100.0, &style);
+    let length = text_length_of(renderer.output(), "1");
+    // `x * 1.0` 은 IEEE-754 상 반올림 없는 항등 연산이다.
+    assert_eq!(length * style.script_advance_scale(), length);
+}
+
 #[test]
 fn test_svg_draw_text_corner_quote_uses_halfwidth_text_length() {
     let mut renderer = SvgRenderer::new();

--- a/src/renderer/web_canvas.rs
+++ b/src/renderer/web_canvas.rs
@@ -2164,13 +2164,12 @@ impl Renderer for WebCanvasRenderer {
         };
 
         // 위첨자/아래첨자: 글꼴 크기 축소 + y좌표 조정
-        let (font_size, y) = if style.superscript {
-            (base_font_size * 0.7, y - base_font_size * 0.3)
-        } else if style.subscript {
-            (base_font_size * 0.7, y + base_font_size * 0.15)
-        } else {
-            (base_font_size, y)
-        };
+        let (font_size, y) = style.script_draw_metrics(base_font_size, y);
+        // [#2771] 폰트를 이미 0.7 배로 설정했으므로 measure_text 도 0.7 배 폭을
+        // 돌려준다. 맞춤 대상 advance(본문 기준)를 같은 배율로 줄이지 않으면
+        // fit_scale = base / (0.7·base) ≈ 1.43 이 되어 글리프가 가로로 늘어난다.
+        // 비첨자는 정확히 1.0 이라 종전 fit_scale 이 불변이다.
+        let script_advance_scale = style.script_advance_scale();
 
         let font_family = super::canvas_font_family_chain(&style.font_family);
 
@@ -2359,7 +2358,7 @@ impl Renderer for WebCanvasRenderer {
                             .map(|metrics| metrics.width())
                             .and_then(|actual_w| {
                                 canvas_cluster_fit_scale(
-                                    cluster_advance,
+                                    cluster_advance * script_advance_scale,
                                     actual_w * ratio,
                                     style.letter_spacing,
                                     pin_ascii_advance,

--- a/src/serializer/hml/body.rs
+++ b/src/serializer/hml/body.rs
@@ -6,7 +6,7 @@ use crate::model::shape::{
     CommonObjAttr, HorzAlign, HorzRelTo, RectangleShape, ShapeObject, TextWrap, VertAlign,
     VertRelTo,
 };
-use crate::model::table::{Cell, Table};
+use crate::model::table::{Cell, Table, VerticalAlign};
 use crate::parser::HmlImportMetadata;
 
 use super::error::{unsupported_ir, HmlExportError};
@@ -466,7 +466,15 @@ fn write_cell(writer: &mut XmlWriter, cell: &Cell, path: &str) -> Result<(), Hml
             cell.padding.bottom,
         ),
     );
-    writer.open("PARALIST", &[]);
+    // [#3189] 종전엔 속성 없이 방출해 셀 세로 정렬이 저장 때마다 사라졌다.
+    // 한컴 실물 HML 도 CELL/PARALIST 에 VertAlign 을 적어 넣는다.
+    writer.open(
+        "PARALIST",
+        &[(
+            "VertAlign",
+            cell_vert_align_name(cell.vertical_align).to_string(),
+        )],
+    );
     for (index, paragraph) in cell.paragraphs.iter().enumerate() {
         write_paragraph(writer, paragraph, None, &format!("{path}/P[{index}]"))?;
     }
@@ -533,6 +541,16 @@ fn vert_align_name(value: VertAlign) -> &'static str {
         VertAlign::Inside => "Inside",
         VertAlign::Outside => "Outside",
         VertAlign::Top => "Top",
+    }
+}
+
+/// [#3189] 셀 세로 정렬 이름. 개체 위치용 `vert_align_name`(VertAlign) 과 달리
+/// 표 셀은 Top/Center/Bottom 세 값뿐이다.
+fn cell_vert_align_name(value: VerticalAlign) -> &'static str {
+    match value {
+        VerticalAlign::Top => "Top",
+        VerticalAlign::Center => "Center",
+        VerticalAlign::Bottom => "Bottom",
     }
 }
 

--- a/src/serializer/hml/preflight.rs
+++ b/src/serializer/hml/preflight.rs
@@ -670,9 +670,11 @@ fn validate_table(table: &Table, path: &str, blockers: &mut Vec<HmlSaveBlocker>)
 }
 
 fn validate_cell(cell: &Cell, path: &str, blockers: &mut Vec<HmlSaveBlocker>) {
+    // [#3189] cell.vertical_align 은 이제 PARALIST@VertAlign 으로 왕복하므로
+    // 더 이상 blocker 가 아니다 (Top/Bottom 셀도 저장 가능). 글상자
+    // (`validate_text_box`) 쪽 vertical_align 은 아직 방출 경로가 없어 그대로 둔다.
     let omitted = cell.list_header_width_ref != 0
         || cell.text_direction != 0
-        || cell.vertical_align != VerticalAlign::Center
         || !cell.apply_inner_margin
         || cell.is_header
         || !cell.raw_list_extra.is_empty()

--- a/tests/issue_3189_hml_cell_vertical_align.rs
+++ b/tests/issue_3189_hml_cell_vertical_align.rs
@@ -1,0 +1,140 @@
+//! Issue #3189 회귀 가드 — HML 표 셀 세로 정렬(`PARALIST@VertAlign`) 왕복.
+//!
+//! 종전엔 네 겹으로 값이 사라졌다.
+//! 1. reader 의 `start_element` 디스패치에 `PARALIST` 처리가 아예 없어 속성을 읽지 않음
+//! 2. adapter 의 `into_table()` 이 모든 셀을 `VerticalAlign::Center` 로 하드코딩
+//! 3. serializer 의 `write_cell()` 이 `PARALIST` 를 속성 없이 방출
+//! 4. preflight 의 `validate_cell()` 이 비-Center 셀을 blocker 로 막아 저장 자체를 차단
+//!
+//! 그래서 `parse → IR → serialize → re-parse` 전 구간을 한 테스트에서 확인한다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+use rhwp::model::table::VerticalAlign;
+use rhwp::parser::hml::parse_hml;
+
+const FIXTURE: &str = include_str!("../samples/hml/formatting_table.hml");
+
+/// fixture(1행 1열 표)의 CELL 원문. 세 번 복제해 1행 3열로 늘린다.
+const FIXTURE_CELL: &str = r#"<CELL BorderFill="3" ColAddr="0" ColSpan="1" Dirty="false" Editable="false" HasMargin="false" Header="false" Height="282" Protect="false" RowAddr="0" RowSpan="1" Width="41956"><CELLMARGIN Bottom="141" Left="510" Right="510" Top="141"/><PARALIST LineWrap="Break" LinkListID="0" LinkListIDNext="0" TextDirection="0" VertAlign="Center"><P ParaShape="0" Style="0"><TEXT CharShape="0"><CHAR>table</CHAR></TEXT></P></PARALIST></CELL>"#;
+
+const EXPECTED_ALIGNS: [VerticalAlign; 3] = [
+    VerticalAlign::Top,
+    VerticalAlign::Center,
+    VerticalAlign::Bottom,
+];
+
+/// 실물 fixture 를 Top/Center/Bottom 세 셀짜리 1행 3열 표로 바꾼다.
+/// 저장 경로(preflight)를 통과하는 것이 확인된 문서를 최소 수술만 해서 쓴다.
+fn fixture_with_three_aligned_cells() -> Vec<u8> {
+    assert!(
+        FIXTURE.contains(FIXTURE_CELL),
+        "fixture 의 CELL 원문을 찾지 못함 — 샘플이 바뀌었다면 상수를 갱신할 것"
+    );
+    let mut cells = String::new();
+    for (col, align) in ["Top", "Center", "Bottom"].iter().enumerate() {
+        cells.push_str(
+            &FIXTURE_CELL
+                .replacen(r#"ColAddr="0""#, &format!(r#"ColAddr="{col}""#), 1)
+                .replacen(
+                    r#"VertAlign="Center""#,
+                    &format!(r#"VertAlign="{align}""#),
+                    1,
+                ),
+        );
+    }
+    FIXTURE
+        .replacen(r#"ColCount="1""#, r#"ColCount="3""#, 1)
+        .replacen(FIXTURE_CELL, &cells, 1)
+        .into_bytes()
+}
+
+fn cell_aligns(document: &rhwp::model::document::Document) -> Vec<VerticalAlign> {
+    document
+        .sections
+        .iter()
+        .flat_map(|section| &section.paragraphs)
+        .flat_map(|paragraph| &paragraph.controls)
+        .find_map(|control| match control {
+            Control::Table(table) => Some(table.as_ref()),
+            _ => None,
+        })
+        .expect("표 컨트롤이 있어야 함")
+        .cells
+        .iter()
+        .map(|cell| cell.vertical_align)
+        .collect()
+}
+
+#[test]
+fn cell_vertical_align_survives_hml_save_and_reload() {
+    let bytes = fixture_with_three_aligned_cells();
+
+    let core = DocumentCore::from_bytes(&bytes).expect("주입 HML 은 파싱되어야 함");
+    assert_eq!(
+        cell_aligns(core.document()),
+        EXPECTED_ALIGNS,
+        "PARALIST@VertAlign 이 IR 로 올라오지 않음"
+    );
+
+    // 종전엔 여기서 "cell fields cannot round-trip through HML" blocker 로 막혔다.
+    let exported = core
+        .export_hml_native()
+        .expect("Top/Bottom 정렬 셀도 저장할 수 있어야 함");
+    let xml = std::str::from_utf8(&exported).expect("HML 출력은 UTF-8");
+    for align in ["Top", "Center", "Bottom"] {
+        assert!(
+            xml.contains(&format!(r#"<PARALIST VertAlign="{align}">"#)),
+            "PARALIST VertAlign={align} 이 방출되지 않음"
+        );
+    }
+
+    let reparsed = DocumentCore::from_bytes(&exported).expect("저장한 HML 은 다시 열려야 함");
+    assert_eq!(
+        cell_aligns(reparsed.document()),
+        EXPECTED_ALIGNS,
+        "저장 후 되읽기에서 셀 세로 정렬이 유실됨"
+    );
+}
+
+#[test]
+fn absent_vert_align_folds_to_center_not_default_top() {
+    // `VerticalAlign::default()` 는 Top 이지만 HML 경로의 실효 기본값은 Center 다
+    // (종전 adapter 하드코딩). 속성 없는 PARALIST 와 PARALIST 자체가 없는 셀 모두
+    // Center 로 접혀야 기존 문서의 정렬이 바뀌지 않는다.
+    let xml = br#"<HWPML Version="2.91"><HEAD/><BODY><SECTION><P><TEXT><TABLE RowCount="1" ColCount="2">
+        <ROW>
+          <CELL ColAddr="0" RowAddr="0"><PARALIST><P><TEXT><CHAR>a</CHAR></TEXT></P></PARALIST></CELL>
+          <CELL ColAddr="1" RowAddr="0"/>
+        </ROW>
+      </TABLE></TEXT></P></SECTION></BODY><TAIL/></HWPML>"#;
+    let parsed = parse_hml(xml).expect("최소 표 HML 은 파싱되어야 함");
+
+    assert_eq!(
+        cell_aligns(&parsed.document),
+        vec![VerticalAlign::Center, VerticalAlign::Center],
+        "속성이 없는 셀은 Center 로 접혀야 함"
+    );
+}
+
+#[test]
+fn textbox_paralist_does_not_hijack_enclosing_cell_alignment() {
+    // PARALIST 는 글상자(DRAWTEXT) 아래에도 나온다. 셀 안 글상자의 PARALIST 가
+    // 뒤늦게 등장한다는 이유로 바깥 셀의 정렬을 덮어쓰면 안 된다 — 문단 귀속(#2723)과
+    // 같은 `nearest_paragraph_owner_is_cell` 판정을 공유한다.
+    let xml = br#"<HWPML Version="2.91"><HEAD/><BODY><SECTION><P><TEXT><TABLE RowCount="1" ColCount="1">
+        <ROW><CELL ColAddr="0" RowAddr="0" Width="4000" Height="1200"><PARALIST VertAlign="Bottom"><P><TEXT><RECTANGLE X0="0" X1="1000" X2="1000" X3="0" Y0="0" Y1="0" Y2="500" Y3="500">
+          <SHAPEOBJECT><SIZE Width="1000" Height="500"/></SHAPEOBJECT>
+          <DRAWINGOBJECT><DRAWTEXT><PARALIST VertAlign="Top">
+            <P><TEXT><CHAR>BOXTEXT</CHAR></TEXT></P>
+          </PARALIST></DRAWTEXT></DRAWINGOBJECT>
+        </RECTANGLE></TEXT></P></PARALIST></CELL></ROW>
+      </TABLE></TEXT></P></SECTION></BODY><TAIL/></HWPML>"#;
+    let parsed = parse_hml(xml).expect("셀 안 글상자 HML 은 파싱되어야 함");
+
+    assert_eq!(
+        cell_aligns(&parsed.document),
+        vec![VerticalAlign::Bottom],
+        "글상자 PARALIST 가 바깥 셀 정렬을 덮어씀"
+    );
+}


### PR DESCRIPTION
**이 PR 로 닫히는 이슈**: #3189 · #2771

(포크에서 올린 PR 이라 `Closes` 키워드가 자동 연결되지 않습니다 — 머지 후 수동으로 닫아 주시거나,
말씀 주시면 제가 닫겠습니다.)

## 배경

#3534 · #3537 에 이은 세 번째 조각입니다. 둘 다 **"IR 에는 값이 있는데 소비하는 쪽이 무시한다"**
는 같은 성격이라 묶었습니다. 서브시스템은 다르지만(HML 파서/저장 vs 렌더러) 파일이 겹치지 않아
리뷰를 나눠 보시기 쉽습니다 — 커밋도 이슈별로 1개씩입니다.

## 1. HML 표 셀 세로 정렬이 전 계층에서 무시됨 (#3189)

이슈가 지목한 3곳에 더해 **한 계층이 더** 있었습니다 — `HmlCell`(`parser/hml/reader.rs:162-172`)에
`vertical_align` 필드가 없고 `capture_start` 디스패치(`:432-453`)에 `"PARALIST"` arm 자체가 없어,
**애초에 XML 에서 값을 읽지도 않았습니다.**

- `reader.rs` — 필드 추가, `"PARALIST"` arm + `capture_paralist()`
- `adapter.rs:240` — `VerticalAlign::Center` 하드코딩 → `source_cell.vertical_align`
- `serializer/hml/body.rs:469` — `PARALIST` 에 `VertAlign` 방출
- `serializer/hml/preflight.rs:675` — 셀 세로 정렬 차단 절 제거

**귀속 규칙이 핵심입니다.** `PARALIST` 는 셀뿐 아니라 글상자(`DRAWTEXT`) 아래에도 나옵니다.
실제로 `samples/hml/formatting_table.hml` 에 `DRAWTEXT` 밑과 `CELL` 밑에 하나씩 있습니다. 기존
`nearest_paragraph_owner_is_cell()` 을 재사용해 셀 안 글상자의 `PARALIST` 가 바깥 셀 값을
덮어쓰지 않게 했고, 이를 판별 테스트로 고정했습니다(셀 `Bottom` + 안쪽 글상자 `Top` → 셀은
`Bottom` 유지. 안쪽 태그가 문서 순서상 뒤라 순진한 `cells.last_mut()` 는 이 테스트에서 깨집니다).

**기본값 함정**: `VerticalAlign::default()` 는 `Top` 인데 HML 의 실효 기본값은 `Center` 입니다.
`PARALIST` 가 없는 셀은 `start_cell` 이 `Center` 로 심고, 속성 없는 `PARALIST` 는
`parse_cell_vertical_align(None)` 이 `Center` 로 접습니다 — `Top` 은 HML 경로에서 도달 불가입니다.
이걸 놓치면 기존 문서의 셀 정렬이 통째로 바뀝니다.

`DRAWTEXT` 의 `PARALIST` 는 **일부러** 속성 없이 뒀습니다. 글상자 세로 정렬은 방출 경로가 없고
preflight 차단도 그대로라, 속성만 붙이면 왕복되는 것처럼 보이는 거짓이 됩니다.

**스냅샷 갱신 0건** — 저장소에 시리얼라이저 HML 출력을 담은 golden/기대값 파일이 없습니다
(`PARALIST` 등장 9개 파일 전수 확인: 샘플 2 + 퍼즈 코퍼스 1 + HML 입력을 **작성**하는 테스트 3 +
문서 2 + `body.rs`). 모든 HML 테스트가 재파싱된 IR 로 단언합니다.

> 참고: `samples/hml/aligns.hml` 은 NUL 바이트가 있어 ripgrep 이 바이너리로 건너뜁니다
> (`PARALIST` 16개 보유). 향후 HML 작업 때 검색이 조용히 새므로 알아 둘 만합니다.

## 2. 위첨자/아래첨자 — SVG/Canvas 가로 1.43배 늘어남 + Skia 무시 (#2771)

**결함 1** — 첨자를 `base * 0.7` 로 그리면서 `textLength` 에는 **스케일 안 된** `cluster_advance`
를 넘겨, `lengthAdjust="spacingAndGlyphs"` 가 0.7배 글리프를 원래 폭으로 다시 늘립니다
(1/0.7 = 1.43). `cluster_advance` 의 출처인 `layout/text_measurement.rs:66-79` 에 첨자 분기가
없습니다. `svg.rs` 는 이슈가 짚은 2곳이 아니라 **3곳**이 대상이었습니다(`:2864` 그림자,
`:2929` 가운뎃점 오버레이, `:2936` 본문). Canvas 도 같습니다(`web_canvas.rs:2167` 대 `:2355`).

**결함 2** — `src/renderer/skia/` 전체에 `superscript|subscript` 가 **0건**입니다. 글자 크기도
baseline 오프셋도 없습니다.

`renderer/mod.rs` 에 상수와 `TextStyle::script_draw_metrics` / `script_advance_scale` 를 두고,
흩어져 있던 상수 사본 **4곳**(`svg`·`web_canvas`·`html`·`paint/json`)을 그리로 모았습니다.

**`script_advance_scale` 은 비첨자 런에서 `font_size / base_font_size` 가 아니라 상수 `1.0` 을
돌려줍니다.** 나눗셈 형태는 `base_font_size` 가 무한대일 때 `NaN` 이 되어 **비첨자 런의
`textLength` 를 조용히 없앱니다.** 상수 형태는 `x * 1.0` 이 반올림 없는 항등이라, 기존 golden SVG
7개 파일 **817개** `lengthAdjust` 값이 비트 동일합니다(첨자 부재는 "0.7배 크기쌍 + 대응 baseline
오프셋" 서명 스캔으로 확인 — 7개 파일 모두 0건).

Skia 에서 `font_size` 는 형광펜 사각형·점선 리더·가운뎃점·밑줄 기하도 몰기 때문에 첨자 런에서
함께 줄어듭니다. `svg.rs` 가 밑줄 계산 전에 `font_size` 를 재바인딩하는 것과 **같은 계약**이라
의도된 방향입니다. 이를 덮는 golden PNG 는 저장소에 없습니다(`tests` 하위 png 0개).

## 검증

`web_canvas.rs` 는 `cfg(target_arch = "wasm32")`, `skia/*` 는 `feature = "native-skia"` 라
**기본 `cargo check` 로는 둘 다 컴파일되지 않습니다.** 따로 확인했습니다.

```
cargo fmt --all -- --check                                          # clean
cargo clippy --profile release-test --all-targets -- -D warnings    # clean
cargo check --profile release-test --features native-skia --all-targets   # clean
cargo check --target wasm32-unknown-unknown --lib                   # clean
cargo test --profile release-test --lib                             # 3005 passed / 0 failed
cargo test --profile release-test --features native-skia --lib      # 첨자 테스트 포함 통과
cargo test --profile release-test --tests                           # 355 바이너리 / 4285 passed / 0 failed
```

신규 회귀 테스트:

| 테스트 | 대상 |
|---|---|
| `cell_vertical_align_survives_hml_save_and_reload` | #3189 Top/Center/Bottom 왕복 |
| `absent_vert_align_folds_to_center_not_default_top` | #3189 기본값 함정 가드 |
| `textbox_paralist_does_not_hijack_enclosing_cell_alignment` | #3189 귀속 판별 |
| `test_svg_draw_text_script_scales_text_length_by_glyph_size` | #2771 SVG 첨자 |
| `test_svg_draw_text_non_script_text_length_is_unchanged` | #2771 비첨자 무변경 |
| `test_script_advance_scale_is_exact_identity_for_non_script` | #2771 비트 동일성(`to_bits()`) |
| `test_script_draw_metrics_matches_shared_contract` | #2771 상수 통합 계약 |
| `issue_2771_script_run_shrinks_glyph_and_shifts_baseline` | #2771 skia 래스터 잉크 bbox |

## 충돌 여부

열린 PR 어느 것과도 겹치지 않습니다 — #3534·#3539 는 `parser/hwp3`·`parser/hwpx`,
#3537 은 HWPX 저장/파서, #3478·#3482 는 `src/main.rs`, #3533 은 `parser/hwp3` 입니다.
이 PR 은 `parser/hml`·`serializer/hml`·`renderer/*`·`paint/json.rs` 만 건드립니다.
