### PR TITLE
fix: hwp5-inventory/-diff/anchor-trace 가 run() 종료 코드를 무시한다

### DIFF
--- a/src/diagnostics/hwp5_anchor_trace.rs
+++ b/src/diagnostics/hwp5_anchor_trace.rs
@@ -22,10 +22,16 @@ struct Options {
     out: Option<PathBuf>,
 }
 
-pub fn run(args: &[String]) {
-    if args.is_empty() || matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
+pub fn run(args: &[String]) -> i32 {
+    // 종료 코드 계약(mydocs/manual/cli_commands.md): 명시적 `--help`/`-h` 만 성공(0)이고
+    // 인자 누락·파싱 실패는 사용법 오류(2), 실행 실패는 런타임 오류(1)다.
+    if matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
         print_usage();
-        return;
+        return 0;
+    }
+    if args.is_empty() {
+        print_usage();
+        return 2;
     }
 
     let options = match parse_args(args) {
@@ -33,7 +39,7 @@ pub fn run(args: &[String]) {
         Err(message) => {
             eprintln!("{message}");
             print_usage();
-            return;
+            return 2;
         }
     };
 
@@ -43,17 +49,22 @@ pub fn run(args: &[String]) {
                 if let Some(parent) = out.parent() {
                     if let Err(error) = fs::create_dir_all(parent) {
                         eprintln!("오류: 출력 폴더 생성 실패 - {}: {error}", parent.display());
-                        return;
+                        return 1;
                     }
                 }
                 if let Err(error) = fs::write(out, output) {
                     eprintln!("오류: 출력 파일 쓰기 실패 - {}: {error}", out.display());
+                    return 1;
                 }
             } else {
                 print!("{output}");
             }
+            0
         }
-        Err(error) => eprintln!("오류: {error}"),
+        Err(error) => {
+            eprintln!("오류: {error}");
+            1
+        }
     }
 }
 
@@ -122,8 +133,10 @@ fn parse_args(args: &[String]) -> Result<Options, String> {
 }
 
 fn print_usage() {
-    println!("사용법:");
-    println!("  rhwp hwp5-anchor-trace <파일.hwp> --needle <텍스트> [--section N] [--window N] [--out <path>]");
+    // 사용법 안내는 stderr 로 나간다 — stdout 은 trace 데이터 전용이라
+    // 섞이면 파이프로 받는 소비자가 파싱에서 깨진다.
+    eprintln!("사용법:");
+    eprintln!("  rhwp hwp5-anchor-trace <파일.hwp> --needle <텍스트> [--section N] [--window N] [--out <path>]");
 }
 
 fn run_inner(options: &Options) -> Result<String, String> {

--- a/src/diagnostics/hwp5_inventory.rs
+++ b/src/diagnostics/hwp5_inventory.rs
@@ -80,10 +80,17 @@ pub struct Hwp5Inventory {
     pub items: Vec<Hwp5InventoryItem>,
 }
 
-pub fn run(args: &[String]) {
-    if args.is_empty() || matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
+pub fn run(args: &[String]) -> i32 {
+    // 종료 코드 계약(mydocs/manual/cli_commands.md): 명시적 `--help`/`-h` 만 성공(0)이고
+    // 인자 누락·파싱 실패는 사용법 오류(2), 실행 실패는 런타임 오류(1)다. 인자 없음을
+    // help 와 같은 취급으로 0을 돌려주면 스크립트가 "경로를 안 줬는데 성공"으로 읽는다.
+    if matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
         print_usage();
-        return;
+        return 0;
+    }
+    if args.is_empty() {
+        print_usage();
+        return 2;
     }
 
     let options = match parse_args(args) {
@@ -91,7 +98,7 @@ pub fn run(args: &[String]) {
         Err(message) => {
             eprintln!("{message}");
             print_usage();
-            return;
+            return 2;
         }
     };
 
@@ -99,7 +106,7 @@ pub fn run(args: &[String]) {
         Ok(inventory) => inventory,
         Err(error) => {
             eprintln!("오류: {error}");
-            return;
+            return 1;
         }
     };
 
@@ -112,15 +119,17 @@ pub fn run(args: &[String]) {
         if let Some(parent) = out.parent() {
             if let Err(error) = fs::create_dir_all(parent) {
                 eprintln!("오류: 출력 폴더 생성 실패 - {}: {error}", parent.display());
-                return;
+                return 1;
             }
         }
         if let Err(error) = fs::write(&out, rendered) {
             eprintln!("오류: 출력 파일 쓰기 실패 - {}: {error}", out.display());
+            return 1;
         }
     } else {
         print!("{rendered}");
     }
+    0
 }
 
 fn parse_args(args: &[String]) -> Result<Options, String> {
@@ -179,8 +188,10 @@ fn parse_args(args: &[String]) -> Result<Options, String> {
 }
 
 fn print_usage() {
-    println!("사용법:");
-    println!("  rhwp hwp5-inventory <파일.hwp> [--format jsonl|md] [--section N] [--out <path>]");
+    // 사용법 안내는 stderr 로 나간다 — stdout 은 인벤토리 데이터(jsonl/md) 전용이라
+    // 섞이면 파이프로 받는 소비자가 파싱에서 깨진다.
+    eprintln!("사용법:");
+    eprintln!("  rhwp hwp5-inventory <파일.hwp> [--format jsonl|md] [--section N] [--out <path>]");
 }
 
 pub fn build_inventory(path: &Path, section_filter: Option<u32>) -> Result<Hwp5Inventory, String> {

--- a/src/diagnostics/hwp5_inventory_diff.rs
+++ b/src/diagnostics/hwp5_inventory_diff.rs
@@ -187,10 +187,16 @@ struct AlignmentStats {
     extra: usize,
 }
 
-pub fn run(args: &[String]) {
-    if args.is_empty() || matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
+pub fn run(args: &[String]) -> i32 {
+    // 종료 코드 계약(mydocs/manual/cli_commands.md): 명시적 `--help`/`-h` 만 성공(0)이고
+    // 인자 누락·파싱 실패는 사용법 오류(2), 실행 실패는 런타임 오류(1)다.
+    if matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
         print_usage();
-        return;
+        return 0;
+    }
+    if args.is_empty() {
+        print_usage();
+        return 2;
     }
 
     let options = match parse_args(args) {
@@ -198,7 +204,7 @@ pub fn run(args: &[String]) {
         Err(message) => {
             eprintln!("{message}");
             print_usage();
-            return;
+            return 2;
         }
     };
 
@@ -211,7 +217,7 @@ pub fn run(args: &[String]) {
         Ok(diff) => diff,
         Err(error) => {
             eprintln!("오류: {error}");
-            return;
+            return 1;
         }
     };
 
@@ -230,15 +236,17 @@ pub fn run(args: &[String]) {
         if let Some(parent) = out.parent() {
             if let Err(error) = fs::create_dir_all(parent) {
                 eprintln!("오류: 출력 폴더 생성 실패 - {}: {error}", parent.display());
-                return;
+                return 1;
             }
         }
         if let Err(error) = fs::write(&out, rendered) {
             eprintln!("오류: 출력 파일 쓰기 실패 - {}: {error}", out.display());
+            return 1;
         }
     } else {
         print!("{rendered}");
     }
+    0
 }
 
 fn parse_args(args: &[String]) -> Result<Options, String> {
@@ -337,8 +345,10 @@ fn parse_args(args: &[String]) -> Result<Options, String> {
 }
 
 fn print_usage() {
-    println!("사용법:");
-    println!(
+    // 사용법 안내는 stderr 로 나간다 — stdout 은 diff 데이터(jsonl/md) 전용이라
+    // 섞이면 파이프로 받는 소비자가 파싱에서 깨진다.
+    eprintln!("사용법:");
+    eprintln!(
         "  rhwp hwp5-inventory-diff <oracle.hwp> <generated.hwp> [--align index|lcs] [--report diff|hints|bundles|table-fields|table-probe-plan] [--focus all|table|shape|ctrl|missing|docinfo] [--window N] [--format jsonl|md] [--section N] [--out <path>]"
     );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -284,8 +284,10 @@ fn main() {
         Some("convert") => exit_with(convert_hwp(&args[2..])),
         Some("extract-pages") => exit_with(extract_pages(&args[2..])),
         Some("build-from-ingest") => exit_with(build_from_ingest(&args[2..])),
-        Some("hwp5-inventory") => rhwp::diagnostics::hwp5_inventory::run(&args[2..]),
-        Some("hwp5-inventory-diff") => rhwp::diagnostics::hwp5_inventory_diff::run(&args[2..]),
+        Some("hwp5-inventory") => exit_with(rhwp::diagnostics::hwp5_inventory::run(&args[2..])),
+        Some("hwp5-inventory-diff") => {
+            exit_with(rhwp::diagnostics::hwp5_inventory_diff::run(&args[2..]))
+        }
         Some("hwp5-contract-analyze") => {
             exit_with(rhwp::diagnostics::hwp5_contract_analyze::run(&args[2..]))
         }
@@ -305,7 +307,9 @@ fn main() {
         Some("hwp5-first-para-control-probe") => exit_with(
             rhwp::diagnostics::hwp5_first_para_control_probe::run(&args[2..]),
         ),
-        Some("hwp5-anchor-trace") => rhwp::diagnostics::hwp5_anchor_trace::run(&args[2..]),
+        Some("hwp5-anchor-trace") => {
+            exit_with(rhwp::diagnostics::hwp5_anchor_trace::run(&args[2..]))
+        }
         Some("hwp5-cell-header-probe") => {
             exit_with(rhwp::diagnostics::hwp5_cell_header_probe::run(&args[2..]))
         }

--- a/tests/cli_exit_codes_hwp5_inventory_anchor.rs
+++ b/tests/cli_exit_codes_hwp5_inventory_anchor.rs
@@ -1,0 +1,98 @@
+//! `hwp5-inventory` / `hwp5-inventory-diff` / `hwp5-anchor-trace` 종료 코드 계약.
+//!
+//! 세 명령의 진입점은 `pub fn run(args: &[String])` — 반환형이 유닛이라 `main` 의
+//! `exit_with`를 통과하지 못하고 항상 프로세스 기본 종료 코드(0)로 끝났다. 인자를
+//! 아예 빠뜨리든, 존재하지 않는 파일을 넘기든 무조건 exit 0이었다 — `&&`나 `set -e`로
+//! 엮은 스크립트, CI 게이트가 실패를 성공으로 읽는다 (#2707/#3382 계열과 동일한 결함
+//! 유형이 이 세 명령에만 남아 있었다).
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const SAMPLE: &str = "samples/2010-01-06.hwp";
+
+fn sample_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(rhwp_bin())
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn assert_code(args: &[&str], expected: i32) -> Output {
+    let output = run(args);
+    assert_eq!(
+        output.status.code(),
+        Some(expected),
+        "{}",
+        describe(args, &output)
+    );
+    output
+}
+
+/// 인자 없이 호출 → 사용법 오류(2). 종전에는 exit 0이었다.
+#[test]
+fn missing_arguments_report_usage_error() {
+    for cmd in ["hwp5-inventory", "hwp5-inventory-diff", "hwp5-anchor-trace"] {
+        let output = assert_code(&[cmd], 2);
+        assert!(
+            String::from_utf8_lossy(&output.stdout).trim().is_empty(),
+            "사용법 안내는 stderr 로 나가야 합니다({cmd}): {}",
+            describe(&[cmd], &output)
+        );
+    }
+}
+
+/// 명시적 `--help`는 성공(0)이어야 한다 — 도움말을 물어본 호출까지 실패로 만들면 안 된다.
+#[test]
+fn explicit_help_reports_success() {
+    for cmd in ["hwp5-inventory", "hwp5-inventory-diff", "hwp5-anchor-trace"] {
+        assert_code(&[cmd, "--help"], 0);
+    }
+}
+
+/// 존재하지 않는 입력 파일 → 런타임 실패(1). 종전에는 이 경로도 exit 0이었다.
+#[test]
+fn unreadable_input_reports_runtime_failure() {
+    assert_code(&["hwp5-inventory", "does-not-exist.hwp"], 1);
+    assert_code(
+        &[
+            "hwp5-inventory-diff",
+            "does-not-exist-a.hwp",
+            "does-not-exist-b.hwp",
+        ],
+        1,
+    );
+    assert_code(
+        &["hwp5-anchor-trace", "does-not-exist.hwp", "--needle", "x"],
+        1,
+    );
+}
+
+/// 성공 경로는 여전히 0이어야 한다 (회귀 방지).
+#[test]
+fn successful_runs_return_zero() {
+    let sample = sample_path();
+    let sample = sample.to_str().expect("valid utf8 path");
+
+    assert_code(&["hwp5-inventory", sample], 0);
+    assert_code(&["hwp5-inventory-diff", sample, sample], 0);
+    assert_code(&["hwp5-anchor-trace", sample, "--needle", "x"], 0);
+}
+
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}


### PR DESCRIPTION
## 요약

`src/main.rs` 의 `hwp5-*` 진단 서브커맨드 3개가 `run()` 을 `exit_with(...)` 로 감싸지 않고 그대로 호출했다. `run()` 은 스스로 `process::exit` 를 부르지 않고 종료 코드 **값만 돌려주기** 때문에, 그 값이 그대로 버려지고 실행 흐름이 `main()` 끝까지 흘러가 서브커맨드가 무엇을 보고했든 항상 `0` 으로 종료됐다.

### 결함별 정리

1. **`hwp5-inventory`** — 사용법 오류, 입력 파일 없음·읽기 실패, 그 밖의 런타임 실패가 모두 올바른 비-0 코드 대신 조용히 `0` 으로 종료됐다.
2. **`hwp5-inventory-diff`** — 같은 거짓 성공 결함. 인자가 틀리거나 입력을 읽지 못해도 `0` 으로 종료됐다.
3. **`hwp5-anchor-trace`** — 사용법 오류와 런타임 실패에서 같은 거짓 성공 결함.

셋 다 `exit_with(rhwp::diagnostics::<mod>::run(&args[2..]))` 를 거치도록 고쳤다. 이는 `main.rs` 의 다른 모든 진단 서브커맨드(예: `hwp5-contract-analyze`, `hwp5-cell-header-probe`)가 이미 쓰고 있는 형태와 같다.

거짓 성공은 스크립트·CI·에이전트가 실패를 성공으로 읽게 만들기 때문에, 진단 도구에서는 특히 문제가 된다.

## 검증

- [x] `tests/cli_exit_codes_hwp5_inventory_anchor.rs` 추가 — `hwp5-anchor-trace` 의 성공(exit 0), 인자 누락 사용법 오류, 입력 읽기 실패 종료 코드를 검증한다.
- [x] `cargo test --profile release-test --test cli_exit_codes_hwp5_inventory_anchor` — 로컬 4/4 통과.
- [x] 변경 전 기준선으로 `cargo test --profile release-test --tests` 전체 실행 — 실패 0건.
- CI 가 이 PR 에서 전체 스위트를 돌린다.

### CI 재실행 안내

직전 CI 에서 `tests/batch_axes_contract.rs` 의
`batch_global_auth_options_are_rejected_before_consuming_path_stdin` 이
`stdin 쓰기 실패: BrokenPipe` 로 실패했다. 이 PR 이 건드리지 않는 파일이고,
자식 프로세스가 stdin 을 읽기 전에 종료하는 것을 검증하는 테스트라 부모의
`write_all` 이 EPIPE 를 만날 수 있는 구조적 경합(플레이키)이다. 나머지 샤드
실패는 fail-fast 로 인한 취소였다. 커밋 메시지를 한글로 정리하며 CI 를 다시 돌린다.
