### PR TITLE
fix(studio): 머리말/꼬리말·각주에서 문단 서식이 적용되지 않는다

### DIFF
--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -1900,11 +1900,67 @@ export class InputHandler {
   /** 커서 위치 문단에 문단 서식을 적용한다 */
   private applyParaFormat(props: Record<string, unknown>): void {
     try {
+      if (this.applyParaFormatInNoteOrHeader(props)) return;
       const targets = this.getParaFormatTargetsAtCursor();
       this.executeParaFormatCommand(targets, props);
     } catch (err) {
       console.warn('[InputHandler] applyParaFormat 실패:', err);
     }
+  }
+
+  /**
+   * 머리말/꼬리말·각주 문단에 문단 서식을 적용한다. 해당 문맥이 아니면 false.
+   *
+   * 코어에는 `applyParaFormatInHf` / `applyParaFormatInFootnote` 가 이미 있는데 호출하는
+   * 곳이 없었다 — `getParaFormatTargetsForRange` 가 두 문맥에서 빈 배열을 반환해 정렬·줄
+   * 간격이 아무 반응 없이 끝났다. 조회 쪽(`getParaProperties`)은 두 문맥을 정확히 분기하고
+   * 있어 툴바 표시만 맞고 적용은 안 되는 상태였다.
+   *
+   * `ApplyParaFormatCommand` 의 되돌리기는 문단 모양 ID 를 `setParaShapeId` /
+   * `setCellParaShapeId` 로 복원하는데 이 두 문맥용 setter 가 코어에 없다. 되돌리기를
+   * 포기하지 않으려고 표 구조 변경과 같은 스냅샷 경로를 쓴다.
+   * 근본 해결: 코어에 `setParaShapeIdInHf` / `setParaShapeIdInFootnote` 를 추가하고
+   * `ParaFormatTarget` 에 두 갈래를 넣어 네 문맥(본문/셀/머리말/각주)을 한 커맨드로 통일한다.
+   */
+  private applyParaFormatInNoteOrHeader(props: Record<string, unknown>): boolean {
+    const cur = this.cursor;
+    const propsJson = JSON.stringify(props);
+    const cursorBefore = cur.getPosition();
+
+    if (cur.isInHeaderFooter()) {
+      const isHeader = cur.headerFooterMode === 'header';
+      const sectionIdx = cur.hfSectionIdx;
+      const applyTo = cur.hfApplyTo;
+      const hfParaIdx = cur.hfParaIdx;
+      this.executeOperation({
+        kind: 'snapshot',
+        operationType: 'applyParaFormatInHf',
+        operation: (wasm) => {
+          wasm.applyParaFormatInHf(sectionIdx, isHeader, applyTo, hfParaIdx, propsJson);
+          return { ...cursorBefore };
+        },
+      });
+      return true;
+    }
+
+    if (cur.isInFootnote()) {
+      // 인자 축은 조회 쪽(getParaProperties)과 같다 — sec / para / controlIdx / innerParaIdx.
+      const sectionIdx = cur.fnSectionIdx;
+      const paraIdx = cur.fnParaIdx;
+      const controlIdx = cur.fnControlIdx;
+      const innerParaIdx = cur.fnInnerParaIdx;
+      this.executeOperation({
+        kind: 'snapshot',
+        operationType: 'applyParaFormatInFootnote',
+        operation: (wasm) => {
+          wasm.applyParaFormatInFootnote(sectionIdx, paraIdx, controlIdx, innerParaIdx, propsJson);
+          return { ...cursorBefore };
+        },
+      });
+      return true;
+    }
+
+    return false;
   }
 
   private executeParaFormatCommand(targets: ParaFormatTarget[], props: Record<string, unknown>): boolean {

--- a/rhwp-studio/tests/mutation-routing-guard.test.ts
+++ b/rhwp-studio/tests/mutation-routing-guard.test.ts
@@ -210,7 +210,7 @@ const BASELINE: Readonly<Record<string, number>> = {
   'src/ui/table-cell-props-dialog.ts': 2,
   'src/ui/toolbar.ts': 4,
   // engine/input-handler* — 드래그/nudge 등 직접-뮤테이션 최고밀도 영역.
-  'src/engine/input-handler.ts': 27, // +1: 누름틀 제거 이관 시 removeFieldAt 이 양식모드(직접 유지)/일반모드(snapshot) 두 분기로 분리 / +1: Edit 오버레이 커밋이 셀 내부는 setFormValueInCell 로 분기(CheckBox 와 동일 조건 — 기존 flat 호출은 표 컨트롤 슬롯을 가리켜 실패)
+  'src/engine/input-handler.ts': 29, // +1: 누름틀 제거 이관 시 removeFieldAt 이 양식모드(직접 유지)/일반모드(snapshot) 두 분기로 분리 / +1: Edit 오버레이 커밋이 셀 내부는 setFormValueInCell 로 분기(CheckBox 와 동일 조건 — 기존 flat 호출은 표 컨트롤 슬롯을 가리켜 실패) / +2: 머리말·꼬리말(applyParaFormatInHf)과 각주(applyParaFormatInFootnote) 문단 서식 배선 — 둘 다 snapshot 라우팅
   'src/engine/input-handler-connector.ts': 1,
   'src/engine/input-handler-keyboard.ts': 21,
   'src/engine/input-handler-mouse.ts': 3,

--- a/rhwp-studio/tests/note-header-para-format-wiring.test.ts
+++ b/rhwp-studio/tests/note-header-para-format-wiring.test.ts
@@ -1,0 +1,103 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// 머리말/꼬리말·각주 문단 서식이 "구현은 됐는데 아무도 안 부르는" 상태로 되돌아가는 것을
+// 막는다.
+//
+// 결함 형태: 코어에 applyParaFormatInHf / applyParaFormatInFootnote 가 있고 브리지에도
+// 노출돼 있는데 호출부가 0곳이었다. getParaFormatTargetsForRange 가 두 문맥에서 빈 배열을
+// 반환해, 정렬·줄 간격을 눌러도 아무 반응 없이 끝났다. 조회 쪽(getParaProperties)은 두
+// 문맥을 정확히 분기하고 있어서 툴바 표시만 맞고 적용은 안 되는 비대칭이었다.
+//
+// 그래서 "브리지에 있는 쓰기 API 가 실제로 호출되는가"를 직접 센다. 호출부가 사라지면
+// (이 결함의 재발 형태) 실패한다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(rel: string): string {
+  return readFileSync(join(rootDir, rel), 'utf8');
+}
+
+/** src/ 아래 .ts 전수 (테스트 제외). */
+function sourceFiles(): string[] {
+  const out: string[] = [];
+  const walk = (rel: string) => {
+    for (const ent of readdirSync(join(rootDir, rel), { withFileTypes: true })) {
+      const child = `${rel}/${ent.name}`;
+      if (ent.isDirectory()) walk(child);
+      else if (ent.name.endsWith('.ts') && !ent.name.endsWith('.test.ts')) out.push(child);
+    }
+  };
+  walk('src');
+  return out;
+}
+
+/** 브리지 정의와 뮤테이션 레지스트리 등재는 "호출"이 아니다. */
+const NOT_A_CALL_SITE = new Set([
+  'src/core/wasm-bridge.ts',
+  'src/core/mutation-method-registry.ts',
+]);
+
+function callSites(method: string): string[] {
+  const re = new RegExp(`\\.\\s*${method}\\s*\\(`);
+  return sourceFiles()
+    .filter(rel => !NOT_A_CALL_SITE.has(rel))
+    .filter(rel => re.test(source(rel)));
+}
+
+for (const method of ['applyParaFormatInHf', 'applyParaFormatInFootnote']) {
+  test(`${method} 는 호출되는 코드가 있어야 한다`, () => {
+    const sites = callSites(method);
+    assert.ok(
+      sites.length > 0,
+      `${method} 가 브리지에만 있고 호출부가 없다 — 머리말/꼬리말·각주에서 문단 서식이 `
+        + `아무 반응 없이 끝난다. getParaProperties 는 두 문맥을 분기하므로 툴바 표시만 `
+        + `맞고 적용은 안 되는 비대칭이 된다.`,
+    );
+  });
+}
+
+test('문단 서식 진입점이 머리말/꼬리말과 각주를 모두 분기한다', () => {
+  const src = source('src/engine/input-handler.ts');
+  const start = src.indexOf('private applyParaFormatInNoteOrHeader');
+  assert.notEqual(start, -1, 'applyParaFormatInNoteOrHeader 를 찾지 못함');
+  const end = src.indexOf('\n  private ', start + 1);
+  const block = src.slice(start, end === -1 ? undefined : end);
+
+  // 한쪽만 배선하면(이 결함의 부분 수정 형태) 실패한다.
+  assert.match(block, /isInHeaderFooter\(\)/);
+  assert.match(block, /applyParaFormatInHf\(/);
+  assert.match(block, /isInFootnote\(\)/);
+  assert.match(block, /applyParaFormatInFootnote\(/);
+});
+
+test('문단 서식 진입점이 그 분기를 실제로 호출한다', () => {
+  // 분기 메서드가 있어도 진입점에서 부르지 않으면 결함은 그대로다.
+  // (이 단언 없이는 진입점 호출을 지워도 테스트가 통과했다.)
+  const src = source('src/engine/input-handler.ts');
+  const start = src.indexOf('private applyParaFormat(props: Record<string, unknown>): void {');
+  assert.notEqual(start, -1, 'applyParaFormat 진입점을 찾지 못함');
+  const end = src.indexOf('\n  private ', start + 1);
+  const entry = src.slice(start, end === -1 ? undefined : end);
+
+  assert.match(
+    entry,
+    /this\.applyParaFormatInNoteOrHeader\(props\)/,
+    'applyParaFormat 이 머리말/꼬리말·각주 분기를 호출하지 않는다 — 분기가 도달 불가라 '
+      + '정렬·줄 간격이 여전히 무반응이다.',
+  );
+});
+
+test('되돌리기 라우팅을 거친다 (executeOperation 경유)', () => {
+  const src = source('src/engine/input-handler.ts');
+  const start = src.indexOf('private applyParaFormatInNoteOrHeader');
+  const end = src.indexOf('\n  private ', start + 1);
+  const block = src.slice(start, end === -1 ? undefined : end);
+
+  // 직접 wasm 을 부르면 undo 에 안 남고 redo 스택도 무효화되지 않는다 (#2327).
+  const executeOperationCount = [...block.matchAll(/this\.executeOperation\(/g)].length;
+  assert.equal(executeOperationCount, 2, '머리말/꼬리말과 각주 각각 executeOperation 을 거쳐야 한다');
+});


### PR DESCRIPTION
## 변경 요약

머리말/꼬리말 편집 중 정렬이나 줄 간격을 바꿔도 **아무 반응이 없습니다**. 각주도 같습니다.
콘솔에는 이 로그만 남습니다.

```
[InputHandler] 문단 서식 Undo/Redo: unsupported context
```

**구현은 됐는데 아무도 부르지 않았습니다.** 코어에 `applyParaFormatInHf` 와
`applyParaFormatInFootnote` 가 있고 `WasmBridge` 에도 노출돼 있으며 `MUTATING_METHODS` 에도
등재돼 있는데, 호출하는 코드가 한 곳도 없었습니다.

`getParaFormatTargetsForRange` 가 두 문맥에서 곧바로 빈 배열을 반환합니다.

```ts
// input-handler.ts
if (this.cursor.isInHeaderFooter() || this.cursor.isInFootnote()) return [];
```

조회 쪽은 반대로 정확히 배선돼 있습니다 — `getParaProperties` 가 `getParaPropertiesInHf` /
`getParaPropertiesInFootnote` 로 분기합니다. 그래서 **툴바에는 현재 문단 속성이 제대로
표시되는데 바꾸는 것만 안 되는** 비대칭 상태였습니다.

두 문맥을 조회 쪽과 같은 인자 축으로 배선합니다. 머리말/꼬리말만 고치면 각주가 그대로 남아
같은 결함이 절반 남으므로 **둘 다** 처리하고, 회귀 테스트가 한쪽만 배선된 상태를 실패로
잡습니다.

### 되돌리기 경로에 대해

`ApplyParaFormatCommand` 의 undo 는 문단 모양 ID 를 `setParaShapeId` / `setCellParaShapeId`
로 복원하는데, 이 두 문맥용 setter 가 코어에 없습니다. 되돌리기를 포기하지 않으려고 표
구조 변경과 같은 **스냅샷 경로**(`executeOperation({kind:'snapshot'})`)를 씁니다.

근본 해결은 코어에 `setParaShapeIdInHf` / `setParaShapeIdInFootnote` 를 추가해 네 문맥
(본문/셀/머리말/각주)을 한 커맨드로 통일하는 것입니다. 이 PR 의 범위를 넘어서므로 코드
주석에 남겼습니다 — 원하시면 별도 이슈로 올리겠습니다.

## ⚠️ #4119 와 같은 줄을 바꿉니다 — 머지 순서 주의

`tests/mutation-routing-guard.test.ts` 의 뮤테이션 표면 원장에서 두 PR 이 같은 줄을
각각 바꿉니다.

| | `'src/engine/input-handler.ts'` |
|---|---|
| `devel` | 27 |
| #4119 (셀 블록 서식) | 28 (+1) |
| **이 PR** | 29 (+2) |
| **둘 다 머지되면 정답** | **30** |

나중에 머지되는 쪽은 이 줄에서 충돌합니다. 충돌을 한쪽 값으로 해결하면 실제 호출 수와
어긋나 가드 테스트가 `devel` 에서 실패합니다. **30 으로 맞춰야 합니다.** 두 번째 PR 을
rebase 할 때 제가 갱신하겠습니다 — 순서를 알려주시면 그에 맞추겠습니다.

## 관련 이슈

없음 — QA 리포트에서 출발했습니다. 같은 조사에서 올린 이슈는 아래입니다.

- #4109 — 표 세로 경계 드래그가 역방향으로 clamp
- #4117 — 셀 선택 모드 클릭 전에는 표 경계 리사이즈가 시작되지 않음
- #4118 — 셀별 뮤테이터 1회 비용이 표 셀 수에 비례
- #4121 — 머리말/꼬리말에서 텍스트 선택이 만들어지지 않음 (이 PR 과 인접, 별개 건)

## 테스트

- [x] `cargo test` 통과 — `cargo test --profile release-test --tests` : 468 바이너리, **5,277 통과 / 0 실패**
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo fmt --all -- --check` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — **해당 없음**. 변경은 편집 명령 배선이고 렌더
      출력 경로를 건드리지 않습니다.
- [x] 웹(WASM) 렌더링 확인 — 머리말에 텍스트 입력 후 가운데 정렬 → `justify` → `center` 반영
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 — **해당 없음**

`rhwp-studio` 게이트 (`local_validation.md` §4.3):

| 게이트 | 결과 |
|---|---|
| `npx tsc --noEmit` | 에러 0 |
| `npm test` | 752 pass / 4 fail |

`npm test` 의 4건은 **`upstream/devel` 자체에서도 실패**하는 선행 red 입니다. 이 브랜치에서
변경을 stash 하고 같은 4개 파일을 돌려 `pass 0 / fail 4` 로 동일함을 확인했습니다.

```
tests/cell-selection-caret-sync.test.ts
tests/focused-cursor-geometry.test.ts
tests/nested-cell-backspace-merge.test.ts
tests/selection-ordering-nested-cell.test.ts
```

### 회귀 테스트 — red→green 증명

`tests/note-header-para-format-wiring.test.ts` (5 케이스)

| 되돌린 것 | 결과 |
|---|---|
| 진입점 분기 제거 (분기 메서드는 남김) | `fail 1` |
| 각주만 배선하지 않음 (부분 수정 형태) | `fail 3` |

처음 작성한 테스트는 호출부 존재만 확인해서 **진입점 분기를 지워도 통과**했습니다. 그 상태를
red 로 만들지 못하는 테스트는 결함을 판별하지 못하므로, 진입점 호출 단언을 추가했습니다.

## 스크린샷

해당 없음 — 머리말에서 정렬이 반영되는지 여부이고, 위 `justify → center` 값 변화가 그
증거입니다.

## 남은 것 (이 PR 범위 밖)

머리말/꼬리말 안에서는 **텍스트 선택 자체가 되지 않습니다** — 드래그도, Shift+Home 도
선택이 만들어지지 않습니다. 코어에 `getSelectionRectsInHeaderFooter` 추가가 필요해 **#4121**
로 따로 올렸습니다.
