### PR TITLE
perf(studio): 그림 좁은 질의와 snapshot rollback을 통합한다

### DIFF
--- a/mydocs/orders/20260731.md
+++ b/mydocs/orders/20260731.md
@@ -1,5 +1,32 @@
 # 오늘 할일 - 2026년 7월 31일
 
+## lpaiu-cs PR #3653·#3655·#3656·#3660 통합 검토
+
+[#3653](https://github.com/edwardkim/rhwp/pull/3653),
+[#3655](https://github.com/edwardkim/rhwp/pull/3655),
+[#3656](https://github.com/edwardkim/rhwp/pull/3656),
+[#3660](https://github.com/edwardkim/rhwp/pull/3660)은 `@lpaiu-cs`의 #3315 그림 경계 최적화, 셀 문단
+메타 회귀, snapshot rollback 보정이다. 원 PR을 개별로 merge하지 않고 latest `devel` 위
+[#3661](https://github.com/edwardkim/rhwp/pull/3661) 하나로 누적했다. #3660의 stacked #3653 선행
+commit은 중복하지 않았고, source devel merge commit도 제외했다.
+
+- #3653은 기본 inline JSON을 보존한 opt-in byte omission과 final emitted payload key lookup을 추가한다.
+  #3660은 flow-image layout metadata만 좁게 받고 byte는 key별 object URL로 재사용하되, 비정상 응답은
+  partial render 대신 기존 full tree로 fail closed한다. #3315는 Track 3·4의 umbrella라 open 유지한다.
+- #3655는 table/textbox/picture caption/nested by-path에서 사라진 문단의 메타가 병합 undo 뒤
+  복원되는지를 실물 `DocumentCore` 회귀로 넓힌다. #3656은 operation 또는 after snapshot 저장 실패 때
+  before snapshot을 복원하고 orphan id를 discard한다. 통합 merge 뒤 #3439·#3350 close 상태를 확인한다.
+- source head 4건과 #3661 exact code head에서 lint·WASM check, frontend gates, Native Skia, test archive,
+  default-feature 8 shards, CodeQL, Canvas visual diff, `Build & Test` aggregate가 모두 success다. 전체 local
+  release-test는 이 exact integration CI와 중복하므로 실행하지 않는다.
+- review 전용 target에서 fresh `wasm-pack build --target web --out-dir pkg`는 exit 0이다. in-app Studio
+  shell은 boot했으나 hidden file input의 automated chooser 제약으로 fixture load는 성공으로 주장하지 않는다.
+  Rust 실문서 narrow-query 등가성 회귀와 exact CI Canvas diff가 renderer 근거다.
+- archive review·통합 기록·오늘할일만 추가한 뒤 staged LFS 판독, review-only fast-pass를 실제 확인하고
+  #3661 하나만 merge한다. 이후 original PR supersede/comment, issue 상태, devel sync, 정확한 review target·branch
+  정리까지 수행한다. 근거는 `mydocs/pr/archives/pr_3653_review.md`–`pr_3660_review.md`와
+  `mydocs/pr/archives/pr_3653_review_impl.md`에 남긴다.
+
 ## #3536 CanvasKit P40 사전검증·이미지 재생 guard 검토
 
 [#3536](https://github.com/edwardkim/rhwp/pull/3536)은 `@seo-rii`의 CanvasKit P40 guard 변경이다. 최신

--- a/mydocs/pr/archives/pr_3653_review.md
+++ b/mydocs/pr/archives/pr_3653_review.md
@@ -1,0 +1,53 @@
+---
+kind: pr-review
+status: active
+---
+
+# PR #3653 검토 — 그림 바이트 키 조회와 base64 생략 opt-in
+
+| 항목 | 값 |
+| --- | --- |
+| 작성자 / reviewer | `@lpaiu-cs` / `@jangster77` |
+| 원 PR / 관련 이슈 | [#3653](https://github.com/edwardkim/rhwp/pull/3653) / [#3315](https://github.com/edwardkim/rhwp/issues/3315) Track 3 |
+| 원 head 참고값 | `c8f0e99bceb66790f4f7b6c83c328cb91983b96a` |
+| 통합 후보 | [#3661](https://github.com/edwardkim/rhwp/pull/3661) `52903c91bf132f7f3a977afc9cc265859b024c85` |
+| 원 변경 규모 | 8 files, +549 / -55 |
+| 권고 | #3661의 통합 범위로 수용. #3315는 umbrella로 open 유지 |
+
+## 변경과 통합 판정
+
+전체 `PageLayerTree`를 반복해서 JSON으로 넘기면 이미지 base64가 입력마다 WASM 경계를 다시 건넌다.
+이 PR은 기존 기본 직렬화는 바꾸지 않고 `omitImageBytes=true`일 때만 바이트를 생략하며,
+`getSourceImageBytes(key)`로 실제 방출 payload를 다시 받는 additive API를 둔다.
+
+- `bin:{epoch}:{bin_data_id}:{variant}` 키는 snapshot 복원·새 문서에서 epoch를 달리하고, JPEG
+  워터마크 bake와 원본/변환 payload를 variant로 구분한다.
+- 키를 해석하는 단일 경로가 `emitted_image_bytes`를 사용하므로 BMP/PCX/TIFF·회색 JPEG 변환과
+  watermark PNG bake가 기존 JSON 방출물과 조용히 갈라지지 않는다.
+- PageLayerTree cache fingerprint에는 image-byte omission bit를 포함해 inline과 omission 결과가
+  같은 cache entry를 공유하지 않는다.
+- 기본 호출은 여전히 image data URL을 포함한다. 구형 WASM·해석 불가 키는 Studio가 전체 tree
+  경로로 되돌아갈 수 있다.
+
+원 기능 commit은 통합 branch의 `18631bce7`로 patch 동등하게 누적했다. source branch의 devel
+병합은 포함하지 않았고, 뒤의 #3660은 이 API 위에 쌓이는 관계여서 한 번만 선행 적용했다.
+
+## 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| source #3653 CI | full CI, CodeQL, Canvas visual diff success |
+| 통합 code head CI | lint·WASM check, frontend package gates, Native Skia, archive, default-feature 8 shards, CodeQL, Canvas visual diff, `Build & Test` 모두 success |
+| 체리픽 동등성 | `c8f0e99bc` = `18631bce7` patch-id, `git diff --check` 통과 |
+| 회귀 계약 | image-key의 바이트·mime 동등성, omission 출력, 기본 inline 보존, cache variant 분리, stale/malformed key 거부를 integration test로 고정 |
+| 로컬 WASM | `CARGO_TARGET_DIR=target/review-lpaiu-cs-20260731 CARGO_INCREMENTAL=0 wasm-pack build --target web --out-dir pkg` exit 0 |
+| 추가 전체 Cargo | source 및 정확한 통합 head full CI와 중복되므로 작업지시에 따라 실행하지 않음. 성공 근거로 사용하지 않음 |
+
+## 범위와 권고
+
+이 PR은 #3315 Track 3의 바이트 전달 계약만 만든다. 전체 tree를 좁은 flow query로 대체하는
+소비자 최적화는 #3660에서 검토한다. 따라서 통합 PR 본문에는 `Closes #3315`를 쓰지 않고
+umbrella 이슈를 open으로 둔다.
+
+**권고: 수용.** #3661의 같은 code head는 full CI와 `MERGEABLE`을 확인했다. review 문서만 추가한
+head는 별도 fast-pass를 통과한 뒤 통합 PR 하나로 merge한다.

--- a/mydocs/pr/archives/pr_3653_review_impl.md
+++ b/mydocs/pr/archives/pr_3653_review_impl.md
@@ -1,0 +1,52 @@
+---
+kind: pr-review
+status: active
+---
+
+# lpaiu-cs PR #3653·#3655·#3656·#3660 통합 검토·구현 기록
+
+## 접수와 누적 범위
+
+`upstream/devel` 위의 `review/lpaiu-cs-20260731`에 `@lpaiu-cs` open PR 4건의 contributor 기능
+commit만 번호순으로 누적하고 [#3661](https://github.com/edwardkim/rhwp/pull/3661)을 만들었다. reviewer
+`@jangster77`는 원 PR 네 건에 먼저 지정했다. 원 source branch의 devel merge commit은 통합하지 않았다.
+
+| 원 PR | source head | 통합 commit | 판정 |
+| --- | --- | --- | --- |
+| #3653 | `c8f0e99bceb66790f4f7b6c83c328cb91983b96a` | `18631bce7` | 그림 byte-by-key API와 omission opt-in |
+| #3655 | `de0bf178b746bb54f02843ab2109c085a7638db2` | `e2a3cd1ff` | cell/container undo meta 회귀 |
+| #3656 | `9daeb0bb81ef9a7c2e3174a6ee8ab916c759a940` | `f0edd0889` | snapshot execute 실패 rollback |
+| #3660 | `5991109d6efd50e46343dd1788e46e91f5ab572d` | `52903c91b` | narrow flow-image query 소비자 |
+
+네 mapping은 `git patch-id --stable`에서 각각 동등하다. #3660 source는 #3653을 이미 포함한 stacked
+branch이므로 #3653 기능을 중복 적용하지 않았고, 통합 branch에서 `18631bce7` 뒤 `52903c91b`을 한 번만
+적용했다. base 병합이나 contributor source를 rewrite·force-push하지 않았다.
+
+## 수용 계약
+
+1. #3653의 기본 PageLayerTree JSON은 호환성을 위해 image bytes를 계속 포함한다. omission은 opt-in이고
+   key lookup은 최종 방출 mime/bytes와 동등해야 한다.
+2. #3660은 모든 flow image metadata를 정상 해석할 때만 DOM object-URL 경로를 쓴다. 불완전 응답은
+   partial render가 아니라 기존 full-tree data-URL fallback이어야 한다.
+3. #3655는 production change 없이 table·textbox·caption·nested by-path의 병합/undo 메타 경계를
+   독립 회귀로 보장한다.
+4. #3656은 history 등록 전 operation 또는 after snapshot 저장 실패 시 문서와 snapshot id를 before
+   상태로 돌리고, rollback 실패도 원 오류와 함께 드러낸다.
+
+## 검증 상태와 후속 순서
+
+code head는 `52903c91bf132f7f3a977afc9cc265859b024c85`다. source #3653·#3655·#3656·#3660의 full CI와
+#3661 exact code head의 lint/WASM, frontend gates, Native Skia, archive, default-feature 8 shards, CodeQL,
+Canvas visual diff, `Build & Test` aggregate가 모두 성공했다. 현재 상태는 `CLEAN`·`MERGEABLE`이다.
+로컬은 전용 target에서 fresh `wasm-pack build`만 exit 0을 확인했고, 전체 Cargo는 exact CI와 중복하지
+않도록 실행하지 않았다.
+
+1. review 문서와 오늘할일만 commit·push한다. LFS 대상 여부를 staged file별로 판독하고 non-LFS면
+   `GIT_LFS_SKIP_PUSH=1` dry-run 뒤 실제 push한다.
+2. review-only head가 fast-pass인 것을 확인한다. 코드 검증을 fast-pass 결과로 바꾸지 않는다.
+3. #3661을 squash merge하고 merge SHA·`upstream/devel` sync를 확인한다.
+4. #3350·#3439의 close 상태를 실제 merge 뒤 확인한다. #3315는 umbrella로 open 유지한다.
+5. 원 PR 4건에는 통합 PR·검증 범위·감사의 실제 줄바꿈 comment를 남기고 supersede close한다. source
+   fork branch는 보존한다.
+6. 실행 중 Cargo/Rust 작업이 없음을 확인한 뒤 `target/review-lpaiu-cs-20260731`만 recoverable하게
+   정리하고 review branch/ref를 정리한다.

--- a/mydocs/pr/archives/pr_3655_review.md
+++ b/mydocs/pr/archives/pr_3655_review.md
@@ -1,0 +1,42 @@
+---
+kind: pr-review
+status: active
+---
+
+# PR #3655 검토 — 셀 문단 병합 메타 회귀 경로 보강
+
+| 항목 | 값 |
+| --- | --- |
+| 작성자 / reviewer | `@lpaiu-cs` / `@jangster77` |
+| 원 PR / 관련 이슈 | [#3655](https://github.com/edwardkim/rhwp/pull/3655) / [#3439](https://github.com/edwardkim/rhwp/issues/3439) |
+| 원 head 참고값 | `de0bf178b746bb54f02843ab2109c085a7638db2` |
+| 통합 후보 | [#3661](https://github.com/edwardkim/rhwp/pull/3661) `52903c91bf132f7f3a977afc9cc265859b024c85` |
+| 원 변경 규모 | 1 file, +232 / -63 |
+| 권고 | #3661로 수용. merge 시 #3439 close |
+
+## 변경과 통합 판정
+
+이미 고쳐진 `Paragraph::capture_meta` / `apply_meta` 계약이 table cell 외의 문단 컨테이너와
+실제 깊이 2 `by-path`에서도 유지되는지를 실물 `DocumentCore` 조작으로 넓힌 test-only PR이다.
+
+- table cell, textbox, picture caption의 각 문단 컨테이너에서 병합 뒤 undo 분할을 수행한다.
+- 사라진 둘째 문단의 para shape·style·column break·numbering restart·raw header extra·extended tab을
+  함께 복원하고, 첫 문단의 메타가 바뀌지 않음을 확인한다.
+- 중첩 표는 상위 셀 안에 실제 table control을 만들고 depth-2 path로 insert/split/merge/undo 한다.
+  그래서 얕은 cell index를 by-path처럼 취급하는 false positive를 피한다.
+- 일반 Enter split에서 meta를 넘기지 않을 때 앞 문단 상속이라는 기존 동작도 유지한다.
+
+기능 commit `de0bf178b`은 통합에서 `e2a3cd1ff`와 patch 동등하다. production 동작을 변경하지
+않으므로 source branch devel merge는 제외하고 회귀만 누적했다.
+
+## 검증과 권고
+
+| 검증 | 결과 |
+| --- | --- |
+| source #3655 CI | full CI, CodeQL, Canvas visual diff success |
+| 통합 code head CI | lint·WASM check, frontend package gates, Native Skia, archive, default-feature 8 shards, CodeQL, Canvas visual diff, `Build & Test` 모두 success |
+| 체리픽 동등성 | `de0bf178b` = `e2a3cd1ff` patch-id, `git diff --check` 통과 |
+| 추가 로컬 Cargo | exact integration CI와 중복되므로 작업지시에 따라 실행하지 않음. 성공 근거로 사용하지 않음 |
+
+**권고: 수용.** #3439의 남은 셀 컨테이너 경로를 직접 재현하는 회귀로 범위가 정확하다. #3661의
+동일 code head full CI를 확인했으며, 문서-only fast-pass 뒤 통합 merge 때 #3439의 자동 close 상태를 확인한다.

--- a/mydocs/pr/archives/pr_3656_review.md
+++ b/mydocs/pr/archives/pr_3656_review.md
@@ -1,0 +1,41 @@
+---
+kind: pr-review
+status: active
+---
+
+# PR #3656 검토 — 실패한 snapshot command의 원자적 rollback
+
+| 항목 | 값 |
+| --- | --- |
+| 작성자 / reviewer | `@lpaiu-cs` / `@jangster77` |
+| 원 PR / 관련 이슈 | [#3656](https://github.com/edwardkim/rhwp/pull/3656) / [#3350](https://github.com/edwardkim/rhwp/issues/3350) |
+| 원 head 참고값 | `9daeb0bb81ef9a7c2e3174a6ee8ab916c759a940` |
+| 통합 후보 | [#3661](https://github.com/edwardkim/rhwp/pull/3661) `52903c91bf132f7f3a977afc9cc265859b024c85` |
+| 원 변경 규모 | 2 files, +35 / -3 |
+| 권고 | #3661로 수용. merge 시 #3350 close |
+
+## 변경과 통합 판정
+
+`SnapshotCommand.execute()`는 최초 실행에서 before snapshot을 저장한 뒤 operation과 after snapshot을
+수행한다. 그 사이에 throw하면 command는 history에 들어가지 않아 snapshot discard 주체가 사라지고,
+operation이 문서를 일부 바꾼 경우 원자성도 깨졌다.
+
+PR은 operation과 after-save 전체를 `try`로 감싸고 실패 시 before snapshot으로 복원한 뒤 before/after
+id를 discard한다. rollback도 실패하면 원 operation error와 rollback error를 `AggregateError`로 함께
+전달해 원인을 지우지 않는다. 성공·no-op·redo 경로는 이전 계약을 그대로 둔다.
+
+회귀는 현재 WASM bridge가 failure injection을 제공하지 않는 한계를 숨기지 않고, execute body에
+before restore, null-safe discard, aggregate error, after-save 포함 try 범위가 존재하는 source contract로
+고정한다. 기능 commit `9daeb0bb8`은 통합에서 `f0edd0889`와 patch 동등하다.
+
+## 검증과 권고
+
+| 검증 | 결과 |
+| --- | --- |
+| source #3656 CI | full CI, CodeQL, Canvas visual diff success |
+| 통합 code head CI | lint·WASM check, frontend package gates, Native Skia, archive, default-feature 8 shards, CodeQL, Canvas visual diff, `Build & Test` 모두 success |
+| 체리픽 동등성 | `9daeb0bb8` = `f0edd0889` patch-id, `git diff --check` 통과 |
+| 추가 로컬 Cargo | exact integration CI와 중복되므로 작업지시에 따라 실행하지 않음. 성공 근거로 사용하지 않음 |
+
+**권고: 수용.** history 등록 전 실패의 rollback 책임을 유일하게 이 command가 지는 경계를 정확히
+복구한다. #3661의 current-head full CI를 확인했고, review-only fast-pass 후 merge하여 #3350 close 상태를 확인한다.

--- a/mydocs/pr/archives/pr_3660_review.md
+++ b/mydocs/pr/archives/pr_3660_review.md
@@ -1,0 +1,58 @@
+---
+kind: pr-review
+status: active
+---
+
+# PR #3660 검토 — 본문 그림 narrow query와 object URL 재사용
+
+| 항목 | 값 |
+| --- | --- |
+| 작성자 / reviewer | `@lpaiu-cs` / `@jangster77` |
+| 원 PR / 관련 이슈 | [#3660](https://github.com/edwardkim/rhwp/pull/3660) / [#3315](https://github.com/edwardkim/rhwp/issues/3315) Track 4 |
+| 원 head 참고값 | `5991109d6efd50e46343dd1788e46e91f5ab572d` |
+| 통합 후보 | [#3661](https://github.com/edwardkim/rhwp/pull/3661) `52903c91bf132f7f3a977afc9cc265859b024c85` |
+| 원 변경 규모 | stacked #3653 포함 18 files, +1,794 / -127; 통합에는 #3660 전용 기능 commit만 한 번 적용 |
+| 권고 | #3661의 #3653 선행 API와 함께 수용. #3315는 open 유지 |
+
+## 변경과 통합 판정
+
+본문 flow 그림을 DOM overlay로 분리할 때 Studio는 매 편집마다 전체 PageLayerTree에서 base64를 받았다.
+이 PR은 bbox·clip·crop·transform·effect·mime·source key만 담은 `getPageFlowImageOps()`를 먼저 묻고,
+바이트는 key별 `Blob` object URL로 한 번만 만든다.
+
+- Rust narrow query는 layer inheritance, master-page 제외, replay plane, nested `clipRect` 교집합을
+기존 tree 소비자와 같은 pre-order로 보존한다.
+- TypeScript parser는 한 항목이라도 malformed·unresolvable이면 `null`을 반환한다. partial image를
+그리지 않고 전체 tree의 기존 data-URL 경로로 fall back한다.
+- source key가 없는 합성 그림은 narrow query를 cacheable false로 만들어 fallback한다.
+- `FlowImageUrlCache`는 document revision 교체와 `dispose`에서 모든 object URL을 revoke한다. bbox는
+본문 흐름에 따라 바뀌므로 page/key 캐시로 재사용하지 않고, 바이트 URL만 재사용한다.
+- DOM split은 narrow image count가 layer summary와 같을 때만 활성화한다. raw SVG가 섞이면 기존
+static layer 경로를 유지한다.
+
+#3660 source는 #3653 위에 stack돼 있으므로 source branch의 선행 commit을 중복 체리픽하지 않았다.
+전용 기능 commit `5991109d6`은 통합 `52903c91b`의 마지막 commit이며, #3653 통합 commit
+`18631bce7`을 선행해 전체 patch를 정확히 재구성한다.
+
+## 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| source #3660 CI | full CI, CodeQL, Canvas visual diff, `Build & Test` success |
+| 통합 code head CI | lint·WASM check, frontend package gates, Native Skia, archive, default-feature 8 shards, CodeQL, Canvas visual diff, `Build & Test` 모두 success |
+| Rust 회귀 | 실제 flow-image HWP/HWPX 4개에서 tree와 narrow query의 개수·순서·bbox·clip·effect·transform·mime·key 동등성, key-byte 해석, bbox 이동, no-flow 페이지를 고정 |
+| Studio 회귀 | data URL/object URL mapping, cacheable false, malformed/unresolvable all-or-nothing fallback, object URL release를 고정 |
+| 로컬 WASM | review 전용 target에서 `wasm-pack build --target web --out-dir pkg` exit 0; Studio shell boot 확인 |
+| 추가 전체 Cargo | source 및 exact integration CI와 중복되므로 작업지시에 따라 실행하지 않음. 성공 근거로 사용하지 않음 |
+
+로컬 in-app Studio에서 fixture file chooser는 자동 제어 surface가 hidden input을 열지 못해 실제 fixture
+load까지 완료하지 못했다. 이를 browser 성공으로 바꾸지 않는다. 이미 source와 exact integration head의
+Canvas visual diff, frontend gates, Rust 실문서 등가성 회귀가 수용 근거이며, 최종 aggregate가 별도 merge
+조건이다.
+
+## 권고
+
+**권고: 수용.** 성능 수치를 일반 renderer 정합 성공으로 확대하지 않고, narrow query와 기존 tree의
+등가성·fallback·URL 수명 계약으로 한정한다. #3315는 Track 4 뒤에도 umbrella이므로 open을 유지한다.
+#3661 code head의 8 shards와 `Build & Test` 성공, `MERGEABLE`을 확인했다. 문서-only fast-pass 뒤 하나의
+통합 PR로 merge한다.

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -686,6 +686,43 @@ export class WasmBridge {
     }
   }
 
+  /**
+   * 본문(flow) 그림의 배치 정보만 받는다 (Task #3315).
+   *
+   * 전체 레이어 트리를 받아 flow 그림을 걸러내면 그림 1장에 수 MB 를 편집마다 옮긴다.
+   * 이 질의는 바이트를 빼고 bbox·잘림·효과·신원 키만 주므로 수백 바이트다. 바이트는
+   * `getSourceImageBytes(key)` 로 그림이 바뀔 때만 따로 받는다.
+   *
+   * 구형 WASM(미지원)에서는 `null` — 호출부는 종전의 전체 트리 경로로 되돌아간다.
+   */
+  getPageFlowImageOps(pageNum: number): string | null {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    const d = this.doc as unknown as { getPageFlowImageOps?: (p: number) => string };
+    if (typeof d.getPageFlowImageOps !== 'function') return null;
+    try {
+      return d.getPageFlowImageOps(pageNum);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * 그림 신원 키로 바이트를 받는다 (Task #3315).
+   *
+   * 키를 풀 수 없으면 `null` — 세대가 바뀐 낡은 키이거나 없는 그림이다. 호출부는 종전
+   * 경로로 되돌아가야 한다.
+   */
+  getSourceImageBytes(key: string): Uint8Array | null {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    const d = this.doc as unknown as { getSourceImageBytes?: (k: string) => Uint8Array };
+    if (typeof d.getSourceImageBytes !== 'function') return null;
+    try {
+      return d.getSourceImageBytes(key);
+    } catch {
+      return null;
+    }
+  }
+
   getPageLayerTreeObject(pageNum: number, profile: LayerRenderProfile = 'screen'): PageLayerTree {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     const d = this.doc as unknown as {

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -1890,9 +1890,23 @@ export class SnapshotCommand implements EditCommand {
         this.cursorAfter = result;
       }
       this.afterId = wasm.saveSnapshot();
-    } catch (e) {
-      this.discard(wasm); // before/after id 를 null-safe 로 해제
-      throw e;
+    } catch (operationError) {
+      // [#3350] 최초 execute 가 실패하면 명령 전체를 원자적으로 되돌린다. 이 커맨드는
+      // history 에 push 되기 전이므로 before 스냅샷을 가진 SnapshotCommand만 rollback을
+      // 수행할 수 있다. after-save 실패도 execute 실패이므로 같은 계약을 따른다.
+      try {
+        if (this.beforeId !== null) {
+          wasm.restoreSnapshot(this.beforeId);
+        }
+      } catch (rollbackError) {
+        this.discard(wasm);
+        throw new AggregateError(
+          [operationError, rollbackError],
+          `${this.type} 실행 실패 후 rollback도 실패했습니다`,
+        );
+      }
+      this.discard(wasm);
+      throw operationError;
     }
 
     // operation 참조 해제 (클로저에 캡처된 리소스 해제)

--- a/rhwp-studio/src/view/flow-image-clip.ts
+++ b/rhwp-studio/src/view/flow-image-clip.ts
@@ -14,8 +14,14 @@ export interface FlowImageCrop {
 
 export interface FlowImagePaintOp {
   bbox: FlowImageBbox;
-  mime: string;
-  base64: string;
+  /**
+   * `<img>.src` 로 그대로 넣는 값.
+   *
+   * 전체 레이어 트리 경로는 `data:{mime};base64,{...}`, 좁은 질의 경로는 신원 키별 object
+   * URL 이다(Task #3315). 두 생산자가 같은 필드를 채우므로 DOM 조립부는 어느 쪽에서 왔는지
+   * 알 필요가 없다.
+   */
+  src: string;
   crop: FlowImageCrop | null;
   originalSizeHu: [number, number] | null;
   rotation: number;
@@ -109,8 +115,7 @@ export function collectFlowImagePaintOps(
         }
         images.push({
           bbox: op.bbox,
-          mime: op.mime,
-          base64: op.base64,
+          src: `data:${op.mime};base64,${op.base64}`,
           crop: isFiniteCrop(op.crop) ? op.crop : null,
           originalSizeHu: isPositiveSizeTuple(op.originalSizeHu) ? op.originalSizeHu : null,
           rotation: finiteNumber(op.transform?.rotation),
@@ -196,4 +201,61 @@ function isFiniteCrop(value: unknown): value is FlowImageCrop {
 function finiteNumber(value: unknown): number {
   const number = Number(value);
   return Number.isFinite(number) ? number : 0;
+}
+
+/**
+ * 좁은 질의(`getPageFlowImageOps`) 응답을 `FlowImagePaintOp` 로 옮긴다 (Task #3315).
+ *
+ * 위 `collectFlowImagePaintOps` 와 **같은 타입을 내는 두 번째 생산자**다. 나란히 두는 이유는
+ * 둘이 어긋나면 화면이 갈리기 때문이다 — Rust 쪽 등가성은 `tests/issue_3315_flow_image_narrow_query.rs`
+ * 가 실문서로 고정하고, 여기서는 필드 옮김만 한다.
+ *
+ * 잘림은 Rust 가 이미 조상 `clipRect` 를 교차해 접어 준다. 그래서 계보를 다시 훑지 않는다.
+ *
+ * `null` 을 돌려주면 이 경로를 쓸 수 없다는 뜻이다 — 호출부는 전체 트리 경로로 되돌아가야
+ * 한다. 그런 경우는 셋이다: ①응답이 유효한 JSON 이 아니다 ②`cacheable:false`(신원 키를 낼 수
+ * 없는 합성 그림이 섞여 바이트를 되찾을 방법이 없다) ③키로 URL 을 만들지 못했다(세대가 바뀐
+ * 낡은 키). 부분적으로 성공한 목록을 돌려주면 그림 몇 장이 조용히 사라지므로 전부 아니면 전무다.
+ */
+export function flowImageOpsFromNarrowQuery(
+  json: string,
+  resolveSrc: (key: string, mime: string) => string | null,
+): FlowImagePaintOp[] | null {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  if (payload === null || typeof payload !== 'object') return null;
+  const response = payload as { cacheable?: unknown; images?: unknown };
+  if (response.cacheable !== true) return null;
+  if (!Array.isArray(response.images)) return null;
+
+  const images: FlowImagePaintOp[] = [];
+  for (const entry of response.images) {
+    if (entry === null || typeof entry !== 'object') return null;
+    const op = entry as LayerPaintOpLike & {
+      clip?: unknown;
+      sourceImageKey?: unknown;
+    };
+    if (!isFiniteBbox(op.bbox)) return null;
+    if (typeof op.mime !== 'string' || typeof op.sourceImageKey !== 'string') return null;
+
+    const src = resolveSrc(op.sourceImageKey, op.mime);
+    if (src === null) return null;
+
+    images.push({
+      bbox: op.bbox,
+      src,
+      crop: isFiniteCrop(op.crop) ? op.crop : null,
+      originalSizeHu: isPositiveSizeTuple(op.originalSizeHu) ? op.originalSizeHu : null,
+      rotation: finiteNumber(op.transform?.rotation),
+      horzFlip: op.transform?.horzFlip === true,
+      vertFlip: op.transform?.vertFlip === true,
+      filter: composeImageFilter(op),
+      clip: isFiniteBbox(op.clip) ? op.clip : null,
+    });
+  }
+  return images;
 }

--- a/rhwp-studio/src/view/flow-image-url-cache.ts
+++ b/rhwp-studio/src/view/flow-image-url-cache.ts
@@ -1,0 +1,63 @@
+/**
+ * 그림 신원 키별 object URL 캐시 (Task #3315).
+ *
+ * 종전에는 그림마다 `data:{mime};base64,{...}` 를 만들어 `<img>.src` 에 넣었다. 그 문자열은
+ * 레이어 트리 JSON 에서 온 것이고, JSON 은 편집마다 다시 받으므로 **같은 그림의 같은 바이트를
+ * 키 입력마다 다시 옮기고 다시 문자열로 만들었다**.
+ *
+ * 신원 키(`bin:{epoch}:{bin_data_id}:{variant}`)는 바이트가 바뀌면 함께 바뀌므로, 키를 캐시
+ * 키로 쓰면 스스로 무효화된다 — 편집 때 비울 필요가 없고, 비우면 캐시를 두는 의미가 없다.
+ *
+ * ## 수명
+ *
+ * `URL.createObjectURL` 은 명시적으로 revoke 하지 않으면 문서가 살아 있는 동안 남는다. 문서를
+ * 갈아끼우면 epoch 가 올라가 옛 키는 다시 조회되지 않으므로, 그 시점에 전부 revoke 한다.
+ * 개별 항목을 참조 카운트로 회수하지는 않는다 — `<img>` 가 아직 디코드 중인 URL 을 거두면 그림이
+ * 빈 채로 남고, 페이지의 그림 수는 revoke 를 정교하게 할 만큼 크지 않다.
+ */
+export class FlowImageUrlCache {
+  private urls = new Map<string, string>();
+
+  /**
+   * 키에 해당하는 object URL. 캐시에 없으면 `loadBytes` 로 바이트를 받아 만든다.
+   *
+   * 바이트를 받을 수 없으면 `null` — 세대가 바뀐 낡은 키이거나 구형 WASM 이다. 호출부는
+   * 종전의 base64 경로로 되돌아가야 한다.
+   */
+  urlFor(
+    key: string,
+    mime: string,
+    loadBytes: (key: string) => Uint8Array | null,
+  ): string | null {
+    const cached = this.urls.get(key);
+    if (cached !== undefined) return cached;
+
+    const bytes = loadBytes(key);
+    if (bytes === null || bytes.length === 0) return null;
+
+    // Blob 은 전달한 바이트를 복사해 소유하므로, WASM 메모리가 이후 재배치돼도 안전하다.
+    // `as BlobPart` 는 저장소 관례 — lib.dom 의 BlobPart 가 SharedArrayBuffer 로 뒷받침될
+    // 수 있는 뷰를 배제하는데, 런타임은 모든 ArrayBufferView 를 받는다
+    // (`src/hwpctl/index.ts`, `src/command/commands/file.ts` 와 같은 형태).
+    const url = URL.createObjectURL(new Blob([bytes as BlobPart], { type: mime }));
+    this.urls.set(key, url);
+    return url;
+  }
+
+  /** 캐시에 들고 있는 키 수 (진단·테스트용). */
+  get size(): number {
+    return this.urls.size;
+  }
+
+  has(key: string): boolean {
+    return this.urls.has(key);
+  }
+
+  /** 문서를 갈아끼울 때·정리할 때 전부 회수한다. */
+  releaseAll(): void {
+    for (const url of this.urls.values()) {
+      URL.revokeObjectURL(url);
+    }
+    this.urls.clear();
+  }
+}

--- a/rhwp-studio/src/view/page-renderer.ts
+++ b/rhwp-studio/src/view/page-renderer.ts
@@ -12,9 +12,11 @@ import {
 import { collectVectorRawSvgDataUrls } from './raw-svg-prefetch';
 import {
   collectFlowImagePaintOps,
+  flowImageOpsFromNarrowQuery,
   visibleFlowImageBbox,
   type FlowImagePaintOp,
 } from './flow-image-clip';
+import { FlowImageUrlCache } from './flow-image-url-cache';
 import type { RenderBackend } from './render-backend';
 
 interface LayerPlaneSummary {
@@ -78,6 +80,13 @@ export class PageRenderer {
    * 비우기에 기대지 않고 항목 자체가 어느 문서의 것인지 말하게 한다.
    */
   private prefetchedImageSignatures = new Map<number, PrefetchSignature>();
+  /**
+   * DOM flow 그림의 신원 키별 object URL (Task #3315).
+   *
+   * 키가 내용에서 유도되므로 스스로 무효화된다 — 편집 때 비우지 않는다. 문서를 갈아끼울 때만
+   * 회수한다(`invalidateDocumentRevision`·`dispose`).
+   */
+  private flowImageUrls = new FlowImageUrlCache();
   private prefetchRequestTokens = new Map<number, number>();
   private nextPrefetchRequestToken = 0;
   private flowSplitSupported: boolean | null = null;
@@ -114,6 +123,8 @@ export class PageRenderer {
     this.cancelAll();
     this.releaseAllPageDiagnostics();
     this.layerSummaryCache.clear();
+    // 문서가 갈리면 옛 신원 키는 다시 조회되지 않는다 — object URL 을 여기서 거둔다(#3315).
+    this.flowImageUrls.releaseAll();
   }
 
   /** 페이지를 Canvas에 렌더링한다 (renderScale = zoom × DPR) */
@@ -480,7 +491,8 @@ export class PageRenderer {
 
       const element = new Image();
       element.alt = '';
-      element.src = `data:${image.mime};base64,${image.base64}`;
+      // data URL(전체 트리 경로) 또는 신원 키별 object URL(좁은 질의 경로) — #3315.
+      element.src = image.src;
       element.style.position = 'absolute';
       element.style.pointerEvents = 'none';
       // 그림 효과(회색조/흑백/밝기/명암) — WASM canvas 경로(render_image)와 달리
@@ -651,7 +663,28 @@ export class PageRenderer {
     );
   }
 
+  /**
+   * 본문 그림의 DOM 배치 정보.
+   *
+   * [#3315] 좁은 질의를 먼저 쓴다. 종전에는 여기서 전체 레이어 트리 JSON 을 받았는데, 그림
+   * 1장이 4.77MB 면 그 JSON 이 6.6MB 라 편집마다 경계 복사와 `JSON.parse` 로 20 ms 가 나갔다.
+   * 좁은 질의는 같은 문서에서 309 bytes 다.
+   *
+   * 캐시로는 풀 수 없다 — 본문이 흐르면 그림이 그대로여도 bbox 가 움직인다. 그래서 질의를
+   * 좁히고, **바이트만** 신원 키별 object URL 로 캐시한다.
+   *
+   * 좁은 질의를 못 쓰는 경우(구형 WASM·합성 그림이 섞인 페이지·낡은 키)에는 종전 경로로
+   * 되돌아간다. 조용히 그림을 빠뜨리는 것보다 느린 게 낫다.
+   */
   private getFlowImagePaintOps(pageIdx: number): FlowImagePaintOp[] {
+    const narrowJson = this.wasm.getPageFlowImageOps(pageIdx);
+    if (narrowJson !== null) {
+      const images = flowImageOpsFromNarrowQuery(narrowJson, (key, mime) =>
+        this.flowImageUrls.urlFor(key, mime, (k) => this.wasm.getSourceImageBytes(k)),
+      );
+      if (images !== null) return images;
+    }
+
     let json: string;
     try {
       json = this.wasm.getPageLayerTree(pageIdx);
@@ -1130,6 +1163,7 @@ export class PageRenderer {
     this.prefetchRequestTokens.clear();
     this.layerSummaryCache.clear();
     this.canvaskitDiagnosticsByPage.clear();
+    this.flowImageUrls.releaseAll();
     this.canvaskitRenderer = null;
   }
 }

--- a/rhwp-studio/tests/command-history-snapshot.test.ts
+++ b/rhwp-studio/tests/command-history-snapshot.test.ts
@@ -86,6 +86,24 @@ test('[결함3] execute 는 operation·after-save 어느 throw 에도 스냅샷�
     'after-save 가 catch 밖(try 이후)에 남아있음 — 누수 경로');
 });
 
+test('[#3350] 최초 execute 실패는 before 스냅샷 복원 후 ID를 해제한다', () => {
+  const block = methodBlock(command, 'execute(wasm: WasmBridge): DocumentPosition {');
+  const catchStart = block.search(/\}\s*catch \(operationError\)/);
+  assert.notEqual(catchStart, -1, '최초 execute 실패 catch가 있어야 함');
+  const catchBody = block.slice(catchStart);
+
+  const idxRestore = catchBody.indexOf('wasm.restoreSnapshot(this.beforeId)');
+  const idxDiscard = catchBody.indexOf('this.discard(wasm)');
+  assert.ok(idxRestore !== -1 && idxDiscard !== -1 && idxRestore < idxDiscard,
+    '부분 변경을 before 스냅샷으로 rollback한 뒤 ID를 해제해야 함');
+  assert.match(catchBody, /catch \(rollbackError\)/,
+    'rollback 실패도 별도로 포착해야 함');
+  assert.match(catchBody, /new AggregateError\(\s*\[operationError, rollbackError\]/,
+    '원래 operation 오류와 rollback 오류를 함께 보존해야 함');
+  assert.match(catchBody, /throw operationError/,
+    'rollback 성공 시 원래 operation 오류를 그대로 전파해야 함');
+});
+
 test('[결함1] 스냅샷 예산은 WASM 상한에서 순간 +2 여유를 뺀 값이다', () => {
   // 새 SnapshotCommand.execute 는 before/after 2개를 예산 강제 이전에 저장하므로,
   // 예산 == MAX 면 그 순간 store 가 MAX 초과 → WASM 무통보 축출 → orphan.

--- a/rhwp-studio/tests/issue-3315-flow-image-narrow-query.test.ts
+++ b/rhwp-studio/tests/issue-3315-flow-image-narrow-query.test.ts
@@ -1,0 +1,164 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  collectFlowImagePaintOps,
+  flowImageOpsFromNarrowQuery,
+} from '../src/view/flow-image-clip.ts';
+import { FlowImageUrlCache } from '../src/view/flow-image-url-cache.ts';
+
+// [#3315] 좁은 질의 경로와 전체 트리 경로는 같은 `FlowImagePaintOp` 를 내는 두 생산자다.
+// 둘이 어긋나면 화면이 갈리므로, 여기서는 ①필드 옮김이 맞는지 ②쓸 수 없을 때 부분 결과를
+// 내놓지 않고 전부 포기하는지를 고정한다. Rust 쪽 등가성은
+// tests/issue_3315_flow_image_narrow_query.rs 가 실문서로 잡는다.
+
+const narrowResponse = (overrides: Record<string, unknown> = {}) => JSON.stringify({
+  cacheable: true,
+  images: [
+    {
+      bbox: { x: 10, y: 20, width: 30, height: 40 },
+      clip: { x: 12, y: 22, width: 20, height: 30 },
+      mime: 'image/png',
+      sourceImageKey: 'bin:0:1:src',
+      crop: { left: 0, top: 0, right: 100, bottom: 100 },
+      originalSizeHu: [4000, 3000],
+      effect: 'grayScale',
+      brightness: 10,
+      contrast: -10,
+      transform: { rotation: 90, horzFlip: true, vertFlip: false },
+      ...overrides,
+    },
+  ],
+});
+
+const resolveOk = (key: string) => `blob:${key}`;
+
+test('좁은 질의 응답을 FlowImagePaintOp 로 옮긴다', () => {
+  const images = flowImageOpsFromNarrowQuery(narrowResponse(), resolveOk);
+
+  assert.ok(images);
+  assert.equal(images.length, 1);
+  const image = images[0];
+  assert.deepEqual(image.bbox, { x: 10, y: 20, width: 30, height: 40 });
+  assert.deepEqual(image.clip, { x: 12, y: 22, width: 20, height: 30 });
+  assert.equal(image.src, 'blob:bin:0:1:src');
+  assert.deepEqual(image.crop, { left: 0, top: 0, right: 100, bottom: 100 });
+  assert.deepEqual(image.originalSizeHu, [4000, 3000]);
+  assert.equal(image.rotation, 90);
+  assert.equal(image.horzFlip, true);
+  assert.equal(image.vertFlip, false);
+  // 효과는 값으로 받아 studio 가 조립한다 — canvas 경로와 같은 문자열이어야 한다.
+  assert.equal(image.filter, 'grayscale(100%) brightness(1.1000) contrast(0.9000)');
+});
+
+test('전체 트리 경로는 data URL 을, 좁은 질의 경로는 키별 URL 을 같은 필드에 담는다', () => {
+  const fromTree = collectFlowImagePaintOps(
+    {
+      kind: 'leaf',
+      ops: [
+        { type: 'image', bbox: { x: 1, y: 2, width: 3, height: 4 }, mime: 'image/png', base64: 'AA==' },
+      ],
+    },
+    (op) => op.type === 'image',
+  );
+  assert.equal(fromTree[0].src, 'data:image/png;base64,AA==');
+
+  const fromNarrow = flowImageOpsFromNarrowQuery(narrowResponse(), resolveOk);
+  assert.ok(fromNarrow);
+  assert.match(fromNarrow[0].src, /^blob:/);
+});
+
+test('cacheable 이 아니면 이 경로를 쓰지 않는다', () => {
+  // 신원 키를 낼 수 없는 합성 그림이 섞인 페이지 — 바이트를 되찾을 방법이 없다.
+  const json = JSON.stringify({ cacheable: false, images: [] });
+  assert.equal(flowImageOpsFromNarrowQuery(json, resolveOk), null);
+});
+
+test('키 하나라도 못 풀면 전부 포기한다', () => {
+  // 부분 목록을 돌려주면 그림 몇 장이 조용히 사라진다 — 그건 느린 것보다 나쁘다.
+  const json = JSON.stringify({
+    cacheable: true,
+    images: [
+      { bbox: { x: 0, y: 0, width: 1, height: 1 }, mime: 'image/png', sourceImageKey: 'bin:0:1:src' },
+      { bbox: { x: 5, y: 5, width: 1, height: 1 }, mime: 'image/png', sourceImageKey: 'bin:0:2:src' },
+    ],
+  });
+  const resolveSecondFails = (key: string) => (key === 'bin:0:2:src' ? null : `blob:${key}`);
+  assert.equal(flowImageOpsFromNarrowQuery(json, resolveSecondFails), null);
+});
+
+test('형식이 어긋난 응답은 되돌림을 유발한다', () => {
+  for (const json of [
+    'not json',
+    'null',
+    '[]',
+    JSON.stringify({ cacheable: true }),
+    JSON.stringify({ cacheable: true, images: [null] }),
+    // bbox 없음
+    JSON.stringify({ cacheable: true, images: [{ mime: 'image/png', sourceImageKey: 'bin:0:1:src' }] }),
+    // 키 없음 — 바이트를 받을 수 없다
+    JSON.stringify({ cacheable: true, images: [{ bbox: { x: 0, y: 0, width: 1, height: 1 }, mime: 'image/png' }] }),
+  ]) {
+    assert.equal(flowImageOpsFromNarrowQuery(json, resolveOk), null, `되돌려야 한다: ${json}`);
+  }
+});
+
+test('빈 목록은 유효한 결과다 — 그림 없는 쪽에서 전체 트리를 받지 않는다', () => {
+  const images = flowImageOpsFromNarrowQuery(
+    JSON.stringify({ cacheable: true, images: [] }),
+    resolveOk,
+  );
+  assert.deepEqual(images, []);
+});
+
+// ── object URL 캐시 ──
+
+test('object URL 캐시는 키당 한 번만 바이트를 받는다', () => {
+  const revoked: string[] = [];
+  const created: string[] = [];
+  const originalCreate = globalThis.URL.createObjectURL;
+  const originalRevoke = globalThis.URL.revokeObjectURL;
+  let counter = 0;
+  globalThis.URL.createObjectURL = () => {
+    const url = `blob:stub/${++counter}`;
+    created.push(url);
+    return url;
+  };
+  globalThis.URL.revokeObjectURL = (url: string) => {
+    revoked.push(url);
+  };
+
+  try {
+    const cache = new FlowImageUrlCache();
+    let loads = 0;
+    const loadBytes = () => {
+      loads += 1;
+      return new Uint8Array([1, 2, 3]);
+    };
+
+    const first = cache.urlFor('bin:0:1:src', 'image/png', loadBytes);
+    const second = cache.urlFor('bin:0:1:src', 'image/png', loadBytes);
+    assert.equal(first, second, '같은 키는 같은 URL');
+    assert.equal(loads, 1, '바이트는 한 번만 받는다 — 편집마다 다시 받으면 캐시가 무의미하다');
+    assert.equal(cache.size, 1);
+    assert.equal(cache.has('bin:0:1:src'), true);
+
+    cache.urlFor('bin:0:2:src', 'image/png', loadBytes);
+    assert.equal(cache.size, 2);
+
+    cache.releaseAll();
+    assert.equal(cache.size, 0);
+    assert.deepEqual(revoked, created, '회수하지 않으면 문서를 갈아끼울 때마다 URL 이 쌓인다');
+  } finally {
+    globalThis.URL.createObjectURL = originalCreate;
+    globalThis.URL.revokeObjectURL = originalRevoke;
+  }
+});
+
+test('바이트를 받을 수 없으면 URL 을 만들지 않는다', () => {
+  const cache = new FlowImageUrlCache();
+  assert.equal(cache.urlFor('bin:9:1:src', 'image/png', () => null), null);
+  // 빈 바이트도 그림이 될 수 없다 — 캐시에 남겨 두면 다음 조회가 빈 URL 을 재사용한다.
+  assert.equal(cache.urlFor('bin:9:2:src', 'image/png', () => new Uint8Array()), null);
+  assert.equal(cache.size, 0);
+});

--- a/rhwp-studio/tests/render-backend.test.ts
+++ b/rhwp-studio/tests/render-backend.test.ts
@@ -428,9 +428,27 @@ test('PageRenderer splits flow static images before the first Canvas2D flow rend
   assert.doesNotMatch(source, /'flow-static',\s*layers,\s*allowReuse,\s*false/);
   assert.match(source, /createOrReuseFlowImageLayer\(/);
   assert.match(source, /usesDomFlowImages \? overlays\.rawSvgCount/);
-  assert.match(source, /element\.src = `data:\$\{image\.mime\};base64,\$\{image\.base64\}`/);
+  // [#3315] DOM <img> 는 생산자가 정한 src 를 그대로 쓴다 — 전체 트리 경로의 data URL 이든
+  // 좁은 질의 경로의 신원 키별 object URL 이든 조립부는 분기하지 않는다.
+  assert.match(source, /element\.src = image\.src/);
   assert.match(source, /HWP_UNITS_PER_CSS_PIXEL = 75/);
   assert.match(source, /applyFlowImageCrop\(element, image, displayScale\)/);
+});
+
+// [#3315] 편집마다 전체 레이어 트리(그림 1장에 6.6MB)를 받던 자리를 좁은 질의가 대체한다.
+// 못 쓰는 경우에는 반드시 종전 경로로 되돌아가야 한다 — 조용히 그림을 빠뜨리면 안 된다.
+test('PageRenderer prefers the narrow flow-image query and keeps the full-tree fallback', () => {
+  const source = readFileSync(new URL('../src/view/page-renderer.ts', import.meta.url), 'utf8');
+  assert.match(source, /this\.wasm\.getPageFlowImageOps\(pageIdx\)/);
+  assert.match(source, /flowImageOpsFromNarrowQuery\(/);
+  assert.match(source, /this\.wasm\.getSourceImageBytes\(k\)/);
+  // fallback 경로가 남아 있어야 한다.
+  assert.match(source, /this\.wasm\.getPageLayerTree\(pageIdx\)/);
+  assert.match(source, /collectFlowImagePaintOps\(/);
+  // object URL 은 문서를 갈아끼울 때와 정리할 때 회수한다.
+  assert.match(source, /private flowImageUrls = new FlowImageUrlCache\(\)/);
+  const releaseSites = source.match(/this\.flowImageUrls\.releaseAll\(\)/g) ?? [];
+  assert.equal(releaseSites.length, 2, 'invalidateDocumentRevision 과 dispose 두 곳에서 회수');
 });
 
 test('PageRenderer deferred image rerender preserves static layer reuse policy', () => {

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -1373,11 +1373,28 @@ impl DocumentCore {
         page_num: u32,
         profile: RenderProfile,
     ) -> Result<String, HwpError> {
+        self.get_page_layer_tree_with_options_native(
+            page_num,
+            profile,
+            crate::paint::LayerJsonOptions::default(),
+        )
+    }
+
+    /// [Task #3315] `options` 로 그림 base64 생략을 켤 수 있는 레이어 트리 JSON.
+    ///
+    /// 생략본과 종전 JSON 은 **서로 다른 캐시 변형**이다 — 같은 슬롯을 쓰면 한쪽 소비자가
+    /// 다른 쪽 모양을 받는다. 그래서 아래 지문에 생략 여부를 함께 접는다.
+    pub fn get_page_layer_tree_with_options_native(
+        &self,
+        page_num: u32,
+        profile: RenderProfile,
+        options: crate::paint::LayerJsonOptions,
+    ) -> Result<String, HwpError> {
         // [Task #2222] 직렬화 JSON 캐시 — 트리 캐시(#2227 with_page_tree_cached)가
         // 있어도 1MB 급 재직렬화가 renderPage 마다 렌더 비용과 맞먹게 반복된다
         // (주보 p2 실측: 15.2ms/회, JSON 1.05MB). 출력옵션 지문이 다르면 미스.
         let idx = page_num as usize;
-        let fp = self.layer_output_options_fingerprint(profile);
+        let fp = self.layer_output_options_fingerprint(profile, options);
         if let Some(variants) = self.layer_tree_json_cache.borrow().get(idx) {
             if let Some((_, json)) = variants.iter().find(|(f, _)| *f == fp) {
                 return Ok(json.clone());
@@ -1385,7 +1402,7 @@ impl DocumentCore {
         }
         let json = self
             .build_page_layer_tree_with_profile(page_num, profile)?
-            .to_json();
+            .to_json_with_options(options);
         {
             // 토글(투명선/잘림보기 등) 왕복이 매번 미스가 되지 않도록 페이지당
             // 옵션 변형 4개까지 보관 (초과 시 가장 오래된 변형 제거).
@@ -1404,7 +1421,12 @@ impl DocumentCore {
     }
 
     /// [Task #2222] 레이어 출력옵션 5종과 profile의 비트 지문 — JSON 캐시 키.
-    fn layer_output_options_fingerprint(&self, profile: RenderProfile) -> u8 {
+    /// [Task #3315] 그림 바이트 생략 여부를 최상위 비트에 함께 접는다.
+    fn layer_output_options_fingerprint(
+        &self,
+        profile: RenderProfile,
+        options: crate::paint::LayerJsonOptions,
+    ) -> u8 {
         let profile_bits = match profile {
             RenderProfile::FastPreview => 0,
             RenderProfile::Screen => 1,
@@ -1417,6 +1439,7 @@ impl DocumentCore {
             | (u8::from(self.clip_enabled) << 3)
             | (u8::from(self.debug_overlay) << 4)
             | (profile_bits << 5)
+            | (u8::from(options.omit_image_bytes) << 7)
     }
 
     /// 페이지가 그리는 그림들의 신원 키만 작은 JSON 으로 반환한다 (Task #3315).
@@ -1470,6 +1493,32 @@ impl DocumentCore {
         }
         buf.push_str("]}");
         Ok(buf)
+    }
+
+    /// 그림 신원 키로 그 op 이 내보내는 바이트와 mime 을 되돌려준다 (Task #3315).
+    ///
+    /// `get_page_layer_tree_with_options_native` 가 base64 를 생략했을 때 소비자가 바이트를
+    /// 받는 경로다. 반환값은 인라인 base64 가 담고 있던 것과 **같은 바이트여야** 하므로 변환은
+    /// JSON 경로와 같은 `emitted_image_bytes` 를 쓴다 — 사본을 두면 두 경로가 갈라진다.
+    ///
+    /// 키의 epoch 가 현재 문서 세대와 다르면 `None` 이다. 스냅샷 복원처럼 id→바이트 대응이
+    /// 깨지는 연산 뒤에 옛 키로 물어본 경우이므로, 낡은 바이트를 주는 대신 소비자가 트리를
+    /// 다시 받게 한다.
+    ///
+    /// 세션에 삽입한 그림은 `load_shared()` 가 같은 할당을 돌려주지만(#3411), 파일에서 읽은
+    /// `Loaded` 바이트는 여기서 한 벌 복사된다. 이 조회는 페이지의 그림이 바뀔 때만 불리므로
+    /// 키 입력마다 도는 경로가 아니다.
+    pub fn get_source_image_bytes_native(&self, key: &str) -> Option<(&'static str, Vec<u8>)> {
+        let (epoch, bin_data_id, variant) = crate::paint::parse_source_image_key(key)?;
+        if epoch != self.bin_data_epoch {
+            return None;
+        }
+        let content =
+            crate::renderer::layout::find_bin_data(&self.document.bin_data_content, bin_data_id)?;
+        let data = content.data.load_shared();
+        let (mime, bytes) =
+            crate::renderer::image_resolver::emitted_image_bytes(&data, variant.bakes_watermark());
+        Some((mime, bytes.into_owned()))
     }
 
     /// 페이지 overlay 이미지와 replay-plane summary만 작은 JSON으로 반환한다.

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -1521,6 +1521,222 @@ impl DocumentCore {
         Some((mime, bytes.into_owned()))
     }
 
+    /// 본문(flow) 그림의 **배치 정보만** 작은 JSON 으로 반환한다 (Task #3315).
+    ///
+    /// studio 는 flow 그림을 DOM `<img>` 로 내보내려고 편집마다 전체 레이어 트리 JSON 을
+    /// 받아 왔다(`getFlowImagePaintOps`). 그림 1장이 4.77MB 면 그 JSON 이 6.6MB 라, 경계
+    /// 복사와 `JSON.parse` 만으로 키 입력당 20 ms 가 나갔다.
+    ///
+    /// 캐시로는 풀 수 없는 문제다 — 본문이 흐르면 그림 bbox 가 움직이므로 그림이 그대로여도
+    /// 결과가 달라진다. 그래서 캐시가 아니라 **질의를 좁힌다**: 바이트를 빼고 bbox·clip·
+    /// 효과·신원 키만 준다. 바이트는 `get_source_image_bytes_native(key)` 로 그림이 바뀔 때만
+    /// 따로 받는다.
+    ///
+    /// `clip` 은 조상 `ClipRect` 를 교차해 접은 값이다. 소비자가 트리 없이도 같은 잘림을
+    /// 재현할 수 있어야 하므로, 계보를 넘기는 대신 결과만 준다. 교차가 비면 그 그림은 보이지
+    /// 않으므로 목록에서 빠진다.
+    ///
+    /// `sourceImageKey` 를 낼 수 없는 그림(`bin_data_id == 0` 합성 그림)이 하나라도 있으면
+    /// `cacheable:false` 다 — 소비자는 그 페이지에 한해 종전의 전체 트리 경로로 되돌아가야
+    /// 한다. 키가 없으면 바이트를 받을 방법이 없기 때문이다.
+    pub fn get_page_flow_image_ops_native(&self, page_num: u32) -> Result<String, HwpError> {
+        use crate::paint::{
+            paint_op_replay_plane_with_layer, LayerNode, LayerNodeKind, PaintOp, PaintReplayPlane,
+        };
+        use crate::renderer::render_tree::{BoundingBox, RenderLayerInfo};
+
+        fn intersect(first: Option<BoundingBox>, second: BoundingBox) -> Option<BoundingBox> {
+            let Some(first) = first else {
+                return Some(second);
+            };
+            let left = first.x.max(second.x);
+            let top = first.y.max(second.y);
+            let right = (first.x + first.width).min(second.x + second.width);
+            let bottom = (first.y + first.height).min(second.y + second.height);
+            if right <= left || bottom <= top {
+                return None;
+            }
+            Some(BoundingBox {
+                x: left,
+                y: top,
+                width: right - left,
+                height: bottom - top,
+            })
+        }
+
+        fn write_bbox(buf: &mut String, bbox: BoundingBox) {
+            let _ = write!(
+                buf,
+                "{{\"x\":{:.3},\"y\":{:.3},\"width\":{:.3},\"height\":{:.3}}}",
+                bbox.x, bbox.y, bbox.width, bbox.height
+            );
+        }
+
+        struct Collector {
+            images: String,
+            epoch: u32,
+            cacheable: bool,
+        }
+
+        impl Collector {
+            fn visit(
+                &mut self,
+                node: &LayerNode,
+                inherited_layer: Option<RenderLayerInfo>,
+                clip: Option<BoundingBox>,
+            ) {
+                let active_layer = node.layer.or(inherited_layer);
+                match &node.kind {
+                    LayerNodeKind::Group { children, .. } => {
+                        for child in children {
+                            self.visit(child, active_layer, clip);
+                        }
+                    }
+                    LayerNodeKind::ClipRect {
+                        child,
+                        clip: node_clip,
+                        ..
+                    } => {
+                        // 교차가 비면 이 아래는 전부 보이지 않는다 — 내려가지 않는다.
+                        if let Some(next) = intersect(clip, *node_clip) {
+                            self.visit(child, active_layer, Some(next));
+                        }
+                    }
+                    LayerNodeKind::Leaf { ops } => {
+                        for op in ops {
+                            let PaintOp::Image {
+                                bbox,
+                                image,
+                                resolved,
+                            } = op
+                            else {
+                                continue;
+                            };
+                            if paint_op_replay_plane_with_layer(op, active_layer)
+                                != PaintReplayPlane::Flow
+                            {
+                                continue;
+                            }
+                            let Some(data) = image.data.as_deref() else {
+                                continue;
+                            };
+                            // 보이는 영역이 없으면 소비자가 그릴 것도 없다.
+                            let Some(visible) = intersect(clip, *bbox) else {
+                                continue;
+                            };
+                            let key = crate::paint::source_image_key(self.epoch, image);
+                            if key.is_none() {
+                                self.cacheable = false;
+                            }
+                            self.write_image(
+                                *bbox,
+                                visible,
+                                clip,
+                                image,
+                                resolved.as_deref(),
+                                data,
+                                key,
+                            );
+                        }
+                    }
+                }
+            }
+
+            #[allow(clippy::too_many_arguments)]
+            fn write_image(
+                &mut self,
+                bbox: BoundingBox,
+                visible: BoundingBox,
+                clip: Option<BoundingBox>,
+                image: &crate::renderer::render_tree::ImageNode,
+                resolved: Option<&crate::paint::ResolvedImagePayload>,
+                data: &[u8],
+                key: Option<String>,
+            ) {
+                let buf = &mut self.images;
+                if !buf.is_empty() {
+                    buf.push(',');
+                }
+                buf.push_str("{\"bbox\":");
+                write_bbox(buf, bbox);
+                // 잘림이 실제로 그림을 자를 때만 싣는다 — 소비자가 wrapper 를 만들 조건과 같다.
+                if clip.is_some()
+                    && (visible.x != bbox.x
+                        || visible.y != bbox.y
+                        || visible.width != bbox.width
+                        || visible.height != bbox.height)
+                {
+                    buf.push_str(",\"clip\":");
+                    write_bbox(buf, visible);
+                }
+                let mime = crate::renderer::image_resolver::emitted_image_mime(
+                    data,
+                    resolved,
+                    crate::renderer::image_resolver::is_watermark_image(image),
+                );
+                let _ = write!(buf, ",\"mime\":\"{}\"", mime);
+                match key {
+                    Some(key) => {
+                        let _ = write!(
+                            buf,
+                            ",\"sourceImageKey\":\"{}\"",
+                            crate::document_core::helpers::json_escape(&key)
+                        );
+                    }
+                    None => buf.push_str(",\"sourceImageKey\":null"),
+                }
+                if let Some((left, top, right, bottom)) = image.crop {
+                    let _ = write!(
+                        buf,
+                        ",\"crop\":{{\"left\":{},\"top\":{},\"right\":{},\"bottom\":{}}}",
+                        left, top, right, bottom
+                    );
+                }
+                if let Some((width, height)) = image.original_size_hu {
+                    let _ = write!(buf, ",\"originalSizeHu\":[{},{}]", width, height);
+                }
+                // 효과는 값으로 넘긴다 — CSS filter 조립은 studio 의 `composeImageFilter` 가
+                // `web_canvas.rs::compose_image_filter` 와 맞춰 두었으므로 여기서 되풀이하지 않는다.
+                let _ = write!(
+                    buf,
+                    ",\"effect\":\"{}\",\"brightness\":{},\"contrast\":{}",
+                    match image.effect {
+                        crate::model::image::ImageEffect::RealPic => "realPic",
+                        crate::model::image::ImageEffect::GrayScale => "grayScale",
+                        crate::model::image::ImageEffect::BlackWhite => "blackWhite",
+                        crate::model::image::ImageEffect::Pattern8x8 => "pattern8x8",
+                    },
+                    image.brightness,
+                    image.contrast
+                );
+                if matches!(
+                    resolved.map(|payload| payload.kind),
+                    Some(crate::paint::ResolvedImageKind::BakedWatermark)
+                ) {
+                    buf.push_str(",\"bakedWatermark\":true");
+                }
+                let _ = write!(
+                    buf,
+                    ",\"transform\":{{\"rotation\":{:.3},\"horzFlip\":{},\"vertFlip\":{}}}}}",
+                    image.transform.rotation, image.transform.horz_flip, image.transform.vert_flip
+                );
+            }
+        }
+
+        let tree = self.build_page_layer_tree(page_num)?;
+        let mut collector = Collector {
+            images: String::new(),
+            epoch: self.bin_data_epoch,
+            cacheable: true,
+        };
+        collector.visit(&tree.root, None, None);
+
+        Ok(format!(
+            "{{\"cacheable\":{},\"images\":[{}]}}",
+            collector.cacheable, collector.images
+        ))
+    }
+
     /// 페이지 overlay 이미지와 replay-plane summary만 작은 JSON으로 반환한다.
     ///
     /// Studio는 BehindText/InFrontOfText 그림 overlay 계산을 위해 전체 PageLayerTree JSON을

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -68,13 +68,37 @@ const KNOWN_TEXT_FEATURES: &[&str] = &[
     "text.vertical.mixedPerGlyph",
 ];
 
+/// 레이어 트리 JSON 직렬화 옵션 (Task #3315).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct LayerJsonOptions {
+    /// 그림 바이트를 base64 로 싣지 않는다.
+    ///
+    /// `sourceImageKey` 를 낼 수 있는 op 만 대상이다 — 키가 없으면 소비자가 바이트를 되찾을
+    /// 길이 없으므로 그 op 은 종전대로 base64 를 싣는다. 기본값이 `false` 라서 이 옵션을
+    /// 지정하지 않는 기존 호출부의 JSON 은 한 바이트도 달라지지 않는다.
+    pub omit_image_bytes: bool,
+}
+
+/// 직렬화 도중 트리 아래로 흘려야 하는 값. 그림 op 하나를 쓰려면 문서 세대(키 발급)와
+/// 생략 여부가 함께 필요해 한 덩이로 옮겼다.
+#[derive(Debug, Clone, Copy)]
+struct JsonWriteContext {
+    bin_data_epoch: u32,
+    options: LayerJsonOptions,
+}
+
 impl PageLayerTree {
     pub fn to_json(&self) -> String {
+        self.to_json_with_options(LayerJsonOptions::default())
+    }
+
+    /// [Task #3315] 그림 base64 생략을 켤 수 있는 직렬화. `to_json()` 은 기본 옵션 위임이다.
+    pub fn to_json_with_options(&self, options: LayerJsonOptions) -> String {
         let mut buf = String::with_capacity(32_768);
         buf.push('{');
         let _ = write!(
             buf,
-            "\"schemaVersion\":{},\"schemaMinorVersion\":{},\"schema\":{{\"major\":{},\"minor\":{}}},\"resourceTableVersion\":{},\"resourceTableMinorVersion\":{},\"resourceTable\":{{\"major\":{},\"minor\":{}}},\"unit\":{},\"coordinateSystem\":{},\"profile\":{},\"buildOptions\":{{\"showTransparentBorders\":{},\"clipEnabled\":{}}},\"debugOptions\":{{\"debugOverlay\":{}}},\"outputOptions\":{{\"showParagraphMarks\":{},\"showControlCodes\":{},\"showTransparentBorders\":{},\"clipEnabled\":{},\"debugOverlay\":{}}},\"pageWidth\":{:.3},\"pageHeight\":{:.3},\"root\":",
+            "\"schemaVersion\":{},\"schemaMinorVersion\":{},\"schema\":{{\"major\":{},\"minor\":{}}},\"resourceTableVersion\":{},\"resourceTableMinorVersion\":{},\"resourceTable\":{{\"major\":{},\"minor\":{}}},\"unit\":{},\"coordinateSystem\":{},\"profile\":{},\"imageBytes\":{},\"buildOptions\":{{\"showTransparentBorders\":{},\"clipEnabled\":{}}},\"debugOptions\":{{\"debugOverlay\":{}}},\"outputOptions\":{{\"showParagraphMarks\":{},\"showControlCodes\":{},\"showTransparentBorders\":{},\"clipEnabled\":{},\"debugOverlay\":{}}},\"pageWidth\":{:.3},\"pageHeight\":{:.3},\"root\":",
             LAYER_TREE_SCHEMA.schema_version,
             LAYER_TREE_SCHEMA.schema_minor_version,
             LAYER_TREE_SCHEMA.schema_version,
@@ -86,6 +110,13 @@ impl PageLayerTree {
             json_escape(LAYER_TREE_SCHEMA.unit),
             json_escape(LAYER_TREE_SCHEMA.coordinate_system),
             json_escape(render_profile_str(self.profile)),
+            // [#3315] 그림 바이트가 op 안에 있는지(`inline`), 키로 따로 받아야 하는지(`byKey`).
+            // 소비자가 op 마다 `base64` 유무를 추측하지 않고 문서 단위로 판정할 수 있게 한다.
+            json_escape(if options.omit_image_bytes {
+                "byKey"
+            } else {
+                "inline"
+            }),
             self.output_options.show_transparent_borders,
             self.output_options.clip_enabled,
             self.output_options.debug_overlay,
@@ -102,7 +133,10 @@ impl PageLayerTree {
             &mut buf,
             &mut text_source_state,
             &self.resources,
-            self.resources.source_image_epoch(),
+            JsonWriteContext {
+                bin_data_epoch: self.resources.source_image_epoch(),
+                options,
+            },
         );
         buf.push_str(",\"textSources\":");
         write_text_source_entries(&mut buf, &self.text_sources);
@@ -382,7 +416,7 @@ impl LayerNode {
         buf: &mut String,
         text_sources: &mut TextSourceExportState,
         resources: &ResourceArena,
-        bin_data_epoch: u32,
+        ctx: JsonWriteContext,
     ) {
         buf.push('{');
         buf.push_str("\"bounds\":");
@@ -412,7 +446,7 @@ impl LayerNode {
                     if idx > 0 {
                         buf.push(',');
                     }
-                    child.write_json(buf, text_sources, resources, bin_data_epoch);
+                    child.write_json(buf, text_sources, resources, ctx);
                 }
                 buf.push(']');
             }
@@ -429,7 +463,7 @@ impl LayerNode {
                     json_escape(clip_kind_str(*clip_kind))
                 );
                 buf.push_str(",\"child\":");
-                child.write_json(buf, text_sources, resources, bin_data_epoch);
+                child.write_json(buf, text_sources, resources, ctx);
             }
             LayerNodeKind::Leaf { ops } => {
                 buf.push_str(",\"kind\":\"leaf\",\"ops\":[");
@@ -438,7 +472,7 @@ impl LayerNode {
                     if idx > 0 {
                         buf.push(',');
                     }
-                    op.write_json(buf, text_sources, &leaf_visuals, resources, bin_data_epoch);
+                    op.write_json(buf, text_sources, &leaf_visuals, resources, ctx);
                 }
                 buf.push(']');
             }
@@ -454,7 +488,7 @@ impl PaintOp {
         text_sources: &mut TextSourceExportState,
         leaf_visuals: &LeafTextVisualOps,
         resources: &ResourceArena,
-        bin_data_epoch: u32,
+        ctx: JsonWriteContext,
     ) {
         match self {
             PaintOp::PageBackground { bbox, background } => {
@@ -834,47 +868,47 @@ impl PaintOp {
                 buf.push('{');
                 buf.push_str("\"type\":\"image\",\"bbox\":");
                 write_bbox(buf, *bbox);
+                // [#3315] 키가 있는 op 만 base64 를 생략할 수 있다 — 소비자가 그 키로
+                // `getSourceImageBytes` 를 불러 같은 바이트를 받는다. 키를 낼 수 없는 합성
+                // 그림(`bin_data_id == 0`)은 되찾을 길이 없으므로 종전대로 싣는다.
+                let source_image_key = crate::paint::source_image_key(ctx.bin_data_epoch, image);
+                let omit_bytes = ctx.options.omit_image_bytes && source_image_key.is_some();
                 if let Some(payload) = resolved.as_deref() {
-                    let _ = write!(buf, ",\"mime\":\"{}\",\"base64\":", payload.mime);
-                    write_json_base64(buf, &payload.data[..]);
+                    if omit_bytes {
+                        let _ = write!(
+                            buf,
+                            ",\"mime\":\"{}\",\"imageBytesOmitted\":true",
+                            payload.mime
+                        );
+                    } else {
+                        let _ = write!(buf, ",\"mime\":\"{}\",\"base64\":", payload.mime);
+                        write_json_base64(buf, &payload.data[..]);
+                    }
                     if matches!(payload.kind, ResolvedImageKind::BakedWatermark) {
                         buf.push_str(",\"bakedWatermark\":true");
                     }
                 } else if let Some(data) = &image.data {
                     // Task #516 Stage 5.2: overlay layer 의 <img> data URL 생성용 mime 노출.
                     // PCX 등 비표준은 PNG 변환 후 emit (CLI SVG 와 동일 정책 적용).
-                    let mime = crate::renderer::svg::detect_image_mime_type(data);
-                    let (final_mime, final_data): (&str, std::borrow::Cow<[u8]>) = if mime
-                        == "image/x-pcx"
-                    {
-                        match crate::renderer::svg::pcx_bytes_to_png_bytes(data) {
-                            Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
-                            None => (mime, std::borrow::Cow::Borrowed(&data[..])),
-                        }
-                    } else if mime == "image/bmp" {
-                        match crate::renderer::svg::bmp_bytes_to_png_bytes(data) {
-                            Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
-                            None => (mime, std::borrow::Cow::Borrowed(&data[..])),
-                        }
-                    } else if mime == "image/tiff" {
-                        match crate::renderer::image_resolver::tiff_bytes_to_png_bytes(data) {
-                            Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
-                            None => (mime, std::borrow::Cow::Borrowed(&data[..])),
-                        }
-                    } else if mime == "image/jpeg" {
-                        match crate::renderer::image_resolver::grayscale_jpeg_bytes_to_png_bytes(
+                    // [#3315] 변환 사슬의 단일 권위는 `emitted_image_bytes` 다 — 키로 바이트를
+                    // 되돌려주는 경로가 같은 함수를 써야 두 결과가 갈라지지 않는다.
+                    let (final_mime, final_data) =
+                        crate::renderer::image_resolver::emitted_image_bytes(
                             data,
-                        ) {
-                            Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
-                            None => (mime, std::borrow::Cow::Borrowed(&data[..])),
-                        }
+                            crate::renderer::image_resolver::is_watermark_image(image),
+                        );
+                    if omit_bytes {
+                        let _ = write!(
+                            buf,
+                            ",\"mime\":\"{}\",\"imageBytesOmitted\":true",
+                            final_mime
+                        );
                     } else {
-                        (mime, std::borrow::Cow::Borrowed(&data[..]))
-                    };
-                    let _ = write!(buf, ",\"mime\":\"{}\",\"base64\":", final_mime);
-                    write_json_base64(buf, &final_data);
+                        let _ = write!(buf, ",\"mime\":\"{}\",\"base64\":", final_mime);
+                        write_json_base64(buf, &final_data);
+                    }
                 }
-                if let Some(key) = crate::paint::source_image_key(bin_data_epoch, image) {
+                if let Some(key) = source_image_key {
                     let _ = write!(buf, ",\"sourceImageKey\":{}", json_escape(&key));
                 }
                 if let Some(fill_mode) = image.fill_mode {
@@ -4290,7 +4324,11 @@ mod tests {
 
         let json = tree.to_json();
 
-        assert!(json.contains("\"schemaMinorVersion\":20"));
+        // 상수에서 끌어온다 — 숫자를 박아 두면 schema minor 를 올릴 때마다 무관한 테스트가 깨진다.
+        assert!(json.contains(&format!(
+            "\"schemaMinorVersion\":{}",
+            LAYER_TREE_SCHEMA.schema_minor_version
+        )));
         assert!(json.contains("\"payloadResourceKey\":\"glyphPayload:bitmapGlyph:imageRef:0"));
         assert!(json.contains("placement:0.123,0.568,10.988,10.543"));
         assert!(json.contains(&format!(":resource:{image_resource_key}\"")));

--- a/src/paint/mod.rs
+++ b/src/paint/mod.rs
@@ -32,6 +32,7 @@ pub use font_glyph::{
     FontBitmapGlyphDecodeError, FontBitmapGlyphDecodeOptions, FontGlyphLoweringReport,
     FontSvgGlyphDecodeError, FontSvgGlyphDecodeOptions,
 };
+pub use json::LayerJsonOptions;
 pub use layer_tree::{
     CacheHint, ClipKind, GroupKind, LayerNode, LayerNodeKind, LayerOutputOptions, PageLayerTree,
     TextSourceAnnotation, TextSourceEntry, TextSourceId, TextSourceRange, TextSourceSpan,
@@ -57,9 +58,9 @@ pub use replay_order::{
     PaintReplayPlane,
 };
 pub use resources::{
-    font_blob_resource_key, image_resource_key, resource_digest_hex, source_image_key,
-    svg_resource_key, FontBlobResourceId, ImageResourceId, ResourceArena, SvgResourceId,
-    RESOURCE_KEY_ALGORITHM,
+    font_blob_resource_key, image_resource_key, parse_source_image_key, resource_digest_hex,
+    source_image_key, svg_resource_key, FontBlobResourceId, ImageResourceId, ResourceArena,
+    SourceImageVariant, SvgResourceId, RESOURCE_KEY_ALGORITHM,
 };
 pub use schema::{
     LayerTreeSchema, LAYER_TREE_SCHEMA, PAGE_LAYER_TREE_COORDINATE_SYSTEM,

--- a/src/paint/resources.rs
+++ b/src/paint/resources.rs
@@ -269,15 +269,66 @@ pub fn source_image_key(
         return None;
     }
 
+    // 술어는 `image_resolver::is_watermark_image` 가 단일 권위다 — 여기서 사본을 들면
+    // 키가 가리키는 바이트와 실제로 내보내는 바이트가 조용히 갈라진다 (#3315).
     let bakes_watermark = crate::renderer::image_resolver::detect_image_mime_type(data)
         == "image/jpeg"
-        && !matches!(image.effect, crate::model::image::ImageEffect::RealPic)
-        && (image.brightness != 0 || image.contrast != 0);
-    let variant = if bakes_watermark { "wmpng" } else { "src" };
+        && crate::renderer::image_resolver::is_watermark_image(image);
+    let variant = if bakes_watermark {
+        SourceImageVariant::BakedWatermarkPng
+    } else {
+        SourceImageVariant::Source
+    };
     Some(format!(
-        "bin:{bin_data_epoch}:{}:{variant}",
-        image.bin_data_id
+        "bin:{bin_data_epoch}:{}:{}",
+        image.bin_data_id,
+        variant.as_str()
     ))
+}
+
+/// `source_image_key` 의 variant — 같은 원본에서 다른 바이트가 나오는 갈림 (Task #3315).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceImageVariant {
+    /// 원본 바이트. 브라우저가 못 읽는 포맷(BMP/PCX/TIFF/회색 JPEG)이면 PNG 변환까지.
+    Source,
+    /// JPEG 워터마크를 한컴 규칙으로 bake 한 PNG.
+    BakedWatermarkPng,
+}
+
+impl SourceImageVariant {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SourceImageVariant::Source => "src",
+            SourceImageVariant::BakedWatermarkPng => "wmpng",
+        }
+    }
+
+    pub fn bakes_watermark(self) -> bool {
+        matches!(self, SourceImageVariant::BakedWatermarkPng)
+    }
+}
+
+/// `source_image_key` 가 만든 키를 되읽는다 (Task #3315).
+///
+/// 발급과 해석을 같은 모듈에 묶는다 — 소비자가 문자열을 직접 쪼개게 두면 접두어나 variant
+/// 를 바꿀 때 조용히 어긋난다. 모르는 variant 는 받아들이지 않는다: `src` 로 넘겨 버리면
+/// 워터마크 그림에 원본 JPEG 을 돌려주고도 성공한 것처럼 보인다.
+pub fn parse_source_image_key(key: &str) -> Option<(u32, u16, SourceImageVariant)> {
+    let mut parts = key.split(':');
+    if parts.next()? != "bin" {
+        return None;
+    }
+    let epoch = parts.next()?.parse::<u32>().ok()?;
+    let bin_data_id = parts.next()?.parse::<u16>().ok()?;
+    let variant = match parts.next()? {
+        "src" => SourceImageVariant::Source,
+        "wmpng" => SourceImageVariant::BakedWatermarkPng,
+        _ => return None,
+    };
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((epoch, bin_data_id, variant))
 }
 
 pub fn svg_resource_key(byte_len: usize, digest: &str) -> String {

--- a/src/paint/schema.rs
+++ b/src/paint/schema.rs
@@ -15,7 +15,9 @@ pub struct LayerTreeSchema {
 
 pub const LAYER_TREE_SCHEMA: LayerTreeSchema = LayerTreeSchema {
     schema_version: 1,
-    schema_minor_version: 20,
+    // 21: [#3315] 문서 단위 `imageBytes`("inline"|"byKey")와 그림 op 의 `imageBytesOmitted`.
+    //     생략은 opt-in 이라 기존 소비자가 받는 JSON 은 종전과 같다.
+    schema_minor_version: 21,
     resource_table_version: 1,
     resource_table_minor_version: 5,
     unit: "px",

--- a/src/renderer/image_resolver.rs
+++ b/src/renderer/image_resolver.rs
@@ -167,6 +167,37 @@ pub(crate) fn resolve_image_payload(image: &ImageNode) -> Option<ResolvedImagePa
     }
 }
 
+/// 그림 op 이 실제로 내보내는 바이트와 mime 을 결정한다 (Task #3315).
+///
+/// `resolve_image_payload` 는 변환에 **성공한** 경우만 payload 를 주고, 실패하면 `None` 이라
+/// 호출부가 원본 바이트로 되돌아간다. 그래서 "JSON 에 실린 바이트"는 두 분기의 합이었고,
+/// `paint/json.rs` 가 그 되돌림 사슬을 사본으로 들고 있었다. base64 를 생략한 뒤 키로 같은
+/// 바이트를 되돌려주려면 **최종 결과가 한 곳에서만 정해져야** 한다 — 두 곳에 두면 갈라진다.
+///
+/// `bakes_watermark` 는 `paint::source_image_key` 의 variant 판정과 같은 값이다. 키가 이미
+/// variant 를 담고 있으므로 키로 조회할 때는 `ImageNode` 없이도 같은 바이트를 재현한다.
+/// 워터마크 bake 가 실패하면 회색 JPEG 경로로 내려가는데, 이는 `resolved == None` 일 때
+/// json 쪽 되돌림이 하던 것과 같은 순서다.
+pub(crate) fn emitted_image_bytes(
+    data: &[u8],
+    bakes_watermark: bool,
+) -> (&'static str, std::borrow::Cow<'_, [u8]>) {
+    let mime = detect_image_mime_type(data);
+    let converted = match mime {
+        "image/bmp" => bmp_bytes_to_png_bytes(data),
+        "image/x-pcx" => pcx_bytes_to_png_bytes(data),
+        "image/tiff" => tiff_bytes_to_png_bytes(data),
+        "image/jpeg" if bakes_watermark => watermark_jpeg_bytes_to_hancom_baked_png_bytes(data)
+            .or_else(|| grayscale_jpeg_bytes_to_png_bytes(data)),
+        "image/jpeg" => grayscale_jpeg_bytes_to_png_bytes(data),
+        _ => None,
+    };
+    match converted {
+        Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
+        None => (mime, std::borrow::Cow::Borrowed(data)),
+    }
+}
+
 pub(crate) fn image_node_with_resolved_payload(
     image: &ImageNode,
     resolved: Option<&ResolvedImagePayload>,
@@ -183,7 +214,11 @@ pub(crate) fn image_node_with_resolved_payload(
     image
 }
 
-fn is_watermark_image(image: &ImageNode) -> bool {
+/// 워터마크 bake 대상 판정. `paint::source_image_key` 의 variant 결정과 같은 술어를 써야
+/// 키가 가리키는 바이트와 실제로 내보내는 바이트가 어긋나지 않는다 (Task #3315).
+///
+/// mime 검사는 포함하지 않는다 — 호출부가 JPEG 분기 안에서 쓴다.
+pub(crate) fn is_watermark_image(image: &ImageNode) -> bool {
     !matches!(image.effect, ImageEffect::RealPic) && (image.brightness != 0 || image.contrast != 0)
 }
 

--- a/src/renderer/image_resolver.rs
+++ b/src/renderer/image_resolver.rs
@@ -198,6 +198,27 @@ pub(crate) fn emitted_image_bytes(
     }
 }
 
+/// 그림 op 이 내보내는 mime 만 (Task #3315).
+///
+/// 바이트가 필요 없는 소비자 — 배치 정보만 주는 좁은 질의 — 를 위한 것이다. `resolved` 가
+/// 붙어 있으면 그 mime 이 최종값이므로 변환을 다시 돌지 않는다. 큰 JPEG 은 메모 키 해싱만으로
+/// 3.7MB 당 1.35 ms 라, 매 편집에 도는 경로에서는 이 절약이 그대로 이득이다.
+///
+/// `resolved` 가 없을 때 "그러면 변환이 실패했다는 뜻이니 원본 mime 이다" 로 단축하지 않고
+/// `emitted_image_bytes` 에 위임한다. 그 전제는 `paint/builder.rs` 가 트리를 만들 때만
+/// 성립하고, 직접 조립한 `PaintOp::Image { resolved: None }` 에는 성립하지 않는다 — 구조가
+/// 보장하지 않는 불변식에 기대면 조용히 갈라진다.
+pub(crate) fn emitted_image_mime(
+    data: &[u8],
+    resolved: Option<&ResolvedImagePayload>,
+    bakes_watermark: bool,
+) -> &'static str {
+    match resolved {
+        Some(payload) => payload.mime,
+        None => emitted_image_bytes(data, bakes_watermark).0,
+    }
+}
+
 pub(crate) fn image_node_with_resolved_payload(
     image: &ImageNode,
     resolved: Option<&ResolvedImagePayload>,

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -812,6 +812,16 @@ impl HwpDocument {
             .map_err(|e| e.into())
     }
 
+    /// 본문(flow) 그림의 배치 정보만 작은 JSON 으로 반환한다 (Task #3315).
+    ///
+    /// 전체 레이어 트리를 받아 flow 그림을 걸러내던 studio 경로를 대체한다. 바이트는 빠져
+    /// 있고 `sourceImageKey` 로 `getSourceImageBytes` 를 부르면 된다.
+    #[wasm_bindgen(js_name = getPageFlowImageOps)]
+    pub fn get_page_flow_image_ops(&self, page_num: u32) -> Result<String, JsValue> {
+        self.get_page_flow_image_ops_native(page_num)
+            .map_err(|e| e.into())
+    }
+
     /// 그림 신원 키로 바이트를 Uint8Array 로 반환한다 (Task #3315).
     ///
     /// `getPageLayerTreeWithProfile(page, profile, true)` 로 base64 를 생략했을 때 바이트를

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -181,11 +181,16 @@ fn get_page_layer_tree_with_profile_impl(
     document: &HwpDocument,
     page_num: u32,
     profile: &str,
+    omit_image_bytes: bool,
 ) -> Result<String, JsValue> {
     let profile = crate::paint::RenderProfile::parse(profile)
         .ok_or_else(|| JsValue::from_str(&format!("unsupported render profile: {profile}")))?;
     document
-        .get_page_layer_tree_with_profile_native(page_num, profile)
+        .get_page_layer_tree_with_options_native(
+            page_num,
+            profile,
+            crate::paint::LayerJsonOptions { omit_image_bytes },
+        )
         .map_err(|error| error.into())
 }
 
@@ -713,19 +718,26 @@ impl HwpDocument {
             .map_err(|e| e.into())
     }
 
+    /// 페이지 레이어 트리를 profile 별로 반환한다.
+    ///
+    /// [Task #3315] `omit_image_bytes` 를 `true` 로 주면 그림 base64 를 싣지 않고
+    /// `sourceImageKey` 만 남긴다 — 바이트는 `getSourceImageBytes(key)` 로 따로 받는다.
+    /// 인자를 생략하면(`undefined`) 종전과 똑같은 JSON 이므로 기존 호출부는 영향이 없다.
     #[wasm_bindgen(js_name = getPageLayerTreeWithProfile)]
     pub fn get_page_layer_tree_with_profile(
         &self,
         page_num: u32,
         profile: &str,
+        omit_image_bytes: Option<bool>,
     ) -> Result<String, JsValue> {
+        let omit_image_bytes = omit_image_bytes.unwrap_or(false);
         #[cfg(feature = "subsecond-dev")]
         {
             let mut hot = subsecond::HotFn::current(get_page_layer_tree_with_profile_impl);
-            return hot.call((self, page_num, profile));
+            return hot.call((self, page_num, profile, omit_image_bytes));
         }
         #[cfg(not(feature = "subsecond-dev"))]
-        get_page_layer_tree_with_profile_impl(self, page_num, profile)
+        get_page_layer_tree_with_profile_impl(self, page_num, profile, omit_image_bytes)
     }
 
     #[cfg(all(feature = "subsecond-dev", target_arch = "wasm32"))]
@@ -798,6 +810,24 @@ impl HwpDocument {
     pub fn get_page_source_image_keys(&self, page_num: u32) -> Result<String, JsValue> {
         self.get_page_source_image_keys_native(page_num)
             .map_err(|e| e.into())
+    }
+
+    /// 그림 신원 키로 바이트를 Uint8Array 로 반환한다 (Task #3315).
+    ///
+    /// `getPageLayerTreeWithProfile(page, profile, true)` 로 base64 를 생략했을 때 바이트를
+    /// 받는 경로다. mime 은 레이어 트리의 그림 op 이 계속 싣고 있으므로 여기서 되풀이하지
+    /// 않는다.
+    ///
+    /// 키를 풀 수 없으면 던진다 — 세대가 바뀐 낡은 키이거나 없는 그림이다. 호출부는 잡아서
+    /// 레이어 트리를 다시 받는 쪽으로 되돌아가면 된다.
+    #[wasm_bindgen(js_name = getSourceImageBytes)]
+    pub fn get_source_image_bytes(&self, key: &str) -> Result<Vec<u8>, JsValue> {
+        match self.get_source_image_bytes_native(key) {
+            Some((_mime, bytes)) => Ok(bytes),
+            None => Err(JsValue::from_str(&format!(
+                "unresolvable source image key: {key}"
+            ))),
+        }
     }
 
     /// 페이지 정보를 JSON 문자열로 반환한다.

--- a/tests/issue_2342_cell_merge_para_meta.rs
+++ b/tests/issue_2342_cell_merge_para_meta.rs
@@ -10,7 +10,10 @@
 
 use rhwp::document_core::DocumentCore;
 use rhwp::model::control::Control;
-use rhwp::model::paragraph::{ColumnBreakType, NumberingRestart, ParaMeta};
+use rhwp::model::image::Picture;
+use rhwp::model::paragraph::{ColumnBreakType, NumberingRestart, ParaMeta, Paragraph};
+use rhwp::model::shape::Caption;
+use rhwp::model::table::{Cell, Table};
 use serde_json::Value;
 
 /// 2×2 표 하나를 가진 문서. 반환값은 표가 놓인 본문 문단 인덱스.
@@ -36,15 +39,98 @@ fn table_control_idx(core: &DocumentCore, para_idx: usize) -> usize {
         .expect("표 컨트롤")
 }
 
-fn cell_paragraphs<'a>(
-    core: &'a DocumentCore,
+fn doc_with_textbox() -> (DocumentCore, usize, usize) {
+    let mut core = DocumentCore::new_empty();
+    core.create_blank_document_native().expect("blank document");
+    let inserted = core
+        .create_shape_control_native(
+            0,
+            0,
+            0,
+            21_600,
+            7_200,
+            0,
+            0,
+            true,
+            "TopAndBottom",
+            "textbox",
+            false,
+            false,
+            &[],
+        )
+        .expect("글상자 생성");
+    let inserted: Value = serde_json::from_str(&inserted).expect("shape result json");
+    let para_idx = inserted["paraIdx"].as_u64().expect("shape paraIdx") as usize;
+    let ctrl_idx = inserted["controlIdx"].as_u64().expect("shape controlIdx") as usize;
+    (core, para_idx, ctrl_idx)
+}
+
+fn doc_with_picture_caption() -> (DocumentCore, usize, usize) {
+    let mut core = DocumentCore::new_empty();
+    core.create_blank_document_native().expect("blank document");
+
+    let mut picture = Picture::default();
+    picture.common.width = 21_600;
+    picture.common.height = 7_200;
+    picture.caption = Some(Caption {
+        width: 10_000,
+        max_width: 10_000,
+        paragraphs: vec![Paragraph::default()],
+        ..Default::default()
+    });
+
+    let para_idx = 0;
+    let para = &mut core.document_mut().sections[0].paragraphs[para_idx];
+    para.controls.push(Control::Picture(Box::new(picture)));
+    let ctrl_idx = para.controls.len() - 1;
+    (core, para_idx, ctrl_idx)
+}
+
+fn control_paragraphs(
+    core: &DocumentCore,
     para_idx: usize,
     ctrl_idx: usize,
     cell_idx: usize,
-) -> &'a [rhwp::model::paragraph::Paragraph] {
+) -> &[Paragraph] {
     match &core.document().sections[0].paragraphs[para_idx].controls[ctrl_idx] {
         Control::Table(table) => &table.cells[cell_idx].paragraphs,
-        other => panic!("표가 아님: {other:?}"),
+        Control::Shape(shape) => {
+            assert_eq!(cell_idx, 0, "글상자의 cell index");
+            &shape
+                .drawing()
+                .and_then(|drawing| drawing.text_box.as_ref())
+                .expect("글상자")
+                .paragraphs
+        }
+        Control::Picture(picture) => {
+            assert_eq!(cell_idx, 0, "그림 캡션의 cell index");
+            &picture.caption.as_ref().expect("그림 캡션").paragraphs
+        }
+        other => panic!("셀 문단 컨테이너가 아님: {other:?}"),
+    }
+}
+
+fn control_paragraphs_mut(
+    core: &mut DocumentCore,
+    para_idx: usize,
+    ctrl_idx: usize,
+    cell_idx: usize,
+) -> &mut Vec<Paragraph> {
+    match &mut core.document_mut().sections[0].paragraphs[para_idx].controls[ctrl_idx] {
+        Control::Table(table) => &mut table.cells[cell_idx].paragraphs,
+        Control::Shape(shape) => {
+            assert_eq!(cell_idx, 0, "글상자의 cell index");
+            &mut shape
+                .drawing_mut()
+                .and_then(|drawing| drawing.text_box.as_mut())
+                .expect("글상자")
+                .paragraphs
+        }
+        Control::Picture(picture) => {
+            assert_eq!(cell_idx, 0, "그림 캡션의 cell index");
+            &mut picture.caption.as_mut().expect("그림 캡션").paragraphs
+        }
+        other => panic!("셀 문단 컨테이너가 아님: {other:?}"),
     }
 }
 
@@ -56,7 +142,7 @@ fn removed_meta(result: &str) -> ParaMeta {
 }
 
 /// 두 번째 문단에 알아볼 수 있는 메타를 심는다.
-fn stamp_meta(para: &mut rhwp::model::paragraph::Paragraph) {
+fn stamp_meta(para: &mut Paragraph) {
     para.para_shape_id = 20;
     para.style_id = 5;
     para.column_type = ColumnBreakType::Page;
@@ -66,7 +152,7 @@ fn stamp_meta(para: &mut rhwp::model::paragraph::Paragraph) {
     para.tab_extended = vec![[100, 0, 0x0200, 0, 0, 0, 9]];
 }
 
-fn assert_meta_restored(para: &rhwp::model::paragraph::Paragraph) {
+fn assert_meta_restored(para: &Paragraph) {
     assert_eq!(para.para_shape_id, 20, "문단 모양");
     assert_eq!(para.style_id, 5, "스타일");
     assert_eq!(para.column_type, ColumnBreakType::Page, "단 나눔");
@@ -88,78 +174,168 @@ fn assert_meta_restored(para: &rhwp::model::paragraph::Paragraph) {
     );
 }
 
-/// 표 셀: 병합 → undo(분할)가 사라진 문단의 메타를 되돌린다.
-#[test]
-fn cell_merge_undo_restores_removed_paragraph_meta() {
-    let (mut core, para_idx) = doc_with_table();
-    let ctrl_idx = table_control_idx(&core, para_idx);
-
+fn assert_flat_merge_undo_restores_meta(
+    mut core: DocumentCore,
+    para_idx: usize,
+    ctrl_idx: usize,
+    container: &str,
+) {
     core.insert_text_in_cell_native(0, para_idx, ctrl_idx, 0, 0, 0, "첫째")
-        .expect("첫 문단");
+        .unwrap_or_else(|e| panic!("{container} 첫 문단 삽입 실패: {e}"));
     core.split_paragraph_in_cell_native(0, para_idx, ctrl_idx, 0, 0, 2, None)
-        .expect("셀 분할");
+        .unwrap_or_else(|e| panic!("{container} 문단 분할 실패: {e}"));
     core.insert_text_in_cell_native(0, para_idx, ctrl_idx, 0, 1, 0, "둘째")
-        .expect("둘째 문단");
+        .unwrap_or_else(|e| panic!("{container} 둘째 문단 삽입 실패: {e}"));
 
     {
-        let Control::Table(table) =
-            &mut core.document_mut().sections[0].paragraphs[para_idx].controls[ctrl_idx]
-        else {
-            panic!("표가 아님");
-        };
-        table.cells[0].paragraphs[0].para_shape_id = 10;
-        stamp_meta(&mut table.cells[0].paragraphs[1]);
+        let paragraphs = control_paragraphs_mut(&mut core, para_idx, ctrl_idx, 0);
+        paragraphs[0].para_shape_id = 10;
+        stamp_meta(&mut paragraphs[1]);
     }
 
     let merged = core
         .merge_paragraph_in_cell_native(0, para_idx, ctrl_idx, 0, 1)
-        .expect("셀 병합");
+        .unwrap_or_else(|e| panic!("{container} 문단 병합 실패: {e}"));
     let meta = removed_meta(&merged);
 
     core.split_paragraph_in_cell_native(0, para_idx, ctrl_idx, 0, 0, 2, Some(meta))
-        .expect("undo 분할");
+        .unwrap_or_else(|e| panic!("{container} undo 분할 실패: {e}"));
 
-    let paras = cell_paragraphs(&core, para_idx, ctrl_idx, 0);
-    assert_eq!(paras[1].text, "둘째");
-    assert_meta_restored(&paras[1]);
-    assert_eq!(paras[0].para_shape_id, 10, "앞 문단은 그대로");
+    let paragraphs = control_paragraphs(&core, para_idx, ctrl_idx, 0);
+    assert_eq!(paragraphs[1].text, "둘째", "{container} 둘째 문단 텍스트");
+    assert_meta_restored(&paragraphs[1]);
+    assert_eq!(
+        paragraphs[0].para_shape_id, 10,
+        "{container} 앞 문단은 그대로"
+    );
 }
 
-/// 중첩 by-path 경로도 같은 규약을 따른다.
+/// 표 셀: 병합 → undo(분할)가 사라진 문단의 메타를 되돌린다.
+#[test]
+fn cell_merge_undo_restores_removed_paragraph_meta() {
+    let (core, para_idx) = doc_with_table();
+    let ctrl_idx = table_control_idx(&core, para_idx);
+    assert_flat_merge_undo_restores_meta(core, para_idx, ctrl_idx, "표 셀");
+}
+
+/// 글상자 arm 도 병합 결과에 사라진 문단의 메타를 싣는다.
+#[test]
+fn textbox_merge_undo_restores_removed_paragraph_meta() {
+    let (core, para_idx, ctrl_idx) = doc_with_textbox();
+    assert_flat_merge_undo_restores_meta(core, para_idx, ctrl_idx, "글상자");
+}
+
+/// 그림 캡션 arm 도 병합 결과에 사라진 문단의 메타를 싣는다.
+#[test]
+fn picture_caption_merge_undo_restores_removed_paragraph_meta() {
+    let (core, para_idx, ctrl_idx) = doc_with_picture_caption();
+    assert_flat_merge_undo_restores_meta(core, para_idx, ctrl_idx, "그림 캡션");
+}
+
+fn doc_with_nested_table() -> (DocumentCore, usize, Vec<(usize, usize, usize)>) {
+    let (mut core, para_idx) = doc_with_table();
+    let outer_ctrl_idx = table_control_idx(&core, para_idx);
+
+    let mut inner_table = Table {
+        row_count: 1,
+        col_count: 1,
+        row_sizes: vec![5_000],
+        cells: vec![Cell {
+            col_span: 1,
+            row_span: 1,
+            width: 5_000,
+            height: 5_000,
+            paragraphs: vec![Paragraph::default()],
+            ..Default::default()
+        }],
+        cell_grid: vec![Some(0)],
+        ..Default::default()
+    };
+    inner_table.common.width = 5_000;
+    inner_table.common.height = 5_000;
+
+    let outer_table =
+        match &mut core.document_mut().sections[0].paragraphs[para_idx].controls[outer_ctrl_idx] {
+            Control::Table(table) => table,
+            other => panic!("바깥 표가 아님: {other:?}"),
+        };
+    let outer_cell_para = &mut outer_table.cells[0].paragraphs[0];
+    outer_cell_para
+        .controls
+        .push(Control::Table(Box::new(inner_table)));
+    let inner_ctrl_idx = outer_cell_para.controls.len() - 1;
+
+    let path = vec![(outer_ctrl_idx, 0, 0), (inner_ctrl_idx, 0, 0)];
+    (core, para_idx, path)
+}
+
+fn nested_cell_paragraphs<'a>(
+    core: &'a DocumentCore,
+    para_idx: usize,
+    path: &[(usize, usize, usize)],
+) -> &'a [Paragraph] {
+    let Control::Table(outer_table) =
+        &core.document().sections[0].paragraphs[para_idx].controls[path[0].0]
+    else {
+        panic!("바깥 표가 아님");
+    };
+    let outer_cell_para = &outer_table.cells[path[0].1].paragraphs[path[0].2];
+    let Control::Table(inner_table) = &outer_cell_para.controls[path[1].0] else {
+        panic!("안쪽 표가 아님");
+    };
+    &inner_table.cells[path[1].1].paragraphs
+}
+
+fn nested_cell_paragraphs_mut<'a>(
+    core: &'a mut DocumentCore,
+    para_idx: usize,
+    path: &[(usize, usize, usize)],
+) -> &'a mut Vec<Paragraph> {
+    let Control::Table(outer_table) =
+        &mut core.document_mut().sections[0].paragraphs[para_idx].controls[path[0].0]
+    else {
+        panic!("바깥 표가 아님");
+    };
+    let outer_cell_para = &mut outer_table.cells[path[0].1].paragraphs[path[0].2];
+    let Control::Table(inner_table) = &mut outer_cell_para.controls[path[1].0] else {
+        panic!("안쪽 표가 아님");
+    };
+    &mut inner_table.cells[path[1].1].paragraphs
+}
+
+/// 진짜 깊이 2 by-path 경로도 같은 규약을 따른다.
 #[test]
 fn nested_cell_merge_undo_restores_removed_paragraph_meta() {
-    let (mut core, para_idx) = doc_with_table();
-    let ctrl_idx = table_control_idx(&core, para_idx);
-    let path = [(ctrl_idx, 0usize, 0usize)];
+    let (mut core, para_idx, first_path) = doc_with_nested_table();
 
-    core.insert_text_in_cell_native(0, para_idx, ctrl_idx, 0, 0, 0, "첫째")
-        .expect("첫 문단");
-    core.split_paragraph_in_cell_by_path(0, para_idx, &path, 2, None)
-        .expect("by-path 분할");
-    core.insert_text_in_cell_native(0, para_idx, ctrl_idx, 0, 1, 0, "둘째")
-        .expect("둘째 문단");
+    core.insert_text_in_cell_by_path(0, para_idx, &first_path, 0, "첫째")
+        .expect("깊이 2 첫 문단");
+    core.split_paragraph_in_cell_by_path(0, para_idx, &first_path, 2, None)
+        .expect("깊이 2 by-path 분할");
+
+    let mut second_path = first_path.clone();
+    second_path.last_mut().expect("안쪽 경로").2 = 1;
+    core.insert_text_in_cell_by_path(0, para_idx, &second_path, 0, "둘째")
+        .expect("깊이 2 둘째 문단");
 
     {
-        let Control::Table(table) =
-            &mut core.document_mut().sections[0].paragraphs[para_idx].controls[ctrl_idx]
-        else {
-            panic!("표가 아님");
-        };
-        stamp_meta(&mut table.cells[0].paragraphs[1]);
+        let paragraphs = nested_cell_paragraphs_mut(&mut core, para_idx, &first_path);
+        paragraphs[0].para_shape_id = 10;
+        stamp_meta(&mut paragraphs[1]);
     }
 
-    let merge_path = [(ctrl_idx, 0usize, 1usize)];
     let merged = core
-        .merge_paragraph_in_cell_by_path(0, para_idx, &merge_path)
-        .expect("by-path 병합");
+        .merge_paragraph_in_cell_by_path(0, para_idx, &second_path)
+        .expect("깊이 2 by-path 병합");
     let meta = removed_meta(&merged);
 
-    core.split_paragraph_in_cell_by_path(0, para_idx, &path, 2, Some(meta))
-        .expect("undo 분할");
+    core.split_paragraph_in_cell_by_path(0, para_idx, &first_path, 2, Some(meta))
+        .expect("깊이 2 undo 분할");
 
-    let paras = cell_paragraphs(&core, para_idx, ctrl_idx, 0);
-    assert_eq!(paras[1].text, "둘째");
-    assert_meta_restored(&paras[1]);
+    let paragraphs = nested_cell_paragraphs(&core, para_idx, &first_path);
+    assert_eq!(paragraphs[1].text, "둘째");
+    assert_meta_restored(&paragraphs[1]);
+    assert_eq!(paragraphs[0].para_shape_id, 10, "앞 문단은 그대로");
 }
 
 /// 메타를 넘기지 않으면 기존 Enter 분할 시맨틱 그대로다 — 앞 문단에서 상속받는다.
@@ -170,21 +346,14 @@ fn cell_split_without_meta_keeps_enter_inheritance() {
 
     core.insert_text_in_cell_native(0, para_idx, ctrl_idx, 0, 0, 0, "첫째둘째")
         .expect("문단");
-    {
-        let Control::Table(table) =
-            &mut core.document_mut().sections[0].paragraphs[para_idx].controls[ctrl_idx]
-        else {
-            panic!("표가 아님");
-        };
-        table.cells[0].paragraphs[0].para_shape_id = 10;
-    }
+    control_paragraphs_mut(&mut core, para_idx, ctrl_idx, 0)[0].para_shape_id = 10;
 
     core.split_paragraph_in_cell_native(0, para_idx, ctrl_idx, 0, 0, 2, None)
         .expect("Enter 분할");
 
-    let paras = cell_paragraphs(&core, para_idx, ctrl_idx, 0);
+    let paragraphs = control_paragraphs(&core, para_idx, ctrl_idx, 0);
     assert_eq!(
-        paras[1].para_shape_id, 10,
+        paragraphs[1].para_shape_id, 10,
         "Enter 분할은 앞 문단을 상속한다"
     );
 }

--- a/tests/issue_3315_flow_image_narrow_query.rs
+++ b/tests/issue_3315_flow_image_narrow_query.rs
@@ -1,0 +1,347 @@
+//! Task #3315: 본문(flow) 그림의 배치 정보만 받는 좁은 질의.
+//!
+//! studio 는 flow 그림을 DOM `<img>` 로 내보내려고 편집마다 전체 레이어 트리 JSON 을 받아
+//! 왔다. 이 질의가 그것을 대체하려면 **전체 트리에서 뽑아낸 것과 같은 것을 말해야** 한다 —
+//! 개수·순서·bbox·잘림·효과가 어긋나면 화면이 달라진다. 여기서 고정하는 것은 크기 이득이
+//! 아니라 그 일치다.
+//!
+//! 캐시가 아니라 질의를 좁힌 이유도 함께 고정한다: 본문이 흐르면 그림이 그대로여도 bbox 가
+//! 움직이므로 `(page, imageKeys)` 캐시로는 풀 수 없다.
+
+use serde_json::Value;
+
+/// 그림 op 의 replay plane — studio `layerPaintOpReplayPlane` 을 그대로 옮긴 것.
+///
+/// `layer.textWrap` 이 있으면 그것이 우선이고, 없을 때만 op 의 `wrap` 을 본다. `behindText`·
+/// `inFrontOfText` 만 flow 가 아니다 — `square` 같은 본문 배치 wrap 은 flow 다. 그리고
+/// 바탕쪽 유래 개체는 항상 본문 뒤로 눌린다(`capMasterPagePlane`).
+fn is_flow_image(op: &Value, layer: Option<&Value>) -> bool {
+    let master_page = layer
+        .and_then(|l| l.get("masterPage"))
+        .and_then(Value::as_bool)
+        == Some(true);
+    if master_page {
+        return false;
+    }
+    let wrap = match layer
+        .and_then(|l| l.get("textWrap"))
+        .and_then(Value::as_str)
+    {
+        Some(layer_wrap) => Some(layer_wrap),
+        None => op.get("wrap").and_then(Value::as_str),
+    };
+    !matches!(wrap, Some("behindText") | Some("inFrontOfText"))
+}
+
+/// 전체 레이어 트리에서 flow plane 그림 op 을 studio 의 `collectFlowImagePaintOps` 와 같은
+/// 계약으로 뽑는다 — pre-order, `layer` 상속, `clipRect` 조상 교차.
+fn collect_flow_images_from_tree<'a>(
+    node: &'a Value,
+    inherited_layer: Option<&'a Value>,
+    clip: Option<[f64; 4]>,
+    out: &mut Vec<Value>,
+) {
+    let active_layer = node.get("layer").or(inherited_layer);
+    let next_clip = if node.get("kind").and_then(Value::as_str) == Some("clipRect") {
+        match bbox_of(node.get("clip")) {
+            Some(node_clip) => match intersect(clip, node_clip) {
+                Some(next) => Some(next),
+                // 교차가 비면 이 아래는 보이지 않는다.
+                None => return,
+            },
+            None => clip,
+        }
+    } else {
+        clip
+    };
+
+    if let Some(ops) = node.get("ops").and_then(Value::as_array) {
+        for op in ops {
+            if op.get("type").and_then(Value::as_str) != Some("image") {
+                continue;
+            }
+            if !is_flow_image(op, active_layer) {
+                continue;
+            }
+            let Some(bbox) = bbox_of(op.get("bbox")) else {
+                continue;
+            };
+            if intersect(next_clip, bbox).is_none() {
+                continue;
+            }
+            out.push(op.clone());
+        }
+    }
+    if let Some(children) = node.get("children").and_then(Value::as_array) {
+        for child in children {
+            collect_flow_images_from_tree(child, active_layer, next_clip, out);
+        }
+    }
+    if let Some(child) = node.get("child") {
+        collect_flow_images_from_tree(child, active_layer, next_clip, out);
+    }
+}
+
+fn bbox_of(value: Option<&Value>) -> Option<[f64; 4]> {
+    let value = value?;
+    Some([
+        value.get("x")?.as_f64()?,
+        value.get("y")?.as_f64()?,
+        value.get("width")?.as_f64()?,
+        value.get("height")?.as_f64()?,
+    ])
+}
+
+fn intersect(first: Option<[f64; 4]>, second: [f64; 4]) -> Option<[f64; 4]> {
+    let Some(first) = first else {
+        return Some(second);
+    };
+    let left = first[0].max(second[0]);
+    let top = first[1].max(second[1]);
+    let right = (first[0] + first[2]).min(second[0] + second[2]);
+    let bottom = (first[1] + first[3]).min(second[1] + second[3]);
+    if right <= left || bottom <= top {
+        return None;
+    }
+    Some([left, top, right - left, bottom - top])
+}
+
+/// 본문 흐름에 실제로 얽힌 flow 그림이 있는 표본들.
+///
+/// `insert_picture_native` 로 넣은 그림은 (0,0) 에 고정된 부동 개체라 본문이 흘러도 움직이지
+/// 않는다 — 이 트랙이 다루는 "본문 인라인 그림"이 아니다. 그래서 등가성은 실문서로 잰다.
+const FLOW_IMAGE_SAMPLES: &[&str] = &[
+    "samples/143E433F503322BD33.hwp",
+    "samples/3-10월_교육_통합_2022.hwp",
+    "samples/20250130-hongbo.hwp",
+    "samples/3-09월_교육_통합_2023.hwpx",
+];
+
+fn open(relative: &str) -> rhwp::wasm_api::HwpDocument {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let bytes = std::fs::read(std::path::Path::new(repo_root).join(relative))
+        .unwrap_or_else(|error| panic!("read {relative}: {error}"));
+    rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .unwrap_or_else(|error| panic!("parse {relative}: {error:?}"))
+}
+
+/// 대형 JPEG 을 세션 중에 넣은 문서 — 크기 이득을 재는 데 쓴다.
+fn open_with_large_inserted_image() -> rhwp::wasm_api::HwpDocument {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let jpeg = std::fs::read(std::path::Path::new(repo_root).join("samples/images/tiger01.jpg"))
+        .expect("read tiger01.jpg");
+    let mut doc = open("samples/hwpx/issue_241.hwpx");
+    doc.insert_picture_native(
+        0,
+        0,
+        0,
+        &[],
+        &jpeg,
+        400,
+        300,
+        2400,
+        1800,
+        "jpg",
+        "tiger",
+        None,
+        None,
+    )
+    .expect("insert picture");
+    doc
+}
+
+fn narrow(doc: &rhwp::wasm_api::HwpDocument, page: u32) -> Value {
+    let json = doc
+        .get_page_flow_image_ops_native(page)
+        .expect("flow image ops");
+    serde_json::from_str(&json).expect("좁은 질의 JSON 이 유효해야 한다")
+}
+
+fn tree_flow_images(doc: &rhwp::wasm_api::HwpDocument, page: u32) -> Vec<Value> {
+    let json = doc
+        .get_page_layer_tree_with_profile_native(page, rhwp::paint::RenderProfile::Screen)
+        .expect("layer tree");
+    let tree: Value = serde_json::from_str(&json).expect("레이어 JSON 이 유효해야 한다");
+    let mut out = Vec::new();
+    collect_flow_images_from_tree(&tree["root"], None, None, &mut out);
+    out
+}
+
+/// 이 질의가 전체 트리 경로를 대체할 수 있다는 것 — 이 파일의 핵심 단언.
+#[test]
+fn issue_3315_narrow_query_matches_full_tree() {
+    let mut total_images = 0;
+    for sample in FLOW_IMAGE_SAMPLES {
+        let doc = open(sample);
+        let pages = doc.page_count().min(3);
+        for page in 0..pages {
+            let narrow = narrow(&doc, page);
+            let from_tree = tree_flow_images(&doc, page);
+            let images = narrow["images"].as_array().expect("images 배열");
+
+            assert_eq!(
+                images.len(),
+                from_tree.len(),
+                "{sample} p{page}: 좁은 질의와 전체 트리의 flow 그림 개수가 다르다"
+            );
+            total_images += images.len();
+
+            for (index, (narrow_op, tree_op)) in images.iter().zip(&from_tree).enumerate() {
+                let at = format!("{sample} p{page} #{index}");
+                assert_eq!(
+                    narrow_op["bbox"], tree_op["bbox"],
+                    "{at}: bbox 가 다르다 — 소비자가 다른 자리에 그린다"
+                );
+                assert_eq!(narrow_op["mime"], tree_op["mime"], "{at}: mime 이 다르다");
+                assert_eq!(
+                    narrow_op["effect"], tree_op["effect"],
+                    "{at}: effect 가 다르다"
+                );
+                assert_eq!(
+                    narrow_op["brightness"], tree_op["brightness"],
+                    "{at}: brightness 가 다르다"
+                );
+                assert_eq!(
+                    narrow_op["contrast"], tree_op["contrast"],
+                    "{at}: contrast 가 다르다"
+                );
+                assert_eq!(
+                    narrow_op["transform"], tree_op["transform"],
+                    "{at}: transform 이 다르다 — 회전·반전이 어긋난다"
+                );
+                assert_eq!(narrow_op["crop"], tree_op["crop"], "{at}: crop 이 다르다");
+                assert_eq!(
+                    narrow_op["originalSizeHu"], tree_op["originalSizeHu"],
+                    "{at}: originalSizeHu 가 다르다"
+                );
+                assert_eq!(
+                    narrow_op["bakedWatermark"], tree_op["bakedWatermark"],
+                    "{at}: bakedWatermark 가 다르다 — CSS filter 적용 여부가 갈린다"
+                );
+                assert_eq!(
+                    narrow_op["sourceImageKey"], tree_op["sourceImageKey"],
+                    "{at}: 신원 키가 다르다 — 바이트를 못 찾거나 남의 바이트를 받는다"
+                );
+            }
+        }
+    }
+    assert!(
+        total_images >= 4,
+        "표본이 flow 그림을 실제로 담고 있어야 이 테스트가 의미가 있다 (총 {total_images}장)"
+    );
+}
+
+#[test]
+fn issue_3315_narrow_query_keys_resolve_to_bytes() {
+    for sample in FLOW_IMAGE_SAMPLES {
+        let doc = open(sample);
+        let narrow = narrow(&doc, 0);
+        if narrow["cacheable"].as_bool() != Some(true) {
+            // 합성 그림이 섞인 페이지는 키를 못 내므로 이 단언의 대상이 아니다.
+            continue;
+        }
+        for image in narrow["images"].as_array().expect("images") {
+            let key = image["sourceImageKey"]
+                .as_str()
+                .expect("cacheable 페이지의 모든 그림은 키를 가져야 한다");
+            let (mime, bytes) = doc
+                .get_source_image_bytes_native(key)
+                .unwrap_or_else(|| panic!("{sample}: 키로 바이트를 받을 수 없다 ({key})"));
+            assert!(!bytes.is_empty(), "{sample}: 빈 바이트 ({key})");
+            assert_eq!(
+                Some(mime),
+                image["mime"].as_str(),
+                "{sample}: 좁은 질의의 mime 과 키 조회의 mime 이 다르다 ({key})"
+            );
+        }
+    }
+}
+
+#[test]
+fn issue_3315_narrow_query_is_much_smaller_than_the_tree() {
+    let doc = open_with_large_inserted_image();
+    let tree = doc.get_page_layer_tree_native(0).expect("layer tree");
+    let narrow = doc
+        .get_page_flow_image_ops_native(0)
+        .expect("flow image ops");
+
+    assert!(
+        narrow.len() * 100 < tree.len(),
+        "좁은 질의가 충분히 작지 않다 (tree={} bytes, narrow={} bytes)",
+        tree.len(),
+        narrow.len()
+    );
+    println!(
+        "[#3315] 전체 트리 {} bytes / 좁은 질의 {} bytes ({:.0}배)",
+        tree.len(),
+        narrow.len(),
+        tree.len() as f64 / narrow.len() as f64
+    );
+}
+
+/// 캐시가 아니라 좁은 질의여야 하는 이유를 고정한다.
+///
+/// 그림 바이트가 그대로면 `sourceImageKey` 도 그대로다. 그런데 본문 앞에 글자를 넣으면 그림이
+/// 밀려 bbox 가 달라진다 — 즉 `(page, imageKeys)` 를 키로 한 캐시는 **틀린 배치를 재사용**한다.
+///
+/// 부동 개체로 삽입한 그림은 (0,0) 에 고정돼 이 성질을 보이지 않는다. 본문 흐름에 얽힌 실문서가
+/// 필요하다 — `143E433F503322BD33.hwp` 는 글자를 넣으면 y 가 468.6 → 503.3 으로 밀린다.
+#[test]
+fn issue_3315_bbox_moves_while_key_stays_so_caching_would_be_wrong() {
+    let mut doc = open("samples/143E433F503322BD33.hwp");
+    let before = narrow(&doc, 0);
+
+    for _ in 0..3 {
+        doc.insert_text_native(0, 0, 0, "가나다라마바사아자차")
+            .expect("insert text");
+    }
+    let after = narrow(&doc, 0);
+
+    let before_images = before["images"].as_array().expect("images");
+    let after_images = after["images"].as_array().expect("images");
+    assert!(
+        !before_images.is_empty(),
+        "표본에 flow 그림이 있어야 한다 — 없으면 이 테스트가 대상을 못 재고 있다"
+    );
+    assert_eq!(
+        before_images.len(),
+        after_images.len(),
+        "이 테스트는 그림이 같은 쪽에 남는 조건에서만 의미가 있다"
+    );
+
+    let keys = |ops: &Vec<Value>| -> Vec<Value> {
+        ops.iter().map(|op| op["sourceImageKey"].clone()).collect()
+    };
+    assert_eq!(
+        keys(before_images),
+        keys(after_images),
+        "본문 편집은 그림 바이트를 바꾸지 않으므로 키가 유지돼야 한다"
+    );
+
+    let bboxes =
+        |ops: &Vec<Value>| -> Vec<Value> { ops.iter().map(|op| op["bbox"].clone()).collect() };
+    assert_ne!(
+        bboxes(before_images),
+        bboxes(after_images),
+        "키가 같은데 bbox 도 같으면 캐시로 풀 수 있다는 뜻이 된다 — \
+         이 단언이 깨졌다면 좁은 질의의 근거를 다시 확인해야 한다"
+    );
+}
+
+#[test]
+fn issue_3315_narrow_query_survives_documents_without_flow_images() {
+    let doc = open("samples/hwpx/issue_241.hwpx");
+
+    let narrow = narrow(&doc, 0);
+    let from_tree = tree_flow_images(&doc, 0);
+    assert_eq!(
+        narrow["images"].as_array().map(Vec::len),
+        Some(from_tree.len()),
+        "flow 그림이 없는 페이지에서도 전체 트리와 같은 답이어야 한다"
+    );
+    assert_eq!(
+        narrow["cacheable"].as_bool(),
+        Some(true),
+        "빈 목록은 cacheable 이다"
+    );
+}

--- a/tests/issue_3315_image_bytes_by_key.rs
+++ b/tests/issue_3315_image_bytes_by_key.rs
@@ -1,0 +1,288 @@
+//! Task #3315: 그림 바이트를 레이어 트리 JSON 에서 빼고 신원 키로 따로 받는다.
+//!
+//! 이 옵션이 성립하려면 **생략본 + 키 조회가 인라인 base64 와 같은 것을 말해야** 한다.
+//! 바이트가 한 바이트라도 다르면 소비자는 같은 그림을 다르게 그린다. 그래서 여기서 고정하는
+//! 것은 크기 이득이 아니라 등가성이다 — 크기는 그 등가성이 성립한 뒤의 부산물이다.
+//!
+//! 변환 사슬(BMP/PCX/TIFF/회색 JPEG → PNG, JPEG 워터마크 bake)이 JSON 경로와 키 조회 경로에
+//! 각각 사본으로 존재하면 이 등가성이 조용히 깨진다. 두 경로가 같은 함수를 쓰는지 확인하는
+//! 자리도 이 테스트다.
+
+use base64::Engine;
+use serde_json::Value;
+
+use rhwp::paint::{parse_source_image_key, LayerJsonOptions, SourceImageVariant};
+
+/// 그림 op 을 등장 순서대로 모은다. 인라인본과 생략본을 짝지어 비교하려면 순서가 같아야 한다.
+fn collect_image_ops(node: &Value, out: &mut Vec<Value>) {
+    if let Some(ops) = node.get("ops").and_then(Value::as_array) {
+        for op in ops {
+            if op.get("type").and_then(Value::as_str) == Some("image") {
+                out.push(op.clone());
+            }
+        }
+    }
+    if let Some(children) = node.get("children").and_then(Value::as_array) {
+        for child in children {
+            collect_image_ops(child, out);
+        }
+    }
+    // clipRect 노드는 단일 `child` 를 갖는다.
+    if let Some(child) = node.get("child") {
+        collect_image_ops(child, out);
+    }
+}
+
+fn image_ops(json: &str) -> Vec<Value> {
+    let value: Value = serde_json::from_str(json).expect("레이어 JSON 이 유효해야 한다");
+    let mut ops = Vec::new();
+    collect_image_ops(&value["root"], &mut ops);
+    ops
+}
+
+fn open_sample() -> rhwp::wasm_api::HwpDocument {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let bytes = std::fs::read(std::path::Path::new(repo_root).join("samples/hwpx/issue_241.hwpx"))
+        .expect("read samples/hwpx/issue_241.hwpx");
+    rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse issue_241.hwpx")
+}
+
+fn inline_json(doc: &rhwp::wasm_api::HwpDocument) -> String {
+    doc.get_page_layer_tree_native(0)
+        .expect("inline layer tree")
+}
+
+fn omitted_json(doc: &rhwp::wasm_api::HwpDocument) -> String {
+    doc.get_page_layer_tree_with_options_native(
+        0,
+        rhwp::paint::RenderProfile::Screen,
+        LayerJsonOptions {
+            omit_image_bytes: true,
+        },
+    )
+    .expect("omitted layer tree")
+}
+
+#[test]
+fn issue_3315_omitted_bytes_are_recoverable_by_key() {
+    let doc = open_sample();
+    let inline_ops = image_ops(&inline_json(&doc));
+    let omitted_ops = image_ops(&omitted_json(&doc));
+
+    assert!(!inline_ops.is_empty(), "도장 그림이 있어야 한다");
+    assert_eq!(
+        inline_ops.len(),
+        omitted_ops.len(),
+        "생략은 op 을 지우는 게 아니라 payload 만 뺀다"
+    );
+
+    for (inline_op, omitted_op) in inline_ops.iter().zip(&omitted_ops) {
+        let encoded = inline_op["base64"]
+            .as_str()
+            .expect("인라인본에는 base64 가 있어야 한다");
+        let expected = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .expect("인라인 base64 왕복");
+
+        let key = omitted_op["sourceImageKey"]
+            .as_str()
+            .expect("생략된 op 에는 키가 있어야 한다");
+        let (mime, actual) = doc
+            .get_source_image_bytes_native(key)
+            .expect("키로 바이트를 받을 수 있어야 한다");
+
+        assert_eq!(
+            actual, expected,
+            "키로 받은 바이트가 인라인 base64 와 달라졌다 (key={key})"
+        );
+        assert_eq!(
+            Some(mime),
+            inline_op["mime"].as_str(),
+            "키 조회의 mime 이 JSON 의 mime 과 달라졌다 (key={key})"
+        );
+    }
+}
+
+#[test]
+fn issue_3315_omitted_ops_keep_mime_and_declare_omission() {
+    let doc = open_sample();
+    let omitted = omitted_json(&doc);
+    let ops = image_ops(&omitted);
+
+    assert!(
+        omitted.contains("\"imageBytes\":\"byKey\""),
+        "문서 단위로 생략본임을 알려야 한다"
+    );
+    for op in &ops {
+        assert!(
+            op.get("base64").is_none(),
+            "생략본에 base64 가 남아 있다: {op}"
+        );
+        assert_eq!(
+            op["imageBytesOmitted"].as_bool(),
+            Some(true),
+            "op 마다 생략을 명시해야 한다 — 소비자가 부재를 추측하게 두지 않는다"
+        );
+        assert!(
+            op.get("mime").and_then(Value::as_str).is_some(),
+            "mime 은 남는다 — 소비자가 Blob 타입을 정하는 데 쓴다"
+        );
+        // bbox·effect 같은 배치 정보는 생략과 무관하게 그대로다.
+        assert!(op.get("bbox").is_some(), "bbox 가 사라졌다: {op}");
+    }
+}
+
+#[test]
+fn issue_3315_default_serialization_is_byte_identical() {
+    let doc = open_sample();
+    let inline = inline_json(&doc);
+
+    assert!(
+        inline.contains("\"imageBytes\":\"inline\""),
+        "기본값은 인라인이다"
+    );
+    assert!(
+        !inline.contains("\"imageBytesOmitted\""),
+        "기본 경로에는 생략 표식이 없어야 한다"
+    );
+    for op in image_ops(&inline) {
+        assert!(
+            op.get("base64").is_some(),
+            "옵션을 켜지 않은 호출은 종전대로 바이트를 싣는다"
+        );
+    }
+}
+
+/// 크기 이득은 이 트랙의 대상 시나리오 — **본문에 인라인된 대형 JPEG** — 에서만 의미가 있다.
+///
+/// 도장처럼 작은 그림만 있는 문서에서는 JSON 이 텍스트·글리프로 지배되므로 생략해도 몇 %만
+/// 줄어든다(실측 248KB → 233KB). 그 숫자로 이 옵션을 정당화하면 안 되므로, 여기서는 #2520 이
+/// 문제로 지목한 크기의 그림을 실제로 넣고 잰다.
+#[test]
+fn issue_3315_omitting_bytes_shrinks_the_payload_for_large_images() {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let jpeg = std::fs::read(std::path::Path::new(repo_root).join("samples/images/tiger01.jpg"))
+        .expect("read tiger01.jpg");
+    let mut doc = open_sample();
+    doc.insert_picture_native(
+        0,
+        0,
+        0,
+        &[],
+        &jpeg,
+        400,
+        300,
+        2400,
+        1800,
+        "jpg",
+        "tiger",
+        None,
+        None,
+    )
+    .expect("insert picture");
+
+    let inline = inline_json(&doc);
+    let omitted = omitted_json(&doc);
+
+    // 생략본에는 그림 바이트가 없으므로 원본 크기에 비례하지 않는다.
+    assert!(
+        omitted.len() * 4 < inline.len(),
+        "생략본이 충분히 작지 않다 (원본 그림 {} bytes, inline={} bytes, omitted={} bytes)",
+        jpeg.len(),
+        inline.len(),
+        omitted.len()
+    );
+    println!(
+        "[#3315] 원본 그림 {} bytes / inline JSON {} bytes / 생략 JSON {} bytes ({:.1}배 축소)",
+        jpeg.len(),
+        inline.len(),
+        omitted.len(),
+        inline.len() as f64 / omitted.len() as f64
+    );
+
+    // 크기가 줄었어도 바이트를 되찾을 수 있어야 의미가 있다.
+    for op in image_ops(&omitted) {
+        let key = op["sourceImageKey"].as_str().expect("키");
+        assert!(
+            doc.get_source_image_bytes_native(key).is_some(),
+            "생략했는데 키로 되찾을 수 없다 (key={key})"
+        );
+    }
+}
+
+#[test]
+fn issue_3315_inline_and_omitted_are_separate_cache_variants() {
+    let doc = open_sample();
+
+    // 같은 페이지를 번갈아 물어본다. 두 모양이 캐시 슬롯을 공유하면 뒤의 호출이 앞의 모양을
+    // 돌려받는다 — #2222 JSON 캐시가 지문에 생략 여부를 접지 않으면 나는 결함이다.
+    let first_inline = inline_json(&doc);
+    let omitted = omitted_json(&doc);
+    let second_inline = inline_json(&doc);
+    let second_omitted = omitted_json(&doc);
+
+    assert_eq!(first_inline, second_inline, "인라인본이 캐시에서 오염됐다");
+    assert_eq!(omitted, second_omitted, "생략본이 캐시에서 오염됐다");
+    assert_ne!(first_inline, omitted, "두 모양이 같을 수 없다");
+}
+
+#[test]
+fn issue_3315_unresolvable_keys_are_refused() {
+    let doc = open_sample();
+    let key = image_ops(&omitted_json(&doc))[0]["sourceImageKey"]
+        .as_str()
+        .expect("키")
+        .to_string();
+    let (epoch, bin_data_id, _variant) = parse_source_image_key(&key).expect("키 해석");
+
+    // 세대가 다른 키 — 스냅샷 복원 뒤에 옛 키로 물어본 경우. 낡은 바이트를 주면 안 된다.
+    let stale = format!("bin:{}:{bin_data_id}:src", epoch.wrapping_add(1));
+    assert!(
+        doc.get_source_image_bytes_native(&stale).is_none(),
+        "세대가 다른 키를 받아들였다"
+    );
+
+    // 없는 그림.
+    assert!(
+        doc.get_source_image_bytes_native(&format!("bin:{epoch}:60000:src"))
+            .is_none(),
+        "없는 bin_data_id 를 받아들였다"
+    );
+
+    for malformed in [
+        "",
+        "bin",
+        "bin:0:1",
+        "bin:0:1:src:extra",
+        "img:0:1:src",
+        "bin:x:1:src",
+        // 모르는 variant 를 src 로 흘리면 워터마크 그림에 원본 JPEG 을 주고도 성공해 보인다.
+        "bin:0:1:png",
+    ] {
+        assert!(
+            parse_source_image_key(malformed).is_none(),
+            "형식이 틀린 키를 받아들였다: {malformed:?}"
+        );
+        assert!(
+            doc.get_source_image_bytes_native(malformed).is_none(),
+            "형식이 틀린 키로 바이트를 돌려줬다: {malformed:?}"
+        );
+    }
+}
+
+#[test]
+fn issue_3315_key_round_trips_through_parser() {
+    for (epoch, id, variant) in [
+        (0u32, 1u16, SourceImageVariant::Source),
+        (7, 60001, SourceImageVariant::BakedWatermarkPng),
+    ] {
+        let key = format!("bin:{epoch}:{id}:{}", variant.as_str());
+        assert_eq!(
+            parse_source_image_key(&key),
+            Some((epoch, id, variant)),
+            "발급 포맷과 해석이 어긋난다: {key}"
+        );
+    }
+    assert!(!SourceImageVariant::Source.bakes_watermark());
+    assert!(SourceImageVariant::BakedWatermarkPng.bakes_watermark());
+}


### PR DESCRIPTION
## 통합 내용

lpaiu-cs의 열린 변경 네 건에서 원 head의 `devel` 병합 commit은 제외하고 기능 commit만 번호순으로 통합했습니다.

- #3653 — 레이어 JSON의 그림 base64 opt-in 생략과 `getSourceImageBytes(key)` API
- #3655 — 셀 문단 병합 metadata의 글상자·캡션·중첩 표 회귀 보강
- #3656 — 실패한 snapshot command의 before 복원과 snapshot ID 정리
- #3660 — 본문 flow 그림을 전체 레이어 트리 대신 좁은 배치 질의와 key별 object URL로 전달

#3660은 #3653의 키 조회 API를 전제로 하므로 두 커밋의 순서를 유지했습니다.

## 관련 이슈

Closes #3350
Closes #3439

#3315은 Track 2·3의 umbrella 이슈이므로 닫지 않습니다.

## 검증

- 네 원 기능 커밋은 `git range-diff`에서 체리픽 commit과 patch 동등입니다.
- #3653·#3655·#3656·#3660의 최신 source full CI가 모두 성공했습니다.
- 통합 head에서는 실제 headless Chrome(Canvas2D)으로 `3-10월_교육_통합_2022.hwp`의 키별 바이트 조회, blob URL 그림 3장 디코드, 문서 교체 뒤 기존 URL 전부 revoke 및 cache 0을 확인했습니다.
- 이 통합 head의 full CI를 병합 게이트로 사용합니다.
