### PR TITLE
fix(studio): 실패한 스냅샷 작업을 원자적으로 롤백

### DIFF
--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -1890,9 +1890,23 @@ export class SnapshotCommand implements EditCommand {
         this.cursorAfter = result;
       }
       this.afterId = wasm.saveSnapshot();
-    } catch (e) {
-      this.discard(wasm); // before/after id 를 null-safe 로 해제
-      throw e;
+    } catch (operationError) {
+      // [#3350] 최초 execute 가 실패하면 명령 전체를 원자적으로 되돌린다. 이 커맨드는
+      // history 에 push 되기 전이므로 before 스냅샷을 가진 SnapshotCommand만 rollback을
+      // 수행할 수 있다. after-save 실패도 execute 실패이므로 같은 계약을 따른다.
+      try {
+        if (this.beforeId !== null) {
+          wasm.restoreSnapshot(this.beforeId);
+        }
+      } catch (rollbackError) {
+        this.discard(wasm);
+        throw new AggregateError(
+          [operationError, rollbackError],
+          `${this.type} 실행 실패 후 rollback도 실패했습니다`,
+        );
+      }
+      this.discard(wasm);
+      throw operationError;
     }
 
     // operation 참조 해제 (클로저에 캡처된 리소스 해제)

--- a/rhwp-studio/tests/command-history-snapshot.test.ts
+++ b/rhwp-studio/tests/command-history-snapshot.test.ts
@@ -86,6 +86,24 @@ test('[결함3] execute 는 operation·after-save 어느 throw 에도 스냅샷�
     'after-save 가 catch 밖(try 이후)에 남아있음 — 누수 경로');
 });
 
+test('[#3350] 최초 execute 실패는 before 스냅샷 복원 후 ID를 해제한다', () => {
+  const block = methodBlock(command, 'execute(wasm: WasmBridge): DocumentPosition {');
+  const catchStart = block.search(/\}\s*catch \(operationError\)/);
+  assert.notEqual(catchStart, -1, '최초 execute 실패 catch가 있어야 함');
+  const catchBody = block.slice(catchStart);
+
+  const idxRestore = catchBody.indexOf('wasm.restoreSnapshot(this.beforeId)');
+  const idxDiscard = catchBody.indexOf('this.discard(wasm)');
+  assert.ok(idxRestore !== -1 && idxDiscard !== -1 && idxRestore < idxDiscard,
+    '부분 변경을 before 스냅샷으로 rollback한 뒤 ID를 해제해야 함');
+  assert.match(catchBody, /catch \(rollbackError\)/,
+    'rollback 실패도 별도로 포착해야 함');
+  assert.match(catchBody, /new AggregateError\(\s*\[operationError, rollbackError\]/,
+    '원래 operation 오류와 rollback 오류를 함께 보존해야 함');
+  assert.match(catchBody, /throw operationError/,
+    'rollback 성공 시 원래 operation 오류를 그대로 전파해야 함');
+});
+
 test('[결함1] 스냅샷 예산은 WASM 상한에서 순간 +2 여유를 뺀 값이다', () => {
   // 새 SnapshotCommand.execute 는 before/after 2개를 예산 강제 이전에 저장하므로,
   // 예산 == MAX 면 그 순간 store 가 MAX 초과 → WASM 무통보 축출 → orphan.


### PR DESCRIPTION
## 변경 요약

- `SnapshotCommand.execute()`의 operation 또는 after-snapshot 저장이 실패하면 before snapshot을 복원한 뒤 점유한 snapshot ID를 해제합니다.
- 작업 오류는 rollback 성공 시 원래 오류로 다시 전파합니다.
- rollback도 실패하면 작업 오류와 rollback 오류를 모두 담은 `AggregateError`를 반환해 진단 정보를 보존합니다.

## 관련 이슈

closes #3350

## 회귀 테스트 참고

현재 프로덕션 API에는 현실적으로 오류를 주입할 수 있는 throw 경로가 없어, 저장소의 기존 관례에 맞춘 source-contract 회귀 테스트로 복원 순서와 ID 해제 계약을 고정했습니다.

## 검증

- [x] `node --test tests/command-history-snapshot.test.ts` (6 passed)
- [x] `npm test` (687 passed)
- [x] TypeScript 전체 typecheck
- [x] Vite production build
- [x] `git diff --check origin/devel...HEAD`