### PR TITLE
fix(studio): 교차 출처(cross-origin)에서 열기 피커가 막히면 파일 입력으로 폴백한다

### DIFF
--- a/rhwp-studio/src/command/commands/file.ts
+++ b/rhwp-studio/src/command/commands/file.ts
@@ -59,25 +59,36 @@ import { openRecentEntry } from '@/recent/recent-open';
  * 문서를 로드한다. `file:open` 커맨드와 "최근 문서" 메타-only 항목 재열기가 공유한다.
  */
 async function openFileViaPicker(services: CommandServices): Promise<void> {
-  try {
-    const canReplace = await confirmSaveBeforeReplacingDocument(services);
-    if (!canReplace) return;
+  const canReplace = await confirmSaveBeforeReplacingDocument(services);
+  if (!canReplace) return;
 
-    const windowLike = window as FileSystemWindowLike;
-    const nativeOpenPickerAvailable = canUseOpenFilePicker(windowLike);
-    const handle = await pickOpenFileHandle(windowLike);
-    if (!handle) {
-      // File System Access API picker가 있었다면 null은 사용자 취소(예: Esc)다.
-      // 이때 숨김 input fallback을 다시 열면 파일 선택창이 곧바로 재오픈된다.
-      if (nativeOpenPickerAvailable) return;
-      const fileInput = document.getElementById('file-input') as HTMLInputElement | null;
-      if (fileInput) {
-        fileInput.dataset.skipUnsavedGuard = 'true';
-        fileInput.click();
-      }
-      return;
+  const windowLike = window as FileSystemWindowLike;
+  let nativeOpenPickerAvailable = canUseOpenFilePicker(windowLike);
+  let handle: FileSystemFileHandleLike | null = null;
+  if (nativeOpenPickerAvailable) {
+    try {
+      handle = await pickOpenFileHandle(windowLike);
+    } catch (error) {
+      // 교차 출처 서브프레임 등에서 showOpenFilePicker 자체가 거부되는 경우(SecurityError 등) —
+      // 저장 흐름(tryFileSystemSave)과 동일하게 조용히 숨김 input 폴백으로 전환한다.
+      console.warn('[file:open] File System Access API 실패, 폴백:', error);
+      nativeOpenPickerAvailable = false;
     }
+  }
 
+  if (!handle) {
+    // File System Access API picker가 있었다면 null은 사용자 취소(예: Esc)다.
+    // 이때 숨김 input fallback을 다시 열면 파일 선택창이 곧바로 재오픈된다.
+    if (nativeOpenPickerAvailable) return;
+    const fileInput = document.getElementById('file-input') as HTMLInputElement | null;
+    if (fileInput) {
+      fileInput.dataset.skipUnsavedGuard = 'true';
+      fileInput.click();
+    }
+    return;
+  }
+
+  try {
     const { bytes, name } = await readFileFromHandle(handle);
     services.eventBus.emit('open-document-bytes', {
       bytes,


### PR DESCRIPTION
`window.showOpenFilePicker()`는 최상위 프레임과 출처가 다른 서브프레임에서 호출되면 `SecurityError`("Cross origin sub frames aren't allowed to show a file picker.")를 던진다. `openFileViaPicker`는 이 에러를 잡지 못하고 그대로 `alert`로 흘려보내, 이런 임베드 환경에서 열기(File > 열기, `Ctrl+O`)가 완전히 막혀 있었다.

저장 흐름은 이미 같은 종류의 실패를 처리하고 있다. `tryFileSystemSave`는 `saveDocumentToFileSystem`에서 나는 취소 이외의 모든 에러를 잡아 blob 다운로드로 조용히 폴백한다. 이 PR은 열기 흐름에도 같은 패턴을 적용한다 — `pickOpenFileHandle`에서 사용자 취소(`AbortError`)가 아닌 에러가 나면 네이티브 피커를 사용 불가로 간주하고, 기존의 숨김 `#file-input` 폴백으로 전환한다. 사용자가 명시적으로 취소한 경우의 동작은 그대로다.

`window.showOpenFilePicker`가 실제 교차 출처 `SecurityError`를 던지도록 강제한 뒤 열기 메뉴를 눌러, alert 대신 숨김 파일 입력이 열리는 것을 확인했다. `npx tsc --project tsconfig.ci-unit.json --noEmit`과 `npm run test`(763개) 모두 통과한다.

Closes #4123