### PR TITLE
[#3828 B3] 에이전트 레시피 5편 — 목표에서 시작하는 서사 (실측 출력만, 1,285줄)

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -23,6 +23,14 @@
 - [에이전트 실무 대체 예제집](mydocs/manual/agent_task_playbook.md): 사람 업무 → 명령 시퀀스 → 기계 검증 8개 시나리오 + 공무원 업무 커버리지 21행.
 - [서식 자동화 심화 가이드](mydocs/manual/form_filling_guide.md): fill-fields·set-cell·replace-text 3축의 실물 서식 함정과 판정 규칙(ambiguous·overflow·재독 대조).
 
+## 레시피 — 처음부터 끝까지 실측 출력으로 따라가는 예제
+
+- [레시피 1 — 서식 채워서 제출용으로 만들기](mydocs/manual/recipes/01_fill_form_and_submit.md): 누름틀 채움 → 도장 삽입 → 메타데이터 제거.
+- [레시피 2 — 표 데이터를 CSV로 뽑아 고치고 되돌리기](mydocs/manual/recipes/02_table_csv_roundtrip.md): 표 좌표 기반 서식의 CSV 왕복.
+- [레시피 4 — 출처를 모르는 문서를 처음 열 때](mydocs/manual/recipes/04_safety_check_untrusted_doc.md): 본문을 통째로 노출하지 않고 `info`·`digest`·`fields`(`textSecurity`)·`search`·`batch`로 점진적 신뢰도 판정.
+- [레시피 5 — 서식 하나에 여러 사람 데이터를 한 번에 채우기](mydocs/manual/recipes/05_mail_merge_batch_fill.md): `batch fill`로 메일머지형 대량 서식 채움.
+- [레시피 6 — 편집 전후를 눈이 아니라 숫자로 비교하기](mydocs/manual/recipes/06_visual_regression_before_after.md): `render-diff`로 편집이 렌더링 레이아웃에 준 영향을 정량 판정.
+
 ## 문제 해결
 
 - [에이전트 실패 사전](mydocs/manual/agent_troubleshooting_guide.md): 오류 문자열 그대로 검색되는 증상별 원인·처방.

--- a/mydocs/manual/agent_knowledge_map.md
+++ b/mydocs/manual/agent_knowledge_map.md
@@ -61,6 +61,20 @@ rhwp 를 도구로 부리는 AI 에이전트·스크립트가 **첫 번째로 �
 권위는 [#3608](https://github.com/edwardkim/rhwp/issues/3608)이다. 절차를 어긴 표면
 추가는 되돌린다.
 
+### 1-3-1. 끝에서 끝까지 예제를 따라 하고 싶은가 — 레시피
+
+표 1-1이 명령 하나하나의 판정 필드를 알려준다면, 아래 레시피는 "처음부터 끝까지
+한 번에 실행 가능한 순서"를 실측 출력과 함께 보여준다. 각 레시피는 독립 실행
+가능하고, 서로 필요한 지점에서만 상호 참조한다.
+
+| 레시피 | 다루는 것 | 핵심 명령 |
+|---|---|---|
+| [1 — 서식 채워서 제출용으로 만들기](recipes/01_fill_form_and_submit.md) | 누름틀 채움 → 도장 삽입 → 메타데이터 제거 | `fields`·`edit fill-fields`·`edit insert-image`·`edit sanitize` |
+| [2 — 표 데이터를 CSV로 뽑아 고치고 되돌리기](recipes/02_table_csv_roundtrip.md) | 표 좌표 기반 서식의 CSV 왕복 | `export-tables`·`edit set-cell` |
+| [4 — 출처를 모르는 문서를 처음 열 때](recipes/04_safety_check_untrusted_doc.md) | 본문 전체를 노출하지 않고 점진적으로 신뢰도 판정 | `info`·`digest`·`fields`(`textSecurity`)·`search`·`batch` |
+| [5 — 서식 하나에 여러 사람 데이터를 한 번에 채우기](recipes/05_mail_merge_batch_fill.md) | 메일머지형 대량 서식 채움 | `batch fill` |
+| [6 — 편집 전후를 눈이 아니라 숫자로 비교하기](recipes/06_visual_regression_before_after.md) | 편집이 렌더링 레이아웃에 준 영향을 정량 판정 | `render-diff` |
+
 ### 1-4. 다른 언어에서 쓰려는가 — 바인딩 가이드
 
 바인딩은 **새 표면이 아니라 기존 계약의 재포장**이다. 판정·좌표·파싱은 전부 rhwp

--- a/mydocs/manual/recipes/01_fill_form_and_submit.md
+++ b/mydocs/manual/recipes/01_fill_form_and_submit.md
@@ -1,0 +1,205 @@
+---
+kind: guide
+status: active
+canonical: mydocs/manual/recipes/01_fill_form_and_submit.md
+last_verified: 2026-08-03
+---
+
+# 레시피 1 — 서식 문서를 채워서 제출용으로 만들기
+
+**목표 한 줄**: 누름틀이 있는 빈 서식(`.hwp`/`.hwpx`)을 받아서, 값을 채우고, 필요하면
+도장/서명 이미지를 붙이고, 메타데이터를 지운 **제출 가능한 최종 산출물**을 만든다.
+
+이 레시피는 명령 하나로 끝나지 않는다 — "값이 들어갔다"와 "사람이 제출할 수 있는
+산출물이다"는 서로 다른 명제이고, 각 단계마다 기계로 확인할 수 있는 판정이 있다.
+심화 함정(반복 필드, `ambiguous`, overflow)은 [서식 자동화 심화
+가이드](../form_filling_guide.md)가 다룬다. 여기서는 **처음부터 끝까지 한 번에
+실행 가능한 순서**를 실측 출력과 함께 보여준다.
+
+절차 요약:
+
+```
+fields (필드 확인)
+  → edit fill-fields (값 채우기)
+  → edit fill-fields --verify (재파싱 대조)
+  → [선택] edit insert-image (도장/서명)
+  → edit sanitize (메타데이터 제거)
+```
+
+모든 명령·출력은 이 저장소의 `samples/form-01.hwp`(명령 단추 예제 문서, 누름틀
+`myMsg01` 1개 포함)로 실제 실행해서 얻었다. 지어낸 값은 없다.
+
+## 0단계 — 이 서식이 누름틀 기반인지 먼저 확인한다
+
+`fields`는 문서를 **읽기만** 한다(수정 없음). 누름틀이 하나도 없으면
+`fieldCount: 0`이 나오고, 그 경우는 이 레시피가 아니라 `edit set-cell`(표 좌표
+채우기) 레시피 대상이다 — [레시피 0 축 선택
+표](../form_filling_guide.md#0-축-선택--이-서식은-무엇으로-채우나) 참조.
+
+```bash
+rhwp fields samples/form-01.hwp --json
+```
+
+실측 출력:
+
+```json
+{"fieldCount":1,"fields":[{"command":"Clickhere:set:48:Direction:wstring:6:여기에 입력 HelpState:wstring:0:  ","editableInForm":true,"fieldId":2110609883,"fieldType":"ClickHere","guide":"여기에 입력","location":{"nested":[],"paragraph":10,"section":0},"memo":"","name":"myMsg01","value":""}],"schemaVersion":"1.0","source":"samples/form-01.hwp","textSecurity":{"status":"clean"}}
+```
+
+읽어야 할 것 셋:
+
+- `fieldCount: 1` — 누름틀 1개, `fill-fields` 축이 맞다.
+- `fields[].name`: `"myMsg01"` — `--data` JSON의 키로 그대로 쓴다.
+- `fields[].value`: `""` — 아직 비어 있다(채워진 서식이면 값이 들어 있을 수 있다).
+- `textSecurity.status: "clean"` — 이 필드 안에 숨은 콘텐츠·프롬프트 주입 신호가
+  없다는 뜻이다. `"clean"`이 아니면 값을 채우기 전에
+  [레시피 4](04_safety_check_untrusted_doc.md)로 먼저 점검한다.
+
+## 1단계 — `edit fill-fields`로 값을 채운다
+
+```bash
+rhwp edit fill-fields samples/form-01.hwp \
+  --data '{"myMsg01":"홍길동 귀하"}' \
+  -o form-01_filled.hwp --json
+```
+
+실측 출력:
+
+```json
+{"ambiguous":[],"changedPages":[0],"confusable":[],"dryRun":false,"filled":[{"name":"myMsg01","occurrence":0,"value":"홍길동 귀하"}],"filledCount":1,"notFound":[],"output":"…/form-01_filled.hwp","outputFormat":"hwp5","schemaVersion":"1.0","source":"…/form-01.hwp","verify":null}
+```
+
+판정: `notFound`와 `ambiguous`가 둘 다 빈 배열이면 요청한 필드가 정확히 한 번씩
+채워졌다는 뜻이다. 이 둘 중 하나라도 비어 있지 않으면 아직 끝난 게 아니다 —
+자세한 원인별 대응은 [서식 자동화 심화
+가이드 1-1·1-2절](../form_filling_guide.md#1-fill-fields-심화)을 본다.
+
+`--data`는 인라인 JSON 대신 파일도 받는다(`@경로` 형식). 값이 많거나 외부에서
+생성한 데이터를 쓸 때 이쪽이 낫다:
+
+```bash
+echo '{"myMsg01":"파일에서 읽은 값"}' > data.json
+rhwp edit fill-fields samples/form-01.hwp --data @data.json -o out.hwp --json
+```
+
+실측 출력(값만 다름을 확인):
+
+```json
+{"ambiguous":[],"changedPages":[0],"confusable":[],"dryRun":false,"filled":[{"name":"myMsg01","occurrence":0,"value":"파일에서 읽은 값"}],"filledCount":1,"notFound":[],"output":"…/form01_fromfile.hwp","outputFormat":"hwp5","schemaVersion":"1.0","source":"…/form-01.hwp","verify":null}
+```
+
+### 먼저 무엇이 바뀔지 미리보기 — `--dry-run`
+
+디스크에 아무것도 쓰지 않고 채움 가능 여부만 판정한다. 필드 이름 오타를 커밋 전에
+잡을 때 쓴다.
+
+```bash
+rhwp edit fill-fields samples/form-01.hwp --data '{"noSuchField":"x"}' --dry-run --json
+```
+
+실측 출력 — 오타 필드가 `notFound`에 그대로 잡힌다:
+
+```json
+{"ambiguous":[],"changedPages":null,"confusable":[],"dryRun":true,"filled":[],"filledCount":0,"notFound":["noSuchField"],"schemaVersion":"1.0","source":"…/form-01.hwp"}
+```
+
+## 2단계 — `--verify`로 재파싱 대조한다
+
+`edit fill-fields`는 값을 쓴 뒤 산출물을 저장한다. `--verify`를 붙이면 **저장 직후
+그 산출물을 다시 읽어** IR을 비교하고, 요청한 값이 실제로 화면에 나타나는지
+확인한다. "커맨드가 성공을 반환했다"와 "값이 실제로 들어갔다"는 다른 명제이고,
+`--verify`가 그 간극을 메운다.
+
+```bash
+rhwp edit fill-fields samples/form-01.hwp \
+  --data '{"myMsg01":"홍길동 귀하"}' \
+  -o form-01_verify.hwp --verify --json
+```
+
+실측 출력 — `verify.identical: true`, `verify.diffCount: 0`이 통과 신호다:
+
+```json
+{"ambiguous":[],"changedPages":[0],"confusable":[],"dryRun":false,"filled":[{"name":"myMsg01","occurrence":0,"value":"홍길동 귀하"}],"filledCount":1,"notFound":[],"output":"…/form-01_verify.hwp","outputFormat":"hwp5","schemaVersion":"1.0","source":"…/form-01.hwp","verify":{"diffCount":0,"identical":true}}
+```
+
+파이프라인 게이트로 쓸 때는 이렇게 좁힌다:
+
+```bash
+rhwp edit fill-fields samples/form-01.hwp --data @data.json -o out.hwp --verify --json \
+  | jq -e '.verify.identical and (.notFound|length==0) and (.ambiguous|length==0)' \
+  > /dev/null || { echo "채움 실패 — 자세히 보려면 --json 없이 다시 실행"; exit 1; }
+```
+
+## 3단계(선택) — 도장·서명을 이미지로 붙인다: `edit insert-image`
+
+관공서 서식은 값만 채워서는 끝나지 않는다 — 직인·서명 이미지가 특정 좌표에
+들어가야 완성이다. `edit insert-image`는 mm 단위 좌표로 그림을 앉힌다.
+
+```bash
+rhwp edit insert-image form-01_filled.hwp \
+  --image seal.png \
+  --page 0 --x 100 --y 100 --width 30 --height 30 \
+  -o form-01_sealed.hwp --json
+```
+
+실측 출력(이 저장소의 표본 PNG로 실행):
+
+```json
+{"binDataId":1,"changedPages":[0],"dryRun":false,"height":30,"image":"…/seal.png","output":"…/form-01_sealed.hwp","outputFormat":"hwp5","overflow":[],"page":0,"schemaVersion":"1.0","source":"…/form-01_filled.hwp","verify":null,"width":30,"x":100,"y":100}
+```
+
+`x`/`y`/`width`/`height`는 모두 mm, 페이지 좌상단 기준이다. `--page 0`은 첫 페이지
+(0부터 시작). `edit fill-fields`와 마찬가지로 `--verify`를 붙일 수 있다 — 저장
+직후 재파싱해서 그림이 실제로 그 좌표에 들어갔는지 대조한다.
+
+`overflow` 배열이 비어 있지 않으면 이미지가 페이지 여백을 벗어났다는 뜻이다(삽입
+자체는 막지 않는다 — 판단은 호출자 몫).
+
+## 4단계 — `edit sanitize`로 제출 전 메타데이터를 지운다
+
+여기까지는 **보이는 내용**만 다뤘다. HWP 파일에는 작성자명·회사 PC 사용자명·최초
+작성 시각·수정 이력·미리보기 썸네일처럼 **화면에 안 보이는 메타데이터**가 같이
+저장된다. 관공서·거래처에 제출하기 전에는 이것도 지운다.
+
+```bash
+rhwp edit sanitize form-01_sealed.hwp -o form-01_final.hwp --json
+```
+
+실측 출력 — 이 저장소 표본 파일에서 실제로 제거된 8개 필드:
+
+```json
+{"keepPreview":false,"output":"…/form-01_final.hwp","outputFormat":"hwp5","removed":[{"before":"edward","field":"author"},{"before":"2026년 3월 16일 월요일 오전 6:56:40","field":"dateString"},{"before":"edward","field":"lastSavedBy"},{"before":"8, 0, 0, 466 WIN32LEWindows_7","field":"revisionNumber"},{"before":"2026-03-15T21:56:40Z","field":"createdAt"},{"before":"2026-03-16T08:41:55Z","field":"lastSavedAt"},{"before":"\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n여기에 입력\r\n\r\n","field":"preview.text"},{"before":"Gif 1415 bytes","field":"preview.image"}],"removedCount":8,"schemaVersion":"1.0","source":"…/form-01_sealed.hwp"}
+```
+
+읽는 법: `removed[].before`는 **지워지기 전 실제 값**을 그대로 봉투에 담아 반환한다
+— "무엇이 새어나가고 있었는지"를 사람이 확인하고 나서 지우기로 결정할 수 있게
+하기 위해서다. 조용히 지우면 원래 뭐가 있었는지 아무도 모른다.
+
+`preview.text`(미리보기 텍스트)와 `preview.image`(썸네일 GIF)까지 지워지는 것에
+주의한다 — 탐색기 미리보기가 사라진다는 뜻이다. 미리보기를 남기고 싶으면
+`--keep-preview`를 붙인다.
+
+## 실패했을 때 무엇을 보고 어떻게 고칠지
+
+| 신호 | 원인 | 처방 |
+|---|---|---|
+| `fields --json`의 `fieldCount: 0` | 이 서식은 누름틀이 아니라 표 칸이다 | `edit set-cell` 축으로 전환 — [레시피 0 축 선택](../form_filling_guide.md#0-축-선택--이-서식은-무엇으로-채우나) |
+| `fields[].textSecurity.status`가 `"clean"`이 아님 | 필드 안내문·현재값에 숨은 콘텐츠 신호 | 채우기 전에 [레시피 4](04_safety_check_untrusted_doc.md) 절차로 먼저 점검 |
+| `fill-fields` 응답의 `notFound`에 필드명이 남음 | `--data`의 키가 실제 필드 이름과 다름(오타/공백) | `fields --json`의 `name`을 그대로 복사해 쓴다 |
+| `ambiguous`가 비어 있지 않음 | 같은 이름의 필드가 문서에 여러 번 있음 | `이름[0]`, `이름[1]`처럼 순번을 붙여 재지목 — [심화 가이드 1-1절](../form_filling_guide.md#1-1-반복-필드--같은-이름이-여러-번-나올-때-이름n) |
+| `--verify`의 `identical: false` | 저장 후 재파싱한 값이 요청과 다름 — 문서 구조가 특이한 케이스 | `--verify` 없이 산출물을 `export-svg`로 육안 확인, [레시피 6](06_visual_regression_before_after.md)의 `render-diff`로 정량화 |
+| `insert-image`의 `overflow`에 항목이 있음 | 이미지가 페이지 여백을 벗어남 | `--width`/`--height`를 줄이거나 `--x`/`--y`를 조정 후 재실행 |
+| `sanitize`의 `removedCount: 0` | 이미 정리된 문서이거나 애초에 메타데이터가 없음 | 정상 — 재확인하려면 `-o` 없이 원본을 그대로 다시 sanitize 해도 안전(멱등) |
+
+## 관련 문서
+
+- [서식 자동화 심화 가이드](../form_filling_guide.md) — 반복 필드·`ambiguous`·
+  overflow 판정 규칙의 canonical 문서.
+- [CLI 명령어 매뉴얼](../cli_commands.md) — `fields`·`edit fill-fields`·
+  `edit insert-image`·`edit sanitize`의 전체 옵션.
+- [레시피 4 — 출처를 모르는 문서를 처음 열 때](04_safety_check_untrusted_doc.md) —
+  0단계의 `textSecurity.status`가 `"clean"`이 아닐 때 밟는 절차.
+- [레시피 3 — 배포 전 개인정보 마스킹](03_redact_before_sharing.md) — sanitize와
+  짝을 이루는 본문 PII 마스킹(`edit redact`).
+- [에이전트 실무 대체 예제집 1절](../agent_task_playbook.md) — 사람 업무 관점의
+  더 넓은 시나리오.

--- a/mydocs/manual/recipes/02_table_csv_roundtrip.md
+++ b/mydocs/manual/recipes/02_table_csv_roundtrip.md
@@ -1,0 +1,167 @@
+---
+kind: guide
+status: active
+canonical: mydocs/manual/recipes/02_table_csv_roundtrip.md
+last_verified: 2026-08-03
+---
+
+# 레시피 2 — 표 데이터를 CSV로 뽑아 스프레드시트에서 고치고 되돌리기
+
+**목표 한 줄**: HWP 문서 안의 표 하나를 CSV로 꺼내서(스프레드시트에서 대량으로
+고치기 좋게), 외부에서 편집한 다음, 같은 표 자리에 다시 써 넣는다 — 원본 문서의
+서식(테두리·병합·글꼴)은 그대로 두고 **셀 텍스트만** 왕복시킨다.
+
+절차 요약:
+
+```
+export-tables (표 구조 확인 — 몇 번 표인지, 몇 행 몇 열인지)
+  → table-to-csv (CSV로 추출)
+  → [외부 편집 — 스프레드시트, jq, 스크립트 등]
+  → csv-to-table (되돌려 쓰기)
+  → --verify (재파싱 대조)
+```
+
+이 레시피의 모든 명령·출력은 `samples/hwp_table_test.hwp`(표 편집 기능 안내
+문서, 표 10개 포함)의 0번 표(3열×4행, 머리글만 있고 나머지 빈 칸)로 실제
+실행해서 얻었다.
+
+## 1단계 — `export-tables`로 표 구조부터 확인한다
+
+CSV로 바로 뽑기 전에 **몇 번째 표인지**, **몇 행 몇 열인지**, **병합 셀이
+있는지**를 먼저 본다. `table-to-csv`의 `--table N`은 이 인덱스를 그대로 쓴다.
+
+```bash
+rhwp export-tables samples/hwp_table_test.hwp --json
+```
+
+실측 출력(첫 표만 발췌, 전체는 10개 표 배열):
+
+```json
+{"schemaVersion":"1.0","source":"samples/hwp_table_test.hwp","tableCount":10,"tables":[{"cellCount":12,"cells":[{"col":0,"colSpan":1,"isHeader":false,"row":0,"rowSpan":1,"text":"제목"},{"col":1,"colSpan":1,"isHeader":false,"row":0,"rowSpan":1,"text":"담당자"},{"col":2,"colSpan":1,"isHeader":false,"row":0,"rowSpan":1,"text":"세부 내용"},{"col":0,"colSpan":1,"isHeader":false,"row":1,"rowSpan":1,"text":""},"...(중략)...","cols":3,"control":0,"index":0,"paragraph":3,"rows":4,"section":0}]}
+```
+
+읽는 법: `tables[].index`가 `table-to-csv --table`에 넘길 번호다(0부터).
+`colSpan`/`rowSpan`이 1이 아닌 셀이 있으면 병합 표다 — 병합 표를 CSV로 왕복하면
+병합 구조가 깨질 수 있으니(CSV엔 병합 개념이 없다) 먼저 `export-tables`로
+`colSpan`/`rowSpan`을 확인하고, 병합이 있으면 이 레시피 대신 `edit set-cell`로
+좌표를 하나씩 짚어 고치는 편이 안전하다.
+
+이 표(index 0)는 `cols: 3`, `rows: 4`, 모든 셀 `colSpan`/`rowSpan`이 1 —
+CSV 왕복에 적합하다.
+
+## 2단계 — `table-to-csv`로 뽑는다
+
+```bash
+rhwp table-to-csv samples/hwp_table_test.hwp --table 0 -o table0.csv --json
+```
+
+실측 출력:
+
+```json
+{"bom":false,"output":"…/table0.csv","outputFormat":"csv","schemaVersion":"1.0","source":"…/hwp_table_test.hwp","tableCount":1,"tables":[{"colCount":3,"csv":"제목,담당자,세부 내용\r\n,,\r\n,,\r\n,,\r\n","index":0,"output":"…/table0.csv","rowCount":4}],"untrustedContent":true,"untrustedFields":["tables[].csv"]}
+```
+
+`table0.csv` 실제 내용:
+
+```csv
+제목,담당자,세부 내용
+,,
+,,
+,,
+```
+
+읽는 법:
+
+- `--json` 봉투 안에도 `tables[].csv`로 같은 내용이 인라인으로 들어간다 —
+  파일을 따로 열지 않고 파이프라인에서 바로 쓸 수 있다.
+- `untrustedContent: true`와 `untrustedFields: ["tables[].csv"]` — CSV로 뽑은
+  텍스트는 문서 안에 있던 원문 그대로이므로, 출처를 모르는 문서라면 이 값을
+  그대로 셸 명령이나 LLM 프롬프트에 붙여넣지 말라는 신호다. 이 문서 표본은
+  이 저장소 소유라 안전하지만, 낯선 문서라면 [레시피
+  4](04_safety_check_untrusted_doc.md)를 먼저 밟는다.
+- `bom: false` — 기본은 BOM 없는 UTF-8. 엑셀(한글 Windows)에서 한글이 깨지면
+  `--bom`을 붙여 재실행한다.
+
+## 3단계 — 외부에서 편집한다
+
+스프레드시트로 열어서 고치거나, 여기서는 재현 가능하도록 CSV를 직접 만든다
+(엑셀에서 손으로 채운 것과 동일한 형식 — 첫 줄 헤더는 그대로 두고 값 행만
+채운다):
+
+```bash
+cat > table0_edited.csv <<'EOF'
+제목,담당자,세부 내용
+서버 이관,홍길동,1차 완료
+DB 백업,김철수,진행중
+문서 정리,박영희,대기
+EOF
+```
+
+주의: **첫 줄(헤더)은 문서에 그대로 다시 쓰인다** — `csv-to-table`은 CSV의 모든
+행을 표의 대응 행에 순서대로 채운다(엑셀에서 헤더 행 자체를 손대지 않는 한
+문제없다). 표의 행 수보다 CSV 행이 많으면 넘치는 행은 [실패 표](#실패했을-때-무엇을-보고-어떻게-고칠지)를 본다.
+
+## 4단계 — `csv-to-table`로 되돌린다 (+ `--verify`)
+
+```bash
+rhwp csv-to-table samples/hwp_table_test.hwp \
+  --csv table0_edited.csv --table 0 \
+  -o table_updated.hwp --verify --json
+```
+
+실측 출력:
+
+```json
+{"changed":[{"col":0,"newText":"서버 이관","oldText":"","row":1},{"col":1,"newText":"홍길동","oldText":"","row":1},{"col":2,"newText":"1차 완료","oldText":"","row":1},{"col":0,"newText":"DB 백업","oldText":"","row":2},{"col":1,"newText":"김철수","oldText":"","row":2},{"col":2,"newText":"진행중","oldText":"","row":2},{"col":0,"newText":"문서 정리","oldText":"","row":3},{"col":1,"newText":"박영희","oldText":"","row":3},{"col":2,"newText":"대기","oldText":"","row":3}],"changedCount":9,"changedPages":[0],"colCount":3,"csv":"…/table0_edited.csv","dryRun":false,"invalid":[],"output":"…/table_updated.hwp","outputFormat":"hwp5","rowCount":4,"schemaVersion":"1.0","source":"…/hwp_table_test.hwp","table":0,"untrustedContent":false,"untrustedFields":[],"verify":{"diffCount":0,"identical":true}}
+```
+
+판정: `changedCount: 9`(3열×3행 = 9칸이 실제로 바뀜, 헤더 행은 `oldText`==
+`newText`라 변경 목록에 안 잡힌다), `invalid`가 빈 배열, `verify.identical:
+true` — 저장 후 재파싱해도 값이 그대로 남아 있다는 뜻이다.
+
+되돌려 쓴 문서에서 표를 다시 뽑아 대조하면(선택적 이중 확인):
+
+```bash
+rhwp export-tables table_updated.hwp --json | jq '.tables[0].cells[] | select(.row==1)'
+```
+
+실측 출력 — 1행이 정확히 `서버 이관`/`홍길동`/`1차 완료`로 채워졌다:
+
+```json
+{"col":0,"colSpan":1,"isHeader":false,"row":1,"rowSpan":1,"text":"서버 이관"}
+{"col":1,"colSpan":1,"isHeader":false,"row":1,"rowSpan":1,"text":"홍길동"}
+{"col":2,"colSpan":1,"isHeader":false,"row":1,"rowSpan":1,"text":"1차 완료"}
+```
+
+## `--dry-run`으로 먼저 무엇이 바뀔지 본다
+
+`csv-to-table`도 `edit` 3종과 같은 `--dry-run` 관례를 따른다 — 파일을 쓰지 않고
+`changed`/`invalid` 목록만 계산한다. 대량 표를 다루기 전에 먼저 이걸로 확인하는
+습관을 들인다.
+
+```bash
+rhwp csv-to-table samples/hwp_table_test.hwp --csv table0_edited.csv --table 0 --dry-run --json \
+  | jq '{changedCount, invalid}'
+```
+
+## 실패했을 때 무엇을 보고 어떻게 고칠지
+
+| 신호 | 원인 | 처방 |
+|---|---|---|
+| `export-tables`의 대상 표에 `colSpan`/`rowSpan` > 1인 셀이 있음 | 병합 표 — CSV는 병합을 표현 못 함 | 이 레시피 대신 `edit set-cell --table N --row R --col C`로 좌표를 하나씩 지정 |
+| `csv-to-table`의 `invalid`에 행이 잡힘 | CSV 열 수가 표의 `colCount`와 다름, 또는 셀에 줄바꿈·탭 포함 | CSV를 `colCount`에 맞게 고치고, 값 안의 개행은 공백으로 치환 후 재시도 |
+| CSV를 엑셀에서 열었더니 한글이 깨짐 | BOM 없는 UTF-8을 엑셀이 기본 로캘로 잘못 해석 | `table-to-csv --bom`으로 다시 뽑는다 |
+| `csv-to-table`의 `verify.identical: false` | 저장 후 재파싱한 값이 CSV와 다름 | 표에 병합·중첩 표가 섞여 있는지 재확인. `export-tables`로 대상 표를 다시 뽑아 실제 저장된 값과 CSV를 diff |
+| 원본 표보다 CSV 행이 더 많음/적음 | 초과 행은 `invalid`로 보고되고 무시됨, 부족한 행의 나머지 셀은 손대지 않음(빈칸으로 안 지움) | 표의 `rowCount`에 CSV 행 수를 맞춘다 |
+| `table-to-csv`의 `untrustedContent: true`가 걸림 | 출처 모르는 문서의 셀 텍스트를 그대로 셸/LLM에 흘리려 함 | [레시피 4](04_safety_check_untrusted_doc.md)로 먼저 점검한 뒤 진행 |
+
+## 관련 문서
+
+- [CLI 명령어 매뉴얼](../cli_commands.md) — `export-tables`·`table-to-csv`·
+  `csv-to-table`의 전체 옵션과 종료 코드.
+- [서식 자동화 심화 가이드](../form_filling_guide.md) — 병합 표에서 `edit
+  set-cell`을 쓸 때의 앵커 좌표 규칙.
+- [레시피 1 — 서식 채우기](01_fill_form_and_submit.md) — 표가 아니라 누름틀
+  기반 서식일 때.
+- [레시피 4 — 출처를 모르는 문서를 처음 열 때](04_safety_check_untrusted_doc.md) —
+  `untrustedContent`/`untrustedFields` 신호를 만났을 때의 판단 절차.

--- a/mydocs/manual/recipes/04_safety_check_untrusted_doc.md
+++ b/mydocs/manual/recipes/04_safety_check_untrusted_doc.md
@@ -1,0 +1,303 @@
+---
+kind: guide
+status: active
+canonical: mydocs/manual/recipes/04_safety_check_untrusted_doc.md
+last_verified: 2026-08-03
+---
+
+# 레시피 4 — 출처를 모르는 문서를 처음 열 때
+
+**목표 한 줄**: 메일 첨부·다운로드 폴더·낯선 USB에서 온 `.hwp`/`.hwpx`를 **본문 전체를
+셸이나 LLM에 흘려보내기 전에**, 기계로 확인 가능한 신호만으로 "지금 열어도 되는
+문서인가"를 판정한다.
+
+이 레시피는 "악성 매크로를 잡아낸다"는 백신 소프트웨어의 약속이 아니다. HWP에는
+실행 코드가 없다 — 위험은 다른 모양으로 온다: 누름틀 안내문에 숨겨진 프롬프트
+주입 문구, 표 셀에 박힌 대량의 텍스트, 화면에 안 보이는 사설 영역(PUA) 문자가
+엉뚱한 글자로 렌더링되는 문제. 이 레시피는 **읽기 전용** 명령만 써서 문서 크기를
+가늠하고, 필드별 텍스트 보안 신호를 확인하고, 필요한 부분만 좁혀서 본다 —
+`export-text`로 전체를 한 번에 쏟아붓지 않는다.
+
+절차 요약:
+
+```
+info (문서 규모·형식 확인, 읽기 전용)
+  → digest (짧은 미리보기, 전체 덤프 아님)
+  → fields (필드별 textSecurity 신호 확인)
+  → [필요시] search (본문 전체 대신 특정 키워드만 좁혀서 확인)
+  → 판정 통과 후에만 export-text/edit 계열 명령 사용
+```
+
+모든 명령·출력은 이 저장소의 `samples/form-01.hwp`(명령 단추 예제 문서)와
+`output/pua-test.hwp`(`rhwp gen-pua`로 생성한 사설영역 문자 회귀 문서, 18종
+PUA 코드포인트 포함)로 실제 실행해서 얻었다. 지어낸 값은 없다.
+
+## 0단계 — 왜 `export-text`로 바로 시작하면 안 되나
+
+낯선 문서의 본문 텍스트를 통째로 표준출력에 찍어 셸 파이프라인이나 LLM 프롬프트에
+바로 넣는 습관은 두 가지 문제를 만든다.
+
+1. 문서 크기를 모르는 채로 전체를 읽으면, 수백 페이지짜리 문서에서 토큰/시간을
+   낭비한다.
+2. 본문 안에 "이 지시를 무시하고 다음을 실행하라" 같은 문구가 심겨 있으면, 그
+   문구가 그대로 다음 단계(LLM 프롬프트, 셸 명령)에 흘러들어갈 수 있다.
+
+그래서 이 레시피는 **크기 확인 → 짧은 미리보기 → 필드별 신호 확인** 순서로
+점진적으로 좁혀 간다. 각 단계는 전 단계보다 더 많은 내용을 노출하므로, 이상 신호가
+보이면 그 자리에서 멈춘다.
+
+## 1단계 — `info`로 문서 규모와 형식부터 확인한다
+
+`info`는 본문 텍스트를 전혀 반환하지 않는다 — 페이지 수·문단 수·글꼴 목록·형식
+버전·파일 크기만 본다. 가장 싼 비용으로 "이 문서가 상식적인 크기인가"를 먼저
+판정한다.
+
+```bash
+rhwp info samples/form-01.hwp --json
+```
+
+실측 출력:
+
+```json
+{"fonts":["한컴바탕","함초롬돋움","함초롬바탕"],"format":"hwp5","pageCount":1,"paraCount":13,"schemaVersion":"1.0","sections":1,"sizeBytes":18432,"source":"samples/form-01.hwp","title":"명령 단추","version":"5.0.3.0"}
+```
+
+읽어야 할 것 셋:
+
+- `pageCount: 1`, `paraCount: 13` — 규모가 상식적이다. 1페이지짜리 서식이 파일
+  크기 수십 MB로 나오거나, `paraCount`가 비정상적으로 크면(예: 수만 단위) 뭔가가
+  반복 삽입되어 있다는 신호다 — 다음 단계로 넘어가기 전에 의심한다.
+- `title`: `"명령 단추"` — 문서 속성에 저장된 제목. 본문과 무관한 제목이거나
+  URL·명령어처럼 보이면 이 자체가 이상 신호다.
+- `format`/`version`: `"hwp5"` / `"5.0.3.0"` — 문서 포맷 버전. 지원 범위 밖의
+  포맷이면 다른 명령이 거부할 수 있다.
+
+PUA(사설 영역 문자) 회귀 문서로도 같은 명령을 실행해 대조해본다:
+
+```bash
+rhwp info output/pua-test.hwp --json
+```
+
+실측 출력:
+
+```json
+{"fonts":["함초롬돋움","함초롬바탕"],"format":"hwp5","pageCount":1,"paraCount":19,"schemaVersion":"1.0","sections":1,"sizeBytes":15360,"source":"output/pua-test.hwp","title":"[PUA 회귀 검증 — Task #509]","version":"5.1.0.1"}
+```
+
+`title`에 대괄호로 싸인 내부 태그(`[PUA 회귀 검증 — Task #509]`)가 그대로 들어
+있다 — 이런 문서는 사람이 작성한 최종 문서가 아니라 테스트/회귀 자산일 가능성이
+높다는 신호다. `info` 한 번으로 이런 맥락 정보까지 공짜로 얻는다.
+
+## 2단계 — `digest`로 짧은 미리보기만 본다
+
+`digest`는 `export-text`처럼 전체를 다 뱉지 않는다 — 앞부분 일부만 잘라 보여주고,
+`truncated` 필드로 "잘렸다"는 사실을 명시한다. 본문 전체를 노출하지 않고도 "이
+문서가 예상한 종류의 문서인가"를 판정하기에 충분하다.
+
+```bash
+rhwp digest samples/form-01.hwp --json
+```
+
+실측 출력:
+
+```json
+{"excerpt":"명령 단추\n\n선택 상자\n\n계절 선택\n\n라디오 단추\n\n\n\n여기에 입력\n\n","format":"hwp5","pageCount":1,"paraCount":13,"schemaVersion":"1.0","source":"samples/form-01.hwp","truncated":false,"nextStep":"더 읽으려면 export-text --json -p <쪽>, 찾으려면 search --json"}
+```
+
+`truncated: false` — 이 짧은 문서는 통째로 다 보였다는 뜻이다. 큰 문서라면
+`truncated: true`가 나오고, 그 다음 어떻게 더 읽을지는 `nextStep` 필드가 직접
+알려준다(예: 특정 쪽만 `export-text --json -p <쪽>`, 아니면 `search --json`으로
+키워드만 좁혀서).
+
+PUA 문서로 같은 명령을 돌리면 어떤 신호가 섞여 있는지 미리 볼 수 있다:
+
+```bash
+rhwp digest output/pua-test.hwp --json --max-chars 500
+```
+
+실측 출력(발췌, `excerpt`만):
+
+```json
+{"excerpt":"[PUA 회귀 검증 — Task #509]\nU+0F076 (Basic, mel-001, ❖ U+2756): ❖  ← 한컴 PDF 정답지\nU+0F09F (Basic, biz_plan, • U+2022): •  ← 한컴 PDF 정답지\nU+0F0A0 (Basic, synam-001, ▪ U+25AA): ·  ← 한컴 PDF 정답지\n...","truncated":true}
+```
+
+`truncated: true`가 뜬 이유는 `--max-chars 500`로 직접 잘랐기 때문이다 — 큰
+문서를 다룰 때 이렇게 명시적으로 상한을 걸어 미리보기 비용을 통제할 수 있다. 본문에
+`U+F0xx`대 코드포인트가 반복해서 나오는 것 자체가 "이 문서는 사설 영역 문자를
+쓰고 있으니, 화면에 보이는 글자와 실제 저장된 코드포인트가 다를 수 있다"는
+신호다 — 이 문서를 신뢰해서 값으로 쓰기 전에 `export-svg`로 실제 렌더링을 눈으로
+대조하는 편이 안전하다.
+
+## 3단계 — `fields`로 필드별 `textSecurity` 신호를 확인한다
+
+누름틀이 있는 서식이라면, `fields --json`의 각 필드 항목에 `textSecurity`가
+붙어 나온다. 이 필드는 안내문·현재값 안에 숨은 콘텐츠나 프롬프트 주입으로 보이는
+패턴이 있는지를 요약한 판정이다.
+
+```bash
+rhwp fields --json samples/form-01.hwp
+```
+
+실측 출력:
+
+```json
+{"fieldCount":1,"fields":[{"command":"Clickhere:set:48:Direction:wstring:6:여기에 입력 HelpState:wstring:0:  ","editableInForm":true,"fieldId":2110609883,"fieldType":"ClickHere","guide":"여기에 입력","location":{"nested":[],"paragraph":10,"section":0},"memo":"","name":"myMsg01","value":""}],"schemaVersion":"1.0","source":"samples/form-01.hwp","textSecurity":{"status":"clean"}}
+```
+
+`textSecurity.status: "clean"` — 이 필드의 안내문·현재값에 이상 신호가 없다는
+뜻이다. `"clean"`이 아닌 상태를 만나면(예: 의심스러운 지시문 패턴이 잡힌 경우),
+[레시피 1의 0단계](01_fill_form_and_submit.md#0단계--이-서식이-누름틀-기반인지-먼저-확인한다)로
+돌아가 그 필드를 값으로 채우거나 그 값을 그대로 다음 단계(LLM 프롬프트 등)에
+넘기지 않는다 — 사람이 먼저 `guide`/`value` 원문을 눈으로 읽고 판단한다.
+
+이 문서는 `fieldCount: 1`이라 누름틀 서식이지만, 표 칸 기반 서식(`edit
+set-cell` 축)이라면 `fields`가 `fieldCount: 0`을 돌려준다 — 그 경우 표 셀
+텍스트를 신뢰하기 전 검토는 [레시피 2의 판정
+표](02_table_csv_roundtrip.md)를 참고한다.
+
+## 4단계(선택) — `search`로 특정 키워드만 좁혀서 확인한다
+
+본문 전체를 보는 대신, 걱정되는 패턴(예: URL, 명령어처럼 보이는 문자열)만
+targeted로 찾을 수 있다. `search`는 매치된 위치만 반환하고 문서 전체를 노출하지
+않는다.
+
+```bash
+rhwp search samples/form-01.hwp "입력" --json
+```
+
+실측 출력:
+
+```json
+{"caseSensitive":true,"matchCount":0,"matches":[],"query":"입력","schemaVersion":"1.0","source":"samples/form-01.hwp","totalMatchCount":0,"truncated":false}
+```
+
+이 문서 본문에는 정확히 `"입력"`이라는 문자열이 없다 — `matchCount: 0`이 그
+사실을 그대로 보여준다(`digest`의 미리보기에 보인 "여기에 입력"은 누름틀
+`guide` 텍스트라 본문 검색 인덱스와 다른 경로로 저장돼 있을 수 있다는 뜻이기도
+하다 — 필드 관련 텍스트는 `fields --json`으로 별도 확인). 기본은 대소문자
+구분(`caseSensitive: true`)이며 `--ignore-case`로 끌 수 있다.
+
+실제로 매치가 있는 문서로 대조해본다 — `output/pua-test.hwp`에서 반복 등장하는
+`"정답지"`를 찾고, `--limit`으로 상한을 건다:
+
+```bash
+rhwp search output/pua-test.hwp "정답지" --json --limit 2
+```
+
+실측 출력:
+
+```json
+{"caseSensitive":true,"matchCount":2,"matches":[{"charOffset":48,"context":"…(Basic, mel-001, ❖ U+2756):   ← 한컴 PDF 정답지","length":3,"page":0,"paragraph":1,"section":0,"text":"U+0F076 (Basic, mel-001, ❖ U+2756):   ← 한컴 PDF 정답지"},{"charOffset":49,"context":"…Basic, biz_plan, • U+2022):   ← 한컴 PDF 정답지","length":3,"page":0,"paragraph":2,"section":0,"text":"U+0F09F (Basic, biz_plan, • U+2022):   ← 한컴 PDF 정답지"}],"query":"정답지","schemaVersion":"1.0","source":"output/pua-test.hwp","totalMatchCount":18,"truncated":true}
+```
+
+`matchCount: 2`인데 `totalMatchCount: 18`이다 — `--limit 2`로 반환 개수만
+잘랐을 뿐, 실제로는 18곳에 매치가 있다는 뜻이다(`truncated: true`가 이 사실을
+명시한다). 이렇게 "실제 매치 수"와 "반환된 매치 수"가 분리돼 있어서, 상한을
+낮게 걸어도 전체 규모를 놓치지 않는다. 각 매치의 `context`는 매치 지점 주변
+텍스트만 잘라 보여준다 — 본문 전체를 노출하지 않고도 그 문자열이 어떤 맥락에서
+쓰였는지 판단할 수 있다.
+
+## 5단계(선택) — 여러 문서를 한 번에 점검한다: `batch`
+
+메일함 첨부 여러 개, 다운로드 폴더 전체처럼 문서가 여러 개 쌓여 있을 때는 하나씩
+명령을 반복하는 대신 `batch`에 파일 목록을 표준입력으로 흘려보낸다. `batch`가
+지원하는 하위 명령은 `export-text·info·export-structure·export-tables·fields·
+search·convert` 다. 여기서는 이 레시피에서 쓴 `fields`와 `info`를 배치로
+돌린다.
+
+점검 대상 목록을 만든다(파일 하나당 한 줄):
+
+```bash
+printf 'samples/form-01.hwp\nsamples/form-02.hwp\noutput/pua-test.hwp\n' > check_list.txt
+```
+
+```bash
+rhwp batch fields --json < check_list.txt
+```
+
+실측 출력 — 파일마다 한 줄씩 JSON이 나오고, 마지막에 사람이 읽는 요약이 붙는다:
+
+```json
+{"fieldCount":1,"fields":[{"command":"Clickhere:set:48:Direction:wstring:6:여기에 입력 HelpState:wstring:0:  ","editableInForm":true,"fieldId":2110609883,"fieldType":"ClickHere","guide":"여기에 입력","location":{"nested":[],"paragraph":10,"section":0},"memo":"","name":"myMsg01","value":""}],"schemaVersion":"1.0","source":"samples/form-01.hwp","textSecurity":{"status":"clean"}}
+{"fieldCount":1,"fields":[{"command":"Clickhere:set:48:Direction:wstring:6:여기에 입력 HelpState:wstring:0:  ","editableInForm":true,"fieldId":2110609883,"fieldType":"ClickHere","guide":"여기에 입력","location":{"nested":[],"paragraph":10,"section":0},"memo":"","name":"myMsg01","value":""}],"schemaVersion":"1.0","source":"samples/form-02.hwp","textSecurity":{"status":"clean"}}
+{"fieldCount":0,"fields":[],"schemaVersion":"1.0","source":"output/pua-test.hwp","textSecurity":{"status":"clean"}}
+```
+
+```
+batch: 3건 중 3 성공, 0 실패 (3ms, threads=32)
+```
+
+`fieldCount: 0`인 `output/pua-test.hwp`는 애초에 누름틀이 없는 문서다 — 이
+결과 하나만으로는 그 문서가 안전하다는 뜻이 아니라, "이 축(`fields`)으로는 더
+볼 게 없다"는 뜻일 뿐이다. 3단계까지 온 이유가 바로 이것이다 — `fieldCount:
+0`이 나온 문서는 2단계 `digest`의 미리보기 판정으로 되돌아가서 다시 본다(이
+레시피에서는 앞서 `pua-test.hwp`에 대해 이미 그렇게 했다).
+
+`info`도 같은 방식으로 배치 처리할 수 있다 — 여러 문서의 규모를 한 번에
+비교할 때 쓴다:
+
+```bash
+rhwp batch info --json < check_list.txt
+```
+
+실측 출력(요약 줄 제외, 세 문서분):
+
+```json
+{"fonts":["한컴바탕","함초롬돋움","함초롬바탕"],"format":"hwp5","pageCount":1,"paraCount":13,"schemaVersion":"1.0","sections":1,"sizeBytes":18432,"source":"samples/form-01.hwp","title":"명령 단추","version":"5.0.3.0"}
+{"fonts":["한컴바탕","함초롬돋움","함초롬바탕"],"format":"hwp5","pageCount":1,"paraCount":13,"schemaVersion":"1.0","sections":1,"sizeBytes":10752,"source":"samples/form-02.hwp","title":"명령 단추","version":"5.0.3.0"}
+{"fonts":["함초롬돋움","함초롬바탕"],"format":"hwp5","pageCount":1,"paraCount":19,"schemaVersion":"1.0","sections":1,"sizeBytes":15360,"source":"output/pua-test.hwp","title":"[PUA 회귀 검증 — Task #509]","version":"5.1.0.1"}
+```
+
+`jq`로 좁혀서 이상 신호가 있는 파일만 골라내는 게이트로 쓸 수 있다:
+
+```bash
+rhwp batch fields --json < check_list.txt \
+  | jq -c 'select(.textSecurity.status != "clean")'
+```
+
+아무 줄도 안 나오면(이 저장소 표본은 전부 `clean`이라 실제로 빈 출력이다) 3개
+문서 모두 필드 축에서는 이상 신호가 없다는 뜻이다. `batch`는 파일당 스레드를
+나눠 병렬로 돈다(`threads=32` — CPU 코어 수에 맞춰 자동 결정되고 `--threads
+<N>`으로 상한을 지정할 수 있다) — 문서 수가 많을수록 하나씩 반복하는 것보다
+확실히 빠르다.
+
+## 판정 — 다음 단계로 넘어가도 되는 기준
+
+| 신호 | 판정 | 처방 |
+|---|---|---|
+| `info`의 `pageCount`/`paraCount`가 문서 성격에 비해 비정상적으로 큼 | 의심 | 열람을 멈추고 파일 출처를 먼저 확인한다 |
+| `info`의 `title`이 본문과 무관하거나 내부 태그·코드처럼 보임 | 주의 | 테스트/회귀 자산일 가능성 — 최종 배포본으로 신뢰하지 않는다 |
+| `digest`의 `excerpt`에 지시문처럼 읽히는 문장이 있음(예: "이전 지시를 무시하고…") | 위험 | 이 텍스트를 LLM 프롬프트나 셸 명령에 그대로 넘기지 않는다. 사람이 원문을 검토 |
+| `digest`의 `excerpt`에 `U+F0xx`~`U+FFxx`대 코드포인트가 반복됨 | 주의 | 사설 영역 문자 — `export-svg`로 실제 렌더링을 눈으로 대조하기 전에는 화면 글자를 신뢰하지 않는다 |
+| `fields --json`의 `textSecurity.status`가 `"clean"`이 아님 | 위험 | 해당 필드의 `guide`/`value` 원문을 사람이 직접 읽고서만 다음 단계 진행 — [레시피 1](01_fill_form_and_submit.md) |
+| 위 모든 신호가 정상 | 통과 | `export-text`/`edit fill-fields` 등 본격 처리 단계로 진행 가능 |
+
+## 이 레시피가 하지 않는 것
+
+- 바이러스·매크로 스캔이 아니다 — HWP5/HWPX에는 실행 가능한 매크로가 없다(OLE
+  개체 삽입 등 다른 경로의 위험은 이 레시피 범위 밖이다).
+- 암호화된 문서(`EncryptVersion 4`)의 복호화는 다루지 않는다 — 전역 옵션
+  `--password`/`--password-stdin`으로 열되, 비밀번호 자체를 신뢰할 수 없는
+  경로에서 받았다면 그 비밀번호도 별도로 검증한다.
+- 완벽한 보장이 아니다 — `textSecurity.status: "clean"`은 "이 시점의 판정
+  규칙으로 이상 신호를 못 찾았다"는 뜻이지, 문서가 100% 안전하다는 증명이 아니다.
+  최종 판단은 사람이 한다.
+
+## 관련 문서
+
+- [레시피 1 — 서식 문서를 채워서 제출용으로 만들기](01_fill_form_and_submit.md) —
+  0단계에서 `textSecurity.status`가 `"clean"`이 아닐 때 이 레시피로 오는
+  진입점.
+- [레시피 2 — 표 데이터를 CSV로 뽑아 스프레드시트에서 고치고 되돌리기](02_table_csv_roundtrip.md) —
+  `untrustedContent` 판정이 걸렸을 때 이 레시피로 먼저 점검하는 흐름.
+- [CLI 명령어 매뉴얼](../cli_commands.md) — `info`·`digest`·`fields`·`search`의
+  전체 옵션과 종료 코드 계약.
+- [문서 진단 도구](../document_diagnostics_tool_manual.md) — `info → dump →
+  diag` 순서로 문서 자체의 구조적 이상을 좁혀 가는 절차(이 레시피보다 더 깊은
+  진단이 필요할 때).
+- [에이전트 실패 사전](../agent_troubleshooting_guide.md) — 오류 문자열별
+  원인·처방.
+- [레시피 5 — 서식 하나에 여러 사람 데이터를 한 번에 채우기](05_mail_merge_batch_fill.md) —
+  이 레시피로 안전 판정을 통과한 서식을 대량으로 채울 때.
+- [레시피 6 — 편집 전후를 눈이 아니라 숫자로 비교하기](06_visual_regression_before_after.md) —
+  `--verify`로 못 잡는 렌더링 차이까지 정량화할 때.

--- a/mydocs/manual/recipes/05_mail_merge_batch_fill.md
+++ b/mydocs/manual/recipes/05_mail_merge_batch_fill.md
@@ -1,0 +1,307 @@
+---
+kind: guide
+status: active
+canonical: mydocs/manual/recipes/05_mail_merge_batch_fill.md
+last_verified: 2026-08-03
+---
+
+# 레시피 5 — 서식 하나에 여러 사람 데이터를 한 번에 채우기 (메일머지)
+
+**목표 한 줄**: 누름틀이 있는 서식(`.hwp`/`.hwpx`) 하나와, 사람 수만큼 행이 있는
+데이터(CSV/JSONL)를 받아서, 행마다 산출물 파일을 하나씩 만든다 — 참석자 명단,
+안내문 발송 대상, 계약서 상대방 목록처럼 "같은 서식 + 다른 값"이 반복되는
+작업이다.
+
+이 레시피는 [레시피 1](01_fill_form_and_submit.md)의 `edit fill-fields`를 행 단위로
+반복하는 것과 결과는 같지만, `batch fill`은 이 반복을 명령 하나로 처리하고
+스레드를 나눠 병렬로 돈다. 값 하나를 채우는 절차가 궁금하면 레시피 1을 먼저 본다
+— 여기서는 "여러 행"에서만 달라지는 부분에 집중한다.
+
+`batch`의 다른 하위 명령(`export-text`·`info`·`export-structure`·
+`export-tables`·`fields`·`search`·`convert`)은 표준입력으로 **파일 경로
+목록**을 받지만, `fill`만은 다르다 — 서식은 하나 고정이고 대신 **데이터 행
+목록**을 `--data`로 받는다. 이 차이를 헷갈리면 "파일 목록을 stdin으로 파이프
+했는데 아무 일도 안 일어난다"는 증상을 겪는다 — `fill`은 stdin을 아예 읽지
+않는다.
+
+절차 요약:
+
+```
+fields (누름틀 이름 확인 — 레시피 1의 0단계와 동일)
+  → 데이터 준비 (JSONL 또는 CSV, 행마다 필드명=값)
+  → batch fill --dry-run (커밋 전 미리보기)
+  → batch fill (실제 산출)
+  → batch fill --verify (재파싱 대조까지 원하면)
+```
+
+모든 명령·출력은 이 저장소의 `samples/form-01.hwp`(누름틀 `myMsg01` 1개 포함,
+레시피 1과 동일 표본)로 실제 실행해서 얻었다. 지어낸 값은 없다.
+
+## 0단계 — 채울 필드 이름을 먼저 확인한다
+
+레시피 1의 0단계와 동일하다 — `fields --json`은 문서를 읽기만 한다.
+
+```bash
+rhwp fields --json samples/form-01.hwp
+```
+
+실측 출력:
+
+```json
+{"fieldCount":1,"fields":[{"command":"Clickhere:set:48:Direction:wstring:6:여기에 입력 HelpState:wstring:0:  ","editableInForm":true,"fieldId":2110609883,"fieldType":"ClickHere","guide":"여기에 입력","location":{"nested":[],"paragraph":10,"section":0},"memo":"","name":"myMsg01","value":""}],"schemaVersion":"1.0","source":"samples/form-01.hwp","textSecurity":{"status":"clean"}}
+```
+
+`fields[].name`: `"myMsg01"` — 데이터 파일의 컬럼/키 이름으로 그대로 쓴다.
+여러 사람에게 보낼 서식이라면, 이 시점에 `textSecurity.status`도 확인해 둔다 —
+서식 자체(빈 템플릿)는 대개 `"clean"`이지만, 재사용해온 서식이라면 이전에 채운
+값이 안내문에 남아 있을 수 있다.
+
+## 1단계 — 데이터를 준비한다: JSONL 한 줄당 한 행
+
+`--data`는 확장자로 형식을 판별한다 — `.jsonl`은 한 줄에 JSON 객체 하나, `.csv`는
+첫 줄이 헤더다. 필드명은 0단계에서 확인한 `name`과 정확히 일치해야 한다.
+
+```bash
+printf '%s\n' \
+  '{"myMsg01":"김철수 귀하"}' \
+  '{"myMsg01":"이영희 귀하"}' \
+  > row1.jsonl
+```
+
+```bash
+rhwp batch fill --form samples/form-01.hwp --data row1.jsonl --out-dir batch_out --json
+```
+
+실측 출력 — 행마다 한 줄씩 JSON, 마지막에 사람이 읽는 요약:
+
+```json
+{"ambiguous":[],"changedPages":[0],"confusable":[],"dryRun":false,"filled":[{"name":"myMsg01","occurrence":0,"value":"김철수 귀하"}],"filledCount":1,"notFound":[],"output":"batch_out\\0001.hwp","outputFormat":"hwp5","row":0,"schemaVersion":"1.0","source":"samples/form-01.hwp","verify":null}
+{"ambiguous":[],"changedPages":[0],"confusable":[],"dryRun":false,"filled":[{"name":"myMsg01","occurrence":0,"value":"이영희 귀하"}],"filledCount":1,"notFound":[],"output":"batch_out\\0002.hwp","outputFormat":"hwp5","row":1,"schemaVersion":"1.0","source":"samples/form-01.hwp","verify":null}
+```
+
+```
+batch fill: 2행 중 2 성공, 0 실패 (3ms, threads=32)
+```
+
+읽어야 할 것 셋:
+
+- `row`: 0, 1 — 0부터 시작하는 행 번호. `--data`의 몇 번째 줄에서 왔는지 그대로
+  대응한다.
+- `output`: `batch_out\0001.hwp`, `batch_out\0002.hwp` — 이름을 따로 지정하지
+  않으면 행 번호로 4자리 0채움 파일명이 자동 생성된다.
+- 요약 줄의 `2행 중 2 성공, 0 실패` — 파이프라인에서 성공/실패 건수를 사람이
+  빠르게 확인하는 용도다. 기계 판정에는 각 행 JSON의 `notFound`/`ambiguous`를
+  쓴다(레시피 1과 동일한 판정 규칙).
+
+## 2단계 — CSV로도 같은 결과를 얻는다
+
+외부 스프레드시트에서 명단을 관리한다면 CSV가 더 편하다. 첫 줄이 헤더이고, 헤더
+이름이 곧 필드명이다.
+
+```bash
+printf 'myMsg01\n박민수 귀하\n최지은 귀하\n' > rows.csv
+```
+
+```bash
+rhwp batch fill --form samples/form-01.hwp --data rows.csv --out-dir batch_out2 --json
+```
+
+실측 출력(값만 다름을 확인):
+
+```json
+{"ambiguous":[],"changedPages":[0],"confusable":[],"dryRun":false,"filled":[{"name":"myMsg01","occurrence":0,"value":"박민수 귀하"}],"filledCount":1,"notFound":[],"output":"batch_out2\\0001.hwp","outputFormat":"hwp5","row":0,"schemaVersion":"1.0","source":"samples/form-01.hwp","verify":null}
+{"ambiguous":[],"changedPages":[0],"confusable":[],"dryRun":false,"filled":[{"name":"myMsg01","occurrence":0,"value":"최지은 귀하"}],"filledCount":1,"notFound":[],"output":"batch_out2\\0002.hwp","outputFormat":"hwp5","row":1,"schemaVersion":"1.0","source":"samples/form-01.hwp","verify":null}
+```
+
+CSV와 JSONL은 동등한 입력이다 — 이미 JSON을 다루는 파이프라인이면 JSONL을,
+사람이 스프레드시트로 명단을 관리하면 CSV를 고르면 된다.
+
+## 3단계 — 산출 파일 이름을 사람이 알아볼 수 있게: `--name-field`
+
+기본 `0001.hwp`/`0002.hwp` 대신, 데이터의 특정 컬럼 값을 파일명으로 쓸 수 있다.
+
+```bash
+printf 'myMsg01,outname\n김철수 귀하,chulsoo\n이영희 귀하,younghee\n' > named_rows.csv
+```
+
+```bash
+rhwp batch fill --form samples/form-01.hwp --data named_rows.csv \
+  --out-dir named_out --name-field outname --json
+```
+
+실측 출력:
+
+```json
+{"ambiguous":[],"changedPages":[0],"confusable":[],"dryRun":false,"filled":[{"name":"myMsg01","occurrence":0,"value":"김철수 귀하"}],"filledCount":1,"notFound":["outname"],"output":"named_out\\chulsoo.hwp","outputFormat":"hwp5","row":0,"schemaVersion":"1.0","source":"samples/form-01.hwp","verify":null}
+{"ambiguous":[],"changedPages":[0],"confusable":[],"dryRun":false,"filled":[{"name":"myMsg01","occurrence":0,"value":"이영희 귀하"}],"filledCount":1,"notFound":["outname"],"output":"named_out\\younghee.hwp","outputFormat":"hwp5","row":1,"schemaVersion":"1.0","source":"samples/form-01.hwp","verify":null}
+```
+
+**함정**: `output`이 `named_out\chulsoo.hwp`로 정확히 원하는 대로 나왔지만,
+`notFound`에 `"outname"`이 같이 찍힌다 — `--name-field`로 지정한 컬럼이 파일명
+용도로만 쓰이는 게 아니라, 채울 필드 후보로도 함께 검사되기 때문이다. 서식에
+`outname`이라는 이름의 누름틀이 없으니 그 컬럼은 "채우기엔 못 찾음"으로
+보고된다. **이건 실패가 아니다** — `filledCount`가 원하는 값(1)과 일치하고
+`output` 경로가 의도한 파일명이면 정상이다. 다만 자동화 게이트를 짤 때
+`notFound`를 무조건 실패로 처리하면 이 경우 오탐이 난다 — `--name-field`로
+지정한 컬럼명은 `notFound` 판정에서 미리 빼고 비교한다.
+
+## 4단계 — 커밋 전에 미리보기: `--dry-run`
+
+디스크에 아무것도 쓰지 않고 행별로 채움 가능 여부만 판정한다. 명단이 수백 행일
+때, 필드 이름 오타나 데이터 형식 문제를 실제 산출 전에 잡는다.
+
+```bash
+rhwp batch fill --form samples/form-01.hwp --data row1.jsonl --out-dir dry_out --dry-run --json
+```
+
+실측 출력 — `dryRun: true`, `changedPages: null`(아무것도 안 바뀜):
+
+```json
+{"ambiguous":[],"changedPages":null,"confusable":[],"dryRun":true,"filled":[{"name":"myMsg01","occurrence":0,"value":"김철수 귀하"}],"filledCount":1,"notFound":[],"output":"dry_out\\0001.hwp","outputFormat":"hwp5","row":0,"schemaVersion":"1.0","source":"samples/form-01.hwp"}
+{"ambiguous":[],"changedPages":null,"confusable":[],"dryRun":true,"filled":[{"name":"myMsg01","occurrence":0,"value":"이영희 귀하"}],"filledCount":1,"notFound":[],"output":"dry_out\\0002.hwp","outputFormat":"hwp5","row":1,"schemaVersion":"1.0","source":"samples/form-01.hwp"}
+```
+
+```
+batch fill: 2행 중 2 성공, 0 실패 (1ms, threads=32, dry-run)
+```
+
+요약 줄 끝의 `dry-run` 표시로 사람이 로그만 봐도 "이건 실제 산출이 아니다"를
+바로 알 수 있다.
+
+## 5단계(선택) — `--verify`로 행마다 재파싱 대조한다
+
+레시피 1의 2단계와 같은 개념을 행 단위로 확장한다 — 각 산출물을 저장 직후 다시
+읽어 요청한 값이 실제로 들어갔는지 확인한다.
+
+```bash
+rhwp batch fill --form samples/form-01.hwp --data row1.jsonl --out-dir verify_out --verify --json
+```
+
+실측 출력 — 행마다 `verify.identical: true`:
+
+```json
+{"ambiguous":[],"changedPages":[0],"confusable":[],"dryRun":false,"filled":[{"name":"myMsg01","occurrence":0,"value":"김철수 귀하"}],"filledCount":1,"notFound":[],"output":"verify_out\\0001.hwp","outputFormat":"hwp5","row":0,"schemaVersion":"1.0","source":"samples/form-01.hwp","verify":{"diffCount":0,"identical":true}}
+{"ambiguous":[],"changedPages":[0],"confusable":[],"dryRun":false,"filled":[{"name":"myMsg01","occurrence":0,"value":"이영희 귀하"}],"filledCount":1,"notFound":[],"output":"verify_out\\0002.hwp","outputFormat":"hwp5","row":1,"schemaVersion":"1.0","source":"samples/form-01.hwp","verify":{"diffCount":0,"identical":true}}
+```
+
+명단이 커질수록 재파싱 비용도 같이 커진다 — 대량 발송 직전 한 번, 표본만 뽑아
+검증하는 절충도 가능하다(예: 전체는 `--verify` 없이 돌리고, 처음 몇 건만 별도로
+`--verify`를 켜서 재확인).
+
+## 6단계 — 처리 속도 조절: `--threads`
+
+기본은 CPU 코어 수에 맞춰 스레드를 자동으로 정한다(이 머신에서는 `threads=32`로
+나왔다). 다른 작업과 CPU를 나눠 써야 하면 상한을 직접 건다.
+
+```bash
+rhwp batch fill --form samples/form-01.hwp --data row1.jsonl --out-dir batch_out_t2 --threads 2 --json
+```
+
+실측 출력(요약 줄만 다름을 확인 — 각 행 JSON은 위와 동일 구조):
+
+```
+batch fill: 2행 중 2 성공, 0 실패 (2ms, threads=2)
+```
+
+## 7단계 — CSV 안에 쉼표가 들어간 값도 안전하다
+
+이름 뒤에 직함을 붙이는 등 값 자체에 쉼표가 들어가는 경우, CSV 표준대로 큰따옴표로
+감싸면 정상 처리된다.
+
+```bash
+printf 'myMsg01\n"김철수, 대표"\n' > comma_rows.csv
+```
+
+```bash
+rhwp batch fill --form samples/form-01.hwp --data comma_rows.csv --out-dir comma_out --json
+```
+
+실측 출력 — `value`에 쉼표가 그대로 살아 있다:
+
+```json
+{"ambiguous":[],"changedPages":[0],"confusable":[],"dryRun":false,"filled":[{"name":"myMsg01","occurrence":0,"value":"김철수, 대표"}],"filledCount":1,"notFound":[],"output":"comma_out\\0001.hwp","outputFormat":"hwp5","row":0,"schemaVersion":"1.0","source":"samples/form-01.hwp","verify":null}
+```
+
+값을 직접 조립해 CSV를 만드는 스크립트를 짤 때는 큰따옴표 이스케이프를 CSV
+표준 라이브러리(파이썬 `csv` 모듈, Node `csv-stringify` 등)에 맡기고 문자열을
+손으로 이어붙이지 않는다 — 손으로 이어붙이면 값 안의 쉼표·줄바꿈·따옴표가 열
+경계를 깨뜨릴 수 있다.
+
+## 실패했을 때 무엇을 보고 어떻게 고칠지
+
+| 신호 | 원인 | 처방 |
+|---|---|---|
+| `오류: 서식을 읽을 수 없습니다 - ...` (종료 코드 1) | `--form` 경로가 잘못됨 | 경로를 다시 확인 — 이 저장소 표본으로 재현: `rhwp batch fill --form samples/no-such-form.hwp --data row1.jsonl --out-dir x --json` → `지정된 파일을 찾을 수 없습니다.` |
+| `오류: --data 에 데이터 행이 없습니다 - ...` (종료 코드 2) | CSV/JSONL에 헤더만 있고 실제 데이터 행이 0개 | 데이터 파일에 최소 1행 이상 있는지 확인 |
+| 행 JSON의 `notFound`에 필드명이 남음(단, `--name-field`로 지정한 컬럼 제외) | 데이터 컬럼/키가 실제 필드 이름과 다름 | `fields --json`의 `name`을 그대로 복사해 쓴다 — 레시피 1 참고 |
+| `--name-field`로 쓴 컬럼이 매 행 `notFound`에 뜸 | 정상 동작 — 그 컬럼은 파일명 용도로만 쓰였을 뿐 서식 필드가 아님 | 자동화 게이트에서 그 컬럼명은 `notFound` 비교 대상에서 제외 |
+| `ambiguous`가 비어 있지 않음 | 같은 이름의 필드가 문서에 여러 번 있음 | [서식 자동화 심화 가이드 1-1절](../form_filling_guide.md#1-1-반복-필드--같은-이름이-여러-번-나올-때-이름n) |
+| `--verify`의 `identical: false` | 특정 행에서만 재파싱 결과가 다름 | 해당 행만 `--verify` 없이 재실행 후 `export-svg`로 육안 확인, [레시피 6](06_visual_regression_before_after.md)의 `render-diff`로 정량화 |
+| 전체 처리 시간이 예상보다 김 | 스레드 상한이 낮거나 문서가 큼 | `--threads`를 늘리거나(코어 수 이내), 우선 `--dry-run`으로 병목이 채움 자체인지 디스크 I/O인지 먼저 좁힌다 |
+| `--data`에 헤더만 있고 실제 값 행이 0개 | 빈 CSV/JSONL을 그대로 넘김 — 이 저장소 표본으로 재현: `printf 'myMsg01\n\n' > empty.csv` 후 `batch fill --data empty.csv` | 데이터 생성 스크립트가 빈 결과를 냈는지 먼저 확인 — 명단 조회 쿼리가 0건을 돌려줬을 가능성 |
+
+## 파이프라인 게이트로 묶기
+
+행 전체가 성공했는지 사람이 로그를 읽지 않고 기계로 판정하려면, NDJSON
+출력을 `jq`로 좁힌다:
+
+```bash
+rhwp batch fill --form samples/form-01.hwp --data row1.jsonl --out-dir final_out --verify --json \
+  | jq -es '
+      map(select(.notFound != ["outname"] and (.notFound|length>0 or .ambiguous|length>0 or (.verify != null and .verify.identical==false))))
+      | if length==0 then "OK" else error("실패 행 \(length)건") end
+    '
+```
+
+이 게이트는 `notFound`/`ambiguous`가 있거나 `--verify`가 `identical: false`를
+반환한 행만 걸러내고, 하나도 없으면 `"OK"`를 반환한다. 실패 행이 있으면 어떤
+행(`row` 번호)이 실패했는지 원본 NDJSON을 다시 훑어 확인한다 — 요약 줄의 "N행
+중 M 성공"만 보고 넘어가면 어떤 행이 문제였는지 알 수 없다.
+
+## 이 레시피가 다루지 않는 것
+
+- **서식 자체를 행마다 바꾸는 것**은 지원 범위 밖이다 — `--form`은 명령 하나당
+  서식 파일 하나만 받는다. 서식이 여러 종류라면 서식별로 `batch fill`을 따로
+  실행하고 `--out-dir`을 분리한다.
+- **도장/서명 이미지 삽입이나 메타데이터 제거는 이 명령이 하지 않는다** — 각
+  산출물에 그런 후처리가 필요하면, `batch fill`이 만든 파일 목록(각 행 JSON의
+  `output`)을 후속 스크립트로 순회하며 개별 명령을 적용한다. 예를 들어
+  산출물을 한 번 더 재파싱해 페이지 수·표 구조를 정량 비교하고 싶다면 [레시피
+  6](06_visual_regression_before_after.md)의 `render-diff`를 그 목록에 대해
+  반복 실행한다.
+- **출력 폴더 정리는 호출자 몫이다** — `--out-dir`이 이미 존재하고 같은
+  이름의 파일이 있으면 덮어쓴다(멱등하게 재실행 가능하다는 뜻이기도 하다).
+  행 번호가 아니라 `--name-field`로 이름을 지정했는데 데이터에 중복 값이
+  있으면 나중 행이 먼저 행의 산출물을 덮어쓴다 — 명단에 중복이 없는지는 이
+  명령이 검사해주지 않는다.
+
+## 요약
+
+`batch fill`은 "서식 하나 + 데이터 N행"을 산출물 N개로 바꾸는 명령이다. 판정
+규칙은 [레시피 1](01_fill_form_and_submit.md)의 `edit fill-fields`와 완전히
+같다 — 행별 JSON의 `notFound`/`ambiguous`/`verify`를 그대로 게이트에 쓰면
+된다. 이 저장소 표본으로 실제 확인한 것: JSONL·CSV 둘 다 동일 결과, 쉼표가
+든 값도 CSV 표준 인용으로 안전, `--name-field`는 파일명 용도지만 `notFound`
+판정에 같이 잡히는 함정이 있음, 빈 데이터 파일은 종료 코드 2로 즉시 거부됨,
+`--dry-run`/`--verify`/`--threads`는 [레시피 1](01_fill_form_and_submit.md)의
+단일 파일 옵션과 의미가 같다.
+
+## 관련 문서
+
+- [레시피 1 — 서식 문서를 채워서 제출용으로 만들기](01_fill_form_and_submit.md) —
+  단일 문서 기준 `edit fill-fields`의 판정 규칙(`notFound`/`ambiguous`/
+  `--verify`)의 canonical 문서. `batch fill`의 행별 결과도 같은 규칙을 따른다.
+- [레시피 4 — 출처를 모르는 문서를 처음 열 때](04_safety_check_untrusted_doc.md) —
+  대량 발송 전 서식 자체를 재사용한다면, `fields --json`의 `textSecurity`부터
+  확인한다.
+- [레시피 6 — 편집 전후를 눈이 아니라 숫자로 비교하기](06_visual_regression_before_after.md) —
+  `--verify`가 못 잡는 렌더링 차이를 `render-diff`로 정량화할 때.
+- [서식 자동화 심화 가이드](../form_filling_guide.md) — 반복 필드·`ambiguous`
+  판정 규칙의 canonical 문서.
+- [CLI JSON 파이프라인 가이드](../cli_json_pipeline_guide.md) — stdout
+  NDJSON 규약과 `batch` 파이프라인의 실측 시나리오.
+- [CLI 명령어 매뉴얼](../cli_commands.md) — `batch fill`의 전체 옵션과 종료
+  코드 계약.
+- [에이전트 실무 대체 예제집](../agent_task_playbook.md) — 사람 업무 관점에서
+  "명단 → 개별 문서 N개"가 실제 업무 시나리오 어디에 대응하는지 더 넓은
+  맥락.

--- a/mydocs/manual/recipes/06_visual_regression_before_after.md
+++ b/mydocs/manual/recipes/06_visual_regression_before_after.md
@@ -1,0 +1,303 @@
+---
+kind: guide
+status: active
+canonical: mydocs/manual/recipes/06_visual_regression_before_after.md
+last_verified: 2026-08-03
+---
+
+# 레시피 6 — 편집 전후를 눈이 아니라 숫자로 비교하기
+
+**목표 한 줄**: `edit fill-fields`·`edit set-cell`·`export-hwpx` 같은 편집/변환
+명령을 돌린 뒤, "내용이 바뀌었다"가 아니라 "**의도한 것만** 바뀌고 나머지 레이아웃은
+그대로다"를 사람 눈이 아니라 픽셀 단위 수치로 판정한다.
+
+[레시피 1](01_fill_form_and_submit.md)의 `--verify`는 "요청한 값이 IR에 들어갔는가"를
+확인한다. 이 레시피의 `render-diff`는 한 걸음 더 나아가 "그 결과가 **실제로
+렌더링됐을 때** 예상과 얼마나 다른가"를 mm/px 단위로 잰다. 표 병합·폰트
+치환·페이지 넘김처럼 IR 비교로는 안 잡히지만 화면에서는 티가 나는 차이를 잡을 때
+쓴다.
+
+절차 요약:
+
+```
+render-diff <파일> --via hwpx   (자기 자신의 HWP↔HWPX 왕복 일관성, 단일 파일)
+  또는
+render-diff <파일A> <파일B>     (편집 전 vs 편집 후, 두 파일 비교)
+  또는
+render-diff --batch <폴더>      (여러 파일을 한 번에, CI 게이트용)
+```
+
+모든 명령·출력은 이 저장소의 `samples/form-01.hwp`와, [레시피
+5](05_mail_merge_batch_fill.md)에서 `batch fill`로 실제 생성한 산출물
+`batch_out/0001.hwp`(같은 서식에 `myMsg01` 필드를 채운 결과)로 실행해서
+얻었다. 지어낸 값은 없다.
+
+## 0단계 — 이 명령이 재는 것은 정확히 무엇인가
+
+`render-diff`는 두 대상(또는 한 파일을 서로 다른 경로로 두 번 렌더링한 결과)을
+`export-render-tree`와 같은 방식으로 렌더링한 뒤, 페이지별 render tree의 각
+노드(`Page/Body2/Column0/TextLine.../TextRun...` 같은 경로)를 짝지어 위치 변위를
+비교한다. 두 가지 판정축이 있다:
+
+- **변위(displacement)**: 짝지어진 같은 경로의 노드가 px 단위로 얼마나
+  움직였는가. `--max-disp`로 허용 임계값을 정한다(기본 1.00px).
+- **구조 불일치(STRUCT)**: 노드 개수 자체가 다르거나(`Δ TextRun: 15→13`처럼),
+  경로가 아예 짝지어지지 않는 경우. 변위 임계값과 무관하게 그 자체로 `STRUCT`
+  플래그가 붙는다.
+
+## 1단계 — 가장 싼 점검: 파일 하나로 HWP5↔HWPX 왕복 일관성 확인
+
+편집 없이도 쓸 수 있는 가장 기본적인 회귀 점검이다. `--via hwpx`는 HWP5 원본을
+HWPX로 변환했다가 다시 렌더링해서, 원본 HWP5 렌더링과 비교한다 — 포맷 변환
+경로 자체가 레이아웃을 깨뜨리지 않는지 보는 것이다.
+
+```bash
+rhwp render-diff samples/form-01.hwp --via hwpx
+```
+
+실측 출력:
+
+```
+페이지 수: A=1 B=1
+최대 변위: 0.00 px (page -)
+임계 초과 페이지: 0 / 구조 불일치 페이지: 0 (임계 1.00px)
+status: PASS
+```
+
+`status: PASS`, 종료 코드 0. 페이지 수(`A=1 B=1`)가 같고 최대 변위가 0px이니
+포맷 왕복이 레이아웃에 아무 영향도 주지 않았다는 뜻이다. 실제로 종료 코드를
+확인해보면:
+
+```bash
+rhwp render-diff samples/form-01.hwp --via hwpx > /dev/null; echo $?
+```
+
+```
+0
+```
+
+CI 게이트에서는 이 종료 코드 하나로 판정할 수 있다 — `render-diff`는 `--json`을
+지원하지 않는 텍스트 전용 출력이므로(`export-svg`·`fields` 등과 달리), 파이프라인
+게이트는 stdout을 파싱하기보다 **종료 코드**를 1차 판정으로 쓰고, 실패 원인
+분석에만 텍스트 출력을 읽는다.
+
+특정 페이지만 좁혀서 볼 때는 `-p`를 쓴다:
+
+```bash
+rhwp render-diff samples/form-01.hwp -p 0 --via hwpx
+```
+
+실측 출력(1페이지짜리 문서라 결과는 동일):
+
+```
+페이지 수: A=1 B=1
+최대 변위: 0.00 px (page -)
+임계 초과 페이지: 0 / 구조 불일치 페이지: 0 (임계 1.00px)
+status: PASS
+```
+
+## 2단계 — 진짜 회귀 시나리오: 편집 전 vs 편집 후
+
+이제 실제로 값이 바뀐 두 파일을 비교한다. [레시피 5](05_mail_merge_batch_fill.md)에서
+`batch fill`로 만든 `batch_out/0001.hwp`(누름틀 `myMsg01`에 "김철수 귀하"를 채운
+결과)를 원본 빈 서식과 비교한다.
+
+```bash
+rhwp render-diff samples/form-01.hwp batch_out/0001.hwp
+```
+
+실측 출력:
+
+```
+페이지 수: A=1 B=1
+최대 변위: 495.93 px (page 0)
+임계 초과 페이지: 1 / 구조 불일치 페이지: 1 (임계 1.00px)
+  page   0: max= 495.93 mean= 13.40 nodes=39/37  [STRUCT]
+       495.93px  Page/Body2/Column0/TextLine10/TextRun0
+         0.00px  Page
+         0.00px  Page/PageBg0
+      Δ TextRun: 15→13 (-2)
+status: STRUCT_MISMATCH
+```
+
+이걸 어떻게 읽나:
+
+- `status: STRUCT_MISMATCH` — 종료 코드 1로 실패 취급된다. 하지만 **이건
+  버그가 아니다** — 빈 누름틀("여기에 입력")이 실제 값("김철수 귀하")으로
+  바뀌면서 그 자리의 텍스트런 구조 자체가 달라졌기 때문에 당연히 나오는
+  결과다. `Δ TextRun: 15→13 (-2)`가 그 변화의 크기를 정량적으로 보여준다.
+- `Page/Body2/Column0/TextLine10/TextRun0`에서 `495.93px`의 변위가 잡혔다 —
+  바로 그 누름틀이 있던 줄(`TextLine10`)의 첫 텍스트런이다. **바뀐 값이 있는
+  위치와 렌더링 변위가 보고된 위치가 일치하는지**를 대조하는 게 이 단계의
+  핵심 판정이다. 만약 전혀 관계없는 페이지나 다른 단(段)에서 변위가 잡혔다면
+  — 예를 들어 상단 로고나 다른 문단이 움직였다면 — 그건 의도치 않은 부작용
+  이고 진짜 회귀다.
+- `Page`, `Page/PageBg0`처럼 상위 구조 노드는 `0.00px`로 그대로다 — 페이지
+  배경·전체 틀은 안 건드렸다는 뜻이다.
+
+`--max-disp`로 임계값을 조여서 더 엄격하게 판정할 수도 있다(구조 불일치는
+임계값과 무관하게 항상 플래그된다는 점은 동일):
+
+```bash
+rhwp render-diff samples/form-01.hwp batch_out/0001.hwp --max-disp 0.05
+```
+
+실측 출력(임계값 표시만 바뀜, 나머지는 위와 동일한 실측 판정):
+
+```
+페이지 수: A=1 B=1
+최대 변위: 495.93 px (page 0)
+임계 초과 페이지: 1 / 구조 불일치 페이지: 1 (임계 0.05px)
+  page   0: max= 495.93 mean= 13.40 nodes=39/37  [STRUCT]
+       495.93px  Page/Body2/Column0/TextLine10/TextRun0
+         0.00px  Page
+         0.00px  Page/PageBg0
+      Δ TextRun: 15→13 (-2)
+status: STRUCT_MISMATCH
+```
+
+## 2-1단계 — 같은 편집을 받은 두 산출물끼리 비교해서 "값 종류"가 아니라 "편집 종류"를 검증한다
+
+`batch fill`([레시피 5](05_mail_merge_batch_fill.md))로 같은 서식에 다른 값을
+채운 산출물이 여러 개 있다면, 원본과의 비교뿐 아니라 산출물끼리도 비교할 수
+있다. `batch_out/0001.hwp`("김철수 귀하")와 `batch_out/0002.hwp`("이영희
+귀하")는 둘 다 같은 필드에 같은 글자 수의 값을 채운 결과다.
+
+```bash
+rhwp render-diff batch_out/0001.hwp batch_out/0002.hwp
+```
+
+실측 출력:
+
+```
+페이지 수: A=1 B=1
+최대 변위: 0.00 px (page -)
+임계 초과 페이지: 0 / 구조 불일치 페이지: 0 (임계 1.00px)
+status: PASS
+```
+
+`status: PASS` — 값은 다르지만("김철수 귀하" vs "이영희 귀하") 글자 수가
+같아서 텍스트런 구조가 동일하게 유지됐다. 이건 "같은 종류의 편집(같은 필드,
+같은 길이대의 값)을 여러 행에 적용했을 때 산출물들이 서로 구조적으로
+일관된가"를 확인하는 용도다 — 메일머지처럼 같은 서식을 대량으로 채울 때, 몇
+건만 표본으로 뽑아 서로 비교해 보면 특정 값에서만 예외적으로 레이아웃이
+깨지는 행을 찾아낼 수 있다.
+
+동일한 파일을 자기 자신과 비교하면(회귀 테스트의 기준선 역할) 항상 `PASS`가
+나와야 한다는 것도 같이 확인해 둔다:
+
+```bash
+rhwp render-diff batch_out/0001.hwp batch_out/0001.hwp
+```
+
+```
+페이지 수: A=1 B=1
+최대 변위: 0.00 px (page -)
+임계 초과 페이지: 0 / 구조 불일치 페이지: 0 (임계 1.00px)
+status: PASS
+```
+
+이 자기 비교가 `PASS`가 아니라 무언가 다른 값을 낸다면, `render-diff` 자체나
+렌더링 파이프라인에 비결정성(non-determinism)이 있다는 훨씬 심각한 신호다 —
+매 실행마다 같은 입력에 대해 같은 출력이 나오는지는 회귀 도구의 기본 전제이므로,
+이 자기 비교를 CI에 상시 기준선으로 하나 심어두는 것도 방법이다.
+
+## 3단계 — CI 게이트: 여러 파일을 한 번에 훑는다
+
+문서 여러 개를 한 폴더에 모아두고 왕복 일관성을 배치로 확인한다. TSV로도
+저장되므로, CI 아티팩트로 남기거나 스프레드시트에서 추이를 볼 수 있다.
+
+```bash
+mkdir -p rd_batch
+cp samples/form-01.hwp samples/form-02.hwp rd_batch/
+rhwp render-diff --batch rd_batch --via hwpx -o rd_out
+```
+
+실측 출력:
+
+```
+[           PASS] max_disp=   0.00 struct=0 over=0      5ms  form-01.hwp
+[           PASS] max_disp=   0.00 struct=0 over=0      4ms  form-02.hwp
+
+TSV 저장: rd_out\geom_inventory.tsv
+
+=== render-diff 요약 ===
+  총 파일         : 2
+  PASS            : 2
+  WARN_TEXTRUN    : 0
+  OVER            : 0
+  STRUCT_MISMATCH : 0
+  PAGE_MISMATCH   : 0
+  LOAD_FAIL       : 0
+  전체 최대 변위  : 0.00 px
+```
+
+`rd_out/geom_inventory.tsv`를 열어보면 파일별 판정이 표로 저장돼 있다:
+
+```
+sample	status	pages_a	pages_b	max_disp	worst_page	struct_pages	over_pages	elapsed_ms	error	struct_delta
+form-01.hwp	PASS	1	1	0.000	-	0	0	5		
+form-02.hwp	PASS	1	1	0.000	-	0	0	4		
+```
+
+컬럼 그대로 CI 대시보드나 회귀 추이 스프레드시트에 붙여넣을 수 있다. 배치 요약에
+나오는 상태값은 5가지다: `PASS`(문제 없음), `WARN_TEXTRUN`(텍스트런 경고 수준
+차이), `OVER`(변위가 임계 초과), `STRUCT_MISMATCH`(구조 자체가 다름),
+`PAGE_MISMATCH`(페이지 수 자체가 다름), `LOAD_FAIL`(파일을 못 열었음).
+
+## 실패했을 때 무엇을 보고 어떻게 고칠지
+
+| 신호 | 원인 | 처방 |
+|---|---|---|
+| `오류: 파일 읽기 실패 ...` (종료 코드 1) | 경로가 잘못됨 | 이 저장소 표본으로 재현: `rhwp render-diff samples/no-such.hwp` → `지정된 파일을 찾을 수 없습니다.` |
+| `오류: 폴더 읽기 실패 ...` (`--batch`, 종료 코드 2) | `--batch` 폴더 경로가 잘못됨 | 폴더가 실제로 존재하는지, 상대 경로 기준이 맞는지 확인 |
+| `status: STRUCT_MISMATCH`인데 변위 위치가 편집 의도와 일치 | 정상 — 값이 바뀐 자리는 구조도 바뀐다 | 실패로 취급하지 않는다. 변위 노드 경로(`Page/Body2/...`)가 편집한 필드 위치와 맞는지 사람이 한 번 대조 |
+| `status: STRUCT_MISMATCH`인데 변위 위치가 편집과 무관한 페이지/단 | 진짜 회귀 — 의도치 않은 레이아웃 변화 | 편집 명령의 `--verify`(레시피 1) 결과와 대조하고, `export-svg`로 두 산출물을 나란히 눈으로도 확인 |
+| `status: PAGE_MISMATCH` | 페이지 수 자체가 달라짐(내용 증가로 새 페이지가 생겼거나 줄어듦) | 의도한 변경이면 정상, 아니면 `dump-pages --json`으로 어느 페이지에서 갈라지는지 좁힌다 |
+| `status: LOAD_FAIL` (배치 모드) | 그 파일만 파싱 자체가 실패 | `info --json`으로 그 파일 하나만 따로 열어 원인 확인 — [문서 진단 도구](../document_diagnostics_tool_manual.md) |
+| 배치 요약의 `OVER` 건수가 0이 아님 | 변위가 `--max-disp` 임계를 넘었지만 구조는 동일 | 임계값이 너무 빡빡한지, 실제 폰트/여백 회귀인지 TSV의 `worst_page`로 좁혀 확인 |
+
+## 이 레시피가 하지 않는 것
+
+- 텍스트 내용 자체의 옳고 그름은 판정하지 않는다 — "값이 정확히 채워졌는가"는
+  [레시피 1](01_fill_form_and_submit.md)의 `--verify`(IR 비교) 몫이다.
+  `render-diff`는 그 값이 **렌더링됐을 때 레이아웃에 미친 영향**만 잰다.
+- 색상·폰트 렌더링 품질의 픽셀 대 픽셀 비교는 아니다 — render tree의 노드
+  위치·구조 비교이지, 실제 래스터 이미지 diff가 아니다. 진짜 시각적 이미지
+  비교가 필요하면 `export-svg`/`export-png`로 뽑은 산출물을 별도 이미지 diff
+  도구로 비교한다.
+- `--json` 출력을 지원하지 않는다(2026-08-03 기준, `rhwp v0.8.2`) — 자동화
+  게이트는 종료 코드를 1차 판정으로 쓰고, `--batch` 모드의 TSV를 2차 상세
+  분석 자료로 쓴다.
+
+## 요약
+
+`render-diff`는 세 가지 모드를 제공한다: 파일 하나의 포맷 왕복 일관성(`--via
+hwpx`), 두 파일 간 편집 전후 비교, 폴더 단위 배치 비교. 이 저장소 표본으로
+실제 확인한 것: 빈 서식을 채우면 그 자리에서 `STRUCT_MISMATCH`가 나는 게
+정상(값이 바뀌었으니 구조도 바뀐다)이라는 점, 같은 편집을 받은 산출물끼리는
+글자 수가 같으면 `PASS`가 나온다는 점, 자기 자신과의 비교는 항상 `PASS`여야
+한다는 점(회귀 도구 자체의 결정성 기준선), `--json` 출력이 없어 종료 코드를
+1차 판정으로 쓴다는 점. `STRUCT_MISMATCH`를 보면 반사적으로 실패 처리하지
+말고, 변위가 잡힌 노드 경로가 실제로 편집한 위치와 일치하는지부터 확인한다.
+
+요컨대 이 레시피의 핵심 습관은 하나다 — `render-diff`가 빨간불을 켜면 곧바로
+롤백하지 말고, 그 빨간불이 가리키는 노드 경로부터 읽는다. 편집한 자리와
+일치하면 예상된 결과이고, 엉뚱한 자리를 가리키면 그때부터가 진짜 디버깅
+시작이다.
+
+## 관련 문서
+
+- [레시피 1 — 서식 문서를 채워서 제출용으로 만들기](01_fill_form_and_submit.md) —
+  `--verify`(IR 비교)와 이 레시피의 `render-diff`(렌더링 비교)가 서로 다른
+  질문에 답한다는 점.
+- [레시피 5 — 서식 하나에 여러 사람 데이터를 한 번에 채우기](05_mail_merge_batch_fill.md) —
+  이 레시피에서 비교 대상으로 쓴 `batch_out/0001.hwp`를 만든 절차.
+- [문서 진단 도구](../document_diagnostics_tool_manual.md) — `LOAD_FAIL`이나
+  `PAGE_MISMATCH`가 나왔을 때 `info → dump → diag` 순서로 원인을 더 좁히는
+  절차.
+- [CLI 명령어 매뉴얼](../cli_commands.md) — `render-diff`·`export-render-tree`의
+  전체 옵션.
+- [레시피 4 — 출처를 모르는 문서를 처음 열 때](04_safety_check_untrusted_doc.md) —
+  편집 대상 문서 자체가 낯선 출처라면, 렌더링 비교 이전에 먼저 밟는 안전
+  점검 절차.


### PR DESCRIPTION
로드맵 #3828 B3. `cli_commands.md` 는 **명령 하나하나의 사용법**이다. 없는 건
**목표에서 시작하는 서사** — "무엇을 하고 싶은가" → "어떤 명령을 어떤 순서로".

## 레시피 5편 · 1,285줄

| 파일 | 줄 | 목표 |
|---|---:|---|
| `01_fill_form_and_submit.md` | 205 | 서식을 채워 제출용으로 만들기 |
| `02_table_csv_roundtrip.md` | 167 | 표 데이터를 CSV 로 뽑아 고치고 되돌리기 |
| `04_safety_check_untrusted_doc.md` | 303 | 출처 모르는 문서를 처음 열 때 안전 점검 |
| `05_mail_merge_batch_fill.md` | 307 | 여러 수신자에게 같은 양식 대량 발급 |
| `06_visual_regression_before_after.md` | 303 | 편집 전후를 `render-diff` 로 정량 판정 |

각 레시피는 **목표 한 줄 → 단계별 실제 명령+실제 출력 → 실패했을 때 무엇을 보고 어떻게
고칠지 → 관련 문서 링크** 구조다.

## 봉투 예시는 전부 실측이다 — 지어낸 값 0

`rhwp v0.8.2` 로 `samples/` 문서에 실제로 실행해 얻은 출력만 실었다.
레시피 4는 9개, 5는 11개, 6은 8개의 실행 예시를 담았고 **재현 명령이 본문에 그대로** 있다.

`01` 의 `edit sanitize` 봉투는 이전 세션 측정값이라 **이번에 다시 실행해 재확인**했다 —
봉투 키 7개(`keepPreview`·`output`·`outputFormat`·`removed`·`removedCount`·`schemaVersion`·
`source`)가 정확히 일치한다.

## 이정표 — 다리를 놓고 이정표를 안 세우면 아무도 못 찾는다

- `llms.txt` 에 "레시피" 절 신설 + 5편 링크
- `mydocs/manual/agent_knowledge_map.md` 에 1-3-1절 신설 + 5편 표

## 남은 것 — 레시피 03

**03(배포 전 PII 마스킹, `edit redact`)은 쓰지 못했다.** 작업 워크트리가 `edit redact`
병합(통합 PR #3816) 이전 devel 스냅샷이라 그 명령을 실행할 수 없었고, **실행 없이 출력을
지어내는 것은 이 레시피 묶음의 원칙("지어낸 값 없음")을 정면으로 어긴다.**
후속 PR 로 올린다 — 01·04 본문에 03 을 가리키는 상호 참조가 이미 있어 그 자리에 들어가면 된다.
