### PR TITLE
test(provenance): recordFields 공선언 회피 봉쇄 래칫 — json:true 전수 (#4188)

### DIFF
--- a/tests/provenance_contract.rs
+++ b/tests/provenance_contract.rs
@@ -1564,3 +1564,47 @@ fn declared_record_fields_actually_appear_in_envelopes() {
         problems.join("\n"),
     );
 }
+
+/// [R10 조각] `json:true` 명령은 `recordFields` 를 비워 두고 가드를 지나갈 수 없다.
+///
+/// 위의 전수 대조는 **선언한** 필드가 실물에 나타나는지만 본다 — 선언이 아예
+/// 없거나 빈 배열이면 대조할 것이 없어 공허하게 통과한다. 즉 "선언 회피가 가드
+/// 회피의 가장 쉬운 길"(R12 가 map 축에서 봉쇄한 바로 그 부류)이 recordFields
+/// 축에는 열려 있었다. 이 래칫은 선언의 존재·비어있지 않음 자체를 전수로
+/// 요구해 그 길을 닫는다. 현재 `json:true` 전 명령이 비어있지 않은 선언을
+/// 가지므로 면제 목록은 0건으로 시작하며, 봉투 필드를 약속할 수 없는 명령이
+/// 생기면 **사유와 함께** EMPTY_RECORD_FIELDS_EXEMPT 에만 적는다.
+const EMPTY_RECORD_FIELDS_EXEMPT: &[(&str, &str)] = &[
+    // (명령, json 봉투의 고정 필드를 약속할 수 없는 사유)
+];
+
+#[test]
+fn every_json_command_declares_nonempty_record_fields() {
+    let cap = capabilities();
+    let mut problems: Vec<String> = Vec::new();
+    for c in cap["commands"].as_array().expect("commands") {
+        if c["json"] != Value::Bool(true) {
+            continue;
+        }
+        let name = c["name"].as_str().expect("name");
+        if let Some((_, why)) = EMPTY_RECORD_FIELDS_EXEMPT.iter().find(|(n, _)| *n == name) {
+            assert!(!why.trim().is_empty(), "{name} 면제 사유가 비었습니다");
+            continue;
+        }
+        let declared = c["recordFields"].as_array().map(Vec::len).unwrap_or(0);
+        if declared == 0 {
+            problems.push(format!(
+                "  - {name}: json:true 인데 recordFields 가 없거나 비어 있습니다 — \
+                 declared_record_fields_actually_appear_in_envelopes 가 공허 통과합니다"
+            ));
+        }
+    }
+    assert!(
+        problems.is_empty(),
+        "recordFields 공선언 회피 {}건:\n{}\n\n\
+         봉투가 약속하는 최상위 필드를 capabilities 에 선언하거나, 약속할 수 없다면 \
+         EMPTY_RECORD_FIELDS_EXEMPT 에 사유와 함께 적으세요.",
+        problems.len(),
+        problems.join("\n"),
+    );
+}


### PR DESCRIPTION
## 무엇 (#4188 — R10 의 R8-불변 조각)

기존 전수 대조(`declared_record_fields_actually_appear_in_envelopes`)는 **선언한** 필드가 실물에 나타나는지만 봅니다 — 선언이 없거나 빈 배열이면 대조가 공허하게 통과합니다. 이 래칫은 `json:true` 전 명령에 비어있지 않은 `recordFields` 선언 자체를 요구해 "선언 회피" 경로를 닫습니다. 신규 테스트 1본 + 사유 필수 면제 상수(현재 0건) — 기존 파일 1개에 삽입만.

## 판단

로드맵상 R10 착수 게이트는 R8 판정 선행이지만, 이 조각은 R8 의 어느 판정에서도 결과가 같습니다 — json:true 아닌 명령은 기준 목록 밖이고, 이후 json:true 가 되는 순간 자동 편입되는 전방 호환입니다. #4186(verify) 이 머지되면 36번째 명령으로 자동 검사 대상이 되며 verify 는 선언을 갖고 있어 green 이 유지됩니다.

## 검증 (red → green)

- devel 기준 green: json:true 34개 명령 전수 통과, 면제 0.
- **red 실증**: `info` 의 recordFields 를 비운 변이에서 정확히 그 1건 검출로 red, 복원 후 green.
- clippy `-D warnings`·release-test focused green, `git diff --check` 통과.

closes #4188
refs #3907

🤖 Generated with [Claude Code](https://claude.com/claude-code)
