### PR TITLE
diag(layout): 셀 안 쪽 밖 배치가 진단에 한 줄도 안 남던 사각지대 — LAYOUT_OVERFLOW_CELL (8문서 2,910자 관측)

### DIFF
--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -1434,6 +1434,12 @@ pub struct LayoutEngine {
     /// 현재 페이지 본문 영역 (표 HorzRelTo::Page / VertRelTo::Page 위치 계산용)
     /// (x, y, width, height). 미설정 시 (0, 0, 0, 0) — 호출부에서 col_area로 폴백.
     current_body_area: std::cell::Cell<(f64, f64, f64, f64)>,
+    /// 현재 페이지의 물리 높이 (px).
+    ///
+    /// [#3637] 셀 안 넘침 진단의 기준선이다. 본문 하단이 아니라 **쪽 하단**이어야 한다 —
+    /// 본문 하단과 쪽 하단 사이(아래 여백·꼬리말 영역)에 그려진 글자는 실제로 보이므로
+    /// 결함이 아니다. 본문 하단으로 재면 그 구간이 통째로 오탐이 된다.
+    current_page_height: std::cell::Cell<f64>,
     /// HWP3-origin HWP5 변환본 여부.
     /// [#2403] 소스분기 질의 표면 — set_layout_profile 로 배선 (종전 hwp3_variant/
     /// hwpx_source Cell 2개 통합).
@@ -1535,6 +1541,7 @@ impl LayoutEngine {
             show_control_codes: std::cell::Cell::new(false),
             current_paper_width: std::cell::Cell::new(0.0),
             current_body_area: std::cell::Cell::new((0.0, 0.0, 0.0, 0.0)),
+            current_page_height: std::cell::Cell::new(0.0),
             profile: std::cell::Cell::new(Default::default()),
             use_hwp3_origin_flow_spacing_before: std::cell::Cell::new(false),
             render_normalization: std::cell::RefCell::new(std::sync::Arc::new(
@@ -3084,6 +3091,7 @@ impl LayoutEngine {
                 // 바탕쪽은 본문보다 먼저 렌더링되므로 표 위치 계산용 현재 페이지 context를
                 // 여기서 명시적으로 채워야 `vertRelTo=PAGE`, `horzRelTo=PAGE`가 올바르게 동작한다.
                 self.current_paper_width.set(layout.page_width);
+                self.current_page_height.set(layout.page_height);
                 self.current_body_area.set((
                     body_area.x,
                     body_area.y,
@@ -4570,6 +4578,9 @@ impl LayoutEngine {
 
         // 현재 페이지 용지 너비 설정 (표 HorzRelTo::Paper 위치 계산용)
         self.current_paper_width.set(layout.page_width);
+        // [#3637] 쪽 높이도 여기서 채운다. 바탕쪽 분기(위)에서만 채우면 바탕쪽 없는
+        // 문서에서 0 으로 남아 셀 넘침 진단이 통째로 침묵한다.
+        self.current_page_height.set(layout.page_height);
         // 현재 페이지 본문 영역 설정 (표 HorzRelTo::Page / VertRelTo::Page 계산용 — Task #347)
         let ba = &layout.body_area;
         self.current_body_area

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -3234,6 +3234,43 @@ impl LayoutEngine {
                     line_visual_bottom, col_bottom, line_visual_bottom - col_bottom,
                 );
             }
+            // [#3637] 셀 안 줄이 **쪽 본문 하단**을 넘는 경우.
+            //
+            // 위 진단은 `is_body_flow_col_area && cell_ctx.is_none()` 이라 본문 흐름만
+            // 본다. 셀은 `col_area` 가 셀 사각형이라 그 조건이 언제나 거짓이고, 그래서
+            // 셀 안에서 쪽 밖으로 나간 글자는 **한 줄도 보고되지 않았다**.
+            //
+            // 실측: 쪽 밖 글자가 있는 문서 91건 중 8건이 이 침묵 구간이었다
+            // (총 2,910자, 최대 471.8px 초과). 텍스트 추출에는 남아 있어 텍스트 diff 로도
+            // 안 잡히고, 진단마저 없어 관측 자체가 불가능했다.
+            //
+            // 기준선 두 가지가 함께 맞아야 오탐이 사라진다.
+            //
+            // 1. **쪽 하단** (본문 하단 아님). 본문 하단과 쪽 하단 사이는 아래 여백·꼬리말
+            //    구간이라 거기 그려진 글자는 실제로 보인다. 본문 하단으로 재면 그 구간이
+            //    통째로 오탐이 된다.
+            // 2. 줄의 **윗변**(`text_y`). 아랫변으로 재면 마지막 줄 디센더가 경계를 스치는
+            //    정상 상태까지 잡는다. 윗변이 이미 쪽 밖이면 그 줄은 **어느 부분도 그려지지
+            //    않는다** — 배율·글꼴에 무관한 판정이다.
+            //
+            // MATCH 대조군 80건 실측: 아랫변 기준은 9건(11%) 오탐, 초과폭이 전부
+            // 5.4~23.9px(줄 높이 이내)였다. 윗변으로 바꾸니 7건, 기준을 쪽 하단으로 옮겨야
+            // 0 이 된다. 진짜 침묵 구간 8건은 146.0~512.0px 라 어느 기준에서도 남는다.
+            if cell_ctx.is_some() && !blank_spacer_line {
+                let page_h = self.current_page_height.get();
+                if page_h > 0.0 && text_y > page_h + 0.5 {
+                    eprintln!(
+                        "LAYOUT_OVERFLOW_CELL: section={} pi={} line={} y={:.1} \
+                         page_bottom={:.1} overflow={:.1}px",
+                        section_index,
+                        para_index,
+                        line_idx,
+                        text_y,
+                        page_h,
+                        text_y - page_h,
+                    );
+                }
+            }
             // [Task #604 R3] wrap_anchor 가 있으면 본 문단은 anchor 그림/표 옆 wrap text.
             // 각 라인의 LineSeg cs(column_start)/sw(segment_width)를 x 오프셋/너비로 적용.
             // typeset 의 wrap_around state machine 매칭 결과 (ColumnContent.wrap_anchors)


### PR DESCRIPTION
셀 안에서 쪽 밖으로 나간 글자를 진단이 **한 줄도 보고하지 않던** 사각지대를 엽니다.

Refs #3637

## 무엇이 안 보였나

기존 진단은 본문 흐름만 봅니다.

```rust
if is_body_flow_col_area && cell_ctx.is_none() && line_visual_bottom > col_bottom + 0.5 { … }
```

`is_body_flow_col_area` 는 `col_area` 가 본문 영역과 같은지 봅니다. 셀은 `col_area` 가
셀 사각형이라 이 조건이 **언제나 거짓**입니다. 그래서 셀 안에서 쪽 경계를 넘어간
글자는 진단에 흔적조차 남기지 않았습니다.

그 글자들은 `export-text` 에도 SVG `<text>` 요소에도 남아 있어 텍스트 diff·IR diff
로도 안 잡힙니다. 진단마저 없으니 **관측 자체가 불가능**했습니다.

실측 — 10k 서베이(r28)에서 쪽 밖 글자가 확인된 91문서 중 **8문서가 이 침묵 구간**
이었습니다.

| 문서 | 쪽 밖 글자 | 최대 초과 |
|---|---|---|
| `148738070_무학대선건 보도자료` | 762자 | 353.2px |
| `148780987_6월30일대변인정례브리핑` | 661자 | 354.5px |
| `156060125_금융지주 경쟁력 강화 제도개선` | 481자 | 348.2px |
| `2737927_[별표 1] 재건축부담금 평가지침` | 417자 | 213.1px |
| `17713169_[별표 20의5] 선박에너지효율지수` | 327자 | 471.8px |
| 그 외 3건 | 262자 | — |
| **합계** | **2,910자** | |

## 추가하는 것

`LAYOUT_OVERFLOW_CELL` 한 줄입니다. **동작은 바뀌지 않습니다** — 좌표·쪽수·렌더 결과
어느 것도 건드리지 않고 stderr 에 관측만 더합니다.

```
LAYOUT_OVERFLOW_CELL: section=0 pi=42 line=3 y=1259.4 page_bottom=1122.5 overflow=136.9px
```

## 기준선을 두 번 고쳤습니다

오탐이 나는 진단은 없느니만 못해서, 대조군으로 두 번 조정했습니다.

| 기준 | MATCH 대조군 80건 오탐 |
|---|---|
| 줄 아랫변 vs **본문** 하단 | 9건 (11%) |
| 줄 윗변 vs **본문** 하단 | 7건 |
| 줄 윗변 vs **쪽** 하단 | **0건** |

두 가지가 함께 맞아야 했습니다.

1. **쪽 하단**이 기준입니다(본문 하단 아님). 본문 하단과 쪽 하단 사이는 아래 여백·
   꼬리말 구간이라 거기 그려진 글자는 **실제로 보입니다**. 본문 하단으로 재면 그
   구간이 통째로 오탐이 됩니다.
2. 줄의 **윗변**이 기준입니다(아랫변 아님). 아랫변으로 재면 마지막 줄 디센더가 경계를
   스치는 정상 상태까지 잡습니다. 윗변이 이미 쪽 밖이면 그 줄은 어느 부분도 그려지지
   않는다는 뜻이라, 배율·글꼴에 무관하게 갈립니다.

또 `current_page_height` 를 **주 렌더 경로에도** 배선했습니다. 종전 `current_body_area`
와 나란히 바탕쪽 분기에서만 채우면 바탕쪽 없는 문서에서 0 으로 남아 진단이 통째로
침묵합니다(실제로 겪었습니다).

## 검증 — 줄 단위 대조

문서 단위로 "둘 다 발생"을 세면 착각합니다. 실제로 첫 판본에서 그렇게 오독했습니다 —
진단이 잡은 줄은 본문 하단만 넘은 **정상 셀 줄**이었고, 판별기가 센 쪽 밖 글자는
다른 줄이었는데 같은 문서에서 둘 다 일어나 "검출"로 보였습니다.

그래서 진단이 지목한 y 가 실제 쪽 밖 글자의 y 와 겹치는지까지 확인했습니다.

| | 문서 진단 | 문서 실제 | **줄 대응** | **대응 없음(오탐)** |
|---|---|---|---|---|
| `MATCH` 대조군 80건 | 0 | 0 | 0 | **0** |
| 침묵 8건 | 8 | 8 | **120** | **0** |

진단이 지목한 줄 120개가 전부 실제 쪽 밖 글자 위치와 겹칩니다(±30px).

## 이 PR 이 하지 않는 것

**결함을 고치지 않습니다.** 8문서 2,910자는 여전히 안 보입니다. 이 PR 은 그것을
**관측 가능하게** 만들 뿐입니다. 원인 조사는 #3637 후속입니다.
