### PR TITLE
fix(model): CharShape 기본 상대크기를 OWPML 기본값 100 으로 — HWP3 변환본 한컴 백지 해소 (#4141)

### DIFF
--- a/mydocs/plans/task_m100_4141.md
+++ b/mydocs/plans/task_m100_4141.md
@@ -1,0 +1,333 @@
+# 수행계획서 — task_m100_4141
+
+- **이슈**: [#4141](https://github.com/edwardkim/rhwp/issues/4141) `[변환/hwp3] CharShape 상대크기가 0 으로
+  직렬화 — 한컴이 전 본문을 ~0.1pt 로 렌더 (사실상 백지, SO-SUEOP 46쪽 전수)`
+- **발견 경위**: [#4097](https://github.com/edwardkim/rhwp/issues/4097) HWP3 축 한컴 판정 중 분리
+  (`mydocs/working/task_m100_4097_stage5.md` §5). 그 판정의 before/after 가 **둘 다 백지**였던 원인이다.
+- **선행 이슈**: [#3676](https://github.com/edwardkim/rhwp/issues/3676) 같은 변환 경로의 필드 계약 결함
+  3종(닫힘). 이 이슈는 그 계약 목록에 빠져 있던 네 번째 필드다.
+- **브랜치**: `task_m100_4141`
+- **분기 기준**: `upstream/devel` `0fdac31ba`
+- **기록 시각**: 2026-08-07 KST
+- **절차 상태**: 작업지시자 승인 완료(2026-08-07) — 구현 진행
+
+## 1. 문제
+
+`rhwp convert` 로 만든 HWP3 → HWP5 변환본을 한컴으로 열면 **사실상 백지**다. 오류·복구 대화상자 없이
+열리지만 본문 글자가 전부 ~0.1pt 로 그려진다.
+
+한컴 PDF 내보내기 실측 (`samples/SO-SUEOP.hwp`, PyMuPDF):
+
+| | 원본 | 변환본 |
+| --- | --- | --- |
+| 텍스트 span 크기 | 9.7 ~ 50.5 pt | **전 46쪽 10,604개 span 전부 ~0.12 pt** |
+| span 위치(origin) | 정상 | 정상 — 크기만 붕괴 |
+| 개봉 | 정상 | 정상 (대화상자 없음) |
+| 페이지 수 | 46 | 46 |
+
+원인은 `CharShape.relative_sizes`(상대크기)가 **0** 으로 직렬화되는 것이다. 한컴은
+`크기 × 상대크기%` 로 해석하므로 10pt × 0% ≈ 0.1pt 다.
+
+rhwp 자신은 정상으로 읽는다 — `export-text`·`info`·자체 렌더 전부 정상. 렌더러가
+`relative_sizes` 를 **아예 읽지 않기 때문**이다(`src/renderer/style_resolver.rs:339-361` 은
+`base_size`·`spacings`·`ratios` 만 소비. `src/renderer/`·`src/paint/` 참조 0건).
+#3546·#3557·#3676 과 같은 **"자기정합은 유지되고 한컴만 깨지는"** 계열이다.
+
+### 왜 기존 게이트로 안 잡히나
+
+- `tests/hwp5_roundtrip_baseline.rs:78-81` `out_of_scope` 가 `detect_format != FileFormat::Hwp` 를 자동
+  제외 → HWP3 변환 경로는 게이트 밖.
+- `convert --verify` / `export-hwpx --verify` 는 `src/serializer/hwpx/roundtrip.rs` 인데, DocInfo
+  char_shapes 를 **개수만**(`:626-631` `IrDifference::CharShapeCount`), 문단은
+  `(start_pos, char_shape_id)` 쌍만(`:1069-1092`) 비교한다. **CharShape 속성값은 비교 대상이 아니다.**
+- `tests/` 전체에 `relSz` 검사 0건. `relative_sizes` 는 `tests/hml_serializer.rs:379`
+  1건(왕복 동등성)뿐이라 양쪽이 같이 0 이면 통과한다.
+
+## 2. 근본 원인 — 이슈가 지목한 것보다 넓다
+
+`CharShape` 는 `src/model/style.rs:99` 에서 `#[derive(Debug, Clone, Default)]` 다 — 수동 `Default`
+impl 이 없다. 따라서 `relative_sizes = [0u8; 7]` 이 파생 기본값이고, 이 필드를 채우지 않는 **모든**
+경로가 0 을 흘린다.
+
+relSz=0 을 만드는 프로덕션 경로 **6곳**:
+
+| # | 위치 | 상황 |
+| --- | --- | --- |
+| 1 | `src/parser/hwp3/mod.rs:526` `convert_char_shape` | HWP3 레코드에 상대크기 필드가 없어(`records.rs:193-203`) 대입문 자체가 없다. 호출부 `:2556`·`:2573`·`:3580` |
+| 2 | `src/parser/hwp3/mod.rs:3566` | 인덱스 0 자리에 `CharShape::default()` push — **모든** HWP3 문서에 존재 |
+| 3 | `src/parser/hwpx/header.rs:588` | `charPr` 에 `<hh:relSz>` 자식이 없으면 `[0;7]` 유지 |
+| 4 | `src/parser/hwpx/header.rs:848-858` | charPr id 갭을 `resize_with(idx+1, CharShape::default)` 로 메움 |
+| 5 | `src/parser/hml/reader.rs:599-605` | `RELSIZE` 부재 시 `[0;7]` |
+| 6 | `src/document_core/html_table_import.rs:627`, `src/document_core/commands/html_import.rs:845` | HTML import |
+
+세 라이터 모두 **무가드·무검증**으로 IR 값을 방출한다:
+
+- HWP5 `src/serializer/char_shape.rs:21-23` — CHAR_SHAPE payload **오프셋 28..35**.
+  레이아웃(정본 `src/parser/doc_info.rs:520-577`): font_ids 0..14 / ratios 14..21 / spacings 21..28 /
+  **relative_sizes 28..35** / char_offsets 35..42 / base_size 42..46 / attr 46..50.
+  단 `src/serializer/doc_info.rs:79-85` 가 `cs.raw_data` 를 우선하므로 **HWP5→HWP5 는 무손실**이고
+  raw_data 없는 HWP3/HWPX/HML/편집 IR 만 필드 재인코딩된다.
+- HWPX `src/serializer/hwpx/header.rs:638` — `write_lang_attrs(w, "hh:relSz", ...)`, if 가드 없음.
+  `export-hwpx` 는 HWP3 입력을 받는다(`src/main.rs:272` → `:11311` → `:11358` → `src/parser/mod.rs:1294`).
+- HML `src/serializer/hml/head.rs:131` — `write_language_array(writer, "RELSIZE", ...)`, 가드 없음.
+
+그리고 **HWP5 바이너리 파서는 이미 100 을 폴백**한다 — `src/parser/doc_info.rs:542-545`
+`let mut relative_sizes = [100u8; 7]; ... read_u8().unwrap_or(100)`. 같은 "값 없음" 상황에서 모델
+Default(0)와 파서 폴백(100)이 **서로 다르다.** 이 불일치가 진짜 결함이다.
+
+## 3. 정답지 근거 — 100 이 맞다
+
+1. **저장소 내 OWPML 스키마** `mydocs/manual/OWPML SCHEMA/Header XML schema.xml:716-728` —
+   `relSz` 는 `default="100"`, `xs:positiveInteger`, minInclusive **10** / maxInclusive **250**.
+   `positiveInteger` 이므로 **0 은 타입 수준에서 이미 불법**이다.
+   대조: `ratio` default=100 [50,200] · `spacing` default=0 [-50,50] · `offset` default=0 [-100,100].
+
+2. **같은 문서의 한컴산 HWPX** `samples/SO-SUEOP.hwpx` — `Contents/header.xml` charPr 51개 실측:
+
+   | 필드 | 분포 | 해석 |
+   | --- | --- | --- |
+   | `relSz` | **51개 전부 100** (편차 0) | HWP3 유래는 예외 없이 100 이어야 한다 |
+   | `ratio` | 95×30, 90×11, 100×8, 97×2 | 편차 있음 → HWP3 IR 의 `ratios=95` 는 **진짜 데이터** |
+   | `spacing` | -1×25, 0×11, -2×10, -3×3 | 편차 있음 → HWP3 IR 의 `spacings=-1` 은 **진짜 데이터** |
+   | `offset` | 51개 전부 0 | `char_offsets=0` 은 유효값 → **무변경** |
+
+3. **선행 실측(저장소 기록)** `src/document_core/queries/hidden_text.rs:281-282` —
+   "HWPX 60개 문서 4,298개 charPr 실측에서 relSz != 100 은 0건".
+
+→ **오직 `relative_sizes` 만 잘못됐다.** `ratios`·`spacings`·`char_offsets` 는 손대지 않는다.
+
+## 4. 수정 — `impl Default for CharShape` 수동 작성
+
+`src/model/style.rs:99` 에서 `Default` 를 derive 목록에서 빼고 수동 impl 을 쓴다.
+`relative_sizes: [100; 7]` 만 파생값과 다르고 나머지 필드는 파생값 그대로 나열한다.
+
+이 한 곳이 §2 의 **6개 누출 경로를 전부** 해소한다 — 모두 `CharShape::default()` 또는
+`..Default::default()` 를 통과하기 때문이다. 렌더러가 `relative_sizes` 를 읽지 않으므로
+**렌더 영향 0** 이다.
+
+필드 전체 나열이 강제되는 것은 장점이다 — 앞으로 `CharShape` 에 필드가 추가되면 이 impl 이
+컴파일 에러를 내므로 조용한 표류가 불가능하다. 주석에 그 이유를 남긴다.
+
+### 함께 바꾸지 않는 필드
+
+| 필드 | 이유 |
+| --- | --- |
+| `ratios` | **렌더러가 읽는다**(`style_resolver.rs:355` `cs.ratios[lang] as f64 / 100.0`) → §8 별도 이슈 |
+| `base_size` | 같은 이유(`style_resolver.rs:341`) |
+| `shade_color` | `hidden_text.rs:46` `NO_SHADE_BLACK` sentinel 이 0 에 걸려 있다 |
+| `shadow_color`/`underline_color` | `serializer/hml/preflight.rs:177-197` 의 "HML reader 미매핑 필드" 판정이 뒤집힌다 |
+| `char_offsets` | §3 표 — 0 이 정답 |
+
+이 비대칭을 못 박는 유닛 테스트를 `src/model/style.rs` 의 `mod tests` 에 추가한다
+(`char_shape_default_matches_spec_only_for_relative_sizes`) — "왜 ratios 는 안 고쳤나"를
+코드에서 읽히게 한다.
+
+### 기각한 대안
+
+- **`convert_char_shape` 만 수정** (이슈 원안) — 6곳 중 1곳만 덮는다. 특히 `hwp3/mod.rs:3566` 의
+  인덱스 0 placeholder 는 **모든** HWP3 문서에 있어 전수 계약 테스트가 그 자리에서 실패한다.
+- **라이터에서 write-time clamp** — ① IR ↔ 저장 바이트가 달라져 `ir_field_sweep_baseline` hwpx lane 에
+  신규 발산이 생긴다(`local_validation.md:114-118` 이 금지하는 형태). ② 계약 테스트가 저장 바이트를
+  보므로 IR 이 깨져도 초록이 된다 — 큰 소리로 실패해야 할 결함을 조용한 결함으로 바꾼다.
+  `debug_assert!` 대체도 불가 — `release-test` 는 `inherits = "release"` 라 `debug_assertions = false` 다.
+- **읽기 시 0→100 정규화** — HWP5 는 `raw_data` 우선이라 재저장 시 여전히 0 이 나간다. 실제 문제를 못 고친다.
+
+### 이미 배포된 파일
+
+이 수정은 **재변환해야 적용된다.** rhwp 가 이미 만들어 배포한 relSz=0 파일은 자동 복구되지 않는다.
+사용자는 HWP3 원본에서 다시 변환해야 한다. 보고서·PR 본문에 명기한다.
+
+## 5. 회귀 계약 테스트 — 신규 `tests/issue_4141_hwp3_relative_size_contract.rs`
+
+`tests/issue_3676_hwp3_convert_hancom_openable.rs` 확장이 아니라 신규 파일로 만든다:
+
+1. 실패 부류가 다르다 — #3676 은 "한컴이 **열지 못한다**"(개봉 거부), #4141 은 "**열리는데** 백지".
+   3676 의 모듈 doc(`:1-24`) 전체가 개봉 거부 서사여서 여기 붙이면 그 문서가 거짓이 된다.
+2. 스트림이 다르다 — 3676 의 `section_streams`(`:95-110`)는 **BodyText 전용**인데 CHAR_SHAPE 는
+   **DocInfo** 에 있다.
+3. 표본 범위가 다르다 — 3676 은 `samples/hwp3-sample.hwp` 단일 고정, 여기는 전수 스윕이 필요하다.
+
+### 재사용 자산
+
+`walk_records` 를 또 손으로 쓰지 않는다 — 정본은 `Record::read_all` 이다. 가장 깨끗한 기존
+골격은 `tests/issue_3507_sectiondef_ctrl_data.rs:52-62`.
+
+- `rhwp::parser::cfb_reader::CfbReader::{open, read_file_header, read_doc_info}` — `read_doc_info` 가
+  압축 해제까지 한다
+- `rhwp::parser::record::Record::read_all` + `rhwp::parser::tags::HWPTAG_CHAR_SHAPE`(= `HWPTAG_BEGIN + 5`)
+- 변환 헬퍼는 `tests/issue_3676_*.rs:46-61` 두 함수를 경로 파라미터화해 복사
+- HWPX ZIP 엔트리는 같은 파일 `:112-120` `section0_xml` 을 일반화해 `Contents/header.xml` 도 읽게 한다
+- 포맷 판별은 `rhwp::parser::{detect_format, FileFormat}` (`tests/ir_field_sweep_baseline.rs:54` 선례)
+- HML 은 `rhwp::serializer::hml::serialize_hml` (`tests/hml_serializer.rs:11` 선례)
+
+### 테스트 — 라이터 3축 전부
+
+| # | 테스트 | 입력 | 검사 |
+| --- | --- | --- | --- |
+| ① | `hwp3_convert_emits_valid_relative_sizes_for_every_sample` | `samples/**/*.hwp` 중 `detect_format == Hwp3` **전수** | HWP5 DocInfo CHAR_SHAPE **28..35** |
+| ② | `so_sueop_convert_relative_sizes_are_all_100` | `samples/SO-SUEOP.hwp` 이름 고정 | 같음 + 레코드 수·위반 건수를 메시지에 |
+| ③ | `hwp3_export_hwpx_emits_valid_rel_sz` | `SO-SUEOP.hwp`, `hwp3-sample.hwp` | `Contents/header.xml` 의 `<hh:relSz>` 7속성 |
+| ④ | `hwp3_export_hml_emits_valid_relsize` | `hwp3-sample.hwp` | HML `<RELSIZE>` 7속성 |
+| ⑤ | `public_document_core_export_also_emits_valid_relative_sizes` | `hwp3-sample.hwp` | ①과 같되 `export_hwp_with_adapter` 경로 |
+
+**HWP3 lane 은 `== 100` 강단언**이다. `Hwp3CharShape`(`src/parser/hwp3/records.rs:193-203`)에
+상대크기 필드 자체가 없으므로 HWP3 유래는 예외 없이 스펙 기본값이어야 한다. `10..=250` 범위
+검사는 별도 헬퍼로 두고(스펙 근거를 담는 자리) 향후 비-HWP3 입력에 쓴다.
+
+**전수 스윕을 택하는 이유**: 누출 경로가 6곳이고 그중 `hwp3/mod.rs:3566`(인덱스 0)은 모든 HWP3
+문서에 있다. 단일 표본은 "인덱스 0만 고친 부분 수정"을 통과시킬 수 있다.
+암호 표본(`samples/HWP3-password-123456.hwp`)은 파싱 실패로 건너뛰되 `assert!(swept >= 10)` 로
+"전부 건너뛰어 초록"을 막는다(`tests/ir_field_sweep_baseline.rs:289` 선례).
+
+### 유닛 테스트
+
+- `src/model/style.rs` — §4 의 `char_shape_default_matches_spec_only_for_relative_sizes`
+- `src/parser/hwpx/header.rs` — 기존 헬퍼 `parse_single_char_pr`(`:2199-2216`) 재사용.
+  `<hh:relSz>` 자식 부재 → `[100;7]`, charPr id 갭 filler → `[100;7]`
+- `src/parser/hml/reader.rs` — `RELSIZE` 없는 `<CHARSHAPE>` → `[100;7]`
+
+## 6. 문서 정합
+
+Default 변경으로 사실과 어긋나게 되는 서술을 함께 고친다. **결론은 유지**한다 — 렌더러가
+`relative_sizes` 를 곱하지 않는다는 판단(D-11 / INV-21)은 그대로 옳다. 소멸하는 것은
+"덤으로 default 0 사고를 막는다"는 **부수 논거**뿐이다.
+
+- `src/document_core/queries/hidden_text.rs:281-284` 독 코멘트, 같은 파일 `:1078-1081` 테스트 주석
+  (테스트 자체는 `:1083` 에서 `[0;7]` 을 명시 대입하므로 유효)
+- `mydocs/tech/agent_architecture/decision_log.md`(D-11), `invariants.md`(INV-21) — #4141 각주 추가
+- `mydocs/tech/agent_security/hidden_content.md`, `mydocs/report/task_sec_hidden/README.md` 의 대응 서술
+
+## 7. 검증 게이트 (`local_validation.md` 4.3 — Rust parser/model/CLI)
+
+renderer lane(`:74`)은 **불필요** — `relative_sizes` 의 렌더 경로 참조가 0건이고 `ratios`/`base_size` 는
+건드리지 않는다. "안 건드렸음"의 증적으로 §4 유닛 테스트를 첨부한다.
+`samples/` 에 파일을 추가·교체·이동하지 않으므로 `local_validation.md:102-105` 의 fixture baseline
+등록 절차(IR sweep 행 추가 + overflow-cell 원장)는 해당 없음.
+
+~~~bash
+# ① 신규 계약
+CARGO_INCREMENTAL=0 cargo test --profile release-test \
+  --test issue_4141_hwp3_relative_size_contract -- --nocapture
+
+# ② 모델/파서 유닛
+CARGO_INCREMENTAL=0 cargo test --profile release-test --lib model::style
+CARGO_INCREMENTAL=0 cargo test --profile release-test --lib parser::hwpx::header
+CARGO_INCREMENTAL=0 cargo test --profile release-test --lib parser::hml
+CARGO_INCREMENTAL=0 cargo test --profile release-test --lib document_core::queries::hidden_text
+
+# ③ 인접 계약 (회귀 위험 지점)
+CARGO_INCREMENTAL=0 cargo test --profile release-test \
+  --test issue_3676_hwp3_convert_hancom_openable --test hml_serializer \
+  --test hidden_text_contract --test hwp5_roundtrip_baseline \
+  --test hwpx_roundtrip_baseline --test convert_verify_corpus_ratchet
+
+# ④ IR sweep — 덤프 diff 가 비어야 한다 (local_validation.md:107-112)
+RHWP_IR_SWEEP_DUMP=/tmp/ir_field_sweep_current.tsv \
+  CARGO_INCREMENTAL=0 cargo test --profile release-test \
+  --test ir_field_sweep_baseline -- --nocapture
+diff -u tests/fixtures/ir_field_sweep_baseline.tsv /tmp/ir_field_sweep_current.tsv
+
+# ⑤ 전체 + 정적 검사 (작업지시자 승인 후)
+CARGO_INCREMENTAL=0 cargo test --profile release-test --tests
+CARGO_INCREMENTAL=0 cargo fmt --check
+CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings
+~~~
+
+### 깨질 가능성 사전 확인 — 깨지는 것 없음
+
+| 후보 | 확인 |
+| --- | --- |
+| `hidden_text.rs:1077` `default_relative_sizes_can_never_cause_a_zero_size_misjudgment` | `:1083` 이 `[0;7]` **명시 대입** → 통과. 주석만 갱신 |
+| `hidden_text.rs:1064` `effective_size_ignores_relative_sizes_like_the_renderer_does` | `:1071` 이 `[10;7]` 명시 대입 → 무영향 |
+| `tests/hwp5_roundtrip_baseline.rs` | HWP3 는 `out_of_scope`, HWP5 는 `raw_data` 우선 → 무영향 |
+| `tests/hml_serializer.rs:379` | **왕복 동등성**만 본다(양쪽 같이 100) → 통과 |
+| `tests/hwpx_roundtrip_*.rs`, `convert_verify_corpus_ratchet` | `diff_documents` 가 charPr 속성값 미비교 → 무영향 |
+| `src/serializer/hml/preflight.rs:174-197` | 배열 5종을 아예 비교하지 않는다 → 무영향 |
+| `src/serializer/hwpx/header.rs:2170-2196`, `src/model/style.rs:1055-1061` | 단언 대상이 underline/strikeout/outline/shadow, bold/italic 뿐 → 무영향 |
+| golden/fixture | `tests/fixtures/**` 에 `RELSIZE`/`relSz` 0건 → 갱신 없음 |
+| 렌더 스냅샷 | 렌더러가 `relative_sizes` 를 안 읽음 → 무영향 |
+
+**IR sweep 3 lane 전부 무변동으로 판단**한다: `hwp5` lane 은 HWP3 를 제외하고 HWP5 는 `raw_data`
+우선이라 `serialize_char_shape` 가 호출되지 않는다. `hwp5rb` lane 은
+`src/diagnostics/ir_field_sweep.rs:1045-1049` 가 `raw_stream_dirty`/`raw_stream` 만 건드리고
+**`CharShape.raw_data` 는 지우지 않는다**. `hwpx` lane 은 Default 변경이 왕복 양쪽에 대칭
+작용한다(0→"0"→0 이 100→"100"→100 이 될 뿐). 단 이건 논증이므로 ④를 실제로 돌려 빈 diff 를
+증적으로 남긴다. 행이 하나라도 바뀌면 `RHWP_IR_SWEEP_DETAIL` 로 원인을 규명하고 baseline 으로
+덮지 않는다(`local_validation.md:114-118`).
+
+## 8. 단계
+
+### Stage 1 — 재현·계측 (프로덕션 코드 변경 0)
+
+1. 현행 devel 바이너리로 HWP3 표본 전수를 `convert` + `export-hwpx` → CHAR_SHAPE 28..35 와
+   header.xml `relSz` 실측표(표본 × 레코드수 × 위반 건수)
+2. 6개 누출 경로가 실제로 0 을 만드는지 확인 — 특히 `hwp3/mod.rs:3566`(인덱스 0),
+   `hwpx/header.rs:853`(갭 filler)
+3. **인덱스 0 CharShape 가 참조되는지 계측.** 참조된다면 `base_size=0`·`ratios=0` 이 함께 나가므로
+   이번 이슈와 별개의 2차 원인이다
+4. §9 후속 이슈 근거: `ratios == 0` 인 CharShape 가 **참조되는** 문서가 코퍼스에 있는지 계측
+5. 전수 스윕 계약 테스트의 실행 시간 실측
+
+**게이트**: 실측표가 이슈 본문 수치(SO-SUEOP 10,604 span / SO-SUEOP.hwpx 51 charPr)와 정합.
+
+### Stage 2 — TDD 수정 + 계약 테스트
+
+1. 계약 테스트 먼저 작성 → **빨강 확인**. Stage 1 실측치를 실패 메시지에 인용
+2. `src/model/style.rs` Default 수동 impl (§4)
+3. **초록 확인**
+4. 문서 정합 (§6)
+
+**게이트**: §7 ①~⑤. 특히 ④ IR sweep diff 가 빈 출력.
+
+### Stage 3 — 한컴 판정 + 마무리
+
+에이전트가 `output/issue_4141/` 에 before/after × (hwp, hwpx) 4파일과 `PANJEONG.md`
+(`output/issue_4097_hwp3/PANJEONG.md` 판형)를 준비하고, 인계 전 **바이트 사전 검증**
+(before = 0×전건 / after = 100×전건)을 마친다. `output/` 은 `.gitignore:15` 로 제외되므로
+산출물은 커밋되지 않고 수치만 보고서로 옮긴다.
+
+작업지시자가 한컴 2022 로 4파일을 열어 1쪽 육안 + 스크린샷 → `pdf/README.md:75-93` 패턴으로
+PDF 출력 → PyMuPDF 로 span 크기 계측.
+
+**합격 기준 (사전 고정)**
+
+| # | 기준 |
+| --- | --- |
+| A1 | `after` 의 **1pt 미만 span = 0개** (before 는 10,604개 전부 0.12pt) |
+| A2 | `after` 크기 분포가 원본 `pdf/SO-SUEOP-2024.pdf` 와 정합 — min/max/median ±5%, 최빈값 상위 8종 일치 |
+| A3 | `after` 쪽수 = 46 = `before` = 원본 (크기만 고쳤으므로 조판 불변) |
+| A4 | 1쪽 육안 정상 |
+| A5 | **음성 대조군**: `before` 재현 — 10,604 span 전부 ≈0.12pt |
+
+A5 가 재현되지 않으면 판정 절차를 먼저 의심하고 결과를 채택하지 않는다.
+
+## 9. 후속 이슈 (별도 등록)
+
+**제목 초안**: `[model] CharShape.ratios 기본값 0 이 OWPML 유효범위 [50,200] 밖이고 렌더러가 장평 0 으로 소비한다`
+
+`ratios` 기본값도 `[0;7]` 이고 OWPML `ratio` 는 default=100 / [50,200] 이라 0 은 범위 밖이다.
+그런데 **렌더러가 이 값을 읽는다** — `src/renderer/style_resolver.rs:355`
+`ratios.push(cs.ratios[lang] as f64 / 100.0)` → 장평 0 = 글자 폭 0.
+HWP3 축은 `convert_char_shape`(`hwp3/mod.rs:540`)가 레코드에서 채우므로 안전하지만, HWPX id 갭
+filler·HML RELSIZE 부재·HTML import 경로가 이 값을 만든다.
+
+**분리하는 이유**: 렌더 가시 변경이라 `local_validation.md:74` 의 renderer lane(Native Skia 3종 +
+wasm-pack + 시각 증적)이 발동한다. #4141 에 묶으면 한컴 판정 결과의 귀속이 흐려진다.
+근거는 Stage 1 ③④ 계측표를 첨부한다.
+
+## 10. 리스크
+
+| 리스크 | 대응 |
+| --- | --- |
+| IR sweep baseline 이 예상과 달리 흔들림 | §7 ④를 실제로 돌려 판정. 발산 발생 시 `RHWP_IR_SWEEP_DETAIL` 로 원인 규명, baseline 으로 숨기지 않음 |
+| Default 수동 impl 에서 필드 하나를 파생값과 다르게 옮겨 적음 | §4 유닛 테스트가 5개 필드를 명시 단언. 추가로 diff 리뷰에서 struct 선언 순서와 1:1 대조 |
+| 한컴에서 `after` 가 여전히 비정상 | A5 음성 대조군이 재현되면 판정 절차는 유효 → 인덱스 0 CharShape 참조 시 `base_size=0`·`ratios=0` 이라는 2차 원인을 Stage 1 ③ 계측으로 먼저 좁혀 둔다 |
+| 열린 PR [#4144](https://github.com/edwardkim/rhwp/pull/4144)(`task_m100_4097`)와 충돌 | #4144 는 `src/parser/hwp3/mod.rs` 를 건드리지만 이 작업의 유일한 프로덕션 변경은 `src/model/style.rs` 다 → 충돌 없음 |
+| 이미 배포된 relSz=0 파일 | 자동 복구 불가. 재변환 필요를 보고서·PR 본문에 명기 |
+
+## 11. 산출물
+
+- `mydocs/working/task_m100_4141_stage1.md` — 계측 기록
+- `mydocs/working/task_m100_4141_stage2.md` — 구현·검증 기록
+- `mydocs/report/task_m100_4141_report.md` — 최종 보고서 (`Issue: #4141` 명시)
+- 후속 이슈 초안 (§9)

--- a/mydocs/report/task_m100_4141_report.md
+++ b/mydocs/report/task_m100_4141_report.md
@@ -1,0 +1,282 @@
+# task_m100_4141 최종 보고서 — CharShape 상대크기 0 직렬화
+
+- **Issue**: [#4141](https://github.com/edwardkim/rhwp/issues/4141)
+- **계획서**: [`mydocs/plans/task_m100_4141.md`](../plans/task_m100_4141.md)
+- **단계 기록**: [stage1](../working/task_m100_4141_stage1.md) · [stage2](../working/task_m100_4141_stage2.md)
+- **브랜치**: `task_m100_4141` (분기 기준 `upstream/devel` `0fdac31ba`)
+- **작성 시각**: 2026-08-07 KST
+- **프로덕션 코드 변경**: `src/model/style.rs` 1곳
+
+## 1. 요약
+
+HWP3 문서를 `rhwp convert` 로 HWP5 변환한 뒤 한컴으로 열면 **사실상 백지**였다. 오류·복구
+대화상자 없이 열리는데 본문 글자가 전부 ~0.1pt 로 그려진다.
+
+원인은 `CharShape.relative_sizes` 가 **0** 으로 저장되는 것이었다. OWPML 은 `relSz` 를
+`xs:positiveInteger` minInclusive=10 / maxInclusive=250, `default="100"` 으로 정의하므로
+(`mydocs/manual/OWPML SCHEMA/Header XML schema.xml:716-728`) **0 은 타입 수준에서 이미 불법**이다.
+한컴은 실효 크기를 `기준 크기 × 상대크기%` 로 해석한다 — 10pt × 0% ≈ 0.1pt.
+
+이슈는 `convert_char_shape` 한 곳을 지목했지만, 조사 결과 **모델의 파생 `Default` 가 근본
+원인**이었다. `src/model/style.rs` 에 수동 `impl Default` 를 써서 한 곳에서 해소했다.
+
+## 2. 왜 지금까지 안 잡혔나
+
+rhwp 는 이 결함을 **구조적으로 볼 수 없다.** 렌더러가 `relative_sizes` 를 아예 읽지 않는다
+(`src/renderer/style_resolver.rs:339-361` 은 `base_size`·`spacings`·`ratios` 만 소비.
+`src/renderer/`·`src/paint/` 참조 0건). 그 결과:
+
+| 게이트 | 왜 통과했나 |
+| --- | --- |
+| `export-text`·`info`·자체 렌더 | 크기 계산에 relSz 를 안 쓴다 |
+| `convert --verify` / `export-hwpx --verify` | `src/serializer/hwpx/roundtrip.rs` 가 DocInfo char_shapes 를 **개수만**(`:626-631`), 문단은 `(start_pos, char_shape_id)` 쌍만(`:1069-1092`) 비교. **속성값 미비교** |
+| `hwp5_roundtrip_baseline` | `out_of_scope`(`:78-81`)가 `detect_format != Hwp` 를 자동 제외 → HWP3 는 범위 밖 |
+| `ir_field_sweep_baseline` | 파서→직렬화→재파싱이 대칭으로 0 을 유지하므로 IR 은 정말 같다 |
+
+#3546·#3557·#3676 과 같은 **"자기정합은 유지되고 한컴만 깨지는"** 계열이다.
+
+## 3. 실측 (Stage 1)
+
+수정 전 바이너리로 HWP3 표본 전수를 변환해 **저장 바이트/XML 에서 직접** 읽었다.
+
+| 축 | 결과 |
+| --- | --- |
+| HWP5 `convert` | 표본 15건, CHAR_SHAPE **68,744개 전건(100%)이 relSz=0** |
+| HWPX `export-hwpx` | 동수 전건 `<hh:relSz ...="0">` — 이슈가 "미실측"으로 남긴 축을 확정 |
+| HML | HWP3→HML 은 **도달 불가**(`export_hml_native` 가 HML 출처 전용 `hml_metadata` 요구). 대신 `RELSIZE` 자식 없는 HML 왕복이 `RELSIZE="0"` 방출 — 배포 CLI 로 재현 |
+| 인덱스 0 CharShape | `ratios=0`·`base_size=0` 이지만 **전 15표본에서 참조 0건** → 2차 원인 아님 |
+
+`samples/SO-SUEOP.hwp` 의 2,512개는 이슈 본문 수치와 정확히 일치한다.
+
+### 정답지 — 오직 `relative_sizes` 만 잘못됐다
+
+`samples/SO-SUEOP.hwpx`(같은 문서의 한컴산 HWPX) charPr 51개 실측:
+
+| 필드 | 한컴 HWPX | rhwp 변환본 | 판정 |
+| --- | --- | --- | --- |
+| `relSz` | **51/51 = 100** (편차 0) | 0 | **결함** |
+| `ratio` | 95×30, 90×11, 100×8, 97×2 | 95 | 정상 — HWP3 레코드의 진짜 데이터 |
+| `spacing` | -1×25, 0×11, -2×10, -3×3 | -1 | 정상 — 진짜 데이터 |
+| `offset` | 51/51 = 0 | 0 | 정상 — 0 이 유효값 |
+
+`ratio`·`spacing` 은 편차가 있어 진짜 데이터임이 드러난다. 편차가 0 인 `relSz` 만 결함이다.
+선행 실측도 같은 방향이다 — HWPX 60개 문서 4,298개 charPr 에서 `relSz != 100` 은 0건
+(`src/document_core/queries/hidden_text.rs:281-282`).
+
+## 4. 수정
+
+`src/model/style.rs` 에서 `#[derive(Debug, Clone, Default)]` 의 `Default` 를 빼고 수동 impl 을 썼다.
+**`relative_sizes: [100; 7]` 한 줄만** 파생값과 다르고 나머지 30개 필드는 파생값 그대로다.
+
+이 한 곳이 relSz=0 을 만드는 **6개 경로를 전부** 해소한다 — 전부 `CharShape::default()` 또는
+`..Default::default()` 를 통과한다:
+
+1. `src/parser/hwp3/mod.rs:526` `convert_char_shape` (HWP3 레코드에 상대크기 개념 자체가 없다)
+2. `src/parser/hwp3/mod.rs:3566` 인덱스 0 placeholder
+3. `src/parser/hwpx/header.rs:588` `<hh:relSz>` 자식 부재
+4. `src/parser/hwpx/header.rs:848-858` charPr id 갭 채움
+5. `src/parser/hml/reader.rs:599-605` `RELSIZE` 부재
+6. `src/document_core/html_table_import.rs:627`, `src/document_core/commands/html_import.rs:845`
+
+라이터 셋(HWP5 `serializer/char_shape.rs:21`, HWPX `serializer/hwpx/header.rs:638`,
+HML `serializer/hml/head.rs:131`)이 모두 가드 없이 IR 을 방출하므로 3축이 **같은 커밋 하나로**
+동시에 초록이 됐다.
+
+부수 효과로 **모델 Default 와 HWP5 파서 폴백의 불일치**가 해소됐다 —
+`src/parser/doc_info.rs:542-545` 는 이미 100 을 폴백하고 있었다.
+
+### 함께 바꾸지 않은 것
+
+`ratios`·`base_size` 는 **렌더러가 소비하므로**(`style_resolver.rs:341`,`:355`) 그대로 뒀다.
+기본값 변경은 렌더 회귀 검증 lane 을 요구하고, #4141 의 한컴 판정 결과 귀속을 흐린다.
+`char_offsets`·`spacings` 는 0 이 스펙상 유효값이고, 색상 필드는 sentinel 로 쓰인다.
+
+이 비대칭을 `char_shape_default_matches_spec_only_for_relative_sizes` 가 코드로 고정한다.
+
+### 기각한 대안
+
+- **`convert_char_shape` 만 수정**(이슈 원안) — 6곳 중 1곳만 덮는다. 특히 인덱스 0 placeholder 는
+  모든 HWP3 문서에 있어 전수 계약 테스트가 그 자리에서 실패한다.
+- **라이터 write-time clamp** — IR ↔ 저장 바이트가 달라져 `ir_field_sweep_baseline` hwpx lane 에
+  신규 발산이 생기고, 계약 테스트가 IR 결함을 못 잡게 된다.
+  `debug_assert!` 대체도 불가 — `release-test` 는 `inherits = "release"`.
+- **읽기 시 0→100 정규화** — HWP5 는 `raw_data` 우선이라 재저장 시 여전히 0 이 나간다.
+
+## 5. 회귀 고정
+
+### 통합 계약 — `tests/issue_4141_hwp3_relative_size_contract.rs` (신규 5건)
+
+한컴이 CI 에 없으므로 **저장 바이트/XML 에서** 검사한다. #3676 파일을 확장하지 않고 새로 만들었다
+— 실패 부류(개봉 거부 vs 열리는데 백지), 스트림(BodyText vs DocInfo), 표본 범위가 모두 다르다.
+
+| 테스트 | 축 |
+| --- | --- |
+| `hwp3_convert_emits_valid_relative_sizes_for_every_sample` | HWP5 DocInfo CHAR_SHAPE 오프셋 28..35, HWP3 표본 **전수** |
+| `so_sueop_convert_relative_sizes_are_all_100` | 같음, 재현 표본 이름 고정 |
+| `public_document_core_export_also_emits_valid_relative_sizes` | 같음, `export_hwp_with_adapter` 경로 |
+| `hwp3_export_hwpx_emits_valid_rel_sz` | HWPX `Contents/header.xml` 의 `<hh:relSz>` |
+| `hml_roundtrip_without_relsize_child_emits_valid_relsize` | HML `RELSIZE` — 자식 없는 fixture 왕복 |
+
+HWP3 lane 은 `== 100` **강단언**이다 — `Hwp3CharShape`(`src/parser/hwp3/records.rs:193-203`)에
+상대크기 필드가 없으므로 변환본은 예외 없이 스펙 기본값이어야 한다. 범위 검사(10~250)는 별도
+헬퍼로 두고 HWPX/HML 축에 쓴다.
+
+전수 스윕에 `assert!(swept >= 10)` 하한을 뒀다 — 표본이 전부 건너뛰어져 조용히 통과하는 것을 막는다.
+
+재사용: `Record::read_all`(`src/parser/record.rs:34`) + `CfbReader::read_doc_info`.
+`walk_records` 를 손으로 다시 쓰지 않았다.
+
+### 유닛 3건
+
+- `src/model/style.rs::char_shape_default_matches_spec_only_for_relative_sizes`
+- `src/parser/hwpx/header.rs::char_pr_without_rel_sz_child_defaults_to_100_percent`
+- `src/parser/hwpx/header.rs::char_pr_id_gap_filler_gets_valid_relative_size`
+
+## 6. 검증
+
+### TDD — 빨강을 먼저 확인했다
+
+수정 없이 5건 전부 실패(`0 passed; 5 failed`), 실패 메시지의 수치가 Stage 1 실측과 일치.
+수정 후 `5 passed; 0 failed` (0.61s).
+
+### 게이트 (`local_validation.md` 4.3 — Rust parser/model/CLI)
+
+| 대상 | 결과 |
+| --- | --- |
+| `issue_4141_hwp3_relative_size_contract` | **5 passed** |
+| `issue_3676_hwp3_convert_hancom_openable` | 5 passed |
+| `hml_serializer` | 31 passed |
+| `hidden_text_contract` | 24 passed |
+| `hwp5_roundtrip_baseline` | 3 passed |
+| `hwpx_roundtrip_baseline` | 4 passed |
+| `--lib model::style` | 6 passed |
+| `--lib parser::hwpx::header` | 51 passed |
+| `ir_field_sweep_baseline` | 2 passed, **덤프가 baseline 과 SHA-256 일치(무변동)** |
+| `cargo fmt --check` | 변경 3파일 위반 해소 |
+| `cargo clippy --lib --tests -D warnings` | **exit 0, 경고 0** |
+
+IR sweep 무변동은 계획 단계에서 논증이었고, 덤프를 실제로 떠서 확인했다(줄 수 598=598,
+줄바꿈 정규화 후 해시 일치).
+
+renderer lane 은 실행하지 않았다 — `relative_sizes` 는 렌더 경로 참조가 0건이고 렌더러가
+소비하는 `ratios`·`base_size` 는 건드리지 않았다.
+
+**전체 `cargo test --profile release-test --tests` 와 `cargo clippy --all-targets` 는
+작업지시자 승인 대기다** (`docs_and_git_workflow.md:181-184`).
+
+## 7. 한컴 판정 — 수행 완료 (2026-08-07)
+
+CI 에 한컴이 없으므로 최종 정답지 판정은 수동이다. 번들을 `output/issue_4141/` 에 준비하고
+(`.gitignore:15` 로 비커밋) 작업지시자가 한컴으로 열어 PDF 로 출력했다. PyMuPDF 계측:
+
+| | 쪽수 | span | min | max | median | **1pt 미만** |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 원본 `pdf/SO-SUEOP-2024.pdf` | 46 | 14,417 | 7.17 | 50.64 | **9.71** | 0 |
+| `before` (수정 전) | 46 | 10,604 | 0.12 | 0.12 | 0.12 | **10,604** |
+| `after` (수정 후) | **47** | 7,730 | 6.96 | 50.51 | **9.71** | **0** |
+
+| # | 기준 | 결과 |
+| --- | --- | --- |
+| A1 | 1pt 미만 span = 0개 | **PASS** — 0개 |
+| A2 | 크기 분포 min/max/median ±5% | **PASS** — min −2.9%, max −0.3%, median **0%** |
+| A2′ | 최빈 8종 일치 | **FAIL** |
+| A3 | 쪽수 46 | **FAIL** — 47쪽 |
+| A4 | 1쪽 육안 정상 | **FAIL** — §7.2 |
+| A5 | **음성 대조군** — `before` 재현 | **PASS** — 10,604 span 전부 0.12pt, 이슈 수치와 정확히 일치 |
+
+A5 가 정확히 재현됐으므로 판정 절차는 유효하다.
+
+### 7.1 판정 — 이 이슈의 계약은 해소됐다
+
+정의된 결함은 "본문 글자가 전부 ~0.1pt 로 그려진다"이고 그것은 해소됐다:
+1pt 미만 span **10,604개 → 0개**, median 이 원본과 소수점까지 일치(9.71).
+본문도 온전하다(추출 문자수 원본 50,172자 → `after` 54,219자).
+
+### 7.2 다만 문서는 아직 사용 가능하지 않다 — 별개 결함 둘
+
+A3·A4 실패의 원인은 #4141 과 인과가 없는 결함 둘이다.
+
+**① 글자 음영이 검정 — [#4155](https://github.com/edwardkim/rhwp/issues/4155) (이 판정에서 발견해 등록)**
+
+`after` 는 본문 전체가 검정 막대로 덮인다. 텍스트는 제 위치·제 크기로 그려지고 그 위에 줄 크기
+순검정 사각형이 칠해진다. `shade_color` 바이트가 **before/after 동일**(`0x00000000` × 2,512)이므로
+#4141 과 인과가 없다 — 글자가 0.12pt 일 때는 음영 사각형도 0×0 으로 찌부러져 보이지 않았을 뿐이다
+(`before` 3쪽 검정 fill 3개 크기 0×0 → `after` 65개 줄 크기).
+
+근인은 HWP3 `shade_ratio` 미반영과 HWP5 라이터의 "음영 없음" sentinel 미번역이다.
+한컴은 "음영 없음"을 `0xFFFFFFFF` 로 쓴다(`samples/` HWP5 380건에서 22,189건. 검정은 **0건**).
+**#4141 merge 이후 별도 작업**한다(작업지시자 판단).
+
+**② 1쪽 글맵시 누락 — [#4097](https://github.com/edwardkim/rhwp/issues/4097) 축**
+
+그 수정은 [PR #4144](https://github.com/edwardkim/rhwp/pull/4144) 에 있고 이 브랜치는
+`upstream/devel` 분기라 미포함이다.
+
+**③ A3(쪽수 47 vs 46) 는 원인 미확정.** `before` 는 전 글자가 0.12pt 라 그 46쪽이 레이아웃
+기준선이 될 수 없다. #4155·#4097 이 남은 상태에서는 기여를 분리할 수 없으므로 **셋이 해소된 뒤
+재측정해야 판단이 선다.** 지금 단정하지 않는다.
+
+### 7.3 번들과 절차 (재현용)
+
+### 인계 전 바이트 사전검증 (완료)
+
+| 파일 | CHAR_SHAPE / relSz | relSz | ratios | base_size 최빈 |
+| --- | ---: | --- | --- | --- |
+| `before.hwp` | 2,512 | **0 × 2,512** | 100 × 977 | 1000 × 1706 |
+| `after.hwp` | 2,512 | **100 × 2,512** | 100 × 977 | 1000 × 1706 |
+| `before.hwpx` | 2,512 | **0 × 2,512** | — | — |
+| `after.hwpx` | 2,512 | **100 × 2,512** | — | — |
+
+**격리된 변수는 상대크기 하나다.** `.hwpx` 는 12개 ZIP 엔트리 중 `Contents/header.xml` 하나만
+다르다. `.hwp` 는 총 크기 99,840 동일에 6,227바이트가 다른데, DocInfo 가 deflate 압축이라
+2,512×7바이트 변경이 스트림 전체로 번지기 때문이다.
+
+합격 기준은 **판정 전에 고정**했고(A1~A5, 위 표) A5 를 음성 대조군으로 둬 절차 자체를
+검증하게 했다. 절차와 계측 스크립트는 `output/issue_4141/PANJEONG.md` 와 `measure_spans.py` 에 있다.
+
+## 8. 사용자 영향 — 재변환이 필요하다
+
+이 수정은 **재변환해야 적용된다.** rhwp 가 이미 만들어 배포한 relSz=0 파일은 자동 복구되지
+않는다. 읽기 시 정규화를 넣지 않은 이유는 §4 의 기각 사유대로 HWP5 가 `raw_data` 를 우선해
+재저장 시 여전히 0 이 나가기 때문이다. HWP3 원본에서 다시 변환해야 한다.
+
+## 9. 후속
+
+### 글자 음영 검정 — [#4155](https://github.com/edwardkim/rhwp/issues/4155) (등록 완료)
+
+이 이슈의 한컴 판정에서 발견해 실측 근거와 함께 등록했다(§7.2). **#4141 merge 이후 별도
+작업**한다 — 같은 브랜치에 묶으면 한컴 판정 결과의 귀속이 흐려지기 때문이다.
+
+이 문서가 다루는 `relative_sizes` 와 **같은 부류**다: rhwp 가 쓰는 sentinel 을 한컴이 공유하지
+않아, 자기정합은 유지되고 한컴만 깨진다. 다만 필드도 근인도 다르다(모델 파생 기본값 vs
+`shade_ratio` 미반영 + 라이터 sentinel 미번역).
+
+### `ratios` 기본값 (별도 이슈)
+
+`ratios` 기본값도 `[0;7]` 이고 OWPML `ratio` 는 default=100 / [50,200] 이라 0 은 범위 밖이다.
+그런데 **렌더러가 이 값을 읽는다**(`style_resolver.rs:355` → 장평 0 = 글자 폭 0).
+
+- HWP3 축은 안전하다 — `convert_char_shape`(`hwp3/mod.rs:540`)가 레코드에서 채우고, 유일하게
+  `ratios=0` 인 인덱스 0 레코드는 참조되지 않는다(전 15표본 0건 계측).
+- **HML 축은 실제로 노출된다** — `RELSIZE`/`RATIO` 없는 HML 을 배포 CLI 로 왕복시키면
+  `RATIO="0"` 이 나간다(Stage 1 §5 재현). HML 은 렌더 경로이기도 하다.
+
+렌더 가시 변경이라 renderer lane(Native Skia 3종 + wasm-pack + 시각 증적)이 발동하므로
+별도 이슈로 분리한다. 근거는 Stage 1 §7 계측표.
+
+### #4097 판정 재개
+
+`pdf/task4097/README.md` 가 "#4141 해소 후 같은 쌍을 다시 만들면 이 축의 **양성 판정**이 비로소
+가능해진다"고 적어 뒀다. 이 수정이 그 전제를 푼다 — #4097 의 HWP3 글맵시 축 한컴 판정을
+다시 만들 수 있다.
+
+## 10. 커밋
+
+| 커밋 | 내용 |
+| --- | --- |
+| `252e35224` | 계획서 + Stage 1 실측 (프로덕션 변경 0) |
+| `5e0df1871` | `impl Default for CharShape` + 계약 테스트 5건 + 유닛 3건 + 문서 정합 |
+| (본 커밋) | Stage 3 — 판정 번들·한컴 판정 결과·최종 보고서 (프로덕션 변경 0) |
+
+프로덕션 코드 변경은 `src/model/style.rs` 한 곳뿐이다. Stage 3 에서 쓴 임시 프로브
+(`convert_char_shape` 의 `shade_ratio` 출력)는 측정 후 삭제했고 `git status` 로 확인했다.

--- a/mydocs/report/task_sec_hidden/README.md
+++ b/mydocs/report/task_sec_hidden/README.md
@@ -67,8 +67,17 @@ HWP 스펙상 실효 크기는 `base_size × relative_sizes[언어] / 100` 이�
 은닉 판정의 기준은 "이 도구가 그려 내는 결과"여야 하므로 **`base_size` 만** 쓴다.
 
 현실 문서에서 차이는 없다 — HWPX 60개 문서 4,298개 `charPr` 실측에서 `relSz != 100` 은 0건.
-덤으로 `CharShape::default()` 의 `relative_sizes = [0; 7]`(HWP3 변환 경로가 채우지 않는다)을
-0% 로 곱해 **모든 글자를 0pt 로 보고**하는 사고가 구조적으로 불가능해진다.
+덤으로 `relative_sizes = 0` 인 파일을 0% 로 곱해 **모든 글자를 0pt 로 보고**하는 사고가
+구조적으로 불가능해진다.
+
+> **갱신 (#4141, 2026-08-07).** 위 "덤" 문장은 원래 `CharShape::default()` 가 `[0; 7]` 이고
+> HWP3 변환 경로가 그 배열을 채우지 않는다는 사실을 근거로 들었다. 그 기본값은
+> [#4141](https://github.com/edwardkim/rhwp/issues/4141) 에서 OWPML 기본값 `[100; 7]` 로
+> 바뀌었다(0 은 `relSz` 유효범위 10~250 밖이라 한컴이 본문 전체를 0.1pt 로 그렸다).
+> **판정 규칙은 그대로다** — 0 은 여전히 외부 파일로 들어올 수 있고(수정 이전 rhwp 가 만든
+> HWP3 변환본이 전부 그렇다), 곱하지 않으므로 안전하다. 회귀 고정:
+> `src/document_core/queries/hidden_text.rs` 의
+> `default_relative_sizes_can_never_cause_a_zero_size_misjudgment`.
 
 ### 배경을 어떻게 정하는가 — 안쪽부터
 

--- a/mydocs/working/task_m100_4141_stage1.md
+++ b/mydocs/working/task_m100_4141_stage1.md
@@ -1,0 +1,190 @@
+# Stage 1 — task_m100_4141 재현·계측
+
+- **이슈**: [#4141](https://github.com/edwardkim/rhwp/issues/4141)
+- **계획서**: [`mydocs/plans/task_m100_4141.md`](../plans/task_m100_4141.md)
+- **브랜치**: `task_m100_4141` (분기 기준 `upstream/devel` `0fdac31ba`)
+- **작업 시각**: 2026-08-07 KST
+- **프로덕션 코드 변경**: 0
+
+## 1. 계측 방법
+
+수정 전 바이너리(`cargo build --profile release-test --bin rhwp`, 분기 기준 그대로)로 `samples/`
+하위 HWP3 서명(`HWP Document File`) 파일 전수를 `convert`(→HWP5)와 `export-hwpx`(→HWPX) 한 뒤,
+산출물에서 **저장 바이트/XML 을 직접** 읽었다.
+
+- HWP5: CFB `DocInfo` 스트림을 압축 해제(`FileHeader[36] & 0x01`)하고 레코드를 순회해
+  `HWPTAG_CHAR_SHAPE`(= `HWPTAG_BEGIN + 5` = 21) payload 를 수집. 오프셋 **28..35** 가
+  `relative_sizes` 다 (레이아웃 정본 `src/parser/doc_info.rs:520-577`).
+- HWPX: `Contents/header.xml` 의 `<hh:relSz>` 태그.
+- 인덱스 0 참조 여부: `BodyText/Section*` 의 `HWPTAG_PARA_CHAR_SHAPE`(= `HWPTAG_BEGIN + 52` = 68)
+  payload 를 `(pos: u32, char_shape_id: u32)` 쌍으로 읽어 id 별 참조 건수를 집계.
+
+계측 스크립트는 임시(scratchpad)이며 커밋하지 않는다.
+
+## 2. HWP5 `convert` 축 — 전수 결함
+
+| 표본 | CHAR_SHAPE | relSz≠100 | relSz=0 | ratios=0 | idx0 참조 | relSz 범위밖 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `SO-SUEOP.hwp` | 2,512 | 2,512 | 2,512 | 1 | 0 | 2,512 |
+| `hwp3-pagedef-1915.hwp` | 53 | 53 | 53 | 1 | 0 | 53 |
+| `hwp3-sample.hwp` | 747 | 747 | 747 | 1 | 0 | 747 |
+| `hwp3-sample10.hwp` | 28,193 | 28,193 | 28,193 | 1 | 0 | 28,193 |
+| `hwp3-sample11.hwp` | 20,445 | 20,445 | 20,445 | 1 | 0 | 20,445 |
+| `hwp3-sample13.hwp` | 262 | 262 | 262 | 1 | 0 | 262 |
+| `hwp3-sample14.hwp` | 445 | 445 | 445 | 1 | 0 | 445 |
+| `hwp3-sample16.hwp` | 6,520 | 6,520 | 6,520 | 1 | 0 | 6,520 |
+| `hwp3-sample19.hwp` | 93 | 93 | 93 | 1 | 0 | 93 |
+| `hwp3-sample4.hwp` | 2,567 | 2,567 | 2,567 | 1 | 0 | 2,567 |
+| `hwp3-sample5.hwp` | 5,831 | 5,831 | 5,831 | 1 | 0 | 5,831 |
+| `issue1892_hwp3_drawing_group_roundtrip.hwp` | 110 | 110 | 110 | 1 | 0 | 110 |
+| `issue1892_hwp3_tab_roundtrip.hwp` | 63 | 63 | 63 | 1 | 0 | 63 |
+| `issue1950_hwp3_tab_charoffset.hwp` | 156 | 156 | 156 | 1 | 0 | 156 |
+| `issue_265.hwp` | 747 | 747 | 747 | 1 | 0 | 747 |
+| **합계 (15건)** | **68,744** | **68,744** | **68,744** | **15** | **0** | **68,744** |
+
+`samples/HWP3-password-123456.hwp` 는 `convert` 가 비밀번호를 요구해 제외(16건 중 1건).
+
+**판정: CHAR_SHAPE 68,744개 전건(100%)이 `relative_sizes = [0;7]` 이다.** OWPML `relSz` 는
+`xs:positiveInteger` minInclusive=10 / maxInclusive=250 이므로(`Header XML schema.xml:716-728`)
+0 은 타입 수준에서 이미 불법이다.
+
+`SO-SUEOP.hwp` 의 2,512 는 이슈 본문의 "2512개, 최빈값 1000=10pt" 와 **정확히 일치**한다.
+
+### 대표 레코드 실측 (`SO-SUEOP.hwp` 변환본)
+
+```text
+idx0  ratios=[0×7]   spacings=[0×7]    relative_sizes=[0×7]  char_offsets=[0×7]  base_size=0
+idx1  ratios=[95×7]  spacings=[-1×7]   relative_sizes=[0×7]  char_offsets=[0×7]  base_size=1000
+idx2  ratios=[95×7]  spacings=[-1×7]   relative_sizes=[0×7]  char_offsets=[0×7]  base_size=1000
+```
+
+`samples/SO-SUEOP.hwpx`(같은 문서의 한컴산 HWPX) 정답지와 대조:
+
+| 필드 | 한컴 HWPX (charPr 51개) | rhwp 변환본 | 판정 |
+| --- | --- | --- | --- |
+| `relSz` | **51/51 = 100** (편차 0) | **0** | **결함** |
+| `ratio` | 95×30, 90×11, 100×8, 97×2 | 95 | 정상 — HWP3 레코드의 진짜 데이터 |
+| `spacing` | -1×25, 0×11, -2×10, -3×3 | -1 | 정상 — 진짜 데이터 |
+| `offset` | 51/51 = 0 | 0 | 정상 — 0 이 유효값 |
+
+→ **오직 `relative_sizes` 만 잘못됐다.** 계획서 §3 의 판단이 실측으로 확정됐다.
+
+## 3. 인덱스 0 CharShape 는 참조되지 않는다
+
+`src/parser/hwp3/mod.rs:3566` 이 인덱스 0 자리에 `CharShape::default()` 를 push 하므로
+`ratios=[0;7]`·`base_size=0` 인 레코드가 표본마다 **정확히 1개** 생긴다. 이것이 위 표의
+`ratios=0` 열이 전 표본 1인 이유다.
+
+그런데 **그 레코드를 참조하는 문단이 없다.** `SO-SUEOP.hwp` 변환본 실측:
+
+```text
+PARA_CHAR_SHAPE 참조 총건수 1,918 / 고유 id 1,918
+참조된 최소 id = 16     (id 0 참조 = 0건)
+```
+
+집계기가 실제로 참조를 읽고 있음은 총건수 1,918 로 확인된다(파싱 불량으로 0 이 나온 것이 아니다).
+전 15표본에서 idx0 참조는 0건이다.
+
+**따라서 `base_size=0`·`ratios=0` 은 이번 백지 증상의 2차 원인이 아니다.** 한컴 판정에서
+`after` 가 여전히 비정상일 경우를 대비한 리스크 항목(계획서 §10)이 이 계측으로 해소됐다.
+
+## 4. HWPX `export-hwpx` 축 — 동일하게 전수 결함
+
+이슈 본문이 "미실측"으로 남긴 항목을 확정했다.
+
+| 표본 | `<hh:relSz>` | 범위 밖 | 값 분포 |
+| --- | ---: | ---: | --- |
+| `SO-SUEOP.hwp` | 2,512 | 2,512 | 전부 `0` |
+| `hwp3-sample10.hwp` | 28,193 | 28,193 | 전부 `0` |
+| `hwp3-sample11.hwp` | 20,445 | 20,445 | 전부 `0` |
+| (나머지 12건) | HWP5 축과 동수 | 동수 | 전부 `0` |
+
+`src/serializer/hwpx/header.rs:638` 이 `write_lang_attrs(w, "hh:relSz", ...)` 를 가드 없이 부르고,
+`export-hwpx` 는 HWP3 입력을 차단하지 않는다(`src/main.rs:272` → `:11311` → `:11358` →
+`src/parser/mod.rs:1294`). 따라서 산출 HWPX 에 `<hh:relSz hangul="0" .../>` 가 그대로 나간다.
+
+## 5. HML 축 — HWP3 경로는 도달 불가, 그러나 HML 왕복은 결함
+
+계획서 §5 의 테스트 ④(HWP3 → HML)를 **재조정한다.**
+
+`DocumentCore::export_hml_native()`(`src/document_core/commands/document.rs:1352-1359`)는
+`self.hml_metadata` 를 요구하고, 그 값은 HML 출처에만 설정된다. HWP3 출처는
+`hml_metadata_missing_error` 로 막힌다. CLI 도움말도 `export-hml <입력.hml>` 로 입력을 HML 로 한정한다.
+→ **HWP3 → HML 은 도달 불가 경로다.**
+
+대신 **HML → HML 왕복**이 실제로 결함이다. `RELSIZE` 자식이 없는 `<CHARSHAPE>` 를 읽으면
+`src/parser/hml/reader.rs:599-605` 가 `[0;7]` 을 남기고, `src/serializer/hml/head.rs:131` 이
+가드 없이 그대로 방출한다.
+
+저장소 안에 그 fixture 가 있다 — `tests/fixtures/hml/exambank_math_equations_min.hml` 의
+`<CHARSHAPE>` 는 `FONTID` 만 갖고 `RATIO`·`RELSIZE` 가 없다:
+
+```xml
+<CHARSHAPE Height="1000" Id="0" TextColor="0"><FONTID Hangul="0" .../></CHARSHAPE>
+```
+
+배포 CLI 로 왕복시킨 실측:
+
+```bash
+rhwp export-hml tests/fixtures/hml/exambank_math_equations_min.hml -o /tmp/exambank_rt.hml
+```
+
+```xml
+<RELSIZE Hangul="0" Latin="0" Hanja="0" Japanese="0" Other="0" Symbol="0" User="0"/>
+<RATIO   Hangul="0" Latin="0" Hanja="0" Japanese="0" Other="0" Symbol="0" User="0"/>
+```
+
+`RELSIZE="0"` 은 이번 이슈의 결함이고, **`RATIO="0"` 은 §7 후속 이슈의 결함**이다.
+HML 은 렌더 경로이기도 하므로(`export-svg`/`export-pdf` 가 `.hml` 을 받는다) `RATIO="0"` 은
+장평 0 = 글자 폭 0 으로 실제 렌더에 영향한다.
+
+→ 테스트 ④를 **"RELSIZE 없는 HML 을 왕복하면 유효범위 안의 값이 나온다"** 로 바꾼다.
+이 fixture 가 red→green 을 실제로 보여준다. 기존 HML 표본(`samples/hml/*.hml`)은 전부
+`RELSIZE="100"` 이라 수정 전후 모두 통과해 red 가 되지 않는다.
+
+## 6. 전수 스윕 비용
+
+CLI 기준 단건 변환 시간(프로세스 기동 포함):
+
+```text
+samples/hwp3-sample10.hwp   8,416 ms   (CHAR_SHAPE 28,193 — 최대)
+samples/hwp3-sample11.hwp   1,989 ms
+samples/SO-SUEOP.hwp          783 ms
+```
+
+계약 테스트는 프로세스 기동 없이 in-process 로 도므로 이보다 빠르다. 15표본 전수 스윕은
+십수 초 규모로 예상되며 통합 테스트 예산 안이다. 실측치는 Stage 2 에서 확정한다.
+
+## 7. 후속 이슈 근거 (`ratios` 기본값)
+
+계획서 §9 의 후속 이슈에 붙일 근거가 이 단계에서 확보됐다.
+
+- `ratios` 기본값도 `[0;7]` 이고 OWPML `ratio` 는 default=100 / [50,200] 이라 0 은 범위 밖이다.
+- **렌더러가 이 값을 읽는다** — `src/renderer/style_resolver.rs:355`
+  `ratios.push(cs.ratios[lang] as f64 / 100.0)` → 장평 0 = 글자 폭 0.
+- **HWP3 축은 안전하다** — `convert_char_shape`(`hwp3/mod.rs:540`)가 레코드에서 채우고, 유일하게
+  `ratios=0` 인 인덱스 0 레코드는 §3 대로 **참조되지 않는다**(전 15표본 0건).
+- **HML 축은 실제로 노출된다** — §5 의 CLI 실측이 `RATIO="0"` 을 재현한다. 이것이 후속 이슈의
+  가장 강한 재현 사례다.
+
+→ 별도 이슈로 분리하는 판단(계획서 §9)이 유지된다. HWP3 축과 인과가 없으므로 이번 PR 의 한컴
+판정 결과 귀속을 흐리지 않는다.
+
+## 8. Stage 1 게이트 판정
+
+| 항목 | 기준 | 결과 |
+| --- | --- | --- |
+| SO-SUEOP CHAR_SHAPE 수 | 이슈 본문 2,512 와 일치 | **일치** (2,512) |
+| SO-SUEOP.hwpx charPr 수 | 51 | **일치** (relSz 51/51 = 100) |
+| relSz 결함 범위 | 전수 | **68,744/68,744 (100%)** |
+| HWPX 축 (이슈 미실측) | 확정 필요 | **확정** — 전건 `relSz="0"` |
+| 인덱스 0 참조 (2차 원인 후보) | 계측 필요 | **참조 0건** — 2차 원인 아님 |
+| HML 축 | 확인 필요 | HWP3→HML **도달 불가**, HML 왕복은 **결함 확인** |
+
+**게이트 통과.** Stage 2(TDD 수정)로 진행한다.
+
+## 9. Stage 2 로 넘기는 변경
+
+- 계약 테스트 ④를 "HWP3 → HML" 에서 **"RELSIZE 없는 HML 왕복"**으로 재조정
+  (fixture: `tests/fixtures/hml/exambank_math_equations_min.hml`)
+- 실패 메시지에 이 단계의 실측치(68,744 전건 / SO-SUEOP 2,512)를 인용

--- a/mydocs/working/task_m100_4141_stage2.md
+++ b/mydocs/working/task_m100_4141_stage2.md
@@ -161,7 +161,7 @@ CARGO_INCREMENTAL=0 cargo clippy --profile release-test --lib --tests -- -D warn
 **exit 0, 경고 0.**
 
 전체 `cargo test --profile release-test --tests` 와 `cargo clippy --all-targets` 는
-`docs_and_git_workflow.md:171-174` 에 따라 **작업지시자 승인 후** 실행한다.
+`docs_and_git_workflow.md:181-184` 에 따라 **작업지시자 승인 후** 실행한다.
 
 renderer lane(`local_validation.md:74`)은 실행하지 않는다 — `relative_sizes` 는 렌더 경로 참조가
 0건이고 렌더러가 소비하는 `ratios`·`base_size` 는 건드리지 않았다. 그 사실을

--- a/mydocs/working/task_m100_4141_stage2.md
+++ b/mydocs/working/task_m100_4141_stage2.md
@@ -1,0 +1,174 @@
+# Stage 2 — task_m100_4141 수정과 계약 고정
+
+- **이슈**: [#4141](https://github.com/edwardkim/rhwp/issues/4141)
+- **계획서**: [`mydocs/plans/task_m100_4141.md`](../plans/task_m100_4141.md)
+- **선행 단계**: [stage1](task_m100_4141_stage1.md)
+- **브랜치**: `task_m100_4141` (분기 기준 `upstream/devel` `0fdac31ba`)
+- **작업 시각**: 2026-08-07 KST
+- **프로덕션 코드 변경**: `src/model/style.rs` 1곳 (`impl Default for CharShape`)
+
+## 1. TDD 순서 — 빨강을 먼저 확인했다
+
+계약 테스트를 먼저 쓰고 **수정 없이** 돌려 5건 전부 실패함을 확인한 뒤 수정했다.
+
+### 빨강 (수정 전)
+
+```text
+test result: FAILED. 0 passed; 5 failed; finished in 0.82s
+```
+
+실패 메시지가 Stage 1 실측치와 정확히 일치했다 — 테스트가 진짜 결함을 보고 있다는 증거다:
+
+```text
+samples/SO-SUEOP.hwp: CHAR_SHAPE 2512개 중 2512개의 상대크기가 100 이 아니다
+  (첫 위반 id=0 한글=0). ...
+samples/hwp3-sample.hwp: CHAR_SHAPE 747개 중 747개 ...
+samples/hwp3-sample10.hwp: CHAR_SHAPE 28193개 중 28193개 ...
+tests/fixtures/hml/exambank_math_equations_min.hml: <RELSIZE> 2개 중 2개가
+  유효범위 10~250 밖이다 (첫 위반: `<RELSIZE Hangul="0" ... />`)
+samples/SO-SUEOP.hwp: <hh:relSz> 2512개 중 2512개가 유효범위 10~250 밖이다
+```
+
+### 초록 (수정 후)
+
+```text
+test result: ok. 5 passed; 0 failed; finished in 0.61s
+```
+
+## 2. 수정 — `src/model/style.rs` 한 곳
+
+`#[derive(Debug, Clone, Default)]` 에서 `Default` 를 빼고 수동 impl 을 썼다.
+**`relative_sizes: [100; 7]` 한 줄만 파생값과 다르고** 나머지 30개 필드는 파생값을 그대로 나열했다.
+
+이 한 곳이 Stage 1 §2 의 **6개 누출 경로를 전부** 해소한다 — 전부
+`CharShape::default()` 또는 `..Default::default()` 를 통과하기 때문이다. 실제로 라이터가 셋인
+3축(HWP5 바이트 / HWPX XML / HML XML)이 **같은 커밋 하나로** 동시에 초록이 됐다.
+
+주석에 네 가지를 남겼다: ① 왜 파생 Default 로는 안 되는가(OWPML `positiveInteger` [10,250],
+한컴의 `크기 × 상대크기%` 해석, 6개 누출 경로) ② HWP5 파서가 이미 100 을 폴백하므로
+파생값 0 은 그 폴백과도 불일치였다는 점 ③ 왜 `ratios`·`base_size` 는 그대로 두는가(렌더러가
+소비 → 별도 이슈) ④ 왜 필드를 전부 나열하는가(새 필드 추가 시 컴파일 에러로 표류 차단).
+
+### 함께 바꾸지 않은 것
+
+`ratios`·`base_size`(렌더러가 소비), `shade_color`·`shadow_color`·`underline_color`(sentinel),
+`char_offsets`·`spacings`(0 이 스펙상 유효값). 이 비대칭을
+`src/model/style.rs` 의 `char_shape_default_matches_spec_only_for_relative_sizes` 가 고정한다 —
+다음 사람이 "왜 ratios 는 안 고쳤나"를 코드에서 읽는다.
+
+## 3. 추가한 테스트
+
+### 통합 계약 — `tests/issue_4141_hwp3_relative_size_contract.rs` (신규, 5건)
+
+`tests/issue_3676_hwp3_convert_hancom_openable.rs` 를 확장하지 않고 새 파일로 만들었다.
+실패 부류가 다르고(개봉 거부 vs 열리는데 백지), 스트림이 다르고(BodyText vs DocInfo),
+표본 범위가 다르다(단일 vs 전수).
+
+| 테스트 | 축 | 대상 |
+| --- | --- | --- |
+| `hwp3_convert_emits_valid_relative_sizes_for_every_sample` | HWP5 바이트 | HWP3 표본 **전수** (오프셋 28..35) |
+| `so_sueop_convert_relative_sizes_are_all_100` | HWP5 바이트 | `samples/SO-SUEOP.hwp` 이름 고정 |
+| `public_document_core_export_also_emits_valid_relative_sizes` | HWP5 바이트 | `export_hwp_with_adapter` 경로 |
+| `hwp3_export_hwpx_emits_valid_rel_sz` | HWPX XML | `Contents/header.xml` 의 `<hh:relSz>` |
+| `hml_roundtrip_without_relsize_child_emits_valid_relsize` | HML XML | `RELSIZE` 자식 없는 fixture 왕복 |
+
+재사용: `Record::read_all`(`src/parser/record.rs:34`) + `CfbReader::read_doc_info`(압축 해제 포함).
+`walk_records` 를 손으로 다시 쓰지 않았다 — `tests/issue_3507_sectiondef_ctrl_data.rs:52-62` 골격을 따랐다.
+
+전수 스윕에 `assert!(swept >= 10)` 하한을 뒀다 — 표본이 전부 건너뛰어져 조용히 통과하는 것을 막는다.
+
+### 유닛 (3건)
+
+- `src/model/style.rs::char_shape_default_matches_spec_only_for_relative_sizes`
+- `src/parser/hwpx/header.rs::char_pr_without_rel_sz_child_defaults_to_100_percent`
+  — `<hh:relSz>` 자식 부재 시 100. 명시된 `ratio=95` 는 덮이지 않음도 함께 단언
+- `src/parser/hwpx/header.rs::char_pr_id_gap_filler_gets_valid_relative_size`
+  — id 0·3 만 있는 header.xml 의 갭 채움 자리(`resize_with`)도 유효범위 안
+
+## 4. 문서 정합
+
+Default 변경으로 **사실과 어긋나게 된 서술**을 고쳤다. 결론은 전부 유지된다 — 사라진 것은
+부수 논거 하나뿐이다.
+
+| 위치 | 처리 |
+| --- | --- |
+| `src/document_core/queries/hidden_text.rs` `effective_pt` 독 코멘트 | "덤으로 default `[0;7]` 오독 사고가 불가능해진다" 논거 소멸 → 이력 절로 명시. **판정 규칙은 불변** |
+| 같은 파일 `default_relative_sizes_can_never_cause_a_zero_size_misjudgment` 주석 | 이 테스트가 지키는 것은 기본값이 아니라 **입력 내성**임을 명확히. 0 은 여전히 외부 파일로 들어온다(수정 이전 rhwp 산출물 전부) |
+| `mydocs/report/task_sec_hidden/README.md` | 같은 문장 → 갱신 각주 추가 |
+| `decision_log.md` D-11 / `invariants.md` INV-21 | **수정 불필요** — 기본값을 근거로 들지 않는다. "렌더러가 안 곱하므로 판정기도 안 곱한다"는 논지는 그대로 유효 |
+
+## 5. 검증 게이트 결과
+
+### 초점 테스트
+
+| 대상 | 결과 |
+| --- | --- |
+| `issue_4141_hwp3_relative_size_contract` (신규) | **5 passed** (0.61s) |
+| `issue_3676_hwp3_convert_hancom_openable` | 5 passed |
+| `hml_serializer` | 31 passed |
+| `hidden_text_contract` | 24 passed |
+| `hwp5_roundtrip_baseline` | 3 passed (38.71s) |
+| `hwpx_roundtrip_baseline` | 4 passed |
+| `--lib model::style` | 6 passed |
+| `--lib parser::hwpx::header` | 51 passed (신규 2건 포함) |
+
+### IR field sweep — 논증이 아니라 실측으로 확인
+
+계획서 §7 은 3 lane 전부 무변동을 **논증**으로 예측했다. 덤프를 실제로 떠서 확인했다.
+
+```bash
+RHWP_IR_SWEEP_DUMP=<dump> cargo test --profile release-test \
+  --test ir_field_sweep_baseline -- --nocapture
+```
+
+```text
+test ir_field_sweep_does_not_regress ... ok
+test baseline_samples_exist ... ok
+test result: ok. 2 passed; 0 failed; finished in 42.27s
+```
+
+덤프 대조 — 줄 수 598 = 598, **줄바꿈 정규화 후 SHA-256 일치**:
+
+```text
+baseline 68e716d35d63efef...
+current  68e716d35d63efef...
+diff -u --strip-trailing-cr → 빈 출력
+```
+
+(정규화 없는 `diff` 는 전 행 차이로 보이는데, 저장소 checkout 이 CRLF 이고 덤프가 LF 라서다.
+내용 차분은 0 이다.)
+
+무변동의 이유는 lane 별로 다르다:
+
+- `hwp5` — `hwp5_out_of_scope` 가 HWP3 를 제외하고, HWP5 는 `raw_data` 우선이라
+  `serialize_char_shape` 가 호출되지 않는다
+- `hwp5rb` — `src/diagnostics/ir_field_sweep.rs:1045-1049` 가 `raw_stream_dirty`/`raw_stream` 만
+  건드리고 **`CharShape.raw_data` 는 지우지 않는다**
+- `hwpx` — Default 변경이 왕복 양쪽에 대칭 작용한다 (0→"0"→0 이 100→"100"→100 이 될 뿐)
+
+### 포맷
+
+`cargo fmt --check` 의 `Diff in` 위반은 이번에 만진 3파일뿐이었고 rustfmt 로 해소했다.
+`Incorrect newline style` 경고는 저장소 전역 선행 상태다(Windows CRLF checkout) — 이번 변경과
+무관하며, staged blob 은 CR 0바이트로 LF 정규화됨을 확인했다.
+
+### clippy
+
+```bash
+CARGO_INCREMENTAL=0 cargo clippy --profile release-test --lib --tests -- -D warnings
+```
+
+**exit 0, 경고 0.**
+
+전체 `cargo test --profile release-test --tests` 와 `cargo clippy --all-targets` 는
+`docs_and_git_workflow.md:171-174` 에 따라 **작업지시자 승인 후** 실행한다.
+
+renderer lane(`local_validation.md:74`)은 실행하지 않는다 — `relative_sizes` 는 렌더 경로 참조가
+0건이고 렌더러가 소비하는 `ratios`·`base_size` 는 건드리지 않았다. 그 사실을
+`char_shape_default_matches_spec_only_for_relative_sizes` 가 코드로 고정한다.
+
+## 6. 남은 것 (Stage 3)
+
+- 한컴 판정 번들 (`output/issue_4141/`, 비커밋) 과 바이트 사전검증
+- 최종 보고서
+- `ratios` 후속 이슈 등록 (Stage 1 §7 근거)

--- a/mydocs/working/task_m100_4141_stage3.md
+++ b/mydocs/working/task_m100_4141_stage3.md
@@ -1,0 +1,222 @@
+# Stage 3 — task_m100_4141 한컴 판정 번들과 후속 이슈 초안
+
+- **이슈**: [#4141](https://github.com/edwardkim/rhwp/issues/4141)
+- **선행 단계**: [stage1](task_m100_4141_stage1.md) · [stage2](task_m100_4141_stage2.md)
+- **최종 보고서**: [`mydocs/report/task_m100_4141_report.md`](../report/task_m100_4141_report.md)
+- **작업 시각**: 2026-08-07 KST
+- **프로덕션 코드 변경**: 0
+
+## 1. 한컴 판정 번들 (`output/issue_4141/`, 비커밋)
+
+`.gitignore:15` 의 `/output/` 로 제외되므로 산출물은 커밋되지 않는다. 수치만 보고서로 옮긴다.
+
+```text
+output/issue_4141/
+  PANJEONG.md              판정 안내 (#4097 판형 답습)
+  measure_spans.py         PyMuPDF span 크기 계측 + A1~A5 자동 판정
+  SO-SUEOP-before.hwp      수정 전 rhwp convert
+  SO-SUEOP-after.hwp       수정 후 rhwp convert
+  SO-SUEOP-before.hwpx     수정 전 rhwp export-hwpx
+  SO-SUEOP-after.hwpx      수정 후 rhwp export-hwpx
+```
+
+`before` 는 분기 기준(`upstream/devel` `0fdac31ba`, 수정 전) 빌드로, `after` 는 수정 후 빌드로
+**같은 명령**을 실행해 만들었다.
+
+### 인계 전 바이트 사전검증 — 통과
+
+| 파일 | CHAR_SHAPE / relSz 태그 | relSz | ratios(장평) | base_size 최빈 |
+| --- | ---: | --- | --- | --- |
+| `before.hwp` | 2,512 | **0 × 2,512** | 100 × 977 | 1000 × 1706 |
+| `after.hwp` | 2,512 | **100 × 2,512** | 100 × 977 | 1000 × 1706 |
+| `before.hwpx` | 2,512 | **0 × 2,512** | — | — |
+| `after.hwpx` | 2,512 | **100 × 2,512** | — | — |
+
+**격리된 변수는 상대크기 하나다** — CHAR_SHAPE 개수·장평·기준 크기가 before/after 동일하다.
+
+- `.hwpx` 는 12개 ZIP 엔트리 중 **`Contents/header.xml` 하나만** 다르다.
+- `.hwp` 는 총 크기 99,840 으로 동일하고 6,227바이트가 다르다 — DocInfo 가 deflate 압축이라
+  2,512 × 7바이트 변경이 스트림 전체로 번지기 때문이다.
+
+```text
+29fa7bf2b3f3ded72d11785545f251031289b3be0c0e5637262dfdae7a23a2af  SO-SUEOP-before.hwp
+6a89786e273e6cc6da6f43bae77408c2a0698886411e474e79d97cbd51b7229d  SO-SUEOP-before.hwpx
+cbe7d76c7b215e25e3db2c326d50469f2e59076af48ce335428cc9ba54827558  SO-SUEOP-after.hwp
+7d763c85ad04216282baa3f355bd319ee2d6da33acc30e9b1ea0408b1a047c8c  SO-SUEOP-after.hwpx
+```
+
+## 2. 한컴 판정 결과 (2026-08-07 수행)
+
+작업지시자가 한컴으로 열어 PDF 로 출력했다 —
+`output/issue_4141/SO-SUEOP-{before,after}.pdf`. PyMuPDF 계측 결과:
+
+| | 쪽수 | span | min | max | median | **1pt 미만** |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 원본 `pdf/SO-SUEOP-2024.pdf` | 46 | 14,417 | 7.17 | 50.64 | **9.71** | 0 |
+| `before` (수정 전) | 46 | 10,604 | 0.12 | 0.12 | 0.12 | **10,604** |
+| `after` (수정 후) | **47** | 7,730 | 6.96 | 50.51 | **9.71** | **0** |
+
+### 합격 기준 판정
+
+| # | 기준 | 결과 |
+| --- | --- | --- |
+| A1 | `after` 의 1pt 미만 span = 0개 | **PASS** — 0개 |
+| A2 | 크기 분포 min/max/median ±5% | **PASS** — min −2.9%, max −0.3%, median **0%**(9.71 일치) |
+| A2′ | 최빈 8종 일치 | **FAIL** — 원본은 9.71 이 8,426개로 압도적, `after` 는 8.54/9.71/9.72 로 분산 |
+| A3 | `after` 쪽수 = 46 | **FAIL** — 47쪽 |
+| A4 | 1쪽 육안 정상 | **FAIL** — 아래 §3 |
+| A5 | **음성 대조군** — `before` 재현 | **PASS** — 10,604 span 전부 0.12pt. 이슈 본문 수치와 **정확히 일치** |
+
+**A5 가 정확히 재현됐으므로 판정 절차 자체는 유효하다.** 결과를 채택한다.
+
+### 판정 — #4141 의 계약은 해소됐다
+
+이 이슈가 정의한 결함은 "본문 글자가 전부 ~0.1pt 로 그려진다"이고, 그것은 **해소됐다**:
+1pt 미만 span 10,604개 → **0개**, median 이 원본과 소수점까지 일치(9.71).
+본문도 온전하다 — 추출 문자수 원본 50,172자, `after` 54,219자.
+
+**다만 문서는 아직 사용 가능하지 않다.** A3·A4 실패의 원인은 #4141 과 별개인 결함 둘이다(§3).
+
+## 3. 판정에서 드러난 별개 결함 둘
+
+### ① 글자 음영이 검정 — [#4155](https://github.com/edwardkim/rhwp/issues/4155) (신규 등록)
+
+`after` 는 **본문 전체가 검정 막대**로 덮인다. PDF 를 뜯어보면 텍스트는 제 위치·제 크기로
+그려져 있고 그 위에 줄 크기 순검정 사각형이 칠해져 있다(3쪽 fill 65개. 원본 같은 쪽은
+글리프 크기 fill 35개).
+
+**#4141 과 인과가 없다** — `shade_color` 바이트가 before/after **동일**하다(둘 다
+`0x00000000` × 2,512). #4141 이전에는 글자가 0.12pt 라 음영 사각형도 찌부러져 있었을 뿐이다:
+
+```text
+before 3쪽 검정 fill: 3개, 크기 0×0
+after  3쪽 검정 fill: 65개, 줄 크기
+```
+
+근인 둘 — HWP3 `shade_ratio`(음영 비율) 미반영, HWP5 라이터의 "음영 없음" sentinel 미번역.
+실측 근거는 이슈 본문에 전부 담았다(한컴산 HWP5 380건 코퍼스, HWP3 `shade_ratio` 임시 프로브,
+같은 원본에 대한 한컴 저장본 4쌍 대조).
+
+**작업지시자 판단(2026-08-07): #4141 merge 이후 별도 작업.** 이 브랜치에서는 다루지 않는다.
+계약 테스트 설계는 이슈 §"수정 방향" 3번과 실측 표에 값까지 명시돼 있어 그대로 재작성 가능하다.
+
+### ② 1쪽 글맵시 누락 — [#4097](https://github.com/edwardkim/rhwp/issues/4097) 축
+
+원본 1쪽의 세로 글맵시 제목("수업용소설해설")이 `after` 에 없다. 그 수정은
+[PR #4144](https://github.com/edwardkim/rhwp/pull/4144)(`task_m100_4097`)에 있고, 이 브랜치는
+`upstream/devel` 에서 분기해 **미포함**임을 확인했다(`git merge-base --is-ancestor` 실패).
+
+`pdf/task4097/README.md` 가 "#4141 해소 후 같은 쌍을 다시 만들면 이 축의 **양성 판정**이 비로소
+가능해진다"고 적어 뒀다 — 이 수정이 그 전제를 풀었다.
+
+### A3(쪽수 47 vs 46) 는 원인 미확정
+
+`before` 는 전 글자가 0.12pt 라 조판이 무의미하므로 그 46쪽은 레이아웃 기준선이 될 수 없다.
+`after` 47쪽이 원본 46쪽과 다른 것은 HWP3 → HWP5 **조판 충실도** 축인데, #4155·#4097 이
+남아 있는 상태에서는 기여를 분리할 수 없다. **세 결함이 해소된 뒤 재측정해야 판단이 선다** —
+지금 단정하지 않는다.
+
+## 4. 원래 합격 기준 (사전 고정분, 참고)
+
+| # | 기준 |
+| --- | --- |
+| A1 | `after` 의 1pt 미만 span = 0개 (before 는 10,604개 전부 0.12pt) |
+| A2 | `after` 크기 분포가 원본과 정합 — min/max/median ±5%, 최빈 8종 일치 |
+| A3 | `after` 쪽수 = 46 = `before` = 원본 |
+| A4 | 1쪽 육안 정상 |
+| A5 | **음성 대조군**: `before` 재현 — 10,604 span 전부 ≈0.12pt |
+
+## 5. 후속 이슈 초안 — `ratios` 기본값
+
+작업지시자 승인 후 등록한다. GitHub 권한상 label·assignee 는 지정하지 못한다.
+
+---
+
+**제목**
+
+```text
+[model] CharShape.ratios 기본값 0 이 OWPML 유효범위 [50,200] 밖 — 렌더러가 장평 0 으로 소비한다
+```
+
+**본문**
+
+```markdown
+> [#4141](https://github.com/edwardkim/rhwp/issues/4141) 수정 중 발견해 분리 등록합니다.
+> 같은 부류(모델 파생 기본값이 스펙 유효범위 밖)이지만 **렌더 가시 변경이라 검증 lane 이 다릅니다.**
+
+## 증상
+
+`RELSIZE`/`RATIO` 자식이 없는 HML 을 배포 CLI 로 왕복시키면 장평이 0 으로 나갑니다.
+
+    rhwp export-hml tests/fixtures/hml/exambank_math_equations_min.hml -o /tmp/rt.hml
+
+    <RATIO Hangul="0" Latin="0" Hanja="0" Japanese="0" Other="0" Symbol="0" User="0"/>
+
+입력 fixture 의 `<CHARSHAPE>` 는 `FONTID` 만 갖고 `RATIO` 자식이 없습니다.
+
+## 원인
+
+`CharShape.ratios` 의 기본값이 `[0; 7]` 입니다. OWPML `ratio` 는 default=100,
+유효범위 [50, 200] 이므로(`mydocs/manual/OWPML SCHEMA/Header XML schema.xml`) 0 은 범위 밖입니다.
+
+`relative_sizes` 와 달리 **렌더러가 이 값을 소비합니다** —
+`src/renderer/style_resolver.rs:355` `ratios.push(cs.ratios[lang] as f64 / 100.0)`.
+장평 0 = 글자 폭 0 입니다.
+
+값을 채우지 않는 경로:
+
+- `src/parser/hwpx/header.rs:588` — `charPr` 에 `<hh:ratio>` 자식이 없을 때
+- `src/parser/hwpx/header.rs:848-858` — charPr id 갭 `resize_with(idx+1, CharShape::default)`
+- `src/parser/hml/reader.rs:599-605` — `RATIO` 부재
+- `src/document_core/html_table_import.rs:627`, `src/document_core/commands/html_import.rs:845`
+- `src/parser/hwp3/mod.rs:3566` — 인덱스 0 placeholder
+
+## HWP3 축은 안전합니다 (#4141 과 인과 없음)
+
+- `convert_char_shape`(`src/parser/hwp3/mod.rs:540`)가 `ratios` 를 HWP3 레코드에서 채웁니다.
+- `ratios=0` 인 유일한 레코드는 인덱스 0 placeholder 인데, **어떤 문단도 참조하지 않습니다** —
+  HWP3 표본 15건 전수에서 `PARA_CHAR_SHAPE` 참조 0건 (SO-SUEOP 은 참조 1,918건 중 최소 id 가 16).
+
+그래서 #4141 의 백지 증상과는 무관하고, 그 PR 에 묶지 않았습니다.
+
+## 수정 방향 (제안)
+
+1. `impl Default for CharShape`(`src/model/style.rs`, #4141 에서 도입)의 `ratios` 를
+   `[100; 7]` 로. `base_size` 도 같은 축이라 함께 검토합니다.
+2. #4141 이 남긴 `char_shape_default_matches_spec_only_for_relative_sizes` 단언을 갱신 —
+   그 테스트가 지금 `ratios == [0;7]` 을 "의도된 미수정"으로 고정하고 있습니다.
+3. HML/HWPX 왕복 계약에 `RATIO` 유효범위 단언 추가
+   (`tests/issue_4141_hwp3_relative_size_contract.rs` 의 범위 검사 헬퍼 재사용 가능).
+
+## 검증 부담 (분리한 이유)
+
+렌더러가 소비하므로 `local_validation.md` 4.3 의 **renderer lane** 이 발동합니다 —
+Native Skia 3종 + `wasm-pack build` + 시각 증적. `relative_sizes`(렌더 참조 0건)와 달리
+골든 스냅샷이 움직일 수 있습니다.
+
+## 관계
+
+- [#4141](https://github.com/edwardkim/rhwp/issues/4141) — 같은 모델 기본값 결함의 `relative_sizes` 축.
+  근거 계측: `mydocs/working/task_m100_4141_stage1.md` §3, §5, §7
+```
+
+---
+
+## 6. 절차 상태
+
+- 한컴 판정 완료(2026-08-07). **#4141 의 계약은 해소**됐고, 판정에서 드러난 별개 결함
+  [#4155](https://github.com/edwardkim/rhwp/issues/4155) 를 실측 근거와 함께 등록했다.
+- **#4155 는 #4141 merge 이후 별도 작업**한다(작업지시자 판단, 2026-08-07). 이 브랜치의 범위는
+  `relative_sizes` 하나로 유지한다 — 한컴 판정 결과의 귀속을 흐리지 않기 위해서다.
+- 이 단계에서 임시 프로브(`convert_char_shape` 의 `shade_ratio` 출력)를 썼고 **측정 후 삭제**했다.
+  프로덕션 코드 변경 0 을 `git status` 로 확인했다.
+- 오늘할일(`mydocs/orders/`)은 **contributor 가 작성하지 않는다** — 이 작업의 산출물에서 제외한다
+  (작업지시자 지적, 2026-08-07). 2026-08-07 갱신된 `collaborator_self_merge.md` §8.2.1 도
+  오늘할일·`pr_N_review.md` 를 **PR 채번 이후** 단계로 옮겼고, 그 경로는 collaborator 몫이다.
+  PR 번호를 예측해 `pr_N_*` 파일명을 미리 만들지도 않는다.
+- **remote push 와 PR 생성은 작업지시자 승인 대기**다
+  (`docs_and_git_workflow.md:166-184`, `AGENTS.md:31`). 2026-08-07 갱신된 규칙상 구현·로컬
+  검증이 끝난 merge 후보는 별도 Draft 지시가 없으면 **Open PR** 로 생성한다.
+- 전체 `cargo test --profile release-test --tests` 와 `cargo clippy --all-targets -- -D warnings` 도
+  별도 승인 대기다(`docs_and_git_workflow.md:181-184`).
+- `ratios` 후속 이슈(§5) 등록은 승인 대기다.

--- a/src/document_core/queries/hidden_text.rs
+++ b/src/document_core/queries/hidden_text.rs
@@ -279,9 +279,15 @@ fn char_shade(color: ColorRef) -> Option<ColorRef> {
 /// 같은 식을 쓴다.
 ///
 /// 현실 문서에서 차이는 없다 — HWPX 60개 문서 4,298개 `charPr` 실측에서 `relSz != 100`
-/// 은 0건이었다. 덤으로, `CharShape::default()` 의 `relative_sizes = [0; 7]`(HWP3 변환
-/// 경로가 채우지 않는다)을 0% 로 오독해 **모든 글자를 0pt 로 보고**하는 사고도 구조적으로
-/// 불가능해진다.
+/// 은 0건이었다.
+///
+/// # 이력 (#4141)
+///
+/// 종전 이 주석은 "`CharShape::default()` 의 `relative_sizes = [0; 7]` 을 0% 로 오독해
+/// 모든 글자를 0pt 로 보고하는 사고도 구조적으로 불가능해진다"를 부수 논거로 들었다.
+/// 그 전제는 사라졌다 — `CharShape::default()` 는 이제 스펙 기본값 `[100; 7]` 이다
+/// (`model/style.rs`). **결론은 그대로다**: 렌더러가 안 곱하므로 판정기도 안 곱한다.
+/// 사라진 것은 근거 하나뿐이고, 아래 회귀 테스트가 0 입력에 대한 안전성을 직접 고정한다.
 pub fn effective_pt(shape: &CharShape) -> f64 {
     shape.base_size.max(0) as f64 / 100.0
 }
@@ -1076,9 +1082,13 @@ mod tests {
 
     #[test]
     fn default_relative_sizes_can_never_cause_a_zero_size_misjudgment() {
-        // `CharShape::default()` 는 relative_sizes = [0; 7] 이고 HWP3 변환 경로가 이
-        // 배열을 채우지 않는다. 이 값을 0% 로 곱했다면 HWP3 문서 전체가 0pt 로 보고됐을
-        // 것이다. relSz 를 아예 보지 않으므로 그 사고가 구조적으로 불가능하다.
+        // relSz=0 은 OWPML 유효범위 10~250 밖이지만 외부 파일에는 실제로 들어온다 —
+        // #4141 이전 rhwp 가 만든 HWP3 변환본이 전부 그렇다(CHAR_SHAPE 68,744개 전건).
+        // 그 값을 0% 로 곱했다면 문서 전체가 0pt 로 보고됐을 것이다. relSz 를 아예
+        // 보지 않으므로 그 사고가 구조적으로 불가능하다.
+        //
+        // (#4141 이후 `CharShape::default()` 자체는 [100; 7] 이다. 그래서 여기서 0 을
+        //  명시 대입한다 — 이 테스트가 지키는 것은 기본값이 아니라 *입력 내성*이다.)
         let mut cs = shape(1000, 0x0000_0000, NO_SHADE);
         cs.relative_sizes = [0; 7];
         assert!((effective_pt(&cs) - 10.0).abs() < 1e-9);

--- a/src/model/style.rs
+++ b/src/model/style.rs
@@ -96,7 +96,10 @@ pub struct SubstFont {
 }
 
 /// 글자 모양 (HWPTAG_CHAR_SHAPE)
-#[derive(Debug, Clone, Default)]
+///
+/// `Default` 는 [수동 구현](#impl-Default-for-CharShape)이다 — 파생하면 `relative_sizes` 가
+/// 스펙 위반값 0 이 된다(#4141).
+#[derive(Debug, Clone)]
 pub struct CharShape {
     /// 원본 레코드 바이트 (라운드트립 보존용, 있으면 직렬화 시 우선 사용)
     pub raw_data: Option<Vec<u8>>,
@@ -159,6 +162,75 @@ pub struct CharShape {
     pub kerning: bool,
     /// 글꼴에 어울리는 빈칸 사용 여부 (bit 25)
     pub use_font_space: bool,
+}
+
+/// `relative_sizes` 만 Rust 파생 기본값(0)이 아니라 **스펙 기본값 100** 이다. 나머지 필드는
+/// 파생값과 같다.
+///
+/// # 왜 파생 Default 로는 안 되는가 (#4141)
+///
+/// OWPML 은 `relSz` 를 `xs:positiveInteger` minInclusive=10 / maxInclusive=250,
+/// `default="100"` 으로 정의한다(`mydocs/manual/OWPML SCHEMA/Header XML schema.xml:716-728`).
+/// **0 은 타입 수준에서 이미 불법이다.** 한컴은 실효 크기를 `기준 크기 × 상대크기%` 로
+/// 해석하므로 0 이 저장되면 10pt 글자가 0.1pt 로 그려져 문서가 사실상 백지가 된다
+/// (`samples/SO-SUEOP.hwp` 변환본 한컴 PDF 실측: 46쪽 10,604 span 전부 0.12pt).
+///
+/// 이 값을 채우지 않는 생성 경로가 여럿이다 — HWP3 변환(`parser/hwp3/mod.rs:526`, HWP3
+/// 레코드에 상대크기 개념 자체가 없다), HWPX `charPr` 의 `relSz` 자식 부재와 id 갭
+/// 채움(`parser/hwpx/header.rs:588`, `:848-858`), HML `RELSIZE` 부재
+/// (`parser/hml/reader.rs:599-605`), HTML import. 세 라이터(HWP5·HWPX·HML)는 모두 가드 없이
+/// IR 값을 그대로 방출한다. 기본값을 스펙에 맞추면 그 전부가 한 곳에서 해소된다.
+///
+/// HWP5 바이너리 파서는 이미 100 을 폴백한다(`parser/doc_info.rs:542-545`) — 파생 Default 의
+/// 0 은 그 폴백과도 불일치였다.
+///
+/// # 왜 `ratios`·`base_size` 는 그대로 두는가
+///
+/// 렌더러가 소비하는 필드다(`renderer/style_resolver.rs:341`,`:355`). 기본값을 바꾸면 렌더
+/// 회귀 검증 lane 이 필요해지므로 별도 이슈로 분리한다. `relative_sizes` 는 렌더 경로에서
+/// 참조가 0건이라(`document_core/queries/hidden_text.rs:267-287`) 이 변경의 렌더 영향은 없다.
+///
+/// # 왜 필드를 전부 나열하는가
+///
+/// `CharShape` 에 필드가 추가되면 이 impl 이 컴파일 에러를 낸다. 새 필드의 기본값을 스펙과
+/// 대조하도록 강제하는 장치다 — 조용한 표류를 막는다.
+impl Default for CharShape {
+    fn default() -> Self {
+        Self {
+            raw_data: None,
+            font_ids: [0; 7],
+            ratios: [0; 7],
+            spacings: [0; 7],
+            // ↓ 이 한 줄만 파생값과 다르다 (파생값 0 은 OWPML 유효범위 10~250 밖)
+            relative_sizes: [100; 7],
+            char_offsets: [0; 7],
+            base_size: 0,
+            attr: 0,
+            italic: false,
+            bold: false,
+            underline_type: UnderlineType::None,
+            outline_type: 0,
+            shadow_type: 0,
+            shadow_offset_x: 0,
+            shadow_offset_y: 0,
+            text_color: 0,
+            underline_color: 0,
+            shade_color: 0,
+            shadow_color: 0,
+            border_fill_id: 0,
+            strike_color: 0,
+            strikethrough: false,
+            subscript: false,
+            superscript: false,
+            emboss: false,
+            engrave: false,
+            emphasis_dot: 0,
+            underline_shape: 0,
+            strike_shape: 0,
+            kerning: false,
+            use_font_space: false,
+        }
+    }
 }
 
 /// CharShape 비교: raw_data 필드 제외 (라운드트립용 원본 바이트는 논리적 동일성과 무관)
@@ -1058,6 +1130,47 @@ mod tests {
         assert!(!cs.bold);
         assert!(!cs.italic);
         assert_eq!(cs.underline_type, UnderlineType::None);
+    }
+
+    /// `Default` 수동 구현이 스펙과 어긋나는 필드는 `relative_sizes` **하나뿐**임을 고정한다.
+    ///
+    /// 이 비대칭은 의도된 것이다(#4141). `relative_sizes` 는 렌더 경로에서 참조가 0건이라
+    /// 스펙값으로 고쳐도 렌더가 안 바뀌지만, `ratios`·`base_size` 는 렌더러가 소비하므로
+    /// (`renderer/style_resolver.rs:341`,`:355`) 같이 고치면 렌더 회귀 검증이 필요해진다.
+    /// 그래서 별도 이슈로 분리했다 — 이 테스트가 그 경계를 코드에서 읽히게 한다.
+    #[test]
+    fn char_shape_default_matches_spec_only_for_relative_sizes() {
+        let cs = CharShape::default();
+
+        // 이번에 고친 것 — OWPML relSz default="100", 유효범위 10~250
+        // (mydocs/manual/OWPML SCHEMA/Header XML schema.xml:716-728)
+        assert_eq!(
+            cs.relative_sizes, [100; 7],
+            "상대크기 기본값은 OWPML 기본값 100 이어야 한다. 0 이면 한컴이 \
+             `크기 × 상대크기%` 로 해석해 전 본문을 0.1pt 로 그린다 (#4141)"
+        );
+
+        // 의도적으로 고치지 않은 것 — 렌더러가 소비하므로 별도 이슈
+        assert_eq!(
+            cs.ratios, [0; 7],
+            "장평 기본값을 바꾸려면 렌더 회귀 검증(Native Skia·시각 증적)이 필요하다. \
+             #4141 범위 밖이며 별도 이슈로 다룬다 — 무심코 바꾸지 마라"
+        );
+        assert_eq!(
+            cs.base_size, 0,
+            "기준 크기도 렌더러가 소비한다 — 위와 같은 이유"
+        );
+
+        // 0 이 스펙상 유효값이라 손대지 않는 것
+        // (OWPML offset default=0 범위 [-100,100], spacing default=0 범위 [-50,50])
+        assert_eq!(cs.char_offsets, [0; 7]);
+        assert_eq!(cs.spacings, [0; 7]);
+
+        // sentinel 로 쓰이는 색상값 — hidden_text 판정과 HML preflight 가 0 에 의존한다
+        assert_eq!(cs.shade_color, 0);
+        assert_eq!(cs.shadow_color, 0);
+        assert_eq!(cs.underline_color, 0);
+        assert_eq!(cs.text_color, 0);
     }
 
     #[test]

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -3206,6 +3206,72 @@ mod tests {
         assert_eq!(cs.shadow_offset_y, 10);
     }
 
+    /// [#4141] `<hh:relSz>` 자식이 없는 `charPr` 은 OWPML 기본값 100 으로 남아야 한다.
+    ///
+    /// 종전엔 `CharShape::default()` 의 파생값 0 이 남아, 그 IR 을 그대로 방출하는 라이터
+    /// (`serializer/hwpx/header.rs:638`, `serializer/char_shape.rs:21`)를 통해 유효범위
+    /// 10~250 밖의 `relSz="0"` 이 저장됐다. 한컴은 `크기 × 상대크기%` 로 해석한다.
+    #[test]
+    fn char_pr_without_rel_sz_child_defaults_to_100_percent() {
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:charProperties itemCnt="1">
+      <hh:charPr id="0" height="1000" textColor="#000000" shadeColor="none" useFontSpace="0" useKerning="0" symMark="NONE">
+        <hh:fontRef hangul="0" latin="0" hanja="0" japanese="0" other="0" symbol="0" user="0"/>
+        <hh:ratio hangul="95" latin="95" hanja="95" japanese="95" other="95" symbol="95" user="95"/>
+      </hh:charPr>
+    </hh:charProperties>
+  </hh:refList>
+</hh:head>"##;
+
+        let (doc_info, _) = parse_hwpx_header(xml).unwrap();
+
+        assert_eq!(
+            doc_info.char_shapes[0].relative_sizes, [100; 7],
+            "relSz 자식이 없으면 OWPML 기본값 100 이어야 한다 (Header XML schema.xml:716-728)"
+        );
+        // 명시된 장평은 그대로 살아야 한다 — 기본값 채움이 실제 값을 덮으면 안 된다.
+        assert_eq!(doc_info.char_shapes[0].ratios, [95; 7]);
+    }
+
+    /// [#4141] `charPr` id 갭을 메우는 자리도 유효한 상대크기를 가져야 한다.
+    ///
+    /// `parse_char_properties` 는 `id` 를 배열 인덱스로 쓰고 빈 자리를
+    /// `resize_with(idx + 1, CharShape::default)` 로 메운다. 그 자리가 참조되면
+    /// 저장 바이트에 relSz=0 이 그대로 나간다.
+    #[test]
+    fn char_pr_id_gap_filler_gets_valid_relative_size() {
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:charProperties itemCnt="2">
+      <hh:charPr id="0" height="1000" textColor="#000000" shadeColor="none" useFontSpace="0" useKerning="0" symMark="NONE">
+        <hh:relSz hangul="100" latin="100" hanja="100" japanese="100" other="100" symbol="100" user="100"/>
+      </hh:charPr>
+      <hh:charPr id="3" height="1000" textColor="#000000" shadeColor="none" useFontSpace="0" useKerning="0" symMark="NONE">
+        <hh:relSz hangul="100" latin="100" hanja="100" japanese="100" other="100" symbol="100" user="100"/>
+      </hh:charPr>
+    </hh:charProperties>
+  </hh:refList>
+</hh:head>"##;
+
+        let (doc_info, _) = parse_hwpx_header(xml).unwrap();
+
+        assert!(
+            doc_info.char_shapes.len() >= 4,
+            "id 3 까지 자리가 잡혀야 한다: {}",
+            doc_info.char_shapes.len()
+        );
+        for (id, cs) in doc_info.char_shapes.iter().enumerate() {
+            assert!(
+                cs.relative_sizes.iter().all(|&v| (10..=250).contains(&v)),
+                "charPr id={id} (갭 채움 자리 포함)의 상대크기가 유효범위 10~250 밖이다: {:?}",
+                cs.relative_sizes
+            );
+        }
+    }
+
     #[test]
     fn parse_char_pr_captures_sym_mark() {
         // symMark(강조점)은 종전에 파서가 no-op 으로 무시해 hwpx 재로드 시 NONE 으로 유실됐다.

--- a/tests/issue_4141_hwp3_relative_size_contract.rs
+++ b/tests/issue_4141_hwp3_relative_size_contract.rs
@@ -1,0 +1,395 @@
+//! Issue #4141: HWP3 변환본의 글자 상대크기가 0 으로 저장돼 한컴이 전 본문을 ~0.1pt 로 그린다.
+//!
+//! ## 증상
+//!
+//! `rhwp convert` 로 만든 HWP3 → HWP5 변환본을 한컴이 **연다**(오류·복구 대화상자 없음).
+//! 그런데 사실상 백지다 — `samples/SO-SUEOP.hwp` 46쪽 10,604개 텍스트 span 이 전부 ~0.12pt 로
+//! 그려진다(원본은 9.7~50.5pt). 위치는 정상이고 크기만 붕괴한다.
+//!
+//! 개봉 자체를 거부하는 [#3676] 과는 **실패 부류가 다르다**. 그래서 계약도 따로 둔다.
+//!
+//! ## 근인
+//!
+//! `CharShape.relative_sizes` 가 `[0; 7]` 로 직렬화된다. 한컴은 `크기 × 상대크기%` 로 해석하므로
+//! 10pt × 0% ≈ 0.1pt 다 — 실측 0.12pt 와 부합한다.
+//!
+//! OWPML 은 `relSz` 를 `xs:positiveInteger` minInclusive=10 / maxInclusive=250,
+//! `default="100"` 으로 정의한다(`mydocs/manual/OWPML SCHEMA/Header XML schema.xml:716-728`).
+//! **0 은 타입 수준에서 이미 불법이다.**
+//!
+//! 같은 문서의 한컴산 HWPX(`samples/SO-SUEOP.hwpx`)는 charPr 51개가 예외 없이 `relSz=100` 이다.
+//! 반면 `ratio`(95/90/100/97)와 `spacing`(-1/-2/-3/0)은 편차가 있다 — 그 둘은 HWP3 레코드의
+//! 진짜 데이터고, 잘못된 것은 `relSz` 하나뿐이다.
+//!
+//! ## 이 테스트가 필요한 이유
+//!
+//! 판정의 정답지는 한컴이지만 CI 에는 한컴이 없다. 그리고 rhwp 자신은 이 결함을 **볼 수 없다** —
+//! 렌더러가 `relative_sizes` 를 아예 읽지 않아(`src/renderer/style_resolver.rs:339-361`)
+//! `export-text`·자체 렌더·`convert --verify` 가 전부 정상으로 나온다. `hwp5_roundtrip_baseline`
+//! 은 HWP3 를 자동 제외하고, `--verify` 의 IR diff 는 CharShape **속성값을 비교하지 않는다**.
+//!
+//! 그래서 **저장 바이트/XML 에서** 직접 검사한다. 이 테스트가 CI 의 유일한 방어선이다.
+//!
+//! [#3676]: https://github.com/edwardkim/rhwp/issues/3676
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use rhwp::parser::cfb_reader::CfbReader;
+use rhwp::parser::{detect_format, record::Record, tags, FileFormat};
+
+/// CHAR_SHAPE payload 안에서 `relative_sizes`(7 × u8)가 놓이는 구간.
+///
+/// 레이아웃 정본은 `src/parser/doc_info.rs:520-577` 이고 라이터
+/// `src/serializer/char_shape.rs:12-27` 이 같은 순서로 쓴다:
+/// font_ids 0..14 / ratios 14..21 / spacings 21..28 / **relative_sizes 28..35** /
+/// char_offsets 35..42 / base_size 42..46 / attr 46..50.
+const REL_SIZE_RANGE: std::ops::Range<usize> = 28..35;
+
+/// OWPML `relSz` 유효범위 — `Header XML schema.xml:716-728`.
+const REL_SIZE_MIN: u8 = 10;
+const REL_SIZE_MAX: u8 = 250;
+
+/// HWP3 유래 CharShape 이 가져야 할 값.
+///
+/// `Hwp3CharShape`(`src/parser/hwp3/records.rs:193-203`)에는 상대크기 필드 **자체가 없다**.
+/// 따라서 HWP3 변환본은 예외 없이 OWPML 기본값이어야 한다 — 범위 검사보다 강한 단언이다.
+const HWP3_EXPECTED: u8 = 100;
+
+const SAMPLES_ROOT: &str = "samples";
+const SO_SUEOP: &str = "samples/SO-SUEOP.hwp";
+const HWP3_SAMPLE: &str = "samples/hwp3-sample.hwp";
+/// `<CHARSHAPE>` 가 `FONTID` 만 갖고 `RELSIZE`·`RATIO` 자식이 없는 HML.
+/// HML 리더가 채우지 않으면 왕복 저장에 `RELSIZE="0"` 이 나간다.
+const HML_WITHOUT_RELSIZE: &str = "tests/fixtures/hml/exambank_math_equations_min.hml";
+
+/// Stage 1 실측(2026-08-07, 분기 기준 `upstream/devel` 0fdac31ba): 수정 전에는 HWP3 표본 15건의
+/// CHAR_SHAPE **68,744개 전건**이 relSz=0 이었다. 스윕이 조용히 비면 회귀를 놓치므로 하한을 둔다.
+const MIN_SWEPT_SAMPLES: usize = 10;
+
+fn repo_path(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+/// `samples/` 에서 HWP3 서명 파일을 재귀 수집한다 (루트 기준 상대경로, 사전순).
+fn hwp3_samples() -> Vec<(PathBuf, String)> {
+    fn walk(dir: &Path, root: &Path, acc: &mut Vec<(PathBuf, String)>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                walk(&path, root, acc);
+            } else if path
+                .extension()
+                .is_some_and(|e| e.eq_ignore_ascii_case("hwp"))
+            {
+                let Ok(bytes) = std::fs::read(&path) else {
+                    continue;
+                };
+                if detect_format(&bytes) != FileFormat::Hwp3 {
+                    continue;
+                }
+                let rel = path
+                    .strip_prefix(root)
+                    .expect("strip_prefix")
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                acc.push((path, rel));
+            }
+        }
+    }
+    let root = repo_path(SAMPLES_ROOT);
+    let mut acc = Vec::new();
+    walk(&root, &root, &mut acc);
+    acc.sort_by(|a, b| a.1.cmp(&b.1));
+    assert!(
+        !acc.is_empty(),
+        "samples 에 HWP3 표본이 없다 — 표본 배치를 확인하라"
+    );
+    acc
+}
+
+/// CLI `convert` 와 같은 경로로 HWP3 를 HWP5 바이트로 만든다.
+/// (`tests/issue_3676_hwp3_convert_hancom_openable.rs:46-54` 와 같은 조합, 경로만 파라미터화)
+fn convert_to_hwp5_bytes(path: &Path) -> Option<Vec<u8>> {
+    let raw = std::fs::read(path).expect("표본 읽기");
+    let mut doc = rhwp::parser::hwp3::parse_hwp3(&raw).ok()?;
+    rhwp::document_core::converters::hwpx_to_hwp::convert_if_hwpx_source(
+        &mut doc,
+        FileFormat::Hwp3,
+    );
+    rhwp::serializer::cfb_writer::serialize_hwp(&doc).ok()
+}
+
+/// public 저장 경로 (`DocumentCore::export_hwp_with_adapter`).
+fn convert_to_hwp5_bytes_via_document_core(path: &Path) -> Vec<u8> {
+    let raw = std::fs::read(path).expect("표본 읽기");
+    let mut core = rhwp::document_core::DocumentCore::from_bytes(&raw).expect("HWP3 파싱");
+    core.export_hwp_with_adapter().expect("HWP5 직렬화")
+}
+
+/// 저장된 HWP5 바이트의 DocInfo 에서 CHAR_SHAPE payload 를 꺼낸다.
+///
+/// `Record::read_all` 이 레코드 순회의 정본이다(`src/parser/record.rs:34`) — 테스트마다
+/// `walk_records` 를 손으로 다시 쓰지 않는다. `read_doc_info` 가 압축 해제까지 한다.
+fn char_shape_payloads(bytes: &[u8]) -> Vec<Vec<u8>> {
+    let mut cfb = CfbReader::open(bytes).expect("CFB 열기");
+    let file_header = cfb.read_file_header().expect("FileHeader 읽기");
+    let compressed = file_header.get(36).is_some_and(|b| b & 0x01 != 0);
+    let doc_info = cfb.read_doc_info(compressed).expect("DocInfo 읽기");
+    Record::read_all(&doc_info)
+        .expect("DocInfo record 파싱")
+        .into_iter()
+        .filter(|record| record.tag_id == tags::HWPTAG_CHAR_SHAPE)
+        .map(|record| record.data)
+        .collect()
+}
+
+/// HWPX/HML 처럼 텍스트 엔트리를 하나 꺼낸다.
+fn zip_text_entry(bytes: &[u8], name: &str) -> String {
+    let mut archive = zip::ZipArchive::new(std::io::Cursor::new(bytes)).expect("ZIP 열기");
+    let mut entry = archive
+        .by_name(name)
+        .unwrap_or_else(|e| panic!("{name} 찾기: {e}"));
+    let mut text = String::new();
+    entry.read_to_string(&mut text).expect("엔트리 읽기");
+    text
+}
+
+/// `<hh:relSz .../>` 나 `<RELSIZE .../>` 같은 태그에서 정수 속성값을 모은다.
+fn tag_int_attrs(tag: &str) -> Vec<i64> {
+    let mut out = Vec::new();
+    let bytes = tag.as_bytes();
+    let mut i = 0;
+    while let Some(open) = bytes[i..].iter().position(|&b| b == b'"') {
+        let start = i + open + 1;
+        let Some(close) = bytes[start..].iter().position(|&b| b == b'"') else {
+            break;
+        };
+        if let Ok(v) = tag[start..start + close].parse::<i64>() {
+            out.push(v);
+        }
+        i = start + close + 1;
+    }
+    out
+}
+
+/// 여는 태그 `<name ... />` 를 전부 찾는다 (속성 안에 `>` 가 없다는 전제 — 숫자 속성뿐이다).
+fn find_tags<'a>(xml: &'a str, name: &str) -> Vec<&'a str> {
+    let open = format!("<{name}");
+    let mut out = Vec::new();
+    let mut rest = xml;
+    while let Some(at) = rest.find(&open) {
+        let after = &rest[at + open.len()..];
+        // `<hh:relSz` 가 `<hh:relSzFoo` 를 잡지 않도록 경계 확인
+        if !after.starts_with([' ', '/', '>', '\t', '\n', '\r']) {
+            rest = &rest[at + open.len()..];
+            continue;
+        }
+        let Some(end) = after.find('>') else { break };
+        out.push(&rest[at..at + open.len() + end + 1]);
+        rest = &after[end + 1..];
+    }
+    out
+}
+
+/// 유효범위 위반을 `(인덱스, 값)` 으로 모은다.
+fn out_of_range(values: &[u8]) -> Vec<(usize, u8)> {
+    values
+        .iter()
+        .enumerate()
+        .filter(|(_, &v)| !(REL_SIZE_MIN..=REL_SIZE_MAX).contains(&v))
+        .map(|(i, &v)| (i, v))
+        .collect()
+}
+
+const LANG: [&str; 7] = ["한글", "영어", "한자", "일어", "기타", "기호", "사용자"];
+
+fn why_it_matters() -> &'static str {
+    "한컴은 `크기 × 상대크기%` 로 해석하므로 0 이면 10pt 글자가 0.1pt 로 그려져 문서가 \
+     백지가 된다 (#4141: SO-SUEOP 46쪽 10,604 span 전수 0.12pt 한컴 PDF 실측). rhwp \
+     렌더러는 이 필드를 읽지 않아 자체 검증으로는 드러나지 않는다."
+}
+
+/// HWP5 저장 바이트의 CHAR_SHAPE 상대크기를 검사하고 사람이 읽을 실패 사유를 만든다.
+fn check_hwp5_relative_sizes(label: &str, hwp5: &[u8]) -> Result<usize, String> {
+    let payloads = char_shape_payloads(hwp5);
+    if payloads.is_empty() {
+        return Err(format!(
+            "{label}: CHAR_SHAPE 레코드가 없다 — 저장 경로를 확인하라"
+        ));
+    }
+    let mut violations = Vec::new();
+    for (id, payload) in payloads.iter().enumerate() {
+        if payload.len() < REL_SIZE_RANGE.end {
+            return Err(format!(
+                "{label}: CHAR_SHAPE id={id} payload 가 {}바이트로 짧다 (상대크기는 오프셋 \
+                 {}..{} 에 있어야 한다)",
+                payload.len(),
+                REL_SIZE_RANGE.start,
+                REL_SIZE_RANGE.end
+            ));
+        }
+        let sizes = &payload[REL_SIZE_RANGE];
+        if let Some((slot, &value)) = sizes.iter().enumerate().find(|(_, &v)| v != HWP3_EXPECTED) {
+            violations.push((id, slot, value));
+        }
+    }
+    if violations.is_empty() {
+        return Ok(payloads.len());
+    }
+    let (id, slot, value) = violations[0];
+    Err(format!(
+        "{label}: CHAR_SHAPE {}개 중 {}개의 상대크기가 {HWP3_EXPECTED} 이 아니다 \
+         (첫 위반 id={id} {}={value}). HWP3 레코드에는 상대크기 필드가 없으므로 \
+         (src/parser/hwp3/records.rs:193) 변환본은 예외 없이 OWPML 기본값 {HWP3_EXPECTED} 이어야 \
+         한다 — 유효범위는 {REL_SIZE_MIN}~{REL_SIZE_MAX} 다 (Header XML schema.xml:716-728). {}",
+        payloads.len(),
+        violations.len(),
+        LANG[slot],
+        why_it_matters()
+    ))
+}
+
+/// XML 의 `relSz` 계열 태그가 유효범위 안인지 검사한다.
+fn check_xml_rel_sz(
+    label: &str,
+    xml: &str,
+    tag_name: &str,
+    schema_ref: &str,
+) -> Result<usize, String> {
+    let tags = find_tags(xml, tag_name);
+    if tags.is_empty() {
+        return Err(format!(
+            "{label}: <{tag_name}> 이 하나도 없다 — 저장 경로를 확인하라"
+        ));
+    }
+    let mut bad = Vec::new();
+    for tag in &tags {
+        let values: Vec<u8> = tag_int_attrs(tag)
+            .into_iter()
+            .map(|v| v.clamp(0, 255) as u8)
+            .collect();
+        if !out_of_range(&values).is_empty() {
+            bad.push(*tag);
+        }
+    }
+    if bad.is_empty() {
+        return Ok(tags.len());
+    }
+    Err(format!(
+        "{label}: <{tag_name}> {}개 중 {}개가 유효범위 {REL_SIZE_MIN}~{REL_SIZE_MAX} 밖이다 \
+         (첫 위반: `{}`). OWPML 은 상대크기를 positiveInteger 로 정의하므로 0 은 스키마 \
+         위반이다 ({schema_ref}). {}",
+        tags.len(),
+        bad.len(),
+        bad[0],
+        why_it_matters()
+    ))
+}
+
+// ── ① HWP5 저장 바이트 — HWP3 표본 전수 ────────────────────────────────────
+
+/// HWP3 표본 전수를 변환해 저장 바이트의 상대크기가 전부 100 인지 본다.
+///
+/// 단일 표본으로는 부족하다 — `src/parser/hwp3/mod.rs:3566` 이 인덱스 0 자리에
+/// `CharShape::default()` 를 넣으므로 **모든** HWP3 문서에 기본값 레코드가 하나씩 생기고,
+/// 변환기 한 곳만 고친 부분 수정도 그 자리를 통과시킬 수 있다.
+#[test]
+fn hwp3_convert_emits_valid_relative_sizes_for_every_sample() {
+    let mut failures = Vec::new();
+    let mut swept = 0usize;
+    let mut total_shapes = 0usize;
+
+    for (path, rel) in hwp3_samples() {
+        // 암호 HWP3 는 비밀번호 없이 파싱되지 않는다 — 건너뛴다.
+        let Some(hwp5) = convert_to_hwp5_bytes(&path) else {
+            continue;
+        };
+        swept += 1;
+        match check_hwp5_relative_sizes(&rel, &hwp5) {
+            Ok(n) => total_shapes += n,
+            Err(message) => failures.push(format!("  {message}")),
+        }
+    }
+
+    assert!(
+        swept >= MIN_SWEPT_SAMPLES,
+        "HWP3 표본 스윕이 {swept}건뿐이다 (하한 {MIN_SWEPT_SAMPLES}). 전부 건너뛰어 조용히 \
+         통과하는 것을 막는 가드다 — 표본 배치나 파싱 실패를 확인하라"
+    );
+    assert!(
+        failures.is_empty(),
+        "HWP3 표본 {swept}건 중 {}건 실패 (통과분 CHAR_SHAPE {total_shapes}개):\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}
+
+/// #4141 의 재현 표본을 이름으로 고정한다 — 한컴 판정의 대상 문서다.
+#[test]
+fn so_sueop_convert_relative_sizes_are_all_100() {
+    let path = repo_path(SO_SUEOP);
+    let hwp5 = convert_to_hwp5_bytes(&path).expect("SO-SUEOP HWP3 변환");
+    let count = check_hwp5_relative_sizes(SO_SUEOP, &hwp5).unwrap_or_else(|m| panic!("{m}"));
+    assert!(
+        count > 1000,
+        "{SO_SUEOP}: CHAR_SHAPE 가 {count}개다. Stage 1 실측은 2,512개였다 — 표본이나 변환 \
+         경로가 바뀌었는지 확인하라"
+    );
+}
+
+/// public 저장 경로(`DocumentCore::export_hwp_with_adapter`)도 같은 계약을 지킨다.
+#[test]
+fn public_document_core_export_also_emits_valid_relative_sizes() {
+    let hwp5 = convert_to_hwp5_bytes_via_document_core(&repo_path(HWP3_SAMPLE));
+    check_hwp5_relative_sizes(HWP3_SAMPLE, &hwp5).unwrap_or_else(|m| panic!("{m}"));
+}
+
+// ── ② HWPX 저장 XML ────────────────────────────────────────────────────────
+
+/// `export-hwpx` 는 HWP3 입력을 받는다(`src/main.rs:272` → `:11311` → `parser/mod.rs:1294`).
+/// HWPX 라이터(`src/serializer/hwpx/header.rs:638`)에는 가드가 없어 IR 의 0 이 그대로 나간다.
+#[test]
+fn hwp3_export_hwpx_emits_valid_rel_sz() {
+    for rel in [SO_SUEOP, HWP3_SAMPLE] {
+        let raw = std::fs::read(repo_path(rel)).expect("표본 읽기");
+        let core = rhwp::document_core::DocumentCore::from_bytes(&raw).expect("HWP3 파싱");
+        let hwpx = core.export_hwpx_native().expect("HWPX 저장");
+        let xml = zip_text_entry(&hwpx, "Contents/header.xml");
+        check_xml_rel_sz(rel, &xml, "hh:relSz", "Header XML schema.xml:716-728")
+            .unwrap_or_else(|m| panic!("{m}"));
+    }
+}
+
+// ── ③ HML 저장 XML ─────────────────────────────────────────────────────────
+
+/// HWP3 → HML 은 도달 불가 경로다 — `export_hml_native` 가 HML 출처에만 있는 `hml_metadata` 를
+/// 요구한다(`src/document_core/commands/document.rs:1352-1359`). 대신 **HML 왕복**이 같은
+/// 결함을 노출한다: `RELSIZE` 자식이 없는 `<CHARSHAPE>` 를 읽으면 IR 이 0 으로 남고
+/// (`src/parser/hml/reader.rs:599-605`) 라이터가 가드 없이 방출한다
+/// (`src/serializer/hml/head.rs:131`). 이 fixture 로 배포 CLI 에서 재현된다.
+#[test]
+fn hml_roundtrip_without_relsize_child_emits_valid_relsize() {
+    let raw = std::fs::read(repo_path(HML_WITHOUT_RELSIZE)).expect("HML fixture 읽기");
+    let xml_in = String::from_utf8_lossy(&raw);
+    assert!(
+        find_tags(&xml_in, "RELSIZE").is_empty(),
+        "{HML_WITHOUT_RELSIZE} 에 RELSIZE 가 생겼다 — 이 fixture 는 '자식이 없을 때'를 \
+         재현해야 한다. 다른 fixture 를 쓰거나 회귀 조건을 다시 잡아라"
+    );
+
+    let core = rhwp::document_core::DocumentCore::from_bytes(&raw).expect("HML 파싱");
+    let out = core.export_hml_native().expect("HML 저장");
+    let xml_out = String::from_utf8_lossy(&out);
+    check_xml_rel_sz(
+        HML_WITHOUT_RELSIZE,
+        &xml_out,
+        "RELSIZE",
+        "Header XML schema.xml:716-728 (HWPML 대응 필드)",
+    )
+    .unwrap_or_else(|m| panic!("{m}"));
+}


### PR DESCRIPTION
Fixes #4141

## 요약

HWP3 문서를 `rhwp convert` 로 HWP5 변환한 뒤 한컴으로 열면 **사실상 백지**였다. 오류·복구
대화상자 없이 열리는데 본문 글자가 전부 ~0.1pt 로 그려진다(`samples/SO-SUEOP.hwp` 46쪽
10,604개 span 전부 0.12pt, 한컴 PDF 실측).

`CharShape.relative_sizes` 가 **0** 으로 저장되고, 한컴이 실효 크기를 `기준 크기 × 상대크기%` 로
해석하기 때문이다. OWPML `relSz` 는 `xs:positiveInteger` [10,250] `default="100"` 이므로
(`mydocs/manual/OWPML SCHEMA/Header XML schema.xml:716-728`) **0 은 타입 수준에서 이미 불법**이다.

## 근본 원인 — 이슈가 지목한 것보다 넓다

이슈는 `convert_char_shape` 한 곳을 제안했으나, 조사 결과 **모델의 파생 `Default`** 가 원인이었다.
`CharShape` 가 `derive(Default)` 라 `relative_sizes = [0; 7]` 이고, 이 값을 채우지 않는 프로덕션
경로가 6곳이다:

| # | 위치 | 상황 |
|---|---|---|
| 1 | `parser/hwp3/mod.rs:526` | HWP3 레코드에 상대크기 개념 자체가 없다 |
| 2 | `parser/hwp3/mod.rs:3566` | 인덱스 0 placeholder — **모든** HWP3 문서에 존재 |
| 3 | `parser/hwpx/header.rs:588` | `charPr` 에 `<hh:relSz>` 자식 부재 |
| 4 | `parser/hwpx/header.rs:848-858` | charPr id 갭 `resize_with` 채움 |
| 5 | `parser/hml/reader.rs:599-605` | `RELSIZE` 부재 |
| 6 | `document_core/html_table_import.rs:627`, `commands/html_import.rs:845` | HTML import |

라이터 셋(HWP5 `serializer/char_shape.rs:21`, HWPX `serializer/hwpx/header.rs:638`,
HML `serializer/hml/head.rs:131`)이 모두 가드 없이 IR 을 방출한다. 그래서 **수동 `impl Default`
한 곳으로 3축이 동시에 해소**된다.

부수 효과로 모델 Default 와 HWP5 파서 폴백의 불일치도 없어진다 —
`parser/doc_info.rs:542-545` 는 이미 100 을 폴백하고 있었다.

## 정답지 근거 — 오직 `relative_sizes` 만 잘못됐다

`samples/SO-SUEOP.hwpx`(같은 문서의 **한컴산** HWPX) charPr 51개 실측:

| 필드 | 한컴 | rhwp 변환본 | 판정 |
|---|---|---|---|
| `relSz` | **51/51 = 100** (편차 0) | 0 | **결함** |
| `ratio` | 95×30, 90×11, 100×8, 97×2 | 95 | 정상 — HWP3 의 진짜 데이터 |
| `spacing` | -1×25, 0×11, -2×10, -3×3 | -1 | 정상 — 진짜 데이터 |
| `offset` | 51/51 = 0 | 0 | 정상 — 0 이 유효값 |

`ratio`·`spacing` 은 편차가 있어 진짜 데이터임이 드러난다. 편차 0 인 `relSz` 만 결함이다.

## 왜 기존 게이트로 안 잡혔나

rhwp 는 이 결함을 **구조적으로 볼 수 없다** — 렌더러가 `relative_sizes` 를 아예 읽지 않는다
(`renderer/style_resolver.rs:339-361`, `src/renderer/`·`src/paint/` 참조 0건).

- `hwp5_roundtrip_baseline` — `out_of_scope` 가 HWP3 를 자동 제외
- `convert --verify` — `serializer/hwpx/roundtrip.rs` 가 char_shapes 를 **개수만** 비교. 속성값 미비교
- `ir_field_sweep_baseline` — 파서→직렬화→재파싱이 대칭으로 0 을 유지하므로 IR 은 정말 같다

그래서 계약 테스트는 **저장 바이트/XML 에서 직접** 검사한다.

## 변경

프로덕션 코드는 `src/model/style.rs` **한 곳**뿐이다. `derive` 에서 `Default` 를 빼고 수동 impl 을
썼다 — `relative_sizes: [100; 7]` 한 줄만 파생값과 다르고 나머지 30개 필드는 파생값 그대로다.
필드 전체 나열이 강제되므로 새 필드 추가 시 컴파일 에러가 나서 조용한 표류를 막는다.

`ratios`·`base_size` 는 **렌더러가 소비하므로 의도적으로 그대로 뒀다**
(`style_resolver.rs:341`,`:355`). 그 비대칭을
`char_shape_default_matches_spec_only_for_relative_sizes` 가 코드로 고정한다.

## 회귀 고정

신규 `tests/issue_4141_hwp3_relative_size_contract.rs` 5건 — HWP5 저장 바이트(CHAR_SHAPE 오프셋
28..35) HWP3 표본 **전수 스윕**, HWPX `header.xml` 의 `<hh:relSz>`, `RELSIZE` 없는 HML 왕복.
HWP3 lane 은 `== 100` 강단언이다(HWP3 레코드에 상대크기 필드가 없으므로 예외 없이 스펙 기본값).
전수 스윕에 `assert!(swept >= 10)` 하한을 둬 조용한 통과를 막는다.

유닛 3건 — 모델 Default 비대칭 고정, HWPX `relSz` 자식 부재, charPr id 갭 채움.

`Record::read_all`(`parser/record.rs:34`)과 `CfbReader::read_doc_info` 를 재사용했다.
`walk_records` 를 손으로 다시 쓰지 않았다(`tests/issue_3507_sectiondef_ctrl_data.rs:52-62` 골격).

## 검증

TDD red(5 failed, 실패 메시지 수치가 Stage 1 실측과 일치) → green.

| 대상 | 결과 |
|---|---|
| `issue_4141_hwp3_relative_size_contract` | 5 passed |
| `issue_3676_hwp3_convert_hancom_openable` | 5 passed |
| `hml_serializer` / `hidden_text_contract` | 31 / 24 passed |
| `hwp5_roundtrip_baseline` / `hwpx_roundtrip_baseline` | 3 / 4 passed |
| `--lib model::style` / `parser::hwpx::header` | 6 / 51 passed |
| `ir_field_sweep_baseline` | 2 passed, **덤프가 baseline 과 SHA-256 일치(무변동)** |
| `cargo fmt --check` | 위반 0 |
| `cargo clippy --all-targets -- -D warnings` | 통과 |
| `cargo test --profile release-test --tests` | 통과 |

IR sweep 무변동은 계획 단계에서 논증이었고 **덤프를 실제로 떠서** 확인했다(줄 수 598=598,
줄바꿈 정규화 후 해시 일치).

renderer lane 은 실행하지 않았다 — `relative_sizes` 는 렌더 경로 참조가 0건이고 렌더러가
소비하는 `ratios`·`base_size` 는 건드리지 않았다.

## 한컴 판정 (수행 완료)

| | 쪽수 | span | median | **1pt 미만** |
|---|---:|---:|---:|---:|
| 원본 `pdf/SO-SUEOP-2024.pdf` | 46 | 14,417 | **9.71** | 0 |
| `before` | 46 | 10,604 | 0.12 | **10,604** |
| `after` | 47 | 7,730 | **9.71** | **0** |

**A1 통과** (1pt 미만 0개), **A2 통과** (min −2.9% / max −0.3% / median 0%),
**A5 음성 대조군 통과** (before 가 10,604 span 전부 0.12pt 로 이슈 수치와 정확히 재현 →
판정 절차 자체가 유효함을 확인).

**이 이슈의 계약은 해소됐다.** 본문도 온전하다(추출 문자수 50,172 → 54,219).

다만 문서는 아직 사용 가능하지 않다 — 판정에서 **이 PR 과 인과 없는** 결함 둘이 드러났다:

- **#4155** 글자 음영 검정 (이 판정에서 발견해 실측 근거와 함께 등록). `shade_color` 바이트가
  before/after **동일**하므로 인과가 없다. 글자가 0.12pt 일 때는 음영 사각형도 0×0 으로
  찌부러져 보이지 않았을 뿐이다. **이 PR merge 이후 별도 작업**한다.
- **#4097** 1쪽 글맵시 누락. 그 수정은 #4144 에 있고 이 브랜치는 `upstream/devel` 분기라 미포함.
- 쪽수 47 vs 46 은 **원인 미확정**. `before` 는 전 글자가 0.12pt 라 레이아웃 기준선이 될 수 없고,
  위 둘이 남은 상태에서는 기여를 분리할 수 없다. 셋이 해소된 뒤 재측정해야 판단이 선다.

판정 번들은 `output/`(`.gitignore`)이라 비커밋이고 수치만 보고서로 옮겼다. 인계 전 바이트
사전검증에서 격리 변수가 상대크기 하나임을 확인했다(CHAR_SHAPE 개수·장평·기준 크기가
before/after 동일, `.hwpx` 는 12개 엔트리 중 `header.xml` 하나만 다름).

## 사용자 영향 — 재변환이 필요하다

이 수정은 **재변환해야 적용된다.** 이미 배포된 relSz=0 파일은 자동 복구되지 않는다. 읽기 시
정규화를 넣지 않은 이유는 HWP5 가 `raw_data` 를 우선해 재저장 시 여전히 0 이 나가기 때문이다.

## 부수 효과 — #4097 판정 재개 가능

`pdf/task4097/README.md` 가 "#4141 해소 후 같은 쌍을 다시 만들면 이 축의 **양성 판정**이 비로소
가능해진다"고 적어 뒀다. 이 수정이 그 전제를 푼다.

## 문서

`mydocs/plans/task_m100_4141.md`, `working/task_m100_4141_stage{1,2,3}.md`,
`report/task_m100_4141_report.md`. Default 변경으로 사실과 어긋나게 된 서술 2곳
(`hidden_text.rs` 독 코멘트, `report/task_sec_hidden/README.md`)을 함께 정정했다 —
**결론은 유지**된다(렌더러가 안 곱하므로 판정기도 안 곱한다). 소멸한 것은 부수 논거 하나뿐이다.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
