### PR TITLE
feat(mcp): 전 도구 MCP annotations 4필드 선언 — 기존 선언에서 유도 (#4225, T3)

### DIFF
--- a/mydocs/report/task_t3_mcp_annotations.md
+++ b/mydocs/report/task_t3_mcp_annotations.md
@@ -1,0 +1,71 @@
+# T3 — MCP 도구 주석(annotations) 선언 (#4220, refs #3907)
+
+## 무엇
+
+`capabilities --mcp` 매니페스트와 `mcp-serve` `tools/list` 의 전 도구(무상태 43 + 세션 12)에
+MCP 표준 `annotations` 4필드를 선언했다. 종전에는 0건이라, MCP 호스트가 "이 도구가 읽기
+전용인가 / 원본을 덮는가"를 실행 전에 판정할 근거가 없었다.
+
+## 스펙 출처
+
+- https://modelcontextprotocol.io/specification/2025-06-18/server/tools — `Tool.annotations`
+  ("optional properties describing tool behavior"; 클라이언트는 신뢰할 수 없는 서버의
+  힌트를 신뢰하면 안 된다는 경고 포함).
+- `modelcontextprotocol/schema/2025-06-18/schema.ts` — `ToolAnnotations`:
+  `readOnlyHint`(기본 false) · `destructiveHint`(기본 true, readOnlyHint=false 일 때만 의미) ·
+  `idempotentHint`(기본 false) · `openWorldHint`(기본 true). 2025-03-26 개정판 신설, 2025-06-18 유지.
+
+스펙 기본값이 위험 쪽(destructive=true, openWorld=true)으로 기울어 있으므로, 기본값에
+기대지 않고 4필드를 전부 명시한다 — `inputSchema.required` 를 빈 배열이라도 선언하는
+기존 규약과 같은 이유다.
+
+## 판정 규칙 (단일 출처에서 유도 — 손 나열 금지)
+
+무상태 도구(`derive_mcp_tool_annotations`, src/main.rs):
+
+| 필드 | 유도 근거 |
+|---|---|
+| `readOnlyHint` | 봉투 `outputFields` 에 산출 경로 필드(`output`/`outputDir`)가 **없으면** true. 출력이 선택인 도구(`hwp_table_to_csv`)는 "쓸 수 있다"는 이유로 false — 힌트는 안전 방향으로 보수적이어야 한다. |
+| `destructiveHint` | cli 배선(`args`+`optionalArgs`)에 `--in-place` 축이 있을 때만 true. 그 밖의 쓰기는 산출 분리(-o) 원칙의 추가형이다. 현재 해당 도구는 **hwp_redact 하나**. |
+| `idempotentHint` | 전부 true — 무상태 도구는 매 호출이 같은 원본에서 다시 계산하는 결정론 변환이라 같은 인자 재실행은 같은 산출을 다시 쓸 뿐이다. |
+| `openWorldHint` | 전부 false — 로컬 파일만 다루며 네트워크 등 개방 세계 축이 없다. |
+
+세션 도구(`session_tool_annotations`, src/mcp_serve.rs): 읽기/편집 경계는 프로필 경계의
+단일 출처 `agent_profiles::SESSION_READ_TOOLS` 에서 유도하고, 그 표가 말하지 않는 축만 판정:
+
+- `hwp_doc_render_page`/`hwp_doc_save` 는 read 표 소속 여부와 무관하게 파일을 쓰므로
+  (inputSchema 의 `output` 속성) readOnlyHint=false.
+- `hwp_doc_save` 만 destructiveHint=true — `output` 이 hwp_open 으로 연 **원본 경로일 수
+  있고** `session_save` 에 같은 경로 거부가 없다. 무상태 `--in-place` 축의 세션판이다.
+- `hwp_open` idempotent=false(호출마다 새 docId), `hwp_doc_replace_text` idempotent=false
+  (이미 치환된 IR 위에 겹쳐 적용될 수 있다 — 매번 원본에서 다시 계산하는 무상태
+  `hwp_replace_text` 가 true 인 것과 대비).
+
+`tools/list` 의 무상태 도구 주석은 매니페스트 값을 **그대로 되비춘다** — 서버가 따로
+판정하면 두 표면이 어긋난다.
+
+## 동반 변경
+
+- `capabilities_schema.rs`: `McpTool.annotations` + `McpToolAnnotations` 정의 추가,
+  `CAPABILITIES_SCHEMA_VERSION` 1.1 → 1.2 (필드 추가 = minor, #4114 교훈 — 봉투에 새
+  필드를 실으면 스키마 선언을 동반한다. 미동반 시 `mcp_schema_matches_live_manifest_output`
+  가 잡는다).
+- Node 바인딩: `gen:types` 는 `capabilities`(–mcp 아님)에서 생성하므로 드리프트 없음
+  (gen:check 로 확인).
+
+## 대조 테스트 (tests/mcp_tool_annotations_contract.rs)
+
+① 전 도구 4필드 boolean 선언 + 스펙 밖 필드 금지 ② readOnlyHint ↔ 봉투 산출 경로
+선언 정합 + category=edit 도구는 readOnly 불가(원천이 다른 두 선언의 교차 검증)
+③ destructiveHint ↔ `--in-place` 배선 실물 + 황금 목록 `[hwp_redact]`
+④ `tools/list` 되비춤 정합 + 세션 12종 도구별 판정 고정.
+
+red 실증: hwp_redact 의 annotations 를 제거하는 변이 → ① red → 복원 green.
+
+## 게이트
+
+- cargo test: mcp_tool_annotations_contract(신규) · mcp_server_contract ·
+  capabilities_schema_contract · capabilities_subcommands_contract ·
+  agent_profile_router_contract — 전부 green.
+- cargo clippy -D warnings, rustfmt(변경 파일) — 통과.
+- bindings/node `gen:check` — 드리프트 없음.

--- a/src/capabilities_schema.rs
+++ b/src/capabilities_schema.rs
@@ -26,7 +26,8 @@
 use serde_json::{json, Value};
 
 /// capabilities 스키마 버전. 봉투 schemaVersion 과 독립적으로 진화한다.
-pub const CAPABILITIES_SCHEMA_VERSION: &str = "1.1";
+/// 1.2: McpTool 에 annotations(MCP 표준 ToolAnnotations) 필드 추가 (#4220 T3, minor).
+pub const CAPABILITIES_SCHEMA_VERSION: &str = "1.2";
 
 /// JSON Schema draft — 소비자(코드 생성기)가 파서를 고를 수 있게 명시한다.
 const SCHEMA_DIALECT: &str = "https://json-schema.org/draft/2020-12/schema";
@@ -333,9 +334,42 @@ fn mcp_tool_def() -> Value {
                 prim("string", "봉투 필드 이름"),
                 "이 도구가 돌려주는 JSON 봉투의 최상위 필드 목록.",
             ),
+            "annotations": r("McpToolAnnotations"),
         }),
         &["name", "description", "inputSchema", "cli"],
         "MCP 도구 하나의 정의. 호스트가 tools/list 에 그대로 등록할 수 있는 모양이다.",
+    )
+}
+
+/// [#4220 T3] MCP 표준 ToolAnnotations (2025-03-26 개정판 신설) — 호스트가 실행 전에
+/// 도구 성격을 판정하는 힌트. rhwp 는 스펙 기본값에 기대지 않고 4필드를 전부 명시한다.
+fn mcp_tool_annotations_def() -> Value {
+    object(
+        json!({
+            "readOnlyHint": prim(
+                "boolean",
+                "true 면 환경을 바꾸지 않는다 — 파일을 쓰지 않는 조회·stdout 전용 도구. 유도 근거: outputFields 에 산출 경로 필드(output/outputDir)가 없음.",
+            ),
+            "destructiveHint": prim(
+                "boolean",
+                "true 면 파괴적 갱신이 가능하다 — 원본을 덮어쓰는 --in-place 축이 있는 도구만. 산출 분리(-o) 도구는 추가형이라 false. readOnlyHint=false 일 때만 의미가 있다.",
+            ),
+            "idempotentHint": prim(
+                "boolean",
+                "true 면 같은 인자 재실행이 추가 효과를 내지 않는다 — 무상태 도구는 매번 원본에서 다시 계산하는 결정론 변환이라 전부 true.",
+            ),
+            "openWorldHint": prim(
+                "boolean",
+                "true 면 외부 개방 세계(네트워크 등)와 상호작용한다. rhwp 도구는 로컬 파일만 다루므로 전부 false.",
+            ),
+        }),
+        &[
+            "readOnlyHint",
+            "destructiveHint",
+            "idempotentHint",
+            "openWorldHint",
+        ],
+        "MCP 표준 tool annotations — tools/list 에 그대로 실리는 도구 성격 힌트. MCP 규약상 신뢰할 수 없는 서버의 힌트는 참고용이다(클라이언트 확인 대체 불가).",
     )
 }
 
@@ -455,7 +489,7 @@ pub fn capabilities_schema() -> Value {
 
     json!({
         "$schema": SCHEMA_DIALECT,
-        "$id": "https://github.com/edwardkim/rhwp/schema/capabilities/1.1",
+        "$id": "https://github.com/edwardkim/rhwp/schema/capabilities/1.2",
         "title": "rhwp capabilities",
         "capabilitiesSchemaVersion": CAPABILITIES_SCHEMA_VERSION,
         "description":
@@ -476,6 +510,7 @@ pub fn mcp_manifest_schema() -> Value {
         ("McpServerInfo", mcp_server_info_def()),
         ("McpInvocation", mcp_invocation_def()),
         ("McpTool", mcp_tool_def()),
+        ("McpToolAnnotations", mcp_tool_annotations_def()),
         ("McpInputSchema", mcp_input_schema_def()),
         ("McpCliBinding", mcp_cli_binding_def()),
         ("McpOptionalArg", mcp_optional_arg_def()),
@@ -488,7 +523,7 @@ pub fn mcp_manifest_schema() -> Value {
 
     json!({
         "$schema": SCHEMA_DIALECT,
-        "$id": "https://github.com/edwardkim/rhwp/schema/capabilities-mcp/1.1",
+        "$id": "https://github.com/edwardkim/rhwp/schema/capabilities-mcp/1.2",
         "title": "rhwp MCP tool manifest",
         "capabilitiesSchemaVersion": CAPABILITIES_SCHEMA_VERSION,
         "description":

--- a/src/main.rs
+++ b/src/main.rs
@@ -1549,7 +1549,68 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
             add_password_stdin_contract(definition);
         }
     }
+    // [#4220 T3] MCP 표준 tool annotations — 손으로 나열한 표가 아니라 각 도구의
+    // **기존 선언**(outputFields 의 산출 경로 필드, cli 배선의 --in-place 축)에서
+    // 유도해 단다. 도구를 추가·개편하면 주석이 자동으로 따라오고, 유도 규칙 자체는
+    // tests/mcp_tool_annotations_contract.rs 가 실물 출력으로 대조한다.
+    for definition in &mut tools {
+        definition["annotations"] = derive_mcp_tool_annotations(definition);
+    }
     tools
+}
+
+/// [#4220 T3] MCP 표준 `annotations` 값 하나 (2025-03-26 개정판 신설 ToolAnnotations,
+/// 2025-06-18 유지 — schema.ts 의 readOnlyHint/destructiveHint/idempotentHint/openWorldHint).
+///
+/// 스펙 기본값(readOnlyHint=false, destructiveHint=true, idempotentHint=false,
+/// openWorldHint=true)에 기대지 않고 네 필드를 전부 명시한다 — inputSchema.required 를
+/// 빈 배열이라도 반드시 선언하는 것과 같은 이유로, 소비자가 "선언 누락"과 "기본값
+/// 의도"를 구분할 수 있어야 한다.
+///
+/// `openWorldHint` 는 전 도구 공통 false 다: rhwp 도구는 로컬 파일만 다루며
+/// 네트워크 등 외부 개방 세계에 닿는 축이 없다.
+fn mcp_annotations(read_only: bool, destructive: bool, idempotent: bool) -> serde_json::Value {
+    serde_json::json!({
+        "readOnlyHint": read_only,
+        "destructiveHint": destructive,
+        "idempotentHint": idempotent,
+        "openWorldHint": false,
+    })
+}
+
+/// [#4220 T3] 무상태 도구 하나의 annotations 유도 — 근거는 그 도구 자신의 선언이다.
+///
+/// - `readOnlyHint`: 봉투 `outputFields` 에 산출 경로 필드(`output`/`outputDir`)가
+///   없으면 true. 파일을 쓰지 않는 도구는 환경을 바꾸지 않는다 — 조회(query)와
+///   stdout 전용 export(hwp_export_text·hwp_export_tables 등)가 여기 속한다.
+///   `hwp_table_to_csv` 처럼 출력이 선택인 도구는 "쓸 수 있다"는 이유로 false 다
+///   (힌트는 안전 방향으로 보수적이어야 한다).
+/// - `destructiveHint`: cli 배선에 `--in-place` 축이 있을 때만 true. 그 밖의 쓰기는
+///   전부 산출 분리(-o) 원칙의 추가형(additive)이다 — 원본 문서를 덮지 않는다
+///   (redact 의 원본 보호 exit 2, export 계열의 같은 경로 거부가 그 증거다).
+/// - `idempotentHint`: 무상태 도구는 전부 true — 매 호출이 같은 원본에서 다시
+///   계산하는 결정론 변환이라, 같은 인자 재실행은 같은 산출을 다시 쓸 뿐 추가
+///   효과가 없다(세션 편집 누적과 대비되는 성질이다 — mcp_serve 참고).
+fn derive_mcp_tool_annotations(definition: &serde_json::Value) -> serde_json::Value {
+    let writes_files = definition["outputFields"].as_array().is_some_and(|fields| {
+        fields
+            .iter()
+            .any(|f| matches!(f.as_str(), Some("output" | "outputDir")))
+    });
+    let in_place = cli_wiring_has_flag(&definition["cli"], "--in-place");
+    mcp_annotations(!writes_files, in_place, true)
+}
+
+/// cli 배선(필수 `args` + `optionalArgs[].args`)에 특정 플래그가 있는가.
+fn cli_wiring_has_flag(cli: &serde_json::Value, flag: &str) -> bool {
+    let args_contain = |args: &serde_json::Value| {
+        args.as_array()
+            .is_some_and(|a| a.iter().any(|t| t.as_str() == Some(flag)))
+    };
+    args_contain(&cli["args"])
+        || cli["optionalArgs"]
+            .as_array()
+            .is_some_and(|opts| opts.iter().any(|o| args_contain(&o["args"])))
 }
 
 /// [#3263] 도구 자기서술 — 에이전트가 첫 호출 1회로 명령·계약·스키마를 파악하는 입구.

--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -495,7 +495,32 @@ fn resource_error_response(
     response
 }
 
-/// tools/list 응답: 선언 도구(MCP 필수 3종만 노출) + 세션 도구 3종.
+/// [#4220 T3] 세션 도구의 annotations — 읽기/편집 경계는 프로필 경계의 단일 출처인
+/// `agent_profiles::SESSION_READ_TOOLS` 에서 유도하고, 그 표가 말하지 않는 축만
+/// 여기서 판정한다:
+///
+/// - 파일 쓰기 축(`writes_file`): inputSchema 에 `output` 경로 속성이 있는 도구
+///   (`hwp_doc_render_page`/`hwp_doc_save`)는 read 표에 있어도 readOnlyHint=false —
+///   디스크에 산출물을 쓰는 것은 환경 변경이다.
+/// - `destructiveHint`: `hwp_doc_save` 만 true. `output` 이 hwp_open 으로 연 **원본
+///   경로일 수 있고** 같은 경로 거부가 없다(session_save 는 그대로 fs::write 한다) —
+///   무상태 표면의 `--in-place` 축에 해당하는 세션의 덮어쓰기 축이다.
+///   `hwp_doc_render_page` 는 새 SVG 산출물을 만드는 추가형이라 false.
+/// - `idempotentHint`: `hwp_open` 은 호출마다 새 docId 를 발급하므로 false.
+///   `hwp_doc_replace_text` 는 **이미 치환된 IR 위에** 다시 적용돼 겹칠 수 있으므로
+///   false (find 가 replace 의 부분열이면 재실행이 결과를 또 바꾼다 — 매번 원본에서
+///   다시 계산하는 무상태 `hwp_replace_text` 가 true 인 것과 대비된다). 그 밖은
+///   같은 인자 재실행이 같은 상태로 수렴한다(fill/set 계열은 값 대입, save 는 같은
+///   스냅숏 재기록, close 재호출은 상태 무변경 오류).
+fn session_tool_annotations(name: &str, writes_file: bool) -> serde_json::Value {
+    let read_axis = crate::agent_profiles::SESSION_READ_TOOLS.contains(&name);
+    let read_only = read_axis && !writes_file;
+    let destructive = name == "hwp_doc_save";
+    let idempotent = !matches!(name, "hwp_open" | "hwp_doc_replace_text");
+    crate::mcp_annotations(read_only, destructive, idempotent)
+}
+
+/// tools/list 응답: 선언 도구(MCP 필수 3종 + annotations 노출) + 세션 도구.
 fn served_tools(
     tool_defs: &[serde_json::Value],
     session_allows: &dyn Fn(&str) -> bool,
@@ -507,6 +532,9 @@ fn served_tools(
                 "name": t["name"],
                 "description": t["description"],
                 "inputSchema": t["inputSchema"],
+                // [#4220 T3] 매니페스트(capabilities --mcp)가 유도해 둔 값을 그대로
+                // 되비춘다 — 서버가 따로 판정하면 두 표면이 어긋난다(단일 출처).
+                "annotations": t["annotations"],
             })
         })
         .collect();
@@ -642,6 +670,15 @@ fn served_tools(
             "required": ["docId"]
         }
     }));
+    // [#4220 T3] 세션 도구 annotations — 정의 리터럴에 값을 복제하지 않고 이름·
+    // 스키마에서 한 자리에서 유도한다(무상태 도구의 outputFields 유도와 같은 원칙).
+    for t in &mut session {
+        let name = t["name"].as_str().unwrap_or_default().to_string();
+        let writes_file = t["inputSchema"]["properties"]
+            .as_object()
+            .is_some_and(|props| props.contains_key("output"));
+        t["annotations"] = session_tool_annotations(&name, writes_file);
+    }
     tools.extend(
         session
             .into_iter()

--- a/tests/mcp_tool_annotations_contract.rs
+++ b/tests/mcp_tool_annotations_contract.rs
@@ -1,0 +1,339 @@
+//! [#4220 T3] MCP tool annotations 계약 — 도구 성격 힌트가 실물 선언과 어긋나지 않는다.
+//!
+//! MCP 2025-03-26 개정판이 신설한 ToolAnnotations(readOnlyHint/destructiveHint/
+//! idempotentHint/openWorldHint)를 rhwp 는 손으로 나열하지 않고 기존 선언에서
+//! 유도한다(단일 출처): readOnlyHint 는 outputFields 의 산출 경로 필드에서,
+//! destructiveHint 는 cli 배선의 `--in-place` 축에서, 세션 도구의 읽기/편집 경계는
+//! `agent_profiles::SESSION_READ_TOOLS` 에서 온다. 여기서 검증하는 것은 유도
+//! 구현의 재실행이 아니라 **실물 출력끼리의 정합**이다 — 매니페스트의 주석이
+//! 같은 매니페스트의 category·배선·봉투 선언과 모순되면 실패한다.
+//!
+//! 스펙 근거: https://modelcontextprotocol.io/specification/2025-06-18/server/tools
+//! (Tool.annotations) + schema.ts ToolAnnotations — 기본값은 readOnlyHint=false,
+//! destructiveHint=true, idempotentHint=false, openWorldHint=true 이므로, 기본값에
+//! 기대지 않고 4필드를 전부 명시하는 것 자체가 계약이다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::collections::BTreeMap;
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+/// 스펙이 정의한 4필드 — 이 목록 밖 필드는 내지 않고, 이 목록은 전부 낸다.
+const ANNOTATION_FIELDS: [&str; 4] = [
+    "readOnlyHint",
+    "destructiveHint",
+    "idempotentHint",
+    "openWorldHint",
+];
+
+fn run_json(args: &[&str]) -> serde_json::Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패");
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "rhwp {} 실패:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("stdout 이 순수 JSON 이 아니다")
+}
+
+fn manifest_tools() -> Vec<serde_json::Value> {
+    run_json(&["capabilities", "--mcp"])["tools"]
+        .as_array()
+        .expect("tools 배열")
+        .clone()
+}
+
+/// annotations 가 4필드를 정확히, 전부 boolean 으로 선언했는지.
+fn assert_four_bool_fields(name: &str, annotations: &serde_json::Value) {
+    let obj = annotations
+        .as_object()
+        .unwrap_or_else(|| panic!("{name}: annotations 가 객체가 아니다: {annotations}"));
+    for field in ANNOTATION_FIELDS {
+        assert!(
+            obj.get(field).is_some_and(serde_json::Value::is_boolean),
+            "{name}: annotations.{field} 가 boolean 으로 선언돼야 한다: {annotations}"
+        );
+    }
+    let extra: Vec<&String> = obj
+        .keys()
+        .filter(|k| !ANNOTATION_FIELDS.contains(&k.as_str()))
+        .collect();
+    assert!(
+        extra.is_empty(),
+        "{name}: 스펙 밖 annotations 필드 {extra:?} — title 등은 별도 판단 없이 싣지 않는다"
+    );
+}
+
+/// ① 매니페스트의 전 도구가 annotations 4필드를 선언한다.
+#[test]
+fn every_manifest_tool_declares_all_four_annotation_fields() {
+    let tools = manifest_tools();
+    assert!(
+        tools.len() >= 30,
+        "도구가 너무 적다({}) — 가드가 공허해진다",
+        tools.len()
+    );
+    for t in &tools {
+        let name = t["name"].as_str().expect("name");
+        assert_four_bool_fields(name, &t["annotations"]);
+    }
+}
+
+/// ② readOnlyHint=true ↔ 그 도구의 봉투가 산출 경로 필드를 선언하지 않는다.
+///    그리고 편집 category(edit) 명령으로 내려가는 도구는 절대 readOnly 가 아니다 —
+///    category 는 capabilities 명령 표면의 독립 선언이라 유도 구현과 원천이 다르다.
+#[test]
+fn read_only_tools_write_nothing_and_are_never_edit_category() {
+    let caps = run_json(&["capabilities"]);
+    let categories: BTreeMap<String, String> = caps["commands"]
+        .as_array()
+        .expect("commands")
+        .iter()
+        .map(|c| {
+            (
+                c["name"].as_str().unwrap().to_string(),
+                c["category"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+
+    for t in manifest_tools() {
+        let name = t["name"].as_str().expect("name");
+        let read_only = t["annotations"]["readOnlyHint"].as_bool().expect("bool");
+        let writes = t["outputFields"].as_array().is_some_and(|fields| {
+            fields
+                .iter()
+                .any(|f| matches!(f.as_str(), Some("output" | "outputDir")))
+        });
+        assert_eq!(
+            read_only, !writes,
+            "{name}: readOnlyHint({read_only}) 가 봉투의 산출 경로 선언(writes={writes})과 모순된다"
+        );
+
+        let command = t["cli"]["command"].as_str().expect("cli.command");
+        let category = categories
+            .get(command)
+            .unwrap_or_else(|| panic!("{name}: cli.command {command} 가 capabilities 에 없다"));
+        if category == "edit" {
+            assert!(
+                !read_only,
+                "{name}: category=edit 명령({command})으로 내려가는 도구가 readOnlyHint=true 다"
+            );
+        }
+    }
+}
+
+/// ③ destructiveHint=true ↔ cli 배선에 `--in-place` 축이 있다. 오늘의 파괴 축은
+///    hwp_redact 하나다 — 새 in-place 축을 들이면 이 황금 목록을 의식적으로 늘려라.
+#[test]
+fn destructive_axis_matches_in_place_wiring() {
+    let wiring_has_in_place = |cli: &serde_json::Value| {
+        let in_args = |args: &serde_json::Value| {
+            args.as_array()
+                .is_some_and(|a| a.iter().any(|t| t.as_str() == Some("--in-place")))
+        };
+        in_args(&cli["args"])
+            || cli["optionalArgs"]
+                .as_array()
+                .is_some_and(|opts| opts.iter().any(|o| in_args(&o["args"])))
+    };
+
+    let mut destructive: Vec<String> = Vec::new();
+    for t in manifest_tools() {
+        let name = t["name"].as_str().expect("name");
+        let hint = t["annotations"]["destructiveHint"].as_bool().expect("bool");
+        let in_place = wiring_has_in_place(&t["cli"]);
+        assert_eq!(
+            hint, in_place,
+            "{name}: destructiveHint({hint}) 가 --in-place 배선 실물({in_place})과 모순된다"
+        );
+        if hint {
+            // 파괴적이면서 읽기 전용일 수는 없다.
+            assert_eq!(
+                t["annotations"]["readOnlyHint"], false,
+                "{name}: destructiveHint=true 인데 readOnlyHint=true 다"
+            );
+            destructive.push(name.to_string());
+        }
+    }
+    assert_eq!(
+        destructive,
+        vec!["hwp_redact".to_string()],
+        "무상태 표면의 파괴 축 황금 목록이 바뀌었다 — 의도한 변경이면 근거와 함께 갱신하라"
+    );
+}
+
+/// 무상태 도구는 전부 결정론 변환 — idempotent 이고, 로컬 파일만 다루므로 폐쇄 세계다.
+#[test]
+fn stateless_tools_are_idempotent_and_closed_world() {
+    for t in manifest_tools() {
+        let name = t["name"].as_str().expect("name");
+        assert_eq!(
+            t["annotations"]["idempotentHint"], true,
+            "{name}: 무상태 도구는 매번 원본에서 다시 계산한다 — idempotentHint=true 여야 한다"
+        );
+        assert_eq!(
+            t["annotations"]["openWorldHint"], false,
+            "{name}: rhwp 는 로컬 파일만 다룬다 — openWorldHint=false 여야 한다"
+        );
+    }
+}
+
+// ── ④ 서버(tools/list) 정합 — 무상태 되비춤 + 세션 도구 일관성 ──────────────
+
+/// 살아있는 mcp-serve 프로세스 (mcp_server_contract.rs 의 최소 재현).
+struct Server {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: i64,
+}
+
+impl Server {
+    fn started() -> Server {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+            .arg("mcp-serve")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("rhwp mcp-serve 실행 실패");
+        let stdin = child.stdin.take().expect("stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout"));
+        let mut s = Server {
+            child,
+            stdin,
+            stdout,
+            next_id: 1,
+        };
+        let r = s.request(
+            "initialize",
+            serde_json::json!({
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "annotations-contract", "version": "0"}
+            }),
+        );
+        assert!(
+            r["result"]["serverInfo"].is_object(),
+            "initialize 실패: {r}"
+        );
+        s
+    }
+
+    fn request(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        let msg =
+            serde_json::json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params});
+        writeln!(self.stdin, "{msg}").expect("요청 쓰기 실패");
+        self.stdin.flush().expect("flush");
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let n = self.stdout.read_line(&mut line).expect("응답 읽기 실패");
+            assert!(n > 0, "서버가 응답 없이 종료했습니다 (method={method})");
+            if line.trim().is_empty() {
+                continue;
+            }
+            let v: serde_json::Value = serde_json::from_str(line.trim()).expect("순수 JSON-RPC");
+            if v.get("id").and_then(|i| i.as_i64()) == Some(id) {
+                return v;
+            }
+        }
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn served_tools_reflect_manifest_and_session_tools_are_consistent() {
+    let manifest: BTreeMap<String, serde_json::Value> = manifest_tools()
+        .into_iter()
+        .map(|t| {
+            (
+                t["name"].as_str().unwrap().to_string(),
+                t["annotations"].clone(),
+            )
+        })
+        .collect();
+
+    let mut s = Server::started();
+    let r = s.request("tools/list", serde_json::json!({}));
+    let served = r["result"]["tools"].as_array().expect("tools").clone();
+
+    let mut session_seen = 0usize;
+    for t in &served {
+        let name = t["name"].as_str().expect("name");
+        // 전 도구(무상태 + 세션)가 4필드를 선언한다.
+        assert_four_bool_fields(name, &t["annotations"]);
+
+        if let Some(declared) = manifest.get(name) {
+            // 무상태 도구: 서버는 매니페스트가 유도한 값을 그대로 되비춘다(단일 출처).
+            assert_eq!(
+                &t["annotations"], declared,
+                "{name}: tools/list 의 annotations 가 capabilities --mcp 선언과 다르다"
+            );
+            continue;
+        }
+        session_seen += 1;
+        let a = &t["annotations"];
+        // 세션에도 개방 세계 축은 없다.
+        assert_eq!(a["openWorldHint"], false, "{name}: {a}");
+        match name {
+            // 핸들 조회 5종 — 환경 무변경.
+            "hwp_doc_text" | "hwp_doc_info" | "hwp_doc_fields" | "hwp_doc_tables"
+            | "hwp_doc_search" => {
+                assert_eq!(a["readOnlyHint"], true, "{name}: {a}");
+                assert_eq!(a["destructiveHint"], false, "{name}: {a}");
+            }
+            // open 은 호출마다 새 docId — 읽기 전용이되 멱등은 아니다.
+            "hwp_open" => {
+                assert_eq!(a["readOnlyHint"], true, "{name}: {a}");
+                assert_eq!(a["idempotentHint"], false, "{name}: {a}");
+            }
+            "hwp_close" => {
+                assert_eq!(a["readOnlyHint"], true, "{name}: {a}");
+                assert_eq!(a["destructiveHint"], false, "{name}: {a}");
+            }
+            // 파일을 쓰는 세션 축 — render_page 는 추가형, save 는 원본 경로를 받을 수
+            // 있는 세션의 in-place 축이라 유일하게 파괴적이다.
+            "hwp_doc_render_page" => {
+                assert_eq!(a["readOnlyHint"], false, "{name}: {a}");
+                assert_eq!(a["destructiveHint"], false, "{name}: {a}");
+            }
+            "hwp_doc_save" => {
+                assert_eq!(a["readOnlyHint"], false, "{name}: {a}");
+                assert_eq!(a["destructiveHint"], true, "{name}: {a}");
+            }
+            // IR 누적 편집 — 디스크는 안 건드리지만 환경(세션 문서 상태)을 바꾼다.
+            "hwp_doc_replace_text" => {
+                assert_eq!(a["readOnlyHint"], false, "{name}: {a}");
+                assert_eq!(a["destructiveHint"], false, "{name}: {a}");
+                // 이미 치환된 IR 위에 겹쳐 적용될 수 있다 — 무상태 쪽과 다른 지점.
+                assert_eq!(a["idempotentHint"], false, "{name}: {a}");
+            }
+            "hwp_doc_set_cell" | "hwp_doc_fill_fields" => {
+                assert_eq!(a["readOnlyHint"], false, "{name}: {a}");
+                assert_eq!(a["destructiveHint"], false, "{name}: {a}");
+                assert_eq!(a["idempotentHint"], true, "{name}: {a}");
+            }
+            other => panic!("계약에 없는 세션 도구 {other} — 이 match 에 판정을 추가하라: {a}"),
+        }
+    }
+    assert_eq!(
+        session_seen, 12,
+        "세션 도구 수가 달라졌다 — agent_profiles::ALL_SESSION_TOOLS 와 이 계약을 함께 갱신하라"
+    );
+}


### PR DESCRIPTION
## 무엇 (#4225 — #4220 T3)

`capabilities --mcp` 매니페스트와 `mcp-serve` `tools/list` 의 전 도구(무상태 43 + 세션 12)에 MCP 표준 `annotations` 4필드를 선언한다. 스펙 기본값(destructive=true·openWorld=true)에 기대지 않고 전부 명시한다 — `inputSchema.required` 를 빈 배열이라도 선언하는 기존 규약과 같은 이유다. 스펙 출처: modelcontextprotocol.io 2025-06-18 server/tools + schema.ts ToolAnnotations(2025-03-26 신설). 변경 5파일 +547/−4.

## 판단

값은 손 나열이 아니라 **기존 선언에서 유도**한다(단일 출처):
① readOnlyHint — `outputFields` 에 산출 경로 필드가 없으면 true(출력이 선택인 hwp_table_to_csv 는 보수적으로 false)
② destructiveHint — cli 배선의 `--in-place` 축이 있을 때만 true(무상태는 hwp_redact 하나; 세션은 원본 경로를 받을 수 있고 같은 경로 거부가 없는 hwp_doc_save 하나 — 실코드 확인)
③ idempotentHint — 무상태는 매번 원본에서 재계산하는 결정론 변환이라 전부 true, 세션은 hwp_open(새 docId)·hwp_doc_replace_text(치환 IR 위 겹침)만 false
④ openWorldHint — 전부 false.
세션 읽기/편집 경계는 `agent_profiles::SESSION_READ_TOOLS` 에서 유도, tools/list 의 무상태 주석은 매니페스트 값을 그대로 되비춰 두 표면이 어긋날 수 없다. capabilities_schema 에 McpToolAnnotations 동반 선언, 버전 1.1→1.2(필드 추가 = minor, #4114 교훈).

## red → green

hwp_redact 의 annotations 제거 변이 → 전수 검사가 "annotations 가 객체가 아니다: null" 로 red → 유도 복원 후 green.

## 검증

- 신규 `tests/mcp_tool_annotations_contract.rs`(339줄) 5건: 4필드 전수(스펙 밖 필드 금지) · readOnly↔봉투 산출 선언 정합+category=edit 교차검증 · destructive↔--in-place 실물+황금 목록 [hwp_redact] · 무상태 멱등·폐쇄 세계 전수 · tools/list 되비춤+세션 12종 판정 고정
- mcp_server_contract 22 · capabilities_schema_contract 17 · subcommands 4 · profile_router 8 · agent_toolkit 13 · boundary_integrity 20 · cli_json 31 · password_parity 2 · digest_macro 8 — 전부 green
- clippy -D warnings · rustfmt(변경 파일) 통과 · Node gen:check 드리프트 없음
- 상세: `mydocs/report/task_t3_mcp_annotations.md`

closes #4225
refs #4220 #3907

🤖 Generated with [Claude Code](https://claude.com/claude-code)
