### PR TITLE
[#3719 §6-5] edit insert-image — 도장·서명 삽입 + --verify 가 정상 삽입을 항상 실패로 보고하던 코어 결함 수정

### DIFF
--- a/mydocs/report/task_m100_insert_image/README.md
+++ b/mydocs/report/task_m100_insert_image/README.md
@@ -1,0 +1,180 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_insert_image/README.md
+last_verified: 2026-08-02
+---
+
+# `edit insert-image` 처리 기록 — 도장·서명 삽입 (로드맵 #3719 §6-5)
+
+## 문제
+
+에이전트가 실물 서식을 끝까지 채워도 **직인·서명을 얹을 표면이 없었다.** 누름틀
+(`edit fill-fields`)·표 칸(`edit set-cell`)·체크박스는 모두 CLI 로 닿는데, 도장 하나
+때문에 사람이 한컴을 열어야 했고 그 순간 자동화 사슬이 끊긴다. 제출용 문서에서
+도장은 장식이 아니라 **접수 요건**이다.
+
+코어에는 이미 검증된 그림 삽입 경로(`insert_picture_native`, studio 가 쓰는 것)가
+있었으나 브라우저 밖에서 부를 방법이 없었다.
+
+## 구현
+
+새 삽입 로직을 만들지 않았다. 기존 코어를 그대로 부르고, 인자 파싱·저장·봉투·
+`--verify`·`changedPages` 는 형제 명령 `edit set-cell`(#3381) 의 형태를 따랐다.
+
+### 명령
+
+```
+rhwp edit insert-image <파일> --image <경로> [--page N] [--x N --y N]
+       [--width N --height N] [-o <경로>] [--dry-run] [--verify] [--json]
+```
+
+봉투: `{schemaVersion, source, image, page, x, y, width, height, binDataId,
+dryRun, overflow, changedPages, output, outputFormat, verify}`
+(`output`·`outputFormat`·`verify` 는 실행했을 때만 — dry-run 은 산출이 없다.)
+
+### 재사용한 코어
+
+| 쓰임 | 함수 | 위치 |
+| --- | --- | --- |
+| 그림 삽입 | `DocumentCore::insert_picture_native` | `src/document_core/commands/object_ops/picture.rs:1433` |
+| 쪽 → 앵커 문단 | `DocumentCore::dump_page_items_json` | `src/document_core/queries/rendering.rs:4907` |
+| 눈검증 대상 쪽 | `DocumentCore::pages_covering_paragraphs` | `src/document_core/queries/changed_pages.rs:18` |
+| 산출 형식 결정 | `edit_output_format` (#3383) | `src/main.rs` |
+| 직렬화 | `edit_serialize` → `export_hwp_with_adapter` / `export_hwpx_native` | `src/main.rs` |
+| 저장 후 자기검증 | `edit_verify_report` (#3702) → `diff_documents` | `src/main.rs` |
+
+`insert_picture_native` 의 **본문 floating 분기**(용지 기준 offset,
+`treat_as_char=false`, `TextWrap::Square`)를 쓴다. 이는 한컴 native 의 그림 삽입
+기본값과 같고(사용자 시연 2026-05-30 근거로 #1151 v9 에서 맞춘 동작), 도장처럼
+"본문 흐름과 무관하게 지정한 자리에 얹는" 개체에 정확히 맞는 배치다.
+
+### 길이 단위 — HWPUNIT (이 명령의 최대 함정)
+
+`--x/--y/--width/--height` 는 전부 **HWPUNIT(1/7200 inch)** 이며 픽셀이 아니다.
+A4 세로 = 59528 × 84188 HWPUNIT. px 로 오해하면 도장이 1/75 크기로 찍히는데
+**종료 코드는 0** 이라 에이전트는 성공으로 읽는다. 그래서 단위를 세 곳에 못 박았다:
+
+- `--help` 본문 (`길이 단위는 모두 **HWPUNIT(1/7200 inch)** — 픽셀이 아니다`)
+- MCP 도구 description 과 각 속성 description
+- 인자 오류 문구 자체 (`--x 뒤에 0 이상의 정수가 필요합니다 (HWPUNIT, 1/7200 inch)`)
+
+크기 규약(실측 §2·§3):
+
+| 지정 | 결과 |
+| --- | --- |
+| 둘 다 생략 | 원본 픽셀 × 75 (96dpi 환산). 40×20px → 3000×1500 |
+| 한쪽만 | 원본 비율 유지. 40×20px 에 `--width 8000` → 8000×4000 |
+| 둘 다 | 그대로 |
+
+어느 경우든 **최종 값을 봉투에 실어** 조용한 보정이 없게 했다.
+
+### 쪽 지정(앵커) 방식
+
+용지 기준 floating 그림은 **앵커 문단이 놓인 쪽**에 그려진다. 그래서 "몇 쪽" 을
+"어느 문단" 으로 옮겨야 하는데, 그 환산은 이미 조판 결과가 알고 있다 — 새 조판
+로직을 짜지 않고 진단 질의 `dump_page_items_json(Some(page))` 를 읽어 그 쪽의 첫
+본문 항목을 앵커로 고른다. 미주(`isEndnote`)는 구역 뒤에 합성된 문단이라 제외하고,
+항목이 하나도 없는 쪽(어울림 문단·감춘 빈 줄만 귀속된 쪽)은 `extras` 에서 찾는다.
+
+검증은 선언이 아니라 결과로 한다 — `--page N` 이 `changedPages` 에 N 을 담는지
+전 쪽(0·1·2) 순회로 확인한다(실측 §13: `[0]` `[1]` `[2]`).
+
+### 쪽 밖 배치는 조용히 자르지 않는다
+
+에이전트는 렌더 결과를 보지 않는다. 신호가 없으면 쪽 밖으로 나간 도장을 완성본으로
+판단한다. 그래서 **자르지 않고**(요청 좌표 그대로 넣고) `overflow` 로 숫자를 보고한다:
+
+```json
+{"page":0,"paperWidthHu":59528,"paperHeightHu":84188,
+ "rightHu":59529,"bottomHu":84189,"overflowXHu":1,"overflowYHu":1}
+```
+
+용지 크기는 `PageDef` 에서 읽되 `landscape` 면 가로·세로를 바꿔 쓴다
+(`page_layout.rs:69` 와 같은 규칙). 경계에 **정확히 닿는** 배치는 넘침이 아니다
+(실측 §6) — 판정이 과민하면 정상 배치마다 거짓 경보가 뜨고, 그러면 에이전트는
+경보 자체를 무시하게 된다.
+
+### 실패 경계 (종료 코드 사전 #2707 준수)
+
+| 상황 | 코드 | 근거 |
+| --- | --- | --- |
+| 지원 안 하는 형식(`.svg` 등) | **2** | 인자 문제이지 런타임 실패가 아니다 |
+| 확장자는 맞는데 내용이 그림이 아님 | **2** | 매직바이트 재판정 — 크기를 못 재면 좌표가 무의미 |
+| 쪽 번호 범위 초과 | **2** | 형제 명령(`dump-pages`)과 같은 규약 |
+| 음수·소수·`3000px` 같은 값 | **2** | 코어가 음수를 0 으로 깎으므로 **조용한 보정 대신** 끊는다 |
+| `--width 0` / `--height 0` | **2** | 크기 0 은 그림이 아니다 |
+| 알 수 없는 옵션·입력 파일 2개·값 없는 플래그 | **2** | #3349 파싱 규약 |
+| 그림 파일 없음 / 문서 없음 | **1** | 인자 형태는 맞다 — 런타임 실패 |
+| `--verify` IR 차이 | **3** | #3702 규약 |
+
+실패 경로의 **stdout 은 전부 0바이트**다(실측 §8~§12). 실패 시 산출물도 만들지 않는다.
+
+지원 형식은 `png · jpg · jpeg · bmp · tif · tiff` — BinData 로 넣을 수 있으면서
+**원본 픽셀 크기를 헤더만 읽어 잴 수 있는** 형식이다. 크기를 못 재면 배율·좌표가
+의미를 잃으므로 삽입을 시작조차 하지 않는다.
+
+## 곁가지로 잡은 코어 결함 — `img_dim` 비대칭
+
+`edit insert-image --verify` 가 **정상 삽입에도 항상 exit 3** 이었다. 진단(실측 §14b):
+
+```
+DIFF: PictureSize { path: "/ctrl[2]pic",
+       detail: "imgDim: expected=(0, 0) actual=(3000, 1500)" }
+```
+
+`insert_picture_native` 가 `img_dim` 을 기본값 `(0,0)` 으로 두는데,
+
+- HWP5 직렬화기는 `img_dim == (0,0)` 이면 `crop.right/bottom` 을 원본 크기 자리에
+  기록하고(`serializer/control.rs:1133`, #1929 폴백),
+- HWP5 파서는 그 값을 다시 `img_dim` 으로 적재한다(`parser/control/shape.rs:948`).
+
+그래서 **삽입 직후 IR 과 저장본 재파싱 IR 이 언제나 이 한 필드만큼 어긋났다.**
+`insert_picture_native` 의 세 분기(본문·표 셀·글상자) Picture 에 `img_dim` 을
+`(natural_px × 75)` 로 채워 정합시켰다 — 직렬화기가 이미 쓰던 값과 **같은 값**이다.
+
+렌더 무영향 근거: `compute_image_crop_src`(`renderer/svg.rs:3344`)는 `imgDim` 이
+없으면 `crop.right/bottom` 을 같은 자리에 쓰는 폴백을 가진다. 즉 두 경로의 배율
+`scale_x/scale_y` 가 동일하다. HWPX 산출은 종전 `imgDim 0/0` 대신 실제 좌표 범위를
+얻어 **HWP5 산출과의 비대칭이 해소**된다.
+
+무회귀: `cargo test --release --lib` 3030 passed / 0 failed.
+
+## 드리프트 가드
+
+| 가드 | 대응 |
+| --- | --- |
+| MCP `inputSchema` 에 `type:object` + `properties` + `required` 배열 | `required: ["path","image"]` (실측 §18) |
+| 선언한 입력 속성 전부가 CLI 인자에 배선 | 9속성 전부 — 값 없는 `dryRun` 은 `optionalArgs` presence 규약. 미배선 0건 |
+| `--json` 명령은 MCP 도구 필수 | `hwp_insert_image` (매니페스트 도구 26종) |
+| capabilities 등재 명령은 `--help` 에도 | `edit` 축에 `insert-image` 절 추가 |
+| 선언한 flags 는 실제 수용 | `capabilities_and_mcp_declare_insert_image_axis` 가 선언 조합을 그대로 호출해 확인 |
+| 실패 경로 stdout 0바이트 | 인자 오류 7종 · 런타임 실패 2종 전수 |
+| `commands[edit].flags` 누락 없이 | `--image --page --x --y --width --height` 추가 + **`--verify` 도 함께**(edit 4종이 모두 받는데 선언만 빠져 있던 기존 드리프트) |
+
+## 검증
+
+- 신규 `insert_image_contract` **19건** green (본류·크기 규약 2·dry-run·넘침 2·
+  형식 6종·앵커 전 쪽·실패 9종·`--verify`·HWPX 형식 보존·자기서술·봉투↔선언 대조)
+- 무회귀 계약 시험 81건 green — cli_json 26 · mcp_server 22 · profile_router 7 ·
+  set_cell 5 · verify 4 · changed_pages 5 · fill_fields 7 · replace_text 5
+- `cargo test --release --lib` 3030 passed / 0 failed / 7 ignored
+- `cargo clippy -- -D warnings` 경고 0 · rustfmt `--check` 차이 0
+- MCP 서버 실호출 왕복 성공(실측 §19) — `tools/call hwp_insert_image` → 474112바이트 산출
+
+시험은 **좌표·쪽 수를 박지 않는다.** 용지 크기는 `--dry-run` 넘침 보고에서, 쪽 수는
+`info --json` 에서, 봉투 키 이름은 `capabilities --mcp` 의 `outputFields` 에서 읽어
+쓴다 — 샘플이나 선언이 바뀌면 시험이 함께 따라가거나 소리 내어 깨진다.
+
+## 남은 것
+
+- **에이전트 프로필 미등재**: `agent_profiles.rs` 의 `행정서식` 프로필 도구 목록에
+  `hwp_insert_image` 를 넣어야 그 역할로 필터링한 에이전트가 쓸 수 있다. 같은 목록을
+  동시 작업 중인 다른 축들이 함께 건드리므로 충돌을 피해 후속 분리했다(한 줄 추가).
+- **세션 도구 미제공**: 무상태 CLI/MCP 만 있고 `hwp_doc_insert_image` (핸들 편집)는
+  없다. `hwp_doc_set_cell` 계열과 같은 자리에 적층할 수 있다.
+- **표 셀·글상자 좌표 지정 없음**: 코어는 `cell_path` 로 셀 안 배치를 지원하지만 v1
+  CLI 는 본문 용지 기준만 노출한다(도장·서명의 실사용 형태). 셀 지정이 필요해지면
+  `--table/--row/--col` 축을 `set-cell` 좌표계 그대로 얹으면 된다.
+- **`mydocs/manual/cli_commands.md` 반영**: 명령 레퍼런스 문서는 이 PR 범위 밖으로
+  두었다(같은 파일을 여러 축이 동시 수정 중).

--- a/mydocs/report/task_m100_insert_image/evidence.txt
+++ b/mydocs/report/task_m100_insert_image/evidence.txt
@@ -1,0 +1,130 @@
+# task_m100_insert_image — 실측 원문 (rhwp v0.8.2)
+# 채집일 2026-08-02 / 대상 samples/field-01.hwp (HWP5 3쪽), 도장 40x20px
+
+## 1) 기본 삽입 — 쪽·좌표·크기 지정 (HWPUNIT)
+$ rhwp edit insert-image samples/field-01.hwp --image stamp.png --page 0 --x 30000 --y 40000 --width 6000 --height 3000 -o out.hwp --json
+{"binDataId":4,"changedPages":[0],"dryRun":false,"height":3000,"image":"C:/Users/swsz9/AppData/Local/Temp/stamp.png","output":"C:/Users/swsz9/AppData/Local/Temp/e1.hwp","outputFormat":"hwp5","overflow":[],"page":0,"schemaVersion":"1.0","source":"samples/field-01.hwp","verify":null,"width":6000,"x":30000,"y":40000}
+exit=0
+
+## 2) 크기 생략 — 원본 픽셀 x75 (96dpi 환산). 40x20px -> 3000x1500 HWPUNIT
+{"binDataId":4,"changedPages":[0],"dryRun":false,"height":1500,"image":"C:/Users/swsz9/AppData/Local/Temp/stamp.png","output":"C:/Users/swsz9/AppData/Local/Temp/e2.hwp","outputFormat":"hwp5","overflow":[],"page":0,"schemaVersion":"1.0","source":"samples/field-01.hwp","verify":null,"width":3000,"x":0,"y":0}
+exit=0
+
+## 3) 한쪽만 지정 — 원본 비율 유지 (40:20 -> 8000:4000)
+{"binDataId":4,"changedPages":[0],"dryRun":false,"height":4000,"image":"C:/Users/swsz9/AppData/Local/Temp/stamp.png","output":"C:/Users/swsz9/AppData/Local/Temp/e3.hwp","outputFormat":"hwp5","overflow":[],"page":0,"schemaVersion":"1.0","source":"samples/field-01.hwp","verify":null,"width":8000,"x":0,"y":0}
+exit=0
+
+## 4) --dry-run — 산출 0, 배치 예정만 (changedPages/binDataId/output 은 null)
+{"binDataId":null,"changedPages":null,"dryRun":true,"height":1500,"image":"C:/Users/swsz9/AppData/Local/Temp/stamp.png","overflow":[],"page":0,"schemaVersion":"1.0","source":"samples/field-01.hwp","width":3000,"x":1000,"y":2000}
+exit=0
+산출물 존재? NO
+
+## 5) 쪽 밖 배치 — 자르지 않고 overflow 로 보고 (용지 경계 +1 HWPUNIT)
+{"binDataId":4,"changedPages":[0],"dryRun":false,"height":3000,"image":"C:/Users/swsz9/AppData/Local/Temp/stamp.png","output":"C:/Users/swsz9/AppData/Local/Temp/e5.hwp","outputFormat":"hwp5","overflow":[{"bottomHu":84189,"overflowXHu":1,"overflowYHu":1,"page":0,"paperHeightHu":84188,"paperWidthHu":59528,"rightHu":59529}],"page":0,"schemaVersion":"1.0","source":"samples/field-01.hwp","verify":null,"width":6000,"x":53529,"y":81189}
+exit=0
+
+## 6) 용지 경계에 정확히 닿는 배치 — 넘침 아님 (거짓 경보 금지)
+{"binDataId":null,"changedPages":null,"dryRun":true,"height":3000,"image":"C:/Users/swsz9/AppData/Local/Temp/stamp.png","overflow":[],"page":0,"schemaVersion":"1.0","source":"samples/field-01.hwp","width":6000,"x":53528,"y":81188}
+exit=0
+
+## 7) 형식별 수용 — png/jpg/bmp/tif 전부 같은 규약(40x20px -> 3000x1500)
+  png  width=3000 height=1500 binDataId=4 exit=0
+  jpg  width=3000 height=1500 binDataId=4 exit=0
+  bmp  width=3000 height=1500 binDataId=4 exit=0
+  tif  width=3000 height=1500 binDataId=4 exit=0
+
+## 8) 지원 안 하는 형식 — 인자 오류(2), stdout 0바이트
+exit=2
+stdout bytes=0  stderr=오류: 지원하지 않는 그림 형식입니다 - svg (지원: png, jpg, jpeg, bmp, tif, tiff)
+산출물 존재? NO
+
+## 9) 확장자 거짓말(.png 인데 내용은 아님) — 매직바이트로 잡아 2
+exit=2
+stdout bytes=0  stderr=오류: 그림 형식을 알아볼 수 없습니다 - C:/Users/swsz9/AppData/Local/Temp/liar.png (지원: png, jpg, jpeg, bmp, tif, tiff)
+
+## 10) 없는 그림 파일 — 런타임 실패(1), 인자 오류(2) 아님
+exit=1
+stdout bytes=0  stderr=오류: 그림 파일을 읽을 수 없습니다 - C:/Users/swsz9/AppData/Local/Temp/ghost.png: 지정된 파일을 찾을 수 없습니다. (os error 2)
+
+## 11) 쪽 범위 초과 — 인자 오류(2). 문서는 3쪽(info.pageCount)
+  info.pageCount=3
+exit=2
+stdout bytes=0  stderr=오류: 페이지 번호가 범위를 벗어났습니다 (0~2): 3
+
+## 12) 음수 좌표 — 조용히 0 으로 깎지 않고 인자 오류(2)
+exit=2
+stdout bytes=0  stderr=오류: --x 뒤에 0 이상의 정수가 필요합니다 (HWPUNIT, 1/7200 inch): -100
+
+## 13) 쪽 지정(앵커) — --page N 이 changedPages 에 N 을 담는가 (0,1,2쪽 전수)
+  --page 0  changedPages=[0]
+  --page 1  changedPages=[1]
+  --page 2  changedPages=[2]
+
+## 14) --verify — 저장 직후 IR 자기검증 (코어 img_dim 정합 후 identical:true)
+{"binDataId":4,"changedPages":[0],"dryRun":false,"height":1500,"image":"C:/Users/swsz9/AppData/Local/Temp/stamp.png","output":"C:/Users/swsz9/AppData/Local/Temp/e14.hwp","outputFormat":"hwp5","overflow":[],"page":0,"schemaVersion":"1.0","source":"samples/field-01.hwp","verify":{"diffCount":0,"identical":true},"width":3000,"x":10000,"y":10000}
+exit=0
+
+## 14b) [수정 전 실측] 같은 명령이 diffCount=1 로 exit 3 이었다
+    DIFF: PictureSize { section: 0, paragraph: 0, path: "/ctrl[2]pic",
+           detail: "imgDim: expected=(0, 0) actual=(3000, 1500)" }
+    → insert_picture_native 가 img_dim 을 (0,0) 으로 두고, HWP5 직렬화기는
+      crop.right/bottom 을 원본 크기 자리에 쓰고, HWP5 파서는 그것을 img_dim 으로
+      되읽는다. 정상 삽입인데 --verify 가 항상 exit 3 이었다.
+
+## 15) HWPX 입력 — 산출 형식 보존 (HWPX -> HWPX)
+{"binDataId":26,"changedPages":[0],"dryRun":false,"height":2500,"image":"C:/Users/swsz9/AppData/Local/Temp/stamp.png","output":"C:/Users/swsz9/AppData/Local/Temp/e15.hwpx","outputFormat":"hwpx","overflow":[],"page":0,"schemaVersion":"1.0","source":"samples/2025년 기부·답례품 실적 지자체 보고서_양식.hwpx","verify":null,"width":5000,"x":20000,"y":20000}
+exit=0
+
+## 16) 사람용 출력 (--json 없이) + 쪽 밖 경고는 stderr
+그림 삽입 완료: samples/field-01.hwp → C:/Users/swsz9/AppData/Local/Temp/e16.hwp — 0쪽 (53529, 81189) 크기 6000×3000 HWPUNIT ← C:/Users/swsz9/AppData/Local/Temp/stamp.png (원본 40×20px)
+경고: 그림이 쪽 밖으로 나갑니다 (용지 59528×84188 HWPUNIT, 오른쪽 59529 아래 84189) — 상세는 --json 의 overflow
+exit=0
+
+## 17) 자기서술 — capabilities commands[edit].flags 에 insert-image 축 등재
+  flags      = ['--data', '--find', '--replace', '--ignore-case', '--table', '--row', '--col', '--text', '--occurrence', '--keep-style', '--image', '--page', '--x', '--y', '--width', '--height', '-o', '--dry-run', '--verify', '--json']
+  summary    = 문서 편집 — fill-fields: 누름틀 채우기 / replace-text: 일괄 치환(--occurrence k번째만) / set-cell: 표 셀 기록 / insert-image: 도장·서명 그림 삽입(길이는 HWPUNIT)
+
+## 18) MCP 도구 정의 (capabilities --mcp) — required 배열 + 전 속성 CLI 배선
+  inputSchema.type      = object
+  inputSchema.required  = ['path', 'image']
+  properties            = ['dryRun', 'height', 'image', 'output', 'page', 'path', 'width', 'x', 'y']
+  cli.args              = ['edit', 'insert-image', '{path}', '--image', '{image}', '--json']
+  cli.optionalArgs.when = ['page', 'x', 'y', 'width', 'height', 'output', 'dryRun']
+  배선 안 된 속성        = [] (0건이어야 함)
+  outputFields          = ['schemaVersion', 'source', 'image', 'page', 'x', 'y', 'width', 'height', 'binDataId', 'dryRun', 'overflow', 'output', 'outputFormat', 'verify', 'changedPages']
+  매니페스트 도구 총수   = 26
+
+## 19) MCP 서버 실호출 — tools/call hwp_insert_image (stdio JSON-RPC 왕복)
+  응답: {"binDataId":4,"changedPages":[1],"dryRun":false,"height":3000,"image":"C:/Users/swsz9/AppData/Local/Temp/stamp.png","output":"C:/Users/swsz9/AppData/Local/Temp/mcp-stamp.hwp","outputFormat":"hwp5","overflow":[],"page":1,"schemaVersion":"1.0","source":"samples/field-01.hwp","verify":null,"width":6000,"x":30000,"y":40000}
+  isError: False
+  산출물 존재? YES (474112 bytes)
+
+## 20) 검증 게이트 실측
+$ cargo build --release --bin rhwp
+    Finished `release` profile [optimized] target(s) in 7m 59s        (경고 0)
+
+$ cargo test --release --test insert_image_contract \
+      --test cli_json_contract --test mcp_server_contract \
+      --test agent_profile_router_contract --test edit_set_cell_contract \
+      --test edit_verify_contract --test changed_pages_contract \
+      --test edit_fill_fields_contract --test edit_replace_text_contract
+  insert_image_contract          19 passed; 0 failed   (신규)
+  cli_json_contract              26 passed; 0 failed
+  mcp_server_contract            22 passed; 0 failed
+  agent_profile_router_contract   7 passed; 0 failed
+  edit_set_cell_contract          5 passed; 0 failed
+  edit_verify_contract            4 passed; 0 failed
+  changed_pages_contract          5 passed; 0 failed
+  edit_fill_fields_contract       7 passed; 0 failed
+  edit_replace_text_contract      5 passed; 0 failed
+  ── 합계 100 passed; 0 failed
+
+$ cargo test --release --lib          # 코어 img_dim 변경 무회귀
+  test result: ok. 3030 passed; 0 failed; 7 ignored; finished in 12.73s
+
+$ cargo clippy -- -D warnings
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 01s   (경고 0)
+
+$ git diff --name-only HEAD | grep '\.rs$' | xargs -n 10 rustfmt --edition 2021 \
+      --config-path rustfmt.toml --config newline_style=Auto --check
+  (차이 없음 — 종료 0)

--- a/src/document_core/commands/object_ops/picture.rs
+++ b/src/document_core/commands/object_ops/picture.rs
@@ -1509,6 +1509,20 @@ impl DocumentCore {
             right: (natural_width_px * 75) as i32,
             bottom: (natural_height_px * 75) as i32,
         };
+        // [#3719 §6-5] crop 이 기준으로 삼는 전체 좌표 범위를 IR 에도 남긴다.
+        //
+        // 종전에는 `img_dim` 을 기본값 (0,0) 으로 두었는데, HWP5 직렬화기는 그 경우
+        // `crop.right/bottom` 을 원본 크기 자리에 기록하고(control.rs 의 #1929 폴백)
+        // HWP5 파서는 그 값을 다시 `img_dim` 으로 적재한다. 그래서 **삽입 직후 IR 과
+        // 저장본 재파싱 IR 이 항상 이 한 필드만큼 어긋났다** — `edit insert-image
+        // --verify` 가 정상 삽입에도 exit 3 을 내는 형태였다(실측 diffCount=1,
+        // `imgDim: expected=(0,0) actual=(3000,1500)`).
+        //
+        // 값은 직렬화기가 이미 쓰던 것과 같고, 렌더러의 폴백(`compute_image_crop_src`
+        // 는 imgDim 이 없으면 crop.right/bottom 을 같은 자리에 쓴다)과도 같은 배율이라
+        // 그림이 놓이는 결과는 바뀌지 않는다. HWPX 산출은 종전 `imgDim 0/0` 대신 실제
+        // 좌표 범위를 얻는다(HWP5 산출과의 비대칭 해소).
+        let img_dim = ((natural_width_px * 75), (natural_height_px * 75));
         let image_attr = ImageAttr {
             bin_data_id: position_id,
             brightness: 0,
@@ -1557,6 +1571,7 @@ impl DocumentCore {
                     border_x: bx,
                     border_y: by,
                     crop,
+                    img_dim,
                     image_attr,
                     ..Default::default()
                 };
@@ -1633,6 +1648,7 @@ impl DocumentCore {
                 border_x: bx,
                 border_y: by,
                 crop,
+                img_dim,
                 image_attr,
                 ..Default::default()
             };
@@ -1715,6 +1731,7 @@ impl DocumentCore {
             border_x: bx,
             border_y: by,
             crop,
+            img_dim,
             image_attr,
             ..Default::default()
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -966,6 +966,37 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
             serde_json::json!([{ "when": "bare", "args": ["--bare"] }]),
             &["schemaVersion", "irSchemaVersion", "dialect", "definitionCount", "schema"],
         ),
+        tool_with_optional_args(
+            "hwp_insert_image",
+            "[#3719 §6-5] 도장·서명 같은 그림을 쪽 좌표에 붙여 새 문서를 만든다 — 채워 넣은 서식에 직인을 얹는 실물 제출의 마지막 조각. **길이 단위는 전부 HWPUNIT(1/7200 inch)이며 픽셀이 아니다** (A4 세로 = 59528 × 84188). 용지 왼쪽 위 모서리 기준 (x, y) 에 놓는 떠 있는 그림이다. 크기를 생략하면 원본 픽셀을 96dpi 로 환산하고, 한쪽만 주면 원본 비율을 지킨다. 쪽 밖으로 나가면 자르지 않고 overflow 로 보고한다. 지원 형식은 png·jpg·jpeg·bmp·tif·tiff 이며 그 밖은 인자 오류다. 산출물은 입력 형식을 따른다.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string", "description": "입력 HWP/HWPX 문서 경로" },
+                    "image": { "type": "string", "description": "삽입할 그림 파일 경로 (png/jpg/jpeg/bmp/tif/tiff)" },
+                    "page": { "type": "integer", "minimum": 0, "description": "붙일 쪽 (0부터). 생략하면 첫 쪽" },
+                    "x": { "type": "integer", "minimum": 0, "description": "용지 왼쪽 모서리에서의 가로 위치 (HWPUNIT, 1/7200 inch). 생략하면 0" },
+                    "y": { "type": "integer", "minimum": 0, "description": "용지 위쪽 모서리에서의 세로 위치 (HWPUNIT, 1/7200 inch). 생략하면 0" },
+                    "width": { "type": "integer", "minimum": 1, "description": "그림 너비 (HWPUNIT, 1/7200 inch). 생략하면 원본 픽셀 × 75" },
+                    "height": { "type": "integer", "minimum": 1, "description": "그림 높이 (HWPUNIT, 1/7200 inch). 생략하면 원본 픽셀 × 75" },
+                    "output": { "type": "string", "description": "출력 파일 경로. 생략하면 <입력명>_image.hwp (HWPX 입력이면 _image.hwpx)" },
+                    "dryRun": { "type": "boolean", "description": "true 면 파일을 쓰지 않고 배치 예정만 보고" }
+                },
+                "required": ["path", "image"],
+            }),
+            "edit",
+            serde_json::json!(["edit", "insert-image", "{path}", "--image", "{image}", "--json"]),
+            serde_json::json!([
+                { "when": "page", "args": ["--page", "{page}"] },
+                { "when": "x", "args": ["--x", "{x}"] },
+                { "when": "y", "args": ["--y", "{y}"] },
+                { "when": "width", "args": ["--width", "{width}"] },
+                { "when": "height", "args": ["--height", "{height}"] },
+                { "when": "output", "args": ["-o", "{output}"] },
+                { "when": "dryRun", "args": ["--dry-run"] }
+            ]),
+            &["schemaVersion", "source", "image", "page", "x", "y", "width", "height", "binDataId", "dryRun", "overflow", "output", "outputFormat", "verify", "changedPages"],
+        ),
         tool(
             "hwp_run_plan",
             "[#3703] 선언적 편집 계획(JSON)을 정적 선검증→원자 실행→저널로 수행한다. 도구 호출을 체이닝하는 대신 의도를 계획서 하나로 선언하면, 전 step 의 실행 가능성을 미리 판정하고(불가 시 실행 0·invalid[]·exit 2) 인메모리로 적용해 단언(verify 자기검증) 통과 시에만 단 한 번 저장한다 — 실패 시 디스크 무변경. fill_fields step 은 화면상 구별되지 않는 필드 이름을 steps[].confusable 로 경고한다. steps: fill_fields{data} · replace_text{find,replace[,occurrence]} · set_cell{table,row,col,text[,keepStyle]} · set_checkbox{occurrence}.",
@@ -1403,7 +1434,7 @@ fn capabilities_command_entries() -> Vec<serde_json::Value> {
         cmd_json(
             "edit",
             "edit",
-            "문서 편집 — fill-fields: 누름틀 채우기 / replace-text: 일괄 치환(--occurrence k번째만) / set-cell: 표 셀 기록",
+            "문서 편집 — fill-fields: 누름틀 채우기 / replace-text: 일괄 치환(--occurrence k번째만) / set-cell: 표 셀 기록 / insert-image: 도장·서명 그림 삽입(길이는 HWPUNIT)",
             false,
             &[
                 "--data",
@@ -1418,8 +1449,17 @@ fn capabilities_command_entries() -> Vec<serde_json::Value> {
                 // hwp_set_checkbox 가 이 플래그를 고정 배선한다 — 목록에만 없었다.
                 "--occurrence",
                 "--keep-style",
+                // [#3719 §6-5] insert-image 축. 길이 인자는 전부 HWPUNIT(1/7200 inch).
+                "--image",
+                "--page",
+                "--x",
+                "--y",
+                "--width",
+                "--height",
                 "-o",
                 "--dry-run",
+                // [#3702] edit 4종이 모두 받는 저장 직후 자기검증 — 선언만 빠져 있었다.
+                "--verify",
                 "--json",
             ],
             &[
@@ -1437,8 +1477,18 @@ fn capabilities_command_entries() -> Vec<serde_json::Value> {
                 "newText",
                 "keepStyle",
                 "overflow",
+                // [#3719 §6-5] insert-image 봉투 축.
+                "image",
+                "page",
+                "x",
+                "y",
+                "width",
+                "height",
+                "binDataId",
                 "output",
                 "outputFormat",
+                "verify",
+                "changedPages",
             ],
         ),
         // ── 배치 ──
@@ -2053,7 +2103,22 @@ fn print_help() {
     println!("      --json                    계약 봉투 JSON을 stdout에 출력");
     println!("      병합으로 덮인 칸은 앵커 좌표 안내와 함께 오류 종료");
     println!();
-    println!("      edit 3종 공통: 산출물은 **입력 형식을 보존**한다 (HWPX 입력 → HWPX 산출).");
+    println!("  edit insert-image <파일> --image <그림> [옵션]");
+    println!("      도장·서명 그림을 쪽 좌표에 붙인다 (용지 기준 떠 있는 그림)");
+    println!();
+    println!("      --image <경로>            png·jpg·jpeg·bmp·tif·tiff (그 밖은 인자 오류)");
+    println!("      --page <번호>             붙일 쪽 (0부터, 기본 0)");
+    println!("      --x/--y <값>              용지 왼쪽 위 모서리 기준 위치 (기본 0)");
+    println!("      --width/--height <값>     그림 크기 (생략: 원본 픽셀 ×75, 한쪽만: 비율 유지)");
+    println!(
+        "      길이 단위는 모두 **HWPUNIT(1/7200 inch)** — 픽셀이 아니다 (A4 세로 59528×84188)"
+    );
+    println!("      -o, --output <파일>       출력 파일 (기본: 입력명_image.<입력과 같은 확장자>)");
+    println!("      --dry-run                 파일을 쓰지 않고 배치 예정만 보고");
+    println!("      --json                    계약 봉투 JSON을 stdout에 출력");
+    println!("      (쪽 밖으로 나가면 자르지 않고 --json 응답의 overflow 로 알린다)");
+    println!();
+    println!("      edit 4종 공통: 산출물은 **입력 형식을 보존**한다 (HWPX 입력 → HWPX 산출).");
     println!("      HWPX 입력에 -o ….hwp 를 지정하면 그 경로를 존중해 HWP5 로 저장하되");
     println!("      형식 변경(이미지·차트 유실 가능)을 stderr 로 경고한다.");
     println!();
@@ -10708,12 +10773,13 @@ fn collect_field_records(doc: &rhwp::wasm_api::HwpDocument) -> Vec<serde_json::V
 /// **실패 시 원본 불변**(하나라도 실패하면 출력 파일을 쓰지 않는다).
 fn run_edit(args: &[String]) -> i32 {
     const USAGE: &str =
-        "사용법: rhwp edit <fill-fields|replace-text|set-cell> <파일.hwp|파일.hwpx> [옵션] (rhwp --help 참조)";
+        "사용법: rhwp edit <fill-fields|replace-text|set-cell|insert-image> <파일.hwp|파일.hwpx> [옵션] (rhwp --help 참조)";
 
     match args.first().map(String::as_str) {
         Some("fill-fields") => edit_fill_fields(&args[1..]),
         Some("replace-text") => edit_replace_text(&args[1..]),
         Some("set-cell") => edit_set_cell(&args[1..]),
+        Some("insert-image") => edit_insert_image(&args[1..]),
         Some(other) => {
             eprintln!("오류: 알 수 없는 edit 하위 명령 - {}", other);
             eprintln!("{USAGE}");
@@ -12707,6 +12773,459 @@ fn edit_set_cell(args: &[String]) -> i32 {
         println!(
             "셀 기록 완료: {} → {} — 표{} ({},{}) {:?} → {:?}",
             file_path, output_path, table_no, row, col, old_text, new_text
+        );
+    }
+    if verify_failed {
+        eprintln!("검증 실패(--verify): 저장본 재파싱 IR 차이 — 상세는 --json 또는 ir-diff");
+        process::exit(3);
+    }
+    EXIT_OK
+}
+
+/// [#3719 §6-5] `edit insert-image` 가 받는 그림 형식.
+///
+/// BinData 로 넣을 수 있고 **원본 픽셀 크기를 헤더만 읽어 잴 수 있는** 형식만 담는다.
+/// 크기를 못 재면 배율·배치 좌표가 의미를 잃으므로 삽입을 시작하지 않는다.
+const INSERT_IMAGE_FORMATS: [&str; 6] = ["png", "jpg", "jpeg", "bmp", "tif", "tiff"];
+
+/// 96dpi 픽셀 1개 = 75 HWPUNIT(7200/96). 코어가 crop 을 `px * 75` 로 잡는 것과 같은 환산비다.
+const HWPUNIT_PER_PX: u32 = 75;
+
+/// 그림의 원본 픽셀 크기 — 전체 디코드 없이 헤더만 읽는다.
+///
+/// 확장자는 거짓말할 수 있으므로 매직 바이트로 형식을 다시 판정한다. 알아보지 못하면
+/// `None` — 호출부가 인자 오류(exit 2)로 끊는다.
+fn insert_image_dimensions(bytes: &[u8]) -> Option<(u32, u32)> {
+    use image::ImageFormat;
+
+    let format = image::guess_format(bytes).ok()?;
+    if !matches!(
+        format,
+        ImageFormat::Png | ImageFormat::Jpeg | ImageFormat::Bmp | ImageFormat::Tiff
+    ) {
+        return None;
+    }
+    let (width, height) = image::ImageReader::with_format(std::io::Cursor::new(bytes), format)
+        .into_dimensions()
+        .ok()?;
+    if width == 0 || height == 0 {
+        return None;
+    }
+    Some((width, height))
+}
+
+/// `--page` 가 가리키는 쪽의 **앵커 문단**(구역 인덱스, 문단 인덱스).
+///
+/// 용지 기준(Paper-relative) floating 그림은 앵커 문단이 놓인 쪽에 그려진다. 그래서
+/// "몇 쪽" 을 "어느 문단" 으로 옮겨야 하는데, 그 환산은 이미 조판 결과가 알고 있다 —
+/// 기존 진단 질의 `dump_page_items_json` 을 그대로 읽어 그 쪽의 첫 본문 항목을 고른다
+/// (새 조판 로직 0). 미주(`isEndnote`)는 구역 뒤에 합성된 문단이라 앵커로 쓰지 않는다.
+fn insert_image_page_anchor(
+    doc: &rhwp::wasm_api::HwpDocument,
+    page: u32,
+) -> Option<(usize, usize)> {
+    let empty: Vec<serde_json::Value> = Vec::new();
+    let pages = doc.dump_page_items_json(Some(page));
+    let page_json = pages.as_array()?.first()?;
+    let section = page_json["section"].as_u64()? as usize;
+
+    for column in page_json["columns"].as_array().unwrap_or(&empty) {
+        for item in column["items"].as_array().unwrap_or(&empty) {
+            if item["isEndnote"] == true {
+                continue;
+            }
+            if let Some(para) = item["paraIndex"].as_u64() {
+                return Some((section, para as usize));
+            }
+        }
+    }
+    // 항목이 하나도 없는 쪽(어울림 문단·감춘 빈 줄만 귀속된 쪽)은 extras 로 온다.
+    for extra in page_json["extras"].as_array().unwrap_or(&empty) {
+        if let Some(para) = extra["paraIndex"].as_u64() {
+            return Some((section, para as usize));
+        }
+    }
+    None
+}
+
+/// `edit insert-image` — 도장·서명 같은 그림을 쪽 좌표에 붙인다 (#3719 §6-5).
+///
+/// 실물 서식 제출의 마지막 조각이다. 채워 넣은 서식에 직인·서명 이미지를 얹지 못하면
+/// 사람이 한 번 더 한컴을 열어야 하고, 그 순간 자동화 사슬이 끊긴다.
+///
+/// 새 삽입 로직을 만들지 않는다 — 검증된 코어 `insert_picture_native` 의 **본문 floating
+/// 분기**(용지 기준 offset, `treat_as_char=false`, 한컴 native 기본값)를 그대로 쓴다.
+/// 인자 파싱·저장·봉투·`--verify`·`changedPages` 는 `edit set-cell` 과 같은 형태다.
+///
+/// **길이 단위는 전부 HWPUNIT(1/7200 inch)** 이다 — px 로 오해하면 도장이 점만 하게
+/// 찍히거나 아예 안 보인다. A4 세로는 59528 × 84188 HWPUNIT.
+fn edit_insert_image(args: &[String]) -> i32 {
+    const USAGE: &str = "사용법: rhwp edit insert-image <파일> --image <그림> [--page N] [--x N --y N] [--width N --height N] [-o <출력>] [--dry-run] [--verify] [--json]";
+
+    let mut file_path: Option<&str> = None;
+    let mut image_path: Option<&str> = None;
+    let mut page_arg: u32 = 0;
+    let mut x_hu: u32 = 0;
+    let mut y_hu: u32 = 0;
+    let mut width_arg: Option<u32> = None;
+    let mut height_arg: Option<u32> = None;
+    let mut out_path: Option<String> = None;
+    let mut dry_run = false;
+    let mut json_mode = false;
+    // [#3702] 저장 직후 자기검증 — 판정은 데이터, 차이 시 exit 3.
+    let mut verify_mode = false;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--image" => {
+                i += 1;
+                match args.get(i) {
+                    Some(v) => image_path = Some(v),
+                    None => {
+                        eprintln!("오류: --image 뒤에 그림 파일 경로가 필요합니다.");
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            "--page" | "--x" | "--y" | "--width" | "--height" => {
+                let name = args[i].clone();
+                // 단위를 오류 문구에도 박아 둔다 — px 로 넣으면 도장이 사라진다.
+                let unit = if name == "--page" {
+                    " (0부터)"
+                } else {
+                    " (HWPUNIT, 1/7200 inch)"
+                };
+                i += 1;
+                let Some(v) = args.get(i) else {
+                    eprintln!("오류: {name} 뒤에 0 이상의 정수가 필요합니다{unit}.");
+                    return EXIT_USAGE;
+                };
+                let Ok(value) = v.parse::<u32>() else {
+                    eprintln!("오류: {name} 뒤에 0 이상의 정수가 필요합니다{unit}: {v}");
+                    return EXIT_USAGE;
+                };
+                match name.as_str() {
+                    "--page" => page_arg = value,
+                    "--x" => x_hu = value,
+                    "--y" => y_hu = value,
+                    "--width" => width_arg = Some(value),
+                    _ => height_arg = Some(value),
+                }
+            }
+            "-o" | "--output" => {
+                i += 1;
+                match args.get(i) {
+                    Some(v) => out_path = Some(v.clone()),
+                    None => {
+                        eprintln!("오류: -o 뒤에 출력 파일 경로가 필요합니다.");
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            "--dry-run" => dry_run = true,
+            "--json" => json_mode = true,
+            "--verify" => verify_mode = true,
+            other if other.starts_with('-') => {
+                eprintln!("알 수 없는 옵션: {other}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if file_path.replace(other).is_some() {
+                    eprintln!("오류: 입력 파일은 하나만 지정할 수 있습니다: {other}");
+                    return EXIT_USAGE;
+                }
+            }
+        }
+        i += 1;
+    }
+
+    let (Some(file_path), Some(image_path)) = (file_path, image_path) else {
+        eprintln!("{USAGE}");
+        return EXIT_USAGE;
+    };
+    for (name, value) in [("--width", width_arg), ("--height", height_arg)] {
+        if value == Some(0) {
+            eprintln!("오류: {name} 는 1 이상이어야 합니다 (HWPUNIT, 1/7200 inch).");
+            return EXIT_USAGE;
+        }
+    }
+
+    // ── 그림 선검증 — 문서를 읽기 전에 끊는다 ──
+    // 지원하지 않는 형식은 **인자 문제**다(런타임 실패가 아니다) → exit 2.
+    let image_ext = Path::new(image_path)
+        .extension()
+        .map(|e| e.to_string_lossy().to_ascii_lowercase())
+        .unwrap_or_default();
+    if !INSERT_IMAGE_FORMATS.contains(&image_ext.as_str()) {
+        eprintln!(
+            "오류: 지원하지 않는 그림 형식입니다 - {} (지원: {})",
+            if image_ext.is_empty() {
+                "확장자 없음".to_string()
+            } else {
+                image_ext.clone()
+            },
+            INSERT_IMAGE_FORMATS.join(", ")
+        );
+        return EXIT_USAGE;
+    }
+    let image_bytes = match fs::read(image_path) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: 그림 파일을 읽을 수 없습니다 - {}: {}", image_path, e);
+            return EXIT_RUNTIME;
+        }
+    };
+    // 확장자만 믿지 않는다 — 내용이 그림이 아니면 원본 픽셀 크기를 못 재고,
+    // 크기를 모르면 배치 좌표가 의미를 잃는다.
+    let Some((natural_w_px, natural_h_px)) = insert_image_dimensions(&image_bytes) else {
+        eprintln!(
+            "오류: 그림 형식을 알아볼 수 없습니다 - {} (지원: {})",
+            image_path,
+            INSERT_IMAGE_FORMATS.join(", ")
+        );
+        return EXIT_USAGE;
+    };
+
+    // 크기 결정: 둘 다 없으면 원본 픽셀(96dpi 환산), 하나만 주면 원본 비율 유지.
+    // 어느 쪽이든 최종 값은 봉투에 그대로 실어 "조용한 보정" 이 없게 한다.
+    let (width_hu, height_hu) = match (width_arg, height_arg) {
+        (Some(w), Some(h)) => (w, h),
+        (Some(w), None) => (
+            w,
+            ((w as u64 * natural_h_px as u64) / natural_w_px as u64).max(1) as u32,
+        ),
+        (None, Some(h)) => (
+            ((h as u64 * natural_w_px as u64) / natural_h_px as u64).max(1) as u32,
+            h,
+        ),
+        (None, None) => (
+            natural_w_px.saturating_mul(HWPUNIT_PER_PX),
+            natural_h_px.saturating_mul(HWPUNIT_PER_PX),
+        ),
+    };
+    // 코어는 offset·크기를 i32/u32 로 다룬다. 범위를 넘는 값이 조용히 감기면 도장이
+    // 엉뚱한 곳에 찍히므로 인자 오류로 끊는다.
+    for (name, value) in [
+        ("--x", x_hu),
+        ("--y", y_hu),
+        ("--width", width_hu),
+        ("--height", height_hu),
+    ] {
+        if value > i32::MAX as u32 {
+            eprintln!(
+                "오류: {name} 값이 너무 큽니다 (HWPUNIT 최대 {}): {value}",
+                i32::MAX
+            );
+            return EXIT_USAGE;
+        }
+    }
+
+    let bytes = match fs::read(file_path) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
+            return EXIT_RUNTIME;
+        }
+    };
+    let mut doc = match rhwp::wasm_api::HwpDocument::from_bytes(&bytes) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: HWP 파싱 실패 - {}", e);
+            return EXIT_RUNTIME;
+        }
+    };
+
+    let page_count = doc.page_count();
+    if page_arg >= page_count {
+        eprintln!(
+            "오류: 페이지 번호가 범위를 벗어났습니다 (0~{}): {page_arg}",
+            page_count.saturating_sub(1)
+        );
+        return EXIT_USAGE;
+    }
+    let Some((sec, para)) = insert_image_page_anchor(&doc, page_arg) else {
+        eprintln!("오류: {page_arg}쪽(0 기준)에서 그림을 붙일 본문 문단을 찾지 못했습니다.");
+        return EXIT_RUNTIME;
+    };
+
+    // [#3480 과 같은 취지] 쪽 밖으로 나가면 **조용히 자르지 않는다**. 에이전트는 렌더
+    // 결과를 보지 않으므로 신호가 없으면 잘려 나간 도장을 완성본으로 판단한다.
+    let page_def = &doc.document().sections[sec].section_def.page_def;
+    let (paper_w, paper_h) = if page_def.landscape {
+        (page_def.height as i64, page_def.width as i64)
+    } else {
+        (page_def.width as i64, page_def.height as i64)
+    };
+    let right = x_hu as i64 + width_hu as i64;
+    let bottom = y_hu as i64 + height_hu as i64;
+    let overflow = if right > paper_w || bottom > paper_h {
+        Some(serde_json::json!({
+            "page": page_arg,
+            "paperWidthHu": paper_w,
+            "paperHeightHu": paper_h,
+            "rightHu": right,
+            "bottomHu": bottom,
+            "overflowXHu": (right - paper_w).max(0),
+            "overflowYHu": (bottom - paper_h).max(0),
+        }))
+    } else {
+        None
+    };
+
+    let mut bin_data_id = serde_json::Value::Null;
+    if !dry_run {
+        // 그림 설명(대체 텍스트)은 파일명 — 한컴이 개체 속성에 보여 주는 값이다.
+        let description = Path::new(image_path)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let inserted = match doc.insert_picture_native(
+            sec,
+            para,
+            0,
+            &[],
+            &image_bytes,
+            width_hu,
+            height_hu,
+            natural_w_px,
+            natural_h_px,
+            &image_ext,
+            &description,
+            Some(x_hu as i32),
+            Some(y_hu as i32),
+        ) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("오류: 그림 삽입 실패 - {}", e);
+                // 실패 시 원본 불변 — 출력 파일을 쓰지 않고 즉시 끝낸다.
+                return EXIT_RUNTIME;
+            }
+        };
+        // binDataId 는 새 조회 API 없이 방금 삽입한 컨트롤에서 직접 읽는다 —
+        // 같은 그림을 다시 참조하거나(도장 재사용) 산출물을 감사할 때 쓰는 주소다.
+        let ctrl_idx = serde_json::from_str::<serde_json::Value>(&inserted)
+            .ok()
+            .and_then(|v| v["controlIdx"].as_u64())
+            .unwrap_or_default() as usize;
+        if let Some(rhwp::model::control::Control::Picture(picture)) = doc
+            .document()
+            .sections
+            .get(sec)
+            .and_then(|s| s.paragraphs.get(para))
+            .and_then(|p| p.controls.get(ctrl_idx))
+        {
+            bin_data_id = serde_json::json!(picture.image_attr.bin_data_id);
+        }
+    }
+
+    // [#3383] 입력 형식을 보존한다 — 기본 확장자도 산출 형식을 따른다.
+    let out_format = edit_output_format(&bytes, out_path.as_deref());
+    let output_path = out_path.unwrap_or_else(|| {
+        let stem = Path::new(file_path)
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_else(|| "output".to_string());
+        format!("{}_image.{}", stem, out_format.ext())
+    });
+
+    let mut verify_report = serde_json::Value::Null;
+    let mut verify_failed = false;
+    if !dry_run {
+        let out_bytes = match edit_serialize(&mut doc, out_format) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!(
+                    "오류: {} 직렬화 실패 - {}",
+                    out_format.label().to_uppercase(),
+                    e
+                );
+                return EXIT_RUNTIME;
+            }
+        };
+        if let Err(e) = fs::write(&output_path, &out_bytes) {
+            eprintln!("오류: 출력 쓰기 실패 - {}: {}", output_path, e);
+            return EXIT_RUNTIME;
+        }
+        // [#3702] 저장 직후 자기검증 — 편집 후 IR ↔ 저장본 재파싱 IR.
+        if verify_mode {
+            let cross = out_format == EditOutputFormat::Hwp
+                && rhwp::parser::detect_format(&bytes) == rhwp::parser::FileFormat::Hwpx;
+            let (report, failed) = edit_verify_report(&doc, &out_bytes, cross);
+            verify_report = report;
+            verify_failed = failed;
+        }
+    }
+
+    // [#3712] 눈검증 대상 페이지 — 앵커 문단이 걸친 쪽 전부.
+    let changed_pages = if dry_run {
+        serde_json::Value::Null
+    } else {
+        match doc.pages_covering_paragraphs(&[(sec, para)]) {
+            Some(pages) => serde_json::json!(pages),
+            None => serde_json::Value::Null,
+        }
+    };
+
+    if json_mode {
+        let mut envelope = serde_json::json!({
+            "schemaVersion": "1.0",
+            "source": file_path,
+            "image": image_path,
+            "page": page_arg,
+            "x": x_hu,
+            "y": y_hu,
+            "width": width_hu,
+            "height": height_hu,
+            "binDataId": bin_data_id,
+            "dryRun": dry_run,
+            "changedPages": changed_pages,
+            "overflow": overflow.clone().map(|o| vec![o]).unwrap_or_default(),
+        });
+        if !dry_run {
+            envelope["output"] = serde_json::Value::String(output_path.clone());
+            envelope["outputFormat"] = serde_json::Value::String(out_format.label().to_string());
+            envelope["verify"] = verify_report.clone();
+        }
+        println!("{envelope}");
+        if verify_failed {
+            process::exit(3);
+        }
+        return EXIT_OK;
+    }
+
+    if dry_run {
+        println!(
+            "배치 예정: {} {}쪽 ({}, {}) 크기 {}×{} HWPUNIT ← {} (원본 {}×{}px)",
+            file_path,
+            page_arg,
+            x_hu,
+            y_hu,
+            width_hu,
+            height_hu,
+            image_path,
+            natural_w_px,
+            natural_h_px
+        );
+    } else {
+        println!(
+            "그림 삽입 완료: {} → {} — {}쪽 ({}, {}) 크기 {}×{} HWPUNIT ← {} (원본 {}×{}px)",
+            file_path,
+            output_path,
+            page_arg,
+            x_hu,
+            y_hu,
+            width_hu,
+            height_hu,
+            image_path,
+            natural_w_px,
+            natural_h_px
+        );
+    }
+    if overflow.is_some() {
+        eprintln!(
+            "경고: 그림이 쪽 밖으로 나갑니다 (용지 {}×{} HWPUNIT, 오른쪽 {} 아래 {}) — 상세는 --json 의 overflow",
+            paper_w, paper_h, right, bottom
         );
     }
     if verify_failed {

--- a/tests/insert_image_contract.rs
+++ b/tests/insert_image_contract.rs
@@ -1,0 +1,1167 @@
+//! [#3719 §6-5] `edit insert-image` 출력·안전 계약 회귀 테스트 (도장·서명 삽입).
+//!
+//! 실물 서식 제출의 마지막 조각이다. 검증 원칙은 형제 편집 명령(#3381 set-cell)과 같다:
+//! ① `--dry-run` 은 파일을 만들지 않는다 ② 실패 경로의 stdout 은 0바이트 ③ 반영 여부는
+//! **산출물 재파싱**으로 확인한다(선언을 믿지 않는다) ④ 쪽 밖 배치는 조용히 잘리지 않고
+//! `overflow` 로 보고된다.
+//!
+//! 단위 함정이 이 명령의 핵심 위험이다 — 길이는 전부 HWPUNIT(1/7200 inch)이며 픽셀이
+//! 아니다. px 로 오해하면 도장이 점만 하게 찍혀도 종료 코드는 0 이므로, 크기 규약
+//! (생략=원본 픽셀 ×75 / 한쪽만=비율 유지)을 값으로 고정한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use rhwp::model::control::Control;
+use rhwp::wasm_api::HwpDocument;
+
+/// 3쪽짜리 실물 HWP5 — 형제 편집 계약 시험이 쓰는 것과 같은 문서.
+const SAMPLE: &str = "samples/field-01.hwp";
+
+/// 96dpi 픽셀 1개 = 75 HWPUNIT. CLI 의 기본 환산비와 같은 상수를 시험 쪽에서도 고정한다.
+const HWPUNIT_PER_PX: u32 = 75;
+
+fn sample() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+/// argv 에 그대로 실을 수 있는 소유 문자열 — `&[&str]` 배열이 임시값을 빌리지 않게 한다.
+fn sample_arg() -> String {
+    sample().to_string_lossy().to_string()
+}
+
+fn temp_path(tag: &str, ext: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "rhwp-insimg-{tag}-{}-{}.{ext}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos()
+    ))
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn parse_json(args: &[&str], output: &Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout 이 순수 JSON 이 아닙니다 ({e}).\n{}",
+            describe(args, output)
+        )
+    })
+}
+
+/// 시험 시점에 도장 대용 그림을 합성한다 — 이미지 파일을 저장소에 커밋하지 않기 위해서다.
+/// 가로세로를 다르게 잡아 "한쪽만 지정 시 비율 유지"를 값으로 확인할 수 있게 한다.
+fn write_stamp_as(path: &Path, format: image::ImageFormat, width: u32, height: u32) {
+    // JPEG 은 알파 채널을 받지 않는다 — 형식별 색공간 차이는 인코더에 맡기고
+    // 시험은 "확장자별로 받아들이는가" 만 본다.
+    let image = image::DynamicImage::ImageRgb8(image::RgbImage::from_pixel(
+        width,
+        height,
+        image::Rgb([210, 30, 30]),
+    ));
+    let mut bytes = Vec::new();
+    image
+        .write_to(&mut Cursor::new(&mut bytes), format)
+        .unwrap_or_else(|e| panic!("{format:?} 인코딩 실패: {e}"));
+    std::fs::write(path, &bytes).expect("도장 그림 쓰기");
+}
+
+fn write_stamp_png(path: &Path, width: u32, height: u32) {
+    write_stamp_as(path, image::ImageFormat::Png, width, height);
+}
+
+/// 문서의 쪽 수를 **문서에게 물어본다** — 샘플이 바뀌어도 시험이 거짓말하지 않게.
+fn page_count_of(path: &str) -> u64 {
+    let args = ["info", "--json", path];
+    let output = run(&args);
+    let v = parse_json(&args, &output);
+    v["pageCount"].as_u64().expect("info.pageCount")
+}
+
+/// 용지 크기(HWPUNIT)를 **CLI 에게 물어본다**.
+///
+/// A4 를 상수로 박으면 다른 규격(A3·가로)의 샘플에서 시험이 조용히 무의미해진다.
+/// 확실히 넘치는 좌표로 `--dry-run` 을 한 번 돌려 overflow 보고에서 용지 크기를 읽는다
+/// (파일을 만들지 않으므로 부작용 0).
+fn paper_size_hu(path: &str, image: &str) -> (i64, i64) {
+    let probe = "1000000";
+    let args = [
+        "edit",
+        "insert-image",
+        path,
+        "--image",
+        image,
+        "--x",
+        probe,
+        "--y",
+        probe,
+        "--dry-run",
+        "--json",
+    ];
+    let output = run(&args);
+    let v = parse_json(&args, &output);
+    let report = &v["overflow"][0];
+    (
+        report["paperWidthHu"].as_i64().expect("paperWidthHu"),
+        report["paperHeightHu"].as_i64().expect("paperHeightHu"),
+    )
+}
+
+/// `capabilities --mcp` 가 선언한 `hwp_insert_image` 도구 정의.
+fn insert_image_tool_definition() -> serde_json::Value {
+    let args = ["capabilities", "--mcp"];
+    let output = run(&args);
+    let v = parse_json(&args, &output);
+    v["tools"]
+        .as_array()
+        .expect("tools")
+        .iter()
+        .find(|t| t["name"] == "hwp_insert_image")
+        .expect("hwp_insert_image 도구")
+        .clone()
+}
+
+/// 산출물을 다시 파싱해 **실제로 들어간** 그림들의 (binDataId, 폭, 높이, x, y) 를 모은다.
+/// 선언(봉투)이 아니라 파일이 답하게 한다.
+fn pictures_of(path: &Path) -> Vec<(u16, u32, u32, u32, u32)> {
+    let bytes = std::fs::read(path).expect("산출물 읽기");
+    let doc = HwpDocument::from_bytes(&bytes).expect("산출물 파싱");
+    let mut found = Vec::new();
+    for section in &doc.document().sections {
+        for paragraph in &section.paragraphs {
+            for control in &paragraph.controls {
+                if let Control::Picture(picture) = control {
+                    found.push((
+                        picture.image_attr.bin_data_id,
+                        picture.common.width,
+                        picture.common.height,
+                        picture.common.horizontal_offset,
+                        picture.common.vertical_offset,
+                    ));
+                }
+            }
+        }
+    }
+    found
+}
+
+// ── ① 삽입 본류: 봉투 + 산출물 재파싱 ────────────────────────────────────────
+
+#[test]
+fn insert_image_writes_picture_and_reports_placement() {
+    let src = sample_arg();
+    let stamp = temp_path("stamp", "png");
+    write_stamp_png(&stamp, 40, 20);
+    let out = temp_path("out", "hwp");
+
+    // 좌표는 박지 않고 **용지 크기에서 유도**한다 — 규격이 다른 샘플로 바뀌어도
+    // "쪽 안쪽 배치" 라는 전제가 유지된다(도장은 보통 우하단에 찍힌다).
+    let (paper_w, paper_h) = paper_size_hu(src.as_str(), stamp.to_str().unwrap());
+    let width = (paper_w / 8).to_string();
+    let height = (paper_h / 16).to_string();
+    let x = (paper_w / 2).to_string();
+    let y = (paper_h / 2).to_string();
+
+    let args = [
+        "edit",
+        "insert-image",
+        src.as_str(),
+        "--image",
+        stamp.to_str().unwrap(),
+        "--page",
+        "0",
+        "--x",
+        x.as_str(),
+        "--y",
+        y.as_str(),
+        "--width",
+        width.as_str(),
+        "--height",
+        height.as_str(),
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+
+    let v = parse_json(&args, &output);
+    assert_eq!(v["schemaVersion"], "1.0", "{v}");
+    assert_eq!(v["page"], 0, "{v}");
+    assert_eq!(v["x"].as_i64(), Some(paper_w / 2), "{v}");
+    assert_eq!(v["y"].as_i64(), Some(paper_h / 2), "{v}");
+    assert_eq!(v["width"].as_i64(), Some(paper_w / 8), "{v}");
+    assert_eq!(v["height"].as_i64(), Some(paper_h / 16), "{v}");
+    assert_eq!(v["dryRun"], false, "{v}");
+    assert_eq!(v["outputFormat"], "hwp5", "{v}");
+    assert!(
+        v["overflow"].as_array().expect("overflow 배열").is_empty(),
+        "쪽 안쪽 배치인데 넘침으로 보고됐습니다: {v}"
+    );
+    // 눈검증 대상 쪽은 비어 있지 않아야 한다 — 없으면 에이전트가 검증을 건너뛴다.
+    let changed = v["changedPages"].as_array().expect("changedPages 배열");
+    assert!(!changed.is_empty(), "{v}");
+
+    let bin_data_id = v["binDataId"].as_u64().expect("binDataId") as u16;
+    assert!(bin_data_id > 0, "BinData 등록 번호가 0 입니다: {v}");
+
+    // 파일이 답한다 — 봉투가 말한 그대로의 그림이 실제로 들어갔는가.
+    assert!(out.exists(), "{}", describe(&args, &output));
+    let expected = (
+        bin_data_id,
+        (paper_w / 8) as u32,
+        (paper_h / 16) as u32,
+        (paper_w / 2) as u32,
+        (paper_h / 2) as u32,
+    );
+    let pictures = pictures_of(&out);
+    assert!(
+        pictures.contains(&expected),
+        "산출물에 봉투가 말한 그림이 없습니다: 기대 {expected:?} / 실제 {pictures:?} / {v}"
+    );
+
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&stamp);
+}
+
+/// 봉투가 **자기서술과 같은 말**을 하는가 — 매니페스트의 outputFields 전부가 실제
+/// 봉투 키로 나와야 한다. 선언만 있고 값이 없으면 파서를 자동 생성한 에이전트가 깨진다.
+#[test]
+fn envelope_carries_every_declared_output_field() {
+    let src = sample_arg();
+    let stamp = temp_path("fields", "png");
+    write_stamp_png(&stamp, 40, 20);
+    let out = temp_path("fields-out", "hwp");
+
+    let args = [
+        "edit",
+        "insert-image",
+        src.as_str(),
+        "--image",
+        stamp.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+        "--verify",
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_json(&args, &output);
+    let envelope = v.as_object().expect("봉투는 JSON 객체");
+
+    // 필드 이름을 시험에 박지 않는다 — 선언(매니페스트)을 읽어 그대로 대조한다.
+    let declared = insert_image_tool_definition();
+    let fields: Vec<&str> = declared["outputFields"]
+        .as_array()
+        .expect("outputFields")
+        .iter()
+        .filter_map(|f| f.as_str())
+        .collect();
+    assert!(fields.len() >= 10, "선언이 너무 얕습니다: {fields:?}");
+    let missing: Vec<&str> = fields
+        .iter()
+        .copied()
+        .filter(|f| !envelope.contains_key(*f))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "선언했는데 봉투에 없는 키: {missing:?}\n봉투: {v}"
+    );
+
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&stamp);
+}
+
+// ── ② 크기 규약 (HWPUNIT 함정) ───────────────────────────────────────────────
+
+#[test]
+fn omitted_size_uses_natural_pixels_in_hwpunit() {
+    let src = sample_arg();
+    // 크기를 안 주면 원본 픽셀을 96dpi 로 환산한다(px × 75). px 를 그대로 쓰면
+    // 도장이 1/75 크기로 찍히고도 종료 코드는 0 이므로 값으로 못 박는다.
+    let stamp = temp_path("natural", "png");
+    write_stamp_png(&stamp, 40, 20);
+    let out = temp_path("natural-out", "hwp");
+
+    let args = [
+        "edit",
+        "insert-image",
+        src.as_str(),
+        "--image",
+        stamp.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_json(&args, &output);
+    assert_eq!(v["width"], 40 * HWPUNIT_PER_PX, "{v}");
+    assert_eq!(v["height"], 20 * HWPUNIT_PER_PX, "{v}");
+
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&stamp);
+}
+
+#[test]
+fn single_axis_size_keeps_natural_aspect_ratio() {
+    let src = sample_arg();
+    // 도장은 보통 "폭만" 정해진다. 나머지 축을 0 이나 원본 픽셀로 두면 찌그러지므로
+    // 원본 비율(40:20)을 지켜 채우고, 결과를 봉투에 실어 조용한 보정이 없게 한다.
+    let stamp = temp_path("ratio", "png");
+    write_stamp_png(&stamp, 40, 20);
+    let out = temp_path("ratio-out", "hwp");
+
+    let args = [
+        "edit",
+        "insert-image",
+        src.as_str(),
+        "--image",
+        stamp.to_str().unwrap(),
+        "--width",
+        "8000",
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_json(&args, &output);
+    assert_eq!(v["width"], 8000, "{v}");
+    assert_eq!(v["height"], 4000, "{v}");
+
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&stamp);
+}
+
+// ── ③ dry-run 은 산출물을 만들지 않는다 ──────────────────────────────────────
+
+#[test]
+fn dry_run_creates_no_file_and_reports_plan_only() {
+    let src = sample_arg();
+    let stamp = temp_path("dry", "png");
+    write_stamp_png(&stamp, 40, 20);
+    let out = temp_path("dry-out", "hwp");
+
+    let args = [
+        "edit",
+        "insert-image",
+        src.as_str(),
+        "--image",
+        stamp.to_str().unwrap(),
+        "--x",
+        "1000",
+        "--y",
+        "2000",
+        "-o",
+        out.to_str().unwrap(),
+        "--dry-run",
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_json(&args, &output);
+    assert_eq!(v["dryRun"], true, "{v}");
+    assert!(
+        v["binDataId"].is_null(),
+        "실행 0 인데 등록 번호가 있습니다: {v}"
+    );
+    assert!(v["output"].is_null(), "{v}");
+    // 예측 목록을 실측 목록으로 오인하지 않도록 dry-run 은 null 이다(#3712 규약).
+    assert!(v["changedPages"].is_null(), "{v}");
+    assert!(
+        !out.exists(),
+        "--dry-run 이 파일을 만들었습니다: {}",
+        out.display()
+    );
+
+    let _ = std::fs::remove_file(&stamp);
+}
+
+// ── ④ 쪽 밖 배치는 자르지 않고 보고한다 ─────────────────────────────────────
+
+#[test]
+fn out_of_page_placement_is_reported_not_silently_clipped() {
+    let src = sample_arg();
+    // 에이전트는 렌더 결과를 보지 않는다. 신호가 없으면 쪽 밖으로 나간 도장을
+    // 완성본으로 판단하므로, 자르지 말고 넘친 양을 숫자로 알려야 한다.
+    let stamp = temp_path("overflow", "png");
+    write_stamp_png(&stamp, 40, 20);
+    let out = temp_path("overflow-out", "hwp");
+
+    // 용지 크기를 물어본 뒤 **딱 1 HWPUNIT 넘치게** 놓는다. 경계에서 반응하는지가
+    // 핵심이다 — 아주 큰 값으로만 시험하면 경계 off-by-one 을 못 잡는다.
+    let (paper_w, paper_h) = paper_size_hu(src.as_str(), stamp.to_str().unwrap());
+    let width_hu = 6000i64;
+    let height_hu = 3000i64;
+    let x = (paper_w - width_hu + 1).to_string();
+    let y = (paper_h - height_hu + 1).to_string();
+
+    let args = [
+        "edit",
+        "insert-image",
+        src.as_str(),
+        "--image",
+        stamp.to_str().unwrap(),
+        "--x",
+        x.as_str(),
+        "--y",
+        y.as_str(),
+        "--width",
+        "6000",
+        "--height",
+        "3000",
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "쪽 밖 배치는 실패가 아니라 보고 대상이다: {}",
+        describe(&args, &output)
+    );
+    let v = parse_json(&args, &output);
+    let overflow = v["overflow"].as_array().expect("overflow 배열");
+    assert_eq!(overflow.len(), 1, "쪽 밖 배치인데 보고가 없습니다: {v}");
+    let report = &overflow[0];
+    assert_eq!(report["overflowXHu"].as_i64(), Some(1), "{v}");
+    assert_eq!(report["overflowYHu"].as_i64(), Some(1), "{v}");
+    assert_eq!(report["paperWidthHu"].as_i64(), Some(paper_w), "{v}");
+    assert_eq!(report["paperHeightHu"].as_i64(), Some(paper_h), "{v}");
+
+    // 자르지 않았다 — 요청한 좌표·크기가 그대로 들어가 있어야 한다.
+    let pictures = pictures_of(&out);
+    assert!(
+        pictures.iter().any(|p| p.1 == width_hu as u32
+            && p.2 == height_hu as u32
+            && p.3 == (paper_w - width_hu + 1) as u32
+            && p.4 == (paper_h - height_hu + 1) as u32),
+        "쪽 밖 배치가 조용히 보정됐습니다: {pictures:?}"
+    );
+
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&stamp);
+}
+
+/// 경계 **안쪽** 1 HWPUNIT 은 넘침이 아니다 — 넘침 판정이 과민하면 정상 배치마다
+/// 거짓 경보가 뜨고, 에이전트는 경보 자체를 무시하게 된다.
+#[test]
+fn exact_page_edge_is_not_reported_as_overflow() {
+    let src = sample_arg();
+    let stamp = temp_path("edge", "png");
+    write_stamp_png(&stamp, 40, 20);
+
+    let (paper_w, paper_h) = paper_size_hu(src.as_str(), stamp.to_str().unwrap());
+    let width_hu = 6000i64;
+    let height_hu = 3000i64;
+    let x = (paper_w - width_hu).to_string();
+    let y = (paper_h - height_hu).to_string();
+
+    let args = [
+        "edit",
+        "insert-image",
+        src.as_str(),
+        "--image",
+        stamp.to_str().unwrap(),
+        "--x",
+        x.as_str(),
+        "--y",
+        y.as_str(),
+        "--width",
+        "6000",
+        "--height",
+        "3000",
+        "--dry-run",
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_json(&args, &output);
+    assert!(
+        v["overflow"].as_array().expect("overflow 배열").is_empty(),
+        "용지 경계에 정확히 닿는 배치를 넘침으로 봤습니다: {v}"
+    );
+
+    let _ = std::fs::remove_file(&stamp);
+}
+
+// ── ⑤ 인자 오류 (exit 2) + stdout 0바이트 ───────────────────────────────────
+
+#[test]
+fn unsupported_image_format_is_usage_error_with_silent_stdout() {
+    let src = sample_arg();
+    // 지원하지 않는 형식은 **인자 문제**다 — 런타임 실패(1)가 아니라 2 로 끊는다.
+    let bogus = temp_path("bogus", "svg");
+    std::fs::write(&bogus, b"<svg xmlns=\"http://www.w3.org/2000/svg\"/>").expect("bogus 쓰기");
+    let out = temp_path("bogus-out", "hwp");
+
+    let args = [
+        "edit",
+        "insert-image",
+        src.as_str(),
+        "--image",
+        bogus.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "실패 경로 stdout 은 0바이트여야 합니다: {}",
+        describe(&args, &output)
+    );
+    assert!(!out.exists(), "실패했는데 산출물이 생겼습니다");
+
+    let _ = std::fs::remove_file(&bogus);
+}
+
+#[test]
+fn extension_lie_is_caught_by_magic_bytes() {
+    let src = sample_arg();
+    // 확장자만 믿으면 BinData 에 그림 아닌 바이트가 들어가고, 크기를 못 재
+    // 배치 좌표가 의미를 잃는다. 내용으로 다시 판정해 인자 오류로 끊는다.
+    let liar = temp_path("liar", "png");
+    std::fs::write(&liar, b"NOT-A-PNG-AT-ALL").expect("liar 쓰기");
+
+    let args = [
+        "edit",
+        "insert-image",
+        src.as_str(),
+        "--image",
+        liar.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(output.stdout.is_empty(), "{}", describe(&args, &output));
+
+    let _ = std::fs::remove_file(&liar);
+}
+
+#[test]
+fn page_out_of_range_is_usage_error() {
+    let src = sample_arg();
+    let stamp = temp_path("range", "png");
+    write_stamp_png(&stamp, 40, 20);
+
+    let args = [
+        "edit",
+        "insert-image",
+        src.as_str(),
+        "--image",
+        stamp.to_str().unwrap(),
+        "--page",
+        "9999",
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(output.stdout.is_empty(), "{}", describe(&args, &output));
+
+    let _ = std::fs::remove_file(&stamp);
+}
+
+#[test]
+fn missing_image_argument_is_usage_error() {
+    let src = sample_arg();
+    let args = ["edit", "insert-image", src.as_str(), "--json"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(output.stdout.is_empty(), "{}", describe(&args, &output));
+}
+
+#[test]
+fn negative_or_non_numeric_length_is_usage_error() {
+    let src = sample_arg();
+    // 음수 오프셋은 코어가 0 으로 깎는다 — 조용한 보정 대신 인자 오류로 끊는다.
+    let stamp = temp_path("neg", "png");
+    write_stamp_png(&stamp, 40, 20);
+
+    for bad in ["-100", "3.5", "3000px"] {
+        let args = [
+            "edit",
+            "insert-image",
+            src.as_str(),
+            "--image",
+            stamp.to_str().unwrap(),
+            "--x",
+            bad,
+            "--json",
+        ];
+        let output = run(&args);
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "{}",
+            describe(&args, &output)
+        );
+        assert!(output.stdout.is_empty(), "{}", describe(&args, &output));
+    }
+
+    let _ = std::fs::remove_file(&stamp);
+}
+
+// ── ⑥ 저장 직후 자기검증 (--verify) ─────────────────────────────────────────
+
+#[test]
+fn verify_reports_identical_ir_after_save() {
+    let src = sample_arg();
+    let stamp = temp_path("verify", "png");
+    write_stamp_png(&stamp, 40, 20);
+    let out = temp_path("verify-out", "hwp");
+
+    let args = [
+        "edit",
+        "insert-image",
+        src.as_str(),
+        "--image",
+        stamp.to_str().unwrap(),
+        "--x",
+        "10000",
+        "--y",
+        "10000",
+        "-o",
+        out.to_str().unwrap(),
+        "--verify",
+        "--json",
+    ];
+    let output = run(&args);
+    let v = parse_json(&args, &output);
+    // 판정은 데이터다 — verify 봉투가 반드시 있어야 하고, 차이가 있으면 exit 3.
+    assert!(v["verify"].is_object(), "--verify 봉투 누락: {v}");
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "저장본 재파싱 IR 차이: {}",
+        describe(&args, &output)
+    );
+
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&stamp);
+}
+
+// ── ⑦ 입력 형식 보존 (HWPX 입력 → HWPX 산출) ────────────────────────────────
+
+#[test]
+fn hwpx_input_keeps_hwpx_output_format() {
+    const HWPX_SAMPLE: &str = "samples/2025년 기부·답례품 실적 지자체 보고서_양식.hwpx";
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join(HWPX_SAMPLE);
+    if !src.exists() {
+        eprintln!("HWPX 샘플 없음 — 건너뜀");
+        return;
+    }
+    let stamp = temp_path("hwpx", "png");
+    write_stamp_png(&stamp, 40, 20);
+    let out = temp_path("hwpx-out", "hwpx");
+
+    let args = [
+        "edit",
+        "insert-image",
+        src.to_str().unwrap(),
+        "--image",
+        stamp.to_str().unwrap(),
+        "--x",
+        "20000",
+        "--y",
+        "20000",
+        "--width",
+        "5000",
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_json(&args, &output);
+    assert_eq!(v["outputFormat"], "hwpx", "{v}");
+    assert!(out.exists(), "{}", describe(&args, &output));
+
+    let pictures = pictures_of(&out);
+    assert!(
+        pictures.iter().any(|p| p.1 == 5000 && p.3 == 20000),
+        "HWPX 산출물에 그림이 없습니다: {pictures:?}"
+    );
+
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&stamp);
+}
+
+// ── ⑧ 형식별 수용 (png·jpg·jpeg·bmp·tif·tiff) ──────────────────────────────
+
+#[test]
+fn every_declared_format_is_actually_accepted() {
+    // 형식 목록은 도움말·오류 문구가 광고하는 계약이다. 선언만 하고 실제로는 거부하면
+    // 에이전트는 "지원한다더니 안 된다" 는 막다른 길에 선다 — 확장자마다 실제로 넣어 본다.
+    let src = sample_arg();
+    let cases: [(&str, image::ImageFormat); 6] = [
+        ("png", image::ImageFormat::Png),
+        ("jpg", image::ImageFormat::Jpeg),
+        ("jpeg", image::ImageFormat::Jpeg),
+        ("bmp", image::ImageFormat::Bmp),
+        ("tif", image::ImageFormat::Tiff),
+        ("tiff", image::ImageFormat::Tiff),
+    ];
+
+    for (ext, format) in cases {
+        let stamp = temp_path(&format!("fmt-{ext}"), ext);
+        write_stamp_as(&stamp, format, 40, 20);
+        let out = temp_path(&format!("fmt-{ext}-out"), "hwp");
+
+        let args = [
+            "edit",
+            "insert-image",
+            src.as_str(),
+            "--image",
+            stamp.to_str().unwrap(),
+            "-o",
+            out.to_str().unwrap(),
+            "--json",
+        ];
+        let output = run(&args);
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "{ext} 를 받아들이지 못했습니다.\n{}",
+            describe(&args, &output)
+        );
+        let v = parse_json(&args, &output);
+        // 원본 픽셀을 형식과 무관하게 같은 규약으로 읽어야 한다(40×20 → ×75).
+        assert_eq!(v["width"], 40 * HWPUNIT_PER_PX, "{ext}: {v}");
+        assert_eq!(v["height"], 20 * HWPUNIT_PER_PX, "{ext}: {v}");
+        assert!(v["binDataId"].as_u64().unwrap_or(0) > 0, "{ext}: {v}");
+        assert!(out.exists(), "{ext}: 산출물 없음");
+
+        let _ = std::fs::remove_file(&out);
+        let _ = std::fs::remove_file(&stamp);
+    }
+}
+
+// ── ⑨ 쪽 지정(앵커) ─────────────────────────────────────────────────────────
+
+#[test]
+fn page_argument_anchors_the_picture_on_that_page() {
+    // `--page N` 은 "N쪽에 놓아라" 는 뜻이고, 그 판정은 조판이 한다. 앵커 문단을
+    // 잘못 고르면 도장이 다른 쪽에 찍히는데 종료 코드는 0 이다 — changedPages 가
+    // 요청한 쪽을 담는지로 확인한다(쪽 번호를 박지 않고 문서에게 물어 순회).
+    let src = sample_arg();
+    let stamp = temp_path("anchor", "png");
+    write_stamp_png(&stamp, 40, 20);
+
+    let pages = page_count_of(src.as_str());
+    assert!(
+        pages >= 2,
+        "쪽 지정 시험에는 2쪽 이상이 필요합니다: {pages}"
+    );
+
+    for page in 0..pages {
+        let page_arg = page.to_string();
+        let out = temp_path(&format!("anchor-{page}"), "hwp");
+        let args = [
+            "edit",
+            "insert-image",
+            src.as_str(),
+            "--image",
+            stamp.to_str().unwrap(),
+            "--page",
+            page_arg.as_str(),
+            "-o",
+            out.to_str().unwrap(),
+            "--json",
+        ];
+        let output = run(&args);
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "{}",
+            describe(&args, &output)
+        );
+        let v = parse_json(&args, &output);
+        assert_eq!(v["page"].as_u64(), Some(page), "{v}");
+        let changed: Vec<u64> = v["changedPages"]
+            .as_array()
+            .expect("changedPages")
+            .iter()
+            .filter_map(|p| p.as_u64())
+            .collect();
+        assert!(
+            changed.contains(&page),
+            "{page}쪽을 요청했는데 바뀐 쪽 목록에 없습니다 (앵커 문단 오선택): {changed:?} / {v}"
+        );
+
+        let _ = std::fs::remove_file(&out);
+    }
+
+    // 마지막 쪽 다음은 인자 오류다 — 쪽 수도 문서에게 물어 유도한다.
+    let over = pages.to_string();
+    let args = [
+        "edit",
+        "insert-image",
+        src.as_str(),
+        "--image",
+        stamp.to_str().unwrap(),
+        "--page",
+        over.as_str(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(output.stdout.is_empty(), "{}", describe(&args, &output));
+
+    let _ = std::fs::remove_file(&stamp);
+}
+
+// ── ⑩ 없는 파일 — 런타임 실패(1)이지 인자 오류(2)가 아니다 ──────────────────
+
+#[test]
+fn missing_files_are_runtime_errors_with_silent_stdout() {
+    // 종료 코드 사전(#2707)의 구분을 지킨다: 인자 형태는 맞는데 그 파일이 없는 것은
+    // 런타임 실패(1)다. 형식 미지원(2)과 뒤섞이면 에이전트의 재시도 판단이 무너진다.
+    let src = sample_arg();
+    let stamp = temp_path("exists", "png");
+    write_stamp_png(&stamp, 40, 20);
+    let ghost_image = temp_path("ghost", "png");
+    let ghost_doc = temp_path("ghost-doc", "hwp");
+
+    // ① 그림이 없다
+    let args = [
+        "edit",
+        "insert-image",
+        src.as_str(),
+        "--image",
+        ghost_image.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(output.stdout.is_empty(), "{}", describe(&args, &output));
+
+    // ② 문서가 없다
+    let args = [
+        "edit",
+        "insert-image",
+        ghost_doc.to_str().unwrap(),
+        "--image",
+        stamp.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(output.stdout.is_empty(), "{}", describe(&args, &output));
+
+    let _ = std::fs::remove_file(&stamp);
+}
+
+#[test]
+fn unknown_option_and_duplicate_input_are_usage_errors() {
+    let src = sample_arg();
+    let stamp = temp_path("parse", "png");
+    write_stamp_png(&stamp, 40, 20);
+
+    // 알 수 없는 옵션을 조용히 무시하면 "요청한 대로 됐다" 는 거짓 성공이 된다.
+    let args = [
+        "edit",
+        "insert-image",
+        src.as_str(),
+        "--image",
+        stamp.to_str().unwrap(),
+        "--rotate",
+        "90",
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(output.stdout.is_empty(), "{}", describe(&args, &output));
+
+    // 입력 파일은 하나뿐이다.
+    let args = [
+        "edit",
+        "insert-image",
+        src.as_str(),
+        src.as_str(),
+        "--image",
+        stamp.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(output.stdout.is_empty(), "{}", describe(&args, &output));
+
+    // 값이 필요한 플래그에 값이 없다.
+    for flag in [
+        "--image", "--page", "--x", "--y", "--width", "--height", "-o",
+    ] {
+        let args = ["edit", "insert-image", src.as_str(), flag];
+        let output = run(&args);
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "{flag}: {}",
+            describe(&args, &output)
+        );
+        assert!(
+            output.stdout.is_empty(),
+            "{flag}: {}",
+            describe(&args, &output)
+        );
+    }
+
+    // 0 크기는 그림이 아니다.
+    for flag in ["--width", "--height"] {
+        let args = [
+            "edit",
+            "insert-image",
+            src.as_str(),
+            "--image",
+            stamp.to_str().unwrap(),
+            flag,
+            "0",
+            "--json",
+        ];
+        let output = run(&args);
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "{flag}: {}",
+            describe(&args, &output)
+        );
+        assert!(
+            output.stdout.is_empty(),
+            "{flag}: {}",
+            describe(&args, &output)
+        );
+    }
+
+    let _ = std::fs::remove_file(&stamp);
+}
+
+// ── ⑪ 자기서술 계약 (capabilities / MCP) ────────────────────────────────────
+
+#[test]
+fn capabilities_and_mcp_declare_insert_image_axis() {
+    // 매니페스트만 읽는 에이전트에게는 선언이 곧 기능이다 — 빠지면 영영 못 쓴다.
+    let cap: serde_json::Value =
+        serde_json::from_slice(&run(&["capabilities"]).stdout).expect("capabilities JSON");
+    let edit = cap["commands"]
+        .as_array()
+        .expect("commands")
+        .iter()
+        .find(|c| c["name"] == "edit")
+        .expect("edit 항목");
+    let flags: Vec<&str> = edit["flags"]
+        .as_array()
+        .expect("edit flags")
+        .iter()
+        .filter_map(|f| f.as_str())
+        .collect();
+    for expected in ["--image", "--page", "--x", "--y", "--width", "--height"] {
+        assert!(
+            flags.contains(&expected),
+            "edit flags 에 {expected} 누락: {flags:?}"
+        );
+    }
+
+    let mcp: serde_json::Value = serde_json::from_slice(&run(&["capabilities", "--mcp"]).stdout)
+        .expect("capabilities --mcp JSON");
+    let tool = mcp["tools"]
+        .as_array()
+        .expect("tools")
+        .iter()
+        .find(|t| t["name"] == "hwp_insert_image")
+        .expect("hwp_insert_image 도구");
+    let required: Vec<&str> = tool["inputSchema"]["required"]
+        .as_array()
+        .expect("required 배열")
+        .iter()
+        .filter_map(|r| r.as_str())
+        .collect();
+    assert!(required.contains(&"path"), "{tool}");
+    assert!(required.contains(&"image"), "{tool}");
+    // 단위 함정은 설명에 박혀 있어야 한다 — 픽셀로 오해하면 도장이 사라진다.
+    let description = tool["description"].as_str().unwrap_or_default();
+    assert!(description.contains("HWPUNIT"), "{tool}");
+    let output_fields: Vec<&str> = tool["outputFields"]
+        .as_array()
+        .expect("outputFields")
+        .iter()
+        .filter_map(|f| f.as_str())
+        .collect();
+    for expected in ["binDataId", "overflow", "changedPages"] {
+        assert!(
+            output_fields.contains(&expected),
+            "hwp_insert_image 출력 계약에 {expected} 누락: {tool}"
+        );
+    }
+
+    // 선언한 입력 속성은 전부 자식 CLI 에 닿아야 한다. 닿지 않으면 서버가 그 인자를
+    // 조용히 버리고 성공을 보고한다 — 도구 하나 범위에서 같은 규칙을 다시 못 박는다.
+    let wired: Vec<String> = tool["cli"]["args"]
+        .as_array()
+        .expect("cli.args")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .filter(|s| s.starts_with('{') && s.ends_with('}') && s.len() > 2)
+        .map(|s| s[1..s.len() - 1].to_string())
+        .chain(
+            tool["cli"]["optionalArgs"]
+                .as_array()
+                .expect("cli.optionalArgs")
+                .iter()
+                .filter_map(|o| o["when"].as_str().map(String::from)),
+        )
+        .collect();
+    let properties = tool["inputSchema"]["properties"]
+        .as_object()
+        .expect("properties");
+    let orphans: Vec<&String> = properties.keys().filter(|k| !wired.contains(k)).collect();
+    assert!(
+        orphans.is_empty(),
+        "선언만 되고 배선되지 않은 입력 인자: {orphans:?}\n{tool}"
+    );
+
+    // 선언한 CLI 플래그는 실제로 수용돼야 한다 — 매니페스트가 광고한 축을 그대로 호출해 본다.
+    let src = sample_arg();
+    let stamp = temp_path("declared", "png");
+    write_stamp_png(&stamp, 40, 20);
+    let out = temp_path("declared-out", "hwp");
+    let args = [
+        "edit",
+        "insert-image",
+        src.as_str(),
+        "--image",
+        stamp.to_str().unwrap(),
+        "--page",
+        "0",
+        "--x",
+        "1000",
+        "--y",
+        "1000",
+        "--width",
+        "3000",
+        "--height",
+        "1500",
+        "-o",
+        out.to_str().unwrap(),
+        "--verify",
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "선언한 플래그 조합이 거부됐습니다.\n{}",
+        describe(&args, &output)
+    );
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&stamp);
+
+    // `--help` 에도 있어야 한다(사람용/기계용 양방향 현행화).
+    let help = String::from_utf8_lossy(&run(&["--help"]).stdout).to_string();
+    assert!(help.contains("edit insert-image"), "--help 에 누락");
+    assert!(help.contains("HWPUNIT"), "--help 에 단위 규약 누락");
+    for flag in ["--image", "--page", "--x", "--y", "--width", "--height"] {
+        assert!(help.contains(flag), "--help 에 {flag} 안내 누락");
+    }
+}


### PR DESCRIPTION
#3719 §6-5. 도장·서명·로고를 문서에 넣는다 — `rhwp edit insert-image`.

## 무엇

```
rhwp edit insert-image <파일> --image <그림> [--page N] [--x --y --width --height]
                              [--dry-run] [--verify] [-o …] [--json]
```

MCP 도구 `hwp_insert_image` 동시 등록. **새 삽입·조판 로직은 0이다** — 코어
`insert_picture_native`(picture.rs:1433 본문 floating 분기)와 `dump_page_items_json`(쪽→앵커 문단),
`pages_covering_paragraphs`(changedPages), `edit_output_format`/`edit_serialize`/`edit_verify_report`
를 그대로 재사용했다.

## 곁가지로 잡은 코어 결함 — `--verify` 가 **정상 삽입에도 항상 exit 3** 이었다

이 PR 의 실질 가치는 여기다.

`insert_picture_native` 는 `img_dim` 을 `(0,0)` 으로 둔다. 그런데 HWP5 직렬화기는
`crop.right/bottom` 을 **원본 크기 자리에** 쓰고, HWP5 파서는 그걸 되읽어 `img_dim` 으로 넣는다.
그래서 왕복하면 값이 달라진다:

```
imgDim: expected=(0,0) actual=(3000,1500)   diffCount=1  → exit 3
```

삽입은 멀쩡한데 검증이 **항상 실패를 보고**한다. `--verify` 를 믿는 에이전트는 정상 작업을
실패로 판단하고 되돌리거나 재시도한다.

세 분기 Picture 에 **직렬화기가 이미 쓰던 값**을 채워 정합했다. 렌더러
`compute_image_crop_src` 가 `imgDim` 부재 시 같은 값을 폴백으로 쓰므로 **배율이 동일 = 렌더 불변**이고,
HWPX 산출의 `imgDim 0/0` 비대칭도 함께 해소된다. `cargo test --release --lib` **3,030 passed** 로
무회귀를 확인했다.

## 실측

- 빌드 7분 59초, 경고 0
- 계약 시험 **합계 100 passed / 0 failed** — insert_image 19(신규) · cli_json 26 · mcp_server 22 ·
  agent_profile_router 7 · edit_set_cell 5 · edit_verify 4 · changed_pages 5 · edit_fill_fields 7 ·
  edit_replace_text 5
- `cargo test --release --lib` **3,030 passed / 0 failed** / 7 ignored
- `cargo clippy -- -D warnings` 경고 0 · rustfmt 차이 0
- MCP 실호출 왕복: `tools/call hwp_insert_image` → 474,112바이트 산출, `isError:false`

**드리프트 가드 전부 통과**: `required` 배열 `["path","image"]` · 9속성 전부 CLI 배선(미배선 0) ·
`--json`↔MCP 도구 26종 · capabilities↔help 양방향 · 선언 flags 실제 수용 ·
실패 경로 stdout 0바이트(인자 오류 7종 + 런타임 실패 2종 **전수**).
`commands[edit].flags` 에 신규 6개를 넣으면서 **기존 누락이던 `--verify` 도 정정**했다.

## 남은 것 (의도적 범위 밖)

1. **`agent_profiles.rs` 의 `행정서식` 프로필에 `hwp_insert_image` 미등재** — 그 역할로 필터링한
   에이전트는 아직 못 쓴다. 한 줄이면 되지만 같은 목록을 동시 작업 중인 다른 축들이 건드려서
   **충돌 회피로 분리**했다. 별도 PR 로 올린다
2. 세션 도구 `hwp_doc_insert_image` 없음 (무상태 CLI/MCP 만)
3. 표 셀·글상자 좌표 지정 미노출 — 코어는 `cell_path` 를 지원하나 v1 은 본문 용지 기준만
4. `mydocs/manual/cli_commands.md` 미반영 — 동시 수정 중인 파일이라 범위 밖
