### PR TITLE
test(hml): RECTANGLE POSITION 음수 오프셋 왕복 회귀 테스트 (최초 결함 주장 철회)

### DIFF
--- a/tests/hml_parser.rs
+++ b/tests/hml_parser.rs
@@ -991,3 +991,31 @@ fn parse_document_dispatches_hml_into_document_ir() {
 
     assert_eq!(document.sections[0].paragraphs[0].text, "안녕 HML 123");
 }
+
+/// `RECTANGLE` 의 `POSITION HorzOffset`/`VertOffset` 는 음수(왼쪽/위쪽으로 벗어난 앵커 상대
+/// 배치)일 수 있고, 우리 자신의 HML writer
+/// (`serializer/hml/body.rs::position_attributes`, `(offset as i32).to_string()`)도 음수를
+/// 그대로 방출한다. 따라서 음수 오프셋 왕복은 반드시 성립해야 하는 계약이다.
+///
+/// 이 왕복이 성립하는 이유는 타입에 있다. `reader.rs` 의 `RECTANGLE` 분기는 타입 파라미터
+/// 없이 `parse_attribute` 를 부르지만, 대입 대상이 `HmlRectangle::horizontal_offset: i32`
+/// (모델의 `HwpUnit = u32` 가 아니라 파서 중간 구조체의 `i32`)라 `T` 가 `i32` 로 추론되고
+/// `i32::from_str` 이 `-` 부호를 받아들인다. 이후 `adapter.rs` 가 `as u32` 로 재해석해
+/// 모델에 싣는다.
+///
+/// 이 계약은 타입 추론에 의존하므로 조용히 깨질 수 있다 — `HmlRectangle` 의 필드 타입을
+/// `u32` 로 바꾸거나 `parse_attribute::<u32>` 로 못박으면 `u32::from_str` 이 `-` 를 거부해
+/// 음수 오프셋을 가진 문서 전체가 열리지 않게 된다. 이 테스트가 그 회귀를 잡는다.
+#[test]
+fn rectangle_position_parses_negative_offsets_like_table_does() {
+    let xml = br#"<HWPML Version="2.91"><HEAD/><BODY><SECTION><P><TEXT><RECTANGLE>
+        <SHAPEOBJECT><SIZE Width="1000" Height="500"/><POSITION TreatAsChar="true" FlowWithText="false" AllowOverlap="true" HorzOffset="-100" VertOffset="-200" HorzRelTo="Page" VertRelTo="Page" HorzAlign="Left" VertAlign="Top"/></SHAPEOBJECT>
+      </RECTANGLE></TEXT></P></SECTION></BODY><TAIL/></HWPML>"#;
+
+    let parsed = parse_hml(xml)
+        .expect("RECTANGLE POSITION with negative offsets should parse, matching TABLE's behavior");
+    let rectangle = first_rectangle(&parsed.document);
+
+    assert_eq!(rectangle.common.horizontal_offset as i32, -100);
+    assert_eq!(rectangle.common.vertical_offset as i32, -200);
+}


### PR DESCRIPTION
## 정정 안내

이 PR 은 처음에 "`RECTANGLE` 의 `POSITION HorzOffset`/`VertOffset` 이 음수를 파싱하지 못한다"는 **결함 수정**으로 올렸습니다. 그 전제가 **틀렸습니다**. 현재 코드는 이미 음수 오프셋을 정상적으로 왕복합니다.

제가 잘못 읽은 부분은 대입 대상의 타입입니다. `parse_attribute` 는 타입 파라미터 없이 호출되면 대입 대상 타입으로 `T` 가 추론되는데, 그 대상이 모델의 `HwpUnit = u32` 가 아니라 **파서 중간 구조체**의 필드였습니다.

```rust
// src/parser/hml/reader.rs
pub(crate) struct HmlRectangle {
    pub horizontal_offset: i32,   // <- HwpUnit(u32) 이 아니라 i32
    pub vertical_offset: i32,
```

따라서 `T = i32` 로 추론되고 `i32::from_str` 이 `-` 부호를 받아들입니다. 이후 `src/parser/hml/adapter.rs:181` 이 `source.horizontal_offset as u32` 로 모델에 싣고, 테스트는 이를 `as i32` 로 되읽어 `-100` 을 얻습니다. 즉 왕복이 이미 성립합니다.

덧붙여 제가 넣었던 `as u32` 캐스트는 `i32` 필드에 `u32` 를 대입하는 꼴이라 **컴파일조차 되지 않았습니다** (`E0308` 2건). CI 가 이를 잡아냈습니다.

## 이 PR 이 지금 하는 일

`src/parser/hml/reader.rs` 변경을 모두 되돌리고, **회귀 테스트만** 남겼습니다. 동작 변화는 없습니다.

남긴 이유는 이 계약이 오직 **타입 추론**으로만 성립하기 때문입니다. 코드에는 `i32` 라는 근거가 드러나 있지 않아서, 다음 중 하나만 일어나도 조용히 깨집니다.

- `HmlRectangle` 의 오프셋 필드 타입을 `u32` 로 바꾸는 경우
- `parse_attribute::<u32>` 로 타입을 못박는 경우

이때 `u32::from_str` 이 `-` 를 거부하고, `parse_hml` 이 `InvalidXml` 로 실패해 **음수 오프셋을 가진 문서가 통째로 열리지 않게** 됩니다. 우리 자신의 HML writer(`serializer/hml/body.rs::position_attributes`)가 `(offset as i32).to_string()` 로 음수를 그대로 방출하므로, 저장했다 다시 여는 경로에서 바로 드러납니다.

## 검증

- `tests/hml_parser.rs` 의 `rectangle_position_parses_negative_offsets_like_table_does` 추가 — `HorzOffset="-100" VertOffset="-200"` 인 `RECTANGLE` 이 파싱되고 모델에서 `-100`/`-200` 으로 복원되는지 검증합니다.
- `cargo fmt` 기준 포맷 확인 완료.
- 이 PC 에서는 MSVC 링커 손상(`dbghelp.lib`)과 GNU `dlltool` 부재로 저장소 전체 빌드가 불가해, 최종 검증은 CI 에 맡깁니다. 이 PR 이 `src` 를 건드리지 않으므로 CI 초록은 곧 "현재 코드가 이미 음수 오프셋을 왕복한다"는 실증이 됩니다.

불필요한 리뷰 시간을 쓰게 해 죄송합니다. 필요 없다고 판단하시면 닫아 주셔도 됩니다.
