### PR TITLE
fix(hwpx): hp:offset 음수 방출을 u32 wraparound 부호화로 바로잡는다 (#3544)

### DIFF
--- a/mydocs/report/pr-hwpx-unsigned-offset-body.md
+++ b/mydocs/report/pr-hwpx-unsigned-offset-body.md
@@ -1,0 +1,95 @@
+## 요약
+
+`#3544` — HWPX 재저장 시 OWPML 스키마상 unsigned 인 `<hp:offset>` 의 `x`/`y` 에
+음수가 기록되던 문제를 고칩니다. 저장기의 `write_offset` 한 곳을 고쳐
+`samples/hwpx` 81종 재저장 기준 위반 **64건 → 0건**이 됩니다.
+
+Fixes #3544
+
+## 근인 — 클램프 문제가 아니라 인코딩 비대칭
+
+이슈에서 미확인으로 남겨 두신 "음수가 생성되는 지점"을 특정했습니다. 음수는
+레이아웃이 잘못 계산한 값이 아니라, **한컴이 의도적으로 쓴 값을 rhwp 가 잘못된
+표기로 되돌려 쓴 것**이었습니다.
+
+한컴은 음수 오프셋을 u32 wraparound 십진수로 기록합니다(예: `-2429` →
+`"4294964867"`). rhwp 파서도 같은 관례로 복호합니다.
+
+```rust
+// src/parser/hwpx/section.rs
+b"x" => { let v = parse_u32(&attr); shape_attr.offset_x = v as i32; ... }
+```
+
+즉 **복호(파서)는 있는데 대응하는 부호화(저장기)가 없었습니다.** `write_offset` 이
+IR 의 signed 값을 그대로 `to_string()` 한 탓에, 파서가 `4294964867` → `-2429` 로
+읽어들인 값이 저장 때 `-2429` 문자열로 나가 XSD 를 위반했습니다.
+
+그래서 0 클램프가 아니라 **부호화 복원**으로 고쳤습니다. 클램프였다면 한컴이 기록한
+음수 오프셋 정보가 소실되어 그룹 내부 좌표가 틀어집니다. IR 이 `i32` 인 것은 레이아웃
+계산상 정당하므로 IR 은 그대로 두고, XML 경계에서만 파서 복호의 역함수를 적용합니다.
+
+## 변경
+
+`src/serializer/hwpx/shape.rs` 의 `write_offset`:
+
+```rust
+let x = (sa.offset_x as u32).to_string();
+let y = (sa.offset_y as u32).to_string();
+```
+
+같은 `hp:offset` 을 쓰는 `src/serializer/hwpx/picture.rs` 는 IR 필드가
+`HwpUnit = u32` 라 음수를 방출할 수 없음을 확인했습니다 — 수정 지점은 이 한 곳뿐입니다.
+
+## 검증
+
+### red → green
+
+수정 블록을 되돌린 상태에서 신규 테스트가 실제로 실패함을 먼저 확인했습니다.
+
+| 게이트 | red (수정 전) | green (수정 후) |
+|---|---|---|
+| `tests/issue_3544_hwpx_unsigned_offset.rs` (실물 코퍼스) | FAILED — 음수 `hp:offset` 16건 방출 | ok |
+| `serializer::hwpx::shape::tests::issue3544_…` (단위) | FAILED — `x="-8974" y="-2"` | ok |
+
+### 코퍼스 실측 (samples/hwpx 81종)
+
+| 대상 | 위반 문서 | 위반 건수 |
+|---|---:|---:|
+| 원본 (한컴 산출) | 0 | **0** |
+| 재저장 — 수정 전 | 17 | **64** |
+| 재저장 — 수정 후 | 0 | **0** |
+
+수정 전 64건은 이슈에 보고된 건수(64건)와 일치합니다.
+
+### 회귀
+
+- `cargo test --profile release-test --lib` — **3016 passed, 0 failed**
+- `rhwp export-hwpx <각 샘플> --verify` — **81/81 통과** (IR 왕복 동일).
+  값이 아니라 표기만 바뀌었음을 뒷받침합니다.
+- `rustfmt --check` (변경 파일), `cargo clippy --profile release-test --bin rhwp -- -D warnings` — 통과
+
+### 시각 검증
+
+**N/A.** XML 속성의 어휘 표기만 바뀌고 디코드 결과 정수값은 동일합니다(`--verify`
+81/81 로 IR 왕복 동일 확인). 렌더 경로에 입력되는 좌표가 변하지 않아 렌더 산출물
+비교 대상이 없습니다.
+
+## 테스트 설계 노트
+
+자체 왕복 `--verify` 는 이 버그를 잡지 못합니다 — rhwp 파서가 음수 표기도 관대하게
+읽어 IR 이 왕복상 일치해 버리기 때문입니다(수정 전에도 `--verify` 는 exit 0). 그래서
+신규 테스트는 IR 이 아니라 **방출된 XML 문자열 자체를 계약으로 고정**하고, 두 가지를
+함께 단언해 향후 "0 클램프" 류 회귀도 막습니다.
+
+1. 저장본 `hp:offset` 에 음수 십진수가 0건일 것 (XSD unsigned)
+2. 원본의 wraparound 값이 저장본에도 남아 있을 것 (클램프였다면 전멸)
+
+## 남은 범위
+
+이번 수정은 이슈가 제시한 `hp:offset` 계열을 닫습니다. 다른 unsigned 좌표 속성에
+같은 인코딩 비대칭이 있는지는 위 코퍼스 검증 범위 밖이며, 발견되면 별도 이슈로
+다루는 편이 변경 범위를 좁게 유지한다고 판단했습니다.
+
+처리결과 문서: `mydocs/report/pr-hwpx-unsigned-offset.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/mydocs/report/pr-hwpx-unsigned-offset.md
+++ b/mydocs/report/pr-hwpx-unsigned-offset.md
@@ -1,0 +1,109 @@
+# hp:offset 저장 시 XSD unsigned 속성에 음수가 기록되는 문제 수정
+
+- **Issue**: #3544
+- **Branch**: `task/3544-hwpx-unsigned-coords`
+- **Type**: fix
+- **Component**: serializer/hwpx
+
+## 배경
+
+OWPML 스키마에서 `<hp:offset>` 의 `x`/`y` 는 unsigned 좌표 속성이다. 그런데 rhwp 로
+HWPX 를 재저장하면 `<hp:offset x="0" y="-2"/>`, `x="-8974"` 처럼 음수가 기록되어
+스키마를 위반했다. 원본(한컴 산출) 파일은 같은 검증에서 위반 0건이므로, 음수는
+로드~저장 사이에서 생기는 값이다.
+
+## 근인 — 클램프 문제가 아니라 인코딩 비대칭
+
+이슈에서 미확인으로 남긴 "음수가 생성되는 지점"을 특정했다. 음수는 **레이아웃이
+잘못 계산한 값이 아니라, 한컴이 의도적으로 쓴 값을 rhwp 가 잘못된 표기로 되돌려
+쓴 것**이다.
+
+한컴은 음수 오프셋을 **u32 wraparound 십진수**로 기록한다(예: `-2429` →
+`"4294964867"`). rhwp 파서도 같은 관례로 복호한다:
+
+```rust
+// src/parser/hwpx/section.rs
+b"x" => { let v = parse_u32(&attr); shape_attr.offset_x = v as i32; ... }
+```
+
+즉 **복호(파서)는 있는데 대응하는 부호화(저장기)가 없었다.** `write_offset` 이
+IR 의 signed 값을 그대로 `to_string()` 했기 때문에, 파서가 `4294964867` → `-2429`
+로 읽어들인 값이 저장 때 `-2429` 라는 문자열로 나가 XSD 를 위반했다.
+
+따라서 올바른 수정은 **0 클램프가 아니라 부호화 복원**이다. 클램프였다면 한컴이
+기록한 음수 오프셋 정보가 소실되어 그룹 내부 좌표가 틀어진다. IR 이 `i32` 인 것은
+레이아웃 계산상 정당하므로 IR 은 그대로 두고, XML 경계에서만 파서 복호의 역함수를
+적용한다.
+
+## 수정 내용
+
+`src/serializer/hwpx/shape.rs` 의 `write_offset` 한 곳:
+
+```rust
+let x = (sa.offset_x as u32).to_string();
+let y = (sa.offset_y as u32).to_string();
+```
+
+같은 `hp:offset` 을 쓰는 `src/serializer/hwpx/picture.rs` 는 IR 필드가
+`HwpUnit = u32` 라 음수를 방출할 수 없음을 확인했다 — 수정 대상은 이 한 곳뿐이다.
+
+## 검증
+
+### red → green
+
+수정 블록을 되돌린 상태에서 신규 테스트가 실제로 실패함을 먼저 확인했다.
+
+| 게이트 | red (수정 전) | green (수정 후) |
+|---|---|---|
+| `tests/issue_3544_hwpx_unsigned_offset.rs` (실물 코퍼스) | FAILED — 음수 `hp:offset` 16건 방출 | ok |
+| `serializer::hwpx::shape::tests::issue3544_…` (단위) | FAILED — `x="-8974" y="-2"` | ok |
+
+red 로그 발췌 (실물 샘플 재저장 산출물):
+
+```
+hp:offset x/y 는 XSD unsigned — 음수 방출은 스키마 위반: 
+["<hp:offset x=\"-81046\" y=\"-36735\"/>", "<hp:offset x=\"-1303\" y=\"1477\"/>",
+ "<hp:offset x=\"-87\" y=\"-2429\"/>", "<hp:offset x=\"-27876\" y=\"-33148\"/>", …]
+```
+
+### 코퍼스 실측 (samples/hwpx 81종)
+
+| 대상 | 위반 문서 | 위반 건수 |
+|---|---:|---:|
+| 원본 (한컴 산출) | 0 | **0** |
+| 재저장 — 수정 전 | 17 | **64** |
+| 재저장 — 수정 후 | 0 | **0** |
+
+수정 전 64건은 이슈가 보고한 건수(64건)와 일치한다.
+
+### 회귀
+
+- `cargo test --profile release-test --lib` — **3016 passed, 0 failed**
+- `cargo test --profile release-test --test issue_3544_hwpx_unsigned_offset` — 1 passed
+- `rhwp export-hwpx <각 샘플> --verify` — **81/81 통과** (IR 왕복 동일).
+  값이 아니라 표기만 바뀌었음을 뒷받침한다.
+- `rustfmt --edition 2021 --check` (변경 파일) — 통과
+- `cargo clippy --profile release-test --bin rhwp -- -D warnings` — 통과
+
+### 시각 검증
+
+**N/A.** XML 속성의 어휘 표기만 바뀌고 디코드 결과 정수값은 동일하다(위 `--verify`
+81/81 로 IR 왕복 동일 확인). 렌더 경로에 입력되는 좌표가 변하지 않으므로 렌더
+산출물 비교 대상이 없다.
+
+## 테스트 설계 노트
+
+자체 왕복 `--verify` 는 이 버그를 잡지 못한다 — rhwp 파서가 음수 표기도 관대하게
+읽어 IR 이 왕복상 일치해 버리기 때문이다(실제로 수정 전에도 `--verify` 는 exit 0).
+그래서 신규 테스트는 IR 이 아니라 **방출된 XML 문자열 자체를 계약으로 고정**한다.
+
+두 가지를 함께 단언해 향후 "0 클램프" 류 회귀도 막는다.
+
+1. 저장본 `hp:offset` 에 음수 십진수가 0건일 것 (XSD unsigned)
+2. 원본의 wraparound 값이 저장본에도 남아 있을 것 (클램프였다면 전멸)
+
+## 남은 범위
+
+이번 수정은 이슈가 제시한 `hp:offset` 계열을 닫는다. 다른 unsigned 좌표 속성에
+같은 인코딩 비대칭이 있는지는 위 코퍼스 검증 범위 밖이며, 발견되면 별도 이슈로
+다루는 편이 변경 범위를 좁게 유지한다.

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -526,8 +526,13 @@ fn write_offset<W: Write>(
     w: &mut Writer<W>,
     sa: &ShapeComponentAttr,
 ) -> Result<(), SerializeError> {
-    let x = sa.offset_x.to_string();
-    let y = sa.offset_y.to_string();
+    // [#3544] hp:offset x/y 는 OWPML XSD 상 unsigned. 한컴 산출물은 음수 오프셋을
+    // u32 wraparound 십진수로 기록하고(예: -2429 → "4294964867"), 파서도
+    // `parse_u32 as i32` 로 같은 관례를 복호한다. IR 은 레이아웃 계산을 위해
+    // signed 가 정당하므로 값은 두고, XML 경계에서만 부호화를 복원한다 —
+    // signed 그대로 문자열화하면 `y="-2"` 류 스키마 위반이 된다.
+    let x = (sa.offset_x as u32).to_string();
+    let y = (sa.offset_y as u32).to_string();
     empty_tag(w, "hp:offset", &[("x", &x), ("y", &y)])
 }
 
@@ -1535,6 +1540,21 @@ mod tests {
             xml.contains(r#"textDirection="VERTICAL""#) && !xml.contains("VERTICALALL"),
             "VERTICAL (ALL 아님) 보존: {}",
             xml
+        );
+    }
+
+    /// [Issue #3544] hp:offset x/y 는 OWPML XSD 상 unsigned — 음수 IR 오프셋은
+    /// 한컴 관례대로 u32 wraparound 십진수로 방출해야 한다 (파서 `parse_u32 as
+    /// i32` 복호의 역함수). signed 그대로 문자열화하면 `y="-2"` 류 스키마 위반.
+    #[test]
+    fn issue3544_negative_offset_emitted_as_u32_wraparound() {
+        let mut rect = RectangleShape::default();
+        rect.drawing.shape_attr.offset_x = -8974;
+        rect.drawing.shape_attr.offset_y = -2;
+        let xml = serialize_rect(&rect);
+        assert!(
+            xml.contains(r#"<hp:offset x="4294958322" y="4294967294"/>"#),
+            "음수 오프셋은 u32 wraparound 십진수로 방출되어야 한다: {xml}"
         );
     }
 

--- a/tests/issue_3544_hwpx_unsigned_offset.rs
+++ b/tests/issue_3544_hwpx_unsigned_offset.rs
@@ -1,0 +1,103 @@
+//! [Issue #3544] OWPML XSD 상 `hp:offset` 의 x/y 는 unsigned 좌표 속성이다.
+//! 한컴 산출 원본은 음수 오프셋을 u32 wraparound 십진 문자열로 기록하고
+//! (예: `x="4294886250"` = -81046), 파서도 `parse_u32 as i32` 로 그 관례를
+//! 복호한다. 종전 저장기는 IR 의 signed 값을 그대로 문자열화해 `x="-8974"`,
+//! `y="-2"` 같은 XSD 위반을 만들었다 — 복호(파서)만 있고 부호화(저장기)가
+//! 없는 인코딩 비대칭이 근인이다. 자체 왕복 --verify 는 파서가 음수도 관대하게
+//! 읽어 잡지 못하므로, 방출 문자열 자체를 계약으로 고정한다.
+
+use std::io::Read;
+
+use rhwp::document_core::DocumentCore;
+
+/// 원본에 wraparound `hp:offset` 이 28건 실존하는 실물 코퍼스 샘플 (#3542 와 동일).
+const SAMPLE: &str = "samples/hwpx/opengov/36392900_결재문서본문_일일굴착복구공사현황보고.hwpx";
+
+fn sample_path() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+/// ZIP 바이트에서 Contents/section*.xml 을 이어붙여 돌려준다.
+fn section_xml_of(bytes: &[u8]) -> String {
+    let mut zip = zip::ZipArchive::new(std::io::Cursor::new(bytes)).expect("ZIP 열기 실패");
+    let names: Vec<String> = zip.file_names().map(str::to_string).collect();
+    let mut xml = String::new();
+    for name in names {
+        if name.starts_with("Contents/section") && name.ends_with(".xml") {
+            zip.by_name(&name)
+                .expect("section 엔트리")
+                .read_to_string(&mut xml)
+                .expect("section XML 은 UTF-8 이어야 한다");
+        }
+    }
+    xml
+}
+
+/// XML 문자열 안의 모든 `<hp:offset .../>` 태그 원문을 수집한다.
+fn offset_tags(xml: &str) -> Vec<&str> {
+    let mut tags = Vec::new();
+    let mut rest = xml;
+    while let Some(pos) = rest.find("<hp:offset ") {
+        let tail = &rest[pos..];
+        let end = tail.find('>').expect("hp:offset 태그는 닫혀야 한다");
+        tags.push(&tail[..=end]);
+        rest = &tail[end..];
+    }
+    tags
+}
+
+/// 태그 원문에 u32 상위 절반(>= 2^31) 십진 속성값이 있으면 true — wraparound 부호화 여부.
+fn has_wraparound_value(tag: &str) -> bool {
+    tag.split('"')
+        .filter_map(|tok| tok.parse::<u64>().ok())
+        .any(|v| v >= 1 << 31 && v < 1 << 32)
+}
+
+#[test]
+fn issue_3544_offset_never_negative_and_keeps_wraparound_encoding() {
+    let bytes = std::fs::read(sample_path()).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"));
+
+    // 전제: 원본 자체가 wraparound 부호화된 음수 오프셋을 실제로 담고 있어야
+    // 이 샘플이 #3544 재현 코퍼스로 유효하다.
+    let original = section_xml_of(&bytes);
+    let original_wrapped = offset_tags(&original)
+        .iter()
+        .filter(|t| has_wraparound_value(t))
+        .count();
+    assert!(
+        original_wrapped > 0,
+        "샘플 전제 위반: 원본에 wraparound hp:offset 이 없다"
+    );
+    assert!(
+        offset_tags(&original).iter().all(|t| !t.contains("\"-")),
+        "샘플 전제 위반: 한컴 원본 hp:offset 에 음수가 있을 수 없다"
+    );
+
+    let doc = DocumentCore::from_bytes(&bytes).unwrap_or_else(|e| panic!("parse {SAMPLE}: {e:?}"));
+    let exported = doc
+        .export_hwpx_native()
+        .unwrap_or_else(|e| panic!("export {SAMPLE}: {e:?}"));
+    let saved = section_xml_of(&exported);
+    let saved_tags = offset_tags(&saved);
+    assert!(!saved_tags.is_empty(), "저장본에 hp:offset 이 있어야 한다");
+
+    // 계약 1: XSD unsigned — 저장본 hp:offset 에 음수 십진수가 한 건도 없어야 한다.
+    let negatives: Vec<&&str> = saved_tags.iter().filter(|t| t.contains("\"-")).collect();
+    assert!(
+        negatives.is_empty(),
+        "hp:offset x/y 는 XSD unsigned — 음수 방출은 스키마 위반 (한컴 관례는 u32 \
+         wraparound): {negatives:?}"
+    );
+
+    // 계약 2: 클램프가 아니라 부호화 — 원본의 음수 오프셋 정보가 wraparound 형태로
+    // 살아 있어야 한다 (0 클램프였다면 wraparound 값이 전멸한다).
+    let saved_wrapped = saved_tags
+        .iter()
+        .filter(|t| has_wraparound_value(t))
+        .count();
+    assert!(
+        saved_wrapped > 0,
+        "원본 wraparound {original_wrapped}건이 저장본에서 전부 사라졌다 — 값 소실(클램프) \
+         의심: {saved_tags:?}"
+    );
+}


### PR DESCRIPTION
## 요약

`#3544` — HWPX 재저장 시 OWPML 스키마상 unsigned 인 `<hp:offset>` 의 `x`/`y` 에
음수가 기록되던 문제를 고칩니다. 저장기의 `write_offset` 한 곳을 고쳐
`samples/hwpx` 81종 재저장 기준 위반 **64건 → 0건**이 됩니다.

Fixes #3544

## 근인 — 클램프 문제가 아니라 인코딩 비대칭

이슈에서 미확인으로 남겨 두신 "음수가 생성되는 지점"을 특정했습니다. 음수는
레이아웃이 잘못 계산한 값이 아니라, **한컴이 의도적으로 쓴 값을 rhwp 가 잘못된
표기로 되돌려 쓴 것**이었습니다.

한컴은 음수 오프셋을 u32 wraparound 십진수로 기록합니다(예: `-2429` →
`"4294964867"`). rhwp 파서도 같은 관례로 복호합니다.

```rust
// src/parser/hwpx/section.rs
b"x" => { let v = parse_u32(&attr); shape_attr.offset_x = v as i32; ... }
```

즉 **복호(파서)는 있는데 대응하는 부호화(저장기)가 없었습니다.** `write_offset` 이
IR 의 signed 값을 그대로 `to_string()` 한 탓에, 파서가 `4294964867` → `-2429` 로
읽어들인 값이 저장 때 `-2429` 문자열로 나가 XSD 를 위반했습니다.

그래서 0 클램프가 아니라 **부호화 복원**으로 고쳤습니다. 클램프였다면 한컴이 기록한
음수 오프셋 정보가 소실되어 그룹 내부 좌표가 틀어집니다. IR 이 `i32` 인 것은 레이아웃
계산상 정당하므로 IR 은 그대로 두고, XML 경계에서만 파서 복호의 역함수를 적용합니다.

## 변경

`src/serializer/hwpx/shape.rs` 의 `write_offset`:

```rust
let x = (sa.offset_x as u32).to_string();
let y = (sa.offset_y as u32).to_string();
```

같은 `hp:offset` 을 쓰는 `src/serializer/hwpx/picture.rs` 는 IR 필드가
`HwpUnit = u32` 라 음수를 방출할 수 없음을 확인했습니다 — 수정 지점은 이 한 곳뿐입니다.

## 검증

### red → green

수정 블록을 되돌린 상태에서 신규 테스트가 실제로 실패함을 먼저 확인했습니다.

| 게이트 | red (수정 전) | green (수정 후) |
|---|---|---|
| `tests/issue_3544_hwpx_unsigned_offset.rs` (실물 코퍼스) | FAILED — 음수 `hp:offset` 16건 방출 | ok |
| `serializer::hwpx::shape::tests::issue3544_…` (단위) | FAILED — `x="-8974" y="-2"` | ok |

### 코퍼스 실측 (samples/hwpx 81종)

| 대상 | 위반 문서 | 위반 건수 |
|---|---:|---:|
| 원본 (한컴 산출) | 0 | **0** |
| 재저장 — 수정 전 | 17 | **64** |
| 재저장 — 수정 후 | 0 | **0** |

수정 전 64건은 이슈에 보고된 건수(64건)와 일치합니다.

### 회귀

- `cargo test --profile release-test --lib` — **3016 passed, 0 failed**
- `rhwp export-hwpx <각 샘플> --verify` — **81/81 통과** (IR 왕복 동일).
  값이 아니라 표기만 바뀌었음을 뒷받침합니다.
- `rustfmt --check` (변경 파일), `cargo clippy --profile release-test --bin rhwp -- -D warnings` — 통과

### 시각 검증

**N/A.** XML 속성의 어휘 표기만 바뀌고 디코드 결과 정수값은 동일합니다(`--verify`
81/81 로 IR 왕복 동일 확인). 렌더 경로에 입력되는 좌표가 변하지 않아 렌더 산출물
비교 대상이 없습니다.

## 테스트 설계 노트

자체 왕복 `--verify` 는 이 버그를 잡지 못합니다 — rhwp 파서가 음수 표기도 관대하게
읽어 IR 이 왕복상 일치해 버리기 때문입니다(수정 전에도 `--verify` 는 exit 0). 그래서
신규 테스트는 IR 이 아니라 **방출된 XML 문자열 자체를 계약으로 고정**하고, 두 가지를
함께 단언해 향후 "0 클램프" 류 회귀도 막습니다.

1. 저장본 `hp:offset` 에 음수 십진수가 0건일 것 (XSD unsigned)
2. 원본의 wraparound 값이 저장본에도 남아 있을 것 (클램프였다면 전멸)

## 남은 범위

이번 수정은 이슈가 제시한 `hp:offset` 계열을 닫습니다. 다른 unsigned 좌표 속성에
같은 인코딩 비대칭이 있는지는 위 코퍼스 검증 범위 밖이며, 발견되면 별도 이슈로
다루는 편이 변경 범위를 좁게 유지한다고 판단했습니다.

처리결과 문서: `mydocs/report/pr-hwpx-unsigned-offset.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
