### PR TITLE
feat(#3759): rhwp run --dry-run — 실행 전에 계획을 검사한다 (선검증 preview, 디스크 무변경)

### DIFF
--- a/mydocs/report/task_m100_3759/README.md
+++ b/mydocs/report/task_m100_3759/README.md
@@ -1,0 +1,52 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_3759/README.md
+last_verified: 2026-08-02
+---
+
+# #3759 처리 기록 — 계획 v2 `--dry-run` (#3719 §6-3)
+
+## 문제
+
+계획 실행기(#3703)는 **실행해야만** 계획의 유효성을 알 수 있었다. 선검증이 위반을 잡아
+`exit 2` + 출력 파일 부재로 안전하게 끝내긴 하지만, 계획을 *생성하는* 에이전트가 알고
+싶은 건 그 전 단계다 — "이 계획, 돌리면 되나? 무엇이 얼마나 바뀌나?"
+
+## 구현
+
+- `rhwp run <계획.json> --dry-run [--json]` — 선검증만 돌고 **디스크 무변경**.
+- 유효하면 `preview[]` + `dryRun:true` + exit 0. 위반이 있으면 실행 모드와 **똑같이**
+  `invalid[]` + exit 2 (dry-run 이 통과시킨 계획이 실행에서 막히는 일이 없다).
+- `preview` 는 선검증이 이미 계산한 값 그대로다 — 판정자와 미리보기가 같은 계산이라
+  "검사 결과와 실제 실행이 다를" 여지가 구조적으로 없다.
+
+| action | preview 필드 |
+|---|---|
+| `fill_fields` | `targets[{name, occurrence, sameNameCount, value}]` |
+| `replace_text` | `find`, `matches`(전체 일치), `willReplace`(occurrence 지정 시 1) |
+| `set_checkbox` | `occurrence`, `available`(빈 체크박스 총수) |
+| `set_cell` | `table`,`row`,`col`, `currentText`(현재값), `newText` |
+
+## 설계 판단 — 플래그를 계획서 필드로
+
+`dryRun` 을 계획서(`plan.dryRun`)에 두면 MCP `hwp_run_plan{plan}` 이 **인자 추가도
+cmdTemplate 변경도 없이** 같은 계약을 얻는다. CLI `--dry-run` 은 그 필드를 덮어쓰는
+편의 입구일 뿐이고, **의도의 단일 출처는 계획서**다 (#3719 불변식 1 — 단일 출처).
+
+사람 모드는 `검사 통과: N step 실행 가능 (디스크 무변경, 산출 예정 …)` + step 별 한 줄
+요약(`preview_line`)을 낸다.
+
+## 검증
+
+- 신규 `run_plan_dry_run_contract` 5건 green:
+  ① 유효 계획 preview + **산출 파일 부재**(계약의 핵심) ② 위반 시 실행 모드와 동일 판정
+  ③ 계획서가 실은 `dryRun` 이 CLI 플래그와 동등 ④ 실행 모드 무회귀 ⑤ MCP 경로 디스크 무변경
+- 무회귀: `run_plan_contract` · `cli_json_contract`
+- clippy `-D warnings` 0 · fmt clean
+
+## 남은 것
+
+- 계획 스키마 JSON Schema 공개(#3719 §6-4) — dry-run 이 "검사"라면 스키마는 "생성"의
+  정답지다. 둘이 짝을 이뤄야 에이전트가 계획을 안전하게 만들 수 있다.
+- 조건부 step(`if` 필드값) — dry-run 의 preview 가 분기까지 예측해야 하므로 이후 과제.

--- a/src/main.rs
+++ b/src/main.rs
@@ -948,14 +948,14 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
                 "properties": {
                     "plan": {
                         "type": "object",
-                        "description": "계획서. { planVersion:\"1.0\", input:<원본 경로>, output:<산출 경로>, steps:[{action:…}…], assertions:{ notFoundEmpty?, verify? } }"
+                        "description": "계획서. { planVersion:\"1.0\", input:<원본 경로>, output:<산출 경로>, steps:[{action:…}…], assertions:{ notFoundEmpty?, verify? }, dryRun?:true } — dryRun:true 면 선검증만 하고 preview 저널을 낸다(디스크 무변경). 계획을 실행 전에 검사할 때 쓴다."
                     }
                 },
                 "required": ["plan"],
             }),
             "run",
             serde_json::json!(["run", "--plan-json", "{plan}", "--json"]),
-            &["schemaVersion", "planVersion", "input", "output", "outputFormat", "steps", "steps[].confusable", "verify", "invalid", "changedPages"],
+            &["schemaVersion", "planVersion", "input", "output", "outputFormat", "steps", "steps[].confusable", "verify", "invalid", "changedPages", "dryRun", "preview"],
         ),
     ];
     for definition in &mut tools {
@@ -1069,7 +1069,7 @@ fn capabilities_command_entries() -> Vec<serde_json::Value> {
             "edit",
             "선언적 편집 계획 실행 — 정적 선검증·원자 실행·저널 (#3703)",
             false,
-            &["--json", "--plan-json"],
+            &["--json", "--plan-json", "--dry-run"],
             &[
                 "schemaVersion",
                 "planVersion",
@@ -1938,6 +1938,7 @@ fn print_help() {
     println!("      steps: fill_fields{{data}} · replace_text{{find,replace[,occurrence]}}");
     println!("             · set_cell{{table,row,col,text}} · set_checkbox{{occurrence}}");
     println!("      --plan-json '<JSON>'      파일 대신 인라인 계획 (MCP hwp_run_plan 경로)");
+    println!("      --dry-run                 선검증만 — preview 저널, 디스크 무변경 (계획서 dryRun:true 와 동일)");
     println!("      단언 실패는 exit 3 — 저널(steps[]·verify)로 판정을 데이터로 보고");
     println!();
     println!("내부 개발·회귀 도구 (일반 사용자 대상 아님):");
@@ -10747,10 +10748,13 @@ fn cmd_run_plan(args: &[String]) -> i32 {
     let mut plan_path: Option<&str> = None;
     let mut plan_inline: Option<&str> = None;
     let mut json_mode = false;
+    // [#3721] 선검증만 돌리고 디스크는 건드리지 않는다 — 계획을 제출 전에 검사.
+    let mut dry_run = false;
     let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
             "--json" => json_mode = true,
+            "--dry-run" => dry_run = true,
             "--plan-json" => {
                 i += 1;
                 match args.get(i) {
@@ -10779,20 +10783,38 @@ fn cmd_run_plan(args: &[String]) -> i32 {
             }
         },
         (None, None) => {
-            eprintln!("사용법: rhwp run <계획.json> [--json]  (파일 대신 --plan-json '<JSON>')");
+            eprintln!("사용법: rhwp run <계획.json> [--json] [--dry-run]  (파일 대신 --plan-json '<JSON>')");
             return EXIT_USAGE;
         }
     };
-    let plan: serde_json::Value = match serde_json::from_str(&plan_text) {
+    let mut plan: serde_json::Value = match serde_json::from_str(&plan_text) {
         Ok(v) => v,
         Err(e) => {
             eprintln!("오류: 계획 JSON 파싱 실패 - {}", e);
             return EXIT_USAGE;
         }
     };
+    // 플래그는 계획서 필드를 덮어쓴다 — 의도의 단일 출처는 계획서이고, CLI 는 그 편의 입구다.
+    // (계획서가 dryRun 을 실을 수 있으므로 MCP hwp_run_plan 은 인자 추가 없이 같은 계약을 얻는다.)
+    if dry_run {
+        if let Some(obj) = plan.as_object_mut() {
+            obj.insert("dryRun".to_string(), serde_json::Value::Bool(true));
+        }
+    }
     let (journal, code) = run_plan_engine(&plan);
     if json_mode {
         println!("{}", journal);
+    } else if code == EXIT_OK && journal["dryRun"] == true {
+        println!(
+            "검사 통과: {} step 실행 가능 (디스크 무변경, 산출 예정 {})",
+            journal["preview"].as_array().map(|s| s.len()).unwrap_or(0),
+            journal["output"].as_str().unwrap_or("-")
+        );
+        if let Some(preview) = journal["preview"].as_array() {
+            for step in preview {
+                println!("  - {}", preview_line(step));
+            }
+        }
     } else if code == EXIT_OK {
         println!(
             "완료: {} step 적용, 산출 {}",
@@ -10816,6 +10838,40 @@ fn cmd_run_plan(args: &[String]) -> i32 {
         eprintln!("{}", journal);
     }
     code
+}
+
+/// [#3721] dry-run 미리보기 한 줄 — 사람 모드에서 "무엇이 얼마나 바뀌나"를 읽게 한다.
+fn preview_line(step: &serde_json::Value) -> String {
+    let idx = step["step"].as_u64().unwrap_or(0);
+    match step["action"].as_str().unwrap_or("") {
+        "fill_fields" => format!(
+            "step {}: 누름틀 {}칸 채움",
+            idx,
+            step["targets"].as_array().map(|a| a.len()).unwrap_or(0)
+        ),
+        "replace_text" => format!(
+            "step {}: '{}' {}건 중 {}건 치환",
+            idx,
+            step["find"].as_str().unwrap_or(""),
+            step["matches"].as_u64().unwrap_or(0),
+            step["willReplace"].as_u64().unwrap_or(0)
+        ),
+        "set_checkbox" => format!(
+            "step {}: 빈 체크박스 {}개 중 {}번째 표시",
+            idx,
+            step["available"].as_u64().unwrap_or(0),
+            step["occurrence"].as_u64().unwrap_or(0)
+        ),
+        "set_cell" => format!(
+            "step {}: 표 {} ({},{}) 기록 — 현재값 {:?}",
+            idx,
+            step["table"].as_u64().unwrap_or(0),
+            step["row"].as_u64().unwrap_or(0),
+            step["col"].as_u64().unwrap_or(0),
+            step["currentText"].as_str().unwrap_or("")
+        ),
+        other => format!("step {}: {}", idx, other),
+    }
 }
 
 /// 계획 실행 본체 — (저널, 종료 코드). CLI 와 MCP `hwp_run_plan` 이 같은 판정을 공유한다.
@@ -10882,6 +10938,9 @@ fn run_plan_engine(plan: &serde_json::Value) -> (serde_json::Value, i32) {
     let all_names: Vec<String> = name_counts.keys().cloned().collect();
     let confusable_groups = rhwp::document_core::text_security::confusable_collisions(&all_names);
     let mut invalid: Vec<serde_json::Value> = Vec::new();
+    // [#3721] 선검증이 이미 계산한 값을 미리보기로 모은다 — dry-run 은 이걸 그대로 낸다.
+    // (실행 모드에서는 쓰이지 않지만, 판정자와 미리보기가 같은 계산이라 어긋날 수 없다.)
+    let mut preview: Vec<serde_json::Value> = Vec::new();
     for (idx, step) in steps.iter().enumerate() {
         let action = step["action"].as_str().unwrap_or("");
         match action {
@@ -10891,14 +10950,24 @@ fn run_plan_engine(plan: &serde_json::Value) -> (serde_json::Value, i32) {
                         "reason": "data 는 {\"필드이름\":\"값\"} 객체여야 합니다" }));
                     continue;
                 };
-                for key in data.keys() {
+                let mut targets: Vec<serde_json::Value> = Vec::new();
+                for (key, value) in data.iter() {
                     let (name, occurrence) = parse_field_key(key);
                     let total = name_counts.get(name).copied().unwrap_or(0);
                     if total == 0 || occurrence >= total {
                         invalid.push(serde_json::json!({ "step": idx, "action": action,
                             "reason": format!("필드 '{}' 이(가) 없거나 순번이 범위 밖입니다 (동명 {}개)", key, total) }));
+                        continue;
                     }
+                    targets.push(serde_json::json!({
+                        "name": name, "occurrence": occurrence, "sameNameCount": total,
+                        "value": value.as_str().map(|v| v.to_string())
+                            .unwrap_or_else(|| value.to_string()),
+                    }));
                 }
+                preview.push(
+                    serde_json::json!({ "step": idx, "action": action, "targets": targets }),
+                );
             }
             "replace_text" => {
                 let Some(find) = step["find"].as_str().filter(|s| !s.is_empty()) else {
@@ -10922,7 +10991,12 @@ fn run_plan_engine(plan: &serde_json::Value) -> (serde_json::Value, i32) {
                         invalid.push(serde_json::json!({ "step": idx, "action": action,
                             "reason": format!("'{}' 일치 0건 — 치환할 곳이 없습니다", find) }));
                     }
-                    _ => {}
+                    // occurrence 지정이면 1건만, 아니면 전건 — 실행 분기와 같은 규칙.
+                    occurrence => preview.push(serde_json::json!({
+                        "step": idx, "action": action, "find": find,
+                        "matches": count,
+                        "willReplace": if occurrence.is_some() { 1 } else { count },
+                    })),
                 }
             }
             "set_checkbox" => {
@@ -10935,6 +11009,9 @@ fn run_plan_engine(plan: &serde_json::Value) -> (serde_json::Value, i32) {
                 if (n as usize) >= count {
                     invalid.push(serde_json::json!({ "step": idx, "action": action,
                         "reason": format!("occurrence {} 이(가) 범위 밖입니다 (빈 체크박스 □ {}건)", n, count) }));
+                } else {
+                    preview.push(serde_json::json!({ "step": idx, "action": action,
+                        "occurrence": n, "available": count }));
                 }
             }
             "set_cell" => {
@@ -10977,10 +11054,18 @@ fn run_plan_engine(plan: &serde_json::Value) -> (serde_json::Value, i32) {
                         continue;
                     }
                 };
-                if let Err(e) = resolve_table_cell(doc.document(), table, row, col) {
-                    let (CellResolveError::Usage(msg) | CellResolveError::Runtime(msg)) = e;
-                    invalid
-                        .push(serde_json::json!({ "step": idx, "action": action, "reason": msg }));
+                match resolve_table_cell(doc.document(), table, row, col) {
+                    Err(e) => {
+                        let (CellResolveError::Usage(msg) | CellResolveError::Runtime(msg)) = e;
+                        invalid.push(
+                            serde_json::json!({ "step": idx, "action": action, "reason": msg }),
+                        );
+                    }
+                    Ok((.., current)) => preview.push(serde_json::json!({
+                        "step": idx, "action": action,
+                        "table": table, "row": row, "col": col,
+                        "currentText": current, "newText": text,
+                    })),
                 }
             }
             "" => {
@@ -10997,6 +11082,21 @@ fn run_plan_engine(plan: &serde_json::Value) -> (serde_json::Value, i32) {
                 "input": input, "output": output, "invalid": invalid,
             }),
             EXIT_USAGE,
+        );
+    }
+
+    // [#3721] dry-run — 선검증만 하고 여기서 끝낸다. 실행도, 저장도 없다.
+    // 계획을 *제출 전에* 검사하는 가장 싼 안전장치이고, 미리보기는 위에서 판정자가
+    // 이미 계산한 값 그대로라 "검사 결과와 실제 실행이 다를" 여지가 없다.
+    if plan["dryRun"].as_bool().unwrap_or(false) {
+        return (
+            serde_json::json!({
+                "schemaVersion": "1.0", "planVersion": "1.0", "dryRun": true,
+                "input": input, "output": output,
+                "preview": preview, "invalid": [],
+                "assertions": { "notFoundEmpty": assert_not_found_empty, "verify": assert_verify },
+            }),
+            EXIT_OK,
         );
     }
 

--- a/tests/run_plan_dry_run_contract.rs
+++ b/tests/run_plan_dry_run_contract.rs
@@ -1,0 +1,216 @@
+//! [#3721] 계획 v2 — `--dry-run`: 실행 전에 계획을 검사한다 (#3719 §6-3).
+//!
+//! 계약: 선검증만 돌고 **디스크는 절대 건드리지 않는다**. 유효하면 preview 저널 + exit 0,
+//! 위반이 있으면 기존 경로와 똑같이 invalid[] + exit 2. 계획서가 `dryRun:true` 를 담을 수
+//! 있으므로 MCP `hwp_run_plan` 도 인자 추가 없이 같은 계약을 얻는다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+const SAMPLE: &str = "samples/field-01.hwp";
+
+fn sample() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn temp_path(tag: &str, ext: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "rhwp-plandry-{tag}-{}-{}.{ext}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ))
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp")
+}
+
+/// 유효한 계획 + `--dry-run` → preview 저널, exit 0, **산출 파일 없음**.
+#[test]
+fn dry_run_previews_without_touching_disk() {
+    let p = sample();
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let out = temp_path("ok", "hwp");
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": p.to_str().unwrap(),
+        "output": out.to_str().unwrap(),
+        "steps": [
+            { "action": "fill_fields", "data": {"회사명": "미리보기사"} },
+            { "action": "replace_text", "find": "마케팅", "replace": "기획" },
+        ],
+    });
+    let plan_path = temp_path("ok", "json");
+    std::fs::write(&plan_path, serde_json::to_vec(&plan).unwrap()).unwrap();
+
+    let output = run(&["run", plan_path.to_str().unwrap(), "--dry-run", "--json"]);
+    assert_eq!(output.status.code(), Some(0), "유효한 계획은 exit 0");
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).expect("envelope");
+
+    assert_eq!(v["dryRun"], true, "dryRun 표시 필수: {v}");
+    assert!(
+        v["invalid"].as_array().is_none_or(|a| a.is_empty()),
+        "유효한 계획이므로 invalid 는 비어 있다: {v}"
+    );
+    let preview = v["preview"].as_array().expect("preview 배열");
+    assert_eq!(preview.len(), 2, "step 수만큼 미리보기: {v}");
+    assert_eq!(preview[0]["action"], "fill_fields", "{v}");
+    assert_eq!(preview[1]["action"], "replace_text", "{v}");
+    // 무엇이 얼마나 바뀔지 — 실행하지 않고도 답이 나와야 한다.
+    assert!(
+        preview[1]["matches"].as_u64().is_some_and(|n| n >= 1),
+        "치환 예정 건수를 미리 보고한다: {v}"
+    );
+    // 계약의 핵심: 디스크 무변경.
+    assert!(!out.exists(), "dry-run 은 산출 파일을 만들지 않는다");
+
+    let _ = std::fs::remove_file(&plan_path);
+}
+
+/// 위반이 있는 계획 + `--dry-run` → 기존 선검증 경로와 동일 (invalid[] + exit 2).
+#[test]
+fn dry_run_reports_violations_same_as_real_run() {
+    let p = sample();
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let out = temp_path("bad", "hwp");
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": p.to_str().unwrap(),
+        "output": out.to_str().unwrap(),
+        "steps": [
+            { "action": "fill_fields", "data": {"없는필드XYZ": "값"} },
+            { "action": "replace_text", "find": "이런문자열은없다9999", "replace": "X" },
+        ],
+    });
+    let plan_path = temp_path("bad", "json");
+    std::fs::write(&plan_path, serde_json::to_vec(&plan).unwrap()).unwrap();
+
+    let output = run(&["run", plan_path.to_str().unwrap(), "--dry-run", "--json"]);
+    assert_eq!(output.status.code(), Some(2), "위반은 exit 2");
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).expect("envelope");
+    let invalid = v["invalid"].as_array().expect("invalid 배열");
+    assert_eq!(invalid.len(), 2, "두 위반을 한 번에 보고: {v}");
+    assert!(!out.exists(), "위반 시에도 산출 없음");
+
+    let _ = std::fs::remove_file(&plan_path);
+}
+
+/// 계획서가 `dryRun:true` 를 직접 담아도 같은 계약 — MCP 경로가 인자 추가 없이 얻는 길.
+#[test]
+fn plan_carried_dry_run_flag_is_equivalent() {
+    let p = sample();
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let out = temp_path("carried", "hwp");
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "dryRun": true,
+        "input": p.to_str().unwrap(),
+        "output": out.to_str().unwrap(),
+        "steps": [ { "action": "fill_fields", "data": {"회사명": "계획내플래그"} } ],
+    });
+    let plan_path = temp_path("carried", "json");
+    std::fs::write(&plan_path, serde_json::to_vec(&plan).unwrap()).unwrap();
+
+    // --dry-run 플래그 없이, 계획서의 dryRun 만으로.
+    let output = run(&["run", plan_path.to_str().unwrap(), "--json"]);
+    assert_eq!(output.status.code(), Some(0));
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).expect("envelope");
+    assert_eq!(v["dryRun"], true, "{v}");
+    assert!(!out.exists(), "계획서가 실은 dryRun 도 디스크 무변경");
+
+    let _ = std::fs::remove_file(&plan_path);
+}
+
+/// 실행 모드는 종전 그대로 — dry-run 추가가 기존 계약을 흔들지 않는다.
+#[test]
+fn real_run_still_writes_and_reports_dry_run_false() {
+    let p = sample();
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let out = temp_path("real", "hwp");
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": p.to_str().unwrap(),
+        "output": out.to_str().unwrap(),
+        "steps": [ { "action": "fill_fields", "data": {"회사명": "실제실행"} } ],
+    });
+    let plan_path = temp_path("real", "json");
+    std::fs::write(&plan_path, serde_json::to_vec(&plan).unwrap()).unwrap();
+
+    let output = run(&["run", plan_path.to_str().unwrap(), "--json"]);
+    assert_eq!(output.status.code(), Some(0));
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).expect("envelope");
+    assert!(v["steps"].is_array(), "실행 저널은 steps 를 낸다: {v}");
+    assert_ne!(v["dryRun"], true, "실행 모드는 dryRun 이 참이 아니다: {v}");
+    assert!(out.exists(), "실행 모드는 산출을 남긴다");
+
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&plan_path);
+}
+
+/// MCP `hwp_run_plan` 도 계획서의 dryRun 으로 같은 계약을 얻는다 (도구 인자 추가 없음).
+#[test]
+fn mcp_run_plan_honors_plan_dry_run() {
+    let p = sample();
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let out = temp_path("mcp", "hwp");
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "dryRun": true,
+        "input": p.to_str().unwrap(),
+        "output": out.to_str().unwrap(),
+        "steps": [ { "action": "fill_fields", "data": {"회사명": "MCP미리보기"} } ],
+    });
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("mcp-serve")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+    writeln!(
+        stdin,
+        "{}",
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": { "name": "hwp_run_plan", "arguments": { "plan": plan } }
+        })
+    )
+    .unwrap();
+    stdin.flush().unwrap();
+
+    let mut line = String::new();
+    assert!(stdout.read_line(&mut line).unwrap() > 0);
+    let v: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+    let text = v["result"]["content"][0]["text"].as_str().expect("본문");
+    let body: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(body["dryRun"], true, "{body}");
+    assert!(!out.exists(), "MCP 경로도 디스크 무변경");
+
+    let _ = child.kill();
+    let _ = child.wait();
+}


### PR DESCRIPTION
## 요약 (#3759 · #3719 §6-3 · 적층 0단)

계획 실행기(#3703)는 **실행해야만** 계획이 유효한지 알 수 있었습니다. 선검증이 위반을
잡아 `exit 2` + 출력 파일 부재로 안전하게 끝내긴 하지만, 계획을 *생성하는* 에이전트가
알고 싶은 건 그 전 단계입니다 — **"이 계획, 돌리면 되나? 무엇이 얼마나 바뀌나?"**

`--dry-run` 은 선검증만 돌리고 `preview[]` 를 냅니다. 디스크는 건드리지 않습니다.

```bash
rhwp run 제출계획.json --dry-run --json
```

```jsonc
{ "schemaVersion":"1.0", "planVersion":"1.0", "dryRun":true,
  "input":"서식.hwp", "output":"제출본.hwp", "invalid":[],
  "preview":[
    { "step":0, "action":"fill_fields",  "targets":[{"name":"회사명","occurrence":0,"sameNameCount":1,"value":"…"}] },
    { "step":1, "action":"replace_text", "find":"2025", "matches":7, "willReplace":7 },
    { "step":2, "action":"set_checkbox", "occurrence":1, "available":5 },
    { "step":3, "action":"set_cell", "table":1,"row":0,"col":0, "currentText":"기존값", "newText":"새값" }
  ] }
```

## 계약

- 유효하면 `preview[]` + `dryRun:true` + **exit 0**, 산출 파일 없음.
- 위반이 있으면 실행 모드와 **똑같이** `invalid[]` + exit 2 (판정 일관 — dry-run 이
  통과시킨 계획이 실행에서 막히는 일이 없습니다).
- `preview` 는 선검증이 **이미 계산한 값 그대로**입니다. 판정자와 미리보기가 같은
  계산이라 "검사 결과와 실제 실행이 다를" 여지가 구조적으로 없습니다.

## 설계 판단 — 플래그를 계획서 필드로

`dryRun` 을 계획서(`plan.dryRun`)에 두면 MCP `hwp_run_plan{plan}` 이 **인자 추가도,
cmdTemplate 변경도 없이** 같은 계약을 얻습니다. CLI `--dry-run` 은 그 필드를 덮어쓰는
편의 입구일 뿐이고, **의도의 단일 출처는 계획서**입니다 (#3719 불변식 1).

## 검증

- 신규 `run_plan_dry_run_contract` **5건**:
  ① 유효 계획 preview + **산출 파일 부재**(계약의 핵심)
  ② 위반 시 실행 모드와 동일한 `invalid[]`+exit 2
  ③ 계획서가 실은 `dryRun` 이 CLI 플래그와 동등
  ④ 실행 모드 무회귀(`steps[]` 산출·파일 생성·`dryRun` 참 아님)
  ⑤ MCP `hwp_run_plan` 이 계획서 dryRun 존중 — 디스크 무변경
- 무회귀: `run_plan_contract` · `cli_json_contract`
- clippy `-D warnings` 0 · fmt clean

## 처리결과문서

- mydocs/report/task_m100_3759/README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
