### PR TITLE
tools: OVR 산출물 기본 경로를 gitignore된 output/ 으로 통일

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,23 +184,23 @@ cargo fmt --all -- --check       # CI와 같은 포맷 검증
 
 ```bash
 # 개체(표·그림) geometry 무회귀 — 원커맨드: devel 을 worktree 빌드해 baseline 자동 생성 후
-# 현 트리와 대조, PR 본문용 markdown 요약(out/ovr/ovr_diff.md)까지 출력
-python tools/object_visual_regression.py --preset ovr5 -o out/ovr --diff-against devel
+# 현 트리와 대조, PR 본문용 markdown 요약(output/ovr/ovr_diff.md)까지 출력
+python tools/object_visual_regression.py --preset ovr5 -o output/ovr --diff-against devel
 
 # (수동 3단계 흐름도 그대로 동작 — 수정 전 baseline 저장, 수정 후 비교)
-python tools/object_visual_regression.py <샘플.hwp> -o out/ovr --no-hwp --save-baseline
-python tools/object_visual_regression.py <샘플.hwp> -o out/ovr2 --no-hwp --baseline out/ovr/baseline.json
+python tools/object_visual_regression.py <샘플.hwp> -o output/ovr --no-hwp --save-baseline
+python tools/object_visual_regression.py <샘플.hwp> -o output/ovr2 --no-hwp --baseline output/ovr/baseline.json
 
 # 편집-스윕 — 편집 경로 PR(vpos·pagination·undo)의 가짜 페이지 변동 검출
 # devel 과 브랜치에서 각각 스윕 → 공통/해소/신규 분류 리포트 (신규 존재 시 exit 1)
-cargo run --release --example edit_sweep -- samples -o out/sweep/branch.tsv
-cargo run --release --example edit_sweep -- --compare out/sweep/devel.tsv out/sweep/branch.tsv -o out/sweep/report.md
+cargo run --release --example edit_sweep -- samples -o output/sweep/branch.tsv
+cargo run --release --example edit_sweep -- --compare output/sweep/devel.tsv output/sweep/branch.tsv -o output/sweep/report.md
 
 # 라운드트립 시각 기하 회귀
 cargo run --release --bin rhwp -- render-diff <샘플.hwp>
 
 # HWPX→HWP 변환 페이지네이션 정합
-python tools/roundtrip_fidelity_harness.py --files <샘플.hwpx> --workdir out/rtf -o out/rtf/result.tsv
+python tools/roundtrip_fidelity_harness.py --files <샘플.hwpx> --workdir output/rtf -o output/rtf/result.tsv
 ```
 
 - OVR(개체 시각 회귀)로 "변경 범위 밖 문서의 개체가 움직이지 않았음"을 결과와 함께

--- a/examples/edit_sweep.rs
+++ b/examples/edit_sweep.rs
@@ -8,11 +8,11 @@
 //!
 //! 사용:
 //!     # 스윕 → TSV (경로·전후 쪽수·변동·상태)
-//!     cargo run --release --example edit_sweep -- samples -o out/sweep/devel.tsv
+//!     cargo run --release --example edit_sweep -- samples -o output/sweep/devel.tsv
 //!     # 편집 종류 선택(기본 insert1 = para0 앞 1자 삽입)
-//!     cargo run --release --example edit_sweep -- samples -o out/sweep/a.tsv --edit insert1
+//!     cargo run --release --example edit_sweep -- samples -o output/sweep/a.tsv --edit insert1
 //!     # 두 스윕 대조 → 공통/해소/신규 분류 md 리포트
-//!     cargo run --release --example edit_sweep -- --compare out/sweep/devel.tsv out/sweep/branch.tsv -o out/sweep/report.md
+//!     cargo run --release --example edit_sweep -- --compare output/sweep/devel.tsv output/sweep/branch.tsv -o output/sweep/report.md
 //!
 //! 대상: 지정 디렉터리 재귀의 .hwp/.hwpx/.hml, 기본 <2MB 캡(--max-kb, 0=무제한).
 //! 파일 단위 panic 은 catch_unwind 로 격리해 스윕 전체를 죽이지 않고 status 에 기록한다.

--- a/mydocs/manual/pr_review/collaborator_external_pr.md
+++ b/mydocs/manual/pr_review/collaborator_external_pr.md
@@ -45,6 +45,11 @@ local CI 검증이 완료된 경우 review 문서와 오늘할일은 실행 결�
 않은 GitHub Actions·작업지시자 승인·merge만 미래 조건으로 남기며, 완료 검증을 "실행할 예정"으로
 표현하지 않는다.
 
+source branch의 오늘할일이 최신 `upstream/devel`보다 오래된 경우에는
+[최신 `devel` 오늘할일을 보존하는 trailing 기록](../pr_review_workflow.md#321-최신-devel-오늘할일을-보존하는-trailing-기록)을
+따른다. 최신 내용을 source에 복사하거나 `devel`을 병합하지 않고, merge tree에서 기존 기록과 새 기록이
+함께 보존되는지 검증한다.
+
 ## 9.3 PR head push
 
 contributor 원 commit을 rewrite하지 않는다. review 문서·오늘할일·보정 code는 별도 commit으로 나누고,

--- a/mydocs/manual/pr_review_workflow.md
+++ b/mydocs/manual/pr_review_workflow.md
@@ -125,6 +125,23 @@ base 반영을 강제하지 않는 정책이면, 같은 PR·같은 source reposi
 재사용해 trailing review-only commit을 fast-pass할 수 있다. contributor가 source·test를 새로 push한 경우에는
 그 새 code head의 CI를 먼저 통과시킨 뒤 review 기록을 한 번만 이어 붙인다.
 
+#### 3.2.1 최신 `devel` 오늘할일을 보존하는 trailing 기록
+
+contributor source branch의 `mydocs/orders/YYYYMMDD.md`가 최신 `upstream/devel`보다 오래될 수 있다.
+이 경우 review 기록을 추가하려고 최신 `devel`의 오늘할일 전체를 source에 복사하거나 `devel`을 merge/rebase하면,
+source에 없는 archive link를 도입하거나 today add/add 충돌과 불필요한 full CI를 만들 수 있다.
+
+1. `git fetch upstream devel` 뒤 `git diff HEAD..upstream/devel -- mydocs/orders/YYYYMMDD.md`로 최신 base의
+   변경 구간을 확인한다.
+2. contributor source에 이미 있는 오늘할일은 보존하고, 현재 PR의 항목만 위 diff에서 변경되지 않은 section
+   경계에 추가한다. 최신 `devel`의 다른 PR 기록을 source branch에 복사하지 않는다.
+3. trailing 문서 commit을 만든 뒤 최신 `upstream/devel`에서 merge simulation을 수행한다. merge tree의
+   `git diff --check`와 변경한 오늘할일·review 문서의 Markdown 링크 검사가 모두 통과해야 한다.
+
+이 방식은 source history를 선형으로 유지하면서, 실제 merge tree에는 최신 `devel`의 기존 오늘 기록과
+현재 PR 기록이 함께 남는지 확인한다. 변경되지 않은 경계를 찾을 수 없거나 simulation이 충돌하면 source에
+`devel`을 억지로 병합하지 말고 작업지시자에게 보고한다.
+
 ### 3.3 순차로 유지할 일
 
 공유 상태를 바꾸거나 선행 결과가 필요한 작업은 아래 순서를 지킨다.

--- a/mydocs/manual/verification/edit_sweep.md
+++ b/mydocs/manual/verification/edit_sweep.md
@@ -25,13 +25,13 @@ PR #2314 검증에서 일회성 하네스로 수행해 "devel 변동 70건 → P
 
 ```bash
 # devel 에서 baseline 스윕
-git switch devel && cargo run --release --example edit_sweep -- samples -o out/sweep/devel.tsv
+git switch devel && cargo run --release --example edit_sweep -- samples -o output/sweep/devel.tsv
 
 # 작업 브랜치에서 스윕
-git switch <branch> && cargo run --release --example edit_sweep -- samples -o out/sweep/branch.tsv
+git switch <branch> && cargo run --release --example edit_sweep -- samples -o output/sweep/branch.tsv
 
 # 대조 → 공통/해소/신규 분류 리포트 (PR 본문 첨부용)
-cargo run --release --example edit_sweep -- --compare out/sweep/devel.tsv out/sweep/branch.tsv -o out/sweep/report.md
+cargo run --release --example edit_sweep -- --compare output/sweep/devel.tsv output/sweep/branch.tsv -o output/sweep/report.md
 ```
 
 실측: 581 샘플 전수 스윕 약 12초 (release, M-계열 macOS). 편집 종류는
@@ -45,7 +45,7 @@ cargo run --release --example edit_sweep -- --compare out/sweep/devel.tsv out/sw
   정당 성장 여부를 가려야 하며, 자동 게이트는 후보 검출까지만 담당한다.
 - 상태 전이(ok↔parse/edit/panic)는 커버리지 변화로 별도 분류 — 무변동
   위장을 막는다.
-- baseline TSV 는 커밋하지 않는다(출력은 `out/` 아래).
+- baseline TSV 는 커밋하지 않는다(출력은 `.gitignore`된 `output/` 아래).
 
 ## 한계
 

--- a/mydocs/orders/20260807.md
+++ b/mydocs/orders/20260807.md
@@ -35,6 +35,9 @@
 - 보정 code head의 GitHub Actions full CI·CodeQL·Native Skia·네 test shard가 모두 성공했다. 이 review와
   오늘할일 문서는 동일 source branch에 review-only trailing commit으로 추가했으며, 최신 head의
   fast-pass aggregate와 merge 가능 상태를 다시 확인한다.
+- source보다 최신인 `upstream/devel` today 기록을 source에 복사하면 archive 링크가 깨질 수 있음을
+  확인했다. 현재 PR 항목만 변경되지 않은 section 경계에 추가하고 merge tree 링크 검사를 수행하도록
+  PR workflow와 collaborator 외부 PR 가이드를 보강했다.
 
 상세 근거: [PR #4153 검토](../pr/archives/pr_4153_review.md),
 [메인터너 보정 기록](../pr/archives/pr_4153_review_impl.md).

--- a/mydocs/orders/20260807.md
+++ b/mydocs/orders/20260807.md
@@ -21,6 +21,24 @@
 상세 근거: [#536 Stage 1](../working/task_m100_536_stage1.md),
 [#4139 검토](../pr/archives/pr_4139_review.md).
 
+## PR #4153 - OVR·편집 스윕 산출물 경로 통일
+
+- [PR #4153](https://github.com/edwardkim/rhwp/pull/4153)의 원 기여 commit `06989c41f`은
+  OVR 기본 산출물 경로를 저장소 루트의 `.gitignore`된 `output/ovr`로 정하고 CONTRIBUTING 예시를
+  같은 경로로 통일했다.
+- 이슈 [#4152](https://github.com/edwardkim/rhwp/issues/4152)의 수용 범위와 대조해
+  `examples/edit_sweep.rs`와 `mydocs/manual/verification/edit_sweep.md`에 남은 `out/sweep` 안내를
+  메인터너 보정 `3a7c88b13`으로 `output/sweep`으로 통일했다. 일반 CLI의 별도 `out/` 관례는
+  변경하지 않았다.
+- `git diff --check`, Markdown 링크 검사, Python 문법·도움말, `.gitignore` 경로 확인, `cargo fmt --check`,
+  최신 `devel` merge simulation을 통과했다. `target/release/rhwp`가 없어 OVR 전체 실행은 하지 않았다.
+- 보정 code head의 GitHub Actions full CI·CodeQL·Native Skia·네 test shard가 모두 성공했다. 이 review와
+  오늘할일 문서는 동일 source branch에 review-only trailing commit으로 추가했으며, 최신 head의
+  fast-pass aggregate와 merge 가능 상태를 다시 확인한다.
+
+상세 근거: [PR #4153 검토](../pr/archives/pr_4153_review.md),
+[메인터너 보정 기록](../pr/archives/pr_4153_review_impl.md).
+
 ## kevin9327 누적 PR 검토 - #4105, #4106, #4108, #4114, #4116
 
 - 초기 `upstream/devel` `9f564bbe` 위에 다섯 PR의 원 commit을 순서대로 누적 cherry-pick했고 충돌은 없었다.

--- a/mydocs/pr/archives/pr_4153_review.md
+++ b/mydocs/pr/archives/pr_4153_review.md
@@ -41,9 +41,14 @@
 ## CI와 판정
 
 메인터너 보정 head `3a7c88b13`에서 GitHub Actions full CI, CodeQL, Native Skia, slow shard와
-일반 shard 1/3·2/3·3/3, Build & Test가 모두 성공했다. 이 문서와 오늘할일은 그 code candidate
-뒤의 문서 전용 trailing commit이다.
+일반 shard 1/3·2/3·3/3, Build & Test가 모두 성공했다. review·오늘할일 head `9edcf0829`도
+review-only fast-pass preflight와 Build & Test aggregate를 통과했다.
 
-**권고: 수용.** trailing commit을 push한 뒤에는 같은 PR source branch의 녹색 code candidate를
+검토 중 source보다 최신인 `upstream/devel`의 오늘할일 전체를 복사하면 source에 없는 archive link가
+깨짐을 Markdown 링크 검사로 확인했다. 최신 devel을 source에 merge하지 않고 현재 PR 항목만 변경되지 않은
+section 경계에 넣은 뒤 merge tree 링크 검사로 확인하는 절차를 PR workflow와 collaborator 외부 PR 가이드에
+보강했다.
+
+**권고: 수용.** 이번 문서 보강 commit을 push한 뒤에는 같은 PR source branch의 녹색 code candidate를
 review-only fast-pass로 재사용할 수 있는지와 최신 head의 preflight·Build & Test aggregate·mergeable
 상태를 다시 확인한다. 최종 merge는 작업지시자 승인을 전제로 한다.

--- a/mydocs/pr/archives/pr_4153_review.md
+++ b/mydocs/pr/archives/pr_4153_review.md
@@ -1,0 +1,49 @@
+# PR #4153 검토 기록
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4153](https://github.com/edwardkim/rhwp/pull/4153) |
+| 이슈 | [#4152](https://github.com/edwardkim/rhwp/issues/4152) |
+| 작성자 | `humdrum00001010` |
+| base | `devel` |
+| contributor 원 head | `06989c41fcf9ddbc1fe811aaffa0281183613448` |
+| 메인터너 보정 head | `3a7c88b1395c9837d272806747519ce4ad441648` |
+| 작성 시점 merge 상태 | `CLEAN` / `MERGEABLE` |
+
+라우팅: collaborator 매개 외부 PR. 보조 경로는 접수·로컬 검증과 review-only fast-pass다.
+시각·fixture 증적은 renderer, layout, sample, 기준 PDF를 바꾸지 않아 적용하지 않았다.
+
+## 변경 검토
+
+원 contributor 변경은 `tools/object_visual_regression.py`의 `-o` 기본값을 저장소 루트의
+`output/ovr`로 정하고 CONTRIBUTING OVR·roundtrip 안내를 `output/`으로 통일한다. 이 경로는
+루트 `.gitignore`의 `/output/` 규칙에 포함된다.
+
+초기 검토에서 이슈 #4152가 요구한 편집-스윕 안내가 `out/sweep`으로 남은 것을 확인했다.
+메인터너 보정 `3a7c88b13`은 `examples/edit_sweep.rs`의 Rustdoc 세 곳과
+`mydocs/manual/verification/edit_sweep.md`의 명령·설명을 `output/sweep`으로 바꿨다.
+일반 rhwp CLI의 독립적인 `out/` 관례는 이 이슈 범위 밖이므로 수정하지 않았다.
+
+## 로컬 검증
+
+- `git diff --check`를 실행해 whitespace 오류가 없음을 확인했다.
+- `python3 -m py_compile tools/object_visual_regression.py`와 `--help`를 실행해 Python 문법과
+  기본값 도움말이 정상임을 확인했다.
+- 유효한 `samples/KTX.hwp`로 `-o` 생략 경로를 실행해 `output/ovr`가 생성되고 `/output/` ignore
+  규칙에 매칭됨을 확인했다. 현재 `target/release/rhwp`가 없어 실제 OVR 산출까지는 진행하지 못했고,
+  도구는 예상대로 바이너리 부재 오류 `2`로 종료했다. 생성한 빈 검증 디렉터리는 제거했다.
+- `python3 scripts/check_markdown_links.py mydocs/manual/verification/edit_sweep.md`,
+  `git check-ignore -v output/sweep/devel.tsv output/sweep/report.md`, `cargo fmt --check`를 통과했다.
+- 최신 `upstream/devel`에 대한 merge simulation은 충돌 없이 완료했고 `git merge --abort`로 정리했다.
+
+## CI와 판정
+
+메인터너 보정 head `3a7c88b13`에서 GitHub Actions full CI, CodeQL, Native Skia, slow shard와
+일반 shard 1/3·2/3·3/3, Build & Test가 모두 성공했다. 이 문서와 오늘할일은 그 code candidate
+뒤의 문서 전용 trailing commit이다.
+
+**권고: 수용.** trailing commit을 push한 뒤에는 같은 PR source branch의 녹색 code candidate를
+review-only fast-pass로 재사용할 수 있는지와 최신 head의 preflight·Build & Test aggregate·mergeable
+상태를 다시 확인한다. 최종 merge는 작업지시자 승인을 전제로 한다.

--- a/mydocs/pr/archives/pr_4153_review_impl.md
+++ b/mydocs/pr/archives/pr_4153_review_impl.md
@@ -1,0 +1,30 @@
+# PR #4153 메인터너 보정 기록
+
+## 목적
+
+이슈 [#4152](https://github.com/edwardkim/rhwp/issues/4152)의 산출물 경로 통일 범위가 OVR 도구와
+CONTRIBUTING에만 반영되고 편집-스윕의 Rustdoc·매뉴얼에는 남지 않은 상태를 보완한다.
+
+## commit 구성
+
+| 순서 | SHA | 역할 |
+| --- | --- | --- |
+| 1 | `06989c41f` | contributor: OVR 기본 산출물과 CONTRIBUTING 안내를 `output/`으로 통일 |
+| 2 | `3a7c88b13` | maintainer: 편집-스윕 Rustdoc·매뉴얼의 `out/sweep`을 `output/sweep`으로 통일 |
+| 3 | 이 문서 commit | review·오늘할일 기록만 추가 |
+
+contributor 원 commit은 수정하거나 재작성하지 않았다. 보정은 같은 visibility branch
+`review/humdrum00001010-20260807`에서 원 head 뒤에 단일 commit으로 추가했다.
+
+## 검증과 push
+
+- 보정 전후 원격 source branch와 PR head가 모두 contributor SHA `06989c41f`임을 확인했다.
+- 수정 파일 두 개는 `filter: unspecified`이고 `git lfs status`에 push object가 없었다.
+  따라서 `GIT_LFS_SKIP_PUSH=1`을 사용한 dry-run과 실제 push가 성공했다.
+- `git diff --check`, targeted Markdown 링크 검사, ignore 경로 검사, `cargo fmt --check`를 통과했다.
+- `3a7c88b13`의 GitHub Actions full CI와 CodeQL이 성공했다.
+
+## 후속 조건
+
+review·오늘할일 commit은 source code를 바꾸지 않는다. push 뒤 최신 PR head가 그 commit과 일치하는지,
+review-only fast-pass preflight 및 aggregate가 성공하는지 확인한 뒤 작업지시자 승인에 따라 merge한다.

--- a/mydocs/pr/archives/pr_4153_review_impl.md
+++ b/mydocs/pr/archives/pr_4153_review_impl.md
@@ -11,7 +11,8 @@ CONTRIBUTING에만 반영되고 편집-스윕의 Rustdoc·매뉴얼에는 남지
 | --- | --- | --- |
 | 1 | `06989c41f` | contributor: OVR 기본 산출물과 CONTRIBUTING 안내를 `output/`으로 통일 |
 | 2 | `3a7c88b13` | maintainer: 편집-스윕 Rustdoc·매뉴얼의 `out/sweep`을 `output/sweep`으로 통일 |
-| 3 | 이 문서 commit | review·오늘할일 기록만 추가 |
+| 3 | `9edcf0829` | review·오늘할일 기록만 추가 |
+| 4 | 이 문서 commit | 최신 devel today 보존·merge simulation 절차를 workflow에 보강 |
 
 contributor 원 commit은 수정하거나 재작성하지 않았다. 보정은 같은 visibility branch
 `review/humdrum00001010-20260807`에서 원 head 뒤에 단일 commit으로 추가했다.
@@ -23,8 +24,11 @@ contributor 원 commit은 수정하거나 재작성하지 않았다. 보정은 �
   따라서 `GIT_LFS_SKIP_PUSH=1`을 사용한 dry-run과 실제 push가 성공했다.
 - `git diff --check`, targeted Markdown 링크 검사, ignore 경로 검사, `cargo fmt --check`를 통과했다.
 - `3a7c88b13`의 GitHub Actions full CI와 CodeQL이 성공했다.
+- `9edcf0829`의 review-only fast-pass CI가 성공했다. source에 없는 최신 devel archive 기록을 복사하면
+  링크가 깨지는 것을 확인해, source의 기존 항목을 보존하고 변경되지 않은 경계에 현재 PR 기록만 넣은
+  merge simulation으로 정합을 확인했다.
 
 ## 후속 조건
 
-review·오늘할일 commit은 source code를 바꾸지 않는다. push 뒤 최신 PR head가 그 commit과 일치하는지,
+이번 workflow 보강 commit도 source code를 바꾸지 않는다. push 뒤 최신 PR head가 그 commit과 일치하는지,
 review-only fast-pass preflight 및 aggregate가 성공하는지 확인한 뒤 작업지시자 승인에 따라 merge한다.

--- a/tools/object_visual_regression.py
+++ b/tools/object_visual_regression.py
@@ -10,15 +10,15 @@ fitz 로 페이지 래스터 + 이미지 bbox 를 얻어, 개체를 읽기순으
 
 좌표계: render-tree bbox 는 96 DPI px. 한글 PDF 는 pt(72 DPI) → 96 DPI 로 래스터하여 정합.
 
-사용:
+사용 (-o 생략 시 기본 산출물 경로는 output/ovr — 루트 .gitignore 의 /output/ 아래):
     # 한글 대조 + 시각 갤러리 + baseline 저장
-    python tools/object_visual_regression.py <file.hwp> -o out/ovr --save-baseline
+    python tools/object_visual_regression.py <file.hwp> -o output/ovr --save-baseline
     # rhwp 버전 간 회귀 비교 (한글 불필요, 빠름)
-    python tools/object_visual_regression.py <file.hwp> -o out/ovr --baseline out/ovr/baseline.json --no-hwp
+    python tools/object_visual_regression.py <file.hwp> -o output/ovr --baseline output/ovr/baseline.json --no-hwp
     # rhwp 래스터 크롭까지 (native-skia 빌드 필요)
-    python tools/object_visual_regression.py <file.hwp> -o out/ovr --rhwp-png
+    python tools/object_visual_regression.py <file.hwp> -o output/ovr --rhwp-png
     # 원커맨드 before/after: 지정 ref 를 worktree 빌드해 baseline 자동 생성 → 현 트리와 대조
-    python tools/object_visual_regression.py --preset ovr5 -o out/ovr --diff-against devel
+    python tools/object_visual_regression.py --preset ovr5 -o output/ovr --diff-against devel
 
 요구: rhwp release 바이너리(+ --rhwp-png 시 native-skia). --no-hwp 아니면 Windows+한컴+pyhwpx+PyMuPDF.
 --diff-against 는 cargo 빌드 2회(기준 ref + 현 트리)를 자동 수행 — 한컴 불필요, geometry 무회귀 전용.
@@ -522,7 +522,8 @@ def run_one(f: Path, outdir: Path, args, head) -> int:
 def main() -> int:
     ap = argparse.ArgumentParser(description="개체 단위 시각/geometry 회귀 (rhwp vs 한글)")
     ap.add_argument("files", type=Path, nargs="*", help="대상 HWP (여러 개 가능, --preset 과 병용 가능)")
-    ap.add_argument("-o", "--out", type=Path, required=True)
+    ap.add_argument("-o", "--out", type=Path, default=ROOT / "output" / "ovr",
+                    help="산출물 디렉터리 (기본: <repo>/output/ovr — .gitignore 의 /output/ 아래)")
     ap.add_argument("--preset", choices=sorted(PRESETS),
                     help="관례 샘플 세트 추가 — ovr5: KTX/exam_math/21_언어/aift/biz_plan")
     ap.add_argument("--diff-against", metavar="REF",


### PR DESCRIPTION
`tools/object_visual_regression.py` 는 `-o` 가 기본값 없이 required 이고, docstring 과 CONTRIBUTING.md "렌더링 PR 자가 검증" 절 예시가 모두 `out/` 경로를 안내한다. 루트 `.gitignore` 에는 `/output/` 만 있어, 안내대로 실행하면 산출물이 매번 `git status` 에 untracked 노이즈로 잡힌다.

`-o` 에 repo 루트 기준 `output/ovr` 기본값을 부여하고, docstring 과 CONTRIBUTING.md 의 `out/ovr`·`out/ovr2`·`out/sweep`·`out/rtf` 예시를 `output/` 로 갱신한다. #4142 가 제안한 `.gitignore` `/out/` 추가 대신 이미 ignore 되는 `output/` 로 산출물을 모으는 방향이며, `.gitignore` 는 변경하지 않는다. 로컬에서 `-o` 생략 실행 시 산출물이 `output/ovr/` 에 생성되고 `git check-ignore` 로 `/output/` 규칙 적용을 확인했다.

Closes #4152

🤖 Generated with [Claude Code](https://claude.com/claude-code)