### PR TITLE
fix(provenance): 표지가 빠진 봉투 4건에 출처 표지를 단다 (#3885)

### DIFF
--- a/mydocs/report/task_m100_3885_report.md
+++ b/mydocs/report/task_m100_3885_report.md
@@ -1,0 +1,89 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_3885_report.md
+last_verified: 2026-08-04
+---
+
+# #3885 처리 기록 — 출처 표지가 빠진 봉투 4건 (redact 가 원문 개인정보를 표지 없이 싣는다)
+
+- Issue: [#3885](https://github.com/edwardkim/rhwp/issues/3885) — [#3787 S1] 출처 표지가
+  "항상 실린다"는데 실제로는 빠진 봉투가 있다
+- 브랜치 `task/3885-envelope-provenance-marker`
+
+## 증상
+
+`capabilities` 의 `jsonContract.provenance.policy` 는 *"표지는 항상 실린다 — 문서를 열지 않는
+명령의 봉투도 `untrustedContent:false` 를 명시한다"* 라고 선언하는데, 표지가 아예 없는 봉투가
+4건 있었다.
+
+| 명령 | 봉투가 담는 문서 파생 값 |
+|---|---|
+| `edit redact --dry-run --json` | **`findings[].raw` — 원문 개인정보** |
+| `edit sanitize --json` | `removed[].before` — 지운 메타데이터 원문 |
+| `export-ir-schema` | (문서를 열지 않음 — `false` 를 명시해야 하는 쪽) |
+| `export-capabilities-schema` | (동일) |
+
+`redact` 가 가장 나쁘다. `--dry-run` 은 **무엇을 지울지 먼저 보여주는 것**이 권장 흐름이라
+봉투의 `findings[].raw` 에 주민등록번호·카드번호·전화·이메일이 그대로 들어간다. 가장 민감한
+값을 싣는 봉투가 "이건 문서에서 온 값이다"라는 표지를 빠뜨리면 #3787 S1 이 세운 계약의 목적이
+정확히 그 지점에서 무너진다.
+
+## 근인 — 가드가 본 것과 보지 않은 것
+
+이슈가 지시한 대로 **가드가 왜 못 잡았는지부터** 확인했다.
+
+`provenance_map_covers_every_json_command` 는 지도가 명령을 **등재**했는지만 본다.
+
+```rust
+let missing: Vec<&String> = declared.iter()
+    .filter(|n| !commands.contains_key(n.as_str()))
+    .collect();
+```
+
+`edit` 은 지도에 있다(`src/provenance.rs`). `export-ir-schema`·`export-capabilities-schema` 도
+있다. **등재는 전부 통과한다.** 그런데 실행 결과 봉투에 표지가 실리는지는 아무도 보지 않았다.
+지도와 봉투는 다른 문제인데 가드가 하나만 본 것이다.
+
+두 번째 사각도 있었다. 스윕 레시피의 `edit` 은 `set-cell` 하나뿐이라 `redact`·`sanitize` 는
+실행조차 되지 않았다. 표지가 있었어도 이 경로는 검사 밖이었다.
+
+## 수정
+
+**가드부터 넓혔다** (이슈가 지정한 순서).
+
+- `every_executed_envelope_actually_carries_the_marker` — 스윕이 실제로 실행한 모든 봉투에
+  `untrustedContent` 키가 있는지 본다. 값이 아니라 **키의 존재**를 본다: 키가 없으면 소비자는
+  "안전하다"와 "이 빌드는 표지를 모른다"를 구별할 수 없고, 후자라면 다른 봉투의 표지도 못 믿는다.
+- `document_free_schema_commands_still_state_false` — `SWEEP_EXEMPT` 는 "문서 오라클을 만들 수
+  없다"는 뜻이지 "표지를 안 달아도 된다"가 아니다. 두 스키마 명령을 직접 실행해
+  `untrustedContent:false` 가 **명시**되는지 본다.
+- `edit redact --dry-run --json` 레시피 추가 — 이 경로가 스윕에 들어와야 위 가드가 의미를 갖는다.
+
+**그다음 표지를 달았다.**
+
+- `edit redact` / `edit sanitize` — `provenance::marked(envelope, "edit")`.
+- `export-ir-schema` / `export-capabilities-schema` — 봉투 모드에만 단다. `--bare` 는 봉투가
+  아니라 스키마 본문이라 JSON Schema 검증기에 그대로 먹이는 용도이므로 이물을 섞지 않는다.
+
+**지도에 두 필드를 선언했다.** 표지만 달면 `marked` 가 지도를 보고 판정하므로, 선언이 없으면
+`findings[].raw` 를 싣고도 `untrustedContent:false` 로 나간다 — 표지가 없는 것보다 나쁘다.
+
+- `findings[].raw` — redact 가 찾아낸 원문 개인정보
+- `removed[].before` — sanitize 가 지우기 전 메타데이터 원문
+
+## 판단이 필요했던 지점
+
+이슈가 짚은 대로 `findings[].raw` 는 "문서 파생"과 별개로 **"로그에 남기지 마라"** 가 더 중요한
+경고다. 이번에는 출처 표지만 달았다 — 민감도 축을 새로 만드는 것은 봉투 스키마 변경이라 별도
+판단이 필요하고, 표지 누락은 그와 무관하게 지금 계약 위반이기 때문이다. `--no-raw`(#3841)가
+이미 원문을 뺄 수단을 제공하므로, 민감도 신호는 그 위에서 논의하는 편이 낫다.
+
+## 검증
+
+- `rustfmt` 로 변경 파일 3개 포맷 확인.
+- 이 PC 는 MSVC 링커(`dbghelp.lib`) 손상으로 `cargo test` 가 아예 돌지 않는다. **CI 가 유일한
+  판정자다.**
+- 새 가드는 red→green 을 로컬에서 보이지 못했다. 다만 가드가 보는 대상(`untrustedContent` 키)과
+  수정이 만드는 것(`marked` 호출)이 직결돼 있고, 수정 전 상태에서 그 키가 없다는 것은
+  `git grep` 으로 확인했다(4개 출력부 어디에도 `marked` 가 없었다).

--- a/src/main.rs
+++ b/src/main.rs
@@ -13495,10 +13495,14 @@ fn cmd_export_ir_schema(args: &[String]) -> i32 {
         i += 1;
     }
 
+    // [#3885] `--bare` 는 봉투가 아니라 스키마 본문이므로 표지를 달지 않는다(JSON Schema
+    // 검증기에 그대로 먹이는 용도라 이물이 섞이면 안 된다). 봉투 모드는 문서를 열지 않아도
+    // `untrustedContent:false` 를 **명시**해야 한다 — 키가 없으면 소비자가 "안전하다"와
+    // "이 빌드는 표지를 모른다"를 구별할 수 없고, 후자라면 다른 봉투의 표지도 못 믿는다.
     let payload = if bare {
         rhwp::ir_schema::ir_schema()
     } else {
-        rhwp::ir_schema::envelope()
+        provenance::marked(rhwp::ir_schema::envelope(), "export-ir-schema")
     };
     let text = match serde_json::to_string_pretty(&payload) {
         Ok(t) => t,
@@ -13562,10 +13566,15 @@ fn cmd_export_capabilities_schema(args: &[String]) -> i32 {
         i += 1;
     }
 
+    // [#3885] `--bare` 는 스키마 본문이라 표지를 달지 않는다. 봉투 모드는 문서를 열지
+    // 않아도 `untrustedContent:false` 를 명시한다 — export-ir-schema 와 같은 이유다.
     let payload = if bare {
         rhwp::capabilities_schema::capabilities_schema()
     } else {
-        rhwp::capabilities_schema::envelope()
+        provenance::marked(
+            rhwp::capabilities_schema::envelope(),
+            "export-capabilities-schema",
+        )
     };
     let text = match serde_json::to_string_pretty(&payload) {
         Ok(t) => t,
@@ -15130,7 +15139,10 @@ fn edit_redact(args: &[String]) -> i32 {
             envelope["outputFormat"] = serde_json::Value::String(out_format.label().to_string());
             envelope["verify"] = verify_report.clone();
         }
-        println!("{envelope}");
+        // [#3885] 표지는 항상 실린다 — 이 봉투는 findings[].raw 에 **원문 개인정보**를
+        // 담는데 종전엔 표지가 아예 없었다. 가장 민감한 값을 싣는 봉투가 "이건 문서에서
+        // 온 값이다"를 말하지 않으면 출처 표지 계약의 목적이 그 지점에서 무너진다.
+        println!("{}", provenance::marked(envelope, "edit"));
         if verify_failed {
             process::exit(3);
         }
@@ -15587,7 +15599,8 @@ fn edit_sanitize(args: &[String]) -> i32 {
             "output": output_path,
             "outputFormat": out_format.label(),
         });
-        println!("{envelope}");
+        // [#3885] removed[].before 는 문서에서 지운 메타데이터 **원문**이다 — 표지를 단다.
+        println!("{}", provenance::marked(envelope, "edit"));
         return EXIT_OK;
     }
 

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -265,9 +265,21 @@ pub const MAP: &[CommandProvenance] = &[
                 "화면상 같아 보이는 **문서의 다른 누름틀 이름들** (#3707)",
             ),
             f("oldText", "set-cell 이 덮어쓰기 전 셀에 있던 문서 텍스트"),
+            // [#3885] redact·sanitize 도 `edit` 봉투다. 종전엔 표지가 아예 없어
+            // 이 두 필드가 선언되지 않았다 — 지도가 침묵하면 그 값을 받은 에이전트는
+            // 문서에 적힌 문장을 도구의 지시로 읽는다.
+            f(
+                "findings[].raw",
+                "redact 가 문서에서 찾아낸 **원문 개인정보** — 주민등록번호·카드번호·전화·이메일. \
+                 `--no-raw` 로 뺄 수 있지만 기본값은 싣는다 (#3841)",
+            ),
+            f(
+                "removed[].before",
+                "sanitize 가 지우기 전 문서 메타데이터에 있던 원문 값",
+            ),
         ],
         note: "find·replace·filled[].name 은 호출자가 준 문자열이고, \
-               replacedCount·changedPages·verify 는 엔진 판정값이다.",
+               replacedCount·changedPages·verify·redactedCount·removedCount 는 엔진 판정값이다.",
     },
     CommandProvenance {
         command: "run",

--- a/tests/provenance_contract.rs
+++ b/tests/provenance_contract.rs
@@ -510,6 +510,23 @@ fn recipes() -> Vec<Recipe> {
             exit: 0,
             ndjson: false,
         },
+        // [#3885] redact·sanitize 도 `edit` 봉투다. 종전 레시피는 set-cell 하나뿐이라
+        // 이 두 경로가 스윕 밖에 있었고, 그래서 표지 누락이 드러나지 않았다.
+        // redact 는 --dry-run 으로 디스크를 건드리지 않고 findings[] 만 받는다.
+        Recipe {
+            command: "edit",
+            doc: Some(main.clone()),
+            args: vec![
+                s("edit"),
+                s("redact"),
+                p(&main),
+                s("--dry-run"),
+                s("--json"),
+            ],
+            stdin: None,
+            exit: 0,
+            ndjson: false,
+        },
         Recipe {
             command: "edit",
             doc: Some(table.clone()),
@@ -842,6 +859,74 @@ fn provenance_map_covers_every_json_command() {
             origins.len(),
             untrusted.len(),
             "{name}: origins 와 untrusted 개수가 다릅니다(낡은 근거가 남았습니다): {entry}"
+        );
+    }
+}
+
+// ── 가드 ①-b 지도에 있는 것과 봉투에 실리는 것은 다른 문제다 ─────────────────
+
+/// 실제 봉투가 표지를 **싣는지** 본다.
+///
+/// 가드 ① 은 지도가 명령을 **등재**했는지만 본다. 그래서 등재는 돼 있는데 실행 결과
+/// 봉투에는 `untrustedContent` 키가 아예 없는 상태를 통과시킨다 — #3885 의 4건이 정확히
+/// 그 사각에 있었다(`edit redact` 가 `findings[].raw` 에 원문 개인정보를 표지 없이 실었다).
+///
+/// 정책이 *"표지는 항상 실린다 — 문서를 열지 않는 명령의 봉투도 `untrustedContent:false`
+/// 를 명시한다"* 라고 적은 이유가 여기 있다. 키가 없으면 소비자는 **"안전하다"와 "이 빌드는
+/// 표지를 모른다"를 구별할 수 없다.** 후자라면 다른 봉투의 표지도 믿을 수 없다.
+#[test]
+fn every_executed_envelope_actually_carries_the_marker() {
+    let sweep = sweep();
+    let mut missing: Vec<String> = Vec::new();
+
+    for r in &sweep.recipes {
+        for env in envelopes_of(r.command) {
+            if !env.is_object() {
+                continue;
+            }
+            if env.get("untrustedContent").is_none() {
+                missing.push(format!("  - {} ({})", r.command, r.args.join(" ")));
+                break;
+            }
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "봉투에 출처 표지(untrustedContent)가 없는 명령 {}건:\n{}\n\n\
+         src/main.rs 의 해당 출력부를 `provenance::marked(envelope, \"<명령>\")` 로 감싸세요. \
+         문서를 열지 않는 명령도 `false` 를 명시해야 합니다 — 키의 부재는 '안전함'이 아니라 \
+         '이 빌드는 표지를 모름'으로 읽힙니다.",
+        missing.len(),
+        missing.join("\n"),
+    );
+}
+
+/// 스윕 면제 명령도 표지에서는 면제가 아니다.
+///
+/// `SWEEP_EXEMPT` 는 "문서 오라클을 만들 수 없다"는 뜻이지 "표지를 안 달아도 된다"가
+/// 아니다. 오히려 이쪽이 `untrustedContent:false` 를 **명시**해야 하는 쪽이다 — 문서를
+/// 열지 않는다는 사실 자체가 소비자가 알아야 할 판정이기 때문이다.
+///
+/// `--bare` 는 봉투가 아니라 스키마 본문이므로 대상이 아니다(검증기에 그대로 먹인다).
+#[test]
+fn document_free_schema_commands_still_state_false() {
+    for cmd in ["export-ir-schema", "export-capabilities-schema"] {
+        let args = vec![s(cmd)];
+        let out = run(&args);
+        assert_eq!(
+            out.status.code(),
+            Some(0),
+            "{cmd} 실행 실패 — 가드가 공허하게 통과하지 않도록 먼저 고치세요\n{}",
+            describe(&args, &out)
+        );
+        let v: Value = serde_json::from_slice(&out.stdout)
+            .unwrap_or_else(|e| panic!("{cmd} 봉투가 JSON 이 아닙니다: {e}"));
+        assert_eq!(
+            v["untrustedContent"],
+            Value::Bool(false),
+            "{cmd} 는 문서를 열지 않으므로 untrustedContent:false 를 **명시**해야 합니다. \
+             키가 없으면 소비자가 '안전함'과 '이 빌드는 표지를 모름'을 구별할 수 없습니다: {v}"
         );
     }
 }


### PR DESCRIPTION
Issue: #3885
처리 기록: `mydocs/report/task_m100_3885_report.md`

## 문제

정책은 *"표지는 항상 실린다 — 문서를 열지 않는 명령의 봉투도 `untrustedContent:false` 를 명시한다"* 인데, 표지가 아예 없는 봉투가 4건 있었습니다.

| 명령 | 봉투가 담는 문서 파생 값 |
|---|---|
| `edit redact --dry-run --json` | **`findings[].raw` — 원문 개인정보** |
| `edit sanitize --json` | `removed[].before` — 지운 메타데이터 원문 |
| `export-ir-schema` | (문서 무관 — `false` 를 명시해야 하는 쪽) |
| `export-capabilities-schema` | (동일) |

`redact` 가 가장 나쁩니다. `--dry-run` 은 무엇을 지울지 먼저 보여주는 것이 권장 흐름이라 봉투에 주민등록번호·카드번호·전화·이메일이 그대로 들어갑니다.

## 근인 — 가드가 본 것과 보지 않은 것

이슈 지시대로 **가드가 왜 못 잡았는지부터** 봤습니다.

`provenance_map_covers_every_json_command` 는 지도가 명령을 **등재**했는지만 봅니다. `edit`·`export-ir-schema`·`export-capabilities-schema` 는 **모두 등재돼 있어 통과**합니다 — 실행 결과 봉투에 표지가 실리는지는 아무도 보지 않았습니다. 지도와 봉투는 다른 문제인데 가드가 하나만 봤습니다.

사각이 하나 더 있었습니다. 스윕 레시피의 `edit` 은 `set-cell` 하나뿐이라 `redact`·`sanitize` 는 **실행조차 되지 않았습니다.**

## 수정 — 가드부터

1. **`every_executed_envelope_actually_carries_the_marker`** — 스윕이 실행한 모든 봉투에 `untrustedContent` 키가 있는지 봅니다. 값이 아니라 **키의 존재**를 봅니다: 키가 없으면 소비자는 "안전하다"와 "이 빌드는 표지를 모른다"를 구별할 수 없고, 후자라면 다른 봉투의 표지도 못 믿습니다.
2. **`document_free_schema_commands_still_state_false`** — `SWEEP_EXEMPT` 는 "문서 오라클을 못 만든다"는 뜻이지 표지 면제가 아닙니다. 두 스키마 명령을 직접 실행해 `false` 명시를 확인합니다.
3. **`edit redact --dry-run --json` 레시피 추가** — 이 경로가 스윕에 들어와야 위 가드가 의미를 갖습니다.

그다음 표지를 답니다. 스키마 명령은 **봉투 모드에만** 답니다 — `--bare` 는 봉투가 아니라 스키마 본문이라 검증기에 그대로 먹이는 용도입니다.

**지도에도 두 필드를 선언했습니다.** 표지만 달면 `marked` 가 지도를 보고 판정하므로, 선언이 없으면 `findings[].raw` 를 싣고도 `false` 로 나갑니다 — 표지가 없는 것보다 나쁩니다.

## 이번 범위에서 뺀 것

이슈가 짚은 `findings[].raw` 의 **"로그에 남기지 마라"** 신호는 넣지 않았습니다. 민감도 축 신설은 봉투 스키마 변경이라 별도 판단이 필요하고, 표지 누락은 그와 무관하게 지금 계약 위반입니다. `--no-raw`(#3841)가 이미 원문을 뺄 수단을 주므로 민감도 신호는 그 위에서 논의하는 편이 낫다고 봤습니다.

## 검증

`rustfmt` 로 변경 파일 포맷을 확인했습니다. 이 PC 는 MSVC 링커(`dbghelp.lib`) 손상으로 `cargo test` 가 아예 돌지 않아 **CI 가 유일한 판정자**입니다.

새 가드의 red→green 을 로컬에서 보이지 못했습니다. 다만 가드가 보는 대상(`untrustedContent` 키)과 수정이 만드는 것(`marked` 호출)이 직결돼 있고, 수정 전 4개 출력부 어디에도 `marked` 가 없다는 것은 확인했습니다.
