### PR TITLE
fix: HWP3 셀 패딩·HWPX OLE 위치 음수값 처리 결함 2건

### DIFF
--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -936,6 +936,22 @@ struct Hwp3DrawingCarry<'a> {
 /// `info_buf` 로만 넘기고, `Control` 생성·push 는 호출자 tail 에서 제어문자
 /// 1개당 정확히 1개만 한다(그래서 `controls`/`ctrl_data_records` 도 받지 않는다).
 #[allow(clippy::too_many_arguments)]
+/// HWP3 셀 패딩 바이트(부호 있는 16비트, 단위 1/100mm)를 IR HU(1/7200inch)
+/// 스케일(×4)로 변환한다.
+///
+/// [부호 확장 결함] 종전엔 `read_i16(..) as u32 * 4` 로 계산했다. 음수 i16를
+/// 곧바로 `as u32` 로 캐스팅하면 부호 확장된 큰 양수(예: -5 → 4294967291)가
+/// 되고, 거기에 `* 4` 를 곱하면 release 빌드에서는 오버플로가 랩어라운드돼
+/// 엉뚱한 패딩 값이 나오고 debug 빌드(오버플로 체크 on, 테스트가 기본으로
+/// 도는 프로필)에서는 곱셈 자체가 패닉한다. 음수 셀 패딩(HWP3 문서에서
+/// 드물지만 유효한 값)을 만나면 파서가 죽거나 표가 깨지는 결함이었다.
+/// `i32` 중간값을 거치면 부호가 보존되고 오버플로 없이 계산된다.
+fn read_hwp3_padding_scaled(mut bytes: &[u8]) -> i16 {
+    use byteorder::{LittleEndian, ReadBytesExt};
+    let raw = bytes.read_i16::<LittleEndian>().unwrap_or(0) as i32;
+    (raw * 4) as i16
+}
+
 fn parse_hwp3_object_dispatch(
     body_cursor: &mut Cursor<&[u8]>,
     doc_char_shapes: &mut Vec<crate::model::style::CharShape>,
@@ -1061,19 +1077,15 @@ fn parse_hwp3_object_dispatch(
         // 미리 채워두면 serializer/hwpx_to_hwp 수정 없이 attr가 올바르게 저장된다.
         table.raw_ctrl_data = build_raw_ctrl_data(&table.common);
 
-        let cell_padding_left =
-            (&info_buf[34..36]).read_i16::<LittleEndian>().unwrap_or(0) as u32 * 4;
-        let cell_padding_right =
-            (&info_buf[36..38]).read_i16::<LittleEndian>().unwrap_or(0) as u32 * 4;
-        let cell_padding_top =
-            (&info_buf[38..40]).read_i16::<LittleEndian>().unwrap_or(0) as u32 * 4;
-        let cell_padding_bottom =
-            (&info_buf[40..42]).read_i16::<LittleEndian>().unwrap_or(0) as u32 * 4;
+        let cell_padding_left = read_hwp3_padding_scaled(&info_buf[34..36]);
+        let cell_padding_right = read_hwp3_padding_scaled(&info_buf[36..38]);
+        let cell_padding_top = read_hwp3_padding_scaled(&info_buf[38..40]);
+        let cell_padding_bottom = read_hwp3_padding_scaled(&info_buf[40..42]);
 
-        table.padding.left = cell_padding_left as i16;
-        table.padding.right = cell_padding_right as i16;
-        table.padding.top = cell_padding_top as i16;
-        table.padding.bottom = cell_padding_bottom as i16;
+        table.padding.left = cell_padding_left;
+        table.padding.right = cell_padding_right;
+        table.padding.top = cell_padding_top;
+        table.padding.bottom = cell_padding_bottom;
 
         let caption_width = (&info_buf[46..48]).read_u16::<LittleEndian>().unwrap_or(0) as u32 * 4;
         let caption_pos = (&info_buf[70..72]).read_u16::<LittleEndian>().unwrap_or(0);
@@ -1173,10 +1185,10 @@ fn parse_hwp3_object_dispatch(
             cell.width = w as u32;
             cell.height = h as u32;
 
-            cell.padding.left = cell_padding_left as i16;
-            cell.padding.right = cell_padding_right as i16;
-            cell.padding.top = cell_padding_top as i16;
-            cell.padding.bottom = cell_padding_bottom as i16;
+            cell.padding.left = cell_padding_left;
+            cell.padding.right = cell_padding_right;
+            cell.padding.top = cell_padding_top;
+            cell.padding.bottom = cell_padding_bottom;
 
             let v_align = cell_info[19];
             cell.vertical_align = match v_align {
@@ -4662,6 +4674,26 @@ mod tests {
     use super::*;
     use std::fs::File;
     use std::io::Read;
+
+    #[test]
+    fn read_hwp3_padding_scaled_preserves_negative_values_without_overflow() {
+        // [부호 확장 결함] 종전 `read_i16(..) as u32 * 4` 는 음수 셀 패딩을
+        // 부호 확장된 거대한 u32 로 만들어 debug 빌드에서 곱셈 오버플로 패닉,
+        // release 빌드에서는 랩어라운드된 엉뚱한 값을 만들었다. 이 회귀 테스트는
+        // 음수 입력이 패닉 없이 부호를 보존한 채 ×4 스케일된 결과를 내는지 확인한다.
+        let negative_five: [u8; 2] = (-5i16).to_le_bytes();
+        assert_eq!(
+            read_hwp3_padding_scaled(&negative_five),
+            -20,
+            "음수 셀 패딩은 부호를 보존한 채 ×4 스케일돼야 함"
+        );
+
+        let positive: [u8; 2] = 30i16.to_le_bytes();
+        assert_eq!(read_hwp3_padding_scaled(&positive), 120);
+
+        let zero: [u8; 2] = 0i16.to_le_bytes();
+        assert_eq!(read_hwp3_padding_scaled(&zero), 0);
+    }
 
     #[test]
     fn test_convert_para_shape_wires_border_connection_into_attr1_bit28() {

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -6302,8 +6302,16 @@ fn parse_common_shape_children(
                                         _ => HorzAlign::Left,
                                     };
                                 }
-                                b"vertOffset" => common.vertical_offset = parse_u32(&attr),
-                                b"horzOffset" => common.horizontal_offset = parse_u32(&attr),
+                                // [버그 수정] chart/OLE 공용 <hp:pos> 파서만 유일하게 `parse_u32`
+                                // 를 써서 음수 오프셋(왼쪽/위쪽 앵커 이탈)을 0 으로 뭉갰다 —
+                                // 이미지·표 등 다른 개체 <hp:pos> 파서(위 parse_i32_wrapping 분기)
+                                // 와 동형으로 맞춘다.
+                                b"vertOffset" => {
+                                    common.vertical_offset = parse_i32_wrapping(&attr) as u32
+                                }
+                                b"horzOffset" => {
+                                    common.horizontal_offset = parse_i32_wrapping(&attr) as u32
+                                }
                                 b"treatAsChar" => common.treat_as_char = parse_bool(&attr),
                                 // [#2784] affectLSpacing(줄 간격에 영향) — 공통 개체 pos 되읽기.
                                 b"affectLSpacing" => common.affect_line_spacing = parse_bool(&attr),
@@ -8292,6 +8300,48 @@ mod tests {
             ole.drawing_aspect,
             crate::model::shape::OleDrawingAspect::Icon,
             "drawAspect=ICON 이 보존돼야 함"
+        );
+    }
+
+    #[test]
+    fn bugfind_ole_negative_pos_offset_is_not_zeroed() {
+        // [버그] `parse_common_shape_children` (chart/OLE 공용 `<hp:pos>` 파서)는
+        // vertOffset/horzOffset 을 `parse_u32` 로 읽는다 — `str::parse::<u32>` 는
+        // 부호 문자를 거부해 실패 시 `unwrap_or(0)` 로 조용히 0 이 된다. 반면 이미지/
+        // 표 등 다른 개체의 `<hp:pos>` 파서(section.rs:3150-3151, parse_object_layout_child)
+        // 는 `parse_i32_wrapping` 을 써서 음수 오프셋(왼쪽/위쪽으로 벗어난 앵커 상대
+        // 배치)을 올바르게 보존한다. 우리 자신의 직렬화기(serializer/hwpx/shape.rs)가
+        // signed 오프셋을 그대로 십진수로 방출하므로(예: "-100"), 그런 OLE/차트가
+        // 저장 후 재로드되면 위치가 0 으로 뭉개진다.
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="1" zOrder="0" binaryItemIDRef="ole1">
+        <hp:sz width="2600" height="2600"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="PARA" vertOffset="-200" horzOffset="-100"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Ole(ole) = shape.as_ref() else {
+            panic!("expected ole shape");
+        };
+        assert_eq!(
+            ole.common.horizontal_offset as i32, -100,
+            "hp:pos horzOffset=\"-100\" 이 0 으로 뭉개지면 안 됨"
+        );
+        assert_eq!(
+            ole.common.vertical_offset as i32, -200,
+            "hp:pos vertOffset=\"-200\" 이 0 으로 뭉개지면 안 됨"
         );
     }
 


### PR DESCRIPTION
## 요약

diagnostic exit-code(#3752), attribute escaping(#3753), RECTANGLE POSITION 음수 오프셋(#3754) 등 이미 열린 PR과 겹치지 않는, 부호 처리 관련 확정 결함 2건을 고쳤습니다.

### 1. `src/parser/hwp3/mod.rs` — HWP3 표 셀 패딩 부호 확장 오버플로

- **위치**: `read_hwp3_padding_scaled`(신규 헬퍼), 기존 호출부는 `parse_hwp3_object_dispatch` 내 표/셀 파싱 블록(원래 라인 1080번대 부근)
- **버그**: 셀 패딩(왼/오/위/아래)을 `read_i16(..) as u32 * 4` 로 스케일했습니다. 음수 `i16`을 곧바로 `as u32`로 캐스팅하면 부호 확장된 거대한 양수(예: `-5` → `4294967291`)가 되고, 여기에 `*4`를 곱하면 release 빌드에서는 오버플로가 랩어라운드돼 엉뚱한 패딩 값이 나오고, debug 빌드(오버플로 체크 on — `cargo test` 기본 프로필)에서는 곱셈 자체가 **패닉**합니다. HWP3 문서에서 음수 셀 패딩은 드물지만 유효한 값이라, 그런 문서를 만나면 파서가 죽거나 표가 깨졌습니다.
- **발견 방법**: `#3754`(RECTANGLE POSITION 음수 오프셋)와 같은 부호 처리 버그 클래스를 찾으려고 `src/parser/hwp3/mod.rs` 안의 수동 정수 파싱 지점(`as u16`/`as u32`/`as i16`/`as i32` 캐스팅)을 전수 grep. 같은 함수 안 `horz_align`/`vert_align` 처리(라인 1033번대)는 `i32` 중간값을 거쳐 부호를 보존하는데, 바로 아래 셀 패딩 코드만 `u32`를 거쳐 부호를 잃는 비대칭을 확인.
- **수정**: `i32` 중간값을 거치는 `read_hwp3_padding_scaled` 헬퍼로 통일. 부호를 보존한 채 오버플로 없이 계산.
- **테스트**: `src/parser/hwp3/mod.rs`의 `read_hwp3_padding_scaled_preserves_negative_values_without_overflow` — 음수(-5→-20)/양수(30→120)/0 입력에 대해 패닉 없이 올바른 값이 나오는지 확인. `cargo test --lib parser::hwp3::tests::read_hwp3_padding_scaled_preserves_negative_values_without_overflow` 로 로컬 통과 확인(디스크 여유 협소로 이 단위 범위만 실행).

### 2. `src/parser/hwpx/section.rs` — OLE/차트 `<hp:pos>` 음수 오프셋이 0으로 뭉개짐

- **위치**: `parse_common_shape_children`(chart/OLE 공용 `<hp:pos>` 파서)의 `vertOffset`/`horzOffset` 처리
- **버그**: `parse_u32`로 읽었는데, `str::parse::<u32>`는 부호 문자(`-`)를 거부해 실패하면 `unwrap_or(0)`으로 조용히 `0`이 됩니다. 반면 이미지·표 등 다른 개체의 `<hp:pos>` 파서(`parse_object_layout_child` 등)는 이미 `parse_i32_wrapping`을 써서 음수 오프셋(앵커 기준 왼쪽/위쪽 이탈)을 올바르게 보존합니다. `serializer/hwpx/shape.rs`가 signed 오프셋을 그대로 십진수(`"-100"`)로 방출하므로, 음수 위치의 OLE/차트가 저장 후 재로드되면 위치가 0으로 뭉개지는 왕복 결함입니다.
- **발견 방법**: 같은 파일 안에서 `<hp:pos>`를 다루는 다른 파서들과 대조해 `parse_u32` vs `parse_i32_wrapping` 사용이 개체 종류별로 일관되지 않음을 확인.
- **수정**: `parse_i32_wrapping`으로 통일해 다른 개체 파서와 동형으로 맞춤.
- **테스트**: `src/parser/hwpx/section.rs`의 `bugfind_ole_negative_pos_offset_is_not_zeroed` — `vertOffset="-200" horzOffset="-100"`인 OLE `<hp:pos>`를 파싱해 값이 보존되는지 확인. `cargo test --lib parser::hwpx::section::tests::bugfind_ole_negative_pos_offset_is_not_zeroed` 로 로컬 통과 확인.

## 검증 범위와 제약

- 로컬 디스크가 작업 중 3.6GB → 1.6GB 여유까지 줄어(C: 드라이브 상시 포화 상태), 위 두 단위 테스트만 targeted로 실행해 통과를 확인했습니다. 전체 `cargo test --tests`나 `cargo build` 풀 스코프는 디스크 안전 여유가 없어 실행하지 않았습니다.
- `cargo fmt --all -- --check` 는 통과(컴파일 없는 가벼운 검사라 항상 실행).
- 원래 목표였던 "3-5건" 중 확정·검증 가능한 2건만 제출합니다. 추가 후보(HML/HWPX round-trip, HWP3 drawing 등)를 더 찾아보려 했으나, 디스크 여유가 안전 임계값(1GB) 근처까지 떨어져 추가 빌드/테스트를 안전하게 돌릴 수 없어 여기서 중단했습니다.