### PR TITLE
fix(picture): tac/앵커 마이그레이션 시 stale packed attr 동기화 (#3781)

### DIFF
--- a/src/document_core/commands/object_ops/picture.rs
+++ b/src/document_core/commands/object_ops/picture.rs
@@ -473,6 +473,11 @@ impl DocumentCore {
             let had_caption = pic.caption.is_some();
             let caption_created = Self::apply_picture_props_inner(pic, props_json);
             let now_tac = pic.common.treat_as_char;
+            // tac 토글이 enum 에만 반영되고 packed attr 이 낡으면 직렬화가 옛 앵커를
+            // 되살린다 — 여기서 즉시 동기화 (migrate 경로는 rel_to 갱신 후 재동기화).
+            crate::document_core::converters::common_obj_attr_writer::sync_anchor_bits(
+                &mut pic.common,
+            );
             (
                 caption_created,
                 had_caption && pic.caption.is_none(),
@@ -669,6 +674,11 @@ impl DocumentCore {
             let was_tac = pic.common.treat_as_char;
             caption_created = Self::apply_picture_props_inner(pic, props_json);
             let now_tac = pic.common.treat_as_char;
+            // 본문 setter 와 같은 이유로 여기서도 packed attr 을 동기화한다 —
+            // 머리말/꼬리말 경로도 같은 tac 토글 마이그레이션을 수행한다 (Issue #3781).
+            crate::document_core::converters::common_obj_attr_writer::sync_anchor_bits(
+                &mut pic.common,
+            );
             if !was_tac && now_tac {
                 if let crate::model::control::Control::Picture(pic_box) =
                     &mut inner_para.controls[inner_control_idx]
@@ -725,6 +735,9 @@ impl DocumentCore {
         pic.common.vert_rel_to = VertRelTo::Para;
         pic.common.horizontal_offset = 0;
         pic.common.vertical_offset = 0;
+        // stale packed attr 동기화 — 없으면 바이너리 왕복에서 Paper 앵커 부활
+        // (treatAsChar=1 + PAPER 모순 → 한글 렌더 깨짐, Issue #3781 실측).
+        crate::document_core::converters::common_obj_attr_writer::sync_anchor_bits(&mut pic.common);
 
         let picture_height_hu = pic.common.height as i32;
         let baseline = (picture_height_hu as f64 * 0.85).round() as i32;

--- a/src/document_core/converters/common_obj_attr_writer.rs
+++ b/src/document_core/converters/common_obj_attr_writer.rs
@@ -115,6 +115,30 @@ pub(crate) fn pack_common_attr_bits(common: &CommonObjAttr) -> u32 {
     a
 }
 
+/// tac/rel_to 마이그레이션 후 stale packed `attr` 동기화.
+///
+/// 배경 (Issue #3781 실측): `insert_picture_native` 가 `attr` 비트를 seed 하고
+/// `migrate_picture_floating_to_inline` 은 **enum 필드만** 갱신한다. 직렬화는
+/// `attr != 0` 이면 packed 값을 우선하므로(라운드트립 보존 계약), 마이그레이션된
+/// 그림이 HWP 바이너리 왕복에서 floating(Paper) 앵커로 되살아나
+/// `treatAsChar=1 + vertRelTo=PAPER` 모순 산출물이 된다 (한글 렌더 깨짐).
+/// 앵커 관련 비트(tac bit0 · vert_rel 3-4 · horz_rel 8-9)만 enum 에서 재기입하고,
+/// criterion/wrap/flow 등 나머지 비트는 보존한다 (전체 재패킹은 enum 미동기
+/// 필드의 정보 손실 위험).
+pub(crate) fn sync_anchor_bits(common: &mut CommonObjAttr) {
+    if common.attr == 0 {
+        return; // 직렬화가 pack_common_attr_bits 로 전량 재패킹 — 손댈 것 없음.
+    }
+    let mut a = common.attr;
+    a &= !(0x01 | (0x03 << 3) | (0x03 << 8));
+    if common.treat_as_char {
+        a |= 0x01;
+    }
+    a |= (vert_rel_to_to_bits(common.vert_rel_to) & 0x03) << 3;
+    a |= (horz_rel_to_to_bits(common.horz_rel_to) & 0x03) << 8;
+    common.attr = a;
+}
+
 fn vert_rel_to_to_bits(v: VertRelTo) -> u32 {
     match v {
         VertRelTo::Paper => 0,
@@ -423,5 +447,53 @@ mod tests {
         let bytes = serialize_common_obj_attr(&original);
         let parsed = parse_common_obj_attr(&bytes);
         assert_eq!(parsed.text_flow, TextFlow::BothSides);
+    }
+}
+
+#[cfg(test)]
+mod sync_anchor_bits_tests {
+    use super::*;
+    use crate::model::shape::{HorzRelTo, VertRelTo};
+
+    /// Issue #3781 실측 회귀: insert 가 seed 한 floating attr
+    /// ((4<<15)|(2<<18) — tac=0·rel=Paper) 위에서 inline 마이그레이션(enum 갱신) 후
+    /// sync 하면 tac/rel 비트만 Para 로 바뀌고 criterion 비트는 보존된다.
+    #[test]
+    fn sync_anchor_bits_updates_stale_floating_seed() {
+        let mut common = CommonObjAttr {
+            attr: (4 << 15) | (2 << 18),
+            treat_as_char: false,
+            vert_rel_to: VertRelTo::Paper,
+            horz_rel_to: HorzRelTo::Paper,
+            ..Default::default()
+        };
+        // 마이그레이션이 하는 일 (enum 갱신).
+        common.treat_as_char = true;
+        common.vert_rel_to = VertRelTo::Para;
+        common.horz_rel_to = HorzRelTo::Para;
+        sync_anchor_bits(&mut common);
+        assert_eq!(common.attr & 0x01, 0x01, "tac bit");
+        assert_eq!((common.attr >> 3) & 0x03, 2, "vert_rel_to = Para");
+        assert_eq!(
+            (common.attr >> 8) & 0x03,
+            3,
+            "horz_rel_to = Para (Paper0/Page1/Column2/Para3)"
+        );
+        assert_eq!((common.attr >> 15) & 0x07, 4, "width criterion 보존");
+        assert_eq!((common.attr >> 18) & 0x03, 2, "height criterion 보존");
+    }
+
+    /// attr=0(합성 경로) 은 무접촉 — 직렬화가 전량 재패킹한다.
+    #[test]
+    fn sync_anchor_bits_leaves_zero_attr_untouched() {
+        let mut common = CommonObjAttr {
+            attr: 0,
+            treat_as_char: true,
+            vert_rel_to: VertRelTo::Para,
+            horz_rel_to: HorzRelTo::Para,
+            ..Default::default()
+        };
+        sync_anchor_bits(&mut common);
+        assert_eq!(common.attr, 0);
     }
 }


### PR DESCRIPTION
Closes #3781

## 문제

`insert_picture_native` 는 `CommonObjAttr.attr` 을 floating 비트(rel=Paper)로 시드하는데, `migrate_picture_floating_to_inline` 과 tac 토글 setter 가 **enum 필드만** 갱신하고 packed attr 을 남깁니다. 직렬화는 왕복 계약상 0 이 아닌 packed attr 을 우선하므로, HWP 바이너리 왕복에서 **Paper 앵커가 부활**합니다:

```
treatAsChar=1 + vertRelTo=PAPER  (모순 조합)
```

한글(한컴)이 이 조합을 접으면서 그림이 깨진 획처럼 렌더됩니다 (실서비스 문서 실측).

## 수정

- `sync_anchor_bits()`: enum 필드에서 **앵커 비트만** 외과적 재기록 (tac bit0 / vert_rel 3-4 / horz_rel 8-9) — criterion/wrap/flow 비트 보존
- 호출 3곳: 본문 tac 토글 · 머리말/꼬리말 tac 토글(같은 마이그레이션을 수행하는 형제 자리) · `migrate_picture_floating_to_inline` 말미
- `attr == 0`(합성 경로)은 불변 — 직렬화가 enum 에서 새로 합성하는 기존 계약 유지

## red→green

유닛 회귀 2건 동봉: ① stale floating 시드 → Para 비트 재기록 + criterion 보존 ② `attr=0` 합성 경로 불변. `sync_anchor_bits` 원복 시 ① 이 FAIL 합니다. 바이너리 왕복 통합 재현은 실서비스 HWP 라 첨부가 어려웠습니다 — 필요하시면 개인정보 제거 샘플 제작을 시도해 보겠습니다.

## 검증

- `cargo fmt --all -- --check` ✅
- `cargo test --profile release-test --tests` — **4,601 passed / 0 failed** ✅

환경: macOS arm64, 라이브러리 사용