### PR TITLE
fix(mcp): hwp_doc_set_cell 이 CLI 가 거부하는 개행·탭을 통과시켜 셀에 raw 개행을 박는다

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10330,6 +10330,24 @@ fn estimate_text_width_px(
         .sum()
 }
 
+/// [#3603] `set-cell` 계열이 셀 값으로 거부하는 제어문자 안내문.
+///
+/// CLI(`edit set-cell`)와 세션 도구(`hwp_doc_set_cell`)가 **같은 문장**으로 거부해야 한다 —
+/// 두 경로가 서로 다른 문장(또는 한쪽만 검사)을 내면 에이전트는 같은 제약을 두 번 배워야
+/// 하고, 무엇보다 세션 경로만 통과시키면 한 셀 문단 안에 raw 개행이 박힌 문서가 만들어진다.
+/// v1 셀 기록 계약은 '한 줄 값'이다.
+const SET_CELL_CONTROL_CHAR_MESSAGE: &str =
+    "오류: --text 에 줄바꿈·탭은 넣을 수 없습니다 (한 줄 값 기록).";
+
+/// 셀 값에 제어문자가 있으면 공통 안내문을 돌려준다 (없으면 `None`).
+///
+/// 문장뿐 아니라 **판정식까지** 공유해야 '문장은 같은데 거부 조건이 다른' 어긋남이 안 생긴다.
+fn set_cell_control_char_rejection(text: &str) -> Option<&'static str> {
+    text.chars()
+        .any(|ch| matches!(ch, '\r' | '\n' | '\t'))
+        .then_some(SET_CELL_CONTROL_CHAR_MESSAGE)
+}
+
 /// [#3603] 격자 주소(export-tables 좌표) → 모델 좌표 해석.
 /// CLI(edit set-cell)와 세션 도구(hwp_doc_set_cell)가 공유한다 — 병합으로 덮인 칸은
 /// 앵커 좌표를 안내하며 실패한다(보호 동작). 반환: (sec, para, ctrl, cell_idx,
@@ -10515,8 +10533,9 @@ fn edit_set_cell(args: &[String]) -> i32 {
         );
         return EXIT_USAGE;
     };
-    if new_text.chars().any(|ch| matches!(ch, '\r' | '\n' | '\t')) {
-        eprintln!("오류: --text 에 줄바꿈·탭은 넣을 수 없습니다 (한 줄 값 기록).");
+    // 판정과 문장 모두 세션 도구(hwp_doc_set_cell)와 공유한다 — 문서를 읽기 전에 끊는다.
+    if let Some(message) = set_cell_control_char_rejection(new_text) {
+        eprintln!("{message}");
         return EXIT_USAGE;
     }
 

--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -702,6 +702,12 @@ fn session_set_cell(args: &serde_json::Value, sessions: &mut Sessions) -> serde_
     let Some(doc_id) = args.get("docId").and_then(|d| d.as_str()) else {
         return tool_error("docId 가 필요합니다".into());
     };
+    // [#3603] 필수 인자가 모두 갖춰진 뒤, 핸들을 건드리기 전에 거부한다 — 무상태 CLI 는
+    // 파일을 읽기도 전에 EXIT_USAGE 로 끊는다. 여기만 통과시키면 셀 문단 하나에 raw 개행이
+    // 박힌 채 IR 에 누적되고, 그 핸들은 hwp_close 전까지 되돌릴 방법이 없다.
+    if let Some(message) = crate::set_cell_control_char_rejection(&new_text) {
+        return tool_error(message.to_string());
+    }
     let id = doc_id.to_string();
     let Some(sd) = sessions.docs.get_mut(&id) else {
         return tool_error(format!("열려 있지 않은 핸들: {id} (hwp_open 먼저)"));
@@ -729,6 +735,9 @@ fn session_set_cell(args: &serde_json::Value, sessions: &mut Sessions) -> serde_
         |(cell_w, text_w, lines)| {
             serde_json::json!({
                 "target": format!("table{}[{},{}]", table_no, row, col),
+                // CLI 의 overflow 항목과 키 집합을 맞춘다 — 넘친 값이 무엇이었는지 없으면
+                // 여러 칸을 연달아 채운 에이전트가 어느 값이 넘쳤는지 되짚을 수 없다.
+                "text": new_text,
                 "cellWidthPx": (cell_w * 100.0).round() / 100.0,
                 "textWidthPx": (text_w * 100.0).round() / 100.0,
                 "lines": lines,
@@ -776,6 +785,9 @@ fn session_set_cell(args: &serde_json::Value, sessions: &mut Sessions) -> serde_
             "table": table_no, "row": row, "col": col,
             "oldText": old_text,
             "newText": new_text,
+            // CLI 봉투와 같은 키 — 검정 정규화를 건너뛰었는지는 제출 서식에서 결과가
+            // 달라지는 판단 재료라, 무엇이 적용됐는지 봉투만 보고 알 수 있어야 한다.
+            "keepStyle": keep_style,
             "overflow": overflow.map(|o| vec![o]).unwrap_or_default(),
         })
         .to_string(),

--- a/tests/mcp_session_setcell_contract.rs
+++ b/tests/mcp_session_setcell_contract.rs
@@ -230,3 +230,147 @@ fn set_cell_rejects_numeric_indices_before_narrowing() {
         "범위 안내가 있어야 합니다: {value}"
     );
 }
+
+/// [#3603] 세션 도구는 CLI 와 **같은 문장으로** 제어문자를 거부한다.
+///
+/// 종전에는 세션 경로만 통과시켜, 한 셀 문단 안에 raw 개행이 들어간 채 IR 에 누적됐다
+/// (저장본을 다시 읽어야 겨우 드러난다). 거부 문장은 테스트가 따로 적어 두지 않고 CLI 를
+/// 실제로 돌려 얻는다 — 문자열을 두 벌 관리하면 그 자체가 다음 어긋남의 씨앗이다.
+#[test]
+fn set_cell_rejects_control_chars_with_cli_message() {
+    let src = sample();
+    if !src.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let cli_out = temp_path("ctrlchar-cli");
+    let cli = run_cli(&[
+        "edit",
+        "set-cell",
+        src.to_str().unwrap(),
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "가\n나",
+        "-o",
+        cli_out.to_str().unwrap(),
+        "--json",
+    ]);
+    assert_eq!(
+        cli.status.code(),
+        Some(2),
+        "CLI 는 EXIT_USAGE(2) 로 끊습니다"
+    );
+    assert!(!cli_out.exists(), "거부된 편집은 파일을 만들지 않습니다");
+    let cli_message = String::from_utf8_lossy(&cli.stderr).trim().to_string();
+    assert!(!cli_message.is_empty(), "CLI 안내문이 비어 있습니다");
+
+    let mut s = Server::started();
+    let d = s.open(&src);
+    let (err, before) = s.call("hwp_doc_tables", serde_json::json!({"docId": d}));
+    assert!(!err, "{before}");
+
+    for bad in ["가\n나", "가\t나", "가\r나", "줄1\r\n줄2"] {
+        let (err, v) = s.call(
+            "hwp_doc_set_cell",
+            serde_json::json!({"docId": d, "table": 0, "row": 0, "col": 0, "text": bad}),
+        );
+        assert!(err, "{bad:?} 는 isError 여야 합니다: {v}");
+        assert_eq!(
+            v.as_str().unwrap_or_default(),
+            cli_message,
+            "{bad:?}: CLI 와 같은 문장으로 거부해야 합니다"
+        );
+    }
+
+    // 거부는 핸들을 건드리기 전에 끝난다 — 격자가 한 글자도 달라지면 안 된다.
+    let (err, after) = s.call("hwp_doc_tables", serde_json::json!({"docId": d}));
+    assert!(!err, "{after}");
+    assert_eq!(before, after, "거부된 편집이 핸들 IR 을 바꿨습니다");
+}
+
+/// 봉투 키가 무상태 `edit set-cell --json` 과 같다.
+///
+/// overflow 에서 `text` 가 빠지면 여러 칸을 연달아 채운 에이전트가 '어느 값이 넘쳤는지'
+/// 를 되짚을 수 없고, `keepStyle` 이 빠지면 검정 정규화가 걸렸는지 봉투만으로 못 읽는다.
+#[test]
+fn set_cell_envelope_carries_keep_style_and_overflow_text() {
+    let src = sample();
+    if !src.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let mut s = Server::started();
+    let d = s.open(&src);
+
+    let (err, v) = s.call(
+        "hwp_doc_set_cell",
+        serde_json::json!({
+            "docId": d, "table": 0, "row": 0, "col": 0, "text": "봉투대조", "keepStyle": true
+        }),
+    );
+    assert!(!err, "{v}");
+    assert_eq!(
+        v["keepStyle"],
+        serde_json::json!(true),
+        "요청한 keepStyle 이 봉투에 그대로 실려야 합니다: {v}"
+    );
+
+    // 기본값(미지정)도 봉투에 실린다 — 무엇이 적용됐는지 늘 알 수 있어야 한다.
+    let (err, d2) = s.call(
+        "hwp_doc_set_cell",
+        serde_json::json!({"docId": d, "table": 0, "row": 0, "col": 0, "text": "기본"}),
+    );
+    assert!(!err, "{d2}");
+    assert_eq!(v["keepStyle"].is_boolean(), true, "{v}");
+    assert_eq!(d2["keepStyle"], serde_json::json!(false), "{d2}");
+
+    // 넘치는 값을 넣어 overflow 를 강제하고 CLI 와 키 집합을 대조한다.
+    let long = "가나다라마바사아자차카타파하".repeat(4);
+    let cli = run_cli(&[
+        "edit",
+        "set-cell",
+        src.to_str().unwrap(),
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        &long,
+        "--dry-run",
+        "--json",
+    ]);
+    assert_eq!(
+        cli.status.code(),
+        Some(0),
+        "{}",
+        String::from_utf8_lossy(&cli.stderr)
+    );
+    let cv: serde_json::Value = serde_json::from_slice(&cli.stdout).expect("edit set-cell --json");
+    let cli_overflow = cv["overflow"].as_array().expect("overflow").clone();
+    if cli_overflow.is_empty() {
+        eprintln!("이 샘플에서는 넘침이 나지 않음 — 키 대조 건너뜀");
+        return;
+    }
+
+    let (err, ov) = s.call(
+        "hwp_doc_set_cell",
+        serde_json::json!({"docId": d, "table": 0, "row": 0, "col": 0, "text": long}),
+    );
+    assert!(!err, "{ov}");
+    let sess_overflow = ov["overflow"].as_array().expect("overflow");
+    assert_eq!(sess_overflow.len(), cli_overflow.len(), "{ov}");
+    let cli_keys: Vec<&String> = cli_overflow[0].as_object().expect("obj").keys().collect();
+    let sess_keys: Vec<&String> = sess_overflow[0].as_object().expect("obj").keys().collect();
+    assert_eq!(
+        sess_keys, cli_keys,
+        "overflow 항목 키 집합이 CLI 와 같아야 합니다: {ov}"
+    );
+    assert_eq!(sess_overflow[0]["text"], serde_json::json!(long), "{ov}");
+}


### PR DESCRIPTION
## 요약

`src/mcp_serve.rs` 는 세션 도구가 무상태 CLI twin 과 **동형**임을 명시적으로 약속합니다. `hwp_doc_set_cell` 축에서 그 약속이 세 갈래로 깨져 있었습니다.

### ① 제어문자 — CLI 는 거부하는데 세션은 통과시킨다

```
$ rhwp edit set-cell samples/table-001.hwp --table 0 --row 0 --col 0 --text $'가\n나' --json
exit 2
오류: --text 에 줄바꿈·탭은 넣을 수 없습니다 (한 줄 값 기록).
(출력 파일 생성 안 됨)

# 같은 입력, 세션 도구
hwp_doc_set_cell {"docId":"doc-1","table":0,"row":0,"col":0,"text":"가\n나"}
  isError=false
  {"newText":"가\n나","oldText":"구 분",...}

# 저장본 되읽기 (export-tables)
cell(0,0) text = '가\n나'      ← raw 개행이 한 셀 문단에 박힌 채 저장됨
```

CLI 가 이 가드를 두는 이유는 코어의 다문자 셀 편집이 `\r \n \t` 를 계약 밖으로 두기 때문입니다. 세션만 통과시키면 계약 밖 IR 이 만들어지고, 그 핸들은 `hwp_close` 전까지 되돌릴 방법이 없습니다.

### ② overflow 항목에 `text` 키가 없다

```
CLI  overflow[0] keys = ['cellWidthPx', 'lines', 'target', 'text', 'textWidthPx']
세션 overflow[0] keys = ['cellWidthPx', 'lines', 'target',         'textWidthPx']
```

숫자 부분은 바이트까지 같고 `text` 만 빠져 있었습니다. 여러 칸을 연달아 채운 에이전트가 **어느 값이 넘쳤는지** 되짚을 수 없습니다.

### ③ 봉투에 `keepStyle` 이 없다

```
CLI  봉투 keys = [..., 'dryRun', 'keepStyle', 'newText', ...]
세션 봉투 keys = ['col','docId','newText','oldText','overflow','row','schemaVersion','table']
```

검정 정규화를 건너뛰었는지는 제출 서식에서 결과가 달라지는 판단 재료인데, 봉투만 보고는 알 수 없었습니다.

## 수정

핵심은 **문장이 아니라 판정식까지 공유**하는 것입니다. 문장만 상수로 빼면 "문구는 같은데 거부 조건이 다른" 어긋남이 그대로 남습니다.

```rust
const SET_CELL_CONTROL_CHAR_MESSAGE: &str =
    "오류: --text 에 줄바꿈·탭은 넣을 수 없습니다 (한 줄 값 기록).";

fn set_cell_control_char_rejection(text: &str) -> Option<&'static str> { … }
```

CLI 와 세션이 이 함수 하나를 부릅니다. 세션은 **필수 인자 검증 뒤·핸들 접근 전**에 거부해 CLI 와 같은 지점(문서를 읽기 전)에서 끊습니다. 더불어 overflow 에 `text`, 봉투에 `keepStyle` 을 더했습니다.

## AFTER

```
세션 hwp_doc_set_cell text="가\n나"
  isError=true  "오류: --text 에 줄바꿈·탭은 넣을 수 없습니다 (한 줄 값 기록)."
CLI  edit set-cell --text $'가\n나'
  exit 2        "오류: --text 에 줄바꿈·탭은 넣을 수 없습니다 (한 줄 값 기록)."   ← 글자 그대로 동일

세션 봉투 키 = ['col','docId','keepStyle','newText','oldText','overflow','row','schemaVersion','table']
```

## 회귀 가드 2종

- `set_cell_rejects_control_chars_with_cli_message` — 거부 문장을 테스트가 따로 적어 두지 않고 **CLI 를 실제로 돌려 얻어** 대조합니다. 문자열을 두 벌 관리하면 그 자체가 다음 어긋남의 씨앗입니다. 4종(`\n`·`\t`·`\r`·`\r\n`)을 모두 보고, 거부 전후 `hwp_doc_tables` 결과가 한 글자도 달라지지 않았는지까지 확인합니다 — 거부가 핸들을 건드리기 전에 끝나야 하기 때문입니다.
- `set_cell_envelope_carries_keep_style_and_overflow_text` — `keepStyle` 은 지정값·기본값 둘 다 봉투에 실리는지, overflow 는 CLI 와 **키 집합이 같은지** 대조합니다.

## 검증

- `cargo test --test mcp_session_setcell_contract` — **6/6** (신규 2종 포함)
- `edit_set_cell_contract` 5/5 · `mcp_session_edit_contract` 5/5 — 무회귀
- `cargo clippy --profile release-test --bin rhwp` — 경고 0 / `cargo fmt --check` — 통과

## 같은 감사의 나머지 (별도 PR)

`hwp_doc_save` 가 출력 확장자를 무시해 `.hwp` 안에 ZIP(PK) 바이트를 쓰는 건과, HWP3 출처 저장이 살아 있는 IR 을 바꾸는 건이 남아 있습니다. **후자가 먼저 들어가야 합니다** — 전자를 고치면 HWPX 핸들이 새로 어댑터 경로를 타게 되어 후자의 영향 범위가 넓어집니다. 순서를 지켜 따로 올리겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
