### PR TITLE
fix(hwp5): 표·연결선 레코드의 0 패딩을 한컴 저장본에 맞춘다 (#3570)

### DIFF
--- a/src/document_core/commands/object_ops/table.rs
+++ b/src/document_core/commands/object_ops/table.rs
@@ -575,7 +575,8 @@ impl DocumentCore {
             outer_margin_bottom: 283,
             raw_ctrl_data,
             raw_table_record_attr: 0x00000006, // 한컴 기본값 (bit1=셀분리금지, bit2=repeat_header)
-            raw_table_record_extra: vec![0u8; 2],
+            // [#3570] 한컴은 TABLE 레코드를 zone 개수까지만 쓴다 — 여분 2바이트 없음.
+            raw_table_record_extra: Vec::new(),
             dirty: true,
             local_resize_rows: Vec::new(),
             local_resize_cols: Vec::new(),
@@ -1002,7 +1003,8 @@ impl DocumentCore {
             outer_margin_bottom: outer_margin,
             raw_ctrl_data,
             raw_table_record_attr: 0x04000006,
-            raw_table_record_extra: vec![0u8; 2],
+            // [#3570] 한컴은 TABLE 레코드를 zone 개수까지만 쓴다 — 여분 2바이트 없음.
+            raw_table_record_extra: Vec::new(),
             dirty: true,
             local_resize_rows: Vec::new(),
             local_resize_cols: Vec::new(),

--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -52,7 +52,6 @@ pub struct AdapterReport {
     /// HWPX 표 TABLE record row-size payload 를 행별 셀 수로 보강한 횟수
     pub table_record_row_sizes_materialized: u32,
     /// HWPX 표 TABLE record trailing zone/count payload 를 한컴 저장 관례로 보강한 횟수
-    pub table_record_extra_materialized: u32,
     /// `cell.list_attr bit 16` 보강 횟수 (Stage 3)
     pub cells_list_attr_bit16_set: u32,
     /// HWPX 출처 셀 LIST_HEADER width_ref/raw_list_extra materialize 횟수
@@ -130,7 +129,6 @@ impl AdapterReport {
                 + self.table_ctrl_header_attr_materialized
                 + self.table_record_attr_materialized
                 + self.table_record_row_sizes_materialized
-                + self.table_record_extra_materialized
                 + self.cells_list_attr_bit16_set
                 + self.cells_list_header_contract_materialized
                 + self.border_fills_no_fill_normalized
@@ -1526,7 +1524,6 @@ fn adapt_table_with_context(
         materialize_table_outer_margin(table, report);
         materialize_table_record_attr(table, report);
         materialize_table_record_row_sizes(table, report);
-        materialize_table_record_extra(table, report);
         materialize_table_ctrl_header_attr(table, report);
 
         table.raw_ctrl_data = serialize_common_obj_attr(&table.common);
@@ -1670,13 +1667,6 @@ fn materialize_table_record_row_sizes(table: &mut Table, report: &mut AdapterRep
     if table.row_sizes != row_sizes {
         table.row_sizes = row_sizes;
         report.table_record_row_sizes_materialized += 1;
-    }
-}
-
-fn materialize_table_record_extra(table: &mut Table, report: &mut AdapterReport) {
-    if table.raw_table_record_extra.is_empty() {
-        table.raw_table_record_extra = vec![0, 0];
-        report.table_record_extra_materialized += 1;
     }
 }
 
@@ -1968,7 +1958,8 @@ mod tests {
 
         assert_eq!(table.raw_table_record_attr, 0x0400_000e);
         assert_eq!(table.row_sizes, vec![3]);
-        assert_eq!(table.raw_table_record_extra, vec![0, 0]);
+        // [#3570] 한컴은 zone 개수까지만 쓰고 끝낸다 — 여분 2바이트를 넣지 않는다.
+        assert!(table.raw_table_record_extra.is_empty());
         assert_eq!(
             u32::from_le_bytes(
                 table.raw_ctrl_data[common_obj_offsets::FLAGS]
@@ -2839,12 +2830,12 @@ mod tests {
             assert!(!table.raw_ctrl_data.is_empty());
             assert_eq!(table.raw_table_record_attr & 0x04, 0x04);
             assert_eq!(table.row_sizes, vec![1]);
-            assert_eq!(table.raw_table_record_extra, vec![0, 0]);
+            // [#3570] 한컴은 zone 개수까지만 쓰고 끝낸다 — 여분 2바이트 없음.
+            assert!(table.raw_table_record_extra.is_empty());
             assert_eq!(table.cells[0].raw_list_extra.len(), 13);
         }
 
         assert_eq!(report.tables_ctrl_data_synthesized, 2);
-        assert_eq!(report.table_record_extra_materialized, 2);
         assert_eq!(report.cells_list_header_contract_materialized, 2);
     }
 

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -1295,7 +1295,14 @@ fn serialize_shape_control(
                     w.write_i32(cp.y).unwrap();
                     w.write_u16(cp.point_type).unwrap();
                 }
-                w.write_bytes(&conn.raw_trailing).unwrap();
+                // [#3570] 한컴은 제어점 뒤에 0 4바이트를 더 쓴다(전수 20건 모두
+                // `00000000`). 종전에는 raw_trailing 이 비면 아무것도 쓰지 않아
+                // 레코드가 4바이트 짧았다. 다각형(위)과 같은 관례로 채운다.
+                if conn.raw_trailing.is_empty() {
+                    w.write_u32(0).unwrap();
+                } else {
+                    w.write_bytes(&conn.raw_trailing).unwrap();
+                }
             } else {
                 w.write_i32(if line.started_right_or_bottom { 1 } else { 0 })
                     .unwrap();
@@ -1667,7 +1674,14 @@ fn serialize_group_child(
                     w.write_i32(cp.y).unwrap();
                     w.write_u16(cp.point_type).unwrap();
                 }
-                w.write_bytes(&conn.raw_trailing).unwrap();
+                // [#3570] 한컴은 제어점 뒤에 0 4바이트를 더 쓴다(전수 20건 모두
+                // `00000000`). 종전에는 raw_trailing 이 비면 아무것도 쓰지 않아
+                // 레코드가 4바이트 짧았다. 다각형(위)과 같은 관례로 채운다.
+                if conn.raw_trailing.is_empty() {
+                    w.write_u32(0).unwrap();
+                } else {
+                    w.write_bytes(&conn.raw_trailing).unwrap();
+                }
             } else {
                 w.write_i32(if line.started_right_or_bottom { 1 } else { 0 })
                     .unwrap();

--- a/tests/issue_3570_record_padding.rs
+++ b/tests/issue_3570_record_padding.rs
@@ -1,0 +1,206 @@
+//! Issue #3570: 표·연결선 레코드의 0 패딩 길이가 한컴 저장본과 다르다.
+//!
+//! 한컴이 같은 원본을 저장한 파일을 정답지로 삼아 맞췄다.
+//!
+//! | 레코드 | 종전 | 한컴 | 조치 |
+//! |---|---|---|---|
+//! | `TABLE`(77) | rhwp 가 **+2** | zone 개수까지만 | 여분 2바이트 제거 |
+//! | `SC_LINE`(78) 연결선 | rhwp 가 **−4** | 제어점 뒤 0 4바이트 | 4바이트 채움 |
+//!
+//! 둘 다 0 으로 채워진 패딩이라 정보 손실은 없었지만, 길이가 달라 다른 도구와의 대조·이식이
+//! 어긋났다. 표 쪽은 종전에 어댑터가 `raw_table_record_extra = [0, 0]` 을 **의도적으로**
+//! 넣던 계약을 되돌린 것이라, 한컴 개방까지 실측해 확인했다(387쪽 편람 → 384쪽 정상 개방).
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::Read;
+
+/// 표와 연결선을 함께 가진 표본.
+const SAMPLE: &str = "samples/task1771/nested_group_vectors.hwpx";
+
+const TAG_TABLE: u16 = 77;
+const TAG_SC_LINE: u16 = 78;
+
+fn sample_path() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+/// 저장 바이트에서 BodyText 전 구역의 (태그, 데이터) 를 읽는다.
+fn body_records(hwp: &[u8]) -> Vec<(u16, Vec<u8>)> {
+    let cursor = std::io::Cursor::new(hwp);
+    let mut comp = cfb::CompoundFile::open(cursor).expect("cfb 열기");
+    let mut fh = comp.open_stream("/FileHeader").expect("FileHeader");
+    let mut fh_data = Vec::new();
+    fh.read_to_end(&mut fh_data).expect("FileHeader 읽기");
+    let compressed = fh_data.get(36).map(|b| (b & 0x01) != 0).unwrap_or(false);
+    drop(fh);
+
+    let names: Vec<String> = comp
+        .walk()
+        .filter(|e| e.is_stream())
+        .map(|e| e.path().to_string_lossy().replace('\\', "/"))
+        .filter(|p| p.starts_with("/BodyText/Section"))
+        .collect();
+
+    let mut out = Vec::new();
+    for name in names {
+        let mut s = comp.open_stream(&name).expect("Section");
+        let mut raw = Vec::new();
+        s.read_to_end(&mut raw).expect("Section 읽기");
+        drop(s);
+        let data = if compressed {
+            let mut d = flate2::read::DeflateDecoder::new(&raw[..]);
+            let mut v = Vec::new();
+            d.read_to_end(&mut v).expect("inflate");
+            v
+        } else {
+            raw
+        };
+        let mut pos = 0usize;
+        while pos + 4 <= data.len() {
+            let header = u32::from_le_bytes(data[pos..pos + 4].try_into().expect("헤더"));
+            let tag = (header & 0x3FF) as u16;
+            let mut size = ((header >> 20) & 0xFFF) as usize;
+            pos += 4;
+            if size == 0xFFF {
+                if pos + 4 > data.len() {
+                    break;
+                }
+                size = u32::from_le_bytes(data[pos..pos + 4].try_into().expect("확장")) as usize;
+                pos += 4;
+            }
+            if pos + size > data.len() {
+                break;
+            }
+            out.push((tag, data[pos..pos + size].to_vec()));
+            pos += size;
+        }
+    }
+    out
+}
+
+/// CLI `convert` 와 동일한 경로로 저장한다.
+///
+/// 표의 여분 2바이트는 **HWPX→HWP 어댑터**(`materialize_table_record_extra`)가 넣던
+/// 것이라, 어댑터를 건너뛰고 직렬화하면 이 테스트가 수정 여부와 무관하게 통과한다.
+fn saved_records() -> Vec<(u16, Vec<u8>)> {
+    use rhwp::document_core::converters::hwpx_to_hwp::convert_if_hwpx_source;
+    let bytes = std::fs::read(sample_path()).expect("표본 읽기");
+    let mut doc = rhwp::parser::parse_document(&bytes).expect("파싱");
+    let _ = convert_if_hwpx_source(&mut doc, rhwp::parser::FileFormat::Hwpx);
+    let saved = rhwp::serializer::serialize_document(&doc).expect("직렬화");
+    body_records(&saved)
+}
+
+/// 표 레코드는 zone 개수(u16)까지만 쓰고 끝난다 — 여분 2바이트가 붙지 않는다.
+///
+/// 배치: `속성(4) + 행(2) + 열(2) + 셀간격(2) + 안쪽여백(8) + 행별셀수(2×N) +
+/// 테두리배경(2) + zone 개수(2) + zone(10×M)`.
+#[test]
+fn table_record_ends_at_zone_count() {
+    let recs = saved_records();
+    let tables: Vec<&Vec<u8>> = recs
+        .iter()
+        .filter(|(t, _)| *t == TAG_TABLE)
+        .map(|(_, d)| d)
+        .collect();
+    assert!(
+        !tables.is_empty(),
+        "표 레코드를 찾지 못했다 — 표본이 바뀌었는지 확인하라"
+    );
+
+    let mut offenders = Vec::new();
+    for (i, d) in tables.iter().enumerate() {
+        if d.len() < 20 {
+            offenders.push(format!("표 {i}: 길이 {} < 최소 20", d.len()));
+            continue;
+        }
+        let rows = u16::from_le_bytes(d[4..6].try_into().expect("행")) as usize;
+        // 속성4 + 행2 + 열2 + 셀간격2 + 안쪽여백8 = 18, + 행별셀수 2×N,
+        // + 테두리배경2 + zone 개수2 → zone 개수 필드의 끝
+        let base = 22 + 2 * rows;
+        if d.len() < base {
+            offenders.push(format!("표 {i}: 길이 {} < 필요 {base}", d.len()));
+            continue;
+        }
+        let zones = u16::from_le_bytes(d[base - 2..base].try_into().expect("zone")) as usize;
+        let expected = base + 10 * zones;
+        if d.len() != expected {
+            offenders.push(format!(
+                "표 {i}: 길이 {} 기대 {expected} (행 {rows}, zone {zones}) — 여분 {}바이트",
+                d.len(),
+                d.len() as i64 - expected as i64
+            ));
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "표 레코드에 한컴이 쓰지 않는 여분 바이트가 붙었다 ({}건):\n  {}",
+        offenders.len(),
+        offenders
+            .iter()
+            .take(3)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n  ")
+    );
+}
+
+/// 연결선 레코드는 제어점 뒤에 4바이트를 더 쓴다 (한컴 실측 20건 전부 `00000000`).
+///
+/// 배치: `시작점(8) + 끝점(8) + 연결정보(20) + 제어점수(4) + 제어점(10×N) + 꼬리(4)`.
+///
+/// 추적 표본에는 연결선이 없어(일반 직선뿐) 합성 문서로 계약을 고정한다.
+#[test]
+fn connector_record_has_trailing_word() {
+    use rhwp::model::control::Control;
+    use rhwp::model::document::{Document, Section};
+    use rhwp::model::paragraph::Paragraph;
+    use rhwp::model::shape::{
+        ConnectorControlPoint, ConnectorData, GroupShape, LineShape, ShapeObject,
+    };
+
+    let mut connector = LineShape::default();
+    connector.connector = Some(ConnectorData {
+        control_points: vec![ConnectorControlPoint::default(); 2],
+        ..Default::default()
+    });
+
+    let group = GroupShape {
+        children: vec![ShapeObject::Line(connector)],
+        ..Default::default()
+    };
+    let mut para = Paragraph::default();
+    para.controls
+        .push(Control::Shape(Box::new(ShapeObject::Group(group))));
+    para.char_count = 9; // 확장 컨트롤 8 + 문단 종결자
+
+    let mut doc = Document::default();
+    doc.sections.push(Section {
+        paragraphs: vec![para],
+        ..Default::default()
+    });
+    doc.doc_properties.section_count = 1;
+
+    let saved = rhwp::serializer::serialize_document(&doc).expect("직렬화");
+    let lines: Vec<Vec<u8>> = body_records(&saved)
+        .into_iter()
+        .filter(|(t, _)| *t == TAG_SC_LINE)
+        .map(|(_, d)| d)
+        .collect();
+    assert_eq!(lines.len(), 1, "연결선 레코드가 하나여야 한다");
+
+    let d = &lines[0];
+    let n = u32::from_le_bytes(d[36..40].try_into().expect("제어점수")) as usize;
+    assert_eq!(n, 2, "제어점 수가 어긋난다");
+    let expected = 40 + 10 * n + 4;
+    assert_eq!(
+        d.len(),
+        expected,
+        "연결선 레코드 길이가 한컴과 다르다 — 제어점 뒤 꼬리 4바이트가 빠졌다"
+    );
+    assert_eq!(
+        &d[d.len() - 4..],
+        &[0, 0, 0, 0],
+        "꼬리 4바이트는 0 이어야 한다"
+    );
+}


### PR DESCRIPTION
작업지시자 판단(**"한컴이 정답지다"**)에 따라, 한컴이 같은 원본을 저장한 파일을 기준으로
양쪽을 맞췄다.

| 레코드 | 종전 | 한컴 | 조치 |
|---|---|---|---|
| `TABLE`(77) | rhwp 가 **+2** | zone 개수까지만 | 여분 2바이트 제거 |
| `SC_LINE`(78) 연결선 | rhwp 가 **−4** | 제어점 뒤 0 4바이트 | 4바이트 채움 |

둘 다 0 으로 채워진 패딩이라 정보 손실은 없었지만, 길이가 달라 다른 도구와의 대조·이식이
어긋났다.

## 실측 (`samples/2025 행정업무운영 편람(최종).hwpx` → convert, 한컴 저장본 대조)

| | 수정 전 | 수정 후 |
|---|---|---|
| `TABLE` 크기 불일치 | 388건 | **0건** |
| `SC_LINE` 크기 불일치 | 20건 | **0건** |
| 한컴 개방 | — | **384쪽 정상** (정답지와 쪽수 일치) |

## 표 — 기존 계약을 되돌렸다

`converters/hwpx_to_hwp.rs` 의 `materialize_table_record_extra` 가
`raw_table_record_extra = [0, 0]` 을 **의도적으로** 넣던 계약(커밋 `fe3479928`
"add hwpx2hwp contract diagnostics")을 제거했다. 이번 정답지에서 한컴은 **388건 전수**에서
zone 개수까지만 쓰고 끝낸다.

되돌리는 변경이라 **한컴 개방까지 실측**해 확인했다(384쪽 정상). 계약에 딸린
`AdapterReport` 카운터와 그것을 단언하던 in-crate 테스트 2곳도 함께 정리했다.

표 **생성 경로**(`object_ops/table.rs`)의 기본값도 같은 이유로 맞췄다 — 새로 만든 표가
변환본과 다른 인코딩을 갖지 않도록.

## 연결선

다각형(같은 함수 위쪽)과 **같은 관례**로, `raw_trailing` 이 비면 0 4바이트를 쓴다.
HWP5 출처는 파싱에서 `raw_trailing` 을 채우므로 영향이 없다.

## 회귀 테스트

`tests/issue_3570_record_padding.rs` — 레코드 배치를 직접 계산해 검증한다.

1. 표는 zone 개수 필드에서 끝난다 (`22 + 2×행 + 10×zone`)
2. 연결선은 제어점 뒤 4바이트를 갖는다 (`40 + 10×N + 4`), 값은 0

작성 중 두 가지를 음성 대조로 잡았다.

- 표 테스트가 **어댑터를 거치지 않아** 수정 여부와 무관하게 통과했다 — 여분 2바이트는
  어댑터가 넣으므로, CLI 와 같이 `convert_if_hwpx_source` 를 거치도록 고쳤다
- 연결선은 추적 표본에 없어(일반 직선뿐) **합성 문서**로 고정했다

**수정을 되돌리면 두 테스트 모두 실패**한다.

## 검증

- `cargo nextest run --no-fail-fast` **4370건 전량 통과**
- `cargo clippy --all-targets -- -D warnings` 경고 0 · `rustfmt --check` 통과
- 한컴 COM 개방 실측 384쪽

Closes #3570

🤖 Generated with [Claude Code](https://claude.com/claude-code)
