### PR TITLE
[#3719 §6-6] batch fill — 메일머지 (데이터 행 입력 + 산출 이름 정규화, 편집 로직 재사용)

### DIFF
--- a/mydocs/report/task_m100_batch_fill/README.md
+++ b/mydocs/report/task_m100_batch_fill/README.md
@@ -1,0 +1,171 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_batch_fill/README.md
+last_verified: 2026-08-02
+---
+
+# #3719 §6-6 처리 기록 — `batch fill` (서식 1 + 데이터 N행 → 산출 N개)
+
+## 문제
+
+`edit fill-fields` 는 서식 1 → 산출 1 이다. 100명분 통지서를 만들려면 에이전트가
+같은 도구를 100번 부르고, 그 사이 "몇 번째까지 했는지"를 스스로 들고 있어야 한다.
+중간에 한 건이 실패하면 어디서 끊겼는지도 호출자의 기억에만 남는다. 메일머지는
+문서 도구의 기본 수요인데 rhwp 에는 그 축이 없었다.
+
+한편 `batch` 축은 이미 있다. 하지만 기존 7축의 입력은 **파일 경로 목록(stdin)** 이다.
+메일머지의 입력은 경로가 아니라 **행**이다 — 같은 문서를 N번 여는 대신, 한 서식에
+N개의 값 묶음을 붙인다. 이 차이를 뭉개면(예: 행마다 서식을 복사한 임시 파일을 만들어
+stdin 으로 흘리기) 임시 파일 관리라는 새 실패 축이 생긴다.
+
+## 구현
+
+### 1. 채움 로직은 새로 쓰지 않았다 — 코어를 갈랐다
+
+`edit_fill_fields` 를 둘로 나눴다(`src/main.rs`).
+
+- `fill_fields_core(file_path, data, out_path, dry_run, verify) -> Result<FillOutcome, String>`
+  — 채움의 **단 하나의** 구현. 종전 `edit_fill_fields` 본문 그대로다.
+- `edit_fill_fields(args)` — 인자 파싱 + 사람용/JSON 출력만 남은 껍데기.
+
+배치가 새 편집 경로를 갖지 않는 것이 요점이다. 순번 지목(`이름[N]`, #3476)·모호성
+보고(`ambiguous`)·혼동 이름 경고(`confusable`, #3707)·형식 보존(#3383)·저장 직후
+자기검증(#3702)·`changedPages`(#3712)가 두 곳으로 갈라지면, 단건으로 검증한 서식이
+배치에서 다르게 채워지고 그 차이는 **산출물 N개가 나온 뒤에야** 드러난다.
+
+실패 표현만 바꿨다. 종전에는 `eprintln!` + `return EXIT_RUNTIME` 이었는데, 배치는
+뒤 행이 남아 있어 프로세스를 끊을 수 없다. 그래서 코어는 `Err(사람이 읽는 사유)` 를
+돌려주고, 단건은 stderr + exit 1 로, 배치는 그 행의 `error` 레코드로 바꾼다.
+
+### 2. 스트리밍 기계도 새로 쓰지 않았다 — 공유했다
+
+`run_batch` 안에 인라인돼 있던 "작업 간 병렬 + 한계 재정렬 버퍼" 를
+`batch_stream_records(n, threads, make, out) -> BatchStreamTally` 로 뽑았다.
+작업 단위가 무엇인지는 `make: Fn(usize) -> Value + Sync` 가 정하고,
+순서 보존·역압(back-pressure)·broken pipe 중단·종료 코드 집계는 두 축이 공유한다.
+
+- `run_batch`: `make = |idx| batch_record(mode, &paths[idx])` (경로)
+- `run_batch_fill`: `make = |idx| batch_fill_record(form, idx, &rows[idx], …)` (행)
+
+종료 코드 집계는 `BatchStreamTally::exit_code()` 한 곳으로 모았다 —
+`error` 있으면 1 > `verifyPages` 불일치 4 > `verify` 차이 3 > 0.
+
+### 3. `fill` 축은 파싱부터 갈랐다
+
+`run_batch` 최상단에서 `fill` 이면 바로 `run_batch_fill(&args[1..])` 로 넘긴다.
+stdin 경로 목록 읽기를 **절대 타지 않게** 하는 것이 목적이다. MCP 서버가 자식을
+띄울 때 stdin 을 null 로 닫으므로(`mcp_serve::run_cli_tool`) 읽으려 들면 그 자리에서
+빈 목록이 되는데, 그 경로 자체를 없앴다.
+
+### 4. 산출 이름 — 미리, 결정적으로, 덮어쓰지 않게
+
+`batch_fill_output_paths` 가 **한 바이트도 쓰기 전에** 전 행의 경로를 정한다
+(`batch convert` 의 사전 충돌 점검과 같은 규약).
+
+- `--name-field` 값 → `sanitize_output_stem` → 비면 1 기준 순번(`0001`, 최소 4자리)
+- 금지 문자(`< > : " / \ | ? *`)·제어 문자는 `_` 로 치환 → 구분자가 사라지므로
+  `../../탈출` 같은 값도 `--out-dir` 밖으로 나갈 수 없다
+- Windows 가 조용히 잘라내는 이름 끝 공백·점 제거, 예약 장치 이름(CON·NUL·COM1…)은
+  앞에 `_`
+- 80자 상한(경로 260자 한도 여유)
+- 중복은 소문자 키로 판정해 `_2`·`_3` 을 붙인다 — 대소문자만 다른 이름도 한 파일이
+  되는 파일시스템에서 **Linux CI 는 통과하고 사용자만 데이터를 잃는** 사고를 막는다
+
+미리 계산하는 두 번째 이유는 병렬 실행에서도 이름이 행 순서만으로 정해지기 때문이다.
+`--threads 1` 과 `--threads 8` 의 결과가 같아야 한다.
+
+### 5. 데이터 읽기 — JSONL / CSV
+
+- `.jsonl`·`.ndjson`: 한 줄 한 객체. 빈 줄은 건너뛴다.
+- `.csv`: 첫 줄 헤더 = 누름틀 이름. `parse_csv_records` 는 RFC 4180 그 자체만 구현한다
+  (따옴표 안의 쉼표·줄바꿈·`""`, CRLF/LF). 전용 crate 를 새로 들이지 않았다.
+- UTF-8 BOM 제거 — 엑셀 저장본을 남겨 두면 첫 헤더가 `BOM+이름` 이 되어 그 열이
+  통째로 `notFound` 가 된다(오류 없이 한 칸 빈 문서가 나온다).
+
+**행의 결함은 파일 전체의 실패가 아니다.** 깨진 JSONL 줄·헤더와 칸 수가 다른 CSV 행은
+`FillRow::Broken` 으로 들고 가서 `error` 레코드가 된다. 반면 확장자·헤더 중복·빈 헤더·
+닫히지 않은 따옴표·0행은 **한 행도 처리하기 전에** 끝낼 입력 오류라 exit 2 다.
+
+### 6. 표면 동기화 (드리프트 가드)
+
+- `capabilities`: `batch.subcommands` += `fill`,
+  `batch.flags` += `--form`·`--name-field`·`--dry-run`,
+  `commands[batch].flags` 동일 갱신(축 선언과 항목 선언이 어긋나면 안 된다),
+  `batch.input`·`batch.output`·`batch.mcp.available` 에 fill 의 다른 입력 축 명시
+- `capabilities --mcp`: `hwp_batch_fill` 신규 —
+  `required: ["form","data","outDir"]`, 선택 3종은 `optionalArgs.when` 으로 배선
+  (`nameField`→`--name-field`, `verify`→`--verify`, `dryRun`→`--dry-run`).
+  `MCP_STDIN_TOOLS` 에는 **넣지 않았다** — stdin 을 읽지 않는다.
+- `--help`: `batch fill` 전용 블록. "이 축만 stdin 을 읽지 않는다"를 못 박았다.
+
+## 명령 계약
+
+```
+rhwp batch fill --form <서식.hwp|서식.hwpx> --data <행.jsonl|행.csv> --out-dir <폴더> --json
+                [--name-field <필드>] [--verify] [--dry-run] [--threads <N>]
+```
+
+레코드(행마다 한 줄)는 단건 `edit fill-fields --json` 봉투 + `row` 다.
+
+| 상황 | 레코드 | 종료 코드 |
+| --- | --- | --- |
+| 전 행 성공 | `{schemaVersion, source, row, dryRun, output, outputFormat, filledCount, filled, notFound, ambiguous, confusable, changedPages, verify}` | 0 |
+| 서식에 없는 이름 섞임 | 위와 같되 `notFound:[…]` (**행 실패가 아니다**) | 0 |
+| 행 파싱 실패·채움 실패 | `{schemaVersion, source, row, error, exitClass:"runtime"}` | 1 |
+| 인자·데이터 형식 오류 | 없음(stdout 0바이트) | 2 |
+| `--verify` 불일치 | `verify:{identical:false, diffCount:N}` (산출물은 남는다) | 3 |
+
+`--dry-run` 은 `dryRun:true` 와 함께 **만들 예정** 경로를 `output` 에 담는다.
+디스크에는 파일도 폴더도 만들지 않는다 — 선검증은 실행과 같은 명령줄에서 `--dry-run`
+하나만 빼면 되는 것이라야 뜻이 있어서 `--out-dir` 는 이때도 요구한다.
+
+## 실측 (evidence.txt 원문)
+
+1. JSONL 3행 → 산출 3개, `--name-field 작성자` 값이 겹치자 `홍길동.hwp` /
+   `홍길동_2.hwp` 로 갈렸다(덮어쓰기 0). exit 0, 19ms/32스레드.
+2. 엑셀 CSV(BOM+CRLF+따옴표): `주식회사 가,나` · `줄1\n줄2` · `인용 "값"` 이 그대로
+   들어갔고 `notFound` 는 비었다. `홍/길:동` → `홍_길_동.hwp`, 이름 필드가 빈 행은
+   `0002.hwp`. `--verify` 는 두 행 다 `identical:true`.
+3. 깨진 행 2개를 섞은 4행: 레코드 **4건 전부**(`row` 0·1·2·3), 산출 2개, exit 1.
+   순번은 `0001`·`0004` 로 행 번호를 따라간다(실패 행이 순번을 당기지 않는다).
+4. `--dry-run`: 레코드 3건 `dryRun:true`·`changedPages:null`, out-dir 자체가 생기지
+   않음, exit 0.
+5. stdin 에 쓰레기 2줄을 흘려도 결과 동일(3행 3산출) — 데이터는 파일에서만 온다.
+6. 인자 오류 8종 전부 exit 2 / stdout 0바이트 / out-dir 미생성.
+7. 축 스코프 6종 전부 exit 2 (`batch info --form|--name-field|--dry-run`,
+   `batch fill --mode|--query|--verify-pages`).
+8. 자기서술: `batch.subcommands` 에 `fill`, `batch.flags` 10종, `commands[batch].flags`
+   동일, `hwp_batch_fill` 의 `required`/`props`/`args`/`optionalArgs` 전부 배선,
+   `invocation.stdinTools` 에는 없음.
+
+## 검증
+
+- 신규 `tests/batch_fill_contract.rs` **25건 green**
+  (기본 축 2 · CSV 2 · 이름 충돌·정규화 5 · 실패 전파 4 · 선검증/입력축/verify 3 ·
+   인자 오류 1(8케이스) · 축 스코프 1 · 자기서술 4 · 부분 성공 2 · 재파싱 1).
+- 무회귀: `batch_axes_contract` 17 · `cli_json_contract` 26 · `mcp_server_contract` 22 ·
+  `edit_fill_fields_contract` 7 · `changed_pages_contract` 5 · `run_plan_contract` 8.
+- `cargo clippy -- -D warnings` 0.
+- fmt: 변경한 `.rs` 2개 `rustfmt --check` clean
+  (이 PC 는 `cargo fmt --all` 이 os error 206 으로 불가 → 파일 단위 `newline_style=Auto`).
+
+드리프트 가드는 기존 것 + 신규 자기서술 테스트가 모두 통과한다:
+`capabilities_mcp_tool_definitions_contract`(required 배열) ·
+`every_declared_input_property_is_wired_to_the_cli`(선언=배선) ·
+`capabilities_covers_every_help_command` / `help_covers_every_capabilities_command` ·
+`capabilities_declared_flags_are_real_cli_flags`(축↔항목 일치) ·
+신규 `declared_batch_flags_are_accepted_by_some_axis`(선언한 플래그를 CLI 가 실제로 수용).
+
+## 남은 것
+
+- **매뉴얼**: `mydocs/manual/cli_commands.md` 의 `batch` 절에 fill 축을 추가해야 한다.
+  이번 작업은 같은 저장소를 동시에 만지는 다른 작업과 충돌하지 않도록
+  `src/main.rs` · 신규 테스트 · 본 보고서로 범위를 한정했다.
+- **암호 문서**: `batch` 축 전체가 `--password` 계열을 거부한다(기존 규약). 암호 서식의
+  메일머지는 batch 의 credential 전달 계약이 정의된 뒤의 일이다.
+- **입력 형식 혼합**: 산출 형식은 서식 형식을 따른다(HWPX 서식 → HWPX 산출). fill 축에는
+  형식을 바꾸는 스위치를 두지 않았다 — 형식 변환은 `convert`/`export-hwpx` 의 책임이다.
+- **`--out-dir` 의 기존 파일**: 중복 해소는 이번 실행 안에서만 한다. 같은 폴더에 두 번
+  실행하면 앞 실행의 산출물을 덮어쓴다(`batch convert` 와 같은 동작). 실행 간 보존이
+  필요하면 별도 이슈로 다룬다.

--- a/mydocs/report/task_m100_batch_fill/evidence.txt
+++ b/mydocs/report/task_m100_batch_fill/evidence.txt
@@ -1,0 +1,119 @@
+=== rhwp v0.8.2 / upstream/devel a8d7bdfbf / 2026-08-02T11:14:52Z ===
+=== 실행 환경: Windows 11, release 빌드 (RUSTFLAGS=-C linker=rust-lld) ===
+
+--- [1] 서식의 실제 누름틀 (테스트 데이터의 출처 — 이름을 하드코딩하지 않는다) ---
+$ rhwp fields samples/field-01.hwp --json
+      5 "name":"목차1"
+      1 "name":"부서명"
+      1 "name":"이메일"
+      1 "name":"작성자"
+      1 "name":"전화번호"
+      1 "name":"제목"
+      1 "name":"회사명"
+
+--- [2] JSONL 3행 -> 산출 3개, --name-field 값이 겹치면 _2 (덮어쓰지 않는다) ---
+$ rhwp batch fill --form samples/field-01.hwp --data rows.jsonl --out-dir out1 --name-field 작성자 --json
+{"ambiguous":[],"changedPages":[0,2],"confusable":[],"dryRun":false,"filled":[{"name":"작성자","occurrence":0,"value":"홍길동"},{"name":"제목","occurrence":0,"value":"1분기"},{"name":"회사명","occurrence":0,"value":"가나다 주식회사"}],"filledCount":3,"notFound":[],"output":"C:/Users/swsz9/AppData/Local/Temp/claude/C--/d6031f1b-3749-41c1-b386-cad754a4b595/scratchpad/ev/out1\\홍길동.hwp","outputFormat":"hwp5","row":0,"schemaVersion":"1.0","source":"samples/field-01.hwp","verify":null}
+{"ambiguous":[],"changedPages":[0,2],"confusable":[],"dryRun":false,"filled":[{"name":"작성자","occurrence":0,"value":"김철수"},{"name":"제목","occurrence":0,"value":"2분기"},{"name":"회사명","occurrence":0,"value":"라마바 주식회사"}],"filledCount":3,"notFound":[],"output":"C:/Users/swsz9/AppData/Local/Temp/claude/C--/d6031f1b-3749-41c1-b386-cad754a4b595/scratchpad/ev/out1\\김철수.hwp","outputFormat":"hwp5","row":1,"schemaVersion":"1.0","source":"samples/field-01.hwp","verify":null}
+{"ambiguous":[],"changedPages":[0,2],"confusable":[],"dryRun":false,"filled":[{"name":"작성자","occurrence":0,"value":"홍길동"},{"name":"제목","occurrence":0,"value":"3분기"},{"name":"회사명","occurrence":0,"value":"사아자"}],"filledCount":3,"notFound":[],"output":"C:/Users/swsz9/AppData/Local/Temp/claude/C--/d6031f1b-3749-41c1-b386-cad754a4b595/scratchpad/ev/out1\\홍길동_2.hwp","outputFormat":"hwp5","row":2,"schemaVersion":"1.0","source":"samples/field-01.hwp","verify":null}
+batch fill: 3행 중 3 성공, 0 실패 (14ms, threads=32)
+exit=0
+산출 파일: 김철수.hwp 홍길동.hwp 홍길동_2.hwp 
+
+--- [3] CSV: BOM + CRLF + 따옴표 안의 쉼표/줄바꿈/이중따옴표 (엑셀 저장본) ---
+$ rhwp batch fill --form samples/field-01.hwp --data rows.csv --out-dir out2 --name-field 작성자 --verify --json
+{"ambiguous":[],"changedPages":[0,2],"confusable":[],"dryRun":false,"filled":[{"name":"작성자","occurrence":0,"value":"홍/길:동"},{"name":"제목","occurrence":0,"value":"줄1\n줄2"},{"name":"회사명","occurrence":0,"value":"주식회사 가,나"}],"filledCount":3,"notFound":[],"output":"C:/Users/swsz9/AppData/Local/Temp/claude/C--/d6031f1b-3749-41c1-b386-cad754a4b595/scratchpad/ev/out2\\홍_길_동.hwp","outputFormat":"hwp5","row":0,"schemaVersion":"1.0","source":"samples/field-01.hwp","verify":{"diffCount":0,"identical":true}}
+{"ambiguous":[],"changedPages":[0,2],"confusable":[],"dryRun":false,"filled":[{"name":"작성자","occurrence":0,"value":""},{"name":"제목","occurrence":0,"value":"인용 \"값\""},{"name":"회사명","occurrence":0,"value":"사아자"}],"filledCount":3,"notFound":[],"output":"C:/Users/swsz9/AppData/Local/Temp/claude/C--/d6031f1b-3749-41c1-b386-cad754a4b595/scratchpad/ev/out2\\0002.hwp","outputFormat":"hwp5","row":1,"schemaVersion":"1.0","source":"samples/field-01.hwp","verify":{"diffCount":0,"identical":true}}
+batch fill: 2행 중 2 성공, 0 실패 (18ms, threads=32)
+exit=0
+산출 파일: 0002.hwp 홍_길_동.hwp    (금지문자 / : 는 _ 로 치환, 이름 필드가 비면 순번)
+
+--- [4] 실패 행은 스트림에 남는다 (사라지면 처리 누락을 셀 수 없다) + exit 1 ---
+$ rhwp batch fill --form samples/field-01.hwp --data broken.jsonl --out-dir out3 --json
+{"ambiguous":[],"changedPages":[0],"confusable":[],"dryRun":false,"filled":[{"name":"회사명","occurrence":0,"value":"정상 앞"}],"filledCount":1,"notFound":[],"output":"C:/Users/swsz9/AppData/Local/Temp/claude/C--/d6031f1b-3749-41c1-b386-cad754a4b595/scratchpad/ev/out3\\0001.hwp","outputFormat":"hwp5","row":0,"schemaVersion":"1.0","source":"samples/field-01.hwp","verify":null}
+{"error":"JSONL 행 파싱 실패 - expected value at line 1 column 1","exitClass":"runtime","row":1,"schemaVersion":"1.0","source":"samples/field-01.hwp"}
+{"error":"JSONL 행은 {\"필드이름\":\"값\"} 형식의 JSON 객체여야 합니다","exitClass":"runtime","row":2,"schemaVersion":"1.0","source":"samples/field-01.hwp"}
+{"ambiguous":[],"changedPages":[0],"confusable":[],"dryRun":false,"filled":[{"name":"회사명","occurrence":0,"value":"정상 뒤"}],"filledCount":1,"notFound":[],"output":"C:/Users/swsz9/AppData/Local/Temp/claude/C--/d6031f1b-3749-41c1-b386-cad754a4b595/scratchpad/ev/out3\\0004.hwp","outputFormat":"hwp5","row":3,"schemaVersion":"1.0","source":"samples/field-01.hwp","verify":null}
+batch fill: 4행 중 2 성공, 2 실패 (14ms, threads=32)
+exit=1
+산출 파일: 0001.hwp 0004.hwp    (4행 중 2행만 산출, 레코드는 4건 전부)
+
+--- [5] --dry-run: 산출 0, 폴더조차 만들지 않는다, exit 0 ---
+$ rhwp batch fill ... --out-dir out4 --dry-run --json
+{"ambiguous":[],"changedPages":null,"confusable":[],"dryRun":true,"filled":[{"name":"작성자","occurrence":0,"value":"홍길동"},{"name":"제목","occurrence":0,"value":"1분기"},{"name":"회사명","occurrence":0,"value":"가나다 주식회사"}],"filledCount":3,"notFound":[],"output":"C:/Users/swsz9/AppData/Local/Temp/claude/C--/d6031f1b-3749-41c1-b386-cad754a4b595/scratchpad/ev/out4\\0001.hwp","outputFormat":"hwp5","row":0,"schemaVersion":"1.0","source":"samples/field-01.hwp"}
+{"ambiguous":[],"changedPages":null,"confusable":[],"dryRun":true,"filled":[{"name":"작성자","occurrence":0,"value":"김철수"},{"name":"제목","occurrence":0,"value":"2분기"},{"name":"회사명","occurrence":0,"value":"라마바 주식회사"}],"filledCount":3,"notFound":[],"output":"C:/Users/swsz9/AppData/Local/Temp/claude/C--/d6031f1b-3749-41c1-b386-cad754a4b595/scratchpad/ev/out4\\0002.hwp","outputFormat":"hwp5","row":1,"schemaVersion":"1.0","source":"samples/field-01.hwp"}
+{"ambiguous":[],"changedPages":null,"confusable":[],"dryRun":true,"filled":[{"name":"작성자","occurrence":0,"value":"홍길동"},{"name":"제목","occurrence":0,"value":"3분기"},{"name":"회사명","occurrence":0,"value":"사아자"}],"filledCount":3,"notFound":[],"output":"C:/Users/swsz9/AppData/Local/Temp/claude/C--/d6031f1b-3749-41c1-b386-cad754a4b595/scratchpad/ev/out4\\0003.hwp","outputFormat":"hwp5","row":2,"schemaVersion":"1.0","source":"samples/field-01.hwp"}
+batch fill: 3행 중 3 성공, 0 실패 (2ms, threads=32, dry-run)
+exit=0
+out4 존재? 아니오
+
+--- [6] 데이터는 stdin 이 아니라 --data 파일이다 (stdin 쓰레기를 무시) ---
+$ printf "이 줄은 경로도 데이터도 아니다\n" | rhwp batch fill ... --out-dir out5 --json
+batch fill: 3행 중 3 성공, 0 실패 (15ms, threads=32)
+{"ambiguous":[],"changedPages":[0,2],"confusable":[],"dryRun":false,"filled":[{"name":"작성자","occurrence":0,"value":"홍길동"},{"name":"제목","occurrence":0,"value":"1분기"},{"name":"회사명","occurrence":0,"value":"가나다 주식회사"}],"filledCount":3,"notFound":[],"output":"C:/Users/swsz9/AppData/Local/Temp/claude/C--/d6031f1b-3749-41c1-b386-cad754a4b595/scratchpad/ev/out5\\0001.hwp","outputFormat":"hwp5","row":0,"schemaVersion":"1.0","source":"samples/field-01.hwp","verify":null}
+산출 파일 수: 3   (stdin 2줄을 읽었다면 결과가 달라진다)
+
+--- [7] 인자 오류는 전부 exit 2, stdout 0 바이트, 산출물 0 ---
+  --form 없음 -> exit=2 stdout=0바이트  "오류: batch fill 은 --form <서식> --data <행 파일> --out-dir <폴더> 가 모두 필요합니다."
+  --data 없음 -> exit=2 stdout=0바이트  "오류: batch fill 은 --form <서식> --data <행 파일> --out-dir <폴더> 가 모두 필요합니다."
+  --out-dir 없음 -> exit=2 stdout=0바이트  "오류: batch fill 은 --form <서식> --data <행 파일> --out-dir <폴더> 가 모두 필요합니다."
+  --json 없음 -> exit=2 stdout=0바이트  "오류: batch 는 현재 --json 출력만 지원합니다."
+  모르는 확장자 -> exit=2 stdout=0바이트  "오류: --data 는 .jsonl 또는 .csv 여야 합니다 - .txt"
+  0행 -> exit=2 stdout=0바이트  "오류: --data 에 데이터 행이 없습니다 - C:/Users/swsz9/AppData/Local/Temp/claude/C--/d6031f1b-3749-41c1-b386-cad754a4b595/scratchpad/ev/empty.jsonl"
+  CSV 따옴표 미종료 -> exit=2 stdout=0바이트  "오류: --data CSV 의 따옴표가 닫히지 않았습니다."
+  CSV 헤더 중복 -> exit=2 stdout=0바이트  "오류: --data CSV 헤더에 같은 이름이 두 번 있습니다 - 회사명"
+  out-dir x 생성? 아니오
+
+--- [8] 축 스코프: fill 전용 플래그는 다른 축에서, 다른 축 플래그는 fill 에서 거부 ---
+  rhwp batch info --json --form f -> exit=2
+  rhwp batch info --json --name-field n -> exit=2
+  rhwp batch info --json --dry-run -> exit=2
+  rhwp batch fill --json --mode auto -> exit=2
+  rhwp batch fill --json --query 가 -> exit=2
+  rhwp batch fill --json --verify-pages -> exit=2
+
+--- [9] 자기서술 드리프트 가드 (jq 로 발췌) ---
+$ rhwp capabilities | jq -c "{subcommands: .batch.subcommands, flags: .batch.flags}"
+{"subcommands":["export-text","info","export-structure","export-tables","fields","search","convert","fill"],"flags":["--json","--threads","--mode","--query","--out-dir","--verify","--verify-pages","--form","--name-field","--dry-run"]}
+$ rhwp capabilities | jq -c ".commands[]|select(.name==\"batch\")|.flags"
+["--json","--threads","--mode","--query","--out-dir","--verify","--verify-pages","--form","--name-field","--dry-run"]
+$ rhwp capabilities | jq -r ".batch.input"
+stdin, 한 줄당 파일 경로 하나 (batch 에서는 경로 목록 전용). 단 fill 축은 stdin 을 읽지 않는다 — --form 서식 1개 + --data 행 파일(.jsonl|.csv) 1개를 받고, 한 행이 산출물 하나가 된다
+$ rhwp capabilities | jq -r ".batch.output"
+convert·fill 축만 파일을 쓴다. convert: 목적지는 --out-dir 하나, 이름은 <입력이름>.hwp — 대소문자만 다른 이름을 포함해 같은 이름이 둘 이상이면 한 건도 쓰지 않고 exit 2. fill: 이름은 --name-field 값(파일명 금지 문자는 _ 로 치환), 없으면 0001 순번이며 겹치면 뒤에 _2·_3 을 붙여 덮어쓰지 않는다
+$ rhwp capabilities --mcp | jq -c ".tools[]|select(.name==\"hwp_batch_fill\")|{required, props, args, optional}"
+{"required":["form","data","outDir"],"props":["data","dryRun","form","nameField","outDir","verify"],"args":["batch","fill","--json","--form","{form}","--data","{data}","--out-dir","{outDir}"],"optional":["nameField","verify","dryRun"]}
+$ rhwp capabilities --mcp | jq -c ".invocation.stdinTools"     (fill 은 stdin 도구가 아니다)
+["hwp_batch","hwp_batch_search"]
+
+--- [10] --help 발췌 ---
+  batch fill --form <서식> --data <행.jsonl|행.csv> --out-dir <폴더> --json [옵션]
+      서식 1개 + 데이터 N행 → 산출 N개 (메일머지). 행마다 NDJSON 레코드 하나
+      이 축만 stdin 을 읽지 않는다 — 다른 batch 축은 stdin 으로 파일 경로
+      목록을 받지만, fill 의 입력은 경로가 아니라 --data 파일의 '행'이다
+
+      --form <서식>           누름틀이 있는 템플릿 문서 (필수)
+      --data <행 파일>        .jsonl: 한 줄에 {"필드이름":"값"} 객체 하나
+                              .csv:   첫 줄 헤더 = 누름틀 이름 (BOM·따옴표 허용)
+      --out-dir <폴더>        산출물을 모을 폴더 (필수)
+      --name-field <필드>     산출 파일 이름으로 쓸 데이터 필드
+                              생략 시 0001.hwp 순번. 파일명 금지 문자는 _ 로
+                              치환하고, 이름이 겹치면 뒤에 _2 를 붙인다
+      --verify                행마다 저장 직후 자기검증 (차이 → 3)
+
+--- [11] 검증 (CI 와 같은 명령) ---
+$ cargo test --release --test batch_fill_contract --test batch_axes_contract --test cli_json_contract --test mcp_server_contract --test edit_fill_fields_contract --test changed_pages_contract --test run_plan_contract
+     Running tests\batch_axes_contract.rs (target\release\deps\batch_axes_contract-dd2be36da61aace0.exe)
+test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.07s
+     Running tests\batch_fill_contract.rs (target\release\deps\batch_fill_contract-178b84ebc9977459.exe)
+test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.37s
+     Running tests\changed_pages_contract.rs (target\release\deps\changed_pages_contract-1c54539e2b55b1e6.exe)
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.71s
+     Running tests\cli_json_contract.rs (target\release\deps\cli_json_contract-ee6cdd976ade5bc1.exe)
+test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.93s
+     Running tests\edit_fill_fields_contract.rs (target\release\deps\edit_fill_fields_contract-6896b3e2856d48ec.exe)
+test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.51s
+     Running tests\mcp_server_contract.rs (target\release\deps\mcp_server_contract-5191a9bfb95cd860.exe)
+test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 28.06s
+     Running tests\run_plan_contract.rs (target\release\deps\run_plan_contract-e9406484337789b2.exe)
+test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.54s

--- a/src/main.rs
+++ b/src/main.rs
@@ -878,6 +878,49 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
                 "matches",
             ],
         ),
+        // [#3719 §6-6] 진짜 메일머지. hwp_fill_fields 는 서식 1 → 산출 1 이라, 100명분을
+        // 만들려면 도구를 100번 부르고 그 사이 상태를 에이전트가 들고 있어야 한다. 이
+        // 도구는 서식 1 + 데이터 N행 → 산출 N개를 한 번의 호출로 끝낸다.
+        tool_with_optional_args(
+            "hwp_batch_fill",
+            "서식 하나에 데이터 여러 행을 채워 산출 문서 N개를 한 번에 만든다 (메일머지). 데이터는 .jsonl(한 줄 한 객체) 또는 .csv(첫 줄 헤더 = 누름틀 이름) **파일 경로**로 준다 — 다른 batch 도구와 달리 stdin 파일 목록이 아니다. 먼저 hwp_fields 로 서식의 필드 이름을 확인한다. 응답은 행마다 한 줄인 NDJSON 이며, 실패한 행도 error 레코드로 남으므로 처리 누락을 셀 수 있다. dryRun 으로 파일을 만들지 않고 각 행이 채워지는지만 선검증할 수 있다.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "form": { "type": "string", "description": "서식 HWP/HWPX 문서 경로 (누름틀이 있는 템플릿 1개)" },
+                    "data": { "type": "string", "description": "데이터 행 파일 경로. .jsonl 이면 한 줄에 {\"필드이름\":\"값\"} 객체 하나, .csv 면 첫 줄 헤더가 누름틀 이름(BOM·따옴표 허용)" },
+                    "outDir": { "type": "string", "description": "산출 문서를 모을 폴더. 없으면 만든다" },
+                    "nameField": { "type": "string", "description": "산출 파일 이름으로 쓸 데이터 필드 이름. 생략하면 0001·0002 순번. 파일명 금지 문자는 _ 로 치환하고 이름이 겹치면 뒤에 _2 를 붙인다" },
+                    "verify": { "type": "boolean", "description": "true 면 행마다 저장 직후 자기검증(저장본 재파싱 IR 대조). 차이가 있으면 CLI 종료 코드 3" },
+                    "dryRun": { "type": "boolean", "description": "true 면 파일을 쓰지 않고 각 행이 채울 수 있는지만 판정" }
+                },
+                "required": ["form", "data", "outDir"],
+            }),
+            "batch",
+            serde_json::json!(["batch", "fill", "--json", "--form", "{form}", "--data", "{data}", "--out-dir", "{outDir}"]),
+            serde_json::json!([
+                { "when": "nameField", "args": ["--name-field", "{nameField}"] },
+                { "when": "verify", "args": ["--verify"] },
+                { "when": "dryRun", "args": ["--dry-run"] }
+            ]),
+            &[
+                "schemaVersion",
+                "source",
+                "row",
+                "dryRun",
+                "output",
+                "outputFormat",
+                "filledCount",
+                "filled",
+                "notFound",
+                "ambiguous",
+                "confusable",
+                "changedPages",
+                "verify",
+                "error",
+                "exitClass",
+            ],
+        ),
         tool_with_optional_args(
             "hwp_replace_text",
             "HWP 문서 전체에서 문자열을 일괄 치환해 새 문서를 만든다 (기관명 변경·연도 갱신·용어 정비). dryRun 으로 파일을 만들지 않고 치환 예정 건수만 확인할 수 있다. 치환 0건이면 출력 파일을 만들지 않는다. 산출물은 입력 형식을 따른다(HWPX 입력 → HWPX 산출).",
@@ -1353,11 +1396,12 @@ fn capabilities_command_entries() -> Vec<serde_json::Value> {
         cmd_json(
             "batch",
             "batch",
-            "stdin 파일 목록을 한 프로세스에서 파일 간 병렬 처리, NDJSON 스트림 출력",
+            "stdin 파일 목록을 한 프로세스에서 파일 간 병렬 처리, NDJSON 스트림 출력 (fill 축만 stdin 대신 --form 서식 + --data 행 파일로 메일머지)",
             true,
-            // --query 는 search 축의 필수 인자다(없으면 exit 2). --out-dir,
-            // --verify, --verify-pages 는 convert 축 전용이다. 모두 같은 top-level
-            // batch 명령의 인자이므로 축 단위 batch.flags 와 함께 명령 항목에도 선언한다.
+            // --query 는 search 축의 필수 인자다(없으면 exit 2). --out-dir 는 convert·fill
+            // 공용, --verify-pages 는 convert 전용, --form·--name-field·--dry-run 은 fill
+            // 전용이다. 모두 같은 top-level batch 명령의 인자이므로 축 단위 batch.flags 와
+            // 함께 명령 항목에도 선언한다.
             &[
                 "--json",
                 "--threads",
@@ -1366,8 +1410,20 @@ fn capabilities_command_entries() -> Vec<serde_json::Value> {
                 "--out-dir",
                 "--verify",
                 "--verify-pages",
+                "--form",
+                "--name-field",
+                "--dry-run",
             ],
-            &["schemaVersion", "source", "error", "exitClass"],
+            &[
+                "schemaVersion",
+                "source",
+                "error",
+                "exitClass",
+                "row",
+                "output",
+                "filledCount",
+                "notFound",
+            ],
         ),
         // ── 진단 ──
         cmd("dump", "diagnostic", "문서 조판부호 구조 덤프"),
@@ -1585,15 +1641,17 @@ fn show_capabilities(args: &[String]) -> i32 {
             },
         },
         "batch": {
-            "subcommands": ["export-text", "info", "export-structure", "export-tables", "fields", "search", "convert"],
-            "flags": ["--json", "--threads", "--mode", "--query", "--out-dir", "--verify", "--verify-pages"],
-            "ordering": "stdin 입력 순서 보존",
-            "input": "stdin, 한 줄당 파일 경로 하나 (batch 에서는 경로 목록 전용)",
+            "subcommands": ["export-text", "info", "export-structure", "export-tables", "fields", "search", "convert", "fill"],
+            "flags": ["--json", "--threads", "--mode", "--query", "--out-dir", "--verify", "--verify-pages", "--form", "--name-field", "--dry-run"],
+            "ordering": "입력 순서 보존 (fill 은 데이터 행 순서)",
+            // [#3719] fill 축만 입력 축이 다르다 — 여기를 읽고 stdin 에 경로를 밀어 넣으면
+            // 그 프로세스는 아무것도 읽지 않은 채 데이터 파일만 처리한다.
+            "input": "stdin, 한 줄당 파일 경로 하나 (batch 에서는 경로 목록 전용). 단 fill 축은 stdin 을 읽지 않는다 — --form 서식 1개 + --data 행 파일(.jsonl|.csv) 1개를 받고, 한 행이 산출물 하나가 된다",
             "authentication": "지원하지 않음 — --password·--password-stdin·--output-password·--output-password-stdin 은 usage error; 암호화 batch 의 credential 전달 계약은 아직 정의되지 않았다",
-            // [#3626] convert 축만 파일을 쓴다 — 목적지·충돌 규약·종료 코드 집계를 밝힌다.
-            "output": "convert 축만 파일을 쓴다 — 목적지는 --out-dir 하나, 이름은 <입력이름>.hwp. 대소문자만 다른 이름을 포함해 같은 이름이 둘 이상이면 한 건도 쓰지 않고 exit 2",
+            // [#3626→#3719] 파일을 쓰는 축(convert·fill)의 목적지·충돌 규약을 밝힌다.
+            "output": "convert·fill 축만 파일을 쓴다. convert: 목적지는 --out-dir 하나, 이름은 <입력이름>.hwp — 대소문자만 다른 이름을 포함해 같은 이름이 둘 이상이면 한 건도 쓰지 않고 exit 2. fill: 이름은 --name-field 값(파일명 금지 문자는 _ 로 치환), 없으면 0001 순번이며 겹치면 뒤에 _2·_3 을 붙여 덮어쓰지 않는다",
             "mcp": {
-                "available": ["export-text", "info", "export-structure", "export-tables", "fields", "search (hwp_batch_search)"],
+                "available": ["export-text", "info", "export-structure", "export-tables", "fields", "search (hwp_batch_search)", "fill (hwp_batch_fill)"],
                 "excluded": { "convert": "파일을 쓰는 축이라 현재 hwp_batch MCP 도구에는 노출하지 않으며 CLI 에서만 사용한다" },
             },
             "exitAggregation": "error 레코드가 하나라도 있으면 1, 없고 verifyPages 불일치가 있으면 4, verify 차이만 있으면 3, 전부 통과면 0",
@@ -1694,8 +1752,23 @@ fn print_help() {
     println!("      --out-dir <폴더>        convert 전용(필수): 산출물을 모을 폴더");
     println!("                              산출 이름은 <입력이름>.hwp — 이름이 겹치면");
     println!("                              한 건도 쓰지 않고 사용법 오류(2)로 끝낸다");
-    println!("      --verify                convert 전용: 재파싱 IR 비교 (전건 차이 → 3)");
+    println!("      --verify                convert·fill 전용: 재파싱 IR 비교 (차이 → 3)");
     println!("      --verify-pages          convert 전용: 재파싱 쪽수 비교 (전건 불일치 → 4)");
+    println!();
+    println!("  batch fill --form <서식> --data <행.jsonl|행.csv> --out-dir <폴더> --json [옵션]");
+    println!("      서식 1개 + 데이터 N행 → 산출 N개 (메일머지). 행마다 NDJSON 레코드 하나");
+    println!("      이 축만 stdin 을 읽지 않는다 — 다른 batch 축은 stdin 으로 파일 경로");
+    println!("      목록을 받지만, fill 의 입력은 경로가 아니라 --data 파일의 '행'이다");
+    println!();
+    println!("      --form <서식>           누름틀이 있는 템플릿 문서 (필수)");
+    println!("      --data <행 파일>        .jsonl: 한 줄에 {{\"필드이름\":\"값\"}} 객체 하나");
+    println!("                              .csv:   첫 줄 헤더 = 누름틀 이름 (BOM·따옴표 허용)");
+    println!("      --out-dir <폴더>        산출물을 모을 폴더 (필수)");
+    println!("      --name-field <필드>     산출 파일 이름으로 쓸 데이터 필드");
+    println!("                              생략 시 0001.hwp 순번. 파일명 금지 문자는 _ 로");
+    println!("                              치환하고, 이름이 겹치면 뒤에 _2 를 붙인다");
+    println!("      --verify                행마다 저장 직후 자기검증 (차이 → 3)");
+    println!("      --dry-run               파일을 만들지 않고 각 행의 채움 가능 여부만 판정");
     println!();
     println!("  export-markdown <파일.hwp> [옵션]");
     println!("      페이지별 텍스트를 Markdown(.md)으로 내보내기");
@@ -4041,9 +4114,15 @@ fn export_markdown(args: &[String]) -> i32 {
 fn run_batch(args: &[String]) -> i32 {
     use std::io::{BufRead, Write};
 
-    const USAGE: &str = "사용법: <파일 목록> | rhwp batch <export-text|info|export-structure|export-tables|fields|search|convert> --json [--mode auto|outline|clause] [--query <검색어>] [--threads <N>] [convert: --out-dir <폴더> [--verify] [--verify-pages]]  (stdin: 한 줄당 파일 경로 하나)";
+    const USAGE: &str = "사용법: <파일 목록> | rhwp batch <export-text|info|export-structure|export-tables|fields|search|convert> --json [--mode auto|outline|clause] [--query <검색어>] [--threads <N>] [convert: --out-dir <폴더> [--verify] [--verify-pages]]  (stdin: 한 줄당 파일 경로 하나)\n      rhwp batch fill --form <서식> --data <행.jsonl|행.csv> --out-dir <폴더> --json  (fill 만 stdin 을 읽지 않는다)";
 
     let subcommand = args.first().map(String::as_str);
+    // [#3719 §6-6] fill 축은 **입력 축 자체가 다르다** — stdin 파일 목록이 아니라 서식 1 개와
+    // 데이터 파일 1 개를 받고, 산출은 행 수만큼 나온다. 인자 문법이 다른 축과 겹치지 않으므로
+    // 파싱부터 갈라 놓는다(경로 목록 읽기를 절대 타지 않게 하는 것이 요점이다).
+    if subcommand == Some("fill") {
+        return run_batch_fill(&args[1..]);
+    }
     let is_structure = subcommand == Some("export-structure");
     // [#3346] --query 는 search 축 전용이다 (--mode 가 export-structure 전용인 것과 같은 규약).
     let is_search = subcommand == Some("search");
@@ -4061,7 +4140,7 @@ fn run_batch(args: &[String]) -> i32 {
     ) {
         match subcommand {
             Some(unknown) => eprintln!(
-                "오류: batch 는 export-text·info·export-structure·export-tables·fields·search·convert 만 지원합니다 - {}",
+                "오류: batch 는 export-text·info·export-structure·export-tables·fields·search·convert·fill 만 지원합니다 - {}",
                 unknown
             ),
             None => eprintln!("오류: batch 서브커맨드를 지정해주세요."),
@@ -4283,13 +4362,84 @@ fn run_batch(args: &[String]) -> i32 {
     let stdout = std::io::stdout();
     let mut out = std::io::BufWriter::new(stdout.lock());
 
-    // 파일 간 병렬 처리 + 한계 재정렬 버퍼(bounded reorder buffer) 스트리밍.
-    //
-    // 배리어 없이 완전 병렬로 돌리되, 완료 레코드는 stdin 입력 순서대로 즉시 방출한다.
-    // 완료-미방출 레코드가 cap 을 넘으면 워커가 대기(역압)해 메모리를 상한한다.
-    // 단, 방출 차례(next_emit) 레코드는 cap 과 무관하게 넣을 수 있어야 교착이 없다 —
-    // 느린 파일 하나가 버퍼를 채워도, 그 파일이 곧 방출 차례이므로 항상 전진한다.
-    let n = paths.len();
+    let tally = batch_stream_records(
+        paths.len(),
+        threads,
+        |idx| batch_record(mode, &paths[idx]),
+        &mut out,
+    );
+
+    if tally.aborted {
+        return EXIT_RUNTIME;
+    }
+    if let Err(e) = out.flush() {
+        eprintln!("오류: stdout 쓰기 실패 - {}", e);
+        return EXIT_RUNTIME;
+    }
+
+    eprintln!(
+        "batch: {}건 중 {} 성공, {} 실패 ({}ms, threads={})",
+        tally.emitted,
+        tally.emitted - tally.failed,
+        tally.failed,
+        started.elapsed().as_millis(),
+        threads
+    );
+    if tally.verify_diff > 0 || tally.verify_pages_diff > 0 {
+        eprintln!(
+            "batch: 검증 판정 — verify 차이 {}건, verify-pages 불일치 {}건 (변환·저장 자체는 성공)",
+            tally.verify_diff, tally.verify_pages_diff
+        );
+    }
+    tally.exit_code()
+}
+
+/// [#3238→#3719] batch 축이 공유하는 스트리밍 집계 결과.
+struct BatchStreamTally {
+    emitted: usize,
+    failed: usize,
+    verify_diff: usize,
+    verify_pages_diff: usize,
+    /// stdout 소비자가 끊겨(broken pipe 등) 스트림을 끝까지 내지 못했다.
+    aborted: bool,
+}
+
+impl BatchStreamTally {
+    /// [#3626] 종료 코드 집계. 하드 실패(산출물이 아예 없음)가 가장 나쁘므로 기존 규약대로
+    /// 1 이 우선한다. 그 아래는 단건 convert 의 우선순위를 그대로 따른다 — 단건도 쪽수
+    /// 검사를 IR 검사보다 먼저 해 exit 4 로 끊는다. 검증 판정을 1 로 접지 않는 이유는
+    /// 소비자가 재실행 대상(1)과 검토 대상(3/4)을 갈라야 하기 때문이다.
+    fn exit_code(&self) -> i32 {
+        if self.failed > 0 {
+            EXIT_RUNTIME
+        } else if self.verify_pages_diff > 0 {
+            4
+        } else if self.verify_diff > 0 {
+            3
+        } else {
+            EXIT_OK
+        }
+    }
+}
+
+/// [#3238→#3719] 작업 간 병렬 처리 + 한계 재정렬 버퍼(bounded reorder buffer) 스트리밍.
+///
+/// 배리어 없이 완전 병렬로 돌리되, 완료 레코드는 **입력 순서대로** 즉시 방출한다.
+/// 완료-미방출 레코드가 cap 을 넘으면 워커가 대기(역압)해 메모리를 상한한다.
+/// 단, 방출 차례(next_emit) 레코드는 cap 과 무관하게 넣을 수 있어야 교착이 없다 —
+/// 느린 작업 하나가 버퍼를 채워도, 그 작업이 곧 방출 차례이므로 항상 전진한다.
+///
+/// [#3719] `run_batch`(stdin 경로 목록)와 `run_batch_fill`(데이터 행)이 이 하나를 쓴다.
+/// 작업 단위가 무엇인지는 `make` 가 정하고, 순서 보존·역압·종료 코드 집계 규약은 공유한다.
+fn batch_stream_records<F>(
+    n: usize,
+    threads: usize,
+    make: F,
+    out: &mut impl std::io::Write,
+) -> BatchStreamTally
+where
+    F: Fn(usize) -> serde_json::Value + Sync,
+{
     let cap = threads.saturating_mul(8).max(1);
     let next_claim = std::sync::atomic::AtomicUsize::new(0);
     let abort = std::sync::atomic::AtomicBool::new(false);
@@ -4309,7 +4459,7 @@ fn run_batch(args: &[String]) -> i32 {
                 if idx >= n {
                     break;
                 }
-                let record = batch_record(mode, &paths[idx]);
+                let record = make(idx);
                 let mut guard = buf.lock().expect("batch buf lock");
                 while guard.len() >= cap
                     && idx != next_emit.load(std::sync::atomic::Ordering::Relaxed)
@@ -4373,7 +4523,190 @@ fn run_batch(args: &[String]) -> i32 {
         (failed, emitted, verify_diff, verify_pages_diff)
     });
 
-    if abort.load(std::sync::atomic::Ordering::Relaxed) {
+    BatchStreamTally {
+        emitted,
+        failed,
+        verify_diff,
+        verify_pages_diff,
+        aborted: abort.load(std::sync::atomic::Ordering::Relaxed),
+    }
+}
+
+// ─── [#3719 §6-6] batch fill — 서식 1 + 데이터 N행 → 산출 N개 (진짜 메일머지) ───
+
+/// 데이터 파일의 한 행. 읽지 못한 행도 **버리지 않고** 들고 간다 — 스트림에서 조용히
+/// 사라지면 소비자는 N행을 넣고 N-1건을 받고도 그것을 성공으로 읽는다.
+enum FillRow {
+    Data(serde_json::Map<String, serde_json::Value>),
+    /// 이 행을 읽지 못한 사유. 그대로 `error` 레코드가 된다.
+    Broken(String),
+}
+
+/// [#3719 §6-6] `batch fill` — 서식 하나에 데이터 N행을 채워 산출 N개를 만든다.
+///
+/// 다른 batch 축과 **입력 축이 다르다**: stdin 은 읽지 않고, `--data` 파일의 한 행이
+/// 산출물 하나가 된다(기존 축의 입력은 '경로'지만 여기서는 '행'이다). 채움 자체는 단건
+/// `edit fill-fields` 와 같은 `fill_fields_core` 를 행마다 부를 뿐 — 새 편집 로직은 없다.
+fn run_batch_fill(args: &[String]) -> i32 {
+    use std::io::Write;
+
+    const USAGE: &str = "사용법: rhwp batch fill --form <서식.hwp|서식.hwpx> --data <행.jsonl|행.csv> --out-dir <폴더> --json [--name-field <필드>] [--verify] [--dry-run] [--threads <N>]\n      데이터는 stdin 이 아니라 --data 파일이다 — 다른 batch 축은 stdin 으로 파일 경로 목록을 받지만 fill 의 입력은 경로가 아니라 '행'이다.";
+
+    let mut form: Option<&str> = None;
+    let mut data_path: Option<&str> = None;
+    let mut out_dir: Option<std::path::PathBuf> = None;
+    let mut name_field: Option<&str> = None;
+    let mut json_mode = false;
+    let mut verify_mode = false;
+    let mut dry_run = false;
+    let mut threads_opt: Option<usize> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        // 옵션 이름은 리터럴로 고정한다 — 인자에서 온 문자열을 그대로 찍으면 CodeQL
+        // cleartext-logging 대상이 된다(batch convert 의 --verify 와 같은 규약).
+        let opt: &'static str = match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+                continue;
+            }
+            "--verify" => {
+                verify_mode = true;
+                i += 1;
+                continue;
+            }
+            "--dry-run" => {
+                dry_run = true;
+                i += 1;
+                continue;
+            }
+            "--form" => "--form",
+            "--data" => "--data",
+            "--out-dir" => "--out-dir",
+            "--name-field" => "--name-field",
+            "--threads" => "--threads",
+            other => {
+                eprintln!("알 수 없는 옵션: {}", other);
+                eprintln!("{USAGE}");
+                return EXIT_USAGE;
+            }
+        };
+        let Some(value) = args.get(i + 1) else {
+            eprintln!("오류: {opt} 뒤에 값이 필요합니다.");
+            eprintln!("{USAGE}");
+            return EXIT_USAGE;
+        };
+        // 값 자리에 플래그가 오면 삼키지 않는다 — 삼키면 "지정했다고 믿는 옵션이 실제로는
+        // 없는" 채로 실행돼 산출물이 엉뚱한 곳에 생긴다.
+        if value.is_empty() || value.starts_with('-') {
+            eprintln!(
+                "오류: {opt} 뒤에 플래그가 아닌 값이 필요합니다 (이름이 - 로 시작하면 ./ 를 붙이세요)."
+            );
+            return EXIT_USAGE;
+        }
+        match opt {
+            "--form" => form = Some(value),
+            "--data" => data_path = Some(value),
+            "--out-dir" => out_dir = Some(std::path::PathBuf::from(value)),
+            "--name-field" => name_field = Some(value),
+            _ => match value.parse::<usize>() {
+                Ok(n) if n >= 1 => threads_opt = Some(n),
+                _ => {
+                    eprintln!("오류: 스레드 수가 올바르지 않습니다 - {}", value);
+                    return EXIT_USAGE;
+                }
+            },
+        }
+        i += 2;
+    }
+
+    if !json_mode {
+        eprintln!("오류: batch 는 현재 --json 출력만 지원합니다.");
+        eprintln!("{USAGE}");
+        return EXIT_USAGE;
+    }
+    // `--dry-run` 에서도 --out-dir 를 요구한다. 선검증은 **실행과 같은 명령줄에서 --dry-run
+    // 하나만 빼면 되는 것**이라야 뜻이 있다 — 인자 모양이 다르면 선검증이 통과한 명령과
+    // 실제로 실행하는 명령이 서로 다른 명령이 된다.
+    let (Some(form), Some(data_path), Some(out_dir)) = (form, data_path, out_dir.as_deref()) else {
+        eprintln!(
+            "오류: batch fill 은 --form <서식> --data <행 파일> --out-dir <폴더> 가 모두 필요합니다."
+        );
+        eprintln!("{USAGE}");
+        return EXIT_USAGE;
+    };
+
+    // 서식은 행마다 다시 열린다. 못 여는 서식이면 N행을 다 돌고 같은 실패를 N번 보고하게
+    // 되므로 — 그건 진단이 아니다 — 한 행을 처리하기 전에 여기서 한 번 판정한다.
+    let form_bytes = match fs::read(form) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("오류: 서식을 읽을 수 없습니다 - {}: {}", form, e);
+            return EXIT_RUNTIME;
+        }
+    };
+    if let Err(e) = rhwp::wasm_api::HwpDocument::from_bytes(&form_bytes) {
+        eprintln!("오류: 서식 HWP 파싱 실패 - {}: {}", form, e);
+        return EXIT_RUNTIME;
+    }
+    // [#3383] 산출 형식은 서식 형식을 따른다 — 파일 이름의 확장자도 여기서 정해진다.
+    let out_format = edit_output_format(&form_bytes, None);
+
+    let rows = match read_fill_rows(Path::new(data_path)) {
+        Ok(r) => r,
+        Err((message, code)) => {
+            eprintln!("오류: {message}");
+            if code == EXIT_USAGE {
+                eprintln!("{USAGE}");
+            }
+            return code;
+        }
+    };
+
+    // 산출 경로는 **한 행도 쓰기 전에** 전부 정한다 — 병렬 실행에서도 이름이 행 순서만으로
+    // 결정되고, 이름 충돌 해소가 실행 순서에 좌우되지 않는다.
+    let outputs = batch_fill_output_paths(&rows, out_dir, name_field, out_format.ext());
+    if !dry_run {
+        if let Err(e) = fs::create_dir_all(out_dir) {
+            eprintln!(
+                "오류: 출력 폴더를 만들 수 없습니다 - {}: {}",
+                out_dir.display(),
+                e
+            );
+            return EXIT_RUNTIME;
+        }
+    }
+
+    let threads = threads_opt
+        .unwrap_or_else(|| {
+            std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(1)
+        })
+        .max(1);
+
+    let started = std::time::Instant::now();
+    let stdout = std::io::stdout();
+    let mut out = std::io::BufWriter::new(stdout.lock());
+
+    let tally = batch_stream_records(
+        rows.len(),
+        threads,
+        |idx| {
+            batch_fill_record(
+                form,
+                idx,
+                &rows[idx],
+                outputs[idx].as_deref(),
+                dry_run,
+                verify_mode,
+            )
+        },
+        &mut out,
+    );
+
+    if tally.aborted {
         return EXIT_RUNTIME;
     }
     if let Err(e) = out.flush() {
@@ -4382,32 +4715,320 @@ fn run_batch(args: &[String]) -> i32 {
     }
 
     eprintln!(
-        "batch: {}건 중 {} 성공, {} 실패 ({}ms, threads={})",
-        emitted,
-        emitted - failed,
-        failed,
+        "batch fill: {}행 중 {} 성공, {} 실패 ({}ms, threads={}{})",
+        tally.emitted,
+        tally.emitted - tally.failed,
+        tally.failed,
         started.elapsed().as_millis(),
-        threads
+        threads,
+        if dry_run { ", dry-run" } else { "" }
     );
-    if verify_diff > 0 || verify_pages_diff > 0 {
+    if tally.verify_diff > 0 {
         eprintln!(
-            "batch: 검증 판정 — verify 차이 {}건, verify-pages 불일치 {}건 (변환·저장 자체는 성공)",
-            verify_diff, verify_pages_diff
+            "batch fill: 검증 판정 — verify 차이 {}건 (채움·저장 자체는 성공)",
+            tally.verify_diff
         );
     }
-    // [#3626] 종료 코드 집계. 하드 실패(산출물이 아예 없음)가 가장 나쁘므로 기존 규약대로
-    // 1 이 우선한다. 그 아래는 단건 convert 의 우선순위를 그대로 따른다 — 단건도 쪽수
-    // 검사를 IR 검사보다 먼저 해 exit 4 로 끊는다. 검증 판정을 1 로 접지 않는 이유는
-    // 소비자가 재실행 대상(1)과 검토 대상(3/4)을 갈라야 하기 때문이다.
-    if failed > 0 {
-        EXIT_RUNTIME
-    } else if verify_pages_diff > 0 {
-        4
-    } else if verify_diff > 0 {
-        3
-    } else {
-        EXIT_OK
+    tally.exit_code()
+}
+
+/// [#3719 §6-6] 행 하나 → NDJSON 레코드 하나. 실패도 레코드다(스트림은 계속된다).
+///
+/// 한 행의 파서 panic 이 메일머지 전체를 죽여서는 안 된다 — 기존 `batch_record` 와 같은
+/// 격리 규약이다.
+fn batch_fill_record(
+    form: &str,
+    row_index: usize,
+    row: &FillRow,
+    output: Option<&Path>,
+    dry_run: bool,
+    verify_mode: bool,
+) -> serde_json::Value {
+    let mut record = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        batch_fill_record_inner(form, row, output, dry_run, verify_mode)
+    })) {
+        Ok(record) => record,
+        Err(payload) => {
+            let message = payload
+                .downcast_ref::<&str>()
+                .map(|s| (*s).to_string())
+                .or_else(|| payload.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "원인 불명".to_string());
+            batch_fail_record(form, format!("내부 오류(panic): {}", message))
+        }
+    };
+    // 행 번호는 성공·실패 어느 쪽에도 붙는다. 없으면 어느 행이 빠졌는지 셀 수 없어
+    // 스트림 전체가 감사 불가가 된다.
+    record["row"] = serde_json::json!(row_index);
+    record
+}
+
+fn batch_fill_record_inner(
+    form: &str,
+    row: &FillRow,
+    output: Option<&Path>,
+    dry_run: bool,
+    verify_mode: bool,
+) -> serde_json::Value {
+    let data = match row {
+        FillRow::Data(map) => map,
+        FillRow::Broken(reason) => return batch_fail_record(form, reason.clone()),
+    };
+    let Some(output) = output else {
+        return batch_fail_record(form, "산출 경로를 정하지 못했습니다".to_string());
+    };
+    let output_path = output.to_string_lossy().to_string();
+    match fill_fields_core(form, data, Some(output_path.clone()), dry_run, verify_mode) {
+        Ok(outcome) => {
+            let mut record = outcome.envelope;
+            if dry_run {
+                // 선검증에도 목적지를 밝힌다. 같은 봉투에 `dryRun: true` 가 함께 있으므로
+                // "만들 예정" 경로임이 레코드 안에서 구분된다(디스크에 파일은 없다).
+                record["output"] = serde_json::Value::String(output_path);
+                record["outputFormat"] =
+                    serde_json::Value::String(outcome.output_format.label().to_string());
+            }
+            record
+        }
+        Err(message) => batch_fail_record(form, message),
     }
+}
+
+/// [#3719 §6-6] 행마다 산출 파일 경로를 정한다.
+///
+/// 이름은 `--name-field` 값, 없으면 1 기준 순번이다. 파일명에 쓸 수 없는 문자는 치환하고,
+/// 서로 다른 행이 같은 이름을 내면 뒤에 순번을 붙인다 — 덮어쓰면 앞 행의 산출물이
+/// **조용히** 사라져서 성공 레코드 N건과 실제 파일 수가 어긋난다.
+fn batch_fill_output_paths(
+    rows: &[FillRow],
+    out_dir: &Path,
+    name_field: Option<&str>,
+    ext: &str,
+) -> Vec<Option<std::path::PathBuf>> {
+    // 대소문자만 다른 이름도 한 파일이 되는 파일시스템(Windows·macOS 기본)이 있다.
+    // batch convert 와 같은 보수적 규약으로 소문자 키 하나로 판정해야, OS 를 바꾼
+    // 재실행이 달라지지 않는다.
+    let mut taken: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let width = rows.len().to_string().len().max(4);
+    let mut paths = Vec::with_capacity(rows.len());
+    for (idx, row) in rows.iter().enumerate() {
+        let FillRow::Data(map) = row else {
+            // 읽지 못한 행은 산출물이 없다 — 이름도 잡지 않는다.
+            paths.push(None);
+            continue;
+        };
+        let seq = format!("{:0width$}", idx + 1, width = width);
+        let base = name_field
+            .and_then(|f| map.get(f))
+            .map(|v| match v {
+                serde_json::Value::String(s) => s.clone(),
+                other => other.to_string(),
+            })
+            .map(|s| sanitize_output_stem(&s))
+            .filter(|s| !s.is_empty())
+            // 이름 필드가 비었거나 치환 후 아무것도 남지 않으면 순번으로 되돌린다.
+            .unwrap_or_else(|| seq.clone());
+
+        let mut candidate = base.clone();
+        let mut dup = 1usize;
+        while !taken.insert(format!("{}.{}", candidate.to_lowercase(), ext)) {
+            dup += 1;
+            candidate = format!("{base}_{dup}");
+        }
+        paths.push(Some(out_dir.join(format!("{candidate}.{ext}"))));
+    }
+    paths
+}
+
+/// [#3719 §6-6] 데이터 값에서 파일 이름을 만든다 — 데이터에서 온 문자열이 경로 문법을
+/// 타지 못하게 한다.
+///
+/// 경로 구분자·Windows 금지 문자·제어 문자는 `_` 로 바꾼다. 구분자가 사라지므로
+/// `../..` 같은 값도 `--out-dir` 밖으로 나갈 수 없다. Windows 는 이름 끝의 공백·점을
+/// 조용히 잘라내므로 미리 없애고, 예약 장치 이름(CON·NUL·COM1…)은 앞에 `_` 를 붙여 피한다.
+fn sanitize_output_stem(raw: &str) -> String {
+    /// 경로 길이 한도(Windows 260자)에 여유를 두는 이름 길이 상한.
+    const MAX_CHARS: usize = 80;
+    const RESERVED: [&str; 22] = [
+        "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8",
+        "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+    ];
+
+    let mut stem = String::new();
+    for ch in raw.chars().take(MAX_CHARS) {
+        let forbidden =
+            matches!(ch, '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*') || ch.is_control();
+        stem.push(if forbidden { '_' } else { ch });
+    }
+    let trimmed = stem.trim().trim_end_matches(['.', ' ']).trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    let head = trimmed.split('.').next().unwrap_or("").to_ascii_uppercase();
+    if RESERVED.contains(&head.as_str()) {
+        format!("_{trimmed}")
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// [#3719 §6-6] `--data` 파일 → 행 목록.
+///
+/// `Err((사유, 종료 코드))` 는 **한 행도 처리하기 전에** 끝낼 입력 오류다(확장자·헤더·
+/// 빈 파일). 개별 행의 결함은 여기서 끝내지 않고 `FillRow::Broken` 으로 스트림에 남긴다 —
+/// 한 행이 깨졌다고 나머지 N-1행의 산출물을 포기할 이유가 없다.
+fn read_fill_rows(path: &Path) -> Result<Vec<FillRow>, (String, i32)> {
+    let text = fs::read_to_string(path).map_err(|e| {
+        (
+            format!("--data 파일을 읽을 수 없습니다 - {}: {}", path.display(), e),
+            EXIT_RUNTIME,
+        )
+    })?;
+    // 엑셀이 저장한 CSV 는 UTF-8 BOM 으로 시작한다. 남겨 두면 첫 헤더 이름이 통째로
+    // 어긋나(BOM+이름) 문서의 누름틀과 영영 매칭되지 않는다.
+    let text: &str = text.strip_prefix('\u{feff}').unwrap_or(&text);
+
+    let ext = path
+        .extension()
+        .map(|e| e.to_string_lossy().to_ascii_lowercase())
+        .unwrap_or_default();
+    let rows = match ext.as_str() {
+        "jsonl" | "ndjson" => parse_jsonl_rows(text),
+        "csv" => parse_csv_rows(text)?,
+        "" => {
+            return Err((
+                "--data 파일에 확장자가 없습니다 — .jsonl 또는 .csv 로 지정하세요.".to_string(),
+                EXIT_USAGE,
+            ));
+        }
+        other => {
+            return Err((
+                format!("--data 는 .jsonl 또는 .csv 여야 합니다 - .{other}"),
+                EXIT_USAGE,
+            ));
+        }
+    };
+    if rows.is_empty() {
+        // 0행을 성공(exit 0)으로 끝내면 "전부 처리했다"와 구분되지 않는다.
+        return Err((
+            format!("--data 에 데이터 행이 없습니다 - {}", path.display()),
+            EXIT_USAGE,
+        ));
+    }
+    Ok(rows)
+}
+
+/// JSONL: 한 줄 한 객체. 빈 줄은 건너뛴다.
+fn parse_jsonl_rows(text: &str) -> Vec<FillRow> {
+    text.lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(
+            |line| match serde_json::from_str::<serde_json::Value>(line) {
+                Ok(serde_json::Value::Object(m)) => FillRow::Data(m),
+                Ok(_) => FillRow::Broken(
+                    "JSONL 행은 {\"필드이름\":\"값\"} 형식의 JSON 객체여야 합니다".to_string(),
+                ),
+                Err(e) => FillRow::Broken(format!("JSONL 행 파싱 실패 - {e}")),
+            },
+        )
+        .collect()
+}
+
+/// CSV: 첫 줄 헤더가 누름틀 이름이다. 헤더 이름은 **공백까지 그대로** 문서의 이름으로 쓴다.
+fn parse_csv_rows(text: &str) -> Result<Vec<FillRow>, (String, i32)> {
+    let records = parse_csv_records(text).map_err(|e| (e, EXIT_USAGE))?;
+    let mut it = records.into_iter();
+    let Some(header) = it.next() else {
+        return Err(("--data CSV 에 헤더 줄이 없습니다.".to_string(), EXIT_USAGE));
+    };
+    for (i, name) in header.iter().enumerate() {
+        if name.is_empty() {
+            return Err((
+                format!("--data CSV 헤더 {}번째 칸의 이름이 비었습니다.", i + 1),
+                EXIT_USAGE,
+            ));
+        }
+        // 같은 이름이 두 번이면 뒤 칸이 앞 칸을 덮어 **한 열이 통째로 무시된다**.
+        if header[..i].contains(name) {
+            return Err((
+                format!("--data CSV 헤더에 같은 이름이 두 번 있습니다 - {name}"),
+                EXIT_USAGE,
+            ));
+        }
+    }
+    Ok(it
+        .map(|record| {
+            if record.len() != header.len() {
+                // 칸 수가 다르면 값이 한 칸씩 밀려 엉뚱한 누름틀로 들어간다. 채우고 나면
+                // 아무 오류 없이 잘못된 문서가 나오므로 행 단위로 거부한다.
+                return FillRow::Broken(format!(
+                    "CSV 칸 수가 헤더와 다릅니다 - 헤더 {}칸, 행 {}칸",
+                    header.len(),
+                    record.len()
+                ));
+            }
+            FillRow::Data(
+                header
+                    .iter()
+                    .cloned()
+                    .zip(record.into_iter().map(serde_json::Value::String))
+                    .collect(),
+            )
+        })
+        .collect())
+}
+
+/// [#3719 §6-6] RFC 4180 CSV 읽기 — 엑셀 저장본을 그대로 받는다.
+///
+/// 따옴표 안의 쉼표·줄바꿈·이중 따옴표(`""`)를 보존하고 CRLF/LF 를 모두 줄 끝으로 읽는다.
+/// 전용 crate 를 새로 들이지 않는 이유는 여기서 필요한 문법이 RFC 4180 그 자체뿐이라서다.
+fn parse_csv_records(text: &str) -> Result<Vec<Vec<String>>, String> {
+    let mut records: Vec<Vec<String>> = Vec::new();
+    let mut record: Vec<String> = Vec::new();
+    let mut field = String::new();
+    let mut in_quotes = false;
+    let mut chars = text.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if in_quotes {
+            if c == '"' {
+                if chars.peek() == Some(&'"') {
+                    chars.next();
+                    field.push('"');
+                } else {
+                    in_quotes = false;
+                }
+            } else {
+                field.push(c);
+            }
+            continue;
+        }
+        match c {
+            // 여는 따옴표는 칸 맨 앞에서만 뜻이 있다. 칸 중간의 따옴표는 값의 일부다.
+            '"' if field.is_empty() => in_quotes = true,
+            ',' => record.push(std::mem::take(&mut field)),
+            '\r' | '\n' => {
+                if c == '\r' && chars.peek() == Some(&'\n') {
+                    chars.next();
+                }
+                record.push(std::mem::take(&mut field));
+                records.push(std::mem::take(&mut record));
+            }
+            _ => field.push(c),
+        }
+    }
+    if in_quotes {
+        // 여기서 멈추지 않으면 "따옴표 하나 빠뜨린 CSV"가 뒤 행 전체를 한 칸으로 삼킨다.
+        return Err("--data CSV 의 따옴표가 닫히지 않았습니다.".to_string());
+    }
+    if !field.is_empty() || !record.is_empty() {
+        record.push(field);
+        records.push(record);
+    }
+    // 마지막 개행이 만든 빈 줄은 행이 아니다(엑셀 저장본은 늘 개행으로 끝난다).
+    records.retain(|r| !(r.len() == 1 && r[0].trim().is_empty()));
+    Ok(records)
 }
 
 /// [#3238] batch 가 처리하는 서브커맨드 축.
@@ -11307,20 +11928,105 @@ fn edit_fill_fields(args: &[String]) -> i32 {
             }
         };
 
-    let bytes = match fs::read(file_path) {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
+    let outcome = match fill_fields_core(file_path, &data, out_path, dry_run, verify_mode) {
+        Ok(o) => o,
+        Err(message) => {
+            eprintln!("오류: {message}");
             return EXIT_RUNTIME;
         }
     };
-    let mut doc = match rhwp::wasm_api::HwpDocument::from_bytes(&bytes) {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("오류: HWP 파싱 실패 - {}", e);
-            return EXIT_RUNTIME;
+    let FillOutcome {
+        envelope,
+        output_path,
+        verify_failed,
+        ..
+    } = outcome;
+
+    if json_mode {
+        println!("{envelope}");
+        if verify_failed {
+            process::exit(3);
         }
-    };
+        return EXIT_OK;
+    }
+
+    let empty: Vec<serde_json::Value> = Vec::new();
+    let filled = envelope["filled"].as_array().unwrap_or(&empty);
+    let not_found: Vec<&str> = envelope["notFound"]
+        .as_array()
+        .unwrap_or(&empty)
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+    let confusable = envelope["confusable"].as_array().unwrap_or(&empty);
+
+    if dry_run {
+        println!("변경 예정: {} (필드 {}개)", file_path, filled.len());
+    } else {
+        println!(
+            "채우기 완료: {} → {} (필드 {}개)",
+            file_path,
+            output_path,
+            filled.len()
+        );
+    }
+    for f in filled {
+        println!(
+            "  {} = {:?}",
+            f["name"].as_str().unwrap_or(""),
+            f["value"].as_str().unwrap_or("")
+        );
+    }
+    if !not_found.is_empty() {
+        println!("  문서에 없는 필드 이름: {}", not_found.join(", "));
+    }
+    if verify_failed {
+        eprintln!("검증 실패(--verify): 저장본 재파싱 IR 차이 — 상세는 --json 또는 ir-diff");
+        process::exit(3);
+    }
+    for c in confusable {
+        // 사람에게도 알린다 — 화면상 같은 이름이라 눈으로는 잡을 수 없는 축이다.
+        eprintln!(
+            "경고: '{}' 과(와) 화면상 구별되지 않는 이름의 누름틀이 문서에 함께 있습니다 \
+             — 채운 칸이 의도한 칸인지 확인하세요.",
+            c["name"].as_str().unwrap_or("")
+        );
+    }
+    EXIT_OK
+}
+
+/// [#3719 §6-6] `edit fill-fields`(단건)와 `batch fill`(메일머지)이 공유하는 채움 결과.
+struct FillOutcome {
+    /// `edit fill-fields --json` 봉투 그대로. 배치 레코드는 여기에 `row` 만 더한다 —
+    /// 소비자가 단건과 배치를 같은 코드로 읽게 하기 위함(기존 batch 축 규약).
+    envelope: serde_json::Value,
+    /// 산출 경로. `--dry-run` 이면 **만들 예정** 경로다(디스크에 파일은 없다).
+    output_path: String,
+    /// [#3383] 산출 형식 — 입력 형식을 따른다.
+    output_format: EditOutputFormat,
+    /// `--verify` 판정이 "차이 있음"인가. 단건은 exit 3, 배치는 집계 대상.
+    verify_failed: bool,
+}
+
+/// [#3719 §6-6] 누름틀 채움의 **단 하나의** 구현. 단건 CLI 도 배치도 이 함수만 부른다.
+///
+/// 배치를 위해 새 편집 로직을 쓰지 않는다 — 채움 규칙(순번 지목·모호성 보고·혼동 이름
+/// 경고·형식 보존·저장 직후 자기검증·changedPages)이 두 곳으로 갈라지면 단건으로 검증한
+/// 서식이 배치에서 다르게 채워지고, 그 차이는 산출물 N개가 나온 뒤에야 드러난다.
+///
+/// 실패는 `Err(사람이 읽는 사유)` 다. 단건은 stderr + exit 1 로, 배치는 그 행의 `error`
+/// 레코드로 바꾼다 — 프로세스를 끊지 않는 이유는 뒤 행이 남아 있기 때문이다.
+fn fill_fields_core(
+    file_path: &str,
+    data: &serde_json::Map<String, serde_json::Value>,
+    out_path: Option<String>,
+    dry_run: bool,
+    verify_mode: bool,
+) -> Result<FillOutcome, String> {
+    let bytes = fs::read(file_path)
+        .map_err(|e| format!("파일을 읽을 수 없습니다 - {}: {}", file_path, e))?;
+    let mut doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .map_err(|e| format!("HWP 파싱 실패 - {}", e))?;
 
     // [#3476] 이름별 **개수**를 센다. 실제 제출 서식은 같은 항목 묶음을 여러 번 요구해
     // (규제영향분석서의 `피규제집단명` ×14 등) 이름만으로는 하나만 지목된다.
@@ -11352,7 +12058,7 @@ fn edit_fill_fields(args: &[String]) -> i32 {
     let confusable_groups = rhwp::document_core::text_security::confusable_collisions(&all_names);
     let mut confusable: Vec<serde_json::Value> = Vec::new();
 
-    for (key, value) in &data {
+    for (key, value) in data {
         let value_str = match value {
             serde_json::Value::String(s) => s.clone(),
             other => other.to_string(),
@@ -11391,11 +12097,9 @@ fn edit_fill_fields(args: &[String]) -> i32 {
             );
             continue;
         }
-        if let Err(e) = doc.set_field_value_by_name_at(name, occurrence, &value_str) {
-            eprintln!("오류: 필드 '{}' 설정 실패 - {}", key, e);
-            // 실패 시 원본 불변 — 출력 파일을 쓰지 않고 즉시 끝낸다.
-            return EXIT_RUNTIME;
-        }
+        // 실패 시 원본 불변 — 출력 파일을 쓰지 않고 즉시 끝낸다.
+        doc.set_field_value_by_name_at(name, occurrence, &value_str)
+            .map_err(|e| format!("필드 '{}' 설정 실패 - {}", key, e))?;
         if let Some(loc) = name_locs.get(name).and_then(|l| l.get(occurrence)) {
             changed_paras.push(*loc);
         }
@@ -11427,21 +12131,10 @@ fn edit_fill_fields(args: &[String]) -> i32 {
     let mut verify_report = serde_json::Value::Null;
     let mut verify_failed = false;
     if !dry_run {
-        let out_bytes = match edit_serialize(&mut doc, out_format) {
-            Ok(b) => b,
-            Err(e) => {
-                eprintln!(
-                    "오류: {} 직렬화 실패 - {}",
-                    out_format.label().to_uppercase(),
-                    e
-                );
-                return EXIT_RUNTIME;
-            }
-        };
-        if let Err(e) = fs::write(&output_path, &out_bytes) {
-            eprintln!("오류: 출력 쓰기 실패 - {}: {}", output_path, e);
-            return EXIT_RUNTIME;
-        }
+        let out_bytes = edit_serialize(&mut doc, out_format)
+            .map_err(|e| format!("{} 직렬화 실패 - {}", out_format.label().to_uppercase(), e))?;
+        fs::write(&output_path, &out_bytes)
+            .map_err(|e| format!("출력 쓰기 실패 - {}: {}", output_path, e))?;
         // [#3702] 저장 직후 자기검증 — 편집 후 IR ↔ 저장본 재파싱 IR.
         if verify_mode {
             let cross = out_format == EditOutputFormat::Hwp
@@ -11462,63 +12155,29 @@ fn edit_fill_fields(args: &[String]) -> i32 {
         }
     };
 
-    if json_mode {
-        let mut envelope = serde_json::json!({
-            "schemaVersion": "1.0",
-            "source": file_path,
-            "dryRun": dry_run,
-            "changedPages": changed_pages,
-            "filledCount": filled.len(),
-            "filled": filled,
-            "notFound": not_found,
-            "ambiguous": ambiguous,
-            "confusable": confusable,
-        });
-        if !dry_run {
-            envelope["output"] = serde_json::Value::String(output_path.clone());
-            envelope["outputFormat"] = serde_json::Value::String(out_format.label().to_string());
-            envelope["verify"] = verify_report.clone();
-        }
-        println!("{envelope}");
-        if verify_failed {
-            process::exit(3);
-        }
-        return EXIT_OK;
+    let mut envelope = serde_json::json!({
+        "schemaVersion": "1.0",
+        "source": file_path,
+        "dryRun": dry_run,
+        "changedPages": changed_pages,
+        "filledCount": filled.len(),
+        "filled": filled,
+        "notFound": not_found,
+        "ambiguous": ambiguous,
+        "confusable": confusable,
+    });
+    if !dry_run {
+        envelope["output"] = serde_json::Value::String(output_path.clone());
+        envelope["outputFormat"] = serde_json::Value::String(out_format.label().to_string());
+        envelope["verify"] = verify_report;
     }
 
-    if dry_run {
-        println!("변경 예정: {} (필드 {}개)", file_path, filled.len());
-    } else {
-        println!(
-            "채우기 완료: {} → {} (필드 {}개)",
-            file_path,
-            output_path,
-            filled.len()
-        );
-    }
-    for f in &filled {
-        println!(
-            "  {} = {:?}",
-            f["name"].as_str().unwrap_or(""),
-            f["value"].as_str().unwrap_or("")
-        );
-    }
-    if !not_found.is_empty() {
-        println!("  문서에 없는 필드 이름: {}", not_found.join(", "));
-    }
-    if verify_failed {
-        eprintln!("검증 실패(--verify): 저장본 재파싱 IR 차이 — 상세는 --json 또는 ir-diff");
-        process::exit(3);
-    }
-    for c in &confusable {
-        // 사람에게도 알린다 — 화면상 같은 이름이라 눈으로는 잡을 수 없는 축이다.
-        eprintln!(
-            "경고: '{}' 과(와) 화면상 구별되지 않는 이름의 누름틀이 문서에 함께 있습니다 \
-             — 채운 칸이 의도한 칸인지 확인하세요.",
-            c["name"].as_str().unwrap_or("")
-        );
-    }
-    EXIT_OK
+    Ok(FillOutcome {
+        envelope,
+        output_path,
+        output_format: out_format,
+        verify_failed,
+    })
 }
 
 /// `edit replace-text` — 문서 전체 일괄 치환 (기관명 변경·연도 갱신·용어 정비).

--- a/tests/batch_fill_contract.rs
+++ b/tests/batch_fill_contract.rs
@@ -1,0 +1,1615 @@
+//! [#3719 §6-6] `batch fill` — 서식 1 + 데이터 N행 → 산출 N개 (진짜 메일머지) 계약 테스트.
+//!
+//! 핵심 계약:
+//! ① 행마다 NDJSON 레코드 하나, **실패한 행도 스트림에 남는다**(사라지면 처리 누락을
+//!    셀 수 없다) ② 성공 레코드는 단건 `edit fill-fields --json` 봉투 + `row`
+//! ③ 산출 이름이 겹쳐도 덮어쓰지 않는다 ④ 데이터는 stdin 이 아니라 `--data` **파일**이다
+//! ⑤ 종료 코드: 전부 성공 0 / 한 행이라도 실패 1 / 인자 오류 2 / verify 불일치 3.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+/// 누름틀을 가진 서식.
+const FORM: &str = "samples/field-01.hwp";
+
+fn sample(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        // fill 축은 stdin 을 읽지 않는다. null 로 두면 실수로 읽는 순간 즉시 EOF 라
+        // "무한 대기"가 아니라 재현 가능한 실패로 드러난다.
+        .stdin(Stdio::null())
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+/// 잘못 해석된 출력 경로가 저장소 루트에 파일을 만들지 않도록 실행 위치를 격리한다.
+fn run_in_dir(args: &[&str], current_dir: &Path) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .current_dir(current_dir)
+        .stdin(Stdio::null())
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+/// stdin 에 본문을 흘려 넣고 실행한다. fill 축이 stdin 을 **읽지 않음**을 증명할 때 쓴다.
+fn run_with_stdin(args: &[&str], stdin_body: &str) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("rhwp 실행 실패");
+    // 자식이 stdin 을 읽지 않고 끝내는 것이 정상 경로다 — BrokenPipe 는 무시한다.
+    if let Err(err) = child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(stdin_body.as_bytes())
+    {
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::BrokenPipe,
+            "stdin 쓰기 실패: {err:?}"
+        );
+    }
+    child.wait_with_output().expect("rhwp 종료 대기 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\n종료: {:?}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn ndjson(args: &[&str], output: &Output) -> Vec<serde_json::Value> {
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| {
+            serde_json::from_str(l)
+                .unwrap_or_else(|e| panic!("NDJSON 아님 ({e}): {l}\n{}", describe(args, output)))
+        })
+        .collect()
+}
+
+fn json_of(args: &[&str], output: &Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|e| panic!("JSON 아님 ({e}): {}", describe(args, output)))
+}
+
+/// 산출물을 쓰는 축이라 테스트마다 격리된 임시 폴더를 쓰고, 실패 assertion 뒤에도 지운다.
+struct TmpDir(PathBuf);
+
+impl TmpDir {
+    fn new(tag: &str) -> Self {
+        let dir = std::env::temp_dir().join(format!(
+            "rhwp-batch-fill-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("임시 폴더 생성 실패");
+        Self(dir)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+
+    fn join(&self, name: &str) -> PathBuf {
+        self.0.join(name)
+    }
+
+    /// 산출 폴더. 미리 만들지 않는다 — `--dry-run` 이 폴더조차 만들지 않음을 볼 수 있게.
+    fn out_dir(&self) -> PathBuf {
+        self.0.join("out")
+    }
+}
+
+impl Drop for TmpDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+/// 서식에 **한 번만** 나오는 누름틀 이름들. 테스트 데이터를 하드코딩하지 않고 실제 문서에서
+/// 얻는다 — 샘플이 바뀌면 테스트가 조용히 무의미해지는 것을 막는다. 같은 이름이 여러 번 있는
+/// 필드는 ambiguous 축(#3476)이라 여기의 관심사가 아니다.
+fn unique_field_names() -> Vec<String> {
+    let form = sample(FORM);
+    let args = ["fields", form.to_str().expect("경로"), "--json"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = json_of(&args, &output);
+
+    let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    let mut order: Vec<String> = Vec::new();
+    for f in v["fields"].as_array().expect("fields 배열") {
+        let Some(name) = f["name"].as_str() else {
+            continue;
+        };
+        if !counts.contains_key(name) {
+            order.push(name.to_string());
+        }
+        *counts.entry(name.to_string()).or_insert(0) += 1;
+    }
+    let names: Vec<String> = order.into_iter().filter(|n| counts[n] == 1).collect();
+    assert!(
+        names.len() >= 2,
+        "이 테스트에는 한 번만 나오는 누름틀이 2개 이상 필요합니다: {names:?}"
+    );
+    names
+}
+
+/// `{이름: 값}` 한 행을 JSONL 한 줄로.
+fn jsonl_line(pairs: &[(&str, &str)]) -> String {
+    let mut map = serde_json::Map::new();
+    for (k, v) in pairs {
+        map.insert(
+            (*k).to_string(),
+            serde_json::Value::String((*v).to_string()),
+        );
+    }
+    format!("{}\n", serde_json::Value::Object(map))
+}
+
+fn written_files(dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut names: Vec<String> = entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+    names.sort();
+    names
+}
+
+// ── 기본 축: 행 N개 → 산출 N개 ─────────────────────────────────────────────
+
+#[test]
+fn jsonl_rows_become_one_document_each() {
+    let names = unique_field_names();
+    let tmp = TmpDir::new("jsonl");
+    let data = tmp.join("rows.jsonl");
+    let body: String = ["가나다 주식회사", "라마바 주식회사", "사아자 협동조합"]
+        .iter()
+        .enumerate()
+        .map(|(i, v)| jsonl_line(&[(&names[0], v), (&names[1], &format!("문서 {i}"))]))
+        .collect();
+    std::fs::write(&data, body).expect("데이터 파일 쓰기");
+
+    let form = sample(FORM);
+    let out = tmp.out_dir();
+    let args = [
+        "batch",
+        "fill",
+        "--form",
+        form.to_str().expect("경로"),
+        "--data",
+        data.to_str().expect("경로"),
+        "--out-dir",
+        out.to_str().expect("경로"),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+
+    let records = ndjson(&args, &output);
+    assert_eq!(records.len(), 3, "{}", describe(&args, &output));
+    for (i, v) in records.iter().enumerate() {
+        assert_eq!(v["schemaVersion"], "1.0", "{v}");
+        // row 는 성공·실패 어느 쪽에도 붙는다 — 없으면 어느 행이 빠졌는지 셀 수 없다.
+        assert_eq!(v["row"], i, "행 번호가 입력 순서와 달라졌습니다: {v}");
+        assert!(v.get("error").is_none(), "{v}");
+        assert_eq!(v["filledCount"], 2, "{v}");
+        assert!(
+            v["notFound"].as_array().expect("notFound").is_empty(),
+            "{v}"
+        );
+        let written = v["output"].as_str().expect("output");
+        assert!(
+            Path::new(written).is_file(),
+            "레코드가 가리키는 산출물이 없습니다: {written}\n{}",
+            describe(&args, &output)
+        );
+    }
+    assert_eq!(
+        written_files(&out).len(),
+        3,
+        "행 수와 산출물 수가 다릅니다: {:?}",
+        written_files(&out)
+    );
+}
+
+#[test]
+fn record_is_isomorphic_to_single_command_envelope() {
+    // 배치 레코드 = 단건 `edit fill-fields --json` 봉투 + row. 소비자가 단건과 배치를
+    // 같은 코드로 읽는 것이 기존 batch 축 규약이다.
+    let names = unique_field_names();
+    let tmp = TmpDir::new("iso");
+    let data = tmp.join("row.jsonl");
+    std::fs::write(&data, jsonl_line(&[(&names[0], "값")])).expect("데이터 파일 쓰기");
+
+    let form = sample(FORM);
+    let out = tmp.out_dir();
+    let batch_args = [
+        "batch",
+        "fill",
+        "--form",
+        form.to_str().expect("경로"),
+        "--data",
+        data.to_str().expect("경로"),
+        "--out-dir",
+        out.to_str().expect("경로"),
+        "--json",
+    ];
+    let batch_output = run(&batch_args);
+    assert_eq!(
+        batch_output.status.code(),
+        Some(0),
+        "{}",
+        describe(&batch_args, &batch_output)
+    );
+    let record = ndjson(&batch_args, &batch_output)
+        .into_iter()
+        .next()
+        .expect("레코드 1건");
+
+    let single_out = tmp.join("single.hwp");
+    let inline = {
+        let mut m = serde_json::Map::new();
+        m.insert(
+            names[0].clone(),
+            serde_json::Value::String("값".to_string()),
+        );
+        serde_json::Value::Object(m).to_string()
+    };
+    let single_args = [
+        "edit",
+        "fill-fields",
+        form.to_str().expect("경로"),
+        "--data",
+        inline.as_str(),
+        "-o",
+        single_out.to_str().expect("경로"),
+        "--json",
+    ];
+    let single_output = run(&single_args);
+    assert_eq!(
+        single_output.status.code(),
+        Some(0),
+        "{}",
+        describe(&single_args, &single_output)
+    );
+    let single = json_of(&single_args, &single_output);
+
+    let mut batch_keys: Vec<&String> = record.as_object().expect("객체").keys().collect();
+    batch_keys.retain(|k| k.as_str() != "row");
+    let single_keys: Vec<&String> = single.as_object().expect("객체").keys().collect();
+    assert_eq!(
+        batch_keys, single_keys,
+        "배치 레코드는 단건 봉투와 같은 필드여야 합니다(row 제외)\n배치: {record}\n단건: {single}"
+    );
+    assert_eq!(record["filledCount"], single["filledCount"], "{record}");
+}
+
+// ── CSV 축 ────────────────────────────────────────────────────────────────
+
+#[test]
+fn csv_reads_bom_and_rfc4180_quoting() {
+    // 엑셀 저장본을 그대로 받는다: UTF-8 BOM · CRLF · 따옴표 안의 쉼표/줄바꿈/이중 따옴표.
+    // BOM 을 남기면 첫 헤더 이름이 통째로 어긋나 그 열이 조용히 notFound 가 된다.
+    let names = unique_field_names();
+    let tmp = TmpDir::new("csv");
+    let data = tmp.join("rows.csv");
+    let body = format!(
+        "\u{feff}{},{}\r\n\"쉼표, 포함\",\"따옴표 \"\"안\"\" 값\"\r\n\"줄1\n줄2\",평범\r\n",
+        names[0], names[1]
+    );
+    std::fs::write(&data, body).expect("데이터 파일 쓰기");
+
+    let form = sample(FORM);
+    let out = tmp.out_dir();
+    let args = [
+        "batch",
+        "fill",
+        "--form",
+        form.to_str().expect("경로"),
+        "--data",
+        data.to_str().expect("경로"),
+        "--out-dir",
+        out.to_str().expect("경로"),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let records = ndjson(&args, &output);
+    assert_eq!(records.len(), 2, "{}", describe(&args, &output));
+
+    let value_of = |record: &serde_json::Value, name: &str| -> String {
+        record["filled"]
+            .as_array()
+            .expect("filled")
+            .iter()
+            .find(|f| f["name"] == name)
+            .unwrap_or_else(|| panic!("{name} 이 채워지지 않았습니다: {record}"))["value"]
+            .as_str()
+            .expect("value")
+            .to_string()
+    };
+    assert_eq!(value_of(&records[0], &names[0]), "쉼표, 포함");
+    assert_eq!(value_of(&records[0], &names[1]), "따옴표 \"안\" 값");
+    assert_eq!(value_of(&records[1], &names[0]), "줄1\n줄2");
+    // BOM 이 첫 헤더에 붙어 있었다면 그 열은 notFound 가 된다.
+    for v in &records {
+        assert!(
+            v["notFound"].as_array().expect("notFound").is_empty(),
+            "BOM·인용 처리가 어긋나 매칭되지 않은 열이 있습니다: {v}"
+        );
+    }
+}
+
+#[test]
+fn csv_column_count_mismatch_is_a_row_error_not_a_shifted_document() {
+    // 칸 수가 다르면 값이 한 칸씩 밀려 **오류 없이 잘못된 문서**가 나온다. 행 단위로 거부하되
+    // 스트림에는 남긴다.
+    let names = unique_field_names();
+    let tmp = TmpDir::new("csvlen");
+    let data = tmp.join("rows.csv");
+    let body = format!("{},{}\n정상A,정상B\n칸이,너무,많다\n", names[0], names[1]);
+    std::fs::write(&data, body).expect("데이터 파일 쓰기");
+
+    let form = sample(FORM);
+    let out = tmp.out_dir();
+    let args = [
+        "batch",
+        "fill",
+        "--form",
+        form.to_str().expect("경로"),
+        "--data",
+        data.to_str().expect("경로"),
+        "--out-dir",
+        out.to_str().expect("경로"),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "행 하나가 실패하면 exit 1 이어야 합니다\n{}",
+        describe(&args, &output)
+    );
+    let records = ndjson(&args, &output);
+    assert_eq!(records.len(), 2, "{}", describe(&args, &output));
+    assert!(records[0].get("error").is_none(), "{}", records[0]);
+    assert!(
+        records[1]["error"].as_str().is_some(),
+        "칸 수 불일치 행이 error 레코드가 아닙니다: {}",
+        records[1]
+    );
+    assert_eq!(records[1]["row"], 1, "{}", records[1]);
+    assert_eq!(written_files(&out).len(), 1, "{:?}", written_files(&out));
+}
+
+// ── 산출 이름 ─────────────────────────────────────────────────────────────
+
+#[test]
+fn duplicate_name_field_values_do_not_overwrite_each_other() {
+    // 같은 이름이면 뒤 행이 앞 행을 덮어써 **조용히** 데이터가 사라진다 — 성공 레코드 N건과
+    // 실제 파일 수가 어긋나면 안 된다.
+    let names = unique_field_names();
+    let tmp = TmpDir::new("dup");
+    let data = tmp.join("rows.jsonl");
+    let body: String = ["일차", "이차", "삼차"]
+        .iter()
+        .map(|v| jsonl_line(&[(&names[0], "홍길동"), (&names[1], v)]))
+        .collect();
+    std::fs::write(&data, body).expect("데이터 파일 쓰기");
+
+    let form = sample(FORM);
+    let out = tmp.out_dir();
+    let args = [
+        "batch",
+        "fill",
+        "--form",
+        form.to_str().expect("경로"),
+        "--data",
+        data.to_str().expect("경로"),
+        "--out-dir",
+        out.to_str().expect("경로"),
+        "--name-field",
+        names[0].as_str(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+
+    let records = ndjson(&args, &output);
+    let outputs: Vec<&str> = records
+        .iter()
+        .map(|v| v["output"].as_str().expect("output"))
+        .collect();
+    let mut unique: Vec<String> = outputs.iter().map(|s| s.to_lowercase()).collect();
+    unique.sort();
+    unique.dedup();
+    assert_eq!(
+        unique.len(),
+        3,
+        "같은 이름의 행이 같은 경로를 가리켰습니다: {outputs:?}"
+    );
+    assert_eq!(
+        written_files(&out).len(),
+        3,
+        "덮어쓰기로 산출물이 사라졌습니다: {:?}",
+        written_files(&out)
+    );
+}
+
+#[test]
+fn name_field_cannot_escape_the_output_directory() {
+    // 파일 이름은 데이터에서 온다. 경로 구분자를 그대로 두면 `--out-dir` 밖에 파일이 생긴다.
+    let names = unique_field_names();
+    let tmp = TmpDir::new("escape");
+    let data = tmp.join("rows.jsonl");
+    std::fs::write(
+        &data,
+        jsonl_line(&[(&names[0], "../../탈출"), (&names[1], "값")]),
+    )
+    .expect("데이터 파일 쓰기");
+
+    let form = sample(FORM);
+    let out = tmp.out_dir();
+    let args = [
+        "batch",
+        "fill",
+        "--form",
+        form.to_str().expect("경로"),
+        "--data",
+        data.to_str().expect("경로"),
+        "--out-dir",
+        out.to_str().expect("경로"),
+        "--name-field",
+        names[0].as_str(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let record = ndjson(&args, &output).into_iter().next().expect("레코드");
+    let written = PathBuf::from(record["output"].as_str().expect("output"));
+    assert_eq!(
+        written.parent(),
+        Some(out.as_path()),
+        "산출물이 --out-dir 밖으로 나갔습니다: {}",
+        written.display()
+    );
+    assert_eq!(written_files(&out).len(), 1, "{:?}", written_files(&out));
+}
+
+// ── 실패·선검증·입력 축 ────────────────────────────────────────────────────
+
+#[test]
+fn broken_rows_stay_in_the_stream_and_force_exit_1() {
+    // 실패 행이 스트림에서 사라지면 소비자는 N행을 넣고 N-2건을 받고도 성공으로 읽는다.
+    let names = unique_field_names();
+    let tmp = TmpDir::new("broken");
+    let data = tmp.join("rows.jsonl");
+    let body = format!(
+        "{}이건 JSON 이 아니다\n[\"배열은 객체가 아니다\"]\n{}",
+        jsonl_line(&[(&names[0], "정상 앞")]),
+        jsonl_line(&[(&names[0], "정상 뒤")]),
+    );
+    std::fs::write(&data, body).expect("데이터 파일 쓰기");
+
+    let form = sample(FORM);
+    let out = tmp.out_dir();
+    let args = [
+        "batch",
+        "fill",
+        "--form",
+        form.to_str().expect("경로"),
+        "--data",
+        data.to_str().expect("경로"),
+        "--out-dir",
+        out.to_str().expect("경로"),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}",
+        describe(&args, &output)
+    );
+
+    let records = ndjson(&args, &output);
+    assert_eq!(
+        records.len(),
+        4,
+        "실패 행이 스트림에서 사라졌습니다\n{}",
+        describe(&args, &output)
+    );
+    for (i, v) in records.iter().enumerate() {
+        assert_eq!(v["row"], i, "{v}");
+    }
+    assert!(records[0].get("error").is_none(), "{}", records[0]);
+    for bad in [&records[1], &records[2]] {
+        assert!(bad["error"].as_str().is_some(), "{bad}");
+        assert_eq!(bad["exitClass"], "runtime", "{bad}");
+        assert!(
+            bad.get("output").is_none(),
+            "실패 행에 산출 경로가 붙으면 안 됩니다: {bad}"
+        );
+    }
+    assert!(records[3].get("error").is_none(), "{}", records[3]);
+    assert_eq!(written_files(&out).len(), 2, "{:?}", written_files(&out));
+}
+
+#[test]
+fn dry_run_writes_nothing_and_exits_zero() {
+    let names = unique_field_names();
+    let tmp = TmpDir::new("dryrun");
+    let data = tmp.join("rows.jsonl");
+    let body: String = ["하나", "둘"]
+        .iter()
+        .map(|v| jsonl_line(&[(&names[0], v)]))
+        .collect();
+    std::fs::write(&data, body).expect("데이터 파일 쓰기");
+
+    let form = sample(FORM);
+    let out = tmp.out_dir();
+    let args = [
+        "batch",
+        "fill",
+        "--form",
+        form.to_str().expect("경로"),
+        "--data",
+        data.to_str().expect("경로"),
+        "--out-dir",
+        out.to_str().expect("경로"),
+        "--dry-run",
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+
+    let records = ndjson(&args, &output);
+    assert_eq!(records.len(), 2, "{}", describe(&args, &output));
+    for v in &records {
+        assert_eq!(v["dryRun"], true, "{v}");
+        // 목적지는 밝히되 `dryRun: true` 가 함께 있어 "만들 예정" 임이 구분된다.
+        let planned = v["output"].as_str().expect("output");
+        assert!(
+            !Path::new(planned).exists(),
+            "--dry-run 이 파일을 만들었습니다: {planned}"
+        );
+        assert_eq!(v["filledCount"], 1, "{v}");
+    }
+    assert!(
+        !out.exists(),
+        "--dry-run 이 출력 폴더를 만들었습니다: {}",
+        out.display()
+    );
+}
+
+#[test]
+fn data_comes_from_the_file_not_stdin() {
+    // 다른 batch 축은 stdin 으로 경로 목록을 받는다. fill 은 읽지 않아야 한다 — 읽으면
+    // MCP 서버의 프로토콜 stdin 을 자식이 삼키는 형태의 사고가 난다.
+    let names = unique_field_names();
+    let tmp = TmpDir::new("stdin");
+    let data = tmp.join("rows.jsonl");
+    std::fs::write(&data, jsonl_line(&[(&names[0], "파일에서 온 값")])).expect("데이터 파일 쓰기");
+
+    let form = sample(FORM);
+    let out = tmp.out_dir();
+    let args = [
+        "batch",
+        "fill",
+        "--form",
+        form.to_str().expect("경로"),
+        "--data",
+        data.to_str().expect("경로"),
+        "--out-dir",
+        out.to_str().expect("경로"),
+        "--json",
+    ];
+    let output = run_with_stdin(&args, "이 줄은 경로도 데이터도 아니다\n또 한 줄\n");
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdin 의 쓰레기 입력이 결과를 바꿨습니다\n{}",
+        describe(&args, &output)
+    );
+    let records = ndjson(&args, &output);
+    assert_eq!(records.len(), 1, "{}", describe(&args, &output));
+    assert_eq!(records[0]["filledCount"], 1, "{}", records[0]);
+}
+
+#[test]
+fn verify_verdict_is_data_and_drives_exit_3() {
+    let names = unique_field_names();
+    let tmp = TmpDir::new("verify");
+    let data = tmp.join("rows.jsonl");
+    std::fs::write(&data, jsonl_line(&[(&names[0], "검증")])).expect("데이터 파일 쓰기");
+
+    let form = sample(FORM);
+    let out = tmp.out_dir();
+    let args = [
+        "batch",
+        "fill",
+        "--form",
+        form.to_str().expect("경로"),
+        "--data",
+        data.to_str().expect("경로"),
+        "--out-dir",
+        out.to_str().expect("경로"),
+        "--verify",
+        "--json",
+    ];
+    let output = run(&args);
+    let records = ndjson(&args, &output);
+    assert_eq!(records.len(), 1, "{}", describe(&args, &output));
+    let identical = records[0]["verify"]["identical"]
+        .as_bool()
+        .unwrap_or_else(|| panic!("--verify 판정이 데이터로 오지 않았습니다: {}", records[0]));
+    // 판정은 실패가 아니다 — 저장은 됐고 산출물도 있다. 3 은 "검토 대상", 1 은 "재실행 대상".
+    let expected = if identical { 0 } else { 3 };
+    assert_eq!(
+        output.status.code(),
+        Some(expected),
+        "verify 판정과 종료 코드가 어긋났습니다\n{}",
+        describe(&args, &output)
+    );
+    assert!(
+        Path::new(records[0]["output"].as_str().expect("output")).is_file(),
+        "검증 판정과 무관하게 산출물은 남아야 합니다: {}",
+        records[0]
+    );
+}
+
+// ── 부분 성공의 봉투 표현 ──────────────────────────────────────────────────
+
+#[test]
+fn unknown_field_names_are_partial_success_not_row_failure() {
+    // 서식에 없는 이름은 **그 행의 실패가 아니다** — 나머지는 채워진 문서가 나온다.
+    // 대신 notFound 에 남아 "완성본"으로 오해할 수 없게 한다. 이것을 error 로 접으면
+    // 소비자가 재실행 대상(1)과 검토 대상을 구분할 수 없다.
+    let names = unique_field_names();
+    let tmp = TmpDir::new("partial");
+    let data = tmp.join("rows.jsonl");
+    std::fs::write(
+        &data,
+        jsonl_line(&[
+            (&names[0], "채워짐"),
+            ("이_문서에_없는_필드", "무시됨"),
+            ("또_없는_필드", "무시됨"),
+        ]),
+    )
+    .expect("데이터 파일 쓰기");
+
+    let form = sample(FORM);
+    let out = tmp.out_dir();
+    let args = [
+        "batch",
+        "fill",
+        "--form",
+        form.to_str().expect("경로"),
+        "--data",
+        data.to_str().expect("경로"),
+        "--out-dir",
+        out.to_str().expect("경로"),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "없는 필드 이름은 행 실패가 아닙니다\n{}",
+        describe(&args, &output)
+    );
+
+    let record = ndjson(&args, &output).into_iter().next().expect("레코드");
+    assert!(record.get("error").is_none(), "{record}");
+    assert_eq!(
+        record["filledCount"], 1,
+        "실제로 채운 수여야 합니다: {record}"
+    );
+    let not_found: Vec<&str> = record["notFound"]
+        .as_array()
+        .expect("notFound")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+    assert_eq!(not_found.len(), 2, "{record}");
+    for missing in ["이_문서에_없는_필드", "또_없는_필드"] {
+        assert!(
+            not_found.contains(&missing),
+            "{missing} 이 notFound 에 없습니다: {record}"
+        );
+    }
+    assert!(
+        Path::new(record["output"].as_str().expect("output")).is_file(),
+        "부분 성공은 산출물을 남깁니다: {record}"
+    );
+}
+
+#[test]
+fn filled_values_survive_reparse_in_every_output() {
+    // 레코드가 "채웠다"고 말하는 것과 문서에 실제로 들어간 것은 다른 축이다.
+    // 산출물을 다시 열어 값이 살아 있는지 본다 — 여기서 끊기면 메일머지 전체가 무의미하다.
+    let names = unique_field_names();
+    let tmp = TmpDir::new("reparse");
+    let data = tmp.join("rows.jsonl");
+    let values = ["첫째 값", "둘째 값", "셋째 값"];
+    let body: String = values
+        .iter()
+        .map(|v| jsonl_line(&[(&names[0], v)]))
+        .collect();
+    std::fs::write(&data, body).expect("데이터 파일 쓰기");
+
+    let form = sample(FORM);
+    let out = tmp.out_dir();
+    let args = [
+        "batch",
+        "fill",
+        "--form",
+        form.to_str().expect("경로"),
+        "--data",
+        data.to_str().expect("경로"),
+        "--out-dir",
+        out.to_str().expect("경로"),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+
+    let records = ndjson(&args, &output);
+    assert_eq!(records.len(), values.len(), "{}", describe(&args, &output));
+    for (record, expected) in records.iter().zip(values.iter()) {
+        let written = record["output"].as_str().expect("output");
+        let probe = ["fields", written, "--json"];
+        let probe_out = run(&probe);
+        assert_eq!(
+            probe_out.status.code(),
+            Some(0),
+            "산출물을 다시 열 수 없습니다\n{}",
+            describe(&probe, &probe_out)
+        );
+        let reparsed = json_of(&probe, &probe_out);
+        let value = reparsed["fields"]
+            .as_array()
+            .expect("fields")
+            .iter()
+            .find(|f| f["name"] == names[0].as_str())
+            .unwrap_or_else(|| panic!("{} 필드가 산출물에 없습니다: {reparsed}", names[0]))
+            ["value"]
+            .as_str()
+            .unwrap_or("");
+        assert_eq!(
+            value, *expected,
+            "산출물의 값이 데이터 행과 다릅니다: {written}"
+        );
+    }
+}
+
+// ── 산출 이름 충돌·정규화 ──────────────────────────────────────────────────
+
+#[test]
+fn case_only_collisions_get_distinct_files() {
+    // Windows·macOS 기본 파일시스템은 대소문자를 구분하지 않는다. 소문자 키로 판정하지
+    // 않으면 그 OS 에서만 산출물이 사라져, Linux CI 는 통과하고 사용자만 데이터를 잃는다.
+    let names = unique_field_names();
+    let tmp = TmpDir::new("case");
+    let data = tmp.join("rows.jsonl");
+    let body: String = ["Alpha", "alpha", "ALPHA"]
+        .iter()
+        .map(|v| jsonl_line(&[(&names[0], v)]))
+        .collect();
+    std::fs::write(&data, body).expect("데이터 파일 쓰기");
+
+    let form = sample(FORM);
+    let out = tmp.out_dir();
+    let args = [
+        "batch",
+        "fill",
+        "--form",
+        form.to_str().expect("경로"),
+        "--data",
+        data.to_str().expect("경로"),
+        "--out-dir",
+        out.to_str().expect("경로"),
+        "--name-field",
+        names[0].as_str(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    assert_eq!(
+        written_files(&out).len(),
+        3,
+        "대소문자만 다른 이름이 서로를 덮어썼습니다: {:?}",
+        written_files(&out)
+    );
+}
+
+#[test]
+fn windows_reserved_device_names_still_produce_a_file() {
+    // CON·NUL 등은 Windows 에서 파일로 만들 수 없다. 그대로 쓰면 그 행만 조용히
+    // 실패하거나(플랫폼별 분기) 장치에 쓰게 된다.
+    let names = unique_field_names();
+    let tmp = TmpDir::new("reserved");
+    let data = tmp.join("rows.jsonl");
+    let body: String = ["CON", "NUL", "com1"]
+        .iter()
+        .map(|v| jsonl_line(&[(&names[0], v)]))
+        .collect();
+    std::fs::write(&data, body).expect("데이터 파일 쓰기");
+
+    let form = sample(FORM);
+    let out = tmp.out_dir();
+    let args = [
+        "batch",
+        "fill",
+        "--form",
+        form.to_str().expect("경로"),
+        "--data",
+        data.to_str().expect("경로"),
+        "--out-dir",
+        out.to_str().expect("경로"),
+        "--name-field",
+        names[0].as_str(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "예약 장치 이름에서 실패했습니다\n{}",
+        describe(&args, &output)
+    );
+    let files = written_files(&out);
+    assert_eq!(files.len(), 3, "{files:?}");
+    for f in &files {
+        let stem = f.split('.').next().unwrap_or("").to_ascii_uppercase();
+        assert!(
+            !matches!(stem.as_str(), "CON" | "NUL" | "COM1"),
+            "예약 장치 이름이 그대로 쓰였습니다: {f}"
+        );
+    }
+}
+
+#[test]
+fn very_long_name_field_value_is_truncated_to_a_writable_name() {
+    // Windows 경로 한도(260) 안에 들어와야 한다. 자르지 않으면 그 행만 쓰기 실패한다.
+    let names = unique_field_names();
+    let tmp = TmpDir::new("long");
+    let data = tmp.join("rows.jsonl");
+    let long = "가".repeat(400);
+    std::fs::write(&data, jsonl_line(&[(&names[0], long.as_str())])).expect("데이터 파일 쓰기");
+
+    let form = sample(FORM);
+    let out = tmp.out_dir();
+    let args = [
+        "batch",
+        "fill",
+        "--form",
+        form.to_str().expect("경로"),
+        "--data",
+        data.to_str().expect("경로"),
+        "--out-dir",
+        out.to_str().expect("경로"),
+        "--name-field",
+        names[0].as_str(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "긴 이름에서 실패했습니다\n{}",
+        describe(&args, &output)
+    );
+    let files = written_files(&out);
+    assert_eq!(files.len(), 1, "{files:?}");
+    let stem_chars = files[0].chars().count();
+    assert!(
+        stem_chars <= 100,
+        "이름이 잘리지 않았습니다({stem_chars}자): {}",
+        files[0]
+    );
+}
+
+#[test]
+fn unknown_name_field_falls_back_to_sequence_numbers() {
+    // 이름 필드를 잘못 적었을 때 전부 같은 이름으로 몰아 덮어쓰면 안 된다.
+    let names = unique_field_names();
+    let tmp = TmpDir::new("noname");
+    let data = tmp.join("rows.jsonl");
+    let body: String = ["하나", "둘", "셋"]
+        .iter()
+        .map(|v| jsonl_line(&[(&names[0], v)]))
+        .collect();
+    std::fs::write(&data, body).expect("데이터 파일 쓰기");
+
+    let form = sample(FORM);
+    let out = tmp.out_dir();
+    let args = [
+        "batch",
+        "fill",
+        "--form",
+        form.to_str().expect("경로"),
+        "--data",
+        data.to_str().expect("경로"),
+        "--out-dir",
+        out.to_str().expect("경로"),
+        "--name-field",
+        "존재하지_않는_필드",
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let files = written_files(&out);
+    assert_eq!(files.len(), 3, "순번 폴백이 겹쳤습니다: {files:?}");
+    for (i, f) in files.iter().enumerate() {
+        assert!(
+            f.starts_with(&format!("000{}", i + 1)),
+            "순번 이름이 아닙니다: {files:?}"
+        );
+    }
+}
+
+// ── 실패의 전파 방식: 중단이 아니라 계속 ────────────────────────────────────
+
+#[test]
+fn many_broken_rows_do_not_abort_the_run() {
+    // 계약의 요점: 실패는 **레코드**이고 프로세스는 끝까지 간다. 첫 실패에서 끊으면
+    // 뒤 행의 산출물이 통째로 사라지는데, 스트림만 보면 그 사실을 알 수 없다.
+    let names = unique_field_names();
+    let tmp = TmpDir::new("manybroken");
+    let data = tmp.join("rows.jsonl");
+    let mut body = String::new();
+    let mut expect_ok = Vec::new();
+    for i in 0..8 {
+        if i % 2 == 0 {
+            body.push_str(&jsonl_line(&[(&names[0], &format!("정상 {i}"))]));
+            expect_ok.push(i);
+        } else {
+            body.push_str(&format!("깨진 행 {i}\n"));
+        }
+    }
+    std::fs::write(&data, body).expect("데이터 파일 쓰기");
+
+    let form = sample(FORM);
+    let out = tmp.out_dir();
+    let args = [
+        "batch",
+        "fill",
+        "--form",
+        form.to_str().expect("경로"),
+        "--data",
+        data.to_str().expect("경로"),
+        "--out-dir",
+        out.to_str().expect("경로"),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}",
+        describe(&args, &output)
+    );
+
+    let records = ndjson(&args, &output);
+    assert_eq!(
+        records.len(),
+        8,
+        "실패가 여러 건이어도 8행 전부가 스트림에 있어야 합니다\n{}",
+        describe(&args, &output)
+    );
+    for (i, v) in records.iter().enumerate() {
+        assert_eq!(v["row"], i, "행 번호가 밀렸습니다: {v}");
+        let is_ok = expect_ok.contains(&i);
+        assert_eq!(
+            v.get("error").is_none(),
+            is_ok,
+            "행 {i} 의 성패가 뒤바뀌었습니다: {v}"
+        );
+    }
+    assert_eq!(
+        written_files(&out).len(),
+        4,
+        "실패 뒤의 정상 행이 처리되지 않았습니다: {:?}",
+        written_files(&out)
+    );
+}
+
+#[test]
+fn unreadable_form_fails_before_any_row_and_writes_nothing() {
+    // 서식은 행마다 열린다. 못 여는 서식이면 같은 실패를 N번 보고하게 되므로 —
+    // 그건 진단이 아니다 — 한 행을 처리하기 전에 끝낸다.
+    let names = unique_field_names();
+    let tmp = TmpDir::new("noform");
+    let data = tmp.join("rows.jsonl");
+    let body: String = ["가", "나", "다"]
+        .iter()
+        .map(|v| jsonl_line(&[(&names[0], v)]))
+        .collect();
+    std::fs::write(&data, body).expect("데이터 파일 쓰기");
+
+    let missing = tmp.join("없는서식.hwp");
+    let out = tmp.out_dir();
+    let args = [
+        "batch",
+        "fill",
+        "--form",
+        missing.to_str().expect("경로"),
+        "--data",
+        data.to_str().expect("경로"),
+        "--out-dir",
+        out.to_str().expect("경로"),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "한 행도 처리하지 못했는데 stdout 에 레코드가 있습니다\n{}",
+        describe(&args, &output)
+    );
+    assert!(!out.exists(), "출력 폴더가 생겼습니다: {}", out.display());
+}
+
+#[test]
+fn threads_do_not_change_row_order_or_output_names() {
+    // 병렬로 돌려도 방출은 입력 순서다(기존 batch 규약). 산출 이름은 행 순서만으로
+    // 정해지므로 스레드 수를 바꾼 재실행이 달라지면 안 된다.
+    let names = unique_field_names();
+    let tmp = TmpDir::new("threads");
+    let data = tmp.join("rows.jsonl");
+    let body: String = (0..12)
+        .map(|i| jsonl_line(&[(&names[0], &format!("행 {i:02}"))]))
+        .collect();
+    std::fs::write(&data, body).expect("데이터 파일 쓰기");
+
+    let form = sample(FORM);
+    let mut signatures = Vec::new();
+    for threads in ["1", "8"] {
+        let out = tmp.join(&format!("out{threads}"));
+        let args = [
+            "batch",
+            "fill",
+            "--form",
+            form.to_str().expect("경로"),
+            "--data",
+            data.to_str().expect("경로"),
+            "--out-dir",
+            out.to_str().expect("경로"),
+            "--threads",
+            threads,
+            "--json",
+        ];
+        let output = run(&args);
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "{}",
+            describe(&args, &output)
+        );
+        let records = ndjson(&args, &output);
+        assert_eq!(records.len(), 12, "{}", describe(&args, &output));
+        let signature: Vec<(u64, String, String)> = records
+            .iter()
+            .map(|v| {
+                (
+                    v["row"].as_u64().expect("row"),
+                    v["filled"][0]["value"].as_str().unwrap_or("").to_string(),
+                    Path::new(v["output"].as_str().expect("output"))
+                        .file_name()
+                        .expect("파일명")
+                        .to_string_lossy()
+                        .to_string(),
+                )
+            })
+            .collect();
+        for (i, (row, _, _)) in signature.iter().enumerate() {
+            assert_eq!(*row as usize, i, "threads={threads} 에서 순서가 깨졌습니다");
+        }
+        assert_eq!(written_files(&out).len(), 12, "{:?}", written_files(&out));
+        signatures.push(signature);
+    }
+    assert_eq!(
+        signatures[0], signatures[1],
+        "스레드 수에 따라 결과가 달라졌습니다"
+    );
+}
+
+// ── 인자 오류(2) ──────────────────────────────────────────────────────────
+
+#[test]
+fn missing_or_malformed_arguments_are_usage_errors() {
+    let names = unique_field_names();
+    let tmp = TmpDir::new("usage");
+    let form = sample(FORM);
+    let form_s = form.to_str().expect("경로").to_string();
+    let out = tmp.out_dir();
+    let out_s = out.to_str().expect("경로").to_string();
+
+    let good = tmp.join("rows.jsonl");
+    std::fs::write(&good, jsonl_line(&[(&names[0], "값")])).expect("데이터 파일 쓰기");
+    let good_s = good.to_str().expect("경로").to_string();
+
+    // 확장자로 형식을 정한다 — 모르는 확장자를 추측해서 읽지 않는다.
+    let unknown_ext = tmp.join("rows.txt");
+    std::fs::write(&unknown_ext, "아무거나\n").expect("데이터 파일 쓰기");
+    // 0행을 성공(0)으로 끝내면 "전부 처리했다"와 구분되지 않는다.
+    let empty = tmp.join("empty.jsonl");
+    std::fs::write(&empty, "\n\n").expect("데이터 파일 쓰기");
+    // 따옴표가 닫히지 않으면 뒤 행 전체가 한 칸으로 삼켜진다.
+    let unclosed = tmp.join("unclosed.csv");
+    std::fs::write(&unclosed, format!("{}\n\"열린 따옴표\n", names[0])).expect("데이터 파일 쓰기");
+    // 같은 헤더가 둘이면 한 열이 통째로 무시된다.
+    let dup_header = tmp.join("dup.csv");
+    std::fs::write(&dup_header, format!("{0},{0}\n가,나\n", names[0])).expect("데이터 파일 쓰기");
+
+    let cases: Vec<(&str, Vec<String>)> = vec![
+        (
+            "--form 없음",
+            vec![
+                "batch",
+                "fill",
+                "--data",
+                &good_s,
+                "--out-dir",
+                &out_s,
+                "--json",
+            ]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+        ),
+        (
+            "--data 없음",
+            vec![
+                "batch",
+                "fill",
+                "--form",
+                &form_s,
+                "--out-dir",
+                &out_s,
+                "--json",
+            ]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+        ),
+        (
+            "--out-dir 없음",
+            vec![
+                "batch", "fill", "--form", &form_s, "--data", &good_s, "--json",
+            ]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+        ),
+        (
+            "--json 없음",
+            vec![
+                "batch",
+                "fill",
+                "--form",
+                &form_s,
+                "--data",
+                &good_s,
+                "--out-dir",
+                &out_s,
+            ]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+        ),
+        (
+            "--out-dir 값 자리에 플래그",
+            vec![
+                "batch",
+                "fill",
+                "--form",
+                &form_s,
+                "--data",
+                &good_s,
+                "--out-dir",
+                "--json",
+            ]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+        ),
+        (
+            "모르는 확장자",
+            vec![
+                "batch",
+                "fill",
+                "--form",
+                &form_s,
+                "--data",
+                unknown_ext.to_str().expect("경로"),
+                "--out-dir",
+                &out_s,
+                "--json",
+            ]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+        ),
+        (
+            "데이터 0행",
+            vec![
+                "batch",
+                "fill",
+                "--form",
+                &form_s,
+                "--data",
+                empty.to_str().expect("경로"),
+                "--out-dir",
+                &out_s,
+                "--json",
+            ]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+        ),
+        (
+            "CSV 따옴표 미종료",
+            vec![
+                "batch",
+                "fill",
+                "--form",
+                &form_s,
+                "--data",
+                unclosed.to_str().expect("경로"),
+                "--out-dir",
+                &out_s,
+                "--json",
+            ]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+        ),
+        (
+            "CSV 헤더 중복",
+            vec![
+                "batch",
+                "fill",
+                "--form",
+                &form_s,
+                "--data",
+                dup_header.to_str().expect("경로"),
+                "--out-dir",
+                &out_s,
+                "--json",
+            ]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+        ),
+    ];
+
+    for (label, argv) in cases {
+        let args: Vec<&str> = argv.iter().map(String::as_str).collect();
+        let output = run(&args);
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "{label} 은 사용법 오류(2)여야 합니다\n{}",
+            describe(&args, &output)
+        );
+        assert!(
+            output.stdout.is_empty(),
+            "{label}: 인자 오류에서 stdout 은 0바이트여야 합니다\n{}",
+            describe(&args, &output)
+        );
+        assert!(
+            !out.exists(),
+            "{label}: 인자 오류인데 출력 폴더가 생겼습니다"
+        );
+    }
+}
+
+#[test]
+fn fill_flags_are_axis_scoped() {
+    // `--form`·`--name-field`·`--dry-run` 은 fill 축 전용이고, 다른 축의 전용 플래그는
+    // fill 에서 거부된다 (`--query`·`--mode` 와 같은 규약).
+    let tmp = TmpDir::new("scope");
+    let form = sample(FORM);
+    let form_s = form.to_str().expect("경로").to_string();
+
+    for extra in [
+        vec!["--form", &form_s],
+        vec!["--name-field", "이름"],
+        vec!["--dry-run"],
+    ] {
+        let mut args = vec!["batch", "info", "--json"];
+        args.extend(extra.iter().map(|s| &**s));
+        let output = run_in_dir(&args, tmp.path());
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "fill 전용 플래그가 다른 축에서 통과했습니다\n{}",
+            describe(&args, &output)
+        );
+    }
+
+    for extra in [
+        vec!["--mode", "auto"],
+        vec!["--query", "가"],
+        vec!["--verify-pages"],
+    ] {
+        let mut args = vec!["batch", "fill", "--json"];
+        args.extend(extra.iter().map(|s| &**s));
+        let output = run_in_dir(&args, tmp.path());
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "다른 축의 플래그가 fill 에서 통과했습니다\n{}",
+            describe(&args, &output)
+        );
+    }
+}
+
+// ── 자기서술 드리프트 가드 ─────────────────────────────────────────────────
+
+fn capabilities() -> serde_json::Value {
+    let args = ["capabilities"];
+    json_of(&args, &run(&args))
+}
+
+fn capabilities_mcp() -> serde_json::Value {
+    let args = ["capabilities", "--mcp"];
+    json_of(&args, &run(&args))
+}
+
+#[test]
+fn capabilities_declares_the_fill_axis() {
+    let v = capabilities();
+    let subs: Vec<&str> = v["batch"]["subcommands"]
+        .as_array()
+        .expect("batch.subcommands")
+        .iter()
+        .filter_map(|s| s.as_str())
+        .collect();
+    assert!(subs.contains(&"fill"), "batch 축에 fill 누락: {subs:?}");
+
+    let axis: Vec<&str> = v["batch"]["flags"]
+        .as_array()
+        .expect("batch.flags")
+        .iter()
+        .filter_map(|s| s.as_str())
+        .collect();
+    for expected in [
+        "--form",
+        "--name-field",
+        "--dry-run",
+        "--out-dir",
+        "--verify",
+    ] {
+        assert!(
+            axis.contains(&expected),
+            "batch.flags 에 {expected} 누락: {axis:?}"
+        );
+    }
+
+    // 축 선언과 명령 항목 선언이 어긋나면 소비자는 어느 쪽도 믿을 수 없다
+    // (cli_json_contract::capabilities_declared_flags_are_real_cli_flags 와 같은 규약).
+    let entry: Vec<&str> = v["commands"]
+        .as_array()
+        .expect("commands")
+        .iter()
+        .find(|c| c["name"] == "batch")
+        .expect("batch 항목")["flags"]
+        .as_array()
+        .expect("commands[batch].flags")
+        .iter()
+        .filter_map(|s| s.as_str())
+        .collect();
+    let missing: Vec<&str> = axis
+        .iter()
+        .copied()
+        .filter(|f| !entry.contains(f))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "batch.flags 에는 있는데 commands[batch].flags 에 없는 플래그: {missing:?}"
+    );
+
+    // fill 은 stdin 을 읽지 않는다는 사실이 자기서술에 있어야, 매니페스트만 읽은
+    // 에이전트가 stdin 에 경로를 밀어 넣고 "왜 아무것도 안 되지" 를 겪지 않는다.
+    let input = v["batch"]["input"].as_str().expect("batch.input");
+    assert!(
+        input.contains("fill"),
+        "fill 축의 다른 입력 축이 batch.input 에 없습니다: {input}"
+    );
+}
+
+#[test]
+fn declared_batch_flags_are_accepted_by_some_axis() {
+    // 드리프트 가드: 선언한 플래그는 **실제로 수용**돼야 한다. 매니페스트는 에이전트가
+    // 도구 정의를 자동 생성하는 원천이라, 여기 있는데 CLI 가 모르는 플래그는 그 에이전트를
+    // 영영 exit 2 에 가둔다.
+    let v = capabilities();
+    let flags: Vec<String> = v["batch"]["flags"]
+        .as_array()
+        .expect("batch.flags")
+        .iter()
+        .filter_map(|s| s.as_str())
+        .map(String::from)
+        .collect();
+    let subs: Vec<String> = v["batch"]["subcommands"]
+        .as_array()
+        .expect("batch.subcommands")
+        .iter()
+        .filter_map(|s| s.as_str())
+        .map(String::from)
+        .collect();
+    assert!(!flags.is_empty() && !subs.is_empty(), "가드가 공허합니다");
+
+    // 값이 필요한 플래그에는 아무 값이나 붙인다. 어차피 `--json` 을 주지 않으므로 어떤
+    // 축도 실제 작업을 시작하지 않는다 — 인자 파서만 통과하는지 본다(부작용 없음).
+    let needs_value =
+        |flag: &str| !matches!(flag, "--json" | "--verify" | "--verify-pages" | "--dry-run");
+    let tmp = TmpDir::new("flagprobe");
+
+    for flag in &flags {
+        let accepted = subs.iter().any(|sub| {
+            let mut args = vec!["batch", sub.as_str(), flag.as_str()];
+            if needs_value(flag) {
+                args.push("1");
+            }
+            let output = run_in_dir(&args, tmp.path());
+            !String::from_utf8_lossy(&output.stderr).contains(&format!("알 수 없는 옵션: {flag}"))
+        });
+        assert!(
+            accepted,
+            "capabilities 가 선언한 {flag} 를 받아 주는 batch 축이 하나도 없습니다"
+        );
+    }
+}
+
+#[test]
+fn mcp_declares_batch_fill_and_wires_every_input() {
+    let v = capabilities_mcp();
+    let tools = v["tools"].as_array().expect("tools");
+    let tool = tools
+        .iter()
+        .find(|t| t["name"] == "hwp_batch_fill")
+        .unwrap_or_else(|| panic!("hwp_batch_fill 도구 누락: {v}"));
+
+    let schema = &tool["inputSchema"];
+    assert_eq!(schema["type"], "object", "{tool}");
+    let props = schema["properties"].as_object().expect("properties");
+    let required: Vec<&str> = schema["required"]
+        .as_array()
+        .expect("required 는 배열이어야 합니다")
+        .iter()
+        .filter_map(|s| s.as_str())
+        .collect();
+    for key in ["form", "data", "outDir"] {
+        assert!(required.contains(&key), "required 에 {key} 누락: {tool}");
+    }
+
+    // 선언만 하고 배선하지 않으면 서버는 그 인자를 조용히 버린 채 성공을 보고한다.
+    let mut wired: Vec<String> = tool["cli"]["args"]
+        .as_array()
+        .expect("cli.args")
+        .iter()
+        .filter_map(|a| a.as_str())
+        .filter(|s| s.starts_with('{') && s.ends_with('}') && s.len() > 2)
+        .map(|s| s[1..s.len() - 1].to_string())
+        .collect();
+    for o in tool["cli"]["optionalArgs"]
+        .as_array()
+        .expect("cli.optionalArgs")
+    {
+        wired.push(o["when"].as_str().expect("when").to_string());
+    }
+    for key in props.keys() {
+        assert!(
+            wired.contains(key),
+            "hwp_batch_fill.{key} 가 CLI 인자에 배선되지 않았습니다: {tool}"
+        );
+    }
+    assert_eq!(tool["cli"]["command"], "batch", "{tool}");
+
+    // stdin 도구가 아니다 — 서버가 paths 를 요구하면 fill 은 영영 호출되지 않는다.
+    let stdin_tools: Vec<&str> = v["invocation"]["stdinTools"]
+        .as_array()
+        .expect("invocation.stdinTools")
+        .iter()
+        .filter_map(|s| s.as_str())
+        .collect();
+    assert!(
+        !stdin_tools.contains(&"hwp_batch_fill"),
+        "fill 은 stdin 을 읽지 않는데 stdinTools 에 있습니다: {stdin_tools:?}"
+    );
+}
+
+#[test]
+fn help_documents_the_fill_axis_and_its_different_input() {
+    let args = ["--help"];
+    let output = run(&args);
+    let help = String::from_utf8_lossy(&output.stdout);
+    for needle in ["batch fill", "--form", "--name-field", "--data"] {
+        assert!(
+            help.contains(needle),
+            "--help 에 {needle} 가 없습니다 (capabilities 등재 명령은 help 에도 있어야 합니다)"
+        );
+    }
+    assert!(
+        help.contains("stdin 을 읽지 않는다"),
+        "fill 이 stdin 을 읽지 않는다는 사실이 --help 에 없습니다"
+    );
+}


### PR DESCRIPTION
#3719 §6-6. 데이터 여러 행으로 서식 문서를 한 번에 채운다 — 메일머지.

```
rhwp batch fill --json --form 양식.hwp --name-field 이름 --out-dir 산출/ [--threads N] < rows.csv
```

MCP 도구 `hwp_batch_fill` 동시 등록.

## 입력이 '경로'가 아니라 '행'이다

다른 batch 축은 stdin 으로 **문서 경로 목록**을 받는다. fill 은 **데이터 행**을 받는다.
그래서 `run_batch` 최상단에서 `fill` 을 분기해 **경로 목록 읽기 경로를 아예 타지 않게** 했다.
같은 stdin 인데 의미가 다른 것을 한 흐름에 욱여넣으면 나중에 반드시 깨진다.

## 새 편집 로직은 0이다 — 갈라서 공유했다

**`edit_fill_fields` → `fill_fields_core(file, data, out, dry_run, verify) -> Result<FillOutcome, String>`**
로 갈라 단건·배치가 같은 함수를 쓴다. 실패 표현만 `Err(사유)` 로 바꿨다 — 배치는 프로세스를
끊는 대신 행 단위 `error` 레코드를 만들어야 하기 때문이다.

스트리밍 기계도 공유한다. `run_batch` 안에 인라인이던 병렬 + 한계 재정렬 버퍼를
**`batch_stream_records(n, threads, make, out) -> BatchStreamTally`** 로 추출했다.
순서 보존 · 역압 · broken pipe · 종료 코드 집계가 한 곳(`BatchStreamTally::exit_code()`)에 모인다.

`src/main.rs` 의 `-129` 는 **전부 이 추출**이고 동작 변경이 아니다. 기존 축의 무회귀는
`batch_axes_contract` **17/0** 과 `edit_fill_fields_contract` **7/0** 으로 확인했다.

## 산출 이름이 이 축의 함정이다

파일 이름이 **데이터에서 온다.** 검증 없이 쓰면 경로 탈출과 덮어쓰기가 된다.

- 쓰기 **전에 전 행 사전 계산** — 병렬에서도 결정적이다
- 금지 문자 치환 · Windows 예약 장치 이름 회피 · 80자 상한
- **소문자 키로 중복 판정** → `_2`/`_3`. `홍길동` 과 `홍길동 ` 이 같은 파일을 노리면 안 된다
- `--out-dir` 탈출 시도는 테스트로 고정

CSV 는 crate 추가 없이 RFC 4180 만 구현했고 UTF-8 BOM 을 제거한다.

## 실측

| | |
|---|---|
| `batch_fill_contract` (신규) | **25 passed / 0 failed** |
| `batch_axes_contract` | 17 / 0 |
| `cli_json_contract` | 26 / 0 |
| `mcp_server_contract` | 22 / 0 |
| `edit_fill_fields_contract` | 7 / 0 |
| `changed_pages_contract` | 5 / 0 |
| `run_plan_contract` | 8 / 0 |
| `clippy -D warnings` | 0 |
| rustfmt | clean |

**선검사 `agent_preflight.py`(#3795) 10게이트 전부 통과** — 오염(4 staged) · MCP inputSchema(26도구) ·
선언속성↔CLI배선 · capabilities↔help(54명령) · 선언 flags 실재(63) · 실패경로 stdout 0바이트(3경로).

테스트 25건이 덮는 것: CSV 2(BOM·CRLF·인용, 칸 수 불일치) · **이름 충돌·정규화 5**(중복, 대소문자,
예약어, 400자, out-dir 탈출) · **실패 전파 4**(스트림 잔존, 8행 중 4행 실패해도 미중단,
서식 불가 시 0행 처리 + stdout 0바이트, `threads 1↔8` 동일 결과) · 부분 성공 2(`notFound` 는
행 실패가 아니다, 산출물 재파싱 값 일치) · 선검증/입력축/verify 3 · 인자 오류 8케이스 · 축 스코프 6케이스 ·
자기서술 4.

## 남은 것 (의도적)

- **`mydocs/manual/cli_commands.md` 미갱신** — 공유 트리에서 동시 작업 중인 파일이라 충돌 회피로
  범위 밖에 뒀다. README 「남은 것」에 사유 명시
- 암호 문서는 batch 축 전체가 `--password` 계열을 거부하는 **기존 규약을 승계**
- `--out-dir` 중복 해소는 **이번 실행 안에서만**. 같은 폴더에 두 번 실행하면 앞 산출물을
  덮어쓴다(`batch convert` 와 동일 동작) — README 에 기록
- fill 축에 형식 변환 스위치는 두지 않았다(산출 형식 = 서식 형식). 변환은 `convert`/`export-hwpx` 책임
