### PR TITLE
test(hwpx): 속성값 이스케이프 계약 회귀 테스트 (최초 결함 주장 철회)

### DIFF
--- a/src/serializer/hwpx/utils.rs
+++ b/src/serializer/hwpx/utils.rs
@@ -154,4 +154,66 @@ mod tests {
         );
         assert!(!xml.contains('\u{03}'));
     }
+
+    /// HWPX 속성값의 마크업 문자 이스케이프 계약.
+    ///
+    /// `start_tag_attrs`/`empty_tag` 는 값에 `filter_xml_1_0_chars` 만 적용하고 나머지는
+    /// quick-xml 에 맡긴다. 이스케이프는 `push_attribute` 가 아니라 그 인자인
+    /// `(&str, &str)` → `Attribute` 변환에서 일어난다 — quick-xml 이 문서화한 동작:
+    /// "Key is stored as-is, but the value will be escaped."
+    ///
+    /// 이 위임 관계는 눈에 보이지 않아서 양쪽으로 조용히 깨질 수 있다.
+    /// (a) 값을 `&[u8]` 로 넘기도록 바꾸면 그 `From` 구현은 이스케이프하지 않으므로
+    ///     `&`/`<` 가 그대로 새어나가 저장된 `section*.xml` 이 불법 XML 이 되거나,
+    ///     `"` 가 속성값을 조기 종료시켜 뒤 내용이 마크업으로 해석된다.
+    /// (b) 반대로 여기서 `xml_escape` 를 한 번 더 적용하면 이중 이스케이프가 되어
+    ///     `&` 가 `&amp;amp;` 로 저장되고, 다시 읽으면 `&amp;` 가 되어 값이 손상된다.
+    ///     (예: Picture href 의 쿼리스트링 `?a=1&b=2`)
+    ///
+    /// 그래서 형식만 보지 않고 실제 파서로 왕복시켜 값이 그대로 복원되는지까지 확인한다.
+    #[test]
+    fn event_writers_escape_markup_chars_in_attribute_values() {
+        use quick_xml::{Reader, XmlVersion};
+
+        let mut bytes = Vec::new();
+        let mut writer = Writer::new(&mut bytes);
+        start_tag_attrs(&mut writer, "hp:start", &[("href", r#"a&b<c>d"e"#)]).unwrap();
+        end_tag(&mut writer, "hp:start").unwrap();
+        empty_tag(&mut writer, "hp:empty", &[("href", r#"x&y"z<w"#)]).unwrap();
+
+        let xml = String::from_utf8(bytes).unwrap();
+
+        // 원문이 그대로 새어나가면 불법 XML / 속성 인젝션이다.
+        assert!(
+            !xml.contains(r#"href="a&b<c>d"e""#),
+            "속성값이 이스케이프되지 않고 그대로 방출됨: {xml}"
+        );
+        // 마크업 문자는 엔티티로 나타나야 한다.
+        assert!(
+            xml.contains("&amp;") && xml.contains("&lt;") && xml.contains("&gt;"),
+            "{xml}"
+        );
+        // 이중 이스케이프 방지 — `&amp;amp;` 가 보이면 값이 손상된 것이다.
+        assert!(!xml.contains("&amp;amp;"), "이중 이스케이프됨: {xml}");
+
+        // 형식이 아니라 의미 보존 확인: 실제 파서로 왕복시켜 원래 값이 그대로 나와야 한다.
+        let mut reader = Reader::from_str(&xml);
+        let mut seen = Vec::new();
+        loop {
+            match reader.read_event().unwrap() {
+                Event::Start(e) | Event::Empty(e) => {
+                    for a in e.attributes().flatten() {
+                        seen.push(
+                            a.normalized_value(XmlVersion::Implicit1_0)
+                                .unwrap()
+                                .into_owned(),
+                        );
+                    }
+                }
+                Event::Eof => break,
+                _ => {}
+            }
+        }
+        assert_eq!(seen, vec![r#"a&b<c>d"e"#, r#"x&y"z<w"#]);
+    }
 }


### PR DESCRIPTION
## 정정 안내

이 PR 은 처음에 "`start_tag_attrs`/`empty_tag` 가 속성값을 이스케이프하지 않는다"는 **결함 수정**으로 올렸습니다. 그 전제가 **틀렸습니다**. 되짚어 확인한 결과 현재 코드는 이미 올바르게 동작하며, 제가 넣었던 `xml_escape` 추가는 오히려 **이중 이스케이프** 회귀였습니다. CI 가 이를 정확히 잡아냈습니다.

원인은 이스케이프가 일어나는 위치를 잘못 짚은 것입니다. quick-xml 의 `BytesStart::push_attr` 에 확실히 `// FIXME: need to escape attribute content` 주석이 있지만, 이스케이프는 그보다 앞선 **인자 변환 단계**에서 이미 끝나 있습니다.

```rust
impl<'a> From<(&'a str, &'a str)> for Attribute<'a> {
    /// Key is stored as-is, but the value will be escaped.
```

`el.push_attribute((*k, value.as_str()))` 는 `(&str, &str)` 를 넘기므로 이 변환을 타고, 값은 이미 이스케이프됩니다. (이스케이프하지 않는 것은 `(&[u8], &[u8])` 계열 변환입니다.) 저장소 전체에서 `push_attribute` 호출부는 `utils.rs` 의 이 두 곳뿐이고, 둘 다 `(&str, &str)` 경로입니다.

### 실측

최소 재현기로 두 구현을 나란히 돌린 결과입니다. 입력 `a&b<c>d"e`:

| 구현 | 방출 XML | 왕복 복원값 | 값 보존 |
|---|---|---|---|
| 현재 코드 (`filter` 만) | `href="a&amp;b&lt;c&gt;d&quot;e"` | `a&b<c>d"e` | ✅ true |
| 이 PR 최초안 (`xml_escape` 추가) | `href="a&amp;amp;b&amp;lt;..."` | `a&amp;b&lt;...` | ❌ false |

## 이 PR 이 지금 하는 일

`src` 변경을 모두 되돌리고, **회귀 테스트만** 남겼습니다. 동작 변화는 없습니다.

남긴 이유는 이 계약이 코드에 드러나지 않기 때문입니다. `utils.rs` 만 봐서는 이스케이프가 어디서 일어나는지 알 수 없고(제가 실제로 잘못 읽었습니다), 양쪽 방향으로 조용히 깨질 수 있습니다.

- 값을 `&[u8]` 로 넘기도록 바꾸면 이스케이프가 사라져 `&`/`<` 가 새어나가고, `"` 가 속성값을 조기 종료시켜 뒤 내용이 마크업으로 해석됩니다.
- 헬퍼에서 한 번 더 이스케이프하면 `&` 가 `&amp;amp;` 로 저장되어 값이 손상됩니다 (예: Picture href 의 쿼리스트링 `?a=1&b=2`).

그래서 형식만 보지 않고 **실제 파서로 왕복시켜 원래 값이 그대로 복원되는지**까지 검증합니다.

## 검증

- `src/serializer/hwpx/utils.rs` 의 `event_writers_escape_markup_chars_in_attribute_values` 추가 — 원문 유출 없음 / 마크업 문자가 엔티티로 존재 / `&amp;amp;` 없음(이중 이스케이프 방지) / 왕복 후 원값 복원.
- 이 PC 에서는 MSVC 링커 손상(`dbghelp.lib`)과 GNU `dlltool` 부재로 저장소 전체 빌드가 불가해, 테스트 본문 로직은 quick-xml 0.41 최소 크레이트로 따로 실행해 4개 단언이 모두 통과함을 확인했습니다. 저장소 기준 최종 검증은 CI 에 맡깁니다.

불필요한 리뷰 시간을 쓰게 해 죄송합니다. 필요 없다고 판단하시면 닫아 주셔도 됩니다.
