### PR TITLE
[#3719 §6-4·6-8] export-plan-schema + 조건부 step — 스키마↔실행기 정렬을 외부 검증기로 교차 확인

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod ooxml_chart;
 pub mod paint;
 pub mod parser;
 pub mod password_crypto;
+pub mod plan_schema;
 pub mod provenance;
 pub mod renderer;
 pub mod serializer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1365,7 +1365,7 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
         // 문서를 열지 않는 무상태 도구이므로 hwp_export_provenance_map 처럼 입력이 없다.
         tool_with_optional_args(
             "hwp_export_agent_manifest",
-            "capabilities·export-ir-schema·export-provenance-map(있으면 export-plan-schema)의 산출을 한 번의 호출로 조립해 돌려준다. 처음 붙는 에이전트의 부트스트랩 왕복을 줄이는 용도. 아직 없는 축은 필드를 넣지 않고 missingAxes 로 무엇이 빠졌는지 밝힌다.",
+            "capabilities·export-ir-schema·export-provenance-map·export-plan-schema 의 산출을 한 번의 호출로 조립해 돌려준다. 처음 붙는 에이전트의 부트스트랩 왕복을 줄이는 용도. 아직 없는 축이 생기면 필드를 넣지 않고 missingAxes 로 무엇이 빠졌는지 밝힌다.",
             serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -1379,7 +1379,7 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
             "export-agent-manifest",
             serde_json::json!(["export-agent-manifest", "--json"]),
             serde_json::json!([{ "when": "bare", "args": ["--bare"] }]),
-            &["schemaVersion", "capabilities", "irSchema", "provenanceMap", "missingAxes"],
+            &["schemaVersion", "capabilities", "irSchema", "provenanceMap", "planSchema", "missingAxes"],
         ),
         // [#3719 §6-11] 공개 전 정리 — 되돌릴 수 없는 쓰기라 dryRun 이 1차 흐름이다.
         tool_with_optional_args(
@@ -1726,15 +1726,15 @@ fn capabilities_command_entries() -> Vec<serde_json::Value> {
                 "commands",
             ],
         ),
-        // [#3828 B2] capabilities·export-ir-schema·export-provenance-map(·있으면
-        // export-plan-schema)을 한 봉투로 묶는다 — 처음 붙는 에이전트의 왕복 4회를 1회로.
+        // [#3828 B2] capabilities·export-ir-schema·export-provenance-map·export-plan-schema
+        // 를 한 봉투로 묶는다 — 처음 붙는 에이전트의 왕복 4회를 1회로.
         cmd_json(
             "export-agent-manifest",
             "query",
-            "capabilities+irSchema+provenanceMap(+planSchema, 있으면)을 한 번의 호출로 조립 — 누락 축은 missingAxes 로 명시 (#3828 B2)",
+            "capabilities+irSchema+provenanceMap+planSchema 를 한 번의 호출로 조립 — 누락 축이 생기면 missingAxes 로 명시 (#3828 B2)",
             false,
             &["--json", "--bare"],
-            &["schemaVersion", "capabilities", "irSchema", "provenanceMap", "missingAxes"],
+            &["schemaVersion", "capabilities", "irSchema", "provenanceMap", "planSchema", "missingAxes"],
         ),
         cmd(
             "mcp-serve",
@@ -13723,14 +13723,14 @@ fn cmd_export_capabilities_schema(args: &[String]) -> i32 {
     EXIT_OK
 }
 
-/// [#3828 B2] `export-agent-manifest` 조립 코어 — capabilities·irSchema·provenanceMap
-/// (그리고 있으면 planSchema)을 왕복 1회로 묶는다.
+/// [#3828 B2] `export-agent-manifest` 조립 코어 — capabilities·irSchema·provenanceMap·
+/// planSchema 를 왕복 1회로 묶는다.
 ///
 /// 각 서브필드는 해당 명령의 기존 산출 함수를 그대로 불러 조립만 한다 — 스키마·지도
-/// 로직을 여기서 다시 만들지 않는다. `planSchema` 축(#3808 `export-plan-schema`)은
-/// 이 브랜치 시점에 아직 병합되지 않아 필드를 넣지 않고, 대신 `missingAxes` 로
-/// 무엇이 빠졌는지 기계가 읽게 명시한다 — null 로 채우면 "값이 비었다"와 "명령이
-/// 아직 없다"를 소비자가 구분할 수 없다.
+/// 로직을 여기서 다시 만들지 않는다. `missingAxes` 는 네 축이 모두 실린 지금 빈
+/// 배열이지만 필드 자체는 남긴다 — 앞으로 축이 늘 때 "아직 없는 축"을 이 배열로
+/// 알리는 것이 B2 의 계약이고, null 로 채우면 "값이 비었다"와 "명령이 아직 없다"를
+/// 소비자가 구분할 수 없다.
 fn agent_manifest_value(bare: bool) -> serde_json::Value {
     let mut fields = serde_json::Map::new();
     fields.insert(
@@ -13745,9 +13745,10 @@ fn agent_manifest_value(bare: bool) -> serde_json::Value {
             "export-provenance-map",
         ),
     );
-    // planSchema: `export-plan-schema`(#3808)가 이 시점에 아직 없다 — 있으면 여기서
-    // rhwp::plan_schema 류 함수를 불러 필드를 채우고 missingAxes 에서 뺀다.
-    fields.insert("missingAxes".to_string(), serde_json::json!(["planSchema"]));
+    // [#3808] planSchema 축 — irSchema 처럼 bare 본문을 싣는다. 본문이 `$id`·
+    // `planSchemaVersion` 을 자체 내장하므로 봉투 메타를 중복하지 않는다.
+    fields.insert("planSchema".to_string(), rhwp::plan_schema::plan_schema());
+    fields.insert("missingAxes".to_string(), serde_json::json!([]));
 
     if bare {
         return serde_json::Value::Object(fields);
@@ -13794,7 +13795,7 @@ fn cmd_export_agent_manifest(args: &[String]) -> i32 {
     println!("  capabilities     포함");
     println!("  irSchema         포함");
     println!("  provenanceMap    포함");
-    println!("  planSchema       없음 — export-plan-schema(#3808) 미병합");
+    println!("  planSchema       포함");
     println!();
     println!("기계 계약은 --json 을 쓰세요 (--bare 로 최상위 표지 없이).");
     EXIT_OK

--- a/src/main.rs
+++ b/src/main.rs
@@ -340,6 +340,8 @@ fn main() {
         Some("explain") => exit_with(explain_document(&args[2..])),
         Some("edit") => exit_with(run_edit(&args[2..])),
         Some("run") => exit_with(cmd_run_plan(&args[2..])),
+        // [#3719 §6-4] 계획을 *만드는* 쪽의 정답지 — `run` 바로 옆에 둔다.
+        Some("export-plan-schema") => exit_with(cmd_export_plan_schema(&args[2..])),
         // [#2707] 알 수 없는 명령·명령 누락은 사용법 오류다. 표준 CLI 관례대로 stderr 로 안내하고
         // 종료 코드 2로 끝낸다(기존에는 stdout + 0이라 오타 낸 명령이 스크립트에서 성공으로 보였다).
         other => {
@@ -1457,20 +1459,40 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
         ),
         tool(
             "hwp_run_plan",
-            "[#3703] 선언적 편집 계획(JSON)을 정적 선검증→원자 실행→저널로 수행한다. 도구 호출을 체이닝하는 대신 의도를 계획서 하나로 선언하면, 전 step 의 실행 가능성을 미리 판정하고(불가 시 실행 0·invalid[]·exit 2) 인메모리로 적용해 단언(verify 자기검증) 통과 시에만 단 한 번 저장한다 — 실패 시 디스크 무변경. fill_fields step 은 화면상 구별되지 않는 필드 이름을 steps[].confusable 로 경고한다. steps: fill_fields{data} · replace_text{find,replace[,occurrence]} · set_cell{table,row,col,text[,keepStyle]} · set_checkbox{occurrence}.",
+            "[#3703] 선언적 편집 계획(JSON)을 정적 선검증→원자 실행→저널로 수행한다. 도구 호출을 체이닝하는 대신 의도를 계획서 하나로 선언하면, 전 step 의 실행 가능성을 미리 판정하고(불가 시 실행 0·invalid[]·exit 2) 인메모리로 적용해 단언(verify 자기검증) 통과 시에만 단 한 번 저장한다 — 실패 시 디스크 무변경. fill_fields step 은 화면상 구별되지 않는 필드 이름을 steps[].confusable 로 경고한다. steps: fill_fields{data} · replace_text{find,replace[,occurrence]} · set_cell{table,row,col,text[,keepStyle]} · set_checkbox{occurrence}. [#3719 §6-8] 각 step 은 선택 필드 if 로 조건을 달 수 있고(fieldExists·fieldEquals·textFound), 조건이 거짓이면 그 step 만 건너뛰며 저널에 skipped:true 로 남는다. 계획서의 정확한 문법은 hwp_export_plan_schema 로 먼저 받아 보라.",
             serde_json::json!({
                 "type": "object",
                 "properties": {
                     "plan": {
                         "type": "object",
-                        "description": "계획서. { planVersion:\"1.0\", input:<원본 경로>, output:<산출 경로>, steps:[{action:…}…], assertions:{ notFoundEmpty?, verify? }, dryRun?:true } — dryRun:true 면 선검증만 하고 preview 저널을 낸다(디스크 무변경). 계획을 실행 전에 검사할 때 쓴다."
+                        "description": "계획서. { planVersion:\"1.0\", input:<원본 경로>, output:<산출 경로>, steps:[{action:…, if?:{…}}…], assertions:{ notFoundEmpty?, verify? }, dryRun?:true } — dryRun:true 면 선검증만 하고 preview 저널을 낸다(디스크 무변경). 계획을 실행 전에 검사할 때 쓴다. 전체 JSON Schema 는 hwp_export_plan_schema 참조"
                     }
                 },
                 "required": ["plan"],
             }),
             "run",
             serde_json::json!(["run", "--plan-json", "{plan}", "--json"]),
-            &["schemaVersion", "planVersion", "input", "output", "outputFormat", "steps", "steps[].confusable", "verify", "invalid", "changedPages", "dryRun", "preview"],
+            &["schemaVersion", "planVersion", "input", "output", "outputFormat", "steps", "steps[].confusable", "steps[].skipped", "verify", "invalid", "changedPages", "dryRun", "preview"],
+        ),
+        tool_with_optional_args(
+            "hwp_export_plan_schema",
+            "[#3719 §6-4] hwp_run_plan 이 받는 **계획서 자체**의 JSON Schema 를 돌려준다. hwp_run_plan 이 계획을 실행한다면 이 도구는 계획을 어떻게 쓰는지 알려준다 — step 4종의 필수·선택 필드, 조건절 if 의 문법, assertions 의 뜻이 판별 유니온으로 적혀 있다. 계획을 처음 만들 때 한 번 받아 두면 필드명을 지어내 invalid[] 로 되돌아오는 왕복을 없앨 수 있다. 문서를 입력으로 받지 않는다(계획서 문법의 서술이지 특정 문서의 속성이 아니다).",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "bare": {
+                        "type": "boolean",
+                        "description": "참이면 봉투 없이 계획 스키마 본문만 (JSON Schema 검증기에 바로 먹일 때)"
+                    }
+                },
+                // 문서를 받지 않으므로 필수 인자가 없다 — 그래도 빈 배열을 선언한다.
+                // 소비자가 required 의 부재와 "필수 없음"을 구분할 수 없으면 안 된다.
+                "required": [],
+            }),
+            "export-plan-schema",
+            serde_json::json!(["export-plan-schema", "--json"]),
+            serde_json::json!([{ "when": "bare", "args": ["--bare"] }]),
+            &["schemaVersion", "planSchemaVersion", "dialect", "definitionCount", "schema"],
         ),
         tool_with_optional_args(
             "hwp_export_capabilities_schema",
@@ -1653,6 +1675,23 @@ fn capabilities_command_entries() -> Vec<serde_json::Value> {
                 "steps",
                 "verify",
                 "invalid",
+            ],
+        ),
+        // [#3719 §6-4] 계획서 문법의 단일 출처 — `run` 바로 뒤에 둔다. 계획을 실행하는
+        // 명령과 계획을 쓰는 법을 알려주는 명령이 자기서술에서도 붙어 있어야 에이전트가
+        // 하나를 보고 다른 하나를 놓치지 않는다.
+        cmd_json(
+            "export-plan-schema",
+            "export",
+            "계획서(run) 문법의 JSON Schema 산출 — 계획 생성의 단일 출처 (#3719 §6-4)",
+            false,
+            &["--json", "--bare", "-o"],
+            &[
+                "schemaVersion",
+                "planSchemaVersion",
+                "dialect",
+                "definitionCount",
+                "schema",
             ],
         ),
         cmd_json(
@@ -3051,7 +3090,17 @@ fn print_help() {
     println!("             · set_cell{{table,row,col,text}} · set_checkbox{{occurrence}}");
     println!("      --plan-json '<JSON>'      파일 대신 인라인 계획 (MCP hwp_run_plan 경로)");
     println!("      --dry-run                 선검증만 — preview 저널, 디스크 무변경 (계획서 dryRun:true 와 동일)");
+    println!("      step 마다 if 조건 가능: {{fieldExists}}·{{fieldEquals:{{name,value}}}}·{{textFound}}");
+    println!("      조건이 거짓이면 그 step 만 건너뛰고 저널에 skipped:true·reason 으로 남긴다");
+    println!("      (거짓인 step 은 선검증도 면제 — 없는 필드를 채우는 step 도 위반이 아니다)");
     println!("      단언 실패는 exit 3 — 저널(steps[]·verify)로 판정을 데이터로 보고");
+    println!();
+    println!("  export-plan-schema [--bare] [-o <파일>] [--json]");
+    println!("      run 계획서 문법의 JSON Schema 출력 — 계획을 쓰기 전에 읽는 정답지");
+    println!();
+    println!("      --bare                  봉투 없이 계획 스키마 본문만 출력");
+    println!("      -o, --out <파일>        스키마를 파일로 저장 (생략 시 stdout)");
+    println!("      --json                  -o 와 함께 쓰면 저장 결과를 JSON 봉투로 보고");
     println!();
     println!("내부 개발·회귀 도구 (일반 사용자 대상 아님):");
     println!("  test-caption <파일.hwp> [-o <폴더>] 캡션 라운드트립 검증");
@@ -13534,6 +13583,79 @@ fn cmd_export_ir_schema(args: &[String]) -> i32 {
     EXIT_OK
 }
 
+/// [#3719 §6-4] `export-plan-schema` — `run` 계획서 문법의 JSON Schema 를 낸다.
+///
+/// 문서를 입력으로 받지 않는다 — 스키마는 **계획서 문법의 자기서술**이지 특정 문서의
+/// 속성이 아니다. `run --json` 이 이미 쓴 계획을 검사한다면, 이 명령은 계획을 **쓰기
+/// 전에** 읽는 정답지다. 필드명을 지어내고 `invalid[]` 로 되돌아오는 왕복이 계획 생성
+/// 실패의 대부분이라, 그 왕복을 없애는 것이 목적이다.
+fn cmd_export_plan_schema(args: &[String]) -> i32 {
+    let mut out_path: Option<&str> = None;
+    let mut json_mode = false;
+    let mut bare = false;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => json_mode = true,
+            // 봉투 없이 스키마 본문만 — JSON Schema 검증기에 바로 먹이려는 용도.
+            "--bare" => bare = true,
+            "-o" | "--out" => {
+                i += 1;
+                match args.get(i) {
+                    Some(v) => out_path = Some(v.as_str()),
+                    None => {
+                        eprintln!("오류: -o 뒤에 출력 경로가 필요합니다.");
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            other => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {}", other);
+                return EXIT_USAGE;
+            }
+        }
+        i += 1;
+    }
+
+    let payload = if bare {
+        rhwp::plan_schema::plan_schema()
+    } else {
+        rhwp::plan_schema::envelope()
+    };
+    let text = match serde_json::to_string_pretty(&payload) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("오류: 스키마 직렬화 실패 - {}", e);
+            return EXIT_RUNTIME;
+        }
+    };
+
+    if let Some(path) = out_path {
+        if let Err(e) = fs::write(path, text.as_bytes()) {
+            eprintln!("오류: 스키마를 쓸 수 없습니다 - {}: {}", path, e);
+            return EXIT_RUNTIME;
+        }
+        if json_mode {
+            // 파일로 뺐어도 stdout 은 기계 계약을 유지한다 — 어디에 썼는지 알려준다.
+            println!(
+                "{}",
+                serde_json::json!({
+                    "schemaVersion": "1.0",
+                    "planSchemaVersion": rhwp::plan_schema::PLAN_SCHEMA_VERSION,
+                    "output": path,
+                    "bytes": text.len(),
+                })
+            );
+        } else {
+            println!("계획 스키마 저장: {} ({} bytes)", path, text.len());
+        }
+        return EXIT_OK;
+    }
+
+    println!("{text}");
+    EXIT_OK
+}
+
 /// [#3776] `export-capabilities-schema` — capabilities 자체의 JSON Schema 를 낸다.
 fn cmd_export_capabilities_schema(args: &[String]) -> i32 {
     let mut out_path: Option<&str> = None;
@@ -13747,22 +13869,47 @@ fn cmd_run_plan(args: &[String]) -> i32 {
     if json_mode {
         println!("{}", journal);
     } else if code == EXIT_OK && journal["dryRun"] == true {
+        let preview_all = journal["preview"].as_array().cloned().unwrap_or_default();
+        // [#3719 §6-8] 건너뛸 step 은 "실행 가능"에 넣지 않는다 — dry-run 이 예고하는
+        // 실행 개수와 run(실제 실행)이 보고할 적용 개수가 같은 말을 해야 한다.
+        let skipped_count = preview_all.iter().filter(|s| s["skipped"] == true).count();
         println!(
-            "검사 통과: {} step 실행 가능 (디스크 무변경, 산출 예정 {})",
-            journal["preview"].as_array().map(|s| s.len()).unwrap_or(0),
+            "검사 통과: {} step 실행 가능{} (디스크 무변경, 산출 예정 {})",
+            preview_all.len() - skipped_count,
+            if skipped_count == 0 {
+                String::new()
+            } else {
+                format!(" · {} step 건너뜀 예정", skipped_count)
+            },
             journal["output"].as_str().unwrap_or("-")
         );
-        if let Some(preview) = journal["preview"].as_array() {
-            for step in preview {
-                println!("  - {}", preview_line(step));
-            }
+        for step in &preview_all {
+            println!("  - {}", preview_line(step));
         }
     } else if code == EXIT_OK {
+        // [#3719 §6-8] 건너뛴 step 을 적용한 것과 같이 세면 "다 됐다"는 보고가 거짓이 된다.
+        let skipped: Vec<&serde_json::Value> = journal["steps"]
+            .as_array()
+            .map(|steps| steps.iter().filter(|s| s["skipped"] == true).collect())
+            .unwrap_or_default();
+        let total = journal["steps"].as_array().map(|s| s.len()).unwrap_or(0);
         println!(
-            "완료: {} step 적용, 산출 {}",
-            journal["steps"].as_array().map(|s| s.len()).unwrap_or(0),
+            "완료: {} step 적용{}, 산출 {}",
+            total - skipped.len(),
+            if skipped.is_empty() {
+                String::new()
+            } else {
+                format!(" · {} step 건너뜀", skipped.len())
+            },
             journal["output"].as_str().unwrap_or("-")
         );
+        for step in &skipped {
+            println!(
+                "  - step {} 건너뜀: {}",
+                step["step"].as_u64().unwrap_or(0),
+                step["reason"].as_str().unwrap_or("")
+            );
+        }
         if let Some(steps) = journal["steps"].as_array() {
             for step in steps {
                 if let Some(confusable) = step["confusable"].as_array() {
@@ -13785,6 +13932,14 @@ fn cmd_run_plan(args: &[String]) -> i32 {
 /// [#3721] dry-run 미리보기 한 줄 — 사람 모드에서 "무엇이 얼마나 바뀌나"를 읽게 한다.
 fn preview_line(step: &serde_json::Value) -> String {
     let idx = step["step"].as_u64().unwrap_or(0);
+    // [#3719 §6-8] 건너뛸 step 은 다른 필드가 비어 있으므로 액션별 분기보다 먼저 본다.
+    if step["skipped"] == true {
+        return format!(
+            "step {} 건너뜀 예정: {}",
+            idx,
+            step["reason"].as_str().unwrap_or("")
+        );
+    }
     match step["action"].as_str().unwrap_or("") {
         "fill_fields" => format!(
             "step {}: 누름틀 {}칸 채움",
@@ -13872,6 +14027,10 @@ fn run_plan_engine(plan: &serde_json::Value) -> (serde_json::Value, i32) {
     // [#3712] 같은 순회에서 문단 주소도 담는다 — 저널 changedPages 산출 근거.
     let mut name_locs: std::collections::HashMap<String, Vec<(usize, usize)>> =
         std::collections::HashMap::new();
+    // [#3719 §6-8] 조건절 fieldEquals 가 볼 **현재 값**. 같은 순회에서 담아 두면
+    // 조건 판정이 문서를 다시 훑지 않는다(동명 필드는 선언 순서 = 순번 순서).
+    let mut name_values: std::collections::HashMap<String, Vec<String>> =
+        std::collections::HashMap::new();
     for fi in doc.collect_all_fields().iter() {
         if let Some(n) = fi.field.field_name() {
             *name_counts.entry(n.to_string()).or_insert(0) += 1;
@@ -13879,6 +14038,10 @@ fn run_plan_engine(plan: &serde_json::Value) -> (serde_json::Value, i32) {
                 .entry(n.to_string())
                 .or_default()
                 .push((fi.location.section_index, fi.location.para_index));
+            name_values
+                .entry(n.to_string())
+                .or_default()
+                .push(fi.value.clone());
         }
     }
     // `edit fill-fields`·세션 경로와 같은 text-security 판정이다. 계획 실행만
@@ -13889,8 +14052,49 @@ fn run_plan_engine(plan: &serde_json::Value) -> (serde_json::Value, i32) {
     // [#3721] 선검증이 이미 계산한 값을 미리보기로 모은다 — dry-run 은 이걸 그대로 낸다.
     // (실행 모드에서는 쓰이지 않지만, 판정자와 미리보기가 같은 계산이라 어긋날 수 없다.)
     let mut preview: Vec<serde_json::Value> = Vec::new();
+
+    // [#3719 §6-8] 조건부 step — 조건은 **입력 문서 기준으로 실행 전에 한 번** 판정한다.
+    // 실행 중에 다시 보면 선검증이 통과시킨 step 이 실행에서 조건을 잃는(또는 그 반대)
+    // 상태가 생겨, "무엇이 왜 안 바뀌었는지"가 저널만 봐서는 재구성되지 않는다.
+    // 판정 결과는 Some(사유) = 건너뜀, None = 실행.
+    let mut skip_reasons: Vec<Option<String>> = Vec::with_capacity(steps.len());
+    for step in steps.iter() {
+        match step.get("if") {
+            None => skip_reasons.push(None),
+            Some(condition) => {
+                match evaluate_step_condition(condition, &doc, &name_counts, &name_values) {
+                    Ok(reason) => skip_reasons.push(reason),
+                    Err(_) => {
+                        // 문법 오류는 아래 선검증 루프에서 다시 판정해 invalid 에 담는다
+                        // (사유 메시지를 한 곳에서만 만들기 위함) — 여기서는 자리만 채운다.
+                        skip_reasons.push(None);
+                    }
+                }
+            }
+        }
+    }
+
     for (idx, step) in steps.iter().enumerate() {
         let action = step["action"].as_str().unwrap_or("");
+        // [#3719 §6-8] 조건 문법 오류는 계획 자체가 무효다 — invalid 로 즉시 보고한다.
+        if let Some(condition) = step.get("if") {
+            if let Err(message) =
+                evaluate_step_condition(condition, &doc, &name_counts, &name_values)
+            {
+                invalid
+                    .push(serde_json::json!({ "step": idx, "action": action, "reason": message }));
+                continue;
+            }
+        }
+        // 조건이 거짓인 step 은 **실행 가능성 검사를 면제**한다. 없는 필드를 채우는
+        // step 이라도 애초에 실행되지 않으므로 위반이 아니다 — 여기서 걸러 내지 않으면
+        // 조건절은 "쓸 수는 있으나 쓰면 계획이 통과하지 않는" 장식이 된다.
+        if let Some(reason) = &skip_reasons[idx] {
+            preview.push(serde_json::json!({
+                "step": idx, "action": action, "skipped": true, "reason": reason,
+            }));
+            continue;
+        }
         match action {
             "fill_fields" => {
                 let Some(data) = step["data"].as_object() else {
@@ -14057,6 +14261,14 @@ fn run_plan_engine(plan: &serde_json::Value) -> (serde_json::Value, i32) {
     let mut changed_paras: Vec<(usize, usize)> = Vec::new();
     for (idx, step) in steps.iter().enumerate() {
         let action = step["action"].as_str().unwrap_or("");
+        // [#3719 §6-8] 건너뛴 step 도 저널에 남긴다. 조용히 사라지면 소비자는 "왜 그
+        // 칸이 안 바뀌었는지"를 알 방법이 없다 — 조건이 거짓이었다는 사실 자체가 결과다.
+        if let Some(reason) = &skip_reasons[idx] {
+            journal_steps.push(serde_json::json!({
+                "step": idx, "action": action, "skipped": true, "reason": reason,
+            }));
+            continue;
+        }
         match action {
             "fill_fields" => {
                 let data = step["data"].as_object().expect("선검증 통과");
@@ -14266,6 +14478,115 @@ fn run_plan_engine(plan: &serde_json::Value) -> (serde_json::Value, i32) {
         ),
         EXIT_OK,
     )
+}
+
+/// [#3719 §6-8] step 조건절 판정 — `Ok(None)` = 조건 참(실행), `Ok(Some(사유))` =
+/// 조건 거짓(건너뜀), `Err(사유)` = 조건 **문법** 오류(계획 자체가 무효).
+///
+/// 거짓과 문법 오류를 같은 축으로 접으면 오타 하나가 "조건이 거짓이었다"로 둔갑해
+/// 계획이 조용히 아무 일도 하지 않고 성공을 보고한다. 그래서 두 축을 나눈다 —
+/// 거짓은 정상 판정(exit 0, skipped 저널), 문법 오류는 `invalid` + exit 2 다.
+///
+/// 판정은 **입력 문서** 기준이다. 앞 step 의 편집 결과를 조건이 보게 하면 선검증(실행 전)
+/// 과 실행(편집 후)이 서로 다른 답을 낼 수 있고, 그러면 "검사를 통과한 계획이 실행에서
+/// 다르게 동작"한다.
+fn evaluate_step_condition(
+    condition: &serde_json::Value,
+    doc: &rhwp::wasm_api::HwpDocument,
+    name_counts: &std::collections::HashMap<String, usize>,
+    name_values: &std::collections::HashMap<String, Vec<String>>,
+) -> Result<Option<String>, String> {
+    let Some(map) = condition.as_object() else {
+        return Err(
+            "if 는 { fieldExists | fieldEquals | textFound } 중 하나를 담은 객체여야 합니다"
+                .to_string(),
+        );
+    };
+    // 조건 두 개를 나열하면 and 인지 or 인지가 계획서 어디에도 적혀 있지 않다.
+    // 추측해서 실행하는 대신 거절한다 — 되돌릴 수 없는 쓰기의 전제 조건이다.
+    if map.len() != 1 {
+        return Err(format!(
+            "if 는 조건을 정확히 하나만 담아야 합니다 (현재 {}개: {}) — 둘 이상은 and/or 가 정의돼 있지 않습니다",
+            map.len(),
+            map.keys().cloned().collect::<Vec<_>>().join(", ")
+        ));
+    }
+    let (key, value) = map.iter().next().expect("길이 1");
+    match key.as_str() {
+        "fieldExists" => {
+            let Some(spec) = value.as_str().filter(|s| !s.is_empty()) else {
+                return Err(
+                    "if.fieldExists 는 비어 있지 않은 필드 이름 문자열이어야 합니다".to_string(),
+                );
+            };
+            let (name, occurrence) = parse_field_key(spec);
+            let total = name_counts.get(name).copied().unwrap_or(0);
+            if occurrence < total {
+                Ok(None)
+            } else {
+                Ok(Some(format!(
+                    "조건 fieldExists '{}' 불충족 — 문서의 동명 누름틀 {}개",
+                    spec, total
+                )))
+            }
+        }
+        "fieldEquals" => {
+            let Some(operand) = value.as_object() else {
+                return Err(
+                    "if.fieldEquals 는 {\"name\":<필드 이름>, \"value\":<비교값>} 객체여야 합니다"
+                        .to_string(),
+                );
+            };
+            if let Some(unknown) = operand
+                .keys()
+                .find(|k| k.as_str() != "name" && k.as_str() != "value")
+            {
+                return Err(format!(
+                    "if.fieldEquals 에 알 수 없는 키: {} (name·value 만 받습니다)",
+                    unknown
+                ));
+            }
+            let (Some(spec), Some(expected)) = (
+                operand.get("name").and_then(|v| v.as_str()),
+                operand.get("value").and_then(|v| v.as_str()),
+            ) else {
+                return Err("if.fieldEquals 의 name·value 는 둘 다 문자열이어야 합니다".to_string());
+            };
+            if spec.is_empty() {
+                return Err("if.fieldEquals 의 name 이 비어 있습니다".to_string());
+            }
+            let (name, occurrence) = parse_field_key(spec);
+            match name_values.get(name).and_then(|v| v.get(occurrence)) {
+                Some(actual) if actual == expected => Ok(None),
+                Some(actual) => Ok(Some(format!(
+                    "조건 fieldEquals '{}' == '{}' 불충족 — 현재값 '{}'",
+                    spec, expected, actual
+                ))),
+                None => Ok(Some(format!(
+                    "조건 fieldEquals '{}' == '{}' 불충족 — 해당 누름틀이 없습니다",
+                    spec, expected
+                ))),
+            }
+        }
+        "textFound" => {
+            let Some(needle) = value.as_str().filter(|s| !s.is_empty()) else {
+                return Err("if.textFound 는 비어 있지 않은 문자열이어야 합니다".to_string());
+            };
+            // 한 건만 확인하면 되므로 limit 1 — 존재 판정에 전건 수집은 낭비다.
+            if doc.grep(needle, true, Some(1)).is_empty() {
+                Ok(Some(format!(
+                    "조건 textFound '{}' 불충족 — 본문에서 찾지 못했습니다",
+                    needle
+                )))
+            } else {
+                Ok(None)
+            }
+        }
+        other => Err(format!(
+            "알 수 없는 조건: {} (fieldExists·fieldEquals·textFound)",
+            other
+        )),
+    }
 }
 
 /// `edit_serialize` 와 같은 바이트를 내되 **IR 을 건드리지 않는다**.

--- a/src/main.rs
+++ b/src/main.rs
@@ -13618,9 +13618,12 @@ fn cmd_export_plan_schema(args: &[String]) -> i32 {
     }
 
     let payload = if bare {
+        // --bare 는 JSON Schema 검증기에 그대로 먹이는 본문이다 — 봉투 표지를 섞지 않는다.
         rhwp::plan_schema::plan_schema()
     } else {
-        rhwp::plan_schema::envelope()
+        // [#3787 S1] "표지는 항상 실린다" — 문서를 열지 않는 명령의 봉투도
+        // untrustedContent:false 를 명시한다는 것이 capabilities 의 선언이다.
+        provenance::marked(rhwp::plan_schema::envelope(), "export-plan-schema")
     };
     let text = match serde_json::to_string_pretty(&payload) {
         Ok(t) => t,
@@ -13639,12 +13642,15 @@ fn cmd_export_plan_schema(args: &[String]) -> i32 {
             // 파일로 뺐어도 stdout 은 기계 계약을 유지한다 — 어디에 썼는지 알려준다.
             println!(
                 "{}",
-                serde_json::json!({
-                    "schemaVersion": "1.0",
-                    "planSchemaVersion": rhwp::plan_schema::PLAN_SCHEMA_VERSION,
-                    "output": path,
-                    "bytes": text.len(),
-                })
+                provenance::marked(
+                    serde_json::json!({
+                        "schemaVersion": "1.0",
+                        "planSchemaVersion": rhwp::plan_schema::PLAN_SCHEMA_VERSION,
+                        "output": path,
+                        "bytes": text.len(),
+                    }),
+                    "export-plan-schema"
+                )
             );
         } else {
             println!("계획 스키마 저장: {} ({} bytes)", path, text.len());

--- a/src/plan_schema.rs
+++ b/src/plan_schema.rs
@@ -1,0 +1,672 @@
+//! [#3719 §6-4] `export-plan-schema` — 계획서(`rhwp run`)의 JSON Schema 를 기계 산출한다.
+//!
+//! `run --json` 이 계획을 **검사**한다면 이 스키마는 계획을 **만드는** 쪽의 정답지다.
+//! 에이전트는 지금까지 계획서의 모양을 도구 설명 한 문단(`hwp_run_plan.description`)에서
+//! 역추론했다. 한 문단은 "무엇이 필수인지"·"어떤 값이 허용되는지"를 담지 못하므로,
+//! 모델은 그럴듯한 필드명을 지어내고 실행기는 그때서야 `invalid[]` 로 되돌려보낸다.
+//! 왕복 한 번이 실패 한 번이다 — 계획을 **쓰기 전에** 읽을 수 있는 계약이 필요하다.
+//!
+//! ## 왜 손으로 쓰는가
+//!
+//! `run_plan_engine` 은 계획서를 `serde_json::Value` 로 직접 읽는다(파생할 타입이 없다).
+//! 실제 계획 예시에서 역추론하면 "그 예시가 마침 쓰지 않은 선택 필드"가 계약에서 통째로
+//! 빠진다(`caseSensitive`·`keepStyle`·`occurrence` 가 그런 부류다). 여기 적은 목록이
+//! 곧 "우리가 계획 생성기에게 약속하는 계획서 표면"이며, 판정자(`run_plan_engine`)의
+//! 선검증 분기와 1:1로 대응한다.
+//!
+//! ## 판별 유니온
+//!
+//! step 4종은 `action` 을 판별자로 하는 `oneOf` 다. 각 분기가 `action` 을 `const` 로
+//! 고정하므로 정확히 하나만 통과한다 — 소비자(코드 생성기)는 이 모양을 태그드 유니온으로
+//! 그대로 옮길 수 있다.
+//!
+//! ## 열린 객체와 닫힌 객체
+//!
+//! 계획서 본체·step 은 `additionalProperties: true`(추가-전용 진화)다. 반면 **조건절은
+//! 닫혀 있다** — 실행기가 모르는 조건 키를 `invalid` 로 거부하기 때문이다. 스키마가
+//! 실행기보다 관대하면 "스키마는 통과하는데 실행은 거부하는" 계획이 생기고, 그건
+//! 계약이 아니라 함정이다.
+//!
+//! ## 버저닝
+//!
+//! `planSchemaVersion` 은 봉투 `schemaVersion` 과 **분리**된 계획서 문법의 버전이다.
+//! 필드 추가 = minor, 의미 변경·삭제 = major. 계획서 자신이 싣는 `planVersion` 과도
+//! 다른 축이다(`planVersion` 은 계획서가 선언하는 값, 이쪽은 스키마 문서의 판번호).
+
+use serde_json::{json, Value};
+
+/// 계획 스키마 버전. 봉투 schemaVersion·계획서 planVersion 과 독립적으로 진화한다.
+pub const PLAN_SCHEMA_VERSION: &str = "1.0";
+
+/// 계획서가 선언해야 하는 `planVersion` 값 — 실행기가 이 값만 받는다.
+const REQUIRED_PLAN_VERSION: &str = "1.0";
+
+/// JSON Schema draft — 소비자(코드 생성기)가 파서를 고를 수 있게 명시한다.
+const SCHEMA_DIALECT: &str = "https://json-schema.org/draft/2020-12/schema";
+
+/// `$defs` 참조 하나.
+fn r(name: &str) -> Value {
+    json!({ "$ref": format!("#/$defs/{name}") })
+}
+
+/// 설명이 달린 `$defs` 참조. 2020-12 는 `$ref` 옆 키워드를 허용하므로, 참조라는 이유로
+/// 설명을 잃지 않는다 — 참조된 정의의 일반 설명과 "이 자리에서의 뜻"은 다른 정보다.
+fn r_doc(name: &str, description: &str) -> Value {
+    json!({ "$ref": format!("#/$defs/{name}"), "description": description })
+}
+
+/// 설명이 달린 원시 타입.
+fn prim(ty: &str, description: &str) -> Value {
+    json!({ "type": ty, "description": description })
+}
+
+/// 값이 고정된 문자열 — 판별 유니온의 판별자와 버전 상수에 쓴다.
+fn constant(value: &str, description: &str) -> Value {
+    json!({ "type": "string", "const": value, "description": description })
+}
+
+/// 0 이상 정수 — 순번·표 좌표는 음수를 가질 수 없다.
+fn uint(description: &str) -> Value {
+    json!({ "type": "integer", "minimum": 0, "description": description })
+}
+
+/// 배열 타입. `min_items` 로 "비어 있으면 무의미한 배열"을 스키마 수준에서 막는다.
+fn array_of(items: Value, min_items: usize, description: &str) -> Value {
+    json!({
+        "type": "array",
+        "items": items,
+        "minItems": min_items,
+        "description": description,
+    })
+}
+
+/// 열린 객체 — 필수 필드를 명시하되 추가 필드를 허용한다.
+///
+/// `additionalProperties: true` 는 의도적이다. 계획서는 **추가-전용 진화** 계약이라
+/// 새 선택 필드가 붙어도 기존 계획서가 계속 유효해야 한다. false 로 두면 step 종류를
+/// 하나 늘릴 때마다 예전 스키마를 든 생성기가 전부 동시에 거짓 위반을 낸다.
+fn object(properties: Value, required: &[&str], description: &str) -> Value {
+    json!({
+        "type": "object",
+        "description": description,
+        "properties": properties,
+        "required": required,
+        "additionalProperties": true,
+    })
+}
+
+/// 닫힌 객체 — 선언되지 않은 키를 거부한다.
+///
+/// 실행기가 모르는 키를 거부하는 자리에만 쓴다(조건절). 스키마가 실행기보다 관대하면
+/// 통과하는 계획이 실행에서 거부되고, 소비자는 어느 쪽을 믿어야 할지 알 수 없다.
+fn closed_object(properties: Value, required: &[&str], description: &str) -> Value {
+    json!({
+        "type": "object",
+        "description": description,
+        "properties": properties,
+        "required": required,
+        "additionalProperties": false,
+    })
+}
+
+// ── 계획서 봉투 ──────────────────────────────────────────────────────────
+
+fn plan_def() -> Value {
+    object(
+        json!({
+            "planVersion": constant(
+                REQUIRED_PLAN_VERSION,
+                "계획서 문법 판번호. 실행기는 \"1.0\" 만 받고 그 밖의 값은 exit 2 로 거절한다.",
+            ),
+            "input": prim("string", "원본 문서 경로 (HWP/HWPX/HML). 실행기는 이 파일을 읽기만 한다."),
+            "output": prim(
+                "string",
+                "산출 경로. 전 step 이 인메모리로 적용되고 단언을 통과한 뒤 **단 한 번** 여기에 쓴다. \
+                 확장자가 산출 형식을 정한다(생략 시 입력 형식 보존).",
+            ),
+            "steps": array_of(
+                r("Step"),
+                1,
+                "적용할 편집 목록. 선언 순서대로 인메모리에 적용된다. 비어 있으면 exit 2 — \
+                 아무것도 하지 않는 계획은 의도가 아니라 실수다.",
+            ),
+            "assertions": r_doc(
+                "Assertions",
+                "저장 전에 통과해야 하는 단언. 생략하면 기본값으로 판정한다.",
+            ),
+            "dryRun": json!({
+                "type": "boolean",
+                "default": false,
+                "description": "참이면 선검증만 하고 저장하지 않는다(디스크 무변경). 저널 대신 \
+                                preview[] 를 낸다 — 각 항목은 step·action 에 더해 조건이 거짓이면 \
+                                skipped:true·reason 을 싣는다. `run --dry-run` 플래그와 동등하다.",
+            }),
+        }),
+        &["planVersion", "input", "output", "steps"],
+        "`rhwp run` 이 받는 편집 계획서. 도구 호출을 체이닝하는 대신 의도 하나를 선언하면 \
+         실행기가 전 step 의 실행 가능성을 먼저 판정하고(불가 시 실행 0·exit 2), \
+         인메모리 원자 실행 뒤 단언 통과 시에만 저장한다.",
+    )
+}
+
+fn assertions_def() -> Value {
+    object(
+        json!({
+            "notFoundEmpty": json!({
+                "type": "boolean",
+                "default": true,
+                "description": "지목한 대상이 하나도 빠지지 않았음을 요구한다. 선검증이 구조적으로 \
+                                보장하므로(없는 대상은 실행 전에 invalid) 저널에 계약 표기로 실린다.",
+            }),
+            "verify": json!({
+                "type": "boolean",
+                "default": false,
+                "description": "저장 직전 산출 바이트를 다시 읽어 인메모리 IR 과 대조한다. \
+                                차이가 있으면 exit 3 이고 **디스크는 무변경**이다.",
+            }),
+        }),
+        &[],
+        "사후 단언 — 실패하면 저장하지 않는다. 계획이 스스로 검증 조건을 들고 다니게 해서 \
+         \"성공했다고 보고했는데 산출물이 깨진\" 상태를 구조적으로 없앤다.",
+    )
+}
+
+// ── step 판별 유니온 ─────────────────────────────────────────────────────
+
+fn step_def() -> Value {
+    json!({
+        "description": "편집 step 하나. `action` 이 판별자인 태그드 유니온이며, 4종 전부 \
+                        선택 필드 `if`(조건절)를 받는다.",
+        "oneOf": [
+            r("FillFieldsStep"),
+            r("ReplaceTextStep"),
+            r("SetCellStep"),
+            r("SetCheckboxStep"),
+        ],
+    })
+}
+
+/// step 분기 하나를 만든다.
+///
+/// `action`(판별자)과 `if`(조건절)를 **여기서 한 번만** 붙인다. 분기마다 손으로 적으면
+/// 새 step 종류가 조건절을 빠뜨린 채 추가될 수 있다 — 4종 전부가 조건을 받는다는 것이
+/// §6-8 의 계약이므로 그 사실을 조립 지점에 고정한다.
+fn step_variant(
+    action: &str,
+    action_doc: &str,
+    extra: Value,
+    required: &[&str],
+    doc: &str,
+) -> Value {
+    let mut properties = serde_json::Map::new();
+    properties.insert("action".to_string(), constant(action, action_doc));
+    if let Some(map) = extra.as_object() {
+        for (key, value) in map {
+            properties.insert(key.clone(), value.clone());
+        }
+    }
+    // `if` 는 JSON Schema 키워드이기도 하지만 여기서는 `properties` 아래의 **이름**이라
+    // 충돌하지 않는다. 계획서가 쓰는 실제 키가 `if` 이므로 다른 이름을 쓸 수 없다.
+    properties.insert(
+        "if".to_string(),
+        r_doc(
+            "StepCondition",
+            "선택 조건. 거짓이면 이 step 을 건너뛰고 저널에 skipped:true 로 남긴다. \
+             거짓인 step 은 선검증에서도 면제된다(없는 필드를 채우는 step 이라도 위반이 아니다).",
+        ),
+    );
+    let mut required_all = vec!["action".to_string()];
+    required_all.extend(required.iter().map(|s| s.to_string()));
+    object(
+        Value::Object(properties),
+        &required_all.iter().map(String::as_str).collect::<Vec<_>>(),
+        doc,
+    )
+}
+
+fn fill_fields_step_def() -> Value {
+    step_variant(
+        "fill_fields",
+        "누름틀(필드)에 값을 채우는 step 임을 지목한다.",
+        json!({
+            "data": json!({
+                "type": "object",
+                "description": "필드 이름 → 채울 값. 같은 이름이 여러 번 나오는 서식은 \
+                                `이름[순번]`(0 기준)으로 지목한다(예: \"피규제집단명[13]\"). \
+                                순번 없이 이름만 주면 첫 칸을 채우고 저널의 ambiguous 로 알린다.",
+                "additionalProperties": {
+                    "type": ["string", "number", "boolean"],
+                    "description": "채울 값. 문자열이 아니면 JSON 표기 그대로 문자열화해 넣는다.",
+                },
+            }),
+        }),
+        &["data"],
+        "누름틀 채우기 (메일머지). 화면상 구별되지 않는 이름의 쌍둥이 필드가 있으면 채우되 \
+         저널의 `confusable` 로 반드시 보고한다.",
+    )
+}
+
+fn replace_text_step_def() -> Value {
+    step_variant(
+        "replace_text",
+        "본문 문자열을 치환하는 step 임을 지목한다.",
+        json!({
+            "find": json!({
+                "type": "string",
+                "minLength": 1,
+                "description": "찾을 문자열. 빈 문자열은 거부한다(문서 전체를 뜻하게 되므로).",
+            }),
+            "replace": prim("string", "바꿔 넣을 문자열. 빈 문자열이면 삭제다."),
+            "caseSensitive": json!({
+                "type": "boolean",
+                "default": true,
+                "description": "대소문자를 구별할지. 기본은 구별한다.",
+            }),
+            "occurrence": uint(
+                "0 기준 일치 순번. 주면 그 한 건만, 생략하면 전건을 치환한다. \
+                 범위를 벗어나면 선검증에서 거부한다.",
+            ),
+        }),
+        &["find", "replace"],
+        "문자열 치환 (기관명 변경·연도 갱신·용어 정비). 일치 0건이면 선검증에서 거부한다 \
+         — 조용히 0건 치환을 성공으로 보고하지 않는다.",
+    )
+}
+
+fn set_cell_step_def() -> Value {
+    step_variant(
+        "set_cell",
+        "표 한 칸의 내용을 바꾸는 step 임을 지목한다.",
+        json!({
+            "table": uint("0 기준 표 번호 (문서 순서)."),
+            "row": json!({
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 65535,
+                "description": "0 기준 행 번호. HWP 격자 주소는 u16 이라 65535 를 넘으면 거부한다.",
+            }),
+            "col": json!({
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 65535,
+                "description": "0 기준 열 번호. HWP 격자 주소는 u16 이라 65535 를 넘으면 거부한다.",
+            }),
+            "text": json!({
+                "type": "string",
+                // 실행기가 \r·\n·\t 를 선검증에서 거부한다 — 스키마도 같은 말을 해야
+                // 검증기를 통과한 계획이 실행에서 막히지 않는다.
+                "pattern": "^[^\r\n\t]*$",
+                "description": "칸에 기록할 한 줄 값. 줄바꿈·탭은 거부한다(칸 구조가 깨지므로).",
+            }),
+            "keepStyle": json!({
+                "type": "boolean",
+                "default": false,
+                "description": "참이면 기존 글자색을 유지한다. 기본은 검정으로 바꾼다 \
+                                — 서식 안내문의 회색 예시 글자를 그대로 두면 제출본에 남는다.",
+            }),
+        }),
+        &["table", "row", "col", "text"],
+        "표 칸 기록. 좌표는 실행 시점에 다시 해석하므로 앞 step 의 편집으로 밀린 표도 안전하다. \
+         병합으로 덮인 칸은 앵커 좌표 안내와 함께 거부한다.",
+    )
+}
+
+fn set_checkbox_step_def() -> Value {
+    step_variant(
+        "set_checkbox",
+        "빈 체크박스를 표시하는 step 임을 지목한다.",
+        json!({
+            "occurrence": uint(
+                "0 기준 빈 체크박스(□) 순번. 범위를 벗어나면 선검증에서 거부한다.",
+            ),
+        }),
+        &["occurrence"],
+        "체크박스 표시 — 문서의 n 번째 빈 체크박스 □ 를 ☑ 로 바꾼다.",
+    )
+}
+
+// ── 조건절 (§6-8) ────────────────────────────────────────────────────────
+
+fn step_condition_def() -> Value {
+    let mut def = closed_object(
+        json!({
+            "fieldExists": prim(
+                "string",
+                "그 이름의 누름틀이 문서에 있으면 참. `이름[순번]`(0 기준)으로 특정 순번의 \
+                 존재를 물을 수도 있다 — 동명 필드가 몇 개인지에 따라 참·거짓이 갈린다.",
+            ),
+            "fieldEquals": r_doc(
+                "FieldEqualsCondition",
+                "지목한 누름틀의 **현재 값**이 주어진 값과 정확히 같으면 참.",
+            ),
+            "textFound": prim(
+                "string",
+                "그 문자열이 본문에 한 건이라도 있으면 참 (대소문자 구별).",
+            ),
+        }),
+        &[],
+        "step 조건절. 정확히 한 종류만 쓴다 — 두 조건을 함께 주면 and 인지 or 인지가 \
+         계획서에 적혀 있지 않으므로 거부한다. 판정은 **입력 문서 기준으로 실행 전에 한 번** \
+         이루어지며, 앞 step 의 편집 결과가 뒤 step 의 조건을 바꾸지 않는다 \
+         (선검증과 실행이 같은 판정을 보게 하기 위한 것이다).",
+    );
+    // 실행기는 조건 **개수**를 세어 둘 이상이면 거부한다. 스키마가 그 말을 하지 않으면
+    // 검증기를 통과한 계획이 실행에서 막힌다 — 설명문에 적는 것만으로는 부족하다.
+    if let Some(map) = def.as_object_mut() {
+        map.insert("minProperties".to_string(), json!(1));
+        map.insert("maxProperties".to_string(), json!(1));
+    }
+    def
+}
+
+// ── dry-run 미리보기 (§6-11) ─────────────────────────────────────────────
+
+fn preview_step_def() -> Value {
+    object(
+        json!({
+            "step": uint("0 기준 step 순번 — 계획서 steps[] 의 인덱스와 같다. 건너뛴 step 도 \
+                          자리를 지키므로 저널 항목과 계획서 항목을 순번으로 짝지을 수 있다."),
+            "action": prim(
+                "string",
+                "그 step 의 action (fill_fields·replace_text·set_cell·set_checkbox 중 하나).",
+            ),
+            "skipped": json!({
+                "type": "boolean",
+                "description": "참이면 `if` 조건이 거짓이라 이 step 은 실행되지 않는다 — 선검증도 \
+                                면제된다. 거짓(또는 생략)이면 정상적으로 실행 가능하다고 판정된 것이다.",
+            }),
+            "reason": prim(
+                "string",
+                "`skipped` 가 참일 때만 실리는 사유 — 어느 조건이 왜 거짓이었는지. 실행 가능한 \
+                 step 에는 없다.",
+            ),
+        }),
+        &["step", "action"],
+        "`dryRun:true` 저널의 `preview[]` 원소 하나. `skipped` 가 없거나 거짓이면 그 step 은 실제 \
+         실행에서도 적용될 것이라는 뜻이고, 참이면 `reason` 과 함께 건너뛸 것이라는 뜻이다 — \
+         dry-run 이 예고하는 실행 개수와 `run`(실제 실행)이 보고할 적용 개수가 같은 말을 하도록 한다.",
+    )
+}
+
+fn field_equals_condition_def() -> Value {
+    closed_object(
+        json!({
+            "name": prim(
+                "string",
+                "누름틀 이름. `이름[순번]`(0 기준)으로 동명 필드 중 하나를 지목할 수 있다.",
+            ),
+            "value": prim("string", "비교할 값. 문자열 완전 일치로만 판정한다."),
+        }),
+        &["name", "value"],
+        "`fieldEquals` 의 피연산자 — 어떤 필드의 값이 무엇과 같은지.",
+    )
+}
+
+// ── 조립 ─────────────────────────────────────────────────────────────────
+
+/// `$defs` 의 정의 수 — 봉투가 규모를 미리 알리는 데 쓴다.
+fn definition_count(schema: &Value) -> usize {
+    schema
+        .get("$defs")
+        .and_then(|d| d.as_object())
+        .map(|o| o.len())
+        .unwrap_or(0)
+}
+
+/// `rhwp run` 계획서 전체의 JSON Schema.
+pub fn plan_schema() -> Value {
+    // 정의가 늘면 json! 매크로 재귀 한도에 걸린다 — 맵으로 조립한다.
+    let defs: serde_json::Map<String, Value> = [
+        ("Plan", plan_def()),
+        ("Assertions", assertions_def()),
+        ("Step", step_def()),
+        ("FillFieldsStep", fill_fields_step_def()),
+        ("ReplaceTextStep", replace_text_step_def()),
+        ("SetCellStep", set_cell_step_def()),
+        ("SetCheckboxStep", set_checkbox_step_def()),
+        ("StepCondition", step_condition_def()),
+        ("FieldEqualsCondition", field_equals_condition_def()),
+        ("PreviewStep", preview_step_def()),
+    ]
+    .into_iter()
+    .map(|(name, def)| (name.to_string(), def))
+    .collect();
+
+    json!({
+        "$schema": SCHEMA_DIALECT,
+        "$id": "https://github.com/edwardkim/rhwp/schema/plan/1.0",
+        "title": "rhwp 편집 계획서",
+        "planSchemaVersion": PLAN_SCHEMA_VERSION,
+        "description":
+            "`rhwp run` 이 실행하는 선언적 편집 계획서의 공개 계약. 계획을 **만드는** 쪽이 \
+             읽는 문서다 — 필수·선택 필드와 허용 값이 실행기의 선검증 분기와 1:1로 대응한다. \
+             진화 규약: 필드 추가 = minor, 의미 변경·삭제 = major.",
+        "$ref": "#/$defs/Plan",
+        // 표준 JSON Schema 키워드가 아니지만(x- 접두어 벤더 확장), `dryRun:true` 저널의
+        // `preview[]` 원소 모양을 이 스키마 문서 안에서 가리킬 유일한 자리다 — Plan 자체는
+        // 입력을 서술하고 preview 는 출력이라, Plan.properties 안에 넣으면 "계획서가
+        // 받는 필드"로 오독된다. $ref 를 여기 두면 정의 도달성 검사(고아 $defs 없음)도
+        // 그대로 통과한다.
+        "x-dryRunPreview": r_doc(
+            "PreviewStep",
+            "`dryRun:true` 로 실행했을 때 저널의 `preview[]` 배열 원소 하나의 모양. 입력 \
+             계획서가 받는 필드가 아니라 실행기가 돌려주는 저널의 계약이다.",
+        ),
+        "$defs": defs,
+    })
+}
+
+/// `export-plan-schema` 봉투 — 스키마 본문과 메타를 함께 싣는다.
+///
+/// `definitionCount` 는 소비자가 코드 생성 규모를 먼저 가늠하고, 스키마가 통째로 비는
+/// 회귀를 한 숫자로 잡게 한다.
+pub fn envelope() -> Value {
+    let schema = plan_schema();
+    let def_count = definition_count(&schema);
+    json!({
+        "schemaVersion": "1.0",
+        "planSchemaVersion": PLAN_SCHEMA_VERSION,
+        "dialect": SCHEMA_DIALECT,
+        "definitionCount": def_count,
+        "schema": schema,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 닫힌 객체와 그 사유 — 사유 없는 예외는 허용목록이 아니라 구멍이다.
+    const CLOSED_DEFS: &[(&str, &str)] = &[
+        (
+            "StepCondition",
+            "실행기가 모르는 조건 키를 invalid 로 거부한다 — 스키마가 더 관대하면 통과한 계획이 실행에서 막힌다",
+        ),
+        (
+            "FieldEqualsCondition",
+            "피연산자가 name·value 둘뿐이다 — 셋째 키는 뜻이 정의돼 있지 않다",
+        ),
+    ];
+
+    #[test]
+    fn schema_has_root_and_defs() {
+        let schema = plan_schema();
+        assert_eq!(schema["$ref"], "#/$defs/Plan");
+        assert!(schema["$defs"]["Plan"].is_object());
+        assert!(schema["$defs"]["StepCondition"].is_object());
+    }
+
+    #[test]
+    fn every_ref_resolves_to_a_definition() {
+        // 끊어진 $ref 는 코드 생성기를 즉시 망가뜨린다 — 스키마의 최소 건전성이다.
+        let schema = plan_schema();
+        let defs = schema["$defs"].as_object().expect("$defs");
+        let mut missing = Vec::new();
+        collect_refs(&schema, &mut |name| {
+            if !defs.contains_key(name) {
+                missing.push(name.to_string());
+            }
+        });
+        assert!(missing.is_empty(), "정의되지 않은 참조: {missing:?}");
+    }
+
+    #[test]
+    fn definitions_are_reachable_from_root() {
+        // 아무도 가리키지 않는 정의는 죽은 계약이다.
+        let schema = plan_schema();
+        let defs = schema["$defs"].as_object().expect("$defs");
+        let mut referenced = std::collections::HashSet::new();
+        referenced.insert("Plan".to_string());
+        collect_refs(&schema, &mut |name| {
+            referenced.insert(name.to_string());
+        });
+        let orphans: Vec<&String> = defs.keys().filter(|k| !referenced.contains(*k)).collect();
+        assert!(orphans.is_empty(), "아무도 참조하지 않는 정의: {orphans:?}");
+    }
+
+    #[test]
+    fn objects_are_open_unless_listed_with_a_reason() {
+        // 추가-전용 진화 계약: step 종류가 늘어도 기존 계획서가 깨지면 안 된다.
+        // 닫아야 하는 자리는 사유와 함께 CLOSED_DEFS 에 등재한다.
+        let schema = plan_schema();
+        let defs = schema["$defs"].as_object().expect("$defs");
+        for (name, def) in defs {
+            if def["type"] != "object" {
+                continue;
+            }
+            let closed = CLOSED_DEFS.iter().find(|(n, _)| n == name);
+            match closed {
+                Some((_, why)) => {
+                    assert_eq!(
+                        def["additionalProperties"], false,
+                        "{name} 은 닫힌 객체로 등재됐는데 실제로는 열려 있다 ({why})"
+                    );
+                }
+                None => assert_eq!(
+                    def["additionalProperties"], true,
+                    "{name} 이 추가 필드를 막고 있다 — 계획서는 추가-전용 진화다. \
+                     정말 닫아야 하면 CLOSED_DEFS 에 사유와 함께 등재하라"
+                ),
+            }
+        }
+        for (name, why) in CLOSED_DEFS {
+            assert!(defs.contains_key(*name), "낡은 CLOSED_DEFS 항목: {name}");
+            assert!(!why.trim().is_empty(), "{name} 의 닫은 사유가 비었습니다");
+        }
+    }
+
+    #[test]
+    fn step_union_is_discriminated_by_action() {
+        // 판별자가 없으면 oneOf 는 소비자에게 "넷 중 뭔지 직접 알아내라"는 말이다.
+        let schema = plan_schema();
+        let variants = schema["$defs"]["Step"]["oneOf"]
+            .as_array()
+            .expect("Step.oneOf");
+        assert_eq!(variants.len(), 4, "step 4종");
+        let mut actions = Vec::new();
+        for variant in variants {
+            let name = variant["$ref"]
+                .as_str()
+                .and_then(|p| p.strip_prefix("#/$defs/"))
+                .expect("oneOf 분기는 $defs 참조");
+            let def = &schema["$defs"][name];
+            let action = def["properties"]["action"]["const"]
+                .as_str()
+                .unwrap_or_else(|| panic!("{name} 에 action const 가 없다"));
+            assert!(
+                def["required"]
+                    .as_array()
+                    .expect("required")
+                    .iter()
+                    .any(|r| r == "action"),
+                "{name} 이 action 을 필수로 선언하지 않았다"
+            );
+            // 조건부 step 은 4종 전부의 계약이다 — 하나라도 빠지면 유니온이 거짓말한다.
+            assert!(
+                def["properties"]["if"]["$ref"] == "#/$defs/StepCondition",
+                "{name} 이 조건절 `if` 를 받지 않는다"
+            );
+            actions.push(action.to_string());
+        }
+        actions.sort();
+        assert_eq!(
+            actions,
+            ["fill_fields", "replace_text", "set_cell", "set_checkbox"]
+        );
+    }
+
+    #[test]
+    fn every_definition_and_property_carries_a_description() {
+        // 설명 없는 정의는 모델에게 없는 정의다 — 이름만으로는 무엇을 넣을지 알 수 없다.
+        let schema = plan_schema();
+        let mut missing = Vec::new();
+        for (name, def) in schema["$defs"].as_object().expect("$defs") {
+            check_described(def, name, &mut missing);
+        }
+        assert!(missing.is_empty(), "설명 없는 스키마 노드: {missing:?}");
+    }
+
+    #[test]
+    fn envelope_reports_definition_count() {
+        let env = envelope();
+        assert_eq!(env["schemaVersion"], "1.0");
+        assert_eq!(env["planSchemaVersion"], PLAN_SCHEMA_VERSION);
+        assert_eq!(env["dialect"], SCHEMA_DIALECT);
+        let count = env["definitionCount"].as_u64().expect("definitionCount");
+        assert!(count >= 9, "정의가 너무 적다: {count}");
+        assert_eq!(env["schema"]["$ref"], "#/$defs/Plan");
+    }
+
+    /// 스키마 노드와 그 하위 `properties` 가 전부 설명을 갖는지 본다.
+    /// 순수 `$ref` 노드(키가 `$ref` 하나뿐)는 참조된 정의가 설명을 갖고 있으므로 면제한다.
+    fn check_described(node: &Value, path: &str, missing: &mut Vec<String>) {
+        let Some(map) = node.as_object() else {
+            return;
+        };
+        let pure_ref = map.len() == 1 && map.contains_key("$ref");
+        if !pure_ref
+            && !map
+                .get("description")
+                .and_then(Value::as_str)
+                .is_some_and(|d| !d.trim().is_empty())
+        {
+            missing.push(path.to_string());
+        }
+        if let Some(props) = map.get("properties").and_then(Value::as_object) {
+            for (key, value) in props {
+                check_described(value, &format!("{path}.{key}"), missing);
+            }
+        }
+        // `additionalProperties` 가 스키마면 그것도 값의 계약이다.
+        if let Some(extra) = map.get("additionalProperties") {
+            if extra.is_object() {
+                check_described(extra, &format!("{path}.additionalProperties"), missing);
+            }
+        }
+    }
+
+    /// `$ref` 를 재귀 수집한다.
+    fn collect_refs(value: &Value, sink: &mut impl FnMut(&str)) {
+        match value {
+            Value::Object(map) => {
+                for (key, item) in map {
+                    if key == "$ref" {
+                        if let Some(path) = item.as_str() {
+                            if let Some(name) = path.strip_prefix("#/$defs/") {
+                                sink(name);
+                            }
+                        }
+                    } else {
+                        collect_refs(item, sink);
+                    }
+                }
+            }
+            Value::Array(items) => {
+                for item in items {
+                    collect_refs(item, sink);
+                }
+            }
+            _ => {}
+        }
+    }
+}

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -400,8 +400,13 @@ pub const MAP: &[CommandProvenance] = &[
     CommandProvenance {
         command: "export-agent-manifest",
         untrusted: NONE,
-        note: "문서를 열지 않는다 — capabilities·export-ir-schema·export-provenance-map \
-               (있으면 export-plan-schema)의 자기서술을 조립한 것뿐이다.",
+        note: "문서를 열지 않는다 — capabilities·export-ir-schema·export-provenance-map·\
+               export-plan-schema 의 자기서술을 조립한 것뿐이다.",
+    },
+    CommandProvenance {
+        command: "export-plan-schema",
+        untrusted: NONE,
+        note: "문서를 열지 않는다 — run 계획서 문법의 자기서술(JSON Schema)이다.",
     },
 ];
 

--- a/tests/agent_profile_router_contract.rs
+++ b/tests/agent_profile_router_contract.rs
@@ -291,15 +291,20 @@ fn every_stateless_tool_belongs_to_some_specific_profile() {
         }
     }
 
-    // [#3762/#3776/#3787/#3828] 자기서술(문서 IR·capabilities·출처지도·agent manifest)
-    // 스키마 도구 — 업무를
+    // [#3762/#3776/#3787/#3828/#3719] 자기서술(문서 IR·capabilities·출처지도·agent
+    // manifest·계획서 문법) 스키마 도구 — 업무를
     // 수행하는 직무가 아니라 외부 바인딩·코드 생성기 저자를 위한 개발자 도구이므로
     // 의도적으로 `개발통합`(필터 없음)에만 있고 특정 업무 프로필에는 없다.
+    //
+    // `hwp_export_plan_schema`(#3719 §6-4)도 같은 성격이다 — 문서를 입력으로 받지 않고
+    // `hwp_run_plan` 이 받는 계획서 **문법**을 서술한다. 계획을 실제로 수행하는
+    // `hwp_run_plan` 은 업무 프로필에 있고, 그 문법 설명서만 여기 남는다.
     let meta_only_by_design: std::collections::HashSet<&str> = [
         "hwp_export_ir_schema",
         "hwp_export_capabilities_schema",
         "hwp_export_provenance_map",
         "hwp_export_agent_manifest",
+        "hwp_export_plan_schema",
     ]
     .into_iter()
     .collect();

--- a/tests/plan_schema_contract.rs
+++ b/tests/plan_schema_contract.rs
@@ -1,0 +1,1133 @@
+//! [#3719 §6-4·§6-8] `export-plan-schema` 계약과 조건부 step.
+//!
+//! 스키마는 계획을 **만드는** 쪽이 읽는 문서다. 그래서 여기서 지키는 것은 두 가지다 —
+//! (1) 스키마 자체의 건전성(끊어진 참조·설명 없는 정의가 없을 것),
+//! (2) **스키마와 실행기가 같은 말을 할 것**. 스키마가 광고하는 action·조건을 실행기가
+//! 모르거나, 실행기가 아는 것을 스키마가 빠뜨리면 계획 생성기는 통과할 리 없는 계획을
+//! 자신 있게 만들어 낸다. 그 어긋남은 컴파일 에러도 런타임 오류도 내지 않는다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const SAMPLE: &str = "samples/field-01.hwp";
+
+fn sample() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp 실행")
+}
+
+fn temp_path(tag: &str, ext: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "rhwp-planschema-{tag}-{}-{}.{ext}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ))
+}
+
+/// 테스트가 중간에 죽어도 임시 산출물을 남기지 않는다.
+struct TempFileGuard(PathBuf);
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self(path)
+    }
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+fn schema_body() -> serde_json::Value {
+    let out = run(&["export-plan-schema", "--bare"]);
+    assert_eq!(out.status.code(), Some(0), "--bare 실행 실패");
+    serde_json::from_slice(&out.stdout).expect("스키마 본문 JSON")
+}
+
+/// 계획을 파일에 쓰고 `run --json` 으로 돌린 뒤 (종료 코드, 저널) 을 돌려준다.
+fn run_plan(tag: &str, plan: &serde_json::Value) -> (i32, serde_json::Value) {
+    let plan_path = TempFileGuard::new(temp_path(tag, "json"));
+    std::fs::write(plan_path.path(), serde_json::to_vec_pretty(plan).unwrap()).unwrap();
+    let output = run(&[
+        "run",
+        plan_path.path().to_str().expect("계획 경로 UTF-8"),
+        "--json",
+    ]);
+    let journal: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "저널 JSON 파싱 실패({e}). stdout: {} stderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (output.status.code().unwrap_or(-1), journal)
+}
+
+/// 샘플의 누름틀 (이름, 현재값) 목록 — 문서 순서 = 동명 필드의 순번 순서.
+///
+/// 이름·값을 테스트에 하드코딩하면 샘플이 바뀔 때 **조용히** 낡는다(그 테스트는 계속
+/// 통과하지만 아무것도 지키지 않게 된다). 실물에서 읽어 쓴다.
+fn sample_fields() -> Vec<(String, String)> {
+    let p = sample();
+    if !p.exists() {
+        return Vec::new();
+    }
+    let out = run(&["fields", p.to_str().unwrap(), "--json"]);
+    let Ok(v) = serde_json::from_slice::<serde_json::Value>(&out.stdout) else {
+        return Vec::new();
+    };
+    v["fields"]
+        .as_array()
+        .map(|fields| {
+            fields
+                .iter()
+                .filter_map(|f| {
+                    let name = f["name"].as_str().filter(|n| !n.is_empty())?;
+                    Some((
+                        name.to_string(),
+                        f["value"].as_str().unwrap_or("").to_string(),
+                    ))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// 샘플의 실제 누름틀 이름 하나.
+fn a_real_field_name() -> Option<String> {
+    sample_fields().into_iter().next().map(|(name, _)| name)
+}
+
+/// 샘플 본문 텍스트 전체 — `textFound` 조건의 사례를 실물에서 고르기 위한 것.
+fn sample_text() -> String {
+    let p = sample();
+    if !p.exists() {
+        return String::new();
+    }
+    let out = run(&["export-text", p.to_str().unwrap(), "--json"]);
+    let Ok(v) = serde_json::from_slice::<serde_json::Value>(&out.stdout) else {
+        return String::new();
+    };
+    v["pages"]
+        .as_array()
+        .map(|pages| {
+            pages
+                .iter()
+                .filter_map(|p| p["text"].as_str())
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default()
+}
+
+/// 계획 하나를 돌려 저널의 step 배열만 돌려준다 (exit 0 을 단언).
+fn journal_steps(tag: &str, steps: serde_json::Value) -> serde_json::Value {
+    let out = TempFileGuard::new(temp_path(tag, "hwp"));
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": sample().to_str().unwrap(),
+        "output": out.path().to_str().unwrap(),
+        "steps": steps,
+    });
+    let (code, journal) = run_plan(tag, &plan);
+    assert_eq!(code, 0, "계획이 실행되지 않았다: {journal}");
+    journal["steps"].clone()
+}
+
+// ── 1) 봉투·플래그 계약 ──────────────────────────────────────────────────
+
+#[test]
+fn envelope_carries_version_dialect_and_definition_count() {
+    let args = ["export-plan-schema"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{args:?}");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("봉투 JSON");
+    assert_eq!(v["schemaVersion"], "1.0", "{v}");
+    assert_eq!(v["planSchemaVersion"], "1.0", "{v}");
+    assert_eq!(
+        v["dialect"], "https://json-schema.org/draft/2020-12/schema",
+        "소비자가 파서를 고를 수 있어야 한다: {v}"
+    );
+    // 스키마가 통째로 비는 회귀를 숫자 하나로 잡는다.
+    let count = v["definitionCount"].as_u64().expect("definitionCount");
+    let defs = v["schema"]["$defs"].as_object().expect("$defs");
+    assert_eq!(
+        count as usize,
+        defs.len(),
+        "definitionCount 가 실제 정의 수와 다르다"
+    );
+    assert!(count >= 9, "정의가 너무 적다: {count}");
+}
+
+#[test]
+fn bare_emits_the_schema_body_without_the_envelope() {
+    let v = schema_body();
+    assert_eq!(v["$ref"], "#/$defs/Plan", "{v}");
+    assert!(v["$defs"]["Plan"].is_object());
+    assert!(
+        v.get("definitionCount").is_none(),
+        "--bare 는 봉투 키를 싣지 않는다 — JSON Schema 도구에 그대로 먹이는 용도다"
+    );
+}
+
+#[test]
+fn output_file_and_json_report() {
+    let out_file = TempFileGuard::new(temp_path("out", "json"));
+    let path = out_file.path().to_str().expect("경로 UTF-8").to_string();
+    let out = run(&["export-plan-schema", "-o", &path, "--json"]);
+    assert_eq!(out.status.code(), Some(0));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("저장 보고 봉투");
+    assert_eq!(v["output"], path.as_str(), "{v}");
+    let bytes = v["bytes"].as_u64().expect("bytes");
+    let written = std::fs::read(out_file.path()).expect("저장된 스키마");
+    assert_eq!(written.len() as u64, bytes, "보고한 크기와 실제가 다르다");
+    let parsed: serde_json::Value = serde_json::from_slice(&written).expect("저장본도 JSON");
+    assert_eq!(
+        parsed["definitionCount"].as_u64(),
+        parsed["schema"]["$defs"]
+            .as_object()
+            .map(|d| d.len() as u64),
+        "저장본이 반쪽만 쓰이면 여기서 걸린다: {parsed}"
+    );
+}
+
+#[test]
+fn unknown_option_is_usage_error_with_silent_stdout() {
+    let out = run(&["export-plan-schema", "--nope"]);
+    assert_eq!(out.status.code(), Some(2), "알 수 없는 옵션 = 사용법 오류");
+    assert!(
+        out.stdout.is_empty(),
+        "실패 경로의 stdout 은 0바이트여야 한다 — 파이프로 받는 쪽이 반쪽 JSON 을 먹으면 안 된다: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+// ── 2) 스키마 건전성 ─────────────────────────────────────────────────────
+
+#[test]
+fn every_ref_resolves_and_nothing_is_orphaned() {
+    let schema = schema_body();
+    let defs = schema["$defs"].as_object().expect("$defs");
+    let mut referenced = std::collections::HashSet::new();
+    referenced.insert("Plan".to_string());
+    let mut missing = Vec::new();
+    collect_refs(&schema, &mut |name| {
+        referenced.insert(name.to_string());
+        if !defs.contains_key(name) {
+            missing.push(name.to_string());
+        }
+    });
+    assert!(missing.is_empty(), "정의되지 않은 참조: {missing:?}");
+    let orphans: Vec<&String> = defs.keys().filter(|k| !referenced.contains(*k)).collect();
+    assert!(orphans.is_empty(), "아무도 참조하지 않는 정의: {orphans:?}");
+}
+
+#[test]
+fn every_definition_and_property_carries_a_description() {
+    // 설명 없는 정의는 모델에게 없는 정의다 — 이름만 보고 무엇을 넣을지 알 수 없다.
+    // 유닛 테스트와 겹치지만, 여기서는 **실제 바이너리가 낸 산출물**을 본다.
+    let schema = schema_body();
+    let mut missing = Vec::new();
+    for (name, def) in schema["$defs"].as_object().expect("$defs") {
+        check_described(def, name, &mut missing);
+    }
+    assert!(
+        missing.is_empty(),
+        "설명 없는 스키마 노드 {}건: {missing:?}",
+        missing.len()
+    );
+}
+
+// ── 3) 스키마 ↔ 실행기 드리프트 가드 ────────────────────────────────────
+
+#[test]
+fn schema_actions_are_exactly_what_the_engine_accepts() {
+    let p = sample();
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let schema = schema_body();
+    let variants = schema["$defs"]["Step"]["oneOf"]
+        .as_array()
+        .expect("Step.oneOf");
+    assert!(!variants.is_empty(), "분기가 0건이면 이 가드는 공허하다");
+
+    // 스키마가 광고하는 action 은 전부 실행기가 알아야 한다. 필드가 빠진 껍데기 step 을
+    // 보내 "왜 불가한지"만 본다 — 문서 내용을 몰라도 되는 판정이다.
+    for variant in variants {
+        let name = variant["$ref"]
+            .as_str()
+            .and_then(|r| r.strip_prefix("#/$defs/"))
+            .expect("oneOf 분기는 $defs 참조");
+        let action = schema["$defs"][name]["properties"]["action"]["const"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{name} 에 action const 가 없다"));
+        let out = TempFileGuard::new(temp_path(&format!("action-{action}"), "hwp"));
+        let plan = serde_json::json!({
+            "planVersion": "1.0",
+            "input": p.to_str().unwrap(),
+            "output": out.path().to_str().unwrap(),
+            "steps": [ { "action": action } ],
+        });
+        let (code, journal) = run_plan(&format!("action-{action}"), &plan);
+        assert_eq!(code, 2, "껍데기 step 은 선검증에서 걸린다: {journal}");
+        let reason = journal["invalid"][0]["reason"].as_str().unwrap_or("");
+        assert!(
+            !reason.contains("알 수 없는 action"),
+            "스키마가 광고하는 action '{action}' 을 실행기가 모른다: {reason}"
+        );
+    }
+
+    // 반대 방향 — 스키마에 없는 action 은 실행기도 거절해야 한다. 이쪽이 무너지면
+    // 스키마는 "표면 전체"가 아니라 "표면의 일부"가 되고, 소비자는 그 사실을 모른다.
+    let out = TempFileGuard::new(temp_path("action-unknown", "hwp"));
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": p.to_str().unwrap(),
+        "output": out.path().to_str().unwrap(),
+        "steps": [ { "action": "delete_page" } ],
+    });
+    let (code, journal) = run_plan("action-unknown", &plan);
+    assert_eq!(code, 2, "{journal}");
+    assert!(
+        journal["invalid"][0]["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("알 수 없는 action"),
+        "스키마에 없는 action 을 실행기가 받아들였다: {journal}"
+    );
+}
+
+#[test]
+fn schema_conditions_are_exactly_what_the_engine_accepts() {
+    let p = sample();
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let schema = schema_body();
+    let keys: Vec<String> = schema["$defs"]["StepCondition"]["properties"]
+        .as_object()
+        .expect("StepCondition.properties")
+        .keys()
+        .cloned()
+        .collect();
+    assert!(!keys.is_empty(), "조건이 0종이면 이 가드는 공허하다");
+    assert_eq!(
+        schema["$defs"]["StepCondition"]["additionalProperties"], false,
+        "조건절은 닫혀 있어야 한다 — 실행기가 모르는 키를 거절하기 때문이다"
+    );
+
+    for key in &keys {
+        // 각 조건이 **거짓**이 되는 사례를 만든다. 통과하면 (1) 실행기가 그 키를 알고
+        // (2) 거짓 판정이 skipped 저널로 나온다는 두 사실이 한 번에 증명된다.
+        let condition = match key.as_str() {
+            "fieldExists" => serde_json::json!({ "fieldExists": "이런누름틀은없다9999" }),
+            "fieldEquals" => serde_json::json!({
+                "fieldEquals": { "name": "이런누름틀은없다9999", "value": "값" }
+            }),
+            "textFound" => serde_json::json!({ "textFound": "이런문자열은문서에없다9999" }),
+            other => panic!(
+                "스키마에 새 조건 '{other}' 이 생겼는데 이 테스트에 거짓 사례가 없습니다 — \
+                 조건을 늘렸으면 여기도 늘리세요(그러지 않으면 새 조건은 검증 밖에 있습니다)"
+            ),
+        };
+        let out = TempFileGuard::new(temp_path(&format!("cond-{key}"), "hwp"));
+        let plan = serde_json::json!({
+            "planVersion": "1.0",
+            "input": p.to_str().unwrap(),
+            "output": out.path().to_str().unwrap(),
+            // 실행기가 조건을 몰랐다면 이 step 은 선검증에서 걸려 exit 2 가 된다.
+            "steps": [ { "action": "set_checkbox", "occurrence": 999999, "if": condition } ],
+        });
+        let (code, journal) = run_plan(&format!("cond-{key}"), &plan);
+        assert_eq!(
+            code, 0,
+            "조건 '{key}' 이 거짓이면 step 을 건너뛰고 선검증도 면제되어야 한다: {journal}"
+        );
+        let step = &journal["steps"][0];
+        assert_eq!(step["skipped"], true, "조건 '{key}': {journal}");
+        assert!(
+            step["reason"]
+                .as_str()
+                .is_some_and(|r| r.contains(key.as_str())),
+            "건너뛴 사유에 어떤 조건이었는지 남아야 한다 (조건 '{key}'): {journal}"
+        );
+    }
+
+    // 스키마에 없는 조건 키는 실행기도 거절해야 한다 (문법 오류 = invalid + exit 2).
+    let out = TempFileGuard::new(temp_path("cond-unknown", "hwp"));
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": p.to_str().unwrap(),
+        "output": out.path().to_str().unwrap(),
+        "steps": [ { "action": "set_checkbox", "occurrence": 0, "if": { "fieldMissing": "x" } } ],
+    });
+    let (code, journal) = run_plan("cond-unknown", &plan);
+    assert_eq!(code, 2, "{journal}");
+    assert!(
+        journal["invalid"][0]["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("알 수 없는 조건"),
+        "스키마에 없는 조건을 실행기가 받아들였다: {journal}"
+    );
+    assert!(
+        !out.path().exists(),
+        "조건 문법 오류는 실행 0 — 산출물이 생기면 안 된다"
+    );
+}
+
+// ── 4) 조건부 step 동작 (§6-8) ──────────────────────────────────────────
+
+#[test]
+fn false_condition_skips_the_step_and_exempts_prevalidation() {
+    let p = sample();
+    let Some(field) = a_real_field_name() else {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    };
+    let out = TempFileGuard::new(temp_path("exempt", "hwp"));
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": p.to_str().unwrap(),
+        "output": out.path().to_str().unwrap(),
+        "steps": [
+            { "action": "fill_fields", "data": { field.as_str(): "실행됨" } },
+            // 조건이 없으면 이 step 은 선검증 위반(없는 필드)이라 계획 전체가 exit 2 다.
+            // 조건이 거짓이므로 면제되어야 한다 — 여기가 §6-8 의 핵심 계약이다.
+            { "action": "fill_fields", "data": { "이런누름틀은없다9999": "값" },
+              "if": { "fieldExists": "이런누름틀은없다9999" } },
+        ],
+        "assertions": { "verify": true },
+    });
+    let (code, journal) = run_plan("exempt", &plan);
+    assert_eq!(code, 0, "거짓 조건 step 은 위반이 아니다: {journal}");
+    let steps = journal["steps"].as_array().expect("steps[]");
+    assert_eq!(steps.len(), 2, "건너뛴 step 도 저널에 남는다: {journal}");
+    assert_eq!(steps[0]["filledCount"], 1, "{journal}");
+    assert!(steps[0].get("skipped").is_none(), "{journal}");
+    assert_eq!(steps[1]["skipped"], true, "{journal}");
+    assert_eq!(steps[1]["step"], 1, "0 기준 step 번호 유지: {journal}");
+    assert_eq!(steps[1]["action"], "fill_fields", "{journal}");
+    assert!(
+        steps[1]["reason"].as_str().is_some_and(|r| !r.is_empty()),
+        "왜 건너뛰었는지 없이 사라지면 '왜 안 바뀌었는지' 를 알 수 없다: {journal}"
+    );
+    assert!(out.path().exists(), "나머지 step 은 정상 저장된다");
+}
+
+#[test]
+fn true_condition_runs_the_step() {
+    let p = sample();
+    let Some(field) = a_real_field_name() else {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    };
+    let out = TempFileGuard::new(temp_path("cond-true", "hwp"));
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": p.to_str().unwrap(),
+        "output": out.path().to_str().unwrap(),
+        "steps": [
+            { "action": "fill_fields", "data": { field.as_str(): "조건참" },
+              "if": { "fieldExists": field.as_str() } },
+        ],
+        "assertions": { "verify": true },
+    });
+    let (code, journal) = run_plan("cond-true", &plan);
+    assert_eq!(code, 0, "{journal}");
+    let step = &journal["steps"][0];
+    assert!(
+        step.get("skipped").is_none(),
+        "조건 참이면 실행한다: {journal}"
+    );
+    assert_eq!(step["filledCount"], 1, "{journal}");
+
+    // 왕복 재독 — 조건 참인 step 이 실제로 문서를 바꿨는가.
+    let fields = run(&["fields", out.path().to_str().unwrap(), "--json"]);
+    assert_eq!(fields.status.code(), Some(0));
+    assert!(
+        String::from_utf8_lossy(&fields.stdout).contains("조건참"),
+        "산출물 재독에 새 값이 없다"
+    );
+}
+
+#[test]
+fn human_mode_reports_skipped_steps_and_does_not_count_them_as_applied() {
+    let p = sample();
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let out = TempFileGuard::new(temp_path("human", "hwp"));
+    let plan_path = TempFileGuard::new(temp_path("human", "json"));
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": p.to_str().unwrap(),
+        "output": out.path().to_str().unwrap(),
+        "steps": [
+            { "action": "set_checkbox", "occurrence": 999999,
+              "if": { "textFound": "이런문자열은문서에없다9999" } },
+        ],
+    });
+    std::fs::write(plan_path.path(), serde_json::to_vec_pretty(&plan).unwrap()).unwrap();
+    let output = run(&["run", plan_path.path().to_str().unwrap()]);
+    assert_eq!(output.status.code(), Some(0));
+    let text = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        text.contains("0 step 적용"),
+        "건너뛴 step 을 적용한 것처럼 세면 '다 됐다'는 보고가 거짓이 된다: {text}"
+    );
+    assert!(
+        text.contains("건너뜀"),
+        "사람 모드에도 근거를 남긴다: {text}"
+    );
+}
+
+#[test]
+fn condition_syntax_error_is_usage_error_with_silent_stdout_in_human_mode() {
+    let p = sample();
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let out = TempFileGuard::new(temp_path("syntax", "hwp"));
+    let plan_path = TempFileGuard::new(temp_path("syntax", "json"));
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": p.to_str().unwrap(),
+        "output": out.path().to_str().unwrap(),
+        // 두 조건을 나열하면 and 인지 or 인지가 계획서에 적혀 있지 않다 — 추측 금지.
+        "steps": [ { "action": "set_checkbox", "occurrence": 0,
+                     "if": { "fieldExists": "a", "textFound": "b" } } ],
+    });
+    std::fs::write(plan_path.path(), serde_json::to_vec_pretty(&plan).unwrap()).unwrap();
+    let output = run(&["run", plan_path.path().to_str().unwrap()]);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "조건 문법 오류 = 사용법 오류"
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "실패 경로의 stdout 은 0바이트여야 한다: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(!out.path().exists(), "실행 0 — 산출물 부재");
+}
+
+// ── 5) 자기서술 등재 ────────────────────────────────────────────────────
+
+#[test]
+fn capabilities_and_mcp_declare_the_command() {
+    let cap: serde_json::Value =
+        serde_json::from_slice(&run(&["capabilities"]).stdout).expect("capabilities");
+    let entry = cap["commands"]
+        .as_array()
+        .expect("commands")
+        .iter()
+        .find(|c| c["name"] == "export-plan-schema")
+        .unwrap_or_else(|| panic!("capabilities 에 export-plan-schema 누락: {cap}"));
+    assert_eq!(entry["json"], true, "{entry}");
+    for flag in ["--json", "--bare", "-o"] {
+        assert!(
+            entry["flags"].as_array().unwrap().iter().any(|f| f == flag),
+            "{flag} 선언 누락: {entry}"
+        );
+    }
+
+    let mcp: serde_json::Value = serde_json::from_slice(&run(&["capabilities", "--mcp"]).stdout)
+        .expect("capabilities --mcp");
+    let tool = mcp["tools"]
+        .as_array()
+        .expect("tools")
+        .iter()
+        .find(|t| t["name"] == "hwp_export_plan_schema")
+        .unwrap_or_else(|| panic!("MCP 도구 누락: {mcp}"));
+    assert_eq!(tool["inputSchema"]["type"], "object", "{tool}");
+    assert!(tool["inputSchema"]["properties"].is_object(), "{tool}");
+    // 필수가 없어도 빈 배열을 선언한다 — "필수 없음"과 "선언 누락"은 다른 상태다.
+    assert!(
+        tool["inputSchema"]["required"].is_array(),
+        "required 배열 누락: {tool}"
+    );
+    assert_eq!(tool["cli"]["command"], "export-plan-schema", "{tool}");
+    // 선언한 입력 속성은 전부 CLI 에 닿아야 한다 (선언만 하고 버리면 계약이 거짓말한다).
+    let wired: Vec<&str> = tool["cli"]["optionalArgs"]
+        .as_array()
+        .map(|a| a.iter().filter_map(|o| o["when"].as_str()).collect())
+        .unwrap_or_default();
+    for key in tool["inputSchema"]["properties"]
+        .as_object()
+        .expect("properties")
+        .keys()
+    {
+        assert!(
+            wired.contains(&key.as_str()),
+            "{key} 가 cli.optionalArgs 에 배선되지 않았다: {tool}"
+        );
+    }
+
+    // hwp_run_plan 은 건너뛴 step 을 출력 계약으로 광고해야 한다 — 소비자가 저널에서
+    // skipped 를 기대할 근거가 자기서술에 있어야 한다.
+    let run_tool = mcp["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|t| t["name"] == "hwp_run_plan")
+        .expect("hwp_run_plan");
+    assert!(
+        run_tool["outputFields"]
+            .as_array()
+            .expect("outputFields")
+            .iter()
+            .any(|f| f == "steps[].skipped"),
+        "{run_tool}"
+    );
+}
+
+// ── 6) 조건 분기별 사례 ─────────────────────────────────────────────────
+
+#[test]
+fn field_exists_honours_the_occurrence_suffix() {
+    // `이름[N]` 은 fill_fields 의 키 문법과 같은 어휘다. 조건이 이 표기를 모르면
+    // "14칸 중 13번째가 있으면" 같은 판정을 계획서로 쓸 수 없다.
+    let fields = sample_fields();
+    let Some((name, total)) = duplicated_field(&fields) else {
+        eprintln!("동명 누름틀이 있는 샘플이 없음 — 건너뜀");
+        return;
+    };
+    let last = format!("{name}[{}]", total - 1);
+    let past_end = format!("{name}[{total}]");
+
+    let steps = journal_steps(
+        "occ-suffix",
+        serde_json::json!([
+            // 마지막 순번은 존재한다 → 실행.
+            { "action": "set_checkbox", "occurrence": 999999, "if": { "fieldExists": past_end } },
+            { "action": "fill_fields", "data": { last.as_str(): "마지막칸" },
+              "if": { "fieldExists": last } },
+        ]),
+    );
+    assert_eq!(
+        steps[0]["skipped"], true,
+        "순번 {total} 은 범위 밖이므로 조건이 거짓이어야 한다: {steps}"
+    );
+    assert!(
+        steps[1].get("skipped").is_none(),
+        "마지막 순번은 존재하므로 조건이 참이어야 한다: {steps}"
+    );
+    assert_eq!(steps[1]["filledCount"], 1, "{steps}");
+}
+
+#[test]
+fn field_equals_compares_the_current_value_of_the_right_occurrence() {
+    // 동명 필드가 여럿일 때 순번을 무시하고 첫 칸만 보면, "13번째 칸이 이미 채워져
+    // 있으면 건너뛰라"는 의도가 조용히 첫 칸 판정으로 바뀐다.
+    let fields = sample_fields();
+    let Some((idx_in_group, name, value)) = a_field_occurrence_with_value(&fields) else {
+        eprintln!("값이 든 누름틀이 없음 — 건너뜀");
+        return;
+    };
+    let spec = format!("{name}[{idx_in_group}]");
+    let steps = journal_steps(
+        "eq-occurrence",
+        serde_json::json!([
+            { "action": "set_checkbox", "occurrence": 999999,
+              "if": { "fieldEquals": { "name": spec, "value": format!("{value}-불일치") } } },
+        ]),
+    );
+    assert_eq!(steps[0]["skipped"], true, "값이 다르면 거짓: {steps}");
+    assert!(
+        steps[0]["reason"]
+            .as_str()
+            .is_some_and(|r| r.contains("현재값")),
+        "무엇과 비교했는지 사유에 남아야 한다: {steps}"
+    );
+    // 조건이 참이면 step 이 실행되고, 이 step 은 선검증에서 걸린다(occurrence 범위 밖).
+    // 즉 "조건 참 → 선검증 대상"이 증명된다. 그래서 여기서는 exit 2 를 기대한다.
+    let out = TempFileGuard::new(temp_path("eq-true-validates", "hwp"));
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": sample().to_str().unwrap(),
+        "output": out.path().to_str().unwrap(),
+        "steps": [ { "action": "set_checkbox", "occurrence": 999999,
+                     "if": { "fieldEquals": { "name": spec, "value": value } } } ],
+    });
+    let (code, journal) = run_plan("eq-true-validates", &plan);
+    assert_eq!(
+        code, 2,
+        "조건이 참이면 그 step 은 선검증을 받아야 한다 (면제는 거짓일 때만): {journal}"
+    );
+    assert!(!out.path().exists(), "선검증 실패 = 실행 0");
+}
+
+#[test]
+fn text_found_is_case_sensitive() {
+    // 대소문자를 뭉개면 "Total" 을 찾는 조건이 "total" 에도 걸린다 — 서식 판별에서
+    // 그 차이는 다른 문서를 같은 문서로 보게 만든다.
+    let text = sample_text();
+    let (Some(token), Some(field)) = (an_ascii_word(&text), a_real_field_name()) else {
+        eprintln!("본문 ASCII 낱말 또는 누름틀이 없음 — 건너뜀");
+        return;
+    };
+    let flipped = flip_case(&token);
+    if text.contains(&flipped) {
+        eprintln!("대소문자를 뒤집은 낱말도 본문에 있음 — 건너뜀");
+        return;
+    }
+    let steps = journal_steps(
+        "case",
+        serde_json::json!([
+            // 뒤집은 낱말은 없다 → 거짓 → 건너뜀.
+            { "action": "set_checkbox", "occurrence": 999999, "if": { "textFound": flipped } },
+            // 원래 낱말은 있다 → 참 → 실행.
+            { "action": "fill_fields", "data": { field.as_str(): "대소문자" },
+              "if": { "textFound": token } },
+        ]),
+    );
+    assert_eq!(
+        steps[0]["skipped"], true,
+        "대소문자가 다르면 찾지 못해야 한다 ('{flipped}'): {steps}"
+    );
+    assert!(
+        steps[1].get("skipped").is_none(),
+        "본문에 있는 낱말 '{token}' 을 찾지 못했다: {steps}"
+    );
+    assert_eq!(steps[1]["filledCount"], 1, "{steps}");
+}
+
+#[test]
+fn every_action_can_carry_a_condition() {
+    // 조건절은 step 4종 **전부**의 계약이다. 한 종류라도 빠지면 스키마가 거짓말한다.
+    let p = sample();
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let schema = schema_body();
+    let variants = schema["$defs"]["Step"]["oneOf"]
+        .as_array()
+        .expect("Step.oneOf");
+    for variant in variants {
+        let def_name = variant["$ref"]
+            .as_str()
+            .and_then(|r| r.strip_prefix("#/$defs/"))
+            .expect("$defs 참조");
+        let action = schema["$defs"][def_name]["properties"]["action"]["const"]
+            .as_str()
+            .expect("action const");
+        // 필수 필드를 일부러 뺀 껍데기 step. 조건이 거짓이면 선검증 면제로 통과해야 한다.
+        let steps = journal_steps(
+            &format!("cond-action-{action}"),
+            serde_json::json!([
+                { "action": action, "if": { "fieldExists": "이런누름틀은없다9999" } }
+            ]),
+        );
+        assert_eq!(
+            steps[0]["skipped"], true,
+            "action '{action}' 이 조건절을 받지 못한다: {steps}"
+        );
+        assert_eq!(steps[0]["action"], action, "{steps}");
+    }
+}
+
+#[test]
+fn skipped_steps_keep_their_index_and_order() {
+    // 저널의 step 번호는 계획서의 인덱스다. 건너뛴 step 때문에 번호가 밀리면 소비자가
+    // 저널 항목과 계획서 항목을 짝지을 수 없다.
+    let Some(field) = a_real_field_name() else {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    };
+    let steps = journal_steps(
+        "order",
+        serde_json::json!([
+            { "action": "fill_fields", "data": { field.as_str(): "첫째" } },
+            { "action": "set_checkbox", "occurrence": 999999,
+              "if": { "textFound": "이런문자열은문서에없다9999" } },
+            { "action": "replace_text", "find": "이런문자열도없다8888", "replace": "X",
+              "if": { "fieldExists": "이런누름틀은없다9999" } },
+            { "action": "fill_fields", "data": { field.as_str(): "넷째" } },
+        ]),
+    );
+    let steps = steps.as_array().expect("steps[]");
+    assert_eq!(steps.len(), 4, "건너뛴 step 도 자리를 지킨다: {steps:?}");
+    for (i, step) in steps.iter().enumerate() {
+        assert_eq!(step["step"], i, "step 번호가 계획서 인덱스와 어긋났다");
+    }
+    assert!(steps[0].get("skipped").is_none());
+    assert_eq!(steps[1]["skipped"], true);
+    assert_eq!(steps[2]["skipped"], true);
+    assert!(steps[3].get("skipped").is_none());
+}
+
+#[test]
+fn skipped_steps_do_not_change_the_visual_verification_target() {
+    // changedPages 는 "눈으로 확인할 쪽"이다. 실행되지 않은 step 이 이 목록을 늘리면
+    // 사람이 멀쩡한 쪽을 들여다보게 된다.
+    let Some(field) = a_real_field_name() else {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    };
+    let real_step = serde_json::json!(
+        { "action": "fill_fields", "data": { field.as_str(): "변경" } }
+    );
+    let out_a = TempFileGuard::new(temp_path("pages-a", "hwp"));
+    let plan_a = serde_json::json!({
+        "planVersion": "1.0", "input": sample().to_str().unwrap(),
+        "output": out_a.path().to_str().unwrap(), "steps": [real_step.clone()],
+    });
+    let (code_a, journal_a) = run_plan("pages-a", &plan_a);
+    assert_eq!(code_a, 0, "{journal_a}");
+
+    let out_b = TempFileGuard::new(temp_path("pages-b", "hwp"));
+    let plan_b = serde_json::json!({
+        "planVersion": "1.0", "input": sample().to_str().unwrap(),
+        "output": out_b.path().to_str().unwrap(),
+        "steps": [
+            real_step,
+            { "action": "set_cell", "table": 0, "row": 0, "col": 0, "text": "안바뀜",
+              "if": { "textFound": "이런문자열은문서에없다9999" } },
+        ],
+    });
+    let (code_b, journal_b) = run_plan("pages-b", &plan_b);
+    assert_eq!(code_b, 0, "{journal_b}");
+    assert_eq!(
+        journal_a["changedPages"], journal_b["changedPages"],
+        "건너뛴 step 이 눈검증 대상 쪽을 늘렸다: {} vs {}",
+        journal_a["changedPages"], journal_b["changedPages"]
+    );
+}
+
+#[test]
+fn conditions_do_not_see_earlier_steps_edits() {
+    // 조건은 **입력 문서** 기준이다. 앞 step 의 편집을 조건이 보게 되면 선검증(편집 전)과
+    // 실행(편집 후)이 서로 다른 답을 내고, 검사를 통과한 계획이 실행에서 다르게 동작한다.
+    let fields = sample_fields();
+    let Some((name, _)) = fields.iter().find(|(_, v)| v.is_empty()).cloned() else {
+        eprintln!("빈 누름틀이 없음 — 건너뜀");
+        return;
+    };
+    let steps = journal_steps(
+        "isolation",
+        serde_json::json!([
+            { "action": "fill_fields", "data": { name.as_str(): "새값" } },
+            // 앞 step 이 방금 넣은 값을 조건이 보면 참이 된다 — 보면 안 된다.
+            { "action": "set_checkbox", "occurrence": 999999,
+              "if": { "fieldEquals": { "name": name.as_str(), "value": "새값" } } },
+        ]),
+    );
+    assert_eq!(
+        steps[1]["skipped"], true,
+        "조건이 앞 step 의 편집 결과를 보고 있다 — 입력 문서 기준이어야 한다: {steps}"
+    );
+}
+
+#[test]
+fn all_steps_skipped_still_produces_an_honest_journal() {
+    // 전부 건너뛴 계획도 실패가 아니다(조건이 다 거짓이었을 뿐). 다만 저널이 그 사실을
+    // 말하지 않으면 "성공했는데 아무것도 안 바뀐" 상태가 설명 불가가 된다.
+    let out = TempFileGuard::new(temp_path("all-skipped", "hwp"));
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": sample().to_str().unwrap(),
+        "output": out.path().to_str().unwrap(),
+        "steps": [
+            { "action": "set_checkbox", "occurrence": 999999,
+              "if": { "textFound": "이런문자열은문서에없다9999" } },
+            { "action": "fill_fields", "data": { "이런누름틀은없다9999": "값" },
+              "if": { "fieldExists": "이런누름틀은없다9999" } },
+        ],
+        "assertions": { "verify": true },
+    });
+    let (code, journal) = run_plan("all-skipped", &plan);
+    assert_eq!(code, 0, "{journal}");
+    let steps = journal["steps"].as_array().expect("steps[]");
+    assert_eq!(steps.len(), 2, "{journal}");
+    assert!(steps.iter().all(|s| s["skipped"] == true), "{journal}");
+    assert_eq!(
+        journal["verify"]["identical"], true,
+        "무편집 산출물도 자기검증을 통과해야 한다: {journal}"
+    );
+    assert!(out.path().exists(), "저장 자체는 정상 수행된다");
+}
+
+// ── 7) 스키마 상수 ↔ 실행기 드리프트 ────────────────────────────────────
+
+#[test]
+fn schema_pins_the_plan_version_the_engine_requires() {
+    // 스키마가 const 로 박은 planVersion 과 실행기가 받는 값이 다르면, 스키마를 따라
+    // 만든 계획이 전부 exit 2 가 된다.
+    let p = sample();
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let schema = schema_body();
+    let pinned = schema["$defs"]["Plan"]["properties"]["planVersion"]["const"]
+        .as_str()
+        .expect("planVersion const");
+    let Some(field) = a_real_field_name() else {
+        return;
+    };
+    for (version, want_ok) in [(pinned.to_string(), true), ("2.0".to_string(), false)] {
+        let out = TempFileGuard::new(temp_path(&format!("ver-{version}"), "hwp"));
+        let plan = serde_json::json!({
+            "planVersion": version,
+            "input": p.to_str().unwrap(),
+            "output": out.path().to_str().unwrap(),
+            "steps": [ { "action": "fill_fields", "data": { field.as_str(): "판번호" } } ],
+        });
+        let (code, journal) = run_plan(&format!("ver-{version}"), &plan);
+        if want_ok {
+            assert_eq!(
+                code, 0,
+                "스키마가 박은 planVersion '{version}' 을 실행기가 거절했다: {journal}"
+            );
+        } else {
+            assert_eq!(code, 2, "실행기가 '{version}' 을 받아들였다: {journal}");
+        }
+    }
+}
+
+#[test]
+fn schema_assertions_match_the_journal_echo() {
+    // 저널은 판정에 쓴 단언을 그대로 되돌려준다. 스키마가 선언한 단언 이름과 그 에코가
+    // 어긋나면, 계획서에 쓴 단언이 실제로 켜졌는지 확인할 방법이 없어진다.
+    let Some(field) = a_real_field_name() else {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    };
+    let schema = schema_body();
+    let declared: std::collections::BTreeSet<String> = schema["$defs"]["Assertions"]["properties"]
+        .as_object()
+        .expect("Assertions.properties")
+        .keys()
+        .cloned()
+        .collect();
+
+    let out = TempFileGuard::new(temp_path("assert-echo", "hwp"));
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": sample().to_str().unwrap(),
+        "output": out.path().to_str().unwrap(),
+        "steps": [ { "action": "fill_fields", "data": { field.as_str(): "단언" } } ],
+        "assertions": { "notFoundEmpty": true, "verify": true },
+    });
+    let (code, journal) = run_plan("assert-echo", &plan);
+    assert_eq!(code, 0, "{journal}");
+    let echoed: std::collections::BTreeSet<String> = journal["assertions"]
+        .as_object()
+        .expect("저널 assertions 에코")
+        .keys()
+        .cloned()
+        .collect();
+    assert_eq!(
+        declared, echoed,
+        "스키마가 선언한 단언과 저널 에코가 다르다 — 스키마 {declared:?} / 저널 {echoed:?}"
+    );
+}
+
+// ── 8) MCP 경로 ─────────────────────────────────────────────────────────
+
+#[test]
+fn mcp_serves_the_plan_schema_and_reports_skipped_steps() {
+    let p = sample();
+    if !p.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    // (1) 스키마 도구 — MCP 호스트가 계획을 쓰기 전에 받아 가는 경로.
+    let schema_frame = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": { "name": "hwp_export_plan_schema", "arguments": { "bare": true } }
+    });
+    // (2) 조건부 계획 — 같은 서버에서 저널에 skipped 가 실려 돌아오는지.
+    let out = TempFileGuard::new(temp_path("mcp-cond", "hwp"));
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": p.to_str().unwrap(),
+        "output": out.path().to_str().unwrap(),
+        "steps": [ { "action": "set_checkbox", "occurrence": 999999,
+                     "if": { "textFound": "이런문자열은문서에없다9999" } } ],
+    });
+    let plan_frame = serde_json::json!({
+        "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+        "params": { "name": "hwp_run_plan", "arguments": { "plan": plan } }
+    });
+    let responses = mcp_call(&[schema_frame, plan_frame]);
+
+    let body: serde_json::Value = serde_json::from_str(
+        responses[0]["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap(),
+    )
+    .expect("스키마 본문");
+    assert_eq!(responses[0]["result"]["isError"], false, "{}", responses[0]);
+    assert_eq!(body["$ref"], "#/$defs/Plan", "bare 본문이 아니다: {body}");
+    assert!(
+        body["$defs"].as_object().is_some_and(|d| d.len() >= 9),
+        "정의가 비었다: {body}"
+    );
+
+    let journal: serde_json::Value = serde_json::from_str(
+        responses[1]["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap(),
+    )
+    .expect("저널");
+    assert_eq!(
+        journal["steps"][0]["skipped"], true,
+        "MCP 경로에도 skipped 가 실려야 한다: {journal}"
+    );
+    assert!(
+        journal["steps"][0]["reason"]
+            .as_str()
+            .is_some_and(|r| !r.is_empty()),
+        "{journal}"
+    );
+}
+
+// ── 보조 ────────────────────────────────────────────────────────────────
+
+/// 동명이 둘 이상인 누름틀 (이름, 개수).
+fn duplicated_field(fields: &[(String, String)]) -> Option<(String, usize)> {
+    let mut counts: std::collections::BTreeMap<&str, usize> = std::collections::BTreeMap::new();
+    for (name, _) in fields {
+        *counts.entry(name.as_str()).or_insert(0) += 1;
+    }
+    counts
+        .into_iter()
+        .find(|(_, n)| *n > 1)
+        .map(|(name, n)| (name.to_string(), n))
+}
+
+/// 값이 들어 있는 누름틀 하나 — (동명 그룹 내 순번, 이름, 값).
+fn a_field_occurrence_with_value(fields: &[(String, String)]) -> Option<(usize, String, String)> {
+    let mut seen: std::collections::BTreeMap<&str, usize> = std::collections::BTreeMap::new();
+    for (name, value) in fields {
+        let occurrence = *seen.entry(name.as_str()).or_insert(0);
+        seen.insert(name.as_str(), occurrence + 1);
+        if !value.is_empty() {
+            return Some((occurrence, name.clone(), value.clone()));
+        }
+    }
+    None
+}
+
+/// 본문에서 ASCII 낱말(길이 3 이상, 대소문자가 섞일 수 있는 것) 하나.
+fn an_ascii_word(text: &str) -> Option<String> {
+    text.split(|c: char| !c.is_ascii_alphabetic())
+        .find(|w| w.len() >= 3 && w.chars().any(|c| c.is_ascii_uppercase()))
+        .map(str::to_string)
+}
+
+/// 대소문자를 뒤집는다.
+fn flip_case(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_uppercase() {
+                c.to_ascii_lowercase()
+            } else {
+                c.to_ascii_uppercase()
+            }
+        })
+        .collect()
+}
+
+/// `mcp-serve` 에 프레임을 순서대로 보내고 같은 수의 응답을 읽는다.
+fn mcp_call(frames: &[serde_json::Value]) -> Vec<serde_json::Value> {
+    use std::io::{BufRead, BufReader, Write};
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("mcp-serve")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("mcp-serve 기동");
+    {
+        let stdin = child.stdin.as_mut().expect("stdin");
+        for frame in frames {
+            writeln!(stdin, "{frame}").expect("프레임 쓰기");
+        }
+        stdin.flush().expect("flush");
+    }
+    let mut reader = BufReader::new(child.stdout.take().expect("stdout"));
+    let mut responses = Vec::new();
+    for _ in frames {
+        let mut line = String::new();
+        let read = reader.read_line(&mut line).expect("응답 읽기");
+        assert!(read > 0, "서버가 응답 없이 끊겼다");
+        responses.push(serde_json::from_str(line.trim()).expect("JSON-RPC 응답"));
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    responses
+}
+
+/// 스키마 노드와 그 하위 `properties` 가 전부 설명을 갖는지 본다.
+/// 순수 `$ref` 노드는 참조된 정의가 설명을 갖고 있으므로 면제한다.
+fn check_described(node: &serde_json::Value, path: &str, missing: &mut Vec<String>) {
+    let Some(map) = node.as_object() else {
+        return;
+    };
+    let pure_ref = map.len() == 1 && map.contains_key("$ref");
+    if !pure_ref
+        && !map
+            .get("description")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|d| !d.trim().is_empty())
+    {
+        missing.push(path.to_string());
+    }
+    if let Some(props) = map.get("properties").and_then(serde_json::Value::as_object) {
+        for (key, value) in props {
+            check_described(value, &format!("{path}.{key}"), missing);
+        }
+    }
+    if let Some(extra) = map.get("additionalProperties") {
+        if extra.is_object() {
+            check_described(extra, &format!("{path}.additionalProperties"), missing);
+        }
+    }
+}
+
+/// `$ref` 를 재귀 수집한다.
+fn collect_refs(value: &serde_json::Value, sink: &mut impl FnMut(&str)) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, item) in map {
+                if key == "$ref" {
+                    if let Some(name) = item.as_str().and_then(|p| p.strip_prefix("#/$defs/")) {
+                        sink(name);
+                    }
+                } else {
+                    collect_refs(item, sink);
+                }
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                collect_refs(item, sink);
+            }
+        }
+        _ => {}
+    }
+}

--- a/tests/plan_schema_contract.rs
+++ b/tests/plan_schema_contract.rs
@@ -171,6 +171,10 @@ fn envelope_carries_version_dialect_and_definition_count() {
         "definitionCount 가 실제 정의 수와 다르다"
     );
     assert!(count >= 9, "정의가 너무 적다: {count}");
+    // [#3787 S1] "표지는 항상 실린다" — 문서를 열지 않는 명령의 봉투도
+    // untrustedContent:false 를 명시한다.
+    assert_eq!(v["untrustedContent"], false, "출처 표지 누락: {v}");
+    assert_eq!(v["untrustedFields"], serde_json::json!([]), "{v}");
 }
 
 #[test]
@@ -182,6 +186,10 @@ fn bare_emits_the_schema_body_without_the_envelope() {
         v.get("definitionCount").is_none(),
         "--bare 는 봉투 키를 싣지 않는다 — JSON Schema 도구에 그대로 먹이는 용도다"
     );
+    assert!(
+        v.get("untrustedContent").is_none(),
+        "--bare 는 출처 표지도 섞지 않는다 — 검증기에 그대로 먹이는 본문이다"
+    );
 }
 
 #[test]
@@ -192,6 +200,7 @@ fn output_file_and_json_report() {
     assert_eq!(out.status.code(), Some(0));
     let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("저장 보고 봉투");
     assert_eq!(v["output"], path.as_str(), "{v}");
+    assert_eq!(v["untrustedContent"], false, "저장 보고도 봉투다: {v}");
     let bytes = v["bytes"].as_u64().expect("bytes");
     let written = std::fs::read(out_file.path()).expect("저장된 스키마");
     assert_eq!(written.len() as u64, bytes, "보고한 크기와 실제가 다르다");

--- a/tests/plan_schema_contract.rs
+++ b/tests/plan_schema_contract.rs
@@ -1131,3 +1131,28 @@ fn collect_refs(value: &serde_json::Value, sink: &mut impl FnMut(&str)) {
         _ => {}
     }
 }
+
+// ── 8) 에이전트 매니페스트 접합 (#3828 B2 ↔ #3808) ──────────────────────
+
+/// B2(`export-agent-manifest`)는 이 PR 이 없던 시점에 병합되어 `missingAxes` 로
+/// `["planSchema"]` 를 광고했다. 두 축이 한 트리에 모인 지금 그 광고가 남아 있으면
+/// "축이 있는데 없다고 말하는" 자기서술 거짓이 된다 — 매니페스트가 planSchema 를
+/// 실제로 싣고, 그 본문이 `export-plan-schema --bare` 와 동일(단일 출처)함을 고정한다.
+#[test]
+fn agent_manifest_carries_the_plan_schema_axis() {
+    let args = ["export-agent-manifest", "--json"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{args:?}");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("매니페스트 JSON");
+    assert_eq!(
+        v["missingAxes"],
+        serde_json::json!([]),
+        "네 축이 모두 실렸는데 빠진 축을 광고하고 있다: {}",
+        v["missingAxes"]
+    );
+    assert_eq!(
+        v["planSchema"],
+        schema_body(),
+        "매니페스트의 planSchema 가 export-plan-schema --bare 와 다르다 — 단일 출처 위반"
+    );
+}

--- a/tests/provenance_contract.rs
+++ b/tests/provenance_contract.rs
@@ -322,10 +322,16 @@ const SWEEP_EXEMPT: &[(&str, &str)] = &[
     (
         "export-agent-manifest",
         "문서를 입력으로 받지 않는다 — 인자가 --json 과 --bare 뿐이고, 내는 것은 \
-         capabilities·irSchema·provenanceMap 을 조립한 rhwp 자신의 매니페스트다. \
-         구성 요소는 이미 각자의 계약으로 고정돼 있고(capabilities 는 이 파일의 다른 \
-         가드, provenanceMap 은 export-provenance-map), 여기서 다시 볼 문서 유래 \
-         문자열이 없다.",
+         capabilities·irSchema·provenanceMap·planSchema 를 조립한 rhwp 자신의 \
+         매니페스트다. 구성 요소는 이미 각자의 계약으로 고정돼 있고(capabilities 는 \
+         이 파일의 다른 가드, provenanceMap 은 export-provenance-map, planSchema 는 \
+         tests/plan_schema_contract.rs), 여기서 다시 볼 문서 유래 문자열이 없다.",
+    ),
+    (
+        "export-plan-schema",
+        "문서를 입력으로 받지 않는 계획서 문법 스키마다. 인자가 --bare·-o·--json 뿐이고 \
+         --bare가 아닌 모드도 특정 문서가 아닌 스키마 봉투를 낸다. \
+         봉투 모양은 tests/plan_schema_contract.rs 가 따로 고정한다.",
     ),
 ];
 


### PR DESCRIPTION
#3719 §6-4·§6-8. 계획을 **자기서술**하게 만들고, step 에 조건을 붙인다.

```
rhwp export-plan-schema [--json] [--bare]
```

JSON Schema 2020-12 로 계획 형식을 스스로 기술한다. 정의 **9개** —
`Plan` · `Assertions` · `Step`(판별 유니온) · `FillFieldsStep` · `ReplaceTextStep` ·
`SetCellStep` · `SetCheckboxStep` · `StepCondition` · `FieldEqualsCondition`.
**전 정의·전 속성이 description 을 갖는다.**

## 설계 중 스키마와 실행기가 어긋나 있었다 — 양방향으로 맞췄다

이게 이 PR 의 실질이다. 자기서술이 **실물과 다르면 없느니만 못하다** — 에이전트는
스키마를 믿고 계획을 쓴다.

| 어긋난 지점 | 어느 쪽이 틀렸나 |
|---|---|
| 조건절에 개수 제약이 없어 **조건 2개 계획이 검증기를 통과**했다 | 스키마가 **관대**했다 |
| `data` 에 `minProperties: 1` 을 넣어 **실행기가 받는 계획을 무효로 봤다** | 스키마가 **엄격**했다 |

둘 다 **실행기 기준으로** 고쳤다. 외부 검증기 교차(python `jsonschema`, draft 2020-12)
**유효 4 / 무효 검출 14 = 18/18**, 메타스키마 통과가 이 정렬의 증거다.

## 조건은 입력 문서 기준으로 **실행 전 1회만** 판정한다

step 실행 직전에 재판정하면 **선검증(편집 전)과 실행(편집 후)이 다른 답**을 낼 수 있다.
`--dry-run` 이 "이 step 은 건너뜁니다" 라고 했는데 실제로는 실행되는 형태다.

대가로 **연쇄 조건은 못 쓴다**(앞 step 의 편집을 뒤 조건이 못 본다).
테스트로 고정했다 — `conditions_do_not_see_earlier_steps_edits`.

## 검증

`plan_schema_contract` **24** + `plan_schema` 유닛 **7** + `run_plan_contract` **8** +
`cli_json_contract` **26** + `mcp_server_contract` **22** = **87 passed / 0 failed** ·
`clippy -D warnings` 0 · rustfmt clean ·
선검사(#3795) **10종 전부 통과**(도구 26 · 명령 55 · 플래그 62 · 실패경로 3).

**로컬 미검증 항목 없음.** 다만 `cargo test --release --lib` 이 기본 병렬도에서 rustc
메모리 경합으로 1회 죽어 `-j 2` 로 재실행해 통과했다 — 코드 문제가 아니라 이 PC 의
병렬 빌드 경합이고 README 에 기록했다.

## `dryRun` 을 스키마에 넣지 않았다 — 의도적이다

`run --dry-run`(#3759)은 **아직 devel 에 없는 별개 PR** 이라, 지금 실행기는 그 필드를 읽지 않는다.
**스키마가 광고하면 에이전트가 `dryRun: true` 를 넣고 파일이 써진다.** 검사인 줄 알았는데
문서가 편집되는 것이 이 축에서 가장 나쁜 실패다.

#3759 머지 시 필드 추가 = minor. 같은 이유로 dry-run `preview[]` 의 `skipped` 반영도
못 했다(`preview` 가 이 브랜치에 없다). **두 PR 중 나중에 머지되는 쪽이** `preview` 에
`{step, action, skipped, reason}` 을 더해야 한다 — README 에 명시했다.

## 머지 충돌 예고

`hwp_run_plan` 의 description·outputFields 한 줄과 `run` help 블록은 **#3759 도 건드리는 자리**다.
의미 병합 1~2줄이 필요하다.

조건 조합(and/or)·부정(`not`), 저널(출력) 스키마는 의도적 제외.
