### PR TITLE
docs(#3606): README 'AI 에이전트에서 쓰기' — 30초 온보딩 절 (M6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,29 @@ npx vite --host 0.0.0.0 --port 7700
 
 Open `http://localhost:7700` in your browser.
 
+## AI 에이전트에서 쓰기 (MCP)
+
+rhwp 는 MCP(Model Context Protocol) 서버를 내장한다 — 설정 한 줄이면 Claude Code 등
+MCP 호스트가 HWP/HWPX 를 읽고·검색하고·채우고·변환한다:
+
+```jsonc
+// .mcp.json
+{ "mcpServers": { "rhwp": { "command": "rhwp", "args": ["mcp-serve"] } } }
+```
+
+첫 호출 3종 (조사 → 위치 → 채움):
+
+```jsonc
+hwp_info        { "path": "문서.hwp" }                       // 규모·형식 파악
+hwp_search      { "path": "문서.hwp", "query": "위임전결" }   // 몇 쪽 어느 셀인지
+hwp_fill_fields { "path": "서식.hwp", "data": {"성명":"홍길동"} }  // 누름틀 채움
+```
+
+대형 문서는 `hwp_open` → `hwp_doc_*` 세션 도구로 재파싱 없이 반복 조회·편집한다.
+전체 도구 지도·오류 의미론은 [MCP 통합 가이드](mydocs/manual/mcp_integration_guide.md),
+막히면 [에이전트 실패 사전](mydocs/manual/agent_troubleshooting_guide.md).
+CLI 만 쓸 때의 입구는 `rhwp capabilities` 한 번이면 된다(전 명령 기계 계약 자기서술).
+
 ## CLI Usage
 
 ### SVG Export


### PR DESCRIPTION
## 무엇

mcp-serve(#3571)·세션 도구까지 서버는 완성 단계인데, **처음 온 에이전트(또는 그 사용자)가 30초 안에 붙는 경로**가 README 에 없었습니다. 지금은 mydocs/manual 까지 들어와야 등록법을 찾습니다 — 유입이 시작된 시점에서 첫 화면의 다리가 빠져 있었습니다.

## 내용 (CLI Usage 절 바로 위, 10여 줄)

- `.mcp.json` 등록 스니펫 한 줄
- 첫 호출 3종: `hwp_info`(조사) → `hwp_search`(위치) → `hwp_fill_fields`(채움)
- 대형 문서용 세션 도구(`hwp_open` → `hwp_doc_*`) 안내 한 줄
- 심화 링크 2개: [MCP 통합 가이드](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/mcp_integration_guide.md) · [에이전트 실패 사전](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/agent_troubleshooting_guide.md)
- CLI 사용자 입구: `rhwp capabilities` 한 줄

## 검증

- `scripts/check_markdown_links.py` 통과
- 서술된 도구·명령 전부 devel 실존 (#3571·#3597·#3599·#3602·#3607 머지분)

closes #3606 · 로드맵 #3608 M6