### PR TITLE
fix(preflight): 선언 flags 검사 오탐 — 스키마 출력 명령이 자기 출력에 걸린다

### DIFF
--- a/tools/agent_preflight.py
+++ b/tools/agent_preflight.py
@@ -535,9 +535,19 @@ def check_declared_flags_real(binary: Path, caps_j, rep: Report) -> None:
             if not str(flag).startswith("--"):
                 continue
             checked += 1
-            # 인자 없이 플래그만 줘서 "알 수 없는 옵션" 이 나오는지만 본다.
+            # 인자 없이 플래그만 줘서 CLI 가 그 플래그를 아는지 본다.
+            #
+            # 판정은 **stderr 만** 본다. stdout 을 섞으면
+            # `export-capabilities-schema --bare` 처럼 **종료 코드 사전을 출력하는 명령**이
+            # 자기 출력 안의 "사용법 오류 (인자 없음, 알 수 없는 옵션/명령)" 에 걸려
+            # 스스로를 미구현으로 신고한다(실측 오탐 2건).
+            #
+            # 종료 코드도 먼저 본다 — 플래그가 정상 동작하면 0 이다. 0 으로 끝났으면
+            # CLI 가 받아들인 것이므로 진단 문자열이 어디에 있든 실패로 보지 않는다.
             r = run([str(binary), name, str(flag)])
-            blob = (r.stdout + r.stderr)
+            if r.returncode == 0:
+                continue
+            blob = r.stderr
             if "알 수 없는 옵션" in blob or "unknown option" in blob.lower():
                 rep.fail(
                     check,


### PR DESCRIPTION
선검사(#3795)가 모든 워크트리에서 같은 걸 반복 보고했다:

```
· export-capabilities-schema --json — 선언됐지만 CLI 가 거부한다
· export-capabilities-schema --bare — 선언됐지만 CLI 가 거부한다
```

**그런데 실제로는 정상 동작한다:**

```
$ rhwp export-capabilities-schema --json   → exit 0, 유효한 JSON
$ rhwp export-capabilities-schema --bare   → exit 0, 유효한 스키마
```

## 원인 — 검사기가 자기 출력에 걸렸다

판정을 `stdout + stderr` 합본에서 `"알 수 없는 옵션"` 문자열로 한다. 그런데
이 명령의 출력은 **종료 코드 사전**을 담고 있다:

```json
"description": "사용법 오류 (인자 없음, 알 수 없는 옵션/명령)"
```

**스키마를 출력하는 명령이 자기 스키마 안의 오류 설명에 걸려 스스로를 미구현으로
신고한다.** 문자열 판정이 구조 판정을 대신할 때 나오는 전형적인 오탐이다.

## 수정

**종료 코드를 먼저 본다** — 0 이면 CLI 가 받아들인 것이므로 진단 문자열이 어디에 있든
실패로 보지 않는다. 그리고 **진단 문자열은 `stderr` 에서만** 찾는다.

## 실측 — 양방향 확인

| | 결과 |
|---|---|
| 수정 후 오탐 | **2건 → 0건**, 플래그 **103개 전부 통과** |
| red 시험 — 없는 플래그(`info --존재하지않는플래그`)를 일부러 선언 | **여전히 잡는다** |

고치면서 검사를 약화시키지 않았다는 것을 두 번째 줄이 보인다.

## 왜 이게 중요한가

**오탐 1건이 반복 보고되면 곧 전체를 무시하게 된다.** 이 도구는 "실패를 전부 모아서
한 번에 보여주는 것"이 존재 이유인데, 그 목록에 늘 거짓이 하나 섞여 있으면 목록 자체가
신뢰를 잃는다. 검사기의 신뢰가 그 자체로 기능이다.
