### PR TITLE
fix(mcp): hwp_doc_save가 output 확장자를 무시하고 원본 포맷만으로 저장한다

### DIFF
--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -1279,10 +1279,17 @@ fn session_save(args: &serde_json::Value, sessions: &mut Sessions) -> serde_json
         );
     };
 
-    let format = if sd.source_is_hwpx {
-        crate::EditOutputFormat::Hwpx
-    } else {
-        crate::EditOutputFormat::Hwp
+    // [버그] `output` 경로의 확장자를 무시하고 원본 포맷(source_is_hwpx)만으로 직렬화
+    // 형식을 정했다 — HWPX 핸들을 `.hwp` 경로로 저장해도 zip(HWPX) 바이트를 그대로
+    // 써 버려 확장자와 실제 내용이 어긋났다. CLI의 `edit_output_format`(main.rs)은
+    // 명시적 출력 확장자를 우선하는데, MCP 세션 경로만 비동형이었다. 같은 규칙을 쓴다.
+    let explicit_ext = std::path::Path::new(output)
+        .extension()
+        .map(|ext| ext.to_string_lossy().to_ascii_lowercase());
+    let format = match (sd.source_is_hwpx, explicit_ext.as_deref()) {
+        (true, Some("hwp")) => crate::EditOutputFormat::Hwp,
+        (true, _) => crate::EditOutputFormat::Hwpx,
+        (false, _) => crate::EditOutputFormat::Hwp,
     };
     // HWP5 산출 경로의 어댑터(`convert_if_hwpx_source`)는 `Hwpx | Hwp3` 양쪽에서 돌며
     // 살아 있는 IR 을 제자리에서 고친다. 도구 계약이 "핸들은 저장 후에도 열려 있다"

--- a/tests/mcp_session_edit_contract.rs
+++ b/tests/mcp_session_edit_contract.rs
@@ -225,6 +225,57 @@ fn session_save_preserves_hwpx_format() {
     let _ = std::fs::remove_file(&out);
 }
 
+/// [버그] `hwp_doc_save` 는 `output` 경로의 확장자를 무시하고 원본 포맷
+/// (`source_is_hwpx`) 만으로 직렬화 형식을 정했다 — HWPX 로 연 핸들을 `.hwp`
+/// 경로로 저장해도 zip(HWPX) 바이트를 그대로 써서 확장자와 실제 내용이
+/// 어긋났다. CLI 의 `edit_output_format` 은 명시적 출력 확장자를 우선하는데
+/// (`.hwp` 지정 시 HWP5 로 변환), MCP 세션 경로만 비동형이었다. `.hwp` 로
+/// 저장하면 실제로 HWP5(CFB, `D0 CF 11 E0`) 바이트가 나와야 한다.
+#[test]
+fn session_save_honors_explicit_hwp_output_extension_for_hwpx_source() {
+    let src = sample();
+    if !src.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let hwpx_src = temp_path("ext-src", "hwpx");
+    let conv = run_cli(&[
+        "export-hwpx",
+        src.to_str().unwrap(),
+        hwpx_src.to_str().unwrap(),
+    ]);
+    assert_eq!(conv.status.code(), Some(0), "사전 변환 실패");
+
+    let mut s = Server::started();
+    let doc_id = s.open(&hwpx_src);
+
+    // HWPX 핸들인데 출력 경로 확장자는 .hwp — CLI 규약대로 HWP5 로 변환 저장돼야 한다.
+    let out = temp_path("ext-out", "hwp");
+    let (err, sv) = s.call(
+        "hwp_doc_save",
+        serde_json::json!({"docId": doc_id, "output": out.to_str().unwrap()}),
+    );
+    assert!(!err, "{sv}");
+    assert_eq!(
+        sv["outputFormat"], "hwp5",
+        "output 확장자 .hwp 를 존중해 HWP5 로 저장해야 합니다: {sv}"
+    );
+
+    let bytes = std::fs::read(&out).expect(".hwp 출력 파일을 읽을 수 없습니다");
+    assert!(
+        bytes.starts_with(&[0xD0, 0xCF, 0x11, 0xE0]),
+        ".hwp 로 저장했는데 HWP5(CFB) 바이트가 아닙니다 — 처음 4바이트: {:02X?}",
+        &bytes[..bytes.len().min(4)]
+    );
+    assert!(
+        !bytes.starts_with(b"PK"),
+        ".hwp 로 저장했는데 여전히 HWPX(zip) 바이트가 그대로 나왔습니다: {sv}"
+    );
+
+    let _ = std::fs::remove_file(&hwpx_src);
+    let _ = std::fs::remove_file(&out);
+}
+
 #[test]
 fn session_fill_reports_judgment_fields_like_stateless() {
     // 무상태 hwp_fill_fields 와 같은 판정 어휘 — notFound 는 침묵하지 않는다.


### PR DESCRIPTION
## 버그

`hwp_doc_save` (MCP 세션 저장 도구)는 `output` 경로의 확장자를 보지 않고
`sd.source_is_hwpx`(핸들을 연 원본 포맷)만으로 직렬화 형식을 정했습니다.

그 결과 HWPX 문서로 연 핸들을 `output: "foo.hwp"` 로 저장해도 zip(HWPX)
바이트가 `.hwp` 확장자 그대로 기록됩니다 — 확장자와 실제 파일 내용이
어긋난 산출물이 `isError: false`, `outputFormat: "hwpx"` 로 조용히
나옵니다.

CLI `edit` 계열이 쓰는 `edit_output_format` (`src/main.rs`)은 명시적 출력
확장자를 우선합니다: HWPX 입력 + `.hwp` 출력이면 경고와 함께 HWP5로
변환 저장합니다. MCP 세션 저장 경로(`session_save`, `src/mcp_serve.rs`)만
이 규칙과 비동형이었습니다.

## 수정

`session_save` 에 CLI와 동일한 `(source_is_hwpx, 출력 확장자)` 매칭 규칙을
적용했습니다 — HWPX 핸들 + `.hwp` 출력이면 HWP5로 변환 저장(`Hwp`),
그 외엔 원본 포맷을 유지합니다.

## Before / After

**수정 전** (`tests/mcp_session_edit_contract.rs` 에 추가한 회귀 테스트로 재현):
```
HWPX 핸들 → hwp_doc_save({"output": "*.hwp"})
→ {"outputFormat": "hwpx", ...}   // 확장자와 실제 포맷 불일치
→ 파일 바이트: 50 4B ... (PK, zip/HWPX)  // .hwp 인데 zip
```

**수정 후**:
```
HWPX 핸들 → hwp_doc_save({"output": "*.hwp"})
→ {"outputFormat": "hwp5", ...}
→ 파일 바이트: D0 CF 11 E0 ... (CFB, HWP5)
```

## 테스트

```
cargo fmt --all -- --check                                      → 통과
cargo clippy --profile release-test --bin rhwp -- -D warnings   → 통과
cargo test --profile release-test \
  --test mcp_session_edit_contract \
  --test edit_verify_contract \
  --test mcp_session_query_contract \
  --test mcp_session_setcell_contract                           → 24 passed, 0 failed
```

새 회귀 테스트 `session_save_honors_explicit_hwp_output_extension_for_hwpx_source` 는
수정 전 커밋에 대해 먼저 돌려 실패(outputFormat left="hwpx" right="hwp5")를
직접 확인한 뒤, 수정을 적용해 통과함을 검증했습니다.

## 참고

이 PR을 준비하는 동안 같은 세션의 다른 MCP 인자 검증 버그들
(`hwp_doc_text` page 타입 강제변환, `hwp_doc_set_cell` 개행 가드,
검색어 선행 `-` 오분류)은 이미 devel 에 병합돼 있는 것을 확인했습니다
(`ffeaa00e3`, `5c91b849e`). 이 PR은 그 목록에서 유일하게 아직 남아 있던
`hwp_doc_save` 출력 확장자 버그만 다룹니다.