### PR TITLE
feat(cli): dump-pages --json 페이지네이션 진단 계약을 추가한다 (#3697)

### DIFF
--- a/mydocs/report/task_m100_3697_pr_body.md
+++ b/mydocs/report/task_m100_3697_pr_body.md
@@ -1,0 +1,66 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_3697_pr_body.md
+last_verified: 2026-08-01
+---
+
+# Task #3697 PR 초안 (파킹)
+
+- 제목: `feat(cli): dump-pages --json 페이지네이션 진단 계약을 추가한다 (#3697)`
+- 브랜치: fork `kevin9327/rhwp` `task/dump-pages-json` (push 완료, devel f80b910aa 기준)
+- 상태: 열린 PR 볼륨 상한(약 10건, 당시 11건) 초과로 파킹 — #3714 로 개설 직후 close. 큐에 여유가 생기면 리베이스 후 재개설.
+
+## 본문
+
+Closes #3697 (#3608 1-C 잔여 공백)
+
+## 무엇
+
+`dump-pages` 에 `--json` 을 추가해 페이지네이션 진단의 기계 계약을 만듭니다.
+
+```
+rhwp dump-pages <파일.hwp> [-p <쪽>] [--respect-vpos-reset] --json
+```
+
+단건 JSON 봉투(#3237 규약): `schemaVersion`("1.0") · `source` · `pageCount` ·
+`pageFilter` · `respectVposReset` · `pages`.
+
+- 항목 kind 6종: fullParagraph / partialParagraph / table / partialTable / shape /
+  endnoteSeparator — 텍스트 덤프의 진단 필드(vpos reset·rewind, line_seg 요약,
+  분할 표 rows·cut, 미주 출처 #1082, 단별 usedHeight/hwpUsedHeight/usedDiff)를
+  구조화 필드로 그대로 노출.
+- `extras`: #1700 계열 items 밖 문단(wrapAroundPara / hiddenEmptyPara)을 텍스트
+  덤프와 같은 귀속 규칙(#1705 wrap zone · #1955 글뒤로 앵커)으로 노출.
+- 실패 경로 stdout 0바이트, exit 계약(#2707: 0/1/2) 유지. capabilities 광고 갱신.
+
+## 왜 이런 구조
+
+구역 전처리(미주 합침 #1082, items 밖 문단 페이지 귀속 #1700·#1705·#1955)를
+`page_dump_section_ctx` helper 로 추출해 **텍스트/JSON 두 출력이 같은 코드를
+공유**합니다. 두 표면이 서로 다른 진단을 보고하는 드리프트를 구조적으로 차단하고,
+텍스트 출력은 바이트 동일을 유지했습니다.
+
+스코프: #3608 1-C 표는 이 항목에 MCP 도구를 짝짓지 않았으므로(1-D 진단 도구
+원칙) CLI 계약만 구현하고, `cli_json_contract.rs` 의 MCP 커버리지 테스트에서
+dump-pages 를 명시 제외했습니다. 에이전트 수요가 실증되면 별도 이슈로 승격합니다.
+
+## 검증 (red→green)
+
+| 게이트 | 결과 |
+|---|---|
+| red — 구현 제거 상태에서 신설 계약 테스트 | 3/4 실패 재현 (`--json` 미지원 exit 2) |
+| green — `cargo test --profile release-test --test dump_pages_json_contract` | 4 passed |
+| green — `cargo test --profile release-test --test cli_json_contract` | 22 passed |
+| 텍스트 출력 바이트 동일 | devel 기준 빌드와 전/후 비교, 3샘플×2변형(전체·`-p 1`) **6/6 IDENTICAL** — 미주 샘플(`3-09월_교육_통합_2024-미주사이20.hwp`)·어울림 표(`issue1510_coanchored_float_tables.hwp`) 포함 |
+| clippy `-D warnings` (release-test) | 통과 — 도중 doc 오귀속(doc_lazy_continuation) 1건 검출·수정 |
+| rustfmt --check (변경 4파일) | 통과 (Windows CRLF newline-style 오탐 제외) |
+
+green 은 devel(f80b910aa) 리베이스 후 재컴파일로 재실행했습니다.
+
+시각 변화 없음: CLI 진단 출력 전용 변경이고, 기존 텍스트 출력은 위 표의 바이트
+동일 비교로 불변을 확인했습니다 (렌더링 경로 미접촉 — 전/후 이미지 해당 없음).
+
+처리결과 문서: `mydocs/report/task_m100_3697_report.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/mydocs/report/task_m100_3697_report.md
+++ b/mydocs/report/task_m100_3697_report.md
@@ -1,0 +1,70 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_3697_report.md
+last_verified: 2026-08-01
+---
+
+# Task #3697 최종 보고 — dump-pages --json 페이지네이션 진단 기계 계약
+
+- Issue: [#3697](https://github.com/edwardkim/rhwp/issues/3697) —
+  [#3608](https://github.com/edwardkim/rhwp/issues/3608) 1-C 표의 잔여 공백
+- 브랜치 `task/dump-pages-json` / 2026-08-01 완결
+
+## 문제와 해법
+
+`dump-pages` 는 페이지네이션 결과(페이지·단·항목·vpos·line_seg·감춤/어울림 문단)를
+보여주는 핵심 조판 진단인데 출력이 사람용 텍스트뿐이라, 에이전트는 `pi=NN` 을
+정규식으로 긁고 있었다 — 형식이 조금만 바뀌어도 조용히 깨지는 표면.
+
+`dump-pages <파일> [-p <쪽>] [--respect-vpos-reset] --json` 으로 단건 JSON 봉투
+(#3237 규약)를 추가했다:
+
+1. **봉투** — `schemaVersion`("1.0")·`source`·`pageCount`·`pageFilter`·
+   `respectVposReset`·`pages`. 실패 경로 stdout 0바이트, exit 계약(#2707: 0/1/2) 유지.
+2. **항목 kind 6종** — fullParagraph / partialParagraph / table / partialTable /
+   shape / endnoteSeparator. 텍스트 덤프의 진단 필드를 구조화 노출: vpos
+   reset·rewind(`vpos_range` 공유 분석), line_seg 요약, 분할 표 rows·cut, 미주
+   출처(#1082 `endnoteSource`), 단별 `usedHeight`/`hwpUsedHeight`/`usedDiff`.
+3. **extras** — #1700 계열 items 밖 문단(wrapAroundPara / hiddenEmptyPara)을
+   텍스트 덤프와 같은 귀속 규칙(#1705 wrap zone·#1955 글뒤로 앵커)으로 노출.
+
+핵심 구조 결정: 구역 전처리(미주 합침 #1082, items 밖 문단 페이지 귀속 #1700·
+#1705·#1955)를 `page_dump_section_ctx` helper 로 추출해 **텍스트/JSON 두 출력이
+같은 코드를 공유**한다. 두 표면이 서로 다른 진단을 보고하는 드리프트를 구조적으로
+차단하고, 텍스트 출력은 바이트 동일을 유지했다.
+
+스코프: #3608 1-C 표가 이 항목에 MCP 도구를 짝짓지 않았으므로(1-D 진단 도구
+원칙) CLI 계약만 구현. `cli_json_contract.rs` 의 MCP 커버리지 테스트에서
+dump-pages 를 명시 제외했고, 에이전트 수요 실증 시 별도 이슈로 승격한다.
+
+## 검증
+
+| 게이트 | 결과 |
+|---|---|
+| red (구현 stash 후 신설 계약 테스트) | 3/4 실패 재현 — `--json` 미지원, exit 2 |
+| green (`--test dump_pages_json_contract`) | 4 passed (봉투 스키마·-p 필터·범위초과 exit 2 침묵·파일없음 exit 1 침묵) |
+| green (`--test cli_json_contract`) | 22 passed (capabilities 광고·MCP 커버리지 제외 포함) |
+| 텍스트 출력 바이트 동일 | origin/devel 기준 빌드와 전/후 비교 — 3샘플×2변형(전체·`-p 1`) **6/6 IDENTICAL** (미주 샘플 `3-09월_교육_통합_2024-미주사이20.hwp`, 어울림 표 `issue1510_coanchored_float_tables.hwp` 포함) |
+| clippy `-D warnings` (bin, release-test) | 통과 — 도중 doc_lazy_continuation 1건 검출·수정(아래) |
+| rustfmt --check (변경 4파일) | 통과 (Windows CRLF newline-style 오탐만) |
+| rebase | origin/devel(f80b910aa) 기준, 무충돌 |
+
+green 은 rebase 후 이 워크트리에서 재컴파일("Compiling rhwp … rhwp-wt-d" 확인)로
+재실행했다 — 공유 target 캐시가 다른 워크트리 빌드로 바뀔 수 있어, 스테일 바이너리
+green 을 배제하기 위함.
+
+## 도중 검출·수정한 결함
+
+clippy 가 `PageDumpSectionCtx` 삽입 위치 결함을 잡았다: 기존
+`compute_hwp_used_height` 의 doc 주석 블록과 함수 사이에 struct 를 끼워 넣어 doc
+이 struct 로 오귀속(doc_lazy_continuation). doc 주석을 원 함수 앞으로 되돌려
+해소했다.
+
+## 남긴 것 (범위 밖 후속 후보)
+
+- dump-pages 의 세션/MCP 도구 노출 — 에이전트 수요 실증 후 별도 이슈로 승격.
+- `--respect-vpos-reset` 이 JSON 출력에 미치는 영향의 별도 계약 테스트(현재는
+  봉투 필드로만 노출).
+- 공유 CARGO_TARGET_DIR 환경에서 워크트리 간 바이너리 클로버링 — 테스트 전
+  강제 재컴파일(touch) 우회를 썼다. 환경 문서화 후보.

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -4744,6 +4744,408 @@ impl DocumentCore {
         Err(HwpError::PageOutOfRange(page_num))
     }
 
+    /// [#3697] dump-pages 텍스트/JSON 두 출력이 공유하는 구역 전처리.
+    ///
+    /// 미주 문단 합침(#1082)과 items 밖 문단(어울림/빈 줄 감춤) 페이지 귀속
+    /// (#1700·#1705·#1955)을 한 곳에 두어, 텍스트 덤프와 JSON 계약이 서로 다른
+    /// 진단을 보고하는 드리프트를 구조적으로 차단한다.
+    fn page_dump_section_ctx<'a>(
+        &'a self,
+        sec_idx: usize,
+        pr: &'a PaginationResult,
+        sec_start_page: u32,
+    ) -> PageDumpSectionCtx<'a> {
+        use crate::model::control::Control;
+        use crate::renderer::hwpunit_to_px;
+        use crate::renderer::pagination::PageItem;
+
+        let dpi = self.dpi;
+        let body_paragraphs = self.section_render_paragraphs(sec_idx);
+        // [Task #1082] 미주 paragraphs 를 본문 뒤에 합쳐 인덱싱 정합.
+        // 미주 PageItem 의 para_index = body_paragraphs.len() + 미주 로컬 인덱스
+        // (typeset.rs en_para_idx 와 동일). 합치지 않으면 미주 항목이 out-of-bounds 로
+        // 본문이 빈 것처럼 표시된다(시험지 다단 미주 디버깅 차단).
+        let body_len = body_paragraphs.len();
+        let paragraphs: std::borrow::Cow<'a, [Paragraph]> = if pr.endnote_paragraphs.is_empty() {
+            std::borrow::Cow::Borrowed(body_paragraphs)
+        } else {
+            std::borrow::Cow::Owned(
+                body_paragraphs
+                    .iter()
+                    .chain(pr.endnote_paragraphs.iter())
+                    .cloned()
+                    .collect(),
+            )
+        };
+
+        // [Task #1700] cc.items 에 없는 문단(어울림 흡수 / 빈 줄 감춤)을 페이지 PI 로 표면화
+        // 하기 위한 사전 패스. 한글(OLE)은 이들을 본문 문단으로 카운트하므로 문단→페이지
+        // 매핑이 정합된다. 레이아웃/렌더 트리는 변경하지 않으므로 기하·페이지 수·시각 불변.
+        // 1) items 문단 → 표시 페이지(global+1) 매핑 — **마지막** 출현 페이지(다중 페이지 표는
+        //    끝 페이지에 빈 문단이 따라오므로 last-page 가 한글과 정합).
+        let mut item_disp_page: std::collections::HashMap<usize, u32> =
+            std::collections::HashMap::new();
+        // [#1705] 표의 첫(앵커) 출현 페이지 — 어울림 빈 문단이 표 옆 wrap zone 에 있을 때 사용.
+        let mut item_first_page: std::collections::HashMap<usize, u32> =
+            std::collections::HashMap::new();
+        for (li, page) in pr.pages.iter().enumerate() {
+            let disp = sec_start_page + li as u32 + 1;
+            for cc in &page.column_contents {
+                for item in &cc.items {
+                    let pidx = match item {
+                        PageItem::FullParagraph { para_index }
+                        | PageItem::PartialParagraph { para_index, .. }
+                        | PageItem::Table { para_index, .. }
+                        | PageItem::PartialTable { para_index, .. }
+                        | PageItem::Shape { para_index, .. } => Some(*para_index),
+                        _ => None,
+                    };
+                    if let Some(p) = pidx {
+                        item_disp_page.insert(p, disp); // 마지막(끝) 페이지
+                        item_first_page.entry(p).or_insert(disp); // 첫(앵커) 페이지
+                    }
+                }
+            }
+        }
+        // 2) 표면화 대상을 페이지별로 그룹화: (para_index, is_wrap, table_pi).
+        //    - 어울림(wrap-around): 앵커 표(table_para_index)의 페이지에 귀속.
+        //    - 빈 줄 감춤(hidden_empty_paras): 직전 item 문단(대개 표)의 페이지에 귀속.
+        let mut extra_by_page: std::collections::HashMap<u32, Vec<(usize, bool, usize)>> =
+            std::collections::HashMap::new();
+        let mut emitted_extra: std::collections::HashSet<usize> = std::collections::HashSet::new();
+        for page in pr.pages.iter() {
+            for cc in &page.column_contents {
+                for wp in &cc.wrap_around_paras {
+                    if !emitted_extra.insert(wp.para_index) {
+                        continue;
+                    }
+                    // [#1705] 어울림(floating) 표의 트레일링 빈 문단 귀속:
+                    //   line_seg 폭(sw)이 좁으면(표 옆 wrap zone) 표의 **첫(앵커) 페이지**,
+                    //   전체 폭이면(표 아래로 흐름) 표의 **마지막 페이지**.
+                    //   한글은 wrap zone 문단을 앵커 페이지에, 전체폭 문단을 표 끝 페이지에 둔다.
+                    let sw_px = paragraphs
+                        .get(wp.para_index)
+                        .and_then(|p| p.line_segs.first())
+                        .map(|s| hwpunit_to_px(s.segment_width as i32, dpi))
+                        .unwrap_or(0.0);
+                    let body_w = page.layout.body_area.width;
+                    let is_wrap_zone = sw_px > 0.0 && sw_px < body_w * 0.9;
+                    // [#1955] 글뒤로/글앞으로 anchor 표는 플로우를 소비하지 않으므로
+                    // 후행 문단은 폭과 무관하게 **앵커 페이지** 귀속 (한글: stored
+                    // LINE_SEG vpos 가 앵커 쪽 위치를 가리킴).
+                    let anchor_behind = paragraphs
+                        .get(wp.table_para_index)
+                        .map(|p| {
+                            p.controls.iter().any(|c| {
+                                matches!(c, Control::Table(t)
+                                    if !t.common.treat_as_char
+                                        && matches!(t.common.text_wrap,
+                                            crate::model::shape::TextWrap::BehindText
+                                                | crate::model::shape::TextWrap::InFrontOfText))
+                            })
+                        })
+                        .unwrap_or(false);
+                    let disp = if is_wrap_zone || anchor_behind {
+                        item_first_page.get(&wp.table_para_index)
+                    } else {
+                        item_disp_page.get(&wp.table_para_index)
+                    }
+                    .copied()
+                    .unwrap_or(sec_start_page + 1);
+                    extra_by_page.entry(disp).or_default().push((
+                        wp.para_index,
+                        true,
+                        wp.table_para_index,
+                    ));
+                }
+            }
+        }
+        let mut hidden_sorted: Vec<usize> = pr
+            .hidden_empty_paras
+            .iter()
+            .copied()
+            .filter(|p| !item_disp_page.contains_key(p) && !emitted_extra.contains(p))
+            .collect();
+        hidden_sorted.sort_unstable();
+        for hidx in hidden_sorted {
+            let mut disp = sec_start_page + 1;
+            for j in (0..hidx).rev() {
+                if let Some(d) = item_disp_page.get(&j) {
+                    disp = *d;
+                    break;
+                }
+            }
+            extra_by_page
+                .entry(disp)
+                .or_default()
+                .push((hidx, false, 0));
+            emitted_extra.insert(hidx);
+        }
+
+        PageDumpSectionCtx {
+            paragraphs,
+            body_len,
+            extra_by_page,
+        }
+    }
+
+    /// [#3697] 페이지네이션 결과를 기계 계약 JSON 으로 덤프 (#3608 1-C).
+    ///
+    /// 텍스트 덤프(`dump_page_items`)와 같은 순회·같은 구역 전처리
+    /// (`page_dump_section_ctx`)를 공유하고, 표현만 구조화 필드로 바꾼다.
+    /// 반환값은 `pages` 배열 — 봉투(schemaVersion·source 등)는 CLI 가 감싼다.
+    pub fn dump_page_items_json(&self, page_filter: Option<u32>) -> serde_json::Value {
+        use crate::model::control::Control;
+        use crate::renderer::pagination::PageItem;
+
+        let dpi = self.dpi;
+        let mut pages_out: Vec<serde_json::Value> = Vec::new();
+        let mut global_page = 0u32;
+
+        for (sec_idx, pr) in self.pagination.iter().enumerate() {
+            let ctx = self.page_dump_section_ctx(sec_idx, pr, global_page);
+            let paragraphs: &[Paragraph] = &ctx.paragraphs;
+            let body_len = ctx.body_len;
+            let measured = self.measured_sections.get(sec_idx);
+
+            // 미주 항목(pi >= body_len)의 원본 위치 — 텍스트 덤프의 `src=...` 와 동일.
+            let endnote_source_json = |para_index: usize| -> serde_json::Value {
+                if para_index < body_len {
+                    return serde_json::Value::Null;
+                }
+                pr.endnote_para_sources
+                    .get(para_index - body_len)
+                    .map(|src| {
+                        serde_json::json!({
+                            "section": src.section_index,
+                            "para": src.para_index,
+                            "controlIndex": src.control_index,
+                            "noteParaIndex": src.note_para_index,
+                        })
+                    })
+                    .unwrap_or(serde_json::Value::Null)
+            };
+
+            for page in pr.pages.iter() {
+                if let Some(pf) = page_filter {
+                    if global_page != pf {
+                        global_page += 1;
+                        continue;
+                    }
+                }
+
+                let la = &page.layout;
+                let mut columns_out: Vec<serde_json::Value> = Vec::new();
+                for (col_idx, cc) in page.column_contents.iter().enumerate() {
+                    let hwp_used_px = compute_hwp_used_height(cc, paragraphs, dpi);
+                    let mut items_out: Vec<serde_json::Value> = Vec::new();
+                    for item in &cc.items {
+                        let v = match item {
+                            PageItem::FullParagraph { para_index } => {
+                                let height = measured
+                                    .and_then(|m| m.get_measured_paragraph(*para_index))
+                                    .map(|mp| {
+                                        let lh_sum: f64 = mp.line_heights.iter().sum();
+                                        let ls_sum: f64 = mp.line_spacings.iter().sum();
+                                        serde_json::json!({
+                                            "total": mp.spacing_before
+                                                + lh_sum
+                                                + ls_sum
+                                                + mp.spacing_after,
+                                            "spacingBefore": mp.spacing_before,
+                                            "lineHeightSum": lh_sum,
+                                            "lineSpacingSum": ls_sum,
+                                            "spacingAfter": mp.spacing_after,
+                                        })
+                                    });
+                                serde_json::json!({
+                                    "kind": "fullParagraph",
+                                    "paraIndex": para_index,
+                                    "isEndnote": *para_index >= body_len,
+                                    "endnoteSource": endnote_source_json(*para_index),
+                                    "height": height,
+                                    "vpos": vpos_range_json(paragraphs.get(*para_index), None, None),
+                                    "lineSegs": line_seg_brief_json(paragraphs.get(*para_index)),
+                                    "textPreview": para_text_preview(paragraphs.get(*para_index)),
+                                })
+                            }
+                            PageItem::PartialParagraph {
+                                para_index,
+                                start_line,
+                                end_line,
+                            } => serde_json::json!({
+                                "kind": "partialParagraph",
+                                "paraIndex": para_index,
+                                "startLine": start_line,
+                                "endLine": end_line,
+                                "isEndnote": *para_index >= body_len,
+                                "endnoteSource": endnote_source_json(*para_index),
+                                "vpos": vpos_range_json(
+                                    paragraphs.get(*para_index),
+                                    Some(*start_line),
+                                    Some(*end_line),
+                                ),
+                                "lineSegs": line_seg_brief_json(paragraphs.get(*para_index)),
+                            }),
+                            PageItem::Table {
+                                para_index,
+                                control_index,
+                            } => serde_json::json!({
+                                "kind": "table",
+                                "paraIndex": para_index,
+                                "controlIndex": control_index,
+                                "isEndnote": *para_index >= body_len,
+                                "endnoteSource": endnote_source_json(*para_index),
+                                "table": table_summary_json(
+                                    paragraphs,
+                                    *para_index,
+                                    *control_index,
+                                    dpi,
+                                    true,
+                                ),
+                                "vpos": vpos_range_json(paragraphs.get(*para_index), None, None),
+                                "lineSegs": line_seg_brief_json(paragraphs.get(*para_index)),
+                            }),
+                            PageItem::PartialTable {
+                                para_index,
+                                control_index,
+                                start_row,
+                                end_row,
+                                is_continuation,
+                                start_cut,
+                                end_cut,
+                                ..
+                            } => serde_json::json!({
+                                "kind": "partialTable",
+                                "paraIndex": para_index,
+                                "controlIndex": control_index,
+                                "startRow": start_row,
+                                "endRow": end_row,
+                                "isContinuation": is_continuation,
+                                "startCut": start_cut,
+                                "endCut": end_cut,
+                                "isEndnote": *para_index >= body_len,
+                                "endnoteSource": endnote_source_json(*para_index),
+                                "table": table_summary_json(
+                                    paragraphs,
+                                    *para_index,
+                                    *control_index,
+                                    dpi,
+                                    false,
+                                ),
+                                "vpos": vpos_range_json(paragraphs.get(*para_index), None, None),
+                                "lineSegs": line_seg_brief_json(paragraphs.get(*para_index)),
+                            }),
+                            PageItem::Shape {
+                                para_index,
+                                control_index,
+                            } => {
+                                let control = paragraphs
+                                    .get(*para_index)
+                                    .and_then(|p| p.controls.get(*control_index))
+                                    .map(|c| match c {
+                                        Control::Shape(s) => serde_json::json!({
+                                            "type": "shape",
+                                            "textWrap": format!("{:?}", s.common().text_wrap),
+                                            "treatAsChar": s.common().treat_as_char,
+                                        }),
+                                        Control::Picture(p) => serde_json::json!({
+                                            "type": "picture",
+                                            "treatAsChar": p.common.treat_as_char,
+                                        }),
+                                        Control::Equation(_) => {
+                                            serde_json::json!({ "type": "equation" })
+                                        }
+                                        _ => serde_json::json!({ "type": "other" }),
+                                    });
+                                serde_json::json!({
+                                    "kind": "shape",
+                                    "paraIndex": para_index,
+                                    "controlIndex": control_index,
+                                    "isEndnote": *para_index >= body_len,
+                                    "endnoteSource": endnote_source_json(*para_index),
+                                    "control": control,
+                                    "vpos": vpos_range_json(paragraphs.get(*para_index), None, None),
+                                    "lineSegs": line_seg_brief_json(paragraphs.get(*para_index)),
+                                })
+                            }
+                            PageItem::EndnoteSeparator {
+                                separator_length,
+                                margin_above,
+                                margin_below,
+                                line_width,
+                                color,
+                                ..
+                            } => serde_json::json!({
+                                "kind": "endnoteSeparator",
+                                "separatorLength": separator_length,
+                                "marginAbove": margin_above,
+                                "marginBelow": margin_below,
+                                "lineWidth": line_width,
+                                "color": format!("#{:06x}", color & 0x00ff_ffff),
+                            }),
+                        };
+                        items_out.push(v);
+                    }
+                    columns_out.push(serde_json::json!({
+                        "index": col_idx,
+                        "itemCount": cc.items.len(),
+                        "usedHeight": cc.used_height,
+                        "hwpUsedHeight": hwp_used_px,
+                        "usedDiff": hwp_used_px.map(|h| cc.used_height - h),
+                        "zoneYOffset": cc.zone_y_offset,
+                        "items": items_out,
+                    }));
+                }
+
+                // [Task #1700] cc.items 에 없는 문단(어울림/빈 줄 감춤) — 텍스트 덤프와 동일 귀속.
+                let disp_page = global_page + 1;
+                let extras_out: Vec<serde_json::Value> = ctx
+                    .extra_by_page
+                    .get(&disp_page)
+                    .map(|list| {
+                        list.iter()
+                            .map(|(pidx, is_wrap, tpi)| {
+                                if *is_wrap {
+                                    serde_json::json!({
+                                        "kind": "wrapAroundPara",
+                                        "paraIndex": pidx,
+                                        "tableParaIndex": tpi,
+                                        "textPreview": para_text_preview(paragraphs.get(*pidx)),
+                                    })
+                                } else {
+                                    serde_json::json!({
+                                        "kind": "hiddenEmptyPara",
+                                        "paraIndex": pidx,
+                                        "textPreview": para_text_preview(paragraphs.get(*pidx)),
+                                    })
+                                }
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                pages_out.push(serde_json::json!({
+                    "pageIndex": global_page,
+                    "displayPage": global_page + 1,
+                    "section": sec_idx,
+                    "pageNumber": page.page_number,
+                    "bodyArea": {
+                        "x": la.body_area.x,
+                        "y": la.body_area.y,
+                        "width": la.body_area.width,
+                        "height": la.body_area.height,
+                    },
+                    "columns": columns_out,
+                    "extras": extras_out,
+                }));
+
+                global_page += 1;
+            }
+        }
+        serde_json::Value::Array(pages_out)
+    }
+
     /// 페이지네이션 결과를 텍스트로 덤프 (디버깅용).
     /// page_filter: None이면 전체, Some(n)이면 해당 페이지만.
     pub fn dump_page_items(&self, page_filter: Option<u32>) -> String {
@@ -4756,130 +5158,13 @@ impl DocumentCore {
         let mut global_page = 0u32;
 
         for (sec_idx, pr) in self.pagination.iter().enumerate() {
-            let body_paragraphs = self.section_render_paragraphs(sec_idx);
-            // [Task #1082] 미주 paragraphs 를 본문 뒤에 합쳐 인덱싱 정합.
-            // 미주 PageItem 의 para_index = body_paragraphs.len() + 미주 로컬 인덱스
-            // (typeset.rs en_para_idx 와 동일). 합치지 않으면 미주 항목이 out-of-bounds 로
-            // 본문이 빈 것처럼 표시된다(시험지 다단 미주 디버깅 차단).
-            let body_len = body_paragraphs.len();
-            let combined: Vec<Paragraph>;
-            let paragraphs: &[Paragraph] = if pr.endnote_paragraphs.is_empty() {
-                body_paragraphs
-            } else {
-                combined = body_paragraphs
-                    .iter()
-                    .chain(pr.endnote_paragraphs.iter())
-                    .cloned()
-                    .collect();
-                &combined
-            };
+            // [#3697] 구역 전처리(미주 합침 #1082 · items 밖 문단 귀속 #1700 계열)는
+            // JSON 덤프(`dump_page_items_json`)와 공유한다 — 두 출력의 드리프트 차단.
+            let ctx = self.page_dump_section_ctx(sec_idx, pr, global_page);
+            let paragraphs: &[Paragraph] = &ctx.paragraphs;
+            let body_len = ctx.body_len;
+            let extra_by_page = &ctx.extra_by_page;
             let measured = self.measured_sections.get(sec_idx);
-
-            // [Task #1700] cc.items 에 없는 문단(어울림 흡수 / 빈 줄 감춤)을 페이지 PI 로 표면화
-            // 하기 위한 사전 패스. 한글(OLE)은 이들을 본문 문단으로 카운트하므로 문단→페이지
-            // 매핑이 정합된다. 레이아웃/렌더 트리는 변경하지 않으므로 기하·페이지 수·시각 불변.
-            // 1) items 문단 → 표시 페이지(global+1) 매핑 — **마지막** 출현 페이지(다중 페이지 표는
-            //    끝 페이지에 빈 문단이 따라오므로 last-page 가 한글과 정합).
-            let sec_start_page = global_page;
-            let mut item_disp_page: std::collections::HashMap<usize, u32> =
-                std::collections::HashMap::new();
-            // [#1705] 표의 첫(앵커) 출현 페이지 — 어울림 빈 문단이 표 옆 wrap zone 에 있을 때 사용.
-            let mut item_first_page: std::collections::HashMap<usize, u32> =
-                std::collections::HashMap::new();
-            for (li, page) in pr.pages.iter().enumerate() {
-                let disp = sec_start_page + li as u32 + 1;
-                for cc in &page.column_contents {
-                    for item in &cc.items {
-                        let pidx = match item {
-                            PageItem::FullParagraph { para_index }
-                            | PageItem::PartialParagraph { para_index, .. }
-                            | PageItem::Table { para_index, .. }
-                            | PageItem::PartialTable { para_index, .. }
-                            | PageItem::Shape { para_index, .. } => Some(*para_index),
-                            _ => None,
-                        };
-                        if let Some(p) = pidx {
-                            item_disp_page.insert(p, disp); // 마지막(끝) 페이지
-                            item_first_page.entry(p).or_insert(disp); // 첫(앵커) 페이지
-                        }
-                    }
-                }
-            }
-            // 2) 표면화 대상을 페이지별로 그룹화: (para_index, is_wrap, table_pi).
-            //    - 어울림(wrap-around): 앵커 표(table_para_index)의 페이지에 귀속.
-            //    - 빈 줄 감춤(hidden_empty_paras): 직전 item 문단(대개 표)의 페이지에 귀속.
-            let mut extra_by_page: std::collections::HashMap<u32, Vec<(usize, bool, usize)>> =
-                std::collections::HashMap::new();
-            let mut emitted_extra: std::collections::HashSet<usize> =
-                std::collections::HashSet::new();
-            for page in pr.pages.iter() {
-                for cc in &page.column_contents {
-                    for wp in &cc.wrap_around_paras {
-                        if !emitted_extra.insert(wp.para_index) {
-                            continue;
-                        }
-                        // [#1705] 어울림(floating) 표의 트레일링 빈 문단 귀속:
-                        //   line_seg 폭(sw)이 좁으면(표 옆 wrap zone) 표의 **첫(앵커) 페이지**,
-                        //   전체 폭이면(표 아래로 흐름) 표의 **마지막 페이지**.
-                        //   한글은 wrap zone 문단을 앵커 페이지에, 전체폭 문단을 표 끝 페이지에 둔다.
-                        let sw_px = paragraphs
-                            .get(wp.para_index)
-                            .and_then(|p| p.line_segs.first())
-                            .map(|s| hwpunit_to_px(s.segment_width as i32, dpi))
-                            .unwrap_or(0.0);
-                        let body_w = page.layout.body_area.width;
-                        let is_wrap_zone = sw_px > 0.0 && sw_px < body_w * 0.9;
-                        // [#1955] 글뒤로/글앞으로 anchor 표는 플로우를 소비하지 않으므로
-                        // 후행 문단은 폭과 무관하게 **앵커 페이지** 귀속 (한글: stored
-                        // LINE_SEG vpos 가 앵커 쪽 위치를 가리킴).
-                        let anchor_behind = paragraphs
-                            .get(wp.table_para_index)
-                            .map(|p| {
-                                p.controls.iter().any(|c| {
-                                    matches!(c, Control::Table(t)
-                                        if !t.common.treat_as_char
-                                            && matches!(t.common.text_wrap,
-                                                crate::model::shape::TextWrap::BehindText
-                                                    | crate::model::shape::TextWrap::InFrontOfText))
-                                })
-                            })
-                            .unwrap_or(false);
-                        let disp = if is_wrap_zone || anchor_behind {
-                            item_first_page.get(&wp.table_para_index)
-                        } else {
-                            item_disp_page.get(&wp.table_para_index)
-                        }
-                        .copied()
-                        .unwrap_or(sec_start_page + 1);
-                        extra_by_page.entry(disp).or_default().push((
-                            wp.para_index,
-                            true,
-                            wp.table_para_index,
-                        ));
-                    }
-                }
-            }
-            let mut hidden_sorted: Vec<usize> = pr
-                .hidden_empty_paras
-                .iter()
-                .copied()
-                .filter(|p| !item_disp_page.contains_key(p) && !emitted_extra.contains(p))
-                .collect();
-            hidden_sorted.sort_unstable();
-            for hidx in hidden_sorted {
-                let mut disp = sec_start_page + 1;
-                for j in (0..hidx).rev() {
-                    if let Some(d) = item_disp_page.get(&j) {
-                        disp = *d;
-                        break;
-                    }
-                }
-                extra_by_page
-                    .entry(disp)
-                    .or_default()
-                    .push((hidx, false, 0));
-                emitted_extra.insert(hidx);
-            }
 
             for (local_idx, page) in pr.pages.iter().enumerate() {
                 if let Some(pf) = page_filter {
@@ -5943,6 +6228,78 @@ impl DocumentCore {
     // =====================================================================
 }
 
+/// [#3697] dump-pages 텍스트/JSON 두 출력이 공유하는 구역 전처리 결과.
+struct PageDumpSectionCtx<'a> {
+    /// 본문(+미주 #1082) 문단. 미주가 없으면 원본 슬라이스 차용.
+    paragraphs: std::borrow::Cow<'a, [Paragraph]>,
+    /// 본문 문단 수 — 이 인덱스 이상은 미주 문단.
+    body_len: usize,
+    /// 표시 페이지(global+1) → (para_index, 어울림 여부, 앵커 표 para_index) — #1700 계열.
+    extra_by_page: std::collections::HashMap<u32, Vec<(usize, bool, usize)>>,
+}
+
+/// [#3697] dump-pages JSON 의 문단 미리보기 — 텍스트 덤프와 같은 제어문자 제거 + 40자.
+/// 기계 소비자용이므로 텍스트 덤프의 "(빈)" 대체 표기는 쓰지 않는다 (빈 문단 = "").
+fn para_text_preview(para: Option<&Paragraph>) -> String {
+    para.map(|p| {
+        p.text
+            .chars()
+            .filter(|c| *c > '\u{001F}')
+            .take(40)
+            .collect()
+    })
+    .unwrap_or_default()
+}
+
+/// [#3697] dump-pages JSON 의 표 컨트롤 요약.
+/// `with_geometry` 는 전체 표 항목에서만 true (텍스트 덤프와 같은 정보 범위).
+fn table_summary_json(
+    paragraphs: &[Paragraph],
+    para_index: usize,
+    control_index: usize,
+    dpi: f64,
+    with_geometry: bool,
+) -> serde_json::Value {
+    use crate::model::control::Control;
+    use crate::renderer::hwpunit_to_px;
+
+    paragraphs
+        .get(para_index)
+        .and_then(|p| p.controls.get(control_index))
+        .and_then(|c| {
+            if let Control::Table(t) = c {
+                let mut v = serde_json::json!({
+                    "rowCount": t.row_count,
+                    "colCount": t.col_count,
+                });
+                if with_geometry {
+                    if let Some(obj) = v.as_object_mut() {
+                        obj.insert(
+                            "widthPx".into(),
+                            serde_json::json!(hwpunit_to_px(t.common.width as i32, dpi)),
+                        );
+                        obj.insert(
+                            "heightPx".into(),
+                            serde_json::json!(hwpunit_to_px(t.common.height as i32, dpi)),
+                        );
+                        obj.insert(
+                            "textWrap".into(),
+                            serde_json::json!(format!("{:?}", t.common.text_wrap)),
+                        );
+                        obj.insert(
+                            "treatAsChar".into(),
+                            serde_json::json!(t.common.treat_as_char),
+                        );
+                    }
+                }
+                Some(v)
+            } else {
+                None
+            }
+        })
+        .unwrap_or(serde_json::Value::Null)
+}
+
 /// 단이 HWP 원본 layout 에서 사용했을 높이를 LINE_SEG vpos 기준으로 추정 (px).
 ///
 /// 알고리즘:
@@ -6057,29 +6414,38 @@ fn compute_hwp_used_height(
     Some(hwpunit_to_px((bottom_hwpu - base_top).max(0), dpi))
 }
 
-/// LINE_SEG vertical_pos 범위를 문자열로 포맷.
+/// [#3697] vpos 범위 분석 결과 — 텍스트(`format_vpos_range`)/JSON(`vpos_range_json`)
+/// 두 표현이 같은 판정(리셋/되감기)을 공유하기 위한 중간 형태.
+struct VposRange {
+    first: i32,
+    last: i32,
+    /// 요청 범위가 한 줄이면 true (텍스트 표현이 단일값으로 축약).
+    single: bool,
+    resets: Vec<usize>,
+    rewinds: Vec<usize>,
+}
+
+/// LINE_SEG vertical_pos 범위 분석.
 ///
 /// `start_line..end_line` 가 None 이면 문단 전체 범위.
 /// `vertical_pos == 0` 인 줄(문단 첫 줄 제외)을 vpos-reset 으로 마킹.
-fn format_vpos_range(
+fn vpos_range(
     para: Option<&Paragraph>,
     start_line: Option<usize>,
     end_line: Option<usize>,
-) -> String {
-    let Some(p) = para else { return String::new() };
+) -> Option<VposRange> {
+    let p = para?;
     if p.line_segs.is_empty() {
-        return String::new();
-    };
+        return None;
+    }
     let total = p.line_segs.len();
     let s = start_line.unwrap_or(0).min(total.saturating_sub(1));
     let end_exclusive = end_line.unwrap_or(total).min(total);
     if s >= end_exclusive {
-        return String::new();
-    };
+        return None;
+    }
     let e = end_exclusive - 1;
 
-    let first = p.line_segs[s].vertical_pos;
-    let last = p.line_segs[e].vertical_pos;
     let mut resets: Vec<usize> = Vec::new();
     let mut rewinds: Vec<usize> = Vec::new();
     for i in s..=e {
@@ -6091,18 +6457,81 @@ fn format_vpos_range(
             rewinds.push(i);
         }
     }
-    let mut s_out = if s == e {
-        format!("vpos={}", first)
-    } else {
-        format!("vpos={}..{}", first, last)
+    Some(VposRange {
+        first: p.line_segs[s].vertical_pos,
+        last: p.line_segs[e].vertical_pos,
+        single: s == e,
+        resets,
+        rewinds,
+    })
+}
+
+/// LINE_SEG vertical_pos 범위를 문자열로 포맷.
+fn format_vpos_range(
+    para: Option<&Paragraph>,
+    start_line: Option<usize>,
+    end_line: Option<usize>,
+) -> String {
+    let Some(r) = vpos_range(para, start_line, end_line) else {
+        return String::new();
     };
-    for r in resets {
-        s_out.push_str(&format!(" [vpos-reset@line{}]", r));
+    let mut s_out = if r.single {
+        format!("vpos={}", r.first)
+    } else {
+        format!("vpos={}..{}", r.first, r.last)
+    };
+    for i in r.resets {
+        s_out.push_str(&format!(" [vpos-reset@line{}]", i));
     }
-    for r in rewinds {
-        s_out.push_str(&format!(" [vpos-rewind@line{}]", r));
+    for i in r.rewinds {
+        s_out.push_str(&format!(" [vpos-rewind@line{}]", i));
     }
     s_out
+}
+
+/// [#3697] `format_vpos_range` 와 같은 분석(`vpos_range`)의 JSON 표현.
+fn vpos_range_json(
+    para: Option<&Paragraph>,
+    start_line: Option<usize>,
+    end_line: Option<usize>,
+) -> serde_json::Value {
+    match vpos_range(para, start_line, end_line) {
+        Some(r) => serde_json::json!({
+            "first": r.first,
+            "last": r.last,
+            "resets": r.resets,
+            "rewinds": r.rewinds,
+        }),
+        None => serde_json::Value::Null,
+    }
+}
+
+/// [#3697] `format_line_seg_brief` 와 같은 요약(첫/마지막 줄)의 JSON 표현.
+fn line_seg_brief_json(para: Option<&Paragraph>) -> serde_json::Value {
+    fn seg_json(seg: &crate::model::paragraph::LineSeg) -> serde_json::Value {
+        serde_json::json!({
+            "textStart": seg.text_start,
+            "lineHeight": seg.line_height,
+            "textHeight": seg.text_height,
+            "baselineDistance": seg.baseline_distance,
+            "lineSpacing": seg.line_spacing,
+            "columnStart": seg.column_start,
+            "segmentWidth": seg.segment_width,
+        })
+    }
+    let Some(p) = para else {
+        return serde_json::Value::Null;
+    };
+    if p.line_segs.is_empty() {
+        return serde_json::json!({ "count": 0 });
+    }
+    let first = &p.line_segs[0];
+    let last = p.line_segs.last().unwrap_or(first);
+    serde_json::json!({
+        "count": p.line_segs.len(),
+        "first": seg_json(first),
+        "last": seg_json(last),
+    })
 }
 
 /// dump-pages에서 line_seg 계약을 빠르게 대조하기 위한 한 줄 요약.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1232,7 +1232,21 @@ fn show_capabilities(args: &[String]) -> i32 {
         ),
         // ── 진단 ──
         cmd("dump", "diagnostic", "문서 조판부호 구조 덤프"),
-        cmd("dump-pages", "diagnostic", "페이지네이션 항목 덤프"),
+        cmd_json(
+            "dump-pages",
+            "diagnostic",
+            "페이지네이션 항목 덤프 (--json: 조판 진단 기계 계약)",
+            false,
+            &["-p", "--respect-vpos-reset", "--json"],
+            &[
+                "schemaVersion",
+                "source",
+                "pageCount",
+                "pageFilter",
+                "respectVposReset",
+                "pages",
+            ],
+        ),
         cmd(
             "dump-extents",
             "diagnostic",
@@ -1503,7 +1517,7 @@ fn print_help() {
     println!("  dump-endnote-lines <파일.hwp> <section> <para> <control> [note-para]");
     println!("      특정 미주 원본 문단의 line_seg, TextRun, TAC 수식 위치를 함께 덤프");
     println!();
-    println!("  dump-pages <파일.hwp> [-p <번호>] [--respect-vpos-reset]");
+    println!("  dump-pages <파일.hwp> [-p <번호>] [--respect-vpos-reset] [--json]");
     println!("      페이지네이션 결과 덤프 (페이지별 문단/표 배치 목록)");
     println!();
     println!("  dump-records <파일.hwp>");
@@ -5104,13 +5118,16 @@ fn dump_extents(args: &[String]) -> i32 {
 
 fn dump_pages(args: &[String]) -> i32 {
     if args.is_empty() {
-        eprintln!("사용법: rhwp dump-pages <파일.hwp> [-p <페이지번호>]");
+        eprintln!(
+            "사용법: rhwp dump-pages <파일.hwp> [-p <페이지번호>] [--respect-vpos-reset] [--json]"
+        );
         return EXIT_USAGE;
     }
 
     let file_path = &args[0];
     let mut target_page: Option<u32> = None;
     let mut respect_vpos_reset = false;
+    let mut json_mode = false;
 
     let mut i = 1;
     while i < args.len() {
@@ -5135,6 +5152,10 @@ fn dump_pages(args: &[String]) -> i32 {
             }
             "--respect-vpos-reset" => {
                 respect_vpos_reset = true;
+                i += 1;
+            }
+            "--json" => {
+                json_mode = true;
                 i += 1;
             }
             _ => {
@@ -5176,8 +5197,22 @@ fn dump_pages(args: &[String]) -> i32 {
         }
     }
 
-    println!("문서 로드: {} ({}페이지)", file_path, page_count);
-    print!("{}", doc.dump_page_items(target_page));
+    if json_mode {
+        // [#3697] 페이지네이션 진단 기계 계약 (#3608 1-C). stdout 은 순수 JSON 단건 봉투 —
+        // 진행/요약 출력은 내지 않는다 (jsonContract 규약).
+        let envelope = serde_json::json!({
+            "schemaVersion": "1.0",
+            "source": file_path,
+            "pageCount": page_count,
+            "pageFilter": target_page,
+            "respectVposReset": respect_vpos_reset,
+            "pages": doc.dump_page_items_json(target_page),
+        });
+        println!("{envelope}");
+    } else {
+        println!("문서 로드: {} ({}페이지)", file_path, page_count);
+        print!("{}", doc.dump_page_items(target_page));
+    }
     EXIT_OK
 }
 

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -383,6 +383,10 @@ fn capabilities_mcp_covers_every_json_command() {
         .filter_map(|c| c["name"].as_str())
         // capabilities 자신은 도구가 아니라 도구 목록의 원천이라 제외한다.
         .filter(|n| *n != "capabilities")
+        // [#3697] dump-pages 는 CLI 진단 계약만 우선 노출한다 — #3608 1-C 표는 이
+        // 항목에 MCP 도구를 짝짓지 않았다(1-D 의 진단 도구 원칙). 에이전트 수요가
+        // 실증되면 별도 이슈로 승격해 이 제외를 지운다.
+        .filter(|n| *n != "dump-pages")
         .filter(|n| !mcp_commands.contains(n))
         .collect();
     assert!(

--- a/tests/dump_pages_json_contract.rs
+++ b/tests/dump_pages_json_contract.rs
@@ -1,0 +1,203 @@
+//! [#3697] `dump-pages --json` 페이지네이션 진단 기계 계약 (#3608 1-C).
+//!
+//! 계약: `--json` 모드의 stdout 은 순수 JSON 단건 봉투이고 `schemaVersion` 을 포함한다.
+//! 필드 추가는 허용, 기존 필드의 변경·삭제는 본 테스트가 실패로 잡는다.
+//! 종료 코드는 [#2707] 계약(0/1/2)을 그대로 따르고, 실패 경로 stdout 은 0바이트다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// 파싱까지 성공하는 실제 샘플 (cli_json_contract.rs 와 동일).
+const SAMPLE: &str = "samples/hwp3-sample.hwp";
+
+fn sample_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(rhwp_bin())
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn parse_stdout_json(args: &[&str], output: &Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout 이 순수 JSON 이 아닙니다 ({e}).\n{}",
+            describe(args, output)
+        )
+    })
+}
+
+// ── 봉투 스키마 ────────────────────────────────────────────────────────────
+
+#[test]
+fn dump_pages_json_envelope_contract() {
+    let sample = sample_path();
+    let args = ["dump-pages", sample.to_str().unwrap(), "--json"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+
+    let v = parse_stdout_json(&args, &output);
+    // 스키마 고정: 아래 필드의 존재·타입이 계약이다 (필드 추가는 허용).
+    assert_eq!(v["schemaVersion"], "1.0", "{v}");
+    assert!(v["source"].is_string(), "{v}");
+    assert!(v["pageCount"].as_u64().unwrap() >= 1, "{v}");
+    assert!(v["pageFilter"].is_null(), "{v}");
+    assert_eq!(v["respectVposReset"], false, "{v}");
+
+    let pages = v["pages"].as_array().expect("pages 는 배열");
+    assert_eq!(
+        pages.len() as u64,
+        v["pageCount"].as_u64().unwrap(),
+        "필터 없는 pages 는 전체 페이지 수와 일치해야 한다: {v}"
+    );
+
+    let p0 = &pages[0];
+    assert_eq!(p0["pageIndex"], 0, "{p0}");
+    assert_eq!(p0["displayPage"], 1, "{p0}");
+    assert!(p0["section"].as_u64().is_some(), "{p0}");
+    assert!(p0["pageNumber"].as_u64().is_some(), "{p0}");
+    for key in ["x", "y", "width", "height"] {
+        assert!(
+            p0["bodyArea"][key].as_f64().is_some(),
+            "bodyArea.{key} 는 숫자여야 한다: {p0}"
+        );
+    }
+
+    let columns = p0["columns"].as_array().expect("columns 는 배열");
+    assert!(!columns.is_empty(), "{p0}");
+    let c0 = &columns[0];
+    assert_eq!(c0["index"], 0, "{c0}");
+    assert!(c0["usedHeight"].as_f64().is_some(), "{c0}");
+    let items = c0["items"].as_array().expect("items 는 배열");
+    assert_eq!(
+        c0["itemCount"].as_u64().unwrap(),
+        items.len() as u64,
+        "{c0}"
+    );
+
+    // 모든 항목은 kind 를 가지며, 문단/표/도형 항목은 paraIndex 를 가진다.
+    for page in pages {
+        for col in page["columns"].as_array().unwrap() {
+            for item in col["items"].as_array().unwrap() {
+                let kind = item["kind"].as_str().expect("kind 는 문자열");
+                assert!(
+                    [
+                        "fullParagraph",
+                        "partialParagraph",
+                        "table",
+                        "partialTable",
+                        "shape",
+                        "endnoteSeparator",
+                    ]
+                    .contains(&kind),
+                    "알 수 없는 kind: {item}"
+                );
+                if kind != "endnoteSeparator" {
+                    assert!(item["paraIndex"].as_u64().is_some(), "{item}");
+                    assert!(item["isEndnote"].is_boolean(), "{item}");
+                }
+                if kind == "partialParagraph" {
+                    assert!(item["startLine"].as_u64().is_some(), "{item}");
+                    assert!(item["endLine"].as_u64().is_some(), "{item}");
+                }
+                if kind == "table" || kind == "partialTable" || kind == "shape" {
+                    assert!(item["controlIndex"].as_u64().is_some(), "{item}");
+                }
+                if kind == "partialTable" {
+                    assert!(item["startRow"].as_u64().is_some(), "{item}");
+                    assert!(item["endRow"].as_u64().is_some(), "{item}");
+                    assert!(item["isContinuation"].is_boolean(), "{item}");
+                }
+            }
+        }
+        assert!(page["extras"].is_array(), "{page}");
+    }
+}
+
+// ── -p 필터 ────────────────────────────────────────────────────────────────
+
+#[test]
+fn dump_pages_json_page_filter_returns_single_page() {
+    let sample = sample_path();
+    let args = ["dump-pages", sample.to_str().unwrap(), "-p", "0", "--json"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+
+    let v = parse_stdout_json(&args, &output);
+    assert_eq!(v["pageFilter"], 0, "{v}");
+    let pages = v["pages"].as_array().expect("pages 는 배열");
+    assert_eq!(pages.len(), 1, "{v}");
+    assert_eq!(pages[0]["pageIndex"], 0, "{v}");
+}
+
+// ── 실패 경로: stdout 침묵 + exit 계약 ─────────────────────────────────────
+
+#[test]
+fn dump_pages_json_out_of_range_exit_usage_silent_stdout() {
+    let sample = sample_path();
+    let args = [
+        "dump-pages",
+        sample.to_str().unwrap(),
+        "-p",
+        "999",
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "실패 경로 stdout 은 비어야 합니다.\n{}",
+        describe(&args, &output)
+    );
+}
+
+#[test]
+fn dump_pages_json_missing_file_exit_runtime_silent_stdout() {
+    let args = ["dump-pages", "없는파일-dump-pages.hwp", "--json"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "실패 경로 stdout 은 비어야 합니다.\n{}",
+        describe(&args, &output)
+    );
+}
+
+/// [#3289] 아카이브 실행 시 컴파일타임 경로는 빌드 러너 전용이므로,
+/// nextest가 런타임에 재매핑해 주입하는 CARGO_BIN_EXE_rhwp를 우선한다.
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}


### PR DESCRIPTION
Closes #3697 (#3608 1-C 잔여 공백)

## 무엇

`dump-pages` 에 `--json` 을 추가해 페이지네이션 진단의 기계 계약을 만듭니다.

```
rhwp dump-pages <파일.hwp> [-p <쪽>] [--respect-vpos-reset] --json
```

단건 JSON 봉투(#3237 규약): `schemaVersion`("1.0") · `source` · `pageCount` ·
`pageFilter` · `respectVposReset` · `pages`.

- 항목 kind 6종: fullParagraph / partialParagraph / table / partialTable / shape /
  endnoteSeparator — 텍스트 덤프의 진단 필드(vpos reset·rewind, line_seg 요약,
  분할 표 rows·cut, 미주 출처 #1082, 단별 usedHeight/hwpUsedHeight/usedDiff)를
  구조화 필드로 그대로 노출.
- `extras`: #1700 계열 items 밖 문단(wrapAroundPara / hiddenEmptyPara)을 텍스트
  덤프와 같은 귀속 규칙(#1705 wrap zone · #1955 글뒤로 앵커)으로 노출.
- 실패 경로 stdout 0바이트, exit 계약(#2707: 0/1/2) 유지. capabilities 광고 갱신.

## 왜 이런 구조

구역 전처리(미주 합침 #1082, items 밖 문단 페이지 귀속 #1700·#1705·#1955)를
`page_dump_section_ctx` helper 로 추출해 **텍스트/JSON 두 출력이 같은 코드를
공유**합니다. 두 표면이 서로 다른 진단을 보고하는 드리프트를 구조적으로 차단하고,
텍스트 출력은 바이트 동일을 유지했습니다.

스코프: #3608 1-C 표는 이 항목에 MCP 도구를 짝짓지 않았으므로(1-D 진단 도구
원칙) CLI 계약만 구현하고, `cli_json_contract.rs` 의 MCP 커버리지 테스트에서
dump-pages 를 명시 제외했습니다. 에이전트 수요가 실증되면 별도 이슈로 승격합니다.

## 검증 (red→green)

| 게이트 | 결과 |
|---|---|
| red — 구현 제거 상태에서 신설 계약 테스트 | 3/4 실패 재현 (`--json` 미지원 exit 2) |
| green — `cargo test --profile release-test --test dump_pages_json_contract` | 4 passed |
| green — `cargo test --profile release-test --test cli_json_contract` | 22 passed |
| 텍스트 출력 바이트 동일 | devel 기준 빌드와 전/후 비교, 3샘플×2변형(전체·`-p 1`) **6/6 IDENTICAL** — 미주 샘플(`3-09월_교육_통합_2024-미주사이20.hwp`)·어울림 표(`issue1510_coanchored_float_tables.hwp`) 포함 |
| clippy `-D warnings` (release-test) | 통과 — 도중 doc 오귀속(doc_lazy_continuation) 1건 검출·수정 |
| rustfmt --check (변경 4파일) | 통과 (Windows CRLF newline-style 오탐 제외) |

green 은 devel(f80b910aa) 리베이스 후 재컴파일로 재실행했습니다.

시각 변화 없음: CLI 진단 출력 전용 변경이고, 기존 텍스트 출력은 위 표의 바이트
동일 비교로 불변을 확인했습니다 (렌더링 경로 미접촉 — 전/후 이미지 해당 없음).

처리결과 문서: `mydocs/report/task_m100_3697_report.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
