### PR TITLE
fix(studio): 각주에서 찾아가기 본문 전환 (#4030)

### DIFF
--- a/mydocs/orders/20260804.md
+++ b/mydocs/orders/20260804.md
@@ -1,5 +1,20 @@
 # 오늘 할일 - 2026년 8월 4일
 
+## #4030 - 각주에서 대형 문서 찾아가기 본문 전환
+
+- 실제 219쪽 HWP의 각주 1번에서 `Option+G → 200`을 수행하면 본문 위치는 바뀌어도 각주 전용
+  caret·상태 갱신이 결과를 덮어 `10 / 219 쪽`으로 남는 것을 재현했다.
+- 페이지 화면 이동이 성공한 뒤에만 각주 모드를 종료하고 본문 cursor를 배치하도록 보정했다. 이동
+  실패 경로는 기존 각주 편집 상태를 보존한다.
+- 실제 fixture E2E에서 각주 모드 종료, `200 / 219 쪽`, viewport `225242 / 225377.5`, 문단 2191
+  cursor, 다음 `Option+G` 재호출을 확인했다. TypeScript, E2E manifest 84/84, 기존 #3953/#4026
+  E2E와 Studio 단위 테스트 763/763도 통과했다.
+- [PR #4033](https://github.com/edwardkim/rhwp/pull/4033)을 `devel` 대상으로 생성했다. archive review와
+  오늘 기록을 포함한 최신 head의 GitHub Actions 통과 및 작업지시자 승인을 확인한 뒤 병합한다.
+
+상세 근거: [#4030 Stage 1](../working/task_m100_4030_stage1.md),
+[PR #4033 검토](../pr/archives/pr_4033_review.md).
+
 ## #4026 - 각주 편집 전역 단축키
 
 - 각주 편집 모드의 조기 반환 때문에 macOS `Option+G`와 `Cmd+Z`가 공통 단축키 라우팅에

--- a/mydocs/pr/archives/pr_4033_review.md
+++ b/mydocs/pr/archives/pr_4033_review.md
@@ -1,0 +1,75 @@
+# PR #4033 검토
+
+## 결론
+
+**수용 후보.** 각주 편집 중 `Option+G`로 대형 문서의 대상 쪽을 찾을 때 본문 위치와 viewport는
+이동했지만, 각주 전용 caret·상태 갱신이 최종 결과를 덮고 있었다. 페이지 화면 이동이 성공한 뒤에만
+각주 컨텍스트를 종료하고 본문 cursor를 배치해, 실패 시의 각주 편집 상태는 유지하면서 정상 이동을
+복구했다.
+
+최종 병합 조건은 review 문서와 오늘 기록을 포함한 최신 PR head의 GitHub Actions 통과와 작업지시자
+승인이다.
+
+## 접수 및 기준
+
+| 항목 | 내용 |
+| --- | --- |
+| PR | [#4033](https://github.com/edwardkim/rhwp/pull/4033) `fix(studio): 각주에서 찾아가기 본문 전환 (#4030)` |
+| 작성자 | `jangster77` |
+| 대상 | `devel` |
+| 검토한 구현 head | `6388d2f0051978c92c6c44b6223098f8ab8e8f58` |
+| 구현 기준 devel | `9aa0ec8b6` |
+| 관련 이슈 | [#4030](https://github.com/edwardkim/rhwp/issues/4030) |
+| 구현 변경 규모 | 5 files, +193 / -0 |
+| 문서 작성 시점 mergeable | `MERGEABLE` |
+| 문서 작성 시점 merge 상태 | `BLOCKED` (GitHub Actions 진행 중) |
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, local_validation.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+                  collaborator_self_merge.md, intake_and_review.md,
+                  local_validation.md
+```
+
+## 변경 내용
+
+- `InputHandler`에 본문 탐색용 각주 모드 종료 API를 추가했다. 문서 mutation·history·dirty 상태는
+  건드리지 않고 기존 `footnoteModeChanged=false` UI 계약만 발행한다.
+- 페이지 찾아가기는 화면 이동이 성공한 뒤, `moveCursorTo()`의 본문 caret 배치 전에 위 API를 호출한다.
+  화면 이동 실패 시에는 기존 각주 편집 상태를 보존한다.
+- 실제 219쪽 HWP의 각주 1번에서 `Option+G → 200`을 수행하는 #4030 browser E2E와 E2E MANIFEST
+  행을 추가했다.
+
+## 로컬 검증
+
+아래 검증은 구현 head `6388d2f00`에서 완료됐다.
+
+| 검증 | 결과 |
+| --- | --- |
+| `git diff --check` | 통과 |
+| `cd rhwp-studio && npx tsc --noEmit` | 통과 |
+| `cd rhwp-studio && npm run e2e:manifest-check` | 84개 파일 / 84개 행, 이상 없음 |
+| `VITE_URL=http://127.0.0.1:7700 node e2e/issue-4030-footnote-goto-transition.test.mjs --mode=headless` | 실제 219쪽 HWP의 각주 1번에서 200쪽 이동, 각주 모드 종료, `200 / 219 쪽`, viewport `225242 / 225377.5`, 문단 2191 cursor, `Option+G` 재호출 통과 |
+| 기존 #3953 headless E2E | 158쪽 이동, 상태 표시줄 진입, 잘못된 입력 재입력 통과 |
+| 기존 #4026 headless E2E | 각주 `Cmd+Z`와 `Option+G` 대화상자 표시 통과 |
+| `cd rhwp-studio && npm test` | 763/763 통과 |
+
+## 시각·fixture 판단
+
+이 PR은 Canvas/render, 레이아웃, pagination 계산, HWP/HWPX fixture를 변경하지 않는다. 입력
+컨텍스트 전환과 대화상자 이동 순서만 변경하므로 기준 PDF와 visual sweep은 적용하지 않았다. 대신
+사용자가 보고한 실제 219쪽 HWP의 각주 상태에서 page status, viewport, 본문 cursor를 함께 보는
+headless browser E2E를 실행했다.
+
+## 범위 밖 변경 및 잔여 위험
+
+- 머리말/꼬리말 및 책갈피 찾아가기는 이번 이슈 범위 밖으로 유지했다.
+- `gotoPage()`가 실패하면 각주 모드를 종료하지 않는다.
+- `getPositionOfPage()`가 본문 cursor를 둘 수 없는 표 위치를 반환할 때의 기존 ±5 문단 fallback은
+  그대로 유지한다.
+
+## 최종 권고
+
+review 문서와 오늘 기록을 추가한 최신 PR head의 required GitHub Actions가 통과하고 작업지시자가
+승인하면 PR #4033을 병합한다. 병합 뒤 #4030 자동 종료 상태와 원격 branch 정리를 확인한다.

--- a/mydocs/working/task_m100_4030_stage1.md
+++ b/mydocs/working/task_m100_4030_stage1.md
@@ -1,0 +1,70 @@
+# Task M100 #4030 Stage 1 - 각주에서 대형 문서 찾아가기 전 본문 전환
+
+- 이슈: [#4030](https://github.com/edwardkim/rhwp/issues/4030)
+- 브랜치: `fix/issue-4030-footnote-goto-transition`
+- 기준: `upstream/devel` `9aa0ec8b6`
+- 기록일: 2026-08-04 KST
+- 상태: 구현 및 상세 검증 완료
+
+## 재현
+
+`samples/정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwp`는
+219쪽이며, 본문 문단 216의 각주 1번을 편집한 뒤 `Option+G`로 200쪽을 입력하면 대화상자는 닫힌다.
+그러나 각주 편집 모드가 남아 상태 표시줄은 `10 / 219 쪽`으로 표시되고, 대상 쪽의 본문 caret 상태가
+완료되지 않는다.
+
+## 조사 결과
+
+대상 200쪽의 본문 위치는 문단 2191로 계산되고 `GotoDialog`는 해당 위치로 이동을 시도한다. 다만
+`Cursor`가 각주 모드인 상태에서는 `getRect()`와 caret 갱신이 각주 전용 위치를 계속 사용한다. 따라서
+본문 위치와 viewport는 바뀌어도 마지막 상태 표시와 caret 갱신이 원 각주가 있는 10쪽 결과로 덮인다.
+
+같은 각주를 명시적으로 종료한 뒤 같은 200쪽 이동을 실행한 제어 실험에서는 `200 / 219 쪽`,
+`scrollTop=225242`, 본문 모드가 확인됐다.
+
+## 구현 계획
+
+1. `InputHandler`에 문서 본문 탐색을 위한 각주 모드 종료 API를 추가하고 기존 `footnoteModeChanged`
+   이벤트 계약을 유지한다.
+2. `GotoDialog`가 화면 이동에 성공한 뒤 본문 cursor를 배치하기 전에 위 API를 호출한다. 화면 이동 자체가
+   실패하면 기존 각주 편집 상태를 보존한다.
+3. 실제 219쪽 HWP의 각주 1번에서 `Option+G → 200`을 수행하는 E2E를 추가해 모드 종료, 상태 표시줄,
+   viewport, 본문 cursor, 다음 `Option+G` 재호출을 함께 검증한다.
+
+## 수용 기준
+
+- 각주 편집 중 `Option+G → 200`이 본문 모드로 전환되고 상태 표시줄에 `200 / 219 쪽`을 표시한다.
+- 대상 쪽의 본문 cursor가 배치되고 viewport가 실제 대상 위치까지 이동한다.
+- 이동 완료 후 `Option+G`를 다시 열고 닫을 수 있다.
+- TypeScript, Studio 단위 테스트, 새 headless E2E, E2E 매니페스트 검사가 통과한다.
+
+## 구현
+
+- `InputHandler.exitFootnoteModeForBodyNavigation()`을 추가했다. 각주 모드일 때만 cursor의 저장된
+  본문 위치를 복원하고 기존 `footnoteModeChanged=false` 이벤트를 발행한다. 문서 내용을 바꾸지 않으므로
+  history나 dirty 상태는 변경하지 않는다.
+- `GotoDialog`는 페이지 화면 이동이 성공한 뒤, 본문 cursor를 배치하기 전에 이 API를 호출한다. 따라서
+  화면 이동 실패 경로는 각주 편집 상태를 그대로 보존한다.
+- `issue-4030-footnote-goto-transition.test.mjs`와 E2E 매니페스트를 추가했다. 테스트는 실제 219쪽 HWP의
+  각주 1번(문단 216)에서 시작하고, 임의로 만든 문서나 고정 canvas 좌표에 의존하지 않는다.
+
+## 검증 결과
+
+### 수정 전 및 제어 실험
+
+| 경로 | 관찰 결과 |
+| --- | --- |
+| 수정 전 각주 1번에서 `Option+G → 200` | 본문 cursor는 문단 2191로 바뀌었지만 각주 모드가 남아 상태 표시줄이 `10 / 219 쪽`, `scrollTop=10000`으로 남음 |
+| 같은 각주를 명시 종료한 제어 경로 | `200 / 219 쪽`, `scrollTop=225242`, 본문 cursor 문단 2191, 각주 모드 종료 |
+
+### 수정 후 자동 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| `git diff --check` | 통과 |
+| `cd rhwp-studio && npx tsc --noEmit` | 통과 |
+| `cd rhwp-studio && npm run e2e:manifest-check` | `84개 파일 / 84개 행`, 이상 없음 |
+| `issue-4030-footnote-goto-transition.test.mjs --mode=headless` | 실제 219쪽 HWP의 각주 1번에서 200쪽 이동, 각주 모드 종료, `200 / 219 쪽`, viewport `225242 / 225377.5`, 문단 2191 cursor, 재호출 통과 |
+| `issue-3953-large-document-goto.test.mjs --mode=headless` | 158쪽 이동, 상태 표시줄 진입, 잘못된 입력 재입력 통과 |
+| `issue-4026-footnote-global-shortcuts.test.mjs --mode=headless` | 각주 `Cmd+Z` 및 `Option+G` 대화상자 표시 회귀 없음 |
+| `cd rhwp-studio && npm test` | 763/763 통과 |

--- a/rhwp-studio/e2e/MANIFEST.md
+++ b/rhwp-studio/e2e/MANIFEST.md
@@ -56,6 +56,7 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `issue-3682-chart-object-probe.test.mjs` | 진단 | active | #3682 차트 개체 P1~P5 행동 현황 수집 프로브 | chart/세로막대형/묶은세로막대형.hwp | 수동 | legacy-name · 최신 devel의 기존 미등재 항목 보완 |
 | `issue-3953-large-document-goto.test.mjs` | 상시 | active | #3953 대형 HWP 후반부 찾아가기, 오류 재입력과 상태 표시줄 진입 | 정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwp | 수동 | |
 | `issue-4026-footnote-global-shortcuts.test.mjs` | 상시 | active | #4026 각주 편집 중 Cmd+Z 되돌리기와 Option+G 찾아가기 | footnote-01.hwp | 수동 | |
+| `issue-4030-footnote-goto-transition.test.mjs` | 상시 | active | #4030 실제 대형 HWP 각주에서 Option+G 200쪽 이동 시 본문 모드·상태 표시·viewport 전환 | 정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwp | 수동 | |
 | `issue-595.test.mjs` | 진단 | hold | Issue #595 진단 e2e | exam_math.hwp | 수동 | legacy-name · #595 진단 (assertion 0) |
 | `line-spacing.test.mjs` | 상시 | active | 줄간격 변경에 따른 페이지 넘김 검증 | — | 수동 |  |
 | `navigation-shortcuts.test.mjs` | 상시 | active | 플랫폼별 navigation shortcut | — | 수동 |  |

--- a/rhwp-studio/e2e/issue-4030-footnote-goto-transition.test.mjs
+++ b/rhwp-studio/e2e/issue-4030-footnote-goto-transition.test.mjs
@@ -1,0 +1,112 @@
+/**
+ * #4030: 각주 편집 중에도 대형 문서의 찾아가기가 본문 모드로 전환되어야 한다.
+ */
+import { runTest, loadHwpFile, assert } from './helpers.mjs';
+
+const SAMPLE = '정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwp';
+const FOOTNOTE = { sectionIndex: 0, paragraphIndex: 216, controlIndex: 0, footnoteIndex: 0 };
+const TARGET_PAGE = 200;
+
+async function waitForUi(page) {
+  await page.evaluate(() => new Promise(resolve => setTimeout(resolve, 300)));
+}
+
+async function enterKnownFootnote(page) {
+  const entered = await page.evaluate((target) => {
+    const handler = window.__inputHandler;
+    const wasm = window.__wasm;
+    if (!handler || !wasm) throw new Error('input handler 또는 wasm을 찾을 수 없습니다');
+
+    const info = wasm.getFootnoteInfo(target.sectionIndex, target.paragraphIndex, target.controlIndex);
+    if (!info?.ok || info.number !== 1) throw new Error('대형 HWP의 각주 1번 fixture를 찾을 수 없습니다');
+    const pageResult = wasm.getPageOfPosition(target.sectionIndex, target.paragraphIndex);
+    if (!pageResult?.ok || pageResult.page == null) throw new Error('각주 anchor의 본문 쪽을 찾을 수 없습니다');
+
+    handler.cursor.moveTo({
+      sectionIndex: target.sectionIndex,
+      paragraphIndex: target.paragraphIndex,
+      charOffset: 0,
+    });
+    handler.cursor.enterFootnoteMode(
+      target.sectionIndex,
+      target.paragraphIndex,
+      target.controlIndex,
+      target.footnoteIndex,
+      pageResult.page,
+    );
+    handler.eventBus.emit('footnoteModeChanged', true);
+    handler.cursor.setFnCursorPosition(0, 2);
+    handler.active = true;
+    handler.focus();
+    handler.updateCaret();
+    return {
+      inFootnote: handler.cursor.isInFootnote(),
+      footnoteNumber: info.number,
+      sourcePage: pageResult.page + 1,
+    };
+  }, FOOTNOTE);
+  await waitForUi(page);
+  return entered;
+}
+
+async function openGotoWithOptionG(page) {
+  await page.keyboard.down('Alt');
+  await page.keyboard.press('KeyG');
+  await page.keyboard.up('Alt');
+  await page.waitForSelector('.modal-overlay .goto-dialog-body', { timeout: 10_000 });
+}
+
+async function setGotoPage(page, value) {
+  await page.$eval('.goto-dialog-body input[type="number"]', (input, pageValue) => {
+    input.value = String(pageValue);
+  }, value);
+  await page.keyboard.press('Enter');
+}
+
+runTest('#4030 각주에서 대형 문서 찾아가기 본문 전환', async ({ page }) => {
+  const loaded = await loadHwpFile(page, SAMPLE);
+  assert(loaded.pageCount >= TARGET_PAGE, `대형 HWP가 ${TARGET_PAGE}쪽 이상으로 로드됨 (${loaded.pageCount}쪽)`);
+
+  const entered = await enterKnownFootnote(page);
+  assert(entered.inFootnote, `각주 1번 편집 모드 진입 (${entered.sourcePage}쪽)`);
+  assert(entered.footnoteNumber === 1, '대형 HWP의 실제 각주 fixture 확인');
+
+  await openGotoWithOptionG(page);
+  await setGotoPage(page, TARGET_PAGE);
+  await page.waitForSelector('.modal-overlay', { hidden: true, timeout: 10_000 });
+  await page.waitForFunction((target) => {
+    const text = document.getElementById('sb-page')?.textContent ?? '';
+    return text.startsWith(`${target} / `);
+  }, { timeout: 10_000 }, TARGET_PAGE);
+
+  const moved = await page.evaluate((target) => {
+    const handler = window.__inputHandler;
+    const wasm = window.__wasm;
+    const position = handler?.getCursorPosition?.() ?? null;
+    const expected = wasm?.getPositionOfPage?.(target - 1) ?? null;
+    return {
+      inFootnote: handler?.cursor?.isInFootnote?.() ?? true,
+      status: document.getElementById('sb-page')?.textContent ?? '',
+      scrollTop: document.getElementById('scroll-container')?.scrollTop ?? 0,
+      targetOffset: handler?.virtualScroll?.getPageOffset?.(target - 1) ?? null,
+      position,
+      expected,
+    };
+  }, TARGET_PAGE);
+  assert(!moved.inFootnote, '찾아가기 완료 후 각주 편집 모드 종료');
+  assert(moved.status.startsWith(`${TARGET_PAGE} / `), `상태 표시줄이 ${TARGET_PAGE}쪽을 표시 (${moved.status})`);
+  assert(
+    moved.targetOffset != null && Math.abs(moved.scrollTop - moved.targetOffset) < 250,
+    `viewport가 대상 ${TARGET_PAGE}쪽 근처 offset으로 이동 (${moved.scrollTop} / ${moved.targetOffset})`,
+  );
+  assert(
+    moved.expected?.ok && moved.position?.sectionIndex === moved.expected.sec && moved.position?.paragraphIndex === moved.expected.para,
+    `대상 쪽의 본문 cursor 배치 (${JSON.stringify(moved.position)})`,
+  );
+
+  await openGotoWithOptionG(page);
+  const reopened = await page.$('.modal-overlay .goto-dialog-body');
+  assert(reopened !== null, '본문 전환 뒤 Option+G로 찾아가기 다시 열기');
+  await page.keyboard.press('Escape');
+  await page.waitForSelector('.modal-overlay', { hidden: true, timeout: 10_000 });
+});

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -3666,6 +3666,13 @@ export class InputHandler {
   /** 현재 커서 위치를 반환한다 */
   getCursorPosition(): DocumentPosition { return this.cursor.getPosition(); }
 
+  /** 본문 탐색 전에 각주 전용 편집 컨텍스트를 종료한다. */
+  exitFootnoteModeForBodyNavigation(): void {
+    if (!this.cursor.isInFootnote()) return;
+    this.cursor.exitFootnoteMode();
+    this.eventBus.emit('footnoteModeChanged', false);
+  }
+
   /** 커서를 지정 위치로 이동하고 캐럿을 표시한다. 성공하면 true 반환. */
   moveCursorTo(pos: DocumentPosition): boolean {
     // 이동 전 위치가 유효한지 사전 검증 (경고 로그 방지)

--- a/rhwp-studio/src/ui/goto-dialog.ts
+++ b/rhwp-studio/src/ui/goto-dialog.ts
@@ -245,6 +245,9 @@ export class GotoDialog extends ModalDialog {
       return false;
     }
 
+    // 화면 이동이 성공한 경우에만 각주 편집 컨텍스트를 끝낸다. 이동이 실패하면 사용자는
+    // 기존 각주를 계속 편집할 수 있어야 하고, 본문 커서는 아래에서만 배치해야 한다.
+    ih.exitFootnoteModeForBodyNavigation();
     const moved = this.tryMoveCursor(
       ih,
       posResult.sec!,


### PR DESCRIPTION
Closes #4030

## 변경
- 페이지 찾아가기의 화면 이동 성공 뒤 각주 편집 컨텍스트를 종료하고 본문 cursor를 배치합니다.
- 실제 219쪽 HWP의 각주 1번에서 `Option+G → 200`을 검증하는 headless E2E와 매니페스트를 추가합니다.

## 검증
- `cd rhwp-studio && npx tsc --noEmit`
- `cd rhwp-studio && npm run e2e:manifest-check`
- `VITE_URL=http://127.0.0.1:7700 node e2e/issue-4030-footnote-goto-transition.test.mjs --mode=headless`
- 기존 #3953 / #4026 headless E2E
- `cd rhwp-studio && npm test` (763/763)

상세 재현·제어 실험·검증 결과는 `mydocs/working/task_m100_4030_stage1.md`에 기록했습니다.