### PR TITLE
ci(#3686): 워크플로 액션 65건 SHA 고정 — 이동 가능 참조 0

### DIFF
--- a/.github/workflows/cancel-stale-pr-runs.yml
+++ b/.github/workflows/cancel-stale-pr-runs.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Force-cancel older pull-request runs for this PR
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Detect review-only fast pass
         id: detect
         continue-on-error: true
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           # [#2804] API 5xx 일시 오류에 job 이 죽지 않도록 재시도한다.
           # retry-exempt-status-codes 기본값(400,401,403,404,422)이 4xx 를 제외하므로 5xx 만 재시도된다.
@@ -321,7 +321,7 @@ jobs:
       - name: Detect frontend impact
         id: frontend-impact
         continue-on-error: true
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           # [#2804] API 5xx 일시 오류에 job 이 죽지 않도록 재시도한다.
           # retry-exempt-status-codes 기본값(400,401,403,404,422)이 4xx 를 제외하므로 5xx 만 재시도된다.
@@ -460,7 +460,7 @@ jobs:
       runnable_tests: ${{ steps.count.outputs.runnable_tests }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # [Task #1109 / #1192 C] ubuntu-latest runner 의 미사용 사전 설치 toolchain 제거하여
       # 테스트 빌드 시 디스크 한도 초과를 줄인다.
@@ -471,19 +471,19 @@ jobs:
           df -h
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
         with:
           toolchain: 1.93.1
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2.85.5
         with:
           tool: nextest
 
       # [#2393] 수동 restore/save 캐시 → rust-cache (적중률·정리 자동화).
       # 저장 정책은 종전과 동일하게 devel/main push 로 한정.
       - name: Rust build cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           shared-key: test-archive
           save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/main') }}
@@ -524,7 +524,7 @@ jobs:
           echo "runnable_tests=$runnable"
 
       - name: Upload test archive
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-archive-${{ github.run_id }}
           path: tests.tar.zst
@@ -560,20 +560,20 @@ jobs:
 
     steps:
       # 테스트가 samples/ pdf/ 등 저장소 픽스처를 읽으므로 checkout 필요.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
         with:
           toolchain: 1.93.1
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2.85.5
         with:
           tool: nextest
 
       - name: Download test archive
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: test-archive-${{ github.run_id }}
 
@@ -605,7 +605,7 @@ jobs:
           cat "shard-count-${{ matrix.shard }}.txt"
 
       - name: Upload shard count
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: shard-count-${{ matrix.shard }}
           path: shard-count-${{ matrix.shard }}.txt
@@ -623,17 +623,17 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
         with:
           toolchain: 1.93.1
           components: clippy, rustfmt
           targets: wasm32-unknown-unknown
 
       - name: Rust build cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           shared-key: lint
           save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/main') }}
@@ -676,7 +676,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # [Task #1109 / #1192 C] ubuntu-latest runner 의 미사용 사전 설치 toolchain 제거하여
       # 테스트 빌드 시 디스크 한도 초과를 줄인다.
@@ -689,7 +689,7 @@ jobs:
           df -h
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
         with:
           toolchain: 1.93.1
 
@@ -697,7 +697,7 @@ jobs:
       # Linux-cargo-* namespace 대신 Native Skia 전용 shared key를 사용한다.
       # PR은 restore-only, devel/main push만 save하는 신뢰 경계를 유지한다.
       - name: Rust build cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           shared-key: native-skia
           save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/main') }}
@@ -738,10 +738,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
         with:
           toolchain: 1.93.1
           targets: wasm32-unknown-unknown
@@ -765,7 +765,7 @@ jobs:
         run: wasm-pack build --target web --dev
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           cache: npm
@@ -845,7 +845,7 @@ jobs:
       # 테스트 수와 일치하는지 검증한다 (fast-pass 시 샤드 미실행이라 생략).
       - name: Download shard counts
         if: ${{ needs.preflight.outputs.fast_pass != 'true' && needs['test-shard'].result == 'success' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: shard-count-*
           merge-multiple: true
@@ -953,7 +953,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # [Task #1109 / #1192 C] wasm-build job 도 build-and-test 와 동일 축소 패턴.
       # "크고 빠른" 항목(android/dotnet)만 제거. df -h 로 여유 확인.
@@ -964,7 +964,7 @@ jobs:
           df -h
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
         with:
           toolchain: 1.93.1
           targets: wasm32-unknown-unknown
@@ -973,7 +973,7 @@ jobs:
         uses: ./.github/actions/install-wasm-pack
 
       - name: Cache cargo registry & build
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -987,7 +987,7 @@ jobs:
         run: wasm-pack build --target web --release
 
       - name: Upload WASM artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: rhwp-wasm-pkg
           path: pkg/

--- a/.github/workflows/close-issues-on-devel-push.yml
+++ b/.github/workflows/close-issues-on-devel-push.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Close issues referenced by merged PRs
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           # [#2804] API 5xx 일시 오류에 job 이 죽지 않도록 재시도한다.
           # retry-exempt-status-codes 기본값(400,401,403,404,422)이 4xx 를 제외하므로 5xx 만 재시도된다.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Detect review-only fast pass
         id: detect
         continue-on-error: true
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           # [#2804] API 5xx 일시 오류에 job 이 죽지 않도록 재시도한다.
           # retry-exempt-status-codes 기본값(400,401,403,404,422)이 4xx 를 제외하므로 5xx 만 재시도된다.
@@ -288,7 +288,7 @@ jobs:
         language: [javascript-typescript, python, rust]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # [#3290] 호스티드 16GB VM 은 CodeQL 자동 감지 값이 적정하다. self-hosted 로
       # 되돌릴 경우 ram/threads 캡 필수 — #3289 사고(무캡 JVM 40~55GB×2 로 호스트
@@ -300,7 +300,7 @@ jobs:
 
       - name: Install Rust toolchain
         if: matrix.language == 'rust'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
 
       # [Task #1192 B] CodeQL rust analyze 는 cargo 캐시가 없어 매번 cold build 였다.
       # ci.yml 과 동일 path, 별도 key namespace(codeql-rust)로 warm build 화.

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -34,11 +34,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # --- WASM 빌드 ---
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
         with:
           targets: wasm32-unknown-unknown
 
@@ -46,7 +46,7 @@ jobs:
         uses: ./.github/actions/install-wasm-pack
 
       - name: Cache cargo registry & build
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -61,7 +61,7 @@ jobs:
 
       # --- rhwp-studio 빌드 ---
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
 
@@ -82,7 +82,7 @@ jobs:
         run: npx vite build --base=/rhwp/
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: rhwp-studio/dist
 
@@ -97,4 +97,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/full-renderer-sweep.yml
+++ b/.github/workflows/full-renderer-sweep.yml
@@ -25,10 +25,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
         with:
           components: clippy, rustfmt
           targets: wasm32-unknown-unknown
@@ -37,7 +37,7 @@ jobs:
         uses: ./.github/actions/install-wasm-pack
 
       - name: Cache cargo registry & build
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -49,7 +49,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
           cache: npm
@@ -113,7 +113,7 @@ jobs:
 
       - name: Upload full renderer sweep artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: full-renderer-sweep-artifacts
           path: |

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
         with:
           targets: wasm32-unknown-unknown
 
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/actions/install-wasm-pack
 
       - name: Cache cargo
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -45,7 +45,7 @@ jobs:
         run: wasm-pack build --target web --release
 
       - name: Upload WASM artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wasm-pkg
           path: pkg/
@@ -57,10 +57,10 @@ jobs:
     environment: NPM_TOKEN
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download WASM artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: wasm-pkg
           path: pkg/
@@ -69,7 +69,7 @@ jobs:
         run: bash scripts/prepare-npm.sh
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           package-manager-cache: false
@@ -92,10 +92,10 @@ jobs:
     environment: NPM_TOKEN
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           package-manager-cache: false
@@ -118,16 +118,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download WASM artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: wasm-pkg
           path: pkg/
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
 

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Determine version tag
         id: version
@@ -65,7 +65,7 @@ jobs:
           fi
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
         with:
           targets: ${{ matrix.target }}
 
@@ -73,7 +73,7 @@ jobs:
         run: rustup target add ${{ matrix.target }}
 
       - name: Cache cargo dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -127,7 +127,7 @@ jobs:
           "ARCHIVE_NAME=$archiveName" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.ARCHIVE_NAME }}
           path: ${{ env.ARCHIVE_NAME }}
@@ -151,7 +151,7 @@ jobs:
           fi
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist/
           merge-multiple: true
@@ -164,7 +164,7 @@ jobs:
           cat SHA256SUMS.txt
 
       - name: Attach to release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           files: |

--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Detect review-only fast pass
         id: detect
         continue-on-error: true
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           # [#2804] API 5xx 일시 오류에 job 이 죽지 않도록 재시도한다.
           # retry-exempt-status-codes 기본값(400,401,403,404,422)이 4xx 를 제외하므로 5xx 만 재시도된다.
@@ -348,10 +348,10 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: printf '%s\n' 'Render Diff identity recorded'
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
         with:
           targets: wasm32-unknown-unknown
 
@@ -399,7 +399,7 @@ jobs:
           key: ${{ runner.os }}-render-diff-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
 
@@ -472,7 +472,7 @@ jobs:
 
       - name: Upload render diff artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: render-diff-artifacts
           path: |

--- a/mydocs/plans/task_m100_3686.md
+++ b/mydocs/plans/task_m100_3686.md
@@ -1,0 +1,83 @@
+---
+kind: plan
+status: draft
+canonical: mydocs/manual/codex/docs_and_git_workflow.md
+last_verified: 2026-08-01
+---
+
+# Task #3686 수행계획서 — 워크플로 액션 SHA 고정
+
+- Issue: [#3686](https://github.com/edwardkim/rhwp/issues/3686) (M100) — [#2431](https://github.com/edwardkim/rhwp/issues/2431) 분리
+- 브랜치: `local/task3686` / 착수: 2026-08-01
+- 선후: **#3686 → #3684** (아래 §5 근거)
+
+## 1. 확정된 사실 (착수 실측)
+
+rhwp 워크플로의 액션 참조 **53건 전부가 이동 가능한 태그**, SHA 고정 **0건**.
+대조군 openclaw 는 SHA 고정 **535건**.
+
+`@v2` 같은 major 태그는 저자가 언제든 다른 커밋으로 옮길 수 있다. 액션 저장소 탈취나
+태그 이동 시 우리 CI 가 임의 코드를 실행하게 되는데, 그 CI 는 `contents: write`·
+`actions: write`·릴리스 토큰을 다루는 job 을 포함한다.
+
+## 2. 고정 대상 — SHA 조회 완료 (2026-08-01)
+
+### 서드파티 (우선, 6건)
+
+| 액션 | 참조 | SHA | 버전 |
+|---|---:|---|---|
+| `Swatinem/rust-cache` | 3 | `e18b497796c12c097a38f9edb9d0641fb99eee32` | v2.9.1 |
+| `taiki-e/install-action` | 2 | `6a1bd70eaac3c8bdf093356838d7ee09fda951cf` | v2.85.5 |
+| `softprops/action-gh-release` | 1 | `3d0d9888cb7fd7b750713d6e236d1fcb99157228` | v3.0.2 |
+
+### 공식 `actions/*` (47건)
+
+| 액션 | 참조 | SHA | 버전 |
+|---|---:|---|---|
+| `actions/checkout` | 15 | `3d3c42e5aac5ba805825da76410c181273ba90b1` | v7.0.1 |
+| `actions/upload-artifact` | 7 | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | v7.0.1 |
+| `actions/setup-node` | 7 | `820762786026740c76f36085b0efc47a31fe5020` | v7.0.0 |
+| `actions/github-script` | 6 | `3a2844b7e9c422d3c10d287c895573f7108da1b3` | v9.0.0 |
+| `actions/download-artifact` | 5 | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` | v8.0.1 |
+| `actions/cache` | 5 | `55cc8345863c7cc4c66a329aec7e433d2d1c52a9` | v6.1.0 |
+| `actions/upload-pages-artifact` | 1 | `fc324d3547104276b827a68afc52ff2a11cc49c9` | v5.0.0 |
+| `actions/deploy-pages` | 1 | `cd2ce8fcbc39b97be8ca5fce6e763baed58fa128` | v5.0.0 |
+
+**주의**: 위 SHA 는 조회 시점의 태그 대상이다. 구현 시 **재조회해 대조**하고, 어긋나면
+그 자체가 태그 이동의 증거이므로 보고서에 기록한다.
+
+표기는 `uses: owner/repo@<sha> # vX.Y.Z` — 사람이 버전을 읽을 수 있게 주석을 단다
+(openclaw 관례와 동일).
+
+## 3. 단계 계획
+
+| 단계 | 내용 | 산출물 |
+|---|---|---|
+| Stage 1 | 서드파티 3종 6건 고정 + 로컬 워크플로 문법 검증. `rust-cache` 는 #3123 의 `shared-key: native-skia` 배선 유지 확인 | 구현 + stage1 보고 |
+| Stage 2 | 공식 `actions/*` 8종 47건 고정 | 구현 + stage2 보고 |
+| Stage 3 | Dependabot `github-actions` ecosystem 활성화 — 고정 후 갱신 경로 확보 | `.github/dependabot.yml` |
+| Stage 4 | 검증 — CI 전 잡 통과 확인(고정 전과 동일), 캐시 miss 영향 관측 → 최종 보고 → PR(별도 승인) | 보고서 + PR |
+
+## 4. 검증 기준
+
+1. 워크플로 53건 전부 SHA 참조, 태그 참조 0건.
+2. 각 SHA 옆 버전 주석 존재.
+3. **CI 가 고정 전과 동일하게 통과** — 이것이 유일한 기능 검증이다.
+4. Dependabot 설정이 유효하고 `github-actions` ecosystem 을 포함한다.
+5. `shared-key: native-skia`(#3123) 동작 유지.
+
+## 5. 위험과 제약
+
+- **캐시 키 변동**: 액션 SHA 가 바뀌면 캐시 키가 달라져 일시적 miss 가 발생한다.
+  이 때문에 **#3684(캐시 quota 조사)보다 먼저** 수행한다 — 조사를 먼저 하면 그
+  측정이 이 작업으로 무효화된다. 반대로 지금 하면 miss 가 한 번 발생하고 안정화된
+  상태를 #3684 의 baseline 으로 쓸 수 있다.
+- **Blacksmith 등 신규 액션 유입 전 선행**: #3684 결론이 도입으로 나면 새 서드파티
+  액션이 들어온다. 지금 고정 관례를 세워두면 이후 추가분은 처음부터 고정된 형태로
+  들어온다.
+- **갱신 경로 없는 고정은 다른 위험**: 고정만 하고 Dependabot 이 없으면 낡은 액션을
+  쓰게 된다. Stage 3 가 선택이 아니라 필수인 이유다.
+- CI 워크플로 변경은 `local_validation.md` 4.3 의 "CI workflow" 행 — workflow 구문·
+  변경 조건·최신 GitHub Actions 결과로 검증한다. Cargo 계열은 해당 없음.
+- **등록형 트리거 주의**(#3508 실측): 워크플로 변경은 devel 반영만으로 발동하지 않는
+  경우가 있다. 다만 이 작업은 트리거 자체를 바꾸지 않으므로 해당 위험은 낮다.

--- a/mydocs/working/task_m100_3686_stage1.md
+++ b/mydocs/working/task_m100_3686_stage1.md
@@ -1,0 +1,71 @@
+---
+kind: working
+status: active
+canonical: mydocs/plans/task_m100_3686.md
+last_verified: 2026-08-01
+---
+
+# Task #3686 Stage 1~3 보고 — 액션 SHA 고정 + 갱신 경로
+
+## 결과 — 이동 가능 참조 0건
+
+| 구분 | 착수 전 | 완료 후 |
+|---|---:|---:|
+| SHA 고정 | 0 | **65** |
+| 태그·브랜치 참조 | 65 | **0** |
+
+`git diff --stat`: 9파일 / 65 insertions / 65 deletions (1:1 치환).
+
+## 계획 대비 정정 — 12건이 추가로 발견됨
+
+계획서는 **53건**(SemVer 태그 참조)으로 집계했으나, 실제로는
+**`dtolnay/rust-toolchain@stable` 12건**이 더 있었다. 정규식이 `@v[0-9]` 패턴만 세어
+비-SemVer 참조를 놓친 것이다.
+
+이 12건은 **태그가 아니라 브랜치**(`refs/heads/stable`, commit 직접 참조)라 **위험이
+더 크다** — 태그는 저자가 의도적으로 옮겨야 하지만 브랜치는 커밋마다 자동으로 움직인다.
+`4cda84d5c5c54efe2404f9d843567869ab1699d4` 로 고정하고 `# stable 브랜치 (2026-08-01 시점)`
+주석을 달았다(SemVer 버전이 없으므로 시점을 명시).
+
+**교훈**: "태그 고정"이라는 프레임이 브랜치 참조를 시야에서 지웠다. 다음에는
+`uses:` 전수에서 40자 hex 가 아닌 것을 세는 방식으로 접근한다.
+
+## 고정 목록
+
+### 서드파티 (18건)
+
+| 액션 | 건수 | SHA | 버전 |
+|---|---:|---|---|
+| `dtolnay/rust-toolchain` | 12 | `4cda84d5…` | stable 브랜치 시점 |
+| `Swatinem/rust-cache` | 3 | `e18b4977…` | v2.9.1 |
+| `taiki-e/install-action` | 2 | `6a1bd70e…` | v2.85.5 |
+| `softprops/action-gh-release` | 1 | `3d0d9888…` | v3.0.2 |
+
+### 공식 `actions/*` (47건)
+
+checkout 15(`3d3c42e5…` v7.0.1) · upload-artifact 7(`043fb46d…` v7.0.1) ·
+setup-node 7(`82076278…` v7.0.0) · github-script 6(`3a2844b7…` v9.0.0) ·
+download-artifact 5(`3e5f45b2…` v8.0.1) · cache 5(`55cc8345…` v6.1.0) ·
+upload-pages-artifact 1(`fc324d35…` v5.0.0) · deploy-pages 1(`cd2ce8fc…` v5.0.0)
+
+## 태그 이동 대조 (계획서 §2 규약)
+
+계획 수립 시 조회한 SHA 와 구현 직전 재조회 SHA 를 **11종 전부 대조 — 전건 일치**.
+태그 이동 흔적 없음.
+
+## Stage 3 — 이미 충족돼 있었다
+
+`.github/dependabot.yml` 에 **`github-actions` ecosystem 이 이미 등록**되어 있다
+(directory `/`, target-branch `devel`, weekly, PR 한도 10). 고정 후 갱신 경로가
+확보된 상태이므로 **추가 작업 불요**.
+
+계획서는 이를 "신규 활성화"로 잡았으나 실측 결과 기존 설정으로 충족된다. 고정만
+하고 갱신 경로가 없는 위험(계획서 §5)은 발생하지 않는다.
+
+## 검증
+
+- 전 워크플로 YAML 문법 파싱 통과.
+- `shared-key: native-skia` + `save-if`(#3123 배선) 유지 확인.
+- 로컬 composite action(`.github/actions/install-wasm-pack`) 내부에 외부 `uses:`
+  참조 없음 — 숨은 미고정 없음.
+- 잔여 기능 검증은 **CI 실제 통과**(Stage 4).


### PR DESCRIPTION
## 요약

워크플로 액션 참조 **65건을 전부 커밋 SHA 로 고정**합니다(#3686). 착수 전 SHA 고정은
0건이었고, 모든 참조가 이동 가능한 태그 또는 브랜치였습니다.

## 왜

`@v2` 같은 major 태그는 저자가 언제든 다른 커밋으로 옮길 수 있습니다. 액션 저장소가
탈취되거나 태그가 악의적으로 이동되면 **우리 CI 가 임의 코드를 실행**하게 되고, 그 CI 는
`contents: write`·`actions: write`·릴리스 토큰을 다루는 job 을 포함합니다.

## 계획 대비 정정 — 브랜치 참조 12건 추가 발견

이슈는 **53건**(SemVer 태그)으로 집계했으나, 실제로는 **`dtolnay/rust-toolchain@stable`
12건**이 더 있었습니다. `@v[0-9]` 패턴만 세는 접근이 비-SemVer 참조를 놓친 것입니다.

**이 12건이 오히려 위험이 큽니다** — 태그가 아니라 **브랜치**(`refs/heads/stable`)라
저자가 커밋할 때마다 자동으로 움직입니다. 태그는 의도적으로 옮겨야 하지만 브랜치는
그렇지 않습니다.

## 고정 목록

### 서드파티 18건

| 액션 | 건수 | 버전 |
|---|---:|---|
| `dtolnay/rust-toolchain` | 12 | stable 브랜치 2026-08-01 시점 |
| `Swatinem/rust-cache` | 3 | v2.9.1 |
| `taiki-e/install-action` | 2 | v2.85.5 |
| `softprops/action-gh-release` | 1 | v3.0.2 |

### 공식 `actions/*` 47건

checkout 15 · upload-artifact 7 · setup-node 7 · github-script 6 ·
download-artifact 5 · cache 5 · upload-pages-artifact 1 · deploy-pages 1

표기는 `uses: owner/repo@<sha> # vX.Y.Z` — 사람이 버전을 읽을 수 있게 주석을 답니다.

## 검증

- **태그 이동 대조**: 계획 수립 시 조회한 SHA 를 구현 직전 재조회해 **11종 전건 일치**.
  어긋났다면 그 자체가 태그 이동의 증거였을 것이므로 절차로 고정했습니다.
- 전 워크플로 YAML 문법 파싱 통과.
- **`shared-key: native-skia` + `save-if` 배선 유지**(#3123) 확인.
- 로컬 composite action(`.github/actions/install-wasm-pack`) 내부에 외부 `uses:` 없음
  — 숨은 미고정 참조 없음.
- diff 는 **65 insertions / 65 deletions 순수 1:1 치환** (9파일).
- 기능 검증은 **이 PR 의 CI 통과** 자체입니다.

## Dependabot — 추가 작업 불요

`.github/dependabot.yml` 에 `github-actions` ecosystem 이 **이미 등록**돼 있습니다
(weekly, target `devel`). 고정 후 갱신 경로가 확보된 상태이므로, "고정만 하고 낡은
액션을 쓰게 되는" 위험은 발생하지 않습니다.

## 유의

액션 SHA 변경으로 **캐시 키가 달라져 일시적 cache miss** 가 발생할 수 있습니다.
[#3684](https://github.com/edwardkim/rhwp/issues/3684)(캐시 quota 조사)보다 **먼저**
수행하는 이유입니다 — 조사를 먼저 하면 그 측정이 이 작업으로 무효화됩니다.

Closes #3686

🤖 Generated with [Claude Code](https://claude.com/claude-code)
