### PR TITLE
fix(mcp): 선언만 되고 CLI 에 닿지 않는 입력 인자 10건 배선 — dryRun:true 인데 파일이 써진다

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -478,7 +478,7 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
                 "nextStep",
             ],
         ),
-        tool(
+        tool_with_optional_args(
             "hwp_export_text",
             "문서의 페이지별 본문 텍스트를 추출한다. 특정 페이지만 필요하면 page 를 준다.",
             path_schema(serde_json::json!({
@@ -486,9 +486,12 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
             })),
             "export-text",
             serde_json::json!(["export-text", "--json", "{path}"]),
+            serde_json::json!([
+                { "when": "page", "args": ["-p", "{page}"] }
+            ]),
             &["pageCount", "pages"],
         ),
-        tool(
+        tool_with_optional_args(
             "hwp_export_structure",
             "문서의 개요/조문 계층을 트리로 추출한다. 법령·규정의 '제N조' 구조를 얻어 조문 단위로 인용하거나 청킹할 때 쓴다.",
             path_schema(serde_json::json!({
@@ -500,6 +503,9 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
             })),
             "export-structure",
             serde_json::json!(["export-structure", "--json", "{path}"]),
+            serde_json::json!([
+                { "when": "mode", "args": ["--mode", "{mode}"] }
+            ]),
             &["mode", "nodeCount", "structure"],
         ),
         tool(
@@ -678,7 +684,7 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
             serde_json::json!(["fields", "{path}", "--json"]),
             &["source", "fieldCount", "fields"],
         ),
-        tool(
+        tool_with_optional_args(
             "hwp_batch",
             "여러 문서를 한 프로세스에서 병렬 처리해 NDJSON 스트림으로 받는다. 파일 목록은 stdin 으로 한 줄에 하나씩 넣는다. 아카이브 전체를 스윕할 때 쓴다.",
             serde_json::json!({
@@ -700,9 +706,12 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
             }),
             "batch",
             serde_json::json!(["batch", "{subcommand}", "--json"]),
+            serde_json::json!([
+                { "when": "threads", "args": ["--threads", "{threads}"] }
+            ]),
             &["schemaVersion", "source", "error", "exitClass"],
         ),
-        tool(
+        tool_with_optional_args(
             "hwp_fill_fields",
             "HWP 서식(템플릿)의 누름틀에 값을 채워 새 문서를 만든다. 먼저 hwp_fields 로 어떤 필드가 있는지 확인한 뒤 사용한다. 같은 이름이 여러 번 나오는 서식(규제영향분석서 등)은 이름에 순번을 붙여 지목한다. dryRun 으로 파일을 만들지 않고 변경 예정만 확인할 수 있다. 산출물은 입력 형식을 따른다(HWPX 입력 → HWPX 산출).",
             serde_json::json!({
@@ -721,6 +730,10 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
             }),
             "edit",
             serde_json::json!(["edit", "fill-fields", "{path}", "--data", "{data}", "--json"]),
+            serde_json::json!([
+                { "when": "output", "args": ["-o", "{output}"] },
+                { "when": "dryRun", "args": ["--dry-run"] }
+            ]),
             &[
                 "schemaVersion",
                 "source",
@@ -733,7 +746,7 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
                 "outputFormat",
             ],
         ),
-        tool(
+        tool_with_optional_args(
             "hwp_batch_search",
             "여러 문서를 한 프로세스에서 병렬 검색해 NDJSON 스트림으로 받는다. 매치마다 구역·문단·페이지 주소가 붙어 '어느 문서 몇 쪽'을 답할 수 있다. 파일 목록은 stdin 으로 한 줄에 하나씩 넣는다.",
             serde_json::json!({
@@ -751,6 +764,9 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
             }),
             "batch",
             serde_json::json!(["batch", "search", "--json", "--query", "{query}"]),
+            serde_json::json!([
+                { "when": "threads", "args": ["--threads", "{threads}"] }
+            ]),
             &[
                 "schemaVersion",
                 "source",
@@ -761,7 +777,7 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
                 "matches",
             ],
         ),
-        tool(
+        tool_with_optional_args(
             "hwp_replace_text",
             "HWP 문서 전체에서 문자열을 일괄 치환해 새 문서를 만든다 (기관명 변경·연도 갱신·용어 정비). dryRun 으로 파일을 만들지 않고 치환 예정 건수만 확인할 수 있다. 치환 0건이면 출력 파일을 만들지 않는다. 산출물은 입력 형식을 따른다(HWPX 입력 → HWPX 산출).",
             serde_json::json!({
@@ -777,6 +793,10 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
             }),
             "edit",
             serde_json::json!(["edit", "replace-text", "{path}", "--find", "{find}", "--replace", "{replace}", "--json"]),
+            serde_json::json!([
+                { "when": "output", "args": ["-o", "{output}"] },
+                { "when": "dryRun", "args": ["--dry-run"] }
+            ]),
             &["schemaVersion", "source", "find", "replace", "caseSensitive", "dryRun", "replacedCount", "output", "outputFormat"],
         ),
         tool(
@@ -795,7 +815,7 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
             serde_json::json!(["edit", "replace-text", "{path}", "--find", "□", "--replace", "☑", "--occurrence", "{occurrence}", "-o", "{output}", "--json"]),
             &["schemaVersion", "source", "find", "replace", "occurrence", "dryRun", "replacedCount", "output", "outputFormat"],
         ),
-        tool(
+        tool_with_optional_args(
             "hwp_set_cell",
             "HWP 표의 격자 좌표(hwp_export_tables 와 동일)로 셀 값을 바꿔 새 문서를 만든다 — 누름틀 없는 실물 표 양식 채우기. 먼저 hwp_export_tables 로 좌표를 확인한 뒤 사용한다. 병합으로 덮인 칸은 앵커 좌표를 안내하며 실패한다. 산출물은 입력 형식을 따른다(HWPX 입력 → HWPX 산출).",
             serde_json::json!({
@@ -813,6 +833,10 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
             }),
             "edit",
             serde_json::json!(["edit", "set-cell", "{path}", "--table", "{table}", "--row", "{row}", "--col", "{col}", "--text", "{text}", "--json"]),
+            serde_json::json!([
+                { "when": "output", "args": ["-o", "{output}"] },
+                { "when": "dryRun", "args": ["--dry-run"] }
+            ]),
             &["schemaVersion", "source", "table", "row", "col", "oldText", "newText", "dryRun", "overflow", "output", "outputFormat"],
         ),
     ];

--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -953,8 +953,14 @@ fn run_cli_tool(def: &serde_json::Value, args: &serde_json::Value) -> serde_json
             let Some(key) = optional.get("when").and_then(|v| v.as_str()) else {
                 return tool_error("MCP optionalArgs.when 정의가 올바르지 않습니다".into());
             };
-            if args.get(key).is_none() {
-                continue;
+            // 존재 여부만으로는 부족하다. `--dry-run` 같은 presence 플래그는 값이 없어
+            // "있으면 켜짐" 이므로, `dryRun: false` 를 존재로 세면 **끄라고 보낸 요청이
+            // 켜는 요청이 된다**. JSON 의 false/null 은 "그 축을 쓰지 않음" 으로 읽는다.
+            match args.get(key) {
+                None | Some(serde_json::Value::Null) | Some(serde_json::Value::Bool(false)) => {
+                    continue;
+                }
+                Some(_) => {}
             }
             let Some(template) = optional.get("args").and_then(|v| v.as_array()) else {
                 return tool_error(format!(

--- a/tests/mcp_server_contract.rs
+++ b/tests/mcp_server_contract.rs
@@ -181,6 +181,125 @@ fn tools_list_matches_capabilities_manifest() {
     }
 }
 
+/// 선언된 입력 속성 중 **어느 CLI 경로로도 전달되지 않는** 것 — 즉 스키마에만
+/// 존재하는 유령 인자를 stdin 전송 축만 남기고 전부 거부한다.
+///
+/// 이 목록은 argv 가 아닌 다른 축으로 전달되는 속성만 담는다. 늘리려면 그 축이
+/// 실제로 존재함을 근거로 적어야 한다 — allowlist 가 커지면 가드가 무의미해진다.
+const NON_ARGV_PROPERTIES: &[(&str, &str)] = &[
+    (
+        "paths",
+        "자식 CLI stdin 으로 한 줄에 하나씩 흘려 넣는다(batch 계열).",
+    ),
+    (
+        "password",
+        "민감값이라 argv 금지 — cli.passwordStdin 계약으로 stdin 전달.",
+    ),
+];
+
+#[test]
+fn every_declared_input_property_is_wired_to_the_cli() {
+    // 드리프트 가드 2: 이름뿐 아니라 **인자 배선**까지 본다.
+    //
+    // `inputSchema` 에 선언만 하고 `cli.args` 자리표시자에도 `cli.optionalArgs.when`
+    // 에도 넣지 않으면, 서버는 그 인자를 조용히 버린 채 성공을 보고한다. 에이전트는
+    // 스키마를 읽고 인자를 보냈으므로 반영됐다고 믿는다 — `dryRun: true` 를 보냈는데
+    // 파일이 써지고 응답에는 `"dryRun": false` 가 오는 형태였다(#3712 이전 devel).
+    // 컴파일 에러도 런타임 오류도 없이 계약만 거짓말한다.
+    let cap = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(["capabilities", "--mcp"])
+        .output()
+        .expect("capabilities 실행 실패");
+    let manifest: serde_json::Value =
+        serde_json::from_slice(&cap.stdout).expect("capabilities --mcp JSON");
+    let tools = manifest["tools"].as_array().expect("tools 배열");
+    assert!(
+        !tools.is_empty(),
+        "도구가 0건이면 이 가드는 공허하게 통과한다"
+    );
+
+    let mut orphans: Vec<String> = Vec::new();
+    for t in tools {
+        let name = t["name"].as_str().unwrap_or("<이름없음>");
+        let Some(props) = t["inputSchema"]["properties"].as_object() else {
+            continue;
+        };
+        // argv 템플릿(필수)에 쓰인 `{키}` 전부.
+        let mut wired: Vec<String> = t["cli"]["args"]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str())
+                    .filter(|s| s.starts_with('{') && s.ends_with('}') && s.len() > 2)
+                    .map(|s| s[1..s.len() - 1].to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+        // 선택 인자는 `when` 키 자체가 배선 지점이다(값 없는 presence 플래그 포함).
+        if let Some(optional) = t["cli"]["optionalArgs"].as_array() {
+            for o in optional {
+                if let Some(key) = o["when"].as_str() {
+                    wired.push(key.to_string());
+                }
+            }
+        }
+        for key in props.keys() {
+            if wired.iter().any(|w| w == key) {
+                continue;
+            }
+            if NON_ARGV_PROPERTIES.iter().any(|(k, _)| k == key) {
+                continue;
+            }
+            orphans.push(format!(
+                "  - {name}.{key} — inputSchema 에만 있고 cli.args/optionalArgs 어디에도 없음"
+            ));
+        }
+    }
+
+    assert!(
+        orphans.is_empty(),
+        "선언만 되고 배선되지 않은 MCP 입력 인자 {}건:\n{}\n\n\
+         스키마에 쓴 인자는 반드시 자식 CLI 에 닿아야 한다. 닿지 않으면 서버는 그 인자를\n\
+         조용히 버리고 성공을 보고하며, 에이전트는 반영됐다고 믿는다(dryRun 이 그 형태였다).\n\
+         고치는 법: `tool_with_optional_args` 로 `{{ \"when\": \"<키>\", \"args\": [...] }}` 를\n\
+         더하라. argv 가 아닌 축(stdin 등)으로 전달한다면 NON_ARGV_PROPERTIES 에 근거와\n\
+         함께 등재하라.",
+        orphans.len(),
+        orphans.join("\n"),
+    );
+}
+
+/// 값 없는 presence 플래그는 "있으면 켜짐" 이다. `false` 를 존재로 세면 **끄라고 보낸
+/// 요청이 켜는 요청이 된다** — 되돌릴 수 없는 쓰기에서 특히 위험하다.
+#[test]
+fn boolean_false_does_not_inject_a_presence_flag() {
+    let p = sample(SAMPLE);
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let out = std::env::temp_dir().join("rhwp_mcp_dryrun_false.hwp");
+    let _ = std::fs::remove_file(&out);
+
+    let mut s = Server::started();
+    let r = s.call_tool(
+        "hwp_replace_text",
+        serde_json::json!({
+            "path": p.to_string_lossy(),
+            "find": "가",
+            "replace": "나",
+            "output": out.to_string_lossy(),
+            "dryRun": false,
+        }),
+    );
+    let text = r["result"]["content"][0]["text"].as_str().unwrap_or("");
+    assert!(
+        !text.contains("\"dryRun\":true") && !text.contains("\"dryRun\": true"),
+        "dryRun:false 를 보냈는데 --dry-run 이 주입됐다 — presence 플래그가 값을 무시했다: {text}"
+    );
+    let _ = std::fs::remove_file(&out);
+}
+
 #[test]
 fn tools_call_stateless_info_works() {
     let p = sample(SAMPLE);


### PR DESCRIPTION
## 요약

MCP `inputSchema` 에 **선언만 되고 실행 배선이 없는 입력 인자 10건**입니다. 서버가 그 값을 조용히 버리므로, 에이전트가 보낸 요청과 실제 실행이 다릅니다. 실측:

```
hwp_export_structure {mode:"outline"}  →  mode=clause, nodeCount=15      (CLI --mode outline 은 mode=outline, nodeCount=0)
hwp_export_text      {page:1}          →  16쪽 전부                       (page 를 무시)
hwp_replace_text     {dryRun:true, output:"…/out.hwpx"}
                                       →  dryRun=false 로 실행되고 4.1MB 파일이 저장소 루트에 생성됨
```

`dryRun` 이 가장 나쁩니다 — **파일을 만들지 말라고 보낸 요청이 파일을 만들고**, `output` 마저 버려져 산출물이 호출자가 지정하지 않은 자리에 떨어집니다.

배선된 인자: `output`·`dryRun`(fill_fields·replace_text·set_cell), `page`(export_text), `mode`(export_structure), `threads`(batch 2종).

## 함정 — presence 판정으로는 부족하다

`optionalArgs` 확장은 `args.get(key).is_none()` 으로 "왔는가"만 봤습니다. `--dry-run` 처럼 **값이 없는 스위치**는 `args` 에 자리표시자가 없고 `when` 만으로 배선되므로, 이 규칙 그대로 `dryRun` 을 이으면 **`dryRun:false` 에도 `--dry-run` 이 붙습니다** — 끄라고 보낸 요청이 켜는 요청이 되어, 편집 도구가 조용히 아무것도 쓰지 않는 정반대 결함이 됩니다.

그래서 확장 지점 한 곳에 규칙을 둡니다: JSON `false`·`null` 은 "그 축을 쓰지 않음"으로 읽고 인자를 만들지 않습니다. 특정 키 예외가 아니라 불리언 스위치 배선 전반의 규칙이라, 앞으로 추가되는 스위치도 같은 판정을 받습니다. `page:0`·`threads:1` 은 `false` 가 아니므로 그대로 통과합니다.

## AFTER

```
hwp_export_text {page:1}  →  pages 길이: 1 | page 번호: [1]
```

## 검증

- `cargo test --test mcp_server_contract` — **22/22** (신규 계약 테스트 포함)
- `cargo test --test cli_json_contract` — 8/8
- `cargo clippy --profile release-test --bin rhwp` — 경고 0 / `cargo fmt --check` — 통과
- 실기: `mcp-serve` stdio 로 `page:1` 왕복 확인

## 남은 같은 계열

`hwp_batch`/`hwp_batch_search` 의 `paths` 는 argv 가 아니라 stdin 으로 가는 유일한 예외이고, 그 사실은 매니페스트의 `invocation.stdinTools` 가 선언합니다 — 배선 대상이 아닙니다.

이 계열을 근본적으로 막으려면 "모든 `inputSchema` 속성은 `cli.args` 또는 `optionalArgs` 어딘가에 닿아야 한다"는 드리프트 가드가 필요합니다. 이번 PR 범위를 넘어 별도로 올리겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
