### PR TITLE
[#3828 B4] rhwp explain — 문서 자기서술, 도메인 지식 0 인 에이전트를 위한 결정론적 문장

### DIFF
--- a/src/document_core/queries/explain.rs
+++ b/src/document_core/queries/explain.rs
@@ -1,0 +1,80 @@
+//! `explain` 명령의 전용 집계 — 각주/미주 개수.
+//!
+//! `info`·`export-structure`·`export-tables`·`fields` 는 이미 문서 요약에 필요한
+//! 대부분을 돌려준다. 이 모듈은 그 네 조회가 채우지 못하는 마지막 구멍 하나,
+//! 각주·미주 개수만 담당한다. 새 판정 로직이 아니라 `table_extract::collect_from_paragraph`
+//! 와 같은 컨테이너 재귀(글상자·머리말·꼬리말·표 셀·각주·미주)를 그대로 따라간다 —
+//! 최상위 문단의 controls 만 훑으면 글상자·표 셀 안에 놓인 각주/미주를 놓친다.
+
+use crate::model::control::Control;
+use crate::model::document::Document;
+use crate::model::paragraph::Paragraph;
+
+/// 문서 안 각주·미주 개수.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoteCounts {
+    pub footnote_count: usize,
+    pub endnote_count: usize,
+}
+
+/// 병적으로 깊은 중첩(손상/악의적 문서)에서 스택이 터지지 않게 하는 상한.
+/// `table_extract::MAX_NEST_DEPTH` 와 같은 값을 쓴다.
+const MAX_NEST_DEPTH: usize = 8;
+
+fn count_from_paragraph(para: &Paragraph, depth: usize, counts: &mut NoteCounts) {
+    if depth >= MAX_NEST_DEPTH {
+        return;
+    }
+    for control in &para.controls {
+        match control {
+            Control::Footnote(f) => {
+                counts.footnote_count += 1;
+                for p in &f.paragraphs {
+                    count_from_paragraph(p, depth + 1, counts);
+                }
+            }
+            Control::Endnote(e) => {
+                counts.endnote_count += 1;
+                for p in &e.paragraphs {
+                    count_from_paragraph(p, depth + 1, counts);
+                }
+            }
+            Control::Table(table) => {
+                for cell in &table.cells {
+                    for p in &cell.paragraphs {
+                        count_from_paragraph(p, depth + 1, counts);
+                    }
+                }
+            }
+            Control::Shape(shape) => {
+                if let Some(tb) = shape.drawing().and_then(|d| d.text_box.as_ref()) {
+                    for p in &tb.paragraphs {
+                        count_from_paragraph(p, depth + 1, counts);
+                    }
+                }
+            }
+            Control::Header(h) => {
+                for p in &h.paragraphs {
+                    count_from_paragraph(p, depth + 1, counts);
+                }
+            }
+            Control::Footer(f) => {
+                for p in &f.paragraphs {
+                    count_from_paragraph(p, depth + 1, counts);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// 문서 전체(본문·글상자·머리말/꼬리말·표 셀 포함)의 각주/미주 개수를 센다.
+pub fn count_notes(doc: &Document) -> NoteCounts {
+    let mut counts = NoteCounts::default();
+    for section in &doc.sections {
+        for para in &section.paragraphs {
+            count_from_paragraph(para, 0, &mut counts);
+        }
+    }
+    counts
+}

--- a/src/document_core/queries/mod.rs
+++ b/src/document_core/queries/mod.rs
@@ -2,6 +2,8 @@ mod bookmark_query;
 mod cursor_nav;
 mod cursor_rect;
 pub(crate) mod doc_tree_nav;
+/// [#3828] `explain` 명령 전용 집계(각주/미주 개수) — 다른 조회가 채우지 못하는 구멍.
+pub mod explain;
 // [#3281] `fields` CLI 가 필드 위치(NestedEntry)를 읽어야 하므로 공개한다.
 // 읽기 전용 질의 모듈이며 `structure`·`rendering` 과 같은 가시성이다.
 pub mod field_query;

--- a/src/main.rs
+++ b/src/main.rs
@@ -336,6 +336,7 @@ fn main() {
         Some("bench") => exit_with(rhwp::diagnostics::bench::run(&args[2..])),
         Some("thumbnail") => exit_with(extract_thumbnail(&args[2..])),
         Some("fields") => exit_with(show_fields(&args[2..])),
+        Some("explain") => exit_with(explain_document(&args[2..])),
         Some("edit") => exit_with(run_edit(&args[2..])),
         Some("run") => exit_with(cmd_run_plan(&args[2..])),
         // [#2707] 알 수 없는 명령·명령 누락은 사용법 오류다. 표준 CLI 관례대로 stderr 로 안내하고
@@ -507,6 +508,7 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
                 | "hwp_search"
                 | "hwp_extract_data"
                 | "hwp_fields"
+                | "hwp_explain"
                 | "hwp_inspect_hidden_text"
                 | "hwp_inspect_injection"
                 | "hwp_inspect_unicode"
@@ -916,6 +918,28 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
             "fields",
             serde_json::json!(["fields", "{path}", "--json"]),
             &["source", "fieldCount", "fields"],
+        ),
+        // [#3828] 처음 보는 문서를 한 번에 파악하는 요약 — hwp_info/hwp_export_structure/
+        // hwp_export_tables/hwp_fields 를 이미 열어본 값의 조합일 뿐 새 판정은 없다.
+        tool(
+            "hwp_explain",
+            "문서를 처음 보는 에이전트를 위해 결정론적 규칙 문장으로 요약한다 — 형식·쪽수·문단 수, 표 개수와 크기·병합 여부, 누름틀 이름, 각주/미주 개수, 암호 여부. hwp_info 등 개별 조회를 하나씩 부르기 전에 먼저 호출하면 문서의 전체 그림을 한 번에 얻는다.",
+            path_schema(serde_json::json!({})),
+            "explain",
+            serde_json::json!(["explain", "{path}", "--json"]),
+            &[
+                "schemaVersion",
+                "source",
+                "format",
+                "pageCount",
+                "paragraphCount",
+                "tables",
+                "fields",
+                "footnoteCount",
+                "endnoteCount",
+                "encrypted",
+                "summary",
+            ],
         ),
         // [#3787 S3] 신뢰할 수 없는 문서를 LLM 에 먹이기 전에 부르는 도구.
         // 본문 텍스트는 그대로 프롬프트가 되므로, 사람이 열어도 안 보이는 문자열이
@@ -1813,6 +1837,28 @@ fn capabilities_command_entries() -> Vec<serde_json::Value> {
             &["--json"],
             &["schemaVersion", "source", "fieldCount", "fields"],
         ),
+        // [#3828] 새 판정 로직이 아니라 info/export-structure/export-tables/fields의
+        // 조합 — 처음 보는 문서를 사람/에이전트가 한 번에 파악하는 결정론적 요약.
+        cmd_json(
+            "explain",
+            "query",
+            "문서를 결정론적 규칙 문장으로 요약(형식·쪽수·문단·표·누름틀·각주/미주·암호 여부)",
+            false,
+            &["--json"],
+            &[
+                "schemaVersion",
+                "source",
+                "format",
+                "pageCount",
+                "paragraphCount",
+                "tables",
+                "fields",
+                "footnoteCount",
+                "endnoteCount",
+                "encrypted",
+                "summary",
+            ],
+        ),
         // [#3787 S2/S3/S4] 문서를 읽기만 하는 보안 검사 명령군. 세 하위 명령의 플래그와
         // 봉투 필드는 합집합으로 광고해 capabilities 자체가 어느 축도 숨기지 않게 한다.
         cmd_json(
@@ -2542,6 +2588,13 @@ fn print_help() {
     println!("      --pages <a..b>          해당 쪽 범위만 발췌 (0 기준, 양끝 포함) —");
     println!("                              nextStep 이 남은 범위의 다음 호출을 안내");
     println!("      --max-chars <N>         발췌 최대 문자 수 (기본: 2000, 절 모드는 절별 240)");
+    println!();
+    println!("  explain <파일.hwp|파일.hwpx|파일.hml> [--json]");
+    println!("      문서를 처음 보는 에이전트를 위한 결정론적 요약 문장(형식·쪽수·문단 수·");
+    println!("      표·누름틀·각주/미주·암호 여부) — info/export-structure/export-tables/");
+    println!("      fields 를 조합한 템플릿 조립일 뿐 LLM 판정은 없다 (#3828)");
+    println!();
+    println!("      --json                  요약 봉투를 JSON으로 stdout에 출력");
     println!();
     println!("  capabilities [--mcp]");
     println!("      도구 자기서술 JSON 출력 (명령·플래그·JSON 계약·종료 코드) — 에이전트용");
@@ -16190,6 +16243,238 @@ fn show_fields(args: &[String]) -> i32 {
             }
         );
     }
+    EXIT_OK
+}
+
+/// [#3828] `explain --json` 봉투의 표 항목 — `export-tables` 격자에서 텍스트를 빼고
+/// 크기·병합 여부만 남긴다. 셀 내용을 싣지 않으므로 이 필드들은 전부 엔진값이다
+/// (`src/provenance.rs` 의 `explain` 항목이 그 근거를 명시한다).
+fn explain_table_summary(
+    grid: &rhwp::document_core::queries::table_extract::TableGrid,
+) -> serde_json::Value {
+    let has_merged_cells = grid.cells.iter().any(|c| c.row_span > 1 || c.col_span > 1);
+    serde_json::json!({
+        "index": grid.index,
+        "rows": grid.rows,
+        "cols": grid.cols,
+        "hasMergedCells": has_merged_cells,
+    })
+}
+
+/// [#3828] 표 하나를 사람 문장 조각으로 만든다 — "표 1(3×4, 병합 셀 있음)".
+/// 1 기준 번호를 쓰는 이유는 `export-tables` 의 0 기준 `index` 를 그대로 읽는 사람이
+/// "0번 표"라는 어색한 표현을 안 보게 하려는 것뿐이고, JSON 쪽 `index` 는 0 기준을
+/// 그대로 유지해 `export-tables`·`hwp_table_to_csv` 의 표 번호와 어긋나지 않는다.
+fn explain_table_phrase(t: &serde_json::Value) -> String {
+    let human_no = t["index"].as_u64().unwrap_or(0) + 1;
+    let rows = t["rows"].as_u64().unwrap_or(0);
+    let cols = t["cols"].as_u64().unwrap_or(0);
+    if t["hasMergedCells"] == true {
+        format!("표 {human_no}({rows}×{cols}, 병합 셀 있음)")
+    } else {
+        format!("표 {human_no}({rows}×{cols})")
+    }
+}
+
+/// [#3828] `explain`·`explain --json` 이 공유하는 사람 문장 조립.
+///
+/// 결정론적 템플릿 조립이다 — 네 조회(`info`·`export-structure`·`export-tables`·
+/// `fields`)와 각주/미주 집계가 이미 확정한 값을 문장으로 옮길 뿐, 여기서 새로
+/// 판정하는 값은 없다. "부분 목록 금지"(#3719) 원칙에 따라 확신 없는 값은 만들지
+/// 않는다 — 표·필드 이름은 있는 그대로 전부 나열하고, 축약·상위 N개 자르기를 하지
+/// 않는다.
+fn explain_summary(
+    format_label: &str,
+    page_count: u32,
+    para_count: usize,
+    tables: &[serde_json::Value],
+    field_names: &[String],
+    footnote_count: usize,
+    endnote_count: usize,
+    encrypted: bool,
+) -> String {
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "이 문서는 {format_label} 형식, {page_count}쪽, 문단 {para_count}개다."
+    ));
+
+    if tables.is_empty() {
+        lines.push("표는 없다.".to_string());
+    } else {
+        let phrases: Vec<String> = tables.iter().map(explain_table_phrase).collect();
+        lines.push(format!(
+            "표가 {}개 있다 — {}.",
+            tables.len(),
+            phrases.join(", ")
+        ));
+    }
+
+    if field_names.is_empty() {
+        lines.push("누름틀은 없다.".to_string());
+    } else {
+        lines.push(format!(
+            "누름틀이 {}개 있다 — 이름: {}.",
+            field_names.len(),
+            field_names.join(", ")
+        ));
+    }
+
+    if footnote_count == 0 && endnote_count == 0 {
+        lines.push("각주와 미주는 모두 없다.".to_string());
+    } else {
+        lines.push(format!(
+            "각주가 {footnote_count}개, 미주가 {endnote_count}개 있다."
+        ));
+    }
+
+    lines.push(if encrypted {
+        "암호로 보호돼 있다.".to_string()
+    } else {
+        "암호로 보호돼 있지 않다.".to_string()
+    });
+
+    lines.join("\n")
+}
+
+/// [#3828] `explain --json` 이 내는 계약 봉투. `capabilities --mcp` 의 `hwp_explain`
+/// 도구와 CLI `explain --json`이 이 함수 하나를 공유한다.
+fn explain_json_value(
+    file_path: &str,
+    format_label: &str,
+    page_count: u32,
+    para_count: usize,
+    tables: Vec<serde_json::Value>,
+    field_names: Vec<String>,
+    footnote_count: usize,
+    endnote_count: usize,
+    encrypted: bool,
+) -> serde_json::Value {
+    let summary = explain_summary(
+        format_label,
+        page_count,
+        para_count,
+        &tables,
+        &field_names,
+        footnote_count,
+        endnote_count,
+        encrypted,
+    );
+    provenance::marked(
+        serde_json::json!({
+            "schemaVersion": "1.0",
+            "source": file_path,
+            "format": format_label,
+            "pageCount": page_count,
+            "paragraphCount": para_count,
+            "tables": tables,
+            "fields": field_names,
+            "footnoteCount": footnote_count,
+            "endnoteCount": endnote_count,
+            "encrypted": encrypted,
+            "summary": summary,
+        }),
+        "explain",
+    )
+}
+
+/// `rhwp explain <파일> [--json]` — 처음 보는 문서를 결정론적 규칙 문장으로 설명한다.
+///
+/// [#3828] 새 판정 로직이 아니라 기존 조회(`info`·`export-structure`·`export-tables`·
+/// `fields`)가 이미 계산한 값의 조합이다 — LLM 을 쓰지 않는다. 암호 문서는
+/// `load_document` 가 다른 명령과 같은 규약(비밀번호 없으면 `EXIT_USAGE`, 틀리면
+/// `EXIT_RUNTIME`)으로 거부하므로 explain 도 자동으로 그 규약을 따른다.
+fn explain_document(args: &[String]) -> i32 {
+    let mut json_mode = false;
+    let mut file_path: Option<&str> = None;
+    for arg in args {
+        match arg.as_str() {
+            "--json" => json_mode = true,
+            other if other.starts_with('-') => {
+                eprintln!("알 수 없는 옵션: {other}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if file_path.replace(other).is_some() {
+                    eprintln!("오류: 입력 파일은 하나만 지정할 수 있습니다: {other}");
+                    return EXIT_USAGE;
+                }
+            }
+        }
+    }
+    let Some(file_path) = file_path else {
+        eprintln!("사용법: rhwp explain <파일.hwp|파일.hwpx|파일.hml> [--json]");
+        return EXIT_USAGE;
+    };
+
+    let data = match fs::read(file_path) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
+            return EXIT_RUNTIME;
+        }
+    };
+
+    let detected_format = rhwp::parser::detect_format(&data);
+    let doc = match load_document(&data) {
+        Ok(d) => d,
+        Err(e) => return e.report(),
+    };
+
+    let document = doc.document();
+    let format_label = match detected_format {
+        rhwp::parser::FileFormat::Hwp => "HWP5",
+        rhwp::parser::FileFormat::Hwpx => "HWPX",
+        rhwp::parser::FileFormat::Hwp3 => "HWP3",
+        rhwp::parser::FileFormat::Hml => "HML",
+        rhwp::parser::FileFormat::DrmProtected => "DRM",
+        rhwp::parser::FileFormat::Empty => "빈 파일",
+        rhwp::parser::FileFormat::Unknown => "알 수 없음",
+    };
+    let page_count = doc.page_count();
+    let para_count: usize = document.sections.iter().map(|s| s.paragraphs.len()).sum();
+
+    use rhwp::document_core::queries::table_extract::extract_tables;
+    let tables: Vec<serde_json::Value> = extract_tables(document)
+        .iter()
+        .map(explain_table_summary)
+        .collect();
+
+    let field_records = collect_field_records(&doc);
+    let field_names: Vec<String> = field_records
+        .iter()
+        .map(|f| f["name"].as_str().unwrap_or("").to_string())
+        .collect();
+
+    let notes = rhwp::document_core::queries::explain::count_notes(document);
+    let encrypted = document.header.encrypted;
+
+    if json_mode {
+        let envelope = explain_json_value(
+            file_path,
+            format_label,
+            page_count,
+            para_count,
+            tables,
+            field_names,
+            notes.footnote_count,
+            notes.endnote_count,
+            encrypted,
+        );
+        println!("{envelope}");
+        return EXIT_OK;
+    }
+
+    let summary = explain_summary(
+        format_label,
+        page_count,
+        para_count,
+        &tables,
+        &field_names,
+        notes.footnote_count,
+        notes.endnote_count,
+        encrypted,
+    );
+    println!("{summary}");
     EXIT_OK
 }
 

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -177,6 +177,17 @@ pub const MAP: &[CommandProvenance] = &[
         note: "fieldCount·location 좌표·editableInForm 은 엔진값이다.",
     },
     CommandProvenance {
+        command: "explain",
+        untrusted: &[
+            f("fields[]", "collect_field_records — 누름틀 이름 목록"),
+            f(
+                "summary",
+                "explain_summary — 표 개수·누름틀 이름 등을 엮은 사람용 문장. 위 fields[] 와 같은 이름 문자열이 그대로 섞여 들어간다",
+            ),
+        ],
+        note: "format·pageCount·paragraphCount·footnoteCount·endnoteCount·encrypted 는 엔진값이고, tables[] 는 rows/cols/hasMergedCells 만 담아 셀 텍스트를 싣지 않는다.",
+    },
+    CommandProvenance {
         command: "export-tables",
         untrusted: &[
             f("tables[].caption", "표 캡션 텍스트"),

--- a/tests/explain_contract.rs
+++ b/tests/explain_contract.rs
@@ -1,0 +1,301 @@
+//! [#3828] `explain` 출력 계약 회귀 테스트.
+//!
+//! 계약: `explain --json` 의 stdout 은 순수 JSON 한 덩어리이고 `schemaVersion` 을
+//! 포함한다. 값 자체는 새 판정이 아니라 `info`·`export-structure`·`export-tables`·
+//! `fields` 가 이미 계산한 값의 조합이므로, 이 시험은 그 조합이 실제 문서에서
+//! 정확한지(표 크기·병합 여부·누름틀 이름·각주/미주 개수·암호 여부)와 종료 코드
+//! 계약(#2707)을 검증한다. 암호 문서는 다른 명령과 같은 `load_document` 규약을
+//! 타므로 explain 도 자동으로 같은 종료 코드를 낸다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// 누름틀 11개, 표 없음.
+const SAMPLE_FIELDS: &str = "samples/field-01.hwp";
+/// 표 1개(19×9, 병합 셀 있음), 누름틀 없음.
+const SAMPLE_TABLE: &str = "samples/table-001.hwp";
+/// 표·누름틀 모두 없는 일반 문서(HWP5).
+const SAMPLE_PLAIN: &str = "samples/para-001.hwp";
+/// 각주 9개.
+const SAMPLE_FOOTNOTE: &str = "samples/footnote-01.hwp";
+/// 미주 6개.
+const SAMPLE_ENDNOTE: &str = "samples/endnote-01.hwp";
+/// 비밀번호 "123456" 로 걸린 HWP5 문서.
+const SAMPLE_ENCRYPTED: &str = "samples/hwp3-sample16-hwp5-2024-password-123456.hwp";
+
+fn sample(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(rhwp_bin())
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn run_json(rel: &str) -> serde_json::Value {
+    let p = sample(rel);
+    let args = ["explain", p.to_str().unwrap(), "--json"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout 이 순수 JSON 이 아닙니다 ({e}).\n{}",
+            describe(&args, &output)
+        )
+    })
+}
+
+/// [#3289] 아카이브 실행 시 컴파일타임 경로는 빌드 러너 전용이므로,
+/// nextest가 런타임에 재매핑해 주입하는 CARGO_BIN_EXE_rhwp를 우선한다.
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}
+
+#[test]
+fn explain_json_envelope_contract() {
+    let v = run_json(SAMPLE_FIELDS);
+    assert_eq!(v["schemaVersion"], "1.0", "{v}");
+    assert!(v["source"].is_string(), "{v}");
+    assert!(v["format"].is_string(), "{v}");
+    assert!(v["pageCount"].as_u64().is_some(), "{v}");
+    assert!(v["paragraphCount"].as_u64().is_some(), "{v}");
+    assert!(v["tables"].is_array(), "{v}");
+    assert!(v["fields"].is_array(), "{v}");
+    assert!(v["footnoteCount"].as_u64().is_some(), "{v}");
+    assert!(v["endnoteCount"].as_u64().is_some(), "{v}");
+    assert!(v["encrypted"].is_boolean(), "{v}");
+    assert!(v["summary"].is_string(), "{v}");
+}
+
+#[test]
+fn explain_reports_field_names() {
+    let v = run_json(SAMPLE_FIELDS);
+    let names: Vec<&str> = v["fields"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|f| f.as_str())
+        .collect();
+    assert!(
+        names.len() >= 3,
+        "이름 있는 필드가 여럿이어야 합니다: {names:?}"
+    );
+    assert!(names.contains(&"회사명"), "{names:?}");
+    assert_eq!(v["tables"].as_array().unwrap().len(), 0, "{v}");
+    let summary = v["summary"].as_str().unwrap();
+    assert!(
+        summary.contains("누름틀이"),
+        "요약에 누름틀 문장이 있어야 합니다: {summary}"
+    );
+    assert!(summary.contains("회사명"), "{summary}");
+    assert!(
+        summary.contains("표는 없다"),
+        "표 없는 문서는 '표는 없다' 문장이어야 합니다: {summary}"
+    );
+}
+
+#[test]
+fn explain_reports_table_shape_and_merge() {
+    let v = run_json(SAMPLE_TABLE);
+    let tables = v["tables"].as_array().unwrap();
+    assert_eq!(tables.len(), 1, "{v}");
+    let t = &tables[0];
+    assert_eq!(t["index"], 0, "{t}");
+    assert_eq!(t["rows"], 19, "{t}");
+    assert_eq!(t["cols"], 9, "{t}");
+    assert_eq!(t["hasMergedCells"], true, "{t}");
+    // 표 항목에는 셀 텍스트·캡션이 없어야 한다 — 요약은 크기/병합 여부만 담는다.
+    assert!(t.get("cells").is_none(), "{t}");
+    assert!(t.get("text").is_none(), "{t}");
+    let summary = v["summary"].as_str().unwrap();
+    assert!(summary.contains("표 1(19×9, 병합 셀 있음)"), "{summary}");
+    assert_eq!(v["fields"].as_array().unwrap().len(), 0, "{v}");
+    assert!(summary.contains("누름틀은 없다"), "{summary}");
+}
+
+#[test]
+fn explain_document_without_tables_or_fields_is_empty_not_error() {
+    let v = run_json(SAMPLE_PLAIN);
+    assert_eq!(v["tables"].as_array().unwrap().len(), 0, "{v}");
+    assert_eq!(v["fields"].as_array().unwrap().len(), 0, "{v}");
+    assert_eq!(v["footnoteCount"], 0, "{v}");
+    assert_eq!(v["endnoteCount"], 0, "{v}");
+    let summary = v["summary"].as_str().unwrap();
+    assert!(summary.contains("표는 없다"), "{summary}");
+    assert!(summary.contains("누름틀은 없다"), "{summary}");
+    assert!(summary.contains("각주와 미주는 모두 없다"), "{summary}");
+}
+
+#[test]
+fn explain_reports_footnote_count() {
+    let v = run_json(SAMPLE_FOOTNOTE);
+    let footnotes = v["footnoteCount"].as_u64().expect("footnoteCount");
+    assert!(footnotes >= 1, "{v}");
+    assert_eq!(v["endnoteCount"], 0, "{v}");
+    let summary = v["summary"].as_str().unwrap();
+    assert!(
+        summary.contains(&format!("각주가 {footnotes}개")),
+        "{summary}"
+    );
+}
+
+#[test]
+fn explain_reports_endnote_count() {
+    let v = run_json(SAMPLE_ENDNOTE);
+    let endnotes = v["endnoteCount"].as_u64().expect("endnoteCount");
+    assert!(endnotes >= 1, "{v}");
+    assert_eq!(v["footnoteCount"], 0, "{v}");
+    let summary = v["summary"].as_str().unwrap();
+    assert!(
+        summary.contains(&format!("미주가 {endnotes}개")),
+        "{summary}"
+    );
+}
+
+#[test]
+fn explain_default_output_is_human_summary() {
+    let p = sample(SAMPLE_FIELDS);
+    let args = ["explain", p.to_str().unwrap()];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        serde_json::from_str::<serde_json::Value>(&stdout).is_err(),
+        "기본 출력은 JSON 이 아니어야 합니다(--json 전용).\n{}",
+        describe(&args, &output)
+    );
+    assert!(stdout.contains("이 문서는"), "{stdout}");
+}
+
+#[test]
+fn explain_missing_file_exit_runtime_silent_stdout() {
+    let args = ["explain", "없는파일-explain.hwp", "--json"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "실패 경로 stdout 은 비어야 합니다.\n{}",
+        describe(&args, &output)
+    );
+}
+
+#[test]
+fn explain_usage_error_exit_two() {
+    let args = ["explain"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+}
+
+#[test]
+fn explain_multiple_files_exit_usage() {
+    let p = sample(SAMPLE_FIELDS);
+    let args = ["explain", p.to_str().unwrap(), p.to_str().unwrap(), "--json"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+}
+
+// ── 암호 문서 — 다른 명령과 같은 `load_document` 규약을 그대로 물려받는다 ──────
+
+#[test]
+fn explain_encrypted_document_without_password_is_usage_error() {
+    // [#3828] 규약: 다른 조회 명령(info 등)과 같은 종료 코드(EXIT_USAGE=2) —
+    // "암호로 보호돼 있어 상세 분석 불가"는 이 계약을 통해 자동으로 지켜진다.
+    let p = sample(SAMPLE_ENCRYPTED);
+    let args = ["explain", p.to_str().unwrap(), "--json"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "암호 문서 거부 경로 stdout 은 비어야 합니다.\n{}",
+        describe(&args, &output)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("암호"), "{stderr}");
+}
+
+#[test]
+fn explain_encrypted_document_wrong_password_exit_runtime() {
+    let p = sample(SAMPLE_ENCRYPTED);
+    let args = [
+        "explain",
+        p.to_str().unwrap(),
+        "--password",
+        "wrong-password",
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}",
+        describe(&args, &output)
+    );
+}
+
+#[test]
+fn explain_encrypted_document_with_password_reports_encrypted_true() {
+    let p = sample(SAMPLE_ENCRYPTED);
+    let args = [
+        "explain",
+        p.to_str().unwrap(),
+        "--password",
+        "123456",
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).expect("json");
+    assert_eq!(v["encrypted"], true, "{v}");
+    let summary = v["summary"].as_str().unwrap();
+    assert!(
+        summary.contains("암호로 보호돼 있다"),
+        "{summary}"
+    );
+}

--- a/tests/explain_contract.rs
+++ b/tests/explain_contract.rs
@@ -221,7 +221,12 @@ fn explain_usage_error_exit_two() {
 #[test]
 fn explain_multiple_files_exit_usage() {
     let p = sample(SAMPLE_FIELDS);
-    let args = ["explain", p.to_str().unwrap(), p.to_str().unwrap(), "--json"];
+    let args = [
+        "explain",
+        p.to_str().unwrap(),
+        p.to_str().unwrap(),
+        "--json",
+    ];
     let output = run(&args);
     assert_eq!(
         output.status.code(),
@@ -294,8 +299,5 @@ fn explain_encrypted_document_with_password_reports_encrypted_true() {
     let v: serde_json::Value = serde_json::from_slice(&output.stdout).expect("json");
     assert_eq!(v["encrypted"], true, "{v}");
     let summary = v["summary"].as_str().unwrap();
-    assert!(
-        summary.contains("암호로 보호돼 있다"),
-        "{summary}"
-    );
+    assert!(summary.contains("암호로 보호돼 있다"), "{summary}");
 }

--- a/tests/provenance_contract.rs
+++ b/tests/provenance_contract.rs
@@ -495,6 +495,14 @@ fn recipes() -> Vec<Recipe> {
             ndjson: false,
         },
         Recipe {
+            command: "explain",
+            doc: Some(field.clone()),
+            args: vec![s("explain"), p(&field), s("--json")],
+            stdin: None,
+            exit: 0,
+            ndjson: false,
+        },
+        Recipe {
             command: "edit",
             doc: Some(table.clone()),
             args: vec![


### PR DESCRIPTION
로드맵 #3828 B4. HWP 를 처음 보는 에이전트에게 "이 문서는 무엇인가"를 **결정론적 규칙
문장**으로 설명한다. 새 판정 로직이 아니라 `info`·`export-structure`·`export-tables`·`fields`
**기존 조회의 조합**이다. LLM 은 넣지 않는다.

```
rhwp explain <파일> [--json]
```

## 실측 (3가지 문서 종류로 확인)

```
$ rhwp explain samples/field-01.hwp
이 문서는 HWP5 형식, 3쪽, 문단 16개다.
표는 없다.
누름틀이 11개 있다 — 이름: 회사명, 작성자, 부서명, 전화번호, 이메일, 목차1, 목차1, 목차1, 목차1, 목차1, 제목.
각주와 미주는 모두 없다.
암호로 보호돼 있지 않다.

$ rhwp explain samples/table-001.hwp
표가 1개 있다 — 표 1(19×9, 병합 셀 있음).

$ rhwp explain samples/hwp3-sample16-...-password-123456.hwp
오류: 비밀번호가 필요한 암호 문서입니다 (--password <pw> 로 전달).  (exit 2)
$ rhwp explain ... --password 123456
...표 91개... 암호로 보호돼 있다.
```

## 부분 목록 금지 원칙(#3719) 준수

표·누름틀 이름은 **항상 전부 나열**한다(상위 N개 자르기 없음). 0건이면 "표는 없다"/
"누름틀은 없다"로 **명시**한다(필드 누락이 아니라 확정된 0이다). 확신 없는 값은
만들지 않는다 — 전부 기존 조회의 확정값을 재사용한다.

## 출처 표지(#3787 S1) 연동

`src/provenance.rs` 에 `explain` 을 등록했다 — `fields[]`·`summary` 만 문서 파생이고
`pageCount`·`tableCount` 등은 rhwp 가 만든 값이다. 새 명령을 추가할 때마다 출처 지도
드리프트 가드가 자동으로 걸리는지 실증됐다.

## 검증

`explain_contract` **13** + `cli_json_contract` **26** + `mcp_server_contract` **22** +
`provenance_contract` **7** = **68 passed / 0 failed**.
`clippy -D warnings` 0 · rustfmt clean · 선검사(#3795) 관련 항목 전부 통과
(MCP 스키마 40개 도구 · capabilities↔help 62개 명령 · 실패경로 stdout 0바이트).

선검사에 **이 작업과 무관한 기존 실패 2건**(`export-capabilities-schema --json/--bare`)이
남아 있다 — 건드리지 않은 코드이므로 이 PR 범위 밖이다. 별도로 보고한다.

## 커밋 3개

① 각주/미주 집계 코어 + 출처 지도 등록 ② CLI/MCP 배선 ③ 계약 테스트 + provenance 스윕
