### PR TITLE
fix(hwpx): #3545 초기 상태 누름틀의 안내문 본문 텍스트가 저장에서 영구 소실되는 문제

### DIFF
--- a/mydocs/report/task_m100_3545_pr_body.md
+++ b/mydocs/report/task_m100_3545_pr_body.md
@@ -1,0 +1,108 @@
+## 무엇을 고치나
+
+Issue #3545 의 **잔여 축**입니다. 선행 PR #3659(merge `952c831a`)가 HWPX
+`fieldBegin@dirty` ↔ `properties` 비트 15 왕복을 해소해 **채운 값**은 보존되지만,
+초기 상태(`dirty="0"`) 누름틀의 **안내문 본문 run 을 적재 때 물리 삭제**하는 축은
+그대로 남아 있었습니다. 그 결과 HWPX 를 **열고 저장하기만 해도** 해당 텍스트가
+파일에서 영구 소실됩니다.
+
+한컴은 미기입 누름틀의 안내문을 파일에는 본문 run 으로 유지하고 렌더·인쇄에서만
+구분 취급합니다 — 동봉 샘플 `samples/hwpx/form-01.hwpx` 실물이 그 정준형입니다.
+XSD·구조 검증은 통과하고, 재적재하면 같은 정규화가 다시 지워 값 API 표면에도 안
+나타나며, 빈 필드 안내문 합성 렌더 덕분에 화면도 멀쩡해 보입니다. **저장 전후 파일
+대조로만 드러나는 조용한 내용 소실**입니다.
+
+## 전 / 후 (저장본 `Contents/section0.xml`, `samples/hwpx/form-01.hwpx`)
+
+원본 (한컴 정준형):
+
+```xml
+<hp:fieldBegin ... type="CLICK_HERE" name="myMsg01" editable="1" dirty="0" ...>
+<hp:run charPrIDRef="6"><hp:t>여기에 입력</hp:t></hp:run>
+<hp:run charPrIDRef="1"><hp:ctrl><hp:fieldEnd .../></hp:ctrl><hp:t/></hp:run>
+```
+
+**전** — rhwp 저장본에서 본문 텍스트가 사라짐 (run 껍데기만 남음):
+
+```xml
+<hp:run charPrIDRef="6"><hp:t></hp:t></hp:run>
+```
+
+**후** — 원본 형상 복원 (charPrIDRef 까지 동형):
+
+```xml
+<hp:run charPrIDRef="6"><hp:t>여기에 입력</hp:t></hp:run>
+```
+
+> 시각(렌더) 전/후 이미지는 첨부하지 않았습니다. 이 결함은 **렌더에 나타나지 않는**
+> 부류이기 때문입니다 — rhwp 는 빈 필드에 안내문을 합성 렌더하므로 수정 전후 SVG 가
+> 동일합니다. 관측 가능한 유일한 표면인 저장본 XML 대조로 대신했습니다.
+
+## 해법 — 삭제는 유지, 잔재를 기록해 저장 시 복원
+
+정규화 계약(편집 IR 은 빈 필드, 값 API 는 빈 값)을 **1비트도 바꾸지 않고**, 삭제
+시점에 잔재를 파생 상태로 기록해 HWPX 저장에서만 원본 run 을 되살립니다.
+
+1. `model::control::GuideResidue { text, char_shape_id }` 신설 +
+   `Field.guide_residue: Option<GuideResidue>`.
+2. `clear_initial_field_texts` 가 삭제할 때 제거 텍스트와 *그 텍스트를 담던 run 의
+   `charPrIDRef`* 를 함께 기록합니다 (삭제 수술이 경계를 zero-width 로 접기 **전**
+   좌표에서 조회해야 정확).
+3. HWPX 저장기가 0-length 필드의 `fieldEnd` 방출 직전, 기록된 char shape 경계까지만
+   run 을 끊고 그 안에 `<hp:t>` 를 되돌립니다. IR 위치 축은 건드리지 않으므로
+   저장→재적재 고정점이 유지됩니다.
+
+### 이슈의 방향 (i)/(ii) 에 대해
+
+- 이슈가 지적한 **(ii) 저장 시 재구성**의 약점은 "삭제 수술로 원본 char shape 가 이미
+  소실돼 서식 충실 재구성이 불가능"이었습니다. 삭제 **시점에** 텍스트와 char shape 를
+  같이 기록하면 그 전제가 무너집니다 — 복원본은 원본과 문자열 동형입니다.
+- **(i) 적재 보존 → 소비 계층 해석**은 IR 정규화 전제를 바꿔 값 API·렌더·텍스트
+  추출·라운드트립 지표·렌더 golden 전반에 영향을 줍니다. 이 PR 은 그 결정을 선점하지
+  않습니다. 정규화 계약을 그대로 두므로, (i) 로 가기로 결정되면 이 복원 경로는 그대로
+  대체·제거되고 데이터 소실만 그동안 막습니다.
+
+## 잘못 주입하지 않는 게이트
+
+- 원본부터 잔재가 없던 필드는 표식이 없어 아무것도 주입되지 않습니다
+  (`samples/issue1893_clickhere_field_roundtrip.hwpx` 의 `id=1549188905` — `Direction`
+  파라미터조차 없는 빈 스팬). 계약 테스트로 고정했습니다.
+- 값이 채워진 필드(`start != end`)와 수정됨 표식(bit 15)이 선 필드는 건너뜁니다 —
+  중복 주입과 사용자가 비운 값의 부활을 막습니다.
+
+## 검증 (red → green 실행 확인)
+
+| 게이트 | 결과 |
+| --- | --- |
+| red (수정 전) `--test issue_3545_clickhere_dirty_roundtrip` | 3 failed / 5 passed — 저장본 안내문 run **0회** |
+| green (수정 후) 같은 타깃 | **8 passed** |
+| `cargo test --profile release-test --lib` (변경 소스 소속 타깃) | **3016 passed / 0 failed** |
+| 필드·HWPX 왕복 focused 타깃 16종 | **84 passed / 0 failed** |
+| `rustfmt --check` (변경 파일) | 통과 |
+| `cargo clippy --profile release-test --bin rhwp -- -D warnings` | 통과 |
+
+focused 16종: `edit_field_occurrence_contract`, `edit_fill_fields_contract`,
+`fields_json_contract`, `hwpx_form_roundtrip`, `hwpx_roundtrip_baseline`,
+`hwpx_roundtrip_integration`, `ir_field_sweep_baseline`, `issue_1391_memo_field_roundtrip`,
+`issue_1434_clickhere_guide_hancom_command`, `issue_1893`, `issue_258_clickhere_form_mode`,
+`issue_3375_field_guide_print_profile`, `issue_3380_field_value_equals_guide`,
+`issue_3545_clickhere_dirty_roundtrip`, `issue_493_hwpx_cell_field_name`,
+`issue_838_field_set_value`. `--tests` 전체 스위트는 로컬 제약으로 실행하지 않고 CI 에
+위임했습니다.
+
+추가한 계약 테스트 5건: 저장 보존(charPrIDRef 동형까지), 저장→재적재→재저장 고정점
+(값 API 는 빈 값 유지), 채운 필드 중복 방지, 실물 행정 서식의 잔재 보존 + 원본 빈 스팬
+무주입.
+
+## 남긴 것
+
+- **HWP5 저장 축**: 같은 적재 정규화가 HWP5 원본에도 걸리므로 `export_hwp` 경로에는
+  소실이 남습니다. 이 이슈가 HWPX 축으로 좁혀 제기됐고 HWP5 직렬화는 별도 golden
+  면적을 건드리므로 후속 건으로 분리했습니다. 표식은 포맷 무관하게 기록되므로 HWP5
+  저장기 배선만 추가하면 됩니다.
+- 슬롯 위치 추정 실패(mismatch) 퇴화 경로는 복원 대상에서 제외했습니다 — 그 경로는
+  run·위치 정합이 이미 무너져 있어 주입이 개선이라 단정할 수 없습니다.
+
+처리결과 문서: `mydocs/report/task_m100_3545_report.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/mydocs/report/task_m100_3545_report.md
+++ b/mydocs/report/task_m100_3545_report.md
@@ -1,0 +1,127 @@
+---
+kind: report
+status: active
+last_verified: 2026-08-01
+---
+
+# Task #3545 처리결과 — 초기 상태 누름틀 안내문의 파일 수준 보존
+
+- Issue: [#3545](https://github.com/edwardkim/rhwp/issues/3545) —
+  「[HWPX] 안내문과 같은 본문 텍스트를 가진 누름틀이 로드만 해도 텍스트를 잃고,
+  저장하면 파일에서 영구 소실된다」
+- 브랜치 `task/3545-hwpx-pressframe-text-loss` (기준 `upstream/devel` f80b910aa)
+- 선행 축: [#3659](https://github.com/edwardkim/rhwp/pull/3659) (merge `952c831a`) 가
+  HWPX `fieldBegin@dirty` ↔ `Field.properties` 비트 15 왕복을 해소 — **채운 값**은
+  이제 보존된다. 이 작업은 이슈에 남겨 둔 **잔여 축**, 즉 초기 상태(`dirty="0"`)
+  안내문 잔재의 물리 삭제를 다룬다.
+
+## 문제
+
+적재 정규화 `clear_initial_field_texts`(`src/document_core/commands/document.rs`)는
+`properties` 비트 15 == 0 인 ClickHere 필드의 본문 텍스트가 안내문과 같으면 이를
+`para.text` 에서 **물리 삭제**한다. 함수 주석은 이 텍스트를 "메모 추가 등의 동작 시
+삽입되는" 이례 상태로 전제하지만, 동봉 샘플 실물은 그 반대를 보여준다.
+
+`samples/hwpx/form-01.hwpx` 원본:
+
+```xml
+<hp:fieldBegin ... type="CLICK_HERE" name="myMsg01" editable="1" dirty="0" ...>
+<hp:run charPrIDRef="6"><hp:t>여기에 입력</hp:t></hp:run>
+<hp:ctrl><hp:fieldEnd .../></hp:ctrl>
+```
+
+즉 한컴은 미기입 누름틀의 안내문을 **파일에는 본문 run 으로 유지**하고 렌더·인쇄에서만
+구분 취급한다. 이것이 정준형이다. rhwp 는 적재 때 이 run 을 지우고 저장기가 되살리지
+않으므로, **열고 저장하기만 해도 그 텍스트가 파일에서 영구 소실**된다. XSD·구조 검증은
+통과하고, 재적재하면 같은 정규화가 다시 지워 값 API 표면에도 안 나타나며, 빈 필드
+안내문 합성 렌더 덕에 화면도 멀쩡해 보인다 — 저장 전후 파일 대조로만 드러나는 부류다.
+
+## 해법 — 삭제는 유지, 잔재를 기록해 저장 시 복원
+
+정규화 계약(편집 IR 은 빈 필드, 값 API 는 빈 값)을 **그대로 두고**, 삭제 시점에 잔재를
+파생 상태로 기록해 HWPX 저장에서만 원본 run 을 되살린다.
+
+1. **IR 표식** — `model::control::GuideResidue { text, char_shape_id }` 신설,
+   `Field.guide_residue: Option<GuideResidue>` 추가 (`src/model/control.rs`).
+2. **기록** — `clear_initial_field_texts` 가 삭제할 때 제거 텍스트 원문과 *그 텍스트를
+   담던 run 의 `charPrIDRef`* 를 함께 남긴다. char shape 는 삭제 수술이 경계를
+   zero-width 로 접기 **전** 좌표에서 조회해야 정확하다.
+3. **복원** — HWPX 저장기 `render_runs` 가 0-length 필드의 `fieldEnd` 를 방출하기 직전,
+   기록된 char shape 경계까지만 run 을 끊고 그 안에 `<hp:t>` 를 되돌린다
+   (`emit_guide_residue` / `emit_field_end_at`, `src/serializer/hwpx/section.rs`).
+   IR 위치 축(`expected_utf16_pos`)은 건드리지 않는다 — 방출 XML 에만 텍스트가 돌아온다.
+
+### 왜 이 형태인가
+
+- 이슈가 제시한 **(ii) 저장 시 재구성**의 결정적 약점은 "삭제 수술로 원본 char shape 가
+  이미 소실돼 서식 충실 재구성이 불가능"이었다. 삭제 **시점에** 텍스트와 char shape 를
+  같이 기록하면 이 전제가 무너진다 — 복원본은 원본과 문자열 동형이다.
+- **(i) 적재 시 보존 → 소비 계층 해석**은 IR 정규화 전제를 바꾸므로 값 API·렌더·텍스트
+  추출·라운드트립 지표·렌더 golden 전반에 영향을 준다. 이 PR 은 그 큰 결정을 선점하지
+  않는다: 정규화 계약을 1비트도 바꾸지 않으므로 (i) 로 가더라도 그대로 대체된다.
+- 삭제 자체가 이미 zero-width char run 을 원본 서식의 근거로 남겨 두고 있었으므로
+  (#1893 주석), 복원은 그 근거를 소비하는 자연스러운 역연산이다.
+
+### 잘못 주입하지 않는 게이트
+
+- 원본부터 잔재가 없던 필드는 표식이 없어 아무것도 주입되지 않는다
+  (`samples/issue1893_clickhere_field_roundtrip.hwpx` 의 `id=1549188905` — `Direction`
+  파라미터조차 없는 빈 스팬).
+- 값이 채워진 필드(`start != end`)와 수정됨 표식이 선 필드(`bit 15`)는 건너뛴다 —
+  중복 주입·사용자가 비운 값의 부활을 막는다.
+
+## 검증
+
+red → green 은 실제 실행으로 확인했다.
+
+| 게이트 | 결과 |
+| --- | --- |
+| red (수정 전) `--test issue_3545_clickhere_dirty_roundtrip` | **3 failed / 5 passed** — 저장본 안내문 run 0회 |
+| green (수정 후) 같은 타깃 | **8 passed** |
+| `cargo test --profile release-test --lib` (변경 소스 소속 타깃) | **3016 passed / 0 failed** (7 ignored) |
+| 필드·HWPX 왕복 focused 타깃 16종 | **84 passed / 0 failed** |
+| `rustfmt --check` (변경 파일) | 통과 (CRLF 오탐 제거 후 exit 0) |
+| `cargo clippy --profile release-test --bin rhwp -- -D warnings` | 통과 |
+
+focused 16종: `edit_field_occurrence_contract`, `edit_fill_fields_contract`,
+`fields_json_contract`, `hwpx_form_roundtrip`, `hwpx_roundtrip_baseline`,
+`hwpx_roundtrip_integration`, `ir_field_sweep_baseline`, `issue_1391_memo_field_roundtrip`,
+`issue_1434_clickhere_guide_hancom_command`, `issue_1893`, `issue_258_clickhere_form_mode`,
+`issue_3375_field_guide_print_profile`, `issue_3380_field_value_equals_guide`,
+`issue_3545_clickhere_dirty_roundtrip`, `issue_493_hwpx_cell_field_name`,
+`issue_838_field_set_value`.
+
+> `cargo test --profile release-test --tests` 전체 스위트는 이 세션에서 실행하지
+> 않았다(로컬 디스크·시간 제약). 변경 소스 소속 타깃(`--lib`)과 필드·HWPX 왕복 면적을
+> focused 로 덮었고, 전체 회귀는 PR CI 에 위임한다.
+
+red 실패 메시지(대표):
+
+```text
+initial_guide_body_run_survives_hwpx_save
+  assertion `left == right` failed: 초기 상태 누름틀의 안내문 본문 run 이 저장에서 소실/중복됐다
+  left: 0   right: 1
+```
+
+계약 테스트 5건은 `tests/issue_3545_clickhere_dirty_roundtrip.rs` 에 추가했다 —
+저장 보존, 저장→재적재→재저장 고정점(값 API 는 빈 값 유지), 채운 필드 중복 방지,
+실물 행정 서식의 잔재 보존 + 원본 빈 스팬 무주입.
+
+## 남긴 것 (범위 밖)
+
+- **HWP5 저장 축**: 같은 적재 정규화가 HWP5 원본에도 적용되므로 `export_hwp` 경로에도
+  같은 소실이 남아 있다. 이 이슈는 HWPX 축으로 좁혀 제기됐고 HWP5 직렬화는 별도
+  golden 면적을 건드리므로 후속 건으로 분리한다. 표식(`guide_residue`)은 포맷 무관하게
+  기록되므로 HWP5 저장기 배선만 추가하면 된다.
+- **mismatch 경로**: 슬롯 위치 추정 실패로 `fieldEnd` 를 말미 일괄 방출하는 퇴화 경로는
+  복원 대상에서 제외했다 — 그 경로는 run/위치 정합이 이미 무너져 있어 주입이 개선이라
+  단정할 수 없다.
+- 이슈의 **(i) 렌더 전용 억제** 전환 판단은 그대로 열려 있다.
+
+## 교훈
+
+- "정규화가 파일을 조용히 줄인다"는 부류는 값 API·렌더 어느 표면에도 안 나타난다.
+  **저장 전후 파일 대조**가 유일한 관측면이라, 계약 테스트도 IR 이 아니라 저장본 XML 을
+  직접 봐야 한다.
+- 파괴적 정규화를 유지해야 한다면, **파괴 시점이 원본 형상을 기록할 유일한 기회**다.
+  나중에 재구성하려 하면 이미 근거가 없다.

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -1839,6 +1839,26 @@ impl DocumentCore {
                 // 필드의 end 마커를 컨트롤로 오산해 begin 갭을 유실 — 필드쌍 교차 페어링 유발).
                 if offsets_valid && start < end && end <= orig_offsets.len() {
                     let u_start = orig_offsets[start];
+                    // [#3545] 지워진 본문 run 을 HWPX 저장에서 되살리기 위한 잔재 기록.
+                    // 한컴 정준형은 미기입 누름틀의 안내문을 파일에 본문 run 으로 남기므로
+                    // (form-01.hwpx), 기록 없이 저장하면 파일에서 영구 소실된다. 서식까지
+                    // 되살리도록 그 텍스트를 담던 run 의 char shape 도 함께 남긴다 — 아래
+                    // 수술이 zero-width 로 접기 전의 원본 좌표에서 조회해야 정확하다.
+                    let residue_shape_id = para
+                        .char_shapes
+                        .iter()
+                        .rev()
+                        .find(|cs| cs.start_pos <= u_start)
+                        .map(|cs| cs.char_shape_id)
+                        .unwrap_or(0);
+                    let residue_text: String = orig_chars[start..end].iter().collect();
+                    let ctrl_idx = para.field_ranges[fri].control_idx;
+                    if let Some(Control::Field(f)) = para.controls.get_mut(ctrl_idx) {
+                        f.guide_residue = Some(crate::model::control::GuideResidue {
+                            text: residue_text,
+                            char_shape_id: residue_shape_id,
+                        });
+                    }
                     // 삭제 폭 = 삭제 문자들의 utf16 폭만. orig_offsets[end] 는 필드 end
                     // 마커의 8유닛 갭을 건너뛴 다음 문자 위치라 갭까지 폭에 포함되어
                     // 후속 오프셋에서 마커 갭이 소실된다(슬롯 방출 위치 붕괴).

--- a/src/document_core/queries/field_query.rs
+++ b/src/document_core/queries/field_query.rs
@@ -1058,6 +1058,7 @@ fn collect_fields_from_paragraph(
                                 memo_paragraphs: Vec::new(),
                                 memo_text_direction: None,
                                 raw_parameters_xml: None,
+                                guide_residue: None,
                             },
                             location: loc,
                             value,
@@ -1316,6 +1317,7 @@ fn insert_click_here_field_in_para(
         memo_paragraphs: Vec::new(),
         memo_text_direction: None,
         raw_parameters_xml: None,
+        guide_residue: None,
     };
 
     para.controls.insert(insert_idx, Control::Field(field));
@@ -1526,6 +1528,7 @@ mod tests {
             memo_paragraphs: Vec::new(),
             memo_text_direction: None,
             raw_parameters_xml: None,
+            guide_residue: None,
         })
     }
 

--- a/src/model/control.rs
+++ b/src/model/control.rs
@@ -237,6 +237,18 @@ pub struct HiddenComment {
     pub paragraphs: Vec<Paragraph>,
 }
 
+/// 초기 상태 누름틀에서 적재 정규화가 제거한 안내문 본문 run 의 원본 형상 (#3545).
+///
+/// 편집 IR 은 빈 필드로 정규화된 상태가 authoritative 이고, 이 구조체는 **저장 시
+/// 원본 파일 형상을 되돌리기 위한 파생 상태**다 (값 API·렌더는 이 값을 보지 않는다).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GuideResidue {
+    /// 제거된 본문 텍스트 원문 (한컴이 안내문 뒤에 붙이는 trailing 공백까지 그대로).
+    pub text: String,
+    /// 그 텍스트를 담던 run 의 `charPrIDRef` — 복원 시 원본 서식을 함께 되살린다.
+    pub char_shape_id: u32,
+}
+
 /// 필드 컨트롤
 #[derive(Debug, Clone, Default)]
 pub struct Field {
@@ -272,6 +284,15 @@ pub struct Field {
     /// 가지나 IR 은 Command/Number 만 추출하므로, 무손실 roundtrip 을 위해 원문을
     /// 그대로 보존한다 (HWP5 경로엔 무관 — HWPX 파서만 적재).
     pub raw_parameters_xml: Option<String>,
+    /// [#3545] 적재 정규화(`clear_initial_field_texts`)가 지운 안내문 본문 run 의 잔재.
+    ///
+    /// 한컴은 미기입 누름틀(dirty="0")의 안내문을 **파일에는 본문 run 으로 유지**하고
+    /// 렌더·인쇄에서만 구분 취급한다 (`samples/hwpx/form-01.hwpx` 의
+    /// `<hp:run charPrIDRef="6"><hp:t>여기에 입력</hp:t></hp:run>`). rhwp 는 편집 IR 을
+    /// 빈 필드로 정규화하므로, 저장에서 이 잔재를 되살리지 않으면 파일 차원에서
+    /// 텍스트가 영구 소실된다. 정규화 계약(값 API 는 빈 값)은 그대로 두고 HWPX 저장
+    /// 시에만 원본 run 을 복원한다.
+    pub guide_residue: Option<GuideResidue>,
 }
 
 impl Field {

--- a/src/parser/control.rs
+++ b/src/parser/control.rs
@@ -136,6 +136,7 @@ fn parse_field_control(ctrl_id: u32, ctrl_data: &[u8]) -> Control {
         memo_paragraphs: Vec::new(),
         memo_text_direction: None,
         raw_parameters_xml: None,
+        guide_residue: None,
     })
 }
 

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -733,9 +733,20 @@ impl RunSplitter {
     /// `pos` 이하 위치의 경계를 모두 적용 — 규칙 1 (경계 먼저, 콘텐츠는 새 run 소속).
     fn cut_before(&mut self, pos: u32) {
         while self.needs_cut(pos) {
-            self.close_run();
-            self.next += 1;
+            self.cut_one();
         }
+    }
+
+    /// 경계 1개만 적용한다 — 같은 위치에 여러 경계가 겹칠 때 그중 특정 run 에
+    /// 콘텐츠를 넣어야 하는 경우에 쓴다 (#3545 안내문 잔재 복원).
+    fn cut_one(&mut self) {
+        self.close_run();
+        self.next += 1;
+    }
+
+    /// 현재 열려 있는 run 의 `charPrIDRef`.
+    fn current_shape_id(&self) -> u32 {
+        self.segs[self.next - 1].1
     }
 
     /// 현재 run 을 `<hp:run charPrIDRef>` 로 감싸 완성 목록에 추가.
@@ -783,6 +794,53 @@ fn emit_field_end(out: &mut String, para: &Paragraph, fr: &FieldRange) {
             out.push_str("</hp:ctrl>");
         }
     }
+}
+
+/// [#3545] 적재 정규화가 지운 **초기 상태 누름틀의 안내문 본문 run** 을 되살린다.
+///
+/// 한컴은 미기입 누름틀(`dirty="0"`)의 안내문을 파일에는 begin~end 사이 본문 run 으로
+/// 유지하고 렌더·인쇄에서만 구분 취급한다 (`samples/hwpx/form-01.hwpx` 의
+/// `<hp:run charPrIDRef="6"><hp:t>여기에 입력</hp:t></hp:run>`). rhwp 는 적재 시
+/// `clear_initial_field_texts` 로 이를 빈 필드로 정규화하므로, 저장에서 되살리지 않으면
+/// 파일 차원에서 텍스트가 영구 소실된다(XSD 는 통과하는 조용한 내용 소실).
+///
+/// IR 위치 축(`expected_utf16_pos`)은 건드리지 않고 **방출 XML 에만** 텍스트를 되돌린다.
+/// 재적재하면 같은 정규화가 다시 지우므로 IR 은 저장→적재 고정점을 유지한다.
+fn emit_guide_residue(splitter: &mut RunSplitter, para: &Paragraph, fr: &FieldRange, pos: u32) {
+    // 값이 채워진 필드는 본문 run 이 이미 있다 — 중복 주입 금지.
+    if fr.start_char_idx != fr.end_char_idx {
+        return;
+    }
+    let Some(Control::Field(f)) = para.controls.get(fr.control_idx) else {
+        return;
+    };
+    // 수정됨(bit 15) 표식이 선 필드는 초기 상태가 아니다 — 사용자가 비운 값을 되살리면 안 된다.
+    if f.is_dirty() {
+        return;
+    }
+    let Some(residue) = f.guide_residue.as_ref() else {
+        return;
+    };
+    if residue.text.is_empty() {
+        return;
+    }
+    // 잔재를 담던 run 의 경계까지만 먼저 끊는다 — 삭제 수술이 같은 위치에 접어 둔
+    // zero-width run 들이 원본 서식(charPrIDRef)의 유일한 근거다.
+    while splitter.needs_cut(pos) && splitter.current_shape_id() != residue.char_shape_id {
+        splitter.cut_one();
+    }
+    let mut tab_idx = 0usize;
+    splitter
+        .content
+        .push_str(&render_hp_t_content(&residue.text, &[], &mut tab_idx));
+}
+
+/// `pos` 위치에서 경계를 적용하고 `fieldEnd` 를 방출한다.
+/// 0-length 필드면 그 직전에 안내문 잔재를 복원한다 (#3545).
+fn emit_field_end_at(splitter: &mut RunSplitter, para: &Paragraph, fr: &FieldRange, pos: u32) {
+    emit_guide_residue(splitter, para, fr, pos);
+    splitter.cut_before(pos);
+    emit_field_end(&mut splitter.content, para, fr);
 }
 
 /// 고아(다단락) fieldEnd 를 `<hp:ctrl><hp:fieldEnd .../></hp:ctrl>` 로 방출 (Task #1556).
@@ -1028,8 +1086,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
         }
         for (i, fr) in para.field_ranges.iter().enumerate() {
             if fr.start_char_idx == fr.end_char_idx && !field_end_emitted[i] {
-                splitter.cut_before(expected_utf16_pos);
-                emit_field_end(&mut splitter.content, para, fr);
+                emit_field_end_at(&mut splitter, para, fr, expected_utf16_pos);
                 expected_utf16_pos = expected_utf16_pos.saturating_add(8);
                 field_end_emitted[i] = true;
             }
@@ -1109,8 +1166,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
                     && fr.end_char_idx == idx
                     && fr.control_idx == emitted_ctrl_idx
                 {
-                    splitter.cut_before(expected_utf16_pos);
-                    emit_field_end(&mut splitter.content, para, fr);
+                    emit_field_end_at(&mut splitter, para, fr, expected_utf16_pos);
                     expected_utf16_pos = expected_utf16_pos.saturating_add(8);
                     field_end_emitted[i] = true;
                 }
@@ -1147,8 +1203,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
                     &para.tab_extended,
                     &mut tab_idx,
                 );
-                splitter.cut_before(expected_utf16_pos);
-                emit_field_end(&mut splitter.content, para, fr);
+                emit_field_end_at(&mut splitter, para, fr, expected_utf16_pos);
                 field_end_emitted[i] = true;
             }
         }
@@ -1218,8 +1273,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
                     &para.tab_extended,
                     &mut tab_idx,
                 );
-                splitter.cut_before(expected_utf16_pos);
-                emit_field_end(&mut splitter.content, para, fr);
+                emit_field_end_at(&mut splitter, para, fr, expected_utf16_pos);
                 // [#1407] fieldEnd 는 8유닛 슬롯을 소비한다. expected 를 +8 진행하지
                 // 않으면 다음 idx 에서 텍스트-끝 슬롯(newNum 등)이 이 8유닛 갭을
                 // 가로채 텍스트가 +8 밀린다 (143E 문단 0.14: char_offsets[3] 27→35).
@@ -1250,8 +1304,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
             if begin_slot_pending {
                 continue;
             }
-            splitter.cut_before(expected_utf16_pos);
-            emit_field_end(&mut splitter.content, para, fr);
+            emit_field_end_at(&mut splitter, para, fr, expected_utf16_pos);
             expected_utf16_pos = expected_utf16_pos.saturating_add(8);
             field_end_emitted[i] = true;
         }
@@ -1292,8 +1345,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
                 && fr.start_char_idx == fr.end_char_idx
                 && fr.control_idx == emitted_ctrl_idx
             {
-                splitter.cut_before(expected_utf16_pos);
-                emit_field_end(&mut splitter.content, para, fr);
+                emit_field_end_at(&mut splitter, para, fr, expected_utf16_pos);
                 expected_utf16_pos = expected_utf16_pos.saturating_add(8);
                 field_end_emitted[i] = true;
             }
@@ -1302,8 +1354,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
     // [Task #1893] 방어: 지연분이 슬롯 루프에서 매칭되지 못했으면 말미에 방출(종전 동작).
     for (i, fr) in para.field_ranges.iter().enumerate() {
         if !field_end_emitted[i] {
-            splitter.cut_before(expected_utf16_pos);
-            emit_field_end(&mut splitter.content, para, fr);
+            emit_field_end_at(&mut splitter, para, fr, expected_utf16_pos);
             expected_utf16_pos = expected_utf16_pos.saturating_add(8);
             field_end_emitted[i] = true;
         }

--- a/tests/issue_3545_clickhere_dirty_roundtrip.rs
+++ b/tests/issue_3545_clickhere_dirty_roundtrip.rs
@@ -148,3 +148,122 @@ fn initial_state_still_normalized_on_load() {
         "왕복 후에도 초기 상태 유지"
     );
 }
+
+// =====================================================================
+// [#3545 잔여 축] 초기 상태(dirty="0") 안내문 본문 run 의 파일 수준 보존
+//
+// 한컴 정준형(form-01.hwpx 실물)은 미기입 누름틀의 안내문을 **본문 run 으로 파일에
+// 유지**하고 렌더/인쇄에서만 구분 취급한다. rhwp 는 적재 정규화가 이 텍스트를 IR 에서
+// 지우므로, 저장기가 잔재를 복원 방출하지 않으면 저장할 때마다 파일에서 영구 소실된다
+// (XSD 는 통과하는 조용한 내용 소실 — 재적재 시 다시 지워져 값 API 표면에는 안 보인다).
+// =====================================================================
+
+/// form-01.hwpx 원본의 안내문 본문 run (charPrIDRef="6" 전용 run 내부).
+const BODY_GUIDE_RUN: &str = "<hp:t>여기에 입력</hp:t>";
+
+/// 저장 축: 초기 상태 누름틀의 안내문 본문 run 이 저장본에 1회 보존되어야 한다.
+#[test]
+fn initial_guide_body_run_survives_hwpx_save() {
+    let doc = load(&sample_bytes());
+    let xml = section_xml(&doc.export_hwpx().expect("export_hwpx"));
+    assert_eq!(
+        xml.matches(BODY_GUIDE_RUN).count(),
+        1,
+        "초기 상태 누름틀의 안내문 본문 run 이 저장에서 소실/중복됐다"
+    );
+    // 원본 형상 그대로 — 잔재를 담던 run 의 charPrIDRef 까지 복원되어야 서식이 산다.
+    assert!(
+        xml.contains(r#"<hp:run charPrIDRef="6"><hp:t>여기에 입력</hp:t></hp:run>"#),
+        "복원된 안내문 run 의 char shape 가 원본(charPrIDRef=\"6\")과 다르다"
+    );
+    assert!(
+        xml.contains(FIELD_ANCHOR),
+        "잔재 복원은 초기 상태(dirty=\"0\") 표식을 바꾸면 안 된다"
+    );
+}
+
+/// 고정점: 저장→재적재→재저장에서도 본문 run 이 1회 유지되고, 값 API 는 빈 값을 유지한다.
+#[test]
+fn initial_guide_body_run_save_reload_save_fixed_point() {
+    let doc = load(&sample_bytes());
+    let saved1 = doc.export_hwpx().expect("export 1");
+    let reloaded = load(&saved1);
+    assert_eq!(
+        field_value(&reloaded, FIELD),
+        "",
+        "재적재 후에도 필드 값 API 는 빈 값이어야 한다 (정규화 계약 유지)"
+    );
+    let xml2 = section_xml(&reloaded.export_hwpx().expect("export 2"));
+    assert_eq!(
+        xml2.matches(BODY_GUIDE_RUN).count(),
+        1,
+        "저장→재적재→재저장 고정점에서 안내문 본문 run 이 소실/중복됐다"
+    );
+}
+
+/// 무회귀 가드: 채운 필드(dirty="1")는 실값 run 만 방출한다 — 잔재 복원이 중복 주입되면 안 된다.
+#[test]
+fn filled_field_body_run_not_duplicated() {
+    let mut doc = load(&sample_bytes());
+    doc.set_field_value_by_name_api(FIELD, GUIDE)
+        .expect("set_field_value_by_name");
+    let xml = section_xml(&doc.export_hwpx().expect("export_hwpx"));
+    assert_eq!(
+        xml.matches(BODY_GUIDE_RUN).count(),
+        1,
+        "채운 필드의 값 run 은 정확히 1회여야 한다 (잔재 복원 중복 주입 금지)"
+    );
+    assert!(
+        xml.contains(r#"name="myMsg01" editable="1" dirty="1""#),
+        "채운 필드는 dirty=\"1\" 이어야 한다"
+    );
+}
+
+/// 실물 행정 서식 코퍼스 대표본(issue1893 fixture): 안내문 run 보존 + 원본부터 빈 스팬은
+/// 잔재가 없으므로 텍스트를 주입하면 안 된다.
+#[test]
+fn gov_form_guide_runs_preserved_and_empty_spans_untouched() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("samples/issue1893_clickhere_field_roundtrip.hwpx");
+    let bytes = std::fs::read(&path).expect("read issue1893 fixture");
+    let doc = load(&bytes);
+    let xml = section_xml(&doc.export_hwpx().expect("export_hwpx"));
+
+    // 소속관서 필드(id=1549188898): 원본은 begin~end 사이에 <hp:t>소속관서</hp:t> 보유.
+    let span = field_span(&xml, "1549188898");
+    assert!(
+        span.contains(r#"<hp:run charPrIDRef="20"><hp:t>소속관서</hp:t></hp:run>"#),
+        "초기 상태 누름틀(소속관서)의 안내문 본문 run 이 원본 형상으로 복원되지 않았다: {span}"
+    );
+
+    // id=1549188905: 원본부터 빈 스팬(begin 직후 end, 텍스트 run 없음) — 주입 금지.
+    let empty_span = field_span(&xml, "1549188905");
+    assert!(
+        !contains_nonempty_hp_t(empty_span),
+        "원본부터 빈 누름틀 스팬에 텍스트가 주입됐다: {empty_span}"
+    );
+}
+
+/// fieldBegin(id=..)부터 대응 fieldEnd(beginIDRef=..) 직전까지의 XML 조각.
+fn field_span<'a>(xml: &'a str, id: &str) -> &'a str {
+    let begin = xml
+        .find(&format!(r#"id="{id}""#))
+        .unwrap_or_else(|| panic!("fieldBegin id={id} 없음"));
+    let end = xml
+        .find(&format!(r#"beginIDRef="{id}""#))
+        .unwrap_or_else(|| panic!("fieldEnd beginIDRef={id} 없음"));
+    assert!(begin < end, "fieldBegin 이 fieldEnd 앞이어야 함 (id={id})");
+    &xml[begin..end]
+}
+
+/// 조각 안에 내용이 있는 `<hp:t>` 가 존재하는지 (빈 `<hp:t></hp:t>`/`<hp:t/>` 는 무시).
+fn contains_nonempty_hp_t(fragment: &str) -> bool {
+    let mut rest = fragment;
+    while let Some(i) = rest.find("<hp:t>") {
+        rest = &rest[i + "<hp:t>".len()..];
+        if !rest.starts_with("</hp:t>") {
+            return true;
+        }
+    }
+    false
+}


### PR DESCRIPTION
## 무엇을 고치나

Issue #3545 의 **잔여 축**입니다. 선행 PR #3659(merge `952c831a`)가 HWPX
`fieldBegin@dirty` ↔ `properties` 비트 15 왕복을 해소해 **채운 값**은 보존되지만,
초기 상태(`dirty="0"`) 누름틀의 **안내문 본문 run 을 적재 때 물리 삭제**하는 축은
그대로 남아 있었습니다. 그 결과 HWPX 를 **열고 저장하기만 해도** 해당 텍스트가
파일에서 영구 소실됩니다.

한컴은 미기입 누름틀의 안내문을 파일에는 본문 run 으로 유지하고 렌더·인쇄에서만
구분 취급합니다 — 동봉 샘플 `samples/hwpx/form-01.hwpx` 실물이 그 정준형입니다.
XSD·구조 검증은 통과하고, 재적재하면 같은 정규화가 다시 지워 값 API 표면에도 안
나타나며, 빈 필드 안내문 합성 렌더 덕분에 화면도 멀쩡해 보입니다. **저장 전후 파일
대조로만 드러나는 조용한 내용 소실**입니다.

## 전 / 후 (저장본 `Contents/section0.xml`, `samples/hwpx/form-01.hwpx`)

원본 (한컴 정준형):

```xml
<hp:fieldBegin ... type="CLICK_HERE" name="myMsg01" editable="1" dirty="0" ...>
<hp:run charPrIDRef="6"><hp:t>여기에 입력</hp:t></hp:run>
<hp:run charPrIDRef="1"><hp:ctrl><hp:fieldEnd .../></hp:ctrl><hp:t/></hp:run>
```

**전** — rhwp 저장본에서 본문 텍스트가 사라짐 (run 껍데기만 남음):

```xml
<hp:run charPrIDRef="6"><hp:t></hp:t></hp:run>
```

**후** — 원본 형상 복원 (charPrIDRef 까지 동형):

```xml
<hp:run charPrIDRef="6"><hp:t>여기에 입력</hp:t></hp:run>
```

> 시각(렌더) 전/후 이미지는 첨부하지 않았습니다. 이 결함은 **렌더에 나타나지 않는**
> 부류이기 때문입니다 — rhwp 는 빈 필드에 안내문을 합성 렌더하므로 수정 전후 SVG 가
> 동일합니다. 관측 가능한 유일한 표면인 저장본 XML 대조로 대신했습니다.

## 해법 — 삭제는 유지, 잔재를 기록해 저장 시 복원

정규화 계약(편집 IR 은 빈 필드, 값 API 는 빈 값)을 **1비트도 바꾸지 않고**, 삭제
시점에 잔재를 파생 상태로 기록해 HWPX 저장에서만 원본 run 을 되살립니다.

1. `model::control::GuideResidue { text, char_shape_id }` 신설 +
   `Field.guide_residue: Option<GuideResidue>`.
2. `clear_initial_field_texts` 가 삭제할 때 제거 텍스트와 *그 텍스트를 담던 run 의
   `charPrIDRef`* 를 함께 기록합니다 (삭제 수술이 경계를 zero-width 로 접기 **전**
   좌표에서 조회해야 정확).
3. HWPX 저장기가 0-length 필드의 `fieldEnd` 방출 직전, 기록된 char shape 경계까지만
   run 을 끊고 그 안에 `<hp:t>` 를 되돌립니다. IR 위치 축은 건드리지 않으므로
   저장→재적재 고정점이 유지됩니다.

### 이슈의 방향 (i)/(ii) 에 대해

- 이슈가 지적한 **(ii) 저장 시 재구성**의 약점은 "삭제 수술로 원본 char shape 가 이미
  소실돼 서식 충실 재구성이 불가능"이었습니다. 삭제 **시점에** 텍스트와 char shape 를
  같이 기록하면 그 전제가 무너집니다 — 복원본은 원본과 문자열 동형입니다.
- **(i) 적재 보존 → 소비 계층 해석**은 IR 정규화 전제를 바꿔 값 API·렌더·텍스트
  추출·라운드트립 지표·렌더 golden 전반에 영향을 줍니다. 이 PR 은 그 결정을 선점하지
  않습니다. 정규화 계약을 그대로 두므로, (i) 로 가기로 결정되면 이 복원 경로는 그대로
  대체·제거되고 데이터 소실만 그동안 막습니다.

## 잘못 주입하지 않는 게이트

- 원본부터 잔재가 없던 필드는 표식이 없어 아무것도 주입되지 않습니다
  (`samples/issue1893_clickhere_field_roundtrip.hwpx` 의 `id=1549188905` — `Direction`
  파라미터조차 없는 빈 스팬). 계약 테스트로 고정했습니다.
- 값이 채워진 필드(`start != end`)와 수정됨 표식(bit 15)이 선 필드는 건너뜁니다 —
  중복 주입과 사용자가 비운 값의 부활을 막습니다.

## 검증 (red → green 실행 확인)

| 게이트 | 결과 |
| --- | --- |
| red (수정 전) `--test issue_3545_clickhere_dirty_roundtrip` | 3 failed / 5 passed — 저장본 안내문 run **0회** |
| green (수정 후) 같은 타깃 | **8 passed** |
| `cargo test --profile release-test --lib` (변경 소스 소속 타깃) | **3016 passed / 0 failed** |
| 필드·HWPX 왕복 focused 타깃 16종 | **84 passed / 0 failed** |
| `rustfmt --check` (변경 파일) | 통과 |
| `cargo clippy --profile release-test --bin rhwp -- -D warnings` | 통과 |

focused 16종: `edit_field_occurrence_contract`, `edit_fill_fields_contract`,
`fields_json_contract`, `hwpx_form_roundtrip`, `hwpx_roundtrip_baseline`,
`hwpx_roundtrip_integration`, `ir_field_sweep_baseline`, `issue_1391_memo_field_roundtrip`,
`issue_1434_clickhere_guide_hancom_command`, `issue_1893`, `issue_258_clickhere_form_mode`,
`issue_3375_field_guide_print_profile`, `issue_3380_field_value_equals_guide`,
`issue_3545_clickhere_dirty_roundtrip`, `issue_493_hwpx_cell_field_name`,
`issue_838_field_set_value`. `--tests` 전체 스위트는 로컬 제약으로 실행하지 않고 CI 에
위임했습니다.

추가한 계약 테스트 5건: 저장 보존(charPrIDRef 동형까지), 저장→재적재→재저장 고정점
(값 API 는 빈 값 유지), 채운 필드 중복 방지, 실물 행정 서식의 잔재 보존 + 원본 빈 스팬
무주입.

## 남긴 것

- **HWP5 저장 축**: 같은 적재 정규화가 HWP5 원본에도 걸리므로 `export_hwp` 경로에는
  소실이 남습니다. 이 이슈가 HWPX 축으로 좁혀 제기됐고 HWP5 직렬화는 별도 golden
  면적을 건드리므로 후속 건으로 분리했습니다. 표식은 포맷 무관하게 기록되므로 HWP5
  저장기 배선만 추가하면 됩니다.
- 슬롯 위치 추정 실패(mismatch) 퇴화 경로는 복원 대상에서 제외했습니다 — 그 경로는
  run·위치 정합이 이미 무너져 있어 주입이 개선이라 단정할 수 없습니다.

처리결과 문서: `mydocs/report/task_m100_3545_report.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
