### PR TITLE
[M18~M20] 바인딩 동등성 계약 4편 — Python·Node 표류 20건 (치명 3건 실행 확인)

### DIFF
--- a/mydocs/README.md
+++ b/mydocs/README.md
@@ -74,6 +74,8 @@ front matter는 `mydocs/manual`, `mydocs/tech`, `mydocs/troubleshootings`의 모
 | [폰트 fallback 전략](tech/font_fallback_strategy.md) | canonical | active | `tech/font_fallback_strategy.md` | 2026-07-16 |
 | [편집 action undo/redo 아키텍처](tech/edit_action_undo_redo_architecture.md) | canonical | active | `tech/edit_action_undo_redo_architecture.md` | 2026-07-16 |
 | [포맷 파서와 공통 Document IR 경계](tech/parser_architecture.md) | canonical | active | `tech/parser_architecture.md` | 2026-07-17 |
+| [바인딩 동등성 계약](tech/bindings/parity_contract.md) | canonical | active | `tech/bindings/parity_contract.md` | 2026-08-03 |
+| [바인딩 문서 지도](tech/bindings/README.md) | guide | active | `tech/bindings/README.md` | 2026-08-03 |
 | [ThorVG 결정 기록](tech/thorvg_decision.md) | decision | active | `tech/thorvg_decision.md` | 2026-07-16 |
 | [이전 개발 로드맵](tech/archive/dev_roadmap_v1_backup.md) | snapshot | historical | `tech/archive/README.md` | 2026-07-16 |
 | [이슈별 기술 조사 지도](tech/investigations/README.md) | guide | active | `tech/investigations/README.md` | 2026-07-17 |

--- a/mydocs/tech/README.md
+++ b/mydocs/tech/README.md
@@ -32,6 +32,7 @@ last_verified: 2026-07-19
 | 에이전트 보안 — 문서가 에이전트를 조종하는 경로 | [에이전트 보안 문서 지도](agent_security/README.md) | [위협 모델](agent_security/threat_model.md), [공격 표면](agent_security/attack_surface.md), [소비 에이전트 가이드](agent_security/consumer_guide.md), 로드맵 #3793·구현 #3787 |
 | 신뢰할 수 없는 문서에 대한 경계 | [에이전트 경계 무결성 계약 — 경로·교정단서·자원한계·핸들](agent_boundary_contract.md) | 회귀 `tests/boundary_integrity_contract.rs`, 처리 결과 [task_sec_boundary](../report/task_sec_boundary/README.md) |
 | 외부 바인딩 공통 기반(M18~M20) | [IR 스키마 버저닝·표면 판단·파이썬 1호 명세](bindings_foundation.md) | 로드맵 #3608 M18~M20, [에이전트 표면 플레이북](../manual/agent_surface_playbook.md) |
+| 바인딩들 사이의 동등성 계약 | [바인딩 동등성 계약](bindings/parity_contract.md) | [바인딩 문서 지도](bindings/README.md), [새 언어 바인딩 추가 절차](bindings/new_binding_guide.md), [파이썬·Node 실측 대조](bindings/python_node_comparison.md) |
 | 이슈별 기술 조사 | [이슈별 기술 조사 지도](investigations/README.md) | [Issue #511 IR wrap 조사](investigations/issue-511/README.md), [Issue #1151 picture TAC 조사](investigations/issue-1151/README.md), [Issue #1584 이후 HWPX 잔여 IR 차이 조사](investigations/issue-1584/README.md), [Issue #1658 페이지네이션 조사](investigations/issue-1658/README.md), [Issue #1772 잔여 OVER 조사](investigations/issue-1772/README.md), [Issue #2125 font ownership 조사](investigations/issue-2125/README.md) |
 
 ## 현재 구조를 읽는 법

--- a/mydocs/tech/bindings/README.md
+++ b/mydocs/tech/bindings/README.md
@@ -1,0 +1,162 @@
+---
+kind: guide
+status: active
+canonical: mydocs/tech/bindings/README.md
+last_verified: 2026-08-03
+---
+
+# 외부 바인딩 문서 지도 — 동등성 계약 축
+
+`mydocs/tech/bindings/` 는 rhwp 의 **외부 언어 바인딩들이 서로 어긋나지 않게 하는 계약**을
+보존한다. 바인딩 하나하나의 사용법이 아니라 **바인딩들 사이**를 다룬다.
+
+로드맵 [#3608](https://github.com/edwardkim/rhwp/issues/3608) M18~M20 축의 전제는
+"같은 문서를 물으면 언어와 무관하게 같은 답이 나온다"이다. 바인딩이 하나일 때는 자명하고,
+둘이 되는 순간 **아무도 강제하지 않으면 깨진다.** 실제로 깨져 있다 — 확인된 표류가
+20건이다.
+
+## 이 디렉터리의 문서
+
+| 문서 | kind | 무엇을 답하나 |
+|---|---|---|
+| [`parity_contract.md`](parity_contract.md) | canonical | **새 바인딩이 지켜야 할 것.** 봉투 이름 규약·판정 vs 실패·버전 정합·노출 범위·강제 테스트 설계 |
+| [`new_binding_guide.md`](new_binding_guide.md) | guide | **C#/Swift 를 추가하려는 사람이 읽는 12단계.** 기존 두 구현을 코드 경로로 인용 |
+| [`python_node_comparison.md`](python_node_comparison.md) | reference | **현행 두 바인딩의 실측 차이 20건**과 의도/표류 판정 |
+
+## 이 디렉터리와 다른 문서의 관계
+
+```
+bindings_foundation.md  (../)          ← 설계 전제: 왜 서브프로세스인가, IR 스키마 버저닝
+        │                                (M18~M20 공통 기반, #3142 RFC 의 실행편)
+        ▼
+parity_contract.md  (여기, canonical)  ← 둘 이상이 됐을 때 무엇을 같게 유지하나
+        ├── new_binding_guide.md       ← 그 계약을 새 언어에 적용하는 절차
+        └── python_node_comparison.md  ← 그 계약에 비춘 현행 스냅샷
+                │
+                ▼
+manual/python_binding_guide.md         ← 언어별 사용법 (이 축 밖)
+manual/node_binding_guide.md
+bindings/*/docs/DESIGN.md              ← 언어별 결정 기록 (버린 대안 포함)
+```
+
+**중복을 피하는 경계:**
+
+- [`bindings_foundation.md`](../bindings_foundation.md) 는 **왜 이 표면인가**를 답한다.
+  표면 판단 매트릭스(CLI 서브프로세스 / 장수명 서버 / C ABI / WASM), IR 스키마 버저닝
+  전략, 마일스톤별 착수 조건이 거기 있다. 이 디렉터리는 그걸 다시 쓰지 않는다.
+- 이 디렉터리는 **둘 이상일 때 무엇을 같게 유지하나**를 답한다.
+- 언어별 사용법과 결정 기록은 `mydocs/manual/` 과 `bindings/*/docs/` 에 있다.
+
+## 언제 무엇을 읽나
+
+| 상황 | 읽을 것 |
+|---|---|
+| 새 언어 바인딩을 만든다 | [`new_binding_guide.md`](new_binding_guide.md) 를 순서대로. 각 단계가 [`parity_contract.md`](parity_contract.md) 의 해당 절을 가리킨다 |
+| 기존 바인딩에 명령·옵션을 추가한다 | [`parity_contract.md`](parity_contract.md) §5(노출 범위) → 다른 바인딩에도 같이 넣었는지 확인 |
+| 두 바인딩이 다르게 동작한다는 제보를 받았다 | [`python_node_comparison.md`](python_node_comparison.md) 에 이미 있는지 먼저 본다 |
+| 오류·예외를 새로 만든다 | [`parity_contract.md`](parity_contract.md) §3.3 매핑표 — 이름은 언어별로 정하지 않는다 |
+| 봉투에 필드를 더한다(본체 쪽) | [`parity_contract.md`](parity_contract.md) §2 — camelCase 이고, 바인딩은 자동으로 따라온다 |
+| CI 에 패리티 가드를 붙인다 | [`parity_contract.md`](parity_contract.md) §6 의 A·B·C 3층 |
+
+## 동등성을 강제하는 3층 (요약)
+
+계약을 문서로만 두면 지켜지지 않는다. 표류 20건이 그 증거다. 설계 전문은
+[`parity_contract.md`](parity_contract.md) §6.
+
+| 층 | 무엇을 대조하나 | 현재 |
+|---|---|---|
+| **A** 자기서술 대조 | `capabilities` ↔ 바인딩의 공개 표면 (선언→래퍼, 래퍼→선언, 옵션→플래그, 종료 코드 사전) | Node 에 2개, 파이썬에 1개. **A-1 이 파이썬에 없는 것이 표류 12건의 원인** |
+| **B** 교차 실행 골든 | 같은 케이스를 CLI·각 바인딩으로 돌려 **봉투 원문 바이트 비교** | 없음 (신규 설계) |
+| **C** 오류·판정 매핑 | 9개 실패 상황의 (종료 코드, 예외 계열, **예외인가 값인가**) | 파이썬에 절반 |
+
+A층만으로는 부족하다 — 각 바인딩이 *혼자서* 도구와 어긋나지 않았는지만 보므로, 두
+바인딩이 서로 다른 방식으로 어긋나 있으면 둘 다 통과시킨다. 그래서 B층이 있다.
+
+## 현재 상태 (2026-08-03 실측)
+
+| 마일스톤 | 언어 | 디렉터리 | 소스 | 표면 |
+|---|---|---|---|---|
+| M18 | Python | `bindings/python` | `src/rhwp` 11파일 3,148줄 | CLI 서브프로세스 — 1층 28명령 + 세션 + 계획 |
+| M19 | Node/TS | `bindings/node` | `src` 14파일 5,377줄 | 동일 + 생성 타입 + 브라우저(WASM) 어댑터 |
+| M20 | C#/Swift | `bindings/csharp`·`swift`·`Native` | 아래 참조 | **미착수** |
+
+### M20 자리에 이미 다른 것이 있다
+
+`bindings/csharp`·`bindings/swift`·`bindings/Native` 는 **비어 있지 않다.**
+
+```
+bindings/Native/src/lib.rs                        376줄   cdylib, C ABI
+bindings/csharp/RhwpNative.cs                      63줄   P/Invoke
+bindings/swift/Sources/Rhwp/*.swift                274줄
+bindings/swift/Sources/CRhwpNative/*.h             17줄
+```
+
+노출 함수는 넷뿐이다 — `rhwp_export_text`, `rhwp_export_markdown`, `rhwp_read_text`,
+`rhwp_string_free`. 봉투는 `{"ok":true,"pageCount":N,"files":[…]}` 형태로
+**`schemaVersion` 도 종료 코드도 판정 표현도 없다.**
+
+`bindings/README.md:5-9` 가 이 계열을 "Native ABI" 로, python·node 를 "CLI subprocess
+bindings" 로 명시적으로 갈라 놓았다. **즉 M20(서브프로세스 계열의 C#/Swift)이 미착수인
+것은 맞지만, 그 디렉터리 이름은 이미 다른 계약이 쓰고 있다.**
+
+M20 이 먼저 답해야 할 세 질문과 그때까지의 최소 방어는
+[`parity_contract.md`](parity_contract.md) §8 에 있다.
+
+## 핵심 결정 세 줄 요약
+
+세 결정의 근거와 버린 대안은 [`parity_contract.md`](parity_contract.md) 본문에 있다.
+
+1. **봉투 원문 키는 어떤 바인딩도 바꾸지 않는다.** 언어 관례(snake_case 등)는 *별칭 조회
+   계층*으로만 제공하고, 직렬화 가능한 `.raw` 는 CLI 가 낸 그대로 보존한다. 기존 두
+   바인딩이 이미 그렇게 되어 있고, 일괄 변환 함수는 만들어 두었지만 내부에서 한 번도
+   호출하지 않는다(§2).
+2. **exit 3/4 는 판정이라 반환값, exit 1/2 는 고장이라 예외.** opt-in 스위치로만 3/4 를
+   예외로 올릴 수 있고 기본값은 반드시 거짓. 계획 선검증 위반(exit 2 + `invalid`)만이
+   유일한 정당한 예외의 예외다(§3).
+3. **버전은 semver 로 묻지 않고 `capabilities` 로 기능을 묻는다.** 봉투 `schemaVersion`
+   major 불일치는 거부, minor·필드 추가는 통과, 바이너리 semver 는 확인하지 않는다.
+   버전 범위 표를 바인딩마다 들고 있으면 그게 곧 수기 매핑이고 언어 수만큼 복제된다(§4).
+
+## 지금 가장 급한 일
+
+[`python_node_comparison.md`](python_node_comparison.md) 의 표류 20건 중 우선순위:
+
+| 순위 | 항목 | 왜 |
+|---|---|---|
+| 1 | **D-19** 파이썬에 "선언 → 래퍼" 패리티 테스트 추가 | D-2·D-12 의 구조적 원인. 이걸 먼저 넣어야 나머지가 재발하지 않는다 |
+| 2 | **D-1** 파이썬 `convert`/`export_hwpx` 의 `-o` → 위치 인자 | 두 API 가 **항상 exit 2** 로 죽어 있다(실행으로 확인) |
+| 3 | **D-4** 파이썬 `Plan.check()` 에 `--dry-run` 게이트 추가 | 검사인 줄 알고 문서가 편집될 수 있다 |
+| 4 | **D-9** `VerifyReport` 진리값 의미 통일 | 같아 보이는 코드가 언어마다 반대 결론을 낸다 |
+| 5 | **D-2·D-12** 파이썬 `render_diff` 와 누락 옵션 4건 | 옵션이 없으면 기능이 없는 것과 같다 |
+
+## 이 축이 드러낸 본체 쪽 결함 (실측)
+
+바인딩 동등성을 계약으로 못 박으면 본체의 어긋남도 함께 드러난다. 둘 다 별도 이슈감이다.
+
+| 결함 | 실측 | 영향 |
+|---|---|---|
+| `export-structure --json` 의 `structure.node_count` 가 snake_case | 최상위는 `nodeCount`. 봉투 전체에서 `_` 가 든 키는 이것 하나 | 별칭 계층이 없는 언어(정적 매핑)에서 필드가 사라진다 |
+| `export-tables -o --json` 이 봉투 대신 사람 문장을 낸다 | `표 추출 완료: 12개 → …` | `--json` 봉투 계약 전체의 예외. 바인딩이 옵션을 닫은 것은 회피일 뿐 수정이 아니다 |
+
+## 실측 조건
+
+이 디렉터리의 모든 수치·동작 주장은 아래에서 직접 실행해 얻었다. 근거를 대지 못하는
+항목은 각 문서에 **확인되지 않음**으로 표시했다.
+
+- 바이너리: `target/release/rhwp.exe`, `rhwp v0.8.2`, 봉투 `schemaVersion 1.0`
+- `capabilities`: 명령 61개(그중 `json:true` 31개), 범주 분포
+  `diagnostic 25 / export 18 / query 8 / internal 5 / edit 3 / serve 1 / batch 1`
+- 표본 문서: `samples/2010-01-06.hwp` (hwp5, 6쪽, 87문단)
+- 파이썬 바인딩: `bindings/python/src` 를 `PYTHONPATH` 로 임포트해 **실행 검증**
+- Node 바인딩: **소스 정적 대조만** — 이 PC 에 `node_modules` 가 없어 `vitest`·`tsc` 미실행
+- 실행일: 2026-08-03
+
+## 관련 문서
+
+- [`bindings_foundation.md`](../bindings_foundation.md) — M18~M20 공통 기반 (설계 전제)
+- [`tech 문서 지도`](../README.md) — 상위 지도
+- [`python_binding_guide.md`](../../manual/python_binding_guide.md) — 파이썬 사용법
+- [`node_binding_guide.md`](../../manual/node_binding_guide.md) — Node 사용법
+- [`agent_surface_playbook.md`](../../manual/agent_surface_playbook.md) — 표면 추가 절차
+- [`cli_commands.md`](../../manual/cli_commands.md) — CLI 명령 레퍼런스
+- 로드맵 [#3608](https://github.com/edwardkim/rhwp/issues/3608) M18~M20

--- a/mydocs/tech/bindings/new_binding_guide.md
+++ b/mydocs/tech/bindings/new_binding_guide.md
@@ -1,0 +1,484 @@
+---
+kind: guide
+status: active
+canonical: mydocs/tech/bindings/parity_contract.md
+last_verified: 2026-08-03
+---
+
+# 새 언어 바인딩 추가 절차 — 파이썬·Node 가 실제로 한 일에서 뽑은 12단계
+
+C#·Swift(M20) 또는 그 뒤의 언어를 붙이려는 사람이 읽는 문서다. 각 단계마다 **기존 두
+구현이 그 자리에서 무엇을 했는지 코드 경로로 인용**한다 — 새로 설계할 것은 거의 없고,
+대부분은 이미 두 번 풀린 문제를 세 번째 언어로 옮기는 일이다.
+
+- 지켜야 할 계약: [`parity_contract.md`](parity_contract.md) (권위)
+- 두 구현의 현행 차이: [`python_node_comparison.md`](python_node_comparison.md)
+- 설계 전제: [`bindings_foundation.md`](../bindings_foundation.md)
+
+## 0. 시작 전 — 착수 조건과 세 가지 함정
+
+### 0.1 착수 조건
+
+`bindings_foundation.md` §4: **M20 은 "공공 SI 수요 실증 1건"(이슈 유입 또는 사용 보고)이
+착수 조건이다.** 수요 없이 만든 바인딩은 유지비만 남긴다.
+
+### 0.2 함정 ① — `bindings/csharp`·`bindings/swift` 는 비어 있지 않다
+
+**실측**: 그 자리에 이미 다른 계약의 구현이 있다.
+
+```
+bindings/Native/src/lib.rs   376줄  cdylib, C ABI 함수 4개
+bindings/csharp/RhwpNative.cs 63줄  P/Invoke 2개 (ExportText, ExportMarkdown)
+bindings/swift/Sources/…     274줄  Rhwp.swift + RhwpDocumentTextView.swift
+```
+
+노출 표면은 `rhwp_export_text`·`rhwp_export_markdown`·`rhwp_read_text`·`rhwp_string_free`
+넷뿐이고(`bindings/swift/Sources/CRhwpNative/rhwp_native_ffi.h`), 봉투는
+`{"ok":true,"pageCount":N,"files":[…]}` 형태로 **`schemaVersion` 도 종료 코드도 없다**
+(`bindings/Native/src/lib.rs:323-341`).
+
+`bindings/README.md:5-9` 가 이 계열을 "Native ABI" 로 따로 묶어 두었다.
+자세한 비교와 M20 이 답해야 할 질문은 [`parity_contract.md`](parity_contract.md) §8 에 있다.
+**그 질문에 먼저 답하지 않고 같은 디렉터리에 서브프로세스 바인딩을 만들면 한 네임스페이스에
+두 계약이 공존한다.**
+
+### 0.3 함정 ② — 재구현하고 싶어지는 순간이 온다
+
+바인딩은 재포장이다. **문서 파싱·좌표 계산·판정 로직을 바인딩 언어로 다시 쓰지 않는다.**
+두 번 쓰면 두 답이 언젠가 갈라지고, 그때 어느 쪽이 맞는지 아무도 모른다
+(`bindings/README.md:12-16`).
+
+### 0.4 함정 ③ — 파이썬을 그대로 베끼면 알려진 버그까지 온다
+
+[`python_node_comparison.md`](python_node_comparison.md) 의 표류 20건 중 12건이 파이썬 쪽이다.
+특히 D-1(`convert`/`export_hwpx` 의 `-o`), D-4(`--dry-run` 게이트 없음), D-5(인용 이스케이프)는
+**베끼면 그대로 옮겨 온다.** 두 구현이 다를 때는 그 문서의 판정을 따른다.
+
+---
+
+## 1단계 — 표면 선택: 서브프로세스인가 C ABI 인가
+
+`bindings_foundation.md` §2 의 매트릭스가 답한다: **1차 권고는 CLI 서브프로세스 래퍼.**
+C ABI 는 "수요 실증 후 승격".
+
+이유는 유지비다. 서브프로세스는 #2707 종료 코드 사전과 봉투 계약을 **그대로 재사용**하므로
+바인딩에 남는 것은 봉투 파서뿐이다. C ABI 는 ABI 안정성·메모리 규약·플랫폼별 배포 행렬을
+새로 만들어야 하고, 그건 되돌릴 수 없는 배포 표면이 된다.
+
+**C ABI 를 고른다면 이 문서의 나머지는 절반만 적용된다** — 종료 코드가 없으므로 §5 의
+판정/실패 구분을 다른 방식으로 표현해야 하고, 그 설계는 아직 없다.
+
+---
+
+## 2단계 — 모듈 골격을 두 구현과 같은 이름으로 자른다
+
+두 바인딩의 파일 구성이 거의 1:1 이다. 세 번째도 같게 자른다 — 그래야 "저기서는 어떻게
+했지"를 파일 이름으로 찾을 수 있다.
+
+| 역할 | Python | Node | 새 바인딩 |
+|---|---|---|---|
+| 바이너리 탐색 | `_binary.py` (137줄) | `binary.ts` (163줄) | `Binary` |
+| 종료 코드 → 오류 | `errors.py` (216줄) | `errors.ts` (268줄) | `Errors` |
+| 프로세스 실행 | `_process.py` (295줄) | `process.ts` (359줄) | `Process` |
+| 이름 변환 | `_naming.py` (95줄) | `naming.ts` (146줄) | `Naming` |
+| 봉투 래퍼 | `models.py` (178줄) | `envelope.ts` (254줄) | `Envelope` |
+| 1층 명령 | `commands.py` (505줄) | `commands.ts` (835줄) + `document-analysis.ts` (212줄) | `Commands` |
+| 2층 세션 | `session.py` (394줄) | `session.ts` (456줄) | `Session` |
+| 3층 계획 | `plan.py` (235줄) | `plan.ts` (312줄) | `Plan` |
+| 스키마 소비 | `schema.py` (282줄) | `schema.ts` (324줄) | `Schema` |
+| 생성 타입 | `ir.py` (613줄) | `ir.ts` + `envelopes.ts` (1,533줄) | 정적 타입 언어면 필수 |
+
+**3층 구조(무상태 / 세션 / 계획)는 CLI 의 층과 같다.** 새로 발명한 계층이 아니라
+`rhwp <명령>` / `mcp-serve` / `run --plan-json` 세 표면을 그대로 비춘 것이다.
+
+---
+
+## 3단계 — 바이너리 탐색: 순서 자체가 계약이다
+
+```
+1. 환경변수 RHWP_BIN
+2. 패키지 동봉
+3. PATH
+```
+
+`bindings_foundation.md` §3 이 고정했다. **순서를 바꾸면 안 되는 이유**가 두 구현의 주석에
+같은 문장으로 있다(`_binary.py:9-10`, `binary.ts:10-11`): 개발자가 로컬 빌드를 가리키고
+싶을 때(1) 패키지 동봉본(2)이 가로채면 "왜 내 수정이 반영 안 되지"라는 진단 불가 상황이
+생긴다.
+
+**구현 체크리스트:**
+
+- [ ] `RHWP_BIN` 이 **설정됐는데 못 쓰면 다음으로 넘어가지 않고 즉시 예외**.
+      (`_binary.py:75-80`, `binary.ts:78-100`) — 조용히 다른 바이너리가 실행되면
+      디버깅이 불가능해진다.
+- [ ] `RHWP_BIN` 이 디렉터리면 그 안의 실행 파일을 본다. (`_binary.py:71-72`, `binary.ts:87-90`)
+- [ ] 홈 디렉터리(`~`) 확장을 한다. **Node 는 안 한다**([D-16](python_node_comparison.md)) —
+      파이썬 쪽이 맞다.
+- [ ] 실행 가능한 **파일**인지 확인한다. Windows 는 실행 비트가 없으므로 확장자
+      (`.exe`/`.bat`/`.cmd`)로 판단. (`_binary.py:55-57`, `binary.ts:63-66`)
+- [ ] `stat` 자체가 실패하는 경우(경로 길이·권한)를 예외 없이 `false` 로 처리.
+- [ ] 결과를 프로세스 수명 동안 캐시하고, **테스트용 무효화 함수**를 둔다.
+      이름은 `clearBinaryCache` 계열로 — 파이썬의 `clear_cache` 는 무엇의 캐시인지
+      말하지 않는다([D-15](python_node_comparison.md)).
+- [ ] 못 찾았을 때 **시도한 위치를 전부** 메시지에 담는다. "없다"만 알려주면 사용자가
+      어디에 둬야 할지 모른다. (`_binary.py:133-137`, `binary.ts:158-162`)
+
+---
+
+## 4단계 — 프로세스 실행: 계약을 신뢰하되 검증한다
+
+`--json` 모드의 계약(실측: `rhwp capabilities` 의 `jsonContract`):
+
+```
+stdout   : 데이터(JSON/NDJSON)만 — 진단·진행·요약은 stderr
+failure  : 단건 명령 실패 시 stdout 0바이트; batch 는 error 레코드 + 최종 exit 1
+schemaPolicy: 필드 추가 허용, 변경·삭제는 schemaVersion 범프
+```
+
+**구현 체크리스트:**
+
+- [ ] 셸을 태우지 않는다. `spawn(…, {shell:false})` (`process.ts:87`) — 셸을 거치면
+      윈도우 인용 규칙 때문에 한글 경로가 깨진다.
+- [ ] stdout/stderr 를 **UTF-8 로 명시 디코딩**한다. 플랫폼 기본 인코딩을 따르면
+      윈도우에서만 한글이 깨지고, 그 깨짐이 "바인딩 버그"로 오인된다.
+      (`_process.py:106-107`, `process.ts:123-124`)
+- [ ] 불리언을 인자 **값 위치**에 넣으면 즉시 `TypeError`. 불리언은 플래그로 표현해야
+      하므로 값 위치에 오면 호출 조립 버그다. (`_process.py:61-66`, `process.ts:62-67`)
+- [ ] **봉투 파싱을 종료 코드 검사보다 먼저** 한다. exit 3 일 때도 봉투가 나오고, 그
+      봉투에 판정 근거가 들어 있다. 순서를 뒤집으면 가장 중요한 정보를 버린다.
+      (`_process.py:156-194`, `process.ts:191-236`)
+- [ ] stdout 이 JSON 이 아니거나 **성공인데 비어 있으면** `ProtocolError`.
+      빈 결과를 "차이 없음"으로 오독하는 것이 이 축에서 가장 위험한 실패다.
+- [ ] NDJSON: exit 1 은 예외로 올리지 않고 레코드의 `error` 필드를 호출자가 보게 한다.
+      exit 2 만 예외. (`_process.py:246-248`, `process.ts:296-299`)
+- [ ] 스트리밍 이터레이터를 제공하고, **소비자가 중간에 멈춰도 자식을 정리**한다.
+      남으면 파일을 잡고 있어 다음 작업이 막힌다. (`_process.py:291-295`, `process.ts:353-358`)
+- [ ] 제한 시간 기본 **300초**. `null`/`None` 이면 무제한. (`_process.py:27`, `process.ts:31`)
+
+---
+
+## 5단계 — 오류 매핑: 판정과 고장을 섞지 않는다
+
+[`parity_contract.md`](parity_contract.md) §3 이 권위다. 요약:
+
+```
+exit 1  → RhwpRuntimeError   (예외)
+exit 2  → UsageError         (예외)
+exit 3  → 반환값             (opt-in 시 VerdictFailed)
+exit 4  → 반환값             (opt-in 시 VerdictFailed)
+그 외 0 아님 → RhwpRuntimeError ("알 수 없는 종료 코드" — 조용히 통과 금지)
+```
+
+**실측으로 확인한 도구 동작:**
+
+```
+$ rhwp info nope.hwp --json
+오류: 파일을 읽을 수 없습니다 - nope.hwp: … (os error 2)      # stderr
+exit=1, stdout 0바이트
+
+$ rhwp bogus-cmd --json
+오류: 알 수 없는 명령입니다 - bogus-cmd                        # stderr
+exit=2, stdout 0바이트
+
+$ rhwp export-hwpx samples/2010-01-06.hwp out.hwpx --verify --json
+exit=3, stdout 에 봉투 (verify.identical=false)
+```
+
+**구현 체크리스트:**
+
+- [ ] 예외 계열 이름을 §3.3 표 그대로 쓴다. **시간 초과는 `RhwpTimeoutError`** —
+      언어 내장 이름을 가리지 않는다.
+- [ ] 예외에 `argv`·`exitCode`·`stderr`·`envelope` 를 싣는다.
+- [ ] 재현용 명령 문자열 getter(`command`)를 둔다. **역슬래시를 따옴표보다 먼저
+      이스케이프한다** — 순서가 뒤바뀌면 이미 넣은 이스케이프를 다시 이스케이프한다.
+      (`errors.ts:190-201`. 파이썬은 이 처리가 없다 — [D-5](python_node_comparison.md))
+- [ ] `UsageError` 에서 stderr 의 `힌트:` 줄을 `suggestion` 으로 꺼낸다.
+      (`errors.py:112-119`, `errors.ts:130-140`)
+- [ ] `UsageError` 에서 봉투의 `nextCall`(기계가 따라할 교정 호출)을 꺼낸다.
+      (`errors.ts:145-151`. 파이썬에는 없다 — [D-8](python_node_comparison.md))
+- [ ] opt-in 스위치를 둔다: `raise_on_verdict` / `throwOnVerdict` / 언어 관례.
+      **기본값은 반드시 거짓.**
+- [ ] 계획 선검증 위반은 exit 2 지만 `invalid` 가 있으면 값으로 돌려준다
+      (§3.5). `invalid` 가 없는 exit 2 는 그대로 올린다.
+
+---
+
+## 6단계 — 봉투 래퍼: 원문을 바꾸지 않는다
+
+[`parity_contract.md`](parity_contract.md) §2 가 권위다. 결정: **원문 키는 보존, 언어
+관례는 별칭 조회 계층으로만.**
+
+**구현 체크리스트:**
+
+- [ ] `.raw` 는 CLI 가 낸 그대로. 직렬화하면 CLI stdout 과 같아야 한다.
+- [ ] 조회는 원문 키·snake_case·camelCase 세 형태를 모두 받는다.
+      (`models.py:47-61`, `envelope.ts:125-138`)
+- [ ] **없는 필드는 조용한 `null` 이 아니라 예외.** 메시지에 **있는 필드 목록**을 함께
+      싣는다 — 오타가 "값 없음"으로 둔갑하면 그게 가장 찾기 어려운 버그다.
+      예외는 **오류 계열 안에** 둔다(Node 는 일반 `Error` 를 던진다 — [D-17](python_node_comparison.md)).
+- [ ] `verify` 는 전용 타입으로 감싸고, **미요청은 `null`**. `null`(검증 안 함)과
+      실패를 섞으면 검증하지 않은 저장을 통과로 읽는다.
+- [ ] `verifyPages` 도 감싼다. 실측 봉투에 `{"after":6,"before":6,"identical":true}` 로
+      들어 있는데 두 바인딩 모두 빠뜨렸다([D-10](python_node_comparison.md)).
+- [ ] `changedPages` 는 `null`(모른다) 과 `[]`(바뀐 쪽 없다) 를 구분한다.
+- [ ] **`verify` 객체에 진리값 훅을 두지 않는다.** `if (result.verify)` 가 언어마다 다른
+      뜻이 되는 것이 [D-9](python_node_comparison.md) 다. `identical` 을 읽게 강제한다.
+- [ ] `schemaVersion` major 를 대조하고 불일치면 `ProtocolError`
+      ([`parity_contract.md`](parity_contract.md) §4.4-1. **두 바인딩 모두 아직 안 한다**).
+
+---
+
+## 7단계 — 이름 변환: 규칙을 코드로, 표는 만들지 않는다
+
+```
+약어 경계  ([A-Z])([A-Z][a-z])   →  $1_$2      # 고정 길이 (ReDoS 회피)
+단어 경계  ([a-z0-9])([A-Z])     →  $1_$2
+그 뒤 소문자화
+```
+
+`HTMLPage` → `html_page`, `pageCountA` → `page_count_a`, `irSchemaVersion` →
+`ir_schema_version` (파이썬 규칙으로 실측 확인). 역변환은 `_` 분리 후 첫 글자 대문자화.
+
+**수기 매핑표를 만들지 않는 것이 이 단계의 요점이다**(`_naming.py:3-6`, `naming.ts:4-6`):
+사람이 이름을 다시 붙이기 시작하면 봉투에 필드가 하나 늘 때마다 바인딩이 뒤처지고,
+어느 쪽이 맞는지 알 수 없게 된다.
+
+**주의**: 일괄 변환 함수(`snake_keys`/`snakeKeys`)를 만들되 **내부에서 호출하지 않는다.**
+두 바인딩 모두 그렇게 되어 있다(grep 결과 사용처 0). 호출자가 원할 때만 쓰는 도구다.
+
+**예약어 회피**를 언어별로 둔다: 파이썬 `keyword.iskeyword` (`_naming.py:86-90`),
+Node 는 34개 집합 (`naming.ts:131-141`), C# 은 `@` 접두, Swift 는 백틱.
+
+---
+
+## 8단계 — 타입 생성: 정적 타입 언어면 필수
+
+동적 언어(파이썬)는 `Envelope` 하나로 충분했다. **정적 타입 언어는 다르다** —
+사용자가 그 언어를 고른 이유의 상당 부분이 "필드 이름을 컴파일러가 확인해 준다"인데
+`Dictionary<string, object>` 만 주면 그 값어치를 통째로 버린다
+(`bindings/node/docs/DESIGN.md` D3).
+
+### 두 출처
+
+| 출처 | 서술하는 것 | 산출 |
+|---|---|---|
+| `rhwp export-ir-schema` | 문서 모델(IR) | IR 타입 |
+| `rhwp capabilities` | 명령별 봉투(`recordFields`) | 봉투 타입 |
+
+**어느 한쪽으로 다른 쪽을 흉내 내면 그 순간 수기 매핑이 부활한다**
+(`bindings/node/tools/gen-types.ts:12-20`).
+
+### 실측 — 출처가 실제로 무엇을 주는가
+
+```
+$ rhwp export-ir-schema --json
+{ definitionCount: 41, dialect: "https://json-schema.org/draft/2020-12/schema",
+  irSchemaVersion: "1.0", schema: {...}, schemaVersion: "1.0" }
+
+$ rhwp capabilities        ← --json 을 받지 않는다! (실측: "알 수 없는 옵션: --json")
+{ commands: [61개], exitCodes: {...}, jsonContract: {...}, formats, batch,
+  tool: "rhwp", version: "0.8.2", schemaVersion: "1.0" }
+
+commands[].recordFields 예 (render-diff):
+  schemaVersion, mode, sourceA, sourceB, via, pageFilter, threshold,
+  pageCountA, pageCountB, pageCountMismatch, maxDisp, worstPage,
+  overPages, structPages, hardStructPages, status, regression, pages
+```
+
+`capabilities` 가 `--json` 을 거부한다는 점을 놓치지 말 것. 두 바인딩 모두 이 명령만
+`--json` 을 붙이지 않는다(`commands.py:169-172`, `commands.ts:255-260`).
+
+### 생성기 계약
+
+- [ ] `--check` 모드: 생성 결과가 디스크와 다르면 **exit 1**. CI 가 "스키마는 바뀌었는데
+      타입을 다시 안 만든 PR"을 잡는다. (`gen_models.py:14-18`, `gen-types.ts:29-32`)
+- [ ] 생성물은 저장소에 커밋한다. 대가는 문서 세 곳에 "손으로 고치면 다음 재생성에서
+      사라진다"를 적는 것.
+- [ ] 끊어진 `$ref` 를 먼저 검사한다 — 생성기가 절반쯤 만들다 죽는 것을 막는다.
+      (`schema.py:208-222` `dangling_references`)
+
+---
+
+## 9단계 — 1층: 무상태 명령 래퍼
+
+### 어떤 명령을 감싸는가
+
+[`parity_contract.md`](parity_contract.md) §5.3 이 기준이다. 실측 기준 **28개**:
+
+```
+batch  build-from-ingest  capabilities  convert  csv-to-table  digest
+export-capabilities-schema  export-doclang  export-hml  export-hwpx
+export-ir-schema  export-markdown  export-pdf  export-provenance-map
+export-structure  export-svg  export-tables  export-text  extract-data
+extract-pages  fields  info  inspect  ir-diff  render-diff  search
+table-to-csv  thumbnail
+```
+
+여기에 `edit` → `fill_fields`/`replace_text`/`set_cell` 3개, `run` → 3층 `Plan`.
+제외: `dump-pages`(진단), `category:internal` 5건, `mcp-serve`(2층이 담당).
+
+### 플래그는 명령과 다른 기준으로 가른다
+
+**`capabilities` 의 `flags` 는 "이 명령이 이 플래그를 파싱한다"만 말한다. `--json` 모드에서
+무엇을 하는지는 말하지 않는다.** 이 PC 에서 재실측한 결과:
+
+| 플래그 | 실측 | 처리 |
+|---|---|---|
+| `export-text -o`, `export-structure -o` | 무시(파일 안 생김) | 열지 않는다 |
+| `export-tables -o` | stdout 이 `표 추출 완료: 12개 → …` 사람 문장으로 바뀐다 | 열지 않는다 |
+| `export-capabilities-schema -o` | 봉투 유지(`output`·`bytes`) | 연다 |
+| `convert -o`, `export-hwpx -o` | `알 수 없는 옵션: -o`, **exit 2** | **위치 인자로** |
+| `render-diff --batch` | NDJSON 스트림 | 열지 않는다(반환 타입이 달라진다) |
+
+**`convert`/`export-hwpx` 는 반드시 위치 인자다.** 파이썬이 `-o` 를 쓰고 있어 두 API 가
+죽어 있다([D-1](python_node_comparison.md)). Node 쪽 구현을 따른다
+(`commands.ts:538-552`, `:559-575`). `convert` 는 산출 경로가 **필수**이므로 프로세스를
+띄우기 전에 `UsageError` 를 낸다.
+
+### 그 밖의 체크리스트
+
+- [ ] 모든 래퍼가 `--json` 을 붙인다. **예외는 `capabilities` 하나.**
+      (파이썬은 스키마 명령 4곳에서도 빠뜨렸다 — [D-3](python_node_comparison.md))
+- [ ] 검색어처럼 `-` 로 시작할 수 있는 값은 `--` 구분자 뒤에 넘긴다.
+      (`commands.py:126-129`, `commands.ts:206-217`)
+- [ ] 반복 가능한 값 플래그(`--font-path`)는 쉼표로 잇지 말고 **플래그를 반복**한다 —
+      경로에 쉼표가 들어갈 수 있다. (`commands.ts:77-89`)
+- [ ] 하위 명령이 있는 `inspect` 는 **CLI 순서(`검사`, `파일`)** 로 인자를 받는다.
+      파이썬은 반대다([D-11](python_node_comparison.md)).
+- [ ] `batch` 는 파일 목록을 stdin 으로 흘려 넣고 NDJSON 레코드를 돌려준다.
+      빈 목록은 실행 전에 거부. (`commands.py:484-505`)
+
+---
+
+## 10단계 — 2층 세션, 3층 계획
+
+### 2층 — `mcp-serve` stdio 클라이언트
+
+- [ ] JSON-RPC 프레임을 줄 단위로 주고받는다. 응답 `id` 대조 필수.
+- [ ] `hwp_open` → 핸들(`docId`) → `hwp_doc_*` 도구 → `hwp_close`.
+- [ ] 언어의 자원 정리 문법을 쓰되 **멱등 `close()` 가 계약**이다
+      (`session.py:210-236`, `session.ts:256-286`). 문법 설탕(`with`, `await using`,
+      `IDisposable`)은 그 위에 얹는다.
+- [ ] 이미 닫힌 핸들 재사용은 `SessionClosedError`.
+- [ ] **`timeout` 과 `cwd` 를 둘 다 받는다.** 파이썬은 `cwd` 가, Node 는 `timeout` 이
+      없다([D-14](python_node_comparison.md)).
+- [ ] 정리 경로에서 새 예외를 만들지 않는다 — 원인 예외를 가리면 진단이 어려워진다.
+      (`session.ts:396-407`)
+
+### 3층 — 계획 빌더
+
+- [ ] 체이닝 빌더 → 계획서 JSON(`planVersion`, `input`, `output`, `steps`, `assertions`,
+      `dryRun`) → `run --plan-json <문자열> --json`. (`plan.py:172-187`, `plan.ts:196-221`)
+- [ ] step 이 하나도 없으면 실행 전에 거부.
+- [ ] `check()` 는 `dryRun: true` 를 실어 보낸다.
+- [ ] **`check()` 전에 `capabilities` 로 `run` 의 `--dry-run` 지원을 확인한다.**
+      없으면 던진다 — `run()` 으로 대체하면 검사인 줄 알고 문서가 편집된다.
+      (`plan.ts:248-275`. 파이썬에는 없다 — [D-4](python_node_comparison.md))
+      확인 결과는 캐시하고 테스트용 무효화 함수를 둔다.
+- [ ] 선검증 위반(`invalid`)은 예외가 아니라 결과. `ok`·`violations`·`preview`·`steps`
+      접근자를 둔다. (`plan.py:36-88`, `plan.ts:41-83`)
+- [ ] 위반을 사람이 읽을 여러 줄로 만드는 `describe_violations` 를 둔다 — 로그와 오류
+      메시지에 그대로 쓰인다.
+
+---
+
+## 11단계 — 테스트
+
+[`parity_contract.md`](parity_contract.md) §6 이 층 구조를 정한다. 새 바인딩이 **처음부터**
+갖춰야 하는 것:
+
+### 11.1 바이너리 없이 도는 단위 테스트
+
+기여자에게 Rust 툴체인을 요구하면 기여가 줄고, 줄어든 기여는 곧 뒤처짐이다
+(`bindings/node/docs/DESIGN.md` D10). 탐색·변환·예외 매핑·계획 직렬화는 순수 로직이다.
+
+**가짜 바이너리 픽스처의 함정 두 가지** (Node 가 문서화해 뒀다,
+`test/helpers/fake-binary.ts:8-25`):
+
+1. **인코딩.** 실물 rhwp(Rust)는 콘솔 코드페이지와 무관하게 항상 UTF-8 바이트를 낸다.
+   픽스처가 플랫폼 기본 인코딩을 따르면 윈도우에서만 한글이 깨지고, 그 깨짐이 "바인딩
+   버그"로 오인된다. **파이썬판이 이 함정에 두 번 걸렸다.**
+2. **Windows 의 `.cmd` 래퍼.** `shell:false` 로는 `.bat`/`.cmd` 를 실행할 수 없다.
+   Node 는 인터프리터 실행 파일 자체를 rhwp 로 삼고 스크립트를 첫 인자로 앞세운다.
+   **새 언어도 같은 문제를 만난다.**
+3. 시나리오 이름을 자유 문자열로 두지 않는다 — 오타가 `default` 분기로 떨어져 exit 1 이
+   되면 "런타임 실패 경로가 잘 도네"라며 **테스트가 거짓 통과**한다.
+
+### 11.2 통합 테스트 (바이너리 필요, 없으면 건너뜀)
+
+파이썬 `pytestmark = pytest.mark.integration` + `binary_path` 픽스처가 없으면
+`pytest.skip` (`tests/conftest.py:44-50`). Node `describe.skipIf(!hasBinary)`.
+
+### 11.3 A층 — 자기서술 대조 (필수)
+
+- **A-1 선언 → 래퍼**: `capabilities` 의 `json:true` 명령마다 대응 함수가 있는가.
+  **수기 목록을 두지 않고 모듈이 실제로 내보내는 이름을 본다.**
+  이름 변환도 바인딩 자신의 `to_camel` 을 써야 규칙이 두 벌이 되지 않는다.
+  (`parity.integration.test.ts:76-111`. **파이썬에는 없고, 그래서 D-2·D-12 가 살아남았다.**)
+- **A-2 래퍼 → 선언**: 반대 방향. 노출 기준 목록에 없는데 감쌌으면 실패.
+- **A-3 옵션 → 플래그**: 조립한 플래그가 `capabilities.flags` 에 있는가.
+  **이 테스트가 있었으면 D-1 이 머지 전에 잡혔다.** 구현하려면 인자 조립을 실행에서
+  분리해야 한다 — 새 바인딩은 처음부터 그렇게 짠다.
+- **A-4 종료 코드 사전**: 매핑하는 다섯 코드를 도구가 전부 설명하는가.
+
+### 11.4 B층 — 교차 실행 골든 (신규)
+
+같은 케이스를 CLI·기존 바인딩·새 바인딩으로 돌려 **봉투 원문을 바이트 비교**한다.
+정규화 대상은 `source`·`output`(경로)뿐. `bytes`·`sizeBytes` 는 정규화하지 않는다 —
+다르면 그게 결함이다. 케이스 목록은 **저장소 한 곳**에 둔다.
+
+### 11.5 C층 — 오류·판정 매핑 대조 (신규)
+
+[`parity_contract.md`](parity_contract.md) §6.3 의 9개 케이스. "예외인가 값인가" 열이
+핵심이다 — 클래스 이름이 같아도 한쪽이 던지고 한쪽이 돌려주면 다른 결과가 된다.
+
+---
+
+## 12단계 — 패키징
+
+| 항목 | Python | Node | 새 바인딩 지침 |
+|---|---|---|---|
+| 이름 | `rhwp` (PyPI) | `@rhwp/node` (npm) | 생태계 관례 |
+| 버전 | `0.1.0` | `0.1.0` | rhwp 버전(`0.8.2`)과 **독립** |
+| 라이선스 | MIT | MIT | MIT |
+| **런타임 의존성** | **0** (`dependencies = []`) | **0** (`"dependencies": {}`) | **0 을 유지한다** |
+| 개발 의존성 | 상한 고정 (`mypy>=1.0,<1.11`) | `devDependencies` | 상한을 건다 |
+| 하한 | Python `>=3.8` | Node `>=18` | 실제로 검증한 최저만 |
+| 바이너리 동봉 | 미구현 | 미구현 | §3 의 2번 경로 |
+
+**런타임 의존성 0 이 규약이다**(`pyproject.toml:29-30`: "바인딩이 무거우면 '재포장'이
+아니라 새 표면이 된다"). 서브프로세스 실행·JSON 파싱은 어느 언어든 표준 라이브러리에 있다.
+
+**개발 의존성에 상한을 거는 이유**(`pyproject.toml:33-34`): 상한이 없으면 린터·타입체커의
+정책 변경이 제품 CI 를 바꾼다.
+
+---
+
+## 13. 완료 판정 — 이걸 다 채우면 끝이다
+
+- [ ] `bindings_foundation.md` §4 의 착수 조건이 충족됐다.
+- [ ] [`parity_contract.md`](parity_contract.md) §5.3 기준의 명령 28개 + `edit` 3 + `Plan` 을 노출한다.
+- [ ] §9 의 플래그 표를 그대로 따른다(`convert`/`export-hwpx` 는 위치 인자).
+- [ ] §3.3 예외 계열 8종을 같은 이름으로 갖는다(시간 초과는 접두형).
+- [ ] exit 3/4 가 기본 경로에서 예외가 아니다 — 실행으로 확인했다.
+- [ ] `schemaVersion` major 대조가 있다.
+- [ ] 계획 `check()` 에 `capabilities` 게이트가 있다.
+- [ ] A층 4개 테스트가 CI 에서 돈다.
+- [ ] B층 골든 러너에 새 언어가 등록됐다.
+- [ ] C층 9케이스가 돈다.
+- [ ] 런타임 의존성 0.
+- [ ] `bindings/README.md` 에 항목을 추가하고, 이 문서의 §2 표에 열을 추가했다.
+- [ ] [`python_node_comparison.md`](python_node_comparison.md) 에 3자 비교로 확장했거나,
+      새 비교 문서를 만들고 상호 링크했다.
+
+## 14. 관련 문서
+
+- [`parity_contract.md`](parity_contract.md) — 지켜야 할 계약 (권위)
+- [`python_node_comparison.md`](python_node_comparison.md) — 베끼면 안 되는 자리 목록
+- [`README.md`](README.md) — 이 디렉터리의 지도
+- [`bindings_foundation.md`](../bindings_foundation.md) — 표면 판단·착수 조건
+- [`python_binding_guide.md`](../../manual/python_binding_guide.md) ·
+  [`node_binding_guide.md`](../../manual/node_binding_guide.md) — 언어별 사용법
+- [`agent_surface_playbook.md`](../../manual/agent_surface_playbook.md) — 표면 추가 절차
+- `bindings/python/docs/DESIGN.md` · `bindings/node/docs/DESIGN.md` — 버린 대안 기록
+- 로드맵 [#3608](https://github.com/edwardkim/rhwp/issues/3608) M18~M20

--- a/mydocs/tech/bindings/parity_contract.md
+++ b/mydocs/tech/bindings/parity_contract.md
@@ -1,0 +1,616 @@
+---
+kind: canonical
+status: active
+canonical: mydocs/tech/bindings/parity_contract.md
+last_verified: 2026-08-03
+---
+
+# 바인딩 동등성 계약 — 언어가 늘어도 답이 하나이기 위한 규약
+
+로드맵 [#3608](https://github.com/edwardkim/rhwp/issues/3608) M18~M20 의 바인딩 축은
+"같은 문서를 물으면 언어와 무관하게 같은 답이 나온다"를 전제로 서 있다. 그런데 그
+전제는 **아무도 강제하지 않으면 반드시 깨진다.** 실제로 깨져 있고, 이 문서를 쓰면서
+확인한 표류가 §7 에 20건 있다.
+
+이 문서는 바인딩 하나하나의 사용법이 아니라 **바인딩들 사이의 계약**을 고정한다.
+설계 전제(왜 서브프로세스인가, IR 스키마 버저닝)는
+[`bindings_foundation.md`](../bindings_foundation.md) 가 권위이고, 이 문서는 그 위에서
+"둘 이상이 됐을 때 무엇을 같게 유지하는가"만 다룬다.
+
+- 언어별 사용법: [`python_binding_guide.md`](../../manual/python_binding_guide.md),
+  [`node_binding_guide.md`](../../manual/node_binding_guide.md)
+- 새 언어를 추가하는 절차: [`new_binding_guide.md`](new_binding_guide.md)
+- 현행 두 바인딩의 실측 차이 목록: [`python_node_comparison.md`](python_node_comparison.md)
+
+## 0. 이 문서가 쓰는 "실측"의 뜻
+
+이 문서의 모든 수치·동작 주장은 아래 환경에서 직접 실행해 얻었다. 근거를 대지 못하는
+항목은 본문에 **확인되지 않음**으로 명시한다.
+
+| 항목 | 값 |
+|---|---|
+| 바이너리 | `target/release/rhwp.exe`, `rhwp v0.8.2` |
+| 봉투 `schemaVersion` | `1.0` |
+| `capabilities` 명령 수 | 61개 (그중 `json:true` 31개) |
+| 표본 문서 | `samples/2010-01-06.hwp` (hwp5, 6쪽, 87문단) |
+| 파이썬 바인딩 | `bindings/python/src` 를 `PYTHONPATH` 로 직접 임포트, `RHWP_BIN` 지정 |
+| 실행일 | 2026-08-03 |
+
+Node 바인딩은 **소스 정적 대조만** 했다. 이 PC 에는 `bindings/node/node_modules` 가 없어
+`vitest`·`tsc` 를 돌리지 못했다 — Node 쪽의 "실행하면 이렇게 된다"는 주장은 코드 경로
+인용으로만 뒷받침되며, 그 사실을 해당 자리마다 적었다.
+
+---
+
+## 1. 계약의 범위 — 무엇이 "같아야" 하는가
+
+바인딩은 새 표면이 아니라 **CLI `--json` 봉투와 `mcp-serve` 세션 도구의 재포장**이다
+(`bindings_foundation.md` §2). 따라서 동등성은 "API 가 똑같이 생겼다"가 아니라
+**같은 입력이 같은 봉투를 만들어 낸다**로 정의한다.
+
+| 계층 | 동등해야 하는가 | 근거 |
+|---|---|---|
+| 봉투 원문(`.raw`) | **바이트 단위로 동일** | 같은 CLI 를 같은 인자로 부른다면 다를 이유가 없다 |
+| 노출하는 명령 집합 | **동일** | 한쪽에만 있으면 그 언어 사용자는 "이 도구엔 그 기능이 없다"고 결론 내린다 |
+| 명령별 옵션 집합 | **동일** | 옵션이 없으면 그 기능이 없는 것과 같다 |
+| 종료 코드 → 오류 표현 | **의미가 동일** (이름은 언어 관례) | §3 |
+| 접근자 이름 | 언어 관례를 따른다 | §2 |
+| 비동기/동기 | 언어 관례를 따른다 | Node 는 Promise, 파이썬은 동기 — 강제하지 않는다 |
+| 자원 정리 문법 | 언어 관례를 따른다 | `with` / `await using` / `IDisposable` |
+
+**"언어 관례를 따른다"가 허용되는 자리와 아닌 자리를 가르는 기준은 하나다: 그 차이가
+호출자의 *결론*을 바꾸는가.** `doc.fill_fields` 냐 `doc.fillFields` 냐는 결론을 바꾸지
+않는다. `render_diff` 가 있느냐 없느냐는 바꾼다.
+
+---
+
+## 2. 봉투 필드 이름 — 결정과 근거
+
+### 2.1 결정
+
+> **봉투의 원문 키는 어떤 바인딩도 바꾸지 않는다. 언어 관례(snake_case 등)는
+> *별칭 조회 계층*으로만 제공하고, 직렬화 가능한 원문(`.raw`)은 CLI 가 낸 그대로
+> 보존한다.**
+
+즉 "이름을 바꾼다 vs 그대로 둔다"의 답은 **둘 다**이되 층이 다르다.
+
+- **저장 층**: 원문 그대로. `env.raw["pageCount"]` 는 언제나 존재한다.
+- **조회 층**: 원문 키·snake_case·camelCase 를 모두 받는다. 없는 키는 조용히
+  `None`/`undefined` 가 아니라 예외.
+
+### 2.2 이 결정이 "이미 그렇게 되어 있다"는 근거
+
+먼저 기존 둘이 실제로 무엇을 하는지 확인했다. 둘 다 원문을 보존한다.
+
+| 동작 | 파이썬 | Node |
+|---|---|---|
+| 원문 보관 | `models.py:38` — `object.__setattr__(self, "_raw", dict(raw))` | `envelope.ts:81` — 생성자가 `source` 를 그대로 보관 |
+| snake→원문 색인 | `models.py:41-44` — `index.setdefault(to_snake(key), key)` | `envelope.ts:87-92` — `index.set(toSnake(key), key)` |
+| `.raw` 반환 | `models.py:82-84` — 원문 dict 사본 | `envelope.ts:100-102` — `{ ...this.source }` |
+| 3중 조회 | `models.py:47-61` — 원문 → snake 색인 → camel 역변환 | `envelope.ts:125-138` — 같은 순서 |
+
+결정적 근거는 **일괄 변환 함수가 존재하지만 바인딩 내부에서 한 번도 호출되지 않는다**는
+사실이다.
+
+- 파이썬: `_naming.py:59` `snake_keys` / `:74` `camel_keys` — `bindings/python/src` 전체
+  grep 결과 정의부와 재귀 호출 외 사용처 0.
+- Node: `naming.ts:80` `snakeKeys` / `:85` `camelKeys` — `bindings/node/src` 전체 grep 결과
+  정의부와 `index.ts` 재수출 외 사용처 0.
+
+두 바인딩 모두 이 함수들을 **호출자에게 선택지로만 제공**한다. 개명은 기본 경로가 아니다.
+
+### 2.3 왜 이 쪽인가 (버린 대안)
+
+**버린 대안 ①: 봉투를 통째로 언어 관례로 변환해서 넘긴다.**
+`snake_keys(envelope)` 를 파이프라인에 넣으면 `env["page_count"]` 만 유효해진다.
+그러면 세 가지가 깨진다.
+
+1. **로그와 버그 리포트가 갈라진다.** 사용자가 붙여 넣은 JSON 이 CLI 출력과 다르면,
+   메인테이너는 그게 도구 버그인지 바인딩 변환 버그인지 먼저 가려야 한다.
+2. **문서가 언어 수만큼 갈라진다.** `capabilities` 의 `recordFields` 는 camelCase 목록
+   하나다(실측: `render-diff` 의 `recordFields` 에 `pageCountA`·`hardStructPages` 등).
+   변환하면 언어마다 그 목록을 다시 써야 하고, 그 순간 수기 매핑이 부활한다.
+3. **왕복이 깨진다.** 계획서(`run --plan-json`)는 camelCase 로 보내야 한다. 받을 때
+   바꾸고 보낼 때 되돌리면 변환 규칙 두 벌이 항상 왕복 일치해야 하는데, 그건
+   `to_snake ∘ to_camel = id` 를 요구한다. 성립하지 않는다 — `pageCountA` →
+   `page_count_a` → `pageCountA` 는 돌아오지만, 원문이 이미 snake 인 키
+   (§2.4 의 `node_count`)는 돌아오지 않는다.
+
+**버린 대안 ②: 원문 키만 받고 별칭을 두지 않는다.**
+파이썬에서 `env["pageCount"]` 만 되고 `env.page_count` 가 안 되면, 그 언어를 쓰는 이유의
+절반이 사라진다. 별칭은 **읽기 편의**일 뿐 저장 형식이 아니므로 위 세 문제를 만들지 않는다.
+
+### 2.4 이 결정이 드러낸 본체 쪽 결함 (실측)
+
+원문 보존을 계약으로 못 박으면, 원문이 규약을 어길 때 그 사실이 그대로 드러난다.
+
+```
+rhwp export-structure samples/2010-01-06.hwp --json
+→ 최상위 키: mode, nodeCount, schemaVersion, source, structure,
+             untrustedContent, untrustedFields          (camelCase)
+→ structure 하위 키: mode, node_count, roots            (snake_case!)
+```
+
+봉투 전체를 재귀 순회해 `_` 가 든 키를 뽑으면 정확히 하나 나온다: `structure.node_count`.
+같은 값이 최상위에는 `nodeCount` 로 있다. `info --json` 은 0건이다.
+
+**판정: 본체 쪽 결함이다.** 봉투 키는 camelCase 가 계약인데 한 자리가 어긋나 있다.
+두 바인딩 모두 3중 조회 덕에 **우연히** 동작하지만(`env["node_count"]` 도
+`env["nodeCount"]` 도 통한다), 별칭 계층이 없는 언어(C#·Swift 의 정적 매핑)가 붙는 순간
+그 자리에서 필드가 사라진다. 별도 업스트림 이슈감이다.
+
+### 2.5 언어별 별칭 규칙 (M20 이 따라야 할 표)
+
+| 언어 | 원문 저장 | 별칭 | 예약어 회피 |
+|---|---|---|---|
+| Python | `Envelope.raw` (dict) | `env.page_count` / `env["pageCount"]` / `env["page_count"]` | `_naming.py:86` `reserved_safe` — `from` → `from_` |
+| Node/TS | `Envelope.raw` (제네릭 객체) | `env.get('pageCount')` / `get('page_count')` | `naming.ts:131-141` `RESERVED` 집합 |
+| C# (M20) | `Envelope.Raw` (`JsonElement` 또는 `IReadOnlyDictionary`) | `env.Get("pageCount")` + `PageCount` PascalCase 프로퍼티 | C# 예약어는 `@` 접두 |
+| Swift (M20) | `Envelope.raw` | `env["pageCount"]` + `pageCount` 프로퍼티 | 백틱 |
+
+**변환 규칙은 코드로 고정하고 손으로 매핑표를 만들지 않는다.** 두 바인딩의 규칙은
+정규식 두 개다.
+
+```
+약어 경계  파이썬 _naming.py:18  ([A-Z]+)([A-Z][a-z])
+           Node   naming.ts:22   ([A-Z])([A-Z][a-z])      ← 고정 길이
+단어 경계  양쪽                  ([a-z0-9])([A-Z])
+```
+
+Node 가 앞 그룹을 고정 길이로 바꾼 이유가 주석에 있다(`naming.ts:16-21`): 가변 길이
+`[A-Z]+` 는 `AAAA…Aa` 입력에서 역추적이 다항으로 늘어난다(ReDoS). 결과는 같다 —
+`HTMLPage` 로 실측 확인했다(파이썬 규칙도 `html_page`). **새 바인딩은 고정 길이 쪽을
+쓴다.** 파이썬은 아직 가변 길이다(§7 D-6).
+
+---
+
+## 3. 판정 vs 실패 — #3719 불변식의 언어별 표현
+
+### 3.1 종료 코드 사전 (실측: `rhwp capabilities` 의 `exitCodes`)
+
+| 코드 | 도구 설명(원문 요약) | 성격 |
+|---|---|---|
+| 0 | 성공 | — |
+| 1 | 런타임 실패 (읽기·파싱·렌더·쓰기) | **고장** |
+| 2 | 사용법 오류 (인자 없음, 알 수 없는 옵션/명령, 페이지 범위 초과) | **고장(호출자 버그)** |
+| 3 | 검증 단언 실패 — `convert`/`export-hwpx --verify` IR 차이, `edit` 3종 `--verify` 저장본 불일치, `run` 계획 assertions 미충족, `render-diff --json` 시각 회귀 | **판정** |
+| 4 | `--verify-pages` 페이지 수 불일치 | **판정** |
+
+### 3.2 계약
+
+> **exit 3/4 는 예외가 아니다. 봉투를 반환값으로 돌려주고, 판정은 봉투의 필드로 읽는다.
+> 예외를 원하는 호출자는 명시적으로 요청한다(기본값 아님).
+> exit 1/2 는 예외다. 알 수 없는 코드도 예외로 올린다.**
+
+근거는 두 바인딩의 주석이 같은 문장으로 적고 있다(`errors.py:9-14`, `errors.ts:10-13`):
+`--verify` 가 불일치를 보고한 것은 **도구가 정상 동작한 결과**다. 예외로 만들면 호출자가
+`try/except` 로 "고장"처럼 다루고, 정작 봉투에 담긴 판정 근거(`diffCount`·`status`·`pages`)를
+읽지 않는다.
+
+**실측으로 확인한 실행 경로** (파이썬, `RHWP_BIN` 지정):
+
+```
+rhwp export-hwpx samples/2010-01-06.hwp <out> --verify --json   → exit 3
+rhwp.export_hwpx(S, verify=True, verify_pages=True)
+  → 예외 없음. r.verify.identical == False, bool(r.verify) == False
+```
+
+exit 3 이 값으로 돌아온다는 것을 실제 실행으로 확인했다.
+
+### 3.3 언어별 매핑표 (M20 이 채워야 할 자리)
+
+| 상황 | Python (`errors.py`) | Node (`errors.ts`) | C#/Swift 지침 |
+|---|---|---|---|
+| 기반 | `RhwpError` (:51) | `RhwpError` (:57) | 언어의 최상위 예외를 상속한 단일 기반 |
+| 바이너리 없음 | `BinaryNotFoundError` (:96) | `BinaryNotFoundError` (:116) | 이름 동일 |
+| exit 2 | `UsageError` (:104) | `UsageError` (:124) | 이름 동일 |
+| exit 1 | `RhwpRuntimeError` (:122) | `RhwpRuntimeError` (:160) | 이름 동일 |
+| exit 3/4 (opt-in) | `VerdictFailed` (:130) | `VerdictFailed` (:168) | 이름 동일 |
+| stdout 계약 위반 | `ProtocolError` (:144) | `ProtocolError` (:181) | 이름 동일 |
+| 닫힌 세션 재사용 | `SessionClosedError` (:152) | `SessionClosedError` (:184) | 이름 동일 |
+| 제한 시간 초과 | `TimeoutError` (:156) | `RhwpTimeoutError` (:187) | **`RhwpTimeoutError` 로 통일** |
+| opt-in 스위치 이름 | `raise_on_verdict` | `throwOnVerdict` | 언어의 "예외를 올린다" 동사를 쓴다 |
+
+시간 초과만 이름이 갈렸다. 파이썬이 내장 `TimeoutError` 를 가리는 쪽을 택했고
+(`errors.py:156` 에 `noqa: A001 - 내장 이름 가림은 의도적(패키지 일관성)`), Node 는
+접두를 붙였다. **새 바인딩은 접두형을 쓴다** — 내장 이름을 가리면 `except TimeoutError`
+한 줄이 어느 쪽을 잡는지 파일마다 임포트를 봐야 알 수 있고, 그건 오류 처리 코드가 가장
+피해야 할 성질이다. 파이썬 쪽 정정은 §7 D-7.
+
+### 3.4 예외에 반드시 실어야 하는 것
+
+두 바인딩 모두 예외에 네 가지를 담는다. **이것이 계약이다.**
+
+| 필드 | 왜 필요한가 |
+|---|---|
+| `argv` | 재현 가능한 명령. 버그 리포트에 그대로 붙일 수 있어야 한다 |
+| `exit_code` / `exitCode` | 프로세스를 못 띄웠으면 `None`/`undefined` — "0 아님"과 구분된다 |
+| `stderr` | 진단은 stdout 이 아니라 stderr 에 있다. did-you-mean 힌트 포함 |
+| `envelope` | **exit 3 일 때도 봉투가 나온다.** 판정 근거를 버리지 않는다 |
+
+파싱을 종료 코드 검사보다 **먼저** 하는 이유가 여기 있다(`_process.py:156-194`,
+`process.ts:191-236`). 순서를 뒤집으면 exit 3 봉투를 통째로 버린다.
+
+### 3.5 계획 계층의 예외 — 유일한 정당한 예외의 예외
+
+`run --plan-json` 의 선검증 위반은 **exit 2** 로 나온다. 기본 규약대로면 `UsageError` 다.
+그러나 계획 실행에서 위반은 정상적인 결과이므로, `invalid[]` 를 담은 봉투는 값으로
+돌려준다.
+
+- 파이썬 `plan.py:205-226` — `UsageError` 를 잡아 `exc.envelope` 에 `invalid` 가 있으면
+  `PlanResult` 로 변환, 없으면 재발생.
+- Node `plan.ts:290-302` — 동일 로직.
+
+**새 바인딩은 이 예외를 그대로 승계한다.** 조건도 같다: `invalid` 키가 **없는** exit 2 는
+진짜 호출 조립 버그이므로 그대로 올린다.
+
+### 3.6 batch 의 부분 실패
+
+`batch` 는 NDJSON 이고 **부분 실패도 실패**다(capabilities `jsonContract.failure`:
+"batch 는 error 레코드 + 최종 exit 1"). 규약:
+
+- exit 1 을 예외로 올리지 않는다. 성공 레코드를 버리면 안 되기 때문이다.
+- exit 2 는 스트림이 성립하지 않은 것이므로 예외로 올린다.
+- 실패 항목은 `error` 필드를 단 레코드로 스트림에 남는다.
+
+근거: `_process.py:207-249`, `process.ts:277-301` — 두 구현이 동일하다.
+
+---
+
+## 4. 버전 정합 — 확인하나, 무시하나
+
+### 4.1 현행 상태 (실측)
+
+**어느 바인딩도 런타임에 버전을 확인하지 않는다.**
+
+- 파이썬: `__init__.py:115` `SUPPORTED_SCHEMA_VERSION = "1.0"` — 상수 선언뿐.
+  비교는 통합 테스트 `test_envelope_parity.py:82` 에서만.
+- Node: `index.ts:65` 동일 상수 — 비교하는 코드 없음. 통합 테스트
+  `commands.integration.test.ts:58` 은 상수가 아니라 리터럴 `'1.0'` 과 비교한다.
+- 바인딩 패키지 버전(둘 다 `0.1.0`)과 rhwp 바이너리 버전(`0.8.2`)을 대조하는 코드도 없다.
+
+### 4.2 결정
+
+> **① 봉투 `schemaVersion` 의 major 불일치는 거부한다(예외).
+> ② minor 차이와 필드 추가는 통과시킨다.
+> ③ 바이너리 semver 버전은 확인하지 않는다 — 대신 `capabilities` 로 *기능의 유무*를 묻는다.**
+
+### 4.3 근거
+
+**① major 를 막는 이유.** 봉투 계약은 "필드 추가 허용, 변경·삭제는 schemaVersion 범프"다
+(실측: `capabilities.jsonContract.schemaPolicy`). 즉 major 가 올랐다는 것은 **필드의 의미가
+바뀌었거나 사라졌다**는 뜻이고, 그 봉투를 구 바인딩이 읽으면 조용히 틀린 값을 낸다.
+`ProtocolError` 는 "stdout 이 계약을 어겼다"는 계열이므로 이 자리에 맞다.
+
+**② minor 를 통과시키는 이유.** 추가-전용 진화에서 새 필드는 구 바인딩에게 그냥 안 보일
+뿐 해롭지 않다. 여기서 막으면 바이너리를 올릴 때마다 모든 바인딩이 동시에 릴리스돼야 하고,
+그 결합은 "언어가 늘어도 계약은 한 곳" 이라는 축의 전제를 깨뜨린다.
+
+**③ semver 를 안 보는 이유가 이 절의 핵심이다.** `rhwp 0.8.2` 라는 문자열은 "이 기능이
+있는가"에 답하지 못한다. 버전 범위 표(`>=0.8.0` 이면 `--dry-run` 지원 …)를 바인딩마다
+들고 있으면 그 표가 곧 수기 매핑이고, 언어 수만큼 복제되며, 포크·패치 빌드에서 틀린다.
+
+**대신 쓸 것이 이미 있다.** Node 가 선례를 만들었다 — `plan.ts:248-275`
+`assertDryRunSupported`:
+
+```
+capabilities 를 읽어 commands 중 name == 'run' 의 flags 에
+'--dry-run' 이 있는지 본다. 없으면 던진다:
+  "이 rhwp 는 계획 --dry-run 을 지원하지 않습니다 (#3759 이전 버전).
+   check() 를 실행으로 대체하지 않습니다 — 검사인 줄 알고 문서가 편집되면 안 됩니다."
+```
+
+**버전이 아니라 자기서술에 묻는다.** 이것이 계약이다. 결과는 프로세스 수명 동안 캐시하고
+(`plan.ts:240`), 테스트를 위한 무효화 함수를 둔다(`clearPlanCapabilityCache`, `plan.ts:277`).
+
+### 4.4 새 바인딩이 구현해야 하는 세 지점
+
+1. `Envelope` 생성 시점 또는 `runJson` 반환 직전에 `schemaVersion` major 대조.
+   불일치면 `ProtocolError` — 메시지에 **바인딩이 아는 버전과 도구가 낸 버전을 모두** 싣는다.
+2. 기능 유무가 안전에 영향을 주는 자리(현재 알려진 것: 계획 `--dry-run`)마다
+   `capabilities` 게이트. **"지원 안 하면 안전한 쪽으로 대체"는 금지** — `check()` 를
+   `run()` 으로 대체하면 검사인 줄 알고 파일이 만들어진다.
+3. 바인딩 패키지 버전은 rhwp 버전과 **독립**으로 매긴다(현행 둘 다 `0.1.0` 대 `0.8.2`).
+   동기화하면 바인딩 버그 수정에도 rhwp 릴리스가 필요해진다.
+
+### 4.5 미결
+
+`irSchemaVersion`(실측 `1.0`, `export-ir-schema` 봉투의 필드)이 올랐을 때 생성 타입을 가진
+바인딩(Node·M20)이 어떻게 반응해야 하는지는 **확인되지 않음**. 현재 두 바인딩 모두
+`IrSchema.version` 으로 읽기만 하고(`schema.py:164-174`, `schema.ts:213-219`) 대조하지 않는다.
+생성물이 저장소에 커밋되므로 CI 의 `--check` 재생성이 사실상의 가드지만, 그건 개발 시점
+가드일 뿐 사용자 런타임 가드가 아니다.
+
+---
+
+## 5. 노출 범위 — 무엇을 바인딩에 넣지 않는가
+
+### 5.1 실측: 도구가 선언한 표면
+
+`rhwp capabilities` 기준 명령 61개, 그중 `json:true` 31개. 범주 분포는
+`diagnostic 25 / export 18 / query 8 / internal 5 / edit 3 / serve 1 / batch 1`.
+
+`json:true` 이면서 `category:diagnostic` 인 것은 정확히 셋이다:
+**`dump-pages`, `ir-diff`, `render-diff`**.
+
+### 5.2 현행 노출 (실측)
+
+| 명령 | 범주 | Python | Node |
+|---|---|---|---|
+| `dump-pages` | diagnostic | 미노출 | 미노출 |
+| `ir-diff` | diagnostic | `ir_diff` | `irDiff` |
+| `render-diff` | diagnostic | **미노출** | `renderDiff` |
+
+파이썬 미노출은 실행으로 확인했다: `hasattr(rhwp, "render_diff") == False`.
+
+Node 의 패리티 테스트는 `diagnostic`·`internal`·`serve` 를 통째로 제외 목록에 넣어 두고
+(`parity.integration.test.ts:50`), 정작 `ir-diff`·`render-diff` 는 감싼다. **제외 목록과
+실제 노출이 어긋나 있고, 테스트는 그 어긋남을 잡지 못한다** — 그 테스트는
+"선언 → 래퍼 존재" 한 방향만 보기 때문이다(§6.2).
+
+### 5.3 결정
+
+> **노출 여부는 `category` 가 아니라 "봉투가 안정 계약인가"로 가른다.**
+
+| 기준 | 노출 | 예 |
+|---|---|---|
+| `capabilities` 에 `json:true` + `recordFields` 가 선언돼 있고, 그 필드가 계약 테스트로 지켜진다 | **한다** | `ir-diff`, `render-diff` |
+| 봉투 모양이 엔진 내부 구조를 그대로 비추어 자주 바뀐다 | **안 한다** | `dump-pages` (조판 진단용 페이지 항목 덤프) |
+| 픽스처 생성기 등 저장소 내부용 (`category:internal`) | **안 한다** | 5건 |
+| 프로세스를 띄우는 축 (`category:serve`) | **안 한다** — 2층 `Session` 이 이미 담당 | `mcp-serve` |
+| CLI 가 서브커맨드로 갈라지는 명령 | 서브커맨드마다 함수 | `edit` → `fill_fields`/`replace_text`/`set_cell` |
+| 위층이 감싸는 명령 | 1층에 두지 않는다 | `run` → 3층 `Plan` |
+
+`edit` 을 문자열 디스패치(`edit(path, "fill-fields", …)`)로 두지 않는 이유는
+Node 주석이 정확하다(`parity.integration.test.ts:56`): 오타를 런타임까지 미룬다.
+
+`run` 을 1층에 두지 않는 이유(같은 파일 :63-66): 호출자가 계획서 JSON 을 손으로 조립하게
+되고, 빌더의 문법 검사와 `check()` 미리보기를 통째로 우회한다.
+
+### 5.4 플래그는 명령과 다른 기준으로 가른다
+
+Node 가 `DESIGN.md` D14 에서 세운 규칙을 이 문서가 계약으로 승격한다.
+
+> **`capabilities` 의 `flags` 는 "이 명령이 이 플래그를 파싱한다"만 말한다. `--json`
+> 모드에서 그 플래그가 무엇을 하는지는 말하지 않는다. 봉투 계약을 깨거나 아무 일도
+> 하지 않는 플래그는 닫는다.**
+
+이 PC 에서 재실측한 결과 (표는 전부 직접 실행):
+
+| 플래그 | 실측 동작 | 판정 |
+|---|---|---|
+| `export-text -o` (`--json` 동반) | 무시 — 파일이 생기지 않음 | 닫는다 |
+| `export-structure -o` | 동일 | 닫는다 |
+| `export-tables -o` | stdout 이 `표 추출 완료: 12개 → …` 사람 문장으로 **바뀐다** | 닫는다. **본체 쪽 결함** |
+| `export-capabilities-schema -o` | stdout 이 봉투를 유지 | 연다 |
+| `convert -o` / `export-hwpx -o` | `알 수 없는 옵션: -o`, **exit 2** | 위치 인자로 넘긴다 |
+| `render-diff --batch` | 봉투가 아니라 NDJSON 스트림 | 닫는다(반환 타입이 달라진다) |
+
+`export-tables -o` 는 바인딩이 옵션을 닫은 것이 **회피일 뿐 수정이 아니다.** `--json` 을
+준 호출에서 출력 형식이 바뀌는 것은 명령 하나의 사정이 아니라 봉투 계약 전체의 예외이므로,
+별도 업스트림 이슈감으로 남긴다.
+
+### 5.5 노출한 명령의 옵션은 전부 열어야 한다
+
+§5.4 의 예외를 뺀 나머지에서, **한쪽 바인딩에만 있는 옵션은 표류다.** 현행 실측 차이는
+§7 D-12 에 있다(파이썬에 `export_text(page=)`, `export_structure(mode=)`,
+`digest(max_chars=)`, `ir_diff(section=, paragraph=)` 가 없다).
+
+---
+
+## 6. 동등성을 테스트로 강제하는 방법
+
+계약을 문서로만 두면 지켜지지 않는다. §7 의 표류 20건이 그 증거다. 이 절은 **강제 장치의
+설계**다. 세 층으로 나눈다.
+
+### 6.1 A층 — 자기서술 대조 (바인딩마다, 바이너리 필요)
+
+`capabilities` 가 단일 출처다. 수기 목록을 두지 않는다.
+
+**A-1. 선언 → 래퍼 (이미 Node 에 있음)**
+`parity.integration.test.ts:76-111`. 선언된 `json:true` 명령마다 대응 함수가 모듈에
+있는지. 없으면 그 명령을 그 언어 사용자는 못 쓴다.
+
+**A-2. 래퍼 → 선언 (양쪽 모두 없음 — 신규)**
+반대 방향. 모듈이 내보내는 명령 래퍼마다 `capabilities` 에 대응 명령이 있는지.
+없으면 도구에서 사라진 명령을 바인딩이 계속 광고하고 있는 것이다.
+**§5.2 의 어긋남(제외 목록에 diagnostic 을 넣고 diagnostic 을 감쌈)은 이 방향의 테스트가
+없어서 드러나지 않았다.** 이 테스트는 §5.3 의 노출 기준을 명시 목록으로 받아
+"기준에 없는데 감쌌다"를 실패로 만든다.
+
+**A-3. 옵션 → 플래그**
+래퍼가 조립하는 플래그가 `capabilities` 의 `flags` 에 있는지. 이 테스트가 있었다면
+파이썬의 `convert(out=)` → `-o` 버그(§7 D-1)가 머지 전에 잡혔다.
+구현은 인자 조립을 **실행에서 분리**해야 한다 — 현재 두 바인딩 모두 조립과 실행이
+한 함수에 있어 argv 만 뽑아 볼 수 없다. 이것이 이 층의 유일한 구조 변경 요구다.
+
+**A-4. 종료 코드 사전 대조 (양쪽에 이미 있음)**
+바인딩이 매핑하는 다섯 코드를 도구의 `exitCodes` 가 전부 설명하는지.
+`parity.integration.test.ts:159-172`, `test_envelope_parity.py:107-121`.
+
+### 6.2 B층 — 교차 실행 골든 (바인딩들 사이, 신규)
+
+A층은 각 바인딩이 **혼자서** 도구와 어긋나지 않았는지만 본다. 두 바인딩이 서로 다른
+방식으로 어긋나 있으면 A층은 둘 다 통과시킨다. 그래서 B층이 필요하다.
+
+**설계:**
+
+```
+입력: 고정 표본 문서 N개 × 명령·옵션 조합 M개  (= 케이스 목록 JSON 한 벌)
+절차:
+  1. CLI 로 직접 실행 → stdout 원문을 기준(golden)으로 저장
+  2. 각 바인딩으로 같은 케이스 실행 → envelope.raw 를 JSON 직렬화
+  3. 정규화 후 바이트 비교
+비교 대상: 봉투 원문만. 접근자 이름·반환 타입은 비교하지 않는다(§1)
+```
+
+**정규화가 필요한 필드 (실측으로 확인한 비결정 요소):**
+
+| 필드 | 왜 다른가 | 처리 |
+|---|---|---|
+| `source` | 호출자가 넘긴 경로 문자열 그대로 (실측: `"samples/2010-01-06.hwp"`) | 파일명만 남긴다 |
+| `output` | 절대 경로 (실측: `"C:/Users/…/out.hwpx"`) | 파일명만 남긴다 |
+| `bytes`·`sizeBytes` | 산출물 크기 — 같은 입력이면 같아야 한다 | **정규화하지 않는다.** 다르면 그게 결함이다 |
+
+**케이스 목록을 어디에 두는가**: 저장소 한 곳(`bindings/parity/cases.json` 등)에 두고
+언어별 러너가 읽는다. 언어마다 목록을 복제하면 그 목록 자체가 갈라진다.
+
+**실패 시 보고**: 어느 케이스의 어느 키가 다른지 + 양쪽 값. "다르다"만 알려주면
+`export-structure` 의 `node_count` 같은 자리를 찾는 데 반나절이 든다.
+
+**이 층이 잡았을 표류**: D-3(파이썬이 `--json` 없이 스키마 명령을 부른다 — 오늘은
+출력이 같아 무해하지만, 달라지는 순간 이 테스트가 즉시 잡는다).
+
+### 6.3 C층 — 오류·판정 매핑 대조 (신규)
+
+봉투가 같아도 **오류 표현이 다르면 동등하지 않다.** 케이스 목록은 §3.3 표에서 나온다.
+
+```
+케이스: (상황, 기대 종료 코드, 기대 예외 계열, 예외인가 값인가)
+  없는 파일          → exit 1 → RhwpRuntimeError      → 예외
+  알 수 없는 명령    → exit 2 → UsageError            → 예외
+  --verify 불일치    → exit 3 → (없음)                 → 값 (verify.identical == False)
+  --verify + opt-in  → exit 3 → VerdictFailed          → 예외
+  --verify-pages 불일치 → exit 4 → (없음)              → 값
+  계획 선검증 위반   → exit 2 → (없음, invalid 있음)   → 값 (PlanResult.ok == False)
+  계획 조립 버그     → exit 2 → UsageError             → 예외
+  stdout 이 JSON 아님 → —     → ProtocolError          → 예외
+  제한 시간 초과     → —      → RhwpTimeoutError       → 예외
+```
+
+각 바인딩이 이 표를 자기 언어로 구현하고, **표 자체는 저장소 한 곳**에 둔다.
+파이썬은 이 표의 절반을 이미 갖고 있다(`test_envelope_parity.py:148-157`).
+
+**"예외인가 값인가" 열이 이 층의 존재 이유다.** 클래스 이름이 같아도 한쪽이 던지고
+한쪽이 돌려주면 같은 코드가 다른 결과를 낸다.
+
+### 6.4 어디서 도는가
+
+| 층 | 바이너리 | 두 바인딩 런타임 | CI 위치 |
+|---|---|---|---|
+| A | 필요 | 각각 따로 | 각 바인딩 잡 (이미 있음) |
+| B | 필요 | **동시에 필요** | 새 잡 — Python·Node 를 함께 설치한 러너 |
+| C | 필요 | 각각 따로 | 각 바인딩 잡 |
+
+B층만 새 잡을 요구한다. 언어가 늘 때마다 그 러너에 한 줄 추가하는 구조여야 한다 —
+"바인딩 × 바인딩" 행렬로 짜면 M20 에서 6쌍이 된다. **각자 golden 과 비교**하는 별 모양이
+정답이다.
+
+### 6.5 마킹 규약
+
+바이너리가 없으면 A·B·C 층은 **건너뛴다**(파이썬 `pytestmark = pytest.mark.integration`,
+Node `describe.skipIf(!hasBinary)`). 단위 테스트는 가짜 바이너리로 바이너리 없이 돈다 —
+두 바인딩 모두 이미 이 구조다(`tests/conftest.py`, `test/helpers/fake-binary.ts`).
+
+---
+
+## 7. 확인된 표류 목록 (2026-08-03 기준)
+
+세부 근거와 판정(의도인가 표류인가)은 [`python_node_comparison.md`](python_node_comparison.md)
+에 있다. 여기에는 계약 위반 여부만 적는다.
+
+| # | 내용 | 계약 위반 | 심각도 |
+|---|---|---|---|
+| D-1 | 파이썬 `convert(out=)`·`export_hwpx(out=)` 가 `-o` 를 붙여 **항상 exit 2** | §5.5 | **치명** — 기능이 죽어 있다 |
+| D-2 | 파이썬에 `render_diff` 없음 | §1 명령 집합 | 높음 |
+| D-3 | 파이썬 스키마 명령이 `--json` 없이 실행 | §6.2 | 낮음(현재 무해) |
+| D-4 | 파이썬 `Plan.check()` 에 `--dry-run` 지원 게이트 없음 | §4.4-2 | **높음** — 검사가 실행이 될 수 있다 |
+| D-5 | 파이썬 `_quote` 가 역슬래시를 이스케이프하지 않음 | §3.4 `argv` | 중간 |
+| D-6 | 파이썬 약어 정규식이 ReDoS 가능 형태 | §2.5 | 중간 |
+| D-7 | `TimeoutError` vs `RhwpTimeoutError` | §3.3 | 중간 |
+| D-8 | 파이썬 `UsageError` 에 `next_call` 없음 | §3.4 | 낮음 |
+| D-9 | `VerifyReport` 진리값 의미가 다름 | §1 결론을 바꾼다 | **높음** |
+| D-10 | 양쪽 다 `verifyPages` 접근자 없음 | §1 (공통 결손) | 낮음 |
+| D-11 | `inspect` 인자 순서가 반대 | §1 | 중간 |
+| D-12 | 파이썬에 4개 명령의 옵션 누락 | §5.5 | 중간 |
+| D-13 | 파이썬 `iter_ndjson` 이 공개 API 아님 | §1 | 낮음 |
+| D-14 | `Session` 옵션 비대칭 (timeout / cwd) | §1 | 낮음 |
+| D-15 | 바이너리 탐색 보조 API 이름·노출 비대칭 | §1 | 낮음 |
+| D-16 | `RHWP_BIN` 의 `~` 확장이 파이썬만 됨 | §1 | 낮음 |
+| D-17 | `Envelope` 접근자 집합 비대칭 | 언어 관례 범위 | 낮음 |
+| D-18 | `raise_for_exit`/`isKnownExitCode` 노출 비대칭 | §1 | 낮음 |
+| D-19 | 파이썬에 "선언 → 래퍼" 패리티 테스트 없음 | §6.1 A-1 | **높음** — D-2·D-12 의 원인 |
+| D-20 | Node `runRaw` 가 예외에 봉투를 싣지 않음 | §3.4 | 낮음 |
+
+**D-19 가 구조적 원인이다.** 파이썬에는 표면 완결성 테스트가 없어서 D-2·D-12 가
+머지까지 살아남았다. §6.1 A-1 을 파이썬에 추가하는 것이 이 목록에서 가장 먼저 할 일이다.
+
+---
+
+## 8. `bindings/` 안의 세 번째 계약 — M20 이 먼저 정리해야 할 것
+
+`bindings/csharp`·`bindings/swift`·`bindings/Native` 는 **비어 있지 않다.** 실측:
+
+```
+bindings/Native/src/lib.rs                        376줄  (cdylib, C ABI)
+bindings/csharp/RhwpNative.cs                      63줄  (P/Invoke)
+bindings/swift/Sources/Rhwp/Rhwp.swift            182줄
+bindings/swift/Sources/Rhwp/RhwpDocumentTextView.swift  92줄
+bindings/swift/Sources/CRhwpNative/rhwp_native_ffi.h    17줄
+```
+
+`bindings/README.md:5-9` 이 이들을 "Native ABI" 로, python·node 를 "CLI subprocess
+bindings" 로 **명시적으로 갈라 놓았다.** 즉 M20 이 미착수인 것은 맞지만, 그 자리에는
+이미 다른 계약의 구현물이 있다.
+
+### 8.1 그 계약은 이 문서의 계약과 호환되지 않는다
+
+| 항목 | CLI 서브프로세스 계열 (M18·M19) | C ABI 계열 (기존 csharp/swift) |
+|---|---|---|
+| 표면 | 명령 28개 + 세션 + 계획 | **함수 3개** — `rhwp_export_text`, `rhwp_export_markdown`, `rhwp_read_text` (`rhwp_native_ffi.h`) |
+| 봉투 | `schemaVersion` 필수, camelCase, 명령별 `recordFields` | `{"ok":true,"pageCount":N,"files":[…]}` / `{"ok":false,"error":"…"}` (`Native/src/lib.rs:323-341`) |
+| `schemaVersion` | 있음 | **없음** |
+| 종료 코드 | 0/1/2/3/4 사전 | 없음 — `ok` 불리언 하나 |
+| 판정(exit 3/4) | 값으로 표현 | **표현 수단 없음** |
+| 오류 | 5계열 예외 + 봉투 보존 | `error` 문자열 하나 (Swift 는 `RhwpError.exportFailed(String)`, `Rhwp.swift:49-53`) |
+| 진단 보존 | `argv`·`stderr`·`envelope` | 없음 |
+| panic 처리 | 해당 없음 | `catch_unwind` → `{"ok":false,"error":"FFI 호출 중 panic이 발생했습니다."}` (`lib.rs:274-289`) |
+
+`bindings_foundation.md` §2 의 표면 판단 매트릭스는 C ABI 를 **"수요 실증 후 승격"** 으로
+두었다. 기존 구현은 그 판단보다 앞서 존재하는 코드다.
+
+### 8.2 M20 이 답해야 할 질문 (이 문서는 답을 강제하지 않는다)
+
+1. C#/Swift 의 CLI 서브프로세스 바인딩을 **같은 디렉터리에** 만들 것인가, 별 이름으로
+   가를 것인가. 같은 디렉터리에 두면 `Rhwp` 네임스페이스에 두 계약이 공존한다.
+2. 기존 C ABI 를 **유지**할 것인가(SwiftUI `RhwpDocumentTextView` 라는 실사용 형태가 있다),
+   서브프로세스 계열로 흡수할 것인가.
+3. 유지한다면 C ABI 쪽에 `schemaVersion` 과 종료 코드 상당물을 도입할 것인가.
+
+**확인되지 않음**: 기존 C ABI 계열이 어느 이슈에서 왔는지, 현재 사용자가 있는지.
+`bindings/README.md` 에도 `bindings_foundation.md` 에도 그 이력이 없다.
+
+### 8.3 그때까지의 최소 방어
+
+`bindings/README.md` 가 두 계열을 갈라 놓은 문장을 **강화한다**: C ABI 계열은 이 문서의
+동등성 계약 대상이 **아니며**, §6 의 A·B·C 층 테스트도 적용하지 않는다. 한 디렉터리
+안에 두 계약이 있다는 사실 자체를 문서가 먼저 말해야, 다음 사람이 `bindings/csharp` 를
+보고 "M20 이 이미 됐네" 라고 결론 내리지 않는다.
+
+---
+
+## 9. 문서 자체의 표류 (실측)
+
+`bindings/README.md:24-26` 은 파이썬을 "**submitted, not merged** (PR #3775)", Node 를
+"**in progress**" 로 적고 있다. 그러나 이 워크트리(upstream/devel 기준)에는 두 디렉터리가
+모두 소스와 테스트를 갖춘 상태로 존재한다(파이썬 `src/rhwp` 11파일 3,148줄, Node `src`
+14파일 5,377줄 — `wc -l` 실측). **상태 문구가 뒤처졌다.**
+
+같은 파일 :22-26 이 가리키는 `mydocs/manual/python_binding_guide.md` 는 실제로 존재한다
+(193줄). 링크는 유효하고 상태 문구만 낡았다.
+
+바인딩이 늘수록 이런 상태 문구가 늘어난다. **상태는 문서에 쓰지 말고 디렉터리 존재로
+말하게 하는 편이 낫다** — 이 문서는 상태를 쓰지 않고 "실측 시점의 코드가 이렇다"만 쓴다.
+
+---
+
+## 10. 관련 문서
+
+- [`bindings_foundation.md`](../bindings_foundation.md) — 표면 판단·IR 스키마 버저닝의 권위
+- [`new_binding_guide.md`](new_binding_guide.md) — 새 언어를 붙이는 절차
+- [`python_node_comparison.md`](python_node_comparison.md) — 표류 20건의 근거와 판정
+- [`README.md`](README.md) — 이 디렉터리의 지도
+- [`python_binding_guide.md`](../../manual/python_binding_guide.md) ·
+  [`node_binding_guide.md`](../../manual/node_binding_guide.md) — 언어별 사용법
+- [`envelope_provenance.md`](../envelope_provenance.md) — `untrustedContent` 표지 계약
+- 로드맵 [#3608](https://github.com/edwardkim/rhwp/issues/3608) M18~M20

--- a/mydocs/tech/bindings/python_node_comparison.md
+++ b/mydocs/tech/bindings/python_node_comparison.md
@@ -1,0 +1,498 @@
+---
+kind: reference
+status: active
+canonical: mydocs/tech/bindings/parity_contract.md
+last_verified: 2026-08-03
+---
+
+# 파이썬(M18)·Node(M19) 바인딩 실측 대조
+
+두 바인딩이 **실제로** 어디가 다른지, 그 차이가 **의도인지 표류인지** 판정한 표다.
+계약 자체는 [`parity_contract.md`](parity_contract.md) 가 권위이고, 이 문서는 그 계약에
+비춘 현행 스냅샷이다.
+
+**표류를 숨기지 않는 것이 이 문서의 목적이다.** 아래 20건 중 12건은 파이썬 쪽이
+뒤처진 것이고, 그중 2건은 **기능이 아예 동작하지 않는다**(D-1) 또는 **안전 장치가
+없다**(D-4).
+
+## 0. 실측 조건
+
+| 항목 | 값 |
+|---|---|
+| 바이너리 | `target/release/rhwp.exe`, `rhwp v0.8.2`, 봉투 `schemaVersion 1.0` |
+| 파이썬 | `bindings/python/src` 를 `PYTHONPATH` 로 임포트, `RHWP_BIN` 지정, **실행 검증함** |
+| Node | **소스 정적 대조만** — 이 PC 에 `node_modules` 가 없어 `vitest`·`tsc` 미실행 |
+| 표본 | `samples/2010-01-06.hwp` |
+| 일자 | 2026-08-03 |
+
+Node 쪽 "이렇게 동작한다"는 서술은 전부 코드 경로 인용이다. 실행으로 확인한 항목은
+그 자리에 **실측**이라고 적었다.
+
+## 1. 규모
+
+| | 파이썬 | Node |
+|---|---|---|
+| 소스 | `src/rhwp` 11파일 3,148줄 | `src` 14파일 5,377줄 |
+| 테스트 | 15파일 (`conftest.py` 포함) | 20파일 (`helpers/` 2 포함) |
+| 예제 | 9개 (`01`~`09`) | 12개 (`01`~`12`, 브라우저·렌더diff·타입봉투 추가) |
+| 패키지 문서 | `docs/` 5개 1,553줄 | `docs/` 5개 2,940줄 |
+| 1층 명령 래퍼 | 28개 | 31개 |
+
+Node 가 큰 이유의 대부분은 **생성 타입 두 벌**이다(`ir.ts` 875줄, `envelopes.ts` 658줄 —
+`tools/gen-types.ts` 산출물). 이건 의도된 차이다(§3-1).
+
+---
+
+## 2. 같은 것 — 계약의 뼈대는 실제로 공유된다
+
+대조하기 전에 무엇이 이미 같은지 확인해 둔다. 아래는 두 구현이 **같은 문장·같은 순서**로
+되어 있는 자리다.
+
+| 항목 | 파이썬 | Node |
+|---|---|---|
+| 바이너리 탐색 순서 `RHWP_BIN` → 동봉 → PATH | `_binary.py:113-137` | `binary.ts:132-162` |
+| `RHWP_BIN` 이 잘못되면 조용히 넘기지 않고 즉시 예외 | `_binary.py:77-80` | `binary.ts:97-100` |
+| 탐색 결과 프로세스 수명 캐시 + 무효화 함수 | `_binary.py:33,41` | `binary.ts:26,38` |
+| 종료 코드 상수 5개 | `errors.py:39-48` | `errors.ts:19-27` |
+| exit 3/4 = 값, opt-in 시 예외 | `errors.py:200-209` | `errors.ts:235-245` |
+| 사전에 없는 코드는 **조용히 통과시키지 않는다** | `errors.py:211-216` | `errors.ts:247-252` |
+| 봉투 파싱을 종료 코드 검사보다 먼저 | `_process.py:162-194` | `process.ts:195-226` |
+| 성공인데 stdout 이 비면 `ProtocolError` | `_process.py:196-203` | `process.ts:228-235` |
+| batch: exit 1 은 예외 아님, exit 2 는 예외 | `_process.py:246-248` | `process.ts:296-299` |
+| 계획 선검증 위반(`invalid`)은 예외 아니라 값 | `plan.py:205-226` | `plan.ts:290-302` |
+| 원문 봉투 보존 + snake/camel 3중 조회 | `models.py:38-61` | `envelope.ts:81-138` |
+| 없는 필드는 조용한 `None`/`undefined` 아니라 예외 | `models.py:59-61` | `envelope.ts:135-137` |
+| `verify` 미요청은 `None`/`null`, 실패와 구분 | `models.py:109-117` | `envelope.ts:182-187` |
+| `changedPages`: `None`(모름) ≠ `[]`(없음) | `models.py:119-130` | `envelope.ts:195-199` |
+| 기본 제한 시간 300초 | `_process.py:27` | `process.ts:31` (300,000ms) |
+| 불리언을 인자 값 위치에 넣으면 `TypeError` | `_process.py:61-66` | `process.ts:62-67` |
+| 셸을 태우지 않는다 | `subprocess.run(argv)` | `spawn(…, {shell:false})` |
+| 스트리밍 중단 시 자식 정리 | `_process.py:291-295` | `process.ts:353-358` |
+
+**뼈대는 공유돼 있다.** 아래 표류는 뼈대가 아니라 표면과 세부에서 났다.
+
+---
+
+## 3. 의도된 차이 (표류 아님)
+
+### 3-1. 타입 생성 유무
+
+Node 는 `capabilities.recordFields` 와 `export-ir-schema` **두 출처**에서 타입을 생성한다
+(`tools/gen-types.ts` → `src/envelopes.ts`·`src/ir.ts`). 파이썬은 동적 `Envelope` 하나로
+끝낸다.
+
+근거가 문서에 있다(`bindings/node/docs/DESIGN.md` D3): 파이썬의 `Envelope` 는 봉투에 있는
+것을 전부 노출하므로 **구조적으로 뒤처질 수 없고**, 동적 언어에서는 그것으로 충분했다.
+TypeScript 는 다르다 — 사용자가 그 언어를 고른 이유의 상당 부분이 "필드 이름을 컴파일러가
+확인해 준다"인데, `Record<string, unknown>` 만 주면 그 값어치를 통째로 버린다.
+
+**판정: 의도.** M20 의 C#·Swift 는 정적 타입 계열이므로 Node 쪽 패턴을 승계한다.
+
+### 3-2. 동기 vs 비동기 · 브라우저 어댑터 · 자원 정리 문법
+
+- 파이썬은 동기(`subprocess.run`), Node 는 전부 `Promise`. `parity_contract.md` §1 이 허용.
+- Node 에만 `browser.ts`(249줄) — `createBrowserClient`/`createNodeClient` 로 같은
+  인터페이스 아래 WASM 경로를 둔다. 파이썬에는 대응물이 있을 이유가 없다(M19 범위).
+- 파이썬 `with`(`session.py:238-247`), Node `close()` + `Symbol.asyncDispose`
+  (`session.ts:288`, `:409`). 폴리필을 넣지 않는 이유는 `DESIGN.md` D12.
+
+**판정: 셋 다 의도.**
+
+### 3-3. `inspect` 의 옵션 검증 방식
+
+파이썬은 런타임에 잘못된 조합을 `ValueError` 로 거부한다(`commands.py:191-212`).
+Node 는 오버로드 3개로 컴파일 시점에 가른다(`document-analysis.ts:167-184`).
+
+**판정: 절반 의도, 절반 표류.** 정적 검사로 옮긴 것은 타당하나, JS(타입 없는) 호출자가
+`inspect('injection', p, {thresholdPt: 9})` 를 넘기면 **조용히 무시된다** — 파이썬은
+거부한다. 인자 순서 문제는 별건이다(D-11).
+
+---
+
+## 4. 표류 — 파이썬이 뒤처진 것
+
+### D-1. `convert(out=)`·`export_hwpx(out=)` 가 항상 실패한다 — **치명**
+
+파이썬은 산출 경로를 `-o` 플래그로 붙인다.
+
+```
+commands.py:344   _flag(args, "-o", out)        # export_hwpx
+commands.py:369   _flag(args, "-o", out)        # convert
+```
+
+CLI 는 `-o` 를 모른다. 산출 경로가 **위치 인자**다.
+
+```
+$ rhwp convert samples/2010-01-06.hwp -o out.hwp --json
+알 수 없는 옵션: -o
+사용법: rhwp convert <입력.hwp|입력.hwpx> <출력.hwp> [--verify] [--verify-pages] [--json]
+exit=2
+
+$ rhwp export-hwpx samples/2010-01-06.hwp -o out.hwpx --json
+알 수 없는 옵션: -o
+exit=2
+```
+
+바인딩을 직접 실행해 확인했다(**실측**):
+
+```
+rhwp.export_hwpx(S, out=…)  → UsageError: 호출 인자가 올바르지 않습니다 (exit 2)
+rhwp.convert(S,     out=…)  → UsageError: 호출 인자가 올바르지 않습니다 (exit 2)
+```
+
+Node 는 위치 인자로 넘기고, **그 사실을 주석에 실측으로 적어 뒀다**
+(`commands.ts:534-536`: "이 명령은 `-o` 를 모른다(\"알 수 없는 옵션: -o\", exit 2)").
+게다가 `convert` 는 산출 경로가 필수라는 것까지 반영해, 프로세스를 띄우기 전에 같은
+판정을 내린다(`commands.ts:559-566`).
+
+**판정: 표류.** 파이썬 쪽 변환 API 두 개가 산출 경로를 지정하는 순간 죽어 있다.
+`parity_contract.md` §6.1 A-3(옵션 → 플래그 대조)이 있었으면 머지 전에 잡혔다.
+
+### D-2. `render_diff` 없음
+
+`hasattr(rhwp, "render_diff") == False` (**실측**). Node 는 `commands.ts:657` 에 있다.
+
+`render-diff` 는 `--json` 모드에서 시각 회귀를 **exit 3** 으로 낸다(실측:
+`capabilities.exitCodes["3"]` 에 "render-diff --json 시각 회귀 검출(사람 모드는 종전대로 1)").
+즉 이 축의 판정 규약이 적용되는 명령인데, 파이썬 사용자는 그 판정에 닿을 방법이 없다.
+
+`capabilities` 대조를 실행해 파이썬 미노출 `json` 명령을 뽑으면 정확히 셋이다(**실측**):
+`export-capabilities-schema`, `export-ir-schema`, `render-diff`.
+앞의 둘은 `schema.py` 에 다른 이름의 대체물이 있고(D-3), `render-diff` 는 대체물이 없다.
+
+**판정: 표류.**
+
+### D-3. 스키마 명령을 `--json` 없이 부른다
+
+```
+schema.py:239   run_json(["export-ir-schema"], …)
+schema.py:249   run_json(["export-capabilities-schema"], …)
+schema.py:277   run_json(["export-ir-schema"], …)
+schema.py:282   run_json(["export-capabilities-schema"], …)
+```
+
+파이썬의 다른 27개 래퍼는 전부 `args.append("--json")` 을 한다. 이 넷만 빠져 있다.
+
+오늘은 무해하다(**실측**): `export-ir-schema` 와 `export-ir-schema --json` 의 stdout 이
+**44,119바이트로 동일**하고, 최상위 키도 같다(`definitionCount`, `dialect`,
+`irSchemaVersion`, `schema`, `schemaVersion`).
+
+하지만 그건 우연이다. `--json` 이 붙지 않은 호출은 "사람 모드"이고, `export-tables -o`
+처럼 사람 모드에서 출력이 바뀐 전례가 있다(§5-1). Node 는 `--json` 을 붙인다
+(`commands.ts:277`, `:299`).
+
+부수 차이: Node 는 `--bare`(스키마 본문만)와 `-o`(파일 저장, 봉투 유지)를 옵션으로 연다.
+파이썬은 둘 다 없다.
+
+**판정: 표류(잠복).** `parity_contract.md` §6.2 B층 골든 비교가 있으면 출력이 갈라지는
+순간 즉시 잡힌다.
+
+### D-4. `Plan.check()` 에 `--dry-run` 지원 게이트가 없다 — **안전**
+
+Node:
+
+```
+plan.ts:223-227   async check(...) { await assertDryRunSupported(options); … }
+plan.ts:248-275   capabilities 의 run 명령 flags 에 '--dry-run' 이 없으면 던진다:
+   "check() 를 실행으로 대체하지 않습니다 — 검사인 줄 알고 문서가 편집되면 안 됩니다."
+```
+
+파이썬:
+
+```
+plan.py:188-194   def check(...): return _execute(self.to_dict(dry_run=True), …)
+```
+
+게이트가 없다. 계획서에 `dryRun: True` 필드를 실어 보낼 뿐이다(`plan.py:186-187`).
+#3759 이전 바이너리가 그 필드를 무시하면 **검사인 줄 알았던 호출이 실제 편집을 수행한다.**
+
+**판정: 표류.** Node 의 설계 기록이 이 위험을 명시적으로 다뤘고(`DESIGN.md` D13),
+파이썬은 그 이전에 만들어져 반영되지 않았다.
+`parity_contract.md` §4.4-2 가 이걸 계약으로 못 박는다.
+
+### D-5. `_quote` 가 역슬래시를 이스케이프하지 않는다
+
+**실측** — 입력 `C:\my dir\` (끝에 역슬래시 1개):
+
+```
+파이썬 errors.py:160-165  →  "C:\my dir\"      ← 끝 역슬래시가 닫는 따옴표를 먹는다
+Node   errors.ts:197-201  →  "C:\\my dir\\"
+```
+
+Node 주석이 이유를 정확히 적어 뒀다: 붙여넣으면 명령이 깨지고, 최악의 경우 다음 인자와
+뭉쳐 **다른 명령**이 된다. 파이썬의 조건식은 트리거 문자 집합에 역슬래시가 아예 없다
+(`if arg and not any(ch.isspace() or ch in "\"'" for ch in arg)`) — Node 는 `[\s"'\\]`.
+
+영향 범위는 `RhwpError.command` 뿐이다(버그 리포트용 재현 문자열). 실행에는 쓰이지 않는다.
+
+**판정: 표류.** Node 가 나중에 고친 자리를 파이썬이 그대로 갖고 있다.
+
+### D-6. 약어 정규식이 ReDoS 가능 형태
+
+```
+_naming.py:18   ([A-Z]+)([A-Z][a-z])      ← 가변 길이
+naming.ts:22    ([A-Z])([A-Z][a-z])       ← 고정 길이
+```
+
+Node 주석(`naming.ts:16-21`)이 이유와 등가성을 함께 적었다: 앞 그룹이 가변이면
+`AAAA…Aa` 에서 역추적이 다항으로 늘어난다. 결과는 같다 — 경계는 "대문자 하나 뒤에
+대문자+소문자"라는 국소 조건이기 때문이다.
+
+**실측 등가 확인**: `to_snake("HTMLPage")` → `html_page` (파이썬), 고정 길이 규칙도 동일.
+
+노출도는 낮다(봉투 키는 도구가 만든다). 그러나 `Envelope` 는 **문서에서 온 키**도 색인에
+넣는다(`models.py:41-44` 는 최상위 키 전부를 돈다) — 누름틀 이름 같은 사용자 데이터가
+키가 되는 경로가 있으므로 완전히 무관하지는 않다.
+
+**판정: 표류.**
+
+### D-7. `TimeoutError` vs `RhwpTimeoutError`
+
+파이썬은 내장 `TimeoutError` 를 가린다(`errors.py:156`, `noqa: A001 - 내장 이름 가림은
+의도적(패키지 일관성)`). Node 는 `RhwpTimeoutError` (`errors.ts:187`).
+
+한쪽이 의도라고 주석에 적었으므로 "실수"는 아니다. 그러나 두 바인딩 사이에서 **같은
+개념의 이름이 다르다**는 사실은 남는다. `parity_contract.md` §3.3 이 접두형으로 통일하기로
+결정했다 — 내장을 가리면 `except TimeoutError` 한 줄이 어느 쪽을 잡는지 임포트를 봐야
+알 수 있고, 그건 오류 처리 코드가 가장 피해야 할 성질이다.
+
+**판정: 표류(계약이 한쪽을 골라야 하는 자리).**
+
+### D-8. `UsageError.next_call` 없음
+
+Node `errors.ts:145-151` 는 봉투의 `nextCall`(서버가 실어 보낸 교정 호출 — 기계가 그대로
+따라할 수 있는 형태)을 getter 로 꺼낸다. 파이썬에는 없다.
+
+파이썬은 `suggestion`(stderr 의 `힌트:` 줄)만 있고, Node 는 둘 다 있다.
+
+**판정: 표류.** 에이전트가 교정 루프를 도는 축(#3828 계열)에서 파이썬 쪽만 한 단계
+떨어진다.
+
+### D-11. `inspect` 인자 순서가 반대
+
+```
+파이썬 commands.py:175   inspect(path, subcommand, *, …)
+Node   document-analysis.ts:185   inspect(target, path, options)
+```
+
+**같은 이름의 함수가 첫 인자로 다른 것을 받는다.** 두 바인딩을 함께 쓰는 코드베이스
+(예: 파이썬 파이프라인 + Node CLI 도구)에서 이건 즉시 사고다. 게다가 둘 다 문자열이라
+타입이 걸러 주지도 않는다.
+
+Node 쪽이 CLI 순서(`rhwp inspect <검사> <파일>`)와 일치한다.
+
+**판정: 표류.** 어느 쪽으로 통일할지는 `parity_contract.md` 가 정하지 않았다 —
+CLI 순서를 따르는 Node 쪽이 자연스럽지만, 파이썬은 이미 배포 형태를 갖췄으므로
+호환 유지 기간이 필요하다. **확인되지 않음: 파이썬 패키지가 PyPI 에 실제로 배포됐는지.**
+
+### D-12. 명령 옵션 누락 4건
+
+| 명령 | Node 옵션 | 파이썬 |
+|---|---|---|
+| `export-text` | `page` (`-p`) — `commands.ts:114-120` | **없음** (`commands.py:73`) |
+| `export-structure` | `mode`(`auto`/`outline`/`clause`) — `commands.ts:141-159` | **없음** (`commands.py:78`) |
+| `digest` | `maxChars` (`--max-chars`) — `commands.ts:229-232` | **없음** (`commands.py:134`) |
+| `ir-diff` | `section`(`-s`), `paragraph`(`-p`) — `commands.ts:577-592` | **없음** (`commands.py:375`) |
+
+셋 다 CLI 에서 동작하는 것을 확인했다(**실측**):
+
+```
+rhwp export-text  … -p 1 --json          → {"omittedCount":0,"pageCount":1,"pages":[…]}
+rhwp export-structure … --mode clause --json → {"mode":"clause", …}
+```
+
+`export-structure --mode` 는 자동 판정이 기대와 다를 때(규정 문서를 개요로 읽었을 때)
+되돌리는 유일한 수단이다. `digest --max-chars` 는 문맥 창이 좁은 모델에 넘길 때 필수다.
+**옵션이 없으면 그 기능이 없는 것과 같다.**
+
+**판정: 표류.** 원인은 D-19.
+
+### D-13. `iter_ndjson` 이 공개 API 가 아니다
+
+`hasattr(rhwp, "iter_ndjson") == False` (**실측**). 함수는 `_process.py:252` 에 있지만
+`_process.__all__`(:23)에도 `__init__.py` 의 임포트 목록(:53)에도 없다.
+
+패키지 문서는 이걸 쓰라고 안내한다 — `bindings/python/docs/TROUBLESHOOTING.md:311`:
+`from rhwp._process import iter_ndjson`. **밑줄 모듈에서 임포트하라고 문서가 안내하는
+상태**다. Node 는 `index.ts:133` 에서 `iterNdjson` 을 정식 수출한다.
+
+**판정: 표류.**
+
+### D-14. `Session` 옵션 비대칭
+
+```
+파이썬 session.py:52   Session(*, profile=None, timeout=300.0)      ← cwd 없음
+Node   session.ts:36   SessionOptions { profile?, cwd? }            ← timeout 없음
+```
+
+세션은 장수명 프로세스라 **양쪽 다 필요하다.** 파이썬은 작업 디렉터리를 못 바꾸고,
+Node 는 응답이 영원히 안 와도 안 끊긴다.
+
+**판정: 양방향 표류(각자 하나씩 없다).**
+
+### D-15. 바이너리 탐색 보조 API 비대칭
+
+| | 파이썬 | Node |
+|---|---|---|
+| 캐시 비우기 | `clear_cache` (패키지 루트에 노출) | `clearBinaryCache` |
+| 실행 파일 이름 | `binary_name()` — **루트 미노출** | `binaryName()` — 노출 |
+| 동봉 위치 | `BUNDLED_DIR` 상수 — **루트 미노출** | `bundledDir()` 함수 — 노출 |
+| `ENV_VAR` | 노출 | 노출 |
+
+파이썬의 `clear_cache` 라는 이름은 패키지 루트에서 **무엇의** 캐시인지 말하지 않는다
+(계획 캐시·스키마 캐시가 늘면 충돌한다). 또 `_binary.py:24` 의 `__all__` 에는 `ENV_VAR` 가
+없는데 `__init__.py:51` 이 그것을 임포트한다 — 동작은 하지만 `__all__` 이 실제 표면과
+어긋나 있다.
+
+**판정: 표류(경미).**
+
+### D-16. `RHWP_BIN` 의 `~` 확장
+
+```
+파이썬 _binary.py:70   Path(raw).expanduser()
+Node   binary.ts:86    resolve(raw)                ← ~ 확장 없음
+```
+
+`RHWP_BIN=~/bin/rhwp` 가 파이썬에서는 되고 Node 에서는 안 된다. Node 는 `~` 로 시작하는
+디렉터리를 실제로 찾다가 `BinaryNotFoundError` 를 낸다.
+
+부수: 파이썬은 `shutil.which`(`_binary.py:91`)를 쓰므로 Windows 에서 `PATHEXT` 와
+현재 디렉터리 규칙을 따르고, Node 는 `PATH` 항목을 직접 순회한다(`binary.ts:110-118`).
+**확인되지 않음**: 이 차이가 실제로 다른 바이너리를 고르는 경로가 있는지 실측하지 않았다.
+
+**판정: 표류(경미).**
+
+### D-19. 파이썬에 "선언 → 래퍼" 패리티 테스트가 없다 — **구조적 원인**
+
+Node `test/parity.integration.test.ts:76-111`:
+
+> 선언된 `json` 명령마다 바인딩에 대응 함수가 있다.
+> 수기 목록을 두지 않는다 — 모듈이 실제로 내보내는 이름이 곧 표면이다.
+> `export-tables` → `exportTables` 변환도 **바인딩 자신의 `toCamel`** 을 쓴다.
+
+파이썬 `tests/test_envelope_parity.py` 는 7개 테스트를 갖지만 **이 테스트가 없다.**
+있는 것은 "선언한 필드가 봉투에 나오는가", "종료 코드 사전이 상수를 덮는가",
+"MCP 도구가 실존 명령을 가리키는가" 등 — 전부 **도구 쪽 정합성**이고, **바인딩의 표면
+완결성**을 보는 것은 하나도 없다.
+
+**그래서 D-2 와 D-12 가 살아남았다.** 이 목록에서 가장 먼저 고칠 항목이다.
+
+---
+
+## 5. 표류 — Node 가 뒤처지거나 양쪽이 같이 빠진 것
+
+### D-9. `VerifyReport` 의 진리값 의미가 다르다 — **높음**
+
+```
+파이썬 models.py:160-162   def __bool__(self): return self.identical
+Node   envelope.ts:34-62   VerifyReport 에 진리값 훅 없음 (객체는 항상 truthy)
+```
+
+같아 보이는 코드가 반대 결론을 낸다.
+
+```python
+if result.verify:          # 파이썬: "검증을 통과했나"
+```
+```ts
+if (saved.verify) {        // Node: "검증을 요청했나" — 실패해도 참
+```
+
+Node 문서는 이 함정을 알고 있어서 예제를 `if (!saved.verify?.identical)` 로 쓴다
+(`index.ts:32`). 즉 **회피는 하지만 방지는 안 한다.**
+
+파이썬 쪽 설계 의도 자체는 명시돼 있다(`models.py:161`: "`if result.verify:` 가
+'통과했나'로 읽히도록"). 그러나 그 의도는 `verify` 가 `None` 일 때(미요청) 와 `identical`
+이 거짓일 때가 **둘 다 거짓**이 된다는 뜻이기도 하다 — 두 바인딩이 공들여 구분한
+"검증 안 함 ≠ 검증 실패"를 파이썬의 진리값이 다시 뭉갠다.
+
+**판정: 양쪽 다 문제.** `parity_contract.md` §1 의 "결론을 바꾸는 차이" 에 해당한다.
+가장 안전한 통일은 **어느 쪽도 진리값 훅을 두지 않고 `identical` 을 읽게 강제**하는 것이다.
+
+### D-10. `verifyPages` 접근자가 양쪽에 없다
+
+**실측** 봉투:
+
+```json
+"verify":      {"diffCount":0,"identical":true},
+"verifyPages": {"after":6,"before":6,"identical":true}
+```
+
+두 바인딩 모두 `verify` 는 전용 클래스로 감싸지만(`models.py:110`, `envelope.ts:182`)
+`verifyPages` 는 감싸지 않는다. 파이썬에서는 3중 조회 덕에
+`r["verify_pages"]` 가 동작하고(**실측**: `{'after': 6, 'before': 6, 'identical': True}`),
+Node 에서는 `env.child('verifyPages')` 로 닿는다.
+
+exit 4 는 exit 3 과 **다른 판정**인데(페이지 수 불일치), 그 근거를 읽는 길이 일반 조회뿐이다.
+
+**판정: 공통 결손.** 심각도는 낮으나 M20 이 정적 매핑을 만들 때 빠뜨리기 쉬운 자리다.
+
+### D-17. `Envelope` 접근자 집합 비대칭
+
+| | 파이썬 | Node |
+|---|---|---|
+| 매핑 프로토콜 | `Mapping` 구현 (`for k in env`, `len`, `.keys()`) | 없음 — `keys()` 만 |
+| 중첩 자동 래핑 | 접근 시점에 자동 (`models.py:165-173`) | 없음 — `child()`/`children()` 명시 |
+| 기본값 조회 | `get_path(dotted, default)` | `getPath(dotted)` (기본값 인자 없음), `getOr(key, fallback)` |
+| 직렬화 | 없음 | `toJSON()` |
+| 없는 키 예외 타입 | `KeyError` / `AttributeError` | 일반 `Error` — **`RhwpError` 계열 아님** |
+
+마지막 줄이 눈에 띈다. Node 의 `Envelope.get` 은 `throw new Error(...)`
+(`envelope.ts:135`)로 오류 분류 체계 밖의 예외를 던진다. `catch (e) { if (e instanceof
+RhwpError) … }` 로 거르는 코드가 이걸 놓친다.
+
+**판정: 앞의 세 줄은 언어 관례(허용), 마지막 줄은 표류.**
+
+### D-18. `raise_for_exit` / `isKnownExitCode` 노출 비대칭
+
+Node 는 `raiseForExit` 과 `isKnownExitCode` 를 `index.ts:94-95` 에서 수출한다.
+파이썬은 `errors.py:35` 의 `__all__` 에 `raise_for_exit` 을 넣었지만 `__init__.py` 가
+임포트하지 않아 **`rhwp.raise_for_exit` 이 존재하지 않는다**(`hasattr` 실측: `False`).
+`isKnownExitCode` 대응물은 아예 없다.
+
+저수준 `run_raw(check=False)` 를 쓰는 사용자는 종료 코드 처리를 손으로 다시 써야 한다.
+
+**판정: 표류(경미).**
+
+### D-20. Node `runRaw` 가 예외에 봉투를 싣지 않는다
+
+파이썬 `_process.py:78,130` 은 `envelope_hint` 를 받아 `raise_for_exit` 에 넘긴다.
+Node `process.ts:172-178` 의 `runRaw` 는 `envelope` 를 넘기지 않는다(`runJson` 은 넘긴다,
+`process.ts:224`).
+
+`runRaw` 를 직접 쓰면서 봉투를 미리 갖고 있는 경로에서 판정 근거가 예외에서 빠진다.
+실사용 빈도는 낮다.
+
+**판정: 표류(경미).**
+
+---
+
+## 6. 요약 — 어느 쪽이 앞서 있나
+
+| 영역 | 앞선 쪽 | 왜 |
+|---|---|---|
+| 명령 표면 완결성 | **Node** | 패리티 테스트가 강제 (D-2·D-12·D-19) |
+| CLI 실제 동작 반영 | **Node** | `-o` 3종을 실측으로 가름 (D-1, D-3) |
+| 안전 게이트 | **Node** | `--dry-run` capabilities 확인 (D-4) |
+| 문자열 처리 견고성 | **Node** | 인용 이스케이프·ReDoS (D-5, D-6) |
+| 오류 진단 정보 | **Node** | `nextCall` (D-8) |
+| 판정 읽기의 안전성 | **Node** | 진리값 함정을 만들지 않음 (D-9) |
+| 저수준 API 접근성 | **Node** | `iterNdjson`·`raiseForExit` 수출 (D-13, D-18) |
+| 오류 계열의 일관성 | **파이썬** | 봉투 조회 실패도 표준 예외 계열 (D-17) |
+| 봉투 조회 편의 | **파이썬** | `Mapping` + 자동 래핑 + `get_path(default)` |
+| 환경변수 관용도 | **파이썬** | `~` 확장 (D-16) |
+
+**Node 가 앞선 자리의 거의 전부가 "파이썬을 만든 뒤에 알게 된 것"이다.** M19 가 M18 을
+읽고 만들어졌으니 자연스러운 결과이고, 문제는 그 학습이 **역류하지 않았다**는 것이다.
+바인딩이 셋·넷이 되면 이 역류 비용이 언어 수만큼 곱해진다. 그래서
+[`parity_contract.md`](parity_contract.md) §6 이 필요하다.
+
+## 7. 관련 문서
+
+- [`parity_contract.md`](parity_contract.md) — 이 표가 비추는 계약
+- [`new_binding_guide.md`](new_binding_guide.md) — 새 언어가 두 구현에서 뽑아야 할 단계
+- [`README.md`](README.md) — 이 디렉터리의 지도
+- [`bindings_foundation.md`](../bindings_foundation.md) — 설계 전제
+- [`python_binding_guide.md`](../../manual/python_binding_guide.md) ·
+  [`node_binding_guide.md`](../../manual/node_binding_guide.md)
+- `bindings/python/docs/DESIGN.md` · `bindings/node/docs/DESIGN.md` — 버린 대안 기록
+- 로드맵 [#3608](https://github.com/edwardkim/rhwp/issues/3608) M18~M20


### PR DESCRIPTION
로드맵 #3608 **M18~M20 외부 바인딩**. 바인딩이 늘어날수록 "같은 계약인가"가 문제가 된다.
그 계약을 문서로 고정하고, 기존 둘을 전수 비교해 **표류 20건**을 찾았다(12건이 파이썬 뒤처짐).

**4편 1,760줄** — `parity_contract.md`(616) · `new_binding_guide.md`(484) ·
`python_node_comparison.md`(498) · `README.md`(162)

## 치명 3건 — 전부 실행으로 확인

**D-1 · 항상 실패하는 옵션**
`rhwp.convert(out=)`·`rhwp.export_hwpx(out=)` 가 `-o` 를 붙이는데 **CLI 는 위치 인자만
받는다** → 항상 `UsageError`(exit 2). 바인딩을 실제 임포트해 재현했다. Node 는 위치
인자로 넘기고 그 사실을 `commands.ts:534-536` 에 실측 주석으로 남겨 뒀다.

**D-4 · 검사인 줄 알았는데 편집한다**
파이썬 `Plan.check()` 에 `--dry-run` 지원 게이트가 없다(`plan.py:188-194`).
Node 는 `capabilities` 로 확인 후 거부한다(`plan.ts:248-275`).
**미지원 바이너리에서 검사 호출이 실제 편집을 수행한다.**

**D-19 · 구조적 원인**
파이썬에 **"선언 → 래퍼" 패리티 테스트가 없다.** Node 에는 있다
(`parity.integration.test.ts:76-111`). **그래서 위 결함들이 머지까지 살아남았다.**

그 외 17건: `_quote` 역슬래시 미이스케이프(`C:\my dir\` → 깨짐, 실측) · ReDoS 정규식 ·
**`VerifyReport` 진리값이 언어마다 반대 뜻**(`if result.verify` = 통과 /
`if (saved.verify)` = 요청함) · `inspect` 인자 순서 반대 등.

## 명명 규약 — 결정과 근거

**"원문 키는 어떤 바인딩도 바꾸지 않는다. 언어 관례는 별칭 조회 계층으로만."**

기존 둘이 **이미 그렇다**는 것을 먼저 확인했다 — `.raw` 는 원문 보존, snake→원문 색인은
조회용 별칭, 그리고 결정적으로 **일괄 변환 함수(`snake_keys`/`snakeKeys`)가 존재하지만
두 바인딩 내부 호출이 0회**다(grep).

근거 셋: 로그·버그리포트가 CLI 출력과 갈라진다 / `capabilities.recordFields` 목록이
언어 수만큼 복제된다 / 계획서 왕복이 `to_snake ∘ to_camel = id` 를 요구하는데 성립하지 않는다.

## 전제 정정 — csharp/swift/Native 는 비어 있지 않다

지시받은 전제("소스 0개")가 틀렸다. `Native/src/lib.rs` **376줄**(cdylib C ABI) ·
`csharp/RhwpNative.cs` **63줄**(P/Invoke) · `swift/Sources/**` **291줄** 이 이미 있다.
노출 함수 4개, 봉투는 `{"ok":true,...}` 로 **`schemaVersion` 도 종료 코드도 판정 표현도 없다**.

M20 미착수는 맞지만 **디렉터리 이름은 다른 계약이 이미 점유**하고 있다 — §8 에 기록했다.

## 이 축이 드러낸 본체 결함 2건 (별도 이슈감)

- `export-structure --json` 봉투에서 최상위는 `nodeCount` 인데 `structure.node_count` 만
  snake_case 다. 전체 재귀 순회 결과 `_` 든 키는 **이것 하나**(`info` 는 0건).
  별칭 계층이 없는 정적 매핑 언어에서 필드가 사라진다
- `export-tables -o --json` 이 봉투 대신 `표 추출 완료: 12개 → …` **사람 문장**을 낸다 —
  바인딩이 옵션을 닫은 건 회피일 뿐 수정이 아니다

## 확인하지 못한 것

**Node 바인딩은 실행 검증하지 못했다** — 이 PC 에 `node_modules` 가 없어 `vitest`/`tsc` 미실행.
Node 주장은 전부 코드 경로 인용이며 **각 문서 §0 에 명시**했다.
