### PR TITLE
fix(typeset): 각주 안전마진을 조건부로 — 저장 좌표가 각주 영역 위에 둔 줄은 통과 (#4054)

### DIFF
--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -14184,6 +14184,17 @@ impl TypesetEngine {
             let mut cumulative = 0.0;
             let mut end_line = cursor_line;
             let mut used_saved_tail_vpos_fit = false;
+            // [#4024] 저장 사다리 신뢰(`saved_tail_vpos_fit`)는 `li..line_count` 만 보고
+            // 그때까지 쌓인 `cumulative` 를 모른다. 그래서 한 번 참이 되면 예산을 넘긴
+            // 채로 남은 줄을 계속 통과시켜 초과가 단조 증가한다(1480000 pi=724: 잔여
+            // 18.5px 에 6줄 통과, 초과 19.7 -> 137.0px).
+            //
+            // 쪽 단위 실측(무작위 대형 문서 60건): 소실 쪽의 연쇄는 전부 길이 3 이상
+            // (중앙 5, 최대초과 중앙 117.2px)인데, 소실 없는 쪽은 66% 가 길이 1~2
+            // (중앙 2, 최대초과 중앙 49.4px)다. 한컴 정답 36쪽을 고정하는
+            // `issue_554` hwp3-sample4 의 유일한 통과도 길이 1 이다.
+            const TAIL_FIT_CHAIN_CAP: usize = 2;
+            let mut tail_fit_chain = 0usize;
             for li in cursor_line..line_count {
                 if forced_page_break_line
                     .map(|break_line| li == break_line && li > cursor_line)
@@ -14289,6 +14300,15 @@ impl TypesetEngine {
                                 .max(0.0),
                             self.dpi,
                         );
+                    if saved_tail_vpos_fit
+                        && !hwp_authoritative
+                        && !native_hwp5_reset_tail_fits_actual_footnote_boundary
+                    {
+                        tail_fit_chain += 1;
+                        if tail_fit_chain > TAIL_FIT_CHAIN_CAP {
+                            break;
+                        }
+                    }
                     if !hwp_authoritative
                         && !saved_tail_vpos_fit
                         && !native_hwp5_reset_tail_fits_actual_footnote_boundary

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -14289,9 +14289,44 @@ impl TypesetEngine {
                                 .max(0.0),
                             self.dpi,
                         );
+                    // [#4054] 각주 안전마진(40px = 3000 HWPUNIT)은 각주 영역과 본문 꼬리가
+                    // 겹칠 위험을 상수로 막는다. 그런데 저장 LineSeg 가 이 줄을 **각주 영역
+                    // 위**에 두고 있고 흐름 커서가 그 좌표보다 위에 있으면, 겹침은 rhwp·한글
+                    // 양쪽 기준 모두에서 실측으로 배제된다. 그 경우에만 마진 몫의 초과를
+                    // 통과시킨다.
+                    //
+                    // 10k 실측(판정 가능한 이른 분할 135지점): 이 마진이 최대 원인이었다 —
+                    // 73지점·133줄·42문서. 한글은 그 자리에 줄을 두는데 rhwp 만 다음 쪽으로
+                    // 밀어내며, 쪽수 지표는 뒤쪽의 저장 좌표 신뢰가 흡수해 침묵한다.
+                    let saved_line_clears_footnote_area = st.current_footnote_height > 0.0
+                        && st.col_count == 1
+                        && overflow <= st.footnote_safety_margin
+                        && para
+                            .line_segs
+                            .get(li)
+                            .and_then(|seg| {
+                                line_seg_visible_bounds_px(
+                                    seg,
+                                    current_page_vpos_base.unwrap_or(0),
+                                    self.dpi,
+                                )
+                            })
+                            .is_some_and(|(top, bottom)| {
+                                let text_limit =
+                                    st.base_available_height() - st.current_footnote_height;
+                                // (1) 저장 좌표가 쪽 안의 값이다(기준선 정합).
+                                top >= 0.0
+                                    && top <= st.base_available_height()
+                                    // (2) 한글도 이 줄을 각주 영역 위에 뒀다.
+                                    && bottom <= text_limit
+                                    // (3) 흐름 커서가 저장 좌표보다 위에 있다 — rhwp 가 실제로
+                                    //     그리는 위치는 한글보다 높다.
+                                    && st.current_height <= top + 16.0
+                            });
                     if !hwp_authoritative
                         && !saved_tail_vpos_fit
                         && !native_hwp5_reset_tail_fits_actual_footnote_boundary
+                        && !saved_line_clears_footnote_area
                     {
                         break;
                     }


### PR DESCRIPTION
## 무엇을 고치나

각주가 있는 쪽에서 `footnote_safety_margin`(3000 HWPUNIT = **40px**)이 본문 예산을 상수로 깎아, **한글은 그 자리에 두는 줄을 rhwp 만 다음 쪽으로 밀어낸다.** 이슈 #4054.

마진의 목적은 각주 영역과 본문 꼬리의 겹침 방지다. 그런데 **저장 LineSeg 가 그 줄을 각주 영역 위에 두고 있고, 흐름 커서가 그 좌표보다 위에 있으면** 겹침은 rhwp·한글 양쪽 기준에서 실측으로 배제된다. 그 경우에만 마진 몫의 초과를 통과시킨다.

```
(1) 저장 좌표가 쪽 안의 값이다            top >= 0 && top <= base_available
(2) 한글도 이 줄을 각주 영역 위에 뒀다     bottom <= base_available - footnote_height
(3) 흐름 커서가 저장 좌표보다 위에 있다    current_height <= top + 16
```

**(3)이 핵심이다.** rhwp 가 실제로 그리는 위치가 한글보다 높으므로, 한글이 겹치지 않았다면 rhwp 도 겹치지 않는다. 마진 상수를 내리는 것과 달리 **각주 겹침 계약을 건드리지 않는다.**

## 왜 이 마진인가 — 10k 모집단 실측

줄 분할 루프의 예산 초과 지점 8,025건을 **저장 좌표 되돌아감 지점**(한글이 실제로 끊은 줄)과 대조했다. 하니스 `output/poc/task4054/`, COM 불필요.

```
이르게 끊은 지점 550건 · 밀린 줄 2,037줄 · 문서 159건
```

저장 좌표 상·하단이 모두 성립해 **판정 가능한 135지점**의 원인 분해:

| 원인 | 지점 | 잃은 줄 | 문서 |
|---|---|---|---|
| **각주 안전마진 40px** | **73 (54%)** | 133 | 42 |
| 흐름 과대(rhwp 앞섬) | 33 (24%) | 108 | 17 |
| 설명 안 됨 | 18 (13%) | 24 | 10 |
| 각주 예약 과대 | 11 (8%) | 38 | 7 |

이 축이 최대 원인이다. 저장 좌표가 예산을 넘는 폭은 중앙 35.5px·최대 52.8px 로 **대부분 40px 안**이라, 마진이 유일한 구속조건이다.

## 검증

**10k 쪽수 게이트** — 정답지는 r31 서베이(PR #4053)가 한글 COM 으로 잰 쪽수이고, 재측정은 `rhwp info` 로 COM 없이 했다.

| | devel | 패치 |
|---|---|---|
| 정답 일치 문서 | 9,519 | **9,523** (+4) |
| 쪽수 변동 | — | 12건 |
| 정답 기준 | — | **개선 5 · 회귀 1 · 중립 6** |

- `cargo nextest run --release --features native-skia` **5,293/5,293** 통과
- `cargo clippy --release --features native-skia --all-targets -- -D warnings` 통과
- `cargo fmt --check` 내용 diff 없음(CRLF 로컬 노이즈만)

## 한계 (숨기지 않음)

- **회귀 1건** — `1270000-201800036` 126→124(정답 126). 갈라지는 지점이 **각주 없는 쪽**이라 이 예외가 직접 건드린 자리가 아니라 앞선 쪽 변화의 파급이다
- 이른 분할 550건 중 판정 가능한 것은 135건뿐이다. 나머지는 저장 좌표가 없거나 기준선·쪽이 어긋나 이 계측기로 귀속할 수 없다
- 이 패치가 여는 것은 54% 코호트 전부가 아니라 세 조건을 모두 만족하는 부분집합이다

## 관련

- #4054 — 이슈 본문과 모집단 측정 3회(각주 예약 과대 → 62% 코호트 분해)
- PR #4053 — r31 10k 서베이 보고서(이 게이트의 정답지)
- PR #4041(#4024) — 같은 루프의 반대편 레버. 얹어서 재보면 회귀가 1→3건으로 늘어 **독립 PR 로 분리**했다

🤖 Generated with [Claude Code](https://claude.com/claude-code)
