### PR TITLE
[M21] 퍼징 운영 문서 4편 — 인프라는 있는데 CI 에서 안 돌고 있었다

### DIFF
--- a/mydocs/tech/fuzzing/README.md
+++ b/mydocs/tech/fuzzing/README.md
@@ -1,0 +1,170 @@
+---
+kind: guide
+status: active
+canonical: mydocs/tech/fuzzing/agent_surface_robustness.md
+last_verified: 2026-08-03
+---
+
+# 퍼징·견고성 문서 지도
+
+`mydocs/tech/fuzzing/` 은 rhwp 의 **퍼징 인프라를 어떻게 운영하는가**를 다룬다.
+로드맵 [#3608](https://github.com/edwardkim/rhwp/issues/3608) **M21 — 퍼징·견고성**의
+운영 문서이고, 근거가 되는 RFC 는 [#3141](https://github.com/edwardkim/rhwp/issues/3141) 이다.
+
+> **이 묶음은 새 인프라를 제안하지 않는다.** 퍼징 인프라는 **이미 저장소에 있다**
+> (`fuzz/`, 커밋 `e78883617`·`2b87440ea`). 이 문서들은 그것을 **돌리고, 나온 것을
+> 처리하고, 에이전트 표면 계약과 연결하는 방법**을 적는다.
+
+이 묶음의 모든 기술 주장에는 **코드 경로(`파일:줄`)·커밋 해시·실제 명령 출력**이 붙는다.
+근거를 대지 못한 항목은 **"확인되지 않음"** 으로 적었다.
+
+---
+
+## 1. 지금 있는 것 — 실측 (2026-08-03, `rhwp v0.8.2`, HEAD `9095cd52d`)
+
+### 1-1. 하네스 6개
+
+`fuzz/Cargo.toml` 의 `[[bin]]` 6개, `fuzz/fuzz_targets/*.rs` 6개 (`ls fuzz/fuzz_targets/` 실측).
+
+| 타깃 | 겨냥하는 진입점 | 층 |
+| --- | --- | --- |
+| `parse_hwp` | `rhwp::parser::parse_hwp(&[u8])` — HWP 5.x, CFB 컨테이너 | 포맷 최상위 |
+| `parse_hwp3` | `rhwp::parser::hwp3::parse_hwp3(&[u8])` — HWP 3.x 바이너리 | 포맷 최상위 |
+| `parse_hwpx` | `rhwp::parser::hwpx::parse_hwpx(&[u8])` — HWPX, ZIP 컨테이너 | 포맷 최상위 |
+| `parse_hml` | `rhwp::parser::hml::parse_hml(&[u8])` — HML, XML | 포맷 최상위 |
+| `parse_wmf` | `WMFConverter::new(data, SVGPlayer::new()).run()` | 임베드 이미지 |
+| `parse_ooxml_chart` | `rhwp::ooxml_chart::parser::parse_chart_xml(&[u8])` | 임베드 차트 |
+
+6개 전부 `let _ = parse_xxx(data);` 형태다 — `Err` 반환은 **정상**이고, 검출 대상은
+패닉·abort·OOM·타임아웃뿐이다(각 하네스 파일 상단 주석).
+
+### 1-2. 시드 코퍼스 12개 (269KB)
+
+`fuzz/corpus/<타깃>/` 실측: `parse_hwp` 3 · `parse_hwp3` 2 · `parse_hwpx` 3 ·
+`parse_hml` 2 · `parse_wmf` 1 · `parse_ooxml_chart` 1. 출처와 확장 방법은
+[operations.md §3](operations.md) 참조.
+
+### 1-3. 도입 이력
+
+| 단계 | 커밋 | 무엇 |
+| --- | --- | --- |
+| 1단계 (#3158) | `e78883617` (2026-07-24) | `fuzz/` 독립 크레이트 + 하네스 4개 + 시드 10개 + `fuzz/README.md` |
+| 2단계 (#3273→#3275) | `2b87440ea` (2026-07-25) | `parse_wmf`·`parse_ooxml_chart` 하네스 2개 + 합성 시드 2개 |
+
+`fuzz/Cargo.toml` 의 `[workspace] members = ["."]` 로 루트 워크스페이스에서 분리돼 있어
+본 크레이트의 빌드·`cargo test` 에 영향이 없다(`fuzz/Cargo.toml` 15~17행).
+
+---
+
+## 2. RFC #3141 의 계획 대비 어디까지 왔나
+
+RFC 6장이 정한 6단계와 7장(OSS-Fuzz)의 현재 상태다.
+
+| RFC 항목 | 상태 | 근거 |
+| --- | --- | --- |
+| ① `cargo fuzz init` 스캐폴드 | **완료** | `fuzz/` 존재, 커밋 `e78883617` |
+| ② 1순위 하네스 4개 | **완료** | `fuzz/fuzz_targets/parse_{hwp,hwp3,hwpx,hml}.rs` |
+| ③ 시드 코퍼스 | **완료** | `fuzz/corpus/` 12개 |
+| ④ `-rss_limit_mb=2048 -timeout=30` 기본 | **문서화 완료** | `fuzz/README.md` §권장 플래그 |
+| ⑤ CI 스모크 퍼징 | **미착수** | `.github/workflows/` 12개 파일 전수 grep 결과 `fuzz` 0건 |
+| ⑥ 2순위 내부 파서 하네스 | **부분** — WMF·OOXML 차트만. `parse_body_text_section`·`parse_doc_info`·`parse_control`·EMF 없음 | `fuzz/Cargo.toml` `[[bin]]` 6개 |
+| ⑦ OSS-Fuzz 등재 | **확인되지 않음** | 저장소에 `project.yaml`·`build.sh` 없음. 신청 여부는 이 저장소에서 확인 불가 |
+| ⑧ `fuzz/regressions/<타깃>/` | **미생성** | `ls fuzz/regressions` → `No such file or directory` |
+
+메인테이너 확인 (#3141 코멘트 2건):
+- "1단계 구현 #3158 이 devel `e78883617e` 로 merge … 이 이슈는 2단계 이후 진행을 위해 열어 둡니다"
+- "2단계 … `2b87440ea9` 로 merge … 로드맵 잔여: EMF 등 내부 파서 직접 하네스, CI 통합, OSS-Fuzz 등재"
+
+### 현황판 드리프트 — 고쳐야 할 것
+
+로드맵 #3608 §8 의 M21 체크리스트는 **네 항목 모두 미체크**다.
+
+```
+### M21 — 퍼징·견고성 (#3141 RFC 실행)
+- [ ] cargo-fuzz 타깃 4종(HWP5/HWP3/HWPX/HML 파서)
+- [ ] 크래시 코퍼스 회귀 스위트 편입
+- [ ] OSS-Fuzz 등재 신청
+- [ ] 발견 결함의 이슈→수정 파이프라인 실적 공개
+```
+
+그런데 첫 항목은 `e78883617`(4종) + `2b87440ea`(총 6종)로 **이미 머지됐다**.
+#3608 본문이 "체크 = 머지 · 진행률의 유일 기준"이라고 선언하므로, 이 어긋남은
+진행률을 실제보다 낮게 보이게 한다. **현황판 갱신이 M21 의 첫 작업이다.**
+
+---
+
+## 3. 이 묶음의 문서 4개
+
+| 문서 | 무엇을 답하나 |
+| --- | --- |
+| **README.md** (이 문서) | 지금 뭐가 있고 RFC 대비 어디까지 왔나 |
+| [operations.md](operations.md) | **어떻게 돌리나** — 명령·플래그·코퍼스·시간 예산·CI·이 PC 실측 |
+| [crash_triage.md](crash_triage.md) | **나왔을 때 어떻게 하나** — 최소화·재현·층 판별·회귀 테스트 승격 |
+| [agent_surface_robustness.md](agent_surface_robustness.md) | **안 죽는 것만으로 충분한가** — 봉투·exit·부분 결과 (이 묶음의 canonical) |
+
+읽는 순서: 처음이면 이 문서 → `operations.md`. 크래시를 손에 들고 있으면
+곧장 `crash_triage.md`. 왜 이 축이 에이전트 도구에서 특별한지는
+`agent_surface_robustness.md`.
+
+---
+
+## 4. 인접 축과의 경계 — 이 묶음이 다루지 않는 것
+
+[에이전트 보안 위협 모델](../agent_security/threat_model.md) §1.1 의 도식이 경계를 이미 그어 놓았다.
+
+```
+ ┌──────────────┐        ┌────────────────┐        ┌──────────────────┐
+ │  .hwp/.hwpx  │  ①    │  rhwp 프로세스  │  ②    │ 에이전트 컨텍스트 │
+ └──────────────┘ ─────▶ └────────────────┘ ─────▶ └──────────────────┘
+   신뢰 없음               메모리 안전                 지시로 읽힘
+                          (Rust, fuzz 대상)
+```
+
+- **① 파일 → rhwp** — **이 묶음의 주제.** threat_model.md 는 이 경계를 "메모리 안전은
+  Rust 와 `fuzz/` 하네스가 담당하며, **이 문서의 주제가 아니다**"라고 명시적으로 넘긴다.
+  넘겨받은 곳이 여기다.
+- **② rhwp → 에이전트 컨텍스트** — [agent_security/](../agent_security/README.md) 의 주제.
+  단, ①의 실패가 ②의 봉투로 어떻게 새어 나오는지는 경계가 겹친다 —
+  그 겹침이 [agent_surface_robustness.md](agent_surface_robustness.md) 다.
+
+| 축 | 다루는 실패 | 문서 |
+| --- | --- | --- |
+| 퍼징(이 묶음) | 패닉 · abort · OOM · 무한루프 | 여기 |
+| 에이전트 보안 | 문서가 에이전트를 조종함 | [agent_security/](../agent_security/README.md) |
+| 경계 무결성 | 경로·교정단서·자원한계·핸들 | [agent_boundary_contract.md](../agent_boundary_contract.md) |
+| 왕복 정합성 | 정상 입력의 1속성 소실 | #2740 (닫힘). 퍼징 대상 아님 — RFC #3141 §3 |
+
+---
+
+## 5. 확인되지 않음 (추측으로 채우지 않은 칸)
+
+| 항목 | 왜 확인 못 했나 | 확인하려면 |
+| --- | --- | --- |
+| `cargo +nightly fuzz build` 가 이 저장소에서 통과하는가 | nightly·cargo-fuzz 미설치, MSVC 링크 불가([operations.md §6](operations.md)) | Linux/macOS 또는 CI 에서 1회 실행 |
+| 누적 퍼징 실행 시간·발견 건수 | 저장소에 실행 기록 없음. `fuzz/artifacts/` 는 `.gitignore` 대상 | 실행 로그를 남기는 규약부터 정해야 함 |
+| OSS-Fuzz 등재 신청 여부 | 저장소 밖 정보 | `google/oss-fuzz` 저장소 검색, 메인테이너 확인 |
+| `fuzz/README.md` 의 Windows `rust-lld` 우회가 실제로 통하는가 | 이 PC 는 그 앞 단계(nightly 부재)에서 막힘 | Windows + nightly 환경에서 실측 |
+| 코퍼스 12개의 실제 커버리지 비율 | `cargo fuzz coverage` 미실행 | 퍼징 가능한 환경에서 측정 |
+
+---
+
+## 6. 이 문서를 다시 검증하는 법
+
+6개월 뒤 아래를 그대로 돌려 §1 표가 아직 참인지 확인한다.
+
+```sh
+ls fuzz/fuzz_targets/                       # 하네스 개수
+grep -c '^\[\[bin\]\]' fuzz/Cargo.toml      # 등록된 타깃 수 (일치해야 함)
+du -sh fuzz/corpus                          # 코퍼스 크기
+ls fuzz/regressions 2>/dev/null || echo "미생성"
+grep -ril fuzz .github/                     # CI 편입 여부 (0건이면 수동 전용)
+```
+
+`ls fuzz/fuzz_targets/` 개수와 `[[bin]]` 개수가 어긋나면 **어느 한쪽이 죽은 것**이다 —
+`[[bin]]` 이 없는 하네스는 빌드되지 않고, 파일 없는 `[[bin]]` 은 빌드를 깬다.
+
+## 관련
+
+- 로드맵: [#3608](https://github.com/edwardkim/rhwp/issues/3608) M21 · RFC: [#3141](https://github.com/edwardkim/rhwp/issues/3141)
+- 저장소 안 운영 문서: [`fuzz/README.md`](../../../fuzz/README.md) (실행 명령의 1차 출처)
+- 제보 경로: [`SECURITY.md`](../../../SECURITY.md) · [agent_security/disclosure.md](../agent_security/disclosure.md)

--- a/mydocs/tech/fuzzing/agent_surface_robustness.md
+++ b/mydocs/tech/fuzzing/agent_surface_robustness.md
@@ -1,0 +1,471 @@
+---
+kind: canonical
+status: active
+canonical: mydocs/tech/fuzzing/agent_surface_robustness.md
+last_verified: 2026-08-03
+---
+
+# 에이전트 표면의 견고성 — 안 죽는 것만으로는 부족하다
+
+> 퍼징은 "파서가 죽는가"를 묻는다. 그런데 rhwp 는 이제 **에이전트 도구**다.
+> 에이전트 표면에서는 죽지 않는 것만으로 부족하다 — **잘못된 봉투를 내면
+> 에이전트가 잘못된 판단을 한다.** 이 문서는 그 간극을 정의하고, 퍼징 자산을
+> 그 간극을 메우는 데 어떻게 쓸지 정한다.
+
+이 묶음의 canonical 문서다. 실행은 [operations.md](operations.md), 크래시 처리는
+[crash_triage.md](crash_triage.md), 지도는 [README.md](README.md).
+
+기준선: **2026-08-03**, `rhwp v0.8.2`, HEAD `9095cd52d`. 모든 주장에 코드 경로·테스트
+이름·커밋 해시를 붙였고, 대지 못한 것은 **"확인되지 않음"** 으로 적었다.
+
+---
+
+## 0. 이 문서가 정하는 것
+
+| 정한다 | 정하지 않는다 |
+| --- | --- |
+| 파싱 실패가 **exit code 와 봉투에 어떻게 나타나야 하는가** | 파서를 어떻게 고치는가 → [crash_triage.md](crash_triage.md) |
+| 손상 문서에서 **부분 결과를 참인 것처럼 내지 않는다**는 계약 | 문서 내용이 에이전트를 조종하는 경로 → [agent_security/](../agent_security/README.md) |
+| 퍼징 코퍼스를 **표면 계약 검증**에 쓰는 방법 | 인젝션 탐지 정책 → [detection_policy](../agent_security/detection_policy.md) |
+
+---
+
+## 1. 왜 "패닉 없음"이 충분하지 않은가
+
+### 1-1. 두 성공 판정이 다르다
+
+```
+   퍼징의 성공 판정            에이전트 표면의 성공 판정
+   ─────────────────           ────────────────────────────
+   프로세스가 살아 있다        봉투에 적힌 것이 참이다
+```
+
+하네스 6개는 전부 이렇게 생겼다.
+
+```rust
+fuzz_target!(|data: &[u8]| {
+    let _ = rhwp::parser::parse_hwp(data);
+});
+```
+— `fuzz/fuzz_targets/parse_hwp.rs`. `fuzz/README.md` 가 그 의도를 명시한다:
+"각 하네스는 `let _ = parse_xxx(data);` 형태로 **반환값을 무시**합니다."
+
+**반환값을 버리는 하네스는 반환값이 틀린 것을 볼 수 없다.** 이건 결함이 아니라
+설계다 — 퍼징의 일이 아니기 때문이다. 문제는 그 일을 **누구도 안 하고 있다**는 것이다.
+
+### 1-2. 실패 모드 세 가지
+
+| # | 모드 | 퍼저가 보나 | 에이전트에게 무슨 일이 | 예 |
+| --- | --- | --- | --- | --- |
+| **F1** | 죽는다 (패닉·abort·OOM·무한루프) | **본다** | 도구 호출이 exit 101 이나 무응답 → 판정 불능 | #3311 |
+| **F2** | 거짓으로 성공한다 | **못 본다** | `Ok` + 그럴듯한 봉투 → **에이전트가 사실로 받아들임** | #2743 "조용한 구간" |
+| **F3** | 성공했는데 봉투가 불완전하다 | **못 본다** | 부분 결과를 전부인 것으로 오인 → 거짓 통과 | 부분 목록 문제 |
+
+**F2 가 이 문서의 존재 이유다.** 그리고 F2 는 가설이 아니라 **이 저장소에서 실제로
+일어났던 일**이다. `tests/issue_2743_hml_resource_id_limit.rs` 주석:
+
+> "**조용한 구간**: `Id="1000000"` → 힙 최대 120,009,531 바이트를 쓰고도
+> `parse_hml` 이 **`Ok` 를 반환한다. 오류도 경고도 없어 호출자가 알 수 없다.**"
+
+382바이트짜리 파일이 120MB 를 먹고 **성공으로 끝났다.** `-rss_limit_mb=2048` 은
+2GB 를 안 넘었으니 크래시를 기록하지 않는다. 퍼저에게 이 입력은 **평범한 정상 입력**이다.
+
+같은 파일의 회귀 테스트가 그래서 `is_ok()` 를 단언하지 않고 **결과 테이블 길이와
+경고 개수**를 단언한다 — "그렇게 해야 수정 전에 red 가 된다"(테스트 주석).
+**이 발상이 그대로 에이전트 표면 계약의 원리다.**
+
+### 1-3. 그렇다고 퍼징이 덜 중요한 게 아니다 — 전제조건이다
+
+F1 이 남아 있으면 F2·F3 를 논할 수 없다. 패닉은 **exit 101** 로 끝나는데,
+그 코드는 [#2707 exit 사전](#2-1-exit-사전)에 **없다**. 사전에 없는 코드를 받은
+에이전트는 성공인지 실패인지, 재시도해도 되는지 판정할 수 없다.
+
+즉 순서는 이렇다: **퍼징이 F1 을 지우고 → 표면 계약이 F2·F3 를 지운다.**
+
+---
+
+## 2. 불변식 A — 파싱 실패는 exit code 와 봉투에 정확히 반영된다
+
+### 2-1. exit 사전
+
+[#3719](https://github.com/edwardkim/rhwp/issues/3719) §4 가 갱신한 사전(#2707 승계):
+
+| 코드 | 의미 |
+| --- | --- |
+| 0 | 성공 |
+| **1** | **런타임 실패 (읽기·파싱·렌더·쓰기)** ← 손상 문서가 오는 자리 |
+| 2 | 사용법 오류 — 인자 없음/미지 옵션·명령/범위 초과, 계획 선검증 위반 |
+| 3 | 검증 단언 실패 (`--verify` 계열) |
+| 4 | `--verify-pages` 페이지 수 불일치 |
+
+같은 §4 의 횡단 불변식 두 개가 이 축의 근거다.
+
+> 2. **판정은 데이터** — 봉투 필드가 1차, exit 코드는 그 파생. **둘이 모순되면 버그다.**
+> 6. **stdout 순수성** — 데이터만. 진단·진행·요약은 stderr.
+
+### 2-2. 실패 불변식 — "stdout 0바이트"
+
+파싱이 실패하면 stdout 은 **한 바이트도 나오지 않는다.** 부분 JSON 을 흘리면 소비자가
+잘린 객체를 파싱하려다 또 다른 오판을 한다.
+
+계약 테스트가 이미 이 불변식을 여러 표면에서 고정하고 있다(실측).
+
+| 테스트 | 무엇을 고정하나 |
+| --- | --- |
+| `tests/cli_json_contract.rs::info_json_missing_file_exit_runtime_and_silent_stdout` | exit **1** + `stdout.is_empty()` — "실패 시 stdout 에 부분 JSON 을 흘리지 않는다 — 소비자는 stdout 만 파싱한다" |
+| `tests/cli_json_contract.rs::info_json_multiple_files_exit_usage_silent_stdout` | exit **2** + stdout 0바이트 |
+| `tests/digest_macro_contract.rs::digest_missing_file_exit_runtime_silent_stdout` | digest 축 동형 |
+| `tests/digest_v2_contract.rs` (파일 주석) | "실패 시 stdout 0바이트, 종료 코드는 [#2707] 계약(0/1/2)" |
+| `tests/boundary_integrity_contract.rs:539` | "실패 경로 stdout 은 0바이트여야 합니다" |
+| `tests/capabilities_schema_contract.rs:351` | "알 수 없는 옵션은 사용법 오류(2), stdout 0바이트" |
+| `tests/batch_fill_contract.rs:1373` | "인자 오류에서 stdout 은 0바이트여야 합니다" |
+
+**그러나 이 테스트들은 전부 "없는 파일" 또는 "인자 오류"로 실패를 만든다.**
+`grep -rn "0바이트\|stdout.is_empty" tests/` 실측 결과, **손상된 문서 바이트로
+실패를 만드는 계약 테스트는 없다.** 없는 파일과 손상 파일은 다른 코드 경로다 —
+전자는 `fs::read` 에서, 후자는 파서 안에서 실패한다.
+
+이 공백이 §5 가 메우려는 것이다.
+
+### 2-3. 패닉이 이 불변식을 깨는 방식
+
+패닉이 나면:
+- exit 은 **101** — 사전에 없다.
+- stdout 은 그 시점까지 쓰인 것이 남는다 — `println!` 이 이미 실행됐다면 **부분 JSON 이
+  나간다.** stdout 0바이트 불변식이 깨진다.
+- stderr 에는 백트레이스가 나간다 — 에이전트가 이걸 "도구가 준 정보"로 읽는다.
+
+`tests/issue_cli_test_caption_no_panic.rs` 가 정확히 이 관점의 테스트다.
+
+```rust
+assert_ne!(code, Some(101),
+    "Rust panic(exit 101) 발생 — 범위 밖 인덱싱 회귀. stderr: {}", ...);
+```
+
+**패닉은 파서 문제이자 동시에 계약 위반이다.** 이게 퍼징 축과 에이전트 표면 축이
+만나는 정확한 지점이다.
+
+---
+
+## 3. 불변식 B — 부분 결과를 참인 것처럼 내지 않는다
+
+### 3-1. 원칙 — 부분 목록 금지
+
+#3719 §4 횡단 불변식 4: **"부분 목록 금지 — 확정 불가는 `null`. 부분 목록은
+침묵보다 나쁘다."**
+
+[detection_policy.md](../agent_security/detection_policy.md) §④ 가 이유를 표로 정리한다.
+
+| 응답 | 소비자가 읽는 것 | 실제 | 결과 |
+| --- | --- | --- | --- |
+| `null` | "모른다 — 전체를 보라" | 모름 | 안전 |
+| **부분 목록** | **"이게 전부다"** | 일부만 | **거짓 통과** |
+
+원문: "부분 목록은 **정밀한 척하는 것**이고, 정밀한 척은 소비자에게 '나머지는 안전'
+이라는 잘못된 [확신을 준다]."
+
+코드에도 같은 문장이 박혀 있다.
+
+- `src/document_core/queries/changed_pages.rs:17` — "없으면 None — **부분 목록 금지** (#3630 P3)"
+- `src/mcp_serve.rs:1011` — "대상 문단이 하나라도 조판 커버리지 밖이면 부분 목록 대신 `null`"
+- `src/main.rs:14105` — "확정 불가면 null(부분 목록 금지)"
+
+### 3-2. 지금 잘 되고 있는 것 — 절단은 봉투에 드러난다
+
+[agent_boundary_contract.md](../agent_boundary_contract.md) S7 이 "산출량에 상한을 걸 수
+있고, **절단은 반드시 봉투에 드러난다**"를 계약으로 세웠고, 봉투가 실제로 그렇다.
+
+`digest --sections` 봉투(`src/main.rs` ~7260):
+
+```json
+{
+  "schemaVersion": "1.0", "source": "...", "sectionCount": 12,
+  "sections": [ ... ],
+  "truncated": true,
+  "nextStep": "절 원문은 export-text --json -p <쪽>, 찾으려면 search --json"
+}
+```
+
+`truncated` 계산이 두 축을 모두 본다:
+
+```rust
+let truncated = any_truncated || section_count > sections.len();
+```
+
+— 개별 발췌가 잘렸거나(`any_truncated`), **절 자체가 빠졌으면**(`section_count >
+sections.len()`) `true`. 이게 §3-1 원칙의 구현이다.
+
+### 3-3. **실측 공백** — 손상 문서의 열화가 봉투에 안 나타난다
+
+여기가 이 문서에서 가장 중요한 발견이다.
+
+`info --json` 봉투는 `info_json_value()`(`src/main.rs:6993`)가 만들고, 필드는
+**정확히 열 개**다.
+
+```
+schemaVersion · source · format · sizeBytes · version ·
+sections · pageCount · paraCount · fonts · title
+```
+
+**`warnings` 가 없다.** 그런데 파서는 경고를 갖고 있다:
+
+- `parse_hml` 은 `HmlParseResult.warnings` 를 돌려주고, `HmlWarningCode::InvalidReference`
+  가 "상한 초과 리소스를 건너뛰었음"을 뜻한다
+  (`tests/issue_2743_hml_resource_id_limit.rs` 가 개수를 단언한다).
+- `show_info()`(`src/main.rs:7370`)는 **사람 모드에서만** 그것을 찍는다:
+
+```rust
+if json_mode {
+    let info = info_json_value(file_path, file_size, detected_format, &doc);
+    println!("{info}");
+    return EXIT_OK;              // ← 여기서 끝난다
+}
+...
+if let Some(metadata) = doc.hml_metadata() {
+    println!("warnings: {}", metadata.warnings.len());
+    for warning in &metadata.warnings { eprintln!("warning [{:?}] ...", ...); }
+}
+```
+
+**JSON 모드는 경고 출력에 도달하지 못한다.** 데이터가 없어서가 아니라 배선이 없어서다 —
+WASM 표면은 같은 정보를 JSON 으로 낸다(`src/wasm_api.rs:5770` 의 `"warnings": warnings`).
+
+#### 그래서 무슨 일이 벌어지나
+
+`Id="1000000"` 이 든 HML 을 에이전트가 `info --json` 으로 연다.
+
+| | 일어나는 일 |
+| --- | --- |
+| 파서 | 상한 초과 리소스 6종을 **건너뛰고** `InvalidReference` 경고 6개를 남긴다 |
+| exit | **0** |
+| stdout | 완전한 형태의 봉투 — `sections`·`pageCount`·`paraCount`·`fonts` 전부 채워짐 |
+| 봉투 안의 열화 신호 | **없음** |
+| 에이전트의 결론 | "정상 문서다. 글꼴 목록은 이렇다." |
+
+`fonts` 배열은 `document.doc_info.font_faces.first()` 에서 온다(`src/main.rs:7023`).
+글꼴 리소스가 상한으로 잘려 나갔다면 **그 배열은 부분 목록**이고, 봉투는 그것이
+부분이라고 말하지 않는다. §3-1 이 금지한 바로 그 형태다.
+
+> **판정**: 이건 파서 결함이 아니다. 상한 기구는 의도대로 동작했다.
+> **봉투 계약의 공백**이다. 퍼저는 이걸 절대 못 잡는다(F2).
+> **확인되지 않음**: 이 공백이 이슈로 등록돼 있는지 저장소에서 확인하지 못했다.
+
+#### 고치는 방향 (제안 — 결정 아님)
+
+- `info --json` 에 `warnings: []` 추가 — #3719 불변식 5("필드 추가는 자유")에 부합하므로
+  `schemaVersion` 범프 없이 가능하다.
+- 또는 최소한 `degraded: true` 같은 **단일 불리언**. 부분 목록보다 낫다.
+- HML 이외 포맷에도 같은 개념이 필요한가는 별도 조사가 필요하다 —
+  HWP5/HWPX/HWP3 파서가 "건너뜀"을 구조적으로 보고하는지는 **확인되지 않음**.
+
+---
+
+## 4. 불변식 C — 손상 입력이 봉투 스키마를 바꾸지 않는다
+
+[envelope_provenance.md](../envelope_provenance.md) 가 세운 표지 계약:
+
+```json
+{ "schemaVersion": "1.0", "source": "...", "matches": [ … ],
+  "untrustedContent": true, "untrustedFields": ["matches[].text", "matches[].context"] }
+```
+
+봉투 안에는 **엔진이 만든 값**(`pageCount`·`bytes`·`exitClass`)과 **문서에서 온 값**
+(`pages[].text`·`title`·`tables[].cells[].text`)이 섞여 나가고, 표지가 그 구분을 밝힌다.
+
+퍼징 관점에서 이 계약에 붙는 질문은 하나다.
+
+> **손상된 문서가 봉투의 구조 자체를 바꿀 수 있는가?**
+
+[agent_security/disclosure.md](../agent_security/disclosure.md) §1 이 이걸 **취약점 부류 ②
+"봉투 오염"**으로 분류한다 — "문서 내용이 봉투의 **구조나 메타 필드**를 바꾼다 …
+소비자가 판정 자체를 신뢰할 수 없게 된다." 그리고 "①과 ②는 **언제나 취약점**이다."
+
+무작위·손상 입력이 이 부류를 만들 수 있는 경로 후보:
+
+| 경로 | 어떻게 | 지금 상태 |
+| --- | --- | --- |
+| 제목 문자열이 JSON 을 깨뜨림 | `title` 은 문서에서 온다(`document_title(doc)`) — 이스케이프 실패 시 봉투가 깨진 JSON 이 됨 | `serde_json` 이 직렬화하므로 이론상 안전. **손상 입력으로 시험된 적 없음** |
+| 제어문자·불법 UTF-8 | 파서가 손상 바이트를 문자열로 만들 때 | 확인되지 않음 |
+| 극단적 길이 | 문서에서 온 문자열이 수백 MB → 봉투가 컨텍스트를 범람 | S7 상한이 일부 축에만 있음 |
+| `untrustedFields` 누락 | 새 필드가 표지 없이 추가됨 | `src/provenance.rs:74` 의 `pub const MAP` 이 단일 출처. 드리프트 가드 유무는 확인되지 않음 |
+
+**이 표의 대부분이 "확인되지 않음"이라는 사실 자체가 결론이다** — 봉투를 손상 입력으로
+때려 본 적이 없다.
+
+---
+
+## 5. 퍼징 코퍼스를 표면 계약 검증에 쓰기
+
+### 5-1. 왜 되는가
+
+퍼징 하네스는 파서 함수 하나만 부른다. **CLI 는 그 위에 층이 하나 더 있다.**
+
+```
+   fuzz 하네스              CLI 에이전트 표면
+   ───────────              ─────────────────────────────
+   parse_hwp(data)          fs::read → parse → 봉투 조립 → stdout/exit
+        │                        │        │        │
+   반환값 버림              (같음)   (같음)   ← 여기가 검증 안 됨
+```
+
+같은 입력을 **CLI 프로세스**에 먹이면 파서 층은 그대로 지나가고, 그 위 두 층
+(봉투 조립·종료 코드)이 추가로 검증된다. **코퍼스는 이미 있다** —
+`fuzz/corpus/` 12개 + 앞으로 쌓일 회귀 입력.
+
+### 5-2. 무엇을 단언하나 — 계약 3개
+
+무작위/손상 입력 하나를 `rhwp <명령> --json <파일>` 에 넣었을 때, 문서가 정상이든
+쓰레기든 **항상** 참이어야 하는 것.
+
+| # | 단언 | 근거 |
+| --- | --- | --- |
+| **A1** | exit code ∈ {0, 1, 2} — **101 이 나오면 실패** | #2707/#3719 exit 사전. 101 은 사전에 없다 |
+| **A2** | exit ≠ 0 이면 **stdout 0바이트** | §2-2 의 기존 계약을 손상 입력으로 확장 |
+| **A3** | exit == 0 이면 stdout 은 **유효 JSON** 이고 `schemaVersion` 을 포함 | `tests/cli_json_contract.rs` 의 `parse_stdout_json` 이 이미 쓰는 판정 |
+| A4 | exit == 0 이면 그 명령의 **필수 필드가 전부 존재** | 명령별 봉투 필드 목록이 이미 선언돼 있다 — MCP 도구 정의의 마지막 인자(`src/main.rs:653`·`668`·`683`·`698` 등) |
+| A5 | stdout 에 진단·경고 문자열이 섞이지 않는다 | #3719 불변식 6 stdout 순수성 |
+| A6 | 프로세스가 유한 시간 안에 끝난다 | `-timeout` 의 표면판 |
+
+A1~A3 이 핵심이고, 나머지는 있으면 좋다.
+
+> **A1 이 특히 중요한 이유**: 퍼저는 패닉을 **크래시**로 보고 잡지만, 그건
+> `fuzz/` 하네스를 돌릴 때만이다. CLI 경로에서만 나는 패닉
+> (`issue_cli_test_caption_no_panic.rs` 가 잡은 것이 정확히 그런 것)은
+> **어떤 하네스도 안 본다.** A1 이 그 사각을 덮는다.
+
+### 5-3. 구현안 3가지
+
+**안 ① — 코퍼스 재생 계약 스위트 (권장, 먼저)**
+
+`cargo-fuzz` 없이 평범한 `#[test]` 로 `fuzz/corpus/**` 와 `fuzz/regressions/**` 전체를
+읽어 CLI 프로세스에 먹이고 A1~A3 를 단언한다.
+
+- 비용: 파일 수 × 프로세스 기동. 코퍼스가 12개면 수 초.
+- 툴체인 추가 없음 — **stable 에서 돌고, 지금 CI 에 그대로 들어간다.**
+- 모델로 삼을 파일: `tests/issue_3311_malformed_cfb_no_panic.rs`(케이스 목록 → 루프 →
+  단언)와 `tests/cli_json_contract.rs`(프로세스 기동 + `parse_stdout_json`).
+  **두 패턴을 합치면 그대로 나온다.**
+- 이름 후보: `tests/fuzz_corpus_envelope_contract.rs`.
+
+**안 ② — 손상 변이 스윕**
+
+정상 샘플의 바이트를 규칙적으로 뒤집어(헤더 필드 치환·절단·구간 무작위화) 수백 케이스를
+만들어 같은 단언을 돌린다. `tests/issue_3311_malformed_cfb_no_panic.rs` 가 이미
+`real_field{off}_val{val}` · `real_truncated_1_over_{n}` 로 이 방식을 쓴다 — 177 케이스.
+**시드 고정 의사난수**를 쓰면 재현 가능하고 CI 에서 안정적이다.
+
+**안 ③ — 봉투 조립 함수 직접 퍼징**
+
+`info_json_value`·`digest` 조립 함수를 부르는 fuzz 타깃을 추가한다.
+
+- 장점: 프로세스 기동 없이 초당 수천 회.
+- 걸림돌: 이 함수들이 `src/main.rs` 안에 있어 **`fuzz` 크레이트에서 접근할 수 없다**
+  (바이너리 크레이트). 라이브러리로 끌어올리는 리팩터가 선행돼야 한다.
+  `#3719` 불변식 3("새 로직 금지 — 상위 층은 검증된 코어 함수를 재사용한다")과
+  방향이 같으므로 언젠가 할 일이지만, **지금 이걸 먼저 하는 건 순서가 틀렸다.**
+
+### 5-4. 순서
+
+```
+① 코퍼스 재생 계약 스위트  ── stable, 지금 CI 에 들어감, 툴체인 0
+        │                     ↳ operations.md §7-3 단계 A 와 같은 잡에 얹는다
+        ▼
+② 손상 변이 스윕           ── #3311 패턴 재사용
+        ▼
+③ 봉투 조립 함수 퍼징      ── main.rs → lib 리팩터 선행
+```
+
+①은 **[operations.md §7-3](operations.md) 의 "단계 A 회귀 코퍼스 재생"과 같은 작업**이다.
+단계 A 가 파서 생존만 볼 것을 A1~A3 까지 보게 넓히면 된다 — **비용은 같고 얻는 게 많다.**
+
+### 5-5. 하지 말아야 할 것
+
+- **CLI 를 libFuzzer 하네스로 감싸지 마라.** 프로세스 기동 비용 때문에 exec/s 가
+  두세 자릿수로 떨어져 변이 퍼징의 의미가 없어진다. 코퍼스 재생은 재생으로 족하다.
+- **A3 를 "JSON 이면 아무거나"로 느슨하게 두지 마라.** `schemaVersion` 부재는
+  소비자에게 스키마 협상 불능이다.
+- **정상 문서에서만 계약을 시험하지 마라.** 지금 계약 테스트가 그 상태다 —
+  `tests/cli_json_contract.rs` 의 `SAMPLE` 은 `samples/hwp3-sample.hwp`,
+  주석 그대로 "파싱까지 성공하는 실제 샘플"이다.
+
+---
+
+## 6. 지금 있는 것 / 없는 것 (실측 요약)
+
+| 계약 | 상태 | 근거 |
+| --- | --- | --- |
+| 실패 → exit 1 | **있음** | `cli_json_contract.rs`·`digest_macro_contract.rs` 등 |
+| 실패 → stdout 0바이트 | **있음** (없는 파일·인자 오류에 한정) | 위 + `boundary_integrity_contract.rs:539` |
+| **손상 문서**로 위 두 가지 검증 | **없음** | `tests/` 전수 grep 결과 손상 바이트 → 봉투 계약 테스트 0건 |
+| 패닉(exit 101) 금지 | **부분** | `issue_cli_test_caption_no_panic.rs` 1개 명령만 |
+| 손상 CFB 무패닉(라이브러리 층) | **있음** | `issue_3311_malformed_cfb_no_panic.rs` 177 케이스 |
+| 절단이 봉투에 드러남 | **있음** | `digest` `truncated`, S7 계약 |
+| 부분 목록 금지 | **있음**(changedPages 등) / **공백**(info 의 열화) | §3-1 vs §3-3 |
+| 봉투 출처 표지 | **있음** | `untrustedContent`/`untrustedFields`, `src/provenance.rs` |
+| 손상 입력에 대한 봉투 스키마 불변성 | **확인되지 않음** | §4 |
+| 코퍼스 → 표면 계약 재생 | **없음** | §5 가 제안 |
+
+---
+
+## 7. 위협 모델과의 접합
+
+[agent_security/threat_model.md](../agent_security/threat_model.md) §1.1 의 도식에서
+① 은 퍼징, ② 는 보안 축이 맡는다. **그런데 F2·F3 는 정확히 그 사이에 있다.**
+
+```
+ ┌──────────────┐   ①    ┌────────────────┐   ②    ┌──────────────────┐
+ │  손상 .hwp   │ ─────▶ │  rhwp 프로세스  │ ─────▶ │ 에이전트 컨텍스트 │
+ └──────────────┘        └────────────────┘        └──────────────────┘
+     퍼징이 봄            ▲            ▲             보안 축이 봄
+                          │            └── 봉투 조립: 아무도 안 봄 ← 이 문서
+                          └── 파서: 퍼징이 봄
+```
+
+두 축의 실패 정의를 나란히 두면 왜 이 문서가 별도로 필요한지가 분명해진다.
+
+| 축 | "안전하다"의 뜻 | 실패했을 때 |
+| --- | --- | --- |
+| 퍼징(①) | 프로세스가 산다 | 크래시 · DoS |
+| **이 문서** | **봉투에 적힌 게 참이다** | **에이전트가 거짓을 사실로 씀** |
+| 보안(②) | 문서가 에이전트를 조종 못 한다 | 간접 프롬프트 인젝션 |
+
+세 축은 같은 문장으로 이어진다: **죽지 않고(①), 참을 말하고(이 문서), 명령하지
+않는다(②).** 셋 중 하나만 빠져도 에이전트 도구로서 신뢰할 수 없다.
+
+---
+
+## 8. 확인되지 않음
+
+| 항목 | 왜 | 확인하려면 |
+| --- | --- | --- |
+| §3-3 의 `info --json` 경고 공백이 이슈로 등록됐는지 | 저장소 검색으로 특정 못 함 | 이슈 검색 후 없으면 등록 |
+| HWP5/HWPX/HWP3 파서가 "건너뜀"을 구조적으로 보고하는지 | HML 만 `HmlWarningCode` 를 가짐 | 각 파서의 경고 기구 조사 |
+| 손상 입력이 봉투 JSON 을 깨뜨릴 수 있는지 | 시험된 적 없음 | §5 안 ①·② 실행 |
+| `untrustedFields` 에 드리프트 가드가 있는지 | `src/provenance.rs` 미조사 | 해당 파일과 계약 테스트 확인 |
+| A1(exit 101 금지)을 전 명령에 대해 시험한 적 있는지 | `test-caption` 1건만 확인 | `capabilities` 의 명령 목록 × 손상 입력 |
+| MCP 표면(`mcp-serve`)의 동일 불변식 | CLI 만 조사함. MCP 는 `isError` 어휘가 별도 | `src/mcp_serve.rs` 의 오류 경로 조사 |
+
+---
+
+## 9. 다음 조각 (제안 — 착수 시 개별 이슈로)
+
+| # | 조각 | 크기 | 왜 지금 |
+| --- | --- | --- | --- |
+| 1 | `fuzz/regressions/` 생성 + 코퍼스 재생 계약 스위트(A1~A3) | 중 | operations.md §7-3 단계 A 와 한 몸. **stable 에서 돌아 CI 즉시 편입** |
+| 2 | #3608 M21 현황판 갱신(하네스 6종 머지 반영) | 소 | 진행률이 실제보다 낮게 보인다 |
+| 3 | `info --json` 열화 신호(§3-3) | 소 | 부분 목록 금지 원칙의 명백한 공백 |
+| 4 | WMF 잔여 후보 2곳 이슈화([operations.md §5-3](operations.md)) | 소 | 코드 근거가 이미 확정됨 |
+| 5 | 2순위 하네스(`parse_body_text_section`·`parse_doc_info`·`parse_control`·EMF) | 대 | RFC #3141 §4 잔여 |
+
+---
+
+## 관련
+
+- [README.md](README.md) — 묶음 지도 · [operations.md](operations.md) — 실행 · [crash_triage.md](crash_triage.md) — 트리아지
+- [agent_security/threat_model.md](../agent_security/threat_model.md) §1.1 — 신뢰 경계 ①/②
+- [agent_security/detection_policy.md](../agent_security/detection_policy.md) §④ — 부분 목록 금지
+- [agent_security/disclosure.md](../agent_security/disclosure.md) §1 — 봉투 오염 = 취약점 부류 ②
+- [agent_boundary_contract.md](../agent_boundary_contract.md) — S5·S6·S7·S8
+- [envelope_provenance.md](../envelope_provenance.md) — `untrustedContent`/`untrustedFields`
+- [weak_agent_proofing.md](../weak_agent_proofing.md) — 에이전트의 무능(환각·검증 누락) 축
+- 이슈: [#3608](https://github.com/edwardkim/rhwp/issues/3608) M21 · [#3141](https://github.com/edwardkim/rhwp/issues/3141) RFC · [#3719](https://github.com/edwardkim/rhwp/issues/3719) 6층 지도 · [#3787](https://github.com/edwardkim/rhwp/issues/3787) 경계 무결성 · [#3311](https://github.com/edwardkim/rhwp/issues/3311) 실제 발견 사례

--- a/mydocs/tech/fuzzing/crash_triage.md
+++ b/mydocs/tech/fuzzing/crash_triage.md
@@ -1,0 +1,409 @@
+---
+kind: guide
+status: active
+canonical: mydocs/tech/fuzzing/agent_surface_robustness.md
+last_verified: 2026-08-03
+---
+
+# 크래시 트리아지 — 나온 것을 어떻게 처리하나
+
+> 퍼저가 뭔가를 뱉었다. 여기서부터 무엇을 하나.
+> 실행 자체는 [operations.md](operations.md), 묶음 지도는 [README.md](README.md).
+
+이 문서의 목표는 **크래시 입력 하나를 저장소의 영구 자산(회귀 테스트)으로 바꾸는 것**이다.
+고치기만 하고 테스트를 남기지 않으면 같은 클래스가 다시 들어온다 — 이 저장소에서
+실제로 일어난 일이다(§6-0).
+
+기준선: 2026-08-03, `rhwp v0.8.2`, HEAD `9095cd52d`.
+
+---
+
+## 0. 절차 한 장
+
+```
+fuzz/artifacts/<타깃>/<파일>
+      │
+ ①    ├── 재현       cargo +nightly fuzz run <타깃> <파일>          (§2)
+      │
+ ②    ├── 최소화     cargo +nightly fuzz tmin <타깃> <파일>         (§3)
+      │
+ ③    ├── 층 판별    스택 최상단 프레임 → 파서 층 지도              (§4)
+      │
+ ④    ├── 클래스 분류 6종 중 하나로 — 반복되면 스윕 이슈            (§5)
+      │
+ ⑤    ├── 회귀 테스트 승격  tests/issue_####_*.rs                  (§6)
+      │
+ ⑥    ├── 이슈 → 분석 → 수정 → 처리결과 문서 → PR                 (§7)
+      │
+ ⑦    └── 최소화 입력을 fuzz/regressions/<타깃>/ 에 커밋            (§8)
+```
+
+⑤와 ⑥의 순서를 바꾸지 마라. **테스트가 red 인 것을 먼저 보고** 나서 고친다.
+red 를 못 본 수정은 무엇을 고쳤는지 증명하지 못한다.
+
+---
+
+## 1. 산출물 읽기
+
+크래시 산출물은 `fuzz/artifacts/<타깃>/` 에 떨어진다. `fuzz/.gitignore` 가
+`artifacts/` 를 제외 대상으로 두므로 **자동으로는 커밋되지 않는다** — 의도된 설계다
+(코퍼스와 회귀 케이스와 일회성 산출물을 섞지 않는다).
+
+파일 이름의 접두사가 1차 분류다.
+
+| 접두사 | 무엇 | 어느 플래그가 잡았나 |
+| --- | --- | --- |
+| `crash-<sha1>` | 패닉 / abort / 세그폴트 | 기본 |
+| `oom-<sha1>` | 메모리 상한 초과 | `-rss_limit_mb=2048` |
+| `timeout-<sha1>` | 한 입력이 제한 시간 초과 | `-timeout=30` |
+| `slow-unit-<sha1>` | 느리지만 끝나긴 함 | 기본(경고) |
+| `leak-<sha1>` | LeakSanitizer | 기본 |
+
+`oom-`/`timeout-` 은 **패닉이 아니다.** 그래서 "테스트가 실패한다"가 아니라
+"프로세스가 죽는다"로 나타난다 — 회귀 테스트를 쓸 때 이 차이가 결정적이다(§6-5).
+
+> `slow-unit-` 은 결함이 아닐 수 있다. 큰 정상 문서를 파싱하면 당연히 느리다.
+> 입력 크기 대비 시간이 **비선형**인지 먼저 보라 — 385바이트가 30초를 먹으면
+> 그건 #2743 류다.
+
+---
+
+## 2. 재현
+
+```sh
+cargo +nightly fuzz run parse_hwp fuzz/artifacts/parse_hwp/crash-e3b0c442...
+```
+
+파일 인자를 주면 변이 없이 그 입력 하나만 실행한다. 확인할 것:
+
+1. **결정적인가.** 3회 돌려 같은 지점에서 죽는가. 비결정적이면 스레드·시간·환경
+   의존이므로 최소화가 무의미하다.
+2. **스택 최상단이 어디인가.** 이게 §3 의 입력이다.
+3. **입력이 얼마나 큰가.** 크면 §3 최소화 전에는 사람이 읽을 수 없다.
+
+재현 실패라면 대개 셋 중 하나다.
+- 코드가 이미 고쳐졌다 (다른 PR 이 우연히 막았다) → 그래도 **회귀 테스트는 만든다**.
+  #3311 이 정확히 이 경우였다(§6-0).
+- 빌드 프로파일이 다르다 — 오버플로 패닉은 debug 어서션이 켜져야 난다.
+- 산출물이 잘렸다.
+
+---
+
+## 3. 최소화
+
+```sh
+cargo +nightly fuzz tmin parse_hwp fuzz/artifacts/parse_hwp/crash-e3b0c442...
+```
+
+`tmin` 은 "같은 크래시를 유지하면서" 입력을 줄인다. 결과는
+`fuzz/artifacts/<타깃>/minimized-from-<sha1>` 로 나온다.
+
+최소화가 중요한 이유는 크기가 아니라 **설명 가능성**이다. #2743 의 재현 입력은
+**382바이트**였고, 그래서 회귀 테스트가 바이트열을 소스에 직접 적을 수 있었다.
+
+```rust
+let bytes = hml_with_charshape_id("1000000");
+assert_eq!(bytes.len(), 382, "재현 입력 크기 고정");
+```
+— `tests/issue_2743_hml_resource_id_limit.rs`
+
+**바이너리 blob 을 커밋해야만 재현되는 테스트보다, 소스에서 합성되는 테스트가 낫다.**
+합성 가능한 크기까지 줄이는 것이 `tmin` 의 진짜 목표다.
+
+`tmin` 이 충분히 못 줄이면:
+- `-runs=100000` 등으로 시도 횟수를 늘린다.
+- 텍스트 포맷(HML·OOXML 차트)이면 **손으로 줄인다.** XML 은 사람이 읽을 수 있다.
+- 컨테이너 포맷이면 최소화가 어렵다 — CFB/ZIP 은 체크섬·오프셋이 얽혀 있어
+  한 바이트만 빼도 다른 실패가 된다. 이 경우 **합성 스윕**을 쓴다(§6-2).
+
+---
+
+## 4. 어느 파서 층인가 — 층 지도
+
+스택 최상단 프레임의 파일 경로를 이 표에 대응시킨다. 층이 정해지면 담당 하네스,
+전형적 결함 클래스, 그리고 **비슷한 선례**가 함께 정해진다.
+
+| 층 | 코드 | 하네스 | 전형적 결함 | 선례 |
+| --- | --- | --- | --- | --- |
+| CFB 컨테이너 | `src/parser/cfb_reader.rs` | `parse_hwp` | 손상 섹터 id → OOB 슬라이스, DIFAT 순환 | #3311 · #3181 · `905b3261e` |
+| HWP5 진입 | `src/parser/mod.rs:184` (`parse_hwp`) | `parse_hwp` | 포맷 판별·헤더 | — |
+| HWP5 DocInfo | `src/parser/doc_info.rs` | (2순위 미구현) | 무상한 카운트 할당 | `12ecfece6` (TAB_DEF) |
+| HWP5 BodyText | `src/parser/body_text.rs` | (2순위 미구현) | 레코드 크기 오버플로 | `6b29fa1da` |
+| HWP5 컨트롤 | `src/parser/control.rs`, `control/shape.rs` | (2순위 미구현) | **부호확장 → 무한루프** | #3012 |
+| IR 조립(표) | `src/model/table.rs` | 간접 | span 0 → `u16` 언더플로 | `ed339e78f` |
+| HWP3 | `src/parser/hwp3/mod.rs` | `parse_hwp3` | **스케일 곱셈 오버플로** | `cdd55c838`·`e288b0a7f`·`6bcbadcd1`·`77627e953` |
+| HWPX(ZIP) | `src/parser/hwpx/mod.rs` | `parse_hwpx` | zip 폭탄, XML 폭증 | 확인되지 않음 |
+| HML(XML) | `src/parser/hml/mod.rs`, `hml/reader.rs` | `parse_hml` | **상한 기구의 빈틈** | #2743 |
+| WMF | `src/wmf/converter/mod.rs` + `src/wmf/parser/**` | `parse_wmf` | 음수 카운트 → `with_capacity` | #3004 · #3000 · #3301 |
+| OOXML 차트 | `src/ooxml_chart/parser.rs` | `parse_ooxml_chart` | XML 파서 경계 | 확인되지 않음 |
+| EMF | `src/emf/**` | **하네스 없음** | (WMF 와 동형 예상) | RFC #3141 §4 2순위 |
+
+### 4-1. 두 층 이상이 관여할 때
+
+컨테이너를 통과해 내부에서 죽으면 **하네스는 컨테이너 것인데 결함은 내부**다.
+이때 하는 일:
+
+1. 결함은 **내부 층**으로 귀속시킨다. 수정도 거기서 한다.
+2. 회귀 테스트는 **가능하면 내부 함수를 직접 부른다.** 컨테이너를 거치면 테스트가
+   컨테이너 변경에 취약해진다.
+3. 그 층에 하네스가 없다면(위 표의 "2순위 미구현") **하네스를 만드는 게 후속 작업이다** —
+   RFC #3141 §4 가 이미 목록을 갖고 있다.
+
+### 4-2. HML 층 특유의 주의
+
+`parse_hml` 하네스는 **기본 `HmlLimits` 를 그대로 쓴다**(하네스 파일 주석: "상한 기구의
+빈틈(#2743류)을 찾는 것이 목적이므로 상한을 풀지 않는다"). 즉 HML 크래시가 나왔다면
+그건 **상한을 뚫었다**는 뜻이고, 고칠 곳은 `src/parser/hml/reader.rs:40` 의
+`HmlLimits` 에 항목을 추가하는 쪽일 가능성이 높다.
+
+---
+
+## 5. 결함 클래스 분류
+
+RFC #3141 §1 이 관찰한 대로, 이 저장소의 결함은 소수의 클래스가 반복된다.
+분류가 중요한 이유는 **클래스가 반복되면 전수 스윕 이슈를 여는 것**이 관행이기
+때문이다(#3004 → #3012 흐름).
+
+| # | 클래스 | 서명 | 대표 |
+| --- | --- | --- | --- |
+| C1 | **부호 있는 정수 → `usize` 무검증 캐스팅** | `capacity overflow`, 또는 끝나지 않는 루프 | #3004 · #3012 · `cdd55c838` |
+| C2 | **무검증 할당** (파일 값이 곧 할당 크기) | `oom-`, 또는 `handle_alloc_error` abort | #2743 · #2722 · #3000 |
+| C3 | **산술 오버플로** (곱셈 스케일 변환) | debug 에서 `attempt to multiply with overflow` | `e288b0a7f`·`6bcbadcd1`·`77627e953` |
+| C4 | **언더플로** (`a - b` 에서 b>a) | `attempt to subtract with overflow` | `ed339e78f` (span 0) |
+| C5 | **경계 없는 인덱싱/슬라이싱** | `range end index N out of range for slice of length M` | #3311 |
+| C6 | **순환/무한 반복** (체인 순회) | `timeout-` | #3181 (DIFAT 순환) |
+
+**분류할 때 던지는 질문 하나: "이 클래스를 같은 파일에서 이미 고친 적이 있나?"**
+있다면 그건 스윕 대상이다. `1b02247ff`(#3301) 커밋 메시지가 그 사고방식을 그대로 적는다 —
+"이미 겪은 클래스(#3008 Region scan_count, #3181 CFB DIFAT 순환)와 같은 패턴이 남은 곳."
+
+---
+
+## 6. 회귀 테스트로 승격 — 이 저장소의 세 가지 패턴
+
+### 6-0. 왜 반드시 하나 — #3311 이 준 교훈
+
+`tests/issue_3311_malformed_cfb_no_panic.rs` 주석이 이유를 그대로 적었다.
+
+> "결함 자체는 `6a761a793`(#3220 …)에서 해소됐다 … 다만 그 수정들은 **개별 방어를
+> 추가했을 뿐 "손상 입력은 패닉하지 않는다"는 계약을 고정하지 않았다.**
+> 이 테스트가 그 계약을 못박아 같은 클래스의 재유입을 검출한다."
+
+수정만으로는 부족하다. **계약을 못박아야** 같은 클래스가 다시 못 들어온다.
+
+### 6-1. 패턴 A — 재현 입력 고정형 (`tests/issue_2743_hml_resource_id_limit.rs`)
+
+최소화 입력이 **소스에서 합성 가능한 크기**일 때 쓴다. 최선의 형태다.
+
+구성 요소 4개:
+
+```rust
+/// ① 재현 입력을 함수로 합성 — 파라미터가 결함의 축이다
+fn hml_with_charshape_id(id: &str) -> Vec<u8> { ... }
+
+#[test]
+fn hml_resource_id_beyond_limit_is_skipped_with_warning() {
+    let bytes = hml_with_charshape_id("1000000");
+    assert_eq!(bytes.len(), 382, "재현 입력 크기 고정");   // ② 크기 고정
+
+    let parsed = parse_hml(&bytes).expect("상한 초과 Id 여도 문서는 열려야 함");
+    let len = parsed.document.doc_info.char_shapes.len();
+    assert!(len < 1_000, "...");                            // ③ 결과 단언
+    assert_eq!(invalid_reference_warnings(&parsed), 1, "..."); // ④ 경고 단언
+}
+```
+
+- **② 크기 고정 단언**은 픽스처가 바뀌면 알려 준다.
+- **③ 결과 단언이 "죽지 않음"보다 강하다.** #2743 의 "조용한 구간"은 `Ok` 를
+  반환하면서 120MB 를 먹었다 — `parse_hml(...).is_ok()` 만 단언했으면 **수정 전에도
+  통과**해서 red 가 안 됐다. 테스트 주석이 이걸 명시한다: "따라서 아래 가드는
+  '죽지 않음'이 아니라 **결과 테이블 길이와 경고**를 단언한다(그렇게 해야 수정 전에
+  red 가 된다)."
+- 같은 파일이 **경계값 테스트**(65535 수용 / 65536 거부)와 **무회귀 테스트**
+  (정상 범위 Id 는 동작 완전 불변)를 함께 둔다. 셋을 같이 써라.
+
+### 6-2. 패턴 B — 합성 스윕형 (`tests/issue_3311_malformed_cfb_no_panic.rs`)
+
+컨테이너 포맷이라 최소화가 안 되거나, 결함이 **값의 조합**일 때 쓴다.
+
+```rust
+/// 리포터가 보고한 실측 값 — 이 조합이 구 커밋에서 패닉을 냈다.
+const REPORTED_FAT_ENTRIES: u32 = 824;
+const REPORTED_POISON_SECTOR: u32 = 1_851_072_928;
+const REPORTED_LEN: usize = 3072;
+
+fn synth_malformed_cfb(len, fat_count, difat_count, first_difat, poison) -> Vec<u8> { ... }
+
+fn malformed_cases() -> Vec<(String, Vec<u8>)> {
+    // ① 리포터 조건 정확 재현 1건
+    // ② 경계 스윕: len 6종 × fat 5종 × poison 5종 = 150건
+    // ③ 실 샘플 헤더 뮤테이션 + 절단
+}
+
+#[test]
+fn malformed_cfb_returns_err_instead_of_panicking() {
+    let cases = malformed_cases();
+    assert!(cases.len() >= 150, "케이스 수가 급감했다 — ... 커버리지가 줄었는지 확인할 것");
+    let mut opened = 0;
+    for (name, bytes) in &cases {
+        match HwpDocument::from_bytes(bytes) { Ok(_) => opened += 1, Err(_) => {} }
+    }
+    assert!(opened < cases.len(), "손상 입력이 모두 정상 개봉됐다 — 케이스가 더 이상 malformed 가 아니다");
+}
+```
+
+이 패턴의 세 가지 발명:
+
+1. **리포터 실측값을 상수로 명시** — 6개월 뒤 "왜 824인가"를 답할 수 있다.
+2. **케이스 수 하한 단언**(`>= 150`) — 샘플 경로가 바뀌어 케이스가 조용히 사라지는 것을 잡는다.
+3. **"전부 열리면 실패"** — 케이스가 더 이상 손상 입력이 아니게 되는 퇴화를 잡는다.
+
+여기서 패닉 단언은 **암묵적**이다. 패닉하면 그 지점에 도달하지 못해 테스트가 실패한다
+(주석: "패닉하면 이 지점에 도달하지 못하고 테스트가 실패한다 — 그것이 이 가드가
+잡으려는 회귀다").
+
+### 6-3. 패턴 C — CLI 프로세스형 (`tests/issue_cli_test_caption_no_panic.rs`)
+
+크래시가 **CLI 표면**에서 재현될 때. `exit 101`(Rust 패닉)을 직접 단언한다.
+
+```rust
+let out = Command::new(rhwp_bin()).args(["test-caption", sample]).output()...;
+assert_ne!(out.status.code(), Some(101),
+    "Rust panic(exit 101) 발생 — 범위 밖 인덱싱 회귀. stderr: {}", ...);
+assert_eq!(out.status.code(), Some(0), "예기치 않은 종료 코드. ...");
+```
+
+**패닉은 exit 101 이다.** 프로세스를 띄우는 테스트에서는 이게 가장 정확한 서명이고,
+동시에 [#2707 exit 사전](agent_surface_robustness.md) 과 맞물린다 — 손상 문서는
+**101 이 아니라 1** 로 끝나야 한다.
+
+### 6-4. 어느 패턴을 고르나
+
+```
+최소화 입력이 소스에 적을 만한가?
+   ├─ 예 ────────────────────▶ 패턴 A (재현 입력 고정형)
+   └─ 아니오
+        ├─ 결함이 값 조합인가? ▶ 패턴 B (합성 스윕형)
+        └─ CLI 에서 재현되나?  ▶ 패턴 C (프로세스형)
+```
+
+세 패턴은 배타적이지 않다. #3311 은 B 를 쓰면서 실 샘플 뮤테이션까지 섞었다.
+
+### 6-5. ⚠️ 회귀 테스트가 CI 러너를 죽이면 안 된다
+
+이건 이 저장소에서 **메인테이너가 직접 보정한 규칙**이다.
+`tests/issue_2743_hml_resource_id_limit.rs` 안에 그대로 남아 있다.
+
+> **[메인테이너 보정]** 종전에는 Id `2000000000` 을 썼다. 가드가 살아 있으면
+> 안전하지만, **가드가 회귀로 사라지면 `CharShape` 120B × 20억 = 240GB** 를 요구해
+> 테스트가 실패하는 대신 러너가 죽는다. 원저자도 "수정 전에는 테스트 실패가 아니라
+> 프로세스가 죽는다"고 주석에 적어 두었는데, 그것이 바로 CI 에서 허용될 수 없는 성질이다.
+>
+> 상한(65,535)을 크게 넘는다는 성질은 Id `2_000_000` 으로도 동일하게 검증되며,
+> 회귀 시 요구량은 240MB 로 진단 가능한 범위에 머문다.
+
+**규칙: C2(무검증 할당)·C6(무한루프) 클래스의 회귀 테스트는 "회귀했을 때 어떻게
+실패하는가"를 설계해야 한다.**
+
+| 클래스 | 회귀 시 나쁜 실패 | 대신 이렇게 |
+| --- | --- | --- |
+| C2 무검증 할당 | 러너 OOM 킬 → 로그 없음 | 요구량이 수백 MB 대에 머무는 값을 고른다 |
+| C6 무한루프 | CI 타임아웃(수십 분) | 반복 상한을 단언하거나, 별도 스레드 + 시간 예산 |
+| C3/C4 오버플로 | (없음 — 깔끔히 패닉) | 그대로 두면 된다 |
+
+원래 값(240GB·`2000000000`)은 **주석에 남긴다.** 값을 낮춘 이유를 못 적으면
+다음 사람이 "왜 이렇게 어중간하지" 하며 되돌린다.
+
+---
+
+## 7. 이슈 → 수정 → PR
+
+이 저장소의 기여 절차는 고정돼 있다: **이슈 등록 → 분석 → 코드 변경 → 처리결과 문서 → PR.**
+퍼징 발견물도 예외가 아니다.
+
+1. **이슈 등록** — 제목에 층·클래스를 담는다. #3311 의 제목이 좋은 형태다:
+   `패닉(OOB slice): LenientCfbReader::open 이 malformed CFB FAT 에서 'range end index out of range'`
+   본문에 넣을 것: 환경(커밋 해시·features·OS) / 패닉 원문 스택 / 원인 추정 /
+   기대 동작 / 재현 방법. **최소화 입력을 첨부하거나 합성 코드를 적는다.**
+2. **red 확인** — §6 의 회귀 테스트를 먼저 쓰고 실패를 본다.
+3. **수정** — 같은 클래스의 기존 수정을 본떠라. C1 이면
+   `src/wmf/parser/objects/graphics/region.rs:96` 의 `if scan_count < 0 { Err }` 형태,
+   C3 이면 `read_hwp3_padding_scaled` 처럼 **i32 중간값을 거치는 헬퍼**로 통일하는 형태다.
+4. **green + fmt/clippy** — PR 전 `cargo fmt --all -- --check`, `cargo clippy -- -D warnings`.
+   CI `lint` 잡이 이 둘을 그대로 돌린다(`.github/workflows/ci.yml`).
+5. **처리결과 문서** — `mydocs/report/task_m100_####_report.md`.
+6. **PR** — 닫는 이슈 명시.
+
+### 보안 성격 판단
+
+원격 코드 실행급이거나 메모리 안전을 넘는 것이면 **공개 이슈로 올리지 않는다** —
+[`SECURITY.md`](../../../SECURITY.md) 의 GitHub Security Advisory 경로를 쓴다.
+판단 기준은 [agent_security/disclosure.md](../agent_security/disclosure.md).
+
+단순 파서 패닉(DoS)은 #3311 처럼 **공개 이슈**로 접수된 선례가 있다. 제보자 본인이
+"실사용에선 격리 서브프로세스 + fail-closed 로 무해 격리되지만, 라이브러리 견고성
+차원에서 제보합니다"라고 성격을 명시했고, 메인테이너가 그대로 공개 처리했다.
+
+---
+
+## 8. 회귀 코퍼스에 커밋
+
+```
+fuzz/regressions/<타깃>/<이슈번호>-<짧은설명>
+```
+
+`fuzz/README.md` §트리아지가 정한 규약이다 — **`fuzz/corpus/` 가 아니라
+`fuzz/regressions/`.** 둘을 섞으면 회귀 케이스가 코퍼스 최소화(`cmin`)에 먹혀
+사라진다.
+
+**이 디렉터리는 아직 존재하지 않는다**(`ls fuzz/regressions` → not found).
+첫 크래시를 처리하는 사람이 만든다. 만들 때 같이 할 일:
+
+- [ ] `fuzz/README.md` 의 코퍼스 표에 `regressions/` 행 추가
+- [ ] 회귀 입력을 읽어 파서를 부르는 재생 테스트 1개
+      (`tests/fuzz_regressions.rs` 같은 이름) — **cargo-fuzz 없이 `cargo test` 로 돈다**
+- [ ] #3608 M21 체크리스트의 "크래시 코퍼스 회귀 스위트 편입" 체크
+
+재생 테스트의 뼈대는 이미 저장소에 있다 — `tests/issue_3311_malformed_cfb_no_panic.rs`
+가 파일을 읽어 `HwpDocument::from_bytes` 에 넣는 형태 그대로다.
+
+---
+
+## 9. 이 PC 에서의 제약
+
+[operations.md §6](operations.md) 의 결론이 그대로 적용된다. Windows SDK 의
+`dbghelp.lib` 손상으로 **MSVC 타깃 실행 파일을 만들 수 없어** `cargo fuzz run`·
+`cargo fuzz tmin`·`cargo test` 가 모두 불가하다.
+
+| 단계 | 이 PC | 대안 |
+| --- | --- | --- |
+| ① 재현 | ✗ | 퍼징 가능 환경 |
+| ② 최소화 | ✗ | 퍼징 가능 환경. 텍스트 포맷이면 **손으로** 줄일 수 있다 |
+| ③ 층 판별 | ✓ | 스택 문자열 + 코드 읽기로 충분 |
+| ④ 클래스 분류 | ✓ | 코드 읽기 |
+| ⑤ 회귀 테스트 작성 | ✓ (작성만) | 실행·red 확인은 CI |
+| ⑥ 이슈·PR | ✓ | — |
+
+**red 를 못 보고 PR 을 올리는 것은 이 저장소의 관행에 어긋난다.** 이 환경에서
+작업한다면 PR 본문에 "red 미확인, CI 로 확인 요청"을 명시해라 —
+`e288b0a7f` 커밋이 그렇게 했다("로컬 빌드 검증은 리뷰어 몫으로 남긴다").
+
+---
+
+## 10. 확인되지 않음
+
+| 항목 | 이유 |
+| --- | --- |
+| `cargo fuzz tmin` 이 이 저장소 타깃에서 실제로 얼마나 줄이는가 | 실행 불가 |
+| `oom-`/`timeout-` 산출물의 실제 파일명 형식 | libFuzzer 문서 기반 서술. 이 저장소에서 나온 적 없음 |
+| HWPX(ZIP)·OOXML 차트 층의 전형적 결함 | 해당 층에서 확정된 결함 사례가 저장소에 없음 |
+| EMF 층 | 하네스 자체가 없음(RFC #3141 §4 2순위) |
+| 퍼징 발견물이 이 저장소 이슈로 접수된 총 건수 | #3311 하나만 확인. 그 외는 라벨·본문으로 식별되지 않음 |
+
+## 관련
+
+- [README.md](README.md) · [operations.md](operations.md) · [agent_surface_robustness.md](agent_surface_robustness.md)
+- 회귀 테스트 원본: `tests/issue_2743_hml_resource_id_limit.rs` · `tests/issue_3311_malformed_cfb_no_panic.rs` · `tests/issue_cli_test_caption_no_panic.rs`
+- [`fuzz/README.md`](../../../fuzz/README.md) §트리아지 절차 — 규약의 1차 출처
+- [`SECURITY.md`](../../../SECURITY.md) · [agent_security/disclosure.md](../agent_security/disclosure.md)
+- 이슈: [#3141](https://github.com/edwardkim/rhwp/issues/3141) · [#3311](https://github.com/edwardkim/rhwp/issues/3311) · [#3608](https://github.com/edwardkim/rhwp/issues/3608) M21

--- a/mydocs/tech/fuzzing/operations.md
+++ b/mydocs/tech/fuzzing/operations.md
@@ -1,0 +1,565 @@
+---
+kind: guide
+status: active
+canonical: mydocs/tech/fuzzing/agent_surface_robustness.md
+last_verified: 2026-08-03
+---
+
+# 퍼징 운영 — 어떻게 돌리고 무엇을 보나
+
+> 인프라 자체의 1차 출처는 저장소 안의 [`fuzz/README.md`](../../../fuzz/README.md) 다.
+> 이 문서는 그것을 복제하지 않고, **운영 판단**을 더한다 — 얼마나 돌릴지, 코퍼스를
+> 어떻게 키울지, CI 에 넣을지, 이 환경에서 되는지, 나온 걸 누가 받는지.
+> 묶음 지도는 [README.md](README.md), 크래시 처리는 [crash_triage.md](crash_triage.md).
+
+측정 기준선: **2026-08-03**, `rhwp v0.8.2`(`Cargo.toml:3`), HEAD `9095cd52d`.
+
+---
+
+## 0. 먼저 — 퍼징이 이 저장소에서 무엇을 검출하는가
+
+RFC [#3141](https://github.com/edwardkim/rhwp/issues/3141) §1 이 세 가지 결함 클래스를
+지목했고, 하네스 6개는 그 세 가지만 본다.
+
+| 클래스 | 어떻게 검출되나 | 저장소의 실제 사례 |
+| --- | --- | --- |
+| **패닉 / abort** | libFuzzer 가 프로세스 종료를 크래시로 기록 | #3311 (`cfb_reader.rs:407` OOB 슬라이스) |
+| **자원 고갈(OOM)** | `-rss_limit_mb` 초과 시 크래시 | #2743 (HML `Id` → 382B 파일이 120MB, 385B 가 240GB 요구 후 abort) |
+| **무한루프 / 타임아웃** | `-timeout` 초과 시 크래시 | #3012 (`parse_polygon_shape_data` 부호확장) |
+
+**검출하지 않는 것**(RFC §9):
+
+- 렌더링 정합성·왕복(round-trip) 속성 소실 — #2740 영역이다. 하네스가 `Err` 를 버리므로
+  "틀린 결과를 조용히 내는" 결함은 원리상 보이지 않는다.
+- **봉투가 잘못된 판정을 내는 것** — 하네스는 파서 함수만 부르고 CLI 봉투를 만들지 않는다.
+  이 공백이 [agent_surface_robustness.md](agent_surface_robustness.md) 의 주제다.
+
+하네스 6개는 전부 반환값을 버린다:
+
+```rust
+fuzz_target!(|data: &[u8]| {
+    let _ = rhwp::parser::parse_hwp(data);
+});
+```
+— `fuzz/fuzz_targets/parse_hwp.rs`
+
+**`Err` 는 성공이다.** 손상 입력이 `Err` 로 끝나는 것이 계약이고, 퍼저가 잡는 건
+프로세스가 죽거나 안 끝나는 경우뿐이다.
+
+---
+
+## 1. 준비 — 툴체인
+
+```sh
+rustup toolchain install nightly
+cargo install cargo-fuzz
+```
+
+cargo-fuzz 는 `-Z sanitizer` 계열 플래그를 쓰므로 **nightly 가 필수**다
+(`fuzz/README.md` §사전 준비).
+
+이 저장소는 `rust-toolchain.toml` 로 **stable 1.93.1 을 핀**한다.
+
+```toml
+[toolchain]
+channel = "1.93.1"
+components = ["clippy", "rustfmt"]
+targets = ["wasm32-unknown-unknown"]
+profile = "minimal"
+```
+
+따라서 퍼징 명령에는 **반드시 `+nightly` 를 붙인다** — rustup 의 우선순위에서
+명령행 `+toolchain` 이 `rust-toolchain.toml` 핀보다 위이기 때문이다.
+`+nightly` 를 빼면 1.93.1 로 떨어지고 cargo-fuzz 가 sanitizer 플래그에서 실패한다.
+(이 저장소에서 실제로 실행해 확인한 것은 아니다 — §6 참조. **확인되지 않음**.)
+
+---
+
+## 2. 실행
+
+### 2-1. 빌드만 (배선 점검용)
+
+```sh
+cargo +nightly fuzz build
+```
+
+하네스가 참조하는 `pub` 경로가 실제로 존재하는지, 6개가 전부 링크되는지 확인한다.
+`fuzz/Cargo.toml` 의 `[[bin]]` 개수(6)와 `fuzz/fuzz_targets/*.rs` 개수(6)가 어긋나면
+여기서 깨진다.
+
+### 2-2. 개별 타깃 실행
+
+```sh
+cargo +nightly fuzz run parse_hwp          -- -rss_limit_mb=2048 -timeout=30
+cargo +nightly fuzz run parse_hwp3         -- -rss_limit_mb=2048 -timeout=30
+cargo +nightly fuzz run parse_hwpx         -- -rss_limit_mb=2048 -timeout=30
+cargo +nightly fuzz run parse_hml          -- -rss_limit_mb=2048 -timeout=30
+cargo +nightly fuzz run parse_wmf          -- -rss_limit_mb=2048 -timeout=30
+cargo +nightly fuzz run parse_ooxml_chart  -- -rss_limit_mb=2048 -timeout=30
+```
+
+`--` 뒤는 libFuzzer 인자다. cargo-fuzz 는 `fuzz/corpus/<타깃>/` 을 코퍼스 디렉터리로
+자동 사용하고, 크래시 산출물을 `fuzz/artifacts/<타깃>/` 에 쓴다
+(둘 다 `fuzz/.gitignore` 에서 `artifacts/` 만 제외 — 코퍼스는 커밋 대상).
+
+### 2-3. 플래그를 그 값으로 쓰는 이유
+
+| 플래그 | 값 | 왜 |
+| --- | --- | --- |
+| `-rss_limit_mb` | `2048` | #2743 류 **무검증 할당**을 OOM 크래시로 승격시킨다. libFuzzer 기본값도 2048 이지만, 값이 아니라 **의도**를 남기려고 항상 명시한다 |
+| `-timeout` | `30` | #3012 류 **부호확장 무한루프**를 잡는다. 기본값 1200초는 이 용도로 너무 길다 — 20분간 한 입력에 묶여 있으면 그 세션은 사실상 죽은 것이다 |
+| `-jobs` / `-workers` | 코어 수 | 병렬 실행. 코퍼스 디렉터리를 공유하므로 발견 입력이 서로에게 즉시 전파된다 |
+| `-max_len` | (기본) | 포맷 파일은 헤더 제약이 강해 짧은 입력이 얕게 끝난다. 시드가 있으면 굳이 조이지 않는다 |
+
+**`-rss_limit_mb` 를 크게 잡지 마라.** 값을 키우면 "죽지는 않는" 상태가 되어
+#2743 류가 검출되지 않는다. #2743 은 `Id="1000000"` 에서 **`Ok` 를 반환하면서**
+120MB 를 먹었다 — 상한이 없으면 퍼저에게 보이지 않는 결함이다
+(`tests/issue_2743_hml_resource_id_limit.rs` 주석의 "조용한 구간").
+
+### 2-4. 단건 재현 (크래시 입력 하나만)
+
+```sh
+cargo +nightly fuzz run parse_hwp fuzz/artifacts/parse_hwp/crash-<해시>
+```
+
+파일 인자를 주면 퍼징하지 않고 그 입력 하나만 실행한다. 자세한 절차는
+[crash_triage.md §2](crash_triage.md).
+
+---
+
+## 3. 코퍼스 — 어디서 오고 어떻게 키우나
+
+### 3-1. 지금 있는 시드 (실측 `ls fuzz/corpus/*/`)
+
+| 코퍼스 | 파일 | 크기 | 출처 |
+| --- | --- | ---: | --- |
+| `parse_hwp` | `english.hwp` · `Textmail.hwp` · `shortcut.hwp` | 29K·34K·42K | `samples/basic/` |
+| `parse_hwp3` | `hwp3-pagedef-1915.hwp` · `hwp3-sample.hwp` | 2.4K·87K | `samples/` |
+| `parse_hwpx` | `neartop_reset_sb2500.hwpx` · `saved_single_line_spacing_after.hwpx` · `tac-host-spacing.hwpx` | 3.7K·3.7K·4.1K | `samples/task2136` · `samples/task2093` · `samples/` |
+| `parse_hml` | `exambank_math_equations_min.hml` · `formatting_table.hml` | 4.0K·29K | `tests/fixtures/hml/` · `samples/hml/` |
+| `parse_wmf` | `minimal_placeable.wmf` | 46B | **합성** — META_PLACEABLE(0x9AC6CDD7) + 최소 헤더 + META_EOF |
+| `parse_ooxml_chart` | `bar_chart.xml` | 782B | **합성** — 최소 `c:chartSpace` 막대 차트 |
+
+합계 12개 / 269KB (`du -sh fuzz/corpus`).
+
+### 3-2. `samples/` 를 시드로 쓸 수 있나 — 쓸 수 있고, 그게 정답이다
+
+`samples/` 에는 **`.hwp`/`.hwpx` 353개, 총 448MB** 가 이미 커밋돼 있다
+(`ls samples/*.hwp samples/*.hwpx | wc -l` = 353, `du -sh samples` = 448M).
+시드 코퍼스 12개는 그중 **작은 것만 고른 부분집합**이다.
+
+CFB/ZIP 컨테이너 포맷은 구조 제약이 강해서 **시드 없이는 변이가 헤더를 못 넘는다**
+(RFC #3141 §9). 즉 시드가 커버리지를 사실상 결정한다. 그런데 코퍼스를 무작정 키우면
+libFuzzer 는 매 사이클마다 전체 코퍼스를 실행하므로 **초당 실행 횟수(exec/s)가 떨어진다.**
+둘 사이의 운영 규칙:
+
+1. **코퍼스에 넣기 전에 `cmin` 을 돌린다.** 커버리지가 같은 파일은 하나만 남긴다.
+   ```sh
+   cargo +nightly fuzz cmin parse_hwp
+   ```
+2. **큰 파일을 그냥 넣지 않는다.** 448MB 를 통째로 넣으면 exec/s 가 무너진다.
+   먼저 작은 것부터(수 KB~수십 KB), 커버리지가 정체되면 다음 크기대를 추가한다.
+3. **로컬 실험용 코퍼스는 별도 디렉터리를 쓴다.** `cargo fuzz run <타깃> <디렉터리>` 로
+   임시 코퍼스를 지정할 수 있고, 커밋 대상인 `fuzz/corpus/` 를 오염시키지 않는다.
+4. **커밋하는 것은 "커버리지를 늘린 최소화 입력"만.** `fuzz/README.md` §시드 코퍼스가
+   정한 규약이다.
+
+시드 후보 우선순위 — 파서 분기를 많이 여는 순:
+
+| 우선 | 무엇 | 왜 |
+| --- | --- | --- |
+| 1 | 임베드 객체가 든 문서(WMF·차트·OLE) | `parse_wmf`/`parse_ooxml_chart` 경로가 컨테이너 밖에서만 열림 |
+| 2 | 표·중첩표 문서 | `parse_control` 아래 `control/shape.rs` — #3012 결함 위치 |
+| 3 | HWP 3.x 실물 | 스케일 곱셈 오버플로가 몰린 곳(§5 참조) |
+| 4 | 암호·DRM 문서 | 별도 경로. 다만 복호화 실패가 대부분이라 얕게 끝남 |
+
+### 3-3. 회귀 코퍼스는 아직 없다
+
+`fuzz/README.md` §트리아지는 최소화한 크래시 입력을 `fuzz/corpus/` 가 **아니라**
+`fuzz/regressions/<타깃>/` 에 커밋하라고 정하는데, 그 디렉터리는 **존재하지 않는다**.
+
+```
+$ ls fuzz/regressions
+ls: cannot access 'fuzz/regressions': No such file or directory
+```
+
+즉 규약만 있고 실물이 없다. 첫 크래시가 나오는 순간 [crash_triage.md §8](crash_triage.md)
+절차로 생성한다. #3608 M21 체크리스트의 "크래시 코퍼스 회귀 스위트 편입"이 이 항목이다.
+
+---
+
+## 4. 얼마나 돌려야 의미가 있나
+
+libFuzzer 는 종료 조건이 없다 — 사람이 끊어야 한다. 판단 근거를 세 가지로 나눈다.
+
+### 4-1. 저장소가 가진 유일한 실측 기준점
+
+이슈 #3311 의 제보자가 남긴 값이 지금으로선 유일한 실측치다.
+
+> "발견: cargo-fuzz(libFuzzer) **4분 런**, 정부 공개 HWP/HWPX 시드에서 mutate"
+> — #3311 §환경
+
+**4분에 패닉 하나.** 이건 "퍼징이 금방 성과를 낸다"는 뜻이 아니라, **당시 코드에
+얕은 결함이 있었다**는 뜻이다. 같은 4분이 지금도 뭔가를 낸다는 보장은 없다.
+
+### 4-2. 세션 종료 판단 — 시계가 아니라 지표로
+
+libFuzzer 가 매 줄에 찍는 지표를 본다.
+
+```
+#65536  pulse  cov: 4312 ft: 8901 corp: 143/1247Kb exec/s: 812 rss: 210Mb
+```
+
+| 지표 | 의미 | 어떻게 쓰나 |
+| --- | --- | --- |
+| `cov` | 도달한 커버리지 포인트 | **이게 안 늘면 그 세션은 끝난 것** |
+| `ft` | feature 수(경로 조합) | `cov` 가 멈춰도 `ft` 가 늘면 아직 진행 중 |
+| `corp` | 코퍼스 항목 수 / 크기 | 새 항목이 안 생기면 정체 |
+| `exec/s` | 초당 실행 | 급락하면 코퍼스가 비대하거나 느린 입력에 물린 것 |
+| `rss` | 상주 메모리 | `-rss_limit_mb` 에 근접하면 OOM 결함 후보 |
+
+**운영 규칙: `cov` 와 `corp` 가 30분 동안 변하지 않으면 그 타깃은 그 코퍼스로
+포화한 것이다.** 더 돌리는 대신 (ㄱ) 시드를 추가하거나 (ㄴ) 더 깊은 하네스를
+만드는 편이 낫다.
+
+### 4-3. 권장 예산
+
+| 상황 | 타깃당 시간 | 목적 |
+| --- | --- | --- |
+| PR 스모크 | 60초 | **회귀 검출만.** 새 결함 발견은 기대하지 않는다 |
+| 파서 변경 후 로컬 | 10~30분 | 방금 만진 경로의 얕은 결함 |
+| 주간 스윕 | 타깃당 2~4시간 | `cov` 정체까지 |
+| 상시 | 무기한 | OSS-Fuzz 등재 시 Google 인프라가 담당(RFC §7) |
+
+RFC §6-5 가 제안한 CI 스모크가 "PR당 60초 × 하네스"인 것도 같은 논리다 —
+CI 퍼징의 목적은 **발견이 아니라 회귀 차단**이다.
+
+---
+
+## 5. 퍼징이 실제로 무엇을 잡았나 / 무엇을 잡을 수 있었나
+
+### 5-1. 잡았다 — #3311 (유일한 확인 사례)
+
+`tests/issue_3311_malformed_cfb_no_panic.rs` 상단 주석이 출처를 명시한다.
+
+> "외부 리포터(**cargo-fuzz**, 격리 CDR 파이프라인 하드닝 중)가 `LenientCfbReader::open`
+> 의 OOB 슬라이스 패닉을 보고했다(`cfb_reader.rs:407`, "range end index 8020 out of
+> range for slice of length 3072")."
+
+경위:
+- 제보(#3311, 2026-07-17 커밋 `8d3bfa4b` 기준) — 외부 사용자가 **자기 파이프라인에서**
+  cargo-fuzz 를 돌리다 발견. 이 저장소의 `fuzz/` 는 그 시점에 아직 없었다(`e78883617` = 07-24).
+- 결함 자체는 `6a761a793`(#3220, 07-24)에서 **다른 작업으로 이미 해소**돼 있었다.
+- `635d620cc`(#3311, 08-01)가 **계약으로 못박았다** — 177 케이스 무패닉 가드.
+
+교훈이 두 개다. ① 퍼징은 실제로 이 코드베이스에서 결함을 냈다. ② 그러나 그때
+퍼저를 돌린 건 우리가 아니라 **밖의 누군가**였다.
+
+### 5-2. 잡을 수 있었다 — 손으로 찾은 결함 13건
+
+`git log --oneline` 에서 "무검증 할당·부호확장·오버플로·무한루프" 계열 수정만 추린 것이다.
+전부 **사람이 코드를 읽어서** 찾았다(RFC §1 의 핵심 관찰과 동일).
+
+| 커밋 | 날짜 | 결함 | 클래스 | 퍼저가 잡았을까 |
+| --- | --- | --- | --- | --- |
+| `905b3261e` | 07-19 | lenient CFB 파서가 손상 헤더 값에 패닉 | 패닉 | **예** — `parse_hwp` |
+| `12ecfece6` | 07-20 | TAB_DEF·연결선 제어점 무제한 할당·무한루프 | OOM/루프 | **예** — `parse_hwp` |
+| `6b29fa1da` | 07-20 | 확장 레코드 `pos+size` 오버플로가 경계 검사 무력화(wasm32) | 오버플로 | 부분 — wasm32 전용 경로 |
+| `821d84465` | 07-22 | 표 그리드 68GB · HML 리소스 Id 선형 비례 (#2722·#2743) | OOM | **예** — `-rss_limit_mb` 로 |
+| `55e5ba086` | 07-22 | Region `scan_count`(i16) 음수 부호확장 → capacity overflow (#3004) | 부호확장 | **예** — `parse_wmf` |
+| `3202e746b` | 07-22 | DIB `colors_used`(u32) 무상한 `with_capacity` (#3000) | 무상한 | **예** — `parse_wmf` |
+| `6a761a793` | 07-24 | 악성 입력 무한루프·오버플로 방어 6건 (#3220) | 혼합 | **예** — 6건 중 CFB·WMF 다수 |
+| `1b02247ff` | 07-25 | WMF/CFB 메모리 안전 3건 (#3301) | 혼합 | **예** — `parse_wmf` |
+| `cdd55c838` | 08-02 | HWP3 셀 패딩 `read_i16 as u32 * 4` 부호확장 | 부호확장 | **예** — `parse_hwp3` |
+| `e288b0a7f` | 08-02 | HWP3 표/그림 여백 `i16 * 4` 오버플로 | 오버플로 | **예**(debug 빌드) |
+| `6bcbadcd1` | 08-02 | HWP3 drawing margin/size/offset 스케일 곱셈 오버플로 | 오버플로 | **예**(debug 빌드) |
+| `77627e953` | 08-02 | HWP3 셀 안여백 `u32` 곱셈 오버플로 | 오버플로 | **예**(debug 빌드) |
+| `ed339e78f` | 08-02 | HWP5 `row_span`/`col_span` 0 → `u16` 언더플로 패닉 | 언더플로 | **예** — `parse_hwp` |
+
+**"예"가 12건이다.** 퍼징 인프라는 07-24 에 들어왔는데, 그 뒤로도(08-02) 같은 클래스가
+5건 손으로 잡혔다. 인프라가 있는 것과 **돌아가는 것**은 다르다는 증거다.
+
+> ⚠️ 오버플로 3건(`e288b0a7f`·`6bcbadcd1`·`77627e953`)은 **debug 빌드에서만 패닉**한다
+> (release 는 wrap). cargo-fuzz 는 기본적으로 디버그 어서션을 켠 채 빌드하므로 검출
+> 대상이지만, 릴리스 프로파일로 빌드하면 조용히 틀린 값이 된다 — 그건 퍼징이 아니라
+> 왕복 정합성의 영역이다.
+
+### 5-3. 아직 남아 있다 — 지금 코드에 있는 후보 2곳 (HEAD `9095cd52d` 실측)
+
+`fuzz/regressions` 도 없고 퍼저도 안 돌았으니, **RFC 가 지목한 클래스가 아직 코드에
+남아 있는지** 직접 확인했다. 남아 있다.
+
+**후보 ①** — `src/wmf/parser/records/drawing/poly_line.rs:47`
+
+```rust
+let (number_of_points, number_of_points_bytes) =
+    crate::wmf::parser::read_i16_from_le_bytes(buf)?;   // i16 — 음수 가능
+record_size.consume(number_of_points_bytes);
+
+let mut a_points = Vec::with_capacity(number_of_points as usize);   // ← 부호확장
+```
+
+`number_of_points` 는 MS-WMF 정의상 **signed 16-bit** 이고(같은 파일 15~17행 주석),
+`read_i16_from_le_bytes` 는 `impl_from_le_bytes!` 매크로가 생성한 `(i16, usize)` 반환
+함수다(`src/wmf/parser/mod.rs:73-89`). 음수면 `as usize` 가 부호확장돼 `usize::MAX` 근처가
+되고 `Vec::with_capacity` 가 capacity overflow 로 패닉한다.
+
+**같은 결함이 `src/wmf/parser/records/drawing/polygon.rs:50` 에도 있다** (동일 형태).
+
+이게 오탐이 아닌 근거: **동일 패턴이 이미 고쳐진 자리**가 바로 옆에 있다.
+`src/wmf/parser/objects/graphics/region.rs:96` 은
+
+```rust
+if scan_count < 0 {
+    ... cause: format!("The scan_count field `{scan_count}` must not be negative"),
+```
+
+로 막고, 같은 파일 7~28행의 인라인 테스트가 기전을 그대로 적어 놓았다 —
+"`scan_count`에 -1(0xFFFF)을 넣으면 `as usize` 부호확장으로 `Vec::with_capacity`가
+usize::MAX 근처 값을 요청해 capacity overflow". 그 수정이 `55e5ba086`(#3004)이고,
+`poly_line`/`polygon` 두 곳은 그때 함께 손보지 않았다.
+
+**후보 ②** — `src/wmf/parser/objects/structure/bitmap16.rs:126`
+
+```rust
+pub fn calc_length(&self) -> usize {
+    ((((self.width * self.bits_pixel as i16 + 15) >> 4) << 1) * self.height) as usize
+}
+```
+
+`width`·`height` 는 `i16`(같은 파일 13·16행). i16 끼리 곱하므로 debug 빌드에서
+곱셈 오버플로 패닉, 음수면 `as usize` 부호확장. 반환값은
+`Bitmap16::parse` 가 `read_variable(buf, bitmap.calc_length())` 로 **읽기 길이**에
+그대로 쓴다(56~60행).
+
+**두 후보 모두 `parse_wmf` 하네스의 사정거리 안이다.** `META_POLYLINE::parse` 는
+`src/wmf/converter/mod.rs:224` 에서, `META_POLYGON::parse` 는 같은 파일 230행에서
+`WMFConverter::run()` 의 레코드 디스패치가 직접 부른다 — 하네스 진입점이 바로 그
+`run()` 이다(`fuzz/fuzz_targets/parse_wmf.rs`).
+
+이 후보들은 #3273 처리 문서(`mydocs/report/task_m100_3273_report.md` §후속)가 이미
+"퍼징 실행 시 자동 재현될 것으로 기대"라고 적어 둔 항목이다. **1년 가까이 기대만 남아
+있다** — 퍼저를 한 번도 안 돌렸기 때문이다.
+
+> 이 문서는 조사 문서이므로 여기서 수정하지 않는다. 확인된 후보는
+> [crash_triage.md §7](crash_triage.md) 의 이슈→수정 절차를 따른다.
+
+---
+
+## 6. 이 PC 에서 퍼징이 되나 — **안 된다** (실측)
+
+Windows 11 / `<저장소>` 워크트리 기준. 세 단계에서 막힌다.
+
+### 6-1. nightly 툴체인이 없다
+
+```
+$ rustup toolchain list
+stable-x86_64-pc-windows-gnu
+stable-x86_64-pc-windows-msvc (default)
+1.93.1-x86_64-pc-windows-msvc (active)
+```
+
+nightly 없음. `cargo +nightly fuzz build` 는 첫 줄에서 멈춘다.
+
+### 6-2. cargo-fuzz 가 설치돼 있지 않다
+
+```
+$ cargo fuzz --version
+error: no such command: `fuzz`
+help: a command with a similar name exists: `fix`
+```
+
+`~/.cargo/bin/` 실측에도 `cargo-fuzz.exe` 없음(있는 것: cargo-clippy, cargo-fmt,
+cargo-miri, rustfmt 등 14개).
+
+### 6-3. 근본 원인 — MSVC 링커가 깨져 있다
+
+이건 설치로 해결되지 않는다. 최소 크레이트 하나를 핀된 툴체인으로 링크해 봤다.
+
+```
+$ rustup run 1.93.1 cargo build     # 빈 hello-world 크레이트
+error: linking with `link.exe` failed: exit code: 1123
+  = note: CVTRES : fatal error CVT1107:
+      'C:\Program Files (x86)\Windows Kits\10\lib\10.0.26100.0\um\x64\dbghelp.lib'
+      이(가) 손상되었습니다.
+    LINK : fatal error LNK1123: COFF로 변환하는 동안 오류가 발생했습니다.
+```
+
+**Windows SDK 의 `dbghelp.lib` 자체가 손상**됐다. rustc 는 이 라이브러리를 모든
+MSVC 타깃 바이너리에 무조건 링크하므로, 이 PC 에서 **MSVC 타깃 실행 파일은
+어떤 것도 만들 수 없다.** cargo-fuzz 는 실행 파일을 만드는 도구다.
+
+### 6-4. GNU 툴체인은 링크된다 — 그러나 우회가 되지 않는다
+
+```
+$ rustup run stable-x86_64-pc-windows-gnu cargo build --target x86_64-pc-windows-gnu
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.66s
+```
+
+GNU 타깃은 정상 링크된다. 다만 libFuzzer 는 sanitizer 런타임에 의존하고,
+`x86_64-pc-windows-gnu` 에 대한 rustc sanitizer 지원 여부는 **이 환경에서 확인하지 못했다**
+(nightly 가 없어 `-Z sanitizer` 를 시험할 수 없다). **확인되지 않음.**
+
+`fuzz/README.md` 가 적어 둔 Windows 우회
+
+```sh
+RUSTFLAGS="-C linker=rust-lld" cargo +nightly fuzz build
+```
+
+역시 **이 PC 에서 검증하지 못했다** — 그 앞 단계(6-1)에서 막히기 때문이다. 다만 이
+우회가 문서에 적혀 있다는 사실 자체는, 과거 누군가 Windows 에서 같은 벽에 부딪혔다는
+방증이다.
+
+### 6-5. 결론 — 이 환경에서의 운영 방침
+
+| 하고 싶은 일 | 이 PC 에서 | 대안 |
+| --- | --- | --- |
+| 하네스 배선 점검 | ✗ | 코드 리뷰 + `[[bin]]`↔파일 개수 대조(§2-1) |
+| 실제 퍼징 | ✗ | Linux/macOS, 또는 CI(§7), 또는 OSS-Fuzz |
+| 크래시 재현 | ✗ | 최소화 입력을 **회귀 테스트로 승격**하면 `cargo test` 로 확인 가능 — 그 테스트는 MSVC 링크가 필요하므로 이 PC 에선 여전히 불가 |
+| 코퍼스 정리(`cmin`) | ✗ | 퍼징 가능 환경에서 |
+| 코드 근거 조사 | ✓ | §5-3 이 그 방식으로 후보 2곳을 찾았다 |
+
+**이 환경의 유일한 검증 수단은 CI 다.** 이는 퍼징만의 문제가 아니라 이 워크트리
+전반의 조건이다.
+
+---
+
+## 7. CI 에서 도는가 — **돌지 않는다** (수동 전용)
+
+### 7-1. 실측
+
+```
+$ grep -ril "fuzz" .github/
+(출력 없음)
+```
+
+`.github/workflows/` 의 워크플로 12개 — `ci.yml` · `codeql.yml` · `cache-generation-sweep.yml` ·
+`cancel-stale-pr-runs.yml` · `close-issues-on-devel-push.yml` · `deploy-pages.yml` ·
+`full-renderer-sweep.yml` · `node-binding.yml` · `npm-publish.yml` · `python-binding.yml` ·
+`release-binary.yml` · `render-diff.yml` — **어디에도 `fuzz` 문자열이 없다.**
+
+`ci.yml` 의 잡 8종도 마찬가지다: `preflight` · `build-test-archive` · `test-shard`(8샤드) ·
+`lint`(fmt/clippy/WASM check) · `native-skia-tests` · `frontend-package-gates` ·
+`build-and-test` · `wasm-build`.
+
+즉 **퍼징은 100% 수동**이고, 지금까지 이 저장소에서 정기적으로 돌았다는 기록은 없다.
+`fuzz/` 디렉터리를 건드린 커밋은 3개뿐이다(`git log -- fuzz/`): `489319d2c` ·
+`e78883617` · `2b87440ea` — 전부 인프라 도입 커밋이고, **크래시 유입 커밋은 0건**이다.
+
+### 7-2. 인접한 것 — CodeQL 은 돈다
+
+`.github/workflows/codeql.yml` 이 정적 분석을 돌린다. 다만 CodeQL 의 Rust 지원 범위와
+이 저장소 설정에서 무엇을 보는지는 **확인하지 않았다**. 퍼징과 겹치지 않는 축으로 두고,
+필요하면 별도로 조사한다.
+
+### 7-3. 넣는다면 — 두 단계로 나눈다
+
+RFC §6-5 는 "PR당 60초 × 하네스" 또는 "회귀 코퍼스 재생만이라도"라고 두 선택지를 준다.
+비용·효용을 실제 CI 구조에 맞춰 갈라 보면 순서가 분명하다.
+
+**단계 A — 회귀 코퍼스 재생 (먼저, 싸다)**
+
+- 하는 일: `fuzz/regressions/<타깃>/` 의 입력을 **각각 1회씩** 실행. 변이 없음.
+- 비용: 입력 수 × 수 ms. `test-shard` 에 얹으면 사실상 공짜다.
+- 얻는 것: **고친 결함의 재유입 차단.** 지금 `test-shard` 가 하는 일과 성격이 같다.
+- 전제: `fuzz/regressions/` 가 생겨야 한다(§3-3). 그리고 이 경로는 **cargo-fuzz 없이도**
+  구현 가능하다 — 회귀 입력을 읽어 `parse_*` 를 부르는 평범한 `#[test]` 면 된다.
+  `tests/issue_3311_malformed_cfb_no_panic.rs` 가 정확히 그 모양이다.
+- **권장: 이 형태로 먼저 넣는다.** nightly·cargo-fuzz 를 CI 에 들이지 않고
+  회귀 차단의 90%를 얻는다.
+
+**단계 B — 스모크 퍼징 (나중에, 비싸다)**
+
+- 하는 일: 타깃 6개 × 60초 변이 실행.
+- 비용: 러너 시간 6분 + nightly 설치 + cargo-fuzz 빌드(캐시 필요).
+- 얻는 것: 새 결함의 조기 발견 — 다만 60초는 §4-1 기준으로도 얕다.
+- 리스크: **비결정적 실패.** 퍼징은 매 실행이 다르므로 "관계없는 PR 에서 빨간불"이
+  생긴다. 그 순간 팀은 게이트를 무시하기 시작한다. 넣는다면
+  `workflow_dispatch` + 야간 스케줄로 두고 **PR 게이트로 삼지 않는 것**이 안전하다.
+  (`full-renderer-sweep.yml` 이 이미 그런 무거운 스윕 잡의 선례다.)
+
+**단계 C — OSS-Fuzz (RFC §7)**
+
+상시 퍼징은 근본적으로 우리 CI 가 할 일이 아니다. RFC 가 지적한 대로 등재 요건
+(MIT 라이선스 — 충족)은 이미 갖췄고, 남는 건 트리아지 부담을 감당할지에 대한
+**메인테이너 판단**이다. 등재 상태는 **확인되지 않음**([README.md §5](README.md)).
+
+---
+
+## 8. 커버리지 측정
+
+```sh
+cargo +nightly fuzz coverage parse_hwp
+```
+
+`fuzz/.gitignore` 가 `coverage/` 를 제외 대상으로 이미 잡아 두었다 — 즉 이 명령이
+쓰는 산출 경로를 상정한 설계다. 실제로 실행된 적이 있는지는 **확인되지 않음**
+(`fuzz/corpus` 외 산출물이 저장소에 없다).
+
+커버리지를 볼 때의 질문은 하나다: **컨테이너를 뚫었나?**
+`parse_hwp` 코퍼스가 `cfb_reader.rs` 만 훑고 `body_text.rs`·`control.rs` 에 못 닿았다면,
+RFC §4 의 2순위 하네스(`parse_body_text_section`·`parse_doc_info`·`parse_control`)를
+만드는 편이 시드를 더 넣는 것보다 낫다.
+
+---
+
+## 9. 무엇이 나오면 어디로 가나
+
+```
+크래시 산출물 (fuzz/artifacts/<타깃>/)
+        │
+        ├─▶ [crash_triage.md] 최소화 → 재현 → 층 판별
+        │
+        ├─▶ 이슈 등록 (기여 절차: 이슈 → 분석 → 수정 → 처리결과 문서 → PR)
+        │
+        ├─▶ 수정 PR + 회귀 테스트 (tests/issue_####_*.rs)
+        │
+        └─▶ 최소화 입력을 fuzz/regressions/<타깃>/ 에 커밋
+```
+
+보안 성격 판단이 필요하면 [`SECURITY.md`](../../../SECURITY.md) 와
+[agent_security/disclosure.md](../agent_security/disclosure.md) 를 따른다 —
+**공개 이슈로 먼저 올리지 않는다.** 단, 파서 크래시(DoS)는 #3311 처럼 공개 이슈로
+접수된 선례가 있으므로, 원격 코드 실행급이 아니면 공개 이슈가 관행이다.
+
+---
+
+## 10. 운영 체크리스트
+
+퍼징 세션 하나를 돌리기 전/후에 확인할 것.
+
+**전**
+- [ ] `cargo +nightly fuzz build` 통과 — 6개 타깃 전부
+- [ ] `fuzz/corpus/<타깃>/` 에 시드가 있는가 (빈 코퍼스는 헤더도 못 넘는다)
+- [ ] `-rss_limit_mb=2048 -timeout=30` 을 붙였는가
+- [ ] 디스크 여유 — `fuzz/target/` 과 코퍼스 증식이 GB 단위로 늘 수 있다
+      (`e288b0a7f` 커밋 메시지가 "C: 드라이브 상시 포화"로 테스트를 완주 못 한 기록을 남겼다)
+
+**후**
+- [ ] `cov`/`corp` 가 늘었는가 — 안 늘었으면 시드나 하네스를 바꿀 때다
+- [ ] 새로 늘어난 코퍼스 항목을 `cmin` 으로 줄였는가
+- [ ] 크래시가 있으면 [crash_triage.md](crash_triage.md) 로
+- [ ] 실행 조건(커밋 해시·타깃·시간·exec/s·최종 cov)을 어딘가에 남겼는가 —
+      **지금 이 저장소에는 그런 기록이 하나도 없다**(§7-1)
+
+---
+
+## 11. 확인되지 않음
+
+| 항목 | 이유 |
+| --- | --- |
+| `cargo +nightly fuzz build` 의 실제 통과 여부 | 이 PC 실행 불가(§6). #3158·#3273 처리 문서도 같은 이유로 미검증이라 기록 |
+| `+nightly` 가 `rust-toolchain.toml` 핀을 실제로 이기는가 | rustup 문서상 그렇지만 이 저장소에서 실행 확인 안 함 |
+| windows-gnu 타깃의 sanitizer/libFuzzer 지원 | nightly 부재로 시험 불가 |
+| 지금까지의 누적 퍼징 시간·발견 건수 | 저장소에 기록 없음. `fuzz/artifacts/` 는 gitignore |
+| OSS-Fuzz 등재 신청 상태 | 저장소 밖 정보 |
+| CodeQL 이 이 저장소에서 무엇을 보는가 | `codeql.yml` 내용 미조사 |
+| §5-3 후보 2곳이 **실제로** 퍼저에서 재현되는가 | 코드 근거만 확인. 실행 재현은 못 함 |
+
+## 관련
+
+- [README.md](README.md) — 이 묶음 지도 · [crash_triage.md](crash_triage.md) · [agent_surface_robustness.md](agent_surface_robustness.md)
+- [`fuzz/README.md`](../../../fuzz/README.md) — 실행 명령의 1차 출처
+- [agent_security/threat_model.md](../agent_security/threat_model.md) §1.1 — 신뢰 경계 ①/②
+- 이슈: [#3608](https://github.com/edwardkim/rhwp/issues/3608) M21 · [#3141](https://github.com/edwardkim/rhwp/issues/3141) RFC · [#3311](https://github.com/edwardkim/rhwp/issues/3311) 실제 발견 사례


### PR DESCRIPTION
로드맵 #3608 **M21(퍼징·견고성)** 운영 문서 **4편 1,615줄**. 인프라는 이미 있으니
새로 만들지 않고 **운영 문서**를 쓴다.

## 조사 결과 — 인프라는 있는데 아무도 안 돌리고 있다

퍼징 타깃 **6개**(`parse_hwp`·`parse_hwp3`·`parse_hwpx`·`parse_hml`·`parse_wmf`·
`parse_ooxml_chart`)가 두 단계로 들어와 있고 시드 코퍼스 12개/269KB 가 있다. 그런데:

```
$ grep -ril fuzz .github/
0
```

CI 에서 돌지 않는다. `fuzz/regressions/` 는 `fuzz/README.md` 가 규정하는데 **존재하지 않는다**.
`git log -- fuzz/` 커밋 3개가 전부 인프라 도입이고 **크래시 유입 0건**이다.

**퍼징이 실제로 잡은 것은 #3311 하나**인데, 그것도 우리 `fuzz/` 가 생기기 **전에**
외부 사용자가 4분 런으로 찾은 것이다(테스트 주석에 명시). 반대로 퍼저가 잡을 수 있었던
손수정 결함은 커밋 로그에서 **12건**이다.

## 이 문서가 코드 결함을 찾았다

`#3273` 처리 문서의 *"퍼징 실행 시 자동 재현될 것으로 기대"* 항목을 추적해
**미수정 패닉 2곳**을 찾았고 별도 PR 로 고쳤다 — WMF POLYLINE/POLYGON 의 음수
`NumberOfPoints` 가 `capacity overflow` 로 실제 패닉한다(red→green 실증).

## `agent_surface_robustness.md` 가 이 묶음의 독자적 축이다

퍼징은 보통 "파서가 안 죽는가"를 본다. **에이전트 표면에서는 죽지 않는 것만으로 부족하다** —
잘못된 봉투를 내면 에이전트가 잘못된 판단을 한다.

실측 공백 하나를 짚었다: **`info --json` 봉투에 `warnings` 가 없다**(`main.rs:6993`).
`show_info()` 가 JSON 분기에서 `return EXIT_OK` 로 끝나 HML 경고 출력(`:7434`)에 도달하지
못한다. 결과적으로 리소스가 조용히 잘린 문서가 **exit 0 + 완전해 보이는 봉투**를 낸다 —
`fonts` 가 부분 목록인데 봉투는 그렇다고 말하지 않는다(#3719 "부분 목록 금지" 위반).

퍼저는 원리상 이걸 못 본다(하네스가 반환값을 버린다). 대안으로 **코퍼스 재생 계약 스위트**를
제안했다 — cargo-fuzz 없이 stable `cargo test` 로 돌아 CI 즉시 편입이 가능하다.

## 이 PC 는 퍼징 불가 (실측)

nightly 없음 → `cargo fuzz` 미설치 → **근본적으로 MSVC `dbghelp.lib` 손상으로
링크 자체가 안 된다**(`CVT1107`/`LNK1123`). 최소 크레이트로 재현해 확인했다.

## 부수 — 현황판 드리프트

#3608 M21 체크리스트 4항목이 전부 미체크인데 첫 항목("cargo-fuzz 타깃 4종")은 **이미 머지됐다**.
#3608 본문이 "체크 = 진행률의 유일 기준"이라고 선언하므로 갱신이 필요하다.
