### PR TITLE
fix(layout): 분할 표 조각의 vpos 원점 오류로 본문이 쪽 밖에 그려지던 결함 — 8문서 2,005자 회수

### DIFF
--- a/src/renderer/layout/table_partial.rs
+++ b/src/renderer/layout/table_partial.rs
@@ -397,6 +397,31 @@ impl LayoutEngine {
             };
             let line_ranges: Option<Vec<(usize, usize)>> = cut_units
                 .map(|(su, eu)| self.cell_line_ranges_from_cut(cell, table, styles, su, eu));
+            // [#3637] 이 조각이 시작하는 vpos.
+            //
+            // `LINE_SEG.vertical_pos` 는 **셀 시작** 기준 누적값이다. 연속 조각에서 그
+            // 절대값을 이 쪽의 `text_y_start` 에 그대로 더하면, 앞 쪽으로 넘어간 부분의
+            // 높이만큼 통째로 아래로 밀린다(아래 표-직후 스냅).
+            //
+            // 원점은 `cut_units` 가 정한 **가시 범위의 첫 줄**에서 가져와야 한다. "루프에서
+            // 처음 만나는 문단" 으로는 얻을 수 없다 — 빈 문단도 `line_segs` 가 1개라
+            // 스킵되지 않아 `p[0]`(vpos≈0)이 잡히고 보정이 0 이 된다(실제로 겪은 무효 수정).
+            let fragment_start_vpos: i32 = line_ranges
+                .as_ref()
+                .and_then(|ranges| {
+                    ranges
+                        .iter()
+                        .enumerate()
+                        .find(|(_, (s, e))| s < e)
+                        .and_then(|(pi, (s, _))| {
+                            cell.paragraphs
+                                .get(pi)?
+                                .line_segs
+                                .get(*s)
+                                .map(|seg| seg.vertical_pos.max(0))
+                        })
+                })
+                .unwrap_or(0);
             // [Task #1073] 이 셀이 per-중첩행 분해 대상(단일 문단 + 가시 텍스트 없음 + 단일
             // 중첩 표 2행+)이면 cut 유닛 인덱스가 곧 중첩행 범위 → 렌더 NestedTableSplit 에
             // start_row 로 전달(연속 페이지가 중첩행 0부터 재렌더되는 결함 정정).
@@ -1369,12 +1394,23 @@ impl LayoutEngine {
 
                 if has_table_ctrl && mixed_nested_split.is_none() {
                     // LINE_SEG vpos 기반으로 para_y 보정.
+                    //
+                    // [#3637] 원점은 이 **조각**의 시작 vpos 다 (셀 시작이 아니라).
+                    //
+                    // 실측 (무학대선 보도자료 2쪽, 조각 시작 vpos=7160=95.5px):
+                    //   보정 전  p[19] → 583.1,  p[27] → 977.2   (= text_y_start + 절대 vpos)
+                    //   보정 후  p[19] → 487.6,  p[27] → 881.7
+                    // 두 곳 모두 오차가 정확히 95.5px 였고, 그만큼 표 직후에 빈 공간이
+                    // 생겨 뒤 내용이 쪽 밖으로 밀려 어느 렌더 경로에서도 보이지 않았다.
                     let is_last_para = cp_idx + 1 == composed_paras.len();
                     if !is_last_para {
                         if let Some(next_para) = cell.paragraphs.get(cp_idx + 1) {
                             if let Some(next_seg) = next_para.line_segs.first() {
-                                let next_vpos_y =
-                                    text_y_start + hwpunit_to_px(next_seg.vertical_pos, self.dpi);
+                                let next_vpos_y = text_y_start
+                                    + hwpunit_to_px(
+                                        (next_seg.vertical_pos - fragment_start_vpos).max(0),
+                                        self.dpi,
+                                    );
                                 para_y = para_y.max(next_vpos_y);
                             }
                         }

--- a/tests/issue_3637_split_table_fragment_vpos.rs
+++ b/tests/issue_3637_split_table_fragment_vpos.rs
@@ -1,0 +1,132 @@
+//! Issue #3637: 분할 표 조각에서 표-직후 vpos 스냅이 셀 원점을 써서 내용이 쪽 밖으로 밀린다.
+//!
+//! ## 근인
+//!
+//! `LINE_SEG.vertical_pos` 는 **셀 시작** 기준 누적값이다. `table_partial.rs` 의 표-직후
+//! 보정은 그 절대값을 **이 쪽의** `text_y_start` 에 그대로 더했다.
+//!
+//! ```text
+//! let next_vpos_y = text_y_start + hwpunit_to_px(next_seg.vertical_pos, dpi);
+//! para_y = para_y.max(next_vpos_y);
+//! ```
+//!
+//! 표가 쪽을 넘나들며 잘린 **연속 조각**에서는 원점이 어긋난다 — 앞 쪽으로 넘어간
+//! 부분의 높이만큼 통째로 아래로 밀린다.
+//!
+//! 실측 (이 표본 2쪽, 조각 시작 vpos = 7160 HU = 95.5px):
+//!
+//! | 위치 | 수정 전 | 수정 후 |
+//! |---|---|---|
+//! | `p[19]` 뒤 | 583.1 | 487.7 |
+//! | `p[27]` 뒤 | 977.2 | 881.7 |
+//!
+//! 두 곳 모두 오차가 정확히 95.5px 였다. 그만큼 표 직후에 빈 공간이 생기고, 뒤 내용이
+//! 쪽 경계를 넘어가 **어느 렌더 경로에서도 보이지 않았다**.
+//!
+//! 넘어간 글자는 `export-text` 에도 SVG `<text>` 요소에도 남아 있어 텍스트 diff 나
+//! IR diff 로는 잡히지 않는다. 좌표만 쪽 밖일 뿐이다.
+//!
+//! ## 계약
+//!
+//! 분할 표 조각 안에서도 글자가 쪽 높이 안에 그려진다.
+//!
+//! 이 표본은 완전 해소가 아니다. 그래서 "0" 이 아니라 **회귀 상한**으로 고정한다.
+//!
+//! ```text
+//! 수정 전  762자  (2쪽 352 · 3쪽 116 · 4쪽 294)
+//! 수정 후  239자  (2쪽 239, 3·4쪽 완전 해소)
+//! ```
+//!
+//! 잔존 239자는 흐름이 저장 사다리보다 촘촘한 **별개 축**이다 — 이 수정 범위 밖이다.
+#![cfg(not(target_arch = "wasm32"))]
+
+/// 재현 문서 — 본문 전체가 1×1 표 안에 있고 그 표가 쪽 2~4 로 잘리는 보도자료.
+///
+/// **저장소에 넣지 않는다.** `samples/` 아래 `.hwp` 는 `ir_field_sweep_baseline` 이
+/// 전수 스윕하므로(`HWP5_ROOT = "samples"`), 파일 추가만으로 그 게이트가 깨진다.
+/// 기준선을 재생성하면 이 PR 과 무관한 항목까지 끌어들여 진짜 회귀를 가린다.
+/// (`samples/issueNNNN/` 배치는 `.hwpx` 만 보호한다 — `HWPX_ROOT` 가 `samples/hwpx` 로
+/// 좁기 때문이다.)
+///
+/// 코퍼스에 문서가 있으면 검증하고, 없으면 건너뛴다.
+const CORPUS_DOC: &str =
+    r"C:\Users\planet\hwpdocs\korea_policy_downloads\148738070_20120829_무학대선건 보도자료.hwp";
+
+/// 재현 문서 경로를 환경변수로 덮어쓸 수 있다.
+const CORPUS_ENV: &str = "RHWP_ISSUE3637_DOC";
+
+/// 수정 후 실측 239자, 수정을 되돌리면 762자.
+///
+/// 상한은 그 사이(400)로 잡는다 — 0 으로 두면 잔존 별개 축 때문에 늘 실패하고,
+/// 762 이상으로 두면 이 수정이 되돌려져도 통과해 회귀를 못 잡는다.
+const MAX_OUT_OF_PAGE_GLYPHS: usize = 400;
+
+/// 재현 문서 경로 (없으면 `None` → 테스트 건너뜀).
+fn corpus_doc() -> Option<std::path::PathBuf> {
+    let p = std::env::var(CORPUS_ENV)
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::path::PathBuf::from(CORPUS_DOC));
+    p.exists().then_some(p)
+}
+
+/// SVG 한 쪽에서 쪽 높이를 넘는 `<text>` 개수를 센다.
+fn out_of_page_glyphs(svg: &str) -> (f64, usize) {
+    let height = svg
+        .split("height=\"")
+        .nth(1)
+        .and_then(|s| s.split('"').next())
+        .and_then(|s| s.parse::<f64>().ok())
+        .unwrap_or(0.0);
+    let mut over = 0usize;
+    for chunk in svg.split("<text").skip(1) {
+        let Some(rest) = chunk.split(" y=\"").nth(1) else {
+            continue;
+        };
+        let Some(y) = rest.split('"').next().and_then(|s| s.parse::<f64>().ok()) else {
+            continue;
+        };
+        // 여유 2px — baseline 이 경계에 걸친 글리프는 결함으로 세지 않는다.
+        if y > height + 2.0 {
+            over += 1;
+        }
+    }
+    (height, over)
+}
+
+/// 분할 표 조각의 내용이 쪽 밖으로 대량 밀려나지 않는다.
+#[test]
+fn split_table_fragment_keeps_content_inside_page() {
+    let Some(path) = corpus_doc() else {
+        eprintln!(
+            "건너뜀: 재현 문서가 없다. 코퍼스가 있으면 {CORPUS_ENV} 로 경로를 지정하라.\n  {CORPUS_DOC}"
+        );
+        return;
+    };
+    let bytes = std::fs::read(&path).expect("재현 문서 읽기");
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("파싱");
+    let page_count = doc.page_count();
+    assert!(
+        page_count >= 4,
+        "쪽이 너무 적다({page_count}) — 표본이 바뀌었는지 확인하라"
+    );
+
+    let mut total = 0usize;
+    let mut per_page = Vec::new();
+    for p in 0..page_count {
+        let svg = doc.render_page_svg(p).expect("SVG 렌더");
+        let (h, over) = out_of_page_glyphs(&svg);
+        assert!(h > 0.0, "{}쪽 뷰박스 높이를 읽지 못했다", p + 1);
+        if over > 0 {
+            per_page.push(format!("{}쪽 {over}자", p + 1));
+        }
+        total += over;
+    }
+
+    assert!(
+        total <= MAX_OUT_OF_PAGE_GLYPHS,
+        "쪽 밖에 그려진 글자가 {total}자로 상한 {MAX_OUT_OF_PAGE_GLYPHS}자를 넘는다 ({}).\n\
+         분할 표 조각의 표-직후 vpos 보정이 **셀 원점**을 쓰면 연속 조각이 앞부분 높이만큼 \
+         밀려 내용이 쪽 밖으로 나간다. 원점은 `cut_units` 가 정한 조각 시작 vpos 여야 한다.",
+        per_page.join(", ")
+    );
+}


### PR DESCRIPTION
분할 표 조각에서 표-직후 vpos 보정이 **셀 원점**을 써서, 뒤 내용이 쪽 밖으로 밀려
어느 렌더 경로에서도 보이지 않던 결함을 고칩니다.

Refs #3637

## 근인

`LINE_SEG.vertical_pos` 는 **셀 시작** 기준 누적값입니다. 그런데 표-직후 보정은 그
절대값을 **이 쪽의** `text_y_start` 에 그대로 더했습니다.

```rust
let next_vpos_y = text_y_start + hwpunit_to_px(next_seg.vertical_pos, self.dpi);
para_y = para_y.max(next_vpos_y);
```

표가 쪽을 넘나들며 잘린 **연속 조각**에서는 원점이 어긋납니다 — 앞 쪽으로 넘어간
부분의 높이만큼 통째로 아래로 밀립니다.

실측 (재현 문서 2쪽, 조각 시작 vpos = 7160 HU = **95.5px**):

| 위치 | 수정 전 | 수정 후 |
|---|---|---|
| `p[19]` 다음 줄 | 583.1 | **487.7** |
| `p[27]` 다음 줄 | 977.2 | **881.7** |

두 곳 모두 오차가 정확히 95.5px 였습니다. 그만큼 표 직후에 빈 공간이 생기고, 뒤
내용이 쪽 경계를 넘어가 보이지 않았습니다.

## 왜 안 잡혔나

넘어간 글자는 **사라지지 않습니다**. `export-text` 에도 SVG `<text>` 요소에도 그대로
남습니다. 좌표만 쪽 밖이라 그려지지 않을 뿐이라, 텍스트 diff 로도 IR diff 로도
잡히지 않았습니다. 10k 서베이(r28)에서 쪽 밖 글자가 확인된 91문서 중 **8문서**가
이 유형이었고, 그 8건은 기존 진단(`LAYOUT_OVERFLOW_DRAW`)이 `cell_ctx.is_none()`
조건이라 **한 줄도 보고하지 않던** 구간이었습니다(관측은 #3643 이 열었습니다).

## 수정

원점을 `cut_units` 가 정한 **조각 시작 vpos** 로 잡습니다.

```rust
let fragment_start_vpos: i32 = line_ranges.as_ref()
    .and_then(|ranges| ranges.iter().enumerate()
        .find(|(_, (s, e))| s < e)                      // 가시 범위가 있는 첫 문단
        .and_then(|(pi, (s, _))| cell.paragraphs.get(pi)?
            .line_segs.get(*s).map(|seg| seg.vertical_pos.max(0))))
    .unwrap_or(0);
```

**"루프에서 처음 만나는 문단" 으로는 얻을 수 없습니다.** 빈 문단도 `line_segs` 가
1개라 `start_line < end_line` 이 성립해 스킵되지 않고, 그러면 `p[0]`(vpos≈0)이 잡혀
보정이 0 이 됩니다. 실제로 그렇게 만든 첫 판본이 무효였습니다 — 공백이 소수점까지
변하지 않았습니다.

## 검증

| 항목 | 결과 |
|---|---|
| 공백 위치 | 예측 487.6·881.7 → 실측 **487.7·881.7** (0.1px 이내) |
| 92셋 렌더 게이트 | **92/92 = 100%** |
| 쪽 밖 글자 (침묵 8건) | 2,910자 → **905자** (−69%), 악화 **0건** |
| 10k `MATCH` 대조군 | **300/300, 회귀 0** |
| 10k `PAGE_DELTA` 표본 | 389건, **회귀 0** |
| 렌더 유닛 테스트 | 964 통과 / 0 실패 |
| `clippy -D warnings` | 경고 0 |

**음성 대조**: 수정을 제거하면 재현 문서의 쪽 밖 글자가 239자 → **762자** 로 뜁니다
(2쪽 352 · 3쪽 116 · 4쪽 294). 회귀 테스트 상한을 그 사이(400)에 두어, 수정이
되돌려지면 반드시 실패하고 잔존 별개 축 때문에 헛되이 실패하지도 않습니다.

## 이 PR 이 하지 않는 것

**쪽수는 바뀌지 않습니다.** 10k `PAGE_DELTA` 389건에서 쪽수 일치로 전환된 문서는
없습니다. 이 수정의 성과는 쪽수 축이 아니라 **보이지 않던 본문의 회수**입니다.

**완전 해소도 아닙니다.** 재현 문서 기준 762자 중 239자가 남습니다(3·4쪽은 완전
해소, 2쪽만 잔존). 남은 몫은 흐름이 저장 사다리보다 촘촘한 **별개 축**이고, 기존
razor-thin 계열(#2148 · #2237)과 겹칠 가능성이 있습니다. #3637 에 후속으로 남깁니다.

## 재현 문서 — 저장소에 넣지 않았습니다

```
hwpdocs/korea_policy_downloads/148738070_20120829_무학대선건 보도자료.hwp
```

본문 전체가 1×1 표 안에 있고 그 표가 쪽 2~4 로 잘리는 구조라, 이 결함의 조건을
최소로 갖춘 문서입니다. 대한민국 정책브리핑 공개 자료입니다.

**저장소에 넣지 않은 이유**: `samples/` 아래 `.hwp` 는 `ir_field_sweep_baseline` 이
전수 스윕합니다(`HWP5_ROOT = "samples"`). 파일 추가만으로 그 게이트가 깨지고, 기준선을
재생성하면 이 PR 과 무관한 항목까지 끌어들여 진짜 회귀를 가립니다. 실제로 처음엔
`samples/issue3637/` 에 넣었다가 CI 에서 이 게이트가 깨졌습니다 — `samples/issueNNNN/`
배치는 `.hwpx` 만 보호합니다(`HWPX_ROOT` 가 `samples/hwpx` 로 좁습니다).

회귀 테스트는 코퍼스 문서가 있으면 검증하고 **없으면 건너뜁니다**. 경로는
`RHWP_ISSUE3637_DOC` 로 지정할 수 있습니다. CI 에서는 건너뛰므로, 이 PR 의 회귀 방어는
로컬 코퍼스 보유자에게만 작동합니다 — 대신 위의 690문서 게이트 결과로 근거를 남깁니다.
