### PR TITLE
fix(hwpx): 수식 스키마와 누름틀 dirty 왕복을 통합한다

### DIFF
--- a/mydocs/orders/20260731.md
+++ b/mydocs/orders/20260731.md
@@ -141,3 +141,48 @@ branch의 merge commit은 중복을 피하기 위해 제외했고 conflict는 �
   분리했고, `#[ignore]` 회귀를 삭제하지 않는다. review·asset·오늘할일만 추가한 head의 fast-pass가
   통과하면 #3657을 merge하고 #3593/#3595 close 상태, #3658 open 상태, 원 PR supersede와 contributor
   comment, devel sync·검토 자원 정리를 순서대로 확인한다.
+
+## JamesPsh HWPX serializer PR 2건 통합 검토
+
+[#3646](https://github.com/edwardkim/rhwp/pull/3646)과
+[#3651](https://github.com/edwardkim/rhwp/pull/3651)은 `@JamesPsh`의 HWPX serializer 수정이다.
+원 PR을 개별 merge하지 않고 `devel` `6d36bafa` 위
+[#3659](https://github.com/edwardkim/rhwp/pull/3659)에 기능 commit만 번호순으로 체리픽했다. 원
+head의 `devel` 병합 commit은 제외했고 `git range-diff`에서 두 patch의 동등성과 conflict 없음을 확인했다.
+
+- #3646은 `hp:equation`에서 스키마 비허용 `instid` 방출을 제거하고 `id` 유지 계약을 고정한다.
+  #3651은 `fieldBegin@dirty`와 `Field.properties` bit 15를 양방향 보존해 안내문과 같은 값의
+  ClickHere 필드가 HWPX 재저장 후 사라지지 않도록 한다.
+- 원 PR 두 건과 #3659 current code head `00450ccb`의 full CI에서 lint, Native Skia, default-feature
+  8 shards, `Build & Test`, CodeQL이 모두 성공했고, #3651 및 통합 PR의 Canvas visual diff도
+  success다. 로컬 전체 Cargo는 이미 성공한 원 PR·정확한 통합 head CI와 중복하지 않도록 작업지시에
+  따라 실행하지 않았다.
+- HWPX 속성 직렬화 변경이므로 새 PDF 정합이나 수동 visual sweep을 성공 근거로 주장하지 않는다.
+  대신 #3651은 실제 `form-01.hwpx` fixture에서 dirty 읽기·방출·재적재와 초기 상태 무회귀를 고정한다.
+- archive review·통합 계획·오늘할일만 추가한 review-only head의 fast-pass를 확인한 뒤 #3659을
+  merge한다. merge 뒤 #3543은 close, 초기 상태 텍스트의 물리 삭제 설계 축이 남은 #3545는 open으로
+  유지하고, 원 PR 두 건에는 통합 근거와 감사 comment를 남긴 뒤 source fork를 보존한 채 supersede
+  close한다. 상세 근거는 `mydocs/pr/archives/pr_3646_review.md`,
+  `mydocs/pr/archives/pr_3646_review_impl.md`, `mydocs/pr/archives/pr_3651_review.md`에 남긴다.
+
+## #3646·#3651 HWPX 수식 스키마·ClickHere dirty 통합 검토
+
+[#3646](https://github.com/edwardkim/rhwp/pull/3646)과
+[#3651](https://github.com/edwardkim/rhwp/pull/3651)은 `@JamesPsh`의 HWPX 직렬화 계약 수정이다.
+원 PR을 개별 merge하지 않고 `devel` `6d36bafa` 위
+[#3659](https://github.com/edwardkim/rhwp/pull/3659)에 기능 commit만 번호순으로 체리픽했다. 원 head의
+`devel` 병합 commit은 제외했고, `4b4eed64` → `30d850618`, `1ac0270b` → `00450ccb`은 각각
+`git range-diff`에서 patch 동등이다.
+
+- #3646은 `hp:equation`에 스키마상 허용되지 않는 `instid`가 나오지 않도록 하고, `id`는 남는 출력
+  계약을 회귀로 고정한다. #3651은 `fieldBegin@dirty`와 `Field.properties` bit 15를 양방향으로
+  보존해 안내문과 같은 ClickHere 입력값도 HWPX 재저장 뒤 사라지지 않게 한다.
+- #3659 code head `00450ccb`의 CI preflight, lint, Native Skia, test archive, default-feature 8 shards,
+  `Build & Test`, CodeQL, Canvas visual diff는 모두 success다. 원 #3646·#3651 current head CI도 모두
+  success다. 로컬 전체 Cargo는 이 원 PR 및 통합 head 검증과 중복되므로 작업지시에 따라 실행하지 않았다.
+- 두 변경은 renderer·layout·typeset 범위가 아니므로 PDF 정합이나 수동 visual evidence를 성공 근거로
+  확대하지 않는다. Canvas visual diff success는 CI guard 결과로만 기록한다. #3543은 통합 merge 때
+  close하고, 초기 `dirty="0"` 안내문 물리 삭제라는 별도 설계 축이 남은 #3545는 open으로 유지한다.
+- archive review·통합 계획·오늘할일만 추가한 head의 LFS 사전 판독 및 review-only fast-pass가 통과하면
+  #3659을 merge한다. 이후 원 PR 두 건에는 통합 근거와 감사 comment를 실제 줄바꿈으로 남기고 supersede
+  close하며, source fork branch는 보존한다. `devel` sync와 통합·source refs 정리까지 후속 처리한다.

--- a/mydocs/pr/archives/pr_3646_review.md
+++ b/mydocs/pr/archives/pr_3646_review.md
@@ -1,0 +1,50 @@
+---
+kind: pr-review
+status: active
+---
+
+# PR #3646 검토 — 수식 `instid`의 스키마 비허용 방출 제거
+
+| 항목 | 값 |
+| --- | --- |
+| 작성자 / reviewer | `@JamesPsh` / `@jangster77` |
+| 원 PR / 관련 이슈 | [#3646](https://github.com/edwardkim/rhwp/pull/3646) / [#3543](https://github.com/edwardkim/rhwp/issues/3543) |
+| 원 head 참고값 | `2be15696bd7adba6622ac1cbe584662e2c13a5b3` |
+| 통합 후보 | [#3659](https://github.com/edwardkim/rhwp/pull/3659) `00450ccb1cb075c688b037462c760e1f4dd23700` |
+| 원 변경 규모 | 1 file, +17 / -1 |
+| 권고 | #3659로 수용 |
+
+## 변경과 통합 판정
+
+`hp:equation`은 공용 도형 컴포넌트가 아니므로 `instid` 속성을 가질 수 없다. 이 PR은 수식
+직렬화 경로에서 그 속성만 제거하고, `id`는 유지하는 `equation_omits_instid` 회귀를 추가한다.
+파서도 수식의 `instid`를 모델에 보존하지 않으므로, 변경은 기존 IR 왕복 모델과도 일치한다.
+
+원 head의 `devel` 병합 commit `2be15696b`은 통합에서 제외했다. 기능 commit `4b4eed64a`는
+통합 branch에서 `30d850618`으로 patch 동등하게 적용됐으며, 충돌은 없었다. `hp:chart`의
+별도 스키마 위반 가능성은 공용 경로의 범위가 달라 이번 PR에 섞지 않았다.
+
+## 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| 원 #3646 head CI | lint, Native Skia, default-feature 8 shards, `Build & Test`, CodeQL success |
+| 통합 #3659 code head CI | 동일 full CI, CodeQL 및 `Build & Test` success |
+| 체리픽 동등성 / diff | `git range-diff` 동등, `git diff --check` 통과 |
+| 추가 로컬 Cargo | 원 PR 및 정확한 통합 head CI와 중복되므로 작업지시에 따라 실행하지 않음. 성공 근거로 사용하지 않음 |
+
+원 PR CI는 [CI run](https://github.com/edwardkim/rhwp/actions/runs/30627555187), 정확한 통합
+code head CI는 [#3659 CI run](https://github.com/edwardkim/rhwp/actions/runs/30627974311)에서 확인했다.
+
+## 증적 범위
+
+이 변경은 HWPX serializer의 속성 계약만 바꾸며 renderer·layout·typeset 경로를 건드리지 않는다.
+따라서 PDF 정합을 새 성공 근거로 만들지 않았다. 대신 회귀는 `render_equation` 결과에 `instid`가
+없고 필수 `id`는 남는지를 직접 고정하며, 통합 CI의 Canvas visual diff도 성공했다.
+
+## 권고와 merge 전 조건
+
+**권고: 수용.** #3659의 code head full CI는 성공했고 상태는 작성 시점 `CLEAN`·`MERGEABLE`이다.
+archive review·통합 계획·오늘할일만 추가한 review-only head의 fast-pass를 확인한 뒤 #3659을
+merge한다. merge 뒤 #3543 close 상태, #3545 open 상태, 원 PR #3646의 supersede 처리와
+contributor 결과 comment, `devel` 동기화와 검토 ref 정리를 확인한다.

--- a/mydocs/pr/archives/pr_3646_review_impl.md
+++ b/mydocs/pr/archives/pr_3646_review_impl.md
@@ -1,0 +1,44 @@
+---
+kind: review-plan
+status: active
+---
+
+# JamesPsh HWPX 통합 검토·반영 계획 (PR #3646, #3651)
+
+기준은 `upstream/devel`의 `6d36bafaab0d253781a19e5b17eb51104e403834`다. 작성자
+`@JamesPsh`의 열린 HWPX serializer PR 두 건은 개별 merge하지 않고, 이 기준 위
+[#3659](https://github.com/edwardkim/rhwp/pull/3659) 하나로 누적 반영한다.
+
+| 순서 | 원 PR | 원 기능 commit | 통합 후보 반영 |
+| --- | --- | --- | --- |
+| 1 | #3646 | `4b4eed64a` | `30d850618` |
+| 2 | #3651 | `1ac0270b1` | `00450ccb1` |
+
+원 head의 `devel` 병합 commit `2be15696b`·`9f1c2addf`은 중복을 피하기 위해 제외했다.
+두 기능 patch는 `git range-diff`에서 동등하며 체리픽 conflict는 없다.
+
+## 검증과 범위 경계
+
+- #3646 원 head와 #3651 원 head의 full CI가 각각 success다.
+- #3659 code head `00450ccb1`은 lint, Native Skia, default-feature 8 shards, `Build & Test`,
+  CodeQL, Canvas visual diff를 모두 통과했다.
+- 로컬 전체 Cargo는 원 PR 및 통합 head CI가 확인한 범위를 중복하지 않도록 작업지시에 따라 실행하지
+  않았으며, 성공 근거로 적지 않는다.
+- 두 변경은 HWPX 속성 보존·스키마 적합성만 다룬다. renderer·layout·typeset 변경이 아니므로 새 PDF
+  정합이나 수동 visual sweep을 성공 근거로 주장하지 않는다.
+- #3543은 이 통합 PR이 닫는다. #3545는 `dirty="0"` 초기 안내문 잔재를 적재에서 물리 삭제하는
+  별도 설계 축이 남아 있으므로 open으로 유지한다.
+
+## 반영 순서
+
+1. archive review·오늘할일만 한 commit으로 #3659 head에 추가한다. source/test/workflow와 기존
+   sample·PDF·golden은 이 commit에 섞지 않는다.
+2. push 전 변경 파일의 LFS attribute와 `git lfs status`를 확인한다. 비-LFS면
+   `GIT_LFS_SKIP_PUSH=1` dry-run과 실제 push를 사용한다.
+3. source/local/remote SHA를 대조하고, latest review-only head의 fast-pass와 `CLEAN`·`MERGEABLE`을
+   확인한다.
+4. #3659을 squash merge한 뒤 merge SHA와 #3543 close, #3545 open 상태를 확인한다.
+5. 원 #3646·#3651에는 통합 PR과 merge SHA, 구체적인 검토 근거를 실제 LF body-file comment로 남긴 뒤
+   supersede close한다. source fork branch는 삭제하지 않는다.
+6. `devel` sync, upstream integration branch·local source refs의 정확한 종료 대상만 post-merge 절차에
+   따라 정리한다. 이번 검토에서는 전용 Cargo target을 만들지 않았으므로 제거할 target은 없다.

--- a/mydocs/pr/archives/pr_3651_review.md
+++ b/mydocs/pr/archives/pr_3651_review.md
@@ -1,0 +1,59 @@
+---
+kind: pr-review
+status: active
+---
+
+# PR #3651 검토 — ClickHere `fieldBegin@dirty` 왕복 보존
+
+| 항목 | 값 |
+| --- | --- |
+| 작성자 / reviewer | `@JamesPsh` / `@jangster77` |
+| 원 PR / 관련 이슈 | [#3651](https://github.com/edwardkim/rhwp/pull/3651) / [#3545](https://github.com/edwardkim/rhwp/issues/3545) |
+| 원 head 참고값 | `9f1c2addf5ae8e3968394f2ffff0967e634359f1` |
+| 통합 후보 | [#3659](https://github.com/edwardkim/rhwp/pull/3659) `00450ccb1cb075c688b037462c760e1f4dd23700` |
+| 원 변경 규모 | 4 files, +170 / -2 |
+| 권고 | #3659로 수용. #3545의 잔여 설계 축은 open 유지 |
+
+## 변경과 통합 판정
+
+HWPX parser가 `hp:fieldBegin@dirty`를 버리고 serializer도 방출하지 않아, ClickHere 필드의
+`properties` bit 15가 HWPX 축에서는 항상 0이 됐다. 그 결과 안내문과 같은 실제 값을 채운 필드는
+`clear_initial_field_texts` 정규화에서 다시 사라질 수 있었다.
+
+PR은 `dirty`를 bit 15로 읽고, `Field::is_dirty()`를 통해 자기닫힘과 자식 보유 `fieldBegin` 두
+직렬화 경로에서 모두 다시 쓴다. 새 `issue_3545_clickhere_dirty_roundtrip` 회귀는 실제
+`samples/hwpx/form-01.hwpx`를 사용해 다음 경계를 고정한다.
+
+- 안내문과 같은 값을 채운 뒤 HWPX 저장·재적재해도 값이 남는다.
+- 입력 상태의 `dirty="1"` 파일은 적재만으로 값이 지워지지 않는다.
+- 초기 상태와 채운 상태가 각각 `dirty="0"`·`"1"`로 방출된다.
+- 초기 상태 `dirty="0"`의 기존 정규화는 바뀌지 않는다.
+
+원 head의 `devel` 병합 commit `9f1c2addf`은 통합에서 제외했다. 기능 commit `1ac0270b1`은
+통합 branch에서 `00450ccb1`으로 patch 동등하게 적용됐고 충돌은 없었다.
+
+## 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| 원 #3651 head CI | lint, Native Skia, default-feature 8 shards, `Build & Test`, CodeQL, Canvas visual diff success |
+| 통합 #3659 code head CI | 동일 full CI, CodeQL 및 `Build & Test` success |
+| HWPX 회귀 | 실제 form fixture의 parser·serializer·재적재와 초기 상태 무회귀를 한 integration test에 고정 |
+| 체리픽 동등성 / diff | `git range-diff` 동등, `git diff --check` 통과 |
+| 추가 로컬 Cargo | 원 PR 및 정확한 통합 head CI와 중복되므로 작업지시에 따라 실행하지 않음. 성공 근거로 사용하지 않음 |
+
+원 PR CI는 [CI run](https://github.com/edwardkim/rhwp/actions/runs/30627559514), 정확한 통합
+code head CI는 [#3659 CI run](https://github.com/edwardkim/rhwp/actions/runs/30627974311)에서 확인했다.
+
+## 남은 범위
+
+이 PR은 입력된 필드의 보존 표식 왕복만 해결한다. 초기 상태 `dirty="0"` 필드의 안내문 텍스트를
+IR 적재에서 물리 삭제하는 기존 정규화를 무손실 해석으로 바꿀지는 renderer·API·roundtrip 계약에
+영향을 주는 별도 설계 결정이다. 이를 해결된 것으로 표시하지 않고 #3545를 open으로 유지한다.
+
+## 권고와 merge 전 조건
+
+**권고: 수용.** #3659의 code head full CI가 성공했고 상태는 작성 시점 `CLEAN`·`MERGEABLE`이다.
+archive review·통합 계획·오늘할일만 추가한 review-only head의 fast-pass를 확인한 뒤 #3659을
+merge한다. merge 뒤 #3543 close, #3545 open 상태, 원 PR #3651의 supersede 처리와 contributor
+결과 comment, `devel` 동기화와 검토 ref 정리를 확인한다.

--- a/src/model/control.rs
+++ b/src/model/control.rs
@@ -344,6 +344,12 @@ impl Field {
         self.properties & 1 != 0
     }
 
+    /// 수정됨(dirty) 표식 (properties bit 15) — `clear_initial_field_texts` 의 보존 게이트.
+    /// HWPX `<hp:fieldBegin dirty="..">` 가 이 비트의 대응물이다 (#3545).
+    pub fn is_dirty(&self) -> bool {
+        self.properties & (1 << 15) != 0
+    }
+
     /// 누름틀(ClickHere) command 문자열을 한컴 포맷으로 재구축한다.
     ///
     /// 한컴 정답지(`samples/field-01.hwp`, `form-01.hwp`) 동형 (#1434):

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -4556,6 +4556,13 @@ fn parse_field_begin_attrs(e: &quick_xml::events::BytesStart) -> Field {
                     f.properties |= 1;
                 }
             }
+            b"dirty" => {
+                // properties bit 15 = 수정됨 표식 — 버리면 clear_initial_field_texts 의
+                // 보존 게이트(#3380)가 HWPX 축에서 항상 열려 텍스트가 유실된다 (#3545)
+                if parse_bool_attr(&attr) {
+                    f.properties |= 1 << 15;
+                }
+            }
             _ => {}
         }
     }

--- a/src/serializer/hwpx/field.rs
+++ b/src/serializer/hwpx/field.rs
@@ -42,19 +42,21 @@ pub fn field_begin_open_tag(field: &Field) -> String {
     // 왕복 시 영구 손실된다. 없으면(None) 속성 자체를 생략(#1391 자기닫힘 태그 호환).
     match field.instance_id {
         Some(fieldid) => format!(
-            r#"<hp:fieldBegin id="{}" type="{}" name="{}" editable="{}" fieldid="{}""#,
+            r#"<hp:fieldBegin id="{}" type="{}" name="{}" editable="{}" dirty="{}" fieldid="{}""#,
             id_str,
             ft,
             name,
             bool01(field.is_editable_in_form()),
+            bool01(field.is_dirty()),
             fieldid,
         ),
         None => format!(
-            r#"<hp:fieldBegin id="{}" type="{}" name="{}" editable="{}""#,
+            r#"<hp:fieldBegin id="{}" type="{}" name="{}" editable="{}" dirty="{}""#,
             id_str,
             ft,
             name,
             bool01(field.is_editable_in_form()),
+            bool01(field.is_dirty()),
         ),
     }
 }
@@ -77,6 +79,7 @@ pub fn write_field_begin<W: Write>(w: &mut Writer<W>, field: &Field) -> Result<(
     let ft = field_type_str(field.field_type);
     let fieldid_str = field.instance_id.map(|v| v.to_string());
     let editable_str = bool01(field.is_editable_in_form());
+    let dirty_str = bool01(field.is_dirty());
     match &fieldid_str {
         Some(fieldid_str) => empty_tag(
             w,
@@ -86,6 +89,7 @@ pub fn write_field_begin<W: Write>(w: &mut Writer<W>, field: &Field) -> Result<(
                 ("type", ft),
                 ("name", field.ctrl_data_name.as_deref().unwrap_or("")),
                 ("editable", editable_str),
+                ("dirty", dirty_str),
                 ("fieldid", fieldid_str),
             ],
         ),
@@ -97,6 +101,7 @@ pub fn write_field_begin<W: Write>(w: &mut Writer<W>, field: &Field) -> Result<(
                 ("type", ft),
                 ("name", field.ctrl_data_name.as_deref().unwrap_or("")),
                 ("editable", editable_str),
+                ("dirty", dirty_str),
             ],
         ),
     }

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -2321,7 +2321,7 @@ fn render_equation(eq: &Equation) -> String {
     let allow_overlap = if c.allow_overlap { "1" } else { "0" };
 
     format!(
-        r#"<hp:equation id="{id}" zOrder="{z_order}" numberingType="EQUATION" textWrap="{}" textFlow="{}" lock="{lock}" dropcapstyle="None" instid="{id}" version="{version}" baseLine="{baseline}" textColor="{text_color}" baseUnit="{base_unit}" lineMode="{line_mode}" font="{font}"><hp:script>{script}</hp:script><hp:sz width="{width}" widthRelTo="{width_rel_to}" height="{height}" heightRelTo="{height_rel_to}"/><hp:pos treatAsChar="{treat}" affectLSpacing="0" flowWithText="{flow_with_text}" allowOverlap="{allow_overlap}" holdAnchorAndSO="{hold}" vertRelTo="{}" horzRelTo="{}" vertAlign="{}" horzAlign="{}" vertOffset="{vert_offset}" horzOffset="{horz_offset}"/><hp:outMargin left="{margin_left}" right="{margin_right}" top="{margin_top}" bottom="{margin_bottom}"/>{shape_comment}</hp:equation>"#,
+        r#"<hp:equation id="{id}" zOrder="{z_order}" numberingType="EQUATION" textWrap="{}" textFlow="{}" lock="{lock}" dropcapstyle="None" version="{version}" baseLine="{baseline}" textColor="{text_color}" baseUnit="{base_unit}" lineMode="{line_mode}" font="{font}"><hp:script>{script}</hp:script><hp:sz width="{width}" widthRelTo="{width_rel_to}" height="{height}" heightRelTo="{height_rel_to}"/><hp:pos treatAsChar="{treat}" affectLSpacing="0" flowWithText="{flow_with_text}" allowOverlap="{allow_overlap}" holdAnchorAndSO="{hold}" vertRelTo="{}" horzRelTo="{}" vertAlign="{}" horzAlign="{}" vertOffset="{vert_offset}" horzOffset="{horz_offset}"/><hp:outMargin left="{margin_left}" right="{margin_right}" top="{margin_top}" bottom="{margin_bottom}"/>{shape_comment}</hp:equation>"#,
         text_wrap_to_hwpx(c.text_wrap),
         text_flow_to_hwpx(c.text_flow),
         vert_rel_to_hwpx(c.vert_rel_to),
@@ -2751,6 +2751,22 @@ mod tests {
             render_equation(&Equation::default()).contains(r#"allowOverlap="0""#),
             "기본값(false)은 종전대로 allowOverlap=\"0\" 이어야 함(회귀 방지)"
         );
+    }
+
+    /// [Issue #3543] 수식(`hp:equation`)은 스키마 비허용 `instid` 속성을 방출하지
+    /// 않아야 한다. instid 는 도형 컴포넌트 공통(KS X 6101:2024 표 209) 소관이고
+    /// equation 요소 정의(표 207·샘플 114)에는 없다 — 한컴 저장본도 수식에는
+    /// 방출하지 않는다. 파서는 수식의 instid 를 버리므로 제거해도 왕복 불변.
+    #[test]
+    fn equation_omits_instid() {
+        use crate::model::control::Equation;
+
+        let xml = render_equation(&Equation::default());
+        assert!(
+            !xml.contains("instid"),
+            "수식은 스키마 비허용 instid 를 방출하면 안 됨(KS X 6101 표 207): {xml}"
+        );
+        assert!(xml.contains(r#" id=""#), "id 속성은 유지돼야 함: {xml}");
     }
 
     /// [Issue #2790] legacy 공용 도형 경로(ellipse/arc/polygon/curve/chart/ole)의 textFlow

--- a/tests/issue_3545_clickhere_dirty_roundtrip.rs
+++ b/tests/issue_3545_clickhere_dirty_roundtrip.rs
@@ -1,0 +1,150 @@
+//! [Issue #3545] 안내문과 같은 본문 텍스트를 가진 누름틀이 HWPX 로드만 해도 텍스트를
+//! 잃고, 저장하면 파일에서 영구 소실된다.
+//!
+//! 적재 정규화 `clear_initial_field_texts` 는 properties 비트 15(수정됨 표식) == 0 인
+//! ClickHere 필드의 안내문 잔재를 지운다. HWP5 축은 #3380 이 채움 경로에서 비트를 세워
+//! 해소했지만 HWPX 축은 왕복 통로가 없었다 — 파서가 `<hp:fieldBegin dirty="...">` 를
+//! 버리고 저장기도 dirty 를 방출하지 않아, HWPX 로드 후 비트 15 는 항상 0 이다.
+//! OWPML fieldBegin 의 `dirty` 가 이 표식의 대응물이다 (한컴 실물: 초기 상태
+//! `samples/hwpx/form-01.hwpx` 는 dirty="0", 입력된 `samples/누름틀-2024.hwpx` 는
+//! dirty="1").
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::{Read, Write};
+use std::path::Path;
+
+const SAMPLE: &str = "samples/hwpx/form-01.hwpx";
+const FIELD: &str = "myMsg01";
+/// `samples/hwpx/form-01.hwpx` 의 `myMsg01` 안내문. 본문 텍스트도 이 값과 같다(초기 상태).
+const GUIDE: &str = "여기에 입력";
+/// 유일 누름틀의 fieldBegin 속성 앵커 — 표 셀 등 다른 요소의 dirty 와 겹치지 않는다.
+const FIELD_ANCHOR: &str = r#"type="CLICK_HERE" name="myMsg01" editable="1" dirty="0""#;
+
+fn sample_bytes() -> Vec<u8> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    std::fs::read(&path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"))
+}
+
+fn load(bytes: &[u8]) -> rhwp::wasm_api::HwpDocument {
+    rhwp::wasm_api::HwpDocument::from_bytes(bytes).expect("parse")
+}
+
+fn field_value(doc: &rhwp::wasm_api::HwpDocument, name: &str) -> String {
+    let json = doc.get_field_list();
+    let v: serde_json::Value = serde_json::from_str(&json).expect("field list JSON");
+    let fields = v["fields"]
+        .as_array()
+        .or_else(|| v.as_array())
+        .expect("fields 배열");
+    fields
+        .iter()
+        .find(|f| f["name"] == name)
+        .map(|f| f["value"].as_str().unwrap_or("").to_string())
+        .unwrap_or_else(|| panic!("필드 {name} 없음"))
+}
+
+/// 샘플의 누름틀 fieldBegin 만 dirty="1" 로 바꾼 HWPX 를 만든다 (파서 축 단독 재현용).
+fn with_dirty_flag(bytes: &[u8]) -> Vec<u8> {
+    let mut src = zip::ZipArchive::new(std::io::Cursor::new(bytes.to_vec())).expect("zip 열기");
+    let mut out = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    for i in 0..src.len() {
+        let mut entry = src.by_index(i).expect("zip 엔트리");
+        let name = entry.name().to_string();
+        if name == "Contents/section0.xml" {
+            let mut xml = String::new();
+            entry.read_to_string(&mut xml).expect("section XML");
+            let patched = xml.replace(
+                FIELD_ANCHOR,
+                &FIELD_ANCHOR.replace("dirty=\"0\"", "dirty=\"1\""),
+            );
+            assert_ne!(patched, xml, "샘플에 앵커 누름틀이 있어야 한다");
+            out.start_file(name, zip::write::SimpleFileOptions::default())
+                .expect("start_file");
+            out.write_all(patched.as_bytes()).expect("write section");
+        } else {
+            out.raw_copy_file(entry).expect("raw copy");
+        }
+    }
+    out.finish().expect("finish").into_inner()
+}
+
+/// 저장본의 본문 section XML 을 연결해 돌려준다.
+fn section_xml(hwpx: &[u8]) -> String {
+    let mut zip = zip::ZipArchive::new(std::io::Cursor::new(hwpx.to_vec())).expect("저장본 ZIP");
+    let names: Vec<String> = zip.file_names().map(str::to_string).collect();
+    let mut xml = String::new();
+    for name in names {
+        if name.starts_with("Contents/section") && name.ends_with(".xml") {
+            zip.by_name(&name)
+                .expect("section 엔트리")
+                .read_to_string(&mut xml)
+                .expect("section XML 은 UTF-8");
+        }
+    }
+    xml
+}
+
+/// #3380 의 HWPX 쌍둥이: 안내문과 같은 값을 채워도 HWPX 저장·재적재에서 살아남아야 한다.
+#[test]
+fn value_equal_to_guide_survives_hwpx_roundtrip() {
+    let mut doc = load(&sample_bytes());
+    doc.set_field_value_by_name_api(FIELD, GUIDE)
+        .expect("set_field_value_by_name");
+    let saved = doc.export_hwpx().expect("export_hwpx");
+    let reloaded = load(&saved);
+    assert_eq!(
+        field_value(&reloaded, FIELD),
+        GUIDE,
+        "안내문과 같은 값이 HWPX 저장·재적재에서 유실됐다"
+    );
+}
+
+/// 파서 축 단독: dirty="1" 인 누름틀은 본문이 안내문과 같아도 로드에서 지워지지 않는다.
+#[test]
+fn dirty_field_text_survives_load() {
+    let doc = load(&with_dirty_flag(&sample_bytes()));
+    assert_eq!(
+        field_value(&doc, FIELD),
+        GUIDE,
+        "dirty=\"1\" 누름틀의 텍스트가 로드만으로 유실됐다"
+    );
+}
+
+/// 저장기 축: fieldBegin 이 dirty 속성을 상태 그대로 방출해야 한다.
+#[test]
+fn export_emits_dirty_attribute() {
+    // 초기 상태 → dirty="0"
+    let doc = load(&sample_bytes());
+    let xml = section_xml(&doc.export_hwpx().expect("export_hwpx"));
+    assert!(
+        xml.contains(FIELD_ANCHOR),
+        "초기 상태 누름틀은 dirty=\"0\" 로 방출되어야 한다: {}",
+        &xml[..xml.len().min(2000)]
+    );
+    // 채운 상태(비트 15) → dirty="1"
+    let mut doc = load(&sample_bytes());
+    doc.set_field_value_by_name_api(FIELD, "주식회사 가나다")
+        .expect("set_field_value_by_name");
+    let xml = section_xml(&doc.export_hwpx().expect("export_hwpx"));
+    assert!(
+        xml.contains(r#"name="myMsg01" editable="1" dirty="1""#),
+        "채운 누름틀은 dirty=\"1\" 로 방출되어야 한다"
+    );
+}
+
+/// 무회귀: dirty="0" 초기 안내문 잔재의 정규화(제거)는 종전대로 유지된다.
+#[test]
+fn initial_state_still_normalized_on_load() {
+    let doc = load(&sample_bytes());
+    assert_eq!(
+        field_value(&doc, FIELD),
+        "",
+        "초기 상태(dirty=\"0\") 안내문 잔재는 로드 시 정규화되어야 한다"
+    );
+    let reloaded = load(&doc.export_hwpx().expect("export_hwpx"));
+    assert_eq!(
+        field_value(&reloaded, FIELD),
+        "",
+        "왕복 후에도 초기 상태 유지"
+    );
+}


### PR DESCRIPTION
## 통합 내용

JamesPsh의 열린 HWPX 직렬화 PR 두 건에서 최신 `devel` 병합 커밋은 제외하고 기능 커밋만 번호순으로 통합했습니다.

- #3646 — `hp:equation`에 스키마상 허용되지 않는 `instid`를 방출하지 않도록 하고 출력 계약 회귀를 추가합니다.
- #3651 — `hp:fieldBegin@dirty`와 `Field.properties` bit 15를 양방향으로 보존해 ClickHere 값이 안내문과 같아도 HWPX 재저장 후 사라지지 않도록 합니다.

## 범위와 추적

- `Closes #3543`
- #3545의 초기 상태(`dirty="0"`) 안내문 텍스트를 적재 중 물리 삭제하는 별도 설계 축은 의도적으로 포함하지 않습니다. 해당 이슈는 계속 열어 둡니다.

## 검증

- 각 원 PR의 CI는 최신 head에서 실행 중입니다.
- 동일한 두 기능 커밋을 적용한 이 통합 head의 전체 CI를 병합 게이트로 사용합니다.
- 로컬 전체 Cargo 재실행은 원 PR 및 통합 head CI와 중복되므로 하지 않았습니다.

## 통합 근거

원 PR의 `devel` 병합 커밋은 제외하고 아래 기능 커밋만 적용했습니다.

- `4b4eed64` — #3646
- `1ac0270b` — #3651
