### PR TITLE
feat(ops/#4025): 취소 스크립트 --author 모드 — 대량 PR 사후 정리 (8/4 사고 대응)

### DIFF
--- a/mydocs/manual/pr_review/multi_pr_update_branch.md
+++ b/mydocs/manual/pr_review/multi_pr_update_branch.md
@@ -47,6 +47,29 @@ contributor 또는 maintainer가 Update branch를 수행해 PR head가 바뀌면
    API를 쓴다. script를 쓸 수 없는 환경에서만 아래 수동 API 절차를 따른다.
 4. 수동 취소 뒤에도 완료 상태와 `cancelled` 결론을 재확인한다.
 
+### 한 기여자의 대량 PR 사후 정리 — `--author` 모드 (#4025)
+
+에이전트 오작동 등으로 **한 기여자의 PR 이 대량 생성돼 러너가 포화**된 경우
+(2026-08-04 실측: fork PR 69건, 진행 15 + 대기 39), 위 PR 단위 절차로는 풀리지 않는다
+— PR 모드는 **최신 head run 보존**이 설계 목적인데 사고에서는 그 최신 run 들이 러너를
+먹기 때문이다.
+
+```
+scripts/cancel_stale_pr_runs.sh --author <로그인> [--dry-run]
+```
+
+- 해당 author 의 **열린 PR head 브랜치 목록**과 대조해 목록 밖(devel·main·타 기여자)은
+  **취소하지 않는다.** 8/4 실측에서 이 대조가 devel CI 를 지켰다.
+- `gh run cancel` 1차 → 잔여분 `force-cancel` 2차. **1차만으로는 부족하다**
+  (8/4 실측: 1차 후 44건 잔여 — 취소 반영 지연·신규 큐잉).
+- 요약에 `대상 N건 → 잔여 M건 (보호 K건)` 을 출력한다. 잔여가 있으면 재실행한다.
+- 조회는 `status=in_progress|queued` 로 좁힌다(전량 `--paginate` 는 수 분 소요 실측).
+
+**선행 판단**: 정리 전에 원인을 확인한다. 기여자 실수인지 에이전트 오작동인지에 따라
+후속 커뮤니케이션 톤이 달라진다 — 8/4 에는 이 확인이 늦어 close 코멘트를 정정해야 했다.
+평시 `approval_policy` 는 `first_time_contributors` 를 유지하고
+(`all_external_contributors` 강화는 릴리즈 시에만), 사고는 이 도구로 사후 대응한다.
+
 러너 구성 전환 등으로 배정 가능한 label이 사라진 run은 `queued`에 고착될 수 있다. 이 run은 일반 cancel이
 끝나지 않고 같은 concurrency group을 계속 점유해, 후속 run이 job을 하나도 시작하지 못한 `pending`으로
 연쇄 고착될 수 있다. 새 run이 `pending`이면 최신 run만 재실행하지 말고 같은 PR·workflow의 이전

--- a/scripts/cancel_stale_pr_runs.sh
+++ b/scripts/cancel_stale_pr_runs.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # [#3508] multi_pr_update_branch.md 2.5의 stale run 수동 정리를 원커맨드로 감싼다.
+# [#4025] --author 모드: 한 기여자의 열린 PR run 을 일괄 정리한다(에이전트 오작동 대응).
 #
 #   사용법: scripts/cancel_stale_pr_runs.sh <PR번호> [--dry-run]
+#          scripts/cancel_stale_pr_runs.sh --author <로그인> [--dry-run]
 #
 # - 현재 head SHA를 확인하고, 같은 PR head(head_repository+head_branch)의 이전 SHA
 #   active run만 force-cancel API로 취소한다. 일반 `gh run cancel`은 시도하지 않는다(2.5 규정).
@@ -11,8 +13,98 @@
 set -euo pipefail
 
 REPO="${RHWP_REPO:-edwardkim/rhwp}"
-PR="${1:?사용법: $0 <PR번호> [--dry-run]}"
+PR="${1:?사용법: $0 <PR번호> | --author <로그인>  [--dry-run]}"
 DRY="${2:-}"
+
+# ─── [#4025] --author 모드 ────────────────────────────────────────────────
+# 2026-08-04 실측: 에이전트 오작동으로 fork PR 69건이 하루에 생성돼 러너가 포화됐다
+# (진행 15 + 대기 39). PR 모드는 "최신 head run 보존"이 설계 목적이라 이 상황을 못 푼다
+# — 사고에서는 그 최신 run 들이 러너를 먹기 때문이다. 그래서 별도 모드로 둔다.
+#
+# 안전 경계: **열린 PR 의 head 브랜치 목록과 대조**해 목록 밖(devel·main·타 기여자)은
+# 절대 취소하지 않는다. 8/4 실측에서 이 대조가 devel CI 를 지켰다.
+if [ "$PR" = "--author" ]; then
+  AUTHOR="${2:?사용법: $0 --author <로그인> [--dry-run]}"
+  DRY="${3:-}"
+
+  branches=$(gh pr list --repo "$REPO" --state open --author "$AUTHOR" \
+    --limit 200 --json headRefName --jq '[.[].headRefName]')
+  bcount=$(jq 'length' <<<"$branches")
+  echo "author=$AUTHOR  열린 PR head 브랜치 ${bcount}개 (${REPO})"
+  if [ "$bcount" -eq 0 ]; then
+    echo "  열린 PR 이 없습니다 — 정리할 대상이 없습니다."
+    exit 0
+  fi
+
+  # [#4025] --paginate 전량 조회는 run 이력이 쌓이면 수 분씩 걸린다(실측 타임아웃).
+  # active 상태만 서버에서 걸러 받는다 — 정리 대상은 정의상 active 뿐이다.
+  fetch_active() {
+    { gh api "repos/$REPO/actions/runs?status=in_progress&per_page=100" --jq '.workflow_runs[]' 2>/dev/null
+      gh api "repos/$REPO/actions/runs?status=queued&per_page=100" --jq '.workflow_runs[]' 2>/dev/null; }
+  }
+  active=$(fetch_active | jq -s --argjson brs "$branches" '
+      [ .[]
+        | select(.status == "queued" or .status == "in_progress"
+                 or .status == "pending" or .status == "requested"
+                 or .status == "waiting")
+        | select(.head_branch as $b | $brs | index($b))
+        | {id, name: (.name // .display_title), branch: .head_branch,
+           status, url: .html_url}
+      ]')
+  acount=$(jq 'length' <<<"$active")
+
+  # 보호된(대조 밖) active run 수 — 요약에 함께 보고한다.
+  protected=$(fetch_active | jq -s --argjson brs "$branches" '
+      [ .[]
+        | select(.status == "queued" or .status == "in_progress")
+        | select(.head_branch as $b | ($brs | index($b)) | not)
+      ] | length')
+
+  echo "  대상 active run ${acount}건 / 보호(대조 밖) ${protected}건"
+  jq -r '.[] | "    [\(.status)] \(.name)  \(.branch)  \(.url)"' <<<"$active" | head -40
+  [ "$acount" -gt 40 ] && echo "    … 외 $((acount - 40))건"
+
+  if [ "$DRY" = "--dry-run" ]; then
+    echo "  --dry-run: 취소하지 않고 종료합니다."
+    exit 0
+  fi
+  if [ "$acount" -eq 0 ]; then
+    echo "  취소할 run 이 없습니다."
+    exit 0
+  fi
+
+  # 1차 gh run cancel → 2차 force-cancel.
+  # 8/4 실측: 1차만으로는 44건이 남았다(취소 반영 지연·신규 큐잉). 2차가 필수다.
+  ok=0
+  for run_id in $(jq -r '.[].id' <<<"$active"); do
+    gh run cancel "$run_id" --repo "$REPO" >/dev/null 2>&1 && ok=$((ok + 1)) || true
+  done
+  echo "  1차 cancel 요청: ${ok}/${acount}"
+  sleep 20
+
+  remain=$(fetch_active | jq -s --argjson brs "$branches" '
+      [ .[]
+        | select(.status == "queued" or .status == "in_progress")
+        | select(.head_branch as $b | $brs | index($b))
+        | .id
+      ]')
+  rcount=$(jq 'length' <<<"$remain")
+  if [ "$rcount" -gt 0 ]; then
+    echo "  2차 force-cancel 대상 ${rcount}건"
+    for run_id in $(jq -r '.[]' <<<"$remain"); do
+      gh api --method POST "repos/$REPO/actions/runs/$run_id/force-cancel" >/dev/null 2>&1 || true
+    done
+    sleep 20
+  fi
+
+  final=$(fetch_active | jq -s --argjson brs "$branches" '
+      [ .[] | select(.status == "queued" or .status == "in_progress")
+        | select(.head_branch as $b | $brs | index($b)) ] | length')
+  echo "완료: 대상 ${acount}건 → 잔여 ${final}건 (보호 ${protected}건은 건드리지 않음)"
+  [ "$final" -gt 0 ] && echo "  잔여가 있으면 재실행하세요(신규 큐잉 가능성)."
+  exit 0
+fi
+# ─────────────────────────────────────────────────────────────────────────
 
 pr_json=$(gh pr view "$PR" --repo "$REPO" \
   --json state,headRefOid,headRefName,headRepositoryOwner,headRepository)


### PR DESCRIPTION
## 요약

`scripts/cancel_stale_pr_runs.sh` 에 **`--author` 모드**를 추가합니다. 기존 PR 단위
모드는 불변입니다.

```
scripts/cancel_stale_pr_runs.sh --author <로그인> [--dry-run]
```

## 왜 필요한가 — 2026-08-04 실제 사고

한 기여자의 **에이전트 오작동**으로 fork PR **69건**이 하루에 생성돼 각각
CI·CodeQL·Render Diff 를 돌렸습니다. 러너 포화(진행 15 + 대기 39)로 다른 기여자와
메인테이너 작업이 대기 상태가 됐고, 수동으로 54건을 취소해야 했습니다.

**기존 PR 모드로는 풀리지 않습니다** — 그 모드는 *최신 head run 보존*이 설계 목적인데,
사고 상황에서는 바로 그 최신 run 들이 러너를 먹고 있기 때문입니다.

## 안전 경계

- **열린 PR head 브랜치 목록과 대조** — 목록 밖(devel·main·타 기여자)은 취소하지
  않습니다. 8/4 실측에서 이 대조가 devel CI 를 지켰습니다.
- 요약에 `대상 N건 → 잔여 M건 (보호 K건)` 출력.
- `--dry-run` 은 목록만 보여주고 아무것도 취소하지 않습니다.

## 2단 취소 (실측 근거)

`gh run cancel` 1차 → 잔여분 `force-cancel` 2차. **1차만으로는 부족합니다** —
8/4 실측에서 1차 후 **44건이 남았습니다**(취소 반영 지연·신규 큐잉).

## 구현 중 고친 것 — 성능

첫 판은 `--paginate` 로 전체 run 이력을 훑어 **180초 타임아웃**이 났습니다.
`status=in_progress|queued` 로 좁혀 **2.5초**로 줄였습니다. 사고 대응 도구가 느리면
쓸모가 없습니다.

## 검증 4종

| 검증 | 결과 |
|---|---|
| 빈 author (열린 PR 0건) | 정상 종료 |
| 열린 PR 있는 author | 대상 0 / 보호 0 정확 판정 |
| **기존 PR 모드 무회귀** | 정상 동작 |
| 인자 없이 실행 | 사용법 안내 |

`bash -n` 문법 검사 통과.

## 매뉴얼

`mydocs/manual/pr_review/multi_pr_update_branch.md` 에 절 추가. **선행 판단**을
명시했습니다 — 정리 전에 원인(기여자 실수 vs 에이전트 오작동)을 확인한다. 8/4 에는
이 확인이 늦어 close 코멘트를 정정해야 했습니다. 평시 `approval_policy` 는
`first_time_contributors` 유지, 강화는 릴리즈 시에만이라는 거버넌스도 함께 적었습니다.

Closes #4025

🤖 Generated with [Claude Code](https://claude.com/claude-code)
