### PR TITLE
docs(protocol): 병렬 세션 잠금 규약을 실무 절차에 편입 — playbook §2 0단계 + 잠금 매체 실측 (#3914)

### DIFF
--- a/mydocs/manual/agent_surface_playbook.md
+++ b/mydocs/manual/agent_surface_playbook.md
@@ -56,6 +56,19 @@ helper 를 재사용한다. 서버 전용 경로를 새로 만들면 CLI 와 계
 
 ## 2. 추가 절차 (순서 고정)
 
+0. **잠금 확인·할당 (착수 = 할당)** — 조사보다 먼저 한다. 대상 이슈의 assignee 와
+   같은 이슈를 가리키는 열린 PR 을 확인하고, 비어 있으면 즉시 선점한다.
+   ```bash
+   gh issue view <n> --repo edwardkim/rhwp --json assignees -q '.assignees[].login'
+   gh pr list --repo edwardkim/rhwp --state open --limit 100 --search "<n>"
+   gh issue edit <n> --repo edwardkim/rhwp --add-assignee @me   # 권한 있는 계정만 성공
+   ```
+   **외부 기여자 계정은 assignee 편집이 거부된다**(실측 2026-08-06:
+   `gh issue edit --add-assignee` 가 `failed to update 1 issue` — 3회 재현). 그 경우
+   **이슈에 착수 코멘트("착수합니다 — <범위>")를 남기는 것이 잠금**이다. 선점된
+   이슈(assignee 있음 또는 착수 코멘트 있음)는 착수하지 않고, 작업을 접으면 즉시
+   해제(코멘트)한다. 사고 사례·판정 기준·볼륨 캡의 canonical 은
+   [병렬 세션 규약](../tech/autonomous_maintenance/parallel_session_protocol.md)이다.
 1. **이슈 등록** — 공백을 실측으로 서술하고(#3608 매트릭스 갱신 포함) 검증 계획을 적는다.
 2. **red 계약 테스트** — `tests/*_contract.rs` 신설. 구현 전 FAILED 를 확인한다.
    기존 테스트 파일 수정보다 신설을 우선한다(병렬 PR 충돌 회피).
@@ -63,8 +76,15 @@ helper 를 재사용한다. 서버 전용 경로를 새로 만들면 CLI 와 계
 4. **검증** — 신규 green + 인접 계약 스위트 무회귀 + `clippy -D warnings` 0 +
    rustfmt clean(변경 파일 기준).
 5. **누적 머지 충돌검사** — `upstream/devel` 에서 임시 브랜치를 만들어 열린 PR
-   브랜치 전부를 순차 merge, 충돌 0 확인. 겹치는 파일이 있으면 적층(베이스 PR 을
-   본문에 명시)으로 전환한다.
+   브랜치 전부를 순차 merge, 충돌 0 확인. 겹치는 파일이 있으면 **선등재 성립
+   여부를 먼저 보고**, 안 되면 적층(베이스 PR 을 본문에 명시, 체인 3단 이하)으로
+   전환한다.
+
+   **접합 기법 — 선등재**: 겹침이 "목록·표에 한 줄 추가" 형태이고 그 목록의 소비자가
+   기준 집합만 순회한다면(초과 항목 무해), 상대 PR 이 추가할 항목을 미리 등재해
+   머지 순서와 무관하게 무수정 통과시킬 수 있다. 실증 #3903 ↔ #3808 (SWEEP_EXEMPT
+   면제 호출표 선등재 — 누적 머지로 전후 대조). 성립 조건과 한계의 canonical 은
+   [선등재 패턴](../tech/autonomous_maintenance/pre_registration_pattern.md).
 6. **처리 문서 + 증적 2종** — `mydocs/report/task_m100_<이슈>/README.md` 에:
    ① 실행 원문(터미널 봉투) 캡처 ② **산출물을 실제 rhwp 로 열어 렌더한 화면**
    (`export-svg` → PNG 변환 → 합성). 편집 계열은 전/후 비교로.

--- a/mydocs/tech/autonomous_maintenance/parallel_session_protocol.md
+++ b/mydocs/tech/autonomous_maintenance/parallel_session_protocol.md
@@ -2,7 +2,7 @@
 kind: canonical
 status: active
 canonical: mydocs/tech/autonomous_maintenance/parallel_session_protocol.md
-last_verified: 2026-08-04
+last_verified: 2026-08-06
 ---
 
 # 병렬 세션 규약 — 착수 = 할당
@@ -29,7 +29,8 @@ last_verified: 2026-08-04
 ```bash
 gh issue view <n> --repo edwardkim/rhwp --json assignees -q '.assignees[].login'
 gh pr list --repo edwardkim/rhwp --state open --limit 100 --search "<n>"
-gh issue edit <n> --repo edwardkim/rhwp --add-assignee @me
+gh issue edit <n> --repo edwardkim/rhwp --add-assignee @me   # 권한 있는 계정만 성공
+gh issue comment <n> --repo edwardkim/rhwp --body "착수합니다 — <범위>"  # 외부 기여자의 잠금은 이것
 ```
 
 ---
@@ -321,8 +322,24 @@ gh issue view <n> --repo edwardkim/rhwp --json assignees -q '.assignees[].login'
 gh issue edit <n> --repo edwardkim/rhwp --add-assignee @me
 ```
 
-**assignee 가 이미 있으면 착수하지 않는다.** 같은 계정이 이미 걸려 있어도 마찬가지다 —
-같은 계정의 다른 세션이 잡고 있다는 뜻이기 때문이고, 그게 정확히 이 사고의 형태다.
+> [!IMPORTANT]
+> **실측(2026-08-06): 외부 기여자 계정은 assignee 편집이 거부된다.** #3914·#3884·#3627
+> 세 이슈에 `gh issue edit <n> --add-assignee kevin9327` 을 실행한 결과 세 건 모두
+> `failed to update 1 issue` — GitHub 는 collaborator(또는 해당 이슈에 assignable 한
+> 계정)만 지정을 허용한다. 명령 자체는 실행되므로 `gh` 의 projectCards 문제(아래 NOTE)와는
+> 별개다. 따라서 잠금 매체는 계정 권한에 따라 갈린다:
+>
+> | 계정 | 1차 잠금 매체 |
+> |---|---|
+> | 메인테이너·collaborator | `assignee` 지정 |
+> | **외부 기여자(병렬 세션 포함)** | **이슈 착수 코멘트** — `"착수합니다 — <범위>"` 형식, 범위를 반드시 적는다(§10-3 부분 잠금 겸용) |
+>
+> 착수 전 확인도 두 매체를 다 본다 — assignee 가 비어 있어도 **착수 코멘트가 있으면
+> 선점된 것**이다. 이 실측으로 §11 의 미확인 4번이 해소됐다.
+
+**assignee(또는 착수 코멘트)가 이미 있으면 착수하지 않는다.** 같은 계정이 이미 걸려
+있어도 마찬가지다 — 같은 계정의 다른 세션이 잡고 있다는 뜻이기 때문이고, 그게 정확히
+이 사고의 형태다.
 
 **작업을 접거나 미루면 즉시 해제한다.** 걸어 놓고 안 하는 것은 큐를 막는다.
 
@@ -660,7 +677,7 @@ gh pr list --repo edwardkim/rhwp --state open --limit 100 --json number,body \
 
 | 시점 | 할 것 | 명령 |
 |---|---|---|
-| **착수 결정 직후** | assignee 확인 → 비었으면 할당 | `gh issue view <n> --json assignees` / `gh issue edit <n> --add-assignee @me` |
+| **착수 결정 직후** | assignee·착수 코멘트 확인 → 비었으면 선점 (외부 기여자는 착수 코멘트가 잠금 — §5-1 실측) | `gh issue view <n> --json assignees` / `gh issue edit <n> --add-assignee @me` / `gh issue comment <n> --body "착수합니다 — <범위>"` |
 | 〃 | 같은 이슈의 열린 PR 확인 | `gh pr list --state open --limit 100 --search "<n>"` |
 | 〃 | 열린 PR 잔량 확인 (10건 내외) | `gh pr list --author @me --state open --limit 100 -q length` |
 | **브랜치** | `upstream/devel` 기준. 적층은 3단 이하 | — |
@@ -710,7 +727,7 @@ gh pr list --repo edwardkim/rhwp --state open --limit 100 --json number,body \
 | 1 | [README](README.md) §3-2 의 08-01 개설 건수 불일치(문서 14 vs 실측 48)의 **원인** | `28+18+14=60` 이 정확히 떨어져 "최신 60건 조회 절단"이 유력하나, 원 명령을 복원해 확인하지 못함 |
 | 2 | 볼륨 캡 **10 이라는 숫자의 산출 근거**(리뷰 처리량 실측 등) | 메인테이너 요청값이라는 것만 확인. 산출 과정은 확인 못 함 |
 | 3 | 적층(stacking) 허용 여부 — #3719 §7 은 "3단 이하 안전", #3796 §6 은 "적층 금지" | **두 문서가 어긋난다.** 어느 쪽이 현행인지 확인 못 함 |
-| 4 | `gh issue edit --add-assignee` 가 이 저장소에서 정상 동작하는지 | `gh pr edit` 는 projectCards 조회로 실패한다고 기록됨(`../../orders/20260722.md`). `gh issue edit` 도 같은 제약인지 실행으로 확인 못 함 |
+| 4 | ~~`gh issue edit --add-assignee` 가 이 저장소에서 정상 동작하는지~~ | **해소(2026-08-06 실측, §5-1)** — 명령은 실행되나 외부 기여자 권한으로 `failed to update 1 issue`(3이슈 3회 재현). projectCards 류 오류가 아니라 GitHub assignable 권한 제약. 우회 = 착수 코멘트 선점 |
 | 5 | 인계 커밋 `e54f16e14`(#3902) · `d0a1dc360`(#3904) 의 현재 접근 가능 여부 | 닫힌 PR 의 브랜치라 정리됐을 수 있음. 확인 못 함 |
 | 6 | 이슈 **부분 범위** 잠금(코멘트 선언 등)의 실효성 | 제안일 뿐 실증 없음 |
 | 7 | 잠금 **만료 규칙**의 존재 | 저장소에서 찾지 못함 |


### PR DESCRIPTION
## 무엇 (로드맵 R93 + R92 의 실무 편입)

병렬 세션 규약(#3914, canonical: `mydocs/tech/autonomous_maintenance/parallel_session_protocol.md`)은 문서로는 확정됐지만, 그 문서 §4-4 스스로 지적하듯 **실무 진입점인 `agent_surface_playbook.md` §2 절차에는 잠금 단계가 없었습니다**. 규약이 있어도 절차에 없으면 도달하지 않는다는 것이 두 사고(#3902/#3903, #3897/#3904)의 교훈이라, 절차에 끌어올립니다.

## 변경

1. **playbook §2 에 0단계 신설** — 잠금 확인·할당(조사보다 먼저): assignee·착수 코멘트·같은 이슈 열린 PR 3중 확인 후 선점. protocol 문서 §5-0 제안의 이행입니다.
2. **playbook §2-5 에 선등재 접합 절 추가** (R92) — 겹침이 "기준 집합만 순회하는 목록" 형태면 상대 항목을 미리 등재해 머지 순서 무관 무수정 통과. 실증 #3903↔#3808, canonical 은 `pre_registration_pattern.md`.
3. **잠금 매체 실측 반영** — 오늘(2026-08-06) #3914·#3884·#3627 세 이슈에 `gh issue edit --add-assignee kevin9327` 실행 결과 **3건 모두 `failed to update 1 issue`**: 외부 기여자는 GitHub assignable 권한이 없어 assignee 를 걸 수 없습니다. 규약의 잠금 매체를 계정 권한별로 분리했습니다 — collaborator 는 assignee, **외부 기여자(병렬 세션 포함)는 이슈 착수 코멘트("착수합니다 — <범위>")가 1차 잠금**. protocol §5-1 에 실측 표, §0·§9 요약 갱신, §11 미확인 4번 해소.

## 검증

- 신설 상호 링크 2건(playbook→protocol, playbook→pre_registration_pattern) 실파일 존재 확인.
- 열린 PR 6건(#4104·#4096·#4094·#4093·#4084·#4082)의 변경 파일 42개와 이 PR 의 2개 파일 교집합 0 — 충돌면 없음.

## 로드맵 연동

- R93 `[실측]`: DoD "워크플로 문서가 assignee 선점을 세션 간 잠금으로 명문화" — 이 PR 이 그 명문화입니다(+실측으로 매체 보정).
- R92 `[실측]`: DoD "선등재 패턴이 playbook 에 한 절로 문서화되고 실증 사례가 링크" — §2-5 신설 절이 그것입니다.
- 태그 갱신(→완료)은 머지 후 #3907 코멘트로 짝 맞춰 반영합니다(운영 규칙 2).

refs #3914

🤖 Generated with [Claude Code](https://claude.com/claude-code)