### PR TITLE
feat(#3140): mcp-serve — rhwp 를 실제 MCP 서버로 (stdio JSON-RPC + 세션 핸들)

### DIFF
--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -320,6 +320,29 @@ MCP 서버(및 함수 호출 클라이언트)가 **그대로 등록할 수 있�
 rhwp capabilities --mcp | jq '.tools[] | {name, description}'
 ```
 
+### `mcp-serve` — MCP 서버 (#3140)
+rhwp 를 **실제 MCP 서버**로 실행한다. 전송은 MCP 표준 stdio(줄 단위 JSON-RPC 2.0)이며,
+`initialize` → `tools/list` → `tools/call` 을 직접 받는다. Claude Code 등 MCP 호스트에는
+명령 한 줄로 등록한다:
+
+```jsonc
+// MCP 호스트 설정 예 (예: .mcp.json)
+{ "mcpServers": { "rhwp": { "command": "rhwp", "args": ["mcp-serve"] } } }
+```
+
+- **도구 목록은 `capabilities --mcp` 와 단일 출처**(`mcp_tool_definitions`)다 — 선언과 서버가
+  어긋날 수 없고, 드리프트 가드(`tools_list_matches_capabilities_manifest`)가 이를 고정한다.
+- 무상태 도구 13종(`hwp_info`·`hwp_search`·`hwp_fill_fields` 등)은 선언의 `cli.args` 배선을
+  그대로 해석해 자기 자신을 서브프로세스로 실행한다 — #2707 종료 코드·stdout 순수성 등
+  검증된 CLI 계약을 문자 그대로 재사용한다. stdout 이 JSON 이면 `structuredContent` 로도 준다.
+- **세션 도구 3종**(서버 전용): `hwp_open`(파싱 1회 → `docId` 핸들) → `hwp_doc_text`(재파싱
+  없이 페이지 텍스트 반복 조회) → `hwp_close`(해제). #3140 이 짚은 "상태 유지 세션" 공백을
+  채운다 — 대형 문서를 여러 번 조회할 때 프로세스별 재파싱 비용이 사라진다.
+- 도구 실행 실패(없는 파일 등)는 MCP 규약대로 프로토콜 오류가 아니라 `isError:true` 도구
+  결과로 돌아온다. 알 수 없는 메서드는 JSON-RPC `-32601`.
+- 의존성 추가 없음 — 프로토콜 표면이 좁아 serde_json 만으로 구현했고, WASM 대상에는
+  포함되지 않는다.
+
 ### `info <파일> [--json]`
 HWP 파일 정보 표시(버전/구역 수/암호화 등).
 - `--json` (#3237): stdout 에 순수 JSON 하나 —

--- a/mydocs/report/task_m100_3140_report.md
+++ b/mydocs/report/task_m100_3140_report.md
@@ -1,0 +1,76 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_3140_report.md
+last_verified: 2026-07-30
+---
+
+# #3140 처리 기록 — `mcp-serve`: rhwp 를 실제 MCP 서버로
+
+## 배경
+
+#3140 은 rhwp 를 MCP 서버로 노출하자는 제안이다. 0단계(도구 스키마)는
+`capabilities --mcp`(#3263)로 끝났지만, 그것은 **선언**일 뿐이었다 — 실행하려면
+외부 호스트가 매니페스트를 해석해 CLI 를 직접 fork 해야 했고, #3140 이 짚은
+세 공백 중 "상태 유지 세션"은 CLI 로는 원리적으로 못 메운다(프로세스마다 재파싱).
+
+## 구현 — `rhwp mcp-serve`
+
+`src/mcp_serve.rs` (신규, 바이너리 전용 모듈. WASM 대상 미포함).
+
+### 프로토콜
+MCP 표준 stdio 전송: 줄 단위 JSON-RPC 2.0.
+`initialize` / `notifications/initialized` / `ping` / `tools/list` / `tools/call` 지원.
+알 수 없는 메서드는 `-32601`, 파싱 불가 입력은 `-32700`, 요청 구조 오류는 `-32602`.
+도구 실행 실패(없는 파일 등)는 MCP 규약대로 프로토콜 오류가 아니라
+`isError:true` **도구 결과**로 돌아간다.
+
+### 설계 결정 1 — 단일 출처
+도구 정의를 `mcp_tool_definitions()` 로 추출해 `capabilities --mcp`(선언 출력)와
+`mcp-serve`(실행 서버)가 **같은 목록**을 쓴다. 여기에만 추가하면 양쪽이 함께
+갱신되고, 계약 테스트(`tools_list_matches_capabilities_manifest`)가 이를 고정한다.
+
+### 설계 결정 2 — 무상태 도구는 검증된 CLI 배선을 그대로 실행
+13종(`hwp_info` … `hwp_set_cell`)은 선언의 `cli.args` 자리표시자를 arguments 로
+치환해 **자기 자신을 서브프로세스로** 실행한다. 서버 전용 실행 경로를 새로 만들면
+CLI 와 어긋날 수 있지만, 이 방식은 #2707 종료 코드·stdout 순수성·`--json` 봉투
+계약을 문자 그대로 재사용한다. stdout 이 JSON 이면 `structuredContent` 로도 준다.
+`hwp_batch`/`hwp_batch_search` 의 `paths` 배열은 stdin 으로 흘려 넣는다
+(선언의 `stdinTools` 와 정합).
+
+### 설계 결정 3 — 세션 도구로 "상태 유지" 공백을 채움 (서버 전용 3종)
+- `hwp_open {path}` → 문서를 한 번 파싱해 `docId` 핸들 발급 (`pageCount` 동봉)
+- `hwp_doc_text {docId, page?}` → **재파싱 없이** 핸들에서 페이지 텍스트 조회
+- `hwp_close {docId}` → 해제. 닫힌 핸들 재사용은 `isError:true`
+
+### 설계 결정 4 — 의존성 추가 없음
+프로토콜 표면이 좁아(메서드 5종) `rmcp`+tokio 없이 serde_json 만으로 구현했다.
+비동기 런타임·신규 크레이트가 들어오지 않아 빌드·감사 표면이 그대로다.
+세션 수요가 편집 왕복으로 확장될 때 `rmcp` 전환을 재평가하면 된다.
+
+## 검증
+
+- 신규 계약 테스트 `tests/mcp_server_contract.rs` 6건 all green:
+  - `initialize_handshake_and_ping`
+  - `tools_list_matches_capabilities_manifest` (선언·서버 단일 출처 드리프트 가드)
+  - `tools_call_stateless_info_works` (hwp_info 실호출)
+  - `session_open_read_close_without_reparse` (open→2회 조회→close→닫힌 핸들 isError)
+  - `unknown_method_returns_jsonrpc_error` (-32601)
+  - `unknown_tool_returns_is_error`
+- 기존 `cli_json_contract` 22건 무회귀 (capabilities/--mcp/드리프트 가드 포함)
+- `cargo clippy --release --bin rhwp -- -D warnings`: 0 warnings
+- `cargo fmt --check`: 변경 파일 기준 clean
+
+## 문서
+
+- `mydocs/manual/cli_commands.md` 에 `### mcp-serve` 절 추가 (호스트 등록 예 포함)
+- `--help`·`capabilities` 명령 목록에 `mcp-serve` 등재 (드리프트 가드 ② 정합)
+- `capabilities --mcp` 의 `invocation` 에 `server: "mcp-serve"` 힌트 추가
+- 서버 자기서술의 낡은 문구 수정: "읽는 도구 모음 (읽기 전용)" → "읽고 편집하는
+  도구 모음" (hwp_fill_fields·hwp_replace_text·hwp_set_cell 이 이미 편집 도구)
+
+## 남은 일 (이 PR 범위 밖)
+
+- 세션 도구 확장: 핸들 기반 검색/표 추출, 편집 왕복(`hwp_doc_edit` → `save_as`)
+- 비밀번호 보호 문서의 세션 열기(`--password` 대응)
+- `resources`/`prompts` 등 MCP 확장 표면

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::process;
 
 mod atomic_file;
+mod mcp_serve;
 
 /// [#2707] CLI 종료 코드 계약 — 성공.
 const EXIT_OK: i32 = 0;
@@ -172,6 +173,7 @@ fn main() {
         Some("export-hml") => export_hml(&args[2..]),
         Some("export-doclang") => exit_with(export_doclang(&args[2..])),
         Some("capabilities") => exit_with(show_capabilities(&args[2..])),
+        Some("mcp-serve") => exit_with(mcp_serve::run()),
         Some("batch") => exit_with(run_batch(&args[2..])),
         Some("info") => exit_with(show_info(&args[2..])),
         Some("dump") => exit_with(dump_controls(&args[2..])),
@@ -238,6 +240,31 @@ fn main() {
 /// 손으로 옮겨 적지 않게 한다. `--json` 계약을 가진 명령이 늘면
 /// `capabilities_mcp_covers_every_json_command` 가 누락을 잡는다.
 fn show_mcp_tools() -> i32 {
+    let tools = mcp_tool_definitions();
+
+    let manifest = serde_json::json!({
+        "schemaVersion": "1.0",
+        "protocol": "mcp",
+        "server": {
+            "suggestedName": "rhwp",
+            "version": rhwp::version(),
+            "description": "HWP/HWPX 한국어 문서를 읽고 편집하는 도구 모음",
+        },
+        "invocation": {
+            "transport": "cli",
+            "note": "각 도구의 cli.args 에서 {name} 자리표시자를 inputSchema 의 같은 이름 값으로 치환해 실행한다. stdout 은 순수 JSON, 진단은 stderr, 종료 코드는 0/1/2(+ir-diff 차이 3). 자리표시자 치환 없이 바로 쓰려면 `rhwp mcp-serve`(stdio JSON-RPC 서버, #3140)를 실행한다.",
+            "stdinTools": ["hwp_batch", "hwp_batch_search"],
+            "server": "mcp-serve",
+        },
+        "tools": tools,
+    });
+    println!("{manifest}");
+    EXIT_OK
+}
+
+/// [#3263→#3140] MCP 도구 정의의 단일 출처 — `capabilities --mcp`(선언 출력)와
+/// `mcp-serve`(실행 서버)가 같은 목록을 쓴다. 여기에만 추가하면 양쪽이 함께 갱신된다.
+fn mcp_tool_definitions() -> Vec<serde_json::Value> {
     /// 문서 경로 하나를 받는 도구의 표준 입력 스키마.
     fn path_schema(extra: serde_json::Value) -> serde_json::Value {
         let mut props = serde_json::json!({
@@ -272,7 +299,7 @@ fn show_mcp_tools() -> i32 {
         })
     }
 
-    let tools = vec![
+    vec![
         tool(
             "hwp_info",
             "HWP/HWPX/HML 문서의 메타데이터(포맷·구역/페이지/문단 수·폰트)를 조회한다. 문서를 열기 전에 규모와 형식을 파악할 때 쓴다.",
@@ -480,25 +507,7 @@ fn show_mcp_tools() -> i32 {
             serde_json::json!(["edit", "set-cell", "{path}", "--table", "{table}", "--row", "{row}", "--col", "{col}", "--text", "{text}", "--json"]),
             &["schemaVersion", "source", "table", "row", "col", "oldText", "newText", "dryRun", "overflow", "output", "outputFormat"],
         ),
-    ];
-
-    let manifest = serde_json::json!({
-        "schemaVersion": "1.0",
-        "protocol": "mcp",
-        "server": {
-            "suggestedName": "rhwp",
-            "version": rhwp::version(),
-            "description": "HWP/HWPX 한국어 문서를 읽는 도구 모음 (읽기 전용)",
-        },
-        "invocation": {
-            "transport": "cli",
-            "note": "각 도구의 cli.args 에서 {name} 자리표시자를 inputSchema 의 같은 이름 값으로 치환해 실행한다. stdout 은 순수 JSON, 진단은 stderr, 종료 코드는 0/1/2(+ir-diff 차이 3).",
-            "stdinTools": ["hwp_batch", "hwp_batch_search"],
-        },
-        "tools": tools,
-    });
-    println!("{manifest}");
-    EXIT_OK
+    ]
 }
 
 /// [#3263] 도구 자기서술 — 에이전트가 첫 호출 1회로 명령·계약·스키마를 파악하는 입구.
@@ -606,6 +615,11 @@ fn show_capabilities(args: &[String]) -> i32 {
                 "commands",
                 "batch",
             ],
+        ),
+        cmd(
+            "mcp-serve",
+            "serve",
+            "MCP 서버 (stdio JSON-RPC) — capabilities --mcp 도구 전부 + 세션 도구 실행 (#3140)",
         ),
         // ── 내보내기/변환 ──
         cmd_json(
@@ -993,6 +1007,10 @@ fn print_help() {
     println!("      도구 자기서술 JSON 출력 (명령·플래그·JSON 계약·종료 코드) — 에이전트용");
     println!();
     println!("      --mcp                   MCP 도구 정의(name/description/inputSchema) 출력");
+    println!();
+    println!("  mcp-serve");
+    println!("      MCP 서버 실행 (stdio JSON-RPC) — AI 에이전트 호스트가 도구로 연결 (#3140)");
+    println!("      capabilities --mcp 의 도구 전부 + 세션(hwp_open/hwp_doc_text/hwp_close)");
     println!();
     println!("  dump <파일.hwp|파일.hwpx|파일.hml> [--section <번호>] [--para <번호>]");
     println!("      문서 조판부호 구조 덤프 (디버깅용)");

--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -1,0 +1,392 @@
+//! [#3140] `mcp-serve` — rhwp 를 MCP(Model Context Protocol) 서버로 노출한다.
+//!
+//! 전송은 MCP 표준 stdio(줄 단위 JSON-RPC 2.0)다. `capabilities --mcp`(#3263)가
+//! 도구 **선언**을 냈다면, 본 모듈은 그 선언을 단일 출처(`crate::mcp_tool_definitions`)로
+//! 공유하면서 **실행**까지 잇는다:
+//!
+//! - 무상태 도구(`hwp_info` 등 13종): 선언의 `cli.args` 배선을 그대로 해석해 자기 자신을
+//!   서브프로세스로 실행한다 — 검증된 CLI 계약(#2707 종료 코드, stdout 순수성)을 문자
+//!   그대로 재사용하므로 서버와 CLI 가 어긋날 수 없다.
+//! - 세션 도구(`hwp_open`/`hwp_doc_text`/`hwp_close`): #3140 이 짚은 "상태 유지" 공백.
+//!   문서를 한 번 파싱해 핸들로 잡아두고, 재파싱 없이 반복 조회한다.
+//!
+//! 의존성은 추가하지 않는다 — 프로토콜 표면(initialize/ping/tools/list/tools/call)이
+//! 좁아 serde_json 만으로 충분하고, WASM 대상에는 아예 포함되지 않는다.
+
+use std::collections::HashMap;
+use std::io::{BufRead, Write};
+
+use rhwp::wasm_api::HwpDocument;
+
+const PROTOCOL_VERSION: &str = "2025-06-18";
+/// JSON-RPC 2.0 예약 오류 코드.
+const PARSE_ERROR: i64 = -32700;
+const METHOD_NOT_FOUND: i64 = -32601;
+const INVALID_PARAMS: i64 = -32602;
+
+/// 열린 문서 핸들 테이블. 서버 프로세스가 사는 동안 유지된다.
+struct Sessions {
+    docs: HashMap<String, HwpDocument>,
+    next_id: u64,
+}
+
+impl Sessions {
+    fn new() -> Self {
+        Sessions {
+            docs: HashMap::new(),
+            next_id: 1,
+        }
+    }
+}
+
+pub fn run() -> i32 {
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    let tool_defs = crate::mcp_tool_definitions();
+    let mut sessions = Sessions::new();
+
+    for line in stdin.lock().lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => break,
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let msg: serde_json::Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(e) => {
+                write_msg(
+                    &stdout,
+                    &error_response(
+                        serde_json::Value::Null,
+                        PARSE_ERROR,
+                        &format!("JSON 파싱 실패: {e}"),
+                    ),
+                );
+                continue;
+            }
+        };
+
+        let id = msg.get("id").cloned();
+        let method = msg.get("method").and_then(|m| m.as_str()).unwrap_or("");
+        let params = msg.get("params").cloned().unwrap_or(serde_json::json!({}));
+
+        // 알림(id 없음)은 응답하지 않는다.
+        let Some(id) = id else {
+            continue;
+        };
+
+        let response = match method {
+            "initialize" => ok_response(
+                id,
+                serde_json::json!({
+                    "protocolVersion": params.get("protocolVersion")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(PROTOCOL_VERSION),
+                    "capabilities": { "tools": {} },
+                    "serverInfo": {
+                        "name": "rhwp",
+                        "version": rhwp::version(),
+                    }
+                }),
+            ),
+            "ping" => ok_response(id, serde_json::json!({})),
+            "tools/list" => {
+                ok_response(id, serde_json::json!({ "tools": served_tools(&tool_defs) }))
+            }
+            "tools/call" => match handle_tool_call(&params, &tool_defs, &mut sessions) {
+                Ok(result) => ok_response(id, result),
+                Err(e) => error_response(id, INVALID_PARAMS, &e),
+            },
+            other => error_response(
+                id,
+                METHOD_NOT_FOUND,
+                &format!("지원하지 않는 메서드: {other}"),
+            ),
+        };
+        write_msg(&stdout, &response);
+    }
+    crate::EXIT_OK
+}
+
+fn write_msg(stdout: &std::io::Stdout, msg: &serde_json::Value) {
+    let mut lock = stdout.lock();
+    // stdout 순수성: 프로토콜 스트림에는 JSON-RPC 한 줄만 나간다.
+    let _ = writeln!(lock, "{msg}");
+    let _ = lock.flush();
+}
+
+fn ok_response(id: serde_json::Value, result: serde_json::Value) -> serde_json::Value {
+    serde_json::json!({ "jsonrpc": "2.0", "id": id, "result": result })
+}
+
+fn error_response(id: serde_json::Value, code: i64, message: &str) -> serde_json::Value {
+    serde_json::json!({
+        "jsonrpc": "2.0", "id": id,
+        "error": { "code": code, "message": message }
+    })
+}
+
+/// tools/list 응답: 선언 도구(MCP 필수 3종만 노출) + 세션 도구 3종.
+fn served_tools(tool_defs: &[serde_json::Value]) -> Vec<serde_json::Value> {
+    let mut tools: Vec<serde_json::Value> = tool_defs
+        .iter()
+        .map(|t| {
+            serde_json::json!({
+                "name": t["name"],
+                "description": t["description"],
+                "inputSchema": t["inputSchema"],
+            })
+        })
+        .collect();
+    tools.push(serde_json::json!({
+        "name": "hwp_open",
+        "description": "문서를 파싱해 세션 핸들(docId)을 연다. 대형 문서를 여러 번 조회할 때 재파싱을 피한다. 조회가 끝나면 hwp_close 로 닫는다.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "HWP/HWPX/HML 문서 경로" }
+            },
+            "required": ["path"]
+        }
+    }));
+    tools.push(serde_json::json!({
+        "name": "hwp_doc_text",
+        "description": "hwp_open 으로 연 핸들에서 페이지 텍스트를 재파싱 없이 읽는다.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "docId": { "type": "string", "description": "hwp_open 이 돌려준 핸들" },
+                "page": { "type": "integer", "minimum": 0, "description": "0부터 시작하는 페이지 번호. 생략하면 전체" }
+            },
+            "required": ["docId"]
+        }
+    }));
+    tools.push(serde_json::json!({
+        "name": "hwp_close",
+        "description": "hwp_open 으로 연 핸들을 닫아 메모리를 해제한다.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "docId": { "type": "string", "description": "닫을 핸들" }
+            },
+            "required": ["docId"]
+        }
+    }));
+    tools
+}
+
+/// tools/call 본체. Err 는 JSON-RPC 오류(잘못된 요청 구조), Ok(isError=true) 는
+/// 도구 실행 실패(MCP 규약: 실행 실패는 프로토콜 오류가 아니라 도구 결과다).
+fn handle_tool_call(
+    params: &serde_json::Value,
+    tool_defs: &[serde_json::Value],
+    sessions: &mut Sessions,
+) -> Result<serde_json::Value, String> {
+    let name = params
+        .get("name")
+        .and_then(|n| n.as_str())
+        .ok_or("params.name 이 필요합니다")?;
+    let args = params
+        .get("arguments")
+        .cloned()
+        .unwrap_or(serde_json::json!({}));
+
+    match name {
+        "hwp_open" => Ok(session_open(&args, sessions)),
+        "hwp_doc_text" => Ok(session_doc_text(&args, sessions)),
+        "hwp_close" => Ok(session_close(&args, sessions)),
+        _ => {
+            let Some(def) = tool_defs.iter().find(|t| t["name"] == name) else {
+                return Ok(tool_error(format!("알 수 없는 도구: {name}")));
+            };
+            Ok(run_cli_tool(def, &args))
+        }
+    }
+}
+
+fn tool_error(message: String) -> serde_json::Value {
+    serde_json::json!({
+        "content": [{ "type": "text", "text": message }],
+        "isError": true
+    })
+}
+
+fn tool_ok_text(text: String) -> serde_json::Value {
+    // stdout 이 JSON 이면 structuredContent 로도 준다 — 에이전트가 재파싱을 아낀다.
+    match serde_json::from_str::<serde_json::Value>(&text) {
+        Ok(v) => serde_json::json!({
+            "content": [{ "type": "text", "text": text }],
+            "structuredContent": v,
+            "isError": false
+        }),
+        Err(_) => serde_json::json!({
+            "content": [{ "type": "text", "text": text }],
+            "isError": false
+        }),
+    }
+}
+
+// ── 세션 도구 ──────────────────────────────────────────────────────────────
+
+fn session_open(args: &serde_json::Value, sessions: &mut Sessions) -> serde_json::Value {
+    let Some(path) = args.get("path").and_then(|p| p.as_str()) else {
+        return tool_error("path 가 필요합니다".into());
+    };
+    let data = match std::fs::read(path) {
+        Ok(d) => d,
+        Err(e) => return tool_error(format!("{path} 읽기 실패: {e}")),
+    };
+    let doc = match HwpDocument::from_bytes(&data) {
+        Ok(d) => d,
+        Err(e) => return tool_error(format!("{path} 파싱 실패: {e:?}")),
+    };
+    let page_count = doc.page_count();
+    let doc_id = format!("doc-{}", sessions.next_id);
+    sessions.next_id += 1;
+    sessions.docs.insert(doc_id.clone(), doc);
+    tool_ok_text(
+        serde_json::json!({
+            "schemaVersion": "1.0",
+            "docId": doc_id,
+            "source": path,
+            "pageCount": page_count,
+        })
+        .to_string(),
+    )
+}
+
+fn session_doc_text(args: &serde_json::Value, sessions: &mut Sessions) -> serde_json::Value {
+    let Some(doc_id) = args.get("docId").and_then(|d| d.as_str()) else {
+        return tool_error("docId 가 필요합니다".into());
+    };
+    let Some(doc) = sessions.docs.get_mut(doc_id) else {
+        return tool_error(format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"));
+    };
+    let page_count = doc.page_count();
+    let pages: Vec<u32> = match args.get("page").and_then(|p| p.as_u64()) {
+        Some(p) => {
+            let p = p as u32;
+            if p >= page_count {
+                return tool_error(format!("페이지 범위 초과: {p} (0~{})", page_count - 1));
+            }
+            vec![p]
+        }
+        None => (0..page_count).collect(),
+    };
+    let mut page_objs = Vec::with_capacity(pages.len());
+    for p in pages {
+        match doc.extract_page_text_native(p) {
+            Ok(text) => page_objs.push(serde_json::json!({ "page": p, "text": text })),
+            Err(e) => return tool_error(format!("페이지 {p} 텍스트 추출 실패: {e:?}")),
+        }
+    }
+    tool_ok_text(
+        serde_json::json!({
+            "schemaVersion": "1.0",
+            "docId": doc_id,
+            "pageCount": page_objs.len(),
+            "pages": page_objs,
+        })
+        .to_string(),
+    )
+}
+
+fn session_close(args: &serde_json::Value, sessions: &mut Sessions) -> serde_json::Value {
+    let Some(doc_id) = args.get("docId").and_then(|d| d.as_str()) else {
+        return tool_error("docId 가 필요합니다".into());
+    };
+    if sessions.docs.remove(doc_id).is_none() {
+        return tool_error(format!("열려 있지 않은 핸들: {doc_id}"));
+    }
+    tool_ok_text(
+        serde_json::json!({
+            "schemaVersion": "1.0",
+            "docId": doc_id,
+            "closed": true,
+        })
+        .to_string(),
+    )
+}
+
+// ── 무상태 도구: 선언된 cli.args 배선을 그대로 실행 ─────────────────────────
+
+/// `cli.args` 템플릿의 `{키}` 자리표시자를 arguments 값으로 치환한다.
+/// 값이 문자열이면 그대로, 객체/숫자/불리언이면 JSON 직렬화 문자열로 넣는다
+/// (`--data` 가 JSON 문자열을 받는 것과 정합).
+fn substitute_args(
+    template: &[serde_json::Value],
+    args: &serde_json::Value,
+) -> Result<Vec<String>, String> {
+    let mut out = Vec::with_capacity(template.len());
+    for t in template {
+        let s = t.as_str().unwrap_or_default();
+        if s.starts_with('{') && s.ends_with('}') && s.len() > 2 {
+            let key = &s[1..s.len() - 1];
+            let Some(v) = args.get(key) else {
+                return Err(format!("필수 인자 누락: {key}"));
+            };
+            out.push(match v {
+                serde_json::Value::String(sv) => sv.clone(),
+                other => other.to_string(),
+            });
+        } else {
+            out.push(s.to_string());
+        }
+    }
+    Ok(out)
+}
+
+fn run_cli_tool(def: &serde_json::Value, args: &serde_json::Value) -> serde_json::Value {
+    let template: Vec<serde_json::Value> =
+        def["cli"]["args"].as_array().cloned().unwrap_or_default();
+    let cli_args = match substitute_args(&template, args) {
+        Ok(a) => a,
+        Err(e) => return tool_error(e),
+    };
+
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => return tool_error(format!("실행 파일 경로 조회 실패: {e}")),
+    };
+    let mut cmd = std::process::Command::new(exe);
+    cmd.args(&cli_args)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    // stdin 도구(hwp_batch 계열): paths 배열을 한 줄에 하나씩 흘려 넣는다.
+    let stdin_paths: Option<String> = args.get("paths").and_then(|p| p.as_array()).map(|arr| {
+        arr.iter()
+            .filter_map(|v| v.as_str())
+            .collect::<Vec<_>>()
+            .join("\n")
+    });
+    if stdin_paths.is_some() {
+        cmd.stdin(std::process::Stdio::piped());
+    }
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => return tool_error(format!("CLI 실행 실패: {e}")),
+    };
+    if let (Some(paths), Some(mut si)) = (stdin_paths, child.stdin.take()) {
+        let _ = si.write_all(paths.as_bytes());
+        let _ = si.write_all(b"\n");
+        // drop 으로 stdin 닫힘 — batch 가 EOF 를 본다.
+    }
+    let output = match child.wait_with_output() {
+        Ok(o) => o,
+        Err(e) => return tool_error(format!("CLI 종료 대기 실패: {e}")),
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let code = output.status.code().unwrap_or(-1);
+    // #2707 계약: 0=성공. 3(ir-diff 차이)·1(batch 부분 실패)도 stdout 에 유효한 JSON
+    // 결과가 있으므로 도구 결과로 그대로 전달한다. stdout 이 비어 있을 때만 실패다.
+    if stdout.is_empty() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return tool_error(format!("종료 코드 {code}: {stderr}"));
+    }
+    tool_ok_text(stdout)
+}

--- a/tests/mcp_server_contract.rs
+++ b/tests/mcp_server_contract.rs
@@ -1,0 +1,259 @@
+//! [#3140] `mcp-serve` — rhwp 를 실제 MCP 서버로 노출하는 stdio JSON-RPC 계약.
+//!
+//! `capabilities --mcp`(#3263)는 도구 **선언**만 냈다 — 실행하려면 외부 호스트가
+//! 매니페스트를 해석해 CLI 를 fork 해야 했다. 본 명령은 그 마지막 층을 채운다:
+//! MCP stdio 전송(줄 단위 JSON-RPC 2.0)로 initialize → tools/list → tools/call 을
+//! 직접 받고, 선언과 실행이 한 프로세스에서 만난다.
+//!
+//! 세션(#3140 의 "상태 유지" 공백): `hwp_open` 이 문서를 파싱해 핸들을 돌려주고,
+//! `hwp_doc_text` 가 재파싱 없이 핸들에서 읽으며, `hwp_close` 가 해제한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+const SAMPLE: &str = "samples/hwp3-sample.hwp";
+
+fn sample(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+/// 살아있는 mcp-serve 프로세스와 그 stdio 파이프.
+struct Server {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: i64,
+}
+
+impl Server {
+    fn start() -> Server {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+            .arg("mcp-serve")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("rhwp mcp-serve 실행 실패");
+        let stdin = child.stdin.take().expect("stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout"));
+        Server {
+            child,
+            stdin,
+            stdout,
+            next_id: 1,
+        }
+    }
+
+    /// 요청 1건을 보내고 같은 id 의 응답 1줄을 기다린다.
+    fn request(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        let msg =
+            serde_json::json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params});
+        writeln!(self.stdin, "{msg}").expect("요청 쓰기 실패");
+        self.stdin.flush().expect("flush");
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let n = self.stdout.read_line(&mut line).expect("응답 읽기 실패");
+            assert!(n > 0, "서버가 응답 없이 종료했습니다 (method={method})");
+            if line.trim().is_empty() {
+                continue;
+            }
+            let v: serde_json::Value = serde_json::from_str(line.trim())
+                .unwrap_or_else(|e| panic!("stdout 이 순수 JSON-RPC 가 아닙니다 ({e}): {line}"));
+            // 서버발 알림은 건너뛰고 내 id 의 응답만 취한다.
+            if v.get("id").and_then(|i| i.as_i64()) == Some(id) {
+                return v;
+            }
+        }
+    }
+
+    fn notify(&mut self, method: &str) {
+        let msg = serde_json::json!({"jsonrpc": "2.0", "method": method});
+        writeln!(self.stdin, "{msg}").expect("알림 쓰기 실패");
+        self.stdin.flush().expect("flush");
+    }
+
+    /// initialize 핸드셰이크까지 마친 서버를 돌려준다.
+    fn started() -> Server {
+        let mut s = Server::start();
+        let r = s.request(
+            "initialize",
+            serde_json::json!({
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "contract-test", "version": "0"}
+            }),
+        );
+        assert!(
+            r["result"]["serverInfo"]["name"].is_string(),
+            "initialize 응답에 serverInfo 가 없습니다: {r}"
+        );
+        assert!(
+            r["result"]["capabilities"]["tools"].is_object(),
+            "tools capability 선언이 없습니다: {r}"
+        );
+        s.notify("notifications/initialized");
+        s
+    }
+
+    /// tools/call 을 보내고 content[0].text 를 JSON 으로 파싱해 돌려준다.
+    fn call_tool(&mut self, name: &str, args: serde_json::Value) -> serde_json::Value {
+        let r = self.request(
+            "tools/call",
+            serde_json::json!({"name": name, "arguments": args}),
+        );
+        let result = &r["result"];
+        assert_eq!(
+            result["isError"], false,
+            "{name} 호출이 isError 를 보고했습니다: {r}"
+        );
+        let text = result["content"][0]["text"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{name} 응답에 content[0].text 가 없습니다: {r}"));
+        serde_json::from_str(text)
+            .unwrap_or_else(|e| panic!("{name} 의 text 가 JSON 이 아닙니다 ({e}): {text}"))
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn initialize_handshake_and_ping() {
+    let mut s = Server::started();
+    let r = s.request("ping", serde_json::json!({}));
+    assert!(
+        r["result"].is_object(),
+        "ping 은 빈 result 를 돌려준다: {r}"
+    );
+}
+
+#[test]
+fn tools_list_matches_capabilities_manifest() {
+    // 드리프트 가드: 서버가 노출하는 도구는 capabilities --mcp 선언과 같은 목록이어야
+    // 한다(단일 출처). 세션 도구 3종(open/doc_text/close)은 서버 전용으로 추가된다.
+    let cap = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(["capabilities", "--mcp"])
+        .output()
+        .expect("capabilities 실행 실패");
+    let manifest: serde_json::Value =
+        serde_json::from_slice(&cap.stdout).expect("capabilities --mcp JSON");
+    let declared: Vec<String> = manifest["tools"]
+        .as_array()
+        .expect("tools 배열")
+        .iter()
+        .map(|t| t["name"].as_str().unwrap().to_string())
+        .collect();
+
+    let mut s = Server::started();
+    let r = s.request("tools/list", serde_json::json!({}));
+    let served: Vec<String> = r["result"]["tools"]
+        .as_array()
+        .unwrap_or_else(|| panic!("tools/list 응답에 tools 배열이 없습니다: {r}"))
+        .iter()
+        .map(|t| t["name"].as_str().unwrap().to_string())
+        .collect();
+
+    for name in &declared {
+        assert!(
+            served.contains(name),
+            "capabilities 선언 도구 {name} 이 서버 tools/list 에 없습니다: {served:?}"
+        );
+    }
+    for extra in ["hwp_open", "hwp_doc_text", "hwp_close"] {
+        assert!(
+            served.contains(&extra.to_string()),
+            "세션 도구 {extra} 가 없습니다: {served:?}"
+        );
+    }
+    // MCP 필수 필드.
+    for t in r["result"]["tools"].as_array().unwrap() {
+        assert!(t["description"].is_string(), "{t}");
+        assert!(t["inputSchema"].is_object(), "{t}");
+    }
+}
+
+#[test]
+fn tools_call_stateless_info_works() {
+    let p = sample(SAMPLE);
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let mut s = Server::started();
+    let v = s.call_tool("hwp_info", serde_json::json!({"path": p.to_str().unwrap()}));
+    assert!(
+        v["pageCount"].as_u64().unwrap_or(0) >= 1,
+        "hwp_info 가 페이지 수를 돌려줘야 합니다: {v}"
+    );
+}
+
+#[test]
+fn session_open_read_close_without_reparse() {
+    let p = sample(SAMPLE);
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let mut s = Server::started();
+
+    let opened = s.call_tool("hwp_open", serde_json::json!({"path": p.to_str().unwrap()}));
+    let doc_id = opened["docId"]
+        .as_str()
+        .unwrap_or_else(|| panic!("hwp_open 이 docId 를 돌려줘야 합니다: {opened}"))
+        .to_string();
+    assert!(opened["pageCount"].as_u64().unwrap_or(0) >= 1, "{opened}");
+
+    // 같은 핸들로 두 번 읽는다 — 프로세스가 살아있으므로 재파싱이 없어야 한다.
+    let t1 = s.call_tool("hwp_doc_text", serde_json::json!({"docId": doc_id}));
+    let t2 = s.call_tool(
+        "hwp_doc_text",
+        serde_json::json!({"docId": doc_id, "page": 0}),
+    );
+    assert!(t1["pages"].is_array(), "{t1}");
+    assert!(
+        t2["pages"].as_array().map(|a| a.len()) == Some(1),
+        "page 지정 시 1페이지만: {t2}"
+    );
+
+    let closed = s.call_tool("hwp_close", serde_json::json!({"docId": doc_id}));
+    assert_eq!(closed["closed"], true, "{closed}");
+
+    // 닫힌 핸들 사용은 isError 여야 한다.
+    let r = s.request(
+        "tools/call",
+        serde_json::json!({"name": "hwp_doc_text", "arguments": {"docId": doc_id}}),
+    );
+    assert_eq!(
+        r["result"]["isError"], true,
+        "닫힌 핸들 재사용은 isError=true: {r}"
+    );
+}
+
+#[test]
+fn unknown_method_returns_jsonrpc_error() {
+    let mut s = Server::started();
+    let r = s.request("no/such-method", serde_json::json!({}));
+    assert_eq!(
+        r["error"]["code"], -32601,
+        "알 수 없는 메서드는 -32601: {r}"
+    );
+}
+
+#[test]
+fn unknown_tool_returns_is_error() {
+    let mut s = Server::started();
+    let r = s.request(
+        "tools/call",
+        serde_json::json!({"name": "no_such_tool", "arguments": {}}),
+    );
+    assert_eq!(r["result"]["isError"], true, "{r}");
+}


### PR DESCRIPTION
## 무엇

`rhwp mcp-serve` — rhwp 를 **실제 MCP 서버**로 실행하는 명령을 추가합니다.
#3140 의 0단계(도구 스키마)는 `capabilities --mcp`(#3263)로 끝났지만 그것은 선언일 뿐이었고,
실행하려면 외부 호스트가 매니페스트를 해석해 CLI 를 직접 fork 해야 했습니다. 본 PR 이
그 마지막 층을 채웁니다: MCP 표준 stdio 전송(줄 단위 JSON-RPC 2.0)으로
`initialize` → `tools/list` → `tools/call` 을 직접 받습니다.

```jsonc
// MCP 호스트 등록 예 (.mcp.json)
{ "mcpServers": { "rhwp": { "command": "rhwp", "args": ["mcp-serve"] } } }
```

## 설계 결정

1. **단일 출처** — 도구 정의를 `mcp_tool_definitions()` 로 추출해 선언(`capabilities --mcp`)과
   서버(`tools/list`)가 같은 목록을 씁니다. 계약 테스트
   `tools_list_matches_capabilities_manifest` 가 드리프트를 고정합니다.
2. **무상태 도구 13종은 검증된 CLI 배선을 그대로 실행** — 선언의 `cli.args` 자리표시자를
   arguments 로 치환해 자기 자신을 서브프로세스로 실행합니다. 서버 전용 실행 경로를 새로
   만들면 CLI 와 어긋날 수 있지만, 이 방식은 #2707 종료 코드·stdout 순수성·`--json` 봉투
   계약을 문자 그대로 재사용합니다. stdout 이 JSON 이면 `structuredContent` 로도 줍니다.
   `hwp_batch` 계열의 `paths` 배열은 stdin 으로 흘려 넣습니다(선언의 `stdinTools` 정합).
3. **세션 도구 3종(서버 전용)으로 "상태 유지" 공백을 채움** — #3140 이 짚은, CLI 로는
   원리적으로 못 메우는 공백(프로세스마다 재파싱)입니다.
   `hwp_open {path}` → 파싱 1회 후 `docId` 핸들 / `hwp_doc_text {docId, page?}` → 재파싱
   없이 반복 조회 / `hwp_close {docId}` → 해제. 닫힌 핸들 재사용은 `isError:true`.
4. **의존성 추가 없음** — 프로토콜 표면이 좁아(메서드 5종) `rmcp`+tokio 없이 serde_json
   만으로 구현했습니다. WASM 대상에는 포함되지 않습니다. 세션 수요가 편집 왕복으로
   확장될 때 `rmcp` 전환을 재평가하면 됩니다.

## 검증

- 신규 계약 테스트 `tests/mcp_server_contract.rs` **6건 green**:
  initialize 핸드셰이크·ping / tools_list 선언 정합(드리프트 가드) / hwp_info 실호출 /
  세션 open→2회 조회→close→닫힌 핸들 isError / 알 수 없는 메서드 -32601 / 알 수 없는 도구 isError
- 기존 `cli_json_contract` **22건 무회귀** (capabilities 드리프트 가드 ①②③ 포함)
- `cargo clippy --release --bin rhwp -- -D warnings` 0건, `cargo fmt --check` clean(변경 파일 기준)

## 함께 고친 것

- 서버 자기서술의 낡은 문구: "읽는 도구 모음 (읽기 전용)" → "읽고 편집하는 도구 모음"
  (`hwp_fill_fields`·`hwp_replace_text`·`hwp_set_cell` 이 이미 편집 도구)
- `--help`·`capabilities` 명령 목록에 `mcp-serve` 등재(드리프트 가드 ② 정합),
  `mydocs/manual/cli_commands.md` 에 `### mcp-serve` 절 추가

## 처리 문서

`mydocs/report/task_m100_3140_report.md`

refs #3140 (1단계 서버 본체 + 세션. 편집 왕복 세션·resources 표면은 후속)