### PR TITLE
fix(hwpx): OLE/차트·도형 오프셋 파싱에서 음수값 유실 2건

### DIFF
--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -2654,17 +2654,17 @@ fn parse_picture(
                         for attr in ce.attributes().flatten() {
                             match attr.key.as_ref() {
                                 b"x" => {
-                                    let v = parse_u32(&attr);
-                                    shape_attr.offset_x = v as i32;
+                                    let v = parse_i32_wrapping(&attr);
+                                    shape_attr.offset_x = v;
                                     if !has_pos {
-                                        common.horizontal_offset = v;
+                                        common.horizontal_offset = v as u32;
                                     }
                                 }
                                 b"y" => {
-                                    let v = parse_u32(&attr);
-                                    shape_attr.offset_y = v as i32;
+                                    let v = parse_i32_wrapping(&attr);
+                                    shape_attr.offset_y = v;
                                     if !has_pos {
-                                        common.vertical_offset = v;
+                                        common.vertical_offset = v as u32;
                                     }
                                 }
                                 _ => {}
@@ -3157,17 +3157,17 @@ fn parse_object_layout_child(
             for attr in ce.attributes().flatten() {
                 match attr.key.as_ref() {
                     b"x" => {
-                        let v = parse_u32(&attr);
-                        shape_attr.offset_x = v as i32;
+                        let v = parse_i32_wrapping(&attr);
+                        shape_attr.offset_x = v;
                         if !*has_pos {
-                            common.horizontal_offset = v;
+                            common.horizontal_offset = v as u32;
                         }
                     }
                     b"y" => {
-                        let v = parse_u32(&attr);
-                        shape_attr.offset_y = v as i32;
+                        let v = parse_i32_wrapping(&attr);
+                        shape_attr.offset_y = v;
                         if !*has_pos {
-                            common.vertical_offset = v;
+                            common.vertical_offset = v as u32;
                         }
                     }
                     _ => {}
@@ -8011,6 +8011,57 @@ mod tests {
         assert_eq!(connector.control_points.len(), 2);
         assert_eq!(connector.control_points[1].x, 100);
         assert_eq!(connector.control_points[1].point_type, 26);
+    }
+
+    #[test]
+    fn bugfind_shape_offset_negative_x_y_not_dropped_to_zero() {
+        // hp:offset(개체 내부 shape-transform 오프셋) x/y 는 음수일 수 있는데,
+        // 종전엔 parse_u32 로 읽어 "-500" 같은 문자열이 파싱 실패로 0 이 됐다
+        // (hp:pos 의 vertOffset/horzOffset 형제 필드는 이미 parse_i32_wrapping 사용).
+        // hp:pos 가 없어 offset 이 common.horizontal_offset/vertical_offset 에도
+        // 그대로 폴백되는 경로를 함께 확인한다.
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:connectLine id="1" zOrder="0" textWrap="SQUARE" textFlow="BOTH_SIDES" instid="1" type="STRAIGHT_ONEWAY">
+        <hp:offset x="-500" y="-800"/>
+        <hp:orgSz width="100" height="1"/>
+        <hp:curSz width="100" height="0"/>
+        <hp:lineShape color="#000000" width="141" style="SOLID" headStyle="NORMAL" tailStyle="NORMAL" headfill="1" tailfill="1" headSz="MEDIUM_MEDIUM" tailSz="MEDIUM_MEDIUM"/>
+        <hp:startPt x="0" y="0" subjectIDRef="1" subjectIdx="0"/>
+        <hp:endPt x="100" y="0" subjectIDRef="2" subjectIdx="0"/>
+      </hp:connectLine>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"##;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Line(line) = shape.as_ref() else {
+            panic!("expected line shape");
+        };
+
+        assert_eq!(
+            line.drawing.shape_attr.offset_x, -500,
+            "offset x=-500 이 0으로 뭉개지면 안 됨"
+        );
+        assert_eq!(
+            line.drawing.shape_attr.offset_y, -800,
+            "offset y=-800 이 0으로 뭉개지면 안 됨"
+        );
+        assert_eq!(
+            line.common.horizontal_offset as i32, -500,
+            "hp:pos 가 없으면 offset 이 common.horizontal_offset 으로 폴백돼야 함"
+        );
+        assert_eq!(
+            line.common.vertical_offset as i32, -800,
+            "hp:pos 가 없으면 offset 이 common.vertical_offset 으로 폴백돼야 함"
+        );
     }
 
     #[test]

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -6302,8 +6302,12 @@ fn parse_common_shape_children(
                                         _ => HorzAlign::Left,
                                     };
                                 }
-                                b"vertOffset" => common.vertical_offset = parse_u32(&attr),
-                                b"horzOffset" => common.horizontal_offset = parse_u32(&attr),
+                                b"vertOffset" => {
+                                    common.vertical_offset = parse_i32_wrapping(&attr) as u32
+                                }
+                                b"horzOffset" => {
+                                    common.horizontal_offset = parse_i32_wrapping(&attr) as u32
+                                }
                                 b"treatAsChar" => common.treat_as_char = parse_bool(&attr),
                                 // [#2784] affectLSpacing(줄 간격에 영향) — 공통 개체 pos 되읽기.
                                 b"affectLSpacing" => common.affect_line_spacing = parse_bool(&attr),
@@ -8292,6 +8296,47 @@ mod tests {
             ole.drawing_aspect,
             crate::model::shape::OleDrawingAspect::Icon,
             "drawAspect=ICON 이 보존돼야 함"
+        );
+    }
+
+    #[test]
+    fn bugfind_ole_pos_negative_offset_is_not_wrapped_to_huge_u32() {
+        // hp:pos 의 vertOffset/horzOffset 은 HWPUNIT 음수값을 unsigned 32-bit
+        // decimal 문자열("4294965296" = i32 -2000)로 저장할 수 있다.
+        // 표(hp:tbl)/그림(hp:pic)/선(hp:line) 파서는 parse_i32_wrapping 을 쓰지만
+        // OLE/차트가 공유하는 parse_common_shape_children 은 parse_u32 를 써서,
+        // 음수 오프셋이 거대한 양수(약 42억)로 뭉개졌다.
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="1" zOrder="0" binaryItemIDRef="ole1">
+        <hp:sz width="2600" height="2600"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="PARA"
+                vertOffset="4294965296" horzOffset="4294964867"/>
+        <hc:extent x="1" y="1"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Ole(ole) = shape.as_ref() else {
+            panic!("expected ole shape");
+        };
+        assert_eq!(
+            ole.common.vertical_offset as i32, -2000,
+            "vertOffset 이 부호 없는 거대한 값이 아니라 음수 HWPUNIT 으로 보존돼야 함"
+        );
+        assert_eq!(
+            ole.common.horizontal_offset as i32, -2429,
+            "horzOffset 이 부호 없는 거대한 값이 아니라 음수 HWPUNIT 으로 보존돼야 함"
         );
     }
 

--- a/tests/batch_axes_contract.rs
+++ b/tests/batch_axes_contract.rs
@@ -18,6 +18,27 @@ fn sample(rel: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
 }
 
+/// 자식이 stdin 을 다 읽기 전에 종료하면 파이프의 읽기 끝이 닫혀 `write_all` 이 `EPIPE` 를
+/// 받는다. 이 파일의 테스트들은 바로 그 동작(`*_rejected_before_consuming_path_stdin`,
+/// `*_rejects_flag_as_out_dir_before_any_write`)을 검증하므로, `BrokenPipe` 는 오류가 아니라
+/// **검증 대상의 정상적인 부산물**이다. 오류로 다루면 기능이 의도대로 일찍 거부할수록 테스트가
+/// 더 자주 깨진다 (#3763).
+///
+/// 실제 계약은 이 함수가 돌려주는 종료 코드·stdout 으로 확인한다. 자식이 정말 stdin 을
+/// 필요로 했다면 그 단언에서 잡히므로 검증력은 줄지 않는다. 그 밖의 쓰기 오류는 그대로 패닉한다.
+fn write_stdin_tolerating_broken_pipe(child: &mut std::process::Child, stdin_body: &str) {
+    match child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(stdin_body.as_bytes())
+    {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::BrokenPipe => {}
+        Err(error) => panic!("stdin 쓰기 실패: {error:?}"),
+    }
+}
+
 fn run_with_stdin(args: &[&str], stdin_body: &str) -> Output {
     let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
         .args(args)
@@ -26,12 +47,7 @@ fn run_with_stdin(args: &[&str], stdin_body: &str) -> Output {
         .stderr(Stdio::piped())
         .spawn()
         .expect("rhwp 실행 실패");
-    child
-        .stdin
-        .as_mut()
-        .expect("stdin")
-        .write_all(stdin_body.as_bytes())
-        .expect("stdin 쓰기 실패");
+    write_stdin_tolerating_broken_pipe(&mut child, stdin_body);
     child.wait_with_output().expect("rhwp 종료 대기 실패")
 }
 
@@ -45,12 +61,7 @@ fn run_with_stdin_in_dir(args: &[&str], stdin_body: &str, current_dir: &Path) ->
         .stderr(Stdio::piped())
         .spawn()
         .expect("rhwp 실행 실패");
-    child
-        .stdin
-        .as_mut()
-        .expect("stdin")
-        .write_all(stdin_body.as_bytes())
-        .expect("stdin 쓰기 실패");
+    write_stdin_tolerating_broken_pipe(&mut child, stdin_body);
     child.wait_with_output().expect("rhwp 종료 대기 실패")
 }
 

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -24,6 +24,10 @@ fn run(args: &[&str]) -> Output {
 }
 
 /// stdin 으로 파일 목록을 흘려 넣는 batch 실행 헬퍼.
+///
+/// 자식이 stdin 을 다 읽기 전에 종료하면(예: 인자 검증에서 usage 오류로 즉시 거부)
+/// `write_all` 이 `EPIPE` 를 받는다. 이는 오류가 아니라 검증 대상 동작의 정상적인
+/// 부산물이므로 넘어간다 — 실제 계약은 종료 코드·stdout 으로 확인한다 (#3763).
 fn run_with_stdin(args: &[&str], stdin_body: &str) -> Output {
     let mut child = Command::new(rhwp_bin())
         .args(args)
@@ -32,12 +36,16 @@ fn run_with_stdin(args: &[&str], stdin_body: &str) -> Output {
         .stderr(Stdio::piped())
         .spawn()
         .expect("rhwp 실행 실패");
-    child
+    match child
         .stdin
         .as_mut()
         .expect("stdin")
         .write_all(stdin_body.as_bytes())
-        .expect("stdin 쓰기 실패");
+    {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::BrokenPipe => {}
+        Err(error) => panic!("stdin 쓰기 실패: {error:?}"),
+    }
     child.wait_with_output().expect("rhwp 종료 대기 실패")
 }
 

--- a/tests/info_title_contract.rs
+++ b/tests/info_title_contract.rs
@@ -34,6 +34,9 @@ fn run(args: &[&str]) -> Output {
         .expect("rhwp 실행 실패")
 }
 
+/// 자식이 stdin 을 다 읽기 전에 종료하면(예: 인자 검증에서 usage 오류로 즉시 거부)
+/// `write_all` 이 `EPIPE` 를 받는다. 이는 오류가 아니라 검증 대상 동작의 정상적인
+/// 부산물이므로 넘어간다 — 실제 계약은 종료 코드·stdout 으로 확인한다 (#3763).
 fn run_with_stdin(args: &[&str], stdin_body: &str) -> Output {
     let mut child = Command::new(rhwp_bin())
         .args(args)
@@ -42,12 +45,16 @@ fn run_with_stdin(args: &[&str], stdin_body: &str) -> Output {
         .stderr(Stdio::piped())
         .spawn()
         .expect("rhwp 실행 실패");
-    child
+    match child
         .stdin
         .as_mut()
         .expect("stdin")
         .write_all(stdin_body.as_bytes())
-        .expect("stdin 쓰기 실패");
+    {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::BrokenPipe => {}
+        Err(error) => panic!("stdin 쓰기 실패: {error:?}"),
+    }
     child.wait_with_output().expect("rhwp 종료 대기 실패")
 }
 


### PR DESCRIPTION
## 요약

HWPX 파서에서 음수 HWPUNIT 오프셋을 다루는 필드 중, 형제 필드(hp:tbl/hp:pic/hp:line 의 vertOffset/horzOffset)는 이미 `parse_i32_wrapping`을 쓰는데 아직 `parse_u32`를 쓰는 경로 2곳을 대조 발견해 고쳤습니다. 각각 별도 커밋 + 회귀 테스트.

### 1. OLE/차트 hp:pos vertOffset·horzOffset (`bf9c4e67b`)

`parse_common_shape_children`(hp:ole, hp:chart 공용)의 `<hp:pos vertOffset="..." horzOffset="...">`가 `parse_u32`를 쓰고 있었습니다. HWPX는 음수 HWPUNIT을 unsigned 32-bit decimal 문자열로 저장하는 경우가 있는데(`"4294965296"` = i32 `-2000`), `parse_u32`는 그대로 거대한 양수로 저장해 위/왼쪽으로 벗어난 OLE·차트 개체 좌표가 뭉개졌습니다.

- 회귀 테스트: `bugfind_ole_pos_negative_offset_is_not_wrapped_to_huge_u32`

### 2. 도형 hp:offset x/y (`d5f520c18`)

`parse_picture`와 `parse_object_layout_child`(선/사각형/타원 등 공용)의 `<hp:offset x="..." y="...">` (개체 내부 shape-transform 오프셋)도 `parse_u32`를 쓰고 있었습니다. 이 경우 `"-500"`처럼 순수 음수 문자열은 u32 파싱 자체가 실패해 `unwrap_or(0)`으로 조용히 0이 되고, `shape_attr.offset_x/y` 뿐 아니라 (`hp:pos`가 없을 때 폴백되는) `common.horizontal_offset/vertical_offset`까지 음수 오프셋이 유실됐습니다.

- 회귀 테스트: `bugfind_shape_offset_negative_x_y_not_dropped_to_zero`

## 검증

- `cargo test --lib parser::hwpx::section::tests::bugfind_ole_pos_negative_offset_is_not_wrapped_to_huge_u32` — pass
- `cargo test --lib parser::hwpx::section::tests::bugfind_shape_offset_negative_x_y_not_dropped_to_zero` — pass
- `cargo test --lib parser::hwpx::section::tests:: -- offset` (관련 offset 기존 테스트 120개 포함) — 전부 pass, 회귀 없음
- `cargo fmt --all -- --check` — clean

**디스크 제약 안내**: 작업 중 C: 드라이브 여유공간이 4.3GB → 1.8GB까지 떨어져(빌드 캐시 성장), 이후 전체 빌드/전체 테스트 스위트는 실행하지 못했습니다. 위 narrow test 실행 결과만으로 검증했습니다. 원래 3-5건을 찾는 게 목표였으나 디스크 여유가 임계치에 가까워 2건에서 커밋+푸시하고 마감합니다.

## Test plan

- [x] `bugfind_ole_pos_negative_offset_is_not_wrapped_to_huge_u32` (narrow, pass)
- [x] `bugfind_shape_offset_negative_x_y_not_dropped_to_zero` (narrow, pass)
- [x] 관련 기존 offset 테스트 120개 회귀 없음 확인
- [x] `cargo fmt --all -- --check`
- [ ] 전체 `cargo test`는 디스크 제약으로 미실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 📌 추가 커밋 안내 — #3763 플레이키 수정을 함께 실었습니다

이 PR 의 변경과 무관하게 CI 가 계속 빨갰습니다. `devel`(cc38291) 자체가 #3742 머지 이후
`tests/batch_axes_contract.rs` 의 stdin 헬퍼 때문에 깨져 있고, 그 커밋을 기반으로 하는 모든 PR 이
같은 지점에서 막힙니다.

```
thread 'batch_global_auth_options_are_rejected_before_consuming_path_stdin' panicked at tests/batch_axes_contract.rs:34:10:
stdin 쓰기 실패: Os { code: 32, kind: BrokenPipe, message: "Broken pipe" }
```

재실행으로는 빠져나가지 못했습니다 — 이 PR 도 재실행했지만 같은 지점에서 다시 실패했습니다.
그래서 이 브랜치의 CI 를 **읽을 수 있게** 하려고 #3766 의 테스트 하네스 수정
(`tests/` 3개 파일, 제품 코드 무변경)을 그대로 실었습니다.

원인 분석은 #3763 에 있습니다. **#3766 이 먼저 머지되면 이 커밋은 빈 diff 가 되어 리베이스 때
자연히 떨어져 나갑니다.** 리뷰 시 마지막 커밋
`test(cli): stdin 계약 테스트의 BrokenPipe 플레이키를 함께 싣는다 (#3763)` 는 이 PR 의 본 주제가
아니니 분리해서 보시면 됩니다.
