### PR TITLE
fix(studio): 툴바·표 경계·HF/FN 문단 서식 통합

### DIFF
--- a/mydocs/orders/20260807.md
+++ b/mydocs/orders/20260807.md
@@ -1,5 +1,24 @@
 # 오늘 할 일 - 2026년 8월 7일
 
+## PR #4166 - jeong-sik Studio 문단·표 경계 통합
+
+- [PR #4166](https://github.com/edwardkim/rhwp/pull/4166)에 @jeong-sik의 #4120, #4133,
+  #4134를 최신 `devel` 기준으로 순서대로 통합했다. 원 contributor head는 변경하지 않았다.
+- #4120은 머리말/꼬리말 문단 상태를 툴바·눈금자 reader와 통일하고 Fixed·Minimum·SpaceOnly
+  줄 간격에서 이전 선택값을 남기지 않는다. #4133은 반올림 경계에서 중복된 표 세로 경계를
+  병합해 드래그 범위가 한 방향으로 뒤집히는 문제를 해결한다.
+- #4134의 머리말/꼬리말·각주 문단 서식 적용은 실제 Chromium에서 값 변경과 Undo는 성공했지만
+  Undo 뒤 편집 모드가 이탈했다. 메인터너 보정 `d2a0f2e6f`은 일반 snapshot 의미를 바꾸지 않고
+  두 경로에만 `SubmodeSnapshotCommand`를 사용해 Undo/Redo 후 같은 편집 문맥을 유지한다.
+- Studio focused 35건, 전체 `npm test` 802건, TypeScript, production build와 headless Chromium
+  툴바·머리말·각주 왕복을 통과했다. code head의 CI, CodeQL, Render Diff도 성공했다.
+- 이 review·오늘할일 문서 commit을 trailing documentation commit으로 push한 뒤 최신 head의
+  fast-pass 또는 fallback CI aggregate를 확인한다. 작업지시자 승인 뒤 병합하면 `Closes #4109`의
+  자동 종료와 원 PR #4120·#4133·#4134의 후속 정리를 확인한다.
+
+상세 근거: [PR #4166 검토](../pr/archives/pr_4166_review.md),
+[통합·메인터너 보정 기록](../pr/archives/pr_4166_review_impl.md).
+
 ## PR #4156 - humdrum00001010 누적 PR 통합
 
 - [PR #4156](https://github.com/edwardkim/rhwp/pull/4156)을 merge commit

--- a/mydocs/pr/archives/pr_4166_review.md
+++ b/mydocs/pr/archives/pr_4166_review.md
@@ -1,0 +1,80 @@
+---
+kind: pr_review
+status: accepted-with-maintainer-correction
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-07
+---
+
+# PR #4166 검토 - Studio 문단 상태·표 경계·서브모드 서식 통합
+
+## 대상과 변경 경계
+
+| 항목 | 값 |
+| --- | --- |
+| 통합 PR / 작성자 | [#4166](https://github.com/edwardkim/rhwp/pull/4166) / @jangster77 |
+| 기준 `devel` | `98acdd9a1a12578e1da0ceeffcdc54a60c750ab2` |
+| 통합 code head | `d2a0f2e6f2ff0b1f444cadbfb376fc2288d900ee` |
+| 가시성 검토 브랜치 | `review/jeong-sik-20260807-integration` |
+| 원 PR | [#4120](https://github.com/edwardkim/rhwp/pull/4120), [#4133](https://github.com/edwardkim/rhwp/pull/4133), [#4134](https://github.com/edwardkim/rhwp/pull/4134) / @jeong-sik |
+| 원 contributor head | #4120 `93ee8fcf9e84a7b3316e28d292f27b9ca9e31df6`, #4133 `f44e506c2f841c8d2131ed3b857fcd1bce60f72b`, #4134 `088af5756a2be0d500f5a845623b8aa0b609cd81` |
+| 원 PR 적용 순서 | #4120 → #4133 → #4134 |
+| 연동 이슈 | `Closes #4109` |
+
+세 원 PR의 최신 원격 head가 위 SHA와 같은 것을 통합 직전 다시 확인했다. contributor 원 commit은
+rebase, amend, reset, force-push하지 않았고, 최신 `devel` 위 검토 브랜치에 cherry-pick으로만 누적했다.
+
+- #4120은 머리말/꼬리말 문단 상태를 툴바·눈금자와 문단 모양 대화상자의 공통 reader로 통일하고,
+  Percent가 아닌 줄 간격에서 툴바 선택값을 비운다.
+- #4133은 반올림 경계에서 갈라진 같은 표 선 좌표를 1.0px 이내 대표 좌표로 병합하고, 병합 전 좌표도
+  대표 인덱스를 찾을 수 있게 map을 보존한다.
+- #4134는 이미 존재하던 머리말/꼬리말·각주 문단 서식 WASM API를 Studio 입력 경로에 연결한다.
+
+Canvas paint, HWP/HWPX 파서, pagination, 저장 포맷 또는 기준 PDF를 바꾸지 않는다. 표 경계의
+DOM resize overlay와 입력·history 경로만 바꾸므로 PDF/SVG visual sweep 대상은 아니며, 아래의
+headless Chromium 동작 검증으로 실제 상호작용을 확인했다.
+
+## 충돌과 메인터너 보정
+
+#4134의 `mutation-routing-guard` 기준선은 앞서 `devel`에 들어간 #4119의 input-handler 변경과
+같은 행을 수정해 충돌했다. #4119의 한 호출과 #4134의 두 호출을 모두 반영해 기준선 `30`으로
+해소했다. 기능 코드나 contributor 원 commit은 생략하지 않았다.
+
+초기 통합 상태에서 #4134를 실제 브라우저로 검증하자, 머리말과 각주 모두 줄 간격 변경 자체와
+값 Undo는 성공했지만 Undo 뒤 편집 모드가 `true → false`로 이탈했다. 원인은 일반
+`SnapshotCommand`가 `EditContext`를 노출하지 않아 history 복원기가 이를 본문 명령으로 처리한 것이다.
+
+메인터너 보정 `d2a0f2e6f`은 일반 `SnapshotCommand`의 기존 본문 복귀 정책을 변경하지 않았다.
+대신 `applyParaFormatInHf`와 `applyParaFormatInFootnote`의 descriptor에 현재 문맥을 붙이고,
+그 두 경우에만 `SubmodeSnapshotCommand`를 사용한다. 이 전용 클래스만 `EditContext`를 노출하므로
+머리말 구조 삽입처럼 Undo 뒤 본문으로 돌아가야 하는 기존 snapshot 작업의 의미는 유지된다.
+
+## 완료한 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| 적용 source SHA 재확인 | #4120, #4133, #4134의 원격 head가 누적 검토에 쓴 SHA와 모두 일치 |
+| diff 정합 | `git diff --check upstream/devel...HEAD` 통과 |
+| focused Studio 검증 | 문단 서식 배선·서브모드 history·mutation guard 35 passed |
+| TypeScript | `npx tsc --noEmit` 통과 |
+| Studio 전체 단위 테스트 | `npm test` 802 passed, 0 failed |
+| Studio production build | `npm run build` 통과. Vite chunk 크기 경고만 있고 exit 0 |
+| 표 경계 좌표 | `table-border-lines.test.ts`가 반올림 분리 병합, 대표 인덱스 map, 최소 셀 폭, 사슬 병합 차단을 검증 |
+| Chromium 툴바 | 본문 300%·머리말 100%에서 머리말 편집 툴바가 100%를 표시했고, Fixed 30 줄 간격에서 선택 인덱스가 `-1`이 됨 |
+| Chromium 머리말 | 160% → 300% 적용, Undo 160%, Redo 300%, 세 단계 모두 머리말 편집 모드 유지 |
+| Chromium 각주 | `footnote-01.hwp`에서 130% → 300% 적용, Undo 130%, Redo 300%, 세 단계 모두 각주 편집 모드 유지 |
+| GitHub code candidate | code head `d2a0f2e6f`의 CI, CodeQL, Render Diff 모두 성공 |
+
+`mutation-routing-guard`는 이번 변경과 무관한 기존 이관 후보
+`src/engine/input-handler-table.ts: 9 → 7`을 안내로 출력했다. 해당 파일을 이 통합 PR에서
+수정하지 않았고, guard도 통과했으므로 기준선 변경 범위에 포함하지 않았다.
+
+## 수용 판단과 merge 조건
+
+**메인터너 보정 포함 수용 권고.** 원 PR 세 건의 입력·툴바·표 경계 계약과 #4134의 Undo/Redo
+편집 문맥을 실제 브라우저까지 확인했다.
+
+이 문서와 오늘할일은 통과한 code head 뒤에만 붙이는 trailing documentation commit이다. 문서 push 뒤에는
+최신 PR head의 preflight·branch protection aggregate가 성공했고, `mergeable=MERGEABLE`,
+`mergeStateStatus=CLEAN`인지 다시 확인해야 한다. 그 조건과 작업지시자의 merge 승인이 충족되면 #4166을
+병합하고 #4109의 자동 종료, 원 PR #4120·#4133·#4134의 후속 comment·close, 원격 작업 브랜치 정리를
+순서대로 확인한다.

--- a/mydocs/pr/archives/pr_4166_review_impl.md
+++ b/mydocs/pr/archives/pr_4166_review_impl.md
@@ -1,0 +1,45 @@
+---
+kind: review-implementation
+status: completed-local
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-07
+---
+
+# PR #4166 통합·메인터너 보정 기록
+
+## 적용 순서와 commit 경계
+
+| 순서 | SHA | 역할 |
+| --- | --- | --- |
+| 1 | `bb88ddce834beb2a67d4db9d8b36a58d956e9b76` | 머리말/꼬리말 문단 reader를 툴바·눈금자에 연결 |
+| 2 | `1e7be43ab1c274d33458daab9a614bad33472d32` | Percent가 아닌 줄 간격에서 툴바의 이전 선택값 제거 |
+| 3 | `aeee39734a9a129d9fb4d715873880a6a1c514dc` | 표 경계 좌표 병합과 hit-test 대표 인덱스 map 추가 |
+| 4 | `0f0bcce831dd254ccfb726610e244ba24406f788` | 머리말/꼬리말·각주 문단 서식 적용 경로 연결 |
+| 5 | `d2a0f2e6f2ff0b1f444cadbfb376fc2288d900ee` | HF/FN 문단 서식 Undo/Redo 편집 문맥 보존 메인터너 보정 |
+
+통합은 최신 `upstream/devel` `98acdd9a` 위에서 #4120 → #4133 → #4134 순서로 수행했다.
+#4134의 `mutation-routing-guard` 기준선 충돌은 현재 `devel`의 #4119 호출 한 건과 #4134 호출
+두 건을 합쳐 `30`으로 해소했다.
+
+## 보정 범위
+
+1. `OperationDescriptor`의 snapshot 경로에 선택적 `EditContext`를 선언했다.
+2. 일반 `SnapshotCommand`에는 문맥 복원을 추가하지 않았다. 이 클래스는 기존 구조 편집의
+   Undo 뒤 본문 복귀 계약을 그대로 유지한다.
+3. `SubmodeSnapshotCommand`가 일반 snapshot 동작을 상속하고, 명시적으로 전달된 HF/FN 문맥만
+   history 복원기에 노출한다.
+4. 머리말/꼬리말과 각주의 문단 서식 호출부가 각각 현재 커서 좌표와 서브모드 식별자를
+   descriptor에 전달한다.
+5. source guard를 추가해 두 경로의 전용 명령 선택과 문맥 노출이 빠지면 테스트가 실패하게 했다.
+
+## 완료한 검증과 판정
+
+`npx tsc --noEmit`, focused Studio 35건, `npm test` 802건, `npm run build`를 순차로 통과했다.
+headless Chromium에서 머리말·각주의 줄 간격을 각각 적용하고 Undo·Redo한 뒤에도 해당 편집
+서브모드에 남는 것을 확인했다. 일반 snapshot의 문맥 비노출 정책을 검사하는
+`undo-submode-insert.test.ts`도 함께 통과해 기존 구조 편집 계약이 바뀌지 않았음을 확인했다.
+
+원격 `d2a0f2e6f` code head에서는 CI, CodeQL, Render Diff가 모두 성공했다. 이 문서와 오늘할일은
+후속 documentation commit으로만 push한다. push 직후 최신 head의 review-only fast-pass 또는
+workflow fallback 결과를 확인하고, 작업지시자의 merge 승인 뒤 #4166 병합과 원 PR 후속 처리를
+수행한다.

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -218,7 +218,14 @@ export type OperationDescriptor =
   | { kind: 'command'; command: EditCommand; meta?: OperationMetadata }
   // [Task #2370] snapshot 의 operation 은 아무것도 바꾸지 않았을 때 `null` 을 반환해
   // "기록하지 말 것"을 알린다(그 경우 커서 이동·리프레시도 건너뛴다).
-  | { kind: 'snapshot'; operationType: string; operation: (wasm: WasmBridge) => DocumentPosition | null; meta?: OperationMetadata }
+  | {
+      kind: 'snapshot';
+      operationType: string;
+      operation: (wasm: WasmBridge) => DocumentPosition | null;
+      /** 본문 좌표와 분리된 HF/FN 편집 문맥. undo/redo 뒤 같은 문맥으로 돌아간다. */
+      editContext?: EditContext;
+      meta?: OperationMetadata;
+    }
   | { kind: 'record'; command: EditCommand; meta?: OperationMetadata };
 
 // ─── 본문/셀 분기 헬퍼 ────────────────────────────────
@@ -2051,4 +2058,25 @@ export class SnapshotCommand implements EditCommand {
       this.afterId = null;
     }
   }
+}
+
+/**
+ * 머리말/꼬리말·각주 안에서만 쓰는 스냅샷 명령.
+ *
+ * 일반 SnapshotCommand는 구조 편집처럼 undo 뒤 본문으로 돌아가야 하는 작업도 담당한다.
+ * 그래서 편집 문맥을 일반 클래스에 붙이지 않고, 서브모드를 보존해야 하는 호출부만 이 타입을
+ * 명시적으로 선택한다.
+ */
+export class SubmodeSnapshotCommand extends SnapshotCommand {
+  constructor(
+    operationType: string,
+    cursorBefore: DocumentPosition,
+    cursorAfter: DocumentPosition,
+    operation: ((wasm: WasmBridge) => DocumentPosition | null) | null,
+    private readonly context: EditContext,
+  ) {
+    super(operationType, cursorBefore, cursorAfter, operation);
+  }
+
+  editContext(): EditContext { return this.context; }
 }

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -6,7 +6,7 @@ import { CaretRenderer } from './caret-renderer';
 import { FieldMarkerRenderer } from './field-marker-renderer';
 import { SelectionRenderer } from './selection-renderer';
 import { CommandHistory } from './history';
-import { DeleteSelectionCommand, ApplyCharFormatCommand, ApplyParaFormatCommand, SnapshotCommand, SetFormValueCommand, TextMutationEffectAccumulator, IMMEDIATE_TEXT_MUTATION_EFFECTS } from './command';
+import { DeleteSelectionCommand, ApplyCharFormatCommand, ApplyParaFormatCommand, SnapshotCommand, SubmodeSnapshotCommand, SetFormValueCommand, TextMutationEffectAccumulator, IMMEDIATE_TEXT_MUTATION_EFFECTS } from './command';
 import type { OperationDescriptor, ParaFormatTarget, RefreshPolicy, TextMutationEffects, EditCommand, EditContext, FormValueTarget } from './command';
 import { selectCellIndicesInRange, paraFormatTargetsForCellBlock } from './cell-block-format';
 import type { SelectedCellBlock } from './cell-block-format';
@@ -1988,9 +1988,18 @@ export class InputHandler {
       const sectionIdx = cur.hfSectionIdx;
       const applyTo = cur.hfApplyTo;
       const hfParaIdx = cur.hfParaIdx;
+      const hfCharOffset = cur.hfCharOffset;
       this.executeOperation({
         kind: 'snapshot',
         operationType: 'applyParaFormatInHf',
+        editContext: {
+          mode: 'headerFooter',
+          sectionIdx,
+          isHeader,
+          applyTo,
+          paraIdx: hfParaIdx,
+          charOffset: hfCharOffset,
+        },
         operation: (wasm) => {
           wasm.applyParaFormatInHf(sectionIdx, isHeader, applyTo, hfParaIdx, propsJson);
           return { ...cursorBefore };
@@ -2005,9 +2014,22 @@ export class InputHandler {
       const paraIdx = cur.fnParaIdx;
       const controlIdx = cur.fnControlIdx;
       const innerParaIdx = cur.fnInnerParaIdx;
+      const charOffset = cur.fnCharOffset;
+      const footnoteIndex = cur.fnFootnoteIndex;
+      const pageNum = cur.fnPageNum;
       this.executeOperation({
         kind: 'snapshot',
         operationType: 'applyParaFormatInFootnote',
+        editContext: {
+          mode: 'footnote',
+          sectionIdx,
+          paraIdx,
+          controlIdx,
+          footnoteIndex,
+          pageNum,
+          innerParaIdx,
+          charOffset,
+        },
         operation: (wasm) => {
           wasm.applyParaFormatInFootnote(sectionIdx, paraIdx, controlIdx, innerParaIdx, propsJson);
           return { ...cursorBefore };
@@ -2481,7 +2503,17 @@ export class InputHandler {
       }
       case 'snapshot': {
         const cursorBefore = this.cursor.getPosition();
-        const cmd = new SnapshotCommand(desc.operationType, cursorBefore, cursorBefore, desc.operation);
+        // 일반 snapshot은 구조 편집의 본문 복귀 의미를 유지한다. HF/FN 안에서만
+        // 문맥을 보존하는 전용 명령을 써서 undo/redo의 대상 범위를 호출부가 드러낸다.
+        const cmd = desc.editContext
+          ? new SubmodeSnapshotCommand(
+              desc.operationType,
+              cursorBefore,
+              cursorBefore,
+              desc.operation,
+              desc.editContext,
+            )
+          : new SnapshotCommand(desc.operationType, cursorBefore, cursorBefore, desc.operation);
         const newPos = this.history.execute(cmd, this.wasm);
         const markPastedFieldEndOutside = this.pastedFieldEndOutsidePending;
         // 무변경 경로에서도 pending 플래그는 소비한다 — 남겨 두면 다음 연산으로 샌다.

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2195,19 +2195,10 @@ export class InputHandler {
       const pos = this.cursor.getPosition();
       const inFootnote = this.cursor.isInFootnote();
       const inCell = !inFootnote && pos.parentParaIndex !== undefined;
-      const paraProps = inFootnote
-        ? this.wasm.getParaPropertiesInFootnote(
-            this.cursor.fnSectionIdx,
-            this.cursor.fnParaIdx,
-            this.cursor.fnControlIdx,
-            this.cursor.fnInnerParaIdx,
-          )
-        : inCell
-        ? this.wasm.getCellParaPropertiesAt(
-            pos.sectionIndex, pos.parentParaIndex!, pos.controlIndex!,
-            pos.cellIndex!, pos.cellParaIndex!,
-          )
-        : this.wasm.getParaPropertiesAt(pos.sectionIndex, pos.paragraphIndex);
+      // 문단 모양 대화상자와 같은 리더를 쓴다. 여기에 갈래를 따로 두면 문맥이 하나 빠져도
+      // 컴파일이 통과하고, 실제로 머리말/꼬리말 갈래가 빠져 있었다 — 머리말 편집 중 툴바와
+      // 눈금자가 본문 문단 값을 보여줬다(대화상자는 머리말 값을 정확히 읽는데).
+      const paraProps = this.getParaProperties();
       this.eventBus.emit('cursor-para-changed', paraProps);
 
       // 스타일 드롭다운 갱신용

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -1956,11 +1956,67 @@ export class InputHandler {
   /** 커서 위치 문단에 문단 서식을 적용한다 */
   private applyParaFormat(props: Record<string, unknown>): void {
     try {
+      if (this.applyParaFormatInNoteOrHeader(props)) return;
       const targets = this.getParaFormatTargetsAtCursor();
       this.executeParaFormatCommand(targets, props);
     } catch (err) {
       console.warn('[InputHandler] applyParaFormat 실패:', err);
     }
+  }
+
+  /**
+   * 머리말/꼬리말·각주 문단에 문단 서식을 적용한다. 해당 문맥이 아니면 false.
+   *
+   * 코어에는 `applyParaFormatInHf` / `applyParaFormatInFootnote` 가 이미 있는데 호출하는
+   * 곳이 없었다 — `getParaFormatTargetsForRange` 가 두 문맥에서 빈 배열을 반환해 정렬·줄
+   * 간격이 아무 반응 없이 끝났다. 조회 쪽(`getParaProperties`)은 두 문맥을 정확히 분기하고
+   * 있어 툴바 표시만 맞고 적용은 안 되는 상태였다.
+   *
+   * `ApplyParaFormatCommand` 의 되돌리기는 문단 모양 ID 를 `setParaShapeId` /
+   * `setCellParaShapeId` 로 복원하는데 이 두 문맥용 setter 가 코어에 없다. 되돌리기를
+   * 포기하지 않으려고 표 구조 변경과 같은 스냅샷 경로를 쓴다.
+   * 근본 해결: 코어에 `setParaShapeIdInHf` / `setParaShapeIdInFootnote` 를 추가하고
+   * `ParaFormatTarget` 에 두 갈래를 넣어 네 문맥(본문/셀/머리말/각주)을 한 커맨드로 통일한다.
+   */
+  private applyParaFormatInNoteOrHeader(props: Record<string, unknown>): boolean {
+    const cur = this.cursor;
+    const propsJson = JSON.stringify(props);
+    const cursorBefore = cur.getPosition();
+
+    if (cur.isInHeaderFooter()) {
+      const isHeader = cur.headerFooterMode === 'header';
+      const sectionIdx = cur.hfSectionIdx;
+      const applyTo = cur.hfApplyTo;
+      const hfParaIdx = cur.hfParaIdx;
+      this.executeOperation({
+        kind: 'snapshot',
+        operationType: 'applyParaFormatInHf',
+        operation: (wasm) => {
+          wasm.applyParaFormatInHf(sectionIdx, isHeader, applyTo, hfParaIdx, propsJson);
+          return { ...cursorBefore };
+        },
+      });
+      return true;
+    }
+
+    if (cur.isInFootnote()) {
+      // 인자 축은 조회 쪽(getParaProperties)과 같다 — sec / para / controlIdx / innerParaIdx.
+      const sectionIdx = cur.fnSectionIdx;
+      const paraIdx = cur.fnParaIdx;
+      const controlIdx = cur.fnControlIdx;
+      const innerParaIdx = cur.fnInnerParaIdx;
+      this.executeOperation({
+        kind: 'snapshot',
+        operationType: 'applyParaFormatInFootnote',
+        operation: (wasm) => {
+          wasm.applyParaFormatInFootnote(sectionIdx, paraIdx, controlIdx, innerParaIdx, propsJson);
+          return { ...cursorBefore };
+        },
+      });
+      return true;
+    }
+
+    return false;
   }
 
   private executeParaFormatCommand(targets: ParaFormatTarget[], props: Record<string, unknown>): boolean {

--- a/rhwp-studio/src/engine/table-border-lines.ts
+++ b/rhwp-studio/src/engine/table-border-lines.ts
@@ -1,0 +1,53 @@
+/**
+ * 표 경계선 좌표 병합.
+ *
+ * 셀 bbox 의 좌/우·상/하 좌표를 소수점 1자리로 반올림해 모으면, **한 물리적 경계**를
+ * 공유하는 두 셀의 값이 반올림 경계에 걸쳐 서로 다른 원소로 남는다(관측 예: 셀(0,0) 우측
+ * 299.9 / 셀(0,1) 좌측 299.8). 그러면 같은 경계에 괘선이 둘 생기고, 이웃 괘선으로 드래그
+ * 범위를 정하는 쪽에서 자기 자신을 이웃으로 잡아 범위가 뒤집힌다.
+ *
+ * 임계 이내로 붙은 좌표를 하나로 묶고, **묶여 사라진 좌표도 대표 인덱스를 가리키는 맵**을
+ * 함께 돌려준다. 맵이 없으면 hit-test 가 자기 좌표로 인덱스를 되찾지 못해 그 셀의 경계가
+ * 잡히지 않는다.
+ */
+
+/**
+ * 같은 경계로 볼 좌표 간 거리 상한(px, 줌 적용 전 페이지 좌표).
+ *
+ * 최소 셀 크기가 MIN_TABLE_CELL_SIZE_HWP=200(= 2.67px)이므로 1.0px 는 실제로 떨어진 두
+ * 경계를 삼키지 않는다. 실제 반올림 오차는 0.1px 수준이라 여유가 충분하다.
+ */
+export const BORDER_LINE_MERGE_EPS_PX = 1.0;
+
+export type MergedBorderCoords = {
+  /** 병합 후 대표 좌표 (오름차순). 각 그룹의 최솟값을 쓴다. */
+  positions: number[];
+  /** 병합 **전** 반올림 좌표 → 대표 좌표의 인덱스. 그룹의 모든 좌표가 들어 있다. */
+  indexByCoord: Map<number, number>;
+};
+
+/**
+ * 임계 이내로 붙은 좌표들을 하나의 경계선으로 묶는다.
+ *
+ * 그룹 판정은 **그룹 대표(첫 좌표)와의 거리**로 한다. 직전 좌표와의 거리로 이으면
+ * 0.9px 씩 이어진 사슬이 임계를 넘어 커지면서 실제로 떨어진 경계까지 삼킬 수 있다.
+ * 대표 기준이면 한 그룹의 폭이 eps 를 넘지 않는다.
+ */
+export function mergeBorderCoords(
+  roundedCoords: Iterable<number>,
+  eps: number = BORDER_LINE_MERGE_EPS_PX,
+): MergedBorderCoords {
+  const sorted = [...new Set(roundedCoords)].sort((a, b) => a - b);
+  const positions: number[] = [];
+  const indexByCoord = new Map<number, number>();
+
+  for (const coord of sorted) {
+    const representative = positions[positions.length - 1];
+    if (representative === undefined || coord - representative > eps) {
+      positions.push(coord);
+    }
+    indexByCoord.set(coord, positions.length - 1);
+  }
+
+  return { positions, indexByCoord };
+}

--- a/rhwp-studio/src/engine/table-resize-renderer.ts
+++ b/rhwp-studio/src/engine/table-resize-renderer.ts
@@ -1,5 +1,6 @@
 import { VirtualScroll } from '@/view/virtual-scroll';
 import type { CellBbox } from '@/core/types';
+import { mergeBorderCoords } from './table-border-lines';
 
 /** 경계선 종류 */
 export type BorderEdgeType = 'row' | 'col';
@@ -35,9 +36,22 @@ export class TableResizeRenderer {
     }
   }
 
-  /** 셀 bbox 배열에서 행/열 경계선 좌표를 계산한다 (페이지 좌표 기준) */
-  computeBorderLines(bboxes: CellBbox[]): { rowLines: RowLine[]; colLines: ColLine[] } {
-    if (bboxes.length === 0) return { rowLines: [], colLines: [] };
+  /**
+   * 셀 bbox 배열에서 행/열 경계선 좌표를 계산한다 (페이지 좌표 기준).
+   *
+   * rowIndexByY/colIndexByX 는 병합 **전** 반올림 좌표에서 대표 괘선 인덱스를 찾는 맵이다.
+   * 셀 좌표로 인덱스를 되찾는 쪽(hitTestBorder)은 반드시 이 맵을 써야 한다 — 괘선 목록의
+   * 대표 좌표만으로 맵을 다시 만들면, 병합돼 사라진 좌표를 가진 셀의 경계를 못 찾는다.
+   */
+  computeBorderLines(bboxes: CellBbox[]): {
+    rowLines: RowLine[];
+    colLines: ColLine[];
+    rowIndexByY: Map<number, number>;
+    colIndexByX: Map<number, number>;
+  } {
+    if (bboxes.length === 0) {
+      return { rowLines: [], colLines: [], rowIndexByY: new Map(), colIndexByX: new Map() };
+    }
 
     // 표 전체 범위
     let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
@@ -48,12 +62,6 @@ export class TableResizeRenderer {
       maxY = Math.max(maxY, b.y + b.h);
     }
 
-    // 행 경계선 (수평): 셀 상단/하단 y 좌표 수집
-    const rowYSet = new Map<number, number>(); // y(rounded) → index
-    // 열 경계선 (수직): 셀 좌측/우측 x 좌표 수집
-    const colXSet = new Map<number, number>(); // x(rounded) → index
-
-    // 표 상단/하단, 좌측/우측 추가
     const ry = (v: number) => Math.round(v * 10) / 10; // 소수점 1자리 반올림
 
     // 모든 셀의 상/하단, 좌/우측 좌표 수집
@@ -66,19 +74,24 @@ export class TableResizeRenderer {
       colXs.add(ry(b.x + b.w));
     }
 
-    // 정렬하여 인덱스 부여
-    const sortedRowYs = [...rowYs].sort((a, b) => a - b);
-    const sortedColXs = [...colXs].sort((a, b) => a - b);
+    // 반올림 경계에 걸쳐 갈라진 같은 경계를 하나로 묶는다.
+    const rows = mergeBorderCoords(rowYs);
+    const cols = mergeBorderCoords(colXs);
 
-    const rowLines: RowLine[] = sortedRowYs.map((y, i) => ({
+    const rowLines: RowLine[] = rows.positions.map((y, i) => ({
       y, xStart: minX, xEnd: maxX, index: i,
     }));
 
-    const colLines: ColLine[] = sortedColXs.map((x, i) => ({
+    const colLines: ColLine[] = cols.positions.map((x, i) => ({
       x, yStart: minY, yEnd: maxY, index: i,
     }));
 
-    return { rowLines, colLines };
+    return {
+      rowLines,
+      colLines,
+      rowIndexByY: rows.indexByCoord,
+      colIndexByX: cols.indexByCoord,
+    };
   }
 
   /** 마우스 좌표가 경계선 위인지 판별한다 (페이지 좌표 기준) */
@@ -89,11 +102,11 @@ export class TableResizeRenderer {
   ): BorderEdge | null {
     if (bboxes.length === 0) return null;
 
-    const { rowLines, colLines } = this.computeBorderLines(bboxes);
+    // 인덱스 맵은 반드시 computeBorderLines 가 준 것을 쓴다. 괘선 목록의 대표 좌표로
+    // 다시 만들면 병합돼 사라진 좌표를 가진 셀의 경계가 잡히지 않는다.
+    const { rowIndexByY, colIndexByX } = this.computeBorderLines(bboxes);
     const pageIndex = bboxes[0].pageIndex;
     const rounded = (v: number) => Math.round(v * 10) / 10;
-    const rowIndexByY = new Map(rowLines.map(line => [rounded(line.y), line.index]));
-    const colIndexByX = new Map(colLines.map(line => [rounded(line.x), line.index]));
 
     const candidates: Array<{ edge: BorderEdge; distance: number; priority: number }> = [];
 

--- a/rhwp-studio/src/ui/toolbar.ts
+++ b/rhwp-studio/src/ui/toolbar.ts
@@ -569,7 +569,13 @@ export class Toolbar {
       const val = Math.round(props.lineSpacing);
       this.ensureLsOption(val);
       this.lsSelect.value = String(val);
+      return;
     }
+    // 백분율이 아닌 줄 간격(고정 값/최소/여백만 지정)은 이 백분율 목록으로 표현할 수 없다.
+    // 직전 문단의 값을 남겨 두면 두 가지가 함께 깨진다 — 표시가 실제와 어긋나고, 사용자가
+    // 그 표시값과 같은 항목을 고르면 select 의 change 가 발화하지 않아(핸들러가 change 에
+    // 달려 있다) "눌러도 안 먹고 여러 번 눌러야 반영되는" 상태가 된다. 비워서 둘 다 막는다.
+    this.lsSelect.selectedIndex = -1;
   }
 
   /** 커서 위치의 스타일을 드롭다운에 반영한다 */

--- a/rhwp-studio/tests/cursor-para-changed-reader.test.ts
+++ b/rhwp-studio/tests/cursor-para-changed-reader.test.ts
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// "커서 위치의 문단 속성"을 읽는 곳이 둘이었다.
+//   - getParaProperties()      — 문단 모양 대화상자용. 머리말/각주/셀/본문 4문맥.
+//   - cursor-para-changed 발행 — 툴바·눈금자용.      각주/셀/본문 3문맥 (머리말 누락).
+// 갈래를 따로 두면 문맥이 하나 빠져도 컴파일이 통과한다. 실제로 머리말 편집 중 툴바가
+// 본문 문단 값을 보여줬다.
+//
+// 실측 (headless Chrome, 본문 300% / 머리말 100%):
+//   대화상자가 읽는 값 100  vs  툴바 표시 300
+// 그 상태에서 사용자가 300을 고르면 select 값이 그대로라 change 가 발화하지 않아
+// (toolbar.ts 의 핸들러는 'change' 에 달려 있다) 아무 일도 일어나지 않는다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const source = (path: string): string => readFileSync(join(rootDir, path), 'utf8');
+
+function paraChangedEmitBlock(): string {
+  const ih = source('src/engine/input-handler.ts');
+  const start = ih.indexOf('// 문단 속성 (눈금자 마커용) + 스타일');
+  assert.notEqual(start, -1, '문단 속성 발행 블록을 찾지 못했다');
+  const end = ih.indexOf("this.eventBus.emit('cursor-para-changed'", start);
+  assert.notEqual(end, -1, 'cursor-para-changed 발행을 찾지 못했다');
+  return ih.slice(start, end);
+}
+
+test('cursor-para-changed 는 대화상자와 같은 리더를 쓴다', () => {
+  const block = paraChangedEmitBlock();
+  assert.match(block, /const paraProps = this\.getParaProperties\(\)/,
+    '문단 속성 리더를 따로 구현하고 있다');
+});
+
+test('cursor-para-changed 는 문맥 갈래를 자체 구현하지 않는다', () => {
+  // 자체 갈래가 남아 있으면 문맥이 추가될 때 또 한쪽만 갱신된다.
+  const block = paraChangedEmitBlock();
+  assert.doesNotMatch(block, /this\.wasm\.getParaPropertiesAt\(/,
+    '본문 갈래를 발행 블록이 직접 호출한다');
+  assert.doesNotMatch(block, /this\.wasm\.getCellParaPropertiesAt\(/,
+    '셀 갈래를 발행 블록이 직접 호출한다');
+  assert.doesNotMatch(block, /this\.wasm\.getParaPropertiesInFootnote\(/,
+    '각주 갈래를 발행 블록이 직접 호출한다');
+});
+
+test('문단 속성 리더는 네 문맥을 모두 덮는다', () => {
+  const ih = source('src/engine/input-handler.ts');
+  const start = ih.indexOf('getParaProperties(): ParaProperties {');
+  assert.notEqual(start, -1, 'getParaProperties 를 찾지 못했다');
+  const body = ih.slice(start, ih.indexOf('\n  }', start));
+
+  assert.match(body, /this\.cursor\.isInHeaderFooter\(\)/, '머리말/꼬리말 문맥이 없다');
+  assert.match(body, /getParaPropertiesInHf\(/, '머리말/꼬리말 조회가 없다');
+  assert.match(body, /this\.cursor\.isInFootnote\(\)/, '각주 문맥이 없다');
+  assert.match(body, /getParaPropertiesInFootnote\(/, '각주 조회가 없다');
+  assert.match(body, /getCellParaPropertiesAt\(/, '셀 조회가 없다');
+  assert.match(body, /getParaPropertiesAt\(/, '본문 조회가 없다');
+});

--- a/rhwp-studio/tests/mutation-routing-guard.test.ts
+++ b/rhwp-studio/tests/mutation-routing-guard.test.ts
@@ -210,7 +210,7 @@ const BASELINE: Readonly<Record<string, number>> = {
   'src/ui/table-cell-props-dialog.ts': 2,
   'src/ui/toolbar.ts': 4,
   // engine/input-handler* — 드래그/nudge 등 직접-뮤테이션 최고밀도 영역.
-  'src/engine/input-handler.ts': 28, // +1: 누름틀 제거 이관 시 removeFieldAt 이 양식모드(직접 유지)/일반모드(snapshot) 두 분기로 분리 / +1: Edit 오버레이 커밋이 셀 내부는 setFormValueInCell 로 분기(CheckBox 와 동일 조건 — 기존 flat 호출은 표 컨트롤 슬롯을 가리켜 실패) / +1: 셀 블록 글자 서식이 applyCharFormatInCell 을 executeOperation snapshot 안에서 호출(여러 셀에 걸친 글자 서식 커맨드 부재)
+  'src/engine/input-handler.ts': 30, // +1: 누름틀 제거 이관 시 removeFieldAt 이 양식모드(직접 유지)/일반모드(snapshot) 두 분기로 분리 / +1: Edit 오버레이 커밋이 셀 내부는 setFormValueInCell 로 분기(CheckBox 와 동일 조건 — 기존 flat 호출은 표 컨트롤 슬롯을 가리켜 실패) / +1: 셀 블록 글자 서식이 applyCharFormatInCell 을 executeOperation snapshot 안에서 호출(여러 셀에 걸친 글자 서식 커맨드 부재) / +2: 머리말·꼬리말(applyParaFormatInHf)과 각주(applyParaFormatInFootnote) 문단 서식 배선 — 둘 다 snapshot 라우팅
   'src/engine/input-handler-connector.ts': 1,
   'src/engine/input-handler-keyboard.ts': 21,
   'src/engine/input-handler-mouse.ts': 3,

--- a/rhwp-studio/tests/note-header-para-format-wiring.test.ts
+++ b/rhwp-studio/tests/note-header-para-format-wiring.test.ts
@@ -1,0 +1,103 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// 머리말/꼬리말·각주 문단 서식이 "구현은 됐는데 아무도 안 부르는" 상태로 되돌아가는 것을
+// 막는다.
+//
+// 결함 형태: 코어에 applyParaFormatInHf / applyParaFormatInFootnote 가 있고 브리지에도
+// 노출돼 있는데 호출부가 0곳이었다. getParaFormatTargetsForRange 가 두 문맥에서 빈 배열을
+// 반환해, 정렬·줄 간격을 눌러도 아무 반응 없이 끝났다. 조회 쪽(getParaProperties)은 두
+// 문맥을 정확히 분기하고 있어서 툴바 표시만 맞고 적용은 안 되는 비대칭이었다.
+//
+// 그래서 "브리지에 있는 쓰기 API 가 실제로 호출되는가"를 직접 센다. 호출부가 사라지면
+// (이 결함의 재발 형태) 실패한다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(rel: string): string {
+  return readFileSync(join(rootDir, rel), 'utf8');
+}
+
+/** src/ 아래 .ts 전수 (테스트 제외). */
+function sourceFiles(): string[] {
+  const out: string[] = [];
+  const walk = (rel: string) => {
+    for (const ent of readdirSync(join(rootDir, rel), { withFileTypes: true })) {
+      const child = `${rel}/${ent.name}`;
+      if (ent.isDirectory()) walk(child);
+      else if (ent.name.endsWith('.ts') && !ent.name.endsWith('.test.ts')) out.push(child);
+    }
+  };
+  walk('src');
+  return out;
+}
+
+/** 브리지 정의와 뮤테이션 레지스트리 등재는 "호출"이 아니다. */
+const NOT_A_CALL_SITE = new Set([
+  'src/core/wasm-bridge.ts',
+  'src/core/mutation-method-registry.ts',
+]);
+
+function callSites(method: string): string[] {
+  const re = new RegExp(`\\.\\s*${method}\\s*\\(`);
+  return sourceFiles()
+    .filter(rel => !NOT_A_CALL_SITE.has(rel))
+    .filter(rel => re.test(source(rel)));
+}
+
+for (const method of ['applyParaFormatInHf', 'applyParaFormatInFootnote']) {
+  test(`${method} 는 호출되는 코드가 있어야 한다`, () => {
+    const sites = callSites(method);
+    assert.ok(
+      sites.length > 0,
+      `${method} 가 브리지에만 있고 호출부가 없다 — 머리말/꼬리말·각주에서 문단 서식이 `
+        + `아무 반응 없이 끝난다. getParaProperties 는 두 문맥을 분기하므로 툴바 표시만 `
+        + `맞고 적용은 안 되는 비대칭이 된다.`,
+    );
+  });
+}
+
+test('문단 서식 진입점이 머리말/꼬리말과 각주를 모두 분기한다', () => {
+  const src = source('src/engine/input-handler.ts');
+  const start = src.indexOf('private applyParaFormatInNoteOrHeader');
+  assert.notEqual(start, -1, 'applyParaFormatInNoteOrHeader 를 찾지 못함');
+  const end = src.indexOf('\n  private ', start + 1);
+  const block = src.slice(start, end === -1 ? undefined : end);
+
+  // 한쪽만 배선하면(이 결함의 부분 수정 형태) 실패한다.
+  assert.match(block, /isInHeaderFooter\(\)/);
+  assert.match(block, /applyParaFormatInHf\(/);
+  assert.match(block, /isInFootnote\(\)/);
+  assert.match(block, /applyParaFormatInFootnote\(/);
+});
+
+test('문단 서식 진입점이 그 분기를 실제로 호출한다', () => {
+  // 분기 메서드가 있어도 진입점에서 부르지 않으면 결함은 그대로다.
+  // (이 단언 없이는 진입점 호출을 지워도 테스트가 통과했다.)
+  const src = source('src/engine/input-handler.ts');
+  const start = src.indexOf('private applyParaFormat(props: Record<string, unknown>): void {');
+  assert.notEqual(start, -1, 'applyParaFormat 진입점을 찾지 못함');
+  const end = src.indexOf('\n  private ', start + 1);
+  const entry = src.slice(start, end === -1 ? undefined : end);
+
+  assert.match(
+    entry,
+    /this\.applyParaFormatInNoteOrHeader\(props\)/,
+    'applyParaFormat 이 머리말/꼬리말·각주 분기를 호출하지 않는다 — 분기가 도달 불가라 '
+      + '정렬·줄 간격이 여전히 무반응이다.',
+  );
+});
+
+test('되돌리기 라우팅을 거친다 (executeOperation 경유)', () => {
+  const src = source('src/engine/input-handler.ts');
+  const start = src.indexOf('private applyParaFormatInNoteOrHeader');
+  const end = src.indexOf('\n  private ', start + 1);
+  const block = src.slice(start, end === -1 ? undefined : end);
+
+  // 직접 wasm 을 부르면 undo 에 안 남고 redo 스택도 무효화되지 않는다 (#2327).
+  const executeOperationCount = [...block.matchAll(/this\.executeOperation\(/g)].length;
+  assert.equal(executeOperationCount, 2, '머리말/꼬리말과 각주 각각 executeOperation 을 거쳐야 한다');
+});

--- a/rhwp-studio/tests/note-header-para-format-wiring.test.ts
+++ b/rhwp-studio/tests/note-header-para-format-wiring.test.ts
@@ -101,3 +101,26 @@ test('되돌리기 라우팅을 거친다 (executeOperation 경유)', () => {
   const executeOperationCount = [...block.matchAll(/this\.executeOperation\(/g)].length;
   assert.equal(executeOperationCount, 2, '머리말/꼬리말과 각주 각각 executeOperation 을 거쳐야 한다');
 });
+
+test('스냅샷 되돌리기 뒤에도 머리말/꼬리말·각주 편집 문맥을 복원한다', () => {
+  const inputHandler = source('src/engine/input-handler.ts');
+  const command = source('src/engine/command.ts');
+  const start = inputHandler.indexOf('private applyParaFormatInNoteOrHeader');
+  const end = inputHandler.indexOf('\n  private ', start + 1);
+  const block = inputHandler.slice(start, end === -1 ? undefined : end);
+
+  // SnapshotCommand 는 컨텍스트가 없으면 undo/redo에서 본문 명령으로 취급해 HF/FN 모드를
+  // 빠져나간다. 두 갈래 모두 현재 커서 문맥을 descriptor에 넘겨야 한다.
+  assert.match(block, /operationType: 'applyParaFormatInHf',[\s\S]*?editContext: \{[\s\S]*?mode: 'headerFooter'/);
+  assert.match(block, /operationType: 'applyParaFormatInFootnote',[\s\S]*?editContext: \{[\s\S]*?mode: 'footnote'/);
+  assert.match(
+    command,
+    /editContext\?: EditContext;[\s\S]*?export class SubmodeSnapshotCommand extends SnapshotCommand[\s\S]*?editContext\(\): EditContext \{ return this\.context; \}/,
+    '서브모드 전용 snapshot 명령이 descriptor의 HF/FN 문맥을 undo/redo 복원 경로로 노출해야 한다',
+  );
+  assert.match(
+    inputHandler,
+    /desc\.editContext[\s\S]*?new SubmodeSnapshotCommand\(/,
+    'HF/FN 문맥을 가진 snapshot은 일반 SnapshotCommand 대신 전용 명령을 써야 한다',
+  );
+});

--- a/rhwp-studio/tests/table-border-lines.test.ts
+++ b/rhwp-studio/tests/table-border-lines.test.ts
@@ -1,0 +1,113 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mergeBorderCoords, BORDER_LINE_MERGE_EPS_PX } from '../src/engine/table-border-lines.ts';
+
+// 셀 bbox 좌표를 소수점 1자리로 반올림해 모으면, 한 물리적 경계를 공유하는 두 셀의 값이
+// 반올림 경계에 걸쳐 서로 다른 원소로 남는다.
+//
+// 실측 (3x3 표, 새 문서, 100% 줌): 셀(0,0) 우측 299.9 / 셀(0,1) 좌측 299.8 → 괘선 2개.
+// 이웃 괘선으로 드래그 범위를 정하는 쪽이 자기 자신을 이웃으로 잡아 범위가 뒤집힌다.
+//   아래쪽 인덱스(299.8): max 297.2 < cur  → 오른쪽으로 못 감
+//   위쪽 인덱스(299.9): min 302.5 > cur    → 왼쪽으로 못 감
+// 어느 인덱스를 잡느냐는 hitTestBorder 의 후보 정렬에 달려 있어 방향이 갈린다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const source = (path: string): string => readFileSync(join(rootDir, path), 'utf8');
+
+/** 최소 셀 크기 (MIN_TABLE_CELL_SIZE_HWP=200 → px) */
+const MIN_CELL_PX = 200 / 75;
+
+test('반올림 경계에 걸쳐 갈라진 같은 경계를 하나로 묶는다', () => {
+  // 실측 좌표: 113.4 / 299.8 / 299.9 / 486.3
+  const { positions } = mergeBorderCoords([113.4, 299.8, 299.9, 486.3]);
+  assert.deepEqual(positions, [113.4, 299.8, 486.3]);
+});
+
+test('묶여 사라진 좌표도 대표 괘선 인덱스를 가리킨다', () => {
+  // 이 맵이 없으면 자기 좌표로 인덱스를 되찾는 셀의 경계가 hit-test 에서 사라진다.
+  const { indexByCoord } = mergeBorderCoords([113.4, 299.8, 299.9, 486.3]);
+  assert.equal(indexByCoord.get(299.8), 1);
+  assert.equal(indexByCoord.get(299.9), 1, '병합된 좌표가 대표 인덱스를 못 찾는다');
+  assert.equal(indexByCoord.get(113.4), 0);
+  assert.equal(indexByCoord.get(486.3), 2);
+});
+
+test('최소 셀 크기만큼 떨어진 두 경계는 묶이지 않는다', () => {
+  // 임계(1.0px)가 최소 셀 크기(2.67px)보다 작아야 실제로 떨어진 경계를 삼키지 않는다.
+  assert.ok(BORDER_LINE_MERGE_EPS_PX < MIN_CELL_PX,
+    `임계 ${BORDER_LINE_MERGE_EPS_PX}px 가 최소 셀 크기 ${MIN_CELL_PX}px 이상이다`);
+  const { positions } = mergeBorderCoords([100, 100 + MIN_CELL_PX]);
+  assert.equal(positions.length, 2, '실제로 떨어진 두 경계를 삼켰다');
+});
+
+test('임계를 넘는 좌표는 묶이지 않는다', () => {
+  const { positions } = mergeBorderCoords([100, 101.5]);
+  assert.deepEqual(positions, [100, 101.5]);
+});
+
+test('한 괘선으로 묶이는 좌표들의 폭은 임계를 넘지 않는다', () => {
+  // 직전 좌표와의 거리로 이으면 0.9px 씩 이어진 사슬이 계속 자라 최소 셀 크기(2.67px)를
+  // 삼킨다. 그룹 판정은 대표(그룹 첫 좌표) 기준이어야 폭이 임계로 묶인다.
+  const coords = [100, 100.9, 101.8, 102.7, 103.6, 104.5];
+  const { indexByCoord } = mergeBorderCoords(coords);
+
+  const spanByIndex = new Map<number, { min: number; max: number }>();
+  for (const c of coords) {
+    const i = indexByCoord.get(c)!;
+    const cur = spanByIndex.get(i);
+    if (!cur) spanByIndex.set(i, { min: c, max: c });
+    else spanByIndex.set(i, { min: Math.min(cur.min, c), max: Math.max(cur.max, c) });
+  }
+
+  for (const [i, { min, max }] of spanByIndex) {
+    const span = Math.round((max - min) * 1000) / 1000;
+    assert.ok(span <= BORDER_LINE_MERGE_EPS_PX,
+      `괘선 ${i} 의 폭 ${span}px 가 임계 ${BORDER_LINE_MERGE_EPS_PX}px 를 넘었다 (사슬 병합)`);
+    assert.ok(span < MIN_CELL_PX,
+      `괘선 ${i} 의 폭 ${span}px 가 최소 셀 크기 ${MIN_CELL_PX}px 이상 — 셀 하나를 삼켰다`);
+  }
+});
+
+test('빈 입력과 단일 좌표를 처리한다', () => {
+  assert.deepEqual(mergeBorderCoords([]).positions, []);
+  const one = mergeBorderCoords([42.5]);
+  assert.deepEqual(one.positions, [42.5]);
+  assert.equal(one.indexByCoord.get(42.5), 0);
+});
+
+test('입력 순서와 무관하게 같은 결과를 낸다', () => {
+  const a = mergeBorderCoords([486.3, 299.9, 113.4, 299.8]);
+  assert.deepEqual(a.positions, [113.4, 299.8, 486.3]);
+  assert.equal(a.indexByCoord.get(299.9), 1);
+});
+
+test('hitTestBorder 는 computeBorderLines 가 준 인덱스 맵을 쓴다', () => {
+  // 괘선 목록의 대표 좌표로 맵을 다시 만들면 병합돼 사라진 좌표가 빠져,
+  // 그 좌표를 가진 셀의 경계가 잡히지 않는다.
+  const renderer = source('src/engine/table-resize-renderer.ts');
+  const start = renderer.indexOf('hitTestBorder(');
+  assert.notEqual(start, -1, 'hitTestBorder 를 찾지 못했다');
+  const body = renderer.slice(start, renderer.indexOf('\n  /** 경계선 위에 마커', start));
+
+  assert.match(body, /const \{ rowIndexByY, colIndexByX \} = this\.computeBorderLines\(bboxes\)/,
+    'computeBorderLines 의 인덱스 맵을 쓰지 않는다');
+  assert.doesNotMatch(body, /new Map\(rowLines\.map/,
+    '괘선 목록에서 인덱스 맵을 재조립한다');
+  assert.doesNotMatch(body, /new Map\(colLines\.map/,
+    '괘선 목록에서 인덱스 맵을 재조립한다');
+});
+
+test('computeBorderLines 는 병합을 거친다', () => {
+  const renderer = source('src/engine/table-resize-renderer.ts');
+  const start = renderer.indexOf('computeBorderLines(bboxes: CellBbox[])');
+  assert.notEqual(start, -1, 'computeBorderLines 를 찾지 못했다');
+  const body = renderer.slice(start, renderer.indexOf('\n  /** 마우스 좌표가', start));
+
+  assert.match(body, /mergeBorderCoords\(rowYs\)/, '행 좌표를 병합하지 않는다');
+  assert.match(body, /mergeBorderCoords\(colXs\)/, '열 좌표를 병합하지 않는다');
+  assert.match(body, /rowIndexByY: rows\.indexByCoord/, '행 인덱스 맵을 돌려주지 않는다');
+  assert.match(body, /colIndexByX: cols\.indexByCoord/, '열 인덱스 맵을 돌려주지 않는다');
+});

--- a/rhwp-studio/tests/toolbar-linespacing-sync.test.ts
+++ b/rhwp-studio/tests/toolbar-linespacing-sync.test.ts
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// 툴바 줄 간격은 백분율 전용 목록이다. 문단의 줄 간격 종류는 네 가지이고
+// (Percent / Fixed / SpaceOnly / Minimum — para-shape-dialog.ts 의 LINE_SPACING_TYPES)
+// 문단 모양 대화상자가 넷 다 설정할 수 있다.
+//
+// 백분율이 아닌 문단에서 목록을 그대로 두면 직전 문단의 값이 남아 두 가지가 함께 깨진다.
+//   (1) 표시가 실제와 어긋난다 — 실측: Fixed 13.3 문단에서 "160" 표시
+//   (2) 그 표시값과 같은 항목을 고르면 select 의 change 가 발화하지 않는다.
+//       줄 간격 핸들러는 'change' 에만 달려 있으므로 아무 일도 일어나지 않는다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const source = (path: string): string => readFileSync(join(rootDir, path), 'utf8');
+
+function updateParaStateBody(): string {
+  const toolbar = source('src/ui/toolbar.ts');
+  const start = toolbar.indexOf('private updateParaState(props: ParaProperties): void {');
+  assert.notEqual(start, -1, 'updateParaState 를 찾지 못했다');
+  const end = toolbar.indexOf('\n  }', start);
+  assert.notEqual(end, -1, 'updateParaState 끝을 찾지 못했다');
+  return toolbar.slice(start, end);
+}
+
+test('백분율이 아닌 줄 간격에서는 툴바 목록을 비운다', () => {
+  const body = updateParaStateBody();
+  assert.match(body, /this\.lsSelect\.selectedIndex = -1;/,
+    '백분율이 아닌 문단에서 직전 값이 그대로 남는다');
+});
+
+test('백분율 갈래가 비우기 갈래로 흘러내리지 않는다', () => {
+  // return 이 없으면 방금 맞춘 백분율 값을 곧바로 -1 로 지워 목록이 항상 비어 버린다.
+  const body = updateParaStateBody();
+  assert.match(body, /this\.lsSelect\.value = String\(val\);\s*\n\s*return;/,
+    '백분율 갈래에 return 이 없다');
+});
+
+test('줄 간격 적용은 select 의 change 에 달려 있다', () => {
+  // 이 배선이 change 인 한, 표시값과 원하는 값이 같으면 선택해도 발화하지 않는다.
+  // 위 두 케이스가 막으려는 것이 정확히 그 상태다.
+  const toolbar = source('src/ui/toolbar.ts');
+  const start = toolbar.indexOf('private setupLineSpacingDropdown()');
+  assert.notEqual(start, -1, 'setupLineSpacingDropdown 을 찾지 못했다');
+  const body = toolbar.slice(start, toolbar.indexOf("this.lsSelect.addEventListener('dblclick'", start));
+  assert.match(body, /this\.lsSelect\.addEventListener\('change'/,
+    '줄 간격 적용 배선을 찾지 못했다 — 이 테스트의 전제가 바뀌었다');
+});


### PR DESCRIPTION
## 통합 대상

- #4120: 머리말/꼬리말 문단 상태를 툴바·눈금자에 정확히 반영하고, 비율 이외 줄 간격에서 이전 선택값을 남기지 않습니다.
- #4133: 같은 표 경계를 가리키는 반올림 좌표를 병합해 세로 경계 드래그 범위가 뒤집히는 문제를 해결합니다.
- #4134: 머리말/꼬리말·각주 문단 서식 적용 경로를 연결합니다.

## 메인터너 보정

#4134의 스냅샷 경로는 적용 자체는 가능하지만 Undo/Redo 뒤 편집 문맥을 본문으로 되돌렸습니다. 일반 스냅샷의 기존 본문 복귀 정책은 유지하고, 이 문단 서식 두 경로에만 `SubmodeSnapshotCommand`를 사용해 머리말/꼬리말·각주 편집 문맥을 복원하도록 보정했습니다.

## 검증

- `npx tsc --noEmit`
- `npm test` - 802 passed
- `npm run build`
- headless Chromium: 머리말/각주 줄 간격 적용 → Undo → Redo와 편집 문맥 유지
- headless Chromium: 머리말 줄 간격 툴바 반영, Fixed 줄 간격 선택 해제

Closes #4109