### PR TITLE
feat(mcp): resources 표면 잔여 — 스키마 3종·레시피 6편을 프로토콜 경로로 (#3627)

### DIFF
--- a/mydocs/report/task_m100_3627_resources_r74.md
+++ b/mydocs/report/task_m100_3627_resources_r74.md
@@ -1,0 +1,48 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_3627_resources_r74.md
+last_verified: 2026-08-06
+---
+
+# 처리 결과 — MCP resources 잔여: 스키마 3종 + 레시피 6편 (#3627, 로드맵 R74)
+
+## 분석 — 지도가 낡아 있었고, 공백은 절반이었다
+
+로드맵 R74 의 "지금"은 "resources/* 는 미구현"이라 적지만 **실물은 다르다** —
+`src/mcp_serve.rs` 에 resources/list·resources/read 가 이미 있고(매니페스트 +
+문서 3편: llms.txt·지식 지도·실패 사전), 계약 테스트도 있다(2026-08-06 실측).
+남은 공백은 R74 설계가 지목한 노출 목록의 절반: **스키마(export-*-schema)와
+레시피가 여전히 CLI·파일로만 닿는다.**
+
+## 설계 판단
+
+- **스키마 = 생성기, 레시피 = include_str!** — 두 부류의 본문 성질이 다르다.
+  스키마는 코드에서 파생되므로 파일로 얼리면 첫 변경부터 낡는다 → lib 의
+  `ir_schema()`·`plan_schema()`·`capabilities_schema()` 를 직접 부른다(단일 출처:
+  CLI 의 export-*-schema 와 같은 함수). 레시피는 저장소 문서가 원본이므로 기존
+  DOC_RESOURCES 방식(컴파일 시점 안기)을 그대로 따른다.
+- **드리프트 가드는 왕복으로** — 목록을 하드코딩 재대조하지 않고
+  `resources/list → resources/read` 왕복(광고한 모든 URI 가 읽히고 mimeType 이
+  일치)으로 잡는다. 리소스가 늘어도 가드가 자동으로 따라온다.
+- 프로필 무필터 정책·`rhwp://` 스킴 등 기존 결정은 그대로 승계(주석의 근거 유지).
+
+## 변경
+
+- `src/mcp_serve.rs` — `SchemaResource`(생성기 테이블) + 스키마 3종, DOC_RESOURCES
+  에 레시피 6편, served_resources·read_resource 배선.
+- `tests/mcp_resources_contract.rs` 신설 — ① 스키마·레시피 광고 ② **전 URI
+  왕복 가드**(read-back·mimeType 일치·JSON 파싱·ir 의 irSchemaVersion) ③ 미지
+  URI -32002 + data.uri.
+
+## 실측
+
+`cargo test --release --test mcp_resources_contract` — 결과는 PR 본문에 기록
+(3본 green). 기존 `mcp_server_contract` 의 resources 검사(문서 3편·매니페스트)는
+무변경 통과 대상 — 이 변경은 목록 **추가**만 한다.
+
+## 남긴 판단
+
+- capabilities 매니페스트 리소스의 프로필 렌더링(기존 동작)은 유지 — 스키마
+  3종은 프로필과 무관한 전역 계약이라 필터하지 않는다.
+- 레시피 07~10 이 생기면 같은 자리에 행만 추가된다(#4110·#4111 이 그 예약).

--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -316,6 +316,95 @@ const DOC_RESOURCES: &[DocResource] = &[
         mime_type: "text/markdown",
         text: include_str!("../mydocs/manual/agent_troubleshooting_guide.md"),
     },
+    // [#3627 잔여 / R7·R34] 레시피 6편 — 목표에서 시작하는 완주 서사. 지식 지도가
+    // "무엇을 부르나"라면 레시피는 "어떤 순서로 목표까지 가나"다. MCP 클라이언트가
+    // 프로토콜 표준 경로로 읽을 수 있어야 CLI·저장소 없이도 서사가 닿는다.
+    DocResource {
+        uri: "rhwp://recipes/01_fill_form_and_submit.md",
+        name: "recipe-01-fill-form",
+        title: "레시피 1 — 서식 문서를 채워서 제출용으로 만들기",
+        description: "필드 조회→채움→검증→산출 완주 서사 (실측 출력 인용).",
+        mime_type: "text/markdown",
+        text: include_str!("../mydocs/manual/recipes/01_fill_form_and_submit.md"),
+    },
+    DocResource {
+        uri: "rhwp://recipes/02_table_csv_roundtrip.md",
+        name: "recipe-02-table-csv",
+        title: "레시피 2 — 표 데이터를 CSV 로 뽑아 고치고 되돌리기",
+        description: "export-tables→스프레드시트 편집→csv-to-table 왕복 서사.",
+        mime_type: "text/markdown",
+        text: include_str!("../mydocs/manual/recipes/02_table_csv_roundtrip.md"),
+    },
+    DocResource {
+        uri: "rhwp://recipes/03_redact_before_sharing.md",
+        name: "recipe-03-redact",
+        title: "레시피 3 — 배포 전 개인정보 마스킹",
+        description: "redact --dry-run 검토→실행→재검사 서사 (--no-raw 기본).",
+        mime_type: "text/markdown",
+        text: include_str!("../mydocs/manual/recipes/03_redact_before_sharing.md"),
+    },
+    DocResource {
+        uri: "rhwp://recipes/04_safety_check_untrusted_doc.md",
+        name: "recipe-04-safety-check",
+        title: "레시피 4 — 출처를 모르는 문서를 처음 열 때",
+        description: "inspect 3축(은닉·주입·유니코드) 선검사 서사.",
+        mime_type: "text/markdown",
+        text: include_str!("../mydocs/manual/recipes/04_safety_check_untrusted_doc.md"),
+    },
+    DocResource {
+        uri: "rhwp://recipes/05_mail_merge_batch_fill.md",
+        name: "recipe-05-mail-merge",
+        title: "레시피 5 — 서식 하나에 여러 사람 데이터를 한 번에 채우기",
+        description: "batch fill 메일머지 서사 (행 파일→산출물 N).",
+        mime_type: "text/markdown",
+        text: include_str!("../mydocs/manual/recipes/05_mail_merge_batch_fill.md"),
+    },
+    DocResource {
+        uri: "rhwp://recipes/06_visual_regression_before_after.md",
+        name: "recipe-06-visual-regression",
+        title: "레시피 6 — 편집 전후를 눈이 아니라 숫자로 비교하기",
+        description: "render-diff 픽셀 판정 서사 (bbox 불변 증명).",
+        mime_type: "text/markdown",
+        text: include_str!("../mydocs/manual/recipes/06_visual_regression_before_after.md"),
+    },
+];
+
+/// [#3627 잔여] 스키마 리소스 — 본문이 파일이 아니라 **생성기**다.
+///
+/// export-ir-schema · export-plan-schema · export-capabilities-schema 가 내는 것과
+/// 같은 lib 함수를 부른다 — CLI 봉투와 이 리소스가 한 원천에서 같은 값을 낸다.
+/// 파일로 얼리지 않는 이유: 스키마는 코드에서 파생되므로 얼린 사본은 첫 변경부터
+/// 낡는다(DOC_RESOURCES 가 원본 문서를 직접 안는 것과 같은 원리의 생성기 판).
+struct SchemaResource {
+    uri: &'static str,
+    name: &'static str,
+    title: &'static str,
+    description: &'static str,
+    generate: fn() -> serde_json::Value,
+}
+
+const SCHEMA_RESOURCES: &[SchemaResource] = &[
+    SchemaResource {
+        uri: "rhwp://schemas/ir",
+        name: "ir-schema",
+        title: "공개 IR JSON Schema",
+        description: "Document IR 의 JSON Schema 2020-12 — 바인딩·외부 검증기의 단일 출처 (export-ir-schema 동일).",
+        generate: rhwp::ir_schema::ir_schema,
+    },
+    SchemaResource {
+        uri: "rhwp://schemas/plan",
+        name: "plan-schema",
+        title: "편집 계획서(run) JSON Schema",
+        description: "run 계획서 문법의 JSON Schema — 계획 생성의 단일 출처 (export-plan-schema 동일).",
+        generate: rhwp::plan_schema::plan_schema,
+    },
+    SchemaResource {
+        uri: "rhwp://schemas/capabilities",
+        name: "capabilities-schema",
+        title: "capabilities 봉투 JSON Schema",
+        description: "capabilities 자기서술 봉투의 JSON Schema (export-capabilities-schema 동일).",
+        generate: rhwp::capabilities_schema::capabilities_schema,
+    },
 ];
 
 /// resources/list 응답 본문.
@@ -334,6 +423,16 @@ fn served_resources() -> Vec<serde_json::Value> {
                         --profile 로 띄운 서버는 tools/list 와 같은 필터된 목록을 낸다.",
         "mimeType": "application/json",
     })];
+    resources.extend(SCHEMA_RESOURCES.iter().map(|r| {
+        serde_json::json!({
+            "uri": r.uri,
+            "name": r.name,
+            "title": r.title,
+            "description": r.description,
+            "mimeType": "application/json",
+            // size 없음 — 본문이 생성기라 목록 시점에 길이를 약속하지 않는다.
+        })
+    }));
     resources.extend(DOC_RESOURCES.iter().map(|r| {
         serde_json::json!({
             "uri": r.uri,
@@ -362,6 +461,8 @@ fn read_resource(
             "application/json",
             crate::mcp_manifest_value(profile).to_string(),
         )
+    } else if let Some(r) = SCHEMA_RESOURCES.iter().find(|r| r.uri == uri) {
+        ("application/json", (r.generate)().to_string())
     } else {
         match DOC_RESOURCES.iter().find(|r| r.uri == uri) {
             Some(r) => (r.mime_type, r.text.to_string()),

--- a/tests/mcp_resources_contract.rs
+++ b/tests/mcp_resources_contract.rs
@@ -1,0 +1,170 @@
+//! [#3627 / 로드맵 R74] MCP resources 표면 계약 — 스키마·레시피 확장분.
+//!
+//! 계약 둘: ① resources/list 가 스키마 3종·레시피 6편을 포함해 광고한다.
+//! ② **광고한 모든 URI 가 실제로 읽힌다** — 목록과 실물의 드리프트 가드.
+//!   목록을 하드코딩으로 재대조하지 않고 list → read 왕복으로 잡는다: 리소스가
+//!   늘어도 이 가드는 자동으로 따라오고, 목록에만 넣고 read 분기를 빠뜨리는
+//!   실수(선언 회피의 역방향)가 즉시 red 가 된다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+struct Server {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: i64,
+}
+
+impl Server {
+    fn started() -> Server {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+            .arg("mcp-serve")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("rhwp mcp-serve 실행 실패");
+        let stdin = child.stdin.take().expect("stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout"));
+        let mut s = Server {
+            child,
+            stdin,
+            stdout,
+            next_id: 1,
+        };
+        let r = s.request(
+            "initialize",
+            serde_json::json!({
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "resources-contract", "version": "0"}
+            }),
+        );
+        assert!(
+            r["result"]["capabilities"]["resources"].is_object(),
+            "resources capability 선언이 없습니다: {r}"
+        );
+        let msg = serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"});
+        writeln!(s.stdin, "{msg}").expect("알림 쓰기 실패");
+        s.stdin.flush().expect("flush");
+        s
+    }
+
+    fn request(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        let msg =
+            serde_json::json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params});
+        writeln!(self.stdin, "{msg}").expect("요청 쓰기 실패");
+        self.stdin.flush().expect("flush");
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let n = self.stdout.read_line(&mut line).expect("응답 읽기 실패");
+            assert!(n > 0, "서버가 응답 없이 종료했습니다 (method={method})");
+            if line.trim().is_empty() {
+                continue;
+            }
+            let v: serde_json::Value = serde_json::from_str(line.trim())
+                .unwrap_or_else(|e| panic!("stdout 이 순수 JSON-RPC 가 아닙니다 ({e}): {line}"));
+            if v.get("id").and_then(|i| i.as_i64()) == Some(id) {
+                return v;
+            }
+        }
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn listed_resources() -> Vec<serde_json::Value> {
+    let mut s = Server::started();
+    let r = s.request("resources/list", serde_json::json!({}));
+    r["result"]["resources"]
+        .as_array()
+        .unwrap_or_else(|| panic!("resources/list 에 resources 배열이 없습니다: {r}"))
+        .clone()
+}
+
+#[test]
+fn list_advertises_schemas_and_recipes() {
+    let uris: Vec<String> = listed_resources()
+        .iter()
+        .map(|x| x["uri"].as_str().expect("uri 누락").to_string())
+        .collect();
+    for expected in [
+        "rhwp://schemas/ir",
+        "rhwp://schemas/plan",
+        "rhwp://schemas/capabilities",
+        "rhwp://recipes/01_fill_form_and_submit.md",
+        "rhwp://recipes/02_table_csv_roundtrip.md",
+        "rhwp://recipes/03_redact_before_sharing.md",
+        "rhwp://recipes/04_safety_check_untrusted_doc.md",
+        "rhwp://recipes/05_mail_merge_batch_fill.md",
+        "rhwp://recipes/06_visual_regression_before_after.md",
+    ] {
+        assert!(
+            uris.iter().any(|u| u == expected),
+            "resources/list 에 {expected} 가 없습니다 (실물: {uris:?})"
+        );
+    }
+}
+
+#[test]
+fn every_listed_resource_reads_back() {
+    let listed = listed_resources();
+    let mut s = Server::started();
+    for res in &listed {
+        let uri = res["uri"].as_str().expect("uri 누락");
+        let declared_mime = res["mimeType"].as_str().expect("mimeType 누락");
+        let r = s.request("resources/read", serde_json::json!({ "uri": uri }));
+        assert!(
+            r.get("error").is_none(),
+            "{uri}: 광고된 리소스가 읽히지 않습니다 — {r}"
+        );
+        let c = &r["result"]["contents"][0];
+        assert_eq!(c["uri"].as_str(), Some(uri), "{uri}: contents.uri 불일치");
+        assert_eq!(
+            c["mimeType"].as_str(),
+            Some(declared_mime),
+            "{uri}: 목록과 read 의 mimeType 이 갈라졌습니다"
+        );
+        let text = c["text"].as_str().unwrap_or_default();
+        assert!(!text.trim().is_empty(), "{uri}: 본문이 비었습니다");
+        if declared_mime == "application/json" {
+            let v: serde_json::Value = serde_json::from_str(text)
+                .unwrap_or_else(|e| panic!("{uri}: application/json 인데 파싱 실패 ({e})"));
+            if uri == "rhwp://schemas/ir" {
+                assert!(
+                    v.get("irSchemaVersion").is_some(),
+                    "{uri}: irSchemaVersion 최상위 키가 없습니다 (R82 규약)"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn unknown_resource_is_resource_not_found() {
+    let mut s = Server::started();
+    let r = s.request(
+        "resources/read",
+        serde_json::json!({ "uri": "rhwp://schemas/없는-스키마" }),
+    );
+    assert_eq!(
+        r["error"]["code"].as_i64(),
+        Some(-32002),
+        "미지 URI 는 -32002 여야 합니다: {r}"
+    );
+    assert_eq!(
+        r["error"]["data"]["uri"].as_str(),
+        Some("rhwp://schemas/없는-스키마"),
+        "오류에 문제의 uri 가 실려야 합니다: {r}"
+    );
+}


### PR DESCRIPTION
## 무엇 (#3627 — 로드맵 R74 의 잔여 절반)

R74 의 설계 질문("어느 문서를 리소스로 낼지")에서 **이미 착지한 절반**(매니페스트 + llms.txt·지식 지도·실패 사전)을 제외한 잔여 — **스키마 3종과 레시피 6편** — 를 resources 표면에 얹습니다. 지금 스키마·레시피는 CLI·저장소 파일로만 닿아서, MCP 클라이언트가 프로토콜 표준 경로로 읽을 방법이 없습니다.

착수 코멘트(#3627)에서 선언한 1차 범위(스키마·레시피·capabilities, 단일 출처 파생 + 드리프트 가드) 그대로입니다.

## 변경

| 리소스 | 본문 | 단일 출처 |
|---|---|---|
| rhwp://schemas/ir · plan · capabilities | **생성기** — lib 의 ir_schema()·plan_schema()·capabilities_schema() 호출 | CLI export-*-schema 와 같은 함수 |
| rhwp://recipes/01~06 | include_str! (컴파일 시점) | mydocs/manual/recipes/ 원본 |

- 스키마를 파일로 얼리지 않는 이유: 코드에서 파생되므로 얼린 사본은 첫 변경부터 낡습니다. 생성기 테이블(SchemaResource)로 두면 CLI 봉투와 리소스가 한 원천에서 같은 값을 냅니다.
- 레시피는 기존 DOC_RESOURCES 방식 승계(설치본에 mydocs/ 가 없으므로 런타임 디스크 읽기가 아니라 컴파일 시점에 안는다 — 기존 주석의 근거 그대로).

## 드리프트 가드 (R74 DoD)

신설 `tests/mcp_resources_contract.rs` 3본:

1. resources/list 가 스키마 3종·레시피 6편을 광고한다.
2. **광고한 모든 URI 가 읽힌다** — list → read 왕복으로 mimeType 일치·본문 비지 않음·application/json 파싱·ir 의 irSchemaVersion(R82) 확인. 목록을 하드코딩 재대조하지 않으므로 리소스가 늘어도 가드가 자동으로 따라오고, "목록에만 넣고 read 분기를 빠뜨리는" 실수가 즉시 red 가 됩니다.
3. 미지 URI 는 -32002 + error.data.uri.

## 로드맵 정정 겸

R74 의 "지금"("resources/* 미구현")은 낡은 서술입니다 — resources 표면 자체는 이미 devel 에 있습니다(실측: src/mcp_serve.rs 의 [#3627] 절 + 기존 계약 테스트). 이 PR 는 그 위의 잔여 공백만 채우며, 트랙 문서 갱신은 머지 후 #3907 코멘트와 짝으로 반영합니다(열린 PR #4108 과의 README 충돌 회피).

## 검증

- `cargo test --release --test mcp_resources_contract` → 3 passed (아래 실측 참조).
- 기존 resources 검사(`mcp_server_contract`)는 목록 **추가**만 있어 무변경 통과 대상.
- rustfmt 클린(변경 파일 기준). 열린 PR 변경 파일과 교집합 0 — src/mcp_serve.rs 는 어느 열린 PR 도 건드리지 않습니다.
- 처리 문서: `mydocs/report/task_m100_3627_resources_r74.md`

refs #3627

🤖 Generated with [Claude Code](https://claude.com/claude-code)
