### PR TITLE
fix(hwp3): 문서 파생 길이로 인한 슬라이스 시작 OOB 패닉 2곳 차단 (parse_hwp3 DoS)

### DIFF
--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -3486,7 +3486,28 @@ fn parse_hwp3_inner(
     cursor.set_position(info_block_end);
 
     // 4. 본문 텍스트 압축 해제 (`doc_info.compressed` 확인 후 `flate2` 사용)
-    let remaining_data = &data[(30 + current_pos as usize + doc_info.info_block_length as usize)..];
+    //
+    // [보안] `info_block_length` 는 u16 이지만 **문서가 정하는 값**이라, 짧은/손상된
+    // 파일에서 본문 시작 오프셋이 파일 끝을 넘길 수 있다. 종전엔 `&data[start..]` 가
+    // 그대로 슬라이싱해 `range start index N out of range` 패닉(DoS)이었다 — 신뢰 경계
+    // 밖 `.hwp` 로 `parse_hwp3` 를 부르는 라이브러리·MCP 소비자를 죽인다. 경계를 확인해
+    // 파싱 오류로 끝낸다(오버플로 방지 위해 saturating_add).
+    let body_start = 30usize
+        .saturating_add(current_pos as usize)
+        .saturating_add(doc_info.info_block_length as usize);
+    let remaining_data = match data.get(body_start..) {
+        Some(slice) => slice,
+        None => {
+            return Err(Hwp3Error::ParseError {
+                message: format!(
+                    "정보 블록 길이({})가 파일 범위를 벗어납니다 (본문 시작 {} > 파일 크기 {})",
+                    doc_info.info_block_length,
+                    body_start,
+                    data.len()
+                ),
+            });
+        }
+    };
 
     let mut decompressed_data = Vec::new();
     let body_data = if doc_info.compressed != 0 {
@@ -3640,7 +3661,11 @@ fn parse_hwp3_inner(
                     next_id
                 };
 
-                let img_data = block.data[32..].to_vec();
+                // [보안] `block.data.len()` 은 문서가 정한 length 라 24~31 일 수 있다.
+                // 위 `>= 24` 가드는 name(`[0..16]`)만 보장하므로 `[32..]` 슬라이스는
+                // 별도로 경계를 확인한다 — 종전엔 24~31 바이트 블록에서 슬라이스 시작
+                // OOB 패닉(DoS)이었다. 이미지 데이터가 없는 짧은 블록은 빈 바이트로 둔다.
+                let img_data = block.data.get(32..).unwrap_or(&[]).to_vec();
 
                 // WMF/EMF도 포함한 magic 기반 확장자 판별. 배경 이미지(#6)도 같은
                 // BinData 경로를 사용하므로 공용 helper로 유지한다.

--- a/tests/hwp3_slice_index_oob_no_panic.rs
+++ b/tests/hwp3_slice_index_oob_no_panic.rs
@@ -1,0 +1,45 @@
+//! HWP3 파서가 문서 파생 길이 필드로 슬라이스를 시작할 때 경계를 넘지 않는다.
+//!
+//! `info_block_length`(doc_info, u16)는 **문서가 정하는 값**이다. 짧은/손상된 `.hwp`
+//! 에서 본문 시작 오프셋 `30 + docinfo(128) + summary(1008) + info_block_length` 가
+//! 파일 끝을 넘으면, 종전 `&data[start..]` 는 `range start index N out of range for
+//! slice of length M` 로 **패닉**했다(mod.rs:3489). WMF(#3875)와 같은 부류의 DoS —
+//! 신뢰 경계 밖 `.hwp` 로 `parse_hwp3` 를 부르는 라이브러리·MCP 소비자를 죽인다.
+//!
+//! 형제 사이트(`block.data[32..]`, `>= 24` 가드뿐)도 같은 커밋에서 함께 막았다.
+
+fn sample() -> Vec<u8> {
+    std::fs::read(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/samples/hwp3-pagedef-1915.hwp"
+    ))
+    .expect("HWP3 샘플")
+}
+
+/// 유효 파일은 여전히 정상 파싱된다(가드가 정상 경로를 막지 않음 — 양성 대조).
+#[test]
+fn valid_hwp3_still_parses() {
+    let data = sample();
+    let r = std::panic::catch_unwind(|| rhwp::parser::hwp3::parse_hwp3(&data));
+    assert!(r.is_ok(), "유효 HWP3 가 패닉했습니다");
+    assert!(
+        matches!(r, Ok(Ok(_))),
+        "유효 HWP3 파싱이 실패했습니다(가드가 정상 경로를 막음)"
+    );
+}
+
+/// `info_block_length` 를 0xFFFF 로 키우면 본문 시작이 파일 끝을 넘는다 → 패닉 금지.
+#[test]
+fn oversized_info_block_length_does_not_panic() {
+    let mut data = sample();
+    // info_block_length: doc_info off 126 = 파일 off 156 (u16 LE). encrypted(off 126)는 0 유지.
+    data[156] = 0xFF;
+    data[157] = 0xFF;
+    let r = std::panic::catch_unwind(|| {
+        let _ = rhwp::parser::hwp3::parse_hwp3(&data);
+    });
+    assert!(
+        r.is_ok(),
+        "info_block_length 가 파일 범위를 넘을 때 패닉했습니다 (DoS)"
+    );
+}


### PR DESCRIPTION
`parse_hwp3` 가 신뢰 경계 밖 `.hwp` 를 처리할 때 **문서가 정하는 길이 필드**로 슬라이스 시작 인덱스를 잡아, 그 값이 파일 끝을 넘으면 `range start index N out of range for slice of length M` **패닉(DoS)** 이 납니다. WMF #3875 와 같은 부류이며, rhwp 를 라이브러리·MCP 서버로 쓰는 소비자를 통째로 죽입니다.

## 두 사이트 (같은 클래스)

**① `mod.rs:3489` 본문 시작 오프셋** — `30 + docinfo(128) + summary(1008) + info_block_length`. `info_block_length` 는 u16 이지만 문서값이라, 짧은/손상된 파일에서 시작 오프셋이 파일을 넘긴다. `saturating_add` + `data.get(..)` 경계 확인 후 `ParseError` 로 끝낸다.

**② `mod.rs:3643` 포함 이미지** — `block.data[32..]` 가 `>= 24` 가드만 있어(name `[0..16]` 만 보장), 24~31바이트 블록에서 시작 OOB. `data.get(32..)` 로 안전 처리(짧은 블록은 빈 이미지).

## red→green (로컬 release-test, 실측 재현)

`tests/hwp3_slice_index_oob_no_panic.rs`:

| 케이스 | devel(수정 전) | 수정 후 |
|---|---|---|
| `hwp3-pagedef-1915.hwp`(2460B)의 `info_block_length`(파일 off 156) → `0xFFFF` | **패닉** `range start index 66701 out of range for slice of length 2460` (mod.rs:3489) | 정상 (파싱 오류로 끝남) |
| 유효 HWP3 (양성 대조) | 정상 파싱 | 정상 파싱 |

②는 같은 클래스라 같은 커밋에서 방어적으로 함께 막았습니다(24~31 바이트 `id==1` 블록 크래프팅 대신 명백한 off-by-guard `>=24`→`get(32..)` 교정).

전체 스위트는 CI로 부탁드립니다. HWP3 는 `fuzz/fuzz_targets/parse_hwp3.rs` 사정거리 안입니다(#3877).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
