### PR TITLE
feat(#3627): mcp-serve 에 MCP resources 표면 — 계약·지식지도·실패사전을 프로토콜 1홉으로

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -305,6 +305,14 @@ fn main() {
 /// 손으로 옮겨 적지 않게 한다. `--json` 계약을 가진 명령이 늘면
 /// `capabilities_mcp_covers_every_json_command` 가 누락을 잡는다.
 fn show_mcp_tools(profile: Option<&'static agent_profiles::AgentProfile>) -> i32 {
+    println!("{}", mcp_manifest_value(profile));
+    EXIT_OK
+}
+
+/// [#3627] 매니페스트 **값** — `capabilities --mcp` 의 stdout 과 `mcp-serve` 의
+/// `rhwp://capabilities/mcp` 리소스가 같은 함수를 쓴다. 프로필 필터가 두 곳에
+/// 복제되면 자기서술이 tools/list 에 없는 도구를 광고하게 된다.
+fn mcp_manifest_value(profile: Option<&'static agent_profiles::AgentProfile>) -> serde_json::Value {
     let mut tools = mcp_tool_definitions();
     if let Some(p) = profile {
         tools.retain(|t| {
@@ -315,7 +323,7 @@ fn show_mcp_tools(profile: Option<&'static agent_profiles::AgentProfile>) -> i32
         });
     }
 
-    let manifest = serde_json::json!({
+    serde_json::json!({
         "schemaVersion": "1.0",
         "protocol": "mcp",
         "server": {
@@ -337,9 +345,7 @@ fn show_mcp_tools(profile: Option<&'static agent_profiles::AgentProfile>) -> i32
             "recipe": p.recipe,
         })),
         "profiles": agent_profiles::names(),
-    });
-    println!("{manifest}");
-    EXIT_OK
+    })
 }
 
 /// [#3263→#3140] MCP 도구 정의의 단일 출처 — `capabilities --mcp`(선언 출력)와

--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -26,6 +26,8 @@ const PROTOCOL_VERSION: &str = "2025-06-18";
 const PARSE_ERROR: i64 = -32700;
 const METHOD_NOT_FOUND: i64 = -32601;
 const INVALID_PARAMS: i64 = -32602;
+/// [#3627] MCP resources 규약이 못박은 코드 — "Resource not found: -32002".
+const RESOURCE_NOT_FOUND: i64 = -32002;
 
 /// 열린 문서 핸들 하나 — 편집·저장의 형식 보존(#3383)을 위해 원본 형식을 기억한다.
 struct SessionDoc {
@@ -135,7 +137,9 @@ pub fn run(args: &[String]) -> i32 {
                     "protocolVersion": params.get("protocolVersion")
                         .and_then(|v| v.as_str())
                         .unwrap_or(PROTOCOL_VERSION),
-                    "capabilities": { "tools": {} },
+                    // [#3627] subscribe/listChanged 는 아직 없다 — 스펙상 빈 객체가
+                    // "두 기능 모두 미지원" 의 정식 선언이다(생략이 아니라).
+                    "capabilities": { "tools": {}, "resources": {} },
                     "serverInfo": {
                         "name": "rhwp",
                         "version": rhwp::version(),
@@ -155,6 +159,15 @@ pub fn run(args: &[String]) -> i32 {
                     Err(e) => error_response(id, INVALID_PARAMS, &e),
                 }
             }
+            "resources/list" => {
+                ok_response(id, serde_json::json!({ "resources": served_resources() }))
+            }
+            "resources/read" => match read_resource(&params, profile) {
+                Ok(result) => ok_response(id, result),
+                Err((code, message, uri)) => {
+                    resource_error_response(id, code, &message, uri.as_deref())
+                }
+            },
             other => error_response(
                 id,
                 METHOD_NOT_FOUND,
@@ -182,6 +195,136 @@ fn error_response(id: serde_json::Value, code: i64, message: &str) -> serde_json
         "jsonrpc": "2.0", "id": id,
         "error": { "code": code, "message": message }
     })
+}
+
+// ── [#3627] resources 표면 ─────────────────────────────────────────────────
+
+/// 서버가 내는 문서 리소스 하나. 필드 이름은 MCP `resources/list` 의 Resource
+/// 객체(uri/name/title/description/mimeType)와 1:1 로 대응한다.
+struct DocResource {
+    uri: &'static str,
+    name: &'static str,
+    title: &'static str,
+    description: &'static str,
+    mime_type: &'static str,
+    text: &'static str,
+}
+
+/// 프로필과 무관하게 항상 노출되는 자기서술 매니페스트의 URI.
+const CAPABILITIES_URI: &str = "rhwp://capabilities/mcp";
+
+/// [#3627] 저장소의 canonical 문서를 `include_str!` 로 **컴파일 시점에** 안는다.
+///
+/// rhwp 는 단일 실행 파일로 배포된다 — 저장소 밖에 설치된 exe 옆에는 `mydocs/` 가
+/// 없으므로 런타임 디스크 읽기는 정작 리소스가 필요한 설치 환경에서 그대로 실패한다
+/// (개발 트리에서만 되는 리소스는 계약이 아니다). 원본 파일을 그대로 가리키므로
+/// 복제본은 생기지 않고(문서를 고치면 다음 빌드가 따라온다), 템플릿 XML 을
+/// `include_str!` 로 안는 `serializer::hwpx::static_assets` 선례와 같은 방식이다.
+///
+/// URI 는 커스텀 `rhwp://` 스킴이다. 본문이 바이너리 안에 있으므로 `file://` 은
+/// 설치본에 존재하지 않는 경로를 광고하게 되고, `https://` 는 스펙상 클라이언트가
+/// 직접 가져올 수 있을 때만 쓴다.
+const DOC_RESOURCES: &[DocResource] = &[
+    DocResource {
+        uri: "rhwp://docs/llms.txt",
+        name: "llms.txt",
+        title: "rhwp 문서 지도 (llms.txt)",
+        description: "에이전트 진입점 — 계약·실무·문제 해결 문서로 가는 링크 목록.",
+        mime_type: "text/plain",
+        text: include_str!("../llms.txt"),
+    },
+    DocResource {
+        uri: "rhwp://docs/agent_knowledge_map.md",
+        name: "agent_knowledge_map.md",
+        title: "에이전트 지식 지도",
+        description: "작업별 명령 결정 표·봉투 필드 사전·주소 어휘. 첫 문서로 읽는다.",
+        mime_type: "text/markdown",
+        text: include_str!("../mydocs/manual/agent_knowledge_map.md"),
+    },
+    DocResource {
+        uri: "rhwp://docs/agent_troubleshooting_guide.md",
+        name: "agent_troubleshooting_guide.md",
+        title: "에이전트 실패 사전",
+        description: "오류 문자열 그대로 검색되는 증상별 원인·처방.",
+        mime_type: "text/markdown",
+        text: include_str!("../mydocs/manual/agent_troubleshooting_guide.md"),
+    },
+];
+
+/// resources/list 응답 본문.
+///
+/// 프로필은 리소스 **목록**을 필터하지 않는다 — 지식 지도·실패 사전은 특정 도구의
+/// 사용설명서가 아니라 봉투 어휘·판정 규칙 같은 전 표면 공통 문서라, 가리면 그
+/// 프로필이 실제로 가진 도구를 쓰는 능력만 깎인다. 대신 계약 문서인 매니페스트는
+/// **내용**이 프로필로 렌더된다(read_resource) — tools/list 에 없는 도구를
+/// 자기서술이 광고하면 에이전트가 "알 수 없는 도구" 를 밟는다.
+fn served_resources() -> Vec<serde_json::Value> {
+    let mut resources = vec![serde_json::json!({
+        "uri": CAPABILITIES_URI,
+        "name": "capabilities-mcp",
+        "title": "rhwp MCP 자기서술 매니페스트",
+        "description": "이 서버가 제공하는 도구의 이름·설명·입력 스키마·CLI 배선. \
+                        --profile 로 띄운 서버는 tools/list 와 같은 필터된 목록을 낸다.",
+        "mimeType": "application/json",
+    })];
+    resources.extend(DOC_RESOURCES.iter().map(|r| {
+        serde_json::json!({
+            "uri": r.uri,
+            "name": r.name,
+            "title": r.title,
+            "description": r.description,
+            "mimeType": r.mime_type,
+            "size": r.text.len(),
+        })
+    }));
+    resources
+}
+
+/// resources/read 본체. Err 는 (코드, 메시지, uri) — 미지의 URI 는 스펙이 정한
+/// -32002, 잘못된 요청 구조는 -32602 로 가른다.
+fn read_resource(
+    params: &serde_json::Value,
+    profile: Option<&'static crate::agent_profiles::AgentProfile>,
+) -> Result<serde_json::Value, (i64, String, Option<String>)> {
+    let Some(uri) = params.get("uri").and_then(|u| u.as_str()) else {
+        return Err((INVALID_PARAMS, "params.uri 가 필요합니다".into(), None));
+    };
+    let (mime_type, text) = if uri == CAPABILITIES_URI {
+        // 단일 출처: `capabilities --mcp` 의 stdout 과 같은 함수가 낸 값이다.
+        (
+            "application/json",
+            crate::mcp_manifest_value(profile).to_string(),
+        )
+    } else {
+        match DOC_RESOURCES.iter().find(|r| r.uri == uri) {
+            Some(r) => (r.mime_type, r.text.to_string()),
+            None => {
+                return Err((
+                    RESOURCE_NOT_FOUND,
+                    format!("알 수 없는 리소스: {uri}"),
+                    Some(uri.to_string()),
+                ))
+            }
+        }
+    };
+    // contents 는 배열이다 — 한 URI 가 여러 조각을 낼 수 있다는 스펙 형태를 지킨다.
+    Ok(serde_json::json!({
+        "contents": [{ "uri": uri, "mimeType": mime_type, "text": text }]
+    }))
+}
+
+/// 리소스 오류는 스펙 예시대로 `data.uri` 로 어떤 URI 가 문제였는지 되돌려준다.
+fn resource_error_response(
+    id: serde_json::Value,
+    code: i64,
+    message: &str,
+    uri: Option<&str>,
+) -> serde_json::Value {
+    let mut response = error_response(id, code, message);
+    if let Some(uri) = uri {
+        response["error"]["data"] = serde_json::json!({ "uri": uri });
+    }
+    response
 }
 
 /// tools/list 응답: 선언 도구(MCP 필수 3종만 노출) + 세션 도구 3종.

--- a/tests/mcp_server_contract.rs
+++ b/tests/mcp_server_contract.rs
@@ -257,3 +257,133 @@ fn unknown_tool_returns_is_error() {
     );
     assert_eq!(r["result"]["isError"], true, "{r}");
 }
+
+// ── [#3627] resources 표면 ─────────────────────────────────────────────────
+
+/// `resources/list` 는 자기서술 매니페스트 1종 + canonical 문서 3종을 낸다.
+#[test]
+fn resources_list_declares_manifest_and_docs() {
+    let mut s = Server::started();
+    let r = s.request("resources/list", serde_json::json!({}));
+    let resources = r["result"]["resources"]
+        .as_array()
+        .unwrap_or_else(|| panic!("resources/list 응답에 resources 배열이 없습니다: {r}"));
+    let uris: Vec<&str> = resources
+        .iter()
+        .map(|x| x["uri"].as_str().unwrap_or_default())
+        .collect();
+    for expected in [
+        "rhwp://capabilities/mcp",
+        "rhwp://docs/llms.txt",
+        "rhwp://docs/agent_knowledge_map.md",
+        "rhwp://docs/agent_troubleshooting_guide.md",
+    ] {
+        assert!(uris.contains(&expected), "{expected} 가 없습니다: {uris:?}");
+    }
+    // MCP 필수 필드 — 빠지면 호스트가 리소스 목록을 그리지 못한다.
+    for x in resources {
+        assert!(x["name"].is_string(), "{x}");
+        assert!(x["mimeType"].is_string(), "{x}");
+    }
+}
+
+/// initialize 가 resources capability 를 선언해야 한다 — 선언이 없으면 호스트는
+/// `resources/list` 를 아예 부르지 않는다. 스펙상 빈 객체가 "subscribe·listChanged
+/// 둘 다 미지원" 의 정식 선언이다(생략이 아니라).
+#[test]
+fn initialize_declares_resources_capability() {
+    let mut s = Server::start();
+    let r = s.request(
+        "initialize",
+        serde_json::json!({
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "contract-test", "version": "0"}
+        }),
+    );
+    assert!(
+        r["result"]["capabilities"]["resources"].is_object(),
+        "resources capability 선언이 없습니다: {r}"
+    );
+}
+
+/// 복제 금지 가드 — 리소스 본문은 저장소의 canonical 문서와 **바이트 동일**해야 한다.
+/// `include_str!` 로 원본을 그대로 가리키므로 복제본이 생기면 여기서 갈린다.
+#[test]
+fn resources_read_serves_canonical_docs() {
+    let mut s = Server::started();
+    let r = s.request(
+        "resources/read",
+        serde_json::json!({"uri": "rhwp://docs/agent_troubleshooting_guide.md"}),
+    );
+    let c = &r["result"]["contents"][0];
+    assert_eq!(
+        c["uri"], "rhwp://docs/agent_troubleshooting_guide.md",
+        "contents[].uri 는 요청 URI 와 같아야 합니다: {r}"
+    );
+    assert_eq!(c["mimeType"], "text/markdown", "{r}");
+    let text = c["text"]
+        .as_str()
+        .unwrap_or_else(|| panic!("contents[].text 가 없습니다: {r}"));
+    let on_disk = std::fs::read_to_string(sample("mydocs/manual/agent_troubleshooting_guide.md"))
+        .expect("실패 사전 문서 읽기 실패");
+    assert_eq!(
+        text, on_disk,
+        "리소스 본문이 저장소 canonical 문서와 다릅니다 — 복제본이 생겼습니다"
+    );
+}
+
+/// 프로필 정합 — 자기서술 매니페스트가 tools/list 에 없는 도구를 광고하면 에이전트가
+/// "알 수 없는 도구" 를 밟는다. 두 표면은 같은 단일 출처를 써야 한다.
+#[test]
+fn resources_read_capabilities_matches_tools_list() {
+    let mut s = Server::started();
+    let served: Vec<String> = s.request("tools/list", serde_json::json!({}))["result"]["tools"]
+        .as_array()
+        .expect("tools 배열")
+        .iter()
+        .map(|t| t["name"].as_str().unwrap_or_default().to_string())
+        .collect();
+
+    let r = s.request(
+        "resources/read",
+        serde_json::json!({"uri": "rhwp://capabilities/mcp"}),
+    );
+    let c = &r["result"]["contents"][0];
+    assert_eq!(c["mimeType"], "application/json", "{r}");
+    let manifest: serde_json::Value = serde_json::from_str(
+        c["text"]
+            .as_str()
+            .unwrap_or_else(|| panic!("contents[].text 가 없습니다: {r}")),
+    )
+    .expect("매니페스트가 JSON 이 아닙니다");
+    for t in manifest["tools"].as_array().expect("tools 배열") {
+        let name = t["name"].as_str().unwrap_or_default().to_string();
+        assert!(
+            served.contains(&name),
+            "매니페스트가 광고한 {name} 이 tools/list 에 없습니다: {served:?}"
+        );
+    }
+}
+
+/// 없는 리소스는 스펙이 정한 -32002 와 `data.uri` 로 답한다.
+#[test]
+fn resources_read_unknown_uri_returns_resource_not_found() {
+    let mut s = Server::started();
+    let r = s.request(
+        "resources/read",
+        serde_json::json!({"uri": "rhwp://docs/no_such_doc.md"}),
+    );
+    assert_eq!(
+        r["error"]["code"], -32002,
+        "알 수 없는 리소스는 -32002: {r}"
+    );
+    assert_eq!(
+        r["error"]["data"]["uri"], "rhwp://docs/no_such_doc.md",
+        "error.data.uri 로 문제의 URI 를 돌려줘야 합니다: {r}"
+    );
+
+    // uri 자체가 없으면 요청 구조 오류다 — 리소스 부재와 구분한다.
+    let r = s.request("resources/read", serde_json::json!({}));
+    assert_eq!(r["error"]["code"], -32602, "{r}");
+}


### PR DESCRIPTION
Closes #3627 의 첫 조각 (#3608 M16).

## 왜

에이전트가 rhwp 의 계약을 알려면 지금은 저장소 문서를 몇 홉 탐색해야 합니다. MCP 에는 이걸 위한 표면이 이미 있는데(`resources`) rhwp 는 `tools` 만 열어 뒀습니다. 이 PR 은 그 표면을 열어 **프로토콜 1홉**으로 줄입니다.

```
resources/list  →  rhwp://capabilities/mcp                        (자기서술 매니페스트)
                   rhwp://docs/llms.txt                           (문서 지도)
                   rhwp://docs/agent_knowledge_map.md             (지식 지도)
                   rhwp://docs/agent_troubleshooting_guide.md     (실패 사전)
```

## 실측

```
capabilities: {"resources": {}, "tools": {}}
resources: ['rhwp://capabilities/mcp', 'rhwp://docs/llms.txt',
            'rhwp://docs/agent_knowledge_map.md', 'rhwp://docs/agent_troubleshooting_guide.md']
매니페스트 도구 수: 23
미지 URI: -32002 | data.uri: rhwp://docs/no_such.md
```

## 설계 판단 3가지

**① URI 는 커스텀 `rhwp://` 스킴.** 본문이 바이너리 안에 있으므로 `file://` 은 설치본에 **존재하지 않는 경로**를 광고하게 됩니다. `https://` 는 스펙이 "클라이언트가 직접 가져올 수 있을 때만" 쓰라고 못박습니다. 스펙은 커스텀 스킴을 명시적으로 허용하고(RFC3986 준수 조건), `rhwp://capabilities/mcp`·`rhwp://docs/<파일>` 이 그 조건을 만족합니다.

**② 문서는 `include_str!` 로 컴파일 시점에 안습니다.** rhwp 는 단일 exe 로 배포됩니다 — 저장소 밖에 설치된 exe 옆에는 `mydocs/` 가 없으므로 **런타임 디스크 읽기는 정작 리소스가 필요한 설치 환경에서 그대로 실패**합니다. 개발 트리에서만 되는 리소스는 계약이 아닙니다. 원본 파일을 그대로 가리키므로 복제본은 생기지 않고(문서를 고치면 다음 빌드가 따라옵니다), 템플릿 XML 을 `include_str!` 로 안는 `serializer::hwpx::static_assets` 선례와 같은 방식입니다. 실측 비용: 바이너리 17,340,928 → **17,363,968 바이트 (+23KB, 0.13%)**.

**③ 프로필은 리소스 목록을 필터하지 않되, 매니페스트 내용은 필터합니다.** 지식 지도·실패 사전은 특정 도구의 사용설명서가 아니라 봉투 어휘·판정 규칙 같은 **전 표면 공통 문서**입니다 — 가리면 그 프로필이 실제로 가진 도구를 쓰는 능력만 깎입니다. 반대로 매니페스트는 **계약 문서**라, `--profile 경영보고` 로 띄운 서버가 `tools/list` 에서 뺀 `hwp_fill_fields` 를 자기서술로 광고하면 에이전트가 "알 수 없는 도구" 를 밟습니다. 그래서 `show_mcp_tools` 에서 `mcp_manifest_value()` 를 갈라내 **`capabilities --mcp` 와 단일 출처를 공유**하게 했습니다 — 필터가 두 곳에 복제되지 않습니다.

## 회귀 가드 5종

- `initialize_declares_resources_capability` — 선언이 없으면 호스트는 `resources/list` 를 아예 부르지 않습니다. 스펙상 빈 객체가 "subscribe·listChanged 둘 다 미지원"의 정식 선언입니다(생략이 아니라).
- `resources_list_declares_manifest_and_docs` — 4종 존재 + MCP 필수 필드
- **`resources_read_serves_canonical_docs`** — 리소스 본문이 저장소 문서와 **바이트 동일**한지. 복제본이 생기면 여기서 갈립니다.
- **`resources_read_capabilities_matches_tools_list`** — 매니페스트가 광고한 도구 ⊆ `tools/list`. 프로필 정합의 핵심.
- `resources_read_unknown_uri_returns_resource_not_found` — 미지 URI 는 `-32002` + `error.data.uri`, `uri` 자체 누락은 `-32602` (리소스 부재와 요청 구조 오류를 가릅니다)

## 검증

- `cargo test --test mcp_server_contract` — **11/11** (신규 5종 포함)
- `cli_json_contract` 5/5 · `agent_profile_router_contract` 22/22 — 무회귀
- `cargo clippy --profile release-test --bin rhwp` — 경고 0 / `cargo fmt --check` — 통과

## 의도적으로 남긴 것

- `resources/templates/list`·`subscribe`·`listChanged` — 전부 스펙상 선택이고, 빈 `"resources": {}` 가 미지원을 정확히 선언하므로 미구현이 규약 위반이 아닙니다. 템플릿은 임의 `mydocs/` 경로를 서빙하게 되는 순간 훨씬 큰 보안 표면(스펙의 "Servers MUST validate all resource URIs")이 됩니다.
- 페이지네이션 — 고정 4건이라 `nextCursor` 가 없습니다. 목록이 늘면 필요합니다.
- `prompts` 템플릿 2종(#3627 본문) — `prompts/list`·`prompts/get` 과 별도 capability 를 가진 **세 번째 프로토콜 표면**이라 diff 가 두 배가 됩니다. 후속으로 뺐습니다.
- `mydocs/manual/` 전체 — 임베드하면 바이너리가 문서 번들이 됩니다. `llms.txt` 자신이 진입점으로 지정한 3종만 골랐습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
