### PR TITLE
fix(rhwp-studio): macOS 영문 Option+G 찾아가기 보정 (#3784)

### DIFF
--- a/mydocs/orders/20260802.md
+++ b/mydocs/orders/20260802.md
@@ -1,5 +1,13 @@
 # 오늘 할 일 - 2026년 8월 2일
 
+## #3784 macOS 영문 Option+G 찾아가기
+
+- [#3784](https://github.com/edwardkim/rhwp/issues/3784) 등록 후
+  `fix/3784-macos-option-g-goto`에서 `Option+G`의 `©` 문자값을 물리 `KeyG`로 보정했다.
+- shortcut-map 6건, Studio 전체 721건, TypeScript 검사와 headless Chromium 활성 입력기 검증을
+  통과했다.
+- 코드·테스트·계획·결과·PR 본문 초안을 하나의 커밋으로 고정하고, 원격 push 및 PR 생성 승인 대기다.
+
 ## Kevin #3689–#3735 · planet6897 #3736 통합 검토
 
 [#3742](https://github.com/edwardkim/rhwp/pull/3742)

--- a/mydocs/plans/task_m100_3784.md
+++ b/mydocs/plans/task_m100_3784.md
@@ -1,0 +1,43 @@
+# 수행계획서 — task_m100_3784
+
+- **이슈**: #3784 `fix(rhwp-studio): macOS 영문 입력 Option+G로 찾아가기 실행`
+- **브랜치**: `fix/3784-macos-option-g-goto`
+- **분기 기준**: `upstream/devel` `cc3829116`
+- **기록 시각**: 2026-08-02 KST
+- **절차 상태**: Stage 1 구현·focused 검증 완료, PR 생성 승인 대기
+
+## 1. 문제
+
+macOS 영문 입력 모드에서 `Option+G`는 브라우저에 문자 값 `©`로 전달된다. 물리 키는
+`KeyboardEvent.code = KeyG`로 유지되지만, 찾아가기 단축키는 문자 값 `g`만 등록되어 있어
+`edit:goto` 명령을 찾지 못한다. 한글 입력 모드의 `ㅎ` 매핑은 정상이다.
+
+## 2. 설계
+
+`shortcut-map.ts`의 영문 `Alt+G` 정의에 `code: 'KeyG'`를 추가한다. 단축키 매처는 이미 modifier를
+먼저 검증한 뒤 문자 값과 물리 키 코드를 비교하므로, `Option` 조합에서 문자 값이 바뀌어도 올바른
+물리 키를 판별할 수 있다.
+
+## 3. 범위
+
+- 영문 `Option+G`의 `KeyG` 기반 매핑 추가
+- macOS 영문 문자 값 `©` 회귀 테스트 추가
+- 기존 영문 `g`와 한글 `ㅎ` 단축키 호환 확인
+
+## 4. 비범위
+
+- 다른 `Option` 단축키의 전면 재설계
+- IME 구현 또는 브라우저 입력 이벤트 전반 변경
+- Rust/WASM, 문서 모델, 렌더러 변경
+
+## 5. 검증
+
+- `npm --prefix rhwp-studio test -- --test-name-pattern='Option\\+G|shortcut'`
+- `npm --prefix rhwp-studio exec -- tsc --noEmit`
+- `git diff --check`
+
+## 6. 완료 기준
+
+- macOS 영문 `key: '©', code: 'KeyG', altKey: true`가 `edit:goto`로 매핑된다.
+- 한글 `Alt+ㅎ`와 일반 `Alt+G` 매핑이 유지된다.
+- focused Studio 검증과 TypeScript 검사가 통과한다.

--- a/mydocs/plans/task_m100_3784_impl.md
+++ b/mydocs/plans/task_m100_3784_impl.md
@@ -1,0 +1,24 @@
+# 구현계획서 — task_m100_3784
+
+- **이슈**: #3784
+- **수행계획서**: `mydocs/plans/task_m100_3784.md`
+- **브랜치**: `fix/3784-macos-option-g-goto`
+- **절차 상태**: Stage 1·2 완료, PR 생성 승인 대기
+
+## Stage 1 — 단축키 계약 보정
+
+1. `defaultShortcuts`의 `edit:goto` 영문 정의에 `code: 'KeyG'`를 추가한다.
+2. 기존 한글 `Alt+ㅎ` 정의는 별도 대체 경로로 그대로 유지한다.
+3. `shortcut-map` 단위 테스트에 macOS 영문 `Option+G`의 문자 값 `©`와 물리 키 `KeyG` 조합을 추가한다.
+
+## Stage 2 — focused 검증과 PR 준비
+
+1. Studio 단위 테스트와 TypeScript 검사를 순차 실행한다.
+2. 계획 대비 변경·검증 결과를 단계 기록에 남긴다.
+3. 코드·테스트·문서를 하나의 일반 커밋으로 고정하고 PR 제목·본문 초안을 준비한다.
+
+## 회귀 경계
+
+- `altKey` 외 `ctrlKey`/`metaKey`가 없는 조합만 찾아가기로 인식한다.
+- 문자 값이 `g`인 비-macOS 및 기존 한글 `ㅎ` 경로는 유지한다.
+- `KeyH` 등 다른 물리 키는 찾아가기로 매칭하지 않는다.

--- a/mydocs/pr_body_draft_3784.md
+++ b/mydocs/pr_body_draft_3784.md
@@ -1,0 +1,21 @@
+# fix(rhwp-studio): macOS 영문 Option+G 찾아가기 보정 (#3784)
+
+## 요약
+
+macOS 영문 입력에서 `Option+G`가 문자값 `©`로 전달되어 찾아가기 명령이 실행되지 않던 문제를
+수정합니다. 문자값 대신 변하지 않는 물리 키 코드 `KeyG`도 매칭합니다.
+
+- 영문 `Alt+G` 정의에 `code: 'KeyG'` 추가
+- `©`/`KeyG` macOS 이벤트 회귀 테스트 추가
+- 기존 영문 `g`와 한글 `ㅎ` 매핑 유지
+
+## 검증
+
+- `node --test tests/shortcut-map.test.ts` — 6 passed
+- `./node_modules/.bin/tsc --noEmit`
+- `npm test` — 721 passed
+- headless Chromium에서 활성 편집기에 `key='©'`, `code='KeyG'`, `altKey=true` 이벤트를 주입해
+  기본 동작 취소와 찾아가기 대화상자 표시 확인
+- `git diff --check`
+
+Closes #3784

--- a/mydocs/report/task_m100_3784_report.md
+++ b/mydocs/report/task_m100_3784_report.md
@@ -1,0 +1,24 @@
+# task_m100_3784 처리결과 보고서 — macOS Option+G 찾아가기
+
+- **Issue**: [#3784](https://github.com/edwardkim/rhwp/issues/3784)
+- **브랜치**: `fix/3784-macos-option-g-goto`
+- **상태**: PR 준비 완료, 생성 승인 대기
+
+## 결과
+
+macOS 영문 입력의 `Option+G`가 `©` 문자값으로 전달되더라도, 변하지 않는 물리 키 코드 `KeyG`로
+`edit:goto`를 찾도록 보정했다. 한글 입력의 `Alt+ㅎ`와 일반 `Alt+G` 매핑은 유지된다.
+
+## 검증
+
+- shortcut-map 회귀 테스트 6건 통과
+- Studio 전체 단위 테스트 721건 통과
+- TypeScript `--noEmit` 통과
+- headless Chromium에서 실제 활성 편집 입력기로 `©`/`KeyG` 이벤트를 전달해 찾아가기 대화상자와
+  기본 동작 취소를 확인
+- `git diff --check` 통과
+
+## PR 준비 상태
+
+PR 제목과 본문 초안은 `mydocs/pr_body_draft_3784.md`에 준비했다. 이슈와 구현·검증 기록은 같은
+커밋으로 고정하며, 원격 push와 PR 생성은 별도 승인 뒤 수행한다.

--- a/mydocs/working/task_m100_3784_stage1.md
+++ b/mydocs/working/task_m100_3784_stage1.md
@@ -1,0 +1,47 @@
+# task_m100_3784 Stage 1 결과 — macOS Option+G 찾아가기
+
+- **Issue**: [#3784](https://github.com/edwardkim/rhwp/issues/3784)
+- **브랜치**: `fix/3784-macos-option-g-goto`
+- **기준**: `upstream/devel` `cc3829116`
+- **기록 시각**: 2026-08-02 KST
+- **상태**: 구현·focused 검증 완료, PR 생성 승인 대기
+
+## 1. 기준선과 원인
+
+macOS 영문 입력에서 `Option+G`는 `KeyboardEvent.key = '©'`와
+`KeyboardEvent.code = 'KeyG'`로 전달된다. 기존 `edit:goto` 매핑은 문자 값 `g`만 검사해
+찾아가기를 열지 못했다. 한글 입력의 `ㅎ` 경로는 별도 문자 매핑으로 동작했다.
+
+`matchShortcut()`은 modifier 검증 후 `key`와 `code`를 모두 비교할 수 있었고, 이미
+`Option+C`와 장평·자간 단축키가 물리 키 보정을 사용한다. 따라서 입력 처리 순서나 IME 경계를
+바꾸지 않고 찾아가기 정의에만 `code: 'KeyG'`를 추가했다.
+
+## 2. 구현
+
+- `rhwp-studio/src/command/shortcut-map.ts`
+  - 영문 `Alt+G` 정의를 `key: 'g', code: 'KeyG'`로 보정했다.
+  - 한글 `Alt+ㅎ` 정의는 그대로 유지했다.
+- `rhwp-studio/tests/shortcut-map.test.ts`
+  - macOS 영문 `key: '©', code: 'KeyG', altKey: true`를 `edit:goto`로 고정했다.
+  - 기존 영문 `g`, 한글 `ㅎ` 및 다른 물리 키 `KeyH`의 비매칭도 함께 확인했다.
+
+## 3. 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| `node --test tests/shortcut-map.test.ts` | 6 passed |
+| `./node_modules/.bin/tsc --noEmit` | 통과 |
+| `npm test` | 721 passed / 0 failed |
+| headless Chromium 실제 이벤트 경로 | 통과 |
+| `git diff --check` | 통과 |
+
+브라우저 검증에서는 문서를 만든 뒤 편집 영역을 클릭해 입력기를 활성화하고, 활성 입력기에
+`key: '©'`, `code: 'KeyG'`, `altKey: true`인 취소 가능한 `keydown` 이벤트를 전달했다.
+이벤트는 `preventDefault()` 되었고 찾아가기 대화상자의 제목이 `찾아가기`로 표시됐다.
+
+## 4. 비범위와 다음 단계
+
+- 다른 macOS `Option` 조합의 문자값 보정은 다루지 않았다.
+- 실제 macOS 하드웨어의 키보드 레이아웃 검증은 별도 사용자 확인 대상이다. 본 단계는 브라우저가
+  전달하는 해당 이벤트 계약과 rhwp-studio의 실제 입력 처리 경로를 검증했다.
+- 코드·테스트·문서 커밋 후 PR 제목과 본문을 준비하고, PR 생성은 작업지시자 승인 뒤 수행한다.

--- a/rhwp-studio/src/command/shortcut-map.ts
+++ b/rhwp-studio/src/command/shortcut-map.ts
@@ -66,7 +66,8 @@ export const defaultShortcuts: [ShortcutDef, string][] = [
   [{ key: 'l', ctrl: true }, 'edit:find-again'],
   [{ key: 'v', alt: true, shift: true }, 'edit:compare-documents'],
   [{ key: 'h', ctrl: true, shift: true }, 'edit:document-history'],
-  [{ key: 'g', alt: true }, 'edit:goto'],
+  // macOS 영문 입력에서 Option+G의 key는 ©가 되지만 물리 키는 KeyG로 유지된다.
+  [{ key: 'g', code: 'KeyG', alt: true }, 'edit:goto'],
   [{ key: 'ㅎ', alt: true }, 'edit:goto'],
 
   // 입력

--- a/rhwp-studio/tests/shortcut-map.test.ts
+++ b/rhwp-studio/tests/shortcut-map.test.ts
@@ -42,6 +42,13 @@ test('IME pending 상태처럼 key가 Process여도 code로 장평/자간 단축
   assert.equal(command({ key: 'Process', code: 'KeyW', altKey: true, shiftKey: true }), 'format:char-spacing-increase');
 });
 
+test('macOS 영문 입력 Option+G의 © 문자 값도 물리 KeyG로 찾아가기를 실행한다', () => {
+  assert.equal(command({ key: 'g', code: 'KeyG', altKey: true }, 'mac'), 'edit:goto');
+  assert.equal(command({ key: '©', code: 'KeyG', altKey: true }, 'mac'), 'edit:goto');
+  assert.equal(command({ key: 'ㅎ', code: 'KeyG', altKey: true }, 'mac'), 'edit:goto');
+  assert.equal(command({ key: '©', code: 'KeyH', altKey: true }, 'mac'), null);
+});
+
 test('표 줄/칸 추가·지우기 단축키는 대화상자 명령으로 매핑한다', () => {
   assert.equal(command({ key: 'Enter', altKey: true }, 'mac'), 'table:insert-row-col');
   assert.equal(command({ key: 'enter', altKey: true }, 'mac'), 'table:insert-row-col');


### PR DESCRIPTION
# fix(rhwp-studio): macOS 영문 Option+G 찾아가기 보정 (#3784)

## 요약

macOS 영문 입력에서 `Option+G`가 문자값 `©`로 전달되어 찾아가기 명령이 실행되지 않던 문제를
수정합니다. 문자값 대신 변하지 않는 물리 키 코드 `KeyG`도 매칭합니다.

- 영문 `Alt+G` 정의에 `code: 'KeyG'` 추가
- `©`/`KeyG` macOS 이벤트 회귀 테스트 추가
- 기존 영문 `g`와 한글 `ㅎ` 매핑 유지

## 검증

- `node --test tests/shortcut-map.test.ts` — 6 passed
- `./node_modules/.bin/tsc --noEmit`
- `npm test` — 721 passed
- headless Chromium에서 활성 편집기에 `key='©'`, `code='KeyG'`, `altKey=true` 이벤트를 주입해
  기본 동작 취소와 찾아가기 대화상자 표시 확인
- `git diff --check`

Closes #3784
