### PR TITLE
[#3719 §6-11] edit redact / sanitize — 체크섬 통과 못 하면 마스킹하지 않는다 (오탐 0)

### DIFF
--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -542,8 +542,87 @@ rhwp edit set-cell 양식.hwpx --table 0 --row 2 --col 1 --text "1,234" -o 작�
 rhwp export-tables 작성본.hwpx --json | jq '.tables[0].cells[] | select(.row==2 and .col==1).text'
 ```
 
+### `edit redact <파일> [--kind …] [--mask <문자>] [--dry-run] [-o <출력>|--in-place]` (#3719 §6-11)
+공개 전 개인정보 마스킹 — 주민등록번호·전화번호·이메일·카드번호를 찾아 **자릿수를 유지한 채**
+가린다. 탐지는 읽기 전용 코어(`document_core::queries::pii_scan`)가 하고, 실제 변경은 검증된
+치환 경로(`replace_all_native`)를 재사용하므로 새 편집 로직이 없다. 주소는 `grep` 재사용이라
+매치마다 구역·문단·**쪽**·문자 오프셋이 따라온다.
+
+- `--kind <목록>` — `ssn|phone|email|card|all` 을 쉼표로 나열 (기본 `all`)
+- `--mask <문자>` — 마스킹 문자 **한 글자**. 영숫자는 거부한다(본문과 구별 불가). 두 글자
+  이상이면 자릿수 보존이 깨지므로 조용히 자르지 않고 exit 2.
+- `--dry-run` — **권장 첫 단계**. 파일을 만들지 않고 `findings[]` 만 보고한다.
+- `-o, --output <파일>` / `--in-place` — 둘 중 하나가 **반드시** 필요하다(§원본 보호).
+- `--verify` — 저장 직후 IR 자기검증(차이 시 exit 3, #3702)
+- `--json` 봉투:
+  `{"schemaVersion":"1.0","source","kinds","mask","dryRun","inPlace","findingCount",`
+  `"findings":[{"kind","raw","masked","section","paragraph","page","charOffset"}],`
+  `"redactedCount","changedPages","output"?,"outputFormat"?,"verify"?}`
+  - `output`/`outputFormat`/`verify` 는 실제 저장했을 때만 실린다 — **탐지 0건이면 출력
+    파일을 만들지 않는다**.
+
+**탐지 규칙(보수적)** — 마스킹은 되돌릴 수 없고 오탐은 본문을 훼손하므로, 형태가 맞아도
+검증을 통과하지 못하면 **탐지하지 않는다**.
+
+| 종류 | 형태 | 추가 검증 |
+| --- | --- | --- |
+| `ssn` | `######-#######` | 생년월일 실재(윤년 포함) + 성별/세기 코드 1~8 + mod 11 검증 숫자 |
+| `card` | `4-4-4-4`(`-`/공백), Amex `4-6-5`, 연속 15·16자리 | Luhn |
+| `phone` | `01[016789]-3~4자리-4자리`, `02-3~4자리-4자리` | 하이픈 필수 |
+| `email` | `지역부@라벨(.라벨)+` | 라벨 2개 이상 + 최상위 도메인 영문 2자 이상 |
+
+- 앞뒤가 숫자면 더 긴 토큰의 일부로 보고 버린다(계좌번호 안의 16자리 부분열 오인 방지).
+- **02 외 지역번호, 13·14·19자리 카드, 여권번호·계좌번호는 v1 범위 밖**이다 — 체크섬이
+  없거나 문서번호와 구별할 근거가 없어 보수적 판정이 불가능하다. 근거와 확장 조건은
+  [처리 기록](../report/task_m100_redact/README.md)에 있다.
+
+**원본 보호** — `-o` 도 `--in-place` 도 없으면 **실행하지 않는다**(exit 2). 다른 `edit`
+명령과 달리 `_redacted.hwp` 같은 기본 이름도 만들지 않는다. `-o` 가 원본 자신을 가리켜도
+같은 이유로 거부한다. 쓰기는 원자적이라 `--in-place` 도중 실패해도 원본이 잘리지 않는다.
+
+> `findings[].raw` 는 **원문 개인정보 그 자체**다. 감사를 위해 넣었지만 로그·이슈에 그대로
+> 붙이면 유출 경로가 된다.
+
+```bash
+# 권장 흐름: 먼저 무엇이 지워질지 본다 → 확인 후 적용
+rhwp edit redact 계약서.hwp --dry-run --json | jq '.findings[] | {kind, page, masked}'
+rhwp edit redact 계약서.hwp -o 공개본.hwp --verify --json | jq '{redactedCount, changedPages}'
+rhwp edit redact 계약서.hwp --kind ssn,card -o 공개본.hwp --json   # 종류를 좁힐 수도 있다
+```
+
+### `edit sanitize <파일> [--keep-preview] [-o <출력>] [--json]` (#3719 §6-11)
+문서 메타데이터 제거 — 작성자·제목·주제·최종수정자·작성/수정 일시·미리보기.
+**본문 내용은 건드리지 않는다**(`export-text` 결과가 전후 동일).
+
+- `--keep-preview` — 미리보기 **이미지**를 남긴다(기본은 제거). 미리보기 텍스트는 언제나 대상.
+- `-o, --output <파일>` — 출력 파일 (기본 `<입력명>_sanitized.<입력과 같은 확장자>`)
+- `--json` 봉투:
+  `{"schemaVersion":"1.0","source","keepPreview","removedCount","removed":[{"field","before"}],"output","outputFormat"}`
+
+지우는 대상은 셋이다.
+
+1. **OLE 요약 정보**(`\x05HwpSummaryInformation`) — `title`·`subject`·`author`·`keywords`·
+   `comments`·`lastSavedBy`·`revisionNumber`·`dateString`(문자열)과 `createdAt`·
+   `lastSavedAt`·`lastPrintedAt`(FILETIME → ISO 8601 로 보고). 속성 오프셋 표가 절대 위치를
+   담고 있어 **바이트 길이를 바꾸지 않고** 비운다.
+2. **HWPX 저작자 메타**(`Contents/content.hpf` 의 `<opf:metadata>`) — 직렬화기가 원본에서
+   그대로 splice 하는 유일한 저작자 경로다. 중립 블록으로 교체한다.
+3. **미리보기**(PrvText·PrvImage) — ZIP 엔트리와 HWP5 계약 스트림 양쪽.
+
+`removed[]` 는 **거짓 보고를 하지 않는다**. HWP5 직렬화기는 PrvText 가 비면 본문 앞부분으로
+다시 채우므로, 미리보기 텍스트는 **지금 본문과 다를 때만**(= 예전 판의 잔재일 때만) 지우고
+보고한다. HWPX 원본의 `/HwpSummaryInformation` 은 파일에 없던 계약 fallback 상수라 HWPX 로
+저장할 때는 손대지 않고, HWP5 로 변환할 때만 처리한다. 그래서 **두 번째 실행은
+`removedCount: 0`** 이다 — 첫 실행이 실제로 지웠다는 증거다.
+
+```bash
+rhwp edit sanitize 보고서.hwp -o 배포본.hwp --json | jq '.removed[] | "\(.field): \(.before)"'
+rhwp edit sanitize 배포본.hwp -o /tmp/재확인.hwp --json | jq .removedCount   # → 0
+```
+
 ### `edit` 산출 형식 (#3383)
-`edit` 3종(`fill-fields`/`replace-text`/`set-cell`)은 **입력 형식을 보존**한다.
+`edit` 5종(`fill-fields`/`replace-text`/`set-cell`/`redact`/`sanitize`)은
+**입력 형식을 보존**한다.
 
 - HWPX 입력 → HWPX 산출(`export_hwpx_native`), 기본 확장자도 `.hwpx`
 - 그 밖의 입력(HWP5/HWP3) → HWP5 산출. 이때 직렬화는 **어댑터 경유**

--- a/mydocs/report/task_m100_redact/README.md
+++ b/mydocs/report/task_m100_redact/README.md
@@ -1,0 +1,195 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_redact/README.md
+last_verified: 2026-08-02
+---
+
+# 로드맵 #3719 §6-11 처리 기록 — `edit redact` · `edit sanitize` (공개 전 정리)
+
+## 문제
+
+문서를 공개·제출하기 직전에 두 가지를 반드시 지워야 한다.
+
+1. **본문 안의 개인정보** — 계약서·신청서·회의록에 남은 주민등록번호·전화번호·
+   이메일·카드번호. 사람이 눈으로 찾으면 반드시 빠뜨린다(표 셀·글상자 안은 특히).
+2. **문서 메타데이터** — 작성자·최종수정자·작성일시·미리보기. 본문을 아무리 다듬어도
+   파일 속성에 실명이 남고, **미리보기에는 본문에서 이미 지운 문장이 남아 있다**.
+   PDF 로 내보내면 사라지지만 HWP/HWPX 원본을 그대로 배포하면 전부 따라간다.
+
+rhwp 에는 이 두 작업을 위한 출구가 없었다. `export-text` 로 뽑아 눈으로 훑고
+`replace-text` 로 하나씩 치는 방법뿐이었는데, ① 주소(몇 쪽 어느 셀)를 잃고
+② 무엇을 놓쳤는지 알 수 없으며 ③ 메타데이터는 손도 못 댄다.
+
+## 설계 원칙 — 왜 이렇게 **좁혔는가**
+
+이 명령의 핵심 위험은 기능 부족이 아니라 **오탐**이다. 마스킹은 되돌릴 수 없고,
+오탐 하나가 본문의 금액·일련번호·문서번호를 영구히 `******` 로 만든다. 사용자는
+원본을 이미 덮어썼을 수 있다.
+
+그래서 판정 규칙을 다음 순서로 세웠다.
+
+> **형태가 맞아도 검증을 통과하지 못하면 탐지하지 않는다.**
+
+| 종류 | 형태 | 추가 검증 | 근거 |
+| --- | --- | --- | --- |
+| 주민등록번호 | `######-#######` | ① 생년월일 실재(윤년 포함) ② 성별/세기 코드 1~8 ③ mod 11 검증 숫자 | 형태만 보면 `123456-1234567` 같은 **예시 문자열**까지 지운다. 검증 숫자만 걸면 임의 숫자쌍 11개 중 1개가 우연히 통과하므로 세기 코드까지 함께 건다 |
+| 카드번호 | `4-4-4-4`(`-`/공백), Amex `4-6-5`, 연속 15·16자리 | Luhn | Luhn 없이는 16자리 회계 숫자·계좌번호를 전부 삼킨다 |
+| 전화번호 | `01[016789]-3~4자리-4자리`, `02-3~4자리-4자리` | (하이픈 필수) | 하이픈 없는 `01012345678` 은 문서번호와 형태가 같다 |
+| 이메일 | `지역부@라벨(.라벨)+` | 라벨 2개 이상 + 최상위 도메인이 영문 2자 이상 | `a@localhost`·`user@example.12` 는 주소가 아니다 |
+
+공통으로 **숫자 경계 검사**를 건다 — 앞뒤가 숫자면 더 긴 토큰의 일부로 보고 버린다.
+22자리 계좌번호 안에서 16자리 부분열을 카드로 오인하지 않기 위해서다.
+
+### 의도적으로 **하지 않는** 것
+
+- **02 외의 지역번호(031·051·064…)는 탐지하지 않는다.** 목록을 넣으면 커버리지는
+  오르지만, `0XX-XXX-XXXX` 형태의 회계 코드·민원 접수번호와 구별할 근거가 사라진다.
+  로드맵이 지정한 형태(`010-####-####`·`02-###-####`)로 좁히고, 넓히려면 실문서
+  오탐 실측을 근거로 별도 이슈에서 확장한다.
+- **13·14·19자리 카드는 탐지하지 않는다.** 자릿수를 넓힐수록 Luhn 만으로는
+  1/10 확률의 우연 통과가 그대로 오탐이 된다.
+- **여권번호·계좌번호·주소는 v1 범위 밖이다.** 체크섬이 없거나(계좌) 형태가 기관마다
+  달라(여권) 보수적 판정이 불가능하다. 넣으면 "오탐 0" 원칙 자체가 무너진다.
+
+놓치는 쪽으로 기운 설계이므로 **`--dry-run` 이 권장 첫 단계**다. 무엇이 지워질지
+전부 보여준 뒤에 사용자가 적용을 결정한다.
+
+## 구현
+
+### 1) 탐지 코어 — `src/document_core/queries/pii_scan.rs` (신규, 662줄)
+
+**읽기 전용 판정만** 한다. 문서를 바꾸지 않는다.
+
+- `detect_values(text, kinds) -> Vec<(PiiKind, String)>` — 순수 함수. 문서 없이
+  규칙 자체를 테스트할 수 있게 공개했다(오탐 회귀 케이스의 1차 방어선).
+- `DocumentCore::scan_pii(kinds, mask) -> Vec<PiiFinding>` — 본문·표 셀·글상자를
+  순회해 값을 모으고, **주소는 [`grep`](../../../src/document_core/queries/grep.rs) 을
+  재사용**해 붙인다. 구역·문단·**페이지**·문자 오프셋이 매치마다 따라온다
+  (분할 표의 행별 페이지 보정까지 grep 이 이미 처리한다).
+- `mask_value(raw, mask)` — 영숫자만 마스킹 문자로 바꾸고 구분자(`-`·`@`·`.`)는
+  남긴다. **문자 수가 보존된다** — 길이가 바뀌면 줄바꿈이 밀려 조판이 흔들린다.
+
+정규식 의존성을 새로 넣지 않았다. 체크섬·경계 검사를 어차피 손으로 해야 하므로
+문자 스캐너가 규칙을 더 정확히 표현한다.
+
+### 2) `rhwp edit redact` — 개인정보 마스킹
+
+```
+rhwp edit redact <파일> [--kind ssn|phone|email|card|all] [--mask <문자>]
+                        [--dry-run] [--verify] [-o <출력>|--in-place] [--json]
+```
+
+- **새 편집 로직이 없다.** 실제 변경은 검증된 `replace_all_native` 를 값 단위로
+  호출한다. 짧은 값이 긴 값의 부분열일 때 원문을 깨뜨리지 않도록 **긴 값부터** 친다.
+- **원본 보호**: `-o` 도 `--in-place` 도 없으면 `exit 2` 로 거부한다. 다른 edit
+  명령처럼 `_redacted.hwp` 기본 이름을 만들지도 **않는다** — 되돌릴 수 없는 작업에서
+  "어디에 무엇이 생겼는지 모르는 상태"를 만들지 않기 위해서다. `-o` 가 원본 자신을
+  가리켜도 같은 사고이므로 같은 코드로 거부한다(`fs::canonicalize` 비교).
+- `--mask` 는 **영숫자가 아닌 한 글자**만 받는다. 두 글자면 자릿수 보존이 깨지고,
+  영숫자면 마스킹인지 본문인지 구별할 수 없다. 조용히 자르지 않고 `exit 2`.
+- 쓰기는 `atomic_file::write_atomically` — `--in-place` 도중 실패해도 원본이
+  잘린 채 남지 않는다.
+- `--dry-run` 은 파일을 **만들지 않는다**. 봉투에 `findings[{kind, raw, masked,
+  section, paragraph, page, charOffset}]`.
+- `--verify`(#3702)·`changedPages`(#3712) 는 기존 편집 명령과 같은 경로를 쓴다.
+
+> `findings[].raw` 는 **원문 개인정보 그 자체**다. help·도구 설명·문서에 "로그에
+> 남기지 말 것"을 명시했다. 감사에 필요해서 넣었지만 새는 곳이기도 하다.
+
+### 3) `rhwp edit sanitize` — 메타데이터 제거
+
+```
+rhwp edit sanitize <파일> [--keep-preview] [-o <출력>] [--json]
+```
+
+본문은 건드리지 않는다. 지우는 것은 셋이다.
+
+1. **OLE 요약 정보** (`\x05HwpSummaryInformation`) — title·subject·author·keywords·
+   comments·lastSavedBy·revisionNumber·dateString(문자열)과 createdAt·lastSavedAt·
+   lastPrintedAt(FILETIME).
+   속성 오프셋 표가 **절대 위치**를 담고 있어 크기를 줄이면 나머지 속성이 전부
+   어긋난다. 그래서 **바이트 길이를 바꾸지 않는다** — 문자열은 `cch=1`(NUL 하나)로
+   만들고 남은 자리를 0으로 덮으며, FILETIME 은 0(미설정)으로 만든다.
+2. **HWPX 저작자 메타** (`Contents/content.hpf` 의 `<opf:metadata>`) — 직렬화기가
+   원본에서 그대로 splice 하는 유일한 저작자 경로다
+   ([`content.rs`](../../../src/serializer/hwpx/content.rs)). 중립 블록으로 바꾼다.
+3. **미리보기** — PrvText·PrvImage(ZIP 엔트리와 HWP5 계약 스트림 양쪽).
+
+`removed[{field, before}]` 로 무엇을 지웠는지 남긴다. 조용히 지우면 감사가 불가능하다.
+
+#### 거짓 보고를 막은 두 지점
+
+- **미리보기 텍스트는 "지금 본문과 다를 때만" 지우고 보고한다.** HWP5 직렬화기는
+  PrvText 가 비면 본문 앞부분으로 다시 채운다(`supplement_preview`). 본문과 같은
+  미리보기는 유출이 아니라 파생물이므로 매번 "지웠다"고 보고하면 감사 기록이
+  거짓말이 된다. **다를 때**가 진짜 사고다 — 본문에서 지운 문장이 미리보기에만
+  남아 있는 경우.
+- **HWPX 원본의 `/HwpSummaryInformation` 은 HWPX 로 저장할 때 건드리지 않는다.**
+  그 스트림은 파일에 없던 계약 fallback 상수이고(`parser::hwpx::contract_streams`)
+  HWPX 산출물에도 실리지 않는다. 없던 것을 지웠다고 보고하지 않기 위해 출력 형식이
+  HWP5(변환)일 때만 처리한다.
+
+결과적으로 **두 번째 실행은 `removedCount: 0`** 이다 — 첫 실행이 실제로 지웠다는 증거다.
+
+### 4) 자기서술 (드리프트 가드)
+
+- MCP 도구 2종 `hwp_redact`·`hwp_sanitize` — `inputSchema` 에 `type`/`properties`/
+  `required` 배열, 선언한 속성 전부를 `cli.args`·`optionalArgs.when` 에 배선.
+- `capabilities.commands[edit].flags` 에 `--kind`·`--mask`·`--in-place`·
+  `--keep-preview`·`--verify` 추가, `outputFields` 에 새 봉투 필드 추가.
+- `--help` 에 두 하위 명령 절 추가(capabilities↔help 양방향 가드).
+
+## 실측 (evidence.txt 원문)
+
+`samples/field-01.hwp` 의 누름틀에 **가공** 값을 심어 만든 문서로 확인했다
+(실제 개인정보는 저장소에 넣지 않는다). 유효한 값 4개와 검증에 실패하는 미끼 2개를
+같은 문서에 함께 넣었다.
+
+| 심은 값 | 판정 | 근거 |
+| --- | --- | --- |
+| `900101-1234568` | 탐지 | mod 11 검증 숫자 통과 |
+| `900101-1234567` | **미탐지** | 검증 숫자 불일치 |
+| `4111-1111-1111-1111` | 탐지 | Luhn 통과 |
+| `1234-5678-9012-3456` | **미탐지** | Luhn 실패(합 64) |
+| `010-1234-5678` | 탐지 | 이동전화 형태 |
+| `hong@example.com` | 탐지 | 라벨 2개 + 영문 TLD |
+
+- `--dry-run --json` → `findingCount: 4`, 미끼 2개는 `findings` 에 없음, 산출 파일 미생성.
+- 실제 마스킹 → `redactedCount: 4`, `changedPages: [0]`, `--verify` `identical: true`.
+- 산출 본문: `카드 ****-****-****-**** / 미끼 900101-1234567 / 미끼 1234-5678-9012-3456`
+  — **미끼는 훼손되지 않았다**.
+- `-o`·`--in-place` 없이 실행 → `exit 2`, stdout 0바이트, 원본 바이트 불변.
+- `sanitize`(HWP5) → `removedCount: 10`(title·author·dateString·keywords·lastSavedBy·
+  revisionNumber·createdAt·lastSavedAt·preview.text·preview.image), 재실행 `0`.
+- `sanitize`(HWPX) → `removedCount: 3`(hwpx.metadata·preview.text·preview.image),
+  재실행 `0`, `outputFormat: hwpx`.
+- HWPX→HWP5 변환 sanitize → `removedCount: 9`(요약 정보 6종 포함).
+- 본문 무변경: `export-text` 전 페이지 문자 단위 동일 — HWP5 3쪽, HWPX 23쪽.
+- `--keep-preview` 산출물은 `thumbnail` 추출 exit 0, 기본(제거) 산출물은 exit 1.
+- FILETIME 변환 교차 검증: `dateString` "2026년 3월 9일 월요일 오전 3:24:42"(KST) ↔
+  `createdAt` `2026-03-08T18:24:42Z` — 9시간 차로 일치.
+
+## 검증
+
+- `cargo build --release --bin rhwp` 통과.
+- 신규 `tests/redact_sanitize_contract.rs` **11건 green** — 오탐 0·자릿수 보존·원본
+  보호(exit 2)·dry-run 무산출·`--mask` 검증·`--kind` 필터·sanitize 본문 불변·
+  `--keep-preview`·형식 보존·실패 경로 stdout 0바이트·자기서술 배선.
+- `pii_scan` 단위 테스트 **15건 green** — 탐지 규칙마다 오탐 회귀 케이스(세기 코드
+  범위·윤년·구분자 혼용·자릿수 범위·숫자 경계·전화 지역번호·이메일 라벨/TLD).
+- 무회귀: `cli_json_contract` 26건 · `mcp_server_contract` 22건.
+- 드리프트 가드(preflight) 전부 통과 — MCP inputSchema 모양(27개 도구) · 선언 속성
+  ↔ CLI 배선 · capabilities ↔ `--help` 상호 커버(54개 명령) · `--json` 명령 ↔ MCP
+  도구 커버 · 선언 flags 실재(65개) · 실패 경로 stdout 0바이트.
+- `cargo clippy -- -D warnings` 0 · rustfmt clean.
+
+## 남은 것
+
+- **지역번호 확장**: 02 외 지역번호는 실문서 오탐 실측을 근거로 별도 이슈에서 판단한다.
+- **여권번호·계좌번호**: 체크섬이 없어 보수적 판정이 불가능하다. 사용자 지정 정규식
+  축(`--pattern`)을 열어 주는 편이 안전하다 — 판정 책임이 사용자에게 넘어간다.
+- **`findings[].raw` 마스킹 옵션**: 감사 기록을 남기되 원문을 감추고 싶은 수요가
+  있을 수 있다(`--no-raw`). v1 은 로드맵 명세대로 원문을 넣고 문서로 경고했다.
+- **DocumentSummaryInformation**: 한컴이 회사명(company)을 별도 속성 집합에 쓰는
+  문서가 있으면 그 스트림도 대상에 넣어야 한다. 실측 샘플에서는 발견되지 않았다.

--- a/mydocs/report/task_m100_redact/evidence.txt
+++ b/mydocs/report/task_m100_redact/evidence.txt
@@ -1,0 +1,105 @@
+rhwp v0.8.2
+수집 시각(UTC): 2026-08-02T12:29:24Z
+
+※ 실제 개인정보는 저장소에 두지 않는다. 아래 값은 형태만 개인정보인 가공 값이며
+   유효값 4개 + 검증 실패 미끼 2개를 samples/field-01.hwp 누름틀에 심어 만든다.
+
+=== 0. 가짜 개인정보 문서 생성 (edit fill-fields) ===
+filledCount: 4  changedPages: [0]
+
+=== 1. edit redact --dry-run --json (오탐 0 확인) ===
+findingCount: 4  dryRun: True  kinds: ['ssn', 'card', 'phone', 'email']  mask: *
+  card   4111-1111-1111-1111  -> ****-****-****-****  (구역 0, 문단 7, 쪽 0, 오프셋 10)
+  ssn    900101-1234568       -> ******-*******       (구역 0, 문단 8, 쪽 0, 오프셋 11)
+  phone  010-1234-5678        -> ***-****-****        (구역 0, 문단 10, 쪽 0, 오프셋 7)
+  email  hong@example.com     -> ****@*******.***     (구역 0, 문단 11, 쪽 0, 오프셋 9)
+  미끼 미탐지 [900101-1234567]: 통과
+  미끼 미탐지 [1234-5678-9012-3456]: 통과
+  봉투에 output 키 없음(dry-run): 통과
+  dry-run 이 만든 파일 수: 0 (0 이어야 함)
+
+=== 2. 원본 보호 — -o / --in-place 없이 실행 ===
+  exit=2  stdout=0바이트
+  stderr: 오류: 마스킹은 되돌릴 수 없습니다. 산출 경로를 -o <출력> 으로 지정하거나, 원본을 덮어쓸 의도라면 --in-place 를 명시하세요 (먼저 --dry-run 으로 무엇이 지워질지 확인하기를 권합니다).
+  원본 md5 불변: 통과
+
+=== 3. 원본 보호 — -o 가 원본 자신을 지목 ===
+  exit=2  stdout=0바이트
+  원본 md5 불변: 통과
+
+=== 4. edit redact 실제 적용 (--verify) ===
+  redactedCount: 4  changedPages: [0]  outputFormat: hwp5  verify: {'diffCount': 0, 'identical': True}
+
+=== 5. 산출 본문 — 마스킹은 되고 미끼는 살아 있는가 ===
+  | 회사명  : 카드 ****-****-****-**** / 
+  | 미끼 900101-1234567 / 미끼 
+  | 작성자  : 홍길동 ******-*******
+  | Tel  : ***-****-****여기에 입력
+  | E-Mail : ****@*******.***여기에 입력
+
+  마스킹됨 [900101-1234568]: 통과
+  마스킹됨 [4111-1111-1111-1111]: 통과
+  마스킹됨 [010-1234-5678]: 통과
+  마스킹됨 [hong@example.com]: 통과
+  미끼 보존 [900101-1234567]: 통과
+  미끼 보존 [1234-5678-9012-3456]: 통과
+
+=== 6. --kind 필터 / --mask 검증 ===
+  kinds: ['email']  mask: #  findings: [('email', '####@#######.###')]
+  --mask '**' exit=2 (2 여야 함)
+  --mask 'x' exit=2 (2 여야 함)
+
+=== 7. edit sanitize (HWP5) — removed[] 와 재실행 0건 ===
+  removedCount: 10  outputFormat: hwp5
+    title            마케팅 전략 기획서
+    author           cabso
+    dateString       2026년 3월 9일 월요일 오전 3:24:42
+    keywords         기획서표지,표지서식
+    lastSavedBy      cabso
+    revisionNumber   11, 0, 0, 2129 WIN32LEWindows_8
+    createdAt        2026-03-08T18:24:42Z
+    lastSavedAt      2026-03-08T18:34:40Z
+    preview.text     \r\n마케팅 \r\n전략 기획서\r\n \r\n\r\n회사명  : \r\n작성자  : \r\n부서명  : \r\nTel  :…
+    preview.image    Png 19323 bytes
+  재실행 removedCount: 0  (0 이어야 첫 실행이 실제로 지운 것)
+
+=== 8. sanitize 는 본문을 바꾸지 않는다 (export-text 전후 비교) ===
+  3쪽 전부 문자 단위 동일: 통과
+
+=== 9. edit sanitize (HWPX) — 형식 보존 · 재실행 0건 · 본문 불변 ===
+  removedCount: 3  outputFormat: hwpx  fields: ['hwpx.metadata', 'preview.text', 'preview.image']
+  재실행 removedCount: 0
+  23쪽 전부 문자 단위 동일: 통과
+
+=== 10. HWPX→HWP5 변환 sanitize (요약 정보가 실제 산출물에 실리는 경로) ===
+  outputFormat: hwp5  removedCount: 9
+  fields: ['author', 'dateString', 'lastSavedBy', 'revisionNumber', 'createdAt', 'lastSavedAt', 'hwpx.metadata', 'preview.text', 'preview.image']
+  FILETIME 교차검증  dateString='2026년 3월 16일 월요일 오전 6:56:40'  createdAt='2026-03-15T21:56:40Z'
+
+=== 11. --keep-preview 는 썸네일을 남긴다 ===
+  keepPreview: True  removed: ['title', 'author', 'dateString', 'keywords', 'lastSavedBy', 'revisionNumber', 'createdAt', 'lastSavedAt', 'preview.text']
+  --keep-preview 산출물 thumbnail exit=0  (0 이어야 함)
+  기본(제거) 산출물 thumbnail exit=1  (0 이 아니어야 함)
+
+=== 12. 실패 경로 stdout 0바이트 ===
+  exit=1 stdout=0바이트 :: edit redact 없는파일.hwp -o x.hwp --json
+  exit=1 stdout=0바이트 :: edit sanitize 없는파일.hwp --json
+  exit=2 stdout=0바이트 :: edit redact samples/field-01.hwp --json
+  exit=2 stdout=0바이트 :: edit redact samples/field-01.hwp --kind 없는종류 --json
+  exit=2 stdout=0바이트 :: edit sanitize samples/field-01.hwp --없는옵션
+  exit=2 stdout=0바이트 :: edit redact samples/field-01.hwp -o x.hwp --in-place
+
+=== 13. 자기서술 — capabilities / MCP 배선 / help ===
+  commands[edit].flags: ['--data', '--find', '--replace', '--ignore-case', '--table', '--row', '--col', '--text', '--occurrence', '--keep-style', '--kind', '--mask', '--in-place', '--keep-preview', '-o', '--dry-run', '--verify', '--json']
+  hwp_redact
+    type=object required=['path']
+    properties=['dryRun', 'inPlace', 'kind', 'mask', 'output', 'path', 'verify']
+    미배선 속성=[]  (빈 목록이어야 함)
+  hwp_sanitize
+    type=object required=['path']
+    properties=['keepPreview', 'output', 'path']
+    미배선 속성=[]  (빈 목록이어야 함)
+    edit redact <파일.hwp|파일.hwpx> [--kind …] [--dry-run] [-o <출력>|--in-place]
+    edit sanitize <파일.hwp|파일.hwpx> [--keep-preview] [-o <출력>] [--json]
+
+=== 끝 ===

--- a/src/document_core/queries/mod.rs
+++ b/src/document_core/queries/mod.rs
@@ -11,6 +11,8 @@ pub mod rendering;
 /// 주소(구역·문단·페이지)를 가진 검색 — 조판 엔진이 있어야만 가능한 질의.
 pub mod changed_pages;
 pub mod grep;
+/// [#3719 §6-11] 공개 전 개인정보 탐지 — 읽기 전용 판정(마스킹은 CLI 의 치환 경로).
+pub mod pii_scan;
 pub(crate) mod search_query;
 pub mod structure;
 pub mod table_extract;

--- a/src/document_core/queries/pii_scan.rs
+++ b/src/document_core/queries/pii_scan.rs
@@ -1,0 +1,773 @@
+//! 개인정보 탐지 — 주소(구역·문단·페이지·문자 오프셋)를 가진 **읽기 전용** 판정.
+//!
+//! 공개 전 문서에서 지워야 할 값(주민등록번호·전화번호·이메일·카드번호)을 찾아
+//! "무엇을, 어디서" 를 먼저 보여주는 것이 이 모듈의 전부다. 편집은 하지 않는다 —
+//! 실제 마스킹은 CLI 가 기존 치환 경로(`replace_all_native`)로 수행한다.
+//!
+//! # 설계 원칙: 오탐 0 우선
+//!
+//! 마스킹은 **되돌릴 수 없다**. 오탐 하나가 본문 숫자를 영구히 훼손하므로, 형태가
+//! 맞아도 **검증을 통과하지 못하면 탐지하지 않는다**:
+//!
+//! - 주민등록번호: 생년월일 유효성 + 성별/세기 코드 + 검증 숫자(mod 11) 전부 통과해야 한다.
+//! - 카드번호: Luhn 검증을 통과해야 한다.
+//! - 전화번호: 하이픈이 있는 이동전화(01X)·서울(02) 형태만 본다. 하이픈 없는 긴 숫자열,
+//!   그 밖의 지역번호는 회계 코드·문서번호와 구별할 근거가 없어 **의도적으로 제외**한다.
+//! - 이메일: 지역/도메인 문자 집합과 최상위 도메인(영문 2자 이상)을 모두 만족해야 한다.
+//!
+//! 어느 규칙이든 앞뒤가 같은 부류의 문자(숫자 옆의 숫자 등)면 더 긴 토큰의 일부로 보고
+//! 버린다 — 22자리 계좌번호 안에서 16자리 부분열을 카드로 오인하지 않기 위해서다.
+//!
+//! # 주소
+//!
+//! 매치 주소는 [`DocumentCore::grep`] 을 재사용해 얻는다. 같은 값이 표 셀·글상자에 다시
+//! 나오면 그 자리도 함께 보고되므로, 사용자는 마스킹 전에 전 발생 지점을 볼 수 있다.
+
+use serde::Serialize;
+
+use crate::document_core::DocumentCore;
+use crate::model::control::Control;
+
+/// 탐지 종류.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PiiKind {
+    /// 주민등록번호 (`######-#######`, 검증 숫자 통과).
+    Ssn,
+    /// 카드번호 (4-4-4-4 등, Luhn 통과).
+    Card,
+    /// 전화번호 (이동전화 01X, 서울 02 — 하이픈 필수).
+    Phone,
+    /// 이메일 주소.
+    Email,
+}
+
+impl PiiKind {
+    /// CLI `--kind` 토큰.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PiiKind::Ssn => "ssn",
+            PiiKind::Card => "card",
+            PiiKind::Phone => "phone",
+            PiiKind::Email => "email",
+        }
+    }
+
+    /// CLI 토큰을 종류로 해석한다. 알 수 없는 토큰은 `None`.
+    pub fn parse(token: &str) -> Option<PiiKind> {
+        match token {
+            "ssn" => Some(PiiKind::Ssn),
+            "card" => Some(PiiKind::Card),
+            "phone" => Some(PiiKind::Phone),
+            "email" => Some(PiiKind::Email),
+            _ => None,
+        }
+    }
+
+    /// `--kind all` 이 뜻하는 전 종류. 탐지 우선순위 순서다(겹치면 앞이 이긴다).
+    pub const fn all() -> [PiiKind; 4] {
+        [PiiKind::Ssn, PiiKind::Card, PiiKind::Phone, PiiKind::Email]
+    }
+}
+
+/// 탐지 결과 하나 — 원문·마스킹 결과·문서 주소.
+#[derive(Debug, Clone, Serialize)]
+pub struct PiiFinding {
+    /// 탐지 종류 (`ssn`·`card`·`phone`·`email`).
+    pub kind: &'static str,
+    /// 탐지된 원문. **개인정보 그 자체**이므로 로그·이슈에 그대로 붙이지 않는다.
+    pub raw: String,
+    /// 마스킹 결과 — 원문과 **문자 수가 같다**.
+    pub masked: String,
+    /// 구역 인덱스.
+    pub section: usize,
+    /// 본문 문단 인덱스 (표 셀·글상자 매치는 그 컨트롤을 담은 본문 문단).
+    pub paragraph: usize,
+    /// 0부터 시작하는 글로벌 페이지 번호. 조판에 배치되지 않은 문단이면 생략된다.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page: Option<u32>,
+    /// 문단 텍스트 내 시작 위치 (문자 단위).
+    #[serde(rename = "charOffset")]
+    pub char_offset: usize,
+}
+
+/// 텍스트 한 조각에서 찾은 후보 — `(종류, 시작 문자 위치, 문자 길이)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Candidate {
+    kind: PiiKind,
+    start: usize,
+    len: usize,
+}
+
+/// 자릿수를 유지한 마스킹 결과를 만든다.
+///
+/// 영숫자만 `mask` 로 바꾸고 구분자(`-`·`@`·`.`·공백)는 남긴다. 길이가 변하면 조판이
+/// 흔들리므로 **문자 수는 반드시 보존한다**.
+pub fn mask_value(raw: &str, mask: char) -> String {
+    raw.chars()
+        .map(|c| if c.is_alphanumeric() { mask } else { c })
+        .collect()
+}
+
+/// 주민등록번호 검증 숫자 (mod 11).
+///
+/// 앞 12자리에 가중치 `[2,3,4,5,6,7,8,9,2,3,4,5]` 를 곱해 더하고, `(11 - 합 % 11) % 10`
+/// 이 13번째 자리와 같아야 한다. 이 검증이 없으면 `123456-1234567` 같은 예시 문자열까지
+/// 지워 버린다.
+fn ssn_checksum_ok(digits: &[u8; 13]) -> bool {
+    const WEIGHTS: [u32; 12] = [2, 3, 4, 5, 6, 7, 8, 9, 2, 3, 4, 5];
+    let sum: u32 = digits
+        .iter()
+        .zip(WEIGHTS)
+        .map(|(d, w)| u32::from(*d) * w)
+        .sum();
+    let check = (11 - (sum % 11)) % 10;
+    check == u32::from(digits[12])
+}
+
+/// 그레고리력 월별 일수 (윤년 반영).
+fn days_in_month(year: u32, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 => {
+            if (year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400) {
+                29
+            } else {
+                28
+            }
+        }
+        _ => 0,
+    }
+}
+
+/// 성별/세기 코드로 출생 세기를 정한다. 1~8 이외는 탐지하지 않는다.
+///
+/// 9·0(1800년대 출생)은 현존 인구가 사실상 없어 오탐 쪽 비용이 크다 — 제외한다.
+fn ssn_century(code: u8) -> Option<u32> {
+    match code {
+        1 | 2 | 5 | 6 => Some(1900),
+        3 | 4 | 7 | 8 => Some(2000),
+        _ => None,
+    }
+}
+
+/// 주민등록번호 유효성 — 날짜·성별코드·검증숫자를 모두 본다.
+fn ssn_is_valid(digits: &[u8; 13]) -> bool {
+    let century = match ssn_century(digits[6]) {
+        Some(c) => c,
+        None => return false,
+    };
+    let year = century + digits[0] as u32 * 10 + digits[1] as u32;
+    let month = digits[2] as u32 * 10 + digits[3] as u32;
+    let day = digits[4] as u32 * 10 + digits[5] as u32;
+    if !(1..=12).contains(&month) {
+        return false;
+    }
+    if day == 0 || day > days_in_month(year, month) {
+        return false;
+    }
+    ssn_checksum_ok(digits)
+}
+
+/// Luhn 검증 — 카드번호의 표준 체크섬.
+fn luhn_ok(digits: &[u8]) -> bool {
+    if digits.len() < 13 {
+        return false;
+    }
+    let mut sum = 0u32;
+    for (i, d) in digits.iter().rev().enumerate() {
+        let mut v = *d as u32;
+        if i % 2 == 1 {
+            v *= 2;
+            if v > 9 {
+                v -= 9;
+            }
+        }
+        sum += v;
+    }
+    sum.is_multiple_of(10)
+}
+
+/// 이메일 지역부(local-part)에 허용하는 문자.
+fn is_email_local(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '%' | '+' | '-')
+}
+
+/// 이메일 도메인 라벨에 허용하는 문자.
+fn is_email_domain(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '-'
+}
+
+/// `chars[at]` 이 숫자열의 한복판인지 — 앞뒤가 숫자면 더 긴 토큰의 일부다.
+fn digit_boundary_ok(chars: &[char], start: usize, end: usize) -> bool {
+    let left_ok = start == 0 || !chars[start - 1].is_ascii_digit();
+    let right_ok = end >= chars.len() || !chars[end].is_ascii_digit();
+    left_ok && right_ok
+}
+
+/// `chars[start..]` 에서 `pattern` 이 뜻하는 숫자 그룹 배열을 읽는다.
+///
+/// `pattern` 은 각 그룹의 자릿수이고, 그룹 사이에는 **같은** 구분자 한 글자(`-` 또는
+/// 공백)가 와야 한다. 성공하면 `(끝 위치, 숫자열)`.
+fn read_digit_groups(chars: &[char], start: usize, pattern: &[usize]) -> Option<(usize, Vec<u8>)> {
+    let mut i = start;
+    let mut digits: Vec<u8> = Vec::new();
+    let mut separator: Option<char> = None;
+    for (g, want) in pattern.iter().enumerate() {
+        if g > 0 {
+            let sep = *chars.get(i)?;
+            if sep != '-' && sep != ' ' {
+                return None;
+            }
+            match separator {
+                // 구분자가 섞이면(`1234-5678 9012`) 사람이 쓴 카드번호로 보지 않는다.
+                Some(prev) if prev != sep => return None,
+                Some(_) => {}
+                None => separator = Some(sep),
+            }
+            i += 1;
+        }
+        for _ in 0..*want {
+            let c = *chars.get(i)?;
+            if !c.is_ascii_digit() {
+                return None;
+            }
+            digits.push(c as u8 - b'0');
+            i += 1;
+        }
+    }
+    Some((i, digits))
+}
+
+/// 위치 `start` 에서 시작하는 주민등록번호 후보를 읽는다.
+fn scan_ssn(chars: &[char], start: usize) -> Option<usize> {
+    let (end, digits) = read_digit_groups(chars, start, &[6, 7])?;
+    if !digit_boundary_ok(chars, start, end) {
+        return None;
+    }
+    let mut fixed = [0u8; 13];
+    fixed.copy_from_slice(&digits);
+    if !ssn_is_valid(&fixed) {
+        return None;
+    }
+    Some(end)
+}
+
+/// 위치 `start` 에서 시작하는 카드번호 후보를 읽는다 (Luhn 필수).
+///
+/// 받는 형태: `4-4-4-4`(16자리, `-`/공백), Amex `4-6-5`(15자리), 그리고 구분자 없는
+/// 15·16자리 연속 숫자. 13·14·19자리 등 그 밖의 길이는 회계 숫자와 구별할 근거가 없어
+/// 제외한다.
+fn scan_card(chars: &[char], start: usize) -> Option<usize> {
+    const PATTERNS: [&[usize]; 4] = [&[4, 4, 4, 4], &[4, 6, 5], &[16], &[15]];
+    for pattern in PATTERNS {
+        let Some((end, digits)) = read_digit_groups(chars, start, pattern) else {
+            continue;
+        };
+        if !digit_boundary_ok(chars, start, end) {
+            continue;
+        }
+        if luhn_ok(&digits) {
+            return Some(end);
+        }
+    }
+    None
+}
+
+/// 위치 `start` 에서 시작하는 전화번호 후보를 읽는다.
+///
+/// 이동전화 `01[016789]-3~4자리-4자리` 와 서울 `02-3~4자리-4자리` 만 본다. 하이픈이
+/// 없으면 보지 않는다 — `01012345678` 은 문서번호와 형태가 같다.
+fn scan_phone(chars: &[char], start: usize) -> Option<usize> {
+    const MOBILE_SECOND: [char; 6] = ['0', '1', '6', '7', '8', '9'];
+    if *chars.get(start)? != '0' {
+        return None;
+    }
+    let second = *chars.get(start + 1)?;
+    let prefix_len = if second == '1' {
+        // 01X — 세 번째 자리가 이동전화 식별번호여야 한다.
+        let third = *chars.get(start + 2)?;
+        if !MOBILE_SECOND.contains(&third) {
+            return None;
+        }
+        3
+    } else if second == '2' {
+        2
+    } else {
+        return None;
+    };
+    // 국번은 3자리 또는 4자리다. 긴 쪽을 먼저 시도한다.
+    for middle in [4usize, 3] {
+        let pattern = [prefix_len, middle, 4];
+        let Some((end, _)) = read_digit_groups(chars, start, &pattern) else {
+            continue;
+        };
+        if digit_boundary_ok(chars, start, end) {
+            return Some(end);
+        }
+    }
+    None
+}
+
+/// 위치 `at` 의 `@` 를 중심으로 이메일 주소 범위를 넓힌다.
+///
+/// 성공하면 `(시작, 끝)` 문자 위치.
+fn scan_email(chars: &[char], at: usize) -> Option<(usize, usize)> {
+    // 지역부 — 왼쪽으로 확장. 점으로 시작/끝나는 지역부는 받지 않는다.
+    let mut start = at;
+    while start > 0 && is_email_local(chars[start - 1]) {
+        start -= 1;
+    }
+    if start == at {
+        return None;
+    }
+    while start < at && chars[start] == '.' {
+        start += 1;
+    }
+    if start == at || chars[at - 1] == '.' {
+        return None;
+    }
+
+    // 도메인 — 라벨(영숫자·하이픈) 을 점으로 이어 최소 2개, 마지막은 영문 2자 이상.
+    let mut i = at + 1;
+    let mut labels: Vec<(usize, usize)> = Vec::new();
+    loop {
+        let label_start = i;
+        while i < chars.len() && is_email_domain(chars[i]) {
+            i += 1;
+        }
+        if i == label_start {
+            return None;
+        }
+        labels.push((label_start, i));
+        if i < chars.len() && chars[i] == '.' {
+            // 점 뒤에 라벨이 없으면(문장 끝) 여기서 끊는다.
+            if chars.get(i + 1).is_some_and(|c| is_email_domain(*c)) {
+                i += 1;
+                continue;
+            }
+        }
+        break;
+    }
+    if labels.len() < 2 {
+        return None;
+    }
+    let (tld_start, tld_end) = *labels.last().expect("라벨 2개 이상");
+    if tld_end - tld_start < 2
+        || !chars[tld_start..tld_end]
+            .iter()
+            .all(|c| c.is_ascii_alphabetic())
+    {
+        return None;
+    }
+    // 라벨은 하이픈으로 시작하거나 끝날 수 없다.
+    for &(label_start, label_end) in &labels {
+        if chars[label_start] == '-' || chars[label_end - 1] == '-' {
+            return None;
+        }
+    }
+    Some((start, tld_end))
+}
+
+/// 텍스트 한 조각에서 개인정보 후보를 찾는다 (순수 함수 — 테스트 가능).
+///
+/// 겹치는 후보는 [`PiiKind::all`] 순서(주민번호 → 카드 → 전화 → 이메일)로 앞이 이긴다.
+fn detect(text: &str, kinds: &[PiiKind]) -> Vec<Candidate> {
+    let chars: Vec<char> = text.chars().collect();
+    let mut found: Vec<Candidate> = Vec::new();
+    let wants = |k: PiiKind| kinds.contains(&k);
+
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] == '@' && wants(PiiKind::Email) {
+            if let Some((s, e)) = scan_email(&chars, i) {
+                found.push(Candidate {
+                    kind: PiiKind::Email,
+                    start: s,
+                    len: e - s,
+                });
+                i = e;
+                continue;
+            }
+        }
+        if chars[i].is_ascii_digit() {
+            let mut hit: Option<Candidate> = None;
+            if wants(PiiKind::Ssn) {
+                if let Some(end) = scan_ssn(&chars, i) {
+                    hit = Some(Candidate {
+                        kind: PiiKind::Ssn,
+                        start: i,
+                        len: end - i,
+                    });
+                }
+            }
+            if hit.is_none() && wants(PiiKind::Card) {
+                if let Some(end) = scan_card(&chars, i) {
+                    hit = Some(Candidate {
+                        kind: PiiKind::Card,
+                        start: i,
+                        len: end - i,
+                    });
+                }
+            }
+            if hit.is_none() && wants(PiiKind::Phone) {
+                if let Some(end) = scan_phone(&chars, i) {
+                    hit = Some(Candidate {
+                        kind: PiiKind::Phone,
+                        start: i,
+                        len: end - i,
+                    });
+                }
+            }
+            if let Some(c) = hit {
+                i = c.start + c.len;
+                found.push(c);
+                continue;
+            }
+        }
+        i += 1;
+    }
+    found
+}
+
+/// 텍스트에서 탐지된 원문 값들을 문서 순서로 돌려준다 (중복 제거하지 않음).
+///
+/// 테스트가 규칙 자체를 직접 겨눌 수 있도록 공개한다 — 문서를 만들지 않고도
+/// "체크섬이 틀린 문자열은 탐지되지 않는다"를 고정할 수 있다.
+pub fn detect_values(text: &str, kinds: &[PiiKind]) -> Vec<(PiiKind, String)> {
+    let chars: Vec<char> = text.chars().collect();
+    detect(text, kinds)
+        .into_iter()
+        .map(|c| {
+            (
+                c.kind,
+                chars[c.start..c.start + c.len].iter().collect::<String>(),
+            )
+        })
+        .collect()
+}
+
+/// 문단·표 셀·글상자 텍스트를 문서 순서로 모은다 (읽기 전용).
+fn collect_texts(doc: &DocumentCore) -> Vec<String> {
+    let mut texts: Vec<String> = Vec::new();
+    for section in &doc.document.sections {
+        for para in &section.paragraphs {
+            texts.push(para.text.clone());
+            for ctrl in &para.controls {
+                match ctrl {
+                    Control::Table(table) => {
+                        for cell in &table.cells {
+                            for cp in &cell.paragraphs {
+                                texts.push(cp.text.clone());
+                            }
+                        }
+                    }
+                    Control::Shape(shape) => {
+                        if let Some(tb) =
+                            crate::document_core::helpers::get_textbox_from_shape(shape)
+                        {
+                            for tp in &tb.paragraphs {
+                                texts.push(tp.text.clone());
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    texts
+}
+
+impl DocumentCore {
+    /// 문서에서 지워야 할 개인정보를 찾아 **주소가 붙은** 목록을 돌려준다.
+    ///
+    /// 문서를 바꾸지 않는다. 같은 값이 여러 곳에 있으면 전 발생 지점이 나온다
+    /// (마스킹은 전량 치환이므로 사용자가 미리 전부 볼 수 있어야 한다).
+    pub fn scan_pii(&self, kinds: &[PiiKind], mask: char) -> Vec<PiiFinding> {
+        // ① 값 수집 — 문서 순서, 중복 제거(같은 값을 두 번 치환하지 않는다).
+        let mut values: Vec<(PiiKind, String)> = Vec::new();
+        for text in collect_texts(self) {
+            for (kind, raw) in detect_values(&text, kinds) {
+                if !values.iter().any(|(_, v)| *v == raw) {
+                    values.push((kind, raw));
+                }
+            }
+        }
+
+        // ② 주소 붙이기 — grep 재사용(구역·문단·페이지·오프셋을 이미 계산한다).
+        let mut out: Vec<PiiFinding> = Vec::new();
+        for (kind, raw) in values {
+            let masked = mask_value(&raw, mask);
+            for m in self.grep(&raw, true, None) {
+                out.push(PiiFinding {
+                    kind: kind.as_str(),
+                    raw: raw.clone(),
+                    masked: masked.clone(),
+                    section: m.section,
+                    paragraph: m.paragraph,
+                    page: m.page,
+                    char_offset: m.char_offset,
+                });
+            }
+        }
+        out.sort_by_key(|f| (f.section, f.paragraph, f.char_offset));
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL: [PiiKind; 4] = PiiKind::all();
+
+    /// 오탐 0 — 형태만 같고 검증 숫자가 틀린 주민등록번호는 탐지되지 않는다.
+    #[test]
+    fn invalid_ssn_checksum_is_not_detected() {
+        // 900101-1234567 은 형태는 맞지만 mod 11 검증 숫자가 틀리다.
+        let found = detect_values("계약자 900101-1234567 참조", &ALL);
+        assert!(
+            found.iter().all(|(k, _)| *k != PiiKind::Ssn),
+            "검증 숫자가 틀린 문자열을 주민등록번호로 탐지했다: {found:?}"
+        );
+    }
+
+    /// 검증 숫자가 맞으면 탐지된다 — 규칙이 통째로 죽어 있으면 위 테스트가 공허해진다.
+    #[test]
+    fn valid_ssn_is_detected() {
+        let found = detect_values("계약자 900101-1234568 참조", &ALL);
+        assert_eq!(
+            found,
+            vec![(PiiKind::Ssn, "900101-1234568".to_string())],
+            "검증 숫자가 맞는 주민등록번호를 놓쳤다"
+        );
+    }
+
+    /// 성별/세기 코드가 1~8 밖이면(9·0 = 1800년대 출생) 탐지하지 않는다.
+    ///
+    /// 검증 숫자만으로는 `######-#######` 형태의 임의 숫자쌍 11개 중 1개가 우연히
+    /// 통과한다. 세기 코드까지 걸어야 오탐이 실질적으로 사라진다.
+    #[test]
+    fn out_of_range_gender_code_is_not_detected() {
+        for raw in ["900101-9234568", "900101-0234568"] {
+            let found = detect_values(raw, &ALL);
+            assert!(
+                found.iter().all(|(k, _)| *k != PiiKind::Ssn),
+                "세기 코드가 범위 밖인데 탐지했다: {raw} → {found:?}"
+            );
+        }
+    }
+
+    /// 윤년 2월 29일은 유효하다 — 날짜 검사가 과하게 좁으면 실제 개인정보를 놓친다.
+    #[test]
+    fn leap_day_birth_date_is_accepted() {
+        // 000229-3……: 세기 코드 3 → 2000년생, 2000년은 윤년(400으로 나뉨).
+        let found = detect_values("000229-3123454", &ALL);
+        assert_eq!(
+            found,
+            vec![(PiiKind::Ssn, "000229-3123454".to_string())],
+            "윤년 2월 29일 생년월일을 버렸다"
+        );
+    }
+
+    /// 존재하지 않는 날짜(13월·2월 30일)는 검증 숫자와 무관하게 버린다.
+    #[test]
+    fn impossible_birth_date_is_not_detected() {
+        for raw in ["901301-1234567", "900230-1234567"] {
+            let found = detect_values(raw, &ALL);
+            assert!(
+                found.iter().all(|(k, _)| *k != PiiKind::Ssn),
+                "불가능한 생년월일을 주민등록번호로 탐지했다: {raw} → {found:?}"
+            );
+        }
+    }
+
+    /// Luhn 을 통과하지 못하는 16자리는 카드번호가 아니다.
+    #[test]
+    fn non_luhn_card_is_not_detected() {
+        let found = detect_values("계좌 1234-5678-9012-3456 입금", &ALL);
+        assert!(
+            found.iter().all(|(k, _)| *k != PiiKind::Card),
+            "Luhn 실패 숫자열을 카드번호로 탐지했다: {found:?}"
+        );
+        let ok = detect_values("카드 4111-1111-1111-1111 승인", &ALL);
+        assert_eq!(
+            ok,
+            vec![(PiiKind::Card, "4111-1111-1111-1111".to_string())],
+            "Luhn 을 통과하는 카드번호를 놓쳤다"
+        );
+    }
+
+    /// 구분자를 섞어 쓴 숫자열은 사람이 쓴 카드번호로 보지 않는다.
+    ///
+    /// `1234-5678 9012-3456` 같은 형태는 표 안의 코드가 잘못 붙은 것일 가능성이 크다.
+    /// 하이픈/공백 중 하나로 일관돼야 카드번호로 인정한다.
+    #[test]
+    fn mixed_separators_are_not_a_card() {
+        let found = detect_values("4111-1111 1111-1111", &[PiiKind::Card]);
+        assert!(
+            found.is_empty(),
+            "구분자가 섞인 숫자열을 카드번호로 탐지했다: {found:?}"
+        );
+    }
+
+    /// 공백 구분·연속 16자리·Amex 4-6-5 도 Luhn 을 통과하면 카드번호다.
+    #[test]
+    fn card_accepted_shapes() {
+        for raw in [
+            "4111 1111 1111 1111",
+            "4111111111111111",
+            "3782-822463-10005",
+        ] {
+            let found = detect_values(raw, &[PiiKind::Card]);
+            assert_eq!(
+                found,
+                vec![(PiiKind::Card, raw.to_string())],
+                "카드번호 형태를 놓쳤다: {raw}"
+            );
+        }
+    }
+
+    /// 13자리 카드(구형 Visa)는 회계 숫자와 구별할 근거가 없어 **의도적으로 제외**한다.
+    ///
+    /// 놓치는 쪽을 택한 결정이다 — 이 케이스는 규칙이 우연히 넓어지면 즉시 깨진다.
+    #[test]
+    fn thirteen_digit_card_is_out_of_scope_by_design() {
+        let found = detect_values("4222222222222", &[PiiKind::Card]);
+        assert!(
+            found.is_empty(),
+            "범위 밖 자릿수를 카드번호로 탐지했다: {found:?}"
+        );
+    }
+
+    /// 더 긴 숫자열의 부분열을 잘라 오탐하지 않는다.
+    #[test]
+    fn longer_digit_run_is_not_sliced() {
+        let found = detect_values("문서번호 41111111111111119999", &ALL);
+        assert!(
+            found.is_empty(),
+            "긴 숫자열에서 부분 매치가 났다: {found:?}"
+        );
+    }
+
+    /// 전화번호도 앞뒤 숫자 경계를 본다 — 긴 코드 안의 부분열을 잡지 않는다.
+    #[test]
+    fn phone_respects_digit_boundaries() {
+        let found = detect_values("1010-1234-5678", &[PiiKind::Phone]);
+        assert!(
+            found.is_empty(),
+            "앞에 숫자가 붙은 문자열을 전화번호로 탐지했다: {found:?}"
+        );
+    }
+
+    /// 전화번호는 하이픈이 있는 이동전화·서울 국번만 본다.
+    #[test]
+    fn phone_rules() {
+        for raw in [
+            "010-1234-5678",
+            "010-123-4567",
+            "011-234-5678",
+            "016-234-5678",
+            "017-234-5678",
+            "018-234-5678",
+            "019-234-5678",
+            "02-123-4567",
+            "02-1234-5678",
+        ] {
+            assert_eq!(
+                detect_values(raw, &[PiiKind::Phone]),
+                vec![(PiiKind::Phone, raw.to_string())],
+                "전화번호를 놓쳤다: {raw}"
+            );
+        }
+        // 하이픈 없는 숫자열·이동전화가 아닌 01X·02 밖의 지역번호는 의도적으로 제외한다.
+        for raw in [
+            "01012345678",
+            "031-123-4567",
+            "051-123-4567",
+            "012-345-6789",
+        ] {
+            assert!(
+                detect_values(raw, &[PiiKind::Phone]).is_empty(),
+                "범위 밖 전화 형태를 탐지했다: {raw}"
+            );
+        }
+    }
+
+    /// 이메일은 최상위 도메인까지 확인한다.
+    #[test]
+    fn email_rules() {
+        assert_eq!(
+            detect_values("문의 hong.gil-dong@example.co.kr 로", &[PiiKind::Email]),
+            vec![(PiiKind::Email, "hong.gil-dong@example.co.kr".to_string())]
+        );
+        // 문장 끝의 마침표는 주소에 포함하지 않는다 — 포함하면 치환이 문장을 깬다.
+        assert_eq!(
+            detect_values("회신은 hong@example.com.", &[PiiKind::Email]),
+            vec![(PiiKind::Email, "hong@example.com".to_string())]
+        );
+        // 대문자 도메인도 주소다.
+        assert_eq!(
+            detect_values("USER@EXAMPLE.COM", &[PiiKind::Email]),
+            vec![(PiiKind::Email, "USER@EXAMPLE.COM".to_string())]
+        );
+        // 도메인 라벨이 하나뿐이거나 지역부가 없으면 주소가 아니다.
+        for raw in [
+            "@example",
+            "a@localhost",
+            "user@example.12",
+            "a@-example.com",
+            "a@example-.com",
+        ] {
+            assert!(
+                detect_values(raw, &[PiiKind::Email]).is_empty(),
+                "주소가 아닌 문자열을 이메일로 탐지했다: {raw}"
+            );
+        }
+    }
+
+    /// `--kind` 로 좁히면 그 종류만 본다 — 다른 종류는 아예 판정하지 않는다.
+    #[test]
+    fn kind_filter_is_respected() {
+        let text = "홍길동 900101-1234568 / 010-1234-5678 / hong@example.com / 4111-1111-1111-1111";
+        for kind in ALL {
+            let found = detect_values(text, &[kind]);
+            assert!(
+                !found.is_empty() && found.iter().all(|(k, _)| *k == kind),
+                "{kind:?} 로 좁혔는데 결과가 이상하다: {found:?}"
+            );
+        }
+        assert_eq!(
+            detect_values(text, &ALL).len(),
+            4,
+            "전 종류 탐지 수가 다르다"
+        );
+    }
+
+    /// 마스킹은 문자 수를 보존하고 구분자를 남긴다.
+    #[test]
+    fn mask_preserves_length() {
+        for raw in [
+            "900101-1234568",
+            "010-1234-5678",
+            "4111-1111-1111-1111",
+            "hong@example.com",
+        ] {
+            for mask in ['*', '#', '●'] {
+                let masked = mask_value(raw, mask);
+                assert_eq!(
+                    masked.chars().count(),
+                    raw.chars().count(),
+                    "마스킹으로 길이가 바뀌었다: {raw} → {masked}"
+                );
+                assert!(
+                    !masked.chars().any(|c| c.is_alphanumeric()),
+                    "마스킹 후에도 영숫자가 남았다: {masked}"
+                );
+            }
+        }
+        assert_eq!(mask_value("900101-1234568", '*'), "******-*******");
+        assert_eq!(mask_value("hong@example.com", '*'), "****@*******.***");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -966,6 +966,80 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
             serde_json::json!([{ "when": "bare", "args": ["--bare"] }]),
             &["schemaVersion", "irSchemaVersion", "dialect", "definitionCount", "schema"],
         ),
+        // [#3719 §6-11] 공개 전 정리 — 되돌릴 수 없는 쓰기라 dryRun 이 1차 흐름이다.
+        tool_with_optional_args(
+            "hwp_redact",
+            "공개 전 개인정보를 찾아 자릿수를 유지한 채 마스킹한다 (주민등록번호·전화·이메일·카드번호). **되돌릴 수 없다** — 먼저 dryRun:true 로 findings[] 를 받아 무엇이 지워질지 확인하고, 실제 적용 시에는 output 을 반드시 지정한다(원본을 덮어쓰려면 inPlace:true). 탐지는 보수적이다: 주민등록번호는 검증 숫자, 카드번호는 Luhn 을 통과해야 하며 전화는 하이픈이 있는 이동전화·서울(02) 번호만 본다 — 오탐이 본문을 훼손하기 때문이다. findings[].raw 는 원문 개인정보이므로 로그에 남기지 않는다.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string", "description": "입력 HWP/HWPX 문서 경로" },
+                    "kind": {
+                        "type": "string",
+                        "description": "탐지 종류. ssn|phone|email|card|all 을 쉼표로 나열. 생략하면 all"
+                    },
+                    "mask": { "type": "string", "description": "마스킹 문자 한 글자 (기본 *). 영숫자는 쓸 수 없다" },
+                    "output": { "type": "string", "description": "출력 파일 경로. dryRun 이 아니면 output 또는 inPlace 중 하나가 반드시 필요하다(원본 보호, 없으면 exit 2)" },
+                    "inPlace": { "type": "boolean", "description": "true 면 원본을 덮어쓴다 (되돌릴 수 없음)" },
+                    "dryRun": { "type": "boolean", "description": "true 면 파일을 쓰지 않고 findings[] 만 보고 — 권장 첫 단계" },
+                    "verify": { "type": "boolean", "description": "저장 직후 IR 자기검증 (차이 시 exit 3)" }
+                },
+                "required": ["path"],
+            }),
+            "edit",
+            serde_json::json!(["edit", "redact", "{path}", "--json"]),
+            serde_json::json!([
+                { "when": "kind", "args": ["--kind", "{kind}"] },
+                { "when": "mask", "args": ["--mask", "{mask}"] },
+                { "when": "output", "args": ["-o", "{output}"] },
+                { "when": "inPlace", "args": ["--in-place"] },
+                { "when": "dryRun", "args": ["--dry-run"] },
+                { "when": "verify", "args": ["--verify"] }
+            ]),
+            &[
+                "schemaVersion",
+                "source",
+                "kinds",
+                "mask",
+                "dryRun",
+                "inPlace",
+                "findingCount",
+                "findings",
+                "redactedCount",
+                "changedPages",
+                "output",
+                "outputFormat",
+                "verify",
+            ],
+        ),
+        tool_with_optional_args(
+            "hwp_sanitize",
+            "공개 전 문서 메타데이터를 제거한다 — 작성자·제목·주제·최종수정자·작성/수정 일시·미리보기(PrvText/PrvImage). 본문 내용은 건드리지 않으므로 hwp_export_text 결과는 그대로다. 무엇을 지웠는지 removed[{field,before}] 로 보고한다.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string", "description": "입력 HWP/HWPX 문서 경로" },
+                    "output": { "type": "string", "description": "출력 파일 경로. 생략하면 <입력명>_sanitized.hwp (HWPX 입력이면 _sanitized.hwpx)" },
+                    "keepPreview": { "type": "boolean", "description": "true 면 미리보기 이미지를 남긴다 (미리보기 텍스트는 언제나 제거)" }
+                },
+                "required": ["path"],
+            }),
+            "edit",
+            serde_json::json!(["edit", "sanitize", "{path}", "--json"]),
+            serde_json::json!([
+                { "when": "output", "args": ["-o", "{output}"] },
+                { "when": "keepPreview", "args": ["--keep-preview"] }
+            ]),
+            &[
+                "schemaVersion",
+                "source",
+                "keepPreview",
+                "removedCount",
+                "removed",
+                "output",
+                "outputFormat",
+            ],
+        ),
         tool(
             "hwp_run_plan",
             "[#3703] 선언적 편집 계획(JSON)을 정적 선검증→원자 실행→저널로 수행한다. 도구 호출을 체이닝하는 대신 의도를 계획서 하나로 선언하면, 전 step 의 실행 가능성을 미리 판정하고(불가 시 실행 0·invalid[]·exit 2) 인메모리로 적용해 단언(verify 자기검증) 통과 시에만 단 한 번 저장한다 — 실패 시 디스크 무변경. fill_fields step 은 화면상 구별되지 않는 필드 이름을 steps[].confusable 로 경고한다. steps: fill_fields{data} · replace_text{find,replace[,occurrence]} · set_cell{table,row,col,text[,keepStyle]} · set_checkbox{occurrence}.",
@@ -1403,7 +1477,7 @@ fn capabilities_command_entries() -> Vec<serde_json::Value> {
         cmd_json(
             "edit",
             "edit",
-            "문서 편집 — fill-fields: 누름틀 채우기 / replace-text: 일괄 치환(--occurrence k번째만) / set-cell: 표 셀 기록",
+            "문서 편집 — fill-fields: 누름틀 채우기 / replace-text: 일괄 치환(--occurrence k번째만) / set-cell: 표 셀 기록 / redact: 개인정보 마스킹 / sanitize: 메타데이터 제거",
             false,
             &[
                 "--data",
@@ -1418,8 +1492,15 @@ fn capabilities_command_entries() -> Vec<serde_json::Value> {
                 // hwp_set_checkbox 가 이 플래그를 고정 배선한다 — 목록에만 없었다.
                 "--occurrence",
                 "--keep-style",
+                // [#3719 §6-11] redact/sanitize 축. 선언 누락은 매니페스트만 읽는
+                // 에이전트에게 "그 기능이 없는 것"과 같다.
+                "--kind",
+                "--mask",
+                "--in-place",
+                "--keep-preview",
                 "-o",
                 "--dry-run",
+                "--verify",
                 "--json",
             ],
             &[
@@ -1437,6 +1518,16 @@ fn capabilities_command_entries() -> Vec<serde_json::Value> {
                 "newText",
                 "keepStyle",
                 "overflow",
+                "kinds",
+                "mask",
+                "inPlace",
+                "findingCount",
+                "findings",
+                "redactedCount",
+                "keepPreview",
+                "removedCount",
+                "removed",
+                "changedPages",
                 "output",
                 "outputFormat",
             ],
@@ -2053,7 +2144,33 @@ fn print_help() {
     println!("      --json                    계약 봉투 JSON을 stdout에 출력");
     println!("      병합으로 덮인 칸은 앵커 좌표 안내와 함께 오류 종료");
     println!();
-    println!("      edit 3종 공통: 산출물은 **입력 형식을 보존**한다 (HWPX 입력 → HWPX 산출).");
+    println!("  edit redact <파일.hwp|파일.hwpx> [--kind …] [--dry-run] [-o <출력>|--in-place]");
+    println!("      공개 전 개인정보 마스킹 — 주민등록번호·전화·이메일·카드번호");
+    println!();
+    println!("      --kind <목록>             ssn|phone|email|card|all (쉼표 구분, 기본 all)");
+    println!("      --mask <문자>             마스킹 문자 한 글자 (기본 *, 자릿수 보존)");
+    println!("      --dry-run                 **권장 첫 단계** — 무엇이 지워질지만 보고");
+    println!("      -o, --output <파일>       출력 파일");
+    println!("      --in-place                원본을 덮어쓴다 (되돌릴 수 없음)");
+    println!("      --verify                  저장 직후 IR 자기검증 (차이 시 exit 3)");
+    println!("      --json                    계약 봉투 JSON을 stdout에 출력");
+    println!("      되돌릴 수 없는 작업이다 — 먼저 원본을 복사해 두고, --dry-run 으로 확인하라.");
+    println!("      -o 도 --in-place 도 없으면 원본 보호를 위해 실행을 거부한다 (exit 2).");
+    println!("      탐지는 보수적이다: 주민등록번호는 검증 숫자, 카드는 Luhn 을 통과해야 하고");
+    println!(
+        "      전화는 하이픈이 있는 이동전화·서울(02) 번호만 본다 (오탐이 본문을 훼손하므로)."
+    );
+    println!("      --dry-run 출력에는 원문 개인정보가 그대로 들어간다 — 로그에 남기지 말 것.");
+    println!();
+    println!("  edit sanitize <파일.hwp|파일.hwpx> [--keep-preview] [-o <출력>] [--json]");
+    println!("      문서 메타데이터 제거 — 작성자·제목·최종수정자·작성일·미리보기");
+    println!();
+    println!("      --keep-preview            미리보기 이미지를 남긴다 (기본: 제거)");
+    println!("      -o, --output <파일>       출력 파일 (기본: 입력명_sanitized.<입력 확장자>)");
+    println!("      --json                    계약 봉투 JSON을 stdout에 출력");
+    println!("      본문 내용은 건드리지 않는다. 지운 항목은 removed[] 로 보고한다.");
+    println!();
+    println!("      edit 5종 공통: 산출물은 **입력 형식을 보존**한다 (HWPX 입력 → HWPX 산출).");
     println!("      HWPX 입력에 -o ….hwp 를 지정하면 그 경로를 존중해 HWP5 로 저장하되");
     println!("      형식 변경(이미지·차트 유실 가능)을 stderr 로 경고한다.");
     println!();
@@ -10708,12 +10825,15 @@ fn collect_field_records(doc: &rhwp::wasm_api::HwpDocument) -> Vec<serde_json::V
 /// **실패 시 원본 불변**(하나라도 실패하면 출력 파일을 쓰지 않는다).
 fn run_edit(args: &[String]) -> i32 {
     const USAGE: &str =
-        "사용법: rhwp edit <fill-fields|replace-text|set-cell> <파일.hwp|파일.hwpx> [옵션] (rhwp --help 참조)";
+        "사용법: rhwp edit <fill-fields|replace-text|set-cell|redact|sanitize> <파일.hwp|파일.hwpx> [옵션] (rhwp --help 참조)";
 
     match args.first().map(String::as_str) {
         Some("fill-fields") => edit_fill_fields(&args[1..]),
         Some("replace-text") => edit_replace_text(&args[1..]),
         Some("set-cell") => edit_set_cell(&args[1..]),
+        // [#3719 §6-11] 공개 전 정리 — 개인정보 마스킹 / 메타데이터 제거.
+        Some("redact") => edit_redact(&args[1..]),
+        Some("sanitize") => edit_sanitize(&args[1..]),
         Some(other) => {
             eprintln!("오류: 알 수 없는 edit 하위 명령 - {}", other);
             eprintln!("{USAGE}");
@@ -12133,6 +12253,720 @@ fn edit_replace_text(args: &[String]) -> i32 {
     if verify_failed {
         eprintln!("검증 실패(--verify): 저장본 재파싱 IR 차이 — 상세는 --json 또는 ir-diff");
         process::exit(3);
+    }
+    EXIT_OK
+}
+
+// ─── [#3719 §6-11] 공개 전 정리 — edit redact / edit sanitize ───
+
+/// `-o` 도 `--in-place` 도 없이 원본을 덮어쓰려 할 때의 거부 메시지.
+///
+/// 마스킹은 되돌릴 수 없다. "실수로 원본을 잃는" 경로를 아예 만들지 않기 위해,
+/// 산출 경로를 **명시하지 않으면 실행하지 않는다**(다른 edit 명령의 `_replaced` 류
+/// 기본 이름조차 만들지 않는다 — 어디에 무엇이 생겼는지 모른 채로 두지 않기 위해).
+const REDACT_DESTINATION_REQUIRED: &str = "오류: 마스킹은 되돌릴 수 없습니다. \
+     산출 경로를 -o <출력> 으로 지정하거나, 원본을 덮어쓸 의도라면 --in-place 를 \
+     명시하세요 (먼저 --dry-run 으로 무엇이 지워질지 확인하기를 권합니다).";
+
+/// `edit redact` — 개인정보를 찾아 자릿수를 유지한 채 마스킹한다.
+///
+/// 탐지는 [`rhwp::document_core::queries::pii_scan`] 의 읽기 전용 판정을 쓰고, 실제
+/// 변경은 검증된 치환 경로(`replace_all_native`)를 재사용한다 — 새 편집 로직이 없다.
+/// 되돌릴 수 없는 작업이라 ① `--dry-run` 이 권장 흐름이고 ② 산출 경로를 명시하지
+/// 않으면 exit 2 로 거부한다.
+fn edit_redact(args: &[String]) -> i32 {
+    use rhwp::document_core::queries::pii_scan::PiiKind;
+
+    let mut file_path: Option<&str> = None;
+    let mut out_path: Option<String> = None;
+    let mut kinds: Vec<PiiKind> = Vec::new();
+    let mut mask_char: char = '*';
+    let mut dry_run = false;
+    let mut json_mode = false;
+    let mut verify_mode = false;
+    let mut in_place = false;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--kind" => {
+                i += 1;
+                let Some(value) = args.get(i) else {
+                    eprintln!("오류: --kind 뒤에 ssn|phone|email|card|all 이 필요합니다.");
+                    return EXIT_USAGE;
+                };
+                for token in value.split(',').map(str::trim).filter(|t| !t.is_empty()) {
+                    if token == "all" {
+                        kinds.extend(PiiKind::all());
+                        continue;
+                    }
+                    match PiiKind::parse(token) {
+                        Some(k) => kinds.push(k),
+                        None => {
+                            eprintln!(
+                                "오류: 알 수 없는 --kind 값 - {token} (ssn|phone|email|card|all)"
+                            );
+                            return EXIT_USAGE;
+                        }
+                    }
+                }
+            }
+            "--mask" => {
+                i += 1;
+                let Some(value) = args.get(i) else {
+                    eprintln!("오류: --mask 뒤에 마스킹 문자 한 글자가 필요합니다.");
+                    return EXIT_USAGE;
+                };
+                let mut chars = value.chars();
+                match (chars.next(), chars.next()) {
+                    // 두 글자 이상이면 자릿수 보존이 깨진다 — 조용히 자르지 않고 거부한다.
+                    (Some(c), None) if !c.is_alphanumeric() => mask_char = c,
+                    (Some(_), None) => {
+                        eprintln!("오류: --mask 는 영숫자가 아닌 문자여야 합니다 (예: * # ●).");
+                        return EXIT_USAGE;
+                    }
+                    _ => {
+                        eprintln!("오류: --mask 는 정확히 한 글자여야 합니다 (자릿수 보존).");
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            "-o" | "--output" => {
+                i += 1;
+                match args.get(i) {
+                    Some(v) => out_path = Some(v.clone()),
+                    None => {
+                        eprintln!("오류: -o 뒤에 출력 파일 경로가 필요합니다.");
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            "--in-place" => in_place = true,
+            "--dry-run" => dry_run = true,
+            "--verify" => verify_mode = true,
+            "--json" => json_mode = true,
+            other if other.starts_with('-') => {
+                eprintln!("알 수 없는 옵션: {other}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if file_path.replace(other).is_some() {
+                    eprintln!("오류: 입력 파일은 하나만 지정할 수 있습니다: {other}");
+                    return EXIT_USAGE;
+                }
+            }
+        }
+        i += 1;
+    }
+
+    let Some(file_path) = file_path else {
+        eprintln!(
+            "사용법: rhwp edit redact <파일.hwp|파일.hwpx> [--kind ssn|phone|email|card|all] [--mask <문자>] [--dry-run] [--verify] [-o <출력>|--in-place] [--json]"
+        );
+        return EXIT_USAGE;
+    };
+    if kinds.is_empty() {
+        kinds.extend(PiiKind::all());
+    }
+    kinds.sort_unstable();
+    kinds.dedup();
+
+    if out_path.is_some() && in_place {
+        eprintln!("오류: -o 와 --in-place 는 함께 쓸 수 없습니다 (산출 경로가 모호합니다).");
+        return EXIT_USAGE;
+    }
+    // 원본 보호 — 산출 경로가 없는 실제 실행은 거부한다(--dry-run 은 아무것도 쓰지 않음).
+    if !dry_run && out_path.is_none() && !in_place {
+        eprintln!("{REDACT_DESTINATION_REQUIRED}");
+        return EXIT_USAGE;
+    }
+    // -o 로 원본을 지목한 경우도 같은 사고다 — 의도를 --in-place 로 말하게 한다.
+    if let Some(out) = out_path.as_deref() {
+        if !in_place && same_existing_path(file_path, out) {
+            eprintln!("{REDACT_DESTINATION_REQUIRED}");
+            return EXIT_USAGE;
+        }
+    }
+
+    let bytes = match fs::read(file_path) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
+            return EXIT_RUNTIME;
+        }
+    };
+    let mut doc = match rhwp::wasm_api::HwpDocument::from_bytes(&bytes) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: HWP 파싱 실패 - {}", e);
+            return EXIT_RUNTIME;
+        }
+    };
+
+    let findings = doc.scan_pii(&kinds, mask_char);
+    let changed_paras: Vec<(usize, usize)> = {
+        let mut v: Vec<(usize, usize)> =
+            findings.iter().map(|f| (f.section, f.paragraph)).collect();
+        v.sort_unstable();
+        v.dedup();
+        v
+    };
+
+    // 치환은 값 단위 전량이다. 긴 값을 먼저 바꿔야 짧은 값이 긴 값의 부분열일 때
+    // 원문을 깨뜨리지 않는다.
+    let mut targets: Vec<(String, String)> = Vec::new();
+    for f in &findings {
+        if !targets.iter().any(|(raw, _)| *raw == f.raw) {
+            targets.push((f.raw.clone(), f.masked.clone()));
+        }
+    }
+    targets.sort_by(|a, b| b.0.chars().count().cmp(&a.0.chars().count()));
+
+    let mut redacted_count = 0usize;
+    if !dry_run {
+        for (raw, masked) in &targets {
+            match doc.replace_all_native(raw, masked, true) {
+                Ok(result) => {
+                    redacted_count += serde_json::from_str::<serde_json::Value>(&result)
+                        .ok()
+                        .and_then(|v| v["count"].as_u64())
+                        .unwrap_or(0) as usize;
+                }
+                Err(e) => {
+                    // 실패 시 원본 불변 — 출력 파일을 쓰지 않고 즉시 끝낸다.
+                    eprintln!("오류: 마스킹 실패 - {:?}", e);
+                    return EXIT_RUNTIME;
+                }
+            }
+        }
+    }
+
+    let out_format = edit_output_format(&bytes, out_path.as_deref());
+    let output_path = match (&out_path, in_place) {
+        (Some(p), _) => p.clone(),
+        (None, true) => file_path.to_string(),
+        // 여기 도달하려면 dry-run 이다 — 산출 경로를 쓰지 않는다.
+        (None, false) => String::new(),
+    };
+
+    // 탐지 0건이면 무변경이다 — 산출물을 만들지 않는다(원본을 그대로 두는 편이 안전하다).
+    let wrote_output = !dry_run && redacted_count > 0;
+    let mut verify_report = serde_json::Value::Null;
+    let mut verify_failed = false;
+    if wrote_output {
+        let out_bytes = match edit_serialize(&mut doc, out_format) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!(
+                    "오류: {} 직렬화 실패 - {}",
+                    out_format.label().to_uppercase(),
+                    e
+                );
+                return EXIT_RUNTIME;
+            }
+        };
+        if let Err(e) = atomic_file::write_atomically(Path::new(&output_path), &out_bytes) {
+            eprintln!("오류: 출력 쓰기 실패 - {}: {}", output_path, e);
+            return EXIT_RUNTIME;
+        }
+        if verify_mode {
+            let cross = out_format == EditOutputFormat::Hwp
+                && rhwp::parser::detect_format(&bytes) == rhwp::parser::FileFormat::Hwpx;
+            let (report, failed) = edit_verify_report(&doc, &out_bytes, cross);
+            verify_report = report;
+            verify_failed = failed;
+        }
+    }
+
+    let changed_pages = if wrote_output {
+        match doc.pages_covering_paragraphs(&changed_paras) {
+            Some(pages) => serde_json::json!(pages),
+            None => serde_json::Value::Null,
+        }
+    } else {
+        serde_json::Value::Null
+    };
+
+    if json_mode {
+        let mut envelope = serde_json::json!({
+            "schemaVersion": "1.0",
+            "source": file_path,
+            "kinds": kinds.iter().map(|k| k.as_str()).collect::<Vec<_>>(),
+            "mask": mask_char.to_string(),
+            "dryRun": dry_run,
+            "inPlace": in_place,
+            "findingCount": findings.len(),
+            "findings": findings,
+            "redactedCount": redacted_count,
+            "changedPages": changed_pages,
+        });
+        if wrote_output {
+            envelope["output"] = serde_json::Value::String(output_path.clone());
+            envelope["outputFormat"] = serde_json::Value::String(out_format.label().to_string());
+            envelope["verify"] = verify_report.clone();
+        }
+        println!("{envelope}");
+        if verify_failed {
+            process::exit(3);
+        }
+        return EXIT_OK;
+    }
+
+    if dry_run {
+        println!(
+            "마스킹 예정: {} — 탐지 {}건 (원문 {}개). 실제 적용은 -o 또는 --in-place.",
+            file_path,
+            findings.len(),
+            targets.len()
+        );
+        for f in &findings {
+            println!(
+                "  [{}] {} → {} (구역 {}, 문단 {}, 쪽 {})",
+                f.kind,
+                f.raw,
+                f.masked,
+                f.section,
+                f.paragraph,
+                f.page
+                    .map(|p| (p + 1).to_string())
+                    .unwrap_or_else(|| "-".to_string()),
+            );
+        }
+    } else if redacted_count == 0 {
+        println!("마스킹 0건: {} — 탐지 없음 (출력 파일 미생성)", file_path);
+    } else {
+        println!(
+            "마스킹 완료: {} → {} — {}건",
+            file_path, output_path, redacted_count
+        );
+    }
+    if verify_failed {
+        eprintln!("검증 실패(--verify): 저장본 재파싱 IR 차이 — 상세는 --json 또는 ir-diff");
+        process::exit(3);
+    }
+    EXIT_OK
+}
+
+/// 두 경로가 **이미 존재하는 같은 파일**을 가리키는지. 판정 불가면 `false`.
+///
+/// 산출 경로는 대개 존재하지 않으므로 정규화가 실패하는 것이 정상이다. 여기서
+/// 잡으려는 것은 `-o` 로 원본 자신을 지목한 경우 하나뿐이다.
+fn same_existing_path(a: &str, b: &str) -> bool {
+    match (fs::canonicalize(a), fs::canonicalize(b)) {
+        (Ok(x), Ok(y)) => x == y,
+        _ => false,
+    }
+}
+
+/// `\u{5}HwpSummaryInformation` 에서 지울 속성 — `(PID, 봉투 필드 이름)`.
+///
+/// PID 는 HWP5 사양의 `HWPPIDSI_*` 다. 본문과 무관한 작성자·이력 메타만 고른다.
+const SUMMARY_TARGETS: [(u32, &str); 11] = [
+    (0x02, "title"),
+    (0x03, "subject"),
+    (0x04, "author"),
+    (0x05, "keywords"),
+    (0x06, "comments"),
+    (0x08, "lastSavedBy"),
+    (0x09, "revisionNumber"),
+    (0x0B, "lastPrintedAt"),
+    (0x0C, "createdAt"),
+    (0x0D, "lastSavedAt"),
+    (0x14, "dateString"),
+];
+
+/// FILETIME(1601-01-01 UTC 기준 100ns) → `YYYY-MM-DDTHH:MM:SSZ`.
+///
+/// 감사 기록용이다 — 무엇을 지웠는지 사람이 읽을 수 있어야 "조용히 지우지 않았다"가
+/// 성립한다.
+fn filetime_to_iso(ft: u64) -> String {
+    const SECS_1601_TO_1970: i64 = 11_644_473_600;
+    let secs = (ft / 10_000_000) as i64 - SECS_1601_TO_1970;
+    let days = secs.div_euclid(86_400);
+    let rem = secs.rem_euclid(86_400);
+    // Howard Hinnant, civil_from_days (proleptic Gregorian).
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = y + i64::from(m <= 2);
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        year,
+        m,
+        d,
+        rem / 3600,
+        (rem % 3600) / 60,
+        rem % 60
+    )
+}
+
+/// `\u{5}HwpSummaryInformation`(OLE 속성 집합)에서 작성자·이력 메타를 지운다.
+///
+/// **바이트 길이를 바꾸지 않는다** — 속성 오프셋 표가 절대 위치를 담고 있어 크기를
+/// 줄이면 나머지 속성이 전부 어긋난다. 문자열은 `cch=1`(NUL 하나)로 만들고 남은
+/// 자리를 0으로 덮으며, FILETIME 은 0(미설정)으로 만든다.
+///
+/// 반환: `(필드 이름, 지우기 전 값)` 목록. 형식을 해석하지 못하면 빈 목록(무변경).
+fn sanitize_summary_information(data: &mut [u8]) -> Vec<(String, String)> {
+    fn u32_at(d: &[u8], off: usize) -> Option<u32> {
+        d.get(off..off + 4)
+            .map(|b| u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+    }
+
+    let mut removed: Vec<(String, String)> = Vec::new();
+    if data.len() < 48 || data[0] != 0xFE || data[1] != 0xFF {
+        return removed;
+    }
+    let Some(section_off) = u32_at(data, 44).map(|v| v as usize) else {
+        return removed;
+    };
+    let Some(count) = u32_at(data, section_off + 4).map(|v| v as usize) else {
+        return removed;
+    };
+    // 병적으로 큰 개수는 해석을 포기한다(손상 파일에서 헛돌지 않게).
+    if count > 4096 || section_off + 8 + count * 8 > data.len() {
+        return removed;
+    }
+
+    for idx in 0..count {
+        let pair = section_off + 8 + idx * 8;
+        let (Some(pid), Some(rel)) = (u32_at(data, pair), u32_at(data, pair + 4)) else {
+            continue;
+        };
+        let Some((_, field)) = SUMMARY_TARGETS.iter().find(|(p, _)| *p == pid) else {
+            continue;
+        };
+        let abs = section_off + rel as usize;
+        let Some(vt) = u32_at(data, abs) else {
+            continue;
+        };
+        match vt {
+            // VT_LPWSTR — UTF-16LE, cch 는 종단 NUL 을 포함한 문자 수.
+            0x1F => {
+                let Some(cch) = u32_at(data, abs + 4).map(|v| v as usize) else {
+                    continue;
+                };
+                let start = abs + 8;
+                let Some(raw) = data.get(start..start + cch * 2) else {
+                    continue;
+                };
+                let units: Vec<u16> = raw
+                    .chunks_exact(2)
+                    .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                    .take_while(|u| *u != 0)
+                    .collect();
+                if units.is_empty() {
+                    continue;
+                }
+                removed.push((field.to_string(), String::from_utf16_lossy(&units)));
+                data[start..start + cch * 2].fill(0);
+                data[abs + 4..abs + 8].copy_from_slice(&1u32.to_le_bytes());
+            }
+            // VT_FILETIME.
+            0x40 => {
+                let Some(raw) = data.get(abs + 4..abs + 12) else {
+                    continue;
+                };
+                let mut bytes = [0u8; 8];
+                bytes.copy_from_slice(raw);
+                let value = u64::from_le_bytes(bytes);
+                if value == 0 {
+                    continue;
+                }
+                removed.push((field.to_string(), filetime_to_iso(value)));
+                data[abs + 4..abs + 12].fill(0);
+            }
+            _ => {}
+        }
+    }
+    removed
+}
+
+/// HWPX `Contents/content.hpf` 의 `<opf:metadata>` 블록을 중립 블록으로 바꾼다.
+///
+/// 이 블록은 직렬화기가 원본에서 그대로 splice 하는 유일한 저작자 정보 경로다
+/// (`serializer::hwpx::content::write_content_hpf`). 지우지 않으면 HWPX 산출물에
+/// 작성자·작성일이 그대로 남는다. 반환: 지우기 전 블록(있었을 때만).
+fn sanitize_hwpx_metadata(entry: &mut Vec<u8>) -> Option<String> {
+    const NEUTRAL: &str =
+        "<opf:metadata><opf:title/><opf:language>ko</opf:language></opf:metadata>";
+    let text = String::from_utf8(entry.clone()).ok()?;
+    let open = text.find("<opf:metadata>")?;
+    let close = text[open..].find("</opf:metadata>")? + open + "</opf:metadata>".len();
+    let before = text[open..close].to_string();
+    if before == NEUTRAL {
+        return None;
+    }
+    let mut rebuilt = String::with_capacity(text.len());
+    rebuilt.push_str(&text[..open]);
+    rebuilt.push_str(NEUTRAL);
+    rebuilt.push_str(&text[close..]);
+    *entry = rebuilt.into_bytes();
+    Some(before)
+}
+
+/// 본문 문단 텍스트를 공백·제어문자를 뺀 한 줄로 잇는다 (미리보기 대조용).
+///
+/// `serializer::cfb_writer::build_preview_text` 와 같은 범위(본문 문단만, 표·글상자 제외).
+fn body_text_signature(document: &rhwp::model::document::Document) -> String {
+    const MAX: usize = 4000;
+    let mut out = String::new();
+    for section in &document.sections {
+        for para in &section.paragraphs {
+            out.extend(
+                para.text
+                    .chars()
+                    .filter(|c| !c.is_whitespace() && !c.is_control()),
+            );
+            if out.chars().count() >= MAX {
+                return out;
+            }
+        }
+    }
+    out
+}
+
+/// 미리보기 텍스트가 **지금 본문**의 앞부분과 같은지.
+///
+/// 같으면 유출이 아니라 본문의 파생물이다(저장 시 어차피 같은 값이 다시 만들어진다).
+/// 다르면 예전 판의 잔재 — 본문에서 지운 문장이 미리보기에만 남아 있는 전형적 사고다.
+fn preview_text_is_current(preview: &str, body_signature: &str) -> bool {
+    let stripped: String = preview
+        .chars()
+        .filter(|c| !c.is_whitespace() && !c.is_control())
+        .collect();
+    stripped.is_empty() || body_signature.starts_with(&stripped)
+}
+
+/// `edit sanitize` — 문서 메타데이터를 제거한다 (본문은 건드리지 않는다).
+///
+/// 작성자·회사·최종수정자·작성일과 미리보기(PrvText/PrvImage)를 지운다. 무엇을
+/// 지웠는지 `removed[]` 로 남긴다 — 조용히 지우면 감사할 수 없다.
+fn edit_sanitize(args: &[String]) -> i32 {
+    let mut file_path: Option<&str> = None;
+    let mut out_path: Option<String> = None;
+    let mut keep_preview = false;
+    let mut json_mode = false;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "-o" | "--output" => {
+                i += 1;
+                match args.get(i) {
+                    Some(v) => out_path = Some(v.clone()),
+                    None => {
+                        eprintln!("오류: -o 뒤에 출력 파일 경로가 필요합니다.");
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            "--keep-preview" => keep_preview = true,
+            "--json" => json_mode = true,
+            other if other.starts_with('-') => {
+                eprintln!("알 수 없는 옵션: {other}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if file_path.replace(other).is_some() {
+                    eprintln!("오류: 입력 파일은 하나만 지정할 수 있습니다: {other}");
+                    return EXIT_USAGE;
+                }
+            }
+        }
+        i += 1;
+    }
+
+    let Some(file_path) = file_path else {
+        eprintln!(
+            "사용법: rhwp edit sanitize <파일.hwp|파일.hwpx> [--keep-preview] [-o <출력>] [--json]"
+        );
+        return EXIT_USAGE;
+    };
+
+    let bytes = match fs::read(file_path) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
+            return EXIT_RUNTIME;
+        }
+    };
+    let mut doc = match rhwp::wasm_api::HwpDocument::from_bytes(&bytes) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: HWP 파싱 실패 - {}", e);
+            return EXIT_RUNTIME;
+        }
+    };
+
+    let out_format = edit_output_format(&bytes, out_path.as_deref());
+    // HWPX 원본의 `/HwpSummaryInformation` 은 **파일에 없던** 계약 fallback 상수다
+    // (`parser::hwpx::contract_streams`). HWPX 로 저장하면 산출물에도 실리지 않으므로
+    // 손대지 않는다 — 없던 것을 지웠다고 보고하면 감사 기록이 거짓이 된다. HWP5 로
+    // 변환할 때만 실제 산출물에 들어가므로 그때는 지운다.
+    let source_is_hwpx = matches!(
+        rhwp::parser::detect_format(&bytes),
+        rhwp::parser::FileFormat::Hwpx
+    );
+    let touch_summary = !(source_is_hwpx && out_format == EditOutputFormat::Hwpx);
+
+    let mut removed: Vec<(String, String)> = Vec::new();
+    {
+        let document = doc.document_mut();
+
+        // ① OLE 요약 정보 (HWP5 원본 · HWPX→HWP5 변환 계약 스트림).
+        if touch_summary {
+            for (path, data) in document.extra_streams.iter_mut() {
+                if !path
+                    .trim_start_matches(['/', '\u{5}'])
+                    .eq_ignore_ascii_case("HwpSummaryInformation")
+                {
+                    continue;
+                }
+                removed.extend(sanitize_summary_information(data));
+            }
+        }
+
+        // ② HWPX 저작자 메타(content.hpf 의 opf:metadata splice 경로).
+        for (path, entry) in document.hwpx_aux_entries.iter_mut() {
+            if path != "Contents/content.hpf" {
+                continue;
+            }
+            if let Some(before) = sanitize_hwpx_metadata(entry) {
+                removed.push(("hwpx.metadata".to_string(), before));
+            }
+        }
+
+        // ③ 미리보기 — 예전 판의 잔재가 남는 자리다. 본문에서 이미 지운 문장이
+        //    미리보기에만 남아 공개되는 사고가 이 명령의 존재 이유 중 하나다.
+        //    지금 본문과 같은 미리보기는 파생물이므로 보고하지 않는다(저장 시 재생성).
+        let body_signature = body_text_signature(document);
+
+        if let Some(preview) = document.preview.as_mut() {
+            let stale = preview
+                .text
+                .as_deref()
+                .is_some_and(|t| !preview_text_is_current(t, &body_signature));
+            if stale {
+                if let Some(text) = preview.text.take() {
+                    removed.push((
+                        "preview.text".to_string(),
+                        text.chars().take(60).collect::<String>(),
+                    ));
+                }
+            }
+            if !keep_preview {
+                if let Some(image) = preview.image.take() {
+                    removed.push((
+                        "preview.image".to_string(),
+                        format!("{:?} {} bytes", image.format, image.data.len()),
+                    ));
+                }
+            }
+        }
+        if document
+            .preview
+            .as_ref()
+            .is_some_and(|p| p.text.is_none() && p.image.is_none())
+        {
+            document.preview = None;
+        }
+
+        // HWPX 컨테이너의 미리보기 — ZIP 엔트리(HWPX 산출용)와 계약 스트림
+        // (HWPX→HWP5 변환용)은 같은 것의 두 표현이므로 함께 지우고 한 번만 보고한다.
+        let hwpx_preview_text = document
+            .hwpx_aux_entry("Preview/PrvText.txt")
+            .and_then(|b| std::str::from_utf8(b).ok())
+            .map(str::to_string);
+        let drop_hwpx_text = hwpx_preview_text
+            .as_deref()
+            .is_some_and(|t| !preview_text_is_current(t, &body_signature));
+        if drop_hwpx_text {
+            if let Some(text) = hwpx_preview_text {
+                removed.push((
+                    "preview.text".to_string(),
+                    text.chars().take(60).collect::<String>(),
+                ));
+            }
+        }
+        // 직렬화기는 엔트리가 없으면 빈 자리표시자를 넣는다. 이미 자리표시자면
+        // 지울 것이 없다 — 반복 실행이 매번 "지웠다"고 보고하지 않게 한다.
+        let drop_hwpx_image = !keep_preview
+            && document
+                .hwpx_aux_entry("Preview/PrvImage.png")
+                .is_some_and(|b| b != rhwp::serializer::hwpx::static_assets::PRV_IMAGE_PNG);
+        if drop_hwpx_image {
+            if let Some(bytes) = document.hwpx_aux_entry("Preview/PrvImage.png") {
+                removed.push((
+                    "preview.image".to_string(),
+                    format!("Png {} bytes", bytes.len()),
+                ));
+            }
+        }
+        document.hwpx_aux_entries.retain(|(path, _)| {
+            !(path == "Preview/PrvText.txt" && drop_hwpx_text)
+                && !(path == "Preview/PrvImage.png" && drop_hwpx_image)
+        });
+        document.extra_streams.retain(|(path, _)| {
+            !(path == "/PrvText" && drop_hwpx_text) && !(path == "/PrvImage" && !keep_preview)
+        });
+    }
+
+    let output_path = out_path.unwrap_or_else(|| {
+        let stem = Path::new(file_path)
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_else(|| "output".to_string());
+        format!("{}_sanitized.{}", stem, out_format.ext())
+    });
+
+    let out_bytes = match edit_serialize(&mut doc, out_format) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!(
+                "오류: {} 직렬화 실패 - {}",
+                out_format.label().to_uppercase(),
+                e
+            );
+            return EXIT_RUNTIME;
+        }
+    };
+    if let Err(e) = atomic_file::write_atomically(Path::new(&output_path), &out_bytes) {
+        eprintln!("오류: 출력 쓰기 실패 - {}: {}", output_path, e);
+        return EXIT_RUNTIME;
+    }
+
+    if json_mode {
+        let envelope = serde_json::json!({
+            "schemaVersion": "1.0",
+            "source": file_path,
+            "keepPreview": keep_preview,
+            "removedCount": removed.len(),
+            "removed": removed
+                .iter()
+                .map(|(field, before)| serde_json::json!({ "field": field, "before": before }))
+                .collect::<Vec<_>>(),
+            "output": output_path,
+            "outputFormat": out_format.label(),
+        });
+        println!("{envelope}");
+        return EXIT_OK;
+    }
+
+    println!(
+        "메타 제거 완료: {} → {} — {}건",
+        file_path,
+        output_path,
+        removed.len()
+    );
+    for (field, before) in &removed {
+        println!("  {field}: {before}");
     }
     EXIT_OK
 }

--- a/tests/redact_sanitize_contract.rs
+++ b/tests/redact_sanitize_contract.rs
@@ -1,0 +1,640 @@
+//! [#3719 §6-11] `edit redact` · `edit sanitize` 계약 테스트.
+//!
+//! 이 명령들의 위험은 성격이 다르다:
+//!
+//! - `redact` 는 **되돌릴 수 없는 쓰기**다. 오탐 하나가 본문 숫자를 영구히 훼손하고,
+//!   실수로 원본을 덮어쓰면 되돌릴 방법이 없다. 그래서 여기서 고정하는 것은 기능이
+//!   아니라 **안 하는 것**이다 — 검증을 통과하지 못한 문자열은 마스킹하지 않고,
+//!   산출 경로를 명시하지 않으면 실행하지 않으며, `--dry-run` 은 파일을 만들지 않는다.
+//! - `sanitize` 는 **본문을 건드리면 안 된다**. `export-text` 전후 비교로 못박는다.
+//!
+//! 개인정보가 든 샘플은 저장소에 두지 않는다. 테스트가 `edit fill-fields` 로 형태만
+//! 개인정보인 **가짜 값**을 심어 넣고 그 문서를 대상으로 돌린다.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// 누름틀이 있는 서식 샘플 — 값을 심을 자리(회사명·작성자·전화번호·이메일)가 있다.
+const SAMPLE: &str = "samples/field-01.hwp";
+
+/// 검증 숫자(mod 11)를 통과하는 **가공** 주민등록번호. 실재 인물과 무관하다.
+const VALID_SSN: &str = "900101-1234568";
+/// 형태만 같고 검증 숫자가 틀린 문자열 — 마스킹되면 안 된다.
+const INVALID_SSN: &str = "900101-1234567";
+/// Luhn 을 통과하는 시험용 카드번호(공개 테스트 번호).
+const VALID_CARD: &str = "4111-1111-1111-1111";
+/// Luhn 실패 숫자열 — 마스킹되면 안 된다.
+const INVALID_CARD: &str = "1234-5678-9012-3456";
+
+fn repo(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn scratch(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("rhwp-redact-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("작업 디렉터리 생성");
+    dir.join(name)
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], out: &Output) -> String {
+    format!(
+        "args={args:?}\nexit={:?}\nstdout={}\nstderr={}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+fn json_of(args: &[&str], out: &Output) -> serde_json::Value {
+    serde_json::from_slice(&out.stdout)
+        .unwrap_or_else(|e| panic!("stdout 이 JSON 이 아닙니다({e}): {}", describe(args, out)))
+}
+
+/// 형태만 개인정보인 가짜 값을 누름틀에 심은 문서를 만든다.
+///
+/// 유효한 값과 **검증에 실패하는 미끼**를 같은 문서에 함께 넣는다 — 오탐 0을
+/// 증명하려면 미끼가 같은 문서 안에 있어야 한다.
+fn make_pii_document(name: &str) -> Option<PathBuf> {
+    let src = repo(SAMPLE);
+    if !src.exists() {
+        eprintln!("샘플 없음({}) — 건너뜀", src.display());
+        return None;
+    }
+    let out = scratch(name);
+    let _ = std::fs::remove_file(&out);
+    let data = format!(
+        r#"{{"작성자":"홍길동 {VALID_SSN}","전화번호":"010-1234-5678","이메일":"hong@example.com","회사명":"카드 {VALID_CARD} / 미끼 {INVALID_SSN} / 미끼 {INVALID_CARD}"}}"#
+    );
+    let args = [
+        "edit",
+        "fill-fields",
+        src.to_str().unwrap(),
+        "--data",
+        &data,
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let result = run(&args);
+    assert_eq!(
+        result.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &result)
+    );
+    assert!(out.exists(), "가짜 개인정보 문서가 만들어지지 않았습니다");
+    Some(out)
+}
+
+/// 문서 전체 텍스트 — `export-text --json` 의 페이지 배열을 이어 붙인다.
+fn document_text(path: &Path) -> String {
+    let args = ["export-text", path.to_str().unwrap(), "--json"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    let v = json_of(&args, &out);
+    v["pages"]
+        .as_array()
+        .expect("pages 배열")
+        .iter()
+        .map(|p| p["text"].as_str().unwrap_or_default().to_string())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// **오탐 0** — 형태가 같아도 검증(주민번호 mod 11 · 카드 Luhn)을 통과하지 못하면
+/// 탐지 목록에 없어야 하고, 실제 마스킹 후에도 원문 그대로 남아 있어야 한다.
+///
+/// 이 계약이 깨지면 redact 는 문서를 훼손하는 도구가 된다 — 마스킹은 되돌릴 수 없다.
+#[test]
+fn checksum_failures_are_never_masked() {
+    let Some(doc) = make_pii_document("fp.hwp") else {
+        return;
+    };
+    let args = [
+        "edit",
+        "redact",
+        doc.to_str().unwrap(),
+        "--dry-run",
+        "--json",
+    ];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    let v = json_of(&args, &out);
+
+    let raws: Vec<&str> = v["findings"]
+        .as_array()
+        .expect("findings 배열")
+        .iter()
+        .filter_map(|f| f["raw"].as_str())
+        .collect();
+    for decoy in [INVALID_SSN, INVALID_CARD] {
+        assert!(
+            !raws.contains(&decoy),
+            "검증에 실패하는 미끼를 탐지했습니다({decoy}) — 오탐은 본문을 훼손합니다: {raws:?}"
+        );
+    }
+    // 규칙이 통째로 죽어 있으면 위 단언이 공허하게 통과한다 — 진짜 값은 잡아야 한다.
+    for real in [VALID_SSN, VALID_CARD, "010-1234-5678", "hong@example.com"] {
+        assert!(
+            raws.contains(&real),
+            "탐지되어야 할 값을 놓쳤습니다({real}): {raws:?}"
+        );
+    }
+
+    // 실제 마스킹 후에도 미끼는 그대로 있어야 한다.
+    let masked = scratch("fp_masked.hwp");
+    let _ = std::fs::remove_file(&masked);
+    let args = [
+        "edit",
+        "redact",
+        doc.to_str().unwrap(),
+        "-o",
+        masked.to_str().unwrap(),
+        "--json",
+    ];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    let text = document_text(&masked);
+    for decoy in [INVALID_SSN, INVALID_CARD] {
+        assert!(
+            text.contains(decoy),
+            "미끼가 마스킹으로 훼손됐습니다({decoy})"
+        );
+    }
+    for real in [VALID_SSN, VALID_CARD, "010-1234-5678", "hong@example.com"] {
+        assert!(!text.contains(real), "마스킹되지 않고 남았습니다({real})");
+    }
+}
+
+/// 마스킹 후에도 **문자 수가 유지**된다 — 길이가 바뀌면 조판이 흔들린다.
+#[test]
+fn masking_preserves_length() {
+    let Some(doc) = make_pii_document("len.hwp") else {
+        return;
+    };
+    let args = [
+        "edit",
+        "redact",
+        doc.to_str().unwrap(),
+        "--dry-run",
+        "--json",
+    ];
+    let out = run(&args);
+    let v = json_of(&args, &out);
+    let findings = v["findings"].as_array().expect("findings");
+    assert!(!findings.is_empty(), "탐지 0건이면 이 가드는 공허하다: {v}");
+    for f in findings {
+        let raw = f["raw"].as_str().expect("raw");
+        let masked = f["masked"].as_str().expect("masked");
+        assert_eq!(
+            raw.chars().count(),
+            masked.chars().count(),
+            "마스킹으로 길이가 바뀌었습니다: {raw} → {masked}"
+        );
+        assert!(
+            !masked.chars().any(char::is_alphanumeric),
+            "마스킹 후에도 영숫자가 남았습니다: {masked}"
+        );
+    }
+
+    // 산출 문서의 실제 본문에서도 자릿수가 유지되어야 한다.
+    let masked_path = scratch("len_masked.hwp");
+    let _ = std::fs::remove_file(&masked_path);
+    let args = [
+        "edit",
+        "redact",
+        doc.to_str().unwrap(),
+        "-o",
+        masked_path.to_str().unwrap(),
+        "--json",
+    ];
+    assert_eq!(run(&args).status.code(), Some(0));
+    let text = document_text(&masked_path);
+    assert!(
+        text.contains("******-*******"),
+        "주민등록번호 자리가 원래 길이로 마스킹되지 않았습니다"
+    );
+    assert!(
+        text.contains("****-****-****-****"),
+        "카드번호 자리가 원래 길이로 마스킹되지 않았습니다"
+    );
+}
+
+/// 원본 보호 — `-o` 도 `--in-place` 도 없으면 **실행하지 않는다**(exit 2).
+///
+/// 다른 edit 명령처럼 `_redacted.hwp` 같은 기본 이름을 만들지도 않는다: 되돌릴 수
+/// 없는 작업에서 "어디에 무엇이 생겼는지 모르는 상태"를 만들지 않기 위해서다.
+#[test]
+fn refuses_to_run_without_an_explicit_destination() {
+    let Some(doc) = make_pii_document("guard.hwp") else {
+        return;
+    };
+    let before = std::fs::read(&doc).expect("원본 읽기");
+
+    let args = ["edit", "redact", doc.to_str().unwrap(), "--json"];
+    let out = run(&args);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "산출 경로 없는 실행은 exit 2 여야 합니다: {}",
+        describe(&args, &out)
+    );
+    assert!(
+        out.stdout.is_empty(),
+        "실패 경로는 stdout 0바이트여야 합니다: {}",
+        describe(&args, &out)
+    );
+    assert_eq!(
+        std::fs::read(&doc).expect("원본 재읽기"),
+        before,
+        "거부됐는데 원본이 바뀌었습니다"
+    );
+
+    // `-o` 로 원본 자신을 지목하는 것도 같은 사고다.
+    let args = [
+        "edit",
+        "redact",
+        doc.to_str().unwrap(),
+        "-o",
+        doc.to_str().unwrap(),
+        "--json",
+    ];
+    let out = run(&args);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "-o 가 원본을 가리키면 exit 2 여야 합니다: {}",
+        describe(&args, &out)
+    );
+    assert_eq!(
+        std::fs::read(&doc).expect("원본 재읽기"),
+        before,
+        "-o 원본 지목이 거부됐는데 원본이 바뀌었습니다"
+    );
+
+    // --in-place 를 명시하면 허용된다 — 원본이 실제로 바뀐다.
+    let args = [
+        "edit",
+        "redact",
+        doc.to_str().unwrap(),
+        "--in-place",
+        "--json",
+    ];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    assert_ne!(
+        std::fs::read(&doc).expect("원본 재읽기"),
+        before,
+        "--in-place 인데 원본이 그대로입니다"
+    );
+}
+
+/// `--dry-run` 은 **산출 파일을 만들지 않는다**.
+#[test]
+fn dry_run_writes_nothing() {
+    let Some(doc) = make_pii_document("dry.hwp") else {
+        return;
+    };
+    let out_path = scratch("dry_out.hwp");
+    let _ = std::fs::remove_file(&out_path);
+    let before = std::fs::read(&doc).expect("원본 읽기");
+
+    let args = [
+        "edit",
+        "redact",
+        doc.to_str().unwrap(),
+        "-o",
+        out_path.to_str().unwrap(),
+        "--dry-run",
+        "--json",
+    ];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    let v = json_of(&args, &out);
+    assert_eq!(v["dryRun"], true, "{v}");
+    assert_eq!(v["redactedCount"], 0, "dry-run 은 치환하지 않습니다: {v}");
+    assert!(
+        v["output"].is_null(),
+        "dry-run 봉투에 output 이 있습니다: {v}"
+    );
+    assert!(
+        !out_path.exists(),
+        "--dry-run 인데 산출 파일이 생겼습니다: {}",
+        out_path.display()
+    );
+    assert_eq!(
+        std::fs::read(&doc).expect("원본 재읽기"),
+        before,
+        "--dry-run 인데 원본이 바뀌었습니다"
+    );
+}
+
+/// `--mask` 는 자릿수를 유지하는 한 글자여야 한다 — 두 글자·영숫자는 거부한다.
+#[test]
+fn mask_must_be_a_single_non_alphanumeric_char() {
+    let Some(doc) = make_pii_document("mask.hwp") else {
+        return;
+    };
+    for bad in ["**", "x"] {
+        let args = [
+            "edit",
+            "redact",
+            doc.to_str().unwrap(),
+            "--mask",
+            bad,
+            "--dry-run",
+            "--json",
+        ];
+        let out = run(&args);
+        assert_eq!(
+            out.status.code(),
+            Some(2),
+            "--mask {bad} 는 거부되어야 합니다: {}",
+            describe(&args, &out)
+        );
+        assert!(out.stdout.is_empty(), "{}", describe(&args, &out));
+    }
+
+    let args = [
+        "edit",
+        "redact",
+        doc.to_str().unwrap(),
+        "--mask",
+        "#",
+        "--dry-run",
+        "--json",
+    ];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    let v = json_of(&args, &out);
+    assert_eq!(v["mask"], "#", "{v}");
+    assert!(
+        v["findings"]
+            .as_array()
+            .expect("findings")
+            .iter()
+            .all(|f| f["masked"].as_str().is_some_and(|m| m.contains('#'))),
+        "지정한 마스킹 문자가 쓰이지 않았습니다: {v}"
+    );
+}
+
+/// `--kind` 로 종류를 좁히면 그 종류만 탐지된다.
+#[test]
+fn kind_filter_narrows_detection() {
+    let Some(doc) = make_pii_document("kind.hwp") else {
+        return;
+    };
+    let args = [
+        "edit",
+        "redact",
+        doc.to_str().unwrap(),
+        "--kind",
+        "email",
+        "--dry-run",
+        "--json",
+    ];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    let v = json_of(&args, &out);
+    let findings = v["findings"].as_array().expect("findings");
+    assert!(!findings.is_empty(), "이메일을 놓쳤습니다: {v}");
+    assert!(
+        findings.iter().all(|f| f["kind"] == "email"),
+        "--kind email 인데 다른 종류가 섞였습니다: {v}"
+    );
+}
+
+/// `sanitize` 는 메타데이터만 지우고 **본문 텍스트를 바꾸지 않는다**.
+#[test]
+fn sanitize_removes_metadata_without_touching_the_body() {
+    let src = repo(SAMPLE);
+    if !src.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let out_path = scratch("san.hwp");
+    let _ = std::fs::remove_file(&out_path);
+
+    let before_text = document_text(&src);
+    let args = [
+        "edit",
+        "sanitize",
+        src.to_str().unwrap(),
+        "-o",
+        out_path.to_str().unwrap(),
+        "--json",
+    ];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    let v = json_of(&args, &out);
+    assert_eq!(v["schemaVersion"], "1.0", "{v}");
+
+    let removed = v["removed"].as_array().expect("removed 배열");
+    assert!(
+        !removed.is_empty(),
+        "지운 것이 없으면 이 계약은 공허하다 — 샘플에 메타가 있어야 한다: {v}"
+    );
+    assert_eq!(v["removedCount"], removed.len(), "{v}");
+    for entry in removed {
+        assert!(entry["field"].is_string(), "field 누락: {entry}");
+        assert!(entry["before"].is_string(), "before 누락: {entry}");
+    }
+    let fields: Vec<&str> = removed.iter().filter_map(|e| e["field"].as_str()).collect();
+    for expected in ["author", "lastSavedBy"] {
+        assert!(
+            fields.contains(&expected),
+            "작성자 계열 메타를 지우지 않았습니다({expected}): {fields:?}"
+        );
+    }
+
+    assert_eq!(
+        document_text(&out_path),
+        before_text,
+        "sanitize 가 본문 텍스트를 바꿨습니다"
+    );
+
+    // 두 번째 실행은 지울 것이 없어야 한다 — 첫 실행이 실제로 지웠다는 증거다.
+    let again = scratch("san2.hwp");
+    let _ = std::fs::remove_file(&again);
+    let args = [
+        "edit",
+        "sanitize",
+        out_path.to_str().unwrap(),
+        "-o",
+        again.to_str().unwrap(),
+        "--json",
+    ];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    let v = json_of(&args, &out);
+    assert_eq!(
+        v["removedCount"], 0,
+        "이미 정리된 문서에서 또 지울 것이 나왔습니다 — 첫 실행이 지우지 못한 것입니다: {v}"
+    );
+}
+
+/// `--keep-preview` 는 미리보기 이미지를 남긴다.
+#[test]
+fn keep_preview_retains_the_thumbnail() {
+    let src = repo(SAMPLE);
+    if !src.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let out_path = scratch("san_keep.hwp");
+    let _ = std::fs::remove_file(&out_path);
+    let args = [
+        "edit",
+        "sanitize",
+        src.to_str().unwrap(),
+        "--keep-preview",
+        "-o",
+        out_path.to_str().unwrap(),
+        "--json",
+    ];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    let v = json_of(&args, &out);
+    assert_eq!(v["keepPreview"], true, "{v}");
+    assert!(
+        !v["removed"]
+            .as_array()
+            .expect("removed")
+            .iter()
+            .any(|e| e["field"] == "preview.image"),
+        "--keep-preview 인데 미리보기 이미지를 지웠습니다: {v}"
+    );
+
+    // 썸네일 추출이 여전히 성공해야 한다 — 봉투 선언만이 아니라 실물로 확인한다.
+    let args = [
+        "thumbnail",
+        out_path.to_str().unwrap(),
+        "--base64",
+        "--json",
+    ];
+    let out = run(&args);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "--keep-preview 산출물에서 썸네일이 사라졌습니다: {}",
+        describe(&args, &out)
+    );
+}
+
+/// 산출물은 입력 형식을 보존한다 (HWPX 입력 → HWPX 산출).
+#[test]
+fn sanitize_preserves_the_input_format() {
+    let src = repo("samples/3-09월_교육_통합_2022.hwpx");
+    if !src.exists() {
+        eprintln!("HWPX 샘플 없음 — 건너뜀");
+        return;
+    }
+    let out_path = scratch("san_fmt.hwpx");
+    let _ = std::fs::remove_file(&out_path);
+    let args = [
+        "edit",
+        "sanitize",
+        src.to_str().unwrap(),
+        "-o",
+        out_path.to_str().unwrap(),
+        "--json",
+    ];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    let v = json_of(&args, &out);
+    assert_eq!(v["outputFormat"], "hwpx", "{v}");
+    assert_eq!(
+        document_text(&out_path),
+        document_text(&src),
+        "HWPX sanitize 가 본문을 바꿨습니다"
+    );
+}
+
+/// 없는 파일·알 수 없는 옵션은 stdout 을 오염시키지 않는다 (계약 봉투 규약).
+///
+/// 봉투 계약의 소비자는 `stdout` 을 통째로 `JSON.parse` 한다 — 실패 경로가 한 글자라도
+/// 흘리면 파서가 죽거나(운이 좋으면) 잘못 읽는다(운이 나쁘면).
+#[test]
+fn failure_paths_keep_stdout_empty() {
+    let sample_path = repo(SAMPLE);
+    let sample = sample_path.to_str().expect("샘플 경로");
+    let cases: [(Vec<&str>, i32); 6] = [
+        (
+            vec!["edit", "redact", "없는파일.hwp", "-o", "x.hwp", "--json"],
+            1,
+        ),
+        (vec!["edit", "sanitize", "없는파일.hwp", "--json"], 1),
+        (
+            vec!["edit", "redact", sample, "--kind", "없는종류", "--json"],
+            2,
+        ),
+        (vec!["edit", "sanitize", sample, "--없는옵션"], 2),
+        // -o 와 --in-place 동시 지정은 산출 경로가 모호하다.
+        (
+            vec!["edit", "redact", sample, "-o", "x.hwp", "--in-place"],
+            2,
+        ),
+        // 입력 파일 두 개는 어느 쪽을 지울지 알 수 없다.
+        (vec!["edit", "redact", sample, sample, "--in-place"], 2),
+    ];
+    for (args, want) in cases {
+        let out = run(&args);
+        assert_eq!(out.status.code(), Some(want), "{}", describe(&args, &out));
+        assert!(
+            out.stdout.is_empty(),
+            "실패 경로 stdout 오염: {}",
+            describe(&args, &out)
+        );
+    }
+}
+
+/// 자기서술 — capabilities/MCP 에 두 명령이 배선되어 있어야 에이전트가 쓸 수 있다.
+#[test]
+fn capabilities_and_mcp_declare_both_commands() {
+    let cap: serde_json::Value =
+        serde_json::from_slice(&run(&["capabilities"]).stdout).expect("capabilities JSON");
+    let edit = cap["commands"]
+        .as_array()
+        .expect("commands")
+        .iter()
+        .find(|c| c["name"] == "edit")
+        .expect("edit 항목");
+    let flags: Vec<&str> = edit["flags"]
+        .as_array()
+        .expect("flags")
+        .iter()
+        .filter_map(|f| f.as_str())
+        .collect();
+    for flag in ["--kind", "--mask", "--in-place", "--keep-preview"] {
+        assert!(
+            flags.contains(&flag),
+            "commands[edit].flags 에 {flag} 누락: {flags:?}"
+        );
+    }
+
+    let mcp: serde_json::Value =
+        serde_json::from_slice(&run(&["capabilities", "--mcp"]).stdout).expect("mcp JSON");
+    let tools = mcp["tools"].as_array().expect("tools");
+    for name in ["hwp_redact", "hwp_sanitize"] {
+        let tool = tools
+            .iter()
+            .find(|t| t["name"] == name)
+            .unwrap_or_else(|| panic!("{name} 도구 누락"));
+        assert_eq!(tool["inputSchema"]["type"], "object", "{tool}");
+        assert!(tool["inputSchema"]["required"].is_array(), "{tool}");
+        assert_eq!(tool["cli"]["command"], "edit", "{tool}");
+    }
+
+    // 사람이 보는 --help 에도 두 하위 명령이 있어야 한다(기계·사람 자기서술 동기).
+    let help = String::from_utf8_lossy(&run(&["--help"]).stdout).to_string();
+    for line in ["edit redact", "edit sanitize"] {
+        assert!(help.contains(line), "--help 에 '{line}' 이 없습니다");
+    }
+}


### PR DESCRIPTION
#3719 §6-11. 공개 전 개인정보·메타데이터를 지운다.

| 명령 | |
|---|---|
| `rhwp edit redact <파일> [--kind ssn\|phone\|email\|card\|all] [--mask 문자] [--dry-run] [--verify] [--in-place]` | 개인정보 마스킹 |
| `rhwp edit sanitize <파일> [--keep-preview]` | 문서 메타데이터 제거 |

## 오탐이 이 작업의 승부처다

**탐지가 틀리면 문서가 훼손된다.** 되돌릴 수 없는 작업이라 더 그렇다.
그래서 **체크섬을 통과하지 못하면 마스킹하지 않는다** — 주민번호는 mod 11, 카드는 Luhn.

같은 문서에 유효값 4개와 **미끼 2개**를 함께 심어 실증했다:

| 심은 값 | 결과 |
|---|---|
| `900101-1234567` (mod 11 불일치) | **미탐지** — 마스킹 후에도 본문에 **원문 보존** |
| `1234-5678-9012-3456` (Luhn 합 64) | **미탐지** — 원문 보존 |
| 유효값 4개 (주민·카드·전화·이메일) | 전부 **자릿수 유지** 마스킹 |

`redactedCount 4`, `changedPages [0]`, `--verify identical:true`.
**자릿수를 유지하는 이유**: 길이가 바뀌면 레이아웃이 흔들린다.

## 원본 보호

되돌릴 수 없는 작업이라 **`-o` 도 `--in-place` 도 없으면 exit 2 로 거부**한다.
실측: exit 2 + stdout 0바이트 + **원본 md5 불변**.

## `sanitize`

무엇을 지웠는지 봉투에 `removed[]` 로 남긴다 — 조용히 지우면 감사가 불가능하다.
HWP5 `removedCount 10` → 재실행 **0**, HWPX `3` → 재실행 **0**(멱등).
**본문은 건드리지 않는다** — 전 페이지 텍스트 동일(HWP5 3쪽 · HWPX 23쪽) 확인.

## 검증

`redact_sanitize_contract` **11** + `cli_json_contract` **26** + `mcp_server_contract` **22** +
`pii_scan` 단위 **15** = **74 passed / 0 failed**.
`clippy -D warnings` **0**(`manual_is_multiple_of` 4건 수정 후) · rustfmt clean ·
선검사(#3795) **전부 통과**(도구 27 · 명령 54 · 플래그 65 · 미배선 0 · 실패경로 stdout 0바이트).

## 넣지 않은 것 — 전부 "오탐 0" 원칙 때문이다

- **02 외 지역번호**(031·051…) — `0XX-XXX-XXXX` 는 회계 코드·접수번호와 구별할 근거가 없다.
  실문서 오탐을 실측한 뒤 별도 이슈에서 판단
- **13·14·19자리 카드** — 자릿수를 넓힐수록 Luhn 만으로는 **1/10 우연 통과**가 그대로 오탐이 된다
- **여권번호·계좌번호·주소** — 체크섬이 없거나 기관마다 형태가 달라 보수적 판정이 불가능.
  넣으면 "오탐 0" 원칙 자체가 무너진다
- **DocumentSummaryInformation** — 실측 샘플에서 발견되지 않아 제외

## 알려둘 것 — `--dry-run` 봉투의 `raw`

`findings[].raw` 는 **원문 개인정보 그대로**다. 무엇을 지울지 먼저 보여주는 것이 이 명령의
권장 흐름이고 감사 목적상 로드맵 명세대로 넣었지만, **그 자체가 유출 경로**이기도 하다.
help · MCP 도구 설명 · 매뉴얼 **세 곳에 "로그에 남기지 말 것" 경고**를 달았다.
`--no-raw` 옵션은 v1 범위 밖으로 두었고 README 에 후보로 기록했다.
