### PR TITLE
docs: PR #3647 통합 검토 완료 기록

### DIFF
--- a/mydocs/pr/archives/pr_3612_review_impl.md
+++ b/mydocs/pr/archives/pr_3612_review_impl.md
@@ -70,3 +70,12 @@ render/HML/split/checkbox 경로의 계약은 release-test에 포함된 Rust con
 4. 원 PR에는 실제 LF로 된 통합 결과·감사 comment를 남긴 뒤 supersede close한다. contributor fork
    branch는 삭제하지 않는다. 마지막에 `devel` sync, 통합 remote/local branch와 정확한 review target만
    정리한다.
+
+## 완료
+
+통합 PR [#3647](https://github.com/edwardkim/rhwp/pull/3647)은
+[`a54ff52aa8bb2ede5dfe06bb493090d74f9065ab`](https://github.com/edwardkim/rhwp/commit/a54ff52aa8bb2ede5dfe06bb493090d74f9065ab)로
+2026-07-31에 merge됐다. current head `c9790a52b`와 remote head가 일치한 상태에서 CI preflight,
+Lint, Native Skia, default-feature 8개 shard, Build & Test, CodeQL, Canvas visual diff가 모두
+success였다(WASM·frontend는 변경 범위상 skipped). 이 review-only 기록 PR merge 뒤 관련 issue의 완료
+여부와 원 PR supersede close를 실제 상태로 처리한다.


### PR DESCRIPTION
[#3647](https://github.com/edwardkim/rhwp/pull/3647)의 code candidate에는 merge 전 review·오늘할일이 이미 포함됐습니다. 이 PR은 merge 뒤에만 확정되는 실제 merge commit과 최신 CI 완료 상태를 archive 계획 기록에 보존하는 review-only 후속 기록입니다.

변경 파일은 `mydocs/pr/archives/pr_3612_review_impl.md` 하나입니다. `git diff --check`, 해당 문서 링크 검사, 전체 metadata 검사가 통과했으며 LFS 대상이 없습니다. preflight와 최종 Build & Test aggregate가 성공하면 fast-pass로 merge합니다.
