### PR TITLE
fix(hwp3): drawing 객체 margin/size/offset 스케일 곱셈 정수 오버플로 패닉

### DIFF
--- a/src/parser/hwp3/drawing.rs
+++ b/src/parser/hwp3/drawing.rs
@@ -574,6 +574,14 @@ use std::collections::HashMap;
 
 const HWP3_UNIT_SCALE: i32 = 4;
 
+/// 신뢰할 수 없는 파일에서 읽은 HWP3 raw margin(u32)을 `* HWP3_UNIT_SCALE` 스케일 후
+/// `i16` 필드(`TextBox::margin_*`)에 담는다. 곱셈이 `i32`/`i16` 범위를 넘으면 그대로
+/// 캐스팅하는 대신 클램프해 오버플로 panic(malformed/fuzzed 파일에서의 DoS)을 막는다.
+fn hwp3_margin_to_i16(raw_margin: u32) -> i16 {
+    let scaled = raw_margin as i64 * HWP3_UNIT_SCALE as i64;
+    scaled.clamp(i16::MIN as i64, i16::MAX as i64) as i16
+}
+
 pub fn parse_drawing_object_tree(
     cursor: &mut std::io::Cursor<&[u8]>,
     doc_char_shapes: &mut Vec<crate::model::style::CharShape>,
@@ -751,8 +759,8 @@ fn map_to_shape_object(
     let mut final_shape = shape;
 
     let common = CommonObjAttr {
-        width: (header.object_size[0] as u32 * HWP3_UNIT_SCALE as u32),
-        height: (header.object_size[1] as u32 * HWP3_UNIT_SCALE as u32),
+        width: header.object_size[0].saturating_mul(HWP3_UNIT_SCALE as u32),
+        height: header.object_size[1].saturating_mul(HWP3_UNIT_SCALE as u32),
         ..Default::default()
     };
 
@@ -775,19 +783,22 @@ fn map_to_shape_object(
     }
 
     let shape_attr = ShapeComponentAttr {
-        offset_x: header.relative_pos[0] as i32 * HWP3_UNIT_SCALE,
-        offset_y: header.relative_pos[1] as i32 * HWP3_UNIT_SCALE,
-        original_width: (header.object_size[0] as u32 * HWP3_UNIT_SCALE as u32),
-        original_height: (header.object_size[1] as u32 * HWP3_UNIT_SCALE as u32),
-        current_width: (header.object_size[0] as u32 * HWP3_UNIT_SCALE as u32),
-        current_height: (header.object_size[1] as u32 * HWP3_UNIT_SCALE as u32),
+        offset_x: (header.relative_pos[0] as i64 * HWP3_UNIT_SCALE as i64)
+            .clamp(i32::MIN as i64, i32::MAX as i64) as i32,
+        offset_y: (header.relative_pos[1] as i64 * HWP3_UNIT_SCALE as i64)
+            .clamp(i32::MIN as i64, i32::MAX as i64) as i32,
+        original_width: header.object_size[0].saturating_mul(HWP3_UNIT_SCALE as u32),
+        original_height: header.object_size[1].saturating_mul(HWP3_UNIT_SCALE as u32),
+        current_width: header.object_size[0].saturating_mul(HWP3_UNIT_SCALE as u32),
+        current_height: header.object_size[1].saturating_mul(HWP3_UNIT_SCALE as u32),
         rotation_angle,
         ..Default::default()
     };
 
     let border_line = ShapeBorderLine {
         color: header.basic_attr.line_color,
-        width: header.basic_attr.line_width as i32 * HWP3_UNIT_SCALE,
+        width: (header.basic_attr.line_width as i64 * HWP3_UNIT_SCALE as i64)
+            .clamp(i32::MIN as i64, i32::MAX as i64) as i32,
         // [Task #877 Stage 3] HWP3 drawing line_style = 0 (= "선 종류 없음") 인데
         // line_width > 0 인 경우 → 실제 한컴 viewer 는 실선으로 표시. (sample16 RFP
         // 박스 외곽선 회귀: raw line_style=0, line_width=84, line_color=0 검정)
@@ -878,10 +889,10 @@ fn map_to_shape_object(
     let text_box = if (header.basic_attr.options & (1 << 19)) != 0 || !parsed_paragraphs.is_empty()
     {
         Some(TextBox {
-            margin_left: (header.basic_attr.textbox_margin[0] as i32 * HWP3_UNIT_SCALE) as i16,
-            margin_top: (header.basic_attr.textbox_margin[1] as i32 * HWP3_UNIT_SCALE) as i16,
-            margin_right: (header.basic_attr.textbox_margin[0] as i32 * HWP3_UNIT_SCALE) as i16,
-            margin_bottom: (header.basic_attr.textbox_margin[1] as i32 * HWP3_UNIT_SCALE) as i16,
+            margin_left: hwp3_margin_to_i16(header.basic_attr.textbox_margin[0]),
+            margin_top: hwp3_margin_to_i16(header.basic_attr.textbox_margin[1]),
+            margin_right: hwp3_margin_to_i16(header.basic_attr.textbox_margin[0]),
+            margin_bottom: hwp3_margin_to_i16(header.basic_attr.textbox_margin[1]),
             paragraphs: parsed_paragraphs,
             ..Default::default()
         })
@@ -936,6 +947,50 @@ fn map_to_shape_object(
 mod modified_arc_overread_tests {
     use super::*;
     use std::io::Cursor;
+
+    // [POC] textbox_margin/line_width/object_size 는 파일에서 그대로 읽은 신뢰
+    // 불가 u32 값이다. `* HWP3_UNIT_SCALE(4)` 를 i32/i16 로 계산·캐스팅하는
+    // 과정에서 큰 값(예: u32::MAX)이 들어오면 곱셈이 i32 오버플로를 일으켜
+    // debug 빌드에서 panic한다(fuzzing/악성 파일 경로에서 서비스 거부).
+    #[test]
+    fn map_to_shape_object_does_not_panic_on_huge_margins() {
+        let header = Hwp3DrawingObjectCommonHeader {
+            object_type: 6, // TextBox
+            object_size: [u32::MAX, u32::MAX],
+            relative_pos: [u32::MAX, u32::MAX],
+            basic_attr: Hwp3DrawingObjectBasicAttr {
+                line_width: u32::MAX,
+                textbox_margin: [u32::MAX, u32::MAX],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let raw = Hwp3DrawingObject::TextBox(
+            header,
+            Hwp3DrawingTextBox {
+                info1_len: 0,
+                info2_len: 0,
+                paragraph_list_data: Vec::new(),
+            },
+        );
+        let mut doc_char_shapes = Vec::new();
+        let mut doc_para_shapes = Vec::new();
+        let mut doc_border_fills = Vec::new();
+        let mut doc_tab_defs = Vec::new();
+        let mut pic_name_to_id = HashMap::new();
+        let result = map_to_shape_object(
+            raw,
+            &mut doc_char_shapes,
+            &mut doc_para_shapes,
+            &mut doc_border_fills,
+            &mut doc_tab_defs,
+            &mut pic_name_to_id,
+        );
+        assert!(
+            result.is_ok(),
+            "거대한 margin/width 값에서도 panic 없이 처리되어야 함"
+        );
+    }
 
     #[test]
     fn rectangle_no_fill_marker_does_not_apply_to_text_boxes() {


### PR DESCRIPTION
## 요약

HWP3 legacy 드로잉 객체(사각형/텍스트박스/타원/선 등) 파싱에서, raw 헤더의
`textbox_margin` / `object_size` / `relative_pos` / `line_width` (전부 파일에서
그대로 읽은 신뢰 불가 `u32`)를 `HWP3_UNIT_SCALE(4)`로 스케일링하는 곱셈이
정수 오버플로를 유발할 수 있었습니다. 값이 크면(예: `u32::MAX`) 곱셈 자체가
debug 빌드에서 `attempt to multiply with overflow` panic으로 죽습니다 —
변조되었거나 손상된 HWP3 파일을 열 때 서비스 거부(DoS)로 이어집니다.

## 재현

```
cargo test --lib parser::hwp3::drawing::modified_arc_overread_tests::map_to_shape_object_does_not_panic_on_huge_margins
```

수정 전:
```
thread '...' panicked at src\parser\hwp3\drawing.rs:754:16:
attempt to multiply with overflow
```

## 수정

`src/parser/hwp3/drawing.rs`의 `map_to_shape_object`에서 스케일 곱셈을 전부
saturating/clamp 연산으로 교체:

- `CommonObjAttr.width/height` → `u32::saturating_mul`
- `ShapeComponentAttr.offset_x/offset_y` / `original_width/height` /
  `current_width/height` → `i64` 산술 후 `i32` 범위로 clamp, 또는
  `saturating_mul`
- `ShapeBorderLine.width` → `i64` 산술 후 `i32` clamp
- `TextBox.margin_left/top/right/bottom` → 새 헬퍼
  `hwp3_margin_to_i16()`(`i64` 산술 후 `i16` clamp)

오버플로 시 값은 상한/하한으로 saturate되며(정상 파일에서는 동작 변화 없음),
panic 대신 안전하게 처리됩니다.

## 검증

- `cargo test --lib parser::hwp3::drawing::` — 5개 테스트 전부 통과(기존
  회귀 테스트 4개 + 신규 1개)
- `cargo fmt --all -- --check` 통과

디스크 여유 공간이 1.7GB로 빠듯해(작업 지시 기준 <2GB) 이번 PR은 좁은 범위
(`cargo test --lib parser::hwp3::drawing::`)로만 검증했고, 전체 테스트
스위트(`cargo test --tests`)는 돌리지 않았습니다. 변경이 `map_to_shape_object`
함수 내부 산술식에 한정되어 있어 영향 범위는 이 파일의 기존 4개 회귀
테스트가 계속 통과하는 것으로 충분히 커버된다고 판단했습니다.