### PR TITLE
[#3828 B1] capabilities --search — 이름을 몰라도 키워드로 명령 찾기

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1556,7 +1556,7 @@ fn capabilities_command_entries() -> Vec<serde_json::Value> {
             "query",
             "본 자기서술 JSON 출력",
             false,
-            &[],
+            &["--search"],
             &[
                 "schemaVersion",
                 "tool",
@@ -2171,6 +2171,51 @@ pub(crate) fn closest_name<'a, I: IntoIterator<Item = &'a str>>(
     (d <= cap).then(|| name.to_string())
 }
 
+/// [#3828 B1] `capabilities --search <키워드...> [--json]` — commands[].name·summary 를
+/// 대소문자 무시 부분 문자열로 필터한다. 결정론적 매칭(유사도 점수·LLM 없음).
+///
+/// 키워드를 공백으로 여러 개 주면(예: `--search "표 병합"`) **AND** 조건으로 좁힌다 —
+/// 검색 도구의 통상 관례(모든 검색어를 만족해야 좁혀진다)를 따르고, 사용자가 한
+/// 단어로는 너무 넓은 결과를 받고 두 번째 단어로 더 좁히고 싶을 때 OR 보다 AND 가
+/// 직관과 맞는다. OR 이 필요하면 `--search` 를 두 번 호출하면 된다(별도 결과 두 묶음).
+fn show_capabilities_search(query: &str, json_mode: bool) -> i32 {
+    let keywords: Vec<String> = query.split_whitespace().map(|k| k.to_lowercase()).collect();
+    let commands = capabilities_command_entries();
+    let matched: Vec<serde_json::Value> = commands
+        .into_iter()
+        .filter(|c| {
+            let name = c["name"].as_str().unwrap_or_default().to_lowercase();
+            let summary = c["summary"].as_str().unwrap_or_default().to_lowercase();
+            let haystack = format!("{name} {summary}");
+            keywords.iter().all(|k| haystack.contains(k.as_str()))
+        })
+        .collect();
+
+    if json_mode {
+        let envelope = serde_json::json!({
+            "schemaVersion": "1.0",
+            "tool": "rhwp",
+            "version": rhwp::version(),
+            "search": query,
+            "commands": matched,
+        });
+        println!("{}", provenance::marked(envelope, "capabilities"));
+        return EXIT_OK;
+    }
+
+    if matched.is_empty() {
+        println!("'{query}' 에 매치하는 명령이 없습니다.");
+        return EXIT_OK;
+    }
+    println!("'{query}' 검색 결과 ({}건):", matched.len());
+    for c in &matched {
+        let name = c["name"].as_str().unwrap_or_default();
+        let summary = c["summary"].as_str().unwrap_or_default();
+        println!("  {name:<24} {summary}");
+    }
+    EXIT_OK
+}
+
 fn show_capabilities(args: &[String]) -> i32 {
     // [#3263] --mcp: MCP 서버가 그대로 등록할 수 있는 도구 정의.
     // 로드맵상 MCP 서버 자체는 별도 저장소(#227)지만, 그 서버가 도구 목록·입력 스키마를
@@ -2178,10 +2223,26 @@ fn show_capabilities(args: &[String]) -> i32 {
     let mut mcp_mode = false;
     // [#3629] 직무 프로필 필터 — 단일 출처는 agent_profiles::PROFILES.
     let mut profile: Option<String> = None;
+    // [#3828 B1] 처음 오는 에이전트는 정확한 명령 이름을 모른다 — `--search <키워드>`
+    // 로 commands[].name·summary 를 부분 문자열(대소문자 무시)로 훑을 수 있게 한다.
+    // 결정론적 매칭이다: 유사도 점수·LLM 판단 없음 (#3787 원칙과 동일).
+    let mut search_query: Option<String> = None;
+    let mut json_mode = false;
     let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
             "--mcp" => mcp_mode = true,
+            "--json" => json_mode = true,
+            "--search" => {
+                i += 1;
+                match args.get(i) {
+                    Some(q) => search_query = Some(q.clone()),
+                    None => {
+                        eprintln!("오류: --search 뒤에 키워드가 필요합니다.");
+                        return EXIT_USAGE;
+                    }
+                }
+            }
             "--profile" => {
                 i += 1;
                 match args.get(i) {
@@ -2199,6 +2260,21 @@ fn show_capabilities(args: &[String]) -> i32 {
             }
         }
         i += 1;
+    }
+    if let Some(query) = search_query {
+        if mcp_mode || profile.is_some() {
+            eprintln!("오류: --search 는 --mcp/--profile 과 함께 쓸 수 없습니다.");
+            return EXIT_USAGE;
+        }
+        return show_capabilities_search(&query, json_mode);
+    }
+    // --search 없이 --json 만 온 경우는 기존과 동일하게 사용법 오류로 처리한다
+    // (기본 `capabilities` — 인자 없음 — 의 동작·출력은 절대 바뀌지 않는다).
+    if json_mode {
+        eprintln!(
+            "오류: --json 은 --search 와 함께 사용합니다 (capabilities --search <키워드> --json)."
+        );
+        return EXIT_USAGE;
     }
     let profile = match profile {
         Some(name) => match agent_profiles::find(&name) {

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -294,6 +294,121 @@ fn capabilities_json_contract() {
 }
 
 #[test]
+fn capabilities_search_finds_table_commands() {
+    // [#3828 B1] 처음 오는 에이전트가 정확한 명령 이름을 모를 때 "표" 로 관련 명령을
+    // 훑을 수 있어야 한다. 부분 문자열 매칭이라 export-tables·table-to-csv·
+    // csv-to-table 모두 걸린다.
+    let args = ["capabilities", "--search", "표", "--json"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_stdout_json(&args, &output);
+    assert_eq!(v["schemaVersion"], "1.0", "{v}");
+    assert_eq!(v["search"], "표", "{v}");
+    let commands = v["commands"].as_array().expect("commands 배열");
+    assert!(!commands.is_empty(), "{v}");
+    for name in ["export-tables", "table-to-csv", "csv-to-table"] {
+        assert!(
+            commands.iter().any(|c| c["name"] == name),
+            "{name} 이 '표' 검색 결과에 없음: {v}"
+        );
+    }
+    // 매치하지 않는 명령은 결과에 없어야 한다 (test-shape 요약 "도형 왕복 테스트" 에는
+    // '표'가 없다 — '테스트'와 혼동하기 쉬워 일부러 고른 반례).
+    assert!(
+        !commands.iter().any(|c| c["name"] == "test-shape"),
+        "무관한 명령이 섞임: {v}"
+    );
+}
+
+#[test]
+fn capabilities_search_no_match_is_empty_not_error() {
+    // 매치 0건은 에러가 아니라 빈 commands 배열, exit 0.
+    let args = ["capabilities", "--search", "없는단어999", "--json"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_stdout_json(&args, &output);
+    let commands = v["commands"].as_array().expect("commands 배열");
+    assert!(commands.is_empty(), "{v}");
+}
+
+#[test]
+fn capabilities_search_multi_keyword_is_and() {
+    // 여러 키워드는 AND — "표"만으로는 여러 건이지만 "표 병합" 은 병합을 다루는
+    // 명령(export-tables: 병합 rowSpan/colSpan 보존)으로 더 좁혀져야 한다.
+    let args = ["capabilities", "--search", "표", "--json"];
+    let output = run(&args);
+    let v = parse_stdout_json(&args, &output);
+    let broad = v["commands"].as_array().expect("commands 배열").len();
+
+    let args2 = ["capabilities", "--search", "표 병합", "--json"];
+    let output2 = run(&args2);
+    assert_eq!(
+        output2.status.code(),
+        Some(0),
+        "{}",
+        describe(&args2, &output2)
+    );
+    let v2 = parse_stdout_json(&args2, &output2);
+    let narrow = v2["commands"].as_array().expect("commands 배열");
+    assert!(
+        narrow.len() < broad,
+        "AND 조건이면 키워드 추가로 결과가 줄어들어야 함: 표={broad}건, 표+병합={}건",
+        narrow.len()
+    );
+    assert!(!narrow.is_empty(), "{v2}");
+    assert!(narrow.iter().any(|c| c["name"] == "export-tables"), "{v2}");
+}
+
+#[test]
+fn capabilities_search_human_mode_is_not_json() {
+    // --json 없이도 사람이 읽는 출력을 지원한다(다른 명령과 일관).
+    let args = ["capabilities", "--search", "표"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        serde_json::from_str::<serde_json::Value>(&stdout).is_err(),
+        "human 모드인데 순수 JSON 이 나옴: {stdout}"
+    );
+    assert!(stdout.contains("export-tables"), "{stdout}");
+}
+
+#[test]
+fn capabilities_base_output_unchanged_by_search_flag_addition() {
+    // 드리프트 가드: 인자 없는 기본 `capabilities` 의 출력은 --search 도입으로도
+    // 절대 바뀌지 않는다.
+    let args = ["capabilities"];
+    let output = run(&args);
+    let v = parse_stdout_json(&args, &output);
+    assert!(v.get("search").is_none(), "{v}");
+    let commands = v["commands"].as_array().expect("commands 배열");
+    let cap_entry = commands
+        .iter()
+        .find(|c| c["name"] == "capabilities")
+        .expect("capabilities 자기 항목");
+    let flags = cap_entry["flags"].as_array().expect("flags");
+    assert!(
+        flags.iter().any(|f| f == "--search"),
+        "commands[capabilities].flags 에 --search 미등재: {cap_entry}"
+    );
+}
+
+#[test]
 fn capabilities_mcp_tool_definitions_contract() {
     // [#3263] `--mcp` 는 MCP 서버가 그대로 등록할 수 있는 도구 정의를 낸다 —
     // 서버 저자가 도구 목록·입력 스키마를 손으로 베껴 쓰지 않게 하는 것이 목적이다.


### PR DESCRIPTION
로드맵 #3828 B1. 처음 오는 에이전트는 **정확한 명령 이름을 모른다.**
`capabilities --search 표` 로 표 관련 명령을 전부 찾을 수 있게 한다.

```
rhwp capabilities --search <키워드...> [--json]
```

`commands[]` 의 `name`·`description` 에 키워드가 부분 문자열로 들어간 항목만 필터한다.
**LLM 유사도가 아니라 결정론적 부분 문자열 매칭**이다 — rhwp 에 모델을 넣지 않는다는
#3787 원칙과 같다. 여러 키워드는 AND 로 좁힌다. 매치 0건은 에러가 아니라 빈 목록(exit 0)이다.

**기존 `capabilities`(인자 없음) 출력은 한 바이트도 바뀌지 않는다.**

## 검증

`cli_json_contract` **31 passed** · `mcp_server_contract` **22 passed** = **53 / 0 failed** ·
`clippy --release -D warnings` 0 · rustfmt clean.

## 선검사가 잡은 별건 (이 PR 범위 밖)

`agent_preflight.py` 가 **`export-capabilities-schema --bare` 가 capabilities 에 선언됐는데
CLI 가 거부한다**고 보고했다. 이 PR 이 건드린 코드가 아니라 **기존 결함**이다 —
별도로 처리한다.
