### PR TITLE
Task #3315: [성능] 그림 바이트를 키로 받는 API + base64 생략 opt-in

### DIFF
--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -1373,11 +1373,28 @@ impl DocumentCore {
         page_num: u32,
         profile: RenderProfile,
     ) -> Result<String, HwpError> {
+        self.get_page_layer_tree_with_options_native(
+            page_num,
+            profile,
+            crate::paint::LayerJsonOptions::default(),
+        )
+    }
+
+    /// [Task #3315] `options` 로 그림 base64 생략을 켤 수 있는 레이어 트리 JSON.
+    ///
+    /// 생략본과 종전 JSON 은 **서로 다른 캐시 변형**이다 — 같은 슬롯을 쓰면 한쪽 소비자가
+    /// 다른 쪽 모양을 받는다. 그래서 아래 지문에 생략 여부를 함께 접는다.
+    pub fn get_page_layer_tree_with_options_native(
+        &self,
+        page_num: u32,
+        profile: RenderProfile,
+        options: crate::paint::LayerJsonOptions,
+    ) -> Result<String, HwpError> {
         // [Task #2222] 직렬화 JSON 캐시 — 트리 캐시(#2227 with_page_tree_cached)가
         // 있어도 1MB 급 재직렬화가 renderPage 마다 렌더 비용과 맞먹게 반복된다
         // (주보 p2 실측: 15.2ms/회, JSON 1.05MB). 출력옵션 지문이 다르면 미스.
         let idx = page_num as usize;
-        let fp = self.layer_output_options_fingerprint(profile);
+        let fp = self.layer_output_options_fingerprint(profile, options);
         if let Some(variants) = self.layer_tree_json_cache.borrow().get(idx) {
             if let Some((_, json)) = variants.iter().find(|(f, _)| *f == fp) {
                 return Ok(json.clone());
@@ -1385,7 +1402,7 @@ impl DocumentCore {
         }
         let json = self
             .build_page_layer_tree_with_profile(page_num, profile)?
-            .to_json();
+            .to_json_with_options(options);
         {
             // 토글(투명선/잘림보기 등) 왕복이 매번 미스가 되지 않도록 페이지당
             // 옵션 변형 4개까지 보관 (초과 시 가장 오래된 변형 제거).
@@ -1404,7 +1421,12 @@ impl DocumentCore {
     }
 
     /// [Task #2222] 레이어 출력옵션 5종과 profile의 비트 지문 — JSON 캐시 키.
-    fn layer_output_options_fingerprint(&self, profile: RenderProfile) -> u8 {
+    /// [Task #3315] 그림 바이트 생략 여부를 최상위 비트에 함께 접는다.
+    fn layer_output_options_fingerprint(
+        &self,
+        profile: RenderProfile,
+        options: crate::paint::LayerJsonOptions,
+    ) -> u8 {
         let profile_bits = match profile {
             RenderProfile::FastPreview => 0,
             RenderProfile::Screen => 1,
@@ -1417,6 +1439,7 @@ impl DocumentCore {
             | (u8::from(self.clip_enabled) << 3)
             | (u8::from(self.debug_overlay) << 4)
             | (profile_bits << 5)
+            | (u8::from(options.omit_image_bytes) << 7)
     }
 
     /// 페이지가 그리는 그림들의 신원 키만 작은 JSON 으로 반환한다 (Task #3315).
@@ -1470,6 +1493,32 @@ impl DocumentCore {
         }
         buf.push_str("]}");
         Ok(buf)
+    }
+
+    /// 그림 신원 키로 그 op 이 내보내는 바이트와 mime 을 되돌려준다 (Task #3315).
+    ///
+    /// `get_page_layer_tree_with_options_native` 가 base64 를 생략했을 때 소비자가 바이트를
+    /// 받는 경로다. 반환값은 인라인 base64 가 담고 있던 것과 **같은 바이트여야** 하므로 변환은
+    /// JSON 경로와 같은 `emitted_image_bytes` 를 쓴다 — 사본을 두면 두 경로가 갈라진다.
+    ///
+    /// 키의 epoch 가 현재 문서 세대와 다르면 `None` 이다. 스냅샷 복원처럼 id→바이트 대응이
+    /// 깨지는 연산 뒤에 옛 키로 물어본 경우이므로, 낡은 바이트를 주는 대신 소비자가 트리를
+    /// 다시 받게 한다.
+    ///
+    /// 세션에 삽입한 그림은 `load_shared()` 가 같은 할당을 돌려주지만(#3411), 파일에서 읽은
+    /// `Loaded` 바이트는 여기서 한 벌 복사된다. 이 조회는 페이지의 그림이 바뀔 때만 불리므로
+    /// 키 입력마다 도는 경로가 아니다.
+    pub fn get_source_image_bytes_native(&self, key: &str) -> Option<(&'static str, Vec<u8>)> {
+        let (epoch, bin_data_id, variant) = crate::paint::parse_source_image_key(key)?;
+        if epoch != self.bin_data_epoch {
+            return None;
+        }
+        let content =
+            crate::renderer::layout::find_bin_data(&self.document.bin_data_content, bin_data_id)?;
+        let data = content.data.load_shared();
+        let (mime, bytes) =
+            crate::renderer::image_resolver::emitted_image_bytes(&data, variant.bakes_watermark());
+        Some((mime, bytes.into_owned()))
     }
 
     /// 페이지 overlay 이미지와 replay-plane summary만 작은 JSON으로 반환한다.

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -68,13 +68,37 @@ const KNOWN_TEXT_FEATURES: &[&str] = &[
     "text.vertical.mixedPerGlyph",
 ];
 
+/// 레이어 트리 JSON 직렬화 옵션 (Task #3315).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct LayerJsonOptions {
+    /// 그림 바이트를 base64 로 싣지 않는다.
+    ///
+    /// `sourceImageKey` 를 낼 수 있는 op 만 대상이다 — 키가 없으면 소비자가 바이트를 되찾을
+    /// 길이 없으므로 그 op 은 종전대로 base64 를 싣는다. 기본값이 `false` 라서 이 옵션을
+    /// 지정하지 않는 기존 호출부의 JSON 은 한 바이트도 달라지지 않는다.
+    pub omit_image_bytes: bool,
+}
+
+/// 직렬화 도중 트리 아래로 흘려야 하는 값. 그림 op 하나를 쓰려면 문서 세대(키 발급)와
+/// 생략 여부가 함께 필요해 한 덩이로 옮겼다.
+#[derive(Debug, Clone, Copy)]
+struct JsonWriteContext {
+    bin_data_epoch: u32,
+    options: LayerJsonOptions,
+}
+
 impl PageLayerTree {
     pub fn to_json(&self) -> String {
+        self.to_json_with_options(LayerJsonOptions::default())
+    }
+
+    /// [Task #3315] 그림 base64 생략을 켤 수 있는 직렬화. `to_json()` 은 기본 옵션 위임이다.
+    pub fn to_json_with_options(&self, options: LayerJsonOptions) -> String {
         let mut buf = String::with_capacity(32_768);
         buf.push('{');
         let _ = write!(
             buf,
-            "\"schemaVersion\":{},\"schemaMinorVersion\":{},\"schema\":{{\"major\":{},\"minor\":{}}},\"resourceTableVersion\":{},\"resourceTableMinorVersion\":{},\"resourceTable\":{{\"major\":{},\"minor\":{}}},\"unit\":{},\"coordinateSystem\":{},\"profile\":{},\"buildOptions\":{{\"showTransparentBorders\":{},\"clipEnabled\":{}}},\"debugOptions\":{{\"debugOverlay\":{}}},\"outputOptions\":{{\"showParagraphMarks\":{},\"showControlCodes\":{},\"showTransparentBorders\":{},\"clipEnabled\":{},\"debugOverlay\":{}}},\"pageWidth\":{:.3},\"pageHeight\":{:.3},\"root\":",
+            "\"schemaVersion\":{},\"schemaMinorVersion\":{},\"schema\":{{\"major\":{},\"minor\":{}}},\"resourceTableVersion\":{},\"resourceTableMinorVersion\":{},\"resourceTable\":{{\"major\":{},\"minor\":{}}},\"unit\":{},\"coordinateSystem\":{},\"profile\":{},\"imageBytes\":{},\"buildOptions\":{{\"showTransparentBorders\":{},\"clipEnabled\":{}}},\"debugOptions\":{{\"debugOverlay\":{}}},\"outputOptions\":{{\"showParagraphMarks\":{},\"showControlCodes\":{},\"showTransparentBorders\":{},\"clipEnabled\":{},\"debugOverlay\":{}}},\"pageWidth\":{:.3},\"pageHeight\":{:.3},\"root\":",
             LAYER_TREE_SCHEMA.schema_version,
             LAYER_TREE_SCHEMA.schema_minor_version,
             LAYER_TREE_SCHEMA.schema_version,
@@ -86,6 +110,13 @@ impl PageLayerTree {
             json_escape(LAYER_TREE_SCHEMA.unit),
             json_escape(LAYER_TREE_SCHEMA.coordinate_system),
             json_escape(render_profile_str(self.profile)),
+            // [#3315] 그림 바이트가 op 안에 있는지(`inline`), 키로 따로 받아야 하는지(`byKey`).
+            // 소비자가 op 마다 `base64` 유무를 추측하지 않고 문서 단위로 판정할 수 있게 한다.
+            json_escape(if options.omit_image_bytes {
+                "byKey"
+            } else {
+                "inline"
+            }),
             self.output_options.show_transparent_borders,
             self.output_options.clip_enabled,
             self.output_options.debug_overlay,
@@ -102,7 +133,10 @@ impl PageLayerTree {
             &mut buf,
             &mut text_source_state,
             &self.resources,
-            self.resources.source_image_epoch(),
+            JsonWriteContext {
+                bin_data_epoch: self.resources.source_image_epoch(),
+                options,
+            },
         );
         buf.push_str(",\"textSources\":");
         write_text_source_entries(&mut buf, &self.text_sources);
@@ -382,7 +416,7 @@ impl LayerNode {
         buf: &mut String,
         text_sources: &mut TextSourceExportState,
         resources: &ResourceArena,
-        bin_data_epoch: u32,
+        ctx: JsonWriteContext,
     ) {
         buf.push('{');
         buf.push_str("\"bounds\":");
@@ -412,7 +446,7 @@ impl LayerNode {
                     if idx > 0 {
                         buf.push(',');
                     }
-                    child.write_json(buf, text_sources, resources, bin_data_epoch);
+                    child.write_json(buf, text_sources, resources, ctx);
                 }
                 buf.push(']');
             }
@@ -429,7 +463,7 @@ impl LayerNode {
                     json_escape(clip_kind_str(*clip_kind))
                 );
                 buf.push_str(",\"child\":");
-                child.write_json(buf, text_sources, resources, bin_data_epoch);
+                child.write_json(buf, text_sources, resources, ctx);
             }
             LayerNodeKind::Leaf { ops } => {
                 buf.push_str(",\"kind\":\"leaf\",\"ops\":[");
@@ -438,7 +472,7 @@ impl LayerNode {
                     if idx > 0 {
                         buf.push(',');
                     }
-                    op.write_json(buf, text_sources, &leaf_visuals, resources, bin_data_epoch);
+                    op.write_json(buf, text_sources, &leaf_visuals, resources, ctx);
                 }
                 buf.push(']');
             }
@@ -454,7 +488,7 @@ impl PaintOp {
         text_sources: &mut TextSourceExportState,
         leaf_visuals: &LeafTextVisualOps,
         resources: &ResourceArena,
-        bin_data_epoch: u32,
+        ctx: JsonWriteContext,
     ) {
         match self {
             PaintOp::PageBackground { bbox, background } => {
@@ -834,47 +868,47 @@ impl PaintOp {
                 buf.push('{');
                 buf.push_str("\"type\":\"image\",\"bbox\":");
                 write_bbox(buf, *bbox);
+                // [#3315] 키가 있는 op 만 base64 를 생략할 수 있다 — 소비자가 그 키로
+                // `getSourceImageBytes` 를 불러 같은 바이트를 받는다. 키를 낼 수 없는 합성
+                // 그림(`bin_data_id == 0`)은 되찾을 길이 없으므로 종전대로 싣는다.
+                let source_image_key = crate::paint::source_image_key(ctx.bin_data_epoch, image);
+                let omit_bytes = ctx.options.omit_image_bytes && source_image_key.is_some();
                 if let Some(payload) = resolved.as_deref() {
-                    let _ = write!(buf, ",\"mime\":\"{}\",\"base64\":", payload.mime);
-                    write_json_base64(buf, &payload.data[..]);
+                    if omit_bytes {
+                        let _ = write!(
+                            buf,
+                            ",\"mime\":\"{}\",\"imageBytesOmitted\":true",
+                            payload.mime
+                        );
+                    } else {
+                        let _ = write!(buf, ",\"mime\":\"{}\",\"base64\":", payload.mime);
+                        write_json_base64(buf, &payload.data[..]);
+                    }
                     if matches!(payload.kind, ResolvedImageKind::BakedWatermark) {
                         buf.push_str(",\"bakedWatermark\":true");
                     }
                 } else if let Some(data) = &image.data {
                     // Task #516 Stage 5.2: overlay layer 의 <img> data URL 생성용 mime 노출.
                     // PCX 등 비표준은 PNG 변환 후 emit (CLI SVG 와 동일 정책 적용).
-                    let mime = crate::renderer::svg::detect_image_mime_type(data);
-                    let (final_mime, final_data): (&str, std::borrow::Cow<[u8]>) = if mime
-                        == "image/x-pcx"
-                    {
-                        match crate::renderer::svg::pcx_bytes_to_png_bytes(data) {
-                            Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
-                            None => (mime, std::borrow::Cow::Borrowed(&data[..])),
-                        }
-                    } else if mime == "image/bmp" {
-                        match crate::renderer::svg::bmp_bytes_to_png_bytes(data) {
-                            Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
-                            None => (mime, std::borrow::Cow::Borrowed(&data[..])),
-                        }
-                    } else if mime == "image/tiff" {
-                        match crate::renderer::image_resolver::tiff_bytes_to_png_bytes(data) {
-                            Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
-                            None => (mime, std::borrow::Cow::Borrowed(&data[..])),
-                        }
-                    } else if mime == "image/jpeg" {
-                        match crate::renderer::image_resolver::grayscale_jpeg_bytes_to_png_bytes(
+                    // [#3315] 변환 사슬의 단일 권위는 `emitted_image_bytes` 다 — 키로 바이트를
+                    // 되돌려주는 경로가 같은 함수를 써야 두 결과가 갈라지지 않는다.
+                    let (final_mime, final_data) =
+                        crate::renderer::image_resolver::emitted_image_bytes(
                             data,
-                        ) {
-                            Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
-                            None => (mime, std::borrow::Cow::Borrowed(&data[..])),
-                        }
+                            crate::renderer::image_resolver::is_watermark_image(image),
+                        );
+                    if omit_bytes {
+                        let _ = write!(
+                            buf,
+                            ",\"mime\":\"{}\",\"imageBytesOmitted\":true",
+                            final_mime
+                        );
                     } else {
-                        (mime, std::borrow::Cow::Borrowed(&data[..]))
-                    };
-                    let _ = write!(buf, ",\"mime\":\"{}\",\"base64\":", final_mime);
-                    write_json_base64(buf, &final_data);
+                        let _ = write!(buf, ",\"mime\":\"{}\",\"base64\":", final_mime);
+                        write_json_base64(buf, &final_data);
+                    }
                 }
-                if let Some(key) = crate::paint::source_image_key(bin_data_epoch, image) {
+                if let Some(key) = source_image_key {
                     let _ = write!(buf, ",\"sourceImageKey\":{}", json_escape(&key));
                 }
                 if let Some(fill_mode) = image.fill_mode {
@@ -4290,7 +4324,11 @@ mod tests {
 
         let json = tree.to_json();
 
-        assert!(json.contains("\"schemaMinorVersion\":20"));
+        // 상수에서 끌어온다 — 숫자를 박아 두면 schema minor 를 올릴 때마다 무관한 테스트가 깨진다.
+        assert!(json.contains(&format!(
+            "\"schemaMinorVersion\":{}",
+            LAYER_TREE_SCHEMA.schema_minor_version
+        )));
         assert!(json.contains("\"payloadResourceKey\":\"glyphPayload:bitmapGlyph:imageRef:0"));
         assert!(json.contains("placement:0.123,0.568,10.988,10.543"));
         assert!(json.contains(&format!(":resource:{image_resource_key}\"")));

--- a/src/paint/mod.rs
+++ b/src/paint/mod.rs
@@ -32,6 +32,7 @@ pub use font_glyph::{
     FontBitmapGlyphDecodeError, FontBitmapGlyphDecodeOptions, FontGlyphLoweringReport,
     FontSvgGlyphDecodeError, FontSvgGlyphDecodeOptions,
 };
+pub use json::LayerJsonOptions;
 pub use layer_tree::{
     CacheHint, ClipKind, GroupKind, LayerNode, LayerNodeKind, LayerOutputOptions, PageLayerTree,
     TextSourceAnnotation, TextSourceEntry, TextSourceId, TextSourceRange, TextSourceSpan,
@@ -57,9 +58,9 @@ pub use replay_order::{
     PaintReplayPlane,
 };
 pub use resources::{
-    font_blob_resource_key, image_resource_key, resource_digest_hex, source_image_key,
-    svg_resource_key, FontBlobResourceId, ImageResourceId, ResourceArena, SvgResourceId,
-    RESOURCE_KEY_ALGORITHM,
+    font_blob_resource_key, image_resource_key, parse_source_image_key, resource_digest_hex,
+    source_image_key, svg_resource_key, FontBlobResourceId, ImageResourceId, ResourceArena,
+    SourceImageVariant, SvgResourceId, RESOURCE_KEY_ALGORITHM,
 };
 pub use schema::{
     LayerTreeSchema, LAYER_TREE_SCHEMA, PAGE_LAYER_TREE_COORDINATE_SYSTEM,

--- a/src/paint/resources.rs
+++ b/src/paint/resources.rs
@@ -269,15 +269,66 @@ pub fn source_image_key(
         return None;
     }
 
+    // 술어는 `image_resolver::is_watermark_image` 가 단일 권위다 — 여기서 사본을 들면
+    // 키가 가리키는 바이트와 실제로 내보내는 바이트가 조용히 갈라진다 (#3315).
     let bakes_watermark = crate::renderer::image_resolver::detect_image_mime_type(data)
         == "image/jpeg"
-        && !matches!(image.effect, crate::model::image::ImageEffect::RealPic)
-        && (image.brightness != 0 || image.contrast != 0);
-    let variant = if bakes_watermark { "wmpng" } else { "src" };
+        && crate::renderer::image_resolver::is_watermark_image(image);
+    let variant = if bakes_watermark {
+        SourceImageVariant::BakedWatermarkPng
+    } else {
+        SourceImageVariant::Source
+    };
     Some(format!(
-        "bin:{bin_data_epoch}:{}:{variant}",
-        image.bin_data_id
+        "bin:{bin_data_epoch}:{}:{}",
+        image.bin_data_id,
+        variant.as_str()
     ))
+}
+
+/// `source_image_key` 의 variant — 같은 원본에서 다른 바이트가 나오는 갈림 (Task #3315).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceImageVariant {
+    /// 원본 바이트. 브라우저가 못 읽는 포맷(BMP/PCX/TIFF/회색 JPEG)이면 PNG 변환까지.
+    Source,
+    /// JPEG 워터마크를 한컴 규칙으로 bake 한 PNG.
+    BakedWatermarkPng,
+}
+
+impl SourceImageVariant {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SourceImageVariant::Source => "src",
+            SourceImageVariant::BakedWatermarkPng => "wmpng",
+        }
+    }
+
+    pub fn bakes_watermark(self) -> bool {
+        matches!(self, SourceImageVariant::BakedWatermarkPng)
+    }
+}
+
+/// `source_image_key` 가 만든 키를 되읽는다 (Task #3315).
+///
+/// 발급과 해석을 같은 모듈에 묶는다 — 소비자가 문자열을 직접 쪼개게 두면 접두어나 variant
+/// 를 바꿀 때 조용히 어긋난다. 모르는 variant 는 받아들이지 않는다: `src` 로 넘겨 버리면
+/// 워터마크 그림에 원본 JPEG 을 돌려주고도 성공한 것처럼 보인다.
+pub fn parse_source_image_key(key: &str) -> Option<(u32, u16, SourceImageVariant)> {
+    let mut parts = key.split(':');
+    if parts.next()? != "bin" {
+        return None;
+    }
+    let epoch = parts.next()?.parse::<u32>().ok()?;
+    let bin_data_id = parts.next()?.parse::<u16>().ok()?;
+    let variant = match parts.next()? {
+        "src" => SourceImageVariant::Source,
+        "wmpng" => SourceImageVariant::BakedWatermarkPng,
+        _ => return None,
+    };
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((epoch, bin_data_id, variant))
 }
 
 pub fn svg_resource_key(byte_len: usize, digest: &str) -> String {

--- a/src/paint/schema.rs
+++ b/src/paint/schema.rs
@@ -15,7 +15,9 @@ pub struct LayerTreeSchema {
 
 pub const LAYER_TREE_SCHEMA: LayerTreeSchema = LayerTreeSchema {
     schema_version: 1,
-    schema_minor_version: 20,
+    // 21: [#3315] 문서 단위 `imageBytes`("inline"|"byKey")와 그림 op 의 `imageBytesOmitted`.
+    //     생략은 opt-in 이라 기존 소비자가 받는 JSON 은 종전과 같다.
+    schema_minor_version: 21,
     resource_table_version: 1,
     resource_table_minor_version: 5,
     unit: "px",

--- a/src/renderer/image_resolver.rs
+++ b/src/renderer/image_resolver.rs
@@ -167,6 +167,37 @@ pub(crate) fn resolve_image_payload(image: &ImageNode) -> Option<ResolvedImagePa
     }
 }
 
+/// 그림 op 이 실제로 내보내는 바이트와 mime 을 결정한다 (Task #3315).
+///
+/// `resolve_image_payload` 는 변환에 **성공한** 경우만 payload 를 주고, 실패하면 `None` 이라
+/// 호출부가 원본 바이트로 되돌아간다. 그래서 "JSON 에 실린 바이트"는 두 분기의 합이었고,
+/// `paint/json.rs` 가 그 되돌림 사슬을 사본으로 들고 있었다. base64 를 생략한 뒤 키로 같은
+/// 바이트를 되돌려주려면 **최종 결과가 한 곳에서만 정해져야** 한다 — 두 곳에 두면 갈라진다.
+///
+/// `bakes_watermark` 는 `paint::source_image_key` 의 variant 판정과 같은 값이다. 키가 이미
+/// variant 를 담고 있으므로 키로 조회할 때는 `ImageNode` 없이도 같은 바이트를 재현한다.
+/// 워터마크 bake 가 실패하면 회색 JPEG 경로로 내려가는데, 이는 `resolved == None` 일 때
+/// json 쪽 되돌림이 하던 것과 같은 순서다.
+pub(crate) fn emitted_image_bytes(
+    data: &[u8],
+    bakes_watermark: bool,
+) -> (&'static str, std::borrow::Cow<'_, [u8]>) {
+    let mime = detect_image_mime_type(data);
+    let converted = match mime {
+        "image/bmp" => bmp_bytes_to_png_bytes(data),
+        "image/x-pcx" => pcx_bytes_to_png_bytes(data),
+        "image/tiff" => tiff_bytes_to_png_bytes(data),
+        "image/jpeg" if bakes_watermark => watermark_jpeg_bytes_to_hancom_baked_png_bytes(data)
+            .or_else(|| grayscale_jpeg_bytes_to_png_bytes(data)),
+        "image/jpeg" => grayscale_jpeg_bytes_to_png_bytes(data),
+        _ => None,
+    };
+    match converted {
+        Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
+        None => (mime, std::borrow::Cow::Borrowed(data)),
+    }
+}
+
 pub(crate) fn image_node_with_resolved_payload(
     image: &ImageNode,
     resolved: Option<&ResolvedImagePayload>,
@@ -183,7 +214,11 @@ pub(crate) fn image_node_with_resolved_payload(
     image
 }
 
-fn is_watermark_image(image: &ImageNode) -> bool {
+/// 워터마크 bake 대상 판정. `paint::source_image_key` 의 variant 결정과 같은 술어를 써야
+/// 키가 가리키는 바이트와 실제로 내보내는 바이트가 어긋나지 않는다 (Task #3315).
+///
+/// mime 검사는 포함하지 않는다 — 호출부가 JPEG 분기 안에서 쓴다.
+pub(crate) fn is_watermark_image(image: &ImageNode) -> bool {
     !matches!(image.effect, ImageEffect::RealPic) && (image.brightness != 0 || image.contrast != 0)
 }
 

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -181,11 +181,16 @@ fn get_page_layer_tree_with_profile_impl(
     document: &HwpDocument,
     page_num: u32,
     profile: &str,
+    omit_image_bytes: bool,
 ) -> Result<String, JsValue> {
     let profile = crate::paint::RenderProfile::parse(profile)
         .ok_or_else(|| JsValue::from_str(&format!("unsupported render profile: {profile}")))?;
     document
-        .get_page_layer_tree_with_profile_native(page_num, profile)
+        .get_page_layer_tree_with_options_native(
+            page_num,
+            profile,
+            crate::paint::LayerJsonOptions { omit_image_bytes },
+        )
         .map_err(|error| error.into())
 }
 
@@ -713,19 +718,26 @@ impl HwpDocument {
             .map_err(|e| e.into())
     }
 
+    /// 페이지 레이어 트리를 profile 별로 반환한다.
+    ///
+    /// [Task #3315] `omit_image_bytes` 를 `true` 로 주면 그림 base64 를 싣지 않고
+    /// `sourceImageKey` 만 남긴다 — 바이트는 `getSourceImageBytes(key)` 로 따로 받는다.
+    /// 인자를 생략하면(`undefined`) 종전과 똑같은 JSON 이므로 기존 호출부는 영향이 없다.
     #[wasm_bindgen(js_name = getPageLayerTreeWithProfile)]
     pub fn get_page_layer_tree_with_profile(
         &self,
         page_num: u32,
         profile: &str,
+        omit_image_bytes: Option<bool>,
     ) -> Result<String, JsValue> {
+        let omit_image_bytes = omit_image_bytes.unwrap_or(false);
         #[cfg(feature = "subsecond-dev")]
         {
             let mut hot = subsecond::HotFn::current(get_page_layer_tree_with_profile_impl);
-            return hot.call((self, page_num, profile));
+            return hot.call((self, page_num, profile, omit_image_bytes));
         }
         #[cfg(not(feature = "subsecond-dev"))]
-        get_page_layer_tree_with_profile_impl(self, page_num, profile)
+        get_page_layer_tree_with_profile_impl(self, page_num, profile, omit_image_bytes)
     }
 
     #[cfg(all(feature = "subsecond-dev", target_arch = "wasm32"))]
@@ -798,6 +810,24 @@ impl HwpDocument {
     pub fn get_page_source_image_keys(&self, page_num: u32) -> Result<String, JsValue> {
         self.get_page_source_image_keys_native(page_num)
             .map_err(|e| e.into())
+    }
+
+    /// 그림 신원 키로 바이트를 Uint8Array 로 반환한다 (Task #3315).
+    ///
+    /// `getPageLayerTreeWithProfile(page, profile, true)` 로 base64 를 생략했을 때 바이트를
+    /// 받는 경로다. mime 은 레이어 트리의 그림 op 이 계속 싣고 있으므로 여기서 되풀이하지
+    /// 않는다.
+    ///
+    /// 키를 풀 수 없으면 던진다 — 세대가 바뀐 낡은 키이거나 없는 그림이다. 호출부는 잡아서
+    /// 레이어 트리를 다시 받는 쪽으로 되돌아가면 된다.
+    #[wasm_bindgen(js_name = getSourceImageBytes)]
+    pub fn get_source_image_bytes(&self, key: &str) -> Result<Vec<u8>, JsValue> {
+        match self.get_source_image_bytes_native(key) {
+            Some((_mime, bytes)) => Ok(bytes),
+            None => Err(JsValue::from_str(&format!(
+                "unresolvable source image key: {key}"
+            ))),
+        }
     }
 
     /// 페이지 정보를 JSON 문자열로 반환한다.

--- a/tests/issue_3315_image_bytes_by_key.rs
+++ b/tests/issue_3315_image_bytes_by_key.rs
@@ -1,0 +1,288 @@
+//! Task #3315: 그림 바이트를 레이어 트리 JSON 에서 빼고 신원 키로 따로 받는다.
+//!
+//! 이 옵션이 성립하려면 **생략본 + 키 조회가 인라인 base64 와 같은 것을 말해야** 한다.
+//! 바이트가 한 바이트라도 다르면 소비자는 같은 그림을 다르게 그린다. 그래서 여기서 고정하는
+//! 것은 크기 이득이 아니라 등가성이다 — 크기는 그 등가성이 성립한 뒤의 부산물이다.
+//!
+//! 변환 사슬(BMP/PCX/TIFF/회색 JPEG → PNG, JPEG 워터마크 bake)이 JSON 경로와 키 조회 경로에
+//! 각각 사본으로 존재하면 이 등가성이 조용히 깨진다. 두 경로가 같은 함수를 쓰는지 확인하는
+//! 자리도 이 테스트다.
+
+use base64::Engine;
+use serde_json::Value;
+
+use rhwp::paint::{parse_source_image_key, LayerJsonOptions, SourceImageVariant};
+
+/// 그림 op 을 등장 순서대로 모은다. 인라인본과 생략본을 짝지어 비교하려면 순서가 같아야 한다.
+fn collect_image_ops(node: &Value, out: &mut Vec<Value>) {
+    if let Some(ops) = node.get("ops").and_then(Value::as_array) {
+        for op in ops {
+            if op.get("type").and_then(Value::as_str) == Some("image") {
+                out.push(op.clone());
+            }
+        }
+    }
+    if let Some(children) = node.get("children").and_then(Value::as_array) {
+        for child in children {
+            collect_image_ops(child, out);
+        }
+    }
+    // clipRect 노드는 단일 `child` 를 갖는다.
+    if let Some(child) = node.get("child") {
+        collect_image_ops(child, out);
+    }
+}
+
+fn image_ops(json: &str) -> Vec<Value> {
+    let value: Value = serde_json::from_str(json).expect("레이어 JSON 이 유효해야 한다");
+    let mut ops = Vec::new();
+    collect_image_ops(&value["root"], &mut ops);
+    ops
+}
+
+fn open_sample() -> rhwp::wasm_api::HwpDocument {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let bytes = std::fs::read(std::path::Path::new(repo_root).join("samples/hwpx/issue_241.hwpx"))
+        .expect("read samples/hwpx/issue_241.hwpx");
+    rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse issue_241.hwpx")
+}
+
+fn inline_json(doc: &rhwp::wasm_api::HwpDocument) -> String {
+    doc.get_page_layer_tree_native(0)
+        .expect("inline layer tree")
+}
+
+fn omitted_json(doc: &rhwp::wasm_api::HwpDocument) -> String {
+    doc.get_page_layer_tree_with_options_native(
+        0,
+        rhwp::paint::RenderProfile::Screen,
+        LayerJsonOptions {
+            omit_image_bytes: true,
+        },
+    )
+    .expect("omitted layer tree")
+}
+
+#[test]
+fn issue_3315_omitted_bytes_are_recoverable_by_key() {
+    let doc = open_sample();
+    let inline_ops = image_ops(&inline_json(&doc));
+    let omitted_ops = image_ops(&omitted_json(&doc));
+
+    assert!(!inline_ops.is_empty(), "도장 그림이 있어야 한다");
+    assert_eq!(
+        inline_ops.len(),
+        omitted_ops.len(),
+        "생략은 op 을 지우는 게 아니라 payload 만 뺀다"
+    );
+
+    for (inline_op, omitted_op) in inline_ops.iter().zip(&omitted_ops) {
+        let encoded = inline_op["base64"]
+            .as_str()
+            .expect("인라인본에는 base64 가 있어야 한다");
+        let expected = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .expect("인라인 base64 왕복");
+
+        let key = omitted_op["sourceImageKey"]
+            .as_str()
+            .expect("생략된 op 에는 키가 있어야 한다");
+        let (mime, actual) = doc
+            .get_source_image_bytes_native(key)
+            .expect("키로 바이트를 받을 수 있어야 한다");
+
+        assert_eq!(
+            actual, expected,
+            "키로 받은 바이트가 인라인 base64 와 달라졌다 (key={key})"
+        );
+        assert_eq!(
+            Some(mime),
+            inline_op["mime"].as_str(),
+            "키 조회의 mime 이 JSON 의 mime 과 달라졌다 (key={key})"
+        );
+    }
+}
+
+#[test]
+fn issue_3315_omitted_ops_keep_mime_and_declare_omission() {
+    let doc = open_sample();
+    let omitted = omitted_json(&doc);
+    let ops = image_ops(&omitted);
+
+    assert!(
+        omitted.contains("\"imageBytes\":\"byKey\""),
+        "문서 단위로 생략본임을 알려야 한다"
+    );
+    for op in &ops {
+        assert!(
+            op.get("base64").is_none(),
+            "생략본에 base64 가 남아 있다: {op}"
+        );
+        assert_eq!(
+            op["imageBytesOmitted"].as_bool(),
+            Some(true),
+            "op 마다 생략을 명시해야 한다 — 소비자가 부재를 추측하게 두지 않는다"
+        );
+        assert!(
+            op.get("mime").and_then(Value::as_str).is_some(),
+            "mime 은 남는다 — 소비자가 Blob 타입을 정하는 데 쓴다"
+        );
+        // bbox·effect 같은 배치 정보는 생략과 무관하게 그대로다.
+        assert!(op.get("bbox").is_some(), "bbox 가 사라졌다: {op}");
+    }
+}
+
+#[test]
+fn issue_3315_default_serialization_is_byte_identical() {
+    let doc = open_sample();
+    let inline = inline_json(&doc);
+
+    assert!(
+        inline.contains("\"imageBytes\":\"inline\""),
+        "기본값은 인라인이다"
+    );
+    assert!(
+        !inline.contains("\"imageBytesOmitted\""),
+        "기본 경로에는 생략 표식이 없어야 한다"
+    );
+    for op in image_ops(&inline) {
+        assert!(
+            op.get("base64").is_some(),
+            "옵션을 켜지 않은 호출은 종전대로 바이트를 싣는다"
+        );
+    }
+}
+
+/// 크기 이득은 이 트랙의 대상 시나리오 — **본문에 인라인된 대형 JPEG** — 에서만 의미가 있다.
+///
+/// 도장처럼 작은 그림만 있는 문서에서는 JSON 이 텍스트·글리프로 지배되므로 생략해도 몇 %만
+/// 줄어든다(실측 248KB → 233KB). 그 숫자로 이 옵션을 정당화하면 안 되므로, 여기서는 #2520 이
+/// 문제로 지목한 크기의 그림을 실제로 넣고 잰다.
+#[test]
+fn issue_3315_omitting_bytes_shrinks_the_payload_for_large_images() {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let jpeg = std::fs::read(std::path::Path::new(repo_root).join("samples/images/tiger01.jpg"))
+        .expect("read tiger01.jpg");
+    let mut doc = open_sample();
+    doc.insert_picture_native(
+        0,
+        0,
+        0,
+        &[],
+        &jpeg,
+        400,
+        300,
+        2400,
+        1800,
+        "jpg",
+        "tiger",
+        None,
+        None,
+    )
+    .expect("insert picture");
+
+    let inline = inline_json(&doc);
+    let omitted = omitted_json(&doc);
+
+    // 생략본에는 그림 바이트가 없으므로 원본 크기에 비례하지 않는다.
+    assert!(
+        omitted.len() * 4 < inline.len(),
+        "생략본이 충분히 작지 않다 (원본 그림 {} bytes, inline={} bytes, omitted={} bytes)",
+        jpeg.len(),
+        inline.len(),
+        omitted.len()
+    );
+    println!(
+        "[#3315] 원본 그림 {} bytes / inline JSON {} bytes / 생략 JSON {} bytes ({:.1}배 축소)",
+        jpeg.len(),
+        inline.len(),
+        omitted.len(),
+        inline.len() as f64 / omitted.len() as f64
+    );
+
+    // 크기가 줄었어도 바이트를 되찾을 수 있어야 의미가 있다.
+    for op in image_ops(&omitted) {
+        let key = op["sourceImageKey"].as_str().expect("키");
+        assert!(
+            doc.get_source_image_bytes_native(key).is_some(),
+            "생략했는데 키로 되찾을 수 없다 (key={key})"
+        );
+    }
+}
+
+#[test]
+fn issue_3315_inline_and_omitted_are_separate_cache_variants() {
+    let doc = open_sample();
+
+    // 같은 페이지를 번갈아 물어본다. 두 모양이 캐시 슬롯을 공유하면 뒤의 호출이 앞의 모양을
+    // 돌려받는다 — #2222 JSON 캐시가 지문에 생략 여부를 접지 않으면 나는 결함이다.
+    let first_inline = inline_json(&doc);
+    let omitted = omitted_json(&doc);
+    let second_inline = inline_json(&doc);
+    let second_omitted = omitted_json(&doc);
+
+    assert_eq!(first_inline, second_inline, "인라인본이 캐시에서 오염됐다");
+    assert_eq!(omitted, second_omitted, "생략본이 캐시에서 오염됐다");
+    assert_ne!(first_inline, omitted, "두 모양이 같을 수 없다");
+}
+
+#[test]
+fn issue_3315_unresolvable_keys_are_refused() {
+    let doc = open_sample();
+    let key = image_ops(&omitted_json(&doc))[0]["sourceImageKey"]
+        .as_str()
+        .expect("키")
+        .to_string();
+    let (epoch, bin_data_id, _variant) = parse_source_image_key(&key).expect("키 해석");
+
+    // 세대가 다른 키 — 스냅샷 복원 뒤에 옛 키로 물어본 경우. 낡은 바이트를 주면 안 된다.
+    let stale = format!("bin:{}:{bin_data_id}:src", epoch.wrapping_add(1));
+    assert!(
+        doc.get_source_image_bytes_native(&stale).is_none(),
+        "세대가 다른 키를 받아들였다"
+    );
+
+    // 없는 그림.
+    assert!(
+        doc.get_source_image_bytes_native(&format!("bin:{epoch}:60000:src"))
+            .is_none(),
+        "없는 bin_data_id 를 받아들였다"
+    );
+
+    for malformed in [
+        "",
+        "bin",
+        "bin:0:1",
+        "bin:0:1:src:extra",
+        "img:0:1:src",
+        "bin:x:1:src",
+        // 모르는 variant 를 src 로 흘리면 워터마크 그림에 원본 JPEG 을 주고도 성공해 보인다.
+        "bin:0:1:png",
+    ] {
+        assert!(
+            parse_source_image_key(malformed).is_none(),
+            "형식이 틀린 키를 받아들였다: {malformed:?}"
+        );
+        assert!(
+            doc.get_source_image_bytes_native(malformed).is_none(),
+            "형식이 틀린 키로 바이트를 돌려줬다: {malformed:?}"
+        );
+    }
+}
+
+#[test]
+fn issue_3315_key_round_trips_through_parser() {
+    for (epoch, id, variant) in [
+        (0u32, 1u16, SourceImageVariant::Source),
+        (7, 60001, SourceImageVariant::BakedWatermarkPng),
+    ] {
+        let key = format!("bin:{epoch}:{id}:{}", variant.as_str());
+        assert_eq!(
+            parse_source_image_key(&key),
+            Some((epoch, id, variant)),
+            "발급 포맷과 해석이 어긋난다: {key}"
+        );
+    }
+    assert!(!SourceImageVariant::Source.bakes_watermark());
+    assert!(SourceImageVariant::BakedWatermarkPng.bakes_watermark());
+}


### PR DESCRIPTION
## 변경 요약

편집마다 그림 바이트를 base64 로 레이어 트리 JSON 에 인라인하던 것을 **opt-in 으로 끊습니다**. 생략본은 `sourceImageKey` 만 남기고, 소비자는 `getSourceImageBytes(key)` 로 같은 바이트를 받습니다.

```rust
getPageLayerTreeWithProfile(page, profile, omitImageBytes?)  // 인자 생략 시 base64 인라인 유지
getSourceImageBytes(key) -> Uint8Array
```

### 실측 (`release-test`, 4.77MB JPEG 1장 삽입 문서)

| 항목 | 인라인 | 생략 |
|---|---|---|
| 레이어 트리 JSON | 6,615,523 bytes | **233,120 bytes (28.4배 축소)** |
| Rust 직렬화 (20회 평균) | 10.98 ms | **7.67 ms** |
| 키 → 바이트 조회 | — | 0.01 ms (변환 메모 히트) |

인라인 6.6MB 는 #3315 본문에 기록해 둔 "편집마다 6.6MB JSON" 과 같은 값입니다.

### Rust 쪽 이득은 3.3 ms 뿐입니다

숫자를 부풀리지 않으려고 적습니다. #3452 가 base64 를 이스케이프 스캔 없이 버퍼로 직접 쓰게 만든 뒤라 인코딩은 이미 싸졌고, 남은 7.67 ms 는 텍스트·글리프 직렬화입니다.

이 변경의 실제 대상은 **JS 쪽 경계 복사(13.9 ms)와 `JSON.parse`(6.9 ms)** 이며, 그건 소비자 전환(#3315 의 별도 체크박스) 뒤에 실현됩니다. 위 28.4배 축소가 그 이득의 크기를 미리 보여주는 값입니다. 이 PR 은 그 전환이 올라탈 계약만 놓습니다.

## 등가성이 전제라 변환 사슬을 한 곳으로 모았습니다

생략본 + 키 조회가 인라인 base64 와 **같은 바이트**를 말하지 않으면 소비자는 같은 그림을 다르게 그립니다. 그런데 변환 사슬(BMP/PCX/TIFF/회색 JPEG → PNG, JPEG 워터마크 bake)은 두 갈래로 갈라져 있었습니다.

- `resolve_image_payload` 는 변환에 **성공한** 경우만 payload 를 주고, 실패하면 `None` 이라 호출부가 원본으로 되돌아갑니다.
- 그 되돌림 사슬을 `paint/json.rs` 가 사본으로 들고 있었습니다.

즉 "JSON 에 실린 바이트"는 두 분기의 합이었습니다. 키 조회 경로가 세 번째 사본을 들면 언제 갈라질지 모릅니다. 그래서:

- `image_resolver::emitted_image_bytes(data, bakes_watermark)` 신설 — 되돌림까지 포함한 **최종 결과**의 단일 권위. `paint/json.rs` 의 사본을 지웠습니다.
- 워터마크 판정도 `is_watermark_image` 하나로 합쳤습니다 — `paint/resources.rs` 가 같은 술어를 사본으로 갖고 있었고, 그게 갈라지면 **키 variant 와 실제로 내보내는 바이트가 어긋납니다**.

`wmpng` bake 가 원본 바이트만의 함수라는 점이 이 설계의 근거입니다(`watermark_jpeg_bytes_to_hancom_baked_png_bytes(data)`). 밝기·대비는 bake 여부만 가르고 결과 바이트에는 들어가지 않으므로, 키의 variant 만으로 `ImageNode` 없이 같은 바이트를 재현할 수 있습니다.

## 경계 조건

- **키가 없는 그림은 생략하지 않습니다.** `bin_data_id == 0` 인 합성 그림은 바이트를 되찾을 길이 없으므로 종전대로 base64 를 싣습니다.
- **`mime` 은 생략본에도 남깁니다.** 변환된 mime 을 알려면 변환을 거쳐야 해서 그만큼은 계속 내지만, 빼면 소비자가 Blob 타입을 못 정하거나 API 를 하나 더 만들어야 합니다. 정확성을 택했습니다.
- **캐시 변형 분리.** 생략 여부를 #2222 JSON 캐시 지문의 최상위 비트로 접었습니다. 같은 슬롯을 쓰면 한쪽 소비자가 다른 쪽 모양을 받습니다 — 인라인↔생략을 번갈아 호출하는 회귀 테스트로 고정했습니다.
- **세대가 다른 키는 거부합니다.** 스냅샷 복원 뒤 옛 키로 물어보면 `None` 입니다. 낡은 바이트를 주는 대신 소비자가 트리를 다시 받게 합니다.
- **모르는 variant 도 거부합니다.** `src` 로 흘려보내면 워터마크 그림에 원본 JPEG 을 주고도 성공한 것처럼 보입니다.

## 기본 payload 동작 유지

`omit_image_bytes` 는 `Option<bool>` 이라 인자를 생략한 기존 호출부는 종전처럼 base64 인라인 payload를 받습니다. 다만 schema minor 21과 `imageBytes:"inline"` 메타데이터가 추가되므로 JSON 문자열 자체는 이전 버전과 byte-identical하지 않습니다. 생성된 바인딩에서 optional 인자 계약을 확인했습니다.

```js
// pkg/rhwp.js
getPageLayerTreeWithProfile(page_num, profile, omit_image_bytes) {
  ... isLikeNone(omit_image_bytes) ? 0xFFFFFF : omit_image_bytes ? 1 : 0
```

```ts
// pkg/rhwp.d.ts
getPageLayerTreeWithProfile(page_num: number, profile: string, omit_image_bytes?: boolean | null): string;
getSourceImageBytes(key: string): Uint8Array;
```

studio 는 이 PR 에서 손대지 않았습니다(전환은 #3315 의 별도 체크박스). 추가된 필드가 additive 라 기존 `getPageLayerTreeObject` 검증도 그대로 통과합니다.

schema minor 를 20 → 21 로 올렸습니다 — 문서 단위 `imageBytes`(`"inline"`|`"byKey"`)와 그림 op 의 `imageBytesOmitted`.

## 관련 이슈

#3315 Track 2 — **umbrella 이슈라 closing keyword 를 쓰지 않습니다.** PR #3465 merge 때 자동화가 closing keyword 로 판정해 #3315 을 종료했고 collaborator 가 다시 열어야 했습니다(해당 이슈 2026-07-27 코멘트). 같은 일을 만들지 않으려고 참조만 둡니다.

선행 조각: #3411(공유 바이트), #3452(base64 직접 인코딩), #3455(신원 키) — 모두 devel 에 반영된 상태를 전제로 합니다.

## 테스트

- [x] `cargo test --profile release-test --tests` 통과 — **0 failed** (lib 3030 + 통합 전량)
- [x] `cargo clippy --all-targets -- -D warnings` 통과
- [x] `cargo fmt --check` 통과
- [x] Native Skia 3종 통과 — `skia --lib` 58, `issue_2225_missing_picture_placeholder` 2, `render_p37_direct_pdf_export` 4
- [x] `wasm-pack build --target web --out-dir pkg` 성공 + 생성 바인딩 확인
- [x] rhwp-studio `npx tsc --noEmit` 통과, `npm test` **685/685**
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음(JSON 직렬화 경로 전용, SVG 생산자 미변경)
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음(studio 소비자 전환은 이 PR 범위 밖, 기본 경로는 base64 인라인 payload를 유지하고 schema metadata만 additive)

신규 테스트 `tests/issue_3315_image_bytes_by_key.rs` 7건은 현재 fixture의 인라인↔키 조회 등가성과 API 계약을 고정합니다. 변환 포맷별 등가성 확대는 cleanup draft에서 추적합니다.

| 테스트 | 고정하는 성질 |
|---|---|
| `omitted_bytes_are_recoverable_by_key` | 생략본의 키로 받은 바이트·mime 이 인라인 base64 와 같다 |
| `omitted_ops_keep_mime_and_declare_omission` | `base64` 부재 + `imageBytesOmitted:true` + `mime`·`bbox` 보존 |
| `default_serialization_is_byte_identical` | 옵션을 안 켠 호출은 base64 인라인을 유지한다. 전체 JSON byte identity는 검증하지 않는다 |
| `omitting_bytes_shrinks_the_payload_for_large_images` | 대형 JPEG 에서 4배 이상 축소 (+ 축소 후에도 되찾기 가능) |
| `inline_and_omitted_are_separate_cache_variants` | 번갈아 호출해도 캐시 오염 없음 |
| `unresolvable_keys_are_refused` | 낡은 세대·없는 그림·형식 오류·모르는 variant 거부 |
| `key_round_trips_through_parser` | 발급 포맷과 해석이 어긋나지 않음 |

크기 단언을 큰 그림으로 옮긴 이유를 테스트 주석에 남겼습니다 — 도장처럼 작은 그림만 있는 문서에서는 JSON 이 텍스트·글리프로 지배돼 생략해도 248KB → 233KB(6%)뿐입니다. 그 숫자로 이 옵션을 정당화하면 안 되므로 #2520 이 문제로 지목한 크기의 그림으로 잽니다.

무관한 테스트가 schema minor 를 박아 두고 있던 것도 상수 참조로 바꿨습니다(`paint/json.rs` 의 `schemaMinorVersion:20` 하드코딩) — 다음 minor bump 때 또 깨지지 않게.


