### PR TITLE
fix(hwp3): 구역 단 정의(cold)를 미주와 무관하게 보장 — 한글 저장본 대조로 발견 (#3676)

### DIFF
--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -3974,10 +3974,18 @@ fn fixup_hwp3_notes(doc: &mut crate::model::document::Document, doc_info: &Hwp3D
         }
     }
 
+    // [#3676] 구역 첫 문단의 단 정의(`cold`)는 미주와 무관하게 항상 있어야 한다. 한글은
+    // `secd` 뒤에 `cold` 가 없는 구역을 **파일 전체 거부**로 처리한다 — 미주가 없는 HWP3
+    // 변환본이 그래서 안 열렸다(`3050521 형사 제1심 소송기록`, #3676 잔여 1건).
+    // 한글 저장본과 대조하면 `CTRL_HEADER` 가 7개인데 변환본은 6개였고, 빠진 하나가
+    // 정확히 `cold` 다.
+    for section in &mut doc.sections {
+        ensure_hwp3_initial_body_column_def(&mut section.paragraphs);
+    }
+
     if state.has_endnote {
         for section in &mut doc.sections {
             section.section_def.endnote_shape = hwp3_default_endnote_shape(doc_info);
-            ensure_hwp3_initial_body_column_def(&mut section.paragraphs);
             let page_def = &section.section_def.page_def;
             let body_width_hu = page_def
                 .width


### PR DESCRIPTION
## 무엇을 고치나

`ensure_hwp3_initial_body_column_def` 가 `fixup_hwp3_notes` 의 **`if state.has_endnote`
블록 안에** 갇혀 있습니다. 그래서 **미주가 없는 HWP3 문서는 구역 첫 문단의
`ColumnDef`(`cold`) 가 통째로 빠집니다.**

```rust
 if state.has_endnote {
     for section in &mut doc.sections {
         section.section_def.endnote_shape = hwp3_default_endnote_shape(doc_info);
-        ensure_hwp3_initial_body_column_def(&mut section.paragraphs);   // ← 미주 문서에만
```

단 정의는 미주 유무와 무관한 **구역 속성**이므로 미주 블록 밖에서 항상 보장합니다.

## 어떻게 찾았나 — 한글 저장본을 정답지로

같은 원본(`3050521 형사 제1심 소송기록`, HWP3)을 한글 2022 로 열어 HWP5 로 저장하고,
rhwp 변환본과 `dump-records` 로 대조했습니다.

```text
한글 저장본   CTRL_HEADER 7개 — secd  cold  gso gso gso gso  tbl
rhwp 변환본   CTRL_HEADER 6개 — secd        gso gso gso gso  tbl
```

레코드 시퀀스는 187개로 1:1 일치하는데 `cold` 하나만 없었습니다.

## 게이트

| 게이트 | 결과 |
|---|---|
| HWP3 12건 한글 열기(문서당 프로세스 격리) | **12/12 OK** — 기존 열림 회귀 없음 |
| 전체 nextest | **5,085/5,085** |
| clippy `-D warnings` | 통과 |

## 이 PR 이 하지 않는 것

**`#3676` 잔여 1건은 이 수정으로 열리지 않습니다.** 그 문서의 배제 목록에 두 가지를
더합니다(다음 시도가 같은 길을 반복하지 않도록).

| 가설 | 결과 |
|---|---|
| `cold` 누락 | 넣어도 **여전히 거부** |
| `secd` payload 가 9바이트 짧음(38 vs 47) | 한글과 같게 맞춰도 **여전히 거부** |

남은 차이는 레코드 **크기 4곳**뿐입니다 — `PARA_CHAR_SHAPE` 24 vs 8, `PARA_TEXT` 92 vs 82,
`PARA_TEXT` 18 vs 22. 이전 조사가 지목한 "레코드 필드 값 수준" 과 일치합니다.

Refs #3676
