### PR TITLE
fix(render): HWP5 원본에서 내보낸 HWPX 도 저장 줄 시작을 권위로 — 왕복만으로 줄이 302px 밀리던 축 (#3837)

### DIFF
--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -3178,7 +3178,12 @@ impl LayoutEngine {
                 && !uses_stored_segment_geometry
                 && composed.numbering_text.is_none()
                 && para.map(|p| p.controls.is_empty()).unwrap_or(false)
-                && profile.native_hwp5_layout();
+                // [#3837] rhwp 가 HWP5 원본에서 내보낸 HWPX 도 같은 계약이다 — 저장
+                // LINE_SEG 가 그 HWP5 의 것이라 `column_start` 가 여전히 권위다. 이 조건이
+                // 없으면 왕복만으로 들여쓴 줄이 왼쪽으로 밀린다(1370000-200800015: 저장
+                // cs=22677 = 302.4px 가 무시돼 글리프 595개가 그만큼 이동).
+                // 원본 HWPX 는 건드리지 않는다 — 그쪽 저장 계약은 별개 축이다.
+                && (profile.native_hwp5_layout() || profile.hwp5_origin_hwpx());
             // 암호 HWP3의 Square-wrap Picture/Shape 저장 cs/sw는 문단 좌·우 inset까지
             // 포함한 완성 line box다. 여기서 ParaShape margin을 다시 더하거나 빼면
             // 그림과 글자 사이에 여백이 한 번 더 생기고 right edge도 불필요하게 줄어든다.

--- a/tools/glyph_roundtrip_compare.py
+++ b/tools/glyph_roundtrip_compare.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+"""#3837 — 왕복(HWP5→HWPX) 전후의 글리프를 좌표까지 대조한다.
+
+`export-hwpx --verify` 의 IR 차이 31% 는 대부분 표현 차이라 렌더에 안 나타난다. 실제로
+사용자가 겪는 것만 골라내려면 **렌더 글리프**를 봐야 한다. 문서를 SVG 로 전량 내보낸 뒤
+`<text>` 마다 (x, y, font-family, font-size, 글자)를 뽑아 쪽 단위로 대조한다.
+
+사용:
+  python tools/glyph_roundtrip_compare.py SRC RT [--exe target/debug/rhwp.exe]
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections import Counter
+
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+TEXT = re.compile(r"<text\b([^>]*)>(.*?)</text>", re.S)
+ATTR = re.compile(r'([a-zA-Z-]+)="([^"]*)"')
+PAGENUM = re.compile(r"(\d+)")
+
+
+def render(exe: str, path: str, out_dir: str) -> dict[int, list[tuple]]:
+    os.makedirs(out_dir, exist_ok=True)
+    subprocess.run([exe, "export-svg", path, "-o", out_dir], capture_output=True,
+                   text=True, encoding="utf-8", errors="replace", timeout=1800)
+    # 쪽 키는 **파일 순서**로 만든다. 파일명에서 숫자를 뽑으면 단일 쪽 문서(쪽번호 접미사가
+    # 없다)에서 문서 제목 속 숫자를 쪽번호로 오독해, 두 산출물의 쪽이 어긋나 전량 불일치로
+    # 보인다(20160897 "[별지 제11호서식]" → 11쪽으로 오독).
+    pages: dict[int, list[tuple]] = {}
+    files = sorted(glob.glob(os.path.join(out_dir, "*.svg")),
+                   key=lambda p: [int(t) if t.isdigit() else t
+                                  for t in re.split(r"(\d+)", os.path.basename(p))])
+    for pg, f in enumerate(files, start=1):
+        svg = open(f, encoding="utf-8", errors="replace").read()
+        res = []
+        for m in TEXT.finditer(svg):
+            a = dict(ATTR.findall(m.group(1)))
+            body = re.sub(r"<[^>]*>", "", m.group(2))
+            res.append((round(float(a.get("x", 0) or 0), 1),
+                        round(float(a.get("y", 0) or 0), 1),
+                        a.get("font-family", ""), a.get("font-size", ""), body))
+        pages[pg] = res
+    return pages
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("src")
+    ap.add_argument("rt")
+    ap.add_argument("--exe", default="target/debug/rhwp.exe")
+    ap.add_argument("--show", type=int, default=8)
+    a = ap.parse_args()
+    exe = os.path.abspath(a.exe)
+
+    with tempfile.TemporaryDirectory() as td:
+        gs = render(exe, a.src, os.path.join(td, "src"))
+        gr = render(exe, a.rt, os.path.join(td, "rt"))
+    print(f"쪽수  원본 {len(gs)} · 왕복 {len(gr)}")
+
+    total = diff = shown = 0
+    kinds = Counter()
+    bad_pages = Counter()
+    for pg in sorted(set(gs) | set(gr)):
+        s, r = gs.get(pg, []), gr.get(pg, [])
+        total += max(len(s), len(r))
+        for i in range(max(len(s), len(r))):
+            x = s[i] if i < len(s) else None
+            y = r[i] if i < len(r) else None
+            if x == y:
+                continue
+            diff += 1
+            bad_pages[pg] += 1
+            if x and y:
+                if x[4] != y[4]:
+                    kinds["글자"] += 1
+                elif x[2] != y[2] or x[3] != y[3]:
+                    kinds["폰트"] += 1
+                elif x[1] != y[1]:
+                    kinds["y"] += 1
+                else:
+                    kinds["x"] += 1
+            else:
+                kinds["개수"] += 1
+            if shown < a.show:
+                print(f"  p{pg} #{i}\n    src {x}\n    rt  {y}")
+                shown += 1
+    pct = 100.0 * diff / total if total else 0
+    print(f"글리프 {total} · 다름 {diff} ({pct:.2f}%)")
+    print("종류:", dict(kinds))
+    print("어긋난 쪽 상위:", bad_pages.most_common(6))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 무엇을 고치나

rhwp 가 HWP5 를 HWPX 로 내보낸 뒤 **그 산출물을 렌더하면 들여 시작하던 줄이 왼쪽 끝으로
밀립니다.** 저장 `LINE_SEG` 의 `column_start` 를 권위로 쓰는 분기가
`native_hwp5_layout` 프로필에만 열려 있어서입니다.

```rust
// src/renderer/layout/paragraph_layout.rs
let hwp5_stored_line_start_eligible = …
    && profile.native_hwp5_layout();          // ← HWPX 컨테이너면 닫힌다
```

그 산출물의 저장 `LINE_SEG` 는 **원본 HWP5 의 것**이라 `column_start` 는 여전히
권위입니다. 프로필에 이미 있는 `hwp5_origin_hwpx`(`META-INF/rhwp-hwp5-origin` 마커)를
조건에 더합니다.

**원본 HWPX 는 건드리지 않습니다.** 그쪽 저장 계약은 별개 축(#1836·#1880·#1770)이고,
값 통일 시도가 두 번 반증된 자리입니다. 이 변경이 닿는 모집단은 **rhwp 자신이 HWP5 에서
만든 HWPX 뿐**입니다.

## 재현과 측정

`1370000-200800015_D0150004-2-001 지자체 간판정비사업 실태조사` (59쪽 HWP5). 문제 문단은
그림 옆으로 흐르는 줄이라 저장 `cs=22677`(=302.4px)을 갖습니다.

```
src (415.7, 192.5, '한양신명조', 14.67, '2')
rt  (113.4, 192.5, '한양신명조', 14.67, '2')     ← y·글자·폰트·크기 동일, x 만 302px 이동
```

| 게이트 | 결과 |
|---|---|
| 그 문서 글리프 대조 | 28,625개 중 다름 **595 → 55** (2.08% → 0.19%) |
| 남은 55개 | 0.4px 안팎, 같은 글자·폰트·크기·y — **별개 축**입니다 |
| 어긋난 쪽 | 9·10·11·12쪽(540개)이 **전부 사라짐** |
| 무작위 HWP5 8건 왕복 대조 | 수정 전/후 **모두 다름 0** — 회귀 없음 |
| 전체 nextest | **4,979/4,979 통과** |

## 하니스

`tools/glyph_roundtrip_compare.py` 로 승격합니다. 왕복 전후 SVG 글리프를
`(x, y, 폰트, 크기, 글자)` 까지 대조해, #3837 의 **IR 차이 31% 중 렌더에 실제로 나타나는
것만** 골라냅니다(COM 불필요).

```
python tools/glyph_roundtrip_compare.py 원본.hwp 왕복.hwpx
```

측정 중 하니스 함정 하나를 고쳐 넣었습니다 — 쪽 키를 파일명 숫자로 뽑으면 단일 쪽 문서에서
제목 속 숫자(`[별지 제11호서식]`)를 쪽번호로 오독해 **전량 불일치로 보입니다.** 파일 순서로
바꿨습니다.

## 표본을 못 넣은 이유

저장소 샘플 **700KB 이하 25건을 전수 스캔**했지만 이 경로를 타는 것이 없었습니다. 재현본은
81MB 라 넣지 못했고(4쪽만 추출해도 81MB — 이미지가 남습니다), 한글로 최소 표본을 만들려면
**어울림 감싸기 그림**이 필요해 이번에는 접었습니다. 대신 하니스와 위 측정으로 재현
경로를 남깁니다.

Refs #3837
