### PR TITLE
docs: kevin9327 PR 검토 기록 보존

### DIFF
--- a/mydocs/orders/20260804.md
+++ b/mydocs/orders/20260804.md
@@ -1,0 +1,23 @@
+# 오늘 할 일 - 2026년 8월 4일
+
+## kevin9327 열린 PR 9건 누적 검토
+
+- 최신 `upstream/devel` `f5a458e9c` 위 가시성 브랜치
+  `review/kevin9327-20260804`에 #3808, #3903, #3899, #3897, #3887, #3886, #3889,
+  #3898, #3908 원 head를 충돌 없이 누적했다. 원 contributor 브랜치에는 push하지
+  않았다.
+- 로컬 검증은 완료됐다. `cargo fmt --check`, clippy, focused contract 96건,
+  `cargo test --profile release-test --tests`, diff check, Markdown 링크 검사를 모두
+  통과했다. release-test의 장기 `overflow_cell_baseline`(294.20초)과
+  `security_corpus_regression`(189.37초)도 포함한다.
+- 로컬 검증을 수용 판단의 기준으로 사용한다. GitHub Actions는 원격 실행 관찰용이며,
+  이미 끝난 로컬 검증을 다시 입증하는 수용 조건으로 삼지 않는다.
+- #3808, #3903, #3899, #3897, #3886, #3898은 로컬 수용으로 기록했다. 각 원 PR의
+  `BEHIND` 표시는 원격 병합 조정 정보일 뿐 로컬 검증 재실행 사유가 아니다.
+- #3887은 새 preflight가 `gen-pua`, `gen-table`, `measure-width`, `test-caption`,
+  `test-field`, `test-shape`의 미지 플래그 exit 0 무시를 검출해 재작업이 필요하다.
+- #3889는 active 가이드의 표면 수치(61/31/148/39/51)가 실제 후보
+  (64/34/159/43/55)와 달라 재실측·수정이 필요하다. #3908은 열린 PR을 `[완료]`로
+  표기해 자체 상태 규칙과 충돌하므로 완료 상태를 수정해야 한다.
+- 검토 기록은 [누적 기록](../pr/archives/pr_3808_review_impl.md)과 PR별 archive 문서에
+  보존했다. 이 문서와 archive 기록만 담는 문서 전용 PR을 생성한다.

--- a/mydocs/pr/archives/pr_3808_review.md
+++ b/mydocs/pr/archives/pr_3808_review.md
@@ -1,0 +1,24 @@
+---
+kind: review
+status: accepted-local
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-04
+---
+
+# PR #3808 검토 - 계획 스키마와 조건부 step
+
+- 원 head: `e21240f08dc0576ee5a2d9db20a09bc567fceb26`
+- 범위: `export-plan-schema`, 조건부 step 실행, MCP/manifest/provenance 접합, 계약 테스트.
+- 시각 검증: 불필요. 렌더러·레이아웃·fixture를 변경하지 않는다.
+
+## 결과
+
+`plan_schema_contract` 25건과 누적 focused contract, 전체 release-test, fmt, clippy가
+통과했다. 스키마의 action·condition 선언과 실행기, MCP 응답, journal의 skipped step을
+계약으로 대조하는 구성이 적절하다. 별도 구현 결함은 찾지 못했다.
+
+## 후속 기록
+
+수용 판단은 완료된 로컬 검증을 기준으로 한다. `BEHIND` 표시는 원격 병합 조정
+정보일 뿐 재검증 조건이 아니다. 관련 active 문서(#3889·#3908)의 표면 수치는 별도
+재작업으로 정정한다. 누적 기록은 `pr_3808_review_impl.md`를 따른다.

--- a/mydocs/pr/archives/pr_3808_review_impl.md
+++ b/mydocs/pr/archives/pr_3808_review_impl.md
@@ -1,0 +1,56 @@
+---
+kind: review_plan
+status: local-validation-complete
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-04
+---
+
+# kevin9327 열린 PR 9건 누적 검토 기록
+
+기준은 `upstream/devel`의 `f5a458e9c437c0f3d374ca3159a573290f19967c`다.
+외부 기여자 PR 검토 절차에 따라 기본 작업트리에서
+`review/kevin9327-20260804`를 만들고, Git Graph에서 `devel` 위 적용 상태가 보이도록
+원본 head를 누적 체리픽했다. 원 PR 브랜치에는 push하지 않았다.
+
+| 순서 | PR | 원 head | 검토 브랜치 commit | 충돌 |
+| --- | --- | --- | --- | --- |
+| 1 | #3808 | `e21240f08` | `24ea3d9f4`~`23860e951` | 없음 |
+| 2 | #3903 | `0972b386e9` | `e9b6e997d`~`0418d579b` | 없음 |
+| 3 | #3899 | `2162212987` | `5708e2e3c` | 없음 |
+| 4 | #3897 | `0c057605f1` | `48cbd0458` | 없음 |
+| 5 | #3887 | `c5cfba6cda` | `b49b626c1` | 없음 |
+| 6 | #3886 | `de6aeb895e` | `31d7600aa`~`9e650d0c9` | 없음 |
+| 7 | #3889 | `a8f9b2cb29` | `44546e472` | 없음 |
+| 8 | #3898 | `4c99429397` | `0b1bad548` | 없음 |
+| 9 | #3908 | `215fca1bb8` | `9d707d56f` | 없음 |
+
+## 공통 검증
+
+- `git diff --check upstream/devel...HEAD`: 통과.
+- `cargo fmt --check`: 통과.
+- `cargo clippy --all-targets -- -D warnings`: 통과.
+- focused contract 96건: 통과.
+- `cargo test --profile release-test --tests`: 통과. 장기 회귀
+  `overflow_cell_baseline`은 294.20초, `security_corpus_regression`은 189.37초를 포함해
+  마지막 `visual_roundtrip_baseline`까지 실패 없이 완료했다.
+- 변경 Markdown 링크 검사: 498개 문서, 내부 상대 링크 이상 없음.
+- 전체 문서 메타데이터 검사는 `upstream/devel`에도 있는 두 기존 문서의 front matter
+  오류 3건으로 실패했다. 이번 9개 PR이 추가·수정한 문서는 원인이 아니며, 신규 문서의
+  front matter와 canonical 경로는 개별 확인했다.
+
+## 누적 후보 재작업 사항
+
+1. #3887의 `tools/agent_preflight.py --bin <release-test/rhwp>`가 실패한다. `gen-pua`,
+   `gen-table`, `measure-width`, `test-caption`, `test-field`, `test-shape`가 미지 플래그를
+   exit 0으로 무시한다. 새 검사가 문제를 발견했지만 후보 자체가 green이 아니므로
+   명령별 거부 계약 또는 명시적 제외 부류와 테스트가 필요하다.
+2. #3889는 active 가이드에 현행 수치를 고정했지만, 누적 후보의 실제 자기서술은
+   CLI 64개, JSON 계약 34개, `recordFields` 159개, MCP 선언 43개, `tools/list` 55개다.
+   문서의 61·31·148·39·51과 다르며, #3903가 보완한 출처 표지 누락 6종도 현행 예외로
+   적혀 있다.
+3. #3908은 자체 운영 규칙과 달리 아직 열린 #3808과 #3898을 `[완료]`로 표시한다.
+   활성 canonical 로드맵의 완료 표기는 merge 상태와 함께 갱신돼야 한다.
+
+모든 원 PR은 검토 시점에 `BEHIND`였다. 이는 원격 병합 조정 상태일 뿐 로컬 검증의
+유효성을 취소하지 않는다. 수용 판단은 위에서 완료한 로컬 검증으로 고정한다. #3887,
+#3889, #3908만 명시된 실제 결함을 보정해 다시 로컬 검증한다.

--- a/mydocs/pr/archives/pr_3886_review.md
+++ b/mydocs/pr/archives/pr_3886_review.md
@@ -1,0 +1,27 @@
+---
+kind: review
+status: accepted-local
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-04
+---
+
+# PR #3886 검토 - 에이전트 아키텍처 문서 축
+
+- 원 head: `de6aeb895e621b4f7bb824fb62e0840a0cfdaef3`
+- 범위: `mydocs/tech/agent_architecture/` 6편과 기술 문서 지도 연결.
+- 예외 절차: 4,604줄 문서 대형 PR로 `rework_and_exceptions` 절차를 적용했다.
+- 시각 검증: 불필요. 문서 전용 변경이다.
+
+## 결과
+
+신규 문서의 front matter·canonical 경로를 확인했고, 변경 Markdown 상대 링크 검사는
+통과했다. `git diff --check`도 통과했다. 전체 메타데이터 검사는 이번 변경과 무관한
+기존 `mydocs/tech` 문서 두 개의 오류 3건 때문에 실패했다.
+
+문서는 열린 PR과 미확인 항목을 구분해 기록하며, 구현 완료를 사실로 바꾸지 않는다.
+별도 문서 구조 결함은 찾지 못했다.
+
+## 후속 기록
+
+수용 판단은 완료된 링크·형식 로컬 검증을 기준으로 한다. #3889·#3908의 active
+문서 수치·완료 상태는 이 PR과 별개의 실제 문서 결함으로 재작업한다.

--- a/mydocs/pr/archives/pr_3887_review.md
+++ b/mydocs/pr/archives/pr_3887_review.md
@@ -1,0 +1,30 @@
+---
+kind: review
+status: rework-required
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-04
+---
+
+# PR #3887 검토 - preflight 검사 범위 확대
+
+- 원 head: `c5cfba6cda5754e477ddda55367f2b7e31b50f9b`
+- 범위: `tools/agent_preflight.py`의 실패 경로·선언 밖 명령 검사 확대.
+- 시각 검증: 불필요. 개발 도구만 변경한다.
+
+## 차단 사항
+
+`python3 tools/agent_preflight.py --bin target/review-kevin9327-20260804/release-test/rhwp`
+가 실패했다. 새 `check_undeclared_commands_are_not_invisible`가 아래 명령이
+`--rhwp-preflight-bogus-flag`를 exit 0으로 무시한다고 보고한다.
+
+`gen-pua`, `gen-table`, `measure-width`, `test-caption`, `test-field`, `test-shape`
+
+검사는 `tools/agent_preflight.py:622`~`665`에서 새로 추가됐고, 이 명령들은
+`src/main.rs:326`~`335`, `2280`, `2311`~`2315`에서 dispatch·capabilities에 존재한다.
+즉 새 가드가 실제 결함을 발견했으나, PR 자체는 green이 아니다.
+
+## 요청 사항
+
+각 명령이 미지 옵션을 exit 2와 빈 stdout으로 거부하게 하거나, 자기서술 밖 명령의
+명시적 부류·제외 사유·회귀 테스트를 정의해야 한다. 보정 뒤 실제 release binary에
+preflight를 실행해 통과시키는 로컬 검증이 필요하다.

--- a/mydocs/pr/archives/pr_3889_review.md
+++ b/mydocs/pr/archives/pr_3889_review.md
@@ -1,0 +1,37 @@
+---
+kind: review
+status: rework-required
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-04
+---
+
+# PR #3889 검토 - 에이전트 가이드 실측 수치
+
+- 원 head: `a8f9b2cb29cdd067995f06b333823c91fdcb0f63`
+- 범위: agent knowledge map·surface/task/troubleshooting guide 4편 대폭 확충.
+- 예외 절차: 4,141줄 문서 대형 PR로 `rework_and_exceptions` 절차를 적용했다.
+- 시각 검증: 불필요. 문서 전용 변경이다.
+
+## 차단 사항
+
+active 가이드가 현행 실측이라고 적은 수치가 누적 release-test binary의 실제
+`capabilities`·MCP 응답과 다르다.
+
+| 항목 | 문서 | 실제 |
+| --- | ---: | ---: |
+| CLI 명령 | 61 | 64 |
+| JSON 계약 명령 | 31 | 34 |
+| `recordFields` 합집합 | 148 | 159 |
+| `capabilities --mcp` 도구 | 39 | 43 |
+| MCP `tools/list` 도구 | 51 | 55 |
+
+또한 `agent_knowledge_map.md`는 #3903가 보완한 `edit redact`·`edit sanitize`·schema
+봉투 등의 출처 표지 누락 6종을 현행 예외로 서술한다. 이 상태로 active canonical
+가이드를 병합하면 사용자가 이미 보정된 동작을 예외로 오해한다.
+
+## 요청 사항
+
+수용할 관련 변경을 기준으로 실측을 다시 수행해 모든 수치, 전수 표, 출처 표지 예외를
+갱신해야 한다. 과거 기준을 보존할 필요가 있으면 active 가이드가 아니라 날짜·commit이
+명시된 historical snapshot으로 분리한다. 보정 뒤에는 같은 로컬 자기서술 검사를 다시
+실행한다.

--- a/mydocs/pr/archives/pr_3897_review.md
+++ b/mydocs/pr/archives/pr_3897_review.md
@@ -1,0 +1,23 @@
+---
+kind: review
+status: accepted-local
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-04
+---
+
+# PR #3897 검토 - 진단 명령 미지 플래그와 stdout 계약
+
+- 원 head: `0c057605f1ed14e0c68fb10c09ebb22566c6c4fa`
+- 범위: `bench`·`dump`·`diag`의 미지 옵션 거부 및 bench 전건 실패 stdout 처리.
+- 시각 검증: 불필요. CLI 진단 표면만 변경한다.
+
+## 결과
+
+`diagnostics_flag_contract` 11건이 통과했다. 새 분기는 미지 플래그에 exit 2와 빈
+stdout을 보장하고, bench가 성공 행이 없을 때 표와 TSV를 쓰지 않도록 한다. 전체
+release-test도 통과했다. 별도 결함은 찾지 못했다.
+
+## 후속 기록
+
+수용 판단은 완료된 로컬 검증을 기준으로 한다. #3887의 확대 preflight가 아직 다른
+미선언 명령 여섯 개를 잡으므로 그 PR만 실제 결함 보정이 필요하다.

--- a/mydocs/pr/archives/pr_3898_review.md
+++ b/mydocs/pr/archives/pr_3898_review.md
@@ -1,0 +1,24 @@
+---
+kind: review
+status: accepted-local
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-04
+---
+
+# PR #3898 검토 - 개인정보 마스킹 레시피
+
+- 원 head: `4c9942939742f9f8b2dac7e130461cc0bdd4c0b8`
+- 범위: 마스킹 레시피와 문서 지도·LLM 진입점 연결.
+- 시각 검증: 불필요. 문서 전용 변경이다.
+
+## 결과
+
+변경 Markdown 상대 링크 검사와 `git diff --check`가 통과했다. 레시피는
+`redact`→`sanitize`→재검사 순서, `--no-raw` 로그 노출 방지, 출력 경로 명시를
+구체적으로 다룬다. 관련 `redact_sanitize_contract` 15건과 전체 release-test도
+누적 후보에서 통과했다. 별도 결함은 찾지 못했다.
+
+## 후속 기록
+
+수용 판단은 완료된 로컬 검증을 기준으로 한다. #3889의 가이드 수치 보정 시 이
+레시피 링크와 표면 설명도 함께 대조한다.

--- a/mydocs/pr/archives/pr_3899_review.md
+++ b/mydocs/pr/archives/pr_3899_review.md
@@ -1,0 +1,23 @@
+---
+kind: review
+status: accepted-local
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-04
+---
+
+# PR #3899 검토 - stdin BrokenPipe 테스트 헬퍼
+
+- 원 head: `2162212987bc8b34f3c660c9a37705724d19b369`
+- 범위: CLI 계약 테스트 세 곳의 조기 종료 BrokenPipe 처리.
+- 시각 검증: 불필요. 테스트 전용 변경이다.
+
+## 결과
+
+세 헬퍼는 `BrokenPipe`만 정상적인 조기 종료로 허용하고 다른 stdin 오류는 계속
+실패시킨다. 누적 focused contract와 전체 release-test가 통과했으며, 실패 조건을
+완화하는 범위가 필요한 오류 종류로 한정돼 있다. 별도 결함은 찾지 못했다.
+
+## 후속 기록
+
+수용 판단은 완료된 로컬 검증을 기준으로 한다. `BEHIND` 표시는 원격 병합 조정
+정보로만 기록한다.

--- a/mydocs/pr/archives/pr_3903_review.md
+++ b/mydocs/pr/archives/pr_3903_review.md
@@ -1,0 +1,24 @@
+---
+kind: review
+status: accepted-local
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-04
+---
+
+# PR #3903 검토 - 출처 표지 누락 봉투 보완
+
+- 원 head: `0972b386e953198d83c30475b40936a93ed839b7`
+- 범위: schema·redact·sanitize·insert-image 봉투 표지와 provenance sweep 가드.
+- 시각 검증: 불필요. 출력 레이아웃을 변경하지 않는다.
+
+## 결과
+
+`provenance_contract` 9건과 `redact_sanitize_contract` 15건을 포함한 누적 focused
+contract 및 전체 release-test가 통과했다. 특히 `findings[].raw`와
+`removed[].before`를 문서 파생 값으로 선언하고, 실제 봉투 키 존재까지 검증한 점이
+목적에 맞다. 별도 구현 결함은 찾지 못했다.
+
+## 후속 기록
+
+수용 판단은 완료된 로컬 검증을 기준으로 한다. #3889·#3908은 이 변경과 불일치하는
+active 문서이므로 별도 재작업한다.

--- a/mydocs/pr/archives/pr_3908_review.md
+++ b/mydocs/pr/archives/pr_3908_review.md
@@ -1,0 +1,30 @@
+---
+kind: review
+status: rework-required
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-04
+---
+
+# PR #3908 검토 - R1~R100 에이전트 로드맵
+
+- 원 head: `215fca1bb82a199b2f6283cb74cee74c07f4322f`
+- 범위: `mydocs/tech/agent_roadmap/` 11편과 기술 문서 지도 연결.
+- 예외 절차: 1,724줄 문서 대형 PR로 `rework_and_exceptions` 절차를 적용했다.
+- 시각 검증: 불필요. 문서 전용 변경이다.
+
+## 차단 사항
+
+문서 첫머리는 "완료 표기는 머지 링크와 함께만"이라고 정하지만, 아직 열린 PR을
+`[완료]`로 표시한다. 검토 시점에 #3808·#3898은 모두 `BEHIND`인 열린 PR인데,
+`track_d_discovery.md`는 각각 planSchema 접합(R32), 레시피 3(R34)을 완료로 적었다.
+`track_b_guards_security.md`도 열린 #3903의 결과를 "이제" 확정된 상태로 서술한다.
+
+또한 R36은 #3889의 148개 필드 전수 설명을 전제로 하지만, 해당 PR의 active 가이드
+수치는 현재 후보의 실제 159개와 다르다. 이를 그대로 연결하면 로드맵의 DoD가
+실측 대상과 불일치한다.
+
+## 요청 사항
+
+열린 PR은 `[이슈]` 또는 `[문서]`로 표시하고, 실제 merge commit이 생긴 뒤에만
+`[완료]`와 merge 링크로 승격해야 한다. #3889 보정 후 필드 수와 DoD를 재실측하고,
+같은 로컬 자기서술 결과로 다시 검토해야 한다.


### PR DESCRIPTION
## 요약

- kevin9327 열린 PR 9건의 archive 검토 기록과 누적 적용 기록을 보존합니다.
- 오늘할일에 수용 6건과 실제 재작업이 필요한 #3887, #3889, #3908을 분리해 기록합니다.
- 수용 판단은 완료한 로컬 검증을 기준으로 하며, 원격 CI는 그 판단을 다시 입증하는 조건으로 두지 않습니다.

## 로컬 검증

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- focused contract 96건
- `cargo test --profile release-test --tests`
- `git diff --check`
- Markdown 상대 링크 검사 491개 문서

## 범위

`mydocs/orders/20260804.md`와 `mydocs/pr/archives/`의 검토 기록만 변경합니다.
