### PR TITLE
fix(mcp): JSON-RPC 규약 적합 — 버전 협상 부재와 비객체 프레임 무응답(응답 증발)

### DIFF
--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -22,8 +22,17 @@ use std::io::{BufRead, Write};
 use rhwp::wasm_api::HwpDocument;
 
 const PROTOCOL_VERSION: &str = "2025-06-18";
+/// 이 서버가 실제로 말할 수 있는 프로토콜 개정판 목록.
+///
+/// 요청받은 값을 그대로 되비추면 서버는 `"9999-99-99"` 같은 존재하지 않는 개정판까지
+/// "지원한다"고 답하게 된다 — 그래 놓고 몸통은 `structuredContent`(2025-06-18 신설)처럼
+/// 특정 개정판 전용 표면을 내보내므로, 클라이언트는 **끊어야 할 신호를 영영 못 받은 채**
+/// 못 읽는 응답을 받는다. 지원 목록을 명시적으로 두는 이유가 이것이다.
+/// 새 개정판을 실제로 구현하면 이 배열에 한 줄 더하는 것이 유일한 변경점이다.
+const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &[PROTOCOL_VERSION];
 /// JSON-RPC 2.0 예약 오류 코드.
 const PARSE_ERROR: i64 = -32700;
+const INVALID_REQUEST: i64 = -32600;
 const METHOD_NOT_FOUND: i64 = -32601;
 const INVALID_PARAMS: i64 = -32602;
 
@@ -119,8 +128,32 @@ pub fn run(args: &[String]) -> i32 {
             }
         };
 
+        // [JSON-RPC 2.0 §5] 파싱은 됐지만 Request 객체가 **아닌** 프레임 — 배열(배치)·
+        // 문자열·숫자·불리언·null. 예전에는 이 프레임에서 `msg.get("id")` 가 None 을
+        // 돌려줘 알림과 구분되지 않았고, 그래서 한 바이트도 쓰지 않고 다음 줄로 넘어갔다.
+        // 스트림은 멀쩡히 살아 있는데 응답 하나만 통째로 증발하므로, 클라이언트는 그 id 를
+        // 영원히 기다린다. 프레임에서 id 를 알아낼 방법이 없으니 규약대로 id=null 로
+        // -32600 을 돌려준다.
+        if !msg.is_object() {
+            let reason = if msg.is_array() {
+                // MCP 2025-06-18 은 JSON-RPC 배치를 명시적으로 제거했다(changelog
+                // "Remove support for JSON-RPC batching"). "배열이라 못 읽었다"가 아니라
+                // "이 개정판에 배치가 없다"라고 짚어줘야 호스트가 요청을 한 줄에 하나씩
+                // 푸는 쪽으로 고칠 수 있다 — 사유가 곧 수정 지시가 되게 한다.
+                "JSON-RPC 배치(배열)는 MCP 2025-06-18 에서 제거되었습니다 — \
+                 요청을 한 줄에 하나씩 보내세요"
+            } else {
+                "요청은 JSON 객체여야 합니다"
+            };
+            write_msg(
+                &stdout,
+                &error_response(serde_json::Value::Null, INVALID_REQUEST, reason),
+            );
+            continue;
+        }
+
         let id = msg.get("id").cloned();
-        let method = msg.get("method").and_then(|m| m.as_str()).unwrap_or("");
+        let method = msg.get("method").and_then(|m| m.as_str());
         let params = msg.get("params").cloned().unwrap_or(serde_json::json!({}));
 
         // 알림(id 없음)은 응답하지 않는다.
@@ -128,13 +161,23 @@ pub fn run(args: &[String]) -> i32 {
             continue;
         };
 
+        // [JSON-RPC 2.0 §4] method 는 문자열이어야 한다. 없거나 문자열이 아니면 "그런
+        // 메서드가 없다"(-32601)가 아니라 "요청 구조가 틀렸다"(-32600)다. 예전에는
+        // `unwrap_or("")` 로 빈 이름을 만들어 -32601 로 흘려보냈고, 문구까지
+        // "지원하지 않는 메서드: " 처럼 이름이 빈 채로 나가 호출자가 원인을 못 짚었다.
+        let Some(method) = method else {
+            write_msg(
+                &stdout,
+                &error_response(id, INVALID_REQUEST, "method 는 문자열이어야 합니다"),
+            );
+            continue;
+        };
+
         let response = match method {
             "initialize" => ok_response(
                 id,
                 serde_json::json!({
-                    "protocolVersion": params.get("protocolVersion")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or(PROTOCOL_VERSION),
+                    "protocolVersion": negotiate_protocol_version(&params),
                     "capabilities": { "tools": {} },
                     "serverInfo": {
                         "name": "rhwp",
@@ -182,6 +225,24 @@ fn error_response(id: serde_json::Value, code: i64, message: &str) -> serde_json
         "jsonrpc": "2.0", "id": id,
         "error": { "code": code, "message": message }
     })
+}
+
+/// [MCP 2025-06-18 lifecycle §Version Negotiation] 클라이언트가 요청한 개정판을
+/// 지원하면 **같은 값**으로, 아니면 서버가 지원하는 다른 개정판으로 응답한다(둘 다 MUST).
+///
+/// 후자가 핵심이다: 클라이언트는 서버가 제시한 개정판을 자기가 못 하면 연결을 끊게
+/// 되어 있는데, 요청값을 되비추면 그 검사가 **항상 통과**해 버려 끊을 기회 자체가
+/// 사라진다. 버전이 없거나 문자열이 아닌 경우도 "요청한 개정판이 목록에 없다"와 같은
+/// 갈래로 접어 서버 기준판을 제시한다.
+fn negotiate_protocol_version(params: &serde_json::Value) -> &'static str {
+    let Some(requested) = params.get("protocolVersion").and_then(|v| v.as_str()) else {
+        return PROTOCOL_VERSION;
+    };
+    SUPPORTED_PROTOCOL_VERSIONS
+        .iter()
+        .find(|supported| **supported == requested)
+        .copied()
+        .unwrap_or(PROTOCOL_VERSION)
 }
 
 /// tools/list 응답: 선언 도구(MCP 필수 3종만 노출) + 세션 도구 3종.

--- a/tests/mcp_server_contract.rs
+++ b/tests/mcp_server_contract.rs
@@ -14,6 +14,10 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 
 const SAMPLE: &str = "samples/hwp3-sample.hwp";
+/// 서버가 실제로 말하는 개정판. src/mcp_serve.rs 의 PROTOCOL_VERSION 과 짝이다.
+const SERVER_PROTOCOL_VERSION: &str = "2025-06-18";
+/// 무응답 결함을 재현할 때 테스트가 hang 하지 않게 하는 상한.
+const RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 fn sample(rel: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
@@ -256,4 +260,226 @@ fn unknown_tool_returns_is_error() {
         serde_json::json!({"name": "no_such_tool", "arguments": {}}),
     );
     assert_eq!(r["result"]["isError"], true, "{r}");
+}
+
+// ── 프로토콜 적합성 회귀 ────────────────────────────────────────────────────
+
+/// 원시 프레임들을 순서대로 보내고 응답 줄을 **타임아웃과 함께** `want` 개까지 모은다.
+///
+/// `Server::request` 를 못 쓰는 이유: 그쪽은 `read_line` 에서 무한정 막힌다. 여기서
+/// 검증하려는 결함이 바로 "응답을 아예 안 쓴다"이므로, 그 harness 로는 테스트가
+/// 실패하지 않고 **hang** 해버린다. 별도 스레드로 읽고 `recv_timeout` 으로 끊어야
+/// 무응답이 실패로 보고된다.
+fn raw_frames(frames: &[&str], want: usize) -> Vec<serde_json::Value> {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("mcp-serve")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("rhwp mcp-serve 실행 실패");
+    let mut stdin = child.stdin.take().expect("stdin");
+    let stdout = child.stdout.take().expect("stdout");
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            let Ok(line) = line else {
+                break;
+            };
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+
+    for f in frames {
+        writeln!(stdin, "{f}").expect("프레임 쓰기 실패");
+    }
+    stdin.flush().expect("flush");
+
+    let mut out = Vec::new();
+    while out.len() < want {
+        match rx.recv_timeout(RESPONSE_TIMEOUT) {
+            Ok(line) if line.trim().is_empty() => continue,
+            Ok(line) => {
+                out.push(serde_json::from_str(line.trim()).unwrap_or_else(|e| {
+                    panic!("stdout 이 순수 JSON-RPC 가 아닙니다 ({e}): {line}")
+                }))
+            }
+            // 무응답 — hang 대신 여기서 끊고 개수로 호출자가 판정한다.
+            Err(_) => break,
+        }
+    }
+
+    drop(stdin);
+    let _ = child.kill();
+    let _ = child.wait();
+    out
+}
+
+/// [MCP 2025-06-18 lifecycle §Version Negotiation]
+///   "If the server supports the requested protocol version, it MUST respond with
+///    the same version. Otherwise, the server MUST respond with another protocol
+///    version it supports."
+///
+/// 결함일 때 서버는 요청값을 **무조건 그대로** 되비췄다 — "9999-99-99" 도 "banana" 도
+/// 합의된 것처럼 보였다. 그래 놓고 몸통은 2025-06-18 전용 표면(structuredContent)을
+/// 내보내므로, 엄격한 클라이언트는 끊어야 할 신호를 못 받은 채 못 읽는 응답을 받는다.
+#[test]
+fn initialize_negotiates_instead_of_echoing_client_version() {
+    for requested in ["9999-99-99", "2024-11-05", "2025-03-26", "banana", ""] {
+        let mut s = Server::start();
+        let r = s.request(
+            "initialize",
+            serde_json::json!({
+                "protocolVersion": requested,
+                "capabilities": {},
+                "clientInfo": {"name": "contract-test", "version": "0"}
+            }),
+        );
+        let negotiated = r["result"]["protocolVersion"]
+            .as_str()
+            .unwrap_or_else(|| panic!("initialize 응답에 protocolVersion 이 없습니다: {r}"));
+        assert_ne!(
+            negotiated, requested,
+            "지원하지 않는 개정판을 그대로 되비추면 안 됩니다(요청={requested}): {r}"
+        );
+        assert_eq!(
+            negotiated, SERVER_PROTOCOL_VERSION,
+            "지원하지 않는 개정판에는 서버가 지원하는 개정판을 제시해야 합니다: {r}"
+        );
+    }
+}
+
+/// 지원하는 개정판은 **같은 값**으로 돌려줘야 한다(MUST) — 협상이 아니라 확인이다.
+/// 위 테스트만 있으면 "항상 서버 버전을 박아라"로 잘못 고쳐도 통과하므로 짝이 필요하다.
+#[test]
+fn initialize_keeps_supported_version_and_defaults_when_absent() {
+    let mut s = Server::start();
+    let r = s.request(
+        "initialize",
+        serde_json::json!({
+            "protocolVersion": SERVER_PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": {"name": "contract-test", "version": "0"}
+        }),
+    );
+    assert_eq!(
+        r["result"]["protocolVersion"], SERVER_PROTOCOL_VERSION,
+        "지원하는 개정판은 같은 값으로 되돌려줘야 합니다: {r}"
+    );
+
+    // 버전이 없거나 문자열이 아닌 경우 — 둘 다 "요청한 개정판이 목록에 없다"와 같은
+    // 갈래이므로 서버 기준판을 제시한다.
+    for params in [
+        serde_json::json!({"capabilities": {}, "clientInfo": {"name": "t", "version": "0"}}),
+        serde_json::json!({"protocolVersion": 20250618, "capabilities": {}}),
+    ] {
+        let mut s = Server::start();
+        let r = s.request("initialize", params);
+        assert_eq!(
+            r["result"]["protocolVersion"], SERVER_PROTOCOL_VERSION,
+            "protocolVersion 이 없거나 문자열이 아니면 서버 기준판: {r}"
+        );
+    }
+}
+
+/// [JSON-RPC 2.0 §5] 파싱은 됐지만 Request 객체가 아닌 프레임은 -32600 으로 답해야
+/// 하고, 프레임에서 id 를 알아낼 수 없으므로 id 는 null 이다.
+///
+/// 결함일 때 이 경로는 **한 바이트도 쓰지 않았다** — 그래서 read_line 이 아니라
+/// 타임아웃 읽기로 확인한다. 무응답이면 hang 이 아니라 실패로 잡혀야 한다.
+#[test]
+fn non_object_frames_get_invalid_request_instead_of_silence() {
+    for frame in [
+        r#"[{"jsonrpc":"2.0","id":1,"method":"ping"}]"#, // JSON-RPC 배치
+        r#""ping""#,                                     // 문자열
+        "42",                                            // 숫자
+        "true",                                          // 불리언
+        "null",                                          // null
+    ] {
+        let out = raw_frames(&[frame], 1);
+        assert_eq!(
+            out.len(),
+            1,
+            "비객체 프레임에 응답이 없습니다 — 클라이언트가 영원히 대기합니다: {frame}"
+        );
+        let r = &out[0];
+        assert_eq!(r["jsonrpc"], "2.0", "{r}");
+        assert_eq!(
+            r["error"]["code"], -32600,
+            "비객체 프레임은 -32600 Invalid Request 여야 합니다({frame}): {r}"
+        );
+        assert_eq!(
+            r["id"],
+            serde_json::Value::Null,
+            "id 를 알아낼 수 없으면 null 이어야 합니다({frame}): {r}"
+        );
+    }
+}
+
+/// MCP 2025-06-18 changelog 는 "Remove support for JSON-RPC batching" 이다.
+/// 배열은 그냥 형식 오류가 아니라 **이 개정판에서 사라진 기능**이므로, 사유에
+/// 개정판을 밝혀야 호스트가 요청을 한 줄씩 푸는 쪽으로 고칠 수 있다.
+#[test]
+fn jsonrpc_batch_is_rejected_with_batching_removed_note() {
+    let out = raw_frames(
+        &[r#"[{"jsonrpc":"2.0","id":1,"method":"ping"},{"jsonrpc":"2.0","id":2,"method":"ping"}]"#],
+        1,
+    );
+    assert_eq!(out.len(), 1, "배치 프레임에 응답이 없습니다");
+    let r = &out[0];
+    assert_eq!(r["error"]["code"], -32600, "{r}");
+    let msg = r["error"]["message"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("배치") && msg.contains("2025-06-18"),
+        "배치 거절 사유는 어느 개정판에서 사라졌는지 밝혀야 합니다: {r}"
+    );
+}
+
+/// [JSON-RPC 2.0 §4] method 는 문자열이어야 한다 — 없거나 다른 타입이면 요청 구조가
+/// 틀린 것(-32600)이지 메서드가 없는 것(-32601)이 아니다. 결함일 때는 unwrap_or("")
+/// 로 빈 이름을 만들어 -32601 과 "지원하지 않는 메서드: " 라는 빈 문구를 냈다.
+#[test]
+fn request_without_string_method_is_invalid_request_not_method_not_found() {
+    for (frame, want_id) in [
+        (r#"{"jsonrpc":"2.0","id":7}"#, 7),
+        (r#"{"jsonrpc":"2.0","id":8,"method":123}"#, 8),
+        (r#"{"jsonrpc":"2.0","id":9,"method":null}"#, 9),
+    ] {
+        let out = raw_frames(&[frame], 1);
+        assert_eq!(out.len(), 1, "응답이 없습니다: {frame}");
+        let r = &out[0];
+        assert_eq!(
+            r["error"]["code"], -32600,
+            "method 가 문자열이 아니면 -32600({frame}): {r}"
+        );
+        assert_eq!(r["id"], want_id, "id 는 그대로 되돌려줍니다({frame}): {r}");
+    }
+}
+
+/// 결함일 때 배치 프레임은 0 바이트를 냈고 뒤이은 ping 만 응답을 받았다 — 즉 스트림은
+/// 살아 있는데 응답 하나가 통째로 증발했다. 고친 뒤에는 프레임 2건에 응답 2건이,
+/// 그것도 보낸 순서대로 나와야 한다(단일 루프이므로 순서는 계약이다).
+#[test]
+fn invalid_frame_does_not_swallow_the_next_response() {
+    let out = raw_frames(
+        &[
+            r#"[{"jsonrpc":"2.0","id":1,"method":"ping"}]"#,
+            r#"{"jsonrpc":"2.0","id":2,"method":"ping"}"#,
+        ],
+        2,
+    );
+    assert_eq!(
+        out.len(),
+        2,
+        "프레임 2건에 응답 2건이 나와야 합니다: {out:?}"
+    );
+    let bad = &out[0];
+    let good = &out[1];
+    assert_eq!(bad["error"]["code"], -32600, "{bad}");
+    assert_eq!(bad["id"], serde_json::Value::Null, "{bad}");
+    assert!(good["result"].is_object(), "{good}");
+    assert_eq!(good["id"], 2, "{good}");
 }


### PR DESCRIPTION
## 요약

`mcp-serve` 의 JSON-RPC 2.0 / MCP 규약 위반 2건입니다. 둘 다 실제 바이너리를 stdio 로 구동해 재현했습니다.

### ① `initialize` 가 클라이언트가 보낸 `protocolVersion` 을 무조건 되비춘다

```
>>> {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"9999-99-99",...}}
<<< {"id":1,"jsonrpc":"2.0","result":{...,"protocolVersion":"9999-99-99",...}}

>>> {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"banana",...}}
<<< {"id":1,"jsonrpc":"2.0","result":{...,"protocolVersion":"banana",...}}
```

존재하지 않는 개정판도, 아예 버전이 아닌 문자열도 "지원한다"고 답합니다. 그래 놓고 몸통은 **2025-06-18 에 신설된 `structuredContent`** 를 내보냅니다 — 같은 세션에서 실측:

```
>>> initialize protocolVersion=2024-11-05
<<< {...,"protocolVersion":"2024-11-05",...}
>>> tools/call hwp_info
<<< {...,"structuredContent":{"format":"hwp3","pageCount":16,...}}
```

[MCP 2025-06-18 lifecycle](https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle) 은 이렇게 정합니다:

> "If the server supports the requested protocol version, it **MUST** respond with the same version. Otherwise, the server **MUST** respond with another protocol version it supports."
> "If the client does not support the version in the server's response, it **SHOULD** disconnect."

되비추기는 마지막 문장의 메커니즘을 파괴합니다 — 클라이언트의 검사가 **항상 통과**하므로 끊을 기회 자체가 사라지고, 결국 못 읽는 응답을 받습니다.

### ② 파싱은 됐지만 Request 객체가 아닌 프레임이 무응답으로 버려진다

```
>>> [{"jsonrpc":"2.0","id":1,"method":"ping"}]     (JSON-RPC 배치)
<<< (아무것도 없음 — 2초 타임아웃, stdout 0바이트)

>>> "ping"  /  42  /  true  /  null
<<< (전부 무응답)
```

가장 날카로운 증거 — 스트림은 살아 있는데 응답 하나만 증발합니다:

```
>>> [{"jsonrpc":"2.0","id":1,"method":"ping"}]
>>> {"jsonrpc":"2.0","id":2,"method":"ping"}
<<< {"id":2,"jsonrpc":"2.0","result":{}}          ← id 1 은 영영 오지 않는다
```

원인은 `msg.get("id")` 가 비객체 프레임에 `None` 을 돌려주고, 그 `None` 이 **알림(notification)과 구분되지 않아** `continue` 로 빠지는 것입니다. 클라이언트는 id 1 을 영원히 기다립니다.

같은 뿌리의 인접 결함 — `method` 가 없거나 문자열이 아닌 경우:

```
>>> {"jsonrpc":"2.0","id":7}
<<< {"error":{"code":-32601,"message":"지원하지 않는 메서드: "},"id":7,...}
```

`unwrap_or("")` 가 빈 이름을 만들어 `-32601` 로 흘려보내고, 문구까지 이름이 빈 채로 나가 호출자가 원인을 못 짚습니다. [JSON-RPC 2.0 §4](https://www.jsonrpc.org/specification#request_object) 상 `method` 는 String 이어야 하므로 이것은 "그런 메서드가 없다"가 아니라 "요청 구조가 틀렸다"(`-32600`)입니다.

## 수정

- **`SUPPORTED_PROTOCOL_VERSIONS`** 목록 신설 + `negotiate_protocol_version()`. 지원 개정판이면 같은 값으로 확인, 아니면 서버 기준판을 제시합니다. 새 개정판을 실제로 구현하면 배열에 한 줄 더하는 것이 유일한 변경점입니다. **현재 목록은 `["2025-06-18"]` 뿐입니다** — 서버의 실제 와이어 표면이 그것이고, 구현하지 않은 개정판을 주장하면 지금 고치는 결함을 그대로 재생산하게 됩니다.
- **`INVALID_REQUEST(-32600)`** 신설. 비객체 프레임은 id 를 알아낼 수 없으므로 [JSON-RPC 2.0 §5](https://www.jsonrpc.org/specification#response_object) 대로 `id: null` 로 응답합니다.
- **배열은 사유를 밝힙니다** — [2025-06-18 changelog](https://modelcontextprotocol.io/specification/2025-06-18/changelog) 의 "Remove support for JSON-RPC batching" 을 인용해 "이 개정판에 배치가 없다"고 답합니다. "배열이라 못 읽었다"가 아니라 **사유가 곧 수정 지시**가 되게 했습니다.
- `method` 가 문자열이 아니면 `-32600` + 프레임에서 읽어낸 id 를 그대로 되돌립니다.

## 동작 변화표

| 입력 프레임 | 이전 | 이후 |
|---|---|---|
| `initialize` w/ `"9999-99-99"`·`"banana"`·`"2024-11-05"` | 그대로 되비춤 | `"2025-06-18"` |
| `initialize` w/ `"2025-06-18"` | `"2025-06-18"` | 변화 없음 |
| `initialize` w/o `protocolVersion` | `"2025-06-18"` | 변화 없음 |
| `[{...}]` 배치 | **0 바이트** | `-32600`, id `null`, 배치 제거 사유 |
| `"ping"` / `42` / `true` / `null` | **0 바이트** | `-32600`, id `null` |
| `{"id":7}` (method 없음) | `-32601` "지원하지 않는 메서드: " | `-32600`, id `7` |
| `{"id":8,"method":123}` | `-32601` 동문 | `-32600`, id `8` |
| `{not json` | `-32700`, id `null` | 변화 없음 |
| `{"jsonrpc":"2.0","method":"notifications/initialized"}` | 무응답(정상) | 변화 없음 |

## 회귀 가드 6종

무응답 결함은 기존 하네스(`Server::request`)로 검증할 수 없습니다 — `read_line` 에서 막혀 테스트가 **실패가 아니라 hang** 합니다. 그래서 읽기 전용 스레드 + `recv_timeout(5s)` 하네스(`raw_frames`)를 따로 만들어 **회귀가 행이 아니라 실패로 보고**되게 했습니다.

- `initialize_negotiates_instead_of_echoing_client_version` — 미지원 5종
- `initialize_keeps_supported_version_and_defaults_when_absent` — 짝 테스트(없으면 "항상 서버 버전 박기"로 잘못 고쳐도 통과)
- `non_object_frames_get_invalid_request_instead_of_silence` — 배치·문자열·숫자·불리언·null
- `jsonrpc_batch_is_rejected_with_batching_removed_note` — 사유에 개정판이 명시되는지
- `request_without_string_method_is_invalid_request_not_method_not_found`
- `invalid_frame_does_not_swallow_the_next_response` — 프레임 2건 → 응답 2건, 순서 보존

## 검증

- `cargo test --test mcp_server_contract` — **12/12** (신규 6종 포함)
- 인접 계약 `mcp_session_edit`·`mcp_session_query`·`agent_profile_router` — 15/15 무회귀
- `cargo clippy --profile release-test --bin rhwp` — 경고 0 / `cargo fmt --check` — 통과
- 기존 테스트 전부가 `"2025-06-18"` 을 보내므로 협상 변경은 기존 스위트에 무영향입니다.

## 범위 밖 (후속)

JSON-RPC 2.0 §4 는 `id` 도 String·Number·Null 이어야 한다고 정하는데, 현재 `{"id":{"a":1}}` 는 객체를 그대로 응답 id 로 되돌립니다. 같은 계열이지만 이 PR 의 증적 범위 밖이라 별도 이슈로 남깁니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
