### PR TITLE
ci: mydocs 충돌 merge의 녹색 source head 재사용

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,13 @@ jobs:
                 && parents.filter((parent) => parent.sha === baseSha).length === 1;
             }
 
+            function isCiExecutionPath(filename) {
+              return filename.startsWith('.github/workflows/')
+                || filename.startsWith('.github/actions/')
+                || filename === 'scripts/ci-impact-classifier.cjs'
+                || filename === 'scripts/verify_review_only_merge_resolution.py';
+            }
+
             function latestRun(runs) {
               return runs
                 .slice()
@@ -244,6 +251,38 @@ jobs:
 
               if (commits.length === 0) {
                 setResult(false, 'no-pr-commits');
+                return;
+              }
+
+              const latestCommitSha = commits.at(-1).sha;
+              const { data: latestCommit } = await github.rest.repos.getCommit({
+                owner,
+                repo,
+                ref: latestCommitSha,
+              });
+              if (isCurrentBaseUpdateMerge(latestCommit, pr.base.sha)) {
+                if (prFiles.some((file) => isCiExecutionPath(file.filename))) {
+                  setResult(false, 'current-base-source-ci-execution-change');
+                  return;
+                }
+                const sourceParent = latestCommit.parents.find(
+                  (parent) => parent.sha !== pr.base.sha,
+                );
+                if (!sourceParent) {
+                  setResult(false, 'current-base-source-parent-unavailable');
+                  return;
+                }
+                const sourceResult = await buildResult(sourceParent.sha, pr);
+                if (sourceResult.state === 'green') {
+                  setPendingBaseMergeResult(
+                    `direct-source-build-and-test-green:${sourceResult.conclusion}`,
+                    sourceParent.sha,
+                    latestCommitSha,
+                    sourceParent.sha,
+                  );
+                  return;
+                }
+                setResult(false, `direct-source-${sourceResult.reason}`, sourceParent.sha);
                 return;
               }
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -131,6 +131,13 @@ jobs:
                 && parents.filter((parent) => parent.sha === baseSha).length === 1;
             }
 
+            function isCiExecutionPath(filename) {
+              return filename.startsWith('.github/workflows/')
+                || filename.startsWith('.github/actions/')
+                || filename === 'scripts/ci-impact-classifier.cjs'
+                || filename === 'scripts/verify_review_only_merge_resolution.py';
+            }
+
             function latestRun(runs) {
               return runs
                 .slice()
@@ -229,6 +236,38 @@ jobs:
 
               if (commits.length === 0) {
                 setResult(false, 'no-pr-commits');
+                return;
+              }
+
+              const latestCommitSha = commits.at(-1).sha;
+              const { data: latestCommit } = await github.rest.repos.getCommit({
+                owner,
+                repo,
+                ref: latestCommitSha,
+              });
+              if (isCurrentBaseUpdateMerge(latestCommit, pr.base.sha)) {
+                if (prFiles.some((file) => isCiExecutionPath(file.filename))) {
+                  setResult(false, 'current-base-source-ci-execution-change');
+                  return;
+                }
+                const sourceParent = latestCommit.parents.find(
+                  (parent) => parent.sha !== pr.base.sha,
+                );
+                if (!sourceParent) {
+                  setResult(false, 'current-base-source-parent-unavailable');
+                  return;
+                }
+                const sourceResult = await codeqlResult(sourceParent.sha, pr);
+                if (sourceResult.state === 'green') {
+                  setPendingBaseMergeResult(
+                    'direct-source-codeql-checks-green',
+                    sourceParent.sha,
+                    latestCommitSha,
+                    sourceParent.sha,
+                  );
+                  return;
+                }
+                setResult(false, `direct-source-${sourceResult.reason}`, sourceParent.sha);
                 return;
               }
 

--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -228,6 +228,12 @@ jobs:
                   reason: `canvas-visual-diff-not-completed:${renderDiffJob.status}`,
                 };
               }
+              if (renderDiffJob.conclusion === 'skipped') {
+                return {
+                  state: 'skipped',
+                  reason: `canvas-visual-diff-skipped:${candidateSha}`,
+                };
+              }
               if (renderDiffJob.conclusion !== 'success') {
                 return {
                   state: 'failed',

--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -146,6 +146,13 @@ jobs:
                 && parents.filter((parent) => parent.sha === baseSha).length === 1;
             }
 
+            function isCiExecutionPath(filename) {
+              return filename.startsWith('.github/workflows/')
+                || filename.startsWith('.github/actions/')
+                || filename === 'scripts/ci-impact-classifier.cjs'
+                || filename === 'scripts/verify_review_only_merge_resolution.py';
+            }
+
             function latestRun(runs) {
               return runs
                 .slice()
@@ -156,7 +163,7 @@ jobs:
                 })[0];
             }
 
-            async function renderDiffResult(candidateSha, pr) {
+            async function renderDiffResult(candidateSha, pr, allowPriorPrBase = false) {
               const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
                 owner,
                 repo,
@@ -228,8 +235,11 @@ jobs:
                 };
               }
               const expectedIdentityStep = `Render Diff identity PR #${pr.number} base ${pr.base.sha}`;
+              const identityPrefix = `Render Diff identity PR #${pr.number} base `;
               const identityStep = (renderDiffJob.steps || []).find((step) => (
-                step.name === expectedIdentityStep
+                allowPriorPrBase
+                  ? step.name.startsWith(identityPrefix)
+                  : step.name === expectedIdentityStep
               ));
               if (identityStep?.status !== 'completed' || identityStep.conclusion !== 'success') {
                 return { state: 'failed', reason: 'canvas-visual-diff-identity-mismatch' };
@@ -265,6 +275,38 @@ jobs:
 
               if (commits.length === 0) {
                 setResult(false, 'no-pr-commits');
+                return;
+              }
+
+              const latestCommitSha = commits.at(-1).sha;
+              const { data: latestCommit } = await github.rest.repos.getCommit({
+                owner,
+                repo,
+                ref: latestCommitSha,
+              });
+              if (isCurrentBaseUpdateMerge(latestCommit, pr.base.sha)) {
+                if (prFiles.some((file) => isCiExecutionPath(file.filename))) {
+                  setResult(false, 'current-base-source-ci-execution-change');
+                  return;
+                }
+                const sourceParent = latestCommit.parents.find(
+                  (parent) => parent.sha !== pr.base.sha,
+                );
+                if (!sourceParent) {
+                  setResult(false, 'current-base-source-parent-unavailable');
+                  return;
+                }
+                const sourceResult = await renderDiffResult(sourceParent.sha, pr, true);
+                if (sourceResult.state === 'green') {
+                  setPendingBaseMergeResult(
+                    'direct-source-canvas-visual-diff-success',
+                    sourceParent.sha,
+                    latestCommitSha,
+                    sourceParent.sha,
+                  );
+                  return;
+                }
+                setResult(false, `direct-source-${sourceResult.reason}`, sourceParent.sha);
                 return;
               }
 

--- a/mydocs/orders/20260807.md
+++ b/mydocs/orders/20260807.md
@@ -13,8 +13,10 @@
   #4170이 이 경계에 해당하며, CI 자체 변경을 review-only 재사용으로 검증하지 않는다.
 - workflow 계약 36건, actionlint, Markdown 링크·diff 검사를 통과했고 code head `8119074ce`의 GitHub CI
   전체, CodeQL, Canvas visual diff도 모두 성공했다.
-- 이 review·오늘할일은 CI 변경 PR의 trailing documentation commit이다. 이 PR에서는 최신 head의 Full
-  CI를 다시 확인하고, 이후 별도의 mydocs-only current-base 병합 PR에서 fast-pass를 실제 재현한다.
+- 이 review·오늘할일 trailing commit `cfe6a1ccc`는 code head `8119074ce`의 녹색 candidate를 재사용해
+  fast-pass됐다. CI·CodeQL·Render Diff preflight와 aggregate는 성공했고 heavy job, CodeQL 분석,
+  Canvas visual diff는 모두 skip됐다. 이후 별도의 mydocs-only current-base 병합 PR에서 direct
+  source-parent와 trusted remerge bridge를 실제 재현한다.
 
 상세 근거: [PR #4177 검토](../pr/archives/pr_4177_review.md).
 

--- a/mydocs/orders/20260807.md
+++ b/mydocs/orders/20260807.md
@@ -15,8 +15,13 @@
   전체, CodeQL, Canvas visual diff도 모두 성공했다.
 - 이 review·오늘할일 trailing commit `cfe6a1ccc`는 code head `8119074ce`의 녹색 candidate를 재사용해
   fast-pass됐다. CI·CodeQL·Render Diff preflight와 aggregate는 성공했고 heavy job, CodeQL 분석,
-  Canvas visual diff는 모두 skip됐다. 이후 별도의 mydocs-only current-base 병합 PR에서 direct
-  source-parent와 trusted remerge bridge를 실제 재현한다.
+  Canvas visual diff는 모두 skip됐다.
+- 후속 문서 정정 `b3d328ce5`에서는 중간 fast-pass 후보의 Canvas `skipped`를 실패로 처리해 이전 실제
+  Canvas 성공 후보까지 탐색하지 않는 오류를 확인했다. Stage 2는 `skipped` 후보를 건너뛰고 같은 PR
+  identity의 더 이전 Canvas 성공 후보를 계속 탐색하도록 보정했다. workflow 계약 37건, actionlint,
+  Markdown 링크·diff 검사를 통과했고 최신 code head의 CI·CodeQL·Render Diff를 다시 확인한다.
+- direct source-parent와 trusted remerge bridge는 사용자가 별도 mydocs-only current-base 병합 PR의 수동
+  conflict resolve로 검증한다.
 
 상세 근거: [PR #4177 검토](../pr/archives/pr_4177_review.md).
 

--- a/mydocs/orders/20260807.md
+++ b/mydocs/orders/20260807.md
@@ -19,7 +19,8 @@
 - 후속 문서 정정 `b3d328ce5`에서는 중간 fast-pass 후보의 Canvas `skipped`를 실패로 처리해 이전 실제
   Canvas 성공 후보까지 탐색하지 않는 오류를 확인했다. Stage 2는 `skipped` 후보를 건너뛰고 같은 PR
   identity의 더 이전 Canvas 성공 후보를 계속 탐색하도록 보정했다. workflow 계약 37건, actionlint,
-  Markdown 링크·diff 검사를 통과했고 최신 code head의 CI·CodeQL·Render Diff를 다시 확인한다.
+  Markdown 링크·diff 검사를 통과했다. code head `f571572a9`의 GitHub CI 전체, CodeQL, Canvas visual
+  diff도 모두 성공했다.
 - direct source-parent와 trusted remerge bridge는 사용자가 별도 mydocs-only current-base 병합 PR의 수동
   conflict resolve로 검증한다.
 

--- a/mydocs/orders/20260807.md
+++ b/mydocs/orders/20260807.md
@@ -1,5 +1,23 @@
 # 오늘 할 일 - 2026년 8월 7일
 
+## PR #4177 - mydocs 충돌 merge의 녹색 source head 재사용
+
+- [이슈 #4176](https://github.com/edwardkim/rhwp/issues/4176)의 범위로, latest current-base merge의 직접
+  source parent가 같은 PR source의 녹색 candidate이면 source parent가 과거 merge여도 재사용하도록 CI,
+  CodeQL, Render Diff preflight를 보완했다. 실제 #4136과 #4165의 today 충돌 수동 해소 경로는 모두
+  `mydocs/` 하나다.
+- trusted remerge diff, 동일 PR source·candidate identity, 녹색 aggregate를 모두 확인한다. source·test·
+  fixture·PDF·golden·baseline 충돌 해소, identity 불일치, 녹색 후보 부재는 이전처럼 Full CI로 fallback한다.
+- CI 실행 경로(`.github/workflows/**`, `.github/actions/**`, CI impact classifier, merge-resolution
+  verifier)를 바꾼 source PR은 `current-base-source-ci-execution-change`으로 거부해 Full CI를 강제한다.
+  #4170이 이 경계에 해당하며, CI 자체 변경을 review-only 재사용으로 검증하지 않는다.
+- workflow 계약 36건, actionlint, Markdown 링크·diff 검사를 통과했고 code head `8119074ce`의 GitHub CI
+  전체, CodeQL, Canvas visual diff도 모두 성공했다.
+- 이 review·오늘할일은 CI 변경 PR의 trailing documentation commit이다. 이 PR에서는 최신 head의 Full
+  CI를 다시 확인하고, 이후 별도의 mydocs-only current-base 병합 PR에서 fast-pass를 실제 재현한다.
+
+상세 근거: [PR #4177 검토](../pr/archives/pr_4177_review.md).
+
 ## PR #4173 - mydocs 충돌 해소 병합의 review-only fast-pass 재사용
 
 - [이슈 #4172](https://github.com/edwardkim/rhwp/issues/4172)의 범위로, current-base merge에서 자동

--- a/mydocs/plans/task_m100_4176.md
+++ b/mydocs/plans/task_m100_4176.md
@@ -1,0 +1,27 @@
+---
+kind: plan
+status: active
+issue: 4176
+last_verified: 2026-08-07
+---
+
+# Task #4176 계획 - mydocs-only current-base merge의 source head 재사용
+
+## 문제
+
+#4136의 최신 `bed52d02`와 #4165의 최신 `d2621a6`은 각각 녹색 source head 뒤에 현재
+`devel`을 병합하고 today 충돌만 `mydocs/`에서 수동 해소했다. source head가 과거 merge이면
+현재 preflight가 generic merge로 거부해 full CI를 실행한다.
+
+## 범위
+
+1. latest current-base merge의 직접 source parent를 같은 PR source의 녹색 candidate로 재사용한다.
+2. source parent가 과거 merge여도 현재 merge의 trusted `mydocs/` 해소 검사를 통과할 때만 허용한다.
+3. source PR이 CI workflow·action·impact classifier·merge-resolution checker를 수정하면 full CI를 강제한다.
+4. Render Diff는 direct source parent 재사용에서만 같은 PR 번호의 prior-base identity를 허용한다.
+
+## 검증
+
+- CI, CodeQL, Render Diff workflow 계약과 Node 문법 검사
+- `actionlint`, cache sweep·workflow wiring 계약, diff·Markdown 링크 검사
+- #4136·#4165·#4170의 실제 head 구조와 기대 판정 대조

--- a/mydocs/pr/archives/pr_4177_review.md
+++ b/mydocs/pr/archives/pr_4177_review.md
@@ -50,16 +50,30 @@ workflow를 바꾸므로 workflow 계약과 실제 Canvas visual diff 완료 여
 | GitHub CodeQL | run `31188064054`의 Python, JavaScript/TypeScript, Rust 분석과 aggregate 성공 |
 | GitHub Render Diff | run `31188064352`의 Canvas visual diff 성공 |
 
+## 추가 보정
+
+첫 trailing 문서 head `cfe6a1ccc`는 `8119074ce`의 실제 Canvas 성공 결과를 재사용해 fast-pass됐다.
+그 뒤 문서 결과 정정 head `b3d328ce5`는 중간 후보 `cfe6a1ccc`의 Canvas `skipped`를 실패로 간주해
+더 이전의 `8119074ce`를 탐색하지 않고 Canvas를 재실행했다.
+
+Stage 2 보정은 Canvas `skipped`를 재사용 불가 후보로만 분류한다. 후보 loop는 같은 PR·branch·repository·
+base identity를 다시 확인하면서 더 이전의 실제 Canvas 성공 결과를 계속 찾는다. 실제 실패·identity 불일치와
+실행 중 후보는 기존 full Render Diff fallback 또는 대기 처리를 유지한다.
+
+- Stage 2 workflow 계약, cache sweep, workflow wiring은 37건 통과했다.
+- `actionlint .github/workflows/render-diff.yml`, Markdown 링크 검사, `git diff --check`를 통과했다.
+
 ## 수용 판단과 다음 검증
 
 **수용 권고.** CI 실행 경로를 바꾼 PR은 재사용 대상에서 제외하고, mydocs-only current-base merge의
 직접 source parent만 좁게 허용하므로 기존 Full CI fallback 경계를 넓히지 않는다.
 
-이 review와 오늘할일은 code head 뒤의 trailing documentation commit으로 추가했다. code head의 CI
-실행 경로 변경은 `8119074ce`에서 Full CI로 검증했고, trailing head `cfe6a1ccc`는 같은 녹색 candidate를
-재사용해 fast-pass됐다. CI run `31189434770`에서 모든 heavy job과 test shard가 skip됐고 Build & Test
-aggregate가 성공했으며, CodeQL run `31189434069`과 Render Diff run `31189434104`도 분석·Canvas job을
-skip하고 preflight aggregate가 성공했다.
+`8119074ce`의 CI 실행 경로 변경은 Full CI로 검증했고, 첫 trailing head `cfe6a1ccc`는 같은 녹색
+candidate를 재사용해 fast-pass됐다. CI run `31189434770`에서 모든 heavy job과 test shard가 skip됐고
+Build & Test aggregate가 성공했으며, CodeQL run `31189434069`과 Render Diff run `31189434104`도
+분석·Canvas job을 skip하고 preflight aggregate가 성공했다.
 
-그 뒤 별도의 mydocs-only current-base 병합 PR에서 직접 source-parent 재사용과 trusted remerge bridge를
-확인한다. merge 전에는 최신 head의 required check와 merge 상태를 다시 확인하고 작업지시자 승인을 받는다.
+Stage 2는 Render Diff workflow와 계약을 변경하므로 최신 code head에서 CI·CodeQL·Render Diff를 다시
+완료해야 한다. 그 뒤 trailing 문서 head가 `8119074ce`의 실제 Canvas 성공 candidate를 재사용하는지
+확인한다. 별도의 mydocs-only current-base 병합 PR은 사용자가 수동 conflict resolve로 검증한다. merge
+전에는 최신 head의 required check와 merge 상태를 다시 확인하고 작업지시자 승인을 받는다.

--- a/mydocs/pr/archives/pr_4177_review.md
+++ b/mydocs/pr/archives/pr_4177_review.md
@@ -62,6 +62,10 @@ base identity를 다시 확인하면서 더 이전의 실제 Canvas 성공 결�
 
 - Stage 2 workflow 계약, cache sweep, workflow wiring은 37건 통과했다.
 - `actionlint .github/workflows/render-diff.yml`, Markdown 링크 검사, `git diff --check`를 통과했다.
+- Stage 2 code head `f571572a9`의 CI run `31190273592`에서 lint, Native Skia, 세 archive build,
+  네 test shard와 aggregate가 모두 성공했다.
+- CodeQL run `31190269950`의 Python, JavaScript/TypeScript, Rust 분석과 aggregate, Render Diff run
+  `31190270359`의 Canvas visual diff가 모두 성공했다.
 
 ## 수용 판단과 다음 검증
 
@@ -73,7 +77,8 @@ candidate를 재사용해 fast-pass됐다. CI run `31189434770`에서 모든 hea
 Build & Test aggregate가 성공했으며, CodeQL run `31189434069`과 Render Diff run `31189434104`도
 분석·Canvas job을 skip하고 preflight aggregate가 성공했다.
 
-Stage 2는 Render Diff workflow와 계약을 변경하므로 최신 code head에서 CI·CodeQL·Render Diff를 다시
-완료해야 한다. 그 뒤 trailing 문서 head가 `8119074ce`의 실제 Canvas 성공 candidate를 재사용하는지
-확인한다. 별도의 mydocs-only current-base 병합 PR은 사용자가 수동 conflict resolve로 검증한다. merge
-전에는 최신 head의 required check와 merge 상태를 다시 확인하고 작업지시자 승인을 받는다.
+Stage 2는 Render Diff workflow와 계약을 변경하므로 `f571572a9`에서 CI·CodeQL·Render Diff Full CI를
+다시 완료했다. 이 최종 review·오늘할일 commit은 trailing documentation commit으로 push해
+`f571572a9`의 실제 Canvas 성공 candidate를 재사용하는지 확인한다. 별도의 mydocs-only current-base
+병합 PR은 사용자가 수동 conflict resolve로 검증한다. merge 전에는 최신 head의 required check와 merge
+상태를 다시 확인하고 작업지시자 승인을 받는다.

--- a/mydocs/pr/archives/pr_4177_review.md
+++ b/mydocs/pr/archives/pr_4177_review.md
@@ -55,8 +55,11 @@ workflow를 바꾸므로 workflow 계약과 실제 Canvas visual diff 완료 여
 **수용 권고.** CI 실행 경로를 바꾼 PR은 재사용 대상에서 제외하고, mydocs-only current-base merge의
 직접 source parent만 좁게 허용하므로 기존 Full CI fallback 경계를 넓히지 않는다.
 
-이 review와 오늘할일은 code head 뒤의 trailing documentation commit으로 추가한다. PR 전체가 CI
-workflow 변경을 포함하므로 이 trailing commit도 review-only fast-pass 대상이 아니며 최신 head에서
-Full CI를 다시 완료해야 한다. 그 뒤 별도의 mydocs-only current-base 병합 PR에서 녹색 source-parent
-재사용과 fast-pass aggregate를 확인한다. merge 전에는 최신 head의 required check와 merge 상태를 다시
-확인하고 작업지시자 승인을 받는다.
+이 review와 오늘할일은 code head 뒤의 trailing documentation commit으로 추가했다. code head의 CI
+실행 경로 변경은 `8119074ce`에서 Full CI로 검증했고, trailing head `cfe6a1ccc`는 같은 녹색 candidate를
+재사용해 fast-pass됐다. CI run `31189434770`에서 모든 heavy job과 test shard가 skip됐고 Build & Test
+aggregate가 성공했으며, CodeQL run `31189434069`과 Render Diff run `31189434104`도 분석·Canvas job을
+skip하고 preflight aggregate가 성공했다.
+
+그 뒤 별도의 mydocs-only current-base 병합 PR에서 직접 source-parent 재사용과 trusted remerge bridge를
+확인한다. merge 전에는 최신 head의 required check와 merge 상태를 다시 확인하고 작업지시자 승인을 받는다.

--- a/mydocs/pr/archives/pr_4177_review.md
+++ b/mydocs/pr/archives/pr_4177_review.md
@@ -1,0 +1,62 @@
+---
+kind: pr_review
+status: accepted
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-07
+---
+
+# PR #4177 검토 - mydocs 충돌 merge의 녹색 source head 재사용
+
+## 대상과 변경 경계
+
+| 항목 | 값 |
+| --- | --- |
+| PR / 작성자 | [#4177](https://github.com/edwardkim/rhwp/pull/4177) / @jangster77 |
+| 기준 `devel` | `f048429eb282778a49e3bb4e7f748146321721b5` |
+| code head | `8119074ceb7bd4491b7fca134b05eff99970148e` |
+| 연동 이슈 | `Closes #4176` |
+| 작성 시점 merge 상태 | `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN` |
+
+라우팅은 `collaborator_self_merge`를 기본으로 하고, `intake_and_review`, `local_validation`을
+보조 경로로 적용했다. 자기 자신은 GitHub reviewer request 대상으로 지정할 수 없어 별도 reviewer
+request는 생성되지 않았다.
+
+이 PR은 최신 `devel`을 병합하면서 `mydocs/`만 수동 해소한 경우를 보완한다. 직접 source parent가
+같은 PR source의 녹색 CI, CodeQL, Render Diff 결과를 가질 때 source parent 자체가 과거 merge여도
+재사용한다. 실제 재현 대상은 #4136과 #4165다.
+
+재사용은 다음 조건을 모두 유지한다.
+
+- 최신 commit이 current-base merge이고 trusted remerge diff의 수동 해소 경로가 `mydocs/` 아래여야 한다.
+- source·test·sample·PDF·golden·baseline 충돌 해소, identity 불일치, 녹색 후보 부재는 Full CI로 fallback한다.
+- source PR이 `.github/workflows/**`, `.github/actions/**`, CI impact classifier 또는 merge-resolution
+  verifier를 수정하면 `current-base-source-ci-execution-change`으로 판정해 Full CI를 강제한다. #4170이
+  이 경계에 해당한다.
+- Render Diff의 prior-base identity 허용은 위 직접 source-parent 재사용 경로에만 한정한다.
+
+문서·render 산출물 자체의 변경은 없으므로 시각 fixture 증적 경로는 적용하지 않았다. 다만 Render Diff
+workflow를 바꾸므로 workflow 계약과 실제 Canvas visual diff 완료 여부를 검증했다.
+
+## 완료한 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| workflow 계약 | `python3 -m unittest scripts/tests/test_review_only_fast_pass_workflows.py scripts/tests/test_cache_sweep_workflow.py scripts/tests/test_workflow_contract_wiring.py`를 실행해 36건 통과 |
+| workflow 구문 | `actionlint .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/render-diff.yml` 통과 |
+| 문서·diff 정합 | `python3 scripts/check_markdown_links.py --changed-from HEAD`, `git diff --check` 통과 |
+| 실제 bridge 구조 | merge-resolution checker가 #4136 `bed52d02`, #4165 `d2621a6`에 `current-base-merge-resolution-mydocs-only`를 반환 |
+| CI 실행 경계 | #4136·#4165는 CI 실행 경로 변경 없음, #4170은 `.github/workflows/ci.yml`과 `scripts/ci-impact-classifier.cjs` 변경으로 guard 대상임을 확인 |
+| GitHub CI | code head `8119074ce`에서 CI run `31188064589`의 lint, Native Skia, 세 archive build, 네 test shard, aggregate가 모두 성공 |
+| GitHub CodeQL | run `31188064054`의 Python, JavaScript/TypeScript, Rust 분석과 aggregate 성공 |
+| GitHub Render Diff | run `31188064352`의 Canvas visual diff 성공 |
+
+## 수용 판단과 다음 검증
+
+**수용 권고.** CI 실행 경로를 바꾼 PR은 재사용 대상에서 제외하고, mydocs-only current-base merge의
+직접 source parent만 좁게 허용하므로 기존 Full CI fallback 경계를 넓히지 않는다.
+
+이 review와 오늘할일은 code head 뒤의 trailing documentation commit으로 추가한다. PR 전체가 CI
+workflow 변경을 포함하므로 이 trailing commit도 review-only fast-pass 대상이 아니며 최신 head에서
+Full CI를 다시 완료해야 한다. 그 뒤 별도의 mydocs-only current-base 병합 PR에서 녹색 source-parent
+재사용과 fast-pass aggregate를 확인한다. merge 전에는 최신 head의 required check와 merge 상태를 다시
+확인하고 작업지시자 승인을 받는다.

--- a/mydocs/working/task_m100_4176_stage1.md
+++ b/mydocs/working/task_m100_4176_stage1.md
@@ -1,0 +1,26 @@
+---
+kind: working
+status: completed
+issue: 4176
+last_verified: 2026-08-07
+---
+
+# Task #4176 Stage 1 - source parent 재사용 보정
+
+## 구현
+
+- 최신 current-base merge의 source parent를 먼저 녹색 candidate로 조회하도록 세 preflight를 보정했다.
+- CI 실행 경로를 수정한 source PR은 full CI로 고정했다.
+- Render Diff는 이 좁은 경로에서만 같은 PR의 prior-base identity를 수용한다.
+
+## 검증 결과
+
+- `python3 -m unittest scripts/tests/test_review_only_fast_pass_workflows.py`
+  `scripts/tests/test_cache_sweep_workflow.py` `scripts/tests/test_workflow_contract_wiring.py`를 실행해
+  36건이 통과했다.
+- `actionlint`로 CI, CodeQL, Render Diff workflow를 검사했고, `git diff --check`도 통과했다.
+- trusted merge-resolution checker는 #4136 `bed52d02`와 #4165 `d2621a6` 모두에서
+  `current-base-merge-resolution-mydocs-only`를 반환했다.
+- #4136 source head `ecda0c15`와 #4165 source head `fd792a0`의 CI·CodeQL은 모두 녹색이었다.
+- #4136·#4165 PR diff에는 CI 실행 경로가 없고, #4170에는 `.github/workflows/ci.yml`과
+  `scripts/ci-impact-classifier.cjs`가 있어 guard 대상임을 확인했다.

--- a/mydocs/working/task_m100_4176_stage2.md
+++ b/mydocs/working/task_m100_4176_stage2.md
@@ -1,0 +1,33 @@
+---
+kind: working
+status: completed
+issue: 4176
+last_verified: 2026-08-07
+---
+
+# Task #4176 Stage 2 - Render Diff trailing 문서 candidate 탐색 보정
+
+## 원인
+
+`cfe6a1ccc`는 `8119074ce`의 녹색 Render Diff 결과를 재사용한 trailing 문서 commit이다. 따라서
+`cfe6a1ccc`의 Canvas job은 정상적으로 `skipped`다. 다음 문서 commit `b3d328ce5`의 preflight는 이
+후보를 `canvas-visual-diff-not-success:skipped`로 실패 처리하고, 더 이전의 실제 Canvas 성공 candidate
+`8119074ce`를 탐색하지 않아 Canvas를 다시 실행했다.
+
+## 보정
+
+- Render Diff candidate의 Canvas `skipped` 상태를 실패가 아닌 재사용 불가 후보로 분류한다.
+- 후보 loop는 해당 후보를 건너뛰고, 같은 PR·branch·repository·base identity를 가진 더 이전의 실제
+  Canvas 성공 후보를 계속 탐색한다.
+- non-success 실패, identity 불일치, 실행 중 후보는 기존처럼 full Render Diff fallback 또는 대기 사유를
+  유지한다.
+
+## 검증 결과
+
+- workflow 계약 테스트에 skipped candidate가 실패 분기로 들어가기 전 별도 상태로 반환되고, 후보 loop가
+  계속 탐색하는 구조를 추가했다.
+- `python3 -m unittest scripts/tests/test_review_only_fast_pass_workflows.py`
+  `scripts/tests/test_cache_sweep_workflow.py` `scripts/tests/test_workflow_contract_wiring.py`를 실행해
+  37건이 통과했다.
+- `actionlint .github/workflows/render-diff.yml`,
+  `python3 scripts/check_markdown_links.py --changed-from HEAD`, `git diff --check`를 실행해 통과했다.

--- a/scripts/tests/test_review_only_fast_pass_workflows.py
+++ b/scripts/tests/test_review_only_fast_pass_workflows.py
@@ -67,6 +67,38 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
                     workflow,
                 )
 
+    def test_current_base_merge_reuses_a_green_source_parent_except_ci_changes(self) -> None:
+        result_functions = {
+            "ci": "buildResult",
+            "codeql": "codeqlResult",
+            "render-diff": "renderDiffResult",
+        }
+        for name, workflow_path in WORKFLOWS.items():
+            with self.subTest(workflow=name):
+                workflow = workflow_path.read_text(encoding="utf-8")
+                direct_bridge_index = workflow.index("const latestCommitSha = commits.at(-1).sha;")
+                candidate_scan_index = workflow.index("const reviewOnlyCandidates = [];")
+                self.assertLess(direct_bridge_index, candidate_scan_index)
+                self.assertIn("function isCiExecutionPath(filename)", workflow)
+                self.assertIn(
+                    "current-base-source-ci-execution-change",
+                    workflow,
+                )
+                self.assertIn(
+                    f"await {result_functions[name]}(sourceParent.sha, pr",
+                    workflow,
+                )
+                self.assertIn("direct-source-", workflow)
+
+    def test_render_diff_allows_prior_base_only_for_direct_source_parent(self) -> None:
+        workflow = WORKFLOWS["render-diff"].read_text(encoding="utf-8")
+        self.assertIn(
+            "async function renderDiffResult(candidateSha, pr, allowPriorPrBase = false)",
+            workflow,
+        )
+        self.assertIn("allowPriorPrBase\n                  ? step.name.startsWith(identityPrefix)", workflow)
+        self.assertIn("await renderDiffResult(sourceParent.sha, pr, true)", workflow)
+
     def test_resolution_checker_accepts_only_mydocs_conflicts(self) -> None:
         self.assertEqual(
             self._run_resolution_check("mydocs/orders/20260807.md").returncode,
@@ -179,21 +211,25 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
             workflow,
         )
 
-        script = workflow.split("script: |\n", maxsplit=1)[1].split(
-            "\n      # 기준선 병합을 fast-pass bridge로", maxsplit=1
-        )[0]
-        script = "\n".join(
-            line.removeprefix("            ") for line in script.splitlines()
-        )
-        syntax = subprocess.run(
-            ["node", "--check"],
-            input=f"(async () => {{\n{script}\n}})();\n",
-            check=False,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        self.assertEqual(syntax.returncode, 0, syntax.stderr)
+        for name, workflow_path in WORKFLOWS.items():
+            with self.subTest(workflow=name):
+                script = workflow_path.read_text(encoding="utf-8").split(
+                    "script: |\n", maxsplit=1
+                )[1].split(
+                    "\n      # 기준선 병합을 fast-pass bridge로", maxsplit=1
+                )[0]
+                script = "\n".join(
+                    line.removeprefix("            ") for line in script.splitlines()
+                )
+                syntax = subprocess.run(
+                    ["node", "--check"],
+                    input=f"(async () => {{\n{script}\n}})();\n",
+                    check=False,
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+                self.assertEqual(syntax.returncode, 0, syntax.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_review_only_fast_pass_workflows.py
+++ b/scripts/tests/test_review_only_fast_pass_workflows.py
@@ -99,6 +99,21 @@ class ReviewOnlyFastPassWorkflowTests(unittest.TestCase):
         self.assertIn("allowPriorPrBase\n                  ? step.name.startsWith(identityPrefix)", workflow)
         self.assertIn("await renderDiffResult(sourceParent.sha, pr, true)", workflow)
 
+    def test_render_diff_skips_a_reused_candidate_before_trying_an_older_canvas_result(
+        self,
+    ) -> None:
+        workflow = WORKFLOWS["render-diff"].read_text(encoding="utf-8")
+        self.assertIn("state: 'skipped'", workflow)
+        self.assertIn("canvas-visual-diff-skipped:${candidateSha}", workflow)
+        self.assertLess(
+            workflow.index("if (renderDiffJob.conclusion === 'skipped')"),
+            workflow.index("if (renderDiffJob.conclusion !== 'success')"),
+        )
+        self.assertLess(
+            workflow.index("if (result.state === 'failed')"),
+            workflow.index("candidate not reusable yet: ${candidateSha}"),
+        )
+
     def test_resolution_checker_accepts_only_mydocs_conflicts(self) -> None:
         self.assertEqual(
             self._run_resolution_check("mydocs/orders/20260807.md").returncode,


### PR DESCRIPTION
## 요약

- 최신 `devel` 병합 중 `mydocs/` 충돌만 해소한 PR은 source parent가 과거 merge여도 같은 PR의 녹색 CI·CodeQL·Render Diff 결과를 재사용합니다.
- `.github/workflows/**`, `.github/actions/**`, CI classifier·bridge verifier 변경은 재사용하지 않고 Full CI를 강제합니다.
- 기존 identity, trusted remerge diff, 녹색 후보 부재 fallback 검증은 유지합니다.

## 검증

- `python3 -m unittest scripts/tests/test_review_only_fast_pass_workflows.py scripts/tests/test_cache_sweep_workflow.py scripts/tests/test_workflow_contract_wiring.py` (36 passed)
- `actionlint .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/render-diff.yml`
- `python3 scripts/check_markdown_links.py --changed-from HEAD`
- `git diff --check`

Closes #4176