### PR TITLE
ci: Native Skia와 기본 테스트 shard 의존성 분리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,19 +657,15 @@ jobs:
 
   test-slow-shard:
     uses: ./.github/workflows/run-nextest-archives.yml
-    needs: [preflight, native-skia-tests, build-test-archive-slow]
+    # [#4103] shard는 archive만 소비한다. Native Skia는 final aggregate가 별도 집계하므로
+    # 여기서 기다리지 않아 archive 완료 즉시 기본 테스트를 시작할 수 있다.
+    needs: [preflight, build-test-archive-slow]
     if: >-
       ${{
         always()
         && needs.preflight.result == 'success'
         && needs.preflight.outputs.fast_pass != 'true'
         && needs.preflight.outputs.rust_required == 'true'
-        && (
-          (needs.preflight.outputs.native_skia_required == 'true'
-            && needs['native-skia-tests'].result == 'success')
-          || (needs.preflight.outputs.native_skia_required == 'false'
-            && needs['native-skia-tests'].result == 'skipped')
-        )
         && needs['build-test-archive-slow'].result == 'success'
       }}
     permissions:
@@ -681,19 +677,13 @@ jobs:
 
   test-regular-shard-1:
     uses: ./.github/workflows/run-nextest-archives.yml
-    needs: [preflight, native-skia-tests, build-test-archive-a]
+    needs: [preflight, build-test-archive-a]
     if: >-
       ${{
         always()
         && needs.preflight.result == 'success'
         && needs.preflight.outputs.fast_pass != 'true'
         && needs.preflight.outputs.rust_required == 'true'
-        && (
-          (needs.preflight.outputs.native_skia_required == 'true'
-            && needs['native-skia-tests'].result == 'success')
-          || (needs.preflight.outputs.native_skia_required == 'false'
-            && needs['native-skia-tests'].result == 'skipped')
-        )
         && needs['build-test-archive-a'].result == 'success'
       }}
     permissions:
@@ -705,19 +695,13 @@ jobs:
 
   test-regular-shard-2:
     uses: ./.github/workflows/run-nextest-archives.yml
-    needs: [preflight, native-skia-tests, build-test-archive-slow]
+    needs: [preflight, build-test-archive-slow]
     if: >-
       ${{
         always()
         && needs.preflight.result == 'success'
         && needs.preflight.outputs.fast_pass != 'true'
         && needs.preflight.outputs.rust_required == 'true'
-        && (
-          (needs.preflight.outputs.native_skia_required == 'true'
-            && needs['native-skia-tests'].result == 'success')
-          || (needs.preflight.outputs.native_skia_required == 'false'
-            && needs['native-skia-tests'].result == 'skipped')
-        )
         && needs['build-test-archive-slow'].result == 'success'
       }}
     permissions:
@@ -729,19 +713,13 @@ jobs:
 
   test-regular-shard-3:
     uses: ./.github/workflows/run-nextest-archives.yml
-    needs: [preflight, native-skia-tests, build-test-archive-b]
+    needs: [preflight, build-test-archive-b]
     if: >-
       ${{
         always()
         && needs.preflight.result == 'success'
         && needs.preflight.outputs.fast_pass != 'true'
         && needs.preflight.outputs.rust_required == 'true'
-        && (
-          (needs.preflight.outputs.native_skia_required == 'true'
-            && needs['native-skia-tests'].result == 'success')
-          || (needs.preflight.outputs.native_skia_required == 'false'
-            && needs['native-skia-tests'].result == 'skipped')
-        )
         && needs['build-test-archive-b'].result == 'success'
       }}
     permissions:

--- a/mydocs/orders/20260806.md
+++ b/mydocs/orders/20260806.md
@@ -1,5 +1,22 @@
 # 오늘 할 일 - 2026년 8월 6일
 
+## PR #4104 - Native Skia와 기본 테스트 shard 의존성 분리
+
+- [#4103](https://github.com/edwardkim/rhwp/issues/4103)의 수용 기준에 따라 네 기본 테스트 shard의
+  `native-skia-tests` `needs`와 실행 조건을 제거했다. 각 shard는 이제 preflight와 자신이 소비하는
+  archive만 기다린다.
+- `native-skia-tests`는 독립 job으로 유지하고, `Build & Test` aggregate의 Native Skia 결과 검증과
+  `needs`는 보존했다. 따라서 Native Skia 실패·취소는 계속 aggregate 실패가 된다.
+- workflow 계약 18건, review-only fast-pass 계약 4건, `actionlint`, 공백 검사를 통과했다.
+- [CI 31092097921](https://github.com/edwardkim/rhwp/actions/runs/31092097921?pr=4104)과
+  [CodeQL 31092097642](https://github.com/edwardkim/rhwp/actions/runs/31092097642?pr=4104)가 모두
+  성공했다. Lint 종료 뒤 Native Skia와 archive A/B/slow가 10:13:10~12에 병렬 시작했고, archive
+  완료에 맞춰 해당 shard가 시작하며 final aggregate도 성공했다.
+- 이 review·오늘할일 trailing commit을 push해 fast-pass aggregate와 최신 mergeability를 확인한 뒤
+  merge한다.
+
+상세 근거: [PR #4104 검토](../pr/archives/pr_4104_review.md).
+
 ## PR #4087 - build-from-ingest 기반 HWPX 테스트 데이터 생성기
 
 - [PR #4087](https://github.com/edwardkim/rhwp/pull/4087)의 contributor 원 head

--- a/mydocs/pr/archives/pr_4104_review.md
+++ b/mydocs/pr/archives/pr_4104_review.md
@@ -1,0 +1,56 @@
+---
+kind: pr_review
+status: accepted
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-06
+---
+
+# PR #4104 검토 - Native Skia와 기본 테스트 shard 의존성 분리
+
+## 대상과 변경 경계
+
+| 항목 | 값 |
+| --- | --- |
+| PR / 이슈 | [#4104](https://github.com/edwardkim/rhwp/pull/4104) / [#4103](https://github.com/edwardkim/rhwp/issues/4103) |
+| code head | `a86ae08b58ac3dcfdcffac9a0195bab6035a5998` |
+| base | `0102a7ae2be8c06ada3636326c82858de890cef9` |
+| 브랜치 | `task/4103-native-skia-shard-parallel` |
+| 대상 경로 | `.github/workflows/ci.yml`, `scripts/tests/test_ci_impact_workflow.py` |
+| 시각 검증 | 비대상. CI scheduling 및 workflow 계약만 변경한다. |
+
+기존 네 기본 테스트 shard는 `native-skia-tests`를 `needs`와 실행 조건에 함께 넣어, 각자가
+소비하는 test archive가 준비돼도 Native Skia가 성공할 때까지 시작하지 못했다. Native Skia는
+shard에 artifact나 실행 결과를 전달하지 않는다.
+
+## 변경과 안전 계약
+
+각 shard의 선행 job은 `preflight`와 자신이 받는 archive로만 축소했다. `native_skia_required`와
+`native-skia-tests` 결과 분기도 shard 조건에서 제거했다. 반면 `native-skia-tests`는 기존 독립 검증
+job으로 남고, `Build & Test` final aggregate의 `needs` 및 Native Skia 결과 검증은 유지한다. 따라서
+Native Skia 실패·취소는 여전히 PR 성공으로 집계되지 않는다.
+
+회귀 테스트는 네 shard가 정확히 자신의 archive만 기다리고 Native Skia 문자열을 포함하지 않는지,
+Native Skia job이 archive·shard를 기다리지 않는지, final aggregate가 Native Skia를 계속 필요로 하는지를
+고정한다.
+
+## 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| workflow 계약 | `python3 scripts/tests/test_ci_impact_workflow.py` 18 passed |
+| review-only fast-pass 계약 | `python3 scripts/tests/test_review_only_fast_pass_workflows.py` 4 passed |
+| workflow 정적 검사 | `actionlint .github/workflows/ci.yml` 통과 |
+| 공백 검사 | `git diff --check` 통과 |
+| GitHub CI | [CI 31092097921](https://github.com/edwardkim/rhwp/actions/runs/31092097921?pr=4104) 전체 성공 |
+| CodeQL | [CodeQL 31092097642](https://github.com/edwardkim/rhwp/actions/runs/31092097642?pr=4104) 전체 성공 |
+
+원격 실행에서 Lint는 10:13:07에 끝났고, Native Skia와 archive A/B/slow는 10:13:10~12에 함께
+시작했다. Native Skia는 10:18:16에, archive B는 10:18:56에, slow는 10:19:06에 완료됐다. archive
+B/slow 완료 직후 shard 3·slow·2가 10:19:06~09에 시작했으며, archive A 완료(10:21:52) 뒤 shard 1도
+10:21:55에 시작했다. 이번 실행에서는 Native Skia가 archive보다 먼저 끝나 시간상 역전 사례는 없었지만,
+workflow graph 의존성과 정적 회귀 계약에서 shard의 Native Skia 선행 관계가 제거됐음을 확인했다.
+
+## 수용 판단
+
+**수용.** CI·CodeQL과 final `Build & Test` aggregate가 성공했고, Native Skia 결과의 최종 실패 집계는
+보존됐다. 이 review-only 기록을 push한 뒤 fast-pass aggregate와 최신 mergeability를 확인하고 병합한다.

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -198,6 +198,9 @@ class CiImpactWorkflowTests(unittest.TestCase):
         self.assertIn("frontend_mode == 'none'", native)
         self.assertIn("frontend_mode == 'unit'", native)
         self.assertIn("frontend_mode == 'package'", native)
+        self.assertNotIn("build-test-archive-", native)
+        self.assertNotIn("test-regular-shard", native)
+        self.assertNotIn("test-slow-shard", native)
 
     def test_aggregate_harness_stops_at_the_next_job_boundary(self) -> None:
         step = self._step("Check Build & Test worker results")
@@ -214,25 +217,27 @@ class CiImpactWorkflowTests(unittest.TestCase):
             with self.subTest(target=target):
                 self.assertIn(f"'tests/{target}.rs'", classifier)
 
-    def test_rust_workers_require_expected_native_skia_state(self) -> None:
-        for job_name in (
-            "test-slow-shard",
-            "test-regular-shard-1",
-            "test-regular-shard-2",
-            "test-regular-shard-3",
-        ):
+    def test_rust_workers_wait_only_for_their_test_archive(self) -> None:
+        expected_archives = {
+            "test-slow-shard": "build-test-archive-slow",
+            "test-regular-shard-1": "build-test-archive-a",
+            "test-regular-shard-2": "build-test-archive-slow",
+            "test-regular-shard-3": "build-test-archive-b",
+        }
+        for job_name, archive in expected_archives.items():
             with self.subTest(job=job_name):
                 job = self._job(job_name)
                 self.assertIn("needs.preflight.outputs.rust_required == 'true'", job)
-                self.assertIn("native_skia_required == 'true'", job)
-                self.assertIn("needs['native-skia-tests'].result == 'success'", job)
-                self.assertIn("native_skia_required == 'false'", job)
-                self.assertIn("needs['native-skia-tests'].result == 'skipped'", job)
+                self.assertIn(f"needs: [preflight, {archive}]", job)
+                self.assertIn(f"needs['{archive}'].result == 'success'", job)
+                self.assertNotIn("native-skia-tests", job)
+                self.assertNotIn("native_skia_required", job)
 
     def test_aggregate_validates_expected_success_and_skipped_states(self) -> None:
         aggregate = self._job("build-and-test")
         self.assertIn("- frontend-unit-gates", aggregate)
         self.assertIn("- frontend-package-gates", aggregate)
+        self.assertIn("- native-skia-tests", aggregate)
         self.assertIn("RUST_REQUIRED:", aggregate)
         self.assertIn("NATIVE_SKIA_REQUIRED:", aggregate)
         self.assertIn("Rust lane expected success", aggregate)


### PR DESCRIPTION
## 요약

- 기본 테스트 shard 네 개가 `native-skia-tests`를 기다리지 않고, 자신이 소비하는 archive build 완료 후 바로 시작하도록 수정했습니다.
- Native Skia는 독립 검증 job으로 유지하며, `Build & Test` final aggregate가 계속 결과를 집계해 실패·취소를 PR 실패로 처리합니다.
- workflow 계약 테스트에 shard의 Native Skia 비의존성과 Native Skia의 archive/shard 비의존성을 고정했습니다.

Closes #4103

## 로컬 검증

- `python3 scripts/tests/test_ci_impact_workflow.py` (18 passed)
- `python3 scripts/tests/test_review_only_fast_pass_workflows.py` (4 passed)
- `actionlint .github/workflows/ci.yml`
- `git diff --check`

## 확인 예정

- GitHub Actions에서 Native Skia와 archive build가 병렬 시작되는지
- 각 shard가 자신의 archive 완료 뒤 Native Skia 완료 전에도 시작되는지
- Native Skia 실패가 `Build & Test` aggregate를 계속 실패시키는지