### PR TITLE
fix(wmf): 텍스트 레코드(TEXTOUT·EXTTEXTOUT) 음수 StringLength 패닉 차단 — #3875 스윕 완성

### DIFF
--- a/src/wmf/parser/records/drawing/ext_text_out.rs
+++ b/src/wmf/parser/records/drawing/ext_text_out.rs
@@ -117,6 +117,16 @@ impl META_EXTTEXTOUT {
             None
         };
 
+        // `string_length` 는 i16 라 손상된 WMF 가 음수를 담을 수 있다. 음수를
+        // `as usize` 로 넓혀 `read_variable`(내부 `vec![0u8; len]`)에 넘기면
+        // capacity overflow 로 패닉한다 — #3875(POLYLINE/POLYGON)와 같은 클래스다.
+        // 아래 `dx.reserve_exact(string_length as usize)`·`0..string_length` 도
+        // 이 가드 뒤에서는 음수가 아니므로 함께 안전해진다.
+        if string_length < 0 {
+            return Err(crate::wmf::parser::ParseError::UnexpectedPattern {
+                cause: format!("The string_length field `{string_length}` must not be negative"),
+            });
+        }
         let (string, string_bytes) =
             crate::wmf::parser::read_variable(buf, string_length as usize)?;
         record_size.consume(string_bytes);

--- a/src/wmf/parser/records/drawing/text_out.rs
+++ b/src/wmf/parser/records/drawing/text_out.rs
@@ -57,7 +57,18 @@ impl META_TEXTOUT {
         let (string_length, string_length_bytes) = crate::wmf::parser::read_i16_from_le_bytes(buf)?;
         record_size.consume(string_length_bytes);
 
-        let string_len = string_length + (string_length % 2);
+        // `string_length` 는 i16 라 손상된 WMF 가 음수를 담을 수 있다. 음수를
+        // `as usize` 로 넓히면 usize::MAX 근처가 되어 `read_variable`(내부
+        // `vec![0u8; len]`)가 capacity overflow 로 패닉한다(-1 → 18446744073709551615).
+        // #3875 가 POLYLINE/POLYGON 에 넣은 가드와 같은 클래스다.
+        if string_length < 0 {
+            return Err(crate::wmf::parser::ParseError::UnexpectedPattern {
+                cause: format!("The string_length field `{string_length}` must not be negative"),
+            });
+        }
+        // usize 로 넓힌 뒤 홀수 보정을 더한다 — i16 에서 `32767 + 1` 은 오버플로라
+        // (debug 패닉 / release wrap→음수→huge) 넓힌 뒤 더해야 안전하다.
+        let string_len = string_length as usize + (string_length as usize % 2);
 
         let ((string, string_bytes), (y_start, y_start_bytes), (x_start, x_start_bytes)) = (
             crate::wmf::parser::read_variable(buf, string_len as usize)?,

--- a/tests/wmf_text_negative_string_length_no_panic.rs
+++ b/tests/wmf_text_negative_string_length_no_panic.rs
@@ -1,0 +1,115 @@
+//! WMF 텍스트 레코드의 음수/오버플로 문자열 길이는 패닉이 아니라 `Err` 로 끝난다.
+//!
+//! `META_TEXTOUT`(MS-WMF §2.3.5.6)·`META_EXTTEXTOUT`(§2.3.5.2) 의 `StringLength` 는
+//! **부호 있는 16비트**다. 손상되거나 악의적인 WMF 가 음수를 담을 수 있는데, 파서가
+//! 그 값을 `as usize` 로 넓혀 `read_variable`(내부 `vec![0u8; len]`)에 넘기면
+//! `-1i16 as usize` = 18446744073709551615 → **capacity overflow 패닉**이다.
+//!
+//! #3875 가 `META_POLYLINE`/`META_POLYGON` 의 `NumberOfPoints`(같은 i16 음수 결함)에
+//! 넣은 가드와 정확히 같은 클래스다 — 그 PR 의 테스트가 "한 곳을 고칠 때 같은 모양을
+//! 전수로 훑지 않으면 이렇게 남는다"고 적었고, 텍스트 레코드가 바로 그 남은 사각이었다.
+//!
+//! WMF 는 HWP 문서에 그림으로 임베드되므로 이 경로는 신뢰 경계 밖 입력을 받는다.
+//! 패닉은 라이브러리·MCP 서버·WASM 소비자를 통째로 죽이므로 DoS 다.
+
+fn synth_wmf(record_function: u16, body: &[u8]) -> Vec<u8> {
+    let mut out: Vec<u8> = Vec::new();
+    let push_u16 = |v: u16, buf: &mut Vec<u8>| buf.extend_from_slice(&v.to_le_bytes());
+    let push_u32 = |v: u32, buf: &mut Vec<u8>| buf.extend_from_slice(&v.to_le_bytes());
+
+    // ── META_HEADER (type=1, 9 words) ──
+    push_u16(1, &mut out);
+    push_u16(9, &mut out);
+    push_u16(0x0300, &mut out);
+    push_u32(0, &mut out);
+    push_u32(0, &mut out);
+    push_u16(0, &mut out);
+    push_u32(0, &mut out);
+    push_u16(0, &mut out);
+
+    // ── 대상 레코드: size(u32 words) + function(u16) + body ──
+    let record_words = 3 + (body.len() / 2) as u32;
+    push_u32(record_words, &mut out);
+    push_u16(record_function, &mut out);
+    out.extend_from_slice(body);
+
+    // ── META_EOF ──
+    push_u32(3, &mut out);
+    push_u16(0x0000, &mut out);
+    out
+}
+
+type RunOut = std::thread::Result<Result<Vec<u8>, rhwp::wmf::converter::ConvertError>>;
+
+fn run_result(bytes: &[u8]) -> RunOut {
+    std::panic::catch_unwind(|| {
+        rhwp::wmf::converter::WMFConverter::new(bytes, rhwp::wmf::converter::SVGPlayer::new()).run()
+    })
+}
+
+const META_TEXTOUT: u16 = 0x0521;
+const META_EXTTEXTOUT: u16 = 0x0a32;
+
+fn textout_body(string_length: i16) -> Vec<u8> {
+    string_length.to_le_bytes().to_vec()
+}
+
+fn exttextout_body(string_length: i16) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(&0i16.to_le_bytes()); // Y
+    body.extend_from_slice(&0i16.to_le_bytes()); // X
+    body.extend_from_slice(&string_length.to_le_bytes()); // StringLength
+    body.extend_from_slice(&0u16.to_le_bytes()); // fwOpts (ETO 없음 → rectangle 스킵)
+    body
+}
+
+#[test]
+fn textout_negative_string_length_does_not_panic() {
+    // 0x7FFF(32767) 도 넣는다: `string_length + (string_length % 2)` 가 i16 에서
+    // 오버플로하던 두 번째 경로다.
+    for n in [-1i16, i16::MIN, 0x7FFF] {
+        let bytes = synth_wmf(META_TEXTOUT, &textout_body(n));
+        assert!(
+            run_result(&bytes).is_ok(),
+            "META_TEXTOUT StringLength={n} 이 패닉했습니다 (DoS)"
+        );
+    }
+}
+
+#[test]
+fn exttextout_negative_string_length_does_not_panic() {
+    for n in [-1i16, i16::MIN] {
+        let bytes = synth_wmf(META_EXTTEXTOUT, &exttextout_body(n));
+        assert!(
+            run_result(&bytes).is_ok(),
+            "META_EXTTEXTOUT StringLength={n} 이 패닉했습니다 (DoS)"
+        );
+    }
+}
+
+/// 양성 대조 — 음수가 아닌 길이는 이 가드에 걸리지 않는다("전부 Err" 수정 방지).
+#[test]
+fn non_negative_string_length_is_not_rejected_by_the_guard() {
+    for n in [0i16, 2, 4] {
+        for func in [META_TEXTOUT, META_EXTTEXTOUT] {
+            let body = if func == META_TEXTOUT {
+                textout_body(n)
+            } else {
+                exttextout_body(n)
+            };
+            let bytes = synth_wmf(func, &body);
+            let r = run_result(&bytes);
+            assert!(
+                r.is_ok(),
+                "func={func:#06x} StringLength={n} 이 패닉했습니다"
+            );
+            if let Ok(Err(e)) = r {
+                let msg = format!("{e:?}");
+                assert!(
+                    !msg.contains("must not be negative"),
+                    "func={func:#06x} StringLength={n} 인데 음수 가드가 걸렸습니다: {msg}"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
`META_TEXTOUT`(MS-WMF §2.3.5.6)·`META_EXTTEXTOUT`(§2.3.5.2)의 `StringLength`(부호 있는 i16)가 음수일 때 파서가 `as usize`로 넓혀 `read_variable`(내부 `vec![0u8; len]`)에 넘겨 **capacity overflow 패닉** → DoS. WMF는 HWP 문서에 그림으로 임베드되므로 신뢰 경계 밖 입력이고, 패닉은 라이브러리·MCP 서버·WASM 소비자를 통째로 죽입니다.

## #3875 스윕의 남은 사각

이건 방금 머지된 **#3875(POLYLINE/POLYGON `NumberOfPoints` 음수 패닉)와 정확히 같은 클래스**입니다. #3875의 테스트가 직접 적었습니다: *"한 곳을 고칠 때 같은 모양을 전수로 훑지 않으면 이렇게 남는다."* 텍스트 레코드가 바로 그 남은 사각이라, 같은 방식(`if string_length < 0 { Err }`)의 가드를 두 곳에 추가해 스윕을 완성합니다.

부수로, `META_TEXTOUT`의 `string_length + (string_length % 2)`는 `0x7FFF`에서 i16 오버플로(debug 패닉/release wrap→음수→huge)하므로, `usize`로 넓힌 뒤 홀수 보정을 더하도록 함께 고쳤습니다.

## red→green (로컬 release-test)

`tests/wmf_text_negative_string_length_no_panic.rs` — 음수 3종(−1, i16::MIN, 0x7FFF) + 양성 대조(0/2/4가 음수 가드에 안 걸림).

| 상태 | 결과 |
|---|---|
| **src만 devel로 원복** | `textout`·`exttextout` 2건 **FAILED** — `capacity overflow` 패닉 실측 |
| 수정 후 | **3/3 통과** |

전체 스위트는 CI로 부탁드립니다. WMF는 `fuzz/fuzz_targets/parse_wmf.rs` 사정거리 안이라 퍼저가 돌았다면 잡았을 결함입니다(#3877).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
