### PR TITLE
fix(cli): hwp5-* 프로브 8종이 실패에도 exit 0 — 종료 코드 계약 배선 + stdout 오염 제거

### DIFF
--- a/src/diagnostics/hwp5_borderfill_diagonal_probe.rs
+++ b/src/diagnostics/hwp5_borderfill_diagonal_probe.rs
@@ -79,10 +79,17 @@ struct BorderFillView {
     hash: String,
 }
 
-pub fn run(args: &[String]) {
-    if args.is_empty() || matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
+pub fn run(args: &[String]) -> i32 {
+    // 종료 코드 계약(mydocs/manual/cli_commands.md): 명시적 `--help` 만 성공(0)이고,
+    // 인자 누락·파싱 실패는 사용법 오류(2), 실행 실패는 런타임 오류(1)다. 종전에는
+    // 반환형이 `()` 라 main 의 exit_with 를 통과하지 못해 무슨 일이 나든 0으로 끝났다.
+    if matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
         print_usage();
-        return;
+        return super::EXIT_OK;
+    }
+    if args.is_empty() {
+        print_usage();
+        return super::EXIT_USAGE;
     }
 
     let options = match parse_args(args) {
@@ -90,13 +97,15 @@ pub fn run(args: &[String]) {
         Err(message) => {
             eprintln!("{message}");
             print_usage();
-            return;
+            return super::EXIT_USAGE;
         }
     };
 
     if let Err(error) = run_inner(options) {
         eprintln!("오류: {error}");
+        return super::EXIT_RUNTIME;
     }
+    super::EXIT_OK
 }
 
 fn parse_args(args: &[String]) -> Result<Options, String> {
@@ -135,8 +144,12 @@ fn parse_args(args: &[String]) -> Result<Options, String> {
 }
 
 fn print_usage() {
-    println!("사용법:");
-    println!("  rhwp hwp5-borderfill-diagonal-probe <oracle.hwp> <generated.hwp> --out-dir <폴더>");
+    // 안내는 stderr 로 나간다(계약). stdout 은 프로브 데이터 전용이라
+    // 섞이면 JSONL 을 파이프로 받는 소비자가 파싱에서 깨진다.
+    eprintln!("사용법:");
+    eprintln!(
+        "  rhwp hwp5-borderfill-diagonal-probe <oracle.hwp> <generated.hwp> --out-dir <폴더>"
+    );
 }
 
 fn run_inner(options: Options) -> Result<(), String> {

--- a/src/diagnostics/hwp5_cell_header_probe.rs
+++ b/src/diagnostics/hwp5_cell_header_probe.rs
@@ -135,10 +135,17 @@ struct ScopeIndices {
     all_table_blocks: usize,
 }
 
-pub fn run(args: &[String]) {
-    if args.is_empty() || matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
+pub fn run(args: &[String]) -> i32 {
+    // 종료 코드 계약(mydocs/manual/cli_commands.md): 명시적 `--help` 만 성공(0)이고,
+    // 인자 누락·파싱 실패는 사용법 오류(2), 실행 실패는 런타임 오류(1)다. 종전에는
+    // 반환형이 `()` 라 main 의 exit_with 를 통과하지 못해 무슨 일이 나든 0으로 끝났다.
+    if matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
         print_usage();
-        return;
+        return super::EXIT_OK;
+    }
+    if args.is_empty() {
+        print_usage();
+        return super::EXIT_USAGE;
     }
 
     let options = match parse_args(args) {
@@ -146,13 +153,15 @@ pub fn run(args: &[String]) {
         Err(message) => {
             eprintln!("{message}");
             print_usage();
-            return;
+            return super::EXIT_USAGE;
         }
     };
 
     if let Err(error) = run_inner(options) {
         eprintln!("오류: {error}");
+        return super::EXIT_RUNTIME;
     }
+    super::EXIT_OK
 }
 
 fn parse_args(args: &[String]) -> Result<Options, String> {
@@ -204,8 +213,10 @@ fn parse_args(args: &[String]) -> Result<Options, String> {
 }
 
 fn print_usage() {
-    println!("사용법:");
-    println!(
+    // 안내는 stderr 로 나간다(계약). stdout 은 프로브 데이터 전용이라
+    // 섞이면 JSONL 을 파이프로 받는 소비자가 파싱에서 깨진다.
+    eprintln!("사용법:");
+    eprintln!(
         "  rhwp hwp5-cell-header-probe <oracle.hwp> <generated.hwp> --out-dir <폴더> [--section N]"
     );
 }

--- a/src/diagnostics/hwp5_contract_analyze.rs
+++ b/src/diagnostics/hwp5_contract_analyze.rs
@@ -63,10 +63,17 @@ struct ControlSummary {
     scope_path: String,
 }
 
-pub fn run(args: &[String]) {
-    if args.is_empty() || matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
+pub fn run(args: &[String]) -> i32 {
+    // 종료 코드 계약(mydocs/manual/cli_commands.md): 명시적 `--help` 만 성공(0)이고,
+    // 인자 누락·파싱 실패는 사용법 오류(2), 실행 실패는 런타임 오류(1)다. 종전에는
+    // 반환형이 `()` 라 main 의 exit_with 를 통과하지 못해 무슨 일이 나든 0으로 끝났다.
+    if matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
         print_usage();
-        return;
+        return super::EXIT_OK;
+    }
+    if args.is_empty() {
+        print_usage();
+        return super::EXIT_USAGE;
     }
 
     let options = match parse_args(args) {
@@ -74,13 +81,15 @@ pub fn run(args: &[String]) {
         Err(message) => {
             eprintln!("{message}");
             print_usage();
-            return;
+            return super::EXIT_USAGE;
         }
     };
 
     if let Err(error) = run_inner(options) {
         eprintln!("오류: {error}");
+        return super::EXIT_RUNTIME;
     }
+    super::EXIT_OK
 }
 
 fn parse_args(args: &[String]) -> Result<Options, String> {
@@ -133,8 +142,10 @@ fn parse_args(args: &[String]) -> Result<Options, String> {
 }
 
 fn print_usage() {
-    println!("사용법:");
-    println!(
+    // 안내는 stderr 로 나간다(계약). stdout 은 프로브 데이터 전용이라
+    // 섞이면 JSONL 을 파이프로 받는 소비자가 파싱에서 깨진다.
+    eprintln!("사용법:");
+    eprintln!(
         "  rhwp hwp5-contract-analyze <source.hwpx> <oracle.hwp> <generated.hwp> --out-dir <폴더> [--section N]"
     );
 }

--- a/src/diagnostics/hwp5_contract_probe.rs
+++ b/src/diagnostics/hwp5_contract_probe.rs
@@ -75,10 +75,17 @@ struct RecordMeta {
     data_offset: usize,
 }
 
-pub fn run(args: &[String]) {
-    if args.is_empty() || matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
+pub fn run(args: &[String]) -> i32 {
+    // 종료 코드 계약(mydocs/manual/cli_commands.md): 명시적 `--help` 만 성공(0)이고,
+    // 인자 누락·파싱 실패는 사용법 오류(2), 실행 실패는 런타임 오류(1)다. 종전에는
+    // 반환형이 `()` 라 main 의 exit_with 를 통과하지 못해 무슨 일이 나든 0으로 끝났다.
+    if matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
         print_usage();
-        return;
+        return super::EXIT_OK;
+    }
+    if args.is_empty() {
+        print_usage();
+        return super::EXIT_USAGE;
     }
 
     let options = match parse_args(args) {
@@ -86,13 +93,15 @@ pub fn run(args: &[String]) {
         Err(message) => {
             eprintln!("{message}");
             print_usage();
-            return;
+            return super::EXIT_USAGE;
         }
     };
 
     if let Err(error) = run_inner(options) {
         eprintln!("오류: {error}");
+        return super::EXIT_RUNTIME;
     }
+    super::EXIT_OK
 }
 
 fn parse_args(args: &[String]) -> Result<Options, String> {
@@ -144,8 +153,10 @@ fn parse_args(args: &[String]) -> Result<Options, String> {
 }
 
 fn print_usage() {
-    println!("사용법:");
-    println!(
+    // 안내는 stderr 로 나간다(계약). stdout 은 프로브 데이터 전용이라
+    // 섞이면 JSONL 을 파이프로 받는 소비자가 파싱에서 깨진다.
+    eprintln!("사용법:");
+    eprintln!(
         "  rhwp hwp5-contract-probe <oracle.hwp> <generated.hwp> --out-dir <폴더> [--section N]"
     );
 }

--- a/src/diagnostics/hwp5_ctrl_data_trace.rs
+++ b/src/diagnostics/hwp5_ctrl_data_trace.rs
@@ -19,10 +19,17 @@ struct Options {
     record_index: Option<usize>,
 }
 
-pub fn run(args: &[String]) {
-    if args.is_empty() || matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
+pub fn run(args: &[String]) -> i32 {
+    // 종료 코드 계약(mydocs/manual/cli_commands.md): 명시적 `--help` 만 성공(0)이고,
+    // 인자 누락·파싱 실패는 사용법 오류(2), 실행 실패는 런타임 오류(1)다. 종전에는
+    // 반환형이 `()` 라 main 의 exit_with 를 통과하지 못해 무슨 일이 나든 0으로 끝났다.
+    if matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
         print_usage();
-        return;
+        return super::EXIT_OK;
+    }
+    if args.is_empty() {
+        print_usage();
+        return super::EXIT_USAGE;
     }
 
     let options = match parse_args(args) {
@@ -30,13 +37,15 @@ pub fn run(args: &[String]) {
         Err(message) => {
             eprintln!("{message}");
             print_usage();
-            return;
+            return super::EXIT_USAGE;
         }
     };
 
     if let Err(error) = run_inner(options) {
         eprintln!("오류: {error}");
+        return super::EXIT_RUNTIME;
     }
+    super::EXIT_OK
 }
 
 fn parse_args(args: &[String]) -> Result<Options, String> {
@@ -101,8 +110,10 @@ fn parse_args(args: &[String]) -> Result<Options, String> {
 }
 
 fn print_usage() {
-    println!("사용법:");
-    println!(
+    // 안내는 stderr 로 나간다(계약). stdout 은 프로브 데이터 전용이라
+    // 섞이면 JSONL 을 파이프로 받는 소비자가 파싱에서 깨진다.
+    eprintln!("사용법:");
+    eprintln!(
         "  rhwp hwp5-ctrl-data-trace <oracle.hwp> <generated.hwp> --out <path> [--section N] [--record-index N]"
     );
 }

--- a/src/diagnostics/hwp5_first_para_control_probe.rs
+++ b/src/diagnostics/hwp5_first_para_control_probe.rs
@@ -88,10 +88,17 @@ struct FirstParaView {
     base_level: u16,
 }
 
-pub fn run(args: &[String]) {
-    if args.is_empty() || matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
+pub fn run(args: &[String]) -> i32 {
+    // 종료 코드 계약(mydocs/manual/cli_commands.md): 명시적 `--help` 만 성공(0)이고,
+    // 인자 누락·파싱 실패는 사용법 오류(2), 실행 실패는 런타임 오류(1)다. 종전에는
+    // 반환형이 `()` 라 main 의 exit_with 를 통과하지 못해 무슨 일이 나든 0으로 끝났다.
+    if matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
         print_usage();
-        return;
+        return super::EXIT_OK;
+    }
+    if args.is_empty() {
+        print_usage();
+        return super::EXIT_USAGE;
     }
 
     let options = match parse_args(args) {
@@ -99,13 +106,15 @@ pub fn run(args: &[String]) {
         Err(message) => {
             eprintln!("{message}");
             print_usage();
-            return;
+            return super::EXIT_USAGE;
         }
     };
 
     if let Err(error) = run_inner(options) {
         eprintln!("오류: {error}");
+        return super::EXIT_RUNTIME;
     }
+    super::EXIT_OK
 }
 
 fn parse_args(args: &[String]) -> Result<Options, String> {
@@ -161,11 +170,13 @@ fn parse_args(args: &[String]) -> Result<Options, String> {
 }
 
 fn print_usage() {
-    println!("사용법:");
-    println!(
+    // 안내는 stderr 로 나간다(계약). stdout 은 프로브 데이터 전용이라
+    // 섞이면 JSONL 을 파이프로 받는 소비자가 파싱에서 깨진다.
+    eprintln!("사용법:");
+    eprintln!(
         "  rhwp hwp5-first-para-control-probe <oracle.hwp> <generated.hwp> --out-dir <폴더> [--section N]"
     );
-    println!(
+    eprintln!(
         "  옵션: --triplet-matrix  # Stage 14 PARA_HEADER/PARA_TEXT/PARA_CHAR_SHAPE 조합 probe"
     );
 }

--- a/src/diagnostics/hwp5_mel_personnel_probe.rs
+++ b/src/diagnostics/hwp5_mel_personnel_probe.rs
@@ -81,10 +81,17 @@ struct TableBlock {
     cols: u16,
 }
 
-pub fn run(args: &[String]) {
-    if args.is_empty() || matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
+pub fn run(args: &[String]) -> i32 {
+    // 종료 코드 계약(mydocs/manual/cli_commands.md): 명시적 `--help` 만 성공(0)이고,
+    // 인자 누락·파싱 실패는 사용법 오류(2), 실행 실패는 런타임 오류(1)다. 종전에는
+    // 반환형이 `()` 라 main 의 exit_with 를 통과하지 못해 무슨 일이 나든 0으로 끝났다.
+    if matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
         print_usage();
-        return;
+        return super::EXIT_OK;
+    }
+    if args.is_empty() {
+        print_usage();
+        return super::EXIT_USAGE;
     }
 
     let options = match parse_args(args) {
@@ -92,13 +99,15 @@ pub fn run(args: &[String]) {
         Err(message) => {
             eprintln!("{message}");
             print_usage();
-            return;
+            return super::EXIT_USAGE;
         }
     };
 
     if let Err(error) = run_inner(options) {
         eprintln!("오류: {error}");
+        return super::EXIT_RUNTIME;
     }
+    super::EXIT_OK
 }
 
 fn parse_args(args: &[String]) -> Result<Options, String> {
@@ -150,8 +159,10 @@ fn parse_args(args: &[String]) -> Result<Options, String> {
 }
 
 fn print_usage() {
-    println!("사용법:");
-    println!(
+    // 안내는 stderr 로 나간다(계약). stdout 은 프로브 데이터 전용이라
+    // 섞이면 JSONL 을 파이프로 받는 소비자가 파싱에서 깨진다.
+    eprintln!("사용법:");
+    eprintln!(
         "  rhwp hwp5-mel-personnel-probe <oracle.hwp> <generated.hwp> --out-dir <폴더> [--section N]"
     );
 }

--- a/src/diagnostics/hwp5_table_probe.rs
+++ b/src/diagnostics/hwp5_table_probe.rs
@@ -87,10 +87,17 @@ struct RecordMeta {
     data_offset: usize,
 }
 
-pub fn run(args: &[String]) {
-    if args.is_empty() || matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
+pub fn run(args: &[String]) -> i32 {
+    // 종료 코드 계약(mydocs/manual/cli_commands.md): 명시적 `--help` 만 성공(0)이고,
+    // 인자 누락·파싱 실패는 사용법 오류(2), 실행 실패는 런타임 오류(1)다. 종전에는
+    // 반환형이 `()` 라 main 의 exit_with 를 통과하지 못해 무슨 일이 나든 0으로 끝났다.
+    if matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
         print_usage();
-        return;
+        return super::EXIT_OK;
+    }
+    if args.is_empty() {
+        print_usage();
+        return super::EXIT_USAGE;
     }
 
     let options = match parse_args(args) {
@@ -98,13 +105,15 @@ pub fn run(args: &[String]) {
         Err(message) => {
             eprintln!("{message}");
             print_usage();
-            return;
+            return super::EXIT_USAGE;
         }
     };
 
     if let Err(error) = run_inner(options) {
         eprintln!("오류: {error}");
+        return super::EXIT_RUNTIME;
     }
+    super::EXIT_OK
 }
 
 fn parse_args(args: &[String]) -> Result<Options, String> {
@@ -156,8 +165,12 @@ fn parse_args(args: &[String]) -> Result<Options, String> {
 }
 
 fn print_usage() {
-    println!("사용법:");
-    println!("  rhwp hwp5-table-probe <oracle.hwp> <generated.hwp> --out-dir <폴더> [--section N]");
+    // 안내는 stderr 로 나간다(계약). stdout 은 프로브 데이터 전용이라
+    // 섞이면 JSONL 을 파이프로 받는 소비자가 파싱에서 깨진다.
+    eprintln!("사용법:");
+    eprintln!(
+        "  rhwp hwp5-table-probe <oracle.hwp> <generated.hwp> --out-dir <폴더> [--section N]"
+    );
 }
 
 fn run_inner(options: Options) -> Result<(), String> {

--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -1,5 +1,15 @@
 //! Diagnostic tooling for HWP/HWPX compatibility work.
 
+// CLI 종료 코드 계약(mydocs/manual/cli_commands.md)의 진단 명령용 단일 출처.
+// `src/main.rs` 의 EXIT_* 는 바이너리 크레이트 전용이라 라이브러리 쪽 진단 진입점에서
+// 참조할 수 없다. 같은 값을 여기 한 곳에 두어 값 표류를 막는다.
+/// 성공.
+pub const EXIT_OK: i32 = 0;
+/// 런타임 실패 — 읽기·파싱·렌더·쓰기.
+pub const EXIT_RUNTIME: i32 = 1;
+/// 사용법 오류 — 인자 없음, 알 수 없는 옵션.
+pub const EXIT_USAGE: i32 = 2;
+
 pub mod bench;
 pub mod core_pages_probe;
 pub mod hwp5_anchor_trace;

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,22 +251,28 @@ fn main() {
         Some("build-from-ingest") => exit_with(build_from_ingest(&args[2..])),
         Some("hwp5-inventory") => rhwp::diagnostics::hwp5_inventory::run(&args[2..]),
         Some("hwp5-inventory-diff") => rhwp::diagnostics::hwp5_inventory_diff::run(&args[2..]),
-        Some("hwp5-contract-analyze") => rhwp::diagnostics::hwp5_contract_analyze::run(&args[2..]),
-        Some("hwp5-ctrl-data-trace") => rhwp::diagnostics::hwp5_ctrl_data_trace::run(&args[2..]),
-        Some("hwp5-contract-probe") => rhwp::diagnostics::hwp5_contract_probe::run(&args[2..]),
-        Some("hwp5-table-probe") => rhwp::diagnostics::hwp5_table_probe::run(&args[2..]),
+        Some("hwp5-contract-analyze") => {
+            exit_with(rhwp::diagnostics::hwp5_contract_analyze::run(&args[2..]))
+        }
+        Some("hwp5-ctrl-data-trace") => {
+            exit_with(rhwp::diagnostics::hwp5_ctrl_data_trace::run(&args[2..]))
+        }
+        Some("hwp5-contract-probe") => {
+            exit_with(rhwp::diagnostics::hwp5_contract_probe::run(&args[2..]))
+        }
+        Some("hwp5-table-probe") => exit_with(rhwp::diagnostics::hwp5_table_probe::run(&args[2..])),
         Some("hwp5-mel-personnel-probe") => {
-            rhwp::diagnostics::hwp5_mel_personnel_probe::run(&args[2..])
+            exit_with(rhwp::diagnostics::hwp5_mel_personnel_probe::run(&args[2..]))
         }
-        Some("hwp5-borderfill-diagonal-probe") => {
-            rhwp::diagnostics::hwp5_borderfill_diagonal_probe::run(&args[2..])
-        }
-        Some("hwp5-first-para-control-probe") => {
-            rhwp::diagnostics::hwp5_first_para_control_probe::run(&args[2..])
-        }
+        Some("hwp5-borderfill-diagonal-probe") => exit_with(
+            rhwp::diagnostics::hwp5_borderfill_diagonal_probe::run(&args[2..]),
+        ),
+        Some("hwp5-first-para-control-probe") => exit_with(
+            rhwp::diagnostics::hwp5_first_para_control_probe::run(&args[2..]),
+        ),
         Some("hwp5-anchor-trace") => rhwp::diagnostics::hwp5_anchor_trace::run(&args[2..]),
         Some("hwp5-cell-header-probe") => {
-            rhwp::diagnostics::hwp5_cell_header_probe::run(&args[2..])
+            exit_with(rhwp::diagnostics::hwp5_cell_header_probe::run(&args[2..]))
         }
         Some("dump-records") => exit_with(dump_raw_records(&args[2..])),
         Some("test-shape") => test_shape_roundtrip(&args[2..]),

--- a/tests/cli_exit_codes_diagnostic_commands.rs
+++ b/tests/cli_exit_codes_diagnostic_commands.rs
@@ -127,3 +127,64 @@ fn successful_diagnostic_commands_return_zero() {
 fn rhwp_bin() -> String {
     std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
 }
+
+/// `hwp5-*` 프로브 8종의 종료 코드 계약.
+///
+/// 진입점이 `pub fn run(args: &[String])` 즉 반환형이 유닛이라 `main` 의 `exit_with` 를
+/// 통과하지 못했다 — 인자를 빠뜨리든 파일이 없든 **무조건 exit 0** 이었다. `&&` 나
+/// `set -e` 로 엮은 스크립트, CI 게이트가 실패를 성공으로 읽는다.
+///
+/// 세 갈래를 함께 본다: 명시적 `--help` 만 성공(0), 인자 누락·파싱 실패는 사용법
+/// 오류(2), 인자가 갖춰진 뒤의 실행 실패는 런타임 오류(1).
+#[test]
+fn hwp5_probes_report_contract_exit_codes() {
+    const PROBES: [&str; 8] = [
+        "hwp5-borderfill-diagonal-probe",
+        "hwp5-cell-header-probe",
+        "hwp5-contract-analyze",
+        "hwp5-contract-probe",
+        "hwp5-ctrl-data-trace",
+        "hwp5-first-para-control-probe",
+        "hwp5-mel-personnel-probe",
+        "hwp5-table-probe",
+    ];
+    for probe in PROBES {
+        // ① 인자 없음 → 사용법 오류. 종전에는 0 이었다.
+        let no_args = assert_code(&[probe], 2);
+        assert!(
+            String::from_utf8_lossy(&no_args.stdout).trim().is_empty(),
+            "사용법 안내는 stderr 로 나가야 합니다({probe}): {}",
+            describe(&[probe], &no_args)
+        );
+
+        // ② 명시적 --help 는 성공이다 — 도움말을 물어본 호출까지 실패로 만들면 안 된다.
+        assert_code(&[probe, "--help"], 0);
+    }
+}
+
+/// 인자가 갖춰진 뒤의 읽기·파싱 실패는 런타임 오류(1)여야 한다.
+///
+/// 프로브마다 필요한 인자 개수가 달라(2개짜리·3개짜리) 한 벌로 묶을 수 없다.
+/// 인자 개수를 채운 대표 2종만 확인한다 — 반환형 변경이 실제로 실패를 전달하는지가
+/// 요점이고, 그건 한 갈래만 통과해도 증명된다.
+#[test]
+fn hwp5_probes_report_runtime_failure_after_arity_is_satisfied() {
+    let out_dir = std::env::temp_dir().join(format!("rhwp-probe-{}", std::process::id()));
+    let out = out_dir.to_string_lossy().to_string();
+    for probe in ["hwp5-table-probe", "hwp5-cell-header-probe"] {
+        let args = [
+            probe,
+            "없는A-probe.hwp",
+            "없는B-probe.hwp",
+            "--out-dir",
+            &out,
+        ];
+        let output = assert_code(&args, 1);
+        assert!(
+            String::from_utf8_lossy(&output.stdout).trim().is_empty(),
+            "실패 시 stdout 은 비어야 합니다({probe}): {}",
+            describe(&args, &output)
+        );
+    }
+    let _ = std::fs::remove_dir_all(&out_dir);
+}


### PR DESCRIPTION
## 요약

`hwp5-*` 진단 프로브 8종이 **어떤 실패에도 exit 0** 을 냅니다. 그리고 사용법 안내를 stdout 으로 내보내 프로브 데이터와 섞습니다.

```
$ rhwp hwp5-table-probe                    # 인자 없음
사용법:                                     ← stdout 으로 나온다
  rhwp hwp5-table-probe <oracle.hwp> <generated.hwp> --out-dir <폴더> [--section N]
exit 0                                      ← 계약상 2

$ rhwp hwp5-table-probe 없는A.hwp 없는B.hwp --out-dir /tmp/x
exit 0                                      ← 계약상 1
```

`&&` 나 `set -e` 로 엮은 스크립트, `$?` 를 읽는 CI 게이트가 **실패를 성공으로 읽습니다.** stdout 오염은 더 조용한데, 프로브 출력을 파이프로 받는 소비자가 안내문까지 데이터로 삼켜 파싱에서 깨집니다.

## 원인

진입점이 전부 `pub fn run(args: &[String])` — 반환형이 유닛이라 `main` 의 `exit_with(...)` 를 통과할 수 없습니다. 계약을 지키는 다른 명령은 모두 `exit_with(f(&args[2..]))` 로 디스패치되는데, 이 8종은 그 자리에 그냥 호출만 있어 무슨 일이 나든 0으로 떨어집니다.

8종의 `run()` 본문은 **바이트까지 동일**합니다(md5 대조). 그래서 한 벌로 변환했습니다.

## 수정

- `diagnostics/mod.rs` 에 `EXIT_OK`/`EXIT_RUNTIME`/`EXIT_USAGE` 를 둡니다. `main.rs` 의 `EXIT_*` 는 **바이너리 크레이트 전용**이라 라이브러리 쪽 진단 진입점에서 참조할 수 없습니다 — 같은 값을 한 곳에 모아 표류를 막습니다.
- `run(...) -> i32` 로 바꾸고 세 갈래를 가릅니다: **명시적 `--help` 만 성공(0)**, 인자 누락·파싱 실패는 사용법 오류(2), 인자가 갖춰진 뒤의 실행 실패는 런타임 오류(1).
- 디스패치 8곳을 `exit_with(...)` 로 감쌉니다.
- `print_usage()` 의 `println!` → `eprintln!`.

`--help` 를 0으로 남긴 것은 의도입니다 — 도움말을 물어본 호출까지 실패로 만들면 안 됩니다. 종전 코드는 `args.is_empty() || --help` 를 한 갈래로 묶어 둘을 구분할 수 없었습니다.

## AFTER

```
hwp5-table-probe        인자없음=2  --help=0  인자충족+없는파일=1
hwp5-contract-probe     인자없음=2  --help=0
hwp5-ctrl-data-trace    인자없음=2  --help=0
hwp5-cell-header-probe  인자없음=2  --help=0  인자충족+없는파일=1
```

## 회귀 가드 2종

- `hwp5_probes_report_contract_exit_codes` — 8종 전부에 대해 인자 누락 2 + `--help` 0 + **stdout 이 비어 있는지**. 종료 코드만 보면 stdout 오염을 놓칩니다. 실제로 이 가드가 작성 도중 `print_usage` 의 `println!` 을 잡아냈습니다 — 종료 코드는 이미 고쳐 놓은 상태였는데도요.
- `hwp5_probes_report_runtime_failure_after_arity_is_satisfied` — 인자 개수를 채운 뒤의 읽기 실패가 1인지. 프로브마다 필요한 인자 개수가 달라(2개·3개) 한 벌로 못 묶으므로 대표 2종만 봅니다. 반환형 변경이 실제로 실패를 전달하는지가 요점이라 한 갈래만 통과해도 증명됩니다.

## 검증

- `cargo test --test cli_exit_codes_diagnostic_commands` — **7/7** (신규 2종 포함)
- `cli_json_contract` 22/22 — 무회귀
- `cargo clippy --profile release-test --bin rhwp` — 경고 0 / `cargo fmt --check` — 통과

## 같은 계열의 나머지

`core-pages`·`measure-width`·`bench`·`test-shape`·`gen-table` 6종이 같은 뿌리로 남아 있습니다. 이 8종은 `run()` 본문이 동일해 기계적으로 한 벌 변환이 가능했지만, 나머지는 각자 다른 본문이라 갈래마다 판정이 필요합니다 — 섞으면 리뷰가 어려워지므로 따로 올리겠습니다.

앞선 PR 에서 `gen-pua`(원본 덮어쓰기)·`test-field`(패닉 101)·`render-diff`(읽기 실패에 2)를 먼저 처리했습니다 — 그쪽은 데이터 파괴와 계약 밖 종료 코드라 우선순위가 달랐습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
