### PR TITLE
feat: #3648 hwpctl 비-undo 정책 명문화 — 가드 등재·미지원 응답·층위 계약

### DIFF
--- a/mydocs/tech/edit_action_undo_redo_architecture.md
+++ b/mydocs/tech/edit_action_undo_redo_architecture.md
@@ -18,11 +18,51 @@ rhwp-studio의 편집 기능이 늘어나도 다음 사용자 경험을 유지�
 - 문서를 바꾸지 않는 보기/조회 액션은 history에 들어가지 않는다.
 - 복잡한 편집은 snapshot을 허용하되, 허용 조건을 명확히 한다.
 
+## 층위 계약 — undo/redo 는 studio UI 레이어 기능이다
+
+이 문서의 원칙은 **rhwp-studio 의 편집 UI 레이어**를 규율한다. 아래 층위를 먼저 확정한다 — 이
+구분이 없으면 "문서를 바꾸는 모든 호출은 라우터를 통과해야 한다"가 전 층위에 적용되는 것처럼
+읽히고, 실제로 그렇지 않은 표면이 결함으로 오인된다 (#3648).
+
+| 층위 | 히스토리 | 근거 |
+|---|---|---|
+| `rhwp` core (WASM 바인딩) | **비경유** | 순수 문서 엔진이다. 히스토리 개념 자체가 없다. npm `rhwp` 배포 표면(`rhwp_bg.wasm`·`rhwp.js`·`rhwp.d.ts`)에 히스토리 API 가 없다 |
+| `@rhwp/editor` (임베드 transport) | **비경유** | 배포 표면(`index.js`·`transport.js`·`index.d.ts`)에 `HwpCtrl`·`registerAction` 노출이 없다 |
+| `rhwp-studio/src/hwpctl` (자동화 표면) | **비경유 — 정책** | 아래 절 |
+| `rhwp-studio` 편집 UI (`command/`·`engine/input-handler*`·`ui/`) | **경유** | 이 문서의 규율 대상 |
+
+즉 **undo/redo 는 엔진이 보장하는 성질이 아니라 studio UI 레이어가 제공하는 기능**이다. 코어를
+직접 쓰는 소비자(CLI·MCP 세션 도구·임베드 자동화)는 되돌리기를 자기 트랜잭션 경계로 관리한다.
+
+### hwpctl 은 의도적으로 히스토리를 경유하지 않는다 (#3648, 2026-07-31)
+
+`src/hwpctl` 은 한컴 `HwpCtrl` 호환 자동화 표면이고 소비자는 스크립트다. 스크립트는 자기
+트랜잭션 경계를 알기에 "N 개 작업 후 되돌리기"는 호출자가 문서 사본으로 관리할 문제로 판정됐다.
+히스토리 경유는 자동화 레이어를 앱 레이어에 종속시켜 의존 방향을 뒤집는다 — 현재 `HwpCtrl` 은
+raw doc 만 알고 studio 의 `command`/`engine` 을 모른다.
+
+그 결과 세 가지가 따라온다.
+
+1. **raw doc 직접 뮤테이션 23곳은 동결된 현상이다.** 줄여야 할 부채가 아니다.
+   `rhwp-studio/tests/mutation-routing-guard.test.ts` 의 `BASELINE` 이 `src/hwpctl/**` 를 그 수로
+   동결하고, **늘어나는 것만** 리뷰 대상으로 삼는다.
+2. **`Undo`/`Redo` 액션 등록은 유지한다.** 등록을 지우면 호출자에게 "오타로 없는 액션을 불렀다"와
+   "의도적으로 지원하지 않는다"가 똑같이 `미등록` 으로 보인다. 등록을 남기고 사유를 실어야
+   호출자가 둘을 구분해 이 문서로 올 수 있다.
+3. **사유는 조회할 수 있어야 한다.** `Run`/`Execute` 의 반환형은 한컴 호환이라 `boolean` 고정이고,
+   iframe 안 콘솔 경고는 통합자에게 보이지 않는다. `HwpCtrl.GetActionSupport(id)` 가 네 상태를
+   구분한다 — `null`(미등록=오타) / `unimplemented`(구현 대기) / `unsupported`(정책 미지원, 사유·근거
+   포함) / `supported`.
+
+임베드에서 studio UI 와 같은 문서를 공유하는 실사용례가 생기면 히스토리 경유(①안)와 혼합(③안)을
+그 시점에 재검토한다.
+
 ## 기본 원칙
 
 ### 1. 문서 mutation은 라우터를 통과한다
 
-새로운 문서 mutation은 원칙적으로 편집 라우터를 통과해야 한다.
+**studio 편집 UI 레이어**의 새로운 문서 mutation 은 원칙적으로 편집 라우터를 통과해야 한다.
+위 층위 표에서 "비경유"인 표면은 이 원칙의 대상이 아니다.
 
 허용되는 예외:
 
@@ -31,6 +71,7 @@ rhwp-studio의 편집 기능이 늘어나도 다음 사용자 경험을 유지�
 - view state API
 - `EditCommand` 내부의 저수준 `wasm.*` 호출
 - 성능상 drag 중 실시간 preview를 위해 먼저 적용하고 종료 시 `recordApplied`로 기록하는 경로
+- `src/hwpctl` 자동화 표면 — 정책상 비경유 (위 절, #3648)
 
 ### 2. history stack은 하나다
 
@@ -263,11 +304,17 @@ IME/iOS처럼 여러 raw mutation을 묶으면 세 값은 각각 OR 누적되므
 
 PR 검토 시 다음 질문을 확인한다.
 
-- 새 `wasm.*` 호출이 문서를 변경하는가?
+- 어느 층위의 변경인가? (위 층위 표 — 비경유 표면이면 아래 질문은 대상이 아니다)
+- 새 문서 변경 호출이 문서를 변경하는가?
 - 변경한다면 router 또는 `EditCommand` 내부인가?
 - Undo/Redo 기대치가 있는 사용자 액션인가?
 - refresh와 dirty 상태가 일관되게 처리되는가?
 - snapshot을 사용한다면 허용 조건에 맞는가?
 
-향후 `rhwp-studio/src/command/commands`와 `rhwp-studio/src/engine/input-handler*.ts`의 mutation성
-`wasm.*` 호출을 탐지하는 정적 점검을 추가한다.
+정적 점검은 `rhwp-studio/tests/mutation-routing-guard.test.ts` 로 들어갔다(#2327). 스캔 대상은
+`src/ui`·`src/command`·`src/engine/input-handler*`·`src/hwpctl` 이다.
+
+수신자 이름으로 판정하므로 목록(`MUTATION_RECEIVERS`)은 불완전할 수밖에 없다. #3648 은 그
+불완전함이 **조용히** 넘어가서 생겼다 — hwpctl 이 `doc`·`this.wasmDoc` 을 쓰는데 원장은 `wasm`
+만 봐서 23곳이 없는 것처럼 보였고 가드는 통과했다. 그래서 미등재 수신자를 실패로 만드는 검사가
+함께 있다. 새 수신자 이름이 등장하면 세는 쪽이든 세지 않는 쪽이든 의식적으로 분류해야 통과한다.

--- a/rhwp-studio/src/hwpctl/action.ts
+++ b/rhwp-studio/src/hwpctl/action.ts
@@ -10,6 +10,22 @@ import type { HwpCtrl } from './index';
 /** Action 실행 함수 타입 */
 export type ActionExecutor = (ctrl: HwpCtrl, set: ParameterSet | null) => boolean;
 
+/**
+ * 정책상 지원하지 않는 액션의 사유 (#3648).
+ *
+ * "아직 구현하지 않았다"(`executor: null`)와 **다른 사실**이다. 전자는 언젠가 채워질 자리이고
+ * 이쪽은 채우지 않기로 판정된 자리다. 둘을 같은 `false` 로 뭉개면 호출자가 기다려야 하는지
+ * 설계를 바꿔야 하는지 알 수 없다.
+ */
+export interface ActionUnsupportedReason {
+  /** 기계가 분기할 코드. */
+  code: 'notSupportedByDesign';
+  /** 사람이 읽을 사유. */
+  message: string;
+  /** 판정 근거 — 호출자가 문서로 갈 수 있어야 한다. */
+  reference: string;
+}
+
 /** Action 정의 */
 export interface ActionDef {
   /** Action ID */
@@ -20,7 +36,23 @@ export interface ActionDef {
   description: string;
   /** 실행 함수 */
   executor: ActionExecutor | null;
+  /**
+   * 설정되면 이 액션은 **정책상 미지원**이다 (#3648).
+   *
+   * 등록 자체는 유지한다 — 등록을 지우면 호출자에게 "오타로 없는 액션을 불렀다"와
+   * "의도적으로 지원하지 않는다"가 똑같이 `미등록` 으로 보인다. 등록을 남기고 사유를 실어야
+   * 호출자가 그 둘을 구분해 문서로 갈 수 있다.
+   */
+  unsupported?: ActionUnsupportedReason;
 }
+
+/** 액션의 지원 상태 — `HwpCtrl.GetActionSupport` 의 응답 (#3648). */
+export type ActionSupport =
+  | { status: 'supported' }
+  /** 등록돼 있지만 아직 executor 가 없다 — 구현 대기. */
+  | { status: 'unimplemented' }
+  /** 등록돼 있고 정책상 지원하지 않는다. */
+  | ({ status: 'unsupported' } & ActionUnsupportedReason);
 
 export class Action {
   readonly ActID: string;
@@ -45,8 +77,26 @@ export class Action {
     // Wave별 구현에서 기본값 설정 추가
   }
 
+  /**
+   * 정책상 미지원 액션이면 사유를 알리고 `true` 를 돌려준다 (#3648).
+   *
+   * `Run`/`Execute` 의 반환형은 한컴 `HwpCtrl` 호환이라 `boolean` 고정이다. 그래서 사유는
+   * 로그로 알리고, 기계가 읽어야 하면 `HwpCtrl.GetActionSupport(id)` 로 조회한다 —
+   * iframe 안 콘솔은 통합자에게 보이지 않으므로 조회 경로가 있어야 한다.
+   */
+  private reportUnsupported(): boolean {
+    const reason = this.def.unsupported!;
+    console.warn(
+      `[hwpctl] Action "${this.def.id}" 미지원(${reason.code}): ${reason.message}`
+      + ` — 근거: ${reason.reference}`
+      + ` (기계 판독은 GetActionSupport("${this.def.id}") 사용)`,
+    );
+    return false;
+  }
+
   /** Action 실행 (ParameterSet 전달) */
   Execute(set: ParameterSet): boolean {
+    if (this.def.unsupported) return this.reportUnsupported();
     if (this.def.executor) {
       return this.def.executor(this.ctrl, set);
     }
@@ -56,6 +106,7 @@ export class Action {
 
   /** Action 단순 실행 (ParameterSet 없이) */
   Run(): boolean {
+    if (this.def.unsupported) return this.reportUnsupported();
     if (this.def.executor) {
       return this.def.executor(this.ctrl, null);
     }

--- a/rhwp-studio/src/hwpctl/actions/clipboard.ts
+++ b/rhwp-studio/src/hwpctl/actions/clipboard.ts
@@ -47,19 +47,40 @@ function executePaste(ctrl: HwpCtrl, _set: ParameterSet | null): boolean {
   }
 }
 
-function executeUndo(_ctrl: HwpCtrl, _set: ParameterSet | null): boolean {
-  console.warn('[hwpctl] Undo: 미구현 (향후 Phase 4에서 구현)');
-  return false;
-}
-
-function executeRedo(_ctrl: HwpCtrl, _set: ParameterSet | null): boolean {
-  console.warn('[hwpctl] Redo: 미구현 (향후 Phase 4에서 구현)');
-  return false;
-}
+/**
+ * Undo/Redo 는 **정책상 미지원**이다 (#3648 판정, 2026-07-31).
+ *
+ * hwpctl 은 자동화·임베드 표면이고 소비자는 스크립트다. 스크립트는 자기 트랜잭션 경계를 알기에
+ * "N 개 작업 후 되돌리기"는 호출자가 문서 사본으로 관리할 문제로 판정됐다. 히스토리 경유는
+ * 자동화 레이어를 studio 앱 레이어에 종속시켜 의존 방향을 뒤집는다.
+ *
+ * 종전에는 `console.warn('미구현 (향후 Phase 4에서 구현)')` + `false` 였다. 그 메시지는 두 번
+ * 틀렸다 — 구현 대기가 아니라 미지원이고, iframe 안 콘솔은 통합자에게 보이지 않는다.
+ */
+const UNDO_UNSUPPORTED = {
+  code: 'notSupportedByDesign',
+  message:
+    'hwpctl 은 히스토리를 경유하지 않는 자동화 표면입니다. '
+    + '되돌리기는 호출자가 문서 사본으로 관리하세요. undo/redo 는 studio UI 레이어 기능입니다.',
+  reference: 'https://github.com/edwardkim/rhwp/issues/3648',
+} as const;
 
 // Action 등록
 registerAction({ id: 'Copy', parameterSetId: null, description: '복사', executor: executeCopy });
 registerAction({ id: 'Cut', parameterSetId: null, description: '잘라내기', executor: executeCut });
 registerAction({ id: 'Paste', parameterSetId: null, description: '붙여넣기', executor: executePaste });
-registerAction({ id: 'Undo', parameterSetId: null, description: '실행취소', executor: executeUndo });
-registerAction({ id: 'Redo', parameterSetId: null, description: '다시실행', executor: executeRedo });
+// 등록은 유지한다 — 지우면 호출자에게 오타와 의도적 미지원이 똑같이 보인다 (#3648).
+registerAction({
+  id: 'Undo',
+  parameterSetId: null,
+  description: '실행취소 (hwpctl 미지원)',
+  executor: null,
+  unsupported: UNDO_UNSUPPORTED,
+});
+registerAction({
+  id: 'Redo',
+  parameterSetId: null,
+  description: '다시실행 (hwpctl 미지원)',
+  executor: null,
+  unsupported: UNDO_UNSUPPORTED,
+});

--- a/rhwp-studio/src/hwpctl/index.ts
+++ b/rhwp-studio/src/hwpctl/index.ts
@@ -5,6 +5,7 @@
  * 내부적으로 rhwp WASM API를 호출한다.
  */
 import { Action } from './action';
+import type { ActionSupport } from './action';
 import { ParameterSet } from './parameter-set';
 import { getActionDef, getRegisteredCount, getImplementedCount, getAllActions } from './action-registry';
 
@@ -19,6 +20,7 @@ import './actions/page';
 
 export { ParameterSet } from './parameter-set';
 export { Action } from './action';
+export type { ActionSupport, ActionUnsupportedReason } from './action';
 
 export type SaveCallback = () => void;
 
@@ -140,6 +142,25 @@ export class HwpCtrl {
       });
     }
     return new Action(this, def);
+  }
+
+  /**
+   * 액션의 지원 상태를 조회한다 (#3648).
+   *
+   * `Run`/`Execute` 는 한컴 `HwpCtrl` 호환이라 `boolean` 만 돌려주므로, 실패의 **종류**를
+   * 구분할 수 없다. 특히 iframe 안에서는 콘솔 경고가 통합자에게 보이지 않아 원인 판별이
+   * 불가능하다. 이 조회가 세 상태를 구분해 준다.
+   *
+   * - `null` — 등록되지 않은 id. **오타이거나 이 빌드가 모르는 액션이다.**
+   * - `{status:'unimplemented'}` — 등록돼 있고 아직 구현되지 않았다. 기다리면 채워진다.
+   * - `{status:'unsupported', ...}` — 정책상 지원하지 않는다. 사유와 근거가 함께 온다.
+   * - `{status:'supported'}` — 실행할 수 있다.
+   */
+  GetActionSupport(actionId: string): ActionSupport | null {
+    const def = getActionDef(actionId);
+    if (!def) return null;
+    if (def.unsupported) return { status: 'unsupported', ...def.unsupported };
+    return def.executor ? { status: 'supported' } : { status: 'unimplemented' };
   }
 
   /** ParameterSet 생성 */

--- a/rhwp-studio/tests/issue-3648-hwpctl-undo-policy.test.ts
+++ b/rhwp-studio/tests/issue-3648-hwpctl-undo-policy.test.ts
@@ -1,0 +1,102 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [#3648] hwpctl 은 히스토리를 경유하지 않는 자동화 표면으로 판정됐다(②안, 2026-07-31).
+//
+// 그 판정에서 "지금 상태가 가장 나쁘다"고 지목된 것은 `Undo`/`Redo` 를 등록해 두고
+// `console.warn('미구현 (향후 Phase 4에서 구현)')` + `false` 를 돌려주던 부분이다. 그 메시지는
+// 두 번 틀렸다 — 구현 대기가 아니라 정책상 미지원이고, iframe 안 콘솔은 통합자에게 보이지
+// 않아 원인 판별이 불가능한 침묵 실패가 된다.
+//
+// 여기서 고정하는 것은 **세 상태가 구분되는가** 다: 미등록(오타) / 미구현(대기) / 미지원(정책).
+//
+// `command.ts` 처럼 `src/hwpctl` 도 `node --test` strip-only 모드로 import 할 수 없어
+// (`index.ts` 가 TS parameter property 를 쓴다) 소스 가드로 확인한다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const source = (rel: string): string => readFileSync(join(rootDir, rel), 'utf8');
+
+test('[#3648] Undo/Redo 등록은 유지하되 정책상 미지원으로 표시한다', () => {
+  const clipboard = source('src/hwpctl/actions/clipboard.ts');
+
+  // 등록 제거가 아니다 — 지우면 호출자에게 오타와 의도적 미지원이 똑같이 `미등록` 으로 보인다.
+  for (const id of ['Undo', 'Redo']) {
+    assert.match(
+      clipboard,
+      new RegExp(`registerAction\\(\\{[\\s\\S]{0,200}?id: '${id}'`),
+      `${id} 등록은 유지해야 한다 — 등록을 지우면 오타와 미지원이 구분되지 않는다`,
+    );
+  }
+
+  // 사유는 코드·메시지·근거를 함께 갖는다.
+  assert.match(clipboard, /code: 'notSupportedByDesign'/, '기계가 분기할 코드');
+  assert.match(clipboard, /issues\/3648/, '판정 근거로 갈 수 있는 참조');
+  assert.match(clipboard, /unsupported: UNDO_UNSUPPORTED/, 'Undo/Redo 에 사유를 실어야 한다');
+
+  // 종전의 잘못된 서술이 **실행 경로에** 남아 있으면 안 된다.
+  //
+  // 주석에서 과거 문구를 인용하는 것은 기록이므로 막지 않는다 — 실제로 호출되는 코드에서
+  // "구현 대기" 로 보고하던 스텁이 사라졌는지만 본다.
+  assert.doesNotMatch(
+    clipboard,
+    /executeUndo|executeRedo/,
+    'console.warn 스텁 executor 는 제거됐다 — 사유는 정의(ActionDef)가 든다',
+  );
+  // 등록에 executor 가 없어야 한다 — 있으면 디스패처가 미지원 판정 대신 그 함수를 부른다.
+  for (const id of ['Undo', 'Redo']) {
+    const start = clipboard.indexOf(`id: '${id}'`);
+    const entry = clipboard.slice(start, start + clipboard.slice(start).indexOf('});'));
+    assert.match(entry, /executor: null/, `${id} 등록에 실행 스텁이 남아 있으면 안 된다`);
+    assert.match(entry, /unsupported: UNDO_UNSUPPORTED/, `${id} 등록에 사유가 있어야 한다`);
+  }
+});
+
+test('[#3648] 디스패처는 미지원을 미구현과 다르게 다룬다', () => {
+  const action = source('src/hwpctl/action.ts');
+
+  // 정의에 사유 슬롯이 있고, 그 슬롯이 executor 유무보다 먼저 판정된다.
+  assert.match(action, /unsupported\?: ActionUnsupportedReason/, 'ActionDef 에 사유 슬롯');
+  for (const method of ['Execute(set: ParameterSet): boolean {', 'Run(): boolean {']) {
+    const start = action.indexOf(method);
+    assert.notEqual(start, -1, `${method} 를 찾지 못했다`);
+    const body = action.slice(start, start + action.slice(start).indexOf('\n  }'));
+    const idxUnsupported = body.indexOf('this.def.unsupported');
+    const idxExecutor = body.indexOf('this.def.executor');
+    assert.ok(
+      idxUnsupported !== -1 && idxUnsupported < idxExecutor,
+      `${method}: 미지원 판정이 executor 분기보다 먼저여야 한다 — 뒤에 두면 executor 가 없는 `
+        + `미지원 액션이 "미구현" 으로 보고된다`,
+    );
+  }
+
+  // 사유 로그는 코드·메시지·근거·조회 경로를 함께 알린다.
+  const report = action.slice(action.indexOf('private reportUnsupported'));
+  assert.match(report, /reason\.code/, '코드');
+  assert.match(report, /reason\.message/, '사유');
+  assert.match(report, /reason\.reference/, '근거');
+  assert.match(report, /GetActionSupport/, '기계 판독 경로를 로그에서 안내해야 한다');
+});
+
+test('[#3648] GetActionSupport 는 미등록·미구현·미지원·지원을 구분한다', () => {
+  const index = source('src/hwpctl/index.ts');
+  const start = index.indexOf('GetActionSupport(actionId: string)');
+  assert.notEqual(start, -1, 'GetActionSupport 가 있어야 한다');
+  const body = index.slice(start, start + index.slice(start).indexOf('\n  }'));
+
+  // 미등록은 `null` — 오타를 미지원과 섞으면 판정 API 의 의미가 사라진다.
+  assert.match(body, /if \(!def\) return null;/, '미등록은 null');
+  assert.match(body, /status: 'unsupported'/, '정책 미지원 상태');
+  assert.match(body, /status: 'unimplemented'/, '구현 대기 상태');
+  assert.match(body, /status: 'supported'/, '지원 상태');
+
+  // 미지원 판정이 executor 유무보다 먼저 — 순서가 뒤바뀌면 미지원이 미구현으로 보인다.
+  const idxUnsupported = body.indexOf("status: 'unsupported'");
+  const idxExecutor = body.indexOf('def.executor');
+  assert.ok(
+    idxUnsupported < idxExecutor,
+    '미지원을 executor 분기보다 먼저 판정해야 한다',
+  );
+});

--- a/rhwp-studio/tests/mutation-routing-guard.test.ts
+++ b/rhwp-studio/tests/mutation-routing-guard.test.ts
@@ -100,9 +100,13 @@ test('MUTATING_METHODS 는 모두 실제 브리지 공개 메서드여야 한다
 // ── (2) 원장 트립와이어: 뮤테이션 표면 동결 ─────────────────────────────────
 
 /**
- * 뮤테이션 표면 스캔 대상: ui/ + command/ + engine/input-handler*.ts.
+ * 뮤테이션 표면 스캔 대상: ui/ + command/ + engine/input-handler*.ts + hwpctl/.
  * input-handler* 는 드래그/키보드 nudge 등 최고밀도 직접-뮤테이션 영역이므로
  * 반드시 포함한다(누락 시 엔진 층의 신규 미라우팅이 원장에 안 걸림).
+ *
+ * [#3648] `src/hwpctl` 을 추가했다. 자동화 표면은 정책상 히스토리를 경유하지 않지만
+ * (아래 원장 주석), 스캔에서 빼 두면 **그 정책이 지켜지는지도 볼 수 없다** — 미라우팅이
+ * 늘어나는 것을 아무도 모른다. 정책은 "라우팅하지 않는다"이고 원장의 일은 "현상 동결"이다.
  */
 function scanFiles(): string[] {
   const out: string[] = [];
@@ -115,6 +119,7 @@ function scanFiles(): string[] {
   };
   walk('src/ui');
   walk('src/command');
+  walk('src/hwpctl');
   for (const ent of readdirSync(join(rootDir, 'src/engine'), { withFileTypes: true })) {
     if (ent.isFile() && ent.name.startsWith('input-handler') && ent.name.endsWith('.ts')
       && !ent.name.endsWith('.test.ts')) {
@@ -124,9 +129,49 @@ function scanFiles(): string[] {
   return out.sort();
 }
 
+/**
+ * 문서를 직접 변형하는 수신자 이름 (#3648).
+ *
+ * 종전에는 `wasm` 하나에 앵커돼 있어 hwpctl 의 23곳이 통째로 빠졌다 — hwpctl 은
+ * `ctrl.getWasmDoc()` 이 준 raw doc 을 `doc`·`this.wasmDoc` 으로 받아 쓴다.
+ *
+ * 타입이 아니라 이름으로 판정하는 한 이 목록은 불완전할 수밖에 없다. 그래서 목록을 없애는
+ * 대신 **빠뜨렸을 때 조용히 넘어가지 않게** 했다 — 아래
+ * `모든 뮤테이터 호출의 수신자는 분류돼 있어야 한다` 가 미등재 수신자를 실패로 만든다.
+ * #3648 을 만든 실패 양상(새 수신자가 원장에서 사라짐)이 다시 나면 그 테스트가 잡는다.
+ */
+const MUTATION_RECEIVERS = ['wasm', 'wasmDoc', 'doc'] as const;
+
+/**
+ * 뮤테이터와 이름이 같지만 문서를 변형하지 않는 호출의 수신자.
+ *
+ * `this`/`ih` 는 `InputHandler` 자기 위임이다 — 실제 뮤테이션은 그 메서드 안의 `wasm.` 호출
+ * 지점에서 이미 세므로, 위임까지 세면 한 변경을 두 번 센다.
+ */
+const NON_MUTATION_RECEIVERS: Readonly<Record<string, string>> = {
+  this: 'InputHandler 자기 위임 (applyCharFormat/applyParaFormat/applyStyle) — 내부 wasm. 호출을 이미 센다',
+  ih: 'InputHandler 위임 — 위와 같다',
+};
+
+/**
+ * 표준 JS 메서드와 이름이 겹치는 뮤테이터.
+ *
+ * `replaceAll` 은 브리지의 찾아 바꾸기이면서 `String.prototype.replaceAll` 이기도 하다.
+ * 문자열 지역변수 이름은 자유롭게 늘어나므로 수신자로 걸러내면 원장이 이름 하나 늘 때마다
+ * 흔들린다. 이름 층위에서 한 번 선언해 두면 어떤 변수명이든 영향이 없다.
+ */
+const BUILTIN_NAME_COLLISIONS = new Set(['replaceAll']);
+
+/** `수신자.메서드(` 를 훑는다. 수신자는 점 앞의 마지막 식별자(`this.wasmDoc` → `wasmDoc`). */
+function mutatorCalls(src: string): { receiver: string; method: string }[] {
+  const re = new RegExp(`([A-Za-z0-9_$]+)\\s*\\.\\s*(${MUTATING.join('|')})\\s*\\(`, 'g');
+  return [...src.matchAll(re)].map((m) => ({ receiver: m[1], method: m[2] }));
+}
+
 function mutatorCallCount(src: string): number {
-  const re = new RegExp(`\\bwasm\\s*\\.\\s*(${MUTATING.join('|')})\\s*\\(`, 'g');
-  return [...src.matchAll(re)].length;
+  return mutatorCalls(src).filter(
+    ({ receiver }) => (MUTATION_RECEIVERS as readonly string[]).includes(receiver),
+  ).length;
 }
 
 // 뮤테이션 표면 원장 (2026-07-17 동결). 이관/추가 시 이 표를 의식적으로 갱신한다.
@@ -163,7 +208,26 @@ const BASELINE: Readonly<Record<string, number>> = {
   'src/engine/input-handler-picture.ts': 11,
   'src/engine/input-handler-table.ts': 7,
   'src/engine/input-handler-text.ts': 11, // #2424: raw IME delete를 command 공통 typed helper로 이관
+  // ── hwpctl — 의도적 미라우팅 (#3648 정책 판정, 2026-07-31) ──
+  //
+  // hwpctl 은 자동화·임베드 표면이고 소비자는 스크립트다. 스크립트는 자기 트랜잭션 경계를
+  // 알기에 "N 개 작업 후 되돌리기"는 호출자가 문서 사본으로 관리할 문제로 판정됐다. 히스토리
+  // 경유(①안)는 자동화 레이어를 앱 레이어에 종속시켜 의존 방향을 뒤집으므로 채택하지 않았다.
+  //
+  // 따라서 아래 23곳은 **줄여야 할 부채가 아니라 동결된 현상**이다. 다른 키처럼 "이관하면
+  // 값을 낮춘다"가 아니라, 값이 **늘어나는 것만** 리뷰 대상이다 — 자동화 표면에 문서 변경이
+  // 새로 붙었다는 뜻이므로 정책 재확인이 필요하다.
+  'src/hwpctl/actions/clipboard.ts': 2,
+  'src/hwpctl/actions/format.ts': 3,
+  'src/hwpctl/actions/page.ts': 2,
+  'src/hwpctl/actions/table-edit.ts': 6,
+  'src/hwpctl/actions/table.ts': 1,
+  'src/hwpctl/actions/text.ts': 4,
+  'src/hwpctl/index.ts': 5,
 };
+
+/** 원장에서 "동결된 현상"으로 다루는 접두어 — 이관 권고(↓) 대상에서 뺀다. */
+const FROZEN_BY_POLICY = ['src/hwpctl/'];
 
 test('뮤테이션 표면 원장: 신규·증가 사이트는 baseline 갱신을 강제한다', () => {
   const current: Record<string, number> = {};
@@ -184,6 +248,8 @@ test('뮤테이션 표면 원장: 신규·증가 사이트는 baseline 갱신을
   // 이관으로 값이 줄면 baseline 을 낮추라고 안내(실패는 아님 — 진행을 막지 않음).
   const stale: string[] = [];
   for (const [rel, base] of Object.entries(BASELINE)) {
+    // 정책상 동결된 표면은 이관 대상이 아니므로 "이관 권고"를 내지 않는다 (#3648).
+    if (FROZEN_BY_POLICY.some((prefix) => rel.startsWith(prefix))) continue;
     const n = current[rel] ?? 0;
     if (n < base) stale.push(`  ↓ ${rel}: ${base} → ${n} (이관 완료 — baseline 을 ${n}${n === 0 ? ' 로 낮추거나 키 제거' : ''} 로 갱신 권장)`);
   }
@@ -200,4 +266,75 @@ test('뮤테이션 표면 원장: 신규·증가 사이트는 baseline 갱신을
     // 진행 상황 가시화 — 실패시키지 않고 로그만.
     console.log(`[mutation-routing] 이관 진행:\n${stale.join('\n')}`);
   }
+});
+
+// [#3648] 이름으로 수신자를 판정하는 한 `MUTATION_RECEIVERS` 는 불완전할 수밖에 없다.
+// #3648 은 그 불완전함이 **조용히** 넘어갔기 때문에 생겼다 — hwpctl 이 `doc`·`this.wasmDoc`
+// 을 쓰는데 원장은 `wasm` 만 봐서, 23곳이 없는 것처럼 보였고 가드는 5/5 통과했다.
+//
+// 그래서 목록을 없애는 대신 **빠뜨리면 실패하게** 만든다. 새 수신자 이름이 등장하면 세는
+// 쪽(`MUTATION_RECEIVERS`)이든 세지 않는 쪽(`NON_MUTATION_RECEIVERS`)이든 **의식적으로**
+// 분류해야 통과한다.
+test('모든 뮤테이터 호출의 수신자는 분류돼 있어야 한다(미등재 수신자 침묵 차단)', () => {
+  const unclassified = new Map<string, { files: Set<string>; methods: Set<string> }>();
+
+  for (const rel of scanFiles()) {
+    for (const { receiver, method } of mutatorCalls(source(rel))) {
+      // 표준 JS 와 이름이 겹치는 호출은 브리지 수신자일 때만 뮤테이션이다.
+      if (BUILTIN_NAME_COLLISIONS.has(method)
+        && !(MUTATION_RECEIVERS as readonly string[]).includes(receiver)) {
+        continue;
+      }
+      if ((MUTATION_RECEIVERS as readonly string[]).includes(receiver)) continue;
+      if (receiver in NON_MUTATION_RECEIVERS) continue;
+
+      if (!unclassified.has(receiver)) {
+        unclassified.set(receiver, { files: new Set(), methods: new Set() });
+      }
+      const entry = unclassified.get(receiver)!;
+      entry.files.add(rel);
+      entry.methods.add(method);
+    }
+  }
+
+  const violations = [...unclassified.entries()].map(([receiver, e]) =>
+    `  ${receiver}.{${[...e.methods].sort().join(',')}} — ${[...e.files].sort().join(', ')}`,
+  );
+
+  assert.deepEqual(
+    violations,
+    [],
+    '분류되지 않은 뮤테이터 수신자가 있습니다:\n' + violations.join('\n') + '\n\n'
+      + '문서를 직접 변형하면 MUTATION_RECEIVERS 에 추가하고 BASELINE 을 갱신하세요.\n'
+      + '변형하지 않으면(위임·동명이인) NON_MUTATION_RECEIVERS 에 사유와 함께 등재하세요.\n'
+      + '이 검사가 없으면 새 수신자의 뮤테이션이 원장에서 조용히 빠집니다(#3648).',
+  );
+});
+
+// hwpctl 이 스캔 대상에 실제로 들어왔는지 — #3648 의 "이중 미스" 두 겹을 각각 못박는다.
+// 한 겹만 고치면 원장에 올라오지 않으므로, 둘을 따로 확인해야 회귀를 잡는다.
+test('[#3648] hwpctl 은 스캔 대상이고 raw doc 수신자도 계상된다', () => {
+  const scanned = scanFiles();
+  assert.ok(
+    scanned.some((rel) => rel.startsWith('src/hwpctl/')),
+    '스캔 디렉터리에 src/hwpctl 이 없으면 정책 준수 여부를 볼 수 없다',
+  );
+
+  // 겹 ②: 수신자 제약. `doc`·`wasmDoc` 을 세지 않으면 스캔해도 0 으로 보인다.
+  for (const receiver of ['doc', 'wasmDoc']) {
+    assert.ok(
+      (MUTATION_RECEIVERS as readonly string[]).includes(receiver),
+      `${receiver} 수신자를 세지 않으면 hwpctl 의 raw doc 호출이 원장에서 빠진다`,
+    );
+  }
+
+  const total = scanned
+    .filter((rel) => rel.startsWith('src/hwpctl/'))
+    .reduce((sum, rel) => sum + mutatorCallCount(source(rel)), 0);
+  assert.equal(
+    total,
+    23,
+    'hwpctl 직접 뮤테이션은 #3648 정책으로 23곳에 동결됐다 — 늘었다면 자동화 표면에 '
+      + '문서 변경이 새로 붙었다는 뜻이므로 정책을 재확인해야 한다',
+  );
 });


### PR DESCRIPTION
#3648 판정(**②안 — 의도적 비-undo 로 명문화**, 2026-07-31)의 후속 (a)(b)(c) 를 한 PR 로 묶었습니다. 판정 코멘트에서 요청받은 두 가지 제안(응답 스키마, 문서 위치)도 아래에 근거와 함께 적었습니다.

## (a) 가드 등재 + 현상 동결

`scanFiles()` 에 `src/hwpctl` 을 넣고 수신자 제약을 완화했습니다. **둘 다 고쳐야 원장에 올라온다**는 점을 회귀 테스트가 두 겹으로 따로 못박습니다 — 한 겹만 고치면 스캔해도 0 으로 보입니다.

### 수신자 완화 방식은 데이터로 정했습니다

"모든 수신자"로 열면 66건이 늘지만 **43건이 오탐**입니다.

| 수신자 | 건수 | 정체 |
|---|---|---|
| `wasm` | 193 | 브리지 — 기존 계상 |
| `doc` | 18 | hwpctl raw doc — **계상해야 함** |
| `wasmDoc` | 5 | hwpctl raw doc — **계상해야 함** |
| `this` / `ih` | 21 | InputHandler 자기 위임 — 내부 `wasm.` 호출을 이미 셉니다 |
| `value` / `text` | 11 | `String.prototype.replaceAll` — 브리지 찾아바꾸기와 동명이인 |

전 저장소에 수신자가 7종뿐이고 `doc`(18) + `wasmDoc`(5) = **정확히 23** 입니다.

그래서 `MUTATION_RECEIVERS = [wasm, wasmDoc, doc]` 로 세고, `replaceAll` 충돌은 **이름 층위에서 한 번** 선언했습니다 — 수신자로 걸러내면 문자열 지역변수 이름이 하나 늘 때마다 원장이 흔들립니다.

### 목록의 불완전함을 침묵에서 실패로 바꿨습니다

이름으로 판정하는 한 이 목록은 불완전할 수밖에 없습니다. 그런데 **#3648 은 그 불완전함이 조용히 넘어가서 생긴 결함**입니다 — hwpctl 이 `doc`·`this.wasmDoc` 을 쓰는데 원장은 `wasm` 만 봐서 23곳이 없는 것처럼 보였고, 가드는 5/5 통과했습니다.

목록을 없앨 수는 없으니 **빠뜨렸을 때 실패하게** 했습니다. 미등재 수신자가 나오면 세는 쪽(`MUTATION_RECEIVERS`)이든 세지 않는 쪽(`NON_MUTATION_RECEIVERS`, 사유 필수)이든 의식적으로 분류해야 통과합니다. 같은 실패 양상이 다시 나면 이 검사가 잡습니다.

`BASELINE` 에 `src/hwpctl/**` 7키(계 23)를 정책 사유 주석과 함께 동결했습니다. 정책상 동결된 표면은 이관 권고(`↓`) 대상에서 제외합니다 — 줄여야 할 부채가 아니라 동결된 현상이므로, 다른 키와 같은 안내를 내면 의미가 반대로 전달됩니다.

## (b) 명시적 미지원 응답 — 등록 유지

세 상태가 모두 `false` + `console.warn` 으로 뭉개져 있었습니다. **미등록(오타)·미구현(대기)·미지원(정책)은 서로 다른 사실**입니다.

### 제안한 스키마

디스패처가 이미 "executor 없음 = 미구현"을 갖고 있으므로, 새 병렬 기제를 만들지 않고 그 옆에 세 번째 상태를 뒀습니다. 사유는 실행 함수가 아니라 **정의**가 듭니다.

```ts
export interface ActionUnsupportedReason {
  code: 'notSupportedByDesign';   // 기계가 분기할 코드
  message: string;                // 사람이 읽을 사유
  reference: string;              // 판정 근거 — 호출자가 문서로 갈 수 있어야 한다
}

export interface ActionDef {
  // ...
  unsupported?: ActionUnsupportedReason;   // 설정되면 정책상 미지원
}
```

`Execute`/`Run` 은 **executor 분기보다 먼저** 미지원을 판정합니다. 순서가 뒤바뀌면 executor 가 없는 미지원 액션이 "미구현"으로 보고되므로, 그 순서를 테스트로 고정했습니다.

### 사유를 기계가 읽을 경로

`Run`/`Execute` 의 반환형은 한컴 `HwpCtrl` 호환이라 `boolean` 고정입니다. 그리고 지적하신 대로 iframe 안 콘솔 경고는 통합자에게 보이지 않습니다. 그래서 조회 API 를 뒀습니다.

```ts
HwpCtrl.GetActionSupport(actionId): ActionSupport | null
```

| 반환 | 뜻 |
|---|---|
| `null` | **미등록 — 오타이거나 이 빌드가 모르는 액션** |
| `{status:'unimplemented'}` | 등록돼 있고 구현 대기 — 기다리면 채워집니다 |
| `{status:'unsupported', code, message, reference}` | 정책상 미지원 — 사유와 근거가 함께 옵니다 |
| `{status:'supported'}` | 실행 가능 |

미등록을 `null` 로 분리한 것이 요점입니다 — "오타로 없는 액션을 부른 것"과 "의도적 미지원"이 구분되지 않는다는 지적을 이 지점에서 해소합니다.

`Undo`/`Redo` 는 **등록을 유지**하고 `console.warn('미구현 (향후 Phase 4에서 구현)')` 스텁을 제거했습니다. 그 메시지는 두 번 틀렸습니다 — 구현 대기가 아니라 미지원이고, 콘솔은 안 보입니다.

## (c) 층위 계약 문서화 — 제안 위치

`mydocs/tech/edit_action_undo_redo_architecture.md` 에 넣었습니다.

`mydocs/manual/` 이 아니라 여기를 고른 이유는, **이 문서의 원칙 1이 결함의 원인을 담고 있기 때문**입니다. "문서 mutation 은 라우터를 통과한다"가 층위 없이 무조건 서술돼 있어 전 층위에 적용되는 것처럼 읽혔고, 그래서 정책상 비경유인 표면이 결함으로 오인됐습니다. 계약을 다른 문서에 적으면 원칙 1은 그대로 남아 같은 오인을 계속 만듭니다.

추가한 것:

- **층위 표** — core / `@rhwp/editor` / hwpctl / studio 편집 UI 의 히스토리 경유 여부와 근거. npm 배포 표면에 히스토리 API·`HwpCtrl` 노출이 0건인 것도 적었습니다
- **"undo/redo 는 엔진이 보장하는 성질이 아니라 studio UI 레이어 기능"** 을 명시
- hwpctl 절 — 23곳이 동결된 현상인 이유, 등록을 유지하는 이유, 사유 조회 경로
- 원칙 1에 적용 층위 명시 + 예외 목록에 hwpctl 추가
- 감사 규칙 첫 질문에 "어느 층위인가" 추가, 그리고 "향후 정적 점검을 추가한다"를 실제 위치(#2327 가드)와 수신자 목록의 불완전함 대책으로 갱신

## 관련

#3648 — 판정에서 착수 요청받은 (a)(b)(c) 전부입니다.
①(히스토리 경유)·③(혼합)은 임베드에서 studio UI 와 문서를 공유하는 실사용례가 생길 때 재검토로 문서에 남겼습니다.

## 테스트

- [x] rhwp-studio `npm test` — **701/701**, `npx tsc --noEmit` 통과
- [x] `cargo test --profile release-test --tests` — **4463 passed / 0 failed**
- [x] `cargo fmt --check` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음(studio 자동화 표면 + 문서)
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음(렌더 경로 미변경)

### 네 항목 모두 변이로 확인했습니다

통과하는 테스트가 아니라 결함을 잡는 테스트인지 각각 되돌려 봤습니다.

| 변이 | 결과 |
|---|---|
| `scanFiles()` 에서 `walk('src/hwpctl')` 제거 | `[#3648] hwpctl 은 스캔 대상이고…` 실패 |
| `MUTATION_RECEIVERS` 를 `['wasm']` 로 축소 | 수신자 분류 트립와이어 + hwpctl 계상 테스트 둘 다 실패 |
| `Run()` 에서 미지원 판정을 executor 뒤로 이동 | `디스패처는 미지원을 미구현과 다르게 다룬다` 실패 |

`src/hwpctl` 은 `index.ts` 가 TS parameter property 를 써서 `node --test` strip-only 모드로 import 되지 않습니다(`command.ts` 와 같은 제약). 그래서 (b) 는 행위 테스트가 아니라 소스 가드이고, 판정 **순서**까지 고정해 "통과하지만 못 잡는" 형태를 피했습니다.
