### PR TITLE
fix(skia): 반각 강제 구두점 0.5x 배치 + bold face 부재 폰트 합성 굵게, 오른쪽 정렬 말미 공백 제외 — 10k 회귀 0

### DIFF
--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -3585,6 +3585,34 @@ impl LayoutEngine {
             } else {
                 effective_col_x + effective_margin_left
             };
+            // 한글은 셀 밖 오른쪽 정렬 폭에서 말미 공백을 제외한다
+            // (needs_justify 의 후행 공백 제외와 동일 규칙). 포함하면
+            // [그림+말미공백72] 꼬리말이 공백 폭(447px)만큼 왼쪽으로 이탈 —
+            // 식약처 보도자료 OPEN 로고 실측(한글 x=607.3). 반례: 셀 내부는
+            // 한글이 말미 공백을 포함해 정렬(issue_1285 수험번호 TAC 우단
+            // = 셀 inner 우단 오라클 앵커) — cell_ctx 부재로 한정. Center 도
+            // 근거 부재로 기존 동작 유지.
+            let right_trailing_ws_width = if alignment == Alignment::Right && cell_ctx.is_none() {
+                let all_chars: Vec<char> =
+                    comp_line.runs.iter().flat_map(|r| r.text.chars()).collect();
+                let trailing_spaces = all_chars.iter().rev().take_while(|c| **c == ' ').count();
+                if trailing_spaces > 0 {
+                    if let Some(last_run) = comp_line.runs.last() {
+                        let ts = resolved_to_text_style(
+                            styles,
+                            last_run.char_style_id,
+                            last_run.lang_index,
+                        );
+                        estimate_text_width(&" ".repeat(trailing_spaces), &ts)
+                    } else {
+                        0.0
+                    }
+                } else {
+                    0.0
+                }
+            } else {
+                0.0
+            };
             let x_start = match alignment {
                 Alignment::Center => {
                     let align_offset = if center_packed_cell_label_as_right {
@@ -3608,7 +3636,8 @@ impl LayoutEngine {
                     x_base
                         + inline_offset
                         + num_x_offset
-                        + (available_width - effective_text_width).max(0.0)
+                        + (available_width - (effective_text_width - right_trailing_ws_width))
+                            .max(0.0)
                 }
                 _ => x_base + inline_offset + num_x_offset, // Left, Justify, Split, Distribute(분배중)
             };

--- a/src/renderer/skia/text_replay.rs
+++ b/src/renderer/skia/text_replay.rs
@@ -9,7 +9,9 @@ use crate::paint::LayerOutputOptions;
 use crate::renderer::composer::{
     decode_pua_overlap_number, expand_pua_render_text, pua_to_display_text, CharOverlapInfo,
 };
-use crate::renderer::layout::{compute_char_positions, split_into_clusters};
+use crate::renderer::layout::{
+    compute_char_positions, is_halfwidth_cjk_quote, split_into_clusters,
+};
 use crate::renderer::render_tree::BoundingBox;
 use crate::renderer::{clamp_tab_leader_end_x, TextStyle};
 
@@ -147,6 +149,22 @@ impl SkiaTextReplay<'_> {
                     chain
                 };
                 let primary_typeface = typeface_chain.first().cloned();
+                // 한글은 bold face 가 없는 폰트(휴먼명조 등 단일 400 페이스)에
+                // 동일 정규 페이스 + stroke 로 합성 굵게를 적용한다 (오라클
+                // PDF 실측: 굵은 헤더가 정규 휴먼명조 임베드로 방출). custom
+                // typeface 는 스타일 무시 단일 페이스라 여기서 embolden 으로
+                // 합성한다. 시스템 매칭이 진짜 bold 페이스를 반환한 경우는
+                // weight 조건에서 제외돼 이중 굵게가 없다.
+                let want_synthetic_bold = style.bold;
+                let finish_font = |tf: Typeface, size: f32| -> Font {
+                    let is_bold_face = *tf.font_style().weight() >= 600;
+                    let mut font = Font::new(tf, size);
+                    font.set_edging(font::Edging::AntiAlias);
+                    if want_synthetic_bold && !is_bold_face {
+                        font.set_embolden(true);
+                    }
+                    font
+                };
                 let font_for_text = |sample: &str, size: f32| -> Option<Font> {
                     let visible_char = sample.chars().find(|ch| !ch.is_whitespace());
                     if let Some(ch) = visible_char {
@@ -156,16 +174,12 @@ impl SkiaTextReplay<'_> {
                             .find(|tf| tf.unichar_to_glyph(codepoint) != 0)
                             .cloned()
                         {
-                            let mut font = Font::new(tf, size);
-                            font.set_edging(font::Edging::AntiAlias);
-                            return Some(font);
+                            return Some(finish_font(tf, size));
                         }
                         return None;
                     }
                     if let Some(tf) = primary_typeface.clone() {
-                        let mut font = Font::new(tf, size);
-                        font.set_edging(font::Edging::AntiAlias);
-                        Some(font)
+                        Some(finish_font(tf, size))
                     } else {
                         let mut font = Font::default();
                         font.set_size(size);
@@ -549,6 +563,27 @@ impl SkiaTextReplay<'_> {
                                 + char_positions.get(*char_idx).copied().unwrap_or(0.0) as f32
                                 + dx;
                             let char_y = y as f32 + dy;
+                            // 반각 강제 구두점: 측정은 반각(0.3~0.5em)인데 폰트
+                            // 글리프가 전각인 문자(휴먼명조 U+2018 등)를 그대로
+                            // 그리면 다음 글자와 겹친다. web_canvas 와 동일하게
+                            // 0.5× 수평 축소로 반각 공간에 배치 (한글은 자체
+                            // 내장 협폭 글리프로 렌더 — 오라클 PDF Type3 실측).
+                            let needs_halfwidth_scale = cluster
+                                .chars()
+                                .next()
+                                .is_some_and(|ch| {
+                                    matches!(ch, '\u{2018}'..='\u{2027}')
+                                        || is_halfwidth_cjk_quote(ch)
+                                })
+                                && !has_ratio;
+                            if needs_halfwidth_scale {
+                                canvas.save();
+                                canvas.translate((char_x, char_y));
+                                canvas.scale((0.5, 1.0));
+                                canvas.draw_str(cluster, (0.0, 0.0), &font, &text_paint);
+                                canvas.restore();
+                                continue;
+                            }
                             if has_ratio {
                                 canvas.save();
                                 canvas.translate((char_x, char_y));

--- a/src/renderer/skia/text_replay.rs
+++ b/src/renderer/skia/text_replay.rs
@@ -568,14 +568,9 @@ impl SkiaTextReplay<'_> {
                             // 그리면 다음 글자와 겹친다. web_canvas 와 동일하게
                             // 0.5× 수평 축소로 반각 공간에 배치 (한글은 자체
                             // 내장 협폭 글리프로 렌더 — 오라클 PDF Type3 실측).
-                            let needs_halfwidth_scale = cluster
-                                .chars()
-                                .next()
-                                .is_some_and(|ch| {
-                                    matches!(ch, '\u{2018}'..='\u{2027}')
-                                        || is_halfwidth_cjk_quote(ch)
-                                })
-                                && !has_ratio;
+                            let needs_halfwidth_scale = cluster.chars().next().is_some_and(|ch| {
+                                matches!(ch, '\u{2018}'..='\u{2027}') || is_halfwidth_cjk_quote(ch)
+                            }) && !has_ratio;
                             if needs_halfwidth_scale {
                                 canvas.save();
                                 canvas.translate((char_x, char_y));


### PR DESCRIPTION
Skia 래스터 경로만 한글 오라클과 발산하던 두 축을 배선하고, 셀 밖 오른쪽 정렬에서
말미 공백이 폭에 잡히던 문제를 함께 고칩니다.

Refs #3386

## 무엇을 고쳤나

### 1. 반각 강제 구두점이 전각 폭으로 그려진다 (`skia/text_replay.rs`)

한글은 `'` `"` 등 일부 구두점을 반각(0.3~0.5em)으로 **측정**하는데, 폰트가 주는
글리프는 전각입니다. 레이아웃은 반각으로 자리를 잡아 두고 래스터가 전각으로 그리니
다음 글자와 겹쳤습니다.

`web_canvas` 경로는 이미 0.5× 수평 축소로 반각 자리에 맞춰 그리고 있었습니다.
skia 경로에만 그 배선이 빠져 있었습니다. 같은 규칙을 적용합니다.

### 2. bold face 가 없는 폰트에서 굵기가 무시된다 (`skia/text_replay.rs`)

휴먼명조처럼 400 단일 페이스만 있는 폰트는 typeface 가 스타일을 무시한 단일
페이스를 돌려줍니다. 한글은 이때 합성 굵게로 그립니다. skia 경로는 그냥 400 으로
그려서 굵기가 사라졌습니다.

시스템 매칭이 **진짜** bold 페이스(weight >= 600)를 준 경우는 건드리지 않고, 그렇지
않을 때만 `set_embolden(true)` 로 합성합니다.

### 3. 셀 밖 오른쪽 정렬 폭에 말미 공백이 포함된다 (`layout/paragraph_layout.rs`)

오른쪽 정렬 폭을 잴 때 줄 끝 공백까지 세어, 그만큼 내용이 왼쪽으로 밀렸습니다.
꼬리말의 OPEN 로고가 좌측으로 이탈하던 증상의 원인입니다. 폭 계산에서 말미 공백을
제외합니다.

## 검증 — 10k 한글 오라클 서베이 (r28)

전량 완주했습니다. 기준선은 r26(폰트-클린)입니다.

|  | r26 | r28 |
|---|---|---|
| PI 정합 | 9,286/9,905 = **93.75%** | 9,286/9,905 = **93.75%** |
| MATCH | 9,219 | 9,219 |
| PAGE_DELTA | 390 | 390 |
| PI_MISMATCH | 229 | 229 |
| PI_MISMATCH_CARET | 67 | 67 |
| STALL / PROTECTED_SKIP / PARA_COUNT | 63 / 28 / 4 | 63 / 28 / 4 |
| 시각 축 충전 | 9,547 | **9,548** (+1) |
| 픽셀 평균 | 94.405% | **94.406%** (+0.001pp) |

**문서 단위 전이: 회귀 0 · 개선 0** (공통 10,000문서 전수)

판정 분포가 r26 과 전 항목 일치합니다. 1차 실행에서는 PI 모수가 9,901 로 4 작게
나왔는데, 원인은 한글 COM 워치독이 죽인 STALL 4건이었습니다. 격리 재실행에서
4건 모두 회복됐고 판정·쪽수·`vis`·픽셀값이 r26 과 소수 둘째 자리까지 같았습니다
(`output/poc/survey10k_r28_20260730/makeup/stall4_recovered.tsv`). 코드와 무관한
오라클 측 변덕입니다. 시각 축 충전은 오히려 +1 인데, r26 에서 `VERR` 였던 문서
1건이 이번에 성공했습니다.

### 픽셀 효과의 실제 크기

과장하지 않기 위해 대조 경로로 나눠 적습니다.

| 경로 | 문서 | 최대 변화 | 순합 | 개선/하락 |
|---|---|---|---|---|
| `OK` (쪽 직접 비교) | 285 | **0.140pp** | +3.880pp | 282 / 3 |
| `OK2UP` (2-up 시트 분할) | 47 | 2.870pp | +2.380pp | 45 / 2 |

0.5pp 를 넘는 변동 4건은 **전부** `OK2UP` 경로입니다. 그 경로는 한글 2-up 시트를
잘라 쪽을 대응시키므로 렌더가 같아도 pp 단위로 튑니다. 가장 컸던 하락 1건을
직접 갈랐습니다.

```
156488348_[1224]문체부보도자료-인공지능 문화해설 로봇 큐아이 확대 도입.hwpx
  하니스 측정   87.18 -> 84.56   (-2.62pp)
  두 바이너리로 직접 export-png 후 픽셀 비교
                891,662 픽셀 중 55~68 픽셀만 다름 (0.006%)
```

0.006% 의 렌더 차이가 2.62pp 를 만들 수 없습니다. 렌더 회귀가 아니라 2-up 정렬
노이즈입니다.

**따라서 이 PR 의 실효는 `OK` 경로에 갇힙니다.** 285문서(3.0%)가 움직이고 문서당
최대 0.14pp, 하락 3건은 전부 -0.01pp 입니다. 안전하지만 큰 지렛대는 아닙니다.

착수 당시 표적군 측정은 "반경 83%, 전건 무하락 평균 +3.62pp" 였는데, 그것은 손으로
고른 별지/별표 집합 기준이었습니다. 무작위 10k 코퍼스에서는 발현율 3% 에 건당
0.1pp 미만입니다. 실측대로 적습니다.

### 검증 환경

```
바이너리  upstream/devel 96892e31c + 본 PR 2커밋
빌드      cargo build --release --features native-skia
환경      RHWP_FONT_PATH=<repo>\ttfs\hwp;<repo>\ttfs\windows
모집단    10,000 문서 (r26 과 동일 집합)
```

서베이 하니스와 대조 스크립트, 실행 중 밟은 함정 5건을 정리한 README 는
`output/poc/survey10k_r28_20260730/` 에 있습니다.
