### PR TITLE
test(python): 생성 모델 드리프트 게이트 — gen_models --check 스위트 편입 (#4190)

### DIFF
--- a/bindings/python/tests/test_generated_models_drift.py
+++ b/bindings/python/tests/test_generated_models_drift.py
@@ -1,0 +1,42 @@
+"""[R70 절반] 생성 모델 드리프트 게이트 — ``gen_models --check`` 를 스위트에 편입.
+
+기존 ``test_generated_models_match_current_schema`` 는 버전·타입명 수준만 대조해
+**같은 버전 안에서 필드가 어긋나는 드리프트**를 놓친다. 생성기 자신의 ``--check``
+가 바이트 단위 대조를 이미 구현하고 있으므로(단일 출처 — 여기서 대조를 다시
+만들지 않는다), 이 테스트는 그것을 subprocess 로 불러 스위트에 편입한다.
+``pytest tests/ -q`` 가 도는 기존 python-binding 통합 잡에 자동으로 실리므로
+워크플로 파일은 바꾸지 않는다.
+
+Node 쪽 같은 축은 이미 CI 에 있다(``npm run gen:check``) — 이 파일이 파이썬
+절반을 맞춘다. R70 의 나머지 절반(런타임 적합성 스위트, R68 선행)은 다루지
+않는다.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+BINDING_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_generated_ir_models_are_current(wired_binary: Path) -> None:
+    """``src/rhwp/ir.py`` 가 현재 IR 스키마에서 재생성한 결과와 바이트 일치한다."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(BINDING_ROOT / "tools" / "gen_models.py"),
+            "-o",
+            str(BINDING_ROOT / "src" / "rhwp" / "ir.py"),
+            "--check",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(BINDING_ROOT),
+    )
+    assert result.returncode == 0, (
+        "생성 모델이 IR 스키마와 다릅니다 — "
+        "python tools/gen_models.py -o src/rhwp/ir.py 로 재생성해 커밋하세요.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )


### PR DESCRIPTION
## 무엇 (#4190 — R70 의 독립 절반)

생성 타입 드리프트 게이트가 반쪽이었습니다 — Node 는 `gen:check` 가 CI 에 있는데 파이썬 `gen_models.py --check`(바이트 대조)는 어디에도 걸려 있지 않았습니다. 생성기 자신의 `--check` 를 subprocess 로 부르는 pytest 1본(신규 파일 1개)을 추가해 기존 `pytest tests/ -q` 통합 잡에 자동 편입합니다 — **워크플로 파일 무변경, 검사 본체 중복 없음**(단일 출처).

## 판단

R70 착수 게이트(R68 적합성 스위트 선행)는 런타임 절반에 대한 것이고, 이 정적 절반(생성 타입↔선언 대조)은 독립 실행 가능합니다 — 부분 착지임을 명시합니다. 로드맵의 "지금 — 없음" 표기 중 Node 절반은 낡은 표기였음(이미 CI 에 있음)도 확인했습니다.

## 검증 (red → green)

- 스위트에서 green. **red 실증**: `ir.py` 끝에 1줄 덧붙인 변이에서 red, 복원 후 green.
- 전체 pytest 263 passed (파이썬 래퍼 PR 반영 시; 이 브랜치 단독으로는 기존 devel 결함 1건이 남는데 — `test_binding_covers_every_agent_value_command` red — 이 PR 과 무관하며 별도 PR 로 해소합니다).

closes #4190
refs #3907

🤖 Generated with [Claude Code](https://claude.com/claude-code)
