### PR TITLE
fix(typeset): 저장 사다리 신뢰가 예산 초과를 연쇄 통과시키지 않게 — 쪽 밖 소실 71→53줄 (#4024)

### DIFF
--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -14184,6 +14184,17 @@ impl TypesetEngine {
             let mut cumulative = 0.0;
             let mut end_line = cursor_line;
             let mut used_saved_tail_vpos_fit = false;
+            // [#4024] 저장 사다리 신뢰(`saved_tail_vpos_fit`)는 `li..line_count` 만 보고
+            // 그때까지 쌓인 `cumulative` 를 모른다. 그래서 한 번 참이 되면 예산을 넘긴
+            // 채로 남은 줄을 계속 통과시켜 초과가 단조 증가한다(1480000 pi=724: 잔여
+            // 18.5px 에 6줄 통과, 초과 19.7 -> 137.0px).
+            //
+            // 쪽 단위 실측(무작위 대형 문서 60건): 소실 쪽의 연쇄는 전부 길이 3 이상
+            // (중앙 5, 최대초과 중앙 117.2px)인데, 소실 없는 쪽은 66% 가 길이 1~2
+            // (중앙 2, 최대초과 중앙 49.4px)다. 한컴 정답 36쪽을 고정하는
+            // `issue_554` hwp3-sample4 의 유일한 통과도 길이 1 이다.
+            const TAIL_FIT_CHAIN_CAP: usize = 2;
+            let mut tail_fit_chain = 0usize;
             for li in cursor_line..line_count {
                 if forced_page_break_line
                     .map(|break_line| li == break_line && li > cursor_line)
@@ -14289,6 +14300,15 @@ impl TypesetEngine {
                                 .max(0.0),
                             self.dpi,
                         );
+                    if saved_tail_vpos_fit
+                        && !hwp_authoritative
+                        && !native_hwp5_reset_tail_fits_actual_footnote_boundary
+                    {
+                        tail_fit_chain += 1;
+                        if tail_fit_chain > TAIL_FIT_CHAIN_CAP {
+                            break;
+                        }
+                    }
                     if !hwp_authoritative
                         && !saved_tail_vpos_fit
                         && !native_hwp5_reset_tail_fits_actual_footnote_boundary


### PR DESCRIPTION
## 무엇을 고치나

본문 문단이 쪽 아래로 넘어가 **어느 쪽에서도 보이지 않게 소실**됩니다. 텍스트 추출·IR diff
로는 안 잡힙니다(좌표만 쪽 밖입니다).

줄 분할 루프의 예산 가드는 `saved_tail_vpos_fit`(저장 사다리 신뢰) 하나로 풀립니다. 그 술어는

```rust
saved_line_range_fits_body_tail(para, li, line_count, st.base_available_height(), self.dpi)
```

**`li` 부터 끝까지**만 봅니다 — 그때까지 쌓인 `cumulative` 를 모릅니다. 그래서 한 번 참이 되면
예산을 넘긴 채 남은 줄을 계속 통과시키고 초과가 단조 증가합니다.

```
1480000 pi=724  잔여 예산 18.5px
  li=1 cum= 23.5 over= 19.7 tailfit=true -> 계속
  li=2 cum= 46.9 over= 43.1 tailfit=true -> 계속
  …
  li=6 cum=140.8 over=137.0 tailfit=false -> break      ← 6줄 늦게 멈춘다
```

`auth`·`native` 는 전 건 false 로, 범인은 이 술어 하나입니다.

## 어떻게 고치나

술어를 없애지 않습니다(그러면 이 술어가 흡수하던 측정 오차가 드러나 한컴 정답 쪽수가 깨집니다
— 실측 확인). **"누적을 모른다" 는 결함만** 제한합니다: 예산 초과를 연속으로 통과시키는
횟수에 상한 `2` 를 둡니다.

## 왜 연쇄 길이인가

쪽 단위 실측(무작위 대형 문서 60건, 소실 검출기로 소실 쪽 판정):

```
소실 쪽   (4건)  길이 중앙 5 · 최대 6 · 최대초과 중앙 117.2px   길이 {3:1, 5:2, 6:1}
비소실 쪽(80건)  길이 중앙 2 · 최대 6 · 최대초과 중앙  49.4px   길이 {1:24, 2:29, 3:8, 4:12, 5:6, 6:1}
```

소실 쪽은 **전부 길이 3 이상**이고 비소실 쪽은 66% 가 1~2 입니다. 초과폭(px)은 문서마다 줄
높이가 달라 스케일이 안 맞지만, 연쇄 길이는 무차원이라 문서 간 비교가 됩니다.

한컴 정답 36쪽을 고정하는 `issue_554` `hwp3-sample4` 의 **유일한** 통과가 길이 1 이라 상한 2
에서 살아남습니다(36쪽 유지 실측).

## 게이트

| 게이트 | 결과 |
|---|---|
| 92셋 통제셋 | **92/92 무회귀** |
| PI `n=1` (66건) | **회귀 0** |
| PI `n=2~3` (49건) | 무변화 46 · 부분이동 2 · 회귀 1 |
| 10k 모집단 (1,200 표본) | **무변화 1,199 · 회귀 0** · 이동 1 |
| **쪽 밖 소실 (대형 60건)** | **71 -> 53줄 (−25%)** · 중복 113 불변 |
| 전체 nextest | **5,217/5,217** · clippy -D warnings 통과 |

대상 문서 `1371000` 73쪽은 `used` 964.7 -> 906.0px (본문 858.3) 로 내려옵니다.

## 한계 — 완전한 분리는 아닙니다

- 상한 `2` 는 **소실 쪽 표본 4건**에서 나온 값입니다.
- 비소실 쪽에도 길이 5~6 연쇄가 7건 있으므로 이 판별자는 그것들도 함께 자릅니다. 모집단
  게이트에서 회귀 0 이라 실害는 관측되지 않았지만, 근거가 강한 값은 아닙니다.
- 초과폭·연쇄 길이의 **문서 단위** 분포는 겹칩니다. 쪽 단위로 갈라야 분리가 보입니다 —
  집계 단위를 바꾸면 결론이 바뀌므로 재현 시 주의가 필요합니다.

## 남은 것

같은 술어가 통짜 배치 분기의 넘침 가드도 풉니다(이슈 #4024 코멘트). 그쪽은 별도 수정이
필요하며, 이전 시도는 한컴 정답 쪽수 회귀로 보류했습니다.

Refs #4024
