### PR TITLE
fix(cli): bench·dump·diag 미지 플래그 침묵 무시 제거 + 실패 stdout 오염 차단 (#3884 G1·G2·G3)

### DIFF
--- a/src/diagnostics/bench.rs
+++ b/src/diagnostics/bench.rs
@@ -68,6 +68,16 @@ pub fn run(args: &[String]) -> i32 {
                 i += 1;
                 tsv = args.get(i).cloned();
             }
+            // [#3884 G2] 미지 플래그를 파일 이름으로 접지 않는다 — `--json` 을 주면
+            // "그런 파일이 없다"로 실패하던 것이 대표 증상이다. 침묵 무시는 더 나쁘다:
+            // 오타 난 옵션이 측정 조건을 조용히 바꾼 채 성공을 보고한다.
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!(
+                    "사용법: rhwp bench <파일...> | --batch <폴더> [-n 반복수] [--tsv 출력.tsv]"
+                );
+                return super::EXIT_USAGE;
+            }
             other => files.push(other.to_string()),
         }
         i += 1;
@@ -88,9 +98,6 @@ pub fn run(args: &[String]) -> i32 {
         iters = 1;
     }
 
-    println!("=== bench: 단계별 처리 성능 (median of {iters}회, 워밍업 1회) ===");
-    println!("주의: 절대 수치는 측정 머신·빌드 의존. 동일 환경 상대·재현 지표로 해석.");
-
     let mut rows: Vec<Row> = Vec::new();
     let mut failures = 0usize;
     for f in &files {
@@ -102,14 +109,26 @@ pub fn run(args: &[String]) -> i32 {
             }
         }
     }
-    print_table(&rows);
+    // [#3884 G1] 전건 실패면 stdout 을 비운다 — 빈 표에 배너까지 얹어 내보내면
+    // 파이프 소비자가 "측정 결과"로 읽는다. 실패의 전말은 stderr 와 종료 코드가 말한다.
+    if !rows.is_empty() {
+        println!("=== bench: 단계별 처리 성능 (median of {iters}회, 워밍업 1회) ===");
+        println!("주의: 절대 수치는 측정 머신·빌드 의존. 동일 환경 상대·재현 지표로 해석.");
+        print_table(&rows);
+    }
 
     if let Some(path) = tsv {
-        match write_tsv(&path, &rows) {
-            Ok(()) => println!("\nTSV: {path}"),
-            Err(e) => {
-                eprintln!("TSV 쓰기 실패: {e}");
-                failures += 1;
+        if rows.is_empty() {
+            // 측정 성공 0건이면 산출물을 만들지 않는다(redact 의 "탐지 0건 = 파일
+            // 미생성"과 같은 원칙) — 빈 표를 받은 쪽이 "측정했고 결과가 없다"로 오독한다.
+            eprintln!("TSV 생략: 측정 성공이 0건입니다 - {path}");
+        } else {
+            match write_tsv(&path, &rows) {
+                Ok(()) => println!("\nTSV: {path}"),
+                Err(e) => {
+                    eprintln!("TSV 쓰기 실패: {e}");
+                    failures += 1;
+                }
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2475,7 +2475,9 @@ fn capabilities_value() -> serde_json::Value {
         "jsonContract": {
             "stdout": "데이터(JSON/NDJSON)만 — 진단·진행·요약은 stderr",
             "schemaPolicy": "필드 추가 허용, 변경·삭제는 schemaVersion 범프",
-            "failure": "단건 명령 실패 시 stdout 0바이트; batch 는 error 레코드 + 최종 exit 1",
+            // [#3884 G3] run 의 예외는 설계다(판정을 데이터로 보고) — 적지 않으면
+            // "실패 = stdout 0바이트"를 믿는 소비자가 run 에서 깨진다.
+            "failure": "단건 명령 실패 시 stdout 0바이트; batch 는 error 레코드 + 최종 exit 1. 예외: run — 실패도 봉투를 stdout 으로 낸다(입력 오류 exit 1 + error, 계획 무효 exit 2 + invalid[], 단언 실패 exit 3 + verify 저널)",
             // [#3707] 봉투에 담기는 문서 유래 문자열의 유니코드 기만 판정. 이 키가
             // 있으면 바이너리가 검사한다는 뜻이다 — 키가 없으면 '깨끗함'이 아니라
             // '검사하지 않음'으로 읽어야 한다.
@@ -8997,6 +8999,15 @@ fn dump_controls(args: &[String]) -> i32 {
     }
 
     let file_path = &args[0];
+    // [#3884 G2] 첫 인자 자리에 플래그가 오면 "파일을 읽을 수 없습니다 - --json" 같은
+    // 오독 메시지로 새지 않게 사용법 오류로 끊는다.
+    if file_path.starts_with('-') {
+        eprintln!("오류: 알 수 없는 옵션입니다 - {file_path}");
+        eprintln!(
+            "사용법: rhwp dump <파일.hwp|파일.hwpx|파일.hml> [--section <번호>] [--para <번호>]"
+        );
+        return EXIT_USAGE;
+    }
     let mut filter_section: Option<usize> = None;
     let mut filter_para: Option<usize> = None;
 
@@ -9018,6 +9029,15 @@ fn dump_controls(args: &[String]) -> i32 {
                 } else {
                     i += 1;
                 }
+            }
+            // [#3884 G2] 미지 플래그 침묵 무시 금지 — `--json` 을 붙이면 JSON 이 나올
+            // 거라 믿는 소비자에게 사람용 텍스트를 exit 0 으로 돌려주던 구멍이다.
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!(
+                    "사용법: rhwp dump <파일.hwp|파일.hwpx|파일.hml> [--section <번호>] [--para <번호>]"
+                );
+                return EXIT_USAGE;
             }
             _ => {
                 i += 1;
@@ -10534,6 +10554,14 @@ fn extract_data_command(args: &[String]) -> i32 {
 fn diag_document(args: &[String]) -> i32 {
     if args.is_empty() {
         eprintln!("오류: HWP 파일 경로를 지정해주세요.");
+        eprintln!("사용법: rhwp diag <파일.hwp>");
+        return EXIT_USAGE;
+    }
+
+    // [#3884 G2] diag 는 추가 옵션이 없다 — 지금까지는 어떤 플래그를 붙여도(--json 포함)
+    // 조용히 무시하고 exit 0 이라, 옵션이 먹혔다는 착각을 만들었다.
+    if let Some(bad) = args.iter().find(|a| a.starts_with('-')) {
+        eprintln!("오류: 알 수 없는 옵션입니다 - {bad}");
         eprintln!("사용법: rhwp diag <파일.hwp>");
         return EXIT_USAGE;
     }

--- a/tests/diagnostics_flag_contract.rs
+++ b/tests/diagnostics_flag_contract.rs
@@ -1,0 +1,193 @@
+//! [#3884 G1·G2·G3] 자기서술 밖 진단 명령(bench·dump·diag)의 플래그·실패 계약.
+//!
+//! 이 셋은 capabilities 에 `flags`·`json` 을 선언하지 않는 명령이라 드리프트 가드의
+//! 시야 밖에 있었고, 그 사각에서 두 가지가 자랐다:
+//!
+//! - **미지 플래그 침묵 무시** — `--json` 을 붙여도 사람용 텍스트가 exit 0 으로
+//!   나온다(dump·diag). 에이전트는 JSON 을 기대하고 파싱하다 깨진다.
+//! - **실패 경로 stdout 오염** — bench 는 `--json` 을 "파일 이름"으로 접어 실패시키고,
+//!   그 와중에 배너+반쪽 표를 stdout 으로 흘렸다(exit 1 + 518 B).
+//!
+//! 여기서 고정하는 계약은 하나다: **모르는 옵션은 조용히 무시하지 않는다** —
+//! exit 2 + stdout 0바이트 + stderr 안내. 그리고 전건 실패면 stdout 은 빈다.
+//!
+//! G4(inspect·edit 하위 명령의 자기서술 등재)와 "진단 명령을 자기서술에 넣을지"의
+//! 부류 판단은 이 파일 범위 밖이다 — #3884 본문의 열린 질문으로 남는다.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// 아무 유효 문서 — 플래그 거부는 문서를 열기 전에 일어나야 한다.
+const SAMPLE: &str = "samples/field-01.hwp";
+
+fn sample() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp 실행")
+}
+
+fn describe(args: &[&str], out: &Output) -> String {
+    format!(
+        "args={args:?}\nexit={:?}\nstdout={}\nstderr={}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+/// 거부 계약의 공통 골격: exit 2, stdout 0바이트, stderr 에 문제의 플래그 명시.
+fn assert_rejects(args: &[&str], flag: &str) {
+    let out = run(args);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "미지 플래그는 사용법 오류다: {}",
+        describe(args, &out)
+    );
+    assert!(
+        out.stdout.is_empty(),
+        "거부하면서 stdout 을 오염시키면 안 된다: {}",
+        describe(args, &out)
+    );
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains(flag),
+        "무엇이 거부됐는지 stderr 가 말해야 한다({flag}): {}",
+        describe(args, &out)
+    );
+}
+
+// ── bench ────────────────────────────────────────────────────────────────
+
+#[test]
+fn bench_rejects_json_flag_with_silent_stdout() {
+    // [G1 의 대표 증상] --json 이 "실패한 파일"이 되어 exit 1 + 반쪽 표 518 B 가
+    // stdout 으로 새던 자리다. 이제 문서를 열기 전에 사용법 오류로 끊는다.
+    let s = sample();
+    assert_rejects(&["bench", s.to_str().unwrap(), "--json"], "--json");
+}
+
+#[test]
+fn bench_rejects_unknown_flag_with_silent_stdout() {
+    let s = sample();
+    assert_rejects(
+        &["bench", s.to_str().unwrap(), "--bogus-flag"],
+        "--bogus-flag",
+    );
+}
+
+#[test]
+fn bench_total_failure_keeps_stdout_empty() {
+    // [G1] 측정 성공 0건이면 stdout 은 빈다 — 빈 표에 배너를 얹어 내보내면 파이프
+    // 소비자가 "측정 결과"로 읽는다. 실패의 전말은 stderr 와 exit 1 이 말한다.
+    let args = ["bench", "no-such-file-3884.hwp"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(1), "{}", describe(&args, &out));
+    assert!(
+        out.stdout.is_empty(),
+        "전건 실패인데 stdout 이 비지 않았다: {}",
+        describe(&args, &out)
+    );
+    assert!(
+        !out.stderr.is_empty(),
+        "실패 사유는 stderr 로 나가야 한다: {}",
+        describe(&args, &out)
+    );
+}
+
+#[test]
+fn bench_success_still_prints_the_table() {
+    // 회귀 가드: 거부·침묵 규율을 넣으면서 성공 경로의 사람용 표까지 없애면 안 된다.
+    let s = sample();
+    let args = ["bench", s.to_str().unwrap(), "-n", "1"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    let text = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        text.contains("=== bench:"),
+        "성공하면 배너+표가 그대로 나와야 한다: {}",
+        describe(&args, &out)
+    );
+}
+
+// ── dump ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn dump_rejects_unknown_flag_with_silent_stdout() {
+    // [G2 실측] 종전: exit 0 + 18,643 B — 오타 난 옵션이 조용히 무시된 채 성공했다.
+    let s = sample();
+    assert_rejects(
+        &["dump", s.to_str().unwrap(), "--bogus-flag"],
+        "--bogus-flag",
+    );
+}
+
+#[test]
+fn dump_rejects_json_flag_until_it_has_a_json_contract() {
+    // dump 는 --json 계약이 없다. 침묵 무시(사람용 텍스트 + exit 0)보다 정직한 거부가
+    // 낫다 — JSON 봉투를 실제로 갖추는 일은 #3884 의 부류 판단(자기서술 등재) 뒤의 몫.
+    let s = sample();
+    assert_rejects(&["dump", s.to_str().unwrap(), "--json"], "--json");
+}
+
+#[test]
+fn dump_rejects_flag_in_file_position() {
+    // 첫 인자 자리의 플래그가 "파일을 읽을 수 없습니다 - --json"(exit 1)로 새지 않는다.
+    assert_rejects(&["dump", "--json"], "--json");
+}
+
+#[test]
+fn dump_still_accepts_declared_filters() {
+    // 회귀 가드: 선언된 --section/--para 는 계속 받는다.
+    let s = sample();
+    let args = ["dump", s.to_str().unwrap(), "--section", "0"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    assert!(!out.stdout.is_empty(), "{}", describe(&args, &out));
+}
+
+// ── diag ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn diag_rejects_unknown_flag_with_silent_stdout() {
+    // [G2 실측] 종전: diag 는 args[1..] 를 아예 보지 않아 무엇을 붙여도 exit 0 이었다.
+    let s = sample();
+    assert_rejects(&["diag", s.to_str().unwrap(), "--json"], "--json");
+}
+
+#[test]
+fn diag_rejects_flag_in_file_position() {
+    assert_rejects(&["diag", "--verbose"], "--verbose");
+}
+
+// ── run 예외의 자기서술 (G3) ─────────────────────────────────────────────
+
+#[test]
+fn run_failure_envelope_exception_is_self_described() {
+    // run 은 실패도 봉투로 보고하는 의도된 예외다(judgment-as-data). 예외가 실물에만
+    // 있고 자기서술에 없으면, "실패 = stdout 0바이트"를 믿는 소비자가 run 에서 깨진다.
+    //
+    // 호출은 bare `capabilities` — 이 명령은 플래그 없이 JSON 이 기본 출력이고,
+    // `--json` 은 `--search` 전용이다(직접 확인: 병합 전 0889974a0 도 `--json` 을
+    // "알 수 없는 옵션"으로 거부했다 — --search 병합의 회귀가 아니라 원래 계약).
+    let args = ["capabilities"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("capabilities JSON");
+    let failure = v["jsonContract"]["failure"]
+        .as_str()
+        .expect("jsonContract.failure");
+    assert!(
+        failure.contains("run"),
+        "run 의 stdout 예외가 자기서술에 없다: {failure}"
+    );
+    assert!(
+        failure.contains("invalid"),
+        "계획 무효(exit 2 + invalid[]) 예외가 자기서술에 없다: {failure}"
+    );
+}


### PR DESCRIPTION
#3884 의 **G1·G2(최소 수정)·G3** 를 닫습니다. G2 의 부류 판단과 G4 는 의도적으로 범위 밖입니다(아래).

## 실측 before → after

| 호출 | 종전 (실측) | 이후 (실측) |
|---|---|---|
| `bench <문서> --json` | exit 1 + **stdout 518 B** (배너+반쪽 표 — `--json` 이 "실패한 파일"이 됨) | **exit 2 + stdout 0 B** + stderr 안내 |
| `bench <없는 파일>` | exit 1 + stdout 에 배너+빈 표 | exit 1 + **stdout 0 B** (전건 실패 시 배너·표·TSV 미산출) |
| `dump <문서> --bogus-flag` | **exit 0** + 18,643 B (침묵 무시) | exit 2 + stdout 0 B |
| `dump <문서> --json` | **exit 0** + 사람용 텍스트 | exit 2 + stdout 0 B (계약이 없으므로 정직한 거부) |
| `dump --json` (파일 자리 플래그) | exit 1 "파일을 읽을 수 없습니다 - --json" | exit 2 + 사용법 |
| `diag <문서> --json` | **exit 0** (args[1..] 를 아예 안 봄) | exit 2 + stdout 0 B |

G3: `capabilities` 의 `jsonContract.failure` 에 `run` 의 의도된 stdout 예외를 현행 실물 기준으로 명시했습니다 — 입력 오류 exit 1 + `error` 봉투 / 계획 무효 exit 2 + `invalid[]` / 단언 실패 exit 3 + `verify` 저널. (이슈 표의 "exit 2·137 B"는 구판 측정입니다 — 현재 devel 은 #3882 반영으로 run 실패 봉투에 출처 표지까지 실려 191 B, 입력 오류는 exit 1 입니다. 실측으로 재확인했습니다.)

## red→green

`tests/diagnostics_flag_contract.rs` 11건. **src 만 devel 로 원복하면 9 FAILED / 2 ok** — 통과 2건(`bench_success_still_prints_the_table`·`dump_still_accepts_declared_filters`)은 "고치면서 기존 동작을 깨지 않는다"는 회귀 가드라 devel 에서도 통과하는 것이 맞습니다. 수정 후 11/11.

인접 스위트 무회귀: `cli_exit_codes_dump_diag`(4/4 — dump·diag 의 0/1/2 계약 그대로) · `cli_exit_codes_diagnostic_commands`(13/13). bench 의 TSV 는 측정 성공 0건일 때 파일을 만들지 않습니다 — `edit redact` 의 "탐지 0건 = 산출물 미생성"과 같은 원칙입니다.

## 의도적으로 안 한 것 (이슈의 열린 질문)

- **G2 부류 판단** — 진단 명령을 (a) 자기서술에 등재할지 (b) "자기서술 밖 명령" 부류를 정의할지는 표면 전체에 걸치는 결정이라 메인테이너 판단에 맡깁니다. 이 PR 은 어느 쪽을 택해도 필요한 최소 불변식("모르는 옵션은 조용히 무시하지 않는다")만 세웁니다. `dump --json` 의 실제 JSON 봉투 구현도 그 판단 뒤의 몫입니다.
- **G4** (inspect·edit 하위 명령의 발견 가능성) — 별도 작업으로 남깁니다.

## 곁가지 확인 (오탐 방지 기록)

`capabilities --json` 이 exit 2 인 것은 `--search`(#3836) 병합의 회귀가 **아닙니다** — 병합 전 0889974a0 에서도 "알 수 없는 옵션"으로 거부했고, 자기서술의 flags 도 `--search` 만 선언합니다. bare `capabilities` 가 JSON 기본 출력이라는 것이 원래 계약이고, 새 테스트도 bare 호출을 씁니다.

## 검증

`cargo check` 통과 · 위 3개 테스트 파일 release-test 로컬 통과 · `rustfmt` diff 0 (변경 파일 전부). 전체 스위트는 CI 로 부탁드립니다.

Closes #3884 의 G1·G2(최소)·G3 — G2 부류·G4 는 이슈에 열어 둡니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
