### PR TITLE
perf(studio): coalesce latest-revision pagination starts (#3815)

### DIFF
--- a/mydocs/orders/20260804.md
+++ b/mydocs/orders/20260804.md
@@ -42,10 +42,13 @@
 ## #3815 — latest-revision pagination start coalescing
 
 - #3822 위 최상단 branch에 scheduler 제품 변경과 실제 IME·반복 줄바꿈 E2E를 올렸다.
-- latest devel 기준 focused 23건, Studio 763건, TypeScript와 production WASM을 통과했다.
+- 최신 upstream/devel ec1b21096 기준 focused 23건, TypeScript와 production WASM을
+  다시 통과했다. Studio 전체 763건은 upstream에 Studio 파일 변경이 없어 기존 결과를 보존했다.
 - HWP/HWPX continuous-only smoke는 wraps 11 / 69, digits 73으로 모두 GREEN이었다.
-  pending operation p95 49.3ms / 50.6ms는 기존 smoke 대비 ±1.8%라 전체 3회 계측은 반복하지 않았다.
-- 세 Draft PR 본문을 먼저 공유하고 사용자 승인 전에는 push나 PR 생성을 하지 않는다.
+  pending operation p95 50.1ms / 50.9ms는 기존 smoke 대비 -0.2% / +2.4%이며,
+  최종 쪽수 116, revision 132 / 132와 synchronous flush 0을 확인했다.
+- Draft PR [#3946](https://github.com/edwardkim/rhwp/pull/3946)를 GitHub Stack
+  #3947의 최상단 레이어로 게시했다.
 
 ## PR #3831 - Studio 표 나누기·붙이기 검토
 

--- a/mydocs/orders/20260804.md
+++ b/mydocs/orders/20260804.md
@@ -39,6 +39,14 @@
 - Draft PR [#3945](https://github.com/edwardkim/rhwp/pull/3945)를 GitHub Stack
   #3947의 두 번째 레이어로 게시했다.
 
+## #3815 — latest-revision pagination start coalescing
+
+- #3822 위 최상단 branch에 scheduler 제품 변경과 실제 IME·반복 줄바꿈 E2E를 올렸다.
+- latest devel 기준 focused 23건, Studio 763건, TypeScript와 production WASM을 통과했다.
+- HWP/HWPX continuous-only smoke는 wraps 11 / 69, digits 73으로 모두 GREEN이었다.
+  pending operation p95 49.3ms / 50.6ms는 기존 smoke 대비 ±1.8%라 전체 3회 계측은 반복하지 않았다.
+- 세 Draft PR 본문을 먼저 공유하고 사용자 승인 전에는 push나 PR 생성을 하지 않는다.
+
 ## PR #3831 - Studio 표 나누기·붙이기 검토
 
 - [PR #3831](https://github.com/edwardkim/rhwp/pull/3831)을

--- a/mydocs/plans/task_m100_3815.md
+++ b/mydocs/plans/task_m100_3815.md
@@ -1,0 +1,49 @@
+# 수행계획서 — task_m100_3815
+
+- **이슈**: [#3815](https://github.com/edwardkim/rhwp/issues/3815)
+- **브랜치**: stack/issue-3815-pagination-coalescing
+- **부모 레이어**: stack/issue-3822-overlong-token-wrap
+- **최신 기준**: upstream/devel 8d7bc622e
+- **작성일**: 2026-08-04
+- **절차 상태**: 구현·최신 기준 제한 검증 완료, Draft PR 본문 승인 대기
+
+## 문제
+
+115쪽 거대 표 셀 flow 입력에서 beginDeferredPagination이 input dispatch 호출 스택 안에서
+실행되고, 후속 입력마다 active job을 취소한 뒤 처음부터 다시 시작한다. stable tail은 빠르지만
+pagination pending 구간에서 불필요한 시작·폐기 비용이 입력 지연을 키운다.
+
+## 설계
+
+- runner 상태를 idle, begin-scheduled, stepping으로 분리한다.
+- 최초 begin은 입력이 연장하지 않는 100ms target에서 input stack 밖에 실행한다.
+- active restart는 마지막 요청 기준 200ms trailing window로 합친다.
+- begin 뒤 첫 fragment는 즉시 전진하고 다음 step 한 번만 25ms settle gap을 둔다.
+- generation guard로 superseded callback, result와 publication을 차단한다.
+- scheduled begin과 active step에 같은 cancel, flush, save, print, navigation barrier를 적용한다.
+
+## Stack 책임 경계
+
+- #3937: Canvas/SVG 배분 간격과 glyph 폭
+- #3822: prior break 뒤 긴 token 반복 줄바꿈
+- #3815: Studio deferred pagination 시작 coalescing
+
+#3815 제품 코드는 하위 두 renderer 변경과 독립적이지만, 실제 IME→긴 숫자 입력 E2E는
+세 변경이 모두 포함된 최상단 revision에서 실행한다.
+
+## 비범위
+
+- pending 중 약 49~51ms exact cursor query
+- Enter pre-navigation flush
+- MessageChannel 또는 scheduler.postTask backend 교체
+- fragment budget 변경
+- CellFlowTree, PageCheckpoint, DisplaySnapshot과 복잡 HWP flow 확대
+- 저장·인쇄 full pagination barrier
+
+## 완료 기준
+
+- input dispatch와 deferred begin이 겹치지 않는다.
+- 반복 요청이 latest revision begin 하나로 합쳐진다.
+- superseded publication과 동기 flow flush가 없다.
+- HWP/HWPX 연속 입력에서 IME, 두 번의 wrap, caret와 visible ink가 같은 revision이다.
+- 최신 smoke가 기존 3회 측정의 ±10% 안이면 전체 계측을 반복하지 않는다.

--- a/mydocs/plans/task_m100_3815.md
+++ b/mydocs/plans/task_m100_3815.md
@@ -3,7 +3,7 @@
 - **이슈**: [#3815](https://github.com/edwardkim/rhwp/issues/3815)
 - **브랜치**: stack/issue-3815-pagination-coalescing
 - **부모 레이어**: stack/issue-3822-overlong-token-wrap
-- **최신 기준**: upstream/devel aeb5805cb
+- **최신 기준**: upstream/devel cf5d462dc
 - **작성일**: 2026-08-04
 - **절차 상태**: 구현·최신 기준 제한 검증 완료, Draft PR #3946 게시
 

--- a/mydocs/plans/task_m100_3815.md
+++ b/mydocs/plans/task_m100_3815.md
@@ -3,9 +3,9 @@
 - **이슈**: [#3815](https://github.com/edwardkim/rhwp/issues/3815)
 - **브랜치**: stack/issue-3815-pagination-coalescing
 - **부모 레이어**: stack/issue-3822-overlong-token-wrap
-- **최신 기준**: upstream/devel 8d7bc622e
+- **최신 기준**: upstream/devel ec1b21096
 - **작성일**: 2026-08-04
-- **절차 상태**: 구현·최신 기준 제한 검증 완료, Draft PR 본문 승인 대기
+- **절차 상태**: 구현·최신 기준 제한 검증 완료, Draft PR #3946 게시
 
 ## 문제
 

--- a/mydocs/plans/task_m100_3815.md
+++ b/mydocs/plans/task_m100_3815.md
@@ -3,7 +3,7 @@
 - **이슈**: [#3815](https://github.com/edwardkim/rhwp/issues/3815)
 - **브랜치**: stack/issue-3815-pagination-coalescing
 - **부모 레이어**: stack/issue-3822-overlong-token-wrap
-- **최신 기준**: upstream/devel ec1b21096
+- **최신 기준**: upstream/devel aeb5805cb
 - **작성일**: 2026-08-04
 - **절차 상태**: 구현·최신 기준 제한 검증 완료, Draft PR #3946 게시
 
@@ -39,6 +39,13 @@ pagination pending 구간에서 불필요한 시작·폐기 비용이 입력 지
 - fragment budget 변경
 - CellFlowTree, PageCheckpoint, DisplaySnapshot과 복잡 HWP flow 확대
 - 저장·인쇄 full pagination barrier
+
+## 알려진 제한
+
+200ms보다 짧은 간격의 입력이 계속되면 active restart timer가 재예약되므로 pagination step과
+쪽수 게시가 일시 정지한다. 입력이 200ms 이상 쉬면 최신 revision에서 다시 시작하며,
+pagination 완료 뒤 stable-tail fast path로 복귀한다. pending 상태에서는 120ms idle flush도
+이를 선점하지 않는다.
 
 ## 완료 기준
 

--- a/mydocs/pr/archives/pr_3946_review.md
+++ b/mydocs/pr/archives/pr_3946_review.md
@@ -1,0 +1,195 @@
+---
+kind: pr_review
+status: local-validation-passed
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-04
+---
+
+# PR #3946 검토 — latest-revision deferred pagination 시작 병합
+
+## 검토 경로
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, local_validation.md,
+           visual_fixture_evidence.md, multi_pr_update_branch.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+                  collaborator_self_merge.md, intake_and_review.md,
+                  local_validation.md, visual_fixture_evidence.md,
+                  multi_pr_update_branch.md
+remote head before correction: 07e775092d1c08a69a8b71b523a0648eb0d6e7a5
+reviewed local layer head: f5c423a93c25d84c291e17a0b7462b29ec153585
+parent layer head: 8a2a6b65052130d6b3849565db0662c71a9105f7
+upstream/devel: aeb5805cb93c92b8c44036f4c1fe1f2df420119f
+```
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#3946](https://github.com/edwardkim/rhwp/pull/3946) |
+| 작성자 | `postmelee` (collaborator self-merge) |
+| Stack 위치 | 3 / 3 |
+| 대상 / head | `stack/issue-3822-overlong-token-wrap` / `stack/issue-3815-pagination-coalescing` |
+| 작성 시점 원격 상태 | draft, `MERGEABLE`; 보정 restack·push 뒤 재확인 필요 |
+| 보정 전 원격 head | `07e775092d1c08a69a8b71b523a0648eb0d6e7a5` |
+| 리뷰 보정 layer head | `f5c423a93c25d84c291e17a0b7462b29ec153585` |
+| 부모 레이어 head | `8a2a6b65052130d6b3849565db0662c71a9105f7` |
+| 최신 기준 | `upstream/devel` `aeb5805cb93c92b8c44036f4c1fe1f2df420119f` |
+| review 문서 작성 전 PR 고유 규모 | 10 files, +895 / -80 |
+| 관련 issue | [#3815](https://github.com/edwardkim/rhwp/issues/3815) |
+
+draft, mergeability, head SHA와 CI는 변할 수 있는 작성 시점 참고값이다. 최종 merge 조건은 최신 PR head의
+required CI 통과와 작업지시자 승인이다. 사용자 지시에 따라 reviewer request, ready 전환과 merge는 이
+review commit에서 수행하지 않는다.
+
+## 변경 범위와 목적
+
+115쪽 거대 표 셀에서 flow를 바꾸는 입력마다 `beginDeferredPagination()`이 input dispatch 호출 스택
+안에서 실행되고 진행 중 job을 즉시 취소·재시작하던 비용을 줄인다.
+
+`DeferredPaginationRunner`를 `idle`, `begin-scheduled`, `stepping` 상태로 나누고 다음 계약을 적용한다.
+
+- 최초 begin은 입력 paint 기회를 확보하는 고정 100ms target에서 input stack 밖에 실행한다.
+- 최초 timer 대기 중 요청은 target을 연장하지 않고 begin 시점의 최신 descriptor를 쓴다.
+- 전진 중이거나 restart 대기 중인 job은 마지막 요청 뒤 200ms trailing window로 합친다.
+- begin 뒤 첫 fragment는 일반 cadence에서 전진하고 다음 step 한 번만 25ms settle gap을 둔다.
+- generation guard가 취소·대체된 begin, step, settle callback과 stale publication을 차단한다.
+- queued begin도 `hasPendingWork()`로 판단해 navigation, blur, 저장·인쇄 barrier가 회수한다.
+- deferred job이 있으면 120ms idle flush가 같은 작업을 동기로 되풀이하지 않는다.
+
+하위 Stack의 #3944는 Canvas/SVG glyph 폭, #3945는 prior-break 긴 token 반복 줄바꿈, #3946은 Studio
+pagination 시작 병합을 담당한다. scheduler 제품 변경은 하위 renderer와 독립적이지만 실제 IME 뒤 긴
+숫자의 두 번째 줄바꿈은 세 레이어가 모두 있는 최상단 revision에서 검증한다.
+
+## 리뷰 지적 대응
+
+[리뷰 코멘트](https://github.com/edwardkim/rhwp/pull/3946#issuecomment-5177715130)를 다음처럼 검토하고
+보정했다.
+
+### 1. 지속 입력 중 pagination 정지의 Known limit
+
+200ms보다 짧은 간격의 입력이 계속되면 active restart timer가 반복 재예약된다. 이 구간에서는
+pagination step과 공개 쪽수 갱신이 일시 정지하고 `hasPendingWork()` 때문에 120ms idle flush도
+선점하지 않는다. 입력이 200ms 이상 쉬면 최신 revision에서 다시 시작하며 완료 뒤 stable-tail fast
+path로 복귀한다. 이 사용자 관측 결과를 계획서와 Stage 5 기록에 명시했다.
+
+pending 중 exact cursor query 약 49–51ms, Enter 전 navigation flush와 장기 대형 셀 아키텍처는 계속
+이번 PR의 비범위다.
+
+### 2. E2E MANIFEST·진입점·증적 성격
+
+`issue-2214-page-local-repaint.test.mjs`의 MANIFEST 행을 #2214 focused 회귀와 #3815 Stack 통합
+회귀를 함께 설명하도록 갱신했다. HWP/HWPX fixture, `e2e:issue-2214`, `e2e:issue-3815`, CI의
+`node --check`, 로컬 production WASM·Chrome 증적을 구분했다. `rhwp-studio/package.json`에는 다음
+재현 진입점을 추가했다.
+
+```text
+npm run e2e:issue-3815
+```
+
+파일 머리말에도 `--continuous-only`가 #3937/#3822 위의 #3815 로컬 통합 gate이고 CI는 구문만
+검사한다고 기록했다. HWP/HWPX 2 / 2, p95, 115 → 116, revision 일치와 synchronous flush 0은
+GitHub Actions 브라우저 결과가 아니라 로컬 production WASM + Chrome 근거다.
+
+최신 devel에 존재했지만 MANIFEST에 빠져 있던 #3682 진단 프로브 행도 등록했다. 이는 새 MANIFEST
+검사 정합성 보완이며 #3682 제품 동작은 바꾸지 않는다.
+
+### 3. E2E 파일을 분리하지 않은 이유
+
+`--continuous-only`는 #2214 fixture target, 문서 로딩, trace 설치·복구, cursor/tree snapshot,
+composited canvas capture와 pagination 완료 판정을 그대로 사용한다. 시나리오만 옮기면 helper를 대량
+복제하거나 공용 기반을 별도 리팩터링해야 해 이번 scheduler 보정의 위험과 범위를 넓힌다.
+
+대신 같은 파일 안에서 모드를 분리하고 전용 npm script·MANIFEST 용도·header를 추가해 발견 가능성과
+수명 차이를 기록했다. 계약이 독립 확대되거나 공용 helper 추출을 계획할 때 분리를 다시 검토한다.
+
+### 4. `isActive()`와 delay 값 회귀 유지
+
+`hasPendingWork()`는 production flush·restart 판단에 쓰며 queued begin과 stepping을 모두 포함한다.
+`isActive()`는 stepping만 관찰해 queued begin과 실제 core 전진을 단위 테스트에서 구분한다. 의미가
+달라 테스트 관찰 API로 유지했다.
+
+100ms 최초 target, 200ms restart window, 25ms post-first-step gap은 성능·UX 측정과 Known limit을
+정의한다. 값이 바뀌면 근거를 다시 검토해야 하므로 소스 회귀가 이름과 값을 함께 고정하도록 유지했다.
+runner 단위 테스트는 실제 예약 delay와 상태별 적용 횟수를 별도로 검증한다.
+
+### 5. cancel·publication 불변식과 절차 기록
+
+`requestStart()`는 queued begin 전에 기존 core job을 취소한다. dequeue된 stale begin, active restart 뒤
+stale step, settle callback, begin·step 예외의 단일 fallback을 단위 테스트가 고정한다. pending begin과
+step은 공개 쪽수를 바꾸지 않고 complete에서만 115 → 116을 한 번 게시한다.
+
+계획서·Stage 5, E2E MANIFEST/header/npm 진입점을 보정하고 이 review 문서를 추가했다. 보정이 단일
+문서·E2E 배선 commit으로 추적 가능해 별도 `review_impl` 문서는 만들지 않는다.
+
+## 검증
+
+최신 부모 위의 리뷰 보정 layer head에서 다음 제한 검증을 통과했다.
+
+| 검증 | 결과 |
+| --- | --- |
+| `node --test tests/deferred-pagination-runner.test.ts tests/input-edit-invalidation.test.ts` | 23 passed / 0 failed |
+| `cd rhwp-studio && npx tsc --noEmit` | 통과 |
+| `python3 scripts/check_e2e_manifest.py` | tracked 81 / manifest 81, 이상 없음 |
+| `node --check rhwp-studio/e2e/issue-2214-page-local-repaint.test.mjs` | 통과 |
+| `git diff --check` | 통과 |
+
+Stack 전체 Studio unit 763 / 763도 이전 최신 기준 검증에서 통과했다. 이번 correction은 계획·작업 기록,
+MANIFEST, E2E header와 npm 진입점만 바꾸며 scheduler 제품 코드는 변경하지 않는다.
+
+## production WASM + Chrome 증적
+
+최신 devel 기준 production WASM과 새 headless Chrome에서 HWP/HWPX `--continuous-only`를 각 한 번
+실행했다.
+
+| 형식 | 숫자 줄 전환 | 최종 숫자 | pending operation p95 | 최종 쪽수 | 결과 |
+| --- | --- | ---: | ---: | ---: | --- |
+| HWP | 11 / 69 | 73 | 50.1ms | 116 | GREEN |
+| HWPX | 11 / 69 | 73 | 50.9ms | 116 | GREEN |
+
+두 형식 모두 IME `ㅎ → 하 → 한` 뒤 긴 숫자가 pending 중 두 번 줄바꿈됐다. caret, model text,
+visible ink와 layer tree가 최신 revision으로 일치했고 latest begin/final step revision은 132 / 132,
+superseded publication과 synchronous flow flush는 0이었다. 이전 smoke의 50.2ms / 49.7ms 대비 -0.2% /
++2.4%로 ±10% gate 안이어서 형식별 current·80ms·250ms 3회 전체 측정은 반복하지 않았다.
+
+이 수치는 로컬 production WASM + Chrome의 역사·회귀 근거다. Render Diff CI는 E2E의
+`node --check`만 수행하므로 최신 PR head CI와 별도로 해석한다.
+
+## 시각·fixture 판정
+
+시나리오는 composited canvas에서 IME 확정 glyph, pending·complete 숫자 suffix, 셀 bounds와 line band를
+검증한다. 부모 #3944에 보존한 대표 asset은 HWP에서 두 번째 숫자 줄바꿈과 최신 visible ink를 보여준다.
+
+- `mydocs/pr/assets/pr_3944_issue1949_combined_hwp_final.png`
+- SHA-256 `9329c26e6f4ce7d9a1e123928e360f94612e84ef2ecc07f10ff578dfb2fc33d2`
+
+이번 correction은 renderer, layout, paint, sample과 golden을 바꾸지 않는다. 최신 PR head에서는 Render
+Diff와 Canvas visual diff가 다시 통과해야 한다.
+
+![PR 3946 combined HWP final](../assets/pr_3944_issue1949_combined_hwp_final.png)
+
+## 위험과 후속 조건
+
+- 200ms보다 짧은 입력 버스트 중 pagination step과 공개 쪽수 갱신이 멈춘다. 200ms 이상 쉬면 재개된다.
+- pending operation 약 49–51ms의 exact cursor query는 이번 scheduler PR의 비범위다.
+- Enter 전 navigation flush, 저장·인쇄 full pagination barrier는 정확성 경계로 유지한다.
+- CellFlowTree, 영속 PageCheckpoint, viewport DisplaySnapshot과 복잡 HWP flow 확대는 #3743 후속이다.
+- E2E는 #2214 helper에 결합돼 있다. 시나리오 확대나 공용 helper 추출 시 독립 파일을 재검토한다.
+- `mydocs/orders/20260804.md`는 세 레이어가 순서대로 확장한다. devel 변경 시 상위 레이어를 restack한다.
+
+## Stack merge 순서와 최종 조건
+
+1. #3944를 `devel`에 merge한다.
+2. #3945 base가 `devel`로 재지정된 뒤 최신 #3945 head의 CI와 mergeability를 다시 확인한다.
+3. #3945를 merge한다.
+4. #3946 base가 `devel`로 재지정된 뒤 최신 #3946 head의 CI, Render Diff, CodeQL과 mergeability를
+   다시 확인한다.
+5. 모든 최신-head gate가 성공하고 작업지시자가 승인한 뒤에만 #3946을 ready/merge한다.
+
+이 PR의 통합 E2E는 세 레이어를 한 revision에서 함께 검증하는 근거이므로 중간 레이어를 건너뛰거나
+순서를 바꾸지 않는다.
+
+**현재 권고: 보정 restack·push 뒤 최신 head CI 대기.** scheduler 구현과 로컬 제한 검증은 통과했다.
+최신 head의 GitHub Actions, Render Diff와 CodeQL이 모두 성공하고 작업지시자가 승인하면 collaborator
+self-merge 후보로 판단할 수 있다.

--- a/mydocs/pr/archives/pr_3946_review.md
+++ b/mydocs/pr/archives/pr_3946_review.md
@@ -145,13 +145,13 @@ MANIFEST, E2E header와 npm 진입점만 바꾸며 scheduler 제품 코드는 �
 
 | 형식 | 숫자 줄 전환 | 최종 숫자 | pending operation p95 | 최종 쪽수 | 결과 |
 | --- | --- | ---: | ---: | ---: | --- |
-| HWP | 11 / 69 | 73 | 50.1ms | 116 | GREEN |
-| HWPX | 11 / 69 | 73 | 50.9ms | 116 | GREEN |
+| HWP | 11 / 69 | 73 | 49.0ms | 116 | GREEN |
+| HWPX | 11 / 69 | 73 | 49.2ms | 116 | GREEN |
 
 두 형식 모두 IME `ㅎ → 하 → 한` 뒤 긴 숫자가 pending 중 두 번 줄바꿈됐다. caret, model text,
 visible ink와 layer tree가 최신 revision으로 일치했고 latest begin/final step revision은 132 / 132,
-superseded publication과 synchronous flow flush는 0이었다. 이전 smoke의 50.2ms / 49.7ms 대비 -0.2% /
-+2.4%로 ±10% gate 안이어서 형식별 current·80ms·250ms 3회 전체 측정은 반복하지 않았다.
+superseded publication과 synchronous flow flush는 0이었다. 이전 smoke의 50.2ms / 49.7ms 대비 -2.4% /
+-1.0%로 ±10% gate 안이어서 형식별 current·80ms·250ms 3회 전체 측정은 반복하지 않았다.
 
 이 수치는 로컬 production WASM + Chrome의 역사·회귀 근거다. Render Diff CI는 E2E의
 `node --check`만 수행하므로 최신 PR head CI와 별도로 해석한다.

--- a/mydocs/pr/archives/pr_3946_review.md
+++ b/mydocs/pr/archives/pr_3946_review.md
@@ -18,9 +18,9 @@ loaded documents: pr_review_workflow.md, pr_review/README.md,
                   local_validation.md, visual_fixture_evidence.md,
                   multi_pr_update_branch.md
 remote head before correction: 07e775092d1c08a69a8b71b523a0648eb0d6e7a5
-reviewed local layer head: f5c423a93c25d84c291e17a0b7462b29ec153585
-parent layer head: 8a2a6b65052130d6b3849565db0662c71a9105f7
-upstream/devel: aeb5805cb93c92b8c44036f4c1fe1f2df420119f
+reviewed local layer head: 056b9a6d5
+parent layer head: d6eb26204
+upstream/devel: cf5d462dcda1b5ab71160033e1d454b42198ad18
 ```
 
 ## 메타데이터
@@ -33,9 +33,9 @@ upstream/devel: aeb5805cb93c92b8c44036f4c1fe1f2df420119f
 | 대상 / head | `stack/issue-3822-overlong-token-wrap` / `stack/issue-3815-pagination-coalescing` |
 | 작성 시점 원격 상태 | draft, `MERGEABLE`; 보정 restack·push 뒤 재확인 필요 |
 | 보정 전 원격 head | `07e775092d1c08a69a8b71b523a0648eb0d6e7a5` |
-| 리뷰 보정 layer head | `f5c423a93c25d84c291e17a0b7462b29ec153585` |
-| 부모 레이어 head | `8a2a6b65052130d6b3849565db0662c71a9105f7` |
-| 최신 기준 | `upstream/devel` `aeb5805cb93c92b8c44036f4c1fe1f2df420119f` |
+| 리뷰 보정 layer head | `056b9a6d5` |
+| 부모 레이어 head | `d6eb26204` |
+| 최신 기준 | `upstream/devel` `cf5d462dcda1b5ab71160033e1d454b42198ad18` |
 | review 문서 작성 전 PR 고유 규모 | 10 files, +895 / -80 |
 | 관련 issue | [#3815](https://github.com/edwardkim/rhwp/issues/3815) |
 
@@ -138,6 +138,10 @@ step은 공개 쪽수를 바꾸지 않고 complete에서만 115 → 116을 한 �
 Stack 전체 Studio unit 763 / 763도 이전 최신 기준 검증에서 통과했다. 이번 correction은 계획·작업 기록,
 MANIFEST, E2E header와 npm 진입점만 바꾸며 scheduler 제품 코드는 변경하지 않는다.
 
+검토 CI 중 `devel`이 중첩 표 배치 수정 #3949를 포함한 `cf5d462dc`로 전진해 Stack을 다시
+정렬했다. 제품 충돌은 없었으며 spacing 42 / 42, `issue_2189_cell_text_clip` 1 / 1,
+composer 53 / 53, fmt·diff와 production WASM을 제한 재검증했다.
+
 ## production WASM + Chrome 증적
 
 최신 devel 기준 production WASM과 새 headless Chrome에서 HWP/HWPX `--continuous-only`를 각 한 번
@@ -145,13 +149,13 @@ MANIFEST, E2E header와 npm 진입점만 바꾸며 scheduler 제품 코드는 �
 
 | 형식 | 숫자 줄 전환 | 최종 숫자 | pending operation p95 | 최종 쪽수 | 결과 |
 | --- | --- | ---: | ---: | ---: | --- |
-| HWP | 11 / 69 | 73 | 49.0ms | 116 | GREEN |
-| HWPX | 11 / 69 | 73 | 49.2ms | 116 | GREEN |
+| HWP | 11 / 69 | 73 | 49.6ms | 116 | GREEN |
+| HWPX | 11 / 69 | 73 | 49.7ms | 116 | GREEN |
 
 두 형식 모두 IME `ㅎ → 하 → 한` 뒤 긴 숫자가 pending 중 두 번 줄바꿈됐다. caret, model text,
 visible ink와 layer tree가 최신 revision으로 일치했고 latest begin/final step revision은 132 / 132,
-superseded publication과 synchronous flow flush는 0이었다. 이전 smoke의 50.2ms / 49.7ms 대비 -2.4% /
--1.0%로 ±10% gate 안이어서 형식별 current·80ms·250ms 3회 전체 측정은 반복하지 않았다.
+superseded publication과 synchronous flow flush는 0이었다. 이전 smoke의 50.2ms / 49.7ms 대비 -1.2% /
+0.0%로 ±10% gate 안이어서 형식별 current·80ms·250ms 3회 전체 측정은 반복하지 않았다.
 
 이 수치는 로컬 production WASM + Chrome의 역사·회귀 근거다. Render Diff CI는 E2E의
 `node --check`만 수행하므로 최신 PR head CI와 별도로 해석한다.

--- a/mydocs/working/task_m100_3815_stage5.md
+++ b/mydocs/working/task_m100_3815_stage5.md
@@ -2,8 +2,8 @@
 
 - 이슈: [#3815](https://github.com/edwardkim/rhwp/issues/3815)
 - 브랜치: stack/issue-3815-pagination-coalescing
-- 최신 기준: upstream/devel aeb5805cb
-- code candidate: e2ec99228
+- 최신 기준: upstream/devel cf5d462dc
+- code candidate: 416eb37a1
 - 작성일: 2026-08-04
 
 ## Stack
@@ -33,18 +33,24 @@ production WASM과 새 headless Chrome에서 continuous-only 시나리오를 각
 
 | 형식 | 숫자 줄 전환 | 최종 숫자 | pending operation p95 | 결과 |
 | --- | --- | ---: | ---: | --- |
-| HWP | 11 / 69 | 73 | 49.0ms | GREEN |
-| HWPX | 11 / 69 | 73 | 49.2ms | GREEN |
+| HWP | 11 / 69 | 73 | 49.6ms | GREEN |
+| HWPX | 11 / 69 | 73 | 49.7ms | GREEN |
 
 두 형식 모두 IME 조합 뒤 숫자가 두 번 줄바꿈되고 overflow 없이 최종 revision까지 게시됐다.
 최종 쪽수는 116, latest begin/final step revision은 132 / 132이며 synchronous flush는 0이다.
-이전 동일 smoke의 50.2ms / 49.7ms 대비 변화는 각각 -2.4% / -1.0%로 ±10% gate 안이다.
+이전 동일 smoke의 50.2ms / 49.7ms 대비 변화는 각각 -1.2% / 0.0%로 ±10% gate 안이다.
 따라서 2026-08-03에 완료한 current, 80ms, 250ms 형식별 3회 전체 측정은 반복하지 않았다.
 
-이후 devel이 aeb5805cb로 전진했다. 추가 변경은 Stack 제품 파일과 직접 겹치지 않았지만
+첫 최종 검증 뒤 devel이 aeb5805cb로 전진했다. 추가 변경은 Stack 제품 파일과 직접 겹치지 않았지만
 typeset 쪽 경계 수정이 실제 HWP/HWPX 쪽수에 영향을 줄 수 있어 production WASM과 combined
 smoke까지 다시 실행했다. spacing 42 / 42, SVG 41 / 41, composer 53 / 53, Studio focused
 23 / 23, TypeScript와 production WASM을 모두 통과했고 두 형식의 115 → 116 결과도 유지됐다.
+
+검토 CI 중 devel이 중첩 표 배치 수정 #3949를 포함한 cf5d462dc로 다시 전진했다. 공용 오늘할일
+충돌은 양쪽 기록을 보존해 해소했고 제품 코드는 충돌하지 않았다. spacing 42 / 42,
+`issue_2189_cell_text_clip` 1 / 1, composer 53 / 53, fmt·diff와 production WASM을 제한
+재검증했다. HWP/HWPX는 11 / 69, 숫자 73, 116쪽, p95 49.6 / 49.7ms로 GREEN이며 대표
+HWP crop의 SHA-256도 기존 보존 asset과 일치했다.
 
 ## 기존 성능 근거
 

--- a/mydocs/working/task_m100_3815_stage5.md
+++ b/mydocs/working/task_m100_3815_stage5.md
@@ -33,12 +33,12 @@ production WASM과 새 headless Chrome에서 continuous-only 시나리오를 각
 
 | 형식 | 숫자 줄 전환 | 최종 숫자 | pending operation p95 | 결과 |
 | --- | --- | ---: | ---: | --- |
-| HWP | 11 / 69 | 73 | 50.1ms | GREEN |
-| HWPX | 11 / 69 | 73 | 50.9ms | GREEN |
+| HWP | 11 / 69 | 73 | 49.0ms | GREEN |
+| HWPX | 11 / 69 | 73 | 49.2ms | GREEN |
 
 두 형식 모두 IME 조합 뒤 숫자가 두 번 줄바꿈되고 overflow 없이 최종 revision까지 게시됐다.
 최종 쪽수는 116, latest begin/final step revision은 132 / 132이며 synchronous flush는 0이다.
-이전 동일 smoke의 50.2ms / 49.7ms 대비 변화는 각각 -0.2% / +2.4%로 ±10% gate 안이다.
+이전 동일 smoke의 50.2ms / 49.7ms 대비 변화는 각각 -2.4% / -1.0%로 ±10% gate 안이다.
 따라서 2026-08-03에 완료한 current, 80ms, 250ms 형식별 3회 전체 측정은 반복하지 않았다.
 
 이후 devel이 aeb5805cb로 전진했다. 추가 변경은 Stack 제품 파일과 직접 겹치지 않았지만

--- a/mydocs/working/task_m100_3815_stage5.md
+++ b/mydocs/working/task_m100_3815_stage5.md
@@ -2,7 +2,7 @@
 
 - 이슈: [#3815](https://github.com/edwardkim/rhwp/issues/3815)
 - 브랜치: stack/issue-3815-pagination-coalescing
-- 최신 기준: upstream/devel ec1b21096
+- 최신 기준: upstream/devel aeb5805cb
 - code candidate: e2ec99228
 - 작성일: 2026-08-04
 
@@ -19,7 +19,7 @@ cherry-pick은 포함하지 않았다.
 
 - renderer spacing focused: 42 / 42
 - SVG renderer: 41 / 41
-- composer: 52 / 52
+- composer: 53 / 53
 - runner + InputHandler focused: 23 / 23
 - Studio 전체 unit: 763 / 763 (이전 stack 전체 검증, 최신 devel은 Studio 파일 변경 없음)
 - npx tsc --noEmit: 통과
@@ -41,9 +41,9 @@ production WASM과 새 headless Chrome에서 continuous-only 시나리오를 각
 이전 동일 smoke의 50.2ms / 49.7ms 대비 변화는 각각 -0.2% / +2.4%로 ±10% gate 안이다.
 따라서 2026-08-03에 완료한 current, 80ms, 250ms 형식별 3회 전체 측정은 반복하지 않았다.
 
-이후 devel이 ec1b21096로 전진했다. 추가 변경은 Stack 제품 파일과 직접 겹치지 않았지만
+이후 devel이 aeb5805cb로 전진했다. 추가 변경은 Stack 제품 파일과 직접 겹치지 않았지만
 typeset 쪽 경계 수정이 실제 HWP/HWPX 쪽수에 영향을 줄 수 있어 production WASM과 combined
-smoke까지 다시 실행했다. spacing 42 / 42, SVG 41 / 41, composer 52 / 52, Studio focused
+smoke까지 다시 실행했다. spacing 42 / 42, SVG 41 / 41, composer 53 / 53, Studio focused
 23 / 23, TypeScript와 production WASM을 모두 통과했고 두 형식의 115 → 116 결과도 유지됐다.
 
 ## 기존 성능 근거
@@ -54,6 +54,17 @@ step p95 최대는 8.4ms였다.
 
 남은 pending operation 비용은 exact cursor query가 지배하며 이번 scheduler PR의 비범위다.
 flow가 안정되면 stable-tail fast path로 돌아간다.
+
+200ms보다 짧은 간격의 입력이 계속되면 active restart timer가 재예약되어 pagination step과
+쪽수 게시가 잠시 멈춘다. 200ms 이상 쉬면 최신 revision에서 재개되고, 완료 뒤 stable-tail
+fast path로 복귀한다. 이 pending 구간에서는 기존 120ms idle flush도 선점하지 않는다.
+
+HWP/HWPX 2 / 2, pending operation p95, 115 → 116 쪽수, revision 일치와 synchronous flush 0은
+모두 로컬 production WASM + Chrome `--continuous-only` 결과다. Render Diff CI는 이 E2E의
+`node --check`만 실행하며 브라우저 성능·쪽수 결과를 대신하지 않는다. 리뷰 재현을 위해
+`npm run e2e:issue-3815` 진입점과 MANIFEST 설명을 추가했다.
+최신 devel에 이미 추적되던 #3682 진단 프로브의 누락 행도 함께 등록해 새 MANIFEST 검사를
+stack top에서 통과시켰다. 프로브 동작이나 #3682 제품 범위는 변경하지 않는다.
 
 ## 게시 상태
 

--- a/mydocs/working/task_m100_3815_stage5.md
+++ b/mydocs/working/task_m100_3815_stage5.md
@@ -2,8 +2,8 @@
 
 - 이슈: [#3815](https://github.com/edwardkim/rhwp/issues/3815)
 - 브랜치: stack/issue-3815-pagination-coalescing
-- 최신 기준: upstream/devel 8d7bc622e
-- code candidate: fdebb38fb
+- 최신 기준: upstream/devel ec1b21096
+- code candidate: e2ec99228
 - 작성일: 2026-08-04
 
 ## Stack
@@ -21,7 +21,7 @@ cherry-pick은 포함하지 않았다.
 - SVG renderer: 41 / 41
 - composer: 52 / 52
 - runner + InputHandler focused: 23 / 23
-- Studio 전체 unit: 763 / 763
+- Studio 전체 unit: 763 / 763 (이전 stack 전체 검증, 최신 devel은 Studio 파일 변경 없음)
 - npx tsc --noEmit: 통과
 - production wasm-pack release build: 통과
 - wasm32-unknown-unknown library check: 통과
@@ -33,17 +33,18 @@ production WASM과 새 headless Chrome에서 continuous-only 시나리오를 각
 
 | 형식 | 숫자 줄 전환 | 최종 숫자 | pending operation p95 | 결과 |
 | --- | --- | ---: | ---: | --- |
-| HWP | 11 / 69 | 73 | 49.3ms | GREEN |
-| HWPX | 11 / 69 | 73 | 50.6ms | GREEN |
+| HWP | 11 / 69 | 73 | 50.1ms | GREEN |
+| HWPX | 11 / 69 | 73 | 50.9ms | GREEN |
 
 두 형식 모두 IME 조합 뒤 숫자가 두 번 줄바꿈되고 overflow 없이 최종 revision까지 게시됐다.
-이전 동일 smoke의 50.2ms / 49.7ms 대비 변화는 각각 -1.8% / +1.8%로 ±10% gate 안이다.
+최종 쪽수는 116, latest begin/final step revision은 132 / 132이며 synchronous flush는 0이다.
+이전 동일 smoke의 50.2ms / 49.7ms 대비 변화는 각각 -0.2% / +2.4%로 ±10% gate 안이다.
 따라서 2026-08-03에 완료한 current, 80ms, 250ms 형식별 3회 전체 측정은 반복하지 않았다.
 
-이후 devel이 19커밋 전진해 최종 base를 8d7bc622e로 갱신했다. 추가 변경은
-structure query와 문서이며 renderer, composer, Studio 제품 파일과 겹치지 않는다.
-전체 browser smoke는 보존하고 spacing 42 / 42, composer 52 / 52, Studio focused
-23 / 23과 TypeScript spot-check를 반복해 모두 통과했다.
+이후 devel이 ec1b21096로 전진했다. 추가 변경은 Stack 제품 파일과 직접 겹치지 않았지만
+typeset 쪽 경계 수정이 실제 HWP/HWPX 쪽수에 영향을 줄 수 있어 production WASM과 combined
+smoke까지 다시 실행했다. spacing 42 / 42, SVG 41 / 41, composer 52 / 52, Studio focused
+23 / 23, TypeScript와 production WASM을 모두 통과했고 두 형식의 115 → 116 결과도 유지됐다.
 
 ## 기존 성능 근거
 
@@ -56,5 +57,8 @@ flow가 안정되면 stable-tail fast path로 돌아간다.
 
 ## 게시 상태
 
-renderer 이슈 #3937은 생성했지만 세 stack branch는 아직 원격에 push하지 않았고 Draft PR도
-만들지 않았다. 세 본문을 작업지시자에게 먼저 보여준 뒤 승인받아 gh stack으로 제출한다.
+GitHub Stack #3947을 만들고 세 branch를 upstream에 push했다. Draft PR은 아래와 같다.
+
+- [#3944](https://github.com/edwardkim/rhwp/pull/3944): #3937 browser glyph 폭
+- [#3945](https://github.com/edwardkim/rhwp/pull/3945): #3822 overlong token wrap
+- [#3946](https://github.com/edwardkim/rhwp/pull/3946): #3815 pagination coalescing

--- a/mydocs/working/task_m100_3815_stage5.md
+++ b/mydocs/working/task_m100_3815_stage5.md
@@ -1,0 +1,60 @@
+# Task #3815 Stage 5 — 최신 3단 stack 제한 검증
+
+- 이슈: [#3815](https://github.com/edwardkim/rhwp/issues/3815)
+- 브랜치: stack/issue-3815-pagination-coalescing
+- 최신 기준: upstream/devel 8d7bc622e
+- code candidate: fdebb38fb
+- 작성일: 2026-08-04
+
+## Stack
+
+1. #3937 browser glyph 폭 보정
+2. #3822 overlong token 반복 줄바꿈
+3. #3815 pagination coalescing과 연속 입력 E2E
+
+세 레이어를 최신 devel 위에 선형으로 재구성했고 integration merge commit이나 중복
+cherry-pick은 포함하지 않았다.
+
+## 최신 기준 검증
+
+- renderer spacing focused: 42 / 42
+- SVG renderer: 41 / 41
+- composer: 52 / 52
+- runner + InputHandler focused: 23 / 23
+- Studio 전체 unit: 763 / 763
+- npx tsc --noEmit: 통과
+- production wasm-pack release build: 통과
+- wasm32-unknown-unknown library check: 통과
+- git diff --check: 통과
+
+## HWP/HWPX combined smoke
+
+production WASM과 새 headless Chrome에서 continuous-only 시나리오를 각 형식 한 번 실행했다.
+
+| 형식 | 숫자 줄 전환 | 최종 숫자 | pending operation p95 | 결과 |
+| --- | --- | ---: | ---: | --- |
+| HWP | 11 / 69 | 73 | 49.3ms | GREEN |
+| HWPX | 11 / 69 | 73 | 50.6ms | GREEN |
+
+두 형식 모두 IME 조합 뒤 숫자가 두 번 줄바꿈되고 overflow 없이 최종 revision까지 게시됐다.
+이전 동일 smoke의 50.2ms / 49.7ms 대비 변화는 각각 -1.8% / +1.8%로 ±10% gate 안이다.
+따라서 2026-08-03에 완료한 current, 80ms, 250ms 형식별 3회 전체 측정은 반복하지 않았다.
+
+이후 devel이 19커밋 전진해 최종 base를 8d7bc622e로 갱신했다. 추가 변경은
+structure query와 문서이며 renderer, composer, Studio 제품 파일과 겹치지 않는다.
+전체 browser smoke는 보존하고 spacing 42 / 42, composer 52 / 52, Studio focused
+23 / 23과 TypeScript spot-check를 반복해 모두 통과했다.
+
+## 기존 성능 근거
+
+이전 production 측정에서 current 완료 중앙값은 HWP 1,581.6ms, HWPX 1,586.0ms였고,
+input dispatch와 begin overlap, superseded publication과 flow sync flush는 모두 0이었다.
+step p95 최대는 8.4ms였다.
+
+남은 pending operation 비용은 exact cursor query가 지배하며 이번 scheduler PR의 비범위다.
+flow가 안정되면 stable-tail fast path로 돌아간다.
+
+## 게시 상태
+
+renderer 이슈 #3937은 생성했지만 세 stack branch는 아직 원격에 push하지 않았고 Draft PR도
+만들지 않았다. 세 본문을 작업지시자에게 먼저 보여준 뒤 승인받아 gh stack으로 제출한다.

--- a/rhwp-studio/e2e/MANIFEST.md
+++ b/rhwp-studio/e2e/MANIFEST.md
@@ -48,11 +48,12 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `issue-1280-textbox-text-input.test.mjs` | 상시 | active | E2E 회귀: #1280 — rhwp-studio가 삽입한 글상자가 text_box 없는 Rectangle로 생성되어  | — | 수동 |  |
 | `issue-1456-chart-rerender.test.mjs` | 상시 | active | E2E 회귀 — #1456: rhwp-studio 캔버스 차트/OLE(rawSvg) 비동기 디코드 재렌더 안전망 | — | 수동 |  |
 | `issue-2069-ole-object-selection.test.mjs` | 상시 | active | E2E: 한셀 OLE 미리보기는 표처럼 보이더라도 셀 내부 편집으로 진입하지 않는다. | 한셀OLE.hwp | 수동 |  |
-| `issue-2214-page-local-repaint.test.mjs` | 상시 | active | Issue #2214 focused GREEN regression and optional diagnostic. | — | npm+CI |  |
+| `issue-2214-page-local-repaint.test.mjs` | 상시 | active | #2214 focused GREEN과 #3815 stack #3937·#3822 연속 IME·두 번 wrap 통합 회귀 | issue1949_giant_cell_nested_tables_perf.hwp, issue1949_giant_cell_nested_tables_perf.hwpx | npm e2e:issue-2214, npm e2e:issue-3815, CI node-check | production WASM·Chrome의 시간·쪽수·revision 결과는 로컬 증적 |
 | `issue-2318-master-page-zorder.test.mjs` | 상시 | active | Issue #2318: 바탕쪽 개체가 본문 텍스트를 가림 — studio 다층 canvas 합성 검증. /  / sho | basic/shortcut.hwp | 수동 |  |
 | `issue-2635-rawsvg-first-paint.test.mjs` | 상시 | active | Issue #2635: 순수 RawSvg 차트가 첫 화면에 늦게 표시되는 회귀 | chart/원형/쪼개진원형.hwp | 수동 |  |
 | `issue-270-set-field-persist.test.mjs` | 상시 | active | 이슈 #270 — set_field 후 저장/재오픈 시 필드 값 유실 회귀 | field-01.hwp | 수동 |  |
 | `issue-2809-split-alignment.test.mjs` | 상시 | active | Issue #2809 위·아래 Split 문단 속성 및 WASM/editor 정렬 회귀 | issues/2809/jubo_20260104.hwp | npm e2e:issue-2809 |  |
+| `issue-3682-chart-object-probe.test.mjs` | 진단 | active | #3682 차트 개체 P1~P5 행동 현황 수집 프로브 | chart/세로막대형/묶은세로막대형.hwp | 수동 | legacy-name · 최신 devel의 기존 미등재 항목 보완 |
 | `issue-595.test.mjs` | 진단 | hold | Issue #595 진단 e2e | exam_math.hwp | 수동 | legacy-name · #595 진단 (assertion 0) |
 | `line-spacing.test.mjs` | 상시 | active | 줄간격 변경에 따른 페이지 넘김 검증 | — | 수동 |  |
 | `navigation-shortcuts.test.mjs` | 상시 | active | 플랫폼별 navigation shortcut | — | 수동 |  |

--- a/rhwp-studio/e2e/issue-2214-page-local-repaint.test.mjs
+++ b/rhwp-studio/e2e/issue-2214-page-local-repaint.test.mjs
@@ -13,6 +13,7 @@
  * Usage:
  *   node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless
  *   node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless --runs=1  # local smoke
+ *   node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless --continuous-only
  *   node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless --review-only
  *   node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless --diagnose
  *   node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless --diagnose \
@@ -49,6 +50,9 @@ const TARGET = Object.freeze({
   cellPath: [{ controlIndex: 2, cellIndex: 2, cellParaIndex: 5 }],
 });
 const MAX_INSERTS = 128;
+const CONTINUOUS_WRAP_MAX_INSERTS = 160;
+const CONTINUOUS_WRAP_TAIL_INPUTS = 4;
+const CONTINUOUS_INPUT_MIN_GAP_MS = 8;
 
 const SAMPLES = Object.freeze({
   hwp: path.join(REPO_ROOT, 'samples/issue1949_giant_cell_nested_tables_perf.hwp'),
@@ -82,6 +86,12 @@ function summarizeDurations(values) {
     p95Ms: percentile(values, 0.95),
     maxMs: values.length ? Math.max(...values) : null,
   };
+}
+
+function traceDurations(trace, type) {
+  return trace.events
+    .filter((event) => event.type === type && typeof event.durationMs === 'number')
+    .map((event) => event.durationMs);
 }
 
 function writeJson(filePath, value) {
@@ -528,6 +538,28 @@ async function resolveCompositedClip(page) {
   return clip;
 }
 
+async function resolveCaretGlyphClip(page) {
+  return page.evaluate(() => {
+    const canvasView = window.__canvasView;
+    const cursorRect = window.__inputHandler.cursor.getRect();
+    const pageIndex = Number.isInteger(cursorRect?.pageIndex) ? cursorRect.pageIndex : 0;
+    const canvas = canvasView.canvasPool.getCanvas(pageIndex);
+    if (!canvas || !cursorRect) throw new Error('caret glyph canvas unavailable');
+    const canvasRect = canvas.getBoundingClientRect();
+    const tree = window.__wasm.getPageLayerTreeObject(pageIndex);
+    const scale = tree.pageWidth > 0 ? canvasRect.width / tree.pageWidth : 1;
+    const glyphWidth = Math.max(cursorRect.height * 1.5, 24);
+    return {
+      x: Math.max(0, Math.floor(canvasRect.left + (cursorRect.x - glyphWidth) * scale)),
+      y: Math.max(0, Math.floor(canvasRect.top + (cursorRect.y - 2) * scale)),
+      width: Math.max(1, Math.ceil(glyphWidth * scale)),
+      height: Math.max(1, Math.ceil((cursorRect.height + 4) * scale)),
+      pageIndex,
+      scale,
+    };
+  });
+}
+
 async function captureCompositedCrop(page, filePath, clip) {
   mkdirSync(path.dirname(filePath), { recursive: true });
   await page.evaluate(() => {
@@ -740,6 +772,17 @@ async function waitForDeferredPaginationCompletion(page, timeoutMs = 5_000) {
     { timeout: timeoutMs, polling: 25 },
   );
   return performance.now() - startedAt;
+}
+
+async function waitForDeferredPaginationBegin(page, timeoutMs = 1_000) {
+  await page.waitForFunction(
+    () => (
+      window.__inputHandler.hasDeferredPaginationPending()
+      && (window.__issue2214Trace?.events ?? [])
+        .some((event) => event.type === 'wasm.beginDeferredPagination')
+    ),
+    { timeout: timeoutMs, polling: 10 },
+  );
 }
 
 async function runTimeline(page, format, bytes, transitionAt) {
@@ -1079,13 +1122,15 @@ function assertExactFocusedState(
   expectedLineCount,
   expectedBoundsHeight,
   expectedPending,
+  expectedCaretVisible = true,
+  expectedPageCount = 115,
 ) {
   const prefix = `${format} run ${runNumber} ${state.label}`;
   const expectedLength = expectedText.length;
   assert.equal(state.model.length, expectedLength, `${prefix}: model length`);
   assert.equal(state.model.text, expectedText, `${prefix}: model text`);
   assert.equal(state.model.lineCount, expectedLineCount, `${prefix}: line count`);
-  assert.equal(state.pagination.pageCount, 115, `${prefix}: page count`);
+  assert.equal(state.pagination.pageCount, expectedPageCount, `${prefix}: page count`);
   if (expectedPending !== null) {
     assert.equal(state.pagination.pending, expectedPending, `${prefix}: pending state`);
   }
@@ -1124,10 +1169,71 @@ function assertExactFocusedState(
   assertApprox(rect?.y, lastOp.bbox.y, `${prefix}: cursor y at tree end`);
   assertApprox(rect?.height, lastOp.bbox.height, `${prefix}: cursor height`);
 
-  assert.ok(state.caret, `${prefix}: DOM caret`);
-  assert.equal(state.caret.display, 'block', `${prefix}: DOM caret display`);
-  assert.ok(state.caret.clientRect?.width > 0, `${prefix}: DOM caret width`);
-  assertApprox(state.caret.clientRect?.height, rect.height, `${prefix}: DOM caret height`);
+  if (expectedCaretVisible) {
+    assert.ok(state.caret, `${prefix}: DOM caret`);
+    assert.equal(state.caret.display, 'block', `${prefix}: DOM caret display`);
+    assert.ok(state.caret.clientRect?.width > 0, `${prefix}: DOM caret width`);
+    assertApprox(state.caret.clientRect?.height, rect.height, `${prefix}: DOM caret height`);
+  }
+}
+
+function assertContinuousFlowGeometry(format, label, state, digitTokenStart) {
+  const prefix = `${format} ${label}`;
+  const bounds = state.cursor.rect?.cellBounds;
+  assert.ok(bounds, `${prefix}: cell bounds`);
+  const left = bounds.x;
+  const right = bounds.x + bounds.w;
+  const digitOps = [];
+  const suffixBands = [];
+  for (const [index, op] of state.layerTree.targetOps.entries()) {
+    const start = targetRunStart(op, `${prefix} op ${index}`);
+    const textLength = String(op.text ?? '').length;
+    // Existing justified source lines in this fixture carry their original ink
+    // envelope. Validate every run that contains or follows the edited suffix.
+    if (start + textLength <= TARGET.charOffset) continue;
+    assert.ok(
+      op.bbox.x >= left - 0.2,
+      `${prefix}: TextRun ${index} left=${op.bbox.x}, cellLeft=${left}`,
+    );
+    assert.ok(
+      op.bbox.x + op.bbox.width <= right + 0.2,
+      `${prefix}: TextRun ${index} right=${op.bbox.x + op.bbox.width}, cellRight=${right}, `
+        + `key=${op.stableSourceKey}, text=${JSON.stringify(op.text)}`,
+    );
+    if (start + textLength > digitTokenStart) {
+      suffixBands.push({ top: op.bbox.y, bottom: op.bbox.y + op.bbox.height });
+    }
+    if (start >= digitTokenStart && /^1+$/.test(op.text)) digitOps.push(op);
+  }
+  assert.ok(state.model.lines.length > 0, `${prefix}: line ranges`);
+  assert.equal(state.model.lines[0].charStart, 0, `${prefix}: first line start`);
+  for (let index = 1; index < state.model.lines.length; index += 1) {
+    assert.equal(
+      state.model.lines[index - 1].charEnd,
+      state.model.lines[index].charStart,
+      `${prefix}: line ${index - 1}→${index} UTF-16 continuity`,
+    );
+  }
+  assert.equal(state.model.lines.at(-1).charEnd, state.model.length, `${prefix}: final line end`);
+  assert.ok(digitOps.length >= 2, `${prefix}: numeric suffix line runs`);
+  const naturalAdvance = digitOps.at(-1).bbox.width / digitOps.at(-1).text.length;
+  assert.ok(naturalAdvance <= state.cursor.rect.height, `${prefix}: final digit advance`);
+  for (const [index, op] of digitOps.entries()) {
+    const advance = op.bbox.width / op.text.length;
+    assert.ok(advance <= naturalAdvance * 1.5 + 0.2, `${prefix}: digit run ${index} stretch ${advance}`);
+  }
+  const bands = [];
+  for (const band of suffixBands.sort((a, b) => a.top - b.top)) {
+    const previous = bands.at(-1);
+    if (previous && Math.abs(band.top - previous.top) <= 0.2) {
+      previous.bottom = Math.max(previous.bottom, band.bottom);
+    } else {
+      bands.push({ ...band });
+    }
+  }
+  for (let index = 1; index < bands.length; index += 1) {
+    assert.ok(bands[index].top >= bands[index - 1].bottom - 0.2, `${prefix}: suffix line overlap`);
+  }
 }
 
 function assertFocusedTrace(format, runNumber, trace) {
@@ -1350,6 +1456,272 @@ async function runFocusedFormat(page, format, bytes, runNumber) {
     finalLength: checkpoints.at62.model.length,
     trace: traceSummary,
     visual,
+  };
+}
+
+async function runContinuousImeDigitSmoke(page, format, bytes) {
+  await restoreTrace(page);
+  await openDocumentThroughApp(page, format, bytes);
+  await moveToTarget(page);
+  const initial = await readFocusedSnapshot(page);
+  const initialText = initial.model.text;
+  const clip = await resolveCompositedClip(page);
+  const directory = path.join(OUTPUT_ROOT, 'continuous-ime-digit', format);
+  const timelineStart = await page.evaluate(() => performance.now());
+  await installTrace(page);
+
+  const stableKeyboardDurationsMs = await typeKeyboardOnes(page, 55);
+  await waitTwoRafs(page);
+  const beforeCompositionText = `${initialText}${'1'.repeat(55)}`;
+  const beforeComposition = await readFocusedSnapshot(page);
+  assert.equal(beforeComposition.model.text, beforeCompositionText, `${format} continuous IME precondition text`);
+  assert.equal(beforeComposition.model.lineCount, 4, `${format} continuous IME precondition lines`);
+  assert.equal(beforeComposition.pagination.pending, true, `${format} continuous IME precondition pending`);
+
+  await page.evaluate(() => {
+    window.__inputHandler.textarea.dispatchEvent(new CompositionEvent('compositionstart', {
+      bubbles: true,
+      data: '',
+    }));
+  });
+  const compositionStates = [];
+  const compositionCaptures = {};
+  let glyphClip = null;
+  for (const value of ['ㅎ', '하', '한']) {
+    await page.evaluate((text) => {
+      const textarea = window.__inputHandler.textarea;
+      textarea.value = text;
+      textarea.dispatchEvent(new InputEvent('input', {
+        bubbles: true,
+        data: text,
+        inputType: 'insertCompositionText',
+        isComposing: true,
+      }));
+    }, value);
+    await waitTwoRafs(page);
+    const expectedText = `${initialText}${'1'.repeat(55)}${value}`;
+    const state = await collectState(page, `continuous-ime-${value}-2raf`, timelineStart);
+    assert.equal(state.model.lineCount, 5, `${format} continuous IME ${value}: flow line count`);
+    assertExactFocusedState(
+      format,
+      'continuous-ime-digit',
+      state,
+      expectedText,
+      5,
+      945.9,
+      true,
+      false,
+    );
+    compositionStates.push(state);
+
+    if (value === '하') {
+      glyphClip = await resolveCaretGlyphClip(page);
+      compositionCaptures.ha = await captureCompositedCrop(
+        page,
+        path.join(directory, 'ime-ha-2raf.png'),
+        glyphClip,
+      );
+    } else if (value === '한') {
+      assert.ok(glyphClip, `${format} continuous IME: glyph clip`);
+      compositionCaptures.han = await captureCompositedCrop(
+        page,
+        path.join(directory, 'ime-han-2raf.png'),
+        glyphClip,
+      );
+    }
+  }
+  const compositionInkComparison = comparePng(
+    compositionCaptures.han.filePath,
+    compositionCaptures.ha.filePath,
+    path.join(directory, 'ime-ha-vs-han-diff.png'),
+  );
+  assert.equal(compositionInkComparison.comparable, true, `${format} continuous IME: glyph crop comparable`);
+  assert.ok(
+    compositionInkComparison.changedPixelCount > 0,
+    `${format} continuous IME: 한 must replace 하 in the composited canvas within 2-rAF`,
+  );
+  assert.notEqual(
+    compositionCaptures.han.sha256,
+    compositionCaptures.ha.sha256,
+    `${format} continuous IME: glyph crop hash`,
+  );
+  await page.evaluate(() => {
+    window.__inputHandler.textarea.dispatchEvent(new CompositionEvent('compositionend', {
+      bubbles: true,
+      data: '한',
+    }));
+  });
+
+  // Put the following digit token behind an explicit break opportunity. This is the
+  // browser form of #3822: the old composer moved an overlong token after the prior
+  // break, then skipped character-level breaking for that token.
+  await waitForDeferredPaginationBegin(page);
+  await page.keyboard.type(' ');
+  const separatorText = `${initialText}${'1'.repeat(55)}한 `;
+  const separatorState = await readFocusedSnapshot(page);
+  assert.equal(separatorState.model.text, separatorText, `${format} continuous IME separator text`);
+  assert.equal(separatorState.pagination.pending, true, `${format} continuous IME separator pending`);
+
+  // Cross two digit line boundaries while that pagination job is active. No
+  // completion wait is allowed before the second wrap is observed.
+  let digitCount = 0;
+  const digitWraps = [];
+  let tailInputsRemaining = null;
+  const initialImeLineCount = separatorState.model.lineCount;
+  let previousLineCount = initialImeLineCount;
+  const durationsMs = [];
+  while (digitCount < CONTINUOUS_WRAP_MAX_INSERTS) {
+    digitCount += 1;
+    const startedAt = performance.now();
+    await page.keyboard.type('1');
+    durationsMs.push(performance.now() - startedAt);
+    const expectedText = `${separatorText}${'1'.repeat(digitCount)}`;
+    const snapshot = await readFocusedSnapshot(page);
+    const prefix = `${format} continuous IME digit ${digitCount}`;
+    assert.equal(snapshot.model.text, expectedText, `${prefix}: model text`);
+    assert.equal(snapshot.model.length, expectedText.length, `${prefix}: model length`);
+    assert.equal(snapshot.cursor.position.charOffset, expectedText.length, `${prefix}: cursor offset`);
+    assert.equal(snapshot.pagination.pageCount, 115, `${prefix}: page count`);
+    assert.equal(snapshot.pagination.pending, true, `${prefix}: pending`);
+    assert.equal(snapshot.cursor.rect?.cellOverflowed, false, `${prefix}: cursor overflow`);
+
+    if (snapshot.model.lineCount > previousLineCount) {
+      digitWraps.push({ digitCount, from: previousLineCount, to: snapshot.model.lineCount });
+      previousLineCount = snapshot.model.lineCount;
+    }
+    if (snapshot.model.lineCount >= initialImeLineCount + 2 && tailInputsRemaining === null) {
+      assert.equal(snapshot.pagination.pending, true, `${format} continuous IME: second wrap pending`);
+      tailInputsRemaining = CONTINUOUS_WRAP_TAIL_INPUTS;
+    } else if (tailInputsRemaining !== null) {
+      tailInputsRemaining -= 1;
+      if (tailInputsRemaining === 0) break;
+    }
+    await delay(page, CONTINUOUS_INPUT_MIN_GAP_MS);
+  }
+  assert.deepEqual(
+    digitWraps.map((wrap) => wrap.digitCount),
+    [11, 69],
+    `${format} continuous IME: deterministic digit line transitions`,
+  );
+  assert.equal(tailInputsRemaining, 0, `${format} continuous IME: post-wrap tail inputs`);
+
+  await waitTwoRafs(page);
+  const expectedText = `${separatorText}${'1'.repeat(digitCount)}`;
+  const expectedLineCount = initialImeLineCount + 2;
+  const digitTokenStart = TARGET.charOffset + 57;
+  const pendingState = await collectState(page, 'continuous-ime-digit-second-tail-2raf', timelineStart);
+  assertExactFocusedState(
+    format,
+    'continuous-ime-digit',
+    pendingState,
+    expectedText,
+    expectedLineCount,
+    945.9,
+    true,
+  );
+  assertContinuousFlowGeometry(format, 'continuous IME digit pending', pendingState, digitTokenStart);
+  const pendingCapture = await captureCompositedCrop(
+    page,
+    path.join(directory, 'ime-digit-pending.png'),
+    clip,
+  );
+
+  await waitForDeferredPaginationCompletion(page, 15_000);
+  const completedState = await collectState(page, 'continuous-ime-digit-complete', timelineStart);
+  assertExactFocusedState(
+    format,
+    'continuous-ime-digit',
+    completedState,
+    expectedText,
+    expectedLineCount,
+    945.9,
+    false,
+    true,
+    116,
+  );
+  assertContinuousFlowGeometry(format, 'continuous IME digit complete', completedState, digitTokenStart);
+  const completedCapture = await captureCompositedCrop(
+    page,
+    path.join(directory, 'ime-digit-complete.png'),
+    clip,
+  );
+  const comparison = comparePng(
+    completedCapture.filePath,
+    pendingCapture.filePath,
+    path.join(directory, 'ime-digit-pending-vs-complete-diff.png'),
+  );
+  assert.equal(comparison.comparable, true, `${format} continuous IME: comparable crop`);
+  assert.equal(comparison.changedPixelCount, 0, `${format} continuous IME: pending ink must be final ink`);
+  assert.equal(completedCapture.sha256, pendingCapture.sha256, `${format} continuous IME: exact crop hash`);
+
+  const trace = await collectTrace(page);
+  const begins = trace.events.filter((event) => event.type === 'wasm.beginDeferredPagination');
+  const steps = trace.events.filter((event) => event.type === 'wasm.stepDeferredPagination');
+  const latestBegin = begins.at(-1);
+  const finalStep = steps.at(-1);
+  assert.ok(latestBegin, `${format} continuous IME: latest deferred begin`);
+  assert.ok(finalStep, `${format} continuous IME: final deferred step`);
+  assert.equal(finalStep.status, 'complete', `${format} continuous IME: final deferred status`);
+  assert.equal(finalStep.pageCount, 116, `${format} continuous IME: final deferred page count`);
+  assert.equal(
+    finalStep.revision,
+    latestBegin.revision,
+    `${format} continuous IME: latest begin/final step revision`,
+  );
+  assert.ok(
+    latestBegin.sequence < finalStep.sequence,
+    `${format} continuous IME: latest begin must precede final step`,
+  );
+  assert.equal(trace.counts.deferredReplace, 2, `${format} continuous IME: replacement count`);
+  assert.equal(trace.counts.wasmFlush, 0, `${format} continuous IME: WASM flush`);
+  assert.equal(trace.counts.inputFlush, 0, `${format} continuous IME: input flush`);
+  const operationDurationsMs = traceDurations(trace, 'InputHandler.executeOperation');
+  assert.equal(
+    operationDurationsMs.length,
+    57 + digitCount,
+    `${format} continuous IME: operation timing count`,
+  );
+  const timing = {
+    keyboardBeforeFlow: summarizeDurations(stableKeyboardDurationsMs),
+    keyboardPendingFlow: summarizeDurations(durationsMs),
+    operationBeforeFlow: summarizeDurations(operationDurationsMs.slice(0, 55)),
+    operationPendingFlow: summarizeDurations(operationDurationsMs.slice(55)),
+    cursorQuery: summarizeDurations(traceDurations(trace, 'wasm.getCursorRectByPathNear')),
+    filteredRender: summarizeDurations(traceDurations(trace, 'wasm.renderPageToCanvasFiltered')),
+    pageRender: summarizeDurations(traceDurations(trace, 'PageRenderer.renderPage')),
+  };
+  await restoreTrace(page);
+  console.log(
+    `  continuous IME→digit: correctness GREEN, wraps=${digitWraps.map((wrap) => wrap.digitCount).join('/')}, `
+      + `digits=${digitCount}, `
+      + `pendingOpP95=${timing.operationPendingFlow.p95Ms.toFixed(1)}ms`,
+  );
+  return {
+    format,
+    correctness: 'passed',
+    latency: 'measured-not-gated',
+    compositionStates: compositionStates.map((state) => ({
+      label: state.label,
+      lineCount: state.model.lineCount,
+      pending: state.pagination.pending,
+    })),
+    digitWraps,
+    digitCount,
+    durations: summarizeDurations(durationsMs),
+    timing,
+    traceCounts: trace.counts,
+    paginationTrace: {
+      beginCount: begins.length,
+      latestBeginRevision: latestBegin.revision,
+      finalStepRevision: finalStep.revision,
+      finalStepStatus: finalStep.status,
+      finalStepPageCount: finalStep.pageCount,
+    },
+    compositionCaptures,
+    compositionInkComparison,
+    pendingCapture,
+    completedCapture,
+    comparison,
   };
 }
 
@@ -1909,7 +2281,13 @@ async function runFocusedMain() {
     .filter(Boolean);
   const runs = Number(cliValue('runs', '3'));
   const reviewOnly = process.argv.includes('--review-only');
+  const continuousOnly = process.argv.includes('--continuous-only');
   assert.ok(Number.isInteger(runs) && runs > 0, '--runs must be a positive integer');
+  assert.equal(
+    reviewOnly && continuousOnly,
+    false,
+    '--review-only and --continuous-only are mutually exclusive',
+  );
   for (const format of formats) assert.ok(SAMPLES[format], `unsupported format: ${format}`);
 
   mkdirSync(OUTPUT_ROOT, { recursive: true });
@@ -1935,28 +2313,37 @@ async function runFocusedMain() {
   const startedAt = new Date().toISOString();
   const results = [];
   const rawSmokes = [];
+  const continuousSmokes = [];
   const reviewSmokes = [];
   try {
     await loadApp(page);
     for (const format of formats) {
-      if (!reviewOnly) {
+      if (!reviewOnly && !continuousOnly) {
         console.log(`\n[${format.toUpperCase()}] focused GREEN (${runs} runs)`);
         for (let runNumber = 1; runNumber <= runs; runNumber += 1) {
           results.push(await runFocusedFormat(page, format, fixtures[format].bytes, runNumber));
         }
+      }
+      if (!reviewOnly) {
+        console.log(`\n[${format.toUpperCase()}] continuous IME→digit second-wrap`);
+        continuousSmokes.push(await runContinuousImeDigitSmoke(page, format, fixtures[format].bytes));
+      }
+      if (!reviewOnly && !continuousOnly) {
         rawSmokes.push(await runRawStableSmoke(page, format, fixtures[format].bytes, 'ime'));
         rawSmokes.push(await runRawStableSmoke(page, format, fixtures[format].bytes, 'ios'));
         rawSmokes.push(await runRawBoundarySmoke(page, format, fixtures[format].bytes, 'ime'));
         rawSmokes.push(await runRawBoundarySmoke(page, format, fixtures[format].bytes, 'ios'));
       }
-      console.log(`\n[${format.toUpperCase()}] #2424 deletion/IME/output barrier`);
-      reviewSmokes.push(await runDeleteKeySmoke(page, format, fixtures[format].bytes, 'Backspace'));
-      reviewSmokes.push(await runDeleteKeySmoke(page, format, fixtures[format].bytes, 'Delete'));
-      reviewSmokes.push(await runMultiUpdateImeSmoke(page, format, fixtures[format].bytes));
-      reviewSmokes.push(await runImeAcrossPaginationCommitSmoke(page, format, fixtures[format].bytes));
-      reviewSmokes.push(await runSaveBarrierSmoke(page, format, fixtures[format].bytes));
-      if (format === 'hwp') {
-        reviewSmokes.push(await runPrintBarrierSmoke(page, format, fixtures[format].bytes));
+      if (!continuousOnly) {
+        console.log(`\n[${format.toUpperCase()}] #2424 deletion/IME/output barrier`);
+        reviewSmokes.push(await runDeleteKeySmoke(page, format, fixtures[format].bytes, 'Backspace'));
+        reviewSmokes.push(await runDeleteKeySmoke(page, format, fixtures[format].bytes, 'Delete'));
+        reviewSmokes.push(await runMultiUpdateImeSmoke(page, format, fixtures[format].bytes));
+        reviewSmokes.push(await runImeAcrossPaginationCommitSmoke(page, format, fixtures[format].bytes));
+        reviewSmokes.push(await runSaveBarrierSmoke(page, format, fixtures[format].bytes));
+        if (format === 'hwp') {
+          reviewSmokes.push(await runPrintBarrierSmoke(page, format, fixtures[format].bytes));
+        }
       }
     }
   } finally {
@@ -1975,6 +2362,7 @@ async function runFocusedMain() {
       chromePath: process.env.CHROME_PATH ?? process.env.PUPPETEER_EXECUTABLE_PATH ?? null,
       viewport: { width: 1280, height: 900, deviceScaleFactor: 1 },
       runs,
+      continuousOnly,
     },
     fixtures: Object.fromEntries(Object.entries(fixtures).map(([format, value]) => [format, {
       path: value.path,
@@ -1983,6 +2371,7 @@ async function runFocusedMain() {
     }])),
     results,
     rawSmokes,
+    continuousSmokes,
     reviewSmokes,
   };
   writeJson(path.join(OUTPUT_ROOT, 'focused-summary.json'), summary);

--- a/rhwp-studio/e2e/issue-2214-page-local-repaint.test.mjs
+++ b/rhwp-studio/e2e/issue-2214-page-local-repaint.test.mjs
@@ -1176,8 +1176,8 @@ function assertFocusedTrace(format, runNumber, trace) {
     `${prefix}: mutation result must precede resumable begin`,
   );
   assert.ok(
-    boundaryBegin.sequence < firstCursorAfterBoundary.sequence,
-    `${prefix}: resumable begin must precede cursor query`,
+    firstCursorAfterBoundary.sequence < boundaryBegin.sequence,
+    `${prefix}: cursor query and input paint must precede async resumable begin`,
   );
 
   const operationDurations = operations.map((event) => event.durationMs);
@@ -1379,7 +1379,10 @@ function assertRawBoundaryTrace(format, kind, trace) {
   const firstCursorQuery = cursorQueries.find((event) => event.sequence > inserts[0].sequence);
   assert.ok(firstCursorQuery, `${prefix}: cursor query after mutation`);
   assert.ok(inserts[0].sequence < begins[0].sequence, `${prefix}: mutation must precede resumable begin`);
-  assert.ok(begins[0].sequence < firstCursorQuery.sequence, `${prefix}: begin must precede cursor query`);
+  assert.ok(
+    firstCursorQuery.sequence < begins[0].sequence,
+    `${prefix}: cursor query and input paint must precede async resumable begin`,
+  );
 }
 
 function assertRawStableTrace(format, kind, trace) {

--- a/rhwp-studio/e2e/issue-2214-page-local-repaint.test.mjs
+++ b/rhwp-studio/e2e/issue-2214-page-local-repaint.test.mjs
@@ -1,10 +1,12 @@
 /**
- * Issue #2214 focused GREEN regression and optional diagnostic.
+ * Issue #2214 focused GREEN regression, #3815 stack integration, and optional diagnostic.
  *
  * The default path is a focused HWP/HWPX regression that verifies the 56th
  * cell-flow boundary, pre-cursor pagination, exact tree/caret state, and the
  * absence of an additional flush through the 62nd input. The original
- * timeline/PNG controls remain available behind --diagnose.
+ * timeline/PNG controls remain available behind --diagnose. `--continuous-only` is the local
+ * production-WASM + Chrome integration gate for #3815 on top of #3937/#3822; CI only syntax-checks
+ * this browser scenario, so its measured timings and page/revision assertions are local evidence.
  *
  * [#2430] 한양·휴먼 HFT ASCII 실측 교정으로 대상 셀의 줄 채움 임계가 44→56,
  * 관측 범위가 50→62 로 이동했다 (native 계약: tests/issue_2214_page_local_repaint.rs

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -22,6 +22,7 @@
     "e2e:drag-autoscroll": "node e2e/drag-selection-autoscroll.test.mjs",
     "e2e:renderer-contract": "node e2e/renderer-contract.test.mjs",
     "e2e:issue-2214": "node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless",
+    "e2e:issue-3815": "node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless --continuous-only",
     "e2e:issue-3137-perf": "node e2e/probe-input-perf-issue3137.mjs --mode=headless",
     "e2e:issue-2809": "node e2e/issue-2809-split-alignment.test.mjs --mode=headless",
     "e2e:canvaskit-font-coverage": "node e2e/canvaskit-font-coverage.test.mjs",

--- a/rhwp-studio/src/engine/deferred-pagination-runner.ts
+++ b/rhwp-studio/src/engine/deferred-pagination-runner.ts
@@ -9,16 +9,19 @@ export interface DeferredPaginationClient {
 type ScheduledTask = ReturnType<typeof setTimeout>;
 type ScheduleTask = (callback: () => void, delayMs?: number) => ScheduledTask;
 type RunnerState = 'idle' | 'begin-scheduled' | 'stepping';
+type ScheduledStartKind = 'initial' | 'restart';
 
 /**
  * #2424 continuation을 한 macrotask당 한 fragment budget씩 전진시킨다.
- * 입력은 `requestStart()`로 최신 revision 하나만 남긴다. 최초 admission은 다음 task에서 바로
- * 확인하고, 이미 전진 중이거나 restart debounce 중인 job만 지정한 window까지 합친다.
+ * 입력은 `requestStart()`로 최신 revision 하나만 남긴다. 최초 admission은 입력 프레임을 위한
+ * 고정 target delay 뒤에 한 번 확인하고, 이미 전진 중이거나 restart debounce 중인 job은 지정한
+ * window까지 합친다.
  */
 export class DeferredPaginationRunner {
   private scheduled: ScheduledTask | null = null;
   private state: RunnerState = 'idle';
-  private scheduledStartDelayMs: number | null = null;
+  private scheduledStartKind: ScheduledStartKind | null = null;
+  private postFirstStepDelayMs = 0;
   private generation = 0;
 
   constructor(
@@ -42,28 +45,36 @@ export class DeferredPaginationRunner {
   /**
    * 기존 continuation을 폐기하고 최신 descriptor의 begin을 input stack 밖에 예약한다.
    *
-   * 아직 admission을 확인하지 않은 최초 begin은 0ms를 유지한다. 성공해 전진 중인 job 또는
-   * 이미 debounce 중인 restart만 `restartDelayMs`를 다시 적용하므로 unsupported fallback을
-   * 고정 window만큼 늦추지 않는다.
+   * 아직 admission을 확인하지 않은 최초 begin은 `initialDelayMs`의 고정 timer target을 유지한다.
+   * 그 전에 들어온 요청은 timer를 다시 시작하지 않고 begin 시점의 최신 descriptor를 사용한다.
+   * 성공해 전진 중인 job 또는 이미 debounce 중인 restart만 `restartDelayMs`를 다시 적용한다.
    */
-  requestStart(restartDelayMs: number): void {
+  requestStart(restartDelayMs: number, initialDelayMs = 0, postFirstStepDelayMs = 0): void {
     const normalizedRestartDelayMs = Math.max(0, restartDelayMs);
-    const delayMs = this.state === 'stepping'
-      || (this.state === 'begin-scheduled' && (this.scheduledStartDelayMs ?? 0) > 0)
-      ? normalizedRestartDelayMs
-      : 0;
+    const normalizedInitialDelayMs = Math.max(0, initialDelayMs);
+    const normalizedPostFirstStepDelayMs = Math.max(0, postFirstStepDelayMs);
+
+    // 최초 admission timer는 반복 입력으로 추가 지연되지 않는다. begin callback이 WASM의 최신
+    // pending descriptor를 읽으므로 예약을 교체하지 않아도 latest revision 계약을 지킨다.
+    if (this.state === 'begin-scheduled' && this.scheduledStartKind === 'initial') return;
+
+    const isRestart = this.state === 'stepping'
+      || (this.state === 'begin-scheduled' && this.scheduledStartKind === 'restart');
+    const delayMs = isRestart ? normalizedRestartDelayMs : normalizedInitialDelayMs;
+    const startKind: ScheduledStartKind = isRestart ? 'restart' : 'initial';
 
     const generation = ++this.generation;
     this.cancelScheduledTask();
     this.client.cancelDeferredPagination();
     this.state = 'begin-scheduled';
-    this.scheduledStartDelayMs = delayMs;
+    this.scheduledStartKind = startKind;
+    this.postFirstStepDelayMs = normalizedPostFirstStepDelayMs;
     this.scheduled = this.scheduleTask(() => {
       if (!this.isCurrent(generation, 'begin-scheduled')) return;
       this.scheduled = null;
-      this.scheduledStartDelayMs = null;
+      this.scheduledStartKind = null;
       try {
-        this.accept(this.client.beginDeferredPagination(this.fragmentBudget), generation);
+        this.accept(this.client.beginDeferredPagination(this.fragmentBudget), generation, true);
       } catch {
         this.fail(generation);
       }
@@ -77,17 +88,25 @@ export class DeferredPaginationRunner {
       this.client.cancelDeferredPagination();
     }
     this.state = 'idle';
-    this.scheduledStartDelayMs = null;
+    this.scheduledStartKind = null;
+    this.postFirstStepDelayMs = 0;
   }
 
-  private accept(result: DeferredPaginationResult, generation: number): void {
+  private accept(
+    result: DeferredPaginationResult,
+    generation: number,
+    isBegin = false,
+  ): void {
     if (generation !== this.generation) return;
     if (result.status === 'pending') {
       this.state = 'stepping';
-      this.scheduleNextStep(generation);
+      const delayMs = isBegin ? 0 : this.postFirstStepDelayMs;
+      if (!isBegin) this.postFirstStepDelayMs = 0;
+      this.scheduleNextStep(generation, delayMs);
       return;
     }
     this.state = 'idle';
+    this.postFirstStepDelayMs = 0;
     if (result.status === 'complete') {
       this.onComplete(result);
       return;
@@ -95,7 +114,7 @@ export class DeferredPaginationRunner {
     this.onFallback(result);
   }
 
-  private scheduleNextStep(generation: number): void {
+  private scheduleNextStep(generation: number, delayMs = 0): void {
     if (!this.isCurrent(generation, 'stepping') || this.scheduled !== null) return;
     this.scheduled = this.scheduleTask(() => {
       if (!this.isCurrent(generation, 'stepping')) return;
@@ -105,13 +124,14 @@ export class DeferredPaginationRunner {
       } catch {
         this.fail(generation);
       }
-    }, 0);
+    }, delayMs);
   }
 
   private fail(generation: number): void {
     if (generation !== this.generation) return;
     this.state = 'idle';
-    this.scheduledStartDelayMs = null;
+    this.scheduledStartKind = null;
+    this.postFirstStepDelayMs = 0;
     this.onFallback({
       ok: false,
       status: 'fallback',

--- a/rhwp-studio/src/engine/deferred-pagination-runner.ts
+++ b/rhwp-studio/src/engine/deferred-pagination-runner.ts
@@ -7,53 +7,87 @@ export interface DeferredPaginationClient {
 }
 
 type ScheduledTask = ReturnType<typeof setTimeout>;
+type ScheduleTask = (callback: () => void, delayMs?: number) => ScheduledTask;
+type RunnerState = 'idle' | 'begin-scheduled' | 'stepping';
 
 /**
  * #2424 continuation을 한 macrotask당 한 fragment budget씩 전진시킨다.
- * 입력이 오면 `start()`가 기존 shadow job과 예약 task를 폐기하고 최신 revision으로 교체한다.
+ * 입력은 `requestStart()`로 최신 revision 하나만 남긴다. 최초 admission은 다음 task에서 바로
+ * 확인하고, 이미 전진 중이거나 restart debounce 중인 job만 지정한 window까지 합친다.
  */
 export class DeferredPaginationRunner {
   private scheduled: ScheduledTask | null = null;
-  private active = false;
+  private state: RunnerState = 'idle';
+  private scheduledStartDelayMs: number | null = null;
+  private generation = 0;
 
   constructor(
     private readonly client: DeferredPaginationClient,
     private readonly onComplete: (result: DeferredPaginationResult) => void,
     private readonly onFallback: (result: DeferredPaginationResult) => void,
     private readonly fragmentBudget = 1,
-    private readonly scheduleTask: (callback: () => void) => ScheduledTask = (callback) =>
-      setTimeout(callback, 0),
+    private readonly scheduleTask: ScheduleTask = (callback, delayMs = 0) =>
+      setTimeout(callback, delayMs),
     private readonly cancelTask: (task: ScheduledTask) => void = (task) => clearTimeout(task),
   ) {}
 
   isActive(): boolean {
-    return this.active;
+    return this.state === 'stepping';
   }
 
-  start(): DeferredPaginationResult {
+  hasPendingWork(): boolean {
+    return this.state !== 'idle';
+  }
+
+  /**
+   * 기존 continuation을 폐기하고 최신 descriptor의 begin을 input stack 밖에 예약한다.
+   *
+   * 아직 admission을 확인하지 않은 최초 begin은 0ms를 유지한다. 성공해 전진 중인 job 또는
+   * 이미 debounce 중인 restart만 `restartDelayMs`를 다시 적용하므로 unsupported fallback을
+   * 고정 window만큼 늦추지 않는다.
+   */
+  requestStart(restartDelayMs: number): void {
+    const normalizedRestartDelayMs = Math.max(0, restartDelayMs);
+    const delayMs = this.state === 'stepping'
+      || (this.state === 'begin-scheduled' && (this.scheduledStartDelayMs ?? 0) > 0)
+      ? normalizedRestartDelayMs
+      : 0;
+
+    const generation = ++this.generation;
     this.cancelScheduledTask();
     this.client.cancelDeferredPagination();
-    this.active = false;
-    const result = this.client.beginDeferredPagination(this.fragmentBudget);
-    this.accept(result);
-    return result;
+    this.state = 'begin-scheduled';
+    this.scheduledStartDelayMs = delayMs;
+    this.scheduled = this.scheduleTask(() => {
+      if (!this.isCurrent(generation, 'begin-scheduled')) return;
+      this.scheduled = null;
+      this.scheduledStartDelayMs = null;
+      try {
+        this.accept(this.client.beginDeferredPagination(this.fragmentBudget), generation);
+      } catch {
+        this.fail(generation);
+      }
+    }, delayMs);
   }
 
   cancel(): void {
+    ++this.generation;
     this.cancelScheduledTask();
-    if (this.active) {
+    if (this.state === 'stepping') {
       this.client.cancelDeferredPagination();
     }
-    this.active = false;
+    this.state = 'idle';
+    this.scheduledStartDelayMs = null;
   }
 
-  private accept(result: DeferredPaginationResult): void {
+  private accept(result: DeferredPaginationResult, generation: number): void {
+    if (generation !== this.generation) return;
     if (result.status === 'pending') {
-      this.active = true;
-      this.scheduleNextStep();
+      this.state = 'stepping';
+      this.scheduleNextStep(generation);
       return;
     }
-    this.active = false;
+    this.state = 'idle';
     if (result.status === 'complete') {
       this.onComplete(result);
       return;
@@ -61,24 +95,34 @@ export class DeferredPaginationRunner {
     this.onFallback(result);
   }
 
-  private scheduleNextStep(): void {
-    if (!this.active || this.scheduled !== null) return;
+  private scheduleNextStep(generation: number): void {
+    if (!this.isCurrent(generation, 'stepping') || this.scheduled !== null) return;
     this.scheduled = this.scheduleTask(() => {
+      if (!this.isCurrent(generation, 'stepping')) return;
       this.scheduled = null;
-      if (!this.active) return;
       try {
-        this.accept(this.client.stepDeferredPagination(this.fragmentBudget));
+        this.accept(this.client.stepDeferredPagination(this.fragmentBudget), generation);
       } catch {
-        this.active = false;
-        this.onFallback({
-          ok: false,
-          status: 'fallback',
-          revision: 0,
-          fragmentsProcessed: 0,
-          pageCount: 0,
-        });
+        this.fail(generation);
       }
+    }, 0);
+  }
+
+  private fail(generation: number): void {
+    if (generation !== this.generation) return;
+    this.state = 'idle';
+    this.scheduledStartDelayMs = null;
+    this.onFallback({
+      ok: false,
+      status: 'fallback',
+      revision: 0,
+      fragmentsProcessed: 0,
+      pageCount: 0,
     });
+  }
+
+  private isCurrent(generation: number, state: RunnerState): boolean {
+    return generation === this.generation && this.state === state;
   }
 
   private cancelScheduledTask(): void {

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -49,8 +49,12 @@ const DRAG_SCROLL_MAX_STEP_PX = 20;
 const PX_TO_RAW_2X = 150;
 const PX_TO_HWPUNIT = 75;
 const DOCUMENT_PAGINATION_IDLE_FLUSH_DELAY_MS = 120;
+// 최초 입력의 paint 기회를 확보하고 반복 입력이 이 추가 예약 지연을 연장하지 않게 한다.
+const DOCUMENT_PAGINATION_INITIAL_START_DELAY_MS = 100;
 // #3794: 250ms cadence의 obsolete work를 줄이되 최신 job 완료의 10% 회귀 상한 안에 둔다.
 const DOCUMENT_PAGINATION_RESTART_COALESCE_DELAY_MS = 200;
+// 첫 fragment 하나 뒤 다음 입력과 후속 step이 겹치지 않게 하는 짧은 settle gap.
+const DOCUMENT_PAGINATION_POST_FIRST_STEP_DELAY_MS = 25;
 /**
  * [#3412] idle 자동 flush 대상 문서 크기 상한.
  *
@@ -2555,8 +2559,12 @@ export class InputHandler {
     this.deferredPaginationPending = true;
     if (!effects.flowChanged && !replacesPendingJob) return false;
 
-    // 최초 admission은 다음 task에서 바로 확인하고 active restart만 마지막 입력까지 합친다.
-    this.deferredPaginationRunner.requestStart(DOCUMENT_PAGINATION_RESTART_COALESCE_DELAY_MS);
+    // 최초 admission은 고정 timer target을 유지하고, active restart만 마지막 입력까지 합친다.
+    this.deferredPaginationRunner.requestStart(
+      DOCUMENT_PAGINATION_RESTART_COALESCE_DELAY_MS,
+      DOCUMENT_PAGINATION_INITIAL_START_DELAY_MS,
+      DOCUMENT_PAGINATION_POST_FIRST_STEP_DELAY_MS,
+    );
     return true;
   }
 

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -49,6 +49,8 @@ const DRAG_SCROLL_MAX_STEP_PX = 20;
 const PX_TO_RAW_2X = 150;
 const PX_TO_HWPUNIT = 75;
 const DOCUMENT_PAGINATION_IDLE_FLUSH_DELAY_MS = 120;
+// #3794: 250ms cadence의 obsolete work를 줄이되 최신 job 완료의 10% 회귀 상한 안에 둔다.
+const DOCUMENT_PAGINATION_RESTART_COALESCE_DELAY_MS = 200;
 /**
  * [#3412] idle 자동 flush 대상 문서 크기 상한.
  *
@@ -2515,7 +2517,7 @@ export class InputHandler {
    * 하는 셈이라 예약하지 않는다. 문서 크기 상한은 위 상수 주석 참조.
    */
   private shouldAutoFlushDeferredPagination(): boolean {
-    if (this.deferredPaginationRunner.isActive()) return false;
+    if (this.deferredPaginationRunner.hasPendingWork()) return false;
     return this.wasm.pageCount <= DOCUMENT_PAGINATION_IDLE_FLUSH_PAGE_LIMIT;
   }
 
@@ -2548,13 +2550,13 @@ export class InputHandler {
     if (effects.flowChanged && effects.paginationCompleted) return true;
     if (!effects.documentPaginationPending) return false;
 
-    const replacesActiveJob = this.deferredPaginationRunner.isActive();
+    const replacesPendingJob = this.deferredPaginationRunner.hasPendingWork();
     this.cancelDeferredPaginationFlush();
     this.deferredPaginationPending = true;
-    if (!effects.flowChanged && !replacesActiveJob) return false;
+    if (!effects.flowChanged && !replacesPendingJob) return false;
 
-    // 최신 revision의 shadow job으로 교체하고, 한 macrotask당 한 fragment씩 전진한다.
-    this.deferredPaginationRunner.start();
+    // 최초 admission은 다음 task에서 바로 확인하고 active restart만 마지막 입력까지 합친다.
+    this.deferredPaginationRunner.requestStart(DOCUMENT_PAGINATION_RESTART_COALESCE_DELAY_MS);
     return true;
   }
 
@@ -2594,7 +2596,7 @@ export class InputHandler {
   flushDeferredPaginationIfNeeded(reason = 'manual', emitChange = true): boolean {
     const shouldFlush = this.deferredPaginationPending
       || this.deferredPaginationFlushTimer !== null
-      || this.deferredPaginationRunner.isActive();
+      || this.deferredPaginationRunner.hasPendingWork();
     this.cancelDeferredPaginationFlush();
     if (!shouldFlush) return false;
 

--- a/rhwp-studio/tests/deferred-pagination-runner.test.ts
+++ b/rhwp-studio/tests/deferred-pagination-runner.test.ts
@@ -80,6 +80,12 @@ class ManualTasks {
     assert.ok(entry, 'scheduled continuation task');
     return entry[1];
   }
+
+  firstId() {
+    const entry = this.tasks.entries().next().value;
+    assert.ok(entry, 'scheduled continuation task');
+    return entry[0];
+  }
 }
 
 class FakeClient {
@@ -125,23 +131,26 @@ test('최초 begin은 input stack 밖에서 실행하고 이후 한 macrotask당
     (task) => tasks.cancel(task),
   );
 
-  runner.requestStart(200);
+  runner.requestStart(200, 100, 25);
   assert.equal(runner.isActive(), false);
   assert.equal(runner.hasPendingWork(), true);
   assert.deepEqual(client.calls, [['cancel']], 'begin must not run in the input call stack');
-  assert.equal(tasks.first().delayMs, 0, 'first admission runs in the next task without debounce');
+  assert.equal(tasks.first().delayMs, 100, 'first admission has a fixed paint timer target');
 
   tasks.runOne();
   assert.deepEqual(client.calls.at(-1), ['begin', 1, 1]);
   assert.equal(runner.isActive(), true);
+  assert.equal(tasks.first().delayMs, 0, 'first fragment step starts on the regular task cadence');
 
   tasks.runOne();
   assert.deepEqual(client.calls.at(-1), ['step', 1]);
   assert.equal(runner.isActive(), true);
   assert.equal(completed.length, 0);
+  assert.equal(tasks.first().delayMs, 25, 'the first fragment yields through the settle gap');
 
   tasks.runOne();
   assert.equal(runner.isActive(), true);
+  assert.equal(tasks.first().delayMs, 0, 'later fragment steps keep the regular task cadence');
   tasks.runOne();
   assert.equal(runner.isActive(), false);
   assert.equal(completed.length, 1);
@@ -169,7 +178,7 @@ test('공개 페이지 수는 async begin과 pending step 동안 유지되고 co
     (task) => tasks.cancel(task),
   );
 
-  runner.requestStart(200);
+  runner.requestStart(200, 100, 20);
   assert.equal(publicPageCount, 115);
   assert.deepEqual(published, []);
 
@@ -186,7 +195,7 @@ test('공개 페이지 수는 async begin과 pending step 동안 유지되고 co
   assert.deepEqual(published, [116], 'final page count must publish once');
 });
 
-test('begin 전 반복 요청은 pending task 하나와 최신 revision begin 하나만 남긴다', () => {
+test('begin 전 반복 요청은 최초 timer target을 유지하고 최신 revision begin 하나만 남긴다', () => {
   const tasks = new ManualTasks();
   const client = new FakeClient([result('complete', 2, 1)]);
   const completed = [];
@@ -199,17 +208,19 @@ test('begin 전 반복 요청은 pending task 하나와 최신 revision begin �
     (task) => tasks.cancel(task),
   );
 
-  runner.requestStart(200);
+  runner.requestStart(200, 100, 20);
   assert.equal(tasks.tasks.size, 1);
-  assert.equal(tasks.first().delayMs, 0);
+  assert.equal(tasks.first().delayMs, 100);
+  const initialTaskId = tasks.firstId();
   client.beginRevision = 2;
-  runner.requestStart(200);
-  assert.equal(tasks.tasks.size, 1, 'old scheduled begin must be replaced');
-  assert.equal(tasks.first().delayMs, 0, 'unproven admission must not inherit restart debounce');
+  runner.requestStart(200, 100, 20);
+  assert.equal(tasks.tasks.size, 1, 'initial timer must keep one scheduled begin');
+  assert.equal(tasks.firstId(), initialTaskId, 'repeated input must not move the initial timer');
+  assert.equal(tasks.first().delayMs, 100, 'unproven admission keeps the fixed initial timer target');
   assert.equal(client.calls.some(([name]) => name === 'begin'), false);
   assert.deepEqual(
     client.calls.filter(([name]) => name === 'cancel'),
-    [['cancel'], ['cancel']],
+    [['cancel']],
   );
 
   tasks.runOne();
@@ -232,16 +243,18 @@ test('active restart와 그 후 요청은 old step을 버리고 coalescing windo
     (task) => tasks.cancel(task),
   );
 
-  runner.requestStart(200);
+  runner.requestStart(200, 100, 20);
   tasks.runOne();
   assert.equal(runner.isActive(), true);
   const staleStep = tasks.first().callback;
 
   client.beginRevision = 2;
-  runner.requestStart(200);
+  runner.requestStart(200, 100, 20);
   assert.equal(runner.isActive(), false);
   assert.equal(tasks.tasks.size, 1);
   assert.equal(tasks.first().delayMs, 200);
+  const staleRestartBegin = tasks.first().callback;
+  const firstRestartTaskId = tasks.firstId();
   staleStep();
   assert.equal(
     client.calls.some(([name]) => name === 'step'),
@@ -250,14 +263,59 @@ test('active restart와 그 후 요청은 old step을 버리고 coalescing windo
   );
 
   client.beginRevision = 3;
-  runner.requestStart(200);
+  runner.requestStart(200, 100, 20);
   assert.equal(tasks.tasks.size, 1);
+  assert.notEqual(tasks.firstId(), firstRestartTaskId, 'restart window must move to the latest input');
   assert.equal(tasks.first().delayMs, 200, 'latest input must restart the coalescing window');
+  staleRestartBegin();
+  assert.equal(
+    client.calls.some(([name, , revision]) => name === 'begin' && revision === 2),
+    false,
+    'a superseded restart callback must not begin its revision',
+  );
   tasks.runOne();
   assert.deepEqual(client.calls.at(-1), ['begin', 1, 3]);
   tasks.runOne();
   assert.equal(completed.length, 1);
   assert.equal(completed[0].revision, 3);
+});
+
+test('post-first settle task는 restart 뒤 core step을 실행할 수 없다', () => {
+  const tasks = new ManualTasks();
+  const client = new FakeClient([
+    result('pending', 1, 1),
+    result('complete', 2, 1),
+  ]);
+  const completed = [];
+  const runner = new DeferredPaginationRunner(
+    client,
+    (value) => completed.push(value),
+    () => assert.fail('fallback must not run'),
+    1,
+    (callback, delayMs) => tasks.schedule(callback, delayMs),
+    (task) => tasks.cancel(task),
+  );
+
+  runner.requestStart(200, 100, 25);
+  tasks.runOne();
+  tasks.runOne();
+  assert.equal(tasks.first().delayMs, 25);
+  const staleSettledStep = tasks.first().callback;
+
+  client.beginRevision = 2;
+  runner.requestStart(200, 100, 25);
+  assert.equal(tasks.first().delayMs, 200);
+  staleSettledStep();
+  assert.equal(
+    client.calls.filter(([name]) => name === 'step').length,
+    1,
+    'superseded settle callback must not enter the old core job',
+  );
+
+  tasks.runOne();
+  tasks.runOne();
+  assert.equal(completed.length, 1);
+  assert.equal(completed[0].revision, 2);
 });
 
 test('cancel은 queued begin과 이미 dequeue된 stale callback을 모두 무효화한다', () => {
@@ -274,7 +332,7 @@ test('cancel은 queued begin과 이미 dequeue된 stale callback을 모두 무�
     (task) => tasks.cancel(task),
   );
 
-  runner.requestStart(200);
+  runner.requestStart(200, 100);
   const staleBegin = tasks.first().callback;
   runner.cancel();
   assert.equal(runner.hasPendingWork(), false);
@@ -302,7 +360,7 @@ test('unsupported async begin은 step 없이 fallback callback으로 전달한�
     (task) => tasks.cancel(task),
   );
 
-  runner.requestStart(200);
+  runner.requestStart(200, 100);
   assert.equal(fallbacks.length, 0, 'fallback must not run in the input call stack');
   tasks.runOne();
   assert.equal(runner.isActive(), false);
@@ -335,7 +393,7 @@ test('begin과 step 예외는 각각 fallback을 정확히 한 번 게시한다'
       (task) => tasks.cancel(task),
     );
 
-    runner.requestStart(200);
+    runner.requestStart(200, 100);
     tasks.runOne();
     if (failure === 'step') tasks.runOne();
     assert.equal(fallbacks.length, 1, `${failure} fallback count`);

--- a/rhwp-studio/tests/deferred-pagination-runner.test.ts
+++ b/rhwp-studio/tests/deferred-pagination-runner.test.ts
@@ -57,9 +57,9 @@ class ManualTasks {
     this.tasks = new Map();
   }
 
-  schedule(callback) {
+  schedule(callback, delayMs = 0) {
     const id = this.nextId++;
-    this.tasks.set(id, callback);
+    this.tasks.set(id, { callback, delayMs });
     return id;
   }
 
@@ -70,9 +70,15 @@ class ManualTasks {
   runOne() {
     const entry = this.tasks.entries().next().value;
     assert.ok(entry, 'scheduled continuation task');
-    const [id, callback] = entry;
+    const [id, task] = entry;
     this.tasks.delete(id);
-    callback();
+    task.callback();
+  }
+
+  first() {
+    const entry = this.tasks.entries().next().value;
+    assert.ok(entry, 'scheduled continuation task');
+    return entry[1];
   }
 }
 
@@ -101,7 +107,7 @@ class FakeClient {
   }
 }
 
-test('한 macrotask당 한 budget만 처리하고 complete에서 한 번 commit callback을 호출한다', () => {
+test('최초 begin은 input stack 밖에서 실행하고 이후 한 macrotask당 한 budget만 처리한다', () => {
   const tasks = new ManualTasks();
   const client = new FakeClient([
     result('pending', 1, 1),
@@ -115,13 +121,19 @@ test('한 macrotask당 한 budget만 처리하고 complete에서 한 번 commit 
     (value) => completed.push(value),
     (value) => fallbacks.push(value),
     1,
-    (callback) => tasks.schedule(callback),
+    (callback, delayMs) => tasks.schedule(callback, delayMs),
     (task) => tasks.cancel(task),
   );
 
-  assert.equal(runner.start().status, 'pending');
+  runner.requestStart(200);
+  assert.equal(runner.isActive(), false);
+  assert.equal(runner.hasPendingWork(), true);
+  assert.deepEqual(client.calls, [['cancel']], 'begin must not run in the input call stack');
+  assert.equal(tasks.first().delayMs, 0, 'first admission runs in the next task without debounce');
+
+  tasks.runOne();
+  assert.deepEqual(client.calls.at(-1), ['begin', 1, 1]);
   assert.equal(runner.isActive(), true);
-  assert.deepEqual(client.calls, [['cancel'], ['begin', 1, 1]]);
 
   tasks.runOne();
   assert.deepEqual(client.calls.at(-1), ['step', 1]);
@@ -137,7 +149,7 @@ test('한 macrotask당 한 budget만 처리하고 complete에서 한 번 commit 
   assert.equal(fallbacks.length, 0);
 });
 
-test('공개 페이지 수는 pending 동안 유지되고 complete callback에서 한 번 교체된다', () => {
+test('공개 페이지 수는 async begin과 pending step 동안 유지되고 complete에서 한 번 교체된다', () => {
   const tasks = new ManualTasks();
   const client = new FakeClient([
     result('pending', 1, 1, 115),
@@ -153,13 +165,16 @@ test('공개 페이지 수는 pending 동안 유지되고 complete callback에�
     },
     () => assert.fail('fallback must not run'),
     1,
-    (callback) => tasks.schedule(callback),
+    (callback, delayMs) => tasks.schedule(callback, delayMs),
     (task) => tasks.cancel(task),
   );
 
-  const begin = runner.start();
-  assert.equal(begin.pageCount, 115);
+  runner.requestStart(200);
   assert.equal(publicPageCount, 115);
+  assert.deepEqual(published, []);
+
+  tasks.runOne();
+  assert.equal(publicPageCount, 115, 'begin result must stay private');
   assert.deepEqual(published, []);
 
   tasks.runOne();
@@ -171,7 +186,7 @@ test('공개 페이지 수는 pending 동안 유지되고 complete callback에�
   assert.deepEqual(published, [116], 'final page count must publish once');
 });
 
-test('새 입력 start는 예약 step과 이전 core job을 취소하고 최신 revision으로 교체한다', () => {
+test('begin 전 반복 요청은 pending task 하나와 최신 revision begin 하나만 남긴다', () => {
   const tasks = new ManualTasks();
   const client = new FakeClient([result('complete', 2, 1)]);
   const completed = [];
@@ -180,26 +195,97 @@ test('새 입력 start는 예약 step과 이전 core job을 취소하고 최신 
     (value) => completed.push(value),
     () => assert.fail('fallback must not run'),
     1,
-    (callback) => tasks.schedule(callback),
+    (callback, delayMs) => tasks.schedule(callback, delayMs),
     (task) => tasks.cancel(task),
   );
 
-  runner.start();
+  runner.requestStart(200);
   assert.equal(tasks.tasks.size, 1);
+  assert.equal(tasks.first().delayMs, 0);
   client.beginRevision = 2;
-  runner.start();
-  assert.equal(tasks.tasks.size, 1, 'old scheduled step must be replaced');
+  runner.requestStart(200);
+  assert.equal(tasks.tasks.size, 1, 'old scheduled begin must be replaced');
+  assert.equal(tasks.first().delayMs, 0, 'unproven admission must not inherit restart debounce');
+  assert.equal(client.calls.some(([name]) => name === 'begin'), false);
   assert.deepEqual(
     client.calls.filter(([name]) => name === 'cancel'),
     [['cancel'], ['cancel']],
   );
 
   tasks.runOne();
+  assert.deepEqual(client.calls.at(-1), ['begin', 1, 2]);
+  tasks.runOne();
   assert.equal(completed.length, 1);
   assert.equal(completed[0].revision, 2);
 });
 
-test('unsupported begin은 step을 예약하지 않고 fallback callback으로 전달한다', () => {
+test('active restart와 그 후 요청은 old step을 버리고 coalescing window를 다시 시작한다', () => {
+  const tasks = new ManualTasks();
+  const client = new FakeClient([result('complete', 3, 1)]);
+  const completed = [];
+  const runner = new DeferredPaginationRunner(
+    client,
+    (value) => completed.push(value),
+    () => assert.fail('fallback must not run'),
+    1,
+    (callback, delayMs) => tasks.schedule(callback, delayMs),
+    (task) => tasks.cancel(task),
+  );
+
+  runner.requestStart(200);
+  tasks.runOne();
+  assert.equal(runner.isActive(), true);
+  const staleStep = tasks.first().callback;
+
+  client.beginRevision = 2;
+  runner.requestStart(200);
+  assert.equal(runner.isActive(), false);
+  assert.equal(tasks.tasks.size, 1);
+  assert.equal(tasks.first().delayMs, 200);
+  staleStep();
+  assert.equal(
+    client.calls.some(([name]) => name === 'step'),
+    false,
+    'a superseded callback must not enter the old core job',
+  );
+
+  client.beginRevision = 3;
+  runner.requestStart(200);
+  assert.equal(tasks.tasks.size, 1);
+  assert.equal(tasks.first().delayMs, 200, 'latest input must restart the coalescing window');
+  tasks.runOne();
+  assert.deepEqual(client.calls.at(-1), ['begin', 1, 3]);
+  tasks.runOne();
+  assert.equal(completed.length, 1);
+  assert.equal(completed[0].revision, 3);
+});
+
+test('cancel은 queued begin과 이미 dequeue된 stale callback을 모두 무효화한다', () => {
+  const tasks = new ManualTasks();
+  const client = new FakeClient([]);
+  const completed = [];
+  const fallbacks = [];
+  const runner = new DeferredPaginationRunner(
+    client,
+    (value) => completed.push(value),
+    (value) => fallbacks.push(value),
+    1,
+    (callback, delayMs) => tasks.schedule(callback, delayMs),
+    (task) => tasks.cancel(task),
+  );
+
+  runner.requestStart(200);
+  const staleBegin = tasks.first().callback;
+  runner.cancel();
+  assert.equal(runner.hasPendingWork(), false);
+  assert.equal(tasks.tasks.size, 0);
+  staleBegin();
+  assert.equal(client.calls.some(([name]) => name === 'begin'), false);
+  assert.equal(completed.length, 0);
+  assert.equal(fallbacks.length, 0);
+});
+
+test('unsupported async begin은 step 없이 fallback callback으로 전달한다', () => {
   const tasks = new ManualTasks();
   const client = new FakeClient([]);
   client.beginDeferredPagination = (budget) => {
@@ -212,13 +298,48 @@ test('unsupported begin은 step을 예약하지 않고 fallback callback으로 �
     () => assert.fail('complete must not run'),
     (value) => fallbacks.push(value),
     1,
-    (callback) => tasks.schedule(callback),
+    (callback, delayMs) => tasks.schedule(callback, delayMs),
     (task) => tasks.cancel(task),
   );
 
-  assert.equal(runner.start().status, 'fallback');
+  runner.requestStart(200);
+  assert.equal(fallbacks.length, 0, 'fallback must not run in the input call stack');
+  tasks.runOne();
   assert.equal(runner.isActive(), false);
+  assert.equal(runner.hasPendingWork(), false);
   assert.equal(tasks.tasks.size, 0);
   assert.equal(fallbacks.length, 1);
   assert.equal(fallbacks[0].revision, 7);
+});
+
+test('begin과 step 예외는 각각 fallback을 정확히 한 번 게시한다', () => {
+  for (const failure of ['begin', 'step']) {
+    const tasks = new ManualTasks();
+    const client = new FakeClient([]);
+    if (failure === 'begin') {
+      client.beginDeferredPagination = () => {
+        throw new Error('begin failed');
+      };
+    } else {
+      client.stepDeferredPagination = () => {
+        throw new Error('step failed');
+      };
+    }
+    const fallbacks = [];
+    const runner = new DeferredPaginationRunner(
+      client,
+      () => assert.fail('complete must not run'),
+      (value) => fallbacks.push(value),
+      1,
+      (callback, delayMs) => tasks.schedule(callback, delayMs),
+      (task) => tasks.cancel(task),
+    );
+
+    runner.requestStart(200);
+    tasks.runOne();
+    if (failure === 'step') tasks.runOne();
+    assert.equal(fallbacks.length, 1, `${failure} fallback count`);
+    assert.equal(fallbacks[0].status, 'fallback');
+    assert.equal(runner.hasPendingWork(), false);
+  }
 });

--- a/rhwp-studio/tests/input-edit-invalidation.test.ts
+++ b/rhwp-studio/tests/input-edit-invalidation.test.ts
@@ -208,7 +208,7 @@ test('deferred pending이 실제로 있을 때만 page-local idle flush를 예�
   );
   assert.match(
     inputHandlerSource,
-    /this\.deferredPaginationRunner\.requestStart\(DOCUMENT_PAGINATION_RESTART_COALESCE_DELAY_MS\);/,
+    /this\.deferredPaginationRunner\.requestStart\(\s*DOCUMENT_PAGINATION_RESTART_COALESCE_DELAY_MS,\s*DOCUMENT_PAGINATION_INITIAL_START_DELAY_MS,\s*DOCUMENT_PAGINATION_POST_FIRST_STEP_DELAY_MS,\s*\);/,
     'cell-flow 경계는 input stack 밖에서 latest-only resumable begin을 요청해야 한다',
   );
 });
@@ -237,8 +237,18 @@ test('document pagination은 작은 문서의 120ms idle과 명시 boundary에�
   );
   assert.match(
     inputHandlerSource,
+    /const DOCUMENT_PAGINATION_INITIAL_START_DELAY_MS = 100;/,
+    '최초 begin은 입력 paint를 위한 고정 100ms timer target을 둔다',
+  );
+  assert.match(
+    inputHandlerSource,
     /const DOCUMENT_PAGINATION_RESTART_COALESCE_DELAY_MS = 200;/,
     'active restart만 마지막 입력 뒤 200ms까지 합친다',
+  );
+  assert.match(
+    inputHandlerSource,
+    /const DOCUMENT_PAGINATION_POST_FIRST_STEP_DELAY_MS = 25;/,
+    '첫 fragment 뒤 후속 step은 25ms settle gap 뒤 실행한다',
   );
   assert.match(
     inputHandlerSource,

--- a/rhwp-studio/tests/input-edit-invalidation.test.ts
+++ b/rhwp-studio/tests/input-edit-invalidation.test.ts
@@ -200,12 +200,16 @@ test('deferred pending이 실제로 있을 때만 page-local idle flush를 예�
   assert.match(inputHandlerSource, /if \(!effects\.documentPaginationPending\) return false;/);
   assert.match(
     inputHandlerSource,
-    /if \(!effects\.flowChanged && !replacesActiveJob\) return false;/,
+    /const replacesPendingJob = this\.deferredPaginationRunner\.hasPendingWork\(\);/,
   );
   assert.match(
     inputHandlerSource,
-    /this\.deferredPaginationRunner\.start\(\);/,
-    'cell-flow 경계는 동기 full flush 대신 resumable macrotask runner를 시작해야 한다',
+    /if \(!effects\.flowChanged && !replacesPendingJob\) return false;/,
+  );
+  assert.match(
+    inputHandlerSource,
+    /this\.deferredPaginationRunner\.requestStart\(DOCUMENT_PAGINATION_RESTART_COALESCE_DELAY_MS\);/,
+    'cell-flow 경계는 input stack 밖에서 latest-only resumable begin을 요청해야 한다',
   );
 });
 
@@ -233,8 +237,18 @@ test('document pagination은 작은 문서의 120ms idle과 명시 boundary에�
   );
   assert.match(
     inputHandlerSource,
-    /private shouldAutoFlushDeferredPagination\(\): boolean \{\s*if \(this\.deferredPaginationRunner\.isActive\(\)\) return false;\s*return this\.wasm\.pageCount <= DOCUMENT_PAGINATION_IDLE_FLUSH_PAGE_LIMIT;\s*\}/,
-    '전진 중인 resumable job 이 있으면 idle flush 는 같은 일을 동기로 되풀이하므로 예약하지 않는다',
+    /const DOCUMENT_PAGINATION_RESTART_COALESCE_DELAY_MS = 200;/,
+    'active restart만 마지막 입력 뒤 200ms까지 합친다',
+  );
+  assert.match(
+    inputHandlerSource,
+    /private shouldAutoFlushDeferredPagination\(\): boolean \{\s*if \(this\.deferredPaginationRunner\.hasPendingWork\(\)\) return false;\s*return this\.wasm\.pageCount <= DOCUMENT_PAGINATION_IDLE_FLUSH_PAGE_LIMIT;\s*\}/,
+    '예약 begin 또는 전진 중 job이 있으면 idle flush가 같은 일을 동기로 되풀이하면 안 된다',
+  );
+  assert.match(
+    inputHandlerSource,
+    /const shouldFlush = this\.deferredPaginationPending\s*\|\| this\.deferredPaginationFlushTimer !== null\s*\|\| this\.deferredPaginationRunner\.hasPendingWork\(\);/,
+    '명시 barrier는 queued begin도 pending work로 취급해야 한다',
   );
 
   const undoStart = inputHandlerSource.indexOf('private handleUndo(): void {');


### PR DESCRIPTION
> **Stack layer:** 3 / 3
> **Parent:** [#3945](https://github.com/edwardkim/rhwp/pull/3945) — #3822 overlong-token wrap
> **Branch:** `stack/issue-3815-pagination-coalescing`
> **Ultimate base:** `devel@cf5d462dc`

## 변경 요약

115쪽 거대 표 셀의 flow 입력에서 `beginDeferredPagination()`이 input dispatch 호출 스택 안에서 실행되고, 후속 입력마다 active job을 취소한 뒤 처음부터 다시 시작하던 비용을 줄입니다.

`DeferredPaginationRunner`에 명시적 상태와 latest-revision coalescing을 추가합니다.

- 상태: `idle / begin-scheduled / stepping`
- 최초 begin: 반복 입력이 연장하지 않는 `100ms` timer target
- active restart: 마지막 요청 기준 `200ms` trailing window
- begin 뒤 첫 fragment: 즉시 전진
- 다음 step 한 번만 `25ms` settle gap
- 이후 step: 기존 cadence
- generation guard로 superseded callback/result/publication 차단
- scheduled begin과 active step에 동일한 flush/save/print/navigation barrier 적용

## 이 레이어의 변경

- scheduled-begin 상태와 generation guard 추가
- input 호출 스택 밖에서 shadow pagination 시작
- 예약 중 반복 요청을 latest descriptor 하나로 교체
- active restart의 obsolete 계산을 trailing window로 coalesce
- scheduled begin을 `hasPendingWork()`에 포함
- cancel, explicit flush, save/print와 navigation barrier가 scheduled/active 작업을 모두 처리
- begin/step 예외의 synchronous fallback 유지
- InputHandler idle-flush와 replacement 판단 갱신
- IME→공백→긴 숫자 token이 pagination pending 중 두 번 wrap되는 HWP/HWPX E2E 추가

## Stack

| Layer | PR | 역할 |
| ---: | --- | --- |
| 1 | [#3944](https://github.com/edwardkim/rhwp/pull/3944) | Canvas2D/SVG 배분 간격과 glyph 폭 분리 |
| 2 | [#3945](https://github.com/edwardkim/rhwp/pull/3945) | prior break 뒤 긴 무공백 token 재분할 |
| 3 | **[#3946 (이 PR)](https://github.com/edwardkim/rhwp/pull/3946)** | deferred pagination coalescing과 통합 E2E |

#3815 제품 코드는 하위 renderer/composer 레이어와 독립적입니다. 이 PR의 연속 IME→긴 숫자 E2E는 세 변경이 적용된 Stack 전체를 검증합니다.

## 최신 검증

- [x] runner + InputHandler focused: `23/23`
- [x] Studio tests: `763/763` (최신 head 재실행)
- [x] `npx tsc --noEmit`
- [x] E2E MANIFEST: tracked `81/81`, 이상 없음
- [x] `node --check e2e/issue-2214-page-local-repaint.test.mjs`
- [x] production WASM release build
- [x] latest-base `wasm32-unknown-unknown` check
- [x] renderer spacing: `42/42`
- [x] SVG renderer: `41/41`
- [x] composer: `53/53`
- [x] HWP/HWPX continuous-only combined E2E: `2/2`
  - 숫자 줄 전환 `11 / 69`
  - 최종 숫자 `73`, 최종 쪽수 `116`
  - HWP pending operation p95 `49.6ms`
  - HWPX pending operation p95 `49.7ms`
  - latest begin/final step revision `132 / 132`
  - stale publication, synchronous flow flush와 browser error `0`
- [x] collaborator review 기록: `mydocs/pr/archives/pr_3946_review.md`
- [x] `git diff --check`
- [x] GitHub Actions (최신 head 통과)

최종 upstream rebase 뒤 production WASM과 HWP/HWPX combined smoke를 다시 실행해 `115 → 116` 계약을 확인했습니다. `--continuous-only`는 #2214 helper를 재사용하되 `npm run e2e:issue-3815`로 독립 진입할 수 있습니다. CI는 이 브라우저 시나리오를 실행하지 않고 `node --check`만 수행하므로 위 p95·쪽수·revision·flush 결과는 로컬 production WASM + Chrome 증적입니다.

## 기존 성능 결과

| 시나리오 | 형식 | sync p95 | 2-rAF 중앙값 | 완료 중앙값 / 최악 | 폐기 CPU |
| --- | --- | ---: | ---: | ---: | ---: |
| current | HWP | 49.7ms | 64.9ms | `1,581.6 / 1,596.7ms` | 0% |
| current | HWPX | 49.6ms | 65.1ms | `1,586.0 / 1,600.5ms` | 0% |
| 80ms | HWP | 50.1ms | 65.9ms | `1,675.4 / 1,694.9ms` | 4.26% |
| 80ms | HWPX | 49.6ms | 67.8ms | `1,691.4 / 1,705.7ms` | 4.20% |
| 250ms | HWP | 50.0ms | 64.4ms | `1,706.7 / 1,709.1ms` | 19.52% |
| 250ms | HWPX | 49.5ms | 65.1ms | `1,708.9 / 1,710.2ms` | 19.36% |

- input dispatch와 begin overlap: `0`
- step p95 최대 `8.4ms`
- superseded publication: `0`
- flow 입력 중 synchronous pagination flush: `0`
- 최신 smoke의 pending operation p95 변화는 기존 smoke 대비 HWP `-2.4%`, HWPX `-1.0%`로 ±10% gate 안이므로 3회 전체 측정은 반복하지 않았습니다.

## Known limits

- 200ms보다 짧은 입력이 계속되면 pagination step과 공개 쪽수 갱신이 일시 정지합니다. 200ms 이상 쉬면 최신 revision에서 재개되고 완료 뒤 stable-tail fast path로 복귀합니다. pending 중 120ms idle flush는 이를 선점하지 않습니다.
- pagination pending 중 exact cursor query 약 `49–51ms`가 남습니다. flow가 안정되면 stable-tail fast path로 복귀합니다.
- Enter pending의 pre-navigation flush 제거는 범위가 아닙니다.
- scheduler backend를 `MessageChannel` 또는 `scheduler.postTask`로 변경하지 않습니다.
- fragment budget은 기존 `1`을 유지합니다.
- PageCheckpoint, DisplaySnapshot, CellFlowTree와 복잡 HWP flow 확대는 #3743의 후속 작업입니다.
- 저장·인쇄는 계속 full pagination barrier를 사용합니다.

Closes #3815

Parent architecture issue: #3743  
Measurement predecessor: #3794  
Correctness prerequisite: [#3945](https://github.com/edwardkim/rhwp/pull/3945)
