### PR TITLE
[#3719 §6-7] 표 ↔ CSV 왕복 — table-to-csv / csv-to-table (병합 셀 격자 보존)

### DIFF
--- a/mydocs/report/task_m100_table_csv/README.md
+++ b/mydocs/report/task_m100_table_csv/README.md
@@ -1,0 +1,142 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_table_csv/README.md
+last_verified: 2026-08-02
+---
+
+# #3719 §6-7 처리 기록 — `table-to-csv` / `csv-to-table`
+
+## 문제
+
+데이터 보고서 자동화에는 **입구와 출구**가 둘 다 있어야 한다. rhwp 에는 지금까지
+출구가 없었다.
+
+- `export-tables` 는 병합을 `rowSpan`/`colSpan` 으로 **보존**한 격자 JSON 을 낸다.
+  구조는 정확하지만, 엑셀·pandas 같은 표 계산기가 먹는 것은 직사각 격자뿐이라
+  소비자가 매번 격자를 펴는 코드를 다시 쓴다.
+- 그 펴는 코드가 틀리기 쉽다. 모델의 `Table.cells` 는 **앵커 셀만** 담고 병합으로
+  덮인 좌표는 목록에 아예 없으므로(`table_extract.rs`), 앵커를 순서대로 이어 붙이면
+  병합이 있는 행부터 **열이 통째로 밀린다**. 오류도 경고도 없이 값이 어긋난 표가
+  나오고, 에이전트는 렌더를 보지 않으므로 알아채지 못한다.
+- 되돌리는 축은 아예 없었다. 계산 결과를 원본 서식 그대로 표에 되넣으려면
+  `edit set-cell` 을 칸 수만큼 호출해야 했다(왕복 비용 O(칸)).
+
+## 구현
+
+### 코어 — `src/document_core/queries/table_csv.rs` (신규)
+
+파서·렌더 무변경의 순수 변환 모듈. `table_extract::TableGrid` 를 그대로 받는다.
+
+- `grid_matrix(grid)` — 격자를 `rows`×`cols` 로 **채운다**. 앵커 위치에 값, 병합으로
+  덮인 칸은 빈 문자열. 값을 병합 범위에 복제하지 **않는** 이유는 왕복 때문이다 —
+  복제하면 되돌릴 때 "덮인 칸에 값이 있는 CSV" 가 되어 스스로 거부된다.
+- `quote_field` / `matrix_to_csv` / `grid_to_csv` — RFC 4180 인용(`,`·`"`·CR·LF 가
+  있으면 큰따옴표, 내부 `"` 는 `""`), 레코드 구분자는 CRLF(§2.1).
+- `parse_csv` — RFC 4180 판독. LF 단독 구분자와 선두 BOM 도 받는다(유닉스 도구 산출
+  호환). 마지막 레코드 뒤 구분자 하나는 빈 레코드를 만들지 않는다. 닫히지 않은
+  따옴표·닫는 따옴표 뒤 잡문자는 위치(`record`/`field`)와 함께 오류로 낸다 —
+  조용히 이어 붙이면 `"a"b` 가 `ab` 로 통과해 원본과 다른 값이 표에 들어간다.
+- 모듈 단위 테스트 8건(인용 최소화·왕복·후행 구분자·빈 필드·BOM·빈 입력·오류 2종).
+
+### `table-to-csv` (#3719 §6)
+
+```
+rhwp table-to-csv <파일> [--table N] [-o <경로>] [--bom] [--json]
+```
+
+- `--table` 생략 시 **본문 최상위 표 전부**. 표 번호는 `export-tables` 의 `index`
+  이며 `edit set-cell --table` 과 같은 좌표계다(중첩·컨테이너 표는 v1 범위 밖).
+- `-o` 의 뜻은 `--table` 유무로 갈린다: 한 표면 그 경로가 **파일**, 전부면 표별
+  파일(`table<N>.csv`)을 담을 **폴더**(`export-svg` 의 `-o` 규약과 같은 이유).
+- `--bom` 은 **파일 인코딩 표식**이라 파일에만 붙는다. 봉투의 `csv` 문자열에 섞으면
+  JSON 을 그대로 쓰는 소비자가 U+FEFF 를 첫 셀 값의 일부로 읽는다.
+- `-o` 도 `--json` 도 없으면 CSV 본문을 stdout 으로 흘린다(파이프용).
+
+### `csv-to-table` (#3719 §7)
+
+```
+rhwp csv-to-table <파일> --csv <경로> --table N [-o <출력>] [--dry-run] [--verify] [--json]
+```
+
+- **표 크기를 바꾸지 않는다.** 선검증 → 인메모리 적용 → 단 한 번 저장은 `run`(#3703)
+  의 원자 실행과 같은 규약이다. 선검증에 걸리면 한 칸도 쓰지 않고 `invalid[]` +
+  exit 2 — 조용히 잘라내면 "표는 그럴듯한데 뒤쪽 데이터가 통째로 사라진" 보고서가
+  남는다. `invalid[].reason` 4종:
+  - `csvParse` — CSV 문법 오류(위치 포함)
+  - `rowCountMismatch` / `colCountMismatch` — 행·열 수 불일치
+  - `coveredCellNotEmpty` — 병합으로 덮인 칸에 값이 있음(쓸 수 없는 칸이다)
+  - `controlCharacter` — 셀 안 줄바꿈·탭(`set_cell_control_char_rejection` 공유 판정)
+- 좌표 해석은 `resolve_table_cell` 재사용, 쓰기는 `edit set-cell` 과 같은
+  `delete_text_in_cell`/`insert_text_in_cell` 경로. **값이 실제로 달라지는 앵커
+  칸만** 다시 쓴다.
+- `--verify` 는 `edit_verify_report` 재사용(저장 직후 재파싱 IR 대조, 차이 시 exit 3).
+- `changedPages` 는 `pages_covering_paragraphs` 재사용(표 호스트 문단이 걸친 쪽 전부).
+- 산출 형식은 `edit_output_format` 재사용 — 입력 형식 보존(HWPX → HWPX).
+
+#### set-cell 과 **다른** 결정 하나: 글자색을 덮지 않는다
+
+`edit set-cell` 은 기본으로 셀 글자를 검정·비이탤릭으로 덮는다(#3391) — 빈 서식의
+파란 이탤릭 안내문을 지우고 제출용 실값을 쓰는 축이기 때문이다. `csv-to-table` 은
+반대로 **이미 서식이 잡힌 보고서의 값을 갱신**하는 축이라, 표 머리·강조 스타일을
+일괄로 지우면 그 자체가 눈에 보이는 회귀다. 그래서 스타일을 보존한다. 빈 양식
+채우기는 계속 `set-cell`/`fill-fields` 가 담당한다.
+
+### 배선 (드리프트 가드 동시 충족)
+
+- 명령 2개 dispatch + `--help` 절 2개
+- `capabilities` 등재 2건(`table-to-csv`=export, `csv-to-table`=edit) — 선언한
+  flags 는 전부 실제 파서가 받는다
+- MCP 도구 2개 `hwp_table_to_csv` / `hwp_csv_to_table` — `inputSchema` 에
+  `type`/`properties`/`required` 배열, 선언한 입력 속성은 전부 `cli.args` 자리표시자
+  또는 `cli.optionalArgs.when` 에 배선(값 없는 `--bom`/`--dry-run`/`--verify` 는
+  presence 플래그 형태)
+
+## 검증
+
+실행 원문은 [`evidence.txt`](evidence.txt). 요약:
+
+| 게이트 | 결과 |
+| --- | --- |
+| `cargo build --release --bin rhwp` | Finished in 8m 06s, exit 0 |
+| `cargo test --release --test table_csv_contract` | **14 passed; 0 failed** |
+| `cargo test --release --test cli_json_contract` | 26 passed; 0 failed (무회귀) |
+| `cargo test --release --test mcp_server_contract` | 22 passed; 0 failed (무회귀) |
+| `cargo test --release --lib table_csv` | 8 passed; 0 failed (코어 단위) |
+| `cargo clippy -- -D warnings` | Finished in 53.15s, exit 0 (경고 0) |
+| `rustfmt --check` (변경 4파일) | 차이 없음 |
+
+무회귀 중 이 변경이 직접 건드리는 가드 4종이 green 이다 —
+`capabilities_covers_every_help_command` · `help_covers_every_capabilities_command` ·
+`capabilities_mcp_covers_every_json_command` ·
+`every_declared_input_property_is_wired_to_the_cli`.
+
+### 실측 (evidence.txt 발췌)
+
+1. **표 번호는 0 에서 시작하지 않는다** — 샘플은 표 53개 중 최상위 52개이고 첫
+   최상위 `index` 는 **1**(0 번은 머리말 안의 표). 테스트도 상수 대신
+   `export-tables` 가 보고한 실제 `index` 를 쓴다.
+2. **병합 격자 채움** — 병합 있는 첫 최상위 표(index 2, 3×3, 앵커 6개)의 CSV 는
+   레코드 3개, 레코드별 필드 수 `[3, 3, 3]`. 앵커만 이어 붙였다면 `[3, 2, 1]` 이
+   되어 2행부터 열이 밀었을 자리다.
+3. **왕복 무변경** — 뽑은 CSV 를 그대로 되넣으면 `changedCount: 0`,
+   `verify: {"identical": true, "diffCount": 0}`, `changedPages: [1]`.
+4. **한 칸 갱신** — `changedCount: 1`,
+   `changed: [{"row":0,"col":0,"oldText":"","newText":"표값-2026"}]`,
+   `changedPages: [1, 2]`. 저장본을 다시 CSV 로 뽑아 값이 실제로 들어갔음을 확인.
+5. **조용한 절삭 없음** — 행 1개 부족 → `rowCountMismatch`, 덮인 칸에 값 →
+   `coveredCellNotEmpty`, 따옴표 미종결 → `csvParse`. 셋 다 exit 2 이고 **출력
+   파일이 생기지 않는다**.
+6. **실패 경로 stdout 0바이트** — 인자 없음(exit 2)·없는 표 번호(exit 1) 모두
+   stdout 0바이트.
+7. **BOM** — `--bom` 이 파일 선두에 `EF BB BF` 를 넣지만 봉투의 `csv` 문자열에는
+   붙지 않는다. `-o <폴더>` 로 최상위 표 52개가 표별 파일로 나온다.
+
+## 남은 것
+
+- 셀 안 줄바꿈: 내보내기는 RFC 4180 대로 인용해 그대로 내지만, 되넣기는 거부한다
+  (`controlCharacter`). 다문단 셀에 문단 골격을 만들어 넣는 쓰기는 v1 범위 밖 —
+  왕복 무손실을 원하면 이 축을 따로 승격해야 한다.
+- 중첩 표·컨테이너(글상자·머리말) 안의 표는 두 명령 모두 대상이 아니다
+  (`set-cell` 과 같은 v1 경계).
+- 표 크기 변경(행 추가·삭제)은 이 명령의 계약이 아니다. 필요하면 별도 축이다.

--- a/mydocs/report/task_m100_table_csv/evidence.txt
+++ b/mydocs/report/task_m100_table_csv/evidence.txt
@@ -1,0 +1,122 @@
+#3719 §6-7 table-to-csv / csv-to-table 실측 증거
+수집일: 2026-08-02 / 브랜치 pr/table-csv (upstream/devel a8d7bdfbf 기준)
+환경: Windows 11, RUSTFLAGS="-C linker=rust-lld", CARGO_HTTP_CHECK_REVOKE=false
+샘플: samples/2025년 기부·답례품 실적 지자체 보고서_양식.hwpx (표 53개, 병합 포함)
+
+아래는 전부 실제 실행 출력이다 — 추정치나 재구성이 아니다.
+
+=== 0. 샘플 최상위 표 index (하드코딩 금지 근거) ===
+tableCount = 53 / top-level = 52
+첫 최상위 index = 1 (0 아님 — 머리말 표가 0)
+병합 있는 첫 최상위 표: index 2 3 x 3 anchors 6
+
+=== 1. table-to-csv --table 2 --json (병합 격자 채움) ===
+{"bom":false,"schemaVersion":"1.0","source":"samples/2025년 기부·답례품 실적 지자체 보고서_양식.hwpx","tableCount":1,"tables":[{"colCount":3,"csv":",< 2025년 기부·답례품 실적 분석보고서 요약 >,\r\n,,\r\n,,\r\n","index":2,"rowCount":3}]}
+
+index 2 rowCount 3 colCount 3
+레코드 수 3 (= rowCount) / 레코드별 필드 수 [3, 3, 3] (= colCount 전부 3 — 병합 채움 확인)
+csv repr: ',<\u20072025년 기부·답례품 실적 분석보고서 요약\u2007>,\r\n,,\r\n,,\r\n'
+
+=== 2. table-to-csv (전체) — 최상위 표 전부 ===
+tableCount = 52 bom = False
+index 목록 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] ...
+
+=== 3. -o 폴더 + --bom (엑셀 호환) ===
+생성 파일 수: 52
+table2.csv 선두 3바이트: 00000000: efbb bf                                  ...
+
+=== 4. 왕복 — 같은 CSV 되넣기 (changedCount 0 + verify) ===
+CSV 내보내기 완료: samples/2025년 기부·답례품 실적 지자체 보고서_양식.hwpx (표 1개)
+  C:/Users/swsz9/AppData/Local/Temp/claude/C--/d6031f1b-3749-41c1-b386-cad754a4b595/scratchpad/ev/same.csv
+  schemaVersion = "1.0"
+  table = 2
+  rowCount = 3
+  colCount = 3
+  changedCount = 0
+  invalid = []
+  dryRun = false
+  changedPages = [1]
+  outputFormat = "hwpx"
+  verify = {"diffCount": 0, "identical": true}
+
+=== 5. 값 갱신 — 한 칸만 바뀐다 ===
+  changedCount = 1
+  changed = [{"col": 0, "newText": "표값-2026", "oldText": "", "row": 0}]
+  changedPages = [1, 2]
+  되읽기:
+    '표값-2026,<\u20072025년 기부·답례품 실적 분석보고서 요약\u2007>,'
+
+=== 6. 행 수 불일치 — invalid + exit 2 + 무산출 ===
+{"changed":[],"changedCount":0,"changedPages":null,"colCount":3,"csv":"C:/Users/swsz9/AppData/Local/Temp/claude/C--/d6031f1b-3749-41c1-b386-cad754a4b595/scratchpad/ev/short.csv","dryRun":false,"invalid":[{"actual":2,"expected":3,"message":"CSV 행 수 2 가 표 2 의 행 수 3 와 다릅니다 — 표 크기는 바꾸지 않습니다.","reason":"rowCountMismatch"}],"rowCount":3,"schemaVersion":"1.0","source":"samples/2025년 기부·답례품 실적 지자체 보고서_양식.hwpx","table":2}
+  exit=2  산출물 존재=no
+
+=== 7. 병합으로 덮인 칸에 값 — invalid ===
+{"changed":[],"changedCount":0,"changedPages":null,"colCount":3,"csv":"C:/Users/swsz9/AppData/Local/Temp/claude/C--/d6031f1b-3749-41c1-b386-cad754a4b595/scratchpad/ev/covered.csv","dryRun":false,"invalid":[{"col":1,"message":"(1,1) 는 병합으로 덮인 칸이라 쓸 수 없습니다 — 값은 앵커 칸에 두고 이 칸은 비우세요.","reason":"coveredCellNotEmpty","row":1}],"rowCount":3,"schemaVersion":"1.0","source":"samples/2025년 기부·답례품 실적 지자체 보고서_양식.hwpx","table":2}
+  exit=2
+
+=== 8. 잘못된 CSV — 패닉 없이 invalid ===
+{"changed":[],"changedCount":0,"changedPages":null,"colCount":3,"csv":"C:/Users/swsz9/AppData/Local/Temp/claude/C--/d6031f1b-3749-41c1-b386-cad754a4b595/scratchpad/ev/bad.csv","dryRun":false,"invalid":[{"col":0,"message":"CSV 1행 1열: 따옴표가 닫히지 않았습니다","reason":"csvParse","row":0}],"rowCount":3,"schemaVersion":"1.0","source":"samples/2025년 기부·답례품 실적 지자체 보고서_양식.hwpx","table":2}
+  exit=2
+
+=== 9. 실패 경로 stdout 0바이트 ===
+  rhwp table-to-csv → exit=2 stdout=0바이트
+  rhwp csv-to-table → exit=2 stdout=0바이트
+  rhwp table-to-csv --table 99999 → exit=1 stdout=0바이트
+
+=== 10. 자기서술 정합 (capabilities / MCP / help) ===
+  {"batch": false, "category": "export", "flags": ["--table", "-o", "--bom", "--json"], "json": true, "name": "table-to-csv", "recordFields": ["schemaVersion", "source", "tableCount", "tables", "bom", "output", "outputFormat"], "summary": "본문 최상위 표를 병합 격자를 채운 RFC 4180 CSV 로 내보내기"}
+  {"batch": false, "category": "edit", "flags": ["--csv", "--table", "-o", "--dry-run", "--verify", "--json"], "json": true, "name": "csv-to-table", "recordFields": ["schemaVersion", "source", "csv", "table", "rowCount", "colCount", "changedCount", "changed", "invalid", "dryRun", "changedPages", "output", "outputFormat", "verify"], "summary": "CSV 로 기존 표 N 의 셀 덮어쓰기 — 표 크기 불변, 행·열 불일치는 invalid+exit 2"}
+  hwp_table_to_csv | required = ['path'] | properties = ['bom', 'output', 'path', 'table'] | wired = ['bom', 'output', 'path', 'table']
+  hwp_csv_to_table | required = ['path', 'csv', 'table'] | properties = ['csv', 'dryRun', 'output', 'path', 'table', 'verify'] | wired = ['csv', 'dryRun', 'output', 'path', 'table', 'verify']
+  모든 선언 속성이 CLI 에 배선됨 ✔
+  --help 등재: 2
+
+
+=== 11. 빌드·테스트·린트 (CI 와 같은 명령) ===
+$ cargo build --release --bin rhwp
+    Finished `release` profile [optimized] target(s) in 8m 06s        (exit 0)
+
+$ cargo test --release --test table_csv_contract --test cli_json_contract --test mcp_server_contract
+     Running tests\cli_json_contract.rs
+test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.52s
+     Running tests\mcp_server_contract.rs
+test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.07s
+     Running tests\table_csv_contract.rs
+running 14 tests
+test table_to_csv_json_envelope_contract ... ok
+test unknown_top_level_table_is_a_runtime_error_with_silent_stdout ... ok
+test bom_flag_only_affects_the_file_not_the_envelope ... ok
+test malformed_csv_is_invalid_not_a_panic ... ok
+test merged_table_csv_is_a_full_rectangle ... ok
+test capabilities_and_mcp_declare_both_commands ... ok
+test col_count_mismatch_is_invalid_and_writes_nothing ... ok
+test dry_run_writes_no_file ... ok
+test missing_arguments_are_usage_errors_with_silent_stdout ... ok
+test identical_csv_writes_nothing_and_verifies ... ok
+test row_count_mismatch_is_invalid_and_writes_nothing ... ok
+test rfc4180_quoting_survives_a_round_trip_through_the_document ... ok
+test value_in_a_merged_covered_cell_is_invalid ... ok
+test value_written_by_csv_is_readable_back ... ok
+test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.41s
+
+$ cargo test --release --lib table_csv          (코어 모듈 단위 테스트)
+running 8 tests
+test document_core::queries::table_csv::tests::bom_is_stripped ... ok
+test document_core::queries::table_csv::tests::empty_fields_are_kept ... ok
+test document_core::queries::table_csv::tests::empty_input_is_zero_records ... ok
+test document_core::queries::table_csv::tests::quotes_only_when_needed ... ok
+test document_core::queries::table_csv::tests::unterminated_quote_is_an_error ... ok
+test document_core::queries::table_csv::tests::garbage_after_closing_quote_is_an_error ... ok
+test document_core::queries::table_csv::tests::round_trip_preserves_special_characters ... ok
+test document_core::queries::table_csv::tests::trailing_separator_does_not_add_a_record ... ok
+test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 3037 filtered out; finished in 0.00s
+
+$ cargo clippy -- -D warnings
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 53.15s   (exit 0, 경고 0)
+
+$ rustfmt --edition 2021 --config-path rustfmt.toml --config newline_style=Auto --check \
+      src/main.rs src/document_core/queries/table_csv.rs \
+      src/document_core/queries/mod.rs tests/table_csv_contract.rs
+    (출력 없음 = 차이 없음)
+
+합계: 신규 계약 14건 + 코어 단위 8건 green, 무회귀 cli_json 26 · mcp_server 22 green.

--- a/src/document_core/queries/mod.rs
+++ b/src/document_core/queries/mod.rs
@@ -13,4 +13,6 @@ pub mod changed_pages;
 pub mod grep;
 pub(crate) mod search_query;
 pub mod structure;
+// [#3719 §6-7] 표 ↔ CSV 변환 — `table_extract` 격자를 재사용하는 순수 변환 코어.
+pub mod table_csv;
 pub mod table_extract;

--- a/src/document_core/queries/table_csv.rs
+++ b/src/document_core/queries/table_csv.rs
@@ -1,0 +1,265 @@
+//! 표 ↔ CSV 변환 코어 — 데이터 보고서 자동화의 입출구 (로드맵 #3719 §6-7).
+//!
+//! `export-tables` 의 격자 JSON 은 병합을 `rowSpan`/`colSpan` 으로 **보존**하지만, 표
+//! 계산기(엑셀·pandas)가 먹는 것은 직사각 격자뿐이다. 모델의 `Table.cells` 는 앵커 셀만
+//! 담고 병합으로 덮인 좌표는 목록에 아예 없으므로(`table_extract` 참조), 앵커를 순서대로
+//! 이어 붙이면 **병합이 있는 행에서 열이 통째로 밀린다** — 오류 없이 어긋난 데이터가
+//! 나온다. 그래서 여기서는 격자를 `rows`×`cols` 로 **채워서** 내보낸다: 앵커 위치에 값,
+//! 덮인 칸은 빈 문자열.
+//!
+//! 인용은 RFC 4180 이다. 필드에 `,`·`"`·CR·LF 가 있으면 큰따옴표로 감싸고 내부 `"` 는
+//! `""` 로 두 번 쓴다. 레코드 구분자는 CRLF(RFC 4180 §2.1)로 쓰고, 파서는 LF 단독도
+//! 받는다(유닉스 도구가 만든 CSV 호환).
+//!
+//! 파서/렌더 무변경의 순수 변환 모듈이다 — 문서 모델을 읽기만 하고 쓰지 않는다.
+
+use std::fmt;
+
+use super::table_extract::TableGrid;
+
+/// RFC 4180 §2.1 의 레코드 구분자.
+pub const CSV_RECORD_SEPARATOR: &str = "\r\n";
+
+/// UTF-8 BOM — 엑셀이 CP949 로 오해해 한글이 깨지는 것을 막는 선택 표식.
+pub const UTF8_BOM: &str = "\u{feff}";
+
+/// CSV 파싱 실패 위치와 사유. 봉투의 `invalid[]` 항목으로 그대로 옮겨 쓴다.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CsvParseError {
+    /// 0 기준 레코드(행) 번호.
+    pub record: usize,
+    /// 0 기준 필드(열) 번호.
+    pub field: usize,
+    /// 사람이 읽는 사유.
+    pub reason: &'static str,
+}
+
+impl fmt::Display for CsvParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CSV {}행 {}열: {}",
+            self.record + 1,
+            self.field + 1,
+            self.reason
+        )
+    }
+}
+
+/// 필드 하나를 RFC 4180 규칙으로 인용한다.
+///
+/// 인용이 필요 없는 값은 그대로 둔다 — 불필요한 따옴표는 사람이 읽는 진단(diff)을
+/// 어지럽히고, 어떤 소비자는 값의 일부로 오독한다.
+pub fn quote_field(field: &str) -> String {
+    if !field.contains([',', '"', '\r', '\n']) {
+        return field.to_string();
+    }
+    let mut out = String::with_capacity(field.len() + 2);
+    out.push('"');
+    for ch in field.chars() {
+        if ch == '"' {
+            out.push('"');
+        }
+        out.push(ch);
+    }
+    out.push('"');
+    out
+}
+
+/// 병합을 채운 `rows`×`cols` 문자열 행렬.
+///
+/// 앵커 셀의 텍스트는 앵커 좌표에만 놓이고 덮인 칸은 빈 문자열이다. 값을 병합 범위에
+/// 복제하지 않는 이유는 `csv-to-table` 왕복 때문이다 — 복제하면 되돌릴 때 덮인 칸에
+/// 값이 있는 CSV 가 되어 "쓸 수 없는 칸에 값이 있다"로 거부된다.
+pub fn grid_matrix(grid: &TableGrid) -> Vec<Vec<String>> {
+    let rows = grid.rows as usize;
+    let cols = grid.cols as usize;
+    let mut matrix = vec![vec![String::new(); cols]; rows];
+    for cell in &grid.cells {
+        let (r, c) = (cell.row as usize, cell.col as usize);
+        // `table_extract` 가 범위 밖 앵커를 이미 걸러내지만, 격자 크기가 0 인 손상
+        // 문서에서도 패닉하지 않도록 여기서도 확인한다.
+        if let Some(slot) = matrix.get_mut(r).and_then(|row| row.get_mut(c)) {
+            slot.clone_from(&cell.text);
+        }
+    }
+    matrix
+}
+
+/// 문자열 행렬을 CSV 본문으로 직렬화한다 (마지막 레코드에도 구분자를 붙인다).
+pub fn matrix_to_csv(matrix: &[Vec<String>]) -> String {
+    let mut out = String::new();
+    for row in matrix {
+        let mut first = true;
+        for field in row {
+            if !first {
+                out.push(',');
+            }
+            first = false;
+            out.push_str(&quote_field(field));
+        }
+        out.push_str(CSV_RECORD_SEPARATOR);
+    }
+    out
+}
+
+/// 표 격자 하나를 CSV 본문으로 변환한다 (병합 채움 + RFC 4180 인용).
+pub fn grid_to_csv(grid: &TableGrid) -> String {
+    matrix_to_csv(&grid_matrix(grid))
+}
+
+/// CSV 본문을 레코드 배열로 판독한다 (RFC 4180, LF 단독 구분자 허용, 선두 BOM 허용).
+///
+/// 빈 입력은 레코드 0건이다. 마지막 레코드 뒤의 구분자 하나는 빈 레코드를 만들지
+/// 않는다 — 그러지 않으면 정상 CSV 가 항상 "행이 하나 많다"로 거부된다.
+pub fn parse_csv(input: &str) -> Result<Vec<Vec<String>>, CsvParseError> {
+    let body = input.strip_prefix(UTF8_BOM).unwrap_or(input);
+    let chars: Vec<char> = body.chars().collect();
+    let mut records: Vec<Vec<String>> = Vec::new();
+    if chars.is_empty() {
+        return Ok(records);
+    }
+
+    let mut record: Vec<String> = Vec::new();
+    let mut field = String::new();
+    let mut i = 0usize;
+    loop {
+        if chars.get(i) == Some(&'"') {
+            i += 1;
+            loop {
+                match chars.get(i) {
+                    None => {
+                        return Err(CsvParseError {
+                            record: records.len(),
+                            field: record.len(),
+                            reason: "따옴표가 닫히지 않았습니다",
+                        })
+                    }
+                    Some('"') => {
+                        if chars.get(i + 1) == Some(&'"') {
+                            field.push('"');
+                            i += 2;
+                        } else {
+                            i += 1;
+                            break;
+                        }
+                    }
+                    Some(c) => {
+                        field.push(*c);
+                        i += 1;
+                    }
+                }
+            }
+            // 닫는 따옴표 뒤에 올 수 있는 것은 구분자·줄바꿈·끝뿐이다. 그 밖의 문자를
+            // 조용히 이어 붙이면 `"a"b` 가 `ab` 로 통과해 원본과 다른 값이 표에 들어간다.
+            match chars.get(i) {
+                None | Some(',') | Some('\r') | Some('\n') => {}
+                Some(_) => {
+                    return Err(CsvParseError {
+                        record: records.len(),
+                        field: record.len(),
+                        reason: "닫는 따옴표 뒤에 구분자가 아닌 문자가 있습니다 (값 안의 \" 는 \"\" 로 쓰세요)",
+                    })
+                }
+            }
+        } else {
+            while let Some(c) = chars.get(i) {
+                if matches!(c, ',' | '\r' | '\n') {
+                    break;
+                }
+                field.push(*c);
+                i += 1;
+            }
+        }
+        record.push(std::mem::take(&mut field));
+
+        match chars.get(i) {
+            Some(',') => i += 1,
+            Some('\r') | Some('\n') => {
+                if chars.get(i) == Some(&'\r') && chars.get(i + 1) == Some(&'\n') {
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+                records.push(std::mem::take(&mut record));
+                if i >= chars.len() {
+                    break;
+                }
+            }
+            _ => {
+                records.push(std::mem::take(&mut record));
+                break;
+            }
+        }
+    }
+    Ok(records)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quotes_only_when_needed() {
+        assert_eq!(quote_field("보통값"), "보통값");
+        assert_eq!(quote_field("가,나"), "\"가,나\"");
+        assert_eq!(quote_field("따\"옴"), "\"따\"\"옴\"");
+        assert_eq!(quote_field("줄\n바꿈"), "\"줄\n바꿈\"");
+    }
+
+    #[test]
+    fn round_trip_preserves_special_characters() {
+        let matrix = vec![vec![
+            "a,b".to_string(),
+            "c\"d".to_string(),
+            "e\nf".to_string(),
+            String::new(),
+        ]];
+        let csv = matrix_to_csv(&matrix);
+        assert_eq!(parse_csv(&csv).expect("파싱"), matrix);
+    }
+
+    #[test]
+    fn trailing_separator_does_not_add_a_record() {
+        assert_eq!(
+            parse_csv("a,b\r\nc,d\r\n").expect("파싱"),
+            vec![vec!["a", "b"], vec!["c", "d"]]
+        );
+        assert_eq!(
+            parse_csv("a,b\nc,d").expect("파싱"),
+            vec![vec!["a", "b"], vec!["c", "d"]]
+        );
+    }
+
+    #[test]
+    fn empty_fields_are_kept() {
+        assert_eq!(parse_csv("a,,c").expect("파싱"), vec![vec!["a", "", "c"]]);
+        assert_eq!(parse_csv("a,").expect("파싱"), vec![vec!["a", ""]]);
+        assert_eq!(parse_csv(",").expect("파싱"), vec![vec!["", ""]]);
+    }
+
+    #[test]
+    fn bom_is_stripped() {
+        let csv = format!("{UTF8_BOM}값");
+        assert_eq!(parse_csv(&csv).expect("파싱"), vec![vec!["값"]]);
+    }
+
+    #[test]
+    fn empty_input_is_zero_records() {
+        assert!(parse_csv("").expect("파싱").is_empty());
+    }
+
+    #[test]
+    fn unterminated_quote_is_an_error() {
+        let e = parse_csv("a,\"b").expect_err("오류여야 함");
+        assert_eq!(e.record, 0);
+        assert_eq!(e.field, 1);
+    }
+
+    #[test]
+    fn garbage_after_closing_quote_is_an_error() {
+        let e = parse_csv("\"a\"b").expect_err("오류여야 함");
+        assert_eq!(e.record, 0);
+        assert_eq!(e.field, 0);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,6 +266,8 @@ fn main() {
         Some("export-text") => exit_with(export_text(&args[2..])),
         Some("export-markdown") => exit_with(export_markdown(&args[2..])),
         Some("export-tables") => exit_with(export_tables(&args[2..])),
+        Some("table-to-csv") => exit_with(table_to_csv(&args[2..])),
+        Some("csv-to-table") => exit_with(csv_to_table(&args[2..])),
         Some("export-hwpx") => exit_with(export_hwpx(&args[2..])),
         Some("export-hml") => export_hml(&args[2..]),
         Some("export-doclang") => exit_with(export_doclang(&args[2..])),
@@ -758,6 +760,70 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
             serde_json::json!(["export-tables", "{path}", "--json"]),
             &["source", "tableCount", "tables"],
         ),
+        // [#3719 §6] 표 → CSV. hwp_export_tables 는 병합을 span 으로 보존하는 격자
+        // JSON 이라 소비자가 직접 격자를 펴야 한다 — 표 계산기에 바로 먹이는 축은 이쪽이다.
+        tool_with_optional_args(
+            "hwp_table_to_csv",
+            "HWP 표를 병합 격자를 채운 RFC 4180 CSV 로 내보낸다 — 엑셀·pandas 가 그대로 먹는 직사각 표. 병합으로 덮인 칸은 빈 문자열로 채워 열이 밀리지 않는다. table 을 생략하면 본문 최상위 표 전부를 낸다. 표 번호는 hwp_export_tables 의 index 이며 0 에서 시작하지 않을 수 있다(머리말 표가 0 번인 문서가 흔하다) — 먼저 hwp_export_tables 로 확인한다.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string", "description": "HWP/HWPX/HML 문서 경로" },
+                    "table": { "type": "integer", "minimum": 0, "description": "본문 최상위 표 번호 (hwp_export_tables 의 index). 생략하면 전부" },
+                    "output": { "type": "string", "description": "CSV 출력 경로. table 을 지정하면 파일, 생략하면 표별 파일(table<N>.csv)을 담을 디렉터리" },
+                    "bom": { "type": "boolean", "description": "파일 출력에 UTF-8 BOM 을 붙인다 (엑셀 한글 깨짐 방지). 봉투의 csv 문자열에는 붙지 않는다" }
+                },
+                "required": ["path"],
+            }),
+            "table-to-csv",
+            serde_json::json!(["table-to-csv", "{path}", "--json"]),
+            serde_json::json!([
+                { "when": "table", "args": ["--table", "{table}"] },
+                { "when": "output", "args": ["-o", "{output}"] },
+                { "when": "bom", "args": ["--bom"] }
+            ]),
+            &["schemaVersion", "source", "tableCount", "tables", "bom", "output", "outputFormat"],
+        ),
+        // [#3719 §7] CSV → 표. 계산 결과를 원본 서식 그대로 되돌려 넣는 축.
+        tool_with_optional_args(
+            "hwp_csv_to_table",
+            "CSV 파일의 내용으로 기존 표 N 의 셀을 덮어써 새 문서를 만든다 — 표로 만든 보고서의 값 갱신. 표 크기는 바꾸지 않으며, CSV 의 행·열 수가 표와 다르면 한 칸도 쓰지 않고 invalid 로 보고한다(exit 2). 병합으로 덮인 칸의 값은 비어 있어야 하고, 셀 안 줄바꿈·탭은 거부한다. CSV 는 hwp_table_to_csv 산출물을 고쳐 쓰는 것이 안전하다. 산출물은 입력 형식을 따른다(HWPX 입력 → HWPX 산출).",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string", "description": "입력 HWP/HWPX 문서 경로" },
+                    "csv": { "type": "string", "description": "읽을 CSV 파일 경로 (UTF-8, 선두 BOM 허용)" },
+                    "table": { "type": "integer", "minimum": 0, "description": "덮어쓸 본문 최상위 표 번호 (hwp_export_tables 의 index)" },
+                    "output": { "type": "string", "description": "출력 파일 경로. 생략하면 <입력명>_csv.hwp (HWPX 입력이면 _csv.hwpx)" },
+                    "dryRun": { "type": "boolean", "description": "true 면 파일을 쓰지 않고 바뀔 칸만 보고" },
+                    "verify": { "type": "boolean", "description": "저장 직후 재파싱 IR 자기검증 — 차이가 있으면 exit 3" }
+                },
+                "required": ["path", "csv", "table"],
+            }),
+            "csv-to-table",
+            serde_json::json!(["csv-to-table", "{path}", "--csv", "{csv}", "--table", "{table}", "--json"]),
+            serde_json::json!([
+                { "when": "output", "args": ["-o", "{output}"] },
+                { "when": "dryRun", "args": ["--dry-run"] },
+                { "when": "verify", "args": ["--verify"] }
+            ]),
+            &[
+                "schemaVersion",
+                "source",
+                "csv",
+                "table",
+                "rowCount",
+                "colCount",
+                "changedCount",
+                "changed",
+                "invalid",
+                "dryRun",
+                "changedPages",
+                "output",
+                "outputFormat",
+                "verify",
+            ],
+        ),
         tool(
             "hwp_search",
             "문서에서 검색어를 찾아 구역·문단·페이지·문자 오프셋 주소와 문맥을 돌려준다.",
@@ -1208,6 +1274,46 @@ fn capabilities_command_entries() -> Vec<serde_json::Value> {
             false,
             &["-o", "--json"],
             &["schemaVersion", "source", "tableCount", "tables"],
+        ),
+        // [#3719 §6-7] 데이터 보고서 자동화의 입출구 — 표 ↔ CSV.
+        cmd_json(
+            "table-to-csv",
+            "export",
+            "본문 최상위 표를 병합 격자를 채운 RFC 4180 CSV 로 내보내기",
+            false,
+            &["--table", "-o", "--bom", "--json"],
+            &[
+                "schemaVersion",
+                "source",
+                "tableCount",
+                "tables",
+                "bom",
+                "output",
+                "outputFormat",
+            ],
+        ),
+        cmd_json(
+            "csv-to-table",
+            "edit",
+            "CSV 로 기존 표 N 의 셀 덮어쓰기 — 표 크기 불변, 행·열 불일치는 invalid+exit 2",
+            false,
+            &["--csv", "--table", "-o", "--dry-run", "--verify", "--json"],
+            &[
+                "schemaVersion",
+                "source",
+                "csv",
+                "table",
+                "rowCount",
+                "colCount",
+                "changedCount",
+                "changed",
+                "invalid",
+                "dryRun",
+                "changedPages",
+                "output",
+                "outputFormat",
+                "verify",
+            ],
         ),
         cmd_json(
             "extract-pages",
@@ -1708,6 +1814,29 @@ fn print_help() {
     println!();
     println!("      --json                  계약 봉투 JSON을 stdout에 출력");
     println!("      -o, --output <파일>     JSON을 파일로 저장");
+    println!();
+    println!("  table-to-csv <파일.hwp|파일.hwpx> [--table <번호>] [-o <경로>] [--bom] [--json]");
+    println!("      본문 최상위 표를 RFC 4180 CSV로 내보내기 (병합 격자를 채워 열이 밀리지 않음)");
+    println!();
+    println!("      --table <번호>          한 표만 (export-tables 의 index — 0부터 시작하지");
+    println!("                              않을 수 있음). 생략하면 최상위 표 전부");
+    println!("      -o, --output <경로>     --table 지정 시 CSV 파일, 생략 시 표별 파일");
+    println!("                              (table<N>.csv)을 담을 폴더");
+    println!("      --bom                   파일 출력에 UTF-8 BOM 추가 (엑셀 한글 깨짐 방지)");
+    println!("      --json                  계약 봉투 JSON을 stdout에 출력");
+    println!("      -o 도 --json 도 없으면 CSV 본문을 stdout으로 그대로 흘린다 (파이프용)");
+    println!();
+    println!("  csv-to-table <파일.hwp|파일.hwpx> --csv <경로.csv> --table <번호> [옵션]");
+    println!("      CSV 내용으로 기존 표 N의 셀을 덮어쓰기 (표 크기는 바꾸지 않음)");
+    println!();
+    println!("      --csv <경로>            읽을 CSV 파일 (UTF-8, 선두 BOM 허용)");
+    println!("      --table <번호>          덮어쓸 표 (export-tables 의 index)");
+    println!("      -o, --output <파일>     출력 경로 (기본: <입력 stem>_csv.hwp/.hwpx)");
+    println!("      --dry-run               파일을 쓰지 않고 바뀔 칸만 보고");
+    println!("      --verify                저장 직후 재파싱 IR 자기검증 (차이 시 exit 3)");
+    println!("      --json                  계약 봉투 JSON을 stdout에 출력");
+    println!("      행·열 수가 표와 다르거나 병합으로 덮인 칸에 값이 있으면 한 칸도 쓰지 않고");
+    println!("      invalid[] 로 보고하며 사용법 오류(2)로 끝낸다 — 조용히 잘라내지 않는다");
     println!();
     println!("  export-pdf <파일.hwp|파일.hwpx|파일.hml> [옵션]");
     println!("      HWP/HWPX/HML 문서를 PDF로 내보내기 (기본: SVG 호환 backend)");
@@ -3699,6 +3828,602 @@ fn export_tables(args: &[String]) -> i32 {
             "  표{} [구역{}:문단{}]: {}행×{}열, 셀 {}개 (병합 {}개, 중첩 {}개)",
             t.index, t.section, t.paragraph, t.rows, t.cols, t.cell_count, merged, nested
         );
+    }
+    EXIT_OK
+}
+
+/// `table-to-csv` — 본문 최상위 표를 RFC 4180 CSV 로 내보낸다 (#3719 §6).
+///
+/// `export-tables` 의 격자 JSON 은 병합을 span 으로 보존하지만 표 계산기는 직사각
+/// 격자만 먹는다. 앵커 셀을 그대로 이어 붙이면 병합 행에서 열이 밀리므로,
+/// `table_csv::grid_to_csv` 가 격자를 채워서(덮인 칸 = 빈 문자열) 낸다.
+fn table_to_csv(args: &[String]) -> i32 {
+    use rhwp::document_core::queries::table_csv::grid_to_csv;
+    use rhwp::document_core::queries::table_extract::extract_tables;
+
+    let mut file_path: Option<&str> = None;
+    let mut table_arg: Option<usize> = None;
+    let mut out_path: Option<String> = None;
+    let mut bom = false;
+    let mut json_mode = false;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => json_mode = true,
+            "--bom" => bom = true,
+            "--table" => {
+                i += 1;
+                match args.get(i).map(|v| v.parse::<usize>()) {
+                    Some(Ok(value)) => table_arg = Some(value),
+                    _ => {
+                        eprintln!("오류: --table 뒤에 0 이상의 정수가 필요합니다.");
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            "-o" | "--out" | "--output" => {
+                i += 1;
+                match args.get(i) {
+                    Some(p) => out_path = Some(p.clone()),
+                    None => {
+                        eprintln!("오류: -o 뒤에 출력 경로가 필요합니다.");
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            other if other.starts_with('-') => {
+                eprintln!("알 수 없는 옵션: {other}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if file_path.replace(other).is_some() {
+                    eprintln!("오류: 입력 파일은 하나만 지정할 수 있습니다: {other}");
+                    return EXIT_USAGE;
+                }
+            }
+        }
+        i += 1;
+    }
+
+    let Some(file_path) = file_path else {
+        eprintln!(
+            "사용법: rhwp table-to-csv <파일.hwp|파일.hwpx> [--table <번호>] [-o <경로>] [--bom] [--json]"
+        );
+        return EXIT_USAGE;
+    };
+
+    let data = match fs::read(file_path) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
+            return EXIT_RUNTIME;
+        }
+    };
+    let doc = match rhwp::wasm_api::HwpDocument::from_bytes(&data) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: HWP 파싱 실패 - {}", e);
+            return EXIT_RUNTIME;
+        }
+    };
+
+    // 본문 최상위 표만 다룬다 — `edit set-cell`(resolve_table_cell)과 같은 좌표계라야
+    // 내보낸 CSV 의 표 번호를 그대로 되돌려 쓸 수 있다. 중첩 표는 v1 범위 밖이다.
+    let grids = extract_tables(doc.document());
+    let top_level: Vec<&_> = grids
+        .iter()
+        .filter(|g| g.container_path.is_empty())
+        .collect();
+    let selected: Vec<&_> = match table_arg {
+        Some(n) => match top_level.iter().find(|g| g.index == n) {
+            Some(g) => vec![*g],
+            None => {
+                eprintln!(
+                    "오류: 본문 최상위 표 {} 번이 없습니다 (최상위 표 {}개; 중첩 표는 v1 범위 밖).",
+                    n,
+                    top_level.len()
+                );
+                return EXIT_RUNTIME;
+            }
+        },
+        None => top_level.clone(),
+    };
+
+    // 표별 CSV 본문. 격자 채움과 인용은 전부 코어(table_csv)가 한다.
+    let bodies: Vec<(usize, u16, u16, String)> = selected
+        .iter()
+        .map(|g| (g.index, g.rows, g.cols, grid_to_csv(g)))
+        .collect();
+
+    // -o 의 뜻은 --table 유무로 갈린다: 한 표면 그 경로가 파일, 전부면 표별 파일을
+    // 담을 디렉터리다(export-svg 의 -o 규약과 같은 이유 — 산출물이 여러 개다).
+    let mut written: Vec<Option<String>> = vec![None; bodies.len()];
+    if let Some(dest) = out_path.as_deref() {
+        if table_arg.is_some() {
+            let body = &bodies[0].3;
+            if let Err(e) = write_csv_file(dest, body, bom) {
+                eprintln!("오류: 출력 쓰기 실패 - {}: {}", dest, e);
+                return EXIT_RUNTIME;
+            }
+            written[0] = Some(dest.to_string());
+        } else {
+            if let Err(e) = fs::create_dir_all(dest) {
+                eprintln!("오류: 출력 폴더 생성 실패 - {}: {}", dest, e);
+                return EXIT_RUNTIME;
+            }
+            for (slot, (index, _, _, body)) in written.iter_mut().zip(bodies.iter()) {
+                let path = Path::new(dest).join(format!("table{index}.csv"));
+                let shown = path.to_string_lossy().to_string();
+                if let Err(e) = write_csv_file(&shown, body, bom) {
+                    eprintln!("오류: 출력 쓰기 실패 - {}: {}", shown, e);
+                    return EXIT_RUNTIME;
+                }
+                *slot = Some(shown);
+            }
+        }
+    }
+
+    if json_mode {
+        let tables: Vec<serde_json::Value> = bodies
+            .iter()
+            .zip(written.iter())
+            .map(|((index, rows, cols, body), out)| {
+                let mut entry = serde_json::json!({
+                    "index": index,
+                    "rowCount": rows,
+                    "colCount": cols,
+                    "csv": body,
+                });
+                if let Some(p) = out {
+                    entry["output"] = serde_json::Value::String(p.clone());
+                }
+                entry
+            })
+            .collect();
+        let mut envelope = serde_json::json!({
+            "schemaVersion": "1.0",
+            "source": file_path,
+            "tableCount": tables.len(),
+            "tables": tables,
+            // BOM 은 **파일 인코딩** 표식이라 봉투의 csv 문자열에는 붙이지 않는다.
+            // 붙이면 JSON 을 그대로 파싱하는 소비자가 첫 셀 앞의 U+FEFF 를 값으로 읽는다.
+            "bom": bom,
+        });
+        if let Some(p) = out_path {
+            envelope["output"] = serde_json::Value::String(p);
+            envelope["outputFormat"] = serde_json::Value::String("csv".to_string());
+        }
+        println!("{envelope}");
+        return EXIT_OK;
+    }
+
+    if out_path.is_some() {
+        println!("CSV 내보내기 완료: {} (표 {}개)", file_path, bodies.len());
+        for out in written.iter().flatten() {
+            println!("  {out}");
+        }
+        return EXIT_OK;
+    }
+
+    // -o 도 --json 도 없으면 CSV 본문을 그대로 stdout 으로 흘린다 — 파이프 사용.
+    for (index, rows, cols, body) in &bodies {
+        if bodies.len() > 1 {
+            println!("# table{index} ({rows}x{cols})");
+        }
+        print!("{body}");
+    }
+    EXIT_OK
+}
+
+/// CSV 본문 하나를 파일로 쓴다 (선택적 UTF-8 BOM — 엑셀 한글 깨짐 방지).
+fn write_csv_file(path: &str, body: &str, bom: bool) -> std::io::Result<()> {
+    use rhwp::document_core::queries::table_csv::UTF8_BOM;
+    let mut bytes = Vec::with_capacity(body.len() + 3);
+    if bom {
+        bytes.extend_from_slice(UTF8_BOM.as_bytes());
+    }
+    bytes.extend_from_slice(body.as_bytes());
+    fs::write(path, bytes)
+}
+
+/// `csv-to-table` — CSV 내용으로 기존 표 N 의 셀을 덮어쓴다 (#3719 §7).
+///
+/// 표 **크기는 바꾸지 않는다**. CSV 의 행·열 수가 표와 다르면 한 칸도 쓰지 않고
+/// `invalid[]` 로 보고하며 exit 2 다 — 조용히 잘라내면 "표는 그럴듯한데 뒤쪽 데이터가
+/// 통째로 사라진" 보고서가 나오고, 에이전트는 렌더를 보지 않으므로 알아채지 못한다.
+/// 선검증 → 인메모리 적용 → 단 한 번 저장은 `run`(#3703)의 원자 실행과 같은 규약이다.
+fn csv_to_table(args: &[String]) -> i32 {
+    use rhwp::document_core::queries::table_csv::parse_csv;
+    use rhwp::document_core::queries::table_extract::extract_tables;
+
+    let mut file_path: Option<&str> = None;
+    let mut csv_path: Option<String> = None;
+    let mut table_arg: Option<usize> = None;
+    let mut out_path: Option<String> = None;
+    let mut dry_run = false;
+    let mut verify_mode = false;
+    let mut json_mode = false;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => json_mode = true,
+            "--dry-run" => dry_run = true,
+            "--verify" => verify_mode = true,
+            "--csv" => {
+                i += 1;
+                match args.get(i) {
+                    Some(p) => csv_path = Some(p.clone()),
+                    None => {
+                        eprintln!("오류: --csv 뒤에 CSV 파일 경로가 필요합니다.");
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            "--table" => {
+                i += 1;
+                match args.get(i).map(|v| v.parse::<usize>()) {
+                    Some(Ok(value)) => table_arg = Some(value),
+                    _ => {
+                        eprintln!("오류: --table 뒤에 0 이상의 정수가 필요합니다.");
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            "-o" | "--output" => {
+                i += 1;
+                match args.get(i) {
+                    Some(p) => out_path = Some(p.clone()),
+                    None => {
+                        eprintln!("오류: -o 뒤에 출력 파일 경로가 필요합니다.");
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            other if other.starts_with('-') => {
+                eprintln!("알 수 없는 옵션: {other}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if file_path.replace(other).is_some() {
+                    eprintln!("오류: 입력 파일은 하나만 지정할 수 있습니다: {other}");
+                    return EXIT_USAGE;
+                }
+            }
+        }
+        i += 1;
+    }
+
+    let (Some(file_path), Some(csv_path), Some(table_no)) = (file_path, csv_path, table_arg) else {
+        eprintln!(
+            "사용법: rhwp csv-to-table <파일.hwp|파일.hwpx> --csv <경로.csv> --table <번호> [-o <출력>] [--dry-run] [--verify] [--json]"
+        );
+        return EXIT_USAGE;
+    };
+
+    let csv_bytes = match fs::read(&csv_path) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: CSV 파일을 읽을 수 없습니다 - {}: {}", csv_path, e);
+            return EXIT_RUNTIME;
+        }
+    };
+    let csv_text = match String::from_utf8(csv_bytes) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("오류: CSV 가 UTF-8 이 아닙니다 - {}: {}", csv_path, e);
+            return EXIT_RUNTIME;
+        }
+    };
+
+    let bytes = match fs::read(file_path) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
+            return EXIT_RUNTIME;
+        }
+    };
+    let mut doc = match rhwp::wasm_api::HwpDocument::from_bytes(&bytes) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: HWP 파싱 실패 - {}", e);
+            return EXIT_RUNTIME;
+        }
+    };
+
+    // 표 좌표는 export-tables/set-cell 과 같은 격자 — 여기서 한 번만 뽑아 쓴다
+    // (칸마다 재추출하면 표 53개짜리 문서에서 O(칸수) 순회가 된다).
+    let (host_section, host_paragraph, rows, cols, anchors) = {
+        let grids = extract_tables(doc.document());
+        let Some(grid) = grids
+            .iter()
+            .find(|g| g.index == table_no && g.container_path.is_empty())
+        else {
+            let top_level = grids.iter().filter(|g| g.container_path.is_empty()).count();
+            eprintln!(
+                "오류: 본문 최상위 표 {} 번이 없습니다 (최상위 표 {}개; 중첩 표는 v1 범위 밖).",
+                table_no, top_level
+            );
+            return EXIT_RUNTIME;
+        };
+        let anchors: Vec<(u16, u16, String)> = grid
+            .cells
+            .iter()
+            .map(|c| (c.row, c.col, c.text.clone()))
+            .collect();
+        (grid.section, grid.paragraph, grid.rows, grid.cols, anchors)
+    };
+
+    // ── 1) 선검증: 한 칸도 쓰기 전에 전부 판정한다 ──
+    let mut invalid: Vec<serde_json::Value> = Vec::new();
+    let records = match parse_csv(&csv_text) {
+        Ok(r) => r,
+        Err(e) => {
+            invalid.push(serde_json::json!({
+                "reason": "csvParse",
+                "row": e.record,
+                "col": e.field,
+                "message": e.to_string(),
+            }));
+            Vec::new()
+        }
+    };
+
+    if invalid.is_empty() {
+        if records.len() != rows as usize {
+            invalid.push(serde_json::json!({
+                "reason": "rowCountMismatch",
+                "expected": rows,
+                "actual": records.len(),
+                "message": format!(
+                    "CSV 행 수 {} 가 표 {} 의 행 수 {} 와 다릅니다 — 표 크기는 바꾸지 않습니다.",
+                    records.len(), table_no, rows
+                ),
+            }));
+        }
+        for (r, record) in records.iter().enumerate() {
+            if record.len() != cols as usize {
+                invalid.push(serde_json::json!({
+                    "reason": "colCountMismatch",
+                    "row": r,
+                    "expected": cols,
+                    "actual": record.len(),
+                    "message": format!(
+                        "CSV {}행의 열 수 {} 가 표의 열 수 {} 와 다릅니다.",
+                        r, record.len(), cols
+                    ),
+                }));
+            }
+        }
+    }
+
+    if invalid.is_empty() {
+        for (r, record) in records.iter().enumerate() {
+            for (c, value) in record.iter().enumerate() {
+                let (row, col) = (r as u16, c as u16);
+                let is_anchor = anchors.iter().any(|(ar, ac, _)| *ar == row && *ac == col);
+                if !is_anchor {
+                    // 병합으로 덮인 칸에는 쓸 수 없다. 값이 있으면 조용히 버리지 않고
+                    // 거부한다 — 버리면 "썼다고 보고했는데 문서엔 없는" 데이터가 된다.
+                    if !value.is_empty() {
+                        invalid.push(serde_json::json!({
+                            "reason": "coveredCellNotEmpty",
+                            "row": r,
+                            "col": c,
+                            "message": format!(
+                                "({},{}) 는 병합으로 덮인 칸이라 쓸 수 없습니다 — 값은 앵커 칸에 두고 이 칸은 비우세요.",
+                                r, c
+                            ),
+                        }));
+                    }
+                    continue;
+                }
+                // 셀 안 줄바꿈·탭은 set-cell 과 같은 판정으로 거부한다 (문단 골격을
+                // 바꾸는 쓰기는 v1 범위 밖). 내보내기 방향은 인용해서 그대로 낸다.
+                if let Some(message) = set_cell_control_char_rejection(value) {
+                    invalid.push(serde_json::json!({
+                        "reason": "controlCharacter",
+                        "row": r,
+                        "col": c,
+                        "message": message,
+                    }));
+                }
+            }
+        }
+    }
+
+    if !invalid.is_empty() {
+        if json_mode {
+            let envelope = serde_json::json!({
+                "schemaVersion": "1.0",
+                "source": file_path,
+                "csv": csv_path,
+                "table": table_no,
+                "rowCount": rows,
+                "colCount": cols,
+                "changedCount": 0,
+                "changed": [],
+                "invalid": invalid,
+                "dryRun": dry_run,
+                "changedPages": serde_json::Value::Null,
+            });
+            println!("{envelope}");
+        } else {
+            for item in &invalid {
+                eprintln!(
+                    "오류: {}",
+                    item["message"]
+                        .as_str()
+                        .unwrap_or("CSV 가 표와 맞지 않습니다.")
+                );
+            }
+        }
+        return EXIT_USAGE;
+    }
+
+    // ── 2) 적용: 값이 실제로 달라지는 앵커 칸만 다시 쓴다 ──
+    let mut changed: Vec<serde_json::Value> = Vec::new();
+    for (row, col, old_text) in &anchors {
+        let Some(new_text) = records
+            .get(*row as usize)
+            .and_then(|r| r.get(*col as usize))
+        else {
+            continue;
+        };
+        if new_text == old_text {
+            continue;
+        }
+        // 좌표 해석은 set-cell 과 같은 경로(resolve_table_cell)를 쓴다 — 격자 배열
+        // 위치와 모델 셀 인덱스가 어긋날 수 있어(손상 방어 필터) 직접 세지 않는다.
+        let (sec, para, ctrl, cell_idx, para_lens, old) =
+            match resolve_table_cell(doc.document(), table_no, *row, *col) {
+                Ok(v) => v,
+                Err(CellResolveError::Usage(msg)) | Err(CellResolveError::Runtime(msg)) => {
+                    eprintln!("{msg}");
+                    return EXIT_RUNTIME;
+                }
+            };
+        if !dry_run {
+            for (pi, len) in para_lens.iter().enumerate() {
+                if *len == 0 {
+                    continue;
+                }
+                if let Err(e) = doc.delete_text_in_cell(
+                    sec as u32,
+                    para as u32,
+                    ctrl as u32,
+                    cell_idx as u32,
+                    pi as u32,
+                    0,
+                    *len as u32,
+                ) {
+                    eprintln!(
+                        "오류: 셀 비우기 실패({},{} 문단 {}) - {:?}",
+                        row, col, pi, e
+                    );
+                    return EXIT_RUNTIME;
+                }
+            }
+            if !new_text.is_empty() {
+                if let Err(e) = doc.insert_text_in_cell(
+                    sec as u32,
+                    para as u32,
+                    ctrl as u32,
+                    cell_idx as u32,
+                    0,
+                    0,
+                    new_text,
+                ) {
+                    eprintln!("오류: 셀 쓰기 실패({},{}) - {:?}", row, col, e);
+                    return EXIT_RUNTIME;
+                }
+            }
+        }
+        changed.push(serde_json::json!({
+            "row": row, "col": col, "oldText": old, "newText": new_text,
+        }));
+    }
+
+    // ── 3) 저장 ──
+    // set-cell 과 달리 글자색을 검정으로 덮지 않는다. csv-to-table 은 빈 서식을 채우는
+    // 것이 아니라 **이미 서식이 잡힌 보고서의 값을 갱신**하는 축이라, 표 머리·강조
+    // 스타일을 일괄로 지우면 눈에 보이는 회귀가 된다.
+    let out_format = edit_output_format(&bytes, out_path.as_deref());
+    let output_path = out_path.unwrap_or_else(|| {
+        let stem = Path::new(file_path)
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_else(|| "output".to_string());
+        format!("{}_csv.{}", stem, out_format.ext())
+    });
+
+    let mut verify_report = serde_json::Value::Null;
+    let mut verify_failed = false;
+    if !dry_run {
+        let out_bytes = match edit_serialize(&mut doc, out_format) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!(
+                    "오류: {} 직렬화 실패 - {}",
+                    out_format.label().to_uppercase(),
+                    e
+                );
+                return EXIT_RUNTIME;
+            }
+        };
+        if let Err(e) = fs::write(&output_path, &out_bytes) {
+            eprintln!("오류: 출력 쓰기 실패 - {}: {}", output_path, e);
+            return EXIT_RUNTIME;
+        }
+        if verify_mode {
+            let cross = out_format == EditOutputFormat::Hwp
+                && rhwp::parser::detect_format(&bytes) == rhwp::parser::FileFormat::Hwpx;
+            let (report, failed) = edit_verify_report(&doc, &out_bytes, cross);
+            verify_report = report;
+            verify_failed = failed;
+        }
+    }
+
+    // 눈검증 대상 쪽 — 표 호스트 문단이 걸친 쪽 전부(분할 표 포함, #3712).
+    let changed_pages = if dry_run {
+        serde_json::Value::Null
+    } else {
+        match doc.pages_covering_paragraphs(&[(host_section, host_paragraph)]) {
+            Some(pages) => serde_json::json!(pages),
+            None => serde_json::Value::Null,
+        }
+    };
+
+    if json_mode {
+        let mut envelope = serde_json::json!({
+            "schemaVersion": "1.0",
+            "source": file_path,
+            "csv": csv_path,
+            "table": table_no,
+            "rowCount": rows,
+            "colCount": cols,
+            "changedCount": changed.len(),
+            "changed": changed,
+            "invalid": [],
+            "dryRun": dry_run,
+            "changedPages": changed_pages,
+        });
+        if !dry_run {
+            envelope["output"] = serde_json::Value::String(output_path.clone());
+            envelope["outputFormat"] = serde_json::Value::String(out_format.label().to_string());
+            envelope["verify"] = verify_report.clone();
+        }
+        println!("{envelope}");
+        if verify_failed {
+            process::exit(3);
+        }
+        return EXIT_OK;
+    }
+
+    if dry_run {
+        println!(
+            "변경 예정: {} 표{} — {}행×{}열 중 {}칸",
+            file_path,
+            table_no,
+            rows,
+            cols,
+            changed.len()
+        );
+    } else {
+        println!(
+            "표 기록 완료: {} → {} — 표{} {}행×{}열 중 {}칸",
+            file_path,
+            output_path,
+            table_no,
+            rows,
+            cols,
+            changed.len()
+        );
+    }
+    if verify_failed {
+        eprintln!("검증 실패(--verify): 저장본 재파싱 IR 차이 — 상세는 --json 또는 ir-diff");
+        process::exit(3);
     }
     EXIT_OK
 }

--- a/tests/table_csv_contract.rs
+++ b/tests/table_csv_contract.rs
@@ -1,0 +1,760 @@
+//! [#3719 §6-7] `table-to-csv` / `csv-to-table` 계약 회귀 테스트.
+//!
+//! 이 축의 값은 두 가지다.
+//!
+//! 1. **병합 격자 채움** — `Table.cells` 는 앵커 셀만 담고 덮인 좌표는 목록에 없다.
+//!    앵커를 그대로 이어 붙이면 병합이 있는 행에서 열이 밀린 CSV 가 나오고, 그것은
+//!    오류 없이 틀린 데이터다. 그래서 모든 레코드의 필드 수가 `colCount` 와 같아야 한다.
+//! 2. **조용한 절삭 금지** — CSV 의 행·열 수가 표와 다르면 한 칸도 쓰지 않고 `invalid[]`
+//!    로 보고하며 사용법 오류(2)로 끝난다. 잘라 쓰면 "표는 그럴듯한데 뒤쪽 데이터가
+//!    통째로 사라진" 보고서가 남는다.
+//!
+//! 종료 코드는 #2707 계약(0/1/2)을, 봉투는 `schemaVersion` 규약을 따른다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// 표 53개(머리말 표 포함)·병합 다수의 실물 지자체 보고서 양식.
+/// **본문 최상위 표 번호가 0 에서 시작하지 않는다** — 0 번은 머리말 안의 표다.
+const SAMPLE: &str = "samples/2025년 기부·답례품 실적 지자체 보고서_양식.hwpx";
+
+fn sample() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn parse_stdout_json(args: &[&str], output: &Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout 이 순수 JSON 이 아닙니다 ({e}).\n{}",
+            describe(args, output)
+        )
+    })
+}
+
+fn temp_path(label: &str) -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "rhwp-table-csv-{label}-{}-{nonce}",
+        std::process::id()
+    ))
+}
+
+/// 병합이 있는 **본문 최상위** 표 하나를 실제 문서에서 고른다.
+///
+/// 표 번호를 상수로 박으면 샘플이 바뀔 때 조용히 다른 표를 검사하게 된다 —
+/// `export-tables` 가 보고하는 실제 `index` 를 쓴다(containerPath 가 없는 것만).
+fn pick_merged_top_level_table() -> (usize, u64, u64) {
+    let p = sample();
+    let args = ["export-tables", p.to_str().unwrap(), "--json"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    let v = parse_stdout_json(&args, &out);
+    let tables = v["tables"].as_array().expect("tables 배열");
+    let picked = tables
+        .iter()
+        .filter(|t| t["containerPath"].is_null())
+        .find(|t| {
+            t["cells"]
+                .as_array()
+                .map(|cells| {
+                    cells
+                        .iter()
+                        .any(|c| c["rowSpan"].as_u64() > Some(1) || c["colSpan"].as_u64() > Some(1))
+                })
+                .unwrap_or(false)
+        })
+        .unwrap_or_else(|| panic!("병합 있는 최상위 표를 찾지 못했습니다"));
+    (
+        picked["index"].as_u64().expect("index") as usize,
+        picked["rows"].as_u64().expect("rows"),
+        picked["cols"].as_u64().expect("cols"),
+    )
+}
+
+/// RFC 4180 판독기 — 계약이 말하는 인용 규칙을 테스트 쪽에서 **독립 구현**해 대조한다.
+/// 산출과 같은 코드를 재사용하면 둘 다 틀렸을 때 통과하는 순환 검증이 된다.
+fn read_csv(input: &str) -> Vec<Vec<String>> {
+    let chars: Vec<char> = input.chars().collect();
+    let mut records = Vec::new();
+    let mut record: Vec<String> = Vec::new();
+    let mut field = String::new();
+    let mut i = 0usize;
+    let mut quoted = false;
+    while i < chars.len() {
+        let c = chars[i];
+        if quoted {
+            if c == '"' {
+                if chars.get(i + 1) == Some(&'"') {
+                    field.push('"');
+                    i += 1;
+                } else {
+                    quoted = false;
+                }
+            } else {
+                field.push(c);
+            }
+        } else if c == '"' && field.is_empty() {
+            quoted = true;
+        } else if c == ',' {
+            record.push(std::mem::take(&mut field));
+        } else if c == '\n' {
+            record.push(std::mem::take(&mut field));
+            records.push(std::mem::take(&mut record));
+        } else if c != '\r' {
+            field.push(c);
+        }
+        i += 1;
+    }
+    if !field.is_empty() || !record.is_empty() {
+        record.push(field);
+        records.push(record);
+    }
+    records
+}
+
+/// 레코드 배열을 다시 CSV 로 조립한다 (테스트 입력을 만드는 쪽 — 역시 독립 구현).
+fn write_csv(records: &[Vec<String>]) -> String {
+    let mut out = String::new();
+    for record in records {
+        let line: Vec<String> = record
+            .iter()
+            .map(|f| {
+                if f.contains([',', '"', '\r', '\n']) {
+                    format!("\"{}\"", f.replace('"', "\"\""))
+                } else {
+                    f.clone()
+                }
+            })
+            .collect();
+        out.push_str(&line.join(","));
+        out.push_str("\r\n");
+    }
+    out
+}
+
+// ── table-to-csv ───────────────────────────────────────────────────────────
+
+#[test]
+fn table_to_csv_json_envelope_contract() {
+    let p = sample();
+    let args = ["table-to-csv", p.to_str().unwrap(), "--json"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_stdout_json(&args, &output);
+    assert_eq!(v["schemaVersion"], "1.0", "{v}");
+    assert!(v["source"].is_string(), "{v}");
+    assert_eq!(v["bom"], false, "기본은 BOM 없음: {v}");
+    let tables = v["tables"].as_array().expect("tables 배열");
+    assert!(!tables.is_empty(), "표가 0건이면 이 계약은 공허하다: {v}");
+    assert_eq!(v["tableCount"].as_u64(), Some(tables.len() as u64), "{v}");
+    for t in tables {
+        assert!(t["index"].is_u64(), "{t}");
+        assert!(t["rowCount"].is_u64(), "{t}");
+        assert!(t["colCount"].is_u64(), "{t}");
+        assert!(t["csv"].is_string(), "{t}");
+    }
+}
+
+#[test]
+fn merged_table_csv_is_a_full_rectangle() {
+    // 이 축의 핵심 — 병합으로 덮인 칸을 채우지 않으면 그 행만 필드가 모자라 **열이 밀린다**.
+    let (index, rows, cols) = pick_merged_top_level_table();
+    let p = sample();
+    let table = index.to_string();
+    let args = [
+        "table-to-csv",
+        p.to_str().unwrap(),
+        "--table",
+        table.as_str(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_stdout_json(&args, &output);
+    let entry = &v["tables"][0];
+    assert_eq!(entry["index"].as_u64(), Some(index as u64), "{v}");
+    assert_eq!(entry["rowCount"].as_u64(), Some(rows), "{v}");
+    assert_eq!(entry["colCount"].as_u64(), Some(cols), "{v}");
+
+    let records = read_csv(entry["csv"].as_str().expect("csv 문자열"));
+    assert_eq!(
+        records.len(),
+        rows as usize,
+        "CSV 레코드 수가 rowCount 와 달라 격자가 아닙니다: {v}"
+    );
+    for (r, record) in records.iter().enumerate() {
+        assert_eq!(
+            record.len(),
+            cols as usize,
+            "{r}행의 필드 수 {} 가 colCount {cols} 와 다릅니다 — 병합 채움이 빠지면 \
+             이 행부터 열이 통째로 밀립니다: {v}",
+            record.len()
+        );
+    }
+}
+
+#[test]
+fn rfc4180_quoting_survives_a_round_trip_through_the_document() {
+    // 쉼표·따옴표가 든 값을 실제 문서 셀에 넣고 다시 CSV 로 뽑아, 인용이 값 자체를
+    // 바꾸지 않는지 본다. 인용이 없거나 `""` 이스케이프가 빠지면 열 수부터 어긋난다.
+    let (index, rows, cols) = pick_merged_top_level_table();
+    assert!(rows >= 1 && cols >= 1, "표가 비었습니다");
+    let p = sample();
+    let table = index.to_string();
+    let edited = temp_path("quote.hwpx");
+    let needle = "가,나\"다";
+    let set = run(&[
+        "edit",
+        "set-cell",
+        p.to_str().unwrap(),
+        "--table",
+        table.as_str(),
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        needle,
+        "-o",
+        edited.to_str().unwrap(),
+        "--json",
+    ]);
+    assert_eq!(
+        set.status.code(),
+        Some(0),
+        "set-cell 실패:\n{}",
+        String::from_utf8_lossy(&set.stderr)
+    );
+
+    let args = [
+        "table-to-csv",
+        edited.to_str().unwrap(),
+        "--table",
+        table.as_str(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_stdout_json(&args, &output);
+    let csv = v["tables"][0]["csv"].as_str().expect("csv");
+    assert!(
+        csv.starts_with("\"가,나\"\"다\""),
+        "RFC 4180 인용(\" → \"\")이 아닙니다: {csv:?}"
+    );
+    let records = read_csv(csv);
+    assert_eq!(
+        records[0][0], needle,
+        "판독 결과가 원값과 다릅니다: {csv:?}"
+    );
+    assert_eq!(
+        records[0].len(),
+        cols as usize,
+        "인용 때문에 열이 밀렸습니다"
+    );
+    let _ = std::fs::remove_file(&edited);
+}
+
+#[test]
+fn bom_flag_only_affects_the_file_not_the_envelope() {
+    // BOM 은 파일 인코딩 표식이다. 봉투의 csv 문자열에 섞으면 JSON 을 그대로 쓰는
+    // 소비자가 U+FEFF 를 첫 셀 값의 일부로 읽는다.
+    let (index, _, _) = pick_merged_top_level_table();
+    let p = sample();
+    let table = index.to_string();
+    let out = temp_path("bom.csv");
+    let args = [
+        "table-to-csv",
+        p.to_str().unwrap(),
+        "--table",
+        table.as_str(),
+        "-o",
+        out.to_str().unwrap(),
+        "--bom",
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_stdout_json(&args, &output);
+    assert_eq!(v["bom"], true, "{v}");
+    assert_eq!(v["outputFormat"], "csv", "{v}");
+    assert!(!v["tables"][0]["csv"]
+        .as_str()
+        .expect("csv")
+        .starts_with('\u{feff}'));
+
+    let bytes = std::fs::read(&out).expect("CSV 파일");
+    assert_eq!(
+        &bytes[..3],
+        &[0xEF, 0xBB, 0xBF],
+        "파일에는 BOM 이 있어야 합니다"
+    );
+    let _ = std::fs::remove_file(&out);
+}
+
+#[test]
+fn unknown_top_level_table_is_a_runtime_error_with_silent_stdout() {
+    let p = sample();
+    let args = [
+        "table-to-csv",
+        p.to_str().unwrap(),
+        "--table",
+        "99999",
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "실패 경로 stdout 은 0바이트여야 합니다: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn missing_arguments_are_usage_errors_with_silent_stdout() {
+    let p = sample();
+    let path = p.to_str().unwrap();
+    let cases: Vec<Vec<&str>> = vec![
+        vec!["table-to-csv"],
+        vec!["csv-to-table"],
+        vec!["csv-to-table", path],
+    ];
+    for args in cases {
+        let output = run(&args);
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "{}",
+            describe(&args, &output)
+        );
+        assert!(
+            output.stdout.is_empty(),
+            "사용법 오류 stdout 은 0바이트여야 합니다: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+    }
+}
+
+// ── csv-to-table ───────────────────────────────────────────────────────────
+
+/// 표 그대로의 CSV 를 얻는다 (왕복 기준선).
+fn csv_of(table: usize) -> String {
+    let p = sample();
+    let t = table.to_string();
+    let args = [
+        "table-to-csv",
+        p.to_str().unwrap(),
+        "--table",
+        t.as_str(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    parse_stdout_json(&args, &output)["tables"][0]["csv"]
+        .as_str()
+        .expect("csv")
+        .to_string()
+}
+
+#[test]
+fn identical_csv_writes_nothing_and_verifies() {
+    // 같은 내용을 되쓰면 바뀔 칸이 0 이어야 한다 — 왕복(내보내기→되넣기)이 값을
+    // 건드리지 않는다는 뜻이다. --verify 로 저장본 재파싱까지 함께 판정한다.
+    let (index, rows, cols) = pick_merged_top_level_table();
+    let csv_file = temp_path("same.csv");
+    std::fs::write(&csv_file, csv_of(index)).expect("CSV 쓰기");
+    let out = temp_path("same.hwpx");
+    let p = sample();
+    let t = index.to_string();
+    let args = [
+        "csv-to-table",
+        p.to_str().unwrap(),
+        "--csv",
+        csv_file.to_str().unwrap(),
+        "--table",
+        t.as_str(),
+        "-o",
+        out.to_str().unwrap(),
+        "--verify",
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_stdout_json(&args, &output);
+    assert_eq!(v["schemaVersion"], "1.0", "{v}");
+    assert_eq!(v["table"].as_u64(), Some(index as u64), "{v}");
+    assert_eq!(v["rowCount"].as_u64(), Some(rows), "{v}");
+    assert_eq!(v["colCount"].as_u64(), Some(cols), "{v}");
+    assert_eq!(
+        v["changedCount"].as_u64(),
+        Some(0),
+        "왕복이 값을 바꿨다: {v}"
+    );
+    assert_eq!(v["invalid"].as_array().map(Vec::len), Some(0), "{v}");
+    assert_eq!(v["verify"]["identical"], true, "{v}");
+    assert_eq!(v["outputFormat"], "hwpx", "입력 형식 보존: {v}");
+    let pages = v["changedPages"].as_array().expect("changedPages 배열");
+    assert!(!pages.is_empty(), "눈검증 대상 쪽이 비었습니다: {v}");
+    assert!(out.exists(), "산출물이 없습니다");
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&csv_file);
+}
+
+#[test]
+fn value_written_by_csv_is_readable_back() {
+    let (index, _, cols) = pick_merged_top_level_table();
+    let mut records = read_csv(&csv_of(index));
+    let marker = "표값-2026";
+    records[0][0] = marker.to_string();
+    let body = write_csv(&records);
+    let csv_file = temp_path("write.csv");
+    std::fs::write(&csv_file, &body).expect("CSV 쓰기");
+
+    let out = temp_path("write.hwpx");
+    let p = sample();
+    let t = index.to_string();
+    let args = [
+        "csv-to-table",
+        p.to_str().unwrap(),
+        "--csv",
+        csv_file.to_str().unwrap(),
+        "--table",
+        t.as_str(),
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_stdout_json(&args, &output);
+    assert_eq!(v["changedCount"].as_u64(), Some(1), "{v}");
+    assert_eq!(v["changed"][0]["newText"], marker, "{v}");
+
+    // 저장본을 다시 CSV 로 뽑아 값이 실제로 문서에 들어갔는지 본다.
+    let back = run(&[
+        "table-to-csv",
+        out.to_str().unwrap(),
+        "--table",
+        t.as_str(),
+        "--json",
+    ]);
+    assert_eq!(back.status.code(), Some(0));
+    let bv: serde_json::Value = serde_json::from_slice(&back.stdout).expect("봉투");
+    let round = read_csv(bv["tables"][0]["csv"].as_str().expect("csv"));
+    assert_eq!(round[0][0], marker, "되읽은 값이 다릅니다");
+    assert_eq!(round[0].len(), cols as usize, "열 수가 달라졌습니다");
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&csv_file);
+}
+
+#[test]
+fn dry_run_writes_no_file() {
+    let (index, _, _) = pick_merged_top_level_table();
+    let mut records = read_csv(&csv_of(index));
+    records[0][0] = "미리보기".to_string();
+    let body = write_csv(&records);
+    let csv_file = temp_path("dry.csv");
+    std::fs::write(&csv_file, &body).expect("CSV 쓰기");
+    let out = temp_path("dry.hwpx");
+    let p = sample();
+    let t = index.to_string();
+    let args = [
+        "csv-to-table",
+        p.to_str().unwrap(),
+        "--csv",
+        csv_file.to_str().unwrap(),
+        "--table",
+        t.as_str(),
+        "-o",
+        out.to_str().unwrap(),
+        "--dry-run",
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_stdout_json(&args, &output);
+    assert_eq!(v["dryRun"], true, "{v}");
+    assert_eq!(v["changedCount"].as_u64(), Some(1), "{v}");
+    assert!(v["changedPages"].is_null(), "예측 목록으로 오인 금지: {v}");
+    assert!(v["output"].is_null(), "dry-run 에는 산출물이 없다: {v}");
+    assert!(!out.exists(), "dry-run 이 파일을 썼습니다");
+    let _ = std::fs::remove_file(&csv_file);
+}
+
+#[test]
+fn row_count_mismatch_is_invalid_and_writes_nothing() {
+    // 조용한 절삭 금지 — 행이 하나 모자라면 한 칸도 쓰지 않는다.
+    let (index, _, _) = pick_merged_top_level_table();
+    let mut records = read_csv(&csv_of(index));
+    records.pop();
+    let body = write_csv(&records);
+    let csv_file = temp_path("shortrow.csv");
+    std::fs::write(&csv_file, &body).expect("CSV 쓰기");
+    let out = temp_path("shortrow.hwpx");
+    let p = sample();
+    let t = index.to_string();
+    let args = [
+        "csv-to-table",
+        p.to_str().unwrap(),
+        "--csv",
+        csv_file.to_str().unwrap(),
+        "--table",
+        t.as_str(),
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_stdout_json(&args, &output);
+    let invalid = v["invalid"].as_array().expect("invalid 배열");
+    assert!(
+        invalid.iter().any(|i| i["reason"] == "rowCountMismatch"),
+        "{v}"
+    );
+    assert_eq!(v["changedCount"].as_u64(), Some(0), "{v}");
+    assert!(!out.exists(), "invalid 인데 파일을 썼습니다");
+    let _ = std::fs::remove_file(&csv_file);
+}
+
+#[test]
+fn col_count_mismatch_is_invalid_and_writes_nothing() {
+    let (index, _, _) = pick_merged_top_level_table();
+    let mut records = read_csv(&csv_of(index));
+    records[0].push("남는열".to_string());
+    let body = write_csv(&records);
+    let csv_file = temp_path("longcol.csv");
+    std::fs::write(&csv_file, &body).expect("CSV 쓰기");
+    let out = temp_path("longcol.hwpx");
+    let p = sample();
+    let t = index.to_string();
+    let args = [
+        "csv-to-table",
+        p.to_str().unwrap(),
+        "--csv",
+        csv_file.to_str().unwrap(),
+        "--table",
+        t.as_str(),
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_stdout_json(&args, &output);
+    assert!(v["invalid"]
+        .as_array()
+        .expect("invalid")
+        .iter()
+        .any(|i| i["reason"] == "colCountMismatch"));
+    assert!(!out.exists(), "invalid 인데 파일을 썼습니다");
+    let _ = std::fs::remove_file(&csv_file);
+}
+
+#[test]
+fn value_in_a_merged_covered_cell_is_invalid() {
+    // 덮인 칸에는 쓸 수 없다. 조용히 버리면 "썼다고 보고했는데 문서엔 없는" 값이 된다.
+    let (index, rows, cols) = pick_merged_top_level_table();
+    let p = sample();
+    let t = index.to_string();
+    let args = ["export-tables", p.to_str().unwrap(), "--json"];
+    let tv = parse_stdout_json(&args, &run(&args));
+    let grid = tv["tables"]
+        .as_array()
+        .expect("tables")
+        .iter()
+        .find(|t| t["index"].as_u64() == Some(index as u64))
+        .expect("표");
+    let anchors: Vec<(u64, u64)> = grid["cells"]
+        .as_array()
+        .expect("cells")
+        .iter()
+        .map(|c| (c["row"].as_u64().unwrap(), c["col"].as_u64().unwrap()))
+        .collect();
+    let covered = (0..rows)
+        .flat_map(|r| (0..cols).map(move |c| (r, c)))
+        .find(|rc| !anchors.contains(rc))
+        .expect("병합으로 덮인 칸이 있어야 합니다");
+
+    let mut records = read_csv(&csv_of(index));
+    records[covered.0 as usize][covered.1 as usize] = "덮인칸값".to_string();
+    let body = write_csv(&records);
+    let csv_file = temp_path("covered.csv");
+    std::fs::write(&csv_file, &body).expect("CSV 쓰기");
+    let out = temp_path("covered.hwpx");
+    let args = [
+        "csv-to-table",
+        p.to_str().unwrap(),
+        "--csv",
+        csv_file.to_str().unwrap(),
+        "--table",
+        t.as_str(),
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_stdout_json(&args, &output);
+    assert!(v["invalid"]
+        .as_array()
+        .expect("invalid")
+        .iter()
+        .any(|i| i["reason"] == "coveredCellNotEmpty"));
+    assert!(!out.exists(), "invalid 인데 파일을 썼습니다");
+    let _ = std::fs::remove_file(&csv_file);
+}
+
+#[test]
+fn malformed_csv_is_invalid_not_a_panic() {
+    let (index, _, _) = pick_merged_top_level_table();
+    let csv_file = temp_path("bad.csv");
+    std::fs::write(&csv_file, "\"닫히지 않은 따옴표").expect("CSV 쓰기");
+    let p = sample();
+    let t = index.to_string();
+    let args = [
+        "csv-to-table",
+        p.to_str().unwrap(),
+        "--csv",
+        csv_file.to_str().unwrap(),
+        "--table",
+        t.as_str(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_stdout_json(&args, &output);
+    assert!(v["invalid"]
+        .as_array()
+        .expect("invalid")
+        .iter()
+        .any(|i| i["reason"] == "csvParse"));
+    let _ = std::fs::remove_file(&csv_file);
+}
+
+// ── 자기서술 정합 ───────────────────────────────────────────────────────────
+
+#[test]
+fn capabilities_and_mcp_declare_both_commands() {
+    // 드리프트 가드: 명령·MCP 도구·help 세 곳이 함께 갱신돼야 에이전트가 쓸 수 있다.
+    let cap = parse_stdout_json(&["capabilities"], &run(&["capabilities"]));
+    let names: Vec<&str> = cap["commands"]
+        .as_array()
+        .expect("commands")
+        .iter()
+        .filter_map(|c| c["name"].as_str())
+        .collect();
+    for expected in ["table-to-csv", "csv-to-table"] {
+        assert!(names.contains(&expected), "capabilities 누락: {expected}");
+    }
+
+    let mcp = parse_stdout_json(&["capabilities", "--mcp"], &run(&["capabilities", "--mcp"]));
+    let tools = mcp["tools"].as_array().expect("tools");
+    for (tool_name, command) in [
+        ("hwp_table_to_csv", "table-to-csv"),
+        ("hwp_csv_to_table", "csv-to-table"),
+    ] {
+        let t = tools
+            .iter()
+            .find(|t| t["name"] == tool_name)
+            .unwrap_or_else(|| panic!("MCP 도구 누락: {tool_name}"));
+        assert_eq!(t["cli"]["command"], command, "{t}");
+        assert_eq!(t["inputSchema"]["type"], "object", "{t}");
+        assert!(t["inputSchema"]["properties"].is_object(), "{t}");
+        assert!(t["inputSchema"]["required"].is_array(), "{t}");
+    }
+
+    let help = run(&["--help"]);
+    let help_text = String::from_utf8_lossy(&help.stdout);
+    for expected in ["  table-to-csv ", "  csv-to-table "] {
+        assert!(
+            help_text.contains(expected),
+            "--help 에 {expected:?} 가 없습니다"
+        );
+    }
+}


### PR DESCRIPTION
#3719 §6-7. 표를 CSV 로 꺼내고 되돌린다.

## 왜

표가 든 보고서를 에이전트가 다루려면 지금은 `export-tables` 로 구조를 받아 셀 좌표를
하나씩 계산해 `set-cell` 을 반복해야 한다. 표 하나에 수십 번의 왕복이다. 그런데 표 데이터는
**CSV 가 자연스러운 모양**이고, 에이전트도 사람도 CSV 는 그냥 다룰 줄 안다.

## 무엇

| 명령 | |
|---|---|
| `rhwp table-to-csv <파일> --table <N> [--bom] [-o] [--json]` | 표 → CSV |
| `rhwp csv-to-table <파일> --table <N> --csv <경로> [--dry-run] [--verify] [-o] [--json]` | CSV → 표 |

MCP 도구 `hwp_table_to_csv` · `hwp_csv_to_table` 동시 등록.

## 병합 셀이 이 PR 의 급소다

병합 셀을 **격자로 채우지 않으면 열이 밀린다.** 3×3 표(앵커 6개, 표 index 2)로 실측:

| | 필드 수 |
|---|---|
| 격자 채움 (이 PR) | `[3, 3, 3]` |
| 채우지 않으면 | `[3, 2, 1]` — **2행부터 열이 어긋난다** |

되돌릴 때는 반대로, 덮인 셀 자리에 값이 들어오면 `coveredCellNotEmpty` 로 **거부**한다.
병합을 조용히 깨고 쓰면 표 구조가 망가진다.

## 실측 (샘플 표 53개)

- 최상위 표 인덱스는 **1부터**다(0은 머리표). 테스트는 `export-tables` 에서 실제 `index` 를
  집어 쓴다 — 하드코딩 없음
- 왕복: `changedCount: 0`, `verify: {"identical": true, "diffCount": 0}`, `changedPages: [1]`
- 한 셀만 수정: `changedCount: 1`, `changedPages: [1, 2]` (재내보내기로 값 확인)
- `rowCountMismatch` / `coveredCellNotEmpty` / `csvParse` → exit 2, **산출 파일 미생성**
- 실패 경로(인자 없음 exit 2 / 없는 표 exit 1) stdout **0바이트**
- `--bom` 의 `EF BB BF` 는 **파일에만** 들어가고 봉투의 `csv` 문자열엔 없다

검증: `table_csv_contract` **14 passed** · `cli_json_contract` **26** · `mcp_server_contract` **22** ·
코어 단위 **8** · `clippy -D warnings` **0** · rustfmt clean. 드리프트 가드 5종 전부 통과.

## 리뷰 논점 2개

**1. `csv-to-table` 은 셀 서식을 보존한다** — `edit set-cell`(#3391)과 **의도적으로 다르다.**
이 축은 이미 서식이 잡힌 보고서의 값을 갱신하는 용도라, 머리행·강조 서식을 검게 지우면
눈에 보이는 회귀다. 서식이 없는 양식 채우기는 `set-cell`/`fill-fields` 가 계속 담당한다.

**2. 셀 안 줄바꿈은 내보내기 전용이다.** `table-to-csv` 는 RFC 4180 으로 따옴표 처리하지만
`csv-to-table` 은 `controlCharacter` 로 거부한다(`set_cell_control_char_rejection` 과 같은 규칙).
셀에 문단 구조를 써 넣는 건 v1 범위 밖이라고 봤다. 따라서 **여러 문단 셀은 무손실 왕복이
아니다** — 「남은 것」에 적었다.

## 범위 밖 (명시)

중첩표·글상자/머리말 안의 표는 `set-cell` 과 같은 v1 경계다. 표 크기 변경(행 추가·삭제)은
이 계약이 아니다.
