### PR TITLE
fix(studio): 표 세로 경계를 끌면 한 방향으로 못 움직인다 (closes #4109)

### DIFF
--- a/rhwp-studio/src/engine/table-border-lines.ts
+++ b/rhwp-studio/src/engine/table-border-lines.ts
@@ -1,0 +1,53 @@
+/**
+ * 표 경계선 좌표 병합.
+ *
+ * 셀 bbox 의 좌/우·상/하 좌표를 소수점 1자리로 반올림해 모으면, **한 물리적 경계**를
+ * 공유하는 두 셀의 값이 반올림 경계에 걸쳐 서로 다른 원소로 남는다(관측 예: 셀(0,0) 우측
+ * 299.9 / 셀(0,1) 좌측 299.8). 그러면 같은 경계에 괘선이 둘 생기고, 이웃 괘선으로 드래그
+ * 범위를 정하는 쪽에서 자기 자신을 이웃으로 잡아 범위가 뒤집힌다.
+ *
+ * 임계 이내로 붙은 좌표를 하나로 묶고, **묶여 사라진 좌표도 대표 인덱스를 가리키는 맵**을
+ * 함께 돌려준다. 맵이 없으면 hit-test 가 자기 좌표로 인덱스를 되찾지 못해 그 셀의 경계가
+ * 잡히지 않는다.
+ */
+
+/**
+ * 같은 경계로 볼 좌표 간 거리 상한(px, 줌 적용 전 페이지 좌표).
+ *
+ * 최소 셀 크기가 MIN_TABLE_CELL_SIZE_HWP=200(= 2.67px)이므로 1.0px 는 실제로 떨어진 두
+ * 경계를 삼키지 않는다. 실제 반올림 오차는 0.1px 수준이라 여유가 충분하다.
+ */
+export const BORDER_LINE_MERGE_EPS_PX = 1.0;
+
+export type MergedBorderCoords = {
+  /** 병합 후 대표 좌표 (오름차순). 각 그룹의 최솟값을 쓴다. */
+  positions: number[];
+  /** 병합 **전** 반올림 좌표 → 대표 좌표의 인덱스. 그룹의 모든 좌표가 들어 있다. */
+  indexByCoord: Map<number, number>;
+};
+
+/**
+ * 임계 이내로 붙은 좌표들을 하나의 경계선으로 묶는다.
+ *
+ * 그룹 판정은 **그룹 대표(첫 좌표)와의 거리**로 한다. 직전 좌표와의 거리로 이으면
+ * 0.9px 씩 이어진 사슬이 임계를 넘어 커지면서 실제로 떨어진 경계까지 삼킬 수 있다.
+ * 대표 기준이면 한 그룹의 폭이 eps 를 넘지 않는다.
+ */
+export function mergeBorderCoords(
+  roundedCoords: Iterable<number>,
+  eps: number = BORDER_LINE_MERGE_EPS_PX,
+): MergedBorderCoords {
+  const sorted = [...new Set(roundedCoords)].sort((a, b) => a - b);
+  const positions: number[] = [];
+  const indexByCoord = new Map<number, number>();
+
+  for (const coord of sorted) {
+    const representative = positions[positions.length - 1];
+    if (representative === undefined || coord - representative > eps) {
+      positions.push(coord);
+    }
+    indexByCoord.set(coord, positions.length - 1);
+  }
+
+  return { positions, indexByCoord };
+}

--- a/rhwp-studio/src/engine/table-resize-renderer.ts
+++ b/rhwp-studio/src/engine/table-resize-renderer.ts
@@ -1,5 +1,6 @@
 import { VirtualScroll } from '@/view/virtual-scroll';
 import type { CellBbox } from '@/core/types';
+import { mergeBorderCoords } from './table-border-lines';
 
 /** 경계선 종류 */
 export type BorderEdgeType = 'row' | 'col';
@@ -35,9 +36,22 @@ export class TableResizeRenderer {
     }
   }
 
-  /** 셀 bbox 배열에서 행/열 경계선 좌표를 계산한다 (페이지 좌표 기준) */
-  computeBorderLines(bboxes: CellBbox[]): { rowLines: RowLine[]; colLines: ColLine[] } {
-    if (bboxes.length === 0) return { rowLines: [], colLines: [] };
+  /**
+   * 셀 bbox 배열에서 행/열 경계선 좌표를 계산한다 (페이지 좌표 기준).
+   *
+   * rowIndexByY/colIndexByX 는 병합 **전** 반올림 좌표에서 대표 괘선 인덱스를 찾는 맵이다.
+   * 셀 좌표로 인덱스를 되찾는 쪽(hitTestBorder)은 반드시 이 맵을 써야 한다 — 괘선 목록의
+   * 대표 좌표만으로 맵을 다시 만들면, 병합돼 사라진 좌표를 가진 셀의 경계를 못 찾는다.
+   */
+  computeBorderLines(bboxes: CellBbox[]): {
+    rowLines: RowLine[];
+    colLines: ColLine[];
+    rowIndexByY: Map<number, number>;
+    colIndexByX: Map<number, number>;
+  } {
+    if (bboxes.length === 0) {
+      return { rowLines: [], colLines: [], rowIndexByY: new Map(), colIndexByX: new Map() };
+    }
 
     // 표 전체 범위
     let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
@@ -48,12 +62,6 @@ export class TableResizeRenderer {
       maxY = Math.max(maxY, b.y + b.h);
     }
 
-    // 행 경계선 (수평): 셀 상단/하단 y 좌표 수집
-    const rowYSet = new Map<number, number>(); // y(rounded) → index
-    // 열 경계선 (수직): 셀 좌측/우측 x 좌표 수집
-    const colXSet = new Map<number, number>(); // x(rounded) → index
-
-    // 표 상단/하단, 좌측/우측 추가
     const ry = (v: number) => Math.round(v * 10) / 10; // 소수점 1자리 반올림
 
     // 모든 셀의 상/하단, 좌/우측 좌표 수집
@@ -66,19 +74,24 @@ export class TableResizeRenderer {
       colXs.add(ry(b.x + b.w));
     }
 
-    // 정렬하여 인덱스 부여
-    const sortedRowYs = [...rowYs].sort((a, b) => a - b);
-    const sortedColXs = [...colXs].sort((a, b) => a - b);
+    // 반올림 경계에 걸쳐 갈라진 같은 경계를 하나로 묶는다.
+    const rows = mergeBorderCoords(rowYs);
+    const cols = mergeBorderCoords(colXs);
 
-    const rowLines: RowLine[] = sortedRowYs.map((y, i) => ({
+    const rowLines: RowLine[] = rows.positions.map((y, i) => ({
       y, xStart: minX, xEnd: maxX, index: i,
     }));
 
-    const colLines: ColLine[] = sortedColXs.map((x, i) => ({
+    const colLines: ColLine[] = cols.positions.map((x, i) => ({
       x, yStart: minY, yEnd: maxY, index: i,
     }));
 
-    return { rowLines, colLines };
+    return {
+      rowLines,
+      colLines,
+      rowIndexByY: rows.indexByCoord,
+      colIndexByX: cols.indexByCoord,
+    };
   }
 
   /** 마우스 좌표가 경계선 위인지 판별한다 (페이지 좌표 기준) */
@@ -89,11 +102,11 @@ export class TableResizeRenderer {
   ): BorderEdge | null {
     if (bboxes.length === 0) return null;
 
-    const { rowLines, colLines } = this.computeBorderLines(bboxes);
+    // 인덱스 맵은 반드시 computeBorderLines 가 준 것을 쓴다. 괘선 목록의 대표 좌표로
+    // 다시 만들면 병합돼 사라진 좌표를 가진 셀의 경계가 잡히지 않는다.
+    const { rowIndexByY, colIndexByX } = this.computeBorderLines(bboxes);
     const pageIndex = bboxes[0].pageIndex;
     const rounded = (v: number) => Math.round(v * 10) / 10;
-    const rowIndexByY = new Map(rowLines.map(line => [rounded(line.y), line.index]));
-    const colIndexByX = new Map(colLines.map(line => [rounded(line.x), line.index]));
 
     const candidates: Array<{ edge: BorderEdge; distance: number; priority: number }> = [];
 

--- a/rhwp-studio/tests/table-border-lines.test.ts
+++ b/rhwp-studio/tests/table-border-lines.test.ts
@@ -1,0 +1,113 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mergeBorderCoords, BORDER_LINE_MERGE_EPS_PX } from '../src/engine/table-border-lines.ts';
+
+// 셀 bbox 좌표를 소수점 1자리로 반올림해 모으면, 한 물리적 경계를 공유하는 두 셀의 값이
+// 반올림 경계에 걸쳐 서로 다른 원소로 남는다.
+//
+// 실측 (3x3 표, 새 문서, 100% 줌): 셀(0,0) 우측 299.9 / 셀(0,1) 좌측 299.8 → 괘선 2개.
+// 이웃 괘선으로 드래그 범위를 정하는 쪽이 자기 자신을 이웃으로 잡아 범위가 뒤집힌다.
+//   아래쪽 인덱스(299.8): max 297.2 < cur  → 오른쪽으로 못 감
+//   위쪽 인덱스(299.9): min 302.5 > cur    → 왼쪽으로 못 감
+// 어느 인덱스를 잡느냐는 hitTestBorder 의 후보 정렬에 달려 있어 방향이 갈린다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const source = (path: string): string => readFileSync(join(rootDir, path), 'utf8');
+
+/** 최소 셀 크기 (MIN_TABLE_CELL_SIZE_HWP=200 → px) */
+const MIN_CELL_PX = 200 / 75;
+
+test('반올림 경계에 걸쳐 갈라진 같은 경계를 하나로 묶는다', () => {
+  // 실측 좌표: 113.4 / 299.8 / 299.9 / 486.3
+  const { positions } = mergeBorderCoords([113.4, 299.8, 299.9, 486.3]);
+  assert.deepEqual(positions, [113.4, 299.8, 486.3]);
+});
+
+test('묶여 사라진 좌표도 대표 괘선 인덱스를 가리킨다', () => {
+  // 이 맵이 없으면 자기 좌표로 인덱스를 되찾는 셀의 경계가 hit-test 에서 사라진다.
+  const { indexByCoord } = mergeBorderCoords([113.4, 299.8, 299.9, 486.3]);
+  assert.equal(indexByCoord.get(299.8), 1);
+  assert.equal(indexByCoord.get(299.9), 1, '병합된 좌표가 대표 인덱스를 못 찾는다');
+  assert.equal(indexByCoord.get(113.4), 0);
+  assert.equal(indexByCoord.get(486.3), 2);
+});
+
+test('최소 셀 크기만큼 떨어진 두 경계는 묶이지 않는다', () => {
+  // 임계(1.0px)가 최소 셀 크기(2.67px)보다 작아야 실제로 떨어진 경계를 삼키지 않는다.
+  assert.ok(BORDER_LINE_MERGE_EPS_PX < MIN_CELL_PX,
+    `임계 ${BORDER_LINE_MERGE_EPS_PX}px 가 최소 셀 크기 ${MIN_CELL_PX}px 이상이다`);
+  const { positions } = mergeBorderCoords([100, 100 + MIN_CELL_PX]);
+  assert.equal(positions.length, 2, '실제로 떨어진 두 경계를 삼켰다');
+});
+
+test('임계를 넘는 좌표는 묶이지 않는다', () => {
+  const { positions } = mergeBorderCoords([100, 101.5]);
+  assert.deepEqual(positions, [100, 101.5]);
+});
+
+test('한 괘선으로 묶이는 좌표들의 폭은 임계를 넘지 않는다', () => {
+  // 직전 좌표와의 거리로 이으면 0.9px 씩 이어진 사슬이 계속 자라 최소 셀 크기(2.67px)를
+  // 삼킨다. 그룹 판정은 대표(그룹 첫 좌표) 기준이어야 폭이 임계로 묶인다.
+  const coords = [100, 100.9, 101.8, 102.7, 103.6, 104.5];
+  const { indexByCoord } = mergeBorderCoords(coords);
+
+  const spanByIndex = new Map<number, { min: number; max: number }>();
+  for (const c of coords) {
+    const i = indexByCoord.get(c)!;
+    const cur = spanByIndex.get(i);
+    if (!cur) spanByIndex.set(i, { min: c, max: c });
+    else spanByIndex.set(i, { min: Math.min(cur.min, c), max: Math.max(cur.max, c) });
+  }
+
+  for (const [i, { min, max }] of spanByIndex) {
+    const span = Math.round((max - min) * 1000) / 1000;
+    assert.ok(span <= BORDER_LINE_MERGE_EPS_PX,
+      `괘선 ${i} 의 폭 ${span}px 가 임계 ${BORDER_LINE_MERGE_EPS_PX}px 를 넘었다 (사슬 병합)`);
+    assert.ok(span < MIN_CELL_PX,
+      `괘선 ${i} 의 폭 ${span}px 가 최소 셀 크기 ${MIN_CELL_PX}px 이상 — 셀 하나를 삼켰다`);
+  }
+});
+
+test('빈 입력과 단일 좌표를 처리한다', () => {
+  assert.deepEqual(mergeBorderCoords([]).positions, []);
+  const one = mergeBorderCoords([42.5]);
+  assert.deepEqual(one.positions, [42.5]);
+  assert.equal(one.indexByCoord.get(42.5), 0);
+});
+
+test('입력 순서와 무관하게 같은 결과를 낸다', () => {
+  const a = mergeBorderCoords([486.3, 299.9, 113.4, 299.8]);
+  assert.deepEqual(a.positions, [113.4, 299.8, 486.3]);
+  assert.equal(a.indexByCoord.get(299.9), 1);
+});
+
+test('hitTestBorder 는 computeBorderLines 가 준 인덱스 맵을 쓴다', () => {
+  // 괘선 목록의 대표 좌표로 맵을 다시 만들면 병합돼 사라진 좌표가 빠져,
+  // 그 좌표를 가진 셀의 경계가 잡히지 않는다.
+  const renderer = source('src/engine/table-resize-renderer.ts');
+  const start = renderer.indexOf('hitTestBorder(');
+  assert.notEqual(start, -1, 'hitTestBorder 를 찾지 못했다');
+  const body = renderer.slice(start, renderer.indexOf('\n  /** 경계선 위에 마커', start));
+
+  assert.match(body, /const \{ rowIndexByY, colIndexByX \} = this\.computeBorderLines\(bboxes\)/,
+    'computeBorderLines 의 인덱스 맵을 쓰지 않는다');
+  assert.doesNotMatch(body, /new Map\(rowLines\.map/,
+    '괘선 목록에서 인덱스 맵을 재조립한다');
+  assert.doesNotMatch(body, /new Map\(colLines\.map/,
+    '괘선 목록에서 인덱스 맵을 재조립한다');
+});
+
+test('computeBorderLines 는 병합을 거친다', () => {
+  const renderer = source('src/engine/table-resize-renderer.ts');
+  const start = renderer.indexOf('computeBorderLines(bboxes: CellBbox[])');
+  assert.notEqual(start, -1, 'computeBorderLines 를 찾지 못했다');
+  const body = renderer.slice(start, renderer.indexOf('\n  /** 마우스 좌표가', start));
+
+  assert.match(body, /mergeBorderCoords\(rowYs\)/, '행 좌표를 병합하지 않는다');
+  assert.match(body, /mergeBorderCoords\(colXs\)/, '열 좌표를 병합하지 않는다');
+  assert.match(body, /rowIndexByY: rows\.indexByCoord/, '행 인덱스 맵을 돌려주지 않는다');
+  assert.match(body, /colIndexByX: cols\.indexByCoord/, '열 인덱스 맵을 돌려주지 않는다');
+});


### PR DESCRIPTION
## 변경 요약

표의 세로 경계를 마우스로 끌면 한 방향으로 움직이지 않습니다.

`TableResizeRenderer.computeBorderLines` 가 **한 물리적 경계에 괘선을 둘** 만듭니다. 셀의
좌/우 좌표를 소수점 1자리로 반올림해 `Set` 에 모으는데(`ry = (v) => Math.round(v*10)/10`),
한 경계를 공유하는 두 셀의 값이 반올림 경계에 걸치면 서로 다른 원소로 남습니다.

실측 (3×3 표, 새 문서, 100% 줌):

```
셀(0,0) 우측:  113.4 + 186.5 = 299.9
셀(0,1) 좌측:                  299.8   ← 같은 경계인데 괘선 2개 (3×3 인데 열 괘선 5개)
```

`computeResizePositionBounds` 가 그 중복을 이웃으로 잡아 드래그 범위가 뒤집힙니다.
**어느 인덱스를 잡느냐는 `hitTestBorder` 의 후보 정렬에 달려 있어 막히는 방향이 갈립니다.**

| 잡힌 괘선 | 현재 | min | max | 결과 |
|---|---|---|---|---|
| 아래쪽 299.8 | 299.8 | 116.1 | **297.2** | `max < cur` → 오른쪽으로 못 감 |
| 위쪽 299.9 | 299.9 | **302.5** | 483.6 | `min > cur` → 왼쪽으로 못 감 |
| **병합 후** | 299.8 | 116.1 | 483.6 | 정상 |

**생산자에서 묶습니다.** 임계 이내로 붙은 좌표를 하나의 괘선으로 합칩니다. 소비자 5곳
(`input-handler-table.ts:23, 79, 601`, `table-resize-renderer.ts:92, 163`)이 모두 같은
`computeBorderLines` 를 부르므로 한 번에 해소됩니다. #4109 에서 A(생산자) / B(소비자) 중
어느 쪽을 원하시는지 여쭀는데, B 는 소비자 5곳 중 1곳만 고치는 부분 수정이라 A 로
만들었습니다. B 를 원하시면 그쪽으로 바꾸겠습니다.

### 병합이 만들 수 있는 회귀를 함께 막습니다

병합은 좌표를 지웁니다. 그런데 `hitTestBorder` 는 **셀 좌표로 인덱스를 되찾습니다**
(`rowIndexByY.get(rounded(b.y))`). 지워진 쪽 좌표를 가진 셀은 인덱스를 못 찾아 그 경계가
잡히지 않게 됩니다. 그래서 `computeBorderLines` 가 **병합 전 좌표 전부**를 대표 인덱스로
보내는 맵을 함께 돌려주고, `hitTestBorder` 가 괘선 목록에서 맵을 재조립하는 대신 그것을
씁니다.

### 임계값

`1.0px` 입니다. 최소 셀 크기(`MIN_TABLE_CELL_SIZE_HWP=200` = 2.67px)보다 작아 실제로 떨어진
두 경계를 삼키지 않습니다. 관측된 반올림 오차는 0.1px 수준입니다. `computeBorderLines` 는
줌 적용 전 페이지 좌표를 쓰므로 줌에 따라 임계가 흔들리지 않습니다.

그룹 판정은 **직전 좌표가 아니라 그룹 대표(첫 좌표) 기준**입니다. 직전 좌표로 이으면
0.9px 씩 이어진 사슬이 계속 자라 최소 셀 하나를 통째로 삼킵니다.

## 관련 이슈

closes #4109

- #4117 — 셀 선택 모드 클릭 전에는 이 경계 드래그가 **시작조차** 되지 않는 별개 건.
  이 PR 은 드래그가 시작된 뒤의 범위 계산만 고칩니다.

## 테스트

- [x] `cargo test` 통과 — `cargo test --profile release-test --tests` : 468 바이너리, **5,277 통과 / 0 실패**
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo fmt --all -- --check` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — **해당 없음**. `computeBorderLines` 의 소비자 중
      그리는 쪽은 드래그 마커 DOM 오버레이(`table-resize-layer`, z-index 6)뿐이고 문서
      렌더 트리(PDF/SVG)에는 나타나지 않습니다. 다만 **마커 위치가 병합 대표 좌표로 최대
      1.0px(관측 0.1px) 이동**합니다 — 시각 변화가 0 은 아니라 명시합니다.
- [x] 웹(WASM) 렌더링 확인 — headless Chrome 실측, 아래
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 — **해당 없음**

`rhwp-studio` 게이트 (`local_validation.md` §4.3):

| 게이트 | 결과 |
|---|---|
| `npx tsc --noEmit` | 에러 0 |
| `npm test` | **772 pass / 0 fail** |
| `npm run build` | exit 0 |

인덱스 체계가 바뀌는 변경이라 기존 표 리사이즈 테스트가 그대로 통과하는지가 중요합니다 —
`table-mouse-resize-1491`, `table-bbox-cache-invalidation`, `table-hover-pagehint` 포함
전부 통과합니다.

### 회귀 테스트 — red→green 증명

`tests/table-border-lines.test.ts` (9 케이스)

| 되돌린 것 | 결과 |
|---|---|
| 임계를 0 으로 (병합 없음) | `fail 3` |
| 그룹 판정을 직전 좌표 기준(사슬)으로 | `fail 1` — 괘선 폭이 임계를 넘는다 |
| `hitTestBorder` 가 괘선 목록에서 맵 재조립 | `fail 1` |

사슬 케이스는 이 수정 자체가 만들 수 있는 버그를 막습니다 — 대표 기준이 아니면 병합이
최소 셀 크기를 넘어 자랍니다.

### 브라우저 실측 (headless Chrome, 3×3 표)

| 항목 | before | after |
|---|---|---|
| 열 괘선 개수 | 5 | **4** |
| 중복 쌍 (간격 ≤1px) | `299.8 / 299.9` | 없음 |
| 인덱스 되찾기 누락 | — | **0** |
| 열 경계 hit-test | — | **18/18** |

## 스크린샷

해당 없음 — 문서 출력은 그대로이고, 바뀌는 것은 드래그 가능 범위(위 표)와 드래그 마커
오버레이 위치(최대 1.0px, 관측 0.1px)입니다. 정지 화면 비교로는 구분되지 않습니다.

## 측정 조건

수치는 `pkg/` 를 이 브랜치의 base(`d634e608`)로 `wasm-pack build --target web --out-dir pkg`
재실행한 뒤 잰 값입니다. 그 전 시점의 wasm 으로 잰 값과 동일했습니다(괘선 5→4, 중복 쌍
`299.8/299.9`, 경계값 전부 일치).

## 확인하지 못한 것

- **중첩 표는 측정하지 않았습니다.** 스튜디오에서 셀 안에 표를 만드는 API 를 찾지 못했습니다.
- **병합 셀**에서 반올림 갈라짐이 더 자주/크게 나는지 보지 않았습니다.
- 행 경계(수평)에서는 이번 3×3 표에 중복이 없었습니다(`duplicateRowPairs: []`). 코드 경로는
  같지만 실제 갈라짐을 관측하지는 못했습니다.
