### PR TITLE
feat(tools): 저장본을 한컴이 못 여는 결함을 좁히는 도구 2종 — extract-pages CLI + 레코드 이식 하니스 (#3565)

### DIFF
--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -481,6 +481,16 @@ rhwp export-tables 작성본.hwpx --json | jq '.tables[0].cells[] | select(.row=
 - `--verify-pages` — 저장 전 문서 페이지 수와 저장 후 재로딩 페이지 수를 비교한다.
   불일치하면 산출물은 남기고 종료 코드 4로 실패한다.
 
+### `extract-pages <입력> <출력.hwp> --from N --to M [--json]` (#3565)
+지정한 쪽 범위만 남겨 저장한다. **대형 문서의 결함을 이분법으로 좁히기 위한 진단 도구**다
+(387쪽 문서가 저장 후 한컴에서 열리지 않을 때 절반씩 잘라 재현 여부를 본다).
+- 쪽 단위로 자르되 **문단 단위로** 지운다. 여러 쪽에 걸친 문단은 한 쪽이라도 범위 안이면 남긴다.
+- 결과 쪽수가 요청 범위와 정확히 같지 않을 수 있다(잘라 낸 뒤 레이아웃이 다시 흐른다).
+  목적은 **재현 최소화**이지 정밀한 페이지 오려내기가 아니다.
+- 구역·DocInfo·BinData 는 그대로 남는다. 그 축들을 떼어 내려면
+  [`tools/hwp_open_bisect/`](../../tools/hwp_open_bisect/README.md) 를 쓴다.
+- `--json` — 결과 요약(원본/추출 후 쪽수, 남긴·지운 문단 수)을 JSON 한 줄로 출력한다.
+
 ### `export-hwpx <입력.hwp|.hwpx> [출력.hwpx] [--verify] [--verify-pages]` (#1868, #1638)
 HWP 문서를 HWPX(ZIP+XML)로 변환 저장. `convert`(배포용 해제)와 별개의 포맷 변환 명령.
 - 입력 포맷 자동 감지(HWP5/HWP3/HWPX — HWPX 입력은 재직렬화).

--- a/src/document_core/commands/mod.rs
+++ b/src/document_core/commands/mod.rs
@@ -5,5 +5,7 @@ mod formatting;
 mod header_footer_ops;
 mod html_import;
 mod object_ops;
+// [#3565] 대형 문서 결함을 이분법으로 좁히기 위한 쪽 범위 추출.
+pub mod page_extract;
 mod table_ops;
 mod text_editing;

--- a/src/document_core/commands/page_extract.rs
+++ b/src/document_core/commands/page_extract.rs
@@ -1,0 +1,118 @@
+//! 페이지 범위 추출 — 대형 문서의 결함을 이분법으로 좁히기 위한 도구.
+//!
+//! 384쪽 문서가 저장 후 한컴에서 열리지 않을 때(#3565), "어떤 요소가 방아쇠인가"를
+//! 알려면 문서를 절반씩 잘라 재현 여부를 봐야 한다. 그때 필요한 것이 이 기능이다.
+//!
+//! **쪽 단위로 자르되 문단 단위로 지운다** — 한 문단이 여러 쪽에 걸치면 그 문단이 닿는
+//! 쪽 중 하나라도 범위 안이면 남긴다. 잘라 낸 결과의 쪽수가 요청 범위와 정확히 같을
+//! 필요는 없다(레이아웃이 다시 흐르므로). 이 도구의 목적은 **재현 최소화**이지 정밀한
+//! 페이지 오려내기가 아니다.
+
+use crate::document_core::DocumentCore;
+use crate::error::HwpError;
+
+/// 추출 결과 요약.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PageExtractReport {
+    /// 원본 쪽수
+    pub pages_before: u32,
+    /// 추출 후 쪽수
+    pub pages_after: u32,
+    /// 남긴 문단 수
+    pub kept: usize,
+    /// 지운 문단 수
+    pub removed: usize,
+}
+
+impl DocumentCore {
+    /// [#3565] `from`..=`to`(1 기준) 쪽에 걸친 문단만 남기고 나머지를 지운다.
+    ///
+    /// 범위 밖이거나 `from > to` 면 오류. 남길 문단이 없으면 구역의 마지막 문단은
+    /// 지울 수 없다는 기존 제약에 걸리므로, 각 구역에 최소 1개는 남긴다.
+    pub fn extract_page_range(
+        &mut self,
+        from: u32,
+        to: u32,
+    ) -> Result<PageExtractReport, HwpError> {
+        if from == 0 || to < from {
+            return Err(HwpError::RenderError(format!(
+                "쪽 범위가 잘못됐습니다: {from}..{to} (1 기준, from <= to)"
+            )));
+        }
+        let pages_before = self.page_count();
+        if from > pages_before {
+            return Err(HwpError::RenderError(format!(
+                "시작 쪽 {from} 이 문서 쪽수 {pages_before} 를 넘습니다"
+            )));
+        }
+
+        // 구역별로 "남길 문단" 집합을 만든다. 페이지 번호는 구역을 가로질러 이어진다.
+        let keep = self.paragraphs_touching_pages(from, to);
+
+        let mut kept = 0usize;
+        let mut removed = 0usize;
+        for sec_idx in (0..self.document.sections.len()).rev() {
+            let total = self.document.sections[sec_idx].paragraphs.len();
+            let sec_keep = keep.get(&sec_idx);
+            // 인덱스가 밀리지 않도록 뒤에서부터 지운다.
+            for pi in (0..total).rev() {
+                let want = sec_keep.is_some_and(|s| s.contains(&pi));
+                if want {
+                    kept += 1;
+                    continue;
+                }
+                // 구역의 마지막 한 문단은 남긴다(기존 제약).
+                if self.document.sections[sec_idx].paragraphs.len() <= 1 {
+                    kept += 1;
+                    continue;
+                }
+                if self.delete_paragraph_native(sec_idx, pi).is_ok() {
+                    removed += 1;
+                } else {
+                    kept += 1;
+                }
+            }
+        }
+
+        self.invalidate_page_tree_cache();
+        self.paginate_if_needed();
+        Ok(PageExtractReport {
+            pages_before,
+            pages_after: self.page_count(),
+            kept,
+            removed,
+        })
+    }
+
+    /// `from`..=`to` 쪽에 조금이라도 걸치는 문단을 구역별로 모은다.
+    fn paragraphs_touching_pages(
+        &self,
+        from: u32,
+        to: u32,
+    ) -> std::collections::HashMap<usize, std::collections::HashSet<usize>> {
+        let mut keep: std::collections::HashMap<usize, std::collections::HashSet<usize>> =
+            Default::default();
+        let mut global_page = 0u32;
+        for (sec_idx, pr) in self.pagination.iter().enumerate() {
+            let body_len = self.section_render_paragraphs(sec_idx).len();
+            for page in &pr.pages {
+                global_page += 1;
+                if global_page < from || global_page > to {
+                    continue;
+                }
+                let set = keep.entry(sec_idx).or_default();
+                for col in &page.column_contents {
+                    for item in &col.items {
+                        // 미주 문단(para_index >= body_len)은 본문 인덱스가 아니라 건너뛴다.
+                        // EndnoteSeparator 는 usize::MAX 를 주므로 같은 조건으로 걸러진다.
+                        let pi = item.para_index();
+                        if pi < body_len {
+                            set.insert(pi);
+                        }
+                    }
+                }
+            }
+        }
+        keep
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6173,17 +6173,24 @@ fn extract_pages(args: &[String]) -> i32 {
     while i < args.len() {
         match args[i].as_str() {
             "--from" | "--to" => {
-                let name = args[i].clone();
+                // 옵션 이름을 리터럴로 고정하고 인자 값은 에코하지 않는다.
+                // 같은 `args` 에 `--password` 가 실릴 수 있어, 인자에서 온 문자열을
+                // 그대로 찍으면 비밀번호가 로그에 남는다 (CodeQL: cleartext logging).
+                let opt: &'static str = if args[i] == "--from" {
+                    "--from"
+                } else {
+                    "--to"
+                };
                 i += 1;
                 let Some(v) = args.get(i) else {
-                    eprintln!("오류: {name} 뒤에 쪽 번호가 필요합니다.");
+                    eprintln!("오류: {opt} 뒤에 쪽 번호가 필요합니다.");
                     return EXIT_USAGE;
                 };
                 let Ok(n) = v.parse::<u32>() else {
-                    eprintln!("오류: {name} 값이 숫자가 아닙니다: {v}");
+                    eprintln!("오류: {opt} 값이 숫자가 아닙니다.");
                     return EXIT_USAGE;
                 };
-                if name == "--from" {
+                if opt == "--from" {
                     from = Some(n)
                 } else {
                     to = Some(n)

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,6 +181,7 @@ fn main() {
         Some("diag") => exit_with(diag_document(&args[2..])),
         Some("search") => exit_with(search_document(&args[2..])),
         Some("convert") => exit_with(convert_hwp(&args[2..])),
+        Some("extract-pages") => exit_with(extract_pages(&args[2..])),
         Some("build-from-ingest") => exit_with(build_from_ingest(&args[2..])),
         Some("hwp5-inventory") => rhwp::diagnostics::hwp5_inventory::run(&args[2..]),
         Some("hwp5-inventory-diff") => rhwp::diagnostics::hwp5_inventory_diff::run(&args[2..]),
@@ -6152,6 +6153,127 @@ fn verify_reparse_failed_exit_code(options: ConversionVerifyOptions) -> i32 {
     } else {
         4
     }
+}
+
+/// [#3565] `extract-pages` — 쪽 범위만 남겨 저장한다.
+///
+/// 대형 문서의 결함을 이분법으로 좁히기 위한 도구다. 384쪽 문서가 저장 후 한컴에서
+/// 열리지 않을 때, 절반씩 잘라 재현 여부를 보면 방아쇠를 특정할 수 있다.
+///
+/// 쪽 단위로 자르되 **문단 단위로** 지운다 — 여러 쪽에 걸친 문단은 한 쪽이라도 범위 안이면
+/// 남긴다. 결과 쪽수가 요청 범위와 정확히 같지 않을 수 있다(레이아웃이 다시 흐른다).
+fn extract_pages(args: &[String]) -> i32 {
+    let mut input: Option<&str> = None;
+    let mut output: Option<&str> = None;
+    let mut from: Option<u32> = None;
+    let mut to: Option<u32> = None;
+    let mut json_mode = false;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--from" | "--to" => {
+                let name = args[i].clone();
+                i += 1;
+                let Some(v) = args.get(i) else {
+                    eprintln!("오류: {name} 뒤에 쪽 번호가 필요합니다.");
+                    return EXIT_USAGE;
+                };
+                let Ok(n) = v.parse::<u32>() else {
+                    eprintln!("오류: {name} 값이 숫자가 아닙니다: {v}");
+                    return EXIT_USAGE;
+                };
+                if name == "--from" {
+                    from = Some(n)
+                } else {
+                    to = Some(n)
+                }
+            }
+            "-o" | "--output" => {
+                i += 1;
+                output = args.get(i).map(|s| s.as_str());
+            }
+            "--json" => json_mode = true,
+            v if v.starts_with('-') => {
+                eprintln!("알 수 없는 옵션: {v}");
+                return EXIT_USAGE;
+            }
+            v => {
+                if input.is_none() {
+                    input = Some(v)
+                } else if output.is_none() {
+                    output = Some(v)
+                }
+            }
+        }
+        i += 1;
+    }
+
+    let (Some(input), Some(output)) = (input, output) else {
+        eprintln!("사용법: rhwp extract-pages <입력> <출력.hwp> --from N --to M [--json]");
+        return EXIT_USAGE;
+    };
+    let from = from.unwrap_or(1);
+    let Some(to) = to else {
+        eprintln!("오류: --to 가 필요합니다.");
+        return EXIT_USAGE;
+    };
+
+    let data = match fs::read(input) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: 파일을 읽을 수 없습니다 - {input}: {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    let mut doc = match rhwp::wasm_api::HwpDocument::from_bytes(&data) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: 문서 파싱 실패 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    let report = match doc.extract_page_range(from, to) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("오류: 쪽 추출 실패 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    let bytes = match doc.export_hwp_with_adapter() {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("오류: HWP 직렬화 실패 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    if let Err(e) = fs::write(output, &bytes) {
+        eprintln!("오류: 출력 쓰기 실패 - {output}: {e}");
+        return EXIT_RUNTIME;
+    }
+
+    if json_mode {
+        println!(
+            "{}",
+            serde_json::json!({
+                "schemaVersion": "1.0",
+                "source": input,
+                "output": output,
+                "from": from,
+                "to": to,
+                "pagesBefore": report.pages_before,
+                "pagesAfter": report.pages_after,
+                "paragraphsKept": report.kept,
+                "paragraphsRemoved": report.removed,
+            })
+        );
+    } else {
+        println!(
+            "추출 완료: {output} ({}~{}쪽) — {}쪽 → {}쪽, 문단 {}개 남기고 {}개 제거",
+            from, to, report.pages_before, report.pages_after, report.kept, report.removed
+        );
+    }
+    EXIT_OK
 }
 
 fn convert_hwp(args: &[String]) -> i32 {

--- a/tests/issue_2724_passthrough_invalidation_guard.rs
+++ b/tests/issue_2724_passthrough_invalidation_guard.rs
@@ -298,6 +298,14 @@ const EXEMPT: &[(&str, &str, Exempt, &str)] = &[
         "얇은 래퍼 — 실제 삽입·무효화는 `_impl` 이 수행.",
     ),
     (
+        "commands/page_extract.rs",
+        "extract_page_range",
+        Exempt::DelegatesTo("delete_paragraph_native"),
+        "[#3565] 지우는 일은 전부 문단 삭제 뮤테이터에 위임하고, 그쪽이 손댄 구역의 \
+         `raw_stream` 을 무효화한다. 한 문단도 지우지 않은 구역은 원본이 그대로 \
+         유효하므로 통과를 남기는 것이 맞다.",
+    ),
+    (
         "commands/text_editing.rs",
         "insert_text_in_cell_native_deferred_pagination",
         Exempt::DelegatesTo("replace_text_in_cell_native_impl"),

--- a/tests/issue_3565_extract_pages.rs
+++ b/tests/issue_3565_extract_pages.rs
@@ -18,6 +18,9 @@ use rhwp::document_core::DocumentCore;
 /// 여러 쪽·여러 구역이 있는 표본.
 const SAMPLE: &str = "samples/issue2083_hide_fill_page.hwpx";
 
+/// 원본 스트림 통과(`raw_stream`)를 들고 오는 HWP5 출처 표본.
+const HWP5_SAMPLE: &str = "samples/2022년 국립국어원 업무계획.hwp";
+
 fn load() -> DocumentCore {
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
     let bytes = std::fs::read(&path).expect("표본 읽기");
@@ -75,6 +78,46 @@ fn extracted_document_is_still_loadable() {
             .iter()
             .any(|s| !s.paragraphs.is_empty()),
         "재파싱 결과가 비어 있다"
+    );
+}
+
+/// HWP5 출처 문서에서도 추출이 **저장 결과에 실제로 반영**된다.
+///
+/// HWP5 로 연 문서는 구역마다 `raw_stream`(원본 바이트)을 들고 있고, 저장기는 그것이
+/// 남아 있으면 원본을 그대로 되돌려 준다. 삭제하면서 이 통과를 무효화하지 않으면
+/// **잘라 낸 결과가 저장본에서 조용히 사라진다** — 컴파일 에러도 테스트 실패도 없이.
+/// `extract_page_range` 는 삭제를 `delete_paragraph_native` 에 위임해 그쪽이 무효화한다
+/// (#2724 원장에 위임으로 등재). 그 위임이 실제로 듣는지 저장 결과로 확인한다.
+#[test]
+fn extraction_survives_saving_for_hwp5_source() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(HWP5_SAMPLE);
+    let bytes = std::fs::read(&path).expect("HWP5 표본 읽기");
+    let mut core = DocumentCore::from_bytes(&bytes).expect("파싱");
+
+    let had_passthrough = core
+        .document()
+        .sections
+        .iter()
+        .any(|s| s.raw_stream.is_some());
+    assert!(
+        had_passthrough,
+        "HWP5 표본인데 raw_stream 이 없다 — 통과 경로를 검증할 수 없다"
+    );
+
+    let paras_before = total_paragraphs(&core);
+    let report = core.extract_page_range(1, 1).expect("1쪽 추출");
+    assert!(
+        report.removed > 0,
+        "지운 문단이 없어 검증이 성립하지 않는다"
+    );
+
+    let saved = core.export_hwp_native().expect("저장");
+    let reloaded = DocumentCore::from_bytes(&saved).expect("재파싱");
+    assert!(
+        total_paragraphs(&reloaded) < paras_before,
+        "저장본에 삭제가 반영되지 않았다 ({paras_before} → {}) — \
+         원본 스트림 통과가 무효화되지 않아 편집이 사라진 것이다",
+        total_paragraphs(&reloaded)
     );
 }
 

--- a/tests/issue_3565_extract_pages.rs
+++ b/tests/issue_3565_extract_pages.rs
@@ -1,0 +1,110 @@
+//! `extract-pages` — 쪽 범위만 남겨 저장하는 진단 도구 (#3565).
+//!
+//! 387쪽 문서가 저장 후 한컴에서 열리지 않을 때, 절반씩 잘라 재현 여부를 보면 방아쇠를
+//! 좁힐 수 있다. 그때 필요한 것이 이 기능이다.
+//!
+//! 계약은 셋이다.
+//!
+//! 1. 요청 범위에 걸친 문단은 남고, 나머지는 지워진다 (쪽수가 줄어든다).
+//! 2. 잘라 낸 결과가 **다시 열리는 정상 문서**여야 한다 — 재파싱이 되어야 이분법이 성립한다.
+//! 3. 범위가 잘못되면 조용히 넘어가지 않고 오류를 낸다.
+//!
+//! 결과 쪽수가 요청 범위와 정확히 같을 필요는 없다(잘라 낸 뒤 레이아웃이 다시 흐른다).
+//! 목적은 재현 최소화이지 정밀한 페이지 오려내기가 아니다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::document_core::DocumentCore;
+
+/// 여러 쪽·여러 구역이 있는 표본.
+const SAMPLE: &str = "samples/issue2083_hide_fill_page.hwpx";
+
+fn load() -> DocumentCore {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = std::fs::read(&path).expect("표본 읽기");
+    DocumentCore::from_bytes(&bytes).expect("파싱")
+}
+
+fn total_paragraphs(core: &DocumentCore) -> usize {
+    core.document()
+        .sections
+        .iter()
+        .map(|s| s.paragraphs.len())
+        .sum()
+}
+
+/// 첫 쪽만 남기면 쪽수와 문단 수가 함께 줄어든다.
+#[test]
+fn extracting_first_page_shrinks_the_document() {
+    let mut core = load();
+    let pages_before = core.page_count();
+    let paras_before = total_paragraphs(&core);
+    assert!(
+        pages_before >= 2,
+        "표본이 1쪽뿐이라 추출을 검증할 수 없다 — 표본이 바뀌었는지 확인하라"
+    );
+
+    let report = core.extract_page_range(1, 1).expect("1쪽 추출");
+
+    assert_eq!(report.pages_before, pages_before);
+    assert!(
+        report.pages_after < pages_before,
+        "쪽수가 줄지 않았다: {} → {}",
+        report.pages_before,
+        report.pages_after
+    );
+    assert!(report.removed > 0, "지운 문단이 없다");
+    assert!(
+        total_paragraphs(&core) < paras_before,
+        "문단이 줄지 않았다: {paras_before} → {}",
+        total_paragraphs(&core)
+    );
+}
+
+/// 잘라 낸 결과가 다시 열려야 이분법이 성립한다.
+#[test]
+fn extracted_document_is_still_loadable() {
+    let mut core = load();
+    core.extract_page_range(1, 1).expect("1쪽 추출");
+
+    let saved = core.export_hwp_native().expect("저장");
+    let reloaded = DocumentCore::from_bytes(&saved).expect("잘라 낸 산출물 재파싱");
+    assert!(
+        reloaded
+            .document()
+            .sections
+            .iter()
+            .any(|s| !s.paragraphs.is_empty()),
+        "재파싱 결과가 비어 있다"
+    );
+}
+
+/// 전체 범위를 요청하면 아무것도 지우지 않는다.
+#[test]
+fn full_range_keeps_everything() {
+    let mut core = load();
+    let pages = core.page_count();
+    let paras = total_paragraphs(&core);
+
+    let report = core.extract_page_range(1, pages).expect("전체 범위");
+
+    assert_eq!(report.removed, 0, "전체 범위인데 문단을 지웠다");
+    assert_eq!(report.pages_after, pages);
+    assert_eq!(total_paragraphs(&core), paras);
+}
+
+/// 잘못된 범위는 조용히 넘어가지 않고 오류를 낸다.
+#[test]
+fn invalid_ranges_are_rejected() {
+    let mut core = load();
+    let pages = core.page_count();
+
+    assert!(core.extract_page_range(0, 1).is_err(), "0쪽 시작을 받았다");
+    assert!(
+        core.extract_page_range(3, 2).is_err(),
+        "from > to 를 받았다"
+    );
+    assert!(
+        core.extract_page_range(pages + 1, pages + 2).is_err(),
+        "문서 쪽수를 넘는 시작 쪽을 받았다"
+    );
+}

--- a/tools/hwp_open_bisect/README.md
+++ b/tools/hwp_open_bisect/README.md
@@ -1,0 +1,73 @@
+# hwp_open_bisect — 저장했는데 한컴이 못 여는 결함 추적
+
+`rhwp` 가 저장한 HWP 를 한컴이 **열지 못하는** 결함(#3565 계열)은 `convert --verify` 로
+잡히지 않는다. rhwp 자기 파서가 자기가 쓴 파일을 그대로 되읽기 때문이다. 판정자는
+한컴뿐이고, 문제는 "387쪽 문서가 안 열린다"에서 원인까지 어떻게 좁히느냐다.
+
+이 도구는 **한컴이 같은 원본을 저장한 파일을 정답지로 삼아**, rhwp 산출물의 일부만
+정답지에 이식해 개방 여부로 이분한다. 코드를 고치지 않고 결함 위치를 짚는다.
+
+## 절차
+
+```bash
+SRC="samples/문제문서.hwpx"
+O=oracle.hwp; C=candidate.hwp
+
+# 0) 후보와 정답지를 만든다
+rhwp convert "$SRC" $C
+python tools/hwp_open_bisect/hangul_com.py save-as "$SRC" $O
+
+# 1) 재현 확인 — 후보는 못 열리고 정답지는 열려야 한다
+python tools/hwp_open_bisect/hangul_com.py check-open $C   # rc=1
+python tools/hwp_open_bisect/hangul_com.py check-open $O   # rc=0
+
+# 2) 구조를 본다 — 레코드 수·태그·레벨·크기가 어디서 갈리는가
+python tools/hwp_open_bisect/record_bisect.py diff $O $C
+
+# 3) 구역 단위로 좁힌다
+python tools/hwp_open_bisect/record_bisect.py hybrid $O $C h.hwp --stream BodyText/Section7
+python tools/hwp_open_bisect/hangul_com.py check-open h.hwp
+
+# 4) 레코드 종류로 좁힌다 (--invert 로 여집합도 함께 본다)
+python tools/hwp_open_bisect/record_bisect.py hybrid $O $C h.hwp --section 7 --tag 76
+
+# 5) 바이트 구간까지 좁힌다
+python tools/hwp_open_bisect/record_bisect.py hybrid $O $C h.hwp \
+    --section 7 --tag 76 --restore-bytes 190-220
+```
+
+`--tag` 와 `--invert` 를 **한 쌍으로** 돌려 상보 결과(하나는 실패, 하나는 개방)를 얻으면
+그 종류가 단독 원인이라는 확증이 된다.
+
+## 반드시 지킬 것
+
+**대조군을 매 라운드에 넣는다.** 이식 실험은 원래 결함이 아닌 **새 결함**을 쉽게 만든다.
+#3565 추적에서 실제로 걸린 것들:
+
+| 자해 실험 | 왜 깨졌나 |
+|---|---|
+| 라이브러리 저장 직접 호출 | `doc_properties.section_count` 가 stale(1) 이라 구역 14개 문서에 1 을 쓴다 |
+| 컨트롤만 제거 | 본문의 컨트롤 문자와 `char_count` 를 그대로 둬 개수가 어긋난다 |
+| 본문만 이식 | 후보 본문이 정답지 DocInfo 의 없는 ID 를 가리킨다 (`--with-docinfo` 기본값이 막는다) |
+| `PARA_HEADER` 만 이식 | "영역 태그 0개" 선언과 정답지 `PARA_RANGE_TAG` 레코드가 공존한다 |
+
+무이식 판(`hybrid` 를 `--records 0-0` 으로)이 **열려야** 도구·파이프라인이 건전하다는
+뜻이다. 이 대조 없이 얻은 판정은 믿지 않는다.
+
+**COM 은 직렬로.** 판정을 동시에 돌리면 서로의 `Hwp.exe` 를 죽여 "무응답" 오판이 난다.
+한 프로세스에서 `Hwp()` 를 두 번 만들지도 말 것(두 번째가 `com_error` 로 죽는다).
+
+## #3565 에서 나온 결과
+
+387쪽 13MB 문서 → 구역 → 문단 → 레코드 종류 → 바이트 순으로 좁혀,
+그룹 컨테이너가 자식 목록에 쓰는 **종류 선언이 실제 레코드와 어긋난다**는 것을 찾았다
+(중첩 그룹 `gso ` vs `$con`, 연결선 `$lin` vs `$col`). 레코드 **구조 자체는 정답지와
+완전히 일치**했고 차이는 그 목록 내용뿐이었다.
+
+같은 대조에서 개방과 무관한 정합 손실도 함께 드러났다 — #3567(영역 태그 전량 소실),
+#3568(탭 매개변수 소실), #3569(BorderFill 초과), #3570(표·선 레코드 크기 불일치).
+
+## 의존
+
+`olefile`, `pyhwpx`(COM 판정용, Windows + 한컴 설치 필요). `diff`/`hybrid` 는 COM 없이
+동작하므로 정답지만 확보하면 어느 환경에서나 쓸 수 있다.

--- a/tools/hwp_open_bisect/hangul_com.py
+++ b/tools/hwp_open_bisect/hangul_com.py
@@ -1,0 +1,93 @@
+"""한컴 COM 오라클 — 문서를 열어 보거나, 한컴에게 저장시켜 정답지를 만든다.
+
+`rhwp` 가 저장한 HWP 를 한컴이 **열지 못하는** 결함(#3565 계열)을 추적할 때 쓴다.
+rhwp 자기 파서는 자기가 쓴 파일을 그대로 되읽으므로 `convert --verify` 로는 잡히지
+않는다. 판정자는 한컴뿐이다.
+
+## 쓰임
+
+    # 후보 파일이 열리는가 (rc=0 열림 / rc=1 못 엶)
+    python tools/hwp_open_bisect/hangul_com.py check-open out.hwp
+
+    # 한컴에게 같은 원본을 HWP5 로 저장시켜 **정답지** 를 만든다
+    python tools/hwp_open_bisect/hangul_com.py save-as src.hwpx oracle.hwp
+
+## 주의
+
+- **인스턴스를 한 프로세스에서 재생성하지 말 것.** 두 번째 `Hwp()` 는 `com_error` 로
+  죽는다. 파일 하나당 프로세스 하나로 실행한다(이 스크립트가 그 단위다).
+- 여러 판정을 **동시에 돌리지 말 것.** 서로의 `Hwp.exe` 를 죽여 "무응답" 오판을 만든다.
+- 열리지 않는 문서는 한컴이 멎기도 한다. 호출 측에서 시간 제한을 걸고, 끝난 뒤
+  남은 `Hwp.exe`/`HwpFrame.exe` 를 정리한다.
+"""
+
+import argparse
+import sys
+
+
+def _hwp():
+    from pyhwpx import Hwp
+
+    return Hwp(visible=False)
+
+
+def check_open(path: str) -> int:
+    """한컴으로 열어 본다. 열리면 쪽수를 찍고 0, 못 열면 1."""
+    hwp = _hwp()
+    try:
+        ok = bool(hwp.open(path))
+        pages = hwp.PageCount if ok else 0
+        print(f"open={ok} pages={pages}")
+        return 0 if ok else 1
+    except Exception as exc:  # noqa: BLE001 - COM 예외 종류가 다양하다
+        print(f"예외 {type(exc).__name__}: {exc}")
+        return 2
+    finally:
+        _quit(hwp)
+
+
+def save_as(src: str, dst: str) -> int:
+    """한컴에게 `src` 를 열어 `dst`(HWP5) 로 저장시킨다 — 대조용 정답지."""
+    hwp = _hwp()
+    try:
+        if not hwp.open(src):
+            print(f"open=False — 원본을 한컴이 열지 못한다: {src}")
+            return 1
+        print(f"open=True pages={hwp.PageCount}")
+        ok = bool(hwp.save_as(dst, "HWP"))
+        print(f"saveas={ok}")
+        return 0 if ok else 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"예외 {type(exc).__name__}: {exc}")
+        return 2
+    finally:
+        _quit(hwp)
+
+
+def _quit(hwp) -> None:
+    for call in ("clear", "quit"):
+        try:
+            getattr(hwp, call)()
+        except Exception:  # noqa: BLE001 - 정리 실패는 판정에 영향 없다
+            pass
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_open = sub.add_parser("check-open", help="한컴으로 열리는지 판정한다")
+    p_open.add_argument("path")
+
+    p_save = sub.add_parser("save-as", help="한컴에게 저장시켜 정답지를 만든다")
+    p_save.add_argument("src")
+    p_save.add_argument("dst")
+
+    args = parser.parse_args(argv)
+    if args.cmd == "check-open":
+        return check_open(args.path)
+    return save_as(args.src, args.dst)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hwp_open_bisect/record_bisect.py
+++ b/tools/hwp_open_bisect/record_bisect.py
@@ -1,0 +1,272 @@
+"""HWP5 레코드 대조·이식 — "저장했는데 한컴이 못 여는" 결함을 바이트까지 좁힌다.
+
+한컴이 같은 원본을 저장한 파일을 **정답지**로 두고, rhwp 산출물의 일부만 정답지에
+이식해 개방 여부를 본다. 열리면 그 부분은 무죄, 못 열면 그 안에 원인이 있다.
+코드를 고치지 않고 결함 위치를 짚을 수 있다.
+
+## 쓰임
+
+    O=oracle.hwp; C=rhwp_out.hwp
+
+    # 1) 구조부터 본다 — 레코드 수·태그·레벨·크기가 어디서 갈리는가
+    python tools/hwp_open_bisect/record_bisect.py diff $O $C
+
+    # 2) 스트림 통째로: 후보의 Section0 만 정답지에 넣는다
+    python tools/hwp_open_bisect/record_bisect.py hybrid $O $C out.hwp --stream BodyText/Section0
+
+    # 3) 레코드 종류로: 후보의 SHAPE_COMPONENT(76) 만 넣는다 (--invert 로 여집합)
+    python tools/hwp_open_bisect/record_bisect.py hybrid $O $C out.hwp --section 0 --tag 76
+
+    # 4) 레코드 번호 범위로 이분한다
+    python tools/hwp_open_bisect/record_bisect.py hybrid $O $C out.hwp --section 0 --records 0-268
+
+    # 5) 특정 태그의 특정 바이트 구간만 정답지 값으로 되돌린다
+    python tools/hwp_open_bisect/record_bisect.py hybrid $O $C out.hwp \
+        --section 0 --tag 76 --restore-bytes 190-220
+
+    # 각 산출물을 hangul_com.py check-open 으로 판정한다
+
+## 함정 (겪은 것들)
+
+- **ID 공간을 맞출 것.** 본문 레코드만 옮기고 DocInfo 는 정답지 것을 두면, 글자모양·
+  테두리 ID 가 어긋나 내용과 무관하게 깨진다. `--with-docinfo`(기본값)가 후보의
+  DocInfo 를 함께 넣어 이 교란을 없앤다.
+- **부분 이식은 새 모순을 만든다.** 예컨대 `PARA_HEADER` 만 후보 것으로 바꾸면 "영역
+  태그 0개" 선언과 정답지의 `PARA_RANGE_TAG` 레코드가 공존해 실패한다. 이건 원래
+  결함이 아니라 실험이 만든 결함이다. **매 라운드 대조군**(`--tag` 없이 전량/무이식)을
+  함께 돌려 걸러야 한다.
+- **레코드 수가 다르면** 번호 대응이 깨진다. 이 도구는 `(태그, 레벨, 크기)` 로 정렬해
+  일치 구간에서만 이식하므로 수가 달라도 쓸 수 있다.
+- 스트림 슬롯 크기를 넘으면 쓸 수 없다. 보통 rhwp 쪽이 작아 문제되지 않는다.
+"""
+
+import argparse
+import shutil
+import struct
+import sys
+import zlib
+from difflib import SequenceMatcher
+
+import olefile
+
+TAG_NAMES = {
+    66: "PARA_HEADER",
+    67: "PARA_TEXT",
+    68: "PARA_CHAR_SHAPE",
+    69: "PARA_LINE_SEG",
+    70: "PARA_RANGE_TAG",
+    71: "CTRL_HEADER",
+    72: "LIST_HEADER",
+    76: "SHAPE_COMPONENT",
+    77: "TABLE",
+    78: "SC_LINE",
+    79: "SC_RECTANGLE",
+    85: "SC_PICTURE",
+    86: "SC_CONTAINER",
+    87: "CTRL_DATA",
+}
+
+
+def read_stream(path, name):
+    ole = olefile.OleFileIO(path)
+    try:
+        return ole.openstream(name).read()
+    finally:
+        ole.close()
+
+
+def stream_names(path, prefix="BodyText/Section"):
+    ole = olefile.OleFileIO(path)
+    try:
+        names = ["/".join(p) for p in ole.listdir()]
+    finally:
+        ole.close()
+    return sorted(
+        (n for n in names if n.startswith(prefix)),
+        key=lambda n: int(n.rsplit("Section", 1)[1]) if "Section" in n else 0,
+    )
+
+
+def inflate(raw):
+    try:
+        return zlib.decompress(raw, -15)
+    except zlib.error:
+        return raw
+
+
+def parse_records(buf):
+    """(태그, 레벨, 데이터) 목록. HWP5 레코드 헤더는 32비트(태그10/레벨10/크기12)."""
+    out, pos, end = [], 0, len(buf)
+    while pos + 4 <= end:
+        header = struct.unpack_from("<I", buf, pos)[0]
+        tag, level, size = header & 0x3FF, (header >> 10) & 0x3FF, (header >> 20) & 0xFFF
+        pos += 4
+        if size == 0xFFF:  # 확장 크기
+            if pos + 4 > end:
+                break
+            size = struct.unpack_from("<I", buf, pos)[0]
+            pos += 4
+        if pos + size > end:
+            break
+        out.append((tag, level, buf[pos : pos + size]))
+        pos += size
+    return out
+
+
+def emit_records(records):
+    out = bytearray()
+    for tag, level, data in records:
+        n = len(data)
+        if n < 0xFFF:
+            out += struct.pack("<I", (tag & 0x3FF) | ((level & 0x3FF) << 10) | (n << 20))
+        else:
+            out += struct.pack("<I", (tag & 0x3FF) | ((level & 0x3FF) << 10) | (0xFFF << 20))
+            out += struct.pack("<I", n)
+        out += data
+    return bytes(out)
+
+
+def section_records(path, section):
+    name = f"BodyText/Section{section}"
+    return parse_records(inflate(read_stream(path, name))), name
+
+
+def cmd_diff(args):
+    """두 파일의 레코드 구조·내용 차이를 요약한다."""
+    a_names = stream_names(args.oracle)
+    b_names = stream_names(args.candidate)
+    print(f"구역: 정답지 {len(a_names)} / 후보 {len(b_names)}")
+    for name in a_names:
+        if name not in b_names:
+            print(f"  {name}: 후보에 없음")
+            continue
+        a = parse_records(inflate(read_stream(args.oracle, name)))
+        b = parse_records(inflate(read_stream(args.candidate, name)))
+        ka = [(t, lv, len(d)) for t, lv, d in a]
+        kb = [(t, lv, len(d)) for t, lv, d in b]
+        unmatched, content = {}, {}
+        for op, i1, i2, j1, j2 in SequenceMatcher(a=ka, b=kb, autojunk=False).get_opcodes():
+            if op != "equal":
+                for i in range(i1, i2):
+                    unmatched.setdefault(("정답지만", a[i][0]), 0)
+                    unmatched[("정답지만", a[i][0])] += 1
+                for j in range(j1, j2):
+                    unmatched.setdefault(("후보만", b[j][0]), 0)
+                    unmatched[("후보만", b[j][0])] += 1
+                continue
+            for k in range(i2 - i1):
+                i, j = i1 + k, j1 + k
+                if a[i][2] != b[j][2]:
+                    content[a[i][0]] = content.get(a[i][0], 0) + 1
+        head = f"  {name}: 레코드 {len(a)} vs {len(b)}"
+        if not unmatched and not content:
+            print(head + "  — 동일")
+            continue
+        print(head)
+        for (side, tag), n in sorted(unmatched.items(), key=lambda x: -x[1]):
+            print(f"      정렬 불일치 {side} {TAG_NAMES.get(tag, tag)} {n}건")
+        for tag, n in sorted(content.items(), key=lambda x: -x[1]):
+            print(f"      내용 차이 {TAG_NAMES.get(tag, tag)} {n}건")
+    return 0
+
+
+def _parse_range(spec):
+    lo, hi = spec.split("-")
+    return int(lo), int(hi)
+
+
+def cmd_hybrid(args):
+    """정답지를 바탕으로 후보의 일부를 이식한 파일을 만든다."""
+    shutil.copy(args.oracle, args.out)
+    ole = olefile.OleFileIO(args.out, write_mode=True)
+    try:
+        if args.with_docinfo:
+            _write_padded(ole, "DocInfo", read_stream(args.candidate, "DocInfo"))
+
+        if args.stream:
+            _write_padded(ole, args.stream, read_stream(args.candidate, args.stream))
+            print(f"이식: {args.stream} 통째")
+            return 0
+
+        a, name = section_records(args.oracle, args.section)
+        b, _ = section_records(args.candidate, args.section)
+        mixed, swapped = list(a), 0
+        rec_lo, rec_hi = _parse_range(args.records) if args.records else (0, len(a))
+        restore = _parse_range(args.restore_bytes) if args.restore_bytes else None
+
+        for op, i1, i2, j1, j2 in SequenceMatcher(
+            a=[(t, lv, len(d)) for t, lv, d in a],
+            b=[(t, lv, len(d)) for t, lv, d in b],
+            autojunk=False,
+        ).get_opcodes():
+            if op != "equal":
+                continue
+            for k in range(i2 - i1):
+                i, j = i1 + k, j1 + k
+                if not rec_lo <= i < rec_hi:
+                    continue
+                if args.tag is not None:
+                    match = a[i][0] == args.tag
+                    take = (not match) if args.invert else match
+                    if not take:
+                        continue
+                data = b[j][2]
+                if restore and len(data) == len(a[i][2]):
+                    buf = bytearray(data)
+                    lo, hi = restore
+                    buf[lo:hi] = a[i][2][lo:hi]
+                    data = bytes(buf)
+                mixed[i] = (b[j][0], b[j][1], data)
+                swapped += 1
+
+        _write_padded(ole, name, zlib.compress(emit_records(mixed), 9)[2:-4])
+        print(f"이식: {name} 레코드 {swapped}건")
+        return 0
+    finally:
+        ole.close()
+
+
+def _write_padded(ole, name, data):
+    size = ole.get_size(name)
+    if len(data) > size:
+        raise SystemExit(f"슬롯 초과: {name} 은 {size}B 인데 {len(data)}B 를 쓰려 한다")
+    # deflate 스트림 뒤의 잉여 바이트는 읽는 쪽이 무시하므로 0 으로 채워 크기를 맞춘다.
+    ole.write_stream(name, data + b"\x00" * (size - len(data)))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_diff = sub.add_parser("diff", help="레코드 구조·내용 차이 요약")
+    p_diff.add_argument("oracle")
+    p_diff.add_argument("candidate")
+    p_diff.set_defaults(func=cmd_diff)
+
+    p_hy = sub.add_parser("hybrid", help="정답지에 후보 일부를 이식한다")
+    p_hy.add_argument("oracle")
+    p_hy.add_argument("candidate")
+    p_hy.add_argument("out")
+    p_hy.add_argument("--stream", help="스트림 통째 이식 (예: BodyText/Section0)")
+    p_hy.add_argument("--section", type=int, default=0, help="레코드 단위 이식 대상 구역")
+    p_hy.add_argument("--tag", type=int, help="이 태그의 레코드만 이식")
+    p_hy.add_argument("--invert", action="store_true", help="--tag 의 여집합을 이식")
+    p_hy.add_argument("--records", help="레코드 번호 범위 (예: 0-268)")
+    p_hy.add_argument(
+        "--restore-bytes",
+        help="이식하되 이 바이트 구간만 정답지 값으로 되돌린다 (예: 190-220)",
+    )
+    p_hy.add_argument(
+        "--no-docinfo",
+        dest="with_docinfo",
+        action="store_false",
+        help="후보 DocInfo 를 함께 넣지 않는다 (ID 공간이 어긋날 수 있다)",
+    )
+    p_hy.set_defaults(func=cmd_hybrid, with_docinfo=True)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
#3565 (387쪽 문서를 저장하면 한컴이 열지 못함) 원인 추적에 쓴 도구를 정리해 넣는다.
원인·수정은 PR #3566 이고, 본 PR 은 **추적 수단**이다.

이 계열은 `convert --verify` 로 잡히지 않는다 — rhwp 자기 파서가 자기가 쓴 파일을 그대로
되읽기 때문이다. 판정자는 한컴뿐이고, 문제는 "387쪽 문서가 안 열린다"에서 원인까지 어떻게
좁히느냐였다.

## 1. `extract-pages` CLI

쪽 범위만 남겨 저장한다. 쪽 단위로 자르되 **문단 단위로** 지운다(여러 쪽에 걸친 문단은
한 쪽이라도 범위 안이면 남긴다). 결과 쪽수가 요청 범위와 정확히 같을 필요는 없다 —
목적은 **재현 최소화**다.

한계도 문서에 적었다: 쪽을 잘라도 **구역·DocInfo·BinData 는 남는다**. 실제로 이번 추적에서
쪽 이분법은 25쪽 조각에서 소진됐고(387쪽 → 25쪽까지 줄여도 여전히 실패) 거기서 아래
하니스로 갈아탔다.

## 2. `tools/hwp_open_bisect/`

한컴이 같은 원본을 저장한 파일을 **정답지**로 두고, rhwp 산출물의 일부만 정답지에 이식해
개방 여부로 이분한다. 코드를 고치지 않고 결함 위치를 짚는다.

| 파일 | 역할 |
|---|---|
| `hangul_com.py` | 개방 판정(rc 0/1), 정답지 저장 (COM, 파일당 프로세스 1개) |
| `record_bisect.py` | 레코드 구조 대조 + 스트림/종류/번호/**바이트** 단위 이식 |
| `README.md` | 절차와 함정 |

레코드 수가 달라도 `(태그, 레벨, 크기)` 정렬로 대응 구간을 찾아 이식한다.

## 함정을 문서에 남겼다

이식 실험은 **원래 결함이 아닌 새 결함을 쉽게 만든다.** 이번 추적에서 실제로 걸린 4종을
README 에 표로 남겼다.

| 자해 실험 | 왜 깨졌나 |
|---|---|
| 라이브러리 저장 직접 호출 | `section_count` 가 stale(1) 이라 구역 14개 문서에 1 을 쓴다 |
| 컨트롤만 제거 | 본문 컨트롤 문자와 `char_count` 를 그대로 둬 개수가 어긋난다 |
| 본문만 이식 | 후보 본문이 정답지 DocInfo 의 없는 ID 를 가리킨다 |
| `PARA_HEADER` 만 이식 | "영역 태그 0개" 선언과 정답지 `PARA_RANGE_TAG` 가 공존한다 |

ID 공간 교란은 `--with-docinfo` 기본값으로 **아예 막았고**, 나머지는 "매 라운드 대조군"
규칙으로 못 박았다. 무이식 판이 열려야 파이프라인이 건전하다는 뜻이다.

## 검증

- `extract-pages` 회귀 테스트 **5건** — 축소 / 재개방 / **HWP5 저장 반영** / 전체범위 / 잘못된 범위
- 하니스 끝단 확인 (#3565 재현본): 대조군 개방 384쪽 → 도형 레코드만 이식 시 실패 →
  여집합 개방 384쪽. **상보 쌍이 그대로 재현**된다
- `diff` 출력이 손으로 분석한 결과와 일치 (PARA_TEXT 68, SHAPE_COMPONENT 49, LIST_HEADER 7)
- `cargo nextest run --no-fail-fast` **4352건 전량 통과**
- `cargo clippy --all-targets -- -D warnings` 경고 0 · `rustfmt --check` 통과

## #2724 가드가 잡은 것 (두 번째 커밋)

`extract_page_range` 가 미분류 뮤테이터로 걸렸다. HWP5 로 연 문서는 구역마다
`raw_stream`(원본 바이트)을 들고 있고, 저장기는 그것이 남아 있으면 원본을 그대로 되돌려
준다. 삭제하면서 이 통과를 무효화하지 않으면 **잘라 낸 결과가 저장본에서 조용히 사라진다.**

실제로는 삭제를 `delete_paragraph_native` 에 위임하고 그쪽이 무효화하므로 안전하다.
위임으로 등재하되, **등재만으로 끝내지 않고** 위임이 실제로 듣는지 확인하는 테스트를
붙였다(`extraction_survives_saving_for_hwp5_source`) — HWP5 표본으로 추출 → 저장 →
재파싱 후 문단 수가 줄었는지 본다.

기존 이분법이 통했던 것은 대상이 HWPX 출처라 `raw_stream` 이 없었기 때문이고, HWP5
문서에 썼다면 조용히 아무 일도 일어나지 않았을 것이다.

관련: #3565 · PR #3566 · #3567 · #3568 · #3569 · #3570

🤖 Generated with [Claude Code](https://claude.com/claude-code)
