### PR TITLE
docs(pr): #3661 실제 Studio 검증 증적을 보완한다

### DIFF
--- a/mydocs/orders/20260731.md
+++ b/mydocs/orders/20260731.md
@@ -19,9 +19,12 @@ commit은 중복하지 않았고, source devel merge commit도 제외했다.
 - source head 4건과 #3661 exact code head에서 lint·WASM check, frontend gates, Native Skia, test archive,
   default-feature 8 shards, CodeQL, Canvas visual diff, `Build & Test` aggregate가 모두 success다. 전체 local
   release-test는 이 exact integration CI와 중복하므로 실행하지 않는다.
-- review 전용 target에서 fresh `wasm-pack build --target web --out-dir pkg`는 exit 0이다. in-app Studio
-  shell은 boot했으나 hidden file input의 automated chooser 제약으로 fixture load는 성공으로 주장하지 않는다.
-  Rust 실문서 narrow-query 등가성 회귀와 exact CI Canvas diff가 renderer 근거다.
+- review 전용 target에서 fresh `wasm-pack build --target web --out-dir pkg`는 exit 0이다. headless Chrome
+  Canvas2D에서 `3-10월_교육_통합_2022.hwp`를 실제로 열어 cacheable key별 bytes, blob URL 그림 3장의
+  natural-size decode를 확인했다. 이어 `field-01.hwp`로 문서를 바꾸자 기존 DOM URL이 모두 revoke되고
+  cache가 0이 됐다. raw SVG가 섞인 `143E433F503322BD33.hwp`는 DOM split 대신 기존 static 경로로
+  fallback했고, 나머지 flow-image 표본 세 건은 blob DOM layer를 만들었다. Rust 실문서 narrow-query
+  등가성 회귀와 exact CI Canvas diff가 renderer 근거다.
 - archive review·통합 기록·오늘할일만 추가한 뒤 staged LFS 판독, review-only fast-pass를 실제 확인하고
   #3661 하나만 merge한다. 이후 original PR supersede/comment, issue 상태, devel sync, 정확한 review target·branch
   정리까지 수행한다. 근거는 `mydocs/pr/archives/pr_3653_review.md`–`pr_3660_review.md`와

--- a/mydocs/pr/archives/pr_3653_review_impl.md
+++ b/mydocs/pr/archives/pr_3653_review_impl.md
@@ -38,6 +38,11 @@ branch이므로 #3653 기능을 중복 적용하지 않았고, 통합 branch에�
 code head는 `52903c91bf132f7f3a977afc9cc265859b024c85`다. source #3653·#3655·#3656·#3660의 full CI와
 #3661 exact code head의 lint/WASM, frontend gates, Native Skia, archive, default-feature 8 shards, CodeQL,
 Canvas visual diff, `Build & Test` aggregate가 모두 성공했다. 현재 상태는 `CLEAN`·`MERGEABLE`이다.
+
+통합 head의 headless Chrome Canvas2D에서는 `3-10월_교육_통합_2022.hwp` p0의 cacheable flow-image key를
+bytes로 해석해 blob URL 그림 3장이 모두 decode됨을 확인했다. `field-01.hwp`로 문서를 교체하면 기존
+DOM URL이 모두 revoke되고 cache가 0이 됐다. raw SVG가 있는 `143E433F503322BD33.hwp`는 기존 static
+경로로 fallback했고, 추가 flow-image 표본 세 건은 blob DOM layer를 만들었다.
 로컬은 전용 target에서 fresh `wasm-pack build`만 exit 0을 확인했고, 전체 Cargo는 exact CI와 중복하지
 않도록 실행하지 않았다.
 

--- a/mydocs/pr/archives/pr_3660_review.md
+++ b/mydocs/pr/archives/pr_3660_review.md
@@ -42,13 +42,15 @@ static layer 경로를 유지한다.
 | 통합 code head CI | lint·WASM check, frontend package gates, Native Skia, archive, default-feature 8 shards, CodeQL, Canvas visual diff, `Build & Test` 모두 success |
 | Rust 회귀 | 실제 flow-image HWP/HWPX 4개에서 tree와 narrow query의 개수·순서·bbox·clip·effect·transform·mime·key 동등성, key-byte 해석, bbox 이동, no-flow 페이지를 고정 |
 | Studio 회귀 | data URL/object URL mapping, cacheable false, malformed/unresolvable all-or-nothing fallback, object URL release를 고정 |
-| 로컬 WASM | review 전용 target에서 `wasm-pack build --target web --out-dir pkg` exit 0; Studio shell boot 확인 |
+| 실제 브라우저 | headless Chrome Canvas2D에서 cacheable key→bytes, blob URL 그림 3장 decode, 문서 교체 뒤 기존 URL 전부 revoke·cache 0 확인 |
 | 추가 전체 Cargo | source 및 exact integration CI와 중복되므로 작업지시에 따라 실행하지 않음. 성공 근거로 사용하지 않음 |
 
-로컬 in-app Studio에서 fixture file chooser는 자동 제어 surface가 hidden input을 열지 못해 실제 fixture
-load까지 완료하지 못했다. 이를 browser 성공으로 바꾸지 않는다. 이미 source와 exact integration head의
-Canvas visual diff, frontend gates, Rust 실문서 등가성 회귀가 수용 근거이며, 최종 aggregate가 별도 merge
-조건이다.
+실제 Studio 검증은 `3-10월_교육_통합_2022.hwp` p0에서 수행했다. cacheable key의 바이트를 받고 DOM
+blob URL 그림 세 장이 모두 natural size로 decode됨을 확인한 뒤, `field-01.hwp`로 문서를 바꿔 그 URL들이
+전부 revoke되고 cache가 0이 됨을 확인했다. raw SVG가 섞인 `143E433F503322BD33.hwp`는 DOM split을 하지
+않고 기존 static 경로로 fallback했으며, 추가 flow-image HWP/HWPX 표본 세 건은 blob DOM layer를 만들었다.
+이는 source·exact integration head의 Canvas visual diff, frontend gates, Rust 실문서 등가성 회귀를 보완하는
+실제 소비자 경로 검증이다.
 
 ## 권고
 


### PR DESCRIPTION
## 내용

[#3661](https://github.com/edwardkim/rhwp/pull/3661) merge 뒤 검토 기록에 남아 있던 보수적 Studio fixture-load 문구를 실제 통합 head 검증 결과로 정정합니다.

- `mydocs/pr/archives/pr_3660_review.md`에 headless Chrome Canvas2D의 cacheable key→bytes, blob URL 그림 3장 decode, 문서 교체 뒤 URL revoke·cache 0을 기록합니다.
- 통합 계획과 오늘할일에 raw SVG 혼합 표본의 기존 static fallback 및 추가 flow-image 표본의 DOM layer 확인을 보완합니다.
- source, test, workflow, fixture, LFS 자료는 포함하지 않습니다.

## 검증

- #3661 exact code head는 full CI, CodeQL, Canvas visual diff, `Build & Test`를 이미 통과했습니다.
- 이 PR은 Markdown 3개만 바꾸므로 fast-pass 결과만 후속 기록 merge gate로 사용합니다.
- 변경 파일은 모두 non-LFS이며 `GIT_LFS_SKIP_PUSH=1` dry-run과 실제 push를 확인했습니다.
