### PR TITLE
fix(ci/#3684): 캐시 스윕 페이지네이션 정정을 main 에 반영

### DIFF
--- a/.github/workflows/cache-generation-sweep.yml
+++ b/.github/workflows/cache-generation-sweep.yml
@@ -57,19 +57,16 @@ jobs:
             const keep = Math.max(1, Number(process.env.KEEP_GENERATIONS) || 2);
 
             // 열린 PR 의 ref 는 보호한다 — 머지 전에 재사용된다.
-            const openPrRefs = new Set();
-            for await (const res of github.paginate.iterator(
+            const openPrs = await github.paginate(
               github.rest.pulls.list, { ...context.repo, state: 'open', per_page: 100 },
-            )) {
-              for (const pr of res.data) openPrRefs.add(`refs/pull/${pr.number}/merge`);
-            }
+            );
+            const openPrRefs = new Set(openPrs.map((pr) => `refs/pull/${pr.number}/merge`));
 
-            const caches = [];
-            for await (const res of github.paginate.iterator(
+            // paginate 는 이 엔드포인트의 `actions_caches` 를 평탄화해 배열로 준다
+            // (`res.data.actions_caches` 로 접근하면 undefined — 2026-08-02 실측).
+            const caches = await github.paginate(
               github.rest.actions.getActionsCacheList, { ...context.repo, per_page: 100 },
-            )) {
-              caches.push(...res.data.actions_caches);
-            }
+            );
 
             const before = caches.reduce((n, c) => n + c.size_in_bytes, 0);
             const gb = (b) => (b / 1024 ** 3).toFixed(2);


### PR DESCRIPTION
## 요약

[#3813](https://github.com/edwardkim/rhwp/pull/3813)(devel merge 완료)의 **동일 수정을
main 에 반영**합니다. 7 insertions / 10 deletions, 파일 1개.

## 왜 main 에도 필요한가

등록형 워크플로는 **기본 브랜치 기준으로 동작**합니다. devel 만 고치면 dispatch·schedule
은 여전히 main 의 낡은 코드를 실행합니다([#3812](https://github.com/edwardkim/rhwp/pull/3812)
에서 확인한 것과 같은 성질).

## 고치는 결함

첫 `dry_run` dispatch 가 실패했습니다:

```
TypeError: res.data.actions_caches is not iterable
```

[실패 run 30751064499](https://github.com/edwardkim/rhwp/actions/runs/30751064499)

`github.paginate.iterator` 는 이 엔드포인트의 `actions_caches` 를 평탄화해 배열로 주는데,
원시 응답 형태(`{total_count, actions_caches: [...]}`)를 가정한 것이 원인입니다.
`github.paginate()` 직접 호출로 바꿉니다.

## 검증

- devel 판(#3813) CI **18 pass**, merge 완료.
- 이 PR 은 그와 **동일 내용**(`git checkout origin/devel --` 로 가져옴).
- 실동작은 merge 후 `dry_run: true` dispatch 로 확인합니다.

`dry_run` 기본값을 true 로 둔 설계가 실제 삭제 전에 이 버그를 잡았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
