### PR TITLE
feat(tools): font-analyzer — rhwp info --json 계약 재사용으로 재작성 (#4044 리뷰 반영)

### DIFF
--- a/mydocs/orders/20260805.md
+++ b/mydocs/orders/20260805.md
@@ -17,3 +17,16 @@
 상세 근거: [#3930 Stage 1](../working/task_m100_3930_stage1.md),
 [#3930 Stage 6](../working/task_m100_3930_stage6.md),
 [PR #4058 검토](../pr/archives/pr_4058_review.md).
+
+## #4072 - 글꼴 분석기 안전 보정
+
+- 기여자 변경은 글꼴 정보의 단일 신뢰 소스를 `rhwp info --json`으로 정리했다.
+- 메인터너 보정으로 원본과 같은 출력·하드링크 충돌·심볼릭 링크를 차단하고, 명시적
+  `--overwrite`, 재귀 대상 수, 파일별 외부 프로세스 시간 상한을 추가했다.
+- 실제 HWP 원본 복사본을 같은 출력 경로로 지정해 exit 1, SHA-256 불변, HWP 5.0 형식 유지를 확인했다.
+- 원 PR은 이전 기준선에서 갈라졌지만, 원격 head 재확인 뒤 contributor 이력을 rewrite하지 않고
+  보정 commit만 적용했다. 최신 code head의 CI·CodeQL은 모두 통과했다.
+- 검토 기록·오늘 기록 trailing commit의 aggregate 확인과 작업지시자 승인 뒤 병합·후속 처리를 한다.
+
+상세 근거: [PR #4072 검토](../pr/archives/pr_4072_review.md),
+[PR #4072 보정 계획](../pr/archives/pr_4072_review_impl.md).

--- a/mydocs/pr/archives/pr_4072_review.md
+++ b/mydocs/pr/archives/pr_4072_review.md
@@ -1,0 +1,82 @@
+# PR #4072 검토
+
+## 결론
+
+**메인터너 안전 보정 후 수용 후보.** 원 변경은 HWP/HWPX 컨테이너를 직접 추정하지 않고
+`rhwp info --json`의 `fonts[]` 계약만 사용하도록 글꼴 분석기를 재구성했다. 다만 분석 보고서의
+출력 경로로 원본 파일을 지정하면 원본을 텍스트로 덮어쓸 수 있었고, 재귀 분석과 외부 프로세스
+호출에는 자원 상한이 없었다.
+
+메인터너 보정 commit `23a7c70ce`은 원본·출력 경로 충돌, 심볼릭 링크, 무단 덮어쓰기, 과도한
+재귀 대상 수, 멈춘 `rhwp info` 호출을 차단한다. code head의 CI와 CodeQL은 성공했다. 최종 병합
+조건은 이 검토 기록을 포함한 최신 PR head의 required check와 작업지시자 승인이다.
+
+## 접수 및 기준
+
+| 항목 | 내용 |
+| --- | --- |
+| PR | [#4072](https://github.com/edwardkim/rhwp/pull/4072) `feat(tools): font-analyzer — rhwp info --json 계약 재사용으로 재작성` |
+| 작성자 | `kevin9327` |
+| 대상 | `devel` |
+| 원 PR head | `5467610fda2a356f86e668b6b372fea38dd6902c` |
+| 원 PR 기준선 | `efed25b43a972f79e948f8c28abf863eb18aa1d8` |
+| 검토 시작 시점 devel | `32afce965f167cb78a101b26cd3dc64ad9fe7dda` |
+| 메인터너 보정 | `23a7c70cee51ac63b4b8e4e590b19392a95c7422` |
+| 원 PR 변경 규모 | 3 files, +533 / -0 |
+| 작성 시점 상태 | `MERGEABLE`, `CLEAN`, `maintainerCanModify=true` |
+| code head CI | [CI 31004212850](https://github.com/edwardkim/rhwp/actions/runs/31004212850) 성공 |
+| code head CodeQL | [CodeQL 31004212493](https://github.com/edwardkim/rhwp/actions/runs/31004212493) 성공 |
+
+```text
+base route: collaborator_external_pr.md
+modifiers: intake_and_review.md, local_validation.md, rework_and_exceptions.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+                  collaborator_external_pr.md, intake_and_review.md,
+                  local_validation.md, rework_and_exceptions.md
+```
+
+## 변경 내용
+
+### 기여자 원 변경
+
+- HWP/HWPX를 직접 파싱하지 않고 `rhwp info --json`의 `fonts[]`를 글꼴 정보의 단일 신뢰 소스로 사용한다.
+- 단일 파일 조회와 디렉터리 집계, text/JSON/Markdown 출력을 표준 라이브러리만으로 제공한다.
+- `--rhwp-bin`, `RHWP_BIN`, `PATH`, 저장소 `target/` 순서로 실행 파일을 탐색한다.
+
+### 메인터너 안전 보정
+
+- `--output`이 입력 원본과 같거나 하드링크로 같은 inode를 가리키면 거부한다.
+- 입력 또는 출력의 심볼릭 링크를 거부하고, 디렉터리 탐색 중 심볼릭 링크 문서는 제외한다.
+- 기존 출력 파일은 `--overwrite`가 있을 때만 덮어쓴다.
+- `--max-files`의 기본 상한을 10,000개(최대 100,000개)로 두고 초과 시 분석을 시작하지 않는다.
+- 파일별 `rhwp info` 호출에 기본 120초, 최대 1,800초의 `--timeout-seconds` 상한을 적용한다.
+
+## 로컬 검증
+
+아래 검증은 메인터너 보정 commit `23a7c70ce`에서 완료했다.
+
+| 검증 | 결과 |
+| --- | --- |
+| `RHWP_BIN=$PWD/target/release-test/rhwp python3 tools/font-analyzer/tests/test_font_analyzer.py` | 12 passed |
+| `python3 -m py_compile tools/font-analyzer/font_analyzer.py` | 통과 |
+| 실제 `samples/field-01.hwp` 복사본을 같은 `--output` 경로로 지정 | exit 1, SHA-256 불변, HWP 5.0 형식 유지 |
+| `python3 tools/font-analyzer/font_analyzer.py --help` | 안전 옵션 3종 노출 확인 |
+| `git diff --check` | 통과 |
+
+renderer, layout, HWP/HWPX 파일 포맷, fixture는 변경하지 않았다. 따라서 PDF/Canvas 시각 검증은
+이번 안전 보정의 판정 대상이 아니다.
+
+## 원격 적용 주의
+
+원 PR head는 현재 `devel`의 조상이 아닌 이전 기준선에서 갈라졌다. 사용자가 그래프에서 최신
+`devel` 위 변경을 볼 수 있게 만든 로컬 검토 branch는 원 변경을 재현한 branch이므로, 이 branch를
+그대로 원격 `pr/tool-font-analyzer`에 push하면 contributor 이력을 rewrite하게 된다.
+
+원격 반영 전에 `5467610f`가 fork head와 같은지 재확인했고, 원 source commit을 수정하지 않은 채
+메인터너 보정 commit만 그 head 위에 적용했다. 변경 파일 3개는 모두 LFS 비대상이었으며, LFS를
+건너뛴 dry-run과 실제 push 후 PR head가 `23a7c70ce`와 일치함을 확인했다.
+
+## 최종 권고
+
+code head의 full CI·CodeQL은 통과했다. 이 검토 기록과 오늘 기록만 담은 trailing commit을 같은 PR
+head에 push해 aggregate를 재확인하고, 작업지시자 승인 뒤 PR #4072를 병합한다.

--- a/mydocs/pr/archives/pr_4072_review_impl.md
+++ b/mydocs/pr/archives/pr_4072_review_impl.md
@@ -1,0 +1,34 @@
+# PR #4072 메인터너 안전 보정 계획
+
+## 목적
+
+기여자 PR #4072의 글꼴 분석기에서 원본 문서 덮어쓰기와 무제한 자원 소비 가능성을 제거하되,
+HWP/HWPX 글꼴 분석 계약과 출력 형식은 유지한다.
+
+## 기준
+
+| 항목 | SHA |
+| --- | --- |
+| contributor 원 head | `5467610fda2a356f86e668b6b372fea38dd6902c` |
+| 원 기준선 | `efed25b43a972f79e948f8c28abf863eb18aa1d8` |
+| 검토 시점 devel | `32afce965f167cb78a101b26cd3dc64ad9fe7dda` |
+| 메인터너 보정 | `23a7c70cee51ac63b4b8e4e590b19392a95c7422` |
+
+## 단계
+
+1. 완료: 원 PR을 최신 `devel` 위 가시성 검토 branch에 재현하고, 단일 파일·디렉터리 회귀 테스트를 실행했다.
+2. 완료: 원본과 같은 출력, 기존 출력, 심볼릭 링크 입력, 재귀 대상 수 초과, `rhwp info` 시간 초과를
+   회귀 테스트로 추가했다.
+3. 완료: `--overwrite`, `--max-files`, `--timeout-seconds`와 안전 계약을 구현·문서화하고,
+   실제 HWP 복사본의 SHA-256 보존을 확인했다.
+4. 완료: 원격 PR head가 `5467610f`와 같은지 확인하고, contributor commit을 rewrite하지 않도록
+   보정 commit만 그 위에 적용했다.
+5. 완료: LFS 판독·dry-run·실제 push 후 `23a7c70ce`의 full CI와 CodeQL 성공을 확인했다.
+6. 진행: 검토 기록과 오늘할일을 같은 PR head에 추가하고, 최신 aggregate와 작업지시자 승인을 확인한 뒤
+   병합·후속 처리를 한다.
+
+## 롤백
+
+- 원격 push 전: 로컬 `review/kevin9327-4072-20260805`의 보정 commit만 폐기하면 된다.
+- 원격 push 후 CI 실패: contributor 원 commit은 변경하지 않고 보정 commit을 후속 commit으로 수정한다.
+- 원격 source SHA가 달라진 경우: 기존 보정을 push하지 않고 새 source head에서 검토·회귀 테스트를 다시 판정한다.

--- a/tools/font-analyzer/README.md
+++ b/tools/font-analyzer/README.md
@@ -39,6 +39,12 @@ python tools/font-analyzer/font_analyzer.py samples/field-01.hwp --format md
 # 디렉터리 일괄 집계 (하위 디렉터리까지는 --recursive)
 python tools/font-analyzer/font_analyzer.py samples --format md --output out/fonts.md
 
+# 기존 보고서를 명시적으로 덮어쓰기
+python tools/font-analyzer/font_analyzer.py samples --output out/fonts.md --overwrite
+
+# 재귀 분석의 대상 수와 파일별 rhwp 실행 시간을 조정
+python tools/font-analyzer/font_analyzer.py samples -r --max-files 5000 --timeout-seconds 180
+
 # 실패 파일이 하나라도 있으면 종료 코드 1로 처리하고 싶을 때
 python tools/font-analyzer/font_analyzer.py samples --strict
 
@@ -68,6 +74,15 @@ python tools/font-analyzer/font_analyzer.py samples/field-01.hwp --rhwp-bin targ
 디렉터리 모드에서 일부 파일만 실패하면 기본적으로 결과를 출력하고 0으로
 끝나며(깨진 fixture가 섞인 대량 코퍼스 대응), `--strict`일 때만 1을 반환한다.
 
+## 안전 제한
+
+- 입력 및 디렉터리 안의 심볼릭 링크 문서는 분석하지 않는다.
+- 기본 재귀 대상 상한은 10,000개다. `--max-files`로 최대 100,000개까지 명시할 수 있다.
+- 각 `rhwp info` 실행은 기본 120초, 최대 1,800초로 제한한다. 필요하면
+  `--timeout-seconds`로 조정한다.
+- `--output`이 입력 문서(하드링크 포함)와 같거나 심볼릭 링크이면 거부한다.
+- 기존 출력 파일은 `--overwrite`를 명시한 경우에만 덮어쓴다.
+
 ## 테스트
 
 실제 저장소 fixture로 성공·실패 경로를 검증하는 회귀 테스트가 있다.
@@ -80,6 +95,8 @@ RHWP_BIN=target/debug/rhwp python tools/font-analyzer/tests/test_font_analyzer.p
 - `samples/hwp3-sample5-hwpx.hwpx` → 글꼴 1종 이상 (hwpx)
 - 없는 파일 / 잘못된 `RHWP_BIN` / 문서 없는 디렉터리 → 종료 코드 비 0
 - 임시 디렉터리에 fixture 2개를 복사한 일괄 집계 검증
+- 입력·출력 동일 경로, 기존 출력의 무단 덮어쓰기, 심볼릭 링크 입력, 대상 수 상한,
+  `rhwp info` 시간 초과 거부
 
 `RHWP_BIN`을 생략하면 위의 탐색 순서(3→4)로 바이너리를 찾고, 어디에도 없으면
 빌드 방법을 안내하는 메시지와 함께 실패한다.

--- a/tools/font-analyzer/README.md
+++ b/tools/font-analyzer/README.md
@@ -1,0 +1,85 @@
+# font-analyzer — rhwp `info --json` 계약 기반 HWP/HWPX 글꼴 분석기
+
+HWP(CFB/OLE)·HWPX(OWPML ZIP) 컨테이너를 **직접 파싱하지 않는다**. 글꼴 목록의
+유일한 신뢰 소스는 rhwp CLI의 `info --json` 출력(`fonts[]`, `schemaVersion: "1.0"`)이며,
+이 도구는 그 계약 위에서 다음만 담당한다.
+
+- 단일 파일 글꼴 목록 조회
+- 디렉터리 일괄 분석: 글꼴별 사용 파일 수 집계, 실패 파일 목록
+- text / JSON / Markdown 출력
+
+포맷 해석을 rhwp 한 곳에 위임하므로 파서가 개선되면 이 도구의 결과도 함께
+정확해지고, 별도의 포맷 가정(예: HWPX를 OOXML로 취급)이 끼어들 여지가 없다.
+
+## 요구사항
+
+- Python 3.8+ (표준 라이브러리만 사용, 추가 설치 없음)
+- rhwp 실행 파일: `cargo build --bin rhwp` (또는 release/release-test 빌드)
+
+## rhwp 실행 파일 탐색 순서
+
+1. `--rhwp-bin` 인자
+2. `RHWP_BIN` 환경변수
+3. `PATH`의 `rhwp`
+4. 저장소 `target/release-test` → `target/release` → `target/debug`의 `rhwp[.exe]`
+
+`--rhwp-bin`/`RHWP_BIN`으로 명시한 경로가 잘못됐으면 다음 후보로 조용히
+넘어가지 않고 즉시 오류로 종료한다.
+
+## 사용법
+
+```bash
+# 단일 파일 (기본: text 출력)
+python tools/font-analyzer/font_analyzer.py samples/field-01.hwp
+
+# JSON / Markdown
+python tools/font-analyzer/font_analyzer.py samples/field-01.hwp --format json
+python tools/font-analyzer/font_analyzer.py samples/field-01.hwp --format md
+
+# 디렉터리 일괄 집계 (하위 디렉터리까지는 --recursive)
+python tools/font-analyzer/font_analyzer.py samples --format md --output out/fonts.md
+
+# 실패 파일이 하나라도 있으면 종료 코드 1로 처리하고 싶을 때
+python tools/font-analyzer/font_analyzer.py samples --strict
+
+# 바이너리 경로를 직접 지정
+RHWP_BIN=target/debug/rhwp python tools/font-analyzer/font_analyzer.py samples/field-01.hwp
+python tools/font-analyzer/font_analyzer.py samples/field-01.hwp --rhwp-bin target/debug/rhwp
+```
+
+## 출력 형태
+
+단일 파일 JSON:
+
+```json
+{
+  "source": "samples/field-01.hwp",
+  "format": "hwp5",
+  "fonts": ["함초롬돋움", "함초롬바탕"],
+  "fontCount": 2
+}
+```
+
+디렉터리 JSON은 `fileCount`/`okCount`/`errorCount`, 글꼴별 집계
+`fonts[] = {name, fileCount, files[]}`(사용 파일 수 내림차순), 파일별 결과
+`files[]`, 실패 목록 `errors[] = {source, error}`를 담는다.
+
+종료 코드: 성공 0, 오류(없는 입력·rhwp 실패·빈 디렉터리 등) 1.
+디렉터리 모드에서 일부 파일만 실패하면 기본적으로 결과를 출력하고 0으로
+끝나며(깨진 fixture가 섞인 대량 코퍼스 대응), `--strict`일 때만 1을 반환한다.
+
+## 테스트
+
+실제 저장소 fixture로 성공·실패 경로를 검증하는 회귀 테스트가 있다.
+
+```bash
+RHWP_BIN=target/debug/rhwp python tools/font-analyzer/tests/test_font_analyzer.py
+```
+
+- `samples/field-01.hwp` → 글꼴에 `함초롬돋움`·`함초롬바탕` 포함 (hwp5)
+- `samples/hwp3-sample5-hwpx.hwpx` → 글꼴 1종 이상 (hwpx)
+- 없는 파일 / 잘못된 `RHWP_BIN` / 문서 없는 디렉터리 → 종료 코드 비 0
+- 임시 디렉터리에 fixture 2개를 복사한 일괄 집계 검증
+
+`RHWP_BIN`을 생략하면 위의 탐색 순서(3→4)로 바이너리를 찾고, 어디에도 없으면
+빌드 방법을 안내하는 메시지와 함께 실패한다.

--- a/tools/font-analyzer/font_analyzer.py
+++ b/tools/font-analyzer/font_analyzer.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""font-analyzer — rhwp `info --json` 계약을 재사용하는 HWP/HWPX 글꼴 분석 도구.
+
+HWP(CFB)/HWPX(OWPML ZIP) 컨테이너를 직접 파싱하지 않는다. 글꼴 목록의 유일한
+신뢰 소스는 rhwp CLI의 `info --json` 출력이며(`fonts[]`, schemaVersion 1.0),
+이 도구는 그 계약 위에서 단일 파일 조회와 디렉터리 일괄 집계만 담당한다.
+
+사용 예:
+    python tools/font-analyzer/font_analyzer.py samples/field-01.hwp
+    python tools/font-analyzer/font_analyzer.py samples --format md
+    RHWP_BIN=target/debug/rhwp python tools/font-analyzer/font_analyzer.py samples/field-01.hwp --format json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SUPPORTED_SUFFIXES = (".hwp", ".hwpx")
+
+
+class ToolError(RuntimeError):
+    """사용자에게 그대로 보여줄 실행 오류."""
+
+
+def _reconfigure_utf8() -> None:
+    """Windows 콘솔/파이프의 cp949 기본 인코딩으로 인한 한글 깨짐을 막는다."""
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, ValueError):
+            pass
+
+
+def resolve_rhwp_bin(cli_value: str | None) -> str:
+    """rhwp 실행 파일 결정: --rhwp-bin > RHWP_BIN > PATH > 저장소 target/.
+
+    명시적으로 지정한 경로(--rhwp-bin, RHWP_BIN)가 잘못됐으면 다음 후보로
+    넘어가지 않고 즉시 오류를 낸다. 조용한 대체는 회귀를 숨기기 때문이다.
+    """
+    if cli_value:
+        if not Path(cli_value).is_file():
+            raise ToolError(f"--rhwp-bin 경로에 실행 파일이 없습니다: {cli_value}")
+        return cli_value
+
+    env_value = os.environ.get("RHWP_BIN")
+    if env_value:
+        if not Path(env_value).is_file():
+            raise ToolError(f"RHWP_BIN 경로에 실행 파일이 없습니다: {env_value}")
+        return env_value
+
+    found = shutil.which("rhwp")
+    if found:
+        return found
+
+    exe = "rhwp.exe" if os.name == "nt" else "rhwp"
+    for profile in ("release-test", "release", "debug"):
+        candidate = REPO / "target" / profile / exe
+        if candidate.is_file():
+            return str(candidate)
+
+    raise ToolError(
+        "rhwp 실행 파일을 찾지 못했습니다. --rhwp-bin 인자 또는 RHWP_BIN 환경변수로 "
+        "경로를 지정하거나 rhwp를 PATH에 추가하세요 (빌드: cargo build --bin rhwp)."
+    )
+
+
+def rhwp_info(rhwp_bin: str, path: Path) -> dict:
+    """`rhwp info --json <path>`를 실행해 JSON 객체를 반환한다."""
+    try:
+        proc = subprocess.run(
+            [rhwp_bin, "info", "--json", str(path)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+    except OSError as exc:
+        raise ToolError(f"rhwp 실행 실패: {rhwp_bin}: {exc}") from exc
+
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or "원인 미상"
+        raise ToolError(f"rhwp info 실패 (exit {proc.returncode}): {path}: {detail}")
+
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise ToolError(f"rhwp info 출력이 JSON이 아닙니다: {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ToolError(f"rhwp info JSON 최상위가 객체가 아닙니다: {path}")
+    return data
+
+
+def fonts_from_info(info: dict, path: Path) -> list[str]:
+    """info JSON에서 `fonts[]`를 검증해 순서를 유지한 채 중복만 제거한다."""
+    fonts = info.get("fonts")
+    if fonts is None:
+        raise ToolError(
+            f"rhwp info JSON에 fonts 필드가 없습니다 (스키마 변경 의심, "
+            f"schemaVersion={info.get('schemaVersion')!r}): {path}"
+        )
+    if not isinstance(fonts, list) or not all(isinstance(f, str) for f in fonts):
+        raise ToolError(f"rhwp info의 fonts 필드가 문자열 배열이 아닙니다: {path}")
+    seen: dict[str, None] = {}
+    for name in fonts:
+        seen.setdefault(name)
+    return list(seen)
+
+
+def analyze_file(rhwp_bin: str, path: Path) -> dict:
+    """단일 파일의 글꼴 분석 결과를 반환한다."""
+    info = rhwp_info(rhwp_bin, path)
+    fonts = fonts_from_info(info, path)
+    return {
+        "source": str(path),
+        "format": info.get("format"),
+        "fonts": fonts,
+        "fontCount": len(fonts),
+    }
+
+
+def collect_targets(root: Path, recursive: bool) -> list[Path]:
+    """디렉터리에서 지원 확장자(.hwp/.hwpx) 파일을 정렬해 모은다."""
+    it = root.rglob("*") if recursive else root.glob("*")
+    return sorted(
+        p for p in it if p.is_file() and p.suffix.lower() in SUPPORTED_SUFFIXES
+    )
+
+
+def analyze_dir(rhwp_bin: str, root: Path, recursive: bool) -> dict:
+    """디렉터리 일괄 분석: 파일별 결과 + 글꼴별 사용 파일 집계 + 실패 목록."""
+    targets = collect_targets(root, recursive)
+    if not targets:
+        raise ToolError(f"디렉터리에 .hwp/.hwpx 파일이 없습니다: {root}")
+
+    files: list[dict] = []
+    errors: list[dict] = []
+    usage: dict[str, list[str]] = {}
+    for target in targets:
+        try:
+            result = analyze_file(rhwp_bin, target)
+        except ToolError as exc:
+            errors.append({"source": str(target), "error": str(exc)})
+            continue
+        files.append(result)
+        for font in result["fonts"]:
+            usage.setdefault(font, []).append(result["source"])
+
+    aggregated = [
+        {"name": name, "fileCount": len(sources), "files": sources}
+        for name, sources in usage.items()
+    ]
+    aggregated.sort(key=lambda item: (-item["fileCount"], item["name"]))
+
+    return {
+        "root": str(root),
+        "recursive": recursive,
+        "fileCount": len(targets),
+        "okCount": len(files),
+        "errorCount": len(errors),
+        "uniqueFontCount": len(aggregated),
+        "fonts": aggregated,
+        "files": files,
+        "errors": errors,
+    }
+
+
+def format_text(result: dict) -> str:
+    lines: list[str] = []
+    if "root" in result:
+        lines.append(f"디렉터리: {result['root']} (재귀: {result['recursive']})")
+        lines.append(
+            f"파일 {result['fileCount']}개 중 성공 {result['okCount']}개, "
+            f"실패 {result['errorCount']}개, 고유 글꼴 {result['uniqueFontCount']}종"
+        )
+        lines.append("")
+        lines.append("글꼴별 사용 파일 수:")
+        for font in result["fonts"]:
+            lines.append(f"  {font['fileCount']:4d}  {font['name']}")
+        if result["errors"]:
+            lines.append("")
+            lines.append("실패한 파일:")
+            for err in result["errors"]:
+                lines.append(f"  {err['source']}: {err['error']}")
+    else:
+        lines.append(f"파일: {result['source']} (형식: {result['format']})")
+        lines.append(f"글꼴 {result['fontCount']}종:")
+        for font in result["fonts"]:
+            lines.append(f"  - {font}")
+    return "\n".join(lines)
+
+
+def format_markdown(result: dict) -> str:
+    lines: list[str] = []
+    if "root" in result:
+        lines.append(f"# 글꼴 집계: `{result['root']}`")
+        lines.append("")
+        lines.append(
+            f"- 파일: {result['fileCount']}개 (성공 {result['okCount']}, "
+            f"실패 {result['errorCount']})"
+        )
+        lines.append(f"- 고유 글꼴: {result['uniqueFontCount']}종")
+        lines.append("")
+        lines.append("| 글꼴 | 사용 파일 수 |")
+        lines.append("| --- | ---: |")
+        for font in result["fonts"]:
+            lines.append(f"| {font['name']} | {font['fileCount']} |")
+        if result["errors"]:
+            lines.append("")
+            lines.append("## 실패한 파일")
+            lines.append("")
+            lines.append("| 파일 | 오류 |")
+            lines.append("| --- | --- |")
+            for err in result["errors"]:
+                message = err["error"].replace("|", "\\|")
+                lines.append(f"| {err['source']} | {message} |")
+    else:
+        lines.append(f"# 글꼴 목록: `{result['source']}`")
+        lines.append("")
+        lines.append(f"- 형식: {result['format']}")
+        lines.append(f"- 글꼴 수: {result['fontCount']}")
+        lines.append("")
+        lines.append("| 글꼴 |")
+        lines.append("| --- |")
+        for font in result["fonts"]:
+            lines.append(f"| {font} |")
+    return "\n".join(lines)
+
+
+def render(result: dict, fmt: str) -> str:
+    if fmt == "json":
+        return json.dumps(result, ensure_ascii=False, indent=2)
+    if fmt == "md":
+        return format_markdown(result)
+    return format_text(result)
+
+
+def main(argv: list[str] | None = None) -> int:
+    _reconfigure_utf8()
+    parser = argparse.ArgumentParser(
+        prog="font_analyzer",
+        description="rhwp `info --json` 계약을 재사용하는 HWP/HWPX 글꼴 분석 도구",
+    )
+    parser.add_argument("input", help="분석할 .hwp/.hwpx 파일 또는 디렉터리")
+    parser.add_argument(
+        "--recursive",
+        "-r",
+        action="store_true",
+        help="디렉터리 입력일 때 하위 디렉터리까지 재귀 탐색",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json", "md"),
+        default="text",
+        help="출력 형식 (기본: text)",
+    )
+    parser.add_argument("--output", "-o", help="결과를 저장할 파일 (기본: 표준 출력)")
+    parser.add_argument(
+        "--rhwp-bin",
+        help="rhwp 실행 파일 경로 (기본: RHWP_BIN 환경변수 → PATH → 저장소 target/)",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="디렉터리 분석에서 실패 파일이 하나라도 있으면 종료 코드 1",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        rhwp_bin = resolve_rhwp_bin(args.rhwp_bin)
+        target = Path(args.input)
+        if target.is_dir():
+            result = analyze_dir(rhwp_bin, target, args.recursive)
+        elif target.is_file():
+            result = analyze_file(rhwp_bin, target)
+        else:
+            raise ToolError(f"입력 경로가 존재하지 않습니다: {target}")
+    except ToolError as exc:
+        print(f"오류: {exc}", file=sys.stderr)
+        return 1
+
+    rendered = render(result, args.format)
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(rendered + "\n", encoding="utf-8")
+        print(f"저장됨: {out_path}", file=sys.stderr)
+    else:
+        print(rendered)
+
+    if args.strict and result.get("errorCount", 0) > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/font-analyzer/font_analyzer.py
+++ b/tools/font-analyzer/font_analyzer.py
@@ -23,10 +23,27 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 SUPPORTED_SUFFIXES = (".hwp", ".hwpx")
+DEFAULT_MAX_FILES = 10_000
+MAX_FILES_LIMIT = 100_000
+DEFAULT_RHWP_TIMEOUT_SECONDS = 120
+MAX_RHWP_TIMEOUT_SECONDS = 1_800
 
 
 class ToolError(RuntimeError):
     """사용자에게 그대로 보여줄 실행 오류."""
+
+
+def bounded_positive_int(raw: str, argument: str, maximum: int) -> int:
+    """CLI 자원 상한 인자를 양의 정수 범위로 제한한다."""
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"{argument} 값은 정수여야 합니다: {raw}") from exc
+    if not 1 <= value <= maximum:
+        raise argparse.ArgumentTypeError(
+            f"{argument} 값은 1 이상 {maximum} 이하여야 합니다: {raw}"
+        )
+    return value
 
 
 def _reconfigure_utf8() -> None:
@@ -71,7 +88,7 @@ def resolve_rhwp_bin(cli_value: str | None) -> str:
     )
 
 
-def rhwp_info(rhwp_bin: str, path: Path) -> dict:
+def rhwp_info(rhwp_bin: str, path: Path, timeout_seconds: int) -> dict:
     """`rhwp info --json <path>`를 실행해 JSON 객체를 반환한다."""
     try:
         proc = subprocess.run(
@@ -80,7 +97,12 @@ def rhwp_info(rhwp_bin: str, path: Path) -> dict:
             text=True,
             encoding="utf-8",
             errors="replace",
+            timeout=timeout_seconds,
         )
+    except subprocess.TimeoutExpired as exc:
+        raise ToolError(
+            f"rhwp info가 {timeout_seconds}초 안에 끝나지 않았습니다: {path}"
+        ) from exc
     except OSError as exc:
         raise ToolError(f"rhwp 실행 실패: {rhwp_bin}: {exc}") from exc
 
@@ -113,9 +135,9 @@ def fonts_from_info(info: dict, path: Path) -> list[str]:
     return list(seen)
 
 
-def analyze_file(rhwp_bin: str, path: Path) -> dict:
+def analyze_file(rhwp_bin: str, path: Path, timeout_seconds: int) -> dict:
     """단일 파일의 글꼴 분석 결과를 반환한다."""
-    info = rhwp_info(rhwp_bin, path)
+    info = rhwp_info(rhwp_bin, path, timeout_seconds)
     fonts = fonts_from_info(info, path)
     return {
         "source": str(path),
@@ -125,17 +147,32 @@ def analyze_file(rhwp_bin: str, path: Path) -> dict:
     }
 
 
-def collect_targets(root: Path, recursive: bool) -> list[Path]:
+def collect_targets(root: Path, recursive: bool, max_files: int) -> list[Path]:
     """디렉터리에서 지원 확장자(.hwp/.hwpx) 파일을 정렬해 모은다."""
     it = root.rglob("*") if recursive else root.glob("*")
-    return sorted(
-        p for p in it if p.is_file() and p.suffix.lower() in SUPPORTED_SUFFIXES
-    )
+    targets: list[Path] = []
+    for path in it:
+        # 심볼릭 링크는 분석 대상의 실제 위치를 사용자가 예측하기 어렵기 때문에 제외한다.
+        if path.is_symlink() or not path.is_file():
+            continue
+        if path.suffix.lower() not in SUPPORTED_SUFFIXES:
+            continue
+        targets.append(path)
+        if len(targets) > max_files:
+            raise ToolError(
+                f"분석 대상이 --max-files 상한({max_files}개)을 초과했습니다: {root}"
+            )
+    return sorted(targets)
 
 
-def analyze_dir(rhwp_bin: str, root: Path, recursive: bool) -> dict:
+def analyze_dir(
+    rhwp_bin: str,
+    root: Path,
+    recursive: bool,
+    targets: list[Path],
+    timeout_seconds: int,
+) -> dict:
     """디렉터리 일괄 분석: 파일별 결과 + 글꼴별 사용 파일 집계 + 실패 목록."""
-    targets = collect_targets(root, recursive)
     if not targets:
         raise ToolError(f"디렉터리에 .hwp/.hwpx 파일이 없습니다: {root}")
 
@@ -144,7 +181,7 @@ def analyze_dir(rhwp_bin: str, root: Path, recursive: bool) -> dict:
     usage: dict[str, list[str]] = {}
     for target in targets:
         try:
-            result = analyze_file(rhwp_bin, target)
+            result = analyze_file(rhwp_bin, target, timeout_seconds)
         except ToolError as exc:
             errors.append({"source": str(target), "error": str(exc)})
             continue
@@ -169,6 +206,32 @@ def analyze_dir(rhwp_bin: str, root: Path, recursive: bool) -> dict:
         "files": files,
         "errors": errors,
     }
+
+
+def paths_alias(left: Path, right: Path) -> bool:
+    """하드링크와 정규화된 경로를 포함해 두 경로가 같은 파일인지 확인한다."""
+    try:
+        return os.path.samefile(left, right)
+    except OSError:
+        return left.resolve() == right.resolve()
+
+
+def ensure_safe_output(
+    output_path: Path, source_paths: list[Path], overwrite: bool
+) -> None:
+    """분석 보고서가 원본을 덮어쓰지 않도록 출력 경로를 검사한다."""
+    if output_path.is_symlink():
+        raise ToolError(f"출력 경로는 심볼릭 링크일 수 없습니다: {output_path}")
+    if any(paths_alias(output_path, source_path) for source_path in source_paths):
+        raise ToolError(f"출력 경로가 분석 원본과 같습니다: {output_path}")
+    if not output_path.exists():
+        return
+    if not output_path.is_file():
+        raise ToolError(f"출력 경로가 일반 파일이 아닙니다: {output_path}")
+    if not overwrite:
+        raise ToolError(
+            f"출력 파일이 이미 있습니다: {output_path} (덮어쓰려면 --overwrite 사용)"
+        )
 
 
 def format_text(result: dict) -> str:
@@ -270,17 +333,53 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="디렉터리 분석에서 실패 파일이 하나라도 있으면 종료 코드 1",
     )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="기존 출력 파일을 명시적으로 덮어쓴다",
+    )
+    parser.add_argument(
+        "--max-files",
+        type=lambda raw: bounded_positive_int(raw, "--max-files", MAX_FILES_LIMIT),
+        default=DEFAULT_MAX_FILES,
+        help=f"디렉터리 분석 최대 파일 수 (기본: {DEFAULT_MAX_FILES})",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=lambda raw: bounded_positive_int(
+            raw, "--timeout-seconds", MAX_RHWP_TIMEOUT_SECONDS
+        ),
+        default=DEFAULT_RHWP_TIMEOUT_SECONDS,
+        help=(
+            "파일별 rhwp info 제한 시간(초) "
+            f"(기본: {DEFAULT_RHWP_TIMEOUT_SECONDS}, 최대: {MAX_RHWP_TIMEOUT_SECONDS})"
+        ),
+    )
     args = parser.parse_args(argv)
 
     try:
         rhwp_bin = resolve_rhwp_bin(args.rhwp_bin)
         target = Path(args.input)
+        if target.is_symlink():
+            raise ToolError(f"입력 경로는 심볼릭 링크일 수 없습니다: {target}")
         if target.is_dir():
-            result = analyze_dir(rhwp_bin, target, args.recursive)
+            targets = collect_targets(target, args.recursive, args.max_files)
+            source_paths = targets
+            result = analyze_dir(
+                rhwp_bin,
+                target,
+                args.recursive,
+                targets,
+                args.timeout_seconds,
+            )
         elif target.is_file():
-            result = analyze_file(rhwp_bin, target)
+            source_paths = [target]
+            result = analyze_file(rhwp_bin, target, args.timeout_seconds)
         else:
             raise ToolError(f"입력 경로가 존재하지 않습니다: {target}")
+
+        if args.output:
+            ensure_safe_output(Path(args.output), source_paths, args.overwrite)
     except ToolError as exc:
         print(f"오류: {exc}", file=sys.stderr)
         return 1

--- a/tools/font-analyzer/tests/test_font_analyzer.py
+++ b/tools/font-analyzer/tests/test_font_analyzer.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""font-analyzer 실측 회귀 테스트.
+
+실제 저장소 fixture(samples/field-01.hwp, samples/hwp3-sample5-hwpx.hwpx)에
+대해 도구를 서브프로세스로 실행해 `rhwp info --json` 계약 위의 동작을 검증한다.
+
+실행:
+    RHWP_BIN=target/debug/rhwp python tools/font-analyzer/tests/test_font_analyzer.py
+
+RHWP_BIN을 지정하지 않으면 PATH의 rhwp 또는 저장소 target/ 빌드를 자동 탐색한다.
+둘 다 없으면 명확한 오류로 실패한다 (빌드: cargo build --bin rhwp).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+TOOL_DIR = TESTS_DIR.parent
+REPO = TOOL_DIR.parents[1]
+TOOL = TOOL_DIR / "font_analyzer.py"
+
+HWP_FIXTURE = REPO / "samples" / "field-01.hwp"
+HWPX_FIXTURE = REPO / "samples" / "hwp3-sample5-hwpx.hwpx"
+
+sys.path.insert(0, str(TOOL_DIR))
+import font_analyzer  # noqa: E402
+
+RHWP_BIN: str = ""
+
+
+def setUpModule() -> None:  # noqa: N802 (unittest 규약)
+    global RHWP_BIN
+    try:
+        RHWP_BIN = font_analyzer.resolve_rhwp_bin(None)
+    except font_analyzer.ToolError as exc:
+        raise RuntimeError(
+            f"rhwp 실행 파일이 필요합니다: {exc}\n"
+            "RHWP_BIN 환경변수로 지정하거나 cargo build --bin rhwp 후 재실행하세요."
+        ) from exc
+    for fixture in (HWP_FIXTURE, HWPX_FIXTURE):
+        if not fixture.is_file():
+            raise RuntimeError(f"fixture가 없습니다: {fixture}")
+
+
+def run_tool(*args: str, rhwp_bin: str | None = None) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["RHWP_BIN"] = rhwp_bin if rhwp_bin is not None else RHWP_BIN
+    return subprocess.run(
+        [sys.executable, str(TOOL), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+        cwd=str(REPO),
+    )
+
+
+class SingleFileTests(unittest.TestCase):
+    def test_hwp_fixture_contains_expected_fonts(self) -> None:
+        proc = run_tool(str(HWP_FIXTURE), "--format", "json")
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        result = json.loads(proc.stdout)
+        self.assertEqual(result["format"], "hwp5")
+        self.assertIn("함초롬돋움", result["fonts"])
+        self.assertIn("함초롬바탕", result["fonts"])
+        self.assertEqual(result["fontCount"], len(result["fonts"]))
+
+    def test_hwpx_fixture_has_at_least_one_font(self) -> None:
+        proc = run_tool(str(HWPX_FIXTURE), "--format", "json")
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        result = json.loads(proc.stdout)
+        self.assertEqual(result["format"], "hwpx")
+        self.assertGreaterEqual(result["fontCount"], 1)
+        self.assertTrue(all(isinstance(f, str) and f for f in result["fonts"]))
+
+
+class FailureTests(unittest.TestCase):
+    def test_missing_file_exits_nonzero(self) -> None:
+        proc = run_tool(str(REPO / "samples" / "no-such-file.hwp"))
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("오류", proc.stderr)
+
+    def test_invalid_rhwp_bin_exits_nonzero(self) -> None:
+        proc = run_tool(str(HWP_FIXTURE), rhwp_bin=str(REPO / "no-such-rhwp.exe"))
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("RHWP_BIN", proc.stderr)
+
+
+class DirectoryTests(unittest.TestCase):
+    def test_directory_aggregation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            (tmp_dir / HWP_FIXTURE.name).write_bytes(HWP_FIXTURE.read_bytes())
+            (tmp_dir / HWPX_FIXTURE.name).write_bytes(HWPX_FIXTURE.read_bytes())
+
+            proc = run_tool(str(tmp_dir), "--format", "json")
+            self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+            result = json.loads(proc.stdout)
+
+        self.assertEqual(result["fileCount"], 2)
+        self.assertEqual(result["okCount"], 2)
+        self.assertEqual(result["errorCount"], 0)
+        self.assertGreaterEqual(result["uniqueFontCount"], 2)
+        by_name = {font["name"]: font for font in result["fonts"]}
+        self.assertIn("함초롬바탕", by_name)
+        self.assertIn("함초롬돋움", by_name)
+        self.assertGreaterEqual(by_name["함초롬바탕"]["fileCount"], 1)
+
+    def test_directory_without_documents_exits_nonzero(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            proc = run_tool(tmp)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("오류", proc.stderr)
+
+
+class FormattingTests(unittest.TestCase):
+    """바이너리가 필요 없는 순수 포매팅 검증."""
+
+    def test_markdown_aggregate_table(self) -> None:
+        result = {
+            "root": "samples",
+            "recursive": False,
+            "fileCount": 2,
+            "okCount": 1,
+            "errorCount": 1,
+            "uniqueFontCount": 1,
+            "fonts": [{"name": "함초롬바탕", "fileCount": 1, "files": ["a.hwp"]}],
+            "files": [],
+            "errors": [{"source": "b.hwp", "error": "깨진 | 파일"}],
+        }
+        rendered = font_analyzer.format_markdown(result)
+        self.assertIn("| 함초롬바탕 | 1 |", rendered)
+        self.assertIn("깨진 \\| 파일", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/font-analyzer/tests/test_font_analyzer.py
+++ b/tools/font-analyzer/tests/test_font_analyzer.py
@@ -20,6 +20,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 TESTS_DIR = Path(__file__).resolve().parent
 TOOL_DIR = TESTS_DIR.parent
@@ -93,6 +94,16 @@ class FailureTests(unittest.TestCase):
         self.assertNotEqual(proc.returncode, 0)
         self.assertIn("RHWP_BIN", proc.stderr)
 
+    def test_symbolic_link_input_exits_nonzero(self) -> None:
+        if os.name == "nt":
+            self.skipTest("Windows의 심볼릭 링크 생성 권한은 개발 환경마다 다릅니다")
+        with tempfile.TemporaryDirectory() as tmp:
+            alias = Path(tmp) / "linked.hwp"
+            alias.symlink_to(HWP_FIXTURE)
+            proc = run_tool(str(alias))
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("심볼릭 링크", proc.stderr)
+
 
 class DirectoryTests(unittest.TestCase):
     def test_directory_aggregation(self) -> None:
@@ -119,6 +130,49 @@ class DirectoryTests(unittest.TestCase):
             proc = run_tool(tmp)
         self.assertNotEqual(proc.returncode, 0)
         self.assertIn("오류", proc.stderr)
+
+    def test_max_files_limit_stops_directory_collection(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "a.hwp").touch()
+            (root / "b.hwpx").touch()
+            with self.assertRaisesRegex(font_analyzer.ToolError, "--max-files 상한"):
+                font_analyzer.collect_targets(root, recursive=False, max_files=1)
+
+
+class OutputSafetyTests(unittest.TestCase):
+    def test_source_file_cannot_be_output_file(self) -> None:
+        original = HWP_FIXTURE.read_bytes()
+        proc = run_tool(str(HWP_FIXTURE), "--output", str(HWP_FIXTURE))
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("분석 원본", proc.stderr)
+        self.assertEqual(original, HWP_FIXTURE.read_bytes())
+
+    def test_existing_output_requires_explicit_overwrite(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "fonts.txt"
+            output.write_text("keep", encoding="utf-8")
+            denied = run_tool(str(HWP_FIXTURE), "--output", str(output))
+            self.assertNotEqual(denied.returncode, 0)
+            self.assertIn("--overwrite", denied.stderr)
+            self.assertEqual("keep", output.read_text(encoding="utf-8"))
+
+            allowed = run_tool(
+                str(HWP_FIXTURE), "--output", str(output), "--overwrite"
+            )
+            self.assertEqual(allowed.returncode, 0, msg=allowed.stderr)
+            self.assertIn("글꼴", output.read_text(encoding="utf-8"))
+
+
+class TimeoutTests(unittest.TestCase):
+    def test_rhwp_timeout_is_reported_as_tool_error(self) -> None:
+        with mock.patch.object(
+            font_analyzer.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(["rhwp"], 1),
+        ):
+            with self.assertRaisesRegex(font_analyzer.ToolError, "끝나지 않았습니다"):
+                font_analyzer.rhwp_info("rhwp", Path("sample.hwp"), 1)
 
 
 class FormattingTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- #4044 리뷰 반영 분할 PR입니다. font-analyzer를 독립 PR로 분리하고, HWPX를 OOXML(`word/`)로·HWP를 ZIP으로 가정하던 직접 파싱을 전부 제거했습니다.
- 글꼴 목록의 유일한 신뢰 소스로 rhwp CLI의 `info --json` 계약(`fonts[]`, schemaVersion 1.0)을 재사용합니다. 리뷰에서 글꼴 0개를 반환하던 `samples/field-01.hwp`가 이제 `함초롬돋움`·`함초롬바탕`을 반환합니다.
- 포맷 해석을 rhwp 한 곳에 위임하므로 파서 개선이 도구 결과에 자동 반영되고, 별도 포맷 가정이 끼어들 여지가 없습니다.

## 구현
- `tools/font-analyzer/font_analyzer.py` (Python 3 표준 라이브러리만)
  - 파일당 `rhwp info --json` 서브프로세스 1회가 유일한 파싱 경로. `fonts` 필드 부재·형오류는 스키마 변경 의심 오류로 즉시 실패합니다.
  - 바이너리 탐색: `--rhwp-bin` 인자 > `RHWP_BIN` 환경변수 > PATH > `target/{release-test,release,debug}` — fidelity_compare의 기존 `RHWP_BIN` 관례와 동일합니다. 명시한 경로가 잘못되면 조용히 다음 후보로 넘어가지 않고 즉시 오류로 종료합니다.
  - 단일 파일: 글꼴 목록(text/JSON/Markdown). 디렉터리: 글꼴별 사용 파일 수 집계·파일별 결과·실패 목록. 부분 실패는 기본 보고 후 exit 0(깨진 fixture가 섞인 코퍼스 대응), `--strict`면 exit 1.
  - 없는 입력·rhwp 실패·빈 디렉터리 → stderr 메시지 + exit 1.

## Test plan
- 실측 회귀 테스트 7종 통과:
  `RHWP_BIN=target/debug/rhwp python tools/font-analyzer/tests/test_font_analyzer.py`
  → `Ran 7 tests / OK`
  - `samples/field-01.hwp` → 글꼴에 함초롬돋움·함초롬바탕 포함 (hwp5)
  - `samples/hwp3-sample5-hwpx.hwpx` → 글꼴 4종(한양견고딕·한양신명조·한양중고딕·굴림체) ≥ 1 (hwpx)
  - 없는 파일·잘못된 RHWP_BIN·문서 없는 디렉터리 → 종료 코드 비 0
  - 임시 디렉터리에 fixture 2개 복사한 일괄 집계 검증 + 바이너리 불필요한 Markdown 포매팅 단위 검증
- samples/ 전체 일괄 실측: 353개 중 성공 350·실패 3(전부 password 보호 fixture), 고유 글꼴 277종, 최다 사용 함초롬바탕 231개 파일 — 실패 파일은 목록으로 보고되고 집계는 계속됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
