### PR TITLE
test(cli): 남은 stdin 헬퍼 3곳의 BrokenPipe 레이스를 마저 없앤다 (#3763)

### DIFF
--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -32,13 +32,28 @@ fn run_with_stdin(args: &[&str], stdin_body: &str) -> Output {
         .stderr(Stdio::piped())
         .spawn()
         .expect("rhwp 실행 실패");
-    child
+    write_stdin_ignoring_early_exit(&mut child, stdin_body);
+    child.wait_with_output().expect("rhwp 종료 대기 실패")
+}
+
+/// stdin 에 본문을 쓰되, 자식이 stdin 을 읽기 전에 종료한 경우의 BrokenPipe 는
+/// 무시한다. 인자 검증 거부 계열 테스트는 프로세스가 입력을 소비하기 전에
+/// 종료하는 것이 정상 경로라, 쓰기 완료 여부는 검증 대상(종료 코드·출력)이
+/// 아니다 (#3763 — batch_axes_contract.rs 와 같은 처리).
+fn write_stdin_ignoring_early_exit(child: &mut std::process::Child, stdin_body: &str) {
+    use std::io::ErrorKind;
+    if let Err(err) = child
         .stdin
         .as_mut()
         .expect("stdin")
         .write_all(stdin_body.as_bytes())
-        .expect("stdin 쓰기 실패");
-    child.wait_with_output().expect("rhwp 종료 대기 실패")
+    {
+        assert_eq!(
+            err.kind(),
+            ErrorKind::BrokenPipe,
+            "stdin 쓰기 실패: {err:?}"
+        );
+    }
 }
 
 fn describe(args: &[&str], output: &Output) -> String {

--- a/tests/info_title_contract.rs
+++ b/tests/info_title_contract.rs
@@ -42,13 +42,28 @@ fn run_with_stdin(args: &[&str], stdin_body: &str) -> Output {
         .stderr(Stdio::piped())
         .spawn()
         .expect("rhwp 실행 실패");
-    child
+    write_stdin_ignoring_early_exit(&mut child, stdin_body);
+    child.wait_with_output().expect("rhwp 종료 대기 실패")
+}
+
+/// stdin 에 본문을 쓰되, 자식이 stdin 을 읽기 전에 종료한 경우의 BrokenPipe 는
+/// 무시한다. 인자 검증 거부 계열 테스트는 프로세스가 입력을 소비하기 전에
+/// 종료하는 것이 정상 경로라, 쓰기 완료 여부는 검증 대상(종료 코드·출력)이
+/// 아니다 (#3763 — batch_axes_contract.rs 와 같은 처리).
+fn write_stdin_ignoring_early_exit(child: &mut std::process::Child, stdin_body: &str) {
+    use std::io::ErrorKind;
+    if let Err(err) = child
         .stdin
         .as_mut()
         .expect("stdin")
         .write_all(stdin_body.as_bytes())
-        .expect("stdin 쓰기 실패");
-    child.wait_with_output().expect("rhwp 종료 대기 실패")
+    {
+        assert_eq!(
+            err.kind(),
+            ErrorKind::BrokenPipe,
+            "stdin 쓰기 실패: {err:?}"
+        );
+    }
 }
 
 fn describe(args: &[&str], output: &Output) -> String {

--- a/tests/provenance_contract.rs
+++ b/tests/provenance_contract.rs
@@ -67,13 +67,28 @@ fn run_with_stdin(args: &[String], body: &str) -> Output {
         .stderr(Stdio::piped())
         .spawn()
         .expect("rhwp 실행 실패");
-    child
+    write_stdin_ignoring_early_exit(&mut child, body);
+    child.wait_with_output().expect("rhwp 종료 대기 실패")
+}
+
+/// stdin 에 본문을 쓰되, 자식이 stdin 을 읽기 전에 종료한 경우의 BrokenPipe 는
+/// 무시한다. 인자 검증 거부 계열 테스트는 프로세스가 입력을 소비하기 전에
+/// 종료하는 것이 정상 경로라, 쓰기 완료 여부는 검증 대상(종료 코드·출력)이
+/// 아니다 (#3763 — batch_axes_contract.rs 와 같은 처리).
+fn write_stdin_ignoring_early_exit(child: &mut std::process::Child, body: &str) {
+    use std::io::ErrorKind;
+    if let Err(err) = child
         .stdin
         .as_mut()
         .expect("stdin")
         .write_all(body.as_bytes())
-        .expect("stdin 쓰기 실패");
-    child.wait_with_output().expect("rhwp 종료 대기 실패")
+    {
+        assert_eq!(
+            err.kind(),
+            ErrorKind::BrokenPipe,
+            "stdin 쓰기 실패: {err:?}"
+        );
+    }
 }
 
 fn describe(args: &[String], out: &Output) -> String {


### PR DESCRIPTION
Issue: #3763

## 왜 다시 올리나

#3763 은 같은 형태의 헬퍼 **3곳**을 지목했는데, 통합 반영분에는 `tests/batch_axes_contract.rs` **한 곳만** 들어갔습니다. 나머지 두 곳은 지금도 `write_all` 실패를 그대로 패닉시킵니다.

| 파일 | devel 현재 |
|---|---|
| `tests/batch_axes_contract.rs` | ✅ `write_stdin_ignoring_early_exit` |
| `tests/cli_json_contract.rs` | ❌ `expect("stdin 쓰기 실패")` (40행) |
| `tests/info_title_contract.rs` | ❌ `expect("stdin 쓰기 실패")` (50행) |
| `tests/provenance_contract.rs` | ❌ (75행) — **이슈 작성 뒤 새로 생긴 4번째** |

`provenance_contract.rs` 는 이슈를 쓸 당시 없던 파일입니다. 같은 형태가 계속 복제되고 있어 함께 고칩니다.

## 고친 방법

셋 다 **devel 이 채택한 형태를 그대로** 씁니다 — 이름도 `write_stdin_ignoring_early_exit` 로 맞췄습니다. 자식이 stdin 을 읽기 전에 종료하는 것이 검증 대상인 계약에서는 `BrokenPipe` 가 정상 경로이므로 넘기고, 그 밖의 오류는 종전처럼 실패시킵니다.

검증력은 줄지 않습니다. 계약은 `wait_with_output()` 의 종료 코드·출력으로 확인하고 그 단언은 그대로입니다.

이로써 `tests/` 에 `expect("stdin 쓰기 실패")` 는 남지 않습니다.

**제품 코드 변경 없음.** 테스트 하네스만 고칩니다.

## 검증

작업 PC 의 툴체인 문제로 `cargo test` 가 돌지 않아 CI 가 판정합니다. 다만 이 변경은 devel 에 이미 머지되어 동작이 확인된 코드를 같은 모양으로 옮긴 것이라, 형태 자체는 검증된 것입니다.
