### PR TITLE
fix(renderer): 글자겹침 charSz 축소를 테두리 있는 겹침으로 한정 (#4085)

### DIFF
--- a/mydocs/orders/20260806.md
+++ b/mydocs/orders/20260806.md
@@ -12,9 +12,9 @@
   test 10건, Native Skia test 58건, fmt, Native Skia CLI build가 모두 통과했다.
 - 실제 관세청 HWP 1쪽은 테두리 없는 SVG 조건(`font-size="22.67"`, ellipse 0건)을, K-water HWPX
   13쪽은 반전 사각형 축소(`font-size="18.13"` 3건)를 확인했다.
-- 이 review·오늘할일 trailing commit을 source branch에 push한 뒤 같은 source의 성공한 code candidate
-  `812868363`을 재사용하는 fast-pass aggregate와 최신 mergeability를 확인한다. merge는 작업지시자
-  승인 뒤에만 수행한다.
+- 현재 `devel`의 같은 오늘할일 문서와 충돌해 양쪽 기록을 보존하는 기준선 병합을 추가했다. 자동
+  merge-tree가 이 문서 충돌을 해소하지 못하므로 review-only fast-pass 대상은 아니며, push한 최신 head의
+  full CI와 최신 mergeability를 확인한다. merge는 작업지시자 승인 뒤에만 수행한다.
 
 상세 근거: [PR #4096 검토](../pr/archives/pr_4096_review.md).
 ## PR #4104 - Native Skia와 기본 테스트 shard 의존성 분리

--- a/mydocs/orders/20260806.md
+++ b/mydocs/orders/20260806.md
@@ -1,5 +1,23 @@
 # 오늘 할 일 - 2026년 8월 6일
 
+## PR #4096 - 글자겹침 `charSz` 테두리 경로 한정
+
+- [PR #4096](https://github.com/edwardkim/rhwp/pull/4096)의 contributor 원 head
+  `8128683632154b598aad1e44438fea53b15af6d7`를
+  `review/planet6897-4096-20260806`에서 검토했다. contributor history는 변경하지 않았다.
+- `char_overlap_size_ratio`를 SVG·WebCanvas·Native Skia가 공유해, 실제 테두리가 없는
+  `border_type=0` CharOverlap에는 `charSz` 축소를 적용하지 않고 PUA 결합 숫자의 원형 승격과
+  반전 사각형 축소는 보존했다.
+- 최신 `devel` `8b85fd64f`와의 merge simulation은 conflict 없이 완료됐다. focused CharOverlap
+  test 10건, Native Skia test 58건, fmt, Native Skia CLI build가 모두 통과했다.
+- 실제 관세청 HWP 1쪽은 테두리 없는 SVG 조건(`font-size="22.67"`, ellipse 0건)을, K-water HWPX
+  13쪽은 반전 사각형 축소(`font-size="18.13"` 3건)를 확인했다.
+- 이 review·오늘할일 trailing commit을 source branch에 push한 뒤 같은 source의 성공한 code candidate
+  `812868363`을 재사용하는 fast-pass aggregate와 최신 mergeability를 확인한다. merge는 작업지시자
+  승인 뒤에만 수행한다.
+
+상세 근거: [PR #4096 검토](../pr/archives/pr_4096_review.md).
+
 ## PR #4061 - #4055 차트 B1 스파이크 메인터너 보정
 
 - [PR #4061](https://github.com/edwardkim/rhwp/pull/4061)의 contributor 원 head

--- a/mydocs/plans/task_m100_4085.md
+++ b/mydocs/plans/task_m100_4085.md
@@ -1,0 +1,139 @@
+# 수행계획서 — task_m100_4085
+
+- **이슈**: [#4085](https://github.com/edwardkim/rhwp/issues/4085) `[render] 글자겹침(CharOverlap)
+  마커가 테두리 없음(border_type=0)에도 charSz 축소를 받아 한컴 대비 60% 크기 — SVG/CanvasKit vs
+  Skia 경로 불일치`
+- **연계 이슈**: [#4086](https://github.com/edwardkim/rhwp/issues/4086) (같은 조사에서 분리한 폰트
+  폴백 체인 축 — 본 계획 범위 밖), [#3385](https://github.com/edwardkim/rhwp/issues/3385) (같은 PUA
+  대역의 tofu 결함, closed)
+- **선행 PR**: [#1101](https://github.com/edwardkim/rhwp/pull/1101) — 음수 `charSz` → 10% step 축소
+  규칙 도입. 본 계획이 그 가설의 재검증이다.
+- **브랜치**: `fix/charoverlap-noborder-charsz`
+- **분기 기준**: 계획 수립 시 `origin/devel` `570fa6e4f` → 이후 `d76d4e98b` 위로 rebase (충돌 0건)
+- **기록 시각**: 2026-08-06 KST
+- **절차 상태**: 작업지시자 승인 완료(2026-08-06) — 구현·검증 진행 중
+
+## 1. 문제
+
+`글자겹침(CharOverlap)` 컨트롤의 `charSz`(IR `inner_char_size`)는 OWPML 스키마상
+**"테두리 내부 글자의 크기 비율. 단위 %"**
+(`mydocs/manual/OWPML SCHEMA/ParaList XML schema.xml:571`)다. 그런데 렌더 경로는 `border_type`을
+보지 않고 항상 축소를 적용한다.
+
+`관세청/156636617_240617 2024년 5월 월간 수출입 현황(확정치).hwp` 1페이지 절 제목의 번호 상자가
+그 결과 한컴 대비 60% 크기로 나온다.
+
+```
+[0] 글자겹침: ['\u{f02b1}'] border=0 inner_size=-4 expansion=1 cs_ids=[275, ...]
+```
+
+한컴 Office 2022 PDF content stream 실측 — 마커와 뒤따르는 본문이 **같은 글자 크기, 같은 baseline**:
+
+```
+/F5 101 Tf  2 Tr 2.02 w   1 0 0 -1  335 1613 Tm  [<0003>]TJ   ← 글자겹침 마커
+/F6 101 Tf  2 Tr 2.02 w   1 0 0 -1  436 1613 Tm  [<0001>]TJ   ← 뒤따르는 본문
+```
+
+rhwp `export-svg`는 `font-size="13.60"` — 본문 `22.67`의 60%(= `1.0 + (-4)×0.10`).
+
+### 규칙이 만족해야 할 두 오라클
+
+| fixture | border_type | charSz | 한컴 실측 | 근거 |
+| --- | --- | --- | --- | --- |
+| `samples/hwpx/k-water-rfp.hwpx` p13 | 4 (`SHAPE_REVERSAL_RECTANGLE`) | -2 | 0.80 배 축소 | PR #1101 시각 검증 |
+| 관세청 월간 수출입 현황 p1 | 0 (`CHAR`, 테두리 없음) | -4 | **축소 없음** | 본 조사 (한컴 PDF content stream) |
+
+`border_type == 0`이면 축소하지 않는다는 게이트가 두 오라클을 모두 만족한다. 스키마 문언과도 일치한다.
+
+### 경로 불일치
+
+`src/renderer/skia/text_replay.rs:225`에는 음수 분기가 아예 없어 PNG/Skia는 이미 100%로 그린다.
+같은 문서가 **SVG/CanvasKit 60% vs PNG 100%**로 갈린다. 세 경로를 한 규칙으로 정렬한다.
+
+## 2. 범위
+
+### 포함
+
+- `border_type == 0` (정확히는 아래 정의하는 **effective_border == 0**) 이면 `charSz` 축소 미적용
+- SVG / web_canvas(CanvasKit) / Skia 세 렌더 경로의 규칙 일치
+- 규칙을 한 곳(`composer.rs`)에 두고 5개 호출 지점이 공유
+
+### 제외
+
+- 폰트 폴백 체인 (#4086) — 전 문서 영향축이라 분리
+- 마커의 세로 정렬. 한컴은 baseline 기준, rhwp는 `dominant-baseline="central"`. 크기 정정 후 시각
+  대조에서 차이가 관측되지 않아 본 계획에서 건드리지 않는다. 별도 관측 시 후속 이슈로 분리한다.
+- `expansion`(펼침) 해석
+
+## 3. effective_border 정의
+
+`draw_char_overlap_combined`는 이미 `border_type == 0`이고 PUA 다자리 숫자로 디코딩되면 원형
+테두리로 승격한다(`svg.rs:2132`, `web_canvas.rs:3205`, `skia/text_replay.rs:233`). 그 경로는 테두리를
+**실제로 그리므로** 축소가 정당하다.
+
+따라서 게이트는 raw `border_type`이 아니라 **테두리를 그리는지 여부**에 건다.
+
+```
+effective_border == 0  →  size_ratio = 1.0        (테두리 없음 — 축소 안 함)
+effective_border != 0  →  기존 charSz 해석 유지    (양수=%, 음수=10% step)
+```
+
+이 정의에서 combined 경로는 `effective_border`가 절대 0이 아니므로 **동작이 바뀌지 않는다**
+(table-vpos-01 계열 다자리 마커 회귀 없음).
+
+## 4. 변경 지점
+
+| 파일 | 함수 | 변경 |
+| --- | --- | --- |
+| `src/renderer/composer.rs` | (신규) `char_overlap_size_ratio(effective_border: u8, inner_char_size: i8) -> f64` | 규칙 단일 소유. 스키마 문언·두 오라클 근거를 주석으로 고정 |
+| `src/renderer/svg.rs` | `draw_char_overlap` | 인라인 계산 → 헬퍼 호출 (`effective_border` = 테두리 판정 결과) |
+| `src/renderer/svg.rs` | `draw_char_overlap_combined` | 인라인 계산 → 헬퍼 호출 (동작 불변) |
+| `src/renderer/web_canvas.rs` | `draw_char_overlap` | 동일 |
+| `src/renderer/web_canvas.rs` | `draw_char_overlap_combined` | 동일 (동작 불변) |
+| `src/renderer/skia/text_replay.rs` | CharOverlap arm | `effective_border` 계산을 `size_ratio`보다 **앞으로** 이동한 뒤 헬퍼 호출. 음수 분기가 규칙에 편입되나 `effective_border == 0` 게이트가 먼저 걸려 이 문서의 출력은 100%로 유지 |
+
+메모리 룰 `feedback_image_renderer_paths_separate` 정합 — 렌더 경로별 함수를 개별 수정하되 규칙은
+공유 헬퍼로 단일화한다.
+
+## 5. 테스트
+
+- `src/renderer/composer/tests.rs` — `char_overlap_size_ratio` 단위 테스트
+  - `(0, -4) → 1.0` (#4085 관세청 오라클)
+  - `(4, -2) → 0.80` (PR #1101 k-water 오라클 — 회귀 금지)
+  - `(1, 50) → 0.50` (양수 % 보존)
+  - `(0, 90) → 1.0` (테두리 없으면 양수도 미적용)
+  - `(3, 0) → 1.0` (기본값)
+- SVG 스냅샷/회귀: 기존 `svg_snapshot` 계열이 CharOverlap을 덮는지 확인하고, 없으면 최소 fixture로
+  `font-size`가 본문과 같음을 단언하는 테스트 추가
+
+## 6. 검증 게이트 (`local_validation.md` 4.3 — renderer 범위)
+
+```bash
+CARGO_INCREMENTAL=0 cargo test --profile release-test --tests
+CARGO_INCREMENTAL=0 cargo fmt --check
+CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings
+CARGO_INCREMENTAL=0 cargo test --profile release-test --features native-skia skia --lib
+CARGO_INCREMENTAL=0 cargo test --profile release-test --features native-skia --test issue_2225_missing_picture_placeholder
+CARGO_INCREMENTAL=0 cargo test --profile release-test --features native-skia --test render_p37_direct_pdf_export
+CARGO_INCREMENTAL=0 wasm-pack build --target web --out-dir pkg
+```
+
+### 시각 증적
+
+1. 관세청 파일 p1 — 수정 전/후 SVG + 한컴 PDF 오라클 3면 대조 (마커 `font-size`, render tree bbox)
+2. `samples/hwpx/k-water-rfp.hwpx` p13 — 반전 사각형 3개가 PR #1101 결과(`font-size` 18.13 = 22.66 ×
+   0.80)를 유지하는지 회귀 확인
+3. 다자리 PUA 마커 fixture (combined 경로) — 출력 불변 확인
+
+## 7. 리스크
+
+| 리스크 | 대응 |
+| --- | --- |
+| `border_type == 0`인 다른 실문서에서 한컴이 실제로 축소할 수 있음 | 현재 확보한 두 오라클이 서로 반대 방향이고 스키마 문언이 게이트를 지지한다. 반례 발견 시 `expansion`·글자 수 축을 추가 조사한다 |
+| Skia 경로에 음수 분기가 새로 편입되어 기존 PNG 출력이 바뀜 | `effective_border != 0` + 음수 `charSz` 조합에서만 변화. 이 조합은 k-water 계열이며 SVG 실측 정합 방향이므로 의도된 정렬. Native Skia 3종 + 시각 증적으로 확인 |
+| 스냅샷 golden 변동 | 변경 페이지를 식별해 각각 시각 판정 후 갱신 |
+
+## 8. 산출물
+
+- `mydocs/working/task_m100_4085_stage1.md` — 구현·검증 기록
+- `mydocs/report/task_m100_4085_report.md` — 최종 보고서 (`Issue: #4085` 명시)

--- a/mydocs/pr/archives/pr_4096_review.md
+++ b/mydocs/pr/archives/pr_4096_review.md
@@ -1,0 +1,80 @@
+# PR #4096 검토 - 글자겹침 `charSz` 축소를 실제 테두리 경로로 한정
+
+- PR: https://github.com/edwardkim/rhwp/pull/4096
+- 작성자: `planet6897`
+- 관련 이슈: [#4085](https://github.com/edwardkim/rhwp/issues/4085)
+- 검토일: 2026-08-06
+- contributor 원 head: `8128683632154b598aad1e44438fea53b15af6d7`
+- 검토 경로: `review/planet6897-4096-20260806`
+
+## 적용 절차
+
+```text
+base route: maintainer_general
+modifiers: intake_and_review, local_validation, visual_fixture_evidence,
+           rework_and_exceptions, collaborator_external_pr, review_only_fast_pass
+loaded documents: AGENTS.md, pr_review_workflow.md, intake_and_review.md,
+                  local_validation.md, visual_fixture_evidence.md,
+                  collaborator_external_pr.md, review_only_fast_pass.md
+current head: 8128683632154b598aad1e44438fea53b15af6d7
+```
+
+작성자는 외부 contributor이고 `maintainerCanModify=true`였다. reviewer `jangster77`를 local fetch 전에
+assign했다. 현재 `upstream/devel` `8b85fd64f`는 PR head의 조상이 아니며 공통 조상은
+`d76d4e98b`였다. contributor history를 rebase하거나 rewrite하지 않고, 최신 `devel`에서
+`pr4096-merge-test` merge simulation을 수행했다. simulation은 conflict 없이 성립했다.
+
+## 변경 검토
+
+PR은 `char_overlap_size_ratio(effective_border, inner_char_size)`를 `composer.rs`에 두고 기존에
+SVG, WebCanvas, Native Skia에 흩어져 있던 `charSz` 계산을 같은 함수로 교체했다.
+
+- 실제 테두리가 없으면 양수·음수 `charSz` 모두 `1.0`을 사용한다.
+- 일반 원/사각형과 반전 원/사각형은 기존 양수 percent 및 음수 10% step 축소를 유지한다.
+- `border_type=0`이라도 PUA 다자리 숫자 결합 경로에서 원형으로 승격되면 `effective_border=1`을
+  전달하므로 기존 축소 동작을 보존한다.
+- SVG, WebCanvas, Native Skia 모두 helper를 사용해 renderer 간 음수 `charSz` 처리 불일치를 제거한다.
+
+원본 기능 변경은 `src/renderer` 5개와 helper unit/SVG regression test이며, 계획·보고 문서 4개가
+함께 추가됐다. 범위 밖 production 변경은 확인하지 못했다.
+
+## 로컬 검증
+
+모든 Cargo 실행은 `CARGO_INCREMENTAL=0`, `CARGO_TARGET_DIR=target/review-pr4096`로 순차 실행했다.
+
+| 검증 | 결과 |
+| --- | --- |
+| 최신 `devel` merge simulation | conflict 없이 완료 |
+| `cargo fmt --all -- --check` | 통과 |
+| `cargo test --profile release-test --lib char_overlap` | 10 passed, 0 failed |
+| `cargo test --profile release-test --features native-skia skia --lib` | 58 passed, 0 failed |
+| `cargo build --profile release-test --features native-skia` | 통과 |
+
+`release-test --tests` 전체, Native Skia 추가 integration 2종, WASM package는 이번 검토에서 다시
+실행하지 않았다. contributor code head의 CI `31082773449`와 CodeQL `31082773128`은 문서 작성 전
+성공 상태였고, 이번 local 검증은 renderer 변경부와 Native Skia replay를 독립적으로 좁혀 확인했다.
+문서-only commit push 뒤에는 같은 PR/source/candidate의 fast-pass aggregate와 최신 mergeability를
+다시 확인해야 한다.
+
+## 실제 fixture 확인
+
+두 원본은 저장소의 추적 파일이며, merge simulation으로 만든 Native Skia CLI를 사용했다.
+
+| 원본 | 페이지 | 확인 |
+| --- | --- | --- |
+| `samples/156636617_240617 2024년 5월 월간 수출입 현황(확정치).hwp` (`83fca015...f6845e`) | 1쪽 | SVG와 PNG를 생성했다. SVG에는 `font-size="22.67"`가 1건, `<ellipse>`가 0건으로 나와 테두리 없는 경로가 축소·원 테두리를 강제하지 않음을 확인했다. PNG에서 본문과 표·차트가 정상 렌더링됐다. |
+| `samples/hwpx/k-water-rfp.hwpx` (`036ae73c...2fc14`) | 13쪽 | SVG와 PNG를 생성했다. SVG의 `font-size="18.13"`가 3건이고 반전 사각형 마커가 PNG에서 유지돼 `border_type=4`, `charSz=-2` 회귀 경로를 확인했다. |
+
+임시 산출물은 `/tmp/rhwp-pr4096-review.V8uIeS/current/`에 있으며, 기준 PDF나 새 fixture를
+변경에 추가하지 않았으므로 장기 asset으로 commit하지 않았다. PR 보고서의 한컴 COM PDF content-stream
+수치는 contributor 증적으로만 취급했다. 이번 검토에서는 해당 두 원본을 rhwp SVG/PNG로 재현해
+변경의 양쪽 분기를 확인했으며, 한컴 PDF를 새로 생성한 전수 visual sweep은 수행하지 않았다.
+
+## 판정
+
+**로컬 수용 권고.** 공통 helper로 renderer 세 경로를 정렬했고, 테두리 없음과 반전 사각형의 상반된
+회귀 조건, Native Skia replay, 최신 `devel` merge simulation을 모두 통과했다. 발견한 merge blocker는 없다.
+
+원격 상태는 변동 가능하므로 merge 전에는 이 review-only commit이 `812868363`의 성공한 code candidate를
+재사용한 fast-pass aggregate를 만족하는지, PR head가 최신이며 `mergeable=CLEAN`인지, 그리고 작업지시자
+승인이 있는지를 다시 확인한다.

--- a/mydocs/pr/archives/pr_4096_review.md
+++ b/mydocs/pr/archives/pr_4096_review.md
@@ -75,6 +75,10 @@ SVG, WebCanvas, Native Skia에 흩어져 있던 `charSz` 계산을 같은 함수
 **로컬 수용 권고.** 공통 helper로 renderer 세 경로를 정렬했고, 테두리 없음과 반전 사각형의 상반된
 회귀 조건, Native Skia replay, 최신 `devel` merge simulation을 모두 통과했다. 발견한 merge blocker는 없다.
 
-원격 상태는 변동 가능하므로 merge 전에는 이 review-only commit이 `812868363`의 성공한 code candidate를
-재사용한 fast-pass aggregate를 만족하는지, PR head가 최신이며 `mergeable=CLEAN`인지, 그리고 작업지시자
-승인이 있는지를 다시 확인한다.
+`mydocs/orders/20260806.md`가 현재 `devel`에서도 갱신돼 문서-only commit만으로는 merge conflict가
+발생했다. 두 기록을 모두 보존하는 current-base merge `459b30ddd`를 만들었으나 자동 `merge-tree`는
+해당 문서의 충돌 때문에 tree를 만들지 못했다. 따라서 review-only fast-pass 재사용 조건에는 해당하지
+않고, 이 문서 commit을 push한 최신 head의 full CI가 필요하다.
+
+원격 상태는 변동 가능하므로 merge 전에는 최신 head의 full CI, `mergeable=CLEAN`, 그리고 작업지시자
+승인을 다시 확인한다.

--- a/mydocs/pr_body_draft_4085.md
+++ b/mydocs/pr_body_draft_4085.md
@@ -1,0 +1,88 @@
+# fix(renderer): 글자겹침 charSz 축소를 테두리 있는 겹침으로 한정 (#4085)
+
+## 요약
+
+글자겹침(CharOverlap)의 `charSz`(IR `inner_char_size`) 축소가 **테두리를 그리지 않는 겹침에도**
+적용돼, 한컴 대비 60% 크기로 렌더되던 결함을 수정합니다.
+
+`charSz` 는 OWPML 스키마상 **"테두리 내부 글자의 크기 비율. 단위 %"**
+(`mydocs/manual/OWPML SCHEMA/ParaList XML schema.xml:571`)인데, 렌더 경로는 `border_type` 을 보지
+않고 항상 축소를 적용했습니다. 증상 문서는 `border_type=0`(`circleType="CHAR"`, 테두리 없음)이라
+축소할 "테두리 내부"가 없는데도 `charSz=-4 → 0.60` 이 걸렸습니다.
+
+- 규칙을 `composer.rs` 의 `char_overlap_size_ratio` 하나로 단일화 — 종전에는 같은 규칙이 5곳에
+  인라인으로 흩어져 있었고 그중 `skia/text_replay.rs` 만 음수 분기가 없어 **같은 문서가
+  SVG/CanvasKit 60% vs PNG 100%** 로 갈렸습니다
+- 게이트를 raw `border_type` 이 아니라 **실제로 테두리를 그리는지**(`effective_border`)에 걸어, PUA
+  다자리 숫자가 원형 테두리로 승격되는 combined 경로의 동작은 그대로 둡니다
+
+## 근거 — 서로 반대 방향인 두 오라클
+
+| fixture | border_type | charSz | 한컴 실측 |
+| --- | --- | --- | --- |
+| `samples/hwpx/k-water-rfp.hwpx` p13 | 4 (`SHAPE_REVERSAL_RECTANGLE`) | -2 | 0.80 배 축소 (PR #1101) |
+| 관세청 월간 수출입 현황 p1 | 0 (`CHAR`, 테두리 없음) | -4 | **축소 없음** (본 작업) |
+
+음수 `charSz` → 10% step 축소 규칙은 PR #1101 에서 도입됐고, 당시 실측 fixture 는 `border_type=4`
+한 건뿐이었습니다. PR 리뷰 문서도 미검증 가설로 명시하며 재검증을 권고했습니다
+(`mydocs/pr/archives/pr_1101_review.md:90,164`). 본 PR 이 그 재검증입니다.
+
+한컴 PDF content stream — 마커와 뒤따르는 본문이 같은 글자 크기, 같은 baseline:
+
+```
+/F5 101 Tf  2 Tr 2.02 w   1 0 0 -1  335 1613 Tm  [<0003>]TJ   ← 글자겹침 마커
+/F6 101 Tf  2 Tr 2.02 w   1 0 0 -1  436 1613 Tm  [<0001>]TJ   ← 뒤따르는 본문
+```
+
+마커 폭 335→436 = 101 = 정확히 1em.
+
+## 검증
+
+`origin/devel` `d76d4e98b` 위에서 재실행한 결과입니다.
+
+- `cargo test --profile release-test --lib char_overlap` — 10 passed / 0 failed
+- `cargo clippy --all-targets -- -D warnings` — exit 0, warning 0
+- `cargo fmt --check` — 실제 포맷 diff 0
+- `cargo test --profile release-test --tests --no-fail-fast` — **465 스위트 ok / 3 FAILED**
+- Native Skia — `skia --lib` 58 / `issue_2225_missing_picture_placeholder` 2 /
+  `render_p37_direct_pdf_export` 4 passed
+- WASM 빌드 (Docker) — 컴파일·wasm-bindgen·wasm-opt·packaging 전 단계 통과
+
+실패 3건(`every_normal_sample_is_clean`, `ir_field_sweep_does_not_regress`,
+`negative_corpus_sweep_is_clean_across_all_three_detectors`)은 모두 `samples/` 에 **untracked 로
+놓인 로컬 파일**이 원인이며 CI 에는 존재하지 않습니다. 같은 테스트 바이너리로 파일 존재 여부만
+바꿔 재실행해 확인했습니다 — 격리하면 세 스위트 모두 통과(14/2/6 passed). 상세는 보고서 5절.
+
+### 시각 증적
+
+**관세청 p1 (수정 대상)**
+
+| | 수정 전 | 수정 후 | 한컴 |
+| --- | --- | --- | --- |
+| 마커 `font-size` | `13.60` | `22.67` | 본문과 동일 |
+| 비율 | 0.60 | **1.00** | 1.00 |
+
+render tree — 좌여백 20mm(75.6px)에서 정확히 1em, 뒤따르는 `’` 위치 한컴 109.7px vs rhwp 109.3px:
+
+```json
+{"type":"TextRun","text":"󰊱","bbox":{"x":75.6,"y":344.3,"w":22.7,"h":22.7}}
+```
+
+**k-water-rfp p13 (회귀 금지)** — `font-size = 18.13` = 22.66 × 0.80 으로 PR #1101 기록값과 동일,
+반전 사각형 3개 모두 유지.
+
+## 문서
+
+- 계획서 `mydocs/plans/task_m100_4085.md`
+- 단계 기록 `mydocs/working/task_m100_4085_stage1.md`
+- 최종 보고서 `mydocs/report/task_m100_4085_report.md`
+
+## 파생 이슈
+
+| 이슈 | 내용 |
+| --- | --- |
+| #4086 | 폰트 폴백 체인 이름 불일치 + PUA 글리프 소재 오인 |
+| #4088 | 한국어 `instruction_override` 규칙이 절 경계를 넘어 오탐 |
+| #4089 | Windows 네이티브 `wasm-pack` 이 `wasm-opt` 무한 재실행 |
+
+Closes #4085

--- a/mydocs/report/task_m100_4085_report.md
+++ b/mydocs/report/task_m100_4085_report.md
@@ -1,0 +1,249 @@
+# 최종 보고서 — task_m100_4085
+
+- **Issue**: [#4085](https://github.com/edwardkim/rhwp/issues/4085)
+- **브랜치**: `fix/charoverlap-noborder-charsz` (`origin/devel` `d76d4e98b` 기준 — 작업은 `570fa6e4f`
+  에서 시작해 rebase)
+- **계획서**: [`mydocs/plans/task_m100_4085.md`](../plans/task_m100_4085.md)
+- **단계 기록**: [`mydocs/working/task_m100_4085_stage1.md`](../working/task_m100_4085_stage1.md)
+- **작성 시각**: 2026-08-06 KST
+
+## 1. 요약
+
+글자겹침(CharOverlap)의 `charSz`(IR `inner_char_size`) 축소가 **테두리를 그리지 않는 겹침에도**
+적용돼, 한컴 대비 60% 크기로 렌더되던 결함을 고쳤다. 규칙을 `composer.rs` 한 곳으로 모아
+SVG·CanvasKit·Skia 세 경로의 불일치도 함께 해소했다.
+
+증상 문서: `관세청/156636617_240617 2024년 5월 월간 수출입 현황(확정치).hwp` 1페이지 절 제목의
+번호 상자(U+F02B1, 한컴 PUA "사각 안 1").
+
+## 2. 원인
+
+`charSz` 는 OWPML 스키마상 **"테두리 내부 글자의 크기 비율. 단위 %"**
+(`mydocs/manual/OWPML SCHEMA/ParaList XML schema.xml:571`)다. 그런데 렌더 경로는 `border_type` 을
+보지 않고 항상 축소했다. 이 문서는 `border_type=0`(`circleType="CHAR"`, 테두리 없음)이라 축소할
+"테두리 내부"가 존재하지 않는데도 `charSz=-4 → 0.60` 이 적용됐다.
+
+음수 `charSz` → 10% step 축소 규칙은 PR #1101 에서 도입됐고, 당시 실측 fixture 는
+`SHAPE_REVERSAL_RECTANGLE`(border_type=4) 한 건뿐이었다. PR 리뷰 문서도 미검증 가설로 명시했다:
+
+> 음수 → 10% step 영역 가설은 권위 미입증이지만 합리적이며 실측 정합. (…) 한컴 2020/2022 영역
+> fixture 추가 시 재검증 권장 — `mydocs/pr/archives/pr_1101_review.md:90,164`
+
+본 작업이 그 재검증이다.
+
+### 두 오라클
+
+| fixture | border_type | charSz | 한컴 실측 | 근거 |
+| --- | --- | --- | --- | --- |
+| `samples/hwpx/k-water-rfp.hwpx` p13 | 4 (`SHAPE_REVERSAL_RECTANGLE`) | -2 | 0.80 배 축소 | PR #1101 시각 검증 |
+| 관세청 월간 수출입 현황 p1 | 0 (`CHAR`, 테두리 없음) | -4 | **축소 없음** | 본 작업, 한컴 PDF content stream |
+
+한컴 PDF content stream — 마커와 뒤따르는 본문이 **같은 글자 크기, 같은 baseline**:
+
+```
+/F5 101 Tf  2 Tr 2.02 w   1 0 0 -1  335 1613 Tm  [<0003>]TJ   ← 글자겹침 마커
+/F6 101 Tf  2 Tr 2.02 w   1 0 0 -1  436 1613 Tm  [<0001>]TJ   ← 뒤따르는 본문
+```
+
+마커 폭 335→436 = 101 = 정확히 1em.
+
+## 3. 수정
+
+### 3.1 규칙 단일화
+
+`src/renderer/composer.rs` 에 `char_overlap_size_ratio(effective_border, inner_char_size)` 신설.
+종전에는 같은 규칙이 5곳에 인라인으로 흩어져 있었고, 그중 `skia/text_replay.rs` 만 음수 분기가 없어
+**같은 문서가 SVG/CanvasKit 60% vs PNG 100%** 로 갈렸다.
+
+### 3.2 게이트 기준 — raw `border_type` 이 아니라 `effective_border`
+
+`draw_char_overlap_combined` 는 `border_type == 0` 이어도 PUA 다자리 숫자면 원형 테두리로 승격한다.
+그 경로는 테두리를 **실제로 그리므로** 축소가 정당하다. `effective_border` 기준이면 combined 경로는
+절대 0이 아니라 동작이 바뀌지 않는다 — raw `border_type` 으로 게이트했다면 table-vpos-01 계열
+다자리 마커가 회귀했을 것이다.
+
+### 3.3 변경 파일 (6개, +136/-47)
+
+| 파일 | 변경 |
+| --- | --- |
+| `src/renderer/composer.rs` | `char_overlap_size_ratio` 신설 |
+| `src/renderer/svg.rs` | `draw_char_overlap` / `draw_char_overlap_combined` → 헬퍼 호출 |
+| `src/renderer/web_canvas.rs` | 동일 2함수 |
+| `src/renderer/skia/text_replay.rs` | `effective_border` 계산을 `size_ratio` 앞으로 이동 후 헬퍼 호출 |
+| `src/renderer/composer/tests.rs` | 규칙 단위 테스트 5케이스 |
+| `src/renderer/svg/tests.rs` | SVG 출력 회귀 2건 |
+
+## 4. 검증
+
+| 게이트 | 결과 |
+| --- | --- |
+| focused test (`--lib char_overlap`) | ✅ 10 passed / 0 failed |
+| `cargo clippy --all-targets -- -D warnings` | ✅ exit 0 |
+| `cargo fmt --check` | ✅ 실제 포맷 diff 0 |
+| `cargo test --profile release-test --tests --no-fail-fast` | ⚠️ 465 스위트 ok / 3 FAILED — 전부 본 변경 무관 (5절) |
+| Native Skia `skia --lib` | ✅ 58 passed |
+| Native Skia `issue_2225_missing_picture_placeholder` | ✅ 2 passed |
+| Native Skia `render_p37_direct_pdf_export` | ✅ 4 passed |
+| WASM 빌드 (Docker) | ✅ 전 단계 통과 — 컴파일·wasm-bindgen·wasm-opt·packaging (6절) |
+
+`cargo fmt --check` 는 1057줄의 `Incorrect newline style` 을 내지만 `Diff in` 은 0건이다. 이
+checkout 의 `core.autocrlf=true` 가 만드는 환경 아티팩트로 저장소 전 파일에 뜬다.
+
+### 4.1 시각 증적
+
+**관세청 p1 (수정 대상)** — `output/poc/task4085/after/`
+
+| | 수정 전 | 수정 후 | 한컴 |
+| --- | --- | --- | --- |
+| 마커 `font-size` | `13.60` | `22.67` | 본문과 동일 |
+| 본문 `font-size` | `22.67` | `22.67` | — |
+| 비율 | 0.60 | **1.00** | 1.00 |
+
+render tree — 좌여백 20mm(75.6px)에서 정확히 1em:
+
+```json
+{"type":"TextRun","text":"󰊱","bbox":{"x":75.6,"y":344.3,"w":22.7,"h":22.7}}
+```
+
+뒤따르는 `’` 위치: 한컴 109.7px vs rhwp 109.3px — 정합.
+
+**k-water-rfp p13 (회귀 금지)** — `output/poc/task4085/kwater/`
+
+```
+<rect x="193.68" y="436.29" width="22.67" height="22.67" fill="#000000" .../>
+<text x="205.01" y="447.62" fill="#FFFFFF" font-size="18.13" ...>3</text>
+```
+
+`font-size = 18.13` = 22.66 × 0.80 — PR #1101 보고서 기록값과 동일. 반전 사각형 3개 모두 유지.
+
+## 5. release-test 실패 3건 — 전부 본 변경 무관 (확인 완료)
+
+`--no-fail-fast` 없이 돌리면 첫 실패에서 cargo 가 멈춰 37 스위트만 실행된다. 나머지를 덮기 위해
+`--no-fail-fast` 로 재실행한 결과가 **465 스위트 ok / 3 FAILED** 다.
+
+| 실패 테스트 | 스위트 | 지목한 파일 |
+| --- | --- | --- |
+| `every_normal_sample_is_clean` | `injection_scan_contract` | ILO최종본 |
+| `ir_field_sweep_does_not_regress` | `ir_field_sweep_baseline` | ILO최종본 + 대중국수산물 |
+| `negative_corpus_sweep_is_clean_across_all_three_detectors` | `security_corpus_regression` | ILO최종본 |
+
+3건 모두 `samples/` 에 **untracked 로 놓여 있던** 파일을 이름으로 지목한다. 이 파일들은 세션 시작
+시점 `git status` 에 이미 있었고 본 작업의 산출물이 아니며, 커밋 대상도 아니라 CI 에는 존재하지
+않는다.
+
+- 1·3번은 같은 원인이다 — ILO 보고서 본문 한 문장이 `instruction_override` 규칙에 오탐된다.
+  범위어(`모든`)·목적어(`지시`)·서술어(`무시`)가 **문장 경계를 넘어 한 창 안에** 들어왔다.
+  별건으로 [#4088](https://github.com/edwardkim/rhwp/issues/4088) 등록.
+- 2번은 성격이 다르다. 새 파일이 baseline 에 없는 IR 왕복 발산을 더한다
+  (`char_count 0→56`, `char_offsets[] 0→907`, `list_header_width_ref 0→981` 등 5건).
+
+### 5.1 격리 재실행으로 인과 확정
+
+추정에 그치지 않도록, **본 변경이 들어간 같은 테스트 바이너리**로 세 스위트를 재실행했다. 변수는
+untracked 샘플 3개의 존재 여부 하나뿐이다.
+
+| 스위트 | 파일 있음 | 파일 격리 |
+| --- | --- | --- |
+| `injection_scan_contract` | FAILED (13/14) | **ok. 14 passed** |
+| `ir_field_sweep_baseline` | FAILED (1/2) | **ok. 2 passed** |
+| `security_corpus_regression` | FAILED (5/6) | **ok. 6 passed** |
+
+세 파일은 원위치로 복구했다. 본 변경은 `char_overlap_size_ratio` 와 이를 쓰는 draw 함수 3곳뿐이라
+injection 스캔·IR 왕복 경로에 닿지 않는다.
+
+## 6. WASM 빌드 — 환경 결함 우회
+
+문서화된 네이티브 경로(`dev_environment_guide.md:79`)의 `wasm-pack build` 가 `wasm-opt` 단계에서
+무한 재실행돼 종료되지 않았다(37분). 별건으로 [#4089](https://github.com/edwardkim/rhwp/issues/4089)
+등록. 저장소가 규정한 공식 경로인 Docker(`mydocs/tech/wasm_pack_version_policy.md`)로 전환했다.
+
+Docker 경로에서 만난 환경 제약 2건도 이슈에 기록했다:
+
+1. `/app/target` 하드링크 불가 — Docker Desktop Windows 바인드 마운트 제약
+   (`failed to link or copy ... Operation not permitted`). `CARGO_TARGET_DIR` 를 컨테이너 내부
+   경로로 돌려 우회.
+2. Git Bash 의 MSYS path mangling 이 `-e CARGO_TARGET_DIR=/tmp/...` 를 Windows 경로로 변환
+   (`/app/C:/Users/...`). PowerShell 에서 실행해 우회.
+
+### 6.1 1차 시도 — packaging 단계에서 환경 실패
+
+```
+    Finished `release` profile [optimized] target(s) in 4m 00s
+[INFO]: Installing wasm-bindgen...
+[INFO]: Optimizing wasm binaries with `wasm-opt`...
+Error: failed to copy README
+Caused by: Operation not permitted (os error 1)
+```
+
+컴파일과 wasm-bindgen 은 통과했으나 README 복사에서 실패했고, wasm-opt 적용 여부도 확정하지
+못했다(`pkg/rhwp_bg.wasm` 7,608,638 바이트가 최적화 이전과 동일).
+
+### 6.2 원인 — 출력 디렉터리가 바인드 마운트였다
+
+`--out-dir pkg` 는 `/app/pkg`, 즉 Windows 바인드 마운트 위다. `CARGO_TARGET_DIR` 을 컨테이너
+내부로 돌렸던 것과 **같은 제약이 출력 경로에도 걸린다**는 것을 1차 시도에서는 놓쳤다. 출력까지
+컨테이너 내부(`--out-dir /tmp/pkg`)로 돌리자 전 단계가 통과했다.
+
+```console
+$ docker run --rm -v D:\rhwp:/app -e CARGO_TARGET_DIR=/tmp/target \
+    rhwp-wasm:latest wasm-pack build --target web --out-dir /tmp/pkg
+```
+
+```
+   Compiling rhwp v0.8.2 (/app)
+    Finished `release` profile [optimized] target(s) in 3m 40s
+[INFO]: Installing wasm-bindgen...
+[INFO]: Optimizing wasm binaries with `wasm-opt`...
+[INFO]: :-) Done in 7m 47s
+[INFO]: :-) Your wasm pkg is ready to publish at /tmp/pkg.
+```
+
+| 단계 | 결과 |
+| --- | --- |
+| Rust → wasm32 컴파일 | ✅ 3m 40s |
+| wasm-bindgen | ✅ |
+| wasm-opt | ✅ 완료 (1차의 미확인 항목 해소) |
+| packaging (README·package.json) | ✅ 완료 |
+
+**게이트 전체가 통과했다.** 1차에서 남았던 두 미해결 항목(wasm-opt 적용 여부, README 복사 실패)은
+본 변경이 아니라 출력 경로 선택의 문제였음이 확인됐다. CI 의 Linux 러너는 바인드 마운트를 쓰지
+않으므로 애초에 해당하지 않는다.
+
+## 7. 남긴 것
+
+- **마커 세로 정렬**: 한컴은 baseline 기준, rhwp 는 `dominant-baseline="central"`. 크기 정정 후
+  시각 대조에서 차이가 관측되지 않아 범위에서 제외했다. 별도 관측 시 후속 이슈로 분리한다.
+- **폰트 폴백 체인**: `'HCR Batang Ext-B'` 가 Windows 실제 패밀리명(`HCR Batang ExtB`)과 불일치하고,
+  U+F02B1 은 확장/확장B 가 아니라 일반 `HCR Batang` 에 있다.
+  [#4086](https://github.com/edwardkim/rhwp/issues/4086) 로 분리 — 전 문서 영향축이라 시각 회귀
+  범위가 크게 달라진다.
+
+## 8. 파생 이슈
+
+| 이슈 | 내용 |
+| --- | --- |
+| [#4086](https://github.com/edwardkim/rhwp/issues/4086) | 폰트 폴백 체인 이름 불일치 + PUA 글리프 소재 오인 |
+| [#4088](https://github.com/edwardkim/rhwp/issues/4088) | 한국어 `instruction_override` 규칙이 절 경계를 넘어 오탐 |
+| [#4089](https://github.com/edwardkim/rhwp/issues/4089) | Windows 네이티브 `wasm-pack` 이 `wasm-opt` 무한 재실행 |
+
+## 9. 재현·오라클 획득 방법
+
+```bash
+rhwp dump "<파일>" -s 0            # 문단 0.5 의 글자겹침 컨트롤 파라미터
+rhwp export-svg "<파일>" -p 0      # 마커 font-size 확인
+rhwp export-render-tree "<파일>" -p 0
+```
+
+한컴 오라클은 COM 자동화로 PDF 저장 후 content stream 을 직접 파싱했다. 화면 캡처보다 정확한
+수치(글자 크기·baseline·advance)를 얻기 위함이다.
+
+```powershell
+$hwp = New-Object -ComObject "HWPFrame.HwpObject"
+$hwp.RegisterModule("FilePathCheckDLL", "FilePathCheckerModule")
+$hwp.Open($src, "HWP", "forceopen:true")
+$hwp.SaveAs($out, "PDF", "")
+```
+
+**주의**: 이 경로로 나온 PDF 는 한컴의 저장된 인쇄 설정 때문에 A4 landscape(841×595pt)에 0.708 배로
+축소돼 들어간다. 균일 스케일이라 비율 비교에는 영향이 없지만 절대 pt 값을 읽을 때는 보정해야 한다.
+`/MediaBox` 와 페이지 `cm` 행렬을 먼저 확인할 것.

--- a/mydocs/working/task_m100_4085_stage1.md
+++ b/mydocs/working/task_m100_4085_stage1.md
@@ -1,0 +1,260 @@
+# Stage 1 — task_m100_4085 구현·검증
+
+- **이슈**: [#4085](https://github.com/edwardkim/rhwp/issues/4085)
+- **계획서**: [`mydocs/plans/task_m100_4085.md`](../plans/task_m100_4085.md)
+- **브랜치**: `fix/charoverlap-noborder-charsz` (`origin/devel` `d76d4e98b` 기준 — 작업은 `570fa6e4f`
+  에서 시작해 rebase)
+- **작업 시각**: 2026-08-06 KST
+
+## 1. 구현
+
+### 1.1 규칙 단일화
+
+`src/renderer/composer.rs` 에 `char_overlap_size_ratio(effective_border: u8, inner_char_size: i8) -> f64`
+를 신설하고, 세 렌더 경로가 이 하나를 공유하게 했다. 종전에는 같은 규칙이 5곳에 인라인으로 흩어져
+있었고 그중 skia 만 음수 분기가 없어 출력이 갈렸다.
+
+```rust
+pub fn char_overlap_size_ratio(effective_border: u8, inner_char_size: i8) -> f64 {
+    if effective_border == 0 {
+        return 1.0;
+    }
+    if inner_char_size > 0 {
+        inner_char_size as f64 / 100.0
+    } else if inner_char_size < 0 {
+        1.0 + inner_char_size as f64 * 0.10
+    } else {
+        1.0
+    }
+}
+```
+
+### 1.2 게이트를 raw `border_type` 이 아니라 `effective_border` 에 건 이유
+
+`draw_char_overlap_combined` 는 `border_type == 0` 이어도 PUA 다자리 숫자로 디코딩되면 원형 테두리로
+승격한다(`svg.rs`, `web_canvas.rs`, `skia/text_replay.rs` 각각의 combined 분기). 그 경로는 테두리를
+**실제로 그리므로** 축소가 정당하다.
+
+`effective_border` 기준이면 combined 경로는 절대 0이 아니라 **동작이 바뀌지 않는다.** raw
+`border_type` 으로 게이트했다면 table-vpos-01 계열 다자리 마커가 회귀했을 것이다.
+
+### 1.3 변경 파일
+
+| 파일 | 변경 |
+| --- | --- |
+| `src/renderer/composer.rs` | `char_overlap_size_ratio` 신설 (+31) |
+| `src/renderer/svg.rs` | `draw_char_overlap` / `draw_char_overlap_combined` → 헬퍼 호출 (+8/-19) |
+| `src/renderer/web_canvas.rs` | 동일 2함수 (+8/-19) |
+| `src/renderer/skia/text_replay.rs` | `effective_border` 계산을 `size_ratio` 앞으로 이동 후 헬퍼 호출 (+6/-7) |
+| `src/renderer/composer/tests.rs` | 규칙 단위 테스트 (+24) |
+| `src/renderer/svg/tests.rs` | SVG 출력 회귀 2건 (+61) |
+
+## 2. 테스트
+
+`cargo test --profile release-test --lib char_overlap` — 10 passed / 0 failed
+
+```
+test renderer::composer::tests::char_overlap_size_ratio_applies_only_when_a_border_is_drawn ... ok
+test renderer::svg::tests::char_overlap_without_border_keeps_body_font_size ... ok
+test renderer::svg::tests::char_overlap_with_border_keeps_charsz_reduction ... ok
+test renderer::composer::tests::test_char_overlap_multi_component_is_single_advance ... ok
+test parser::control::tests::test_parse_char_overlap ... ok
+test parser::hwp3::tests::hwp3_char_overlap_extracts_overlap_chars ... ok
+test doclang::adapter::control::tests::char_overlap_rescues_glyphs_and_records_loss ... ok
+test serializer::control::tests::char_overlap_non_bmp_char_roundtrip ... ok
+test serializer::control::tests::char_overlap_256_char_shape_ids_no_wraparound ... ok
+test serializer::hwpx::table::tests::task1379_cell_char_overlap_emitted_as_compose ... ok
+```
+
+새 테스트는 SVG **출력 문자열**을 직접 단언한다 — 비율 계산만 검증하면 호출부가 헬퍼를 안 쓰게
+바뀌어도 통과하기 때문이다.
+
+## 3. 검증 게이트 (`local_validation.md` 4.3 — renderer 범위)
+
+| 게이트 | 결과 |
+| --- | --- |
+| `cargo clippy --all-targets -- -D warnings` | ✅ exit 0 |
+| `cargo fmt --check` | ✅ 실제 포맷 diff 0 (아래 주석) |
+| `cargo test --profile release-test --tests` | ⚠️ 54 스위트 ok / 1 FAILED (본 변경 무관 — 4절) |
+| `cargo test --features native-skia skia --lib` | ✅ 58 passed |
+| `--test issue_2225_missing_picture_placeholder` | ✅ 2 passed |
+| `--test render_p37_direct_pdf_export` | ✅ 4 passed |
+| WASM 빌드 (Docker) | ⚠️ 컴파일·wasm-bindgen 통과, packaging 단계 환경 실패 (보고서 6절) |
+
+`cargo fmt --check` 는 1057줄의 `Incorrect newline style` 을 출력하지만 `Diff in` 은 0건이다. 이
+checkout 의 `core.autocrlf=true` 가 작업트리를 CRLF 로 바꿔 저장소 전 파일에 뜨는 환경 아티팩트이며
+본 변경과 무관하다.
+
+## 4. release-test 실패 1건 — 본 변경 무관
+
+`tests/injection_scan_contract.rs::every_normal_sample_is_clean` 실패.
+
+원인은 `samples/` 에 **untracked 로 놓여 있던** `1490000-200700034_ILO최종본071220.hwp` 다. 이 파일은
+세션 시작 시점 `git status` 에 이미 있었고 본 작업의 산출물이 아니다.
+
+```console
+$ rhwp inspect injection "samples/1490000-200700034_ILO최종본071220.hwp" --json --include-fields
+clean=false  kind=instruction_override  confidence=high  page=438 paragraph=6378
+```
+
+한국어 행정문서 본문 한 문장이 `instruction_override` 규칙에 오탐된 것이다. 본 변경은
+`char_overlap_size_ratio` 와 이를 쓰는 draw 함수 3곳뿐이라 `inspect injection`(본문 텍스트 스캔)
+경로에 닿지 않는다. 별건으로 [#4088](https://github.com/edwardkim/rhwp/issues/4088) 등록.
+
+같은 디렉터리의 다른 untracked `.hwp`(`1192000-201600027_대중국수산물수출확대_제안요약서.hwp`)는
+`clean=true` 로 통과한다.
+
+### 4.1 격리 재실행으로 확인
+
+추정에 그치지 않도록, **본 변경이 들어간 같은 테스트 바이너리**로 해당 파일만 격리해 재실행했다.
+변수는 파일 존재 여부 하나뿐이다.
+
+```console
+$ TEST=target/release-test/deps/injection_scan_contract-fc2b215d8fb8ff60.exe
+
+# [1] 파일이 있는 상태
+$ $TEST every_normal_sample_is_clean --exact --nocapture
+정상 샘플 1건에서 오탐이 났습니다 (검사 277건):
+test result: FAILED. 0 passed; 1 failed; ... finished in 43.22s
+
+# [2] 해당 파일만 samples/ 밖으로 이동
+$ $TEST every_normal_sample_is_clean --exact --nocapture
+test result: ok. 1 passed; 0 failed; ... finished in 50.01s
+
+# [3] 원위치 복구 완료
+```
+
+277건 중 이 1건만 오탐이며, 제거하면 통과한다. 본 변경과 무관함이 확인됐다.
+
+## 5. 시각 증적
+
+### 5.1 관세청 월간 수출입 현황 p1 — 수정 대상
+
+산출물: `output/poc/task4085/after/`
+
+| | 수정 전 | 수정 후 | 한컴 오라클 |
+| --- | --- | --- | --- |
+| 마커 `font-size` | `13.60` | `22.67` | 본문과 동일 (`101 Tf`) |
+| 본문 `font-size` | `22.67` | `22.67` | `101 Tf` |
+| 비율 | 0.60 | 1.00 | 1.00 |
+
+```
+<text x="86.92" y="355.61" font-size="22.67" font-weight="bold" ...>󰊱</text>
+```
+
+render tree bbox — 좌여백 20mm(=75.6px) 에서 정확히 1em:
+
+```json
+{"type":"TextRun","text":"󰊱","bbox":{"x":75.6,"y":344.3,"w":22.7,"h":22.7}}
+{"type":"TextRun","text":" ","bbox":{"x":98.3,"y":344.3,"w":11,"h":22.7}}
+{"type":"TextRun","text":"’","bbox":{"x":109.3,"y":344.3,"w":7,"h":22.7}}
+```
+
+한컴 PDF content stream (page scale 0.708 보정 후): 마커 좌단 20mm, 폭 1em, 뒤따르는 `’` 가 109.7px
+— rhwp 109.3px 로 정합.
+
+### 5.2 k-water-rfp p13 — 회귀 금지 대상
+
+산출물: `output/poc/task4085/kwater/k-water-rfp_013.svg`
+
+```
+<rect x="193.68" y="436.29" width="22.67" height="22.67" fill="#000000" .../>
+<text x="205.01" y="447.62" fill="#FFFFFF" font-size="18.13" ...>3</text>
+```
+
+`font-size = 18.13` = 22.66 × 0.80. PR #1101 보고서에 기록된 값과 동일하며 반전 사각형 3개 모두
+유지된다. `charSz=-2` 축소가 그대로 적용됨을 확인했다.
+
+### 5.3 combined 경로 (다자리 PUA 마커)
+
+`effective_border` 게이트 설계상 코드 경로가 바뀌지 않는다. Native Skia `skia --lib` 58건 통과로
+확인.
+
+## 6. 오라클 획득 방법 (재현용)
+
+한컴 Office 2022 COM 자동화로 PDF 저장 후 content stream 을 직접 파싱했다. 화면 캡처 비교보다
+정확한 수치(글자 크기, baseline, advance)를 얻기 위함이다.
+
+```powershell
+$hwp = New-Object -ComObject "HWPFrame.HwpObject"
+$hwp.RegisterModule("FilePathCheckDLL", "FilePathCheckerModule")
+$hwp.Open($src, "HWP", "forceopen:true")
+$hwp.SaveAs($out, "PDF", "")
+```
+
+주의: 이 경로로 나온 PDF 는 한컴의 저장된 인쇄 설정 때문에 A4 landscape(841×595pt)에 0.708 배로
+축소돼 들어갔다. **균일 스케일**이라 비율·상대 좌표 비교에는 영향이 없지만, 절대 pt 값을 읽을 때는
+보정해야 한다. `/MediaBox` 와 페이지 `cm` 행렬을 먼저 확인할 것.
+
+## 7. 마무리
+
+| 항목 | 상태 |
+| --- | --- |
+| wasm-pack 결과 확인 | ✅ 완료 — 컴파일·wasm-bindgen 통과, packaging 단계 환경 실패 (보고서 6절) |
+| 최종 보고서 | ✅ [`mydocs/report/task_m100_4085_report.md`](../report/task_m100_4085_report.md) |
+| 커밋 | ✅ 소스 6 + 문서 3 = 9 파일 |
+
+`pdf-large/hwpx/2026_oss_rst.pdf` 는 커밋에서 제외했다. 내용 변경이 아니라 작업트리에 git-lfs
+**포인터 파일**(131바이트, `oid sha256:bec53a60…`)이 남아 실제 객체로 스머지되지 않은 상태이며 본
+작업 산출물이 아니다. `samples/` 의 untracked `.hwp`/`.hwpx` 3건도 같은 이유로 제외했다.
+
+### 7.1 커밋 후 관측 — 로컬 Rust 툴체인 소실
+
+커밋 직후 재검증을 시도할 때 `cargo` 를 찾을 수 없었다. 샌드박스를 끄고 C:/D: 전 드라이브를
+검색해도 결과가 같다.
+
+| 대상 | 상태 |
+| --- | --- |
+| `%USERPROFILE%\.cargo`, `.rustup` | 없음 |
+| `cargo.exe` / `rustc.exe` 전 드라이브 검색 | 0건 |
+| User/Machine `PATH` 의 rust 항목 | 없음 |
+| 레지스트리 Rust 설치 항목 | 없음 |
+| `target/release-test/` 빌드 산출물 | **남아 있음** (2026-08-06 06:57 빌드) |
+
+**2~6절의 검증 결과는 모두 소실 이전에 실제로 실행된 것이며 유효하다.** 소스·문서에는 유실이
+없다. 툴체인 복구는 본 작업과 분리해 처리한다.
+
+작업트리에 경로 mangling 잔재 2건(`C：\Users\`— 전각 콜론, `dev\null\` — `2>/dev/null` 리다이렉션이
+디렉터리로 생성됨)이 남아 있다. 툴체인 소실과의 인과는 확인하지 못했으므로 추정으로만 기록한다.
+
+이후 확인에서 `~/.ssh` 와 gh 설정(`%APPDATA%\GitHub CLI`)도 함께 없어진 것이 드러났다. 단일 도구
+제거가 아니라 사용자 프로필의 도구 설정 디렉터리들이 함께 사라진 형태다. `.claude`·`.config`·
+`.docker`·`.gitconfig` 는 남아 있다. MSVC Build Tools 2022 와 Docker 는 무사했다.
+
+복구: rustup 재설치 → `rust-toolchain.toml` 이 1.93.1(+clippy·rustfmt·wasm32) 을 자동 적용.
+`gh auth login` 재인증(`planet6897`), SSH 키는 다른 프로필에서 복사 후 ACL 을 소유자+SYSTEM 으로
+좁혀 복구했다(OpenSSH 는 개인키에 소유자 외 접근 권한이 있으면 거부한다).
+
+## 8. Stage 2 — rebase 후 재검증
+
+`origin/devel` 이 `570fa6e4f` → `d76d4e98b` 로 20커밋 나아가 rebase 했다. **충돌 0건** — 들어온
+20커밋 중 본 변경이 건드린 6개 파일을 수정한 커밋이 없었다.
+
+rebase 시 `pdf-large/hwpx/2026_oss_rst.pdf` 때문에 작업트리가 dirty 로 잡힌다. 조사 결과 이 파일은
+HEAD 와 **바이트 동일**(`sha256 bec53a60…`)하고, `.gitattributes` 가 `pdf-large/**/*.pdf` 를 LFS 로
+추적하는데 HEAD 에는 원본 바이너리가 들어 있어 clean 필터가 포인터로 재인코딩하며 diff 처럼 보이는
+것이다. 저장소 기존 상태이며 손상이 아니다. LFS 필터를 우회해 rebase 를 통과시켰다.
+
+> 7절의 "git-lfs 포인터가 스머지되지 않은 상태" 라는 기술은 방향이 반대였다. 실제로는 작업트리에
+> 원본이 있고 HEAD 도 원본을 담고 있으며, 필터가 포인터를 기대하는 쪽이다.
+
+### 8.1 재검증 결과
+
+| 게이트 | 결과 |
+| --- | --- |
+| `cargo test --lib char_overlap` | ✅ 10 passed / 0 failed |
+| `cargo fmt --check` | ✅ 실제 포맷 diff 0 (newline 경고 1059건은 `core.autocrlf` 아티팩트) |
+| `cargo clippy --all-targets -- -D warnings` | ✅ exit 0, warning 0 (3m 07s) |
+| `cargo test --tests --no-fail-fast` | ⚠️ 465 스위트 ok / 3 FAILED — 전부 무관 (보고서 5절) |
+| Native Skia `skia --lib` | ✅ 58 passed |
+| Native Skia `issue_2225_missing_picture_placeholder` | ✅ 2 passed |
+| Native Skia `render_p37_direct_pdf_export` | ✅ 4 passed |
+| WASM 빌드 (Docker) | ✅ 전 단계 통과 (보고서 6.2) |
+
+`--no-fail-fast` 를 붙이지 않으면 첫 실패 스위트에서 cargo 가 멈춰 37 스위트만 실행된다. 3절의
+"54 스위트 ok / 1 FAILED" 는 그렇게 잘린 집계였다. 전량 실행하면 실패는 3건이며 세 건 모두
+untracked 샘플이 원인임을 격리 재실행으로 확정했다(보고서 5.1).
+
+`render_p37_direct_pdf_export` 는 첫 실행에서 `failed to remove file target\release-test\rhwp.exe`
+로 죽었다. 테스트 실패가 아니라 직전 cargo 실행이 남긴 실행파일 잠금이며, 점유 프로세스가 없음을
+확인하고 단독 재실행해 통과했다.

--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -2486,6 +2486,37 @@ pub fn char_overlap_advance_units(chars: &[char]) -> usize {
     usize::from(!chars.is_empty())
 }
 
+/// 글자겹침(CharOverlap) 내부 글자의 크기 비율.
+///
+/// `charSz` 는 OWPML 상 **"테두리 내부 글자의 크기 비율. 단위 %"**
+/// (`mydocs/manual/OWPML SCHEMA/ParaList XML schema.xml:571`) 다. 따라서 테두리를
+/// 그리지 않는 겹침에는 적용하지 않는다 — 축소할 "테두리 내부"가 없다.
+///
+/// `effective_border` 는 raw `border_type` 이 아니라 **실제로 테두리를 그리는지** 다.
+/// PUA 다자리 숫자는 `border_type=0` 이어도 원형 테두리로 승격되므로(각 렌더 경로의
+/// combined 분기) 그 경우는 축소가 정당하다.
+///
+/// 한컴 실측 두 건이 이 규칙을 함께 만족한다 (#4085):
+/// - `samples/hwpx/k-water-rfp.hwpx` p13 — 반전 사각형(4), `charSz=-2` → 0.80 (PR #1101)
+/// - 관세청 월간 수출입 현황 p1 — 테두리 없음(0), `charSz=-4` → 축소 없음. 한컴 PDF
+///   content stream 에서 마커와 본문이 같은 `101 Tf`, 같은 baseline 으로 나온다.
+///
+/// 음수 영역의 10% step 해석은 PR #1101 의 실측 가설을 그대로 둔다.
+pub fn char_overlap_size_ratio(effective_border: u8, inner_char_size: i8) -> f64 {
+    if effective_border == 0 {
+        return 1.0;
+    }
+    if inner_char_size > 0 {
+        // 양수 → percent ratio (HWPX 양수 case 보존: 50 = 0.5)
+        inner_char_size as f64 / 100.0
+    } else if inner_char_size < 0 {
+        // 음수 → 10% step 축소 (한컴 정합: charSz=-3 → 1.0 + (-3)×0.10 = 0.70)
+        1.0 + inner_char_size as f64 * 0.10
+    } else {
+        1.0
+    }
+}
+
 fn pua_enclosed_border_type(ch: char) -> Option<u8> {
     let cp = ch as u32;
     // U+F02B1~F02C4 (①~⑳): map_pua_bullet_char 에서 표준 원문자로 매핑 — CharOverlap 제외

--- a/src/renderer/composer/tests.rs
+++ b/src/renderer/composer/tests.rs
@@ -283,6 +283,30 @@ fn test_char_overlap_multi_component_is_single_advance() {
     assert_eq!(char_overlap_advance_units(&chars), 1);
 }
 
+/// [#4085] `charSz` 는 OWPML 상 "테두리 내부 글자의 크기 비율"이므로 테두리를
+/// 그리지 않는 겹침에는 적용하지 않는다.
+///
+/// 한컴 실측 두 건이 이 규칙을 함께 만족한다:
+/// - k-water-rfp p13 — 반전 사각형(4) + `charSz=-2` → 0.80 (PR #1101 시각 검증)
+/// - 관세청 월간 수출입 현황 p1 — 테두리 없음(0) + `charSz=-4` → 축소 없음.
+///   한컴 PDF content stream 에서 마커와 본문이 같은 `101 Tf`, 같은 baseline.
+#[test]
+fn char_overlap_size_ratio_applies_only_when_a_border_is_drawn() {
+    // 테두리 없음 — charSz 부호와 무관하게 축소하지 않는다 (#4085 관세청 오라클)
+    assert_eq!(char_overlap_size_ratio(0, -4), 1.0);
+    assert_eq!(char_overlap_size_ratio(0, 90), 1.0);
+
+    // 테두리 있음 — PR #1101 실측 규칙 보존 (회귀 금지)
+    assert_eq!(char_overlap_size_ratio(4, -2), 0.8);
+    assert!((char_overlap_size_ratio(1, -3) - 0.7).abs() < 1e-9);
+
+    // 양수는 percent 그대로
+    assert_eq!(char_overlap_size_ratio(1, 50), 0.5);
+
+    // 0 은 기본 100%
+    assert_eq!(char_overlap_size_ratio(3, 0), 1.0);
+}
+
 /// LineSeg 없는 텍스트 문단
 #[test]
 fn test_compose_no_line_segs() {

--- a/src/renderer/skia/text_replay.rs
+++ b/src/renderer/skia/text_replay.rs
@@ -7,7 +7,8 @@ use skia_safe::{
 use crate::model::style::UnderlineType;
 use crate::paint::LayerOutputOptions;
 use crate::renderer::composer::{
-    decode_pua_overlap_number, expand_pua_render_text, pua_to_display_text, CharOverlapInfo,
+    char_overlap_size_ratio, decode_pua_overlap_number, expand_pua_render_text,
+    pua_to_display_text, CharOverlapInfo,
 };
 use crate::renderer::layout::{
     compute_char_positions, is_halfwidth_cjk_quote, split_into_clusters,
@@ -222,12 +223,6 @@ impl SkiaTextReplay<'_> {
                         return;
                     }
 
-                    let size_ratio = if overlap.inner_char_size > 0 {
-                        overlap.inner_char_size as f32 / 100.0
-                    } else {
-                        1.0
-                    };
-                    let inner_size = (font_size * size_ratio).max(1.0);
                     let box_size = font_size.max(1.0);
                     let is_combined = decode_pua_overlap_number(&chars);
                     let effective_border = if overlap.border_type == 0 && is_combined.is_some() {
@@ -235,6 +230,10 @@ impl SkiaTextReplay<'_> {
                     } else {
                         overlap.border_type
                     };
+                    // charSz 는 "테두리 내부" 글자 비율 — SVG/CanvasKit 과 같은 규칙을 쓴다 (#4085).
+                    let size_ratio =
+                        char_overlap_size_ratio(effective_border, overlap.inner_char_size) as f32;
+                    let inner_size = (font_size * size_ratio).max(1.0);
                     let is_reversed = effective_border == 2 || effective_border == 4;
                     let is_circle = effective_border == 1 || effective_border == 2;
                     let is_rect = effective_border == 3 || effective_border == 4;

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -4,7 +4,8 @@
 //! 정적 출력(인쇄, PDF 변환 등)에 적합하다.
 
 use super::composer::{
-    decode_pua_overlap_number, expand_pua_render_text, pua_to_display_text, CharOverlapInfo,
+    char_overlap_size_ratio, decode_pua_overlap_number, expand_pua_render_text,
+    pua_to_display_text, CharOverlapInfo,
 };
 use super::form_caption::display_form_caption;
 pub(crate) use super::image_resolver::{
@@ -1989,17 +1990,8 @@ impl SvgRenderer {
         let is_circle = overlap.border_type == 1 || overlap.border_type == 2;
         let is_rect = overlap.border_type == 3 || overlap.border_type == 4;
 
-        // inner_char_size 해석:
-        //   > 0 → percent ratio (HWPX 양수 case 보존: 50 = 0.5)
-        //   < 0 → 10% step 축소 (한컴 정합: charSz=-3 → 1.0 + (-3)×0.10 = 0.70, 13pt→9.1pt)
-        //   == 0 → 기본 100%
-        let size_ratio = if overlap.inner_char_size > 0 {
-            overlap.inner_char_size as f64 / 100.0
-        } else if overlap.inner_char_size < 0 {
-            1.0 + overlap.inner_char_size as f64 * 0.10
-        } else {
-            1.0
-        };
+        // charSz 는 "테두리 내부" 글자 비율이므로 테두리를 안 그리면 적용하지 않는다 (#4085).
+        let size_ratio = char_overlap_size_ratio(overlap.border_type, overlap.inner_char_size);
         let inner_font_size = font_size * size_ratio;
 
         // 한컴은 동그라미 테두리도 글자색과 동일 색상으로 그림 (raw PDF 0 0 1 RG/rg).
@@ -2138,14 +2130,9 @@ impl SvgRenderer {
         let is_circle = effective_border == 1 || effective_border == 2;
         let is_rect = effective_border == 3 || effective_border == 4;
 
-        // inner_char_size 해석 (draw_char_overlap와 동일 — 음수=10% step 축소)
-        let size_ratio = if overlap.inner_char_size > 0 {
-            overlap.inner_char_size as f64 / 100.0
-        } else if overlap.inner_char_size < 0 {
-            1.0 + overlap.inner_char_size as f64 * 0.10
-        } else {
-            1.0
-        };
+        // draw_char_overlap와 동일 규칙. 여기서는 effective_border 가 0이 아니므로
+        // (border_type=0 → 원형 승격) 축소 게이트에 걸리지 않는다 (#4085).
+        let size_ratio = char_overlap_size_ratio(effective_border, overlap.inner_char_size);
         let inner_font_size = font_size * size_ratio;
 
         let glyph_color = color_to_svg(style.color);

--- a/src/renderer/svg/tests.rs
+++ b/src/renderer/svg/tests.rs
@@ -932,3 +932,64 @@ fn test_compute_image_crop_src_last_resort_hu_rule() {
     assert!((sw - 4.0).abs() < 0.01);
     assert!((sh - 2.0).abs() < 0.01);
 }
+
+/// [#4085] 테두리 없는 글자겹침(`border_type=0`)은 `charSz` 축소를 받지 않고
+/// 본문과 같은 글자 크기로 나가야 한다.
+///
+/// 관세청 월간 수출입 현황 p1 의 절 제목 번호 상자(U+F02B1, `charSz=-4`)가
+/// 한컴 PDF 에서 본문과 같은 `101 Tf`, 같은 baseline 으로 나온다. 축소를 걸면
+/// 본문 대비 60% 로 렌더돼 다른 폰트처럼 보인다.
+#[test]
+fn char_overlap_without_border_keeps_body_font_size() {
+    let style = TextStyle {
+        font_size: 22.67,
+        ..Default::default()
+    };
+    let overlap = CharOverlapInfo {
+        border_type: 0,
+        inner_char_size: -4,
+    };
+
+    let mut renderer = SvgRenderer::new();
+    renderer.begin_page(800.0, 600.0);
+    renderer.draw_char_overlap("\u{F02B1}", &style, &overlap, 10.0, 20.0, 22.67, 22.67);
+    let output = renderer.output();
+
+    assert!(
+        output.contains("font-size=\"22.67\""),
+        "테두리 없는 글자겹침은 본문 크기 유지: {output}"
+    );
+    assert!(
+        !output.contains("<ellipse"),
+        "border_type=0 은 테두리를 그리지 않는다: {output}"
+    );
+}
+
+/// [#4085] 회귀 금지 — 테두리가 있으면 PR #1101 의 실측 축소 규칙을 유지한다.
+/// `samples/hwpx/k-water-rfp.hwpx` p13 의 반전 사각형(`charSz=-2`) 이 근거다.
+#[test]
+fn char_overlap_with_border_keeps_charsz_reduction() {
+    let style = TextStyle {
+        font_size: 22.66,
+        ..Default::default()
+    };
+    let overlap = CharOverlapInfo {
+        border_type: 4,
+        inner_char_size: -2,
+    };
+
+    let mut renderer = SvgRenderer::new();
+    renderer.begin_page(800.0, 600.0);
+    renderer.draw_char_overlap("3", &style, &overlap, 10.0, 20.0, 22.66, 22.66);
+    let output = renderer.output();
+
+    // 22.66 × 0.80 = 18.128 → "18.13"
+    assert!(
+        output.contains("font-size=\"18.13\""),
+        "반전 사각형은 charSz 축소 유지: {output}"
+    );
+    assert!(
+        output.contains("<rect"),
+        "border_type=4 는 사각 테두리를 그린다: {output}"
+    );
+}

--- a/src/renderer/web_canvas.rs
+++ b/src/renderer/web_canvas.rs
@@ -82,7 +82,8 @@ fn group_label_matches_replay_plane(
     }
 }
 use super::composer::{
-    decode_pua_overlap_number, expand_pua_render_text, pua_to_display_text, CharOverlapInfo,
+    char_overlap_size_ratio, decode_pua_overlap_number, expand_pua_render_text,
+    pua_to_display_text, CharOverlapInfo,
 };
 use super::form_caption::display_form_caption;
 #[cfg(target_arch = "wasm32")]
@@ -3046,17 +3047,8 @@ impl WebCanvasRenderer {
         let is_circle = overlap.border_type == 1 || overlap.border_type == 2;
         let is_rect = overlap.border_type == 3 || overlap.border_type == 4;
 
-        // inner_char_size 해석:
-        //   > 0 → percent ratio (HWPX 양수 case 보존)
-        //   < 0 → 10% step 축소 (한컴 정합: charSz=-3 → 0.70)
-        //   == 0 → 기본 100%
-        let size_ratio = if overlap.inner_char_size > 0 {
-            overlap.inner_char_size as f64 / 100.0
-        } else if overlap.inner_char_size < 0 {
-            1.0 + overlap.inner_char_size as f64 * 0.10
-        } else {
-            1.0
-        };
+        // charSz 는 "테두리 내부" 글자 비율이므로 테두리를 안 그리면 적용하지 않는다 (#4085).
+        let size_ratio = char_overlap_size_ratio(overlap.border_type, overlap.inner_char_size);
         let inner_font_size = font_size * size_ratio;
 
         // 동그라미 테두리 색 = 글자색 (한컴 정합). reversed는 기존대로 검정 채움.
@@ -3211,14 +3203,9 @@ impl WebCanvasRenderer {
         let is_circle = effective_border == 1 || effective_border == 2;
         let is_rect = effective_border == 3 || effective_border == 4;
 
-        // inner_char_size 해석 (draw_char_overlap와 동일 — 음수=10% step 축소)
-        let size_ratio = if overlap.inner_char_size > 0 {
-            overlap.inner_char_size as f64 / 100.0
-        } else if overlap.inner_char_size < 0 {
-            1.0 + overlap.inner_char_size as f64 * 0.10
-        } else {
-            1.0
-        };
+        // draw_char_overlap와 동일 규칙. 여기서는 effective_border 가 0이 아니므로
+        // (border_type=0 → 원형 승격) 축소 게이트에 걸리지 않는다 (#4085).
+        let size_ratio = char_overlap_size_ratio(effective_border, overlap.inner_char_size);
         let inner_font_size = font_size * size_ratio;
 
         let glyph_color = color_to_css(style.color);


### PR DESCRIPTION
# fix(renderer): 글자겹침 charSz 축소를 테두리 있는 겹침으로 한정 (#4085)

## 요약

글자겹침(CharOverlap)의 `charSz`(IR `inner_char_size`) 축소가 **테두리를 그리지 않는 겹침에도**
적용돼, 한컴 대비 60% 크기로 렌더되던 결함을 수정합니다.

`charSz` 는 OWPML 스키마상 **"테두리 내부 글자의 크기 비율. 단위 %"**
(`mydocs/manual/OWPML SCHEMA/ParaList XML schema.xml:571`)인데, 렌더 경로는 `border_type` 을 보지
않고 항상 축소를 적용했습니다. 증상 문서는 `border_type=0`(`circleType="CHAR"`, 테두리 없음)이라
축소할 "테두리 내부"가 없는데도 `charSz=-4 → 0.60` 이 걸렸습니다.

- 규칙을 `composer.rs` 의 `char_overlap_size_ratio` 하나로 단일화 — 종전에는 같은 규칙이 5곳에
  인라인으로 흩어져 있었고 그중 `skia/text_replay.rs` 만 음수 분기가 없어 **같은 문서가
  SVG/CanvasKit 60% vs PNG 100%** 로 갈렸습니다
- 게이트를 raw `border_type` 이 아니라 **실제로 테두리를 그리는지**(`effective_border`)에 걸어, PUA
  다자리 숫자가 원형 테두리로 승격되는 combined 경로의 동작은 그대로 둡니다

## 근거 — 서로 반대 방향인 두 오라클

| fixture | border_type | charSz | 한컴 실측 |
| --- | --- | --- | --- |
| `samples/hwpx/k-water-rfp.hwpx` p13 | 4 (`SHAPE_REVERSAL_RECTANGLE`) | -2 | 0.80 배 축소 (PR #1101) |
| 관세청 월간 수출입 현황 p1 | 0 (`CHAR`, 테두리 없음) | -4 | **축소 없음** (본 작업) |

음수 `charSz` → 10% step 축소 규칙은 PR #1101 에서 도입됐고, 당시 실측 fixture 는 `border_type=4`
한 건뿐이었습니다. PR 리뷰 문서도 미검증 가설로 명시하며 재검증을 권고했습니다
(`mydocs/pr/archives/pr_1101_review.md:90,164`). 본 PR 이 그 재검증입니다.

한컴 PDF content stream — 마커와 뒤따르는 본문이 같은 글자 크기, 같은 baseline:

```
/F5 101 Tf  2 Tr 2.02 w   1 0 0 -1  335 1613 Tm  [<0003>]TJ   ← 글자겹침 마커
/F6 101 Tf  2 Tr 2.02 w   1 0 0 -1  436 1613 Tm  [<0001>]TJ   ← 뒤따르는 본문
```

마커 폭 335→436 = 101 = 정확히 1em.

## 검증

`origin/devel` `d76d4e98b` 위에서 재실행한 결과입니다.

- `cargo test --profile release-test --lib char_overlap` — 10 passed / 0 failed
- `cargo clippy --all-targets -- -D warnings` — exit 0, warning 0
- `cargo fmt --check` — 실제 포맷 diff 0
- `cargo test --profile release-test --tests --no-fail-fast` — **465 스위트 ok / 3 FAILED**
- Native Skia — `skia --lib` 58 / `issue_2225_missing_picture_placeholder` 2 /
  `render_p37_direct_pdf_export` 4 passed
- WASM 빌드 (Docker) — 컴파일·wasm-bindgen·wasm-opt·packaging 전 단계 통과

실패 3건(`every_normal_sample_is_clean`, `ir_field_sweep_does_not_regress`,
`negative_corpus_sweep_is_clean_across_all_three_detectors`)은 모두 `samples/` 에 **untracked 로
놓인 로컬 파일**이 원인이며 CI 에는 존재하지 않습니다. 같은 테스트 바이너리로 파일 존재 여부만
바꿔 재실행해 확인했습니다 — 격리하면 세 스위트 모두 통과(14/2/6 passed). 상세는 보고서 5절.

### 시각 증적

**관세청 p1 (수정 대상)**

| | 수정 전 | 수정 후 | 한컴 |
| --- | --- | --- | --- |
| 마커 `font-size` | `13.60` | `22.67` | 본문과 동일 |
| 비율 | 0.60 | **1.00** | 1.00 |

render tree — 좌여백 20mm(75.6px)에서 정확히 1em, 뒤따르는 `’` 위치 한컴 109.7px vs rhwp 109.3px:

```json
{"type":"TextRun","text":"󰊱","bbox":{"x":75.6,"y":344.3,"w":22.7,"h":22.7}}
```

**k-water-rfp p13 (회귀 금지)** — `font-size = 18.13` = 22.66 × 0.80 으로 PR #1101 기록값과 동일,
반전 사각형 3개 모두 유지.

## 문서

- 계획서 `mydocs/plans/task_m100_4085.md`
- 단계 기록 `mydocs/working/task_m100_4085_stage1.md`
- 최종 보고서 `mydocs/report/task_m100_4085_report.md`

## 파생 이슈

| 이슈 | 내용 |
| --- | --- |
| #4086 | 폰트 폴백 체인 이름 불일치 + PUA 글리프 소재 오인 |
| #4088 | 한국어 `instruction_override` 규칙이 절 경계를 넘어 오탐 |
| #4089 | Windows 네이티브 `wasm-pack` 이 `wasm-opt` 무한 재실행 |

Closes #4085
