### PR TITLE
perf: #3315 통합 검토 — 재렌더 안전망과 계약 가드

### DIFF
--- a/mydocs/orders/20260801.md
+++ b/mydocs/orders/20260801.md
@@ -1,5 +1,33 @@
 # 오늘 할일 - 2026년 8월 1일
 
+## lpaiu-cs PR #3662·#3672 통합 검토
+
+[#3662](https://github.com/edwardkim/rhwp/pull/3662)와
+[#3672](https://github.com/edwardkim/rhwp/pull/3672)의 누적 검토 후보는
+[#3680](https://github.com/edwardkim/rhwp/pull/3680)
+`integrate/lpaiu-cs-20260801`이다.
+
+- #3672는 통합 CI 중 [merge commit `c588c8240`](https://github.com/edwardkim/rhwp/commit/c588c8240331a181271c6551e124aa1ff770d900)으로
+  먼저 `devel`에 반영됐다. 따라서 #3680은 원 기능을 중복하지 않고, #3662의 author-preserving
+  contract guards와 RawSvg 재렌더 P1 보정·hwpctl guard 재검증만 최신 base에 남긴다.
+- latest code candidate `71ccfeaaa`는 CI lint/frontend gate/Native Skia/test archive/default-feature
+  8 shards/`Build & Test`, CodeQL, Canvas visual diff까지 모두 success다. 로컬에서는 focused #3315
+  7 passed, full release-test integration 최종 exit 0, clippy·WASM·Studio 716 test와 Chrome Canvas E2E를
+  확인했다. RawSvg 400ms 색상 픽셀은 1.757%(임계 0.3% 초과)였고 같은 문서 refresh 뒤 chart ink도
+  남았다. 이 browser evidence를 HWP/PDF 전체 동등성 주장으로 확대하지 않는다.
+- archive review 2건, 공유 구현 계획, 오늘할일만 같은 PR의 review-only tail로 추가한다. 네 Markdown
+  경로의 LFS attribute는 모두 `unspecified`, `git lfs status`도 비어 있음을 먼저 판독했다.
+  same-branch push 뒤 fast-pass preflight와 final aggregate를 확인한다.
+- fast-pass success와 latest `CLEAN`·`MERGEABLE` 확인 뒤 #3680 하나만 merge commit으로 병합한다.
+  이후 #3662에는 감사와 구체적 검토 근거를 실제 줄바꿈 comment로 남겨 supersede close한다. #3672는
+  이미 merge됐으므로 RawSvg 보정 사실과 감사를 comment로 남기되 close하지 않는다. #3315는 open 유지,
+  #3648은 이미 closed라 중복 close하지 않는다. 마지막으로 devel sync와 exact review/integration ref·target
+  정리를 수행한다.
+
+상세 근거는 [#3662 review](../pr/archives/pr_3662_review.md),
+[#3672 review](../pr/archives/pr_3672_review.md),
+[공유 계획](../pr/archives/pr_3662_review_impl.md)에 기록한다.
+
 ## lpaiu-cs PR #3665·planet6897 PR #3666 통합 검토
 
 [#3665](https://github.com/edwardkim/rhwp/pull/3665)와

--- a/mydocs/pr/archives/pr_3662_review.md
+++ b/mydocs/pr/archives/pr_3662_review.md
@@ -1,0 +1,91 @@
+---
+kind: review
+status: active
+canonical: mydocs/pr/archives/pr_3662_review.md
+last_verified: 2026-08-01
+---
+
+# PR #3662 검토 기록 — #3315 이미지 바이트 계약 가드
+
+## 라우팅
+
+```text
+base route: collaborator self-merge
+modifiers: intake_and_review.md, local_validation.md,
+  visual_fixture_evidence.md, multi_pr_update_branch.md,
+  review_only_fast_pass.md
+integration branch: integrate/lpaiu-cs-20260801
+integration PR: #3680
+```
+
+원 PR은 개별 merge하지 않고 최신 `upstream/devel`
+`c588c8240331a181271c6551e124aa1ff770d900` 위 [#3680](https://github.com/edwardkim/rhwp/pull/3680)에
+`-x`로 누적했다. #3672는 이 통합 검토 도중 별도로 merge되어 base에 포함됐으므로, 그 PR의 사후
+검토와 RawSvg 안전 보정은 [#3672 review](pr_3672_review.md)에 분리한다.
+
+## PR metadata
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#3662](https://github.com/edwardkim/rhwp/pull/3662) |
+| 작성자 | `@lpaiu-cs` (재기여자) |
+| base / source head | `devel` / `0f6ccaa61a8d5bfe66ab423a0d6b5fc9bd0a77bb` (작성 시점 참고) |
+| source 기능 commit | `f07d86a5c5c2fbcbffc27cd2044ebfbcd3ae0a80`, `0f6ccaa61a8d5bfe66ab423a0d6b5fc9bd0a77bb` |
+| 통합 반영 | `fc06bf23dae767f51699e241c66bae3ab390f37b`, `2deb282081932d6ca9e459f9549cdd0830db9230` (`-x` 추적, author 보존) |
+| reviewer | `@edwardkim` 요청 완료 |
+| 관련 issue | [#3315](https://github.com/edwardkim/rhwp/issues/3315) — Track 1–4 umbrella, 열린 상태 유지 |
+
+원 PR의 source base `3b28ab597`은 오래됐고, source head의 CI·mergeability는 작성 시점 참고값일 뿐이다.
+최종 merge 근거는 최신 #3680 code candidate와 그 review-only tail의 CI다.
+
+## 변경 범위와 검토 판정
+
+- Rust paint JSON의 `imageBytes` 계약을 "바이트 동일"이라는 과도한 이름 대신 기존 필드 보존과
+  schema minor 21의 additive metadata 계약으로 고정한다.
+- PNG·BMP·TIFF·회색/색 JPEG·워터마크 JPEG·효과 PNG·손상 BMP rollback에 대해 source image key와
+  방출 JSON 바이트가 같은 변환 결과를 가리키는지 검증한다. 실제 bake가 일어난 watermark case를
+  만들고, 두 variant가 실제로 다르다는 전제까지 고정한 점이 특히 유효하다.
+- `byKey` 모드의 최상위 `imageBytes`는 요청 모드이고, key 없는 합성 그림의 실제 payload 여부는
+  op별 `imageBytesOmitted`가 말한다는 경계를 문서와 회귀로 분리한다.
+- #3350 rollback은 nested catch의 discard가 아니라 성공 경로에서 discard 후 rethrow하는지를 좁혀
+  검증한다. 이로써 성공 경로 누수 회귀를 놓치던 문자열 guard의 범위를 바로잡는다.
+
+코드 검토에서 차단 결함은 발견하지 못했다. 다만 public fixture가 없는 PCX와 watermark 전체
+round-trip은 이 PR의 공개 커버리지 밖이다. 따라서 현재 증거를 모든 이미지 형식·모든 watermark
+경로의 완전한 동등성으로 확대하지 않는다.
+
+## 로컬·시각 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| `cargo fmt --check` | 성공 |
+| `cargo test --profile release-test --test issue_3315_image_bytes_by_key` | 7 passed |
+| `cargo test --profile release-test --tests` | 최종 exit 0 |
+| `cargo clippy --profile release-test --all-targets -- -D warnings` | 성공 |
+| Native Skia 공식 3종 | 58/58, 2/2, 4/4 passed |
+| Rust doc test | 4 passed, 2 ignored |
+| `wasm-pack build --target web --out-dir pkg` | 성공 |
+| Studio | `npx tsc --noEmit`, `npm test` 716 passed |
+
+검토 전용 Cargo 실행은 `CARGO_INCREMENTAL=0`,
+`CARGO_TARGET_DIR=target/review-lpaiu-cs-20260801`로 분리했다.
+
+이 통합 후보는 `src/renderer`·WASM·Studio canvas에도 닿으므로 browser canvas 경로를 별도로 확인했다.
+RawSvg는 400ms 후 색상 픽셀 1.757%로 임계 0.3%를 넘겼고, chart A/B는 각각 1.824%/2.697%, 같은
+문서 `refreshPages()` 후 B도 2.697%였다. 이는 비동기 decode 재렌더를 직접 다루는 변경에 맞춘
+Chrome E2E 근거다. HWP/HWPX fixture·page geometry·기준 PDF는 바뀌지 않았으므로 PDF/SVG visual
+sweep을 수행하거나 전체 HWP/PDF 동등성을 주장하지 않았다. 최신 CI의 Canvas visual diff도 성공했다.
+
+## CI와 권고
+
+최신 code candidate `71ccfeaaa6c911340d18371e348a6b53ff33f4a0`의
+[CI](https://github.com/edwardkim/rhwp/actions/runs/30687707964),
+[CodeQL](https://github.com/edwardkim/rhwp/actions/runs/30687707945),
+[Canvas visual diff](https://github.com/edwardkim/rhwp/actions/runs/30687707952)는 모두 성공했다.
+CI에는 lint, frontend gate, Native Skia, test archive, default-feature 8 shards, `Build & Test`가
+포함된다.
+
+이 기록은 code CI 성공 뒤 same-PR head에 추가하는 single-parent review-only tail이다. 따라서
+최종 merge 조건은 최신 #3680 head의 fast-pass preflight와 `Build & Test` aggregate 성공,
+`CLEAN`·`MERGEABLE` 재확인, 그리고 작업지시자의 기존 자동 승인 범위다. 조건 충족 전 권고는 **보류**,
+충족 후 권고는 **#3680 통합 merge**다.

--- a/mydocs/pr/archives/pr_3662_review_impl.md
+++ b/mydocs/pr/archives/pr_3662_review_impl.md
@@ -1,0 +1,60 @@
+---
+kind: review-plan
+status: active
+canonical: mydocs/pr/archives/pr_3662_review_impl.md
+last_verified: 2026-08-01
+---
+
+# lpaiu-cs 통합 검토·반영 계획 (PR #3662, #3672)
+
+기준은 `upstream/devel`의 `c588c8240331a181271c6551e124aa1ff770d900`이고, 통합 후보는
+[#3680](https://github.com/edwardkim/rhwp/pull/3680) `integrate/lpaiu-cs-20260801`이다.
+원 PR별 판단은 [#3662 review](pr_3662_review.md), [#3672 review](pr_3672_review.md)에 분리한다.
+
+| 순서 | 원 PR/성격 | source 또는 base 반영 | #3680 반영 | author 보존 |
+| --- | --- | --- | --- | --- |
+| 1 | #3662 tone-variant 회귀 | `f07d86a5…` | `fc06bf23…` | `lpaiu-cs` |
+| 2 | #3662 계약·rollback guard | `0f6ccaa6…` | `2deb2820…` | `lpaiu-cs` |
+| 3 | #3672 retry narrowing | `81306ef0…` → base `c588c824…` | source 중복 적용 없음 | 이미 devel merge |
+| 4 | #3672 RawSvg P1 보정 | — | `01a572c3…` | maintainer |
+| 5 | #3670 hwpctl guard 재검증 | base `b2b5c449…` | `94a37788…` | maintainer |
+| 6 | #3315 계약 설명 범위 정정 | — | `71ccfeaa…` | maintainer |
+
+`-x` trailer로 #3662 source와 integration commit을 추적한다. #3672는 #3680 code CI 중 별도 merge돼
+최신 base에 들어갔으므로 rebase에서 source patch가 자동 제외됐다. 그 결과 #3680은 contributor 기능을
+중복하지 않고, 발견한 P1 보정과 #3662의 author-preserving contract guard만 담는다.
+
+## 수용 계약과 경계
+
+- #3662의 계약은 "기존 image JSON field 보존 + schema minor 21의 additive metadata"다. byte-identical
+  default serialization이나 PCX·모든 watermark public round-trip을 주장하지 않는다.
+- #3672의 raster retry key narrowing은 유지하되, RawSvg의 비동기 decode 상태는 그 key로 판정하지 않는다.
+  `rawSvgCount > 0`에서는 재사용을 포기해 timer/fallback을 다시 무장한다.
+- `replaceAll` guard는 확정된 문자열 receiver만 제외하고 새로운 raw document 별칭은 guard failure로
+  드러낸다. complex receiver expression parsing은 후속 P2다.
+- `imageRetryCounts`의 page pool release 누적은 후속 P2로 남긴다. 이번 merge가 이를 해소했다고
+  기록하지 않는다.
+
+## 검증·tail·merge 순서
+
+1. code candidate `71ccfeaaa6c911340d18371e348a6b53ff33f4a0`은 최신 base에서 full CI를 완료했다:
+   [CI](https://github.com/edwardkim/rhwp/actions/runs/30687707964)의 lint, frontend gate, Native Skia,
+   test archive, default-feature 8 shards, `Build & Test`,
+   [CodeQL](https://github.com/edwardkim/rhwp/actions/runs/30687707945),
+   [Canvas visual diff](https://github.com/edwardkim/rhwp/actions/runs/30687707952)가 모두 success다.
+2. 이 archive review 두 건, 이 공유 계획, 오늘할일만 single-parent review-only commit으로 같은
+   #3680 head에 추가한다. source/test/workflow/golden/baseline/기존 fixture는 tail에 섞지 않는다.
+3. 추가 전 planned Markdown 네 경로의 `filter`·`diff`·`merge` attribute가 모두 `unspecified`이고
+   `git lfs status`에 push/commit/staged object가 없음을 확인했다. 따라서 LFS 대상이 아님을 먼저
+   판정한 뒤 `GIT_LFS_SKIP_PUSH=1` dry-run과 same-branch push를 한다.
+4. `71ccfeaa`의 성공 `Build & Test`를 candidate로 삼아 최신 review-only head의 CI preflight와
+   `Build & Test` aggregate가 success인지 확인한다. fast-pass가 fallback하면 full CI 종료까지 기다린다.
+5. latest head가 `CLEAN`·`MERGEABLE`이고 required check가 성공하면, 기존 자동 승인 범위에 따라
+   #3680을 **merge commit**으로 merge한다. #3315에는 closing keyword를 쓰지 않는다.
+6. merge SHA 확인 뒤 열린 원 #3662에는 실제 줄바꿈 body-file comment로 author-preserving 통합·검토
+   근거·검증을 남기고 supersede close한다. 이미 merge된 #3672는 close하지 않고 RawSvg 보정 사실과
+   감사의 review comment만 남긴다. #3315는 open 상태를 재확인한다. #3648은 이미 closed이며 #3670의
+   maintainer 기록이 있으므로 중복 close하지 않는다.
+7. `devel` fast-forward sync 후, 이번 작업이 만든 exact integration/review/local PR refs와
+   `target/review-lpaiu-cs-20260801`만 post-merge 절차에 따라 정리한다. contributor fork branches는
+   삭제하지 않는다.

--- a/mydocs/pr/archives/pr_3672_review.md
+++ b/mydocs/pr/archives/pr_3672_review.md
@@ -1,0 +1,76 @@
+---
+kind: review
+status: active
+canonical: mydocs/pr/archives/pr_3672_review.md
+last_verified: 2026-08-01
+---
+
+# PR #3672 사후 검토 기록 — retry narrowing과 RawSvg 안전 경계
+
+## 라우팅과 상태
+
+```text
+base route: collaborator self-merge
+modifiers: intake_and_review.md, local_validation.md,
+  visual_fixture_evidence.md, multi_pr_update_branch.md,
+  review_only_fast_pass.md
+review correction PR: #3680
+```
+
+[#3672](https://github.com/edwardkim/rhwp/pull/3672)은 통합 검토 중
+2026-08-01 06:12:20Z에 [merge commit `c588c8240`](https://github.com/edwardkim/rhwp/commit/c588c8240331a181271c6551e124aa1ff770d900)으로
+별도 merge됐다. 따라서 이 문서는 원 기능의 사후 review와, 원 기능만으로 남는 RawSvg P1을
+#3680에서 안전하게 보정하는 근거를 함께 남긴다. merge된 원 PR을 supersede close하거나 contributor
+author를 다시 적용하지 않는다.
+
+## PR metadata
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#3672](https://github.com/edwardkim/rhwp/pull/3672) |
+| 작성자 | `@lpaiu-cs` (재기여자) |
+| source base / head | `5891600372d847fc0a000ba3f6ebb9e5861e1f03` / `81306ef0f26ff6c6d43dae65e8c9a177ad01b66f` (작성 시점 참고) |
+| source 기능 commit | `81306ef0f26ff6c6d43dae65e8c9a177ad01b66f` |
+| 실제 반영 | `c588c8240331a181271c6551e124aa1ff770d900` |
+| review P1 보정 | #3680의 `01a572c32a9363ff2ebdfe1bf2dae1adcfb96529` |
+| reviewer | `@edwardkim` 요청 완료 |
+| 관련 issue | [#3315](https://github.com/edwardkim/rhwp/issues/3315) — 열린 umbrella 유지 |
+
+## 변경 범위와 보정 판단
+
+원 기능은 매 편집마다 `resetImageRetryState()`로 전체 retry state를 비우던 방식을 없애고, raster
+image source key·문서 digest/generation을 retry key로 사용해 같은 그림 페이지의 중복 재렌더를 막는다.
+판정 재료가 없을 때 `null`을 돌려 재사용을 포기하는 fail-closed 경계, document identity까지 키에
+넣은 판단은 타당하다.
+
+다만 RawSvg 차트/OLE는 raster source-image key 집합에 들어가지 않고, compact overlay는 RawSvg의
+내용이 아니라 개수만 전달한다. 같은 문서·같은 개수에서 browser decode cache가 비워지거나 RawSvg가
+갱신되면 기존 key가 같아 `scheduleReRender()`가 조기에 return할 수 있다. 첫 draw가 비동기 decode보다
+앞서면 다음 안전망 없이 빈 canvas가 고착할 수 있으므로 이는 P1이다.
+
+#3680의 `01a572c32`은 `rawSvgCount > 0`이면 retry key를 `null`로 해 해당 case의 timer/fallback을
+항상 다시 무장한다. 일반 raster 이미지의 key 기반 재사용은 유지한다. 따라서 원 성능 개선을 넓게
+되돌리지 않고 RawSvg가 판정 재료가 될 수 없는 경계만 fail closed한다.
+
+잔여 P2는 `imageRetryCounts`가 page pool release에서는 지워지지 않고 `dispose()`에서만 정리되는 점이다.
+긴 그림 문서 탐색에서 page key가 누적될 수 있으므로, page release cleanup 또는 bounded LRU는 후속으로
+다뤄야 한다. 이 문서는 그 P2가 해소됐다고 주장하지 않는다.
+
+## 로컬·시각 검증
+
+검토 전용 target에서 `cargo fmt --check`, full
+`cargo test --profile release-test --tests`(최종 exit 0), clippy, Native Skia 3종, Rust doc test,
+WASM build, TypeScript와 Studio 716 test를 통과했다.
+
+RawSvg 관련 사용자-visible 경로는 PDF/SVG fixture 비교 대신 browser Canvas E2E로 확인했다. 400ms 후
+RawSvg의 색상 픽셀은 1.757%(임계 0.3% 초과)였고, chart 문서 A/B 및 같은 문서
+`refreshPages()` 후에도 ink가 남았다(A 1.824%, B 2.697%). page geometry·기준 PDF·fixture를 바꾸는
+PR이 아니므로 이 증적을 HWP/PDF 전체 동등성으로 확대하지 않는다. 최신 head의 Canvas visual diff도
+성공했다.
+
+## CI와 권고
+
+#3672의 source 기능은 이미 `devel`에 merge됐지만, **RawSvg 보정이 포함된 #3680이 merge되기 전에는
+원 기능을 완결로 선언하지 않는다.** 최신 code candidate
+`71ccfeaaa6c911340d18371e348a6b53ff33f4a0`의 CI·CodeQL·Canvas visual diff는 모두 성공했다.
+review-only tail의 fast-pass 성공과 latest head `CLEAN`·`MERGEABLE` 확인 뒤 #3680 merge를 권고한다.

--- a/rhwp-studio/e2e/hwpctl-basic.test.mjs
+++ b/rhwp-studio/e2e/hwpctl-basic.test.mjs
@@ -26,8 +26,29 @@ runTest('hwpctl 호환 레이어 기본 동작', async ({ page }) => {
   const actId = await page.evaluate(() => window.HwpCtrl.CreateAction("TableCreate").ActID);
   assert(actId === 'TableCreate', `ActID = "TableCreate" (실제: "${actId}")`);
 
+  // #3648: boolean Run/Execute만으로는 실패의 종류를 알 수 없으므로, 공개 조회 API와
+  // 정책상 미지원 액션의 호환 반환값을 실제 브라우저 경계에서 함께 확인한다.
+  console.log('  [5] Action 지원 상태 확인...');
+  const support = await page.evaluate(() => {
+    const undo = window.HwpCtrl.CreateAction('Undo');
+    return {
+      missing: window.HwpCtrl.GetActionSupport('__rhwp_missing_action__'),
+      undo: window.HwpCtrl.GetActionSupport('Undo'),
+      tableCreate: window.HwpCtrl.GetActionSupport('TableCreate'),
+      undoRun: undo.Run(),
+      undoExecute: undo.Execute(undo.CreateSet()),
+    };
+  });
+  assert(support.missing === null, '미등록 Action은 null');
+  assert(support.undo?.status === 'unsupported', 'Undo는 정책상 미지원');
+  assert(support.undo?.code === 'notSupportedByDesign', 'Undo 미지원 코드는 기계 판독 가능');
+  assert(support.undo?.reference === 'https://github.com/edwardkim/rhwp/issues/3648', 'Undo 미지원 근거');
+  assert(support.tableCreate?.status === 'supported', 'TableCreate는 지원');
+  assert(support.undoRun === false, '미지원 Undo.Run()은 false');
+  assert(support.undoExecute === false, '미지원 Undo.Execute()는 false');
+
   // ParameterSet
-  console.log('  [5] ParameterSet 동작 확인...');
+  console.log('  [6] ParameterSet 동작 확인...');
   const setResult = await page.evaluate(() => {
     const set = window.HwpCtrl.CreateSet("TableCreation");
     set.SetItem("Rows", 10);
@@ -39,7 +60,7 @@ runTest('hwpctl 호환 레이어 기본 동작', async ({ page }) => {
   assert(setResult.name === 'TableCreation', `Set name = "TableCreation"`);
 
   // InsertText
-  console.log('  [6] InsertText 동작 확인...');
+  console.log('  [7] InsertText 동작 확인...');
   const textResult = await page.evaluate(() => {
     window.HwpCtrl.Clear();
     const ok = window.HwpCtrl.InsertText("테스트 문장");
@@ -50,7 +71,7 @@ runTest('hwpctl 호환 레이어 기본 동작', async ({ page }) => {
   assert(textResult.pos.pos > 0, `커서 이동 (pos=${textResult.pos.pos})`);
 
   // 구현률
-  console.log('  [7] 구현률 확인...');
+  console.log('  [8] 구현률 확인...');
   const implRate = await page.evaluate(() => {
     const total = window.HwpCtrl.constructor.getRegisteredActionCount();
     const impl = window.HwpCtrl.constructor.getImplementedActionCount();

--- a/rhwp-studio/e2e/issue-1456-chart-rerender.test.mjs
+++ b/rhwp-studio/e2e/issue-1456-chart-rerender.test.mjs
@@ -12,6 +12,9 @@
  *     수정 전이면 rawSvg 단독 페이지가 재렌더 트리거 bail → 공백(유채색 ~0) → FAIL.
  *   케이스 B (비재사용/고착): 같은 세션에서 다른 차트로 교체 로드 → 두 캔버스가
  *     유의미하게 다름(B 가 A 의 캐시 픽셀을 재사용하지 않음). #3(CanvasPool) 판정 입력.
+ *   케이스 C (동일 문서 갱신): B를 다시 로드하지 않고 `refreshPages()`만 호출한 뒤에도
+ *     RawSvg가 비공백이다. #3315의 retry 상태 재사용이 같은 문서 갱신에서 안전망을
+ *     건너뛰지 않는 실제 UI 경계다.
  *
  * 실행:
  *   cd rhwp-studio
@@ -96,4 +99,13 @@ runTest('#1456 차트/OLE rawSvg 첫 로드 재렌더', async ({ page }) => {
 
   const diff = pixelDiffRatio(bufA, bufB);
   assert(diff > 0.02, `차트 B↔A 픽셀 차이 ${(diff * 100).toFixed(2)}% > 2% (B가 A 캐시 미재사용)`);
+
+  // ── 케이스 C: 같은 문서 refresh → 비공백 ────────────────────
+  setTestCase('C: 같은 차트 refreshPages 비공백');
+  await page.evaluate(() => window.__canvasView.refreshPages());
+  await page.waitForSelector('#scroll-container canvas', { timeout: 10000 });
+  await waitReRender(page);
+  const { buffer: bufC } = await captureCanvasScreenshot(page, `${OUT_DIR}/chartB-refresh.png`, 'chart B refresh');
+  const ratioC = coloredPixelRatio(bufC);
+  assert(ratioC > 0.003, `차트 B refresh 유채색 픽셀 ${(ratioC * 100).toFixed(3)}% > 0.3% (동일 문서 비공백)`);
 });

--- a/rhwp-studio/src/view/page-renderer.ts
+++ b/rhwp-studio/src/view/page-renderer.ts
@@ -994,6 +994,9 @@ export class PageRenderer {
    * - 문서 신원(digest·generation) — 키의 세대는 문서마다 0 에서 시작해 서로 충돌한다
    *   (`bin:0:1:src`). 문서 경계를 키가 들지 않으면 새 문서가 옛 재시도 상태를 재사용한다.
    *   `prefetchedImageSignatures`·`FlowImageUrlCache` 와 같은 이유·같은 방식이다.
+   * - RawSvg — compact 그림 키에는 포함되지 않고, 브라우저의 SVG decode 캐시는 별도로
+   *   비워질 수 있다. 개수만으로는 재렌더 준비 상태를 증명할 수 없으므로 이 페이지는
+   *   재사용하지 않는다.
    *
    * 판정 재료가 없으면(`null`) **재사용하지 않는다** — 구형 WASM, 키를 낼 수 없는 합성 그림이
    * 섞인 페이지(`cacheable:false`), 문서 신원 미상. 안전망을 없애는 쪽이 아니라 이미 끝난 일을
@@ -1005,6 +1008,10 @@ export class PageRenderer {
     rawSvgCount: number,
     policy: ReRenderPolicy,
   ): string | null {
+    // RawSvg 차트/OLE는 첫 paint 뒤 비동기 decode가 끝나야 다시 그려진다. source-image key는
+    // Image 노드만 대상으로 하고 브라우저 IMAGE_CACHE의 eviction도 관찰하지 못하므로, 같은
+    // 개수라는 이유로 timer/fallback을 건너뛰면 공백이 고착될 수 있다 (#1456).
+    if (rawSvgCount > 0) return null;
     const imageKeys = cacheableImageKeySignature(this.wasm.getPageSourceImageKeys(pageIdx));
     const documentDigest = this.wasm.documentDigest;
     if (imageKeys === null || documentDigest === null) return null;

--- a/rhwp-studio/tests/command-history-snapshot.test.ts
+++ b/rhwp-studio/tests/command-history-snapshot.test.ts
@@ -93,15 +93,30 @@ test('[#3350] 최초 execute 실패는 before 스냅샷 복원 후 ID를 해제�
   const catchBody = block.slice(catchStart);
 
   const idxRestore = catchBody.indexOf('wasm.restoreSnapshot(this.beforeId)');
-  const idxDiscard = catchBody.indexOf('this.discard(wasm)');
-  assert.ok(idxRestore !== -1 && idxDiscard !== -1 && idxRestore < idxDiscard,
-    '부분 변경을 before 스냅샷으로 rollback한 뒤 ID를 해제해야 함');
+  assert.notEqual(idxRestore, -1, '부분 변경을 before 스냅샷으로 rollback해야 함');
   assert.match(catchBody, /catch \(rollbackError\)/,
     'rollback 실패도 별도로 포착해야 함');
   assert.match(catchBody, /new AggregateError\(\s*\[operationError, rollbackError\]/,
     '원래 operation 오류와 rollback 오류를 함께 보존해야 함');
-  assert.match(catchBody, /throw operationError/,
-    'rollback 성공 시 원래 operation 오류를 그대로 전파해야 함');
+
+  // [#3662] rollback **성공** 경로의 discard 를 따로 못박는다.
+  //
+  // 종전에는 `catchBody.indexOf('this.discard(wasm)')` 로 순서만 봤는데, 그 첫 번째 일치는
+  // inner `catch (rollbackError)` 안의 discard 다. 그래서 성공 경로의 discard 를 지워도
+  // 가드가 통과했다 — 스냅샷 2개가 조용히 누수되는 회귀를 못 잡는다.
+  //
+  // inner catch 가 닫힌 **뒤** discard → rethrow 가 이어지는지 확인해 성공 경로에 고정한다.
+  assert.match(
+    catchBody,
+    /\}\s*this\.discard\(wasm\);\s*throw operationError;/,
+    'rollback 성공 시 before/after 를 해제한 뒤 원래 operation 오류를 전파해야 함',
+  );
+
+  // inner catch 안의 discard 도 함께 남아 있어야 한다 — rollback 이 실패해도 ID 는 해제한다.
+  const rollbackCatch = catchBody.slice(catchBody.indexOf('catch (rollbackError)'));
+  const innerBody = rollbackCatch.slice(0, rollbackCatch.indexOf('throw new AggregateError'));
+  assert.match(innerBody, /this\.discard\(wasm\)/,
+    'rollback 실패 경로도 스냅샷 ID 를 해제해야 함');
 });
 
 test('[결함1] 스냅샷 예산은 WASM 상한에서 순간 +2 여유를 뺀 값이다', () => {

--- a/rhwp-studio/tests/issue-3315-image-retry-narrowing.test.ts
+++ b/rhwp-studio/tests/issue-3315-image-retry-narrowing.test.ts
@@ -51,6 +51,14 @@ test('[#3315] 재시도 키는 문서 신원과 그림 내용을 직접 든다',
   assert.match(body, /documentDigest/);
   assert.match(body, /documentGeneration/);
 
+  // RawSvg는 source-image key에 없고 decoder cache readiness도 별도이므로, 같은 개수로
+  // 재시도 안전망을 생략하면 안 된다.
+  assert.match(
+    body,
+    /if \(rawSvgCount > 0\) return null;/,
+    'RawSvg가 있으면 timer/fallback 재렌더를 재사용으로 건너뛰면 안 된다',
+  );
+
   // 판정 재료가 없으면 재사용을 포기한다(안전망 쪽으로 기운다).
   assert.match(body, /return null;/);
 });

--- a/rhwp-studio/tests/mutation-routing-guard.test.ts
+++ b/rhwp-studio/tests/mutation-routing-guard.test.ts
@@ -157,10 +157,19 @@ const NON_MUTATION_RECEIVERS: Readonly<Record<string, string>> = {
  * 표준 JS 메서드와 이름이 겹치는 뮤테이터.
  *
  * `replaceAll` 은 브리지의 찾아 바꾸기이면서 `String.prototype.replaceAll` 이기도 하다.
- * 문자열 지역변수 이름은 자유롭게 늘어나므로 수신자로 걸러내면 원장이 이름 하나 늘 때마다
- * 흔들린다. 이름 층위에서 한 번 선언해 두면 어떤 변수명이든 영향이 없다.
+ * 다만 이름만으로 모든 비브리지 수신자를 건너뛰면 새 raw-document alias까지 조용히 빠진다.
+ * 현재 문자열 수신자만 명시적으로 비뮤테이션으로 분류하고, 모르는 수신자는 원장의
+ * `모든 뮤테이터 호출` 검사에서 실패시킨다.
  */
 const BUILTIN_NAME_COLLISIONS = new Set(['replaceAll']);
+const BUILTIN_NON_MUTATION_RECEIVERS: Readonly<Record<string, string>> = {
+  text: 'String.prototype.replaceAll을 쓰는 HTML escape 문자열',
+  value: 'String.prototype.replaceAll을 쓰는 비교 문자열',
+};
+
+function isKnownBuiltinNonMutationCall(receiver: string, method: string): boolean {
+  return BUILTIN_NAME_COLLISIONS.has(method) && receiver in BUILTIN_NON_MUTATION_RECEIVERS;
+}
 
 /** `수신자.메서드(` 를 훑는다. 수신자는 점 앞의 마지막 식별자(`this.wasmDoc` → `wasmDoc`). */
 function mutatorCalls(src: string): { receiver: string; method: string }[] {
@@ -280,11 +289,9 @@ test('모든 뮤테이터 호출의 수신자는 분류돼 있어야 한다(미�
 
   for (const rel of scanFiles()) {
     for (const { receiver, method } of mutatorCalls(source(rel))) {
-      // 표준 JS 와 이름이 겹치는 호출은 브리지 수신자일 때만 뮤테이션이다.
-      if (BUILTIN_NAME_COLLISIONS.has(method)
-        && !(MUTATION_RECEIVERS as readonly string[]).includes(receiver)) {
-        continue;
-      }
+      // 동명이인이라도 미리 분류한 문자열 수신자만 건너뛴다. 미지 수신자는 raw-document
+      // alias일 수 있으므로 아래 분류 실패로 드러나야 한다.
+      if (isKnownBuiltinNonMutationCall(receiver, method)) continue;
       if ((MUTATION_RECEIVERS as readonly string[]).includes(receiver)) continue;
       if (receiver in NON_MUTATION_RECEIVERS) continue;
 
@@ -309,6 +316,14 @@ test('모든 뮤테이터 호출의 수신자는 분류돼 있어야 한다(미�
       + '변형하지 않으면(위임·동명이인) NON_MUTATION_RECEIVERS 에 사유와 함께 등재하세요.\n'
       + '이 검사가 없으면 새 수신자의 뮤테이션이 원장에서 조용히 빠집니다(#3648).',
   );
+});
+
+test('replaceAll 동명이인은 알려진 문자열 수신자만 비뮤테이션으로 분류한다', () => {
+  assert.equal(isKnownBuiltinNonMutationCall('text', 'replaceAll'), true);
+  assert.equal(isKnownBuiltinNonMutationCall('value', 'replaceAll'), true);
+  assert.equal(isKnownBuiltinNonMutationCall('wasm', 'replaceAll'), false);
+  assert.equal(isKnownBuiltinNonMutationCall('rawDoc', 'replaceAll'), false,
+    '새 raw-document alias는 수신자 분류 실패로 리뷰에 드러나야 한다');
 });
 
 // hwpctl 이 스캔 대상에 실제로 들어왔는지 — #3648 의 "이중 미스" 두 겹을 각각 못박는다.

--- a/rhwp-studio/tests/render-backend.test.ts
+++ b/rhwp-studio/tests/render-backend.test.ts
@@ -523,6 +523,11 @@ test('PageRenderer deferred image rerender preserves static layer reuse policy',
   assert.match(keyBody, /documentDigest/, '문서 digest 를 재료로 쓴다');
   assert.match(keyBody, /documentGeneration/, '문서 generation 을 재료로 쓴다');
   assert.match(keyBody, /policy\.retrySignature/, 'overlay 서명도 유지한다');
+  assert.match(
+    keyBody,
+    /if \(rawSvgCount > 0\) return null;/,
+    'RawSvg는 source-image key와 decoder cache 상태로 판정할 수 없으므로 재사용하지 않는다',
+  );
   // 판정 재료가 없으면 재사용하지 않는다 — 안전망을 없애는 쪽으로 작동해서는 안 된다.
   assert.match(
     keyBody,

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -83,8 +83,8 @@ pub struct LayerJsonOptions {
     ///
     /// 기본값은 `false` 이고, 그때 그림 op 의 payload(`mime`·`base64`)는 종전과 같다. 다만
     /// **JSON 전체가 종전과 같지는 않다** — 이 기능이 최상위 `imageBytes` 를 더하고 schema
-    /// minor 를 21 로 올렸다. 계약은 "기존 필드 불변 + 추가만"(additive)이지 바이트 동일이
-    /// 아니다.
+    /// minor 를 21 로 올렸다. 계약은 "기존 그림 payload 유지 + schema minor 상승과 새 메타데이터"
+    /// 이지 바이트 동일이나 모든 기존 필드 불변이 아니다.
     pub omit_image_bytes: bool,
 }
 

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -74,8 +74,17 @@ pub struct LayerJsonOptions {
     /// 그림 바이트를 base64 로 싣지 않는다.
     ///
     /// `sourceImageKey` 를 낼 수 있는 op 만 대상이다 — 키가 없으면 소비자가 바이트를 되찾을
-    /// 길이 없으므로 그 op 은 종전대로 base64 를 싣는다. 기본값이 `false` 라서 이 옵션을
-    /// 지정하지 않는 기존 호출부의 JSON 은 한 바이트도 달라지지 않는다.
+    /// 길이 없으므로 그 op 은 종전대로 base64 를 싣는다.
+    ///
+    /// 그래서 **한 문서 안에 생략된 op 과 인라인 op 이 섞일 수 있다.** 최상위 `imageBytes` 는
+    /// "이렇게 요청했다"는 **모드**이고, op 마다 실제로 생략됐는지는 `imageBytesOmitted` 가
+    /// 말한다 — 소비자는 후자를 봐야 한다. `imageBytes:"byKey"` 를 "모든 op 에 base64 가
+    /// 없다"로 읽으면 키 없는 합성 그림에서 어긋난다.
+    ///
+    /// 기본값은 `false` 이고, 그때 그림 op 의 payload(`mime`·`base64`)는 종전과 같다. 다만
+    /// **JSON 전체가 종전과 같지는 않다** — 이 기능이 최상위 `imageBytes` 를 더하고 schema
+    /// minor 를 21 로 올렸다. 계약은 "기존 필드 불변 + 추가만"(additive)이지 바이트 동일이
+    /// 아니다.
     pub omit_image_bytes: bool,
 }
 
@@ -110,8 +119,12 @@ impl PageLayerTree {
             json_escape(LAYER_TREE_SCHEMA.unit),
             json_escape(LAYER_TREE_SCHEMA.coordinate_system),
             json_escape(render_profile_str(self.profile)),
-            // [#3315] 그림 바이트가 op 안에 있는지(`inline`), 키로 따로 받아야 하는지(`byKey`).
-            // 소비자가 op 마다 `base64` 유무를 추측하지 않고 문서 단위로 판정할 수 있게 한다.
+            // [#3315] 이 문서를 어떤 **모드**로 요청했는지 — `inline` 이면 바이트가 op 안에,
+            // `byKey` 면 키로 따로 받는다.
+            //
+            // op 단위의 사실은 `imageBytesOmitted` 다. 키를 낼 수 없는 합성 그림은 `byKey`
+            // 모드에서도 base64 를 싣기 때문에, 이 값만 보고 "base64 가 하나도 없다"고 단정할
+            // 수 없다. 모드와 op 단위 사실을 한 필드에 겹쳐 담지 않는다.
             json_escape(if options.omit_image_bytes {
                 "byKey"
             } else {
@@ -4592,5 +4605,99 @@ mod tests {
             parsed["outputOptions"]["debugOverlay"].as_bool(),
             Some(true)
         );
+    }
+}
+
+#[cfg(test)]
+mod image_bytes_mode_tests {
+    //! Task #3315: `imageBytes` 최상위 값과 op 단위 `imageBytesOmitted` 의 관계를 못박는다.
+    //!
+    //! 생략은 신원 키를 낼 수 있는 op 만 대상이므로 **한 문서 안에 두 종류가 섞일 수 있다.**
+    //! 그 상태에서 최상위 값이 무엇을 뜻하는지가 열려 있었다 — 요청 모드인가, 모든 op 의 실제
+    //! 저장 방식인가. 여기서 **요청 모드**로 확정하고, 그러므로 소비자는 op 단위 표식을 봐야
+    //! 한다는 것을 고정한다.
+    //!
+    //! samples 전수에 키 없는 그림이 섞인 문서가 없어(전 표본 `cacheable:true`) 문서 단위
+    //! 테스트로는 이 상태를 만들 수 없다. 그래서 트리를 직접 조립한다.
+
+    use super::LayerJsonOptions;
+    use crate::paint::{LayerNode, PageLayerTree, PaintOp};
+    use crate::renderer::render_tree::{BoundingBox, ImageNode};
+    use serde_json::Value;
+
+    /// 키를 낼 수 있는 그림(`bin_data_id != 0`)과 낼 수 없는 합성 그림(`0`)을 함께 담은 트리.
+    fn mixed_tree() -> PageLayerTree {
+        let png = vec![0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
+        PageLayerTree::new(
+            120.0,
+            80.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 120.0, 80.0),
+                None,
+                vec![
+                    PaintOp::image(
+                        BoundingBox::new(0.0, 0.0, 10.0, 10.0),
+                        ImageNode::new(7, Some(png.clone())),
+                        None,
+                    ),
+                    PaintOp::image(
+                        BoundingBox::new(20.0, 0.0, 10.0, 10.0),
+                        ImageNode::new(0, Some(png)),
+                        None,
+                    ),
+                ],
+            ),
+        )
+    }
+
+    fn image_ops(json: &str) -> Vec<Value> {
+        let value: Value = serde_json::from_str(json).expect("valid layer JSON");
+        value["root"]["ops"]
+            .as_array()
+            .expect("ops")
+            .iter()
+            .filter(|op| op.get("type").and_then(Value::as_str) == Some("image"))
+            .cloned()
+            .collect()
+    }
+
+    #[test]
+    fn issue_3315_top_level_image_bytes_is_the_requested_mode_not_a_per_op_guarantee() {
+        let json = mixed_tree().to_json_with_options(LayerJsonOptions {
+            omit_image_bytes: true,
+        });
+        let ops = image_ops(&json);
+        assert_eq!(ops.len(), 2);
+
+        assert!(
+            json.contains("\"imageBytes\":\"byKey\""),
+            "요청한 모드를 최상위에 싣는다"
+        );
+
+        // 키가 있는 op — 생략됐고 키로 받아야 한다.
+        assert!(ops[0].get("base64").is_none(), "키 있는 op 은 생략된다");
+        assert_eq!(ops[0]["imageBytesOmitted"].as_bool(), Some(true));
+        assert!(ops[0].get("sourceImageKey").is_some());
+
+        // 키가 없는 합성 op — 되찾을 길이 없으므로 base64 를 유지한다.
+        assert!(
+            ops[1].get("base64").is_some(),
+            "키 없는 op 의 바이트를 빼면 소비자가 그 그림을 되찾을 방법이 없다"
+        );
+        assert!(
+            ops[1].get("imageBytesOmitted").is_none(),
+            "생략하지 않은 op 에 생략 표식을 달면 소비자가 헛되게 키를 찾는다"
+        );
+        assert!(ops[1].get("sourceImageKey").is_none());
+    }
+
+    #[test]
+    fn issue_3315_inline_mode_marks_no_op_as_omitted() {
+        let json = mixed_tree().to_json();
+        assert!(json.contains("\"imageBytes\":\"inline\""));
+        assert!(!json.contains("\"imageBytesOmitted\""));
+        for op in image_ops(&json) {
+            assert!(op.get("base64").is_some());
+        }
     }
 }

--- a/src/paint/resources.rs
+++ b/src/paint/resources.rs
@@ -478,6 +478,14 @@ mod tests {
             Some("bin:3:7:wmpng")
         );
 
+        // 밝기와 명암 중 하나만 바뀌어도 기존 bake 술어는 같은 variant를 발급한다.
+        image.brightness = 0;
+        image.contrast = 1;
+        assert_eq!(
+            source_image_key(3, &image).as_deref(),
+            Some("bin:3:7:wmpng")
+        );
+
         // JPEG 이 아니면 효과 필드는 별도 JSON 속성일 뿐 base64 payload는 바뀌지 않는다.
         image.data = Some(vec![0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a]);
         assert_eq!(source_image_key(3, &image).as_deref(), Some("bin:3:7:src"));

--- a/src/paint/schema.rs
+++ b/src/paint/schema.rs
@@ -16,7 +16,7 @@ pub struct LayerTreeSchema {
 pub const LAYER_TREE_SCHEMA: LayerTreeSchema = LayerTreeSchema {
     schema_version: 1,
     // 21: [#3315] 문서 단위 `imageBytes`("inline"|"byKey")와 그림 op 의 `imageBytesOmitted`.
-    //     생략은 opt-in 이라 기존 소비자가 받는 JSON 은 종전과 같다.
+    //     기본 inline 호출도 이 메타데이터와 minor 21을 받지만 그림 payload는 종전대로 유지한다.
     schema_minor_version: 21,
     resource_table_version: 1,
     resource_table_minor_version: 5,

--- a/src/renderer/image_resolver.rs
+++ b/src/renderer/image_resolver.rs
@@ -932,8 +932,8 @@ mod emitted_bytes_key_agreement_tests {
     //! - 키 조회 경로: `parse_source_image_key(key)` 로 되읽은 variant
     //!
     //! 그 둘이 어긋나면 워터마크 그림에 원본 JPEG 을 돌려주고도 성공한 것처럼 보인다. 여기서
-    //! 고정하는 것은 "키만으로 같은 바이트를 재현할 수 있다"는 계약이고, 변환 분기(BMP·PCX·
-    //! TIFF·회색 JPEG·워터마크 JPEG·변환 실패 되돌림)마다 확인한다.
+    //! 고정하는 것은 "키만으로 같은 바이트를 재현할 수 있다"는 계약이고, 이 테스트가 만드는
+    //! 변환 분기(BMP·TIFF·회색 JPEG·워터마크 JPEG·변환 실패 되돌림)마다 확인한다.
 
     use super::{emitted_image_bytes, is_watermark_image};
     use crate::model::image::ImageEffect;
@@ -1034,7 +1034,7 @@ mod emitted_bytes_key_agreement_tests {
     }
 
     #[test]
-    fn issue_3315_key_variant_reproduces_json_bytes_for_every_conversion_branch() {
+    fn issue_3315_key_variant_reproduces_json_bytes_for_covered_conversion_branches() {
         let png = encoded(4, 4, ImageFormat::Png, |_, _| [10, 20, 30]);
         let bmp = encoded(16, 16, ImageFormat::Bmp, |x, _| [x as u8 * 4, 90, 200]);
         let tiff = encoded(4, 4, ImageFormat::Tiff, |x, y| {

--- a/src/renderer/image_resolver.rs
+++ b/src/renderer/image_resolver.rs
@@ -685,10 +685,11 @@ fn decode_image_with_format_limited(
 #[cfg(test)]
 mod tests {
     use super::{
-        bmp_bytes_to_png_bytes, grayscale_jpeg_bytes_to_png_bytes, resolve_image_payload,
-        watermark_jpeg_bytes_to_hancom_baked_png_bytes, ConversionMemo, CONVERSIONS_RUN,
-        MAX_MEMO_BYTES, MAX_MEMO_ENTRIES,
+        bmp_bytes_to_png_bytes, emitted_image_bytes, grayscale_jpeg_bytes_to_png_bytes,
+        is_watermark_image, resolve_image_payload, watermark_jpeg_bytes_to_hancom_baked_png_bytes,
+        ConversionMemo, CONVERSIONS_RUN, MAX_MEMO_BYTES, MAX_MEMO_ENTRIES,
     };
+    use crate::model::image::ImageEffect;
     use crate::paint::ResolvedImageKind;
     use crate::renderer::render_tree::ImageNode;
     use image::{DynamicImage, ImageFormat, Rgb, RgbImage};
@@ -916,5 +917,239 @@ mod tests {
 
         assert!(bmp_bytes_to_png_bytes(&bmp).is_none());
         assert!(resolve_image_payload(&ImageNode::new(1, Some(bmp))).is_none());
+    }
+}
+
+#[cfg(test)]
+mod emitted_bytes_key_agreement_tests {
+    //! Task #3315: 신원 키의 variant 가 JSON 경로와 **같은 바이트**를 가리키는지 고정한다.
+    //!
+    //! `getPageLayerTree` 가 base64 를 생략하면 소비자는 `getSourceImageBytes(key)` 로 바이트를
+    //! 받는다. 두 경로는 `emitted_image_bytes` 를 함께 쓰므로 변환 사슬 자체는 갈라질 수 없지만,
+    //! **넘기는 술어가 다르다** —
+    //!
+    //! - JSON 경로: `is_watermark_image(image)` (ImageNode 를 직접 본다)
+    //! - 키 조회 경로: `parse_source_image_key(key)` 로 되읽은 variant
+    //!
+    //! 그 둘이 어긋나면 워터마크 그림에 원본 JPEG 을 돌려주고도 성공한 것처럼 보인다. 여기서
+    //! 고정하는 것은 "키만으로 같은 바이트를 재현할 수 있다"는 계약이고, 변환 분기(BMP·PCX·
+    //! TIFF·회색 JPEG·워터마크 JPEG·변환 실패 되돌림)마다 확인한다.
+
+    use super::{emitted_image_bytes, is_watermark_image};
+    use crate::model::image::ImageEffect;
+    use crate::paint::{parse_source_image_key, source_image_key};
+    use crate::renderer::render_tree::ImageNode;
+    use image::{DynamicImage, ImageFormat, Rgb, RgbImage};
+    use std::io::Cursor;
+
+    const EPOCH: u32 = 5;
+
+    fn encoded(
+        width: u32,
+        height: u32,
+        format: ImageFormat,
+        pixel: impl Fn(u32, u32) -> [u8; 3],
+    ) -> Vec<u8> {
+        let mut img = RgbImage::new(width, height);
+        for y in 0..height {
+            for x in 0..width {
+                img.put_pixel(x, y, Rgb(pixel(x, y)));
+            }
+        }
+        let mut out = Vec::new();
+        DynamicImage::ImageRgb8(img)
+            .write_to(&mut Cursor::new(&mut out), format)
+            .expect("encode");
+        out
+    }
+
+    fn gray_jpeg() -> Vec<u8> {
+        encoded(8, 8, ImageFormat::Jpeg, |x, y| {
+            let g = 150 + ((x + y) % 32) as u8;
+            [g, g, g]
+        })
+    }
+
+    fn color_jpeg() -> Vec<u8> {
+        encoded(8, 8, ImageFormat::Jpeg, |x, y| {
+            if (x + y) % 2 == 0 {
+                [220, 64, 64]
+            } else {
+                [64, 120, 220]
+            }
+        })
+    }
+
+    /// 워터마크 bake 가 **실제로 성공하는** JPEG.
+    ///
+    /// `watermark_jpeg_bytes_to_hancom_baked_png_bytes` 는 테두리의 85% 이상과 전체의 20% 이상이
+    /// 흰색에 가까워야 bake 한다. 단색·격자 같은 합성 이미지는 그 조건을 못 맞춰 `None` 이
+    /// 되고, 그러면 `wmpng` 와 `src` 두 분기가 같은 되돌림 결과로 수렴해 **variant 가 갈렸는지
+    /// 확인할 수 없다**. 그래서 흰 바탕에 작은 어두운 얼룩을 둔 모양으로 만든다.
+    fn watermark_shaped_jpeg() -> Vec<u8> {
+        encoded(48, 48, ImageFormat::Jpeg, |x, y| {
+            let center = (20..28).contains(&x) && (20..28).contains(&y);
+            if center {
+                [40, 40, 40]
+            } else {
+                [255, 255, 255]
+            }
+        })
+    }
+
+    /// 그림 하나에 대해 두 경로의 (mime, bytes) 가 같은지 확인한다.
+    fn assert_paths_agree(label: &str, image: &ImageNode) {
+        let data = image.data.as_deref().expect("바이트가 있어야 한다");
+
+        // JSON 경로가 쓰는 술어.
+        let (json_mime, json_bytes) = emitted_image_bytes(data, is_watermark_image(image));
+
+        // 키 조회 경로 — 키를 문자열로 내보내고 되읽어 variant 만으로 재현한다.
+        let key = source_image_key(EPOCH, image).expect("bin_data_id != 0 이면 키가 나온다");
+        let (epoch, bin_data_id, variant) =
+            parse_source_image_key(&key).expect("발급한 키는 되읽을 수 있어야 한다");
+        assert_eq!(epoch, EPOCH, "{label}: 키의 세대가 어긋난다");
+        assert_eq!(
+            bin_data_id, image.bin_data_id,
+            "{label}: 키의 id 가 어긋난다"
+        );
+        let (key_mime, key_bytes) = emitted_image_bytes(data, variant.bakes_watermark());
+
+        assert_eq!(
+            json_mime, key_mime,
+            "{label}: mime 이 갈렸다 — 소비자가 Blob 타입을 잘못 정한다 (key={key})"
+        );
+        assert_eq!(
+            json_bytes.as_ref(),
+            key_bytes.as_ref(),
+            "{label}: 바이트가 갈렸다 — 키로 받은 그림이 인라인 base64 와 다르다 (key={key})"
+        );
+    }
+
+    fn watermarked(mut image: ImageNode) -> ImageNode {
+        // `is_watermark_image` 가 참이 되는 최소 조건.
+        image.effect = ImageEffect::GrayScale;
+        image.brightness = 20;
+        image
+    }
+
+    #[test]
+    fn issue_3315_key_variant_reproduces_json_bytes_for_every_conversion_branch() {
+        let png = encoded(4, 4, ImageFormat::Png, |_, _| [10, 20, 30]);
+        let bmp = encoded(16, 16, ImageFormat::Bmp, |x, _| [x as u8 * 4, 90, 200]);
+        let tiff = encoded(4, 4, ImageFormat::Tiff, |x, y| {
+            [32 + x as u8, 96 + y as u8, 160]
+        });
+
+        let cases: Vec<(&str, ImageNode)> = vec![
+            // 변환 없음 — 원본 mime 그대로.
+            ("PNG", ImageNode::new(1, Some(png.clone()))),
+            // 브라우저가 못 읽는 포맷 → PNG 변환.
+            ("BMP", ImageNode::new(2, Some(bmp))),
+            ("TIFF", ImageNode::new(3, Some(tiff))),
+            // 회색 JPEG → PNG 정규화.
+            ("회색 JPEG", ImageNode::new(4, Some(gray_jpeg()))),
+            // 색 JPEG → 변환 없음(정규화 대상이 아니다).
+            ("색 JPEG", ImageNode::new(5, Some(color_jpeg()))),
+            // 워터마크 bake — variant 가 `wmpng` 로 갈리는 유일한 축. bake 가 실제로 성공하는
+            // 모양이어야 두 분기의 결과가 달라지고, 그래야 갈라짐을 잡을 수 있다.
+            (
+                "워터마크 JPEG(bake 성공)",
+                watermarked(ImageNode::new(6, Some(watermark_shaped_jpeg()))),
+            ),
+            // bake 술어는 참인데 bake 가 실패하는 모양 — 두 분기가 같은 되돌림으로 수렴한다.
+            (
+                "워터마크 술어 + bake 실패",
+                watermarked(ImageNode::new(7, Some(gray_jpeg()))),
+            ),
+            // JPEG 이 아니면 효과가 붙어도 bake 대상이 아니다 — variant 는 `src` 로 남아야 한다.
+            ("효과 붙은 PNG", watermarked(ImageNode::new(8, Some(png)))),
+        ];
+
+        for (label, image) in &cases {
+            assert_paths_agree(label, image);
+        }
+    }
+
+    /// bake 가 성공하는 모양에서 두 variant 의 바이트가 **실제로 다름**을 먼저 못박는다.
+    ///
+    /// 이 단언이 없으면 위 등가성 테스트가 "두 경로가 같다"를 확인하는 게 아니라 "두 분기가
+    /// 애초에 구분되지 않는다"를 확인하는 것일 수 있다.
+    #[test]
+    fn issue_3315_watermark_variant_actually_changes_the_bytes() {
+        let jpeg = watermark_shaped_jpeg();
+        let (baked_mime, baked) = emitted_image_bytes(&jpeg, true);
+        let (plain_mime, plain) = emitted_image_bytes(&jpeg, false);
+
+        assert_eq!(baked_mime, "image/png", "bake 결과는 PNG 다");
+        assert_ne!(
+            baked.as_ref(),
+            plain.as_ref(),
+            "이 모양에서 bake 가 돌지 않으면 variant 갈라짐을 검증할 수 없다"
+        );
+        // mime 은 갈리지 않는다 — 흰 바탕 그림은 비-워터마크 경로에서도 회색 JPEG 으로 판정돼
+        // PNG 로 정규화된다. 즉 이 축의 차이는 **바이트에만** 나타나므로, mime 만 비교하는
+        // 검증은 워터마크 갈라짐을 놓친다.
+        assert_eq!(plain_mime, "image/png");
+    }
+
+    #[test]
+    fn issue_3315_variant_marks_watermark_bake_only_for_jpeg() {
+        let png = encoded(4, 4, ImageFormat::Png, |_, _| [1, 2, 3]);
+        let jpeg = color_jpeg();
+
+        // JPEG + 효과 → wmpng
+        let key = source_image_key(EPOCH, &watermarked(ImageNode::new(1, Some(jpeg.clone()))))
+            .expect("키");
+        assert!(
+            key.ends_with(":wmpng"),
+            "JPEG 워터마크는 wmpng 여야 한다: {key}"
+        );
+
+        // JPEG + 효과 없음 → src
+        let key = source_image_key(EPOCH, &ImageNode::new(1, Some(jpeg))).expect("키");
+        assert!(
+            key.ends_with(":src"),
+            "효과 없는 JPEG 은 src 여야 한다: {key}"
+        );
+
+        // PNG + 효과 → src (bake 는 JPEG 경로에만 있다)
+        let key = source_image_key(EPOCH, &watermarked(ImageNode::new(1, Some(png)))).expect("키");
+        assert!(
+            key.ends_with(":src"),
+            "PNG 은 효과가 붙어도 bake 하지 않으므로 src 여야 한다: {key}"
+        );
+    }
+
+    /// 변환이 **실패**하면 두 경로가 함께 원본으로 되돌아가야 한다.
+    ///
+    /// 되돌림이 한쪽에만 있으면 키로 받은 바이트가 인라인과 달라진다. 헤더만 그럴듯한 손상
+    /// BMP 로 그 경로를 태운다 — `resolve_image_payload` 는 `None` 을 주고, 두 경로 모두
+    /// `emitted_image_bytes` 안에서 같은 되돌림을 밟는다.
+    #[test]
+    fn issue_3315_failed_conversion_falls_back_identically_on_both_paths() {
+        let mut broken_bmp = vec![0u8; 64];
+        broken_bmp[..2].copy_from_slice(b"BM");
+        let image = ImageNode::new(9, Some(broken_bmp.clone()));
+
+        let (mime, bytes) = emitted_image_bytes(&broken_bmp, is_watermark_image(&image));
+        assert_eq!(mime, "image/bmp", "변환 실패 시 감지한 원본 mime 을 쓴다");
+        assert_eq!(
+            bytes.as_ref(),
+            &broken_bmp[..],
+            "변환 실패 시 원본 바이트를 쓴다"
+        );
+
+        assert_paths_agree("손상 BMP", &image);
+    }
+
+    /// 신원 키를 낼 수 없는 그림은 키 조회로 되찾을 수 없다 — 그래서 생략 대상이 아니다.
+    #[test]
+    fn issue_3315_synthetic_images_have_no_key() {
+        let png = encoded(2, 2, ImageFormat::Png, |_, _| [0, 0, 0]);
+        // bin_data_id == 0 — 문서 BinData 에 대응하지 않는 합성 그림.
+        assert!(source_image_key(EPOCH, &ImageNode::new(0, Some(png))).is_none());
+        // 바이트를 내보내지 않는 op 도 키가 없다.
+        assert!(source_image_key(EPOCH, &ImageNode::new(1, None)).is_none());
     }
 }

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -720,9 +720,11 @@ impl HwpDocument {
 
     /// 페이지 레이어 트리를 profile 별로 반환한다.
     ///
-    /// [Task #3315] `omit_image_bytes` 를 `true` 로 주면 그림 base64 를 싣지 않고
-    /// `sourceImageKey` 만 남긴다 — 바이트는 `getSourceImageBytes(key)` 로 따로 받는다.
-    /// 인자를 생략하면(`undefined`) 종전과 똑같은 JSON 이므로 기존 호출부는 영향이 없다.
+    /// [Task #3315] `omit_image_bytes` 를 `true` 로 주면 `sourceImageKey`를 낼 수 있는 그림만
+    /// base64를 생략하고, 바이트는 `getSourceImageBytes(key)`로 따로 받는다. 키 없는 합성 그림은
+    /// 소비자가 되찾을 방법이 없으므로 같은 `byKey` 요청에서도 인라인 base64를 유지한다.
+    /// 인자를 생략하면(`undefined`) 그림 payload는 inline으로 유지하지만, schema minor 21과
+    /// 최상위 `imageBytes:"inline"` 메타데이터가 있으므로 JSON 전체의 byte identity는 보장하지 않는다.
     #[wasm_bindgen(js_name = getPageLayerTreeWithProfile)]
     pub fn get_page_layer_tree_with_profile(
         &self,

--- a/tests/issue_3315_image_bytes_by_key.rs
+++ b/tests/issue_3315_image_bytes_by_key.rs
@@ -4,7 +4,7 @@
 //! 바이트가 한 바이트라도 다르면 소비자는 같은 그림을 다르게 그린다. 그래서 여기서 고정하는
 //! 것은 크기 이득이 아니라 등가성이다 — 크기는 그 등가성이 성립한 뒤의 부산물이다.
 //!
-//! 변환 사슬(BMP/PCX/TIFF/회색 JPEG → PNG, JPEG 워터마크 bake)이 JSON 경로와 키 조회 경로에
+//! 변환 사슬(BMP/TIFF/회색 JPEG → PNG, JPEG 워터마크 bake)이 JSON 경로와 키 조회 경로에
 //! 각각 사본으로 존재하면 이 등가성이 조용히 깨진다. 두 경로가 같은 함수를 쓰는지 확인하는
 //! 자리도 이 테스트다.
 
@@ -139,10 +139,10 @@ fn issue_3315_omitted_ops_keep_mime_and_declare_omission() {
 /// 호출의 JSON 은 종전과 바이트 단위로 같지 않다. 이름만 보고 "schema 가 안 바뀌었다"고
 /// 판단하면 소비자 호환 결정을 잘못 내린다.
 ///
-/// 실제로 지켜야 하는 것은 둘이다 — ①그림 op 의 payload(`mime`·`base64`)가 종전과 같다
-/// ②추가된 것은 문서화된 두 필드뿐이고 생략 표식은 나타나지 않는다.
+/// 실제로 지켜야 하는 것은 둘이다 — ①기본 inline 경로의 그림 op payload(`mime`·`base64`)가
+/// 유지된다 ②schema minor 21과 `imageBytes:"inline"` 메타데이터가 선언되고 생략 표식은 없다.
 #[test]
-fn issue_3315_default_serialization_keeps_payloads_and_only_adds_documented_fields() {
+fn issue_3315_default_serialization_keeps_image_payloads_and_declares_schema_v21() {
     let doc = open_sample();
     let inline = inline_json(&doc);
     let value: Value = serde_json::from_str(&inline).expect("레이어 JSON 이 유효해야 한다");

--- a/tests/issue_3315_image_bytes_by_key.rs
+++ b/tests/issue_3315_image_bytes_by_key.rs
@@ -132,23 +132,48 @@ fn issue_3315_omitted_ops_keep_mime_and_declare_omission() {
     }
 }
 
+/// 기본 경로의 계약은 **additive** 다 — "바이트 동일"이 아니다.
+///
+/// 이 테스트의 이름은 원래 `..._is_byte_identical` 이었는데, 그 이름이 주장하는 성질은 **거짓**
+/// 이다. 이 기능이 최상위 `imageBytes` 를 더하고 schema minor 를 20 → 21 로 올렸으므로 기본
+/// 호출의 JSON 은 종전과 바이트 단위로 같지 않다. 이름만 보고 "schema 가 안 바뀌었다"고
+/// 판단하면 소비자 호환 결정을 잘못 내린다.
+///
+/// 실제로 지켜야 하는 것은 둘이다 — ①그림 op 의 payload(`mime`·`base64`)가 종전과 같다
+/// ②추가된 것은 문서화된 두 필드뿐이고 생략 표식은 나타나지 않는다.
 #[test]
-fn issue_3315_default_serialization_is_byte_identical() {
+fn issue_3315_default_serialization_keeps_payloads_and_only_adds_documented_fields() {
     let doc = open_sample();
     let inline = inline_json(&doc);
+    let value: Value = serde_json::from_str(&inline).expect("레이어 JSON 이 유효해야 한다");
 
-    assert!(
-        inline.contains("\"imageBytes\":\"inline\""),
-        "기본값은 인라인이다"
+    // 추가된 계약을 명시적으로 고정한다 — schema minor 를 올렸다는 사실이 계약의 일부다.
+    assert_eq!(
+        value["schemaMinorVersion"].as_u64(),
+        Some(u64::from(rhwp::paint::PAGE_LAYER_TREE_SCHEMA_MINOR_VERSION)),
+        "schema minor 는 상수와 같아야 한다"
+    );
+    // 컴파일 시점 하한 — 이 기능은 minor 21 에서 들어왔다. 내려가면 소비자 협상이 깨진다.
+    // (런타임 `assert!` 는 상수라 clippy 가 거부한다 — const 단언이 더 이르게 잡는다.)
+    const _: () = assert!(rhwp::paint::PAGE_LAYER_TREE_SCHEMA_MINOR_VERSION >= 21);
+    assert_eq!(
+        value["imageBytes"].as_str(),
+        Some("inline"),
+        "옵션을 지정하지 않은 호출의 모드는 inline 이다"
     );
     assert!(
         !inline.contains("\"imageBytesOmitted\""),
         "기본 경로에는 생략 표식이 없어야 한다"
     );
+
     for op in image_ops(&inline) {
         assert!(
             op.get("base64").is_some(),
             "옵션을 켜지 않은 호출은 종전대로 바이트를 싣는다"
+        );
+        assert!(
+            op.get("mime").and_then(Value::as_str).is_some(),
+            "payload 의 mime 도 종전대로다"
         );
     }
 }


### PR DESCRIPTION
## 현재 통합 범위

- [#3662](https://github.com/edwardkim/rhwp/pull/3662) — #3315 이미지 바이트 계약·변환 경로 회귀 가드 (`lpaiu-cs`)
- [#3672](https://github.com/edwardkim/rhwp/pull/3672) — 원 기능 커밋은 최신 `devel`의 [merge commit `c588c8240`](https://github.com/edwardkim/rhwp/commit/c588c8240331a181271c6551e124aa1ff770d900)으로 이미 반영됐다. 이 PR에는 그 검토에서 확인한 RawSvg 재렌더 안전 보정만 남긴다.

원 [#3670](https://github.com/edwardkim/rhwp/pull/3670)의 기능도 [merge commit `b2b5c4492`](https://github.com/edwardkim/rhwp/commit/b2b5c4492)으로 현재 base에 포함돼 있다. 따라서 이 PR은 #3670·#3672의 기여자 기능을 중복 적용하지 않는다. 다만 최종 head에서 #3648의 공개 지원 상태·`replaceAll` mutation guard를 다시 검증하는 maintainer 회귀 보정은 유지한다.

최신 `devel` (`c588c8240`) 위에서 #3662의 기능 커밋만 `-x`로 누적 적용했다. 원 저자 정보는 보존했고, 원 PR의 오래된 `devel` 병합 커밋은 가져오지 않았다. 이 PR이 병합되면 열린 원 PR #3662만 통합 PR로 대체 처리한다.

## 검토 보정

- RawSvg 차트/OLE는 source-image key와 브라우저 decode cache 상태만으로 재렌더 준비를 증명할 수 없다. `rawSvgCount > 0`이면 retry key를 재사용하지 않아 timer/fallback 안전망을 다시 무장한다. 일반 raster 이미지의 키 기반 최적화는 유지한다.
- `replaceAll` 동명이인 가드는 알려진 문자열 수신자만 비뮤테이션으로 제외한다. 새 raw-document 별칭은 분류 실패로 드러난다.
- #3315 공개 JSON 계약의 설명을 실제 동작에 맞췄다. 기본 호출은 그림 payload를 유지하지만 schema minor 21과 `imageBytes:"inline"` 메타데이터를 포함하며, `byKey`에서도 key 없는 합성 그림은 인라인으로 남는다.

## 로컬 검증

- `cargo fmt --check`
- `cargo test --profile release-test --test issue_3315_image_bytes_by_key` — 7 passed
- `cargo test --profile release-test --tests` — exit 0
- `cargo clippy --profile release-test --all-targets -- -D warnings`
- native-Skia: 라이브러리 58 passed, placeholder 2 passed, direct PDF 4 passed
- `cargo test --profile release-test --doc` — 4 passed, 2 ignored
- `wasm-pack build --target web --out-dir pkg` — exit 0
- Studio: `npx tsc --noEmit`, `npm test` — 716 passed
- headless Chrome E2E: hwpctl 지원 상태/Undo 계약, RawSvg 400ms 첫 화면, 차트 문서 교체·동일 문서 `refreshPages()` 비공백

이전 code candidate `22f130c80`의 full CI는 모두 성공했다. 그러나 그 사이 #3672가 최신 base에 병합됐으므로, 새 head `71ccfeaaa`의 CI를 최종 merge 근거로 다시 확인한다.

## 이슈 정책

#3315는 Track 1–4 umbrella이므로 closing keyword를 사용하지 않으며 병합 뒤에도 열어 둔다. #3648은 현재 `devel`의 #3670 병합과 이 PR의 최종 CI를 함께 대조한 뒤 수동으로 종결한다.
