### PR TITLE
fix(mcp): 인자 검증 3건 — page:-1 이 문서 전체를 성공으로 돌려주고, '-' 로 시작하는 검색어는 아예 못 찾는다

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -637,8 +637,8 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
                 "type": "object",
                 "properties": {
                     "path": { "type": "string", "description": "입력 HWP/HWPX 문서 경로" },
-                    "from": { "type": "integer", "minimum": 0, "description": "시작 쪽 (0 기준, 포함)" },
-                    "to": { "type": "integer", "minimum": 0, "description": "끝 쪽 (0 기준, 포함)" },
+                    "from": { "type": "integer", "minimum": 1, "description": "시작 쪽 (1 기준, 포함). 세션 도구(hwp_doc_text·hwp_doc_render_page)의 page 는 0 기준이니 두 기수를 섞지 않는다" },
+                    "to": { "type": "integer", "minimum": 1, "description": "끝 쪽 (1 기준, 포함)" },
                     "output": { "type": "string", "description": "출력 파일 경로" }
                 },
                 "required": ["path", "from", "to", "output"],
@@ -667,7 +667,9 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
                 "required": ["path", "query"],
             }),
             "search",
-            serde_json::json!(["search", "{path}", "{query}", "--json"]),
+            // `--` 뒤는 전부 위치 인자다 — 그래서 `--json` 은 구분자 **앞**에
+            // 와야 한다. 뒤에 두면 세 번째 위치 인자가 되어 "인자가 너무 많습니다" 다.
+            serde_json::json!(["search", "{path}", "--json", "--", "{query}"]),
             &["source", "query", "caseSensitive", "matchCount", "matches"],
         ),
         tool(
@@ -6834,12 +6836,19 @@ fn search_document(args: &[String]) -> i32 {
     let mut ignore_case = false;
     let mut limit: Option<usize> = None;
 
+    // POSIX 옵션 종결자. 검색어가 '-' 로 시작하면 종전에는 플래그로 먹혔다 —
+    // `-i` 는 대소문자 축을 **조용히** 뒤집고(리터럴 "-i" 를 찾으려던 호출이 다음
+    // 위치 인자를 대소문자 무시로 검색한다), 그 외에는 "알 수 없는 옵션" 으로 죽어
+    // 하이픈으로 시작하는 문자열은 아예 검색할 수 없었다.
+    let mut end_of_options = false;
+
     let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
-            "--json" => json_mode = true,
-            "--ignore-case" | "-i" => ignore_case = true,
-            "--limit" => {
+            "--" if !end_of_options => end_of_options = true,
+            "--json" if !end_of_options => json_mode = true,
+            "--ignore-case" | "-i" if !end_of_options => ignore_case = true,
+            "--limit" if !end_of_options => {
                 i += 1;
                 match args.get(i).and_then(|v| v.parse::<usize>().ok()) {
                     Some(n) if n >= 1 => limit = Some(n),
@@ -6849,7 +6858,7 @@ fn search_document(args: &[String]) -> i32 {
                     }
                 }
             }
-            other if other.starts_with('-') => {
+            other if !end_of_options && other.starts_with('-') => {
                 eprintln!("알 수 없는 옵션: {other}");
                 return EXIT_USAGE;
             }

--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -479,6 +479,56 @@ fn mcp_password(args: &serde_json::Value) -> Result<Option<String>, String> {
     Ok(Some(password.to_string()))
 }
 
+/// MCP 인자 강제변환의 단일 계약 — **없음**과 **있는데 형식이 틀림**을 가른다.
+///
+/// `args.get(k).and_then(|v| v.as_u64())` 는 두 경우를 모두 `None` 으로 뭉갠다. 그러면
+/// `page: -1` 같은 오타가 "page 생략"과 구별되지 않아, 한 쪽만 달라던 요청이 문서 전체를
+/// **성공 응답으로** 받아 간다. 호출자(에이전트)는 isError 도 경고도 못 보므로 오타를
+/// 알아챌 방법이 없다 — 조용히 틀린 답을 주는 부류라 반드시 거부해야 한다.
+///
+/// `null` 만 관용적으로 "생략"으로 읽는다. 다수 MCP 호스트가 미지정 선택 인자를 `null` 로
+/// 직렬화하므로, 이를 오류로 만들면 멀쩡한 호출이 깨진다.
+fn opt_u64(args: &serde_json::Value, key: &str) -> Result<Option<u64>, String> {
+    let Some(v) = args.get(key) else {
+        return Ok(None);
+    };
+    if v.is_null() {
+        return Ok(None);
+    }
+    if let Some(n) = v.as_u64() {
+        return Ok(Some(n));
+    }
+    // 파이썬 계열 호스트는 정수를 `3.0` 으로 직렬화하고 JSON Schema 도 이를 integer 로
+    // 인정한다. 소수부 없는 음이 아닌 값만 받아 준다 — `2.5`·`-1`·`"3"`·`true` 는 거부.
+    if let Some(f) = v.as_f64() {
+        if f.fract() == 0.0 && f >= 0.0 && f <= u64::MAX as f64 {
+            return Ok(Some(f as u64));
+        }
+    }
+    Err(format!("{key} 는 0 이상의 정수여야 합니다 (받은 값: {v})"))
+}
+
+/// `opt_u64` 의 불리언 판. `"true"`/`1` 같은 근사값도 거부한다 — 선언이 `boolean` 인데
+/// 실행이 관용 변환을 하면 선언과 실행이 어긋나고, 어긋난 쪽은 늘 조용하다.
+fn opt_bool(args: &serde_json::Value, key: &str) -> Result<Option<bool>, String> {
+    match args.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(serde_json::Value::Bool(b)) => Ok(Some(*b)),
+        Some(v) => Err(format!(
+            "{key} 는 true 또는 false 여야 합니다 (받은 값: {v})"
+        )),
+    }
+}
+
+/// 필수 정수. "생략"과 "형식 오류"를 서로 다른 문구로 보고한다 — 같은 문구로 뭉개면
+/// 호출자가 값이 아니라 호출 형태를 의심하며 헛수고한다.
+fn req_u64(args: &serde_json::Value, key: &str) -> Result<u64, String> {
+    match opt_u64(args, key)? {
+        Some(n) => Ok(n),
+        None => Err(format!("{key} 가 필요합니다")),
+    }
+}
+
 fn session_doc_text(args: &serde_json::Value, sessions: &mut Sessions) -> serde_json::Value {
     let Some(doc_id) = args.get("docId").and_then(|d| d.as_str()) else {
         return tool_error("docId 가 필요합니다".into());
@@ -488,7 +538,13 @@ fn session_doc_text(args: &serde_json::Value, sessions: &mut Sessions) -> serde_
     };
     let doc = &mut sd.doc;
     let page_count = doc.page_count();
-    let pages: Vec<u32> = match args.get("page").and_then(|p| p.as_u64()) {
+    // page 오타(-1·2.5·"3")를 "생략"과 갈라 낸다. 뭉개면 아래 `None` 갈래로
+    // 떨어져 **문서 전체**가 성공 응답으로 나간다 — 한 쪽만 달라던 호출과 구별 불가.
+    let page_arg = match opt_u64(args, "page") {
+        Ok(v) => v,
+        Err(e) => return tool_error(e),
+    };
+    let pages: Vec<u32> = match page_arg {
         Some(raw_page) => {
             let p = match u32::try_from(raw_page) {
                 Ok(p) => p,
@@ -565,8 +621,11 @@ fn session_tables(args: &serde_json::Value, sessions: &mut Sessions) -> serde_js
 }
 
 fn session_render_page(args: &serde_json::Value, sessions: &mut Sessions) -> serde_json::Value {
-    let Some(raw_page) = args.get("page").and_then(|p| p.as_u64()) else {
-        return tool_error("page 가 필요합니다".into());
+    // page 는 필수 인자다. as_u64() 로 뭉개면 `page: -1` 도 "page 가 필요합니다"
+    // 로 보고돼, 보냈는데 없다고 하는 오진이 된다.
+    let raw_page = match req_u64(args, "page") {
+        Ok(v) => v,
+        Err(e) => return tool_error(e),
     };
     let page = match u32::try_from(raw_page) {
         Ok(page) => page,
@@ -623,10 +682,13 @@ fn session_search(args: &serde_json::Value, sessions: &mut Sessions) -> serde_js
     if query.is_empty() {
         return tool_error("query 는 빈 문자열일 수 없습니다".into());
     }
-    let case_sensitive = args
-        .get("caseSensitive")
-        .and_then(|c| c.as_bool())
-        .unwrap_or(true);
+    // `"false"`·`0` 은 as_bool() 에서 None → 기본값 true 로 되돌아간다. 축을
+    // 끄라고 보낸 요청이 켠 채 실행되고, 봉투는 caseSensitive:true 를 **성공**으로
+    // 보고한다. 검색 결과가 조용히 달라지므로 거부가 유일하게 안전한 처리다.
+    let case_sensitive = match opt_bool(args, "caseSensitive") {
+        Ok(v) => v.unwrap_or(true),
+        Err(e) => return tool_error(e),
+    };
     let Some(sd) = sessions.docs.get_mut(doc_id) else {
         return tool_error(format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"));
     };
@@ -652,10 +714,13 @@ fn session_replace_text(args: &serde_json::Value, sessions: &mut Sessions) -> se
     let Some(replace) = args.get("replace").and_then(|r| r.as_str()) else {
         return tool_error("replace 가 필요합니다".into());
     };
-    let case_sensitive = args
-        .get("caseSensitive")
-        .and_then(|c| c.as_bool())
-        .unwrap_or(true);
+    // 검색과 달리 여기서는 **문서가 바뀐다**. caseSensitive 오타가 조용히
+    // true 로 되돌아가면 치환 대상 집합이 달라진 채 IR 에 누적되고, save 가 그대로
+    // 디스크에 굳힌다 — 되돌릴 수 없는 축이라 더더욱 거부해야 한다.
+    let case_sensitive = match opt_bool(args, "caseSensitive") {
+        Ok(v) => v.unwrap_or(true),
+        Err(e) => return tool_error(e),
+    };
     let Some(sd) = sessions.docs.get_mut(doc_id) else {
         return tool_error(format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"));
     };
@@ -685,20 +750,30 @@ fn session_replace_text(args: &serde_json::Value, sessions: &mut Sessions) -> se
 /// [#3603] 핸들의 표 격자 좌표에 값을 기록한다 — resolve_table_cell(CLI 와 공유)로
 /// 좌표를 해석하고, overflow 판정·검정 정규화까지 무상태 edit set-cell 과 동형이다.
 fn session_set_cell(args: &serde_json::Value, sessions: &mut Sessions) -> serde_json::Value {
-    let (Some(table_no), Some(row), Some(col)) = (
-        args.get("table").and_then(|v| v.as_u64()),
-        args.get("row").and_then(|v| v.as_u64()),
-        args.get("col").and_then(|v| v.as_u64()),
-    ) else {
-        return tool_error("table/row/col 이 필요합니다".into());
+    // 셋 다 보냈는데 하나가 음수여도 종전에는 "table/row/col 이 필요합니다" 였다.
+    // 있는 인자를 없다고 말하는 오진이라, 호출자는 값이 아니라 호출 형태를 의심하며
+    // 같은 실수를 반복한다. 축별로 따로 검사해 어느 축이 왜 틀렸는지 지목한다.
+    let table_no = match req_u64(args, "table") {
+        Ok(v) => v,
+        Err(e) => return tool_error(e),
+    };
+    let row = match req_u64(args, "row") {
+        Ok(v) => v,
+        Err(e) => return tool_error(e),
+    };
+    let col = match req_u64(args, "col") {
+        Ok(v) => v,
+        Err(e) => return tool_error(e),
     };
     let Some(new_text) = args.get("text").and_then(|t| t.as_str()).map(String::from) else {
         return tool_error("text 가 필요합니다".into());
     };
-    let keep_style = args
-        .get("keepStyle")
-        .and_then(|k| k.as_bool())
-        .unwrap_or(false);
+    // keepStyle 오타는 "스타일 상속 유지" 요청을 조용히 검정 정규화로 되돌린다 —
+    // 서식지 셀 서식이 말없이 지워지는 경로라 관용 변환을 두면 안 된다.
+    let keep_style = match opt_bool(args, "keepStyle") {
+        Ok(v) => v.unwrap_or(false),
+        Err(e) => return tool_error(e),
+    };
     let Some(doc_id) = args.get("docId").and_then(|d| d.as_str()) else {
         return tool_error("docId 가 필요합니다".into());
     };

--- a/tests/mcp_arg_validation_contract.rs
+++ b/tests/mcp_arg_validation_contract.rs
@@ -1,0 +1,451 @@
+//! MCP 인자 검증 계약 — "생략"과 "형식 오류"를 가른다.
+//!
+//! `args.get(k).and_then(|v| v.as_u64())` 류의 강제변환은 두 경우를 모두 `None` 으로
+//! 뭉갰다. `page: -1` 은 "page 생략"과 같아져 한 쪽만 달라던 호출이 **문서 전체**를
+//! 성공 응답으로 받아 갔고, `caseSensitive: "false"` 는 기본값 true 로 되돌아가
+//! 검색·치환 대상 집합이 조용히 달라졌다. 여기서 고정하는 것은 *조용한 오답의 부재*다.
+//!
+//! `hwp_search` 축은 배선 결함이다 — `{query}` 가 위치 argv 에 그대로 놓여 '-' 로
+//! 시작하는 검색어가 플래그로 먹혔다. CLI 에 `--` 종결자를 넣고 템플릿에서 `--json` 을
+//! 구분자 **앞**으로 옮긴다(뒤는 전부 위치 인자다).
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+/// 16쪽 HWP3 표본 — page 축의 "전체 vs 한 쪽"을 눈에 띄게 가른다.
+const SAMPLE: &str = "samples/hwp3-sample.hwp";
+
+fn sample() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn run_cli(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+struct Server {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: i64,
+}
+
+impl Server {
+    fn started() -> Server {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+            .arg("mcp-serve")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("rhwp mcp-serve 실행 실패");
+        let stdin = child.stdin.take().expect("stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout"));
+        let mut s = Server {
+            child,
+            stdin,
+            stdout,
+            next_id: 1,
+        };
+        let r = s.request(
+            "initialize",
+            serde_json::json!({
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "arg-validation-test", "version": "0"}
+            }),
+        );
+        assert!(r["result"]["serverInfo"]["name"].is_string(), "{r}");
+        s
+    }
+
+    fn request(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        let msg =
+            serde_json::json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params});
+        writeln!(self.stdin, "{msg}").expect("요청 쓰기 실패");
+        self.stdin.flush().expect("flush");
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let n = self.stdout.read_line(&mut line).expect("응답 읽기 실패");
+            assert!(n > 0, "서버가 응답 없이 종료했습니다 (method={method})");
+            if line.trim().is_empty() {
+                continue;
+            }
+            let v: serde_json::Value = serde_json::from_str(line.trim())
+                .unwrap_or_else(|e| panic!("stdout 이 JSON-RPC 가 아닙니다 ({e}): {line}"));
+            if v.get("id").and_then(|i| i.as_i64()) == Some(id) {
+                return v;
+            }
+        }
+    }
+
+    fn call(&mut self, name: &str, args: serde_json::Value) -> (bool, serde_json::Value) {
+        let r = self.request(
+            "tools/call",
+            serde_json::json!({"name": name, "arguments": args}),
+        );
+        let result = &r["result"];
+        let is_error = result["isError"].as_bool().unwrap_or(false);
+        let text = result["content"][0]["text"]
+            .as_str()
+            .unwrap_or("")
+            .to_string();
+        let v = serde_json::from_str(&text).unwrap_or(serde_json::Value::String(text));
+        (is_error, v)
+    }
+
+    fn open(&mut self, path: &Path) -> String {
+        let (err, v) = self.call(
+            "hwp_open",
+            serde_json::json!({"path": path.to_str().unwrap()}),
+        );
+        assert!(!err, "hwp_open 실패: {v}");
+        v["docId"].as_str().expect("docId").to_string()
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// isError 응답의 사람 읽는 문자열.
+fn msg(v: &serde_json::Value) -> String {
+    v.as_str()
+        .map(String::from)
+        .unwrap_or_else(|| v.to_string())
+}
+
+/// 회귀의 핵심: 오타 page 가 "생략"으로 뭉개지면 **문서 전체**가 성공으로 나갔다.
+#[test]
+fn doc_text_mistyped_page_is_rejected_not_widened_to_whole_document() {
+    let src = sample();
+    if !src.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let mut s = Server::started();
+    let doc = s.open(&src);
+
+    let (err, whole) = s.call("hwp_doc_text", serde_json::json!({"docId": doc}));
+    assert!(!err, "{whole}");
+    let all = whole["pageCount"].as_u64().expect("pageCount");
+    assert!(all > 1, "전제: 여러 쪽 표본이어야 합니다: {whole}");
+
+    for bad in [
+        serde_json::json!(-1),
+        serde_json::json!(2.5),
+        serde_json::json!("3"),
+        serde_json::json!(true),
+    ] {
+        let (err, v) = s.call(
+            "hwp_doc_text",
+            serde_json::json!({"docId": doc, "page": bad}),
+        );
+        assert!(err, "page={bad} 는 isError 여야 합니다: {v}");
+        let m = msg(&v);
+        assert!(m.contains("page"), "어느 인자인지 지목해야 합니다: {m}");
+        assert!(m.contains("정수"), "무엇이 틀렸는지 밝혀야 합니다: {m}");
+    }
+
+    // 유효한 한 쪽 요청은 그대로 한 쪽이다(고침이 정상 경로를 좁히지 않았는가).
+    let (err, one) = s.call("hwp_doc_text", serde_json::json!({"docId": doc, "page": 0}));
+    assert!(!err, "{one}");
+    assert_eq!(one["pages"].as_array().map(|a| a.len()), Some(1), "{one}");
+}
+
+/// 다수 호스트가 미지정 선택 인자를 `null` 로 직렬화한다 — 이를 오류로 만들면 멀쩡한
+/// 호출이 깨진다. `null` 만 관용하고 나머지 오타는 거부한다.
+#[test]
+fn doc_text_null_page_still_means_omitted() {
+    let src = sample();
+    if !src.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let mut s = Server::started();
+    let doc = s.open(&src);
+    let (err, v) = s.call(
+        "hwp_doc_text",
+        serde_json::json!({"docId": doc, "page": serde_json::Value::Null}),
+    );
+    assert!(!err, "null page 는 '생략'이어야 합니다: {v}");
+    assert!(v["pageCount"].as_u64().unwrap_or(0) > 1, "{v}");
+}
+
+/// 고침 전에는 누락과 오타가 둘 다 "page 가 필요합니다" — 보냈는데 없다고 하는 오진.
+#[test]
+fn render_page_separates_missing_from_mistyped() {
+    let src = sample();
+    if !src.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let out = std::env::temp_dir().join(format!("rhwp-argval-{}.svg", std::process::id()));
+    let out = out.to_str().unwrap().to_string();
+    let mut s = Server::started();
+    let doc = s.open(&src);
+
+    let (err, absent) = s.call(
+        "hwp_doc_render_page",
+        serde_json::json!({"docId": doc, "output": out}),
+    );
+    assert!(err, "{absent}");
+    assert!(msg(&absent).contains("필요합니다"), "{absent}");
+
+    for bad in [serde_json::json!(-1), serde_json::json!("0")] {
+        let (err, v) = s.call(
+            "hwp_doc_render_page",
+            serde_json::json!({"docId": doc, "page": bad, "output": out}),
+        );
+        assert!(err, "page={bad}: {v}");
+        let m = msg(&v);
+        assert!(
+            m.contains("정수") && !m.contains("필요합니다"),
+            "형식 오류는 '없음'과 다른 문구여야 합니다: {m}"
+        );
+    }
+    assert!(!Path::new(&out).exists(), "거부 경로가 산출물을 남겼습니다");
+}
+
+/// 조용한 축 되돌림: `"false"`/`0` 이 as_bool() 에서 None → 기본값 true.
+/// 치환 쪽은 문서가 바뀌는 축이라 되돌릴 수 없다.
+#[test]
+fn case_sensitive_rejects_non_boolean_in_search_and_replace() {
+    let src = sample();
+    if !src.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let mut s = Server::started();
+    let doc = s.open(&src);
+    for bad in [
+        serde_json::json!("false"),
+        serde_json::json!(0),
+        serde_json::json!("true"),
+    ] {
+        let (err, v) = s.call(
+            "hwp_doc_search",
+            serde_json::json!({"docId": doc, "query": "The", "caseSensitive": bad}),
+        );
+        assert!(err, "search caseSensitive={bad}: {v}");
+        assert!(msg(&v).contains("caseSensitive"), "{v}");
+
+        let (err, v) = s.call(
+            "hwp_doc_replace_text",
+            serde_json::json!({"docId": doc, "find": "z", "replace": "y", "caseSensitive": bad}),
+        );
+        assert!(err, "replace caseSensitive={bad}: {v}");
+        assert!(msg(&v).contains("caseSensitive"), "{v}");
+    }
+
+    // 진짜 불리언은 그대로 통하고 봉투에 반영된다.
+    let (err, v) = s.call(
+        "hwp_doc_search",
+        serde_json::json!({"docId": doc, "query": "The", "caseSensitive": false}),
+    );
+    assert!(!err, "{v}");
+    assert_eq!(v["caseSensitive"], false, "{v}");
+}
+
+/// 고침 전: `table:-1` 이어도 "table/row/col 이 필요합니다" — 있는 인자를 없다고 한다.
+#[test]
+fn set_cell_names_the_bad_axis_instead_of_claiming_absence() {
+    let src = sample();
+    if !src.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let mut s = Server::started();
+    let doc = s.open(&src);
+    for (axis, args) in [
+        (
+            "table",
+            serde_json::json!({"docId": doc, "table": -1, "row": 0, "col": 0, "text": "x"}),
+        ),
+        (
+            "row",
+            serde_json::json!({"docId": doc, "table": 0, "row": -2, "col": 0, "text": "x"}),
+        ),
+        (
+            "col",
+            serde_json::json!({"docId": doc, "table": 0, "row": 0, "col": "2", "text": "x"}),
+        ),
+    ] {
+        let (err, v) = s.call("hwp_doc_set_cell", args);
+        assert!(err, "{axis}: {v}");
+        let m = msg(&v);
+        assert!(m.contains(axis), "틀린 축을 지목해야 합니다: {m}");
+        assert!(
+            !m.contains("table/row/col 이 필요합니다"),
+            "있는 인자를 없다고 하면 안 됩니다: {m}"
+        );
+    }
+
+    // 진짜 누락은 여전히 "필요합니다".
+    let (err, v) = s.call(
+        "hwp_doc_set_cell",
+        serde_json::json!({"docId": doc, "row": 0, "col": 0, "text": "x"}),
+    );
+    assert!(err, "{v}");
+    assert!(msg(&v).contains("table 가 필요합니다"), "{v}");
+}
+
+/// `"true"`/`1`/`"yes"` 는 고침 전 조용히 false(검정 정규화)로 되돌아갔다 —
+/// 셀 서식이 말없이 사라지는 경로다.
+#[test]
+fn keep_style_rejects_non_boolean() {
+    let src = sample();
+    if !src.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let mut s = Server::started();
+    let doc = s.open(&src);
+    for bad in [
+        serde_json::json!("true"),
+        serde_json::json!(1),
+        serde_json::json!("yes"),
+    ] {
+        let (err, v) = s.call(
+            "hwp_doc_set_cell",
+            serde_json::json!({
+                "docId": doc, "table": 0, "row": 0, "col": 0, "text": "x", "keepStyle": bad
+            }),
+        );
+        assert!(err, "keepStyle={bad}: {v}");
+        assert!(msg(&v).contains("keepStyle"), "{v}");
+    }
+}
+
+/// `--` 뒤는 전부 위치 인자다 — 하이픈으로 시작하는 검색어를 그대로 찾는다.
+#[test]
+fn search_cli_honours_end_of_options_separator() {
+    let src = sample();
+    if !src.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let p = src.to_str().unwrap();
+
+    let out = run_cli(&["search", p, "--json", "--", "-i"]);
+    assert_eq!(out.status.code(), Some(0), "exit: {out:?}");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("search --json");
+    assert_eq!(v["query"], "-i", "검색어가 그대로 실려야 합니다: {v}");
+    assert_eq!(
+        v["caseSensitive"], true,
+        "'-i' 는 플래그가 아니라 검색어다 — 축이 뒤집히면 안 됩니다: {v}"
+    );
+
+    // 구분자 **앞**의 옵션은 여전히 옵션이다(회귀 반대편).
+    let out = run_cli(&["search", p, "--json", "--ignore-case", "--", "The"]);
+    assert_eq!(out.status.code(), Some(0), "exit: {out:?}");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("search --json");
+    assert_eq!(v["query"], "The", "{v}");
+    assert_eq!(v["caseSensitive"], false, "{v}");
+}
+
+/// 선언 배선 자체의 회귀 — `--json` 은 `--` 앞, `{query}` 는 뒤.
+#[test]
+fn hwp_search_tool_wires_query_after_separator() {
+    let caps = run_cli(&["capabilities", "--mcp"]);
+    let m: serde_json::Value = serde_json::from_slice(&caps.stdout).expect("capabilities --mcp");
+    let tool = m["tools"]
+        .as_array()
+        .expect("tools")
+        .iter()
+        .find(|t| t["name"] == "hwp_search")
+        .expect("hwp_search 선언");
+    let targs: Vec<&str> = tool["cli"]["args"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|a| a.as_str())
+        .collect();
+    let sep = targs.iter().position(|a| *a == "--").expect("`--` 배선");
+    let q = targs.iter().position(|a| *a == "{query}").expect("{query}");
+    let j = targs.iter().position(|a| *a == "--json").expect("--json");
+    assert!(sep < q, "검색어는 구분자 뒤: {targs:?}");
+    assert!(
+        j < sep,
+        "--json 은 구분자 앞이어야 위치 인자가 되지 않는다: {targs:?}"
+    );
+
+    // 실행 대조: 서버 경유로도 하이픈 검색어가 통해야 한다.
+    let src = sample();
+    if !src.exists() {
+        return;
+    }
+    let mut s = Server::started();
+    let (err, v) = s.call(
+        "hwp_search",
+        serde_json::json!({"path": src.to_str().unwrap(), "query": "-i"}),
+    );
+    assert!(!err, "하이픈 검색어가 거부되면 안 됩니다: {v}");
+    assert_eq!(v["query"], "-i", "{v}");
+    assert_eq!(v["caseSensitive"], true, "{v}");
+}
+
+/// 선언은 `minimum: 0`·`0 기준`인데 CLI/코어는 1 기준이라 0 을 거부했다 — 선언만 읽고
+/// 호출을 조립하는 에이전트는 첫 호출에서 exit 1 을 밟는다.
+#[test]
+fn split_declaration_page_base_matches_execution() {
+    let caps = run_cli(&["capabilities", "--mcp"]);
+    let m: serde_json::Value = serde_json::from_slice(&caps.stdout).expect("capabilities --mcp");
+    let tool = m["tools"]
+        .as_array()
+        .expect("tools")
+        .iter()
+        .find(|t| t["name"] == "hwp_split_document")
+        .expect("hwp_split_document 선언");
+    for axis in ["from", "to"] {
+        let prop = &tool["inputSchema"]["properties"][axis];
+        assert_eq!(prop["minimum"].as_u64(), Some(1), "{axis} 최솟값: {prop}");
+        let d = prop["description"].as_str().unwrap_or_default();
+        assert!(d.contains("1 기준"), "{axis} 기수를 밝혀야 합니다: {d}");
+        assert!(
+            !d.contains("0 기준, 포함"),
+            "{axis} 기수가 실행과 어긋납니다: {d}"
+        );
+    }
+
+    // 실행 대조: 선언 최솟값-1 은 거부되고, 최솟값은 통해야 한다.
+    let src = sample();
+    if !src.exists() {
+        return;
+    }
+    let out = std::env::temp_dir().join(format!("rhwp-argval-split-{}.hwp", std::process::id()));
+    let bad = run_cli(&[
+        "extract-pages",
+        src.to_str().unwrap(),
+        out.to_str().unwrap(),
+        "--from",
+        "0",
+        "--to",
+        "1",
+        "--json",
+    ]);
+    assert_ne!(bad.status.code(), Some(0), "0 기준 호출은 거부돼야 합니다");
+    let good = run_cli(&[
+        "extract-pages",
+        src.to_str().unwrap(),
+        out.to_str().unwrap(),
+        "--from",
+        "1",
+        "--to",
+        "1",
+        "--json",
+    ]);
+    assert_eq!(good.status.code(), Some(0), "선언 최솟값은 통해야 합니다");
+    let _ = std::fs::remove_file(&out);
+}


### PR DESCRIPTION
## 요약

MCP 인자 검증 결함 3건입니다. 공통점은 **조용히 틀린 답을 성공으로 돌려준다**는 것 — 호출자는 `isError` 도 경고도 못 받아 오타를 알아챌 방법이 없습니다.

### ① 강제변환이 "생략"과 "형식 오류"를 같은 `None` 으로 뭉갠다

```
hwp_doc_text {"docId":"doc-1","page": 0}      → isError=false, 1쪽        (정상)
hwp_doc_text {"docId":"doc-1","page": -1}     → isError=false, 16쪽 전체  ← 오타가 "생략"이 됨
hwp_doc_text {"docId":"doc-1","page": 2.5}    → isError=false, 16쪽 전체
hwp_doc_text {"docId":"doc-1","page": "3"}    → isError=false, 16쪽 전체

hwp_doc_search {... "caseSensitive": "false"} → isError=false, 봉투는 caseSensitive:true
hwp_doc_set_cell {"table":-1,"row":0,"col":0} → "table/row/col 이 필요합니다"  ← 셋 다 보냈는데
hwp_doc_set_cell {... "keepStyle": "true"}    → isError=false 로 통과 후 검정 정규화
```

한 쪽만 달라던 요청이 문서 전체를 받아 컨텍스트가 터지고, 축을 끄라고 보낸 요청이 켜진 채 실행됩니다. **치환 쪽은 문서가 바뀌는 축**이라 되돌릴 수 없습니다 — `caseSensitive` 오타로 대상 집합이 달라진 채 IR 에 누적되고 `hwp_doc_save` 가 그대로 디스크에 굳힙니다. `keepStyle` 오타는 "스타일 상속 유지" 요청을 조용히 검정 정규화로 되돌려 셀 서식을 지웁니다.

### ② `hwp_split_document` 선언이 0 기준인데 실행은 1 기준

```
선언:  "from": { "minimum": 0, "description": "시작 쪽 (0 기준, 포함)" }
실행:  extract-pages --from 0 --to 1  →  쪽 범위가 잘못됐습니다: 0..1 (1 기준, from <= to)   exit 1
```

**선언된 최솟값이 100% 실패하는 값**입니다. 선언만 읽고 호출을 조립하는 에이전트는 첫 호출에서 exit 1 을 밟고, 1 을 넣으면 이번엔 조용히 한 쪽씩 어긋납니다.

### ③ `hwp_search` 검색어가 위치 argv 라 '-' 로 시작하면 플래그로 먹힌다

```
query:"-i"   → exit 2  사용법: rhwp search ...
query:"-표"  → exit 2  알 수 없는 옵션: -표

# CLI 직접 호출은 더 나쁩니다 — exit 0 으로 오답을 정답처럼 돌려줍니다:
rhwp search doc.hwp "-i" "The" --json  →  {"caseSensitive":false,"query":"The",...}
rhwp search doc.hwp "The" --json       →  {"caseSensitive":true, "query":"The",...}   (대조군)
```

스키마는 `minLength:1` 문자열이면 무엇이든 약속하는데, 하이픈으로 시작하는 검색어는 **아예 검색할 수 없습니다.**

## 수정

- **`opt_u64`/`opt_bool`/`req_u64` 공통 계약** — 있는데 틀린 값은 어느 인자가 왜 틀렸는지 지목하며 거부하고, `null` 만 "생략"으로 관용합니다(다수 MCP 호스트가 미지정 선택 인자를 `null` 로 직렬화하므로, 이를 오류로 만들면 멀쩡한 호출이 깨집니다). 정수는 `3.0` 처럼 소수부 없는 음이 아닌 값까지 받습니다 — 파이썬 계열 호스트가 정수를 그렇게 보내고 JSON Schema 도 integer 로 인정합니다.
- **선언을 실행에 맞춥니다**(`minimum: 1`, `1 기준`). 출시된 CLI 동작을 건드리지 않는 가장 싼 봉합입니다. 다만 세션 도구(`hwp_doc_text`·`hwp_doc_render_page`)의 `page` 는 0 기준이라 **MCP 표면이 혼합 기수**가 됩니다 — 고칠 수 없는 사실이므로 설명에 명시해 에이전트가 섞지 않게 했습니다.
- **`search` 파서에 POSIX `--` 종결자** + 템플릿을 `["search","{path}","--json","--","{query}"]` 로. `--` 뒤는 전부 위치 인자이므로 **`--json` 은 반드시 구분자 앞**입니다(뒤에 두면 세 번째 위치 인자가 되어 "인자가 너무 많습니다").

## AFTER

```
page:-1                     → isError:true  "page 는 0 이상의 정수여야 합니다 (받은 값: -1)"
caseSensitive:"false"       → isError:true  "caseSensitive 는 true 또는 false 여야 합니다 (받은 값: \"false\")"
hwp_search query:"-i"       → isError:false, query="-i", caseSensitive=true
search --json --ignore-case -- "The"  → query="The", caseSensitive=false   (종결자 앞 옵션은 그대로 옵션)
```

## 검증

- `cargo test --test mcp_arg_validation_contract` — **9/9** (신설)
- 인접 계약 `mcp_server`·`mcp_session_query`·`mcp_session_setcell`·`mcp_session_view`·`search_json`·`split_document_tool` — 32/32 무회귀
- `cargo clippy --profile release-test --bin rhwp` — 경고 0 / `cargo fmt --check` — 통과

## 비호환 주의

지금까지 오타를 조용히 무시하던 호출은 이제 `isError` 를 받습니다 — 그것이 이 PR 의 목적입니다. 유효한 입력의 동작은 그대로이고, 기존 `set_cell_rejects_numeric_indices_before_narrowing`(row 65536 → u16 안내)도 통과합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
