### PR TITLE
fix(pdf): PDF 텍스트 표면의 한컴 PUA 원숫자를 표준 코드포인트로 — 렌더 결정은 불변 (#3824)

### DIFF
--- a/src/renderer/pdf.rs
+++ b/src/renderer/pdf.rs
@@ -665,6 +665,127 @@ fn escape_xml_attr(value: &str) -> String {
     escaped
 }
 
+/// [#3824] PDF 텍스트 표면(`ToUnicode`)의 한컴 PUA 를 표준 코드포인트로 바꾼다.
+///
+/// #3385 가 `export-text` 표면을 고쳤지만, 사용자가 실제로 검색하는 **PDF 표면**은
+/// 그대로 PUA 를 내보내고 있었다. "①" 을 검색하면 안 걸리고 스크린리더는 사설 영역
+/// 문자를 읽는다.
+///
+/// **렌더 결정은 건드리지 않는다.** 글리프 선택은 PUA 로 두어야 fallback 이 맞는다
+/// (`map_pua_bullet_char` 주석 참조). 바꿀 곳은 글리프 → 유니코드 대응표뿐이다.
+///
+/// 매핑은 새로 짓지 않고 텍스트 표면이 쓰는 표(`pua_to_text_surface`)를 그대로
+/// 재사용한다 — 두 표면이 갈리지 않게 하는 것이 이 수정의 요지다.
+///
+/// ## 왜 바이트 수준인가
+///
+/// `ToUnicode` CMap 은 svg2pdf 가 만든다. 그런데 한컴 PUA 의 뜻은 **rhwp 도메인
+/// 지식**이라 범용 SVG 변환기가 알 이유가 없다. 그래서 rhwp 가 자기 출력에서
+/// 대응표만 고친다.
+///
+/// 안전 근거 — 실측으로 확인한 세 성질에 기댄다.
+///   1. CMap 스트림은 **비압축**이다(`/Type /CMap`, `/Filter` 없음).
+///   2. svg2pdf 는 `beginbfchar` 만 쓴다(`beginbfrange` 0개).
+///   3. 대체 문자열이 원본보다 짧으므로 **공백으로 채워 길이를 보존**한다 →
+///      `/Length` 와 xref 오프셋을 건드리지 않는다. 채움 공백은 꺾쇠 **안**에
+///      들어가는데(`<2460    >`), PDF 명세상 16진 문자열 안의 공백은 무시되므로
+///      `<2460>` 과 같은 값이다.
+///
+/// 길이가 늘어나는 경우(다중 문자 대체)는 **건너뛴다** — 길이 보존이 깨지기 때문이다.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn remap_pua_in_tounicode(pdf: &mut [u8]) {
+    const BEGIN: &[u8] = b"beginbfchar";
+    const END: &[u8] = b"endbfchar";
+    let mut cursor = 0usize;
+    while let Some(rel) = find_bytes(&pdf[cursor..], BEGIN) {
+        let start = cursor + rel + BEGIN.len();
+        let Some(rel_end) = find_bytes(&pdf[start..], END) else {
+            break;
+        };
+        let end = start + rel_end;
+        remap_bfchar_block(&mut pdf[start..end]);
+        cursor = end + END.len();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn find_bytes(hay: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || hay.len() < needle.len() {
+        return None;
+    }
+    hay.windows(needle.len()).position(|w| w == needle)
+}
+
+/// `<src> <dst>` 쌍이 늘어선 블록에서 dst 만 고친다.
+#[cfg(not(target_arch = "wasm32"))]
+fn remap_bfchar_block(block: &mut [u8]) {
+    let mut spans: Vec<(usize, usize)> = Vec::new();
+    let mut i = 0usize;
+    while i < block.len() {
+        if block[i] == b'<' {
+            match block[i + 1..].iter().position(|&b| b == b'>') {
+                Some(rel) => {
+                    spans.push((i + 1, i + 1 + rel));
+                    i += rel + 2;
+                }
+                None => break,
+            }
+            continue;
+        }
+        i += 1;
+    }
+    // 짝수 번째가 src, 홀수 번째가 dst 다.
+    for pair in spans.chunks(2) {
+        let dst = match pair {
+            [_src, dst] => *dst,
+            _ => continue,
+        };
+        let (s, e) = dst;
+        let text = match utf16be_hex_to_string(&block[s..e]) {
+            Some(t) => t,
+            None => continue,
+        };
+        let mapped = crate::renderer::composer::pua_to_text_surface(&text);
+        if mapped.as_ref() == text.as_str() {
+            continue;
+        }
+        let hex = string_to_utf16be_hex(mapped.as_ref());
+        if hex.len() > e - s {
+            continue; // 길이 보존이 깨진다 — 손대지 않는다
+        }
+        block[s..s + hex.len()].copy_from_slice(hex.as_bytes());
+        for b in &mut block[s + hex.len()..e] {
+            *b = b' ';
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn utf16be_hex_to_string(hex: &[u8]) -> Option<String> {
+    if hex.is_empty() || !hex.len().is_multiple_of(4) {
+        return None;
+    }
+    let mut units = Vec::with_capacity(hex.len() / 4);
+    for quad in hex.chunks(4) {
+        let mut v: u16 = 0;
+        for &b in quad {
+            let d = (b as char).to_digit(16)? as u16;
+            v = v.checked_mul(16)?.checked_add(d)?;
+        }
+        units.push(v);
+    }
+    String::from_utf16(&units).ok()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn string_to_utf16be_hex(s: &str) -> String {
+    let mut out = String::new();
+    for unit in s.encode_utf16() {
+        out.push_str(&format!("{unit:04X}"));
+    }
+    out
+}
+
 /// 단일 SVG를 PDF로 변환
 #[cfg(not(target_arch = "wasm32"))]
 pub fn svg_to_pdf(svg_content: &str) -> Result<Vec<u8>, String> {
@@ -805,7 +926,10 @@ pub fn svgs_to_pdf_with_options(
     pdf.document_info(info_ref)
         .producer(pdf_writer::TextStr("rhwp"));
 
-    Ok(pdf.finish())
+    // [#3824] 텍스트 표면만 표준 코드포인트로 맞춘다 — 렌더 결정은 불변.
+    let mut bytes = pdf.finish();
+    remap_pua_in_tounicode(&mut bytes);
+    Ok(bytes)
 }
 
 /// Record PageLayerTree pages directly into a native Skia PDF document.
@@ -901,6 +1025,59 @@ pub fn layer_trees_to_pdf_with_options(
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
+
+    /// [#3824] ToUnicode 의 한컴 PUA 를 표준 코드포인트로 바꾸되 **길이를 보존**한다.
+    ///
+    /// 길이가 보존돼야 `/Length` 와 xref 오프셋을 건드리지 않는다 — 이 수정이
+    /// 바이트 수준에서 안전한 근거가 그것뿐이다.
+    #[test]
+    fn tounicode_pua_is_remapped_without_changing_length() {
+        // U+F02B1(사각 안 1)은 평면 15 라 UTF-16BE 서로게이트 쌍 DB80 DEB1 이다.
+        let src = b"beginbfchar
+<0001> <DB80DEB1>
+<0002> <DB80DEB2>
+endbfchar";
+        let mut buf = src.to_vec();
+        let before = buf.len();
+        remap_pua_in_tounicode(&mut buf);
+
+        assert_eq!(buf.len(), before, "길이가 바뀌면 /Length 와 xref 가 깨진다");
+        let out = String::from_utf8(buf).expect("utf-8");
+        assert!(
+            out.contains("<2460") && out.contains("<2461"),
+            "표준 원문자로 안 바뀌었다: {out}"
+        );
+        assert!(!out.contains("DB80"), "PUA 서로게이트가 남아 있다: {out}");
+    }
+
+    /// 뜻을 모르는 코드포인트는 손대지 않는다 — 매핑을 지어내지 않는다는 계약.
+    #[test]
+    fn tounicode_leaves_unmapped_codepoints_alone() {
+        let src = b"beginbfchar
+<0001> <AC00>
+<0002> <0041>
+endbfchar";
+        let mut buf = src.to_vec();
+        remap_pua_in_tounicode(&mut buf);
+        assert_eq!(buf, src.to_vec(), "매핑 없는 문자를 건드렸다");
+    }
+
+    /// `beginbfchar` 블록 **밖**은 건드리지 않는다 — 콘텐츠 스트림 오손 방지.
+    #[test]
+    fn tounicode_does_not_touch_bytes_outside_the_block() {
+        let src = b"<DB80DEB1> beginbfchar
+<0001> <DB80DEB1>
+endbfchar <DB80DEB1>";
+        let mut buf = src.to_vec();
+        remap_pua_in_tounicode(&mut buf);
+        let out = String::from_utf8(buf).expect("utf-8");
+        assert_eq!(
+            out.matches("DB80DEB1").count(),
+            2,
+            "블록 밖 바이트까지 고쳤다: {out}"
+        );
+        assert!(out.contains("<2460"), "블록 안은 고쳐야 한다: {out}");
+    }
 
     #[test]
     fn pdf_backend_aliases_are_explicit() {


### PR DESCRIPTION
Fixes #3824

#3385 가 `export-text` 표면을 고쳤지만, 사용자가 실제로 검색하는 **PDF 표면**은 그대로
PUA 를 내보내고 있었습니다. PDF 에서 "①" 을 검색하면 안 걸리고 스크린리더는 사설 영역
문자를 읽습니다.

```
export-text (IR)        ①②③④⑤          U+2460~U+2464
PDF 텍스트 스트림          U+F02B1~F02B5    한컴 PUA
```

## 무엇을 바꾸지 **않았나**

**글리프 선택은 그대로 PUA 입니다.** 표준 코드포인트로 바꾸면 1순위 폰트의 원 글리프가
먼저 잡혀 fallback 이 안 먹습니다(`map_pua_bullet_char` 주석 근거). 바꾼 곳은
글리프→유니코드 대응표(`ToUnicode` CMap)뿐이라 **렌더는 픽셀 단위로 불변**입니다.

매핑은 새로 짓지 않고 텍스트 표면이 쓰는 표(`pua_to_text_surface`)를 그대로 재사용합니다
— 두 표면이 다시 갈리지 않게 하는 것이 이 수정의 요지입니다.

## 왜 바이트 수준인가

`ToUnicode` 는 svg2pdf 가 만듭니다. 그런데 **한컴 PUA 의 뜻은 rhwp 도메인 지식**이라
범용 SVG 변환기가 알 이유가 없습니다. 그래서 rhwp 가 자기 출력에서 대응표만 고칩니다.

안전 근거 — 실측으로 확인한 세 성질에 기댑니다.

1. CMap 스트림은 **비압축**입니다 (`/Type /CMap`, `/Filter` 없음)
2. svg2pdf 는 **`beginbfchar` 만** 씁니다 (`beginbfrange` 0개)
3. 대체가 원본보다 짧으므로 **공백으로 채워 길이를 보존**합니다 → `/Length` 와 xref
   오프셋을 안 건드립니다. 채움 공백은 꺾쇠 **안**에 들어가는데(`<2460    >`), PDF
   명세상 16진 문자열 안의 공백은 무시되므로 `<2460>` 과 같은 값입니다

길이가 늘어나는 경우(다중 문자 대체)는 **건너뜁니다**.

## 측정

| 게이트 | 결과 |
|---|---|
| **nextest 전량** | **5,047 / 5,047 통과** |
| 단위 테스트 3종 | 3/3 |
| fmt · clippy `-D warnings` | 통과 |
| 대상 문서 PDF 추출 | PUA 5 → **표준 ①②③④⑤**, PUA 0 |
| **파일 크기** | 400,572 → **400,572** (바이트 동일 = 길이 보존 확인) |
| **래스터 해시 1·2쪽** | **완전 동일** (렌더 불변) |

**텍스트 정합 스윕 300문서** (`output/poc/textfidelity_20260723/scan.py`)

| | 이전 | 현재 |
|---|---|---|
| 실질 손실 문서 | 17 | **12** |
| 실질 손실 합계 | 116 | **74** |
| 원숫자 손실 | 45 | **3** |
| **악화 문서** | — | **0** |

## 범위 밖 두 가지 (명시)

**잔여 원숫자 3건은 이 축이 아닙니다.** `2388951` 은 SVG 에 `①②③④` 가 표준
코드포인트로 있고 **`⑤` 만 아예 없습니다**(PUA 도 0). 글자 하나가 렌더에서 누락되는
별개 결함입니다.

**`--backend direct`(Skia 자체 PDF)도 범위 밖입니다.** 실측하니 이미 표준 코드포인트를
내고 PUA 가 0 이며, `beginbfchar` 가 0개(압축 스트림)라 이 후처리도 no-op 입니다.

## 단위 테스트

계약 셋을 각각 못박았습니다.

- `길이를 보존하며 PUA → 표준` — 길이가 바뀌면 `/Length` 와 xref 가 깨집니다
- `매핑 없는 코드포인트는 안 건드림` — 매핑을 지어내지 않는다는 계약
- `beginbfchar 블록 밖은 안 건드림` — 콘텐츠 스트림 오손 방지

🤖 Generated with [Claude Code](https://claude.com/claude-code)
