### PR TITLE
fix(provenance): 출처 표지 빠진 봉투 5건 + 가드 4중 확장 — redact 원문 PII 가 최민감 (#3885)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13496,9 +13496,13 @@ fn cmd_export_ir_schema(args: &[String]) -> i32 {
     }
 
     let payload = if bare {
+        // --bare 는 JSON Schema 검증기에 그대로 먹이는 본문이다 — 봉투 표지를 섞지 않는다.
         rhwp::ir_schema::ir_schema()
     } else {
-        rhwp::ir_schema::envelope()
+        // [#3885] "표지는 항상 실린다" — 문서를 열지 않는 명령의 봉투도
+        // untrustedContent:false 를 명시한다. 키 부재는 "안전"이 아니라
+        // "이 빌드는 표지를 모른다"로 읽히기 때문이다.
+        provenance::marked(rhwp::ir_schema::envelope(), "export-ir-schema")
     };
     let text = match serde_json::to_string_pretty(&payload) {
         Ok(t) => t,
@@ -13517,12 +13521,15 @@ fn cmd_export_ir_schema(args: &[String]) -> i32 {
             // 파일로 뺐어도 stdout 은 기계 계약을 유지한다 — 어디에 썼는지 알려준다.
             println!(
                 "{}",
-                serde_json::json!({
-                    "schemaVersion": "1.0",
-                    "irSchemaVersion": rhwp::ir_schema::IR_SCHEMA_VERSION,
-                    "output": path,
-                    "bytes": text.len(),
-                })
+                provenance::marked(
+                    serde_json::json!({
+                        "schemaVersion": "1.0",
+                        "irSchemaVersion": rhwp::ir_schema::IR_SCHEMA_VERSION,
+                        "output": path,
+                        "bytes": text.len(),
+                    }),
+                    "export-ir-schema"
+                )
             );
         } else {
             println!("IR 스키마 저장: {} ({} bytes)", path, text.len());
@@ -13563,9 +13570,14 @@ fn cmd_export_capabilities_schema(args: &[String]) -> i32 {
     }
 
     let payload = if bare {
+        // --bare 는 JSON Schema 검증기에 그대로 먹이는 본문이다 — 봉투 표지를 섞지 않는다.
         rhwp::capabilities_schema::capabilities_schema()
     } else {
-        rhwp::capabilities_schema::envelope()
+        // [#3885] export-ir-schema 와 같은 사유 — 문서를 열지 않아도 표지는 싣는다.
+        provenance::marked(
+            rhwp::capabilities_schema::envelope(),
+            "export-capabilities-schema",
+        )
     };
     let text = match serde_json::to_string_pretty(&payload) {
         Ok(t) => t,
@@ -13583,13 +13595,16 @@ fn cmd_export_capabilities_schema(args: &[String]) -> i32 {
         if json_mode {
             println!(
                 "{}",
-                serde_json::json!({
-                    "schemaVersion": "1.0",
-                    "capabilitiesSchemaVersion":
-                        rhwp::capabilities_schema::CAPABILITIES_SCHEMA_VERSION,
-                    "output": path,
-                    "bytes": text.len(),
-                })
+                provenance::marked(
+                    serde_json::json!({
+                        "schemaVersion": "1.0",
+                        "capabilitiesSchemaVersion":
+                            rhwp::capabilities_schema::CAPABILITIES_SCHEMA_VERSION,
+                        "output": path,
+                        "bytes": text.len(),
+                    }),
+                    "export-capabilities-schema"
+                )
             );
         } else {
             println!("capabilities 스키마 저장: {} ({} bytes)", path, text.len());
@@ -15130,7 +15145,11 @@ fn edit_redact(args: &[String]) -> i32 {
             envelope["outputFormat"] = serde_json::Value::String(out_format.label().to_string());
             envelope["verify"] = verify_report.clone();
         }
-        println!("{envelope}");
+        // [#3885] findings[].raw 는 마스킹 전 원문 — 개인정보 그 자체다. 가장 민감한
+        // 값을 싣는 봉투가 출처 표지 없이 나가면 S1 계약("표지는 항상 실린다")이
+        // 정확히 그 지점에서 무너진다. --no-raw 면 raw 경로가 봉투에 없으므로
+        // 표지도 masked 만 선언한다(실재 경로 필터).
+        println!("{}", provenance::marked(envelope, "edit"));
         if verify_failed {
             process::exit(3);
         }
@@ -15587,7 +15606,9 @@ fn edit_sanitize(args: &[String]) -> i32 {
             "output": output_path,
             "outputFormat": out_format.label(),
         });
-        println!("{envelope}");
+        // [#3885] removed[].before 는 지워진 문서 속성 원문이다 — 제목·작성자에
+        // 더해 preview.text 는 본문 첫 화면 발췌라 문서 문장이 통째로 실린다.
+        println!("{}", provenance::marked(envelope, "edit"));
         return EXIT_OK;
     }
 
@@ -16584,7 +16605,10 @@ fn edit_insert_image(args: &[String]) -> i32 {
             envelope["outputFormat"] = serde_json::Value::String(out_format.label().to_string());
             envelope["verify"] = verify_report.clone();
         }
-        println!("{envelope}");
+        // [#3885] 이 봉투의 값은 전부 호출자 인자·엔진 판정이라 문서 유래 경로가
+        // 없지만, 표지 자체는 항상 싣는다 — 키 부재는 "안전"이 아니라 "판정 안 함"
+        // 으로 읽어야 하기 때문이다(S1).
+        println!("{}", provenance::marked(envelope, "edit"));
         if verify_failed {
             process::exit(3);
         }

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -265,6 +265,23 @@ pub const MAP: &[CommandProvenance] = &[
                 "화면상 같아 보이는 **문서의 다른 누름틀 이름들** (#3707)",
             ),
             f("oldText", "set-cell 이 덮어쓰기 전 셀에 있던 문서 텍스트"),
+            // [#3885] redact — 마스킹 전 원문. 개인정보 그 자체이므로 이 경로의 값은
+            // 로그·이슈에 옮기지 않는다(--no-raw 면 봉투에 없어 표지에서도 빠진다).
+            f(
+                "findings[].raw",
+                "redact 가 탐지한 개인정보 **원문** — 문서 본문에서 그대로 뽑은 값",
+            ),
+            // 마스킹 결과도 문서 파생이다 — 영숫자는 가려지지만 하이픈·@·점 같은
+            // 구조 문자와 길이가 원문에서 온다. 보수적으로 선언한다(과대 선언이 안전).
+            f(
+                "findings[].masked",
+                "redact 마스킹 결과 — 구조 문자·자릿수가 문서 원문에서 유래",
+            ),
+            f(
+                "removed[].before",
+                "sanitize 가 지운 문서 속성 원문 — 제목·작성자·키워드, 그리고 \
+                 preview.text 는 본문 첫 화면 발췌",
+            ),
         ],
         note: "find·replace·filled[].name 은 호출자가 준 문자열이고, \
                replacedCount·changedPages·verify 는 엔진 판정값이다.",

--- a/tests/provenance_contract.rs
+++ b/tests/provenance_contract.rs
@@ -236,6 +236,14 @@ const CALLER_ECHO: &[(&str, &str)] = &[
     ("output", "호출자가 지정한 산출 경로"),
     ("outputDir", "호출자가 지정한 산출 폴더"),
     ("assetsDir", "호출자가 지정한 자산 폴더"),
+    // 전체 경로 항목 — 잎(leaf)으로 등재하면 같은 잎을 가진 문서 파생 경로
+    // (예: fields[].name — 문서에서 읽은 누름틀 이름)까지 면제돼 가드가 약해진다.
+    (
+        "filled[].name",
+        "fill-fields --data 의 키 반향 — 채움이 성공한 이름은 문서 누름틀 이름과 \
+         같아질 수밖에 없지만, 봉투에 실리는 문자열 자체는 호출자가 준 것이다 \
+         (src/provenance.rs edit 항목 note 의 기존 판정과 동일)",
+    ),
     (
         "path",
         "매니페스트의 산출 파일 경로 — 입력 파일이름에서 조합된다",
@@ -249,6 +257,11 @@ const CALLER_ECHO: &[(&str, &str)] = &[
 ];
 
 fn is_caller_echo(path: &str) -> bool {
+    // 전체 경로 일치 우선 — filled[].name 처럼 특정 자리만 반향인 경우를 잎 등재로
+    // 넓히지 않기 위해서다.
+    if CALLER_ECHO.iter().any(|(k, _)| *k == path) {
+        return true;
+    }
     let leaf = path.rsplit('.').next().unwrap_or(path);
     let leaf = leaf.trim_end_matches("[]");
     CALLER_ECHO.iter().any(|(k, _)| *k == leaf)
@@ -387,6 +400,47 @@ fn recipes() -> Vec<Recipe> {
         .expect("table-to-csv 기준선 CSV")
         .to_string();
     std::fs::write(&table_csv_path, table_csv).expect("CSV 기준선 쓰기");
+
+    // [#3885] redact 스윕용 가짜 개인정보 문서 — 저장소에 PII 샘플을 두지 않는다
+    // (tests/redact_sanitize_contract.rs 와 같은 fill-fields 주입 방식). 값은 전부
+    // 가공이다: 검증 숫자(mod 11)를 통과하는 실재 인물 무관 주민번호, 하이픈 형태
+    // 전화번호. 이 값들이 본문에 들어가야 오라클이 findings[].raw 를 잡는다.
+    let pii = PathBuf::from(out("prov-pii.hwp"));
+    let _ = std::fs::remove_file(&pii);
+    let pii_args = vec![
+        s("edit"),
+        s("fill-fields"),
+        p(&field),
+        s("--data"),
+        s(r#"{"작성자":"홍길동 900101-1234568","전화번호":"010-1234-5678"}"#),
+        s("-o"),
+        p(&pii),
+        s("--json"),
+    ];
+    let pii_fill = run(&pii_args);
+    assert_eq!(
+        pii_fill.status.code(),
+        Some(0),
+        "PII 픽스처를 만들지 못했습니다:\n{}",
+        describe(&pii_args, &pii_fill)
+    );
+
+    // insert-image 레시피용 그림 — 아무 실물 이미지면 된다.
+    let stamp = sample("samples/s1.jpg");
+
+    // [#3880 T1] recordFields 전수 대조용 픽스처 — 선언 필드가 "그 필드를 내는
+    // 호출"에서만 나오는 경우, 그 호출을 스윕에 실제로 넣는다(허용목록 대신).
+    let bad_plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": p(&field),
+        "output": out("prov-run-bad.hwp"),
+        "steps": [ { "action": "fill_fields", "data": { "prov없는필드": "x" } } ],
+    })
+    .to_string();
+    let fill_rows_path = PathBuf::from(out("prov-fill-rows.jsonl"));
+    std::fs::write(&fill_rows_path, "{\"작성자\":\"홍길동 제안\"}\n").expect("fill rows 쓰기");
+    let fill_out_dir = dir.join("prov-fill-out");
+    let _ = std::fs::create_dir_all(&fill_out_dir);
 
     vec![
         Recipe {
@@ -531,6 +585,192 @@ fn recipes() -> Vec<Recipe> {
             stdin: None,
             exit: 0,
             ndjson: false,
+        },
+        // [#3885] edit 는 하위 명령마다 봉투가 다르다 — set-cell 하나로 "edit 를
+        // 덮었다"고 치면 redact 의 findings[].raw(개인정보 원문) 같은 가장 민감한
+        // 경로가 스윕 밖에 남는다. 문서 파생 값을 싣는 하위 명령을 각각 돌린다.
+        Recipe {
+            command: "edit",
+            doc: Some(pii.clone()),
+            args: vec![s("edit"), s("redact"), p(&pii), s("--dry-run"), s("--json")],
+            stdin: None,
+            exit: 0,
+            ndjson: false,
+        },
+        Recipe {
+            command: "edit",
+            doc: Some(pii.clone()),
+            args: vec![
+                s("edit"),
+                s("sanitize"),
+                p(&pii),
+                s("-o"),
+                out("prov-sanitized.hwp"),
+                s("--json"),
+            ],
+            stdin: None,
+            exit: 0,
+            ndjson: false,
+        },
+        // 문서 유래 문자열이 없는 edit 봉투(insert-image)도 표지 존재 검사는 받는다.
+        Recipe {
+            command: "edit",
+            doc: Some(field.clone()),
+            args: vec![
+                s("edit"),
+                s("insert-image"),
+                p(&field),
+                s("--image"),
+                p(&stamp),
+                s("--dry-run"),
+                s("--json"),
+            ],
+            stdin: None,
+            exit: 0,
+            ndjson: false,
+        },
+        // ── [#3880 T1] recordFields 전수 대조 보강 — 선언 필드를 실제로 내는 호출들 ──
+        Recipe {
+            // digest --sections: 선언 필드 sections(절 단위 청크)는 이 플래그에서만 나온다.
+            command: "digest",
+            doc: Some(main.clone()),
+            args: vec![s("digest"), s("--json"), s("--sections"), p(&main)],
+            stdin: None,
+            exit: 0,
+            ndjson: false,
+        },
+        Recipe {
+            // inspect 는 축이 셋이다 — unicode 하나로 "덮었다" 치면 hidden-text 의
+            // hiddenText·hiddenCharCount, injection 의 injectionSignals 등이 사각에 남는다.
+            command: "inspect",
+            doc: Some(main.clone()),
+            args: vec![s("inspect"), s("hidden-text"), p(&main), s("--json")],
+            stdin: None,
+            exit: 0,
+            ndjson: false,
+        },
+        Recipe {
+            command: "inspect",
+            doc: Some(field.clone()),
+            args: vec![s("inspect"), s("injection"), p(&field), s("--json")],
+            stdin: None,
+            exit: 0,
+            ndjson: false,
+        },
+        Recipe {
+            // run 무효 계획 — invalid[] 는 실패 봉투에만 실린다(exit 2). 실패 봉투도
+            // 표지 존재 검사를 받게 하는 부수 효과가 있다.
+            command: "run",
+            doc: Some(field.clone()),
+            args: vec![s("run"), s("--plan-json"), bad_plan, s("--json")],
+            stdin: None,
+            exit: 2,
+            ndjson: false,
+        },
+        Recipe {
+            // table-to-csv -o: output·outputFormat 은 파일 산출에서만 나온다.
+            command: "table-to-csv",
+            doc: Some(table.clone()),
+            args: vec![
+                s("table-to-csv"),
+                p(&table),
+                s("--table"),
+                s("0"),
+                s("-o"),
+                out("prov-t2c.csv"),
+                s("--json"),
+            ],
+            stdin: None,
+            exit: 0,
+            ndjson: false,
+        },
+        Recipe {
+            // csv-to-table 실적용 + --verify: output·outputFormat·verify.
+            command: "csv-to-table",
+            doc: Some(table.clone()),
+            args: vec![
+                s("csv-to-table"),
+                p(&table),
+                s("--csv"),
+                p(&table_csv_path),
+                s("--table"),
+                s("0"),
+                s("-o"),
+                out("prov-c2t.hwp"),
+                s("--verify"),
+                s("--json"),
+            ],
+            stdin: None,
+            exit: 0,
+            ndjson: false,
+        },
+        Recipe {
+            // edit fill-fields --verify: filled·filledCount·notFound·verify.
+            command: "edit",
+            doc: Some(field.clone()),
+            args: vec![
+                s("edit"),
+                s("fill-fields"),
+                p(&field),
+                s("--data"),
+                s(r#"{"회사명":"티일 주식회사"}"#),
+                s("-o"),
+                out("prov-fill.hwp"),
+                s("--verify"),
+                s("--json"),
+            ],
+            stdin: None,
+            exit: 0,
+            ndjson: false,
+        },
+        Recipe {
+            // edit replace-text: replacedCount.
+            command: "edit",
+            doc: Some(pii.clone()),
+            args: vec![
+                s("edit"),
+                s("replace-text"),
+                p(&pii),
+                s("--find"),
+                s("홍길동"),
+                s("--replace"),
+                s("김샘플"),
+                s("-o"),
+                out("prov-repl.hwp"),
+                s("--json"),
+            ],
+            stdin: None,
+            exit: 0,
+            ndjson: false,
+        },
+        Recipe {
+            // batch 오류 레코드 — error·exitClass 는 파일 단위 실패 레코드에만 실린다.
+            // jsonContract: "batch 는 error 레코드 + 최종 exit 1".
+            command: "batch",
+            doc: None,
+            args: vec![s("batch"), s("info"), s("--json")],
+            stdin: Some(s("prov-no-such-file-3885.hwp\n")),
+            exit: 1,
+            ndjson: true,
+        },
+        Recipe {
+            // batch fill — row·output·filledCount·notFound 는 메일머지 행 봉투에만.
+            command: "batch",
+            doc: Some(field.clone()),
+            args: vec![
+                s("batch"),
+                s("fill"),
+                s("--form"),
+                p(&field),
+                s("--data"),
+                p(&fill_rows_path),
+                s("--out-dir"),
+                p(&fill_out_dir),
+                s("--json"),
+            ],
+            stdin: None,
+            exit: 0,
+            ndjson: true,
         },
         Recipe {
             command: "run",
@@ -716,10 +956,16 @@ static SWEEP: OnceLock<Sweep> = OnceLock::new();
 fn sweep() -> &'static Sweep {
     SWEEP.get_or_init(|| {
         let recipes = recipes();
-        let mut envelopes = BTreeMap::new();
+        let mut envelopes: BTreeMap<&'static str, Vec<Value>> = BTreeMap::new();
         let mut oracles: BTreeMap<PathBuf, DocOracle> = BTreeMap::new();
         for r in &recipes {
-            envelopes.insert(r.command, run_recipe(r));
+            // [#3885] insert 는 같은 명령의 앞 레시피 봉투를 덮어쓴다 — edit 처럼
+            // 하위 명령이 여럿인 축은 레시피도 여럿이라, 누적하지 않으면 마지막
+            // 하위 명령만 검사되고 나머지는 조용히 빠진다(redact 가 그렇게 빠졌다).
+            envelopes
+                .entry(r.command)
+                .or_default()
+                .extend(run_recipe(r));
             if let Some(doc) = &r.doc {
                 if !oracles.contains_key(doc) {
                     oracles.insert(doc.clone(), oracle(doc));
@@ -894,6 +1140,15 @@ fn every_text_bearing_command_declares_untrusted_fields() {
         let declared_roots: BTreeSet<&str> = declared.iter().map(|p| root_of(p)).collect();
 
         for env in envelopes_of(r.command) {
+            // [#3885] 표지 존재는 오라클 매치와 무관한 모든 봉투의 의무다. 종전에는
+            // 문서 문자열이 "발견된" 봉투만 검사해서, 표지 키 자체가 없는 봉투는
+            // 어느 단언에도 걸리지 않고 빠져나갔다 — redact 가 정확히 그 구멍이었다.
+            if env.get("untrustedContent").is_none() || env.get("untrustedFields").is_none() {
+                failures.push(format!(
+                    "  - {}: 봉투에 출처 표지(untrustedContent/untrustedFields)가 없습니다",
+                    r.command
+                ));
+            }
             let mut found = BTreeSet::new();
             scan(env, "", or, &mut found);
             if found.is_empty() {
@@ -1135,4 +1390,156 @@ fn schema_version_stays_1_0_because_the_flag_is_additive() {
         }
     }
     assert_eq!(provenance_map()["schemaVersion"], "1.0");
+}
+
+/// [#3885] 스윕 면제는 "문서 오라클을 만들 수 없다"는 뜻이지 "표지를 안 실어도
+/// 된다"가 아니다 — 종전에는 면제 명령의 봉투를 아무 가드도 열어 보지 않아, 스키마
+/// 봉투 2종(export-ir-schema·export-capabilities-schema)이 표지 없이 나가는 것을
+/// 아무도 몰랐다. 면제 명령마다 실제 호출로 표지 존재를 고정하고, 호출표 완전성을
+/// SWEEP_EXEMPT 와 기계로 대조한다 — 새 면제가 표지 검사까지 조용히 면제받는
+/// 드리프트를 막는다.
+#[test]
+fn sweep_exempt_envelopes_still_carry_provenance_marks() {
+    let dir = tmp_dir();
+    let ingest = dir.join("prov-exempt-ingest.json");
+    std::fs::write(&ingest, r#"{"version":"1","questions":[]}"#).expect("ingest 픽스처");
+    let ingest_out = dir.join("prov-exempt-ingest.hwpx");
+
+    let invocations: BTreeMap<&str, Vec<String>> = [
+        ("export-ir-schema", vec![s("export-ir-schema"), s("--json")]),
+        (
+            "export-capabilities-schema",
+            vec![s("export-capabilities-schema"), s("--json")],
+        ),
+        (
+            "export-agent-manifest",
+            vec![s("export-agent-manifest"), s("--json")],
+        ),
+        // [#3808 선등재] 아직 devel 에 없는 명령 — 표는 SWEEP_EXEMPT 기준으로만
+        // 순회하므로 초과 항목은 미사용으로 잠들어 있다가, #3808 이 그 명령을
+        // 면제 목록에 넣는 순간 자동으로 검사에 편입된다(어느 쪽이 먼저 머지돼도
+        // 후속 수정 없음 — 3-PR 누적 머지에서 이 항목 유무로 실측 확인).
+        (
+            "export-plan-schema",
+            vec![s("export-plan-schema"), s("--json")],
+        ),
+        (
+            "build-from-ingest",
+            vec![
+                s("build-from-ingest"),
+                ingest.to_str().expect("경로").to_string(),
+                s("-o"),
+                ingest_out.to_str().expect("경로").to_string(),
+                s("--json"),
+            ],
+        ),
+    ]
+    .into_iter()
+    .collect();
+
+    for (name, _why) in SWEEP_EXEMPT {
+        let args = invocations.get(name).unwrap_or_else(|| {
+            panic!(
+                "SWEEP_EXEMPT 의 {name} 이 표지 존재 검사 호출표에 없습니다 — \
+                 이 테스트의 invocations 에 호출 방법을 더하세요"
+            )
+        });
+        let out = run(args);
+        assert_eq!(
+            out.status.code(),
+            Some(0),
+            "{name} 호출 실패:\n{}",
+            describe(args, &out)
+        );
+        let env: Value = serde_json::from_slice(&out.stdout)
+            .unwrap_or_else(|e| panic!("{name} stdout 이 JSON 이 아닙니다({e})"));
+        assert!(
+            env.get("untrustedContent").is_some() && env.get("untrustedFields").is_some(),
+            "{name} 봉투에 출처 표지(untrustedContent/untrustedFields)가 없습니다"
+        );
+        // 면제 = 문서를 열지 않는 명령이므로 값도 false/빈 배열이어야 한다.
+        assert_eq!(
+            env["untrustedContent"],
+            Value::Bool(false),
+            "{name}: 문서를 열지 않는데 untrustedContent 가 false 가 아닙니다"
+        );
+    }
+}
+
+/// [#3880 T1] 선언한 `recordFields` 가 실물 봉투에 실제로 나타난다 — 스윕 전수.
+///
+/// `info` 의 `warnings` 부재(T1, #3882 로 수정)가 통과했던 구멍이 이것이다:
+/// 자기서술이 필드를 광고하는데 **아무 가드도 실물과 대조하지 않았다.** 스윕이
+/// 이미 전 `--json` 명령을 유효 인자로 실행하므로, 명령별 봉투 최상위 키 합집합과
+/// 선언을 대조한다. 중첩 경로(`steps[].confusable` 류)는 최상위 대조 대상이
+/// 아니다 — 바인딩 파리티 테스트(bindings/python/tests/test_envelope_parity.py)와
+/// 같은 기준이며, 그쪽은 대표 4개 명령만 본다(이쪽이 전수다).
+///
+/// 조건부 필드는 **사유와 함께** CONDITIONAL_RECORD_FIELDS 에 적는다 — 사유 없는
+/// 허용목록은 가드를 무력화한다. 가능하면 허용 대신 레시피가 그 필드를 실제로
+/// 나오게 하는 쪽을 택한다(예: sanitize 레시피가 `-o` 로 저장해 `output` 을 낸다).
+const CONDITIONAL_RECORD_FIELDS: &[(&str, &str, &str)] = &[
+    // (명령, 필드, 스윕 레시피가 그 필드를 못 내는 사유)
+];
+
+#[test]
+fn declared_record_fields_actually_appear_in_envelopes() {
+    let cap = capabilities();
+    let sweep = sweep();
+
+    let mut observed: BTreeMap<&str, BTreeSet<String>> = BTreeMap::new();
+    for r in &sweep.recipes {
+        let keys = observed.entry(r.command).or_default();
+        for env in envelopes_of(r.command) {
+            if let Some(o) = env.as_object() {
+                keys.extend(o.keys().cloned());
+            }
+        }
+    }
+
+    let empty = Vec::new();
+    let mut problems: Vec<String> = Vec::new();
+    for c in cap["commands"].as_array().expect("commands") {
+        if c["json"] != Value::Bool(true) {
+            continue;
+        }
+        let name = c["name"].as_str().expect("name");
+        // 스윕 밖(면제) 명령의 봉투는 sweep_exempt_envelopes_still_carry_provenance_marks
+        // 가 따로 연다 — 여기서는 스윕이 실행해 본 명령만 대조한다.
+        let Some(keys) = observed.get(name) else {
+            continue;
+        };
+        for field in c["recordFields"].as_array().unwrap_or(&empty) {
+            let Some(field) = field.as_str() else {
+                continue;
+            };
+            if field.contains('[') || field.contains('.') {
+                continue;
+            }
+            if keys.contains(field) {
+                continue;
+            }
+            if let Some((_, _, why)) = CONDITIONAL_RECORD_FIELDS
+                .iter()
+                .find(|(cmd, f, _)| *cmd == name && *f == field)
+            {
+                assert!(
+                    !why.trim().is_empty(),
+                    "{name}.{field} 허용 사유가 비었습니다"
+                );
+                continue;
+            }
+            problems.push(format!(
+                "  - {name}: 선언한 '{field}' 가 스윕 봉투 어디에도 없습니다 (실물 키: {keys:?})"
+            ));
+        }
+    }
+    assert!(
+        problems.is_empty(),
+        "자기서술이 광고하는 필드가 실물에 없는 것 {}건:\n{}\n\n\
+         capabilities 선언을 실물에 맞추거나, 레시피가 그 필드를 실제로 내게 하거나, \
+         조건부라면 CONDITIONAL_RECORD_FIELDS 에 사유와 함께 적으세요.",
+        problems.len(),
+        problems.join("\n"),
+    );
 }

--- a/tests/redact_sanitize_contract.rs
+++ b/tests/redact_sanitize_contract.rs
@@ -719,3 +719,79 @@ fn capabilities_and_mcp_declare_both_commands() {
         assert!(help.contains(line), "--help 에 '{line}' 이 없습니다");
     }
 }
+
+/// [#3885] 봉투 출처 표지 — `findings[].raw` 는 문서에서 그대로 나온 개인정보라
+/// untrusted 로 표지돼야 하고, `--no-raw` 면 그 경로가 봉투에 없으니 표지에서도
+/// 빠져야 한다(실재 경로 필터). 표지가 없으면 가장 민감한 값을 실은 봉투가
+/// "출처 판정 안 함"으로 나간다 — S1 계약이 정확히 그 지점에서 무너진다.
+#[test]
+fn redact_envelope_marks_document_values_as_untrusted() {
+    let Some(doc) = make_pii_document("provmark.hwp") else {
+        return;
+    };
+    let p = doc.to_str().expect("경로 UTF-8");
+
+    let args = ["edit", "redact", p, "--dry-run", "--json"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    let v = json_of(&args, &out);
+    assert_eq!(
+        v["untrustedContent"],
+        serde_json::Value::Bool(true),
+        "raw 원문을 싣는 봉투인데 untrustedContent 가 true 가 아닙니다: {v}"
+    );
+    let fields: Vec<&str> = v["untrustedFields"]
+        .as_array()
+        .expect("untrustedFields")
+        .iter()
+        .filter_map(|x| x.as_str())
+        .collect();
+    assert!(fields.contains(&"findings[].raw"), "{v}");
+    assert!(fields.contains(&"findings[].masked"), "{v}");
+
+    let args = ["edit", "redact", p, "--dry-run", "--json", "--no-raw"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    let v = json_of(&args, &out);
+    assert_eq!(v["untrustedContent"], serde_json::Value::Bool(true), "{v}");
+    let fields: Vec<&str> = v["untrustedFields"]
+        .as_array()
+        .expect("untrustedFields")
+        .iter()
+        .filter_map(|x| x.as_str())
+        .collect();
+    assert!(
+        !fields.contains(&"findings[].raw"),
+        "--no-raw 로 raw 가 봉투에 없는데 표지가 그 경로를 주장합니다: {v}"
+    );
+    assert!(fields.contains(&"findings[].masked"), "{v}");
+}
+
+/// [#3885] sanitize 봉투 — `removed[].before` 는 지워진 문서 속성 원문(제목·작성자,
+/// 그리고 본문 첫 화면 발췌인 preview.text)이라 untrusted 로 표지돼야 한다.
+#[test]
+fn sanitize_envelope_marks_removed_before_as_untrusted() {
+    let Some(doc) = make_pii_document("provmark-san.hwp") else {
+        return;
+    };
+    let p = doc.to_str().expect("경로 UTF-8");
+    let outp = scratch("provmark-sanitized.hwp");
+    let o = outp.to_str().expect("경로 UTF-8");
+
+    let args = ["edit", "sanitize", p, "-o", o, "--json"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(0), "{}", describe(&args, &out));
+    let v = json_of(&args, &out);
+    assert!(
+        v["removedCount"].as_u64().unwrap_or(0) > 0,
+        "제거된 속성이 없으면 이 검사는 공허합니다: {v}"
+    );
+    assert_eq!(v["untrustedContent"], serde_json::Value::Bool(true), "{v}");
+    let fields: Vec<&str> = v["untrustedFields"]
+        .as_array()
+        .expect("untrustedFields")
+        .iter()
+        .filter_map(|x| x.as_str())
+        .collect();
+    assert!(fields.contains(&"removed[].before"), "{v}");
+}


### PR DESCRIPTION
#3885 를 닫습니다 — 표지가 빠졌던 봉투를 전부 채우고, **가드가 이들을 못 잡은 경로 자체를 4중으로 막았습니다.** 이슈가 "가드의 범위가 좁은 것이라면 가드부터 넓히는 게 순서"라고 지목한 그대로입니다.

## ① 표지 수정 — 4건 + 1건 (실측·코드로 재확정)

| 명령 | 봉투가 담는 문서 파생 값 | 처리 |
|---|---|---|
| `edit redact` | **`findings[].raw` — 개인정보 원문** | `marked("edit")` + 지도에 `findings[].raw`·`findings[].masked` 선언 |
| `edit sanitize` | `removed[].before` — 속성 원문(제목·작성자, `preview.text` 는 본문 발췌) | `marked("edit")` + 지도에 `removed[].before` 선언 |
| `edit insert-image` | (문서 파생 값 없음) | `marked("edit")` — **이슈의 미확정 2건 중 확정된 쪽** (방출부에 marked 호출이 없음을 코드로 확인) |
| `export-ir-schema` | (문서를 열지 않음) | 봉투·`-o` 보고 둘 다 `marked` — `false` 명시 |
| `export-capabilities-schema` | (동일) | 동일 |

미확정 2건의 다른 쪽 **`run` 은 반박**입니다 — 현행 devel 은 `run_plan_engine` 의 모든 반환 경로가 `marked("run")` 이고, 실측으로도 성공·무효(`invalid[]`)·입력 오류(`error`) 봉투 전부에 표지가 실립니다. `--no-raw`(#3841) 상호작용도 고정했습니다: raw 가 봉투에 없으면 표지에서도 빠집니다(실재 경로 필터, `redact_sanitize_contract` 양방향 테스트).

지도 선언이 하중을 받는 부분입니다 — **선언 없이 `marked` 만 감싸면 raw 를 실은 봉투가 `untrustedContent:false` 로 거짓말**을 하게 됩니다(표지 부재보다 나쁨).

## ② 가드가 왜 못 잡았나 → 각각 막음

1. **스윕 봉투 덮어쓰기** — `envelopes.insert` 가 같은 명령의 앞 레시피 결과를 대체해, 하위 명령이 여럿인 `edit` 는 마지막 하나(set-cell)만 검사됐다 → 누적(`entry().or_default().extend`)으로 교정하고 redact·sanitize·insert-image 레시피를 추가.
2. **표지 존재 무검사** — 오라클 매치가 "발견된" 봉투만 검사해, 표지 키 자체가 없는 봉투는 어느 단언에도 안 걸렸다 → 모든 스윕 봉투에 존재 의무 단언.
3. **면제 = 전면 면제** — `SWEEP_EXEMPT` 는 "오라클을 만들 수 없다"는 뜻인데 표지 검사까지 같이 면제됐다(스키마 봉투 2종이 빠져나간 경로) → 면제 명령 전부를 실호출하는 존재검사 표 신설. **표의 완전성은 기계 대조** — 새 면제가 표를 빠뜨리면 그 자리에서 패닉.
4. **[#3880 T1] `recordFields` 전수 대조 신설** — 선언한 필드가 실물 봉투에 나타나는지. 파이썬 바인딩의 대표 4개 검사(`test_declared_fields_actually_appear`)를 본체 전수로 승격. **도입 즉시 7개 명령 28건 괴리를 발굴**했고, 전부 허용목록 없이 "그 필드를 실제로 내는 호출" 레시피 10종으로 회수했습니다: `digest --sections` · `inspect hidden-text`/`injection`(edit 와 같은 하위 명령 사각) · `run` 무효 계획(실패 봉투도 스윕에 편입) · `table-to-csv -o` · `csv-to-table -o --verify` · `fill-fields --verify` · `replace-text` · `batch` 오류 레코드 · `batch fill`.

부수 판정 1건: 새로 스윕에 들어온 fill 봉투의 `filled[].name` 은 **호출자 키 반향**입니다(기존 `edit` 지도 note 의 판정과 동일 — 채움이 성공한 이름은 문서 누름틀 이름과 같아질 수밖에 없음). `CALLER_ECHO` 에 **전체 경로 매칭**으로 등재했습니다 — 잎(`name`)으로 넓히면 문서 파생인 `fields[].name` 탐지까지 꺼져 가드가 약해지기 때문입니다.

## 이슈에 열어 두는 판단

`findings[].raw` 의 **추가 민감도 신호**(표지와 별개의 "로그에 남기지 마라") 설계는 이슈의 판단 지점 그대로 열어 둡니다 — 이 PR 은 기계적으로 옳은 선언(문서 파생 = untrusted)까지만 합니다.

## 검증 (로컬, release-test)

- GREEN: `provenance_contract` 9/9 · `redact_sanitize_contract` 15/15
- RED(src 만 devel 원복, 테스트는 이 PR 판): `provenance_contract` **5/4 실패** — 실패 4종이 정확히 설계한 그물입니다: 신설 2종(`sweep_exempt_envelopes_still_carry_provenance_marks` · `every_text_bearing_…`의 존재 단언)과 **기존 가드 2종**(`every_json_envelope_carries_the_flag` · `untrusted_flag_matches_map`)이 실패하는데, 후자는 **레시피 추가만으로** 물기 시작한 것입니다 — "가드 자체가 아니라 가드가 보는 범위가 좁았다"는 이슈 진단의 실증
- `cargo check` · `rustfmt` diff 0 · 대상 clippy 경고 0
- 전체 스위트는 CI 로 부탁드립니다

## #3808 과의 접합 — 선등재로 무수정 통과

열린 #3808 이 `SWEEP_EXEMPT` 에 `export-plan-schema` 를 추가하는데, 면제 존재검사의 완전성 대조는 표에 없는 면제를 패닉으로 알리도록 설계했습니다. 그래서 호출표에 그 명령을 **선등재**해 뒀습니다 — 표는 `SWEEP_EXEMPT` 기준으로만 순회하므로 초과 항목은 미사용으로 잠들어 있다가, #3808 이 머지되는 순간 자동으로 검사에 편입됩니다. **어느 쪽이 먼저 머지돼도 후속 수정이 없습니다.** 세 열린 PR(#3808·#3897·이 PR)의 누적 머지 트리에서 `provenance_contract` 통과를 실측으로 확인했습니다(선등재 전에는 정확히 그 완전성 패닉 1건이 났고, 선등재 후 0건 — 대조군까지 확인).

Closes #3885

🤖 Generated with [Claude Code](https://claude.com/claude-code)
