### PR TITLE
fix(ci/#3684): 캐시 스윕 페이지네이션 정정 — dry-run 실패 해소

### DIFF
--- a/.github/workflows/cache-generation-sweep.yml
+++ b/.github/workflows/cache-generation-sweep.yml
@@ -57,19 +57,16 @@ jobs:
             const keep = Math.max(1, Number(process.env.KEEP_GENERATIONS) || 2);
 
             // 열린 PR 의 ref 는 보호한다 — 머지 전에 재사용된다.
-            const openPrRefs = new Set();
-            for await (const res of github.paginate.iterator(
+            const openPrs = await github.paginate(
               github.rest.pulls.list, { ...context.repo, state: 'open', per_page: 100 },
-            )) {
-              for (const pr of res.data) openPrRefs.add(`refs/pull/${pr.number}/merge`);
-            }
+            );
+            const openPrRefs = new Set(openPrs.map((pr) => `refs/pull/${pr.number}/merge`));
 
-            const caches = [];
-            for await (const res of github.paginate.iterator(
+            // paginate 는 이 엔드포인트의 `actions_caches` 를 평탄화해 배열로 준다
+            // (`res.data.actions_caches` 로 접근하면 undefined — 2026-08-02 실측).
+            const caches = await github.paginate(
               github.rest.actions.getActionsCacheList, { ...context.repo, per_page: 100 },
-            )) {
-              caches.push(...res.data.actions_caches);
-            }
+            );
 
             const before = caches.reduce((n, c) => n + c.size_in_bytes, 0);
             const gb = (b) => (b / 1024 ** 3).toFixed(2);


### PR DESCRIPTION
## 문제

[#3812](https://github.com/edwardkim/rhwp/pull/3812) merge 후 첫 `dry_run` dispatch 가
실패했습니다.

```
TypeError: res.data.actions_caches is not iterable (cannot read property undefined)
```

[실패 run 30751064499](https://github.com/edwardkim/rhwp/actions/runs/30751064499)

## 원인

`github.paginate.iterator` 는 이 엔드포인트의 `actions_caches` 를 **평탄화해 배열로**
줍니다. `res.data.actions_caches` 로 접근하면 `undefined` 입니다(2026-08-02 실측).

Octokit 의 paginate 는 응답에 배열 필드가 하나면 그것을 펼쳐 주는데, 제가 원시 응답
형태(`{total_count, actions_caches: [...]}`)를 그대로 가정했습니다.

## 수정

`github.paginate()` 직접 호출로 바꿉니다. 열린 PR 목록도 같은 패턴이라 함께
단순화했습니다(동작 동일, 코드 3줄 감소).

```js
const caches = await github.paginate(
  github.rest.actions.getActionsCacheList, { ...context.repo, per_page: 100 },
);
```

## 검증

- YAML 문법 통과.
- 실동작은 merge 후 `dry_run: true` dispatch 로 확인합니다 — **이 결함이 dry-run 을
  먼저 돌린 이유를 증명**합니다. `dry_run` 기본값을 true 로 둔 설계가 실제 삭제 전에
  버그를 잡았습니다.

## 후속

이 PR 이 devel 에 merge 된 뒤, 동일 수정을 **main 에도 반영**해야 워크플로가 갱신됩니다
(#3812 와 같은 이유 — 등록형 워크플로는 기본 브랜치 기준).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
