### PR TITLE
fix(mcp): hwp_doc_save 가 열린 핸들의 IR 을 바꾼다 — 저장 한 번에 본문 16줄 소실

### DIFF
--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -1163,6 +1163,25 @@ impl DocumentCore {
         self.export_hwp_native()
     }
 
+    /// 어댑터를 **복제본에 적용해** HWP5 를 낸다 — 호출자의 IR 은 그대로다.
+    ///
+    /// `export_hwp_with_adapter` 는 살아 있는 IR 을 직접 정규화한다. 저장 직후 종료하는
+    /// CLI 에서는 관측되지 않지만, 저장 뒤에도 계속 쓰이는 핸들(MCP 세션)에서는 저장이
+    /// 문서를 바꿔 버린다. 특히 어댑터는 `Hwpx | Hwp3` 양쪽에서 돌면서 각 구역 첫 문단의
+    /// `controls[0]` 에 `Control::SectionDef` 를 끼워 넣는데, 같은 문단의
+    /// `field_ranges[].control_idx` 는 밀어 주지 않는다 — 저장 한 번에 누름틀이 가리키는
+    /// 컨트롤이 한 칸씩 어긋난다. 저장은 스냅숏이어야 하므로 복제본에만 어댑터를 태운다.
+    ///
+    /// 비용은 `Document` 1회 clone 이다. 그 값을 치를 이유가 없는 CLI 경로는
+    /// `export_hwp_with_adapter` 를 계속 쓴다.
+    pub fn export_hwp_with_adapter_snapshot(&self) -> Result<Vec<u8>, HwpError> {
+        use crate::document_core::converters::hwpx_to_hwp::convert_if_hwpx_source;
+        let mut snapshot = self.document.clone();
+        let _report = convert_if_hwpx_source(&mut snapshot, self.source_format);
+        crate::serializer::serialize_document(&snapshot)
+            .map_err(|e| HwpError::RenderError(e.to_string()))
+    }
+
     /// HWPX 출처 어댑터를 적용한 뒤 HWP5 EncryptVersion 4 비밀번호 문서로 저장한다.
     ///
     /// 일반 HWP 저장과 마찬가지로 HWPX 출처는 반드시 adapter를 먼저 통과한다. 암호화만

--- a/src/main.rs
+++ b/src/main.rs
@@ -9724,6 +9724,23 @@ fn edit_serialize(
     .map_err(|e| e.to_string())
 }
 
+/// `edit_serialize` 와 같은 바이트를 내되 **IR 을 건드리지 않는다**.
+///
+/// 무상태 CLI 는 저장 직후 프로세스가 끝나므로 어댑터가 살아 있는 IR 을 정규화해도
+/// 관측되지 않는다. 세션 핸들은 다르다 — 도구 계약이 "핸들은 저장 후에도 열려 있다"
+/// 이므로 저장은 스냅숏이어야 한다. 그래서 세션 경로만 이쪽을 쓰고 CLI 의 `&mut`
+/// 경로는 그대로 둔다(CLI 에 문서 1회 clone 비용을 지우지 않는다).
+fn edit_serialize_snapshot(
+    doc: &rhwp::wasm_api::HwpDocument,
+    format: EditOutputFormat,
+) -> Result<Vec<u8>, String> {
+    match format {
+        EditOutputFormat::Hwpx => doc.export_hwpx_native(),
+        EditOutputFormat::Hwp => doc.export_hwp_with_adapter_snapshot(),
+    }
+    .map_err(|e| e.to_string())
+}
+
 /// `edit fill-fields` — 누름틀에 값을 채운다 (메일머지).
 ///
 /// 검증된 코어 경로(`set_field_value_by_name`)를 재사용하므로 새 편집 로직이 없다.

--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -868,7 +868,9 @@ fn session_save(args: &serde_json::Value, sessions: &mut Sessions) -> serde_json
     let Some(output) = args.get("output").and_then(|o| o.as_str()) else {
         return tool_error("output 이 필요합니다".into());
     };
-    let Some(sd) = sessions.docs.get_mut(doc_id) else {
+    // 저장은 스냅숏이다 — `get_mut` 이 아니라 `get` 으로 잡아 "save 는 핸들의 IR 을
+    // 바꾸지 않는다"는 계약을 컴파일러가 지키게 한다.
+    let Some(sd) = sessions.docs.get(doc_id) else {
         return tool_error(format!("열려 있지 않은 핸들: {doc_id} (hwp_open 먼저)"));
     };
 
@@ -877,7 +879,10 @@ fn session_save(args: &serde_json::Value, sessions: &mut Sessions) -> serde_json
     } else {
         crate::EditOutputFormat::Hwp
     };
-    let bytes = match crate::edit_serialize(&mut sd.doc, format) {
+    // HWP5 산출 경로의 어댑터(`convert_if_hwpx_source`)는 `Hwpx | Hwp3` 양쪽에서 돌며
+    // 살아 있는 IR 을 제자리에서 고친다. 도구 계약이 "핸들은 저장 후에도 열려 있다"
+    // 이므로 세션은 복제본에 어댑터를 태우는 스냅숏 경로를 쓴다.
+    let bytes = match crate::edit_serialize_snapshot(&sd.doc, format) {
         Ok(b) => b,
         Err(e) => return tool_error(format!("직렬화 실패: {e}")),
     };

--- a/tests/mcp_session_edit_contract.rs
+++ b/tests/mcp_session_edit_contract.rs
@@ -281,3 +281,65 @@ fn session_edit_tools_are_listed() {
         assert!(names.contains(&t.to_string()), "{t} 누락: {names:?}");
     }
 }
+
+/// 저장은 **스냅숏**이다 — 도구 계약이 "핸들은 저장 후에도 열려 있다" 이므로,
+/// 저장 한 번이 살아 있는 IR 을 바꾸면 계약이 깨진다.
+///
+/// HWP5 산출 경로의 어댑터(`convert_if_hwpx_source`)는 `Hwpx | Hwp3` 양쪽에서 돌면서
+/// 각 구역 첫 문단 `controls[0]` 에 `Control::SectionDef` 를 끼워 넣는다. 그런데 같은
+/// 문단의 `field_ranges[].control_idx` 는 밀어 주지 않으므로, 저장 전에 잡아 둔 좌표가
+/// 저장 후 다른 컨트롤을 가리킨다. 실측(수정 전, samples/hwp3-sample.hwp): 저장 한 번에
+/// 본문이 21,538자 → 21,522자로 줄었다(빈 줄 16개 소실).
+#[test]
+fn session_save_does_not_mutate_live_handle_hwp3_source() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("samples/hwp3-sample.hwp");
+    if !src.exists() {
+        eprintln!("HWP3 샘플 없음 — 건너뜀");
+        return;
+    }
+    let mut s = Server::started();
+    let doc_id = s.open(&src);
+
+    let (err, before) = s.call("hwp_doc_text", serde_json::json!({"docId": doc_id}));
+    assert!(!err, "{before}");
+    let (err, info_before) = s.call("hwp_doc_info", serde_json::json!({"docId": doc_id}));
+    assert!(!err, "{info_before}");
+
+    let out = temp_path("hwp3snap", "hwp");
+    let (err, sv) = s.call(
+        "hwp_doc_save",
+        serde_json::json!({"docId": doc_id, "output": out.to_str().unwrap()}),
+    );
+    assert!(!err, "{sv}");
+    assert_eq!(sv["outputFormat"], "hwp5", "{sv}");
+
+    let (err, after) = s.call("hwp_doc_text", serde_json::json!({"docId": doc_id}));
+    assert!(!err, "{after}");
+    let (err, info_after) = s.call("hwp_doc_info", serde_json::json!({"docId": doc_id}));
+    assert!(!err, "{info_after}");
+    assert_eq!(before, after, "저장이 핸들의 본문을 바꿨습니다");
+    assert_eq!(info_before, info_after, "저장이 핸들의 메타를 바꿨습니다");
+
+    // 이어서 저장해도 같은 바이트여야 한다 — 1회차가 IR 을 바꿨다면 여기서 갈린다.
+    let out2 = temp_path("hwp3snap2", "hwp");
+    let (err, sv2) = s.call(
+        "hwp_doc_save",
+        serde_json::json!({"docId": doc_id, "output": out2.to_str().unwrap()}),
+    );
+    assert!(!err, "{sv2}");
+    assert_eq!(
+        std::fs::read(&out).expect("1차 산출물"),
+        std::fs::read(&out2).expect("2차 산출물"),
+        "연속 저장이 서로 다른 바이트를 냈습니다 — 저장이 상태를 남겼다는 뜻입니다"
+    );
+
+    // 저장 뒤에도 편집이 이어져야 한다 — '핸들은 계속 열려 있다' 의 실질 검증.
+    let (err, rep) = s.call(
+        "hwp_doc_replace_text",
+        serde_json::json!({"docId": doc_id, "find": "그림", "replace": "그림"}),
+    );
+    assert!(!err, "저장 후 편집이 실패했습니다: {rep}");
+
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&out2);
+}


### PR DESCRIPTION
## 요약

`hwp_doc_save` 는 도구 설명에서 **"핸들은 저장 후에도 열려 있다 — 이어서 편집·재저장할 수 있다"** 고 약속합니다. 그런데 저장이 살아 있는 IR 을 바꿉니다.

실측 (`samples/hwp3-sample.hwp`, `mcp-serve` stdio):

```
hwp_doc_text  (저장 전)  →  본문 21,538자
hwp_doc_save             →  {"bytes":64512,"outputFormat":"hwp5",...}
hwp_doc_text  (저장 후)  →  본문 21,522자      ← 빈 줄 16개 소실
hwp_doc_info             →  저장 전후 동일 (메타가 아니라 본문 IR 이 바뀐 것)
```

**저장이 편집이 됐습니다.** 에이전트가 저장 전에 잡아 둔 좌표는 저장 후 다른 것을 가리키고, 이어서 편집하면 그 위에 쌓입니다.

## 원인

`session_save` → `edit_serialize(&mut sd.doc, Hwp)` → `export_hwp_with_adapter(&mut self)` → `convert_if_hwpx_source(&mut self.document, …)`.

이 어댑터는 `FileFormat::Hwpx | FileFormat::Hwp3` **양쪽**에서 돕니다. HWP3 파서는 `Control::SectionDef` 를 아예 만들지 않으므로(`src/parser/hwp3/` 전체에 해당 생성이 0건), 어댑터의 `insert_section_def_control` 이 매 구역 첫 문단의 `controls[0]` 에 **삽입**합니다. 그런데 같은 문단의 `field_ranges[].control_idx` 는 따라 밀리지 않습니다 — 컨트롤 인덱스로 표현된 좌표가 저장 한 번에 한 칸씩 어긋납니다.

무상태 CLI 는 이 경로를 타도 무해합니다. 저장 직후 프로세스가 끝나 아무도 그 IR 을 다시 안 봅니다. **세션이 도입되면서 "저장 뒤에도 같은 인스턴스를 계속 쓴다"는 새 수명이 생겼는데, 어댑터는 그 수명을 모릅니다.**

## 수정

```rust
/// 어댑터를 **복제본에 적용해** HWP5 를 낸다 — 호출자의 IR 은 그대로다.
pub fn export_hwp_with_adapter_snapshot(&self) -> Result<Vec<u8>, HwpError>
```

- `&self` 입니다 — 시그니처가 계약을 표현합니다.
- `session_save` 는 핸들을 `get_mut` 이 아니라 **`get` 으로 잡습니다.** "save 는 IR 을 바꾸지 않는다"를 컴파일러가 지키게 하는 쪽이 주석보다 강합니다.
- **CLI 경로는 그대로 둡니다.** 저장 직후 종료하는 무상태 경로에 `Document` 1회 clone 비용을 지울 이유가 없습니다. 비용을 지는 쪽은 그 값을 실제로 쓰는 세션뿐입니다.
- HWPX 산출 경로(`export_hwpx_native`)는 이미 `&self` 라 그대로입니다.

## AFTER

```
저장 전 본문 길이: 21523 | 저장 후: 21523 | 동일? True
연속 저장 바이트 동일? True
```

## 회귀 가드

`session_save_does_not_mutate_live_handle_hwp3_source` — 네 축을 함께 봅니다.

1. 저장 전후 `hwp_doc_text` 가 같은가 (본문 IR)
2. 저장 전후 `hwp_doc_info` 가 같은가 (메타)
3. **연속 저장이 같은 바이트인가** — 1회차가 IR 을 바꿨다면 2회차 산출물이 갈립니다. 저장이 상태를 남기지 않는다는 것을 산출물로 직접 증명합니다.
4. 저장 뒤 편집이 이어지는가 — "핸들은 계속 열려 있다"의 실질 검증

## 검증

- `cargo test --test mcp_session_edit_contract` — **6/6** (신규 1종 포함)
- `hwpx_to_hwp_adapter` 7/7 · `mcp_session_setcell_contract` 50/50 · `edit_format_preserve_contract` 4/4 — 무회귀
- `cargo clippy --profile release-test --bin rhwp` — 경고 0 / `cargo fmt --check` — 통과

## 후속과 순서 (중요)

같은 감사에서 나온 **`hwp_doc_save` 가 출력 확장자를 무시하는 건**(HWPX 핸들을 `.hwp` 로 저장하면 ZIP(PK) 바이트가 `.hwp` 안에 들어감)이 남아 있습니다. **이 PR 이 먼저 들어가야 합니다** — 확장자 수정은 HWPX 세션 핸들을 어댑터 경로로 **새로 보내는** 변경이라, 지금 상태에서 그것만 먼저 넣으면 이 결함의 영향 범위가 "HWP3 출처만"에서 "`.hwp` 로 저장하는 모든 HWPX 핸들"로 넓어집니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
