### PR TITLE
feat(tools): 에이전트 태스크 벤치마크 1차 — 태스크 10종·기계 오라클·양방향 실증 (#4236, T2)

### DIFF
--- a/mydocs/report/agent_bench_r0_20260808.md
+++ b/mydocs/report/agent_bench_r0_20260808.md
@@ -1,0 +1,135 @@
+# 에이전트 태스크 벤치마크 스위트 1차(r0) — 태스크 정의·기계 오라클·양방향 실증
+
+- **Issue**: [#4220](https://github.com/edwardkim/rhwp/issues/4220) T2 / refs [#3907](https://github.com/edwardkim/rhwp/issues/3907)
+- **브랜치**: `task/t2-agent-bench-suite`
+- **기준**: `upstream/devel` `dc7d7adcc`
+- **작성 시각**: 2026-08-08 KST
+- **환경**: Windows 11, `cargo build --release`(기본 feature), Python 3 stdlib
+
+## 1. 무엇을 만들었나 — 1차의 정직한 절단
+
+T2 의 최종 목표는 "표준 HWP 작업 N종을 에이전트가 rhwp 표면만으로 몇 % 완주하는가"의
+실측이다. 1차는 그 전제 조건인 **판정 기반**만 착지한다:
+
+- **태스크 정의** — [`tools/agent_bench/tasks.json`](../../tools/agent_bench/tasks.json):
+  태스크 10종 각각에 (입력 fixture, 한글 목표 서술, 풀이 인터페이스, 오라클 명령열,
+  타임아웃)을 선언한다. fixture 는 전부 `samples/` 실물이다.
+- **채점 하니스** — [`tools/agent_bench/run_bench.py`](../../tools/agent_bench/run_bench.py):
+  풀이 디렉터리(`<task_id>.py` 모음)를 받아 태스크별로 실행하고, 오라클 명령열을 돌려
+  pass/fail 을 기계 판정한 뒤 성공률 표를 낸다. `RHWP_BIN` 으로 바이너리를 주입한다.
+- **레퍼런스 풀이** — [`reference_solutions/`](../../tools/agent_bench/reference_solutions/):
+  태스크당 1파일, 문서 조작은 rhwp CLI 만 사용. 오라클 판정 가능성의 **양성 증거**.
+- **오풀이(음성 대조)** — [`null_solutions/`](../../tools/agent_bench/null_solutions/):
+  "입력을 그대로 복사" · "검사 없이 전부 깨끗하다 보고" 류의 그럴듯한 게으른 오답.
+  오라클이 이를 전부 걸러내는 것이 **음성 증거**다.
+
+**살아있는 LLM 호출은 하지 않았다.** 이 문서의 수치는 오라클 검증(판정기가 옳은
+풀이와 그른 풀이를 가르는가)이지 에이전트 성공률이 아니다 — 성공률 실측은 후속이다.
+
+판정을 LLM 심판이 아니라 기계 오라클로 고정한 것은 T2 착수 게이트 ①(자기 저작 검증
+함정 회피)의 이행이다. 태스크 원천은
+[`agent_task_playbook.md`](../manual/agent_task_playbook.md)의 35 시나리오와 공무원
+업무 체크리스트 21행에서 축이 겹치지 않게 10종을 골랐다.
+
+## 2. 태스크 10종
+
+| id | 축 | fixture (samples/) | 오라클 판정(요지) |
+|---|---|---|---|
+| t01_form_fill | 서식 채우기 | field-01.hwp | `fields --json` 재독 — 4개 필드 값 일치 |
+| t02_table_roundtrip | 표 CSV 왕복 | 2025년 기부·답례품 실적 지자체 보고서_양식.hwpx | `table-to-csv` 재독 — 목표 칸만 변경, 나머지 35칸 보존 |
+| t03_redact | 레닥션 | field-01.hwp + CLI 로 합성한 가공 PII | `edit redact --dry-run` 잔여 0 + 원문 문자열 부재 + 내용·쪽수 보존 |
+| t04_convert_hwpx | 형식 변환 | 20250130-hongbo.hwp | `info` format/쪽수 + `export-text` 전문 유사도 ≥ 0.999 |
+| t05_replace_preserve_pages | 쪽수 보존 치환 | 20250130-hongbo.hwp | `search` 이전 0건·신규 6건 + `info` 쪽수 보존 |
+| t06_visual_safe_edit | 시각 무회귀 편집 | 기부·답례품 양식.hwpx | 편집 반영 + 비편집 쪽(page 0) SVG **바이트 동일** |
+| t07_text_extract | 텍스트 추출 | 2022년 국립국어원 업무계획.hwp | 자기일관 유사도 ≥ 0.99 + 외부 앵커 3종 포함 |
+| t08_structure_report | 구조 파악 | 2025 행정업무운영 편람(최종).hwpx | `export-structure` 대조 — mode·nodeCount·최상위 수 |
+| t09_bulk_aggregate | 대량 처리 집계 | 혼합 5건(hwp5 4·hwp3 1) | `info` 대조 — 파일별 쪽수 + 합계 정합 |
+| t10_security_sweep | 보안 스윕 판정 | 더러운 2건 + 깨끗한 2건 | `inspect` 3축 × 4건 = 12 판정 전수 대조 |
+
+- 오라클 명령은 전부 devel 에 실존하는 표면만 쓴다: `fields`·`table-to-csv`·
+  `edit redact --dry-run`·`info`·`export-text`·`search`·`export-svg`·
+  `export-structure`·`inspect hidden-text|unicode|injection`. 미머지 PR 의
+  `verify --expect`(#4186)·`scan`(#4217)은 쓰지 않았다 — merge 후 오라클을 verify 로
+  치환/보강할 수 있다(§5).
+- t10 의 "더러운" fixture 는 합성이 아니라 **samples 실물**이다 —
+  `issue1892_hwp3_tab_roundtrip.hwp`(흰 글씨 은닉 텍스트)와
+  `정책연구용역사업 중간진도보고서(…).hwp`(U+200B 제로폭)는
+  `tests/security_corpus_regression.rs` 가 개별 근거와 함께 "탐지가 옳다"고 선언한
+  문서들이다.
+- t03 의 가공 PII(주민번호·전화·이메일)는 `tests/redact_sanitize_contract.rs` 와 같은
+  값(검증숫자 통과·실재 무관)을 하니스 setup 단계가 `edit fill-fields` 로 심는다 —
+  fixture 합성까지 CLI 로만 한다.
+
+## 3. 양방향 실증 — 실측 수치
+
+같은 하니스·같은 바이너리(`devel dc7d7adcc` release)·같은 머신에서 두 번 실행했다.
+
+### 3-1. 레퍼런스 풀이 → **10/10 PASS** (exit 0)
+
+```
+t01_form_fill               PASS            0.8s
+t02_table_roundtrip         PASS            1.9s
+t03_redact                  PASS           29.4s
+t04_convert_hwpx            PASS            0.9s
+t05_replace_preserve_pages  PASS            0.9s
+t06_visual_safe_edit        PASS            0.8s
+t07_text_extract            PASS            0.9s
+t08_structure_report        PASS            1.4s
+t09_bulk_aggregate          PASS            1.2s
+t10_security_sweep          PASS            9.8s
+성공률: 10/10   (전체 소요 약 48s)
+```
+
+### 3-2. 오풀이 → **0/10** (exit 1), 전부 의미 있는 검사에서 절단
+
+```
+t01_form_fill               [회사명] value = '' (기대 '한국수자원공사')
+t02_table_roundtrip         [목표 칸 값] (1,1) = '' (기대 '1,234')
+t03_redact                  [잔여 탐지 0] findingCount = 3 (기대 0)
+t04_convert_hwpx            [형식] format = 'hwp5' (기대 'hwpx')   ← 확장자 사칭을 내용 스니핑이 잡음
+t05_replace_preserve_pages  [이전 문자열 잔존 0] matchCount = 6 (기대 0)
+t06_visual_safe_edit        [편집 반영] (2,1) = '' (기대 '7,777')
+t07_text_extract            [전문 유사도] 0.0000 (기대 ≥ 0.99)
+t08_structure_report        [mode] 'outline' (기대 'clause')
+t09_bulk_aggregate          [hongbo 쪽수] 1 (기대 4)
+t10_security_sweep          [issue1892 hidden] 전부-깨끗 보고가 실제 판정(clean=false)과 불일치
+성공률: 0/10
+```
+
+### 3-3. 종료 코드 규약 실측
+
+| 상황 | exit |
+|---|---|
+| 전 태스크 pass (3-1) | 0 |
+| 하나라도 fail — 오풀이(3-2)·풀이 파일 없음(NO_SOLUTION) | 1 |
+| 구성 오류 — `RHWP_BIN` 경로 부재 | 2 |
+
+## 4. 오라클 설계 노트 (재현에 필요한 실측 사실)
+
+- **SVG 렌더는 결정적이다** — 같은 바이너리로 같은 입력의 page 0 을 두 번 내보내면
+  바이트 동일(실측 23,726B). t06 의 "비편집 쪽 바이트 동일" 게이트가 이 위에 선다.
+  표 12 편집의 `changedPages` 는 `[6,7]` 로 page 0 과 겹치지 않는다.
+- **`export-text` 의 전문은 `--json` 봉투로 받아야 한다** — 무봉투 stdout 은 전문
+  계약이 아니다(35쪽 문서 실측: 봉투 33,719자 vs 무봉투 1,341자). 하니스는
+  `pages[].text` 이어붙이기를 스텝 옵션(`extractPagesTextTo`)으로 내장했다.
+- **t07 의 외부 ground truth 는 부분 앵커다** — 동봉 `samples/2022년 국립국어원
+  업무계획.txt` 는 1,214자 발췌본이고 표 평탄화 방식이 달라 전문 대조가 안 된다
+  (정규화 후 29줄 중 17줄만 포함, 미포함은 전부 표 행). 그래서 판정은 도구 자기일관
+  유사도 + 발췌본에서 확인된 앵커 3종 포함으로 구성했다.
+- **판정이 봉투 안에만 있는 명령**(playbook §원칙)을 그대로 계승했다 — redact 는
+  `findingCount`, inspect 는 `clean` 이 게이트고 exit 는 0 이다. 오라클 검사가 그
+  자리를 짚는다.
+
+## 5. 한계와 후속
+
+1. **에이전트 성공률이 아니다.** 본 실증은 "오라클이 판정 가능하다"까지다. 실제
+   LLM 에이전트를 태스크 서술만 주고 N 회 돌려 성공률을 재는 것(실행 주체·비용
+   판단 포함)은 T2 착수 게이트 ②로, 메인테이너 판단 사항이다.
+2. **오라클은 rhwp 자신의 읽기 표면을 신뢰한다** — 재독 대조 원칙의 의도적 채택.
+   읽기 표면 자체의 회귀는 이 하니스가 아니라 기존 계약 테스트·시각 게이트 몫이다.
+   독립 오라클(한/글) 교차 검증은 범위 밖.
+3. **t07 자기일관 판정은 추출기 회귀를 못 잡는다** — §4 의 앵커 3종만이 외부 근거다.
+4. **verify 게이트(#4186) merge 후** — t04·t02 류의 쪽수·표 기대는 `verify --expect`
+   1회 호출로 치환 가능하다. 오라클 명령열만 바꾸면 되도록 tasks.json 에 선언으로
+   분리해 두었다.
+5. **단일 머신·단일 실행 실측**이다. 시간 수치는 상대 참고용.

--- a/tools/agent_bench/null_solutions/t01_form_fill.py
+++ b/tools/agent_bench/null_solutions/t01_form_fill.py
@@ -1,0 +1,5 @@
+"""오풀이(음성 대조) — 입력을 그대로 복사하고 채웠다고 주장한다."""
+import os
+import shutil
+
+shutil.copyfile(os.environ["BENCH_INPUT"], os.path.join(os.environ["BENCH_OUT_DIR"], "filled.hwp"))

--- a/tools/agent_bench/null_solutions/t02_table_roundtrip.py
+++ b/tools/agent_bench/null_solutions/t02_table_roundtrip.py
@@ -1,0 +1,5 @@
+"""오풀이(음성 대조) — 입력을 그대로 복사하고 표를 고쳤다고 주장한다."""
+import os
+import shutil
+
+shutil.copyfile(os.environ["BENCH_INPUT"], os.path.join(os.environ["BENCH_OUT_DIR"], "updated.hwpx"))

--- a/tools/agent_bench/null_solutions/t03_redact.py
+++ b/tools/agent_bench/null_solutions/t03_redact.py
@@ -1,0 +1,5 @@
+"""오풀이(음성 대조) — 개인정보를 지우지 않은 채 배포본이라 주장한다."""
+import os
+import shutil
+
+shutil.copyfile(os.environ["BENCH_INPUT"], os.path.join(os.environ["BENCH_OUT_DIR"], "redacted.hwp"))

--- a/tools/agent_bench/null_solutions/t04_convert_hwpx.py
+++ b/tools/agent_bench/null_solutions/t04_convert_hwpx.py
@@ -1,0 +1,5 @@
+"""오풀이(음성 대조) — HWP 바이트를 확장자만 바꿔 HWPX 라 주장한다."""
+import os
+import shutil
+
+shutil.copyfile(os.environ["BENCH_INPUT"], os.path.join(os.environ["BENCH_OUT_DIR"], "converted.hwpx"))

--- a/tools/agent_bench/null_solutions/t05_replace_preserve_pages.py
+++ b/tools/agent_bench/null_solutions/t05_replace_preserve_pages.py
@@ -1,0 +1,5 @@
+"""오풀이(음성 대조) — 치환하지 않은 문서를 치환본이라 주장한다."""
+import os
+import shutil
+
+shutil.copyfile(os.environ["BENCH_INPUT"], os.path.join(os.environ["BENCH_OUT_DIR"], "edited.hwp"))

--- a/tools/agent_bench/null_solutions/t06_visual_safe_edit.py
+++ b/tools/agent_bench/null_solutions/t06_visual_safe_edit.py
@@ -1,0 +1,5 @@
+"""오풀이(음성 대조) — 아무것도 안 바꾸면 렌더는 당연히 같다. 편집 반영 검사가 잡는다."""
+import os
+import shutil
+
+shutil.copyfile(os.environ["BENCH_INPUT"], os.path.join(os.environ["BENCH_OUT_DIR"], "updated.hwpx"))

--- a/tools/agent_bench/null_solutions/t07_text_extract.py
+++ b/tools/agent_bench/null_solutions/t07_text_extract.py
@@ -1,0 +1,5 @@
+"""오풀이(음성 대조) — 빈 텍스트를 추출 결과라 주장한다."""
+import os
+
+with open(os.path.join(os.environ["BENCH_OUT_DIR"], "text.txt"), "w", encoding="utf-8") as fh:
+    fh.write("")

--- a/tools/agent_bench/null_solutions/t08_structure_report.py
+++ b/tools/agent_bench/null_solutions/t08_structure_report.py
@@ -1,0 +1,7 @@
+"""오풀이(음성 대조) — 문서를 열지 않고 그럴듯한 기본값을 보고한다."""
+import json
+import os
+
+answers = {"mode": "outline", "nodeCount": 0, "topLevelCount": 0}
+with open(os.path.join(os.environ["BENCH_OUT_DIR"], "answers.json"), "w", encoding="utf-8") as fh:
+    json.dump(answers, fh, ensure_ascii=False)

--- a/tools/agent_bench/null_solutions/t09_bulk_aggregate.py
+++ b/tools/agent_bench/null_solutions/t09_bulk_aggregate.py
@@ -1,0 +1,9 @@
+"""오풀이(음성 대조) — 문서를 열지 않고 쪽수를 전부 1로 보고한다."""
+import json
+import os
+
+inputs = json.loads(os.environ["BENCH_INPUTS_JSON"])
+files = [{"file": os.path.basename(p), "pageCount": 1} for p in inputs]
+summary = {"files": files, "totalPageCount": len(files)}
+with open(os.path.join(os.environ["BENCH_OUT_DIR"], "summary.json"), "w", encoding="utf-8") as fh:
+    json.dump(summary, fh, ensure_ascii=False)

--- a/tools/agent_bench/null_solutions/t10_security_sweep.py
+++ b/tools/agent_bench/null_solutions/t10_security_sweep.py
@@ -1,0 +1,11 @@
+"""오풀이(음성 대조) — 검사하지 않고 전부 깨끗하다고 보고한다."""
+import json
+import os
+
+inputs = json.loads(os.environ["BENCH_INPUTS_JSON"])
+files = [
+    {"file": os.path.basename(p), "hiddenText": True, "unicode": True, "injection": True}
+    for p in inputs
+]
+with open(os.path.join(os.environ["BENCH_OUT_DIR"], "verdict.json"), "w", encoding="utf-8") as fh:
+    json.dump({"files": files}, fh, ensure_ascii=False)

--- a/tools/agent_bench/reference_solutions/t01_form_fill.py
+++ b/tools/agent_bench/reference_solutions/t01_form_fill.py
@@ -1,0 +1,18 @@
+"""레퍼런스 풀이 — 서식 누름틀 채우기: fields 확인 없이 fill-fields 한 방."""
+import json
+import os
+import subprocess
+
+RHWP = os.environ["RHWP_BIN"]
+INP = os.environ["BENCH_INPUT"]
+OUT = os.environ["BENCH_OUT_DIR"]
+params = json.loads(os.environ["BENCH_PARAMS_JSON"])
+
+subprocess.run(
+    [
+        RHWP, "edit", "fill-fields", INP,
+        "--data", json.dumps(params["fields"], ensure_ascii=False),
+        "-o", os.path.join(OUT, "filled.hwp"), "--json",
+    ],
+    check=True, capture_output=True,
+)

--- a/tools/agent_bench/reference_solutions/t02_table_roundtrip.py
+++ b/tools/agent_bench/reference_solutions/t02_table_roundtrip.py
@@ -1,0 +1,30 @@
+"""레퍼런스 풀이 — 표 CSV 왕복: table-to-csv → 칸 수정 → csv-to-table."""
+import csv
+import json
+import os
+import subprocess
+
+RHWP = os.environ["RHWP_BIN"]
+INP = os.environ["BENCH_INPUT"]
+OUT = os.environ["BENCH_OUT_DIR"]
+params = json.loads(os.environ["BENCH_PARAMS_JSON"])
+table = str(params["table"])
+csv_path = os.path.join(OUT, "_roundtrip.csv")
+
+subprocess.run(
+    [RHWP, "table-to-csv", INP, "--table", table, "-o", csv_path, "--json"],
+    check=True, capture_output=True,
+)
+with open(csv_path, newline="", encoding="utf-8-sig") as fh:
+    rows = [row for row in csv.reader(fh)]
+rows[params["row"]][params["col"]] = params["newValue"]
+with open(csv_path, "w", newline="", encoding="utf-8") as fh:
+    csv.writer(fh).writerows(rows)
+subprocess.run(
+    [
+        RHWP, "csv-to-table", INP, "--csv", csv_path, "--table", table,
+        "-o", os.path.join(OUT, "updated.hwpx"), "--json",
+    ],
+    check=True, capture_output=True,
+)
+os.remove(csv_path)

--- a/tools/agent_bench/reference_solutions/t03_redact.py
+++ b/tools/agent_bench/reference_solutions/t03_redact.py
@@ -1,0 +1,12 @@
+"""레퍼런스 풀이 — 개인정보 마스킹: edit redact 기본 kind(전체 축) 적용."""
+import os
+import subprocess
+
+RHWP = os.environ["RHWP_BIN"]
+INP = os.environ["BENCH_INPUT"]
+OUT = os.environ["BENCH_OUT_DIR"]
+
+subprocess.run(
+    [RHWP, "edit", "redact", INP, "-o", os.path.join(OUT, "redacted.hwp"), "--json"],
+    check=True, capture_output=True,
+)

--- a/tools/agent_bench/reference_solutions/t04_convert_hwpx.py
+++ b/tools/agent_bench/reference_solutions/t04_convert_hwpx.py
@@ -1,0 +1,12 @@
+"""레퍼런스 풀이 — HWP→HWPX 변환: export-hwpx."""
+import os
+import subprocess
+
+RHWP = os.environ["RHWP_BIN"]
+INP = os.environ["BENCH_INPUT"]
+OUT = os.environ["BENCH_OUT_DIR"]
+
+subprocess.run(
+    [RHWP, "export-hwpx", INP, os.path.join(OUT, "converted.hwpx")],
+    check=True, capture_output=True,
+)

--- a/tools/agent_bench/reference_solutions/t05_replace_preserve_pages.py
+++ b/tools/agent_bench/reference_solutions/t05_replace_preserve_pages.py
@@ -1,0 +1,18 @@
+"""레퍼런스 풀이 — 쪽수 보존 일괄 치환: edit replace-text (동일 길이 문자열)."""
+import json
+import os
+import subprocess
+
+RHWP = os.environ["RHWP_BIN"]
+INP = os.environ["BENCH_INPUT"]
+OUT = os.environ["BENCH_OUT_DIR"]
+params = json.loads(os.environ["BENCH_PARAMS_JSON"])
+
+subprocess.run(
+    [
+        RHWP, "edit", "replace-text", INP,
+        "--find", params["find"], "--replace", params["replace"],
+        "-o", os.path.join(OUT, "edited.hwp"), "--json",
+    ],
+    check=True, capture_output=True,
+)

--- a/tools/agent_bench/reference_solutions/t06_visual_safe_edit.py
+++ b/tools/agent_bench/reference_solutions/t06_visual_safe_edit.py
@@ -1,0 +1,19 @@
+"""레퍼런스 풀이 — 시각 무회귀 편집: edit set-cell 로 해당 칸만 갱신."""
+import json
+import os
+import subprocess
+
+RHWP = os.environ["RHWP_BIN"]
+INP = os.environ["BENCH_INPUT"]
+OUT = os.environ["BENCH_OUT_DIR"]
+params = json.loads(os.environ["BENCH_PARAMS_JSON"])
+
+subprocess.run(
+    [
+        RHWP, "edit", "set-cell", INP,
+        "--table", str(params["table"]), "--row", str(params["row"]),
+        "--col", str(params["col"]), "--text", params["newValue"],
+        "-o", os.path.join(OUT, "updated.hwpx"), "--json",
+    ],
+    check=True, capture_output=True,
+)

--- a/tools/agent_bench/reference_solutions/t07_text_extract.py
+++ b/tools/agent_bench/reference_solutions/t07_text_extract.py
@@ -1,0 +1,16 @@
+"""레퍼런스 풀이 — 본문 텍스트 추출: export-text --json 의 pages[].text 이어 붙이기."""
+import json
+import os
+import subprocess
+
+RHWP = os.environ["RHWP_BIN"]
+INP = os.environ["BENCH_INPUT"]
+OUT = os.environ["BENCH_OUT_DIR"]
+
+proc = subprocess.run(
+    [RHWP, "export-text", INP, "--json"], check=True, capture_output=True
+)
+envelope = json.loads(proc.stdout.decode("utf-8"))
+joined = "\n".join(page.get("text", "") for page in envelope["pages"])
+with open(os.path.join(OUT, "text.txt"), "w", encoding="utf-8") as fh:
+    fh.write(joined)

--- a/tools/agent_bench/reference_solutions/t08_structure_report.py
+++ b/tools/agent_bench/reference_solutions/t08_structure_report.py
@@ -1,0 +1,20 @@
+"""레퍼런스 풀이 — 구조 파악: export-structure --json 봉투에서 답을 뽑는다."""
+import json
+import os
+import subprocess
+
+RHWP = os.environ["RHWP_BIN"]
+INP = os.environ["BENCH_INPUT"]
+OUT = os.environ["BENCH_OUT_DIR"]
+
+proc = subprocess.run(
+    [RHWP, "export-structure", INP, "--json"], check=True, capture_output=True
+)
+envelope = json.loads(proc.stdout.decode("utf-8"))
+answers = {
+    "mode": envelope["mode"],
+    "nodeCount": envelope["nodeCount"],
+    "topLevelCount": len(envelope["structure"]["roots"]),
+}
+with open(os.path.join(OUT, "answers.json"), "w", encoding="utf-8") as fh:
+    json.dump(answers, fh, ensure_ascii=False)

--- a/tools/agent_bench/reference_solutions/t09_bulk_aggregate.py
+++ b/tools/agent_bench/reference_solutions/t09_bulk_aggregate.py
@@ -1,0 +1,17 @@
+"""레퍼런스 풀이 — 대량 집계: 문서별 info --json 의 pageCount 를 모아 대장을 만든다."""
+import json
+import os
+import subprocess
+
+RHWP = os.environ["RHWP_BIN"]
+OUT = os.environ["BENCH_OUT_DIR"]
+inputs = json.loads(os.environ["BENCH_INPUTS_JSON"])
+
+files = []
+for path in inputs:
+    proc = subprocess.run([RHWP, "info", path, "--json"], check=True, capture_output=True)
+    info = json.loads(proc.stdout.decode("utf-8"))
+    files.append({"file": os.path.basename(path), "pageCount": info["pageCount"]})
+summary = {"files": files, "totalPageCount": sum(f["pageCount"] for f in files)}
+with open(os.path.join(OUT, "summary.json"), "w", encoding="utf-8") as fh:
+    json.dump(summary, fh, ensure_ascii=False)

--- a/tools/agent_bench/reference_solutions/t10_security_sweep.py
+++ b/tools/agent_bench/reference_solutions/t10_security_sweep.py
@@ -1,0 +1,21 @@
+"""레퍼런스 풀이 — 보안 스윕: 문서별 inspect 3축의 clean 판정을 대장으로 만든다."""
+import json
+import os
+import subprocess
+
+RHWP = os.environ["RHWP_BIN"]
+OUT = os.environ["BENCH_OUT_DIR"]
+inputs = json.loads(os.environ["BENCH_INPUTS_JSON"])
+AXES = {"hiddenText": "hidden-text", "unicode": "unicode", "injection": "injection"}
+
+files = []
+for path in inputs:
+    row = {"file": os.path.basename(path)}
+    for key, axis in AXES.items():
+        proc = subprocess.run(
+            [RHWP, "inspect", axis, path, "--json"], check=True, capture_output=True
+        )
+        row[key] = json.loads(proc.stdout.decode("utf-8"))["clean"]
+    files.append(row)
+with open(os.path.join(OUT, "verdict.json"), "w", encoding="utf-8") as fh:
+    json.dump({"files": files}, fh, ensure_ascii=False)

--- a/tools/agent_bench/run_bench.py
+++ b/tools/agent_bench/run_bench.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""에이전트 태스크 벤치마크 하니스 — 풀이 디렉터리를 받아 태스크별 기계 채점.
+
+1차 범위(#4220 T2): 살아있는 LLM 호출 없음. 태스크 정의(tasks.json)의
+(fixture, 목표, 오라클 명령열)에 대해 "풀이 스크립트"를 실행하고, 오라클이
+산출물을 devel 에 실존하는 rhwp CLI 명령으로 재독해 pass/fail 을 판정한다.
+
+사용:
+    RHWP_BIN=target/release/rhwp python tools/agent_bench/run_bench.py \
+        --solutions tools/agent_bench/reference_solutions [--tasks t01,t02] \
+        [--json-out results.json] [--keep-work]
+
+종료 코드 규약:
+    0 — 전 태스크 pass
+    1 — 하나 이상 fail (풀이 없음·풀이 오류·오라클 판정 실패 포함)
+    2 — 사용법/구성 오류 (RHWP_BIN 없음, tasks.json 손상 등)
+
+풀이 인터페이스(각 태스크 공통):
+    <solutions>/<task_id>.py 를 `python <파일>` 로 실행한다. 환경 변수 —
+      RHWP_BIN           rhwp 바이너리 절대 경로
+      BENCH_TASK_ID      태스크 id
+      BENCH_INPUT        1차 입력 문서 절대 경로
+      BENCH_INPUTS_JSON  입력 문서 절대 경로 배열(JSON)
+      BENCH_PARAMS_JSON  태스크 매개변수(JSON) — tasks.json 의 params 그대로
+      BENCH_OUT_DIR      산출물을 써야 하는 디렉터리 절대 경로
+    풀이는 tasks.json 의 outputs 에 선언된 파일명을 BENCH_OUT_DIR 에 만들어야
+    하며, 문서 조작은 rhwp CLI 를 통해서만 한다(오라클은 산출물만 본다).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import difflib
+import io
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TASKS_JSON = Path(__file__).resolve().parent / "tasks.json"
+ORACLE_STEP_TIMEOUT_DEFAULT = 180
+
+
+def _reconfigure_stdout() -> None:
+    """Windows 콘솔(cp949)에서 한글 출력이 깨지지 않게 UTF-8 로 고정한다."""
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, io.UnsupportedOperation):
+            pass
+
+
+# ── 값 참조/경로 해석 ────────────────────────────────────────────────
+
+
+def json_path(value, path: str):
+    """`a.b[0].c` 형태의 미니 경로. 실패하면 KeyError."""
+    if path in ("", "."):
+        return value
+    token_re = re.compile(r"([^.\[\]]+)|\[(\d+)\]")
+    pos = 0
+    cur = value
+    for m in token_re.finditer(path):
+        if m.start() != pos:
+            raise KeyError(f"경로 구문 오류: {path!r} (offset {pos})")
+        pos = m.end()
+        if pos < len(path) and path[pos] == ".":
+            pos += 1
+        key, idx = m.group(1), m.group(2)
+        if key is not None:
+            if not isinstance(cur, dict) or key not in cur:
+                raise KeyError(f"경로 {path!r} 의 {key!r} 가 없습니다")
+            cur = cur[key]
+        else:
+            i = int(idx)
+            if not isinstance(cur, list) or i >= len(cur):
+                raise KeyError(f"경로 {path!r} 의 [{idx}] 가 없습니다")
+            cur = cur[i]
+    if pos != len(path):
+        raise KeyError(f"경로 구문 오류: {path!r} (tail {path[pos:]!r})")
+    return cur
+
+
+OPS = {
+    "eq": lambda a, b: a == b,
+    "ne": lambda a, b: a != b,
+    "ge": lambda a, b: a >= b,
+    "le": lambda a, b: a <= b,
+    "gt": lambda a, b: a > b,
+    "lt": lambda a, b: a < b,
+    "contains": lambda a, b: b in a,
+    "notContains": lambda a, b: b not in a,
+    "isEmpty": lambda a, _b: len(a) == 0,
+    "isNotEmpty": lambda a, _b: len(a) > 0,
+    "lenEq": lambda a, b: len(a) == b,
+}
+
+
+class CheckFailure(Exception):
+    pass
+
+
+class TaskContext:
+    """한 태스크 실행의 자리표·저장값 컨텍스트."""
+
+    def __init__(self, rhwp: Path, fixtures: list[Path], out_dir: Path, work_dir: Path):
+        self.rhwp = rhwp
+        self.fixtures = fixtures
+        self.out_dir = out_dir
+        self.work_dir = work_dir
+        self.saves: dict[str, object] = {}
+        self.save_text: dict[str, str] = {}
+
+    def expand(self, text: str) -> str:
+        mapping = {
+            "RHWP": str(self.rhwp),
+            "REPO": str(REPO_ROOT),
+            "OUT": str(self.out_dir),
+            "WORK": str(self.work_dir),
+            "FIXTURE": str(self.fixtures[0]) if self.fixtures else "",
+        }
+        for i, f in enumerate(self.fixtures):
+            mapping[f"FIXTURE{i}"] = str(f)
+        for key, val in mapping.items():
+            text = text.replace("{" + key + "}", val)
+        return text
+
+    def resolve_value(self, spec):
+        """검사 항목의 값 자리 — 리터럴 또는 {from,path} / {file} 참조."""
+        if isinstance(spec, dict) and ("from" in spec or "file" in spec):
+            if "from" in spec:
+                save = spec["from"]
+                if save not in self.saves:
+                    raise CheckFailure(f"저장값 {save!r} 이 없습니다")
+                return json_path(self.saves[save], spec.get("path", ""))
+            path = Path(self.expand(spec["file"]))
+            if not path.is_file():
+                raise CheckFailure(f"파일이 없습니다: {path}")
+            return path.read_text(encoding="utf-8", errors="replace")
+        return spec
+
+
+# ── 오라클 실행 ──────────────────────────────────────────────────────
+
+
+def run_step(ctx: TaskContext, step: dict) -> None:
+    # 명령 없는 스텝: 풀이 산출 JSON 파일을 읽어 저장값으로 올린다.
+    if "loadJson" in step:
+        path = Path(ctx.expand(step["loadJson"]))
+        if not path.is_file():
+            raise CheckFailure(f"산출물이 없습니다: {path}")
+        try:
+            ctx.saves[step["save"]] = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise CheckFailure(f"산출물이 JSON 이 아닙니다({exc}): {path}") from exc
+        return
+
+    cmd = [ctx.expand(str(part)) for part in step["cmd"]]
+    timeout = step.get("timeoutSec", ORACLE_STEP_TIMEOUT_DEFAULT)
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            timeout=timeout,
+            cwd=str(ctx.work_dir),
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise CheckFailure(f"오라클 명령 타임아웃({timeout}s): {cmd}") from exc
+    expect_exit = step.get("expectExit", 0)
+    if proc.returncode != expect_exit:
+        stderr = proc.stderr.decode("utf-8", errors="replace")[:400]
+        raise CheckFailure(
+            f"오라클 명령 exit {proc.returncode} (기대 {expect_exit}): {cmd}\n{stderr}"
+        )
+    stdout = proc.stdout.decode("utf-8", errors="replace")
+    save = step.get("save")
+    if save:
+        ctx.save_text[save] = stdout
+        if step.get("parse", "json") == "json":
+            try:
+                ctx.saves[save] = json.loads(stdout)
+            except json.JSONDecodeError as exc:
+                raise CheckFailure(
+                    f"오라클 stdout 이 JSON 이 아닙니다({exc}): {cmd}\n{stdout[:300]}"
+                ) from exc
+        else:
+            ctx.saves[save] = stdout
+    if step.get("stdoutTo"):
+        dest = Path(ctx.expand(step["stdoutTo"]))
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(proc.stdout)
+    if step.get("extractPagesTextTo"):
+        # export-text --json 봉투의 pages[].text 를 이어 붙여 파일로 남긴다.
+        if save is None or not isinstance(ctx.saves.get(save), dict):
+            raise CheckFailure("extractPagesTextTo 는 save+JSON 파싱을 전제합니다")
+        pages = ctx.saves[save].get("pages")
+        if not isinstance(pages, list):
+            raise CheckFailure(f"봉투에 pages 배열이 없습니다: {cmd}")
+        joined = "\n".join(str(p.get("text", "")) for p in pages)
+        dest = Path(ctx.expand(step["extractPagesTextTo"]))
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(joined, encoding="utf-8")
+
+
+def _read_csv(path: Path) -> list[list[str]]:
+    with path.open(newline="", encoding="utf-8-sig") as fh:
+        return [row for row in csv.reader(fh)]
+
+
+def _normalize_ws(text: str) -> str:
+    return "\n".join(" ".join(line.split()) for line in text.splitlines() if line.strip())
+
+
+def run_check(ctx: TaskContext, check: dict) -> None:
+    kind = check["type"]
+    label = check.get("label", kind)
+
+    def fail(msg: str):
+        raise CheckFailure(f"[{label}] {msg}")
+
+    if kind == "file_exists":
+        path = Path(ctx.expand(check["path"]))
+        if not path.is_file() or path.stat().st_size == 0:
+            fail(f"산출물이 없거나 비었습니다: {path}")
+        return
+
+    if kind == "json":
+        actual = ctx.resolve_value({"from": check["from"], "path": check.get("path", "")})
+        expected = ctx.resolve_value(check.get("value"))
+        op = check.get("op", "eq")
+        if not OPS[op](actual, expected):
+            fail(f"{check.get('path')} = {actual!r} (기대 {op} {expected!r})")
+        return
+
+    if kind == "json_list":
+        seq = ctx.resolve_value({"from": check["from"], "path": check["listPath"]})
+        if not isinstance(seq, list):
+            fail(f"{check['listPath']} 가 배열이 아닙니다")
+        where = check.get("where", {})
+        matched = [
+            item
+            for item in seq
+            if isinstance(item, dict) and all(item.get(k) == v for k, v in where.items())
+        ]
+        if not matched:
+            fail(f"{check['listPath']} 에서 {where} 항목을 찾지 못했습니다")
+        actual = matched[0].get(check["field"]) if "field" in check else matched[0]
+        expected = ctx.resolve_value(check.get("value"))
+        op = check.get("op", "eq")
+        if not OPS[op](actual, expected):
+            fail(f"{where} 의 {check.get('field')} = {actual!r} (기대 {op} {expected!r})")
+        return
+
+    if kind == "json_sum":
+        seq = ctx.resolve_value({"from": check["from"], "path": check["listPath"]})
+        if not isinstance(seq, list):
+            fail(f"{check['listPath']} 가 배열이 아닙니다")
+        try:
+            total = sum(item[check["field"]] for item in seq)
+        except (KeyError, TypeError) as exc:
+            fail(f"합산 실패: {exc}")
+        expected = ctx.resolve_value(check.get("value"))
+        op = check.get("op", "eq")
+        if not OPS[op](total, expected):
+            fail(f"합계 {total!r} (기대 {op} {expected!r})")
+        return
+
+    if kind == "text_contains":
+        text = ctx.resolve_value(
+            {"file": check["file"]} if "file" in check else {"from": check["from"]}
+        )
+        if not isinstance(text, str):
+            text = json.dumps(text, ensure_ascii=False)
+        needle = check["needle"]
+        present = needle in text
+        if present != check.get("expect", True):
+            fail(f"{needle!r} 포함 여부 {present} (기대 {check.get('expect', True)})")
+        return
+
+    if kind == "bytes_equal":
+        a = Path(ctx.expand(check["a"]))
+        b = Path(ctx.expand(check["b"]))
+        if not a.is_file() or not b.is_file():
+            fail(f"비교 파일이 없습니다: {a} / {b}")
+        same = a.read_bytes() == b.read_bytes()
+        if same != check.get("expect", True):
+            fail(f"바이트 동일 여부 {same} (기대 {check.get('expect', True)})")
+        return
+
+    if kind == "text_similarity":
+        a = ctx.resolve_value({"file": check["a"]})
+        b = ctx.resolve_value({"file": check["b"]})
+        ratio = difflib.SequenceMatcher(
+            None, _normalize_ws(a), _normalize_ws(b)
+        ).ratio()
+        threshold = check.get("value", 0.98)
+        if not OPS[check.get("op", "ge")](ratio, threshold):
+            fail(f"유사도 {ratio:.4f} (기대 {check.get('op', 'ge')} {threshold})")
+        return
+
+    if kind == "csv_cells":
+        rows = _read_csv(Path(ctx.expand(check["file"])))
+        for cell in check["cells"]:
+            r, c = cell["row"], cell["col"]
+            if r >= len(rows) or c >= len(rows[r]):
+                fail(f"CSV 에 ({r},{c}) 칸이 없습니다")
+            if rows[r][c] != cell["eq"]:
+                fail(f"({r},{c}) = {rows[r][c]!r} (기대 {cell['eq']!r})")
+        return
+
+    if kind == "csv_equal_except":
+        rows_a = _read_csv(Path(ctx.expand(check["a"])))
+        rows_b = _read_csv(Path(ctx.expand(check["b"])))
+        if len(rows_a) != len(rows_b):
+            fail(f"행 수 불일치: {len(rows_a)} vs {len(rows_b)}")
+        allowed = {tuple(cell) for cell in check.get("except", [])}
+        diffs = []
+        for r, (ra, rb) in enumerate(zip(rows_a, rows_b)):
+            if len(ra) != len(rb):
+                fail(f"{r}행 열 수 불일치: {len(ra)} vs {len(rb)}")
+            for c, (va, vb) in enumerate(zip(ra, rb)):
+                if va != vb:
+                    diffs.append((r, c))
+        unexpected = [d for d in diffs if d not in allowed]
+        missing = [d for d in allowed if d not in diffs]
+        if unexpected:
+            fail(f"허용 밖 변경 칸: {unexpected[:5]}")
+        if missing:
+            fail(f"바뀌어야 할 칸이 안 바뀌었습니다: {missing}")
+        return
+
+    fail(f"알 수 없는 검사 유형: {kind}")
+
+
+# ── 태스크 실행 ──────────────────────────────────────────────────────
+
+
+def run_task(task: dict, rhwp: Path, solutions_dir: Path, keep_work: bool) -> dict:
+    task_id = task["id"]
+    started = time.monotonic()
+    result = {"id": task_id, "title": task.get("title", ""), "passed": False}
+
+    fixtures = [REPO_ROOT / f for f in task.get("fixtures", [])]
+    for f in fixtures:
+        if not f.is_file():
+            result.update(status="FIXTURE_MISSING", detail=str(f))
+            return result
+
+    work_root = Path(tempfile.mkdtemp(prefix=f"agent-bench-{task_id}-"))
+    out_dir = work_root / "out"
+    work_dir = work_root / "work"
+    out_dir.mkdir()
+    work_dir.mkdir()
+    ctx = TaskContext(rhwp, fixtures, out_dir, work_dir)
+
+    try:
+        # 1) setup — 오라클과 같은 스텝 문법. 실패는 하니스 오류다.
+        for step in task.get("setup", []):
+            try:
+                run_step(ctx, step)
+            except CheckFailure as exc:
+                result.update(status="SETUP_ERROR", detail=str(exc))
+                return result
+
+        solution_input = ctx.expand(task.get("solutionInput", "{FIXTURE}"))
+
+        # 2) 풀이 실행
+        solution = solutions_dir / f"{task_id}.py"
+        if not solution.is_file():
+            result.update(status="NO_SOLUTION", detail=str(solution))
+            return result
+        env = os.environ.copy()
+        env.update(
+            RHWP_BIN=str(rhwp),
+            BENCH_TASK_ID=task_id,
+            BENCH_INPUT=solution_input,
+            BENCH_INPUTS_JSON=json.dumps(
+                [solution_input] if len(fixtures) <= 1 else [str(f) for f in fixtures],
+                ensure_ascii=False,
+            ),
+            BENCH_PARAMS_JSON=json.dumps(task.get("params", {}), ensure_ascii=False),
+            BENCH_OUT_DIR=str(out_dir),
+            PYTHONIOENCODING="utf-8",
+        )
+        timeout = task.get("timeoutSec", 300)
+        try:
+            proc = subprocess.run(
+                [sys.executable, str(solution)],
+                capture_output=True,
+                timeout=timeout,
+                cwd=str(out_dir),
+                env=env,
+            )
+        except subprocess.TimeoutExpired:
+            result.update(status="SOLUTION_TIMEOUT", detail=f"{timeout}s")
+            return result
+        if proc.returncode != 0:
+            stderr = proc.stderr.decode("utf-8", errors="replace")[:400]
+            result.update(status="SOLUTION_ERROR", detail=f"exit {proc.returncode}: {stderr}")
+            return result
+
+        # 3) 오라클 — 명령열 실행 후 검사 평가
+        try:
+            for step in task["oracle"].get("steps", []):
+                run_step(ctx, step)
+            for check in task["oracle"].get("checks", []):
+                run_check(ctx, check)
+        except CheckFailure as exc:
+            result.update(status="ORACLE_FAIL", detail=str(exc))
+            return result
+
+        result.update(status="PASS", passed=True)
+        return result
+    finally:
+        result["durationSec"] = round(time.monotonic() - started, 2)
+        if keep_work:
+            result["workDir"] = str(work_root)
+        else:
+            shutil.rmtree(work_root, ignore_errors=True)
+
+
+def main() -> int:
+    _reconfigure_stdout()
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--solutions", required=True, help="풀이 디렉터리(<task_id>.py 모음)")
+    parser.add_argument("--tasks", help="쉼표로 구분한 태스크 id 부분집합")
+    parser.add_argument("--rhwp-bin", help="rhwp 바이너리 경로(기본: env RHWP_BIN)")
+    parser.add_argument("--json-out", help="결과 JSON 저장 경로")
+    parser.add_argument("--keep-work", action="store_true", help="작업 디렉터리 보존(디버깅)")
+    args = parser.parse_args()
+
+    rhwp_raw = args.rhwp_bin or os.environ.get("RHWP_BIN")
+    if not rhwp_raw:
+        print("오류: RHWP_BIN 환경 변수 또는 --rhwp-bin 이 필요합니다.", file=sys.stderr)
+        return 2
+    rhwp = Path(rhwp_raw).resolve()
+    if not rhwp.is_file():
+        print(f"오류: rhwp 바이너리가 없습니다 - {rhwp}", file=sys.stderr)
+        return 2
+
+    solutions_dir = Path(args.solutions).resolve()
+    if not solutions_dir.is_dir():
+        print(f"오류: 풀이 디렉터리가 없습니다 - {solutions_dir}", file=sys.stderr)
+        return 2
+
+    try:
+        spec = json.loads(TASKS_JSON.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"오류: tasks.json 을 읽을 수 없습니다 - {exc}", file=sys.stderr)
+        return 2
+    tasks = spec["tasks"]
+    if args.tasks:
+        wanted = {t.strip() for t in args.tasks.split(",") if t.strip()}
+        unknown = wanted - {t["id"] for t in tasks}
+        if unknown:
+            print(f"오류: 알 수 없는 태스크 id - {sorted(unknown)}", file=sys.stderr)
+            return 2
+        tasks = [t for t in tasks if t["id"] in wanted]
+
+    results = [run_task(t, rhwp, solutions_dir, args.keep_work) for t in tasks]
+    passed = sum(1 for r in results if r["passed"])
+
+    width = max(len(r["id"]) for r in results)
+    print(f"\n{'태스크':<{width}}  판정          시간    상세")
+    print("-" * (width + 50))
+    for r in results:
+        detail = "" if r["passed"] else (r.get("detail", "") or "")[:80].replace("\n", " ")
+        print(f"{r['id']:<{width}}  {r['status']:<12}  {r.get('durationSec', 0):>5.1f}s  {detail}")
+    print("-" * (width + 50))
+    print(f"성공률: {passed}/{len(results)}")
+
+    if args.json_out:
+        payload = {
+            "summary": {"total": len(results), "passed": passed, "failed": len(results) - passed},
+            "rhwpBin": str(rhwp),
+            "solutionsDir": str(solutions_dir),
+            "tasks": results,
+        }
+        Path(args.json_out).write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
+    return 0 if passed == len(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/agent_bench/tasks.json
+++ b/tools/agent_bench/tasks.json
@@ -1,0 +1,280 @@
+{
+  "schemaVersion": "1.0",
+  "description": "에이전트 태스크 벤치마크 1차(#4220 T2) — 태스크 정의·기계 오라클. 각 태스크는 (fixture, 목표, 오라클 명령열)로 고정되며, 오라클은 devel 에 실존하는 rhwp CLI 명령만 쓴다. 풀이 인터페이스와 실행 방법은 run_bench.py 도크스트링 참조.",
+  "tasks": [
+    {
+      "id": "t01_form_fill",
+      "title": "서식 누름틀 채우기",
+      "category": "서식",
+      "goal": "입력 서식(BENCH_INPUT)의 누름틀을 BENCH_PARAMS_JSON.fields 의 이름→값 대로 채운 문서를 BENCH_OUT_DIR/filled.hwp 로 저장하라. 지정하지 않은 필드는 건드리지 않는다.",
+      "fixtures": ["samples/field-01.hwp"],
+      "params": {
+        "fields": {
+          "회사명": "한국수자원공사",
+          "작성자": "김담당",
+          "부서명": "디지털정책과",
+          "제목": "에이전트 벤치마크 시범 운영"
+        }
+      },
+      "outputs": ["filled.hwp"],
+      "timeoutSec": 120,
+      "oracle": {
+        "steps": [
+          {"save": "fields", "cmd": ["{RHWP}", "fields", "{OUT}/filled.hwp", "--json"]}
+        ],
+        "checks": [
+          {"type": "file_exists", "path": "{OUT}/filled.hwp"},
+          {"type": "json_list", "label": "회사명", "from": "fields", "listPath": "fields", "where": {"name": "회사명"}, "field": "value", "op": "eq", "value": "한국수자원공사"},
+          {"type": "json_list", "label": "작성자", "from": "fields", "listPath": "fields", "where": {"name": "작성자"}, "field": "value", "op": "eq", "value": "김담당"},
+          {"type": "json_list", "label": "부서명", "from": "fields", "listPath": "fields", "where": {"name": "부서명"}, "field": "value", "op": "eq", "value": "디지털정책과"},
+          {"type": "json_list", "label": "제목", "from": "fields", "listPath": "fields", "where": {"name": "제목"}, "field": "value", "op": "eq", "value": "에이전트 벤치마크 시범 운영"}
+        ]
+      }
+    },
+    {
+      "id": "t02_table_roundtrip",
+      "title": "표 CSV 왕복 편집",
+      "category": "표",
+      "goal": "입력 문서(BENCH_INPUT)의 본문 최상위 표 12(12행x3열)에서 (row 1, col 1) 칸 값만 \"1,234\" 로 바꾼 문서를 BENCH_OUT_DIR/updated.hwpx 로 저장하라. 표 크기와 나머지 칸은 그대로 두어야 한다.",
+      "fixtures": ["samples/2025년 기부·답례품 실적 지자체 보고서_양식.hwpx"],
+      "params": {"table": 12, "row": 1, "col": 1, "newValue": "1,234"},
+      "outputs": ["updated.hwpx"],
+      "timeoutSec": 180,
+      "oracle": {
+        "steps": [
+          {"cmd": ["{RHWP}", "table-to-csv", "{FIXTURE}", "--table", "12", "-o", "{WORK}/orig.csv", "--json"]},
+          {"cmd": ["{RHWP}", "table-to-csv", "{OUT}/updated.hwpx", "--table", "12", "-o", "{WORK}/after.csv", "--json"]}
+        ],
+        "checks": [
+          {"type": "csv_cells", "label": "목표 칸 값", "file": "{WORK}/after.csv", "cells": [{"row": 1, "col": 1, "eq": "1,234"}]},
+          {"type": "csv_equal_except", "label": "나머지 칸 보존", "a": "{WORK}/orig.csv", "b": "{WORK}/after.csv", "except": [[1, 1]]}
+        ]
+      }
+    },
+    {
+      "id": "t03_redact",
+      "title": "개인정보 마스킹 후 배포본 생성",
+      "category": "보안",
+      "goal": "입력 문서(BENCH_INPUT)에는 가공 개인정보(주민번호·전화·이메일)가 들어 있다. 개인정보를 자릿수 보존 마스킹으로 지운 배포본을 BENCH_OUT_DIR/redacted.hwp 로 저장하라. 본문 나머지 내용과 쪽수는 보존해야 한다.",
+      "fixtures": ["samples/field-01.hwp"],
+      "setup": [
+        {"cmd": ["{RHWP}", "edit", "fill-fields", "{FIXTURE}", "--data", "{\"작성자\":\"홍길동 900101-1234568\",\"전화번호\":\"010-1234-5678\",\"이메일\":\"hong@example.com\"}", "-o", "{WORK}/pii_input.hwp", "--json"]}
+      ],
+      "solutionInput": "{WORK}/pii_input.hwp",
+      "params": {},
+      "outputs": ["redacted.hwp"],
+      "timeoutSec": 120,
+      "oracle": {
+        "steps": [
+          {"save": "before", "cmd": ["{RHWP}", "edit", "redact", "{WORK}/pii_input.hwp", "--dry-run", "--json"]},
+          {"save": "after", "cmd": ["{RHWP}", "edit", "redact", "{OUT}/redacted.hwp", "--dry-run", "--json"]},
+          {"save": "fields", "cmd": ["{RHWP}", "fields", "{OUT}/redacted.hwp", "--json"]},
+          {"save": "info_before", "cmd": ["{RHWP}", "info", "{WORK}/pii_input.hwp", "--json"]},
+          {"save": "info_after", "cmd": ["{RHWP}", "info", "{OUT}/redacted.hwp", "--json"]},
+          {"save": "text_after", "cmd": ["{RHWP}", "export-text", "{OUT}/redacted.hwp", "--json"], "extractPagesTextTo": "{WORK}/redacted.txt"}
+        ],
+        "checks": [
+          {"type": "json", "label": "입력이 실제로 더러움(sanity)", "from": "before", "path": "findingCount", "op": "ge", "value": 3},
+          {"type": "json", "label": "잔여 탐지 0", "from": "after", "path": "findingCount", "op": "eq", "value": 0},
+          {"type": "text_contains", "label": "전화번호 원문 제거", "file": "{WORK}/redacted.txt", "needle": "010-1234-5678", "expect": false},
+          {"type": "text_contains", "label": "주민번호 원문 제거", "file": "{WORK}/redacted.txt", "needle": "900101-1234568", "expect": false},
+          {"type": "json_list", "label": "비개인정보 내용 보존", "from": "fields", "listPath": "fields", "where": {"name": "작성자"}, "field": "value", "op": "contains", "value": "홍길동"},
+          {"type": "json", "label": "쪽수 보존", "from": "info_after", "path": "pageCount", "op": "eq", "value": {"from": "info_before", "path": "pageCount"}}
+        ]
+      }
+    },
+    {
+      "id": "t04_convert_hwpx",
+      "title": "HWP→HWPX 형식 변환(무손실 게이트)",
+      "category": "변환",
+      "goal": "입력 HWP 문서(BENCH_INPUT)를 HWPX 로 변환해 BENCH_OUT_DIR/converted.hwpx 로 저장하라. 변환본은 원본과 쪽수·본문 텍스트가 같아야 한다.",
+      "fixtures": ["samples/20250130-hongbo.hwp"],
+      "params": {},
+      "outputs": ["converted.hwpx"],
+      "timeoutSec": 180,
+      "oracle": {
+        "steps": [
+          {"save": "info_src", "cmd": ["{RHWP}", "info", "{FIXTURE}", "--json"]},
+          {"save": "info_dst", "cmd": ["{RHWP}", "info", "{OUT}/converted.hwpx", "--json"]},
+          {"save": "text_src", "cmd": ["{RHWP}", "export-text", "{FIXTURE}", "--json"], "extractPagesTextTo": "{WORK}/src.txt"},
+          {"save": "text_dst", "cmd": ["{RHWP}", "export-text", "{OUT}/converted.hwpx", "--json"], "extractPagesTextTo": "{WORK}/dst.txt"}
+        ],
+        "checks": [
+          {"type": "json", "label": "형식", "from": "info_dst", "path": "format", "op": "eq", "value": "hwpx"},
+          {"type": "json", "label": "쪽수 보존", "from": "info_dst", "path": "pageCount", "op": "eq", "value": {"from": "info_src", "path": "pageCount"}},
+          {"type": "text_similarity", "label": "본문 텍스트 보존", "a": "{WORK}/src.txt", "b": "{WORK}/dst.txt", "op": "ge", "value": 0.999}
+        ]
+      }
+    },
+    {
+      "id": "t05_replace_preserve_pages",
+      "title": "쪽수 보존 일괄 치환",
+      "category": "편집",
+      "goal": "입력 문서(BENCH_INPUT)의 모든 \"한국수자원공사\" 를 \"한국수자원공단\" 으로 바꾼 문서를 BENCH_OUT_DIR/edited.hwp 로 저장하라. 치환 후에도 쪽수는 원본과 같아야 한다.",
+      "fixtures": ["samples/20250130-hongbo.hwp"],
+      "params": {"find": "한국수자원공사", "replace": "한국수자원공단"},
+      "outputs": ["edited.hwp"],
+      "timeoutSec": 120,
+      "oracle": {
+        "steps": [
+          {"save": "src_search", "cmd": ["{RHWP}", "search", "{FIXTURE}", "한국수자원공사", "--json"]},
+          {"save": "old_after", "cmd": ["{RHWP}", "search", "{OUT}/edited.hwp", "한국수자원공사", "--json"]},
+          {"save": "new_after", "cmd": ["{RHWP}", "search", "{OUT}/edited.hwp", "한국수자원공단", "--json"]},
+          {"save": "info_src", "cmd": ["{RHWP}", "info", "{FIXTURE}", "--json"]},
+          {"save": "info_dst", "cmd": ["{RHWP}", "info", "{OUT}/edited.hwp", "--json"]}
+        ],
+        "checks": [
+          {"type": "json", "label": "원본에 대상 존재(sanity)", "from": "src_search", "path": "totalMatchCount", "op": "ge", "value": 1},
+          {"type": "json", "label": "이전 문자열 잔존 0", "from": "old_after", "path": "matchCount", "op": "eq", "value": 0},
+          {"type": "json", "label": "치환 수 일치", "from": "new_after", "path": "totalMatchCount", "op": "eq", "value": {"from": "src_search", "path": "totalMatchCount"}},
+          {"type": "json", "label": "쪽수 보존", "from": "info_dst", "path": "pageCount", "op": "eq", "value": {"from": "info_src", "path": "pageCount"}}
+        ]
+      }
+    },
+    {
+      "id": "t06_visual_safe_edit",
+      "title": "시각 무회귀 편집(첫 쪽 렌더 불변)",
+      "category": "편집",
+      "goal": "입력 문서(BENCH_INPUT)의 본문 최상위 표 12에서 (row 2, col 1) 칸 값을 \"7,777\" 로 바꾼 문서를 BENCH_OUT_DIR/updated.hwpx 로 저장하라. 편집하지 않은 쪽의 렌더는 바뀌면 안 된다 — 특히 첫 쪽(page 0)의 SVG 렌더가 원본과 바이트 동일해야 한다.",
+      "fixtures": ["samples/2025년 기부·답례품 실적 지자체 보고서_양식.hwpx"],
+      "params": {"table": 12, "row": 2, "col": 1, "newValue": "7,777", "frozenPage": 0},
+      "outputs": ["updated.hwpx"],
+      "timeoutSec": 180,
+      "oracle": {
+        "steps": [
+          {"cmd": ["{RHWP}", "table-to-csv", "{OUT}/updated.hwpx", "--table", "12", "-o", "{WORK}/after.csv", "--json"]},
+          {"cmd": ["{RHWP}", "export-svg", "{FIXTURE}", "-p", "0", "-o", "{WORK}/svg_src", "--json"]},
+          {"cmd": ["{RHWP}", "export-svg", "{OUT}/updated.hwpx", "-p", "0", "-o", "{WORK}/svg_dst", "--json"]}
+        ],
+        "checks": [
+          {"type": "csv_cells", "label": "편집 반영", "file": "{WORK}/after.csv", "cells": [{"row": 2, "col": 1, "eq": "7,777"}]},
+          {"type": "bytes_equal", "label": "첫 쪽 렌더 불변", "a": "{WORK}/svg_src/2025년 기부·답례품 실적 지자체 보고서_양식_001.svg", "b": "{WORK}/svg_dst/updated_001.svg", "expect": true}
+        ]
+      }
+    },
+    {
+      "id": "t07_text_extract",
+      "title": "본문 텍스트 추출",
+      "category": "추출",
+      "goal": "입력 문서(BENCH_INPUT)의 본문 텍스트 전체를 추출해 BENCH_OUT_DIR/text.txt (UTF-8) 로 저장하라. 쪽 순서대로, 누락 없이.",
+      "fixtures": ["samples/2022년 국립국어원 업무계획.hwp"],
+      "params": {},
+      "outputs": ["text.txt"],
+      "timeoutSec": 180,
+      "oracle": {
+        "steps": [
+          {"save": "ref", "cmd": ["{RHWP}", "export-text", "{FIXTURE}", "--json"], "extractPagesTextTo": "{WORK}/ref.txt"}
+        ],
+        "checks": [
+          {"type": "text_similarity", "label": "전문 유사도", "a": "{OUT}/text.txt", "b": "{WORK}/ref.txt", "op": "ge", "value": 0.99},
+          {"type": "text_contains", "label": "외부 대조 앵커 1(제목)", "file": "{OUT}/text.txt", "needle": "2022년 국립국어원 업무계획", "expect": true},
+          {"type": "text_contains", "label": "외부 대조 앵커 2(1장 제목)", "file": "{OUT}/text.txt", "needle": "2021년 평가", "expect": true},
+          {"type": "text_contains", "label": "외부 대조 앵커 3(본문 문장)", "file": "{OUT}/text.txt", "needle": "말뭉치", "expect": true}
+        ]
+      }
+    },
+    {
+      "id": "t08_structure_report",
+      "title": "문서 구조 파악 보고",
+      "category": "구조",
+      "goal": "입력 문서(BENCH_INPUT)의 조문/개요 구조를 분석해 BENCH_OUT_DIR/answers.json 에 {\"mode\": <auto 모드가 고른 구조 종류>, \"nodeCount\": <전체 구조 노드 수>, \"topLevelCount\": <최상위 노드 수>} 로 보고하라.",
+      "fixtures": ["samples/2025 행정업무운영 편람(최종).hwpx"],
+      "params": {},
+      "outputs": ["answers.json"],
+      "timeoutSec": 300,
+      "oracle": {
+        "steps": [
+          {"save": "ref", "cmd": ["{RHWP}", "export-structure", "{FIXTURE}", "--json"], "timeoutSec": 300},
+          {"loadJson": "{OUT}/answers.json", "save": "ans"}
+        ],
+        "checks": [
+          {"type": "json", "label": "mode", "from": "ans", "path": "mode", "op": "eq", "value": {"from": "ref", "path": "mode"}},
+          {"type": "json", "label": "nodeCount", "from": "ans", "path": "nodeCount", "op": "eq", "value": {"from": "ref", "path": "nodeCount"}},
+          {"type": "json", "label": "topLevelCount", "from": "ref", "path": "structure.roots", "op": "lenEq", "value": {"from": "ans", "path": "topLevelCount"}}
+        ]
+      }
+    },
+    {
+      "id": "t09_bulk_aggregate",
+      "title": "대량 처리 집계 대장",
+      "category": "대량",
+      "goal": "BENCH_INPUTS_JSON 의 문서 5건 각각의 쪽수를 조사해 BENCH_OUT_DIR/summary.json 에 {\"files\": [{\"file\": <파일명>, \"pageCount\": <쪽수>} ...입력 순서대로], \"totalPageCount\": <합계>} 로 보고하라.",
+      "fixtures": [
+        "samples/20250130-hongbo.hwp",
+        "samples/2010-01-06.hwp",
+        "samples/hwp3-sample.hwp",
+        "samples/2026_oss_rst.hwp",
+        "samples/field-01.hwp"
+      ],
+      "params": {},
+      "outputs": ["summary.json"],
+      "timeoutSec": 300,
+      "oracle": {
+        "steps": [
+          {"save": "info0", "cmd": ["{RHWP}", "info", "{FIXTURE0}", "--json"]},
+          {"save": "info1", "cmd": ["{RHWP}", "info", "{FIXTURE1}", "--json"]},
+          {"save": "info2", "cmd": ["{RHWP}", "info", "{FIXTURE2}", "--json"]},
+          {"save": "info3", "cmd": ["{RHWP}", "info", "{FIXTURE3}", "--json"]},
+          {"save": "info4", "cmd": ["{RHWP}", "info", "{FIXTURE4}", "--json"]},
+          {"loadJson": "{OUT}/summary.json", "save": "ans"}
+        ],
+        "checks": [
+          {"type": "json", "label": "5건 전부", "from": "ans", "path": "files", "op": "lenEq", "value": 5},
+          {"type": "json_list", "label": "hongbo 쪽수", "from": "ans", "listPath": "files", "where": {"file": "20250130-hongbo.hwp"}, "field": "pageCount", "op": "eq", "value": {"from": "info0", "path": "pageCount"}},
+          {"type": "json_list", "label": "2010-01-06 쪽수", "from": "ans", "listPath": "files", "where": {"file": "2010-01-06.hwp"}, "field": "pageCount", "op": "eq", "value": {"from": "info1", "path": "pageCount"}},
+          {"type": "json_list", "label": "hwp3-sample 쪽수", "from": "ans", "listPath": "files", "where": {"file": "hwp3-sample.hwp"}, "field": "pageCount", "op": "eq", "value": {"from": "info2", "path": "pageCount"}},
+          {"type": "json_list", "label": "2026_oss_rst 쪽수", "from": "ans", "listPath": "files", "where": {"file": "2026_oss_rst.hwp"}, "field": "pageCount", "op": "eq", "value": {"from": "info3", "path": "pageCount"}},
+          {"type": "json_list", "label": "field-01 쪽수", "from": "ans", "listPath": "files", "where": {"file": "field-01.hwp"}, "field": "pageCount", "op": "eq", "value": {"from": "info4", "path": "pageCount"}},
+          {"type": "json_sum", "label": "합계 정합", "from": "ans", "listPath": "files", "field": "pageCount", "op": "eq", "value": {"from": "ans", "path": "totalPageCount"}}
+        ]
+      }
+    },
+    {
+      "id": "t10_security_sweep",
+      "title": "보안 스윕 판정(은닉·유니코드·주입)",
+      "category": "보안",
+      "goal": "BENCH_INPUTS_JSON 의 문서 4건 각각에 대해 은닉 텍스트(hidden-text)·유니코드 기만(unicode)·프롬프트 주입(injection) 3축 검사를 수행하고, BENCH_OUT_DIR/verdict.json 에 {\"files\": [{\"file\": <파일명>, \"hiddenText\": <clean 여부 bool>, \"unicode\": <bool>, \"injection\": <bool>} ...]} 로 판정을 보고하라. true = 깨끗함, false = 신호 발견.",
+      "fixtures": [
+        "samples/issue1892_hwp3_tab_roundtrip.hwp",
+        "samples/정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwp",
+        "samples/hwp3-sample.hwp",
+        "samples/field-01.hwp"
+      ],
+      "params": {},
+      "outputs": ["verdict.json"],
+      "timeoutSec": 600,
+      "oracle": {
+        "steps": [
+          {"save": "f0_hidden", "cmd": ["{RHWP}", "inspect", "hidden-text", "{FIXTURE0}", "--json"]},
+          {"save": "f0_unicode", "cmd": ["{RHWP}", "inspect", "unicode", "{FIXTURE0}", "--json"]},
+          {"save": "f0_injection", "cmd": ["{RHWP}", "inspect", "injection", "{FIXTURE0}", "--json"]},
+          {"save": "f1_hidden", "cmd": ["{RHWP}", "inspect", "hidden-text", "{FIXTURE1}", "--json"]},
+          {"save": "f1_unicode", "cmd": ["{RHWP}", "inspect", "unicode", "{FIXTURE1}", "--json"]},
+          {"save": "f1_injection", "cmd": ["{RHWP}", "inspect", "injection", "{FIXTURE1}", "--json"]},
+          {"save": "f2_hidden", "cmd": ["{RHWP}", "inspect", "hidden-text", "{FIXTURE2}", "--json"]},
+          {"save": "f2_unicode", "cmd": ["{RHWP}", "inspect", "unicode", "{FIXTURE2}", "--json"]},
+          {"save": "f2_injection", "cmd": ["{RHWP}", "inspect", "injection", "{FIXTURE2}", "--json"]},
+          {"save": "f3_hidden", "cmd": ["{RHWP}", "inspect", "hidden-text", "{FIXTURE3}", "--json"]},
+          {"save": "f3_unicode", "cmd": ["{RHWP}", "inspect", "unicode", "{FIXTURE3}", "--json"]},
+          {"save": "f3_injection", "cmd": ["{RHWP}", "inspect", "injection", "{FIXTURE3}", "--json"]},
+          {"loadJson": "{OUT}/verdict.json", "save": "ans"}
+        ],
+        "checks": [
+          {"type": "json", "label": "4건 전부", "from": "ans", "path": "files", "op": "lenEq", "value": 4},
+          {"type": "json_list", "label": "issue1892 hidden", "from": "ans", "listPath": "files", "where": {"file": "issue1892_hwp3_tab_roundtrip.hwp"}, "field": "hiddenText", "op": "eq", "value": {"from": "f0_hidden", "path": "clean"}},
+          {"type": "json_list", "label": "issue1892 unicode", "from": "ans", "listPath": "files", "where": {"file": "issue1892_hwp3_tab_roundtrip.hwp"}, "field": "unicode", "op": "eq", "value": {"from": "f0_unicode", "path": "clean"}},
+          {"type": "json_list", "label": "issue1892 injection", "from": "ans", "listPath": "files", "where": {"file": "issue1892_hwp3_tab_roundtrip.hwp"}, "field": "injection", "op": "eq", "value": {"from": "f0_injection", "path": "clean"}},
+          {"type": "json_list", "label": "정책연구 hidden", "from": "ans", "listPath": "files", "where": {"file": "정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwp"}, "field": "hiddenText", "op": "eq", "value": {"from": "f1_hidden", "path": "clean"}},
+          {"type": "json_list", "label": "정책연구 unicode", "from": "ans", "listPath": "files", "where": {"file": "정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwp"}, "field": "unicode", "op": "eq", "value": {"from": "f1_unicode", "path": "clean"}},
+          {"type": "json_list", "label": "정책연구 injection", "from": "ans", "listPath": "files", "where": {"file": "정책연구용역사업 중간진도보고서(살아있는 간장 기증자의 의학적 선별기준 연구).hwp"}, "field": "injection", "op": "eq", "value": {"from": "f1_injection", "path": "clean"}},
+          {"type": "json_list", "label": "hwp3-sample hidden", "from": "ans", "listPath": "files", "where": {"file": "hwp3-sample.hwp"}, "field": "hiddenText", "op": "eq", "value": {"from": "f2_hidden", "path": "clean"}},
+          {"type": "json_list", "label": "hwp3-sample unicode", "from": "ans", "listPath": "files", "where": {"file": "hwp3-sample.hwp"}, "field": "unicode", "op": "eq", "value": {"from": "f2_unicode", "path": "clean"}},
+          {"type": "json_list", "label": "hwp3-sample injection", "from": "ans", "listPath": "files", "where": {"file": "hwp3-sample.hwp"}, "field": "injection", "op": "eq", "value": {"from": "f2_injection", "path": "clean"}},
+          {"type": "json_list", "label": "field-01 hidden", "from": "ans", "listPath": "files", "where": {"file": "field-01.hwp"}, "field": "hiddenText", "op": "eq", "value": {"from": "f3_hidden", "path": "clean"}},
+          {"type": "json_list", "label": "field-01 unicode", "from": "ans", "listPath": "files", "where": {"file": "field-01.hwp"}, "field": "unicode", "op": "eq", "value": {"from": "f3_unicode", "path": "clean"}},
+          {"type": "json_list", "label": "field-01 injection", "from": "ans", "listPath": "files", "where": {"file": "field-01.hwp"}, "field": "injection", "op": "eq", "value": {"from": "f3_injection", "path": "clean"}}
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## 무엇 (#4236 — #4220 T2 1차)

`tools/agent_bench/` 신설 — 태스크 10종 선언(tasks.json 280줄)·채점 하니스(run_bench.py 494줄, exit 0/1/2 규약)·레퍼런스 풀이 10·음성 대조 오풀이 10·보고서. **23파일 +1,154줄, 기존 파일 수정 0.**

| id | 축 | 오라클 요지 |
|---|---|---|
| t01 서식 채우기 | fields 재독 4필드 값 일치 |
| t02 표 CSV 왕복 | 목표 칸만 변경 + 나머지 35칸 보존 |
| t03 레닥션 | redact dry-run 잔여 0·원문 부재·내용/쪽수 보존 |
| t04 형식 변환 | format 스니핑·쪽수 보존·텍스트 유사도≥0.999 |
| t05 쪽수 보존 치환 | search 이전 0/신규 6건·쪽수 보존 |
| t06 시각 무회귀 편집 | 편집 반영 + page 0 SVG **바이트 동일**(결정성 실측) |
| t07 텍스트 추출 | 자기일관≥0.99 + 외부 앵커 3종 |
| t08 구조 파악 | export-structure 대조(clause·nodeCount 635) |
| t09 대량 집계 | 혼합 5건 파일별 쪽수+합계 정합 |
| t10 보안 스윕 | inspect 3축×4건=12판정 전수(더러운 fixture 는 samples **실물** 2건) |

## 왜 이 절단인가

성공률 실측의 전제는 "판정기가 옳고 그름을 실제로 가르는가"다. 1차는 그 판정 기반만 만들고 양방향으로 실증했다 — 살아있는 LLM 호출은 없고, **이 수치는 오라클 검증이지 에이전트 성공률이 아니다**(성공률 실측은 후속).

## 실측 (devel dc7d7adcc release, 이 PC)

- 레퍼런스 풀이 **10/10 PASS**(exit 0, ~48s) / 오풀이 **0/10**(exit 1) — 전부 의미 있는 검사에서 절단(예: t04 확장자 사칭을 format 스니핑이 잡음, t10 "전부 깨끗" 보고가 실제 clean=false 와 불일치)
- 종료 코드 실측: 0(전건 pass)·1(fail/풀이 없음)·2(구성 오류)
- 오라클은 devel 실존 명령만 — verify(#4186)·scan(#4217)은 미사용, merge 후 치환/보강 여지를 보고서 §5에 기록
- t03 가공 PII 는 redact_sanitize_contract.rs 와 같은 값을 setup 이 CLI 로 심고, t10 더러운 fixture 는 security_corpus_regression.rs 가 "탐지가 옳다" 선언한 실물 2건

## 검증

- `RHWP_BIN=... run_bench.py --solutions reference_solutions` → 10/10 exit 0 · `--solutions null_solutions` → 0/10 exit 1
- check_markdown_links · git diff --check 통과 · Rust 무변경
- 한계는 보고서에 명기(오라클은 rhwp 읽기 표면 신뢰 — 재독 대조 원칙, 독립 교차검증은 범위 밖)

상세: `mydocs/report/agent_bench_r0_20260808.md`

closes #4236
refs #4220 #3907

🤖 Generated with [Claude Code](https://claude.com/claude-code)
