### PR TITLE
feat(cli): 실패 수복 힌트 — exit 2 정형 nextCall 한 줄, 결정론 3부류 (#4234, T4)

### DIFF
--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -89,6 +89,13 @@ rhwp --password '문서비밀번호' export-text protected.hwp -o output/
 | 4 | `--verify-pages` 페이지 수 불일치 | `convert` / `export-hwpx` 전용 (아래 §3) |
 
 - 알 수 없는 명령·옵션은 **경고 후 진행하지 않고** 즉시 2로 끝난다. 안내는 stderr 로 나간다.
+- **정형 수복 줄 (#4220 T4)** — 사용법 오류(2) 중 다음 호출이 결정론적으로 정해지는
+  부류(임계 내 오타의 확신 교정, 명령 누락 → `capabilities`)에서는 stderr **마지막 줄**에
+  `수복: {"nextCall":{"name":...,"subcommand"?,...,"why":...}}` 한 줄이 붙는다. `nextCall` 어휘는
+  MCP 오류 봉투(R72)와 같고, `name` 은 반드시 실존 명령이다. 애매한 경로(임계 밖 오타,
+  하위 명령 누락)와 런타임 실패(1)에는 이 줄 자체가 없다 — 오제안 0. stdout 은 여전히
+  0 바이트다. 소비자는 "마지막 `수복: ` 줄 하나"만 파싱하면 된다
+  (계약: `tests/nextcall_cli_contract.rs`).
 - 페이지 단위 내보내기 명령의 "N개 … 완료" 메시지는 **실제로 저장에 성공한 개수**다.
   한 장이라도 실패하면 종료 코드는 1이다.
 - `export-png` 는 `native-skia` feature 없이 빌드된 바이너리에서 2로 끝난다(기능 부재).

--- a/mydocs/report/task_t4_nextcall_cli.md
+++ b/mydocs/report/task_t4_nextcall_cli.md
@@ -1,0 +1,95 @@
+---
+kind: report
+status: done
+canonical: mydocs/report/task_t4_nextcall_cli.md
+last_verified: 2026-08-08
+---
+
+# T4 실패 봉투 수복 힌트 일반화 — 설계 검증과 안전 조각 구현 (refs #4220, #3907)
+
+동향 조사(#4220/#4221) §5 T4 의 착수 게이트를 실측으로 통과시키고, 기존 계약과
+충돌하지 않는 **안전 조각만** 구현한 처리 기록이다. 판정의 원칙은 T4 원문
+그대로다 — 다음 호출이 **결정론적으로** 정해지는 실패 부류에만 힌트를 싣고,
+아니면 침묵한다(오제안 0, R72).
+
+## 1. 설계 검증 — 기존 계약 실측
+
+구현 전에 세 계약을 저장소에서 실측했다.
+
+| 계약 | 실측 | 근거 |
+|---|---|---|
+| 실패 3면 계약 (#2707) | 조립 오류 = exit 2 + stderr 산문, 실행 실패 = exit 1 + **stdout 0 B** | `src/main.rs` EXIT_* 상수 주석, `tests/cli_exit_codes.rs` |
+| stdout 0 B 고정 테스트 | `stdout.is_empty()` 단언이 시험군 전반에 수십 건 | `tests/` 전수 grep — batch/digest/edit/export/hidden-text 등 |
+| stderr 검사 방식 | 전부 `contains` 기반, **전문 일치·줄 수 고정 없음** | `tests/` 전수 grep (`assert_eq` 류는 `render_p37` 의 두 호출 stderr 동일성뿐 — 같은 경로라 무영향) |
+| `nextCall` 방출부 | `src/mcp_serve.rs` 뿐 (도구 오타 교정 1 + 닫힌 핸들 8사이트, R72) | grep 실측 — CLI 에는 없음 |
+
+**판정**: stderr 는 추가 전용으로 확장 가능하다(기존 단언이 전부 `contains`).
+stdout 은 한 바이트도 건드릴 수 없다. 따라서 힌트의 자리는 **exit 2 의 stderr
+마지막 한 줄**이 유일하게 안전하다.
+
+## 2. 실패 부류 분류 — 안전 조각 / 후속 구분
+
+### 안전 조각 (이번 구현, 3부류)
+
+| 부류 | 다음 호출이 결정론적인 이유 | 방출 |
+|---|---|---|
+| 미지 명령 + 확신 교정 | #3694 임계(레벤슈타인, 길이/3·clamp 1~3) **안**일 때만 — 기존 did-you-mean 산문이 이미 같은 확신 판정을 함 | `nextCall.name` = 교정 명령 |
+| 명령 누락 | 발견 경로는 언제나 자기서술 입구 하나 — `capabilities` | `nextCall.name` = `capabilities` |
+| 미지 inspect 하위 명령 + 확신 교정 | 위와 같은 임계, 기존 "혹시 이것인가요?" 산문의 형식화 | `nextCall.name` = `inspect`, `subcommand` = 교정 하위 |
+
+셋 다 **기존 확신 장치가 이미 있는 자리의 형식화**라 새 판단 로직이 없고,
+방출부는 중앙 디스패치 1곳 + `inspect_command` 1곳뿐이다(전 명령 일괄 개조 없음).
+
+### 침묵 유지 (오제안 0 — 테스트로 고정)
+
+- 임계 밖 오타(gibberish): 힌트 산문도 수복 줄도 없음 (기존 #3694 계약 유지).
+- inspect 하위 명령 누락: 세 축 중 무엇을 원했는지 결정론적으로 알 수 없음.
+- 실행 실패(exit 1): 인자를 고칠 것이 없는데 교정을 지어내면 재시도 래퍼가
+  "내 호출이 틀렸다"로 오독한다(#2707 취지 그대로).
+
+### 후속 (이번에 구현하지 않은 후보와 사유)
+
+| 후보 | 판정 | 사유 |
+|---|---|---|
+| (c) `--json` 판정 봉투(exit 3)의 `nextCall` 필드 확장 | **후속** | 봉투 새 필드는 `capabilities_schema` 동반 + 스키마 버전 인상이 계약(#4114 교훈). stderr 한 줄과 달리 별도 설계·별도 PR 감이다. |
+| 미지 옵션 교정 | **후속** | 옵션 파서가 명령별 수기 루프 수십 곳이고 옵션 사전이 중앙에 없다 — 결정론 교정을 하려면 등록부 신설이 선행돼야 하며, 그 전 개조는 "전 명령 일괄 개조" 금지에 걸린다. |
+| 필수 인자 누락 | **후속** | 다음 호출이 "같은 명령을 옳게" 뿐이라 nextCall 어휘가 맞지 않다. usage 산문이 이미 처방이고, 형식화하려면 스키마 지시(예: export-*-schema 연계) 등 다른 어휘가 필요하다. |
+| 미지 edit 하위 명령 | **후속** | 현재 did-you-mean 산문 자체가 없다 — 형식화가 아니라 행동 추가라 이번 범위 밖. 어휘가 착지한 뒤 1줄짜리 후속이다. |
+| capabilities 자기서술 등재(수복 줄 문법) | **후속** | 봉투 필드 추가 = 스키마 동반(#4114). 이번엔 매뉴얼(`cli_commands.md` §종료 코드)에만 등재했다. |
+
+## 3. 구현 — 정형 수복 줄 문법
+
+```
+수복: {"nextCall":{"name":"export-svg","why":"요청한 이름이 없음 — 가장 가까운 실존 명령으로 교정"}}
+```
+
+- **자리**: exit 2 stderr 의 **마지막 줄**, 산문(오류·힌트·사용법) 뒤. 소비자는
+  "마지막 `수복: ` 줄 하나"만 파싱하면 된다.
+- **어휘**: `nextCall{name, subcommand?, why}` — MCP 오류 봉투(R72,
+  `tool_error_with_next`)와 같은 모양. CLI·MCP·(장차 R22 계획 거부)가 한 어휘가
+  되는 것이 T4 의 요지다.
+- **`arguments` 는 싣지 않는다**: 호출자의 나머지 argv 가 옳다고 검증한 바 없고
+  (오제안 0 은 인자에도 적용), `--password` 류 민감 인자를 stderr 로 되울리지
+  않는 뜻도 겸한다. `why` 도 고정 문자열이라 argv·문서 유래 문자열이 줄에 섞일
+  경로가 없다(S6 경계 계약과 정합).
+- **stdout 무침해**: 실패 3면 계약에 stderr 한 줄만 더하는 추가 전용 확장.
+
+변경 파일: `src/main.rs`(방출 헬퍼 `eprint_usage_recovery` + 사이트 2곳),
+`tests/nextcall_cli_contract.rs`(신규 계약 8건), `mydocs/manual/cli_commands.md`
+(§종료 코드에 문법 등재).
+
+## 4. 게이트 실측
+
+| 게이트 | 결과 |
+|---|---|
+| red 실증 | 구현 stash 후 신규 계약 8건 중 **방출 4건 red** / 침묵·무회귀 4건 green(침묵은 자명 성립) → 복원 후 전건 green |
+| 신규 계약 | `nextcall_cli_contract` 8/8 통과 — ① 문법(마지막 줄·단일 줄·JSON·name 실존 capabilities 대조) ② 오제안 0(불확실 3경로 침묵) ③ stdout 0 B |
+| 영향권 기존 | did_you_mean 20 · cli_exit_codes 17 · boundary_integrity 4 · capabilities_subcommands 10 · cli_json 31 · capabilities_schema 15 · diagnostics_flag 3 · mcp_server 13 · envelope_integrity 5 · agent_toolkit 22 — **전건 통과** |
+| clippy | `--all-targets -- -D warnings` 통과 |
+| rustfmt | 변경 파일 Diff 0건 (`Incorrect newline style` 4건은 이 PC CRLF 체크아웃 함정 — CI(LF)와 무관, 기지 사항) |
+
+## 5. 남긴 것
+
+§2 의 후속 5건이 그대로 다음 착수 목록이다. 특히 (c) exit 3 봉투 확장은 이
+줄의 어휘가 메인테이너 승인으로 착지한 뒤에 여는 것이 순서다 — 같은 어휘를
+두 표면에 동시에 제안하면 한쪽 보정이 다른 쪽 드리프트가 된다.

--- a/src/main.rs
+++ b/src/main.rs
@@ -348,21 +348,36 @@ fn main() {
         // [#2707] 알 수 없는 명령·명령 누락은 사용법 오류다. 표준 CLI 관례대로 stderr 로 안내하고
         // 종료 코드 2로 끝낸다(기존에는 stdout + 0이라 오타 낸 명령이 스크립트에서 성공으로 보였다).
         other => {
-            match other {
+            // [#4220 T4] 수복 한 줄은 stderr 마지막 줄이어야 하므로(소비자는 마지막
+            // `수복: ` 줄 하나만 파싱한다) 산문을 모두 낸 뒤에 방출한다. 두 부류만
+            // 결정론적이다: 확신 교정(임계 내 오타)과 명령 누락(발견 경로는 언제나
+            // capabilities). 임계 밖 오타는 수복 줄도 침묵한다 — 오제안 0.
+            let recovery: Option<(String, &str)> = match other {
                 Some(command) => {
                     eprintln!("오류: 알 수 없는 명령입니다 - {}", command);
                     // [#3694] did-you-mean — 후보는 capabilities 단일 출처. 이름 환각을
                     // 교정 단서 없이 돌려보내면 경량 에이전트는 맹목 재시도 루프에 빠진다.
                     let names = capabilities_command_names();
-                    if let Some(hint) = closest_name(command, names.iter().map(String::as_str)) {
+                    let hint = closest_name(command, names.iter().map(String::as_str));
+                    if let Some(hint) = &hint {
                         eprintln!("힌트: 가장 가까운 명령은 '{hint}' 입니다");
                     }
+                    hint.map(|h| (h, "요청한 이름이 없음 — 가장 가까운 실존 명령으로 교정"))
                 }
-                None => eprintln!("오류: 명령을 지정해주세요."),
-            }
+                None => {
+                    eprintln!("오류: 명령을 지정해주세요.");
+                    Some((
+                        "capabilities".to_string(),
+                        "명령이 지정되지 않음 — 실행 가능한 명령 목록·계약은 capabilities 가 자기서술",
+                    ))
+                }
+            };
             eprintln!("rhwp v{}", rhwp::version());
             eprintln!("사용법: rhwp <명령> [옵션]");
             eprintln!("'rhwp --help'로 자세한 사용법을 확인하세요.");
+            if let Some((name, why)) = recovery {
+                eprint_usage_recovery(&name, None, why);
+            }
             process::exit(EXIT_USAGE);
         }
     }
@@ -2424,6 +2439,29 @@ pub(crate) fn closest_name<'a, I: IntoIterator<Item = &'a str>>(
     let (d, name) = best?;
     let cap = (input.chars().count() / 3).clamp(1, 3);
     (d <= cap).then(|| name.to_string())
+}
+
+/// [#4220 T4] 사용법 오류(exit 2)의 stderr **마지막 줄**에 싣는 정형 수복 한 줄.
+///
+/// 문법: `수복: ` 접두어 + 한 줄 JSON `{"nextCall":{"name":<명령>,"subcommand"?:<하위>,"why":<이유>}}`.
+/// `nextCall` 어휘는 MCP 오류 봉투(R72, `tool_error_with_next`)와 같다 — CLI 와 MCP 가
+/// 같은 모양을 쓰면 소비자가 한 어휘로 수복 루프를 짠다. 계약 3면:
+///
+/// 1. **오제안 0(R72)** — 다음 호출이 결정론적으로 정해지는 실패 부류에서만 호출한다.
+///    애매하면 이 줄 자체가 없어야 하므로, 호출부가 확신 판정(#3694 임계 등)을 먼저 한다.
+/// 2. **`name` 실존** — 호출부 책임이고 계약 테스트(`tests/nextcall_cli_contract.rs`)가
+///    capabilities 단일 출처와 대조해 고정한다. `arguments` 는 싣지 않는다: CLI 는
+///    호출자의 나머지 argv 가 옳다고 검증한 바 없고(오제안 0 은 인자에도 적용된다),
+///    비밀번호 같은 민감 인자를 stderr 로 되울리지 않는 뜻도 겸한다.
+/// 3. **stdout 무침해** — 실패 3면 계약(#2707: exit 2·stdout 0 B·stderr 안내)에
+///    stderr 한 줄만 더하는 추가 전용 확장이다. 산문(오류·힌트·사용법)을 모두 낸 뒤
+///    마지막에 호출해야 한다 — 소비자는 "마지막 `수복: ` 줄 하나"만 파싱한다.
+fn eprint_usage_recovery(next_command: &str, subcommand: Option<&str>, why: &str) {
+    let mut next = serde_json::json!({ "name": next_command, "why": why });
+    if let Some(sub) = subcommand {
+        next["subcommand"] = serde_json::json!(sub);
+    }
+    eprintln!("수복: {}", serde_json::json!({ "nextCall": next }));
 }
 
 /// [#3828 B1] `capabilities --search <키워드...> [--json]` — commands[].name·summary 를
@@ -17897,13 +17935,24 @@ fn inspect_command(args: &[String]) -> i32 {
         Some("unicode") => inspect_unicode(&args[1..]),
         Some(other) => {
             eprintln!("오류: 알 수 없는 inspect 하위 명령입니다 - {other}");
-            if let Some(hint) = closest_name(other, ["hidden-text", "injection", "unicode"]) {
+            let hint = closest_name(other, ["hidden-text", "injection", "unicode"]);
+            if let Some(hint) = &hint {
                 eprintln!("혹시 이것인가요? inspect {hint}");
             }
             eprintln!("{USAGE}");
+            // [#4220 T4] 확신 교정(#3694 임계 내)일 때만 정형 수복 줄 — 임계 밖은 침묵.
+            if let Some(hint) = hint {
+                eprint_usage_recovery(
+                    "inspect",
+                    Some(&hint),
+                    "요청한 이름이 없음 — 가장 가까운 실존 하위 명령으로 교정",
+                );
+            }
             EXIT_USAGE
         }
         None => {
+            // [#4220 T4] 하위 명령 누락은 어느 축을 원했는지 결정론적으로 알 수 없다 —
+            // 수복 줄을 지어내지 않는다(오제안 0).
             eprintln!("오류: inspect 하위 명령을 지정해주세요 (hidden-text|injection|unicode).");
             eprintln!("{USAGE}");
             EXIT_USAGE

--- a/tests/nextcall_cli_contract.rs
+++ b/tests/nextcall_cli_contract.rs
@@ -1,0 +1,228 @@
+//! [#4220 T4] CLI 실패 봉투 수복 힌트 — exit 2 사용법 오류 stderr 의 정형 수복 한 줄.
+//!
+//! 계약 3면:
+//! 1. **문법** — 수복 줄은 stderr 의 **마지막 줄** 하나뿐이고, `수복: ` 접두어 뒤는
+//!    한 줄 JSON `{"nextCall":{"name":...,"subcommand"?,...,"why":...}}` 이다.
+//!    `nextCall.name` 은 반드시 실존 명령(capabilities 단일 출처 — R72 와 같은 계약),
+//!    `subcommand` 가 있으면 그 명령의 실존 하위 명령이다.
+//! 2. **오제안 0** — 다음 호출이 결정론적으로 정해지지 않는 경로(임계 밖 오타,
+//!    하위 명령 누락)에는 수복 줄 자체가 없다. R72 가 MCP 쪽에서 지켜온 원칙 그대로다.
+//! 3. **stdout 0 B 무침해** — 실패 3면 계약(#2707: exit 2·stdout 0 B·stderr 안내)은
+//!    그대로다. 수복 줄은 stderr 에만 더해지는 추가 전용 확장이다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::process::{Command, Output};
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+/// stderr 에서 수복 줄을 찾아 JSON 으로 파싱한다. 문법 계약(마지막 줄·단일 줄)을
+/// 여기서 함께 단언한다 — 소비자는 "마지막 `수복: ` 줄 하나"만 파싱하면 된다.
+fn parse_recovery_line(args: &[&str], output: &Output) -> serde_json::Value {
+    let err = String::from_utf8_lossy(&output.stderr);
+    let recovery_lines: Vec<&str> = err.lines().filter(|l| l.starts_with("수복: ")).collect();
+    assert_eq!(
+        recovery_lines.len(),
+        1,
+        "수복 줄은 정확히 하나여야 한다\n{}",
+        describe(args, output)
+    );
+    let last = err
+        .lines()
+        .rev()
+        .find(|l| !l.trim().is_empty())
+        .expect("stderr 가 비어 있다");
+    assert!(
+        last.starts_with("수복: "),
+        "수복 줄은 stderr 의 마지막 줄이어야 한다 (마지막 줄: {last:?})\n{}",
+        describe(args, output)
+    );
+    let json_part = last.strip_prefix("수복: ").unwrap();
+    serde_json::from_str(json_part).unwrap_or_else(|e| {
+        panic!(
+            "수복 줄 본문이 한 줄 JSON 이어야 한다({e}): {json_part}\n{}",
+            describe(args, output)
+        )
+    })
+}
+
+/// capabilities 의 명령 이름 목록 — nextCall.name 실존 검사의 단일 출처.
+fn capability_command_names() -> Vec<String> {
+    let out = run(&["capabilities"]);
+    assert_eq!(out.status.code(), Some(0), "capabilities 실행 실패");
+    let v: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("capabilities stdout 이 순수 JSON 이 아니다");
+    v["commands"]
+        .as_array()
+        .expect("commands 배열 없음")
+        .iter()
+        .filter_map(|c| c["name"].as_str().map(String::from))
+        .collect()
+}
+
+// ── ① 문법 — 정형 수복 줄 ────────────────────────────────────────────────
+
+/// 미지 명령 + 확신 교정(#3694 임계 내): 수복 줄이 교정 명령을 nextCall 어휘로 싣는다.
+#[test]
+fn unknown_command_recovery_line_carries_corrected_next_call() {
+    let args = ["exprot-svg"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(2), "{}", describe(&args, &out));
+    assert!(
+        out.stdout.is_empty(),
+        "실패 경로 stdout 은 0 바이트여야 한다\n{}",
+        describe(&args, &out)
+    );
+    let v = parse_recovery_line(&args, &out);
+    assert_eq!(v["nextCall"]["name"], "export-svg", "{v}");
+    assert!(
+        !v["nextCall"]["why"]
+            .as_str()
+            .unwrap_or("")
+            .trim()
+            .is_empty(),
+        "why 는 비어 있으면 안 된다: {v}"
+    );
+    // arguments 는 싣지 않는다 — 나머지 인자가 옳다고 검증한 바 없다(오제안 0).
+    assert!(
+        v["nextCall"].get("arguments").is_none(),
+        "검증하지 않은 인자를 되울리면 안 된다: {v}"
+    );
+}
+
+/// 수복 줄의 nextCall.name 은 반드시 실존 명령이다 (R72 와 같은 실존 계약).
+#[test]
+fn recovery_next_call_name_exists_in_capabilities() {
+    let names = capability_command_names();
+    for args in [&["exprot-svg"][..], &[][..]] {
+        let out = run(args);
+        assert_eq!(out.status.code(), Some(2), "{}", describe(args, &out));
+        let v = parse_recovery_line(args, &out);
+        let name = v["nextCall"]["name"].as_str().expect("nextCall.name 누락");
+        assert!(
+            names.iter().any(|n| n == name),
+            "nextCall.name 이 실존 명령이 아니다: {name} ({v})"
+        );
+    }
+}
+
+/// 명령 누락: 발견 경로는 결정론적이다 — capabilities 자기서술로 보낸다.
+#[test]
+fn missing_command_recovery_points_to_capabilities() {
+    let args: [&str; 0] = [];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(2), "{}", describe(&args, &out));
+    assert!(out.stdout.is_empty(), "{}", describe(&args, &out));
+    let v = parse_recovery_line(&args, &out);
+    assert_eq!(v["nextCall"]["name"], "capabilities", "{v}");
+}
+
+/// 미지 inspect 하위 명령 + 확신 교정: subcommand 필드가 실존 하위 명령을 싣는다.
+#[test]
+fn inspect_unknown_subcommand_recovery_carries_subcommand() {
+    let args = ["inspect", "hiden-text"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(2), "{}", describe(&args, &out));
+    assert!(out.stdout.is_empty(), "{}", describe(&args, &out));
+    let v = parse_recovery_line(&args, &out);
+    assert_eq!(v["nextCall"]["name"], "inspect", "{v}");
+    assert_eq!(v["nextCall"]["subcommand"], "hidden-text", "{v}");
+
+    // subcommand 실존 — capabilities 의 inspect.subcommands 선언과 대조.
+    let caps = run(&["capabilities"]);
+    let caps: serde_json::Value = serde_json::from_slice(&caps.stdout).expect("capabilities JSON");
+    let declared: Vec<&str> = caps["commands"]
+        .as_array()
+        .expect("commands")
+        .iter()
+        .find(|c| c["name"] == "inspect")
+        .expect("inspect 항목 없음")["subcommands"]
+        .as_array()
+        .expect("inspect.subcommands 없음")
+        .iter()
+        .filter_map(|s| s["name"].as_str())
+        .collect();
+    assert!(
+        declared.contains(&"hidden-text"),
+        "교정 대상이 선언된 하위 명령이 아니다: {declared:?}"
+    );
+}
+
+// ── ② 오제안 0 — 불확실 경로에는 수복 줄이 없다 ─────────────────────────
+
+/// 임계 밖 오타(#3694 gibberish 계약과 같은 입력): 힌트도 수복 줄도 없다.
+#[test]
+fn gibberish_command_gets_no_recovery_line() {
+    let args = ["코끼리코끼리"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(2), "{}", describe(&args, &out));
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !err.contains("수복:"),
+        "임계 밖 오타에 수복 줄을 지어내면 안 된다(오제안 0)\n{}",
+        describe(&args, &out)
+    );
+}
+
+/// inspect 하위 명령 누락: 어느 축을 원했는지 결정론적으로 알 수 없다 — 침묵.
+#[test]
+fn inspect_missing_subcommand_gets_no_recovery_line() {
+    let args = ["inspect"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(2), "{}", describe(&args, &out));
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !err.contains("수복:"),
+        "하위 명령 누락은 다음 호출이 결정론적이지 않다 — 침묵해야 한다\n{}",
+        describe(&args, &out)
+    );
+}
+
+/// 실행 실패(exit 1)는 수복 대상 부류가 아니다 — 인자를 고칠 것이 없는데
+/// 교정을 지어내면 재시도 래퍼가 "내 호출이 틀렸다"로 오독한다.
+#[test]
+fn runtime_failure_gets_no_recovery_line() {
+    let args = ["export-text", "없는파일-t4.hwp"];
+    let out = run(&args);
+    assert_eq!(out.status.code(), Some(1), "{}", describe(&args, &out));
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !err.contains("수복:"),
+        "런타임 실패에 수복 줄을 지어내면 안 된다\n{}",
+        describe(&args, &out)
+    );
+}
+
+// ── ③ stdout 0 B 무침해 + 기존 산문 무회귀 ──────────────────────────────
+
+/// 수복 줄이 붙어도 기존 산문 계약(오류·힌트·사용법 안내)은 그대로다.
+#[test]
+fn recovery_line_is_additive_to_existing_prose() {
+    let args = ["exprot-svg"];
+    let out = run(&args);
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(err.contains("알 수 없는 명령"), "{err}");
+    assert!(
+        err.contains("힌트: 가장 가까운 명령은 'export-svg' 입니다"),
+        "{err}"
+    );
+    assert!(err.contains("사용법: rhwp <명령> [옵션]"), "{err}");
+    assert!(
+        out.stdout.is_empty(),
+        "수복 줄은 stderr 전용이다 — stdout 오염 금지\n{}",
+        describe(&args, &out)
+    );
+}


### PR DESCRIPTION
## 무엇 (#4234 — #4220 T4 1차)

사용법 오류(exit 2) 중 다음 호출이 결정론적인 **3부류**에서 stderr **마지막 줄**에 `수복: {"nextCall":{"name":...,"subcommand"?,...,"why":...}}` 정형 한 줄을 싣는다. 어휘는 MCP 오류 봉투(R72 tool_error_with_next)와 동형 — 소비자가 CLI·MCP 를 한 어휘로 수복 루프를 짠다.

1. 미지 명령 + #3694 임계 내 확신 교정 → nextCall.name = 교정 명령
2. 명령 누락 → nextCall.name = capabilities (발견 경로는 결정론적)
3. 미지 inspect 하위 명령 확신 교정 → name=inspect + subcommand (기존 "혹시 이것인가요?" 산문의 형식화)

변경: src/main.rs(헬퍼+사이트 2곳 — 전 명령 개조 없음) · tests/nextcall_cli_contract.rs(신규 8건) · cli_commands.md §종료 코드 등재 · 처리결과문서.

## 어떻게 안전한가 (설계 검증 선행)

- stderr 단언이 시험군 전체에서 **contains 기반뿐**임을 선실측 — 마지막 줄 추가는 무충돌, 기존 산문 무변경.
- stdout 0 B(#2707)·오제안 0(R72) 불가침: 임계 밖 오타·하위 명령 누락·exit 1 에는 줄 자체가 없음을 테스트로 고정.
- `arguments` 미탑재 — 검증 안 된 argv·민감 인자(--password)를 stderr 로 되울리지 않는다. why 는 고정 문자열(S6 정합).
- 후속 5건은 처리문서에 명시(exit 3 봉투 확장은 #4114 교훈대로 capabilities_schema 동반 별도 PR, 미지 옵션은 옵션 등록부 선행 필요).

## red → green / 검증

- **red 실증**: 구현 stash 시 방출 계약 4건 red / 복원 후 8/8 green
- 영향권 기존 10개 스위트 **140건 전건 통과**(did_you_mean 20·cli_exit_codes 17·cli_json 31·caps_schema 15·mcp_server 13 등)
- clippy --all-targets -D warnings · rustfmt(변경 파일) 통과

closes #4234
refs #4220 #3907

🤖 Generated with [Claude Code](https://claude.com/claude-code)
