### PR TITLE
test(mcp): 세션 도구 인자 타입 계약 회귀 테스트 (구현은 #3742 로 이미 머지됨)

### DIFF
--- a/tests/mcp_session_arg_typing_contract.rs
+++ b/tests/mcp_session_arg_typing_contract.rs
@@ -1,0 +1,255 @@
+//! [#3609] 세션 도구의 인자 타입은 **거부**로 끝나야지 기본값으로 흡수되면 안 된다.
+//!
+//! `args.get(k).and_then(as_u64)` 같은 관용구는 "없음" 과 "타입이 틀림" 을 `None`
+//! 하나로 뭉갠다. 그러면 잘못 만든 인자가 **오류가 아니라 기본 동작**이 되어 돌아온다.
+//!
+//! - `hwp_doc_text { page: -1 }` → 한 쪽을 달라고 했는데 **문서 전체**가 온다.
+//!   대형 문서에서는 컨텍스트가 통째로 날아가고, 에이전트는 성공으로 읽는다.
+//! - `hwp_doc_search { caseSensitive: "false" }` → 요청과 **반대로** 실행하고
+//!   봉투에는 `caseSensitive: true` 를 적어 돌려준다. 뒤집힌 줄 알 길이 없다.
+//!
+//! 범위 검사(`page: 99`)는 원래도 제대로 거절했다. 타입만 통과하던 비대칭을 없앤다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+const SAMPLE: &str = "samples/hwp3-sample.hwp";
+
+fn sample() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+struct Server {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: i64,
+}
+
+impl Server {
+    /// initialize 까지 마치고 샘플을 연 서버. 핸들 id 를 함께 돌려준다.
+    fn opened() -> (Server, String) {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+            .arg("mcp-serve")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("rhwp mcp-serve 실행 실패");
+        let stdin = child.stdin.take().expect("stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout"));
+        let mut s = Server {
+            child,
+            stdin,
+            stdout,
+            next_id: 1,
+        };
+        s.request(
+            "initialize",
+            serde_json::json!({
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "arg-typing-test", "version": "0"}
+            }),
+        );
+        let r = s.call(
+            "hwp_open",
+            serde_json::json!({"path": sample().to_string_lossy()}),
+        );
+        let text = r["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap_or_else(|| panic!("hwp_open 응답에 text 가 없습니다: {r}"));
+        let v: serde_json::Value = serde_json::from_str(text).expect("hwp_open 봉투 JSON");
+        let doc_id = v["docId"]
+            .as_str()
+            .unwrap_or_else(|| panic!("docId 가 없습니다: {v}"))
+            .to_string();
+        (s, doc_id)
+    }
+
+    fn request(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        let msg =
+            serde_json::json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params});
+        writeln!(self.stdin, "{msg}").expect("요청 쓰기 실패");
+        self.stdin.flush().expect("flush");
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let n = self.stdout.read_line(&mut line).expect("응답 읽기 실패");
+            assert!(n > 0, "서버가 응답 없이 종료했습니다 (method={method})");
+            if line.trim().is_empty() {
+                continue;
+            }
+            let v: serde_json::Value = serde_json::from_str(line.trim())
+                .unwrap_or_else(|e| panic!("stdout 이 순수 JSON-RPC 가 아닙니다 ({e}): {line}"));
+            if v.get("id").and_then(|i| i.as_i64()) == Some(id) {
+                return v;
+            }
+        }
+    }
+
+    fn call(&mut self, name: &str, args: serde_json::Value) -> serde_json::Value {
+        self.request(
+            "tools/call",
+            serde_json::json!({"name": name, "arguments": args}),
+        )
+    }
+
+    /// 도구가 isError 로 거부했는지.
+    fn rejected(&mut self, name: &str, args: serde_json::Value) -> bool {
+        self.call(name, args)["result"]["isError"] == true
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn skip_if_no_sample() -> bool {
+    if sample().exists() {
+        return false;
+    }
+    eprintln!("샘플 없음 — 건너뜀");
+    true
+}
+
+#[test]
+fn malformed_page_is_rejected_instead_of_dumping_the_whole_document() {
+    if skip_if_no_sample() {
+        return;
+    }
+    let (mut s, doc) = Server::opened();
+
+    // 기준선: 생략은 전체, 정상값은 한 쪽. 이 둘이 구분되지 않으면 아래 판정이 공허하다.
+    let all = s.call("hwp_doc_text", serde_json::json!({"docId": doc}));
+    let all: serde_json::Value =
+        serde_json::from_str(all["result"]["content"][0]["text"].as_str().unwrap()).unwrap();
+    let total = all["pageCount"].as_u64().expect("pageCount");
+    assert!(total > 1, "표본이 2쪽 이상이어야 이 테스트가 의미 있다");
+
+    let one = s.call("hwp_doc_text", serde_json::json!({"docId": doc, "page": 0}));
+    let one: serde_json::Value =
+        serde_json::from_str(one["result"]["content"][0]["text"].as_str().unwrap()).unwrap();
+    assert_eq!(one["pageCount"], 1, "page:0 은 한 쪽만 와야 한다");
+
+    for bad in [
+        serde_json::json!(-1),
+        serde_json::json!(1.5),
+        serde_json::json!("2"),
+        serde_json::json!(true),
+        serde_json::json!([0]),
+    ] {
+        let r = s.call(
+            "hwp_doc_text",
+            serde_json::json!({"docId": doc, "page": bad}),
+        );
+        assert_eq!(
+            r["result"]["isError"], true,
+            "page: {bad} 가 거부되지 않았다 — 잘못된 인자가 조용히 전체 덤프({total}쪽)로 \
+             떨어지면 에이전트는 한 쪽을 받았다고 믿는다: {r}"
+        );
+    }
+}
+
+#[test]
+fn malformed_boolean_is_rejected_instead_of_flipping_to_the_default() {
+    if skip_if_no_sample() {
+        return;
+    }
+    let (mut s, doc) = Server::opened();
+
+    // 기준선: 제대로 준 false 는 봉투에 false 로 실린다.
+    let ok = s.call(
+        "hwp_doc_search",
+        serde_json::json!({"docId": doc, "query": "의", "caseSensitive": false}),
+    );
+    let ok: serde_json::Value =
+        serde_json::from_str(ok["result"]["content"][0]["text"].as_str().unwrap()).unwrap();
+    assert_eq!(
+        ok["caseSensitive"], false,
+        "불리언 false 가 봉투에 반영되지 않는다: {ok}"
+    );
+
+    for bad in [
+        serde_json::json!("false"),
+        serde_json::json!(0),
+        serde_json::json!("true"),
+    ] {
+        assert!(
+            s.rejected(
+                "hwp_doc_search",
+                serde_json::json!({"docId": doc, "query": "의", "caseSensitive": bad}),
+            ),
+            "caseSensitive: {bad} 가 거부되지 않았다 — 기본값 true 로 흡수되면 요청과 \
+             반대로 실행하고 봉투에는 true 를 적어 돌려준다"
+        );
+        assert!(
+            s.rejected(
+                "hwp_doc_replace_text",
+                serde_json::json!({
+                    "docId": doc, "find": "의", "replace": "X", "caseSensitive": bad
+                }),
+            ),
+            "replace_text 의 caseSensitive: {bad} 가 거부되지 않았다"
+        );
+    }
+
+    for bad in [serde_json::json!("true"), serde_json::json!(1)] {
+        assert!(
+            s.rejected(
+                "hwp_doc_set_cell",
+                serde_json::json!({
+                    "docId": doc, "table": 0, "row": 0, "col": 0,
+                    "text": "X", "keepStyle": bad
+                }),
+            ),
+            "keepStyle: {bad} 가 거부되지 않았다 — 스타일 유지 요청이 정규화로 뒤집힌다"
+        );
+    }
+}
+
+#[test]
+fn missing_and_mistyped_coordinates_say_different_things() {
+    if skip_if_no_sample() {
+        return;
+    }
+    let (mut s, doc) = Server::opened();
+
+    let missing = s.call(
+        "hwp_doc_set_cell",
+        serde_json::json!({"docId": doc, "row": 0, "col": 0, "text": "X"}),
+    );
+    let missing = missing["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+    let mistyped = s.call(
+        "hwp_doc_set_cell",
+        serde_json::json!({"docId": doc, "table": -1, "row": 0, "col": 0, "text": "X"}),
+    );
+    let mistyped = mistyped["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+
+    assert!(
+        missing.contains("필요"),
+        "누락은 '필요' 라고 말해야 한다: {missing}"
+    );
+    assert!(
+        !mistyped.contains("필요"),
+        "타입 오류에 '필요합니다' 를 돌려주면 에이전트는 보내지 않은 줄 알고 같은 값을 \
+         다시 보낸다 — 무한 재시도의 씨앗이다: {mistyped}"
+    );
+    assert!(
+        mistyped.contains("-1"),
+        "받은 값을 되돌려줘야 무엇이 틀렸는지 안다: {mistyped}"
+    );
+}


### PR DESCRIPTION
Issue: #3609

## devel 재기준 정리 — 구현은 걷어내고 회귀 테스트만 남겼습니다

이 PR 은 원래 `src/mcp_serve.rs` 의 인자 강제변환을 고치는 내용이었습니다. 그 사이 #3742 통합 머지로 **같은 취지의 구현이 이미 devel 에 들어갔습니다.** 충돌이 난 이유이기도 합니다.

devel 은 `opt_u64` / `opt_bool` / `req_u64` 를 갖추고 세션 도구에 실제로 배선해 두었습니다.

| 도구·인자 | devel 위치 |
|---|---|
| `hwp_doc_text` 의 `page` | `opt_u64` (802행) |
| 좌표 `table` · `row` · `col` | `req_u64` (1034·1038·1042행) |
| `caseSensitive` | `opt_bool` (950·987행) |
| `keepStyle` | `opt_bool` (1051행) |

제가 올렸던 `opt_u32` / `opt_bool(default)` 판보다 devel 쪽이 범위가 넓습니다 — 파이썬 계열 호스트가 정수를 `3.0` 으로 직렬화하는 경우까지 받아 줍니다. 그래서 **구현은 전부 버렸습니다.** 이 PR 의 diff 는 이제 테스트 파일 하나뿐입니다.

## 남긴 이유

계약이 깨지는 방향이 조용합니다. 인자 처리를 다시 `args.get(k).and_then(as_u64)` 관용구로 되돌리면 **"없음" 과 "타입이 틀림" 이 `None` 하나로 합쳐지고**, 잘못된 인자가 오류가 아니라 기본 동작으로 돌아옵니다. 실패가 아니라 거짓 성공이라 에이전트는 재시도조차 하지 않습니다.

- `hwp_doc_text { page: -1 }` → 한 쪽을 달라고 했는데 **문서 전체**가 옵니다.
- `hwp_doc_search { caseSensitive: "false" }` → 요청과 **반대로** 실행하고 봉투에는 `caseSensitive: true` 를 적어 돌려줍니다.

## 테스트

`tests/mcp_session_arg_typing_contract.rs` — `mcp-serve` 를 실제로 띄워 JSON-RPC 로 검증하는 블랙박스 테스트입니다. 내부 함수 이름이나 오류 문구에 기대지 않아 구현을 바꿔도 계속 유효합니다.

- `page` 에 `-1` / `1.5` / `"2"` / `true` / `[0]` 을 주면 모두 `isError`. 생략은 전체, `page:0` 은 한 쪽이라는 **기준선을 먼저 세워** 판정이 공허해지지 않게 했습니다.
- `caseSensitive` 에 `"false"` 를 주면 기본값으로 흡수하지 않고 거부합니다.
- 좌표 인자는 생략과 타입 오류를 **서로 다른 문구**로 보고합니다.

동작 변화 없음. 테스트만 추가합니다.

## 검증

작업 PC 의 MSVC 링커(`dbghelp.lib`)가 손상되어 있고 GNU 툴체인에는 `dlltool` 이 없어 로컬 `cargo test` 가 돌지 않습니다. 저장소 기준 검증은 CI 에 맡깁니다 — 이 PR 이 `src` 를 건드리지 않으므로 CI 초록은 곧 "현재 devel 이 이 계약을 이미 만족한다" 는 실증이 됩니다.
