### PR TITLE
[#3630 P3] 세션 편집 봉투에 changedPages — 어느 쪽을 다시 볼지 (#3712 세션 축 확장)

### DIFF
--- a/mydocs/manual/agent_knowledge_map.md
+++ b/mydocs/manual/agent_knowledge_map.md
@@ -146,6 +146,7 @@ exit 3 ↔ `isError:false` + `identical:false`. 상세는
 | `mcp_server_contract.rs` | `mcp-serve` 핸드셰이크·선언-서버 드리프트 가드·isError (#3140) |
 | `mcp_session_query_contract.rs` | 세션 조회·치환(hwp_doc_search·hwp_doc_replace_text) (#3601) |
 | `mcp_session_edit_contract.rs` | 세션 채움·형식 보존 저장(hwp_doc_fill_fields·hwp_doc_save) (#3598) |
+| `mcp_session_changed_pages_contract.rs` | 세션 편집 3종 `changedPages` — 무상태 판 동형·재조판 후 렌더 가능 (#3719 §6-1) |
 | `issue_3366_thumbnail_contract.rs` | `thumbnail` 종료 코드·파싱 계약 (#3366) |
 | `issue_3372_gian_form_contract.rs` | 일반기안문 표준 서식 자산의 유효성 (#3372) |
 | `render_p22_web_canvas_contract.rs` | 웹 캔버스 레이어 재생이 render node 를 재구축하지 않는 계약 |

--- a/mydocs/report/task_m100_session_changed_pages/README.md
+++ b/mydocs/report/task_m100_session_changed_pages/README.md
@@ -1,0 +1,127 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_session_changed_pages/README.md
+last_verified: 2026-08-02
+---
+
+# 세션 편집 도구의 changedPages — 눈검증 루프를 세션 안에서 닫는다 (#3719 §6-1)
+
+## 문제
+
+무상태 편집 3종(`edit fill-fields`/`replace-text`/`set-cell`)은 #3712 이후 봉투에
+`changedPages` 를 담아 "어느 쪽을 보라"를 지정한다. **세션 편집 3종은 못 냈다.**
+
+세션 쪽이 더 아픈 자리다. `hwp_doc_render_page` 의 도구 설명이 약속하는 문장이
+정확히 "편집 직후 눈검증(VLM) 루프가 세션 안에서 닫힌다" 인데, 렌더할 쪽을 지정하는
+표면이 없으니 에이전트에게 남는 선택지는 둘뿐이었다.
+
+- 전 페이지 렌더 — 편집 한 번마다 문서 크기에 비례하는 비용.
+- 검증 생략 — #3630 실패 유형 3(시각 확인 불가)이 그대로 통과.
+
+#3712 처리 기록도 이 공백을 "**#3704(세션 재조판) 머지 후 후속 적층**" 으로 남겨
+두었다. #3704 가 머지되어 세션 편집 3종이 같은 재조판 규약을 공유하게 됐으므로,
+이제 그 규약 위에 쪽 지정만 얹으면 된다.
+
+## 구현
+
+새 계산은 없다. 무상태 판이 쓰는 코어 질의
+[`DocumentCore::pages_covering_paragraphs`](../../../src/document_core/queries/changed_pages.rs)
+를 그대로 재사용하고, **변경 문단을 무엇으로 잡느냐**도 무상태 판과 같은 출처를 쓴다.
+
+| 세션 도구 | 변경 문단 근거 | 무상태 대응 |
+|---|---|---|
+| `hwp_doc_fill_fields` | `collect_all_fields()` 순회에서 모은 `FieldLocation`(section·para) | `edit fill-fields` 와 동일 |
+| `hwp_doc_replace_text` | **치환 전** grep 매치 주소 — 문자열 치환은 문단을 새로 만들지 않아 인덱스를 밀지 않는다 | `edit replace-text` 와 동일 |
+| `hwp_doc_set_cell` | `resolve_table_cell` 이 돌려준 표 호스트 문단 | `edit set-cell` 과 동일 |
+
+두 경로가 같은 근거·같은 질의를 쓰므로 **답이 갈라질 수 없다**. 계약 테스트도 값을
+직접 적어 두지 않고 두 봉투를 맞대어 본다(§검증).
+
+### 호출 시점이 계약의 절반이다
+
+세션은 편집 뒤에도 같은 인스턴스가 살아 있다. **재조판 전에 쪽을 계산하면 편집 전
+레이아웃을 보고한다** — #3704 가 조회 4종에서 고친 스테일과 같은 함정이다. 편집이
+쪽을 늘린 경우 그 값은 단순히 부정확한 정도가 아니라 "존재하지 않는 쪽" 이거나
+"방금 만들어 낸 쪽을 빠뜨린" 목록이 된다.
+
+`pages_covering_paragraphs` 는 진입에서 `paginate_if_needed()` 를 부르므로, 편집 →
+질의 순서만 지키면 시점 규약이 저절로 지켜진다. 세 도구 모두 기존
+`repaginate_if_needed()` 지점(fill/replace) 또는 셀 편집 코어의 재조판(set_cell)
+**뒤에** 질의를 둔다. 이미 조판이 맞은 두 번째 호출은 dirty 구역이 없어
+`paginate_pass` 가 전 구역을 `continue` 로 건너뛴다 — 사실상 무비용이다.
+
+### null·빈 목록 규약
+
+- 대상 문단이 **하나라도** 조판 커버리지 밖이면 전체 `null`. 부분 목록 금지 —
+  빠뜨린 쪽이 거짓 통과를 만든다(#3630 P3, 원칙 5).
+- **변경이 없으면 빈 목록**이지 `null` 이 아니다. `null` 은 "확정 불가, 전체를 보라"
+  라서, 치환 0건·notFound 뿐인 호출마다 전수 렌더를 유도하게 된다. 무상태
+  `replace-text` 가 0건에서 `null` 을 내는 것은 **산출 파일이 없다**는 별개 사유이고
+  (`wrote_output` 분기), 세션에는 그 사유가 없다. 무상태 `fill-fields` 는 채운 것이
+  없을 때 이미 `[]` 를 낸다 — 세션 3종은 이 축을 하나로 통일한다.
+
+### 자기서술
+
+세션 도구는 `capabilities --mcp` 의 `tools[]` 에 실리지 않는다(그 목록은 무상태
+도구 전용이고, 세션 도구는 `mcp_serve::served_tools()` 가 이름·설명·inputSchema 만
+내보낸다 — `outputFields` 축이 아예 없다). 그래서 **세션 도구가 산출을 자기서술하는
+유일한 채널인 `description`** 에 `changedPages` 규약을 적었다. 없는 필드를 세션
+도구에만 새로 만들면 `tools/list` 가 무상태 도구와 다른 모양이 되어
+`tools_list_matches_capabilities_manifest` 가 지키는 단일 출처가 흐려진다.
+
+## 실측 (evidence.txt 원문)
+
+| # | 확인 | 결과 |
+|---|---|---|
+| 1 | 세션 fill (`회사명`, field-01.hwp 3쪽) | `changedPages:[0]` |
+| 2 | 세션 replace (`마케팅`→`기획`) | `changedPages:[0]` |
+| 3 | 무변경 2종 (치환 0건 · notFound) | `changedPages:[]` |
+| 4 | 무상태 `edit fill-fields`/`replace-text` 대조 | 둘 다 `[0]` — **동형** |
+| 5 | 세션 set_cell vs 무상태 set-cell (table-001.hwp) | 둘 다 `[0]` — **동형** |
+| 6 | 재조판 시점: `회사명`에 5,000자 | 3쪽 → **11쪽**, `changedPages:[0..8]` |
+| 6' | ⑥ 의 8쪽을 곧바로 `hwp_doc_render_page` | `isError:false`, SVG **182,206 bytes** |
+
+⑥ 이 이 작업의 핵심 실측이다. 편집 전 문서는 3쪽이라 3~8쪽은 **존재하지 않았다** —
+재조판 전에 계산했다면 낼 수 없는 값이고, 그 쪽들이 그 자리에서 렌더된다는 것이
+"눈검증 루프가 세션 안에서 닫힌다"의 실물 증거다.
+
+필드 이름·표 좌표·치환어는 전부 `rhwp fields --json` / `export-tables --json` 으로
+문서에서 읽어 썼다(계약 테스트도 같은 방식 — 하드코딩하면 샘플이 바뀔 때 시험이
+조용히 껍데기가 된다).
+
+## 검증
+
+- 신규 [`tests/mcp_session_changed_pages_contract.rs`](../../../tests/mcp_session_changed_pages_contract.rs) 6건:
+  - fill·replace·set_cell 각각 **무상태 봉투와 changedPages 가 같은지** (값을 적지 않고 맞대어 본다)
+  - 지정한 쪽이 **그 자리에서 렌더되는지** — 쪽을 늘리는 채움으로 재조판 시점을 함께 고정하고,
+    "이 채움이 쪽을 늘린다"를 별도 assert 로 둬서 샘플이 바뀌어 전제가 깨지면
+    **시험이 무의미해진 사실 자체가 실패로 드러난다**
+  - 무변경 2종이 `[]` 인지 / 세 도구 설명이 `changedPages` 를 광고하는지(선언↔봉투 드리프트 가드)
+
+| 게이트 | 결과 |
+|---|---|
+| `cargo build --release --bin rhwp` | 성공 (rhwp v0.8.2) |
+| 신규 `mcp_session_changed_pages_contract` | **6/6** |
+| 세션 무회귀 `mcp_session_edit`(7) · `query`(6) · `setcell`(6) · `view`(5) | 24/24 |
+| 드리프트 가드 `mcp_server_contract`(22, `tools_list_matches_capabilities_manifest`·`every_declared_input_property_is_wired_to_the_cli` 포함) · `mcp_arg_validation_contract`(9) · `agent_profile_router_contract`(7) | 38/38 |
+| 무상태 축 무회귀 `cli_json_contract`(26) · `changed_pages_contract`(5, #3712) | 31/31 |
+| **합계** | **99 passed / 0 failed** |
+| `cargo clippy --release -- -D warnings` | 경고 0 |
+| `cargo clippy --release --test mcp_session_changed_pages_contract -- -D warnings` | 경고 0 |
+| fmt (변경 파일 2개) | clean |
+
+fmt 은 이 PC 에서 `cargo fmt --all` 이 `os error 206` 으로 죽으므로 변경 파일만
+`rustfmt --edition 2021 --config-path rustfmt.toml --config newline_style=Auto --check`
+로 돌렸다.
+
+## 남은 것
+
+- **`null` 강등은 이 저장소 코퍼스에서 한 번도 재현되지 않았다.** 샘플 348개에
+  `search` 를 돌려 조판 쪽이 붙지 않은 매치를 찾았고(0건), 누름틀이 있는 샘플 30개에
+  `fill-fields` 를 돌려 `changedPages:null` 을 찾았다(0건). 경로는 구조적으로 살아
+  있다 — `pages_covering_paragraphs` 는 대상 문단이 `PageItem` 어디에도 없으면 `None`
+  을 낸다 — 지만 실측 근거는 아직 없다. 실물이 나오면 그 문서를 픽스처로 고정하는
+  것이 다음 단계다.
+- 세션 편집 도구가 늘어나면 "편집 → 재조판 → `changed_pages_value`" 순서를
+  체크리스트에 넣어야 한다(#3704 가 남긴 규약에 한 줄 추가).

--- a/mydocs/report/task_m100_session_changed_pages/evidence.txt
+++ b/mydocs/report/task_m100_session_changed_pages/evidence.txt
@@ -1,0 +1,26 @@
+# 1) 세션 hwp_doc_fill_fields — changedPages 지정 (라이브, samples/field-01.hwp 3쪽)
+#    필드 이름은 `rhwp fields samples/field-01.hwp --json` 으로 확인 (fieldCount=11, 첫 이름 회사명)
+{"ambiguous":[],"changedPages":[0],"confusable":[],"docId":"doc-1","filled":[{"name":"회사명","occurrence":0,"value":"세션쪽지정사"}],"filledCount":1,"notFound":[],"schemaVersion":"1.0"}
+
+# 2) 세션 hwp_doc_replace_text — 치환 전 매치 주소가 근거
+{"caseSensitive":true,"changedPages":[0],"docId":"doc-1","find":"마케팅","replace":"기획","replacedCount":1,"schemaVersion":"1.0"}
+
+# 3) 무변경은 빈 목록 — null("전체를 보라")로 내리지 않는다
+{"caseSensitive":true,"changedPages":[],"docId":"doc-1","find":"존재하지않는문자열QZX","replace":"y","replacedCount":0,"schemaVersion":"1.0"}
+{"ambiguous":[],"changedPages":[],"confusable":[],"docId":"doc-1","filled":[],"filledCount":0,"notFound":["없는누름틀"],"schemaVersion":"1.0"}
+
+# 4) 무상태 대조 — 같은 문서·같은 편집의 edit --json 봉투 (동형 확인)
+{"ambiguous":[],"changedPages":[0],"confusable":[],"dryRun":false,"filled":[{"name":"회사명","occurrence":0,"value":"세션쪽지정사"}],"filledCount":1,"notFound":[],"output":"C:\\Users\\swsz9\\AppData\\Local\\Temp\\ev-fill.hwp","outputFormat":"hwp5","schemaVersion":"1.0","source":"samples/field-01.hwp","verify":null}
+{"caseSensitive":true,"changedPages":[0],"dryRun":false,"find":"마케팅","occurrence":null,"output":"C:\\Users\\swsz9\\AppData\\Local\\Temp\\ev-repl.hwp","outputFormat":"hwp5","replace":"기획","replacedCount":1,"schemaVersion":"1.0","source":"samples/field-01.hwp","verify":null}
+
+# 5) 세션 hwp_doc_set_cell vs 무상태 edit set-cell (samples/table-001.hwp 1쪽)
+#    좌표는 `rhwp export-tables samples/table-001.hwp --json` 의 첫 본문 최상위 표 첫 칸
+{"changedPages":[0],"col":0,"docId":"doc-1","keepStyle":false,"newText":"세션셀","oldText":"구 분","overflow":[],"row":0,"schemaVersion":"1.0","table":0}
+{"changedPages":[0],"col":0,"dryRun":false,"keepStyle":false,"newText":"세션셀","oldText":"구 분","output":"C:\\Users\\swsz9\\AppData\\Local\\Temp\\ev-cell.hwp","outputFormat":"hwp5","overflow":[],"row":0,"schemaVersion":"1.0","source":"samples/table-001.hwp","table":0,"verify":null}
+
+# 6) 재조판 시점 — 회사명에 5,000자를 채워 쪽을 늘린다 (편집 전 3쪽 → 편집 후 11쪽)
+#    changedPages 의 3~8쪽은 **편집 전에는 존재하지 않던 쪽**이다 —
+#    재조판 전에 계산했다면 낼 수 없는 값이고, 그 자리에서 렌더도 된다.
+{"pageCount(before)": 3, "changedPages": [0, 1, 2, 3, 4, 5, 6, 7, 8], "pageCount(after)": 11}
+{"bytes":182206,"docId":"doc-1","format":"svg","output":"C:\\Users\\swsz9\\AppData\\Local\\Temp\\ev-page8.svg","page":8,"schemaVersion":"1.0"}
+

--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -475,7 +475,7 @@ fn served_tools(
     }));
     session.push(serde_json::json!({
         "name": "hwp_doc_replace_text",
-        "description": "[#3601] 핸들의 IR 에 문자열 일괄 치환을 누적한다(디스크 미기록 — hwp_doc_save 가 기록 지점). replacedCount 0 은 오류가 아니라 계수 보고다. hwp_doc_fill_fields 와 조합해 '채우고 다듬고 한 번에 저장'하는 흐름을 만든다.",
+        "description": "[#3601] 핸들의 IR 에 문자열 일괄 치환을 누적한다(디스크 미기록 — hwp_doc_save 가 기록 지점). replacedCount 0 은 오류가 아니라 계수 보고다. hwp_doc_fill_fields 와 조합해 '채우고 다듬고 한 번에 저장'하는 흐름을 만든다. [#3719] 봉투의 changedPages:[n,…]|null 은 재조판 후 0 기준 쪽 번호 — 그 쪽만 hwp_doc_render_page 로 렌더하면 눈검증이 끝난다(null 이면 확정 불가이니 전체를 보라).",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -489,7 +489,7 @@ fn served_tools(
     }));
     session.push(serde_json::json!({
         "name": "hwp_doc_set_cell",
-        "description": "[#3603] 핸들의 표 격자 좌표(hwp_doc_tables 와 동일)에 값을 기록한다 — 디스크 미기록, hwp_doc_save 가 기록 지점. 병합으로 덮인 칸은 앵커 좌표를 안내하며 실패하고, 칸 넘침은 overflow 로 보고한다(무상태 hwp_set_cell 과 동형).",
+        "description": "[#3603] 핸들의 표 격자 좌표(hwp_doc_tables 와 동일)에 값을 기록한다 — 디스크 미기록, hwp_doc_save 가 기록 지점. 병합으로 덮인 칸은 앵커 좌표를 안내하며 실패하고, 칸 넘침은 overflow 로 보고한다(무상태 hwp_set_cell 과 동형). [#3719] 봉투의 changedPages:[n,…]|null 은 재조판 후 0 기준 쪽 번호로, 분할된 표는 걸친 쪽을 전부 담는다 — 그 쪽만 hwp_doc_render_page 로 렌더하면 눈검증이 끝난다.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -505,7 +505,7 @@ fn served_tools(
     }));
     session.push(serde_json::json!({
         "name": "hwp_doc_fill_fields",
-        "description": "[#3598] hwp_open 으로 연 핸들의 IR 에 누름틀 값을 직접 채운다(디스크 미기록 — hwp_doc_save 가 유일한 기록 지점). 여러 번 호출하면 누적된다. 판정 필드(filledCount/notFound/ambiguous)는 hwp_fill_fields 와 동형이고, 반복 필드는 '이름[N]' 으로 지목한다.",
+        "description": "[#3598] hwp_open 으로 연 핸들의 IR 에 누름틀 값을 직접 채운다(디스크 미기록 — hwp_doc_save 가 유일한 기록 지점). 여러 번 호출하면 누적된다. 판정 필드(filledCount/notFound/ambiguous)는 hwp_fill_fields 와 동형이고, 반복 필드는 '이름[N]' 으로 지목한다. [#3719] 봉투의 changedPages:[n,…]|null 은 재조판 후 0 기준 쪽 번호 — 그 쪽만 hwp_doc_render_page 로 렌더하면 눈검증 루프가 세션 안에서 상수 비용으로 닫힌다(null 이면 확정 불가이니 전체를 보라).",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -966,6 +966,23 @@ fn session_search(args: &serde_json::Value, sessions: &mut Sessions) -> serde_js
     )
 }
 
+/// [#3719 §6-1] 세션 편집 봉투의 `changedPages` — 무상태 판(#3712)과 **같은** 코어
+/// 질의(`DocumentCore::pages_covering_paragraphs`)를 재사용한다. 새 계산은 없다.
+///
+/// 호출 시점이 계약의 절반이다. 세션은 편집 후에도 같은 인스턴스가 살아 있어서
+/// **재조판 전에 쪽을 계산하면 편집 전 레이아웃을 보고한다**(#3704 가 조회 4종에서
+/// 고친 바로 그 스테일). 질의가 진입에서 `paginate_if_needed()` 를 부르므로 편집 →
+/// 질의 순서만 지키면 되고, 이미 조판이 맞았다면 dirty 구역이 없어 사실상 무비용이다.
+///
+/// 대상 문단이 하나라도 조판 커버리지 밖이면 부분 목록 대신 `null` — 빠뜨린 쪽이
+/// 거짓 통과를 만들기 때문이다(#3630 P3, 원칙 5).
+fn changed_pages_value(doc: &mut HwpDocument, targets: &[(usize, usize)]) -> serde_json::Value {
+    match doc.pages_covering_paragraphs(targets) {
+        Some(pages) => serde_json::json!(pages),
+        None => serde_json::Value::Null,
+    }
+}
+
 /// [#3601] 핸들의 IR 에 문자열 일괄 치환을 누적한다 — 디스크 미기록, save 가 기록 지점.
 /// 무상태 `edit replace-text` 와 같은 코어 경로(`replace_all_native`)를 재사용한다.
 fn session_replace_text(args: &serde_json::Value, sessions: &mut Sessions) -> serde_json::Value {
@@ -996,6 +1013,15 @@ fn session_replace_text(args: &serde_json::Value, sessions: &mut Sessions) -> se
             "핸들이 없거나 만료 — hwp_open 으로 docId 를 재발급한 뒤 재시도",
         );
     };
+    // [#3719 §6-1] 치환 **전** 매치 주소를 붙잡는다 — 문자열 치환은 문단을 새로 만들지
+    // 않아 인덱스를 밀지 않으므로, 이 주소가 치환 후에도 그대로 유효하다. 무상태
+    // `edit replace-text`(#3712)가 쓰는 근거와 같은 것이라 두 봉투가 같은 쪽을 답한다.
+    let changed_paras: Vec<(usize, usize)> = sd
+        .doc
+        .grep(find, case_sensitive, None)
+        .iter()
+        .map(|m| (m.section, m.paragraph))
+        .collect();
     let result = match sd.doc.replace_all_native(find, replace, case_sensitive) {
         Ok(r) => r,
         Err(e) => return tool_error(format!("치환 실패: {e}")),
@@ -1012,6 +1038,14 @@ fn session_replace_text(args: &serde_json::Value, sessions: &mut Sessions) -> se
     if count > 0 {
         sd.doc.repaginate_if_needed();
     }
+    // [#3719 §6-1] 눈검증 대상 쪽 — 위 재조판 **뒤**라야 편집 후 레이아웃을 보고한다.
+    // 0건 치환은 IR 이 그대로다: 볼 쪽이 없으니 빈 목록이 정확하다("전체를 보라"는
+    // null 로 내리면 무변경 호출마다 전수 렌더를 유도하게 된다).
+    let changed_pages = if count > 0 {
+        changed_pages_value(&mut sd.doc, &changed_paras)
+    } else {
+        serde_json::json!([])
+    };
     tool_ok_text(
         serde_json::json!({
             "schemaVersion": "1.0",
@@ -1019,6 +1053,7 @@ fn session_replace_text(args: &serde_json::Value, sessions: &mut Sessions) -> se
             "find": find,
             "replace": replace,
             "caseSensitive": case_sensitive,
+            "changedPages": changed_pages,
             "replacedCount": count,
         })
         .to_string(),
@@ -1136,6 +1171,10 @@ fn session_set_cell(args: &serde_json::Value, sessions: &mut Sessions) -> serde_
             // 경고 수준 — 봉투에 남기지 않고 진행 (CLI 와 동일한 관용).
         }
     }
+    // [#3719 §6-1] 눈검증 대상 쪽 — 표 호스트 문단이 걸친 쪽 **전부**(분할 표 포함).
+    // 근거 주소는 무상태 `edit set-cell`(#3712)과 같은 `resolve_table_cell` 의 호스트
+    // 문단이다. 셀 편집 코어가 이미 재조판했으므로 이 질의는 편집 후 조판을 본다.
+    let changed_pages = changed_pages_value(&mut sd.doc, &[(sec, para)]);
     tool_ok_text(
         serde_json::json!({
             "schemaVersion": "1.0",
@@ -1143,6 +1182,7 @@ fn session_set_cell(args: &serde_json::Value, sessions: &mut Sessions) -> serde_
             "table": table_no, "row": row, "col": col,
             "oldText": old_text,
             "newText": new_text,
+            "changedPages": changed_pages,
             // CLI 봉투와 같은 키 — 검정 정규화를 건너뛰었는지는 제출 서식에서 결과가
             // 달라지는 판단 재료라, 무엇이 적용됐는지 봉투만 보고 알 수 있어야 한다.
             "keepStyle": keep_style,
@@ -1175,11 +1215,19 @@ fn session_fill_fields(args: &serde_json::Value, sessions: &mut Sessions) -> ser
     let doc = &mut sd.doc;
 
     let mut name_counts: HashMap<String, usize> = HashMap::new();
+    // [#3719 §6-1] 같은 순회에서 문단 주소도 담는다 — changedPages 산출 근거를 무상태
+    // `edit fill-fields`(#3712)와 같은 출처(FieldLocation)로 맞춘다.
+    let mut name_locs: HashMap<String, Vec<(usize, usize)>> = HashMap::new();
     for fi in doc.collect_all_fields().iter() {
         if let Some(n) = fi.field.field_name() {
             *name_counts.entry(n.to_string()).or_insert(0) += 1;
+            name_locs
+                .entry(n.to_string())
+                .or_default()
+                .push((fi.location.section_index, fi.location.para_index));
         }
     }
+    let mut changed_paras: Vec<(usize, usize)> = Vec::new();
 
     let mut filled: Vec<serde_json::Value> = Vec::new();
     let mut not_found: Vec<String> = Vec::new();
@@ -1233,6 +1281,9 @@ fn session_fill_fields(args: &serde_json::Value, sessions: &mut Sessions) -> ser
                  hwp_close 후 다시 여는 것을 권장합니다"
             ));
         }
+        if let Some(loc) = name_locs.get(name).and_then(|l| l.get(*occurrence)) {
+            changed_paras.push(*loc);
+        }
         filled.push(serde_json::json!({
             "name": name, "occurrence": occurrence, "value": value_str,
         }));
@@ -1245,11 +1296,16 @@ fn session_fill_fields(args: &serde_json::Value, sessions: &mut Sessions) -> ser
     if !apply.is_empty() {
         doc.repaginate_if_needed();
     }
+    // [#3719 §6-1] 눈검증 대상 쪽 — 위 재조판 **뒤**라야 편집 후 레이아웃을 보고한다.
+    // 채운 것이 없으면 빈 목록(볼 쪽 없음)이고, 채웠는데 문단→쪽 매핑을 확정할 수
+    // 없으면 null 이다.
+    let changed_pages = changed_pages_value(doc, &changed_paras);
 
     tool_ok_text(
         serde_json::json!({
             "schemaVersion": "1.0",
             "docId": doc_id,
+            "changedPages": changed_pages,
             "filledCount": filled.len(),
             "filled": filled,
             "notFound": not_found,

--- a/tests/mcp_session_changed_pages_contract.rs
+++ b/tests/mcp_session_changed_pages_contract.rs
@@ -1,0 +1,492 @@
+//! [#3719 §6-1] 세션 편집 도구의 `changedPages` — 눈검증 루프를 세션에서도 닫는다.
+//!
+//! 무상태 편집 3종은 이미 "어느 쪽을 보라"를 봉투로 지정하지만(#3712), 세션 편집
+//! 3종은 못 냈다. 그래서 `hwp_doc_render_page` 가 약속한 "편집 직후 눈검증(VLM)
+//! 루프"가 세션 안에서는 **어느 쪽을 렌더할지 모른 채** 남아 있었다 — 에이전트는
+//! 전수 렌더(예산 폭발)나 무검증(거짓 통과) 중 하나를 고르게 된다(#3630 F3).
+//!
+//! 계약의 핵심 셋:
+//! ① 세션 봉투의 `changedPages` 가 **무상태 봉투와 같은 쪽**을 답한다 — 추적 근거가
+//!    같은 코어(FieldLocation · 치환 전 grep 주소 · resolve_table_cell 호스트 문단)이고
+//!    같은 질의(`pages_covering_paragraphs`)를 쓰므로 두 경로가 갈라질 수 없다.
+//! ② 지정된 쪽은 **그 자리에서 렌더된다** — 재조판 전에 계산했다면 편집 전 레이아웃의
+//!    쪽 번호가 나와 "범위 초과"로 거부되거나 엉뚱한 쪽을 렌더한다(#3704 가 조회
+//!    4종에서 고친 스테일과 같은 함정).
+//! ③ 변경이 없으면 빈 목록이지 `null` 이 아니다 — `null` 은 "확정 불가, 전체를 보라"라
+//!    무변경 호출마다 전수 렌더를 유도하게 된다. 부분 목록은 어느 경우에도 금지.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+/// 누름틀을 가진 HWP5 서식 — fill/replace 축.
+const FIELD_SAMPLE: &str = "samples/field-01.hwp";
+/// 본문 최상위 표를 가진 HWP5 — set_cell 축.
+const TABLE_SAMPLE: &str = "samples/table-001.hwp";
+
+fn sample(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn temp_path(tag: &str, ext: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "rhwp-sesschpages-{tag}-{}-{}.{ext}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ))
+}
+
+fn run_cli(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn cli_json(args: &[&str]) -> serde_json::Value {
+    let out = run_cli(args);
+    assert_eq!(out.status.code(), Some(0), "{args:?} 실패");
+    serde_json::from_slice(&out.stdout).expect("CLI 봉투가 JSON 이 아닙니다")
+}
+
+/// 필드 이름을 **문서에서 읽어** 쓴다 — 하드코딩하면 샘플이 바뀔 때 시험이 조용히
+/// notFound 만 확인하는 껍데기가 된다.
+fn first_field_name(path: &str) -> Option<String> {
+    let v = cli_json(&["fields", path, "--json"]);
+    v["fields"]
+        .as_array()?
+        .iter()
+        .find_map(|f| f["name"].as_str().map(str::to_string))
+        .filter(|n| !n.is_empty())
+}
+
+/// 치환 대상도 문서에서 고른다. 하이픈으로 시작하는 토큰이 argv 에서 flag 로
+/// 오해되지 않도록 영숫자·한글 토큰만 받는다.
+fn first_word(path: &str) -> Option<String> {
+    let v = cli_json(&["export-text", path, "--json"]);
+    for page in v["pages"].as_array()? {
+        for token in page["text"].as_str().unwrap_or("").split_whitespace() {
+            if token.chars().count() >= 2 && token.chars().all(char::is_alphanumeric) {
+                return Some(token.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// `{"<필드이름>": "<값>"}` — 이름이 실행 시점에 정해지므로 맵으로 만든다.
+fn field_data(name: &str, value: &str) -> serde_json::Value {
+    let mut map = serde_json::Map::new();
+    map.insert(
+        name.to_string(),
+        serde_json::Value::String(value.to_string()),
+    );
+    serde_json::Value::Object(map)
+}
+
+struct Server {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: i64,
+}
+
+impl Server {
+    fn started() -> Server {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+            .arg("mcp-serve")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            // 파서 진단이 파이프를 채우면 서버가 블록되어 결함과 무관한 행으로
+            // 오진하게 된다(측정 함정) — 읽을 일이 없으니 아예 버린다.
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("rhwp mcp-serve 실행 실패");
+        let stdin = child.stdin.take().expect("stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout"));
+        let mut s = Server {
+            child,
+            stdin,
+            stdout,
+            next_id: 1,
+        };
+        let r = s.request(
+            "initialize",
+            serde_json::json!({
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "session-changed-pages-test", "version": "0"}
+            }),
+        );
+        assert!(r["result"]["serverInfo"]["name"].is_string(), "{r}");
+        s
+    }
+
+    fn request(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        let msg =
+            serde_json::json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params});
+        writeln!(self.stdin, "{msg}").expect("요청 쓰기 실패");
+        self.stdin.flush().expect("flush");
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let n = self.stdout.read_line(&mut line).expect("응답 읽기 실패");
+            assert!(n > 0, "서버가 응답 없이 종료했습니다 (method={method})");
+            if line.trim().is_empty() {
+                continue;
+            }
+            let v: serde_json::Value = serde_json::from_str(line.trim())
+                .unwrap_or_else(|e| panic!("stdout 이 JSON-RPC 가 아닙니다 ({e}): {line}"));
+            if v.get("id").and_then(|i| i.as_i64()) == Some(id) {
+                return v;
+            }
+        }
+    }
+
+    fn call(&mut self, name: &str, args: serde_json::Value) -> (bool, serde_json::Value) {
+        let r = self.request(
+            "tools/call",
+            serde_json::json!({"name": name, "arguments": args}),
+        );
+        let result = &r["result"];
+        let is_error = result["isError"].as_bool().unwrap_or(false);
+        let text = result["content"][0]["text"]
+            .as_str()
+            .unwrap_or("")
+            .to_string();
+        let v = serde_json::from_str(&text).unwrap_or(serde_json::Value::String(text));
+        (is_error, v)
+    }
+
+    fn open(&mut self, path: &Path) -> String {
+        let (err, v) = self.call(
+            "hwp_open",
+            serde_json::json!({"path": path.to_str().unwrap()}),
+        );
+        assert!(!err, "hwp_open 실패: {v}");
+        v["docId"].as_str().expect("docId").to_string()
+    }
+
+    fn page_count(&mut self, doc_id: &str) -> u64 {
+        let (err, v) = self.call("hwp_doc_info", serde_json::json!({"docId": doc_id}));
+        assert!(!err, "hwp_doc_info 실패: {v}");
+        v["pageCount"].as_u64().expect("pageCount")
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// `changedPages` 는 배열이거나 null 이다 — 다른 타입이면 소비자가 못 읽는다.
+fn changed_pages(v: &serde_json::Value) -> Option<Vec<u64>> {
+    // 키 부재와 `null` 은 serde 인덱싱에서 똑같이 Null 로 보인다 — 소비자가 "필드가
+    // 없네, 이 버전은 지원 안 하나?" 로 오해하지 않도록 존재 자체를 먼저 못박는다.
+    assert!(
+        v.as_object()
+            .is_some_and(|o| o.contains_key("changedPages")),
+        "봉투에 changedPages 키가 없습니다: {v}"
+    );
+    let field = &v["changedPages"];
+    if field.is_null() {
+        return None;
+    }
+    Some(
+        field
+            .as_array()
+            .unwrap_or_else(|| panic!("changedPages 는 배열|null 이어야 합니다: {v}"))
+            .iter()
+            .map(|p| p.as_u64().unwrap_or_else(|| panic!("쪽 번호는 정수: {v}")))
+            .collect(),
+    )
+}
+
+/// ① fill — 세션 봉투가 무상태 봉투와 **같은 쪽**을 답한다.
+#[test]
+fn session_fill_changed_pages_matches_stateless() {
+    let src = sample(FIELD_SAMPLE);
+    if !src.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let path = src.to_str().unwrap();
+    let Some(name) = first_field_name(path) else {
+        eprintln!("누름틀 없는 샘플 — 건너뜀");
+        return;
+    };
+    let data = field_data(&name, "동형확인");
+
+    // 무상태 판 — 지상 진실.
+    let out = temp_path("fill", "hwp");
+    let stateless = cli_json(&[
+        "edit",
+        "fill-fields",
+        path,
+        "--data",
+        &data.to_string(),
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ]);
+    let _ = std::fs::remove_file(&out);
+    assert_eq!(stateless["filledCount"].as_u64(), Some(1), "{stateless}");
+
+    // 세션 판.
+    let mut s = Server::started();
+    let doc_id = s.open(&src);
+    let (err, session) = s.call(
+        "hwp_doc_fill_fields",
+        serde_json::json!({"docId": doc_id, "data": data}),
+    );
+    assert!(!err, "세션 채움 실패: {session}");
+    assert_eq!(session["filledCount"].as_u64(), Some(1), "{session}");
+
+    let sp = changed_pages(&stateless);
+    let ss = changed_pages(&session);
+    assert_eq!(
+        ss, sp,
+        "세션·무상태 changedPages 가 갈라졌습니다\n무상태={stateless}\n세션={session}"
+    );
+    let pages = ss.expect("채움이 있었으니 목록이 확정된다");
+    assert!(
+        !pages.is_empty(),
+        "변경이 있었으니 비어 있지 않다: {session}"
+    );
+    let total = s.page_count(&doc_id);
+    for p in &pages {
+        assert!(*p < total, "0 기준·범위 내: {p} < {total}: {session}");
+    }
+}
+
+/// ② replace — 치환 **전** 매치 주소가 근거이므로 무상태 판과 같은 쪽이 나온다.
+#[test]
+fn session_replace_changed_pages_matches_stateless() {
+    let src = sample(FIELD_SAMPLE);
+    if !src.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let path = src.to_str().unwrap();
+    let Some(find) = first_word(path) else {
+        eprintln!("치환할 토큰 없음 — 건너뜀");
+        return;
+    };
+    let replace = format!("{find}※");
+
+    let out = temp_path("repl", "hwp");
+    let stateless = cli_json(&[
+        "edit",
+        "replace-text",
+        path,
+        "--find",
+        &find,
+        "--replace",
+        &replace,
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ]);
+    let _ = std::fs::remove_file(&out);
+    let replaced = stateless["replacedCount"].as_u64().unwrap_or(0);
+    assert!(replaced > 0, "전제: 토큰이 실제로 치환된다: {stateless}");
+
+    let mut s = Server::started();
+    let doc_id = s.open(&src);
+    let (err, session) = s.call(
+        "hwp_doc_replace_text",
+        serde_json::json!({"docId": doc_id, "find": find, "replace": replace}),
+    );
+    assert!(!err, "세션 치환 실패: {session}");
+    assert_eq!(
+        session["replacedCount"].as_u64(),
+        Some(replaced),
+        "치환 계수부터 동형이어야 한다\n무상태={stateless}\n세션={session}"
+    );
+
+    assert_eq!(
+        changed_pages(&session),
+        changed_pages(&stateless),
+        "세션·무상태 changedPages 가 갈라졌습니다\n무상태={stateless}\n세션={session}"
+    );
+}
+
+/// ③ set_cell — 표 호스트 문단이 근거. 무상태 판과 같은 쪽을 답한다.
+#[test]
+fn session_set_cell_changed_pages_matches_stateless() {
+    let src = sample(TABLE_SAMPLE);
+    if !src.exists() {
+        eprintln!("표 샘플 없음 — 건너뜀");
+        return;
+    }
+    let path = src.to_str().unwrap();
+    let tables = cli_json(&["export-tables", path, "--json"]);
+    let Some(table) = tables["tables"]
+        .as_array()
+        .and_then(|t| t.iter().find(|t| t.get("containerPath").is_none()))
+    else {
+        eprintln!("본문 최상위 표 없음 — 건너뜀");
+        return;
+    };
+    let (t, r, c) = (
+        table["index"].as_u64().expect("index"),
+        table["cells"][0]["row"].as_u64().expect("row"),
+        table["cells"][0]["col"].as_u64().expect("col"),
+    );
+
+    let out = temp_path("cell", "hwp");
+    let stateless = cli_json(&[
+        "edit",
+        "set-cell",
+        path,
+        "--table",
+        &t.to_string(),
+        "--row",
+        &r.to_string(),
+        "--col",
+        &c.to_string(),
+        "--text",
+        "동형",
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ]);
+    let _ = std::fs::remove_file(&out);
+
+    let mut s = Server::started();
+    let doc_id = s.open(&src);
+    let (err, session) = s.call(
+        "hwp_doc_set_cell",
+        serde_json::json!({"docId": doc_id, "table": t, "row": r, "col": c, "text": "동형"}),
+    );
+    assert!(!err, "세션 셀 쓰기 실패: {session}");
+    assert_eq!(
+        session["newText"], stateless["newText"],
+        "전제: 같은 칸을 같은 값으로 고쳤다"
+    );
+    assert_eq!(
+        changed_pages(&session),
+        changed_pages(&stateless),
+        "세션·무상태 changedPages 가 갈라졌습니다\n무상태={stateless}\n세션={session}"
+    );
+}
+
+/// ④ 지정한 쪽은 **그 자리에서 렌더된다** — 눈검증 루프가 실제로 닫히는지 본다.
+///
+/// 재조판 전에 계산했다면 편집 전 레이아웃의 쪽 번호가 나온다. 편집이 쪽을 늘린
+/// 경우 그 번호는 `hwp_doc_render_page` 에서 "페이지 범위 초과"로 거부된다 — 즉
+/// 이 시험은 "쪽 번호가 예쁘다"가 아니라 **약속된 다음 호출이 성공하는가**를 본다.
+#[test]
+fn session_changed_pages_are_renderable_right_away() {
+    let src = sample(FIELD_SAMPLE);
+    if !src.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let path = src.to_str().unwrap();
+    let Some(name) = first_field_name(path) else {
+        eprintln!("누름틀 없는 샘플 — 건너뜀");
+        return;
+    };
+
+    let mut s = Server::started();
+    let doc_id = s.open(&src);
+    let before = s.page_count(&doc_id);
+    // 쪽을 늘리는 채움 — 재조판 시점이 틀리면 여기서 어긋난다.
+    let bulk = "가나다라마바사아자차".repeat(500);
+    let (err, v) = s.call(
+        "hwp_doc_fill_fields",
+        serde_json::json!({"docId": doc_id, "data": field_data(&name, &bulk)}),
+    );
+    assert!(!err, "채움 실패: {v}");
+    let after = s.page_count(&doc_id);
+    assert!(
+        after > before,
+        "전제: 이 채움이 쪽을 늘린다 ({before} → {after}) — 늘지 않으면 시험이 무의미해진다"
+    );
+
+    let pages = changed_pages(&v).expect("채움이 있었으니 목록이 확정된다");
+    assert!(!pages.is_empty(), "{v}");
+    let out = temp_path("render", "svg");
+    for p in &pages {
+        assert!(*p < after, "재조판 후 쪽 수 범위 안: {p} < {after}: {v}");
+        let (rerr, rv) = s.call(
+            "hwp_doc_render_page",
+            serde_json::json!({"docId": doc_id, "page": p, "output": out.to_str().unwrap()}),
+        );
+        assert!(!rerr, "changedPages 가 가리킨 {p} 쪽 렌더 실패: {rv}");
+        assert!(rv["bytes"].as_u64().unwrap_or(0) > 0, "{rv}");
+    }
+    let _ = std::fs::remove_file(&out);
+}
+
+/// ⑤ 무변경은 빈 목록이다 — `null`("전체를 보라")로 내리면 무변경 호출마다 전수
+/// 렌더를 유도한다. 부분 목록 금지와 별개의 축이다.
+#[test]
+fn session_changed_pages_empty_when_nothing_changed() {
+    let src = sample(FIELD_SAMPLE);
+    if !src.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let mut s = Server::started();
+    let doc_id = s.open(&src);
+
+    let (err, fill) = s.call(
+        "hwp_doc_fill_fields",
+        serde_json::json!({"docId": doc_id, "data": {"존재하지_않는_누름틀_이름": "x"}}),
+    );
+    assert!(!err, "{fill}");
+    assert_eq!(fill["filledCount"].as_u64(), Some(0), "{fill}");
+    assert_eq!(
+        changed_pages(&fill),
+        Some(Vec::new()),
+        "채운 것이 없으면 빈 목록: {fill}"
+    );
+
+    let (err, repl) = s.call(
+        "hwp_doc_replace_text",
+        serde_json::json!({"docId": doc_id, "find": "존재하지_않는_문자열_QZX", "replace": "y"}),
+    );
+    assert!(!err, "{repl}");
+    assert_eq!(repl["replacedCount"].as_u64(), Some(0), "{repl}");
+    assert_eq!(
+        changed_pages(&repl),
+        Some(Vec::new()),
+        "치환 0건이면 빈 목록: {repl}"
+    );
+}
+
+/// ⑥ 선언과 봉투의 드리프트 가드 — 세 도구의 tools/list 설명이 changedPages 를
+/// 광고하고, 실제 봉투가 그 키를 낸다. 한쪽만 바뀌면 여기서 잡힌다.
+#[test]
+fn session_edit_tools_declare_changed_pages() {
+    let mut s = Server::started();
+    let r = s.request("tools/list", serde_json::json!({}));
+    let tools = r["result"]["tools"].as_array().expect("tools 배열");
+    for name in [
+        "hwp_doc_fill_fields",
+        "hwp_doc_replace_text",
+        "hwp_doc_set_cell",
+    ] {
+        let t = tools
+            .iter()
+            .find(|t| t["name"] == name)
+            .unwrap_or_else(|| panic!("{name} 이 tools/list 에 없습니다"));
+        assert!(
+            t["description"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("changedPages"),
+            "{name} 설명이 changedPages 를 광고하지 않습니다: {t}"
+        );
+    }
+}


### PR DESCRIPTION
#3630 P3 · #3719 §6-1. 무상태 편집 봉투의 `changedPages`(#3712)를 **세션 편집 3종**으로 확장한다.

## 왜

세션(`mcp-serve`)에서 편집하면 봉투에 무엇이 바뀌었는지는 있는데 **어느 쪽을 다시 봐야 하는지가 없다.**
에이전트는 전체를 렌더하거나(비싸다) 안 보거나(위험하다) 둘 중 하나였다. 무상태 축에는 이미
있는 정보가 세션 축에만 없어서 **같은 편집인데 축에 따라 봉투가 다른** 드리프트이기도 했다.

## 무엇

`hwp_doc_fill_fields` · `hwp_doc_replace_text` · `hwp_doc_set_cell_text` 봉투에 `changedPages` 추가.

새 계산은 **0**이다. `changed_pages_value()` 헬퍼 하나가 기존 코어 질의
`pages_covering_paragraphs`(#3712) 를 감싸고, 세 도구가 **각자의 재조판 지점 뒤에서** 호출한다.
문단 주소의 출처도 기존 것을 그대로 쓴다 — fill 은 `FieldLocation`, replace 는 **치환 전** grep 매치,
set_cell 은 `resolve_table_cell` 호스트 문단.

## 실측

| 편집 | `changedPages` | 무상태 축과 |
|---|---|---|
| fill(`회사명`) | `[0]` | 일치 |
| replace(`마케팅`→`기획`) | `[0]` | 일치 |
| set_cell(table-001 0,0,0) | `[0]` | 일치 |
| 치환 0건 · notFound | `[]` | — |

**재조판 시점이 맞는지가 이 PR 의 급소**여서 따로 증명했다. `회사명` 에 5,000자를 넣어
pageCount **3 → 11** 로 늘리면 `changedPages` 가 `[0..8]` 로 나온다. 3~8쪽은 **편집 전에는
존재하지 않던 쪽**인데 `hwp_doc_render_page{page:8}` 이 즉시 성공한다(SVG 182,206 bytes).
조판 전에 물었다면 이 쪽들은 나오지 않는다.

- 테스트 **99 passed / 0 failed** (신규 6 · 세션 무회귀 24 · 드리프트 가드 38 · 무상태 축 31)
- `cargo clippy --release -- -D warnings` 0 · rustfmt clean

## 판단이 필요했던 두 지점 (리뷰 논점)

**1. 무변경 시 `[]` 로 통일했다.** 무상태 `replace-text` 가 0건에서 `null` 을 내는 건
"산출 파일이 없다"(`wrote_output` 분기)는 **별개 사유**이고 세션엔 그 사유가 없다.
무상태 `fill-fields` 는 이미 `[]` 다. `null` 은 규약상 "전체를 보라"이므로, 무변경마다
전수 렌더를 유도하게 된다.

**2. capabilities `outputFields` 는 건드리지 않았다.** 세션 도구는 `capabilities --mcp` 의
`tools[]` 에 실리지 않고, `served_tools()` 는 무상태·세션 모두 name/description/inputSchema 만
내보내 `outputFields` 축이 아예 없다. 세션 도구에만 새 필드를 만들면 `tools/list` 모양이 갈라져
`tools_list_matches_capabilities_manifest` 가 지키는 단일 출처가 흐려진다. 대신 세 도구
`description` 에 규약을 적고 신규 테스트 `session_edit_tools_declare_changed_pages` 가
선언↔봉투 드리프트를 잡는다. → **`src/main.rs` 무변경.**

## `null` 강등은 실측으로 재현하지 못했다

구조적으로는 살아 있다(대상 문단이 어떤 `PageItem` 에도 없으면 `None`). 하지만 코퍼스
전수 스캔에서 **0건**이었다 — 샘플 348개 `search` 에서 조판 쪽이 안 붙은 매치 0건,
누름틀 샘플 30개 `fill-fields` 에서 `null` 0건. `FieldLocation.para_index` 와
`GrepMatch.paragraph` 가 **둘 다 최상위 호스트 문단**을 가리켜서(표 셀·글상자 안이어도)
커버리지를 벗어나지 않는 게 이유다. 남은 이론적 경로는 `hidden_empty_paras` 같은 미배치 문단뿐이다.
**추측이 아니라 못 찾았다는 사실**로 README 「남은 것」에 적었고, 실물이 나오면 픽스처로 고정한다.
