### PR TITLE
fix(serializer): HWP5→HWPX 변환에서 사라지는 자동 문단 번호 (#3862)

### DIFF
--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -25,7 +25,7 @@ use crate::model::ColorRef;
 
 use super::canonical_defaults::FONTFACE_LANG_NAMES;
 use super::context::SerializeContext;
-use super::utils::{empty_tag, end_tag, start_tag_attrs, write_xml_decl};
+use super::utils::{empty_tag, end_tag, start_tag_attrs, text, write_xml_decl};
 use super::SerializeError;
 
 /// `header.xml` 바이트 생성. Stage 1 진입점.
@@ -997,23 +997,30 @@ fn write_numbering<W: Write>(
         let num_format = numbering_format_str(h.number_format);
         let text_offset_s = h.text_distance.to_string();
         let char_pr_id_ref_s = h.char_shape_id.to_string();
-        empty_tag(
-            w,
-            "hh:paraHead",
-            &[
-                ("start", &start_s),
-                ("level", &level_s),
-                ("align", "LEFT"),
-                ("useInstWidth", "1"),
-                ("autoIndent", "1"),
-                ("widthAdjust", &wa),
-                ("textOffsetType", "PERCENT"),
-                ("textOffset", &text_offset_s),
-                ("numFormat", num_format),
-                ("charPrIDRef", &char_pr_id_ref_s),
-                ("checkable", "0"),
-            ],
-        )?;
+        let attrs = [
+            ("start", start_s.as_str()),
+            ("level", level_s.as_str()),
+            ("align", "LEFT"),
+            ("useInstWidth", "1"),
+            ("autoIndent", "1"),
+            ("widthAdjust", wa.as_str()),
+            ("textOffsetType", "PERCENT"),
+            ("textOffset", text_offset_s.as_str()),
+            ("numFormat", num_format),
+            ("charPrIDRef", char_pr_id_ref_s.as_str()),
+            ("checkable", "0"),
+        ];
+        // [#3838] 번호 형식 문자열은 `hh:paraHead` 의 **텍스트 내용**이다("^1." 등).
+        // 자기닫힘으로 내보내면 형식이 사라져 문단 번호가 아예 렌더되지 않는다.
+        // 한컴 원본 실측: paraHead 232개 중 172개가 내용을 갖는다.
+        let format_str = n.level_formats.get(idx).map(String::as_str).unwrap_or("");
+        if format_str.is_empty() {
+            empty_tag(w, "hh:paraHead", &attrs)?;
+        } else {
+            start_tag_attrs(w, "hh:paraHead", &attrs)?;
+            text(w, format_str)?;
+            end_tag(w, "hh:paraHead")?;
+        }
     }
     end_tag(w, "hh:numbering")?;
     Ok(())
@@ -2387,6 +2394,36 @@ mod tests {
 
         assert_eq!(xml.matches("<hh:paraHead").count(), 10);
         assert!(xml.starts_with(r#"<hh:numbering id="1" start="0">"#));
+    }
+
+    #[test]
+    fn write_numbering_skeleton_emits_level_format_string_as_text() {
+        // [#3838] 번호 형식 문자열("^1." 등)은 `hh:paraHead` 의 **텍스트 내용**이다.
+        // 폴백이 자기닫힘 태그로 속성만 내보내면 형식이 사라져 문단 번호가 아예
+        // 렌더되지 않는다 — IR diff 는 0 이라 `--verify` 게이트가 못 잡는다.
+        //
+        // 한컴 원본 실측(HWPX 40건): paraHead 232개 중 172개가 내용을 갖는다.
+        let mut n = Numbering::default();
+        n.level_formats[0] = "^1.".to_string();
+        n.level_formats[1] = "(^2)".to_string();
+
+        let mut writer = Writer::new(Vec::new());
+        write_numbering(&mut writer, 0, &n).unwrap();
+        let xml = String::from_utf8(writer.into_inner()).unwrap();
+
+        assert!(
+            xml.contains(">^1.</hh:paraHead>"),
+            "level 1 형식 문자열이 텍스트 내용으로 나가야 한다: {xml}"
+        );
+        assert!(
+            xml.contains(">(^2)</hh:paraHead>"),
+            "level 2 형식 문자열이 텍스트 내용으로 나가야 한다: {xml}"
+        );
+        // 형식이 빈 수준은 종전대로 자기닫힘 — 빈 내용을 만들지 않는다.
+        assert!(
+            xml.contains("checkable=\"0\"/>"),
+            "형식이 없는 수준은 자기닫힘을 유지해야 한다: {xml}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #3862

## 무엇이 문제였나

HWP5 → HWPX 변환에서 **자동 문단 번호가 사라집니다.**

```
원본     '1.일반기준<삭제>'
변환본   '일반기준<삭제>'
```

`--verify` 는 **exit 0** 입니다. 셀 텍스트 IR 도 양쪽 동일합니다 — 사라지는 "1." 은
본문이 아니라 **자동 번호**라 IR 비교 대상이 아니기 때문입니다.

## 근인

`write_numbering` 의 HWPX 원문 splice 경로는 형식 문자열을 그대로 옮기지만,
그 아래 **HWP5 경로 폴백**이 `empty_tag` 로 속성만 내보냅니다.

```rust
empty_tag(w, "hh:paraHead", &[ …속성만… ])?;   // <hh:paraHead …/>  자기닫힘
```

**번호 형식 문자열(`^1.` 등)은 `<hh:paraHead>` 의 텍스트 내용**입니다. 형식이
비면 번호가 아예 안 그려집니다.

정보는 IR 에 **있었습니다** — 직렬화기만 참조하지 않았습니다.

| 단계 | 상태 |
|---|---|
| HWP5 파서 `doc_info.rs:823` | `numbering.level_formats[level]` **읽음** |
| 렌더러 `paragraph_layout.rs:6427` | `level_formats` **사용** |
| **HWPX 직렬화기** | **안 씀** |

## 한컴 관례를 먼저 실측했습니다

```
한컴 원본 HWPX 40건의 <hh:paraHead> 232개
  내용 있음 172   예: ^1. · ^2. · ^3) · ^4) · (^5)
  내용 없음  60
```

한컴은 형식 문자열을 텍스트 내용으로 넣습니다. rhwp 생성본은 **전부 자기닫힘**이었습니다.

## 이 PR

폴백에서도 `level_formats[idx]` 를 텍스트 내용으로 방출합니다.
**형식이 빈 수준은 종전대로 자기닫힘**을 유지합니다(내용 없음 60건 관례 보존, 빈
텍스트 노드를 만들지 않음). HWPX 원문 splice 경로는 손대지 않았습니다.

회귀 테스트 `write_numbering_skeleton_emits_level_format_string_as_text` 를 붙였습니다
— 형식 있는 수준은 내용, 없는 수준은 자기닫힘 양쪽을 함께 단정합니다.

## 측정

| 게이트 | 결과 |
|---|---|
| nextest 전량 | **5,044 / 5,044 통과** |
| `serializer::hwpx::header::tests::write_numbering` | 5 / 5 통과 |
| `rustfmt --check` · clippy `-D warnings` | 통과 |
| 최소 재현본 `59111` (16KB) | 글리프 372 -> **374** (원본 일치), `1.` 복원 |

**렌더 스윕 119건** — 원본과 변환본을 각각 SVG 로 렌더해 글리프 튜플
(x, y, 폰트, 크기, 글자)을 전수 비교했습니다.

| | 수정 전 | 수정 후 |
|---|---|---|
| SAME (전량 일치) | 79 | **80** |
| MOVED (개수 같고 위치 다름) | 24 | 27 |
| **COUNT (글자 개수 다름)** | **7** | **3** |
| PAGES (쪽수 다름) | 9 | 9 |

**개선 4건 · 악화 0건.** `COUNT -> MOVED` 3건은 글자가 더 이상 사라지지 않고
위치만 다르다는 뜻이라 개선 경로입니다.

## 배경

[#3837](https://github.com/edwardkim/rhwp/issues/3837) 의 "IR 정합 코호트에서도
렌더가 달라지는 2.5%" 를 파다 나왔습니다. `--verify` 통과가 무손실을 뜻하지 않는다는
구체적 실례입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
