### PR TITLE
feat(#3699): nextCall — isError 에 기계가 따라할 교정 호출 동봉 (내성 P4) — #3698 적층

### DIFF
--- a/mydocs/report/task_m100_3694/README.md
+++ b/mydocs/report/task_m100_3694/README.md
@@ -1,0 +1,29 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_3694/README.md
+last_verified: 2026-08-02
+---
+
+# #3694 처리 기록 — did-you-mean (내성 P1, #3630 1호)
+
+## 구현
+
+- CLI: 알 수 없는 명령 exit 2 stderr 에 `힌트: 가장 가까운 명령은 '…' 입니다` 1줄.
+  후보는 **capabilities 명령 목록 단일 출처** — `show_capabilities` 의 commands vec 을
+  `capabilities_command_entries()` 로 승격해 자기서술과 힌트가 같은 원천을 쓴다.
+- 판정: 의존성 없는 소형 레벤슈타인 + 임계(길이/3, 1~3) 초과 시 무제안 — **오제안 0
+  원칙**(엉뚱한 제안은 경량 에이전트를 더 깊은 루프로 밀어넣는다).
+- MCP: 미지 도구 isError 텍스트를 `{"error":"<기존 원문>","didYouMean":[…]}` 로 승격 —
+  error 필드가 원문을 담아 하위호환, 후보는 tool_defs 실존 도구만.
+
+## 실측 (evidence.txt 원문 동봉)
+
+- `rhwp exprot-svg` → exit 2 + `힌트: 가장 가까운 명령은 'export-svg' 입니다`
+- MCP `hwp_serch` → `{"error":"알 수 없는 도구: hwp_serch","didYouMean":["hwp_search"]}`
+
+## 검증
+
+- 신규 `did_you_mean_contract` 3건 green (오타 힌트+exit 2 유지 / 헛소리 무제안 /
+  MCP 구조화·하위호환), `cli_json_contract` 22건·`mcp_server_contract` 6건 무회귀,
+  clippy 0, rustfmt clean. commands vec 승격은 동작 무변경(자기서술 22건이 가드).

--- a/mydocs/report/task_m100_3694/evidence.txt
+++ b/mydocs/report/task_m100_3694/evidence.txt
@@ -1,0 +1,10 @@
+$ rhwp exprot-svg doc.hwp ; echo exit=$?
+오류: 알 수 없는 명령입니다 - exprot-svg
+힌트: 가장 가까운 명령은 'export-svg' 입니다
+rhwp v0.8.2
+사용법: rhwp <명령> [옵션]
+'rhwp --help'로 자세한 사용법을 확인하세요.
+exit=2
+
+# MCP: tools/call name="hwp_serch" (오타)
+{"id":1,"jsonrpc":"2.0","result":{"content":[{"text":"{\"didYouMean\":[\"hwp_search\"],\"error\":\"알 수 없는 도구: hwp_serch\"}","type":"text"}],"isError":true}}

--- a/mydocs/report/task_m100_3699/README.md
+++ b/mydocs/report/task_m100_3699/README.md
@@ -1,0 +1,26 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_3699/README.md
+last_verified: 2026-08-02
+---
+
+# #3699 처리 기록 — nextCall (내성 P4, #3630 2호)
+
+## 구현
+
+- `tool_error_with_next(message, name, args, why)` — `{"error":"<원문>","nextCall":{name,arguments,why}}`
+  구조화. error 필드 원문 보존 = 하위호환(텍스트 파싱 소비자 무해).
+- 적용 2계열: ① 닫힌/모르는 핸들 **8개 사이트 전부**(세션 도구) → `hwp_open` 교정
+  ② 미지 도구 → didYouMean 최근접이 있으면 그 도구를 nextCall 로 병기.
+- nextCall.name 은 실존 도구만 — 계약 테스트가 capabilities --mcp 선언과 대조 고정.
+
+## 실측 (evidence.txt 원문)
+
+닫힌 핸들 fill 호출 → `{"error":"열려 있지 않은 핸들: doc-999 …","nextCall":{"name":"hwp_open",
+"arguments":{"path":"<열 문서 경로>"},"why":"핸들이 없거나 만료 — …재발급한 뒤 재시도"}}`
+
+## 검증
+
+- 신규 `mcp_next_call_contract` 3건 green (닫힌 핸들→hwp_open / 미지 도구 nextCall
+  실존 대조 / close 경로) · did_you_mean 3·server 6·session_edit 5 무회귀 · clippy 0

--- a/mydocs/report/task_m100_3699/evidence.txt
+++ b/mydocs/report/task_m100_3699/evidence.txt
@@ -1,0 +1,2 @@
+# 닫힌 핸들 → nextCall 교정 (라이브)
+{"id":1,"jsonrpc":"2.0","result":{"content":[{"text":"{\"error\":\"열려 있지 않은 핸들: doc-999 (hwp_open 먼저)\",\"nextCall\":{\"arguments\":{\"path\":\"<열 문서 경로>\"},\"name\":\"hwp_open\",\"why\":\"핸들이 없거나 만료 — hwp_open 으로 docId 를 재발급한 뒤 재시도\"}}","type":"text"}],"isError":true}}

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,7 +236,15 @@ fn main() {
         // 종료 코드 2로 끝낸다(기존에는 stdout + 0이라 오타 낸 명령이 스크립트에서 성공으로 보였다).
         other => {
             match other {
-                Some(command) => eprintln!("오류: 알 수 없는 명령입니다 - {}", command),
+                Some(command) => {
+                    eprintln!("오류: 알 수 없는 명령입니다 - {}", command);
+                    // [#3694] did-you-mean — 후보는 capabilities 단일 출처. 이름 환각을
+                    // 교정 단서 없이 돌려보내면 경량 에이전트는 맹목 재시도 루프에 빠진다.
+                    let names = capabilities_command_names();
+                    if let Some(hint) = closest_name(command, names.iter().map(String::as_str)) {
+                        eprintln!("힌트: 가장 가까운 명령은 '{hint}' 입니다");
+                    }
+                }
                 None => eprintln!("오류: 명령을 지정해주세요."),
             }
             eprintln!("rhwp v{}", rhwp::version());
@@ -727,90 +735,40 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
 ///
 /// `--help`(사람용)와 본 목록(기계용)은 함께 현행화한다 — help 에만 추가된 명령은
 /// `tests/cli_json_contract.rs::capabilities_covers_every_help_command` 가 잡는다.
-fn show_capabilities(args: &[String]) -> i32 {
-    // [#3263] --mcp: MCP 서버가 그대로 등록할 수 있는 도구 정의.
-    // 로드맵상 MCP 서버 자체는 별도 저장소(#227)지만, 그 서버가 도구 목록·입력 스키마를
-    // 손으로 베껴 쓰면 rhwp 가 바뀔 때마다 조용히 낡는다. 원천을 여기서 낸다.
-    let mut mcp_mode = false;
-    // [#3629] 직무 프로필 필터 — 단일 출처는 agent_profiles::PROFILES.
-    let mut profile: Option<String> = None;
-    let mut i = 0;
-    while i < args.len() {
-        match args[i].as_str() {
-            "--mcp" => mcp_mode = true,
-            "--profile" => {
-                i += 1;
-                match args.get(i) {
-                    Some(p) => profile = Some(p.clone()),
-                    None => {
-                        eprintln!("오류: --profile 뒤에 역할 이름이 필요합니다.");
-                        eprintln!("사용 가능: {}", agent_profiles::names().join(", "));
-                        return EXIT_USAGE;
-                    }
-                }
-            }
-            other => {
-                eprintln!("알 수 없는 옵션: {other}");
-                return EXIT_USAGE;
-            }
-        }
-        i += 1;
-    }
-    let profile = match profile {
-        Some(name) => match agent_profiles::find(&name) {
-            Some(p) => Some(p),
-            None => {
-                eprintln!("오류: 알 수 없는 프로필 '{name}'");
-                eprintln!("사용 가능: {}", agent_profiles::names().join(", "));
-                return EXIT_USAGE;
-            }
-        },
-        None => None,
-    };
-    if mcp_mode {
-        return show_mcp_tools(profile);
-    }
-    if profile.is_some() {
-        eprintln!(
-            "오류: --profile 은 --mcp 와 함께 사용합니다 (capabilities --mcp --profile <역할>)."
-        );
-        return EXIT_USAGE;
-    }
+// [#3694] capabilities 명령 목록의 단일 출처 — 자기서술과 did-you-mean 이 공유한다.
+fn cmd(name: &str, category: &str, summary: &str) -> serde_json::Value {
+    serde_json::json!({ "name": name, "category": category, "summary": summary })
+}
 
-    fn cmd(name: &str, category: &str, summary: &str) -> serde_json::Value {
-        serde_json::json!({ "name": name, "category": category, "summary": summary })
-    }
-    fn cmd_json(
-        name: &str,
-        category: &str,
-        summary: &str,
-        batch: bool,
-        flags: &[&str],
-        record_fields: &[&str],
-    ) -> serde_json::Value {
-        serde_json::json!({
-            "name": name, "category": category, "summary": summary,
-            "json": true, "batch": batch, "flags": flags, "recordFields": record_fields,
-        })
-    }
-    /// [#3357] feature 게이트 명령 — 빌드에 따라 실행 가능 여부가 달라지므로 자기서술이
-    /// 가용성을 명시한다. 두 필드는 빌드와 무관하게 항상 방출되고 값만 달라진다
-    /// (스키마 안정성). 매니페스트만 보고 호출을 생성하는 에이전트가 exit 2 를
-    /// 밟기 전에 알 수 있게 한다.
-    fn cmd_gated(
-        name: &str,
-        category: &str,
-        summary: &str,
-        requires_feature: &str,
-        available: bool,
-    ) -> serde_json::Value {
-        serde_json::json!({
-            "name": name, "category": category, "summary": summary,
-            "requiresFeature": requires_feature, "available": available,
-        })
-    }
+fn cmd_json(
+    name: &str,
+    category: &str,
+    summary: &str,
+    batch: bool,
+    flags: &[&str],
+    record_fields: &[&str],
+) -> serde_json::Value {
+    serde_json::json!({
+        "name": name, "category": category, "summary": summary,
+        "json": true, "batch": batch, "flags": flags, "recordFields": record_fields,
+    })
+}
 
-    let commands = vec![
+fn cmd_gated(
+    name: &str,
+    category: &str,
+    summary: &str,
+    requires_feature: &str,
+    available: bool,
+) -> serde_json::Value {
+    serde_json::json!({
+        "name": name, "category": category, "summary": summary,
+        "requiresFeature": requires_feature, "available": available,
+    })
+}
+
+fn capabilities_command_entries() -> Vec<serde_json::Value> {
+    vec![
         // ── 기계 계약(--json) 명령 ──
         cmd_json(
             "info",
@@ -1196,7 +1154,103 @@ fn show_capabilities(args: &[String]) -> i32 {
         cmd("test-field", "internal", "누름틀 왕복 테스트"),
         cmd("gen-table", "internal", "표 샘플 생성"),
         cmd("gen-pua", "internal", "PUA 샘플 생성"),
-    ];
+    ]
+}
+
+/// [#3694] 명령 이름 목록 (did-you-mean 후보).
+fn capabilities_command_names() -> Vec<String> {
+    capabilities_command_entries()
+        .iter()
+        .filter_map(|c| c["name"].as_str().map(String::from))
+        .collect()
+}
+
+/// [#3694] 레벤슈타인 거리 — 의존성 없이 소형 구현 (이름 환각 교정용).
+pub(crate) fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut cur = vec![0usize; b.len() + 1];
+    for i in 1..=a.len() {
+        cur[0] = i;
+        for j in 1..=b.len() {
+            let cost = usize::from(a[i - 1] != b[j - 1]);
+            cur[j] = (prev[j] + 1).min(cur[j - 1] + 1).min(prev[j - 1] + cost);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[b.len()]
+}
+
+/// [#3694] 후보 중 가장 가까운 이름 — 임계(길이 대비 1/3, 최소 1·최대 3) 초과면 None.
+/// 오제안 0 원칙: 애매하면 제안하지 않는 편이 경량 에이전트에게 안전하다.
+pub(crate) fn closest_name<'a, I: IntoIterator<Item = &'a str>>(
+    input: &str,
+    candidates: I,
+) -> Option<String> {
+    let mut best: Option<(usize, &str)> = None;
+    for c in candidates {
+        let d = levenshtein(input, c);
+        if best.map(|(bd, _)| d < bd).unwrap_or(true) {
+            best = Some((d, c));
+        }
+    }
+    let (d, name) = best?;
+    let cap = (input.chars().count() / 3).clamp(1, 3);
+    (d <= cap).then(|| name.to_string())
+}
+
+fn show_capabilities(args: &[String]) -> i32 {
+    // [#3263] --mcp: MCP 서버가 그대로 등록할 수 있는 도구 정의.
+    // 로드맵상 MCP 서버 자체는 별도 저장소(#227)지만, 그 서버가 도구 목록·입력 스키마를
+    // 손으로 베껴 쓰면 rhwp 가 바뀔 때마다 조용히 낡는다. 원천을 여기서 낸다.
+    let mut mcp_mode = false;
+    // [#3629] 직무 프로필 필터 — 단일 출처는 agent_profiles::PROFILES.
+    let mut profile: Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--mcp" => mcp_mode = true,
+            "--profile" => {
+                i += 1;
+                match args.get(i) {
+                    Some(p) => profile = Some(p.clone()),
+                    None => {
+                        eprintln!("오류: --profile 뒤에 역할 이름이 필요합니다.");
+                        eprintln!("사용 가능: {}", agent_profiles::names().join(", "));
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            other => {
+                eprintln!("알 수 없는 옵션: {other}");
+                return EXIT_USAGE;
+            }
+        }
+        i += 1;
+    }
+    let profile = match profile {
+        Some(name) => match agent_profiles::find(&name) {
+            Some(p) => Some(p),
+            None => {
+                eprintln!("오류: 알 수 없는 프로필 '{name}'");
+                eprintln!("사용 가능: {}", agent_profiles::names().join(", "));
+                return EXIT_USAGE;
+            }
+        },
+        None => None,
+    };
+    if mcp_mode {
+        return show_mcp_tools(profile);
+    }
+    if profile.is_some() {
+        eprintln!(
+            "오류: --profile 은 --mcp 와 함께 사용합니다 (capabilities --mcp --profile <역할>)."
+        );
+        return EXIT_USAGE;
+    }
+
+    let commands = capabilities_command_entries();
 
     let caps = serde_json::json!({
         "schemaVersion": "1.0",

--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -372,9 +372,15 @@ fn handle_tool_call(
                 let did_you_mean: Vec<String> = crate::closest_name(name, candidates.into_iter())
                     .into_iter()
                     .collect();
-                return Ok(tool_error(
-                    serde_json::json!({ "error": error, "didYouMean": did_you_mean }).to_string(),
-                ));
+                let mut body = serde_json::json!({ "error": error, "didYouMean": did_you_mean });
+                if let Some(best) = body["didYouMean"][0].as_str() {
+                    body["nextCall"] = serde_json::json!({
+                        "name": best,
+                        "arguments": {},
+                        "why": "요청한 이름이 없음 — 가장 가까운 실존 도구로 교정"
+                    });
+                }
+                return Ok(tool_error(body.to_string()));
             };
             Ok(run_cli_tool(def, &args))
         }
@@ -396,6 +402,23 @@ fn is_session_tool(name: &str) -> bool {
             | "hwp_doc_fill_fields"
             | "hwp_doc_save"
             | "hwp_close"
+    )
+}
+
+/// [#3699] 교정 호출 동봉 오류 — error 필드가 기존 원문을 담아 하위호환.
+/// nextCall.name 은 반드시 실존 도구(호출부 책임, 계약 테스트가 고정).
+fn tool_error_with_next(
+    message: String,
+    next_name: &str,
+    next_args: serde_json::Value,
+    why: &str,
+) -> serde_json::Value {
+    tool_error(
+        serde_json::json!({
+            "error": message,
+            "nextCall": { "name": next_name, "arguments": next_args, "why": why }
+        })
+        .to_string(),
     )
 }
 
@@ -467,7 +490,12 @@ fn session_doc_text(args: &serde_json::Value, sessions: &mut Sessions) -> serde_
         return tool_error("docId 가 필요합니다".into());
     };
     let Some(sd) = sessions.docs.get_mut(doc_id) else {
-        return tool_error(format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"));
+        return tool_error_with_next(
+            format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"),
+            "hwp_open",
+            serde_json::json!({ "path": "<열 문서 경로>" }),
+            "핸들이 없거나 만료 — hwp_open 으로 docId 를 재발급한 뒤 재시도",
+        );
     };
     let doc = &mut sd.doc;
     let page_count = doc.page_count();
@@ -513,9 +541,12 @@ fn with_doc<'a>(
     let id = doc_id.to_string();
     match sessions.docs.get_mut(&id) {
         Some(sd) => Ok((sd, id)),
-        None => Err(tool_error(format!(
-            "열려 있지 않은 핸들: {id} (hwp_open 먼저)"
-        ))),
+        None => Err(tool_error_with_next(
+            format!("열려 있지 않은 핸들: {id} (hwp_open 먼저)"),
+            "hwp_open",
+            serde_json::json!({ "path": "<열 문서 경로>" }),
+            "핸들이 없거나 만료 — hwp_open 으로 docId 를 재발급한 뒤 재시도",
+        )),
     }
 }
 
@@ -611,7 +642,12 @@ fn session_search(args: &serde_json::Value, sessions: &mut Sessions) -> serde_js
         .and_then(|c| c.as_bool())
         .unwrap_or(true);
     let Some(sd) = sessions.docs.get_mut(doc_id) else {
-        return tool_error(format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"));
+        return tool_error_with_next(
+            format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"),
+            "hwp_open",
+            serde_json::json!({ "path": "<열 문서 경로>" }),
+            "핸들이 없거나 만료 — hwp_open 으로 docId 를 재발급한 뒤 재시도",
+        );
     };
     let matches = sd.doc.grep(query, case_sensitive, None);
     let total = matches.len();
@@ -640,7 +676,12 @@ fn session_replace_text(args: &serde_json::Value, sessions: &mut Sessions) -> se
         .and_then(|c| c.as_bool())
         .unwrap_or(true);
     let Some(sd) = sessions.docs.get_mut(doc_id) else {
-        return tool_error(format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"));
+        return tool_error_with_next(
+            format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"),
+            "hwp_open",
+            serde_json::json!({ "path": "<열 문서 경로>" }),
+            "핸들이 없거나 만료 — hwp_open 으로 docId 를 재발급한 뒤 재시도",
+        );
     };
     let result = match sd.doc.replace_all_native(find, replace, case_sensitive) {
         Ok(r) => r,
@@ -687,7 +728,12 @@ fn session_set_cell(args: &serde_json::Value, sessions: &mut Sessions) -> serde_
     };
     let id = doc_id.to_string();
     let Some(sd) = sessions.docs.get_mut(&id) else {
-        return tool_error(format!("열려 있지 않은 핸들: {id} (hwp_open 먼저)"));
+        return tool_error_with_next(
+            format!("열려 있지 않은 핸들: {id} (hwp_open 먼저)"),
+            "hwp_open",
+            serde_json::json!({ "path": "<열 문서 경로>" }),
+            "핸들이 없거나 만료 — hwp_open 으로 docId 를 재발급한 뒤 재시도",
+        );
     };
     let table_no = match usize::try_from(table_no) {
         Ok(value) => value,
@@ -778,7 +824,12 @@ fn session_fill_fields(args: &serde_json::Value, sessions: &mut Sessions) -> ser
         return tool_error("data 는 {\"필드이름\":\"값\"} 객체여야 합니다".into());
     };
     let Some(sd) = sessions.docs.get_mut(doc_id) else {
-        return tool_error(format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"));
+        return tool_error_with_next(
+            format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"),
+            "hwp_open",
+            serde_json::json!({ "path": "<열 문서 경로>" }),
+            "핸들이 없거나 만료 — hwp_open 으로 docId 를 재발급한 뒤 재시도",
+        );
     };
     let doc = &mut sd.doc;
 
@@ -852,7 +903,12 @@ fn session_save(args: &serde_json::Value, sessions: &mut Sessions) -> serde_json
         return tool_error("output 이 필요합니다".into());
     };
     let Some(sd) = sessions.docs.get_mut(doc_id) else {
-        return tool_error(format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"));
+        return tool_error_with_next(
+            format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"),
+            "hwp_open",
+            serde_json::json!({ "path": "<열 문서 경로>" }),
+            "핸들이 없거나 만료 — hwp_open 으로 docId 를 재발급한 뒤 재시도",
+        );
     };
 
     let format = if sd.source_is_hwpx {
@@ -884,7 +940,12 @@ fn session_close(args: &serde_json::Value, sessions: &mut Sessions) -> serde_jso
         return tool_error("docId 가 필요합니다".into());
     };
     if sessions.docs.remove(doc_id).is_none() {
-        return tool_error(format!("열려 있지 않은 핸들: {doc_id}"));
+        return tool_error_with_next(
+            format!("열려 있지 않은 핸들: {doc_id}"),
+            "hwp_open",
+            serde_json::json!({ "path": "<열 문서 경로>" }),
+            "핸들이 없거나 만료 — hwp_open 으로 docId 를 재발급한 뒤 재시도",
+        );
     }
     tool_ok_text(
         serde_json::json!({

--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -363,7 +363,18 @@ fn handle_tool_call(
         "hwp_close" => Ok(session_close(&args, sessions)),
         _ => {
             let Some(def) = tool_defs.iter().find(|t| t["name"] == name) else {
-                return Ok(tool_error(format!("알 수 없는 도구: {name}")));
+                // [#3694] didYouMean — error 필드가 기존 원문을 담아 하위호환.
+                let error = format!("알 수 없는 도구: {name}");
+                let candidates: Vec<&str> = tool_defs
+                    .iter()
+                    .filter_map(|t| t["name"].as_str())
+                    .collect();
+                let did_you_mean: Vec<String> = crate::closest_name(name, candidates.into_iter())
+                    .into_iter()
+                    .collect();
+                return Ok(tool_error(
+                    serde_json::json!({ "error": error, "didYouMean": did_you_mean }).to_string(),
+                ));
             };
             Ok(run_cli_tool(def, &args))
         }

--- a/tests/did_you_mean_contract.rs
+++ b/tests/did_you_mean_contract.rs
@@ -1,0 +1,68 @@
+//! [#3694] did-you-mean — 이름 환각 교정 단서 (#3630 P1 구현).
+//! 후보는 capabilities 명령 목록 단일 출처, 임계 초과 시 무제안(오제안 0 원칙).
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+
+#[test]
+fn unknown_command_hints_closest_and_keeps_exit_2() {
+    let out = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("exprot-svg") // 오타
+        .output()
+        .expect("rhwp");
+    assert_eq!(out.status.code(), Some(2));
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("힌트: 가장 가까운 명령은 'export-svg' 입니다"),
+        "{err}"
+    );
+}
+
+#[test]
+fn gibberish_command_gets_no_hint() {
+    let out = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("코끼리코끼리")
+        .output()
+        .expect("rhwp");
+    assert_eq!(out.status.code(), Some(2));
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(!err.contains("힌트:"), "임계 초과는 무제안: {err}");
+}
+
+#[test]
+fn mcp_unknown_tool_reports_did_you_mean_json() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("mcp-serve")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("mcp-serve");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+    writeln!(
+        stdin,
+        r#"{{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{{"name":"hwp_serch","arguments":{{}}}}}}"#
+    )
+    .unwrap();
+    stdin.flush().unwrap();
+    let mut line = String::new();
+    assert!(stdout.read_line(&mut line).unwrap() > 0);
+    let v: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+    assert_eq!(v["result"]["isError"], true, "{v}");
+    let text = v["result"]["content"][0]["text"].as_str().unwrap();
+    let body: serde_json::Value =
+        serde_json::from_str(text).unwrap_or_else(|e| panic!("구조화 JSON 이어야 함({e}): {text}"));
+    // 하위호환: error 필드가 기존 원문을 담는다.
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("알 수 없는 도구"),
+        "{body}"
+    );
+    assert_eq!(body["didYouMean"][0], "hwp_search", "{body}");
+    let _ = child.kill();
+    let _ = child.wait();
+}

--- a/tests/mcp_next_call_contract.rs
+++ b/tests/mcp_next_call_contract.rs
@@ -1,0 +1,80 @@
+//! [#3699] nextCall — isError 에 기계가 따라할 교정 호출 동봉 (#3630 P4).
+//! error 필드가 기존 원문을 담아 하위호환, nextCall.name 은 실존 도구만.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+
+fn serve_call(req: &str) -> serde_json::Value {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("mcp-serve")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("mcp-serve");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+    writeln!(stdin, "{req}").unwrap();
+    stdin.flush().unwrap();
+    let mut line = String::new();
+    assert!(stdout.read_line(&mut line).unwrap() > 0);
+    let _ = child.kill();
+    let _ = child.wait();
+    serde_json::from_str(line.trim()).unwrap()
+}
+
+fn error_body(v: &serde_json::Value) -> serde_json::Value {
+    assert_eq!(v["result"]["isError"], true, "{v}");
+    let text = v["result"]["content"][0]["text"].as_str().unwrap();
+    serde_json::from_str(text).unwrap_or_else(|e| panic!("구조화 JSON 이어야 함({e}): {text}"))
+}
+
+#[test]
+fn closed_handle_carries_next_call_to_open() {
+    let v = serve_call(
+        r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hwp_doc_fill_fields","arguments":{"docId":"doc-999","data":{"a":"b"}}}}"#,
+    );
+    let body = error_body(&v);
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap()
+            .contains("열려 있지 않은 핸들"),
+        "하위호환 원문: {body}"
+    );
+    assert_eq!(body["nextCall"]["name"], "hwp_open", "{body}");
+    assert!(body["nextCall"]["why"].is_string(), "{body}");
+}
+
+#[test]
+fn unknown_tool_next_call_is_registered_tool() {
+    let v = serve_call(
+        r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hwp_serch","arguments":{}}}"#,
+    );
+    let body = error_body(&v);
+    assert_eq!(body["nextCall"]["name"], "hwp_search", "{body}");
+    // 실존 도구 대조: capabilities --mcp 선언에 있어야 한다.
+    let caps = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(["capabilities", "--mcp"])
+        .output()
+        .unwrap();
+    let m: serde_json::Value = serde_json::from_slice(&caps.stdout).unwrap();
+    assert!(
+        m["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|t| t["name"] == body["nextCall"]["name"]),
+        "{body}"
+    );
+}
+
+#[test]
+fn close_on_unknown_handle_also_guides_open() {
+    let v = serve_call(
+        r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hwp_close","arguments":{"docId":"doc-999"}}}"#,
+    );
+    let body = error_body(&v);
+    assert_eq!(body["nextCall"]["name"], "hwp_open", "{body}");
+}


### PR DESCRIPTION
## 무엇 (#3630 설계 P4 의 구현, P1(#3698) 후속)

정보 없는 오류는 경량 에이전트 맹목 재시도 루프의 원료입니다. isError 텍스트를 `{"error":"<기존 원문>","nextCall":{"name","arguments","why"}}` 로 구조화합니다 — **error 필드가 원문을 담아 하위호환**(텍스트 파싱하던 소비자 무해).

## 적용 (정준 복구가 존재하는 곳만)

1. **닫힌/모르는 핸들 — 세션 도구 8개 사이트 전부** → `nextCall: {name:"hwp_open", arguments:{path:"<열 문서 경로>"}, why:"핸들이 없거나 만료 — docId 재발급 후 재시도"}`
2. **미지 도구** → didYouMean 최근접(#3698 단일 출처)이 있으면 그 도구를 nextCall 로 병기
3. nextCall.name 은 **실존 도구만** — capabilities --mcp 선언 대조를 계약 테스트로 고정

## 실측 (라이브 원문, evidence.txt 동봉)

```
닫힌 핸들 fill → {"error":"열려 있지 않은 핸들: doc-999 (hwp_open 먼저)",
  "nextCall":{"name":"hwp_open","arguments":{"path":"<열 문서 경로>"},"why":"…재발급한 뒤 재시도"}}
```

## 검증

- 신규 `mcp_next_call_contract` **3건 green** · did_you_mean 3 · server 6 · session_edit 5 **무회귀** · clippy 0 · rustfmt clean
- 처리 문서 `mydocs/report/task_m100_3699/`

**#3698 적층**(closest_name 재사용). closes #3699 · #3630 P4 · 로드맵 #3608