### PR TITLE
fix(cli): gen-pua 가 조사 목적 호출에 원본을 덮어쓴다 + 종료 코드 계약 위반 3건

### DIFF
--- a/src/diagnostics/render_geom_diff.rs
+++ b/src/diagnostics/render_geom_diff.rs
@@ -816,8 +816,11 @@ fn run_single(opts: &CliOptions) -> i32 {
         {
             Ok(c) => c,
             Err(e) => {
+                // 읽기·파싱 실패는 런타임 오류(1)다. 2는 인자 개수/형식이 틀린
+                // 사용법 오류 전용 — 계약(cli_commands.md 종료 코드 표)상 스크립트가
+                // "내 호출이 틀렸다"로 오독해 재시도 대신 인자를 고치려 든다.
                 eprintln!("오류: A 로드 실패 {}: {e}", a.display());
-                return 2;
+                return 1;
             }
         };
         let core_b = match fs::read(b)
@@ -826,8 +829,9 @@ fn run_single(opts: &CliOptions) -> i32 {
         {
             Ok(c) => c,
             Err(e) => {
+                // 읽기·파싱 실패는 런타임 오류(1).
                 eprintln!("오류: B 로드 실패 {}: {e}", b.display());
-                return 2;
+                return 1;
             }
         };
         match diff_render_geometry(&core_a, &core_b) {
@@ -843,8 +847,9 @@ fn run_single(opts: &CliOptions) -> i32 {
         let data = match fs::read(f) {
             Ok(d) => d,
             Err(e) => {
+                // 읽기 실패는 런타임 오류(1). 이 갈래도 같은 부류였다.
                 eprintln!("오류: 파일 읽기 실패 {}: {e}", f.display());
-                return 2;
+                return 1;
             }
         };
         match roundtrip_geom(&data, opts.via) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -272,8 +272,8 @@ fn main() {
         Some("test-shape") => test_shape_roundtrip(&args[2..]),
         Some("test-caption") => exit_with(test_caption(&args[2..])),
         Some("gen-table") => gen_table(&args[2..]),
-        Some("gen-pua") => gen_pua_test(&args[2..]),
-        Some("test-field") => test_field_roundtrip(&args[2..]),
+        Some("gen-pua") => exit_with(gen_pua_test(&args[2..])),
+        Some("test-field") => exit_with(test_field_roundtrip(&args[2..])),
         Some("ir-diff") => exit_with(ir_diff(&args[2..])),
         Some("hwpx-roundtrip") => rhwp::diagnostics::hwpx_roundtrip_batch::run(&args[2..]),
         Some("hwp5-roundtrip") => rhwp::diagnostics::hwp5_roundtrip_batch::run(&args[2..]),
@@ -8462,11 +8462,21 @@ fn gen_table(args: &[String]) {
 /// 사용:
 ///   rhwp gen-pua [output_path]
 ///   기본 출력: output/pua-test.hwp
-fn gen_pua_test(args: &[String]) {
-    let output = args
-        .first()
-        .map(|s| s.as_str())
-        .unwrap_or("output/pua-test.hwp");
+fn gen_pua_test(args: &[String]) -> i32 {
+    // gen-pua 의 positional 은 입력이 아니라 **출력** 경로다. capabilities 가 다른
+    // 진단 명령과 나란히 노출하는 탓에 `rhwp gen-pua 문서.hwp` 를 "이 파일을 조사"로
+    // 읽은 호출이 실제로 원본을 말없이 덮어썼다(#3691 조사 중 발생). 사용자가 명시한
+    // 경로가 이미 있으면 거부한다 — 기본 경로는 재생성 대상이라 검사에서 제외한다.
+    let explicit = args.first().map(|s| s.as_str());
+    if let Some(path) = explicit {
+        if Path::new(path).exists() {
+            eprintln!("오류: gen-pua 의 인자는 생성할 **출력** 경로입니다 (입력 파일이 아닙니다).");
+            eprintln!("      이미 존재하는 파일을 덮어쓰지 않습니다: {}", path);
+            eprintln!("사용법: rhwp gen-pua [출력경로]   # 기본 output/pua-test.hwp");
+            return EXIT_USAGE;
+        }
+    }
+    let output = explicit.unwrap_or("output/pua-test.hwp");
 
     println!("PUA 문자 셋트 입력 HWP 문서 생성 중...");
 
@@ -8541,27 +8551,50 @@ fn gen_pua_test(args: &[String]) {
     if let Some(parent) = out_path.parent() {
         fs::create_dir_all(parent).ok();
     }
-    fs::write(out_path, bytes).expect("파일 저장 실패");
+    if let Err(e) = fs::write(out_path, bytes) {
+        // 종료 코드 계약: 쓰기 실패는 런타임 오류(1)다. 종전에는 .expect() 로 패닉해
+        // 계약에 없는 101 로 끝났다.
+        eprintln!("오류: 파일 저장 실패 - {}: {}", output, e);
+        return EXIT_RUNTIME;
+    }
     println!("저장 완료: {} ({} 종 PUA)", output, pua_set.len());
     println!();
     println!("다음 단계:");
     println!("  1. 한컴 2022 편집기에서 본 파일 열기 → PDF 출력 (정답지)");
     println!("  2. rhwp export-svg {} → SVG 출력 비교", output);
     println!("  3. 시각 비교로 매핑 정합 확정");
+    EXIT_OK
 }
 
-fn test_field_roundtrip(args: &[String]) {
-    let input = args
-        .first()
-        .map(|s| s.as_str())
-        .unwrap_or("hwp_webctl/bsbc01_10_000.hwp");
+fn test_field_roundtrip(args: &[String]) -> i32 {
+    // 인자를 생략하면 저장소에 없는 하드코딩 경로("hwp_webctl/bsbc01_10_000.hwp")를
+    // `.expect()` 로 읽어 패닉(exit 101)했다 — 계약(cli_commands.md)에 없는 종료 코드라
+    // CI 게이트가 분류할 수 없다. 형제 명령 test-caption 과 같은 모양으로 맞춘다
+    // (tests/issue_cli_test_caption_no_panic.rs 가 그쪽을 이미 고정하고 있다).
+    if args.is_empty() {
+        eprintln!("사용법: rhwp test-field <파일.hwp> [출력.hwp]");
+        return EXIT_USAGE;
+    }
+    let input = args[0].as_str();
     let output = args
         .get(1)
         .map(|s| s.as_str())
         .unwrap_or("output/field_test.hwp");
 
-    let data = std::fs::read(input).expect("파일 읽기 실패");
-    let mut core = rhwp::document_core::DocumentCore::from_bytes(&data).expect("문서 파싱 실패");
+    let data = match std::fs::read(input) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: 파일 읽기 실패 - {}: {}", input, e);
+            return EXIT_RUNTIME;
+        }
+    };
+    let mut core = match rhwp::document_core::DocumentCore::from_bytes(&data) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("오류: 문서 파싱 실패 - {}: {:?}", input, e);
+            return EXIT_RUNTIME;
+        }
+    };
 
     // 1. 필드 목록 출력
     let fields = core.collect_all_fields();
@@ -8604,18 +8637,34 @@ fn test_field_roundtrip(args: &[String]) {
     let para0 = &core.document().sections[0].paragraphs[0];
 
     // 4. 직렬화 → 저장
-    let saved = core.export_hwp_native().expect("직렬화 실패");
-    std::fs::write(output, &saved).expect("저장 실패");
+    let saved = match core.export_hwp_native() {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("오류: 직렬화 실패 - {:?}", e);
+            return EXIT_RUNTIME;
+        }
+    };
+    if let Err(e) = std::fs::write(output, &saved) {
+        eprintln!("오류: 저장 실패 - {}: {}", output, e);
+        return EXIT_RUNTIME;
+    }
     println!("\n저장: {} ({}바이트)", output, saved.len());
 
     // 5. 재로딩 → 필드 확인
-    let mut core2 = rhwp::document_core::DocumentCore::from_bytes(&saved).expect("재로딩 실패");
+    let mut core2 = match rhwp::document_core::DocumentCore::from_bytes(&saved) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("오류: 재로딩 실패 - {:?}", e);
+            return EXIT_RUNTIME;
+        }
+    };
     let fields3 = core2.collect_all_fields();
     println!("\n=== 재로딩 후 확인 ===");
     for fi in &fields3 {
         let name = fi.field.field_name().unwrap_or("(이름없음)");
         println!("  {} = \"{}\"", name, fi.value);
     }
+    EXIT_OK
 }
 
 fn control_tag(c: &rhwp::model::control::Control) -> &'static str {

--- a/tests/cli_exit_codes_diagnostic_commands.rs
+++ b/tests/cli_exit_codes_diagnostic_commands.rs
@@ -127,3 +127,73 @@ fn successful_diagnostic_commands_return_zero() {
 fn rhwp_bin() -> String {
     std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
 }
+
+/// `render-diff` 는 읽기·파싱 실패를 런타임 오류(1)로 보고해야 한다.
+///
+/// 종전에는 세 갈래(A 로드·B 로드·자기 라운드트립 읽기)가 모두 2를 냈다. 계약상 2는
+/// **인자 개수/형식이 틀린 사용법 오류** 전용이라, 재시도 래퍼가 "입력 파일이 없다"를
+/// "내 호출이 틀렸다"로 오독해 인자를 고치려 든다 — 고칠 게 없는데.
+#[test]
+fn render_diff_separates_runtime_failure_from_usage_error() {
+    // 읽기 실패 = 1 (두 파일 형태, 한 파일 형태 모두)
+    assert_code(&["render-diff", "없는A.hwp", "없는B.hwp"], 1);
+    assert_code(&["render-diff", "없는하나.hwp"], 1);
+    // 인자 개수가 틀린 것은 여전히 2 — 이쪽을 1로 바꾸면 안 된다.
+    assert_code(&["render-diff"], 2);
+}
+
+/// `test-field` 는 패닉(101)이 아니라 계약 코드로 끝나야 한다.
+///
+/// 종전에는 인자를 생략하면 저장소에 없는 하드코딩 경로를 `.expect()` 로 읽어
+/// exit 101 이었다 — 계약(0/1/2/3/4)에 없는 코드라 CI 게이트가 분류할 수 없다.
+/// 형제 명령 `test-caption` 은 이미 같은 계약을 지키고 있다.
+#[test]
+fn test_field_reports_contract_codes_instead_of_panicking() {
+    let no_args = assert_code(&["test-field"], 2);
+    assert!(
+        !String::from_utf8_lossy(&no_args.stderr).contains("panicked"),
+        "패닉 흔적이 남아 있습니다: {}",
+        describe(&["test-field"], &no_args)
+    );
+    let missing = assert_code(&["test-field", "없는파일-testfield.hwp"], 1);
+    assert!(
+        !String::from_utf8_lossy(&missing.stderr).contains("panicked"),
+        "패닉 흔적이 남아 있습니다: {}",
+        describe(&["test-field", "없는파일-testfield.hwp"], &missing)
+    );
+}
+
+/// `gen-pua` 의 positional 은 **출력** 경로다 — 기존 파일을 덮어쓰지 않는다.
+///
+/// capabilities 가 다른 진단 명령과 나란히 노출하는 탓에 `rhwp gen-pua 문서.hwp` 를
+/// "이 문서를 조사"로 읽은 호출이 실제로 원본을 말없이 덮어썼다(조사 중 발생). 조사
+/// 목적 호출이 데이터를 파괴하면 안 되므로, 사용자가 명시한 경로가 이미 있으면 거부한다.
+#[test]
+fn gen_pua_refuses_to_overwrite_an_existing_file() {
+    let victim = std::env::temp_dir().join(format!(
+        "rhwp-genpua-victim-{}-{}.hwp",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos()
+    ));
+    let original = b"NOT-A-REAL-HWP-BUT-MUST-SURVIVE".to_vec();
+    std::fs::write(&victim, &original).expect("피해자 파일 생성");
+
+    let args = ["gen-pua", victim.to_str().unwrap()];
+    let output = assert_code(&args, 2);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("출력"),
+        "인자가 출력 경로임을 밝혀야 합니다: {}",
+        describe(&args, &output)
+    );
+
+    let after = std::fs::read(&victim).expect("피해자 파일 재독");
+    assert_eq!(
+        after, original,
+        "gen-pua 가 기존 파일을 덮어썼습니다 — 조사 목적 호출이 데이터를 파괴합니다"
+    );
+    let _ = std::fs::remove_file(&victim);
+}


### PR DESCRIPTION
## 요약

`cli_commands.md` 의 종료 코드 계약(0 성공 / 1 런타임 / 2 사용법 / 3·4 판정)을 진단 명령 3종이 어기고 있었습니다. 그중 하나는 **조사 목적 호출이 원본 문서를 파괴**합니다.

## ① `gen-pua` 가 원본을 말없이 덮어쓴다 ★

`gen-pua` 의 positional 인자는 **출력** 경로입니다. 그런데 `capabilities` 가 다른 진단 명령(전부 입력 파일을 받습니다)과 나란히 노출하는 탓에, `rhwp gen-pua 문서.hwp` 를 "이 문서를 조사하라"로 읽는 것이 자연스럽습니다. 그러면 원본이 사라집니다.

이건 가정이 아니라 **이번 조사 중 실제로 일어난 일**입니다. 전 명령을 `does-not-exist.hwp` 인자로 스윕하던 중 `gen-pua` 가 그 경로에 진짜 15,360바이트 HWP 5.1 문서를 만들었고, 뒤이어 `export-hwpx`/`export-doclang` 이 그걸 읽어 `.hwpx`·`.dclg.xml` 까지 만들었으며, "읽을 수 없는 입력" 을 확인하던 20여 개 프로브의 판정이 1에서 0으로 뒤집혔습니다.

```
$ ls does-not-exist.hwp        →  No such file
$ rhwp gen-pua does-not-exist.hwp
저장 완료: does-not-exist.hwp (18 종 PUA)      exit 0
$ rhwp info does-not-exist.hwp
파일: does-not-exist.hwp / 크기: 15360 bytes / 버전: 5.1.0.1
```

## ② `test-field` 가 패닉해 exit 101 로 끝난다

```
$ rhwp test-field
thread 'main' panicked at src\main.rs:8579:37:
파일 읽기 실패: Os { code: 3, kind: NotFound }
exit 101
```

인자를 생략하면 저장소에 없는 하드코딩 경로(`hwp_webctl/bsbc01_10_000.hwp`)를 `.expect()` 로 읽습니다. **101 은 계약에 없는 코드**라 `$?` 를 읽는 CI 게이트가 분류할 수 없습니다. 형제 명령 `test-caption` 은 이미 이 계약을 지키고 있고 `tests/issue_cli_test_caption_no_panic.rs` 가 고정하고 있는데, 이쪽만 빠져 있었습니다.

## ③ `render-diff` 가 읽기 실패에 2를 낸다

```
$ rhwp render-diff 없는A.hwp 없는B.hwp
오류: A 로드 실패 없는A.hwp: 지정된 파일을 찾을 수 없습니다.
exit 2      ← 계약상 1
```

세 갈래(A 로드·B 로드·자기 라운드트립 읽기) 모두 2였습니다. 2는 **인자 개수/형식이 틀린 사용법 오류** 전용이라, 재시도 래퍼가 "입력 파일이 없다"를 "내 호출이 틀렸다"로 오독해 고칠 게 없는 인자를 고치려 듭니다.

## AFTER

```
gen-pua 기존파일    : exit=2  (원본 514,560바이트 그대로 보존 확인)
test-field 인자없음 : exit=2  (종전 101)
test-field 없는파일 : exit=1  (종전 101)
render-diff 읽기실패: exit=1  (종전 2)
render-diff 인자없음: exit=2  (유지 — 이쪽을 1로 바꾸면 안 된다)
```

## 회귀 가드 3종

- `gen_pua_refuses_to_overwrite_an_existing_file` — 피해자 파일을 만들고 호출한 뒤 **바이트가 그대로인지** 확인합니다. 종료 코드만 보면 "거부했다고 말하면서 덮어쓰는" 회귀를 놓칩니다.
- `test_field_reports_contract_codes_instead_of_panicking` — 코드뿐 아니라 stderr 에 `panicked` 흔적이 없는지도 봅니다.
- `render_diff_separates_runtime_failure_from_usage_error` — 읽기 실패 1과 인자 오류 2를 **양쪽 다** 고정합니다. 한쪽만 보면 전부 1로 바꾸는 과잉 교정이 통과합니다.

## 검증

- `cargo test --test cli_exit_codes_diagnostic_commands` — **8/8** (신규 3종 포함)
- `cli_json_contract` 22/22 · `issue_cli_test_caption_no_panic` 1/1 — 무회귀
- `cargo clippy --profile release-test --bin rhwp` — 경고 0 / `cargo fmt --check` — 통과

## 같은 계열의 나머지 (별도 PR)

진단 명령 14종(`core-pages`·`measure-width`·`bench`·`test-shape`·`gen-table`·`hwp5-*` 11종)이 같은 뿌리로 실패에도 exit 0 을 냅니다 — 진입점이 `run(&[String]) -> ()` 라 `main` 의 `exit_with` 를 못 탑니다. 게다가 `hwp5-*` 는 사용법 안내를 stdout 으로 내보내 JSONL 데이터와 섞습니다. 17파일 규모라 이번 PR 과 섞지 않고 따로 올리겠습니다 — 이번 3종은 **데이터 파괴와 계약 밖 종료 코드**라 먼저 끊는 것이 맞다고 판단했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
