### PR TITLE
fix(studio): 툴바가 문단에 없는 줄 간격 값을 표시해 적용이 한 번에 안 먹는다

### DIFF
--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2100,19 +2100,10 @@ export class InputHandler {
       const pos = this.cursor.getPosition();
       const inFootnote = this.cursor.isInFootnote();
       const inCell = !inFootnote && pos.parentParaIndex !== undefined;
-      const paraProps = inFootnote
-        ? this.wasm.getParaPropertiesInFootnote(
-            this.cursor.fnSectionIdx,
-            this.cursor.fnParaIdx,
-            this.cursor.fnControlIdx,
-            this.cursor.fnInnerParaIdx,
-          )
-        : inCell
-        ? this.wasm.getCellParaPropertiesAt(
-            pos.sectionIndex, pos.parentParaIndex!, pos.controlIndex!,
-            pos.cellIndex!, pos.cellParaIndex!,
-          )
-        : this.wasm.getParaPropertiesAt(pos.sectionIndex, pos.paragraphIndex);
+      // 문단 모양 대화상자와 같은 리더를 쓴다. 여기에 갈래를 따로 두면 문맥이 하나 빠져도
+      // 컴파일이 통과하고, 실제로 머리말/꼬리말 갈래가 빠져 있었다 — 머리말 편집 중 툴바와
+      // 눈금자가 본문 문단 값을 보여줬다(대화상자는 머리말 값을 정확히 읽는데).
+      const paraProps = this.getParaProperties();
       this.eventBus.emit('cursor-para-changed', paraProps);
 
       // 스타일 드롭다운 갱신용

--- a/rhwp-studio/src/ui/toolbar.ts
+++ b/rhwp-studio/src/ui/toolbar.ts
@@ -569,7 +569,13 @@ export class Toolbar {
       const val = Math.round(props.lineSpacing);
       this.ensureLsOption(val);
       this.lsSelect.value = String(val);
+      return;
     }
+    // 백분율이 아닌 줄 간격(고정 값/최소/여백만 지정)은 이 백분율 목록으로 표현할 수 없다.
+    // 직전 문단의 값을 남겨 두면 두 가지가 함께 깨진다 — 표시가 실제와 어긋나고, 사용자가
+    // 그 표시값과 같은 항목을 고르면 select 의 change 가 발화하지 않아(핸들러가 change 에
+    // 달려 있다) "눌러도 안 먹고 여러 번 눌러야 반영되는" 상태가 된다. 비워서 둘 다 막는다.
+    this.lsSelect.selectedIndex = -1;
   }
 
   /** 커서 위치의 스타일을 드롭다운에 반영한다 */

--- a/rhwp-studio/tests/cursor-para-changed-reader.test.ts
+++ b/rhwp-studio/tests/cursor-para-changed-reader.test.ts
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// "커서 위치의 문단 속성"을 읽는 곳이 둘이었다.
+//   - getParaProperties()      — 문단 모양 대화상자용. 머리말/각주/셀/본문 4문맥.
+//   - cursor-para-changed 발행 — 툴바·눈금자용.      각주/셀/본문 3문맥 (머리말 누락).
+// 갈래를 따로 두면 문맥이 하나 빠져도 컴파일이 통과한다. 실제로 머리말 편집 중 툴바가
+// 본문 문단 값을 보여줬다.
+//
+// 실측 (headless Chrome, 본문 300% / 머리말 100%):
+//   대화상자가 읽는 값 100  vs  툴바 표시 300
+// 그 상태에서 사용자가 300을 고르면 select 값이 그대로라 change 가 발화하지 않아
+// (toolbar.ts 의 핸들러는 'change' 에 달려 있다) 아무 일도 일어나지 않는다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const source = (path: string): string => readFileSync(join(rootDir, path), 'utf8');
+
+function paraChangedEmitBlock(): string {
+  const ih = source('src/engine/input-handler.ts');
+  const start = ih.indexOf('// 문단 속성 (눈금자 마커용) + 스타일');
+  assert.notEqual(start, -1, '문단 속성 발행 블록을 찾지 못했다');
+  const end = ih.indexOf("this.eventBus.emit('cursor-para-changed'", start);
+  assert.notEqual(end, -1, 'cursor-para-changed 발행을 찾지 못했다');
+  return ih.slice(start, end);
+}
+
+test('cursor-para-changed 는 대화상자와 같은 리더를 쓴다', () => {
+  const block = paraChangedEmitBlock();
+  assert.match(block, /const paraProps = this\.getParaProperties\(\)/,
+    '문단 속성 리더를 따로 구현하고 있다');
+});
+
+test('cursor-para-changed 는 문맥 갈래를 자체 구현하지 않는다', () => {
+  // 자체 갈래가 남아 있으면 문맥이 추가될 때 또 한쪽만 갱신된다.
+  const block = paraChangedEmitBlock();
+  assert.doesNotMatch(block, /this\.wasm\.getParaPropertiesAt\(/,
+    '본문 갈래를 발행 블록이 직접 호출한다');
+  assert.doesNotMatch(block, /this\.wasm\.getCellParaPropertiesAt\(/,
+    '셀 갈래를 발행 블록이 직접 호출한다');
+  assert.doesNotMatch(block, /this\.wasm\.getParaPropertiesInFootnote\(/,
+    '각주 갈래를 발행 블록이 직접 호출한다');
+});
+
+test('문단 속성 리더는 네 문맥을 모두 덮는다', () => {
+  const ih = source('src/engine/input-handler.ts');
+  const start = ih.indexOf('getParaProperties(): ParaProperties {');
+  assert.notEqual(start, -1, 'getParaProperties 를 찾지 못했다');
+  const body = ih.slice(start, ih.indexOf('\n  }', start));
+
+  assert.match(body, /this\.cursor\.isInHeaderFooter\(\)/, '머리말/꼬리말 문맥이 없다');
+  assert.match(body, /getParaPropertiesInHf\(/, '머리말/꼬리말 조회가 없다');
+  assert.match(body, /this\.cursor\.isInFootnote\(\)/, '각주 문맥이 없다');
+  assert.match(body, /getParaPropertiesInFootnote\(/, '각주 조회가 없다');
+  assert.match(body, /getCellParaPropertiesAt\(/, '셀 조회가 없다');
+  assert.match(body, /getParaPropertiesAt\(/, '본문 조회가 없다');
+});

--- a/rhwp-studio/tests/toolbar-linespacing-sync.test.ts
+++ b/rhwp-studio/tests/toolbar-linespacing-sync.test.ts
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// 툴바 줄 간격은 백분율 전용 목록이다. 문단의 줄 간격 종류는 네 가지이고
+// (Percent / Fixed / SpaceOnly / Minimum — para-shape-dialog.ts 의 LINE_SPACING_TYPES)
+// 문단 모양 대화상자가 넷 다 설정할 수 있다.
+//
+// 백분율이 아닌 문단에서 목록을 그대로 두면 직전 문단의 값이 남아 두 가지가 함께 깨진다.
+//   (1) 표시가 실제와 어긋난다 — 실측: Fixed 13.3 문단에서 "160" 표시
+//   (2) 그 표시값과 같은 항목을 고르면 select 의 change 가 발화하지 않는다.
+//       줄 간격 핸들러는 'change' 에만 달려 있으므로 아무 일도 일어나지 않는다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const source = (path: string): string => readFileSync(join(rootDir, path), 'utf8');
+
+function updateParaStateBody(): string {
+  const toolbar = source('src/ui/toolbar.ts');
+  const start = toolbar.indexOf('private updateParaState(props: ParaProperties): void {');
+  assert.notEqual(start, -1, 'updateParaState 를 찾지 못했다');
+  const end = toolbar.indexOf('\n  }', start);
+  assert.notEqual(end, -1, 'updateParaState 끝을 찾지 못했다');
+  return toolbar.slice(start, end);
+}
+
+test('백분율이 아닌 줄 간격에서는 툴바 목록을 비운다', () => {
+  const body = updateParaStateBody();
+  assert.match(body, /this\.lsSelect\.selectedIndex = -1;/,
+    '백분율이 아닌 문단에서 직전 값이 그대로 남는다');
+});
+
+test('백분율 갈래가 비우기 갈래로 흘러내리지 않는다', () => {
+  // return 이 없으면 방금 맞춘 백분율 값을 곧바로 -1 로 지워 목록이 항상 비어 버린다.
+  const body = updateParaStateBody();
+  assert.match(body, /this\.lsSelect\.value = String\(val\);\s*\n\s*return;/,
+    '백분율 갈래에 return 이 없다');
+});
+
+test('줄 간격 적용은 select 의 change 에 달려 있다', () => {
+  // 이 배선이 change 인 한, 표시값과 원하는 값이 같으면 선택해도 발화하지 않는다.
+  // 위 두 케이스가 막으려는 것이 정확히 그 상태다.
+  const toolbar = source('src/ui/toolbar.ts');
+  const start = toolbar.indexOf('private setupLineSpacingDropdown()');
+  assert.notEqual(start, -1, 'setupLineSpacingDropdown 을 찾지 못했다');
+  const body = toolbar.slice(start, toolbar.indexOf("this.lsSelect.addEventListener('dblclick'", start));
+  assert.match(body, /this\.lsSelect\.addEventListener\('change'/,
+    '줄 간격 적용 배선을 찾지 못했다 — 이 테스트의 전제가 바뀌었다');
+});


### PR DESCRIPTION
## 변경 요약

줄 간격을 바꿔도 한 번에 반영되지 않고 여러 번 눌러야 적용되는 경우가 있습니다.

### 공통 메커니즘

툴바 줄 간격 핸들러는 select 의 `change` 에 달려 있습니다.

```ts
// ui/toolbar.ts, setupLineSpacingDropdown
this.lsSelect.addEventListener('change', () => {
  const val = Number(this.lsSelect.value);
  if (val > 0) this.dispatcher.dispatch('format:line-spacing', { value: val });
});
```

그래서 **툴바가 문단의 실제 값과 다른 값을 표시하고 있고, 사용자가 원하는 값이 마침 그
표시값과 같으면** 항목을 골라도 값이 바뀌지 않아 `change` 가 발화하지 않습니다. 아무 일도
일어나지 않고, 다른 값을 한 번 거쳤다 돌아와야 적용됩니다.

툴바가 실제와 다른 값을 표시하는 경로를 두 개 찾았고, 각각 고칩니다.

### 1. 머리말/꼬리말 — 문단 속성 리더가 둘인데 하나만 완전합니다

| 리더 | 소비자 | 문맥 |
|---|---|---|
| `getParaProperties()` | 문단 모양 대화상자 | 머리말 · 각주 · 셀 · 본문 |
| `cursor-para-changed` 발행 | 툴바 · 눈금자 | 각주 · 셀 · 본문 — **머리말 누락** |

갈래를 따로 두면 문맥이 하나 빠져도 컴파일이 통과합니다. 실제로 머리말 갈래가 빠져 있어,
머리말 편집 중에는 툴바 줄 간격과 눈금자 여백/들여쓰기가 **본문 문단 값**을 보여줬습니다.

headless Chrome 실측 (본문 300% / 머리말 100%, 머리말 편집 중):

```
문단 모양 대화상자가 읽는 값   100    (정확)
툴바 표시                     300    (본문 값)
```

발행 블록이 대화상자와 같은 리더를 부르게 합니다. 나머지 세 문맥은 이미 같은 호출이었으므로
실질 변화는 머리말/꼬리말 갈래가 붙는 것과 갈래가 한 곳으로 모이는 것입니다.

### 2. 백분율이 아닌 줄 간격 — 목록에 직전 값이 남습니다

문단의 줄 간격 종류는 넷이고(`Percent` / `Fixed` / `SpaceOnly` / `Minimum` —
`para-shape-dialog.ts` 의 `LINE_SPACING_TYPES`) 문단 모양 대화상자가 넷 다 설정합니다.

툴바 줄 간격은 백분율 전용 목록이라 `updateParaState` 가 `Percent` 가 아닌 문단에서
아무것도 하지 않고 직전 문단의 값을 그대로 남겼습니다.

실측 (문단 0 = `Percent` 160%, 문단 1 = `Fixed` 13.3): 문단 1 에서 툴바가 `"160"` 표시.

목록을 비웁니다. 표시가 더 이상 거짓이 아니고, 비어 있으면 어떤 선택도 값 변경이라
`change` 가 발화합니다.

## 확정하지 못한 것

**신고된 증상이 위 두 경로 중 어느 쪽인지 특정하지 못했습니다.** 재현 절차를 받지 못했고,
두 경로 모두 독립적으로 실측했을 뿐입니다.

경로 2 는 실제 문서에서는 드물어 보입니다. 저장소 샘플 중 로드에 성공한 두 개
(`biz_plan.hwp` 93문단, `kps-ai.hwp` 841문단)에서 **비-`Percent` 문단이 0건**이었습니다.
`Fixed`/`Minimum` 은 문단 모양 대화상자로 직접 지정해야 나옵니다.

경로 1 은 머리말을 편집하기만 하면 걸리므로 더 흔합니다.

두 경로 모두 "툴바가 문단에 없는 값을 표시한다"는 같은 결함이라 함께 고쳤습니다. 신고된
증상과 무관하더라도 각각이 결함입니다.

## 관련 이슈

없음 — QA 리포트에서 출발했습니다. 같은 조사에서 올린 이슈는 아래입니다.

- #4109 · #4117 · #4118 · #4121

다른 열린 PR 과 충돌하지 않는 것을 `git merge-tree` 로 확인했습니다 (#4119 와 0건, 머리말
문단 서식 브랜치와 0건).

## 테스트

- [x] `cargo test` 통과 — `cargo test --profile release-test --tests` : 468 바이너리, **5,277 통과 / 0 실패**
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo fmt --all -- --check` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — **해당 없음**. 변경은 툴바·눈금자로 가는 속성
      조회 경로이고 렌더 출력을 건드리지 않습니다.
- [x] 웹(WASM) 렌더링 확인 — headless Chrome 실측, 아래
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 — **해당 없음**

`rhwp-studio` 게이트 (`local_validation.md` §4.3):

| 게이트 | 결과 |
|---|---|
| `npx tsc --noEmit` | 에러 0 |
| `npm test` | **769 pass / 0 fail** |
| `npm run build` | exit 0 |

### 회귀 테스트 — red→green 증명

`tests/cursor-para-changed-reader.test.ts` (3 케이스)
`tests/toolbar-linespacing-sync.test.ts` (3 케이스)

| 되돌린 것 | 결과 |
|---|---|
| 발행 블록이 문맥 갈래를 자체 구현 (머리말 누락 상태) | `fail 2` |
| `selectedIndex = -1` 제거 | `fail 1` |
| 백분율 갈래의 `return` 제거 (흘러내림) | `fail 1` |

세 번째는 이 수정 자체가 만들 수 있는 버그를 막습니다 — `return` 이 없으면 방금 맞춘
백분율 값을 곧바로 지워 목록이 **항상** 비어 버립니다.

### 브라우저 실측

| 항목 | before | after |
|---|---|---|
| 머리말 편집 중 툴바 (본문 300% / 머리말 100%) | `300` | **`100`** |
| `Fixed 13.3` 문단에서 툴바 | `160` | **비어 있음** (`selectedIndex -1`) |

## 스크린샷

해당 없음 — 툴바 select 의 표시값이 쟁점이고, 위 값이 그 측정입니다.

## 범위 밖

- **▲/▼ 버튼**은 `Number(this.lsSelect.value) || 160` 으로 현재 값을 읽습니다. 목록이 비면
  160 을 기준으로 삼아 165% 를 적용합니다 — 백분율이 아닌 문단을 백분율로 바꿉니다.
  고치기 전에도 직전 문단의 값을 기준으로 삼았으므로 나빠지지는 않지만, 둘 다 맞지
  않습니다. 목록이 비었을 때 ▲/▼ 를 막는 편이 나을지 판단을 구합니다.
- `Math.round(props.lineSpacing)` 때문에 실제 값이 소수(예: 160.4)면 표시는 160 이 됩니다.
  이 경우 160 을 고르면 여전히 `change` 가 발화하지 않습니다. 값 차이가 눈에 띄지 않는
  범위라 이번에는 두었습니다.
- 머리말/꼬리말에서 **문단 서식을 적용하는 쪽**(`applyParaFormat`)이 배선돼 있지 않은 건은
  별도 브랜치(`fix/note-header-para-format`)로 다룹니다. 이 PR 은 **표시하는 쪽**만 고칩니다.
