### PR TITLE
docs(task): #3790 Stage 4 merge와 canary 실측 기록

### DIFF
--- a/mydocs/plans/task_m100_3790.md
+++ b/mydocs/plans/task_m100_3790.md
@@ -7,10 +7,11 @@
   `issue-3790-stage4-rust-native`
 - **분기 기준**: Stage 1 `upstream/devel` `3d4863a0d531`, Stage 2
   `upstream/devel` `91f5131815dc`
-- **최신 동기화 기준**: `upstream/devel` `d3fb9de7c0c0` (#4033 포함)
-- **기록 시각**: 2026-08-05 KST
-- **절차 상태**: Stage 3 merge·canary PR #3951 측정 완료, Stage 4 draft PR #4032 review F1–F6
-  보정 및 current-base full CI 통과
+- **최신 동기화 기준**: `upstream/devel` `8d48a4c07fad` (#4032 merge 포함)
+- **기록 시각**: 2026-08-06 KST
+- **절차 상태**: Stage 3 merge·canary PR #3951 측정 완료. Stage 4 PR #4032를 merge commit
+  `8d48a4c07`로 merge하고, canary PR #4078로 CI workflow runner time 94.2% 감소를 실측한 뒤 close.
+  다음은 cache 기준선 대조와 Stage 5
 
 ## 1. 문제
 
@@ -94,16 +95,25 @@ classifier는 다음 값을 하나의 판정으로 만든다.
    각 builder/worker와 Native Skia의 `success|skipped` 조합을 영향축별 진리표로 검증한다. Native Skia
    job이 직접 실행하는 두 Rust 통합 테스트와 default-feature 테스트가 직접 소비하는
    `ttfs/**`, `tests/fixtures/fonts/**`, 표적 HWPX sample은 Rust 경계로 고정한다. 누락된 기존
-   `issue_2293_chart_png_text` Native target은 #4040으로 분리해 추적한다.
-8. **cache 회귀 확인**: #3684를 완료한 #3810의 정리 직후 기준선 4.73GB와 Stage 4 이후 다음 cache sweep
+   `issue_2293_chart_png_text` Native target은 #4040으로 분리해 추적한다. PR #4032를 merge commit
+   `8d48a4c07`로 반영했다.
+8. **Stage 4 canary**: #3951과 같은 2파일 frontend-only 변경으로 PR #4078을 만들어 Stage 4만이 차이가
+   되도록 대조했다. Lint 218초, archive a/b/slow 387·239·324초, shard 1/2/3 202·180·133초, slow shard
+   228초, Native Skia 368초 — 새로 생략된 9개 job의 직접 runner time 2,279초를 확인했다. CI workflow
+   runner time은 2,355초에서 137초로 2,218초(94.2%) 줄었고, CI·CodeQL·Render Diff 합계는 3,238초에서
+   939초로 2,299초(71.0%) 줄었으며 wall clock은 857초에서 575초가 됐다. `Build & Test` aggregate가
+   해당 `success|skipped` 조합을 수용해 진리표도 검증됐다. Frontend unit gates의 59초→127초 증가는
+   Studio 테스트 증가와 runner 편차이므로 절감 계산에서 분리한다. 측정 뒤 #4078은 merge하지 않고
+   close했다.
+9. **cache 회귀 확인**: #3684를 완료한 #3810의 정리 직후 기준선 4.73GB와 Stage 4 이후 다음 cache sweep
    직후 총량을 같은 시점 조건으로 대조한다. 기준선 회귀가 없으면 별도 대기 없이 다음 단계로 진행한다.
-9. **Stage 5 — CodeQL 언어 분리**: 고정된 4.73GB 기준선 회귀 여부를 확인하며 workflow별 언어 축을
+10. **Stage 5 — CodeQL 언어 분리**: 고정된 4.73GB 기준선 회귀 여부를 확인하며 workflow별 언어 축을
    활성화한다.
-10. **후속 enforcement**: controller를 Stage 3~5 진리표에 맞게 축소하고 정상 릴리즈로 main에 등록한 뒤,
+11. **후속 enforcement**: controller를 Stage 3~5 진리표에 맞게 축소하고 정상 릴리즈로 main에 등록한 뒤,
     `workflow_run` audit와 repository admin의 required `CI Impact Policy` 적용 여부를 검증한다.
-11. **Stage 6 — artifact retry**: 논리 label `slow/1/2/3`별 test archive, archive expected count와
+12. **Stage 6 — artifact retry**: 논리 label `slow/1/2/3`별 test archive, archive expected count와
    worker run count의 primary/retry 중 하나 이상을 aggregate에서 인정한다.
-12. **Stage 7 — draft 경량화**: draft에는 영향별 경량 검증을 수행하고 `ready_for_review`에서 최종 검증을
+13. **Stage 7 — draft 경량화**: draft에는 영향별 경량 검증을 수행하고 `ready_for_review`에서 최종 검증을
    보장한다.
 
 각 활성화 단계는 별도 PR로 진행한다. 자연 발생 frontend 표본 5건을 추가로 기다리지 않고 historical

--- a/mydocs/pr/archives/pr_4079_review.md
+++ b/mydocs/pr/archives/pr_4079_review.md
@@ -1,0 +1,90 @@
+---
+kind: pr_review
+status: local-validation-passed
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-06
+---
+
+# PR #4079 검토 — #3790 Stage 4 merge와 canary 실측 기록
+
+## 결론
+
+**문서 전용 merge 후보.** PR #4032 merge 사실과 canary PR #4078의 실측치를 #3790 계획·작업 문서에
+반영한다. 변경이 전부 `mydocs/**`라 review-only fast-pass B 경로
+(`all-review-only-no-code-impact`) 대상이며, source·test·workflow·fixture를 건드리지 않는다.
+
+## 검토 경로
+
+```text
+base route: collaborator_self_merge.md
+modifiers: review_only_fast_pass.md (B 경로), post_merge.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+                  collaborator_self_merge.md, review_only_fast_pass.md,
+                  post_merge.md, local_validation.md
+base: 8d48a4c07fad6bcccebbc2adddef4685456bb313
+record commit: b9219fd1f
+```
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4079](https://github.com/edwardkim/rhwp/pull/4079) |
+| 작성자 | `postmelee` (collaborator self-merge) |
+| 대상 / head | `devel` / `task_m100_3790_canary_record` (upstream branch) |
+| 관련 PR | [#4032](https://github.com/edwardkim/rhwp/pull/4032) merge, [#4078](https://github.com/edwardkim/rhwp/pull/4078) canary close |
+| 관련 issue | [#3790](https://github.com/edwardkim/rhwp/issues/3790) |
+| metadata | label·milestone·assignee·review request 없음 |
+
+## 변경 범위
+
+- `mydocs/plans/task_m100_3790.md` — Stage 4 merge commit 기록, 실행 계획에 **Stage 4 canary** 항목을
+  신설하고 이후 항목 번호를 재정렬, 절차 상태와 최신 동기화 기준 갱신.
+- `mydocs/working/task_m100_3790_stage4.md` — review-only fast-pass 결과, devel push full lane 결과,
+  canary job별 대조표와 workflow 합계표, Stage 5 관찰 추가.
+- `mydocs/pr/archives/pr_4079_review.md` — 이 문서.
+
+## 기록한 실측 근거
+
+| workflow | #3951 runner | #4078 runner | #3951 wall | #4078 wall |
+| --- | --- | --- | --- | --- |
+| CI | 2,355s | 137s | 857s | 148s |
+| CodeQL | 875s | 794s | 655s | 575s |
+| Render Diff | 8s | 8s | 12s | 12s |
+| 합계 | 3,238s | 939s | 857s | 575s |
+
+Stage 4가 새로 생략한 9개 job의 직접 runner time은 2,279초다. CI workflow runner time −2,218초(94.2%),
+세 workflow 합계 −2,299초(71.0%). Frontend unit gates의 59초→127초 증가와 CodeQL 편차는 조건화 결과가
+아니므로 절감 계산에서 분리해 기록했다.
+
+두 canary는 같은 2파일 frontend-only 변경(`rhwp-studio/src/command/shortcut-map.ts`,
+`rhwp-studio/tests/shortcut-map.test.ts`)을 사용해 Stage 4만이 차이가 되도록 통제했다.
+
+## 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| `git diff --check` | 통과 |
+| 변경 파일 경로 | 전부 `mydocs/**` — fast-pass 허용 범위 |
+| 실측 원본 대조 | Actions run 30902591087·30902590876·30902590721 (#3951), 31028405199·31028404752·31028404689 (#4078) |
+| Stage 4 merge commit 확인 | `8d48a4c07`가 `upstream/devel`에 포함됨 |
+
+Cargo·npm 게이트는 적용하지 않았다. `local_validation.md` 4.3의 "mydocs만 변경" 범위이며 PR 고유 변경이
+문서뿐이다. canary의 Studio 로컬 검증(`npm test` 764 passed / 0 failed, `tsc --noEmit` 신규 오류 없음)은
+#4078에서 이미 수행했고 그 결과만 인용한다.
+
+## 시각·fixture 판단
+
+시각 증적 없음. renderer·layout·paint·pagination·golden 출력과 무관한 문서 변경이다.
+
+## 잔여 위험과 후속
+
+- 이 PR은 완료된 작업의 기록이므로 merge 뒤 추가 문서 PR을 만들지 않는다.
+- #3790은 cache 기준선 대조와 Stage 5–7이 남아 close하지 않는다.
+- #4040 Native target 누락과 #4029 cold release archive timeout은 이 PR과 분리해 추적한다.
+
+## 최종 권고
+
+최신 head의 preflight fast-pass와 required `Build & Test` aggregate가 성공하면 collaborator
+self-merge한다. merge 뒤에는 `post_merge.md`에 따라 devel sync와 branch·worktree 정리만 수행하고
+issue comment와 오늘할일은 반복하지 않는다.

--- a/mydocs/working/task_m100_3790_stage4.md
+++ b/mydocs/working/task_m100_3790_stage4.md
@@ -5,9 +5,9 @@
 - **최신 동기화 기준**: `upstream/devel` `d3fb9de7c0c0648e3d8126c25467e2c78a054337`
 - **첫 devel merge head**: `b0be8673149bbd00ebb67f6d5e62b70025cfa612`
 - **최종 code head**: `5eeab15fd291b2b4b27d3b8a77498fcc0ca5723b`
-- **상태**: PR #4032 review F1–F6 보정 완료, 최종 code head full CI 통과, ready 전환과 review-only
-  기록 push 단계
-- **기록일**: 2026-08-05 KST
+- **merge commit**: `8d48a4c07fad6bcccebbc2adddef4685456bb313`
+- **상태**: 완료. PR #4032 merge, canary PR #4078 실측 완료
+- **기록일**: 2026-08-05 KST, canary 실측 2026-08-06 KST
 
 ## 선행 canary
 
@@ -84,12 +84,53 @@ full lane에서 확인했다.
 - 최종 aggregate: shard `3714+753+784+1=5252`, expected runnable `5252` 일치, preflight
   `no-trailing-review-only-commits`로 full lane 진입, `frontend_mode=package`로 Frontend unit gates만 skip
 
+- review-only trailing commit `3a5c6587c`: preflight가 `fast_pass=true`,
+  `reason=build-and-test-green:success`, `candidate_sha=5eeab15fd`로 `5eeab15fd`의 녹색
+  `Build & Test`를 재사용했다. heavy worker 전량 skip, CI 89초·CodeQL 70초·Render Diff 22초.
+- merge 뒤 devel push full lane(`8d48a4c07`): CI 31026511582, CodeQL 31026511634 통과.
+
+## canary 실측 — PR #4078
+
+Stage 3 canary [PR #3951](https://github.com/edwardkim/rhwp/pull/3951)과 같은 2파일 frontend-only
+변경(`rhwp-studio/src/command/shortcut-map.ts`, `rhwp-studio/tests/shortcut-map.test.ts`)을 써서
+Stage 4만이 차이가 되도록 대조했다. canary head는 `eac12e9e3`, base는 `8d48a4c07`다.
+classifier v2는 `frontend_mode=unit`, `render_required=false`, `rust_required=false`,
+`native_skia_required=false`, `reason=classified:studio-unit`을 판정했다.
+
+| job | #3951 Stage 3 | #4078 Stage 4 |
+| --- | --- | --- |
+| CI preflight | 9s | 7s |
+| Frontend unit gates | 59s | 127s |
+| Frontend package gates | skipped | skipped |
+| Lint (fmt, clippy, WASM check) | 218s | skipped |
+| build-test-archive-a / -b / -slow | 387s / 239s / 324s | 모두 skipped |
+| test-regular-shard-1 / -2 / -3 | 202s / 180s / 133s | 모두 skipped |
+| test-slow-shard | 228s | skipped |
+| Native Skia tests | 368s | skipped |
+| WASM Build | skipped | skipped |
+| Build & Test aggregate | 8s success | 3s success |
+
+| workflow | #3951 runner | #4078 runner | #3951 wall | #4078 wall |
+| --- | --- | --- | --- | --- |
+| CI | 2,355s | 137s | 857s | 148s |
+| CodeQL | 875s | 794s | 655s | 575s |
+| Render Diff | 8s | 8s | 12s | 12s |
+| 합계 | 3,238s | 939s | 857s | 575s |
+
+Stage 4가 새로 생략한 9개 job의 직접 runner time은 2,279초다. CI workflow runner time은 2,218초
+(94.2%), 세 workflow 합계는 2,299초(71.0%) 줄었고 wall clock은 857초에서 575초가 됐다.
+`Build & Test` aggregate가 이 `success|skipped` 조합을 수용해 Stage 4 진리표도 실제 selective run에서
+검증됐다.
+
+Frontend unit gates의 59초→127초 증가는 조건화 결과가 아니라 Studio 테스트가 764건으로 늘어난 영향과
+runner 편차이므로 절감 계산에서 분리한다. CodeQL 차이(875초→794초)도 runner 편차이며, 언어 조건화는
+Stage 5 범위라 3개 언어를 그대로 분석했다.
+
+측정 뒤 #4078은 merge하지 않고 close했고 branch·worktree를 정리했다.
+
 ## 다음 단계
 
-1. review-only trailing commit push와 ready 전환 뒤 preflight fast-pass와 required `Build & Test`
-   성공을 확인한다. 기대 candidate는 `5eeab15fd`다.
-2. 사용자가 CI 통과 후 요청하면 collaborator self-merge 절차를 진행한다.
-3. merge 뒤 frontend-only canary에서 Rust lint·세 builder·네 worker·Native Skia가 모두 `skipped`되고
-   `Build & Test` aggregate가 성공하는지 실측한다.
-4. #3810 직후 4.73GB cache 기준선과 다음 cache sweep 직후 총량을 대조한 뒤 Stage 5 CodeQL 언어
-   조건화로 진행한다.
+1. #3810 직후 4.73GB cache 기준선과 다음 cache sweep 직후 총량을 대조한다.
+2. Stage 5 CodeQL 언어 조건화로 진행한다. Stage 4 이후 frontend-only PR의 critical path가 CI에서
+   CodeQL로 옮겨갔고, wall clock 575초 중 `Analyze (rust)` 단독이 563초를 차지한다. 언어 조건화가
+   적용되면 `Analyze (javascript-typescript)` 수준(약 140초)까지 내려갈 여지가 있다.


### PR DESCRIPTION
## 요약

[#3790](https://github.com/edwardkim/rhwp/issues/3790) Stage 4의 merge 사실과 canary 실측치를 계획·작업 문서에 반영합니다. 문서 전용 PR이며 source·test·workflow 변경은 없습니다.

- `mydocs/plans/task_m100_3790.md` — Stage 4 merge commit 기록, 실행 계획에 **Stage 4 canary** 항목 신설(이후 번호 재정렬), 절차 상태·최신 동기화 기준 갱신
- `mydocs/working/task_m100_3790_stage4.md` — review-only fast-pass 결과, devel push full lane 결과, canary 실측 job별 대조표와 workflow 합계표, Stage 5 관찰 추가

## 근거

| 항목 | 값 |
| --- | --- |
| Stage 4 merge commit | `8d48a4c07fad6bcccebbc2adddef4685456bb313` ([PR #4032](https://github.com/edwardkim/rhwp/pull/4032)) |
| canary PR | [#4078](https://github.com/edwardkim/rhwp/pull/4078) (측정 뒤 close, merge 안 함) |
| canary head / base | `eac12e9e3` / `8d48a4c07` |
| 대조 기준 | [PR #3951](https://github.com/edwardkim/rhwp/pull/3951) Stage 3 canary — 같은 2파일 frontend-only 변경 |

| workflow | #3951 runner | #4078 runner | #3951 wall | #4078 wall |
| --- | --- | --- | --- | --- |
| CI | 2,355s | 137s | 857s | 148s |
| CodeQL | 875s | 794s | 655s | 575s |
| Render Diff | 8s | 8s | 12s | 12s |
| 합계 | 3,238s | **939s** | 857s | **575s** |

CI workflow runner time −2,218초(94.2%), 세 workflow 합계 −2,299초(71.0%). 새로 생략된 9개 job의 직접 runner time은 2,279초입니다.

Frontend unit gates의 59초→127초 증가와 CodeQL 편차는 조건화 결과가 아니므로 절감 계산에서 분리해 기록했습니다.

## 검증

- `git diff --check` 통과
- 변경 파일이 전부 `mydocs/**` — [review-only fast-pass](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/pr_review/review_only_fast_pass.md) B 경로(`all-review-only-no-code-impact`) 대상
- 실측 원본은 [#3790 코멘트](https://github.com/edwardkim/rhwp/issues/3790#issuecomment-5194963125)와 각 Actions run에 남아 있습니다

Refs #3790
