### PR TITLE
test(render): 편집 전후 render-diff 회귀 게이트 상시화 — 실측 기반 계약 5건 (#4199)

### DIFF
--- a/mydocs/report/edit_render_gate_r1_20260808.md
+++ b/mydocs/report/edit_render_gate_r1_20260808.md
@@ -1,0 +1,114 @@
+# [R50] 편집 전후 render-diff 회귀 게이트 — r1 실측과 임계 제안 (2026-08-08)
+
+로드맵 트랙 E `R50 render-diff 임계 정책 상시 게이트화`
+(`mydocs/tech/agent_roadmap/track_e_capabilities.md`)의 첫 착지 기록이다.
+render-diff 기구 자체(#3618, `src/diagnostics/render_geom_diff.rs`)는 완비돼
+있었고, 없던 것은 **"편집 전후"를 이 기구에 배선한 상시 게이트**였다 —
+`tests/edit_*.rs` 어디에도 render-diff 호출이 없었다.
+
+이 문서는 임계를 **확정하지 않는다**. 대표 편집 3종의 전후 maxDisp 분포를
+실측하고, 그 분포에서 나오는 임계 **제안과 근거**를 남긴다. R50 DoD 가 요구하는
+"임계값 실측 합의"의 합의 주체는 메인테이너다.
+
+## 1. 방법
+
+- 비교 기구: `rhwp render-diff <전> <후> --json` (pair 모드) — 재구현 없이 기존
+  단일 출처를 그대로 배선. 종료 코드 계약: 0=PASS, 3=회귀 검출.
+- fixture: 기존 편집 계약 테스트와 같은 실물 2종.
+  - `samples/2025년 기부·답례품 실적 지자체 보고서_양식.hwpx` (30쪽, 표 53) — set-cell.
+  - `samples/field-01.hwp` (3쪽, 누름틀) — fill-fields / replace-text.
+- 편집 결과물은 gitignore 된 `output/` 아래에만 생성. 저장소 무변경.
+- 바이너리: `target/release-test/rhwp.exe` (rhwp v0.8.2, devel 5a4f26d0d).
+- 재현: `python tools/measure_edit_render_gate.py` (기본 2회 반복으로 결정성 동시 검증).
+
+## 2. 결정성 선확인 — hard 게이트 전제 성립
+
+같은 문서 자기 pair diff 를 2회 반복, 봉투(JSON 전체)를 비교했다.
+
+| 문서 | maxDisp | status | exit | 반복 봉투 동일 |
+| --- | ---: | --- | ---: | --- |
+| field-01.hwp (3쪽) | 0.0 | PASS | 0 | 예 (완전 동일) |
+| 기부·답례품 양식.hwpx (30쪽) | 0.0 | PASS | 0 | 예 (완전 동일) |
+
+편집 전후 비교 5종(아래 표 전부)도 각 2회 반복에서 봉투가 완전히 동일했다.
+**비결정 관측 0건** — soft(관측) 모드로 낮출 이유가 없어, 게이트를 hard
+(계약 테스트 단언)로 설계했다. 참고: `LAYOUT_OVERFLOW` 진단 로그는 stderr 로만
+나가고 stdout JSON 계약을 오염시키지 않는다(이 역시 반복 간 동일했다).
+
+## 3. 편집 전후 maxDisp 분포 실측
+
+| 편집 | fixture | maxDisp(px) | status | exit | 쪽수 | 변화 페이지 |
+| --- | --- | ---: | --- | ---: | --- | --- |
+| set-cell (표1 (0,0) → "실증테스트값") | 양식.hwpx | 539.6 | OVER | 3 | 30→30 | page 0 만 |
+| set-cell, `--max-disp 600` | 〃 | 539.6 | PASS | 0 | 30→30 | 〃 |
+| fill-fields (회사명 → "주식회사 검증") | field-01 | 152.0 | STRUCT_MISMATCH | 3 | 3→3 | page 0 만 (TextRun −2) |
+| fill-fields, `--max-disp 100000` | 〃 | 152.0 | STRUCT_MISMATCH | 3 | 3→3 | 〃 |
+| replace-text 동폭 (회사→기관, 2자→2자) | field-01 | 0.0 | PASS | 0 | 3→3 | 없음 |
+| replace-text 장문 (회사→14자, red 주입) | field-01 | 279.0 | OVER | 3 | 3→3 | page 0 만 |
+
+관찰:
+
+1. **국소성** — 모든 편집에서 변화(변위·구조)는 편집이 닿은 페이지 1곳에만
+   나타났고, 나머지 페이지는 전부 maxDisp 정확히 0.0·구조 불일치 없음이었다
+   (set-cell 은 30쪽 중 29쪽이 0). 쪽수도 전 케이스 불변.
+2. **편집 페이지의 변위는 편집 그 자체다** — set-cell 539.6px 는 셀의 다행
+   안내문이 실값 한 줄로 접히며 생긴 정당한 변화다. 편집 페이지에 1px 임계를
+   그대로 적용하면 정상 편집이 전부 OVER 가 된다(너무 엄함의 실측 사례).
+3. **fill-fields 의 구조 신호** — 누름틀 안내 run 이 실값 run 으로 합쳐지며
+   TextRun −2. `--max-disp` 를 아무리 키워도 STRUCT_MISMATCH·exit 3 이
+   유지된다 — 구조 회귀는 임계로 침묵시킬 수 없는 독립 하드 신호다.
+4. **동폭 치환은 기하 0** — 같은 글자 수·폭의 치환(회사→기관)은 maxDisp 정확히
+   0.0. 편집·레이아웃 어느 쪽의 잡음도 이 0 을 먼저 깨므로 예민한 카나리다.
+
+## 4. 임계 제안 (확정은 메인테이너 몫)
+
+실측 분포에서 나오는 제안이며, `tests/edit_render_diff_gate.rs` 가 이 값으로
+고정돼 있다. 값 변경은 테스트 상수 수정으로 끝난다.
+
+| 축 | 제안 | 근거 |
+| --- | --- | --- |
+| 비편집 페이지 변위 | **0.0px (동일해야 함)** | 실측 전 케이스에서 정확히 0. 0 초과는 편집이 닿지 않은 곳이 움직인 것 = 레이아웃 회귀. |
+| 쪽수 | **불변** | 실측 전 케이스 불변. 쪽수 변화는 render-diff 자체도 최강 신호(PAGE_MISMATCH)로 정의. |
+| 편집 페이지 변위 상한 | set-cell 류 **600px**, fill-fields 류 **200px** | 실측 최대 539.6 / 152.0 + 여유 ~10~30%. 편집 자체의 정당한 변화를 통과시키되, 회귀로 증폭되면 잡는 봉투. |
+| 동폭 치환 | **0.0px 고정** | 실측 정확히 0. 잡음 조기 경보 카나리. |
+| 구조 신호 | fill-fields TextRun −2 를 **정체까지 고정** | 실측값. 다른 타입·다른 개수로 변하면 편집 의미가 달라진 것. |
+
+너무 엄함/너무 느슨함의 경계 실측: 기본 임계 1.0px 에서는 정상 set-cell 도
+OVER(정상 편집을 막음), 600px 에서는 PASS 하면서 장문 치환 red(279px)는 1.0px
+기본 임계 경로로 계속 잡힌다.
+
+## 5. red 실증 (변이 후 복원)
+
+게이트가 "항상 green" 이 아님을 두 경로로 실증했다.
+
+1. **상시 red 테스트** — `disruptive_edit_is_caught_as_regression`: 장문 치환
+   (회사→주식회사법인등기부등본상호명)은 기본 임계에서 OVER·maxDisp 279.0·
+   exit 3 으로 잡힌다. 이 테스트가 계속 CI 에서 red 경로를 돌린다.
+2. **일회 변이 실증** (2026-08-08, 검증 후 복원) — 카나리 테스트의 `--replace`
+   를 장문으로 바꿔 돌리면:
+   `assertion 'left == right' failed: ... "status":"OVER","maxDisp":279.0,`
+   `"regression":true` (exit 3 ≠ 기대 0) 로 즉시 실패했다. 복원 후 5/5 green.
+
+## 6. 산출물과 재현 절차
+
+- `tests/edit_render_diff_gate.rs` — 계약 테스트 5건. 기존 CI 가 `tests/` 를
+  그대로 돌리므로 워크플로 변경 없음(상시 게이트화).
+- `tools/measure_edit_render_gate.py` — 실측 러너. 재현:
+
+```
+cargo build --profile release-test --bin rhwp   # 바이너리가 없을 때만
+python tools/measure_edit_render_gate.py        # 기본 2회 반복, output/ 아래 봉투 저장
+cargo test --profile release-test --test edit_render_diff_gate
+```
+
+- 검증 로그 (이 PC, 2026-08-08): 계약 테스트 5 passed / 0 failed, 러너 exit 0
+  (전 측정 결정적), `cargo clippy -- -D warnings` 통과.
+
+## 7. 한계와 다음 조각
+
+- fixture 2종·편집 3종의 분포다. 임계 일반화에는 코퍼스 확대(편집 대상 문서
+  10~50종)가 필요하다 — 러너가 그 확대의 재현 도구다.
+- 편집 페이지 상한(600/200)은 이 fixture 의 편집 의미에 묶인 값이다. fixture 나
+  편집 내용을 바꾸면 재실측이 선행돼야 한다(러너 1회 실행).
+- insert-image·redact·sanitize 등 나머지 편집 동사의 전후 분포는 미측정 —
+  같은 러너 패턴으로 후속 조각에서 확장 가능하다.

--- a/tests/edit_render_diff_gate.rs
+++ b/tests/edit_render_diff_gate.rs
@@ -1,0 +1,335 @@
+//! [R50] 편집 전후 render-diff 회귀 게이트 계약 테스트.
+//!
+//! 이미 있는 `rhwp render-diff <전> <후> --json`(pair 모드, 단일 출처:
+//! `src/diagnostics/render_geom_diff.rs`)을 대표 편집 3종의 전후에 배선한다.
+//! 편집 자체는 편집 페이지의 기하를 정당하게 바꾸므로, 게이트가 고정하는 것은
+//! "편집이 얼마나 바뀌었나"가 아니라 **편집 전후 비교의 불변식**이다:
+//!
+//! ① 결정성 — 같은 비교를 반복하면 봉투가 완전히 동일하다 (게이트 전제).
+//! ② 국소성 — 변화(변위·구조)는 편집이 닿은 페이지 1곳에만 나타나고,
+//!    나머지 페이지는 maxDisp == 0.0 · 구조 불일치 없음. 쪽수도 불변.
+//! ③ 상한 — 편집 페이지의 maxDisp 는 실측 기반 제안 임계 이내
+//!    (set-cell 539.6px 실측 → 600px, fill-fields 152.0px 실측 → 200px).
+//!    **임계 확정은 메인테이너 몫** — 근거·분포는
+//!    `mydocs/report/edit_render_gate_r1_20260808.md`.
+//! ④ 카나리 — 동폭 치환(회사→기관)은 기하 변화가 정확히 0 (maxDisp 0.0, PASS).
+//! ⑤ red 실증 — 폭이 크게 다른 장문 치환은 OVER·exit 3 으로 잡힌다.
+//!
+//! red 주입 실증 (2026-08-08, 변이 후 복원):
+//! - 카나리 치환을 장문(회사→주식회사법인등기부등본상호명)으로 바꾸면
+//!   status=OVER, maxDisp=279.0, exit 3 — ④가 red 로 간다.
+//! - 편집 페이지 상한을 실측 아래(--max-disp 1.0 기본)로 두면 set-cell 전후가
+//!   OVER·exit 3 — ③이 red 로 간다 (본 파일에서는 --max-disp 600 으로 green).
+//!
+//! 실측 전량은 `python tools/measure_edit_render_gate.py` 로 재현된다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// 실제 배포 정부 양식(30쪽, 표 53) — set-cell 계약 테스트와 같은 fixture.
+const FORM_HWPX: &str = "samples/2025년 기부·답례품 실적 지자체 보고서_양식.hwpx";
+/// 누름틀 3쪽 문서 — fill-fields/replace-text 계약 테스트와 같은 fixture.
+const FIELD_HWP: &str = "samples/field-01.hwp";
+
+/// render-diff `--json` 종료 코드 계약: 3 = 회귀 검출 (런타임 실패 1 과 구분).
+const EXIT_REGRESSION: i32 = 3;
+
+fn sample(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn temp_out(tag: &str, ext: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "rhwp-r50gate-{tag}-{}-{}.{ext}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos()
+    ))
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn parse_json(args: &[&str], output: &Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout 이 순수 JSON 이 아닙니다 ({e}).\n{}",
+            describe(args, output)
+        )
+    })
+}
+
+/// 전후 pair diff — (종료코드, 봉투). stderr(레이아웃 진단)는 계약 채널이 아니다.
+fn render_diff(a: &Path, b: &Path, extra: &[&str]) -> (i32, serde_json::Value) {
+    let mut args = vec!["render-diff", a.to_str().unwrap(), b.to_str().unwrap()];
+    args.extend_from_slice(extra);
+    args.push("--json");
+    let output = run(&args);
+    let code = output.status.code().unwrap_or(-1);
+    (code, parse_json(&args, &output))
+}
+
+/// 국소성 단언 — 변화(변위>0 또는 구조 불일치)가 있는 페이지 번호 목록.
+fn changed_pages(v: &serde_json::Value) -> Vec<u64> {
+    v["pages"]
+        .as_array()
+        .expect("pages")
+        .iter()
+        .filter(|p| {
+            p["maxDisp"].as_f64().expect("maxDisp") > 0.0
+                || p["structureMismatch"].as_bool().expect("structureMismatch")
+        })
+        .map(|p| p["page"].as_u64().expect("page"))
+        .collect()
+}
+
+/// 쪽수 불변 단언 — 편집이 페이지 수를 바꾸면 게이트 최강 신호다.
+fn assert_page_count_stable(v: &serde_json::Value) {
+    assert_eq!(v["pageCountMismatch"], false, "{v}");
+    assert_eq!(v["pageCountA"], v["pageCountB"], "{v}");
+}
+
+/// export-tables 로 본문 최상위 표 첫 셀 좌표를 고른다 (set-cell 계약 테스트와 동일).
+fn pick_top_level_cell(doc: &Path) -> (u64, u64, u64) {
+    let args = ["export-tables", doc.to_str().unwrap(), "--json"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = parse_json(&args, &output);
+    let table = v["tables"]
+        .as_array()
+        .expect("tables")
+        .iter()
+        .find(|t| t.get("containerPath").is_none())
+        .expect("본문 최상위 표");
+    let cell = &table["cells"][0];
+    (
+        table["index"].as_u64().expect("index"),
+        cell["row"].as_u64().expect("row"),
+        cell["col"].as_u64().expect("col"),
+    )
+}
+
+/// ① 결정성 — 자기 pair diff 는 변위 정확히 0 이고, 반복해도 봉투가 동일하다.
+/// 이 성질이 깨지면 게이트는 hard 로 쓸 수 없다 (soft/관측 모드로 강등해야 한다).
+#[test]
+fn self_pair_diff_is_deterministic_zero() {
+    let doc = sample(FIELD_HWP);
+    let (code1, v1) = render_diff(&doc, &doc, &[]);
+    let (code2, v2) = render_diff(&doc, &doc, &[]);
+    assert_eq!(code1, 0, "{v1}");
+    assert_eq!(code2, 0, "{v2}");
+    assert_eq!(v1["status"], "PASS", "{v1}");
+    assert_eq!(v1["maxDisp"].as_f64(), Some(0.0), "{v1}");
+    assert_eq!(v1["regression"], false, "{v1}");
+    // 봉투 전체 동일 — maxDisp 만이 아니라 페이지 상세까지 결정적이어야 한다.
+    assert_eq!(v1, v2, "같은 비교의 봉투가 달라지면 게이트 판정이 흔들린다");
+}
+
+/// ②③ set-cell 전후 — 변화는 편집 페이지 1곳, 나머지 29쪽 변위 0, 쪽수 30 불변.
+/// 편집 페이지 상한: 실측 539.6px → 제안 임계 600px 에서 PASS·exit 0.
+/// 기본 임계(1.0px)에서는 OVER·exit 3 — red 경로가 살아 있음을 함께 고정한다.
+#[test]
+fn set_cell_before_after_is_localized_and_within_proposed_ceiling() {
+    let doc = sample(FORM_HWPX);
+    let (tbl, row, col) = pick_top_level_cell(&doc);
+    let out = temp_out("setcell", "hwpx");
+    let (ts, rs, cs) = (tbl.to_string(), row.to_string(), col.to_string());
+    let args = [
+        "edit",
+        "set-cell",
+        doc.to_str().unwrap(),
+        "--table",
+        &ts,
+        "--row",
+        &rs,
+        "--col",
+        &cs,
+        "--text",
+        "실증테스트값",
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+
+    // 기본 임계(1.0px): 편집 자체가 임계를 넘으므로 OVER·exit 3 (실측 539.6px).
+    let (code, v) = render_diff(&doc, &out, &[]);
+    assert_eq!(code, EXIT_REGRESSION, "{v}");
+    assert_eq!(v["status"], "OVER", "{v}");
+    assert_eq!(v["regression"], true, "{v}");
+    assert_page_count_stable(&v);
+    // 구조는 불변 — set-cell 은 셀 텍스트만 바꾼다 (실측: structPages 0).
+    assert_eq!(v["structPages"].as_u64(), Some(0), "{v}");
+    assert_eq!(v["hardStructPages"].as_u64(), Some(0), "{v}");
+    // 국소성: 변화가 있는 페이지는 정확히 1곳 (편집이 닿은 페이지).
+    let changed = changed_pages(&v);
+    assert_eq!(changed.len(), 1, "변화 페이지 {changed:?}: {v}");
+    assert_eq!(v["worstPage"].as_u64(), Some(changed[0]), "{v}");
+    // 편집은 보여야 한다 — 변위 0 이면 편집이 반영되지 않은 것.
+    assert!(v["maxDisp"].as_f64().expect("maxDisp") > 0.0, "{v}");
+
+    // 제안 임계 600px (실측 539.6px + 여유): PASS·exit 0. 임계 확정은 메인테이너 몫.
+    let (code600, v600) = render_diff(&doc, &out, &["--max-disp", "600"]);
+    assert_eq!(code600, 0, "{v600}");
+    assert_eq!(v600["status"], "PASS", "{v600}");
+    assert_eq!(v600["regression"], false, "{v600}");
+    let _ = std::fs::remove_file(&out);
+}
+
+/// ②③ fill-fields 전후 — 변화는 편집 페이지 1곳(구조: TextRun -2), 쪽수 3 불변,
+/// 편집 페이지 maxDisp 는 실측 152.0px → 제안 상한 200px 이내.
+/// 구조 불일치는 --max-disp 를 아무리 키워도 침묵하지 않는다 (임계 독립 하드 신호).
+#[test]
+fn fill_fields_before_after_struct_change_is_localized() {
+    let doc = sample(FIELD_HWP);
+    let out = temp_out("fill", "hwp");
+    let args = [
+        "edit",
+        "fill-fields",
+        doc.to_str().unwrap(),
+        "--data",
+        r#"{"회사명":"주식회사 검증"}"#,
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+
+    let (code, v) = render_diff(&doc, &out, &[]);
+    assert_eq!(code, EXIT_REGRESSION, "{v}");
+    assert_eq!(v["status"], "STRUCT_MISMATCH", "{v}");
+    assert_page_count_stable(&v);
+    let changed = changed_pages(&v);
+    assert_eq!(changed.len(), 1, "변화 페이지 {changed:?}: {v}");
+    // 편집 페이지 변위 상한 — 실측 152.0px, 제안 200px (근거는 r1 보고서).
+    let max_disp = v["maxDisp"].as_f64().expect("maxDisp");
+    assert!(
+        max_disp > 0.0 && max_disp <= 200.0,
+        "편집 페이지 변위 {max_disp}px 가 제안 상한 200px 를 벗어남: {v}"
+    );
+    // 구조 변화의 정체 고정 — 누름틀 안내 run 이 실값 run 으로 합쳐지며 TextRun -2.
+    let page = v["pages"]
+        .as_array()
+        .expect("pages")
+        .iter()
+        .find(|p| p["page"].as_u64() == Some(changed[0]))
+        .expect("변화 페이지");
+    let deltas = page["typeDeltas"].as_array().expect("typeDeltas");
+    assert_eq!(deltas.len(), 1, "{v}");
+    assert_eq!(deltas[0]["nodeType"], "TextRun", "{v}");
+    assert_eq!(deltas[0]["net"].as_i64(), Some(-2), "{v}");
+
+    // 임계 독립성: --max-disp 100000 에서도 STRUCT_MISMATCH·exit 3 유지.
+    let (code_hi, v_hi) = render_diff(&doc, &out, &["--max-disp", "100000"]);
+    assert_eq!(code_hi, EXIT_REGRESSION, "{v_hi}");
+    assert_eq!(v_hi["status"], "STRUCT_MISMATCH", "{v_hi}");
+    let _ = std::fs::remove_file(&out);
+}
+
+/// ④ 카나리 — 동폭 치환(회사→기관 2자→2자)은 기하 변화가 정확히 0 이어야 한다.
+/// 편집·레이아웃 어느 쪽이든 잡음이 생기면 이 0.0 이 먼저 깨진다.
+///
+/// red 주입 실증(변이 후 복원, 2026-08-08): --replace 를
+/// "주식회사법인등기부등본상호명"(14자)으로 바꾸면 OVER·maxDisp 279.0·exit 3.
+#[test]
+fn same_width_replace_is_zero_disp_canary() {
+    let doc = sample(FIELD_HWP);
+    let out = temp_out("canary", "hwp");
+    let args = [
+        "edit",
+        "replace-text",
+        doc.to_str().unwrap(),
+        "--find",
+        "회사",
+        "--replace",
+        "기관",
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+
+    let (code, v) = render_diff(&doc, &out, &[]);
+    assert_eq!(code, 0, "{v}");
+    assert_eq!(v["status"], "PASS", "{v}");
+    assert_eq!(v["regression"], false, "{v}");
+    assert_eq!(v["maxDisp"].as_f64(), Some(0.0), "{v}");
+    assert_page_count_stable(&v);
+    assert!(changed_pages(&v).is_empty(), "{v}");
+    let _ = std::fs::remove_file(&out);
+}
+
+/// ⑤ red 경로 상시 실증 — 폭이 크게 다른 장문 치환은 기본 임계에서 반드시
+/// OVER·exit 3 으로 잡힌다. 게이트가 "항상 green" 으로 퇴화하지 않았음을 고정한다.
+#[test]
+fn disruptive_edit_is_caught_as_regression() {
+    let doc = sample(FIELD_HWP);
+    let out = temp_out("red", "hwp");
+    let args = [
+        "edit",
+        "replace-text",
+        doc.to_str().unwrap(),
+        "--find",
+        "회사",
+        "--replace",
+        "주식회사법인등기부등본상호명",
+        "-o",
+        out.to_str().unwrap(),
+        "--json",
+    ];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+
+    let (code, v) = render_diff(&doc, &out, &[]);
+    assert_eq!(code, EXIT_REGRESSION, "{v}");
+    assert_eq!(v["status"], "OVER", "{v}");
+    assert_eq!(v["regression"], true, "{v}");
+    // 파괴적 편집도 국소성은 유지 (실측: page 0 한정, maxDisp 279.0).
+    assert_page_count_stable(&v);
+    assert!(v["maxDisp"].as_f64().expect("maxDisp") > 1.0, "{v}");
+    let _ = std::fs::remove_file(&out);
+}

--- a/tools/measure_edit_render_gate.py
+++ b/tools/measure_edit_render_gate.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python
+"""[R50] 편집 전후 render-diff 회귀 게이트 실측 러너.
+
+대표 편집 3종(set-cell / fill-fields / replace-text)을 실물 fixture 에 적용하고,
+편집 전후를 `rhwp render-diff <전> <후> --json`(pair 모드)으로 비교해 maxDisp
+분포·status·종료 코드를 기록한다. 게이트 전제인 **결정성**(같은 비교를 반복해도
+봉투가 완전히 동일한지)을 먼저 검증한다.
+
+측정만 한다 — 임계 확정은 메인테이너 몫이다. 결과 해석과 임계 제안은
+`mydocs/report/edit_render_gate_r1_20260808.md` 참조.
+
+사용:
+    python tools/measure_edit_render_gate.py
+    python tools/measure_edit_render_gate.py --bin target/release-test/rhwp.exe --runs 3
+
+산출물: --out-dir (기본 output/r50_edit_render_gate/) 아래 편집 결과물과 diff 봉투
+JSON 전부. 저장소에는 아무것도 쓰지 않는다(output/ 은 gitignore).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# 계약 테스트(tests/edit_render_diff_gate.rs)와 같은 실물 fixture.
+FORM_HWPX = ROOT / "samples" / "2025년 기부·답례품 실적 지자체 보고서_양식.hwpx"
+FIELD_HWP = ROOT / "samples" / "field-01.hwp"
+
+
+def run_cmd(exe: Path, args: list[str]) -> tuple[int, bytes, bytes]:
+    """rhwp 하위 명령 실행 — (종료코드, stdout, stderr). stdout 은 JSON 계약 채널."""
+    p = subprocess.run(
+        [str(exe), *args], capture_output=True, timeout=600, check=False
+    )
+    return p.returncode, p.stdout, p.stderr
+
+
+def run_json(exe: Path, args: list[str]) -> tuple[int, dict]:
+    rc, out, err = run_cmd(exe, args)
+    try:
+        return rc, json.loads(out.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError) as e:
+        sys.exit(
+            f"오류: stdout 이 순수 JSON 이 아님 ({e})\n명령: rhwp {' '.join(args)}\n"
+            f"stderr:\n{err.decode('utf-8', 'replace')[:2000]}"
+        )
+
+
+def save(out_dir: Path, name: str, payload: dict) -> None:
+    (out_dir / name).write_text(
+        json.dumps(payload, ensure_ascii=False, indent=1), encoding="utf-8"
+    )
+
+
+def changed_pages(envelope: dict) -> list[int]:
+    """maxDisp>0 또는 구조 불일치가 있는 페이지 번호 목록 (국소성 판정)."""
+    return [
+        p["page"]
+        for p in envelope["pages"]
+        if p["maxDisp"] > 0 or p["structureMismatch"]
+    ]
+
+
+def pair_diff(
+    exe: Path,
+    a: Path,
+    b: Path,
+    out_dir: Path,
+    tag: str,
+    runs: int,
+    extra: list[str] | None = None,
+) -> tuple[int, dict, bool]:
+    """전후 pair diff 를 `runs`회 반복 — (종료코드, 봉투, 결정성 여부)."""
+    envelopes = []
+    rc = 0
+    for i in range(runs):
+        rc, v = run_json(
+            exe, ["render-diff", str(a), str(b), "--json", *(extra or [])]
+        )
+        envelopes.append(v)
+        save(out_dir, f"{tag}_run{i + 1}.json", v)
+    deterministic = all(v == envelopes[0] for v in envelopes[1:])
+    return rc, envelopes[0], deterministic
+
+
+def pick_top_level_cell(exe: Path, doc: Path) -> tuple[int, int, int]:
+    """export-tables 로 본문 최상위 표 첫 셀 좌표를 고른다 (계약 테스트와 동일 로직)."""
+    rc, v = run_json(exe, ["export-tables", str(doc), "--json"])
+    if rc != 0:
+        sys.exit(f"오류: export-tables 실패 (exit {rc})")
+    table = next(t for t in v["tables"] if "containerPath" not in t)
+    cell = table["cells"][0]
+    return table["index"], cell["row"], cell["col"]
+
+
+def main() -> int:
+    if hasattr(sys.stdout, "reconfigure"):  # Windows cp949 콘솔 대비
+        sys.stdout.reconfigure(encoding="utf-8")
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--bin",
+        default=str(ROOT / "target" / "release-test" / "rhwp.exe"),
+        help="rhwp 바이너리 (기본: target/release-test/rhwp.exe)",
+    )
+    ap.add_argument(
+        "--out-dir", default=str(ROOT / "output" / "r50_edit_render_gate")
+    )
+    ap.add_argument("--runs", type=int, default=2, help="결정성 반복 횟수 (기본 2)")
+    args = ap.parse_args()
+
+    exe = Path(args.bin)
+    if not exe.exists():
+        sys.exit(
+            f"오류: 바이너리 없음: {exe}\n"
+            "먼저 빌드: cargo build --profile release-test --bin rhwp"
+        )
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    rows: list[tuple[str, int, dict, bool]] = []
+
+    # ── 1. 결정성 선확인: 같은 문서 자기 pair diff 반복 → maxDisp 0.0, 봉투 동일.
+    for tag, doc in [("self_field01", FIELD_HWP), ("self_form", FORM_HWPX)]:
+        rc, env, det = pair_diff(exe, doc, doc, out_dir, tag, args.runs)
+        rows.append((f"결정성 {tag}", rc, env, det))
+
+    # ── 2. set-cell: 본문 최상위 표 첫 셀에 실값 기록 (기존 계약 테스트와 같은 편집).
+    tbl, row, col = pick_top_level_cell(exe, FORM_HWPX)
+    setcell_out = out_dir / "setcell.hwpx"
+    rc, _, _ = run_cmd(
+        exe,
+        [
+            "edit", "set-cell", str(FORM_HWPX),
+            "--table", str(tbl), "--row", str(row), "--col", str(col),
+            "--text", "실증테스트값", "-o", str(setcell_out), "--json",
+        ],
+    )
+    if rc != 0:
+        sys.exit(f"오류: set-cell 실패 (exit {rc})")
+    rc, env, det = pair_diff(exe, FORM_HWPX, setcell_out, out_dir, "setcell", args.runs)
+    rows.append(("set-cell 전후", rc, env, det))
+    # 제안 임계 600px 적용 시 PASS 인지 (편집 페이지 상한 제안 근거).
+    rc, env, det = pair_diff(
+        exe, FORM_HWPX, setcell_out, out_dir, "setcell_t600", 1, ["--max-disp", "600"]
+    )
+    rows.append(("set-cell 전후 @600px", rc, env, det))
+
+    # ── 3. fill-fields: 누름틀 채우기.
+    filled_out = out_dir / "filled.hwp"
+    rc, _, _ = run_cmd(
+        exe,
+        [
+            "edit", "fill-fields", str(FIELD_HWP),
+            "--data", '{"회사명":"주식회사 검증"}',
+            "-o", str(filled_out), "--json",
+        ],
+    )
+    if rc != 0:
+        sys.exit(f"오류: fill-fields 실패 (exit {rc})")
+    rc, env, det = pair_diff(exe, FIELD_HWP, filled_out, out_dir, "fill", args.runs)
+    rows.append(("fill-fields 전후", rc, env, det))
+    # 구조 불일치는 임계를 아무리 키워도 침묵하지 않는지.
+    rc, env, det = pair_diff(
+        exe, FIELD_HWP, filled_out, out_dir, "fill_t1e5", 1, ["--max-disp", "100000"]
+    )
+    rows.append(("fill-fields 전후 @1e5px", rc, env, det))
+
+    # ── 4. replace-text 동폭 치환(회사→기관): 기하 변화 0 카나리.
+    same_out = out_dir / "replaced_same.hwp"
+    rc, _, _ = run_cmd(
+        exe,
+        [
+            "edit", "replace-text", str(FIELD_HWP),
+            "--find", "회사", "--replace", "기관",
+            "-o", str(same_out), "--json",
+        ],
+    )
+    if rc != 0:
+        sys.exit(f"오류: replace-text(동폭) 실패 (exit {rc})")
+    rc, env, det = pair_diff(exe, FIELD_HWP, same_out, out_dir, "replace_same", args.runs)
+    rows.append(("replace-text 동폭 전후", rc, env, det))
+
+    # ── 5. red 주입: 폭이 크게 다른 장문 치환 — 게이트가 red(exit 3)로 가는지 실증.
+    long_out = out_dir / "replaced_long.hwp"
+    rc, _, _ = run_cmd(
+        exe,
+        [
+            "edit", "replace-text", str(FIELD_HWP),
+            "--find", "회사", "--replace", "주식회사법인등기부등본상호명",
+            "-o", str(long_out), "--json",
+        ],
+    )
+    if rc != 0:
+        sys.exit(f"오류: replace-text(장문) 실패 (exit {rc})")
+    rc, env, det = pair_diff(exe, FIELD_HWP, long_out, out_dir, "replace_long", args.runs)
+    rows.append(("replace-text 장문(red 주입)", rc, env, det))
+
+    # ── 요약표.
+    print(f"\n=== R50 편집 전후 render-diff 실측 (runs={args.runs}) ===")
+    print(f"{'측정':<28} {'exit':>4} {'status':<16} {'maxDisp':>9} "
+          f"{'쪽수':>7} {'변화쪽':<10} 결정적")
+    ok = True
+    for name, rc, env, det in rows:
+        pages = f"{env['pageCountA']}->{env['pageCountB']}"
+        ch = ",".join(map(str, changed_pages(env))) or "-"
+        print(
+            f"{name:<28} {rc:>4} {env['status']:<16} {env['maxDisp']:>9.1f} "
+            f"{pages:>7} {ch:<10} {det}"
+        )
+        ok = ok and det
+    print(f"\n봉투 저장: {out_dir}")
+    if not ok:
+        print("경고: 비결정 측정 발견 — 게이트를 hard 로 올리기 전에 원인 규명 필요")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 무엇 (#4199 — R50)

이미 있는 `rhwp render-diff <전> <후> --json`(pair 모드)을 대표 편집 3종의 전후에 배선한 상시 게이트. 재구현 없음(단일 출처 유지), 기존 파일 수정 0, `.github/workflows` 무변경 — 기존 CI 가 `tests/` 를 그대로 돌리므로 상시화된다.

- `tests/edit_render_diff_gate.rs`(335줄) — 계약 5건: ①결정성(자기 pair diff 봉투 동일·0.0) ②국소성(변화는 편집 페이지 1곳, 나머지 변위 0, 쪽수 불변) ③편집 페이지 상한(제안 임계 600/200px) ④동폭 치환 0.0 카나리 ⑤파괴적 편집 red 검출 상시 실증
- `tools/measure_edit_render_gate.py`(222줄) — 실측 러너(재현·코퍼스 확대용)
- `mydocs/report/edit_render_gate_r1_20260808.md`(114줄) — 분포 실측·임계 제안·red 실증 기록

## 판단

- **hard vs soft**: 결정성 선확인 결과 비결정 관측 0건(전 측정 2회 반복 봉투 완전 동일) → hard 게이트. 비결정이 나타나면 soft 강등이 예고된 경로다(테스트 주석 명시).
- **편집 페이지의 변위는 편집 그 자체**라 기본 임계를 그대로 쓰면 정상 편집도 OVER 가 된다(set-cell 실측 539.6px). 게이트가 고정하는 것은 **비편집 페이지 0.0·쪽수 불변·국소성**의 불변식이고, 편집 페이지 상한(600/200px)은 실측+여유의 **제안** — 확정은 메인테이너 몫.
- **구조 신호는 임계 독립**: fill-fields 의 TextRun −2 는 `--max-disp 100000` 에도 STRUCT_MISMATCH·exit 3 유지(실측) — 구조 회귀는 임계로 침묵 불가함을 함께 고정.

## 검증

- 계약 5/5 green (`cargo test --profile release-test --test edit_render_diff_gate`, 0.36s)
- **red 실증**: 카나리에 장문 치환 변이 주입 → OVER·maxDisp 279.0·exit 3 즉시 실패 확인 후 복원
- 실측 러너 재현 exit 0(전 측정 결정적), `cargo clippy --all-targets` 무경고, rustfmt·`git diff --check` 통과
- 렌더링 코드 무변경(테스트·도구·문서만)이라 전/후 시각 비교 대상 없음

closes #4199
refs #3907

🤖 Generated with [Claude Code](https://claude.com/claude-code)
