### PR TITLE
fix(mcp): 조회 전용 프로필로 원본 문서를 덮어쓸 수 있다 — 세션 축 권한 경계 이탈 (#3629 후속)

### DIFF
--- a/src/agent_profiles.rs
+++ b/src/agent_profiles.rs
@@ -6,14 +6,57 @@
 //! `mcp-serve --profile` 양쪽을 구동한다 — 목록을 다른 곳에 복제하지 않는다
 //! (플레이북 규칙 1).
 
-/// 역할 프로필 하나. `tools` 는 무상태 MCP 도구 이름, `session` 은 세션 도구 포함 여부.
+/// 세션 도구 전체 — `mcp_serve::served_tools` 가 내보내는 목록과 같은 순서.
+///
+/// 자기서술(`capabilities --mcp --profile`)이 "필터 없음"을 이름으로 펼쳐 보일 때 쓴다.
+/// 선언과 서버가 어긋나지 않도록 목록은 여기 하나뿐이다.
+pub const ALL_SESSION_TOOLS: &[&str] = &[
+    "hwp_open",
+    "hwp_doc_text",
+    "hwp_doc_info",
+    "hwp_doc_fields",
+    "hwp_doc_tables",
+    "hwp_doc_render_page",
+    "hwp_doc_search",
+    "hwp_doc_replace_text",
+    "hwp_doc_set_cell",
+    "hwp_doc_fill_fields",
+    "hwp_doc_save",
+    "hwp_close",
+];
+
+/// 세션 도구 중 **문서를 바꾸지 않는** 것들 — 조회 전용 직무가 여는 집합.
+///
+/// 나머지 4종(`hwp_doc_replace_text`/`hwp_doc_set_cell`/`hwp_doc_fill_fields`/
+/// `hwp_doc_save`)은 IR 을 고치거나 디스크에 쓴다. `hwp_doc_render_page` 는 SVG 파일을
+/// 쓰지만 대상이 호출자가 지정한 새 산출물이지 원본 문서가 아니므로 조회 축에 남긴다.
+pub const SESSION_READ_TOOLS: &[&str] = &[
+    "hwp_open",
+    "hwp_doc_text",
+    "hwp_doc_info",
+    "hwp_doc_fields",
+    "hwp_doc_tables",
+    "hwp_doc_search",
+    "hwp_doc_render_page",
+    "hwp_close",
+];
+
+/// 역할 프로필 하나. `tools` 는 무상태 MCP 도구 이름, `session_tools` 는 세션 도구 이름.
 pub struct AgentProfile {
     pub name: &'static str,
     pub summary: &'static str,
     /// 이 직무가 쓰는 무상태 도구 이름들 (mcp_tool_definitions 의 name).
     pub tools: &'static [&'static str],
-    /// 세션 도구(hwp_open/hwp_doc_*/hwp_close) 노출 여부 — 반복 조회·편집 직무만 true.
-    pub session: bool,
+    /// 이 직무가 쓰는 **세션 도구** 이름들.
+    ///
+    /// `None` 이면 세션 표면 자체를 열지 않는다. `Some(&[])` 은 `tools` 와 같은 규약으로
+    /// "필터 없음"(전 세션 도구)을 뜻하고, `Some(목록)` 은 그 목록만 연다.
+    ///
+    /// 종전에는 `bool` 하나였다 — 그래서 조회 전용 직무가 세션을 쓰려면 편집·저장까지
+    /// 통째로 열 수밖에 없었고, 읽기 전용을 표방한 프로필이 `hwp_doc_save` 로 원본을
+    /// 덮어쓸 수 있었다. 프로필은 추천 목록이 아니라 **서버가 실제로 제공하는 도구
+    /// 집합의 경계**이므로(mcp_serve.rs 의 우회 차단 주석), 세션 축도 이름 단위로 건다.
+    pub session_tools: Option<&'static [&'static str]>,
     /// 권장 호출 순서 레시피 — 경량 에이전트가 순서 실수를 하지 않도록 계약으로 제공.
     pub recipe: &'static [&'static str],
 }
@@ -30,7 +73,7 @@ pub const PROFILES: &[AgentProfile] = &[
             "hwp_thumbnail",
             "hwp_export_pdf",
         ],
-        session: false,
+        session_tools: None,
         recipe: &[
             "hwp_info 로 규모·형식 파악",
             "hwp_export_structure 로 목차 확보 후 필요한 절만 hwp_export_text",
@@ -51,7 +94,7 @@ pub const PROFILES: &[AgentProfile] = &[
             "hwp_export_svg",
             "hwp_ir_diff",
         ],
-        session: true,
+        session_tools: Some(&[]),
         recipe: &[
             "hwp_fields 로 무엇을 요구하는 서식인지 조사 (반복 이름은 '이름[N]')",
             "hwp_fill_fields → notFound/ambiguous 가 비어야 완료",
@@ -70,7 +113,7 @@ pub const PROFILES: &[AgentProfile] = &[
             "hwp_batch",
             "hwp_batch_search",
         ],
-        session: false,
+        session_tools: None,
         recipe: &[
             "단건은 hwp_export_tables (병합은 rowSpan/colSpan 보존)",
             "대량은 paths 배열로 hwp_batch subcommand=export-tables",
@@ -88,7 +131,7 @@ pub const PROFILES: &[AgentProfile] = &[
             "hwp_thumbnail",
             "hwp_convert_hwpx",
         ],
-        session: false,
+        session_tools: None,
         recipe: &[
             "hwp_build_from_ingest 로 ingest JSON → HWPX 생성",
             "hwp_export_svg 로 조판 확인 후 hwp_export_pdf 로 발행",
@@ -107,7 +150,7 @@ pub const PROFILES: &[AgentProfile] = &[
             "hwp_thumbnail",
             "hwp_split_document",
         ],
-        session: true,
+        session_tools: Some(SESSION_READ_TOOLS),
         recipe: &[
             "hwp_batch subcommand=info 로 아카이브 대장화",
             "hwp_batch_search 로 전 문서 검색 (어느 문서 몇 쪽)",
@@ -126,7 +169,7 @@ pub const PROFILES: &[AgentProfile] = &[
             "hwp_export_svg",
             "hwp_info",
         ],
-        session: false,
+        session_tools: None,
         recipe: &[
             "변환은 hwp_convert_* 의 verify 봉투로 1차 판정",
             "차이가 있으면 hwp_ir_diff 로 categories 분류",
@@ -137,7 +180,7 @@ pub const PROFILES: &[AgentProfile] = &[
         name: "개발통합",
         summary: "전체 표면 — 필터 없음 (rhwp 를 통합하는 개발 에이전트)",
         tools: &[],
-        session: true,
+        session_tools: Some(&[]),
         recipe: &[
             "capabilities 로 전 명령 계약을 파악하고 시작",
             "mydocs/manual/agent_knowledge_map.md 가 진입점",
@@ -158,4 +201,20 @@ pub fn names() -> Vec<&'static str> {
 /// 무상태 도구가 이 프로필에 포함되는가. tools 가 비어 있으면 전체 허용.
 pub fn allows_tool(profile: &AgentProfile, tool_name: &str) -> bool {
     profile.tools.is_empty() || profile.tools.contains(&tool_name)
+}
+
+/// 세션 도구가 이 프로필에 포함되는가. `tools` 와 같은 규약 — 빈 목록은 전체 허용.
+///
+/// `tools/list` 필터와 `tools/call` 게이트가 **같은 함수**를 써야 한다. 목록에서 뺀
+/// 도구를 호출로 우회할 수 있으면 프로필은 경계가 아니라 추천 목록으로 격하된다.
+pub fn allows_session_tool(profile: &AgentProfile, tool_name: &str) -> bool {
+    match profile.session_tools {
+        None => false,
+        Some(list) => list.is_empty() || list.contains(&tool_name),
+    }
+}
+
+/// 이 프로필이 세션 표면을 조금이라도 여는가 — 자기서술(`capabilities --mcp`)용.
+pub fn opens_session(profile: &AgentProfile) -> bool {
+    profile.session_tools.is_some()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,7 +333,8 @@ fn show_mcp_tools(profile: Option<&'static agent_profiles::AgentProfile>) -> i32
         "profile": profile.map(|p| serde_json::json!({
             "name": p.name,
             "summary": p.summary,
-            "session": p.session,
+            "session": crate::agent_profiles::opens_session(p),
+            "sessionTools": p.session_tools.map(|t| if t.is_empty() { crate::agent_profiles::ALL_SESSION_TOOLS.to_vec() } else { t.to_vec() }),
             "recipe": p.recipe,
         })),
         "profiles": agent_profiles::names(),

--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -93,7 +93,13 @@ pub fn run(args: &[String]) -> i32 {
                 .unwrap_or(false)
         });
     }
-    let include_session = profile.map(|p| p.session).unwrap_or(true);
+    // 세션 도구도 이름 단위로 건다 — 프로필이 없으면 전 도구, 있으면 그 프로필의
+    // session_tools 목록. 종전에는 bool 하나라 조회 전용 직무가 세션을 쓰려면
+    // 편집·저장까지 통째로 열렸다.
+    let session_allows = move |name: &str| match profile {
+        None => true,
+        Some(p) => crate::agent_profiles::allows_session_tool(p, name),
+    };
     let mut sessions = Sessions::new();
 
     for line in stdin.lock().lines() {
@@ -146,11 +152,11 @@ pub fn run(args: &[String]) -> i32 {
             "tools/list" => ok_response(
                 id,
                 serde_json::json!({
-                    "tools": served_tools(&tool_defs, include_session)
+                    "tools": served_tools(&tool_defs, &session_allows)
                 }),
             ),
             "tools/call" => {
-                match handle_tool_call(&params, &tool_defs, include_session, &mut sessions) {
+                match handle_tool_call(&params, &tool_defs, &session_allows, &mut sessions) {
                     Ok(result) => ok_response(id, result),
                     Err(e) => error_response(id, INVALID_PARAMS, &e),
                 }
@@ -185,7 +191,10 @@ fn error_response(id: serde_json::Value, code: i64, message: &str) -> serde_json
 }
 
 /// tools/list 응답: 선언 도구(MCP 필수 3종만 노출) + 세션 도구 3종.
-fn served_tools(tool_defs: &[serde_json::Value], include_session: bool) -> Vec<serde_json::Value> {
+fn served_tools(
+    tool_defs: &[serde_json::Value],
+    session_allows: &dyn Fn(&str) -> bool,
+) -> Vec<serde_json::Value> {
     let mut tools: Vec<serde_json::Value> = tool_defs
         .iter()
         .map(|t| {
@@ -196,10 +205,10 @@ fn served_tools(tool_defs: &[serde_json::Value], include_session: bool) -> Vec<s
             })
         })
         .collect();
-    if !include_session {
-        return tools;
-    }
-    tools.push(serde_json::json!({
+    // 세션 도구는 이름 단위로 걸러 내보낸다 — tools/list 와 tools/call 이 같은
+    // 판정 함수를 쓰므로 목록에서 뺀 도구를 호출로 우회할 수 없다.
+    let mut session: Vec<serde_json::Value> = Vec::new();
+    session.push(serde_json::json!({
         "name": "hwp_open",
         "description": "문서를 파싱해 세션 핸들(docId)을 연다. 대형 문서를 여러 번 조회할 때 재파싱을 피한다. 암호 문서는 선택 password를 쓴다. 조회가 끝나면 hwp_close 로 닫는다.",
         "inputSchema": {
@@ -215,7 +224,7 @@ fn served_tools(tool_defs: &[serde_json::Value], include_session: bool) -> Vec<s
             "required": ["path"]
         }
     }));
-    tools.push(serde_json::json!({
+    session.push(serde_json::json!({
         "name": "hwp_doc_text",
         "description": "hwp_open 으로 연 핸들에서 페이지 텍스트를 재파싱 없이 읽는다.",
         "inputSchema": {
@@ -227,27 +236,27 @@ fn served_tools(tool_defs: &[serde_json::Value], include_session: bool) -> Vec<s
             "required": ["docId"]
         }
     }));
-    tools.push(serde_json::json!({
+    session.push(serde_json::json!({
         "name": "hwp_doc_info",
         "description": "[#3609] 핸들의 메타(형식·페이지/문단 수·폰트)를 재파싱 없이 조회한다. 편집 후 페이지 수 변화를 추적할 때 쓴다. 봉투는 hwp_info 와 동형.",
         "inputSchema": { "type": "object", "properties": { "docId": { "type": "string" } }, "required": ["docId"] }
     }));
-    tools.push(serde_json::json!({
+    session.push(serde_json::json!({
         "name": "hwp_doc_fields",
         "description": "[#3609] 핸들의 누름틀을 재파싱 없이 조사한다. hwp_doc_fill_fields 직후 반영값 확인에 쓴다. 봉투는 hwp_fields 와 동형.",
         "inputSchema": { "type": "object", "properties": { "docId": { "type": "string" } }, "required": ["docId"] }
     }));
-    tools.push(serde_json::json!({
+    session.push(serde_json::json!({
         "name": "hwp_doc_tables",
         "description": "[#3609] 핸들의 표 격자를 재파싱 없이 추출한다. 봉투는 hwp_export_tables 와 동형.",
         "inputSchema": { "type": "object", "properties": { "docId": { "type": "string" } }, "required": ["docId"] }
     }));
-    tools.push(serde_json::json!({
+    session.push(serde_json::json!({
         "name": "hwp_doc_render_page",
         "description": "[#3609] 핸들에서 해당 쪽을 SVG 로 렌더해 저장한다 — 편집 직후 눈검증(VLM) 루프가 세션 안에서 닫힌다.",
         "inputSchema": { "type": "object", "properties": { "docId": { "type": "string" }, "page": { "type": "integer", "minimum": 0 }, "output": { "type": "string", "description": "출력 SVG 경로" } }, "required": ["docId", "page", "output"] }
     }));
-    tools.push(serde_json::json!({
+    session.push(serde_json::json!({
         "name": "hwp_doc_search",
         "description": "[#3601] hwp_open 으로 연 핸들에서 재파싱 없이 검색한다. 주소 어휘(matches[].section/paragraph/page/context)는 hwp_search 와 동형 — 대형 문서에서 '어디를 고칠까'를 반복 탐색할 때 쓴다.",
         "inputSchema": {
@@ -260,7 +269,7 @@ fn served_tools(tool_defs: &[serde_json::Value], include_session: bool) -> Vec<s
             "required": ["docId", "query"]
         }
     }));
-    tools.push(serde_json::json!({
+    session.push(serde_json::json!({
         "name": "hwp_doc_replace_text",
         "description": "[#3601] 핸들의 IR 에 문자열 일괄 치환을 누적한다(디스크 미기록 — hwp_doc_save 가 기록 지점). replacedCount 0 은 오류가 아니라 계수 보고다. hwp_doc_fill_fields 와 조합해 '채우고 다듬고 한 번에 저장'하는 흐름을 만든다.",
         "inputSchema": {
@@ -274,7 +283,7 @@ fn served_tools(tool_defs: &[serde_json::Value], include_session: bool) -> Vec<s
             "required": ["docId", "find", "replace"]
         }
     }));
-    tools.push(serde_json::json!({
+    session.push(serde_json::json!({
         "name": "hwp_doc_set_cell",
         "description": "[#3603] 핸들의 표 격자 좌표(hwp_doc_tables 와 동일)에 값을 기록한다 — 디스크 미기록, hwp_doc_save 가 기록 지점. 병합으로 덮인 칸은 앵커 좌표를 안내하며 실패하고, 칸 넘침은 overflow 로 보고한다(무상태 hwp_set_cell 과 동형).",
         "inputSchema": {
@@ -290,7 +299,7 @@ fn served_tools(tool_defs: &[serde_json::Value], include_session: bool) -> Vec<s
             "required": ["docId", "table", "row", "col", "text"]
         }
     }));
-    tools.push(serde_json::json!({
+    session.push(serde_json::json!({
         "name": "hwp_doc_fill_fields",
         "description": "[#3598] hwp_open 으로 연 핸들의 IR 에 누름틀 값을 직접 채운다(디스크 미기록 — hwp_doc_save 가 유일한 기록 지점). 여러 번 호출하면 누적된다. 판정 필드(filledCount/notFound/ambiguous)는 hwp_fill_fields 와 동형이고, 반복 필드는 '이름[N]' 으로 지목한다.",
         "inputSchema": {
@@ -302,7 +311,7 @@ fn served_tools(tool_defs: &[serde_json::Value], include_session: bool) -> Vec<s
             "required": ["docId", "data"]
         }
     }));
-    tools.push(serde_json::json!({
+    session.push(serde_json::json!({
         "name": "hwp_doc_save",
         "description": "[#3598] 핸들에 누적된 편집을 형식 보존(HWPX→HWPX, 그 외→HWP5, #3383 규약)으로 저장한다. 핸들은 저장 후에도 열려 있다 — 이어서 편집·재저장할 수 있다.",
         "inputSchema": {
@@ -314,7 +323,7 @@ fn served_tools(tool_defs: &[serde_json::Value], include_session: bool) -> Vec<s
             "required": ["docId", "output"]
         }
     }));
-    tools.push(serde_json::json!({
+    session.push(serde_json::json!({
         "name": "hwp_close",
         "description": "hwp_open 으로 연 핸들을 닫아 메모리를 해제한다.",
         "inputSchema": {
@@ -325,6 +334,11 @@ fn served_tools(tool_defs: &[serde_json::Value], include_session: bool) -> Vec<s
             "required": ["docId"]
         }
     }));
+    tools.extend(
+        session
+            .into_iter()
+            .filter(|t| session_allows(t["name"].as_str().unwrap_or_default())),
+    );
     tools
 }
 
@@ -333,7 +347,7 @@ fn served_tools(tool_defs: &[serde_json::Value], include_session: bool) -> Vec<s
 fn handle_tool_call(
     params: &serde_json::Value,
     tool_defs: &[serde_json::Value],
-    include_session: bool,
+    session_allows: &dyn Fn(&str) -> bool,
     sessions: &mut Sessions,
 ) -> Result<serde_json::Value, String> {
     let name = params
@@ -347,7 +361,8 @@ fn handle_tool_call(
 
     // tools/list에서 제거한 세션 도구는 호출로 우회할 수도 없어야 한다. 프로필은
     // 추천 목록이 아니라 서버가 실제로 제공하는 도구 집합의 경계다.
-    if !include_session && is_session_tool(name) {
+    // 목록 필터와 **같은 판정 함수**를 쓴다 — 둘이 갈라지면 경계가 뚫린다.
+    if is_session_tool(name) && !session_allows(name) {
         return Ok(tool_error(format!(
             "현재 프로필에서는 세션 도구를 제공하지 않습니다: {name}"
         )));

--- a/tests/agent_profile_router_contract.rs
+++ b/tests/agent_profile_router_contract.rs
@@ -148,3 +148,107 @@ fn serve_profile_rejects_hidden_session_tool_calls() {
     let _ = child.kill();
     let _ = child.wait();
 }
+
+/// [#3629 후속] 조회 전용 직무는 **세션 쓰기 도구를 갖지 못한다.**
+///
+/// 종전에는 프로필의 세션 축이 `bool` 하나였다. 그래서 대량 RAG·감사용
+/// `아카이브검색`(허용 도구 7종에 쓰기 도구가 하나도 없다)이 세션을 쓰려면
+/// 편집·저장 4종까지 통째로 열릴 수밖에 없었고, 읽기 전용을 표방한 프로필로
+/// `hwp_open` → `hwp_doc_save` 를 이어 **원본 문서를 덮어쓸 수 있었다**(실측).
+///
+/// 목록과 호출 두 층을 함께 본다 — 목록에서 뺐는데 호출로 들어가면 프로필은
+/// 경계가 아니라 추천 목록으로 격하된다(`mcp_serve.rs` 의 우회 차단 주석).
+#[test]
+fn readonly_profile_serves_no_session_write_tools() {
+    const WRITE_TOOLS: [&str; 4] = [
+        "hwp_doc_save",
+        "hwp_doc_fill_fields",
+        "hwp_doc_set_cell",
+        "hwp_doc_replace_text",
+    ];
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(["mcp-serve", "--profile", "아카이브검색"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("mcp-serve");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+
+    writeln!(stdin, r#"{{"jsonrpc":"2.0","id":1,"method":"tools/list"}}"#).unwrap();
+    stdin.flush().unwrap();
+    let mut line = String::new();
+    assert!(stdout.read_line(&mut line).unwrap() > 0, "조기 종료");
+    let listed: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+    let names: Vec<String> = listed["result"]["tools"]
+        .as_array()
+        .expect("tools 배열")
+        .iter()
+        .filter_map(|t| t["name"].as_str().map(String::from))
+        .collect();
+
+    // 조회 세션은 열려 있어야 한다 — 이 프로필의 레시피가 hwp_open 을 쓴다.
+    assert!(names.contains(&"hwp_open".to_string()), "{names:?}");
+    assert!(names.contains(&"hwp_doc_search".to_string()), "{names:?}");
+    for w in WRITE_TOOLS {
+        assert!(
+            !names.contains(&w.to_string()),
+            "조회 전용 프로필이 쓰기 도구 {w} 를 노출했습니다: {names:?}"
+        );
+    }
+
+    // 목록에서 뺐으면 호출로도 들어갈 수 없어야 한다.
+    for (i, w) in WRITE_TOOLS.iter().enumerate() {
+        writeln!(
+            stdin,
+            r#"{{"jsonrpc":"2.0","id":{},"method":"tools/call","params":{{"name":"{w}","arguments":{{"docId":"doc-1","output":"x.hwp"}}}}}}"#,
+            10 + i
+        )
+        .unwrap();
+        stdin.flush().unwrap();
+        let mut l = String::new();
+        assert!(stdout.read_line(&mut l).unwrap() > 0, "조기 종료 ({w})");
+        let r: serde_json::Value = serde_json::from_str(l.trim()).unwrap();
+        assert_eq!(
+            r["result"]["isError"], true,
+            "{w} 호출이 우회로 들어갔습니다: {r}"
+        );
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+/// 자기서술도 실제 제공 집합과 같아야 한다 — 선언 7종, 실제 19종이면 매니페스트로
+/// 도구 정의를 자동 생성하는 소비자가 실물과 다른 표면을 얻는다.
+#[test]
+fn capabilities_declares_the_session_tools_it_actually_serves() {
+    let out = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(["capabilities", "--mcp", "--profile", "아카이브검색"])
+        .output()
+        .expect("capabilities");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("mcp JSON");
+    let declared: Vec<String> = v["profile"]["sessionTools"]
+        .as_array()
+        .expect("profile.sessionTools 가 있어야 합니다")
+        .iter()
+        .filter_map(|t| t.as_str().map(String::from))
+        .collect();
+    assert!(declared.contains(&"hwp_open".to_string()), "{declared:?}");
+    assert!(
+        !declared.contains(&"hwp_doc_save".to_string()),
+        "조회 전용 프로필 선언에 쓰기 도구가 있습니다: {declared:?}"
+    );
+    assert_eq!(v["profile"]["session"], true, "{v}");
+
+    // 세션을 안 여는 프로필은 sessionTools 가 null 이다.
+    let out = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(["capabilities", "--mcp", "--profile", "데이터분석"])
+        .output()
+        .expect("capabilities");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("mcp JSON");
+    assert_eq!(v["profile"]["session"], false, "{v}");
+    assert!(v["profile"]["sessionTools"].is_null(), "{v}");
+}


### PR DESCRIPTION
## 요약

`mcp-serve --profile 아카이브검색`(대량 RAG·감사용 **조회 전용** 직무, 허용 도구 7종에 쓰기 도구가 하나도 없습니다)으로 **원본 문서를 덮어쓸 수 있습니다.** 실측:

```
$ # --profile 아카이브검색 로 mcp-serve 구동
before: 31232 bytes
tools/list = 19 tools
  노출된 쓰기 도구: ['hwp_doc_replace_text', 'hwp_doc_set_cell', 'hwp_doc_fill_fields', 'hwp_doc_save']

id=3 hwp_open      isError=False -> {"docId":"doc-1","pageCount":6,...}
id=4 hwp_doc_save  isError=False -> {"bytes":18432,"output":"...\readonly_profile_victim.hwp",...}

after: 18432 bytes  -> OVERWRITTEN
```

동시에 **선언과 서버가 어긋납니다** — `capabilities --mcp --profile 아카이브검색` 은 **7종**을 선언하는데 서버는 **19종**을 냅니다.

## 원인

프로필의 세션 축이 `bool` 하나였습니다.

```rust
pub session: bool,   // 세션 도구 12종 전부 or 전무
```

`served_tools` 는 그 불리언이 참이면 12종을 **무조건** push 하고, 호출 게이트도 `!include_session && is_session_tool(name)` 이라 같은 구멍을 그대로 물려받습니다. 그래서 "조회는 세션으로 반복하되 쓰기는 안 함"이라는 직무를 표현할 방법 자체가 없었고, 그 직무가 세션을 켜는 순간 편집·저장 4종이 딸려 왔습니다.

`mcp_serve.rs` 의 주석이 정확히 이 계약을 선언하고 있습니다:

> "tools/list에서 제거한 세션 도구는 호출로 우회할 수도 없어야 한다. **프로필은 추천 목록이 아니라 서버가 실제로 제공하는 도구 집합의 경계다.**"

선언된 경계(7종)와 강제되는 경계(19종)가 달랐습니다.

**가드가 놓친 이유:** `tests/agent_profile_router_contract.rs` 는 `행정서식`(세션+편집 의도)과 `데이터분석`(세션 off) 두 가지만 시험합니다 — **조회 전용인데 세션은 켜는** 조합이 미시험이었습니다.

## 수정

```rust
pub session_tools: Option<&'static [&'static str]>,
//  None        → 세션 표면을 열지 않는다
//  Some(&[])   → 필터 없음(전 세션 도구) — `tools` 와 같은 규약
//  Some(목록)  → 그 목록만
```

- **`SESSION_READ_TOOLS`** 상수: 문서를 바꾸지 않는 8종(`hwp_open`/`hwp_doc_text`/`hwp_doc_info`/`hwp_doc_fields`/`hwp_doc_tables`/`hwp_doc_search`/`hwp_doc_render_page`/`hwp_close`). `hwp_doc_render_page` 는 SVG 를 쓰지만 대상이 호출자가 지정한 **새 산출물**이지 원본 문서가 아니라 조회 축에 남겼습니다.
- **`served_tools` 와 `handle_tool_call` 이 같은 판정 함수**(`allows_session_tool`)를 씁니다. 둘이 갈라지면 경계가 다시 뚫리므로 배선을 하나로 모았습니다.
- **`capabilities --mcp --profile` 에 `sessionTools`** 를 실어 선언이 실물과 같아지게 했습니다. `session: false` 인 프로필은 `null` 입니다.

프로필별 결과: `행정서식`·`개발통합` → 전 세션 도구(변화 없음), `아카이브검색` → 조회 8종, 나머지 4종 → 세션 없음(변화 없음).

## AFTER — 같은 시나리오

```
tools/list 개수: 15          (무상태 7 + 조회 세션 8)
쓰기 도구 노출: []
hwp_doc_save 호출 결과 isError = True
  | 현재 프로필에서는 세션 도구를 제공하지 않습니다: hwp_doc_save
```

## 회귀 가드 2종

- `readonly_profile_serves_no_session_write_tools` — **목록과 호출 두 층을 함께** 봅니다. 조회 도구(`hwp_open`/`hwp_doc_search`)는 열려 있어야 하고(이 프로필의 레시피가 씁니다), 쓰기 4종은 `tools/list` 에 없고 `tools/call` 로도 안 들어가야 합니다.
- `capabilities_declares_the_session_tools_it_actually_serves` — 선언=실물. 매니페스트로 도구 정의를 자동 생성하는 소비자(`cli_json_pipeline_guide.md` 가 문서화한 경로)가 실물과 다른 표면을 얻지 않도록 고정합니다.

## 검증

- `cargo test --test agent_profile_router_contract` — **7/7** (신규 2종 포함)
- `mcp_server_contract` 22/22 · `mcp_session_edit_contract` 6/6 · `cli_json_contract` 5/5 — 무회귀
- `cargo clippy --profile release-test --bin rhwp` — 경고 0 / `cargo fmt --check` — 통과
- 실기: `--profile 아카이브검색` 로 stdio 구동해 before/after 대조

## 호환성

`session: bool` 은 `pub` 필드였으므로 형식상 파괴적 변경이지만, `agent_profiles` 를 소비하는 곳은 저장소 안에 `main.rs`·`mcp_serve.rs` 둘뿐이고 둘 다 이 PR 에서 갱신했습니다. 봉투 쪽은 `profile.session`(불리언)이 그대로 남고 `sessionTools` 가 **추가**되므로 기존 소비자는 계속 파싱됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
