### PR TITLE
fix(typeset): line_advance/line_advances_sum 인덱스 초과 클램프 (#3780)

### DIFF
--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -2463,15 +2463,29 @@ struct FormattedParagraph {
 
 impl FormattedParagraph {
     /// 특정 줄의 advance 높이 (콘텐츠 + 줄간격)
+    ///
+    /// Issue #3780: 연속 페이지 재배치에서 기록된 줄 인덱스가 새 레이아웃 줄 수를
+    /// 넘는 off-by-one(len 31, index 31 실측 패닉)이 들어올 수 있다 — 존재하지
+    /// 않는 줄의 advance 는 0.0 으로 방어해 렌더를 지속한다.
     #[inline]
     fn line_advance(&self, line_idx: usize) -> f64 {
+        if line_idx >= self.line_count() {
+            return 0.0;
+        }
         self.line_heights[line_idx] + self.line_spacings[line_idx]
     }
 
-    /// 줄 범위의 advance 합계
+    /// 두 벡터가 함께 인덱싱되는 자리의 안전 상한 (구성은 zip 이라 보통 같다).
+    #[inline]
+    fn line_count(&self) -> usize {
+        self.line_heights.len().min(self.line_spacings.len())
+    }
+
+    /// 줄 범위의 advance 합계 (Issue #3780 — 범위를 실제 줄 수로 클램프)
     fn line_advances_sum(&self, range: std::ops::Range<usize>) -> f64 {
-        range
-            .into_iter()
+        let end = range.end.min(self.line_count());
+        let start = range.start.min(end);
+        (start..end)
             .map(|i| self.line_heights[i] + self.line_spacings[i])
             .sum()
     }
@@ -18596,6 +18610,39 @@ fn endnote_separator_height_px(shape: &FootnoteShape, dpi: f64) -> f64 {
     hwpunit_to_px(shape.separator_above_margin_hu() as i32, dpi)
         + line_height
         + hwpunit_to_px(endnote_separator_below_margin(shape) as i32, dpi)
+}
+
+#[cfg(test)]
+mod issue_3780_line_advance_oob {
+    use super::FormattedParagraph;
+
+    fn fp(lines: usize) -> FormattedParagraph {
+        FormattedParagraph {
+            total_height: 0.0,
+            line_heights: vec![10.0; lines],
+            line_spacings: vec![2.0; lines],
+            spacing_before: 0.0,
+            spacing_after: 0.0,
+            height_for_fit: 0.0,
+        }
+    }
+
+    /// red→green: 클램프를 원복하면 이 두 테스트는 index out of bounds 로 패닉한다
+    /// (len 31 / index 31 — 실측 사고와 동일한 상태).
+    #[test]
+    fn out_of_range_line_advance_is_zero_not_panic() {
+        let p = fp(31);
+        assert_eq!(p.line_advance(31), 0.0);
+        assert_eq!(p.line_advance(30), 12.0, "경계 안 동작 불변");
+    }
+
+    #[test]
+    fn out_of_range_advance_sum_clamps_to_existing_lines() {
+        let p = fp(31);
+        assert_eq!(p.line_advances_sum(29..33), 24.0, "29,30 두 줄만 합산");
+        assert_eq!(p.line_advances_sum(0..31), 31.0 * 12.0, "전 범위 동작 불변");
+        assert_eq!(p.line_advances_sum(40..50), 0.0);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #3780

## 문제

연속 페이지 재배치에서 기록된 줄 인덱스가 새 레이아웃 줄 수를 넘는 off-by-one 이 들어오면 `line_advance`/`line_advances_sum` 의 무방비 인덱싱이 즉시 패닉합니다 (실서비스 대량 문서 렌더에서 `index out of bounds: the len is 31 but the index is 31` 실측 — v0.7.15/v0.7.17/v0.8.2 세 릴리스에서 동일 잔존 확인).

## 수정

- `line_advance`: 범위 밖 인덱스 → 0.0 (존재하지 않는 줄의 advance)
- `line_advances_sum`: 범위를 실제 줄 수로 클램프
- 상한 = `line_heights`/`line_spacings` 두 벡터의 **min** — 한 인덱스로 둘 다 접근하는 자리라 한쪽 길이만 보면 같은 패닉 경로가 남습니다

호출부의 off-by-one 근본(기록된 PartialParagraph 줄 범위 vs 재배치 후 레이아웃)은 별도 추적이 필요하지만, 이 두 함수는 어느 쪽이든 경계 방어가 있어야 렌더가 지속됩니다.

## red→green (수정 전 실패 증명)

재현 문서가 실서비스 자료라 첨부 대신 `FormattedParagraph` 상태 수준의 결정론 재현(줄 31 / 인덱스 31)을 유닛 회귀로 동봉했습니다. **클램프 커밋만 원복한 상태에서 신규 테스트 2건이 실측과 동일한 `index out of bounds` 패닉으로 FAIL** 함을 확인했습니다 (경계 안 동작 불변 단언 포함). `FormattedParagraph` 가 private 이라 `tests/issue_3780_*.rs` 통합 테스트 대신 동일 모듈 유닛 테스트로 두었습니다 — 관례와 다른 점 양해 부탁드립니다.

## 검증

- `cargo fmt --all -- --check` ✅
- `cargo test --profile release-test --tests` — **4,601 passed / 0 failed** ✅
- `cargo clippy` 신규 경고 0 ✅

환경: macOS arm64, 라이브러리 사용 (CLI 아님)