### PR TITLE
perf: #3315 재시도 상태 blanket 리셋 제거 — 편집당 중복 재렌더 제거

### DIFF
--- a/rhwp-studio/src/view/page-renderer.ts
+++ b/rhwp-studio/src/view/page-renderer.ts
@@ -927,11 +927,12 @@ export class PageRenderer {
       this.imageRetryCounts.delete(pageIdx);
       return;
     }
-    const retryKey = `${imageCount}:${rawSvgCount}:${policy.retrySignature}`;
-    if (this.imageRetryCounts.get(pageIdx) === retryKey) return;
+    const retryKey = this.buildImageRetryKey(pageIdx, imageCount, rawSvgCount, policy);
+    if (retryKey !== null && this.imageRetryCounts.get(pageIdx) === retryKey) return;
 
     this.cancelReRender(pageIdx);
-    this.imageRetryCounts.set(pageIdx, retryKey);
+    if (retryKey === null) this.imageRetryCounts.delete(pageIdx);
+    else this.imageRetryCounts.set(pageIdx, retryKey);
     const prefetchRequestToken = ++this.nextPrefetchRequestToken;
     this.prefetchRequestTokens.set(pageIdx, prefetchRequestToken);
 
@@ -973,6 +974,48 @@ export class PageRenderer {
         })
         .catch(() => {});
     });
+  }
+
+  /**
+   * 재시도 상태를 재사용할지 판정하는 키 (Task #3315).
+   *
+   * 종전 키는 `imageCount:rawSvgCount:overlaySignature` 였다. 그 재료는 **그림 내용을 보지
+   * 못한다** — 밝기/대비를 켜면 워터마크 bake 경로로 바이트가 바뀌는데 개수는 그대로라 키가
+   * 불변이고, 그걸 "변화 없음"으로 읽으면 첫 draw 에서 디코드가 안 끝난 그림이 빈 채로 남는다.
+   *
+   * 그 위험을 막으려고 `refreshPages` 가 매 편집에 `resetImageRetryState()` 로 전부 비웠는데,
+   * 그러면 **페이지마다 재렌더가 한 번 더 돈다** — prefetch 가 서명으로 건너뛰어 `finish()` 가
+   * 즉시 불리고 `reRenderPageCanvases` 가 다시 그린다.
+   *
+   * 비우는 대신 키가 봐야 할 것을 직접 들게 한다.
+   *
+   * - `getPageSourceImageKeys` — `bin:{epoch}:{id}:{variant}` 목록. 밝기/대비로 bake 여부가
+   *   바뀌면 variant 가 `src` ↔ `wmpng` 로 갈리므로 **내용 변화가 키에 나타난다.**
+   * - 문서 신원(digest·generation) — 키의 세대는 문서마다 0 에서 시작해 서로 충돌한다
+   *   (`bin:0:1:src`). 문서 경계를 키가 들지 않으면 새 문서가 옛 재시도 상태를 재사용한다.
+   *   `prefetchedImageSignatures`·`FlowImageUrlCache` 와 같은 이유·같은 방식이다.
+   *
+   * 판정 재료가 없으면(`null`) **재사용하지 않는다** — 구형 WASM, 키를 낼 수 없는 합성 그림이
+   * 섞인 페이지(`cacheable:false`), 문서 신원 미상. 안전망을 없애는 쪽이 아니라 이미 끝난 일을
+   * 되풀이하지 않는 쪽으로만 작동해야 한다.
+   */
+  private buildImageRetryKey(
+    pageIdx: number,
+    imageCount: number,
+    rawSvgCount: number,
+    policy: ReRenderPolicy,
+  ): string | null {
+    const imageKeys = cacheableImageKeySignature(this.wasm.getPageSourceImageKeys(pageIdx));
+    const documentDigest = this.wasm.documentDigest;
+    if (imageKeys === null || documentDigest === null) return null;
+    return [
+      documentDigest,
+      this.wasm.documentGeneration,
+      imageKeys,
+      imageCount,
+      rawSvgCount,
+      policy.retrySignature,
+    ].join('|');
   }
 
   private reRenderPageCanvases(
@@ -1167,8 +1210,17 @@ export class PageRenderer {
     this.prefetchRequestTokens.clear();
   }
 
+  /**
+   * 렌더된 페이지를 통째로 버릴 때 파생 상태를 정리한다.
+   *
+   * [#3315] `imageRetryCounts` 는 **여기서 비우지 않는다.** 이 메서드는 편집마다
+   * (`refreshPages` → `releaseAllRenderedPages`) 불리므로, 비우면 페이지마다 재렌더가 한 번 더
+   * 돈다 — prefetch 가 서명으로 건너뛰어 `finish()` 가 즉시 불리고 다시 그린다.
+   *
+   * 문서 경계와 그림 내용 변화는 재시도 키가 직접 든다(`buildImageRetryKey`). 그래서 바깥에서
+   * 비워 줄 시점을 맞출 필요가 없다 — 맞춰야 하는 계약이 #3648·P1 에서 깨진 그 계약이다.
+   */
   resetImageRetryState(): void {
-    this.imageRetryCounts.clear();
     this.prefetchRequestTokens.clear();
     this.layerSummaryCache.clear();
     this.canvaskitDiagnosticsByPage.clear();
@@ -1176,6 +1228,7 @@ export class PageRenderer {
 
   dispose(): void {
     this.cancelAll();
+    this.imageRetryCounts.clear();
     this.prefetchedImageSignatures.clear();
     this.prefetchRequestTokens.clear();
     this.layerSummaryCache.clear();

--- a/rhwp-studio/tests/issue-3315-image-retry-narrowing.test.ts
+++ b/rhwp-studio/tests/issue-3315-image-retry-narrowing.test.ts
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [#3315] `resetImageRetryState()` 의 blanket 리셋 제거.
+//
+// 종전 재시도 키는 `imageCount:rawSvgCount:overlaySignature` 였고, 그 재료는 그림 **내용**
+// 변화를 보지 못한다 — 밝기/대비를 켜면 워터마크 bake 로 바이트가 바뀌는데 개수는 그대로다.
+// 그 위험을 막으려고 `refreshPages` 가 매 편집에 재시도 상태를 전부 비웠는데, 그러면 페이지마다
+// 재렌더가 한 번 더 돈다(prefetch 가 서명으로 건너뛰어 `finish()` 즉시 호출 → 다시 그림).
+//
+// 비우는 대신 키가 봐야 할 것을 직접 들게 했다. 여기서 고정하는 것은 그 구조다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const source = (rel: string): string => readFileSync(join(rootDir, rel), 'utf8');
+
+const methodBody = (src: string, signature: string): string => {
+  const start = src.indexOf(signature);
+  assert.notEqual(start, -1, `${signature} 를 찾지 못했다`);
+  const rest = src.slice(start);
+  return rest.slice(0, rest.indexOf('\n  }'));
+};
+
+test('[#3315] resetImageRetryState 는 재시도 키를 비우지 않는다', () => {
+  const renderer = source('src/view/page-renderer.ts');
+  const body = methodBody(renderer, 'resetImageRetryState(): void {');
+
+  assert.doesNotMatch(
+    body,
+    /imageRetryCounts/,
+    '이 메서드는 편집마다 불린다(refreshPages → releaseAllRenderedPages). 여기서 재시도 키를 '
+      + '비우면 페이지마다 재렌더가 한 번 더 돈다',
+  );
+  // 파생 상태 정리는 그대로 남는다 — 캔버스를 버렸으므로 이들은 무효다.
+  for (const field of ['prefetchRequestTokens', 'layerSummaryCache', 'canvaskitDiagnosticsByPage']) {
+    assert.match(body, new RegExp(`${field}\\.clear\\(\\)`), `${field} 정리는 유지해야 한다`);
+  }
+});
+
+test('[#3315] 재시도 키는 문서 신원과 그림 내용을 직접 든다', () => {
+  const renderer = source('src/view/page-renderer.ts');
+  const body = methodBody(renderer, 'private buildImageRetryKey(');
+
+  // 그림 내용 — variant(`src`↔`wmpng`)가 갈리면 키가 달라진다.
+  assert.match(body, /getPageSourceImageKeys\(pageIdx\)/);
+  assert.match(body, /cacheableImageKeySignature/, '합성 그림이 섞인 페이지는 판정 대상이 아니다');
+
+  // 문서 경계 — 세대는 문서마다 0 에서 시작해 `bin:0:1:src` 가 충돌한다.
+  assert.match(body, /documentDigest/);
+  assert.match(body, /documentGeneration/);
+
+  // 판정 재료가 없으면 재사용을 포기한다(안전망 쪽으로 기운다).
+  assert.match(body, /return null;/);
+});
+
+test('[#3315] 판정 재료가 없으면 재사용 조기 반환이 일어나지 않는다', () => {
+  const renderer = source('src/view/page-renderer.ts');
+
+  // `null` 키로 `Map.get(pageIdx) === null` 비교가 우연히 맞는 일이 없도록 명시적으로 가른다.
+  assert.match(
+    renderer,
+    /if \(retryKey !== null && this\.imageRetryCounts\.get\(pageIdx\) === retryKey\) return;/,
+    'null 키에서는 조기 반환하지 않아야 한다 — 판정할 수 없으면 안전망을 돌려야 한다',
+  );
+  // 그리고 null 키는 기록하지 않는다 — 기록하면 다음 렌더가 그 값과 비교해 버린다.
+  assert.match(
+    renderer,
+    /if \(retryKey === null\) this\.imageRetryCounts\.delete\(pageIdx\);/,
+    'null 키는 저장하지 않고 항목을 지워야 한다',
+  );
+});
+
+test('[#3315] dispose 는 재시도 키를 거둔다', () => {
+  const renderer = source('src/view/page-renderer.ts');
+  const body = methodBody(renderer, '  dispose(): void {');
+  assert.match(
+    body,
+    /this\.imageRetryCounts\.clear\(\)/,
+    'renderer 를 버리면 다시 조회될 일이 없으므로 여기서 정리한다',
+  );
+});
+
+test('[#3315] 문서 교체 경로는 여전히 파생 상태를 정리한다', () => {
+  const view = source('src/view/canvas-view.ts');
+  const body = methodBody(view, 'private reset(): void {');
+  assert.match(
+    body,
+    /this\.releaseAllRenderedPages\(\)/,
+    '문서 교체는 렌더된 페이지를 버려야 한다 — 재시도 키의 문서 신원이 그 경계를 가른다',
+  );
+});

--- a/rhwp-studio/tests/render-backend.test.ts
+++ b/rhwp-studio/tests/render-backend.test.ts
@@ -514,7 +514,23 @@ test('PageRenderer deferred image rerender preserves static layer reuse policy',
   assert.match(source, /retrySignature: overlays\.signature/);
   assert.match(source, /reuseStaticFlow/);
   assert.match(source, /reuseStaticOverlay/);
-  assert.match(source, /const retryKey = `\$\{imageCount\}:\$\{rawSvgCount\}:\$\{policy\.retrySignature\}`/);
+  // [#3315] 재시도 키는 개수·overlay 서명만으로는 그림 **내용** 변화를 못 본다. 문서 신원과
+  // 그림 신원 키를 함께 들어야 blanket 리셋 없이 재사용 판정이 성립한다.
+  assert.match(source, /const retryKey = this\.buildImageRetryKey\(/);
+  const keyBuilder = source.slice(source.indexOf('private buildImageRetryKey('));
+  const keyBody = keyBuilder.slice(0, keyBuilder.indexOf('\n  }'));
+  assert.match(keyBody, /getPageSourceImageKeys\(pageIdx\)/, '그림 신원 키를 재료로 쓴다');
+  assert.match(keyBody, /documentDigest/, '문서 digest 를 재료로 쓴다');
+  assert.match(keyBody, /documentGeneration/, '문서 generation 을 재료로 쓴다');
+  assert.match(keyBody, /policy\.retrySignature/, 'overlay 서명도 유지한다');
+  // 판정 재료가 없으면 재사용하지 않는다 — 안전망을 없애는 쪽으로 작동해서는 안 된다.
+  assert.match(
+    keyBody,
+    /if \(imageKeys === null \|\| documentDigest === null\) return null;/,
+    '판정 재료가 없으면 null 로 재사용을 포기해야 한다',
+  );
+  assert.match(source, /retryKey !== null && this\.imageRetryCounts\.get\(pageIdx\) === retryKey/,
+    'null 키로는 재사용 조기 반환이 일어나면 안 된다');
   assert.match(source, /IMAGE_RE_RENDER_FALLBACK_DELAY_MS = 1500/);
   assert.match(source, /RAW_SVG_EARLY_RE_RENDER_DELAYS_MS = \[0, 32, 96, 240\]/);
   assert.match(source, /const job: ReRenderJob/);


### PR DESCRIPTION
## 변경 요약

`refreshPages` 가 **매 편집**에 `resetImageRetryState()` 로 재시도 키를 전부 비웠습니다. 그러면 `scheduleReRender` 가 매번 재무장하고, prefetch 가 서명으로 즉시 건너뛰어 `finish()` 를 호출하고 `reRenderPageCanvases` 가 한 번 더 돕니다 — **그림이 있는 페이지마다 편집당 재렌더 2회**입니다.

```
편집 → refreshPages → releaseAllRenderedPages → resetImageRetryState()
     → renderPage (1회차)
     → scheduleReRender (키가 비었으니 재무장)
     → queueMicrotask → prefetchLayerImages → 서명 일치로 skip → true
     → finish() → reRenderPageCanvases (2회차)   ← 이게 매 키 입력마다
```

착수 전에 이 항목의 전제가 아직 유효한지 확인했습니다. 로드맵이 지목한 "전체 JSON 왕복"은 이미 사라져 있었습니다 — `prefetchedImageSignatures` 는 리셋 대상이 아니라 2회차부터 서명으로 건너뛰고(#3455), `layerSummaryCache.clear()` 는 이 경로에서 무료입니다(캐시는 `reason === 'text-edit' && allowStaticOverlayReuse` 일 때만 읽는데 `renderPage` → `renderCanvas` 는 `renderContext = {}` 로 부릅니다). 남아 있던 것이 위의 중복 재렌더입니다.

## 비우던 이유를 없앴습니다

종전 재시도 키는 `imageCount:rawSvgCount:overlaySignature` 였고, 그 재료는 그림 **내용** 변화를 보지 못합니다. 밝기/대비를 켜면 워터마크 bake 경로로 바이트가 바뀌는데 개수는 그대로라 키가 불변이고, 그걸 "변화 없음"으로 읽으면 첫 draw 에서 디코드가 안 끝난 그림이 빈 채로 남습니다. 그 위험을 막는 대가로 전부 비우고 있었습니다.

비우는 대신 **키가 봐야 할 것을 직접 들게** 했습니다(`buildImageRetryKey`).

| 재료 | 이유 |
|---|---|
| `getPageSourceImageKeys` | `bin:{epoch}:{id}:{variant}` 목록. 밝기/대비로 bake 여부가 바뀌면 variant 가 `src` ↔ `wmpng` 로 갈리므로 **내용 변화가 키에 나타납니다** |
| 문서 digest + generation | 키의 세대는 문서마다 0 에서 시작해 `bin:0:1:src` 가 충돌합니다. 문서 경계를 키가 들지 않으면 새 문서가 옛 재시도 상태를 재사용합니다 |
| `imageCount`·`rawSvgCount`·overlay 서명 | 종전 재료 유지 |

판정 재료가 없으면(구형 WASM · `cacheable:false` 인 합성 그림 혼재 페이지 · 문서 신원 미상) `null` 을 돌려 **재사용을 포기**합니다. 안전망을 없애는 쪽이 아니라 이미 끝난 일을 되풀이하지 않는 쪽으로만 작동해야 하므로 `shouldSkipImagePrefetch` 와 같은 기울기입니다. `null` 은 저장하지도 않습니다 — 저장하면 다음 렌더가 그 값과 비교합니다.

### `beginDocument()` 를 쓰지 않은 이유

#3665 통합본이 `PageRenderer.beginDocument()`(← `CanvasView.prepareDocumentLoad`)를 문서 로드 경계로 새로 두었습니다. 재시도 키도 그 경계에서 비우면 키에서 문서 신원을 뺄 수 있어 더 짧아집니다.

그렇게 하지 않았습니다. 재시도 상태가 낡으면 **다른 문서의 키를 재사용해 필요한 prefetch 를 건너뛰고 빈 그림이 남습니다** — 조용한 오작동입니다. 키가 신원을 직접 들면 `beginDocument()` 호출 순서에 의존하지 않습니다. 비용도 같습니다(어느 설계든 `getPageSourceImageKeys` 를 부릅니다). 다른 판단이시면 `beginDocument()` 로 옮기겠습니다.

### 호출부 플래그도 택하지 않았습니다

`releaseAllRenderedPages(clearRetry: boolean)` 가 더 짧지만, 호출부가 5곳(줌·리사이즈·refresh 4곳 + 문서 교체 1곳)이고 **맞춰야 하는 그 계약이 이 트랙에서 이미 두 번 깨졌습니다** — #3648(가드 수신자 목록)과 #3665 P1(URL 캐시 수명). 세 번째로 같은 형태를 만들 이유가 없습니다.

## 남긴 것

- `resetImageRetryState()` 의 나머지 정리(`prefetchRequestTokens`·`layerSummaryCache`·`canvaskitDiagnosticsByPage`)는 유지합니다 — 캔버스를 통째로 버렸으므로 실제로 무효입니다.
- `imageRetryCounts` 정리는 `dispose()` 로 옮겼습니다.
- 문서 교체 경로(`reset()` → `releaseAllRenderedPages`)는 그대로입니다.

## 관련 이슈

#3315 Track 3 — **umbrella 이슈라 closing keyword 를 쓰지 않습니다.**
선행: #3455(신원 키 서명), #3660(좁은 질의), #3665(P1/P2 수정 — devel 반영 완료, 이 PR 은 그 위에 리베이스됨).

## 테스트

- [x] rhwp-studio `npm test` — **710/710**, `npx tsc --noEmit` 통과
- [x] `cargo test --profile release-test --tests` — **4466 passed / 0 failed** (최신 `devel` 리베이스 후 재확인)
- [ ] **웹(WASM) 실브라우저 확인 — 하지 못했습니다** (아래)

신규 `tests/issue-3315-image-retry-narrowing.test.ts` 5건 + `render-backend.test.ts` 의 옛 키 형태 가드 갱신(약해지지 않게 새 재료·`null` 포기 경로를 대신 못박았습니다). **두 변이로 무는지 확인했습니다** — blanket 리셋을 복구하면 실패하고, 키에서 문서 신원을 빼면 실패합니다.

### 실브라우저 확인이 필요한 위험

재시도 키가 맞으면 `scheduleReRender` 가 조기 반환하고, 그러면 **prefetch 자체가 돌지 않습니다.** 그림이 이미 디코드돼 있다는 전제(브라우저 디코드 캐시 + WASM `IMAGE_CACHE` 가 따뜻하다)에 기댑니다.

- 종전에도 같은 조기 반환이 있었고(리셋되지 않은 경우) 이 PR 은 그 조건이 성립하는 범위를 넓힙니다 — 새 기제가 아니라 기존 기제의 적용 범위 확대입니다.
- 다만 WASM `IMAGE_CACHE` 가 문서 revision 과 독립적으로 비워지는 경로가 있으면 키는 그대로인데 캐시는 차가울 수 있습니다. 소스만으로 그 독립성을 확정하지 못했습니다.

확인이 필요한 시나리오 셋입니다 — **연속 타이핑 중 그림이 계속 보이는지**, **밝기/대비 변경 직후 그림이 갱신되는지**, **문서를 갈아끼운 뒤 첫 렌더에 그림이 보이는지**. 돌릴 e2e 를 알려 주시면 실행해 증적을 올리겠습니다.
