### PR TITLE
fix(model): delete_text_at 이 클램핑된 char_shape ref 중복을 제거하도록 (#3576)

### DIFF
--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -761,6 +761,14 @@ impl Paragraph {
                 cs.start_pos = utf16_start;
             }
         }
+        // [#3576] 클램핑으로 같은 start_pos 에 몰린 ref 를 정리한다. char_shapes 는
+        // start_pos 오름차순의 '서로 다른' 경계여야 하는데, 삭제 범위 안에 있던 ref 가
+        // 전부 utf16_start 로 클램핑되면 중복이 남는다. 그 상태에서 다시 텍스트를
+        // 삽입하면 뒤쪽(보조) 글자모양이 새 텍스트 일부를 덮어 의도하지 않은 크기·굵기로
+        // 렌더된다 — 양식 채우기의 전체삭제→재삽입 경로에서 발현했다.
+        // 첫 ref 를 남긴다: 삭제 범위 '앞' 의 주 글자모양이 앞에 오기 때문이다.
+        // (오름차순 불변식이 유지되므로 dedup_by_key 로 인접 중복만 보면 충분하다.)
+        self.char_shapes.dedup_by_key(|cs| cs.start_pos);
 
         // 4. line_segs: 삭제 범위 이후 → utf16_delta만큼 감소
         for ls in &mut self.line_segs {

--- a/tests/issue_3576_char_shape_dedup.rs
+++ b/tests/issue_3576_char_shape_dedup.rs
@@ -1,0 +1,224 @@
+//! [#3576] `delete_text_at` 의 char_shape ref 중복 회귀 가드.
+//!
+//! 계약: 문단 텍스트를 삭제한 뒤 `char_shapes` 의 `start_pos` 는 유일해야 한다
+//! (HWP5 규약상 오름차순의 서로 다른 경계). 삭제 범위 안의 ref 들이 클램프로
+//! 한 위치에 몰려 중복이 남으면, 이후 삽입에서 뒤쪽 ref(보조 글자모양)가 새
+//! 텍스트 일부를 덮어 의도하지 않은 크기·굵기로 렌더된다 — 양식 채우기가
+//! `deleteTextInCell`(전체) → `insertTextInCell` 순서로 돌기 때문에 실전에서
+//! "값 칸 하나만 글자가 작게 보인다" 로 발현했다.
+//!
+//! 가드하는 축 세 개:
+//!   ① 전체 삭제 후 `start_pos` 유일 (수정 전 실패 = red-check)
+//!   ② 전체 삭제 → 재삽입 후 새 텍스트가 주 글자모양 하나로 덮인다
+//!   ③ 부분 삭제에서 살아남아야 하는 ref 가 사라지지 않는다 (과잉 dedup 방지)
+//!
+//! 손으로 `Paragraph` 를 만들면 `char_offsets` 불변식이 깨져 `delete_text_at` 이
+//! 슬라이스 범위 패닉을 낸다. 따라서 전부 실제 편집 API 경로로 구성한다.
+//!
+//! fixture: `samples/2010-01-06.hwp` s0 p4 c0 cell0 — 9행 표의 첫 칸.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::model::control::Control;
+use rhwp::model::document::Document;
+use rhwp::wasm_api::HwpDocument;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+const SAMPLE: &str = "samples/2010-01-06.hwp";
+const SEC: usize = 0;
+const PARA: usize = 4;
+const CTRL: usize = 0;
+const CELL: usize = 0;
+
+fn open_sample() -> HwpDocument {
+    let bytes = fs::read(Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE))
+        .unwrap_or_else(|e| panic!("fixture 읽기 실패 {SAMPLE}: {e}"));
+    HwpDocument::from_bytes(&bytes).unwrap_or_else(|e| panic!("파싱: {e:?}"))
+}
+
+/// 대상 셀 첫 문단의 (start_pos, char_shape_id) 목록.
+fn cell_char_shapes(doc: &Document) -> Vec<(u32, u32)> {
+    let para = &doc.sections[SEC].paragraphs[PARA];
+    match para.controls.get(CTRL) {
+        Some(Control::Table(t)) => t
+            .cells
+            .get(CELL)
+            .and_then(|c| c.paragraphs.first())
+            .map(|p| {
+                p.char_shapes
+                    .iter()
+                    .map(|cs| (cs.start_pos, cs.char_shape_id))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        other => panic!("fixture 구조 변경: s{SEC} p{PARA} c{CTRL} 가 표가 아님 ({other:?})"),
+    }
+}
+
+fn cell_text(doc: &Document) -> String {
+    let para = &doc.sections[SEC].paragraphs[PARA];
+    match para.controls.get(CTRL) {
+        Some(Control::Table(t)) => t
+            .cells
+            .get(CELL)
+            .and_then(|c| c.paragraphs.first())
+            .map(|p| p.text.clone())
+            .unwrap_or_default(),
+        _ => String::new(),
+    }
+}
+
+/// 셀 첫 문단에 `text` 를 넣고 `[split_at, 끝)` 구간만 8pt 로 바꿔 run 을 쪼갠다.
+/// 반환: 쪼개진 뒤의 char_shapes.
+fn seed_two_runs(doc: &mut HwpDocument, text: &str, split_at: usize) -> Vec<(u32, u32)> {
+    // fixture 셀에는 원래 내용("구   분")이 있다 — 알려진 상태에서 출발하려면 먼저 비운다.
+    let existing = cell_text(doc.document()).chars().count() as u32;
+    if existing > 0 {
+        doc.delete_text_in_cell(
+            SEC as u32,
+            PARA as u32,
+            CTRL as u32,
+            CELL as u32,
+            0,
+            0,
+            existing,
+        )
+        .unwrap_or_else(|e| panic!("셀 기존 텍스트 비우기: {e:?}"));
+    }
+
+    doc.insert_text_in_cell(
+        SEC as u32,
+        PARA as u32,
+        CTRL as u32,
+        CELL as u32,
+        0,
+        0,
+        text,
+    )
+    .unwrap_or_else(|e| panic!("셀 텍스트 삽입: {e:?}"));
+
+    doc.apply_char_format_in_cell(
+        SEC,
+        PARA,
+        CTRL,
+        CELL,
+        0,
+        split_at,
+        text.chars().count(),
+        r#"{"fontSize":800}"#,
+    )
+    .unwrap_or_else(|e| panic!("셀 글자서식 적용: {e:?}"));
+
+    let shapes = cell_char_shapes(doc.document());
+    assert!(
+        shapes.len() >= 2,
+        "전제 붕괴: run 이 2개 이상으로 쪼개지지 않았다 ({shapes:?}) — \
+         이 조건이 아니면 #3576 은 물리지 않는다",
+    );
+    shapes
+}
+
+#[test]
+fn full_delete_leaves_unique_char_shape_positions() {
+    let mut doc = open_sample();
+    let text = "2026. 01. 05.";
+    let before = seed_two_runs(&mut doc, text, 6);
+
+    doc.delete_text_in_cell(
+        SEC as u32,
+        PARA as u32,
+        CTRL as u32,
+        CELL as u32,
+        0,
+        0,
+        text.chars().count() as u32,
+    )
+    .unwrap_or_else(|e| panic!("셀 텍스트 전체 삭제: {e:?}"));
+
+    let after = cell_char_shapes(doc.document());
+    let positions: Vec<u32> = after.iter().map(|(p, _)| *p).collect();
+    let distinct: BTreeSet<u32> = positions.iter().copied().collect();
+
+    assert_eq!(
+        positions.len(),
+        distinct.len(),
+        "#3576: 전체 삭제 후 char_shape start_pos 가 중복됐다 \
+         (삭제 전 {before:?} → 삭제 후 {after:?}). 클램프만 하고 중복을 제거하지 않는다.",
+    );
+}
+
+#[test]
+fn refill_after_full_delete_uses_single_char_shape() {
+    // 중복 ref 가 남으면 재삽입한 텍스트의 뒷부분이 보조 글자모양(8pt)으로 덮인다.
+    let mut doc = open_sample();
+    let text = "2026. 01. 05.";
+    seed_two_runs(&mut doc, text, 6);
+
+    doc.delete_text_in_cell(
+        SEC as u32,
+        PARA as u32,
+        CTRL as u32,
+        CELL as u32,
+        0,
+        0,
+        text.chars().count() as u32,
+    )
+    .unwrap_or_else(|e| panic!("전체 삭제: {e:?}"));
+
+    let refilled = "2026. 07. 30.";
+    doc.insert_text_in_cell(
+        SEC as u32,
+        PARA as u32,
+        CTRL as u32,
+        CELL as u32,
+        0,
+        0,
+        refilled,
+    )
+    .unwrap_or_else(|e| panic!("재삽입: {e:?}"));
+
+    assert_eq!(cell_text(doc.document()), refilled, "재삽입 텍스트 불일치");
+
+    let shapes = cell_char_shapes(doc.document());
+    assert_eq!(
+        shapes.len(),
+        1,
+        "#3576: 재삽입한 텍스트가 글자모양 하나로 덮이지 않았다 ({shapes:?}) — \
+         보조 run 이 살아남아 새 텍스트 일부를 덮는다.",
+    );
+    assert_eq!(
+        shapes[0].0, 0,
+        "#3576: 유일한 char_shape ref 가 위치 0 에서 시작하지 않는다 ({shapes:?})",
+    );
+}
+
+#[test]
+fn partial_delete_keeps_surviving_refs() {
+    // 과잉 dedup 방지: 삭제 범위가 run 경계 앞에서 끝나면 뒤 run 은 살아 있어야 하고
+    // 위치만 앞으로 당겨져야 한다.
+    let mut doc = open_sample();
+    let text = "2026. 01. 05.";
+    let before = seed_two_runs(&mut doc, text, 6);
+    let before_ids: Vec<u32> = before.iter().map(|(_, id)| *id).collect();
+
+    // 앞 3자만 삭제 — 두 번째 run(6) 은 3 으로 당겨지고 살아 있어야 한다.
+    doc.delete_text_in_cell(SEC as u32, PARA as u32, CTRL as u32, CELL as u32, 0, 0, 3)
+        .unwrap_or_else(|e| panic!("부분 삭제: {e:?}"));
+
+    let after = cell_char_shapes(doc.document());
+    let after_ids: Vec<u32> = after.iter().map(|(_, id)| *id).collect();
+
+    assert_eq!(
+        after_ids, before_ids,
+        "#3576: 부분 삭제에서 살아남아야 하는 char_shape ref 가 사라졌다 \
+         (삭제 전 {before:?} → 삭제 후 {after:?}) — dedup 이 과하다.",
+    );
+    let positions: Vec<u32> = after.iter().map(|(p, _)| *p).collect();
+    let distinct: BTreeSet<u32> = positions.iter().copied().collect();
+    assert_eq!(
+        positions.len(),
+        distinct.len(),
+        "#3576: 부분 삭제 후에도 start_pos 는 유일해야 한다 ({after:?})",
+    );
+}


### PR DESCRIPTION
Closes #3576

## 문제

글자모양 run 이 2개 이상인 문단의 텍스트를 **전체 삭제**하면 삭제 범위 안의 ref 들이 모두 `utf16_start` 로 클램핑되면서 같은 `start_pos` 를 가진 중복 ref 가 남습니다. `char_shapes` 는 `start_pos` 오름차순의 **서로 다른** 경계여야 하므로 그 자체로 불변식 위반이고, 그 상태에서 다시 텍스트를 삽입하면 뒤쪽(보조) 글자모양이 새 텍스트 일부를 덮어 의도하지 않은 크기·굵기로 렌더됩니다.

양식 문서 채우기가 `deleteTextInCell`(전체) → `insertTextInCell` 순서로 돌기 때문에 "값 칸 하나만 날짜 뒷부분이 작게 보인다" 로 발현했습니다.

재현 (devel `cef2363`, 실제 편집 API 경로):

```
삭제 전 char_shapes = [(start_pos, char_shape_id)] = [(0, 3), (6, 27)]
삭제 후 char_shapes =                                 [(0, 3), (0, 27)]   ← 중복
```

## 수정

`src/model/paragraph.rs` `delete_text_at` 의 클램핑 루프 뒤에 dedup 을 넣었습니다.

```rust
self.char_shapes.dedup_by_key(|cs| cs.start_pos);
```

- **첫 ref 를 남깁니다** — 삭제 범위 '앞' 의 주 글자모양이 앞에 오기 때문입니다.
- 오름차순 불변식이 유지되는 경로이므로 인접 중복만 보는 `dedup_by_key` 로 충분합니다. `HashSet` + `retain` 도 되지만 정렬 가정을 이미 쓰는 코드라 이쪽이 가볍습니다 — 선호하는 형태가 있으면 맞추겠습니다.

## 회귀 테스트

`tests/issue_3576_char_shape_dedup.rs` — 세 축을 가드합니다.

| 테스트 | 지키는 것 |
|---|---|
| `full_delete_leaves_unique_char_shape_positions` | 완료조건 1 — 전체 삭제 후 `start_pos` 유일 |
| `refill_after_full_delete_uses_single_char_shape` | 완료조건 2 — 재삽입 텍스트가 주 글자모양 하나로 덮인다 |
| `partial_delete_keeps_surviving_refs` | 완료조건 3 — 부분 삭제에서 살아남아야 하는 ref 가 사라지지 않는다 (과잉 dedup 방지) |

**red-check (완료조건 4)**: 수정 한 줄을 되돌리면 앞 두 개가 실패합니다.

```
assertion `left == right` failed: #3576: 전체 삭제 후 char_shape start_pos 가 중복됐다
(삭제 전 [(0, 3), (6, 27)] → 삭제 후 [(0, 3), (0, 27)])
  left: 2    right: 1
```

세 번째(과잉 dedup 방지)는 수정 전에도 green 이므로, dedup 을 너무 세게 넣으면 그쪽이 잡습니다.

테스트는 전부 **실제 편집 API**(`insertTextInCell` / `applyCharFormatInCell` / `deleteTextInCell`) 경로로 구성했습니다. `Paragraph` 를 손으로 만들면 `char_offsets` 불변식이 깨져 `delete_text_at` 이 `paragraph.rs:750` 에서 슬라이스 범위 패닉을 냅니다(처음에 그렇게 만들어 헛짚었습니다). fixture 셀에 원래 내용이 있어 시작 상태를 먼저 비우는 것도 그래서 필요했습니다.

## PR 전 체크리스트

```
cargo fmt --all -- --check                   OK
cargo clippy -- -D warnings                  0건
cargo test --profile release-test --tests    4,238 passed / 0 failed / 25 ignored (345 스위트)
```

## 배경

[Discussion #3498](https://github.com/edwardkim/rhwp/discussions/3498) 에서 보고한 3건 중 이것만 현행 devel 에 남아 있었습니다. 나머지 2건은 계측 결과 upstream 이 이미 닫아 뒀고([#3552 코멘트](https://github.com/edwardkim/rhwp/issues/3552#issuecomment-5124059979), [정정](https://github.com/edwardkim/rhwp/issues/3552#issuecomment-5124104301)), 제 fork 가 v0.7.13 기준이라 생긴 착오였습니다.