### PR TITLE
feat(search): --context — 매치 앞뒤 문단을 같은 왕복에서

### DIFF
--- a/src/document_core/queries/grep.rs
+++ b/src/document_core/queries/grep.rs
@@ -15,6 +15,7 @@ use serde::Serialize;
 
 use crate::document_core::DocumentCore;
 use crate::model::control::Control;
+use crate::model::paragraph::Paragraph;
 use crate::renderer::pagination::PageItem;
 
 /// 검색 매치 하나.
@@ -46,6 +47,13 @@ pub struct GrepMatch {
     /// `cell`/`textbox` 좌표와 함께 제공된다.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub equation: Option<EquationRef>,
+    /// `--context N` 을 준 경우 매치가 속한 문단 **앞** N개 문단의 텍스트
+    /// (문서/셀/글상자 경계 밖으로는 나가지 않는다 — 있는 만큼만 준다).
+    #[serde(rename = "contextBefore", skip_serializing_if = "Option::is_none")]
+    pub context_before: Option<Vec<String>>,
+    /// `--context N` 을 준 경우 매치가 속한 문단 **뒤** N개 문단의 텍스트.
+    #[serde(rename = "contextAfter", skip_serializing_if = "Option::is_none")]
+    pub context_after: Option<Vec<String>>,
 }
 
 /// 표 셀 매치의 좌표.
@@ -90,6 +98,23 @@ fn make_context(text: &str, offset: usize, length: usize) -> String {
         out.push('…');
     }
     out
+}
+
+/// 매치가 속한 문단을 담은 `paragraphs` 슬라이스에서 `idx` 앞뒤 `n`개 문단의
+/// 텍스트를 뽑는다. 경계(첫/마지막 문단)에서는 있는 만큼만 준다 — 범위 밖으로
+/// 나가지 않는다.
+fn context_window(paragraphs: &[Paragraph], idx: usize, n: usize) -> (Vec<String>, Vec<String>) {
+    let start = idx.saturating_sub(n);
+    let before = paragraphs[start..idx]
+        .iter()
+        .map(|p| p.text.clone())
+        .collect();
+    let end = (idx + 1 + n).min(paragraphs.len());
+    let after = paragraphs[idx + 1..end]
+        .iter()
+        .map(|p| p.text.clone())
+        .collect();
+    (before, after)
 }
 
 impl DocumentCore {
@@ -181,7 +206,23 @@ impl DocumentCore {
     ///
     /// 본문·표 셀·글상자를 순회한다(`search_all` 과 같은 범위). `limit` 이 `Some` 이면
     /// 그 개수에서 멈춘다 — 대형 문서에서 컨텍스트를 아끼기 위한 상한이다.
+    ///
+    /// 기존 계약과 완전히 동일한 얇은 래퍼다(`context: None`) — `grep_with_context` 로
+    /// 위임한다.
     pub fn grep(&self, query: &str, case_sensitive: bool, limit: Option<usize>) -> Vec<GrepMatch> {
+        self.grep_with_context(query, case_sensitive, limit, None)
+    }
+
+    /// `grep` 과 같지만 `context` 가 `Some(n)` 이면 매치가 속한 문단의 앞뒤 `n`개
+    /// 문단 텍스트를 `contextBefore`/`contextAfter` 로 함께 돌려준다(표 셀·글상자
+    /// 매치는 그 컨테이너 안에서, 본문 매치는 구역 문단 목록 안에서 앞뒤를 센다).
+    pub fn grep_with_context(
+        &self,
+        query: &str,
+        case_sensitive: bool,
+        limit: Option<usize>,
+        context: Option<usize>,
+    ) -> Vec<GrepMatch> {
         if query.is_empty() {
             return Vec::new();
         }
@@ -200,7 +241,9 @@ impl DocumentCore {
                      offset: usize,
                      cell: Option<CellRef>,
                      textbox: Option<TextBoxRef>,
-                     equation: Option<EquationRef>| GrepMatch {
+                     equation: Option<EquationRef>,
+                     context_before: Option<Vec<String>>,
+                     context_after: Option<Vec<String>>| GrepMatch {
                         section: sec_idx,
                         paragraph: para_idx,
                         page,
@@ -211,13 +254,32 @@ impl DocumentCore {
                         cell,
                         textbox,
                         equation,
+                        context_before,
+                        context_after,
                     };
+                // 본문 문단 기준 컨텍스트 — 구역 문단 목록 안에서 앞뒤를 센다.
+                let (body_ctx_before, body_ctx_after) = match context {
+                    Some(n) => {
+                        let (b, a) = context_window(&section.paragraphs, para_idx, n);
+                        (Some(b), Some(a))
+                    }
+                    None => (None, None),
+                };
                 let make = |text: &str,
                             offset: usize,
                             cell: Option<CellRef>,
                             textbox: Option<TextBoxRef>,
                             equation: Option<EquationRef>| {
-                    make_at(page, text, offset, cell, textbox, equation)
+                    make_at(
+                        page,
+                        text,
+                        offset,
+                        cell,
+                        textbox,
+                        equation,
+                        body_ctx_before.clone(),
+                        body_ctx_after.clone(),
+                    )
                 };
                 // [#3403] 분할 표 셀은 호스트 문단의 첫 쪽이 아니라 그 행이 실제로 렌더되는
                 // 쪽을 쓴다. 행 범위를 못 찾으면 종전 문단 쪽으로 물러선다.
@@ -245,6 +307,16 @@ impl DocumentCore {
                         Control::Table(table) => {
                             for (cell_idx, cell) in table.cells.iter().enumerate() {
                                 for (cp_idx, cp) in cell.paragraphs.iter().enumerate() {
+                                    // 셀 안의 매치는 구역 문단이 아니라 그 셀의 문단
+                                    // 목록 안에서 앞뒤를 센다.
+                                    let (cell_ctx_before, cell_ctx_after) = match context {
+                                        Some(n) => {
+                                            let (b, a) =
+                                                context_window(&cell.paragraphs, cp_idx, n);
+                                            (Some(b), Some(a))
+                                        }
+                                        None => (None, None),
+                                    };
                                     for offset in super::search_query::find_matches(
                                         &cp.text,
                                         query,
@@ -261,6 +333,8 @@ impl DocumentCore {
                                             }),
                                             None,
                                             None,
+                                            cell_ctx_before.clone(),
+                                            cell_ctx_after.clone(),
                                         ));
                                         if limit.is_some_and(|n| out.len() >= n) {
                                             return out;
@@ -288,6 +362,8 @@ impl DocumentCore {
                                                     Some(EquationRef {
                                                         control: equation_idx,
                                                     }),
+                                                    cell_ctx_before.clone(),
+                                                    cell_ctx_after.clone(),
                                                 ));
                                                 if limit.is_some_and(|n| out.len() >= n) {
                                                     return out;
@@ -303,12 +379,22 @@ impl DocumentCore {
                                 crate::document_core::helpers::get_textbox_from_shape(shape)
                             {
                                 for (tp_idx, tp) in tb.paragraphs.iter().enumerate() {
+                                    // 글상자 안의 매치는 글상자 문단 목록 안에서 앞뒤를
+                                    // 센다(본문 문단 목록이 아니다).
+                                    let (tb_ctx_before, tb_ctx_after) = match context {
+                                        Some(n) => {
+                                            let (b, a) = context_window(&tb.paragraphs, tp_idx, n);
+                                            (Some(b), Some(a))
+                                        }
+                                        None => (None, None),
+                                    };
                                     for offset in super::search_query::find_matches(
                                         &tp.text,
                                         query,
                                         case_sensitive,
                                     ) {
-                                        out.push(make(
+                                        out.push(make_at(
+                                            page,
                                             &tp.text,
                                             offset,
                                             None,
@@ -317,6 +403,8 @@ impl DocumentCore {
                                                 paragraph: tp_idx,
                                             }),
                                             None,
+                                            tb_ctx_before.clone(),
+                                            tb_ctx_after.clone(),
                                         ));
                                         if limit.is_some_and(|n| out.len() >= n) {
                                             return out;
@@ -331,7 +419,8 @@ impl DocumentCore {
                                                 query,
                                                 case_sensitive,
                                             ) {
-                                                out.push(make(
+                                                out.push(make_at(
+                                                    page,
                                                     &equation.script,
                                                     offset,
                                                     None,
@@ -342,6 +431,8 @@ impl DocumentCore {
                                                     Some(EquationRef {
                                                         control: equation_idx,
                                                     }),
+                                                    tb_ctx_before.clone(),
+                                                    tb_ctx_after.clone(),
                                                 ));
                                                 if limit.is_some_and(|n| out.len() >= n) {
                                                     return out;

--- a/src/main.rs
+++ b/src/main.rs
@@ -853,21 +853,31 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
                 "verify",
             ],
         ),
-        tool(
+        tool_with_optional_args(
             "hwp_search",
             "문서에서 검색어를 찾아 구역·문단·페이지·문자 오프셋 주소와 문맥을 돌려준다.",
             serde_json::json!({
                 "type": "object",
                 "properties": {
                     "path": { "type": "string", "description": "HWP/HWPX 문서 경로" },
-                    "query": { "type": "string", "minLength": 1, "description": "검색어" }
+                    "query": { "type": "string", "minLength": 1, "description": "검색어" },
+                    "context": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "매치가 속한 문단의 앞뒤 N개 문단 텍스트를 matches[].contextBefore/contextAfter 로 함께 받는다. 생략하면 종전과 동일(문맥 없음)"
+                    }
                 },
                 "required": ["path", "query"],
             }),
             "search",
-            // `--` 뒤는 전부 위치 인자다 — 그래서 `--json` 은 구분자 **앞**에
-            // 와야 한다. 뒤에 두면 세 번째 위치 인자가 되어 "인자가 너무 많습니다" 다.
+            // `--` 뒤는 전부 위치 인자다 — 그래서 `--json`(과 `--context`)은 구분자
+            // **앞**에 와야 한다. 뒤에 두면 세 번째 위치 인자가 되어 "인자가 너무
+            // 많습니다" 다. `{query}` 는 이 배선의 마지막 원소여야 한다 —
+            // optionalArgs 는 이 "--" 앞에 삽입된다(run_cli_tool 참고).
             serde_json::json!(["search", "{path}", "--json", "--", "{query}"]),
+            serde_json::json!([
+                { "when": "context", "args": ["--context", "{context}"] }
+            ]),
             &[
                 "source",
                 "query",
@@ -1774,7 +1784,13 @@ fn capabilities_command_entries() -> Vec<serde_json::Value> {
             "query",
             "문서 검색 결과를 구역·문단·페이지·문자 오프셋 주소와 함께 출력",
             false,
-            &["--json", "--ignore-case", "--limit", "--max-matches"],
+            &[
+                "--json",
+                "--ignore-case",
+                "--limit",
+                "--max-matches",
+                "--context",
+            ],
             &[
                 "schemaVersion",
                 "source",
@@ -9828,6 +9844,7 @@ fn search_document(args: &[String]) -> i32 {
     let mut json_mode = false;
     let mut ignore_case = false;
     let mut limit: Option<usize> = None;
+    let mut context: Option<usize> = None;
 
     // POSIX 옵션 종결자. 검색어가 '-' 로 시작하면 종전에는 플래그로 먹혔다 —
     // `-i` 는 대소문자 축을 **조용히** 뒤집고(리터럴 "-i" 를 찾으려던 호출이 다음
@@ -9851,6 +9868,19 @@ fn search_document(args: &[String]) -> i32 {
                     Some(n) if n >= 1 => limit = Some(n),
                     _ => {
                         eprintln!("오류: {flag} 뒤에 1 이상의 정수가 필요합니다.");
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            // [#3835] 매치 앞뒤 문단을 함께 보고 싶은 에이전트용 — 매치가 속한 문단의
+            // 앞뒤 N개 문단 텍스트를 matches[].contextBefore/contextAfter 로 얹는다.
+            // 기본(플래그 없음)은 종전과 완전히 동일하다.
+            "--context" if !end_of_options => {
+                i += 1;
+                match args.get(i).and_then(|v| v.parse::<usize>().ok()) {
+                    Some(n) if n >= 1 => context = Some(n),
+                    _ => {
+                        eprintln!("오류: --context 뒤에 1 이상의 정수가 필요합니다.");
                         return EXIT_USAGE;
                     }
                 }
@@ -9882,7 +9912,8 @@ fn search_document(args: &[String]) -> i32 {
 
     let (Some(file_path), Some(query)) = (file_path, query) else {
         eprintln!(
-            "사용법: rhwp search <파일.hwp|파일.hwpx> <검색어> [--json] [--ignore-case] [--max-matches <N>]"
+            "사용법: rhwp search <파일.hwp|파일.hwpx> <검색어> [--json] [--ignore-case] \
+             [--max-matches <N>] [--context <N>]"
         );
         return EXIT_USAGE;
     };
@@ -9905,7 +9936,7 @@ fn search_document(args: &[String]) -> i32 {
     // [#3353] 총량을 보고하려면 전수 스캔이 불가피하다 — `--limit` 의 목적은 스캔 시간이
     // 아니라 출력 컨텍스트 절약이므로, 전수 grep 후 표시만 절단한다. 절단 사실을 숨기면
     // 에이전트가 "정확히 N건"과 "N건만 표시(실제 그 이상)"를 구별할 수 없다.
-    let all_matches = doc.grep(query, !ignore_case, None);
+    let all_matches = doc.grep_with_context(query, !ignore_case, None, context);
     let total_match_count = all_matches.len();
     let matches: Vec<_> = match limit {
         Some(n) => all_matches.into_iter().take(n).collect(),

--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -1493,7 +1493,16 @@ fn run_cli_tool(def: &serde_json::Value, args: &serde_json::Value) -> serde_json
                 ));
             };
             match substitute_args(template, args) {
-                Ok(extra) => cli_args.extend(extra),
+                // [#3835] `cli.args` 에 POSIX `--` 옵션 종결자가 있으면(예: hwp_search 의
+                // `{query}` 앞) 선택 인자를 그 **앞**에 끼워 넣는다. 뒤에 붙이면 이미
+                // 닫힌 옵션 파싱 구간(위치 인자만 허용)에 플래그가 섞여 "인자가 너무
+                // 많습니다" 가 된다. `--` 가 없는 배선은 종전처럼 끝에 붙인다.
+                Ok(extra) => match cli_args.iter().position(|a| a == "--") {
+                    Some(dash_pos) => {
+                        cli_args.splice(dash_pos..dash_pos, extra);
+                    }
+                    None => cli_args.extend(extra),
+                },
                 Err(e) => return tool_error(e),
             }
         }


### PR DESCRIPTION
`rhwp search` 는 매치와 `excerpt` 만 준다. 에이전트가 "이 매치가 내가 찾던 그건가"를
판단하려면 앞뒤 문맥이 필요한데, 지금은 별도 명령으로 다시 왕복해야 한다.

```
rhwp search <파일> --json --context N <검색어>
```

`matches[].contextBefore` / `contextAfter` 에 앞뒤 N개 문단을 담는다.
문서 경계에서는 있는 만큼만 준다 — 범위 밖으로 나가지 않는다.

## 기본값은 한 바이트도 안 바뀐다

`--context` 없으면 봉투가 기존과 완전히 동일하다. 기존 소비자 무회귀.

## `--` 구분자 계약 유지

`search` 에는 검색어가 `-` 로 시작할 때 `--` 뒤에 둔다는 계약(#3748)이 있다.
`--context` 를 추가해도 그 계약이 그대로 동작하는지 테스트로 확인했다.

## 검증

`search_json_contract` · `cli_json_contract` · `mcp_server_contract` 전부 0 failed ·
`clippy --release -D warnings` 0 · rustfmt clean · 선검사 통과.
