### PR TITLE
test(ci): Stage 3 frontend-only unit canary

### DIFF
--- a/rhwp-studio/src/command/shortcut-map.ts
+++ b/rhwp-studio/src/command/shortcut-map.ts
@@ -3,19 +3,21 @@ import { detectPlatformKind, type PlatformKind } from '../engine/navigation-keym
 /** 키보드 단축키 정의 */
 export interface ShortcutDef {
   /** 키 문자 (소문자). 예: 'z', 'b', '=', '-' */
-  key: string;
+  readonly key: string;
   /** 물리 키 코드. IME 입력 중 key가 Process일 때 사용한다. 예: 'KeyJ' */
-  code?: string;
+  readonly code?: string;
   /** Ctrl (Windows) 또는 Meta (Mac) */
-  ctrl?: boolean;
-  shift?: boolean;
-  alt?: boolean;
+  readonly ctrl?: boolean;
+  readonly shift?: boolean;
+  readonly alt?: boolean;
   /** 특정 플랫폼에서만 활성화해야 하는 단축키 */
-  platform?: PlatformKind;
+  readonly platform?: PlatformKind;
 }
 
+export type ShortcutEntry = readonly [ShortcutDef, string];
+
 /** 기본 단축키 → 커맨드 ID 매핑 */
-export const defaultShortcuts: [ShortcutDef, string][] = [
+export const defaultShortcuts: readonly ShortcutEntry[] = [
   // 편집
   [{ key: 'z', ctrl: true }, 'edit:undo'],
   [{ key: 'z', ctrl: true, shift: true }, 'edit:redo'],
@@ -137,7 +139,7 @@ export const defaultShortcuts: [ShortcutDef, string][] = [
  */
 export function matchShortcut(
   e: KeyboardEvent,
-  shortcuts: [ShortcutDef, string][],
+  shortcuts: readonly ShortcutEntry[],
   platform: PlatformKind = detectPlatformKind(),
 ): string | null {
   const ctrlOrMeta = e.ctrlKey || e.metaKey;

--- a/rhwp-studio/tests/shortcut-map.test.ts
+++ b/rhwp-studio/tests/shortcut-map.test.ts
@@ -49,6 +49,15 @@ test('macOS 영문 입력 Option+G의 © 문자 값도 물리 KeyG로 찾아가�
   assert.equal(command({ key: '©', code: 'KeyH', altKey: true }, 'mac'), null);
 });
 
+test('개체 속성 P 단축키를 영문·한글·IME pending 입력에서 동일하게 매핑한다', () => {
+  assert.equal(command({ key: 'p', code: 'KeyP' }), 'format:object-properties');
+  assert.equal(command({ key: 'ㅔ', code: 'KeyP' }), 'format:object-properties');
+  assert.equal(command({ key: 'Process', code: 'KeyP' }), 'format:object-properties');
+  assert.equal(command({ key: 'p', code: 'KeyP', ctrlKey: true }), 'file:print');
+  assert.equal(command({ key: 'p', code: 'KeyP', shiftKey: true }), null);
+  assert.equal(command({ key: 'Process', code: 'KeyO' }), null);
+});
+
 test('표 줄/칸 추가·지우기 단축키는 대화상자 명령으로 매핑한다', () => {
   assert.equal(command({ key: 'Enter', altKey: true }, 'mac'), 'table:insert-row-col');
   assert.equal(command({ key: 'enter', altKey: true }, 'mac'), 'table:insert-row-col');


### PR DESCRIPTION
## 요약

> 이 PR은 #3790 Stage 3의 CI canary이며 merge 대상이 아닙니다. selective/full 측정 근거를 남긴 뒤 close합니다.

- Studio 단축키 정의와 mapping entry를 TypeScript 읽기 전용 계약으로 좁힙니다.
- #3682의 개체 속성 `P` 단축키를 영문·한글·IME pending 입력에서 고정하는 회귀를 추가합니다.
- #3943에서 활성화한 #3790 Stage 3 `frontend_mode=unit`/non-render 경로를 실제 frontend-only 변경으로 검증합니다.

Refs #3790
Related to #3682

## 변경 의도

측정 전용 no-op 대신 최근 수정의 누락된 회귀를 보강했습니다. 렌더러, WASM, package·asset 경계와
Rust 소스는 변경하지 않습니다.

classifier v1의 로컬 예상값은 다음과 같습니다.

| 출력 | 값 |
| --- | --- |
| `classification_status` | `classified` |
| `frontend_mode` | `unit` |
| `render_required` | `false` |
| `rust_required` | `false` |
| `native_skia_required` | `false` |
| `codeql_languages` | `javascript-typescript` |
| `reason` | `classified:studio-unit` |

## Stage 3 canary 기대값

| 검증 | 기대 결과 |
| --- | --- |
| CI preflight | `classified:studio-unit`, `frontend_mode=unit` |
| Frontend unit gates | success |
| Frontend package gates | skipped |
| Render Diff preflight | success, `render_required=false` |
| Canvas visual diff | skipped |
| Rust lint·3 builders·4 workers·Native Skia | success — Stage 4 전이므로 아직 실행 |
| CodeQL JavaScript/Python/Rust | success — Stage 5 전이므로 아직 모두 실행 |
| Build & Test | success |

## 로컬 검증

- `node --test rhwp-studio/tests/shortcut-map.test.ts` — 7/7 통과
- `npx --prefix rhwp-studio tsc --project rhwp-studio/tsconfig.ci-unit.json --noEmit` — 통과
- `npm --prefix rhwp-studio run test` — 760/760 통과
- classifier v1 직접 판정 — `classified:studio-unit`, `unit`, non-render
- `git diff --check` — 통과

## 측정 및 종료

일반 PR run의 selective 진리표를 확인한 뒤 같은 head SHA의 branch ref로 `CI`와 `Render Diff`를
`workflow_dispatch`해 full lane을 실행합니다. selective에서 생략된 `Frontend package gates`와
`Canvas visual diff`의 실제 duration을 주 절감 근거로 사용합니다.

수동 CI의 일부 Rust job은 PR run의 `release-test` 대신 `release` profile을 사용하므로 두 run의 전체
wall time 차이는 순수 절감량으로 해석하지 않습니다. workflow override, 강제 full sentinel과 label 기반
재실행은 추가하지 않습니다. 결과와 run URL을 #3790에 기록한 뒤 이 draft PR은 merge하지 않고 close합니다.
