### PR TITLE
test(ci): Stage 4 frontend-only canary

### DIFF
--- a/rhwp-studio/src/command/shortcut-map.ts
+++ b/rhwp-studio/src/command/shortcut-map.ts
@@ -3,19 +3,21 @@ import { detectPlatformKind, type PlatformKind } from '../engine/navigation-keym
 /** 키보드 단축키 정의 */
 export interface ShortcutDef {
   /** 키 문자 (소문자). 예: 'z', 'b', '=', '-' */
-  key: string;
+  readonly key: string;
   /** 물리 키 코드. IME 입력 중 key가 Process일 때 사용한다. 예: 'KeyJ' */
-  code?: string;
+  readonly code?: string;
   /** Ctrl (Windows) 또는 Meta (Mac) */
-  ctrl?: boolean;
-  shift?: boolean;
-  alt?: boolean;
+  readonly ctrl?: boolean;
+  readonly shift?: boolean;
+  readonly alt?: boolean;
   /** 특정 플랫폼에서만 활성화해야 하는 단축키 */
-  platform?: PlatformKind;
+  readonly platform?: PlatformKind;
 }
 
+export type ShortcutEntry = readonly [ShortcutDef, string];
+
 /** 기본 단축키 → 커맨드 ID 매핑 */
-export const defaultShortcuts: [ShortcutDef, string][] = [
+export const defaultShortcuts: readonly ShortcutEntry[] = [
   // 편집
   [{ key: 'z', ctrl: true }, 'edit:undo'],
   [{ key: 'z', ctrl: true, shift: true }, 'edit:redo'],
@@ -137,7 +139,7 @@ export const defaultShortcuts: [ShortcutDef, string][] = [
  */
 export function matchShortcut(
   e: KeyboardEvent,
-  shortcuts: [ShortcutDef, string][],
+  shortcuts: readonly ShortcutEntry[],
   platform: PlatformKind = detectPlatformKind(),
 ): string | null {
   const ctrlOrMeta = e.ctrlKey || e.metaKey;

--- a/rhwp-studio/tests/shortcut-map.test.ts
+++ b/rhwp-studio/tests/shortcut-map.test.ts
@@ -49,6 +49,15 @@ test('macOS 영문 입력 Option+G의 © 문자 값도 물리 KeyG로 찾아가�
   assert.equal(command({ key: '©', code: 'KeyH', altKey: true }, 'mac'), null);
 });
 
+test('개체 속성 P 단축키를 영문·한글·IME pending 입력에서 동일하게 매핑한다', () => {
+  assert.equal(command({ key: 'p', code: 'KeyP' }), 'format:object-properties');
+  assert.equal(command({ key: 'ㅔ', code: 'KeyP' }), 'format:object-properties');
+  assert.equal(command({ key: 'Process', code: 'KeyP' }), 'format:object-properties');
+  assert.equal(command({ key: 'p', code: 'KeyP', ctrlKey: true }), 'file:print');
+  assert.equal(command({ key: 'p', code: 'KeyP', shiftKey: true }), null);
+  assert.equal(command({ key: 'Process', code: 'KeyO' }), null);
+});
+
 test('표 줄/칸 추가·지우기 단축키는 대화상자 명령으로 매핑한다', () => {
   assert.equal(command({ key: 'Enter', altKey: true }, 'mac'), 'table:insert-row-col');
   assert.equal(command({ key: 'enter', altKey: true }, 'mac'), 'table:insert-row-col');


### PR DESCRIPTION
## 요약

> 이 PR은 #3790 Stage 4의 CI canary이며 **merge 대상이 아닙니다.** selective 측정 근거를 남긴 뒤 close합니다.

- Studio 단축키 정의와 mapping entry를 TypeScript 읽기 전용 계약으로 좁힙니다.
- 개체 속성 `P` 단축키를 영문·한글·IME pending 입력에서 고정하는 회귀를 추가합니다.
- [#4032](https://github.com/edwardkim/rhwp/pull/4032)에서 활성화한 #3790 Stage 4의 `rust_required`/`native_skia_required` 조건화를 실제 frontend-only 변경으로 검증합니다.

Refs #3790

## 변경 의도

측정 전용 no-op 대신 [PR #3951](https://github.com/edwardkim/rhwp/pull/3951) Stage 3 canary와 **동일한 변경 형태**를 사용해 두 단계의 표본을 같은 조건으로 비교합니다. 렌더러, WASM, package·asset 경계와 Rust 소스는 변경하지 않습니다.

## classifier v2 로컬 예상값

`node scripts/ci-impact-classifier.cjs --input <이 PR의 파일 목록>` 실행 결과입니다.

| 출력 | 값 |
| --- | --- |
| `classification_status` | `classified` |
| `classifier_version` | `2` |
| `frontend_mode` | `unit` |
| `render_required` | `false` |
| `rust_required` | `false` |
| `native_skia_required` | `false` |
| `codeql_languages` | `javascript-typescript` |
| `reason` | `classified:studio-unit` |

## Stage 4 기대값

| job | 기대 결과 | Stage 3 canary(#3951) 대비 |
| --- | --- | --- |
| CI preflight | success, `classified:studio-unit` | 동일 |
| Frontend unit gates | **success** | 동일 |
| Frontend package gates | skipped | 동일 |
| Render Diff preflight | success, `render_required=false` | 동일 |
| Canvas visual diff | skipped | 동일 |
| Lint (fmt, clippy, WASM check) | **skipped** | #3951에서는 실행 — Stage 4 신규 |
| build-test-archive-a / -b / -slow | **skipped** | #3951에서는 실행 — Stage 4 신규 |
| test-regular-shard-1 / -2 / -3, test-slow-shard | **skipped** | #3951에서는 실행 — Stage 4 신규 |
| Native Skia tests | **skipped** | #3951에서는 실행 — Stage 4 신규 |
| Build & Test aggregate | success | 동일 |
| CodeQL Analyze (3개 언어) | 실행 | 언어 조건화는 Stage 5 범위라 변동 없음 |

`Build & Test` aggregate가 위 `success|skipped` 진리표를 그대로 수용하면 Stage 4 조건화가 정상 동작한 것입니다. 하나라도 어긋나면 aggregate가 실패해야 합니다.

## 로컬 검증

- `npx tsc --noEmit` — 이 변경으로 인한 신규 오류 없음. `@wasm/rhwp.js` 미해결 3건은 WASM 산출물 미빌드로 인한 **기존** 오류이며 변경 전 `devel`에서도 동일하게 재현했습니다.
- `npm test` (rhwp-studio) — 764 passed / 0 failed. 신규 회귀 `개체 속성 P 단축키를 영문·한글·IME pending 입력에서 동일하게 매핑한다` 통과 확인.
- `node scripts/ci-impact-classifier.cjs` — 위 표의 판정값 확인.
- `git diff --check` — 통과.

## 측정 뒤 처리

실행·skip job과 소요시간, runner 사용량을 [#3790](https://github.com/edwardkim/rhwp/issues/3790)에 기록한 뒤 이 PR은 merge하지 않고 close합니다. `main` 반영도 필요하지 않습니다.
