### PR TITLE
renderer: find_metric 폰트 메트릭 조회를 선계산 색인으로 교체

### DIFF
--- a/mydocs/plans/task_m100_4168.md
+++ b/mydocs/plans/task_m100_4168.md
@@ -1,0 +1,40 @@
+# 수행계획 — task_m100_4168
+
+- **이슈**: [#4168](https://github.com/edwardkim/rhwp/issues/4168)
+- **브랜치**: `task_m100_4168_font_metric_index`
+- **기준**: `upstream/devel` `5a4f26d0d`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+`find_metric`(src/renderer/font_metrics_data.rs)의 폰트 메트릭 테이블 선형 스캔을 1회 선계산
+색인(O(1) 조회)으로 바꾼다. #4167 프로파일에서 거대 셀 문서 IME 키스트로크 60ms 중
+~16%(1,052/6,765 샘플)가 이 함수의 문자열 비교 폴백 사다리에 귀속됐다.
+
+## 2. 변경 경계
+
+- `find_metric`의 **결과는 100% 동일**해야 한다 — 3단 폴백 사다리(정확 매칭 → bold-only →
+  이름 첫 엔트리 + `bold_fallback=bold`)의 첫-매칭 우선순위와 기벽(bold-italic 엔트리만 있는
+  bold 요청의 `bold_fallback=true`)까지 그대로.
+- `resolve_metric_alias` 처리 위치·의미 유지 (#259 alias 매핑 계약).
+- 임의 사용자 폰트명(비-static `&str`) 조회 유지 — 이름 단독 키 + (bold,italic) 4-슬롯
+  배열 선계산으로 `Borrow<str>` 조회를 보존한다 (tuple 키는 수명 제약으로 불가).
+- 다른 파일은 건드리지 않는다.
+
+## 3. 구현·래칫 순서
+
+1. 기존 선형 스캔을 `legacy_find_metric`(cfg(test))으로 원문 보존.
+2. `OnceLock<HashMap<&'static str, [(&'static FontMetric, bool); 4]>>` 색인 — 테이블 순서
+   1회 순회로 조합별/이름별 첫 엔트리를 기록한 뒤 legacy 사다리 순서로 슬롯을 채운다.
+3. 전수 등가성 테스트: FONT_METRICS 전체 이름 + alias LHS 전체 + 미등록 이름 × 4조합에서
+   metric 포인터 동일성 + `bold_fallback` 일치.
+
+## 4. 검증 게이트
+
+- `cargo test --profile release-test --lib font_metrics` (기존 + 신규 등가성)
+- fmt / clippy / `cargo check --target wasm32-unknown-unknown --lib`
+- `cargo test --profile release-test --tests` 전체 무회귀
+- 실측: `issue4149_adjacent_giant_cell_cursor_rect_latency_decomposition`으로 캐럿 질의
+  before/after (기대 ~17-20% 감소)
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/working/task_m100_4168_stage1.md
+++ b/mydocs/working/task_m100_4168_stage1.md
@@ -1,0 +1,41 @@
+---
+kind: working
+status: completed
+issue: 4168
+last_verified: 2026-08-08
+---
+
+# Task #4168 Stage 1 - find_metric 선계산 색인
+
+## 구현
+
+- `find_metric`을 `OnceLock` 선계산 색인 조회로 교체했다. 색인은
+  `HashMap<&'static str, [(metric, bold_fallback); 4]>` — 이름 단독 키라 임의 `&str`
+  조회(`Borrow<str>`)가 유지되고, (bold,italic) 4조합 슬롯을 legacy 3단 폴백 사다리와
+  같은 우선순위(정확 → bold-only(italic 요청 한정) → 이름 첫 엔트리 + `bold_fallback=bold`)로
+  선주입했다.
+- 기존 선형 스캔은 `legacy_find_metric`(cfg(test))으로 바이트 단위 보존해 등가성 오라클로
+  쓴다. `resolve_metric_alias`는 종전대로 조회 진입부에서 적용된다.
+
+## 검증 결과
+
+- 신규 `index_matches_legacy_linear_scan_exhaustively`: FONT_METRICS 600개 이름 전체 +
+  alias 좌변 67개 전체 + 미등록 이름(빈 문자열 포함) × bold/italic 4조합 전수에서 metric
+  포인터 동일성 + `bold_fallback` 일치 — pass.
+- `cargo test --profile release-test --lib font_metrics`: 8 passed / 0 failed.
+- 적대 리뷰(별도 세션): 테이블 중복 트리플 0건 확인, alias 양방향 누락 0, NFD 자모·NUL·
+  30,000자 장문 등 ~3,600 이름 × 4조합 공격 전수 일치, 16스레드 최초 사용 경합 3회 통과,
+  wasm32 check 통과 — 반박 실패(등가성 결함 0건).
+- 실측(거대 셀 문서, release-test): `build_page_tree` ≈20.7ms → ≈17.2ms, 캐럿 질의
+  ≈21.5ms → ≈17.2ms (프로파일 귀속 ~16%와 부합).
+- 알려진 후속: `src/tools/font_metric_gen.rs` 생성기가 구식 선형 스캔을 방출한다(선재
+  드리프트) — 재생성 시 본 색인·테스트가 소실되므로 생성기 갱신을 별도 이슈로 권고.
+
+## 부수 발견 — #4181
+
+게이트 실행 중 `tests/issue_2007_nested_cell_pagination`(p15-16)이 이 레이어에서 비결정
+실패함을 발견, 원인 격리 결과 **devel 선재의 힙 할당 순서 민감성**으로 확정했다(#4181):
+의미 무변경 대조군(색인 빌드만 하고 legacy 스캔 사용, 캐시 value 8바이트 확장) 둘 다 동일
+플레이크를 재현하고, 색인 결과 등가성은 전수·10회 프로세스 반복으로 증명됨. 본 레이어
+게이트는 해당 바이너리를 직렬 재시도로 통과 확인(3회 내 pass)하고 나머지 전 게이트는
+결정적 통과. #4181 해소 전까지 이 fixture 의 실패는 회귀 신호로 오독하지 말 것.

--- a/src/renderer/font_metrics_data.rs
+++ b/src/renderer/font_metrics_data.rs
@@ -3,6 +3,9 @@
 //! font-metric-gen 도구로 TTF 파일에서 추출.
 //! 수동 편집 금지.
 
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
 #[derive(Debug)]
 pub struct HangulMetric {
     pub cho_groups: u8,
@@ -155,7 +158,79 @@ fn resolve_metric_alias(name: &str) -> &str {
     }
 }
 
+/// (bold, italic) → 색인 슬롯 번호. 조합이 4개뿐이라 이름당 배열로 선계산한다.
+fn metric_slot_index(bold: bool, italic: bool) -> usize {
+    ((bold as usize) << 1) | (italic as usize)
+}
+
+/// 이름별 선계산 색인 — 슬롯 값은 (metric, bold_fallback).
+///
+/// [#4149] 글자 측정마다 find_metric 이 호출되어 600 엔트리 선형 스캔
+/// (문자열 비교 × 최대 3단 폴백)이 캐럿 rect 질의 지연의 주요 원인이었다.
+/// 이름이 테이블에 있으면 3단(이름만 매칭)이 항상 성공하므로 슬롯에 Option 이
+/// 필요 없고, 조회 실패 = 이름 부재 = 기존 None 과 동일하다.
+///
+/// 키를 (name, bold, italic) 튜플 대신 이름 단독으로 두는 이유: 튜플 키는
+/// &'static str 수명 때문에 임의 사용자 폰트명(&str)으로 borrow 조회가 불가능하다.
+static METRIC_INDEX: OnceLock<HashMap<&'static str, [(&'static FontMetric, bool); 4]>> =
+    OnceLock::new();
+
+fn metric_index() -> &'static HashMap<&'static str, [(&'static FontMetric, bool); 4]> {
+    METRIC_INDEX.get_or_init(|| {
+        // 선형 스캔의 "테이블 첫 매칭 우선" 계약 재현: 테이블 순서대로 순회하며
+        // (name, bold, italic) 조합별 첫 엔트리와 이름 첫 등장 엔트리만 기록한다.
+        struct FirstSeen {
+            exact: [Option<&'static FontMetric>; 4],
+            first: &'static FontMetric,
+        }
+        let mut seen: HashMap<&'static str, FirstSeen> = HashMap::new();
+        for m in FONT_METRICS.iter() {
+            let entry = seen.entry(m.name).or_insert(FirstSeen {
+                exact: [None; 4],
+                first: m,
+            });
+            let idx = metric_slot_index(m.bold, m.italic);
+            if entry.exact[idx].is_none() {
+                entry.exact[idx] = Some(m);
+            }
+        }
+        // 슬롯 선주입 순서 = legacy 폴백 사다리와 동일:
+        // 1단 정확 매칭 → 2단 bold 매칭(italic 무시) → 3단 이름만 첫 엔트리.
+        seen.into_iter()
+            .map(|(name, fs)| {
+                let mut slots = [(fs.first, false); 4];
+                for bold in [false, true] {
+                    for italic in [false, true] {
+                        slots[metric_slot_index(bold, italic)] =
+                            if let Some(m) = fs.exact[metric_slot_index(bold, italic)] {
+                                (m, false)
+                            } else if let Some(m) = fs.exact[metric_slot_index(bold, false)] {
+                                (m, false)
+                            } else {
+                                // bold 요청이었으면 Faux Bold 보정 표시 (legacy 3단과 동일)
+                                (fs.first, bold)
+                            };
+                    }
+                }
+                (name, slots)
+            })
+            .collect()
+    })
+}
+
 pub fn find_metric(name: &str, bold: bool, italic: bool) -> Option<MetricMatch> {
+    let name = resolve_metric_alias(name);
+    let slots = metric_index().get(name)?;
+    let (metric, bold_fallback) = slots[metric_slot_index(bold, italic)];
+    Some(MetricMatch {
+        metric,
+        bold_fallback,
+    })
+}
+
+/// 기존 선형 스캔 구현 — 색인 등가성 검증 전용으로 보존 (수정 금지).
+#[cfg(test)]
+fn legacy_find_metric(name: &str, bold: bool, italic: bool) -> Option<MetricMatch> {
     let name = resolve_metric_alias(name);
     // 정확한 매칭 (name + bold + italic)
     if let Some(m) = FONT_METRICS
@@ -46229,5 +46304,125 @@ mod tests {
         let m = find_metric("함초롬바탕", false, false);
         assert!(m.is_some(), "함초롬바탕 기존 매핑 회귀");
         assert_eq!(m.unwrap().metric.name, "HCR Batang");
+    }
+
+    #[test]
+    fn index_matches_legacy_linear_scan_exhaustively() {
+        // [#4149] O(1) 색인 도입 계약: legacy 선형 스캔(3단 폴백 사다리)과
+        // 결과가 100% 동일해야 한다. FONT_METRICS 전체 name + 알려진 alias
+        // 전체 + 테이블에 없는 임의 이름 × (bold, italic) 4조합 전수 비교.
+        let mut names: Vec<&str> = FONT_METRICS.iter().map(|m| m.name).collect();
+        // resolve_metric_alias 좌변 전체 (별칭 추가 시 여기도 갱신).
+        names.extend([
+            "함초롬돋움",
+            "한컴돋움",
+            "돋움",
+            "함초롬바탕",
+            "한컴바탕",
+            "바탕",
+            "맑은 고딕",
+            "나눔고딕",
+            "나눔명조",
+            "바탕체",
+            "굴림",
+            "궁서",
+            "굴림체",
+            "돋움체",
+            "궁서체",
+            "D2Coding",
+            "D2 Coding",
+            "고운바탕",
+            "Gowun Batang",
+            "고운돋움",
+            "Gowun Dodum",
+            "Pretendard",
+            "프리텐다드",
+            "HY중고딕",
+            "HY견고딕",
+            "HY헤드라인M",
+            "HY견명조",
+            "HY신명조",
+            "HY그래픽",
+            "HY궁서",
+            "한양신명조",
+            "한양중고딕",
+            "한양견명조",
+            "한양견고딕",
+            "휴먼명조",
+            "신명조",
+            "HY수평선B",
+            "HY수평선M",
+            "HY울릉도B",
+            "HY울릉도M",
+            "HY태백B",
+            "HY동녘B",
+            "HY동녘M",
+            "HY각헤드라인M",
+            "본한글",
+            "본한글vf",
+            "본한글 Medium",
+            "본한글M",
+            "본고딕",
+            "본고딕vf",
+            "Source Han Sans",
+            "Source Han Sans K",
+            "Source Han Sans KR",
+            "SourceHanSans",
+            "SourceHanSansKR",
+            "SourceHanSansK",
+            "Noto Sans CJK KR",
+            "본명조",
+            "본명조vf",
+            "본명조M",
+            "Source Han Serif",
+            "Source Han Serif K",
+            "Source Han Serif KR",
+            "SourceHanSerif",
+            "SourceHanSerifKR",
+            "SourceHanSerifK",
+            "Noto Serif CJK KR",
+        ]);
+        // 테이블에 없는 임의 사용자 폰트명 — 기존과 동일하게 None 이어야 한다.
+        names.extend([
+            "NoSuchFont-Regular",
+            "가상의사용자폰트",
+            "Comic Sans MS",
+            "",
+        ]);
+
+        for name in names {
+            for bold in [false, true] {
+                for italic in [false, true] {
+                    let new = find_metric(name, bold, italic);
+                    let old = legacy_find_metric(name, bold, italic);
+                    match (new, old) {
+                        (None, None) => {}
+                        (Some(n), Some(o)) => {
+                            assert!(
+                                std::ptr::eq(n.metric, o.metric),
+                                "metric 불일치: {name:?} bold={bold} italic={italic} \
+                                 (new={}/b{}/i{}, old={}/b{}/i{})",
+                                n.metric.name,
+                                n.metric.bold,
+                                n.metric.italic,
+                                o.metric.name,
+                                o.metric.bold,
+                                o.metric.italic,
+                            );
+                            assert_eq!(
+                                n.bold_fallback, o.bold_fallback,
+                                "bold_fallback 불일치: {name:?} bold={bold} italic={italic}"
+                            );
+                        }
+                        (n, o) => panic!(
+                            "Some/None 불일치: {name:?} bold={bold} italic={italic} \
+                             new={} old={}",
+                            n.is_some(),
+                            o.is_some()
+                        ),
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
폰트 메트릭 테이블(600 엔트리) 선형 스캔 + 3단 폴백 재스캔이 글자 측정마다 반복돼 거대 셀 문서 IME 키스트로크 60ms 의 ~16%를 차지했다(#4167 프로파일 1,052/6,765 샘플). `OnceLock` 선계산 색인(이름 키 + bold/italic 4-슬롯)으로 O(1) 조회로 바꾸되, legacy 사다리의 첫-매칭 우선순위와 `bold_fallback` 기벽까지 슬롯 선주입으로 그대로 재현한다. 기존 스캔은 `legacy_find_metric`(cfg(test))으로 보존해 전수 등가성 테스트(600 이름 + alias 67 + 미등록 × 4조합, metric 포인터 동일성)의 오라클로 쓴다.

실측: `build_page_tree` ≈20.7ms → ≈17.2ms (거대 셀 문서, release-test). 검증: fmt/clippy/wasm32 check/release-test lib+통합/Native Skia 3종 전부 통과 — 단 `issue_2007_nested_cell_pagination` 은 devel 선재의 힙 할당 순서 민감성(#4181, 본 작업 중 의미 무변경 대조군으로 격리·계측)으로 비결정이며 직렬 재시도 통과를 확인했다. 상세 계획·검증 기록: `mydocs/plans/task_m100_4168.md`, `mydocs/working/task_m100_4168_stage1.md`.

**시리즈 1/4** (타이핑 지연 — merge 순서 준수): 본 PR → #4169 → #4167 Stage 1 → #4167 Stage 2.

Closes #4168

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---
**재검증 (2026-08-08)**: 전 레이어를 최신 `devel`(e64c853) 위로 rebase 후 ci.yml 전 단계를 로컬 완주 — fmt / scripts-tests 6종 / clippy / `cargo build --workspace` + workspace all-targets clippy / wasm32 check / **`cargo nextest run --cargo-profile release-test`** (스택 상단 5,345/5,345 pass) / Native Skia 3종 / wasm-pack dev + binding tests / tsc ci-unit / studio suite(802/802) — 6개 레이어 전부 ALL-PASS. 종전 Lint 실패 원인(workspace all-targets clippy 미실행으로 놓친 테스트 코드 1건)은 수정 완료. nextest 프로세스 격리 하에서 #4181 fixture 는 전 레이어 무재시도 안정.
