### PR TITLE
[M24] WASM 에이전트 표면 설계 4편 — 막힌 건 기능이 아니라 크레이트 경계였다

### DIFF
--- a/mydocs/tech/README.md
+++ b/mydocs/tech/README.md
@@ -32,6 +32,7 @@ last_verified: 2026-07-19
 | 에이전트 보안 — 문서가 에이전트를 조종하는 경로 | [에이전트 보안 문서 지도](agent_security/README.md) | [위협 모델](agent_security/threat_model.md), [공격 표면](agent_security/attack_surface.md), [소비 에이전트 가이드](agent_security/consumer_guide.md), 로드맵 #3793·구현 #3787 |
 | 신뢰할 수 없는 문서에 대한 경계 | [에이전트 경계 무결성 계약 — 경로·교정단서·자원한계·핸들](agent_boundary_contract.md) | 회귀 `tests/boundary_integrity_contract.rs`, 처리 결과 [task_sec_boundary](../report/task_sec_boundary/README.md) |
 | 외부 바인딩 공통 기반(M18~M20) | [IR 스키마 버저닝·표면 판단·파이썬 1호 명세](bindings_foundation.md) | 로드맵 #3608 M18~M20, [에이전트 표면 플레이북](../manual/agent_surface_playbook.md) |
+| WASM/브라우저 에이전트 표면(M24) | [WASM 에이전트 표면 문서 지도](wasm_agent_surface/README.md) | [WASM capabilities 자기서술](wasm_agent_surface/self_description.md), [브라우저 MCP-유사 브리지](wasm_agent_surface/browser_bridge.md), [설치 0 온보딩](wasm_agent_surface/zero_install_onboarding.md), 로드맵 #3608 M24·#3869 |
 | 이슈별 기술 조사 | [이슈별 기술 조사 지도](investigations/README.md) | [Issue #511 IR wrap 조사](investigations/issue-511/README.md), [Issue #1151 picture TAC 조사](investigations/issue-1151/README.md), [Issue #1584 이후 HWPX 잔여 IR 차이 조사](investigations/issue-1584/README.md), [Issue #1658 페이지네이션 조사](investigations/issue-1658/README.md), [Issue #1772 잔여 OVER 조사](investigations/issue-1772/README.md), [Issue #2125 font ownership 조사](investigations/issue-2125/README.md) |
 
 ## 현재 구조를 읽는 법

--- a/mydocs/tech/wasm_agent_surface/README.md
+++ b/mydocs/tech/wasm_agent_surface/README.md
@@ -1,0 +1,159 @@
+---
+kind: guide
+status: active
+canonical: mydocs/tech/wasm_agent_surface/README.md
+last_verified: 2026-08-03
+---
+
+# WASM/브라우저 에이전트 표면 문서 지도
+
+`mydocs/tech/wasm_agent_surface/`는 **로드맵 [#3608](https://github.com/edwardkim/rhwp/issues/3608)
+M24 "WASM/브라우저 에이전트 표면"** 의 설계 문서를 모은다. 같은 축을 다루는 이슈
+[#3869](https://github.com/edwardkim/rhwp/issues/3869)("설치 없는 실행")와 정렬해 쓴다.
+
+이 축의 모든 기술 주장에는 **코드 경로(`파일:줄`) 또는 실제 명령 출력**이 붙는다.
+근거를 대지 못하는 항목은 **"확인되지 않음"** 으로 적었다. 특히 **성능·크기는 지어내지
+않는다** — 이 저장소는 `*.wasm` 을 커밋하지 않으므로(`.gitignore:12`) 번들 크기 대부분이
+아직 실측되지 않은 상태다.
+
+## 왜 이 축이 생겼는가
+
+M24 는 세 줄짜리 체크리스트다(#3608 본문 §8 "장기 지평(M18~M30)" 안의 M24 절).
+
+```
+### M24 — WASM/브라우저 에이전트 표면
+- [ ] wasm_api 에 capabilities 자기서술 대응물
+- [ ] 브라우저 내 MCP-유사 브리지 설계(studio 연동)
+- [ ] 오프라인 데모 페이지(설치 0 온보딩)
+```
+
+세 줄이 각각 다른 공백을 가리킨다.
+
+- **자기서술** — CLI 는 `rhwp capabilities` 로, MCP 는 `tools/list` 로 자기를 서술한다.
+  브라우저 안의 소비자에게는 **대응물이 없다.** `src/wasm_api.rs` 에는 `capabilities`
+  라는 문자열도, 봉투 `schemaVersion` 도 등장하지 않는다(실측: §"재현" 참조).
+- **브리지** — 브라우저에는 stdio 가 없다. MCP JSON-RPC 를 무엇에 얹을지가 미정이다.
+  다만 **바닥부터 시작하지 않는다** — studio 는 이미 `MessageChannel` 기반 RPC 를 돌린다
+  (`rhwp-studio/src/embed/runtime.ts`, 162줄).
+- **온보딩** — #3869 가 말하는 "모든 진입로가 공유하는 첫 관문"(바이너리 확보)을 없애는
+  경로다. rhwp 는 이미 GitHub Pages 로 배포된다(`.github/workflows/deploy-pages.yml`).
+
+## 문서 지도
+
+| 문서 | kind | 다루는 것 | 언제 읽나 |
+| --- | --- | --- | --- |
+| [WASM capabilities 자기서술 설계](self_description.md) | canonical | 브라우저 소비자가 "이 모듈이 뭘 할 수 있나"를 아는 방법, CLI 와의 동등성 유지 | M24 첫 줄을 구현할 때. **이 축의 전제** |
+| [브라우저 내 MCP-유사 브리지](browser_bridge.md) | canonical | JSON-RPC 를 postMessage·MessageChannel·Worker 중 무엇에 얹을지, 그리고 origin 경계 | M24 둘째 줄. studio 연동을 설계할 때 |
+| [설치 0 온보딩 데모](zero_install_onboarding.md) | guide | 아무것도 설치하지 않고 rhwp 를 써보는 경로, 크기 예산, 오프라인 동작 | M24 셋째 줄. #3869 의 진입점 |
+
+셋은 **순서대로 의존한다.** 자기서술이 없으면 브리지가 무엇을 노출할지 정할 수 없고,
+브리지가 없으면 데모 페이지는 "보기 좋은 뷰어"에서 멈춘다.
+
+## 0. 지금 확정된 실측 (2026-08-03)
+
+이 축을 논할 때 반복해서 인용되는 숫자다. 재현 명령은 §"재현"에 있다.
+
+| 항목 | 값 | 근거 |
+| --- | --- | --- |
+| `src/wasm_api.rs` 줄 수 | 7,621 | `wc -l src/wasm_api.rs` |
+| `wasm_bindgen` 출현 | 372곳 | `grep -c wasm_bindgen src/wasm_api.rs` |
+| 고유 `js_name` export | 360개 | `grep -oE "js_name\s*=\s*[A-Za-z0-9_]+" \| sort -u \| wc -l` |
+| 고유 `pub fn` | 367개 | 같은 방식 |
+| CLI 명령 수 / `--json` 계약 | 61 / 31 | `rhwp capabilities \| jq` |
+| MCP 도구 수 | 39 | `rhwp capabilities --mcp \| jq '.tools \| length'` |
+| `wasm_api.rs` 안의 `capabilities`·`schemaVersion` | **0곳** | `grep -c` (§자기서술 1.2) |
+| `rhwp.js` 글루 크기 | 284,769 B | `ls -la rhwp-studio/public/rhwp.js` |
+| `rhwp_bg.wasm` 크기 | **미실측** | `.gitignore:12` 가 `*.wasm` 제외 — 이 작업 트리에 산출물 없음 |
+| 번들 폰트 총량 | 22 MB | `du -sh assets/fonts` |
+
+**`rhwp_bg.wasm` 크기가 미실측이라는 점을 가볍게 넘기지 마라.** `rhwp-studio/vite.config.ts:132`
+주석이 `WASM (~12 MB)` 라고 적지만 이건 **소스 주석이지 측정치가 아니다.** 온보딩 설계의
+모든 크기 논의는 이 숫자에 걸려 있고, 이 숫자는 아직 없다
+([zero_install_onboarding.md §2](zero_install_onboarding.md)).
+
+## 1. 이 축이 하지 않는 것
+
+#3869 §4 를 그대로 승계한다. 문서가 약속을 넓히면 구현이 따라가지 못한다.
+
+- **기존 CLI·MCP·바인딩을 대체하지 않는다.** WASM 표면은 **네 번째 진입로**이지 교체가 아니다.
+- **새 판정·편집 로직을 만들지 않는다.** `src/document_core/` 의 코어를 노출할 뿐이다.
+  다행히 그 코어는 이미 lib 안에 있다(§자기서술 2.3).
+- **렌더링 API 를 에이전트 표면에 섞지 않는다.** `renderPageToCanvas` 계열 12종은
+  브라우저 UI 의 것이다. 에이전트 동사와 같은 이름공간에 두지 않는다.
+- **성능이 네이티브와 같다고 주장하지 않는다.** 이 축의 문서 어디에도 WASM 성능
+  수치는 없다 — **측정하지 않았기 때문이다.**
+
+## 2. 세 문서가 공유하는 결론 하나
+
+조사에서 나온 가장 중요한 사실은 세 문서에 모두 걸린다.
+
+> **에이전트 동사의 *로직* 은 이미 lib 안에 있고 wasm32 로 컴파일된다.
+> 없는 것은 *봉투* 와 *노출* 이다.**
+
+- `extract_data` 는 `src/document_core/queries/extract_data.rs:850` 에 있다(1,251줄).
+- 인젝션 판정은 `injection_scan.rs:1034` 에 있다(1,467줄).
+- 표 격자 추출은 `table_extract.rs:292` 에 있다(304줄).
+- 그런데 **봉투를 조립하는 코드는 전부 `src/main.rs`(17,058줄) 안**, 즉 **bin 크레이트**다.
+  `capabilities_command_entries()` 는 `src/main.rs:1463` 에 있고, lib(`src/lib.rs`, 54줄)은
+  그것을 볼 수 없다.
+
+따라서 M24 는 "WASM 에 기능을 추가하는 일"이 아니라 **"봉투 층을 bin 에서 lib 으로
+끌어내리는 일"** 에 가깝다. 이 판단의 근거와 반례는
+[self_description.md §2](self_description.md) 에 있다.
+
+## 3. 재현
+
+이 지도의 숫자를 다시 만드는 명령이다. 저장소 루트에서 실행한다.
+
+```bash
+wc -l src/wasm_api.rs src/main.rs src/lib.rs
+grep -c wasm_bindgen src/wasm_api.rs
+grep -oE "js_name\s*=\s*[A-Za-z0-9_]+" src/wasm_api.rs | sed 's/.*= *//' | sort -u | wc -l
+
+# 자기서술 부재 확인 — 0 이 나와야 한다
+grep -cE "text_security|inspect|extract_data|digest|export_tables|schemaVersion" src/wasm_api.rs
+
+# CLI 자기서술
+rhwp capabilities | jq '{commands: (.commands|length), json: ([.commands[]|select(.json)]|length)}'
+rhwp capabilities --mcp | jq '.tools | length'
+
+# 크기
+ls -la rhwp-studio/public/rhwp.js
+du -sh assets/fonts
+```
+
+`rhwp` 는 릴리스 바이너리를 가리킨다. 이 PC 에서는
+`target/release/rhwp.exe` 로 실행해 위 수치를 얻었다.
+
+## 4. 확인되지 않음 (이 축 전체)
+
+정직하게 열어 둔다. 채워지기 전에는 설계 결정의 근거로 쓰지 않는다.
+
+1. **`rhwp_bg.wasm` 실제 크기** — release·wasm-opt 적용 후 값. 이 PC 는 rhwp 를
+   빌드하지 못한다(별도 기록). CI 산출물에서 재야 한다.
+2. **WASM vs 네이티브 성능** — #3869 수용 기준이 요구하지만 아직 아무 측정이 없다.
+3. **`document_core/queries/` 전 모듈의 wasm32 컴파일 가능성** — `grep.rs`·
+   `search_query.rs`·`form_query.rs` 가 `std::fs`/`std::io` 를 참조한다. 실제로 wasm32
+   빌드가 깨지는지는 빌드해 보지 않았다.
+4. **wasm-pack 의 wasm-opt 기본 동작** — 워크플로우에 `wasm-opt` 단계가 없고
+   `Cargo.toml` 에 `[package.metadata.wasm-pack]` 도 없다. 기본값이 무엇인지 미확인.
+
+## 5. 관련 문서
+
+- **보안** — [에이전트 보안 문서 지도](../agent_security/README.md),
+  [위협 모델](../agent_security/threat_model.md),
+  [공격 표면](../agent_security/attack_surface.md),
+  [소비 에이전트 가이드](../agent_security/consumer_guide.md).
+  브라우저는 **새 경계**를 추가한다(origin). 위협 모델의 `#3787` 축과 어긋나지 않게 쓴다 —
+  [browser_bridge.md §5](browser_bridge.md).
+- **외부 바인딩** — [IR 스키마 버저닝·표면 판단](../bindings_foundation.md)(M18~M20).
+  WASM 표면은 그 판단표에 **네 번째 열**로 들어간다.
+- **툴체인** — [wasm-pack 버전 고정 정책](../wasm_pack_version_policy.md).
+- **경계 계약** — [에이전트 경계 무결성 계약](../agent_boundary_contract.md).
+
+## 6. 이슈
+
+- [#3608](https://github.com/edwardkim/rhwp/issues/3608) — 마일스톤 현황판. **M24 의 권위**
+- [#3869](https://github.com/edwardkim/rhwp/issues/3869) — 설치 없는 실행. W1~W6 조각 정의
+- [#3787](https://github.com/edwardkim/rhwp/issues/3787) — 에이전트 보안 구현
+- [#3719](https://github.com/edwardkim/rhwp/issues/3719) — 상위 6층 아키텍처 지도

--- a/mydocs/tech/wasm_agent_surface/browser_bridge.md
+++ b/mydocs/tech/wasm_agent_surface/browser_bridge.md
@@ -1,0 +1,509 @@
+---
+kind: canonical
+status: draft
+canonical: mydocs/tech/wasm_agent_surface/browser_bridge.md
+last_verified: 2026-08-03
+---
+
+# 브라우저 내 MCP-유사 브리지 설계
+
+> MCP 는 stdio JSON-RPC 다. **브라우저에는 stdio 가 없다.**
+> 이 문서는 그 자리에 무엇을 놓을지 — `window.postMessage` 인가, `MessageChannel` 인가,
+> Web Worker 인가 — 를 각각의 대가와 함께 확정하고, **문서 내용이 다른 origin 으로
+> 새지 않게 하는 경계**를 명시한다.
+> 로드맵 [#3608](https://github.com/edwardkim/rhwp/issues/3608) M24 둘째 줄에 대응한다.
+
+이 문서의 모든 기술 주장에는 코드 경로(`파일:줄`)가 붙는다. 근거를 대지 못하는 항목은
+**"확인되지 않음"** 으로 적었다. **성능은 측정하지 않았으므로 어떤 성능 주장도 하지 않는다.**
+축 전체의 지도는 [README.md](README.md), 노출할 동사의 목록은
+[self_description.md](self_description.md) 가 정한다.
+
+---
+
+## 0. 결론 먼저
+
+1. **바닥부터 짓지 않는다.** studio 는 이미 `MessageChannel` 기반 요청/응답 RPC 를
+   돌린다 — `rhwp-studio/src/embed/`(protocol 103줄 + rpc-router 102줄 + runtime 162줄)와
+   클라이언트 `npm/editor`(`@rhwp/editor` 0.8.2, index 253줄 + transport 239줄).
+   버전 협상·capability 협상·origin 고정·transferable 이 **이미 구현돼 있다.**
+2. **그 프로토콜은 MCP 가 아니다.** `rhwp-request`/`rhwp-response` 라는 자체 봉투이고,
+   메서드는 **11개**뿐이며 전부 뷰어/내보내기 축이다(`rpc-router.ts:70-101`).
+   에이전트 동사(`digest`·`fields`·`inspect`)는 하나도 없다.
+3. **채택: `MessageChannel` 위에 MCP JSON-RPC 를 얹는다.** 기존 embed 핸드셰이크로
+   포트를 얻고, 그 포트 위 메시지를 JSON-RPC 로 바꾼다. `window.postMessage` 는
+   핸드셰이크에만 쓰고 본 통신에는 쓰지 않는다 — 이유는 §3.
+4. **Web Worker 는 옳은 방향이지만 지금은 아니다.** studio 전체가 메인 스레드에서
+   WASM 을 돌린다(`rhwp-studio/src/core/wasm-bridge.ts:259`, `await init()`).
+   `grep -rn "new Worker" rhwp-studio/src` 결과는 **0건**이다. Worker 로 옮기는 것은
+   브리지 설계가 아니라 **스튜디오 아키텍처 변경**이다.
+5. **보안 경계는 origin 하나다.** 기존 런타임이 이미 첫 연결의 origin 에 고정한다
+   (`runtime.ts:130-133`). MCP-유사 브리지는 그 고정을 **약화시키지 않는 방식으로만**
+   확장한다.
+
+---
+
+## 1. 이미 있는 것 — 전수 조사
+
+### 1.1 계층
+
+```
+호스트 페이지 (임의 origin)
+    │  npm/editor: RhwpEditor  (index.js 253줄)
+    │      └ transport.js 239줄 — 세션 ID·타임아웃·transferable
+    │
+    │  ① window.postMessage({type:'rhwp-connect', ...}, [port2])
+    ▼
+<iframe> rhwp-studio (studio origin)
+    │  installEmbedRuntime  (embed/runtime.ts:113)
+    │      ├ 발신자 검사 (runtime.ts:117-127)
+    │      ├ origin 고정   (runtime.ts:130-133)
+    │      └ bindPort      (runtime.ts:42-73)
+    │  ② 이후 전 통신은 MessagePort 위에서만
+    ▼
+routeEmbedRequest (embed/rpc-router.ts:63)
+    ▼
+studio 핸들러 (main.ts:1412 이후)
+    ▼
+wasm-bridge.ts → HwpDocument (src/wasm_api.rs:337)
+```
+
+배선 지점은 `rhwp-studio/src/main.ts:1412` 한 곳이다.
+
+### 1.2 핸드셰이크 — 이미 협상이 있다
+
+`rhwp-studio/src/embed/protocol.ts:1-7`:
+
+```ts
+export const EMBED_PROTOCOL_VERSION = 1 as const;
+export const EMBED_CAPABILITIES = [
+  'transferable-array-buffer',
+  'hml-export',
+  'renderer-diagnostics-v1',
+  'notify-saved-v1',
+] as const;
+```
+
+**이게 자기서술의 원시 형태다.** 브리지가 새로 발명할 필요가 없는 자리 —
+[self_description.md](self_description.md) 의 `capabilities()` 결과를
+`rhwp-connected` 응답에 실으면 된다.
+
+협상 흐름(실측):
+
+| 단계 | 코드 | 동작 |
+| --- | --- | --- |
+| 연결 시도 검증 | `protocol.ts:67-73` `isConnectAttempt` | `type`·`version`(safe integer)·`sessionId`(비어있지 않은 문자열) |
+| 필수 capability | `protocol.ts:60-65` `isConnectMessage` | `transferable-array-buffer` 를 **반드시** 포함 |
+| 버전 불일치 거부 | `runtime.ts:75-92` `rejectConnect` | `UNSUPPORTED_VERSION` 또는 `UNSUPPORTED_CAPABILITY` + `supportedVersions` |
+| 성공 통지 | `runtime.ts:69-72` | `rhwp-connected` + 서버 capability 배열 |
+| 요청 검증 | `protocol.ts:75-83` `isRequestEnvelope` | `version` 일치 + `method` 가 비어있지 않은 문자열 |
+
+거부 응답이 `supportedVersions` 를 함께 준다는 점이 중요하다 — 클라이언트가 재시도를
+판단할 수 있다. **MCP `initialize` 의 버전 협상과 같은 구조**다.
+
+### 1.3 메서드는 11개, 전부 뷰어 축
+
+`rhwp-studio/src/embed/rpc-router.ts:70-101` 의 `switch` 전수:
+
+| 메서드 | 반환 | 축 |
+| --- | --- | --- |
+| `ready` | `boolean` | 수명주기 |
+| `loadFile(data, fileName, skipUnsavedGuard, suppressDialogs)` | `{pageCount}` | 입력 |
+| `pageCount` | `number` | 조회 |
+| `getRendererDiagnostics(page)` | `EmbedRendererDiagnosticsV1` | 진단 |
+| `getPageSvg(page)` | `string` | 렌더 |
+| `exportHwp` / `exportHwpx` / `exportHml` | `Uint8Array` | 산출 |
+| `getHmlSaveState` | `HmlSaveState` | 조회 |
+| `exportHwpVerify` | `unknown` | 검증 |
+| `notifySaved(fileName?)` | `{ok, wasDirty}` | 수명주기 |
+
+**에이전트 동사는 0개다.** `digest`·`search`·`fields`·`extract-data`·`inspect` 어느
+것도 없다. 그런데 그중 다수는 **WASM 에는 이미 있다**(`searchAllText`
+`wasm_api.rs:4869`, `getFieldList` `4542` 등 — [self_description.md §1.3](self_description.md)).
+
+> **브리지의 첫 작업은 전송을 발명하는 게 아니라, 이미 있는 동사를 라우터에 잇는 것이다.**
+
+`getRendererDiagnostics` 는 `schemaVersion: 1` 을 봉투에 싣는다
+(`rpc-router.ts:35-43`). embed 층에도 봉투 버저닝 선례가 이미 있다는 뜻이다.
+
+### 1.4 클라이언트 — `@rhwp/editor`
+
+`npm/editor/transport.js` 실측:
+
+- 프로토콜 상수를 **복제**한다(`transport.js:1-10`) — TS 원본과 JS 사본이 별개다.
+  드리프트 위험이 이미 존재하고, CI 가 이를 감시한다
+  (`scripts/frontend-editor-embed.test.mjs`, `.github/workflows/ci.yml:951`).
+- 세션 ID 는 `crypto.randomUUID()`, 없으면 `getRandomValues` 16바이트
+  (`transport.js:17-25`). **약한 난수로 물러서지 않는다** — 둘 다 없으면 throw.
+- 타임아웃이 메서드별로 다르다(`transport.js:8-16`):
+  `loadFile`·`exportHwp`·`exportHwpVerify`·`exportHwpx`·`exportHml` 은 60초, 나머지 10초.
+- 이진 데이터는 **복사 후 transfer** 한다(`transport.js:27-38` `copiedBinary`/`prepareParams`).
+  호출자의 버퍼를 detach 시키지 않기 위한 의도적 복사다.
+- 응답 봉투 검증이 엄격하다(`transport.js:40-50`) — `result` 와 `error` 가
+  **동시에 있거나 동시에 없으면 거부**한다.
+
+이 규율(타임아웃 등급·복사 후 전송·배타적 result/error)은 **MCP 브리지에도 그대로
+필요**하다. 새로 정할 것이 아니라 승계할 것이다.
+
+### 1.5 확장 메시징은 별개 계보다
+
+`rhwp-shared/security/sender-validator.js` 는 **`chrome.runtime` 메시징**용이지
+`window.postMessage` 용이 아니다. 그럼에도 설계 원칙 하나를 준다.
+
+```js
+default:
+  return { allowed: false, reason: `알 수 없는 메시지 유형: ${messageType}` };
+```
+
+**기본 거부(default-deny)** 다. 메시지 유형마다 발신자 부류를 명시하고
+(`fetch-file` 은 내부 페이지만, `open-hwp` 는 content script 만), 모르는 유형은 막는다.
+MCP 브리지의 메서드 라우팅도 같아야 한다 — `rpc-router.ts:100` 이 이미
+`throw new Error("Unknown method")` 로 그렇게 한다.
+
+### 1.6 hwpctl — 브라우저 안의 또 하나의 동사 표면
+
+`rhwp-studio/src/hwpctl/`(444 + 116 + 77 + 73 + 51줄)은 한컴 `HwpCtrl` ActiveX 호환
+객체를 WASM 위에 얹은 것이다(`hwpctl/index.ts:1-6` 주석).
+
+여기에도 **자기서술의 원시 형태**가 있다 — `action-registry.ts:22-31` 의
+`getRegisteredCount()` / `getImplementedCount()`. 다만 정직하게 적자면:
+
+- 파일 주석은 "312개 Action의 등록 테이블"이라고 말한다(`action-registry.ts:4`).
+- 실제 `STUB_ACTIONS` 배열 항목은 **30개**다(`action-registry.ts:43-73`, Wave 1~6 각 5개).
+- 그리고 그 30개는 전부 `executor: null` 로 등록된다(`action-registry.ts:75-77`).
+
+**주석의 312 는 목표치이지 실측이 아니다.** 브리지 자기서술이 이 함수를 인용하려면
+"등록 30 / 구현 (executor 등록분)" 을 그대로 노출해야 하며, 312 를 광고하면 안 된다.
+
+---
+
+## 2. 브라우저에 stdio 가 없다는 뜻
+
+MCP 는 stdio JSON-RPC 2.0 이다(rhwp 구현: `src/mcp_serve.rs`, 1,596줄 — **bin 전용**,
+`src/main.rs:9`). 브라우저로 옮길 때 사라지는 것과 남는 것을 가른다.
+
+| MCP 가 stdio 에서 얻는 것 | 브라우저에서 |
+| --- | --- |
+| 프로세스 경계 = 신뢰 경계 | **origin 경계**로 대체된다. 훨씬 미묘하다 |
+| 순서 보장된 단일 바이트 스트림 | `MessagePort` 는 순서를 보장한다. `window.postMessage` 는 **여러 발신자가 섞인다** |
+| 상대방이 하나 | 어떤 창·프레임·확장도 `postMessage` 할 수 있다 |
+| 요청 ID 로 다중화 | 동일 |
+| 이진 데이터는 base64 | **transferable 로 복사 없이 넘길 수 있다** (기존 embed 가 이미 씀, `runtime.ts:23-30`) |
+| 서버 종료 = 프로세스 종료 | 포트 close (`runtime.ts:32-36` `releasePort`) |
+| 수명 = 프로세스 수명 | 탭·프레임 수명. 새로고침으로 문서 상태가 날아간다 |
+
+`stdinTools` 라는 개념도 갈 곳이 없다. CLI 자기서술은
+`"stdinTools": ["hwp_batch", "hwp_batch_search"]` 를 싣지만(실측), 브라우저에는 stdin 이
+없으므로 이 필드는 **의미가 다르게** 되거나 부재로 명시돼야 한다
+([self_description.md §4.3](self_description.md)).
+
+---
+
+## 3. 전송 후보 3종
+
+### 후보 A — `window.postMessage`
+
+호스트 창과 iframe 이 직접 주고받는다. 기존 코드에 **레거시 경로로 남아 있다**
+(`runtime.ts:94-111` `handleLegacy`, `hwpctl-load` 타입 포함).
+
+- 장점: 구현이 가장 단순. 포트 수명 관리가 없다. 확장 content script 에서도 쓸 수 있다.
+- 단점:
+  - **모든 발신자가 같은 채널에 온다.** 매 메시지마다 `event.source`·`event.origin` 을
+    확인해야 한다. 기존 코드가 실제로 그렇게 한다(`runtime.ts:117-127`).
+  - 응답을 `targetOrigin` 으로 되쏘아야 한다(`runtime.ts:110`). 실수하면
+    `"*"` 로 새는 전형적 취약점이 된다.
+  - 세션 개념이 없어 여러 소비자가 동시에 붙으면 구분이 어렵다.
+
+기존 코드가 레거시 경로를 **가장 낮은 우선순위**로 두는 점을 보라 —
+포트 바인딩이 성립한 뒤에는 레거시를 아예 무시한다(`runtime.ts:152` `if (binding) return;`).
+이건 이미 내려진 판정이다.
+
+### 후보 B — `MessageChannel` (채택)
+
+핸드셰이크 한 번으로 전용 포트 쌍을 만들고, 이후 통신은 그 포트에서만 한다.
+
+- 장점:
+  - **채널이 사설이다.** 포트를 가진 쪽만 말할 수 있다. 매 메시지 origin 검사가
+    구조적으로 불필요해진다(그래도 첫 연결에서 origin 을 고정한다 — `runtime.ts:130-133`).
+  - 세션 ID 로 다중화가 이미 된다(`protocol.ts:23-30`).
+  - transferable 이 자연스럽다(`runtime.ts:23-30`).
+  - **이미 구현·테스트돼 있다** (`rhwp-studio/e2e/embed-transport.test.mjs`,
+    `package.json` 의 `e2e:embed`).
+- 단점:
+  - 포트 수명 관리가 필요하다(`releasePort`/`releasePorts`, `runtime.ts:32-40`).
+  - 여전히 **같은 스레드**다. 무거운 호출이 UI 를 멈춘다(§3.4).
+  - 확장 background(service worker)에서 쓰려면 별도 경로가 필요하다 — 확인되지 않음.
+
+### 후보 C — Web Worker
+
+WASM 을 워커에서 돌리고 브리지가 워커와 대화한다.
+
+- 장점: 긴 파싱·검색이 UI 를 멈추지 않는다. 에이전트 호출은 본질적으로 배치성이라
+  **개념적으로 가장 옳다.**
+- 단점 (실측 근거):
+  - **studio 는 워커를 쓰지 않는다.** `grep -rn "new Worker" rhwp-studio/src` = 0건.
+    WASM 초기화는 메인 스레드다(`wasm-bridge.ts:259` `await init()`).
+  - 문서 상태(`HwpDocument`)가 워커 안에 있으면 **렌더 경로가 전부 깨진다.**
+    `renderPageToCanvas` 계열은 캔버스 컨텍스트를 만진다. OffscreenCanvas 로 옮기는 것은
+    별개의 대형 작업이다.
+  - 즉 워커 채택은 브리지 결정이 아니라 **스튜디오 아키텍처 변경**이다.
+
+### 판정
+
+| 기준 | A postMessage | B MessageChannel | C Worker |
+| --- | --- | --- | --- |
+| 사설 채널 | ✗ | ○ | ○ |
+| 기존 구현 재사용 | 부분(레거시) | **전부** | 없음 |
+| UI 블로킹 회피 | ✗ | ✗ | ○ |
+| 확장에서 사용 | ○ | 확인되지 않음 | 확인되지 않음 |
+| 렌더 경로 영향 | 없음 | 없음 | **큼** |
+| 추가 작업량 | 소 | **소** | 대 |
+
+**B 를 채택한다.** A 는 핸드셰이크 전용으로 유지한다(포트를 넘기려면 어차피
+`window.postMessage` 가 필요하다 — `runtime.ts:128`). C 는 **문 열어 두기**:
+JSON-RPC 봉투는 전송에 무관하므로, 나중에 워커로 옮겨도 **메서드 계약은 그대로**다.
+이게 JSON-RPC 를 쓰는 실질적 이유다.
+
+---
+
+## 4. 설계 — MCP-유사 브리지
+
+### 4.1 계층
+
+```
+ 에이전트 호스트 (JS)
+      │  MCP 클라이언트 (JSON-RPC 2.0)
+      ▼
+ ┌──────────────────────────────────────────┐
+ │ rhwp-mcp-bridge  (신규, 얇음)             │
+ │  · initialize / tools/list / tools/call   │
+ │  · JSON-RPC ↔ embed 봉투 변환             │
+ └──────────────────────────────────────────┘
+      │  기존 MessagePort (재사용)
+      ▼
+ ┌──────────────────────────────────────────┐
+ │ embed runtime (runtime.ts:113) — 무변경    │
+ │ rpc-router  (rpc-router.ts:63) — 확장      │
+ └──────────────────────────────────────────┘
+      ▼
+ wasm_api  (에이전트 동사 — self_description.md)
+```
+
+**embed 런타임은 건드리지 않는다.** 검증·origin 고정·포트 수명은 이미 맞다.
+확장은 `rpc-router.ts` 의 `switch` 에 메서드를 더하는 일이다.
+
+### 4.2 JSON-RPC 를 어디에 얹는가 — 두 방식
+
+**방식 1: embed 메서드 하나로 터널링**
+
+```
+{type:'rhwp-request', version:1, sessionId, id, method:'mcp', params:{ …JSON-RPC… }}
+```
+
+- 장점: embed 프로토콜 **버전을 올리지 않아도 된다.** 기존 클라이언트가 안 깨진다.
+- 단점: 봉투가 이중이 된다. 오류가 두 층에서 나온다(embed `RPC_ERROR` vs JSON-RPC
+  `error.code`). 디버깅이 나빠진다.
+
+**방식 2: 포트 위 메시지를 JSON-RPC 로 직접 (권장)**
+
+핸드셰이크에서 클라이언트가 `capabilities: ['mcp-jsonrpc-v1']` 을 선언하면,
+그 포트는 **JSON-RPC 모드**로 바인딩된다. `bindPort`(`runtime.ts:42`)가 분기한다.
+
+- 장점: 봉투가 하나. 표준 MCP 클라이언트를 거의 그대로 쓸 수 있다.
+- 단점: `bindPort` 에 분기가 생긴다. 두 모드를 다 테스트해야 한다.
+
+**방식 2 를 권장한다.** 근거: capability 협상 기제가 **이미 있고**
+(`protocol.ts:60-65`), 미지원 시 `UNSUPPORTED_CAPABILITY` 로 명확히 거부하는 경로도
+있다(`runtime.ts:82-88`). 새 모드를 안전하게 도입할 자리가 준비돼 있다.
+
+### 4.3 메서드 매핑
+
+| MCP | 브리지에서 | 출처 |
+| --- | --- | --- |
+| `initialize` | `rhwp-connect` 핸드셰이크에 흡수. 응답에 `protocolVersion`·서버 정보 | `runtime.ts:69-72` 확장 |
+| `tools/list` | `capabilitiesMcp()` 결과를 그대로 | [self_description.md §4.1](self_description.md) |
+| `tools/call` | `rpc-router` 의 메서드 디스패치 | `rpc-router.ts:70` 확장 |
+| `resources/*` | **하지 않는다** (초기) | §5.5 |
+| `notifications/*` | **하지 않는다** (초기) | 확인되지 않음 |
+
+`tools/list` 가 CLI `capabilities --mcp` 와 같은 모양이어야 한다는 요구는
+[self_description.md §5](self_description.md) 의 동등성 가드가 담당한다.
+**브리지는 자기서술을 생산하지 않는다 — 운반만 한다.** 이 분리를 지키지 않으면
+목록이 세 벌(CLI·WASM·브리지)이 된다.
+
+CLI 도구 39개 중 브라우저에서 의미가 성립하는 것만 나간다. `path` 를 받는 도구는
+전부 `data: Uint8Array` 로 바뀌므로 **`inputSchema` 가 달라진다** — 이 차이는
+자기서술 층에서 이미 처리된다([self_description.md §4.3](self_description.md)).
+
+### 4.4 재사용 지점과 새로 필요한 것
+
+| 항목 | 상태 | 근거 |
+| --- | --- | --- |
+| 버전 협상 | **재사용** | `protocol.ts:60-83` |
+| capability 협상 | **재사용** | `protocol.ts:2-7`, `runtime.ts:75-92` |
+| origin 고정 | **재사용** | `runtime.ts:130-133` |
+| 세션 ID | **재사용** | `transport.js:18-25` |
+| 요청 ID 다중화 | **재사용** | `protocol.ts:23-30` |
+| transferable 이진 | **재사용** | `runtime.ts:23-30`, `transport.js:27-38` |
+| 메서드별 타임아웃 | **재사용** | `transport.js:8-16` |
+| JSON-RPC 2.0 봉투 | 신규 | — |
+| `tools/list` 운반 | 신규 (얇음) | 자기서술이 생산 |
+| 도구 이름 ↔ 라우터 매핑 | 신규 | `rpc-router.ts` 확장 |
+| 에이전트 동사 라우팅 | 신규 | wasm_api 에 이미 있는 것부터 |
+
+**새로 짜야 하는 코드는 놀랄 만큼 적다.** 어려운 부분(협상·경계·수명)은 이미 있다.
+
+### 4.5 이진 데이터
+
+MCP 는 JSON 이므로 이진을 base64 로 싣는다. 브라우저에서는 그럴 이유가 없다.
+
+- 요청: `loadFile` 이 이미 `Uint8Array`/`ArrayBuffer` 를 받는다(`rpc-router.ts:56-61`).
+  `allowLegacyArray` 는 레거시 경로 전용이다.
+- 응답: `postPortResponse`(`runtime.ts:23-30`)가 `Uint8Array` 결과를 **복사한 뒤
+  transfer** 한다.
+
+**따라서 `tools/call` 의 결과가 이진이면 base64 로 바꾸지 않는다.** 대신 MCP
+`content` 배열에서 그 자리를 참조로 두고 실제 바이트는 transfer 로 보낸다.
+표준 MCP 클라이언트와의 호환성이 여기서 갈리며, **어떻게 표현할지는 확인되지 않음** —
+설계 시 결정해야 할 열린 항목이다.
+
+---
+
+## 5. 보안 경계
+
+브라우저는 **새 경계 하나**를 추가한다: origin. 위협 모델의 전제는
+[../agent_security/threat_model.md](../agent_security/threat_model.md) 를 그대로 따르고,
+여기서는 **브라우저에서만 생기는 것**만 적는다. 구현 축은
+[#3787](https://github.com/edwardkim/rhwp/issues/3787).
+
+### 5.1 지금 지켜지는 것 (실측)
+
+| 방어 | 코드 | 무엇을 막나 |
+| --- | --- | --- |
+| 발신자 창 고정 | `runtime.ts:117-127` — `event.source !== options.parentWindow` 면 즉시 반환 | 임의 창의 명령 주입 |
+| origin 스킴 제한 | `protocol.ts:95-103` `isUsableParentOrigin` — `http:`/`https:` 만, `"null"` 거부 | sandbox·`file:` origin 의 불투명 발신자 |
+| **첫 origin 에 고정** | `runtime.ts:130-133` — `binding` 이 있으면 다른 origin 은 무시 | 세션 중간의 origin 전환 |
+| 단일 바인딩 | `runtime.ts:143-146` — 이미 바인딩되면 새 포트를 close | 동시 다중 소비자 |
+| 미사용 포트 폐기 | `runtime.ts:125`·`129` `releasePorts` | 떠도는 포트 누수 |
+| 바인딩 후 레거시 무시 | `runtime.ts:152` | 포트 우회 다운그레이드 |
+| 미지 메서드 거부 | `rpc-router.ts:100` | 임의 함수 호출 |
+| 응답 origin 지정 | `runtime.ts:110` — `{targetOrigin: event.origin}` | 응답 광역 브로드캐스트 |
+
+**MCP-유사 브리지는 이 여덟 개를 하나도 약화시키지 않는다.** 특히 "첫 origin 고정"은
+JSON-RPC 모드에서도 그대로다 — 포트가 이미 바인딩된 뒤에 모드가 결정되기 때문이다.
+
+### 5.2 문서 내용이 새는 경로
+
+브리지가 열리면 **문서 본문이 RPC 응답으로 나간다.** 지금은 페이지 SVG·내보내기
+바이트뿐이지만, 에이전트 동사가 붙으면 `getTextRange`·`searchAllText`·`getFieldList`
+결과가 나간다. 즉 **텍스트가 경계를 넘는다.**
+
+경계를 넘는 지점은 정확히 두 곳이다.
+
+1. `postPortResponse`(`runtime.ts:23-30`) — 포트로. 수신자는 **바인딩된 origin 하나**.
+2. `handleLegacy`(`runtime.ts:110`) — `targetOrigin: event.origin` 으로. 역시 하나.
+
+따라서 **"어느 origin 이 문서를 볼 수 있나"는 첫 연결 시점에 결정되고 바뀌지 않는다.**
+이건 좋은 성질이며, 브리지 설계에서 **반드시 보존해야 하는 불변식**이다.
+
+지켜야 할 규칙:
+
+- **응답 `targetOrigin` 에 `"*"` 를 쓰지 않는다.** 한 번이라도 쓰면 위 불변식이 무너진다.
+- **`tools/list` 는 문서 내용을 담지 않는다.** 자기서술은 문서와 무관해야 한다.
+  담기면 문서를 열지 않은 소비자에게도 내용이 샌다.
+- **오류 메시지에 문서 텍스트를 넣지 않는다.** 현재 `RPC_ERROR` 는 `error.message` 에
+  예외 문자열을 그대로 싣는다(`runtime.ts:64`). 코어 오류가 문서 조각을 포함하면
+  그게 유출 경로가 된다. **확인되지 않음** — 실제로 포함하는지 대조하지 않았다.
+
+### 5.3 위협 모델과의 접속
+
+문서는 공격자가 만들 수 있다는 전제
+([threat_model.md](../agent_security/threat_model.md))는 브라우저에서 더 날카롭다.
+
+- **인젝션 판정이 브라우저에 없다.** `inspect` 계열이 WASM 에 노출돼 있지 않다
+  ([self_description.md §1.3](self_description.md)). 즉 브리지를 통해 나가는 텍스트에는
+  **아무 판정도 붙지 않는다.**
+- **출처 표지도 없다.** `untrustedContent`/`untrustedFields` 가 WASM 봉투에 없다
+  (`grep` 결과 0). 소비 에이전트는 받은 문자열이 문서에서 왔는지 알 수 없다.
+
+> **따라서 브리지를 먼저 열고 판정을 나중에 붙이면, 그 사이 기간 동안 rhwp 는
+> 판정 없는 문서 통로가 된다.** 순서를 지켜야 한다 — 자기서술(표지 포함) → 브리지.
+
+소비자 쪽 책임 경계는 [consumer_guide.md](../agent_security/consumer_guide.md) 를 따른다.
+브리지는 **경계까지**만 책임진다.
+
+### 5.4 CSP
+
+확장은 WASM 실행을 명시적으로 허용한다.
+
+```
+"content_security_policy": {
+  "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
+}
+```
+
+`rhwp-chrome/manifest.json:42-44`, `rhwp-firefox/manifest.json:51-53`.
+
+`'wasm-unsafe-eval'` 없이는 WASM 이 돌지 않는다. 데모 페이지를 호스팅할 때도
+같은 제약이 걸린다 — [zero_install_onboarding.md §4](zero_install_onboarding.md).
+
+studio 의 `index.html` 은 인라인 스크립트를 피하도록 이미 작성돼 있다
+(`rhwp-studio/index.html:8-10` 주석: "확장 CSP가 인라인 스크립트를 금지하므로 외부
+파일로 분리(#1444)"). 브리지 코드도 **인라인 금지 규칙을 승계**해야 한다.
+
+### 5.5 초기에 하지 않는 것
+
+- **`resources/*` 를 노출하지 않는다.** MCP resources 는 "에이전트가 문서를 도구로 읽는"
+  표면이다(#3608 Stage 7). 브라우저에서 이걸 열면 origin 경계와 문서 경계가 겹쳐
+  경로 분석이 복잡해진다. 자기서술과 `tools/*` 가 안정된 뒤에 재검토한다.
+- **여러 소비자 동시 바인딩을 허용하지 않는다.** 현재 단일 바인딩
+  (`runtime.ts:143-146`)을 유지한다. 다중화는 "누가 무엇을 봤나"를 추적 불가능하게 만든다.
+- **확장 background 경로를 겸하지 않는다.** 그건 `chrome.runtime` 계보이고
+  `sender-validator.js` 가 담당한다(§1.5). 두 계보를 한 라우터에 합치면 발신자 검증
+  규칙이 섞인다.
+
+---
+
+## 6. 조각 분해
+
+| # | 조각 | 검증 |
+| --- | --- | --- |
+| B1 | `EMBED_CAPABILITIES` 에 `mcp-jsonrpc-v1` 추가 + 협상 분기 | 미지원 클라이언트가 종전대로 동작 (`e2e:embed`) |
+| B2 | `bindPort` 의 JSON-RPC 모드 — `initialize` 응답만 | 핸드셰이크 왕복 테스트 |
+| B3 | `tools/list` — 자기서술 결과 운반 (§4.3) | CLI `capabilities --mcp` 와 도구 이름 집합 대조 |
+| B4 | `tools/call` — 기존 11개 메서드 먼저 | 각 메서드 왕복 |
+| B5 | 에이전트 동사 라우팅 — WASM 에 **이미 있는 것**부터 (`searchAllText`·`getFieldList`) | 봉투 동등성 |
+| B6 | 없는 동사 — 자기서술 S5 완료 후 | — |
+| B7 | 오류 메시지 유출 점검 (§5.2) | 문서 텍스트 미포함 단언 |
+
+**B3 을 B5 보다 먼저** 한다. 목록 없이 동사를 열면 소비자가 하드코딩하고, 그 순간
+자기서술이 장식이 된다.
+
+---
+
+## 7. 확인되지 않음
+
+1. **확장 background(service worker)에서 `MessageChannel` 브리지가 성립하는가** —
+   `sender-validator.js` 계보와 어떻게 만나는지 미조사.
+2. **`RPC_ERROR` 메시지가 문서 텍스트를 포함하는가** (`runtime.ts:64`) — 코어 오류
+   문자열을 전수 대조하지 않았다.
+3. **이진 결과의 MCP `content` 표현** — transfer 와 표준 호환의 절충안 미정(§4.5).
+4. **동시 다중 소비자 요구가 실제로 있는가** — 지금은 단일 바인딩으로 충분하다고
+   가정했다.
+5. **브리지 왕복 지연** — 측정하지 않았다. 이 문서에 성능 주장이 없는 이유다.
+6. **`e2e/embed-transport.test.mjs` 의 커버리지 범위** — 파일 존재와 스크립트 등록만
+   확인했고 내용은 읽지 않았다.
+
+---
+
+## 8. 관련 문서
+
+- [README.md](README.md) — 이 축의 지도
+- [self_description.md](self_description.md) — 브리지가 **운반할 목록**을 정한다
+- [zero_install_onboarding.md](zero_install_onboarding.md) — 브리지가 실려 나가는 배포 형태
+- [../agent_security/threat_model.md](../agent_security/threat_model.md) — 문서 신뢰 전제
+- [../agent_security/attack_surface.md](../agent_security/attack_surface.md) — 표면별 노출 매핑
+- [../agent_security/consumer_guide.md](../agent_security/consumer_guide.md) — 소비자 책임
+- [../agent_boundary_contract.md](../agent_boundary_contract.md) — 경계 무결성 계약
+- 이슈 [#3608](https://github.com/edwardkim/rhwp/issues/3608) M24 ·
+  [#3869](https://github.com/edwardkim/rhwp/issues/3869) ·
+  [#3787](https://github.com/edwardkim/rhwp/issues/3787)

--- a/mydocs/tech/wasm_agent_surface/self_description.md
+++ b/mydocs/tech/wasm_agent_surface/self_description.md
@@ -1,0 +1,498 @@
+---
+kind: canonical
+status: draft
+canonical: mydocs/tech/wasm_agent_surface/self_description.md
+last_verified: 2026-08-03
+---
+
+# WASM capabilities 자기서술 설계
+
+> CLI 는 `rhwp capabilities` 로, MCP 는 `tools/list` 로 자기를 서술한다.
+> **WASM 은 무엇으로 서술하는가.** 브라우저 안의 소비자 — 스튜디오, 확장, 임베드 호스트,
+> 그리고 언젠가 브리지를 통해 붙을 에이전트 — 가 "이 모듈이 뭘 할 수 있나"를 아는 방법을
+> 확정한다.
+> 로드맵 [#3608](https://github.com/edwardkim/rhwp/issues/3608) M24 첫 줄,
+> [#3869](https://github.com/edwardkim/rhwp/issues/3869) W1·W2 에 대응한다.
+
+이 문서의 모든 기술 주장에는 코드 경로(`파일:줄`) 또는 실제 명령 출력이 붙는다.
+근거를 대지 못하는 항목은 **"확인되지 않음"** 으로 적었다.
+축 전체의 지도는 [README.md](README.md) 에 있다.
+
+---
+
+## 0. 결론 먼저
+
+세 문장으로 요약한다. 근거는 §1~§5 에 있다.
+
+1. **WASM 표면에는 자기서술이 전혀 없다.** `src/wasm_api.rs` 7,621줄 안에
+   `capabilities`·`schemaVersion` 이라는 문자열이 **한 번도** 등장하지 않는다.
+2. **없는 이유는 기능 부족이 아니라 크레이트 경계다.** 자기서술 데이터
+   (`capabilities_command_entries()`)는 **bin 크레이트**인 `src/main.rs:1463` 에 있고,
+   WASM 이 컴파일되는 lib(`src/lib.rs`, 54줄)은 그것을 볼 수 없다.
+3. **따라서 설계의 핵심은 "WASM 에 무엇을 새로 짤까"가 아니라
+   "자기서술의 단일 출처를 lib 으로 내리고, 두 소비자(CLI·WASM)가 같은 출처를 읽게
+   할까"다.** 이걸 안 하면 목록이 둘로 갈리고, 갈린 순간 문서도 둘이 된다.
+
+---
+
+## 1. 지금 있는 것 — 실측 전수
+
+### 1.1 표면 규모
+
+```
+$ wc -l src/wasm_api.rs
+7621 src/wasm_api.rs
+
+$ grep -c "wasm_bindgen" src/wasm_api.rs
+372
+
+$ grep -oE "js_name\s*=\s*[A-Za-z0-9_]+" src/wasm_api.rs | sed 's/.*= *//' | sort -u | wc -l
+360
+
+$ grep -oE "pub fn [a-z_0-9]+" src/wasm_api.rs | sort -u | wc -l
+367
+```
+
+구조체는 둘이다.
+
+- `HwpDocument` — `src/wasm_api.rs:337`. 문서 하나를 감싸는 핸들.
+  `impl Deref for HwpDocument` (341행) 로 `DocumentCore` 에 위임한다.
+  `#[wasm_bindgen]` 이 붙은 `impl` 블록은 `504` 행부터.
+- `HwpViewer` — `src/wasm_api.rs:7440`. 뷰 상태 전용(`7448`, `7522` 에 impl).
+
+에러는 `impl From<HwpError> for JsValue` (`src/wasm_api.rs:45`) 하나로 JS 에 넘어간다.
+즉 **실패는 JS 예외(throw)** 이지 봉투가 아니다. 이 사실이 §4.3 의 설계를 결정한다.
+
+### 1.2 자기서술은 없다 — 실측
+
+```
+$ grep -cE "text_security|TextSecurity|inspect|extract_data|extract-data|digest|export_tables|schemaVersion|schema_version|untrustedContent" src/wasm_api.rs
+0
+```
+
+**0이다.** 봉투 어휘(`schemaVersion`), 출처 표지(`untrustedContent`), 자기서술
+(`capabilities`) 중 어느 것도 WASM 표면에 없다.
+
+반면 CLI 는 그 전부를 싣는다. 실측 출력의 최상위 키:
+
+```
+$ rhwp capabilities | jq 'keys'
+["batch","commands","exitCodes","formats","jsonContract","schemaVersion",
+ "tool","untrustedContent","untrustedFields","version"]
+
+$ rhwp capabilities | jq '{commands:(.commands|length), json:([.commands[]|select(.json)]|length)}'
+{ "commands": 61, "json": 31 }
+
+$ rhwp capabilities --mcp | jq '.tools | length'
+39
+```
+
+### 1.3 에이전트 동사 — 있는 것 vs 없는 것
+
+`js_name` 360개를 CLI 의 에이전트-가치 명령(#3608 §1-A~1-C)에 대응시킨 전수 표다.
+**렌더링 API 는 이 표에 넣지 않는다**(§1.4).
+
+#### 있다 — 이름은 다르지만 같은 일을 한다
+
+| CLI 동사 | WASM 대응 | 코드 경로 | 차이 |
+| --- | --- | --- | --- |
+| `info` | `getDocumentInfo()` | `wasm_api.rs:1017` | 봉투 아님. 코어 문자열 그대로 |
+| `export-structure` | `getStructure(mode)` | `wasm_api.rs:7542` | `mode` 어휘가 `auto\|outline\|clause` 로 **CLI 와 동일** |
+| `search` | `searchText(...)` / `searchAllText(...)` | `wasm_api.rs:4846` / `4869` | 커서 기준 단건 + 전체. `include_cells` 인자가 CLI 엔 없다 |
+| `fields` | `getFieldList()` | `wasm_api.rs:4542` | 반환은 `[{fieldId,fieldType,name,guide,command,value,location}]`(주석 4540행) |
+| — | `getFieldValue(id)` / `getFieldValueByName(name)` | `wasm_api.rs:4550` / `4558` | CLI 엔 개별 조회가 없다 |
+| `edit fill-fields` | `setFieldValue(id,v)` / `setFieldValueByName(...)` | `wasm_api.rs:4566` / `4575` | 한 건씩. CLI 는 `--data` 로 다건 |
+| `edit replace-text` | `replaceOne(...)` / `replaceAll(...)` | `wasm_api.rs:4903` / `4916` | CLI `--occurrence k` 대응이 없다 |
+| `edit insert-image` | `insertPicture` / `insertPictureEx` | `wasm_api.rs` (js_name 목록) | 좌표 인자 형태 미대조 |
+| `convert` / `export-hwpx` | `exportHwp()` / `exportHwpx()` | `wasm_api.rs:5684` / `5700` | 바이트 반환. 파일 경로 개념 없음 |
+| `... --verify` | `exportHwpVerify()` | `wasm_api.rs:5733` | **왕복 검증이 이미 WASM 에 있다** |
+| `export-hml` | `exportHml()` | js_name 목록 | |
+| `thumbnail` | `extractThumbnail(data)` | `wasm_api.rs:7595` | 자유 함수(구조체 밖) |
+| `export-text` (부분) | `getTextRange(...)` / `getPageTextLayout(p)` | `wasm_api.rs:2345` / `1025` | **페이지별 텍스트 봉투는 없다.** 후자는 좌표까지 실린 레이아웃 |
+| 암호 문서 | `openWithPassword` / `exportHwpWithPassword` | js_name 목록 | CLI `--password-stdin` 대응 |
+
+#### 없다 — 코어는 있는데 노출이 없다
+
+| CLI 동사 | WASM | 코어 위치(lib, wasm32 도달 가능) |
+| --- | --- | --- |
+| `digest` | **없음** | 봉투 조립이 `src/main.rs` |
+| `extract-data` | **없음** | `document_core/queries/extract_data.rs:850` `pub fn extract_data(&self, kinds:&[DataKind]) -> Vec<DataItem>` (1,251줄) |
+| `export-tables` (격자) | **없음** | `document_core/queries/table_extract.rs:292` `pub fn extract_tables(doc:&Document) -> Vec<TableGrid>` (304줄) |
+| `table-to-csv` / `csv-to-table` | **없음** | `document_core/queries/table_csv.rs` (265줄) |
+| `inspect hidden-text` | **없음** | `document_core/queries/hidden_text.rs:642` `pub fn detect_hidden_text(...)` (1,117줄) |
+| `inspect injection` | **없음** | `document_core/queries/injection_scan.rs:1034` `pub fn scan_injection(...)` (1,467줄) |
+| `inspect unicode` | **없음** | `document_core/text_security.rs` (1,345줄) |
+| `edit redact` | **없음** | `document_core/queries/pii_scan.rs` (773줄) |
+| `edit sanitize` | **없음** | 확인되지 않음 |
+| `run`(계획 실행기) | **없음** | 확인되지 않음 |
+| `ir-diff` | **없음** | 확인되지 않음 |
+| `export-markdown` / `export-pdf` / `export-doclang` | **없음** | `doclang` 은 lib 모듈(`src/lib.rs:9`) |
+| `extract-pages` | **없음** | 확인되지 않음 |
+| `batch` | **없음** | 브라우저에 "파일 목록"이 없다 — 의미론 재정의 필요 |
+| `capabilities` / `export-*-schema` / `export-provenance-map` | **없음** | §2.2·§2.4 |
+
+혼동 주의: **`getValidationWarnings()`(`wasm_api.rs:5812`)는 `inspect` 가 아니다.**
+스튜디오 타입 정의를 보면 `LinesegArrayEmpty | LinesegUncomputed | LinesegTextRunReflow`
+세 종류의 **HWPX 비표준 감지 경고**다(`rhwp-studio/src/core/wasm-bridge.ts` 의
+`ValidationReport`). 보안 판정과 무관하다.
+
+### 1.4 렌더링 API 와 섞지 않는다는 뜻
+
+`js_name` 360개 중 `render|canvas|paint|layer|overlay|cursor|hitTest|bbox|rect|zoom|dpi|
+viewport|caret|line|preview|thumb` 를 포함하는 이름이 **55개**다(키워드 기반 근사 — 정확
+분류가 아니다). 대표: `renderPageToCanvas`·`renderPageToCanvasFiltered`·
+`renderPagePatchToCanvasFilteredWithProfile`·`getPageLayerTree`·`getCanvasKitReplayPlan`.
+
+이들은 **브라우저 UI 의 것**이다. #3869 §4 가 명시적으로 제외한다. 자기서술이 이 둘을
+한 목록에 담으면 소비자는 "rhwp WASM 이 할 수 있는 일" 360개를 보고 그중 무엇이
+에이전트 동사인지 판별할 방법이 없다.
+
+**따라서 자기서술은 처음부터 두 개의 축을 가진다** — `agent` 과 `render`. 하나의 목록에
+`surface: "agent" | "render" | "ui"` 를 실어 소비자가 걸러 쓰게 한다(§4.2).
+
+---
+
+## 2. 왜 없는가 — 크레이트 경계
+
+### 2.1 lib 과 bin 은 다른 크레이트다
+
+```toml
+# Cargo.toml:13-19
+[lib]
+crate-type = ["rlib", "cdylib"]
+
+[[bin]]
+name = "rhwp"
+path = "src/main.rs"
+```
+
+`wasm-pack build --target web` 은 **lib**(cdylib)을 빌드한다
+(`.github/workflows/deploy-pages.yml:60`). `src/main.rs` 는 그 산출물에 들어가지 않는다.
+
+`src/lib.rs` 는 54줄이고, 공개 모듈은 다음과 같다(`src/lib.rs:7-25`).
+
+```
+capabilities_schema  diagnostics  doclang  document_core  emf  error  ir_schema
+model  ole_chart  ooxml_chart  paint  parser  password_crypto  provenance
+renderer  serializer  wasm_api  wmf
+```
+
+반면 `src/main.rs:7-9` 는 다음을 **자기 모듈로** 선언한다.
+
+```rust
+mod agent_profiles;
+mod atomic_file;
+mod mcp_serve;
+```
+
+즉 **에이전트 프로필 7종도, MCP 서버(`mcp_serve.rs`, 1,596줄)도 bin 전용**이다.
+WASM 은 이들을 볼 수 없다.
+
+### 2.2 자기서술 *데이터* 는 bin 에 있다
+
+- 디스패치: `src/main.rs:277` — `Some("capabilities") => exit_with(show_capabilities(&args[2..]))`
+- 명령 테이블: `src/main.rs:1463` — `fn capabilities_command_entries() -> Vec<serde_json::Value>`
+- 출력: `src/main.rs:2283` — `println!("{}", provenance::marked(caps, "capabilities"))`
+- did-you-mean 후보: `src/main.rs:2132` — `fn capabilities_command_names()`
+
+`capabilities_command_entries()` 는 `serde_json::json!` 리터럴을 손으로 쌓는다.
+`src/capabilities_schema.rs:9-13` 의 모듈 주석이 이 사실을 명시한다.
+
+> `capabilities` 출력은 `serde_json::json!` 리터럴로 조립된 값이라 파생할 타입 자체가 없다.
+
+**이 문장이 M24 첫 줄의 난이도를 정한다.** 타입이 없으므로 WASM 쪽에서 "같은 것"을
+자동으로 만들 수 없다. 사람이 손으로 두 번 쓰면 드리프트가 시작된다.
+
+### 2.3 그런데 *로직* 은 lib 에 있다
+
+`document_core` 는 lib 모듈이다(`src/lib.rs:10`). 그 안 `queries/` 의 규모(`wc -l`):
+
+```
+   1251 extract_data.rs      1467 injection_scan.rs     1117 hidden_text.rs
+    773 pii_scan.rs           738 search_query.rs        530 structure.rs
+    304 table_extract.rs      265 table_csv.rs          1745 field_query.rs
+```
+
+이들은 대부분 순수 IR 조회다. `std::fs`/`std::path`/`std::io` 를 참조하는 파일은
+`cursor_rect.rs`·`form_query.rs`·`grep.rs`·`rendering.rs`·`search_query.rs` 다섯이고,
+`rendering.rs` 는 이미 `#[cfg(not(target_arch = "wasm32"))]` 로 네이티브 전용 경로를
+가른다(`rendering.rs:1004`·`1014`·`1023`·`1044`·`1066`·`1073`, 그리고 `native-skia`
+게이트 `1086` 이후).
+
+**즉 `extract-data`·`inspect`·`export-tables` 를 WASM 에 노출하는 데 필요한 것은
+새 로직이 아니라 `#[wasm_bindgen]` 한 줄과 봉투 조립이다.**
+
+다만 `grep.rs`·`search_query.rs`·`form_query.rs` 의 wasm32 컴파일 가능성은
+**확인되지 않음** — 실제로 빌드해 보지 않았다.
+
+### 2.4 스키마는 이미 lib 에 있다 (그런데 노출은 안 된다)
+
+`src/capabilities_schema.rs` 는 **lib 모듈**이고 613줄이다.
+
+- `CAPABILITIES_SCHEMA_VERSION = "1.1"` — `src/capabilities_schema.rs:29`
+- `schema`(명령 표면)와 `mcpSchema`(도구 매니페스트)를 **분리**한다는 결정이
+  같은 파일 15~19행 주석에 기록돼 있다.
+- `additionalProperties: true` 는 의도적 — "추가-전용 진화" 계약(같은 파일 51~54행).
+
+`src/ir_schema.rs`·`src/provenance.rs`(518줄)도 lib 이다. 그런데
+
+```
+$ grep -c wasm_bindgen src/ir_schema.rs src/capabilities_schema.rs src/provenance.rs src/agent_profiles.rs
+src/ir_schema.rs:0
+src/capabilities_schema.rs:0
+src/provenance.rs:0
+src/agent_profiles.rs:0
+```
+
+**전부 0이다.** 스키마도 출처 표지도 lib 안에 있으면서 브라우저로 나가지 않는다.
+이건 공백이라기보다 **아직 배선하지 않은 것**이다 — 가장 싼 조각이다.
+
+---
+
+## 3. 설계 — 세 후보와 판정
+
+문제를 다시 정의한다. **브라우저 소비자가 런타임에 "이 모듈이 뭘 할 수 있나"를
+알아야 한다.** 후보는 셋이다.
+
+### 후보 A — 런타임 반사(reflection)
+
+`Object.keys(wasmModule)` 로 export 된 함수 이름을 훑는다. 스튜디오는 이미 모듈 전체를
+가져온다(`import * as wasmExports from '@wasm/rhwp.js'`,
+`rhwp-studio/src/core/wasm-bridge.ts:2`).
+
+- 장점: 코드 추가 0. 항상 실제 표면과 일치한다.
+- 단점: **이름만 나온다.** 인자 스키마도, 반환 모양도, 어떤 것이 에이전트 동사이고
+  어떤 것이 렌더링인지도 알 수 없다. 360개 이름을 받은 소비자는 아무것도 판단하지
+  못한다. `capabilities` 가 CLI 에서 하는 일 — 요약·플래그·`recordFields` — 을
+  전혀 대신하지 못한다.
+
+### 후보 B — 빌드 시점 정적 스키마 동봉
+
+`pkg/` 에 `capabilities.json` 을 함께 실어 소비자가 `fetch` 한다.
+
+- 장점: WASM 바이너리를 안 키운다. 파싱이 싸다. CI 에서 CLI 출력으로 생성해
+  **동등성을 생성 시점에 강제**할 수 있다.
+- 단점: **파일이 분리되면 어긋난다.** 소비자가 옛 `capabilities.json` 과 새 `.wasm` 을
+  섞어 쓰는 걸 막을 수단이 없다. 확장(`rhwp-chrome`)은 파일을 개별 복사하므로
+  실제로 어긋날 수 있는 배포 형태다. 오프라인(`file:`)에서 `fetch` 가 막히는 경우도 있다
+  — [zero_install_onboarding.md §4](zero_install_onboarding.md).
+
+### 후보 C — 런타임 함수가 빌드 시점 상수를 돌려준다 (채택)
+
+`lib` 안에 자기서술 데이터를 두고, `wasm_bindgen` 자유 함수 하나가 그것을 JSON 문자열로
+돌려준다. 데이터는 컴파일 시점에 고정되고 배포 단위는 `.wasm` 하나다.
+
+```rust
+// 개념 — 실제 코드가 아니다
+#[wasm_bindgen(js_name = capabilities)]
+pub fn capabilities_json() -> String { /* lib::capabilities::wasm_envelope() */ }
+```
+
+- 장점: **버전 스큐가 구조적으로 불가능**하다. `.wasm` 을 바꾸면 자기서술도 같이 바뀐다.
+- 단점: 바이너리가 커진다. 얼마나 커지는지는 **확인되지 않음** — 현재 `.wasm` 크기
+  자체가 미실측이다(§8).
+
+### 판정
+
+| 기준 | A 반사 | B 정적 파일 | C 내장 함수 |
+| --- | --- | --- | --- |
+| 인자·반환 스키마를 준다 | ✗ | ○ | ○ |
+| 에이전트/렌더 축 구분 | ✗ | ○ | ○ |
+| 버전 스큐 불가 | ○ | ✗ | ○ |
+| 오프라인 `file:` 동작 | ○ | △ | ○ |
+| 바이너리 증가 | 0 | 0 | **미측정** |
+| CLI 와 동등성 강제 지점 | 없음 | CI 생성기 | CI 생성기 + 계약 테스트 |
+
+**C 를 채택한다.** 단, B 를 완전히 버리지 않는다 — **C 가 돌려주는 것과 동일한 JSON 을
+`pkg/capabilities.json` 으로도 내보낸다.** 번들러·타입 생성기는 파일을 원하고,
+런타임 소비자는 함수를 원한다. 둘이 같은 출처에서 나오면 어긋날 수 없다.
+
+---
+
+## 4. 표면 모양
+
+### 4.1 진입점
+
+에이전트 동사와 마찬가지로 **자유 함수**로 둔다. `HwpDocument` 인스턴스가 없어도
+— 즉 **문서를 열기 전에** — 물을 수 있어야 하기 때문이다. 선례가 있다:
+`extract_thumbnail` 은 `src/wasm_api.rs:7595` 에서 자유 함수이고, `version()` 은
+`src/lib.rs:41` 에 있다.
+
+- `capabilities()` → `String` (JSON) — CLI `rhwp capabilities` 대응
+- `capabilitiesMcp()` → `String` — CLI `rhwp capabilities --mcp` 대응
+- `capabilitiesSchema()` → `String` — `export-capabilities-schema` 대응.
+  `src/capabilities_schema.rs` 가 이미 lib 에 있으므로 **배선만 하면 된다**(§2.4)
+
+### 4.2 봉투 — 같아야 하는 것
+
+CLI 실측 출력의 최상위 키 중 **아래는 그대로 유지한다.** 다르면 소비자가 두 벌의
+파서를 써야 하고, 그 순간 문서가 둘로 갈린다(#3869 W2 가 말하는 실패 조건).
+
+| 필드 | CLI 실측 값 | WASM 에서 |
+| --- | --- | --- |
+| `schemaVersion` | `"1.0"` | 동일 문자열 |
+| `tool` | `"rhwp"` | 동일 |
+| `version` | `"0.8.2"` | `env!("CARGO_PKG_VERSION")` — 이미 `version()` 이 쓰는 값 |
+| `formats.read` | `["hwp5","hwpx","hwp3","hml"]` | 동일 |
+| `formats.write` | `["hwp5","hwpx","hml","pdf","svg","png","txt","md","doclang"]` | **다르다** — §4.3 |
+| `commands[].name` | 61개 | 부분집합. 이름은 **글자 그대로 같아야** 한다 |
+| `commands[].category` | `query\|export\|edit\|batch\|diagnostic\|serve\|internal` | 동일 어휘 |
+| `commands[].recordFields` | 봉투 필드 목록 | 동일 |
+| `jsonContract.schemaPolicy` | 추가 허용, 변경·삭제는 범프 | 동일 |
+| `untrustedContent` / `untrustedFields` | `false` / `[]` | **반드시 유지** — §4.4 |
+
+여기에 **WASM 전용 필드 하나**를 더한다.
+
+- `surface`: `"agent" | "render" | "ui"` — §1.4 의 축 구분.
+  `additionalProperties: true` 정책(`src/capabilities_schema.rs:51-54`)이 이 추가를
+  허용한다. **추가는 되고 변경은 안 된다.**
+
+### 4.3 달라야 하는 것 — 그리고 왜
+
+동등성은 **복제가 아니다.** 브라우저에 존재하지 않는 개념을 억지로 실으면 그게 더 큰
+거짓말이 된다. 아래는 **의도적으로 다르게** 두고, 그 이유를 봉투 안에 적는다.
+
+| 필드 | 왜 다른가 |
+| --- | --- |
+| `exitCodes` (0~4) | **브라우저에 종료 코드가 없다.** WASM 실패는 JS 예외다 (`impl From<HwpError> for JsValue`, `src/wasm_api.rs:45`). 대신 `errorCodes` 로 같은 5개 부류를 이름으로 싣고, `exitCodeMapping` 으로 CLI 대응을 명시한다 |
+| `batch` | `stdin` 파일 목록 개념이 없다. 브라우저 대응물(File 배열)은 **의미론이 달라** 같은 이름을 쓰면 안 된다. 초기엔 `batch: null` 로 명시 부재를 싣는다 |
+| `commands[].flags` | 플래그가 아니라 **함수 인자**다. `params` 로 이름을 바꾸고 JSON Schema 로 적는다 |
+| `formats.write` 의 `pdf`·`png` | `export-pdf`·`export-png` 는 WASM 에 없다(§1.3). **없는 걸 있다고 적으면 안 된다.** `svg` 는 `renderPageSvg` 로 있다 |
+| `mcp.invocation.transport` | CLI 는 `"cli"`. 브라우저는 `"postMessage"` 계열 — [browser_bridge.md](browser_bridge.md) 가 정한다 |
+| 파일 경로 인자 | `path` 가 없다. 입력은 바이트(`from_bytes`, `src/wasm_api.rs:358`)다. `inputSchema` 에서 `path: string` 을 `data: Uint8Array` 로 바꾼다 |
+
+**차이는 숨기지 말고 봉투 안에 적는다.** CLI `batch.authentication` 이
+`"지원하지 않음 — ... 계약은 아직 정의되지 않았다"` 라고 한국어 문장으로 부재를
+설명하는 선례가 이미 있다(실측 출력). 같은 방식을 쓴다.
+
+### 4.4 출처 표지는 반드시 간다
+
+CLI `capabilities` 봉투에도 `untrustedContent: false`, `untrustedFields: []` 가 실린다
+(실측). 정책이 명시돼 있다.
+
+> 표지는 항상 실린다 — 문서를 열지 않는 명령의 봉투도 `untrustedContent:false` 를 명시한다
+
+**WASM 에서 이게 더 중요하다.** 브라우저에서는 문서 내용과 UI 상태가 같은 JS 힙에
+섞이고, 문서에서 온 문자열이 그대로 DOM 이나 에이전트 컨텍스트로 흘러갈 수 있다.
+`src/provenance.rs`(518줄)는 이미 lib 이므로 배선만 하면 된다.
+
+위협 모델의 전제 — 문서는 공격자가 만들 수 있다 — 는
+[../agent_security/threat_model.md](../agent_security/threat_model.md) 를 그대로 따른다.
+브라우저가 추가하는 **새 경계(origin)** 는 [browser_bridge.md §5](browser_bridge.md) 가 다룬다.
+
+---
+
+## 5. 동등성을 유지하는 기제
+
+동등성은 선언으로 유지되지 않는다. **깨지면 CI 가 빨개져야** 유지된다.
+
+### 5.1 단일 출처를 lib 으로 내린다
+
+지금은 `capabilities_command_entries()`(bin)가 유일 출처다. 이걸
+`src/capabilities.rs`(lib)로 옮기고, bin 과 wasm 이 **같은 함수를 읽는다.**
+
+```
+        src/capabilities.rs  (lib, 단일 출처)
+                 │
+      ┌──────────┴──────────┐
+  src/main.rs           src/wasm_api.rs
+  (CLI 출력 + 필터)      (WASM 필터 + 봉투)
+```
+
+`surface` 축(§4.2)이 필터의 근거가 된다. WASM 은 `surface == "agent"` 이고 실제로
+`js_name` 이 존재하는 항목만 싣는다.
+
+**이 이동은 동작 무변경 리팩터여야 한다.** `rhwp capabilities` 출력이 바이트 단위로
+같아야 한다 — 그 자체가 첫 계약 테스트다.
+
+### 5.2 기존 드리프트 가드를 확장한다
+
+이미 하나가 돈다.
+
+- `scripts/frontend-wasm-bindings.test.mjs` — `#[wasm_bindgen(js_name = X)]` 로 선언된
+  모든 이름이 `pkg/rhwp.d.ts` 에 나타나는지 단언한다.
+  CI 연결: `.github/workflows/ci.yml:951`.
+
+**이건 *이름* 가드이지 *의미* 가드가 아니다.** 필요한 것은 셋이다.
+
+| 가드 | 무엇을 막나 | 형태 |
+| --- | --- | --- |
+| G1 이름 존재 | 자기서술이 없는 함수를 광고 | `capabilities()` 의 모든 항목이 `pkg/rhwp.d.ts` 에 있다 |
+| G2 역방향 | 광고되지 않은 에이전트 동사 | `surface=="agent"` 로 분류된 `js_name` 중 자기서술에 빠진 것 = 0 |
+| G3 봉투 동등 | CLI 와 WASM 의 봉투 모양 분기 | 같은 문서에 대해 `recordFields` 집합이 일치 |
+
+G1 은 기존 스크립트의 대칭 확장이다. G3 은 #3869 W2 가 요구하는 계약 테스트 그 자체다.
+
+### 5.3 계약 테스트의 모양
+
+#3869 수용 기준은 "WASM 봉투와 CLI `--json` 봉투가 **동일**함을 계약 테스트가 고정"이다.
+현실적인 형태는 다음 셋이다.
+
+1. **Rust 단위 테스트** — 같은 샘플 바이트로 lib 코어를 두 번 호출해 봉투를 비교한다.
+   `wasm32` 타깃이 아니어도 lib 함수는 네이티브에서 돌므로 **CI 에서 가장 싸다.**
+2. **`wasm-bindgen-test`** — 실제 wasm32 에서 도는지 확인. 의존성은 이미 있다
+   (`Cargo.toml:94` `wasm-bindgen-test = "0.3"`).
+3. **Node 계약 테스트** — `scripts/` 의 기존 패턴(`node --test`)을 따라
+   `capabilities()` JSON 과 `rhwp capabilities` 출력을 대조.
+
+`.wasm` 산출물이 필요한 2·3 은 CI 에서만 돌 수 있다. 로컬 개발자는 1 로 대부분을 잡는다.
+
+---
+
+## 6. 조각 분해 (#3869 W1·W2 대응)
+
+착수 순서다. 각 조각은 이전 조각 없이는 검증할 수 없다.
+
+| # | 조각 | 산출 | 검증 |
+| --- | --- | --- | --- |
+| S1 | `capabilities` 데이터를 lib(`src/capabilities.rs`)로 이동 | 동작 무변경 | `rhwp capabilities` 출력 바이트 동일 |
+| S2 | 항목마다 `surface` 축 부여 | `agent`/`render`/`ui` 분류 | 분류 누락 = 0 인 테스트 |
+| S3 | `capabilities()` / `capabilitiesMcp()` / `capabilitiesSchema()` wasm 노출 | js_name 3개 | `pkg/rhwp.d.ts` 에 등장(G1) |
+| S4 | 봉투 조립 헬퍼를 lib 으로 (`schemaVersion`·`untrustedContent` 포함) | 공용 봉투 | CLI 출력 무변경 |
+| S5 | 없는 동사 노출 — `digest`·`extract-data`·`export-tables`·`inspect` 3종 | 새 js_name | G2 + G3 |
+| S6 | `pkg/capabilities.json` 동시 산출 | 빌드 산출물 | 함수 반환값과 바이트 동일 |
+
+**S5 를 S1~S4 보다 먼저 하고 싶은 유혹을 경계한다.** 봉투 없이 동사를 먼저 노출하면
+스튜디오가 그 모양에 붙고, 나중에 봉투를 씌울 때 호환을 깨야 한다.
+
+---
+
+## 7. 하지 않는 것
+
+- **360개 전부를 자기서술하지 않는다.** `surface=="agent"` 만 싣는다. 렌더 API 의
+  자기서술은 별개 문제이며 이 문서의 범위가 아니다.
+- **JSON Schema 를 손으로 두 번 쓰지 않는다.** `src/capabilities_schema.rs` 가 이미
+  단일 출처다(§2.4).
+- **CLI 봉투를 WASM 에 맞추어 바꾸지 않는다.** 방향은 한쪽이다 — WASM 이 CLI 를 따른다.
+  CLI 봉투는 이미 외부 소비자(바인딩·MCP)가 쓰고 있다.
+- **`exitCodes` 를 억지로 옮기지 않는다.** §4.3.
+
+---
+
+## 8. 확인되지 않음
+
+1. **자기서술 내장이 `.wasm` 을 얼마나 키우는가** — 현재 `.wasm` 크기 자체가 미실측이다
+   (`.gitignore:12` 가 `*.wasm` 제외, 이 작업 트리에 산출물 없음).
+   [zero_install_onboarding.md §2](zero_install_onboarding.md) 와 같은 공백이다.
+2. **`document_core/queries/` 전 모듈의 wasm32 컴파일 가능성** — `grep.rs`·
+   `search_query.rs`·`form_query.rs` 가 `std::fs`/`std::io` 를 참조한다. 실제 빌드 미확인.
+3. **`edit sanitize`·`run`·`ir-diff`·`extract-pages` 의 코어 위치** — lib 인지 bin 인지
+   대조하지 않았다.
+4. **`insertPicture` 인자 형태가 CLI `edit insert-image` 와 대응하는지** — 시그니처를
+   줄 단위로 대조하지 않았다.
+5. **WASM 호출 성능** — 이 문서에 성능 주장이 하나도 없는 이유다.
+
+---
+
+## 9. 관련 문서
+
+- [README.md](README.md) — 이 축의 지도
+- [browser_bridge.md](browser_bridge.md) — 자기서술을 **누가 어떻게 물어보는지**
+- [zero_install_onboarding.md](zero_install_onboarding.md) — 자기서술이 실려 나가는 배포 경로
+- [../agent_security/threat_model.md](../agent_security/threat_model.md) — 출처 표지의 근거
+- [../agent_security/consumer_guide.md](../agent_security/consumer_guide.md) — 소비자 책임 경계
+- [../bindings_foundation.md](../bindings_foundation.md) — 외부 바인딩의 표면 판단(M18~M20)
+- [../wasm_pack_version_policy.md](../wasm_pack_version_policy.md) — 툴체인 고정
+- 이슈 [#3608](https://github.com/edwardkim/rhwp/issues/3608) M24 ·
+  [#3869](https://github.com/edwardkim/rhwp/issues/3869) W1·W2 ·
+  [#3787](https://github.com/edwardkim/rhwp/issues/3787)

--- a/mydocs/tech/wasm_agent_surface/zero_install_onboarding.md
+++ b/mydocs/tech/wasm_agent_surface/zero_install_onboarding.md
@@ -1,0 +1,465 @@
+---
+kind: guide
+status: draft
+canonical: mydocs/tech/wasm_agent_surface/zero_install_onboarding.md
+last_verified: 2026-08-03
+---
+
+# 설치 0 온보딩 — 오프라인 데모 페이지 설계
+
+> 사용자가 **아무것도 설치하지 않고** rhwp 를 써보는 경로를 확정한다.
+> 단일 HTML 인가, CDN 인가, 정적 사이트인가. 크기 예산은 얼마인가. 오프라인에서 도는가.
+> 로드맵 [#3608](https://github.com/edwardkim/rhwp/issues/3608) M24 셋째 줄,
+> [#3869](https://github.com/edwardkim/rhwp/issues/3869) §1("실제 첫 관문 — 바이너리")에
+> 대응한다.
+
+이 문서의 모든 기술 주장에는 코드 경로(`파일:줄`) 또는 실측이 붙는다.
+**크기는 지어내지 않는다** — 잰 것과 안 잰 것을 §2 에서 명확히 가른다.
+축 전체의 지도는 [README.md](README.md).
+
+---
+
+## 0. 결론 먼저
+
+1. **"설치 0"의 절반은 이미 존재한다.** rhwp 는 GitHub Pages 로 자동 배포된다
+   (`.github/workflows/deploy-pages.yml`). 브라우저로 URL 을 열면 HWP 가 열린다.
+   #3869 가 말하는 "바이너리 확보"라는 첫 관문은 **브라우저 경로에서는 이미 없다.**
+2. **없는 절반은 에이전트 축이다.** 그 페이지는 **뷰어/에디터**이고, 보여주는 것이
+   렌더링이다. `digest`·`fields`·`inspect` 같은 에이전트 동사를 보여주지 않는다 —
+   애초에 WASM 에 노출돼 있지 않기 때문이다
+   ([self_description.md §1.3](self_description.md)).
+3. **크기 예산을 지금 세울 수 없다.** `.wasm` 크기가 **측정되지 않았다.**
+   저장소가 `*.wasm` 을 제외하고(`.gitignore:12`) 이 작업 트리에 산출물이 없다.
+   유일한 숫자는 소스 주석 `WASM (~12 MB)`(`rhwp-studio/vite.config.ts:132`)이며
+   **이건 측정치가 아니다.**
+4. **단일 HTML 은 지금 불가능하다고 봐야 한다.** 근거는 §3.
+   현실적 채택은 **기존 Pages 배포에 데모 경로를 추가**하는 것이다.
+5. **오프라인은 "첫 로드 이후"만 성립한다.** 서비스워커가 `.wasm` 을 precache 에서
+   **명시적으로 제외**하고 런타임 CacheFirst 로만 잡기 때문이다
+   (`vite.config.ts:130-146`).
+
+---
+
+## 1. 지금 이미 있는 것
+
+### 1.1 배포 파이프라인 (실측)
+
+`.github/workflows/deploy-pages.yml` 전 단계:
+
+| 단계 | 명령 | 줄 |
+| --- | --- | --- |
+| 툴체인 | `dtolnay/rust-toolchain`, `targets: wasm32-unknown-unknown` | 41·43 |
+| wasm-pack | `./.github/actions/install-wasm-pack` (0.15.0 고정) | 46 |
+| **WASM 빌드** | `wasm-pack build --target web --release` | 60 |
+| 산출 복사 | `cp pkg/rhwp_bg.wasm rhwp-studio/public/` · `cp pkg/rhwp.js ...` | 74-75 |
+| 프런트 빌드 | `npx vite build --base=/rhwp/` | 82 |
+| 배포 | `actions/deploy-pages` | 100 |
+
+트리거는 `main` 푸시이며 `mydocs/**`·`docs/**`·`samples/**` 변경은 제외한다(6-19행).
+공개 URL 은 `https://edwardkim.github.io/rhwp/` (`npm/editor/package.json:32` `homepage`).
+
+버전 고정 정책은 [../wasm_pack_version_policy.md](../wasm_pack_version_policy.md).
+
+### 1.2 PWA·서비스워커 (실측)
+
+`rhwp-studio/vite.config.ts` 의 `VitePWA` 설정:
+
+```ts
+// vite.config.ts:131-146
+workbox: {
+  // WASM (~12 MB) is kept out of precache to avoid blocking SW installation;
+  // CacheFirst at runtime still gives offline access after the first load.
+  globPatterns: ['**/*.{js,css,html,png,svg,ico,woff,woff2,ttf,otf}'],
+  maximumFileSizeToCacheInBytes: 20 * 1024 * 1024,
+  runtimeCaching: [
+    { urlPattern: /\.wasm$/, handler: 'CacheFirst',
+      options: { cacheName: 'wasm-cache',
+                 expiration: { maxEntries: 5, maxAgeSeconds: 30*24*60*60 } } },
+  ],
+},
+devOptions: { enabled: false },
+```
+
+읽어야 할 사실 넷:
+
+- `globPatterns` 에 **`wasm` 확장자가 없다.** 의도적 제외이며 주석이 이유를 적는다.
+- 상한이 20 MB 다(`vite.config.ts:135`). `.wasm` 이 이걸 넘으면 런타임 캐시도 실패한다 —
+  **그래서 실제 크기를 재야 한다.**
+- 캐시 만료 30일, 최대 5개.
+- **dev 서버에서는 SW 가 꺼져 있다**(`devOptions.enabled: false`). 오프라인 검증은
+  `vite build` + `preview` 로만 가능하다.
+
+매니페스트(`vite.config.ts:102` 이후)는 `start_url`/`scope` 가 `/rhwp/` 이고(110행),
+`file_handlers` 로 `.hwp`·`.hwpx`·`.hml` 을 등록한다(112행) — **설치형 PWA 로 OS 파일
+연결까지 잡는다.**
+
+### 1.3 무엇이 이미 "설치 0"이고 무엇이 아닌가
+
+| | 상태 |
+| --- | --- |
+| 브라우저로 HWP **열기·보기** | ✅ 이미 된다 |
+| **편집·내보내기**(HWP/HWPX/HML) | ✅ 이미 된다 (`rpc-router.ts:90-94`) |
+| PWA 설치·파일 연결 | ✅ 이미 된다 |
+| iframe 임베드 API | ✅ `@rhwp/editor` (`npm/editor/`) |
+| **에이전트 동사 시연** | ❌ WASM 에 노출 없음 |
+| **자기서술 조회** | ❌ [self_description.md §1.2](self_description.md) |
+| **MCP-유사 호출** | ❌ [browser_bridge.md](browser_bridge.md) |
+| 크기·성능 수치 공개 | ❌ 미측정 |
+
+**즉 M24 셋째 줄의 실제 작업은 "페이지를 만드는 것"이 아니라 "이미 있는 페이지에
+에이전트 축을 보이게 하는 것"이다.**
+
+---
+
+## 2. 크기 예산 — 잰 것과 안 잰 것
+
+### 2.1 실측 (이 작업 트리, 2026-08-03)
+
+```
+$ ls -la rhwp-studio/public/
+284769  rhwp.js              # wasm-bindgen 글루 (JS)
+109086  rhwp.d.ts            # 타입 선언 (런타임 불필요)
+ 38196  rhwp_bg.wasm.d.ts    # 타입 선언 (런타임 불필요)
+  1649  theme-init.js
+   911  favicon.ico
+
+$ du -sh assets/fonts
+22M     assets/fonts
+```
+
+즉 **JS 글루만 278 KB** 다. 이건 잰 값이다.
+
+### 2.2 미실측 — `.wasm` 본체
+
+```
+$ find . -maxdepth 5 -name "*_bg.wasm"
+(결과 없음)
+
+$ grep -n "wasm" .gitignore
+11:/pkg/
+12:*.wasm
+```
+
+**저장소에 `.wasm` 이 없다.** `pkg/` 도 `*.wasm` 도 제외돼 있다. 이 PC 는 rhwp 를
+빌드하지 못하므로(별도 기록) 재려면 **CI 산출물이 필요하다.**
+
+현재 인용 가능한 유일한 숫자는 소스 주석이다.
+
+> `// WASM (~12 MB) is kept out of precache ...` — `rhwp-studio/vite.config.ts:132`
+
+**이건 근거가 아니라 흔적이다.** 언제 잰 것인지, release 인지, wasm-opt 후인지,
+gzip 전인지 알 수 없다. 설계 문서에서 이 숫자를 예산의 기준으로 쓰면 안 된다.
+
+측정 절차(제안):
+
+```bash
+wasm-pack build --target web --release
+ls -la pkg/rhwp_bg.wasm                    # 원본
+gzip -c pkg/rhwp_bg.wasm | wc -c           # gzip 전송량
+brotli -c pkg/rhwp_bg.wasm | wc -c         # brotli 전송량 (Pages 기본)
+```
+
+**세 숫자를 다 재야 한다.** 사용자가 실제로 내려받는 것은 압축본이고, 메모리에
+올라가는 것은 원본이다. 하나만 적으면 다른 하나로 오해받는다.
+
+### 2.3 폰트 22 MB — 진짜 큰 것
+
+`assets/fonts` 는 22 MB 다(`du -sh`). 개별 최대치:
+
+```
+1579172  D2Coding-Bold.woff2
+1485508  D2Coding-Regular.woff2
+ 765684  Cafe24Supermagic-Regular-v1.0.woff2
+ 613412  HappinessSansVF.woff2
+```
+
+`rhwp-studio/public/fonts` 는 `../../assets/fonts` 를 가리키는 링크 파일이다(18바이트).
+그리고 SW `globPatterns` 는 `woff|woff2|ttf|otf` 를 **포함**한다
+(`vite.config.ts:134`) — 즉 **폰트는 precache 대상**이다.
+
+> **`.wasm` 을 12 MB 로 가정하더라도, 폰트가 그보다 크다.**
+> 데모 페이지의 크기 예산은 WASM 이 아니라 폰트가 지배할 가능성이 높다.
+> 다만 vite 빌드가 실제로 몇 개를 번들에 포함시키는지는 **확인되지 않음** —
+> `dist/` 를 만들어 재지 않았다.
+
+### 2.4 예산 표
+
+| 구성요소 | 크기 | 출처 |
+| --- | --- | --- |
+| `rhwp.js` 글루 | 284,769 B | **실측** |
+| `rhwp_bg.wasm` | **미측정** | 주석 `~12 MB` (근거 아님) |
+| 폰트 전량 | 22 MB | **실측**(디렉터리 전체) |
+| 데모용 폰트 부분집합 | 미측정 | 서브셋 정책 없음 |
+| studio JS 번들 | 미측정 | `vite build` 미실행 |
+| 샘플 문서 1건 | 8,704~33,792 B | **실측**(§5.2) |
+| **합계** | **산출 불가** | — |
+
+**합계를 지어내지 않는다.** 두 항목이 비어 있으면 예산은 없는 것이다.
+
+### 2.5 최적화 여지 — wasm-opt 부재
+
+```
+$ grep -rn "wasm-opt" .github/workflows/ Dockerfile
+(결과 없음)
+```
+
+워크플로우 어디에도 명시적 `wasm-opt` 단계가 없다. `Cargo.toml` 에도
+`[package.metadata.wasm-pack]` 섹션이 없다(`grep` 확인). release 프로파일은
+`lto = true`(`Cargo.toml:179-180`)다.
+
+wasm-pack 이 release 빌드에서 wasm-opt 를 자동 실행하는지는 **확인되지 않음** —
+버전(0.15.0)의 기본 동작을 문서로 확인하지 않았다. 이걸 확정하는 것이
+크기 논의의 **선행 조건**이다.
+
+---
+
+## 3. 배포 형태 — 후보 4종
+
+### A. 단일 HTML 파일
+
+`.wasm` 을 base64 `data:` URI 로 인라인해 HTML 하나로 만든다.
+
+- 매력: 진짜 "파일 하나". 이메일·이슈에 첨부 가능.
+- 문제:
+  - base64 는 **약 4/3 로 부푼다.** 12 MB 가정 시 16 MB HTML.
+  - `wasm-pack --target web` 산출물은 `rhwp.js` + `rhwp_bg.wasm` **2파일 전제**이고
+    글루가 `fetch`/`instantiateStreaming` 경로를 쓴다. 인라인하려면 로더를 바꿔야 한다 —
+    **어느 정도 작업인지 확인되지 않음.**
+  - `instantiateStreaming` 을 못 쓰면 컴파일이 느려진다(측정 안 함).
+  - 폰트를 넣으면 파일이 감당 불가가 된다. 빼면 한글 렌더가 깨진다.
+
+**판정: 지금은 채택하지 않는다.** 재검토 조건은 §2 의 실측이 나온 뒤다.
+
+### B. 정적 사이트 (현행 GitHub Pages) — **채택**
+
+이미 돌고 있는 것(§1.1)에 데모 경로를 추가한다.
+
+- 장점: **추가 인프라 0.** brotli 압축·캐시·PWA·SW 가 이미 붙어 있다.
+  URL 하나만 주면 되므로 온보딩 마찰이 실질적으로 0 이다.
+- 단점: 첫 로드에 네트워크가 필요하다. 완전 오프라인 시작은 안 된다.
+
+### C. CDN 배포 (npm 패키지 → jsDelivr/unpkg)
+
+`@rhwp/editor` 는 이미 npm 에 나간다(`.github/workflows/npm-publish.yml`).
+
+- 장점: `<script type="module">` 한 줄로 남의 페이지에 붙는다. `@rhwp/editor` 의
+  iframe 임베드 모델과 잘 맞는다(`npm/editor/index.js`).
+- 단점:
+  - **제3자 origin 의존.** [browser_bridge.md §5](browser_bridge.md) 의 origin 경계
+    논의와 직접 충돌한다. 문서 내용이 CDN 이 서빙한 코드를 지나간다.
+  - CDN 이 죽으면 데모도 죽는다.
+  - 저장소는 이미 **외부 CDN 폰트 로드를 끌 수 있게** 만들어 뒀다(§4.3) — 즉
+    "외부 의존을 줄이자"는 방향이 이미 존재한다. C 는 그 방향의 반대다.
+
+**판정: 데모의 기본 경로로는 쓰지 않는다.** 임베드용 배포로는 유지한다.
+
+### D. 저장소 zip → `file:` 로 로컬 열기
+
+- 장점: 네트워크 없이 배포 가능(USB·사내망).
+- 문제: `file:` origin 은 불투명("null")이다. 그리고 embed 런타임은 **`"null"` origin 을
+  명시적으로 거부**한다(`protocol.ts:96` — `if (!origin || origin === 'null') return false`).
+  즉 **브리지가 동작하지 않는다.** SW 도 `file:` 에서 등록되지 않는다.
+
+**판정: 브리지 없는 단순 뷰어 데모로만 가능.** 에이전트 축에는 부적합.
+
+### 판정 요약
+
+| | A 단일 HTML | **B 정적 사이트** | C CDN | D file: |
+| --- | --- | --- | --- | --- |
+| 추가 인프라 | 없음 | **없음(현행)** | 없음 | 없음 |
+| 첫 로드 네트워크 | 필요 | 필요 | 필요 | 불필요 |
+| 브리지 동작 | ○ | **○** | ○ | **✗** |
+| 제3자 의존 | 없음 | 없음 | **있음** | 없음 |
+| 구현 미지수 | **큼** | 없음 | 작음 | 없음 |
+| SW 오프라인 | ✗ | **○** | ○ | ✗ |
+
+**B 를 채택한다.** A 는 §2 실측 후 재검토, C 는 임베드 전용, D 는 뷰어 전용.
+
+---
+
+## 4. 오프라인 동작
+
+### 4.1 지금 성립하는 오프라인의 정확한 범위
+
+- SW 는 `autoUpdate` 로 등록된다(`vite.config.ts:100`).
+- `js/css/html/png/svg/ico/woff/woff2/ttf/otf` 는 **precache** 된다(134행).
+- `.wasm` 은 precache 되지 **않고**, 런타임 CacheFirst 로만 잡힌다(136-145행).
+
+따라서:
+
+> **첫 방문 이후에만 오프라인이다.** 그리고 첫 방문에서 `.wasm` 이 실제로 요청됐어야
+> 한다 — 문서를 한 번도 열지 않고 나가면 캐시에 안 들어갈 수 있다. **확인되지 않음** —
+> 스튜디오가 초기화 시점에 항상 WASM 을 받는지 대조하지 않았다
+> (`wasm-bridge.ts:259` 의 `await init()` 호출 시점 확인 필요).
+
+### 4.2 검증은 빌드본에서만 가능
+
+`devOptions.enabled: false`(`vite.config.ts:147-149`) 때문에 `npm run dev` 에서는
+SW 가 돌지 않는다. 오프라인 검증 절차:
+
+```bash
+cd rhwp-studio && npx vite build && npx vite preview
+# 브라우저 DevTools → Application → Service Workers → Offline 체크 → 새로고침
+```
+
+### 4.3 외부 폰트 CDN — 데모에서 반드시 꺼야 한다
+
+`rhwp-studio/src/core/font-loader.ts:41-43` 에 **jsDelivr 절대 URL 셋**이 있다.
+
+```
+https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2104@1.0/HANBatang.woff
+https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2104@1.0/HANBatangB.woff
+https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_four@1.0/HCRDotum.woff
+```
+
+끄는 스위치가 **이미 있다** — `vite.config.ts:17-21`:
+
+```ts
+__RHWP_DISABLE_EXTERNAL_WEBFONTS__: JSON.stringify(
+  process.env.RHWP_DISABLE_EXTERNAL_WEBFONTS === '1',
+),
+```
+
+주석: "셀프 호스팅 빌드에서 외부(CDN) 웹폰트 로드를 빌드 시점에 끈다."
+
+**오프라인 데모 빌드는 `RHWP_DISABLE_EXTERNAL_WEBFONTS=1` 로 만든다.** 안 그러면
+오프라인에서 폰트 요청이 실패하고, 더 중요하게는 **제3자에게 요청이 나간다** —
+문서를 보는 행위가 외부에 관측된다. 이건 성능 문제가 아니라 **경계 문제**다
+([browser_bridge.md §5.2](browser_bridge.md)).
+
+### 4.4 CSP
+
+확장 페이지는 `script-src 'self' 'wasm-unsafe-eval'` 을 명시한다
+(`rhwp-chrome/manifest.json:43`, `rhwp-firefox/manifest.json:52`).
+데모 페이지도 같은 제약을 전제로 쓴다 — **인라인 스크립트 금지**.
+studio `index.html:8-10` 이 이미 그 규칙을 따르며 이유를 주석에 남긴다.
+
+이 제약은 §3-A(단일 HTML)에 또 하나의 벽이다. 인라인 `data:` 로더는 CSP 와 싸운다.
+
+---
+
+## 5. 데모 페이지 설계
+
+### 5.1 무엇을 보여주나 — 렌더가 아니라 동사
+
+기존 studio 는 **문서를 예쁘게 보여주는 것**을 시연한다. 데모 페이지는 다르다.
+#3869 의 주장 — "이해도 실행도 아니다. 시작이다" — 을 화면으로 옮긴다.
+
+보여줄 것(우선순위 순):
+
+1. **자기서술** — `capabilities()` 결과를 첫 화면에 그대로. "이 모듈이 할 수 있는 일"
+   ([self_description.md §4.1](self_description.md)).
+2. **`digest`** — #3869 §0 이 인용하는 실측(393쪽 문서 1,375 B vs `export-text`
+   645,108 B)을 **브라우저에서 재현**. 이 대비가 이 축의 핵심 주장이다.
+3. **`fields` → `fill` → `verify`** — 양식 왕복. `exportHwpVerify` 는 **이미 WASM 에
+   있다**(`wasm_api.rs:5733`).
+4. **`search` / `extract-data`** — 주소(구역·문단·페이지·오프셋)가 붙은 결과.
+5. **`inspect`** — 출처 표지가 왜 필요한지 보여주는 자리
+   ([../agent_security/threat_model.md](../agent_security/threat_model.md)).
+
+**1·3·4 의 일부는 지금 WASM 에 이미 있다.** 2·5 는 자기서술 조각 S5 이후에 가능하다.
+
+### 5.2 번들 샘플 — 실측 크기
+
+`rhwp-studio/public/samples/` 에 이미 문서가 실려 나간다(실측):
+
+```
+  8704  shift-return.hwp
+ 16384  para-head-num-2.hwp
+ 16896  oullim-01.hwp
+ 24576  BlogForm_BookReview.hwp
+ 33792  biz_plan.hwp
+131571  form-002.hwpx
+514560  field-01.hwp
+```
+
+데모 기본 문서는 **`biz_plan.hwp`(33,792 B)** 또는 양식 시연용 **`form-002.hwpx`
+(131,571 B)** 가 적당하다. `field-01.hwp`(514,560 B)는 누름틀이 많지만 무겁다.
+
+**파일 업로드 없이도 1클릭으로 동작해야 한다.** 사용자가 자기 HWP 를 찾아 올리는
+순간 "설치 0"의 마찰 감소가 절반 사라진다.
+
+### 5.3 3단계 시나리오
+
+| 단계 | 사용자 행동 | 보여주는 것 | 필요 조각 |
+| --- | --- | --- | --- |
+| 0초 | URL 열기 | `capabilities()` 목록 | 자기서술 S3 |
+| 5초 | "예제 열기" 1클릭 | `digest` 봉투 (수 KB) | S5 |
+| 15초 | 필드 채우기 | `fields`→`fill`→`verify` 왕복 | 이미 대부분 존재 |
+| — | "내 에이전트에 붙이기" | 브리지 스니펫 | [browser_bridge.md](browser_bridge.md) B3 |
+
+마지막 줄이 온보딩의 목적이다. 데모는 장난감이 아니라 **진입점**이다.
+
+### 5.4 봉투를 화면에 그대로 보여준다
+
+가공된 UI 카드가 아니라 **JSON 봉투 원문**을 보여준다. 이유:
+
+- 소비자는 에이전트다. 사람용 요약은 그들이 볼 것이 아니다.
+- `untrustedContent`/`untrustedFields` 표지가 **눈에 보여야** 소비자가 그 존재를 안다
+  ([self_description.md §4.4](self_description.md)).
+- CLI 출력과 나란히 두면 **동등성이 시각적으로 검증**된다(#3869 W2).
+
+---
+
+## 6. 이 문서가 다루지 않는 것
+
+#3869 는 W3(Python 휠)·W4(npm 패키지)로 **브라우저 밖 설치 0**도 요구한다.
+
+```
+pip install rhwp    # 바이너리 없음. WASM 이 휠 안에 들어 있다
+npm install rhwp    # 동일
+```
+
+**이 문서는 그 축을 다루지 않는다.** 브라우저 데모와 휠 패키징은 요구가 다르다
+(전자는 UI·오프라인·origin, 후자는 런타임 임베딩·ABI). 다만 **자기서술은 공유한다** —
+휠 안의 WASM 도 같은 `capabilities()` 를 돌려줘야 한다
+([self_description.md §5.1](self_description.md)).
+
+기존 바인딩(서브프로세스 경로)과의 관계 정리는 #3869 W5 이며,
+[../bindings_foundation.md](../bindings_foundation.md) 가 그 판단표의 자리다.
+
+---
+
+## 7. 조각 분해
+
+| # | 조각 | 선행 | 검증 |
+| --- | --- | --- | --- |
+| Z1 | **`.wasm` 크기 실측** (원본·gzip·brotli) | 없음 | CI 로그에 숫자가 남는다 |
+| Z2 | wasm-pack 0.15.0 의 wasm-opt 기본 동작 확정 | 없음 | 문서·로그 |
+| Z3 | 오프라인 실검증 (`vite build` + SW Offline) | 없음 | 재현 절차 기록 |
+| Z4 | 데모 라우트 추가 (`/rhwp/demo/`) | 자기서술 S3 | 첫 화면에 `capabilities()` |
+| Z5 | `RHWP_DISABLE_EXTERNAL_WEBFONTS=1` 데모 빌드 | Z3 | 네트워크 탭에 외부 요청 0 |
+| Z6 | 1클릭 예제 문서 배선 | Z4 | 업로드 없이 동작 |
+| Z7 | `digest` 대비 시연 | 자기서술 S5 | 봉투 크기 실측 표기 |
+| Z8 | "에이전트에 붙이기" 스니펫 | 브리지 B3 | 복사→동작 |
+
+**Z1 이 첫 조각이다.** 크기를 모르면 §3 의 판정을 재검토할 수도 없고,
+20 MB SW 상한(`vite.config.ts:135`)에 걸리는지도 모른다.
+
+---
+
+## 8. 확인되지 않음
+
+1. **`rhwp_bg.wasm` 크기 (원본·gzip·brotli)** — 이 축 전체에서 가장 큰 공백.
+2. **wasm-pack 0.15.0 release 빌드의 wasm-opt 기본 동작** (§2.5).
+3. **vite 빌드가 실제로 번들하는 폰트 집합** — 22 MB 전량인지 부분인지 미확인.
+4. **초기화 시 `.wasm` 이 항상 요청되는가** — SW 런타임 캐시 진입 조건(§4.1).
+5. **`data:` URI 인라인 로더의 작업량** — `wasm-pack --target web` 글루 수정 범위(§3-A).
+6. **`file:` 에서 뷰어만이라도 도는가** — SW·모듈 스크립트 제약 미검증(§3-D).
+7. **첫 로드 시간·WASM 컴파일 시간** — 측정하지 않았다. **이 문서에 성능 수치가
+   하나도 없는 이유다.**
+
+---
+
+## 9. 관련 문서
+
+- [README.md](README.md) — 이 축의 지도
+- [self_description.md](self_description.md) — 데모 첫 화면이 보여줄 것
+- [browser_bridge.md](browser_bridge.md) — "에이전트에 붙이기"의 실체
+- [../wasm_pack_version_policy.md](../wasm_pack_version_policy.md) — 툴체인 고정
+- [../bindings_foundation.md](../bindings_foundation.md) — 진입로 판단표(M18~M20, W5)
+- [../agent_security/threat_model.md](../agent_security/threat_model.md) — 데모에서
+  `inspect` 를 보여줘야 하는 이유
+- [../agent_security/consumer_guide.md](../agent_security/consumer_guide.md) — 붙인 다음의 책임
+- 이슈 [#3608](https://github.com/edwardkim/rhwp/issues/3608) M24 ·
+  [#3869](https://github.com/edwardkim/rhwp/issues/3869) §1·W3~W6


### PR DESCRIPTION
로드맵 #3608 **M24 "WASM/브라우저 에이전트 표면"** 의 미완 3항목을 설계 문서로 고정한다.
관련 이슈 #3869(설치 없는 실행)와 같은 축이라 정렬했다.

| 문서 | 줄 | kind |
|---|---:|---|
| `self_description.md` — WASM capabilities 자기서술 | 498 | canonical |
| `browser_bridge.md` — 브라우저 내 MCP-유사 브리지 | 509 | canonical |
| `zero_install_onboarding.md` — 설치 0 온보딩 | 465 | guide |
| `README.md` — 축 지도 | 159 | guide |

`mydocs/tech/README.md` 권위 표에 등재(고아 디렉터리 방지). 상호 링크 **깨진 것 0건**.

## 조사에서 나온 핵심 — M24 는 "기능 추가"가 아니다

`wasm_api.rs` 는 **7,621줄, `js_name` 360개**다. 에이전트 동사 중 이미 있는 것과 없는 것을
전수로 갈랐다.

**있다**: `getDocumentInfo` · `getStructure(mode)`(CLI 와 `auto|outline|clause` 어휘 동일) ·
`searchText`/`searchAllText` · `getFieldList`/`setFieldValue`(= fill-fields) ·
`replaceOne`/`replaceAll` · `exportHwp`/`exportHwpx`/`exportHwpVerify` · `extractThumbnail`

**없다**: `digest` · `extract-data` · `export-tables`(격자) · `table-to-csv` · `inspect` 3종 ·
`redact`/`sanitize` · `run`(계획) · **`capabilities` 자기서술 일체**

```
$ grep -cE "text_security|inspect|extract_data|digest|export_tables|untrustedContent" src/wasm_api.rs
0
```

### 그런데 없는 이유가 기능 부족이 아니다 — 크레이트 경계다

로직은 **이미 lib 에 있다**: `queries/extract_data.rs` **1,251줄** ·
`injection_scan.rs` **1,467줄** · `hidden_text.rs` **1,117줄**.
없는 건 **봉투를 만드는 층**이고 그게 bin 전용이다 —
`capabilities_command_entries()`(`main.rs:1463`), `mcp_serve.rs`, `agent_profiles.rs`.

게다가 `capabilities_schema.rs`·`ir_schema.rs`·`provenance.rs` 는 **lib 인데 `wasm_bindgen` 0곳**이다.

**즉 M24 는 "새 기능을 만드는 일"이 아니라 "봉투 층을 bin 에서 lib 으로 내리는 일"이다.**
이 판단이 이후 조각의 크기와 순서를 바꾼다.

## studio 실측 — 브리지 설계의 전제

`wasm-bridge.ts`(3,013줄)가 **메인 스레드**에서 `init()`. `grep "new Worker" rhwp-studio/src` → **0건**.
그 위 `embed/` 가 `MessageChannel` RPC + 버전·capability 협상 + **첫 origin 고정**
(`runtime.ts:130-133`)을 이미 한다. 다만 노출 메서드는 **11개뿐이고 전부 뷰어/내보내기
축, 에이전트 동사 0개**다.

`hwpctl/action-registry.ts` 주석은 "312개"라고 하지만 **실제 등록은 30개, 전부
`executor: null`** 이다 — 주석을 믿지 않고 세어서 적었다.

## 보안 — 브라우저가 더하는 origin 경계

문서 내용이 나가는 지점은 `runtime.ts:23-30`·`110` **두 곳뿐**이고 수신 origin 은 첫 연결에
고정된다. 이 불변식을 보존 대상으로 지정하고, `targetOrigin: "*"` 금지 ·
`tools/list` 에 문서 내용 금지 · **판정(`inspect`)과 출처 표지 없이 브리지를 먼저 열지 말 것**을
#3787 위협 모델과 연결했다.

오프라인 데모는 `RHWP_DISABLE_EXTERNAL_WEBFONTS=1` 이 필수다 —
`font-loader.ts:41-43` 의 jsDelivr 3개가 관측 경로가 된다.

## 쓰지 않은 것

**번들 크기를 한 줄도 쓰지 않았다.** `.gitignore:12` 가 `*.wasm` 을 빼서 트리에 산출물이 없고,
유일한 숫자 `~12 MB` 는 `vite.config.ts:132` **소스 주석**일 뿐이라 예산 근거로 못 쓴다.
실측된 것만 적었다 — `rhwp.js` 글루 **284,769 B**, `assets/fonts` **22 MB**
(폰트가 WASM 보다 클 가능성).

**성능 수치도 한 줄도 쓰지 않았다.** 측정하지 않았기 때문이다.

그 밖에 "확인되지 않음"으로 남긴 것: wasm-opt 기본 동작, `queries/` 일부의 wasm32 컴파일
가능성(`std::fs` 참조), `RPC_ERROR` 메시지의 문서 텍스트 유출 여부, `file:`·확장
background 에서의 브리지 성립.
