### PR TITLE
fix(build/#3890): rhwp-subsecond feature 게이트 정합 + CI 가드를 워크스페이스 전체로

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -814,13 +814,16 @@ jobs:
 
       # [#3664] Native FFI 크레이트가 워크스페이스 밖이라 어느 CI job 도 건드리지
       # 않는 사이 코어 API 변경을 못 따라가 이미 컴파일이 깨져 있었다(C#·Swift 래퍼
-      # 동반 무력화). 워크스페이스에 편입했지만 기본 `cargo clippy` 는 루트 크레이트만
-      # 보므로 명시적으로 지목한다. `--workspace` 를 쓰지 않는 이유는 feature 조건부인
-      # `rhwp-subsecond` 가 기본 빌드에서 실패하기 때문이다(이 축과 무관한 기존 성질).
-      - name: Check Native FFI bindings
+      # 동반 무력화). 기본 `cargo clippy` 는 루트 크레이트만 보므로 별도 검사가 필요하다.
+      #
+      # [#3890] 종전에는 `-p rhwp-native-ffi` 로 좁혔다 — `rhwp-subsecond` 가 feature
+      # 게이트 불일치로 `--workspace` 를 상시 깨뜨렸기 때문이다. 그 결함을 고쳐
+      # **워크스페이스 전체**로 넓힌다. 앞으로 추가되는 멤버가 자동으로 검사 대상이
+      # 되며, 깨진 채 들어오면 여기서 막힌다(그것이 이 가드의 목적이다).
+      - name: Check workspace members (FFI bindings, tools)
         run: |
-          cargo build -p rhwp-native-ffi
-          cargo clippy -p rhwp-native-ffi --all-targets -- -D warnings
+          cargo build --workspace
+          cargo clippy --workspace --all-targets -- -D warnings
 
       - name: Check WASM target
         run: cargo check --target wasm32-unknown-unknown --lib

--- a/mydocs/plans/task_m100_3890.md
+++ b/mydocs/plans/task_m100_3890.md
@@ -1,0 +1,97 @@
+---
+kind: plan
+status: draft
+canonical: mydocs/manual/codex/docs_and_git_workflow.md
+last_verified: 2026-08-03
+---
+
+# Task #3890 수행계획서 — rhwp-subsecond feature 게이트 정합
+
+- Issue: [#3890](https://github.com/edwardkim/rhwp/issues/3890) (M100) — [#3664](https://github.com/edwardkim/rhwp/issues/3664) 분리
+- 브랜치: `local/task3890` / 착수: 2026-08-03
+
+## 1. 확정된 사실 (착수 실측)
+
+| 조합 | 결과 |
+|---|---|
+| `cargo clippy --workspace` (기본 feature) | **실패** — `E0433: could not find subsecond_dev in rhwp` |
+| `cargo check -p rhwp-subsecond --features subsecond-dev` | **성공** (네이티브) |
+| `cargo check -p rhwp-subsecond --target wasm32 --features subsecond-dev` | **성공** |
+
+즉 **feature 를 켜면 어느 타깃에서도 빌드된다.** 문제는 `main.rs` 가 feature 를
+무시하고 무조건 `rhwp::subsecond_dev` 를 부르는 것이다.
+
+```rust
+// tools/rhwp-subsecond/src/main.rs — 전문 3줄
+fn main() {
+    rhwp::subsecond_dev::link_wasm_exports();
+}
+```
+
+```rust
+// src/lib.rs:23-24 — 모듈은 feature 뒤에 있다
+#[cfg(feature = "subsecond-dev")]
+pub mod subsecond_dev;
+```
+
+## 2. 설계 의도 확인 — feature 미포함은 실수가 아니다
+
+도입 PR([#3255](https://github.com/edwardkim/rhwp/pull/3255) 검토 기록)이 명시한다:
+
+> "Subsecond hotpatch 프로덕션 격리 — 3중 확인 완료: ① Rust `subsecond-dev` feature 가
+> default 미포함 … 신규 dep `subsecond` optional·dev 전용 → WASM 번들 무영향"
+
+**따라서 `default = ["subsecond-dev"]`(이슈 후보 2안)는 그 격리를 깨므로 채택하지
+않는다.** 워크스페이스 제외(3안)도 #3664 가 만든 상황을 재생산하므로 제외한다.
+
+→ **1안(`main.rs` 를 feature 로 감싸기)** 이 설계 의도를 지키면서 빌드를 고치는
+유일한 길이다.
+
+## 3. 구현 설계
+
+`main.rs` 를 feature 조건부로 나눈다.
+
+```rust
+#[cfg(feature = "subsecond-dev")]
+fn main() {
+    rhwp::subsecond_dev::link_wasm_exports();
+}
+
+#[cfg(not(feature = "subsecond-dev"))]
+fn main() {
+    eprintln!("rhwp-subsecond 는 개발용 핫패치 도구입니다. \
+               --features subsecond-dev 로 빌드하세요.");
+    std::process::exit(2);
+}
+```
+
+- feature 없이 빌드하면 **컴파일은 되고 실행 시 안내 후 종료 코드 2**(사용법 오류 —
+  `cli_commands.md` 종료 코드 계약과 일치).
+- feature 를 켜면 종전 동작 그대로.
+
+## 4. 단계 계획
+
+| 단계 | 내용 | 산출물 |
+|---|---|---|
+| Stage 1 | `main.rs` feature 분기 구현 + 4조합 빌드 검증(기본/feature × 네이티브/wasm) | 구현 + stage1 보고 |
+| Stage 2 | **CI 가드 확장** — #3664 가 `-p` 로 좁혔던 것을 `--workspace` 로 넓힐 수 있는지 판단·적용. red-check 로 검출력 증명 | CI 변경 + stage2 보고 |
+| Stage 3 | 검증 — release-test 전체·clippy·fmt·wasm 빌드 | stage3 보고 |
+| Stage 4 | 최종 보고 → PR(별도 승인) | 보고서 + PR |
+
+## 5. 검증 기준
+
+1. `cargo clippy --workspace -- -D warnings` **통과**(현재 실패).
+2. `cargo build --workspace` 통과.
+3. `--features subsecond-dev` 로는 **종전 동작 유지** — wasm 타깃 빌드 성공.
+4. 프로덕션 격리 불변 — 기본 빌드에 `subsecond` 크레이트가 들어가지 않는다(의존 그래프 확인).
+5. release-test 전체·fmt 통과.
+
+## 6. 위험과 제약
+
+- **격리 회귀가 최대 위험**이다. #3255 가 3중으로 확인한 "dev 전용" 성질을 깨면
+  WASM 번들에 개발 도구가 섞인다. Stage 1 에서 의존 그래프로 확인한다.
+- `--workspace` 로 가드를 넓히면 **앞으로 추가되는 워크스페이스 멤버가 자동으로
+  검사 대상**이 된다. 이득이지만, 새 멤버가 깨진 채 들어오면 CI 가 막힌다 — 그것이
+  가드의 목적이므로 수용한다.
+- 종료 코드 2 선택은 `cli_commands.md` 의 "사용법 오류" 계약을 따른 것이다. 이
+  크레이트는 CLI 계약 문서에 없지만 같은 규약을 쓰는 편이 일관적이다.

--- a/mydocs/report/task_m100_3890_report.md
+++ b/mydocs/report/task_m100_3890_report.md
@@ -1,0 +1,92 @@
+---
+kind: report
+status: active
+canonical: mydocs/plans/task_m100_3890.md
+last_verified: 2026-08-03
+---
+
+# Task #3890 최종 보고 — rhwp-subsecond feature 게이트 정합과 가드 확장
+
+- Issue: [#3890](https://github.com/edwardkim/rhwp/issues/3890) (M100) — [#3664](https://github.com/edwardkim/rhwp/issues/3664) 분리
+- 브랜치 `local/task3890` / 2026-08-03 당일 완결
+- 단계 기록: `mydocs/working/task_m100_3890_stage{1,2,3}.md`
+
+## 결과
+
+| 검사 | 착수 전 | 완료 후 |
+|---|---|---|
+| `cargo check -p rhwp-subsecond` (기본 feature) | **실패** `E0433` | **성공** |
+| `cargo build --workspace` | **실패** | **성공** |
+| `cargo clippy --workspace -- -D warnings` | **실패** | **통과** |
+| CI 가드 범위 | FFI 1크레이트(`-p`) | **워크스페이스 전체** |
+
+## 근인
+
+`tools/rhwp-subsecond/src/main.rs`(전문 3줄)가 feature 와 무관하게
+`rhwp::subsecond_dev` 를 불렀다. 그 모듈은 루트에서 `#[cfg(feature = "subsecond-dev")]`
+뒤에 있으므로 **기본 feature 로는 컴파일 자체가 불가능**했고, `--workspace` 를 쓰는
+모든 명령이 상시 실패했다.
+
+## 해법 선택 — 이슈의 3안 중 2안을 기각
+
+도입 PR([#3255](https://github.com/edwardkim/rhwp/pull/3255) 검토 기록)을 확인하니
+**feature 미포함은 실수가 아니라 설계**였다:
+
+> "Subsecond hotpatch 프로덕션 격리 — 3중 확인 완료: ① Rust `subsecond-dev` feature 가
+> default 미포함 … 신규 dep `subsecond` optional·dev 전용 → WASM 번들 무영향"
+
+- `default = ["subsecond-dev"]` — **그 격리를 정면으로 깬다. 기각.**
+- 워크스페이스 제외 — #3664 가 만든 "가드 밖에서 썩는" 상황을 재생산한다. **기각.**
+- **`main.rs` feature 분기 — 채택.** 격리를 지키면서 빌드를 고치는 유일한 길.
+
+feature 없이 실행하면 안내 후 **종료 코드 2**(`cli_commands.md` 사용법 오류 계약).
+
+## 부가 성과 — 가드를 원래 의도 범위로 되돌렸다
+
+#3664 는 이 결함 때문에 CI 가드를 `-p rhwp-native-ffi` 로 좁혀야 했다. 이제 넓혔다:
+
+```yaml
+- name: Check workspace members (FFI bindings, tools)
+  run: |
+    cargo build --workspace
+    cargo clippy --workspace --all-targets -- -D warnings
+```
+
+| | 종전 | 현재 |
+|---|---|---|
+| 검사 대상 | FFI 1개 | **3크레이트 전부** |
+| 새 워크스페이스 멤버 | 가드에 수동 등재 필요 | **자동 편입** |
+
+## red-check — 두 축 검출
+
+| 되돌린 결함 | 검출 |
+|---|---|
+| `rhwp-subsecond` feature 분기 제거(#3890 원결함) | 오류 **2건** |
+| `rhwp_string_free` 의 `unsafe` 제거(#3664 축) | clippy 오류 **3건** |
+
+**범위를 넓히면서 기존 검출력을 잃지 않았다**는 증명이다.
+
+## 격리 무회귀 — 3층 확인
+
+| 대상 | `subsecond v0.7` |
+|---|---|
+| `rhwp-subsecond` 기본 feature | **0** |
+| 루트 `rhwp` (네이티브) | **0** |
+| 루트 `rhwp` (**wasm32 타깃**) | **0** |
+| `--features subsecond-dev` | 1 (의도된 경로) |
+
+## 검증
+
+release-test 전체 exit 0 · `--workspace` build/clippy 통과 · fmt · wasm 타깃 체크 ·
+워크플로 YAML 통과.
+
+## 교훈
+
+**"고칠 수 없는 제약"으로 보이던 것이 사실은 별도 결함이었다.** #3664 에서 가드를
+`-p` 로 좁힌 것은 당시로선 옳은 판단이었지만, 그 제약의 출처를 이슈로 분리해 두었기에
+하루 만에 풀 수 있었다. 우회하며 남긴 기록이 다음 작업의 출발점이 된다.
+
+## 남긴 것
+
+`--workspace` 확장의 CI 시간 영향은 PR 실행에서 확인한다 — 로컬 cold 51초를 CI
+예측으로 쓰지 않는다.

--- a/mydocs/working/task_m100_3890_stage1.md
+++ b/mydocs/working/task_m100_3890_stage1.md
@@ -1,0 +1,55 @@
+---
+kind: working
+status: active
+canonical: mydocs/plans/task_m100_3890.md
+last_verified: 2026-08-03
+---
+
+# Task #3890 Stage 1 보고 — feature 게이트 정합
+
+## 결과 — `--workspace` 가 통과한다
+
+| 조합 | 착수 전 | 완료 후 |
+|---|---|---|
+| `cargo check -p rhwp-subsecond` (기본 feature) | **실패** `E0433` | **성공** |
+| `-p ... --features subsecond-dev` (네이티브) | 성공 | 성공 |
+| `-p ... --target wasm32 --features subsecond-dev` | 성공 | 성공 |
+| **`cargo clippy --workspace -- -D warnings`** | **실패** | **통과** — 3크레이트 전부 검사 |
+
+## 구현
+
+`tools/rhwp-subsecond/src/main.rs` 를 feature 로 분기했다.
+
+- `#[cfg(feature = "subsecond-dev")]` — 종전 동작(`link_wasm_exports`) 그대로.
+- `#[cfg(not(...))]` — 안내 후 `exit(2)`. 실제 종료 코드 **2** 확인
+  (`cli_commands.md` 의 "사용법 오류" 계약).
+
+모듈 주석에 이 크레이트가 왜 feature 뒤에 있는지(#3255 프로덕션 격리)와 무엇이
+깨져 있었는지를 남겼다.
+
+## 최대 위험 — 격리 회귀: 발생하지 않음
+
+계획서 §6 이 지목한 위험을 의존 그래프로 확인했다.
+
+| 대상 | `subsecond v0.7` 포함 |
+|---|---|
+| `cargo tree -p rhwp-subsecond` (기본) | **0** |
+| `cargo tree -p rhwp-subsecond --features subsecond-dev` | 1 |
+| `cargo tree -p rhwp` (루트 기본) | **0** |
+
+#3255 가 3중 확인한 "dev 전용" 성질이 그대로다. **기본 빌드에는 개발 도구가 섞이지
+않는다.**
+
+## 왜 2안·3안을 쓰지 않았나 (재확인)
+
+- `default = ["subsecond-dev"]` — 위 격리를 정면으로 깬다.
+- 워크스페이스 제외 — #3664 가 만든 "가드 밖에서 썩는" 상황을 재생산한다.
+
+## 검증
+
+`cargo fmt --check` 통과. 4조합 빌드 전부 확인.
+
+## 다음
+
+Stage 2 — #3664 가 `-p` 로 좁혔던 CI 가드를 `--workspace` 로 넓힐 수 있게 됐다.
+red-check 로 검출력을 증명한다.

--- a/mydocs/working/task_m100_3890_stage2.md
+++ b/mydocs/working/task_m100_3890_stage2.md
@@ -1,0 +1,59 @@
+---
+kind: working
+status: active
+canonical: mydocs/plans/task_m100_3890.md
+last_verified: 2026-08-03
+---
+
+# Task #3890 Stage 2 보고 — CI 가드를 워크스페이스 전체로 확장
+
+## 변경
+
+`.github/workflows/ci.yml` Lint job 의 가드를 넓혔다.
+
+```diff
+- - name: Check Native FFI bindings
+-   run: |
+-     cargo build -p rhwp-native-ffi
+-     cargo clippy -p rhwp-native-ffi --all-targets -- -D warnings
++ - name: Check workspace members (FFI bindings, tools)
++   run: |
++     cargo build --workspace
++     cargo clippy --workspace --all-targets -- -D warnings
+```
+
+#3664 는 `rhwp-subsecond` 의 상시 실패 때문에 `-p` 로 좁혀야 했다. Stage 1 이 그
+결함을 고쳤으므로 원래 의도한 범위로 되돌린다. 주석에 두 이슈의 경위를 남겼다.
+
+## 무엇이 달라지나
+
+| | 종전(`-p`) | 현재(`--workspace`) |
+|---|---|---|
+| 검사 대상 | `rhwp-native-ffi` 만 | **워크스페이스 3크레이트 전부** |
+| 새 멤버 추가 시 | 가드에 수동 등재 필요 | **자동 편입** |
+
+앞으로 워크스페이스에 크레이트가 추가되면 별도 조치 없이 검사 대상이 된다. 깨진 채
+들어오면 CI 가 막는데, 그것이 이 가드의 목적이다.
+
+## red-check — 두 축 모두 검출
+
+| 되돌린 결함 | 검출 |
+|---|---|
+| `rhwp-subsecond` feature 분기 제거(#3890 원결함 재현) | **오류 2건** |
+| `rhwp_string_free` 의 `unsafe` 제거(#3664 축 유지 확인) | **clippy 오류 3건** |
+
+넓힌 가드가 **새로 고친 축과 기존 축을 함께** 잡는다. 범위를 넓히면서 기존 검출력을
+잃지 않았다는 증명이다.
+
+## 검증
+
+- 워크플로 YAML 문법 통과.
+- 가드 명령 로컬 실측: `cargo build --workspace` 5.98초,
+  `cargo clippy --workspace --all-targets -- -D warnings` 51.04초.
+- 복원 후 재통과 확인.
+
+## 비용 관찰
+
+`--workspace` 로 넓히면서 clippy 대상이 늘었으나(51초), Lint job 은 `shared-key: lint`
+캐시를 타므로 warm run 에서는 대부분 재사용된다. 실제 CI 시간 영향은 Stage 3 의 PR
+실행에서 확인한다.

--- a/mydocs/working/task_m100_3890_stage3.md
+++ b/mydocs/working/task_m100_3890_stage3.md
@@ -1,0 +1,37 @@
+---
+kind: working
+status: active
+canonical: mydocs/plans/task_m100_3890.md
+last_verified: 2026-08-03
+---
+
+# Task #3890 Stage 3 보고 — 전체 검증
+
+| 게이트 | 결과 |
+|---|---|
+| `cargo test --profile release-test --tests` 전체 | **exit 0** |
+| `cargo build --workspace` | 성공 (5.98초) |
+| `cargo clippy --workspace --all-targets -- -D warnings` | **통과** ← 이 이슈의 목표 |
+| `cargo fmt --check` | 통과 |
+| `cargo check --target wasm32-unknown-unknown --lib` | 통과 (51.9초) |
+| 워크플로 YAML 문법 | 통과 |
+
+## 격리 3층 확인
+
+계획서 §6 의 최대 위험(프로덕션 격리 회귀)을 세 지점에서 확인했다.
+
+| 대상 | `subsecond v0.7` 포함 |
+|---|---|
+| `cargo tree -p rhwp-subsecond` (기본 feature) | **0** |
+| `cargo tree -p rhwp` (루트, 네이티브) | **0** |
+| `cargo tree --target wasm32 -p rhwp` | **0** |
+| `cargo tree -p rhwp-subsecond --features subsecond-dev` | 1 (의도된 경로) |
+
+#3255 가 3중 확인한 "dev 전용" 성질이 그대로다. **개발 도구가 프로덕션 번들에 섞이지
+않는다.**
+
+## 비용 관찰
+
+`--workspace` 확장으로 clippy 대상이 늘었다(로컬 cold 51초). Lint job 은
+`shared-key: lint` 캐시를 타므로 warm run 영향은 작을 것으로 보이나, **실제 CI 시간은
+PR 실행에서 확인한다** — 로컬 수치를 CI 예측으로 쓰지 않는다.

--- a/tools/rhwp-subsecond/src/main.rs
+++ b/tools/rhwp-subsecond/src/main.rs
@@ -1,3 +1,23 @@
+//! Dioxus subsecond 핫패치용 개발 전용 바이너리.
+//!
+//! [#3890] `rhwp::subsecond_dev` 는 루트 크레이트에서 `subsecond-dev` feature 뒤에
+//! 있다(#3255 의 "프로덕션 격리" 설계 — default 미포함이 의도다). 그런데 이 바이너리가
+//! feature 와 무관하게 그 모듈을 불러 **기본 feature 로는 컴파일 자체가 불가능했고**,
+//! 그 결과 `cargo build/clippy --workspace` 가 상시 실패했다.
+//!
+//! feature 로 분기해 격리는 유지하면서 워크스페이스 빌드가 통과하게 한다.
+
+#[cfg(feature = "subsecond-dev")]
 fn main() {
     rhwp::subsecond_dev::link_wasm_exports();
+}
+
+#[cfg(not(feature = "subsecond-dev"))]
+fn main() {
+    eprintln!(
+        "rhwp-subsecond 는 개발용 핫패치 도구입니다.\n\
+         `cargo run -p rhwp-subsecond --features subsecond-dev` 로 실행하세요."
+    );
+    // 사용법 오류 — `cli_commands.md` 의 종료 코드 계약(2 = 사용법 오류)을 따른다.
+    std::process::exit(2);
 }


### PR DESCRIPTION
## 요약

`rhwp-subsecond` 의 feature 게이트 불일치로 **`cargo build/clippy --workspace` 가 상시
실패**하던 것을 고치고, 그 제약 때문에 좁혀 두었던 CI 가드를 워크스페이스 전체로
넓힙니다.

| 검사 | 착수 전 | 완료 후 |
|---|---|---|
| `cargo check -p rhwp-subsecond` (기본 feature) | **실패** `E0433` | **성공** |
| `cargo build --workspace` | **실패** | **성공** |
| `cargo clippy --workspace -- -D warnings` | **실패** | **통과** |
| CI 가드 범위 | FFI 1크레이트(`-p`) | **워크스페이스 전체** |

## 근인

`tools/rhwp-subsecond/src/main.rs`(전문 3줄)가 feature 와 무관하게
`rhwp::subsecond_dev` 를 불렀습니다. 그 모듈은 루트에서
`#[cfg(feature = "subsecond-dev")]` 뒤에 있으므로 **기본 feature 로는 컴파일 자체가
불가능**했습니다.

## 해법 선택 — 이슈의 3안 중 2안을 기각

도입 PR #3255 검토 기록을 확인하니 **feature 미포함은 실수가 아니라 설계**였습니다:

> "Subsecond hotpatch 프로덕션 격리 — 3중 확인 완료: ① `subsecond-dev` feature 가
> default 미포함 … 신규 dep `subsecond` optional·dev 전용 → WASM 번들 무영향"

- `default = ["subsecond-dev"]` — 그 격리를 정면으로 깹니다. **기각**
- 워크스페이스 제외 — #3664 가 만든 "가드 밖에서 썩는" 상황을 재생산합니다. **기각**
- **`main.rs` feature 분기 — 채택.** 격리를 지키면서 빌드를 고치는 유일한 길입니다.

feature 없이 실행하면 안내 후 **종료 코드 2**(`cli_commands.md` 사용법 오류 계약).

## 부가 성과 — 가드를 원래 의도 범위로

[#3664](https://github.com/edwardkim/rhwp/issues/3664) 는 이 결함 때문에 CI 가드를
`-p rhwp-native-ffi` 로 좁혀야 했습니다. 이제 넓힙니다.

```yaml
- name: Check workspace members (FFI bindings, tools)
  run: |
    cargo build --workspace
    cargo clippy --workspace --all-targets -- -D warnings
```

새 워크스페이스 멤버가 **자동으로 검사 대상**이 됩니다.

## red-check — 두 축 검출

| 되돌린 결함 | 검출 |
|---|---|
| `rhwp-subsecond` feature 분기 제거(#3890 원결함) | 오류 **2건** |
| `rhwp_string_free` 의 `unsafe` 제거(#3664 축) | clippy 오류 **3건** |

범위를 넓히면서 **기존 검출력을 잃지 않았다**는 증명입니다.

## 격리 무회귀 — 3층 확인

계획서가 지목한 최대 위험을 의존 그래프로 확인했습니다.

| 대상 | `subsecond v0.7` |
|---|---|
| `rhwp-subsecond` 기본 feature | **0** |
| 루트 `rhwp` (네이티브) | **0** |
| 루트 `rhwp` (**wasm32 타깃**) | **0** |
| `--features subsecond-dev` | 1 (의도된 경로) |

## 검증

release-test 전체 **exit 0** · `--workspace` build/clippy 통과 · fmt · wasm 타깃 체크 ·
워크플로 YAML 통과.

## 유의

`--workspace` 확장의 **CI 시간 영향은 이 PR 실행에서 확인**합니다. 로컬 cold 51초를
CI 예측으로 쓰지 않습니다. Lint job 은 `shared-key: lint` 캐시를 타므로 warm run
영향은 작을 것으로 보입니다.

Closes #3890

🤖 Generated with [Claude Code](https://claude.com/claude-code)
