### PR TITLE
fix(cli): edit 계열이 HWPX 입력을 HWP5 로 강제 산출 — 입력 형식 보존 + 호환 어댑터 누락 (#3383)

### DIFF
--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -2,7 +2,7 @@
 kind: canonical
 status: active
 canonical: mydocs/manual/cli_commands.md
-last_verified: 2026-07-28
+last_verified: 2026-07-29
 ---
 
 # rhwp CLI 명령어 매뉴얼
@@ -382,11 +382,11 @@ rhwp fields 신청서.hwp --json | jq -r '.fields[] | "\(.name): \(.memo // .gui
 레이아웃·구조는 불변**이다.
 - `--data <JSON|@파일>` — `{"필드이름":"값"}` 형식. `@경로` 면 파일에서 읽는다
   (대량 메일머지에서 셸 인용을 피한다). 값이 문자열이 아니면 JSON 표현으로 넣는다.
-- `-o, --output <파일>` — 출력 파일 (기본 `<입력명>_filled.hwp`)
+- `-o, --output <파일>` — 출력 파일 (기본 `<입력명>_filled.<입력과 같은 확장자>`, §edit 산출 형식)
 - `--dry-run` — **파일을 쓰지 않고** 변경 예정 내역만 보고. 에이전트의 사전 확인 장치.
-- `--json` 봉투: `{"schemaVersion":"1.0","source","dryRun","filledCount","filled":[{name,value}],"notFound":[…],"output"?}`
+- `--json` 봉투: `{"schemaVersion":"1.0","source","dryRun","filledCount","filled":[{name,value}],"notFound":[…],"output"?,"outputFormat"?}`
   - `notFound` — 문서에 없는 필드 이름. 조용히 무시하지 않으므로 오타를 즉시 안다.
-  - `output` 은 실제 저장했을 때만 실린다(`--dry-run` 이면 없음).
+  - `output`/`outputFormat` 은 실제 저장했을 때만 실린다(`--dry-run` 이면 없음).
 - **실패 시 원본 불변**: 필드 설정이 하나라도 실패하면 출력 파일을 쓰지 않고 종료 코드 1.
 - 종료 코드는 §종료 코드 계약 (없는 파일·직렬화/쓰기 실패 1 · 인자/JSON 오류 2)
 
@@ -403,10 +403,10 @@ rhwp fields out.hwp --json | jq -c '[.fields[]|select(.value!="")|{name,value}]'
 - `--find <문자열>` — 찾을 문자열 (빈 문자열은 exit 2)
 - `--replace <문자열>` — 바꿀 문자열 (`""` 이면 삭제)
 - `--ignore-case` — 대소문자 무시
-- `-o, --output <파일>` — 출력 파일 (기본 `<입력명>_replaced.hwp`)
+- `-o, --output <파일>` — 출력 파일 (기본 `<입력명>_replaced.<입력과 같은 확장자>`, §edit 산출 형식)
 - `--dry-run` — **파일을 쓰지 않고** 읽기 전용 검색으로 치환 예정 건수만 보고
-- `--json` 봉투: `{"schemaVersion":"1.0","source","find","replace","caseSensitive","dryRun","replacedCount","output"?}`
-  - `output` 은 실제 저장했을 때만 실린다 — **치환 0건이면 출력 파일을 만들지 않는다**
+- `--json` 봉투: `{"schemaVersion":"1.0","source","find","replace","caseSensitive","dryRun","replacedCount","output"?,"outputFormat"?}`
+  - `output`/`outputFormat` 은 실제 저장했을 때만 실린다 — **치환 0건이면 출력 파일을 만들지 않는다**
     (무변경 산출물 금지, dry-run 과 동일하게 파일 경로를 타지 않음).
 - **실패 시 원본 불변**: 치환·직렬화·쓰기 실패 시 출력 파일 없이 종료 코드 1.
 
@@ -424,18 +424,34 @@ rhwp search 개정본.hwp "2025년" --json | jq .matchCount     # → 0 이어�
 - `--text <문자열>` — 셀에 넣을 값. 빈 문자열은 비우기이며 줄바꿈·탭은 v1에서 허용하지 않는다.
 - `--keep-style` — 셀 안내문의 글자 모양을 유지한다. 기본은 검정·비이탤릭·비진하게로 기록해,
   제출용 양식의 파란 안내문 스타일을 실값이 상속하지 않게 한다 (#3391).
-- `-o, --output <파일>` — 출력 파일 (기본 `<입력명>_cell.hwp`)
+- `-o, --output <파일>` — 출력 파일 (기본 `<입력명>_cell.<입력과 같은 확장자>`, §edit 산출 형식)
 - `--dry-run` — 파일을 쓰지 않고 `oldText` → `newText` 변경 예정만 보고한다.
-- `--json` 봉투: `{"schemaVersion":"1.0","source","table","row","col","oldText","newText","dryRun","keepStyle","output"?}`
+- `--json` 봉투: `{"schemaVersion":"1.0","source","table","row","col","oldText","newText","dryRun","keepStyle","output"?,"outputFormat"?}`
 - 병합으로 덮인 칸은 앵커 좌표를 안내하며 exit 2로 끝난다. 격자 밖 좌표도 exit 2다.
 - 실패 시 원본은 불변이며, v1 범위는 본문 최상위 표와 셀 첫 문단이다.
 
 ```bash
 # 발견 → 기록 → 재독 검증
 rhwp export-tables 양식.hwpx --json | jq '.tables[0].cells[:4]'
-rhwp edit set-cell 양식.hwpx --table 0 --row 2 --col 1 --text "1,234" -o 작성본.hwp --json
-rhwp export-tables 작성본.hwp --json | jq '.tables[0].cells[] | select(.row==2 and .col==1).text'
+rhwp edit set-cell 양식.hwpx --table 0 --row 2 --col 1 --text "1,234" -o 작성본.hwpx --json
+rhwp export-tables 작성본.hwpx --json | jq '.tables[0].cells[] | select(.row==2 and .col==1).text'
 ```
+
+### `edit` 산출 형식 (#3383)
+`edit` 3종(`fill-fields`/`replace-text`/`set-cell`)은 **입력 형식을 보존**한다.
+
+- HWPX 입력 → HWPX 산출(`export_hwpx_native`), 기본 확장자도 `.hwpx`
+- 그 밖의 입력(HWP5/HWP3) → HWP5 산출. 이때 직렬화는 **어댑터 경유**
+  (`export_hwp_with_adapter`)라 HWPX→HWP IR 매핑(#178)을 건너뛰지 않는다.
+- `--json` 봉투의 `outputFormat` 이 실제 저장 형식을 보고한다. 값은 `info --json` 의
+  `format` 과 같은 어휘(`"hwp5"`/`"hwpx"`)라 두 봉투를 그대로 대조할 수 있다.
+- 예외 하나: HWPX 입력에 `-o ….hwp` 를 **명시**하면 그 경로를 그대로 존중해 HWP5 로
+  저장하되(기존 스크립트 호환), 형식이 바뀐다는 사실과 이미지·차트 유실 가능성을
+  stderr 로 경고한다. 반대로 HWP 입력에 `-o ….hwpx` 를 줘도 형식은 바뀌지 않으며
+  (경고만 출력) 형식 변환은 `export-hwpx` 가 담당한다.
+
+종전에는 세 명령 모두 HWP5 를 강제 산출해 HWPX 양식이 조용히 `.hwp` 로 바뀌었고,
+어댑터 없는 경로라 실물 정부 양식에서 차트·이미지 페이지가 유실됐다(#3383).
 
 ---
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -385,24 +385,24 @@ fn show_mcp_tools() -> i32 {
         ),
         tool(
             "hwp_fill_fields",
-            "HWP 서식(템플릿)의 누름틀에 값을 채워 새 문서를 만든다. 먼저 hwp_fields 로 어떤 필드가 있는지 확인한 뒤 사용한다. dryRun 으로 파일을 만들지 않고 변경 예정만 확인할 수 있다.",
+            "HWP 서식(템플릿)의 누름틀에 값을 채워 새 문서를 만든다. 먼저 hwp_fields 로 어떤 필드가 있는지 확인한 뒤 사용한다. dryRun 으로 파일을 만들지 않고 변경 예정만 확인할 수 있다. 산출물은 입력 형식을 따른다(HWPX 입력 → HWPX 산출).",
             serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "path": { "type": "string", "description": "입력 HWP 문서 경로" },
+                    "path": { "type": "string", "description": "입력 HWP/HWPX 문서 경로" },
                     "data": {
                         "type": "object",
                         "additionalProperties": { "type": "string" },
                         "description": "{\"필드이름\":\"값\"} 형태의 채울 값"
                     },
-                    "output": { "type": "string", "description": "출력 파일 경로. 생략하면 <입력명>_filled.hwp" },
+                    "output": { "type": "string", "description": "출력 파일 경로. 생략하면 <입력명>_filled.hwp (HWPX 입력이면 _filled.hwpx)" },
                     "dryRun": { "type": "boolean", "description": "true 면 파일을 쓰지 않고 변경 예정만 보고" }
                 },
                 "required": ["path", "data"],
             }),
             "edit",
             serde_json::json!(["edit", "fill-fields", "{path}", "--data", "{data}", "--json"]),
-            &["schemaVersion", "source", "dryRun", "filledCount", "filled", "notFound", "output"],
+            &["schemaVersion", "source", "dryRun", "filledCount", "filled", "notFound", "output", "outputFormat"],
         ),
         tool(
             "hwp_batch_search",
@@ -434,25 +434,25 @@ fn show_mcp_tools() -> i32 {
         ),
         tool(
             "hwp_replace_text",
-            "HWP 문서 전체에서 문자열을 일괄 치환해 새 문서를 만든다 (기관명 변경·연도 갱신·용어 정비). dryRun 으로 파일을 만들지 않고 치환 예정 건수만 확인할 수 있다. 치환 0건이면 출력 파일을 만들지 않는다.",
+            "HWP 문서 전체에서 문자열을 일괄 치환해 새 문서를 만든다 (기관명 변경·연도 갱신·용어 정비). dryRun 으로 파일을 만들지 않고 치환 예정 건수만 확인할 수 있다. 치환 0건이면 출력 파일을 만들지 않는다. 산출물은 입력 형식을 따른다(HWPX 입력 → HWPX 산출).",
             serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "path": { "type": "string", "description": "입력 HWP 문서 경로" },
+                    "path": { "type": "string", "description": "입력 HWP/HWPX 문서 경로" },
                     "find": { "type": "string", "description": "찾을 문자열 (빈 문자열 불가)" },
                     "replace": { "type": "string", "description": "바꿀 문자열 (빈 문자열이면 삭제)" },
-                    "output": { "type": "string", "description": "출력 파일 경로. 생략하면 <입력명>_replaced.hwp" },
+                    "output": { "type": "string", "description": "출력 파일 경로. 생략하면 <입력명>_replaced.hwp (HWPX 입력이면 _replaced.hwpx)" },
                     "dryRun": { "type": "boolean", "description": "true 면 파일을 쓰지 않고 치환 예정 건수만 보고" }
                 },
                 "required": ["path", "find", "replace"],
             }),
             "edit",
             serde_json::json!(["edit", "replace-text", "{path}", "--find", "{find}", "--replace", "{replace}", "--json"]),
-            &["schemaVersion", "source", "find", "replace", "caseSensitive", "dryRun", "replacedCount", "output"],
+            &["schemaVersion", "source", "find", "replace", "caseSensitive", "dryRun", "replacedCount", "output", "outputFormat"],
         ),
         tool(
             "hwp_set_cell",
-            "HWP 표의 격자 좌표(hwp_export_tables 와 동일)로 셀 값을 바꿔 새 문서를 만든다 — 누름틀 없는 실물 표 양식 채우기. 먼저 hwp_export_tables 로 좌표를 확인한 뒤 사용한다. 병합으로 덮인 칸은 앵커 좌표를 안내하며 실패한다.",
+            "HWP 표의 격자 좌표(hwp_export_tables 와 동일)로 셀 값을 바꿔 새 문서를 만든다 — 누름틀 없는 실물 표 양식 채우기. 먼저 hwp_export_tables 로 좌표를 확인한 뒤 사용한다. 병합으로 덮인 칸은 앵커 좌표를 안내하며 실패한다. 산출물은 입력 형식을 따른다(HWPX 입력 → HWPX 산출).",
             serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -461,14 +461,14 @@ fn show_mcp_tools() -> i32 {
                     "row": { "type": "integer", "minimum": 0, "description": "행 (0부터)" },
                     "col": { "type": "integer", "minimum": 0, "description": "열 (0부터)" },
                     "text": { "type": "string", "description": "셀에 넣을 값 (빈 문자열이면 비우기)" },
-                    "output": { "type": "string", "description": "출력 파일 경로. 생략하면 <입력명>_cell.hwp" },
+                    "output": { "type": "string", "description": "출력 파일 경로. 생략하면 <입력명>_cell.hwp (HWPX 입력이면 _cell.hwpx)" },
                     "dryRun": { "type": "boolean", "description": "true 면 파일을 쓰지 않고 old→new 만 보고" }
                 },
                 "required": ["path", "table", "row", "col", "text"],
             }),
             "edit",
             serde_json::json!(["edit", "set-cell", "{path}", "--table", "{table}", "--row", "{row}", "--col", "{col}", "--text", "{text}", "--json"]),
-            &["schemaVersion", "source", "table", "row", "col", "oldText", "newText", "dryRun", "output"],
+            &["schemaVersion", "source", "table", "row", "col", "oldText", "newText", "dryRun", "output", "outputFormat"],
         ),
     ];
 
@@ -722,6 +722,7 @@ fn show_capabilities(args: &[String]) -> i32 {
                 "newText",
                 "keepStyle",
                 "output",
+                "outputFormat",
             ],
         ),
         // ── 배치 ──
@@ -1086,21 +1087,25 @@ fn print_help() {
     println!();
     println!("      --json                    계약 봉투 JSON을 stdout에 출력");
     println!();
-    println!("  edit fill-fields <파일.hwp> --data <JSON|@파일> [-o <출력.hwp>] [옵션]");
+    println!("  edit fill-fields <파일.hwp|파일.hwpx> --data <JSON|@파일> [-o <출력>] [옵션]");
     println!("      누름틀에 값을 채운다 (서식 자동 작성/메일머지)");
     println!();
     println!("      --data <JSON|@파일>       {{\"필드이름\":\"값\"}} 형식. @경로면 파일에서 읽음");
-    println!("      -o, --output <파일>       출력 파일 (기본: 입력명_filled.hwp)");
+    println!(
+        "      -o, --output <파일>       출력 파일 (기본: 입력명_filled.<입력과 같은 확장자>)"
+    );
     println!("      --dry-run                 파일을 쓰지 않고 변경 예정 내역만 보고");
     println!("      --json                    계약 봉투 JSON을 stdout에 출력");
     println!();
-    println!("  edit replace-text <파일.hwp> --find <문자열> --replace <문자열> [옵션]");
+    println!("  edit replace-text <파일.hwp|파일.hwpx> --find <문자열> --replace <문자열> [옵션]");
     println!("      문서 전체 일괄 치환 (기관명 변경·연도 갱신·용어 정비). 본문+표 셀");
     println!();
     println!("      --find <문자열>           찾을 문자열 (빈 문자열 불가)");
     println!("      --replace <문자열>        바꿀 문자열 (\"\" 이면 삭제)");
     println!("      --ignore-case             대소문자 무시");
-    println!("      -o, --output <파일>       출력 파일 (기본: 입력명_replaced.hwp)");
+    println!(
+        "      -o, --output <파일>       출력 파일 (기본: 입력명_replaced.<입력과 같은 확장자>)"
+    );
     println!("      --dry-run                 파일을 쓰지 않고 치환 예정 건수만 보고");
     println!("      --json                    계약 봉투 JSON을 stdout에 출력");
     println!("      치환 0건이면 출력 파일을 만들지 않음");
@@ -1111,10 +1116,14 @@ fn print_help() {
     println!("      --table/--row/--col       export-tables 격자와 같은 좌표 (0부터)");
     println!("      --text <문자열>           셀에 넣을 값 (비우기는 \"\", 줄바꿈·탭 불가)");
     println!("      --keep-style              셀 안내문 스타일 상속(기본: 검정 글씨로 기록)");
-    println!("      -o, --output <파일>       출력 파일 (기본: 입력명_cell.hwp)");
+    println!("      -o, --output <파일>       출력 파일 (기본: 입력명_cell.<입력과 같은 확장자>)");
     println!("      --dry-run                 파일을 쓰지 않고 old→new 만 보고");
     println!("      --json                    계약 봉투 JSON을 stdout에 출력");
     println!("      병합으로 덮인 칸은 앵커 좌표 안내와 함께 오류 종료");
+    println!();
+    println!("      edit 3종 공통: 산출물은 **입력 형식을 보존**한다 (HWPX 입력 → HWPX 산출).");
+    println!("      HWPX 입력에 -o ….hwp 를 지정하면 그 경로를 존중해 HWP5 로 저장하되");
+    println!("      형식 변경(이미지·차트 유실 가능)을 stderr 로 경고한다.");
     println!();
     println!("내부 개발·회귀 도구 (일반 사용자 대상 아님):");
     println!("  test-caption <파일.hwp> [-o <폴더>] 캡션 라운드트립 검증");
@@ -8297,7 +8306,7 @@ fn collect_field_records(doc: &rhwp::wasm_api::HwpDocument) -> Vec<serde_json::V
 /// **실패 시 원본 불변**(하나라도 실패하면 출력 파일을 쓰지 않는다).
 fn run_edit(args: &[String]) -> i32 {
     const USAGE: &str =
-        "사용법: rhwp edit <fill-fields|replace-text|set-cell> <파일.hwp> [옵션] (rhwp --help 참조)";
+        "사용법: rhwp edit <fill-fields|replace-text|set-cell> <파일.hwp|파일.hwpx> [옵션] (rhwp --help 참조)";
 
     match args.first().map(String::as_str) {
         Some("fill-fields") => edit_fill_fields(&args[1..]),
@@ -8314,6 +8323,92 @@ fn run_edit(args: &[String]) -> i32 {
             EXIT_USAGE
         }
     }
+}
+
+/// `edit` 계열 산출 형식 (#3383).
+///
+/// 종전에는 세 하위 명령이 모두 `export_hwp_native()` 로 HWP5 를 강제 산출했다. 그래서
+/// ① HWPX 입력이 조용히 `.hwp` 로 바뀌고(형식 미보존) ② 어댑터 없는 native 경로라
+/// HWPX→HWP IR 매핑(#178)조차 타지 않아 산출물에서 차트·이미지가 유실됐다.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum EditOutputFormat {
+    Hwp,
+    Hwpx,
+}
+
+impl EditOutputFormat {
+    /// 기본 산출 파일의 확장자(점 제외).
+    fn ext(self) -> &'static str {
+        match self {
+            EditOutputFormat::Hwp => "hwp",
+            EditOutputFormat::Hwpx => "hwpx",
+        }
+    }
+
+    /// JSON 봉투의 `outputFormat` 값. **`info --json` 의 `format` 과 같은 어휘**를 쓴다 —
+    /// 확장자(`hwp`)가 아니라 형식 이름(`hwp5`)이라야 두 봉투를 그대로 대조할 수 있다.
+    fn label(self) -> &'static str {
+        match self {
+            EditOutputFormat::Hwp => "hwp5",
+            EditOutputFormat::Hwpx => "hwpx",
+        }
+    }
+}
+
+/// 입력 형식과 사용자가 지정한 `-o` 경로로 `edit` 산출 형식을 정한다 (#3383).
+///
+/// 기본은 **입력 형식 보존**이다 — HWPX 입력은 HWPX 로, 그 외(HWP5/HWP3)는 HWP5 로.
+/// 예외는 하나뿐이다: HWPX 입력에 사용자가 `-o ….hwp` 를 명시한 경우. 이때는 지정한
+/// **경로를 그대로 존중해** HWP5 로 저장하되(기존 스크립트 호환), 형식이 바뀐다는 사실과
+/// 손실 가능성을 stderr 로 알린다(이슈 제안 2의 과도기 경고).
+///
+/// 반대 방향(HWP 입력에 `-o ….hwpx`)은 `edit` 의 책임이 아니다 — 형식 변환은
+/// `rhwp export-hwpx` 가 담당한다. 여기서는 경고만 하고 형식을 바꾸지 않는다.
+fn edit_output_format(input_bytes: &[u8], explicit_out: Option<&str>) -> EditOutputFormat {
+    let source_is_hwpx = matches!(
+        rhwp::parser::detect_format(input_bytes),
+        rhwp::parser::FileFormat::Hwpx
+    );
+    let explicit_ext = explicit_out.and_then(|path| {
+        Path::new(path)
+            .extension()
+            .map(|ext| ext.to_string_lossy().to_ascii_lowercase())
+    });
+
+    match (source_is_hwpx, explicit_ext.as_deref()) {
+        (true, Some("hwp")) => {
+            eprintln!(
+                "경고: 입력은 HWPX 인데 출력 확장자가 .hwp 라 HWP5 로 저장합니다 — \
+                 형식 변환 과정에서 차트·이미지 등이 유실될 수 있습니다 \
+                 (형식을 보존하려면 -o 를 생략하거나 .hwpx 로 지정하세요)."
+            );
+            EditOutputFormat::Hwp
+        }
+        (true, _) => EditOutputFormat::Hwpx,
+        (false, Some("hwpx")) => {
+            eprintln!(
+                "경고: 입력이 HWPX 가 아니므로 HWP5 로 저장합니다 — 지정한 출력 확장자(.hwpx)와 \
+                 실제 형식이 다릅니다 (HWPX 로 변환하려면 `rhwp export-hwpx` 를 쓰세요)."
+            );
+            EditOutputFormat::Hwp
+        }
+        (false, _) => EditOutputFormat::Hwp,
+    }
+}
+
+/// 결정된 형식으로 편집 결과를 직렬화한다 (#3383).
+///
+/// HWP5 산출은 반드시 **어댑터 경유**(`export_hwp_with_adapter`)다. HWPX 출처 IR 을 HWP
+/// 호환 형태로 옮기는 #178 어댑터를 건너뛰면 한컴 호환성과 이미지·차트가 깨진다.
+fn edit_serialize(
+    doc: &mut rhwp::wasm_api::HwpDocument,
+    format: EditOutputFormat,
+) -> Result<Vec<u8>, String> {
+    match format {
+        EditOutputFormat::Hwpx => doc.export_hwpx_native(),
+        EditOutputFormat::Hwp => doc.export_hwp_with_adapter(),
+    }
+    .map_err(|e| e.to_string())
 }
 
 /// `edit fill-fields` — 누름틀에 값을 채운다 (메일머지).
@@ -8362,7 +8457,7 @@ fn edit_fill_fields(args: &[String]) -> i32 {
     }
 
     let (Some(file_path), Some(data_arg)) = (file_path, data_arg) else {
-        eprintln!("사용법: rhwp edit fill-fields <파일.hwp> --data <JSON|@파일> [-o <출력.hwp>] [--dry-run] [--json]");
+        eprintln!("사용법: rhwp edit fill-fields <파일.hwp|파일.hwpx> --data <JSON|@파일> [-o <출력>] [--dry-run] [--json]");
         return EXIT_USAGE;
     };
 
@@ -8439,6 +8534,8 @@ fn edit_fill_fields(args: &[String]) -> i32 {
         filled.push(serde_json::json!({ "name": name, "value": value_str }));
     }
 
+    // [#3383] 입력 형식을 보존한다 — 기본 확장자도 산출 형식을 따른다.
+    let out_format = edit_output_format(&bytes, out_path.as_deref());
     let output_path = out_path.unwrap_or_else(|| {
         // [#3469] 기본 산출물은 **입력 파일 옆**에 만든다. 종전에는 파일명만 써서
         // 현재 작업 디렉터리에 떨어졌는데, 임의 경로의 문서를 다루는 에이전트·MCP
@@ -8448,7 +8545,7 @@ fn edit_fill_fields(args: &[String]) -> i32 {
             .file_stem()
             .map(|s| s.to_string_lossy().to_string())
             .unwrap_or_else(|| "output".to_string());
-        let name = format!("{}_filled.hwp", stem);
+        let name = format!("{}_filled.{}", stem, out_format.ext());
         match input.parent() {
             Some(dir) if !dir.as_os_str().is_empty() => {
                 dir.join(name).to_string_lossy().to_string()
@@ -8458,10 +8555,14 @@ fn edit_fill_fields(args: &[String]) -> i32 {
     });
 
     if !dry_run {
-        let out_bytes = match doc.export_hwp_native() {
+        let out_bytes = match edit_serialize(&mut doc, out_format) {
             Ok(b) => b,
             Err(e) => {
-                eprintln!("오류: HWP 직렬화 실패 - {}", e);
+                eprintln!(
+                    "오류: {} 직렬화 실패 - {}",
+                    out_format.label().to_uppercase(),
+                    e
+                );
                 return EXIT_RUNTIME;
             }
         };
@@ -8482,6 +8583,7 @@ fn edit_fill_fields(args: &[String]) -> i32 {
         });
         if !dry_run {
             envelope["output"] = serde_json::Value::String(output_path.clone());
+            envelope["outputFormat"] = serde_json::Value::String(out_format.label().to_string());
         }
         println!("{envelope}");
         return EXIT_OK;
@@ -8577,7 +8679,7 @@ fn edit_replace_text(args: &[String]) -> i32 {
 
     let (Some(file_path), Some(find), Some(replace)) = (file_path, find_arg, replace_arg) else {
         eprintln!(
-            "사용법: rhwp edit replace-text <파일.hwp> --find <문자열> --replace <문자열> [-o <출력.hwp>] [--ignore-case] [--dry-run] [--json]"
+            "사용법: rhwp edit replace-text <파일.hwp|파일.hwpx> --find <문자열> --replace <문자열> [-o <출력>] [--ignore-case] [--dry-run] [--json]"
         );
         return EXIT_USAGE;
     };
@@ -8619,21 +8721,27 @@ fn edit_replace_text(args: &[String]) -> i32 {
             .unwrap_or(0) as usize
     };
 
+    // [#3383] 입력 형식을 보존한다 — 기본 확장자도 산출 형식을 따른다.
+    let out_format = edit_output_format(&bytes, out_path.as_deref());
     let output_path = out_path.unwrap_or_else(|| {
         let stem = Path::new(file_path)
             .file_stem()
             .map(|s| s.to_string_lossy().to_string())
             .unwrap_or_else(|| "output".to_string());
-        format!("{}_replaced.hwp", stem)
+        format!("{}_replaced.{}", stem, out_format.ext())
     });
 
     // 0건이면 무변경이다 — 산출물을 만들지 않는다 (dry-run 과 동일하게 파일 경로를 타지 않음).
     let wrote_output = !dry_run && replaced_count > 0;
     if wrote_output {
-        let out_bytes = match doc.export_hwp_native() {
+        let out_bytes = match edit_serialize(&mut doc, out_format) {
             Ok(b) => b,
             Err(e) => {
-                eprintln!("오류: HWP 직렬화 실패 - {}", e);
+                eprintln!(
+                    "오류: {} 직렬화 실패 - {}",
+                    out_format.label().to_uppercase(),
+                    e
+                );
                 return EXIT_RUNTIME;
             }
         };
@@ -8655,6 +8763,7 @@ fn edit_replace_text(args: &[String]) -> i32 {
         });
         if wrote_output {
             envelope["output"] = serde_json::Value::String(output_path.clone());
+            envelope["outputFormat"] = serde_json::Value::String(out_format.label().to_string());
         }
         println!("{envelope}");
         return EXIT_OK;
@@ -9029,19 +9138,25 @@ fn edit_set_cell(args: &[String]) -> i32 {
         }
     }
 
+    // [#3383] 입력 형식을 보존한다 — 기본 확장자도 산출 형식을 따른다.
+    let out_format = edit_output_format(&bytes, out_path.as_deref());
     let output_path = out_path.unwrap_or_else(|| {
         let stem = Path::new(file_path)
             .file_stem()
             .map(|s| s.to_string_lossy().to_string())
             .unwrap_or_else(|| "output".to_string());
-        format!("{}_cell.hwp", stem)
+        format!("{}_cell.{}", stem, out_format.ext())
     });
 
     if !dry_run {
-        let out_bytes = match doc.export_hwp_native() {
+        let out_bytes = match edit_serialize(&mut doc, out_format) {
             Ok(b) => b,
             Err(e) => {
-                eprintln!("오류: HWP 직렬화 실패 - {}", e);
+                eprintln!(
+                    "오류: {} 직렬화 실패 - {}",
+                    out_format.label().to_uppercase(),
+                    e
+                );
                 return EXIT_RUNTIME;
             }
         };
@@ -9065,6 +9180,7 @@ fn edit_set_cell(args: &[String]) -> i32 {
         });
         if !dry_run {
             envelope["output"] = serde_json::Value::String(output_path.clone());
+            envelope["outputFormat"] = serde_json::Value::String(out_format.label().to_string());
         }
         println!("{envelope}");
         return EXIT_OK;

--- a/tests/edit_format_preserve_contract.rs
+++ b/tests/edit_format_preserve_contract.rs
@@ -1,0 +1,434 @@
+//! [#3383] `edit` 3종의 **산출 형식 보존** 계약 회귀 테스트.
+//!
+//! 종전에는 `fill-fields`/`replace-text`/`set-cell` 이 모두 `export_hwp_native()` 로 HWP5 를
+//! 강제 산출했다. 그래서 ① HWPX 입력이 조용히 `.hwp` 로 바뀌고 ② 어댑터 없는 native
+//! 경로라 HWPX→HWP IR 매핑(#178)조차 타지 않아 실물 양식에서 차트·이미지가 유실됐다.
+//!
+//! 계약: ① HWPX 입력 → HWPX 산출이고 **다시 읽어도** HWPX 다 ② HWP 입력은 종전대로
+//! HWP5 다 ③ 확장자가 어긋나는 `-o` 는 **경로를 그대로 존중**하고 stderr 로 경고한다.
+//! 형식 판정은 확장자가 아니라 `info --json` 의 `format`(바이트 감지)으로 확인한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// 누름틀(이름 있는 CLICK_HERE)·표·본문 텍스트를 모두 가진 실물 HWPX 별지 서식.
+/// 한 샘플로 세 하위 명령을 모두 돌릴 수 있다.
+const HWPX_SAMPLE: &str = "samples/issue1893_clickhere_field_roundtrip.hwpx";
+/// 비교군 HWP5 — 종전 동작(HWP5 산출)이 그대로인지 확인한다.
+const HWP_SAMPLE: &str = "samples/field-01.hwp";
+/// HWPX 본문에 실재하는 문자열(치환 대상).
+const HWPX_NEEDLE: &str = "검찰청";
+/// HWP5 본문에 실재하는 문자열(치환 대상) — `edit_replace_text_contract` 와 같은 낱말.
+const HWP_NEEDLE: &str = "회사";
+
+fn sample(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+/// 기본 산출 경로 계약을 그대로 재보려면 **입력을 임시 폴더로 복사**해야 한다.
+/// `fill-fields` 는 산출물을 입력 파일 옆에(#3469), 나머지 둘은 실행 디렉터리에 만들기
+/// 때문에 저장소 안에서 그냥 돌리면 `samples/`·저장소 루트가 더러워진다.
+struct Workdir {
+    dir: PathBuf,
+}
+
+impl Workdir {
+    fn new(tag: &str) -> Workdir {
+        let dir = std::env::temp_dir().join(format!(
+            "rhwp-fmt-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("임시 작업 폴더 생성");
+        Workdir { dir }
+    }
+
+    /// 샘플을 고정된 이름으로 복사해 기본 산출 이름을 예측 가능하게 만든다.
+    fn copy_in(&self, rel: &str, name: &str) -> PathBuf {
+        let dst = self.dir.join(name);
+        std::fs::copy(sample(rel), &dst).expect("샘플 복사");
+        dst
+    }
+
+    fn path(&self, name: &str) -> PathBuf {
+        self.dir.join(name)
+    }
+}
+
+impl Drop for Workdir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+/// nextest archive 는 런타임에 `CARGO_BIN_EXE_rhwp` 를 주입한다(#3289) — 그 값을 먼저 읽고
+/// 컴파일타임 값을 fallback 으로 쓴다.
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}
+
+/// 임시 작업 폴더를 현재 디렉터리로 삼아 실행한다 — 기본 산출물이 그 안에 떨어진다.
+fn run_in(dir: &Path, args: &[&str]) -> Output {
+    Command::new(rhwp_bin())
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn parse_json(args: &[&str], output: &Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout 이 순수 JSON 이 아닙니다 ({e}).\n{}",
+            describe(args, output)
+        )
+    })
+}
+
+fn run_ok(dir: &Path, args: &[&str]) -> serde_json::Value {
+    let output = run_in(dir, args);
+    assert_eq!(output.status.code(), Some(0), "{}", describe(args, &output));
+    parse_json(args, &output)
+}
+
+/// 산출물을 **다시 읽어** 실제 형식을 얻는다 — 확장자가 아니라 파서의 판정이다.
+fn format_of(dir: &Path, path: &Path) -> String {
+    let args = ["info", path.to_str().unwrap(), "--json"];
+    run_ok(dir, &args)["format"]
+        .as_str()
+        .expect("info 봉투의 format")
+        .to_string()
+}
+
+/// 이름이 있는 첫 누름틀을 고른다 — 샘플의 필드 이름을 테스트에 박아 넣지 않는다.
+fn first_field_name(dir: &Path, path: &Path) -> String {
+    let args = ["fields", path.to_str().unwrap(), "--json"];
+    run_ok(dir, &args)["fields"]
+        .as_array()
+        .expect("fields 배열")
+        .iter()
+        .filter_map(|f| f["name"].as_str())
+        .find(|name| !name.is_empty())
+        .expect("이름 있는 누름틀")
+        .to_string()
+}
+
+/// 본문 최상위 표(containerPath 없음)의 첫 셀 좌표 — `edit_set_cell_contract` 와 같은 방식.
+fn first_body_cell(dir: &Path, path: &Path) -> (u64, u64, u64) {
+    let args = ["export-tables", path.to_str().unwrap(), "--json"];
+    let v = run_ok(dir, &args);
+    let table = v["tables"]
+        .as_array()
+        .expect("tables 배열")
+        .iter()
+        .find(|t| t.get("containerPath").is_none())
+        .expect("본문 최상위 표");
+    let cell = &table["cells"][0];
+    (
+        table["index"].as_u64().expect("index"),
+        cell["row"].as_u64().expect("row"),
+        cell["col"].as_u64().expect("col"),
+    )
+}
+
+/// HWPX 입력 + `-o` 생략 → 기본 산출물이 `.hwpx` 이고 재독 형식도 HWPX 다.
+#[test]
+fn fill_fields_hwpx_input_defaults_to_hwpx_output() {
+    let work = Workdir::new("fill");
+    let input = work.copy_in(HWPX_SAMPLE, "input.hwpx");
+    let field = first_field_name(&work.dir, &input);
+    let mut data_map = serde_json::Map::new();
+    data_map.insert(field, serde_json::Value::String("형식보존".to_string()));
+    let data = serde_json::Value::Object(data_map).to_string();
+
+    let args = [
+        "edit",
+        "fill-fields",
+        input.to_str().unwrap(),
+        "--data",
+        &data,
+        "--json",
+    ];
+    let v = run_ok(&work.dir, &args);
+    assert_eq!(v["outputFormat"], "hwpx", "{v}");
+    assert_eq!(v["filledCount"].as_u64(), Some(1), "{v}");
+
+    let out = work.path("input_filled.hwpx");
+    assert!(
+        out.exists(),
+        "HWPX 입력의 기본 산출은 .hwpx 여야 합니다: {v}"
+    );
+    assert!(
+        !work.path("input_filled.hwp").exists(),
+        "HWP5 산출물이 생기면 안 됩니다"
+    );
+    assert_eq!(format_of(&work.dir, &out), "hwpx", "재독 형식 불일치");
+}
+
+/// HWPX 입력 + `-o` 생략 → `_replaced.hwpx`, 재독 형식 HWPX.
+#[test]
+fn replace_text_hwpx_input_defaults_to_hwpx_output() {
+    let work = Workdir::new("replace");
+    let input = work.copy_in(HWPX_SAMPLE, "input.hwpx");
+
+    let args = [
+        "edit",
+        "replace-text",
+        input.to_str().unwrap(),
+        "--find",
+        HWPX_NEEDLE,
+        "--replace",
+        "지방청",
+        "--json",
+    ];
+    let v = run_ok(&work.dir, &args);
+    assert!(
+        v["replacedCount"].as_u64().unwrap_or(0) >= 1,
+        "샘플에 치환 대상이 있어야 합니다: {v}"
+    );
+    assert_eq!(v["outputFormat"], "hwpx", "{v}");
+
+    let out = work.path("input_replaced.hwpx");
+    assert!(
+        out.exists(),
+        "HWPX 입력의 기본 산출은 .hwpx 여야 합니다: {v}"
+    );
+    assert!(
+        !work.path("input_replaced.hwp").exists(),
+        "HWP5 산출물이 생기면 안 됩니다"
+    );
+    assert_eq!(format_of(&work.dir, &out), "hwpx", "재독 형식 불일치");
+
+    // 형식만 보존하고 편집이 날아가면 의미가 없다 — 원문 0건을 재독으로 확인한다.
+    let searched = run_ok(
+        &work.dir,
+        &["search", out.to_str().unwrap(), HWPX_NEEDLE, "--json"],
+    );
+    assert_eq!(searched["matchCount"].as_u64(), Some(0), "{searched}");
+}
+
+/// HWPX 입력 + `-o` 생략 → `_cell.hwpx`, 재독 형식 HWPX, 셀 값도 살아 있다.
+#[test]
+fn set_cell_hwpx_input_defaults_to_hwpx_output() {
+    let work = Workdir::new("setcell");
+    let input = work.copy_in(HWPX_SAMPLE, "input.hwpx");
+    let (table, row, col) = first_body_cell(&work.dir, &input);
+    let (ts, rs, cs) = (table.to_string(), row.to_string(), col.to_string());
+    let new_value = "형식보존셀";
+
+    let args = [
+        "edit",
+        "set-cell",
+        input.to_str().unwrap(),
+        "--table",
+        &ts,
+        "--row",
+        &rs,
+        "--col",
+        &cs,
+        "--text",
+        new_value,
+        "--json",
+    ];
+    let v = run_ok(&work.dir, &args);
+    assert_eq!(v["outputFormat"], "hwpx", "{v}");
+
+    let out = work.path("input_cell.hwpx");
+    assert!(
+        out.exists(),
+        "HWPX 입력의 기본 산출은 .hwpx 여야 합니다: {v}"
+    );
+    assert!(
+        !work.path("input_cell.hwp").exists(),
+        "HWP5 산출물이 생기면 안 됩니다"
+    );
+    assert_eq!(format_of(&work.dir, &out), "hwpx", "재독 형식 불일치");
+
+    // 같은 좌표를 재독해 기록이 HWPX 왕복에서 살아남았는지 대조한다.
+    let after = run_ok(
+        &work.dir,
+        &["export-tables", out.to_str().unwrap(), "--json"],
+    );
+    let cell = after["tables"]
+        .as_array()
+        .expect("tables 배열")
+        .iter()
+        .find(|t| t["index"].as_u64() == Some(table))
+        .expect("같은 index 표")["cells"]
+        .as_array()
+        .expect("cells 배열")
+        .iter()
+        .find(|c| c["row"].as_u64() == Some(row) && c["col"].as_u64() == Some(col))
+        .expect("좌표 셀")
+        .clone();
+    assert_eq!(cell["text"], new_value, "재독 값 불일치: {cell}");
+}
+
+/// HWP5 입력은 종전 그대로다 — 기본 산출 `.hwp`, 재독 형식 HWP5, 경고 없음.
+#[test]
+fn hwp_input_keeps_hwp5_output() {
+    let work = Workdir::new("hwp");
+    let input = work.copy_in(HWP_SAMPLE, "input.hwp");
+
+    let args = [
+        "edit",
+        "replace-text",
+        input.to_str().unwrap(),
+        "--find",
+        HWP_NEEDLE,
+        "--replace",
+        "기관",
+        "--json",
+    ];
+    let output = run_in(&work.dir, &args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_json(&args, &output);
+    assert_eq!(v["outputFormat"], "hwp5", "{v}");
+
+    let out = work.path("input_replaced.hwp");
+    assert!(out.exists(), "HWP 입력의 기본 산출은 .hwp 여야 합니다: {v}");
+    assert!(
+        !work.path("input_replaced.hwpx").exists(),
+        "HWPX 산출물이 생기면 안 됩니다"
+    );
+    assert_eq!(format_of(&work.dir, &out), "hwp5", "재독 형식 불일치");
+    assert!(
+        !String::from_utf8_lossy(&output.stderr).contains("경고"),
+        "형식이 그대로면 경고하지 않습니다.\n{}",
+        describe(&args, &output)
+    );
+}
+
+/// HWPX 입력에 `-o ….hwp` 를 명시하면 **경로를 그대로 존중**해 HWP5 로 저장하고,
+/// 형식이 바뀐다는 사실을 stderr 로 경고한다 (이슈 제안 2의 과도기 규약).
+#[test]
+fn explicit_hwp_output_for_hwpx_input_is_honoured_with_warning() {
+    let work = Workdir::new("explicit-hwp");
+    let input = work.copy_in(HWPX_SAMPLE, "input.hwpx");
+
+    let args = [
+        "edit",
+        "replace-text",
+        input.to_str().unwrap(),
+        "--find",
+        HWPX_NEEDLE,
+        "--replace",
+        "지방청",
+        "-o",
+        "out.hwp",
+        "--json",
+    ];
+    let output = run_in(&work.dir, &args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_json(&args, &output);
+
+    // 경로를 몰래 바꾸지 않는다 — 지정한 문자열 그대로 보고하고 그 자리에 만든다.
+    assert_eq!(v["output"], "out.hwp", "{v}");
+    assert_eq!(v["outputFormat"], "hwp5", "{v}");
+    assert!(work.path("out.hwp").exists(), "{v}");
+    assert!(
+        !work.path("out.hwpx").exists(),
+        "확장자를 임의로 바꿔 쓰면 안 됩니다"
+    );
+    assert_eq!(
+        format_of(&work.dir, &work.path("out.hwp")),
+        "hwp5",
+        "재독 형식 불일치"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("경고") && stderr.contains(".hwp"),
+        "형식이 바뀌면 stderr 로 경고해야 합니다.\n{}",
+        describe(&args, &output)
+    );
+}
+
+/// 반대 방향(HWP 입력 + `-o ….hwpx`)은 형식을 바꾸지 않는다 — 경고만 하고 HWP5 를 쓴다.
+/// 형식 변환은 `edit` 이 아니라 `export-hwpx` 의 책임이다.
+#[test]
+fn explicit_hwpx_output_for_hwp_input_warns_and_keeps_hwp5() {
+    let work = Workdir::new("explicit-hwpx");
+    let input = work.copy_in(HWP_SAMPLE, "input.hwp");
+
+    let args = [
+        "edit",
+        "replace-text",
+        input.to_str().unwrap(),
+        "--find",
+        HWP_NEEDLE,
+        "--replace",
+        "기관",
+        "-o",
+        "out.hwpx",
+        "--json",
+    ];
+    let output = run_in(&work.dir, &args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_json(&args, &output);
+    assert_eq!(v["output"], "out.hwpx", "{v}");
+    assert_eq!(v["outputFormat"], "hwp5", "{v}");
+    assert_eq!(
+        format_of(&work.dir, &work.path("out.hwpx")),
+        "hwp5",
+        "확장자만 .hwpx 일 뿐 내용은 HWP5 여야 합니다"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("경고"),
+        "확장자와 실제 형식이 다르면 경고해야 합니다.\n{}",
+        describe(&args, &output)
+    );
+}
+
+/// `--dry-run` 은 형식이 무엇이든 파일을 만들지 않고 `output`/`outputFormat` 도 보고하지 않는다.
+#[test]
+fn dry_run_reports_no_output_format_and_writes_nothing() {
+    let work = Workdir::new("dry");
+    let input = work.copy_in(HWPX_SAMPLE, "input.hwpx");
+
+    let args = [
+        "edit",
+        "replace-text",
+        input.to_str().unwrap(),
+        "--find",
+        HWPX_NEEDLE,
+        "--replace",
+        "지방청",
+        "--dry-run",
+        "--json",
+    ];
+    let v = run_ok(&work.dir, &args);
+    assert_eq!(v["dryRun"], true, "{v}");
+    assert!(v.get("output").is_none(), "{v}");
+    assert!(v.get("outputFormat").is_none(), "{v}");
+    assert!(!work.path("input_replaced.hwpx").exists());
+    assert!(!work.path("input_replaced.hwp").exists());
+}


### PR DESCRIPTION
**이 PR 로 닫히는 이슈**: #3383

(포크에서 올린 PR 이라 `Closes` 키워드가 자동 연결되지 않습니다 — 머지 후 수동으로 닫아 주시거나,
말씀 주시면 제가 닫겠습니다.)

> ## 머지 순서를 정해 주십시오 (충돌 예고)
>
> 이 PR 은 `src/main.rs` 의 fill-fields · replace-text · set-cell **세 호출부를 모두** 고칩니다.
> 그런데 제 열린 PR 두 건이 같은 함수를 건드립니다 — **#3478**(fill-fields), **#3482**(set-cell).
>
> 지금은 셋 다 `devel` 기준이라 각각은 MERGEABLE 이지만, **어느 하나가 머지되면 나머지가 충돌**
> 합니다. 어느 base 를 잡아도 다른 한쪽과는 부딪히므로 적층으로 피할 수 없습니다.
>
> **선호하시는 순서를 알려 주시면 제가 즉시 리베이스하겠습니다.** 제 제안은
> #3478 → #3482 → 이 PR 순입니다(앞의 둘이 기능 추가, 이건 세 명령 공통 경로라 마지막이 병합
> 부담이 가장 작습니다). 이 PR 을 먼저 보시겠다면 그것도 좋습니다 — 말씀만 주십시오.

## 문제

`edit` 계열 세 명령이 **무조건** HWP5 로 직렬화합니다 — `src/main.rs:8461`(fill-fields),
`:8633`(replace-text), `:9041`(set-cell). 기본 출력명도 확장자를 하드코딩합니다
(`:8451`, `:8627`, `:9037`). HWPX 를 편집하면 HWP5 가 나옵니다.

**이슈가 짚지 못한 결함이 하나 더 있었습니다.** 이 경로는 `export_hwp_with_adapter()` 가 아니라
`export_hwp_native()` 를 부릅니다. 즉 HWPX 입력에 대해
`converters::hwpx_to_hwp::convert_if_hwpx_source` 호환 어댑터가 **통째로 건너뛰어집니다.**
이슈 본문에 적힌 차트·이미지 유실의 유력한 원인입니다. 형식 보존과 별개로 어댑터 경유로
바꿨고, 덤으로 HWP3 입력도 어댑터를 타게 됐습니다.

## 수정

`run_edit` 옆에 `EditOutputFormat` / `edit_output_format(bytes, explicit_out)` /
`edit_serialize(doc, format)` 를 두고 세 호출부가 같은 판정을 공유합니다.

**`source_format` 은 새 public API 를 만들지 않고 `parser::detect_format(&bytes)` 로 얻습니다.**
`main.rs` 가 이미 `:1323`·`:1555` 에서 쓰는 패턴이고, `from_bytes_inner` 가 같은 함수로
`source_format` 을 정하며 `edit` 는 `convert_to_editable` 을 부르지 않으므로 값이 동일함을
확인했습니다. CLI 전용 관심사로 라이브러리 표면을 넓히지 않는 편이 낫다고 봤습니다.

**명시 `-o` 경로는 절대 다시 쓰지 않습니다.**

| 입력 | `-o` | 결과 |
|---|---|---|
| HWPX | (없음) | `{stem}_filled.hwpx` — HWPX 보존 |
| HWP | (없음) | `{stem}_filled.hwp` — 종전과 동일 |
| HWPX | `*.hwp` | 경로 존중, HWP5 산출 + stderr 경고 |
| HWP | `*.hwpx` | 경로 존중, **HWP5 유지** + stderr 경고 |

마지막 행 덕분에 HWP 입력이 HWPX 경로로 새는 일이 관례가 아니라 **구조적으로** 막힙니다
(`export_hwpx_native` 는 자체 HWP→HWPX 분기가 있어 그냥 두면 샐 수 있었습니다).

JSON 봉투에 `outputFormat` 을 추가했습니다. 어휘는 확장자가 아니라 `info --json` 의 `format` 과
같은 `"hwp5"` / `"hwpx"` 입니다 — 첫 구현의 `"hwp"` 가 CLI JSON 계약과 충돌하는 것을 계약
테스트가 잡았습니다.

## 문서·스키마 동반 갱신

`.hwp` 기본값이 코드 밖 **여러 곳**에 문서화돼 있어 같이 고치지 않으면 거짓말이 됩니다.

- MCP 도구 3종 설명 + `output` 스키마 — set-cell 은 `:398`/`:444` 가 아니라 **`:464` 에 별도**로
  있었습니다
- `capabilities` 레지스트리의 `outputFields`
- `--help` 옵션 4줄 + 공통 주석 3줄, usage 문자열 3곳
- `mydocs/manual/cli_commands.md` — 옵션 3줄, 봉투 계약 3곳, `### edit 산출 형식 (#3383)` 절 신설,
  `.hwpx` 예제, `last_verified` 갱신

## 검증

```
cargo fmt --all -- --check                                          # clean
cargo clippy --profile release-test --all-targets -- -D warnings    # clean
cargo test --profile release-test --tests                           # 355 바이너리 / 4285 passed / 0 failed
```

신규 계약 테스트 `tests/edit_format_preserve_contract.rs` 7종 — 세 명령의 HWPX 기본 산출,
HWP 입력 무변경, 명시 `-o` 양방향 경고, dry-run 무산출. 각 테스트는 샘플을 임시 작업폴더로
복사한 뒤 `current_dir` 를 거기로 두고 실행해, 기본 출력명 계약을 저장소를 더럽히지 않고
검증합니다. 형식 판정은 확장자가 아니라 `info --json` 의 바이트 탐지로 합니다.

기존 `edit_set_cell_contract`(HWPX 입력 + `-o *.hwp`)도 새 어댑터 경로에서 그대로 통과합니다.

## 범위 밖

HML 입력은 종전대로 HWP5 로 나갑니다 — 이번 범위는 HWPX 보존에 한정했습니다.
