### PR TITLE
test(docs): 지식지도 §2-2 사전 드리프트 래칫 + 누락 13필드 등재 (#4189)

### DIFF
--- a/mydocs/manual/agent_knowledge_map.md
+++ b/mydocs/manual/agent_knowledge_map.md
@@ -301,7 +301,7 @@ printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocol
 를 싣고 `--dry-run` 에서는 싣지 않는다. `edit set-cell` 은 `oldText` 때문에
 `untrustedContent:true`, `edit fill-fields`·`replace-text` 는 `false` 다(실측).
 
-### 2-2. 전수 사전 — 148개 필드
+### 2-2. 전수 사전 — 166개 필드
 
 `capabilities` 의 `recordFields` 합집합이다. `등장 명령` 은 자기서술 기준이며,
 실제 봉투에는 조건부로 더 실리는 필드가 있다(§2-5).
@@ -332,6 +332,11 @@ printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocol
 | `paraCount` | number | 문단 수 | `info`·`digest` |
 | `fonts` | string[] | 문서가 참조하는 글꼴 이름 — **문서 파생** | `info` |
 | `title` | string | 요약정보의 제목 — **문서 파생** | `info` |
+| `warnings` | string[] | 파싱 경고 목록 — 빈 배열이면 깨끗이 읽었다는 뜻 | `info` |
+| `summary` | string | 사람용 여러 줄 요약(형식·쪽수·표·누름틀·각주) — **문서 파생** | `explain` |
+| `encrypted` | bool | 암호화 문서 여부 | `explain` |
+| `footnoteCount` | number | 각주 수 | `explain` |
+| `endnoteCount` | number | 미주 수 | `explain` |
 | `wasDistribution` | bool | 입력이 배포용(읽기전용)이었나 | `convert` |
 
 #### 요약·개요 (`digest`)
@@ -443,6 +448,10 @@ printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocol
 | `categories` | object | 차이의 분류별 개수 — 키 이름 자체가 문서 파생일 수 있다 | `ir-diff` |
 | `status` | string | `render-diff` 판정(`OK`·`OVER` 등) | `render-diff` |
 | `regression` | bool | 시각 회귀로 판정했나 → exit 3 | `render-diff` |
+| `expectations` | array | 조건별 판정 `{kind,expected,actual,pass}` — 판정은 데이터 | `verify` (PR #4186 선등재) |
+| `passCount` | number | 만족한 기대 수 | `verify` (PR #4186 선등재) |
+| `failCount` | number | 불만족 기대 수 → 1 이상이면 exit 3 | `verify` (PR #4186 선등재) |
+| `verdict` | string | `pass`·`fail` 요약 판정 | `verify` (PR #4186 선등재) |
 | `via` | string | 라운드트립 경유 형식(`hwpx`·`hwp`) | `render-diff` |
 | `threshold` | number | 변위 허용 임계(px) | `render-diff` |
 | `maxDisp` | number | 전 쪽 최대 변위(px) | `render-diff` |
@@ -495,6 +504,8 @@ printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocol
 | `findingCount` | number | 탐지 개수 | `inspect unicode`·`edit redact` |
 | `severityCounts` | object | `{high,medium,low}` 개수 | `inspect unicode` |
 | `kindCounts` | object | `{zero_width,bidi_override,tag_char,confusable}` 개수 | `inspect unicode` |
+| `untrustedContent` | bool | 문서 파생 값이 봉투에 실렸는지 — 출처 표지 요약 | `inspect` 3종 (자기서술 기준; 실물은 §2-5 조건부로 더 넓다) |
+| `untrustedFields` | string[] | 문서 파생 값이 실린 필드 경로 목록 | `inspect` 3종 (위와 같음) |
 
 #### 배치
 
@@ -518,6 +529,12 @@ printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocol
 | `dialect` | string | JSON Schema 방언 URI | 두 schema 명령 |
 | `definitionCount` | number | `$defs` 개수 | 두 schema 명령 |
 | `irSchemaVersion` / `capabilitiesSchemaVersion` | string | 각 스키마의 자체 버전 | 각 명령 |
+| `planSchemaVersion` | string | `run` 계획서 스키마의 자체 버전 | `export-plan-schema` |
+| `capabilities` | object | 명령 표면 자기서술 봉투(내장) | `export-agent-manifest` |
+| `irSchema` | object | 공개 IR JSON Schema 봉투(내장) | `export-agent-manifest` |
+| `provenanceMap` | object | 출처 지도 봉투(내장) | `export-agent-manifest` |
+| `planSchema` | object | `run` 계획서 JSON Schema 봉투(내장) | `export-agent-manifest` |
+| `missingAxes` | string[] | 조립에서 빠진 축 이름 — 전부 있으면 빈 배열 | `export-agent-manifest` |
 
 #### 진단 (`dump-pages`)
 

--- a/tests/knowledge_map_field_dictionary_contract.rs
+++ b/tests/knowledge_map_field_dictionary_contract.rs
@@ -1,0 +1,114 @@
+//! [R36] capabilities `recordFields` 합집합 ⊆ 지식지도 §2-2 전수 사전 — 드리프트 래칫.
+//!
+//! 지식지도의 완결 기준은 "매니페스트가 내는 필드 = 가이드가 설명하는 필드"인데,
+//! 이를 대조하는 가드가 없어 새 명령이 필드를 들고 와도 사전이 조용히 뒤처졌다
+//! (이 가드 착지 시점에 13개 필드가 이미 새고 있었다). 방향은 **부분집합**이다 —
+//! 사전은 세션 도구(`docId`)와 실측 전용 필드(`assertions`·`preview`,
+//! recordFields 밖임이 본문에 명시됨)를 의도적으로 더 실으므로 등호가 아니라
+//! "표면이 선언하는 필드는 사전에 반드시 등재된다"를 요구한다.
+//!
+//! 파싱 계약 — 문서 형식이 바뀌면 이 규칙을 같이 고친다:
+//! - 대상 절: `### 2-2.` 헤딩부터 다음 `### ` 헤딩 직전까지.
+//! - 필드 행: `| ` + 백틱으로 시작하는 행의 **첫 칸**에서 백틱 토큰 전부 —
+//!   `` `a` / `b` `` 병기 행은 두 필드로 센다.
+//! - 헤딩의 "N개 필드"는 유니크 토큰 수와 일치해야 한다(자기일관).
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::process::Command;
+
+const MAP: &str = "mydocs/manual/agent_knowledge_map.md";
+
+fn dictionary_section() -> String {
+    let text = std::fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join(MAP))
+        .expect("지식지도를 읽을 수 없다");
+    let start = text.find("### 2-2.").expect("§2-2 헤딩이 없다");
+    let rest = &text[start..];
+    let end = rest[8..].find("\n### ").map(|i| i + 8).unwrap_or(rest.len());
+    rest[..end].to_string()
+}
+
+/// 표 행 첫 칸의 백틱 토큰들. `| `a` / `b` | ...` → ["a", "b"].
+fn dictionary_fields(section: &str) -> Vec<String> {
+    let mut fields = Vec::new();
+    for line in section.lines() {
+        if !line.starts_with("| `") {
+            continue;
+        }
+        let first_cell = line[2..].split(" | ").next().unwrap_or("");
+        let mut in_tick = false;
+        let mut token = String::new();
+        for ch in first_cell.chars() {
+            match (ch, in_tick) {
+                ('`', false) => in_tick = true,
+                ('`', true) => {
+                    fields.push(std::mem::take(&mut token));
+                    in_tick = false;
+                }
+                (_, true) => token.push(ch),
+                _ => {}
+            }
+        }
+    }
+    fields
+}
+
+fn record_fields_union() -> BTreeSet<String> {
+    let out = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("capabilities")
+        .output()
+        .expect("rhwp capabilities 실행 실패");
+    let cap: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("capabilities 봉투가 JSON 이 아니다");
+    let mut union = BTreeSet::new();
+    for c in cap["commands"].as_array().expect("commands") {
+        if c["json"] != serde_json::Value::Bool(true) {
+            continue;
+        }
+        for f in c["recordFields"].as_array().into_iter().flatten() {
+            if let Some(f) = f.as_str() {
+                union.insert(f.to_string());
+            }
+        }
+    }
+    union
+}
+
+#[test]
+fn every_declared_record_field_is_in_the_dictionary() {
+    let section = dictionary_section();
+    let dict: BTreeSet<String> = dictionary_fields(&section).into_iter().collect();
+    let missing: Vec<String> = record_fields_union()
+        .into_iter()
+        .filter(|f| !dict.contains(f))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "capabilities 가 선언하는데 §2-2 사전에 없는 필드 {}개: {}\n\
+         새 명령이 필드를 들고 왔다 — 지식지도 §2-2 해당 소절에 행을 추가하고 \
+         헤딩의 필드 수를 갱신하세요.",
+        missing.len(),
+        missing.join(", "),
+    );
+}
+
+#[test]
+fn dictionary_heading_count_matches_rows() {
+    let section = dictionary_section();
+    let unique: BTreeSet<String> = dictionary_fields(&section).into_iter().collect();
+    let heading: usize = section
+        .lines()
+        .next()
+        .and_then(|h| {
+            h.split('—').nth(1)?.trim().strip_suffix("개 필드")?.trim().parse().ok()
+        })
+        .expect("§2-2 헤딩에서 'N개 필드' 를 읽지 못했다");
+    assert_eq!(
+        heading,
+        unique.len(),
+        "§2-2 헤딩은 {}개라는데 표의 유니크 필드는 {}개다 — 행을 넣고 빼면 헤딩도 같이 고친다",
+        heading,
+        unique.len(),
+    );
+}

--- a/tests/knowledge_map_field_dictionary_contract.rs
+++ b/tests/knowledge_map_field_dictionary_contract.rs
@@ -25,7 +25,10 @@ fn dictionary_section() -> String {
         .expect("지식지도를 읽을 수 없다");
     let start = text.find("### 2-2.").expect("§2-2 헤딩이 없다");
     let rest = &text[start..];
-    let end = rest[8..].find("\n### ").map(|i| i + 8).unwrap_or(rest.len());
+    let end = rest[8..]
+        .find("\n### ")
+        .map(|i| i + 8)
+        .unwrap_or(rest.len());
     rest[..end].to_string()
 }
 
@@ -101,7 +104,13 @@ fn dictionary_heading_count_matches_rows() {
         .lines()
         .next()
         .and_then(|h| {
-            h.split('—').nth(1)?.trim().strip_suffix("개 필드")?.trim().parse().ok()
+            h.split('—')
+                .nth(1)?
+                .trim()
+                .strip_suffix("개 필드")?
+                .trim()
+                .parse()
+                .ok()
         })
         .expect("§2-2 헤딩에서 'N개 필드' 를 읽지 못했다");
     assert_eq!(


### PR DESCRIPTION
## 무엇 (#4189 — R36)

지식지도 §2-2 "전수 사전"이 capabilities `recordFields` 합집합보다 **13필드 뒤처져** 있었습니다(실측: 합집합 159 vs 사전 149 유니크). 누락 13필드(`warnings`·explain 4종·manifest 5종·`planSchemaVersion`·inspect 출처표지 2종)를 해당 소절에 등재하고(헤딩 148→166), **부분집합 래칫** 계약 테스트를 추가합니다 — 합집합 ⊆ 사전 + 헤딩 수 자기일관.

## 판단

- 등호가 아니라 부분집합인 이유: 사전은 세션 도구(`docId`)와 실측 전용 필드(`assertions`·`preview` — "recordFields 에는 없다"고 본문에 명시)를 의도적으로 더 싣습니다.
- **#4186 선등재 4행 포함**: 열린 #4186(verify)의 봉투 필드(`expectations`·`passCount`·`failCount`·`verdict`)를 미리 등재해 **어느 머지 순서에서도 가드가 green** 입니다(부분집합 방향이라 여분 행은 실패 사유가 아님). #4186 이 닫히면 그 4행만 걷어내면 됩니다.
- 파싱 계약(절 경계·첫 칸 백틱 토큰·병기 행 분리)은 테스트 상단에 명문화 — 문서 형식이 바뀌면 같이 고칩니다.

## 검증 (red → green)

- 신규 계약 2본 green (부분집합·헤딩 자기일관).
- **red 실증**: `warnings` 행 제거 변이에서 정확히 그 필드명으로 red, 복원 후 green.
- clippy·`git diff --check` 통과.

closes #4189
refs #3907

🤖 Generated with [Claude Code](https://claude.com/claude-code)
