### PR TITLE
fix(cli): 남은 진단 명령 5종의 종료 코드 계약 — bench 인자 누락이 '0개 측정 성공'이 된다

### DIFF
--- a/src/diagnostics/bench.rs
+++ b/src/diagnostics/bench.rs
@@ -45,7 +45,9 @@ fn ms_since(t: Instant) -> f64 {
     t.elapsed().as_secs_f64() * 1000.0
 }
 
-pub fn run(args: &[String]) {
+pub fn run(args: &[String]) -> i32 {
+    // 종료 코드 계약(mydocs/manual/cli_commands.md): 파일 처리 실패는 이미 1 로 끝냈지만
+    // 인자 누락만 0 이었다 — 오타로 대상이 비면 "0개 측정 성공" 이 되어 버린다.
     let mut files: Vec<String> = Vec::new();
     let mut batch: Option<String> = None;
     let mut iters = 3usize;
@@ -77,7 +79,7 @@ pub fn run(args: &[String]) {
     }
     if files.is_empty() {
         eprintln!("사용법: rhwp bench <파일...> | --batch <폴더> [-n 반복수] [--tsv 출력.tsv]");
-        return;
+        return super::EXIT_USAGE;
     }
     if iters == 0 {
         iters = 1;
@@ -113,8 +115,11 @@ pub fn run(args: &[String]) {
     // 있으면 non-zero 로 종료해 실패가 성공처럼 숨겨지지 않게 한다.
     if failures > 0 {
         eprintln!("\n{failures}개 파일 처리 실패 — 종료 코드 1");
-        std::process::exit(1);
+        // process::exit 대신 반환한다 — 호출부(main 의 exit_with)가 종료를 맡으면
+        // 이 함수도 다른 진단 명령과 같은 계약 하나만 지키면 된다.
+        return super::EXIT_RUNTIME;
     }
+    super::EXIT_OK
 }
 
 fn collect_samples(dir: &std::path::Path, acc: &mut Vec<String>) {

--- a/src/diagnostics/core_pages_probe.rs
+++ b/src/diagnostics/core_pages_probe.rs
@@ -26,23 +26,26 @@ fn first_text(n: &RenderNode, out: &mut String) {
     }
 }
 
-pub fn run(args: &[String]) {
+pub fn run(args: &[String]) -> i32 {
+    // 종료 코드 계약(mydocs/manual/cli_commands.md): 반환형이 `()` 라 인자 누락도
+    // 읽기·파싱 실패도 전부 0 으로 끝났다 — 페이지네이션 대조 스크립트가 실패를
+    // 성공으로 읽는다.
     let Some(path) = args.first() else {
         eprintln!("사용: rhwp core-pages <파일>");
-        return;
+        return super::EXIT_USAGE;
     };
     let data = match std::fs::read(path) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("읽기 실패: {e}");
-            return;
+            return super::EXIT_RUNTIME;
         }
     };
     let core = match DocumentCore::from_bytes(&data) {
         Ok(c) => c,
         Err(e) => {
             eprintln!("파싱 실패: {e:?}");
-            return;
+            return super::EXIT_RUNTIME;
         }
     };
     let n = core.page_count();
@@ -55,4 +58,5 @@ pub fn run(args: &[String]) {
         let head: String = s.chars().take(24).collect();
         println!("p{:03} {}", p + 1, head);
     }
+    super::EXIT_OK
 }

--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -1,5 +1,15 @@
 //! Diagnostic tooling for HWP/HWPX compatibility work.
 
+// CLI 종료 코드 계약(mydocs/manual/cli_commands.md)의 진단 명령용 단일 출처.
+// `src/main.rs` 의 EXIT_* 는 바이너리 크레이트 전용이라 라이브러리 쪽 진단 진입점에서
+// 참조할 수 없다. 같은 값을 여기 한 곳에 두어 값 표류를 막는다.
+/// 성공.
+pub const EXIT_OK: i32 = 0;
+/// 런타임 실패 — 읽기·파싱·렌더·쓰기.
+pub const EXIT_RUNTIME: i32 = 1;
+/// 사용법 오류 — 인자 없음, 알 수 없는 옵션.
+pub const EXIT_USAGE: i32 = 2;
+
 pub mod bench;
 pub mod core_pages_probe;
 pub mod hwp5_anchor_trace;

--- a/src/diagnostics/text_width_probe.rs
+++ b/src/diagnostics/text_width_probe.rs
@@ -13,7 +13,9 @@
 use crate::renderer::layout::estimate_text_width_unrounded;
 use crate::renderer::TextStyle;
 
-pub fn run(args: &[String]) {
+pub fn run(args: &[String]) -> i32 {
+    // 종료 코드 계약(mydocs/manual/cli_commands.md): 반환형이 `()` 라 인자 누락
+    // (사용법 오류)에도 0 으로 끝나, 폭 사다리 스크립트가 빈 출력을 정상으로 취급했다.
     let mut font = String::from("함초롬바탕");
     let mut size_pt = 10.0f64;
     let mut ratio = 100.0f64;
@@ -44,7 +46,7 @@ pub fn run(args: &[String]) {
     }
     if texts.is_empty() {
         eprintln!("사용: rhwp measure-width --size 10 [--font 이름] [--repeat N] <text>...");
-        return;
+        return super::EXIT_USAGE;
     }
     let style = TextStyle {
         font_family: font.clone(),
@@ -64,4 +66,5 @@ pub fn run(args: &[String]) {
         let label: String = t.chars().take(8).collect();
         println!("{label}\t{n}\t{w:.3}\t{:.4}", w / n as f64);
     }
+    super::EXIT_OK
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,18 +269,18 @@ fn main() {
             rhwp::diagnostics::hwp5_cell_header_probe::run(&args[2..])
         }
         Some("dump-records") => exit_with(dump_raw_records(&args[2..])),
-        Some("test-shape") => test_shape_roundtrip(&args[2..]),
+        Some("test-shape") => exit_with(test_shape_roundtrip(&args[2..])),
         Some("test-caption") => exit_with(test_caption(&args[2..])),
-        Some("gen-table") => gen_table(&args[2..]),
+        Some("gen-table") => exit_with(gen_table(&args[2..])),
         Some("gen-pua") => gen_pua_test(&args[2..]),
         Some("test-field") => test_field_roundtrip(&args[2..]),
         Some("ir-diff") => exit_with(ir_diff(&args[2..])),
         Some("hwpx-roundtrip") => rhwp::diagnostics::hwpx_roundtrip_batch::run(&args[2..]),
         Some("hwp5-roundtrip") => rhwp::diagnostics::hwp5_roundtrip_batch::run(&args[2..]),
         Some("render-diff") => rhwp::diagnostics::render_geom_diff::run(&args[2..]),
-        Some("measure-width") => rhwp::diagnostics::text_width_probe::run(&args[2..]),
-        Some("core-pages") => rhwp::diagnostics::core_pages_probe::run(&args[2..]),
-        Some("bench") => rhwp::diagnostics::bench::run(&args[2..]),
+        Some("measure-width") => exit_with(rhwp::diagnostics::text_width_probe::run(&args[2..])),
+        Some("core-pages") => exit_with(rhwp::diagnostics::core_pages_probe::run(&args[2..])),
+        Some("bench") => exit_with(rhwp::diagnostics::bench::run(&args[2..])),
         Some("thumbnail") => exit_with(extract_thumbnail(&args[2..])),
         Some("fields") => exit_with(show_fields(&args[2..])),
         Some("edit") => exit_with(run_edit(&args[2..])),
@@ -8157,7 +8157,7 @@ fn dump_raw_records(args: &[String]) -> i32 {
     EXIT_OK
 }
 
-fn test_shape_roundtrip(args: &[String]) {
+fn test_shape_roundtrip(args: &[String]) -> i32 {
     let input = if args.is_empty() {
         "saved/g555-s.hwp"
     } else {
@@ -8173,7 +8173,7 @@ fn test_shape_roundtrip(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("입력 파일 읽기 오류: {}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -8181,7 +8181,7 @@ fn test_shape_roundtrip(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("HWP 파싱 오류: {:?}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -8207,7 +8207,7 @@ fn test_shape_roundtrip(args: &[String]) {
         Ok(r) => eprintln!("글상자 생성 성공: {}", r),
         Err(e) => {
             eprintln!("글상자 생성 실패: {:?}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     }
 
@@ -8215,11 +8215,15 @@ fn test_shape_roundtrip(args: &[String]) {
         Ok(bytes) => {
             if let Err(e) = fs::write(output, &bytes) {
                 eprintln!("파일 저장 오류: {}", e);
-            } else {
-                eprintln!("저장 완료: {} ({}KB)", output, bytes.len() / 1024);
+                return EXIT_RUNTIME;
             }
+            eprintln!("저장 완료: {} ({}KB)", output, bytes.len() / 1024);
+            EXIT_OK
         }
-        Err(e) => eprintln!("직렬화 오류: {:?}", e),
+        Err(e) => {
+            eprintln!("직렬화 오류: {:?}", e);
+            EXIT_RUNTIME
+        }
     }
 }
 
@@ -8367,7 +8371,7 @@ fn test_caption(args: &[String]) -> i32 {
     EXIT_OK
 }
 
-fn gen_table(args: &[String]) {
+fn gen_table(args: &[String]) -> i32 {
     let rows: u16 = args.first().and_then(|s| s.parse().ok()).unwrap_or(1000);
     let cols: u16 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(6);
     let output = args
@@ -8449,8 +8453,14 @@ fn gen_table(args: &[String]) {
     if let Some(parent) = out_path.parent() {
         fs::create_dir_all(parent).ok();
     }
-    fs::write(out_path, bytes).expect("파일 저장 실패");
+    if let Err(e) = fs::write(out_path, bytes) {
+        // 종료 코드 계약: 쓰기 실패는 런타임 오류(1)다. 종전에는 .expect() 로 패닉해
+        // 계약에 없는 101 로 끝났다.
+        eprintln!("오류: 파일 저장 실패 - {}: {}", output, e);
+        return EXIT_RUNTIME;
+    }
     println!("저장 완료: {} ({}행 × {}열)", output, rows, cols);
+    EXIT_OK
 }
 
 /// PUA (Private Use Area) 문자 셋트를 입력한 HWP 테스트 문서 생성.

--- a/tests/cli_exit_codes_diagnostic_commands.rs
+++ b/tests/cli_exit_codes_diagnostic_commands.rs
@@ -127,3 +127,41 @@ fn successful_diagnostic_commands_return_zero() {
 fn rhwp_bin() -> String {
     std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
 }
+
+/// 남은 진단 명령 5종의 종료 코드 계약.
+///
+/// 전부 진입점이 `pub fn run(args: &[String])`(또는 `fn f(args) -> ()`)라 `main` 의
+/// `exit_with` 를 통과하지 못했다 — 인자를 빠뜨리든 파일이 없든 **무조건 exit 0** 이었다.
+/// `hwp5-*` 8종과 같은 뿌리지만, 이쪽은 본문이 제각각이라 갈래마다 판정이 필요했다.
+///
+/// `gen-table` 은 여기 없다 — 행·열·출력 경로 전부 기본값이 있어 **인자 없음이 정상
+/// 실행**이다. 그 명령의 실패 축은 쓰기 실패(1)이고 그건 별도로 다룬다.
+#[test]
+fn remaining_diagnostics_report_usage_error_without_arguments() {
+    for cmd in ["core-pages", "measure-width", "bench"] {
+        let output = assert_code(&[cmd], 2);
+        assert!(
+            String::from_utf8_lossy(&output.stdout).trim().is_empty(),
+            "사용법 안내는 stderr 로 나가야 합니다({cmd}): {}",
+            describe(&[cmd], &output)
+        );
+    }
+}
+
+/// 인자가 갖춰진 뒤의 읽기·파싱 실패는 런타임 오류(1)여야 한다.
+///
+/// `bench` 는 종전에도 파일 처리 실패를 1로 냈지만 `std::process::exit(1)` 로 직접
+/// 끊었다 — 반환으로 바꿔 다른 진단 명령과 같은 계약 하나만 지키게 했다. 그 변경이
+/// 코드를 바꾸지 않았는지 여기서 고정한다.
+#[test]
+fn remaining_diagnostics_report_runtime_failure_on_unreadable_input() {
+    for cmd in ["core-pages", "test-shape", "bench"] {
+        let args = [cmd, "없는파일-diag-rest.hwp"];
+        let output = assert_code(&args, 1);
+        assert!(
+            !String::from_utf8_lossy(&output.stderr).contains("panicked"),
+            "패닉 흔적이 남아 있습니다({cmd}): {}",
+            describe(&args, &output)
+        );
+    }
+}


### PR DESCRIPTION
## 요약

`hwp5-*` 8종에 이어 **남은 진단 명령 5종**을 종료 코드 계약 안으로 넣습니다. 뿌리는 같습니다 — 진입점 반환형이 유닛이라 `main` 의 `exit_with` 를 통과하지 못해, 실패해도 exit 0 으로 끝났습니다.

```
core-pages    인자없음 → 0    (계약상 2)
measure-width 인자없음 → 0    (계약상 2)
bench         인자없음 → 0    (계약상 2)
test-shape    읽기실패 → 0    (계약상 1)
gen-table     쓰기실패 → 패닉 101
```

`&&` 나 `set -e` 로 엮은 스크립트, `$?` 를 읽는 CI 게이트가 실패를 성공으로 읽습니다. 페이지네이션 대조·폭 사다리처럼 **출력을 파이프로 받는 스크립트**는 빈 출력을 정상으로 취급하게 됩니다.

## 앞 PR 과 왜 나눴나

`hwp5-*` 8종은 `run()` 본문이 바이트까지 동일해(md5 대조) 기계적으로 한 벌 변환이 가능했습니다. 이 5종은 각자 다른 본문이라 **갈래마다 판정이 필요**합니다 — 어디까지가 사용법 오류이고 어디부터가 런타임 실패인지가 명령마다 다릅니다. 섞으면 리뷰어가 기계적 변환과 판단이 들어간 변경을 구분할 수 없어 따로 올립니다.

## 판정 근거

- **`core-pages`·`measure-width`** — 인자 누락은 2, 읽기·파싱 실패는 1. 단순합니다.
- **`bench`** — 파일 처리 실패는 종전에도 1이었지만 `std::process::exit(1)` 로 직접 끊었습니다. 반환으로 바꿔 다른 진단 명령과 **같은 계약 하나만** 지키게 했습니다. 인자 누락만 0이었는데, 오타로 대상이 비면 "0개 측정 성공"이 되어 버립니다.
- **`test-shape`** — 인자를 생략하면 기본 경로(`saved/g555-s.hwp`)를 시도합니다. 그 파일이 없으면 **읽기 실패(1)** 이지 사용법 오류가 아닙니다 — 호출자는 인자를 안 준 게 아니라 기본값이 안 맞은 것이므로, 인자를 고치라고 안내하면 틀린 방향을 가리킵니다.
- **`gen-table`** — 행·열·출력 경로 **전부 기본값이 있어 인자 없음이 정상 실행**입니다(exit 0 유지). 실패 축은 쓰기 실패뿐이고, 종전에는 `.expect()` 로 패닉해 계약에 없는 101 이었습니다.

## AFTER

```
core-pages    인자없음=2   없는파일=1
measure-width 인자없음=2
bench         인자없음=2   없는파일=1
test-shape    없는파일=1   (인자없음도 기본 경로 부재로 1 — 계약 안)
gen-table     인자없음=0   (전 인자 기본값 있음 — 정상 실행)
```

## 회귀 가드 2종

- `remaining_diagnostics_report_usage_error_without_arguments` — 3종의 인자 누락 2 + **stdout 이 비어 있는지**. 앞 PR 에서 이 축이 `print_usage` 의 stdout 오염을 잡아냈습니다.
- `remaining_diagnostics_report_runtime_failure_on_unreadable_input` — 읽기 실패 1 + **stderr 에 `panicked` 흔적이 없는지**.

`gen-table` 이 가드에 없는 이유는 위 판정대로 인자 없음이 정상 실행이기 때문입니다 — 테스트 주석에 그 이유를 적어 두어 나중에 "왜 얘만 빠졌지" 로 잘못 추가되지 않게 했습니다.

## 검증

- `cargo test --test cli_exit_codes_diagnostic_commands` — **7/7** (신규 2종 포함)
- `cli_json_contract` 22/22 — 무회귀
- `cargo clippy --profile release-test --bin rhwp` — 경고 0 / `cargo fmt --check` — 통과

이로써 `capabilities` 가 광고하는 진단 명령 중 종료 코드 계약을 어기던 것은 전부 정리됐습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
