### PR TITLE
ci: mydocs 충돌 해소 병합도 fast-pass 재사용

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,8 +259,7 @@ jobs:
                   ref: sha,
                 });
                 const parents = commit.parents || [];
-                if (reviewOnlyCandidates.length > 0
-                  && isCurrentBaseUpdateMerge(commit, pr.base.sha)) {
+                if (isCurrentBaseUpdateMerge(commit, pr.base.sha)) {
                   if (baseMergeBridge) {
                     setResult(false, `multiple-current-base-update-merges:${sha}`);
                     return;
@@ -328,8 +327,8 @@ jobs:
               setResult(false, 'preflight-error');
             }
 
-      # 기준선 병합을 fast-pass bridge로 쓸 때는 untrusted source를 실행하지 않고,
-      # Git의 자동 3-way merge 결과가 실제 merge tree와 같은지만 확인한다.
+      # 기준선 병합을 fast-pass bridge로 쓸 때는 untrusted source를 실행하지 않는다.
+      # 자동 3-way merge tree가 같거나, 충돌 해소가 mydocs로 한정될 때만 재사용한다.
       - name: Check out current-base merge tree inputs
         id: checkout-base-merge-tree
         if: ${{ steps.detect.outputs.fast_pass == 'pending-base-merge-tree' }}
@@ -364,7 +363,17 @@ jobs:
           fi
 
           if ! expected_tree="$(git merge-tree --write-tree "${SOURCE_PARENT_SHA}" "${CURRENT_BASE_SHA}" 2>/dev/null)"; then
-            fail 'current-base-merge-tree-conflict-or-unavailable'
+            resolution_check="$(mktemp)"
+            trap 'rm -f "${resolution_check}"' EXIT
+            if ! git show "${CURRENT_BASE_SHA}:scripts/verify_review_only_merge_resolution.py" \
+              > "${resolution_check}"; then
+              fail 'current-base-merge-resolution-check-unavailable'
+            elif resolution_reason="$(python3 "${resolution_check}" \
+              --repository . --base-sha "${CURRENT_BASE_SHA}" "${BASE_MERGE_SHA}")"; then
+              printf 'verified=true\nreason=%s\n' "${resolution_reason}" >> "$GITHUB_OUTPUT"
+            else
+              fail 'current-base-merge-resolution-not-mydocs'
+            fi
             exit 0
           fi
           expected_tree="${expected_tree%%$'\n'*}"
@@ -393,7 +402,11 @@ jobs:
           if [[ "${DETECTED_FAST_PASS}" == 'pending-base-merge-tree' ]]; then
             if [[ "${MERGE_TREE_VERIFIED}" == 'true' ]]; then
               fast_pass='true'
-              reason="current-base-update-merge-tree-green:${CANDIDATE_SHA}"
+              if [[ "${MERGE_TREE_REASON}" == 'current-base-merge-resolution-mydocs-only' ]]; then
+                reason="current-base-update-merge-resolution-mydocs-only-green:${CANDIDATE_SHA}"
+              else
+                reason="current-base-update-merge-tree-green:${CANDIDATE_SHA}"
+              fi
             else
               fast_pass='false'
               reason="${MERGE_TREE_REASON}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -244,8 +244,7 @@ jobs:
                   ref: sha,
                 });
                 const parents = commit.parents || [];
-                if (reviewOnlyCandidates.length > 0
-                  && isCurrentBaseUpdateMerge(commit, pr.base.sha)) {
+                if (isCurrentBaseUpdateMerge(commit, pr.base.sha)) {
                   if (baseMergeBridge) {
                     setResult(false, `multiple-current-base-update-merges:${sha}`);
                     return;
@@ -313,8 +312,8 @@ jobs:
               setResult(false, 'preflight-error');
             }
 
-      # 기준선 병합을 fast-pass bridge로 쓸 때는 untrusted source를 실행하지 않고,
-      # Git의 자동 3-way merge 결과가 실제 merge tree와 같은지만 확인한다.
+      # 기준선 병합을 fast-pass bridge로 쓸 때는 untrusted source를 실행하지 않는다.
+      # 자동 3-way merge tree가 같거나, 충돌 해소가 mydocs로 한정될 때만 재사용한다.
       - name: Check out current-base merge tree inputs
         id: checkout-base-merge-tree
         if: ${{ steps.detect.outputs.fast_pass == 'pending-base-merge-tree' }}
@@ -349,7 +348,17 @@ jobs:
           fi
 
           if ! expected_tree="$(git merge-tree --write-tree "${SOURCE_PARENT_SHA}" "${CURRENT_BASE_SHA}" 2>/dev/null)"; then
-            fail 'current-base-merge-tree-conflict-or-unavailable'
+            resolution_check="$(mktemp)"
+            trap 'rm -f "${resolution_check}"' EXIT
+            if ! git show "${CURRENT_BASE_SHA}:scripts/verify_review_only_merge_resolution.py" \
+              > "${resolution_check}"; then
+              fail 'current-base-merge-resolution-check-unavailable'
+            elif resolution_reason="$(python3 "${resolution_check}" \
+              --repository . --base-sha "${CURRENT_BASE_SHA}" "${BASE_MERGE_SHA}")"; then
+              printf 'verified=true\nreason=%s\n' "${resolution_reason}" >> "$GITHUB_OUTPUT"
+            else
+              fail 'current-base-merge-resolution-not-mydocs'
+            fi
             exit 0
           fi
           expected_tree="${expected_tree%%$'\n'*}"
@@ -378,7 +387,11 @@ jobs:
           if [[ "${DETECTED_FAST_PASS}" == 'pending-base-merge-tree' ]]; then
             if [[ "${MERGE_TREE_VERIFIED}" == 'true' ]]; then
               fast_pass='true'
-              reason="current-base-update-merge-tree-green:${CANDIDATE_SHA}"
+              if [[ "${MERGE_TREE_REASON}" == 'current-base-merge-resolution-mydocs-only' ]]; then
+                reason="current-base-update-merge-resolution-mydocs-only-green:${CANDIDATE_SHA}"
+              else
+                reason="current-base-update-merge-tree-green:${CANDIDATE_SHA}"
+              fi
             else
               fast_pass='false'
               reason="${MERGE_TREE_REASON}"

--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -310,38 +310,39 @@ jobs:
 
               codeCandidateSha = sha;
               break;
+            }
 
-              if (reviewOnlyCandidates.length === 0) {
-                setResult(false, 'no-trailing-review-only-commits');
+            if (reviewOnlyCandidates.length === 0) {
+              setResult(false, 'no-trailing-review-only-commits');
+              return;
+            }
+            if (codeCandidateSha) {
+              reviewOnlyCandidates.push(codeCandidateSha);
+            }
+
+            for (const candidateSha of reviewOnlyCandidates) {
+              const result = await renderDiffResult(candidateSha, pr);
+              if (result.state === 'green') {
+                if (baseMergeBridge) {
+                  setPendingBaseMergeResult(
+                    'canvas-visual-diff-success',
+                    candidateSha,
+                    baseMergeBridge.mergeSha,
+                    baseMergeBridge.sourceParentSha,
+                  );
+                  return;
+                }
+                setResult(true, 'canvas-visual-diff-success', candidateSha);
                 return;
               }
-              if (codeCandidateSha) {
-                reviewOnlyCandidates.push(codeCandidateSha);
+              if (result.state === 'failed') {
+                setResult(false, result.reason, candidateSha);
+                return;
               }
+              core.info(`candidate not reusable yet: ${candidateSha} (${result.reason})`);
+            }
 
-              for (const candidateSha of reviewOnlyCandidates) {
-                const result = await renderDiffResult(candidateSha, pr);
-                if (result.state === 'green') {
-                  if (baseMergeBridge) {
-                    setPendingBaseMergeResult(
-                      'canvas-visual-diff-success',
-                      candidateSha,
-                      baseMergeBridge.mergeSha,
-                      baseMergeBridge.sourceParentSha,
-                    );
-                    return;
-                  }
-                  setResult(true, 'canvas-visual-diff-success', candidateSha);
-                  return;
-                }
-                if (result.state === 'failed') {
-                  setResult(false, result.reason, candidateSha);
-                  return;
-                }
-                core.info(`candidate not reusable yet: ${candidateSha} (${result.reason})`);
-              }
-
-              setResult(false, 'no-green-render-candidate');
+            setResult(false, 'no-green-render-candidate');
             } catch (error) {
               core.warning(`Render Diff preflight failed; running full Render Diff. ${error.message}`);
               setResult(false, 'preflight-error');

--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -71,9 +71,9 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      fast_pass: ${{ steps.detect.outputs.fast_pass || 'false' }}
-      reason: ${{ steps.detect.outputs.reason || 'preflight-unavailable' }}
-      candidate_sha: ${{ steps.detect.outputs.candidate_sha || '' }}
+      fast_pass: ${{ steps.finalize.outputs.fast_pass || 'false' }}
+      reason: ${{ steps.finalize.outputs.reason || 'preflight-unavailable' }}
+      candidate_sha: ${{ steps.finalize.outputs.candidate_sha || '' }}
       render_required: ${{ steps.impact.outputs.render_required || 'true' }}
       impact_reason: ${{ steps.impact.outputs.reason || 'fail-closed:impact-unavailable' }}
 
@@ -94,6 +94,18 @@ jobs:
               core.setOutput('reason', reason);
               core.setOutput('candidate_sha', candidateSha);
               core.info(`fast_pass=${fastPass} reason=${reason} candidate_sha=${candidateSha}`);
+            }
+
+            function setPendingBaseMergeResult(reason, candidateSha, mergeSha, sourceParentSha) {
+              core.setOutput('fast_pass', 'pending-base-merge-tree');
+              core.setOutput('reason', reason);
+              core.setOutput('candidate_sha', candidateSha);
+              core.setOutput('base_merge_sha', mergeSha);
+              core.setOutput('source_parent_sha', sourceParentSha);
+              core.info(
+                `fast_pass=pending-base-merge-tree reason=${reason} candidate_sha=${candidateSha} `
+                + `base_merge_sha=${mergeSha} source_parent_sha=${sourceParentSha}`,
+              );
             }
 
             function isAllowedReviewPath(file) {
@@ -128,9 +140,10 @@ jobs:
               return hasReferenceArtifact ? 'review-reference-only' : 'mydocs-only';
             }
 
-            function isCurrentBaseReviewMerge(commit, baseSha) {
+            function isCurrentBaseUpdateMerge(commit, baseSha) {
               const parents = commit.parents || [];
-              return parents.length === 2 && parents.some((parent) => parent.sha === baseSha);
+              return parents.length === 2
+                && parents.filter((parent) => parent.sha === baseSha).length === 1;
             }
 
             function latestRun(runs) {
@@ -255,17 +268,29 @@ jobs:
                 return;
               }
 
-              const reviewOnlyCandidates = [];
-              let codeCandidateSha = '';
+            const reviewOnlyCandidates = [];
+            let codeCandidateSha = '';
+            let baseMergeBridge = null;
 
-              for (let index = commits.length - 1; index >= 0; index -= 1) {
-                const sha = commits[index].sha;
-                const { data: commit } = await github.rest.repos.getCommit({
-                  owner,
-                  repo,
-                  ref: sha,
-                });
-                const files = commit.files || [];
+            for (let index = commits.length - 1; index >= 0; index -= 1) {
+              const sha = commits[index].sha;
+              const { data: commit } = await github.rest.repos.getCommit({
+                owner,
+                repo,
+                ref: sha,
+              });
+              const parents = commit.parents || [];
+              if (isCurrentBaseUpdateMerge(commit, pr.base.sha)) {
+                if (baseMergeBridge) {
+                  setResult(false, `multiple-current-base-update-merges:${sha}`);
+                  return;
+                }
+                const sourceParent = parents.find((parent) => parent.sha !== pr.base.sha);
+                baseMergeBridge = { mergeSha: sha, sourceParentSha: sourceParent.sha };
+                core.info(`including current-base update merge bridge ${sha}`);
+                continue;
+              }
+              const files = commit.files || [];
 
                 // The commit endpoint may truncate very large file lists. Fall back to full Render Diff.
                 if (files.length === 0 || files.length >= 300) {
@@ -273,28 +298,18 @@ jobs:
                   return;
                 }
 
-                const reviewOnly = files.every((file) => isAllowedReviewPath(file));
-                if (reviewOnly) {
-                  const parents = commit.parents || [];
-                  if (parents.length === 1) {
-                    reviewOnlyCandidates.push(sha);
-                    continue;
-                  }
-                  // Keep the narrow Update branch merge compatibility path. It is
-                  // optional: ordinary trailing review-only records do not require it.
-                  if (reviewOnlyCandidates.length > 0
-                    && isCurrentBaseReviewMerge(commit, pr.base.sha)) {
-                    reviewOnlyCandidates.push(sha);
-                    core.info(`including ${reviewOnlyLabel(files)} update-branch merge candidate ${sha}`);
-                    break;
-                  }
-                  setResult(false, `${reviewOnlyLabel(files)}-merge-not-reusable:${sha}`);
-                  return;
+              const reviewOnly = files.every((file) => isAllowedReviewPath(file));
+              if (reviewOnly) {
+                if (parents.length === 1) {
+                  reviewOnlyCandidates.push(sha);
+                  continue;
                 }
-
-                codeCandidateSha = sha;
-                break;
+                setResult(false, `${reviewOnlyLabel(files)}-merge-not-reusable:${sha}`);
+                return;
               }
+
+              codeCandidateSha = sha;
+              break;
 
               if (reviewOnlyCandidates.length === 0) {
                 setResult(false, 'no-trailing-review-only-commits');
@@ -307,6 +322,15 @@ jobs:
               for (const candidateSha of reviewOnlyCandidates) {
                 const result = await renderDiffResult(candidateSha, pr);
                 if (result.state === 'green') {
+                  if (baseMergeBridge) {
+                    setPendingBaseMergeResult(
+                      'canvas-visual-diff-success',
+                      candidateSha,
+                      baseMergeBridge.mergeSha,
+                      baseMergeBridge.sourceParentSha,
+                    );
+                    return;
+                  }
                   setResult(true, 'canvas-visual-diff-success', candidateSha);
                   return;
                 }
@@ -323,11 +347,99 @@ jobs:
               setResult(false, 'preflight-error');
             }
 
+      # 기준선 병합을 fast-pass bridge로 쓸 때는 untrusted source를 실행하지 않는다.
+      # 자동 3-way merge tree가 같거나, 충돌 해소가 mydocs로 한정될 때만 재사용한다.
+      - name: Check out current-base merge tree inputs
+        id: checkout-base-merge-tree
+        if: ${{ steps.detect.outputs.fast_pass == 'pending-base-merge-tree' }}
+        continue-on-error: true
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          fetch-depth: 0
+          lfs: false
+          persist-credentials: false
+
+      - name: Verify current-base merge tree
+        id: verify-base-merge-tree
+        if: ${{ always() && steps.detect.outputs.fast_pass == 'pending-base-merge-tree' }}
+        shell: bash
+        env:
+          BASE_MERGE_SHA: ${{ steps.detect.outputs.base_merge_sha }}
+          SOURCE_PARENT_SHA: ${{ steps.detect.outputs.source_parent_sha }}
+          CURRENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          fail() {
+            printf 'verified=false\nreason=%s\n' "$1" >> "$GITHUB_OUTPUT"
+          }
+
+          if ! git cat-file -e "${BASE_MERGE_SHA}^{commit}" \
+            || ! git cat-file -e "${SOURCE_PARENT_SHA}^{commit}" \
+            || ! git cat-file -e "${CURRENT_BASE_SHA}^{commit}"; then
+            fail 'current-base-merge-input-unavailable'
+            exit 0
+          fi
+
+          if ! expected_tree="$(git merge-tree --write-tree "${SOURCE_PARENT_SHA}" "${CURRENT_BASE_SHA}" 2>/dev/null)"; then
+            resolution_check="$(mktemp)"
+            trap 'rm -f "${resolution_check}"' EXIT
+            if ! git show "${CURRENT_BASE_SHA}:scripts/verify_review_only_merge_resolution.py" \
+              > "${resolution_check}"; then
+              fail 'current-base-merge-resolution-check-unavailable'
+            elif resolution_reason="$(python3 "${resolution_check}" \
+              --repository . --base-sha "${CURRENT_BASE_SHA}" "${BASE_MERGE_SHA}")"; then
+              printf 'verified=true\nreason=%s\n' "${resolution_reason}" >> "$GITHUB_OUTPUT"
+            else
+              fail 'current-base-merge-resolution-not-mydocs'
+            fi
+            exit 0
+          fi
+          expected_tree="${expected_tree%%$'\n'*}"
+          actual_tree="$(git show -s --format=%T "${BASE_MERGE_SHA}")"
+          if [[ "${expected_tree}" != "${actual_tree}" ]]; then
+            fail 'current-base-merge-tree-mismatch'
+            exit 0
+          fi
+
+          printf 'verified=true\nreason=current-base-merge-tree-match\n' >> "$GITHUB_OUTPUT"
+
+      - name: Finalize review-only fast pass
+        id: finalize
+        if: ${{ always() }}
+        shell: bash
+        env:
+          DETECTED_FAST_PASS: ${{ steps.detect.outputs.fast_pass || 'false' }}
+          DETECTED_REASON: ${{ steps.detect.outputs.reason || 'preflight-unavailable' }}
+          CANDIDATE_SHA: ${{ steps.detect.outputs.candidate_sha || '' }}
+          MERGE_TREE_VERIFIED: ${{ steps.verify-base-merge-tree.outputs.verified || 'false' }}
+          MERGE_TREE_REASON: ${{ steps.verify-base-merge-tree.outputs.reason || 'not-required' }}
+        run: |
+          set -euo pipefail
+          fast_pass="${DETECTED_FAST_PASS}"
+          reason="${DETECTED_REASON}"
+          if [[ "${DETECTED_FAST_PASS}" == 'pending-base-merge-tree' ]]; then
+            if [[ "${MERGE_TREE_VERIFIED}" == 'true' ]]; then
+              fast_pass='true'
+              if [[ "${MERGE_TREE_REASON}" == 'current-base-merge-resolution-mydocs-only' ]]; then
+                reason="current-base-update-merge-resolution-mydocs-only-green:${CANDIDATE_SHA}"
+              else
+                reason="current-base-update-merge-tree-green:${CANDIDATE_SHA}"
+              fi
+            else
+              fast_pass='false'
+              reason="${MERGE_TREE_REASON}"
+            fi
+          fi
+          printf 'fast_pass=%s\nreason=%s\ncandidate_sha=%s\n' \
+            "${fast_pass}" "${reason}" "${CANDIDATE_SHA}" >> "$GITHUB_OUTPUT"
+
       # The workflow keeps the broad rhwp-studio/** trigger so the trusted base classifier,
       # rather than a second path heuristic, decides whether the heavy Canvas job is needed.
       - name: Check out trusted CI impact classifier
         id: checkout-impact-classifier
-        if: ${{ steps.detect.outputs.fast_pass != 'true' }}
+        if: ${{ steps.finalize.outputs.fast_pass != 'true' }}
         continue-on-error: true
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -338,7 +450,7 @@ jobs:
 
       - name: Collect Render Diff impact input
         id: collect-impact
-        if: ${{ steps.detect.outputs.fast_pass != 'true' }}
+        if: ${{ steps.finalize.outputs.fast_pass != 'true' }}
         continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
@@ -388,7 +500,7 @@ jobs:
 
       - name: Classify Render Diff impact
         id: impact
-        if: ${{ steps.detect.outputs.fast_pass != 'true' }}
+        if: ${{ steps.finalize.outputs.fast_pass != 'true' }}
         continue-on-error: true
         run: >-
           node scripts/ci-impact-classifier.cjs

--- a/mydocs/manual/pr_review/review_only_fast_pass.md
+++ b/mydocs/manual/pr_review/review_only_fast_pass.md
@@ -2,7 +2,7 @@
 kind: guide
 status: active
 canonical: mydocs/manual/pr_review_workflow.md
-last_verified: 2026-08-06
+last_verified: 2026-08-07
 ---
 
 # Review-only fast-pass
@@ -30,11 +30,13 @@ Update branch, merge, rebase를 수행하지 않는다. 따라서 직전 green P
 
 다음 조건을 모두 만족해야 한다.
 
-1. candidate 이후 current head까지의 review-only commit은 single-parent다.
-2. 예외적으로 source에 이미 current base를 병합한 commit이 있으면, 그 merge는 정확히 2-parent이고
-   parent 하나만 현재 PR base SHA와 같아야 한다. 그 위에 적어도 하나의 single-parent review-only commit이
-   있어야 하며, preflight가 `git merge-tree`로 계산한 자동 3-way merge tree가 실제 merge commit tree와
-   같을 때만 candidate 탐색의 bridge로 쓸 수 있다. 이 확인은 PR source를 실행하지 않는다.
+1. candidate 이후 current head까지의 review-only commit은 single-parent다. 단, current base 병합 bridge는
+   한 번만 예외로 허용한다.
+2. current base 병합 bridge는 정확히 2-parent이고 parent 하나만 현재 PR base SHA와 같아야 한다. preflight가
+   `git merge-tree`로 계산한 자동 3-way merge tree가 실제 merge commit tree와 같으면 그대로 재사용한다.
+   자동 병합이 충돌한 경우에는 `git show --remerge-diff`가 보고하는 **수동 충돌 해소 경로 전체가 `mydocs/`
+   아래일 때만** 재사용한다. source, test, workflow, sample, PDF 등 하나라도 포함되거나 경로를 확인할 수 없으면
+   full CI로 fallback한다. 이 확인은 current base에 있는 검사기를 사용하며 PR source를 실행하지 않는다.
 3. candidate SHA는 현재 PR commit history의 code 후보여야 하며, CI·CodeQL·Render Diff 결과는 같은 PR의
    head branch, source repository, event, candidate SHA와 정확히 일치해야 한다. 현재 base 전진은 단독으로
    재사용 거부 사유가 아니다.
@@ -46,7 +48,8 @@ Update branch, merge, rebase를 수행하지 않는다. 따라서 직전 green P
    heavy worker가 skipped인 것은 정상이나 aggregate가 pending 또는 failing이면 merge하지 않는다.
 
 trailing range에 reviewer가 만든 일반 merge commit이 있으면 fast-pass는 이를 재사용하지 않는다. current base
-병합도 위 자동 merge tree 일치 조건을 만족하는 한 번의 bridge만 예외적으로 허용한다. 이 호환 경로는 문서
+병합만 위 조건을 만족하는 한 번의 bridge로 예외 허용한다. 따라서 마지막 commit이 오늘할일 충돌을 `mydocs/`
+안에서만 해소한 current-base merge여도 같은 PR source의 녹색 candidate를 재사용할 수 있다. 이 호환 경로는 문서
 기록을 위해 source에 `devel`을 병합하라는 절차가 아니다. 일반 절차는 여전히 Update branch, merge, rebase 없이
 review-only commit만 code candidate 위에 잇는다. contributor가 review 도중 source를 갱신한 경우에는 새 source를
 기존 reviewer 기록에 merge하지 말고 [2.6.1 외부 PR review 기록의 source head 정렬](multi_pr_update_branch.md#261-외부-pr-review-기록의-source-head-정렬)을
@@ -75,8 +78,8 @@ all-review-only-no-code-impact fast-pass를 즉시 선택한다. candidate의 �
 - code, test, CI workflow, Cargo.lock 변경
 - 기존 sample, PDF, golden, baseline, fixture의 수정·삭제·rename
 - 허용 목록 밖의 신규 파일
-- A 경로의 candidate workflow 누락·실패·미완료·PR identity 불일치, current-base merge tree 불일치·충돌·조회 실패,
-  또는 허용되지 않은 merge 형태
+- A 경로의 candidate workflow 누락·실패·미완료·PR identity 불일치, current-base merge tree 불일치,
+  `mydocs/` 밖 충돌 해소·해소 경로 조회 실패·복수 base merge 또는 허용되지 않은 merge 형태
 - preflight가 fast_pass=false를 반환
 
 fast-pass는 merge 조건을 없애지 않는다. 최신 head, mergeable 상태, required aggregate, 작업지시자 승인을

--- a/mydocs/manual/pr_review_workflow.md
+++ b/mydocs/manual/pr_review_workflow.md
@@ -157,7 +157,9 @@ source에 없는 archive link를 도입하거나 today add/add 충돌과 불필�
 
 이 방식은 source history를 선형으로 유지하면서, 실제 merge tree에는 최신 `devel`의 기존 오늘 기록과
 현재 PR 기록이 함께 남는지 확인한다. 변경되지 않은 경계를 찾을 수 없거나 simulation이 충돌하면 source에
-`devel`을 억지로 병합하지 말고 작업지시자에게 보고한다.
+`devel`을 억지로 병합하지 말고 작업지시자에게 보고한다. 불가피하게 current base를 병합해 오늘할일 충돌을
+해소한 경우에는 [review-only fast-pass](pr_review/review_only_fast_pass.md)의 `mydocs/` 한정 bridge 검증을
+따르며, source·test·workflow·증적 파일 충돌 해소에는 이 예외를 적용하지 않는다.
 
 ### 3.3 순차로 유지할 일
 

--- a/mydocs/orders/20260807.md
+++ b/mydocs/orders/20260807.md
@@ -9,11 +9,14 @@
   충돌 해소, 경로 조회 실패, 복수 current-base merge는 계속 full CI로 fallback한다. 검사는 PR head가 아닌
   current base tree에서 읽어 실행한다.
 - 실제 [#4136](https://github.com/edwardkim/rhwp/pull/4136)의 today add/add 충돌 merge에서
-  `mydocs/orders/20260807.md` 하나만 수동 해소됐음을 확인했고, 허용·거부 workflow 계약 33건,
+  `mydocs/orders/20260807.md` 하나만 수동 해소됐음을 확인했고, 허용·거부 workflow 계약 34건,
   actionlint, diff check를 통과했다.
-- code head `3ebaf5f2f`의 GitHub CI 전체, CodeQL, Render Diff가 모두 성공했다. 이 review·오늘할일은
-  trailing documentation commit으로 push한 뒤 최신 head의 fast-pass aggregate를 재확인하고,
-  작업지시자 지시에 따라 병합한다.
+- 최초 trailing review 기록에서 Render Diff 후보 결과 조회가 candidate 탐색 반복문 안의 `break` 뒤에
+  남아 Canvas 전체 경로로 떨어지는 제어 흐름 오류를 확인했다. 최종 code head `b1ecf57e9`은 조회를
+  반복문 밖으로 옮기고, 위치 계약과 추출 GitHub Script의 Node 문법 검사를 추가했다.
+- `b1ecf57e9`의 GitHub CI 전체, CodeQL, Render Diff가 모두 성공했다. 이 review·오늘할일은 trailing
+  documentation commit으로 push한 뒤 최신 head의 CI·CodeQL·Render Diff fast-pass aggregate를
+  재확인하고, 작업지시자 지시에 따라 병합한다.
 
 상세 근거: [PR #4173 검토](../pr/archives/pr_4173_review.md).
 

--- a/mydocs/orders/20260807.md
+++ b/mydocs/orders/20260807.md
@@ -1,5 +1,22 @@
 # 오늘 할 일 - 2026년 8월 7일
 
+## PR #4173 - mydocs 충돌 해소 병합의 review-only fast-pass 재사용
+
+- [이슈 #4172](https://github.com/edwardkim/rhwp/issues/4172)의 범위로, current-base merge에서 자동
+  merge tree가 충돌해도 수동 해소 경로 전체가 `mydocs/` 아래이면 같은 PR source의 녹색 candidate를
+  재사용하도록 CI, CodeQL, Render Diff preflight를 보완했다.
+- 병합은 정확히 두 parent이고 current base가 한 parent여야 한다. source·test·workflow·sample·PDF·golden·baseline
+  충돌 해소, 경로 조회 실패, 복수 current-base merge는 계속 full CI로 fallback한다. 검사는 PR head가 아닌
+  current base tree에서 읽어 실행한다.
+- 실제 [#4136](https://github.com/edwardkim/rhwp/pull/4136)의 today add/add 충돌 merge에서
+  `mydocs/orders/20260807.md` 하나만 수동 해소됐음을 확인했고, 허용·거부 workflow 계약 33건,
+  actionlint, diff check를 통과했다.
+- code head `3ebaf5f2f`의 GitHub CI 전체, CodeQL, Render Diff가 모두 성공했다. 이 review·오늘할일은
+  trailing documentation commit으로 push한 뒤 최신 head의 fast-pass aggregate를 재확인하고,
+  작업지시자 지시에 따라 병합한다.
+
+상세 근거: [PR #4173 검토](../pr/archives/pr_4173_review.md).
+
 ## PR #4171 - johndoekim CFB CLSID·HWP3 상대 크기 통합
 
 - [PR #4171](https://github.com/edwardkim/rhwp/pull/4171)에 @johndoekim의 #4144를 먼저, #4160을

--- a/mydocs/pr/archives/pr_4173_review.md
+++ b/mydocs/pr/archives/pr_4173_review.md
@@ -1,0 +1,63 @@
+---
+kind: pr_review
+status: accepted
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-07
+---
+
+# PR #4173 검토 - mydocs 충돌 해소 병합의 review-only fast-pass 재사용
+
+## 대상과 변경 경계
+
+| 항목 | 값 |
+| --- | --- |
+| PR / 작성자 | [#4173](https://github.com/edwardkim/rhwp/pull/4173) / @jangster77 |
+| 연동 이슈 | [#4172](https://github.com/edwardkim/rhwp/issues/4172) |
+| 기준 `devel` | `23ff5b6f1acd67aaccdf1ecfb47a7dc1918a13ed` |
+| code head | `3ebaf5f2ff5165f569f821bb5b5402b95d07ba9b` |
+| 변경 규모 | 7 files, +407 / -63 |
+| 변경 영역 | CI, CodeQL, Render Diff preflight와 review-only fast-pass 문서·계약 테스트 |
+
+이 PR은 `mydocs/` 안의 오늘할일 등만 수동 충돌 해소한 current-base merge를 review-only bridge로
+재사용한다. source, test, workflow, sample, PDF, golden, baseline의 충돌 해소나 복수 current-base
+merge는 기존과 같이 full CI로 fallback한다. renderer·layout·문서 변환 동작 자체는 바꾸지 않는다.
+
+## 검토 근거
+
+[#4136](https://github.com/edwardkim/rhwp/pull/4136)의 마지막 merge
+`ecda0c15e32168dbb21223e7f2446eb9df491455`를 실제로 검사했다. source parent는
+`0762ad241bb21bc720188938fa0d3451bd3d0caa`, current-base parent는
+`9dbd3dc6c49c36e8d1012a19ec60dea1abd5123c`였으며, `git show --remerge-diff`의 수동 해소 경로는
+`mydocs/orders/20260807.md` 하나였다.
+
+새 검사기는 다음을 모두 확인한다.
+
+1. 대상이 정확히 두 parent를 가진 merge이고 current base SHA가 parent 하나와 일치한다.
+2. 자동 3-way merge tree가 일치하면 기존 경로를 유지한다.
+3. 자동 병합 충돌이면 remerge diff의 경로가 비어 있지 않고 모두 `mydocs/` 아래인지 확인한다.
+4. 검사기는 PR head가 아니라 current base tree에서 읽어 실행한다.
+
+따라서 PR source의 검사기 변경으로 판정을 우회하지 않으며, 검사기를 읽을 수 없거나 경로가 하나라도
+허용 범위를 벗어나면 fast-pass를 선택하지 않는다.
+
+## 완료한 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| #4136 실제 merge 검사 | `current-base-merge-resolution-mydocs-only` |
+| 허용·거부 계약 | `scripts/tests/test_review_only_fast_pass_workflows.py` 포함 33 passed |
+| CI workflow 계약 | cache sweep·workflow wiring 테스트 통과 |
+| workflow 문법 | `actionlint`로 CI, CodeQL, Render Diff 통과 |
+| 변경 정합 | `git diff --check` 통과 |
+| GitHub CI | [CI](https://github.com/edwardkim/rhwp/actions/runs/31182605377) 전체 성공 |
+| GitHub 보조 workflow | [CodeQL](https://github.com/edwardkim/rhwp/actions/runs/31182605093), [Render Diff](https://github.com/edwardkim/rhwp/actions/runs/31182605090) 성공 |
+
+이 PR 자체의 current base에는 새 검사기가 아직 없으므로 최초 code head는 의도대로 full CI가 실행됐다.
+이 문서와 오늘할일은 그 성공 head 뒤의 single-parent review-only commit이며, push 뒤 최신 head의
+preflight와 aggregate가 fast-pass로 성공하는지 다시 확인한다.
+
+## 수용 판단
+
+**수용.** 허용 범위는 `mydocs/` 수동 해소로 한정되고, 자동 merge tree가 일치하지 않는 기존 거부 경계는
+완화하지 않았다. 문서 trailing commit의 fast-pass와 최신 merge 가능 상태를 확인하면 작업지시자 지시에 따라
+병합한다.

--- a/mydocs/pr/archives/pr_4173_review.md
+++ b/mydocs/pr/archives/pr_4173_review.md
@@ -14,8 +14,8 @@ last_verified: 2026-08-07
 | PR / 작성자 | [#4173](https://github.com/edwardkim/rhwp/pull/4173) / @jangster77 |
 | 연동 이슈 | [#4172](https://github.com/edwardkim/rhwp/issues/4172) |
 | 기준 `devel` | `23ff5b6f1acd67aaccdf1ecfb47a7dc1918a13ed` |
-| code head | `3ebaf5f2ff5165f569f821bb5b5402b95d07ba9b` |
-| 변경 규모 | 7 files, +407 / -63 |
+| code head | `b1ecf57e9e63a0032f25452aebbca9230ab11e23` |
+| 변경 규모 | 9 files, +531 / -80 |
 | 변경 영역 | CI, CodeQL, Render Diff preflight와 review-only fast-pass 문서·계약 테스트 |
 
 이 PR은 `mydocs/` 안의 오늘할일 등만 수동 충돌 해소한 current-base merge를 review-only bridge로
@@ -40,21 +40,32 @@ merge는 기존과 같이 full CI로 fallback한다. renderer·layout·문서 �
 따라서 PR source의 검사기 변경으로 판정을 우회하지 않으며, 검사기를 읽을 수 없거나 경로가 하나라도
 허용 범위를 벗어나면 fast-pass를 선택하지 않는다.
 
+## 최종 보정
+
+최초 code head 뒤의 review 기록 commit `8930b89b3`은 CI preflight에서 review-only fast-pass를
+선택했지만, Render Diff는 code candidate 결과를 찾지 못해 Canvas 전체 경로를 실행했다. 원인은
+Render Diff의 GitHub Script에서 candidate SHA를 찾은 직후 `break`한 뒤의 결과 조회 코드가 같은
+반복문 안에 남아 도달할 수 없었던 제어 흐름 오류였다.
+
+최종 code head `b1ecf57e9`은 결과 조회를 반복문 밖으로 옮겼다. 또한 계약 테스트는 후보 조회가
+반복문 밖에 있는지 확인하고, 추출한 Render Diff GitHub Script를 Node 문법 검사로 실행해 같은
+배치 오류를 다시 잡도록 보강했다. 이 보정은 review-only 후보 판정 범위를 넓히지 않는다.
+
 ## 완료한 검증
 
 | 검증 | 결과 |
 | --- | --- |
 | #4136 실제 merge 검사 | `current-base-merge-resolution-mydocs-only` |
-| 허용·거부 계약 | `scripts/tests/test_review_only_fast_pass_workflows.py` 포함 33 passed |
+| 허용·거부 계약 | `scripts/tests/test_review_only_fast_pass_workflows.py` 포함 34 passed |
 | CI workflow 계약 | cache sweep·workflow wiring 테스트 통과 |
 | workflow 문법 | `actionlint`로 CI, CodeQL, Render Diff 통과 |
 | 변경 정합 | `git diff --check` 통과 |
-| GitHub CI | [CI](https://github.com/edwardkim/rhwp/actions/runs/31182605377) 전체 성공 |
-| GitHub 보조 workflow | [CodeQL](https://github.com/edwardkim/rhwp/actions/runs/31182605093), [Render Diff](https://github.com/edwardkim/rhwp/actions/runs/31182605090) 성공 |
+| GitHub CI | [CI](https://github.com/edwardkim/rhwp/actions/runs/31184307222) 전체 성공 |
+| GitHub 보조 workflow | [CodeQL](https://github.com/edwardkim/rhwp/actions/runs/31184306396), [Render Diff](https://github.com/edwardkim/rhwp/actions/runs/31184306339) 성공 |
 
-이 PR 자체의 current base에는 새 검사기가 아직 없으므로 최초 code head는 의도대로 full CI가 실행됐다.
+이 PR 자체의 current base에는 새 검사기가 아직 없으므로 최종 code head는 의도대로 full CI가 실행됐다.
 이 문서와 오늘할일은 그 성공 head 뒤의 single-parent review-only commit이며, push 뒤 최신 head의
-preflight와 aggregate가 fast-pass로 성공하는지 다시 확인한다.
+CI·CodeQL·Render Diff preflight와 aggregate가 fast-pass로 성공하는지 다시 확인한다.
 
 ## 수용 판단
 

--- a/scripts/tests/test_review_only_fast_pass_workflows.py
+++ b/scripts/tests/test_review_only_fast_pass_workflows.py
@@ -169,6 +169,32 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
         self.assertIn("renderDiffRun.head_branch !== pr.head.ref", workflow)
         self.assertIn("renderDiffRun.head_repository?.id !== pr.head.repo?.id", workflow)
 
+    def test_render_diff_preflight_keeps_candidate_lookup_outside_commit_loop(self) -> None:
+        workflow = WORKFLOWS["render-diff"].read_text(encoding="utf-8")
+        self.assertIn(
+            "codeCandidateSha = sha;\n"
+            "              break;\n"
+            "            }\n\n"
+            "            if (reviewOnlyCandidates.length === 0)",
+            workflow,
+        )
+
+        script = workflow.split("script: |\n", maxsplit=1)[1].split(
+            "\n      # 기준선 병합을 fast-pass bridge로", maxsplit=1
+        )[0]
+        script = "\n".join(
+            line.removeprefix("            ") for line in script.splitlines()
+        )
+        syntax = subprocess.run(
+            ["node", "--check"],
+            input=f"(async () => {{\n{script}\n}})();\n",
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        self.assertEqual(syntax.returncode, 0, syntax.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_review_only_fast_pass_workflows.py
+++ b/scripts/tests/test_review_only_fast_pass_workflows.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import subprocess
+import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -10,6 +13,7 @@ WORKFLOWS = {
     "codeql": ROOT / ".github/workflows/codeql.yml",
     "render-diff": ROOT / ".github/workflows/render-diff.yml",
 }
+RESOLUTION_CHECK = ROOT / "scripts/verify_review_only_merge_resolution.py"
 
 
 class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
@@ -34,15 +38,23 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
                 self.assertIn("listJobsForWorkflowRun", workflow)
                 self.assertIn("runCreatedAt < pullCreatedAt", workflow)
 
-    def test_current_base_update_merge_requires_an_automatic_merge_tree(self) -> None:
-        for name in ("ci", "codeql"):
+    def test_current_base_update_merge_allows_only_mydocs_conflict_resolution(self) -> None:
+        for name, workflow_path in WORKFLOWS.items():
             with self.subTest(workflow=name):
-                workflow = WORKFLOWS[name].read_text(encoding="utf-8")
+                workflow = workflow_path.read_text(encoding="utf-8")
                 self.assertIn("isCurrentBaseUpdateMerge", workflow)
                 self.assertIn("pending-base-merge-tree", workflow)
                 self.assertIn("multiple-current-base-update-merges", workflow)
                 self.assertIn("git merge-tree --write-tree", workflow)
                 self.assertIn("current-base-merge-tree-mismatch", workflow)
+                self.assertIn("verify_review_only_merge_resolution.py", workflow)
+                self.assertIn(
+                    "${CURRENT_BASE_SHA}:scripts/verify_review_only_merge_resolution.py",
+                    workflow,
+                )
+                self.assertIn("current-base-merge-resolution-check-unavailable", workflow)
+                self.assertIn("current-base-merge-resolution-not-mydocs", workflow)
+                self.assertIn("current-base-update-merge-resolution-mydocs-only-green", workflow)
                 self.assertIn("current-base-update-merge-tree-green", workflow)
                 self.assertIn(
                     "ref: refs/pull/${{ github.event.pull_request.number }}/head",
@@ -50,6 +62,106 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
                 )
                 self.assertIn("lfs: false", workflow)
                 self.assertIn("persist-credentials: false", workflow)
+                self.assertNotIn(
+                    "reviewOnlyCandidates.length > 0\n                  && isCurrentBaseUpdateMerge",
+                    workflow,
+                )
+
+    def test_resolution_checker_accepts_only_mydocs_conflicts(self) -> None:
+        self.assertEqual(
+            self._run_resolution_check("mydocs/orders/20260807.md").returncode,
+            0,
+        )
+        rejected = self._run_resolution_check("src/lib.rs")
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("current-base-merge-resolution-not-mydocs", rejected.stderr)
+        wrong_base = self._run_resolution_check(
+            "mydocs/orders/20260807.md",
+            expected_base_sha="0" * 40,
+        )
+        self.assertNotEqual(wrong_base.returncode, 0)
+        self.assertIn("current-base-merge-resolution-invalid-merge", wrong_base.stderr)
+
+    def _run_resolution_check(
+        self,
+        conflict_path: str,
+        expected_base_sha: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository = Path(temporary_directory)
+            self._git(repository, "init", "--initial-branch=main")
+            self._git(repository, "config", "user.email", "review@example.invalid")
+            self._git(repository, "config", "user.name", "review")
+            (repository / "README.md").write_text("root\n", encoding="utf-8")
+            self._git(repository, "add", "README.md")
+            self._git(repository, "commit", "-m", "root")
+
+            self._git(repository, "switch", "-c", "feature")
+            feature_file = repository / conflict_path
+            feature_file.parent.mkdir(parents=True, exist_ok=True)
+            feature_file.write_text("feature\n", encoding="utf-8")
+            self._git(repository, "add", conflict_path)
+            self._git(repository, "commit", "-m", "feature")
+
+            self._git(repository, "switch", "main")
+            base_file = repository / conflict_path
+            base_file.parent.mkdir(parents=True, exist_ok=True)
+            base_file.write_text("base\n", encoding="utf-8")
+            self._git(repository, "add", conflict_path)
+            self._git(repository, "commit", "-m", "base")
+            base_sha = self._git_output(repository, "rev-parse", "HEAD")
+
+            self._git(repository, "switch", "feature")
+            merge = subprocess.run(
+                ["git", "merge", "main"],
+                cwd=repository,
+                check=False,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            self.assertNotEqual(merge.returncode, 0)
+            feature_file.write_text("base\nfeature\n", encoding="utf-8")
+            self._git(repository, "add", conflict_path)
+            self._git(repository, "commit", "-m", "resolve mydocs conflict")
+
+            return subprocess.run(
+                [
+                    sys.executable,
+                    str(RESOLUTION_CHECK),
+                    "--repository",
+                    str(repository),
+                    "--base-sha",
+                    expected_base_sha or base_sha,
+                    "HEAD",
+                ],
+                check=False,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+    @staticmethod
+    def _git(repository: Path, *arguments: str) -> None:
+        subprocess.run(
+            ["git", *arguments],
+            cwd=repository,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    @staticmethod
+    def _git_output(repository: Path, *arguments: str) -> str:
+        return subprocess.run(
+            ["git", *arguments],
+            cwd=repository,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        ).stdout.strip()
 
     def test_render_diff_keeps_its_existing_pr_identity_guard(self) -> None:
         workflow = WORKFLOWS["render-diff"].read_text(encoding="utf-8")

--- a/scripts/verify_review_only_merge_resolution.py
+++ b/scripts/verify_review_only_merge_resolution.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Validate that a conflicted current-base merge resolved only mydocs paths."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+SAFE_REASON = "current-base-merge-resolution-mydocs-only"
+
+
+def remerge_resolution_paths(repository: Path, merge_sha: str) -> list[str]:
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repository),
+            "show",
+            "--remerge-diff",
+            "--format=",
+            "--name-only",
+            "--no-renames",
+            "-z",
+            merge_sha,
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", "replace").strip()
+        raise RuntimeError(detail or "git show --remerge-diff failed")
+    return [
+        path.decode("utf-8", "surrogateescape")
+        for path in result.stdout.split(b"\0")
+        if path
+    ]
+
+
+def is_current_base_merge(repository: Path, merge_sha: str, base_sha: str) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(repository), "rev-list", "--parents", "-n", "1", merge_sha],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        return False
+    parts = result.stdout.decode("ascii", "replace").split()
+    return len(parts) == 3 and parts[1:].count(base_sha) == 1
+
+
+def is_mydocs_only(paths: list[str]) -> bool:
+    return bool(paths) and all(path.startswith("mydocs/") for path in paths)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", type=Path, required=True)
+    parser.add_argument("--base-sha", required=True)
+    parser.add_argument("merge_sha")
+    args = parser.parse_args()
+
+    if not is_current_base_merge(args.repository, args.merge_sha, args.base_sha):
+        print("current-base-merge-resolution-invalid-merge", file=sys.stderr)
+        return 1
+
+    try:
+        paths = remerge_resolution_paths(args.repository, args.merge_sha)
+    except RuntimeError as error:
+        print(f"current-base-merge-resolution-unavailable: {error}", file=sys.stderr)
+        return 1
+
+    if not paths:
+        print("current-base-merge-resolution-empty", file=sys.stderr)
+        return 1
+    if not is_mydocs_only(paths):
+        print("current-base-merge-resolution-not-mydocs", file=sys.stderr)
+        return 1
+
+    print(SAFE_REASON)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 목적

현재 devel 병합에서 오늘할일 등 mydocs 아래 파일만 수동 충돌 해소한 경우에도, 같은 PR source의 녹색 검증 결과를 review-only fast-pass로 재사용한다.

Closes #4172

## 허용 경계

- current base를 부모로 갖는 merge는 하나만 허용한다.
- 자동 merge tree가 일치하면 기존 경로를 유지한다.
- 자동 병합 충돌 시 git show remerge-diff가 보고하는 수동 해소 경로 전체가 mydocs 아래일 때만 허용한다.
- source, test, workflow, sample, PDF, golden, baseline 또는 복수 current-base merge는 full CI로 fallback한다.

검사기는 PR head가 아닌 current base tree에서 읽어 실행하므로, 이 fast-pass 판정에 PR source 코드를 실행하지 않는다.

## 검증

- review-only fast-pass workflow 계약 테스트
- cache sweep 및 workflow wiring 계약 테스트
- actionlint로 CI, CodeQL, Render Diff workflow 검증
- git diff check
- #4136의 수동 충돌 해소 merge를 실제 검사기로 확인

모두 통과했다.