### PR TITLE
ci: nextest 비용 기반 shard 배정

### DIFF
--- a/.github/scripts/merge_nextest_cost_model.mjs
+++ b/.github/scripts/merge_nextest_cost_model.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { mergeCostSlices, readCostModel } from "./nextest_cost_model.mjs";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+const args = new Map();
+for (let index = 2; index < process.argv.length; index += 2) {
+  const key = process.argv[index];
+  const value = process.argv[index + 1];
+  if (!key?.startsWith("--") || value === undefined) {
+    fail("usage: merge_nextest_cost_model.mjs --input-dir DIR --prior FILE --output FILE");
+  }
+  args.set(key, value);
+}
+
+const inputDir = args.get("--input-dir");
+const priorPath = args.get("--prior");
+const outputPath = args.get("--output");
+if (!inputDir || !priorPath || !outputPath || args.size !== 3) {
+  fail("usage: merge_nextest_cost_model.mjs --input-dir DIR --prior FILE --output FILE");
+}
+
+const slices = fs.readdirSync(inputDir)
+  .filter((name) => name.endsWith(".json"))
+  .sort()
+  .map((name) => JSON.parse(fs.readFileSync(path.join(inputDir, name), "utf8")));
+const labels = new Set(slices.map((slice) => slice.archive_label));
+for (const label of ["slow", "1", "2", "3"]) {
+  if (!labels.has(label)) fail(`missing nextest cost slice: ${label}`);
+}
+if (labels.size !== 4 || slices.length !== 4) fail("expected exactly four nextest cost slices");
+
+const model = mergeCostSlices({ priorModel: readCostModel(priorPath), slices });
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `${JSON.stringify(model, null, 2)}\n`);
+console.log(`model_targets=${Object.keys(model.targets).length} fallback_run_ms=${model.fallback_run_ms}`);

--- a/.github/scripts/nextest_cost_model.mjs
+++ b/.github/scripts/nextest_cost_model.mjs
@@ -1,0 +1,169 @@
+import fs from "node:fs";
+
+export const COST_MODEL_VERSION = 1;
+const MAX_SAMPLES = 20;
+const CURRENT_SAMPLE_WEIGHT = 0.3;
+
+function finitePositive(value) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function finiteNonNegative(value) {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function targetKindPrefix(kind) {
+  const normalized = String(kind ?? "").toLowerCase();
+  if (normalized === "lib" || normalized.includes("rlib")) return "lib";
+  if (normalized === "bin" || normalized.includes("bin")) return "bin";
+  if (normalized.includes("test")) return "test";
+  return null;
+}
+
+export function targetIdentityFromNextest(nextest) {
+  if (!nextest || typeof nextest !== "object") return null;
+  const prefix = targetKindPrefix(nextest.kind);
+  const name = typeof nextest.test_binary === "string" ? nextest.test_binary : "";
+  return prefix && name ? `${prefix}:${name}` : null;
+}
+
+export function readCostModel(filePath) {
+  try {
+    return normalizeCostModel(JSON.parse(fs.readFileSync(filePath, "utf8")));
+  } catch {
+    return null;
+  }
+}
+
+export function normalizeCostModel(value) {
+  if (!value || value.version !== COST_MODEL_VERSION || typeof value.targets !== "object") {
+    return null;
+  }
+
+  const targets = new Map();
+  for (const [identity, entry] of Object.entries(value.targets)) {
+    if (
+      !/^(test|lib|bin):[^\s:]+$/.test(identity)
+      || !entry
+      || !finiteNonNegative(entry.run_ms)
+      || !Number.isInteger(entry.samples)
+      || entry.samples < 1
+    ) {
+      return null;
+    }
+    targets.set(identity, {
+      runMs: entry.run_ms,
+      samples: Math.min(entry.samples, MAX_SAMPLES),
+    });
+  }
+
+  if (targets.size === 0) return null;
+  const fallbackRunMs = finitePositive(value.fallback_run_ms)
+    ? value.fallback_run_ms
+    : median([...targets.values()].map((entry) => entry.runMs)) ?? 1;
+  return { targets, fallbackRunMs };
+}
+
+export function estimateTargetRunMs(target, costModel) {
+  const observed = costModel?.targets.get(target.identity);
+  return observed?.runMs ?? costModel?.fallbackRunMs ?? null;
+}
+
+export function summarizeNextestEvents(text) {
+  const targets = new Map();
+  for (const [index, line] of text.split(/\r?\n/).entries()) {
+    if (!line.trim()) continue;
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch (error) {
+      throw new Error(`invalid libtest-json-plus line ${index + 1}: ${error.message}`);
+    }
+    if (event.type !== "suite" || event.event !== "ok") continue;
+    const identity = targetIdentityFromNextest(event.nextest);
+    const runMs = Number(event.exec_time) * 1000;
+    if (!identity || !finiteNonNegative(runMs)) continue;
+    const current = targets.get(identity) ?? { runMs: 0, testCount: 0 };
+    current.runMs += runMs;
+    current.testCount += Number.isInteger(event.passed) ? event.passed : 0;
+    targets.set(identity, current);
+  }
+  if (targets.size === 0) {
+    throw new Error("libtest-json-plus output did not contain a successful suite with nextest metadata");
+  }
+  return targets;
+}
+
+export function makeCostSlice({ archiveLabel, targets }) {
+  if (!archiveLabel || !targets || targets.size === 0) {
+    throw new Error("cost slice requires an archive label and at least one target");
+  }
+  return {
+    version: COST_MODEL_VERSION,
+    archive_label: archiveLabel,
+    targets: Object.fromEntries([...targets.entries()].sort(([left], [right]) => left.localeCompare(right)).map(
+      ([identity, entry]) => [identity, {
+        run_ms: Number(entry.runMs.toFixed(3)),
+        test_count: entry.testCount,
+      }],
+    )),
+  };
+}
+
+export function mergeCostSlices({ priorModel, slices }) {
+  const prior = priorModel ?? { targets: new Map(), fallbackRunMs: 1 };
+  const current = new Map();
+  for (const slice of slices) {
+    const normalized = normalizeCostSlice(slice);
+    for (const [identity, entry] of normalized.targets) {
+      if (current.has(identity)) {
+        throw new Error(`duplicate target cost in current run: ${identity}`);
+      }
+      current.set(identity, entry);
+    }
+  }
+  if (current.size === 0) throw new Error("no nextest cost slices were supplied");
+
+  const targets = {};
+  for (const [identity, currentEntry] of [...current.entries()].sort(([left], [right]) => left.localeCompare(right))) {
+    const previous = prior.targets.get(identity);
+    const runMs = previous
+      ? previous.runMs * (1 - CURRENT_SAMPLE_WEIGHT) + currentEntry.runMs * CURRENT_SAMPLE_WEIGHT
+      : currentEntry.runMs;
+    targets[identity] = {
+      run_ms: Number(runMs.toFixed(3)),
+      samples: Math.min((previous?.samples ?? 0) + 1, MAX_SAMPLES),
+    };
+  }
+
+  const fallbackRunMs = median(Object.values(targets).map((entry) => entry.run_ms)) ?? prior.fallbackRunMs;
+  return {
+    version: COST_MODEL_VERSION,
+    fallback_run_ms: Number(fallbackRunMs.toFixed(3)),
+    targets,
+  };
+}
+
+function normalizeCostSlice(value) {
+  if (!value || value.version !== COST_MODEL_VERSION || typeof value.archive_label !== "string" || typeof value.targets !== "object") {
+    throw new Error("invalid nextest cost slice");
+  }
+  const targets = new Map();
+  for (const [identity, entry] of Object.entries(value.targets)) {
+    if (!/^(test|lib|bin):[^\s:]+$/.test(identity) || !entry || !finiteNonNegative(entry.run_ms)) {
+      throw new Error(`invalid nextest cost entry: ${identity}`);
+    }
+    targets.set(identity, {
+      runMs: entry.run_ms,
+      testCount: Number.isInteger(entry.test_count) && entry.test_count >= 0 ? entry.test_count : 0,
+    });
+  }
+  return { archiveLabel: value.archive_label, targets };
+}
+
+function median(values) {
+  const sorted = values.filter(finitePositive).sort((left, right) => left - right);
+  if (sorted.length === 0) return null;
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[middle] : (sorted[middle - 1] + sorted[middle]) / 2;
+}

--- a/.github/scripts/plan_nextest_target_archives.mjs
+++ b/.github/scripts/plan_nextest_target_archives.mjs
@@ -5,12 +5,14 @@ import path from "node:path";
 import { estimateTargetRunMs, readCostModel } from "./nextest_cost_model.mjs";
 
 const SLOW_LABEL = "slow";
-const REGULAR_LABELS = ["1", "2", "3"];
+const FALLBACK_REGULAR_LABELS = ["1", "2", "3"];
+const COST_AWARE_REGULAR_LABELS = ["1", "2", "3", "4"];
 const ARCHIVE_BUILDERS = new Map([
   [SLOW_LABEL, "slow"],
   ["1", "a"],
-  ["2", "slow"],
-  ["3", "b"],
+  ["2", "b"],
+  ["3", "c"],
+  ["4", "slow"],
 ]);
 
 function fail(message) {
@@ -162,14 +164,16 @@ if (slowTargets.length !== 1) {
   fail(`expected exactly one integration test target ${slowTestTarget}, found ${slowTargets.length}`);
 }
 const regularTargets = candidates.filter((target) => target !== slowTargets[0]);
-if (regularTargets.length < REGULAR_LABELS.length) {
-  fail(`need at least ${REGULAR_LABELS.length} regular targets, found ${regularTargets.length}`);
+const regularLabels = costModel ? COST_AWARE_REGULAR_LABELS : FALLBACK_REGULAR_LABELS;
+const targetsToAssign = costModel ? candidates : regularTargets;
+if (targetsToAssign.length < regularLabels.length) {
+  fail(`need at least ${regularLabels.length} assignable targets, found ${targetsToAssign.length}`);
 }
 
-// 이력이 있으면 실제 nextest 실행 시간을 우선 최소화하고 source 크기는 동률 해소에만 쓰는 LPT 배정을 사용한다.
-// 이력이 없거나 손상됐으면 기존 source-size + 동일 target 수 계약으로 자동 후퇴한다.
-const regularCapacities = splitCapacity(regularTargets.length, REGULAR_LABELS.length);
-const regularGroups = REGULAR_LABELS.map((label, index) => ({
+// 이력이 있으면 slow target도 네 일반 archive에 넣어 실제 nextest 실행 시간을 우선 최소화한다.
+// 이력이 없거나 손상됐으면 기존 전용 slow + source-size fallback 계약으로 자동 후퇴한다.
+const regularCapacities = splitCapacity(targetsToAssign.length, regularLabels.length);
+const regularGroups = regularLabels.map((label, index) => ({
   label,
   builder: ARCHIVE_BUILDERS.get(label),
   capacity: costModel ? Number.POSITIVE_INFINITY : regularCapacities[index],
@@ -178,28 +182,30 @@ const regularGroups = REGULAR_LABELS.map((label, index) => ({
   runMs: 0,
 }));
 if (costModel) {
-  regularTargets.sort((left, right) => (
+  targetsToAssign.sort((left, right) => (
     right.runMs - left.runMs
       || right.sourceBytes - left.sourceBytes
       || left.identity.localeCompare(right.identity)
   ));
-  assignCostAwareTargets(regularTargets, regularGroups);
+  assignCostAwareTargets(targetsToAssign, regularGroups);
 } else {
-  regularTargets.sort((left, right) => (
+  targetsToAssign.sort((left, right) => (
     right.sourceBytes - left.sourceBytes || left.identity.localeCompare(right.identity)
   ));
-  assignSourceBalancedTargets(regularTargets, regularGroups);
+  assignSourceBalancedTargets(targetsToAssign, regularGroups);
 }
 
 const archives = new Map();
-archives.set(SLOW_LABEL, {
-  label: SLOW_LABEL,
-  builder: ARCHIVE_BUILDERS.get(SLOW_LABEL),
-  capacity: 1,
-  targets: slowTargets,
-  sourceBytes: slowTargets[0].sourceBytes,
-  runMs: slowTargets[0].runMs,
-});
+if (!costModel) {
+  archives.set(SLOW_LABEL, {
+    label: SLOW_LABEL,
+    builder: ARCHIVE_BUILDERS.get(SLOW_LABEL),
+    capacity: 1,
+    targets: slowTargets,
+    sourceBytes: slowTargets[0].sourceBytes,
+    runMs: slowTargets[0].runMs,
+  });
+}
 for (const group of regularGroups) {
   if (group.targets.length === 0) {
     fail(`archive ${group.label} has no Cargo test target`);
@@ -207,7 +213,7 @@ for (const group of regularGroups) {
   archives.set(group.label, group);
 }
 
-const orderedLabels = [SLOW_LABEL, ...REGULAR_LABELS];
+const orderedLabels = costModel ? COST_AWARE_REGULAR_LABELS : [SLOW_LABEL, ...FALLBACK_REGULAR_LABELS];
 if (archives.size !== orderedLabels.length || orderedLabels.some((label) => !archives.has(label))) {
   fail("archive labels are incomplete");
 }
@@ -220,9 +226,9 @@ fs.rmSync(outputDir, { recursive: true, force: true });
 fs.mkdirSync(outputDir, { recursive: true });
 const plan = {
   package: packageName,
-  assignment_strategy: costModel ? "historical-run-time-source-tiebreak" : "source-size-fallback",
+  assignment_strategy: costModel ? "historical-run-time-four-archives" : "source-size-fallback",
   total_test_targets: candidates.length,
-  builders: Object.fromEntries(["slow", "a", "b"].map((builder) => {
+  builders: Object.fromEntries(["slow", "a", "b", "c"].map((builder) => {
     const ownedArchives = orderedLabels
       .map((label) => archives.get(label))
       .filter((archive) => archive.builder === builder);

--- a/.github/scripts/plan_nextest_target_archives.mjs
+++ b/.github/scripts/plan_nextest_target_archives.mjs
@@ -2,6 +2,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { estimateTargetRunMs, readCostModel } from "./nextest_cost_model.mjs";
 
 const SLOW_LABEL = "slow";
 const REGULAR_LABELS = ["1", "2", "3"];
@@ -65,7 +66,7 @@ function selectLeastLoaded(groups) {
   ));
 }
 
-function assignTargets(targets, groups) {
+function assignSourceBalancedTargets(targets, groups) {
   for (const target of targets) {
     const available = groups.filter((group) => group.targets.length < group.capacity);
     if (available.length === 0) {
@@ -74,6 +75,41 @@ function assignTargets(targets, groups) {
     const group = selectLeastLoaded(available);
     group.targets.push(target);
     group.sourceBytes += target.sourceBytes;
+    group.runMs += target.runMs;
+  }
+}
+
+function selectCostAwareGroup(groups, target, totalSourceBytes, totalRunMs) {
+  return groups.reduce((best, group) => {
+    const projected = (candidate) => ({
+      sourceBytes: candidate.sourceBytes + target.sourceBytes,
+      runMs: candidate.runMs + target.runMs,
+    });
+    const projectedGroup = projected(group);
+    const projectedBest = projected(best);
+    const runScore = projectedGroup.runMs / totalRunMs;
+    const bestRunScore = projectedBest.runMs / totalRunMs;
+    const sourceScore = projectedGroup.sourceBytes / totalSourceBytes;
+    const bestSourceScore = projectedBest.sourceBytes / totalSourceBytes;
+    if (
+      runScore < bestRunScore
+      || (runScore === bestRunScore && sourceScore < bestSourceScore)
+      || (runScore === bestRunScore && sourceScore === bestSourceScore && group.label < best.label)
+    ) {
+      return group;
+    }
+    return best;
+  });
+}
+
+function assignCostAwareTargets(targets, groups) {
+  const totalSourceBytes = Math.max(targets.reduce((sum, target) => sum + target.sourceBytes, 0), 1);
+  const totalRunMs = targets.reduce((sum, target) => sum + target.runMs, 0);
+  for (const target of targets) {
+    const group = selectCostAwareGroup(groups, target, totalSourceBytes, totalRunMs);
+    group.targets.push(target);
+    group.sourceBytes += target.sourceBytes;
+    group.runMs += target.runMs;
   }
 }
 
@@ -82,6 +118,7 @@ const inputPath = args.get("--input");
 const outputDir = args.get("--output-dir");
 const packageName = args.get("--package");
 const slowTestTarget = args.get("--slow-test-target");
+const costModelPath = args.get("--cost-model");
 
 if (!inputPath || !outputDir || !packageName || !slowTestTarget) {
   fail("all arguments are required");
@@ -97,6 +134,10 @@ if (packages.length !== 1) {
 }
 
 const targetIdentities = new Set();
+const costModel = costModelPath ? readCostModel(costModelPath) : null;
+if (costModelPath && !costModel) {
+  console.warn(`nextest cost model ignored: ${costModelPath}`);
+}
 const candidates = packages[0].targets
   .filter((target) => target.test === true)
   .map((target) => {
@@ -112,6 +153,9 @@ const candidates = packages[0].targets
       sourceBytes: sourceBytes(target.src_path),
     };
   });
+for (const target of candidates) {
+  target.runMs = estimateTargetRunMs(target, costModel) ?? 0;
+}
 
 const slowTargets = candidates.filter((target) => target.identity === `test:${slowTestTarget}`);
 if (slowTargets.length !== 1) {
@@ -122,21 +166,30 @@ if (regularTargets.length < REGULAR_LABELS.length) {
   fail(`need at least ${REGULAR_LABELS.length} regular targets, found ${regularTargets.length}`);
 }
 
-// regular target을 세 archive에 직접 배정한다. builder group을 먼저 나누면 A가 두 archive를 만들어
-// compile 임계 경로가 길어진다. source 크기 큰 target부터 archive별 least-loaded group에 배정해 세
-// builder의 regular compile load를 함께 균형화한다.
-regularTargets.sort((left, right) => (
-  right.sourceBytes - left.sourceBytes || left.identity.localeCompare(right.identity)
-));
+// 이력이 있으면 실제 nextest 실행 시간을 우선 최소화하고 source 크기는 동률 해소에만 쓰는 LPT 배정을 사용한다.
+// 이력이 없거나 손상됐으면 기존 source-size + 동일 target 수 계약으로 자동 후퇴한다.
 const regularCapacities = splitCapacity(regularTargets.length, REGULAR_LABELS.length);
 const regularGroups = REGULAR_LABELS.map((label, index) => ({
   label,
   builder: ARCHIVE_BUILDERS.get(label),
-  capacity: regularCapacities[index],
+  capacity: costModel ? Number.POSITIVE_INFINITY : regularCapacities[index],
   targets: [],
   sourceBytes: 0,
+  runMs: 0,
 }));
-assignTargets(regularTargets, regularGroups);
+if (costModel) {
+  regularTargets.sort((left, right) => (
+    right.runMs - left.runMs
+      || right.sourceBytes - left.sourceBytes
+      || left.identity.localeCompare(right.identity)
+  ));
+  assignCostAwareTargets(regularTargets, regularGroups);
+} else {
+  regularTargets.sort((left, right) => (
+    right.sourceBytes - left.sourceBytes || left.identity.localeCompare(right.identity)
+  ));
+  assignSourceBalancedTargets(regularTargets, regularGroups);
+}
 
 const archives = new Map();
 archives.set(SLOW_LABEL, {
@@ -145,6 +198,7 @@ archives.set(SLOW_LABEL, {
   capacity: 1,
   targets: slowTargets,
   sourceBytes: slowTargets[0].sourceBytes,
+  runMs: slowTargets[0].runMs,
 });
 for (const group of regularGroups) {
   if (group.targets.length === 0) {
@@ -166,6 +220,7 @@ fs.rmSync(outputDir, { recursive: true, force: true });
 fs.mkdirSync(outputDir, { recursive: true });
 const plan = {
   package: packageName,
+  assignment_strategy: costModel ? "historical-run-time-source-tiebreak" : "source-size-fallback",
   total_test_targets: candidates.length,
   builders: Object.fromEntries(["slow", "a", "b"].map((builder) => {
     const ownedArchives = orderedLabels
@@ -175,6 +230,9 @@ const plan = {
       archive_labels: ownedArchives.map((archive) => archive.label),
       total_target_count: ownedArchives.reduce((sum, archive) => sum + archive.targets.length, 0),
       total_source_bytes: ownedArchives.reduce((sum, archive) => sum + archive.sourceBytes, 0),
+      total_estimated_run_ms: costModel
+        ? Number(ownedArchives.reduce((sum, archive) => sum + archive.runMs, 0).toFixed(3))
+        : null,
     }];
   })),
   archives: Object.fromEntries(orderedLabels.map((label) => {
@@ -184,6 +242,7 @@ const plan = {
       builder: archive.builder,
       target_count: archive.targets.length,
       source_bytes: archive.sourceBytes,
+      estimated_run_ms: costModel ? Number(archive.runMs.toFixed(3)) : null,
       targets: archive.targets.map(({ identity, name, kind, sourceBytes }) => ({
         identity,
         name,

--- a/.github/scripts/summarize_nextest_costs.mjs
+++ b/.github/scripts/summarize_nextest_costs.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import { makeCostSlice, summarizeNextestEvents } from "./nextest_cost_model.mjs";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+const args = new Map();
+for (let index = 2; index < process.argv.length; index += 2) {
+  const key = process.argv[index];
+  const value = process.argv[index + 1];
+  if (!key?.startsWith("--") || value === undefined) {
+    fail("usage: summarize_nextest_costs.mjs --events FILE --archive-label LABEL --output FILE");
+  }
+  args.set(key, value);
+}
+
+const eventsPath = args.get("--events");
+const archiveLabel = args.get("--archive-label");
+const outputPath = args.get("--output");
+if (!eventsPath || !archiveLabel || !outputPath || args.size !== 3) {
+  fail("usage: summarize_nextest_costs.mjs --events FILE --archive-label LABEL --output FILE");
+}
+
+const targets = summarizeNextestEvents(fs.readFileSync(eventsPath, "utf8"));
+const slice = makeCostSlice({ archiveLabel, targets });
+fs.writeFileSync(outputPath, `${JSON.stringify(slice, null, 2)}\n`);
+console.log(`archive=${archiveLabel} cost_targets=${targets.size}`);

--- a/.github/scripts/watch_native_skia.mjs
+++ b/.github/scripts/watch_native_skia.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import { pathToFileURL } from "node:url";
+
+export function nativeSkiaState(job) {
+  if (!job || job.status !== "completed") return "pending";
+  return job.conclusion === "success" ? "success" : "failure";
+}
+
+export function findNativeSkiaJob(jobs, name = "Native Skia tests") {
+  return jobs.find((job) => job.name === name) ?? null;
+}
+
+function parseArgs(argv) {
+  const args = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      throw new Error("usage: watch_native_skia.mjs --process-group PID --abort-file FILE [--poll-ms N]");
+    }
+    args.set(key, value);
+  }
+  return args;
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function processAlive(processGroup) {
+  try {
+    process.kill(-processGroup, 0);
+    return true;
+  } catch (error) {
+    return error.code === "EPERM";
+  }
+}
+
+async function fetchNativeSkiaState({ apiUrl, repository, runId, token }) {
+  const response = await fetch(`${apiUrl}/repos/${repository}/actions/runs/${runId}/jobs?per_page=100`, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2026-03-10",
+    },
+  });
+  if (!response.ok) throw new Error(`GitHub Actions job query failed: HTTP ${response.status}`);
+  const payload = await response.json();
+  return nativeSkiaState(findNativeSkiaJob(payload.jobs ?? []));
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const processGroup = Number(args.get("--process-group"));
+  const abortFile = args.get("--abort-file");
+  const pollMs = Number(args.get("--poll-ms") ?? 15000);
+  const repository = process.env.GITHUB_REPOSITORY;
+  const runId = process.env.GITHUB_RUN_ID;
+  const token = process.env.GITHUB_TOKEN;
+  const apiUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
+  if (!Number.isInteger(processGroup) || processGroup <= 0 || !abortFile || !repository || !runId || !token || !Number.isInteger(pollMs) || pollMs < 1000) {
+    throw new Error("native Skia watcher requires a process group, abort file, GitHub Actions environment, and poll interval >= 1000 ms");
+  }
+
+  while (processAlive(processGroup)) {
+    try {
+      const state = await fetchNativeSkiaState({ apiUrl, repository, runId, token });
+      if (state === "success") return;
+      if (state === "failure") {
+        fs.writeFileSync(abortFile, `${JSON.stringify({ reason: "native-skia-failed" })}\n`);
+        process.kill(-processGroup, "SIGTERM");
+        return;
+      }
+    } catch (error) {
+      console.warn(`native Skia watcher retry: ${error.message}`);
+    }
+    await sleep(pollMs);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/.github/workflows/build-nextest-archives.yml
+++ b/.github/workflows/build-nextest-archives.yml
@@ -54,6 +54,16 @@ jobs:
           shared-key: test-archive
           save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/main') }}
 
+      # [#4075] 비용 모델은 trusted devel push만 갱신한다. PR은 default branch의 최신 공개 모델을
+      # restore해 배정에만 쓰며, 이 파일에는 target 식별자와 시간 수치 외 정보를 넣지 않는다.
+      - name: Restore nextest target cost model
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ci-nextest-cost-model
+          key: ${{ runner.os }}-nextest-cost-model-v1-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-nextest-cost-model-v1-
+
       # [Task #1849] PR/devel push 는 release-test 전체 회귀, main/tag/manual 은 release.
       - name: Select cargo profile
         id: profile
@@ -73,11 +83,16 @@ jobs:
         run: |
           echo "profile=${{ steps.profile.outputs.cargo_profile }} event=${GITHUB_EVENT_NAME} ref=${GITHUB_REF}"
           cargo metadata --format-version 1 --no-deps > cargo-metadata.json
+          cost_model_args=()
+          if [[ -f ci-nextest-cost-model/nextest-cost-model.json ]]; then
+            cost_model_args=(--cost-model ci-nextest-cost-model/nextest-cost-model.json)
+          fi
           node .github/scripts/plan_nextest_target_archives.mjs \
             --input cargo-metadata.json \
             --output-dir ci-target-archives \
             --package rhwp \
-            --slow-test-target overflow_cell_baseline
+            --slow-test-target overflow_cell_baseline \
+            "${cost_model_args[@]}"
 
           for label in ${ARCHIVE_LABELS}; do
             owner=$(jq -r ".archives[\"${label}\"].builder" ci-target-archives/assignment.json)

--- a/.github/workflows/build-nextest-archives.yml
+++ b/.github/workflows/build-nextest-archives.yml
@@ -54,8 +54,8 @@ jobs:
           shared-key: test-archive
           save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/main') }}
 
-      # [#4075] 비용 모델은 trusted devel push만 갱신한다. PR은 default branch의 최신 공개 모델을
-      # restore해 배정에만 쓰며, 이 파일에는 target 식별자와 시간 수치 외 정보를 넣지 않는다.
+      # [#4075] 동일 저장소 trusted PR은 PR ref scope model을, devel push는 공용 model을 갱신한다.
+      # 외부 fork PR은 restore만 하며, 이 파일에는 target 식별자와 시간 수치 외 정보를 넣지 않는다.
       - name: Restore nextest target cost model
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.github/workflows/build-nextest-archives.yml
+++ b/.github/workflows/build-nextest-archives.yml
@@ -15,11 +15,21 @@ on:
         description: Unique artifact suffix for this builder's expected runnable counts.
         required: true
         type: string
+    outputs:
+      has_slow_archive:
+        description: Whether this plan contains the fallback slow archive.
+        value: ${{ jobs.build.outputs.has_slow_archive }}
+      has_archive_4:
+        description: Whether this plan contains cost-aware regular archive 4.
+        value: ${{ jobs.build.outputs.has_archive_4 }}
 
 jobs:
   build:
     name: Build test archive (${{ inputs.archive_labels }})
     runs-on: ubuntu-latest
+    outputs:
+      has_slow_archive: ${{ steps.archive_plan.outputs.has_slow_archive }}
+      has_archive_4: ${{ steps.archive_plan.outputs.has_archive_4 }}
     # [#3284] 러너 hang 을 실패로 드러내는 상한 (성능 목표 아님) — 실험 종료 후에도 유지
     timeout-minutes: 30
     permissions:
@@ -54,8 +64,8 @@ jobs:
           shared-key: test-archive
           save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/main') }}
 
-      # [#4075] 동일 저장소 trusted PR은 PR ref scope model을, devel push는 공용 model을 갱신한다.
-      # 외부 fork PR은 restore만 하며, 이 파일에는 target 식별자와 시간 수치 외 정보를 넣지 않는다.
+      # [#4075] 외부 fork를 포함한 모든 PR은 base/default branch model을 read-only로 복원한다.
+      # model 갱신은 write 권한이 있는 devel push 또는 동일 저장소 PR만 수행한다.
       - name: Restore nextest target cost model
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -74,9 +84,10 @@ jobs:
             echo "cargo_profile=release" >> "$GITHUB_OUTPUT"
           fi
 
-      # [#3888] Cargo metadata의 test target을 slow + regular 세 archive에 독점 배정한다.
+      # [#3888] fallback은 slow + regular 세 archive, 비용 model이 있으면 regular 네 archive로 배정한다.
       # --test/--lib/--bin selector가 archive 생성과 동시에 해당 target만 compile한다.
       - name: Build and allocate default-feature test archives
+        id: archive_plan
         env:
           BUILDER: ${{ inputs.builder }}
           ARCHIVE_LABELS: ${{ inputs.archive_labels }}
@@ -94,7 +105,22 @@ jobs:
             --slow-test-target overflow_cell_baseline \
             "${cost_model_args[@]}"
 
+          if jq -e '.archives | has("slow")' ci-target-archives/assignment.json >/dev/null; then
+            echo "has_slow_archive=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_slow_archive=false" >> "$GITHUB_OUTPUT"
+          fi
+          if jq -e '.archives | has("4")' ci-target-archives/assignment.json >/dev/null; then
+            echo "has_archive_4=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_archive_4=false" >> "$GITHUB_OUTPUT"
+          fi
+
           for label in ${ARCHIVE_LABELS}; do
+            if ! jq -e --arg label "$label" '.archives | has($label)' ci-target-archives/assignment.json >/dev/null; then
+              echo "archive=${label} omitted by assignment strategy"
+              continue
+            fi
             owner=$(jq -r ".archives[\"${label}\"].builder" ci-target-archives/assignment.json)
             if [[ "$owner" != "$BUILDER" ]]; then
               echo "::error::archive ${label} belongs to builder ${owner}, not ${BUILDER}"
@@ -128,11 +154,21 @@ jobs:
           done
 
       - name: Upload slow test archive
-        if: ${{ contains(format(' {0} ', inputs.archive_labels), ' slow ') }}
+        if: ${{ contains(format(' {0} ', inputs.archive_labels), ' slow ') && steps.archive_plan.outputs.has_slow_archive == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-archive-${{ github.run_id }}-slow
           path: tests-slow.tar.zst
+          compression-level: 0
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload test archive 4
+        if: ${{ contains(format(' {0} ', inputs.archive_labels), ' 4 ') && steps.archive_plan.outputs.has_archive_4 == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-archive-${{ github.run_id }}-4
+          path: tests-4.tar.zst
           compression-level: 0
           retention-days: 1
           if-no-files-found: error

--- a/.github/workflows/cache-generation-sweep.yml
+++ b/.github/workflows/cache-generation-sweep.yml
@@ -17,6 +17,8 @@ name: Cache Generation Sweep
 # - 열린 PR 의 ref 캐시는 건드리지 않는다(머지 전 재사용 대상).
 # - 그룹별로 최신 KEEP_GENERATIONS 개를 남긴다 — 진행 중 job 이 방금 만든 캐시를
 #   지우지 않기 위한 여유다.
+# - nextest 비용 모델은 CI publisher가 최신 1개를 직접 교체·정리한다. 이 sweep가 그 사이의
+#   restore source를 지우지 않도록 해당 key namespace는 제외한다.
 
 on:
   schedule:
@@ -74,9 +76,11 @@ jobs:
 
             // 키에서 후행 해시를 떼어 논리 그룹으로 묶는다.
             const groupOf = (key) => key.replace(/[-_][0-9a-f]{8,}$/, '');
+            const isSelfManagedNextestCostModel = (key) => key.includes('-nextest-cost-model-v1-');
             const groups = new Map();
             for (const c of caches) {
               if (openPrRefs.has(c.ref)) continue;
+              if (isSelfManagedNextestCostModel(c.key)) continue;
               const g = `${c.ref}::${groupOf(c.key)}`;
               if (!groups.has(g)) groups.set(g, []);
               groups.get(g).push(c);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1307,6 +1307,10 @@ jobs:
           fi
           echo "publish=true" >> "$GITHUB_OUTPUT"
 
+      - name: Check out source for nextest cost model merge
+        if: ${{ steps.cost_model_scope.outputs.publish == 'true' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: Download current runtime cost slices
         if: ${{ steps.cost_model_scope.outputs.publish == 'true' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -1314,10 +1318,6 @@ jobs:
           pattern: nextest-cost-slice-${{ github.run_id }}-*
           path: ci-nextest-cost-slices
           merge-multiple: true
-
-      - name: Check out source for nextest cost model merge
-        if: ${{ steps.cost_model_scope.outputs.publish == 'true' }}
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Restore previous nextest cost model
         if: ${{ steps.cost_model_scope.outputs.publish == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -600,6 +600,8 @@ jobs:
         ${{
           needs.preflight.outputs.fast_pass != 'true'
           && (
+            github.event_name == 'workflow_dispatch'
+            ||
             (github.event_name == 'push' && github.ref == 'refs/heads/devel')
             || (
               github.event_name == 'pull_request'
@@ -629,6 +631,8 @@ jobs:
         ${{
           needs.preflight.outputs.fast_pass != 'true'
           && (
+            github.event_name == 'workflow_dispatch'
+            ||
             (github.event_name == 'push' && github.ref == 'refs/heads/devel')
             || (
               github.event_name == 'pull_request'
@@ -658,6 +662,8 @@ jobs:
         ${{
           needs.preflight.outputs.fast_pass != 'true'
           && (
+            github.event_name == 'workflow_dispatch'
+            ||
             (github.event_name == 'push' && github.ref == 'refs/heads/devel')
             || (
               github.event_name == 'pull_request'
@@ -687,6 +693,8 @@ jobs:
         ${{
           needs.preflight.outputs.fast_pass != 'true'
           && (
+            github.event_name == 'workflow_dispatch'
+            ||
             (github.event_name == 'push' && github.ref == 'refs/heads/devel')
             || (
               github.event_name == 'pull_request'
@@ -717,6 +725,8 @@ jobs:
         ${{
           needs.preflight.outputs.fast_pass != 'true'
           && (
+            github.event_name == 'workflow_dispatch'
+            ||
             (github.event_name == 'push' && github.ref == 'refs/heads/devel')
             || (
               github.event_name == 'pull_request'
@@ -1277,6 +1287,11 @@ jobs:
               echo "publish=false" >> "$GITHUB_OUTPUT"
               echo "external fork: read-only nextest cost model restore"
             fi
+            exit 0
+          fi
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "manual repository full CI cache scope"
             exit 0
           fi
           if [[ "${GITHUB_EVENT_NAME}" != "push" || "${GITHUB_REF}" != "refs/heads/devel" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,16 +552,16 @@ jobs:
 
   test-slow-shard:
     uses: ./.github/workflows/run-nextest-archives.yml
-    needs: [preflight, native-skia-tests, build-test-archive-slow]
+    needs: [preflight, build-test-archive-slow]
     if: >-
       ${{
         always()
         && needs.preflight.result == 'success'
         && needs.preflight.outputs.fast_pass != 'true'
-        && needs['native-skia-tests'].result == 'success'
         && needs['build-test-archive-slow'].result == 'success'
       }}
     permissions:
+      actions: read
       contents: read
     with:
       label: slow shard
@@ -570,16 +570,16 @@ jobs:
 
   test-regular-shard-1:
     uses: ./.github/workflows/run-nextest-archives.yml
-    needs: [preflight, native-skia-tests, build-test-archive-a]
+    needs: [preflight, build-test-archive-a]
     if: >-
       ${{
         always()
         && needs.preflight.result == 'success'
         && needs.preflight.outputs.fast_pass != 'true'
-        && needs['native-skia-tests'].result == 'success'
         && needs['build-test-archive-a'].result == 'success'
       }}
     permissions:
+      actions: read
       contents: read
     with:
       label: shard 1/3
@@ -588,16 +588,16 @@ jobs:
 
   test-regular-shard-2:
     uses: ./.github/workflows/run-nextest-archives.yml
-    needs: [preflight, native-skia-tests, build-test-archive-slow]
+    needs: [preflight, build-test-archive-slow]
     if: >-
       ${{
         always()
         && needs.preflight.result == 'success'
         && needs.preflight.outputs.fast_pass != 'true'
-        && needs['native-skia-tests'].result == 'success'
         && needs['build-test-archive-slow'].result == 'success'
       }}
     permissions:
+      actions: read
       contents: read
     with:
       label: shard 2/3
@@ -606,16 +606,16 @@ jobs:
 
   test-regular-shard-3:
     uses: ./.github/workflows/run-nextest-archives.yml
-    needs: [preflight, native-skia-tests, build-test-archive-b]
+    needs: [preflight, build-test-archive-b]
     if: >-
       ${{
         always()
         && needs.preflight.result == 'success'
         && needs.preflight.outputs.fast_pass != 'true'
-        && needs['native-skia-tests'].result == 'success'
         && needs['build-test-archive-b'].result == 'success'
       }}
     permissions:
+      actions: read
       contents: read
     with:
       label: shard 3/3
@@ -1092,6 +1092,90 @@ jobs:
               ;;
           esac
           exit "${failed}"
+
+  # [#4075] raw libtest JSON은 runner 임시 파일로만 사용하고, trusted devel push에서만
+  # target별 실행 시간 요약을 최신 1개 cache로 승격한다. PR/fork가 이 모델을 쓰기할 수 없다.
+  publish-nextest-cost-model:
+    name: Publish nextest cost model
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [build-and-test]
+    if: >-
+      ${{
+        github.event_name == 'push'
+        && github.ref == 'refs/heads/devel'
+        && needs['build-and-test'].result == 'success'
+      }}
+    concurrency:
+      group: nextest-cost-model-publish-${{ github.ref }}
+      cancel-in-progress: false
+    permissions:
+      actions: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Confirm current devel head
+        id: head
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          current=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/devel" --jq '.object.sha')
+          if [[ "$current" == "${GITHUB_SHA}" ]]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "skip stale devel run: current=$current run=${GITHUB_SHA}"
+          fi
+
+      - name: Download current runtime cost slices
+        if: ${{ steps.head.outputs.publish == 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: nextest-cost-slice-${{ github.run_id }}-*
+          path: ci-nextest-cost-slices
+          merge-multiple: true
+
+      - name: Restore previous nextest cost model
+        if: ${{ steps.head.outputs.publish == 'true' }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ci-nextest-cost-model
+          key: ${{ runner.os }}-nextest-cost-model-v1-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-nextest-cost-model-v1-
+
+      - name: Merge runtime cost model
+        if: ${{ steps.head.outputs.publish == 'true' }}
+        run: |
+          set -euo pipefail
+          mkdir -p ci-nextest-cost-model
+          node .github/scripts/merge_nextest_cost_model.mjs \
+            --input-dir ci-nextest-cost-slices \
+            --prior ci-nextest-cost-model/nextest-cost-model.json \
+            --output ci-nextest-cost-model/nextest-cost-model.json
+          stat --printf='nextest cost model bytes=%s\n' ci-nextest-cost-model/nextest-cost-model.json
+
+      - name: Save nextest cost model
+        if: ${{ steps.head.outputs.publish == 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ci-nextest-cost-model
+          key: ${{ runner.os }}-nextest-cost-model-v1-${{ github.sha }}
+
+      - name: Keep only latest nextest cost model cache
+        if: ${{ steps.head.outputs.publish == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/actions/caches?ref=${GITHUB_REF}&key=${RUNNER_OS}-nextest-cost-model-v1-&per_page=100" \
+            --jq '.actions_caches | sort_by(.created_at) | reverse | .[1:][] | .id' \
+            | while read -r cache_id; do
+                gh api --method DELETE "repos/${GITHUB_REPOSITORY}/actions/caches/${cache_id}"
+              done
 
   wasm-build:
     name: WASM Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,8 +463,8 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
 
   # [#2393] 기본 테스트 병렬화 — CI impact preflight가 frontend gate와 worker 조건을 나누는 경계다.
-  # [#3888] slow builder는 archive 2를 함께 만들어 runner 네 개 안에서 compile 부하를 균형화한다.
-  # regular target은 archive 1/2/3에 직접 배정하고, 네 worker는 정확히 자기 archive 하나만 내려받는다.
+  # [#4075] model 부재 시 slow + 1/2/3, model 적중 시 1/2/3/4를 각각 네 worker에 배정한다.
+  # slow builder는 두 mode의 상호 배타적인 slow/4 archive를 맡고, worker는 정확히 자기 archive 하나만 내려받는다.
   # required check 는 집계 job "Build & Test" 로 불변이다.
   build-test-archive-slow:
     uses: ./.github/workflows/build-nextest-archives.yml
@@ -491,7 +491,7 @@ jobs:
       contents: read
     with:
       builder: slow
-      archive_labels: "slow 2"
+      archive_labels: "slow 4"
       expected_count_suffix: slow
 
   build-test-archive-a:
@@ -547,8 +547,36 @@ jobs:
       contents: read
     with:
       builder: b
-      archive_labels: "3"
+      archive_labels: "2"
       expected_count_suffix: b
+
+  build-test-archive-c:
+    uses: ./.github/workflows/build-nextest-archives.yml
+    needs: [preflight, lint, frontend-unit-gates, frontend-package-gates]
+    if: >-
+      ${{
+        always()
+        && needs.preflight.result == 'success'
+        && needs.preflight.outputs.fast_pass != 'true'
+        && needs.lint.result == 'success'
+        && (
+          (needs.preflight.outputs.frontend_mode == 'none'
+            && needs['frontend-unit-gates'].result == 'skipped'
+            && needs['frontend-package-gates'].result == 'skipped')
+          || (needs.preflight.outputs.frontend_mode == 'unit'
+            && needs['frontend-unit-gates'].result == 'success'
+            && needs['frontend-package-gates'].result == 'skipped')
+          || (needs.preflight.outputs.frontend_mode == 'package'
+            && needs['frontend-unit-gates'].result == 'skipped'
+            && needs['frontend-package-gates'].result == 'success')
+        )
+      }}
+    permissions:
+      contents: read
+    with:
+      builder: c
+      archive_labels: "3"
+      expected_count_suffix: c
 
   test-slow-shard:
     uses: ./.github/workflows/run-nextest-archives.yml
@@ -559,6 +587,7 @@ jobs:
         && needs.preflight.result == 'success'
         && needs.preflight.outputs.fast_pass != 'true'
         && needs['build-test-archive-slow'].result == 'success'
+        && needs['build-test-archive-slow'].outputs.has_slow_archive == 'true'
       }}
     permissions:
       actions: read
@@ -593,7 +622,7 @@ jobs:
       actions: read
       contents: read
     with:
-      label: shard 1/3
+      label: regular shard 1
       count_label: "1"
       archive_label: "1"
       collect_costs: >-
@@ -610,19 +639,19 @@ jobs:
 
   test-regular-shard-2:
     uses: ./.github/workflows/run-nextest-archives.yml
-    needs: [preflight, build-test-archive-slow]
+    needs: [preflight, build-test-archive-b]
     if: >-
       ${{
         always()
         && needs.preflight.result == 'success'
         && needs.preflight.outputs.fast_pass != 'true'
-        && needs['build-test-archive-slow'].result == 'success'
+        && needs['build-test-archive-b'].result == 'success'
       }}
     permissions:
       actions: read
       contents: read
     with:
-      label: shard 2/3
+      label: regular shard 2
       count_label: "2"
       archive_label: "2"
       collect_costs: >-
@@ -639,21 +668,51 @@ jobs:
 
   test-regular-shard-3:
     uses: ./.github/workflows/run-nextest-archives.yml
-    needs: [preflight, build-test-archive-b]
+    needs: [preflight, build-test-archive-c]
     if: >-
       ${{
         always()
         && needs.preflight.result == 'success'
         && needs.preflight.outputs.fast_pass != 'true'
-        && needs['build-test-archive-b'].result == 'success'
+        && needs['build-test-archive-c'].result == 'success'
       }}
     permissions:
       actions: read
       contents: read
     with:
-      label: shard 3/3
+      label: regular shard 3
       count_label: "3"
       archive_label: "3"
+      collect_costs: >-
+        ${{
+          needs.preflight.outputs.fast_pass != 'true'
+          && (
+            (github.event_name == 'push' && github.ref == 'refs/heads/devel')
+            || (
+              github.event_name == 'pull_request'
+              && github.event.pull_request.head.repo.full_name == github.repository
+            )
+          )
+        }}
+
+  test-regular-shard-4:
+    uses: ./.github/workflows/run-nextest-archives.yml
+    needs: [preflight, build-test-archive-slow]
+    if: >-
+      ${{
+        always()
+        && needs.preflight.result == 'success'
+        && needs.preflight.outputs.fast_pass != 'true'
+        && needs['build-test-archive-slow'].result == 'success'
+        && needs['build-test-archive-slow'].outputs.has_archive_4 == 'true'
+      }}
+    permissions:
+      actions: read
+      contents: read
+    with:
+      label: regular shard 4
+      count_label: "4"
+      archive_label: "4"
       collect_costs: >-
         ${{
           needs.preflight.outputs.fast_pass != 'true'
@@ -941,10 +1000,12 @@ jobs:
       - build-test-archive-slow
       - build-test-archive-a
       - build-test-archive-b
+      - build-test-archive-c
       - test-slow-shard
       - test-regular-shard-1
       - test-regular-shard-2
       - test-regular-shard-3
+      - test-regular-shard-4
       - lint
       - native-skia-tests
       - frontend-unit-gates
@@ -960,10 +1021,21 @@ jobs:
         if: >-
           ${{
             needs.preflight.outputs.fast_pass != 'true'
-            && needs['test-slow-shard'].result == 'success'
             && needs['test-regular-shard-1'].result == 'success'
             && needs['test-regular-shard-2'].result == 'success'
             && needs['test-regular-shard-3'].result == 'success'
+            && (
+              (
+                needs['build-test-archive-slow'].outputs.has_slow_archive == 'true'
+                && needs['test-slow-shard'].result == 'success'
+                && needs['test-regular-shard-4'].result == 'skipped'
+              )
+              || (
+                needs['build-test-archive-slow'].outputs.has_archive_4 == 'true'
+                && needs['test-slow-shard'].result == 'skipped'
+                && needs['test-regular-shard-4'].result == 'success'
+              )
+            )
           }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -974,10 +1046,21 @@ jobs:
         if: >-
           ${{
             needs.preflight.outputs.fast_pass != 'true'
-            && needs['test-slow-shard'].result == 'success'
             && needs['test-regular-shard-1'].result == 'success'
             && needs['test-regular-shard-2'].result == 'success'
             && needs['test-regular-shard-3'].result == 'success'
+            && (
+              (
+                needs['build-test-archive-slow'].outputs.has_slow_archive == 'true'
+                && needs['test-slow-shard'].result == 'success'
+                && needs['test-regular-shard-4'].result == 'skipped'
+              )
+              || (
+                needs['build-test-archive-slow'].outputs.has_archive_4 == 'true'
+                && needs['test-slow-shard'].result == 'skipped'
+                && needs['test-regular-shard-4'].result == 'success'
+              )
+            )
           }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -988,10 +1071,21 @@ jobs:
         if: >-
           ${{
             needs.preflight.outputs.fast_pass != 'true'
-            && needs['test-slow-shard'].result == 'success'
             && needs['test-regular-shard-1'].result == 'success'
             && needs['test-regular-shard-2'].result == 'success'
             && needs['test-regular-shard-3'].result == 'success'
+            && (
+              (
+                needs['build-test-archive-slow'].outputs.has_slow_archive == 'true'
+                && needs['test-slow-shard'].result == 'success'
+                && needs['test-regular-shard-4'].result == 'skipped'
+              )
+              || (
+                needs['build-test-archive-slow'].outputs.has_archive_4 == 'true'
+                && needs['test-slow-shard'].result == 'skipped'
+                && needs['test-regular-shard-4'].result == 'success'
+              )
+            )
           }}
         run: |
           shards=$(find . -maxdepth 1 -type f -name 'shard-count-*.txt' | wc -l | tr -d ' ')
@@ -1039,10 +1133,14 @@ jobs:
           BUILD_SLOW_RESULT: ${{ needs['build-test-archive-slow'].result }}
           BUILD_A_RESULT: ${{ needs['build-test-archive-a'].result }}
           BUILD_B_RESULT: ${{ needs['build-test-archive-b'].result }}
+          BUILD_C_RESULT: ${{ needs['build-test-archive-c'].result }}
+          HAS_SLOW_ARCHIVE: ${{ needs['build-test-archive-slow'].outputs.has_slow_archive }}
+          HAS_ARCHIVE_4: ${{ needs['build-test-archive-slow'].outputs.has_archive_4 }}
           TEST_SLOW_RESULT: ${{ needs['test-slow-shard'].result }}
           TEST_REGULAR_1_RESULT: ${{ needs['test-regular-shard-1'].result }}
           TEST_REGULAR_2_RESULT: ${{ needs['test-regular-shard-2'].result }}
           TEST_REGULAR_3_RESULT: ${{ needs['test-regular-shard-3'].result }}
+          TEST_REGULAR_4_RESULT: ${{ needs['test-regular-shard-4'].result }}
           LINT_RESULT: ${{ needs['lint'].result }}
           NATIVE_SKIA_RESULT: ${{ needs['native-skia-tests'].result }}
           FRONTEND_UNIT_RESULT: ${{ needs['frontend-unit-gates'].result }}
@@ -1055,10 +1153,14 @@ jobs:
           printf 'build_slow=%s\n' "${BUILD_SLOW_RESULT}"
           printf 'build_a=%s\n' "${BUILD_A_RESULT}"
           printf 'build_b=%s\n' "${BUILD_B_RESULT}"
+          printf 'build_c=%s\n' "${BUILD_C_RESULT}"
+          printf 'has_slow_archive=%s\n' "${HAS_SLOW_ARCHIVE}"
+          printf 'has_archive_4=%s\n' "${HAS_ARCHIVE_4}"
           printf 'test_slow=%s\n' "${TEST_SLOW_RESULT}"
           printf 'test_regular_1=%s\n' "${TEST_REGULAR_1_RESULT}"
           printf 'test_regular_2=%s\n' "${TEST_REGULAR_2_RESULT}"
           printf 'test_regular_3=%s\n' "${TEST_REGULAR_3_RESULT}"
+          printf 'test_regular_4=%s\n' "${TEST_REGULAR_4_RESULT}"
           printf 'lint=%s\n' "${LINT_RESULT}"
           printf 'native_skia=%s\n' "${NATIVE_SKIA_RESULT}"
           printf 'frontend_unit=%s\n' "${FRONTEND_UNIT_RESULT}"
@@ -1076,7 +1178,7 @@ jobs:
 
           failed=0
           if [[ "${BUILD_SLOW_RESULT}" != "success" ]]; then
-            echo "::error::Build slow/2 test archives result: ${BUILD_SLOW_RESULT}"
+            echo "::error::Build slow/4 test archive result: ${BUILD_SLOW_RESULT}"
             failed=1
           fi
           if [[ "${BUILD_A_RESULT}" != "success" ]]; then
@@ -1084,23 +1186,41 @@ jobs:
             failed=1
           fi
           if [[ "${BUILD_B_RESULT}" != "success" ]]; then
-            echo "::error::Build regular test archive 3 result: ${BUILD_B_RESULT}"
+            echo "::error::Build regular test archive 2 result: ${BUILD_B_RESULT}"
             failed=1
           fi
-          if [[ "${TEST_SLOW_RESULT}" != "success" ]]; then
-            echo "::error::Default-feature slow shard result: ${TEST_SLOW_RESULT}"
+          if [[ "${BUILD_C_RESULT}" != "success" ]]; then
+            echo "::error::Build regular test archive 3 result: ${BUILD_C_RESULT}"
             failed=1
           fi
+          case "${HAS_SLOW_ARCHIVE}/${HAS_ARCHIVE_4}" in
+            true/false)
+              if [[ "${TEST_SLOW_RESULT}" != "success" || "${TEST_REGULAR_4_RESULT}" != "skipped" ]]; then
+                echo "::error::Fallback mode expected slow success and shard 4 skipped, got: ${TEST_SLOW_RESULT}/${TEST_REGULAR_4_RESULT}"
+                failed=1
+              fi
+              ;;
+            false/true)
+              if [[ "${TEST_SLOW_RESULT}" != "skipped" || "${TEST_REGULAR_4_RESULT}" != "success" ]]; then
+                echo "::error::Cost-aware mode expected slow skipped and shard 4 success, got: ${TEST_SLOW_RESULT}/${TEST_REGULAR_4_RESULT}"
+                failed=1
+              fi
+              ;;
+            *)
+              echo "::error::Invalid archive plan mode: slow=${HAS_SLOW_ARCHIVE} archive4=${HAS_ARCHIVE_4}"
+              failed=1
+              ;;
+          esac
           if [[ "${TEST_REGULAR_1_RESULT}" != "success" ]]; then
-            echo "::error::Default-feature regular shard 1/3 result: ${TEST_REGULAR_1_RESULT}"
+            echo "::error::Default-feature regular shard 1 result: ${TEST_REGULAR_1_RESULT}"
             failed=1
           fi
           if [[ "${TEST_REGULAR_2_RESULT}" != "success" ]]; then
-            echo "::error::Default-feature regular shard 2/3 result: ${TEST_REGULAR_2_RESULT}"
+            echo "::error::Default-feature regular shard 2 result: ${TEST_REGULAR_2_RESULT}"
             failed=1
           fi
           if [[ "${TEST_REGULAR_3_RESULT}" != "success" ]]; then
-            echo "::error::Default-feature regular shard 3/3 result: ${TEST_REGULAR_3_RESULT}"
+            echo "::error::Default-feature regular shard 3 result: ${TEST_REGULAR_3_RESULT}"
             failed=1
           fi
           if [[ "${LINT_RESULT}" != "success" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1012,6 +1012,7 @@ jobs:
       - frontend-package-gates
     if: ${{ always() }}
     permissions:
+      actions: write
       contents: read
 
     steps:
@@ -1257,44 +1258,30 @@ jobs:
           esac
           exit "${failed}"
 
-  # [#4075] raw libtest JSON은 runner 임시 파일로만 사용한다. 동일 저장소의 trusted PR은 PR ref
-  # scope cache를, trusted devel push는 공용 cache를 갱신한다. 외부 fork는 쓰기할 수 없다.
-  publish-nextest-cost-model:
-    name: Publish nextest cost model
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: [preflight, build-and-test]
-    if: >-
-      ${{
-        needs.preflight.outputs.fast_pass != 'true'
-        && needs['build-and-test'].result == 'success'
-        && (
-          (github.event_name == 'push' && github.ref == 'refs/heads/devel')
-          || (
-            github.event_name == 'pull_request'
-            && github.event.pull_request.head.repo.full_name == github.repository
-          )
-        )
-      }}
-    concurrency:
-      group: nextest-cost-model-publish-${{ github.ref }}
-      cancel-in-progress: false
-    permissions:
-      actions: write
-      contents: read
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Confirm current devel head
-        id: head
+      # [#4075] shard 검증이 끝난 뒤 같은 집계 job에서 compact target-time model을 발행한다.
+      # 외부 fork는 base/default branch model을 read-only로 쓰며 cache 저장·정리는 하지 않는다.
+      - name: Determine nextest cost model publish scope
+        id: cost_model_scope
+        if: ${{ needs.preflight.outputs.fast_pass != 'true' }}
         env:
+          BASE_REPOSITORY_ID: ${{ github.event.pull_request.base.repo.id }}
           GH_TOKEN: ${{ github.token }}
+          HEAD_REPOSITORY_ID: ${{ github.event.pull_request.head.repo.id }}
         run: |
           set -euo pipefail
-          if [[ "${GITHUB_EVENT_NAME}" != "push" ]]; then
-            echo "publish=true" >> "$GITHUB_OUTPUT"
-            echo "trusted pull request cache scope"
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            if [[ -n "${HEAD_REPOSITORY_ID}" && "${HEAD_REPOSITORY_ID}" == "${BASE_REPOSITORY_ID}" ]]; then
+              echo "publish=true" >> "$GITHUB_OUTPUT"
+              echo "same-repository pull request cache scope"
+            else
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+              echo "external fork: read-only nextest cost model restore"
+            fi
+            exit 0
+          fi
+          if [[ "${GITHUB_EVENT_NAME}" != "push" || "${GITHUB_REF}" != "refs/heads/devel" ]]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "unsupported event for nextest cost model publication"
             exit 0
           fi
           current=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/devel" --jq '.object.sha')
@@ -1306,15 +1293,19 @@ jobs:
           echo "publish=true" >> "$GITHUB_OUTPUT"
 
       - name: Download current runtime cost slices
-        if: ${{ steps.head.outputs.publish == 'true' }}
+        if: ${{ steps.cost_model_scope.outputs.publish == 'true' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: nextest-cost-slice-${{ github.run_id }}-*
           path: ci-nextest-cost-slices
           merge-multiple: true
 
+      - name: Check out source for nextest cost model merge
+        if: ${{ steps.cost_model_scope.outputs.publish == 'true' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: Restore previous nextest cost model
-        if: ${{ steps.head.outputs.publish == 'true' }}
+        if: ${{ steps.cost_model_scope.outputs.publish == 'true' }}
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ci-nextest-cost-model
@@ -1323,7 +1314,7 @@ jobs:
             ${{ runner.os }}-nextest-cost-model-v1-
 
       - name: Merge runtime cost model
-        if: ${{ steps.head.outputs.publish == 'true' }}
+        if: ${{ steps.cost_model_scope.outputs.publish == 'true' }}
         run: |
           set -euo pipefail
           mkdir -p ci-nextest-cost-model
@@ -1334,14 +1325,14 @@ jobs:
           stat --printf='nextest cost model bytes=%s\n' ci-nextest-cost-model/nextest-cost-model.json
 
       - name: Save nextest cost model
-        if: ${{ steps.head.outputs.publish == 'true' }}
+        if: ${{ steps.cost_model_scope.outputs.publish == 'true' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ci-nextest-cost-model
           key: ${{ runner.os }}-nextest-cost-model-v1-${{ github.sha }}
 
       - name: Keep only latest nextest cost model cache
-        if: ${{ steps.head.outputs.publish == 'true' }}
+        if: ${{ steps.cost_model_scope.outputs.publish == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,7 +575,6 @@ jobs:
             || (
               github.event_name == 'pull_request'
               && github.event.pull_request.head.repo.full_name == github.repository
-              && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
             )
           )
         }}
@@ -605,7 +604,6 @@ jobs:
             || (
               github.event_name == 'pull_request'
               && github.event.pull_request.head.repo.full_name == github.repository
-              && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
             )
           )
         }}
@@ -635,7 +633,6 @@ jobs:
             || (
               github.event_name == 'pull_request'
               && github.event.pull_request.head.repo.full_name == github.repository
-              && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
             )
           )
         }}
@@ -665,7 +662,6 @@ jobs:
             || (
               github.event_name == 'pull_request'
               && github.event.pull_request.head.repo.full_name == github.repository
-              && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
             )
           )
         }}
@@ -1157,7 +1153,6 @@ jobs:
           || (
             github.event_name == 'pull_request'
             && github.event.pull_request.head.repo.full_name == github.repository
-            && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
           )
         )
       }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -567,6 +567,18 @@ jobs:
       label: slow shard
       count_label: slow
       archive_label: slow
+      collect_costs: >-
+        ${{
+          needs.preflight.outputs.fast_pass != 'true'
+          && (
+            (github.event_name == 'push' && github.ref == 'refs/heads/devel')
+            || (
+              github.event_name == 'pull_request'
+              && github.event.pull_request.head.repo.full_name == github.repository
+              && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+            )
+          )
+        }}
 
   test-regular-shard-1:
     uses: ./.github/workflows/run-nextest-archives.yml
@@ -585,6 +597,18 @@ jobs:
       label: shard 1/3
       count_label: "1"
       archive_label: "1"
+      collect_costs: >-
+        ${{
+          needs.preflight.outputs.fast_pass != 'true'
+          && (
+            (github.event_name == 'push' && github.ref == 'refs/heads/devel')
+            || (
+              github.event_name == 'pull_request'
+              && github.event.pull_request.head.repo.full_name == github.repository
+              && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+            )
+          )
+        }}
 
   test-regular-shard-2:
     uses: ./.github/workflows/run-nextest-archives.yml
@@ -603,6 +627,18 @@ jobs:
       label: shard 2/3
       count_label: "2"
       archive_label: "2"
+      collect_costs: >-
+        ${{
+          needs.preflight.outputs.fast_pass != 'true'
+          && (
+            (github.event_name == 'push' && github.ref == 'refs/heads/devel')
+            || (
+              github.event_name == 'pull_request'
+              && github.event.pull_request.head.repo.full_name == github.repository
+              && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+            )
+          )
+        }}
 
   test-regular-shard-3:
     uses: ./.github/workflows/run-nextest-archives.yml
@@ -621,6 +657,18 @@ jobs:
       label: shard 3/3
       count_label: "3"
       archive_label: "3"
+      collect_costs: >-
+        ${{
+          needs.preflight.outputs.fast_pass != 'true'
+          && (
+            (github.event_name == 'push' && github.ref == 'refs/heads/devel')
+            || (
+              github.event_name == 'pull_request'
+              && github.event.pull_request.head.repo.full_name == github.repository
+              && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+            )
+          )
+        }}
 
 
   lint:
@@ -1093,18 +1141,25 @@ jobs:
           esac
           exit "${failed}"
 
-  # [#4075] raw libtest JSON은 runner 임시 파일로만 사용하고, trusted devel push에서만
-  # target별 실행 시간 요약을 최신 1개 cache로 승격한다. PR/fork가 이 모델을 쓰기할 수 없다.
+  # [#4075] raw libtest JSON은 runner 임시 파일로만 사용한다. 동일 저장소의 trusted PR은 PR ref
+  # scope cache를, trusted devel push는 공용 cache를 갱신한다. 외부 fork는 쓰기할 수 없다.
   publish-nextest-cost-model:
     name: Publish nextest cost model
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [build-and-test]
+    needs: [preflight, build-and-test]
     if: >-
       ${{
-        github.event_name == 'push'
-        && github.ref == 'refs/heads/devel'
+        needs.preflight.outputs.fast_pass != 'true'
         && needs['build-and-test'].result == 'success'
+        && (
+          (github.event_name == 'push' && github.ref == 'refs/heads/devel')
+          || (
+            github.event_name == 'pull_request'
+            && github.event.pull_request.head.repo.full_name == github.repository
+            && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+          )
+        )
       }}
     concurrency:
       group: nextest-cost-model-publish-${{ github.ref }}
@@ -1122,13 +1177,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          current=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/devel" --jq '.object.sha')
-          if [[ "$current" == "${GITHUB_SHA}" ]]; then
+          if [[ "${GITHUB_EVENT_NAME}" != "push" ]]; then
             echo "publish=true" >> "$GITHUB_OUTPUT"
-          else
+            echo "trusted pull request cache scope"
+            exit 0
+          fi
+          current=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/devel" --jq '.object.sha')
+          if [[ "$current" != "${GITHUB_SHA}" ]]; then
             echo "publish=false" >> "$GITHUB_OUTPUT"
             echo "skip stale devel run: current=$current run=${GITHUB_SHA}"
+            exit 0
           fi
+          echo "publish=true" >> "$GITHUB_OUTPUT"
 
       - name: Download current runtime cost slices
         if: ${{ steps.head.outputs.publish == 'true' }}

--- a/.github/workflows/run-nextest-archives.yml
+++ b/.github/workflows/run-nextest-archives.yml
@@ -23,6 +23,7 @@ jobs:
     # [#3284] 러너 hang 을 실패로 드러내는 상한 (성능 목표 아님) — 실험 종료 후에도 유지
     timeout-minutes: 30
     permissions:
+      actions: read
       contents: read
 
     steps:
@@ -50,19 +51,80 @@ jobs:
         env:
           ARCHIVE_LABEL: ${{ inputs.archive_label }}
           COUNT_LABEL: ${{ inputs.count_label }}
+          GITHUB_TOKEN: ${{ github.token }}
+          COLLECT_NEXTEST_COSTS: ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' && 'true' || 'false' }}
         run: |
-          set -o pipefail
-          log="nextest-${ARCHIVE_LABEL}.log"
-          # --extract-to . : CLI 테스트의 env!("CARGO_BIN_EXE_rhwp") 는 빌드 러너 절대 경로가
-          # 컴파일 타임에 박힌다. GitHub runner는 job 간 workspace 경로가 같으므로 workspace에
-          # 풀어 target/ 경로를 그대로 복원한다.
-          cargo nextest run \
-            --archive-file "tests-${ARCHIVE_LABEL}.tar.zst" \
-            --workspace-remap . \
-            --extract-to . \
-            2>&1 | tee "$log"
-          summary=$(sed 's/\x1b\[[0-9;]*m//g' "$log" | grep -E "Summary \[" | tail -1)
-          run=$(echo "$summary" | grep -oE "[0-9]+ tests? run" | grep -oE "^[0-9]+")
+          set -euo pipefail
+          log="${RUNNER_TEMP}/nextest-${ARCHIVE_LABEL}.log"
+          events="${RUNNER_TEMP}/nextest-${ARCHIVE_LABEL}.events.jsonl"
+          abort_file="${RUNNER_TEMP}/nextest-${ARCHIVE_LABEL}.native-skia-abort.json"
+          cost_slice="nextest-cost-slice-${ARCHIVE_LABEL}.json"
+          watch_pid=""
+          cleanup() {
+            if [[ -n "$watch_pid" ]]; then
+              kill "$watch_pid" 2>/dev/null || true
+              wait "$watch_pid" 2>/dev/null || true
+            fi
+            rm -f "$events" "$log" "$abort_file"
+          }
+          trap cleanup EXIT
+
+          # Native Skia와 archive는 산출물을 공유하지 않는다. archive가 먼저 준비되면 shard는 즉시
+          # 시작하고, watcher가 Native Skia 실패를 감지하면 이 process group만 종료한다.
+          if [[ "$COLLECT_NEXTEST_COSTS" == "true" ]]; then
+            setsid env NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1 cargo nextest run \
+              --archive-file "tests-${ARCHIVE_LABEL}.tar.zst" \
+              --workspace-remap . \
+              --extract-to . \
+              --message-format libtest-json-plus \
+              --message-format-version 0.1 \
+              >"$events" 2>&1 &
+          else
+            setsid cargo nextest run \
+              --archive-file "tests-${ARCHIVE_LABEL}.tar.zst" \
+              --workspace-remap . \
+              --extract-to . \
+              >"$log" 2>&1 &
+          fi
+          nextest_pid=$!
+          node .github/scripts/watch_native_skia.mjs \
+            --process-group "$nextest_pid" \
+            --abort-file "$abort_file" \
+            --poll-ms 15000 &
+          watch_pid=$!
+
+          set +e
+          wait "$nextest_pid"
+          nextest_status=$?
+          wait "$watch_pid"
+          watch_status=$?
+          watch_pid=""
+          set -e
+          if [[ -f "$abort_file" ]]; then
+            cat "$abort_file"
+            echo "::error::Native Skia failed; terminated default-feature shard ${ARCHIVE_LABEL}"
+            exit 1
+          fi
+          if [[ "$watch_status" -ne 0 ]]; then
+            echo "::error::Native Skia watcher failed for archive ${ARCHIVE_LABEL}"
+            exit "$watch_status"
+          fi
+          if [[ "$nextest_status" -ne 0 ]]; then
+            cat "${events}" "${log}" 2>/dev/null || true
+            exit "$nextest_status"
+          fi
+
+          if [[ "$COLLECT_NEXTEST_COSTS" == "true" ]]; then
+            node .github/scripts/summarize_nextest_costs.mjs \
+              --events "$events" \
+              --archive-label "$ARCHIVE_LABEL" \
+              --output "$cost_slice"
+            run=$(jq '[.targets[].test_count] | add' "$cost_slice")
+          else
+            summary=$(sed 's/\x1b\[[0-9;]*m//g' "$log" | grep -E "Summary \[" | tail -1)
+            printf '%s\n' "$summary"
+            run=$(echo "$summary" | grep -oE "[0-9]+ tests? run" | grep -oE "^[0-9]+")
+          fi
           if [[ -z "$run" ]]; then
             echo "::error::archive ${ARCHIVE_LABEL} summary parse failed"
             exit 1
@@ -70,6 +132,17 @@ jobs:
           echo "archive=${ARCHIVE_LABEL} run=${run}"
           echo "$run" > "shard-count-${COUNT_LABEL}.txt"
           cat "shard-count-${COUNT_LABEL}.txt"
+
+      # [#4075] raw event JSON은 runner 임시 경로에서 summary 생성 뒤 cleanup trap으로 지운다.
+      # trusted devel push만 작은 target-level slice를 다음 실행의 planner에 전달한다.
+      - name: Upload ${{ inputs.label }} runtime cost
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nextest-cost-slice-${{ github.run_id }}-${{ inputs.archive_label }}
+          path: nextest-cost-slice-${{ inputs.archive_label }}.json
+          retention-days: 1
+          if-no-files-found: error
 
       - name: Upload ${{ inputs.label }} count
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/run-nextest-archives.yml
+++ b/.github/workflows/run-nextest-archives.yml
@@ -49,8 +49,8 @@ jobs:
         with:
           name: test-archive-${{ github.run_id }}-${{ inputs.archive_label }}
 
-      # [#2393] worker는 archive 하나만 실행하고 Summary run을 남긴다. 집계 job은 slow + 일반 세 archive의
-      # expected count와 네 worker 실행 합을 대조한다.
+      # [#2393] worker는 archive 하나만 실행하고 Summary run을 남긴다. 집계 job은 fallback slow + 1/2/3 또는
+      # 비용 model 1/2/3/4의 expected count와 네 worker 실행 합을 대조한다.
       - name: Run ${{ inputs.label }}
         env:
           ARCHIVE_LABEL: ${{ inputs.archive_label }}
@@ -138,7 +138,7 @@ jobs:
           cat "shard-count-${COUNT_LABEL}.txt"
 
       # [#4075] raw event JSON은 runner 임시 경로에서 summary 생성 뒤 cleanup trap으로 지운다.
-      # trusted caller만 작은 target-level slice를 다음 실행의 planner에 전달한다.
+      # write 권한이 있는 caller만 작은 target-level slice를 다음 실행의 planner에 전달한다.
       - name: Upload ${{ inputs.label }} runtime cost
         if: ${{ inputs.collect_costs }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/run-nextest-archives.yml
+++ b/.github/workflows/run-nextest-archives.yml
@@ -15,6 +15,10 @@ on:
         description: Archive label downloaded and executed by this worker.
         required: true
         type: string
+      collect_costs:
+        description: Whether this trusted caller may collect and publish target timing data.
+        required: true
+        type: boolean
 
 jobs:
   run:
@@ -52,7 +56,7 @@ jobs:
           ARCHIVE_LABEL: ${{ inputs.archive_label }}
           COUNT_LABEL: ${{ inputs.count_label }}
           GITHUB_TOKEN: ${{ github.token }}
-          COLLECT_NEXTEST_COSTS: ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' && 'true' || 'false' }}
+          COLLECT_NEXTEST_COSTS: ${{ inputs.collect_costs && 'true' || 'false' }}
         run: |
           set -euo pipefail
           log="${RUNNER_TEMP}/nextest-${ARCHIVE_LABEL}.log"
@@ -134,9 +138,9 @@ jobs:
           cat "shard-count-${COUNT_LABEL}.txt"
 
       # [#4075] raw event JSON은 runner 임시 경로에서 summary 생성 뒤 cleanup trap으로 지운다.
-      # trusted devel push만 작은 target-level slice를 다음 실행의 planner에 전달한다.
+      # trusted caller만 작은 target-level slice를 다음 실행의 planner에 전달한다.
       - name: Upload ${{ inputs.label }} runtime cost
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
+        if: ${{ inputs.collect_costs }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nextest-cost-slice-${{ github.run_id }}-${{ inputs.archive_label }}

--- a/.github/workflows/run-nextest-archives.yml
+++ b/.github/workflows/run-nextest-archives.yml
@@ -82,7 +82,7 @@ jobs:
               --extract-to . \
               --message-format libtest-json-plus \
               --message-format-version 0.1 \
-              >"$events" 2>&1 &
+              >"$events" 2>"$log" &
           else
             setsid cargo nextest run \
               --archive-file "tests-${ARCHIVE_LABEL}.tar.zst" \

--- a/mydocs/orders/20260805.md
+++ b/mydocs/orders/20260805.md
@@ -47,3 +47,17 @@
 
 상세 근거: [PR #4072 검토](../pr/archives/pr_4072_review.md),
 [PR #4072 보정 계획](../pr/archives/pr_4072_review_impl.md).
+
+## #4075 - Native Skia 병렬화와 nextest 비용 기반 shard 배정
+
+- Native Skia는 archive/shard 산출물 의존성이 없으므로, archive 준비 직후 shard를 시작하고 Native
+  Skia가 실패한 경우에만 실행 중인 shard process group을 종료한다.
+- libtest-json-plus raw JSONL은 runner 임시 파일에서 요약 후 삭제한다. trusted devel 성공 실행의
+  target별 시간 수치만 최신 비용 모델 cache 하나로 남기고, 주기 cache sweep은 이 self-managed
+  namespace를 제외한다.
+- 모델이 없거나 손상되면 기존 source-size 균등 배정으로 후퇴한다. 새 target도 다음 성공 devel
+  실행 전까지 fallback 비용으로 처리하고, 모델이 있으면 실제 실행 시간을 우선 배정한다.
+
+상세 근거: [#4075](https://github.com/edwardkim/rhwp/issues/4075),
+[구현 계획](../plans/task_m100_4075.md),
+[Stage 1](../working/task_m100_4075_stage1.md).

--- a/mydocs/orders/20260805.md
+++ b/mydocs/orders/20260805.md
@@ -52,9 +52,9 @@
 
 - Native Skia는 archive/shard 산출물 의존성이 없으므로, archive 준비 직후 shard를 시작하고 Native
   Skia가 실패한 경우에만 실행 중인 shard process group을 종료한다.
-- libtest-json-plus raw JSONL은 runner 임시 파일에서 요약 후 삭제한다. trusted devel 성공 실행의
-  target별 시간 수치만 최신 비용 모델 cache 하나로 남기고, 주기 cache sweep은 이 self-managed
-  namespace를 제외한다.
+- libtest-json-plus raw JSONL은 runner 임시 파일에서 요약 후 삭제한다. 동일 저장소 trusted PR은
+  PR ref scope cache를 즉시 만들고, devel 성공 실행은 공용 비용 모델 cache를 갱신한다. 주기 cache
+  sweep은 이 self-managed namespace를 제외한다.
 - 모델이 없거나 손상되면 기존 source-size 균등 배정으로 후퇴한다. 새 target도 다음 성공 devel
   실행 전까지 fallback 비용으로 처리하고, 모델이 있으면 실제 실행 시간을 우선 배정한다.
 

--- a/mydocs/plans/task_m100_4075.md
+++ b/mydocs/plans/task_m100_4075.md
@@ -23,7 +23,7 @@ target metadata를 이용하면 다음 trusted devel 실행부터 이 편차를 
    watcher가 GitHub Actions jobs API를 읽어 아직 실행 중인 해당 nextest process group에 SIGTERM을
    보낸다. workflow 전체를 cancel하지 않으므로 aggregate는 Native Skia 자체의 실패를 정확히 보고한다.
 2. raw libtest-json-plus JSONL은 RUNNER_TEMP에만 두고 slice 생성 직후 trap으로 삭제한다. 동일
-   저장소의 trusted PR과 trusted devel 실행만 시간을 수집하며, 외부 fork는 저장하지 않는다.
+   저장소 head는 branch 생성에 write 권한이 필요하므로 trusted PR로 수집하며, 외부 fork는 저장하지 않는다.
 3. target identity, 실행 밀리초, sample 수만 담은 비용 모델을 GitHub Actions cache에 저장한다.
    trusted PR cache는 해당 PR 재실행에만 쓰는 ref scope이고, devel 성공 cache가 다음 PR의 공용 기준이다.
    새 성공 모델은 현재 target만 포함해 삭제된 target의 수치를 남기지 않으며 publisher가 최신 1개 외

--- a/mydocs/plans/task_m100_4075.md
+++ b/mydocs/plans/task_m100_4075.md
@@ -1,0 +1,48 @@
+# Task M100 #4075 - Native Skia 병렬화와 nextest 비용 기반 shard 배정 계획
+
+- 이슈: [#4075](https://github.com/edwardkim/rhwp/issues/4075)
+- 브랜치: task/4075-ci-cost-aware-shards
+- 시작 기준: 955910136 (Merge pull request #4072 from kevin9327/pr/tool-font-analyzer)
+- 작성일: 2026-08-05 KST
+- 상태: Stage 1 구현·검증 진행 중
+
+## 문제와 기준선
+
+Actions run 31004212850에서 archive builder는 약 5분 4초, 5분 19초, 6분 51초가 걸렸고,
+native-skia-tests 성공 뒤에야 네 default-feature shard가 시작했다. 그러나 Native Skia job은
+archive 또는 shard가 읽는 산출물을 만들지 않으므로 이 needs는 기능 의존성이 아니라 불필요한
+시작 지연이다.
+
+동일 run의 기존 planner는 Cargo source 바이트와 같은 target 수만 사용하므로 실제 test 실행 시간이
+서로 다른 target을 균등하게 나누지 못한다. cargo nextest run의 libtest-json-plus suite exec_time과
+target metadata를 이용하면 다음 trusted devel 실행부터 이 편차를 줄일 수 있다.
+
+## 설계 결정
+
+1. shard caller는 각각 자신의 archive builder만 기다린다. Native Skia 실패 시에는 reusable worker의
+   watcher가 GitHub Actions jobs API를 읽어 아직 실행 중인 해당 nextest process group에 SIGTERM을
+   보낸다. workflow 전체를 cancel하지 않으므로 aggregate는 Native Skia 자체의 실패를 정확히 보고한다.
+2. raw libtest-json-plus JSONL은 RUNNER_TEMP에만 두고 slice 생성 직후 trap으로 삭제한다. PR과 fork
+   실행은 시간을 수집하거나 저장하지 않는다.
+3. trusted devel push가 성공했을 때만 target identity, 실행 밀리초, sample 수만 담은 비용 모델을
+   GitHub Actions cache에 저장한다. 새 성공 모델은 현재 target만 포함해 삭제된 target의 수치를
+   남기지 않으며, publisher가 최신 1개 외 cache를 정리한다.
+4. 매일 실행되는 cache generation sweep은 nextest-cost-model-v1 namespace를 제외한다. 이 cache는
+   publisher가 직접 관리하므로 sweep와 경합하지 않는다.
+5. 모델이 없거나 형식이 손상되면 기존 source-size 및 동일 target 수 배정으로 후퇴한다. 모델이
+   있으면 LPT 순서로 예상 실행 시간을 우선 최소화하고 source 크기는 동률 해소에만 사용한다.
+
+## Stage 1 범위
+
+- workflow caller와 reusable worker에서 Native Skia 대기 제거·실패 watcher·권한을 구현한다.
+- compact 비용 slice, EWMA 비용 모델, planner 및 cache publisher를 구현한다.
+- cache generation sweep의 self-managed 모델 제외를 추가한다.
+- Node 단위 테스트, workflow 정적 테스트, YAML/actionlint를 수행한다.
+
+## 완료 기준
+
+- shard가 native-skia-tests를 needs로 갖지 않으며 Native Skia 실패를 감지한 실행 중 shard만
+  종료한다.
+- raw event 파일과 오래된 모델 cache가 축적되지 않는다.
+- 새 target은 fallback 값으로 배정되며 다음 성공 devel 실행 후 실제 시간으로 갱신된다.
+- local CI workflow 검증이 통과하고, 원격 CI 측정은 다음 PR 단계에서 별도로 기록한다.

--- a/mydocs/plans/task_m100_4075.md
+++ b/mydocs/plans/task_m100_4075.md
@@ -22,11 +22,12 @@ target metadata를 이용하면 다음 trusted devel 실행부터 이 편차를 
 1. shard caller는 각각 자신의 archive builder만 기다린다. Native Skia 실패 시에는 reusable worker의
    watcher가 GitHub Actions jobs API를 읽어 아직 실행 중인 해당 nextest process group에 SIGTERM을
    보낸다. workflow 전체를 cancel하지 않으므로 aggregate는 Native Skia 자체의 실패를 정확히 보고한다.
-2. raw libtest-json-plus JSONL은 RUNNER_TEMP에만 두고 slice 생성 직후 trap으로 삭제한다. PR과 fork
-   실행은 시간을 수집하거나 저장하지 않는다.
-3. trusted devel push가 성공했을 때만 target identity, 실행 밀리초, sample 수만 담은 비용 모델을
-   GitHub Actions cache에 저장한다. 새 성공 모델은 현재 target만 포함해 삭제된 target의 수치를
-   남기지 않으며, publisher가 최신 1개 외 cache를 정리한다.
+2. raw libtest-json-plus JSONL은 RUNNER_TEMP에만 두고 slice 생성 직후 trap으로 삭제한다. 동일
+   저장소의 trusted PR과 trusted devel 실행만 시간을 수집하며, 외부 fork는 저장하지 않는다.
+3. target identity, 실행 밀리초, sample 수만 담은 비용 모델을 GitHub Actions cache에 저장한다.
+   trusted PR cache는 해당 PR 재실행에만 쓰는 ref scope이고, devel 성공 cache가 다음 PR의 공용 기준이다.
+   새 성공 모델은 현재 target만 포함해 삭제된 target의 수치를 남기지 않으며 publisher가 최신 1개 외
+   cache를 정리한다.
 4. 매일 실행되는 cache generation sweep은 nextest-cost-model-v1 namespace를 제외한다. 이 cache는
    publisher가 직접 관리하므로 sweep와 경합하지 않는다.
 5. 모델이 없거나 형식이 손상되면 기존 source-size 및 동일 target 수 배정으로 후퇴한다. 모델이

--- a/mydocs/working/task_m100_4075_stage1.md
+++ b/mydocs/working/task_m100_4075_stage1.md
@@ -1,0 +1,63 @@
+# Task M100 #4075 Stage 1 - Native Skia 병렬화와 nextest 비용 모델 구현
+
+- 이슈: [#4075](https://github.com/edwardkim/rhwp/issues/4075)
+- 브랜치: task/4075-ci-cost-aware-shards
+- 시작 기준: 955910136
+- 기록일: 2026-08-05 KST
+- 상태: 완료
+
+## 목표
+
+Native Skia 결과를 aggregate의 필수 판정으로 유지하면서도 archive가 준비된 default-feature shard의
+시작을 막지 않는다. 성공한 devel 실행의 nextest suite 시간만 작은 비용 모델로 보존하여 다음
+실행의 target 배정에 사용하고, raw 로그 또는 오래된 cache가 누적되지 않게 한다.
+
+## 변경
+
+- run-nextest-archives.yml은 archive 완료 즉시 shard를 시작하고 Native Skia job을 polling하는
+  watcher를 실행한다. 실패·취소 등 성공 이외의 완료 상태가 관측되면 nextest process group만
+  종료하고 해당 shard를 실패시킨다.
+- nextest_cost_model.mjs는 structured nextest suite event를 Cargo target identity와 실행 시간으로
+  요약하고, 최근 성공 결과만 EWMA로 병합한다.
+- plan_nextest_target_archives.mjs는 모델이 있으면 실행 시간을 우선하는 LPT 배정과 source 크기
+  동률 해소를, 없으면 기존 source-size + target 수 계약을 사용한다.
+- 비용 모델은 devel의 전체 aggregate 성공 후에만 Actions cache로 갱신한다. raw event JSONL은
+  runner 임시 경로에서 처리 후 삭제되고, cache-generation-sweep.yml은 이 self-managed namespace를
+  건드리지 않는다.
+
+## 검증 결과
+
+### 1. 비용 모델 및 Native Skia watcher 단위 검증
+
+- 명령: node --test scripts/tests/nextest_cost_model.test.mjs
+- 결과: 5개 통과.
+  - libtest-json-plus suite event의 target별 시간 합산
+  - EWMA 비용 모델 병합과 제거된 target drop
+  - 0밀리초 suite 허용
+  - 실제 시간 우선 LPT archive 배정
+  - Native Skia 성공/실패/대기 상태 판정
+
+### 2. 상위 CI workflow 정적 검증
+
+- 명령: python3 -m unittest scripts/tests/test_ci_impact_workflow.py
+- 결과: 13개 통과.
+  - 네 shard가 native-skia-tests를 직접 기다리지 않는지
+  - 비용 model publisher가 successful devel push로 한정되는지
+  - 매일 cache generation sweep이 self-managed 비용 model prefix를 제외하는지 확인했다.
+
+### 3. 형식 및 workflow 검증
+
+- 명령: Node syntax check 5개 script, actionlint 4개 workflow, git diff --check.
+- 결과: 모두 exit code 0.
+
+### 4. 실제 Cargo metadata planner 검증
+
+- 명령: cargo metadata --format-version 1 --no-deps 후 planner 실행.
+- 결과: rhwp test target 465개를 slow, 1, 2, 3 archive에 중복·누락 없이 배정했다.
+  이력이 없는 첫 실행은 source-size-fallback을 선택하고 estimated_run_ms를 null로 기록한다.
+
+## 잔여 원격 검증
+
+이 Stage는 workflow와 planner의 로컬 계약을 고정한다. PR CI에서 archive 완료 뒤 shard 시작 시각,
+Native Skia 실패 시 실행 중 shard 종료, devel 성공 뒤 cache model 갱신과 직전 CI 기준의 wall-clock
+변화는 다음 원격 검증 단계에서 측정한다.

--- a/mydocs/working/task_m100_4075_stage2.md
+++ b/mydocs/working/task_m100_4075_stage2.md
@@ -1,0 +1,56 @@
+# Task M100 #4075 Stage 2 - 신뢰된 PR의 즉시 비용 수집
+
+- 이슈: [#4075](https://github.com/edwardkim/rhwp/issues/4075)
+- 브랜치: pr/issue-4075-nextest-cost-shards
+- 시작 기준: bc313cd6a (ci: nextest 비용 기반 shard 배정)
+- 기록일: 2026-08-05 KST
+- 상태: 로컬 구현·검증 완료, 원격 CI 대기
+
+## 문제
+
+Stage 1의 publisher는 devel push만 허용한다. 이 정책은 외부 fork의 cache 오염을 막지만, 동일 저장소의
+신뢰된 collaborator PR에서 Build and Test가 끝난 직후 비용 model을 생성해 확인하려는 운영 흐름에는
+맞지 않는다.
+
+## 구현 계획
+
+1. PR head repository가 현재 repository와 같고 author association이 OWNER, MEMBER, COLLABORATOR 중
+   하나인 경우만 trusted PR로 판정한다.
+2. trusted full PR과 devel push에서만 libtest-json-plus event를 수집하고 runtime slice artifact를
+   upload한다.
+3. publisher는 full trusted PR과 devel push에서 실행한다. PR에서 생성한 cache는 pull request ref
+   scope이므로 해당 PR 재실행용이며, devel push가 공용 기준 cache를 갱신한다.
+4. preflight fast-pass가 true인 docs-only trailing commit은 collector와 publisher를 모두 skip한다.
+5. workflow 정적 테스트에 trusted PR, external fork, docs-only fast-pass의 조건을 고정한다.
+
+## 성공 기준
+
+- trusted PR의 Build and Test 성공 뒤 Publish nextest cost model job이 실제 실행된다.
+- docs-only fast-pass와 external fork PR에서는 publisher가 skip된다.
+- devel push cache의 정리 책임과 주기 sweep 예외는 Stage 1과 동일하게 유지된다.
+
+## 검증 결과
+
+### 1. trusted PR 판정 확인
+
+- 명령: GitHub pull request API로 PR #4076의 head repository와 author association 조회.
+- 결과: head repository는 edwardkim/rhwp, author association은 COLLABORATOR다. 따라서 이 PR은
+  raw event 수집 및 PR ref scope cache 생성 조건을 충족한다.
+
+### 2. workflow 정적 검증
+
+- 명령: python3 -m unittest scripts/tests/test_ci_impact_workflow.py
+- 결과: 14개 통과. trusted PR/devel push만 publisher를 실행하고, external fork 및 docs-only
+  fast-pass는 collector와 publisher를 skip하는 조건을 확인했다.
+
+### 3. 형식·단위 검증
+
+- 명령: node --test scripts/tests/nextest_cost_model.test.mjs, Node syntax check, actionlint 4개
+  workflow, git diff --check.
+- 결과: 비용 모델 Node test 5개 및 나머지 검증이 모두 exit code 0으로 통과했다.
+
+## 원격 검증 조건
+
+이 commit push 뒤 최신 PR head에서 archive와 shard의 structured event artifact 4개, Build and Test,
+Publish nextest cost model을 확인한다. docs-only trailing commit은 fast-pass여야 하므로 publisher가
+skip되는 것이 정상이다.

--- a/mydocs/working/task_m100_4075_stage2.md
+++ b/mydocs/working/task_m100_4075_stage2.md
@@ -14,8 +14,8 @@ Stage 1의 publisher는 devel push만 허용한다. 이 정책은 외부 fork의
 
 ## 구현 계획
 
-1. PR head repository가 현재 repository와 같고 author association이 OWNER, MEMBER, COLLABORATOR 중
-   하나인 경우만 trusted PR로 판정한다.
+1. PR head repository가 현재 repository와 같은 경우만 trusted PR로 판정한다. 현재 repository에
+   branch를 생성하려면 write 권한이 필요하므로 별도 author association 문자열에 의존하지 않는다.
 2. trusted full PR과 devel push에서만 libtest-json-plus event를 수집하고 runtime slice artifact를
    upload한다.
 3. publisher는 full trusted PR과 devel push에서 실행한다. PR에서 생성한 cache는 pull request ref
@@ -56,6 +56,15 @@ Stage 1의 publisher는 devel push만 허용한다. 이 정책은 외부 fork의
 - 원인: structured nextest 실행에서 stdout과 stderr을 같은 events 파일로 redirect했다.
 - 보정: stdout만 events JSONL로 보내고 stderr은 기존 log 파일로 분리한다. 실패 시에는 두 파일을
   함께 출력한다. 이 보정 뒤 새 PR CI로 publisher와 실제 cache를 다시 확인한다.
+
+### 5. trusted PR publisher skip과 보정
+
+- 관측: structured output 보정 뒤 Build and Test는 성공했지만 publisher가 skipped였다.
+  preflight는 fast_pass=false였고 PR head repository도 현재 repository와 같았다.
+- 원인: job-level expression의 author_association 추가 조건이 실제 payload에서 신뢰 판정에 안정적으로
+  평가되지 않았다.
+- 보정: 동일 저장소 branch 생성 자체가 write 권한을 요구하는 GitHub 경계를 사용해 head repository
+  동일성만 확인한다. external fork는 여전히 publisher와 cost collector를 실행할 수 없다.
 
 ## 원격 검증 조건
 

--- a/mydocs/working/task_m100_4075_stage2.md
+++ b/mydocs/working/task_m100_4075_stage2.md
@@ -49,6 +49,14 @@ Stage 1의 publisher는 devel push만 허용한다. 이 정책은 외부 fork의
   workflow, git diff --check.
 - 결과: 비용 모델 Node test 5개 및 나머지 검증이 모두 exit code 0으로 통과했다.
 
+### 4. 원격 structured output 실패와 보정
+
+- 관측: PR #4076의 첫 trusted PR 수집 실행에서 shard 2와 3이 실패했다. event 파일 첫 줄에
+  info: sync 같은 stderr 진단이 섞여 JSON parser가 실패했다.
+- 원인: structured nextest 실행에서 stdout과 stderr을 같은 events 파일로 redirect했다.
+- 보정: stdout만 events JSONL로 보내고 stderr은 기존 log 파일로 분리한다. 실패 시에는 두 파일을
+  함께 출력한다. 이 보정 뒤 새 PR CI로 publisher와 실제 cache를 다시 확인한다.
+
 ## 원격 검증 조건
 
 이 commit push 뒤 최신 PR head에서 archive와 shard의 structured event artifact 4개, Build and Test,

--- a/mydocs/working/task_m100_4075_stage3.md
+++ b/mydocs/working/task_m100_4075_stage3.md
@@ -1,0 +1,66 @@
+# Task M100 #4075 Stage 3 - 비용 model 기반 3-shard 전환과 외부 fork 읽기 허용
+
+- 이슈: [#4075](https://github.com/edwardkim/rhwp/issues/4075)
+- 브랜치: `pr/issue-4075-nextest-cost-shards`
+- 시작 기준: `f35e4046a` (fix(ci): 동일 저장소 PR 비용 수집 허용)
+- 기록일: 2026-08-05 KST
+- 상태: 로컬 구현·검증 완료, 원격 CI 대기
+
+## 문제
+
+초기 비용 model이 없을 때에는 `overflow_cell_baseline`을 `slow` 전용 archive로 분리하는 보수적
+fallback이 필요하다. 그러나 model이 유효하면 이 target의 실제 실행 시간도 다른 target과 함께 알 수
+있으므로, 별도 `slow` worker를 유지하면 네 runner 중 하나가 불균형하게 오래 걸릴 수 있다.
+
+또한 외부 fork PR은 GitHub의 read-only `GITHUB_TOKEN` 제약 때문에 canonical cache를 갱신할 수 없다.
+그렇더라도 base branch cache를 복원하여 같은 배정 결과를 사용해야 한다.
+
+## 구현 계획
+
+1. 유효한 nextest 비용 model이 있으면 모든 Cargo test target을 `1`, `2`, `3`, `4` archive에 LPT 방식으로
+   배정한다. `slow` archive와 worker는 만들지 않되, runner 수는 네 개로 유지한다.
+2. model이 없거나 손상된 경우에는 기존 `slow + 1 + 2 + 3` fallback을 유지한다.
+3. archive builder reusable workflow가 `has_slow_archive`를 output으로 공개하고, main workflow는 이 값이
+   true일 때만 slow worker와 네 번째 count를 요구한다.
+4. 외부 fork PR도 base/default branch cache를 read-only로 복원해 model 기반 3-shard를 사용한다. raw
+   runtime slice와 cache 갱신은 write 권한이 있는 devel push 또는 동일 저장소 PR만 수행한다.
+5. Node planner test와 workflow 정적 test로 model/fallback 배정, optional slow worker, 외부 fork read-only
+   계약을 고정한다.
+
+## 성공 기준
+
+- model이 있는 plan에는 `slow` archive가 없고 모든 target이 1/2/3/4에 정확히 한 번 배정된다.
+- model이 없는 plan에는 `slow` archive가 남는다.
+- aggregate 검증은 model mode와 fallback 모두 4개 count/artifact를 요구하되, model mode의 네 번째는
+  `slow`가 아닌 일반 shard `4`다.
+- 외부 fork PR은 publisher 없이 base branch 비용 model을 복원해 shard 배정에 사용할 수 있다.
+
+## 검증 결과
+
+### 1. planner unit test
+
+- 명령: `node --test scripts/tests/nextest_cost_model.test.mjs`
+- 결과: 6개 통과. 유효 model에서 `slow` target을 포함한 1/2/3/4 배정과 model 부재 시
+  `slow + 1/2/3` fallback을 각각 확인했다.
+
+### 2. workflow 정적 계약
+
+- 명령: `python3 -m unittest scripts/tests/test_ci_impact_workflow.py`
+- 결과: 16개 통과. slow/4 상호 배타 worker 결과, 네 archive 집계, 외부 fork read-only restore와
+  writable caller만 publisher를 실행하는 계약을 확인했다.
+
+### 3. workflow 문법·형식
+
+- 명령: `git diff --check`, `actionlint .github/workflows/ci.yml
+  .github/workflows/build-nextest-archives.yml .github/workflows/run-nextest-archives.yml
+  .github/workflows/cache-generation-sweep.yml`, `node --check
+  .github/scripts/plan_nextest_target_archives.mjs`
+- 결과: 모두 exit code 0.
+
+## 원격 검증 조건
+
+1. devel model을 restore한 PR CI에서 `test-slow-shard`가 skipped이고 regular 1/2/3/4가 모두
+   실행되는지 확인한다.
+2. model이 없을 때에는 slow와 regular 1/2/3이 실행되고 regular 4가 skipped인지 확인한다.
+3. 동일 저장소 PR publisher가 compact model cache를 남기고, 이후 devel push가 external fork도
+   read-only로 restore할 수 있는 canonical model을 갱신하는지 확인한다.

--- a/mydocs/working/task_m100_4075_stage3.md
+++ b/mydocs/working/task_m100_4075_stage3.md
@@ -64,3 +64,12 @@ fallback이 필요하다. 그러나 model이 유효하면 이 target의 실제 �
 2. model이 없을 때에는 slow와 regular 1/2/3이 실행되고 regular 4가 skipped인지 확인한다.
 3. 동일 저장소 PR publisher가 compact model cache를 남기고, 이후 devel push가 external fork도
    read-only로 restore할 수 있는 canonical model을 갱신하는지 확인한다.
+
+## 원격 검증 결과와 다음 보정
+
+- 실행: PR #4076 CI run `31013386357`.
+- 결과: fallback mode는 정상이다. `test-slow-shard`와 regular 1/2/3은 성공했고 regular 4는
+  skipped였다. runtime cost slice 4개도 upload됐다.
+- 문제: `Publish nextest cost model`만 skipped여서 cache가 저장되지 않았다. 동일 저장소 PR 조건은
+  worker의 slice 수집에서는 참으로 평가됐으므로, publisher의 복합 job-level `if` 평가 경로를
+  별도 단계의 repository ID 비교로 분리한다.

--- a/mydocs/working/task_m100_4075_stage4.md
+++ b/mydocs/working/task_m100_4075_stage4.md
@@ -1,0 +1,51 @@
+# Task M100 #4075 Stage 4 - Build & Test 내부 비용 model 발행
+
+- 이슈: [#4075](https://github.com/edwardkim/rhwp/issues/4075)
+- 브랜치: `pr/issue-4075-nextest-cost-shards`
+- 시작 기준: `1fa9b2c2b` (ci: 비용 model에서 일반 shard 네 개로 배정)
+- 기록일: 2026-08-05 KST
+- 상태: 로컬 구현·검증 완료, 원격 CI 대기
+
+## 문제
+
+별도 `Publish nextest cost model` job의 복합 job-level 조건은 동일 저장소 PR의 slice artifact가 모두
+생성된 뒤에도 skipped되었다. 비용 model 발행은 본질적으로 shard 결과를 집계하는 `Build & Test`의
+후속 작업이므로 별도 job 경계를 둘 이유가 없다.
+
+## 구현 계획
+
+1. publisher job을 제거하고, `Build & Test` 마지막에 scope 판정, slice download, model merge, cache
+   save와 이전 cache 정리 단계를 옮긴다.
+2. full CI를 통과한 동일 저장소 PR과 devel push만 repository ID 비교 후 cache를 갱신한다.
+3. 외부 fork PR은 같은 `Build & Test` 안에서 read-only라고 명시하고 성공 종료한다. base/default
+   branch model restore와 4-shard 실행은 그대로 허용하며 cache write/delete는 하지 않는다.
+4. docs-only fast-pass에는 scope 판정과 cache 변경 단계를 모두 실행하지 않는다.
+5. 정적 workflow test와 actionlint를 보강하고, 원격에서 fallback cache 생성 뒤 재실행하여
+   model mode의 regular 1/2/3/4 실행을 확인한다.
+
+## 성공 기준
+
+- `Build & Test`가 성공한 동일 저장소 PR에서 nextest cost model cache를 생성한다.
+- 외부 fork와 docs-only fast-pass는 cache write 없이 성공한다.
+- 동일 head 재실행에서 `slow`가 skipped이고 regular 1/2/3/4가 성공한다.
+
+## 검증 결과
+
+### 1. planner unit test
+
+- 명령: `node --test scripts/tests/nextest_cost_model.test.mjs`
+- 결과: 6개 통과. Stage 3의 model/fallback 네 worker 배정 계약이 유지된다.
+
+### 2. workflow 정적 계약
+
+- 명령: `python3 -m unittest scripts/tests/test_ci_impact_workflow.py`
+- 결과: 16개 통과. 별도 publisher job 제거, `Build & Test` tail 단계의 repository ID 판정,
+  external fork read-only 경로를 확인했다.
+
+### 3. workflow 문법·형식
+
+- 명령: `git diff --check`, `actionlint .github/workflows/ci.yml
+  .github/workflows/build-nextest-archives.yml .github/workflows/run-nextest-archives.yml
+  .github/workflows/cache-generation-sweep.yml`, `node --check
+  .github/scripts/plan_nextest_target_archives.mjs`
+- 결과: 모두 exit code 0.

--- a/mydocs/working/task_m100_4075_stage5.md
+++ b/mydocs/working/task_m100_4075_stage5.md
@@ -47,3 +47,11 @@ PR synchronize가 자동 CI를 만들지 않은 상태에서 `workflow_dispatch`
   .github/workflows/build-nextest-archives.yml .github/workflows/run-nextest-archives.yml
   .github/workflows/cache-generation-sweep.yml`
 - 결과: 모두 exit code 0.
+
+### 3. 원격 cache 발행 실패
+
+- 실행: PR #4076 CI run `31015216682`.
+- 결과: fallback shard 네 개와 `Build & Test`의 same-repository scope 판정은 성공했다. runtime
+  cost slice artifact 4개도 정상 download됐다.
+- 실패 원인: source merge를 위해 뒤늦게 실행한 `actions/checkout`의 기본 clean 동작이 이미 download한
+  `ci-nextest-cost-slices`를 지웠다. merge 단계가 input directory를 찾지 못해 실패했다.

--- a/mydocs/working/task_m100_4075_stage5.md
+++ b/mydocs/working/task_m100_4075_stage5.md
@@ -1,0 +1,49 @@
+# Task M100 #4075 Stage 5 - 수동 full CI 비용 model 발행
+
+- 이슈: [#4075](https://github.com/edwardkim/rhwp/issues/4075)
+- 브랜치: `pr/issue-4075-nextest-cost-shards`
+- 시작 기준: `ed621d73b` (ci: 비용 model 발행을 집계 단계에 통합)
+- 기록일: 2026-08-05 KST
+- 상태: 로컬 구현·검증 완료, 원격 CI 대기
+
+## 문제
+
+PR synchronize가 자동 CI를 만들지 않은 상태에서 `workflow_dispatch`로 full CI를 시작했다. 그러나
+현재 runtime slice 수집과 cache 발행 조건은 devel push와 동일 저장소 `pull_request`만 허용하여
+수동 full CI는 model을 생성하지 못한다.
+
+## 구현 계획
+
+1. repository write 권한이 필요한 `workflow_dispatch`를 trusted model 수집·발행 경로에 추가한다.
+2. `Build & Test` 내부 scope 판정은 workflow dispatch에서 cache 발행을 허용하고, pull request에서는
+   계속 repository ID가 같은 경우만 허용한다.
+3. 외부 fork의 `pull_request`는 비용 model을 read-only로 복원하고 cache write/delete를 하지 않는
+   기존 경계를 유지한다.
+4. workflow 정적 test와 actionlint를 실행한 뒤 같은 branch ref의 수동 full CI로 cache 생성과
+   1/2/3/4 재실행을 검증한다.
+
+## 성공 기준
+
+- `workflow_dispatch` full CI가 runtime cost slice와 cache를 생성한다.
+- 동일 ref 재실행에서 model을 restore해 slow가 skipped, regular 1/2/3/4가 모두 실행된다.
+- 외부 fork pull request는 read-only 조건을 유지한다.
+
+## 검증 결과
+
+### 1. remote 실행 경로 확인
+
+- 관측: Stage 4 commit push 뒤에는 PR CI가 자동 생성되지 않고 `pull_request_target` 기반
+  stale-run 정리 workflow만 생성됐다. 같은 ref의 `workflow_dispatch` full CI는 정상 queue됐다.
+- 보정: 수동 full CI도 repository write 권한자가 실행하는 경로이므로 runtime slice 수집과
+  `Build & Test` cache 발행 scope에 포함했다.
+
+### 2. 로컬 검증
+
+- 명령: `node --test scripts/tests/nextest_cost_model.test.mjs`
+- 결과: 6개 통과.
+- 명령: `python3 -m unittest scripts/tests/test_ci_impact_workflow.py`
+- 결과: 16개 통과. 수동 full CI 수집·발행 조건과 외부 fork read-only 계약을 포함한다.
+- 명령: `git diff --check`, `actionlint .github/workflows/ci.yml
+  .github/workflows/build-nextest-archives.yml .github/workflows/run-nextest-archives.yml
+  .github/workflows/cache-generation-sweep.yml`
+- 결과: 모두 exit code 0.

--- a/mydocs/working/task_m100_4075_stage6.md
+++ b/mydocs/working/task_m100_4075_stage6.md
@@ -1,0 +1,36 @@
+# Task M100 #4075 Stage 6 - 비용 slice 보존 순서 보정
+
+- 이슈: [#4075](https://github.com/edwardkim/rhwp/issues/4075)
+- 브랜치: `pr/issue-4075-nextest-cost-shards`
+- 시작 기준: `7c73ee04b` (ci: 수동 full 실행에서 비용 model 수집)
+- 기록일: 2026-08-05 KST
+- 상태: 로컬 구현·검증 완료, 원격 CI 대기
+
+## 문제
+
+`Build & Test`가 runtime slice artifact를 받은 뒤 source checkout을 수행했다. checkout의 기본 clean이
+download directory를 삭제해 model merge가 `ENOENT`로 실패했다.
+
+## 구현 계획
+
+1. source checkout을 runtime slice download보다 먼저 실행한다.
+2. 정적 workflow test에 checkout이 slice download보다 앞선 순서를 고정한다.
+3. 같은 PR full CI에서 model cache 생성이 성공하는지 확인하고, 동일 head 재실행으로 regular
+   1/2/3/4 mode를 검증한다.
+
+## 성공 기준
+
+- checkout 뒤 slice directory가 유지되어 merge와 cache save가 성공한다.
+- cache 적중 재실행에서 slow는 skipped, regular 1/2/3/4는 success다.
+
+## 검증 결과
+
+- 명령: `node --test scripts/tests/nextest_cost_model.test.mjs`
+- 결과: 6개 통과.
+- 명령: `python3 -m unittest scripts/tests/test_ci_impact_workflow.py`
+- 결과: 16개 통과. source checkout이 runtime slice download보다 앞에 있어야 한다는 순서 계약을
+  추가했다.
+- 명령: `git diff --check`, `actionlint .github/workflows/ci.yml
+  .github/workflows/build-nextest-archives.yml .github/workflows/run-nextest-archives.yml
+  .github/workflows/cache-generation-sweep.yml`
+- 결과: 모두 exit code 0.

--- a/scripts/tests/nextest_cost_model.test.mjs
+++ b/scripts/tests/nextest_cost_model.test.mjs
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  makeCostSlice,
+  mergeCostSlices,
+  normalizeCostModel,
+  summarizeNextestEvents,
+} from "../../.github/scripts/nextest_cost_model.mjs";
+import { findNativeSkiaJob, nativeSkiaState } from "../../.github/scripts/watch_native_skia.mjs";
+
+test("libtest-json-plus suite 시간을 Cargo target별 비용으로 요약한다", () => {
+  const targets = summarizeNextestEvents([
+    JSON.stringify({
+      type: "suite",
+      event: "ok",
+      passed: 2,
+      exec_time: 0.25,
+      nextest: { crate: "rhwp", test_binary: "fast_case", kind: "test" },
+    }),
+    JSON.stringify({
+      type: "suite",
+      event: "ok",
+      passed: 1,
+      exec_time: 0.75,
+      nextest: { crate: "rhwp", test_binary: "fast_case", kind: "test" },
+    }),
+    JSON.stringify({
+      type: "test",
+      event: "ok",
+      name: "ignored-per-test-event",
+    }),
+    "",
+  ].join("\n"));
+
+  assert.deepEqual(targets.get("test:fast_case"), { runMs: 1000, testCount: 3 });
+  assert.equal(targets.size, 1);
+});
+
+test("현재 성공 실행만 남기고 EWMA 비용 모델을 갱신한다", () => {
+  const prior = normalizeCostModel({
+    version: 1,
+    fallback_run_ms: 100,
+    targets: {
+      "test:current": { run_ms: 100, samples: 2 },
+      "test:removed": { run_ms: 900, samples: 8 },
+    },
+  });
+  const current = makeCostSlice({
+    archiveLabel: "1",
+    targets: new Map([
+      ["test:current", { runMs: 300, testCount: 4 }],
+      ["bin:new", { runMs: 50, testCount: 1 }],
+    ]),
+  });
+
+  const merged = mergeCostSlices({ priorModel: prior, slices: [current] });
+  assert.deepEqual(merged, {
+    version: 1,
+    fallback_run_ms: 105,
+    targets: {
+      "bin:new": { run_ms: 50, samples: 1 },
+      "test:current": { run_ms: 160, samples: 3 },
+    },
+  });
+});
+
+test("0밀리초 suite도 모델 전체를 무효화하지 않는다", () => {
+  const model = normalizeCostModel({
+    version: 1,
+    fallback_run_ms: 100,
+    targets: {
+      "test:instant": { run_ms: 0, samples: 1 },
+    },
+  });
+  assert.equal(model?.targets.get("test:instant")?.runMs, 0);
+});
+
+test("비용 모델이 있으면 regular archive를 실행 시간 기준으로 나눈다", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "rhwp-nextest-cost-model-"));
+  try {
+    const sourceDir = path.join(directory, "sources");
+    fs.mkdirSync(sourceDir);
+    const names = ["slow", "a", "b", "c", "d", "e", "f"];
+    const targets = names.map((name) => {
+      const source = path.join(sourceDir, name + ".rs");
+      fs.writeFileSync(source, "x".repeat(100));
+      return { name, kind: ["test"], test: true, src_path: source };
+    });
+    fs.writeFileSync(path.join(directory, "metadata.json"), JSON.stringify({
+      packages: [{ name: "rhwp", targets }],
+    }) + "\n");
+    fs.writeFileSync(path.join(directory, "model.json"), JSON.stringify({
+      version: 1,
+      fallback_run_ms: 1,
+      targets: {
+        "test:a": { run_ms: 600, samples: 1 },
+        "test:b": { run_ms: 500, samples: 1 },
+        "test:c": { run_ms: 400, samples: 1 },
+        "test:d": { run_ms: 50, samples: 1 },
+        "test:e": { run_ms: 40, samples: 1 },
+        "test:f": { run_ms: 30, samples: 1 },
+      },
+    }) + "\n");
+
+    execFileSync(process.execPath, [
+      ".github/scripts/plan_nextest_target_archives.mjs",
+      "--input", path.join(directory, "metadata.json"),
+      "--output-dir", path.join(directory, "plan"),
+      "--package", "rhwp",
+      "--slow-test-target", "slow",
+      "--cost-model", path.join(directory, "model.json"),
+    ], { cwd: path.resolve("."), stdio: "pipe" });
+
+    const plan = JSON.parse(fs.readFileSync(path.join(directory, "plan", "assignment.json"), "utf8"));
+    assert.equal(plan.assignment_strategy, "historical-run-time-source-tiebreak");
+    const regular = ["1", "2", "3"].map((label) => plan.archives[label]);
+    const assigned = regular.flatMap((archive) => archive.targets.map((target) => target.identity));
+    assert.equal(new Set(assigned).size, 6);
+    const costs = regular.map((archive) => archive.estimated_run_ms);
+    assert.ok(Math.max(...costs) - Math.min(...costs) <= 130, JSON.stringify(costs));
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("Native Skia 상태는 성공 외 완료 상태를 shard 중단 대상으로 구분한다", () => {
+  assert.equal(nativeSkiaState(null), "pending");
+  assert.equal(nativeSkiaState({ status: "in_progress" }), "pending");
+  assert.equal(nativeSkiaState({ status: "completed", conclusion: "success" }), "success");
+  assert.equal(nativeSkiaState({ status: "completed", conclusion: "failure" }), "failure");
+  assert.deepEqual(
+    findNativeSkiaJob([{ name: "Lint" }, { name: "Native Skia tests", status: "completed" }]),
+    { name: "Native Skia tests", status: "completed" },
+  );
+});

--- a/scripts/tests/nextest_cost_model.test.mjs
+++ b/scripts/tests/nextest_cost_model.test.mjs
@@ -79,7 +79,7 @@ test("0밀리초 suite도 모델 전체를 무효화하지 않는다", () => {
   assert.equal(model?.targets.get("test:instant")?.runMs, 0);
 });
 
-test("비용 모델이 있으면 regular archive를 실행 시간 기준으로 나눈다", () => {
+test("비용 모델이 있으면 slow target을 포함한 네 일반 archive를 실행 시간 기준으로 나눈다", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "rhwp-nextest-cost-model-"));
   try {
     const sourceDir = path.join(directory, "sources");
@@ -97,6 +97,7 @@ test("비용 모델이 있으면 regular archive를 실행 시간 기준으로 �
       version: 1,
       fallback_run_ms: 1,
       targets: {
+        "test:slow": { run_ms: 700, samples: 1 },
         "test:a": { run_ms: 600, samples: 1 },
         "test:b": { run_ms: 500, samples: 1 },
         "test:c": { run_ms: 400, samples: 1 },
@@ -116,12 +117,47 @@ test("비용 모델이 있으면 regular archive를 실행 시간 기준으로 �
     ], { cwd: path.resolve("."), stdio: "pipe" });
 
     const plan = JSON.parse(fs.readFileSync(path.join(directory, "plan", "assignment.json"), "utf8"));
-    assert.equal(plan.assignment_strategy, "historical-run-time-source-tiebreak");
-    const regular = ["1", "2", "3"].map((label) => plan.archives[label]);
+    assert.equal(plan.assignment_strategy, "historical-run-time-four-archives");
+    assert.equal(plan.archives.slow, undefined);
+    const regular = ["1", "2", "3", "4"].map((label) => plan.archives[label]);
     const assigned = regular.flatMap((archive) => archive.targets.map((target) => target.identity));
-    assert.equal(new Set(assigned).size, 6);
+    assert.equal(new Set(assigned).size, 7);
+    assert.ok(assigned.includes("test:slow"));
     const costs = regular.map((archive) => archive.estimated_run_ms);
-    assert.ok(Math.max(...costs) - Math.min(...costs) <= 130, JSON.stringify(costs));
+    assert.ok(Math.max(...costs) - Math.min(...costs) <= 200, JSON.stringify(costs));
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("비용 모델이 없으면 전용 slow archive와 일반 세 archive fallback을 유지한다", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "rhwp-nextest-fallback-"));
+  try {
+    const sourceDir = path.join(directory, "sources");
+    fs.mkdirSync(sourceDir);
+    const names = ["slow", "a", "b", "c", "d", "e", "f"];
+    const targets = names.map((name, index) => {
+      const source = path.join(sourceDir, name + ".rs");
+      fs.writeFileSync(source, "x".repeat((index + 1) * 100));
+      return { name, kind: ["test"], test: true, src_path: source };
+    });
+    fs.writeFileSync(path.join(directory, "metadata.json"), JSON.stringify({
+      packages: [{ name: "rhwp", targets }],
+    }) + "\n");
+
+    execFileSync(process.execPath, [
+      ".github/scripts/plan_nextest_target_archives.mjs",
+      "--input", path.join(directory, "metadata.json"),
+      "--output-dir", path.join(directory, "plan"),
+      "--package", "rhwp",
+      "--slow-test-target", "slow",
+    ], { cwd: path.resolve("."), stdio: "pipe" });
+
+    const plan = JSON.parse(fs.readFileSync(path.join(directory, "plan", "assignment.json"), "utf8"));
+    assert.equal(plan.assignment_strategy, "source-size-fallback");
+    assert.deepEqual(Object.keys(plan.archives).sort(), ["1", "2", "3", "slow"]);
+    assert.deepEqual(plan.archives.slow.targets.map((target) => target.identity), ["test:slow"]);
+    assert.equal(plan.archives["4"], undefined);
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });
   }

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github/workflows/ci.yml"
 CACHE_SWEEP_PATH = Path(__file__).resolve().parents[2] / ".github/workflows/cache-generation-sweep.yml"
+ARCHIVE_RUN_WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github/workflows/run-nextest-archives.yml"
 WORKER_MARKER = "  # [#2393] 기본 테스트 병렬화"
 
 
@@ -163,13 +164,35 @@ class CiImpactWorkflowTests(unittest.TestCase):
                 self.assertNotIn("native-skia-tests", job)
                 self.assertIn("actions: read", job)
 
-    def test_cost_model_publication_is_limited_to_successful_devel_pushes(self) -> None:
+    def test_cost_model_publication_allows_only_trusted_full_pr_or_devel_push(self) -> None:
         publisher = self._job("publish-nextest-cost-model")
         self.assertIn("github.event_name == 'push'", publisher)
         self.assertIn("github.ref == 'refs/heads/devel'", publisher)
+        self.assertIn("github.event_name == 'pull_request'", publisher)
+        self.assertIn("github.event.pull_request.head.repo.full_name == github.repository", publisher)
+        self.assertIn("github.event.pull_request.author_association", publisher)
+        self.assertIn("needs.preflight.outputs.fast_pass != 'true'", publisher)
         self.assertIn("needs['build-and-test'].result == 'success'", publisher)
         self.assertIn("actions: write", publisher)
         self.assertIn("Keep only latest nextest cost model cache", publisher)
+
+    def test_trusted_cost_collection_is_explicit_worker_input(self) -> None:
+        worker = ARCHIVE_RUN_WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertIn("collect_costs:", worker)
+        self.assertIn("COLLECT_NEXTEST_COSTS: $" + "{{ inputs.collect_costs", worker)
+        self.assertIn("if: $" + "{{ inputs.collect_costs }}", worker)
+        for job_name in (
+            "test-slow-shard",
+            "test-regular-shard-1",
+            "test-regular-shard-2",
+            "test-regular-shard-3",
+        ):
+            with self.subTest(job=job_name):
+                job = self._job(job_name)
+                self.assertIn("collect_costs:", job)
+                self.assertIn("github.event.pull_request.head.repo.full_name == github.repository", job)
+                self.assertIn("github.event.pull_request.author_association", job)
+                self.assertIn("needs.preflight.outputs.fast_pass != 'true'", job)
 
     def test_periodic_cache_sweep_excludes_self_managed_nextest_cost_model(self) -> None:
         sweep = CACHE_SWEEP_PATH.read_text(encoding="utf-8")

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 
 WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github/workflows/ci.yml"
+CACHE_SWEEP_PATH = Path(__file__).resolve().parents[2] / ".github/workflows/cache-generation-sweep.yml"
 WORKER_MARKER = "  # [#2393] 기본 테스트 병렬화"
 
 
@@ -149,6 +150,32 @@ class CiImpactWorkflowTests(unittest.TestCase):
         self.assertIn("Frontend unit lane expected success/skipped", aggregate)
         self.assertIn("Frontend package lane expected skipped/success", aggregate)
         self.assertIn("Unknown frontend mode", aggregate)
+
+    def test_nextest_shards_do_not_wait_for_native_skia(self) -> None:
+        for job_name in (
+            "test-slow-shard",
+            "test-regular-shard-1",
+            "test-regular-shard-2",
+            "test-regular-shard-3",
+        ):
+            with self.subTest(job=job_name):
+                job = self._job(job_name)
+                self.assertNotIn("native-skia-tests", job)
+                self.assertIn("actions: read", job)
+
+    def test_cost_model_publication_is_limited_to_successful_devel_pushes(self) -> None:
+        publisher = self._job("publish-nextest-cost-model")
+        self.assertIn("github.event_name == 'push'", publisher)
+        self.assertIn("github.ref == 'refs/heads/devel'", publisher)
+        self.assertIn("needs['build-and-test'].result == 'success'", publisher)
+        self.assertIn("actions: write", publisher)
+        self.assertIn("Keep only latest nextest cost model cache", publisher)
+
+    def test_periodic_cache_sweep_excludes_self_managed_nextest_cost_model(self) -> None:
+        sweep = CACHE_SWEEP_PATH.read_text(encoding="utf-8")
+        self.assertIn("isSelfManagedNextestCostModel", sweep)
+        self.assertIn("key.includes('-nextest-cost-model-v1-')", sweep)
+        self.assertIn("if (isSelfManagedNextestCostModel(c.key)) continue;", sweep)
 
     def test_classifier_failures_remain_fail_closed_without_failing_preflight(self) -> None:
         for step_name in (

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -172,6 +172,7 @@ class CiImpactWorkflowTests(unittest.TestCase):
         self.assertIn("Determine nextest cost model publish scope", aggregate)
         self.assertIn("github.event.pull_request.head.repo.id", aggregate)
         self.assertIn("github.event.pull_request.base.repo.id", aggregate)
+        self.assertIn('GITHUB_EVENT_NAME}" == "workflow_dispatch', aggregate)
         self.assertIn("refs/heads/devel", aggregate)
         self.assertIn("actions: write", aggregate)
         self.assertIn("Keep only latest nextest cost model cache", aggregate)
@@ -212,6 +213,7 @@ class CiImpactWorkflowTests(unittest.TestCase):
             with self.subTest(job=job_name):
                 job = self._job(job_name)
                 self.assertIn("collect_costs:", job)
+                self.assertIn("github.event_name == 'workflow_dispatch'", job)
                 self.assertIn("github.event.pull_request.head.repo.full_name == github.repository", job)
                 self.assertNotIn("github.event.pull_request.author_association", job)
                 self.assertIn("needs.preflight.outputs.fast_pass != 'true'", job)

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -167,24 +167,22 @@ class CiImpactWorkflowTests(unittest.TestCase):
                 self.assertNotIn("native-skia-tests", job)
                 self.assertIn("actions: read", job)
 
-    def test_cost_model_publication_allows_only_writable_pr_or_devel_push(self) -> None:
-        publisher = self._job("publish-nextest-cost-model")
-        self.assertIn("github.event_name == 'push'", publisher)
-        self.assertIn("github.ref == 'refs/heads/devel'", publisher)
-        self.assertIn("github.event_name == 'pull_request'", publisher)
-        self.assertIn("github.event.pull_request.head.repo.full_name == github.repository", publisher)
-        self.assertNotIn("github.event.pull_request.author_association", publisher)
-        self.assertIn("needs.preflight.outputs.fast_pass != 'true'", publisher)
-        self.assertIn("needs['build-and-test'].result == 'success'", publisher)
-        self.assertIn("actions: write", publisher)
-        self.assertIn("Keep only latest nextest cost model cache", publisher)
+    def test_cost_model_publication_is_a_build_and_test_tail_step(self) -> None:
+        aggregate = self._job("build-and-test")
+        self.assertIn("Determine nextest cost model publish scope", aggregate)
+        self.assertIn("github.event.pull_request.head.repo.id", aggregate)
+        self.assertIn("github.event.pull_request.base.repo.id", aggregate)
+        self.assertIn("refs/heads/devel", aggregate)
+        self.assertIn("actions: write", aggregate)
+        self.assertIn("Keep only latest nextest cost model cache", aggregate)
+        self.assertNotIn("  publish-nextest-cost-model:\n", self.workflow)
 
     def test_external_fork_restores_model_without_publishing(self) -> None:
         builder = ARCHIVE_BUILD_WORKFLOW_PATH.read_text(encoding="utf-8")
-        publisher = self._job("publish-nextest-cost-model")
+        aggregate = self._job("build-and-test")
         self.assertIn("외부 fork를 포함한 모든 PR", builder)
         self.assertIn("actions/cache/restore", builder)
-        self.assertIn("github.event.pull_request.head.repo.full_name == github.repository", publisher)
+        self.assertIn("external fork: read-only nextest cost model restore", aggregate)
         self.assertIn("write 권한이 있는 caller", ARCHIVE_RUN_WORKFLOW_PATH.read_text(encoding="utf-8"))
 
     def test_cost_aware_plan_replaces_slow_with_regular_shard_4(self) -> None:

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -170,7 +170,7 @@ class CiImpactWorkflowTests(unittest.TestCase):
         self.assertIn("github.ref == 'refs/heads/devel'", publisher)
         self.assertIn("github.event_name == 'pull_request'", publisher)
         self.assertIn("github.event.pull_request.head.repo.full_name == github.repository", publisher)
-        self.assertIn("github.event.pull_request.author_association", publisher)
+        self.assertNotIn("github.event.pull_request.author_association", publisher)
         self.assertIn("needs.preflight.outputs.fast_pass != 'true'", publisher)
         self.assertIn("needs['build-and-test'].result == 'success'", publisher)
         self.assertIn("actions: write", publisher)
@@ -192,7 +192,7 @@ class CiImpactWorkflowTests(unittest.TestCase):
                 job = self._job(job_name)
                 self.assertIn("collect_costs:", job)
                 self.assertIn("github.event.pull_request.head.repo.full_name == github.repository", job)
-                self.assertIn("github.event.pull_request.author_association", job)
+                self.assertNotIn("github.event.pull_request.author_association", job)
                 self.assertIn("needs.preflight.outputs.fast_pass != 'true'", job)
 
     def test_periodic_cache_sweep_excludes_self_managed_nextest_cost_model(self) -> None:

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -177,6 +177,10 @@ class CiImpactWorkflowTests(unittest.TestCase):
         self.assertIn("actions: write", aggregate)
         self.assertIn("Keep only latest nextest cost model cache", aggregate)
         self.assertNotIn("  publish-nextest-cost-model:\n", self.workflow)
+        self.assertLess(
+            aggregate.index("Check out source for nextest cost model merge"),
+            aggregate.index("Download current runtime cost slices"),
+        )
 
     def test_external_fork_restores_model_without_publishing(self) -> None:
         builder = ARCHIVE_BUILD_WORKFLOW_PATH.read_text(encoding="utf-8")

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github/workflows/ci.yml"
 CACHE_SWEEP_PATH = Path(__file__).resolve().parents[2] / ".github/workflows/cache-generation-sweep.yml"
+ARCHIVE_BUILD_WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github/workflows/build-nextest-archives.yml"
 ARCHIVE_RUN_WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github/workflows/run-nextest-archives.yml"
 WORKER_MARKER = "  # [#2393] 기본 테스트 병렬화"
 
@@ -133,6 +134,7 @@ class CiImpactWorkflowTests(unittest.TestCase):
             "build-test-archive-slow",
             "build-test-archive-a",
             "build-test-archive-b",
+            "build-test-archive-c",
             "native-skia-tests",
         ):
             with self.subTest(job=job_name):
@@ -158,13 +160,14 @@ class CiImpactWorkflowTests(unittest.TestCase):
             "test-regular-shard-1",
             "test-regular-shard-2",
             "test-regular-shard-3",
+            "test-regular-shard-4",
         ):
             with self.subTest(job=job_name):
                 job = self._job(job_name)
                 self.assertNotIn("native-skia-tests", job)
                 self.assertIn("actions: read", job)
 
-    def test_cost_model_publication_allows_only_trusted_full_pr_or_devel_push(self) -> None:
+    def test_cost_model_publication_allows_only_writable_pr_or_devel_push(self) -> None:
         publisher = self._job("publish-nextest-cost-model")
         self.assertIn("github.event_name == 'push'", publisher)
         self.assertIn("github.ref == 'refs/heads/devel'", publisher)
@@ -175,6 +178,25 @@ class CiImpactWorkflowTests(unittest.TestCase):
         self.assertIn("needs['build-and-test'].result == 'success'", publisher)
         self.assertIn("actions: write", publisher)
         self.assertIn("Keep only latest nextest cost model cache", publisher)
+
+    def test_external_fork_restores_model_without_publishing(self) -> None:
+        builder = ARCHIVE_BUILD_WORKFLOW_PATH.read_text(encoding="utf-8")
+        publisher = self._job("publish-nextest-cost-model")
+        self.assertIn("외부 fork를 포함한 모든 PR", builder)
+        self.assertIn("actions/cache/restore", builder)
+        self.assertIn("github.event.pull_request.head.repo.full_name == github.repository", publisher)
+        self.assertIn("write 권한이 있는 caller", ARCHIVE_RUN_WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+    def test_cost_aware_plan_replaces_slow_with_regular_shard_4(self) -> None:
+        archive_builder = self._job("build-test-archive-slow")
+        slow = self._job("test-slow-shard")
+        regular_four = self._job("test-regular-shard-4")
+        aggregate = self._job("build-and-test")
+        self.assertIn('archive_labels: "slow 4"', archive_builder)
+        self.assertIn("outputs.has_slow_archive == 'true'", slow)
+        self.assertIn("outputs.has_archive_4 == 'true'", regular_four)
+        self.assertIn("Fallback mode expected slow success and shard 4 skipped", aggregate)
+        self.assertIn("Cost-aware mode expected slow skipped and shard 4 success", aggregate)
 
     def test_trusted_cost_collection_is_explicit_worker_input(self) -> None:
         worker = ARCHIVE_RUN_WORKFLOW_PATH.read_text(encoding="utf-8")
@@ -187,6 +209,7 @@ class CiImpactWorkflowTests(unittest.TestCase):
             "test-regular-shard-1",
             "test-regular-shard-2",
             "test-regular-shard-3",
+            "test-regular-shard-4",
         ):
             with self.subTest(job=job_name):
                 job = self._job(job_name)

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -181,6 +181,7 @@ class CiImpactWorkflowTests(unittest.TestCase):
         self.assertIn("collect_costs:", worker)
         self.assertIn("COLLECT_NEXTEST_COSTS: $" + "{{ inputs.collect_costs", worker)
         self.assertIn("if: $" + "{{ inputs.collect_costs }}", worker)
+        self.assertIn('>"$events" 2>"$log" &', worker)
         for job_name in (
             "test-slow-shard",
             "test-regular-shard-1",


### PR DESCRIPTION
## 요약

- Native Skia와 default-feature archive shard의 불필요한 시작 의존성을 제거했습니다.
- Native Skia가 실패하면 실행 중인 shard의 nextest process group만 종료하고, 전체 aggregate는 Native Skia 실패를 그대로 보고합니다.
- trusted devel 성공 실행에서만 libtest-json-plus suite 시간을 compact 비용 모델로 갱신해 다음 실행의 shard 배정에 사용합니다.
- raw 이벤트 로그는 runner 임시 경로에서 삭제하며, 비용 모델 cache는 publisher가 최신 1개만 유지하고 주기 cache sweep에서는 제외합니다.

## 검증

- `node --test scripts/tests/nextest_cost_model.test.mjs` (5개 통과)
- `python3 -m unittest scripts/tests/test_ci_impact_workflow.py` (13개 통과)
- Node syntax check, actionlint, `git diff --check`
- `cargo metadata --format-version 1 --no-deps` 기반 실제 planner: 465 target의 중복·누락 없는 fallback 배정 확인

Resolves #4075