### PR TITLE
fix: HWP5 저장 시 BMP 밖 문자(char) as u16 캐스팅으로 인한 데이터 손상 수정

### DIFF
--- a/src/serializer/byte_writer.rs
+++ b/src/serializer/byte_writer.rs
@@ -6,6 +6,19 @@
 use byteorder::{LittleEndian, WriteBytesExt};
 use std::io;
 
+/// BMP(U+0000~U+FFFF) 밖의 문자를 HWP5 WCHAR(16비트) 슬롯에 그대로 `as u16`으로 캐스팅하면
+/// 상위 비트가 잘려나가 다른 문자로 손상된다(예: '🔶'(U+1F536) as u16 == 0xF536).
+/// HWPX는 이런 문자를 유효하게 담을 수 있으므로(글머리표·각주 기호 등), HWP5로 저장할 때는
+/// BMP를 벗어난 문자를 대체 문자(U+FFFD, REPLACEMENT CHARACTER)로 치환해 최소한 손상된 값이
+/// 엉뚱한 글자로 조용히 바뀌지 않도록 한다.
+pub fn char_to_wchar(c: char) -> u16 {
+    if (c as u32) <= 0xFFFF {
+        c as u16
+    } else {
+        0xFFFD
+    }
+}
+
 /// 바이트 라이터 (버퍼 기반)
 pub struct ByteWriter {
     buf: Vec<u8>,
@@ -109,6 +122,22 @@ impl ByteWriter {
 mod tests {
     use super::*;
     use crate::parser::byte_reader::ByteReader;
+
+    #[test]
+    fn test_char_to_wchar_bmp_passthrough() {
+        assert_eq!(char_to_wchar('A'), 0x0041);
+        assert_eq!(char_to_wchar('가'), 0xAC00);
+        assert_eq!(char_to_wchar('\u{FFFF}'), 0xFFFF);
+    }
+
+    #[test]
+    fn test_char_to_wchar_astral_replaces_instead_of_truncating() {
+        // '🔶'(U+1F536)를 그냥 `as u16`으로 캐스팅하면 상위 비트가 잘려 0xF536(다른 문자)이
+        // 되어 손상된 값이 조용히 기록된다. char_to_wchar는 대신 U+FFFD로 치환해야 한다.
+        let c = '\u{1F536}';
+        assert_ne!(c as u32 as u16, 0xFFFD); // as u16 캐스팅은 0xF536이 되어 손상된다는 전제 확인
+        assert_eq!(char_to_wchar(c), 0xFFFD);
+    }
 
     #[test]
     fn test_write_u8() {

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -4,7 +4,7 @@
 //! 각 Control enum variant를 CTRL_HEADER 레코드(+자식 레코드)로 변환한다.
 
 use super::body_text::serialize_paragraph_list;
-use super::byte_writer::ByteWriter;
+use super::byte_writer::{char_to_wchar, ByteWriter};
 
 use crate::document_core::converters::common_obj_attr_writer::pack_common_attr_bits;
 use crate::model::control::*;
@@ -410,9 +410,9 @@ fn serialize_page_def(pd: &PageDef) -> Vec<u8> {
 fn serialize_footnote_shape(fs: &FootnoteShape) -> Vec<u8> {
     let mut w = ByteWriter::new();
     w.write_u32(fs.attr).unwrap();
-    w.write_u16(fs.user_char as u16).unwrap();
-    w.write_u16(fs.prefix_char as u16).unwrap();
-    w.write_u16(fs.suffix_char as u16).unwrap();
+    w.write_u16(char_to_wchar(fs.user_char)).unwrap();
+    w.write_u16(char_to_wchar(fs.prefix_char)).unwrap();
+    w.write_u16(char_to_wchar(fs.suffix_char)).unwrap();
     w.write_u16(fs.start_number).unwrap();
     // HWP5 노트 구분선 길이는 i16 슬롯. 한컴 전폭 sentinel(14692344)은 i16을 넘지만
     // HWP5 포맷 한계상 하위 16비트로 기록한다(HWPX 경로는 i32 원본을 보존).
@@ -911,9 +911,9 @@ fn serialize_auto_number(an: &AutoNumber) -> Vec<u8> {
         an.assigned_number
     };
     data.extend_from_slice(&num.to_le_bytes());
-    data.extend_from_slice(&(an.user_symbol as u16).to_le_bytes());
-    data.extend_from_slice(&(an.prefix_char as u16).to_le_bytes());
-    data.extend_from_slice(&(an.suffix_char as u16).to_le_bytes());
+    data.extend_from_slice(&char_to_wchar(an.user_symbol).to_le_bytes());
+    data.extend_from_slice(&char_to_wchar(an.prefix_char).to_le_bytes());
+    data.extend_from_slice(&char_to_wchar(an.suffix_char).to_le_bytes());
     data
 }
 
@@ -938,10 +938,10 @@ fn serialize_page_num_pos(pnp: &PageNumberPos) -> Vec<u8> {
     let attr: u32 = (pnp.format as u32 & 0xFF) | ((pnp.position as u32 & 0x0F) << 8);
     let mut data = Vec::new();
     data.extend_from_slice(&attr.to_le_bytes());
-    data.extend_from_slice(&(pnp.user_symbol as u16).to_le_bytes());
-    data.extend_from_slice(&(pnp.prefix_char as u16).to_le_bytes());
-    data.extend_from_slice(&(pnp.suffix_char as u16).to_le_bytes());
-    data.extend_from_slice(&(pnp.dash_char as u16).to_le_bytes());
+    data.extend_from_slice(&char_to_wchar(pnp.user_symbol).to_le_bytes());
+    data.extend_from_slice(&char_to_wchar(pnp.prefix_char).to_le_bytes());
+    data.extend_from_slice(&char_to_wchar(pnp.suffix_char).to_le_bytes());
+    data.extend_from_slice(&char_to_wchar(pnp.dash_char).to_le_bytes());
     data
 }
 

--- a/src/serializer/doc_info.rs
+++ b/src/serializer/doc_info.rs
@@ -7,7 +7,7 @@
 //! DOCUMENT_PROPERTIES → ID_MAPPINGS → BIN_DATA → FACE_NAME →
 //! BORDER_FILL → CHAR_SHAPE → TAB_DEF → NUMBERING → PARA_SHAPE → STYLE
 
-use super::byte_writer::ByteWriter;
+use super::byte_writer::{char_to_wchar, ByteWriter};
 use super::record_writer::write_record;
 
 use crate::model::bin_data::{BinData, BinDataType};
@@ -610,7 +610,7 @@ fn serialize_bullet(bullet: &Bullet) -> Vec<u8> {
     w.write_u32(bullet.char_shape_id).unwrap();
 
     // 글머리표 문자 (WCHAR)
-    w.write_u16(bullet.bullet_char as u16).unwrap();
+    w.write_u16(char_to_wchar(bullet.bullet_char)).unwrap();
 
     // 이미지 글머리표 여부 (INT32)
     w.write_i32(bullet.image_bullet).unwrap();
@@ -621,7 +621,7 @@ fn serialize_bullet(bullet: &Bullet) -> Vec<u8> {
     }
 
     // 체크 글머리표 문자 (WCHAR)
-    w.write_u16(bullet.check_bullet_char as u16).unwrap();
+    w.write_u16(char_to_wchar(bullet.check_bullet_char)).unwrap();
 
     w.into_bytes()
 }

--- a/src/serializer/doc_info.rs
+++ b/src/serializer/doc_info.rs
@@ -621,7 +621,8 @@ fn serialize_bullet(bullet: &Bullet) -> Vec<u8> {
     }
 
     // 체크 글머리표 문자 (WCHAR)
-    w.write_u16(char_to_wchar(bullet.check_bullet_char)).unwrap();
+    w.write_u16(char_to_wchar(bullet.check_bullet_char))
+        .unwrap();
 
     w.into_bytes()
 }

--- a/tests/batch_axes_contract.rs
+++ b/tests/batch_axes_contract.rs
@@ -18,6 +18,27 @@ fn sample(rel: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
 }
 
+/// 자식이 stdin 을 다 읽기 전에 종료하면 파이프의 읽기 끝이 닫혀 `write_all` 이 `EPIPE` 를
+/// 받는다. 이 파일의 테스트들은 바로 그 동작(`*_rejected_before_consuming_path_stdin`,
+/// `*_rejects_flag_as_out_dir_before_any_write`)을 검증하므로, `BrokenPipe` 는 오류가 아니라
+/// **검증 대상의 정상적인 부산물**이다. 오류로 다루면 기능이 의도대로 일찍 거부할수록 테스트가
+/// 더 자주 깨진다 (#3763).
+///
+/// 실제 계약은 이 함수가 돌려주는 종료 코드·stdout 으로 확인한다. 자식이 정말 stdin 을
+/// 필요로 했다면 그 단언에서 잡히므로 검증력은 줄지 않는다. 그 밖의 쓰기 오류는 그대로 패닉한다.
+fn write_stdin_tolerating_broken_pipe(child: &mut std::process::Child, stdin_body: &str) {
+    match child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(stdin_body.as_bytes())
+    {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::BrokenPipe => {}
+        Err(error) => panic!("stdin 쓰기 실패: {error:?}"),
+    }
+}
+
 fn run_with_stdin(args: &[&str], stdin_body: &str) -> Output {
     let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
         .args(args)
@@ -26,12 +47,7 @@ fn run_with_stdin(args: &[&str], stdin_body: &str) -> Output {
         .stderr(Stdio::piped())
         .spawn()
         .expect("rhwp 실행 실패");
-    child
-        .stdin
-        .as_mut()
-        .expect("stdin")
-        .write_all(stdin_body.as_bytes())
-        .expect("stdin 쓰기 실패");
+    write_stdin_tolerating_broken_pipe(&mut child, stdin_body);
     child.wait_with_output().expect("rhwp 종료 대기 실패")
 }
 
@@ -45,12 +61,7 @@ fn run_with_stdin_in_dir(args: &[&str], stdin_body: &str, current_dir: &Path) ->
         .stderr(Stdio::piped())
         .spawn()
         .expect("rhwp 실행 실패");
-    child
-        .stdin
-        .as_mut()
-        .expect("stdin")
-        .write_all(stdin_body.as_bytes())
-        .expect("stdin 쓰기 실패");
+    write_stdin_tolerating_broken_pipe(&mut child, stdin_body);
     child.wait_with_output().expect("rhwp 종료 대기 실패")
 }
 

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -24,6 +24,10 @@ fn run(args: &[&str]) -> Output {
 }
 
 /// stdin 으로 파일 목록을 흘려 넣는 batch 실행 헬퍼.
+///
+/// 자식이 stdin 을 다 읽기 전에 종료하면(예: 인자 검증에서 usage 오류로 즉시 거부)
+/// `write_all` 이 `EPIPE` 를 받는다. 이는 오류가 아니라 검증 대상 동작의 정상적인
+/// 부산물이므로 넘어간다 — 실제 계약은 종료 코드·stdout 으로 확인한다 (#3763).
 fn run_with_stdin(args: &[&str], stdin_body: &str) -> Output {
     let mut child = Command::new(rhwp_bin())
         .args(args)
@@ -32,12 +36,16 @@ fn run_with_stdin(args: &[&str], stdin_body: &str) -> Output {
         .stderr(Stdio::piped())
         .spawn()
         .expect("rhwp 실행 실패");
-    child
+    match child
         .stdin
         .as_mut()
         .expect("stdin")
         .write_all(stdin_body.as_bytes())
-        .expect("stdin 쓰기 실패");
+    {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::BrokenPipe => {}
+        Err(error) => panic!("stdin 쓰기 실패: {error:?}"),
+    }
     child.wait_with_output().expect("rhwp 종료 대기 실패")
 }
 

--- a/tests/info_title_contract.rs
+++ b/tests/info_title_contract.rs
@@ -34,6 +34,9 @@ fn run(args: &[&str]) -> Output {
         .expect("rhwp 실행 실패")
 }
 
+/// 자식이 stdin 을 다 읽기 전에 종료하면(예: 인자 검증에서 usage 오류로 즉시 거부)
+/// `write_all` 이 `EPIPE` 를 받는다. 이는 오류가 아니라 검증 대상 동작의 정상적인
+/// 부산물이므로 넘어간다 — 실제 계약은 종료 코드·stdout 으로 확인한다 (#3763).
 fn run_with_stdin(args: &[&str], stdin_body: &str) -> Output {
     let mut child = Command::new(rhwp_bin())
         .args(args)
@@ -42,12 +45,16 @@ fn run_with_stdin(args: &[&str], stdin_body: &str) -> Output {
         .stderr(Stdio::piped())
         .spawn()
         .expect("rhwp 실행 실패");
-    child
+    match child
         .stdin
         .as_mut()
         .expect("stdin")
         .write_all(stdin_body.as_bytes())
-        .expect("stdin 쓰기 실패");
+    {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::BrokenPipe => {}
+        Err(error) => panic!("stdin 쓰기 실패: {error:?}"),
+    }
     child.wait_with_output().expect("rhwp 종료 대기 실패")
 }
 


### PR DESCRIPTION
## 문제

HWP5 직렬화 코드에서 `char` 타입 필드를 HWP5의 16비트 WCHAR 슬롯에 쓸 때
`as u16`으로 직접 캐스팅하는 패턴이 4개 함수, 10개 필드에 걸쳐 반복돼 있었다.

`char`는 U+0000~U+10FFFF 전체 유니코드 스칼라 값을 담을 수 있지만, HWPX
파서는 이 필드들을 `s.chars().next()`로 BMP 제한 없이 채운다(글머리표
기호, 각주/미주 접두/접미 문자, 자동번호 사용자 기호 등은 실제로 이모지 같은
비BMP 문자를 담을 수 있다). 이런 문자를 그대로 `as u16` 캐스팅하면 상위
비트가 잘려 완전히 다른 문자로 조용히 손상된다. 예: `'🔶'`(U+1F536) `as u16`
== `0xF536`(전혀 다른 글자) — 에러도, 패닉도 없이 잘못된 값이 저장된다.

같은 클래스의 결함이 `byte_writer.rs`의 `write_hwp_string`(문자열 길이
u16::MAX 초과 시 wraparound)에서는 이미 한 번 고쳐졌지만
(`test_write_hwp_string_overlong_truncates_instead_of_wrapping`), `char`
타입 필드들에는 같은 수정이 적용되지 않고 남아 있었다.

## 수정 대상 (4곳, 10개 필드)

1. `src/serializer/doc_info.rs` — `serialize_bullet`: `bullet_char`,
   `check_bullet_char`
2. `src/serializer/control.rs` — `serialize_footnote_shape`: `user_char`,
   `prefix_char`, `suffix_char`
3. `src/serializer/control.rs` — `serialize_auto_number`(추정 함수명):
   `user_symbol`, `prefix_char`, `suffix_char`
4. `src/serializer/control.rs` — `serialize_page_num_pos`: `user_symbol`,
   `prefix_char`, `suffix_char`, `dash_char`

## 수정 방식

`src/serializer/byte_writer.rs`에 공용 헬퍼 `char_to_wchar()`를 추가:
BMP(U+0000~U+FFFF) 안이면 그대로 `as u16`, 밖이면 대체 문자
U+FFFD(REPLACEMENT CHARACTER)로 치환한다. 4개 함수의 10개 캐스팅 지점을
모두 이 헬퍼 호출로 교체했다.

## 검증

- `cargo test --lib serializer::` — 488 passed, 0 failed
  (신규 테스트 `test_char_to_wchar_bmp_passthrough`,
  `test_char_to_wchar_astral_replaces_instead_of_truncating` 포함)
- `cargo test --lib serializer::byte_writer::tests` — 18 passed, 0 failed
- 디스크 여유 공간 제약(작업 중 ~2GB까지 하락)으로 이번 세션에서는 narrow
  `cargo test --lib` 필터만 실행했고 풀 `cargo build`/`cargo test --tests`는
  실행하지 않았다. 컴파일은 `cargo test --lib` 과정에서 전체 크레이트를
  포함해 성공적으로 완료됐다.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---

## 📌 추가 커밋 안내 — #3763 플레이키 수정을 함께 실었습니다

이 PR 의 변경과 무관하게 CI 가 계속 빨갰습니다. `devel`(cc38291) 자체가 #3742 머지 이후
`tests/batch_axes_contract.rs` 의 stdin 헬퍼 때문에 깨져 있고, 그 커밋을 기반으로 하는 모든 PR 이
같은 지점에서 막힙니다.

```
thread 'batch_global_auth_options_are_rejected_before_consuming_path_stdin' panicked at tests/batch_axes_contract.rs:34:10:
stdin 쓰기 실패: Os { code: 32, kind: BrokenPipe, message: "Broken pipe" }
```

재실행으로는 빠져나가지 못했습니다 — 이 PR 도 재실행했지만 같은 지점에서 다시 실패했습니다.
그래서 이 브랜치의 CI 를 **읽을 수 있게** 하려고 #3766 의 테스트 하네스 수정
(`tests/` 3개 파일, 제품 코드 무변경)을 그대로 실었습니다.

원인 분석은 #3763 에 있습니다. **#3766 이 먼저 머지되면 이 커밋은 빈 diff 가 되어 리베이스 때
자연히 떨어져 나갑니다.** 리뷰 시 마지막 커밋
`test(cli): stdin 계약 테스트의 BrokenPipe 플레이키를 함께 싣는다 (#3763)` 는 이 PR 의 본 주제가
아니니 분리해서 보시면 됩니다.
