### PR TITLE
ci: review-only trailing commit 재사용 조건 보정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,15 +134,6 @@ jobs:
               return parents.length === 2 && parents.some((parent) => parent.sha === baseSha);
             }
 
-            async function isCurrentBaseAncestor(candidateSha, baseSha) {
-              const { data: comparison } = await github.rest.repos.compareCommitsWithBasehead({
-                owner,
-                repo,
-                basehead: `${baseSha}...${candidateSha}`,
-              });
-              return comparison.status === 'ahead' || comparison.status === 'identical';
-            }
-
             function latestRun(runs) {
               return runs
                 .slice()
@@ -154,57 +145,47 @@ jobs:
             }
 
             async function buildResult(candidateSha, pr) {
-              const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+              const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
                 owner,
                 repo,
-                ref: candidateSha,
+                workflow_id: 'ci.yml',
+                event: 'pull_request',
                 per_page: 100,
               });
-              let source = 'check-run';
-              let buildRun = latestRun(checkRuns.filter((run) => (
-                run.name === 'Build & Test'
-                && run.app?.slug === 'github-actions'
+              const workflowRun = latestRun(workflowRuns.filter((run) => (
+                run.path === '.github/workflows/ci.yml'
+                && run.event === 'pull_request'
+                && run.head_sha === candidateSha
+                && run.head_branch === pr.head.ref
+                && run.head_repository?.id === pr.head.repo?.id
               )));
+              if (!workflowRun) {
+                return { state: 'missing', reason: `missing-build-and-test:${candidateSha}` };
+              }
+              const runCreatedAt = Date.parse(workflowRun.created_at);
+              const pullCreatedAt = Date.parse(pr.created_at);
+              if (!Number.isFinite(runCreatedAt)
+                || !Number.isFinite(pullCreatedAt)
+                || runCreatedAt < pullCreatedAt) {
+                return { state: 'failed', reason: 'ci-workflow-pr-identity-mismatch' };
+              }
+              if (workflowRun.status !== 'completed') {
+                return {
+                  state: 'pending',
+                  reason: `build-and-test-workflow-not-completed:${workflowRun.status}`,
+                };
+              }
 
+              const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                owner,
+                repo,
+                run_id: workflowRun.id,
+                filter: 'latest',
+                per_page: 100,
+              });
+              const buildRun = latestRun(jobs.filter((job) => job.name === 'Build & Test'));
               if (!buildRun) {
-                // Fork PRs can expose the aggregate only through Actions jobs. Keep the
-                // branch and exact candidate SHA identity guard for that fallback.
-                const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
-                  owner,
-                  repo,
-                  workflow_id: 'ci.yml',
-                  event: 'pull_request',
-                  branch: pr.head.ref,
-                  per_page: 100,
-                });
-                const workflowRun = latestRun(workflowRuns.filter((run) => (
-                  run.path === '.github/workflows/ci.yml'
-                  && run.event === 'pull_request'
-                  && run.head_sha === candidateSha
-                )));
-
-                if (!workflowRun) {
-                  return { state: 'missing', reason: `missing-build-and-test:${candidateSha}` };
-                }
-                if (workflowRun.status !== 'completed') {
-                  return {
-                    state: 'pending',
-                    reason: `build-and-test-workflow-not-completed:${workflowRun.status}`,
-                  };
-                }
-
-                const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
-                  owner,
-                  repo,
-                  run_id: workflowRun.id,
-                  filter: 'latest',
-                  per_page: 100,
-                });
-                buildRun = latestRun(jobs.filter((job) => job.name === 'Build & Test'));
-                if (!buildRun) {
-                  return { state: 'missing', reason: `missing-build-and-test-job:${candidateSha}` };
-                }
-                source = 'actions-job';
+                return { state: 'missing', reason: `missing-build-and-test-job:${candidateSha}` };
               }
               if (buildRun.status !== 'completed') {
                 return {
@@ -218,7 +199,7 @@ jobs:
                   reason: `build-and-test-not-green:${buildRun.conclusion}`,
                 };
               }
-              return { state: 'green', source, conclusion: buildRun.conclusion };
+              return { state: 'green', conclusion: buildRun.conclusion };
             }
 
             try {
@@ -277,13 +258,12 @@ jobs:
                     reviewOnlyCandidates.push(sha);
                     continue;
                   }
-                  // #3233: a docs-only Update branch merge can be an eligible green
-                  // candidate only after a trailing review-only record. Other merge
-                  // shapes may hide code outside the review-only diff.
+                  // Keep the narrow Update branch merge compatibility path. It is
+                  // optional: ordinary trailing review-only records do not require it.
                   if (reviewOnlyCandidates.length > 0
                     && isCurrentBaseReviewMerge(commit, pr.base.sha)) {
                     reviewOnlyCandidates.push(sha);
-                    core.info(`including current-base ${reviewOnlyLabel(files)} merge candidate ${sha}`);
+                    core.info(`including ${reviewOnlyLabel(files)} update-branch merge candidate ${sha}`);
                     break;
                   }
                   setResult(false, `${reviewOnlyLabel(files)}-merge-not-reusable:${sha}`);
@@ -303,16 +283,9 @@ jobs:
               }
 
               for (const candidateSha of reviewOnlyCandidates) {
-                if (!(await isCurrentBaseAncestor(candidateSha, pr.base.sha))) {
-                  core.info(`candidate does not include current base: ${candidateSha}`);
-                  continue;
-                }
                 const result = await buildResult(candidateSha, pr);
                 if (result.state === 'green') {
-                  const successReason = result.source === 'check-run'
-                    ? `build-and-test-green:${result.conclusion}`
-                    : `build-and-test-job-green:${result.conclusion}`;
-                  setResult(true, successReason, candidateSha);
+                  setResult(true, `build-and-test-green:${result.conclusion}`, candidateSha);
                   return;
                 }
                 if (result.state === 'failed') {
@@ -322,7 +295,7 @@ jobs:
                 core.info(`candidate not reusable yet: ${candidateSha} (${result.reason})`);
               }
 
-              setResult(false, 'no-green-current-base-build-candidate');
+              setResult(false, 'no-green-build-candidate');
             } catch (error) {
               core.warning(`CI preflight failed; running full CI. ${error.message}`);
               setResult(false, 'preflight-error');

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -118,15 +118,6 @@ jobs:
               return parents.length === 2 && parents.some((parent) => parent.sha === baseSha);
             }
 
-            async function isCurrentBaseAncestor(candidateSha, baseSha) {
-              const { data: comparison } = await github.rest.repos.compareCommitsWithBasehead({
-                owner,
-                repo,
-                basehead: `${baseSha}...${candidateSha}`,
-              });
-              return comparison.status === 'ahead' || comparison.status === 'identical';
-            }
-
             function latestRun(runs) {
               return runs
                 .slice()
@@ -137,19 +128,47 @@ jobs:
                 })[0];
             }
 
-            async function codeqlResult(candidateSha) {
-              const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+            async function codeqlResult(candidateSha, pr) {
+              const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
                 owner,
                 repo,
-                ref: candidateSha,
+                workflow_id: 'codeql.yml',
+                event: 'pull_request',
+                per_page: 100,
+              });
+              const workflowRun = latestRun(workflowRuns.filter((run) => (
+                run.path === '.github/workflows/codeql.yml'
+                && run.event === 'pull_request'
+                && run.head_sha === candidateSha
+                && run.head_branch === pr.head.ref
+                && run.head_repository?.id === pr.head.repo?.id
+              )));
+              if (!workflowRun) {
+                return { state: 'missing', reason: `missing-codeql-workflow:${candidateSha}` };
+              }
+              const runCreatedAt = Date.parse(workflowRun.created_at);
+              const pullCreatedAt = Date.parse(pr.created_at);
+              if (!Number.isFinite(runCreatedAt)
+                || !Number.isFinite(pullCreatedAt)
+                || runCreatedAt < pullCreatedAt) {
+                return { state: 'failed', reason: 'codeql-workflow-pr-identity-mismatch' };
+              }
+              if (workflowRun.status !== 'completed') {
+                return {
+                  state: 'pending',
+                  reason: `codeql-workflow-not-completed:${workflowRun.status}`,
+                };
+              }
+              const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                owner,
+                repo,
+                run_id: workflowRun.id,
+                filter: 'latest',
                 per_page: 100,
               });
 
               for (const checkName of requiredChecks) {
-                const checkRun = latestRun(checkRuns.filter((run) => (
-                  run.name === checkName
-                  && run.app?.slug === 'github-actions'
-                )));
+                const checkRun = latestRun(jobs.filter((job) => job.name === checkName));
                 if (!checkRun) {
                   return { state: 'missing', reason: `missing-check:${checkName}:${candidateSha}` };
                 }
@@ -225,12 +244,12 @@ jobs:
                     reviewOnlyCandidates.push(sha);
                     continue;
                   }
-                  // #3233 keeps the narrow Update branch merge topology. Its green
-                  // workflow can be reused after one or more review-only records.
+                  // Keep the narrow Update branch merge compatibility path. It is
+                  // optional: ordinary trailing review-only records do not require it.
                   if (reviewOnlyCandidates.length > 0
                     && isCurrentBaseReviewMerge(commit, pr.base.sha)) {
                     reviewOnlyCandidates.push(sha);
-                    core.info(`including current-base ${reviewOnlyLabel(files)} merge candidate ${sha}`);
+                    core.info(`including ${reviewOnlyLabel(files)} update-branch merge candidate ${sha}`);
                     break;
                   }
                   setResult(false, `${reviewOnlyLabel(files)}-merge-not-reusable:${sha}`);
@@ -250,11 +269,7 @@ jobs:
               }
 
               for (const candidateSha of reviewOnlyCandidates) {
-                if (!(await isCurrentBaseAncestor(candidateSha, pr.base.sha))) {
-                  core.info(`candidate does not include current base: ${candidateSha}`);
-                  continue;
-                }
-                const result = await codeqlResult(candidateSha);
+                const result = await codeqlResult(candidateSha, pr);
                 if (result.state === 'green') {
                   setResult(true, 'codeql-checks-green', candidateSha);
                   return;
@@ -266,7 +281,7 @@ jobs:
                 core.info(`candidate not reusable yet: ${candidateSha} (${result.reason})`);
               }
 
-              setResult(false, 'no-green-current-base-codeql-candidate');
+              setResult(false, 'no-green-codeql-candidate');
             } catch (error) {
               core.warning(`CodeQL preflight failed; running full CodeQL. ${error.message}`);
               setResult(false, 'preflight-error');

--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -133,15 +133,6 @@ jobs:
               return parents.length === 2 && parents.some((parent) => parent.sha === baseSha);
             }
 
-            async function isCurrentBaseAncestor(candidateSha, baseSha) {
-              const { data: comparison } = await github.rest.repos.compareCommitsWithBasehead({
-                owner,
-                repo,
-                basehead: `${baseSha}...${candidateSha}`,
-              });
-              return comparison.status === 'ahead' || comparison.status === 'identical';
-            }
-
             function latestRun(runs) {
               return runs
                 .slice()
@@ -289,12 +280,12 @@ jobs:
                     reviewOnlyCandidates.push(sha);
                     continue;
                   }
-                  // #3233 keeps the narrow Update branch merge topology. Its green
-                  // workflow can be reused after one or more review-only records.
+                  // Keep the narrow Update branch merge compatibility path. It is
+                  // optional: ordinary trailing review-only records do not require it.
                   if (reviewOnlyCandidates.length > 0
                     && isCurrentBaseReviewMerge(commit, pr.base.sha)) {
                     reviewOnlyCandidates.push(sha);
-                    core.info(`including current-base ${reviewOnlyLabel(files)} merge candidate ${sha}`);
+                    core.info(`including ${reviewOnlyLabel(files)} update-branch merge candidate ${sha}`);
                     break;
                   }
                   setResult(false, `${reviewOnlyLabel(files)}-merge-not-reusable:${sha}`);
@@ -314,10 +305,6 @@ jobs:
               }
 
               for (const candidateSha of reviewOnlyCandidates) {
-                if (!(await isCurrentBaseAncestor(candidateSha, pr.base.sha))) {
-                  core.info(`candidate does not include current base: ${candidateSha}`);
-                  continue;
-                }
                 const result = await renderDiffResult(candidateSha, pr);
                 if (result.state === 'green') {
                   setResult(true, 'canvas-visual-diff-success', candidateSha);
@@ -330,7 +317,7 @@ jobs:
                 core.info(`candidate not reusable yet: ${candidateSha} (${result.reason})`);
               }
 
-              setResult(false, 'no-green-current-base-render-candidate');
+              setResult(false, 'no-green-render-candidate');
             } catch (error) {
               core.warning(`Render Diff preflight failed; running full Render Diff. ${error.message}`);
               setResult(false, 'preflight-error');

--- a/mydocs/manual/pr_review/collaborator_external_pr.md
+++ b/mydocs/manual/pr_review/collaborator_external_pr.md
@@ -158,7 +158,8 @@ review-only fast-pass를 적용하지 않고 최신 head full CI를 기다린다
 
 [공용 review-only fast-pass](review_only_fast_pass.md)를 함께 읽는다. collaborator가 contributor의
 current code head를 local 검증한 뒤 review 문서·오늘할일·허용된 신규 기준 자료만 source branch에 추가하면
-공용 가이드의 **A 경로**다. 직전 code candidate의 녹색 Build & Test와 최신 head aggregate를 모두 확인한다.
+공용 가이드의 **A 경로**다. `devel` 전진은 Update branch를 요구하지 않으며, 직전 code candidate와 같은 PR
+identity의 녹색 Build & Test·CodeQL·필요한 Render Diff와 최신 head aggregate를 모두 확인한다.
 최종 묶음 직전에 contributor가 새 source를 push했다면, 먼저
 [2.6.1 외부 PR review 기록의 source head 정렬](multi_pr_update_branch.md#261-외부-pr-review-기록의-source-head-정렬)을
 완료한다.

--- a/mydocs/manual/pr_review/review_only_fast_pass.md
+++ b/mydocs/manual/pr_review/review_only_fast_pass.md
@@ -23,33 +23,35 @@ review-only인 경우에 적용하는 공용 modifier다. maintainer·collaborat
 ## A. code PR 뒤의 trailing review-only commit
 
 contributor code PR의 뒤에 review 문서·오늘할일·허용된 신규 기준 자료를 추가하면 workflow는 현재 head에서
-거꾸로 확인해, **현재 base를 포함하고 이후 변경이 모두 review-only인 가장 최근 green PR head**의 결과를
-재사용한다. 따라서 직전 green PR head 자체가 review-only commit이어도, 그 commit의 full CI가 성공했고 그 뒤에
-허용된 기록만 추가됐다면 candidate가 될 수 있다.
+거꾸로 확인해, **같은 PR source branch에서 실행된 녹색 code candidate SHA와 이후 변경이 모두 review-only인
+가장 최근 head**의 결과를 재사용한다. base가 전진했더라도 source·test가 바뀌지 않았다면 문서 기록만을 위해
+Update branch, merge, rebase를 수행하지 않는다. 따라서 직전 green PR head 자체가 review-only commit이어도,
+그 commit의 full CI가 성공했고 그 뒤에 허용된 기록만 추가됐다면 candidate가 될 수 있다.
 
 다음 조건을 모두 만족해야 한다.
 
 1. candidate 이후 current head까지의 review-only commit은 single-parent다.
 2. review-only Update branch merge를 candidate로 쓰는 경우에는 현재 PR base를 parent로 포함한 정확히
    2-parent merge이고, 그 뒤에 적어도 하나의 single-parent review-only commit이 있어야 한다.
-3. candidate SHA는 현재 base를 ancestor로 포함한다. base가 바뀐 뒤 update branch를 하지 않은 옛 run은
-   재사용하지 않는다.
-4. 후보는 최신순으로 조회한다. check/workflow가 없거나 진행 중인 후보는 더 이전 후보를 계속 확인하되,
+3. candidate SHA는 현재 PR commit history의 code 후보여야 하며, CI·CodeQL·Render Diff 결과는 같은 PR의
+   head branch, source repository, event, candidate SHA와 정확히 일치해야 한다. 현재 base 전진은 단독으로
+   재사용 거부 사유가 아니다.
+4. 후보는 최신순으로 조회한다. workflow가 없거나 진행 중인 후보는 더 이전 후보를 계속 확인하되,
    가장 최근 완료 후보가 failed이면 full CI로 fallback한다.
 5. 채택한 candidate SHA의 Build & Test check 또는 같은 SHA의 CI workflow 집계 job이 completed이고
    conclusion이 success, skipped, neutral 중 하나여야 한다.
 6. push 뒤 최신 head의 preflight와 branch protection이 요구하는 Build & Test aggregate를 확인한다.
    heavy worker가 skipped인 것은 정상이나 aggregate가 pending 또는 failing이면 merge하지 않는다.
 
-trailing range에 reviewer가 만든 일반 merge commit이 있으면 fast-pass는 이를 재사용하지 않는다. current
-`devel`을 직접 parent로 둔 review-only update merge만 제한적으로 허용하며, 그 외 merge는 code 변경을 숨길 수
-있다. contributor가 review 도중 source를 갱신한 경우에는 새 source를 기존 reviewer 기록에 merge하지 말고
+trailing range에 reviewer가 만든 일반 merge commit이 있으면 fast-pass는 이를 재사용하지 않는다. 현재
+`devel`을 직접 parent로 둔 review-only update merge만 선택적으로 허용하며, 일반 trailing 기록에는 그 merge가
+필요하지 않다. contributor가 review 도중 source를 갱신한 경우에는 새 source를 기존 reviewer 기록에 merge하지 말고
 [2.6.1 외부 PR review 기록의 source head 정렬](multi_pr_update_branch.md#261-외부-pr-review-기록의-source-head-정렬)을
 적용해 reviewer 기록만 새 source 위로 replay한다.
 
-local Cargo 성공만으로 candidate의 GitHub Actions를 대체하지 않는다. current base 불일치, 가장 최근 완료
-candidate check의 failed, 허용되지 않은 merge 형태, 허용 경로 밖 변경은 full CI fallback이다. 후보가 전부
-missing 또는 진행 중이면 green 검증을 찾지 못한 것이므로 역시 full CI를 실행한다.
+local Cargo 성공만으로 candidate의 GitHub Actions를 대체하지 않는다. candidate workflow의 PR identity 불일치,
+가장 최근 완료 candidate check의 failed, 허용되지 않은 merge 형태, 허용 경로 밖 변경은 full CI fallback이다.
+후보가 전부 missing 또는 진행 중이면 green 검증을 찾지 못한 것이므로 역시 full CI를 실행한다.
 
 collaborator가 contributor code를 local에서 검증한 뒤 review·오늘할일만 같은 source head에 추가하는 경우도
 이 A 경로다. local 검증 결과와 candidate SHA, 재사용한 Build & Test URL을 review 문서에 기록한다.
@@ -70,7 +72,7 @@ all-review-only-no-code-impact fast-pass를 즉시 선택한다. candidate의 �
 - code, test, CI workflow, Cargo.lock 변경
 - 기존 sample, PDF, golden, baseline, fixture의 수정·삭제·rename
 - 허용 목록 밖의 신규 파일
-- A 경로의 candidate check 누락·실패·미완료 또는 허용되지 않은 merge 형태
+- A 경로의 candidate workflow 누락·실패·미완료·PR identity 불일치 또는 허용되지 않은 merge 형태
 - preflight가 fast_pass=false를 반환
 
 fast-pass는 merge 조건을 없애지 않는다. 최신 head, mergeable 상태, required aggregate, 작업지시자 승인을

--- a/mydocs/manual/pr_review_workflow.md
+++ b/mydocs/manual/pr_review_workflow.md
@@ -119,8 +119,10 @@ CI가 끝난 뒤 또는 contributor가 새 commit을 push한 뒤에는 head SHA,
 [다수 PR과 update branch](pr_review/multi_pr_update_branch.md)의 "2.6 검토 중 기준선 갱신"을 따른다.
 collaborator가 contributor PR head에 review-only 기록을 직접 push할 예정이면, 최종 archive review·오늘할일·
 증적 commit은 새 head를 fetch하고 reviewer 기록을 그 위의 단순 trailing commit으로 정렬한 뒤에만 만든다.
-기존 reviewer 기록 위로 새 contributor head를 일반 merge하면 fast-pass의 안전한 current-base merge 조건을
-충족하지 못해 full CI로 분기한다.
+문서 기록만 만들기 위해 최신 `devel`을 contributor branch에 merge하거나 rebase하지 않는다. branch가 최신
+base 반영을 강제하지 않는 정책이면, 같은 PR·같은 source repository·같은 code candidate SHA의 녹색 aggregate를
+재사용해 trailing review-only commit을 fast-pass할 수 있다. contributor가 source·test를 새로 push한 경우에는
+그 새 code head의 CI를 먼저 통과시킨 뒤 review 기록을 한 번만 이어 붙인다.
 
 ### 3.3 순차로 유지할 일
 

--- a/mydocs/orders/20260805.md
+++ b/mydocs/orders/20260805.md
@@ -1,5 +1,22 @@
 # 오늘 할 일 - 2026년 8월 5일
 
+## #4070 - review-only trailing commit CI 재사용
+
+- 최신 `devel` 반영을 강제하지 않는 branch 정책과 달리, review-only fast-pass가 current-base 조상 조건으로
+  기존 녹색 code candidate를 거부하던 불일치를 보정했다.
+- CI·CodeQL은 같은 PR source repository·branch·candidate SHA·PR 생성 이후 Actions run을 확인하고,
+  Render Diff도 같은 candidate 정책을 사용한다. source·test·workflow 변경과 identity 불일치는 계속 full CI로
+  fail-closed 한다.
+- workflow 회귀 테스트 17건, Node 영향 분류 테스트 24건, YAML/actionlint, 실제 fork PR Actions run identity
+  조회를 통과했다.
+- [PR #4071](https://github.com/edwardkim/rhwp/pull/4071)을 `devel` 대상으로 생성했다. 구현 후보의 CI
+  `30999551801`, CodeQL `30999551184`, Render Diff `30999550538`이 모두 통과한 뒤 PR #4048 병합으로
+  `devel`이 `061778ff8`까지 전진했다. 이제 review·오늘 기록만 마지막 commit으로 push해 최신 base에서도
+  fast-pass와 aggregate를 확인한다.
+
+상세 근거: [#4070](https://github.com/edwardkim/rhwp/issues/4070),
+[PR #4071 검토](../pr/archives/pr_4071_review.md).
+
 ## #3930 - HWPX 저장 조판 입력 보존
 
 - HWPX `flowWithText=0` 표를 HWP 저장 후 글자처럼 한 쪽에 배치하던 판단을 보정하고, 실제

--- a/mydocs/pr/archives/pr_4071_review.md
+++ b/mydocs/pr/archives/pr_4071_review.md
@@ -1,0 +1,73 @@
+# PR #4071 검토
+
+## 결론
+
+**수용 후보.** review-only trailing commit이 같은 PR의 검증 완료 code candidate를 재사용할 때,
+현재 `devel`의 전진만으로 재실행하지 않도록 CI 정책을 보정했다. 재사용 대상은 경로만으로 판단하지 않고
+같은 PR source repository·branch·candidate SHA·PR 생성 이후의 Actions run으로 고정한다.
+
+최종 병합 조건은 이 검토·오늘 기록을 포함한 최신 PR head의 GitHub Actions 통과와 작업지시자 승인이다.
+
+## 접수 및 기준
+
+| 항목 | 내용 |
+| --- | --- |
+| PR | [#4071](https://github.com/edwardkim/rhwp/pull/4071) `ci: review-only trailing commit 재사용 조건 보정` |
+| 작성자 | `jangster77` |
+| 대상 | `devel` |
+| 구현 head | `cb25176799d6f3381f363f8b8b1c920c93f1907b` |
+| 구현 기준 devel | `efed25b43` |
+| 관련 이슈 | [#4070](https://github.com/edwardkim/rhwp/issues/4070) |
+| 구현 변경 규모 | 7 files, +150 / -125 |
+| 코드 후보 전체 CI | CI `30999551801`, CodeQL `30999551184`, Render Diff `30999550538` 모두 성공 |
+| 문서 작성 시점 현재 devel | `061778ff8` (PR #4048 병합 commit) |
+| 문서 작성 시점 mergeable | `MERGEABLE` |
+| 문서 작성 시점 merge 상태 | `CLEAN` |
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, local_validation.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+                  collaborator_self_merge.md, intake_and_review.md,
+                  local_validation.md, rework_and_exceptions.md
+```
+
+## 변경 내용
+
+- CI, CodeQL, Render Diff preflight에서 candidate가 현재 base를 조상으로 포함해야 한다는 조건을 제거했다.
+  `devel` 전진만으로 contributor branch에 Update branch·merge·rebase를 요구하지 않는다.
+- CI와 CodeQL은 generic check-run을 재사용하지 않는다. 같은 `pull_request` event의 workflow run에서
+  candidate SHA, head branch, source repository, PR 생성 시각을 확인하고 해당 run의 aggregate job만 조회한다.
+- fork PR에 `listWorkflowRuns`의 서버 측 branch filter를 보내면 일치하는 run이 누락되는 것을 확인해,
+  API 응답을 받은 뒤 branch·repository·SHA를 직접 비교하도록 보정했다.
+- 세 workflow의 정책 불일치를 막는 `test_review_only_fast_pass_workflows.py`를 추가하고, PR workflow 문서에
+  trailing 문서 기록의 정확한 조건을 명시했다.
+- 구현 후보가 전체 CI를 통과한 뒤 PR #4048이 `devel`에 병합되어 base가 `efed25b43`에서 `061778ff8`로
+  전진했다. 이 검토 기록 commit은 그 뒤의 최신 base에서 reuse 동작을 검증하는 대상이다.
+
+## 로컬 검증
+
+아래 검증은 구현 head `cb2517679`에서 완료됐다.
+
+| 검증 | 결과 |
+| --- | --- |
+| `python3 -m unittest scripts/tests/test_ci_impact_workflow.py scripts/tests/test_render_diff_workflow.py scripts/tests/test_review_only_fast_pass_workflows.py` | 17 passed |
+| `node --test scripts/tests/ci-impact-classifier.test.cjs` | 24 passed |
+| PyYAML로 CI·CodeQL·Render Diff workflow 파싱 | 3 files passed |
+| `actionlint .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/render-diff.yml` | 통과 |
+| GitHub Script preflight 3개를 async wrapper로 구문 검사 | 통과 |
+| 실제 PR #4048 source SHA의 CI·CodeQL Actions run 조회 | source repository·branch·SHA 일치, 두 workflow 모두 성공 run 확인 |
+| `git diff --check` | 통과 |
+
+## 범위와 위험
+
+- source, parser, renderer, Studio, fixture는 변경하지 않았다. Canvas/PDF 시각 검증은 대상이 아니다.
+- candidate SHA의 workflow가 누락·실패·미완료하거나 PR identity가 다르면 fail-closed로 full CI를 실행한다.
+- review-only 범위 밖 파일, source·test·workflow 변경, 허용되지 않은 merge 형태도 fast-pass 대상이 아니다.
+- 최신 base 병합을 강제하지 않으므로 merge 직전 GitHub의 최신 mergeable 상태와 required aggregate를 반드시
+  다시 확인한다.
+
+## 최종 권고
+
+이 검토·오늘 기록만 담은 마지막 commit을 같은 PR head에 push한 뒤, 최신 base `061778ff8`에서도
+heavy worker가 skip되고 aggregate가 성공하는지 확인한다. 이 확인과 작업지시자 승인이 끝난 뒤 PR #4071을 병합한다.

--- a/scripts/tests/test_review_only_fast_pass_workflows.py
+++ b/scripts/tests/test_review_only_fast_pass_workflows.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = {
+    "ci": ROOT / ".github/workflows/ci.yml",
+    "codeql": ROOT / ".github/workflows/codeql.yml",
+    "render-diff": ROOT / ".github/workflows/render-diff.yml",
+}
+
+
+class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
+    def test_base_advance_does_not_invalidate_a_trailing_review_record(self) -> None:
+        for name, workflow_path in WORKFLOWS.items():
+            with self.subTest(workflow=name):
+                workflow = workflow_path.read_text(encoding="utf-8")
+                self.assertNotIn("isCurrentBaseAncestor", workflow)
+                self.assertNotIn("candidate does not include current base", workflow)
+                self.assertNotIn("no-green-current-base", workflow)
+                self.assertIn("for (const candidateSha of reviewOnlyCandidates)", workflow)
+
+    def test_ci_and_codeql_bind_a_reused_result_to_the_same_pr_source(self) -> None:
+        for name in ("ci", "codeql"):
+            with self.subTest(workflow=name):
+                workflow = WORKFLOWS[name].read_text(encoding="utf-8")
+                self.assertIn("event: 'pull_request'", workflow)
+                self.assertNotIn("branch: pr.head.ref", workflow)
+                self.assertIn("run.head_sha === candidateSha", workflow)
+                self.assertIn("run.head_branch === pr.head.ref", workflow)
+                self.assertIn("run.head_repository?.id === pr.head.repo?.id", workflow)
+                self.assertIn("listJobsForWorkflowRun", workflow)
+                self.assertIn("runCreatedAt < pullCreatedAt", workflow)
+
+    def test_render_diff_keeps_its_existing_pr_identity_guard(self) -> None:
+        workflow = WORKFLOWS["render-diff"].read_text(encoding="utf-8")
+        self.assertIn("render-diff-workflow-pr-identity-mismatch", workflow)
+        self.assertIn("renderDiffRun.head_branch !== pr.head.ref", workflow)
+        self.assertIn("renderDiffRun.head_repository?.id !== pr.head.repo?.id", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

- review-only trailing commit이 최신 `devel` 병합 없이도 동일 PR의 녹색 CI 결과를 재사용하도록 보정합니다.
- CI와 CodeQL은 같은 PR branch·source repository·candidate SHA·생성 시각으로 Actions run을 확인합니다.
- Render Diff의 기존 identity 검증을 유지하고, 세 workflow의 current-base 조상 조건을 제거합니다.
- PR review workflow 문서에 Update branch를 문서 기록을 위한 선행 조건으로 쓰지 않는 절차를 명시합니다.

## 검증

- `python3 -m unittest scripts/tests/test_ci_impact_workflow.py scripts/tests/test_render_diff_workflow.py scripts/tests/test_review_only_fast_pass_workflows.py`
- `node --test scripts/tests/ci-impact-classifier.test.cjs`
- `actionlint .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/render-diff.yml`
- 실제 PR #4048 원본 SHA의 CI·CodeQL Actions run identity 조회

Closes #4070.
