### PR TITLE
docs(task): #3790 cache 기준선 대조 결과 — 회귀 있음, Stage 4 무관

### DIFF
--- a/mydocs/plans/task_m100_3790.md
+++ b/mydocs/plans/task_m100_3790.md
@@ -105,10 +105,27 @@ classifier는 다음 값을 하나의 판정으로 만든다.
    해당 `success|skipped` 조합을 수용해 진리표도 검증됐다. Frontend unit gates의 59초→127초 증가는
    Studio 테스트 증가와 runner 편차이므로 절감 계산에서 분리한다. 측정 뒤 #4078은 merge하지 않고
    close했다.
-9. **cache 회귀 확인**: #3684를 완료한 #3810의 정리 직후 기준선 4.73GB와 Stage 4 이후 다음 cache sweep
-   직후 총량을 같은 시점 조건으로 대조한다. 기준선 회귀가 없으면 별도 대기 없이 다음 단계로 진행한다.
-10. **Stage 5 — CodeQL 언어 분리**: 고정된 4.73GB 기준선 회귀 여부를 확인하며 workflow별 언어 축을
-   활성화한다.
+9. **cache 회귀 확인 — 완료, 회귀 있음(Stage 4 무관)**: #3810 정리 직후 기준선 4.73GB(24개)와 Stage 4
+   이후 스윕 직후 총량을 같은 시점 조건으로 대조했다. 스윕 직후 총량은 4.73GB → 5.85GB(08-02) →
+   7.16GB(08-03) → 8.46GB(08-04) → **8.84GB(08-05, 50개)** 로, 기준선 대비 +4.11GB(+87%)이며 무료 한도
+   10GB의 88%다. 마지막 값은 비파괴 `workflow_dispatch dry_run=true` 실행
+   [31030157435](https://github.com/edwardkim/rhwp/actions/runs/31030157435)의 예상치다.
+
+   회귀는 Stage 4가 원인이 아니다. Stage 4는 08-05 16:42 UTC merge인데 위 추세는 그 전에 이미
+   완성돼 있었고, 방향으로는 오히려 반대다 — frontend-only PR에서 Rust lint·세 builder·네 worker·
+   Native Skia가 생략되므로 그 job들이 만들던 캐시 세대도 생성되지 않는다.
+
+   세대 상한도 정상이다. (그룹, ref) 쌍 42개 중 2세대를 초과한 쌍은 3개뿐이고 전부 마지막 스윕 이후
+   생성분이다. 실제 원인은 ① 쌍 수 증가로 KEEP=2의 하한 자체가 올라간 것(`refs/heads/devel` 한 ref만
+   19개 5.84GB로 기준선 전체 초과, 열린 PR ref는 스윕에서 보호), ② 삭제된 브랜치의 고아 캐시가
+   (그룹, ref)별 최신 2세대 규칙 때문에 영구히 정리 대상이 아닌 것(현재 약 0.53GB)이다.
+
+   대응은 [#4080](https://github.com/edwardkim/rhwp/issues/4080)으로 분리했다. 4.73GB는 쌍 수가 적던
+   시점의 값이라 더는 유효한 목표가 아니므로 Stage 5의 판단 기준으로 쓰지 않는다.
+10. **Stage 5 — CodeQL 언어 분리**: workflow별 언어 축을 활성화한다. cache 총량은 #4080의 새 기준선을
+   따르고 4.73GB를 게이트로 쓰지 않는다. Stage 4 canary에서 frontend-only PR의 critical path가 CI에서
+   CodeQL로 옮겨갔고 wall clock 575초 중 `Analyze (rust)` 단독이 563초이므로, 언어 조건화의 기대
+   효과가 가장 큰 구간이다.
 11. **후속 enforcement**: controller를 Stage 3~5 진리표에 맞게 축소하고 정상 릴리즈로 main에 등록한 뒤,
     `workflow_run` audit와 repository admin의 required `CI Impact Policy` 적용 여부를 검증한다.
 12. **Stage 6 — artifact retry**: 논리 label `slow/1/2/3`별 test archive, archive expected count와

--- a/mydocs/plans/task_m100_3790_impl.md
+++ b/mydocs/plans/task_m100_3790_impl.md
@@ -102,7 +102,9 @@ Stage 3 merge 직후 frontend-only canary PR #3951에서 unit/package/render 진
 4. Rust 변경 중 render 비영향 경로는 Native Skia를 생략한다.
 5. Rust formatter·passthrough invalidation·IR baseline 회귀가 필요한 경로는 기존 전체 검증을 유지한다.
 6. #3684를 완료한 #3810의 정리 직후 cache 기준선 4.73GB와 조건화 이후 다음 sweep 직후 총량을
-   같은 시점 조건으로 대조한다.
+   같은 시점 조건으로 대조한다. **수행 결과**: 스윕 직후 8.84GB(50개)로 기준선 대비 +87% 회귀했으나
+   Stage 4가 원인이 아니다. 추세가 Stage 4 merge 이전에 이미 완성됐고, 원인은 (그룹, ref) 쌍 수 증가와
+   삭제된 브랜치의 고아 캐시다. 대응은 [#4080](https://github.com/edwardkim/rhwp/issues/4080)으로 분리했다.
 7. Native Skia가 직접 실행하는 `tests/issue_2225_missing_picture_placeholder.rs`와
    `tests/render_p37_direct_pdf_export.rs`는 일반 Rust 비렌더 경로와 달리 `native_skia_required=true`로
    고정한다.
@@ -117,7 +119,8 @@ Stage 3 merge 직후 frontend-only canary PR #3951에서 unit/package/render 진
 
 ## Stage 5 이후
 
-- #3810의 4.73GB cache 기준선 회귀 여부를 확인하며 CodeQL 언어별 matrix를 활성화한다.
+- CodeQL 언어별 matrix를 활성화한다. cache 총량은 #4080의 새 기준선을 따르고 더는 유효하지 않은
+  4.73GB를 게이트로 쓰지 않는다.
 - Stage 3 merge 직후 첫 canary, Stage 5 merge 뒤 두 번째 canary에서 동일 SHA의 수동 full/selective를
   대조한다.
 - default-branch controller는 Stage 3~5 진리표가 확정된 뒤 축소 구현하고 정상 릴리즈로 main에 등록한다.

--- a/mydocs/pr/archives/pr_4081_review.md
+++ b/mydocs/pr/archives/pr_4081_review.md
@@ -1,0 +1,99 @@
+---
+kind: pr_review
+status: local-validation-passed
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-06
+---
+
+# PR #4081 검토 — #3790 cache 기준선 대조 결과
+
+## 결론
+
+**문서 전용 merge 후보.** #3790 실행 계획 9번 "cache 회귀 확인"을 수행하고 결과를 계획·구현·작업
+문서에 확정한다. 변경이 전부 `mydocs/**`라 review-only fast-pass B 경로
+(`all-review-only-no-code-impact`) 대상이다.
+
+판정은 **기준선 회귀 있음, 단 Stage 4 무관**이다. 회귀 대응은 [#4080](https://github.com/edwardkim/rhwp/issues/4080)으로
+분리했고 Stage 5의 게이트에서 4.73GB를 제거했다.
+
+## 검토 경로
+
+```text
+base route: collaborator_self_merge.md
+modifiers: review_only_fast_pass.md (B 경로), post_merge.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+                  collaborator_self_merge.md, review_only_fast_pass.md,
+                  post_merge.md, local_validation.md
+base: 202c18e91f3f8384902d6aba2076c54d0be7bc76
+record commit: a7d805b79
+```
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4081](https://github.com/edwardkim/rhwp/pull/4081) |
+| 작성자 | `postmelee` (collaborator self-merge) |
+| 대상 / head | `devel` / `task_m100_3790_cache_record` (upstream branch) |
+| 관련 issue | [#3790](https://github.com/edwardkim/rhwp/issues/3790), [#4080](https://github.com/edwardkim/rhwp/issues/4080), [#3684](https://github.com/edwardkim/rhwp/issues/3684) |
+| metadata | label·milestone·assignee·review request 없음 |
+
+## 변경 범위
+
+- `mydocs/plans/task_m100_3790.md` — 9번 항목을 수행 결과로 확정하고, 10번 Stage 5의 판단 기준에서
+  4.73GB 게이트를 제거한다.
+- `mydocs/plans/task_m100_3790_impl.md` — 구현 항목 6에 수행 결과를 붙이고 "Stage 5 이후"의 cache
+  기준을 #4080으로 넘긴다.
+- `mydocs/working/task_m100_3790_stage4.md` — 스윕 시계열표와 원인 분석 절을 추가하고 완료된 항목을
+  다음 단계에서 뺀다.
+- `mydocs/pr/archives/pr_4081_review.md` — 이 문서.
+
+## 기록한 대조 결과
+
+| 시점 (UTC) | 정리 전 | 정리 대상 | 정리 후 |
+| --- | --- | --- | --- |
+| #3810 기준선 08-02 14:43 수동 | 42개 / 10.13GB | 18개 / 5.40GB | 24개 / 4.73GB |
+| 08-02 19:39 cron | 31개 / 5.91GB | 1개 / 0.06GB | 30개 / 5.85GB |
+| 08-03 20:03 cron | 50개 / 10.24GB | 10개 / 3.08GB | 40개 / 7.16GB |
+| 08-04 20:03 cron | 50개 / 8.64GB | 1개 / 0.18GB | 49개 / 8.46GB |
+| 08-05 17:28 dry-run | 53개 / 10.01GB | 3개 / 1.17GB | 50개 / 8.84GB |
+
+기준선 대비 +4.11GB(+87%), 무료 한도 10GB의 88%다.
+
+Stage 4 귀속을 기각한 근거는 세 가지다. ① Stage 4 merge는 08-05 16:42 UTC인데 회귀 추세는 그 전에
+완성됐다. ② Stage 4는 frontend-only PR에서 Rust lane job을 생략하므로 캐시 생성을 오히려 줄이며,
+canary #4078에서 해당 job이 실행되지 않았음을 확인했다. ③ 세대 상한이 정상 동작 중이다 —
+(그룹, ref) 쌍 42개 중 2세대 초과는 3개뿐이고 전부 마지막 스윕 이후 생성분이다.
+
+실제 원인은 쌍 수 증가로 KEEP=2의 하한이 올라간 것(`refs/heads/devel` 한 ref만 19개 5.84GB로 기준선
+전체 초과)과 삭제된 브랜치의 고아 캐시가 (그룹, ref)별 최신 2세대 규칙 때문에 영구히 정리 대상이
+아닌 것(약 0.53GB)이다.
+
+## 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| `git diff --check` | 통과 |
+| 변경 파일 경로 | 전부 `mydocs/**` — fast-pass 허용 범위 |
+| 스윕 시계열 원본 | run 30763873837·30848508775·30946087506 로그, #3684 보고서 |
+| Stage 4 이후 값 | dry-run run [31030157435](https://github.com/edwardkim/rhwp/actions/runs/31030157435), `dry_run=true`로 삭제 없음 |
+| 캐시 인벤토리 | `GET /repos/edwardkim/rhwp/actions/caches` 페이지네이션 전량, 53개 10.01GB |
+
+Cargo·npm 게이트는 적용하지 않았다. `local_validation.md` 4.3의 "mydocs만 변경" 범위다.
+
+## 시각·fixture 판단
+
+시각 증적 없음. renderer·layout·paint·pagination·golden 출력과 무관한 문서 변경이다.
+
+## 잔여 위험과 후속
+
+- 실제 cron 스윕이 dry-run 예상치 8.84GB를 확정하는지는 다음 스케줄 실행에서 확인한다. 예상치는
+  `before - staleBytes` 계산값이므로 동시 생성분에 따라 소폭 달라질 수 있다.
+- 캐시 총량이 한도의 88%라 #4080은 조기 처리 대상이다.
+- #3790은 Stage 5–7과 post-main enforcement가 남아 close하지 않는다.
+
+## 최종 권고
+
+최신 head의 preflight fast-pass와 required `Build & Test` aggregate가 성공하면 collaborator
+self-merge한다. merge 뒤에는 `post_merge.md`에 따라 devel sync와 branch·worktree 정리만 수행하고
+issue comment와 오늘할일은 반복하지 않는다.

--- a/mydocs/working/task_m100_3790_stage4.md
+++ b/mydocs/working/task_m100_3790_stage4.md
@@ -128,9 +128,30 @@ Stage 5 범위라 3개 언어를 그대로 분석했다.
 
 측정 뒤 #4078은 merge하지 않고 close했고 branch·worktree를 정리했다.
 
+## cache 기준선 대조 — 완료
+
+스윕 직후 동일 조건으로 대조했다.
+
+| 시점 (UTC) | 정리 전 | 정리 대상 | 정리 후 |
+| --- | --- | --- | --- |
+| #3810 기준선 08-02 14:43 수동 | 42개 / 10.13GB | 18개 / 5.40GB | 24개 / 4.73GB |
+| 08-02 19:39 cron | 31개 / 5.91GB | 1개 / 0.06GB | 30개 / 5.85GB |
+| 08-03 20:03 cron | 50개 / 10.24GB | 10개 / 3.08GB | 40개 / 7.16GB |
+| 08-04 20:03 cron | 50개 / 8.64GB | 1개 / 0.18GB | 49개 / 8.46GB |
+| 08-05 17:28 dry-run | 53개 / 10.01GB | 3개 / 1.17GB | 50개 / 8.84GB |
+
+기준선 대비 +4.11GB(+87%), 무료 한도 10GB의 88%다. 마지막 값은 비파괴
+`workflow_dispatch dry_run=true` 실행 [31030157435](https://github.com/edwardkim/rhwp/actions/runs/31030157435)의
+예상치이며 삭제는 일어나지 않았다.
+
+Stage 4는 원인이 아니다. Stage 4 merge는 08-05 16:42 UTC인데 회귀 추세는 그 전에 완성돼 있었고,
+Stage 4는 오히려 frontend-only PR에서 Rust lane 캐시 생성을 줄인다. 세대 상한도 정상으로,
+(그룹, ref) 쌍 42개 중 2세대 초과는 3개뿐이며 전부 마지막 스윕 이후 생성분이다. 실제 원인은
+쌍 수 증가로 KEEP=2의 하한이 올라간 것과 삭제된 브랜치의 고아 캐시(약 0.53GB)다. 대응은
+[#4080](https://github.com/edwardkim/rhwp/issues/4080)으로 분리했다.
+
 ## 다음 단계
 
-1. #3810 직후 4.73GB cache 기준선과 다음 cache sweep 직후 총량을 대조한다.
-2. Stage 5 CodeQL 언어 조건화로 진행한다. Stage 4 이후 frontend-only PR의 critical path가 CI에서
+1. Stage 5 CodeQL 언어 조건화로 진행한다. Stage 4 이후 frontend-only PR의 critical path가 CI에서
    CodeQL로 옮겨갔고, wall clock 575초 중 `Analyze (rust)` 단독이 563초를 차지한다. 언어 조건화가
    적용되면 `Analyze (javascript-typescript)` 수준(약 140초)까지 내려갈 여지가 있다.


### PR DESCRIPTION
## 요약

[#3790](https://github.com/edwardkim/rhwp/issues/3790) 실행 계획 9번 "cache 회귀 확인"의 수행 결과를 반영합니다. 문서 전용 PR이며 source·test·workflow 변경은 없습니다.

- `mydocs/plans/task_m100_3790.md` — 9번 항목을 수행 결과로 확정, 10번 Stage 5의 판단 기준에서 4.73GB 게이트 제거
- `mydocs/plans/task_m100_3790_impl.md` — 구현 항목 6의 수행 결과 추가, "Stage 5 이후"의 cache 기준 갱신
- `mydocs/working/task_m100_3790_stage4.md` — 스윕 시계열표와 원인 분석 절 추가, 다음 단계에서 완료 항목 제거

## 결론

**기준선 회귀 있음. 원인은 Stage 4가 아닙니다.**

| 시점 (UTC) | 정리 전 | 정리 대상 | 정리 후 |
| --- | --- | --- | --- |
| #3810 기준선 08-02 14:43 수동 | 42개 / 10.13GB | 18개 / 5.40GB | **24개 / 4.73GB** |
| 08-02 19:39 cron | 31개 / 5.91GB | 1개 / 0.06GB | 30개 / 5.85GB |
| 08-03 20:03 cron | 50개 / 10.24GB | 10개 / 3.08GB | 40개 / 7.16GB |
| 08-04 20:03 cron | 50개 / 8.64GB | 1개 / 0.18GB | 49개 / 8.46GB |
| 08-05 17:28 dry-run | 53개 / 10.01GB | 3개 / 1.17GB | **50개 / 8.84GB** |

기준선 대비 +4.11GB(+87%), 무료 한도 10GB의 88%입니다.

- Stage 4 merge는 08-05 16:42 UTC인데 회귀 추세는 그 전에 이미 완성돼 있었습니다.
- Stage 4는 오히려 frontend-only PR에서 Rust lint·세 builder·네 worker·Native Skia를 생략하므로 그 job들의 캐시 생성도 함께 줄입니다.
- 세대 상한도 정상입니다. (그룹, ref) 쌍 42개 중 2세대 초과는 3개뿐이고 전부 마지막 스윕 이후 생성분입니다.
- 실제 원인은 쌍 수 증가로 KEEP=2의 하한이 올라간 것(`refs/heads/devel` 한 ref만 19개 5.84GB)과 삭제된 브랜치의 고아 캐시(약 0.53GB)입니다.

대응은 [#4080](https://github.com/edwardkim/rhwp/issues/4080)으로 분리했고, 4.73GB는 더는 유효한 목표가 아니므로 Stage 5의 게이트에서 제거했습니다.

## 측정 방법

마지막 행은 비파괴 `workflow_dispatch dry_run=true` 실행 [31030157435](https://github.com/edwardkim/rhwp/actions/runs/31030157435)의 예상치입니다. `cache-generation-sweep.yml`의 `if (dryRun) continue` 분기로 삭제는 일어나지 않았습니다. 나머지 행은 각 스윕 run의 로그에서 읽었습니다.

## 검증

- `git diff --check` 통과
- 변경 파일이 전부 `mydocs/**` — review-only fast-pass B 경로(`all-review-only-no-code-impact`) 대상

Refs #3790
Refs #4080
