### PR TITLE
fix(cli): dump·diag·bench 가 미지 플래그를 조용히 무시한다 (#3884 G1·G2)

### DIFF
--- a/mydocs/report/task_m100_3884_report.md
+++ b/mydocs/report/task_m100_3884_report.md
@@ -1,0 +1,58 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_3884_report.md
+last_verified: 2026-08-04
+---
+
+# #3884 처리 기록 — 진단 명령이 미지 플래그를 조용히 무시한다 (G1·G2)
+
+- Issue: [#3884](https://github.com/edwardkim/rhwp/issues/3884) — [#3880 L1] 봉투 규약 위반
+- 브랜치 `task/3884-unknown-flag-rejection`
+
+## 증상
+
+이슈가 실측으로 등록한 위반이다. devel 에서 코드로 재확인했다.
+
+| 명령 | 종전 동작 | 어긴 규약 |
+|---|---|---|
+| `dump <문서> --bogus-flag` | exit 0, stdout 18,643 B | #3349 — 미지 플래그 즉시 exit 2 |
+| `dump <문서> --json` | exit 0, 사람용 텍스트 | 같음 (`--json` 도 미지 플래그로 취급됨) |
+| `diag <문서> --json` | exit 0, 사람용 텍스트 | 같음 |
+| `bench <문서> --json` | exit 1, stdout 518 B | `jsonContract.failure` — 실패 시 stdout 0바이트 |
+
+## 근인 — 세 곳이 서로 다른 방식으로 삼켰다
+
+- `dump_controls` (`src/main.rs`) — 인자 루프의 `_ => { i += 1; }` 가 미지 인자를 **건너뛴다**.
+- `diag_document` (`src/main.rs`) — 플래그를 **아예 파싱하지 않고** `args[0]` 만 쓴다.
+  뒤에 뭘 붙이든 통째로 무시된다.
+- `bench::run` (`src/diagnostics/bench.rs`) — `other => files.push(...)` 로 미지 인자를
+  **파일 경로로 삼킨다.**
+
+`bench` 가 G1(실패 경로 stdout 유출)까지 어긴 것은 이 삼킴의 결과다. `--json` 이 "파일"이
+되어 읽기에 실패하는데, 그 시점엔 이미 헤더 두 줄을 stdout 에 찍은 뒤다.
+
+조용히 무시하는 쪽이 오류보다 나쁘다. 오류라면 호출자가 고칠 수 있지만, 성공으로 돌아오면
+**자기가 요청한 것과 다른 것을 받고도 알 수 없다.** `--json` 을 준 에이전트가 사람용 텍스트를
+JSON 으로 파싱하다 깨지는 경로가 정확히 이것이다.
+
+## 수정
+
+세 곳 모두 #3349 규약대로 **`-` 로 시작하는 미지 인자를 즉시 거부**한다(exit 2, stdout 비움,
+사유는 stderr).
+
+`-` 로 시작하지 않는 인자는 종전 취급을 유지한다 — `bench` 의 파일 목록처럼 위치 인자를
+여럿 받는 명령이 있어서, 모든 미지 인자를 거부하면 정상 호출이 깨진다.
+
+`--json` 을 이 세 명령에 **구현하지는 않았다.** 이슈가 지적한 것은 "선언과 실행이 어긋난다"가
+아니라 "조용히 무시한다"이고, JSON 봉투를 새로 만드는 것은 별도 계약 설계다. 지금은 명확한
+거부로 어긋남을 없앤다.
+
+## 검증
+
+- `tests/issue_3884_unknown_flag_rejection.rs` — 네 조합(`dump --bogus-flag`,
+  `dump --json`, `diag --json`, `bench --json`)이 exit 2 · stdout 0바이트 · stderr 비어 있지
+  않음을 고정한다. 반대 방향으로 정상 호출(`dump`, `dump --section 0`, `diag`)이 그대로
+  성공하는지도 함께 본다 — 거부 규칙이 멀쩡한 호출을 깨면 안 된다.
+- `rustfmt` 로 변경 파일 포맷 확인.
+- 이 PC 는 MSVC 링커(`dbghelp.lib`) 손상으로 `cargo test` 가 돌지 않는다. CI 가 판정한다.

--- a/src/diagnostics/bench.rs
+++ b/src/diagnostics/bench.rs
@@ -68,6 +68,17 @@ pub fn run(args: &[String]) -> i32 {
                 i += 1;
                 tsv = args.get(i).cloned();
             }
+            // [#3884 G2] 종전엔 미지 인자를 전부 파일 경로로 삼켰다. 그래서
+            // `bench <문서> --json` 이 "--json 이라는 파일" 을 읽으려다 실패해 exit 1 로
+            // 끝났고, 그 전에 이미 헤더를 stdout 에 찍은 뒤였다 — 실패 경로에서 stdout 을
+            // 흘리지 않는다는 규약(G1)까지 함께 깨진다. #3349 규약대로 즉시 거부한다.
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!(
+                    "사용법: rhwp bench <파일...> | --batch <폴더> [-n 반복수] [--tsv 출력.tsv]"
+                );
+                return super::EXIT_USAGE;
+            }
             other => files.push(other.to_string()),
         }
         i += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9019,6 +9019,17 @@ fn dump_controls(args: &[String]) -> i32 {
                     i += 1;
                 }
             }
+            // [#3884 G2] 종전엔 미지 인자를 조용히 건너뛰어 `dump <문서> --bogus-flag` 가
+            // exit 0 으로 끝났다. 오타를 성공으로 돌려주면 호출자는 자기가 요청한 것과
+            // 다른 것을 받고도 알 수 없다. `--json` 도 같은 취급이라 JSON 을 기대한
+            // 에이전트가 사람용 텍스트를 파싱하다 깨진다. #3349 규약대로 즉시 거부한다.
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!(
+                    "사용법: rhwp dump <파일.hwp|파일.hwpx|파일.hml> [--section <번호>] [--para <번호>]"
+                );
+                return EXIT_USAGE;
+            }
             _ => {
                 i += 1;
             }
@@ -10539,6 +10550,15 @@ fn diag_document(args: &[String]) -> i32 {
     }
 
     let file_path = &args[0];
+    // [#3884 G2] diag 는 플래그를 아예 파싱하지 않아 뒤에 붙은 인자를 통째로 무시했다.
+    // `diag <문서> --json` 이 exit 0 으로 사람용 텍스트를 내면, JSON 을 기대한 호출자는
+    // 요청이 먹혔다고 믿은 채 파싱에서 깨진다. #3349 규약대로 즉시 거부한다.
+    if let Some(other) = args[1..].iter().find(|a| a.starts_with('-')) {
+        eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+        eprintln!("사용법: rhwp diag <파일.hwp>");
+        return EXIT_USAGE;
+    }
+
     let data = match fs::read(file_path) {
         Ok(d) => d,
         Err(e) => {

--- a/tests/issue_3884_unknown_flag_rejection.rs
+++ b/tests/issue_3884_unknown_flag_rejection.rs
@@ -1,0 +1,97 @@
+//! [#3884 G1·G2] 진단 명령이 미지 플래그를 조용히 무시하던 회귀.
+//!
+//! `capabilities.jsonContract.failure` 는 **"단건 실패 시 stdout 0바이트"** 를 선언하고,
+//! #3349 인자 규약은 **미지 플래그 즉시 exit 2** 를 선언한다. 세 명령이 둘 다 어겼다.
+//!
+//! | 종전 실측 | exit | stdout |
+//! |---|---:|---:|
+//! | `dump <문서> --bogus-flag` | 0 | 18,643 B — 오타를 성공으로 |
+//! | `dump <문서> --json` | 0 | 사람용 텍스트 — `--json` 침묵 무시 |
+//! | `bench <문서> --json` | 1 | 518 B — 실패인데 stdout 이 비지 않음 |
+//!
+//! 조용히 무시하는 쪽이 왜 더 나쁜가: 오류라면 호출자가 고칠 수 있지만, 성공으로
+//! 돌아오면 **자기가 요청한 것과 다른 것을 받고도 알 수 없다.** `--json` 을 준
+//! 에이전트가 사람용 텍스트를 JSON 으로 파싱하다 깨지는 경로가 정확히 이것이다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const SAMPLE: &str = "samples/hwp3-sample.hwp";
+
+fn sample() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+/// 미지 플래그는 exit 2 로 거부하고 stdout 은 비운다.
+#[test]
+fn unknown_flags_are_rejected_with_usage_exit_and_empty_stdout() {
+    let doc = sample();
+    if !doc.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let p = doc.to_string_lossy().to_string();
+
+    for (label, args) in [
+        ("dump --bogus-flag", vec!["dump", &p, "--bogus-flag"]),
+        ("dump --json", vec!["dump", &p, "--json"]),
+        ("diag --json", vec!["diag", &p, "--json"]),
+        ("bench --json", vec!["bench", &p, "--json"]),
+    ] {
+        let out = run(&args);
+        assert_eq!(
+            out.status.code(),
+            Some(2),
+            "{label}: 미지 플래그는 usage 오류(2)여야 합니다 — 조용히 성공하면 호출자가 \
+             요청과 다른 결과를 받고도 알 수 없습니다. stderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            out.stdout.is_empty(),
+            "{label}: 실패 경로에서 stdout 이 {}바이트 나왔습니다 — 반쪽 출력은 소비자가 \
+             파싱하다 죽거나 더 나쁘게는 잘린 값을 참으로 읽게 합니다",
+            out.stdout.len()
+        );
+        assert!(
+            !out.stderr.is_empty(),
+            "{label}: 거부했으면 이유를 stderr 로 알려야 합니다"
+        );
+    }
+}
+
+/// 정상 경로는 그대로여야 한다 — 거부 규칙이 멀쩡한 호출을 깨면 안 된다.
+#[test]
+fn valid_invocations_still_succeed() {
+    let doc = sample();
+    if !doc.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let p = doc.to_string_lossy().to_string();
+
+    for (label, args) in [
+        ("dump", vec!["dump", &p]),
+        ("dump --section 0", vec!["dump", &p, "--section", "0"]),
+        ("diag", vec!["diag", &p]),
+    ] {
+        let out = run(&args);
+        assert_eq!(
+            out.status.code(),
+            Some(0),
+            "{label}: 정상 호출이 깨졌습니다. stderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            !out.stdout.is_empty(),
+            "{label}: 정상 호출인데 출력이 없습니다"
+        );
+    }
+}


### PR DESCRIPTION
Issue: #3884 (G1·G2)
처리 기록: `mydocs/report/task_m100_3884_report.md`

## 재확인

이슈가 실측으로 등록한 위반을 devel 코드에서 재확인했습니다.

| 명령 | 종전 동작 | 어긴 규약 |
|---|---|---|
| `dump <문서> --bogus-flag` | exit 0, stdout 18,643 B | #3349 — 미지 플래그 즉시 exit 2 |
| `dump <문서> --json` | exit 0, 사람용 텍스트 | 같음 |
| `diag <문서> --json` | exit 0, 사람용 텍스트 | 같음 |
| `bench <문서> --json` | exit 1, stdout 518 B | `jsonContract.failure` — 실패 시 stdout 0바이트 |

## 근인 — 세 곳이 서로 다른 방식으로 삼켰다

- **`dump_controls`** — 인자 루프의 `_ => { i += 1; }` 가 미지 인자를 **건너뛴다**.
- **`diag_document`** — 플래그를 **아예 파싱하지 않고** `args[0]` 만 쓴다. 뒤에 뭘 붙이든 무시된다.
- **`bench::run`** — `other => files.push(..)` 로 미지 인자를 **파일 경로로 삼킨다**.

`bench` 가 G1(실패 경로 stdout 유출)까지 어긴 것은 이 삼킴의 **결과**입니다. `--json` 이 "파일"이 되어 읽기에 실패하는데, 그 시점엔 이미 헤더를 stdout 에 찍은 뒤입니다. G1 과 G2 가 별개가 아니라 하나의 근인이었습니다.

조용히 무시하는 쪽이 오류보다 나쁩니다. 오류라면 호출자가 고칠 수 있지만, **성공으로 돌아오면 자기가 요청한 것과 다른 것을 받고도 알 수 없습니다.** `--json` 을 준 에이전트가 사람용 텍스트를 파싱하다 깨지는 경로가 정확히 이것입니다.

## 수정

세 곳 모두 #3349 규약대로 **`-` 로 시작하는 미지 인자를 즉시 거부**합니다 (exit 2, stdout 비움, 사유는 stderr).

`-` 로 시작하지 않는 인자는 종전 취급을 유지했습니다 — `bench` 의 파일 목록처럼 위치 인자를 여럿 받는 명령이 있어, 모든 미지 인자를 거부하면 정상 호출이 깨집니다.

**`--json` 을 이 세 명령에 구현하지는 않았습니다.** 이슈가 지적한 것은 "조용히 무시한다"이고, JSON 봉투 신설은 별도 계약 설계입니다. 지금은 명확한 거부로 어긋남만 없앱니다.

## 검증

`tests/issue_3884_unknown_flag_rejection.rs` — 네 조합이 **exit 2 · stdout 0바이트 · stderr 비어 있지 않음**을 고정합니다. 반대 방향으로 정상 호출(`dump`, `dump --section 0`, `diag`)이 그대로 성공하는지도 함께 봅니다 — 거부 규칙이 멀쩡한 호출을 깨면 안 되기 때문입니다.

이 PC 는 MSVC 링커(`dbghelp.lib`) 손상으로 `cargo test` 가 돌지 않아 CI 가 판정합니다.
