### PR TITLE
feat(studio): 셀프 호스팅 빌드용 외부 웹폰트(CDN) 차단 스위치 (#3585)

### DIFF
--- a/npm/editor/README.md
+++ b/npm/editor/README.md
@@ -473,6 +473,18 @@ npx vite build --base=/your-path/
 # 빌드 결과물(dist/)을 서버에 배포
 ```
 
+외부(CDN) 웹폰트를 사용할 수 없는 환경 — 함초롬체 CDN은 비상업적 사용
+조건이므로 상업 환경, 또는 오프라인/폐쇄망 — 에서는 빌드 시점 스위치로
+CDN 로드를 끕니다. 조판(줄바꿈·페이지 분할)은 내장 폰트 메트릭 기준이라
+변하지 않고, 화면 표시만 번들/시스템 글꼴로 대체됩니다:
+
+```bash
+RHWP_DISABLE_EXTERNAL_WEBFONTS=1 npx vite build --base=/your-path/
+```
+
+브라우저 확장 storage에 저장된 `disableExternalWebFonts` 설정이 있으면
+그 값이 빌드 스위치보다 우선합니다.
+
 ```javascript
 const editor = await createEditor('#editor', {
   studioUrl: 'https://your-domain.com/your-path/'

--- a/rhwp-studio/src/core/extension-settings.ts
+++ b/rhwp-studio/src/core/extension-settings.ts
@@ -2,21 +2,34 @@
  * 확장 페이지에서 공유하는 viewer 설정을 읽는다.
  *
  * 일반 web/PWA 환경에서는 확장 storage API가 없으므로 기본값을 반환한다.
+ * 기본값에는 셀프 호스팅용 빌드 스위치(`RHWP_DISABLE_EXTERNAL_WEBFONTS=1`,
+ * vite.config.ts define)가 반영되며, storage에 저장된 값이 있으면 그 값이
+ * 우선한다.
  */
 
 export interface ExtensionViewerSettings {
   disableExternalWebFonts: boolean;
 }
 
-const DEFAULT_SETTINGS: ExtensionViewerSettings = {
-  disableExternalWebFonts: false,
-};
+function buildTimeDisableExternalWebFonts(): boolean {
+  // Vite define 상수 — node:test 등 번들 밖 실행에서는 미정의이므로 typeof 가드.
+  return typeof __RHWP_DISABLE_EXTERNAL_WEBFONTS__ !== 'undefined'
+    && __RHWP_DISABLE_EXTERNAL_WEBFONTS__ === true;
+}
+
+function defaultSettings(): ExtensionViewerSettings {
+  return {
+    disableExternalWebFonts: buildTimeDisableExternalWebFonts(),
+  };
+}
 
 type StorageItems = Record<string, unknown>;
 
-const DEFAULT_STORAGE_ITEMS: StorageItems = {
-  disableExternalWebFonts: DEFAULT_SETTINGS.disableExternalWebFonts,
-};
+function defaultStorageItems(): StorageItems {
+  return {
+    disableExternalWebFonts: defaultSettings().disableExternalWebFonts,
+  };
+}
 
 interface StorageAreaLike {
   get(
@@ -103,8 +116,8 @@ async function readStorage(
   if (!storage) return null;
   try {
     const items = mode === 'chrome-callback'
-      ? await chromeStorageGet(storage, DEFAULT_STORAGE_ITEMS)
-      : await promiseStorageGet(storage, DEFAULT_STORAGE_ITEMS);
+      ? await chromeStorageGet(storage, defaultStorageItems())
+      : await promiseStorageGet(storage, defaultStorageItems());
     return normalizeSettings(items);
   } catch (error) {
     console.warn('[extension-settings] 확장 설정 로드 실패:', error);
@@ -127,6 +140,6 @@ export async function loadExtensionViewerSettings(): Promise<ExtensionViewerSett
     await readStorage(browserStorage?.sync, 'promise') ??
     await readStorage(browserStorage?.local, 'promise') ??
     await readStorage(chromeStorage?.local, 'chrome-callback') ??
-    DEFAULT_SETTINGS
+    defaultSettings()
   );
 }

--- a/rhwp-studio/src/vite-env.d.ts
+++ b/rhwp-studio/src/vite-env.d.ts
@@ -1,3 +1,4 @@
 /// <reference types="vite/client" />
 
 declare const __APP_VERSION__: string;
+declare const __RHWP_DISABLE_EXTERNAL_WEBFONTS__: boolean;

--- a/rhwp-studio/tests/extension-settings-build-switch.test.ts
+++ b/rhwp-studio/tests/extension-settings-build-switch.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { loadExtensionViewerSettings } from '../src/core/extension-settings.ts';
+
+type MutableGlobal = typeof globalThis & {
+  __RHWP_DISABLE_EXTERNAL_WEBFONTS__?: boolean;
+  chrome?: unknown;
+  browser?: unknown;
+};
+
+const globalRef = globalThis as MutableGlobal;
+
+async function withGlobals(
+  overrides: Partial<Record<'__RHWP_DISABLE_EXTERNAL_WEBFONTS__' | 'chrome' | 'browser', unknown>>,
+  run: () => Promise<void>,
+): Promise<void> {
+  const keys = ['__RHWP_DISABLE_EXTERNAL_WEBFONTS__', 'chrome', 'browser'] as const;
+  const previous = new Map<string, { existed: boolean; value: unknown }>();
+  for (const key of keys) {
+    previous.set(key, { existed: key in globalRef, value: globalRef[key] });
+    if (key in overrides) {
+      (globalRef as Record<string, unknown>)[key] = overrides[key];
+    } else {
+      delete (globalRef as Record<string, unknown>)[key];
+    }
+  }
+  try {
+    await run();
+  } finally {
+    for (const key of keys) {
+      const saved = previous.get(key)!;
+      if (saved.existed) {
+        (globalRef as Record<string, unknown>)[key] = saved.value;
+      } else {
+        delete (globalRef as Record<string, unknown>)[key];
+      }
+    }
+  }
+}
+
+test('빌드 스위치가 없으면 비확장 환경 기본값은 외부 웹폰트 허용(false)이다', async () => {
+  await withGlobals({}, async () => {
+    const settings = await loadExtensionViewerSettings();
+    assert.equal(settings.disableExternalWebFonts, false);
+  });
+});
+
+test('빌드 스위치가 켜지면 비확장 환경 기본값이 외부 웹폰트 사용 안 함(true)이 된다', async () => {
+  await withGlobals({ __RHWP_DISABLE_EXTERNAL_WEBFONTS__: true }, async () => {
+    const settings = await loadExtensionViewerSettings();
+    assert.equal(settings.disableExternalWebFonts, true);
+  });
+});
+
+test('확장 storage에 저장된 명시값은 빌드 스위치보다 우선한다', async () => {
+  const fakeChrome = {
+    runtime: {},
+    storage: {
+      sync: {
+        get(
+          _defaults: Record<string, unknown>,
+          callback?: (items: Record<string, unknown>) => void,
+        ) {
+          callback?.({ disableExternalWebFonts: false });
+        },
+      },
+    },
+  };
+  await withGlobals(
+    { __RHWP_DISABLE_EXTERNAL_WEBFONTS__: true, chrome: fakeChrome },
+    async () => {
+      const settings = await loadExtensionViewerSettings();
+      assert.equal(settings.disableExternalWebFonts, false);
+    },
+  );
+});

--- a/rhwp-studio/vite.config.ts
+++ b/rhwp-studio/vite.config.ts
@@ -15,6 +15,11 @@ const useSubsecondWasm = process.env.RHWP_SUBSECOND === '1';
 export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
+    // 셀프 호스팅 빌드에서 외부(CDN) 웹폰트 로드를 빌드 시점에 끈다.
+    // 확장 storage 설정(disableExternalWebFonts)이 있으면 그 값이 우선한다.
+    __RHWP_DISABLE_EXTERNAL_WEBFONTS__: JSON.stringify(
+      process.env.RHWP_DISABLE_EXTERNAL_WEBFONTS === '1',
+    ),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Closes #3585

## 요약

셀프 호스팅 빌드에서 외부(CDN) 웹폰트 로드를 빌드 시점에 끌 수 있는 스위치
`RHWP_DISABLE_EXTERNAL_WEBFONTS=1`을 추가합니다. 기본 동작은 변하지 않습니다
(미설정 시 기존과 동일하게 CDN 로드).

## 배경 (#3585)

`npm/editor/README.md`가 rhwp-studio 셀프 호스팅을 공식 안내하지만, 기존
옵션 `disableExternalWebFonts`는 브라우저 확장 storage에서만 주입되어
웹/PWA 컨텍스트에서는 켤 방법이 없습니다. 그 결과 셀프 호스팅 배포는 부팅
경로(`CRITICAL_FONTS`)에서 cdn.jsdelivr.net의 함초롬 woff를 항상
요청합니다 — 함초롬체 CDN은 소스 주석에 명시된 대로 비상업적 사용
조건이라, 이 조건을 만족할 수 없는 셀프 호스터에게 공식 차단 경로가
필요합니다.

## 구현

- `vite.config.ts` — define 상수 `__RHWP_DISABLE_EXTERNAL_WEBFONTS__` 추가.
  `RHWP_SUBSECOND`과 같은 방식으로 `process.env`를 빌드 시점에 소비합니다.
- `extension-settings.ts` — 비확장 컨텍스트 기본값에 위 상수를 반영
  (`defaultSettings()`로 호출 시점 계산). 확장 storage에 저장된 명시값은
  기존대로 우선합니다. 동작 경로는 기존 `disableExternalWebFonts` 옵션
  그대로이므로 조판(내장 메트릭)은 불변, 표시 글꼴만 번들/시스템 체인으로
  폴백합니다.
- `npm/editor/README.md` — 셀프 호스팅 절에 사용법 문서화.

## 테스트

- 신규 `rhwp-studio/tests/extension-settings-build-switch.test.ts` 3건:
  스위치 미설정 기본값 유지 / 스위치 켜짐 시 차단 / storage 명시값 우선.
  스위치 켜짐 케이스는 본 수정 없이 실패하는 red→green 테스트입니다.
- 기존 스튜디오 스위트 전건 통과, `RHWP_DISABLE_EXTERNAL_WEBFONTS=1`
  빌드(`tsc && vite build`) 통과.

스위치 이름·주입 방식(define vs 기타)은 선호하시는 형태가 있으면
조정하겠습니다.
