### PR TITLE
ci: current-base 병합 fast-pass 보완

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,9 @@ jobs:
       checks: read
       pull-requests: read
     outputs:
-      fast_pass: ${{ steps.detect.outputs.fast_pass || 'false' }}
-      reason: ${{ steps.detect.outputs.reason || 'preflight-unavailable' }}
-      candidate_sha: ${{ steps.detect.outputs.candidate_sha || '' }}
+      fast_pass: ${{ steps.finalize.outputs.fast_pass || 'false' }}
+      reason: ${{ steps.finalize.outputs.reason || 'preflight-unavailable' }}
+      candidate_sha: ${{ steps.finalize.outputs.candidate_sha || '' }}
       # [#3790 Stage 4] frontend_mode·render_required에 더해 rust_required와
       # native_skia_required를 실제 worker 조건에 사용한다. CodeQL은 Stage 5까지 유지한다.
       # 모든 기본값은 full lane이다.
@@ -99,6 +99,18 @@ jobs:
               core.info(`fast_pass=${fastPass} reason=${reason} candidate_sha=${candidateSha}`);
             }
 
+            function setPendingBaseMergeResult(reason, candidateSha, mergeSha, sourceParentSha) {
+              core.setOutput('fast_pass', 'pending-base-merge-tree');
+              core.setOutput('reason', reason);
+              core.setOutput('candidate_sha', candidateSha);
+              core.setOutput('base_merge_sha', mergeSha);
+              core.setOutput('source_parent_sha', sourceParentSha);
+              core.info(
+                `fast_pass=pending-base-merge-tree reason=${reason} candidate_sha=${candidateSha} `
+                + `base_merge_sha=${mergeSha} source_parent_sha=${sourceParentSha}`,
+              );
+            }
+
             function isAllowedReviewPath(file) {
               const filename = file.filename;
               if (filename.startsWith('mydocs/')) {
@@ -130,9 +142,10 @@ jobs:
               return hasReferenceArtifact ? 'review-reference-only' : 'mydocs-only';
             }
 
-            function isCurrentBaseReviewMerge(commit, baseSha) {
+            function isCurrentBaseUpdateMerge(commit, baseSha) {
               const parents = commit.parents || [];
-              return parents.length === 2 && parents.some((parent) => parent.sha === baseSha);
+              return parents.length === 2
+                && parents.filter((parent) => parent.sha === baseSha).length === 1;
             }
 
             function latestRun(runs) {
@@ -236,6 +249,7 @@ jobs:
 
               const reviewOnlyCandidates = [];
               let codeCandidateSha = '';
+              let baseMergeBridge = null;
 
               for (let index = commits.length - 1; index >= 0; index -= 1) {
                 const sha = commits[index].sha;
@@ -244,6 +258,18 @@ jobs:
                   repo,
                   ref: sha,
                 });
+                const parents = commit.parents || [];
+                if (reviewOnlyCandidates.length > 0
+                  && isCurrentBaseUpdateMerge(commit, pr.base.sha)) {
+                  if (baseMergeBridge) {
+                    setResult(false, `multiple-current-base-update-merges:${sha}`);
+                    return;
+                  }
+                  const sourceParent = parents.find((parent) => parent.sha !== pr.base.sha);
+                  baseMergeBridge = { mergeSha: sha, sourceParentSha: sourceParent.sha };
+                  core.info(`including current-base update merge bridge ${sha}`);
+                  continue;
+                }
                 const files = commit.files || [];
 
                 // The commit endpoint may truncate very large file lists. Fall back to full CI.
@@ -254,18 +280,9 @@ jobs:
 
                 const reviewOnly = files.every((file) => isAllowedReviewPath(file));
                 if (reviewOnly) {
-                  const parents = commit.parents || [];
                   if (parents.length === 1) {
                     reviewOnlyCandidates.push(sha);
                     continue;
-                  }
-                  // Keep the narrow Update branch merge compatibility path. It is
-                  // optional: ordinary trailing review-only records do not require it.
-                  if (reviewOnlyCandidates.length > 0
-                    && isCurrentBaseReviewMerge(commit, pr.base.sha)) {
-                    reviewOnlyCandidates.push(sha);
-                    core.info(`including ${reviewOnlyLabel(files)} update-branch merge candidate ${sha}`);
-                    break;
                   }
                   setResult(false, `${reviewOnlyLabel(files)}-merge-not-reusable:${sha}`);
                   return;
@@ -286,6 +303,15 @@ jobs:
               for (const candidateSha of reviewOnlyCandidates) {
                 const result = await buildResult(candidateSha, pr);
                 if (result.state === 'green') {
+                  if (baseMergeBridge) {
+                    setPendingBaseMergeResult(
+                      `build-and-test-green:${result.conclusion}`,
+                      candidateSha,
+                      baseMergeBridge.mergeSha,
+                      baseMergeBridge.sourceParentSha,
+                    );
+                    return;
+                  }
                   setResult(true, `build-and-test-green:${result.conclusion}`, candidateSha);
                   return;
                 }
@@ -302,11 +328,85 @@ jobs:
               setResult(false, 'preflight-error');
             }
 
+      # 기준선 병합을 fast-pass bridge로 쓸 때는 untrusted source를 실행하지 않고,
+      # Git의 자동 3-way merge 결과가 실제 merge tree와 같은지만 확인한다.
+      - name: Check out current-base merge tree inputs
+        id: checkout-base-merge-tree
+        if: ${{ steps.detect.outputs.fast_pass == 'pending-base-merge-tree' }}
+        continue-on-error: true
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          fetch-depth: 0
+          lfs: false
+          persist-credentials: false
+
+      - name: Verify current-base merge tree
+        id: verify-base-merge-tree
+        if: ${{ always() && steps.detect.outputs.fast_pass == 'pending-base-merge-tree' }}
+        shell: bash
+        env:
+          BASE_MERGE_SHA: ${{ steps.detect.outputs.base_merge_sha }}
+          SOURCE_PARENT_SHA: ${{ steps.detect.outputs.source_parent_sha }}
+          CURRENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          fail() {
+            printf 'verified=false\nreason=%s\n' "$1" >> "$GITHUB_OUTPUT"
+          }
+
+          if ! git cat-file -e "${BASE_MERGE_SHA}^{commit}" \
+            || ! git cat-file -e "${SOURCE_PARENT_SHA}^{commit}" \
+            || ! git cat-file -e "${CURRENT_BASE_SHA}^{commit}"; then
+            fail 'current-base-merge-input-unavailable'
+            exit 0
+          fi
+
+          if ! expected_tree="$(git merge-tree --write-tree "${SOURCE_PARENT_SHA}" "${CURRENT_BASE_SHA}" 2>/dev/null)"; then
+            fail 'current-base-merge-tree-conflict-or-unavailable'
+            exit 0
+          fi
+          expected_tree="${expected_tree%%$'\n'*}"
+          actual_tree="$(git show -s --format=%T "${BASE_MERGE_SHA}")"
+          if [[ "${expected_tree}" != "${actual_tree}" ]]; then
+            fail 'current-base-merge-tree-mismatch'
+            exit 0
+          fi
+
+          printf 'verified=true\nreason=current-base-merge-tree-match\n' >> "$GITHUB_OUTPUT"
+
+      - name: Finalize review-only fast pass
+        id: finalize
+        if: ${{ always() }}
+        shell: bash
+        env:
+          DETECTED_FAST_PASS: ${{ steps.detect.outputs.fast_pass || 'false' }}
+          DETECTED_REASON: ${{ steps.detect.outputs.reason || 'preflight-unavailable' }}
+          CANDIDATE_SHA: ${{ steps.detect.outputs.candidate_sha || '' }}
+          MERGE_TREE_VERIFIED: ${{ steps.verify-base-merge-tree.outputs.verified || 'false' }}
+          MERGE_TREE_REASON: ${{ steps.verify-base-merge-tree.outputs.reason || 'not-required' }}
+        run: |
+          set -euo pipefail
+          fast_pass="${DETECTED_FAST_PASS}"
+          reason="${DETECTED_REASON}"
+          if [[ "${DETECTED_FAST_PASS}" == 'pending-base-merge-tree' ]]; then
+            if [[ "${MERGE_TREE_VERIFIED}" == 'true' ]]; then
+              fast_pass='true'
+              reason="current-base-update-merge-tree-green:${CANDIDATE_SHA}"
+            else
+              fast_pass='false'
+              reason="${MERGE_TREE_REASON}"
+            fi
+          fi
+          printf 'fast_pass=%s\nreason=%s\ncandidate_sha=%s\n' \
+            "${fast_pass}" "${reason}" "${CANDIDATE_SHA}" >> "$GITHUB_OUTPUT"
+
       # [#3790 Stage 4] PR의 classifier 구현은 PR head가 아닌 base SHA에 고정한다.
       # frontend·Rust·Native Skia 축은 활성화하며 CodeQL은 Stage 5까지 관찰한다.
       - name: Check out trusted CI impact classifier
         id: checkout-impact-classifier
-        if: ${{ steps.detect.outputs.fast_pass != 'true' }}
+        if: ${{ steps.finalize.outputs.fast_pass != 'true' }}
         continue-on-error: true
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -317,7 +417,7 @@ jobs:
 
       - name: Collect CI impact input
         id: collect-impact
-        if: ${{ steps.detect.outputs.fast_pass != 'true' }}
+        if: ${{ steps.finalize.outputs.fast_pass != 'true' }}
         continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -423,7 +523,7 @@ jobs:
 
       - name: Classify CI impact
         id: impact
-        if: ${{ steps.detect.outputs.fast_pass != 'true' }}
+        if: ${{ steps.finalize.outputs.fast_pass != 'true' }}
         continue-on-error: true
         run: >-
           node scripts/ci-impact-classifier.cjs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,9 +52,9 @@ jobs:
       checks: read
       pull-requests: read
     outputs:
-      fast_pass: ${{ steps.detect.outputs.fast_pass || 'false' }}
-      reason: ${{ steps.detect.outputs.reason || 'preflight-unavailable' }}
-      candidate_sha: ${{ steps.detect.outputs.candidate_sha || '' }}
+      fast_pass: ${{ steps.finalize.outputs.fast_pass || 'false' }}
+      reason: ${{ steps.finalize.outputs.reason || 'preflight-unavailable' }}
+      candidate_sha: ${{ steps.finalize.outputs.candidate_sha || '' }}
 
     steps:
       - name: Detect review-only fast pass
@@ -79,6 +79,18 @@ jobs:
               core.setOutput('reason', reason);
               core.setOutput('candidate_sha', candidateSha);
               core.info(`fast_pass=${fastPass} reason=${reason} candidate_sha=${candidateSha}`);
+            }
+
+            function setPendingBaseMergeResult(reason, candidateSha, mergeSha, sourceParentSha) {
+              core.setOutput('fast_pass', 'pending-base-merge-tree');
+              core.setOutput('reason', reason);
+              core.setOutput('candidate_sha', candidateSha);
+              core.setOutput('base_merge_sha', mergeSha);
+              core.setOutput('source_parent_sha', sourceParentSha);
+              core.info(
+                `fast_pass=pending-base-merge-tree reason=${reason} candidate_sha=${candidateSha} `
+                + `base_merge_sha=${mergeSha} source_parent_sha=${sourceParentSha}`,
+              );
             }
 
             function isAllowedReviewPath(file) {
@@ -113,9 +125,10 @@ jobs:
               return hasReferenceArtifact ? 'review-reference-only' : 'mydocs-only';
             }
 
-            function isCurrentBaseReviewMerge(commit, baseSha) {
+            function isCurrentBaseUpdateMerge(commit, baseSha) {
               const parents = commit.parents || [];
-              return parents.length === 2 && parents.some((parent) => parent.sha === baseSha);
+              return parents.length === 2
+                && parents.filter((parent) => parent.sha === baseSha).length === 1;
             }
 
             function latestRun(runs) {
@@ -221,6 +234,7 @@ jobs:
 
               const reviewOnlyCandidates = [];
               let codeCandidateSha = '';
+              let baseMergeBridge = null;
 
               for (let index = commits.length - 1; index >= 0; index -= 1) {
                 const sha = commits[index].sha;
@@ -229,6 +243,18 @@ jobs:
                   repo,
                   ref: sha,
                 });
+                const parents = commit.parents || [];
+                if (reviewOnlyCandidates.length > 0
+                  && isCurrentBaseUpdateMerge(commit, pr.base.sha)) {
+                  if (baseMergeBridge) {
+                    setResult(false, `multiple-current-base-update-merges:${sha}`);
+                    return;
+                  }
+                  const sourceParent = parents.find((parent) => parent.sha !== pr.base.sha);
+                  baseMergeBridge = { mergeSha: sha, sourceParentSha: sourceParent.sha };
+                  core.info(`including current-base update merge bridge ${sha}`);
+                  continue;
+                }
                 const files = commit.files || [];
 
                 // The commit endpoint may truncate very large file lists. Fall back to full CodeQL.
@@ -239,18 +265,9 @@ jobs:
 
                 const reviewOnly = files.every((file) => isAllowedReviewPath(file));
                 if (reviewOnly) {
-                  const parents = commit.parents || [];
                   if (parents.length === 1) {
                     reviewOnlyCandidates.push(sha);
                     continue;
-                  }
-                  // Keep the narrow Update branch merge compatibility path. It is
-                  // optional: ordinary trailing review-only records do not require it.
-                  if (reviewOnlyCandidates.length > 0
-                    && isCurrentBaseReviewMerge(commit, pr.base.sha)) {
-                    reviewOnlyCandidates.push(sha);
-                    core.info(`including ${reviewOnlyLabel(files)} update-branch merge candidate ${sha}`);
-                    break;
                   }
                   setResult(false, `${reviewOnlyLabel(files)}-merge-not-reusable:${sha}`);
                   return;
@@ -271,6 +288,15 @@ jobs:
               for (const candidateSha of reviewOnlyCandidates) {
                 const result = await codeqlResult(candidateSha, pr);
                 if (result.state === 'green') {
+                  if (baseMergeBridge) {
+                    setPendingBaseMergeResult(
+                      'codeql-checks-green',
+                      candidateSha,
+                      baseMergeBridge.mergeSha,
+                      baseMergeBridge.sourceParentSha,
+                    );
+                    return;
+                  }
                   setResult(true, 'codeql-checks-green', candidateSha);
                   return;
                 }
@@ -286,6 +312,80 @@ jobs:
               core.warning(`CodeQL preflight failed; running full CodeQL. ${error.message}`);
               setResult(false, 'preflight-error');
             }
+
+      # 기준선 병합을 fast-pass bridge로 쓸 때는 untrusted source를 실행하지 않고,
+      # Git의 자동 3-way merge 결과가 실제 merge tree와 같은지만 확인한다.
+      - name: Check out current-base merge tree inputs
+        id: checkout-base-merge-tree
+        if: ${{ steps.detect.outputs.fast_pass == 'pending-base-merge-tree' }}
+        continue-on-error: true
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          fetch-depth: 0
+          lfs: false
+          persist-credentials: false
+
+      - name: Verify current-base merge tree
+        id: verify-base-merge-tree
+        if: ${{ always() && steps.detect.outputs.fast_pass == 'pending-base-merge-tree' }}
+        shell: bash
+        env:
+          BASE_MERGE_SHA: ${{ steps.detect.outputs.base_merge_sha }}
+          SOURCE_PARENT_SHA: ${{ steps.detect.outputs.source_parent_sha }}
+          CURRENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          fail() {
+            printf 'verified=false\nreason=%s\n' "$1" >> "$GITHUB_OUTPUT"
+          }
+
+          if ! git cat-file -e "${BASE_MERGE_SHA}^{commit}" \
+            || ! git cat-file -e "${SOURCE_PARENT_SHA}^{commit}" \
+            || ! git cat-file -e "${CURRENT_BASE_SHA}^{commit}"; then
+            fail 'current-base-merge-input-unavailable'
+            exit 0
+          fi
+
+          if ! expected_tree="$(git merge-tree --write-tree "${SOURCE_PARENT_SHA}" "${CURRENT_BASE_SHA}" 2>/dev/null)"; then
+            fail 'current-base-merge-tree-conflict-or-unavailable'
+            exit 0
+          fi
+          expected_tree="${expected_tree%%$'\n'*}"
+          actual_tree="$(git show -s --format=%T "${BASE_MERGE_SHA}")"
+          if [[ "${expected_tree}" != "${actual_tree}" ]]; then
+            fail 'current-base-merge-tree-mismatch'
+            exit 0
+          fi
+
+          printf 'verified=true\nreason=current-base-merge-tree-match\n' >> "$GITHUB_OUTPUT"
+
+      - name: Finalize review-only fast pass
+        id: finalize
+        if: ${{ always() }}
+        shell: bash
+        env:
+          DETECTED_FAST_PASS: ${{ steps.detect.outputs.fast_pass || 'false' }}
+          DETECTED_REASON: ${{ steps.detect.outputs.reason || 'preflight-unavailable' }}
+          CANDIDATE_SHA: ${{ steps.detect.outputs.candidate_sha || '' }}
+          MERGE_TREE_VERIFIED: ${{ steps.verify-base-merge-tree.outputs.verified || 'false' }}
+          MERGE_TREE_REASON: ${{ steps.verify-base-merge-tree.outputs.reason || 'not-required' }}
+        run: |
+          set -euo pipefail
+          fast_pass="${DETECTED_FAST_PASS}"
+          reason="${DETECTED_REASON}"
+          if [[ "${DETECTED_FAST_PASS}" == 'pending-base-merge-tree' ]]; then
+            if [[ "${MERGE_TREE_VERIFIED}" == 'true' ]]; then
+              fast_pass='true'
+              reason="current-base-update-merge-tree-green:${CANDIDATE_SHA}"
+            else
+              fast_pass='false'
+              reason="${MERGE_TREE_REASON}"
+            fi
+          fi
+          printf 'fast_pass=%s\nreason=%s\ncandidate_sha=%s\n' \
+            "${fast_pass}" "${reason}" "${CANDIDATE_SHA}" >> "$GITHUB_OUTPUT"
 
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/mydocs/manual/pr_review/multi_pr_update_branch.md
+++ b/mydocs/manual/pr_review/multi_pr_update_branch.md
@@ -2,7 +2,7 @@
 kind: guide
 status: active
 canonical: mydocs/manual/pr_review_workflow.md
-last_verified: 2026-07-25
+last_verified: 2026-08-06
 ---
 
 # 다수 PR과 update branch 처리
@@ -160,7 +160,10 @@ collaborator가 외부 contributor PR의 source branch에 archive review·오늘
 
 3. collaborator commit 위로 `git merge <new-contributor-head>`를 실행하지 않는다. 그 merge는 대개
    current `devel`을 직접 parent로 갖지 않아 fast-pass가 `mydocs-only-merge-not-reusable`로 거부한다.
-   VS Code 그래프의 가시성은 같은 branch에서 contributor head를 조상으로 두는 선형 history로 유지한다.
+   current `devel`을 source에 이미 병합한 예외는 [review-only fast-pass](review_only_fast_pass.md)의
+   자동 merge tree 일치 조건을 충족할 때만 제한적으로 재사용할 수 있지만, 이 예외도 새 merge 생성을
+   정당화하지 않는다. VS Code 그래프의 가시성은 같은 branch에서 contributor head를 조상으로 두는 선형
+   history로 유지한다.
 4. collaborator commit이 이미 contributor source branch에 push됐거나, replay 범위에 merge·미확인 commit이
    있으면 history를 억지로 정리하거나 contributor branch를 force-push하지 않는다. 최신 source에서 full CI를
    받거나, 작업지시자의 명시 승인을 받아 별도 처리 경로를 선택한다.

--- a/mydocs/manual/pr_review/review_only_fast_pass.md
+++ b/mydocs/manual/pr_review/review_only_fast_pass.md
@@ -2,7 +2,7 @@
 kind: guide
 status: active
 canonical: mydocs/manual/pr_review_workflow.md
-last_verified: 2026-07-25
+last_verified: 2026-08-06
 ---
 
 # Review-only fast-pass
@@ -31,8 +31,10 @@ Update branch, merge, rebase를 수행하지 않는다. 따라서 직전 green P
 다음 조건을 모두 만족해야 한다.
 
 1. candidate 이후 current head까지의 review-only commit은 single-parent다.
-2. review-only Update branch merge를 candidate로 쓰는 경우에는 현재 PR base를 parent로 포함한 정확히
-   2-parent merge이고, 그 뒤에 적어도 하나의 single-parent review-only commit이 있어야 한다.
+2. 예외적으로 source에 이미 current base를 병합한 commit이 있으면, 그 merge는 정확히 2-parent이고
+   parent 하나만 현재 PR base SHA와 같아야 한다. 그 위에 적어도 하나의 single-parent review-only commit이
+   있어야 하며, preflight가 `git merge-tree`로 계산한 자동 3-way merge tree가 실제 merge commit tree와
+   같을 때만 candidate 탐색의 bridge로 쓸 수 있다. 이 확인은 PR source를 실행하지 않는다.
 3. candidate SHA는 현재 PR commit history의 code 후보여야 하며, CI·CodeQL·Render Diff 결과는 같은 PR의
    head branch, source repository, event, candidate SHA와 정확히 일치해야 한다. 현재 base 전진은 단독으로
    재사용 거부 사유가 아니다.
@@ -43,10 +45,11 @@ Update branch, merge, rebase를 수행하지 않는다. 따라서 직전 green P
 6. push 뒤 최신 head의 preflight와 branch protection이 요구하는 Build & Test aggregate를 확인한다.
    heavy worker가 skipped인 것은 정상이나 aggregate가 pending 또는 failing이면 merge하지 않는다.
 
-trailing range에 reviewer가 만든 일반 merge commit이 있으면 fast-pass는 이를 재사용하지 않는다. 현재
-`devel`을 직접 parent로 둔 review-only update merge만 선택적으로 허용하며, 일반 trailing 기록에는 그 merge가
-필요하지 않다. contributor가 review 도중 source를 갱신한 경우에는 새 source를 기존 reviewer 기록에 merge하지 말고
-[2.6.1 외부 PR review 기록의 source head 정렬](multi_pr_update_branch.md#261-외부-pr-review-기록의-source-head-정렬)을
+trailing range에 reviewer가 만든 일반 merge commit이 있으면 fast-pass는 이를 재사용하지 않는다. current base
+병합도 위 자동 merge tree 일치 조건을 만족하는 한 번의 bridge만 예외적으로 허용한다. 이 호환 경로는 문서
+기록을 위해 source에 `devel`을 병합하라는 절차가 아니다. 일반 절차는 여전히 Update branch, merge, rebase 없이
+review-only commit만 code candidate 위에 잇는다. contributor가 review 도중 source를 갱신한 경우에는 새 source를
+기존 reviewer 기록에 merge하지 말고 [2.6.1 외부 PR review 기록의 source head 정렬](multi_pr_update_branch.md#261-외부-pr-review-기록의-source-head-정렬)을
 적용해 reviewer 기록만 새 source 위로 replay한다.
 
 local Cargo 성공만으로 candidate의 GitHub Actions를 대체하지 않는다. candidate workflow의 PR identity 불일치,
@@ -72,7 +75,8 @@ all-review-only-no-code-impact fast-pass를 즉시 선택한다. candidate의 �
 - code, test, CI workflow, Cargo.lock 변경
 - 기존 sample, PDF, golden, baseline, fixture의 수정·삭제·rename
 - 허용 목록 밖의 신규 파일
-- A 경로의 candidate workflow 누락·실패·미완료·PR identity 불일치 또는 허용되지 않은 merge 형태
+- A 경로의 candidate workflow 누락·실패·미완료·PR identity 불일치, current-base merge tree 불일치·충돌·조회 실패,
+  또는 허용되지 않은 merge 형태
 - preflight가 fast_pass=false를 반환
 
 fast-pass는 merge 조건을 없애지 않는다. 최신 head, mergeable 상태, required aggregate, 작업지시자 승인을

--- a/mydocs/orders/20260806.md
+++ b/mydocs/orders/20260806.md
@@ -1,5 +1,19 @@
 # 오늘 할 일 - 2026년 8월 6일
 
+## PR #4102 - current-base 병합 뒤 review-only fast-pass
+
+- [#4101](https://github.com/edwardkim/rhwp/issues/4101)의 #4073 재실행 사례를 기준으로, green code head 뒤
+  current base를 source에 병합하고 문서 기록만 추가한 경우의 preflight 후보 탐색을 보정했다.
+- bridge는 current base를 정확히 한 부모로 둔 2-parent merge만 허용하며, `git merge-tree` 결과가 실제 tree와
+  같은지 source 비실행 방식으로 검증한다. 불일치·충돌·조회 실패·다중 bridge·일반 merge는 full CI로 남긴다.
+- workflow fast-pass 계약 4건, CI 영향 workflow 계약 18건, 분류기 27건, `actionlint`, 공백 검사를 통과했고,
+  #4073의 `f10691230`·`d76d4e98` 자동 merge tree가 `49d2511e9` tree와 일치함을 재현했다.
+- code head `b38d715f7`의 전체 CI·CodeQL은 성공했다. 이 review·오늘할일 trailing commit을 push한 뒤 same-PR
+  candidate 재사용으로 heavy worker가 skip되는 aggregate와 최신 mergeability를 확인하고 merge한다.
+
+상세 근거: [PR #4102 검토](../pr/archives/pr_4102_review.md),
+[구현·검토 기록](../pr/archives/pr_4102_review_impl.md).
+
 ## PR #4073 - schema-validator `oneOf` 선택 대안 WARNING 보존
 
 - [PR #4073](https://github.com/edwardkim/rhwp/pull/4073)의 contributor 원 head

--- a/mydocs/pr/archives/pr_4102_review.md
+++ b/mydocs/pr/archives/pr_4102_review.md
@@ -1,0 +1,66 @@
+---
+kind: pr_review
+status: accepted-awaiting-review-only-fast-pass
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-06
+---
+
+# PR #4102 검토 - current-base 병합 뒤 review-only fast-pass
+
+## 절차와 대상
+
+~~~text
+base route: collaborator self-merge
+modifiers: intake_and_review, local_validation, review_only_fast_pass
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+  collaborator_self_merge.md, intake_and_review.md, local_validation.md,
+  review_only_fast_pass.md
+~~~
+
+| 항목 | 값 |
+| --- | --- |
+| PR / 작성자 | [#4102](https://github.com/edwardkim/rhwp/pull/4102) / @jangster77 |
+| 관련 이슈 | [#4101](https://github.com/edwardkim/rhwp/issues/4101) |
+| code head | `b38d715f76de12389133c12aeb24542f89f78e46` |
+| base | `devel` / 문서 작성 시점 `e5e2ecc7c` |
+| 규모 | 6개 파일, +266/-42 |
+| 시각 검증 | 비대상. renderer, HWP/HWPX fixture, Studio UI 변경이 없다. |
+
+## 문제와 보정
+
+[#4073](https://github.com/edwardkim/rhwp/pull/4073)는 green code head `f10691230` 뒤에 current base
+`d76d4e98`을 source에 병합한 `49d2511e9`, 그리고 review 기록 `a911a1110`을 추가했다. 기존 preflight는
+commit 파일 목록을 먼저 보므로 `49d2511e9`를 새 code candidate로 오인했고, 그 SHA의 과거 workflow가 없어
+전체 CI를 다시 실행했다.
+
+PR #4102는 다음의 제한된 bridge만 재사용한다.
+
+1. trailing single-parent review-only commit이 하나 이상 있어야 한다.
+2. bridge는 정확히 두 부모이고 그중 하나만 current PR base SHA여야 한다.
+3. 다른 부모와 current base의 `git merge-tree --write-tree` 결과가 실제 bridge merge tree와 같아야 한다.
+4. 동일 PR·동일 source repository의 green CI/CodeQL candidate가 있어야 한다.
+
+tree 검증은 `refs/pull/<번호>/head`를 읽기 전용으로 checkout할 뿐 source를 실행하지 않는다. tree 충돌·불일치,
+입력 조회 실패, 다중 bridge, 일반 merge, candidate 실패·부재는 모두 `fast_pass=false`로 full CI를 유지한다.
+
+## 로컬 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| workflow fast-pass 계약 | `python3 scripts/tests/test_review_only_fast_pass_workflows.py`: 4 passed |
+| CI 영향 workflow 계약 | `python3 scripts/tests/test_ci_impact_workflow.py`: 18 passed |
+| CI 영향 분류기 | `node scripts/tests/ci-impact-classifier.test.cjs`: 27 passed |
+| workflow 구문 | `actionlint .github/workflows/ci.yml .github/workflows/codeql.yml` 통과 |
+| 공백 오류 | `git diff --check` 통과 |
+| #4073 실물 tree | `git merge-tree --write-tree f10691230 d76d4e98` 결과가 `49d2511e9`의 tree `e76548e3`와 일치 |
+
+## GitHub Actions와 수용 판단
+
+`b38d715f7`의 전체 [CI](https://github.com/edwardkim/rhwp/actions/runs/31087721202)와
+[CodeQL](https://github.com/edwardkim/rhwp/actions/runs/31087720657)은 성공했다. CI preflight와 CodeQL
+preflight에서 bridge 검증 step은 일반 code PR이므로 각각 skip됐고, 이후 full lane의 Lint, Frontend package,
+Native Skia, archive 3개, slow·일반 shard 3개, Build & Test aggregate, CodeQL 세 언어 분석이 모두 성공했다.
+
+**수용.** 이 trailing docs-only commit을 push한 뒤 최신 head가 같은 candidate `b38d715f7`를 재사용해
+preflight·aggregate를 성공시키고 heavy worker를 skip하는지, 그리고 `mergeable=MERGEABLE`·`mergeStateStatus=CLEAN`을
+다시 확인한 뒤 작업지시자 승인에 따라 merge한다.

--- a/mydocs/pr/archives/pr_4102_review_impl.md
+++ b/mydocs/pr/archives/pr_4102_review_impl.md
@@ -1,0 +1,33 @@
+---
+kind: review-implementation
+status: completed-local-awaiting-final-fast-pass
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-06
+---
+
+# PR #4102 구현·검토 기록
+
+## commit 경계
+
+| 순서 | SHA | 역할 |
+| --- | --- | --- |
+| 1 | `b38d715f7` | current-base merge bridge 검증, workflow 회귀 테스트, 운영 문서 보정 |
+| 2 | 이 commit | PR review·오늘할일 trailing review-only 기록 |
+
+## 완료 단계
+
+1. [#4101](https://github.com/edwardkim/rhwp/issues/4101)에 #4073의 full CI 재실행 원인과 fail-closed 요구사항을 기록했다.
+2. CI와 CodeQL의 inline preflight에 pending bridge 상태를 추가했다.
+3. current base를 정확히 한 부모로 둔 merge만 bridge 후보로 보관하고, PR head를 실행하지 않는 `git merge-tree`
+   검증이 true일 때만 final `fast_pass=true`를 출력하도록 했다.
+4. bridge 검증 실패는 preflight 자체를 실패시키지 않고 final `fast_pass=false`로 내려 full lane을 실행하게 했다.
+5. workflow 계약·CI 영향 분류·`actionlint`·#4073 실제 tree 재현과 code head 전체 CI·CodeQL을 완료했다.
+
+## 남은 순서
+
+1. 이 review-only commit push 뒤 preflight와 최종 Build & Test aggregate가 성공하고 heavy worker가 skip됐는지 확인한다.
+2. 최신 PR head와 `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN`을 확인한다.
+3. 작업지시자 승인 뒤 merge하고, #4101 close 상태·후속 comment·`devel` 동기화·작업 branch 정리를 수행한다.
+
+새로운 source merge를 만드는 것은 이 구현의 검증 절차가 아니다. future PR에서 이미 발생한 current-base merge가
+자동 tree 조건을 만족할 때만 이 호환 경로가 선택된다.

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -130,7 +130,7 @@ class CiImpactWorkflowTests(unittest.TestCase):
         ):
             with self.subTest(step=step_name):
                 self.assertIn(
-                    "if: ${{ steps.detect.outputs.fast_pass != 'true' }}",
+                    "if: ${{ steps.finalize.outputs.fast_pass != 'true' }}",
                     self._step(step_name, self.preflight),
                 )
 

--- a/scripts/tests/test_review_only_fast_pass_workflows.py
+++ b/scripts/tests/test_review_only_fast_pass_workflows.py
@@ -34,6 +34,23 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
                 self.assertIn("listJobsForWorkflowRun", workflow)
                 self.assertIn("runCreatedAt < pullCreatedAt", workflow)
 
+    def test_current_base_update_merge_requires_an_automatic_merge_tree(self) -> None:
+        for name in ("ci", "codeql"):
+            with self.subTest(workflow=name):
+                workflow = WORKFLOWS[name].read_text(encoding="utf-8")
+                self.assertIn("isCurrentBaseUpdateMerge", workflow)
+                self.assertIn("pending-base-merge-tree", workflow)
+                self.assertIn("multiple-current-base-update-merges", workflow)
+                self.assertIn("git merge-tree --write-tree", workflow)
+                self.assertIn("current-base-merge-tree-mismatch", workflow)
+                self.assertIn("current-base-update-merge-tree-green", workflow)
+                self.assertIn(
+                    "ref: refs/pull/${{ github.event.pull_request.number }}/head",
+                    workflow,
+                )
+                self.assertIn("lfs: false", workflow)
+                self.assertIn("persist-credentials: false", workflow)
+
     def test_render_diff_keeps_its_existing_pr_identity_guard(self) -> None:
         workflow = WORKFLOWS["render-diff"].read_text(encoding="utf-8")
         self.assertIn("render-diff-workflow-pr-identity-mismatch", workflow)


### PR DESCRIPTION
## 변경

Resolves [#4101](https://github.com/edwardkim/rhwp/issues/4101).

- CI·CodeQL preflight가 `현재 PR base`를 정확히 한 부모로 갖는 2-parent source merge를 임시 bridge로 식별한다.
- bridge 아래의 동일 PR·동일 source repository 녹색 candidate를 찾은 뒤, PR source를 실행하지 않고
  `git merge-tree --write-tree` 결과와 실제 merge tree가 같은지 확인한다.
- tree 일치일 때만 fast-pass를 확정한다. 충돌·tree 불일치·입력 fetch 실패·다중 current-base merge·일반 merge는
  기존처럼 full CI로 fallback한다.
- workflow 계약 테스트와 review-only 운영 문서를 같은 조건으로 갱신했다.

## 검증

- `python3 scripts/tests/test_review_only_fast_pass_workflows.py` — 4 passed
- `python3 scripts/tests/test_ci_impact_workflow.py` — 18 passed
- `node scripts/tests/ci-impact-classifier.test.cjs` — 27 passed
- `actionlint .github/workflows/ci.yml .github/workflows/codeql.yml`
- `git diff --check`
- PR #4073의 `f10691230` + `d76d4e98` 자동 merge tree가 `49d2511e9` tree와 일치함을 로컬 Git으로 재현

## 범위

Rust renderer, HWP/HWPX fixture, Studio UI 변경이 없으므로 시각 검증은 비대상이다.
