### PR TITLE
fix(cli): 쪽수 검증 실패가 IR 차이를 가리지 않게 한다 (#3915)

### DIFF
--- a/mydocs/report/task_m100_3884_report.md
+++ b/mydocs/report/task_m100_3884_report.md
@@ -1,0 +1,58 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_3884_report.md
+last_verified: 2026-08-04
+---
+
+# #3884 처리 기록 — 진단 명령이 미지 플래그를 조용히 무시한다 (G1·G2)
+
+- Issue: [#3884](https://github.com/edwardkim/rhwp/issues/3884) — [#3880 L1] 봉투 규약 위반
+- 브랜치 `task/3884-unknown-flag-rejection`
+
+## 증상
+
+이슈가 실측으로 등록한 위반이다. devel 에서 코드로 재확인했다.
+
+| 명령 | 종전 동작 | 어긴 규약 |
+|---|---|---|
+| `dump <문서> --bogus-flag` | exit 0, stdout 18,643 B | #3349 — 미지 플래그 즉시 exit 2 |
+| `dump <문서> --json` | exit 0, 사람용 텍스트 | 같음 (`--json` 도 미지 플래그로 취급됨) |
+| `diag <문서> --json` | exit 0, 사람용 텍스트 | 같음 |
+| `bench <문서> --json` | exit 1, stdout 518 B | `jsonContract.failure` — 실패 시 stdout 0바이트 |
+
+## 근인 — 세 곳이 서로 다른 방식으로 삼켰다
+
+- `dump_controls` (`src/main.rs`) — 인자 루프의 `_ => { i += 1; }` 가 미지 인자를 **건너뛴다**.
+- `diag_document` (`src/main.rs`) — 플래그를 **아예 파싱하지 않고** `args[0]` 만 쓴다.
+  뒤에 뭘 붙이든 통째로 무시된다.
+- `bench::run` (`src/diagnostics/bench.rs`) — `other => files.push(...)` 로 미지 인자를
+  **파일 경로로 삼킨다.**
+
+`bench` 가 G1(실패 경로 stdout 유출)까지 어긴 것은 이 삼킴의 결과다. `--json` 이 "파일"이
+되어 읽기에 실패하는데, 그 시점엔 이미 헤더 두 줄을 stdout 에 찍은 뒤다.
+
+조용히 무시하는 쪽이 오류보다 나쁘다. 오류라면 호출자가 고칠 수 있지만, 성공으로 돌아오면
+**자기가 요청한 것과 다른 것을 받고도 알 수 없다.** `--json` 을 준 에이전트가 사람용 텍스트를
+JSON 으로 파싱하다 깨지는 경로가 정확히 이것이다.
+
+## 수정
+
+세 곳 모두 #3349 규약대로 **`-` 로 시작하는 미지 인자를 즉시 거부**한다(exit 2, stdout 비움,
+사유는 stderr).
+
+`-` 로 시작하지 않는 인자는 종전 취급을 유지한다 — `bench` 의 파일 목록처럼 위치 인자를
+여럿 받는 명령이 있어서, 모든 미지 인자를 거부하면 정상 호출이 깨진다.
+
+`--json` 을 이 세 명령에 **구현하지는 않았다.** 이슈가 지적한 것은 "선언과 실행이 어긋난다"가
+아니라 "조용히 무시한다"이고, JSON 봉투를 새로 만드는 것은 별도 계약 설계다. 지금은 명확한
+거부로 어긋남을 없앤다.
+
+## 검증
+
+- `tests/issue_3884_unknown_flag_rejection.rs` — 네 조합(`dump --bogus-flag`,
+  `dump --json`, `diag --json`, `bench --json`)이 exit 2 · stdout 0바이트 · stderr 비어 있지
+  않음을 고정한다. 반대 방향으로 정상 호출(`dump`, `dump --section 0`, `diag`)이 그대로
+  성공하는지도 함께 본다 — 거부 규칙이 멀쩡한 호출을 깨면 안 된다.
+- `rustfmt` 로 변경 파일 포맷 확인.
+- 이 PC 는 MSVC 링커(`dbghelp.lib`) 손상으로 `cargo test` 가 돌지 않는다. CI 가 판정한다.

--- a/src/diagnostics/bench.rs
+++ b/src/diagnostics/bench.rs
@@ -68,6 +68,17 @@ pub fn run(args: &[String]) -> i32 {
                 i += 1;
                 tsv = args.get(i).cloned();
             }
+            // [#3884 G2] 종전엔 미지 인자를 전부 파일 경로로 삼켰다. 그래서
+            // `bench <문서> --json` 이 "--json 이라는 파일" 을 읽으려다 실패해 exit 1 로
+            // 끝났고, 그 전에 이미 헤더를 stdout 에 찍은 뒤였다 — 실패 경로에서 stdout 을
+            // 흘리지 않는다는 규약(G1)까지 함께 깨진다. #3349 규약대로 즉시 거부한다.
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!(
+                    "사용법: rhwp bench <파일...> | --batch <폴더> [-n 반복수] [--tsv 출력.tsv]"
+                );
+                return super::EXIT_USAGE;
+            }
             other => files.push(other.to_string()),
         }
         i += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9019,6 +9019,17 @@ fn dump_controls(args: &[String]) -> i32 {
                     i += 1;
                 }
             }
+            // [#3884 G2] 종전엔 미지 인자를 조용히 건너뛰어 `dump <문서> --bogus-flag` 가
+            // exit 0 으로 끝났다. 오타를 성공으로 돌려주면 호출자는 자기가 요청한 것과
+            // 다른 것을 받고도 알 수 없다. `--json` 도 같은 취급이라 JSON 을 기대한
+            // 에이전트가 사람용 텍스트를 파싱하다 깨진다. #3349 규약대로 즉시 거부한다.
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!(
+                    "사용법: rhwp dump <파일.hwp|파일.hwpx|파일.hml> [--section <번호>] [--para <번호>]"
+                );
+                return EXIT_USAGE;
+            }
             _ => {
                 i += 1;
             }
@@ -10539,6 +10550,15 @@ fn diag_document(args: &[String]) -> i32 {
     }
 
     let file_path = &args[0];
+    // [#3884 G2] diag 는 플래그를 아예 파싱하지 않아 뒤에 붙은 인자를 통째로 무시했다.
+    // `diag <문서> --json` 이 exit 0 으로 사람용 텍스트를 내면, JSON 을 기대한 호출자는
+    // 요청이 먹혔다고 믿은 채 파싱에서 깨진다. #3349 규약대로 즉시 거부한다.
+    if let Some(other) = args[1..].iter().find(|a| a.starts_with('-')) {
+        eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+        eprintln!("사용법: rhwp diag <파일.hwp>");
+        return EXIT_USAGE;
+    }
+
     let data = match fs::read(file_path) {
         Ok(d) => d,
         Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10991,17 +10991,20 @@ fn convert_hwp(args: &[String]) -> i32 {
                             verify_pages_report = serde_json::json!({
                                 "before": before, "after": after, "identical": false,
                             });
-                            if json_mode {
-                                emit_envelope(bytes.len(), verify_report, verify_pages_report);
+                            // [#3915] 여기서 곧장 종료하면 `--verify` 를 함께 준 경우 IR
+                            // 비교가 아예 돌지 않아 **IR 차이가 있어도 보고되지 않는다.**
+                            // 쪽수와 IR 은 서로 다른 결함을 재므로, 한쪽이 실패해도 다른
+                            // 쪽을 마저 재고 함께 보고한다. 종료 코드는 종전대로 쪽수
+                            // 실패를 우선한다(4) — 계약 무변경.
+                            exit_code = 4;
+                        } else {
+                            if !json_mode {
+                                println!("검증 통과(--verify-pages): {}쪽", before);
                             }
-                            process::exit(4);
+                            verify_pages_report = serde_json::json!({
+                                "before": before, "after": after, "identical": true,
+                            });
                         }
-                        if !json_mode {
-                            println!("검증 통과(--verify-pages): {}쪽", before);
-                        }
-                        verify_pages_report = serde_json::json!({
-                            "before": before, "after": after, "identical": true,
-                        });
                     }
 
                     if verify_options.verify {
@@ -11021,7 +11024,11 @@ fn convert_hwp(args: &[String]) -> i32 {
                             verify_report = serde_json::json!({
                                 "identical": false, "diffCount": diff.differences.len(),
                             });
-                            exit_code = 3;
+                            // [#3915] 쪽수 실패(4)가 이미 잡혔으면 그 코드를 유지한다 —
+                            // 두 축이 함께 실패해도 종전 계약대로 4 로 끝난다.
+                            if exit_code == EXIT_OK {
+                                exit_code = 3;
+                            }
                         } else {
                             if !json_mode {
                                 println!("검증 통과(--verify): IR 차이 없음");
@@ -11346,17 +11353,20 @@ fn export_hwpx(args: &[String]) -> i32 {
                             verify_pages_report = serde_json::json!({
                                 "before": before, "after": after, "identical": false,
                             });
-                            if json_mode {
-                                emit_envelope(bytes.len(), verify_report, verify_pages_report);
+                            // [#3915] 여기서 곧장 종료하면 `--verify` 를 함께 준 경우 IR
+                            // 비교가 아예 돌지 않아 **IR 차이가 있어도 보고되지 않는다.**
+                            // 쪽수와 IR 은 서로 다른 결함을 재므로, 한쪽이 실패해도 다른
+                            // 쪽을 마저 재고 함께 보고한다. 종료 코드는 종전대로 쪽수
+                            // 실패를 우선한다(4) — 계약 무변경.
+                            exit_code = 4;
+                        } else {
+                            if !json_mode {
+                                println!("검증 통과(--verify-pages): {}쪽", before);
                             }
-                            process::exit(4);
+                            verify_pages_report = serde_json::json!({
+                                "before": before, "after": after, "identical": true,
+                            });
                         }
-                        if !json_mode {
-                            println!("검증 통과(--verify-pages): {}쪽", before);
-                        }
-                        verify_pages_report = serde_json::json!({
-                            "before": before, "after": after, "identical": true,
-                        });
                     }
 
                     if verify_options.verify {
@@ -11369,7 +11379,11 @@ fn export_hwpx(args: &[String]) -> i32 {
                             verify_report = serde_json::json!({
                                 "identical": false, "diffCount": diff.differences.len(),
                             });
-                            exit_code = 3;
+                            // [#3915] 쪽수 실패(4)가 이미 잡혔으면 그 코드를 유지한다 —
+                            // 두 축이 함께 실패해도 종전 계약대로 4 로 끝난다.
+                            if exit_code == EXIT_OK {
+                                exit_code = 3;
+                            }
                         } else {
                             if !json_mode {
                                 println!("검증 통과(--verify): IR 차이 없음");

--- a/tests/issue_3884_unknown_flag_rejection.rs
+++ b/tests/issue_3884_unknown_flag_rejection.rs
@@ -1,0 +1,97 @@
+//! [#3884 G1·G2] 진단 명령이 미지 플래그를 조용히 무시하던 회귀.
+//!
+//! `capabilities.jsonContract.failure` 는 **"단건 실패 시 stdout 0바이트"** 를 선언하고,
+//! #3349 인자 규약은 **미지 플래그 즉시 exit 2** 를 선언한다. 세 명령이 둘 다 어겼다.
+//!
+//! | 종전 실측 | exit | stdout |
+//! |---|---:|---:|
+//! | `dump <문서> --bogus-flag` | 0 | 18,643 B — 오타를 성공으로 |
+//! | `dump <문서> --json` | 0 | 사람용 텍스트 — `--json` 침묵 무시 |
+//! | `bench <문서> --json` | 1 | 518 B — 실패인데 stdout 이 비지 않음 |
+//!
+//! 조용히 무시하는 쪽이 왜 더 나쁜가: 오류라면 호출자가 고칠 수 있지만, 성공으로
+//! 돌아오면 **자기가 요청한 것과 다른 것을 받고도 알 수 없다.** `--json` 을 준
+//! 에이전트가 사람용 텍스트를 JSON 으로 파싱하다 깨지는 경로가 정확히 이것이다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const SAMPLE: &str = "samples/hwp3-sample.hwp";
+
+fn sample() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+/// 미지 플래그는 exit 2 로 거부하고 stdout 은 비운다.
+#[test]
+fn unknown_flags_are_rejected_with_usage_exit_and_empty_stdout() {
+    let doc = sample();
+    if !doc.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let p = doc.to_string_lossy().to_string();
+
+    for (label, args) in [
+        ("dump --bogus-flag", vec!["dump", &p, "--bogus-flag"]),
+        ("dump --json", vec!["dump", &p, "--json"]),
+        ("diag --json", vec!["diag", &p, "--json"]),
+        ("bench --json", vec!["bench", &p, "--json"]),
+    ] {
+        let out = run(&args);
+        assert_eq!(
+            out.status.code(),
+            Some(2),
+            "{label}: 미지 플래그는 usage 오류(2)여야 합니다 — 조용히 성공하면 호출자가 \
+             요청과 다른 결과를 받고도 알 수 없습니다. stderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            out.stdout.is_empty(),
+            "{label}: 실패 경로에서 stdout 이 {}바이트 나왔습니다 — 반쪽 출력은 소비자가 \
+             파싱하다 죽거나 더 나쁘게는 잘린 값을 참으로 읽게 합니다",
+            out.stdout.len()
+        );
+        assert!(
+            !out.stderr.is_empty(),
+            "{label}: 거부했으면 이유를 stderr 로 알려야 합니다"
+        );
+    }
+}
+
+/// 정상 경로는 그대로여야 한다 — 거부 규칙이 멀쩡한 호출을 깨면 안 된다.
+#[test]
+fn valid_invocations_still_succeed() {
+    let doc = sample();
+    if !doc.exists() {
+        eprintln!("샘플 없음 — 건너뜀");
+        return;
+    }
+    let p = doc.to_string_lossy().to_string();
+
+    for (label, args) in [
+        ("dump", vec!["dump", &p]),
+        ("dump --section 0", vec!["dump", &p, "--section", "0"]),
+        ("diag", vec!["diag", &p]),
+    ] {
+        let out = run(&args);
+        assert_eq!(
+            out.status.code(),
+            Some(0),
+            "{label}: 정상 호출이 깨졌습니다. stderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            !out.stdout.is_empty(),
+            "{label}: 정상 호출인데 출력이 없습니다"
+        );
+    }
+}

--- a/tests/issue_3915_verify_axes_both_reported.rs
+++ b/tests/issue_3915_verify_axes_both_reported.rs
@@ -1,0 +1,118 @@
+//! [#3915] `--verify` 와 `--verify-pages` 를 함께 주면 쪽수 실패가 IR 차이를 가린다.
+//!
+//! 쪽수 검증이 실패하면 그 자리에서 `process::exit(4)` 했다. `--verify` 를 함께 줬어도
+//! IR 비교가 **아예 돌지 않아** 차이가 있어도 보고되지 않았다.
+//!
+//! 두 축은 서로 다른 결함을 잰다 — 쪽수는 조판 결과, IR 은 저장 손실이다. 한쪽이 실패했다고
+//! 다른 쪽을 건너뛰면, 사람이 "쪽수만 문제고 내용은 온전하다" 로 잘못 읽는다. 실제로
+//! `synam-001.hwp` 는 두 축이 **함께** 실패하는데 쪽수 실패만 보였다.
+//!
+//! 종료 코드 계약은 바꾸지 않는다 — 쪽수 실패는 그대로 4 다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// 두 축이 함께 실패하는 표본 — 쪽수 35→36, IR 차이 3건.
+const BOTH_FAIL_SAMPLE: &str = "samples/synam-001.hwp";
+/// 두 축 모두 통과하는 표본 — 무회귀 기준선.
+const CLEAN_SAMPLE: &str = "samples/table-001.hwp";
+
+fn repo(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn export(sample: &str, out: &Path, flags: &[&str]) -> Output {
+    let mut args: Vec<String> = vec![
+        "export-hwpx".into(),
+        repo(sample).to_string_lossy().into_owned(),
+        out.to_string_lossy().into_owned(),
+    ];
+    args.extend(flags.iter().map(|f| (*f).to_string()));
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(&args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn stderr(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+/// #3906 본체 — 쪽수가 실패해도 IR 비교를 마저 돌려 함께 보고한다.
+#[test]
+fn page_failure_no_longer_hides_ir_differences() {
+    let dir = std::env::temp_dir().join(format!("rhwp-3915-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("임시 디렉터리");
+    let out = dir.join("both.hwpx");
+
+    let o = export(BOTH_FAIL_SAMPLE, &out, &["--verify", "--verify-pages"]);
+    let err = stderr(&o);
+
+    assert!(
+        err.contains("검증 실패(--verify-pages)"),
+        "쪽수 실패가 보고되지 않았습니다:\n{err}"
+    );
+    assert!(
+        err.contains("검증 실패(--verify)"),
+        "쪽수 실패가 IR 차이를 가렸습니다 — 두 축은 서로 다른 결함을 재므로 함께 보고해야 \
+         합니다:\n{err}"
+    );
+
+    // 종료 코드 계약 무변경 — 쪽수 실패가 우선한다.
+    assert_eq!(
+        o.status.code(),
+        Some(4),
+        "두 축이 함께 실패해도 종료 코드는 종전대로 4 여야 합니다:\n{err}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// 실패인데 "통과" 도 함께 찍히면 안 된다 — 조기 종료를 걷어낼 때 흔한 사고다.
+#[test]
+fn failing_page_axis_does_not_also_report_pass() {
+    let dir = std::env::temp_dir().join(format!("rhwp-3915b-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("임시 디렉터리");
+    let out = dir.join("nopass.hwpx");
+
+    let o = export(BOTH_FAIL_SAMPLE, &out, &["--verify", "--verify-pages"]);
+    let combined = format!("{}{}", stderr(&o), String::from_utf8_lossy(&o.stdout));
+
+    assert!(
+        !combined.contains("검증 통과(--verify-pages)"),
+        "쪽수 축이 실패했는데 통과 메시지도 찍혔습니다:\n{combined}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// 단독 사용과 정상 문서는 종전 그대로여야 한다.
+#[test]
+fn single_axis_and_clean_document_are_unchanged() {
+    let dir = std::env::temp_dir().join(format!("rhwp-3915c-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("임시 디렉터리");
+
+    // --verify-pages 단독: 쪽수만 보고, exit 4.
+    let o = export(BOTH_FAIL_SAMPLE, &dir.join("p.hwpx"), &["--verify-pages"]);
+    let err = stderr(&o);
+    assert!(err.contains("검증 실패(--verify-pages)"), "{err}");
+    assert!(
+        !err.contains("검증 실패(--verify)"),
+        "--verify 를 주지 않았는데 IR 비교가 돌았습니다:\n{err}"
+    );
+    assert_eq!(o.status.code(), Some(4), "{err}");
+
+    // 두 축 모두 통과하는 문서: exit 0, 양쪽 통과 메시지.
+    let o = export(
+        CLEAN_SAMPLE,
+        &dir.join("c.hwpx"),
+        &["--verify", "--verify-pages"],
+    );
+    let combined = format!("{}{}", stderr(&o), String::from_utf8_lossy(&o.stdout));
+    assert_eq!(o.status.code(), Some(0), "{combined}");
+    assert!(combined.contains("검증 통과(--verify-pages)"), "{combined}");
+    assert!(combined.contains("검증 통과(--verify)"), "{combined}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
Issue: #3915

## 문제

`--verify` 와 `--verify-pages` 를 **함께** 주면 쪽수 실패가 IR 차이를 가립니다. 쪽수 분기가 그 자리에서 `process::exit(4)` 해서 IR 비교가 아예 돌지 않았습니다.

**같은 문서인데 플래그를 더 줬더니 정보가 줄어듭니다.**

```console
$ rhwp export-hwpx samples/synam-001.hwp out.hwpx --verify --verify-pages
검증 실패(--verify-pages): 변환 전 35쪽, 재파싱 후 36쪽        ← 이것만

$ rhwp export-hwpx samples/synam-001.hwp out.hwpx --verify      ← 단독
검증 실패(--verify): ... 재파싱 후 IR 차이 3건
```

## 왜 중요한가 — 실제로 저를 오진시켰습니다

두 축은 **서로 다른 결함**을 잽니다. 쪽수는 조판 결과, IR 은 저장 손실입니다.

#3737·#3521·#3518 을 조사하며 이 조합으로 돌린 뒤 **"IR 차이 0인데 쪽수만 +1"** 이라고 세 이슈에 적었습니다. `--verify` 단독으로 돌리니 IR 차이가 나왔습니다. 도구 출력이 사람을 잘못된 결론으로 이끈 사례라, 잘못된 분석이 이슈에 남았습니다.

## 수정

쪽수 실패를 **기록만 하고** IR 비교를 마저 돌린 뒤 한 곳에서 종료합니다.

- **종료 코드 계약 무변경** — 두 축이 함께 실패해도 쪽수 우선으로 `4` 입니다.
- 통과 메시지가 실패와 같이 찍히지 않도록 통과 경로를 `else` 로 묶었습니다(조기 종료를 걷어낼 때 흔한 사고라 테스트로 못박았습니다).
- `export-hwpx` 와 `convert` 두 곳에 같은 형태가 있어 **둘 다** 고쳤습니다.

## 검증 — red→green 실증

`tests/issue_3915_verify_axes_both_reported.rs`

| 검사 | 내용 |
|---|---|
| 본체 | 두 축 동시 실패 시 **둘 다 보고**되고 종료 코드는 4 |
| 사고 방지 | 실패 축에 "통과" 메시지가 함께 찍히지 않음 |
| 무회귀 | `--verify-pages` 단독, 두 축 통과 문서는 종전 그대로 |

**수정 전(RED)**

```
thread 'page_failure_no_longer_hides_ir_differences' panicked:
쪽수 실패가 IR 차이를 가렸습니다 — 두 축은 서로 다른 결함을 재므로 함께 보고해야 합니다
test result: FAILED. 2 passed; 1 failed
```

**수정 후(GREEN)**

```
test result: ok. 3 passed; 0 failed
```

로컬 빌드에서 실측했습니다(`cargo test --profile release-test`). 수정 전 상태로 되돌려 RED 를 직접 확인한 뒤 복원했습니다.
