### PR TITLE
test: 계약 회귀 가드의 검증 범위 정리

### DIFF
--- a/rhwp-studio/tests/command-history-snapshot.test.ts
+++ b/rhwp-studio/tests/command-history-snapshot.test.ts
@@ -93,15 +93,30 @@ test('[#3350] 최초 execute 실패는 before 스냅샷 복원 후 ID를 해제�
   const catchBody = block.slice(catchStart);
 
   const idxRestore = catchBody.indexOf('wasm.restoreSnapshot(this.beforeId)');
-  const idxDiscard = catchBody.indexOf('this.discard(wasm)');
-  assert.ok(idxRestore !== -1 && idxDiscard !== -1 && idxRestore < idxDiscard,
-    '부분 변경을 before 스냅샷으로 rollback한 뒤 ID를 해제해야 함');
+  assert.notEqual(idxRestore, -1, '부분 변경을 before 스냅샷으로 rollback해야 함');
   assert.match(catchBody, /catch \(rollbackError\)/,
     'rollback 실패도 별도로 포착해야 함');
   assert.match(catchBody, /new AggregateError\(\s*\[operationError, rollbackError\]/,
     '원래 operation 오류와 rollback 오류를 함께 보존해야 함');
-  assert.match(catchBody, /throw operationError/,
-    'rollback 성공 시 원래 operation 오류를 그대로 전파해야 함');
+
+  // [#3662] rollback **성공** 경로의 discard 를 따로 못박는다.
+  //
+  // 종전에는 `catchBody.indexOf('this.discard(wasm)')` 로 순서만 봤는데, 그 첫 번째 일치는
+  // inner `catch (rollbackError)` 안의 discard 다. 그래서 성공 경로의 discard 를 지워도
+  // 가드가 통과했다 — 스냅샷 2개가 조용히 누수되는 회귀를 못 잡는다.
+  //
+  // inner catch 가 닫힌 **뒤** discard → rethrow 가 이어지는지 확인해 성공 경로에 고정한다.
+  assert.match(
+    catchBody,
+    /\}\s*this\.discard\(wasm\);\s*throw operationError;/,
+    'rollback 성공 시 before/after 를 해제한 뒤 원래 operation 오류를 전파해야 함',
+  );
+
+  // inner catch 안의 discard 도 함께 남아 있어야 한다 — rollback 이 실패해도 ID 는 해제한다.
+  const rollbackCatch = catchBody.slice(catchBody.indexOf('catch (rollbackError)'));
+  const innerBody = rollbackCatch.slice(0, rollbackCatch.indexOf('throw new AggregateError'));
+  assert.match(innerBody, /this\.discard\(wasm\)/,
+    'rollback 실패 경로도 스냅샷 ID 를 해제해야 함');
 });
 
 test('[결함1] 스냅샷 예산은 WASM 상한에서 순간 +2 여유를 뺀 값이다', () => {

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -74,8 +74,17 @@ pub struct LayerJsonOptions {
     /// 그림 바이트를 base64 로 싣지 않는다.
     ///
     /// `sourceImageKey` 를 낼 수 있는 op 만 대상이다 — 키가 없으면 소비자가 바이트를 되찾을
-    /// 길이 없으므로 그 op 은 종전대로 base64 를 싣는다. 기본값이 `false` 라서 이 옵션을
-    /// 지정하지 않는 기존 호출부의 JSON 은 한 바이트도 달라지지 않는다.
+    /// 길이 없으므로 그 op 은 종전대로 base64 를 싣는다.
+    ///
+    /// 그래서 **한 문서 안에 생략된 op 과 인라인 op 이 섞일 수 있다.** 최상위 `imageBytes` 는
+    /// "이렇게 요청했다"는 **모드**이고, op 마다 실제로 생략됐는지는 `imageBytesOmitted` 가
+    /// 말한다 — 소비자는 후자를 봐야 한다. `imageBytes:"byKey"` 를 "모든 op 에 base64 가
+    /// 없다"로 읽으면 키 없는 합성 그림에서 어긋난다.
+    ///
+    /// 기본값은 `false` 이고, 그때 그림 op 의 payload(`mime`·`base64`)는 종전과 같다. 다만
+    /// **JSON 전체가 종전과 같지는 않다** — 이 기능이 최상위 `imageBytes` 를 더하고 schema
+    /// minor 를 21 로 올렸다. 계약은 "기존 필드 불변 + 추가만"(additive)이지 바이트 동일이
+    /// 아니다.
     pub omit_image_bytes: bool,
 }
 
@@ -110,8 +119,12 @@ impl PageLayerTree {
             json_escape(LAYER_TREE_SCHEMA.unit),
             json_escape(LAYER_TREE_SCHEMA.coordinate_system),
             json_escape(render_profile_str(self.profile)),
-            // [#3315] 그림 바이트가 op 안에 있는지(`inline`), 키로 따로 받아야 하는지(`byKey`).
-            // 소비자가 op 마다 `base64` 유무를 추측하지 않고 문서 단위로 판정할 수 있게 한다.
+            // [#3315] 이 문서를 어떤 **모드**로 요청했는지 — `inline` 이면 바이트가 op 안에,
+            // `byKey` 면 키로 따로 받는다.
+            //
+            // op 단위의 사실은 `imageBytesOmitted` 다. 키를 낼 수 없는 합성 그림은 `byKey`
+            // 모드에서도 base64 를 싣기 때문에, 이 값만 보고 "base64 가 하나도 없다"고 단정할
+            // 수 없다. 모드와 op 단위 사실을 한 필드에 겹쳐 담지 않는다.
             json_escape(if options.omit_image_bytes {
                 "byKey"
             } else {
@@ -4592,5 +4605,99 @@ mod tests {
             parsed["outputOptions"]["debugOverlay"].as_bool(),
             Some(true)
         );
+    }
+}
+
+#[cfg(test)]
+mod image_bytes_mode_tests {
+    //! Task #3315: `imageBytes` 최상위 값과 op 단위 `imageBytesOmitted` 의 관계를 못박는다.
+    //!
+    //! 생략은 신원 키를 낼 수 있는 op 만 대상이므로 **한 문서 안에 두 종류가 섞일 수 있다.**
+    //! 그 상태에서 최상위 값이 무엇을 뜻하는지가 열려 있었다 — 요청 모드인가, 모든 op 의 실제
+    //! 저장 방식인가. 여기서 **요청 모드**로 확정하고, 그러므로 소비자는 op 단위 표식을 봐야
+    //! 한다는 것을 고정한다.
+    //!
+    //! samples 전수에 키 없는 그림이 섞인 문서가 없어(전 표본 `cacheable:true`) 문서 단위
+    //! 테스트로는 이 상태를 만들 수 없다. 그래서 트리를 직접 조립한다.
+
+    use super::LayerJsonOptions;
+    use crate::paint::{LayerNode, PageLayerTree, PaintOp};
+    use crate::renderer::render_tree::{BoundingBox, ImageNode};
+    use serde_json::Value;
+
+    /// 키를 낼 수 있는 그림(`bin_data_id != 0`)과 낼 수 없는 합성 그림(`0`)을 함께 담은 트리.
+    fn mixed_tree() -> PageLayerTree {
+        let png = vec![0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
+        PageLayerTree::new(
+            120.0,
+            80.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 120.0, 80.0),
+                None,
+                vec![
+                    PaintOp::image(
+                        BoundingBox::new(0.0, 0.0, 10.0, 10.0),
+                        ImageNode::new(7, Some(png.clone())),
+                        None,
+                    ),
+                    PaintOp::image(
+                        BoundingBox::new(20.0, 0.0, 10.0, 10.0),
+                        ImageNode::new(0, Some(png)),
+                        None,
+                    ),
+                ],
+            ),
+        )
+    }
+
+    fn image_ops(json: &str) -> Vec<Value> {
+        let value: Value = serde_json::from_str(json).expect("valid layer JSON");
+        value["root"]["ops"]
+            .as_array()
+            .expect("ops")
+            .iter()
+            .filter(|op| op.get("type").and_then(Value::as_str) == Some("image"))
+            .cloned()
+            .collect()
+    }
+
+    #[test]
+    fn issue_3315_top_level_image_bytes_is_the_requested_mode_not_a_per_op_guarantee() {
+        let json = mixed_tree().to_json_with_options(LayerJsonOptions {
+            omit_image_bytes: true,
+        });
+        let ops = image_ops(&json);
+        assert_eq!(ops.len(), 2);
+
+        assert!(
+            json.contains("\"imageBytes\":\"byKey\""),
+            "요청한 모드를 최상위에 싣는다"
+        );
+
+        // 키가 있는 op — 생략됐고 키로 받아야 한다.
+        assert!(ops[0].get("base64").is_none(), "키 있는 op 은 생략된다");
+        assert_eq!(ops[0]["imageBytesOmitted"].as_bool(), Some(true));
+        assert!(ops[0].get("sourceImageKey").is_some());
+
+        // 키가 없는 합성 op — 되찾을 길이 없으므로 base64 를 유지한다.
+        assert!(
+            ops[1].get("base64").is_some(),
+            "키 없는 op 의 바이트를 빼면 소비자가 그 그림을 되찾을 방법이 없다"
+        );
+        assert!(
+            ops[1].get("imageBytesOmitted").is_none(),
+            "생략하지 않은 op 에 생략 표식을 달면 소비자가 헛되게 키를 찾는다"
+        );
+        assert!(ops[1].get("sourceImageKey").is_none());
+    }
+
+    #[test]
+    fn issue_3315_inline_mode_marks_no_op_as_omitted() {
+        let json = mixed_tree().to_json();
+        assert!(json.contains("\"imageBytes\":\"inline\""));
+        assert!(!json.contains("\"imageBytesOmitted\""));
+        for op in image_ops(&json) {
+            assert!(op.get("base64").is_some());
+        }
     }
 }

--- a/src/paint/resources.rs
+++ b/src/paint/resources.rs
@@ -478,6 +478,14 @@ mod tests {
             Some("bin:3:7:wmpng")
         );
 
+        // 밝기와 명암 중 하나만 바뀌어도 기존 bake 술어는 같은 variant를 발급한다.
+        image.brightness = 0;
+        image.contrast = 1;
+        assert_eq!(
+            source_image_key(3, &image).as_deref(),
+            Some("bin:3:7:wmpng")
+        );
+
         // JPEG 이 아니면 효과 필드는 별도 JSON 속성일 뿐 base64 payload는 바뀌지 않는다.
         image.data = Some(vec![0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a]);
         assert_eq!(source_image_key(3, &image).as_deref(), Some("bin:3:7:src"));

--- a/src/renderer/image_resolver.rs
+++ b/src/renderer/image_resolver.rs
@@ -685,10 +685,11 @@ fn decode_image_with_format_limited(
 #[cfg(test)]
 mod tests {
     use super::{
-        bmp_bytes_to_png_bytes, grayscale_jpeg_bytes_to_png_bytes, resolve_image_payload,
-        watermark_jpeg_bytes_to_hancom_baked_png_bytes, ConversionMemo, CONVERSIONS_RUN,
-        MAX_MEMO_BYTES, MAX_MEMO_ENTRIES,
+        bmp_bytes_to_png_bytes, emitted_image_bytes, grayscale_jpeg_bytes_to_png_bytes,
+        is_watermark_image, resolve_image_payload, watermark_jpeg_bytes_to_hancom_baked_png_bytes,
+        ConversionMemo, CONVERSIONS_RUN, MAX_MEMO_BYTES, MAX_MEMO_ENTRIES,
     };
+    use crate::model::image::ImageEffect;
     use crate::paint::ResolvedImageKind;
     use crate::renderer::render_tree::ImageNode;
     use image::{DynamicImage, ImageFormat, Rgb, RgbImage};
@@ -916,5 +917,239 @@ mod tests {
 
         assert!(bmp_bytes_to_png_bytes(&bmp).is_none());
         assert!(resolve_image_payload(&ImageNode::new(1, Some(bmp))).is_none());
+    }
+}
+
+#[cfg(test)]
+mod emitted_bytes_key_agreement_tests {
+    //! Task #3315: 신원 키의 variant 가 JSON 경로와 **같은 바이트**를 가리키는지 고정한다.
+    //!
+    //! `getPageLayerTree` 가 base64 를 생략하면 소비자는 `getSourceImageBytes(key)` 로 바이트를
+    //! 받는다. 두 경로는 `emitted_image_bytes` 를 함께 쓰므로 변환 사슬 자체는 갈라질 수 없지만,
+    //! **넘기는 술어가 다르다** —
+    //!
+    //! - JSON 경로: `is_watermark_image(image)` (ImageNode 를 직접 본다)
+    //! - 키 조회 경로: `parse_source_image_key(key)` 로 되읽은 variant
+    //!
+    //! 그 둘이 어긋나면 워터마크 그림에 원본 JPEG 을 돌려주고도 성공한 것처럼 보인다. 여기서
+    //! 고정하는 것은 "키만으로 같은 바이트를 재현할 수 있다"는 계약이고, 변환 분기(BMP·PCX·
+    //! TIFF·회색 JPEG·워터마크 JPEG·변환 실패 되돌림)마다 확인한다.
+
+    use super::{emitted_image_bytes, is_watermark_image};
+    use crate::model::image::ImageEffect;
+    use crate::paint::{parse_source_image_key, source_image_key};
+    use crate::renderer::render_tree::ImageNode;
+    use image::{DynamicImage, ImageFormat, Rgb, RgbImage};
+    use std::io::Cursor;
+
+    const EPOCH: u32 = 5;
+
+    fn encoded(
+        width: u32,
+        height: u32,
+        format: ImageFormat,
+        pixel: impl Fn(u32, u32) -> [u8; 3],
+    ) -> Vec<u8> {
+        let mut img = RgbImage::new(width, height);
+        for y in 0..height {
+            for x in 0..width {
+                img.put_pixel(x, y, Rgb(pixel(x, y)));
+            }
+        }
+        let mut out = Vec::new();
+        DynamicImage::ImageRgb8(img)
+            .write_to(&mut Cursor::new(&mut out), format)
+            .expect("encode");
+        out
+    }
+
+    fn gray_jpeg() -> Vec<u8> {
+        encoded(8, 8, ImageFormat::Jpeg, |x, y| {
+            let g = 150 + ((x + y) % 32) as u8;
+            [g, g, g]
+        })
+    }
+
+    fn color_jpeg() -> Vec<u8> {
+        encoded(8, 8, ImageFormat::Jpeg, |x, y| {
+            if (x + y) % 2 == 0 {
+                [220, 64, 64]
+            } else {
+                [64, 120, 220]
+            }
+        })
+    }
+
+    /// 워터마크 bake 가 **실제로 성공하는** JPEG.
+    ///
+    /// `watermark_jpeg_bytes_to_hancom_baked_png_bytes` 는 테두리의 85% 이상과 전체의 20% 이상이
+    /// 흰색에 가까워야 bake 한다. 단색·격자 같은 합성 이미지는 그 조건을 못 맞춰 `None` 이
+    /// 되고, 그러면 `wmpng` 와 `src` 두 분기가 같은 되돌림 결과로 수렴해 **variant 가 갈렸는지
+    /// 확인할 수 없다**. 그래서 흰 바탕에 작은 어두운 얼룩을 둔 모양으로 만든다.
+    fn watermark_shaped_jpeg() -> Vec<u8> {
+        encoded(48, 48, ImageFormat::Jpeg, |x, y| {
+            let center = (20..28).contains(&x) && (20..28).contains(&y);
+            if center {
+                [40, 40, 40]
+            } else {
+                [255, 255, 255]
+            }
+        })
+    }
+
+    /// 그림 하나에 대해 두 경로의 (mime, bytes) 가 같은지 확인한다.
+    fn assert_paths_agree(label: &str, image: &ImageNode) {
+        let data = image.data.as_deref().expect("바이트가 있어야 한다");
+
+        // JSON 경로가 쓰는 술어.
+        let (json_mime, json_bytes) = emitted_image_bytes(data, is_watermark_image(image));
+
+        // 키 조회 경로 — 키를 문자열로 내보내고 되읽어 variant 만으로 재현한다.
+        let key = source_image_key(EPOCH, image).expect("bin_data_id != 0 이면 키가 나온다");
+        let (epoch, bin_data_id, variant) =
+            parse_source_image_key(&key).expect("발급한 키는 되읽을 수 있어야 한다");
+        assert_eq!(epoch, EPOCH, "{label}: 키의 세대가 어긋난다");
+        assert_eq!(
+            bin_data_id, image.bin_data_id,
+            "{label}: 키의 id 가 어긋난다"
+        );
+        let (key_mime, key_bytes) = emitted_image_bytes(data, variant.bakes_watermark());
+
+        assert_eq!(
+            json_mime, key_mime,
+            "{label}: mime 이 갈렸다 — 소비자가 Blob 타입을 잘못 정한다 (key={key})"
+        );
+        assert_eq!(
+            json_bytes.as_ref(),
+            key_bytes.as_ref(),
+            "{label}: 바이트가 갈렸다 — 키로 받은 그림이 인라인 base64 와 다르다 (key={key})"
+        );
+    }
+
+    fn watermarked(mut image: ImageNode) -> ImageNode {
+        // `is_watermark_image` 가 참이 되는 최소 조건.
+        image.effect = ImageEffect::GrayScale;
+        image.brightness = 20;
+        image
+    }
+
+    #[test]
+    fn issue_3315_key_variant_reproduces_json_bytes_for_every_conversion_branch() {
+        let png = encoded(4, 4, ImageFormat::Png, |_, _| [10, 20, 30]);
+        let bmp = encoded(16, 16, ImageFormat::Bmp, |x, _| [x as u8 * 4, 90, 200]);
+        let tiff = encoded(4, 4, ImageFormat::Tiff, |x, y| {
+            [32 + x as u8, 96 + y as u8, 160]
+        });
+
+        let cases: Vec<(&str, ImageNode)> = vec![
+            // 변환 없음 — 원본 mime 그대로.
+            ("PNG", ImageNode::new(1, Some(png.clone()))),
+            // 브라우저가 못 읽는 포맷 → PNG 변환.
+            ("BMP", ImageNode::new(2, Some(bmp))),
+            ("TIFF", ImageNode::new(3, Some(tiff))),
+            // 회색 JPEG → PNG 정규화.
+            ("회색 JPEG", ImageNode::new(4, Some(gray_jpeg()))),
+            // 색 JPEG → 변환 없음(정규화 대상이 아니다).
+            ("색 JPEG", ImageNode::new(5, Some(color_jpeg()))),
+            // 워터마크 bake — variant 가 `wmpng` 로 갈리는 유일한 축. bake 가 실제로 성공하는
+            // 모양이어야 두 분기의 결과가 달라지고, 그래야 갈라짐을 잡을 수 있다.
+            (
+                "워터마크 JPEG(bake 성공)",
+                watermarked(ImageNode::new(6, Some(watermark_shaped_jpeg()))),
+            ),
+            // bake 술어는 참인데 bake 가 실패하는 모양 — 두 분기가 같은 되돌림으로 수렴한다.
+            (
+                "워터마크 술어 + bake 실패",
+                watermarked(ImageNode::new(7, Some(gray_jpeg()))),
+            ),
+            // JPEG 이 아니면 효과가 붙어도 bake 대상이 아니다 — variant 는 `src` 로 남아야 한다.
+            ("효과 붙은 PNG", watermarked(ImageNode::new(8, Some(png)))),
+        ];
+
+        for (label, image) in &cases {
+            assert_paths_agree(label, image);
+        }
+    }
+
+    /// bake 가 성공하는 모양에서 두 variant 의 바이트가 **실제로 다름**을 먼저 못박는다.
+    ///
+    /// 이 단언이 없으면 위 등가성 테스트가 "두 경로가 같다"를 확인하는 게 아니라 "두 분기가
+    /// 애초에 구분되지 않는다"를 확인하는 것일 수 있다.
+    #[test]
+    fn issue_3315_watermark_variant_actually_changes_the_bytes() {
+        let jpeg = watermark_shaped_jpeg();
+        let (baked_mime, baked) = emitted_image_bytes(&jpeg, true);
+        let (plain_mime, plain) = emitted_image_bytes(&jpeg, false);
+
+        assert_eq!(baked_mime, "image/png", "bake 결과는 PNG 다");
+        assert_ne!(
+            baked.as_ref(),
+            plain.as_ref(),
+            "이 모양에서 bake 가 돌지 않으면 variant 갈라짐을 검증할 수 없다"
+        );
+        // mime 은 갈리지 않는다 — 흰 바탕 그림은 비-워터마크 경로에서도 회색 JPEG 으로 판정돼
+        // PNG 로 정규화된다. 즉 이 축의 차이는 **바이트에만** 나타나므로, mime 만 비교하는
+        // 검증은 워터마크 갈라짐을 놓친다.
+        assert_eq!(plain_mime, "image/png");
+    }
+
+    #[test]
+    fn issue_3315_variant_marks_watermark_bake_only_for_jpeg() {
+        let png = encoded(4, 4, ImageFormat::Png, |_, _| [1, 2, 3]);
+        let jpeg = color_jpeg();
+
+        // JPEG + 효과 → wmpng
+        let key = source_image_key(EPOCH, &watermarked(ImageNode::new(1, Some(jpeg.clone()))))
+            .expect("키");
+        assert!(
+            key.ends_with(":wmpng"),
+            "JPEG 워터마크는 wmpng 여야 한다: {key}"
+        );
+
+        // JPEG + 효과 없음 → src
+        let key = source_image_key(EPOCH, &ImageNode::new(1, Some(jpeg))).expect("키");
+        assert!(
+            key.ends_with(":src"),
+            "효과 없는 JPEG 은 src 여야 한다: {key}"
+        );
+
+        // PNG + 효과 → src (bake 는 JPEG 경로에만 있다)
+        let key = source_image_key(EPOCH, &watermarked(ImageNode::new(1, Some(png)))).expect("키");
+        assert!(
+            key.ends_with(":src"),
+            "PNG 은 효과가 붙어도 bake 하지 않으므로 src 여야 한다: {key}"
+        );
+    }
+
+    /// 변환이 **실패**하면 두 경로가 함께 원본으로 되돌아가야 한다.
+    ///
+    /// 되돌림이 한쪽에만 있으면 키로 받은 바이트가 인라인과 달라진다. 헤더만 그럴듯한 손상
+    /// BMP 로 그 경로를 태운다 — `resolve_image_payload` 는 `None` 을 주고, 두 경로 모두
+    /// `emitted_image_bytes` 안에서 같은 되돌림을 밟는다.
+    #[test]
+    fn issue_3315_failed_conversion_falls_back_identically_on_both_paths() {
+        let mut broken_bmp = vec![0u8; 64];
+        broken_bmp[..2].copy_from_slice(b"BM");
+        let image = ImageNode::new(9, Some(broken_bmp.clone()));
+
+        let (mime, bytes) = emitted_image_bytes(&broken_bmp, is_watermark_image(&image));
+        assert_eq!(mime, "image/bmp", "변환 실패 시 감지한 원본 mime 을 쓴다");
+        assert_eq!(
+            bytes.as_ref(),
+            &broken_bmp[..],
+            "변환 실패 시 원본 바이트를 쓴다"
+        );
+
+        assert_paths_agree("손상 BMP", &image);
+    }
+
+    /// 신원 키를 낼 수 없는 그림은 키 조회로 되찾을 수 없다 — 그래서 생략 대상이 아니다.
+    #[test]
+    fn issue_3315_synthetic_images_have_no_key() {
+        let png = encoded(2, 2, ImageFormat::Png, |_, _| [0, 0, 0]);
+        // bin_data_id == 0 — 문서 BinData 에 대응하지 않는 합성 그림.
+        assert!(source_image_key(EPOCH, &ImageNode::new(0, Some(png))).is_none());
+        // 바이트를 내보내지 않는 op 도 키가 없다.
+        assert!(source_image_key(EPOCH, &ImageNode::new(1, None)).is_none());
     }
 }

--- a/tests/issue_3315_image_bytes_by_key.rs
+++ b/tests/issue_3315_image_bytes_by_key.rs
@@ -132,23 +132,48 @@ fn issue_3315_omitted_ops_keep_mime_and_declare_omission() {
     }
 }
 
+/// 기본 경로의 계약은 **additive** 다 — "바이트 동일"이 아니다.
+///
+/// 이 테스트의 이름은 원래 `..._is_byte_identical` 이었는데, 그 이름이 주장하는 성질은 **거짓**
+/// 이다. 이 기능이 최상위 `imageBytes` 를 더하고 schema minor 를 20 → 21 로 올렸으므로 기본
+/// 호출의 JSON 은 종전과 바이트 단위로 같지 않다. 이름만 보고 "schema 가 안 바뀌었다"고
+/// 판단하면 소비자 호환 결정을 잘못 내린다.
+///
+/// 실제로 지켜야 하는 것은 둘이다 — ①그림 op 의 payload(`mime`·`base64`)가 종전과 같다
+/// ②추가된 것은 문서화된 두 필드뿐이고 생략 표식은 나타나지 않는다.
 #[test]
-fn issue_3315_default_serialization_is_byte_identical() {
+fn issue_3315_default_serialization_keeps_payloads_and_only_adds_documented_fields() {
     let doc = open_sample();
     let inline = inline_json(&doc);
+    let value: Value = serde_json::from_str(&inline).expect("레이어 JSON 이 유효해야 한다");
 
-    assert!(
-        inline.contains("\"imageBytes\":\"inline\""),
-        "기본값은 인라인이다"
+    // 추가된 계약을 명시적으로 고정한다 — schema minor 를 올렸다는 사실이 계약의 일부다.
+    assert_eq!(
+        value["schemaMinorVersion"].as_u64(),
+        Some(u64::from(rhwp::paint::PAGE_LAYER_TREE_SCHEMA_MINOR_VERSION)),
+        "schema minor 는 상수와 같아야 한다"
+    );
+    // 컴파일 시점 하한 — 이 기능은 minor 21 에서 들어왔다. 내려가면 소비자 협상이 깨진다.
+    // (런타임 `assert!` 는 상수라 clippy 가 거부한다 — const 단언이 더 이르게 잡는다.)
+    const _: () = assert!(rhwp::paint::PAGE_LAYER_TREE_SCHEMA_MINOR_VERSION >= 21);
+    assert_eq!(
+        value["imageBytes"].as_str(),
+        Some("inline"),
+        "옵션을 지정하지 않은 호출의 모드는 inline 이다"
     );
     assert!(
         !inline.contains("\"imageBytesOmitted\""),
         "기본 경로에는 생략 표식이 없어야 한다"
     );
+
     for op in image_ops(&inline) {
         assert!(
             op.get("base64").is_some(),
             "옵션을 켜지 않은 호출은 종전대로 바이트를 싣는다"
+        );
+        assert!(
+            op.get("mime").and_then(Value::as_str).is_some(),
+            "payload 의 mime 도 종전대로다"
         );
     }
 }


### PR DESCRIPTION
## 목적

사용자 소유 PR #3653, #3655, #3656, #3660, #3665의 contribution review gate에서 원본 PR에 게시하지 않는 P3/QUESTION 후속 작업을 한곳에 누적합니다. #3655의 사실과 다른 HWPX 왕복 설명은 원본 PR 본문에서 즉시 바로잡았으므로 별도 코드 항목은 없습니다.

## Cleanup checklist

- [x] source image key가 brightness-only와 contrast-only 양쪽에서 동일한 JPEG bake variant를 사용하는 경계 anchor 추가
- [ ] #3653의 default byte-identity 테스트와 이름을 실제 additive contract인 schema minor 21 및 `imageBytes:"inline"`에 맞게 정리
- [ ] #3653에 BMP/PCX/TIFF/grayscale JPEG/watermark JPEG/fallback의 bytes와 MIME 동등성 검증 추가
- [ ] QUESTION: keyless inline fallback이 섞인 문서에서 top-level `imageBytes:"byKey"`가 요청 모드인지 모든 op의 실제 저장 방식인지 결정
- [ ] #3656에서 정상 rollback 뒤 discard 호출을 실제로 고정하는 fake bridge 행위 테스트 또는 inner catch 이후로 범위를 제한한 source guard 추가
- [x] #3660에서 bbox와 같은 ancestor clip 아래 회전 flow image를 사용해 narrow/full-tree 최종 clip 등가성 고정 (#3665)
- [x] #3660에서 same-document revision은 URL/bytes를 재사용하고 backend가 바뀌는 document replacement의 colliding key는 새 bytes를 읽으며, 새 문서가 flow URL을 한 번도 조회하지 않아도 이전 URL을 교체 경계에서 revoke하는 lifecycle 가드 추가 (#3665 06d03b110)
- [ ] #3665의 문서 경계 배선을 정규식 source guard 대신 fake WasmBridge 행위 테스트로 고정 — `PageRenderer.beginDocument` → `urlFor` 경로를 실제로 구동해 검증한다
- [ ] #3665에서 `PageRenderer.prefetchedImageSignatures`도 문서 (재)로드 경계에서 정리 — 현재는 이전 문서 페이지의 서명이 renderer 수명 동안 남는다. 신원 검사(`shouldSkipImagePrefetch`)로 오사용은 이미 막혀 있고 OS 자원이 아닌 작은 문자열이라 심각도는 낮다

## Lifecycle

#3653, #3656, #3660의 대상 코드는 통합 PR #3661을 통해 `devel`에 반영됐습니다. 미완료 항목 구현 전 이 branch를 최신 `devel`로 갱신하고 전체 checklist를 다시 검증합니다.

#3660의 P1/P2는 이 cleanup으로 내리지 않고 원 PR의 [URL cache lifecycle thread](https://github.com/edwardkim/rhwp/pull/3660#discussion_r3690494544)와 [ancestor clip thread](https://github.com/edwardkim/rhwp/pull/3660#discussion_r3690495657)에서 추적했고, 통합 후 발견된 [no-lookup document replacement thread](https://github.com/edwardkim/rhwp/pull/3665#discussion_r3691069551)는 #3665의 `06d03b110`에서 문서 (재)로드 경계로 수명 권한을 옮겨 해소했습니다. 여기에는 낮은 심각도의 회귀 가드 범위만 누적합니다.

## Validation

- `CARGO_INCREMENTAL=0 cargo test --profile release-test --lib source_image_key_changes_only_when_jpeg_base64_is_baked`
- `cargo fmt --all -- --check`
- `git diff --check origin/devel...HEAD`
