### PR TITLE
[#3633] digest 매크로 신설 — 초소형 모델용 원콜 요약 봉투 + nextStep 고정 유도

### DIFF
--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -355,6 +355,24 @@ HWP 파일 정보 표시(버전/구역 수/암호화 등).
   `{"schemaVersion":"1.0","source","format":"hwp5|hwpx|hwp3|hml","sizeBytes","version","sections","pageCount","paraCount","fonts"}`.
   `version` 은 HML 이면 null. 스키마 계약은 `export-text --json` 항목과 동일 규칙.
 
+### `digest <파일> [--max-chars N] [--json]` (#3633)
+초소형 모델용 매크로 1호 — "info 로 훑고 → export-structure 로 개요를 얻고 →
+export-text 로 첫 장을 읽는" 3단 파이프라인을 **한 번 호출**로 수행한다. 도구
+체이닝을 못 하는 로컬 소형 모델(4B급)이 1차 소비자다. 설계 결정은
+[초소형 모델용 매크로 도구 축 설계 결정](../tech/tiny_model_macro_tools.md).
+- 기계 전용 명령: `--json` 유무와 무관하게 항상 봉투 **한 줄 JSON** 을 낸다 —
+  `{"schemaVersion":"1.0","source","format","pageCount","paraCount","outline":[최상위 노드 제목 최대 20개],"excerpt","truncated","nextStep"}`
+- `excerpt` 는 페이지 0~2 텍스트를 `--max-chars`(기본 2000) **문자 수**에서 절단한
+  발췌. 절단되면 `truncated:true`.
+- `nextStep` 은 고정 문자열 계약(다음 행동 유도문) — 문구 변경은
+  `tests/digest_macro_contract.rs` 가 잡는다.
+- 실패 시 stdout 0바이트, 종료 코드는 #2707 계약(0/1/2).
+
+```bash
+# 처음 보는 문서를 한 번 호출로 파악
+rhwp digest 편람.hwp --json --max-chars 500
+```
+
 ### `search <파일> <검색어> [--json] [--ignore-case] [--limit N]` (#3283)
 문서를 검색해 매치마다 **구역·문단·페이지·문자 오프셋**을 함께 돌려준다.
 평문을 뽑아 외부에서 찾으면 주소가 소멸해 근거 제시가 불가능한데, rhwp 는 조판 엔진이

--- a/mydocs/tech/README.md
+++ b/mydocs/tech/README.md
@@ -24,6 +24,7 @@ last_verified: 2026-07-19
 | 폰트 대체와 충실도 | [폰트 fallback 전략](font_fallback_strategy.md) | [Issue #124 캔버스·폰트 측정 조사](investigations/issue-124/README.md), [Issue #2125 font ownership 조사](investigations/issue-2125/README.md) |
 | 편집 undo/redo | [편집 action undo/redo 아키텍처](edit_action_undo_redo_architecture.md) | 이슈별 실동작 조사 문서 |
 | 기술 채택·비채택 | [ThorVG 결정 기록](thorvg_decision.md) | [Issue #112-115 ThorVG PoC 조사](investigations/issue-112/README.md) |
+| 초소형 모델용 매크로 도구 축 | [초소형 모델용 매크로 도구 축 설계 결정](tiny_model_macro_tools.md) | 계약 테스트 `tests/digest_macro_contract.rs`, CLI 명령은 [CLI 명령 레퍼런스](../manual/cli_commands.md) 재확인 |
 | OLE chart renderer | [OLE chart renderer 선택 결정](hwp_ole_chart_renderer_architecture_decision_1251.md) | [Issue #1251 시각 차이 조사](investigations/issue-1251/README.md) |
 | CI cache 정책 이력 | [Issue #1664 cache 정책 결정](ci_cache_policy_1664.md) | 현재 동작은 `.github/workflows/ci.yml` 재확인 |
 | WASM toolchain 버전 | [wasm-pack 버전 고정 정책](wasm_pack_version_policy.md) | 현재 설치 동작은 `.github/actions/install-wasm-pack/action.yml`과 `Dockerfile` 재확인 |

--- a/mydocs/tech/tiny_model_macro_tools.md
+++ b/mydocs/tech/tiny_model_macro_tools.md
@@ -1,0 +1,132 @@
+---
+kind: decision
+status: active
+canonical: mydocs/tech/tiny_model_macro_tools.md
+last_verified: 2026-07-31
+---
+
+# 초소형 모델용 매크로 도구 축 설계 결정
+
+- **이슈**: [#3633](https://github.com/edwardkim/rhwp/issues/3633) (로드맵 [#3608](https://github.com/edwardkim/rhwp/issues/3608) 신규 항목)
+- **범위**: 매크로 3종의 설계 원칙과 명세. 1호 `digest` 는 구현 완료, 2·3호는 봉투 초안만 확정.
+- **계약 테스트**: `tests/digest_macro_contract.rs`
+
+## 1. 왜 — 초소형 모델의 제약 3가지
+
+현행 에이전트 표면(#3608)은 "capabilities 로 배우고 → info 로 훑고 → export-text/search 로
+파고 → edit 로 고치고 → ir-diff 로 검증"하는 다단 도구 체이닝을 전제한다. 로컬에서 도는
+초소형 모델(4B급)은 이 전제가 성립하지 않는다:
+
+| # | 제약 | 증상 |
+| --- | --- | --- |
+| 1 | **체이닝 불가** | 5회 연쇄 호출 계획을 세우지 못하고 2~3번째 호출에서 목적을 잃는다 |
+| 2 | **컨텍스트 극소** | 도구 설명·중간 산출물 수천 토큰이 그 자체로 컨텍스트를 넘치게 한다 |
+| 3 | **지시 이탈** | "다음에 뭘 하라"가 응답 안에 명시돼 있지 않으면 임의 행동으로 샌다 |
+
+공백은 기능이 아니라 **호출 단위의 굵기**다. 코어 기능은 전부 있고, 한 번 호출로 끝나는
+굵은 포장이 없을 뿐이다.
+
+## 2. 대응 원칙 3가지 (제약 1:1 대응)
+
+1. **원콜 워크플로** — 다단 파이프라인을 도구 **내부**로 옮겨 결정론적으로(모델 판단 개입
+   없이) 수행한다. 모델은 1회 호출만 한다. 내부 단계는 전부 기존 코어 함수 재사용이며
+   매크로에 새 해석 로직을 두지 않는다.
+2. **40자 이내 도구 설명** — 매크로 도구의 MCP `description` 은 40자 이내로 극단 압축한다.
+   도구 목록 자체가 컨텍스트 예산을 잠식하는 모델이 1차 소비자이기 때문이다. 길이는
+   계약 테스트(`digest_registered_in_mcp_with_compact_description`)가 감시한다.
+3. **nextStep 고정 유도** — 봉투의 `nextStep` 은 **고정 문자열 계약**이다. 모델이 다음
+   행동을 지어내지 않고 받아 적게 한다. 문구 변경은 계약 테스트가 잡는 의도적 결정이어야
+   한다(`digest` 의 원천은 `src/main.rs` 의 `DIGEST_NEXT_STEP`).
+
+## 3. 매크로 3종 명세
+
+### 3.1 1호 `hwp_digest` (CLI `digest`) — 구현 완료 (#3633)
+
+- **CLI**: `rhwp digest <파일> [--max-chars N] [--json]` — 기계 전용 명령으로 항상 봉투
+  한 줄 JSON 을 낸다. 실패 시 stdout 0바이트, 종료 코드는 #2707 계약(0/1/2).
+- **내부 파이프라인** (전부 기존 원천 재사용): `load_document` → `info_json_value` 의
+  format·pageCount·paraCount + `build_structure(Auto)` 최상위 노드 제목(최대 20개) +
+  `extract_page_text_native` 페이지 0~2 발췌를 `--max-chars`(기본 2000) 문자에서 절단.
+- **봉투**:
+
+```json
+{
+  "schemaVersion": "1.0",
+  "source": "<경로>",
+  "format": "hwp5|hwpx|hwp3|hml",
+  "pageCount": 16,
+  "paraCount": 195,
+  "outline": ["1. 소개", "2. 연관된 작업들", "..."],
+  "excerpt": "첫 페이지 발췌...",
+  "truncated": true,
+  "nextStep": "더 읽으려면 export-text --json -p <쪽>, 찾으려면 search --json"
+}
+```
+
+### 3.2 2호 `hwp_fill_and_verify` — 봉투 초안 (후속 이슈로 승격)
+
+fields 조회 → fill-fields → 저장 → 재열기 검증을 원콜로 묶는다. 내부 단계는
+`collect_all_fields`/`set_field_value_by_name_at`/`edit_serialize` 재사용.
+
+```json
+{
+  "schemaVersion": "1.0",
+  "source": "<경로>",
+  "output": "<산출 경로>",
+  "outputFormat": "hwp5|hwpx",
+  "filledCount": 3,
+  "filled": [{ "name": "성명", "occurrence": 0, "value": "..." }],
+  "notFound": [],
+  "ambiguous": [],
+  "verify": { "reopened": true, "fieldsMatch": true },
+  "truncated": false,
+  "nextStep": "결과 확인은 fields --json <산출>, 눈검증은 export-svg <산출>"
+}
+```
+
+### 3.3 3호 `hwp_replace_and_verify` — 봉투 초안 (후속 이슈로 승격)
+
+replace-text(dry-run 계수) → 치환 → 저장 → 재열기 검증을 원콜로 묶는다. 내부 단계는
+`replace_all_native`/`edit_serialize` 재사용.
+
+```json
+{
+  "schemaVersion": "1.0",
+  "source": "<경로>",
+  "output": "<산출 경로>",
+  "outputFormat": "hwp5|hwpx",
+  "find": "구기관명",
+  "replace": "신기관명",
+  "replacedCount": 12,
+  "verify": { "reopened": true, "residualFindCount": 0 },
+  "truncated": false,
+  "nextStep": "잔존 확인은 search --json <산출> <찾은말>, 눈검증은 export-svg <산출>"
+}
+```
+
+초안 공통 규약: `verify` 는 산출물을 **재열기**해 얻은 실측이어야 하고(직렬화 반환값
+재보고 금지), `nextStep` 은 1호와 같은 고정 문자열 계약이며, 판정 어휘
+(filledCount/notFound/ambiguous/replacedCount)는 기존 `edit` 표면과 동형이어야 한다.
+
+## 4. 인접 축과의 관계
+
+- **weak-agent-proofing #3630 (P1 did-you-mean · P2 편집 --verify 내장 · P3 changedPages ·
+  P4 nextCall)** — 상보적이다. #3630 은 기존 표면의 **오류·검증을 표면이 대신**하는 축이고,
+  본 축은 **계획(체이닝)을 표면이 대신**하는 축이다. 접점 두 곳: 2·3호의 `verify` 내장은
+  P2 와 같은 원리이므로 P2 가 먼저 머지되면 2·3호는 그 경로를 재사용한다. 성공 봉투의
+  `nextStep`(고정 문자열)과 P4 의 오류 봉투 `nextCall`(교정 제안)은 역할이 다르므로 어휘를
+  통일하되 병합하지 않는다.
+- **역할 라우터 #3629 (capabilities/mcp-serve --profile)** — 라우터에 '초소형(tiny)'
+  프로필을 추가해 매크로 3종 + 최소 도구만 노출하는 것이 본 축의 완성형이다. 다만 프로필
+  스키마가 #3629 에서 확정되므로, **'초소형' 프로필 추가는 #3629 머지 후 후속 이슈로
+  진행한다** (본 축은 프로필 없이도 단독 동작).
+
+## 5. 결정 요약
+
+| 결정 | 근거 |
+| --- | --- |
+| 매크로는 기존 코어 함수 재사용만 (새 해석 로직 금지) | CLI 계약(#2707)·판정 어휘 동형 유지, 드리프트 방지 |
+| `digest` 는 `--json` 유무와 무관하게 항상 봉투 한 줄 | 기계 전용 명령 — 사람용 표면을 이원화하지 않는다 |
+| `nextStep` 은 상수 문자열 + 계약 테스트 고정 | 지시 이탈 차단 — 유도문이 조용히 바뀌면 소비자 프롬프트가 깨진다 |
+| MCP 설명 40자 이내를 테스트로 강제 | 컨텍스트 절약이 목적인 축에서 설명 비대화는 자기모순 |
+| 2·3호는 봉투 초안만 선확정 | 어휘를 먼저 고정해 후속 구현 간 드리프트를 막는다 |

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,6 +176,7 @@ fn main() {
         Some("mcp-serve") => exit_with(mcp_serve::run()),
         Some("batch") => exit_with(run_batch(&args[2..])),
         Some("info") => exit_with(show_info(&args[2..])),
+        Some("digest") => exit_with(digest_document(&args[2..])),
         Some("dump") => exit_with(dump_controls(&args[2..])),
         Some("dump-note-shape") => exit_with(dump_note_shape(&args[2..])),
         Some("dump-endnote-lines") => exit_with(dump_endnote_lines(&args[2..])),
@@ -308,6 +309,27 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
             "info",
             serde_json::json!(["info", "--json", "{path}"]),
             &["format", "sizeBytes", "sections", "pageCount", "paraCount", "fonts"],
+        ),
+        // [#3633] 초소형 모델용 매크로 1호. 설명은 40자 이내로 극단 압축한다 —
+        // 도구 목록 자체가 컨텍스트 예산을 잠식하는 4B급 모델이 1차 소비자이기
+        // 때문이다(계약 테스트 digest_macro_contract 가 길이를 감시한다).
+        tool(
+            "hwp_digest",
+            "문서 요약 한 번에: 메타·개요·발췌·다음 행동",
+            path_schema(serde_json::json!({
+                "maxChars": { "type": "integer", "minimum": 1, "description": "발췌 최대 문자 수. 기본 2000" }
+            })),
+            "digest",
+            serde_json::json!(["digest", "--json", "{path}"]),
+            &[
+                "format",
+                "pageCount",
+                "paraCount",
+                "outline",
+                "excerpt",
+                "truncated",
+                "nextStep",
+            ],
         ),
         tool(
             "hwp_export_text",
@@ -669,6 +691,25 @@ fn show_capabilities(args: &[String]) -> i32 {
             true,
             &["--mode", "-o", "--json"],
             &["schemaVersion", "source", "mode", "nodeCount", "structure"],
+        ),
+        // [#3633] 초소형 모델용 매크로 1호 — info+structure+발췌를 원콜로 묶는다.
+        cmd_json(
+            "digest",
+            "query",
+            "문서 요약 봉투(메타·개요·발췌·nextStep)를 한 번 호출로 출력",
+            false,
+            &["--max-chars", "--json"],
+            &[
+                "schemaVersion",
+                "source",
+                "format",
+                "pageCount",
+                "paraCount",
+                "outline",
+                "excerpt",
+                "truncated",
+                "nextStep",
+            ],
         ),
         cmd_json(
             "capabilities",
@@ -1137,6 +1178,12 @@ fn print_help() {
     println!("      HWP/HWPX/HML 문서 정보 표시");
     println!();
     println!("      --json                  문서 정보를 JSON으로 stdout에 출력");
+    println!();
+    println!("  digest <파일> [--max-chars N] [--json]");
+    println!("      문서 요약 봉투 한 줄 출력 — 메타(info)·개요 상위 노드·첫 페이지 발췌·");
+    println!("      nextStep 유도문을 한 번 호출로 묶은 매크로 (초소형 모델용, #3633)");
+    println!();
+    println!("      --max-chars <N>         발췌 최대 문자 수 (기본: 2000)");
     println!();
     println!("  capabilities [--mcp]");
     println!("      도구 자기서술 JSON 출력 (명령·플래그·JSON 계약·종료 코드) — 에이전트용");
@@ -3915,6 +3962,129 @@ fn info_json_value(
         "paraCount": para_count,
         "fonts": fonts,
     })
+}
+
+/// [#3633] `nextStep` 고정 문자열 계약 — 봉투를 받은 초소형 모델이 다음 행동을
+/// 지어내지 않고 받아 적게 하는 유도문. 문구 변경은 계약 테스트
+/// (`tests/digest_macro_contract.rs`)가 잡는 의도적 결정이어야 한다.
+const DIGEST_NEXT_STEP: &str = "더 읽으려면 export-text --json -p <쪽>, 찾으려면 search --json";
+/// [#3633] excerpt 기본 절단 길이(문자 수) — 4B급 모델의 컨텍스트 예산에 맞춘 보수값.
+const DIGEST_DEFAULT_MAX_CHARS: usize = 2000;
+/// [#3633] outline 에 싣는 최상위 노드 제목 최대 개수 — 트리 전체를 싣지 않는다.
+const DIGEST_OUTLINE_LIMIT: usize = 20;
+/// [#3633] excerpt 원천 페이지 수 — 앞쪽 페이지 0~2 만 발췌한다.
+const DIGEST_EXCERPT_PAGES: u32 = 3;
+
+/// [#3633] `digest` — 초소형 모델용 매크로 도구 축 1호.
+///
+/// 도구 체이닝을 못 하는 모델(4B급)을 위해 "info 로 훑고 → export-structure 로
+/// 개요를 얻고 → export-text 로 첫 장을 읽는" 3단 파이프라인을 한 번 호출로
+/// 결정론적으로 수행한다. 새 로직 없이 기존 원천만 재사용한다:
+/// `load_document` → `info_json_value` 의 필드 + `build_structure` 상위 노드 제목 +
+/// `extract_page_text_native` 발췌(`--max-chars` 문자 절단).
+///
+/// 출력은 항상 봉투 한 줄 JSON 이다(기계 전용 명령 — 표면 규약 통일을 위해
+/// `--json` 플래그는 받아만 둔다). 실패 시 stdout 은 0바이트.
+fn digest_document(args: &[String]) -> i32 {
+    use rhwp::document_core::queries::structure::{build_structure, StructureMode};
+
+    let mut file_path: Option<&str> = None;
+    let mut max_chars = DIGEST_DEFAULT_MAX_CHARS;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {}
+            "--max-chars" => {
+                i += 1;
+                match args.get(i).and_then(|v| v.parse::<usize>().ok()) {
+                    Some(n) if n > 0 => max_chars = n,
+                    _ => {
+                        eprintln!("오류: --max-chars 뒤에 1 이상의 숫자가 필요합니다.");
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            other if other.starts_with('-') => {
+                eprintln!("알 수 없는 옵션: {other}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if file_path.replace(other).is_some() {
+                    eprintln!("오류: 입력 파일은 하나만 지정할 수 있습니다: {other}");
+                    return EXIT_USAGE;
+                }
+            }
+        }
+        i += 1;
+    }
+    let Some(file_path) = file_path else {
+        eprintln!("사용법: rhwp digest <파일> [--max-chars N] [--json]");
+        return EXIT_USAGE;
+    };
+
+    let data = match fs::read(file_path) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
+            return EXIT_RUNTIME;
+        }
+    };
+    let file_size = data.len();
+    let detected_format = rhwp::parser::detect_format(&data);
+    let doc = match load_document(&data) {
+        Ok(d) => d,
+        Err(e) => return e.report(),
+    };
+
+    // 메타는 info --json 과 같은 원천(info_json_value)에서 뽑는다 — 어휘 동형 보장.
+    let info = info_json_value(file_path, file_size, detected_format, &doc);
+
+    // 구조 최상위 노드 제목만 싣는다 — 트리 전체는 export-structure 의 몫이다.
+    let st = build_structure(doc.document(), StructureMode::Auto);
+    let outline: Vec<&str> = st
+        .roots
+        .iter()
+        .take(DIGEST_OUTLINE_LIMIT)
+        .map(|n| n.heading.as_str())
+        .collect();
+
+    // 앞쪽 페이지 텍스트 발췌 → max_chars 문자에서 절단 (char 경계 안전).
+    let page_count = doc.page_count();
+    let mut excerpt_src = String::new();
+    for p in 0..page_count.min(DIGEST_EXCERPT_PAGES) {
+        match doc.extract_page_text_native(p) {
+            Ok(text) => {
+                if !excerpt_src.is_empty() {
+                    excerpt_src.push('\n');
+                }
+                excerpt_src.push_str(&text);
+            }
+            Err(e) => {
+                eprintln!("오류: 페이지 {} 텍스트 추출 실패 - {:?}", p, e);
+                return EXIT_RUNTIME;
+            }
+        }
+    }
+    let truncated = excerpt_src.chars().count() > max_chars;
+    let excerpt: String = if truncated {
+        excerpt_src.chars().take(max_chars).collect()
+    } else {
+        excerpt_src
+    };
+
+    let envelope = serde_json::json!({
+        "schemaVersion": "1.0",
+        "source": file_path,
+        "format": info["format"],
+        "pageCount": info["pageCount"],
+        "paraCount": info["paraCount"],
+        "outline": outline,
+        "excerpt": excerpt,
+        "truncated": truncated,
+        "nextStep": DIGEST_NEXT_STEP,
+    });
+    println!("{envelope}");
+    EXIT_OK
 }
 
 fn show_info(args: &[String]) -> i32 {

--- a/tests/digest_macro_contract.rs
+++ b/tests/digest_macro_contract.rs
@@ -1,0 +1,228 @@
+//! [#3633] `digest` 매크로 계약 테스트 — 초소형 모델용 매크로 도구 축 1호.
+//!
+//! 계약: `digest --json` 은 한 줄 JSON 봉투(schemaVersion·source·format·pageCount·
+//! paraCount·outline·excerpt·truncated·nextStep)를 stdout 에 낸다. `nextStep` 은
+//! 고정 문자열이다 — 체이닝을 못 하는 모델이 다음 행동을 지어내지 않고 받아 적는
+//! 유도 계약이므로, 문구 변경은 본 테스트가 잡는 의도적 결정이어야 한다.
+//! 실패 시 stdout 은 0바이트(소비자는 stdout 만 파싱), 종료 코드는 [#2707] 계약.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// 파싱까지 성공하는 실제 샘플 (cli_json_contract.rs 와 동일 원천).
+const SAMPLE: &str = "samples/hwp3-sample.hwp";
+
+/// [#3633] nextStep 고정 문자열 계약 — 구현과 문자 그대로 일치해야 한다.
+const NEXT_STEP: &str = "더 읽으려면 export-text --json -p <쪽>, 찾으려면 search --json";
+
+fn sample_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(rhwp_bin())
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn parse_stdout_json(args: &[&str], output: &Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout 이 순수 JSON 이 아닙니다 ({e}).\n{}",
+            describe(args, output)
+        )
+    })
+}
+
+// ── ① 봉투 필드·nextStep·절단 계약 ─────────────────────────────────────────
+
+#[test]
+fn digest_json_envelope_contract() {
+    let sample = sample_path();
+    let args = ["digest", "--json", sample.to_str().unwrap()];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+
+    // 봉투는 한 줄 — 초소형 모델이 줄 단위로 그대로 삼킬 수 있어야 한다.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout.lines().filter(|l| !l.trim().is_empty()).count(),
+        1,
+        "봉투는 한 줄이어야 합니다.\n{}",
+        describe(&args, &output)
+    );
+
+    let v = parse_stdout_json(&args, &output);
+    assert_eq!(v["schemaVersion"], "1.0", "{v}");
+    assert!(v["source"].is_string(), "{v}");
+    assert_eq!(v["format"], "hwp3", "{v}");
+    assert!(v["pageCount"].as_u64().unwrap() >= 1, "{v}");
+    assert!(v["paraCount"].as_u64().unwrap() >= 1, "{v}");
+    assert!(v["outline"].is_array(), "{v}");
+    // outline 항목은 문자열(상위 노드 제목) — 트리 전체를 싣지 않는다(컨텍스트 절약).
+    for item in v["outline"].as_array().unwrap() {
+        assert!(
+            item.is_string(),
+            "outline 은 제목 문자열 배열이어야 합니다: {v}"
+        );
+    }
+    assert!(v["excerpt"].is_string(), "{v}");
+    assert!(!v["excerpt"].as_str().unwrap().is_empty(), "{v}");
+    assert!(v["truncated"].is_boolean(), "{v}");
+    // nextStep 고정 문자열 계약.
+    assert_eq!(v["nextStep"], NEXT_STEP, "{v}");
+}
+
+#[test]
+fn digest_max_chars_truncates_excerpt() {
+    let sample = sample_path();
+    let args = [
+        "digest",
+        "--json",
+        "--max-chars",
+        "16",
+        sample.to_str().unwrap(),
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+
+    let v = parse_stdout_json(&args, &output);
+    let excerpt = v["excerpt"].as_str().expect("excerpt 문자열");
+    assert!(
+        excerpt.chars().count() <= 16,
+        "excerpt 는 --max-chars 이하(문자 수 기준)여야 합니다: {v}"
+    );
+    assert_eq!(
+        v["truncated"], true,
+        "절단이 일어났으면 truncated=true 여야 합니다: {v}"
+    );
+    // 절단돼도 nextStep 유도는 살아 있어야 한다.
+    assert_eq!(v["nextStep"], NEXT_STEP, "{v}");
+}
+
+#[test]
+fn digest_invalid_max_chars_exit_usage() {
+    let sample = sample_path();
+    let args = [
+        "digest",
+        "--json",
+        "--max-chars",
+        "코끼리",
+        sample.to_str().unwrap(),
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(output.stdout.is_empty(), "{}", describe(&args, &output));
+}
+
+// ── ② 실패 stdout 순수성 ───────────────────────────────────────────────────
+
+#[test]
+fn digest_missing_file_exit_runtime_silent_stdout() {
+    let args = ["digest", "--json", "없는파일-digest.hwp"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "실패 경로 stdout 은 비어야 합니다.\n{}",
+        describe(&args, &output)
+    );
+}
+
+#[test]
+fn digest_multiple_files_exit_usage_silent_stdout() {
+    let first = sample_path();
+    let second = sample_path();
+    let args = [
+        "digest",
+        first.to_str().unwrap(),
+        second.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "추가 입력을 조용히 무시하면 안 됩니다.\n{}",
+        describe(&args, &output)
+    );
+    assert!(output.stdout.is_empty(), "{}", describe(&args, &output));
+}
+
+// ── ③ capabilities/MCP 등재 ────────────────────────────────────────────────
+
+#[test]
+fn digest_registered_in_capabilities() {
+    let cap = parse_stdout_json(&["capabilities"], &run(&["capabilities"]));
+    let commands = cap["commands"].as_array().expect("commands 배열");
+    let digest = commands
+        .iter()
+        .find(|c| c["name"] == "digest")
+        .unwrap_or_else(|| panic!("capabilities 에 digest 누락: {cap}"));
+    assert_eq!(digest["json"], true, "{digest}");
+    assert!(digest["summary"].is_string(), "{digest}");
+    let fields = digest["recordFields"].as_array().expect("recordFields");
+    for expected in ["outline", "excerpt", "truncated", "nextStep"] {
+        assert!(
+            fields.iter().any(|f| f == expected),
+            "digest recordFields 에 {expected} 누락: {digest}"
+        );
+    }
+}
+
+#[test]
+fn digest_registered_in_mcp_with_compact_description() {
+    let mcp = parse_stdout_json(&["capabilities", "--mcp"], &run(&["capabilities", "--mcp"]));
+    let tools = mcp["tools"].as_array().expect("tools 배열");
+    let digest = tools
+        .iter()
+        .find(|t| t["name"] == "hwp_digest")
+        .unwrap_or_else(|| panic!("MCP 도구 hwp_digest 누락: {mcp}"));
+    assert_eq!(digest["cli"]["command"], "digest", "{digest}");
+    let required = digest["inputSchema"]["required"].as_array().unwrap();
+    assert!(required.iter().any(|r| r == "path"), "{digest}");
+    // [#3633] 초소형 모델 컨텍스트 절약 계약: 설명은 40자 이내로 극단 압축한다.
+    let desc = digest["description"].as_str().expect("description");
+    assert!(
+        desc.chars().count() <= 40,
+        "hwp_digest 설명은 40자 이내여야 합니다 ({}자): {desc}",
+        desc.chars().count()
+    );
+}
+
+/// [#3289] 아카이브 실행 시 컴파일타임 경로는 빌드 러너 전용이므로,
+/// nextest가 런타임에 재매핑해 주입하는 CARGO_BIN_EXE_rhwp를 우선한다.
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}


### PR DESCRIPTION
## 무엇을

초소형 로컬 모델(4B급 — 도구 체이닝·긴 컨텍스트 불가)도 rhwp 로 문서 파악을 안전 수행하게 하는 **매크로 도구 축**(#3633)의 1호, `digest` 를 구현합니다. "info 로 훑고 → export-structure 로 개요를 얻고 → export-text 로 첫 장을 읽는" 3단 파이프라인을 **한 번 호출**로 결정론적으로 수행하고, 봉투의 `nextStep` 고정 문자열로 다음 행동을 유도합니다.

로드맵 #3608 에는 "초소형 모델 매크로 축" 신규 항목(M 신설)으로 제안하며, 본 PR 머지 후 이슈 코멘트로 등재하겠습니다.

## 어떻게

- **CLI `digest <파일> [--max-chars N] [--json]`** — 새 해석 로직 없이 기존 원천만 재사용:
  `load_document` → `info_json_value` 의 format·pageCount·paraCount + `build_structure(Auto)` 최상위 노드 제목(최대 20개) + `extract_page_text_native` 페이지 0~2 발췌를 `--max-chars`(기본 2000) **문자 수**에서 절단.
- 기계 전용 명령: `--json` 유무와 무관하게 항상 봉투 **한 줄** JSON. 실패 시 stdout 0바이트, 종료 코드 #2707 계약(0/1/2).
- `nextStep` 은 **고정 문자열 계약**(`DIGEST_NEXT_STEP` 상수) — 문구 변경은 계약 테스트가 잡는 의도적 결정이어야 합니다.
- `capabilities` cmd_json + MCP `hwp_digest` 등재. 매크로 도구의 MCP 설명은 **40자 이내 극단 압축**(도구 목록 자체가 컨텍스트를 잠식하는 초소형 모델이 1차 소비자) — 길이를 계약 테스트가 감시합니다.
- 설계 결정 문서 `mydocs/tech/tiny_model_macro_tools.md`(kind: decision): 제약 3가지(체이닝 불가·컨텍스트 극소·지시 이탈) → 원칙 3가지(원콜 워크플로·40자 설명·nextStep 고정 유도) → 매크로 3종 명세(2호 `hwp_fill_and_verify`·3호 `hwp_replace_and_verify` 는 봉투 초안만) → #3630(weak-agent-proofing P1~P4)·#3629(역할 라우터)와의 관계('초소형' 프로필 추가는 #3629 머지 후 후속). tech 지도·`cli_commands.md` 등재 포함.

## 실측 봉투 (증적)

```console
$ rhwp digest --json --max-chars 220 samples/hwp3-sample.hwp
{"excerpt":"￼Creating Linux Virtual Servers\n\n\nWensong Zhang, Shiyao Jin, Quanyuan Wu\nNational Laboratory for Parallel & Distributed Processing\nChangsha, Hunan 410073, China\nwensong@iinchina.net\nhttp://proxy.iinchina.net/~wensong\n\n\n\n","format":"hwp3","nextStep":"더 읽으려면 export-text --json -p <쪽>, 찾으려면 search --json","outline":["1. 소개","2. 연관된 작업들","3. 가상 서버 구조","3.1 NAT에 의한 가상 서버","3.2 IP 터널링에 의한 가상 서버","3.3 장점과 단점","3.3.1 NAT에 의한 가상 서버","3.3.2 IP 터널링에 의한 가상 서버","4. 작업 할당 방식(Scheduling Algorithms)","4.1 Round-Robin 작업 할당","4.2 가중치가 있는(weighted) Round-Robin 작업 할당","4.3 최소-접속 작업 할당","4.4 가중치가 있는 최소-접속 작업 할당","5. 고 가용성(High Availability)","6. 결론과 미래에 해야할 일"],"pageCount":16,"paraCount":195,"schemaVersion":"1.0","source":"samples/hwp3-sample.hwp","truncated":true}
exit=0
```

## 검증

- red 선행 확인: 구현 전 `digest_macro_contract` 5건 실패(알 수 없는 명령·등재 누락) → 구현 후 green.
- `cargo test --release --test digest_macro_contract` — **7/7 통과** (봉투 필드·nextStep 고정·`--max-chars` 절단 / 실패 stdout 순수성 exit 1·2 / capabilities·MCP 등재 + 40자 설명).
- `cargo test --release --test cli_json_contract` — **22/22 통과** (무회귀; help↔capabilities↔MCP 드리프트 가드 3종 포함).
- `cargo clippy --release --bin rhwp --tests -- -D warnings` — 경고 0.
- `rustfmt --check` — 신규/수정 파일 diff 없음 (CRLF 개행 오탐 제외).
- `py scripts/check_markdown_links.py` — 신규·수정 md 3건 이상 없음.

Closes #3633

🤖 Generated with [Claude Code](https://claude.com/claude-code)
