### PR TITLE
docs: #3395 체크박스 미완료 범위 기록

### DIFF
--- a/mydocs/pr/archives/pr_3612_review_impl.md
+++ b/mydocs/pr/archives/pr_3612_review_impl.md
@@ -79,3 +79,6 @@ render/HML/split/checkbox 경로의 계약은 release-test에 포함된 Rust con
 Lint, Native Skia, default-feature 8개 shard, Build & Test, CodeQL, Canvas visual diff가 모두
 success였다(WASM·frontend는 변경 범위상 skipped). 이 review-only 기록 PR merge 뒤 관련 issue의 완료
 여부와 원 PR supersede close를 실제 상태로 처리한다.
+
+원 PR #3620의 `hwp_set_checkbox`는 문자 `□`(U+25A1) occurrence 경로만 완료한다. #3395가 추적하는
+문단 글머리표 `☐`(U+2610) 의미론은 구현되지 않았으므로 해당 issue는 open으로 유지한다.

--- a/mydocs/pr/archives/pr_3620_review.md
+++ b/mydocs/pr/archives/pr_3620_review.md
@@ -15,3 +15,12 @@ last_verified: 2026-07-31
 delegation 예외를 계약에 등재한다. broad replace로 사용자의 실제 서식을 훼손하지 않는 조작 단위를 만든
 점이 핵심이다. `replace_occurrence_contract`, guard 회귀와 전체 release-test exit 0을 확인했다. 전후
 PNG는 해당 operation의 설명 증적이며 renderer 변경 검증은 아니다. **통합 PR full CI 조건부 수용**이다.
+
+## 범위 확정
+
+[#3647](https://github.com/edwardkim/rhwp/pull/3647)은
+[`a54ff52a`](https://github.com/edwardkim/rhwp/commit/a54ff52aa8bb2ede5dfe06bb493090d74f9065ab)로 merge됐다.
+이번 도구의 완료 범위는 지정 occurrence의 문자 `□`(U+25A1)를 `☑`로 바꾸는 경로다. 관련
+[#3395](https://github.com/edwardkim/rhwp/issues/3395)가 최초로 지적한 문단 글머리표 `☐`(U+2610)는
+현재 도구가 찾지 않으므로 해결됐다고 표현하지 않는다. 그 실물 양식 경로와 fixture·재독·렌더 회귀는
+후속 범위로 issue를 open 유지한다.


### PR DESCRIPTION
검토 후속 기록입니다. [#3647](https://github.com/edwardkim/rhwp/pull/3647)의 `hwp_set_checkbox`는 문자 `□`(U+25A1) occurrence 경로를 완료했지만, [#3395](https://github.com/edwardkim/rhwp/issues/3395)가 추적하는 문단 글머리표 `☐`(U+2610) 경로는 아직 구현하지 않았습니다.

archive review 두 파일에 이 범위를 정확히 남기고 #3395를 open으로 유지합니다. 변경은 `mydocs`만이며, `git diff --check`, 변경 문서 링크 검사, metadata 검사와 LFS preflight를 통과했습니다. fast-pass preflight·최종 aggregate 성공 후 merge합니다.
