### PR TITLE
fix(studio): 각주 편집 전역 단축키 복구

### DIFF
--- a/mydocs/orders/20260804.md
+++ b/mydocs/orders/20260804.md
@@ -1,5 +1,20 @@
 # 오늘 할일 - 2026년 8월 4일
 
+## #4026 - 각주 편집 전역 단축키
+
+- 각주 편집 모드의 조기 반환 때문에 macOS `Option+G`와 `Cmd+Z`가 공통 단축키 라우팅에
+  도달하지 못하는 문제를 보정했다. `undo`, `redo`, `goto`만 서브모드 공통 명령으로 먼저
+  전달해 각주 입력·이동·삭제·Escape 동작은 바꾸지 않았다.
+- 실제 `footnote-01.hwp`에서 각주 텍스트 입력 후 `Cmd+Z` 커서 복원과 `Option+G` 찾아가기
+  대화상자 표시를 headless browser E2E로 확인했다. TypeScript, Studio 단위 테스트 763건,
+  E2E MANIFEST 83개 파일/83개 행도 통과했다.
+- [PR #4027](https://github.com/edwardkim/rhwp/pull/4027)을 `devel` 대상으로 생성했다. archive
+  review와 오늘 기록을 포함한 최신 head의 GitHub Actions 통과 및 작업지시자 승인을 확인한 뒤
+  병합한다.
+
+상세 근거: [#4026 Stage 1](../working/task_m100_4026_stage1.md),
+[PR #4027 검토](../pr/archives/pr_4027_review.md).
+
 ## #3953 - 대형 HWP 찾아가기 및 상태 표시줄 진입점
 
 - `samples/정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwp`의

--- a/mydocs/pr/archives/pr_4027_review.md
+++ b/mydocs/pr/archives/pr_4027_review.md
@@ -1,0 +1,72 @@
+# PR #4027 검토
+
+## 결론
+
+**수용 후보.** 각주 편집 모드가 전용 키 처리 뒤 무조건 반환하던 탓에 `Cmd/Ctrl+Z`와
+`Option+G`가 공통 단축키 라우팅에 도달하지 못했다. 서브모드에서 안전한 세 명령만
+dispatcher로 전달해 각주 입력·이동·삭제·Escape 동작은 그대로 유지한다.
+
+최종 병합 조건은 review 문서 push 뒤 최신 PR head의 GitHub Actions 통과와 작업지시자 승인이다.
+
+## 접수 및 기준
+
+| 항목 | 내용 |
+| --- | --- |
+| PR | [#4027](https://github.com/edwardkim/rhwp/pull/4027) `fix(studio): 각주 편집 전역 단축키 복구` |
+| 작성자 | `jangster77` |
+| 대상 | `devel` |
+| 검토한 구현 head | `2d236c3f85cc49a48fa89c25d3438cb2dee0d781` |
+| 구현 기준 devel | `4473112d9` |
+| 관련 이슈 | [#4026](https://github.com/edwardkim/rhwp/issues/4026) |
+| 구현 변경 규모 | 4 files, +155 / -0 |
+| 작성 시점 mergeable | `MERGEABLE` |
+| 작성 시점 merge 상태 | `BLOCKED` (GitHub Actions 진행 중) |
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, local_validation.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+                  collaborator_self_merge.md, intake_and_review.md,
+                  local_validation.md
+```
+
+## 변경 내용
+
+- `input-handler-keyboard.ts`에 서브모드 전역 단축키 게이트를 추가했다.
+- 게이트는 `edit:undo`, `edit:redo`, `edit:goto`만 통과시킨다. 서식·클립보드·파일 명령처럼
+  각주 전용 편집 모델과 별도 검토가 필요한 명령은 통과시키지 않는다.
+- 머리말/꼬리말과 각주 전용 분기 시작점에 같은 게이트를 적용했다.
+- `footnote-01.hwp`를 실제로 열어 각주 입력 뒤 macOS `Cmd+Z`와 `Option+G`를 검증하는 E2E를
+  추가했다.
+- 새 #4026 E2E와 최신 `devel`에 누락돼 있던 #3953 찾아가기 E2E를 MANIFEST 단일 권위 표에
+  등록했다.
+
+## 로컬 검증
+
+아래 검증은 구현 head `2d236c3f8`에서 완료됐다.
+
+| 검증 | 결과 |
+| --- | --- |
+| `git diff --check` | 통과 |
+| `cd rhwp-studio && npx tsc --noEmit` | 통과 |
+| `cd rhwp-studio && npm test` | 763/763 통과 |
+| `VITE_URL=http://127.0.0.1:7700 node e2e/issue-4026-footnote-global-shortcuts.test.mjs --mode=headless` | 실제 `footnote-01.hwp`에서 각주 입력 뒤 `Cmd+Z` 커서 `1 -> 0`, 각주 모드 유지, `Option+G` 대화상자 표시 통과 |
+| `cd rhwp-studio && npm run e2e:manifest-check` | 83개 파일 / 83개 행, 이상 없음 |
+
+## 시각·fixture 판단
+
+이 PR은 Canvas/render, 레이아웃, pagination, HWP/HWPX fixture를 변경하지 않는다. 키보드
+이벤트 라우팅과 E2E 목록만 변경하므로 기준 PDF나 visual sweep은 적용하지 않았다. 대신 실제
+브라우저 E2E가 각주 컨텍스트에서 명령 실행과 대화상자 표시를 검증한다.
+
+## 범위 밖 변경 및 잔여 위험
+
+- 각주 텍스트 입력, 방향키, Enter, Backspace/Delete, Escape의 기존 전용 분기는 변경하지 않았다.
+- `Cmd/Ctrl+Z`, redo, `Option+G` 외의 전역 단축키는 서브모드에서 계속 기존 동작을 유지한다.
+- #3953 MANIFEST 행은 최신 `devel`에 이미 존재하던 E2E의 목록 누락만 복구하며 runtime 동작을
+  바꾸지 않는다.
+
+## 최종 권고
+
+review 문서와 오늘 기록을 추가한 최신 PR head의 required GitHub Actions가 통과하고 작업지시자가
+승인하면 PR #4027을 병합한다. 병합 뒤 #4026 자동 close 상태와 원격 branch 정리를 확인한다.

--- a/mydocs/working/task_m100_4026_stage1.md
+++ b/mydocs/working/task_m100_4026_stage1.md
@@ -1,0 +1,50 @@
+# Task M100 #4026 Stage 1 - 각주 전역 단축키 복구
+
+- 이슈: [#4026](https://github.com/edwardkim/rhwp/issues/4026)
+- 브랜치: `fix/issue-4026-footnote-global-shortcuts`
+- 기준: `upstream/devel` `4473112d9`
+- 기록일: 2026-08-04 KST
+- 상태: 구현 및 검증 완료
+
+## 재현
+
+각주가 있는 문서에서 각주 표식 또는 각주 영역을 선택해 각주 편집 모드에 진입한다. macOS에서
+`Option+G` 또는 `Cmd+Z`를 누르면 각각 찾아가기와 되돌리기가 실행되지 않는다.
+
+## 원인
+
+`InputHandler.onKeyDown()`은 각주 전용 문자 입력·방향키·Enter·삭제를 처리한 뒤 무조건 반환한다.
+따라서 그 뒤에 있는 공통 `Cmd/Ctrl` 및 `Option` 단축키 라우팅까지 도달하지 못한다.
+
+## 구현 계획
+
+1. 서브모드에서 안전한 전역 명령(`undo`, `redo`, `goto`)만 별도 게이트로 dispatcher에 전달한다.
+2. 각주·머리말/꼬리말의 문자 입력과 전용 편집 키는 기존 분기에 그대로 둔다.
+3. 실제 `footnote-01.hwp`에서 각주 텍스트 입력 뒤 `Cmd+Z` 복원과 `Option+G` 대화상자 표시를 검증한다.
+
+## 수용 기준
+
+- 각주 편집 중 `Cmd+Z`가 방금 입력한 텍스트를 되돌리고 각주 모드를 유지한다.
+- 각주 편집 중 `Option+G`가 찾아가기 대화상자를 연다.
+- TypeScript 검사와 Studio 단위 테스트가 통과한다.
+
+## 구현
+
+- `input-handler-keyboard.ts`에 서브모드 공통 단축키 게이트를 추가했다. 이 게이트는
+  `edit:undo`, `edit:redo`, `edit:goto`만 dispatcher에 전달한다.
+- 머리말/꼬리말과 각주 전용 분기 시작점에서 이 게이트를 호출한다. 따라서 기존 문자 입력,
+  방향키, Enter, 삭제와 Escape 처리는 기존 순서와 분기를 유지한다.
+- `issue-4026-footnote-global-shortcuts.test.mjs`는 실제 `footnote-01.hwp`에서 각주 편집 모드로
+  진입해 영문자 입력, `Cmd+Z` 복원, `Option+G` 대화상자 표시를 확인한다.
+- E2E 매니페스트에는 새 #4026 테스트와 최신 `devel`에 누락돼 있던 #3953 찾아가기 테스트를 함께
+  등록해 파일 목록과 단일 권위 표를 다시 일치시켰다.
+
+## 검증 결과
+
+| 검증 | 결과 |
+| --- | --- |
+| `git diff --check` | 통과 |
+| `cd rhwp-studio && npx tsc --noEmit` | 통과 |
+| `issue-4026-footnote-global-shortcuts.test.mjs --mode=headless` | `Cmd+Z` 커서 `1 -> 0`, 각주 모드 유지, `Option+G` 찾아가기 대화상자 표시 통과 |
+| `npm run e2e:manifest-check` | `83개 파일 / 83개 행`, 이상 없음 |
+| `cd rhwp-studio && npm test` | 763/763 통과 |

--- a/rhwp-studio/e2e/MANIFEST.md
+++ b/rhwp-studio/e2e/MANIFEST.md
@@ -54,6 +54,8 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `issue-270-set-field-persist.test.mjs` | 상시 | active | 이슈 #270 — set_field 후 저장/재오픈 시 필드 값 유실 회귀 | field-01.hwp | 수동 |  |
 | `issue-2809-split-alignment.test.mjs` | 상시 | active | Issue #2809 위·아래 Split 문단 속성 및 WASM/editor 정렬 회귀 | issues/2809/jubo_20260104.hwp | npm e2e:issue-2809 |  |
 | `issue-3682-chart-object-probe.test.mjs` | 진단 | active | #3682 차트 개체 P1~P5 행동 현황 수집 프로브 | chart/세로막대형/묶은세로막대형.hwp | 수동 | legacy-name · 최신 devel의 기존 미등재 항목 보완 |
+| `issue-3953-large-document-goto.test.mjs` | 상시 | active | #3953 대형 HWP 후반부 찾아가기, 오류 재입력과 상태 표시줄 진입 | 정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwp | 수동 | |
+| `issue-4026-footnote-global-shortcuts.test.mjs` | 상시 | active | #4026 각주 편집 중 Cmd+Z 되돌리기와 Option+G 찾아가기 | footnote-01.hwp | 수동 | |
 | `issue-595.test.mjs` | 진단 | hold | Issue #595 진단 e2e | exam_math.hwp | 수동 | legacy-name · #595 진단 (assertion 0) |
 | `line-spacing.test.mjs` | 상시 | active | 줄간격 변경에 따른 페이지 넘김 검증 | — | 수동 |  |
 | `navigation-shortcuts.test.mjs` | 상시 | active | 플랫폼별 navigation shortcut | — | 수동 |  |

--- a/rhwp-studio/e2e/issue-4026-footnote-global-shortcuts.test.mjs
+++ b/rhwp-studio/e2e/issue-4026-footnote-global-shortcuts.test.mjs
@@ -1,0 +1,78 @@
+/**
+ * #4026: 각주 편집 중에도 전역 되돌리기와 찾아가기 단축키가 동작해야 한다.
+ */
+import { runTest, loadHwpFile, assert } from './helpers.mjs';
+
+async function waitForUi(page) {
+  await page.evaluate(() => new Promise(resolve => setTimeout(resolve, 300)));
+}
+
+async function enterFirstFootnote(page) {
+  await page.evaluate(() => {
+    const handler = window.__inputHandler;
+    if (!handler) throw new Error('input handler를 찾을 수 없습니다');
+
+    handler.cursor.enterFootnoteMode(0, 3, 0, 0, 0);
+    handler.eventBus.emit('footnoteModeChanged', true);
+    handler.cursor.setFnCursorPosition(0, 0);
+    handler.active = true;
+    handler.focus();
+    handler.updateCaret();
+  });
+  await waitForUi(page);
+}
+
+async function footnoteCursor(page) {
+  return await page.evaluate(() => {
+    const cursor = window.__inputHandler?.cursor;
+    return {
+      inFootnote: cursor?.isInFootnote?.() ?? false,
+      innerParaIdx: cursor?.fnInnerParaIdx,
+      charOffset: cursor?.fnCharOffset,
+    };
+  });
+}
+
+async function pressMetaZ(page) {
+  await page.keyboard.down('Meta');
+  await page.keyboard.press('KeyZ');
+  await page.keyboard.up('Meta');
+}
+
+async function openGotoWithOptionG(page) {
+  await page.keyboard.down('Alt');
+  await page.keyboard.press('KeyG');
+  await page.keyboard.up('Alt');
+  await page.waitForSelector('.modal-overlay .goto-dialog-body', { timeout: 10_000 });
+}
+
+runTest('#4026 각주 편집 전역 단축키', async ({ page }) => {
+  await loadHwpFile(page, 'footnote-01.hwp');
+  await enterFirstFootnote(page);
+
+  const beforeInput = await footnoteCursor(page);
+  assert(beforeInput.inFootnote, '각주 편집 모드에 진입');
+
+  await page.keyboard.type('X');
+  await waitForUi(page);
+  const afterInput = await footnoteCursor(page);
+  assert(
+    afterInput.charOffset === beforeInput.charOffset + 1,
+    `각주 텍스트 입력 후 커서 이동 (${beforeInput.charOffset} -> ${afterInput.charOffset})`,
+  );
+
+  await pressMetaZ(page);
+  await waitForUi(page);
+  const afterUndo = await footnoteCursor(page);
+  assert(afterUndo.inFootnote, 'Cmd+Z 후에도 각주 편집 모드 유지');
+  assert(
+    afterUndo.charOffset === beforeInput.charOffset,
+    `Cmd+Z가 각주 입력을 되돌림 (${afterInput.charOffset} -> ${afterUndo.charOffset})`,
+  );
+
+  await openGotoWithOptionG(page);
+  const gotoVisible = await page.$('.modal-overlay .goto-dialog-body');
+  assert(gotoVisible !== null, 'Option+G가 각주 편집 중 찾아가기 대화상자를 표시');
+  await page.keyboard.press('Escape');
+  await page.waitForSelector('.modal-overlay', { hidden: true, timeout: 10_000 });
+});

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -29,6 +29,27 @@ const PAGINATION_BOUNDARY_KEYS = new Set([
   'Escape',
 ]);
 
+/**
+ * 머리말/꼬리말·각주처럼 별도 편집 모델을 쓰는 모드에서도 안전하게 실행할 수 있는
+ * 전역 편집 명령이다. 이 모드의 문자 입력은 아래 전용 분기가 소유하지만, 되돌리기와
+ * 찾아가기는 문서 전체 명령이므로 조기 반환 전에 dispatcher로 전달해야 한다.
+ */
+const SUBMODE_GLOBAL_COMMANDS = new Set([
+  'edit:undo',
+  'edit:redo',
+  'edit:goto',
+]);
+
+function dispatchSubmodeGlobalShortcut(this: any, e: KeyboardEvent): boolean {
+  if (!this.dispatcher) return false;
+  const commandId = matchShortcut(e, defaultShortcuts);
+  if (!commandId || !SUBMODE_GLOBAL_COMMANDS.has(commandId)) return false;
+
+  e.preventDefault();
+  this.dispatcher.dispatch(commandId);
+  return true;
+}
+
 function createRhwpClipboardToken(): string {
   try {
     if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
@@ -529,6 +550,8 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
 
   // ─── 머리말/꼬리말 편집 모드 키보드 처리 ──────────────────
   if (this.cursor.isInHeaderFooter()) {
+    if (dispatchSubmodeGlobalShortcut.call(this, e)) return;
+
     // Shift+Esc 또는 Esc → 편집 모드 탈출
     if (e.key === 'Escape') {
       e.preventDefault();
@@ -610,6 +633,8 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
 
   // ─── 각주 편집 모드 키보드 처리 ──────────────────────────
   if (this.cursor.isInFootnote()) {
+    if (dispatchSubmodeGlobalShortcut.call(this, e)) return;
+
     // Shift+Esc 또는 Escape → 주석 편집 모드 탈출
     if (e.key === 'Escape') {
       e.preventDefault();


### PR DESCRIPTION
## 변경 요약

각주 편집 모드에서 조기 반환으로 차단되던 전역 단축키를 보정했습니다.

- `Cmd/Ctrl+Z`, redo, `Option+G`만 서브모드 공통 명령으로 전달
- 실제 `footnote-01.hwp` 기반 browser E2E 추가
- E2E 매니페스트의 신규 #4026 및 기존 #3953 누락 항목 정합

## 관련 이슈

closes #4026

## 테스트

- [x] `cd rhwp-studio && npx tsc --noEmit`
- [x] `cd rhwp-studio && npm test` (763/763)
- [x] `node e2e/issue-4026-footnote-global-shortcuts.test.mjs --mode=headless`
- [x] `npm run e2e:manifest-check`
