### PR TITLE
fix(convert): HWP3 왕복본이 쪽나눔 허용치를 잃어 미주가 뒤로 밀리던 결함 (#3707)

### DIFF
--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -1975,6 +1975,22 @@ fn adapt_cell_list_attr(cell: &mut Cell, report: &mut AdapterReport) {
 /// 마커가 사라지며 그 문서는 진짜 native HWP5 가 되므로 시멘틱이 자기일관적이다.
 pub const HWPX_ORIGIN_STREAM_PATH: &str = "/RhwpHwpxOrigin";
 
+/// [#3707] HWP3 출처 마커. `RhwpHwpxOrigin` 과 같은 방식이다.
+///
+/// HWP3 파싱은 `apply_hwp3_origin_fixup` 으로 `margin_bottom` 에서 1600 HU(21.3px)를
+/// 빼 한글97 의 마지막 줄 tolerance 를 모방한다. 그 보정은 IR 에만 있고 저장 파일의
+/// 여백은 원본 그대로다(그래야 한컴이 보는 기하가 원본과 같다). 그런데 재파싱 때
+/// 보정을 다시 걸지 판단하는 조건이 **문단 대비 모양 비율**이라, 저장하며 문단마다
+/// 모양이 생성돼 비율이 임계를 넘으면 보정이 사라진다(실측: ps 0.707 · cs 1.115 vs
+/// 임계 0.05 / 0.15).
+///
+/// 그 21.3px 만큼 미주 단 가용이 줄어 단 전환이 일찍 걸리고, 2단 미주의 왼쪽 단이
+/// 조기에 닫혀 미주가 다음 쪽으로 밀린다(SO-SUEOP 44쪽). 한컴은 원본·왕복본 모두
+/// 두 단을 고르게 채우므로 보정이 유지되는 쪽이 정답지와 맞는다.
+///
+/// 저장 여백을 줄이는 대신 **출처만 기록**해 재파싱이 보정을 결정론적으로 되건다.
+pub const HWP3_ORIGIN_STREAM_PATH: &str = "/RhwpHwp3Origin";
+
 /// `source_format` 검사 후 어댑터를 호출하는 보조 함수.
 ///
 /// 호출자: `DocumentCore::export_hwp_with_adapter()` (Stage 5 에서 추가).
@@ -1992,6 +2008,18 @@ pub fn convert_if_hwpx_source(doc: &mut Document, source_format: FileFormat) -> 
     {
         doc.extra_streams
             .push((HWPX_ORIGIN_STREAM_PATH.to_string(), b"1".to_vec()));
+    }
+    // [#3707] HWP3 출처 마커 — 재파싱이 쪽나눔 허용치를 되돌릴 수 있게 한다.
+    // HWP3 파서가 세우는 `pagination_bottom_tolerance`(1600 HU)는 렌더러 내부 값이라
+    // 저장 파일에 남지 않는다. 마커로 출처만 기록해 재파싱이 결정론적으로 복원한다.
+    if matches!(source_format, FileFormat::Hwp3)
+        && !doc
+            .extra_streams
+            .iter()
+            .any(|(p, _)| p == HWP3_ORIGIN_STREAM_PATH)
+    {
+        doc.extra_streams
+            .push((HWP3_ORIGIN_STREAM_PATH.to_string(), b"1".to_vec()));
     }
     convert_to_hwp_ir(doc)
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -527,6 +527,33 @@ fn apply_hwp3_origin_fixup(doc: &mut Document) {
     if doc.is_hwpx_variant {
         return;
     }
+    // [#3707] rhwp 가 만든 HWP3→HWP5 변환본에 쪽나눔 허용치를 되돌린다.
+    //
+    // HWP3 파서는 `pagination_bottom_tolerance = 1600 HU`(21.3px)를 세운다 — 한글97 의
+    // 마지막 줄 tolerance 를 흉내 내 **페이지네이터에게만** 여유를 주는 렌더러 내부
+    // 값이고 파일 포맷 필드가 아니다. HWP5 로 저장·재파싱하면 0 이 되어 본문 가용이
+    // 21.3px 짧아진다.
+    //
+    // 그만큼 미주 단 가용이 줄어 단 전환이 일찍 걸리고, 2단 미주의 왼쪽 단이 조기에
+    // 닫혀 미주가 다음 쪽으로 밀린다(SO-SUEOP 44쪽: 미주 128·129 가 45쪽으로). 한컴은
+    // 원본·왕복본 모두 44쪽에 실으므로 허용치가 살아 있는 쪽이 정답지와 맞는다.
+    //
+    // 파일에 실리는 여백(`margin_bottom`)은 건드리지 않는다 — 줄이면 한컴이 보는 쪽
+    // 기하가 원본과 달라지고 `convert --verify` 의 IR 비교에도 잡힌다. 이 값은 그
+    // 비교에서 제외되는 렌더러 내부 값이라 왕복 정합을 깨지 않는다.
+    if doc
+        .extra_streams
+        .iter()
+        .any(|(p, _)| p == crate::document_core::converters::hwpx_to_hwp::HWP3_ORIGIN_STREAM_PATH)
+    {
+        for section in doc.sections.iter_mut() {
+            let pd = &mut section.section_def.page_def;
+            if pd.pagination_bottom_tolerance == 0 {
+                pd.pagination_bottom_tolerance = 1600.min(pd.margin_bottom);
+            }
+        }
+    }
+
     let total_paragraphs: usize = doc.sections.iter().map(|s| s.paragraphs.len()).sum();
     if total_paragraphs <= 50 {
         return;

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -2149,6 +2149,23 @@ impl TypesetState {
         // 개행이 누적되지 않는다. 실제 꼬리말이 있으면 점유 가능성이 있으므로
         // 보수적으로 밴드를 회수하지 않는다.
         let footnote_penalty = (self.current_footnote_height - self.footer_band_reclaim()).max(0.0);
+        // [#3707 진단] 가용 높이의 차감 내역. 두 문서에서 avail 이 21.4px 다른데
+        // 본문 영역은 같으므로, 어느 항목이 그 차이를 만드는지 가른다. 동작 불변.
+        if std::env::var("RHWP_DIAG_AVAIL").is_ok() {
+            eprintln!(
+                "DIAG_AVAIL base={:.1} fn_h={:.1} reclaim={:.1} penalty={:.1} fn_margin={:.1} zone_y={:.1} bottom_fixed={:.1} → {:.1}",
+                base,
+                self.current_footnote_height,
+                self.footer_band_reclaim(),
+                footnote_penalty,
+                fn_margin,
+                self.current_zone_y_offset,
+                self.current_bottom_fixed_exclusion,
+                (base - footnote_penalty - fn_margin - self.current_zone_y_offset
+                    - self.current_bottom_fixed_exclusion)
+                    .max(0.0),
+            );
+        }
         (base
             - footnote_penalty
             - fn_margin
@@ -6788,6 +6805,21 @@ impl TypesetEngine {
                 .unwrap_or(raw_en_fit);
             let total_advance_fit = line_advances_sum.max(non_tac_object_height.unwrap_or(0.0));
             let remaining_height = (available - st.current_height).max(0.0);
+            // [#3707 진단] 미주 단 전환 판정의 입력. 동작 불변.
+            // 높이 누적(EN_ACC)은 두 문서가 소수점까지 같은데 단 전환만 갈리므로,
+            // 남는 후보는 여기 `available`/`en_col_w`/`current_height` 다.
+            if std::env::var("RHWP_DIAG_ENCOL").is_ok() {
+                eprintln!(
+                    "DIAG_ENCOL pi={} avail={:.1} cur_h={:.1} remain={:.1} col_w={:.1} fit={:.1} adv={:.1}",
+                    en_para_idx,
+                    available,
+                    st.current_height,
+                    remaining_height,
+                    en_col_w,
+                    en_fit,
+                    total_advance_fit,
+                );
+            }
             // [Task #1363 v2 Stage 3] A2: 새 para 를 이어붙인 렌더-정합 시뮬
             // bottom 으로 fit 판정 (saved line_segs 기반 → 렌더와 일치).
             let a2_overflow_with_para = if ssot_level >= EnSsotLevel::A2 {

--- a/tests/issue_3707_hwp3_roundtrip_endnote_columns.rs
+++ b/tests/issue_3707_hwp3_roundtrip_endnote_columns.rs
@@ -1,0 +1,139 @@
+//! Issue #3707: HWP3 왕복본에서 미주가 한 쪽씩 뒤로 밀린다.
+//!
+//! ## 근인
+//!
+//! HWP3 파서는 `page_def.pagination_bottom_tolerance` 를 **1600 HU**(21.3px)로 세운다 —
+//! 한글97 의 마지막 줄 tolerance 를 흉내 내 페이지네이터에게만 여유를 주는 **렌더러 내부
+//! 값**이고 파일 포맷 필드가 아니다. HWP5 로 저장·재파싱하면 0 이 되어 본문 가용이 그만큼
+//! 짧아진다.
+//!
+//! ```text
+//! SO-SUEOP 왕복본: 문단 1,037 · 고유 ps 733 · 고유 cs 1,156
+//!                  ps 0.707 · cs 1.115   (임계 0.05 / 0.15)
+//! ```
+//!
+//! 보정이 사라지면 본문이 21.3px 짧아지고, 그만큼 미주 단 가용이 줄어 단 전환이 일찍
+//! 걸린다. 2단 미주의 왼쪽 단이 조기에 닫혀 미주가 다음 쪽으로 밀린다.
+//!
+//! ```text
+//!                     허용치      본문(미주 단 가용)
+//! 원본 (HWP3)          1600 HU        877.8 px
+//! 왕복본 (수정 전)         0 HU        856.4 px   ← 21.3px 짧다
+//! 왕복본 (수정 후)      1600 HU        877.8 px
+//!
+//! 미주 128·129   원본 44쪽  ·  수정 전 45쪽  ·  수정 후 44쪽
+//! ```
+//!
+//! 한컴은 원본·왕복본 모두 44쪽에 싣는다(PDF 실측). 즉 보정이 유지되는 쪽이 정답지다.
+//!
+//! ## 계약
+//!
+//! 파일에 실리는 여백은 **원본 그대로** 둔다 — 그래야 한컴이 보는 기하가 안 바뀌고
+//! `convert --verify` 의 IR 비교도 깨지지 않는다. 대신 출처 마커(`/RhwpHwp3Origin`)를
+//! 남겨 재파싱이 렌더러 내부 허용치만 되돌린다. 계약은 **미주가 원본과 같은 쪽에 실리는
+//! 것**이다(한컴 정답지와 일치).
+#![cfg(not(target_arch = "wasm32"))]
+
+const SAMPLE: &str = "samples/SO-SUEOP.hwp";
+
+fn sample_path() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+/// HWP3 원본 파싱 → 저장 → 재파싱.
+fn parse_and_roundtrip() -> (rhwp::model::document::Document, Vec<u8>) {
+    let raw = std::fs::read(sample_path()).expect("표본 읽기");
+    let original = rhwp::parser::hwp3::parse_hwp3(&raw).expect("HWP3 파싱");
+    let mut to_save = rhwp::parser::hwp3::parse_hwp3(&raw).expect("HWP3 파싱");
+    rhwp::document_core::converters::hwpx_to_hwp::convert_if_hwpx_source(
+        &mut to_save,
+        rhwp::parser::FileFormat::Hwp3,
+    );
+    let bytes = rhwp::serializer::cfb_writer::serialize_hwp(&to_save).expect("HWP5 직렬화");
+    (original, bytes)
+}
+
+fn margin_bottoms(doc: &rhwp::model::document::Document) -> Vec<u32> {
+    doc.sections
+        .iter()
+        .map(|s| s.section_def.page_def.margin_bottom)
+        .collect()
+}
+
+/// 파일에 실리는 여백은 건드리지 않는다 — 한컴이 보는 쪽 기하가 원본과 같아야 한다.
+#[test]
+fn stored_bottom_margin_is_untouched() {
+    let raw = std::fs::read(sample_path()).expect("표본 읽기");
+    let original = rhwp::parser::hwp3::parse_hwp3(&raw).expect("HWP3 파싱");
+    let (_, bytes) = parse_and_roundtrip();
+    let reparsed = rhwp::parser::parse_document(&bytes).expect("왕복본 재파싱");
+    assert_eq!(
+        margin_bottoms(&reparsed),
+        margin_bottoms(&original),
+        "왕복 후 margin_bottom 이 달라졌다. 여백을 줄여 보정하면 한컴이 보는 쪽 기하가          원본과 달라지고 `convert --verify` 의 IR 비교에도 잡힌다 — 보정은 렌더러 내부          허용치로만 걸어야 한다."
+    );
+}
+
+/// 재파싱이 출처 마커를 보고 쪽나눔 허용치를 되돌린다.
+#[test]
+fn reparse_restores_pagination_bottom_tolerance_via_origin_marker() {
+    let raw = std::fs::read(sample_path()).expect("표본 읽기");
+    let original = rhwp::parser::hwp3::parse_hwp3(&raw).expect("HWP3 파싱");
+    let (_, bytes) = parse_and_roundtrip();
+    let reparsed = rhwp::parser::parse_document(&bytes).expect("왕복본 재파싱");
+
+    let tol = |d: &rhwp::model::document::Document| -> Vec<u32> {
+        d.sections
+            .iter()
+            .map(|s| s.section_def.page_def.pagination_bottom_tolerance)
+            .collect()
+    };
+    let before = tol(&original);
+    assert!(
+        before.iter().any(|&v| v > 0),
+        "HWP3 원본이 허용치를 세우지 않는다 — 표본/파서 확인 (실측 1600 HU)"
+    );
+    assert_eq!(
+        tol(&reparsed),
+        before,
+        "왕복본이 쪽나눔 허용치를 잃었다. 그만큼(21.3px) 본문 가용이 짧아져 2단 미주의          왼쪽 단이 조기에 닫히고 미주가 다음 쪽으로 밀린다."
+    );
+}
+
+/// 미주가 원본과 같은 쪽에 실린다 (한컴 정답지: 128·129 → 44쪽).
+#[test]
+fn endnote_bodies_land_on_the_same_pages_after_roundtrip() {
+    let raw = std::fs::read(sample_path()).expect("표본 읽기");
+    let (_, bytes) = parse_and_roundtrip();
+
+    let page_of = |data: &[u8], needle: &str| -> Option<u32> {
+        let core = rhwp::document_core::DocumentCore::from_bytes(data).expect("파싱");
+        let key: String = needle.chars().filter(|c| !c.is_whitespace()).collect();
+        let pages = core.page_count();
+        (0..pages).find(|&p| {
+            core.extract_page_text_native(p)
+                .map(|t| {
+                    t.chars()
+                        .filter(|c| !c.is_whitespace())
+                        .collect::<String>()
+                        .contains(&key)
+                })
+                .unwrap_or(false)
+        })
+    };
+
+    for needle in ["128) 염상섭의 삼대", "129) <태평천하"] {
+        let a = page_of(&raw, needle);
+        let b = page_of(&bytes, needle);
+        assert!(
+            a.is_some(),
+            "원본에서 미주 {needle:?} 를 찾지 못했다 — 표본 확인"
+        );
+        assert_eq!(
+            b, a,
+            "미주 {needle:?} 가 왕복 후 다른 쪽으로 갔다 (원본 {a:?} → 왕복본 {b:?}).\n\
+             한컴은 두 파일 모두 같은 쪽에 싣는다. 아래 여백 보정이 왕복에서 사라지면 \
+             미주 단 가용이 21.3px 줄어 왼쪽 단이 조기에 닫힌다."
+        );
+    }
+}


### PR DESCRIPTION
## HWP3 왕복본에서 미주가 한 쪽씩 뒤로 밀린다 (#3707)

HWP3 → HWP5 변환본에서 미주 본문이 원본보다 한 쪽 뒤에 실립니다. 한컴은 원본·왕복본을
**같은 쪽**에 싣습니다(PDF 실측).

| 미주 | 한컴 원본 | 한컴 왕복 | rhwp 원본 | rhwp 왕복(수정 전) |
|---|---|---|---|---|
| 128 염상섭의 삼대 | 44 | 44 | **44 ✓** | **45 ✗** |
| 129 <태평천하 | 44 | 44 | 44 ✓ | 45 ✗ |
| 191 (죽음 직전 | 45 | 45 | 45 ✓ | 46 ✗ |

rhwp 의 **원본 파싱은 한컴과 완전히 일치**하고, 왕복본만 어긋납니다.

## 근인 — 렌더러 내부 허용치가 왕복에서 사라진다

HWP3 파서는 `page_def.pagination_bottom_tolerance` 를 **1600 HU**(21.3px)로 세웁니다.

```rust
// parser/hwp3/mod.rs
pagination_bottom_tolerance: 1600u32.min((doc_info.bottom_margin as u32) * 4),
```

한글97 의 마지막 줄 tolerance 를 흉내 내 **페이지네이터에게만** 여유를 주는 값이고 파일
포맷 필드가 아닙니다. HWP5 로 저장·재파싱하면 0 이 되어 본문 가용이 그만큼 짧아집니다.

```
                     허용치      본문(미주 단 가용)
원본 (HWP3)        1600 HU        877.8 px
왕복본 (수정 전)       0 HU        856.4 px   ← 21.3px 짧다
```

이 문서는 미주가 **2단**입니다. 21.3px 이 줄면 단 전환이 그만큼 일찍 걸려 왼쪽 단이
3줄에서 조기에 닫히고 오른쪽 단만 아래로 늘어납니다. 결과적으로 같은 쪽에 미주 2개를 덜
싣고 다음 쪽으로 밀어냅니다.

```
44쪽 미주 2단      왼쪽(x≈113)      오른쪽(x≈406)
원본                8줄              7줄
왕복본(수정 전)      3줄              9줄 (본문 바닥 998.9 초과)
```

## 어떻게 좁혔나 — 기존 진단으로 한 문단까지

`RHWP_ENDNOTE_BOUNDARY_DEBUG` 로 미주 223개의 높이 누적을 두 파일에서 대조했습니다.

```
pi=1129  둘 다  ch_before=731.7 adv=53.6 ch_after=785.3   ← 소수점까지 동일
pi=1130  원본    ch_before=785.3 → 계속 누적
         왕복본  ch_before=  0.0 → 단 전환
```

같은 문단의 **높이 계산은 양쪽 동일**합니다(`EN_SSOT acc=13.3 fit=13.3`). 즉 측정이
아니라 단 경계 판정이 다르다는 뜻이고, 판정 입력을 찍으니 `avail` 만 갈렸습니다
(877.8 vs 856.4, 문서 전 구간 상수).

## 수정

HWP3 출처 마커(`/RhwpHwp3Origin`)를 저장에 남기고, 재파싱이 그 허용치만 되돌립니다.
HWPX 가 쓰는 `/RhwpHwpxOrigin` 과 같은 방식입니다.

**파일에 실리는 `margin_bottom` 은 건드리지 않습니다.** 처음에는 여백에서 1600 HU 를
빼는 방식으로 구현했는데 `convert --verify` 코퍼스 래칫이 파티션 0·2 에서 실패했습니다
— 재파싱 IR 이 원본과 달라져 저장 손실로 잡힙니다. 허용치는 그 비교에서 제외되는 렌더러
내부 값이라 왕복 정합을 깨지 않고, 여백을 줄이면 한컴이 보는 쪽 기하도 원본과 달라집니다.

## 검증

| 항목 | 결과 |
|---|---|
| 미주 128·129 | **44쪽 복원** (한컴 정답지 일치) |
| 본문 가용 | 877.8 복원 |
| 한컴 열기 | 왕복본 46쪽 (원본과 동일) |
| 92셋 통제군 | 92/92 |
| 10k 모집단 586건 | **전량 무변화** |
| 표 코호트 22건 넘침 | 15,805 동일 |
| `convert --verify` 코퍼스 래칫 | **4/4** |
| `cargo nextest` | **4,533 전량 통과** |
| `clippy -D warnings` · rustfmt | 클린 |

## 회귀 테스트

`tests/issue_3707_hwp3_roundtrip_endnote_columns.rs` — 세 계약입니다.

```
reparse_restores_pagination_bottom_tolerance_via_origin_marker
stored_bottom_margin_is_untouched          ← 여백을 건드리지 않는다
endnote_bodies_land_on_the_same_pages_after_roundtrip
```

마커 판정을 끄면 첫째·셋째가 실패하고 메시지가 원인을 짚습니다(`원본 43쪽 → 왕복본
44쪽`). 둘째는 마커와 무관하므로 통과하는 것이 맞습니다.

## 진단 2종 (env 게이트, 동작 불변)

- `RHWP_DIAG_ENCOL` — 미주 단 전환 판정의 입력(`avail`/`cur_h`/`col_w`/`fit`)
- `RHWP_DIAG_AVAIL` — 가용 높이의 차감 내역(base·각주·회수·zone·bottom_fixed)

이 결함을 좁힌 도구입니다. 두 번째가 "차감은 전부 0이고 base 자체가 다르다" 를 보여
줘 근인을 특정했습니다.

## 배경

이 축은 #3504 의 세 갈래 중 하나였습니다. 그때는 **왕복본을 한컴이 열지 못해**(#3676)
정답지 대조가 성립하지 않아 "내용 동일, 실리는 쪽만 다름 — 결함 아님" 으로 분류했는데,
#3676 이 PR #3685 로 해소된 뒤 대조해 보니 결함이 맞았습니다.

Refs #3707

🤖 Generated with [Claude Code](https://claude.com/claude-code)
