### PR TITLE
feat(tools): 포크 수확 하니스 + 옵트인 규약 — 읽기 전용, r0 실측 ahead 35건 (#4243)

### DIFF
--- a/mydocs/manual/fork_harvest_convention.md
+++ b/mydocs/manual/fork_harvest_convention.md
@@ -1,0 +1,127 @@
+---
+kind: guide
+status: active
+canonical: mydocs/manual/fork_harvest_convention.md
+last_verified: 2026-08-08
+---
+
+# 포크 수확(fork harvest) 규약 — 옵트인 매니페스트와 읽기 전용 경계
+
+rhwp 는 포크가 많다(2026-08-08 실측 663개). 포크 위에서 이루어진 개선은 upstream 으로
+PR 이 돌아오지 않으면 사라진다. 이 문서는 두 가지를 정의한다.
+
+1. **수확기(harvester)** — `tools/fork_harvest/harvest.py` 가 공개 GitHub 데이터를 읽어
+   "어느 포크가 upstream 보다 앞서 있고, 무엇을 바꿨으며, 거둘 만한가" 를 보고하는 방법.
+2. **옵트인 규약** — 포크에서 작업하는 사람이나 에이전트가 "이 작업을 upstream 이
+   거둬 가 주면 좋겠다" 고 선언하는 방법.
+
+## 읽기 전용 경계 (가장 중요한 규칙)
+
+수확기는 **읽기 전용** 장치다. 포크에 무언가를 밀어넣는 게 아니라 공개 데이터를 읽어
+거둘 후보를 보고할 뿐이다.
+
+- GitHub 호출은 전부 GET 이다. 포크에 push·이슈 생성·PR 생성·코멘트 등 **어떤 쓰기
+  작업도 하지 않는다**. `harvest.py` 에는 그런 코드 경로 자체가 없다(`gh_get` 이 유일한
+  GitHub 통로이며 메서드를 지정하지 않아 GET 으로 고정된다).
+- 포크 소유자에 대해서는 **로그인명(login) 외 어떤 정보도 수집하지 않는다**
+  (이름·이메일·아바타·프로필 등 금지).
+- 수확 후보를 upstream 에 반영하는 일은 **사람이 통상 PR 절차로** 진행한다
+  (이슈 등록 → 분석 → 코드 변경 → 처리결과 문서 → PR). 수확기는 후보 목록까지만 낸다.
+- 자기증식·자동 전파류 설계는 금지한다. 수확기는 우리 쪽에서 실행하는 수집기일 뿐이며,
+  포크 쪽에 실행을 요구하거나 유도하는 어떤 장치도 두지 않는다.
+
+## 라이선스
+
+upstream(edwardkim/rhwp)의 라이선스는 **MIT** 다(저장소 루트 `LICENSE`). GitHub 포크는
+같은 라이선스를 승계하므로, 포크 위 변경을 통상 PR 절차로 upstream 에 반영하는 데
+라이선스 장벽은 없다. 단, 포크가 루트 `LICENSE` 를 **다른 라이선스로 교체**했거나 별도
+고지를 추가한 경우 그 포크의 변경은 수확 후보에서 제외하고 사람이 개별 판단한다.
+
+## 옵트인: 수확되고 싶은 포크가 하는 일
+
+포크에서 작업하는 사람/에이전트가 자기 작업이 수확 후보로 우선 선별되기를 원하면,
+다음 두 방법 중 하나(또는 둘 다)를 쓴다.
+
+### 방법 1 — 브랜치 이름 `harvest/<주제>`
+
+upstream 반영을 원하는 작업을 `harvest/<주제>` 브랜치에 둔다.
+
+```
+harvest/table-clipping-fix
+harvest/docs-typo-sweep
+```
+
+현재 수확기 r0 은 포크의 **기본 브랜치만** 대조하므로, 이 브랜치 명명은 후속 라운드의
+스캔 대상 예약이다. 지금 당장 확실히 선별되려면 방법 2를 함께 쓰거나, 기본 브랜치에
+작업을 두는 것이 좋다.
+
+### 방법 2 — 루트 `AGENT_WORK.json` 매니페스트
+
+포크 기본 브랜치 루트에 `AGENT_WORK.json` 을 둔다. 수확기를 `--beacon` 으로 실행하면
+ahead>0 포크에서 이 파일을 읽어 선언 내용을 보고서에 우선 반영하고,
+`wantsUpstream: true` 인 포크의 우선순위를 가산한다.
+
+#### 스키마
+
+| 필드 | 형 | 필수 | 의미 |
+|---|---|---|---|
+| `what` | string | 예 | 무엇을 바꿨는지 한 줄 요약 |
+| `why` | string | 아니오 | 왜 바꿨는지(문제·동기) |
+| `files` | string[] | 아니오 | 핵심 변경 파일 경로 목록 |
+| `gates` | string[] | 아니오 | 통과시킨 품질 관문(예: `cargo test`, `cargo fmt --check`) |
+| `wantsUpstream` | boolean | 예 | upstream 반영을 원하는지 — `true` 면 우선순위 가산 |
+
+알 수 없는 필드는 무시된다. JSON 이 파싱되지 않으면 보고서에 "말 안 됨(malformed)" 으로
+표기될 뿐 불이익은 없다(ahead 분석은 그대로 수행).
+
+#### 예시
+
+```json
+{
+  "what": "표 셀 클리핑 게이트의 오프바이원 수정",
+  "why": "행 높이 합산에서 마지막 행이 1px 잘리는 회귀",
+  "files": ["src/render/table.rs", "tests/table_clipping.rs"],
+  "gates": ["cargo test -p rhwp", "cargo fmt --check", "cargo clippy"],
+  "wantsUpstream": true
+}
+```
+
+## 수확기 실행
+
+```
+python tools/fork_harvest/harvest.py --days 180 --beacon
+python tools/fork_harvest/harvest.py --limit 5          # 소규모 재실행(결정성 확인용)
+```
+
+- 출력: `output/fork_harvest/harvest.tsv` + `harvest.md` (gitignore 대상, `--out-dir` 로 변경).
+- exit 규약: `0` 완주 / `1` 부분 실패 있음(오류 행 또는 쿼터 보호 중단 — 보고서에 부분
+  결과임을 정직하게 표기) / `2` 구성 오류(gh 미인증·잘못된 인자·시작 쿼터 부족).
+- 쿼터: core 잔량이 `--min-remaining`(기본 100) 아래로 접근하면 스스로 중단한다.
+
+### 기준 브랜치 선택 근거 (`--base auto`)
+
+upstream 의 기본 브랜치는 `main`, 기여 기준은 `devel` 인데, 실측(2026-08-08)상 `main` 은
+`devel` 대비 **ahead 23 / behind 1232** 로 발산해 있다. 모든 포크를 무조건 `devel` 과
+대조하면 `main` 을 그대로 포크만 한 저장소 전부가 ahead=23 으로 오탐된다. `auto` 는
+포크 기본 브랜치와 **같은 이름의 upstream 브랜치**가 있으면 그것을(main↔main,
+devel↔devel), 없으면 upstream 기본 브랜치를 기준으로 삼아 이 오탐을 제거한다.
+`--base devel` 처럼 명시 지정도 가능하다.
+
+### 우선순위 휴리스틱
+
+점수 = beacon(`wantsUpstream`) +3 / 분류 code +2 · tests +1.5 · docs +1 · 기타 +0.5
+/ ahead 규모 0~2(20커밋 포화) / 최근 push 30일 +1 · 90일 +0.5.
+라벨: ≥4.0 high / ≥2.5 mid / 그 외 low. 휴리스틱은 정렬용일 뿐 최종 판단은 사람이 한다.
+
+## 반복 실행
+
+주기 실행이 필요하면 로컬 cron(또는 Windows 작업 스케줄러)으로 하루 1회 정도를
+**제안**한다 — 예: `0 6 * * * cd <repo> && python tools/fork_harvest/harvest.py --beacon`.
+CI 워크플로 신설은 하지 않는다(쿼터·권한·무인 실행 경계 검토가 선행되어야 하며,
+이 규약의 읽기 전용 경계를 CI 토큰 권한으로 다시 증명해야 하기 때문).
+
+## 한계와 후속
+
+- r0 은 포크 **기본 브랜치만** 대조한다. `harvest/*` 토픽 브랜치 스캔은 후속 라운드.
+- compare API 는 파일 300개·커밋 250개에서 절단된다 — 대형 발산 포크의 분류는 하한값.
+- 첫 실측 회전 결과는 `mydocs/report/fork_harvest_r0_20260808.md` 참조.

--- a/mydocs/report/fork_harvest_r0_20260808.md
+++ b/mydocs/report/fork_harvest_r0_20260808.md
@@ -1,0 +1,76 @@
+# 포크 수확 r0 — 첫 실측 회전 결과 보고 (2026-08-08)
+
+- 도구: `tools/fork_harvest/harvest.py` (규약: `mydocs/manual/fork_harvest_convention.md`)
+- 실행 명령: `python tools/fork_harvest/harvest.py --days 180 --beacon` (전수 회전, limit 없음)
+  + 결정성 확인용 `--limit 5` 소규모 재실행 2회
+- 실행 시각: 2026-08-08 03:19 UTC / 대상: edwardkim/rhwp / 기준 브랜치: `--base auto`
+- 아래 수치는 전부 이번 실행의 실측이다. 산출 원본(TSV·MD)은 `output/`(gitignore) 아래에
+  남기고, 이 문서가 커밋되는 기록이다.
+
+## 1. 요약 수치
+
+| 항목 | 실측 |
+|---|---|
+| 포크 총수(메타데이터 `forks_count`) | 663 |
+| 포크 열거 결과(list API 전수) | 660 (3건은 목록 미반환 — 삭제·비공개 추정) |
+| 활동 포크(생성 후 push 존재 + 최근 180일) | 141 (열거 대비 21.4%) |
+| 대조 시도 | 141 (성공 138 / 오류 3) |
+| **upstream 보다 ahead 인 포크** | **35** (활동 포크의 24.8%, 열거 전체의 5.3%) |
+| 옵트인 비콘(AGENT_WORK.json) 발견 | 0건 (규약이 이번에 처음 제정되므로 당연) |
+| exit code | 1 (오류 행 3건 존재 — 규약대로 부분 실패 표기) |
+
+분류 분포(ahead>0 35건, 변경 파일 확장자 기반): **code 25 / config 7 / docs 2 / other 1**.
+포크 생태계의 발산 대부분이 문서가 아니라 코드라는 뜻으로, 수확 가치가 실재한다.
+
+## 2. 기준 브랜치 선택 실측 (오탐 제거의 근거)
+
+upstream 기본 브랜치는 `main`, 기여 기준은 `devel` 인데 실측상 `main` 은 `devel` 대비
+**ahead 23 / behind 1232** 로 발산해 있다. 과제 원안대로 모든 포크를 `devel` 과 대조하면
+`main` 을 그대로 포크만 한 저장소 전부가 ahead=23 으로 오탐된다. 그래서 하니스 기본값을
+`--base auto`(포크 기본 브랜치와 동명의 upstream 브랜치 우선, 없으면 upstream 기본
+브랜치)로 설계했고, 이번 회전의 ahead 35건은 이 오탐이 제거된 수치다
+(main 포크↔main, devel 포크↔devel 대조).
+
+## 3. 상위 수확 후보 (우선순위순 10건)
+
+| # | 포크 | ahead | 분류 | 요지(최근 커밋 기준) |
+|---|---|---|---|---|
+| 1 | seo-rii/rhwp (`skia`) | +1195 | code | Skia 렌더러 방향의 대규모 병행 개발(Rust 1.97 Clippy 대응, 래스터 diff 테스트) — 파일 300+ (API 절단), 통째 수확이 아니라 주제별 발췌 대상 |
+| 2 | kevin9327/rhwp | +39 | code | **본인 포크**(스윕 봇 상태 보존 + upstream 동기화) — 자기 수확이므로 후보에서 제외하고 참고만 |
+| 3 | edu-ide/rhwp | +35 | code | studio 배포 경로 보정, 개체 묶기·풀기 공동편집 중계 |
+| 4 | dongkseo/rhwp | +34 | code | WASM PDF fallback 폰트 정렬, HWP→PDF 변환의 native CLI 라우팅 |
+| 5 | donggyun112/rhwp | +27 | code | skill 설치 안내를 릴리즈 tarball URL 로 — clone 691MB·6분 제거 |
+| 6 | wizardbc/rhwp | +23 | code | styled import 의 표 자연 페이지네이션 허용, 선택 서식 노출, 부분 문자 보존 |
+| 7 | mindlogic-ai/rhwp (`mindlogic/main`) | +17/-10 | code | studio S3+CloudFront 정적 배포 CI — behind 10 으로 동기화 상태 양호, 되가져오기 마찰 최소 |
+| 8 | dragonnite1221-lgtm/rhwp | +16 | code | HWP 파서 선할당/인덱스 방어(자체 코드리뷰 M1·M3) — 견고성 수확 후보 |
+| 9 | choism4/rhwp | +73 | code | 문장부호 글리프 겹침 수정(렌더폰트 advance 기반 shift), master page 파서 — 쪽번호 round-trip |
+| 10 | KenSuh/rhwp | +34 | code | 도장(seal-place) 기능, 페이지를 가득 채우는 정사각 표의 페이지네이션 수정 |
+
+그 밖에 주목할 소규모 후보: seanshin/rhwp(right tab 정렬 — 셀 우측 끝 기준),
+cskwork/rhwp(수식 HTML 배치 정밀도), JeekLee/rhwp(`--merge` 시 페이지 경계 없는 전체
+추출), unerue/rhwp(studio 하위 경로 배포 보정, behind 10 으로 동기화 양호).
+
+오류 3건도 실전 검증이 됐다: LPFchan/Hwping·cyber-osint/rhwp 는 히스토리 재작성으로
+공통 조상 없음(HTTP 404), noullove/rhwp 는 열거 후 접근 불가(404) — 모두 오류 행으로
+정직하게 격리되고 회전은 계속됐다.
+
+## 4. 쿼터 사용
+
+- 실행 전 core 잔량 5000 → 회전 종료 직후 실측 remaining 4966 / used 34.
+- 하니스 자체 기록은 "시작 잔량 4977 → 종료 잔량 4970 (델타 7)" 이었으나, 실행 중
+  쿼터 창 리셋 epoch 가 이동(1786162335→1786162369)해 **델타가 실호출량(약 190회:
+  목록 7p + 대조 141 + 비콘 35 + 부대)을 과소 보고**했다. 이 실측을 반영해 하니스에
+  리셋 이동 감지·경고 표기를 추가했다. 어느 쪽으로 재도 5000 쿼터 대비 여유가 크다
+  (전수 회전 1회 ≈ 최대 200회 수준).
+
+## 5. 한계와 후속
+
+- **기본 브랜치만 대조** — 규약의 `harvest/<주제>` 토픽 브랜치 스캔은 후속 라운드
+  (r0 에서 비콘 0건이므로 옵트인 규약 전파가 선행 과제).
+- compare API 는 파일 300·커밋 250 에서 절단 — seo-rii 같은 대형 발산 포크의 분류·규모는
+  하한값이다.
+- 포크 총수 663(메타) vs 660(열거) 불일치 3건은 API 특성(삭제·비공개 포크 미반환)으로
+  보이며 하니스가 통제할 수 없다 — 보고서에 그대로 병기한다.
+- 우선순위는 휴리스틱 정렬일 뿐, 실제 upstream 반영은 후보별로 사람이 통상 PR 절차
+  (이슈 → 분석 → 변경 → 문서 → PR)로 진행한다. 수확기는 읽기 전용이며 이번 회전에서도
+  포크에 어떤 쓰기 작업도 하지 않았다.

--- a/tools/fork_harvest/harvest.py
+++ b/tools/fork_harvest/harvest.py
@@ -1,0 +1,543 @@
+#!/usr/bin/env python3
+"""fork harvest — rhwp 포크 생태계 읽기 전용 수확 하니스.
+
+포크 위의 개선은 upstream 으로 돌아오지 않으면 사라진다. 이 도구는 공개
+GitHub 데이터를 **읽기만** 해서 "어느 포크가 upstream 보다 앞서 있고,
+무엇을 바꿨으며, 거둘 만한가" 를 보고서로 만든다.
+
+동작 단계:
+  1. 발견   — `gh api repos/{repo}/forks` 페이지네이션 전수 열거
+  2. 선별   — 활동 필터(생성 이후 push 존재 + 최근 --days 일 이내)
+  3. 대조   — 각 후보의 기본 브랜치를 upstream 브랜치와 compare API 로 대조
+  4. 분류   — ahead>0 포크의 변경 파일 확장자 기반 분류(code/tests/docs/…)
+  5. 보고   — TSV + 마크다운 수확 보고서(우선순위 휴리스틱 포함)
+
+읽기 전용 경계 (절대 불변):
+  - GitHub 에 대한 모든 호출은 GET 뿐이다. 포크에 push·이슈·PR·코멘트 등
+    어떤 쓰기 작업도 하지 않으며, 그런 코드 경로 자체가 없다.
+  - 포크 소유자에 대해서는 로그인명(login) 외 어떤 정보도 수집하지 않는다.
+  - 수확 후보의 upstream 반영은 사람이 통상 PR 절차로 진행한다.
+
+기준 브랜치 선택 (--base auto 의 근거):
+  upstream(edwardkim/rhwp) 의 기본 브랜치는 main 이고 기여 기준은 devel 인데,
+  실측(2026-08-08)상 main 은 devel 대비 ahead 23 / behind 1232 로 발산해 있다.
+  따라서 모든 포크를 무조건 devel 과 대조하면 main 을 그대로 포크만 한
+  저장소가 전부 ahead=23 으로 오탐된다. `auto` 는 포크 브랜치와 같은 이름의
+  브랜치가 upstream 에 있으면 그것을(main↔main, devel↔devel), 없으면
+  upstream 기본 브랜치를 기준으로 삼아 이 오탐을 제거한다.
+
+옵트인 비콘 (--beacon):
+  포크 루트에 AGENT_WORK.json (스키마: what/why/files/gates/wantsUpstream —
+  mydocs/manual/fork_harvest_convention.md 참조) 이 있으면 그 선언을 보고서에
+  우선 반영하고 우선순위를 가산한다.
+
+exit 규약:
+  0 — 완주(모든 후보 대조 성공)
+  1 — 부분 실패 있음(개별 포크 오류 행 존재, 또는 쿼터 보호로 조기 중단;
+      보고서에 부분 결과임을 정직하게 표기)
+  2 — 구성 오류(gh 없음/미인증, 잘못된 인자, upstream 접근 불가,
+      시작 시점 쿼터 부족)
+
+사용 예:
+  python tools/fork_harvest/harvest.py --days 180 --limit 120 --beacon
+  python tools/fork_harvest/harvest.py --limit 5 --out-dir output/fork_harvest
+
+필요 도구: python 표준 라이브러리 + gh CLI(인증된 상태) 뿐.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+
+# Windows 콘솔(cp949)에서도 유니코드 요약 출력이 죽지 않게 한다.
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
+# ---------------------------------------------------------------------------
+# gh 호출 (GET 전용)
+# ---------------------------------------------------------------------------
+
+GH_TIMEOUT_SEC = 60
+
+
+class GhError(RuntimeError):
+    def __init__(self, path: str, returncode: int, stderr: str):
+        super().__init__(f"gh api GET {path} 실패 (exit {returncode}): {stderr.strip()[:300]}")
+        self.path = path
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+def gh_get(path: str) -> object:
+    """`gh api <path>` 를 GET 으로만 호출해 JSON 을 돌려준다.
+
+    읽기 전용 보증: -X/--method 를 절대 지정하지 않으며(gh 기본 = GET),
+    -f/-F 필드 입력도 쓰지 않는다. 이 함수가 이 파일의 유일한 GitHub 통로다.
+    """
+    proc = subprocess.run(
+        ["gh", "api", path],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=GH_TIMEOUT_SEC,
+    )
+    if proc.returncode != 0:
+        raise GhError(path, proc.returncode, proc.stderr or "")
+    return json.loads(proc.stdout)
+
+
+def rate_remaining() -> tuple[int, int]:
+    """core 쿼터 (잔량, 창 리셋 epoch). rate_limit 엔드포인트는 쿼터를 소모하지 않는다.
+
+    리셋 epoch 를 함께 돌려주는 이유: 실행 중 쿼터 창이 리셋되면 시작-종료 잔량
+    델타가 실제 사용량을 과소 보고한다(2026-08-08 첫 회전에서 실측 — 약 190 호출이
+    델타 7 로 보였다). 창이 바뀌었으면 보고서에 델타 신뢰 불가를 표기한다.
+    """
+    data = gh_get("rate_limit")
+    core = data["resources"]["core"]
+    return int(core["remaining"]), int(core["reset"])
+
+
+# ---------------------------------------------------------------------------
+# 분류·우선순위 휴리스틱
+# ---------------------------------------------------------------------------
+
+CODE_EXT = {
+    ".rs", ".ts", ".tsx", ".js", ".mjs", ".cjs", ".py", ".swift", ".kt",
+    ".java", ".c", ".h", ".cc", ".cpp", ".hpp", ".go", ".sh", ".ps1",
+}
+DOC_EXT = {".md", ".txt", ".adoc", ".rst"}
+CONFIG_EXT = {".toml", ".yml", ".yaml", ".json", ".lock", ".xml", ".cfg", ".ini"}
+
+
+def classify_files(filenames: list[str]) -> dict[str, int]:
+    """변경 파일 목록을 code/tests/docs/config/other 로 집계한다."""
+    counts = {"code": 0, "tests": 0, "docs": 0, "config": 0, "other": 0}
+    for name in filenames:
+        lower = name.lower().replace("\\", "/")
+        ext = os.path.splitext(lower)[1]
+        is_testpath = (
+            "/tests/" in f"/{lower}" or lower.startswith("tests/")
+            or "_test." in lower or ".test." in lower or "/fuzz/" in f"/{lower}"
+        )
+        if is_testpath and (ext in CODE_EXT or ext in CONFIG_EXT):
+            counts["tests"] += 1
+        elif ext in CODE_EXT:
+            counts["code"] += 1
+        elif ext in DOC_EXT:
+            counts["docs"] += 1
+        elif ext in CONFIG_EXT:
+            counts["config"] += 1
+        else:
+            counts["other"] += 1
+    return counts
+
+
+def primary_category(counts: dict[str, int]) -> str:
+    if counts["code"] > 0:
+        return "code"
+    if counts["tests"] > 0:
+        return "tests"
+    if counts["docs"] > 0:
+        return "docs"
+    if counts["config"] > 0:
+        return "config"
+    return "other"
+
+
+def priority_score(row: "ForkRow", now: dt.datetime) -> float:
+    """수확 우선순위 점수. 근거는 fork_harvest_convention.md 에 문서화.
+
+    beacon(wantsUpstream) +3 / 분류 code +2 · tests +1.5 · docs +1 · 기타 +0.5
+    ahead 규모 0~2 (20커밋에서 포화) / 최근 push 30일 +1 · 90일 +0.5
+    """
+    score = 0.0
+    if row.beacon and row.beacon.get("wantsUpstream"):
+        score += 3.0
+    score += {"code": 2.0, "tests": 1.5, "docs": 1.0}.get(row.category, 0.5)
+    score += min(row.ahead_by, 20) / 10.0
+    pushed = parse_iso(row.pushed_at)
+    if pushed is not None:
+        age_days = (now - pushed).days
+        if age_days <= 30:
+            score += 1.0
+        elif age_days <= 90:
+            score += 0.5
+    return round(score, 2)
+
+
+def priority_label(score: float) -> str:
+    if score >= 4.0:
+        return "high"
+    if score >= 2.5:
+        return "mid"
+    return "low"
+
+
+# ---------------------------------------------------------------------------
+# 자료 구조
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ForkRow:
+    login: str
+    full_name: str
+    branch: str
+    created_at: str
+    pushed_at: str
+    base: str = ""
+    ahead_by: int = 0
+    behind_by: int = 0
+    file_counts: dict = field(default_factory=dict)
+    total_files: int = 0
+    category: str = ""
+    recent_commits: list = field(default_factory=list)
+    beacon: dict | None = None
+    score: float = 0.0
+    label: str = ""
+    error: str = ""
+
+
+def parse_iso(value: str) -> dt.datetime | None:
+    if not value:
+        return None
+    try:
+        return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# 수집 단계
+# ---------------------------------------------------------------------------
+
+
+def list_forks(repo: str) -> list[dict]:
+    """포크 전수 열거(페이지네이션). 소유자 정보는 login 만 유지한다."""
+    forks: list[dict] = []
+    page = 1
+    while True:
+        batch = gh_get(f"repos/{repo}/forks?per_page=100&sort=oldest&page={page}")
+        if not isinstance(batch, list) or not batch:
+            break
+        for item in batch:
+            forks.append(
+                {
+                    "login": item.get("owner", {}).get("login", ""),
+                    "full_name": item.get("full_name", ""),
+                    "default_branch": item.get("default_branch", ""),
+                    "created_at": item.get("created_at", ""),
+                    "pushed_at": item.get("pushed_at", ""),
+                    "archived": bool(item.get("archived", False)),
+                }
+            )
+        if len(batch) < 100:
+            break
+        page += 1
+    return forks
+
+
+def upstream_branch_names(repo: str) -> set[str]:
+    names: set[str] = set()
+    page = 1
+    while True:
+        batch = gh_get(f"repos/{repo}/branches?per_page=100&page={page}")
+        if not isinstance(batch, list) or not batch:
+            break
+        names.update(b["name"] for b in batch if "name" in b)
+        if len(batch) < 100:
+            break
+        page += 1
+    return names
+
+
+def fetch_beacon(full_name: str, branch: str) -> dict | None:
+    """포크 루트의 AGENT_WORK.json 을 읽는다(없으면 None — 정상)."""
+    import base64
+
+    try:
+        data = gh_get(f"repos/{full_name}/contents/AGENT_WORK.json?ref={branch}")
+    except GhError:
+        return None
+    if not isinstance(data, dict) or data.get("encoding") != "base64":
+        return None
+    try:
+        raw = base64.b64decode(data.get("content", "")).decode("utf-8", errors="replace")
+        manifest = json.loads(raw)
+    except (ValueError, TypeError):
+        return {"_malformed": True}
+    if not isinstance(manifest, dict):
+        return {"_malformed": True}
+    keep = {k: manifest.get(k) for k in ("what", "why", "files", "gates", "wantsUpstream") if k in manifest}
+    return keep or {"_malformed": True}
+
+
+# ---------------------------------------------------------------------------
+# 출력
+# ---------------------------------------------------------------------------
+
+TSV_COLUMNS = [
+    "fork", "branch", "base", "ahead", "behind", "category",
+    "files_code", "files_tests", "files_docs", "files_config", "files_other",
+    "total_files", "recent_commits", "pushed_at", "beacon", "score", "priority",
+    "error",
+]
+
+
+def sanitize_cell(value: object) -> str:
+    return str(value).replace("\t", " ").replace("\r", " ").replace("\n", " ¶ ")
+
+
+def write_tsv(path: str, rows: list[ForkRow]) -> None:
+    lines = ["\t".join(TSV_COLUMNS)]
+    for r in rows:
+        fc = r.file_counts or {}
+        lines.append(
+            "\t".join(
+                sanitize_cell(v)
+                for v in [
+                    r.full_name, r.branch, r.base, r.ahead_by, r.behind_by, r.category,
+                    fc.get("code", 0), fc.get("tests", 0), fc.get("docs", 0),
+                    fc.get("config", 0), fc.get("other", 0), r.total_files,
+                    " | ".join(r.recent_commits),
+                    r.pushed_at,
+                    json.dumps(r.beacon, ensure_ascii=False) if r.beacon else "",
+                    r.score, r.label, r.error,
+                ]
+            )
+        )
+    with open(path, "w", encoding="utf-8", newline="\n") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+def write_markdown(path: str, args, stats: dict, rows: list[ForkRow], partial_reason: str) -> None:
+    now = stats["now"].strftime("%Y-%m-%d %H:%M UTC")
+    ahead_rows = [r for r in rows if not r.error and r.ahead_by > 0]
+    error_rows = [r for r in rows if r.error]
+    cat_dist: dict[str, int] = {}
+    for r in ahead_rows:
+        cat_dist[r.category] = cat_dist.get(r.category, 0) + 1
+
+    md: list[str] = []
+    md.append(f"# 포크 수확 보고서 — {args.repo}")
+    md.append("")
+    md.append(f"- 실행: {now} / 기준 브랜치: `{args.base}` / 활동 창: 최근 {args.days}일 / limit: {args.limit or '없음'} / beacon: {'on' if args.beacon else 'off'}")
+    md.append(f"- 포크 총수 {stats['total_forks']} → 활동 필터 통과 {stats['active_forks']} → 대조 시도 {stats['compared']} → **ahead>0 {len(ahead_rows)}** / 오류 {len(error_rows)}")
+    quota_line = f"- API 쿼터: 시작 잔량 {stats['rate_start']} → 종료 잔량 {stats['rate_end']} (델타 {stats['rate_start'] - stats['rate_end']})"
+    if stats.get("rate_window_reset"):
+        quota_line += " — **실행 중 쿼터 창 리셋 경과: 델타는 실사용량을 과소 보고함**"
+    md.append(quota_line)
+    if partial_reason:
+        md.append(f"- **부분 결과**: {partial_reason}")
+    md.append("- 경계: 이 보고서는 공개 데이터의 **읽기 전용** 수집 결과다. 포크에 어떤 쓰기 작업도 하지 않았다.")
+    md.append("")
+    if cat_dist:
+        md.append("## 분류 분포 (ahead>0)")
+        md.append("")
+        for cat in sorted(cat_dist, key=cat_dist.get, reverse=True):
+            md.append(f"- {cat}: {cat_dist[cat]}")
+        md.append("")
+    md.append("## 수확 후보 (우선순위순)")
+    md.append("")
+    if ahead_rows:
+        md.append("| 우선순위 | 포크 | 브랜치 | 기준 | ahead/behind | 분류 | 파일 | 최근 커밋 | beacon |")
+        md.append("|---|---|---|---|---|---|---|---|---|")
+        for r in ahead_rows:
+            beacon_cell = "—"
+            if r.beacon:
+                beacon_cell = "말 안 됨" if r.beacon.get("_malformed") else sanitize_cell(r.beacon.get("what", "(선언)"))[:60]
+            commits = sanitize_cell("; ".join(r.recent_commits))[:120] or "—"
+            md.append(
+                f"| {r.label} ({r.score}) | {r.full_name} | {r.branch} | {r.base} "
+                f"| +{r.ahead_by}/-{r.behind_by} | {r.category} | {r.total_files} | {commits} | {beacon_cell} |"
+            )
+    else:
+        md.append("(ahead>0 포크 없음)")
+    md.append("")
+    if error_rows:
+        md.append("## 오류 행")
+        md.append("")
+        for r in error_rows:
+            md.append(f"- {r.full_name} ({r.branch}): {sanitize_cell(r.error)[:200]}")
+        md.append("")
+    md.append("## 한계")
+    md.append("")
+    md.append("- 각 포크의 **기본 브랜치만** 대조한다. `harvest/*` 등 토픽 브랜치 스캔은 후속.")
+    md.append("- compare API 는 파일 300개·커밋 250개에서 절단되므로 대형 발산 포크의 파일 분류는 하한값이다.")
+    md.append("- 우선순위는 휴리스틱이며 최종 판단은 사람이 한다.")
+    with open(path, "w", encoding="utf-8", newline="\n") as f:
+        f.write("\n".join(md) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# 메인
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="harvest.py",
+        description="rhwp 포크 생태계 읽기 전용 수확 하니스 (발견→선별→대조→보고)",
+        epilog=(
+            "읽기 전용 보증: GitHub 호출은 전부 GET 이며 포크에 push·이슈·PR 등 "
+            "쓰기 작업을 절대 하지 않는다. 소유자 정보는 로그인명만 수집한다. "
+            "exit: 0 완주 / 1 부분 실패 / 2 구성 오류."
+        ),
+    )
+    p.add_argument("--repo", default="edwardkim/rhwp", help="upstream 저장소 (기본: edwardkim/rhwp)")
+    p.add_argument("--base", default="auto",
+                   help="대조 기준 브랜치. auto=포크 브랜치와 동명 upstream 브랜치 우선, 없으면 upstream 기본 브랜치 (기본: auto)")
+    p.add_argument("--days", type=int, default=180, help="활동 창(일). 이 기간 내 push 가 있어야 후보 (기본: 180)")
+    p.add_argument("--limit", type=int, default=0, help="대조할 후보 포크 상한 (0=무제한; 후보는 pushed_at 내림차순 정렬 후 절단)")
+    p.add_argument("--beacon", action="store_true", help="ahead>0 포크에서 AGENT_WORK.json 옵트인 매니페스트를 조회해 우선 반영")
+    p.add_argument("--out-dir", default="output/fork_harvest", help="TSV·마크다운 출력 디렉터리 (기본: output/fork_harvest — gitignore 대상)")
+    p.add_argument("--min-remaining", type=int, default=100, help="core 쿼터 잔량이 이 값 밑으로 내려가면 중단하고 부분 결과 표기 (기본: 100)")
+    return p
+
+
+def main(argv: list[str]) -> int:
+    args = build_parser().parse_args(argv)
+    if args.days <= 0 or args.limit < 0 or args.min_remaining < 0 or "/" not in args.repo:
+        print("구성 오류: --days>0, --limit>=0, --min-remaining>=0, --repo 는 owner/name 형식이어야 한다", file=sys.stderr)
+        return 2
+
+    now = dt.datetime.now(dt.timezone.utc)
+
+    # -- 시작 전 구성 검증 (실패는 전부 exit 2) ---------------------------
+    try:
+        rate_start, reset_start = rate_remaining()
+        if rate_start < args.min_remaining:
+            print(f"구성 오류: 시작 시점 쿼터 잔량 {rate_start} < --min-remaining {args.min_remaining}", file=sys.stderr)
+            return 2
+        upstream = gh_get(f"repos/{args.repo}")
+        upstream_default = upstream.get("default_branch", "main")
+        branch_names = upstream_branch_names(args.repo)
+        if args.base != "auto" and args.base not in branch_names:
+            print(f"구성 오류: upstream 에 브랜치 '{args.base}' 가 없다", file=sys.stderr)
+            return 2
+    except (GhError, FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError, KeyError) as exc:
+        print(f"구성 오류: gh 접근 실패 — {exc}", file=sys.stderr)
+        return 2
+
+    # -- 1. 발견 -----------------------------------------------------------
+    try:
+        forks = list_forks(args.repo)
+    except GhError as exc:
+        print(f"구성 오류: 포크 열거 실패 — {exc}", file=sys.stderr)
+        return 2
+    total_forks = len(forks)
+
+    # -- 2. 선별 -----------------------------------------------------------
+    cutoff = now - dt.timedelta(days=args.days)
+    candidates = []
+    for fk in forks:
+        if fk["archived"] or not fk["login"] or not fk["default_branch"]:
+            continue
+        created, pushed = parse_iso(fk["created_at"]), parse_iso(fk["pushed_at"])
+        if created is None or pushed is None:
+            continue
+        if pushed <= created or pushed < cutoff:
+            continue
+        candidates.append(fk)
+    candidates.sort(key=lambda fk: (fk["pushed_at"], fk["login"]), reverse=True)
+    active_forks = len(candidates)
+    if args.limit:
+        candidates = candidates[: args.limit]
+
+    # -- 3~4. 대조·분류 ----------------------------------------------------
+    rows: list[ForkRow] = []
+    partial_reason = ""
+    calls_since_check = 0
+    for fk in candidates:
+        if calls_since_check >= 20:
+            calls_since_check = 0
+            try:
+                if rate_remaining()[0] < args.min_remaining:
+                    partial_reason = (
+                        f"쿼터 보호 중단 — 잔량이 --min-remaining({args.min_remaining}) 아래로 접근, "
+                        f"{len(rows)}/{len(candidates)} 후보만 대조함"
+                    )
+                    break
+            except GhError:
+                pass  # 잔량 조회 실패는 치명적이지 않다
+        row = ForkRow(
+            login=fk["login"], full_name=fk["full_name"], branch=fk["default_branch"],
+            created_at=fk["created_at"], pushed_at=fk["pushed_at"],
+        )
+        if args.base == "auto":
+            row.base = fk["default_branch"] if fk["default_branch"] in branch_names else upstream_default
+        else:
+            row.base = args.base
+        try:
+            cmp = gh_get(
+                f"repos/{args.repo}/compare/{row.base}...{row.login}:{row.branch}"
+            )
+            calls_since_check += 1
+            row.ahead_by = int(cmp.get("ahead_by", 0))
+            row.behind_by = int(cmp.get("behind_by", 0))
+            if row.ahead_by > 0:
+                filenames = [f.get("filename", "") for f in cmp.get("files", [])]
+                row.file_counts = classify_files(filenames)
+                row.total_files = len(filenames)
+                row.category = primary_category(row.file_counts)
+                subjects = [
+                    c.get("commit", {}).get("message", "").splitlines()[0]
+                    for c in cmp.get("commits", [])
+                ]
+                row.recent_commits = [s for s in subjects if s][-3:]
+                if args.beacon:
+                    row.beacon = fetch_beacon(row.full_name, row.branch)
+                    calls_since_check += 1
+                row.score = priority_score(row, now)
+                row.label = priority_label(row.score)
+        except GhError as exc:
+            calls_since_check += 1
+            row.error = str(exc)
+        except (subprocess.TimeoutExpired, json.JSONDecodeError, ValueError) as exc:
+            row.error = f"{type(exc).__name__}: {exc}"
+        rows.append(row)
+
+    rows.sort(key=lambda r: (-r.score, -r.ahead_by, r.full_name))
+
+    # -- 5. 보고 -----------------------------------------------------------
+    try:
+        rate_end, reset_end = rate_remaining()
+    except GhError:
+        rate_end, reset_end = -1, reset_start
+    stats = {
+        "now": now, "total_forks": total_forks, "active_forks": active_forks,
+        "compared": len(rows), "rate_start": rate_start, "rate_end": rate_end,
+        "rate_window_reset": reset_end != reset_start,
+    }
+    os.makedirs(args.out_dir, exist_ok=True)
+    tsv_path = os.path.join(args.out_dir, "harvest.tsv")
+    md_path = os.path.join(args.out_dir, "harvest.md")
+    write_tsv(tsv_path, rows)
+    write_markdown(md_path, args, stats, rows, partial_reason)
+
+    ahead = sum(1 for r in rows if not r.error and r.ahead_by > 0)
+    errors = sum(1 for r in rows if r.error)
+    quota_note = str(rate_start - rate_end) if rate_end >= 0 else "?"
+    if stats["rate_window_reset"]:
+        quota_note += " (창 리셋 경과 — 과소 보고)"
+    print(
+        f"포크 {total_forks} / 활동 {active_forks} / 대조 {len(rows)} / ahead>0 {ahead} / 오류 {errors}"
+        f" — 쿼터 델타 {quota_note}"
+    )
+    print(f"출력: {tsv_path} , {md_path}")
+    if partial_reason:
+        print(f"부분 결과: {partial_reason}", file=sys.stderr)
+    return 1 if (errors or partial_reason) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## 무엇 (#4243)

- `tools/fork_harvest/harvest.py`(543줄): 포크 전수 열거 → 활동 필터(--days) → compare 대조 → 분류(code/tests/docs/config) → TSV+MD 수확 보고. `--base auto`·`--beacon`·쿼터 보호(--min-remaining·창 리셋 감지)·exit 0/1/2.
- `mydocs/manual/fork_harvest_convention.md`(127줄): 옵트인 규약 — `harvest/<주제>` 브랜치 또는 루트 `AGENT_WORK.json`(what/why/files/gates/wantsUpstream 스키마+예시). 읽기 전용 경계·MIT 승계 확인·cron 은 제안만(CI 신설 없음).
- `mydocs/report/fork_harvest_r0_20260808.md`(76줄): **첫 실측 회전** — 포크 660 열거(663 메타), 활동 141, **ahead 35**(code 25·config 7·docs 2), 상위 후보 10건(렌더러 +1,195 발췌 대상 포함), 오류 3 격리, 쿼터 ~190회.

신규 3파일 746줄, 기존 파일 수정 0.

## 판단

- **읽기 전용 경계를 코드로 강제** — GitHub 통로는 `gh_get` 단일 함수(메서드 미지정 = GET 고정), 포크에 push·이슈·PR 생성 없음. 자기증식·자동 전파류 설계 금지(문서 명시).
- **실측이 설계를 바꿈**: devel 고정 대조는 main↔devel 발산(ahead 23/behind 1232) 탓에 전 포크 ahead=23 오탐 — 동명 브랜치 대조로 제거. 쿼터 창 리셋로 사용량이 과소 보고되는 것도 실측에서 발견해 감지·경고 내장.
- 수확 후보의 upstream 반영은 사람이 통상 PR 절차로 — 하니스는 발견·선별까지만.

## 검증

- `--limit 5` 재실행 결정성 확인(라이브 변동 외 diff 0), exit 0/1/2 전부 실증(구성 오류·부분 실패 경로 포함)
- check_markdown_links 이상 없음 · git diff --check 통과 · Rust 무관(파이썬+문서만)

closes #4243
refs #3907 #4229

🤖 Generated with [Claude Code](https://claude.com/claude-code)
