### PR TITLE
fix(convert): HWP3 변환본 FileHeader 에 HWP5 버전을 실체화한다 (#3706)

### DIFF
--- a/mydocs/pr_body_draft_3706.md
+++ b/mydocs/pr_body_draft_3706.md
@@ -1,0 +1,54 @@
+# fix(convert): HWP3 변환본 FileHeader 에 HWP5 버전을 실체화한다 (#3706)
+
+## 요약
+
+HWP3 → HWP5 변환본의 FileHeader 가 버전 3 을 선언하던 규격 위반(#3706, #3676 조사에서
+확정)을 수정합니다. 저장 정규화가 `header.raw_data` 를 버리기 전에 그 안의 HWP5
+버전(5.0.3.0)을 필드로 회수하고, 회수 불가면 파서 기본값 5.0.3.0 으로 실체화합니다.
+
+- 전: 변환본 FileHeader 버전 바이트 `00000003` (major=3) — HWP5 규격 위반
+- 후: `00030005` (5.0.3.0) — 한컴 저장본과 같은 5.x 선언
+
+## 근인
+
+두 코드의 전제가 어긋났습니다.
+
+1. HWP3 파서(`parser/hwp3/mod.rs`)는 `version.major = 3` 을 메모리 전용
+   표시(`assign_auto_numbers()` 의 HWP3 문단 카운팅 선택용)로 두고, 실제 저장용 HWP5
+   헤더는 `raw_data` 에 기록 — `serialize_file_header` 의 raw_data 우선 규칙 전제.
+2. 저장 정규화(`normalize_file_header_for_hwp`)가 압축 플래그 실체화 과정에서
+   raw_data 를 무조건 폐기 → 직렬화가 필드 경로로 떨어져 major=3 이 디스크에 기록.
+
+## 범위
+
+- 이 수정은 #3676(한컴 열기 거부)의 근인이 **아닙니다** — #3676 코멘트의 버전 4종
+  실험으로 반증됐고, 거부 근인 3종은 PR #3685 담당입니다. 본 건은 그 조사에서 "별도로
+  정리할 값"으로 남은 독립 규격 위반입니다.
+- 이미 5.x 인 경로(HWPX 파서는 5.1.0.0 을 필드에 직접 기록)는 무변경.
+- 압축 플래그 실체화(기존 동작) 유지 — raw_data 의 flags=0 은 회수하지 않아
+  헤더-스트림 자기모순을 만들지 않습니다.
+- `AdapterReport.file_header_version_materialized` 카운터 신설.
+
+## 검증 (red → green)
+
+회귀 테스트 `tests/issue_3706_hwp3_convert_file_header_version.rs` 3건 — CLI `convert`
+와 같은 경로(parse_hwp3 → convert_if_hwpx_source → serialize_hwp)로 실변환 후 CFB 의
+FileHeader 스트림 바이트를 검사:
+
+1. 변환본이 5.0.3.0 을 선언한다
+2. 버전 회수가 압축 플래그(bit0) 실체화를 깨지 않는다
+3. 재파스·문서 재로드 왕복에서 major=5
+
+| 게이트 | 결과 |
+| --- | --- |
+| red (수정 제거 상태) | **2 failed / 1 passed** — ①·③이 `left: 3, right: 5` 로 실패, ②는 기존 동작이라 통과 |
+| green (수정 적용) | **3 passed** |
+| `--test hwpx_to_hwp_adapter` (변경 파일의 통합 타깃) | **50 passed / 0 failed** (15 ignored) |
+| `--lib document_core::converters::hwpx_to_hwp` (모듈 단위 테스트) | **49 passed / 0 failed** |
+| rustfmt --check (변경 파일 2건) | diff 0 |
+
+처리 기록: `mydocs/report/task_m100_3706_report.md`
+
+Closes #3706
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/mydocs/report/task_m100_3706_report.md
+++ b/mydocs/report/task_m100_3706_report.md
@@ -1,0 +1,74 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_3706_report.md
+last_verified: 2026-08-01
+---
+
+# #3706 처리 기록 — HWP3 → HWP5 변환본 FileHeader 버전 3 기록 수정 (#3676 후속)
+
+- Issue: [#3706](https://github.com/edwardkim/rhwp/issues/3706) —
+  [#3676](https://github.com/edwardkim/rhwp/issues/3676) 조사에서 확정된 규격 위반의
+  분리 등록분 (한컴 열기 거부 근인 3종은 PR #3685 담당, 본 건은 독립)
+- 브랜치 `task/3676-hwp5-hancom-compat`
+
+## 증상
+
+`rhwp convert` 로 만든 HWP3 → HWP5 변환본의 FileHeader 버전 바이트가
+`00000003`(major=3)이다. HWP5 컨테이너는 5.x 를 선언해야 하며(같은 문서의 한컴 저장본
+`samples/hwp3-sample-hwp5.hwp` 는 `01000105` = 5.1.0.1), 버전 3 은 규격 위반이다.
+rhwp 자신은 읽기에서 버전을 강제하지 않아 왕복 검증으로는 드러나지 않는다 — #3676 과
+같은 사각.
+
+## 근인 — 두 코드의 전제 어긋남
+
+1. HWP3 파서(`src/parser/hwp3/mod.rs`)는 `version.major = 3` 을 **메모리 전용
+   표시**(assign_auto_numbers 의 HWP3 문단 카운팅 선택용)로 두고, 실제 저장용 HWP5
+   헤더(5.0.3.0)는 `header.raw_data` 에 넣는다 — `serialize_file_header` 의
+   raw_data 우선 규칙을 전제한 설계다(코드 주석에 명시).
+2. 저장 정규화(`document_core/converters/hwpx_to_hwp.rs::normalize_file_header_for_hwp`)가
+   압축 플래그 실체화 과정에서 **raw_data 를 무조건 버린다.** 직렬화가 필드 경로로
+   떨어지고 메모리 전용 표시값 major=3 이 그대로 디스크에 기록된다.
+
+## 수정
+
+`normalize_file_header_for_hwp` 에서 raw_data 를 버리기 **전에**, `version.major < 5`
+이면 raw_data 바이트 32..36(revision/build/minor/major)의 5.x 버전을 필드로 회수한다.
+회수 불가(raw_data 없음·짧음·major<5)면 파서 기본값 5.0.3.0 으로 실체화한다.
+
+- 이미 5.x 인 경로는 무변경 — HWPX 파서는 5.1.0.0 을 필드에 직접 기록하므로 이 분기에
+  들어오지 않는다.
+- 압축 플래그 실체화(기존 동작)는 그대로 유지 — raw_data 의 flags=0(비압축)은 회수하지
+  않는다. 헤더-스트림 자기모순 방지.
+- `AdapterReport.file_header_version_materialized` 카운터 신설로 관측 표면 유지.
+
+## 검증 — red → green
+
+회귀 테스트 `tests/issue_3706_hwp3_convert_file_header_version.rs` 3건. CLI `convert`
+와 같은 경로(parse_hwp3 → convert_if_hwpx_source → serialize_hwp)로 실변환 후 CFB 에서
+FileHeader 스트림을 꺼내 바이트를 검사한다.
+
+1. `converted_file_header_declares_hwp5_version` — 변환본이 5.0.3.0 을 선언
+2. `converted_file_header_keeps_compressed_flag_materialized` — 압축 플래그(bit0)
+   실체화 유지 (버전 회수가 flags 를 되살리지 않음을 격리)
+3. `converted_reloads_with_hwp5_version` — 재파스·문서 재로드 왕복에서 major=5
+
+| 단계 | 결과 |
+| --- | --- |
+| red (수정 제거 상태) | **2 failed / 1 passed** — ①·③이 `left: 3, right: 5` 로 실패, ②(압축 플래그)는 기존 동작이라 통과 |
+| green (수정 적용) | **3 passed** (0.04s) |
+| `--test hwpx_to_hwp_adapter` (변경 파일의 통합 타깃) | **50 passed / 0 failed** (15 ignored) |
+| `--lib document_core::converters::hwpx_to_hwp` (모듈 단위 테스트) | **49 passed / 0 failed** |
+| rustfmt --check (변경 파일 2건) | diff 0 — "Incorrect newline style" 은 autocrlf 작업본 CRLF 오탐(저장 blob 은 LF) |
+
+수정이 기본값 문서(`Document::default()`, version 0.0.0.0)에도 5.0.3.0 실체화를
+적용하므로, 어댑터 단위 테스트(`empty_doc_normalizes_file_header_once`,
+`idempotent_when_called_twice`)와 통합 타깃 전체로 회귀를 확인했다.
+
+## 남긴 것
+
+- 잔여 위반 여지: HWP3 파서가 raw_data 를 만들지 못하는 경로는 없지만, 방어적으로
+  기본값 5.0.3.0 실체화를 두었다.
+- PR #3685(#3676 근인 3종)와 같은 함수의 인접 영역을 수정한다 — merge 순서에 따라
+  단순 충돌 가능. 본 수정은 3685 의 3종과 독립이므로 어느 쪽이 먼저 들어가도 의미
+  충돌은 없다.

--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -20,7 +20,7 @@ use std::collections::BTreeSet;
 
 use crate::model::bin_data::{BinDataContent, BinDataStatus, BinDataType};
 use crate::model::control::Control;
-use crate::model::document::{Document, Section, SectionDef};
+use crate::model::document::{Document, HwpVersion, Section, SectionDef};
 use crate::model::image::Picture;
 use crate::model::paragraph::Paragraph;
 use crate::model::shape::{common_obj_offsets, ShapeObject, TextBox};
@@ -60,6 +60,8 @@ pub struct AdapterReport {
     pub border_fills_no_fill_normalized: u32,
     /// HWPX 출처 FileHeader를 HWP5 compressed 저장 관례로 보정한 횟수
     pub file_header_compression_normalized: u32,
+    /// [#3706] HWP3 출처 FileHeader 버전(major=3)을 HWP5 버전으로 실체화한 횟수
+    pub file_header_version_materialized: u32,
     /// HWPX 출처 DocProperties.section_count 보정 횟수
     pub doc_properties_section_count_normalized: u32,
     /// HWPX embedded BinData metadata 보정 횟수
@@ -133,6 +135,7 @@ impl AdapterReport {
                 + self.cells_list_header_contract_materialized
                 + self.border_fills_no_fill_normalized
                 + self.file_header_compression_normalized
+                + self.file_header_version_materialized
                 + self.doc_properties_section_count_normalized
                 + self.bin_data_metadata_normalized
                 + self.bin_data_order_materialized
@@ -582,6 +585,33 @@ fn normalize_file_header_for_hwp(doc: &mut Document, report: &mut AdapterReport)
 
     if doc.header.flags & 0x01 == 0 {
         doc.header.flags |= 0x01;
+        changed = true;
+    }
+
+    // [#3706, #3676 후속] HWP3 파서는 HWP5 컨테이너용 버전(5.0.3.0)을 `raw_data` 바이트
+    // (32..36 = revision/build/minor/major)에만 기록하고, 필드 `version` 은
+    // major=3 (메모리 전용 표시)으로 남긴다 — `serialize_file_header` 가
+    // raw_data 를 우선 쓰는 것을 전제한 설계다 (`parser/hwp3/mod.rs`).
+    // 그런데 본 함수가 아래에서 raw_data 를 버리므로 직렬화가 필드 경로로
+    // 떨어져 HWP5 컨테이너에 버전 3 이 기록됐다(규격 위반 — 한컴 저장본은
+    // 예외 없이 5.x). 버리기 전에 raw_data 의 5.x 버전을 필드로 회수하고,
+    // 회수할 수 없으면 파서 기본값 5.0.3.0 으로 실체화한다.
+    // 이미 5.x 인 경로(HWPX 파서는 5.1.0.0 을 필드에 직접 기록)는 무변경.
+    if doc.header.version.major < 5 {
+        let salvaged = doc
+            .header
+            .raw_data
+            .as_deref()
+            .filter(|raw| raw.len() >= 36 && raw[35] >= 5)
+            .map(|raw| (raw[35], raw[34], raw[33], raw[32]));
+        let (major, minor, build, revision) = salvaged.unwrap_or((5, 0, 3, 0));
+        doc.header.version = HwpVersion {
+            major,
+            minor,
+            build,
+            revision,
+        };
+        report.file_header_version_materialized += 1;
         changed = true;
     }
 

--- a/tests/issue_3706_hwp3_convert_file_header_version.rs
+++ b/tests/issue_3706_hwp3_convert_file_header_version.rs
@@ -1,0 +1,107 @@
+//! Issue #3706 (#3676 후속): HWP3 → HWP5 변환본의 FileHeader 에 버전 3 이 기록된다.
+//!
+//! ## 증상
+//!
+//! `rhwp convert` 로 만든 HWP3 → HWP5 변환본의 FileHeader 버전 바이트가
+//! `00000003`(major=3) 이다. HWP5 컨테이너의 FileHeader 는 5.x 버전을 선언해야
+//! 하며(같은 문서의 한컴 저장본 `samples/hwp3-sample-hwp5.hwp` 는 `01000105`
+//! = 5.1.0.1), 버전 3 은 규격 위반이다. #3676 조사에서 한컴 열기 거부의
+//! 근인은 아니었지만(버전 4종 실험으로 반증) 규격 위반 자체는 확정됐다.
+//!
+//! ## 근인
+//!
+//! HWP3 파서(`parser/hwp3/mod.rs`)는 `version.major = 3` 을 메모리 전용
+//! 표시로 두고 **실제 저장용 HWP5 헤더(5.0.3.0)는 `header.raw_data` 에**
+//! 기록한다 — 직렬화(`serialize_file_header`)가 raw_data 를 우선 쓰는 것을
+//! 전제한 설계다. 그런데 저장 정규화
+//! (`document_core/converters/hwpx_to_hwp.rs::normalize_file_header_for_hwp`)가
+//! 압축 플래그를 필드로 실체화하면서 `raw_data` 를 무조건 버려, 직렬화가
+//! 필드 경로로 떨어지고 major=3 이 그대로 디스크에 기록된다.
+//!
+//! ## 이 테스트가 지키는 계약
+//!
+//! 변환본 FileHeader 는 (1) 5.x 버전을 선언하고 (2) 압축 플래그가 실제 스트림
+//! 압축과 일치하며 (3) rhwp 재로드에서도 5.x 로 읽혀야 한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::parser::cfb_reader::CfbReader;
+
+/// HWP3 표본 — #3676 표본군과 같은 계열.
+const SAMPLE: &str = "samples/hwp3-sample.hwp";
+
+fn sample_path() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+/// HWP3 원본을 HWP5 바이트로 변환한다 (CLI `convert` 와 같은 경로:
+/// parse_hwp3 → convert_if_hwpx_source → serialize_hwp).
+fn convert_to_hwp5_bytes() -> Vec<u8> {
+    let raw = std::fs::read(sample_path()).expect("표본 읽기");
+    let mut doc = rhwp::parser::hwp3::parse_hwp3(&raw).expect("HWP3 파싱");
+    rhwp::document_core::converters::hwpx_to_hwp::convert_if_hwpx_source(
+        &mut doc,
+        rhwp::parser::FileFormat::Hwp3,
+    );
+    rhwp::serializer::serialize_hwp(&doc).expect("HWP5 직렬화")
+}
+
+fn converted_file_header() -> Vec<u8> {
+    let bytes = convert_to_hwp5_bytes();
+    let mut cfb = CfbReader::open(&bytes).expect("CFB 열기");
+    cfb.read_file_header().expect("FileHeader 스트림 읽기")
+}
+
+/// ① 변환본 FileHeader 가 HWP5 버전(5.x)을 선언한다.
+///
+/// HWP3 파서가 raw_data 에 기록해 둔 저장용 버전은 5.0.3.0 이다. 저장 정규화가
+/// raw_data 를 버리더라도 이 버전은 필드로 회수돼야 한다.
+#[test]
+fn converted_file_header_declares_hwp5_version() {
+    let fh = converted_file_header();
+    assert!(fh.len() >= 40, "FileHeader 는 최소 40바이트여야 한다");
+    let (revision, build, minor, major) = (fh[32], fh[33], fh[34], fh[35]);
+    assert_eq!(
+        major, 5,
+        "HWP5 컨테이너의 FileHeader 버전이 {major}.{minor}.{build}.{revision} 이다. \
+         HWP5 규격은 major=5 를 요구한다(한컴 저장본 hwp3-sample-hwp5.hwp 는 5.1.0.1). \
+         HWP3 파서가 raw_data 에 기록한 5.0.3.0 이 저장 정규화에서 유실되면 \
+         메모리 전용 표시값 major=3 이 그대로 디스크에 기록된다."
+    );
+    assert_eq!(
+        (major, minor, build, revision),
+        (5, 0, 3, 0),
+        "회수된 버전은 HWP3 파서가 raw_data 에 기록한 5.0.3.0 그대로여야 한다"
+    );
+}
+
+/// ② 버전 회수가 압축 플래그 실체화를 깨지 않는다.
+///
+/// 정규화는 raw_data(flags=0 비압축)를 버리고 압축 플래그를 필드로 실체화한다.
+/// 버전을 raw_data 에서 회수하더라도 flags 는 raw_data 값이 아니라 실체화된
+/// 값(bit0=압축)이어야 한다 — 아니면 "헤더는 비압축, 스트림은 압축" 불일치가 생긴다.
+#[test]
+fn converted_file_header_keeps_compressed_flag_materialized() {
+    let fh = converted_file_header();
+    assert_eq!(
+        fh[36] & 0x01,
+        0x01,
+        "FileHeader 압축 플래그(bit0)가 꺼져 있다. 저장기는 DocInfo/BodyText 를 \
+         압축 기록하므로 플래그가 꺼지면 컨테이너 자기모순이다."
+    );
+}
+
+/// ③ 왕복: 변환본을 rhwp 로 재로드해도 5.x 버전으로 읽힌다.
+#[test]
+fn converted_reloads_with_hwp5_version() {
+    let bytes = convert_to_hwp5_bytes();
+    let fh =
+        rhwp::parser::header::parse_file_header(&converted_file_header()).expect("FileHeader 파싱");
+    assert_eq!(fh.version.major, 5, "재파스한 FileHeader 버전 major=5");
+    // 문서 전체 재로드도 성공해야 한다 (컨테이너 왕복 무결성).
+    let core = rhwp::document_core::DocumentCore::from_bytes(&bytes).expect("변환본 재로드");
+    assert_eq!(
+        core.document().header.version.major,
+        5,
+        "재로드된 문서의 header.version.major 는 5 여야 한다"
+    );
+}


### PR DESCRIPTION
# fix(convert): HWP3 변환본 FileHeader 에 HWP5 버전을 실체화한다 (#3706)

## 요약

HWP3 → HWP5 변환본의 FileHeader 가 버전 3 을 선언하던 규격 위반(#3706, #3676 조사에서
확정)을 수정합니다. 저장 정규화가 `header.raw_data` 를 버리기 전에 그 안의 HWP5
버전(5.0.3.0)을 필드로 회수하고, 회수 불가면 파서 기본값 5.0.3.0 으로 실체화합니다.

- 전: 변환본 FileHeader 버전 바이트 `00000003` (major=3) — HWP5 규격 위반
- 후: `00030005` (5.0.3.0) — 한컴 저장본과 같은 5.x 선언

## 근인

두 코드의 전제가 어긋났습니다.

1. HWP3 파서(`parser/hwp3/mod.rs`)는 `version.major = 3` 을 메모리 전용
   표시(`assign_auto_numbers()` 의 HWP3 문단 카운팅 선택용)로 두고, 실제 저장용 HWP5
   헤더는 `raw_data` 에 기록 — `serialize_file_header` 의 raw_data 우선 규칙 전제.
2. 저장 정규화(`normalize_file_header_for_hwp`)가 압축 플래그 실체화 과정에서
   raw_data 를 무조건 폐기 → 직렬화가 필드 경로로 떨어져 major=3 이 디스크에 기록.

## 범위

- 이 수정은 #3676(한컴 열기 거부)의 근인이 **아닙니다** — #3676 코멘트의 버전 4종
  실험으로 반증됐고, 거부 근인 3종은 PR #3685 담당입니다. 본 건은 그 조사에서 "별도로
  정리할 값"으로 남은 독립 규격 위반입니다.
- 이미 5.x 인 경로(HWPX 파서는 5.1.0.0 을 필드에 직접 기록)는 무변경.
- 압축 플래그 실체화(기존 동작) 유지 — raw_data 의 flags=0 은 회수하지 않아
  헤더-스트림 자기모순을 만들지 않습니다.
- `AdapterReport.file_header_version_materialized` 카운터 신설.

## 검증 (red → green)

회귀 테스트 `tests/issue_3706_hwp3_convert_file_header_version.rs` 3건 — CLI `convert`
와 같은 경로(parse_hwp3 → convert_if_hwpx_source → serialize_hwp)로 실변환 후 CFB 의
FileHeader 스트림 바이트를 검사:

1. 변환본이 5.0.3.0 을 선언한다
2. 버전 회수가 압축 플래그(bit0) 실체화를 깨지 않는다
3. 재파스·문서 재로드 왕복에서 major=5

| 게이트 | 결과 |
| --- | --- |
| red (수정 제거 상태) | **2 failed / 1 passed** — ①·③이 `left: 3, right: 5` 로 실패, ②는 기존 동작이라 통과 |
| green (수정 적용) | **3 passed** |
| `--test hwpx_to_hwp_adapter` (변경 파일의 통합 타깃) | **50 passed / 0 failed** (15 ignored) |
| `--lib document_core::converters::hwpx_to_hwp` (모듈 단위 테스트) | **49 passed / 0 failed** |
| rustfmt --check (변경 파일 2건) | diff 0 |

처리 기록: `mydocs/report/task_m100_3706_report.md`

Closes #3706

🤖 Generated with [Claude Code](https://claude.com/claude-code)
