### PR TITLE
feat(#3703): 계획 실행기 rhwp run — 선언적 편집 계획의 정적 선검증·원자 실행·저널 (#3608 실행 3층) — #3705 적층

### DIFF
--- a/mydocs/report/task_m100_3694/README.md
+++ b/mydocs/report/task_m100_3694/README.md
@@ -1,0 +1,29 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_3694/README.md
+last_verified: 2026-08-02
+---
+
+# #3694 처리 기록 — did-you-mean (내성 P1, #3630 1호)
+
+## 구현
+
+- CLI: 알 수 없는 명령 exit 2 stderr 에 `힌트: 가장 가까운 명령은 '…' 입니다` 1줄.
+  후보는 **capabilities 명령 목록 단일 출처** — `show_capabilities` 의 commands vec 을
+  `capabilities_command_entries()` 로 승격해 자기서술과 힌트가 같은 원천을 쓴다.
+- 판정: 의존성 없는 소형 레벤슈타인 + 임계(길이/3, 1~3) 초과 시 무제안 — **오제안 0
+  원칙**(엉뚱한 제안은 경량 에이전트를 더 깊은 루프로 밀어넣는다).
+- MCP: 미지 도구 isError 텍스트를 `{"error":"<기존 원문>","didYouMean":[…]}` 로 승격 —
+  error 필드가 원문을 담아 하위호환, 후보는 tool_defs 실존 도구만.
+
+## 실측 (evidence.txt 원문 동봉)
+
+- `rhwp exprot-svg` → exit 2 + `힌트: 가장 가까운 명령은 'export-svg' 입니다`
+- MCP `hwp_serch` → `{"error":"알 수 없는 도구: hwp_serch","didYouMean":["hwp_search"]}`
+
+## 검증
+
+- 신규 `did_you_mean_contract` 3건 green (오타 힌트+exit 2 유지 / 헛소리 무제안 /
+  MCP 구조화·하위호환), `cli_json_contract` 22건·`mcp_server_contract` 6건 무회귀,
+  clippy 0, rustfmt clean. commands vec 승격은 동작 무변경(자기서술 22건이 가드).

--- a/mydocs/report/task_m100_3694/evidence.txt
+++ b/mydocs/report/task_m100_3694/evidence.txt
@@ -1,0 +1,10 @@
+$ rhwp exprot-svg doc.hwp ; echo exit=$?
+오류: 알 수 없는 명령입니다 - exprot-svg
+힌트: 가장 가까운 명령은 'export-svg' 입니다
+rhwp v0.8.2
+사용법: rhwp <명령> [옵션]
+'rhwp --help'로 자세한 사용법을 확인하세요.
+exit=2
+
+# MCP: tools/call name="hwp_serch" (오타)
+{"id":1,"jsonrpc":"2.0","result":{"content":[{"text":"{\"didYouMean\":[\"hwp_search\"],\"error\":\"알 수 없는 도구: hwp_serch\"}","type":"text"}],"isError":true}}

--- a/mydocs/report/task_m100_3699/README.md
+++ b/mydocs/report/task_m100_3699/README.md
@@ -1,0 +1,26 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_3699/README.md
+last_verified: 2026-08-02
+---
+
+# #3699 처리 기록 — nextCall (내성 P4, #3630 2호)
+
+## 구현
+
+- `tool_error_with_next(message, name, args, why)` — `{"error":"<원문>","nextCall":{name,arguments,why}}`
+  구조화. error 필드 원문 보존 = 하위호환(텍스트 파싱 소비자 무해).
+- 적용 2계열: ① 닫힌/모르는 핸들 **8개 사이트 전부**(세션 도구) → `hwp_open` 교정
+  ② 미지 도구 → didYouMean 최근접이 있으면 그 도구를 nextCall 로 병기.
+- nextCall.name 은 실존 도구만 — 계약 테스트가 capabilities --mcp 선언과 대조 고정.
+
+## 실측 (evidence.txt 원문)
+
+닫힌 핸들 fill 호출 → `{"error":"열려 있지 않은 핸들: doc-999 …","nextCall":{"name":"hwp_open",
+"arguments":{"path":"<열 문서 경로>"},"why":"핸들이 없거나 만료 — …재발급한 뒤 재시도"}}`
+
+## 검증
+
+- 신규 `mcp_next_call_contract` 3건 green (닫힌 핸들→hwp_open / 미지 도구 nextCall
+  실존 대조 / close 경로) · did_you_mean 3·server 6·session_edit 5 무회귀 · clippy 0

--- a/mydocs/report/task_m100_3699/evidence.txt
+++ b/mydocs/report/task_m100_3699/evidence.txt
@@ -1,0 +1,2 @@
+# 닫힌 핸들 → nextCall 교정 (라이브)
+{"id":1,"jsonrpc":"2.0","result":{"content":[{"text":"{\"error\":\"열려 있지 않은 핸들: doc-999 (hwp_open 먼저)\",\"nextCall\":{\"arguments\":{\"path\":\"<열 문서 경로>\"},\"name\":\"hwp_open\",\"why\":\"핸들이 없거나 만료 — hwp_open 으로 docId 를 재발급한 뒤 재시도\"}}","type":"text"}],"isError":true}}

--- a/mydocs/report/task_m100_3702/README.md
+++ b/mydocs/report/task_m100_3702/README.md
@@ -1,0 +1,41 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_3702/README.md
+last_verified: 2026-08-01
+---
+
+# #3702 처리 기록 — 편집 --verify 내장 (#3630 P2)
+
+## 문제
+
+편집 → 저장 → "잘 됐겠지"는 에이전트 실패 유형 2(#3630)의 원료다. 저장물이 실제로
+의도한 문서인지 확인하려면 별도 재독 호출을 스스로 조립해야 했다.
+
+## 구현
+
+- `edit_verify_report(doc, out_bytes, cross_format)` 단일 헬퍼 — 저장 바이트를
+  즉시 재파싱해 메모리 IR와 `diff_documents` 대조, `{identical, diffCount}` 봉투 반환.
+  - 재파싱 실패는 판정 불가가 아니라 실패로: `identical:false + reparseError` (저장물은 남긴다).
+  - 교차 포맷 저장(hwp→hwpx 등)은 `strip_cross_format_noise` 로 포맷 고유 잡음 제거 후 판정.
+- CLI 3종 `edit fill-fields / replace-text / set-cell` 에 `--verify` 플래그:
+  - 봉투에 `verify:{identical,diffCount}` 동봉, **identical=false 면 봉투 출력 후 exit 3** —
+    판정은 데이터, 프로세스 종료코드와 모순 없음.
+  - 미요청 시 `verify:null` (기존 소비자 무해·하위호환).
+- `mcp-serve` `hwp_doc_save` 에 `verify:true` 인자 — 같은 헬퍼 재사용, 세션 저장도 동일 봉투.
+
+## 실측 (evidence.txt 원문)
+
+- fill-fields/set-cell/hwp_doc_save 3계열 모두 `verify:{"diffCount":0,"identical":true}` 라이브 확인.
+- set-cell 좌표는 하드코딩이 아니라 export-tables 재독으로 고른 실존 최상위 표(index 1) — 이
+  양식은 최상위 표 index 가 0에서 시작하지 않음을 실측으로 확인(계약 테스트도 동일 방식).
+
+## 검증
+
+- 신규 `edit_verify_contract` 4건 green (fill 봉투-exit 정합 / 미요청 null / set-cell 수용 /
+  세션 save verify 보고) · fill 7·replace 4·set-cell 5 무회귀 · clippy 0 · fmt clean.
+
+## 남은 것
+
+- replace-text 라이브 실측은 fill·set-cell 과 같은 경로(동일 헬퍼)라 계약 테스트로 갈음.
+- identical=false 실물 재현(의도적 손상 주입)은 단위 아닌 통합 픽스처가 필요 — v2 후보.

--- a/mydocs/report/task_m100_3702/evidence.txt
+++ b/mydocs/report/task_m100_3702/evidence.txt
@@ -1,0 +1,10 @@
+# fill-fields --verify --json (라이브, field-01.hwp)
+{"ambiguous":[],"dryRun":false,"filled":[{"name":"회사명","occurrence":0,"value":"검증사"}],"filledCount":1,"notFound":[],"output":"C:/Users/swsz9/AppData/Local/Temp/ev-fill.hwp","outputFormat":"hwp5","schemaVersion":"1.0","source":"samples/field-01.hwp","verify":{"diffCount":0,"identical":true}}
+exit=0
+
+# set-cell --verify --json (라이브, 지자체 보고서 hwpx — export-tables 로 고른 실존 좌표)
+{"col":0,"dryRun":false,"keepStyle":false,"newText":"V","oldText":"본 보고서는 \n\n\n\n\n\n\n\n\n\n\n 알려 주시기 바랍니다.","output":"C:/Users/swsz9/AppData/Local/Temp/ev-cell.hwpx","outputFormat":"hwpx","overflow":[],"row":0,"schemaVersion":"1.0","source":"samples/2025년 기부·답례품 실적 지자체 보고서_양식.hwpx","table":1,"verify":{"diffCount":0,"identical":true}}
+exit=0
+
+# mcp-serve hwp_doc_save verify:true (라이브)
+{"id":2,"jsonrpc":"2.0","result":{"content":[{"text":"{\"bytes\":473600,\"docId\":\"doc-1\",\"output\":\"/tmp/ev-sess.hwp\",\"outputFormat\":\"hwp5\",\"schemaVersion\":\"1.0\",\"verify\":{\"diffCount\":0,\"identical\":true}}","type":"text"}],"isError":false,"structuredContent":{"bytes":473600,"docId":"doc-1","output":"/tmp/ev-sess.hwp","outputFormat":"hwp5","schemaVersion":"1.0","verify":{"diffCount":0,"identical":true}}}}

--- a/mydocs/report/task_m100_3703/README.md
+++ b/mydocs/report/task_m100_3703/README.md
@@ -1,0 +1,50 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_3703/README.md
+last_verified: 2026-08-01
+---
+
+# #3703 처리 기록 — 계획 실행기 `rhwp run` (#3608 실행 3층)
+
+## 문제
+
+에이전트 실패의 뿌리는 다단 체이닝이다 — 호출 사이에서 상태를 잃고, 중간 실패가
+반편집 문서를 남긴다. 절차(도구 호출 나열) 대신 **의도(계획서)** 를 받는 3층을 신설했다.
+
+## 구현
+
+- `rhwp run <계획.json> [--json]` + `--plan-json '<인라인>'` (MCP 경로).
+- **정적 선검증(실행 0)**: 필드 존재·순번(`collect_all_fields` 계수), 치환 일치 건수
+  (`grep` 읽기 전용), 셀 좌표(`resolve_table_cell`), 체크박스 □ 계수 — 위반을 전부
+  모아 `invalid[{step,action,reason}]` + exit 2. 출력 파일을 아예 만들지 않는다.
+- **원자 실행**: 전 step 을 인메모리 IR 에만 적용(set_field_value_by_name_at ·
+  replace_nth/all_native · delete/insert_text_in_cell + recolor). 중간 실패 = 디스크
+  무변경. set_cell 좌표는 앞 step 편집으로 밀릴 수 있어 **실행 시점 재해석**.
+- **사후 단언 → 단 한 번 저장**: `assertions.verify` 는 #3702 `edit_verify_report`
+  재사용(저장 바이트 재파싱↔IR 대조). 실패 시 저장 없이 exit 3 — 자연 트랜잭션.
+- **저널 봉투**: step 별 결과(fill 의 filledCount/ambiguous, replace 의 replacedCount,
+  set_cell 의 oldText) + verify + assertions 에코. 판정은 전부 데이터.
+- 새 편집 로직 0 — 판정자와 적용자가 기존 edit 3종과 동일 함수.
+- MCP `hwp_run_plan{plan}`: capabilities 단일 출처에 cmdTemplate
+  `["run","--plan-json","{plan}","--json"]` 로 등록 — mcp_serve 본체 무변경.
+- help·capabilities 명령 목록 동기화 (`capabilities_covers_every_help_command` 게이트).
+
+## 실측 (evidence.txt 원문)
+
+1. 정상 계획(fill+replace, verify:true): 저널 steps 2건 + `verify identical:true` + exit 0.
+2. 위반 2종 섞인 계획: `invalid[]` 에 **두 위반을 한 번에** 보고(두더지잡기 방지),
+   exit 2, 출력 파일 부재 = 실행 0 증명.
+3. MCP `hwp_run_plan` 인라인 계획: isError:false + structuredContent 로 동일 저널.
+
+## 검증
+
+- 신규 `run_plan_contract` 6건 green (선검증 exit 2·출력 부재 / 중간 불가 원자성 /
+  저널-단언 정합 / 왕복 재독 / capabilities 선언 / MCP 저널).
+- 무회귀: cli_json_contract · edit_verify 4 · fill 7 · replace 4 · set-cell 5 · mcp_server.
+- clippy `-D warnings` 0 · fmt clean.
+
+## 남은 것 (v2 후보)
+
+- 계획 내 다중 문서(input 배열)·조건부 step — 로드맵 #3608 실행 3층 절에 기록.
+- verify 실패 실물 재현 픽스처(의도적 손상 주입) — #3702 와 공통 과제.

--- a/mydocs/report/task_m100_3703/evidence.txt
+++ b/mydocs/report/task_m100_3703/evidence.txt
@@ -1,0 +1,11 @@
+# 1) 정상 계획 — rhwp run demo_plan.json --json (라이브)
+{"assertions":{"notFoundEmpty":true,"verify":true},"input":"samples/field-01.hwp","output":"/tmp/plan-out.hwp","outputFormat":"hwp5","planVersion":"1.0","schemaVersion":"1.0","steps":[{"action":"fill_fields","ambiguous":[],"filled":[{"name":"회사명","occurrence":0,"value":"계획실행주식회사"}],"filledCount":1,"notFound":[],"step":0},{"action":"replace_text","find":"마케팅","replacedCount":1,"step":1}],"verify":{"diffCount":0,"identical":true}}
+exit=0
+
+# 2) 선검증 실패 — 위반 2건을 한 번에 모아 보고, 실행 0 (라이브)
+{"input":"samples/field-01.hwp","invalid":[{"action":"fill_fields","reason":"필드 '존재하지않는필드XYZ' 이(가) 없거나 순번이 범위 밖입니다 (동명 0개)","step":1},{"action":"replace_text","reason":"'이런문자열은없다9999' 일치 0건 — 치환할 곳이 없습니다","step":2}],"output":"/tmp/plan-bad.hwp","planVersion":"1.0","schemaVersion":"1.0"}
+exit=2
+(출력 파일 부재 = 실행 0 증명)
+
+# 3) MCP hwp_run_plan — 인라인 계획 (라이브)
+{"id":1,"jsonrpc":"2.0","result":{"content":[{"text":"{\"assertions\":{\"notFoundEmpty\":true,\"verify\":true},\"input\":\"samples/field-01.hwp\",\"output\":\"/tmp/plan-out.hwp\",\"outputFormat\":\"hwp5\",\"planVersion\":\"1.0\",\"schemaVersion\":\"1.0\",\"steps\":[{\"action\":\"fill_fields\",\"ambiguous\":[],\"filled\":[{\"name\":\"회사명\",\"occurrence\":0,\"value\":\"계획실행주식회사\"}],\"filledCount\":1,\"notFound\":[],\"step\":0},{\"action\":\"replace_text\",\"find\":\"마케팅\",\"replacedCount\":1,\"step\":1}],\"verify\":{\"diffCount\":0,\"identical\":true}}","type":"text"}],"isError":false,"structuredContent":{"assertions":{"notFoundEmpty":true,"verify":true},"input":"samples/field-01.hwp","output":"/tmp/plan-out.hwp","outputFormat":"hwp5","planVersion":"1.0","schemaVersion":"1.0","steps":[{"action":"fill_fields","ambiguous":[],"filled":[{"name":"회사명","occurrence":0,"value":"계획실행주식회사"}],"filledCount":1,"notFound":[],"step":0},{"action":"replace_text","find":"마케팅","replacedCount":1,"step":1}],"verify":{"diffCount":0,"identical":true}}}}

--- a/src/main.rs
+++ b/src/main.rs
@@ -284,6 +284,7 @@ fn main() {
         Some("thumbnail") => exit_with(extract_thumbnail(&args[2..])),
         Some("fields") => exit_with(show_fields(&args[2..])),
         Some("edit") => exit_with(run_edit(&args[2..])),
+        Some("run") => exit_with(cmd_run_plan(&args[2..])),
         // [#2707] 알 수 없는 명령·명령 누락은 사용법 오류다. 표준 CLI 관례대로 stderr 로 안내하고
         // 종료 코드 2로 끝낸다(기존에는 stdout + 0이라 오타 낸 명령이 스크립트에서 성공으로 보였다).
         other => {
@@ -823,6 +824,23 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
             serde_json::json!(["edit", "set-cell", "{path}", "--table", "{table}", "--row", "{row}", "--col", "{col}", "--text", "{text}", "--json"]),
             &["schemaVersion", "source", "table", "row", "col", "oldText", "newText", "dryRun", "overflow", "output", "outputFormat"],
         ),
+        tool(
+            "hwp_run_plan",
+            "[#3703] 선언적 편집 계획(JSON)을 정적 선검증→원자 실행→저널로 수행한다. 도구 호출을 체이닝하는 대신 의도를 계획서 하나로 선언하면, 전 step 의 실행 가능성을 미리 판정하고(불가 시 실행 0·invalid[]·exit 2) 인메모리로 적용해 단언(verify 자기검증) 통과 시에만 단 한 번 저장한다 — 실패 시 디스크 무변경. steps: fill_fields{data} · replace_text{find,replace[,occurrence]} · set_cell{table,row,col,text[,keepStyle]} · set_checkbox{occurrence}.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "plan": {
+                        "type": "object",
+                        "description": "계획서. { planVersion:\"1.0\", input:<원본 경로>, output:<산출 경로>, steps:[{action:…}…], assertions:{ notFoundEmpty?, verify? } }"
+                    }
+                },
+                "required": ["plan"],
+            }),
+            "run",
+            serde_json::json!(["run", "--plan-json", "{plan}", "--json"]),
+            &["schemaVersion", "planVersion", "input", "output", "outputFormat", "steps", "verify", "invalid"],
+        ),
     ];
     for definition in &mut tools {
         if definition["name"]
@@ -925,6 +943,23 @@ fn capabilities_command_entries() -> Vec<serde_json::Value> {
                 "excerpt",
                 "truncated",
                 "nextStep",
+            ],
+        ),
+        cmd_json(
+            "run",
+            "edit",
+            "선언적 편집 계획 실행 — 정적 선검증·원자 실행·저널 (#3703)",
+            false,
+            &["--json", "--plan-json"],
+            &[
+                "schemaVersion",
+                "planVersion",
+                "input",
+                "output",
+                "outputFormat",
+                "steps",
+                "verify",
+                "invalid",
             ],
         ),
         cmd_json(
@@ -1690,6 +1725,14 @@ fn print_help() {
     println!("      edit 3종 공통: 산출물은 **입력 형식을 보존**한다 (HWPX 입력 → HWPX 산출).");
     println!("      HWPX 입력에 -o ….hwp 를 지정하면 그 경로를 존중해 HWP5 로 저장하되");
     println!("      형식 변경(이미지·차트 유실 가능)을 stderr 로 경고한다.");
+    println!();
+    println!("  run <계획.json> [--json]              선언적 편집 계획 실행 (#3703)");
+    println!("      전 step 을 정적 선검증(불가 시 실행 0·exit 2)하고 인메모리로 원자");
+    println!("      실행해 단언(verify) 통과 시에만 단 한 번 저장한다 — 실패 시 디스크 무변경.");
+    println!("      steps: fill_fields{{data}} · replace_text{{find,replace[,occurrence]}}");
+    println!("             · set_cell{{table,row,col,text}} · set_checkbox{{occurrence}}");
+    println!("      --plan-json '<JSON>'      파일 대신 인라인 계획 (MCP hwp_run_plan 경로)");
+    println!("      단언 실패는 exit 3 — 저널(steps[]·verify)로 판정을 데이터로 보고");
     println!();
     println!("내부 개발·회귀 도구 (일반 사용자 대상 아님):");
     println!("  test-caption <파일.hwp> [-o <폴더>] 캡션 라운드트립 검증");
@@ -9814,6 +9857,392 @@ fn edit_serialize(
         EditOutputFormat::Hwp => doc.export_hwp_with_adapter(),
     }
     .map_err(|e| e.to_string())
+}
+
+// ─── [#3703] 계획 실행기 — 명령(CLI)·도구(MCP) 위의 3층: 선언적 편집 계획 ───
+
+/// `rhwp run <계획.json>` — 계획서를 정적 선검증 → 원자 실행 → 저널로 수행한다.
+///
+/// 다단 체이닝(호출 사이 상태 유실, 중간 실패의 반편집 문서)이 에이전트 실패의
+/// 뿌리라서 절차 대신 **의도(계획서)** 를 받는다. 판정은 전부 데이터다:
+/// 선검증 위반 = invalid[] + exit 2(실행 0), verify 단언 실패 = exit 3(디스크
+/// 무변경), 성공 = step 저널 + verify + exit 0(단 한 번 저장).
+fn cmd_run_plan(args: &[String]) -> i32 {
+    let mut plan_path: Option<&str> = None;
+    let mut plan_inline: Option<&str> = None;
+    let mut json_mode = false;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => json_mode = true,
+            "--plan-json" => {
+                i += 1;
+                match args.get(i) {
+                    Some(v) => plan_inline = Some(v.as_str()),
+                    None => {
+                        eprintln!("오류: --plan-json 뒤에 계획 JSON 문자열이 필요합니다.");
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            other if !other.starts_with("--") && plan_path.is_none() => plan_path = Some(other),
+            other => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {}", other);
+                return EXIT_USAGE;
+            }
+        }
+        i += 1;
+    }
+    let plan_text = match (plan_inline, plan_path) {
+        (Some(inline), _) => inline.to_string(),
+        (None, Some(path)) => match fs::read_to_string(path) {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!("오류: 계획 파일을 읽을 수 없습니다 - {}: {}", path, e);
+                return EXIT_RUNTIME;
+            }
+        },
+        (None, None) => {
+            eprintln!("사용법: rhwp run <계획.json> [--json]  (파일 대신 --plan-json '<JSON>')");
+            return EXIT_USAGE;
+        }
+    };
+    let plan: serde_json::Value = match serde_json::from_str(&plan_text) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("오류: 계획 JSON 파싱 실패 - {}", e);
+            return EXIT_USAGE;
+        }
+    };
+    let (journal, code) = run_plan_engine(&plan);
+    if json_mode {
+        println!("{}", journal);
+    } else if code == EXIT_OK {
+        println!(
+            "완료: {} step 적용, 산출 {}",
+            journal["steps"].as_array().map(|s| s.len()).unwrap_or(0),
+            journal["output"].as_str().unwrap_or("-")
+        );
+    } else {
+        // 사람 모드에서도 판정 근거는 저널 그대로 남긴다 — 달리 설명할 출처가 없다.
+        eprintln!("{}", journal);
+    }
+    code
+}
+
+/// 계획 실행 본체 — (저널, 종료 코드). CLI 와 MCP `hwp_run_plan` 이 같은 판정을 공유한다.
+fn run_plan_engine(plan: &serde_json::Value) -> (serde_json::Value, i32) {
+    fn usage(reason: &str) -> (serde_json::Value, i32) {
+        (
+            serde_json::json!({ "schemaVersion": "1.0", "error": reason }),
+            EXIT_USAGE,
+        )
+    }
+    fn fail(reason: String) -> (serde_json::Value, i32) {
+        (
+            serde_json::json!({ "schemaVersion": "1.0", "error": reason }),
+            EXIT_RUNTIME,
+        )
+    }
+
+    if plan["planVersion"].as_str() != Some("1.0") {
+        return usage("planVersion \"1.0\" 이 필요합니다");
+    }
+    let Some(input) = plan["input"].as_str() else {
+        return usage("input (원본 문서 경로)이 필요합니다");
+    };
+    let Some(output) = plan["output"].as_str() else {
+        return usage("output (산출 경로)이 필요합니다");
+    };
+    let steps = match plan["steps"].as_array() {
+        Some(s) if !s.is_empty() => s,
+        _ => return usage("steps 는 비어 있지 않은 배열이어야 합니다"),
+    };
+    let assert_verify = plan["assertions"]["verify"].as_bool().unwrap_or(false);
+    // notFoundEmpty 는 선검증이 구조적으로 보장한다 — 계약 표기로 저널에 남긴다.
+    let assert_not_found_empty = plan["assertions"]["notFoundEmpty"]
+        .as_bool()
+        .unwrap_or(true);
+
+    let bytes = match fs::read(input) {
+        Ok(d) => d,
+        Err(e) => return fail(format!("입력을 읽을 수 없습니다 - {}: {}", input, e)),
+    };
+    let mut doc = match rhwp::wasm_api::HwpDocument::from_bytes(&bytes) {
+        Ok(d) => d,
+        Err(e) => return fail(format!("HWP 파싱 실패 - {}", e)),
+    };
+
+    // 1) 정적 선검증 — 실행 0. 위반을 전부 모아 한 번에 보고한다(하나 고치면 다음
+    //    위반이 나오는 두더지잡기 방지). 판정자는 실행이 쓰는 바로 그 함수들이다.
+    let mut name_counts: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    for fi in doc.collect_all_fields().iter() {
+        if let Some(n) = fi.field.field_name() {
+            *name_counts.entry(n.to_string()).or_insert(0) += 1;
+        }
+    }
+    let mut invalid: Vec<serde_json::Value> = Vec::new();
+    for (idx, step) in steps.iter().enumerate() {
+        let action = step["action"].as_str().unwrap_or("");
+        match action {
+            "fill_fields" => {
+                let Some(data) = step["data"].as_object() else {
+                    invalid.push(serde_json::json!({ "step": idx, "action": action,
+                        "reason": "data 는 {\"필드이름\":\"값\"} 객체여야 합니다" }));
+                    continue;
+                };
+                for key in data.keys() {
+                    let (name, occurrence) = parse_field_key(key);
+                    let total = name_counts.get(name).copied().unwrap_or(0);
+                    if total == 0 || occurrence >= total {
+                        invalid.push(serde_json::json!({ "step": idx, "action": action,
+                            "reason": format!("필드 '{}' 이(가) 없거나 순번이 범위 밖입니다 (동명 {}개)", key, total) }));
+                    }
+                }
+            }
+            "replace_text" => {
+                let Some(find) = step["find"].as_str().filter(|s| !s.is_empty()) else {
+                    invalid.push(serde_json::json!({ "step": idx, "action": action,
+                        "reason": "find (비어 있지 않은 문자열)가 필요합니다" }));
+                    continue;
+                };
+                if !step["replace"].is_string() {
+                    invalid.push(serde_json::json!({ "step": idx, "action": action,
+                        "reason": "replace (문자열)가 필요합니다" }));
+                    continue;
+                }
+                let case_sensitive = step["caseSensitive"].as_bool().unwrap_or(true);
+                let count = doc.grep(find, case_sensitive, None).len();
+                match step["occurrence"].as_u64() {
+                    Some(n) if (n as usize) >= count => {
+                        invalid.push(serde_json::json!({ "step": idx, "action": action,
+                            "reason": format!("occurrence {} 이(가) 범위 밖입니다 ('{}' 일치 {}건)", n, find, count) }));
+                    }
+                    None if count == 0 => {
+                        invalid.push(serde_json::json!({ "step": idx, "action": action,
+                            "reason": format!("'{}' 일치 0건 — 치환할 곳이 없습니다", find) }));
+                    }
+                    _ => {}
+                }
+            }
+            "set_checkbox" => {
+                let Some(n) = step["occurrence"].as_u64() else {
+                    invalid.push(serde_json::json!({ "step": idx, "action": action,
+                        "reason": "occurrence (0 기준 순번)가 필요합니다" }));
+                    continue;
+                };
+                let count = doc.grep("□", true, None).len();
+                if (n as usize) >= count {
+                    invalid.push(serde_json::json!({ "step": idx, "action": action,
+                        "reason": format!("occurrence {} 이(가) 범위 밖입니다 (빈 체크박스 □ {}건)", n, count) }));
+                }
+            }
+            "set_cell" => {
+                let (Some(t), Some(r), Some(c), Some(text)) = (
+                    step["table"].as_u64(),
+                    step["row"].as_u64(),
+                    step["col"].as_u64(),
+                    step["text"].as_str(),
+                ) else {
+                    invalid.push(serde_json::json!({ "step": idx, "action": action,
+                        "reason": "table·row·col (정수)과 text (문자열)가 필요합니다" }));
+                    continue;
+                };
+                if text.chars().any(|ch| matches!(ch, '\r' | '\n' | '\t')) {
+                    invalid.push(serde_json::json!({ "step": idx, "action": action,
+                        "reason": "text 에 줄바꿈·탭은 넣을 수 없습니다 (한 줄 값 기록)" }));
+                    continue;
+                }
+                if let Err(e) = resolve_table_cell(doc.document(), t as usize, r as u16, c as u16)
+                {
+                    let (CellResolveError::Usage(msg) | CellResolveError::Runtime(msg)) = e;
+                    invalid
+                        .push(serde_json::json!({ "step": idx, "action": action, "reason": msg }));
+                }
+            }
+            "" => {
+                invalid.push(serde_json::json!({ "step": idx, "reason": "action 이 필요합니다" }))
+            }
+            other => invalid.push(serde_json::json!({ "step": idx, "action": other,
+                "reason": format!("알 수 없는 action: {} (fill_fields·replace_text·set_cell·set_checkbox)", other) })),
+        }
+    }
+    if !invalid.is_empty() {
+        return (
+            serde_json::json!({
+                "schemaVersion": "1.0", "planVersion": "1.0",
+                "input": input, "output": output, "invalid": invalid,
+            }),
+            EXIT_USAGE,
+        );
+    }
+
+    // 2) 원자 실행 — 전 step 을 인메모리 IR 에만 적용한다. 디스크는 아직 무변경이라
+    //    어느 step 이 실패해도 반편집 문서가 남지 않는다.
+    let mut journal_steps: Vec<serde_json::Value> = Vec::new();
+    for (idx, step) in steps.iter().enumerate() {
+        let action = step["action"].as_str().unwrap_or("");
+        match action {
+            "fill_fields" => {
+                let data = step["data"].as_object().expect("선검증 통과");
+                let mut filled: Vec<serde_json::Value> = Vec::new();
+                let mut ambiguous: Vec<serde_json::Value> = Vec::new();
+                for (key, value) in data {
+                    let value_str = match value {
+                        serde_json::Value::String(s) => s.clone(),
+                        other => other.to_string(),
+                    };
+                    let (name, occurrence) = parse_field_key(key);
+                    let total = name_counts.get(name).copied().unwrap_or(0);
+                    if occurrence == 0 && total > 1 && !key.contains('[') {
+                        ambiguous.push(
+                            serde_json::json!({ "name": name, "matched": 1, "total": total }),
+                        );
+                    }
+                    if let Err(e) = doc.set_field_value_by_name_at(name, occurrence, &value_str) {
+                        return fail(format!("step {}: 필드 '{}' 설정 실패 - {}", idx, key, e));
+                    }
+                    filled.push(serde_json::json!({
+                        "name": name, "occurrence": occurrence, "value": value_str,
+                    }));
+                }
+                journal_steps.push(serde_json::json!({
+                    "step": idx, "action": "fill_fields",
+                    "filledCount": filled.len(), "filled": filled,
+                    "notFound": [], "ambiguous": ambiguous,
+                }));
+            }
+            "replace_text" => {
+                let find = step["find"].as_str().expect("선검증 통과");
+                let replace = step["replace"].as_str().expect("선검증 통과");
+                let case_sensitive = step["caseSensitive"].as_bool().unwrap_or(true);
+                let result = match step["occurrence"].as_u64() {
+                    Some(n) => doc.replace_nth_native(find, replace, case_sensitive, n as usize),
+                    None => doc.replace_all_native(find, replace, case_sensitive),
+                };
+                let count = match result {
+                    Ok(r) => serde_json::from_str::<serde_json::Value>(&r)
+                        .ok()
+                        .and_then(|v| v["count"].as_u64())
+                        .unwrap_or(0),
+                    Err(e) => return fail(format!("step {}: 치환 실패 - {:?}", idx, e)),
+                };
+                journal_steps.push(serde_json::json!({
+                    "step": idx, "action": "replace_text",
+                    "find": find, "replacedCount": count,
+                }));
+            }
+            "set_checkbox" => {
+                let n = step["occurrence"].as_u64().expect("선검증 통과") as usize;
+                let count = match doc.replace_nth_native("□", "☑", true, n) {
+                    Ok(r) => serde_json::from_str::<serde_json::Value>(&r)
+                        .ok()
+                        .and_then(|v| v["count"].as_u64())
+                        .unwrap_or(0),
+                    Err(e) => return fail(format!("step {}: 체크박스 기록 실패 - {:?}", idx, e)),
+                };
+                journal_steps.push(serde_json::json!({
+                    "step": idx, "action": "set_checkbox",
+                    "occurrence": n, "replacedCount": count,
+                }));
+            }
+            "set_cell" => {
+                let t = step["table"].as_u64().expect("선검증 통과") as usize;
+                let r = step["row"].as_u64().expect("선검증 통과") as u16;
+                let c = step["col"].as_u64().expect("선검증 통과") as u16;
+                let text = step["text"].as_str().expect("선검증 통과");
+                let keep_style = step["keepStyle"].as_bool().unwrap_or(false);
+                // 앞 step 의 편집으로 좌표가 밀릴 수 있어 실행 시점에 재해석한다.
+                let (sec, para, ctrl, cell_idx, para_lens, old_text) =
+                    match resolve_table_cell(doc.document(), t, r, c) {
+                        Ok(v) => v,
+                        Err(CellResolveError::Usage(m) | CellResolveError::Runtime(m)) => {
+                            return fail(format!("step {}: {}", idx, m));
+                        }
+                    };
+                for (pi, len) in para_lens.iter().enumerate() {
+                    if *len == 0 {
+                        continue;
+                    }
+                    if let Err(e) = doc.delete_text_in_cell(
+                        sec as u32,
+                        para as u32,
+                        ctrl as u32,
+                        cell_idx as u32,
+                        pi as u32,
+                        0,
+                        *len as u32,
+                    ) {
+                        return fail(format!(
+                            "step {}: 셀 비우기 실패(문단 {}) - {:?}",
+                            idx, pi, e
+                        ));
+                    }
+                }
+                if !text.is_empty() {
+                    if let Err(e) = doc.insert_text_in_cell(
+                        sec as u32,
+                        para as u32,
+                        ctrl as u32,
+                        cell_idx as u32,
+                        0,
+                        0,
+                        text,
+                    ) {
+                        return fail(format!("step {}: 셀 쓰기 실패 - {:?}", idx, e));
+                    }
+                    if !keep_style
+                        && !recolor_cell_text_black(doc.document_mut(), sec, para, ctrl, cell_idx)
+                    {
+                        eprintln!("경고: step {} 셀 글자색을 검정으로 바꾸지 못했습니다.", idx);
+                    }
+                }
+                journal_steps.push(serde_json::json!({
+                    "step": idx, "action": "set_cell",
+                    "table": t, "row": r, "col": c, "oldText": old_text,
+                }));
+            }
+            _ => unreachable!("선검증이 막는다"),
+        }
+    }
+
+    // 3) 사후 단언 → 단 한 번 저장. 단언 실패 시 디스크 무변경 — 자연 트랜잭션.
+    let out_format = edit_output_format(&bytes, Some(output));
+    let out_bytes = match edit_serialize(&mut doc, out_format) {
+        Ok(b) => b,
+        Err(e) => return fail(format!("{} 직렬화 실패 - {}", out_format.label(), e)),
+    };
+    let mut verify_report = serde_json::Value::Null;
+    if assert_verify {
+        let cross = out_format == EditOutputFormat::Hwp
+            && rhwp::parser::detect_format(&bytes) == rhwp::parser::FileFormat::Hwpx;
+        let (report, failed) = edit_verify_report(&doc, &out_bytes, cross);
+        verify_report = report;
+        if failed {
+            return (
+                serde_json::json!({
+                    "schemaVersion": "1.0", "planVersion": "1.0",
+                    "input": input, "output": output,
+                    "steps": journal_steps, "verify": verify_report,
+                    "error": "verify 단언 실패 — 디스크 무변경",
+                }),
+                3,
+            );
+        }
+    }
+    if let Err(e) = fs::write(output, &out_bytes) {
+        return fail(format!("출력 파일을 쓸 수 없습니다 - {}: {}", output, e));
+    }
+    (
+        serde_json::json!({
+            "schemaVersion": "1.0", "planVersion": "1.0",
+            "input": input, "output": output, "outputFormat": out_format.label(),
+            "steps": journal_steps, "verify": verify_report,
+            "assertions": { "notFoundEmpty": assert_not_found_empty, "verify": assert_verify },
+        }),
+        EXIT_OK,
+    )
 }
 
 /// `edit fill-fields` — 누름틀에 값을 채운다 (메일머지).

--- a/src/main.rs
+++ b/src/main.rs
@@ -9767,6 +9767,44 @@ fn edit_output_format(input_bytes: &[u8], explicit_out: Option<&str>) -> EditOut
 ///
 /// HWP5 산출은 반드시 **어댑터 경유**(`export_hwp_with_adapter`)다. HWPX 출처 IR 을 HWP
 /// 호환 형태로 옮기는 #178 어댑터를 건너뛰면 한컴 호환성과 이미지·차트가 깨진다.
+/// [#3702] 편집 저장본 자기검증 — 편집 후 IR 과 저장본 재파싱 IR 을 내부 대조한다.
+/// 반환: (verify 봉투 값, exit 3 여부). 비교기는 diff_documents 재사용(신규 로직 없음).
+/// HWPX 소스→HWP5 산출 같은 교차 포맷은 #3505 노이즈 제거를 승계한다.
+fn edit_verify_report(
+    doc: &rhwp::wasm_api::HwpDocument,
+    out_bytes: &[u8],
+    cross_format: bool,
+) -> (serde_json::Value, bool) {
+    let reloaded = match rhwp::wasm_api::HwpDocument::from_bytes(out_bytes) {
+        Ok(d) => d,
+        Err(e) => {
+            // 재파싱 실패는 판정 불가 — identical:false + 사유로 보고(저장물은 남는다).
+            return (
+                serde_json::json!({ "identical": false, "diffCount": null, "reparseError": e.to_string() }),
+                true,
+            );
+        }
+    };
+    let diff =
+        rhwp::serializer::hwpx::roundtrip::diff_documents(doc.document(), reloaded.document());
+    let diff = if cross_format {
+        rhwp::serializer::hwpx::roundtrip::strip_cross_format_noise(diff)
+    } else {
+        diff
+    };
+    if diff.is_empty() {
+        (
+            serde_json::json!({ "identical": true, "diffCount": 0 }),
+            false,
+        )
+    } else {
+        (
+            serde_json::json!({ "identical": false, "diffCount": diff.differences.len() }),
+            true,
+        )
+    }
+}
+
 fn edit_serialize(
     doc: &mut rhwp::wasm_api::HwpDocument,
     format: EditOutputFormat,
@@ -9788,6 +9826,8 @@ fn edit_fill_fields(args: &[String]) -> i32 {
     let mut out_path: Option<String> = None;
     let mut dry_run = false;
     let mut json_mode = false;
+    // [#3702] 저장 직후 자기검증 — 판정은 데이터, 차이 시 exit 3.
+    let mut verify_mode = false;
 
     let mut i = 0;
     while i < args.len() {
@@ -9814,6 +9854,7 @@ fn edit_fill_fields(args: &[String]) -> i32 {
             }
             "--dry-run" => dry_run = true,
             "--json" => json_mode = true,
+            "--verify" => verify_mode = true,
             other if other.starts_with('-') => {
                 eprintln!("알 수 없는 옵션: {other}");
                 return EXIT_USAGE;
@@ -9943,6 +9984,8 @@ fn edit_fill_fields(args: &[String]) -> i32 {
         }
     });
 
+    let mut verify_report = serde_json::Value::Null;
+    let mut verify_failed = false;
     if !dry_run {
         let out_bytes = match edit_serialize(&mut doc, out_format) {
             Ok(b) => b,
@@ -9959,6 +10002,14 @@ fn edit_fill_fields(args: &[String]) -> i32 {
             eprintln!("오류: 출력 쓰기 실패 - {}: {}", output_path, e);
             return EXIT_RUNTIME;
         }
+        // [#3702] 저장 직후 자기검증 — 편집 후 IR ↔ 저장본 재파싱 IR.
+        if verify_mode {
+            let cross = out_format == EditOutputFormat::Hwp
+                && rhwp::parser::detect_format(&bytes) == rhwp::parser::FileFormat::Hwpx;
+            let (report, failed) = edit_verify_report(&doc, &out_bytes, cross);
+            verify_report = report;
+            verify_failed = failed;
+        }
     }
 
     if json_mode {
@@ -9974,8 +10025,12 @@ fn edit_fill_fields(args: &[String]) -> i32 {
         if !dry_run {
             envelope["output"] = serde_json::Value::String(output_path.clone());
             envelope["outputFormat"] = serde_json::Value::String(out_format.label().to_string());
+            envelope["verify"] = verify_report.clone();
         }
         println!("{envelope}");
+        if verify_failed {
+            process::exit(3);
+        }
         return EXIT_OK;
     }
 
@@ -9999,6 +10054,10 @@ fn edit_fill_fields(args: &[String]) -> i32 {
     if !not_found.is_empty() {
         println!("  문서에 없는 필드 이름: {}", not_found.join(", "));
     }
+    if verify_failed {
+        eprintln!("검증 실패(--verify): 저장본 재파싱 IR 차이 — 상세는 --json 또는 ir-diff");
+        process::exit(3);
+    }
     EXIT_OK
 }
 
@@ -10016,6 +10075,8 @@ fn edit_replace_text(args: &[String]) -> i32 {
     let mut ignore_case = false;
     let mut dry_run = false;
     let mut json_mode = false;
+    // [#3702] 저장 직후 자기검증 — 판정은 데이터, 차이 시 exit 3.
+    let mut verify_mode = false;
     // [#3395] 문서 순서 k번째(0 기준) 매치만 치환 — 체크박스류 반복 문자 지목.
     let mut occurrence: Option<usize> = None;
 
@@ -10065,6 +10126,7 @@ fn edit_replace_text(args: &[String]) -> i32 {
             }
             "--dry-run" => dry_run = true,
             "--json" => json_mode = true,
+            "--verify" => verify_mode = true,
             other if other.starts_with('-') => {
                 eprintln!("알 수 없는 옵션: {other}");
                 return EXIT_USAGE;
@@ -10142,6 +10204,8 @@ fn edit_replace_text(args: &[String]) -> i32 {
 
     // 0건이면 무변경이다 — 산출물을 만들지 않는다 (dry-run 과 동일하게 파일 경로를 타지 않음).
     let wrote_output = !dry_run && replaced_count > 0;
+    let mut verify_report = serde_json::Value::Null;
+    let mut verify_failed = false;
     if wrote_output {
         let out_bytes = match edit_serialize(&mut doc, out_format) {
             Ok(b) => b,
@@ -10157,6 +10221,14 @@ fn edit_replace_text(args: &[String]) -> i32 {
         if let Err(e) = fs::write(&output_path, &out_bytes) {
             eprintln!("오류: 출력 쓰기 실패 - {}: {}", output_path, e);
             return EXIT_RUNTIME;
+        }
+        // [#3702] 저장 직후 자기검증 — 편집 후 IR ↔ 저장본 재파싱 IR.
+        if verify_mode {
+            let cross = out_format == EditOutputFormat::Hwp
+                && rhwp::parser::detect_format(&bytes) == rhwp::parser::FileFormat::Hwpx;
+            let (report, failed) = edit_verify_report(&doc, &out_bytes, cross);
+            verify_report = report;
+            verify_failed = failed;
         }
     }
 
@@ -10174,8 +10246,12 @@ fn edit_replace_text(args: &[String]) -> i32 {
         if wrote_output {
             envelope["output"] = serde_json::Value::String(output_path.clone());
             envelope["outputFormat"] = serde_json::Value::String(out_format.label().to_string());
+            envelope["verify"] = verify_report.clone();
         }
         println!("{envelope}");
+        if verify_failed {
+            process::exit(3);
+        }
         return EXIT_OK;
     }
 
@@ -10194,6 +10270,10 @@ fn edit_replace_text(args: &[String]) -> i32 {
             "치환 완료: {} → {} — {:?} → {:?} ({}건)",
             file_path, output_path, find, replace, replaced_count
         );
+    }
+    if verify_failed {
+        eprintln!("검증 실패(--verify): 저장본 재파싱 IR 차이 — 상세는 --json 또는 ir-diff");
+        process::exit(3);
     }
     EXIT_OK
 }
@@ -10483,6 +10563,8 @@ fn edit_set_cell(args: &[String]) -> i32 {
     let mut out_path: Option<String> = None;
     let mut dry_run = false;
     let mut json_mode = false;
+    // [#3702] 저장 직후 자기검증 — 판정은 데이터, 차이 시 exit 3.
+    let mut verify_mode = false;
     // [#3391] 실물 공고 양식의 기입 칸 안내문은 파란 이탤릭이 흔하다. set-cell 은
     // "안내문을 지우고 실값을 쓰는" 용도이므로 제출 요건(검정 글씨)에 맞춰 기본을
     // 검정·비이탤릭·비진하게로 기록한다. --keep-style 로 셀 스타일 상속을 유지한다.
@@ -10547,6 +10629,7 @@ fn edit_set_cell(args: &[String]) -> i32 {
             }
             "--dry-run" => dry_run = true,
             "--json" => json_mode = true,
+            "--verify" => verify_mode = true,
             other if other.starts_with('-') => {
                 eprintln!("알 수 없는 옵션: {other}");
                 return EXIT_USAGE;
@@ -10673,6 +10756,8 @@ fn edit_set_cell(args: &[String]) -> i32 {
         format!("{}_cell.{}", stem, out_format.ext())
     });
 
+    let mut verify_report = serde_json::Value::Null;
+    let mut verify_failed = false;
     if !dry_run {
         let out_bytes = match edit_serialize(&mut doc, out_format) {
             Ok(b) => b,
@@ -10688,6 +10773,14 @@ fn edit_set_cell(args: &[String]) -> i32 {
         if let Err(e) = fs::write(&output_path, &out_bytes) {
             eprintln!("오류: 출력 쓰기 실패 - {}: {}", output_path, e);
             return EXIT_RUNTIME;
+        }
+        // [#3702] 저장 직후 자기검증 — 편집 후 IR ↔ 저장본 재파싱 IR.
+        if verify_mode {
+            let cross = out_format == EditOutputFormat::Hwp
+                && rhwp::parser::detect_format(&bytes) == rhwp::parser::FileFormat::Hwpx;
+            let (report, failed) = edit_verify_report(&doc, &out_bytes, cross);
+            verify_report = report;
+            verify_failed = failed;
         }
     }
 
@@ -10707,8 +10800,12 @@ fn edit_set_cell(args: &[String]) -> i32 {
         if !dry_run {
             envelope["output"] = serde_json::Value::String(output_path.clone());
             envelope["outputFormat"] = serde_json::Value::String(out_format.label().to_string());
+            envelope["verify"] = verify_report.clone();
         }
         println!("{envelope}");
+        if verify_failed {
+            process::exit(3);
+        }
         return EXIT_OK;
     }
 
@@ -10722,6 +10819,10 @@ fn edit_set_cell(args: &[String]) -> i32 {
             "셀 기록 완료: {} → {} — 표{} ({},{}) {:?} → {:?}",
             file_path, output_path, table_no, row, col, old_text, new_text
         );
+    }
+    if verify_failed {
+        eprintln!("검증 실패(--verify): 저장본 재파싱 IR 차이 — 상세는 --json 또는 ir-diff");
+        process::exit(3);
     }
     EXIT_OK
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,7 +288,15 @@ fn main() {
         // 종료 코드 2로 끝낸다(기존에는 stdout + 0이라 오타 낸 명령이 스크립트에서 성공으로 보였다).
         other => {
             match other {
-                Some(command) => eprintln!("오류: 알 수 없는 명령입니다 - {}", command),
+                Some(command) => {
+                    eprintln!("오류: 알 수 없는 명령입니다 - {}", command);
+                    // [#3694] did-you-mean — 후보는 capabilities 단일 출처. 이름 환각을
+                    // 교정 단서 없이 돌려보내면 경량 에이전트는 맹목 재시도 루프에 빠진다.
+                    let names = capabilities_command_names();
+                    if let Some(hint) = closest_name(command, names.iter().map(String::as_str)) {
+                        eprintln!("힌트: 가장 가까운 명령은 '{hint}' 입니다");
+                    }
+                }
                 None => eprintln!("오류: 명령을 지정해주세요."),
             }
             eprintln!("rhwp v{}", rhwp::version());
@@ -831,90 +839,40 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
 ///
 /// `--help`(사람용)와 본 목록(기계용)은 함께 현행화한다 — help 에만 추가된 명령은
 /// `tests/cli_json_contract.rs::capabilities_covers_every_help_command` 가 잡는다.
-fn show_capabilities(args: &[String]) -> i32 {
-    // [#3263] --mcp: MCP 서버가 그대로 등록할 수 있는 도구 정의.
-    // 로드맵상 MCP 서버 자체는 별도 저장소(#227)지만, 그 서버가 도구 목록·입력 스키마를
-    // 손으로 베껴 쓰면 rhwp 가 바뀔 때마다 조용히 낡는다. 원천을 여기서 낸다.
-    let mut mcp_mode = false;
-    // [#3629] 직무 프로필 필터 — 단일 출처는 agent_profiles::PROFILES.
-    let mut profile: Option<String> = None;
-    let mut i = 0;
-    while i < args.len() {
-        match args[i].as_str() {
-            "--mcp" => mcp_mode = true,
-            "--profile" => {
-                i += 1;
-                match args.get(i) {
-                    Some(p) => profile = Some(p.clone()),
-                    None => {
-                        eprintln!("오류: --profile 뒤에 역할 이름이 필요합니다.");
-                        eprintln!("사용 가능: {}", agent_profiles::names().join(", "));
-                        return EXIT_USAGE;
-                    }
-                }
-            }
-            other => {
-                eprintln!("알 수 없는 옵션: {other}");
-                return EXIT_USAGE;
-            }
-        }
-        i += 1;
-    }
-    let profile = match profile {
-        Some(name) => match agent_profiles::find(&name) {
-            Some(p) => Some(p),
-            None => {
-                eprintln!("오류: 알 수 없는 프로필 '{name}'");
-                eprintln!("사용 가능: {}", agent_profiles::names().join(", "));
-                return EXIT_USAGE;
-            }
-        },
-        None => None,
-    };
-    if mcp_mode {
-        return show_mcp_tools(profile);
-    }
-    if profile.is_some() {
-        eprintln!(
-            "오류: --profile 은 --mcp 와 함께 사용합니다 (capabilities --mcp --profile <역할>)."
-        );
-        return EXIT_USAGE;
-    }
+// [#3694] capabilities 명령 목록의 단일 출처 — 자기서술과 did-you-mean 이 공유한다.
+fn cmd(name: &str, category: &str, summary: &str) -> serde_json::Value {
+    serde_json::json!({ "name": name, "category": category, "summary": summary })
+}
 
-    fn cmd(name: &str, category: &str, summary: &str) -> serde_json::Value {
-        serde_json::json!({ "name": name, "category": category, "summary": summary })
-    }
-    fn cmd_json(
-        name: &str,
-        category: &str,
-        summary: &str,
-        batch: bool,
-        flags: &[&str],
-        record_fields: &[&str],
-    ) -> serde_json::Value {
-        serde_json::json!({
-            "name": name, "category": category, "summary": summary,
-            "json": true, "batch": batch, "flags": flags, "recordFields": record_fields,
-        })
-    }
-    /// [#3357] feature 게이트 명령 — 빌드에 따라 실행 가능 여부가 달라지므로 자기서술이
-    /// 가용성을 명시한다. 두 필드는 빌드와 무관하게 항상 방출되고 값만 달라진다
-    /// (스키마 안정성). 매니페스트만 보고 호출을 생성하는 에이전트가 exit 2 를
-    /// 밟기 전에 알 수 있게 한다.
-    fn cmd_gated(
-        name: &str,
-        category: &str,
-        summary: &str,
-        requires_feature: &str,
-        available: bool,
-    ) -> serde_json::Value {
-        serde_json::json!({
-            "name": name, "category": category, "summary": summary,
-            "requiresFeature": requires_feature, "available": available,
-        })
-    }
+fn cmd_json(
+    name: &str,
+    category: &str,
+    summary: &str,
+    batch: bool,
+    flags: &[&str],
+    record_fields: &[&str],
+) -> serde_json::Value {
+    serde_json::json!({
+        "name": name, "category": category, "summary": summary,
+        "json": true, "batch": batch, "flags": flags, "recordFields": record_fields,
+    })
+}
 
-    let commands = vec![
+fn cmd_gated(
+    name: &str,
+    category: &str,
+    summary: &str,
+    requires_feature: &str,
+    available: bool,
+) -> serde_json::Value {
+    serde_json::json!({
+        "name": name, "category": category, "summary": summary,
+        "requiresFeature": requires_feature, "available": available,
+    })
+}
+
+fn capabilities_command_entries() -> Vec<serde_json::Value> {
+    vec![
         // ── 기계 계약(--json) 명령 ──
         cmd_json(
             "info",
@@ -1300,7 +1258,103 @@ fn show_capabilities(args: &[String]) -> i32 {
         cmd("test-field", "internal", "누름틀 왕복 테스트"),
         cmd("gen-table", "internal", "표 샘플 생성"),
         cmd("gen-pua", "internal", "PUA 샘플 생성"),
-    ];
+    ]
+}
+
+/// [#3694] 명령 이름 목록 (did-you-mean 후보).
+fn capabilities_command_names() -> Vec<String> {
+    capabilities_command_entries()
+        .iter()
+        .filter_map(|c| c["name"].as_str().map(String::from))
+        .collect()
+}
+
+/// [#3694] 레벤슈타인 거리 — 의존성 없이 소형 구현 (이름 환각 교정용).
+pub(crate) fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut cur = vec![0usize; b.len() + 1];
+    for i in 1..=a.len() {
+        cur[0] = i;
+        for j in 1..=b.len() {
+            let cost = usize::from(a[i - 1] != b[j - 1]);
+            cur[j] = (prev[j] + 1).min(cur[j - 1] + 1).min(prev[j - 1] + cost);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[b.len()]
+}
+
+/// [#3694] 후보 중 가장 가까운 이름 — 임계(길이 대비 1/3, 최소 1·최대 3) 초과면 None.
+/// 오제안 0 원칙: 애매하면 제안하지 않는 편이 경량 에이전트에게 안전하다.
+pub(crate) fn closest_name<'a, I: IntoIterator<Item = &'a str>>(
+    input: &str,
+    candidates: I,
+) -> Option<String> {
+    let mut best: Option<(usize, &str)> = None;
+    for c in candidates {
+        let d = levenshtein(input, c);
+        if best.map(|(bd, _)| d < bd).unwrap_or(true) {
+            best = Some((d, c));
+        }
+    }
+    let (d, name) = best?;
+    let cap = (input.chars().count() / 3).clamp(1, 3);
+    (d <= cap).then(|| name.to_string())
+}
+
+fn show_capabilities(args: &[String]) -> i32 {
+    // [#3263] --mcp: MCP 서버가 그대로 등록할 수 있는 도구 정의.
+    // 로드맵상 MCP 서버 자체는 별도 저장소(#227)지만, 그 서버가 도구 목록·입력 스키마를
+    // 손으로 베껴 쓰면 rhwp 가 바뀔 때마다 조용히 낡는다. 원천을 여기서 낸다.
+    let mut mcp_mode = false;
+    // [#3629] 직무 프로필 필터 — 단일 출처는 agent_profiles::PROFILES.
+    let mut profile: Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--mcp" => mcp_mode = true,
+            "--profile" => {
+                i += 1;
+                match args.get(i) {
+                    Some(p) => profile = Some(p.clone()),
+                    None => {
+                        eprintln!("오류: --profile 뒤에 역할 이름이 필요합니다.");
+                        eprintln!("사용 가능: {}", agent_profiles::names().join(", "));
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            other => {
+                eprintln!("알 수 없는 옵션: {other}");
+                return EXIT_USAGE;
+            }
+        }
+        i += 1;
+    }
+    let profile = match profile {
+        Some(name) => match agent_profiles::find(&name) {
+            Some(p) => Some(p),
+            None => {
+                eprintln!("오류: 알 수 없는 프로필 '{name}'");
+                eprintln!("사용 가능: {}", agent_profiles::names().join(", "));
+                return EXIT_USAGE;
+            }
+        },
+        None => None,
+    };
+    if mcp_mode {
+        return show_mcp_tools(profile);
+    }
+    if profile.is_some() {
+        eprintln!(
+            "오류: --profile 은 --mcp 와 함께 사용합니다 (capabilities --mcp --profile <역할>)."
+        );
+        return EXIT_USAGE;
+    }
+
+    let commands = capabilities_command_entries();
 
     let caps = serde_json::json!({
         "schemaVersion": "1.0",

--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -377,9 +377,15 @@ fn handle_tool_call(
                 let did_you_mean: Vec<String> = crate::closest_name(name, candidates.into_iter())
                     .into_iter()
                     .collect();
-                return Ok(tool_error(
-                    serde_json::json!({ "error": error, "didYouMean": did_you_mean }).to_string(),
-                ));
+                let mut body = serde_json::json!({ "error": error, "didYouMean": did_you_mean });
+                if let Some(best) = body["didYouMean"][0].as_str() {
+                    body["nextCall"] = serde_json::json!({
+                        "name": best,
+                        "arguments": {},
+                        "why": "요청한 이름이 없음 — 가장 가까운 실존 도구로 교정"
+                    });
+                }
+                return Ok(tool_error(body.to_string()));
             };
             Ok(run_cli_tool(def, &args))
         }
@@ -401,6 +407,23 @@ fn is_session_tool(name: &str) -> bool {
             | "hwp_doc_fill_fields"
             | "hwp_doc_save"
             | "hwp_close"
+    )
+}
+
+/// [#3699] 교정 호출 동봉 오류 — error 필드가 기존 원문을 담아 하위호환.
+/// nextCall.name 은 반드시 실존 도구(호출부 책임, 계약 테스트가 고정).
+fn tool_error_with_next(
+    message: String,
+    next_name: &str,
+    next_args: serde_json::Value,
+    why: &str,
+) -> serde_json::Value {
+    tool_error(
+        serde_json::json!({
+            "error": message,
+            "nextCall": { "name": next_name, "arguments": next_args, "why": why }
+        })
+        .to_string(),
     )
 }
 
@@ -495,7 +518,12 @@ fn session_doc_text(args: &serde_json::Value, sessions: &mut Sessions) -> serde_
         return tool_error("docId 가 필요합니다".into());
     };
     let Some(sd) = sessions.docs.get_mut(doc_id) else {
-        return tool_error(format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"));
+        return tool_error_with_next(
+            format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"),
+            "hwp_open",
+            serde_json::json!({ "path": "<열 문서 경로>" }),
+            "핸들이 없거나 만료 — hwp_open 으로 docId 를 재발급한 뒤 재시도",
+        );
     };
     let doc = &mut sd.doc;
     let page_count = doc.page_count();
@@ -541,9 +569,12 @@ fn with_doc<'a>(
     let id = doc_id.to_string();
     match sessions.docs.get_mut(&id) {
         Some(sd) => Ok((sd, id)),
-        None => Err(tool_error(format!(
-            "열려 있지 않은 핸들: {id} (hwp_open 먼저)"
-        ))),
+        None => Err(tool_error_with_next(
+            format!("열려 있지 않은 핸들: {id} (hwp_open 먼저)"),
+            "hwp_open",
+            serde_json::json!({ "path": "<열 문서 경로>" }),
+            "핸들이 없거나 만료 — hwp_open 으로 docId 를 재발급한 뒤 재시도",
+        )),
     }
 }
 
@@ -639,7 +670,12 @@ fn session_search(args: &serde_json::Value, sessions: &mut Sessions) -> serde_js
         .and_then(|c| c.as_bool())
         .unwrap_or(true);
     let Some(sd) = sessions.docs.get_mut(doc_id) else {
-        return tool_error(format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"));
+        return tool_error_with_next(
+            format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"),
+            "hwp_open",
+            serde_json::json!({ "path": "<열 문서 경로>" }),
+            "핸들이 없거나 만료 — hwp_open 으로 docId 를 재발급한 뒤 재시도",
+        );
     };
     let matches = sd.doc.grep(query, case_sensitive, None);
     let total = matches.len();
@@ -668,7 +704,12 @@ fn session_replace_text(args: &serde_json::Value, sessions: &mut Sessions) -> se
         .and_then(|c| c.as_bool())
         .unwrap_or(true);
     let Some(sd) = sessions.docs.get_mut(doc_id) else {
-        return tool_error(format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"));
+        return tool_error_with_next(
+            format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"),
+            "hwp_open",
+            serde_json::json!({ "path": "<열 문서 경로>" }),
+            "핸들이 없거나 만료 — hwp_open 으로 docId 를 재발급한 뒤 재시도",
+        );
     };
     let result = match sd.doc.replace_all_native(find, replace, case_sensitive) {
         Ok(r) => r,
@@ -715,7 +756,12 @@ fn session_set_cell(args: &serde_json::Value, sessions: &mut Sessions) -> serde_
     };
     let id = doc_id.to_string();
     let Some(sd) = sessions.docs.get_mut(&id) else {
-        return tool_error(format!("열려 있지 않은 핸들: {id} (hwp_open 먼저)"));
+        return tool_error_with_next(
+            format!("열려 있지 않은 핸들: {id} (hwp_open 먼저)"),
+            "hwp_open",
+            serde_json::json!({ "path": "<열 문서 경로>" }),
+            "핸들이 없거나 만료 — hwp_open 으로 docId 를 재발급한 뒤 재시도",
+        );
     };
     let table_no = match usize::try_from(table_no) {
         Ok(value) => value,
@@ -806,7 +852,12 @@ fn session_fill_fields(args: &serde_json::Value, sessions: &mut Sessions) -> ser
         return tool_error("data 는 {\"필드이름\":\"값\"} 객체여야 합니다".into());
     };
     let Some(sd) = sessions.docs.get_mut(doc_id) else {
-        return tool_error(format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"));
+        return tool_error_with_next(
+            format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"),
+            "hwp_open",
+            serde_json::json!({ "path": "<열 문서 경로>" }),
+            "핸들이 없거나 만료 — hwp_open 으로 docId 를 재발급한 뒤 재시도",
+        );
     };
     let doc = &mut sd.doc;
 
@@ -880,7 +931,12 @@ fn session_save(args: &serde_json::Value, sessions: &mut Sessions) -> serde_json
         return tool_error("output 이 필요합니다".into());
     };
     let Some(sd) = sessions.docs.get_mut(doc_id) else {
-        return tool_error(format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"));
+        return tool_error_with_next(
+            format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"),
+            "hwp_open",
+            serde_json::json!({ "path": "<열 문서 경로>" }),
+            "핸들이 없거나 만료 — hwp_open 으로 docId 를 재발급한 뒤 재시도",
+        );
     };
 
     let format = if sd.source_is_hwpx {
@@ -912,7 +968,12 @@ fn session_close(args: &serde_json::Value, sessions: &mut Sessions) -> serde_jso
         return tool_error("docId 가 필요합니다".into());
     };
     if sessions.docs.remove(doc_id).is_none() {
-        return tool_error(format!("열려 있지 않은 핸들: {doc_id}"));
+        return tool_error_with_next(
+            format!("열려 있지 않은 핸들: {doc_id}"),
+            "hwp_open",
+            serde_json::json!({ "path": "<열 문서 경로>" }),
+            "핸들이 없거나 만료 — hwp_open 으로 docId 를 재발급한 뒤 재시도",
+        );
     }
     tool_ok_text(
         serde_json::json!({

--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -368,7 +368,18 @@ fn handle_tool_call(
         "hwp_close" => Ok(session_close(&args, sessions)),
         _ => {
             let Some(def) = tool_defs.iter().find(|t| t["name"] == name) else {
-                return Ok(tool_error(format!("알 수 없는 도구: {name}")));
+                // [#3694] didYouMean — error 필드가 기존 원문을 담아 하위호환.
+                let error = format!("알 수 없는 도구: {name}");
+                let candidates: Vec<&str> = tool_defs
+                    .iter()
+                    .filter_map(|t| t["name"].as_str())
+                    .collect();
+                let did_you_mean: Vec<String> = crate::closest_name(name, candidates.into_iter())
+                    .into_iter()
+                    .collect();
+                return Ok(tool_error(
+                    serde_json::json!({ "error": error, "didYouMean": did_you_mean }).to_string(),
+                ));
             };
             Ok(run_cli_tool(def, &args))
         }

--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -309,7 +309,8 @@ fn served_tools(tool_defs: &[serde_json::Value], include_session: bool) -> Vec<s
             "type": "object",
             "properties": {
                 "docId": { "type": "string", "description": "hwp_open 이 돌려준 핸들" },
-                "output": { "type": "string", "description": "출력 파일 경로" }
+                "output": { "type": "string", "description": "출력 파일 경로" },
+                "verify": { "type": "boolean", "description": "true 면 저장본 재파싱 IR 자기검증(verify 필드)" }
             },
             "required": ["docId", "output"]
         }
@@ -951,6 +952,18 @@ fn session_save(args: &serde_json::Value, sessions: &mut Sessions) -> serde_json
     if let Err(e) = std::fs::write(output, &bytes) {
         return tool_error(format!("{output} 쓰기 실패: {e}"));
     }
+    // [#3702] verify:true — 저장본 재파싱 IR 자기검증. 세션은 exit 가 없으므로
+    // isError:false 를 유지하고 판정은 verify 필드로 낸다(판정은 데이터).
+    let verify = if args
+        .get("verify")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        let (report, _failed) = crate::edit_verify_report(&sd.doc, &bytes, false);
+        report
+    } else {
+        serde_json::Value::Null
+    };
     tool_ok_text(
         serde_json::json!({
             "schemaVersion": "1.0",
@@ -958,6 +971,7 @@ fn session_save(args: &serde_json::Value, sessions: &mut Sessions) -> serde_json
             "output": output,
             "outputFormat": format.label(),
             "bytes": bytes.len(),
+            "verify": verify,
         })
         .to_string(),
     )

--- a/tests/did_you_mean_contract.rs
+++ b/tests/did_you_mean_contract.rs
@@ -1,0 +1,68 @@
+//! [#3694] did-you-mean — 이름 환각 교정 단서 (#3630 P1 구현).
+//! 후보는 capabilities 명령 목록 단일 출처, 임계 초과 시 무제안(오제안 0 원칙).
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+
+#[test]
+fn unknown_command_hints_closest_and_keeps_exit_2() {
+    let out = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("exprot-svg") // 오타
+        .output()
+        .expect("rhwp");
+    assert_eq!(out.status.code(), Some(2));
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("힌트: 가장 가까운 명령은 'export-svg' 입니다"),
+        "{err}"
+    );
+}
+
+#[test]
+fn gibberish_command_gets_no_hint() {
+    let out = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("코끼리코끼리")
+        .output()
+        .expect("rhwp");
+    assert_eq!(out.status.code(), Some(2));
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(!err.contains("힌트:"), "임계 초과는 무제안: {err}");
+}
+
+#[test]
+fn mcp_unknown_tool_reports_did_you_mean_json() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("mcp-serve")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("mcp-serve");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+    writeln!(
+        stdin,
+        r#"{{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{{"name":"hwp_serch","arguments":{{}}}}}}"#
+    )
+    .unwrap();
+    stdin.flush().unwrap();
+    let mut line = String::new();
+    assert!(stdout.read_line(&mut line).unwrap() > 0);
+    let v: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+    assert_eq!(v["result"]["isError"], true, "{v}");
+    let text = v["result"]["content"][0]["text"].as_str().unwrap();
+    let body: serde_json::Value =
+        serde_json::from_str(text).unwrap_or_else(|e| panic!("구조화 JSON 이어야 함({e}): {text}"));
+    // 하위호환: error 필드가 기존 원문을 담는다.
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("알 수 없는 도구"),
+        "{body}"
+    );
+    assert_eq!(body["didYouMean"][0], "hwp_search", "{body}");
+    let _ = child.kill();
+    let _ = child.wait();
+}

--- a/tests/edit_verify_contract.rs
+++ b/tests/edit_verify_contract.rs
@@ -1,0 +1,190 @@
+//! [#3702] 편집 --verify 내장 — 저장 직후 자기검증 봉투 (#3630 P2).
+//! 봉투-exit 정합: identical=false 면 봉투 출력 후 exit 3 (판정은 데이터).
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+const SAMPLE: &str = "samples/field-01.hwp";
+
+fn sample() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn temp_path(tag: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "rhwp-editverify-{tag}-{}-{}.hwp",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ))
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp")
+}
+
+#[test]
+fn fill_verify_reports_and_exit_matches() {
+    let p = sample();
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let out = temp_path("fill");
+    let args = [
+        "edit",
+        "fill-fields",
+        p.to_str().unwrap(),
+        "--data",
+        r#"{"회사명":"검증사"}"#,
+        "-o",
+        out.to_str().unwrap(),
+        "--verify",
+        "--json",
+    ];
+    let output = run(&args);
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).expect("envelope");
+    let identical = v["verify"]["identical"]
+        .as_bool()
+        .unwrap_or_else(|| panic!("verify.identical 필요: {v}"));
+    let expected = if identical { 0 } else { 3 };
+    assert_eq!(output.status.code(), Some(expected), "봉투-exit 모순: {v}");
+    assert!(out.exists(), "판정과 무관하게 산출물은 남는다");
+    let _ = std::fs::remove_file(&out);
+}
+
+#[test]
+fn without_verify_field_is_null_and_exit_0() {
+    let p = sample();
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let out = temp_path("novf");
+    let args = [
+        "edit",
+        "fill-fields",
+        p.to_str().unwrap(),
+        "--data",
+        r#"{"회사명":"A"}"#,
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(output.status.code(), Some(0));
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(v["verify"].is_null(), "미요청 시 null: {v}");
+    let _ = std::fs::remove_file(&out);
+}
+
+#[test]
+fn set_cell_and_replace_accept_verify() {
+    let p = sample();
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let table_sample = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("samples/2025년 기부·답례품 실적 지자체 보고서_양식.hwpx");
+    if !table_sample.exists() {
+        eprintln!("표 샘플 없음 — 건너뜀");
+        return;
+    }
+    let _ = p;
+    // 좌표는 하드코딩하지 않는다 — export-tables 재독으로 실존 최상위 표·셀을 고른다.
+    let listing = run(&["export-tables", table_sample.to_str().unwrap(), "--json"]);
+    assert_eq!(listing.status.code(), Some(0));
+    let tables: serde_json::Value = serde_json::from_slice(&listing.stdout).expect("tables");
+    let table = tables["tables"]
+        .as_array()
+        .expect("tables")
+        .iter()
+        .find(|t| t.get("containerPath").is_none())
+        .expect("본문 최상위 표");
+    let (ts, rs, cs) = (
+        table["index"].as_u64().expect("index").to_string(),
+        table["cells"][0]["row"].as_u64().expect("row").to_string(),
+        table["cells"][0]["col"].as_u64().expect("col").to_string(),
+    );
+    let out = temp_path("cell").with_extension("hwpx");
+    let out_s = out.to_str().unwrap().to_string();
+    let args = [
+        "edit",
+        "set-cell",
+        table_sample.to_str().unwrap(),
+        "--table",
+        &ts,
+        "--row",
+        &rs,
+        "--col",
+        &cs,
+        "--text",
+        "V",
+        "-o",
+        &out_s,
+        "--verify",
+        "--json",
+    ];
+    let output = run(&args);
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).expect("envelope");
+    assert!(v["verify"]["identical"].is_boolean(), "{v}");
+    let _ = std::fs::remove_file(&out);
+}
+
+#[test]
+fn session_save_verify_true_carries_report() {
+    let p = sample();
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("mcp-serve")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+    let out = temp_path("sess");
+    let reqs = [
+        format!(
+            r#"{{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{{"name":"hwp_open","arguments":{{"path":{}}}}}}}"#,
+            serde_json::json!(p.to_str().unwrap())
+        ),
+        format!(
+            r#"{{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{{"name":"hwp_doc_save","arguments":{{"docId":"doc-1","output":{},"verify":true}}}}}}"#,
+            serde_json::json!(out.to_str().unwrap())
+        ),
+    ];
+    for r in &reqs {
+        writeln!(stdin, "{r}").unwrap();
+    }
+    stdin.flush().unwrap();
+    let mut verify_seen = false;
+    let mut line = String::new();
+    for _ in 0..2 {
+        line.clear();
+        assert!(stdout.read_line(&mut line).unwrap() > 0);
+        let v: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+        if v["id"] == 2 {
+            let text = v["result"]["content"][0]["text"].as_str().unwrap();
+            let body: serde_json::Value = serde_json::from_str(text).unwrap();
+            assert!(body["verify"]["identical"].is_boolean(), "{body}");
+            verify_seen = true;
+        }
+    }
+    assert!(verify_seen);
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_file(&out);
+}

--- a/tests/mcp_next_call_contract.rs
+++ b/tests/mcp_next_call_contract.rs
@@ -1,0 +1,80 @@
+//! [#3699] nextCall — isError 에 기계가 따라할 교정 호출 동봉 (#3630 P4).
+//! error 필드가 기존 원문을 담아 하위호환, nextCall.name 은 실존 도구만.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+
+fn serve_call(req: &str) -> serde_json::Value {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("mcp-serve")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("mcp-serve");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+    writeln!(stdin, "{req}").unwrap();
+    stdin.flush().unwrap();
+    let mut line = String::new();
+    assert!(stdout.read_line(&mut line).unwrap() > 0);
+    let _ = child.kill();
+    let _ = child.wait();
+    serde_json::from_str(line.trim()).unwrap()
+}
+
+fn error_body(v: &serde_json::Value) -> serde_json::Value {
+    assert_eq!(v["result"]["isError"], true, "{v}");
+    let text = v["result"]["content"][0]["text"].as_str().unwrap();
+    serde_json::from_str(text).unwrap_or_else(|e| panic!("구조화 JSON 이어야 함({e}): {text}"))
+}
+
+#[test]
+fn closed_handle_carries_next_call_to_open() {
+    let v = serve_call(
+        r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hwp_doc_fill_fields","arguments":{"docId":"doc-999","data":{"a":"b"}}}}"#,
+    );
+    let body = error_body(&v);
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap()
+            .contains("열려 있지 않은 핸들"),
+        "하위호환 원문: {body}"
+    );
+    assert_eq!(body["nextCall"]["name"], "hwp_open", "{body}");
+    assert!(body["nextCall"]["why"].is_string(), "{body}");
+}
+
+#[test]
+fn unknown_tool_next_call_is_registered_tool() {
+    let v = serve_call(
+        r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hwp_serch","arguments":{}}}"#,
+    );
+    let body = error_body(&v);
+    assert_eq!(body["nextCall"]["name"], "hwp_search", "{body}");
+    // 실존 도구 대조: capabilities --mcp 선언에 있어야 한다.
+    let caps = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(["capabilities", "--mcp"])
+        .output()
+        .unwrap();
+    let m: serde_json::Value = serde_json::from_slice(&caps.stdout).unwrap();
+    assert!(
+        m["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|t| t["name"] == body["nextCall"]["name"]),
+        "{body}"
+    );
+}
+
+#[test]
+fn close_on_unknown_handle_also_guides_open() {
+    let v = serve_call(
+        r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hwp_close","arguments":{"docId":"doc-999"}}}"#,
+    );
+    let body = error_body(&v);
+    assert_eq!(body["nextCall"]["name"], "hwp_open", "{body}");
+}

--- a/tests/run_plan_contract.rs
+++ b/tests/run_plan_contract.rs
@@ -65,7 +65,10 @@ fn prevalidation_failure_is_exit_2_with_no_output() {
     assert_eq!(invalid.len(), 1, "{v}");
     assert_eq!(invalid[0]["step"], 1, "0-기반 step 지목: {v}");
     assert!(
-        invalid[0]["reason"].as_str().unwrap_or("").contains("존재하지않는필드XYZ"),
+        invalid[0]["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("존재하지않는필드XYZ"),
         "왜 불가한지: {v}"
     );
     let _ = std::fs::remove_file(&plan_path);

--- a/tests/run_plan_contract.rs
+++ b/tests/run_plan_contract.rs
@@ -1,0 +1,220 @@
+//! [#3703] 계획 실행기 `rhwp run` — 선언적 편집 계획의 정적 선검증·원자 실행·저널.
+//! 계약: 선검증 실패 = exit 2 + 디스크 무변경, 성공 = 저널 봉투 + 단 한 번 저장,
+//! 왕복 재독으로 편집 실적용 확인, MCP `hwp_run_plan` 선언.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+const SAMPLE: &str = "samples/field-01.hwp";
+
+fn sample() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn temp_path(tag: &str, ext: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "rhwp-runplan-{tag}-{}-{}.{ext}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ))
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp")
+}
+
+fn write_plan(tag: &str, plan: &serde_json::Value) -> PathBuf {
+    let p = temp_path(tag, "json");
+    std::fs::write(&p, serde_json::to_vec_pretty(plan).unwrap()).unwrap();
+    p
+}
+
+/// 선검증 실패는 실행 0 — exit 2 에 출력 파일이 아예 생기지 않아야 한다.
+/// 저널은 어느 step 이 왜 불가한지 데이터로 말한다.
+#[test]
+fn prevalidation_failure_is_exit_2_with_no_output() {
+    let p = sample();
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let out = temp_path("preval", "hwp");
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": p.to_str().unwrap(),
+        "output": out.to_str().unwrap(),
+        "steps": [
+            { "action": "fill_fields", "data": {"회사명": "검증사"} },
+            { "action": "fill_fields", "data": {"존재하지않는필드XYZ": "값"} },
+        ],
+    });
+    let plan_path = write_plan("preval", &plan);
+    let output = run(&["run", plan_path.to_str().unwrap(), "--json"]);
+    assert_eq!(output.status.code(), Some(2), "선검증 실패는 exit 2");
+    assert!(!out.exists(), "실행 0 증명 — 출력 파일 부재");
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).expect("envelope");
+    let invalid = v["invalid"].as_array().expect("invalid[]");
+    assert_eq!(invalid.len(), 1, "{v}");
+    assert_eq!(invalid[0]["step"], 1, "0-기반 step 지목: {v}");
+    assert!(
+        invalid[0]["reason"].as_str().unwrap_or("").contains("존재하지않는필드XYZ"),
+        "왜 불가한지: {v}"
+    );
+    let _ = std::fs::remove_file(&plan_path);
+}
+
+/// 중간 step 이 불가하면 앞 step 이 유효해도 디스크 무변경 (자연 트랜잭션).
+#[test]
+fn mid_plan_invalid_step_leaves_disk_unchanged() {
+    let p = sample();
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let out = temp_path("atomic", "hwp");
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": p.to_str().unwrap(),
+        "output": out.to_str().unwrap(),
+        "steps": [
+            { "action": "fill_fields", "data": {"회사명": "선행유효"} },
+            { "action": "replace_text", "find": "이런문자열은문서에없다9999", "replace": "X" },
+        ],
+    });
+    let plan_path = write_plan("atomic", &plan);
+    let output = run(&["run", plan_path.to_str().unwrap(), "--json"]);
+    assert_eq!(output.status.code(), Some(2), "중간 불가 = 전체 불가");
+    assert!(!out.exists(), "선행 step 도 디스크에 닿지 않는다");
+    let _ = std::fs::remove_file(&plan_path);
+}
+
+/// 정상 계획: 저널이 step 별 결과와 verify 자기검증을 담고 exit 0.
+#[test]
+fn journal_reports_steps_and_verify() {
+    let p = sample();
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let out = temp_path("journal", "hwp");
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": p.to_str().unwrap(),
+        "output": out.to_str().unwrap(),
+        "steps": [
+            { "action": "fill_fields", "data": {"회사명": "계획실행사"} },
+        ],
+        "assertions": { "notFoundEmpty": true, "verify": true },
+    });
+    let plan_path = write_plan("journal", &plan);
+    let output = run(&["run", plan_path.to_str().unwrap(), "--json"]);
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).expect("envelope");
+    assert_eq!(output.status.code(), Some(0), "{v}");
+    assert!(out.exists(), "단언 통과 시에만 단 한 번 저장");
+    let steps = v["steps"].as_array().expect("steps[]");
+    assert_eq!(steps.len(), 1, "{v}");
+    assert_eq!(steps[0]["action"], "fill_fields", "{v}");
+    assert_eq!(steps[0]["filledCount"], 1, "{v}");
+    assert_eq!(v["verify"]["identical"], true, "자기검증 동봉: {v}");
+    assert_eq!(v["schemaVersion"], "1.0", "{v}");
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&plan_path);
+}
+
+/// 왕복 재독 — 산출물을 다시 읽어 계획의 편집이 실제 적용됐음을 확인한다.
+#[test]
+fn rerun_reread_confirms_edits_applied() {
+    let p = sample();
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let out = temp_path("reread", "hwp");
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": p.to_str().unwrap(),
+        "output": out.to_str().unwrap(),
+        "steps": [
+            { "action": "fill_fields", "data": {"회사명": "왕복재독사"} },
+        ],
+        "assertions": { "verify": true },
+    });
+    let plan_path = write_plan("reread", &plan);
+    let output = run(&["run", plan_path.to_str().unwrap(), "--json"]);
+    assert_eq!(output.status.code(), Some(0));
+    let fields = run(&["fields", out.to_str().unwrap(), "--json"]);
+    assert_eq!(fields.status.code(), Some(0));
+    let fv: serde_json::Value = serde_json::from_slice(&fields.stdout).expect("fields");
+    let text = fv.to_string();
+    assert!(text.contains("왕복재독사"), "산출물 재독에 새 값: {fv}");
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&plan_path);
+}
+
+/// capabilities --mcp 가 hwp_run_plan 도구를 선언한다 (에이전트 발견 가능성).
+#[test]
+fn capabilities_declares_run_plan_tool() {
+    let output = run(&["capabilities", "--mcp"]);
+    assert_eq!(output.status.code(), Some(0));
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).expect("caps");
+    let names: Vec<&str> = v["tools"]
+        .as_array()
+        .expect("tools")
+        .iter()
+        .filter_map(|t| t["name"].as_str())
+        .collect();
+    assert!(names.contains(&"hwp_run_plan"), "{names:?}");
+}
+
+/// mcp-serve hwp_run_plan — 인라인 계획 객체로 같은 엔진을 태우고 저널을 돌려준다.
+#[test]
+fn mcp_run_plan_returns_journal() {
+    let p = sample();
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let out = temp_path("mcp", "hwp");
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": p.to_str().unwrap(),
+        "output": out.to_str().unwrap(),
+        "steps": [ { "action": "fill_fields", "data": {"회사명": "MCP계획사"} } ],
+        "assertions": { "verify": true },
+    });
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("mcp-serve")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+    writeln!(
+        stdin,
+        r#"{{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{{"name":"hwp_run_plan","arguments":{{"plan":{}}}}}}}"#,
+        serde_json::to_string(&plan).unwrap()
+    )
+    .unwrap();
+    stdin.flush().unwrap();
+    let mut line = String::new();
+    assert!(stdout.read_line(&mut line).unwrap() > 0);
+    let v: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+    assert_eq!(v["result"]["isError"], false, "{v}");
+    let text = v["result"]["content"][0]["text"].as_str().unwrap();
+    let journal: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(journal["verify"]["identical"], true, "{journal}");
+    assert!(out.exists());
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_file(&out);
+}


### PR DESCRIPTION
## 요약 (#3703 · #3608 실행 3층 · #3705 적층)

에이전트 실패의 뿌리는 다단 체이닝입니다 — 호출 사이에서 상태를 잃고, 중간 실패가
반편집 문서를 남깁니다. 이 PR은 절차(도구 호출 나열) 대신 **의도(계획서)** 를 받는
3층, 계획 실행기 `rhwp run` 을 신설합니다.

> 이 PR은 #3705(edit --verify) 위에 적층되어 있습니다 — verify 단언이 그 헬퍼를
> 재사용합니다. 마지막 커밋 1개가 본 변경입니다.

## 동작

```json
{ "planVersion": "1.0", "input": "서식.hwp", "output": "제출본.hwp",
  "steps": [
    { "action": "fill_fields", "data": {"성명":"홍길동"} },
    { "action": "replace_text", "find": "2025년", "replace": "2026년" },
    { "action": "set_cell", "table": 1, "row": 0, "col": 0, "text": "값" },
    { "action": "set_checkbox", "occurrence": 1 }
  ],
  "assertions": { "notFoundEmpty": true, "verify": true } }
```

`rhwp run plan.json --json` (파일 대신 `--plan-json '<인라인>'` 가능):

1. **정적 선검증(실행 0)** — 필드 존재·순번(collect_all_fields 계수)·치환 일치 건수
   (grep 읽기 전용)·셀 좌표(resolve_table_cell)·□ 계수를 전부 미리 검사. 위반을
   **한 번에 모아** `invalid[{step,action,reason}]` + exit 2. 출력 파일을 아예 만들지
   않습니다(두더지잡기 방지 + 실행 0 증명).
2. **원자 실행** — 전 step 을 인메모리 IR 에만 적용. 중간 실패 = 디스크 무변경.
   set_cell 좌표는 앞 step 편집으로 밀릴 수 있어 실행 시점에 재해석합니다.
3. **사후 단언 → 단 한 번 저장** — `assertions.verify` 는 #3702 `edit_verify_report`
   재사용(저장 바이트 재파싱↔IR 대조). 실패 시 저장 없이 exit 3 — 자연 트랜잭션.
4. **저널 봉투** — step 별 결과(filledCount/ambiguous·replacedCount·oldText) + verify
   + assertions 에코. 무엇이 어떻게 됐는지 기계 판정 가능.

새 편집 로직 0 — 판정자와 적용자가 기존 edit 3종과 동일 함수입니다.
MCP `hwp_run_plan{plan}` 은 capabilities 단일 출처에 cmdTemplate 로 등록해
mcp-serve 본체 무변경입니다. help·capabilities 명령 목록 동기화 포함.

## 실측 (mydocs/report/task_m100_3703/evidence.txt)

1. 정상 계획(fill+replace, verify:true): 저널 steps 2건 + `verify identical:true` + exit 0.
2. 위반 2종 계획: `invalid[]` 에 두 위반 동시 보고, exit 2, **출력 파일 부재 = 실행 0 증명**.
3. MCP `hwp_run_plan` 인라인: isError:false + structuredContent 동일 저널.

## 검증

- 신규 `run_plan_contract` 6건 green: 선검증 exit 2·출력 부재 / 중간 불가 원자성 /
  저널-단언 정합 / 왕복 재독(fields 재독으로 새 값 확인) / capabilities 선언 / MCP 저널
- 무회귀: cli_json_contract 22 · edit_verify 4 · fill 7 · replace 4 · set-cell 5 · mcp_server 4
- clippy `-D warnings` 0 · fmt clean

## 처리결과문서

- mydocs/report/task_m100_3703/README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
