### PR TITLE
ci(#3684): 캐시 세대 정리 워크플로를 main 에 등록 — dispatch·schedule 발동 조건

### DIFF
--- a/.github/workflows/cache-generation-sweep.yml
+++ b/.github/workflows/cache-generation-sweep.yml
@@ -1,0 +1,123 @@
+name: Cache Generation Sweep
+
+# [#3684] Actions cache 세대 누적 정리.
+#
+# 근인: rust-cache·CodeQL·frontend-wasm 이 Cargo.lock / SHA 해시별로 새 캐시를
+# 만들고, 구 세대가 GitHub 의 7일 미사용 만료까지 자리를 차지한다. 실측(2026-08-02)
+# 에서 42개 10.13GB 중 29개 7.60GB 가 구 세대였고, 논리 그룹별 최신 1개만 남기면
+# 2.53GB 로 내려간다.
+#
+# 이 워크플로는 **그룹별 최신 N세대만 남기고 나머지를 삭제**한다. 그룹은 키에서
+# 후행 해시를 뗀 것이다(예: `v0-rust-lint-Linux-x64-6f43fa4a-<lock>` →
+# `v0-rust-lint-Linux-x64-6f43fa4a`).
+#
+# 안전 경계:
+# - checkout 하지 않고 PR 코드를 실행하지 않는다.
+# - 권한은 `actions: write` 하나뿐이다.
+# - 열린 PR 의 ref 캐시는 건드리지 않는다(머지 전 재사용 대상).
+# - 그룹별로 최신 KEEP_GENERATIONS 개를 남긴다 — 진행 중 job 이 방금 만든 캐시를
+#   지우지 않기 위한 여유다.
+
+on:
+  schedule:
+    # 매일 1회. devel push 마다 돌 필요가 없다 — 세대는 Cargo.lock 변경 시에만 는다.
+    - cron: "23 18 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 삭제하지 않고 대상만 로그로 남긴다
+        required: false
+        default: true
+        type: boolean
+      keep_generations:
+        description: 그룹별로 남길 최신 세대 수
+        required: false
+        default: "2"
+        type: string
+
+permissions:
+  actions: write
+
+concurrency:
+  group: cache-generation-sweep
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Sweep stale cache generations
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+          KEEP_GENERATIONS: ${{ github.event_name == 'workflow_dispatch' && inputs.keep_generations || '2' }}
+        with:
+          script: |
+            const dryRun = process.env.DRY_RUN === 'true';
+            const keep = Math.max(1, Number(process.env.KEEP_GENERATIONS) || 2);
+
+            // 열린 PR 의 ref 는 보호한다 — 머지 전에 재사용된다.
+            const openPrRefs = new Set();
+            for await (const res of github.paginate.iterator(
+              github.rest.pulls.list, { ...context.repo, state: 'open', per_page: 100 },
+            )) {
+              for (const pr of res.data) openPrRefs.add(`refs/pull/${pr.number}/merge`);
+            }
+
+            const caches = [];
+            for await (const res of github.paginate.iterator(
+              github.rest.actions.getActionsCacheList, { ...context.repo, per_page: 100 },
+            )) {
+              caches.push(...res.data.actions_caches);
+            }
+
+            const before = caches.reduce((n, c) => n + c.size_in_bytes, 0);
+            const gb = (b) => (b / 1024 ** 3).toFixed(2);
+            core.info(`현재 캐시 ${caches.length}개 / ${gb(before)}GB (열린 PR ${openPrRefs.size}건 보호)`);
+
+            // 키에서 후행 해시를 떼어 논리 그룹으로 묶는다.
+            const groupOf = (key) => key.replace(/[-_][0-9a-f]{8,}$/, '');
+            const groups = new Map();
+            for (const c of caches) {
+              if (openPrRefs.has(c.ref)) continue;
+              const g = `${c.ref}::${groupOf(c.key)}`;
+              if (!groups.has(g)) groups.set(g, []);
+              groups.get(g).push(c);
+            }
+
+            const stale = [];
+            for (const [, items] of groups) {
+              items.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+              stale.push(...items.slice(keep));
+            }
+
+            if (stale.length === 0) {
+              core.info(`정리 대상 없음 (그룹별 최신 ${keep}세대 유지)`);
+              return;
+            }
+
+            const staleBytes = stale.reduce((n, c) => n + c.size_in_bytes, 0);
+            core.info(`정리 대상 ${stale.length}개 / ${gb(staleBytes)}GB${dryRun ? ' [dry-run]' : ''}`);
+            for (const c of stale) {
+              core.info(`  ${dryRun ? '(예정)' : '삭제'} ${c.key} (${(c.size_in_bytes / 1024 ** 2).toFixed(0)}MB, ${c.created_at.slice(0, 10)}, ${c.ref})`);
+              if (dryRun) continue;
+              try {
+                await github.rest.actions.deleteActionsCacheById({ ...context.repo, cache_id: c.id });
+              } catch (error) {
+                // 다른 run 이 이미 지웠거나 만료됐을 수 있다 — 치명적이지 않다.
+                core.warning(`삭제 실패 ${c.key}: ${error.message}`);
+              }
+            }
+
+            const after = before - (dryRun ? 0 : staleBytes);
+            core.summary
+              .addHeading('Cache generation sweep', 3)
+              .addTable([
+                [{ data: '항목', header: true }, { data: '값', header: true }],
+                ['정리 전', `${caches.length}개 / ${gb(before)}GB`],
+                [dryRun ? '정리 예정' : '정리함', `${stale.length}개 / ${gb(staleBytes)}GB`],
+                ['정리 후(추정)', `${caches.length - (dryRun ? 0 : stale.length)}개 / ${gb(after)}GB`],
+                ['그룹별 유지 세대', String(keep)],
+                ['보호한 열린 PR', String(openPrRefs.size)],
+              ])
+              .write();


### PR DESCRIPTION
## 요약

[#3810](https://github.com/edwardkim/rhwp/pull/3810)(#3684 캐시 세대 정리)에서 추가한
워크플로를 **`main` 에 등록**합니다. 파일 1개 추가뿐입니다.

## 왜 main 대상인가

GitHub 은 워크플로를 **기본 브랜치(main) 기준으로 등록**합니다. 새 워크플로가 devel 에만
있으면 `workflow_dispatch` 도 `schedule` 도 **발동하지 않습니다**.

#3810 merge 후 실측:

```
$ gh workflow run cache-generation-sweep.yml --ref devel -f dry_run=true
HTTP 404: Not Found
```

파일은 devel 에 정상 반영돼 있고(5,418B), 기존 워크플로(`render-diff.yml` 등)는 devel·
main 양쪽에 있는 것과 대조됩니다.

캐시가 **이미 10.13GB 로 무료 한도(10GB)를 넘은 상태**라 다음 릴리스까지 기다리면 그
동안 `Cache reservation failed` 로 CI 가 read-only 전환될 수 있습니다. 조기 발동이
필요해 이 파일만 먼저 올립니다.

## 변경 범위

- **`.github/workflows/cache-generation-sweep.yml` 추가 (123줄)** — 그것뿐입니다.
- devel 의 동일 파일과 **바이트 동일**(`git checkout origin/devel --` 로 가져옴).
- main 은 v0.8.2 릴리스 시점이고 devel 과 550 커밋 차이지만, 워크플로 파일 하나만
  올리므로 **릴리스 내용에는 영향이 없습니다.**
- 다음 릴리스의 devel→main 머지에서 동일 파일이라 **충돌 없이 흡수**됩니다.

## 워크플로 요약 (#3810 본문에서)

`Cargo.lock`/SHA 해시별 캐시 세대가 7일 만료까지 누적되는 것이 근인입니다. 논리 그룹별
최신 2세대만 남겨 **10.13GB → 4.73GB** 로 내립니다.

안전 경계: `permissions: actions: write` 하나, checkout·PR 코드 실행 없음, **열린 PR 의
ref 캐시 제외**, `dry_run` 기본 true.

## 검증

- YAML 문법 파싱 통과.
- 변경이 이 파일 하나뿐임을 `git diff --stat origin/main` 으로 확인.
- 워크플로 동작 자체는 merge 후 `dry_run: true` 수동 dispatch 로 확인합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
