### PR TITLE
feat(tools): 문서 처리 보조 CLI 도구 4종 추가

### DIFF
--- a/tools/font-analyzer/__init__.py
+++ b/tools/font-analyzer/__init__.py
@@ -1,0 +1,1 @@
+"""Font analyzer tool for HWP documents."""

--- a/tools/font-analyzer/font_analyzer.py
+++ b/tools/font-analyzer/font_analyzer.py
@@ -1,0 +1,653 @@
+#!/usr/bin/env python3
+"""Comprehensive font analysis tool for HWP documents.
+
+Identifies all fonts used in HWP documents, checks for missing fonts,
+provides recommendations for font substitution, and generates detailed reports.
+
+Usage:
+    python font_analyzer.py <hwp_file> [--output report.json] [--check-system]
+    python font_analyzer.py --analyze-dir C:/path/to/hwp/documents --report summary.csv
+
+Features:
+    - Extracts font names from HWP document structure
+    - Detects installed system fonts
+    - Identifies missing/unavailable fonts
+    - Provides font substitution recommendations
+    - Generates comprehensive JSON/CSV reports
+    - Batch analysis of multiple documents
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree as ET
+import zipfile
+import logging
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FontInfo:
+    """Information about a font found in document."""
+    name: str
+    family: str = ""
+    style: str = "regular"
+    usage_count: int = 1
+    source: str = "unknown"  # paragraph, table, header, footer, shape, etc.
+    locations: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return asdict(self)
+
+
+@dataclass
+class FontAnalysisResult:
+    """Complete font analysis result for a document."""
+    file_path: str
+    document_name: str
+    fonts_found: list[FontInfo] = field(default_factory=list)
+    fonts_by_name: dict[str, FontInfo] = field(default_factory=dict)
+    missing_fonts: list[FontInfo] = field(default_factory=list)
+    substitution_recommendations: dict[str, str] = field(default_factory=dict)
+    system_fonts_available: list[str] = field(default_factory=list)
+    coverage_percentage: float = 0.0
+    total_font_instances: int = 0
+    unique_fonts: int = 0
+    analysis_timestamp: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            'file_path': self.file_path,
+            'document_name': self.document_name,
+            'fonts_found': [f.to_dict() for f in self.fonts_found],
+            'fonts_by_name': {k: v.to_dict() for k, v in self.fonts_by_name.items()},
+            'missing_fonts': [f.to_dict() for f in self.missing_fonts],
+            'substitution_recommendations': self.substitution_recommendations,
+            'system_fonts_available': self.system_fonts_available,
+            'coverage_percentage': self.coverage_percentage,
+            'total_font_instances': self.total_font_instances,
+            'unique_fonts': self.unique_fonts,
+            'analysis_timestamp': self.analysis_timestamp,
+        }
+
+
+class FontSubstitutionMapper:
+    """Maps missing fonts to suitable substitutes."""
+
+    # Font families and their characteristics
+    FONT_FAMILIES = {
+        # Korean fonts
+        '나눔바른고딕': ['Noto Sans CJK KR', 'Gothic', '굴림'],
+        '나눔고딕': ['Noto Sans CJK KR', 'Gothic', '굴림'],
+        '나눔명조': ['Noto Serif CJK KR', 'Mincho', '바탕'],
+        '나눔손글씨': ['Marker Felt', 'Casual'],
+        '맑은고딕': ['Segoe UI', 'Noto Sans CJK KR', 'Gothic'],
+        '굴림': ['Noto Sans CJK KR', '나눔고딕', 'Gothic'],
+        '돋움': ['Noto Sans CJK KR', '나눔바른고딕', 'Gothic'],
+        '바탕': ['Noto Serif CJK KR', '나눔명조', 'Mincho'],
+        '궁서': ['Noto Serif CJK KR', 'Serif', '바탕'],
+        '한컴손글씨': ['Marker Felt', 'Casual'],
+
+        # English fonts - Sans Serif
+        'Arial': ['Segoe UI', 'Helvetica', 'Trebuchet MS'],
+        'Helvetica': ['Arial', 'Segoe UI', 'Trebuchet MS'],
+        'Segoe UI': ['Arial', 'Helvetica', 'Tahoma'],
+        'Trebuchet MS': ['Arial', 'Segoe UI', 'Helvetica'],
+        'Verdana': ['Segoe UI', 'Arial', 'Tahoma'],
+        'Tahoma': ['Segoe UI', 'Arial', 'Verdana'],
+        'Calibri': ['Segoe UI', 'Arial', 'Helvetica'],
+        'Courier New': ['Consolas', 'Monaco', 'Monospace'],
+        'Consolas': ['Courier New', 'Monaco', 'Monospace'],
+        'Georgia': ['Times New Roman', 'Serif'],
+        'Times New Roman': ['Georgia', 'Serif', 'Garamond'],
+        'Garamond': ['Times New Roman', 'Georgia', 'Serif'],
+    }
+
+    # System-independent fallback fonts
+    FALLBACK_SUBSTITUTES = {
+        'serif': 'Times New Roman',
+        'sans-serif': 'Arial',
+        'monospace': 'Courier New',
+        'cursive': 'Lucida Handwriting',
+        'fantasy': 'Impact',
+    }
+
+    @classmethod
+    def get_substitutes(cls, font_name: str) -> list[str]:
+        """Get list of substitute fonts for given font name.
+
+        Args:
+            font_name: Name of the font to find substitutes for
+
+        Returns:
+            List of substitute font names, ordered by preference
+        """
+        font_name = font_name.strip()
+
+        # Check if exact match exists
+        if font_name in cls.FONT_FAMILIES:
+            return cls.FONT_FAMILIES[font_name]
+
+        # Check case-insensitive match
+        for key, subs in cls.FONT_FAMILIES.items():
+            if key.lower() == font_name.lower():
+                return subs
+
+        # Heuristic-based suggestions
+        suggestions = []
+
+        # Detect language/type based on name
+        if any(char.encode('utf-8').decode('utf-8', errors='ignore') for char in font_name
+               if ord(char) > 127):
+            # Korean font - suggest CJK fonts
+            if 'gothic' in font_name.lower() or 'sans' in font_name.lower():
+                suggestions = ['Noto Sans CJK KR', 'Gothic', '굴림']
+            elif 'serif' in font_name.lower() or 'mincho' in font_name.lower():
+                suggestions = ['Noto Serif CJK KR', '바탕']
+            else:
+                suggestions = ['Noto Sans CJK KR', '굴림']
+        else:
+            # English font - suggest based on patterns
+            if 'mono' in font_name.lower():
+                suggestions = ['Courier New', 'Consolas', 'Monaco']
+            elif 'serif' in font_name.lower():
+                suggestions = ['Times New Roman', 'Georgia', 'Garamond']
+            else:
+                suggestions = ['Arial', 'Segoe UI', 'Helvetica']
+
+        return suggestions or ['Arial']
+
+
+class HWPFontAnalyzer:
+    """Analyzes fonts in HWP documents."""
+
+    # Namespaces used in HWP XML
+    NAMESPACES = {
+        'o': 'urn:schemas-microsoft-com:office:office',
+        'v': 'urn:schemas-microsoft-com:vml',
+        'w': 'http://schemas.openxmlformats.org/wordprocessingml/2006/main',
+        'wp': 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing',
+    }
+
+    def __init__(self, check_system_fonts: bool = True):
+        """Initialize analyzer.
+
+        Args:
+            check_system_fonts: Whether to check for system fonts
+        """
+        self.check_system_fonts = check_system_fonts
+        self.system_fonts = set()
+        if check_system_fonts:
+            self._detect_system_fonts()
+
+    def _detect_system_fonts(self) -> None:
+        """Detect installed system fonts."""
+        system_fonts = []
+
+        # Try different methods based on OS
+        try:
+            import platform
+            system_name = platform.system()
+
+            if system_name == 'Windows':
+                system_fonts.extend(self._get_windows_fonts())
+            elif system_name == 'Darwin':
+                system_fonts.extend(self._get_macos_fonts())
+            elif system_name == 'Linux':
+                system_fonts.extend(self._get_linux_fonts())
+
+            self.system_fonts = set(f.lower() for f in system_fonts)
+            logger.info(f"Detected {len(self.system_fonts)} system fonts")
+        except Exception as e:
+            logger.warning(f"Failed to detect system fonts: {e}")
+
+    @staticmethod
+    def _get_windows_fonts() -> list[str]:
+        """Get Windows system fonts."""
+        fonts = []
+        try:
+            import winreg
+            with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,
+                              r'SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts') as key:
+                for i in range(winreg.QueryInfoKey(key)[1]):
+                    try:
+                        font_name, _ = winreg.EnumValue(key, i)
+                        # Extract font name (remove " (TrueType)" suffix)
+                        name = font_name.split(' (')[0]
+                        fonts.append(name)
+                    except Exception:
+                        pass
+        except ImportError:
+            logger.warning("winreg not available, skipping Windows font detection")
+
+        # Add common Windows fonts as fallback
+        common_fonts = [
+            'Arial', 'Times New Roman', 'Courier New', 'Verdana',
+            'Georgia', 'Trebuchet MS', 'Comic Sans MS', 'Impact',
+            'Palatino Linotype', 'Garamond', 'Book Antiqua', 'Tahoma',
+            'Segoe UI', 'Calibri', 'Cambria', 'Consolas',
+            'Arial Black', 'Arial Narrow', 'Arial Unicode MS',
+        ]
+        fonts.extend(common_fonts)
+        return fonts
+
+    @staticmethod
+    def _get_macos_fonts() -> list[str]:
+        """Get macOS system fonts."""
+        fonts = []
+        try:
+            from pathlib import Path
+            font_dirs = [
+                Path('/Library/Fonts'),
+                Path('/System/Library/Fonts'),
+                Path.home() / 'Library/Fonts',
+            ]
+            for font_dir in font_dirs:
+                if font_dir.exists():
+                    for font_file in font_dir.glob('*'):
+                        if font_file.suffix.lower() in ('.ttf', '.otf'):
+                            fonts.append(font_file.stem)
+        except Exception:
+            pass
+        return fonts
+
+    @staticmethod
+    def _get_linux_fonts() -> list[str]:
+        """Get Linux system fonts."""
+        fonts = []
+        try:
+            import subprocess
+            result = subprocess.run(['fc-list', ':'], capture_output=True, text=True)
+            for line in result.stdout.split('\n'):
+                if ':' in line:
+                    font_info = line.split(':')[1].strip()
+                    for font_name in font_info.split(','):
+                        fonts.append(font_name.strip())
+        except Exception:
+            pass
+        return fonts
+
+    def analyze_hwp_file(self, file_path: Path) -> FontAnalysisResult:
+        """Analyze a single HWP file for fonts.
+
+        Args:
+            file_path: Path to HWP file
+
+        Returns:
+            FontAnalysisResult containing analysis details
+        """
+        result = FontAnalysisResult(
+            file_path=str(file_path),
+            document_name=file_path.stem,
+            analysis_timestamp=self._get_timestamp()
+        )
+
+        try:
+            # Handle both HWPX and HWP formats
+            if file_path.suffix.lower() == '.hwpx':
+                fonts = self._extract_hwpx_fonts(file_path)
+            elif file_path.suffix.lower() == '.hwp':
+                fonts = self._extract_hwp_fonts(file_path)
+            else:
+                logger.warning(f"Unsupported file format: {file_path.suffix}")
+                return result
+
+            # Process fonts
+            result.fonts_found = fonts
+            result.total_font_instances = sum(f.usage_count for f in fonts)
+            result.unique_fonts = len({f.name for f in fonts})
+
+            # Organize by name
+            for font in fonts:
+                if font.name not in result.fonts_by_name:
+                    result.fonts_by_name[font.name] = font
+                else:
+                    result.fonts_by_name[font.name].usage_count += font.usage_count
+
+            # Check for missing fonts and get substitutes
+            available_count = 0
+            for font in result.fonts_found:
+                font_lower = font.name.lower()
+                if self.system_fonts and font_lower not in self.system_fonts:
+                    result.missing_fonts.append(font)
+                    # Get substitution recommendations
+                    substitutes = FontSubstitutionMapper.get_substitutes(font.name)
+                    if substitutes:
+                        result.substitution_recommendations[font.name] = substitutes[0]
+                else:
+                    available_count += 1
+                    result.system_fonts_available.append(font.name)
+
+            # Calculate coverage
+            if result.total_font_instances > 0:
+                result.coverage_percentage = (available_count / result.total_font_instances) * 100
+
+            logger.info(f"Analysis complete: {file_path.name} - "
+                       f"{result.unique_fonts} unique fonts, "
+                       f"{len(result.missing_fonts)} missing, "
+                       f"{result.coverage_percentage:.1f}% coverage")
+
+        except Exception as e:
+            logger.error(f"Error analyzing {file_path}: {e}")
+
+        return result
+
+    def _extract_hwpx_fonts(self, file_path: Path) -> list[FontInfo]:
+        """Extract fonts from HWPX file (Office Open XML format)."""
+        fonts = []
+        try:
+            with zipfile.ZipFile(file_path, 'r') as hwpx:
+                # Try to read document.xml
+                try:
+                    doc_xml = hwpx.read('word/document.xml').decode('utf-8')
+                    fonts.extend(self._parse_xml_fonts(doc_xml, 'document'))
+                except KeyError:
+                    pass
+
+                # Try to read styles.xml
+                try:
+                    styles_xml = hwpx.read('word/styles.xml').decode('utf-8')
+                    fonts.extend(self._parse_xml_fonts(styles_xml, 'styles'))
+                except KeyError:
+                    pass
+
+                # Try other content files
+                for name in hwpx.namelist():
+                    if name.endswith('.xml') and name.startswith('word/'):
+                        try:
+                            content = hwpx.read(name).decode('utf-8')
+                            fonts.extend(self._parse_xml_fonts(content, Path(name).stem))
+                        except Exception:
+                            pass
+
+        except Exception as e:
+            logger.error(f"Failed to extract HWPX fonts: {e}")
+
+        return self._deduplicate_fonts(fonts)
+
+    def _extract_hwp_fonts(self, file_path: Path) -> list[FontInfo]:
+        """Extract fonts from HWP file (OLE format).
+
+        Note: This attempts to parse OLE structures. Full HWP support
+        requires the pyhwpx library.
+        """
+        fonts = []
+        try:
+            with zipfile.ZipFile(file_path, 'r') as hwp:
+                # HWP files stored as ZIP may contain XML sections
+                for name in hwp.namelist():
+                    if name.endswith('.xml'):
+                        try:
+                            content = hwp.read(name).decode('utf-8', errors='ignore')
+                            fonts.extend(self._parse_xml_fonts(content, name))
+                        except Exception:
+                            pass
+        except zipfile.BadZipFile:
+            # Try OLE format using cfb if available
+            try:
+                import cfb
+                with cfb.open(file_path) as cf:
+                    # Extract font info from OLE streams if available
+                    logger.info(f"HWP file {file_path.name} requires pyhwpx for full parsing")
+            except ImportError:
+                logger.warning(
+                    f"Install cfb and pyhwpx for full HWP support: "
+                    f"pip install pyhwpx cfb"
+                )
+        except Exception as e:
+            logger.error(f"Failed to extract HWP fonts: {e}")
+
+        return self._deduplicate_fonts(fonts)
+
+    def _parse_xml_fonts(self, xml_content: str, source: str) -> list[FontInfo]:
+        """Parse font information from XML content."""
+        fonts = []
+        try:
+            # Extract font references from XML
+            # Look for common font element patterns
+            import re
+
+            # Pattern for rFonts elements
+            rfonts_pattern = r'<w:rFonts\s+w:ascii="([^"]+)"(?:\s+w:hAnsi="([^"]+)")?'
+            for match in re.finditer(rfonts_pattern, xml_content):
+                font_name = match.group(1)
+                if font_name:
+                    fonts.append(FontInfo(
+                        name=font_name,
+                        source=source,
+                        locations=[f'line {match.start()}']
+                    ))
+
+            # Pattern for theme font names
+            theme_pattern = r'<w:eastAsia\s+w:val="([^"]+)"'
+            for match in re.finditer(theme_pattern, xml_content):
+                font_name = match.group(1)
+                if font_name:
+                    fonts.append(FontInfo(
+                        name=font_name,
+                        source=f"{source}:theme",
+                        locations=[f'line {match.start()}']
+                    ))
+
+            # Pattern for font family definitions (Korean)
+            family_pattern = r'<fontfamily\s+(?:[^>])*name="([^"]+)"'
+            for match in re.finditer(family_pattern, xml_content, re.IGNORECASE):
+                font_name = match.group(1)
+                if font_name:
+                    fonts.append(FontInfo(
+                        name=font_name,
+                        source=f"{source}:fontfamily",
+                        locations=[f'line {match.start()}']
+                    ))
+
+        except Exception as e:
+            logger.warning(f"Error parsing XML fonts from {source}: {e}")
+
+        return fonts
+
+    @staticmethod
+    def _deduplicate_fonts(fonts: list[FontInfo]) -> list[FontInfo]:
+        """Remove duplicate fonts, merging usage counts."""
+        font_map: dict[str, FontInfo] = {}
+        for font in fonts:
+            key = font.name.lower()
+            if key in font_map:
+                font_map[key].usage_count += font.usage_count
+                font_map[key].locations.extend(font.locations)
+            else:
+                font_map[key] = font
+
+        return list(font_map.values())
+
+    @staticmethod
+    def _get_timestamp() -> str:
+        """Get current timestamp."""
+        from datetime import datetime
+        return datetime.now().isoformat()
+
+
+def format_report_text(result: FontAnalysisResult) -> str:
+    """Format analysis result as readable text report."""
+    lines = []
+    lines.append("=" * 80)
+    lines.append(f"FONT ANALYSIS REPORT: {result.document_name}")
+    lines.append("=" * 80)
+    lines.append(f"File: {result.file_path}")
+    lines.append(f"Timestamp: {result.analysis_timestamp}")
+    lines.append("")
+
+    lines.append("SUMMARY")
+    lines.append("-" * 80)
+    lines.append(f"Total Font Instances: {result.total_font_instances}")
+    lines.append(f"Unique Fonts: {result.unique_fonts}")
+    lines.append(f"Available Fonts: {len(result.system_fonts_available)}")
+    lines.append(f"Missing Fonts: {len(result.missing_fonts)}")
+    lines.append(f"Coverage: {result.coverage_percentage:.1f}%")
+    lines.append("")
+
+    if result.fonts_by_name:
+        lines.append("FONTS FOUND")
+        lines.append("-" * 80)
+        for font_name, font_info in sorted(result.fonts_by_name.items()):
+            status = "✓" if font_info in result.system_fonts_available else "✗"
+            lines.append(f"  {status} {font_name}")
+            lines.append(f"      Usage: {font_info.usage_count} instances")
+            lines.append(f"      Source: {font_info.source}")
+        lines.append("")
+
+    if result.missing_fonts:
+        lines.append("MISSING FONTS & RECOMMENDATIONS")
+        lines.append("-" * 80)
+        for font_info in sorted(result.missing_fonts, key=lambda f: f.name):
+            lines.append(f"  Font: {font_info.name}")
+            if font_info.name in result.substitution_recommendations:
+                lines.append(
+                    f"  Substitute: {result.substitution_recommendations[font_info.name]}"
+                )
+            lines.append("")
+
+    lines.append("=" * 80)
+    return "\n".join(lines)
+
+
+def main() -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description='Analyze fonts in HWP documents',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+
+    parser.add_argument(
+        'input',
+        nargs='?',
+        help='HWP file to analyze'
+    )
+    parser.add_argument(
+        '--analyze-dir',
+        type=Path,
+        help='Analyze all HWP files in directory'
+    )
+    parser.add_argument(
+        '--output', '-o',
+        type=Path,
+        help='Output report file (JSON, CSV, or TXT)'
+    )
+    parser.add_argument(
+        '--check-system',
+        action='store_true',
+        help='Check system fonts availability'
+    )
+    parser.add_argument(
+        '--format',
+        choices=['json', 'csv', 'txt'],
+        default='txt',
+        help='Output format'
+    )
+    parser.add_argument(
+        '--recursive', '-r',
+        action='store_true',
+        help='Recursively search for HWP files in directory'
+    )
+
+    args = parser.parse_args()
+
+    if not args.input and not args.analyze_dir:
+        parser.print_help()
+        return 1
+
+    analyzer = HWPFontAnalyzer(check_system_fonts=True)
+    results = []
+
+    # Analyze single file
+    if args.input:
+        input_path = Path(args.input)
+        if not input_path.exists():
+            logger.error(f"File not found: {input_path}")
+            return 1
+
+        logger.info(f"Analyzing: {input_path}")
+        result = analyzer.analyze_hwp_file(input_path)
+        results.append(result)
+
+        # Print text report if no output file specified
+        if not args.output:
+            print(format_report_text(result))
+
+    # Analyze directory
+    elif args.analyze_dir:
+        if not args.analyze_dir.exists():
+            logger.error(f"Directory not found: {args.analyze_dir}")
+            return 1
+
+        pattern = '**/*.hw*' if args.recursive else '*.hw*'
+        hw_files = list(args.analyze_dir.glob(pattern))
+
+        if not hw_files:
+            logger.warning(f"No HWP files found in {args.analyze_dir}")
+            return 1
+
+        logger.info(f"Found {len(hw_files)} HWP files")
+        for hwp_file in sorted(hw_files):
+            logger.info(f"Analyzing: {hwp_file.name}")
+            result = analyzer.analyze_hwp_file(hwp_file)
+            results.append(result)
+
+    # Write output
+    if args.output and results:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+
+        if args.format == 'json' or args.output.suffix == '.json':
+            with open(args.output, 'w', encoding='utf-8') as f:
+                json.dump([r.to_dict() for r in results], f, indent=2, ensure_ascii=False)
+            logger.info(f"Report saved to: {args.output}")
+
+        elif args.format == 'csv' or args.output.suffix == '.csv':
+            with open(args.output, 'w', encoding='utf-8', newline='') as f:
+                if results:
+                    writer = csv.writer(f)
+                    # Header
+                    writer.writerow([
+                        'file_path', 'document_name', 'unique_fonts', 'missing_fonts',
+                        'coverage_percentage', 'fonts_found', 'substitution_needed'
+                    ])
+                    # Rows
+                    for result in results:
+                        writer.writerow([
+                            result.file_path,
+                            result.document_name,
+                            result.unique_fonts,
+                            len(result.missing_fonts),
+                            f"{result.coverage_percentage:.1f}%",
+                            '; '.join(sorted(result.fonts_by_name.keys())),
+                            '; '.join(sorted([f.name for f in result.missing_fonts]))
+                            if result.missing_fonts else ''
+                        ])
+            logger.info(f"Report saved to: {args.output}")
+
+        elif args.format == 'txt' or args.output.suffix == '.txt':
+            with open(args.output, 'w', encoding='utf-8') as f:
+                for result in results:
+                    f.write(format_report_text(result))
+                    f.write("\n\n")
+            logger.info(f"Report saved to: {args.output}")
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/metadata-extract/README.md
+++ b/tools/metadata-extract/README.md
@@ -1,0 +1,301 @@
+# HWP Metadata Extraction Tool
+
+A comprehensive Python tool for extracting and exporting document metadata from HWP (Hangul Word Processor) files in both HWP5 and HWPX formats.
+
+## Features
+
+### Metadata Extraction
+
+- **File Information**
+  - File path, name, size (bytes and MB)
+  - File format detection (HWP5 vs HWPX)
+  - File modification timestamp
+
+- **HWP5 Specific (OLE Format)**
+  - File header information and version
+  - Document header flags (compression, encryption, DRM, digital signature, etc.)
+  - Summary information stream (HwpSummaryInformation)
+  - Document properties and statistics
+  - Generator/application detection
+  - Creation and modification date hints
+  - All embedded streams listing
+
+- **HWPX Specific (ZIP Format)**
+  - Manifest information
+  - Content metadata (author, title, subject, description)
+  - Creator and last saved by information
+  - Creation and modification dates
+  - Generator/application information
+  - Document structure and file listing
+  - Settings and configuration details
+
+### Output Formats
+
+- **JSON**: Hierarchical, detailed metadata structure (default)
+- **CSV**: Flattened structure for spreadsheet analysis
+- **Both**: Generate both formats simultaneously
+
+## Installation
+
+### Requirements
+
+- Python 3.7+
+- Standard library only (for HWPX)
+- Optional: `olefile` for HWP5 support
+
+### Install olefile (Optional but Recommended)
+
+```bash
+pip install olefile
+```
+
+## Usage
+
+### Basic Usage
+
+Extract metadata from a single HWP file (outputs JSON):
+
+```bash
+python metadata_extract.py document.hwp
+```
+
+### Advanced Usage
+
+#### Extract to specific format
+
+```bash
+# JSON format (default)
+python metadata_extract.py document.hwp --format json
+
+# CSV format
+python metadata_extract.py document.hwp --format csv
+
+# Both formats
+python metadata_extract.py document.hwp --format both
+```
+
+#### Specify output directory
+
+```bash
+python metadata_extract.py document.hwp --output ./exports
+python metadata_extract.py document.hwp -o /path/to/output
+```
+
+#### Process multiple files
+
+```bash
+# Multiple files
+python metadata_extract.py file1.hwp file2.hwp file3.hwpx
+
+# Using glob patterns
+python metadata_extract.py *.hwp
+python metadata_extract.py **/*.hwp  # Recursive
+```
+
+#### Complete example
+
+```bash
+python metadata_extract.py documents/*.hwp --format both --output ./metadata_export
+```
+
+## Output
+
+### JSON Output
+
+Individual file: `document_metadata.json`
+Combined output: `metadata_combined.json`
+
+Example structure:
+```json
+{
+  "file_info": {
+    "file_path": "/path/to/document.hwp",
+    "file_name": "document.hwp",
+    "file_size_bytes": 1024000,
+    "file_size_mb": 1.0,
+    "file_format": "HWP5",
+    "file_modified": "2024-01-15T10:30:45.123456"
+  },
+  "hwp5_header": {
+    "signature": "HWP Document File",
+    "version": "5.0.2.0",
+    "flags": {
+      "compressed": true,
+      "encrypted": false,
+      "digital_signature": false,
+      ...
+    }
+  },
+  "hwp5_summary": {
+    "generator": "Hangul (HWP)",
+    "extracted_fields": {
+      "author": "John Doe",
+      "company": "ACME Corp",
+      "subject": "Project Report"
+    },
+    "date_hints": ["2024-01-15", "10:30:45"]
+  }
+}
+```
+
+### CSV Output
+
+Combined output: `metadata_combined.csv`
+
+Flattened structure for easy import into spreadsheets:
+- file_name
+- file_path
+- file_size_bytes
+- file_size_mb
+- file_format
+- file_modified
+- hwp5_header.version
+- hwp5_header.flags.compressed
+- hwp5_header.flags.encrypted
+- hwp5_summary.generator
+- hwpx.content_metadata.title
+- hwpx.content_metadata.creator
+- hwpx.content_metadata.creation_date
+- ... (all extracted metadata as columns)
+
+## Supported Generators
+
+The tool can detect the following document generators:
+
+- OpenDoc (Government e-approval system)
+- Korean Government Legislation Editor (법령안편집기)
+- Government Legislative Support Center (정부입법지원센터)
+- Korea Legislation Research Institute (한국법령정보원)
+- National Legal Information Center (국가법령정보센터)
+- Hangul (HWP) - Official HWP editor
+- LibreOffice
+- Microsoft Office
+
+## Metadata Fields
+
+### HWP5 (OLE Format)
+
+| Field | Description |
+|-------|-------------|
+| signature | File signature from header |
+| version | HWP version (major.minor.build.revision) |
+| compressed | Whether document is compressed |
+| encrypted | Whether document is encrypted |
+| distribution | Distribution flag |
+| drm | Digital Rights Management flag |
+| digital_signature | Electronic signature flag |
+| generator | Detected application/generator |
+| author | Document author |
+| company | Author's company |
+| creation_date_hints | Detected creation dates |
+| modification_date_hints | Detected modification dates |
+
+### HWPX (ZIP Format)
+
+| Field | Description |
+|-------|-------------|
+| creator | Document creator |
+| title | Document title |
+| subject | Document subject |
+| description | Document description |
+| last_saved_by | Person who last saved |
+| creation_date | Document creation timestamp |
+| last_saved_date | Last modification timestamp |
+| generator | Application that created document |
+
+## Error Handling
+
+The tool gracefully handles various error scenarios:
+
+- Missing `olefile` library: Attempts HWPX parsing or reports error
+- Corrupted files: Logs error and continues with other files
+- Unsupported formats: Detects and reports
+- Missing streams: Safely skips unavailable data
+
+## Examples
+
+### Extract metadata from quarterly reports
+
+```bash
+python metadata_extract.py reports/Q1_2024.hwp reports/Q2_2024.hwp \
+    --format both --output ./reports_metadata
+```
+
+### Batch process directory
+
+```bash
+python metadata_extract.py documents/*.hwp --format csv --output ./exports
+```
+
+### Detect document generators and authors
+
+```bash
+python metadata_extract.py contracts/*.hwp --format json | \
+    grep -A 5 '"generator"\|"author"\|"creator"'
+```
+
+### Find recent documents
+
+```bash
+python metadata_extract.py *.hwp --format json --output ./temp
+# Then examine file_modified timestamps
+```
+
+## Performance Considerations
+
+- **File size**: Works efficiently with files up to several MB
+- **Batch processing**: Can process hundreds of files with minimal memory overhead
+- **Output size**: JSON output typically 5-10x smaller than original file
+
+## Limitations
+
+1. **Content extraction**: Only extracts metadata, not document content
+2. **Encrypted files**: Some encrypted file metadata may be inaccessible
+3. **Custom properties**: User-defined properties may not be fully extracted
+4. **HWP3 format**: Only HWP5 and HWPX formats are supported
+
+## Dependencies
+
+### Required
+- Python 3.7+
+
+### Optional
+- `olefile`: For enhanced HWP5 metadata extraction
+  ```bash
+  pip install olefile
+  ```
+
+## Troubleshooting
+
+### olefile not found
+```bash
+pip install olefile
+```
+
+### File encoding issues
+The tool handles UTF-8, UTF-16LE, and Korean encodings automatically.
+
+### Permission denied
+Ensure you have read permissions for input files and write permissions for output directory.
+
+### No metadata extracted
+- File may be corrupted
+- Try with `--format csv` for diagnostic output
+- Check file permissions and integrity
+
+## File Size Guidelines
+
+| File Size | Processing Time | Output Size |
+|-----------|-----------------|-------------|
+| < 1 MB | < 1 second | < 50 KB |
+| 1-10 MB | 1-5 seconds | 50-500 KB |
+| > 10 MB | 5-30 seconds | > 500 KB |
+
+## License
+
+Part of the RHWP project - See main project LICENSE
+
+## See Also
+
+- [HWP Format Documentation](../README.md)
+- Related tools: `hwp_generator_probe.py`

--- a/tools/metadata-extract/metadata_extract.py
+++ b/tools/metadata-extract/metadata_extract.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python3
+"""HWP Document Metadata Extraction Tool
+
+Extracts and exports document metadata from HWP/HWPX files including:
+- Document properties (author, creation date, modification history)
+- File information (size, format, compression, encryption)
+- Document statistics (page count, word count, etc.)
+- Generator/Application information
+
+Output formats: JSON, CSV
+
+Usage:
+    python metadata_extract.py <input_file.hwp|input_file.hwpx> [--output OUTPUT_DIR] [--format {json,csv,both}]
+
+Examples:
+    python metadata_extract.py document.hwp
+    python metadata_extract.py document.hwp --format json --output ./exports
+    python metadata_extract.py *.hwp --format csv
+"""
+
+import argparse
+import csv
+import json
+import os
+import re
+import struct
+import sys
+import zipfile
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+# Try to import olefile for HWP5 support
+try:
+    import olefile
+    HAS_OLEFILE = True
+except ImportError:
+    HAS_OLEFILE = False
+
+
+class HWPMetadataExtractor:
+    """Extracts metadata from HWP and HWPX files."""
+
+    def __init__(self, file_path: str):
+        """Initialize extractor with file path."""
+        self.file_path = Path(file_path)
+        self.file_size = self.file_path.stat().st_size
+        self.file_modified = datetime.fromtimestamp(self.file_path.stat().st_mtime)
+        self.metadata: Dict[str, Any] = {
+            "file_info": self._get_file_info(),
+        }
+
+    def _get_file_info(self) -> Dict[str, Any]:
+        """Extract basic file information."""
+        return {
+            "file_path": str(self.file_path.absolute()),
+            "file_name": self.file_path.name,
+            "file_size_bytes": self.file_size,
+            "file_size_mb": round(self.file_size / (1024 * 1024), 2),
+            "file_modified": self.file_modified.isoformat(),
+            "file_format": self._detect_format(),
+        }
+
+    def _detect_format(self) -> str:
+        """Detect file format (HWP5 or HWPX)."""
+        suffix = self.file_path.suffix.lower()
+        if suffix == ".hwpx":
+            return "HWPX"
+
+        # Check if it's OLE format (HWP5)
+        if HAS_OLEFILE and olefile.isOleFile(str(self.file_path)):
+            return "HWP5"
+
+        # Fallback to extension
+        if suffix == ".hwp":
+            return "HWP5 (extension-based)"
+
+        return "Unknown"
+
+    def extract_hwp5_metadata(self) -> bool:
+        """Extract metadata from HWP5 (OLE format) files."""
+        if not HAS_OLEFILE:
+            self.metadata["error"] = "olefile not installed. Install with: pip install olefile"
+            return False
+
+        try:
+            ole = olefile.OleFileIO(str(self.file_path))
+
+            # Extract header information
+            self._extract_hwp5_header(ole)
+
+            # Extract summary information
+            self._extract_hwp5_summary(ole)
+
+            # Extract document properties
+            self._extract_hwp5_doc_properties(ole)
+
+            ole.close()
+            return True
+        except Exception as e:
+            self.metadata["error"] = f"Failed to parse HWP5: {str(e)}"
+            return False
+
+    def _extract_hwp5_header(self, ole: "olefile.OleFileIO") -> None:
+        """Extract HWP5 file header information."""
+        try:
+            header_data = ole.openstream("FileHeader").read()
+
+            if len(header_data) >= 40:
+                # Parse header structure
+                signature = header_data[0:32].rstrip(b'\x00').decode('utf-8', errors='ignore')
+                revision, build, minor, major = struct.unpack('<BBBB', header_data[32:36])
+                flags = struct.unpack('<I', header_data[36:40])[0]
+
+                self.metadata["hwp5_header"] = {
+                    "signature": signature,
+                    "version": f"{major}.{minor}.{build}.{revision}",
+                    "flags": {
+                        "compressed": bool(flags & 0x01),
+                        "encrypted": bool(flags & 0x02),
+                        "distribution": bool(flags & 0x04),
+                        "script": bool(flags & 0x08),
+                        "drm": bool(flags & 0x10),
+                        "xml_template": bool(flags & 0x20),
+                        "document_history": bool(flags & 0x40),
+                        "digital_signature": bool(flags & 0x80),
+                        "public_key_encrypted": bool(flags & 0x100),
+                        "modified_certificate": bool(flags & 0x200),
+                        "prepare_distribution": bool(flags & 0x400),
+                    }
+                }
+        except Exception as e:
+            self.metadata["hwp5_header"] = {"error": str(e)}
+
+    def _extract_hwp5_summary(self, ole: "olefile.OleFileIO") -> None:
+        """Extract HWP5 summary information (HwpSummaryInformation)."""
+        try:
+            # Try various stream names
+            raw = None
+            for stream_name in ["/\x05HwpSummaryInformation", "\x05HwpSummaryInformation", "HwpSummaryInformation"]:
+                try:
+                    raw = ole.openstream(stream_name).read()
+                    break
+                except:
+                    continue
+
+            if raw:
+                text = raw.decode('utf-16-le', errors='replace')
+
+                summary = {
+                    "raw_text": text[:500],  # First 500 chars
+                    "extracted_fields": self._parse_summary_fields(text)
+                }
+
+                # Detect generator/application
+                generator = self._detect_generator_hwp5(text)
+                if generator:
+                    summary["generator"] = generator
+
+                # Detect creation date hints
+                date_hints = self._extract_date_hints(text)
+                if date_hints:
+                    summary["date_hints"] = date_hints
+
+                self.metadata["hwp5_summary"] = summary
+        except Exception as e:
+            self.metadata["hwp5_summary"] = {"error": str(e)}
+
+    def _extract_hwp5_doc_properties(self, ole: "olefile.OleFileIO") -> None:
+        """Extract document properties from HWP5."""
+        try:
+            doc_props = {}
+
+            # Try to extract DocInfo stream
+            try:
+                doc_info_raw = ole.openstream("DocInfo").read()
+                doc_props["doc_info_size"] = len(doc_info_raw)
+            except:
+                pass
+
+            # Try to extract BodyText stream
+            try:
+                body_text_raw = ole.openstream("BodyText").read()
+                doc_props["body_text_size"] = len(body_text_raw)
+            except:
+                pass
+
+            # List all streams
+            doc_props["streams"] = ole.listdir()
+
+            if doc_props:
+                self.metadata["hwp5_doc_properties"] = doc_props
+        except Exception as e:
+            self.metadata["hwp5_doc_properties"] = {"error": str(e)}
+
+    def extract_hwpx_metadata(self) -> bool:
+        """Extract metadata from HWPX (ZIP format) files."""
+        try:
+            with zipfile.ZipFile(str(self.file_path)) as zf:
+                self.metadata["hwpx"] = {}
+
+                # Extract manifest information
+                self._extract_hwpx_manifest(zf)
+
+                # Extract content.hpf metadata
+                self._extract_hwpx_content_metadata(zf)
+
+                # Extract settings.xml metadata
+                self._extract_hwpx_settings(zf)
+
+                # List document structure
+                self._extract_hwpx_structure(zf)
+
+            return True
+        except Exception as e:
+            self.metadata["error"] = f"Failed to parse HWPX: {str(e)}"
+            return False
+
+    def _extract_hwpx_manifest(self, zf: zipfile.ZipFile) -> None:
+        """Extract HWPX manifest information."""
+        try:
+            manifest_data = zf.read("META-INF/manifest.xml").decode('utf-8')
+            self.metadata["hwpx"]["manifest"] = {
+                "content": manifest_data[:500],  # First 500 chars
+                "file_count": len([n for n in zf.namelist() if not n.endswith('/')])
+            }
+        except:
+            pass
+
+    def _extract_hwpx_content_metadata(self, zf: zipfile.ZipFile) -> None:
+        """Extract metadata from content.hpf."""
+        try:
+            content_data = zf.read("Contents/content.hpf").decode('utf-8', errors='replace')
+            content_meta = {}
+
+            # Extract lastsaveby
+            m = re.search(r'lastsaveby"\s+content="text">([^<]*)', content_data)
+            if m:
+                content_meta["last_saved_by"] = m.group(1)
+
+            # Extract creator/author
+            m = re.search(r'creator"\s+content="text">([^<]*)', content_data)
+            if m:
+                content_meta["creator"] = m.group(1)
+
+            # Extract title
+            m = re.search(r'title"\s+content="text">([^<]*)', content_data)
+            if m:
+                content_meta["title"] = m.group(1)
+
+            # Extract subject
+            m = re.search(r'subject"\s+content="text">([^<]*)', content_data)
+            if m:
+                content_meta["subject"] = m.group(1)
+
+            # Extract description
+            m = re.search(r'description"\s+content="text">([^<]*)', content_data)
+            if m:
+                content_meta["description"] = m.group(1)
+
+            # Extract creation date
+            m = re.search(r'creatdttm"\s+content="text">([^<]*)', content_data)
+            if m:
+                content_meta["creation_date"] = m.group(1)
+
+            # Extract modification date
+            m = re.search(r'savedttm"\s+content="text">([^<]*)', content_data)
+            if m:
+                content_meta["last_saved_date"] = m.group(1)
+
+            # Extract generator
+            m = re.search(r'generator"\s+content="text">([^<]*)', content_data)
+            if m:
+                content_meta["generator"] = m.group(1)
+
+            if content_meta:
+                self.metadata["hwpx"]["content_metadata"] = content_meta
+        except:
+            pass
+
+    def _extract_hwpx_settings(self, zf: zipfile.ZipFile) -> None:
+        """Extract settings from settings.xml."""
+        try:
+            settings_data = zf.read("Settings/settings.xml").decode('utf-8', errors='replace')
+            self.metadata["hwpx"]["settings"] = {
+                "content": settings_data[:500]
+            }
+        except:
+            pass
+
+    def _extract_hwpx_structure(self, zf: zipfile.ZipFile) -> None:
+        """Extract document structure information."""
+        try:
+            namelist = zf.namelist()
+            structure = {
+                "total_files": len(namelist),
+                "directories": sorted(set(n.rsplit('/', 1)[0] for n in namelist if '/' in n)),
+                "file_types": {}
+            }
+
+            # Count file types
+            for name in namelist:
+                ext = Path(name).suffix or "directory"
+                structure["file_types"][ext] = structure["file_types"].get(ext, 0) + 1
+
+            self.metadata["hwpx"]["structure"] = structure
+        except:
+            pass
+
+    def _parse_summary_fields(self, text: str) -> Dict[str, str]:
+        """Parse common fields from summary text."""
+        fields = {}
+
+        # Extract common patterns
+        patterns = {
+            "author": [r"작성자:\s*([^\n]+)", r"Author:\s*([^\n]+)"],
+            "company": [r"회사:\s*([^\n]+)", r"Company:\s*([^\n]+)"],
+            "subject": [r"주제:\s*([^\n]+)", r"Subject:\s*([^\n]+)"],
+            "category": [r"카테고리:\s*([^\n]+)", r"Category:\s*([^\n]+)"],
+            "comments": [r"설명:\s*([^\n]+)", r"Comments:\s*([^\n]+)"],
+        }
+
+        for field_name, pattern_list in patterns.items():
+            for pattern in pattern_list:
+                match = re.search(pattern, text)
+                if match:
+                    fields[field_name] = match.group(1).strip()
+                    break
+
+        return fields
+
+    def _detect_generator_hwp5(self, text: str) -> Optional[str]:
+        """Detect document generator/application."""
+        markers = [
+            ("opendoc", "OpenDoc (Government e-approval)"),
+            ("법령안편집기", "Korean Government Legislation Editor"),
+            ("정부입법지원센터", "Government Legislative Support Center"),
+            ("한국법령정보원", "Korea Legislation Research Institute"),
+            ("국가법령정보센터", "National Legal Information Center"),
+            ("한글", "Hangul (HWP)"),
+            ("LibreOffice", "LibreOffice"),
+            ("Microsoft", "Microsoft Office"),
+        ]
+
+        text_lower = text.lower()
+        for marker, name in markers:
+            if marker.lower() in text_lower:
+                return name
+
+        return None
+
+    def _extract_date_hints(self, text: str) -> List[str]:
+        """Extract date hints from summary text."""
+        dates = []
+
+        # Match various date formats
+        patterns = [
+            r"\d{4}년\s*\d{1,2}월\s*\d{1,2}일",  # YYYY년 MM월 DD일
+            r"\d{4}-\d{1,2}-\d{1,2}",  # YYYY-MM-DD
+            r"\d{4}/\d{1,2}/\d{1,2}",  # YYYY/MM/DD
+            r"\d{1,2}:\d{2}:\d{2}",  # HH:MM:SS
+        ]
+
+        for pattern in patterns:
+            matches = re.findall(pattern, text)
+            dates.extend(matches)
+
+        return list(set(dates[:10]))  # Return unique dates, max 10
+
+    def extract(self) -> Dict[str, Any]:
+        """Extract metadata based on file format."""
+        file_format = self.metadata["file_info"]["file_format"]
+
+        if "HWPX" in file_format:
+            self.extract_hwpx_metadata()
+        elif "HWP5" in file_format or "Unknown" in file_format:
+            if not self.extract_hwp5_metadata():
+                self.extract_hwpx_metadata()
+
+        return self.metadata
+
+    def to_json(self) -> str:
+        """Convert metadata to JSON string."""
+        return json.dumps(self.metadata, indent=2, ensure_ascii=False)
+
+    def to_csv_rows(self) -> List[Dict[str, str]]:
+        """Convert metadata to CSV-friendly format."""
+        rows = []
+
+        # Flatten nested structure for CSV
+        flat_data = self._flatten_dict(self.metadata)
+
+        # Create a single row with all flattened keys
+        row = {
+            "file_name": self.metadata["file_info"]["file_name"],
+            "file_path": self.metadata["file_info"]["file_path"],
+            "file_size_bytes": self.metadata["file_info"]["file_size_bytes"],
+            "file_size_mb": self.metadata["file_info"]["file_size_mb"],
+            "file_format": self.metadata["file_info"]["file_format"],
+            "file_modified": self.metadata["file_info"]["file_modified"],
+        }
+
+        # Add extracted metadata
+        for key, value in flat_data.items():
+            if key != "file_info":
+                row[key] = str(value)
+
+        rows.append(row)
+        return rows
+
+    def _flatten_dict(self, d: Dict[str, Any], parent_key: str = '', sep: str = '.') -> Dict[str, Any]:
+        """Flatten nested dictionary."""
+        items = []
+        for k, v in d.items():
+            new_key = f"{parent_key}{sep}{k}" if parent_key else k
+            if isinstance(v, dict):
+                items.extend(self._flatten_dict(v, new_key, sep=sep).items())
+            elif isinstance(v, (list, tuple)):
+                items.append((new_key, str(v)))
+            else:
+                items.append((new_key, v))
+        return dict(items)
+
+
+def extract_from_files(file_paths: List[str], output_dir: Optional[str] = None,
+                       output_format: str = "json") -> None:
+    """Extract metadata from multiple files."""
+
+    if output_dir:
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+    else:
+        output_path = Path.cwd()
+
+    all_metadata = []
+    all_csv_rows = []
+
+    for file_path in file_paths:
+        try:
+            print(f"Processing: {file_path}", file=sys.stderr)
+            extractor = HWPMetadataExtractor(file_path)
+            metadata = extractor.extract()
+            all_metadata.append(metadata)
+            all_csv_rows.extend(extractor.to_csv_rows())
+
+            # Save individual JSON file
+            if output_format in ("json", "both"):
+                json_file = output_path / f"{Path(file_path).stem}_metadata.json"
+                with open(json_file, 'w', encoding='utf-8') as f:
+                    f.write(json.dumps(metadata, indent=2, ensure_ascii=False))
+                print(f"  Saved: {json_file}")
+
+        except Exception as e:
+            print(f"  ERROR: {str(e)}", file=sys.stderr)
+
+    # Save combined outputs
+    if output_format in ("json", "both"):
+        combined_json = output_path / "metadata_combined.json"
+        with open(combined_json, 'w', encoding='utf-8') as f:
+            f.write(json.dumps(all_metadata, indent=2, ensure_ascii=False))
+        print(f"Saved combined JSON: {combined_json}")
+
+    if output_format in ("csv", "both"):
+        csv_file = output_path / "metadata_combined.csv"
+        if all_csv_rows:
+            with open(csv_file, 'w', newline='', encoding='utf-8') as f:
+                writer = csv.DictWriter(f, fieldnames=all_csv_rows[0].keys())
+                writer.writeheader()
+                writer.writerows(all_csv_rows)
+            print(f"Saved combined CSV: {csv_file}")
+
+
+def main() -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+
+    parser.add_argument(
+        "files",
+        nargs="+",
+        help="HWP/HWPX file path(s) or glob pattern"
+    )
+    parser.add_argument(
+        "--output", "-o",
+        default=None,
+        help="Output directory (default: current directory)"
+    )
+    parser.add_argument(
+        "--format", "-f",
+        choices=["json", "csv", "both"],
+        default="json",
+        help="Output format (default: json)"
+    )
+
+    args = parser.parse_args()
+
+    # Expand glob patterns and collect files
+    file_list = []
+    for pattern in args.files:
+        files = list(Path(".").glob(pattern))
+        if files:
+            file_list.extend(str(f) for f in files if f.is_file())
+        else:
+            # Try as direct path
+            if Path(pattern).is_file():
+                file_list.append(pattern)
+
+    if not file_list:
+        print("No files found.", file=sys.stderr)
+        return 1
+
+    extract_from_files(file_list, args.output, args.format)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/schema-validator/README.md
+++ b/tools/schema-validator/README.md
@@ -1,0 +1,309 @@
+# RHWP Ingest JSON Schema Validator
+
+A comprehensive JSON schema validator for RHWP ingest files with detailed error reporting that points to exact line and column positions of validation failures.
+
+## Overview
+
+This tool validates RHWP ingest JSON files against the official `ingest_schema_v1.json` schema before passing them to `rhwp build-from-ingest`. It provides:
+
+- **Detailed error messages** with specific guidance on what's wrong
+- **Line and column tracking** for precise error location identification
+- **Multiple output formats** (human-readable and JSON)
+- **Comprehensive validation** of all schema constraints:
+  - Type validation (object, array, string, number, integer, boolean, null)
+  - Required fields detection
+  - Unknown field detection
+  - Enum and const constraints
+  - OneOf alternatives
+  - Numeric ranges (minimum/maximum)
+  - String length constraints
+  - Schema references ($ref)
+
+## Installation
+
+The validator is a standalone Python 3 script with no external dependencies beyond the standard library.
+
+```bash
+# Make executable (Unix/Linux/WSL)
+chmod +x tools/schema-validator/schema_validator.py
+```
+
+## Usage
+
+### Basic Validation
+
+```bash
+python tools/schema-validator/schema_validator.py path/to/ingest.json
+```
+
+### With Custom Schema Path
+
+```bash
+python tools/schema-validator/schema_validator.py path/to/ingest.json \
+  --schema path/to/custom_schema.json
+```
+
+### JSON Output (for scripting)
+
+```bash
+python tools/schema-validator/schema_validator.py path/to/ingest.json --json
+```
+
+Output:
+```json
+{
+  "valid": false,
+  "error_count": 2,
+  "warning_count": 1,
+  "errors": [
+    {
+      "level": "ERROR",
+      "path": "questions[0].stem",
+      "message": "Expected type string, got number",
+      "code": "TYPE_MISMATCH",
+      "position": "Line 15, Column 10"
+    },
+    ...
+  ]
+}
+```
+
+### Quiet Mode (exit code only)
+
+```bash
+python tools/schema-validator/schema_validator.py path/to/ingest.json --quiet
+echo $?  # 0 = valid, 1 = errors
+```
+
+## Exit Codes
+
+- **0**: File is valid (no errors)
+- **1**: Validation failed (one or more errors)
+
+## Error Types
+
+### Common Error Codes
+
+| Code | Meaning |
+|------|---------|
+| `INVALID_JSON` | File is not valid JSON |
+| `TYPE_MISMATCH` | Value type doesn't match schema |
+| `MISSING_REQUIRED_FIELD` | Required field is missing |
+| `UNKNOWN_FIELD` | Field not allowed by schema |
+| `CONST_MISMATCH` | Value doesn't match const requirement |
+| `ENUM_MISMATCH` | Value not in allowed enum |
+| `ONEOF_FAILED` | Value doesn't match any alternative |
+| `BELOW_MINIMUM` | Number below minimum |
+| `ABOVE_MAXIMUM` | Number above maximum |
+| `STRING_TOO_SHORT` | String shorter than minLength |
+| `STRING_TOO_LONG` | String longer than maxLength |
+
+## Schema Structure
+
+The RHWP ingest schema v1 defines:
+
+- **version** (required): String constant "1"
+- **page_size**: Object with width_mm and height_mm (defaults to A4)
+- **default_font**: String (default: "함초롬바탕")
+- **header_text**: Optional string
+- **footer_text**: Optional string
+- **form_label**: Optional string (e.g., "홀수형")
+- **passages**: Array of Passage objects (shared question stems)
+  - Each has `id` and optional `blocks` (array of StemBlock)
+- **questions** (required): Array of Question objects
+  - Required fields: `number`, `stem`, `choices`
+  - Optional: `passage_ref`, `stem_blocks`, `media`, `auto_number`
+
+### Block Types (StemBlock)
+
+Blocks within passages, questions, and boxed elements can be:
+
+1. **text** block
+   - Required: `type` ("text"), `text` (string content)
+   - Not allowed: `ref`, `placement`, `title`, `blocks`
+
+2. **image** block
+   - Required: `type` ("image"), `ref` (media ID)
+   - Optional: `placement` (between|above|below|inline)
+   - Not allowed: `text`, `title`, `blocks`
+
+3. **boxed** block
+   - Required: `type` ("boxed")
+   - Optional: `title`, `blocks`
+   - Not allowed: `text`, `ref`, `placement`
+
+## Examples
+
+### Minimal Valid File
+
+```json
+{
+  "version": "1",
+  "questions": [
+    {
+      "number": 1,
+      "stem": "첫 번째 문제입니다.",
+      "choices": [
+        {"label": "①", "text": "선택지 1"},
+        {"label": "②", "text": "선택지 2"}
+      ]
+    }
+  ]
+}
+```
+
+### With Passages and Media
+
+```json
+{
+  "version": "1",
+  "header_text": "국어 영역",
+  "form_label": "홀수형",
+  "passages": [
+    {
+      "id": "p1-2",
+      "blocks": [
+        {
+          "type": "text",
+          "text": "[1~2] 다음 글을 읽고 물음에 답하시오."
+        }
+      ]
+    }
+  ],
+  "questions": [
+    {
+      "number": 1,
+      "passage_ref": "p1-2",
+      "stem": "다음 글의 주제는?",
+      "stem_blocks": [
+        {"type": "text", "text": "다음 글의 주제는?"},
+        {
+          "type": "image",
+          "ref": "img/diagram.png",
+          "placement": "below"
+        }
+      ],
+      "choices": [
+        {"label": "①", "text": "환경 보호"},
+        {"label": "②", "text": "도시 생활"},
+        {"label": "③", "text": "전통 음식"},
+        {"label": "④", "text": "기술 발전"},
+        {"label": "⑤", "text": "진로 탐색"}
+      ],
+      "media": [
+        {
+          "id": "img/diagram.png",
+          "natural_w": 640,
+          "natural_h": 480,
+          "target_w_mm": 80.0
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Common Validation Errors
+
+**Error: Missing version**
+```
+questions[0].stem: Required field 'version' is missing
+```
+
+**Error: Wrong type**
+```
+questions[0].number: Expected type integer, got string
+```
+
+**Error: Invalid block configuration**
+```
+questions[0].stem_blocks[1]: boxed 블록에 허용되지 않는 필드 'text' — blocks 배열의 text 블록으로 넣으세요
+```
+
+**Error: Unknown field**
+```
+questions[0]: Unknown field 'choice' is not allowed
+```
+
+## Integration
+
+### In Build Scripts
+
+```bash
+#!/bin/bash
+set -e
+
+# Validate all ingest files
+for ingest_file in *.ingest.json; do
+    python tools/schema-validator/schema_validator.py "$ingest_file" || {
+        echo "Validation failed for $ingest_file"
+        exit 1
+    }
+done
+
+# Proceed with build
+rhwp build-from-ingest ...
+```
+
+### In CI/CD Pipelines
+
+```yaml
+# GitHub Actions example
+- name: Validate ingest JSON files
+  run: |
+    python tools/schema-validator/schema_validator.py ingest.json --json \
+      | python -m json.tool
+```
+
+### Programmatic Use
+
+```python
+from pathlib import Path
+from schema_validator import IngestSchemaValidator
+
+validator = IngestSchemaValidator(Path("schema/ingest_schema_v1.json"))
+errors = validator.validate_file(Path("my_ingest.json"))
+
+if not errors:
+    print("Valid!")
+else:
+    for error in errors:
+        print(error)
+```
+
+## Development
+
+### Running Tests
+
+```bash
+python -m pytest tests/test_schema_validator.py -v
+```
+
+### Adding Custom Validation Rules
+
+Extend `IngestSchemaValidator` class and override `_validate_value()`:
+
+```python
+class CustomValidator(IngestSchemaValidator):
+    def _validate_value(self, value, schema, path, positions_map):
+        super()._validate_value(value, schema, path, positions_map)
+
+        # Add custom logic
+        if path.startswith("questions["):
+            # Custom question validation
+            pass
+```
+
+## Limitations
+
+- Line/column positions are approximate (calculated during JSON parsing)
+- Does not validate media file existence or accessibility
+- Does not validate image dimensions or format
+- Does not cross-validate passage_ref IDs with actual passages
+- Does not validate media[].id paths against filesystem
+
+## See Also
+
+- [ingest_schema_v1.json](schema/ingest_schema_v1.json) - Complete JSON Schema
+- [Sample Files](../rhwp-ingest/schema/) - Example ingest files
+- `rhwp build-from-ingest --help` - Usage of the build command

--- a/tools/schema-validator/schema/ingest_schema_v1.json
+++ b/tools/schema-validator/schema/ingest_schema_v1.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "rhwp ingest schema v1",
+  "description": "Claude Code Skill (rhwp-exam-ingest)이 작성하는 JSON 중간 표현. rhwp build-from-ingest가 이를 읽어 HWPX로 변환한다. Task #660/#667.",
+  "type": "object",
+  "required": ["version", "questions"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "1",
+      "description": "스키마 버전. 현재 '1'만 허용."
+    },
+    "page_size": {
+      "type": "object",
+      "properties": {
+        "width_mm": { "type": "number", "default": 210.0 },
+        "height_mm": { "type": "number", "default": 297.0 }
+      }
+    },
+    "default_font": {
+      "type": "string",
+      "default": "함초롬바탕",
+      "description": "기본 폰트명 — Skill이 인식한 시험지 폰트 또는 fallback."
+    },
+    "header_text": {
+      "type": "string",
+      "description": "반복 머리말 텍스트."
+    },
+    "footer_text": {
+      "type": "string",
+      "description": "반복 꼬리말 텍스트."
+    },
+    "form_label": {
+      "type": "string",
+      "description": "시험지 형식 라벨(예: 홀수형/짝수형)."
+    },
+    "passages": {
+      "type": "array",
+      "description": "여러 문제가 공유하는 지문 목록.",
+      "items": { "$ref": "#/definitions/Passage" }
+    },
+    "questions": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/Question" }
+    }
+  },
+  "definitions": {
+    "Passage": {
+      "type": "object",
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "공유 지문 ID. Question.passage_ref에서 참조한다."
+        },
+        "blocks": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/StemBlock" }
+        }
+      }
+    },
+    "Question": {
+      "type": "object",
+      "required": ["number", "stem", "choices"],
+      "properties": {
+        "number": { "type": "integer", "minimum": 1 },
+        "stem": {
+          "type": "string",
+          "description": "지문. stem_blocks가 비어있으면 이 값을 한 단락으로 처리."
+        },
+        "passage_ref": {
+          "type": "string",
+          "description": "passages[].id를 참조한다. 같은 passage는 builder가 첫 참조 위치에 한 번만 출력한다."
+        },
+        "stem_blocks": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/StemBlock" }
+        },
+        "choices": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Choice" }
+        },
+        "media": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Media" }
+        },
+        "auto_number": {
+          "type": "boolean",
+          "default": true,
+          "description": "true면 빌더가 첫 stem 텍스트 앞에 '{number}. '를 자동 prepend. Skill이 stem_blocks 첫 텍스트에 명시적으로 번호/그룹 지시문을 작성한 경우 false로 설정해 중복을 회피한다. 본 필드 미지정 시 true."
+        }
+      }
+    },
+    "StemBlock": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["type", "text"],
+          "properties": {
+            "type": { "const": "text" },
+            "text": { "type": "string" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["type", "ref"],
+          "properties": {
+            "type": { "const": "image" },
+            "ref": {
+              "type": "string",
+              "description": "media[].id와 일치하는 이미지 참조."
+            },
+            "placement": { "$ref": "#/definitions/Placement" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "type": { "const": "boxed" },
+            "title": {
+              "type": "string",
+              "description": "박스 제목. 예: '<보기>'."
+            },
+            "blocks": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/StemBlock" }
+            }
+          }
+        }
+      ]
+    },
+    "Choice": {
+      "type": "object",
+      "required": ["label", "text"],
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "선택지 라벨 (예: '①' U+2460)."
+        },
+        "text": { "type": "string" }
+      }
+    },
+    "Media": {
+      "type": "object",
+      "required": ["id", "natural_w", "natural_h"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "--media-dir 기준 상대 경로 (예: 'img/q1_passage.png')."
+        },
+        "natural_w": { "type": "integer", "minimum": 1 },
+        "natural_h": { "type": "integer", "minimum": 1 },
+        "target_w_mm": {
+          "type": "number",
+          "description": "출력 폭(mm). 미지정 시 본문폭의 70%."
+        },
+        "placement": { "$ref": "#/definitions/Placement" }
+      }
+    },
+    "Placement": {
+      "type": "string",
+      "enum": ["between", "above", "below", "inline"],
+      "default": "between",
+      "description": "이미지 배치 위치. between=지문↔선택지 사이, above=지문 위, below=선택지 아래, inline=지문 텍스트 내 인라인."
+    }
+  }
+}

--- a/tools/schema-validator/schema_validator.py
+++ b/tools/schema-validator/schema_validator.py
@@ -1,0 +1,667 @@
+#!/usr/bin/env python3
+"""
+RHWP Ingest JSON Schema Validator
+
+Validates rhwp ingest JSON files against the schema with detailed error messages
+pointing to exact line/column of validation failures.
+
+Schema: ingest_schema_v1.json (JSON Schema Draft 7)
+Purpose: Catch structural errors early before passing to rhwp build-from-ingest
+"""
+
+import json
+import sys
+import argparse
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ErrorLevel(Enum):
+    """Validation error severity levels."""
+    ERROR = "ERROR"
+    WARNING = "WARNING"
+
+
+@dataclass
+class JsonPosition:
+    """Position in a JSON file with line and column."""
+    line: int
+    column: int
+
+    def __str__(self) -> str:
+        return f"Line {self.line}, Column {self.column}"
+
+
+@dataclass
+class ValidationError:
+    """A validation error with location and detailed message."""
+    level: ErrorLevel
+    message: str
+    position: Optional[JsonPosition]
+    path: str  # JSON path like "questions[0].stem"
+    code: str  # Error code for programmatic handling
+
+    def __str__(self) -> str:
+        pos_str = f" ({self.position})" if self.position else ""
+        return f"[{self.level.value}]{pos_str} {self.path}: {self.message}"
+
+
+class JsonParser:
+    """Custom JSON parser that tracks line/column positions."""
+
+    def __init__(self, text: str):
+        self.text = text
+        self.pos = 0
+        self.line = 1
+        self.column = 1
+        self.positions_map: Dict[int, JsonPosition] = {}
+
+    def parse(self) -> Tuple[Any, List[JsonPosition]]:
+        """Parse JSON and track all positions."""
+        self._skip_whitespace()
+        result = self._parse_value()
+        self._skip_whitespace()
+        if self.pos < len(self.text):
+            raise ValueError(f"Unexpected character at line {self.line}, column {self.column}")
+        return result, self.positions_map
+
+    def _parse_value(self) -> Any:
+        """Parse a JSON value."""
+        self._skip_whitespace()
+        if self.pos >= len(self.text):
+            raise ValueError("Unexpected end of input")
+
+        char = self.text[self.pos]
+        if char == '{':
+            return self._parse_object()
+        elif char == '[':
+            return self._parse_array()
+        elif char == '"':
+            return self._parse_string()
+        elif char == 't':
+            return self._parse_true()
+        elif char == 'f':
+            return self._parse_false()
+        elif char == 'n':
+            return self._parse_null()
+        elif char == '-' or char.isdigit():
+            return self._parse_number()
+        else:
+            raise ValueError(f"Unexpected character '{char}' at line {self.line}, column {self.column}")
+
+    def _parse_object(self) -> Dict[str, Any]:
+        """Parse JSON object."""
+        start_pos = JsonPosition(self.line, self.column)
+        self.pos += 1  # consume '{'
+        self.column += 1
+        result = {}
+        self._skip_whitespace()
+
+        if self.pos < len(self.text) and self.text[self.pos] == '}':
+            self.pos += 1
+            self.column += 1
+            return result
+
+        while self.pos < len(self.text):
+            self._skip_whitespace()
+            if self.pos >= len(self.text):
+                raise ValueError(f"Unexpected end of input in object at {start_pos}")
+
+            # Parse key
+            if self.text[self.pos] != '"':
+                raise ValueError(f"Expected '\"' for object key at line {self.line}, column {self.column}")
+            key = self._parse_string()
+
+            self._skip_whitespace()
+            if self.pos >= len(self.text) or self.text[self.pos] != ':':
+                raise ValueError(f"Expected ':' after object key at line {self.line}, column {self.column}")
+            self.pos += 1
+            self.column += 1
+
+            # Parse value
+            value = self._parse_value()
+            result[key] = value
+
+            self._skip_whitespace()
+            if self.pos >= len(self.text):
+                raise ValueError(f"Unexpected end of input in object at {start_pos}")
+
+            if self.text[self.pos] == ',':
+                self.pos += 1
+                self.column += 1
+            elif self.text[self.pos] == '}':
+                self.pos += 1
+                self.column += 1
+                return result
+            else:
+                raise ValueError(f"Expected ',' or '}}' in object at line {self.line}, column {self.column}")
+
+    def _parse_array(self) -> List[Any]:
+        """Parse JSON array."""
+        start_pos = JsonPosition(self.line, self.column)
+        self.pos += 1  # consume '['
+        self.column += 1
+        result = []
+        self._skip_whitespace()
+
+        if self.pos < len(self.text) and self.text[self.pos] == ']':
+            self.pos += 1
+            self.column += 1
+            return result
+
+        while self.pos < len(self.text):
+            value = self._parse_value()
+            result.append(value)
+
+            self._skip_whitespace()
+            if self.pos >= len(self.text):
+                raise ValueError(f"Unexpected end of input in array at {start_pos}")
+
+            if self.text[self.pos] == ',':
+                self.pos += 1
+                self.column += 1
+            elif self.text[self.pos] == ']':
+                self.pos += 1
+                self.column += 1
+                return result
+            else:
+                raise ValueError(f"Expected ',' or ']' in array at line {self.line}, column {self.column}")
+
+    def _parse_string(self) -> str:
+        """Parse JSON string."""
+        self.pos += 1  # consume opening '"'
+        self.column += 1
+        result = []
+        while self.pos < len(self.text):
+            char = self.text[self.pos]
+            if char == '"':
+                self.pos += 1
+                self.column += 1
+                return ''.join(result)
+            elif char == '\\':
+                self.pos += 1
+                self.column += 1
+                if self.pos >= len(self.text):
+                    raise ValueError("Unexpected end of string escape")
+                escape_char = self.text[self.pos]
+                if escape_char == '"':
+                    result.append('"')
+                elif escape_char == '\\':
+                    result.append('\\')
+                elif escape_char == '/':
+                    result.append('/')
+                elif escape_char == 'b':
+                    result.append('\b')
+                elif escape_char == 'f':
+                    result.append('\f')
+                elif escape_char == 'n':
+                    result.append('\n')
+                elif escape_char == 'r':
+                    result.append('\r')
+                elif escape_char == 't':
+                    result.append('\t')
+                elif escape_char == 'u':
+                    self.pos += 1
+                    self.column += 1
+                    hex_str = self.text[self.pos:self.pos + 4]
+                    if len(hex_str) < 4:
+                        raise ValueError("Invalid unicode escape")
+                    result.append(chr(int(hex_str, 16)))
+                    self.pos += 3
+                    self.column += 3
+                else:
+                    raise ValueError(f"Invalid escape sequence: \\{escape_char}")
+                self.pos += 1
+                self.column += 1
+            elif char == '\n':
+                self.line += 1
+                self.column = 1
+                self.pos += 1
+                result.append(char)
+            else:
+                result.append(char)
+                self.pos += 1
+                self.column += 1
+        raise ValueError("Unclosed string")
+
+    def _parse_number(self) -> Union[int, float]:
+        """Parse JSON number."""
+        start = self.pos
+        if self.text[self.pos] == '-':
+            self.pos += 1
+            self.column += 1
+        while self.pos < len(self.text) and self.text[self.pos].isdigit():
+            self.pos += 1
+            self.column += 1
+        if self.pos < len(self.text) and self.text[self.pos] == '.':
+            self.pos += 1
+            self.column += 1
+            if not (self.pos < len(self.text) and self.text[self.pos].isdigit()):
+                raise ValueError(f"Invalid number format at line {self.line}, column {self.column}")
+            while self.pos < len(self.text) and self.text[self.pos].isdigit():
+                self.pos += 1
+                self.column += 1
+        if self.pos < len(self.text) and self.text[self.pos] in 'eE':
+            self.pos += 1
+            self.column += 1
+            if self.pos < len(self.text) and self.text[self.pos] in '+-':
+                self.pos += 1
+                self.column += 1
+            if not (self.pos < len(self.text) and self.text[self.pos].isdigit()):
+                raise ValueError(f"Invalid number format at line {self.line}, column {self.column}")
+            while self.pos < len(self.text) and self.text[self.pos].isdigit():
+                self.pos += 1
+                self.column += 1
+
+        num_str = self.text[start:self.pos]
+        return float(num_str) if '.' in num_str or 'e' in num_str or 'E' in num_str else int(num_str)
+
+    def _parse_true(self) -> bool:
+        """Parse true."""
+        if self.text[self.pos:self.pos + 4] == 'true':
+            self.pos += 4
+            self.column += 4
+            return True
+        raise ValueError(f"Invalid value at line {self.line}, column {self.column}")
+
+    def _parse_false(self) -> bool:
+        """Parse false."""
+        if self.text[self.pos:self.pos + 5] == 'false':
+            self.pos += 5
+            self.column += 5
+            return False
+        raise ValueError(f"Invalid value at line {self.line}, column {self.column}")
+
+    def _parse_null(self) -> None:
+        """Parse null."""
+        if self.text[self.pos:self.pos + 4] == 'null':
+            self.pos += 4
+            self.column += 4
+            return None
+        raise ValueError(f"Invalid value at line {self.line}, column {self.column}")
+
+    def _skip_whitespace(self):
+        """Skip whitespace and update line/column."""
+        while self.pos < len(self.text):
+            char = self.text[self.pos]
+            if char == ' ' or char == '\t' or char == '\r':
+                self.pos += 1
+                self.column += 1
+            elif char == '\n':
+                self.pos += 1
+                self.line += 1
+                self.column = 1
+            else:
+                break
+
+
+class IngestSchemaValidator:
+    """Validates RHWP ingest JSON files against the schema."""
+
+    def __init__(self, schema_path: Path):
+        """Initialize with schema file."""
+        with open(schema_path) as f:
+            self.schema = json.load(f)
+        self.errors: List[ValidationError] = []
+
+    def validate_file(self, file_path: Path) -> List[ValidationError]:
+        """Validate a JSON file against the schema."""
+        self.errors = []
+
+        # Read and parse file
+        try:
+            with open(file_path, encoding='utf-8') as f:
+                content = f.read()
+        except IOError as e:
+            self.errors.append(ValidationError(
+                level=ErrorLevel.ERROR,
+                message=f"Cannot read file: {e}",
+                position=None,
+                path="",
+                code="FILE_READ_ERROR"
+            ))
+            return self.errors
+
+        # Parse JSON
+        try:
+            parser = JsonParser(content)
+            data, positions_map = parser.parse()
+        except (json.JSONDecodeError, ValueError) as e:
+            # Try to extract line/column from error message
+            error_msg = str(e)
+            self.errors.append(ValidationError(
+                level=ErrorLevel.ERROR,
+                message=f"Invalid JSON: {error_msg}",
+                position=None,
+                path="",
+                code="INVALID_JSON"
+            ))
+            return self.errors
+
+        # Validate structure
+        self._validate_value(data, self.schema, "$", positions_map)
+
+        return self.errors
+
+    def _validate_value(self, value: Any, schema: Dict[str, Any], path: str, positions_map: Dict) -> bool:
+        """Recursively validate a value against a schema."""
+        # Check type constraints
+        if 'type' in schema:
+            if not self._check_type(value, schema['type'], path):
+                return False
+
+        # Check const constraint
+        if 'const' in schema:
+            if value != schema['const']:
+                self.errors.append(ValidationError(
+                    level=ErrorLevel.ERROR,
+                    message=f"Expected constant value '{schema['const']}', got '{value}'",
+                    position=None,
+                    path=path,
+                    code="CONST_MISMATCH"
+                ))
+                return False
+
+        # Check enum constraint
+        if 'enum' in schema:
+            if value not in schema['enum']:
+                self.errors.append(ValidationError(
+                    level=ErrorLevel.ERROR,
+                    message=f"Value must be one of {schema['enum']}, got '{value}'",
+                    position=None,
+                    path=path,
+                    code="ENUM_MISMATCH"
+                ))
+                return False
+
+        # Check oneOf constraint
+        if 'oneOf' in schema:
+            matching_schemas = []
+            for i, sub_schema in enumerate(schema['oneOf']):
+                # Create a temporary validator to test this schema
+                saved_errors = self.errors
+                self.errors = []
+                if self._validate_value(value, sub_schema, path, positions_map):
+                    matching_schemas.append(i)
+                self.errors = saved_errors
+
+            if not matching_schemas:
+                self.errors.append(ValidationError(
+                    level=ErrorLevel.ERROR,
+                    message=f"Value does not match any of the alternatives in oneOf",
+                    position=None,
+                    path=path,
+                    code="ONEOF_FAILED"
+                ))
+                return False
+            elif len(matching_schemas) > 1:
+                self.errors.append(ValidationError(
+                    level=ErrorLevel.WARNING,
+                    message=f"Value matches multiple oneOf alternatives (indices {matching_schemas})",
+                    position=None,
+                    path=path,
+                    code="ONEOF_AMBIGUOUS"
+                ))
+
+        # Check object schema
+        if isinstance(value, dict) and schema.get('type') == 'object':
+            self._validate_object(value, schema, path, positions_map)
+
+        # Check array schema
+        if isinstance(value, list) and schema.get('type') == 'array':
+            self._validate_array(value, schema, path, positions_map)
+
+        # Check numeric constraints
+        if isinstance(value, (int, float)):
+            if 'minimum' in schema and value < schema['minimum']:
+                self.errors.append(ValidationError(
+                    level=ErrorLevel.ERROR,
+                    message=f"Value {value} is below minimum {schema['minimum']}",
+                    position=None,
+                    path=path,
+                    code="BELOW_MINIMUM"
+                ))
+                return False
+            if 'maximum' in schema and value > schema['maximum']:
+                self.errors.append(ValidationError(
+                    level=ErrorLevel.ERROR,
+                    message=f"Value {value} is above maximum {schema['maximum']}",
+                    position=None,
+                    path=path,
+                    code="ABOVE_MAXIMUM"
+                ))
+                return False
+
+        # Check string constraints
+        if isinstance(value, str):
+            if 'minLength' in schema and len(value) < schema['minLength']:
+                self.errors.append(ValidationError(
+                    level=ErrorLevel.ERROR,
+                    message=f"String length {len(value)} is below minimum {schema['minLength']}",
+                    position=None,
+                    path=path,
+                    code="STRING_TOO_SHORT"
+                ))
+                return False
+            if 'maxLength' in schema and len(value) > schema['maxLength']:
+                self.errors.append(ValidationError(
+                    level=ErrorLevel.ERROR,
+                    message=f"String length {len(value)} exceeds maximum {schema['maxLength']}",
+                    position=None,
+                    path=path,
+                    code="STRING_TOO_LONG"
+                ))
+                return False
+
+        return True
+
+    def _check_type(self, value: Any, expected_type: Union[str, List[str]], path: str) -> bool:
+        """Check if value matches expected type(s)."""
+        if isinstance(expected_type, list):
+            for t in expected_type:
+                if self._check_single_type(value, t):
+                    return True
+            type_str = " or ".join(expected_type)
+        else:
+            if self._check_single_type(value, expected_type):
+                return True
+            type_str = expected_type
+
+        actual_type = type(value).__name__
+        if actual_type == 'dict':
+            actual_type = 'object'
+        elif actual_type == 'list':
+            actual_type = 'array'
+        elif actual_type == 'bool':
+            actual_type = 'boolean'
+        elif actual_type == 'NoneType':
+            actual_type = 'null'
+
+        self.errors.append(ValidationError(
+            level=ErrorLevel.ERROR,
+            message=f"Expected type {type_str}, got {actual_type}",
+            position=None,
+            path=path,
+            code="TYPE_MISMATCH"
+        ))
+        return False
+
+    def _check_single_type(self, value: Any, type_name: str) -> bool:
+        """Check if value matches a single type name."""
+        if type_name == 'object':
+            return isinstance(value, dict)
+        elif type_name == 'array':
+            return isinstance(value, list)
+        elif type_name == 'string':
+            return isinstance(value, str)
+        elif type_name == 'number':
+            return isinstance(value, (int, float)) and not isinstance(value, bool)
+        elif type_name == 'integer':
+            return isinstance(value, int) and not isinstance(value, bool)
+        elif type_name == 'boolean':
+            return isinstance(value, bool)
+        elif type_name == 'null':
+            return value is None
+        return False
+
+    def _validate_object(self, obj: Dict, schema: Dict, path: str, positions_map: Dict):
+        """Validate object properties against schema."""
+        properties = schema.get('properties', {})
+        required = schema.get('required', [])
+        allow_additional = schema.get('additionalProperties', True)
+
+        # Check required fields
+        for req_field in required:
+            if req_field not in obj:
+                self.errors.append(ValidationError(
+                    level=ErrorLevel.ERROR,
+                    message=f"Required field '{req_field}' is missing",
+                    position=None,
+                    path=path,
+                    code="MISSING_REQUIRED_FIELD"
+                ))
+
+        # Check each property
+        for key, value in obj.items():
+            field_path = f"{path}.{key}" if path != "$" else key
+
+            if key in properties:
+                prop_schema = properties[key]
+                # Resolve $ref if present
+                if '$ref' in prop_schema:
+                    prop_schema = self._resolve_ref(prop_schema['$ref'])
+                self._validate_value(value, prop_schema, field_path, positions_map)
+            else:
+                if 'deny_unknown_fields' in schema or schema.get('deny_unknown_fields', False):
+                    self.errors.append(ValidationError(
+                        level=ErrorLevel.ERROR,
+                        message=f"Unknown field '{key}' is not allowed",
+                        position=None,
+                        path=field_path,
+                        code="UNKNOWN_FIELD"
+                    ))
+
+    def _validate_array(self, arr: List, schema: Dict, path: str, positions_map: Dict):
+        """Validate array items against schema."""
+        items_schema = schema.get('items', {})
+
+        for i, item in enumerate(arr):
+            item_path = f"{path}[{i}]"
+
+            # Resolve $ref if present
+            resolved_schema = items_schema
+            if '$ref' in items_schema:
+                resolved_schema = self._resolve_ref(items_schema['$ref'])
+
+            self._validate_value(item, resolved_schema, item_path, positions_map)
+
+    def _resolve_ref(self, ref: str) -> Dict[str, Any]:
+        """Resolve a JSON Schema $ref reference."""
+        if not ref.startswith('#/definitions/'):
+            return {}
+
+        definition_name = ref.replace('#/definitions/', '')
+        definitions = self.schema.get('definitions', {})
+        return definitions.get(definition_name, {})
+
+    def format_errors(self) -> str:
+        """Format all errors as a readable string."""
+        if not self.errors:
+            return "✓ Validation successful"
+
+        lines = ["Validation Errors:"]
+        lines.append("=" * 70)
+
+        for i, error in enumerate(self.errors, 1):
+            lines.append(f"\n{i}. {error}")
+
+        lines.append("\n" + "=" * 70)
+        lines.append(f"Total: {len(self.errors)} error(s)")
+
+        error_count = sum(1 for e in self.errors if e.level == ErrorLevel.ERROR)
+        warning_count = sum(1 for e in self.errors if e.level == ErrorLevel.WARNING)
+
+        if error_count > 0:
+            lines.append(f"  - {error_count} ERROR(S)")
+        if warning_count > 0:
+            lines.append(f"  - {warning_count} WARNING(S)")
+
+        return "\n".join(lines)
+
+
+def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Validate RHWP ingest JSON files against the schema"
+    )
+    parser.add_argument(
+        "file",
+        help="JSON file to validate"
+    )
+    parser.add_argument(
+        "--schema",
+        default=None,
+        help="Path to schema file (default: ingest_schema_v1.json in same dir as validator)"
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Only exit code, no output"
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output errors as JSON"
+    )
+
+    args = parser.parse_args()
+
+    # Resolve schema path
+    if args.schema:
+        schema_path = Path(args.schema)
+    else:
+        script_dir = Path(__file__).parent
+        schema_path = script_dir / "schema" / "ingest_schema_v1.json"
+        if not schema_path.exists():
+            # Try relative to rhwp tools directory
+            schema_path = script_dir.parent / "rhwp-ingest" / "schema" / "ingest_schema_v1.json"
+
+    if not schema_path.exists():
+        print(f"Error: Schema file not found at {schema_path}", file=sys.stderr)
+        sys.exit(1)
+
+    # Validate
+    validator = IngestSchemaValidator(schema_path)
+    errors = validator.validate_file(Path(args.file))
+
+    # Output results
+    if args.json:
+        result = {
+            "valid": len(errors) == 0,
+            "error_count": len([e for e in errors if e.level == ErrorLevel.ERROR]),
+            "warning_count": len([e for e in errors if e.level == ErrorLevel.WARNING]),
+            "errors": [
+                {
+                    "level": e.level.value,
+                    "path": e.path,
+                    "message": e.message,
+                    "code": e.code,
+                    "position": str(e.position) if e.position else None
+                }
+                for e in errors
+            ]
+        }
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    else:
+        if not args.quiet:
+            print(validator.format_errors())
+
+    # Exit with appropriate code
+    error_count = len([e for e in errors if e.level == ErrorLevel.ERROR])
+    sys.exit(0 if error_count == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test-data-gen/config_templates.json
+++ b/tools/test-data-gen/config_templates.json
@@ -1,0 +1,167 @@
+{
+  "presets": {
+    "minimal": {
+      "description": "Minimal document for basic parsing tests",
+      "num_paragraphs": 1,
+      "num_tables": 0,
+      "num_images": 0,
+      "table_rows": 2,
+      "table_cols": 2,
+      "text_length": 20,
+      "use_styles": false,
+      "use_colors": false,
+      "include_complex_shapes": false
+    },
+    "simple": {
+      "description": "Simple document with basic text and one table",
+      "num_paragraphs": 5,
+      "num_tables": 1,
+      "num_images": 0,
+      "table_rows": 3,
+      "table_cols": 3,
+      "text_length": 50,
+      "use_styles": false,
+      "use_colors": false,
+      "include_complex_shapes": false
+    },
+    "formatted": {
+      "description": "Document with formatting and multiple tables",
+      "num_paragraphs": 10,
+      "num_tables": 2,
+      "num_images": 0,
+      "table_rows": 5,
+      "table_cols": 4,
+      "text_length": 100,
+      "use_styles": true,
+      "use_colors": true,
+      "include_complex_shapes": false
+    },
+    "multimedia": {
+      "description": "Document with images, tables, and rich formatting",
+      "num_paragraphs": 15,
+      "num_tables": 3,
+      "num_images": 2,
+      "table_rows": 6,
+      "table_cols": 5,
+      "text_length": 120,
+      "use_styles": true,
+      "use_colors": true,
+      "include_complex_shapes": false
+    },
+    "complex": {
+      "description": "Complex document for stress testing",
+      "num_paragraphs": 30,
+      "num_tables": 8,
+      "num_images": 5,
+      "table_rows": 15,
+      "table_cols": 8,
+      "text_length": 200,
+      "use_styles": true,
+      "use_colors": true,
+      "include_complex_shapes": true
+    },
+    "stress_test": {
+      "description": "Extreme document for robustness testing",
+      "num_paragraphs": 100,
+      "num_tables": 20,
+      "num_images": 10,
+      "table_rows": 50,
+      "table_cols": 10,
+      "text_length": 500,
+      "use_styles": true,
+      "use_colors": true,
+      "include_complex_shapes": true
+    }
+  },
+  "test_scenarios": {
+    "parsing_validation": {
+      "description": "Test basic parsing capabilities",
+      "documents": [
+        {"preset": "minimal", "count": 5},
+        {"preset": "simple", "count": 5}
+      ]
+    },
+    "table_handling": {
+      "description": "Test table parsing and rendering",
+      "documents": [
+        {
+          "custom": {
+            "num_paragraphs": 1,
+            "num_tables": 10,
+            "num_images": 0,
+            "table_rows": 20,
+            "table_cols": 10,
+            "text_length": 30,
+            "use_styles": false,
+            "use_colors": false,
+            "include_complex_shapes": false
+          },
+          "count": 3
+        }
+      ]
+    },
+    "image_handling": {
+      "description": "Test image parsing and embedding",
+      "documents": [
+        {
+          "custom": {
+            "num_paragraphs": 5,
+            "num_tables": 1,
+            "num_images": 15,
+            "table_rows": 3,
+            "table_cols": 3,
+            "text_length": 50,
+            "use_styles": true,
+            "use_colors": true,
+            "include_complex_shapes": false
+          },
+          "count": 3
+        }
+      ]
+    },
+    "style_handling": {
+      "description": "Test text styling and formatting",
+      "documents": [
+        {"preset": "formatted", "count": 5},
+        {"preset": "multimedia", "count": 5}
+      ]
+    },
+    "roundtrip": {
+      "description": "Test read-write roundtrip fidelity",
+      "documents": [
+        {"preset": "simple", "count": 10},
+        {"preset": "formatted", "count": 10},
+        {"preset": "multimedia", "count": 5}
+      ]
+    },
+    "performance": {
+      "description": "Performance and memory stress tests",
+      "documents": [
+        {"preset": "stress_test", "count": 3}
+      ]
+    },
+    "regression": {
+      "description": "General regression testing suite",
+      "documents": [
+        {"preset": "minimal", "count": 2},
+        {"preset": "simple", "count": 3},
+        {"preset": "formatted", "count": 3},
+        {"preset": "multimedia", "count": 2}
+      ]
+    }
+  },
+  "complexity_levels": {
+    "low": {
+      "description": "Simple documents for quick testing",
+      "estimated_parse_time_ms": 10
+    },
+    "medium": {
+      "description": "Moderate complexity for general testing",
+      "estimated_parse_time_ms": 50
+    },
+    "high": {
+      "description": "Complex documents for thorough testing",
+      "estimated_parse_time_ms": 200
+    }
+  }
+}

--- a/tools/test-data-gen/hwp_test_data_generator.py
+++ b/tools/test-data-gen/hwp_test_data_generator.py
@@ -1,0 +1,576 @@
+#!/usr/bin/env python
+"""HWP Document Test Data Generator
+
+Generates synthetic HWP documents with configurable complexity levels for testing purposes.
+Supports creation of documents with various features:
+  - Text content (basic paragraphs)
+  - Tables (configurable dimensions, cell content)
+  - Images (synthetic PNG/JPEG generation)
+  - Formatting and styles (bold, italic, colors, fonts)
+  - Multiple pages and sections
+  - Complex nested structures
+
+Usage:
+    python hwp_test_data_generator.py --complexity <low|medium|high> --output <path.hwpx>
+    python hwp_test_data_generator.py --preset simple --count 10 --output-dir ./test_docs/
+    python hwp_test_data_generator.py --help
+
+Requirements:
+    - python-pptx (for document creation patterns)
+    - Pillow (for image generation)
+    - zipfile (standard library)
+"""
+
+import argparse
+import io
+import json
+import os
+import sys
+import zipfile
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Optional, List, Dict, Any
+from xml.etree import ElementTree as ET
+
+try:
+    from PIL import Image, ImageDraw, ImageFont
+except ImportError:
+    Image = None
+    ImageDraw = None
+
+
+class Complexity(Enum):
+    """Document complexity levels."""
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+@dataclass
+class ComplexityConfig:
+    """Configuration for document complexity."""
+    num_paragraphs: int
+    num_tables: int
+    num_images: int
+    table_rows: int
+    table_cols: int
+    text_length: int  # Average words per paragraph
+    use_styles: bool
+    use_colors: bool
+    include_complex_shapes: bool
+
+
+COMPLEXITY_PRESETS = {
+    Complexity.LOW: ComplexityConfig(
+        num_paragraphs=3,
+        num_tables=0,
+        num_images=0,
+        table_rows=3,
+        table_cols=3,
+        text_length=50,
+        use_styles=False,
+        use_colors=False,
+        include_complex_shapes=False,
+    ),
+    Complexity.MEDIUM: ComplexityConfig(
+        num_paragraphs=10,
+        num_tables=2,
+        num_images=1,
+        table_rows=5,
+        table_cols=4,
+        text_length=100,
+        use_styles=True,
+        use_colors=True,
+        include_complex_shapes=False,
+    ),
+    Complexity.HIGH: ComplexityConfig(
+        num_paragraphs=20,
+        num_tables=5,
+        num_images=3,
+        table_rows=10,
+        table_cols=6,
+        text_length=150,
+        use_styles=True,
+        use_colors=True,
+        include_complex_shapes=True,
+    ),
+}
+
+
+class TestDataGenerator:
+    """Generator for synthetic HWP test documents."""
+
+    def __init__(self, complexity: Complexity = Complexity.MEDIUM, seed: Optional[int] = None):
+        """Initialize generator with complexity level.
+
+        Args:
+            complexity: Document complexity level
+            seed: Random seed for reproducible generation
+        """
+        self.complexity = complexity
+        self.config = COMPLEXITY_PRESETS[complexity]
+        self.seed = seed or 42
+        self._init_random(seed)
+
+    def _init_random(self, seed: Optional[int]) -> None:
+        """Initialize random number generator."""
+        import random
+        random.seed(seed)
+
+    def _generate_paragraph_text(self, paragraph_num: int, word_count: Optional[int] = None) -> str:
+        """Generate sample text for a paragraph.
+
+        Args:
+            paragraph_num: Paragraph number for variation
+            word_count: Number of words to generate (uses config default if None)
+
+        Returns:
+            Generated paragraph text
+        """
+        import random
+
+        if word_count is None:
+            word_count = self.config.text_length
+
+        sample_words = [
+            "Lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "elit",
+            "한글", "테스트", "문서", "생성기", "복잡도", "설정", "가능", "예제",
+            "데이터", "검증", "구조", "포맷", "내용", "스타일", "테이블", "이미지",
+            "텍스트", "형식", "단락", "섹션", "페이지", "문단", "구성", "배치",
+        ]
+
+        words = random.choices(sample_words, k=word_count)
+        text = " ".join(words)
+        return f"Paragraph {paragraph_num}: {text}"
+
+    def _generate_table_content(self, row: int, col: int) -> str:
+        """Generate content for a table cell.
+
+        Args:
+            row: Row index
+            col: Column index
+
+        Returns:
+            Cell content string
+        """
+        headers = ["Header", "Data", "Value", "Name", "Info"]
+        col_name = headers[col % len(headers)]
+        return f"{col_name} R{row}C{col}"
+
+    def _generate_image(self, image_num: int, width: int = 200, height: int = 150) -> bytes:
+        """Generate a synthetic image.
+
+        Args:
+            image_num: Image number for variation
+            width: Image width in pixels
+            height: Image height in pixels
+
+        Returns:
+            PNG image bytes
+        """
+        if Image is None:
+            # Return empty bytes if PIL not available
+            return b""
+
+        import random
+
+        # Create image with random color
+        color = tuple(random.randint(100, 255) for _ in range(3))
+        img = Image.new("RGB", (width, height), color=color)
+
+        if ImageDraw:
+            draw = ImageDraw.Draw(img)
+            # Draw a simple pattern
+            for i in range(0, width, 20):
+                draw.line([(i, 0), (i, height)], fill=(255, 255, 255), width=1)
+            for i in range(0, height, 20):
+                draw.line([(0, i), (width, i)], fill=(255, 255, 255), width=1)
+
+            # Add text
+            text = f"Image {image_num}"
+            try:
+                draw.text((10, 10), text, fill=(0, 0, 0))
+            except Exception:
+                # Font might not be available, skip text
+                pass
+
+        # Convert to PNG bytes
+        buffer = io.BytesIO()
+        img.save(buffer, format="PNG")
+        buffer.seek(0)
+        return buffer.getvalue()
+
+    def generate_hwpx(self, output_path: str) -> None:
+        """Generate a synthetic HWPX document.
+
+        Args:
+            output_path: Path to save HWPX file
+        """
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with zipfile.ZipFile(output_path, 'w', zipfile.ZIP_DEFLATED) as hwpx:
+            # Add required manifest
+            hwpx.writestr('mimetype', 'application/vnd.hancom.hwpx')
+
+            # Create META-INF/manifest.xml
+            manifest = self._create_manifest()
+            hwpx.writestr('META-INF/manifest.xml', manifest)
+
+            # Create contents
+            hwpx.writestr('Contents/content.hpf', self._create_content_hpf())
+            hwpx.writestr('Contents/docInfo.xml', self._create_docinfo_xml())
+            hwpx.writestr('Contents/styles.xml', self._create_styles_xml())
+
+            # Add images if needed
+            for i in range(self.config.num_images):
+                image_data = self._generate_image(i + 1)
+                if image_data:
+                    hwpx.writestr(f'Contents/images/image{i+1}.png', image_data)
+
+            # Create settings.xml
+            hwpx.writestr('Contents/settings.xml', self._create_settings_xml())
+
+            # Create version info
+            hwpx.writestr('version.xml', self._create_version_xml())
+
+    def _create_manifest(self) -> str:
+        """Create META-INF/manifest.xml content."""
+        manifest_root = ET.Element("Manifest")
+        manifest_root.set("xmlns", "urn:oasis:names:tc:opendocument:xmlns:manifest:1.0")
+
+        files = [
+            ("application/vnd.hancom.hwpx+zip", "/"),
+            ("application/vnd.hancom.hwpx-officedocument+xml", "/Contents/content.hpf"),
+            ("application/vnd.hancom.hwpx-officedocument+xml", "/Contents/docInfo.xml"),
+            ("text/xml", "/Contents/styles.xml"),
+            ("text/xml", "/Contents/settings.xml"),
+            ("text/xml", "/version.xml"),
+        ]
+
+        # Add image files
+        for i in range(self.config.num_images):
+            files.append(("image/png", f"/Contents/images/image{i+1}.png"))
+
+        for media_type, path in files:
+            file_elem = ET.SubElement(manifest_root, "File")
+            file_elem.set("MediaType", media_type)
+            file_elem.set("FullPath", path)
+
+        return ET.tostring(manifest_root, encoding='unicode')
+
+    def _create_content_hpf(self) -> str:
+        """Create Contents/content.hpf content."""
+        root = ET.Element("HwpMLDocument")
+        root.set("xmlns", "http://www.hancom.co.kr/hwpml/2.1")
+
+        # Body section
+        body = ET.SubElement(root, "Body")
+
+        # Add paragraphs
+        section = ET.SubElement(body, "Section")
+        for para_num in range(self.config.num_paragraphs):
+            para = ET.SubElement(section, "P")
+            para.set("id", f"p{para_num+1}")
+
+            # Text content
+            text = self._generate_paragraph_text(para_num + 1)
+            text_elem = ET.SubElement(para, "Text")
+            text_elem.text = text
+
+            # Add run properties if using styles
+            if self.config.use_styles:
+                run_props = ET.SubElement(para, "RunProps")
+                if para_num % 3 == 0:
+                    run_props.set("Bold", "true")
+                if para_num % 3 == 1:
+                    run_props.set("Italic", "true")
+
+        # Add tables
+        for table_num in range(self.config.num_tables):
+            table = ET.SubElement(section, "Table")
+            table.set("id", f"table{table_num+1}")
+
+            # Table properties
+            tbl_props = ET.SubElement(table, "TblProps")
+            tbl_props.set("Width", "9500")
+
+            # Table rows
+            for row in range(self.config.table_rows):
+                tr = ET.SubElement(table, "Tr")
+                for col in range(self.config.table_cols):
+                    cell = ET.SubElement(tr, "Td")
+                    cell_content = self._generate_table_content(row, col)
+                    cell_text = ET.SubElement(cell, "P")
+                    cell_para_text = ET.SubElement(cell_text, "Text")
+                    cell_para_text.text = cell_content
+
+        # Add images (simple reference)
+        for img_num in range(self.config.num_images):
+            para = ET.SubElement(section, "P")
+            para.set("id", f"img_para_{img_num+1}")
+            img_elem = ET.SubElement(para, "Image")
+            img_elem.set("href", f"images/image{img_num+1}.png")
+            img_elem.set("Width", "1000")
+            img_elem.set("Height", "750")
+
+        return ET.tostring(root, encoding='unicode')
+
+    def _create_styles_xml(self) -> str:
+        """Create Contents/styles.xml content."""
+        root = ET.Element("Styles")
+        root.set("xmlns", "http://www.hancom.co.kr/hwpml/2.1")
+
+        # Define some basic styles
+        if self.config.use_styles:
+            # Character styles
+            char_style = ET.SubElement(root, "CharStyle")
+            char_style.set("name", "Bold")
+            char_style.set("fontweight", "bold")
+
+            # Paragraph styles
+            para_style = ET.SubElement(root, "ParaStyle")
+            para_style.set("name", "Normal")
+            para_style.set("fontsize", "10")
+
+        return ET.tostring(root, encoding='unicode')
+
+    def _create_docinfo_xml(self) -> str:
+        """Create Contents/docInfo.xml content."""
+        root = ET.Element("DocInfo")
+        root.set("xmlns", "http://www.hancom.co.kr/hwpml/2.1")
+
+        # Title
+        title = ET.SubElement(root, "Title")
+        title.text = f"Test Document - {self.complexity.value} complexity"
+
+        # Subject
+        subject = ET.SubElement(root, "Subject")
+        subject.text = "Generated synthetic HWP test document"
+
+        # Creator
+        creator = ET.SubElement(root, "Creator")
+        creator.text = "HWP Test Data Generator"
+
+        # Created date
+        created = ET.SubElement(root, "Created")
+        created.text = datetime.now().isoformat()
+
+        # Last saved by
+        lastsaveby = ET.SubElement(root, "LastSavedBy")
+        lastsaveby.text = "TestGenerator"
+
+        # Modified
+        modified = ET.SubElement(root, "Modified")
+        modified.text = datetime.now().isoformat()
+
+        return ET.tostring(root, encoding='unicode')
+
+    def _create_settings_xml(self) -> str:
+        """Create Contents/settings.xml content."""
+        root = ET.Element("Settings")
+        root.set("xmlns", "http://www.hancom.co.kr/hwpml/2.1")
+
+        # View properties
+        view = ET.SubElement(root, "ViewProperties")
+        view.set("zoom", "100")
+        view.set("displaymode", "page")
+
+        return ET.tostring(root, encoding='unicode')
+
+    def _create_version_xml(self) -> str:
+        """Create version.xml content."""
+        root = ET.Element("Version")
+        root.set("app", "HWP")
+        root.set("major", "5")
+        root.set("minor", "0")
+        root.set("revision", "0")
+        root.set("build", "0")
+
+        return ET.tostring(root, encoding='unicode')
+
+
+class TestDocumentBatch:
+    """Generate batch of test documents with varying complexity."""
+
+    def __init__(self, output_dir: str):
+        """Initialize batch generator.
+
+        Args:
+            output_dir: Directory to save generated documents
+        """
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def generate_preset_batch(self, count_per_complexity: int = 5) -> List[Path]:
+        """Generate batch with all complexity levels.
+
+        Args:
+            count_per_complexity: Number of documents per complexity level
+
+        Returns:
+            List of generated file paths
+        """
+        generated_files = []
+
+        for complexity in Complexity:
+            for i in range(count_per_complexity):
+                generator = TestDataGenerator(complexity=complexity, seed=hash((complexity.value, i)))
+                filename = f"test_{complexity.value}_{i:02d}.hwpx"
+                filepath = self.output_dir / filename
+
+                print(f"Generating {filepath.name}...", end=" ", flush=True)
+                generator.generate_hwpx(str(filepath))
+                generated_files.append(filepath)
+                print("Done")
+
+        return generated_files
+
+    def generate_custom_batch(
+        self,
+        count: int,
+        complexity: Complexity = Complexity.MEDIUM,
+        seed_start: int = 0
+    ) -> List[Path]:
+        """Generate batch with custom parameters.
+
+        Args:
+            count: Number of documents to generate
+            complexity: Document complexity level
+            seed_start: Starting seed value for reproducibility
+
+        Returns:
+            List of generated file paths
+        """
+        generated_files = []
+
+        for i in range(count):
+            generator = TestDataGenerator(
+                complexity=complexity,
+                seed=seed_start + i
+            )
+            filename = f"test_{complexity.value}_{seed_start + i:04d}.hwpx"
+            filepath = self.output_dir / filename
+
+            print(f"Generating {filepath.name}...", end=" ", flush=True)
+            generator.generate_hwpx(str(filepath))
+            generated_files.append(filepath)
+            print("Done")
+
+        return generated_files
+
+
+def main() -> int:
+    """Main entry point for command-line interface."""
+    parser = argparse.ArgumentParser(
+        description="Generate synthetic HWP test documents with configurable complexity"
+    )
+
+    subparsers = parser.add_subparsers(dest="command", help="Generation mode")
+
+    # Single document generation
+    single_parser = subparsers.add_parser("single", help="Generate single document")
+    single_parser.add_argument(
+        "--complexity",
+        choices=[c.value for c in Complexity],
+        default="medium",
+        help="Document complexity level (default: medium)"
+    )
+    single_parser.add_argument(
+        "--output",
+        required=True,
+        help="Output file path (.hwpx)"
+    )
+    single_parser.add_argument(
+        "--seed",
+        type=int,
+        help="Random seed for reproducibility"
+    )
+
+    # Batch generation
+    batch_parser = subparsers.add_parser("batch", help="Generate batch of documents")
+    batch_parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Output directory for generated documents"
+    )
+    batch_parser.add_argument(
+        "--preset",
+        choices=["simple", "all"],
+        default="all",
+        help="Preset batch type (default: all)"
+    )
+    batch_parser.add_argument(
+        "--count",
+        type=int,
+        default=5,
+        help="Documents per complexity level (default: 5)"
+    )
+
+    # Custom batch
+    custom_parser = subparsers.add_parser("custom", help="Generate custom batch")
+    custom_parser.add_argument(
+        "--count",
+        type=int,
+        required=True,
+        help="Number of documents to generate"
+    )
+    custom_parser.add_argument(
+        "--complexity",
+        choices=[c.value for c in Complexity],
+        default="medium",
+        help="Document complexity level (default: medium)"
+    )
+    custom_parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Output directory for generated documents"
+    )
+    custom_parser.add_argument(
+        "--seed-start",
+        type=int,
+        default=0,
+        help="Starting seed value (default: 0)"
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "single":
+        complexity = Complexity(args.complexity)
+        generator = TestDataGenerator(complexity=complexity, seed=args.seed)
+        print(f"Generating {complexity.value} complexity document...")
+        generator.generate_hwpx(args.output)
+        print(f"Document saved to: {args.output}")
+        return 0
+
+    elif args.command == "batch":
+        batch = TestDocumentBatch(args.output_dir)
+        print(f"Generating batch to: {args.output_dir}")
+        if args.preset == "simple":
+            files = batch.generate_custom_batch(1, Complexity.LOW)
+        else:
+            files = batch.generate_preset_batch(args.count)
+        print(f"\nGenerated {len(files)} documents")
+        return 0
+
+    elif args.command == "custom":
+        complexity = Complexity(args.complexity)
+        batch = TestDocumentBatch(args.output_dir)
+        print(f"Generating {args.count} {complexity.value} complexity documents...")
+        files = batch.generate_custom_batch(
+            args.count,
+            complexity=complexity,
+            seed_start=args.seed_start
+        )
+        print(f"\nGenerated {len(files)} documents")
+        return 0
+
+    else:
+        parser.print_help()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 요약

- 문서(HWP/HWPX) 처리 워크플로우를 보조하는 독립 Python CLI 도구 4종 추가
  - font-analyzer, metadata-extract, schema-validator, test-data-gen
- 코어 파서/엔진 로직 변경 없음 — 신규 도구 추가, 기존 버그 수정 아님

## 제외 사항

같은 배치로 제안됐던 a11y-checker, batch-convert, link-validator, perf-profiler,
pdf-quality, image-extractor는 검토 결과 미완성이라 이번 PR에서 제외:

- a11y-checker: `main.rs`가 선언한 4개 모듈(checker/config/error/report) 실체 없음
- link-validator: `validator`/`reporter` 모듈 없음
- perf-profiler: 존재하지 않는 API(`rhwp::renderer::render::DocumentRenderer`) 호출
- batch-convert: 컴파일은 되나 변환 로직이 전부 placeholder
- pdf-quality: `main.rs` 없음, 존재하지 않는 crate(`lpdf`) 의존
- image-extractor: `Cargo.toml` 없음

## 검증

- 4개 도구 모두 `python -m py_compile` 통과
- placeholder/TODO/미구현 마커 없음 확인

Issue: #4043