### PR TITLE
fix(renderer): wrap overlong tokens after a prior break (#3822)

### DIFF
--- a/mydocs/orders/20260804.md
+++ b/mydocs/orders/20260804.md
@@ -28,6 +28,14 @@
 - Draft PR [#3944](https://github.com/edwardkim/rhwp/pull/3944)를 GitHub Stack
   #3947의 첫 레이어로 게시했다.
 
+## #3822 — prior-break 뒤 긴 token 반복 줄바꿈
+
+- #3937 레이어 위에 #3822 composer 변경만 올린 두 번째 stack branch를 재구성했다.
+- 최신 기준 composer 52건과 #3822 전용 4건을 통과했다.
+- 긴 token의 overflow 해결과 browser glyph 윤곽 확대의 책임을 각각 #3822와 #3937로
+  문서에서 분리했다.
+- 기존 HWP/HWPX 저장·재열기 증적은 역사적 결과로 보존하고 최상단 combined smoke만 반복한다.
+
 ## PR #3831 - Studio 표 나누기·붙이기 검토
 
 - [PR #3831](https://github.com/edwardkim/rhwp/pull/3831)을

--- a/mydocs/orders/20260804.md
+++ b/mydocs/orders/20260804.md
@@ -31,10 +31,13 @@
 ## #3822 — prior-break 뒤 긴 token 반복 줄바꿈
 
 - #3937 레이어 위에 #3822 composer 변경만 올린 두 번째 stack branch를 재구성했다.
-- 최신 기준 composer 52건과 #3822 전용 4건을 통과했다.
+- 최신 upstream/devel ec1b21096 기준 composer 52건과 #3822 전용 4건을 통과했다.
 - 긴 token의 overflow 해결과 browser glyph 윤곽 확대의 책임을 각각 #3822와 #3937로
   문서에서 분리했다.
-- 기존 HWP/HWPX 저장·재열기 증적은 역사적 결과로 보존하고 최상단 combined smoke만 반복한다.
+- 기존 HWP/HWPX 저장·재열기 증적은 역사적 결과로 보존하고, 최신 최상단 combined smoke에서
+  두 형식 모두 줄 전환 11 / 69, 최종 숫자 73과 최종 쪽수 116을 다시 확인했다.
+- Draft PR [#3945](https://github.com/edwardkim/rhwp/pull/3945)를 GitHub Stack
+  #3947의 두 번째 레이어로 게시했다.
 
 ## PR #3831 - Studio 표 나누기·붙이기 검토
 

--- a/mydocs/plans/task_m100_3822.md
+++ b/mydocs/plans/task_m100_3822.md
@@ -1,0 +1,40 @@
+# 수행계획서 — task_m100_3822
+
+- **이슈**: [#3822](https://github.com/edwardkim/rhwp/issues/3822)
+- **브랜치**: stack/issue-3822-overlong-token-wrap
+- **부모 레이어**: stack/issue-3937-distribution-glyph-width
+- **최신 기준**: upstream/devel 8d7bc622e
+- **작성일**: 2026-08-04
+- **절차 상태**: 구현·focused 검증 완료, 최상단 combined smoke 대기
+
+## 문제
+
+표 셀에서 앞선 break point 뒤의 긴 무공백 영문·숫자 token이 새 줄로 이동한 뒤
+그 줄 폭도 넘는데 추가 분할되지 않는다. pagination 완료 뒤에도 caret가 셀 오른쪽에
+고정되고 글자가 숨는다.
+
+## 원인과 설계
+
+fill_lines는 이전 break point에서 줄을 확정한 뒤 현재 token 전체 폭을 새 줄에 더하고
+즉시 continue했다. 따라서 token 자체가 후속 줄보다 긴 경우에도 기존
+char_level_break_hwp fallback에 도달하지 못했다.
+
+수정은 현재 token을 후속 줄의 실제 폭, hanging indent, condense와 HWPUNIT 허용 오차로
+다시 평가한다. 들어가지 않으면 폭을 중복 합산하지 않고 기존 문자 단위 fallback을 실행한다.
+current-token CJK/Hangul 특수 경로와 UTF-16 offset 계약은 유지한다.
+
+## 범위
+
+- prior break 뒤 긴 Latin·숫자 token의 반복 emergency wrap
+- 후속 줄 hanging indent와 비어 있지 않은 base width
+- 실제 HWP/HWPX 연속 두 번째 줄바꿈과 저장·재열기
+
+glyph 윤곽 가로 확대는 부모 #3937, pagination scheduling은 자식 #3815의 범위다.
+CellFlowTree, PageCheckpoint, DisplaySnapshot은 #3743 후속 작업으로 유지한다.
+
+## 완료 기준
+
+- 필요한 만큼 line start가 추가되고 문자 누락·중복이 없다.
+- caret와 모든 TextRun이 셀 경계 안에 남는다.
+- HWP/HWPX 저장·재열기에서 text, line, page count가 일치한다.
+- #3815 최상단 통합 E2E에서 IME 뒤 긴 숫자가 두 번 줄바꿈된다.

--- a/mydocs/plans/task_m100_3822.md
+++ b/mydocs/plans/task_m100_3822.md
@@ -3,7 +3,7 @@
 - **이슈**: [#3822](https://github.com/edwardkim/rhwp/issues/3822)
 - **브랜치**: stack/issue-3822-overlong-token-wrap
 - **부모 레이어**: stack/issue-3937-distribution-glyph-width
-- **최신 기준**: upstream/devel ec1b21096
+- **최신 기준**: upstream/devel aeb5805cb
 - **작성일**: 2026-08-04
 - **절차 상태**: 구현·최신 기준 검증과 최상단 combined smoke 완료, Draft PR #3945 게시
 
@@ -25,7 +25,7 @@ current-token CJK/Hangul 특수 경로와 UTF-16 offset 계약은 유지한다.
 
 ## 범위
 
-- prior break 뒤 긴 Latin·숫자 token의 반복 emergency wrap
+- prior break 뒤 긴 Latin·숫자·한글 어절의 반복 emergency wrap
 - 후속 줄 hanging indent와 비어 있지 않은 base width
 - 실제 HWP/HWPX 연속 두 번째 줄바꿈과 저장·재열기
 

--- a/mydocs/plans/task_m100_3822.md
+++ b/mydocs/plans/task_m100_3822.md
@@ -3,9 +3,9 @@
 - **이슈**: [#3822](https://github.com/edwardkim/rhwp/issues/3822)
 - **브랜치**: stack/issue-3822-overlong-token-wrap
 - **부모 레이어**: stack/issue-3937-distribution-glyph-width
-- **최신 기준**: upstream/devel 8d7bc622e
+- **최신 기준**: upstream/devel ec1b21096
 - **작성일**: 2026-08-04
-- **절차 상태**: 구현·focused 검증 완료, 최상단 combined smoke 대기
+- **절차 상태**: 구현·최신 기준 검증과 최상단 combined smoke 완료, Draft PR #3945 게시
 
 ## 문제
 

--- a/mydocs/plans/task_m100_3822.md
+++ b/mydocs/plans/task_m100_3822.md
@@ -3,7 +3,7 @@
 - **이슈**: [#3822](https://github.com/edwardkim/rhwp/issues/3822)
 - **브랜치**: stack/issue-3822-overlong-token-wrap
 - **부모 레이어**: stack/issue-3937-distribution-glyph-width
-- **최신 기준**: upstream/devel aeb5805cb
+- **최신 기준**: upstream/devel cf5d462dc
 - **작성일**: 2026-08-04
 - **절차 상태**: 구현·최신 기준 검증과 최상단 combined smoke 완료, Draft PR #3945 게시
 

--- a/mydocs/pr/archives/pr_3945_review.md
+++ b/mydocs/pr/archives/pr_3945_review.md
@@ -18,9 +18,9 @@ loaded documents: pr_review_workflow.md, pr_review/README.md,
                   local_validation.md, visual_fixture_evidence.md,
                   multi_pr_update_branch.md
 remote head before correction: a5d26c2d8fc5433d4ec2558c33821f5526a29cd2
-reviewed local layer head: 8c9c35e9fa3518527c1d5aca28adfdf210022fe1
-parent layer head: 3534eb843ae07edf60f061a9b245958c8b7d2cf0
-upstream/devel: aeb5805cb93c92b8c44036f4c1fe1f2df420119f
+reviewed local layer head: 8d8239287
+parent layer head: 3b91ca268
+upstream/devel: cf5d462dcda1b5ab71160033e1d454b42198ad18
 ```
 
 ## 메타데이터
@@ -33,9 +33,9 @@ upstream/devel: aeb5805cb93c92b8c44036f4c1fe1f2df420119f
 | Stack 위치 | 2 / 3 — 부모 [#3944](https://github.com/edwardkim/rhwp/pull/3944), 자식 [#3946](https://github.com/edwardkim/rhwp/pull/3946) |
 | 작성 시점 원격 상태 | draft, `MERGEABLE`; 보정 push와 restack 뒤 재확인 필요 |
 | 보정 전 원격 head | `a5d26c2d8fc5433d4ec2558c33821f5526a29cd2` |
-| 리뷰 보정 layer head | `8c9c35e9fa3518527c1d5aca28adfdf210022fe1` |
-| 부모 레이어 head | `3534eb843ae07edf60f061a9b245958c8b7d2cf0` |
-| 최신 공통 기준 | `upstream/devel` `aeb5805cb93c92b8c44036f4c1fe1f2df420119f` |
+| 리뷰 보정 layer head | `8d8239287` |
+| 부모 레이어 head | `3b91ca268` |
+| 최신 공통 기준 | `upstream/devel` `cf5d462dcda1b5ab71160033e1d454b42198ad18` |
 | review 문서 작성 전 PR 고유 규모 | 5 files, +230 / -22 |
 | 관련 issue | [#3822](https://github.com/edwardkim/rhwp/issues/3822) |
 
@@ -72,7 +72,7 @@ DisplaySnapshot은 #3743 후속 아키텍처 범위로 남긴다.
 
 ### 2. 한글 무공백 어절 회귀 보강
 
-보정 commit `8c9c35e9f`에서 `korean_break_unit == 0`의 다중 문자 한글 어절을 별도 회귀로 추가했다.
+보정 commit `8d8239287`에서 `korean_break_unit == 0`의 다중 문자 한글 어절을 별도 회귀로 추가했다.
 
 ```text
 입력: "A 가나다라마바사"
@@ -114,6 +114,11 @@ fallback 표현을 유지한다.
 | #3822 전용 Latin·한글·숫자·잔여 폭·hanging indent | 5 passed / 0 failed |
 | `env CARGO_INCREMENTAL=0 cargo fmt --check` | 통과 |
 | `git diff --check` | 통과 |
+
+검토 CI 중 `devel`이 중첩 표 배치 수정 #3949를 포함한 `cf5d462dc`로 전진해 Stack을 다시
+정렬했다. composer 제품 충돌은 없었으며 53 / 53과 #3822 focused 5 / 5를 유지했다. 새
+production WASM HWP/HWPX 통합 E2E도 줄 전환 11 / 69, 숫자 73, 최종 116쪽으로 GREEN이고
+pending operation p95는 49.6 / 49.7ms였다.
 
 ## 실제 HWP/HWPX 증적
 

--- a/mydocs/pr/archives/pr_3945_review.md
+++ b/mydocs/pr/archives/pr_3945_review.md
@@ -1,0 +1,159 @@
+---
+kind: pr_review
+status: local-validation-passed
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-04
+---
+
+# PR #3945 검토 — prior break 뒤 긴 token 반복 줄바꿈
+
+## 검토 경로
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, local_validation.md,
+           visual_fixture_evidence.md, multi_pr_update_branch.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+                  collaborator_self_merge.md, intake_and_review.md,
+                  local_validation.md, visual_fixture_evidence.md,
+                  multi_pr_update_branch.md
+remote head before correction: a5d26c2d8fc5433d4ec2558c33821f5526a29cd2
+reviewed local layer head: 8c9c35e9fa3518527c1d5aca28adfdf210022fe1
+parent layer head: 3534eb843ae07edf60f061a9b245958c8b7d2cf0
+upstream/devel: aeb5805cb93c92b8c44036f4c1fe1f2df420119f
+```
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#3945](https://github.com/edwardkim/rhwp/pull/3945) |
+| 작성자 | `postmelee` (collaborator self-merge) |
+| 대상 / head | `stack/issue-3937-distribution-glyph-width` / `stack/issue-3822-overlong-token-wrap` |
+| Stack 위치 | 2 / 3 — 부모 [#3944](https://github.com/edwardkim/rhwp/pull/3944), 자식 [#3946](https://github.com/edwardkim/rhwp/pull/3946) |
+| 작성 시점 원격 상태 | draft, `MERGEABLE`; 보정 push와 restack 뒤 재확인 필요 |
+| 보정 전 원격 head | `a5d26c2d8fc5433d4ec2558c33821f5526a29cd2` |
+| 리뷰 보정 layer head | `8c9c35e9fa3518527c1d5aca28adfdf210022fe1` |
+| 부모 레이어 head | `3534eb843ae07edf60f061a9b245958c8b7d2cf0` |
+| 최신 공통 기준 | `upstream/devel` `aeb5805cb93c92b8c44036f4c1fe1f2df420119f` |
+| review 문서 작성 전 PR 고유 규모 | 5 files, +230 / -22 |
+| 관련 issue | [#3822](https://github.com/edwardkim/rhwp/issues/3822) |
+
+draft, mergeability, 원격 head와 CI는 작성 시점 참고값이다. 최종 merge 조건은 부모 #3944를 먼저
+통합한 뒤 갱신된 #3945 head에서 required CI를 다시 통과하는 것과 작업지시자의 명시적 승인이다. 이
+review 단계에서는 ready 전환과 merge를 수행하지 않는다.
+
+## 변경 범위와 목적
+
+표 셀에서 앞선 break point 뒤의 긴 무공백 token이 다음 줄로 이동한 뒤에도 그 줄 폭을 초과하면 기존
+구현은 token 전체 폭을 더하고 즉시 `continue`했다. 기존 문자 단위 fallback에 도달하지 못해
+Latin·숫자·한글 어절이 셀 오른쪽으로 넘치고 caret와 입력 글자가 숨을 수 있었다.
+
+이번 레이어는 자연 폭, 배분 축소 폭, 15 HWPUNIT 허용 오차와 condense pull 조건을 공통 fit 판정으로
+모은다. 이전 break에서 줄을 확정한 뒤 새 줄의 실제 잔여 폭과 공백 절감량을 복원하고, 현재 token을
+후속 줄의 실제 폭과 hanging indent로 다시 평가한다. 새 줄에도 들어가지 않으면 token 폭을 중복
+합산하지 않고 기존 문자 단위 fallback으로 보내 필요한 만큼 반복 분할한다. 단일 CJK/한글 break 경로와
+UTF-16 offset 계약은 유지한다.
+
+이 PR은 token 재분할과 overflow 해결만 담당한다. browser glyph 윤곽 확대는 부모 #3944,
+pagination 재시작·게시 스케줄링은 자식 #3946의 책임이다. CellFlowTree, PageCheckpoint와 viewport
+DisplaySnapshot은 #3743 후속 아키텍처 범위로 남긴다.
+
+## 리뷰 지적 대응
+
+[리뷰 코멘트](https://github.com/edwardkim/rhwp/pull/3945#issuecomment-5177714900)를 검토하고 다음처럼
+보정했다.
+
+### 1. 새 #3822 경로의 폭 이중 합산 여부
+
+새 경로는 이전 break 뒤 현재 token 이전의 잔여 폭만 복원한다. token이 후속 줄에도 들어가지 않으면
+그 token 폭을 더하지 않고 문자 단위 fallback으로 넘어가므로 이중 합산하지 않는다. hanging indent도
+첫 줄이 아닌 후속 줄 폭으로 판정하며 전용 회귀가 이 계약을 고정한다.
+
+### 2. 한글 무공백 어절 회귀 보강
+
+보정 commit `8c9c35e9f`에서 `korean_break_unit == 0`의 다중 문자 한글 어절을 별도 회귀로 추가했다.
+
+```text
+입력: "A 가나다라마바사"
+예상 line starts: [0, 2, 4, 6, 8]
+```
+
+prior break 뒤 반복 분할 계약은 Latin·한글·숫자 모두 고정됐다. composer 단위 테스트는 52건에서
+53건, #3822 전용 회귀는 4건에서 5건으로 늘었다.
+
+### 3. 기존 condense 회계 경로
+
+리뷰가 식별한 `break_token_idx == ti`의 폭 재계상과 char-level fallback 뒤
+`line_space_savings = 0` 초기화는 이번 변경이 만든 동작이 아니라 기존 condense 계약이다. 이를 함께
+바꾸면 #3822 prior-break 다중 token 수정 범위를 넘어가므로 현재 동작을 보존한다. condense 문서에서
+조기 줄바꿈 재현이 확보되면 두 항목을 함께 후속 점검한다.
+
+같은 지점의 `eff_w(false)`와 `eff_w(is_first_line)`은 동일한 값이다. 기능 차이가 없어 기존 일반
+fallback 표현을 유지한다.
+
+### 4. 쪽수 115 → 116
+
+숨겨졌던 overflow가 실제 줄로 복원되면서 문서 높이와 쪽수가 115에서 116으로 늘어나는 것은 의도된
+정확성 변화다. 다른 Studio E2E의 `115`는 좌표·mm 값으로 page count 계약과 무관하다. 변경된 쪽수는
+자식 #3946의 통합 E2E에서 검증한다.
+
+### 5. collaborator review 기록
+
+이 문서를 `mydocs/pr/archives/pr_3945_review.md`로 추가한다. 보정은 한글 회귀와 관련 계획·작업 기록으로
+명확하므로 별도 `review_impl` 문서는 만들지 않는다.
+
+## 검증
+
+리뷰 보정 layer head에서 다음 로컬 결과를 확인했다.
+
+| 검증 | 결과 |
+| --- | --- |
+| `env CARGO_INCREMENTAL=0 cargo test issue_3822_reflow_overlong_korean_word_after_prior_break --lib` | 1 passed / 0 failed |
+| `env CARGO_INCREMENTAL=0 cargo test renderer::composer::tests --lib` | 53 passed / 0 failed |
+| #3822 전용 Latin·한글·숫자·잔여 폭·hanging indent | 5 passed / 0 failed |
+| `env CARGO_INCREMENTAL=0 cargo fmt --check` | 통과 |
+| `git diff --check` | 통과 |
+
+## 실제 HWP/HWPX 증적
+
+2026-08-03 production WASM snapshot에서 HWP/HWPX 두 번째 숫자 줄바꿈 2 / 2, line count 5 → 6,
+caret 665.4 / cell right 672.8, `overflow=false`를 확인했다. HWP/HWPX × digits, Latin, 완료
+한글→digits 저장·재열기 6 / 6과 실제 IME→공백→두 번의 숫자 wrap 2 / 2도 통과했다. #3822 미적용
+control은 숫자 79번째에서 `cellOverflowed=true`였다.
+
+최상단 combined production WASM E2E에서도 HWP/HWPX 모두 숫자 줄 전환 11 / 69, 최종 숫자 73,
+최종 쪽수 116과 synchronous flush 0을 확인했다. 이 결과는 전체 Stack 통합 증적이며 #3945 단독
+최신 원격 head의 CI를 대신하지 않는다.
+
+## 시각·fixture 판정
+
+이 레이어는 glyph outline이나 paint scaling을 바꾸지 않고 line start와 overflow 판정을 바꾼다. 의도된
+시각 변화는 숨겨졌던 token이 다음 줄들에 나타나고 필요하면 전체 쪽수가 늘어나는 것이다. 별도 SVG
+golden 갱신은 필요하지 않다.
+
+부모 레이어에 보존한 `mydocs/pr/assets/pr_3944_issue1949_combined_hwp_final.png`는 최상단 Stack의 HWP
+완료 상태에서 긴 숫자가 반복 줄바꿈되고 셀 안에 남는 것을 보여준다. 이는 #3945 단독 oracle이 아닌
+combined 증적이라는 한계를 명시한다.
+
+![PR 3945 combined HWP final](../assets/pr_3944_issue1949_combined_hwp_final.png)
+
+## 위험과 알려진 한계
+
+- 기존 단일 CJK/한글 condense 경로의 폭 재계상과 char-level fallback의 공백 절감량 초기화는 유지한다.
+- 15 HWPUNIT 허용 오차와 기존 greedy line-breaking 정책 자체는 바꾸지 않는다.
+- 긴 token을 정상 줄로 복원하면 line count와 page count가 늘 수 있다. 이는 숨은 overflow보다 정확하다.
+- glyph 확대, pagination scheduling과 영속 대형 셀 아키텍처는 각각 #3944, #3946, #3743의 책임이다.
+- 최종 merge 근거는 restack 뒤 최신 #3945 head의 CI여야 한다.
+
+## Stack merge 순서와 최종 조건
+
+1. 부모 [#3944](https://github.com/edwardkim/rhwp/pull/3944)를 먼저 `devel`에 통합한다.
+2. #3945를 최신 `devel` 위로 restack하고 새 head를 확인한다.
+3. 갱신된 #3945 head에서 GitHub Actions, Render Diff와 CodeQL을 다시 통과한다.
+4. 작업지시자의 명시적 승인 뒤에만 #3945를 ready/merge한다.
+5. 이후 자식 [#3946](https://github.com/edwardkim/rhwp/pull/3946)을 같은 방식으로 restack·검증한다.
+
+**현재 권고: 보정 push와 최신-head CI 대기.** 코드 검토의 blocker는 없고 리뷰가 요구한 한글 어절
+회귀와 review 기록은 준비됐다. 부모 #3944 이후 restack한 최신 head의 CI 성공과 작업지시자 승인이
+확인되면 collaborator self-merge 후보로 판단할 수 있다.

--- a/mydocs/working/task_m100_3822_stage2.md
+++ b/mydocs/working/task_m100_3822_stage2.md
@@ -2,8 +2,8 @@
 
 - 이슈: [#3822](https://github.com/edwardkim/rhwp/issues/3822)
 - 브랜치: stack/issue-3822-overlong-token-wrap
-- 최신 기준: upstream/devel aeb5805cb
-- code candidate: 7d6c5d625
+- 최신 기준: upstream/devel cf5d462dc
+- code candidate: ba99fad54
 - 작성일: 2026-08-04
 
 ## 최신 기준 focused 결과
@@ -41,6 +41,11 @@ glyph outline의 실제 가로 비율을 직접 증명하지 않았다. 따라�
 최신 최상단 stack의 production WASM에서 같은 combined E2E를 재실행했다. HWP/HWPX 모두
 숫자 줄 전환 11 / 69, 최종 숫자 73, 최종 쪽수 116과 synchronous flush 0으로 GREEN이었다.
 두 정확성 수정과 #3815 scheduler의 조합이 최신 typeset 변경 뒤에도 유지됐다.
+
+검토 CI 중 devel이 중첩 표 배치 수정 #3949를 포함한 cf5d462dc로 전진했다. composer 제품
+코드는 충돌하지 않았고 53 / 53과 #3822 focused 5 / 5를 유지했다. 새 production WASM
+HWP/HWPX 통합 E2E도 줄 전환 11 / 69, 숫자 73, 최종 116쪽으로 GREEN이며 p95는
+49.6 / 49.7ms였다.
 
 Draft PR은 [#3945](https://github.com/edwardkim/rhwp/pull/3945)이며 부모는
 [#3944](https://github.com/edwardkim/rhwp/pull/3944), 자식은

--- a/mydocs/working/task_m100_3822_stage2.md
+++ b/mydocs/working/task_m100_3822_stage2.md
@@ -2,19 +2,20 @@
 
 - 이슈: [#3822](https://github.com/edwardkim/rhwp/issues/3822)
 - 브랜치: stack/issue-3822-overlong-token-wrap
-- 최신 기준: upstream/devel ec1b21096
+- 최신 기준: upstream/devel aeb5805cb
 - code candidate: 7d6c5d625
 - 작성일: 2026-08-04
 
 ## 최신 기준 focused 결과
 
-- cargo test renderer::composer::tests --lib: 52 / 52 통과
-- #3822 전용 Latin·숫자·잔여 폭·hanging indent: 4 / 4 통과
+- cargo test renderer::composer::tests --lib: 53 / 53 통과
+- #3822 전용 Latin·한글·숫자·잔여 폭·hanging indent: 5 / 5 통과
 - git diff --check: 통과
 
-최종 검증 뒤 devel이 ec1b21096로 전진했다. composer 파일과 직접 겹치지 않았지만
-typeset 쪽 경계 수정이 실제 문서의 page count에 영향을 줄 수 있어 composer 52 / 52와
-#3822 전용 4건을 다시 실행해 모두 통과했다.
+최종 검증 뒤 devel이 aeb5805cb로 전진했다. composer 파일과 직접 겹치지 않았지만
+typeset 쪽 경계 수정이 실제 문서의 page count에 영향을 줄 수 있어 composer 53 / 53과
+#3822 전용 5건을 다시 실행해 모두 통과했다. 리뷰에서 지적된 한글 무공백 어절도 별도
+회귀로 고정해 Latin·숫자와 같은 prior-break 반복 분할 계약을 확인했다.
 
 ## 기존 실제 문서 증적
 

--- a/mydocs/working/task_m100_3822_stage2.md
+++ b/mydocs/working/task_m100_3822_stage2.md
@@ -1,0 +1,40 @@
+# Task #3822 Stage 2 — 최신 stack 줄바꿈 검증
+
+- 이슈: [#3822](https://github.com/edwardkim/rhwp/issues/3822)
+- 브랜치: stack/issue-3822-overlong-token-wrap
+- 최신 기준: upstream/devel 8d7bc622e
+- code candidate: e4cf29df1
+- 작성일: 2026-08-04
+
+## 최신 기준 focused 결과
+
+- cargo test renderer::composer::tests --lib: 52 / 52 통과
+- #3822 전용 Latin·숫자·잔여 폭·hanging indent: 4 / 4 통과
+- git diff --check: 통과
+
+최종 검증 뒤 추가된 devel 19커밋은 composer 파일과 겹치지 않았다. 8d7bc622e로
+다시 rebase한 최상단에서 composer focused spot-check를 반복한다.
+
+## 기존 실제 문서 증적
+
+2026-08-03 production WASM snapshot에서 다음을 확인했다.
+
+- HWP/HWPX 두 번째 숫자 줄바꿈: 2 / 2
+- line count 5 → 6, caret 665.4 / cell right 672.8, overflow false
+- HWP/HWPX × digits, Latin, 완료 한글→digits 저장·재열기: 6 / 6
+- 실제 IME→공백→두 번의 숫자 wrap: 2 / 2
+- #3822 미적용 control은 숫자 79번째에서 cellOverflowed=true
+
+문자 수와 실제 높이가 충분히 늘어 page count가 115 → 116이 되는 것은 숨은 overflow가
+정상 line으로 복원된 결과다.
+
+## 귀속 정정
+
+기존 integration gate의 advance 상한은 TextRun origin과 bbox가 셀 안에 있는지를 검증했지만
+glyph outline의 실제 가로 비율을 직접 증명하지 않았다. 따라서 다음처럼 분리한다.
+
+- #3822: token 재분할과 overflow 해결
+- #3937: Canvas/SVG 영문·숫자 glyph outline 확대 해결
+
+최신 최상단 stack에서 같은 combined E2E를 한 번 실행해 두 정확성 수정과 #3815 scheduler의
+조합을 확인한다.

--- a/mydocs/working/task_m100_3822_stage2.md
+++ b/mydocs/working/task_m100_3822_stage2.md
@@ -2,8 +2,8 @@
 
 - 이슈: [#3822](https://github.com/edwardkim/rhwp/issues/3822)
 - 브랜치: stack/issue-3822-overlong-token-wrap
-- 최신 기준: upstream/devel 8d7bc622e
-- code candidate: e4cf29df1
+- 최신 기준: upstream/devel ec1b21096
+- code candidate: 7d6c5d625
 - 작성일: 2026-08-04
 
 ## 최신 기준 focused 결과
@@ -12,8 +12,9 @@
 - #3822 전용 Latin·숫자·잔여 폭·hanging indent: 4 / 4 통과
 - git diff --check: 통과
 
-최종 검증 뒤 추가된 devel 19커밋은 composer 파일과 겹치지 않았다. 8d7bc622e로
-다시 rebase한 최상단에서 composer focused spot-check를 반복한다.
+최종 검증 뒤 devel이 ec1b21096로 전진했다. composer 파일과 직접 겹치지 않았지만
+typeset 쪽 경계 수정이 실제 문서의 page count에 영향을 줄 수 있어 composer 52 / 52와
+#3822 전용 4건을 다시 실행해 모두 통과했다.
 
 ## 기존 실제 문서 증적
 
@@ -36,5 +37,10 @@ glyph outline의 실제 가로 비율을 직접 증명하지 않았다. 따라�
 - #3822: token 재분할과 overflow 해결
 - #3937: Canvas/SVG 영문·숫자 glyph outline 확대 해결
 
-최신 최상단 stack에서 같은 combined E2E를 한 번 실행해 두 정확성 수정과 #3815 scheduler의
-조합을 확인한다.
+최신 최상단 stack의 production WASM에서 같은 combined E2E를 재실행했다. HWP/HWPX 모두
+숫자 줄 전환 11 / 69, 최종 숫자 73, 최종 쪽수 116과 synchronous flush 0으로 GREEN이었다.
+두 정확성 수정과 #3815 scheduler의 조합이 최신 typeset 변경 뒤에도 유지됐다.
+
+Draft PR은 [#3945](https://github.com/edwardkim/rhwp/pull/3945)이며 부모는
+[#3944](https://github.com/edwardkim/rhwp/pull/3944), 자식은
+[#3946](https://github.com/edwardkim/rhwp/pull/3946)이다.

--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -593,6 +593,10 @@ fn condensed_line_width_hwp(width_hwp: i32, space_savings_hwp: i32) -> i32 {
     width_hwp - space_savings_hwp
 }
 
+// 한컴은 HWPUNIT 정수 양자화 시 미세한 반올림 차이를 허용한다.
+// 15 HU 이내의 초과는 줄에 포함한다.
+const LINE_BREAK_TOLERANCE: i32 = 15;
+
 fn condense_fit_can_pull_next_token(
     current_width_hwp: i32,
     current_space_savings_hwp: i32,
@@ -607,6 +611,28 @@ fn condense_fit_can_pull_next_token(
     // line. The p03 PDF preface is sensitive to that distinction.
     let min_remaining_hwp = to_hwp((max_font_size * 2.5).max(20.0));
     remaining_hwp >= min_remaining_hwp
+}
+
+fn text_token_fits_line_hwp(
+    current_width_hwp: i32,
+    token_width_hwp: i32,
+    space_savings_hwp: i32,
+    effective_width_hwp: i32,
+    max_font_size: f64,
+) -> bool {
+    let natural_candidate = current_width_hwp + token_width_hwp;
+    let condensed_candidate = condensed_line_width_hwp(natural_candidate, space_savings_hwp);
+    let needs_condense_to_fit = natural_candidate > effective_width_hwp + LINE_BREAK_TOLERANCE
+        && condensed_candidate <= effective_width_hwp + LINE_BREAK_TOLERANCE;
+    let condense_pull_allowed = !needs_condense_to_fit
+        || condense_fit_can_pull_next_token(
+            current_width_hwp,
+            space_savings_hwp,
+            effective_width_hwp,
+            max_font_size,
+        );
+
+    condensed_candidate <= effective_width_hwp + LINE_BREAK_TOLERANCE && condense_pull_allowed
 }
 
 /// 토큰을 줄에 배치하는 Greedy 알고리즘
@@ -786,28 +812,16 @@ fn fill_lines(
                         fs_at_last_break = line_max_fs;
                     }
                 }
-                // 한컴은 HWPUNIT 정수 양자화 시 미세한 반올림 차이를 허용
-                // 12 HU(~0.17mm) 이내의 초과는 줄에 포함 (경험적 허용 오차)
-                const LINE_BREAK_TOLERANCE: i32 = 15;
                 let effective_width = eff_w(is_first_line);
-                let natural_candidate = lw + w_hwp;
-                let condensed_candidate =
-                    condensed_line_width_hwp(natural_candidate, line_space_savings);
-                let needs_condense_to_fit = natural_candidate
-                    > effective_width + LINE_BREAK_TOLERANCE
-                    && condensed_candidate <= effective_width + LINE_BREAK_TOLERANCE;
-                let condense_pull_allowed = !needs_condense_to_fit
-                    || condense_fit_can_pull_next_token(
-                        lw,
-                        line_space_savings,
-                        effective_width,
-                        *max_font_size,
-                    );
-                if condensed_candidate > effective_width + LINE_BREAK_TOLERANCE
-                    || !condense_pull_allowed
-                {
+                if !text_token_fits_line_hwp(
+                    lw,
+                    w_hwp,
+                    line_space_savings,
+                    effective_width,
+                    *max_font_size,
+                ) {
                     if *start_idx > line_start_idx {
-                        if let Some(_) = last_break_token_idx {
+                        if let Some(break_token_idx) = last_break_token_idx {
                             results.push(LineBreakResult {
                                 start_idx: line_start_idx,
                                 end_idx: last_break_char_idx,
@@ -826,11 +840,31 @@ fn fill_lines(
                                 next_start,
                                 condense_min_space,
                             );
-                            lw += w_hwp;
                             line_max_fs = *max_font_size;
                             is_first_line = false;
                             last_break_token_idx = None;
-                            continue;
+
+                            // 현재 단일 CJK/한글 토큰 자체가 break point였던 기존 경로는
+                            // 이미 위 결과에 포함됐으므로 동작을 바꾸지 않는다.
+                            if break_token_idx == ti {
+                                lw += w_hwp;
+                                continue;
+                            }
+
+                            // [#3822] 이전 break 뒤로 옮긴 현재 토큰이 새 줄에도
+                            // 들어가는지 다시 확인한다. 종전에는 토큰 전체 폭을 무조건
+                            // 더하고 continue하여, 긴 영문·숫자 토큰의 글자 단위 fallback을
+                            // 건너뛰었다.
+                            if text_token_fits_line_hwp(
+                                lw,
+                                w_hwp,
+                                line_space_savings,
+                                eff_w(false),
+                                *max_font_size,
+                            ) {
+                                lw += w_hwp;
+                                continue;
+                            }
                         }
                     }
                     // 토큰에 저장된 개별 글자 폭을 HWPUNIT로 변환

--- a/src/renderer/composer/tests.rs
+++ b/src/renderer/composer/tests.rs
@@ -863,6 +863,73 @@ fn test_reflow_english_word_wrap() {
     assert_eq!(para.line_segs[1].text_start, 6); // "World" 시작
 }
 
+fn reflow_after_prior_break_line_starts(text: &str, indent_px: f64) -> Vec<u32> {
+    let mut styles = make_styles_with_font_size(16.0);
+    styles.para_styles[0].indent = indent_px;
+    let mut utf16_len = 0u32;
+    let char_offsets = text
+        .chars()
+        .map(|ch| {
+            let offset = utf16_len;
+            utf16_len += ch.len_utf16() as u32;
+            offset
+        })
+        .collect();
+    let mut para = Paragraph {
+        text: text.to_string(),
+        char_offsets,
+        char_count: utf16_len + 1,
+        char_shapes: vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 0,
+        }],
+        line_segs: vec![LineSeg {
+            text_start: 0,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    reflow_line_segs(&mut para, 40.0, &styles, 96.0);
+    para.line_segs.iter().map(|seg| seg.text_start).collect()
+}
+
+#[test]
+fn issue_3822_reflow_overlong_latin_token_after_prior_break() {
+    assert_eq!(
+        reflow_after_prior_break_line_starts("가 ABCDEFGHIJKL", 0.0),
+        vec![0, 2, 7, 12],
+        "이전 공백 뒤 긴 Latin 토큰도 새 줄 폭을 넘을 때 계속 글자 단위로 분할해야 함"
+    );
+}
+
+#[test]
+fn issue_3822_reflow_overlong_digit_token_after_prior_break() {
+    assert_eq!(
+        reflow_after_prior_break_line_starts("A 123456789012", 0.0),
+        vec![0, 2, 7, 12],
+        "이전 공백 뒤 긴 숫자 토큰도 새 줄 폭을 넘을 때 계속 글자 단위로 분할해야 함"
+    );
+}
+
+#[test]
+fn issue_3822_reflow_overlong_digit_preserves_nonempty_post_break_width() {
+    assert_eq!(
+        reflow_after_prior_break_line_starts("A 가.123456789012", 0.0),
+        vec![0, 2, 6, 11],
+        "이전 break 뒤 잔여 글자 폭을 보존한 상태에서 긴 숫자를 분할해야 함"
+    );
+}
+
+#[test]
+fn issue_3822_reflow_overlong_token_uses_subsequent_line_indent_width() {
+    assert_eq!(
+        reflow_after_prior_break_line_starts("A ABCDEFGHIJKL", -8.0),
+        vec![0, 2, 6, 10],
+        "첫 줄 뒤에는 hanging indent가 적용된 후속 줄 폭으로 긴 토큰을 분할해야 함"
+    );
+}
+
 #[test]
 fn test_reflow_condense_shrinks_measured_space_width() {
     let mut styles = make_styles_with_font_size(10.0);

--- a/src/renderer/composer/tests.rs
+++ b/src/renderer/composer/tests.rs
@@ -904,6 +904,15 @@ fn issue_3822_reflow_overlong_latin_token_after_prior_break() {
 }
 
 #[test]
+fn issue_3822_reflow_overlong_korean_word_after_prior_break() {
+    assert_eq!(
+        reflow_after_prior_break_line_starts("A 가나다라마바사", 0.0),
+        vec![0, 2, 4, 6, 8],
+        "이전 공백 뒤 긴 한글 어절도 새 줄 폭을 넘을 때 계속 글자 단위로 분할해야 함"
+    );
+}
+
+#[test]
 fn issue_3822_reflow_overlong_digit_token_after_prior_break() {
     assert_eq!(
         reflow_after_prior_break_line_starts("A 123456789012", 0.0),


### PR DESCRIPTION
> **Stack layer:** 2 / 3
> **Parent:** [#3944](https://github.com/edwardkim/rhwp/pull/3944) — #3937 browser glyph-width fix
> **Branch:** `stack/issue-3822-overlong-token-wrap`
> **Next layer:** [#3946](https://github.com/edwardkim/rhwp/pull/3946) — #3815 pagination coalescing
> **Ultimate base:** `devel@cf5d462dc`

## 변경 요약

표 셀에서 앞선 줄바꿈 지점 뒤에 놓인 긴 무공백 영문·숫자·한글 어절이 새 줄로 이동한 후 더 이상 분할되지 않는 문제를 수정합니다.

기존 `fill_lines()`는 이전 break point에서 줄을 확정한 뒤 현재 token 폭을 새 줄에 더하고 즉시 `continue`했습니다. 이 때문에 현재 token 자체가 새 줄보다 긴 경우에도 `char_level_break_hwp` fallback에 도달하지 못했습니다.

수정 후에는 현재 token을 후속 줄의 실제 폭으로 다시 평가하고, 여전히 들어가지 않으면 기존 문자 단위 fallback을 실행합니다.

## 이 레이어의 변경

- 초기 배치와 prior-break 뒤 재평가에 동일한 token-fit 판정 사용
- 이전 break 뒤 현재 token을 제외한 새 줄 base width 보존
- token이 후속 줄에도 들어가지 않으면 문자 단위 fallback 실행
- token 폭 중복 합산 방지
- 후속 줄 hanging indent 적용
- condense와 HWPUNIT 허용 오차 유지
- current-token CJK/Hangul 특수 경로 유지
- UTF-16 line start를 검증하는 Latin·한글·숫자 회귀 테스트 추가

## Stack

| Layer | PR | 역할 |
| ---: | --- | --- |
| 1 | [#3944](https://github.com/edwardkim/rhwp/pull/3944) | Canvas2D/SVG 배분 간격과 glyph 폭 분리 |
| 2 | **[#3945 (이 PR)](https://github.com/edwardkim/rhwp/pull/3945)** | prior break 뒤 긴 무공백 token 재분할 |
| 3 | [#3946](https://github.com/edwardkim/rhwp/pull/3946) | deferred pagination coalescing과 통합 E2E |

이 composer 변경은 #3944의 glyph 렌더링 변경과 코드상 독립적입니다. 최상단 #3946 E2E가 두 정확성 수정 위에서 실행된 검증 순서를 보존합니다.

## 검증

- [x] latest-base composer tests: `53/53`
- [x] #3822 focused regression: `5/5`
  - Latin overlong token
  - Korean overlong word
  - digit overlong token
  - prior break 뒤 잔여 폭
  - hanging indent 후속 줄 폭
- [x] production WASM build
- [x] HWP/HWPX 연속 두 번째 숫자 줄바꿈: `2/2`
  - line count `5 → 6 → 7`
  - 숫자 줄 전환 `11 / 69`
  - overflow 없이 최종 숫자 `73`
- [x] HWP/HWPX × digits/Latin/완료 한글→digits 저장·재열기: `6/6`
- [x] 실제 IME→공백→두 번의 숫자 wrap: `2/2`
- [x] #3822 미적용 control에서 `cellOverflowed=true` 재현
- [x] 최종 쪽수 `116`, synchronous pagination flush `0`
- [x] collaborator review 기록: `mydocs/pr/archives/pr_3945_review.md`
- [x] `git diff --check`
- [x] GitHub Actions (최신 head 통과)

## 실제 문서 결과

| 형식 | 입력 | 최종 line count | caret x / cell right | overflow |
| --- | --- | ---: | ---: | --- |
| HWP | digits 136자 | 6 | `665.4 / 672.8` | false |
| HWPX | digits 136자 | 6 | `665.4 / 672.8` | false |

영문·숫자·완료 한글→숫자 입력은 저장 후 재열기에서도 text, line layout과 page count가 일치했습니다. 최신 stack smoke에서는 실제 IME 뒤 73자의 숫자가 두 번 줄바꿈되는 것을 다시 확인했습니다.

## Known limits

- 실제 콘텐츠 높이가 충분히 증가하면 page count가 `115 → 116`으로 바뀌는 것이 정상입니다. 기존 115쪽 고정 결과는 넘친 글자가 마지막 줄에 숨은 결과였습니다.
- 영문·숫자 glyph 윤곽 확대는 아래 [#3944](https://github.com/edwardkim/rhwp/pull/3944) 레이어의 별도 renderer 결함입니다.
- pagination scheduler와 pending 입력 지연은 변경하지 않습니다.
- 기존 단일 CJK/한글 condense 경로의 폭 재계상과 char-level fallback의 공백 절감량 초기화는 변경하지 않습니다.
- 탭 뒤 폭 재계산, post-break 최대 글꼴 크기 추적과 저장된 부정합 `LINE_SEG` 재합성은 범위가 아닙니다.
- CellFlowTree, PageCheckpoint와 DisplaySnapshot은 #3743 후속 범위입니다.

Closes #3822

Related: #3815, #3743  
Distinct from: #1838
