### PR TITLE
fix(ci): review-only Render Diff 재실행 방지 (#3559)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,6 +641,9 @@ jobs:
       - name: Format check
         run: cargo fmt --all -- --check
 
+      - name: Validate Render Diff trigger policy
+        run: python3 -m unittest scripts/tests/test_render_diff_workflow.py
+
       - name: Clippy
         run: cargo clippy -- -D warnings
 

--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -25,7 +25,8 @@ on:
       - 'docs/canvaskit-parity-implementation.md'
       - 'docs/text-ir-v2.md'
       - 'rhwp-studio/**'
-      - 'mydocs/**'
+      # Review 기록·asset은 렌더 입력이 아니다. trailing review-only commit이
+      # Canvas visual diff를 다시 시작하지 않게 mydocs/**는 trigger에서 제외한다 (#3559).
       - '.github/workflows/render-diff.yml'
   workflow_dispatch:
     inputs:

--- a/mydocs/manual/pr_review/post_merge.md
+++ b/mydocs/manual/pr_review/post_merge.md
@@ -120,9 +120,12 @@ done
 
 OPEN이면 작업지시자 승인 뒤 수동 close와 후속 comment를 남긴다.
 
+여러 단락의 후속 기록은 [공통 본문 전송 규칙](../pr_review_workflow.md#34-github-markdown-본문-전송)에 따라
+close와 comment를 분리하고 실제 줄바꿈을 담은 `--body-file`을 쓴다.
+
 ~~~bash
-gh issue close N --repo edwardkim/rhwp \
-  --comment "[PR M](https://github.com/edwardkim/rhwp/pull/M) 머지로 해결 (by @contributor). ..."
+gh issue close N --repo edwardkim/rhwp
+gh issue comment N --repo edwardkim/rhwp --body-file <issue-comment.md>
 ~~~
 
 CLOSED여도 같은 merge commit·같은 검증 증적의 maintainer comment가 아직 없으면 다음을 담은 comment를 남긴다.

--- a/mydocs/manual/pr_review_workflow.md
+++ b/mydocs/manual/pr_review_workflow.md
@@ -130,6 +130,20 @@ CI가 끝난 뒤 또는 contributor가 새 commit을 push한 뒤에는 head SHA,
 이 매뉴얼의 기본 경로가 아니다. 필요하면 별도 작업 계획과 작업지시자 승인을 받아 lock·disk·결과 귀속을
 명확히 한 뒤에만 사용한다.
 
+### 3.4 GitHub Markdown 본문 전송
+
+여러 단락의 review·comment·issue comment에는 실제 LF 줄바꿈을 전송한다. 셸 큰따옴표 안의 `\n`은
+줄바꿈이 아니라 문자 그대로이므로 `--body "...\n..."` 또는 `--comment "...\n..."`로 게시하지 않는다.
+
+- PR review와 PR comment는 실제 줄바꿈을 담은 임시 Markdown 파일을 만들고 `--body-file`로 보낸다.
+  `gh pr review N --repo edwardkim/rhwp --approve --body-file <review.md>`,
+  `gh pr comment N --repo edwardkim/rhwp --body-file <comment.md>`처럼 실행한다.
+- 여러 단락의 issue 후속 기록은 `gh issue close N`과 `gh issue comment N --body-file <comment.md>`로
+  분리한다. `gh issue close --comment`는 한 줄의 짧은 기록에만 쓴다.
+- `gh api --input <json>`을 쓸 때는 JSON의 `\n` escape가 실제 LF로 해석되는 유효 JSON인지 확인한다.
+- 게시 직후 해당 review/comment API의 `body`를 읽어 literal `\\n`이 남지 않았는지 확인하고, 임시 본문
+  파일은 정확한 경로만 정리한다.
+
 ## 4. review 산출물의 공통 규칙
 
 PR review 문서는 merge 후에도 모순되지 않아야 한다. draft, mergeable, head SHA, CI 상태는

--- a/mydocs/orders/20260729.md
+++ b/mydocs/orders/20260729.md
@@ -106,6 +106,17 @@ fork 의 `document_core` 연산 9종 upstream 수용 의향을 물었다(v0.7.13
   `MERGEABLE`·`CLEAN`이었다. review-only 기록 commit의 최신 fast-pass aggregate를 확인한 뒤,
   첫 기여자의 조사·최소 수정·회귀 고정의 가치를 구체적으로 전하는 merge comment와 함께 처리한다.
 
+## Issue #3559 — review-only 기록이 Canvas visual diff를 재실행하는 CI fast-pass 결함 (진행 중)
+
+[#3559](https://github.com/edwardkim/rhwp/issues/3559)는 renderer/paint 영향이 없는 code PR 뒤에
+review·오늘할일만 추가했을 때, `mydocs/**` trigger와 Render Diff candidate 조건의 조합으로 무거운
+Canvas visual diff가 다시 실행되는 결함이다.
+
+- `mydocs/**` 단독 기록은 Render Diff trigger에서 제외하고, renderer 영향 경로의 변경은 기존처럼
+  실행한다. trigger 정책을 정적 Python 회귀 검사와 CI Lint 단계로 고정한다.
+- 공통 PR review 절차에는 GitHub Markdown 다단락 본문을 `--body-file`로 게시하고 literal `\\n`을
+  API로 재확인하는 규칙을 추가한다. merge 후 issue comment 예시도 같은 절차로 바꾼다.
+
 ## 이월 추적
 
 - #3508(reaper fork 커버): 다음 릴리즈로 main 반영 후 실증 → close. same-repo 는 복원 실증

--- a/mydocs/pr/archives/pr_3560_review.md
+++ b/mydocs/pr/archives/pr_3560_review.md
@@ -1,0 +1,51 @@
+# PR #3560 검토 — review-only 기록의 Render Diff 재실행 방지
+
+- 검토일: 2026-07-29
+- PR: [#3560](https://github.com/edwardkim/rhwp/pull/3560)
+- 관련 이슈: [#3559](https://github.com/edwardkim/rhwp/issues/3559)
+- 작성자 / reviewer: `@jangster77` / `@jangster77` (collaborator self-merge 후보)
+- base / 원 code head: `devel` / `c4120122b916ca8fc393d81ef55c8e6b16bfd562`
+- 규모: 6 files, +56 / -3 (review 기록 추가 전)
+
+## 변경 범위와 판정
+
+`render-diff.yml`의 pull request trigger에서 `mydocs/**`를 제외한다. review·오늘할일·검토 asset은
+render 입력이 아니므로, renderer/paint와 무관한 code PR 뒤에 review-only commit이 추가됐다는 이유만으로
+`Canvas visual diff`를 다시 시작해서는 안 된다.
+
+renderer, model, paint, Studio, renderer 관련 script와 Render Diff workflow 자체의 기존 trigger는 그대로
+유지한다. 따라서 실제 render 영향 변경은 계속 Canvas visual diff를 실행한다. 이번 PR은 workflow 자체를
+바꾸므로 원 code CI에서 Canvas visual diff가 실행되어 성공한 것도 확인했다.
+
+새 `scripts/tests/test_render_diff_workflow.py`는 pull request trigger에 renderer 경로가 남아 있고
+`mydocs/**`가 다시 추가되지 않는 것을 고정한다. CI Lint가 이 Python unittest를 실행하므로 workflow
+조건의 단순 회귀도 PR CI에서 차단한다.
+
+## Markdown 운영 절차
+
+[#3548](https://github.com/edwardkim/rhwp/pull/3548) 후속 comment에서 셸 큰따옴표 안의 `\n`이 literal로
+게시된 사례를 재발 방지 대상으로 함께 기록했다. 공통 PR review 절차는 다단락 본문에 `--body-file`을
+쓰고, issue close와 다단락 comment를 분리하며, 게시 뒤 API `body`에서 literal `\\n` 부재를 확인하도록
+명시한다. merge 후 manual의 issue close 예시도 이 공통 절차로 연결했다.
+
+## 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| `python3 -m unittest scripts/tests/test_render_diff_workflow.py` | 1 passed |
+| `python3 scripts/check_markdown_links.py mydocs/manual/pr_review/post_merge.md mydocs/manual/pr_review_workflow.md` | 내부 상대 링크 이상 없음 |
+| `actionlint .github/workflows/ci.yml .github/workflows/render-diff.yml` | 변경과 무관한 기존 Render Diff shellcheck 경고 1건만 확인; 현행 `devel`에도 동일 |
+| GitHub Actions — CI | preflight, Lint(새 static test 포함), archive, Native Skia, default-feature 8 shards, `Build & Test` 모두 success |
+| GitHub Actions — CodeQL | preflight와 JavaScript/TypeScript·Python·Rust 분석, aggregate 모두 success |
+| GitHub Actions — Render Diff | preflight와 `Canvas visual diff` success |
+
+이번 변경은 workflow trigger·정적 정책 검사·운영 문서만 바꾸며 HWP/HWPX serializer 또는 renderer 출력
+계산을 바꾸지 않는다. Canvas 결과는 workflow 변경 자체의 CI 검증으로 확인했고, 별도 PDF/SVG review asset은
+merge 판단에 필요하지 않다.
+
+## 권고와 merge 전 조건
+
+**권고: 수용.** 원 code candidate `c4120122b916ca8fc393d81ef55c8e6b16bfd562`의 full CI가 모두
+success인 것을 확인했다. 이 review-only 기록을 추가한 latest head의 preflight와 `Build & Test` aggregate가
+success이고 mergeable 상태가 유지되는지 다시 확인한 뒤, 작업지시자 승인 범위에서 squash merge한다. merge 후
+#3559 상태, PR comment, devel sync와 branch/worktree 정리를 확인한다.

--- a/scripts/tests/test_render_diff_workflow.py
+++ b/scripts/tests/test_render_diff_workflow.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github/workflows/render-diff.yml"
+
+
+class RenderDiffTriggerPolicyTests(unittest.TestCase):
+    def test_review_records_do_not_trigger_canvas_visual_diff(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        pull_request_trigger = workflow.split("  workflow_dispatch:", maxsplit=1)[0]
+
+        self.assertIn("  pull_request:\n", pull_request_trigger)
+        self.assertIn("      - 'src/renderer/**'", pull_request_trigger)
+        self.assertNotIn("'mydocs/**'", pull_request_trigger)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 해결

- review·오늘할일·asset만 추가한 trailing commit이 `Canvas visual diff`를 다시 시작하지 않도록
  Render Diff의 `mydocs/**` trigger를 제거합니다.
- renderer 영향 경로는 기존 trigger를 유지하고, `mydocs/**`가 다시 추가되지 않도록 Python 정적 회귀
  검사와 CI Lint 단계를 추가합니다.

## 운영 절차 보완

- 여러 단락의 GitHub review/comment/issue comment는 `--body-file`로 실제 LF를 전송하고, 게시 뒤
  literal `\\n`을 API로 확인하도록 공통 PR review 절차와 merge 후 예시를 보완합니다.

## 검증

- `python3 -m unittest scripts/tests/test_render_diff_workflow.py`
- `python3 scripts/check_markdown_links.py mydocs/manual/pr_review/post_merge.md mydocs/manual/pr_review_workflow.md`
- `actionlint .github/workflows/ci.yml .github/workflows/render-diff.yml`
  - 기존 devel에도 있는 Render Diff shellcheck 경고 1건만 확인

관련: #3559
