### PR TITLE
Task #3315: [성능] 본문 그림 좁은 질의 — 편집당 6.6MB JSON 왕복 제거

### DIFF
--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -686,6 +686,43 @@ export class WasmBridge {
     }
   }
 
+  /**
+   * 본문(flow) 그림의 배치 정보만 받는다 (Task #3315).
+   *
+   * 전체 레이어 트리를 받아 flow 그림을 걸러내면 그림 1장에 수 MB 를 편집마다 옮긴다.
+   * 이 질의는 바이트를 빼고 bbox·잘림·효과·신원 키만 주므로 수백 바이트다. 바이트는
+   * `getSourceImageBytes(key)` 로 그림이 바뀔 때만 따로 받는다.
+   *
+   * 구형 WASM(미지원)에서는 `null` — 호출부는 종전의 전체 트리 경로로 되돌아간다.
+   */
+  getPageFlowImageOps(pageNum: number): string | null {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    const d = this.doc as unknown as { getPageFlowImageOps?: (p: number) => string };
+    if (typeof d.getPageFlowImageOps !== 'function') return null;
+    try {
+      return d.getPageFlowImageOps(pageNum);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * 그림 신원 키로 바이트를 받는다 (Task #3315).
+   *
+   * 키를 풀 수 없으면 `null` — 세대가 바뀐 낡은 키이거나 없는 그림이다. 호출부는 종전
+   * 경로로 되돌아가야 한다.
+   */
+  getSourceImageBytes(key: string): Uint8Array | null {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    const d = this.doc as unknown as { getSourceImageBytes?: (k: string) => Uint8Array };
+    if (typeof d.getSourceImageBytes !== 'function') return null;
+    try {
+      return d.getSourceImageBytes(key);
+    } catch {
+      return null;
+    }
+  }
+
   getPageLayerTreeObject(pageNum: number, profile: LayerRenderProfile = 'screen'): PageLayerTree {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     const d = this.doc as unknown as {

--- a/rhwp-studio/src/view/flow-image-clip.ts
+++ b/rhwp-studio/src/view/flow-image-clip.ts
@@ -14,8 +14,14 @@ export interface FlowImageCrop {
 
 export interface FlowImagePaintOp {
   bbox: FlowImageBbox;
-  mime: string;
-  base64: string;
+  /**
+   * `<img>.src` 로 그대로 넣는 값.
+   *
+   * 전체 레이어 트리 경로는 `data:{mime};base64,{...}`, 좁은 질의 경로는 신원 키별 object
+   * URL 이다(Task #3315). 두 생산자가 같은 필드를 채우므로 DOM 조립부는 어느 쪽에서 왔는지
+   * 알 필요가 없다.
+   */
+  src: string;
   crop: FlowImageCrop | null;
   originalSizeHu: [number, number] | null;
   rotation: number;
@@ -109,8 +115,7 @@ export function collectFlowImagePaintOps(
         }
         images.push({
           bbox: op.bbox,
-          mime: op.mime,
-          base64: op.base64,
+          src: `data:${op.mime};base64,${op.base64}`,
           crop: isFiniteCrop(op.crop) ? op.crop : null,
           originalSizeHu: isPositiveSizeTuple(op.originalSizeHu) ? op.originalSizeHu : null,
           rotation: finiteNumber(op.transform?.rotation),
@@ -196,4 +201,61 @@ function isFiniteCrop(value: unknown): value is FlowImageCrop {
 function finiteNumber(value: unknown): number {
   const number = Number(value);
   return Number.isFinite(number) ? number : 0;
+}
+
+/**
+ * 좁은 질의(`getPageFlowImageOps`) 응답을 `FlowImagePaintOp` 로 옮긴다 (Task #3315).
+ *
+ * 위 `collectFlowImagePaintOps` 와 **같은 타입을 내는 두 번째 생산자**다. 나란히 두는 이유는
+ * 둘이 어긋나면 화면이 갈리기 때문이다 — Rust 쪽 등가성은 `tests/issue_3315_flow_image_narrow_query.rs`
+ * 가 실문서로 고정하고, 여기서는 필드 옮김만 한다.
+ *
+ * 잘림은 Rust 가 이미 조상 `clipRect` 를 교차해 접어 준다. 그래서 계보를 다시 훑지 않는다.
+ *
+ * `null` 을 돌려주면 이 경로를 쓸 수 없다는 뜻이다 — 호출부는 전체 트리 경로로 되돌아가야
+ * 한다. 그런 경우는 셋이다: ①응답이 유효한 JSON 이 아니다 ②`cacheable:false`(신원 키를 낼 수
+ * 없는 합성 그림이 섞여 바이트를 되찾을 방법이 없다) ③키로 URL 을 만들지 못했다(세대가 바뀐
+ * 낡은 키). 부분적으로 성공한 목록을 돌려주면 그림 몇 장이 조용히 사라지므로 전부 아니면 전무다.
+ */
+export function flowImageOpsFromNarrowQuery(
+  json: string,
+  resolveSrc: (key: string, mime: string) => string | null,
+): FlowImagePaintOp[] | null {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  if (payload === null || typeof payload !== 'object') return null;
+  const response = payload as { cacheable?: unknown; images?: unknown };
+  if (response.cacheable !== true) return null;
+  if (!Array.isArray(response.images)) return null;
+
+  const images: FlowImagePaintOp[] = [];
+  for (const entry of response.images) {
+    if (entry === null || typeof entry !== 'object') return null;
+    const op = entry as LayerPaintOpLike & {
+      clip?: unknown;
+      sourceImageKey?: unknown;
+    };
+    if (!isFiniteBbox(op.bbox)) return null;
+    if (typeof op.mime !== 'string' || typeof op.sourceImageKey !== 'string') return null;
+
+    const src = resolveSrc(op.sourceImageKey, op.mime);
+    if (src === null) return null;
+
+    images.push({
+      bbox: op.bbox,
+      src,
+      crop: isFiniteCrop(op.crop) ? op.crop : null,
+      originalSizeHu: isPositiveSizeTuple(op.originalSizeHu) ? op.originalSizeHu : null,
+      rotation: finiteNumber(op.transform?.rotation),
+      horzFlip: op.transform?.horzFlip === true,
+      vertFlip: op.transform?.vertFlip === true,
+      filter: composeImageFilter(op),
+      clip: isFiniteBbox(op.clip) ? op.clip : null,
+    });
+  }
+  return images;
 }

--- a/rhwp-studio/src/view/flow-image-url-cache.ts
+++ b/rhwp-studio/src/view/flow-image-url-cache.ts
@@ -1,0 +1,63 @@
+/**
+ * 그림 신원 키별 object URL 캐시 (Task #3315).
+ *
+ * 종전에는 그림마다 `data:{mime};base64,{...}` 를 만들어 `<img>.src` 에 넣었다. 그 문자열은
+ * 레이어 트리 JSON 에서 온 것이고, JSON 은 편집마다 다시 받으므로 **같은 그림의 같은 바이트를
+ * 키 입력마다 다시 옮기고 다시 문자열로 만들었다**.
+ *
+ * 신원 키(`bin:{epoch}:{bin_data_id}:{variant}`)는 바이트가 바뀌면 함께 바뀌므로, 키를 캐시
+ * 키로 쓰면 스스로 무효화된다 — 편집 때 비울 필요가 없고, 비우면 캐시를 두는 의미가 없다.
+ *
+ * ## 수명
+ *
+ * `URL.createObjectURL` 은 명시적으로 revoke 하지 않으면 문서가 살아 있는 동안 남는다. 문서를
+ * 갈아끼우면 epoch 가 올라가 옛 키는 다시 조회되지 않으므로, 그 시점에 전부 revoke 한다.
+ * 개별 항목을 참조 카운트로 회수하지는 않는다 — `<img>` 가 아직 디코드 중인 URL 을 거두면 그림이
+ * 빈 채로 남고, 페이지의 그림 수는 revoke 를 정교하게 할 만큼 크지 않다.
+ */
+export class FlowImageUrlCache {
+  private urls = new Map<string, string>();
+
+  /**
+   * 키에 해당하는 object URL. 캐시에 없으면 `loadBytes` 로 바이트를 받아 만든다.
+   *
+   * 바이트를 받을 수 없으면 `null` — 세대가 바뀐 낡은 키이거나 구형 WASM 이다. 호출부는
+   * 종전의 base64 경로로 되돌아가야 한다.
+   */
+  urlFor(
+    key: string,
+    mime: string,
+    loadBytes: (key: string) => Uint8Array | null,
+  ): string | null {
+    const cached = this.urls.get(key);
+    if (cached !== undefined) return cached;
+
+    const bytes = loadBytes(key);
+    if (bytes === null || bytes.length === 0) return null;
+
+    // Blob 은 전달한 바이트를 복사해 소유하므로, WASM 메모리가 이후 재배치돼도 안전하다.
+    // `as BlobPart` 는 저장소 관례 — lib.dom 의 BlobPart 가 SharedArrayBuffer 로 뒷받침될
+    // 수 있는 뷰를 배제하는데, 런타임은 모든 ArrayBufferView 를 받는다
+    // (`src/hwpctl/index.ts`, `src/command/commands/file.ts` 와 같은 형태).
+    const url = URL.createObjectURL(new Blob([bytes as BlobPart], { type: mime }));
+    this.urls.set(key, url);
+    return url;
+  }
+
+  /** 캐시에 들고 있는 키 수 (진단·테스트용). */
+  get size(): number {
+    return this.urls.size;
+  }
+
+  has(key: string): boolean {
+    return this.urls.has(key);
+  }
+
+  /** 문서를 갈아끼울 때·정리할 때 전부 회수한다. */
+  releaseAll(): void {
+    for (const url of this.urls.values()) {
+      URL.revokeObjectURL(url);
+    }
+    this.urls.clear();
+  }
+}

--- a/rhwp-studio/src/view/page-renderer.ts
+++ b/rhwp-studio/src/view/page-renderer.ts
@@ -12,9 +12,11 @@ import {
 import { collectVectorRawSvgDataUrls } from './raw-svg-prefetch';
 import {
   collectFlowImagePaintOps,
+  flowImageOpsFromNarrowQuery,
   visibleFlowImageBbox,
   type FlowImagePaintOp,
 } from './flow-image-clip';
+import { FlowImageUrlCache } from './flow-image-url-cache';
 import type { RenderBackend } from './render-backend';
 
 interface LayerPlaneSummary {
@@ -78,6 +80,13 @@ export class PageRenderer {
    * 비우기에 기대지 않고 항목 자체가 어느 문서의 것인지 말하게 한다.
    */
   private prefetchedImageSignatures = new Map<number, PrefetchSignature>();
+  /**
+   * DOM flow 그림의 신원 키별 object URL (Task #3315).
+   *
+   * 키가 내용에서 유도되므로 스스로 무효화된다 — 편집 때 비우지 않는다. 문서를 갈아끼울 때만
+   * 회수한다(`invalidateDocumentRevision`·`dispose`).
+   */
+  private flowImageUrls = new FlowImageUrlCache();
   private prefetchRequestTokens = new Map<number, number>();
   private nextPrefetchRequestToken = 0;
   private flowSplitSupported: boolean | null = null;
@@ -114,6 +123,8 @@ export class PageRenderer {
     this.cancelAll();
     this.releaseAllPageDiagnostics();
     this.layerSummaryCache.clear();
+    // 문서가 갈리면 옛 신원 키는 다시 조회되지 않는다 — object URL 을 여기서 거둔다(#3315).
+    this.flowImageUrls.releaseAll();
   }
 
   /** 페이지를 Canvas에 렌더링한다 (renderScale = zoom × DPR) */
@@ -478,7 +489,8 @@ export class PageRenderer {
 
       const element = new Image();
       element.alt = '';
-      element.src = `data:${image.mime};base64,${image.base64}`;
+      // data URL(전체 트리 경로) 또는 신원 키별 object URL(좁은 질의 경로) — #3315.
+      element.src = image.src;
       element.style.position = 'absolute';
       element.style.pointerEvents = 'none';
       // 그림 효과(회색조/흑백/밝기/명암) — WASM canvas 경로(render_image)와 달리
@@ -649,7 +661,28 @@ export class PageRenderer {
     );
   }
 
+  /**
+   * 본문 그림의 DOM 배치 정보.
+   *
+   * [#3315] 좁은 질의를 먼저 쓴다. 종전에는 여기서 전체 레이어 트리 JSON 을 받았는데, 그림
+   * 1장이 4.77MB 면 그 JSON 이 6.6MB 라 편집마다 경계 복사와 `JSON.parse` 로 20 ms 가 나갔다.
+   * 좁은 질의는 같은 문서에서 309 bytes 다.
+   *
+   * 캐시로는 풀 수 없다 — 본문이 흐르면 그림이 그대로여도 bbox 가 움직인다. 그래서 질의를
+   * 좁히고, **바이트만** 신원 키별 object URL 로 캐시한다.
+   *
+   * 좁은 질의를 못 쓰는 경우(구형 WASM·합성 그림이 섞인 페이지·낡은 키)에는 종전 경로로
+   * 되돌아간다. 조용히 그림을 빠뜨리는 것보다 느린 게 낫다.
+   */
   private getFlowImagePaintOps(pageIdx: number): FlowImagePaintOp[] {
+    const narrowJson = this.wasm.getPageFlowImageOps(pageIdx);
+    if (narrowJson !== null) {
+      const images = flowImageOpsFromNarrowQuery(narrowJson, (key, mime) =>
+        this.flowImageUrls.urlFor(key, mime, (k) => this.wasm.getSourceImageBytes(k)),
+      );
+      if (images !== null) return images;
+    }
+
     let json: string;
     try {
       json = this.wasm.getPageLayerTree(pageIdx);
@@ -1128,6 +1161,7 @@ export class PageRenderer {
     this.prefetchRequestTokens.clear();
     this.layerSummaryCache.clear();
     this.canvaskitDiagnosticsByPage.clear();
+    this.flowImageUrls.releaseAll();
     this.canvaskitRenderer = null;
   }
 }

--- a/rhwp-studio/tests/issue-3315-flow-image-narrow-query.test.ts
+++ b/rhwp-studio/tests/issue-3315-flow-image-narrow-query.test.ts
@@ -1,0 +1,164 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  collectFlowImagePaintOps,
+  flowImageOpsFromNarrowQuery,
+} from '../src/view/flow-image-clip.ts';
+import { FlowImageUrlCache } from '../src/view/flow-image-url-cache.ts';
+
+// [#3315] 좁은 질의 경로와 전체 트리 경로는 같은 `FlowImagePaintOp` 를 내는 두 생산자다.
+// 둘이 어긋나면 화면이 갈리므로, 여기서는 ①필드 옮김이 맞는지 ②쓸 수 없을 때 부분 결과를
+// 내놓지 않고 전부 포기하는지를 고정한다. Rust 쪽 등가성은
+// tests/issue_3315_flow_image_narrow_query.rs 가 실문서로 잡는다.
+
+const narrowResponse = (overrides: Record<string, unknown> = {}) => JSON.stringify({
+  cacheable: true,
+  images: [
+    {
+      bbox: { x: 10, y: 20, width: 30, height: 40 },
+      clip: { x: 12, y: 22, width: 20, height: 30 },
+      mime: 'image/png',
+      sourceImageKey: 'bin:0:1:src',
+      crop: { left: 0, top: 0, right: 100, bottom: 100 },
+      originalSizeHu: [4000, 3000],
+      effect: 'grayScale',
+      brightness: 10,
+      contrast: -10,
+      transform: { rotation: 90, horzFlip: true, vertFlip: false },
+      ...overrides,
+    },
+  ],
+});
+
+const resolveOk = (key: string) => `blob:${key}`;
+
+test('좁은 질의 응답을 FlowImagePaintOp 로 옮긴다', () => {
+  const images = flowImageOpsFromNarrowQuery(narrowResponse(), resolveOk);
+
+  assert.ok(images);
+  assert.equal(images.length, 1);
+  const image = images[0];
+  assert.deepEqual(image.bbox, { x: 10, y: 20, width: 30, height: 40 });
+  assert.deepEqual(image.clip, { x: 12, y: 22, width: 20, height: 30 });
+  assert.equal(image.src, 'blob:bin:0:1:src');
+  assert.deepEqual(image.crop, { left: 0, top: 0, right: 100, bottom: 100 });
+  assert.deepEqual(image.originalSizeHu, [4000, 3000]);
+  assert.equal(image.rotation, 90);
+  assert.equal(image.horzFlip, true);
+  assert.equal(image.vertFlip, false);
+  // 효과는 값으로 받아 studio 가 조립한다 — canvas 경로와 같은 문자열이어야 한다.
+  assert.equal(image.filter, 'grayscale(100%) brightness(1.1000) contrast(0.9000)');
+});
+
+test('전체 트리 경로는 data URL 을, 좁은 질의 경로는 키별 URL 을 같은 필드에 담는다', () => {
+  const fromTree = collectFlowImagePaintOps(
+    {
+      kind: 'leaf',
+      ops: [
+        { type: 'image', bbox: { x: 1, y: 2, width: 3, height: 4 }, mime: 'image/png', base64: 'AA==' },
+      ],
+    },
+    (op) => op.type === 'image',
+  );
+  assert.equal(fromTree[0].src, 'data:image/png;base64,AA==');
+
+  const fromNarrow = flowImageOpsFromNarrowQuery(narrowResponse(), resolveOk);
+  assert.ok(fromNarrow);
+  assert.match(fromNarrow[0].src, /^blob:/);
+});
+
+test('cacheable 이 아니면 이 경로를 쓰지 않는다', () => {
+  // 신원 키를 낼 수 없는 합성 그림이 섞인 페이지 — 바이트를 되찾을 방법이 없다.
+  const json = JSON.stringify({ cacheable: false, images: [] });
+  assert.equal(flowImageOpsFromNarrowQuery(json, resolveOk), null);
+});
+
+test('키 하나라도 못 풀면 전부 포기한다', () => {
+  // 부분 목록을 돌려주면 그림 몇 장이 조용히 사라진다 — 그건 느린 것보다 나쁘다.
+  const json = JSON.stringify({
+    cacheable: true,
+    images: [
+      { bbox: { x: 0, y: 0, width: 1, height: 1 }, mime: 'image/png', sourceImageKey: 'bin:0:1:src' },
+      { bbox: { x: 5, y: 5, width: 1, height: 1 }, mime: 'image/png', sourceImageKey: 'bin:0:2:src' },
+    ],
+  });
+  const resolveSecondFails = (key: string) => (key === 'bin:0:2:src' ? null : `blob:${key}`);
+  assert.equal(flowImageOpsFromNarrowQuery(json, resolveSecondFails), null);
+});
+
+test('형식이 어긋난 응답은 되돌림을 유발한다', () => {
+  for (const json of [
+    'not json',
+    'null',
+    '[]',
+    JSON.stringify({ cacheable: true }),
+    JSON.stringify({ cacheable: true, images: [null] }),
+    // bbox 없음
+    JSON.stringify({ cacheable: true, images: [{ mime: 'image/png', sourceImageKey: 'bin:0:1:src' }] }),
+    // 키 없음 — 바이트를 받을 수 없다
+    JSON.stringify({ cacheable: true, images: [{ bbox: { x: 0, y: 0, width: 1, height: 1 }, mime: 'image/png' }] }),
+  ]) {
+    assert.equal(flowImageOpsFromNarrowQuery(json, resolveOk), null, `되돌려야 한다: ${json}`);
+  }
+});
+
+test('빈 목록은 유효한 결과다 — 그림 없는 쪽에서 전체 트리를 받지 않는다', () => {
+  const images = flowImageOpsFromNarrowQuery(
+    JSON.stringify({ cacheable: true, images: [] }),
+    resolveOk,
+  );
+  assert.deepEqual(images, []);
+});
+
+// ── object URL 캐시 ──
+
+test('object URL 캐시는 키당 한 번만 바이트를 받는다', () => {
+  const revoked: string[] = [];
+  const created: string[] = [];
+  const originalCreate = globalThis.URL.createObjectURL;
+  const originalRevoke = globalThis.URL.revokeObjectURL;
+  let counter = 0;
+  globalThis.URL.createObjectURL = () => {
+    const url = `blob:stub/${++counter}`;
+    created.push(url);
+    return url;
+  };
+  globalThis.URL.revokeObjectURL = (url: string) => {
+    revoked.push(url);
+  };
+
+  try {
+    const cache = new FlowImageUrlCache();
+    let loads = 0;
+    const loadBytes = () => {
+      loads += 1;
+      return new Uint8Array([1, 2, 3]);
+    };
+
+    const first = cache.urlFor('bin:0:1:src', 'image/png', loadBytes);
+    const second = cache.urlFor('bin:0:1:src', 'image/png', loadBytes);
+    assert.equal(first, second, '같은 키는 같은 URL');
+    assert.equal(loads, 1, '바이트는 한 번만 받는다 — 편집마다 다시 받으면 캐시가 무의미하다');
+    assert.equal(cache.size, 1);
+    assert.equal(cache.has('bin:0:1:src'), true);
+
+    cache.urlFor('bin:0:2:src', 'image/png', loadBytes);
+    assert.equal(cache.size, 2);
+
+    cache.releaseAll();
+    assert.equal(cache.size, 0);
+    assert.deepEqual(revoked, created, '회수하지 않으면 문서를 갈아끼울 때마다 URL 이 쌓인다');
+  } finally {
+    globalThis.URL.createObjectURL = originalCreate;
+    globalThis.URL.revokeObjectURL = originalRevoke;
+  }
+});
+
+test('바이트를 받을 수 없으면 URL 을 만들지 않는다', () => {
+  const cache = new FlowImageUrlCache();
+  assert.equal(cache.urlFor('bin:9:1:src', 'image/png', () => null), null);
+  // 빈 바이트도 그림이 될 수 없다 — 캐시에 남겨 두면 다음 조회가 빈 URL 을 재사용한다.
+  assert.equal(cache.urlFor('bin:9:2:src', 'image/png', () => new Uint8Array()), null);
+  assert.equal(cache.size, 0);
+});

--- a/rhwp-studio/tests/render-backend.test.ts
+++ b/rhwp-studio/tests/render-backend.test.ts
@@ -428,9 +428,27 @@ test('PageRenderer splits flow static images before the first Canvas2D flow rend
   assert.doesNotMatch(source, /'flow-static',\s*layers,\s*allowReuse,\s*false/);
   assert.match(source, /createOrReuseFlowImageLayer\(/);
   assert.match(source, /usesDomFlowImages \? overlays\.rawSvgCount/);
-  assert.match(source, /element\.src = `data:\$\{image\.mime\};base64,\$\{image\.base64\}`/);
+  // [#3315] DOM <img> 는 생산자가 정한 src 를 그대로 쓴다 — 전체 트리 경로의 data URL 이든
+  // 좁은 질의 경로의 신원 키별 object URL 이든 조립부는 분기하지 않는다.
+  assert.match(source, /element\.src = image\.src/);
   assert.match(source, /HWP_UNITS_PER_CSS_PIXEL = 75/);
   assert.match(source, /applyFlowImageCrop\(element, image, displayScale\)/);
+});
+
+// [#3315] 편집마다 전체 레이어 트리(그림 1장에 6.6MB)를 받던 자리를 좁은 질의가 대체한다.
+// 못 쓰는 경우에는 반드시 종전 경로로 되돌아가야 한다 — 조용히 그림을 빠뜨리면 안 된다.
+test('PageRenderer prefers the narrow flow-image query and keeps the full-tree fallback', () => {
+  const source = readFileSync(new URL('../src/view/page-renderer.ts', import.meta.url), 'utf8');
+  assert.match(source, /this\.wasm\.getPageFlowImageOps\(pageIdx\)/);
+  assert.match(source, /flowImageOpsFromNarrowQuery\(/);
+  assert.match(source, /this\.wasm\.getSourceImageBytes\(k\)/);
+  // fallback 경로가 남아 있어야 한다.
+  assert.match(source, /this\.wasm\.getPageLayerTree\(pageIdx\)/);
+  assert.match(source, /collectFlowImagePaintOps\(/);
+  // object URL 은 문서를 갈아끼울 때와 정리할 때 회수한다.
+  assert.match(source, /private flowImageUrls = new FlowImageUrlCache\(\)/);
+  const releaseSites = source.match(/this\.flowImageUrls\.releaseAll\(\)/g) ?? [];
+  assert.equal(releaseSites.length, 2, 'invalidateDocumentRevision 과 dispose 두 곳에서 회수');
 });
 
 test('PageRenderer deferred image rerender preserves static layer reuse policy', () => {

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -1373,11 +1373,28 @@ impl DocumentCore {
         page_num: u32,
         profile: RenderProfile,
     ) -> Result<String, HwpError> {
+        self.get_page_layer_tree_with_options_native(
+            page_num,
+            profile,
+            crate::paint::LayerJsonOptions::default(),
+        )
+    }
+
+    /// [Task #3315] `options` 로 그림 base64 생략을 켤 수 있는 레이어 트리 JSON.
+    ///
+    /// 생략본과 종전 JSON 은 **서로 다른 캐시 변형**이다 — 같은 슬롯을 쓰면 한쪽 소비자가
+    /// 다른 쪽 모양을 받는다. 그래서 아래 지문에 생략 여부를 함께 접는다.
+    pub fn get_page_layer_tree_with_options_native(
+        &self,
+        page_num: u32,
+        profile: RenderProfile,
+        options: crate::paint::LayerJsonOptions,
+    ) -> Result<String, HwpError> {
         // [Task #2222] 직렬화 JSON 캐시 — 트리 캐시(#2227 with_page_tree_cached)가
         // 있어도 1MB 급 재직렬화가 renderPage 마다 렌더 비용과 맞먹게 반복된다
         // (주보 p2 실측: 15.2ms/회, JSON 1.05MB). 출력옵션 지문이 다르면 미스.
         let idx = page_num as usize;
-        let fp = self.layer_output_options_fingerprint(profile);
+        let fp = self.layer_output_options_fingerprint(profile, options);
         if let Some(variants) = self.layer_tree_json_cache.borrow().get(idx) {
             if let Some((_, json)) = variants.iter().find(|(f, _)| *f == fp) {
                 return Ok(json.clone());
@@ -1385,7 +1402,7 @@ impl DocumentCore {
         }
         let json = self
             .build_page_layer_tree_with_profile(page_num, profile)?
-            .to_json();
+            .to_json_with_options(options);
         {
             // 토글(투명선/잘림보기 등) 왕복이 매번 미스가 되지 않도록 페이지당
             // 옵션 변형 4개까지 보관 (초과 시 가장 오래된 변형 제거).
@@ -1404,7 +1421,12 @@ impl DocumentCore {
     }
 
     /// [Task #2222] 레이어 출력옵션 5종과 profile의 비트 지문 — JSON 캐시 키.
-    fn layer_output_options_fingerprint(&self, profile: RenderProfile) -> u8 {
+    /// [Task #3315] 그림 바이트 생략 여부를 최상위 비트에 함께 접는다.
+    fn layer_output_options_fingerprint(
+        &self,
+        profile: RenderProfile,
+        options: crate::paint::LayerJsonOptions,
+    ) -> u8 {
         let profile_bits = match profile {
             RenderProfile::FastPreview => 0,
             RenderProfile::Screen => 1,
@@ -1417,6 +1439,7 @@ impl DocumentCore {
             | (u8::from(self.clip_enabled) << 3)
             | (u8::from(self.debug_overlay) << 4)
             | (profile_bits << 5)
+            | (u8::from(options.omit_image_bytes) << 7)
     }
 
     /// 페이지가 그리는 그림들의 신원 키만 작은 JSON 으로 반환한다 (Task #3315).
@@ -1470,6 +1493,32 @@ impl DocumentCore {
         }
         buf.push_str("]}");
         Ok(buf)
+    }
+
+    /// 그림 신원 키로 그 op 이 내보내는 바이트와 mime 을 되돌려준다 (Task #3315).
+    ///
+    /// `get_page_layer_tree_with_options_native` 가 base64 를 생략했을 때 소비자가 바이트를
+    /// 받는 경로다. 반환값은 인라인 base64 가 담고 있던 것과 **같은 바이트여야** 하므로 변환은
+    /// JSON 경로와 같은 `emitted_image_bytes` 를 쓴다 — 사본을 두면 두 경로가 갈라진다.
+    ///
+    /// 키의 epoch 가 현재 문서 세대와 다르면 `None` 이다. 스냅샷 복원처럼 id→바이트 대응이
+    /// 깨지는 연산 뒤에 옛 키로 물어본 경우이므로, 낡은 바이트를 주는 대신 소비자가 트리를
+    /// 다시 받게 한다.
+    ///
+    /// 세션에 삽입한 그림은 `load_shared()` 가 같은 할당을 돌려주지만(#3411), 파일에서 읽은
+    /// `Loaded` 바이트는 여기서 한 벌 복사된다. 이 조회는 페이지의 그림이 바뀔 때만 불리므로
+    /// 키 입력마다 도는 경로가 아니다.
+    pub fn get_source_image_bytes_native(&self, key: &str) -> Option<(&'static str, Vec<u8>)> {
+        let (epoch, bin_data_id, variant) = crate::paint::parse_source_image_key(key)?;
+        if epoch != self.bin_data_epoch {
+            return None;
+        }
+        let content =
+            crate::renderer::layout::find_bin_data(&self.document.bin_data_content, bin_data_id)?;
+        let data = content.data.load_shared();
+        let (mime, bytes) =
+            crate::renderer::image_resolver::emitted_image_bytes(&data, variant.bakes_watermark());
+        Some((mime, bytes.into_owned()))
     }
 
     /// 페이지 overlay 이미지와 replay-plane summary만 작은 JSON으로 반환한다.

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -1521,6 +1521,222 @@ impl DocumentCore {
         Some((mime, bytes.into_owned()))
     }
 
+    /// 본문(flow) 그림의 **배치 정보만** 작은 JSON 으로 반환한다 (Task #3315).
+    ///
+    /// studio 는 flow 그림을 DOM `<img>` 로 내보내려고 편집마다 전체 레이어 트리 JSON 을
+    /// 받아 왔다(`getFlowImagePaintOps`). 그림 1장이 4.77MB 면 그 JSON 이 6.6MB 라, 경계
+    /// 복사와 `JSON.parse` 만으로 키 입력당 20 ms 가 나갔다.
+    ///
+    /// 캐시로는 풀 수 없는 문제다 — 본문이 흐르면 그림 bbox 가 움직이므로 그림이 그대로여도
+    /// 결과가 달라진다. 그래서 캐시가 아니라 **질의를 좁힌다**: 바이트를 빼고 bbox·clip·
+    /// 효과·신원 키만 준다. 바이트는 `get_source_image_bytes_native(key)` 로 그림이 바뀔 때만
+    /// 따로 받는다.
+    ///
+    /// `clip` 은 조상 `ClipRect` 를 교차해 접은 값이다. 소비자가 트리 없이도 같은 잘림을
+    /// 재현할 수 있어야 하므로, 계보를 넘기는 대신 결과만 준다. 교차가 비면 그 그림은 보이지
+    /// 않으므로 목록에서 빠진다.
+    ///
+    /// `sourceImageKey` 를 낼 수 없는 그림(`bin_data_id == 0` 합성 그림)이 하나라도 있으면
+    /// `cacheable:false` 다 — 소비자는 그 페이지에 한해 종전의 전체 트리 경로로 되돌아가야
+    /// 한다. 키가 없으면 바이트를 받을 방법이 없기 때문이다.
+    pub fn get_page_flow_image_ops_native(&self, page_num: u32) -> Result<String, HwpError> {
+        use crate::paint::{
+            paint_op_replay_plane_with_layer, LayerNode, LayerNodeKind, PaintOp, PaintReplayPlane,
+        };
+        use crate::renderer::render_tree::{BoundingBox, RenderLayerInfo};
+
+        fn intersect(first: Option<BoundingBox>, second: BoundingBox) -> Option<BoundingBox> {
+            let Some(first) = first else {
+                return Some(second);
+            };
+            let left = first.x.max(second.x);
+            let top = first.y.max(second.y);
+            let right = (first.x + first.width).min(second.x + second.width);
+            let bottom = (first.y + first.height).min(second.y + second.height);
+            if right <= left || bottom <= top {
+                return None;
+            }
+            Some(BoundingBox {
+                x: left,
+                y: top,
+                width: right - left,
+                height: bottom - top,
+            })
+        }
+
+        fn write_bbox(buf: &mut String, bbox: BoundingBox) {
+            let _ = write!(
+                buf,
+                "{{\"x\":{:.3},\"y\":{:.3},\"width\":{:.3},\"height\":{:.3}}}",
+                bbox.x, bbox.y, bbox.width, bbox.height
+            );
+        }
+
+        struct Collector {
+            images: String,
+            epoch: u32,
+            cacheable: bool,
+        }
+
+        impl Collector {
+            fn visit(
+                &mut self,
+                node: &LayerNode,
+                inherited_layer: Option<RenderLayerInfo>,
+                clip: Option<BoundingBox>,
+            ) {
+                let active_layer = node.layer.or(inherited_layer);
+                match &node.kind {
+                    LayerNodeKind::Group { children, .. } => {
+                        for child in children {
+                            self.visit(child, active_layer, clip);
+                        }
+                    }
+                    LayerNodeKind::ClipRect {
+                        child,
+                        clip: node_clip,
+                        ..
+                    } => {
+                        // 교차가 비면 이 아래는 전부 보이지 않는다 — 내려가지 않는다.
+                        if let Some(next) = intersect(clip, *node_clip) {
+                            self.visit(child, active_layer, Some(next));
+                        }
+                    }
+                    LayerNodeKind::Leaf { ops } => {
+                        for op in ops {
+                            let PaintOp::Image {
+                                bbox,
+                                image,
+                                resolved,
+                            } = op
+                            else {
+                                continue;
+                            };
+                            if paint_op_replay_plane_with_layer(op, active_layer)
+                                != PaintReplayPlane::Flow
+                            {
+                                continue;
+                            }
+                            let Some(data) = image.data.as_deref() else {
+                                continue;
+                            };
+                            // 보이는 영역이 없으면 소비자가 그릴 것도 없다.
+                            let Some(visible) = intersect(clip, *bbox) else {
+                                continue;
+                            };
+                            let key = crate::paint::source_image_key(self.epoch, image);
+                            if key.is_none() {
+                                self.cacheable = false;
+                            }
+                            self.write_image(
+                                *bbox,
+                                visible,
+                                clip,
+                                image,
+                                resolved.as_deref(),
+                                data,
+                                key,
+                            );
+                        }
+                    }
+                }
+            }
+
+            #[allow(clippy::too_many_arguments)]
+            fn write_image(
+                &mut self,
+                bbox: BoundingBox,
+                visible: BoundingBox,
+                clip: Option<BoundingBox>,
+                image: &crate::renderer::render_tree::ImageNode,
+                resolved: Option<&crate::paint::ResolvedImagePayload>,
+                data: &[u8],
+                key: Option<String>,
+            ) {
+                let buf = &mut self.images;
+                if !buf.is_empty() {
+                    buf.push(',');
+                }
+                buf.push_str("{\"bbox\":");
+                write_bbox(buf, bbox);
+                // 잘림이 실제로 그림을 자를 때만 싣는다 — 소비자가 wrapper 를 만들 조건과 같다.
+                if clip.is_some()
+                    && (visible.x != bbox.x
+                        || visible.y != bbox.y
+                        || visible.width != bbox.width
+                        || visible.height != bbox.height)
+                {
+                    buf.push_str(",\"clip\":");
+                    write_bbox(buf, visible);
+                }
+                let mime = crate::renderer::image_resolver::emitted_image_mime(
+                    data,
+                    resolved,
+                    crate::renderer::image_resolver::is_watermark_image(image),
+                );
+                let _ = write!(buf, ",\"mime\":\"{}\"", mime);
+                match key {
+                    Some(key) => {
+                        let _ = write!(
+                            buf,
+                            ",\"sourceImageKey\":\"{}\"",
+                            crate::document_core::helpers::json_escape(&key)
+                        );
+                    }
+                    None => buf.push_str(",\"sourceImageKey\":null"),
+                }
+                if let Some((left, top, right, bottom)) = image.crop {
+                    let _ = write!(
+                        buf,
+                        ",\"crop\":{{\"left\":{},\"top\":{},\"right\":{},\"bottom\":{}}}",
+                        left, top, right, bottom
+                    );
+                }
+                if let Some((width, height)) = image.original_size_hu {
+                    let _ = write!(buf, ",\"originalSizeHu\":[{},{}]", width, height);
+                }
+                // 효과는 값으로 넘긴다 — CSS filter 조립은 studio 의 `composeImageFilter` 가
+                // `web_canvas.rs::compose_image_filter` 와 맞춰 두었으므로 여기서 되풀이하지 않는다.
+                let _ = write!(
+                    buf,
+                    ",\"effect\":\"{}\",\"brightness\":{},\"contrast\":{}",
+                    match image.effect {
+                        crate::model::image::ImageEffect::RealPic => "realPic",
+                        crate::model::image::ImageEffect::GrayScale => "grayScale",
+                        crate::model::image::ImageEffect::BlackWhite => "blackWhite",
+                        crate::model::image::ImageEffect::Pattern8x8 => "pattern8x8",
+                    },
+                    image.brightness,
+                    image.contrast
+                );
+                if matches!(
+                    resolved.map(|payload| payload.kind),
+                    Some(crate::paint::ResolvedImageKind::BakedWatermark)
+                ) {
+                    buf.push_str(",\"bakedWatermark\":true");
+                }
+                let _ = write!(
+                    buf,
+                    ",\"transform\":{{\"rotation\":{:.3},\"horzFlip\":{},\"vertFlip\":{}}}}}",
+                    image.transform.rotation, image.transform.horz_flip, image.transform.vert_flip
+                );
+            }
+        }
+
+        let tree = self.build_page_layer_tree(page_num)?;
+        let mut collector = Collector {
+            images: String::new(),
+            epoch: self.bin_data_epoch,
+            cacheable: true,
+        };
+        collector.visit(&tree.root, None, None);
+
+        Ok(format!(
+            "{{\"cacheable\":{},\"images\":[{}]}}",
+            collector.cacheable, collector.images
+        ))
+    }
+
     /// 페이지 overlay 이미지와 replay-plane summary만 작은 JSON으로 반환한다.
     ///
     /// Studio는 BehindText/InFrontOfText 그림 overlay 계산을 위해 전체 PageLayerTree JSON을

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -68,13 +68,37 @@ const KNOWN_TEXT_FEATURES: &[&str] = &[
     "text.vertical.mixedPerGlyph",
 ];
 
+/// 레이어 트리 JSON 직렬화 옵션 (Task #3315).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct LayerJsonOptions {
+    /// 그림 바이트를 base64 로 싣지 않는다.
+    ///
+    /// `sourceImageKey` 를 낼 수 있는 op 만 대상이다 — 키가 없으면 소비자가 바이트를 되찾을
+    /// 길이 없으므로 그 op 은 종전대로 base64 를 싣는다. 기본값이 `false` 라서 이 옵션을
+    /// 지정하지 않는 기존 호출부의 JSON 은 한 바이트도 달라지지 않는다.
+    pub omit_image_bytes: bool,
+}
+
+/// 직렬화 도중 트리 아래로 흘려야 하는 값. 그림 op 하나를 쓰려면 문서 세대(키 발급)와
+/// 생략 여부가 함께 필요해 한 덩이로 옮겼다.
+#[derive(Debug, Clone, Copy)]
+struct JsonWriteContext {
+    bin_data_epoch: u32,
+    options: LayerJsonOptions,
+}
+
 impl PageLayerTree {
     pub fn to_json(&self) -> String {
+        self.to_json_with_options(LayerJsonOptions::default())
+    }
+
+    /// [Task #3315] 그림 base64 생략을 켤 수 있는 직렬화. `to_json()` 은 기본 옵션 위임이다.
+    pub fn to_json_with_options(&self, options: LayerJsonOptions) -> String {
         let mut buf = String::with_capacity(32_768);
         buf.push('{');
         let _ = write!(
             buf,
-            "\"schemaVersion\":{},\"schemaMinorVersion\":{},\"schema\":{{\"major\":{},\"minor\":{}}},\"resourceTableVersion\":{},\"resourceTableMinorVersion\":{},\"resourceTable\":{{\"major\":{},\"minor\":{}}},\"unit\":{},\"coordinateSystem\":{},\"profile\":{},\"buildOptions\":{{\"showTransparentBorders\":{},\"clipEnabled\":{}}},\"debugOptions\":{{\"debugOverlay\":{}}},\"outputOptions\":{{\"showParagraphMarks\":{},\"showControlCodes\":{},\"showTransparentBorders\":{},\"clipEnabled\":{},\"debugOverlay\":{}}},\"pageWidth\":{:.3},\"pageHeight\":{:.3},\"root\":",
+            "\"schemaVersion\":{},\"schemaMinorVersion\":{},\"schema\":{{\"major\":{},\"minor\":{}}},\"resourceTableVersion\":{},\"resourceTableMinorVersion\":{},\"resourceTable\":{{\"major\":{},\"minor\":{}}},\"unit\":{},\"coordinateSystem\":{},\"profile\":{},\"imageBytes\":{},\"buildOptions\":{{\"showTransparentBorders\":{},\"clipEnabled\":{}}},\"debugOptions\":{{\"debugOverlay\":{}}},\"outputOptions\":{{\"showParagraphMarks\":{},\"showControlCodes\":{},\"showTransparentBorders\":{},\"clipEnabled\":{},\"debugOverlay\":{}}},\"pageWidth\":{:.3},\"pageHeight\":{:.3},\"root\":",
             LAYER_TREE_SCHEMA.schema_version,
             LAYER_TREE_SCHEMA.schema_minor_version,
             LAYER_TREE_SCHEMA.schema_version,
@@ -86,6 +110,13 @@ impl PageLayerTree {
             json_escape(LAYER_TREE_SCHEMA.unit),
             json_escape(LAYER_TREE_SCHEMA.coordinate_system),
             json_escape(render_profile_str(self.profile)),
+            // [#3315] 그림 바이트가 op 안에 있는지(`inline`), 키로 따로 받아야 하는지(`byKey`).
+            // 소비자가 op 마다 `base64` 유무를 추측하지 않고 문서 단위로 판정할 수 있게 한다.
+            json_escape(if options.omit_image_bytes {
+                "byKey"
+            } else {
+                "inline"
+            }),
             self.output_options.show_transparent_borders,
             self.output_options.clip_enabled,
             self.output_options.debug_overlay,
@@ -102,7 +133,10 @@ impl PageLayerTree {
             &mut buf,
             &mut text_source_state,
             &self.resources,
-            self.resources.source_image_epoch(),
+            JsonWriteContext {
+                bin_data_epoch: self.resources.source_image_epoch(),
+                options,
+            },
         );
         buf.push_str(",\"textSources\":");
         write_text_source_entries(&mut buf, &self.text_sources);
@@ -382,7 +416,7 @@ impl LayerNode {
         buf: &mut String,
         text_sources: &mut TextSourceExportState,
         resources: &ResourceArena,
-        bin_data_epoch: u32,
+        ctx: JsonWriteContext,
     ) {
         buf.push('{');
         buf.push_str("\"bounds\":");
@@ -412,7 +446,7 @@ impl LayerNode {
                     if idx > 0 {
                         buf.push(',');
                     }
-                    child.write_json(buf, text_sources, resources, bin_data_epoch);
+                    child.write_json(buf, text_sources, resources, ctx);
                 }
                 buf.push(']');
             }
@@ -429,7 +463,7 @@ impl LayerNode {
                     json_escape(clip_kind_str(*clip_kind))
                 );
                 buf.push_str(",\"child\":");
-                child.write_json(buf, text_sources, resources, bin_data_epoch);
+                child.write_json(buf, text_sources, resources, ctx);
             }
             LayerNodeKind::Leaf { ops } => {
                 buf.push_str(",\"kind\":\"leaf\",\"ops\":[");
@@ -438,7 +472,7 @@ impl LayerNode {
                     if idx > 0 {
                         buf.push(',');
                     }
-                    op.write_json(buf, text_sources, &leaf_visuals, resources, bin_data_epoch);
+                    op.write_json(buf, text_sources, &leaf_visuals, resources, ctx);
                 }
                 buf.push(']');
             }
@@ -454,7 +488,7 @@ impl PaintOp {
         text_sources: &mut TextSourceExportState,
         leaf_visuals: &LeafTextVisualOps,
         resources: &ResourceArena,
-        bin_data_epoch: u32,
+        ctx: JsonWriteContext,
     ) {
         match self {
             PaintOp::PageBackground { bbox, background } => {
@@ -834,47 +868,47 @@ impl PaintOp {
                 buf.push('{');
                 buf.push_str("\"type\":\"image\",\"bbox\":");
                 write_bbox(buf, *bbox);
+                // [#3315] 키가 있는 op 만 base64 를 생략할 수 있다 — 소비자가 그 키로
+                // `getSourceImageBytes` 를 불러 같은 바이트를 받는다. 키를 낼 수 없는 합성
+                // 그림(`bin_data_id == 0`)은 되찾을 길이 없으므로 종전대로 싣는다.
+                let source_image_key = crate::paint::source_image_key(ctx.bin_data_epoch, image);
+                let omit_bytes = ctx.options.omit_image_bytes && source_image_key.is_some();
                 if let Some(payload) = resolved.as_deref() {
-                    let _ = write!(buf, ",\"mime\":\"{}\",\"base64\":", payload.mime);
-                    write_json_base64(buf, &payload.data[..]);
+                    if omit_bytes {
+                        let _ = write!(
+                            buf,
+                            ",\"mime\":\"{}\",\"imageBytesOmitted\":true",
+                            payload.mime
+                        );
+                    } else {
+                        let _ = write!(buf, ",\"mime\":\"{}\",\"base64\":", payload.mime);
+                        write_json_base64(buf, &payload.data[..]);
+                    }
                     if matches!(payload.kind, ResolvedImageKind::BakedWatermark) {
                         buf.push_str(",\"bakedWatermark\":true");
                     }
                 } else if let Some(data) = &image.data {
                     // Task #516 Stage 5.2: overlay layer 의 <img> data URL 생성용 mime 노출.
                     // PCX 등 비표준은 PNG 변환 후 emit (CLI SVG 와 동일 정책 적용).
-                    let mime = crate::renderer::svg::detect_image_mime_type(data);
-                    let (final_mime, final_data): (&str, std::borrow::Cow<[u8]>) = if mime
-                        == "image/x-pcx"
-                    {
-                        match crate::renderer::svg::pcx_bytes_to_png_bytes(data) {
-                            Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
-                            None => (mime, std::borrow::Cow::Borrowed(&data[..])),
-                        }
-                    } else if mime == "image/bmp" {
-                        match crate::renderer::svg::bmp_bytes_to_png_bytes(data) {
-                            Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
-                            None => (mime, std::borrow::Cow::Borrowed(&data[..])),
-                        }
-                    } else if mime == "image/tiff" {
-                        match crate::renderer::image_resolver::tiff_bytes_to_png_bytes(data) {
-                            Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
-                            None => (mime, std::borrow::Cow::Borrowed(&data[..])),
-                        }
-                    } else if mime == "image/jpeg" {
-                        match crate::renderer::image_resolver::grayscale_jpeg_bytes_to_png_bytes(
+                    // [#3315] 변환 사슬의 단일 권위는 `emitted_image_bytes` 다 — 키로 바이트를
+                    // 되돌려주는 경로가 같은 함수를 써야 두 결과가 갈라지지 않는다.
+                    let (final_mime, final_data) =
+                        crate::renderer::image_resolver::emitted_image_bytes(
                             data,
-                        ) {
-                            Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
-                            None => (mime, std::borrow::Cow::Borrowed(&data[..])),
-                        }
+                            crate::renderer::image_resolver::is_watermark_image(image),
+                        );
+                    if omit_bytes {
+                        let _ = write!(
+                            buf,
+                            ",\"mime\":\"{}\",\"imageBytesOmitted\":true",
+                            final_mime
+                        );
                     } else {
-                        (mime, std::borrow::Cow::Borrowed(&data[..]))
-                    };
-                    let _ = write!(buf, ",\"mime\":\"{}\",\"base64\":", final_mime);
-                    write_json_base64(buf, &final_data);
+                        let _ = write!(buf, ",\"mime\":\"{}\",\"base64\":", final_mime);
+                        write_json_base64(buf, &final_data);
+                    }
                 }
-                if let Some(key) = crate::paint::source_image_key(bin_data_epoch, image) {
+                if let Some(key) = source_image_key {
                     let _ = write!(buf, ",\"sourceImageKey\":{}", json_escape(&key));
                 }
                 if let Some(fill_mode) = image.fill_mode {
@@ -4290,7 +4324,11 @@ mod tests {
 
         let json = tree.to_json();
 
-        assert!(json.contains("\"schemaMinorVersion\":20"));
+        // 상수에서 끌어온다 — 숫자를 박아 두면 schema minor 를 올릴 때마다 무관한 테스트가 깨진다.
+        assert!(json.contains(&format!(
+            "\"schemaMinorVersion\":{}",
+            LAYER_TREE_SCHEMA.schema_minor_version
+        )));
         assert!(json.contains("\"payloadResourceKey\":\"glyphPayload:bitmapGlyph:imageRef:0"));
         assert!(json.contains("placement:0.123,0.568,10.988,10.543"));
         assert!(json.contains(&format!(":resource:{image_resource_key}\"")));

--- a/src/paint/mod.rs
+++ b/src/paint/mod.rs
@@ -32,6 +32,7 @@ pub use font_glyph::{
     FontBitmapGlyphDecodeError, FontBitmapGlyphDecodeOptions, FontGlyphLoweringReport,
     FontSvgGlyphDecodeError, FontSvgGlyphDecodeOptions,
 };
+pub use json::LayerJsonOptions;
 pub use layer_tree::{
     CacheHint, ClipKind, GroupKind, LayerNode, LayerNodeKind, LayerOutputOptions, PageLayerTree,
     TextSourceAnnotation, TextSourceEntry, TextSourceId, TextSourceRange, TextSourceSpan,
@@ -57,9 +58,9 @@ pub use replay_order::{
     PaintReplayPlane,
 };
 pub use resources::{
-    font_blob_resource_key, image_resource_key, resource_digest_hex, source_image_key,
-    svg_resource_key, FontBlobResourceId, ImageResourceId, ResourceArena, SvgResourceId,
-    RESOURCE_KEY_ALGORITHM,
+    font_blob_resource_key, image_resource_key, parse_source_image_key, resource_digest_hex,
+    source_image_key, svg_resource_key, FontBlobResourceId, ImageResourceId, ResourceArena,
+    SourceImageVariant, SvgResourceId, RESOURCE_KEY_ALGORITHM,
 };
 pub use schema::{
     LayerTreeSchema, LAYER_TREE_SCHEMA, PAGE_LAYER_TREE_COORDINATE_SYSTEM,

--- a/src/paint/resources.rs
+++ b/src/paint/resources.rs
@@ -269,15 +269,66 @@ pub fn source_image_key(
         return None;
     }
 
+    // 술어는 `image_resolver::is_watermark_image` 가 단일 권위다 — 여기서 사본을 들면
+    // 키가 가리키는 바이트와 실제로 내보내는 바이트가 조용히 갈라진다 (#3315).
     let bakes_watermark = crate::renderer::image_resolver::detect_image_mime_type(data)
         == "image/jpeg"
-        && !matches!(image.effect, crate::model::image::ImageEffect::RealPic)
-        && (image.brightness != 0 || image.contrast != 0);
-    let variant = if bakes_watermark { "wmpng" } else { "src" };
+        && crate::renderer::image_resolver::is_watermark_image(image);
+    let variant = if bakes_watermark {
+        SourceImageVariant::BakedWatermarkPng
+    } else {
+        SourceImageVariant::Source
+    };
     Some(format!(
-        "bin:{bin_data_epoch}:{}:{variant}",
-        image.bin_data_id
+        "bin:{bin_data_epoch}:{}:{}",
+        image.bin_data_id,
+        variant.as_str()
     ))
+}
+
+/// `source_image_key` 의 variant — 같은 원본에서 다른 바이트가 나오는 갈림 (Task #3315).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceImageVariant {
+    /// 원본 바이트. 브라우저가 못 읽는 포맷(BMP/PCX/TIFF/회색 JPEG)이면 PNG 변환까지.
+    Source,
+    /// JPEG 워터마크를 한컴 규칙으로 bake 한 PNG.
+    BakedWatermarkPng,
+}
+
+impl SourceImageVariant {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SourceImageVariant::Source => "src",
+            SourceImageVariant::BakedWatermarkPng => "wmpng",
+        }
+    }
+
+    pub fn bakes_watermark(self) -> bool {
+        matches!(self, SourceImageVariant::BakedWatermarkPng)
+    }
+}
+
+/// `source_image_key` 가 만든 키를 되읽는다 (Task #3315).
+///
+/// 발급과 해석을 같은 모듈에 묶는다 — 소비자가 문자열을 직접 쪼개게 두면 접두어나 variant
+/// 를 바꿀 때 조용히 어긋난다. 모르는 variant 는 받아들이지 않는다: `src` 로 넘겨 버리면
+/// 워터마크 그림에 원본 JPEG 을 돌려주고도 성공한 것처럼 보인다.
+pub fn parse_source_image_key(key: &str) -> Option<(u32, u16, SourceImageVariant)> {
+    let mut parts = key.split(':');
+    if parts.next()? != "bin" {
+        return None;
+    }
+    let epoch = parts.next()?.parse::<u32>().ok()?;
+    let bin_data_id = parts.next()?.parse::<u16>().ok()?;
+    let variant = match parts.next()? {
+        "src" => SourceImageVariant::Source,
+        "wmpng" => SourceImageVariant::BakedWatermarkPng,
+        _ => return None,
+    };
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((epoch, bin_data_id, variant))
 }
 
 pub fn svg_resource_key(byte_len: usize, digest: &str) -> String {

--- a/src/paint/schema.rs
+++ b/src/paint/schema.rs
@@ -15,7 +15,9 @@ pub struct LayerTreeSchema {
 
 pub const LAYER_TREE_SCHEMA: LayerTreeSchema = LayerTreeSchema {
     schema_version: 1,
-    schema_minor_version: 20,
+    // 21: [#3315] 문서 단위 `imageBytes`("inline"|"byKey")와 그림 op 의 `imageBytesOmitted`.
+    //     생략은 opt-in 이라 기존 소비자가 받는 JSON 은 종전과 같다.
+    schema_minor_version: 21,
     resource_table_version: 1,
     resource_table_minor_version: 5,
     unit: "px",

--- a/src/renderer/image_resolver.rs
+++ b/src/renderer/image_resolver.rs
@@ -167,6 +167,37 @@ pub(crate) fn resolve_image_payload(image: &ImageNode) -> Option<ResolvedImagePa
     }
 }
 
+/// 그림 op 이 실제로 내보내는 바이트와 mime 을 결정한다 (Task #3315).
+///
+/// `resolve_image_payload` 는 변환에 **성공한** 경우만 payload 를 주고, 실패하면 `None` 이라
+/// 호출부가 원본 바이트로 되돌아간다. 그래서 "JSON 에 실린 바이트"는 두 분기의 합이었고,
+/// `paint/json.rs` 가 그 되돌림 사슬을 사본으로 들고 있었다. base64 를 생략한 뒤 키로 같은
+/// 바이트를 되돌려주려면 **최종 결과가 한 곳에서만 정해져야** 한다 — 두 곳에 두면 갈라진다.
+///
+/// `bakes_watermark` 는 `paint::source_image_key` 의 variant 판정과 같은 값이다. 키가 이미
+/// variant 를 담고 있으므로 키로 조회할 때는 `ImageNode` 없이도 같은 바이트를 재현한다.
+/// 워터마크 bake 가 실패하면 회색 JPEG 경로로 내려가는데, 이는 `resolved == None` 일 때
+/// json 쪽 되돌림이 하던 것과 같은 순서다.
+pub(crate) fn emitted_image_bytes(
+    data: &[u8],
+    bakes_watermark: bool,
+) -> (&'static str, std::borrow::Cow<'_, [u8]>) {
+    let mime = detect_image_mime_type(data);
+    let converted = match mime {
+        "image/bmp" => bmp_bytes_to_png_bytes(data),
+        "image/x-pcx" => pcx_bytes_to_png_bytes(data),
+        "image/tiff" => tiff_bytes_to_png_bytes(data),
+        "image/jpeg" if bakes_watermark => watermark_jpeg_bytes_to_hancom_baked_png_bytes(data)
+            .or_else(|| grayscale_jpeg_bytes_to_png_bytes(data)),
+        "image/jpeg" => grayscale_jpeg_bytes_to_png_bytes(data),
+        _ => None,
+    };
+    match converted {
+        Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
+        None => (mime, std::borrow::Cow::Borrowed(data)),
+    }
+}
+
 pub(crate) fn image_node_with_resolved_payload(
     image: &ImageNode,
     resolved: Option<&ResolvedImagePayload>,
@@ -183,7 +214,11 @@ pub(crate) fn image_node_with_resolved_payload(
     image
 }
 
-fn is_watermark_image(image: &ImageNode) -> bool {
+/// 워터마크 bake 대상 판정. `paint::source_image_key` 의 variant 결정과 같은 술어를 써야
+/// 키가 가리키는 바이트와 실제로 내보내는 바이트가 어긋나지 않는다 (Task #3315).
+///
+/// mime 검사는 포함하지 않는다 — 호출부가 JPEG 분기 안에서 쓴다.
+pub(crate) fn is_watermark_image(image: &ImageNode) -> bool {
     !matches!(image.effect, ImageEffect::RealPic) && (image.brightness != 0 || image.contrast != 0)
 }
 

--- a/src/renderer/image_resolver.rs
+++ b/src/renderer/image_resolver.rs
@@ -198,6 +198,27 @@ pub(crate) fn emitted_image_bytes(
     }
 }
 
+/// 그림 op 이 내보내는 mime 만 (Task #3315).
+///
+/// 바이트가 필요 없는 소비자 — 배치 정보만 주는 좁은 질의 — 를 위한 것이다. `resolved` 가
+/// 붙어 있으면 그 mime 이 최종값이므로 변환을 다시 돌지 않는다. 큰 JPEG 은 메모 키 해싱만으로
+/// 3.7MB 당 1.35 ms 라, 매 편집에 도는 경로에서는 이 절약이 그대로 이득이다.
+///
+/// `resolved` 가 없을 때 "그러면 변환이 실패했다는 뜻이니 원본 mime 이다" 로 단축하지 않고
+/// `emitted_image_bytes` 에 위임한다. 그 전제는 `paint/builder.rs` 가 트리를 만들 때만
+/// 성립하고, 직접 조립한 `PaintOp::Image { resolved: None }` 에는 성립하지 않는다 — 구조가
+/// 보장하지 않는 불변식에 기대면 조용히 갈라진다.
+pub(crate) fn emitted_image_mime(
+    data: &[u8],
+    resolved: Option<&ResolvedImagePayload>,
+    bakes_watermark: bool,
+) -> &'static str {
+    match resolved {
+        Some(payload) => payload.mime,
+        None => emitted_image_bytes(data, bakes_watermark).0,
+    }
+}
+
 pub(crate) fn image_node_with_resolved_payload(
     image: &ImageNode,
     resolved: Option<&ResolvedImagePayload>,

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -812,6 +812,16 @@ impl HwpDocument {
             .map_err(|e| e.into())
     }
 
+    /// 본문(flow) 그림의 배치 정보만 작은 JSON 으로 반환한다 (Task #3315).
+    ///
+    /// 전체 레이어 트리를 받아 flow 그림을 걸러내던 studio 경로를 대체한다. 바이트는 빠져
+    /// 있고 `sourceImageKey` 로 `getSourceImageBytes` 를 부르면 된다.
+    #[wasm_bindgen(js_name = getPageFlowImageOps)]
+    pub fn get_page_flow_image_ops(&self, page_num: u32) -> Result<String, JsValue> {
+        self.get_page_flow_image_ops_native(page_num)
+            .map_err(|e| e.into())
+    }
+
     /// 그림 신원 키로 바이트를 Uint8Array 로 반환한다 (Task #3315).
     ///
     /// `getPageLayerTreeWithProfile(page, profile, true)` 로 base64 를 생략했을 때 바이트를

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -181,11 +181,16 @@ fn get_page_layer_tree_with_profile_impl(
     document: &HwpDocument,
     page_num: u32,
     profile: &str,
+    omit_image_bytes: bool,
 ) -> Result<String, JsValue> {
     let profile = crate::paint::RenderProfile::parse(profile)
         .ok_or_else(|| JsValue::from_str(&format!("unsupported render profile: {profile}")))?;
     document
-        .get_page_layer_tree_with_profile_native(page_num, profile)
+        .get_page_layer_tree_with_options_native(
+            page_num,
+            profile,
+            crate::paint::LayerJsonOptions { omit_image_bytes },
+        )
         .map_err(|error| error.into())
 }
 
@@ -713,19 +718,26 @@ impl HwpDocument {
             .map_err(|e| e.into())
     }
 
+    /// 페이지 레이어 트리를 profile 별로 반환한다.
+    ///
+    /// [Task #3315] `omit_image_bytes` 를 `true` 로 주면 그림 base64 를 싣지 않고
+    /// `sourceImageKey` 만 남긴다 — 바이트는 `getSourceImageBytes(key)` 로 따로 받는다.
+    /// 인자를 생략하면(`undefined`) 종전과 똑같은 JSON 이므로 기존 호출부는 영향이 없다.
     #[wasm_bindgen(js_name = getPageLayerTreeWithProfile)]
     pub fn get_page_layer_tree_with_profile(
         &self,
         page_num: u32,
         profile: &str,
+        omit_image_bytes: Option<bool>,
     ) -> Result<String, JsValue> {
+        let omit_image_bytes = omit_image_bytes.unwrap_or(false);
         #[cfg(feature = "subsecond-dev")]
         {
             let mut hot = subsecond::HotFn::current(get_page_layer_tree_with_profile_impl);
-            return hot.call((self, page_num, profile));
+            return hot.call((self, page_num, profile, omit_image_bytes));
         }
         #[cfg(not(feature = "subsecond-dev"))]
-        get_page_layer_tree_with_profile_impl(self, page_num, profile)
+        get_page_layer_tree_with_profile_impl(self, page_num, profile, omit_image_bytes)
     }
 
     #[cfg(all(feature = "subsecond-dev", target_arch = "wasm32"))]
@@ -798,6 +810,24 @@ impl HwpDocument {
     pub fn get_page_source_image_keys(&self, page_num: u32) -> Result<String, JsValue> {
         self.get_page_source_image_keys_native(page_num)
             .map_err(|e| e.into())
+    }
+
+    /// 그림 신원 키로 바이트를 Uint8Array 로 반환한다 (Task #3315).
+    ///
+    /// `getPageLayerTreeWithProfile(page, profile, true)` 로 base64 를 생략했을 때 바이트를
+    /// 받는 경로다. mime 은 레이어 트리의 그림 op 이 계속 싣고 있으므로 여기서 되풀이하지
+    /// 않는다.
+    ///
+    /// 키를 풀 수 없으면 던진다 — 세대가 바뀐 낡은 키이거나 없는 그림이다. 호출부는 잡아서
+    /// 레이어 트리를 다시 받는 쪽으로 되돌아가면 된다.
+    #[wasm_bindgen(js_name = getSourceImageBytes)]
+    pub fn get_source_image_bytes(&self, key: &str) -> Result<Vec<u8>, JsValue> {
+        match self.get_source_image_bytes_native(key) {
+            Some((_mime, bytes)) => Ok(bytes),
+            None => Err(JsValue::from_str(&format!(
+                "unresolvable source image key: {key}"
+            ))),
+        }
     }
 
     /// 페이지 정보를 JSON 문자열로 반환한다.

--- a/tests/issue_3315_flow_image_narrow_query.rs
+++ b/tests/issue_3315_flow_image_narrow_query.rs
@@ -1,0 +1,347 @@
+//! Task #3315: 본문(flow) 그림의 배치 정보만 받는 좁은 질의.
+//!
+//! studio 는 flow 그림을 DOM `<img>` 로 내보내려고 편집마다 전체 레이어 트리 JSON 을 받아
+//! 왔다. 이 질의가 그것을 대체하려면 **전체 트리에서 뽑아낸 것과 같은 것을 말해야** 한다 —
+//! 개수·순서·bbox·잘림·효과가 어긋나면 화면이 달라진다. 여기서 고정하는 것은 크기 이득이
+//! 아니라 그 일치다.
+//!
+//! 캐시가 아니라 질의를 좁힌 이유도 함께 고정한다: 본문이 흐르면 그림이 그대로여도 bbox 가
+//! 움직이므로 `(page, imageKeys)` 캐시로는 풀 수 없다.
+
+use serde_json::Value;
+
+/// 그림 op 의 replay plane — studio `layerPaintOpReplayPlane` 을 그대로 옮긴 것.
+///
+/// `layer.textWrap` 이 있으면 그것이 우선이고, 없을 때만 op 의 `wrap` 을 본다. `behindText`·
+/// `inFrontOfText` 만 flow 가 아니다 — `square` 같은 본문 배치 wrap 은 flow 다. 그리고
+/// 바탕쪽 유래 개체는 항상 본문 뒤로 눌린다(`capMasterPagePlane`).
+fn is_flow_image(op: &Value, layer: Option<&Value>) -> bool {
+    let master_page = layer
+        .and_then(|l| l.get("masterPage"))
+        .and_then(Value::as_bool)
+        == Some(true);
+    if master_page {
+        return false;
+    }
+    let wrap = match layer
+        .and_then(|l| l.get("textWrap"))
+        .and_then(Value::as_str)
+    {
+        Some(layer_wrap) => Some(layer_wrap),
+        None => op.get("wrap").and_then(Value::as_str),
+    };
+    !matches!(wrap, Some("behindText") | Some("inFrontOfText"))
+}
+
+/// 전체 레이어 트리에서 flow plane 그림 op 을 studio 의 `collectFlowImagePaintOps` 와 같은
+/// 계약으로 뽑는다 — pre-order, `layer` 상속, `clipRect` 조상 교차.
+fn collect_flow_images_from_tree<'a>(
+    node: &'a Value,
+    inherited_layer: Option<&'a Value>,
+    clip: Option<[f64; 4]>,
+    out: &mut Vec<Value>,
+) {
+    let active_layer = node.get("layer").or(inherited_layer);
+    let next_clip = if node.get("kind").and_then(Value::as_str) == Some("clipRect") {
+        match bbox_of(node.get("clip")) {
+            Some(node_clip) => match intersect(clip, node_clip) {
+                Some(next) => Some(next),
+                // 교차가 비면 이 아래는 보이지 않는다.
+                None => return,
+            },
+            None => clip,
+        }
+    } else {
+        clip
+    };
+
+    if let Some(ops) = node.get("ops").and_then(Value::as_array) {
+        for op in ops {
+            if op.get("type").and_then(Value::as_str) != Some("image") {
+                continue;
+            }
+            if !is_flow_image(op, active_layer) {
+                continue;
+            }
+            let Some(bbox) = bbox_of(op.get("bbox")) else {
+                continue;
+            };
+            if intersect(next_clip, bbox).is_none() {
+                continue;
+            }
+            out.push(op.clone());
+        }
+    }
+    if let Some(children) = node.get("children").and_then(Value::as_array) {
+        for child in children {
+            collect_flow_images_from_tree(child, active_layer, next_clip, out);
+        }
+    }
+    if let Some(child) = node.get("child") {
+        collect_flow_images_from_tree(child, active_layer, next_clip, out);
+    }
+}
+
+fn bbox_of(value: Option<&Value>) -> Option<[f64; 4]> {
+    let value = value?;
+    Some([
+        value.get("x")?.as_f64()?,
+        value.get("y")?.as_f64()?,
+        value.get("width")?.as_f64()?,
+        value.get("height")?.as_f64()?,
+    ])
+}
+
+fn intersect(first: Option<[f64; 4]>, second: [f64; 4]) -> Option<[f64; 4]> {
+    let Some(first) = first else {
+        return Some(second);
+    };
+    let left = first[0].max(second[0]);
+    let top = first[1].max(second[1]);
+    let right = (first[0] + first[2]).min(second[0] + second[2]);
+    let bottom = (first[1] + first[3]).min(second[1] + second[3]);
+    if right <= left || bottom <= top {
+        return None;
+    }
+    Some([left, top, right - left, bottom - top])
+}
+
+/// 본문 흐름에 실제로 얽힌 flow 그림이 있는 표본들.
+///
+/// `insert_picture_native` 로 넣은 그림은 (0,0) 에 고정된 부동 개체라 본문이 흘러도 움직이지
+/// 않는다 — 이 트랙이 다루는 "본문 인라인 그림"이 아니다. 그래서 등가성은 실문서로 잰다.
+const FLOW_IMAGE_SAMPLES: &[&str] = &[
+    "samples/143E433F503322BD33.hwp",
+    "samples/3-10월_교육_통합_2022.hwp",
+    "samples/20250130-hongbo.hwp",
+    "samples/3-09월_교육_통합_2023.hwpx",
+];
+
+fn open(relative: &str) -> rhwp::wasm_api::HwpDocument {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let bytes = std::fs::read(std::path::Path::new(repo_root).join(relative))
+        .unwrap_or_else(|error| panic!("read {relative}: {error}"));
+    rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .unwrap_or_else(|error| panic!("parse {relative}: {error:?}"))
+}
+
+/// 대형 JPEG 을 세션 중에 넣은 문서 — 크기 이득을 재는 데 쓴다.
+fn open_with_large_inserted_image() -> rhwp::wasm_api::HwpDocument {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let jpeg = std::fs::read(std::path::Path::new(repo_root).join("samples/images/tiger01.jpg"))
+        .expect("read tiger01.jpg");
+    let mut doc = open("samples/hwpx/issue_241.hwpx");
+    doc.insert_picture_native(
+        0,
+        0,
+        0,
+        &[],
+        &jpeg,
+        400,
+        300,
+        2400,
+        1800,
+        "jpg",
+        "tiger",
+        None,
+        None,
+    )
+    .expect("insert picture");
+    doc
+}
+
+fn narrow(doc: &rhwp::wasm_api::HwpDocument, page: u32) -> Value {
+    let json = doc
+        .get_page_flow_image_ops_native(page)
+        .expect("flow image ops");
+    serde_json::from_str(&json).expect("좁은 질의 JSON 이 유효해야 한다")
+}
+
+fn tree_flow_images(doc: &rhwp::wasm_api::HwpDocument, page: u32) -> Vec<Value> {
+    let json = doc
+        .get_page_layer_tree_with_profile_native(page, rhwp::paint::RenderProfile::Screen)
+        .expect("layer tree");
+    let tree: Value = serde_json::from_str(&json).expect("레이어 JSON 이 유효해야 한다");
+    let mut out = Vec::new();
+    collect_flow_images_from_tree(&tree["root"], None, None, &mut out);
+    out
+}
+
+/// 이 질의가 전체 트리 경로를 대체할 수 있다는 것 — 이 파일의 핵심 단언.
+#[test]
+fn issue_3315_narrow_query_matches_full_tree() {
+    let mut total_images = 0;
+    for sample in FLOW_IMAGE_SAMPLES {
+        let doc = open(sample);
+        let pages = doc.page_count().min(3);
+        for page in 0..pages {
+            let narrow = narrow(&doc, page);
+            let from_tree = tree_flow_images(&doc, page);
+            let images = narrow["images"].as_array().expect("images 배열");
+
+            assert_eq!(
+                images.len(),
+                from_tree.len(),
+                "{sample} p{page}: 좁은 질의와 전체 트리의 flow 그림 개수가 다르다"
+            );
+            total_images += images.len();
+
+            for (index, (narrow_op, tree_op)) in images.iter().zip(&from_tree).enumerate() {
+                let at = format!("{sample} p{page} #{index}");
+                assert_eq!(
+                    narrow_op["bbox"], tree_op["bbox"],
+                    "{at}: bbox 가 다르다 — 소비자가 다른 자리에 그린다"
+                );
+                assert_eq!(narrow_op["mime"], tree_op["mime"], "{at}: mime 이 다르다");
+                assert_eq!(
+                    narrow_op["effect"], tree_op["effect"],
+                    "{at}: effect 가 다르다"
+                );
+                assert_eq!(
+                    narrow_op["brightness"], tree_op["brightness"],
+                    "{at}: brightness 가 다르다"
+                );
+                assert_eq!(
+                    narrow_op["contrast"], tree_op["contrast"],
+                    "{at}: contrast 가 다르다"
+                );
+                assert_eq!(
+                    narrow_op["transform"], tree_op["transform"],
+                    "{at}: transform 이 다르다 — 회전·반전이 어긋난다"
+                );
+                assert_eq!(narrow_op["crop"], tree_op["crop"], "{at}: crop 이 다르다");
+                assert_eq!(
+                    narrow_op["originalSizeHu"], tree_op["originalSizeHu"],
+                    "{at}: originalSizeHu 가 다르다"
+                );
+                assert_eq!(
+                    narrow_op["bakedWatermark"], tree_op["bakedWatermark"],
+                    "{at}: bakedWatermark 가 다르다 — CSS filter 적용 여부가 갈린다"
+                );
+                assert_eq!(
+                    narrow_op["sourceImageKey"], tree_op["sourceImageKey"],
+                    "{at}: 신원 키가 다르다 — 바이트를 못 찾거나 남의 바이트를 받는다"
+                );
+            }
+        }
+    }
+    assert!(
+        total_images >= 4,
+        "표본이 flow 그림을 실제로 담고 있어야 이 테스트가 의미가 있다 (총 {total_images}장)"
+    );
+}
+
+#[test]
+fn issue_3315_narrow_query_keys_resolve_to_bytes() {
+    for sample in FLOW_IMAGE_SAMPLES {
+        let doc = open(sample);
+        let narrow = narrow(&doc, 0);
+        if narrow["cacheable"].as_bool() != Some(true) {
+            // 합성 그림이 섞인 페이지는 키를 못 내므로 이 단언의 대상이 아니다.
+            continue;
+        }
+        for image in narrow["images"].as_array().expect("images") {
+            let key = image["sourceImageKey"]
+                .as_str()
+                .expect("cacheable 페이지의 모든 그림은 키를 가져야 한다");
+            let (mime, bytes) = doc
+                .get_source_image_bytes_native(key)
+                .unwrap_or_else(|| panic!("{sample}: 키로 바이트를 받을 수 없다 ({key})"));
+            assert!(!bytes.is_empty(), "{sample}: 빈 바이트 ({key})");
+            assert_eq!(
+                Some(mime),
+                image["mime"].as_str(),
+                "{sample}: 좁은 질의의 mime 과 키 조회의 mime 이 다르다 ({key})"
+            );
+        }
+    }
+}
+
+#[test]
+fn issue_3315_narrow_query_is_much_smaller_than_the_tree() {
+    let doc = open_with_large_inserted_image();
+    let tree = doc.get_page_layer_tree_native(0).expect("layer tree");
+    let narrow = doc
+        .get_page_flow_image_ops_native(0)
+        .expect("flow image ops");
+
+    assert!(
+        narrow.len() * 100 < tree.len(),
+        "좁은 질의가 충분히 작지 않다 (tree={} bytes, narrow={} bytes)",
+        tree.len(),
+        narrow.len()
+    );
+    println!(
+        "[#3315] 전체 트리 {} bytes / 좁은 질의 {} bytes ({:.0}배)",
+        tree.len(),
+        narrow.len(),
+        tree.len() as f64 / narrow.len() as f64
+    );
+}
+
+/// 캐시가 아니라 좁은 질의여야 하는 이유를 고정한다.
+///
+/// 그림 바이트가 그대로면 `sourceImageKey` 도 그대로다. 그런데 본문 앞에 글자를 넣으면 그림이
+/// 밀려 bbox 가 달라진다 — 즉 `(page, imageKeys)` 를 키로 한 캐시는 **틀린 배치를 재사용**한다.
+///
+/// 부동 개체로 삽입한 그림은 (0,0) 에 고정돼 이 성질을 보이지 않는다. 본문 흐름에 얽힌 실문서가
+/// 필요하다 — `143E433F503322BD33.hwp` 는 글자를 넣으면 y 가 468.6 → 503.3 으로 밀린다.
+#[test]
+fn issue_3315_bbox_moves_while_key_stays_so_caching_would_be_wrong() {
+    let mut doc = open("samples/143E433F503322BD33.hwp");
+    let before = narrow(&doc, 0);
+
+    for _ in 0..3 {
+        doc.insert_text_native(0, 0, 0, "가나다라마바사아자차")
+            .expect("insert text");
+    }
+    let after = narrow(&doc, 0);
+
+    let before_images = before["images"].as_array().expect("images");
+    let after_images = after["images"].as_array().expect("images");
+    assert!(
+        !before_images.is_empty(),
+        "표본에 flow 그림이 있어야 한다 — 없으면 이 테스트가 대상을 못 재고 있다"
+    );
+    assert_eq!(
+        before_images.len(),
+        after_images.len(),
+        "이 테스트는 그림이 같은 쪽에 남는 조건에서만 의미가 있다"
+    );
+
+    let keys = |ops: &Vec<Value>| -> Vec<Value> {
+        ops.iter().map(|op| op["sourceImageKey"].clone()).collect()
+    };
+    assert_eq!(
+        keys(before_images),
+        keys(after_images),
+        "본문 편집은 그림 바이트를 바꾸지 않으므로 키가 유지돼야 한다"
+    );
+
+    let bboxes =
+        |ops: &Vec<Value>| -> Vec<Value> { ops.iter().map(|op| op["bbox"].clone()).collect() };
+    assert_ne!(
+        bboxes(before_images),
+        bboxes(after_images),
+        "키가 같은데 bbox 도 같으면 캐시로 풀 수 있다는 뜻이 된다 — \
+         이 단언이 깨졌다면 좁은 질의의 근거를 다시 확인해야 한다"
+    );
+}
+
+#[test]
+fn issue_3315_narrow_query_survives_documents_without_flow_images() {
+    let doc = open("samples/hwpx/issue_241.hwpx");
+
+    let narrow = narrow(&doc, 0);
+    let from_tree = tree_flow_images(&doc, 0);
+    assert_eq!(
+        narrow["images"].as_array().map(Vec::len),
+        Some(from_tree.len()),
+        "flow 그림이 없는 페이지에서도 전체 트리와 같은 답이어야 한다"
+    );
+    assert_eq!(
+        narrow["cacheable"].as_bool(),
+        Some(true),
+        "빈 목록은 cacheable 이다"
+    );
+}

--- a/tests/issue_3315_image_bytes_by_key.rs
+++ b/tests/issue_3315_image_bytes_by_key.rs
@@ -1,0 +1,288 @@
+//! Task #3315: 그림 바이트를 레이어 트리 JSON 에서 빼고 신원 키로 따로 받는다.
+//!
+//! 이 옵션이 성립하려면 **생략본 + 키 조회가 인라인 base64 와 같은 것을 말해야** 한다.
+//! 바이트가 한 바이트라도 다르면 소비자는 같은 그림을 다르게 그린다. 그래서 여기서 고정하는
+//! 것은 크기 이득이 아니라 등가성이다 — 크기는 그 등가성이 성립한 뒤의 부산물이다.
+//!
+//! 변환 사슬(BMP/PCX/TIFF/회색 JPEG → PNG, JPEG 워터마크 bake)이 JSON 경로와 키 조회 경로에
+//! 각각 사본으로 존재하면 이 등가성이 조용히 깨진다. 두 경로가 같은 함수를 쓰는지 확인하는
+//! 자리도 이 테스트다.
+
+use base64::Engine;
+use serde_json::Value;
+
+use rhwp::paint::{parse_source_image_key, LayerJsonOptions, SourceImageVariant};
+
+/// 그림 op 을 등장 순서대로 모은다. 인라인본과 생략본을 짝지어 비교하려면 순서가 같아야 한다.
+fn collect_image_ops(node: &Value, out: &mut Vec<Value>) {
+    if let Some(ops) = node.get("ops").and_then(Value::as_array) {
+        for op in ops {
+            if op.get("type").and_then(Value::as_str) == Some("image") {
+                out.push(op.clone());
+            }
+        }
+    }
+    if let Some(children) = node.get("children").and_then(Value::as_array) {
+        for child in children {
+            collect_image_ops(child, out);
+        }
+    }
+    // clipRect 노드는 단일 `child` 를 갖는다.
+    if let Some(child) = node.get("child") {
+        collect_image_ops(child, out);
+    }
+}
+
+fn image_ops(json: &str) -> Vec<Value> {
+    let value: Value = serde_json::from_str(json).expect("레이어 JSON 이 유효해야 한다");
+    let mut ops = Vec::new();
+    collect_image_ops(&value["root"], &mut ops);
+    ops
+}
+
+fn open_sample() -> rhwp::wasm_api::HwpDocument {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let bytes = std::fs::read(std::path::Path::new(repo_root).join("samples/hwpx/issue_241.hwpx"))
+        .expect("read samples/hwpx/issue_241.hwpx");
+    rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse issue_241.hwpx")
+}
+
+fn inline_json(doc: &rhwp::wasm_api::HwpDocument) -> String {
+    doc.get_page_layer_tree_native(0)
+        .expect("inline layer tree")
+}
+
+fn omitted_json(doc: &rhwp::wasm_api::HwpDocument) -> String {
+    doc.get_page_layer_tree_with_options_native(
+        0,
+        rhwp::paint::RenderProfile::Screen,
+        LayerJsonOptions {
+            omit_image_bytes: true,
+        },
+    )
+    .expect("omitted layer tree")
+}
+
+#[test]
+fn issue_3315_omitted_bytes_are_recoverable_by_key() {
+    let doc = open_sample();
+    let inline_ops = image_ops(&inline_json(&doc));
+    let omitted_ops = image_ops(&omitted_json(&doc));
+
+    assert!(!inline_ops.is_empty(), "도장 그림이 있어야 한다");
+    assert_eq!(
+        inline_ops.len(),
+        omitted_ops.len(),
+        "생략은 op 을 지우는 게 아니라 payload 만 뺀다"
+    );
+
+    for (inline_op, omitted_op) in inline_ops.iter().zip(&omitted_ops) {
+        let encoded = inline_op["base64"]
+            .as_str()
+            .expect("인라인본에는 base64 가 있어야 한다");
+        let expected = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .expect("인라인 base64 왕복");
+
+        let key = omitted_op["sourceImageKey"]
+            .as_str()
+            .expect("생략된 op 에는 키가 있어야 한다");
+        let (mime, actual) = doc
+            .get_source_image_bytes_native(key)
+            .expect("키로 바이트를 받을 수 있어야 한다");
+
+        assert_eq!(
+            actual, expected,
+            "키로 받은 바이트가 인라인 base64 와 달라졌다 (key={key})"
+        );
+        assert_eq!(
+            Some(mime),
+            inline_op["mime"].as_str(),
+            "키 조회의 mime 이 JSON 의 mime 과 달라졌다 (key={key})"
+        );
+    }
+}
+
+#[test]
+fn issue_3315_omitted_ops_keep_mime_and_declare_omission() {
+    let doc = open_sample();
+    let omitted = omitted_json(&doc);
+    let ops = image_ops(&omitted);
+
+    assert!(
+        omitted.contains("\"imageBytes\":\"byKey\""),
+        "문서 단위로 생략본임을 알려야 한다"
+    );
+    for op in &ops {
+        assert!(
+            op.get("base64").is_none(),
+            "생략본에 base64 가 남아 있다: {op}"
+        );
+        assert_eq!(
+            op["imageBytesOmitted"].as_bool(),
+            Some(true),
+            "op 마다 생략을 명시해야 한다 — 소비자가 부재를 추측하게 두지 않는다"
+        );
+        assert!(
+            op.get("mime").and_then(Value::as_str).is_some(),
+            "mime 은 남는다 — 소비자가 Blob 타입을 정하는 데 쓴다"
+        );
+        // bbox·effect 같은 배치 정보는 생략과 무관하게 그대로다.
+        assert!(op.get("bbox").is_some(), "bbox 가 사라졌다: {op}");
+    }
+}
+
+#[test]
+fn issue_3315_default_serialization_is_byte_identical() {
+    let doc = open_sample();
+    let inline = inline_json(&doc);
+
+    assert!(
+        inline.contains("\"imageBytes\":\"inline\""),
+        "기본값은 인라인이다"
+    );
+    assert!(
+        !inline.contains("\"imageBytesOmitted\""),
+        "기본 경로에는 생략 표식이 없어야 한다"
+    );
+    for op in image_ops(&inline) {
+        assert!(
+            op.get("base64").is_some(),
+            "옵션을 켜지 않은 호출은 종전대로 바이트를 싣는다"
+        );
+    }
+}
+
+/// 크기 이득은 이 트랙의 대상 시나리오 — **본문에 인라인된 대형 JPEG** — 에서만 의미가 있다.
+///
+/// 도장처럼 작은 그림만 있는 문서에서는 JSON 이 텍스트·글리프로 지배되므로 생략해도 몇 %만
+/// 줄어든다(실측 248KB → 233KB). 그 숫자로 이 옵션을 정당화하면 안 되므로, 여기서는 #2520 이
+/// 문제로 지목한 크기의 그림을 실제로 넣고 잰다.
+#[test]
+fn issue_3315_omitting_bytes_shrinks_the_payload_for_large_images() {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let jpeg = std::fs::read(std::path::Path::new(repo_root).join("samples/images/tiger01.jpg"))
+        .expect("read tiger01.jpg");
+    let mut doc = open_sample();
+    doc.insert_picture_native(
+        0,
+        0,
+        0,
+        &[],
+        &jpeg,
+        400,
+        300,
+        2400,
+        1800,
+        "jpg",
+        "tiger",
+        None,
+        None,
+    )
+    .expect("insert picture");
+
+    let inline = inline_json(&doc);
+    let omitted = omitted_json(&doc);
+
+    // 생략본에는 그림 바이트가 없으므로 원본 크기에 비례하지 않는다.
+    assert!(
+        omitted.len() * 4 < inline.len(),
+        "생략본이 충분히 작지 않다 (원본 그림 {} bytes, inline={} bytes, omitted={} bytes)",
+        jpeg.len(),
+        inline.len(),
+        omitted.len()
+    );
+    println!(
+        "[#3315] 원본 그림 {} bytes / inline JSON {} bytes / 생략 JSON {} bytes ({:.1}배 축소)",
+        jpeg.len(),
+        inline.len(),
+        omitted.len(),
+        inline.len() as f64 / omitted.len() as f64
+    );
+
+    // 크기가 줄었어도 바이트를 되찾을 수 있어야 의미가 있다.
+    for op in image_ops(&omitted) {
+        let key = op["sourceImageKey"].as_str().expect("키");
+        assert!(
+            doc.get_source_image_bytes_native(key).is_some(),
+            "생략했는데 키로 되찾을 수 없다 (key={key})"
+        );
+    }
+}
+
+#[test]
+fn issue_3315_inline_and_omitted_are_separate_cache_variants() {
+    let doc = open_sample();
+
+    // 같은 페이지를 번갈아 물어본다. 두 모양이 캐시 슬롯을 공유하면 뒤의 호출이 앞의 모양을
+    // 돌려받는다 — #2222 JSON 캐시가 지문에 생략 여부를 접지 않으면 나는 결함이다.
+    let first_inline = inline_json(&doc);
+    let omitted = omitted_json(&doc);
+    let second_inline = inline_json(&doc);
+    let second_omitted = omitted_json(&doc);
+
+    assert_eq!(first_inline, second_inline, "인라인본이 캐시에서 오염됐다");
+    assert_eq!(omitted, second_omitted, "생략본이 캐시에서 오염됐다");
+    assert_ne!(first_inline, omitted, "두 모양이 같을 수 없다");
+}
+
+#[test]
+fn issue_3315_unresolvable_keys_are_refused() {
+    let doc = open_sample();
+    let key = image_ops(&omitted_json(&doc))[0]["sourceImageKey"]
+        .as_str()
+        .expect("키")
+        .to_string();
+    let (epoch, bin_data_id, _variant) = parse_source_image_key(&key).expect("키 해석");
+
+    // 세대가 다른 키 — 스냅샷 복원 뒤에 옛 키로 물어본 경우. 낡은 바이트를 주면 안 된다.
+    let stale = format!("bin:{}:{bin_data_id}:src", epoch.wrapping_add(1));
+    assert!(
+        doc.get_source_image_bytes_native(&stale).is_none(),
+        "세대가 다른 키를 받아들였다"
+    );
+
+    // 없는 그림.
+    assert!(
+        doc.get_source_image_bytes_native(&format!("bin:{epoch}:60000:src"))
+            .is_none(),
+        "없는 bin_data_id 를 받아들였다"
+    );
+
+    for malformed in [
+        "",
+        "bin",
+        "bin:0:1",
+        "bin:0:1:src:extra",
+        "img:0:1:src",
+        "bin:x:1:src",
+        // 모르는 variant 를 src 로 흘리면 워터마크 그림에 원본 JPEG 을 주고도 성공해 보인다.
+        "bin:0:1:png",
+    ] {
+        assert!(
+            parse_source_image_key(malformed).is_none(),
+            "형식이 틀린 키를 받아들였다: {malformed:?}"
+        );
+        assert!(
+            doc.get_source_image_bytes_native(malformed).is_none(),
+            "형식이 틀린 키로 바이트를 돌려줬다: {malformed:?}"
+        );
+    }
+}
+
+#[test]
+fn issue_3315_key_round_trips_through_parser() {
+    for (epoch, id, variant) in [
+        (0u32, 1u16, SourceImageVariant::Source),
+        (7, 60001, SourceImageVariant::BakedWatermarkPng),
+    ] {
+        let key = format!("bin:{epoch}:{id}:{}", variant.as_str());
+        assert_eq!(
+            parse_source_image_key(&key),
+            Some((epoch, id, variant)),
+            "발급 포맷과 해석이 어긋난다: {key}"
+        );
+    }
+    assert!(!SourceImageVariant::Source.bakes_watermark());
+    assert!(SourceImageVariant::BakedWatermarkPng.bakes_watermark());
+}


### PR DESCRIPTION
> ## ⚠️ 이 PR 은 #3653 위에 스택돼 있습니다 — **#3653 을 먼저 봐 주세요**
>
> 이 작업은 #3653 의 `getSourceImageBytes` 없이는 성립하지 않습니다. base 를 #3653 의 브랜치로 두고 싶었지만 GitHub 은 base 브랜치가 대상 저장소에 있어야 해서 포크 브랜치를 base 로 지정할 수 없습니다. 그래서 base 는 `devel` 이고, **Files changed 에 #3653 의 변경이 함께 보입니다.**
>
> | 커밋 | 내용 | 리뷰 |
> |---|---|---|
> | `c8f0e99b` | 키로 바이트를 받는 API + base64 생략 opt-in | **#3653 에서** |
> | `5991109d` | 본문 그림 좁은 질의 (이 PR) | 여기서 |
>
> #3653 이 merge 되면 이 브랜치를 devel 로 리베이스해 이 PR 의 diff 를 두 번째 커밋만으로 줄이겠습니다.

## 변경 요약

studio 는 본문(flow) 그림을 DOM `<img>` 로 내보내려고 편집마다 **전체 레이어 트리 JSON** 을 받았습니다(`getFlowImagePaintOps`). 그림 1장이 4.77MB 면 그 JSON 이 6.6MB 라, 경계 복사와 `JSON.parse` 만으로 키 입력당 20 ms 가 나갔습니다.

**캐시로는 풀 수 없습니다** — 본문이 흐르면 그림이 그대로여도 bbox 가 움직이므로 `(page, imageKeys)` 를 키로 한 캐시는 틀린 배치를 재사용합니다. 그래서 캐시가 아니라 **질의를 좁혔습니다**.

```rust
getPageFlowImageOps(page)   // bbox·clip·효과·신원 키만. 바이트 없음
```

바이트는 `getSourceImageBytes(key)`(#3653)로 **그림이 바뀔 때만** 받아 신원 키별 object URL 로 캐시합니다.

| 항목 | 전체 트리 | 좁은 질의 |
|---|---|---|
| 크기 | 6,628,601 bytes | **309 bytes (21,400배)** |
| Rust 시간 (20회 평균) | 15.20 ms | **5.90 ms** |

20회 평균, `release-test`, 매 회 편집으로 #2222 JSON 캐시를 무효화한 조건입니다. 21,400배 축소라 JS 경계 복사(13.9 ms)·`JSON.parse`(6.9 ms)는 크기에 비례해 사실상 사라집니다 — #3315 Track 2·3 이 노린 20.8 ms 가 이 지점입니다.

## 근거를 검증하다 하마터면 틀린 테스트를 남길 뻔했습니다

"본문이 흐르면 bbox 가 움직인다"를 `insert_picture_native` 로 넣은 그림으로 재려 했는데 **전혀 움직이지 않았습니다.** 그렇게 삽입한 그림은 `layer.textWrap="square"` 인 부동 개체로 (0,0)에 고정돼, 글자를 560자 넣어도 bbox 가 그대로였습니다(다음 쪽으로 밀려 사라질 뿐).

실문서를 훑어 찾았습니다 — `samples/143E433F503322BD33.hwp` 는 글자를 넣으면 키는 그대로인 채 y 가 468.6 → 503.3 으로 밀립니다. 근거가 실제로 성립함을 확인해 그 fixture 로 고정했습니다. 삽입 그림으로만 쟀다면 이 트랙의 설계 판단("캐시가 아니라 좁은 질의")이 검증되지 않은 채 남았을 겁니다.

## 등가성

이 질의가 전체 트리 경로를 대체할 수 있다는 것이 전제이므로, **실문서 4종 × 최대 3쪽**에서 전체 트리에서 뽑은 결과와 대조합니다 — 개수·순서·bbox·clip·mime·crop·`originalSizeHu`·transform·effect·brightness·contrast·`bakedWatermark`·`sourceImageKey` 전부입니다.

- `clip` 은 Rust 가 조상 `ClipRect` 를 교차해 접어 줍니다. 소비자가 계보를 다시 훑지 않아도 같은 잘림을 재현할 수 있어야 하므로 결과만 넘깁니다. 교차가 비면 그 그림은 보이지 않으므로 목록에서 빠집니다.
- 효과는 값으로 넘깁니다. CSS filter 조립은 studio 의 `composeImageFilter` 가 `web_canvas.rs::compose_image_filter` 와 맞춰 둔 계약이라 Rust 에서 되풀이하지 않습니다.
- plane 판정은 Rust 의 `paint_op_replay_plane_with_layer` 를 씁니다. 테스트 쪽 미러가 `layer.textWrap` 우선 규칙을 빠뜨려 처음엔 어긋났고, studio `layerPaintOpReplayPlane` 을 그대로 옮겨 맞췄습니다.

## 되돌림은 전부 아니면 전무

좁은 질의를 못 쓰는 경우에는 **종전 전체 트리 경로로 되돌아갑니다.**

- 구형 WASM (메서드 부재 → `null`)
- `cacheable:false` — 신원 키를 낼 수 없는 합성 그림(`bin_data_id == 0`)이 섞인 페이지. 키가 없으면 바이트를 받을 방법이 없습니다
- 세대가 바뀐 낡은 키로 URL 을 만들지 못한 경우

부분 목록을 돌려주면 그림 몇 장이 조용히 사라집니다. 그건 느린 것보다 나쁩니다.

## object URL 수명

`FlowImageUrlCache` 는 신원 키별로 URL 하나를 들고 있습니다. 키가 내용에서 유도되므로 스스로 무효화돼 편집 때 비우지 않습니다 — 비우면 캐시를 두는 의미가 없습니다.

회수는 문서를 갈아끼울 때(`invalidateDocumentRevision`)와 정리할 때(`dispose`) 전부입니다. 개별 항목을 참조 카운트로 거두지 않습니다 — `<img>` 가 아직 디코드 중인 URL 을 회수하면 그림이 빈 채로 남고, 페이지의 그림 수는 정교한 revoke 를 할 만큼 크지 않습니다.

## 그 밖에

- `FlowImagePaintOp` 의 `mime`+`base64` 를 `src` 하나로 합쳤습니다. 전체 트리 경로는 data URL, 좁은 질의 경로는 object URL 을 같은 필드에 담으므로 DOM 조립부가 분기하지 않습니다.
- `emitted_image_mime` 을 추가해 mime 만 필요한 소비자가 변환(큰 JPEG 은 메모 키 해싱만으로 3.7MB 당 1.35 ms)을 다시 돌지 않게 했습니다. `resolved` 가 없을 때 "변환이 실패한 것이니 원본 mime" 으로 단축하지 **않고** `emitted_image_bytes` 에 위임합니다 — 그 전제는 `paint/builder.rs` 가 만든 트리에만 성립하고 직접 조립한 `PaintOp::Image { resolved: None }` 에는 성립하지 않습니다.
- `render-backend.test.ts` 의 소스 가드가 `element.src = \`data:${image.mime};base64,${image.base64}\`` 를 고정하고 있었습니다. 계약이 바뀐 자리라 갱신하면서 **약해지지 않게** 좁은 질의 우선·fallback 보존·object URL 회수 2곳을 새로 고정했습니다.

## 관련 이슈

#3315 Track 2·3 — **umbrella 이슈라 closing keyword 를 쓰지 않습니다.** PR #3465 merge 때 자동화가 closing keyword 로 판정해 #3315 을 종료했고 collaborator 가 다시 열어야 했습니다.

선행: #3653(필수 의존), #3455(신원 키), #3452(base64 직접 인코딩), #3411(공유 바이트).

## 테스트

- [x] `cargo test --profile release-test --tests` — **4447 passed / 0 failed** (최신 devel `44d046bf7` 와 병합한 결과로 재확인)
- [x] `cargo clippy --all-targets -- -D warnings` 통과
- [x] `cargo fmt --check` 통과
- [x] Native Skia 3종 — `skia --lib` 58, `issue_2225_missing_picture_placeholder` 2, `render_p37_direct_pdf_export` 4
- [x] `wasm-pack build --target web` 성공 + 생성 바인딩 확인 (`getPageFlowImageOps`, `getSourceImageBytes`)
- [x] rhwp-studio `npx tsc --noEmit` 통과, `npm test` **695/695** (병합 결과 기준)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음(신규 질의 + studio 소비자 전용, SVG 생산자 미변경)
- [ ] **웹(WASM) 실브라우저 확인 — 하지 못했습니다** (아래)

신규 테스트: `tests/issue_3315_flow_image_narrow_query.rs` 5건(실문서 등가성·키 해석·크기·bbox 이동·flow 그림 없는 문서), `rhwp-studio/tests/issue-3315-flow-image-narrow-query.test.ts` 9건(필드 옮김·전부-아니면-전무 되돌림·URL 캐시 수명).

### 미검증 — 실브라우저 동작

DOM `<img>` 의 src 가 **data URL → object URL** 로 바뀌는 변경인데 실브라우저에서 확인하지 못했습니다. 소스 가드와 단위 테스트로는 못 잡는 것이 남아 있을 수 있습니다 — 특히 **object URL 회수 시점과 `<img>` 디코드가 겹치는 경계**입니다. 문서를 빠르게 갈아끼우면 `releaseAll()` 이 아직 디코드 중인 URL 을 거둘 수 있습니다.

되돌림 경로를 남겨 둔 것이 이 위험의 방어입니다(전체 트리 경로가 그대로 살아 있습니다). 그래도 merge 전에 실기동 확인이 필요하다고 봅니다 — 제가 돌릴 수 있는 e2e 가 있으면 알려 주시면 실행해 증적을 올리겠습니다.
