### PR TITLE
renderer: 단일줄 과밀 판정을 문단별 memo 로 — 무변경 재측정 제거

### DIFF
--- a/mydocs/plans/task_m100_4168.md
+++ b/mydocs/plans/task_m100_4168.md
@@ -1,0 +1,40 @@
+# 수행계획 — task_m100_4168
+
+- **이슈**: [#4168](https://github.com/edwardkim/rhwp/issues/4168)
+- **브랜치**: `task_m100_4168_font_metric_index`
+- **기준**: `upstream/devel` `5a4f26d0d`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+`find_metric`(src/renderer/font_metrics_data.rs)의 폰트 메트릭 테이블 선형 스캔을 1회 선계산
+색인(O(1) 조회)으로 바꾼다. #4167 프로파일에서 거대 셀 문서 IME 키스트로크 60ms 중
+~16%(1,052/6,765 샘플)가 이 함수의 문자열 비교 폴백 사다리에 귀속됐다.
+
+## 2. 변경 경계
+
+- `find_metric`의 **결과는 100% 동일**해야 한다 — 3단 폴백 사다리(정확 매칭 → bold-only →
+  이름 첫 엔트리 + `bold_fallback=bold`)의 첫-매칭 우선순위와 기벽(bold-italic 엔트리만 있는
+  bold 요청의 `bold_fallback=true`)까지 그대로.
+- `resolve_metric_alias` 처리 위치·의미 유지 (#259 alias 매핑 계약).
+- 임의 사용자 폰트명(비-static `&str`) 조회 유지 — 이름 단독 키 + (bold,italic) 4-슬롯
+  배열 선계산으로 `Borrow<str>` 조회를 보존한다 (tuple 키는 수명 제약으로 불가).
+- 다른 파일은 건드리지 않는다.
+
+## 3. 구현·래칫 순서
+
+1. 기존 선형 스캔을 `legacy_find_metric`(cfg(test))으로 원문 보존.
+2. `OnceLock<HashMap<&'static str, [(&'static FontMetric, bool); 4]>>` 색인 — 테이블 순서
+   1회 순회로 조합별/이름별 첫 엔트리를 기록한 뒤 legacy 사다리 순서로 슬롯을 채운다.
+3. 전수 등가성 테스트: FONT_METRICS 전체 이름 + alias LHS 전체 + 미등록 이름 × 4조합에서
+   metric 포인터 동일성 + `bold_fallback` 일치.
+
+## 4. 검증 게이트
+
+- `cargo test --profile release-test --lib font_metrics` (기존 + 신규 등가성)
+- fmt / clippy / `cargo check --target wasm32-unknown-unknown --lib`
+- `cargo test --profile release-test --tests` 전체 무회귀
+- 실측: `issue4149_adjacent_giant_cell_cursor_rect_latency_decomposition`으로 캐럿 질의
+  before/after (기대 ~17-20% 감소)
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/plans/task_m100_4169.md
+++ b/mydocs/plans/task_m100_4169.md
@@ -1,0 +1,43 @@
+# 수행계획 — task_m100_4169
+
+- **이슈**: [#4169](https://github.com/edwardkim/rhwp/issues/4169)
+- **브랜치**: `task_m100_4169_overflow_memo` (stack: `task_m100_4168_font_metric_index` 위)
+- **기준**: `upstream/devel` `5a4f26d0d`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+`recompose_stored_single_line_if_overflowing`(src/renderer/composer.rs)의 과밀 판정을 문단별로
+메모해, 판정 입력이 안 바뀐 문단의 `estimate_composed_line_width` 재측정을 생략한다. #4167
+프로파일에서 캐럿 질의당 페이지 빌드 비용의 ~30%(1,945/6,765 샘플)가 이 가드의 무변경 재측정
+이었다 — 거대 셀 문서는 셀 문단 대부분이 단일줄이라 사실상 페이지 전 텍스트를 빌드마다 재측정한다.
+
+## 2. 변경 경계
+
+- **무효화 누락 = 가드가 막던 절단 렌더(#4138 계열) 회귀와 동일한 결함** — 텍스트/char_shapes
+  변이 전 경로(프리미티브 우회 직접 대입 포함) 전수 무효화가 계약이다.
+- overflowed=true 문단의 fresh 재래핑 동작은 유지한다(측정만 생략) — 재래핑 생략은 절단 렌더 회귀.
+- `Paragraph`는 Sync 요구(`Arc<Vec<Paragraph>>` 경유 `DocumentCore` Send 단언) — `Cell` 불가,
+  `AtomicU64` 패킹 사용. serde 미보유 확인, `ir_field_sweep` 철저 구조분해에 명시 제외.
+- 파일 저장 포맷에 새지 않는다 (HWP/HWPX 저장기는 필드 명시 기록).
+
+## 3. 구현·래칫 순서
+
+1. `Paragraph.single_line_overflow_memo: AtomicU64` (0=미판정, (f32 폭 bits<<1)|overflowed) +
+   수동 Clone.
+2. 가드에서 memo 히트 시 측정 생략, over 판정은 그대로 소비. 폭 키 불일치·미판정 시 실측 후 기록.
+3. 무효화 전수 배선: 모델 프리미티브 8곳(insert/delete/split/merge/char_shape 계열) +
+   `reflow_line_segs` 수렴점 + 직접 대입 우회(표 계산식, clear_initial_field_texts,
+   `rebuild_char_offsets` 수렴점, 셀 인라인 컨트롤 삭제의 `reflow_paragraph_line_segs_after_control_delete`,
+   클립보드 구조 제거) — 마지막 세 경로는 적대 리뷰 CONFIRMED 결함/동류 누락의 수정이다.
+4. 회귀 테스트: 메모 히트 시 측정 1회 증명, 폭 변경 재판정, over=true 재래핑 유지, 뮤테이션
+   경로별 무효화, 셀 그림 삭제 실명령 재현.
+
+## 4. 검증 게이트
+
+- `cargo test --profile release-test --lib composer` / `--lib issue4149` / `--lib object_ops`
+- 기존 가드 회귀 핀: issue_2287/2430/2525/2527/4138 계열
+- fmt / clippy / wasm32 check / `release-test --tests` 전체
+- 실측: 캐럿 질의 ≈17.2ms → ≈14.3ms (#4168 위 누적)
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/working/task_m100_4168_stage1.md
+++ b/mydocs/working/task_m100_4168_stage1.md
@@ -1,0 +1,41 @@
+---
+kind: working
+status: completed
+issue: 4168
+last_verified: 2026-08-08
+---
+
+# Task #4168 Stage 1 - find_metric 선계산 색인
+
+## 구현
+
+- `find_metric`을 `OnceLock` 선계산 색인 조회로 교체했다. 색인은
+  `HashMap<&'static str, [(metric, bold_fallback); 4]>` — 이름 단독 키라 임의 `&str`
+  조회(`Borrow<str>`)가 유지되고, (bold,italic) 4조합 슬롯을 legacy 3단 폴백 사다리와
+  같은 우선순위(정확 → bold-only(italic 요청 한정) → 이름 첫 엔트리 + `bold_fallback=bold`)로
+  선주입했다.
+- 기존 선형 스캔은 `legacy_find_metric`(cfg(test))으로 바이트 단위 보존해 등가성 오라클로
+  쓴다. `resolve_metric_alias`는 종전대로 조회 진입부에서 적용된다.
+
+## 검증 결과
+
+- 신규 `index_matches_legacy_linear_scan_exhaustively`: FONT_METRICS 600개 이름 전체 +
+  alias 좌변 67개 전체 + 미등록 이름(빈 문자열 포함) × bold/italic 4조합 전수에서 metric
+  포인터 동일성 + `bold_fallback` 일치 — pass.
+- `cargo test --profile release-test --lib font_metrics`: 8 passed / 0 failed.
+- 적대 리뷰(별도 세션): 테이블 중복 트리플 0건 확인, alias 양방향 누락 0, NFD 자모·NUL·
+  30,000자 장문 등 ~3,600 이름 × 4조합 공격 전수 일치, 16스레드 최초 사용 경합 3회 통과,
+  wasm32 check 통과 — 반박 실패(등가성 결함 0건).
+- 실측(거대 셀 문서, release-test): `build_page_tree` ≈20.7ms → ≈17.2ms, 캐럿 질의
+  ≈21.5ms → ≈17.2ms (프로파일 귀속 ~16%와 부합).
+- 알려진 후속: `src/tools/font_metric_gen.rs` 생성기가 구식 선형 스캔을 방출한다(선재
+  드리프트) — 재생성 시 본 색인·테스트가 소실되므로 생성기 갱신을 별도 이슈로 권고.
+
+## 부수 발견 — #4181
+
+게이트 실행 중 `tests/issue_2007_nested_cell_pagination`(p15-16)이 이 레이어에서 비결정
+실패함을 발견, 원인 격리 결과 **devel 선재의 힙 할당 순서 민감성**으로 확정했다(#4181):
+의미 무변경 대조군(색인 빌드만 하고 legacy 스캔 사용, 캐시 value 8바이트 확장) 둘 다 동일
+플레이크를 재현하고, 색인 결과 등가성은 전수·10회 프로세스 반복으로 증명됨. 본 레이어
+게이트는 해당 바이너리를 직렬 재시도로 통과 확인(3회 내 pass)하고 나머지 전 게이트는
+결정적 통과. #4181 해소 전까지 이 fixture 의 실패는 회귀 신호로 오독하지 말 것.

--- a/mydocs/working/task_m100_4169_stage1.md
+++ b/mydocs/working/task_m100_4169_stage1.md
@@ -1,0 +1,41 @@
+---
+kind: working
+status: completed
+issue: 4169
+last_verified: 2026-08-08
+---
+
+# Task #4169 Stage 1 - 단일줄 과밀 판정 memo
+
+## 구현
+
+- `Paragraph.single_line_overflow_memo: AtomicU64` — 0=미판정, `(f32 폭 bits << 1)|overflowed`
+  패킹, Relaxed. `Cell`은 `RenderNormalizedSection.paragraphs: Arc<Vec<Paragraph>>` 경유
+  `DocumentCore` Send 단언이 `Paragraph: Sync`를 요구해 컴파일 불가 — Atomic 선택 근거.
+  Clone은 수동 impl(파생 캐시를 텍스트와 함께 원자적으로 복제 — undo 스냅샷 정합).
+- 가드는 memo 히트 시 `estimate_composed_line_width` 측정만 생략하고, overflowed=true의
+  fresh 재래핑은 매 빌드 그대로 수행한다.
+- 무효화 배선(전수): 모델 프리미티브 8곳(insert_text_at/delete_text_at/split_at/merge_from/
+  apply_char_shape_range/set_single_char_shape/replace_style_char_shape_preserving_overrides/
+  shift_for_inline_control_insert), `reflow_line_segs` 수렴점, 직접 대입 우회 5곳 —
+  table_ops 표 계산식 셀 기록, document.rs clear_initial_field_texts,
+  object_ops/common.rs `reflow_paragraph_line_segs_after_control_delete` 서두(셀 인라인
+  그림/도형/수식/각주 삭제 가족 일괄 — 적대 리뷰 CONFIRMED 결함 수정),
+  field_query.rs `rebuild_char_offsets` 서두(빈 필드 제거 분기 — 감사 중 발견한 동류 누락),
+  clipboard.rs `strip_structural_controls_for_text_clipboard`(clip 사본이 다중 문단 붙여넣기로
+  문서에 스플라이스될 수 있음).
+
+## 검증 결과
+
+- `--lib composer`: 81 passed / 0 failed (신규 5: 메모 히트 측정 생략 증명, over=true 재래핑
+  유지, 폭 키 불일치 재판정, fit 판정 메모, 뮤테이션 경로 무효화).
+- `--lib issue4149`: 신규 `issue4149_cell_picture_delete_clears_single_line_overflow_memo`
+  (실명령 경로: stale verdict 주입 → 그림 삭제 → 미판정 어서션, 결함 분기 branch-1 통과) 포함 pass.
+- `--lib object_ops`: 59 passed / 0 failed. 기존 가드 회귀 핀 issue_2287(2)/2430(2)/2525(1)/
+  2527(3)/4138(2) 전부 pass.
+- 적대 리뷰: 무효화 누락 사냥에서 셀 그림 삭제 CONFIRMED 1건(위 수정 반영). undo/redo 스냅샷
+  클론 정합·f32 폭 키 정밀도(ulp vs 최소 리사이즈 3자리 차)·단일 스레드 TOCTOU 불가·ls==1
+  왕복 무해 — 반박 실패. 관찰: 향후 in-place CharShape 편집 API 도입 시 폭 단독 키가 구멍이
+  된다(현재 사이트 없음 확인).
+- 실측(거대 셀 문서, release-test): `build_page_tree` 17.6ms → 13.7ms (−22%), 캐럿 질의
+  ≈17.2 → ≈14.3ms.

--- a/src/diagnostics/ir_field_sweep.rs
+++ b/src/diagnostics/ir_field_sweep.rs
@@ -519,6 +519,8 @@ fn sweep_paragraph(base: &str, a: &Paragraph, b: &Paragraph, out: &mut Vec<Field
         has_para_text,
         tab_extended,
         numbering_restart,
+        // [#4149] 파생 캐시 — IR 비교 대상 아님 (직렬화·저장 경로에도 미포함).
+        single_line_overflow_memo: _,
     } = a;
 
     macro_rules! f {

--- a/src/document_core/commands/clipboard.rs
+++ b/src/document_core/commands/clipboard.rs
@@ -60,6 +60,10 @@ fn recompute_clipboard_control_mask(para: &Paragraph) -> u32 {
 }
 
 fn strip_structural_controls_for_text_clipboard(para: &mut Paragraph) {
+    // [#4149] clip 사본이지만 다중 문단 붙여넣기에서 중간 문단이 통째로 문서에
+    // 스플라이스되어 렌더 입력이 될 수 있다 — 컨트롤 제거로 compose 입력이
+    // 바뀌므로 단일줄 과밀 memo 를 무효화한다.
+    para.invalidate_single_line_overflow_memo();
     let old_controls = std::mem::take(&mut para.controls);
     let old_records = std::mem::take(&mut para.ctrl_data_records);
     let mut index_map = vec![None; old_controls.len()];

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -1983,7 +1983,11 @@ impl DocumentCore {
                     }
                 }
             }
-            let _ = any_removed;
+            if any_removed {
+                // [#4149] text/char_shapes 직접 수술 — 단일줄 과밀 memo 무효화
+                // (process_table 경유로 셀 문단에도 적용된다).
+                para.invalidate_single_line_overflow_memo();
+            }
         }
 
         fn process_table(table: &mut crate::model::table::Table) {

--- a/src/document_core/commands/object_ops/common.rs
+++ b/src/document_core/commands/object_ops/common.rs
@@ -47,6 +47,12 @@ impl DocumentCore {
         styles: &crate::renderer::style_resolver::ResolvedStyleSet,
         dpi: f64,
     ) {
+        // [#4149] 컨트롤 삭제는 char_offsets −8 시프트로 compose 입력을 바꾼다 —
+        // 높이만 조정하고 reflow_line_segs 를 타지 않는 분기(남은 컨트롤/빈 문단)도
+        // 포함해 단일줄 과밀 memo 를 무효화한다. 삽입 쌍둥이
+        // `shift_for_inline_control_insert` 와 대칭 (셀 그림/도형/수식/각주 삭제
+        // 가족이 전부 이 함수로 수렴).
+        para.invalidate_single_line_overflow_memo();
         // 남은 컨트롤 중 가장 큰 높이 계산
         let max_remaining_ctrl_height = para
             .controls

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -3328,6 +3328,8 @@ impl DocumentCore {
                         cell_para.text = text;
                         let new_len = cell_para.text.chars().count();
                         cell_para.char_offsets = (0..new_len).map(|i| i as u32).collect();
+                        // [#4149] 원시 text 대입 — 단일줄 과밀 memo 무효화.
+                        cell_para.invalidate_single_line_overflow_memo();
                     }
                 }
             }

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -6307,4 +6307,154 @@ mod tests {
             );
         }
     }
+
+    /// [#4149] 셀 문단 편집의 단일 관문 reflow_cell_paragraph / _by_path 를 지나면
+    /// 단일줄 과밀 판정 memo 가 미판정으로 돌아가야 한다 (reflow_line_segs 수렴점).
+    #[test]
+    fn issue4149_reflow_cell_paragraph_clears_single_line_overflow_memo() {
+        use crate::model::control::Control;
+        use crate::model::paragraph::SingleLineOverflowMemo;
+        use crate::model::table::{Cell, Table};
+
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+
+        let mut cell_para = Paragraph::default();
+        cell_para.text = "ABCDE".to_string();
+        cell_para.char_count = 6;
+        cell_para.char_offsets = vec![0, 1, 2, 3, 4];
+        cell_para.char_shapes = vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 0,
+        }];
+        let key = SingleLineOverflowMemo::width_key(123.0);
+        cell_para.single_line_overflow_memo.set(key, true);
+        assert!(!cell_para.single_line_overflow_memo.is_unjudged());
+
+        let table = Table {
+            cells: vec![Cell {
+                width: 8000, // 내폭 > 0 이어야 관문이 reflow_line_segs 까지 진행
+                paragraphs: vec![cell_para],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        core.document.sections[0].paragraphs[0]
+            .controls
+            .push(Control::Table(Box::new(table)));
+        let ctrl_idx = core.document.sections[0].paragraphs[0].controls.len() - 1;
+
+        // flat 관문
+        core.reflow_cell_paragraph(0, 0, ctrl_idx, 0, 0);
+        let memo_after = |core: &DocumentCore| {
+            let Control::Table(t) = &core.document.sections[0].paragraphs[0].controls[ctrl_idx]
+            else {
+                panic!("expected table");
+            };
+            t.cells[0].paragraphs[0]
+                .single_line_overflow_memo
+                .is_unjudged()
+        };
+        assert!(
+            memo_after(&core),
+            "reflow_cell_paragraph 경유 후 memo 는 미판정이어야 함"
+        );
+
+        // path 관문도 동일하게 비워야 한다.
+        {
+            let Control::Table(t) = &mut core.document.sections[0].paragraphs[0].controls[ctrl_idx]
+            else {
+                panic!("expected table");
+            };
+            t.cells[0].paragraphs[0]
+                .single_line_overflow_memo
+                .set(key, true);
+        }
+        core.reflow_cell_paragraph_by_path(0, 0, &[(ctrl_idx, 0, 0)], 0);
+        assert!(
+            memo_after(&core),
+            "reflow_cell_paragraph_by_path 경유 후 memo 는 미판정이어야 함"
+        );
+    }
+
+    /// [#4149 적대 리뷰] 셀 문단 인라인 그림 삭제가 char_offsets 를 −8 시프트하며
+    /// compose 입력을 바꾸는데, 남은 그림 height>0 분기
+    /// (reflow_paragraph_line_segs_after_control_delete branch 1)는 reflow_line_segs
+    /// 를 타지 않아 memo 무효화가 누락됐었다 — stale Some(false) verdict 가
+    /// 재래핑을 억제하면 과폭 절단 렌더. 실명령 경로로 무효화를 고정한다.
+    #[test]
+    fn issue4149_cell_picture_delete_clears_single_line_overflow_memo() {
+        use crate::model::control::Control;
+        use crate::model::image::Picture;
+        use crate::model::paragraph::{LineSeg, SingleLineOverflowMemo};
+        use crate::model::table::{Cell, Table};
+
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+
+        // 저장 ls==1 + 인라인 그림 2개 + 넓은 char run 셀 문단 (리뷰어 시나리오).
+        let mut cell_para = Paragraph::default();
+        cell_para.text = "가나다라마바사아".to_string();
+        let n = cell_para.text.chars().count() as u32;
+        // 그림 2개(8×2 code unit)가 텍스트 앞에 배치된 오프셋 구조.
+        cell_para.char_offsets = (0..n).map(|i| 16 + i).collect();
+        cell_para.char_count = n + 16 + 1;
+        cell_para.char_shapes = vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 0,
+        }];
+        cell_para.line_segs = vec![LineSeg {
+            text_start: 0,
+            line_height: 800,
+            baseline_distance: 640,
+            ..Default::default()
+        }];
+        let mut pic = Picture::default();
+        pic.common.width = 1000;
+        pic.common.height = 1000; // 남은 그림 height>0 → branch 1 (높이 조정만)
+        cell_para
+            .controls
+            .push(Control::Picture(Box::new(pic.clone())));
+        cell_para.controls.push(Control::Picture(Box::new(pic)));
+        cell_para.ctrl_data_records = vec![None, None];
+
+        // 렌더 1회로 설정된 판정을 모사 — 삭제 후 fresh 실측과 모순일 수 있는
+        // stale verdict.
+        let stale_key = SingleLineOverflowMemo::width_key(321.0);
+        cell_para.single_line_overflow_memo.set(stale_key, false);
+
+        let table = Table {
+            cells: vec![Cell {
+                width: 8000,
+                paragraphs: vec![cell_para],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        core.document.sections[0].paragraphs[0]
+            .controls
+            .push(Control::Table(Box::new(table)));
+        let ctrl_idx = core.document.sections[0].paragraphs[0].controls.len() - 1;
+
+        let path_json = format!(
+            r#"[{{"controlIdx":{},"cellIdx":0,"cellParaIdx":0}}]"#,
+            ctrl_idx
+        );
+        core.delete_cell_picture_control_by_path_native(0, 0, &path_json, 0)
+            .expect("셀 그림 삭제");
+
+        let Control::Table(t) = &core.document.sections[0].paragraphs[0].controls[ctrl_idx] else {
+            panic!("expected table");
+        };
+        let para = &t.cells[0].paragraphs[0];
+        assert_eq!(para.controls.len(), 1, "그림 1개가 삭제돼야 함");
+        assert!(
+            para.single_line_overflow_memo.get(stale_key).is_none(),
+            "인라인 그림 삭제 후 stale verdict 가 남으면 재래핑 억제 → 과폭 절단 렌더"
+        );
+        assert!(
+            para.single_line_overflow_memo.is_unjudged(),
+            "삭제 직후 memo 는 미판정 상태여야 함 (다음 렌더에서 fresh 재판정)"
+        );
+    }
 }

--- a/src/document_core/queries/field_query.rs
+++ b/src/document_core/queries/field_query.rs
@@ -1421,6 +1421,9 @@ fn remove_field_in_para(para: &mut Paragraph, char_offset: usize) -> Result<(), 
 /// 원본 char_offsets에서 컨트롤 배치 패턴을 보존하면서,
 /// 텍스트 길이 변경(필드 값 삽입)에 맞게 오프셋을 재계산한다.
 pub(crate) fn rebuild_char_offsets(para: &mut Paragraph) {
+    // [#4149] 호출부는 방금 text/controls 수술을 마친 상태다 (필드 제거·필드값
+    // 기입·클립보드 트림 등, 셀 문단 포함) — 단일줄 과밀 memo 무효화의 수렴점.
+    para.invalidate_single_line_overflow_memo();
     let text_chars: Vec<char> = para.text.chars().collect();
     let text_len = text_chars.len();
 

--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -56,6 +56,80 @@ pub struct Paragraph {
     /// None = 앞 번호 목록에 이어 (기본)
     /// Some(NumberingRestart) = 이전 번호 이어 / 새 번호 시작
     pub numbering_restart: Option<NumberingRestart>,
+    /// [#4149] 셀 단일줄 과밀 판정 memo — `recompose_stored_single_line_if_overflowing`
+    /// 전용 파생 캐시. 판정 입력은 (text, char_shapes, 셀 내폭)뿐이다. 제약:
+    /// - 직렬화 금지: `Paragraph` 는 serde derive 가 없고 HWP/HWPX 저장기는 필드를
+    ///   명시 기록하므로 파일로 새지 않는다. 새 직렬화 경로를 추가하면 이 필드를 제외할 것.
+    /// - 스레드: `DocumentCore` 의 `Send` 단언이 `Arc<Vec<Paragraph>>`
+    ///   (document_core/mod.rs render normalization 캐시) 경유로 `Paragraph: Sync` 를
+    ///   요구한다 — `Cell` 불가, `AtomicU64` 패킹 사용.
+    /// - text/char_shapes 를 바꾸는 모든 경로는 `invalidate_single_line_overflow_memo`
+    ///   호출 필수 (Clone 은 memo 를 함께 복제하지만, 복제본도 자기 상태 기준으로
+    ///   유효하므로 안전 — 이후 변이 시 무효화 규약은 동일하게 적용).
+    pub single_line_overflow_memo: SingleLineOverflowMemo,
+}
+
+/// [#4149] 단일줄 과밀 판정 memo 저장소 — `AtomicU64` 1개에 (폭 키, 판정) 패킹.
+///
+/// 인코딩: `0` = 미판정. 그 외 `(width_key as u64) << 1 | overflowed`.
+/// `width_key` 는 셀 내폭의 `f32` 비트 — guard 가 내폭 > 0 을 보장하므로 키가 0 이
+/// 될 수 없어 유효 인코딩은 sentinel `0` 과 충돌하지 않는다. 폭이 바뀌면(셀 크기
+/// 조정) 키 불일치로 자연 재판정된다. f32 축약의 키 충돌은 인접 ulp 폭(상대 ~2⁻²⁴)
+/// 뿐이라 ×1.8 임계 판정에 영향이 없다.
+///
+/// `Relaxed` 순서로 충분하다 — 값은 (문단, 폭)의 결정적 함수라 경합 시 최악이
+/// 중복 측정일 뿐 오답이 없다.
+#[derive(Debug, Default)]
+pub struct SingleLineOverflowMemo(std::sync::atomic::AtomicU64);
+
+impl SingleLineOverflowMemo {
+    /// 셀 내폭(px) → memo 폭 키.
+    #[inline]
+    pub fn width_key(cell_inner_width_px: f64) -> u32 {
+        (cell_inner_width_px as f32).to_bits()
+    }
+
+    /// 저장된 판정 조회 — 폭 키가 일치할 때만 `Some(overflowed)`.
+    #[inline]
+    pub fn get(&self, width_key: u32) -> Option<bool> {
+        let v = self.0.load(std::sync::atomic::Ordering::Relaxed);
+        if v != 0 && (v >> 1) as u32 == width_key {
+            Some(v & 1 == 1)
+        } else {
+            None
+        }
+    }
+
+    /// 판정 저장. `width_key == 0`(내폭 ≤ 0)은 sentinel 과 겹치므로 저장하지 않는다.
+    #[inline]
+    pub fn set(&self, width_key: u32, overflowed: bool) {
+        if width_key == 0 {
+            return;
+        }
+        let v = ((width_key as u64) << 1) | (overflowed as u64);
+        self.0.store(v, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// 미판정 상태로 되돌린다.
+    #[inline]
+    pub fn clear(&self) {
+        self.0.store(0, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// 미판정 여부 (invalidation 검증용).
+    #[inline]
+    pub fn is_unjudged(&self) -> bool {
+        self.0.load(std::sync::atomic::Ordering::Relaxed) == 0
+    }
+}
+
+impl Clone for SingleLineOverflowMemo {
+    fn clone(&self) -> Self {
+        // 파생 캐시 복제 — 복제본도 자기 (text, char_shapes) 기준으로 유효하다.
+        Self(std::sync::atomic::AtomicU64::new(
+            self.0.load(std::sync::atomic::Ordering::Relaxed),
+        ))
+    }
 }
 
 /// 문단 스코프 메타데이터 — 문단 병합의 역연산(undo)에서 복원해야 하는 값들.
@@ -497,6 +571,12 @@ impl Paragraph {
         }
     }
 
+    /// [#4149] 단일줄 과밀 판정 memo 무효화 — text/char_shapes 를 바꾸는 경로 필수.
+    #[inline]
+    pub fn invalidate_single_line_overflow_memo(&self) {
+        self.single_line_overflow_memo.clear();
+    }
+
     /// 문자의 UTF-16 코드 유닛 수를 반환한다.
     fn char_utf16_len(c: char) -> u32 {
         if (c as u32) > 0xFFFF {
@@ -519,6 +599,8 @@ impl Paragraph {
         if self.char_offsets.is_empty() {
             return;
         }
+        // [#4149] 인라인 컨트롤 삽입은 char_shapes 경계를 옮긴다 — memo 무효화 (보수적).
+        self.invalidate_single_line_overflow_memo();
         let text_len = self.text.chars().count();
         let safe_offset = char_offset.min(text_len);
         // 컨트롤이 삽입되는 UTF-16 위치 — char_offsets 시프트 전에 계산한다.
@@ -567,6 +649,8 @@ impl Paragraph {
         if new_text.is_empty() {
             return char_offset.min(self.text.chars().count());
         }
+        // [#4149] text 변이 — 단일줄 과밀 memo 무효화.
+        self.invalidate_single_line_overflow_memo();
 
         let text_chars: Vec<char> = self.text.chars().collect();
         let text_len = text_chars.len();
@@ -720,6 +804,9 @@ impl Paragraph {
             return 0;
         }
 
+        // [#4149] text 변이 — 단일줄 과밀 memo 무효화.
+        self.invalidate_single_line_overflow_memo();
+
         // 실제 삭제할 문자 수 (범위 클램핑)
         let actual_count = count.min(text_len - char_offset);
         let del_end = char_offset + actual_count;
@@ -850,6 +937,9 @@ impl Paragraph {
     /// 분할의 시맨틱이다. 병합의 역연산으로 쓰는 호출부는 `apply_meta` 로 사라진
     /// 문단의 원래 값을 되돌려야 한다 (Task #2342).
     pub fn split_at(&mut self, char_offset: usize) -> Paragraph {
+        // [#4149] 분할은 양쪽 text 를 모두 바꾼다 — 앞 절반 memo 무효화.
+        // 새 절반은 아래 구성에서 미판정(None)으로 시작한다.
+        self.invalidate_single_line_overflow_memo();
         let control_positions = self.split_logical_control_positions();
         let split_pos = self.split_text_pos_for_logical_offset(char_offset, &control_positions);
         let text_chars: Vec<char> = self.text.chars().collect();
@@ -1101,6 +1191,8 @@ impl Paragraph {
             has_para_text: new_has_para_text,
             tab_extended: Vec::new(),
             numbering_restart: None,
+            // [#4149] 분할 산출 문단은 미판정으로 시작한다.
+            single_line_overflow_memo: SingleLineOverflowMemo::default(),
         }
     }
 
@@ -1113,6 +1205,8 @@ impl Paragraph {
         if other.text.is_empty() && other.controls.is_empty() {
             return self.text.chars().count();
         }
+        // [#4149] 병합은 text/char_shapes 를 바꾼다 — memo 무효화 (미판정 재시작).
+        self.invalidate_single_line_overflow_memo();
 
         let self_text_len = self.text.chars().count();
 
@@ -1451,6 +1545,8 @@ impl Paragraph {
         if start_char_offset >= end_char_offset || self.char_offsets.is_empty() {
             return;
         }
+        // [#4149] char_shapes 변이 — 단일줄 과밀 memo 무효화.
+        self.invalidate_single_line_overflow_memo();
         if self.char_shapes.is_empty() {
             self.char_shapes.push(CharShapeRef {
                 start_pos: 0,
@@ -1574,6 +1670,8 @@ impl Paragraph {
 
     /// 문단의 글자 모양을 단일 CharShapeRef로 초기화한다.
     pub fn set_single_char_shape(&mut self, char_shape_id: u32) {
+        // [#4149] char_shapes 변이 — 단일줄 과밀 memo 무효화.
+        self.invalidate_single_line_overflow_memo();
         self.char_shapes.clear();
         self.char_shapes.push(CharShapeRef {
             start_pos: 0,
@@ -1601,6 +1699,8 @@ impl Paragraph {
         }
 
         if replaced {
+            // [#4149] char_shapes 변이 — 단일줄 과밀 memo 무효화.
+            self.invalidate_single_line_overflow_memo();
             self.merge_adjacent_char_shapes();
         }
     }

--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -9,7 +9,7 @@ use super::style_resolver::{detect_lang_category, ResolvedStyleSet};
 use super::{px_to_hwpunit, TextStyle};
 use crate::model::control::Control;
 use crate::model::document::Section;
-use crate::model::paragraph::{CharShapeRef, LineSeg, Paragraph};
+use crate::model::paragraph::{CharShapeRef, LineSeg, Paragraph, SingleLineOverflowMemo};
 
 /// 글자겹침(CharOverlap) 렌더링 정보
 #[derive(Debug, Clone, serde::Serialize)]
@@ -1528,11 +1528,28 @@ pub fn recompose_stored_single_line_if_overflowing(
     // `stored_lines_overflow`(#2525)와 동일하게 ×1.8 로 좁혀 정당한 장평/자간·
     // 패딩 발산 범위(≤~1.5×)를 넘는 부실 저장만 재래핑한다. #2291 원 타깃
     // (76자 1-lineseg = ~7.6× 초과, 절단 해소)은 임계 위라 계속 재래핑.
-    let over = composed
-        .lines
-        .first()
-        .map(|l| estimate_composed_line_width(l, styles) > cell_inner_width_px * 1.8)
-        .unwrap_or(false);
+    //
+    // [#4149] 판정 memo — 같은 (문단 text·char_shapes, 셀 내폭)이면 판정이 결정적
+    // 인데, 페이지 트리 재빌드마다 estimate_composed_line_width 재측정이 반복돼
+    // 거대 셀 문서의 캐럿 rect 질의당 ~30% 를 차지했다. 폭 키(f32 bits 패킹)로
+    // 판정만 memo 하고(측정 생략), over=true 의 fresh 재래핑 자체는 매 빌드 그대로
+    // 수행한다 — 재래핑 결과는 composed 에만 반영되고 저장 line_segs 는 안 바뀌므로
+    // 재래핑을 생략하면 절단 렌더 회귀. text/char_shapes 변경 경로는
+    // `invalidate_single_line_overflow_memo` 로 비운다 (셀 크기 조정은 키 불일치로
+    // 자연 재판정).
+    let width_key = SingleLineOverflowMemo::width_key(cell_inner_width_px);
+    let over = match para.single_line_overflow_memo.get(width_key) {
+        Some(memoized) => memoized,
+        None => {
+            let measured = composed
+                .lines
+                .first()
+                .map(|l| estimate_composed_line_width(l, styles) > cell_inner_width_px * 1.8)
+                .unwrap_or(false);
+            para.single_line_overflow_memo.set(width_key, measured);
+            measured
+        }
+    };
     if std::env::var("RHWP_DIAG_CELLREWRAP").is_ok() && over {
         if let Some(l) = composed.lines.first() {
             for run in &l.runs {

--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -1093,6 +1093,9 @@ pub(crate) fn reflow_line_segs(
     styles: &ResolvedStyleSet,
     dpi: f64,
 ) {
+    // [#4149] 셀 편집의 단일 관문(reflow_cell_paragraph[_by_path])과 서식 적용
+    // (formatting.rs) 이 모두 여기로 수렴한다 — 단일줄 과밀 memo 무효화.
+    para.invalidate_single_line_overflow_memo();
     // 기존 LineSeg에서 dimension 값 보존 (원본 HWP 호환성 유지)
     let seg_width_hwp = px_to_hwpunit(available_width_px, dpi);
     let orig = para.line_segs.first().cloned();

--- a/src/renderer/composer/tests.rs
+++ b/src/renderer/composer/tests.rs
@@ -1388,3 +1388,198 @@ fn test_kbu1_line_start_forbidden_retraction() {
         "retraction 후 char_start 는 '다' 위치"
     );
 }
+
+// ───────────────────── [#4149] 셀 단일줄 과밀 판정 memo ─────────────────────
+
+/// 가드 전제(저장 단일 lineseg, 비합성 tag)를 만족하는 문단.
+fn issue4149_guard_para(text: &str) -> Paragraph {
+    let n = text.chars().count();
+    Paragraph {
+        text: text.to_string(),
+        char_offsets: (0..n as u32).collect(),
+        char_count: n as u32 + 1,
+        char_shapes: vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 0,
+        }],
+        // 저장 단일 lineseg (tag=0 → TAG_IMPLEMENTATION_PROPERTY 미설정 = 비합성).
+        line_segs: vec![LineSeg {
+            text_start: 0,
+            line_height: 800,
+            baseline_distance: 640,
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+/// 첫 판정이 memo 되고, memo hit 에도 over=true 의 fresh 재래핑은 매 빌드 수행된다 —
+/// 재래핑 결과는 composed 에만 반영되고 저장 line_segs 는 안 바뀌므로 생략하면
+/// 절단 렌더 회귀(#2291).
+#[test]
+fn issue4149_overflow_judgment_memoized_and_rewrap_still_runs_on_hit() {
+    let styles = crate::renderer::style_resolver::ResolvedStyleSet::default();
+    let para = issue4149_guard_para(&"가".repeat(60));
+    let width = 50.0; // 60자 실폭 ≫ 50×1.8
+    let key = crate::model::paragraph::SingleLineOverflowMemo::width_key(width);
+    assert!(para.single_line_overflow_memo.is_unjudged());
+
+    let mut composed = compose_paragraph(&para);
+    assert_eq!(composed.lines.len(), 1);
+    recompose_stored_single_line_if_overflowing(&mut composed, &para, width, &styles);
+    assert!(
+        composed.lines.len() > 1,
+        "과밀 저장 단일줄은 fresh 재래핑돼야 함"
+    );
+    assert_eq!(
+        para.single_line_overflow_memo.get(key),
+        Some(true),
+        "판정이 (폭 키, over) 로 memo 돼야 함"
+    );
+
+    // 두 번째 페이지 빌드 (memo hit): 측정 생략, 재래핑은 수행.
+    let mut composed2 = compose_paragraph(&para);
+    assert_eq!(composed2.lines.len(), 1);
+    recompose_stored_single_line_if_overflowing(&mut composed2, &para, width, &styles);
+    assert!(
+        composed2.lines.len() > 1,
+        "memo hit 에도 재래핑은 수행돼야 함 (절단 렌더 회귀 방지)"
+    );
+}
+
+/// memo hit 시 실폭 측정(estimate_composed_line_width)이 생략됨을 모순 memo 로
+/// 증명한다 — 실측이면 over=true 로 재래핑될 문단에 over=false memo 를 주입했을 때
+/// 재래핑이 일어나지 않으면 측정이 생략된 것이다 (= 같은 문단 2회 판정에 측정 1회).
+#[test]
+fn issue4149_memo_hit_skips_width_measurement() {
+    let styles = crate::renderer::style_resolver::ResolvedStyleSet::default();
+    let para = issue4149_guard_para(&"가".repeat(60));
+    let width = 50.0;
+    let key = crate::model::paragraph::SingleLineOverflowMemo::width_key(width);
+    para.single_line_overflow_memo.set(key, false); // 실측(true)과 모순인 memo
+
+    let mut composed = compose_paragraph(&para);
+    recompose_stored_single_line_if_overflowing(&mut composed, &para, width, &styles);
+    assert_eq!(
+        composed.lines.len(),
+        1,
+        "memo hit 시 재측정 없이 판정을 재사용해야 함"
+    );
+    assert_eq!(
+        para.single_line_overflow_memo.get(key),
+        Some(false),
+        "hit 경로는 memo 를 덮어쓰지 않아야 함"
+    );
+}
+
+/// 폭이 바뀌면(셀 크기 조정) 키 불일치로 자연 재판정된다.
+#[test]
+fn issue4149_width_change_re_judges_via_key_mismatch() {
+    let styles = crate::renderer::style_resolver::ResolvedStyleSet::default();
+    let para = issue4149_guard_para(&"가".repeat(60));
+    let narrow = 50.0;
+    // 넓은 폭에서의 기존 판정(over=false)이 남아 있는 상태.
+    para.single_line_overflow_memo.set(
+        crate::model::paragraph::SingleLineOverflowMemo::width_key(5000.0),
+        false,
+    );
+
+    let mut composed = compose_paragraph(&para);
+    recompose_stored_single_line_if_overflowing(&mut composed, &para, narrow, &styles);
+    assert!(
+        composed.lines.len() > 1,
+        "폭 키 불일치 시 재측정으로 과밀을 다시 잡아야 함"
+    );
+    assert_eq!(
+        para.single_line_overflow_memo.get(
+            crate::model::paragraph::SingleLineOverflowMemo::width_key(narrow)
+        ),
+        Some(true)
+    );
+}
+
+/// 정합(비과밀) 판정도 memo 되고 재래핑은 일어나지 않는다.
+#[test]
+fn issue4149_fit_judgment_memoized_false_without_rewrap() {
+    let styles = crate::renderer::style_resolver::ResolvedStyleSet::default();
+    let para = issue4149_guard_para("가나다");
+    let width = 5000.0;
+    let mut composed = compose_paragraph(&para);
+    recompose_stored_single_line_if_overflowing(&mut composed, &para, width, &styles);
+    assert_eq!(
+        composed.lines.len(),
+        1,
+        "정합 단일줄은 재래핑하지 않아야 함"
+    );
+    assert_eq!(
+        para.single_line_overflow_memo.get(
+            crate::model::paragraph::SingleLineOverflowMemo::width_key(width)
+        ),
+        Some(false)
+    );
+}
+
+/// text/char_shapes 를 바꾸는 모든 경로에서 memo 가 미판정으로 돌아간다.
+/// (셀 편집의 단일 관문 reflow_cell_paragraph[_by_path]는 reflow_line_segs 로
+/// 수렴한다 — document_core 관문 자체는 text_editing.rs 테스트에서 검증.)
+#[test]
+fn issue4149_memo_invalidated_by_mutation_paths() {
+    let styles = crate::renderer::style_resolver::ResolvedStyleSet::default();
+    let key = crate::model::paragraph::SingleLineOverflowMemo::width_key(500.0);
+    let prime = |p: &Paragraph| p.single_line_overflow_memo.set(key, true);
+    let mut para = issue4149_guard_para("가나다라마");
+
+    prime(&para);
+    para.insert_text_at(1, "X");
+    assert!(
+        para.single_line_overflow_memo.is_unjudged(),
+        "insert_text_at 후 미판정"
+    );
+
+    prime(&para);
+    para.delete_text_at(0, 1);
+    assert!(
+        para.single_line_overflow_memo.is_unjudged(),
+        "delete_text_at 후 미판정"
+    );
+
+    prime(&para);
+    para.apply_char_shape_range(0, 2, 7);
+    assert!(
+        para.single_line_overflow_memo.is_unjudged(),
+        "apply_char_shape_range 후 미판정"
+    );
+
+    prime(&para);
+    para.set_single_char_shape(0);
+    assert!(
+        para.single_line_overflow_memo.is_unjudged(),
+        "set_single_char_shape 후 미판정"
+    );
+
+    prime(&para);
+    reflow_line_segs(&mut para, 300.0, &styles, 96.0);
+    assert!(
+        para.single_line_overflow_memo.is_unjudged(),
+        "reflow_line_segs(셀 편집 관문의 수렴점) 후 미판정"
+    );
+
+    prime(&para);
+    let new_half = para.split_at(2);
+    assert!(
+        para.single_line_overflow_memo.is_unjudged(),
+        "split_at 앞 절반 미판정"
+    );
+    assert!(
+        new_half.single_line_overflow_memo.is_unjudged(),
+        "split_at 산출 문단은 미판정으로 시작"
+    );
+
+    prime(&para);
+    let other = issue4149_guard_para("바사");
+    para.merge_from(&other);
+    assert!(
+        para.single_line_overflow_memo.is_unjudged(),
+        "merge_from 후 미판정"
+    );
+}

--- a/src/renderer/font_metrics_data.rs
+++ b/src/renderer/font_metrics_data.rs
@@ -3,6 +3,9 @@
 //! font-metric-gen 도구로 TTF 파일에서 추출.
 //! 수동 편집 금지.
 
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
 #[derive(Debug)]
 pub struct HangulMetric {
     pub cho_groups: u8,
@@ -155,7 +158,79 @@ fn resolve_metric_alias(name: &str) -> &str {
     }
 }
 
+/// (bold, italic) → 색인 슬롯 번호. 조합이 4개뿐이라 이름당 배열로 선계산한다.
+fn metric_slot_index(bold: bool, italic: bool) -> usize {
+    ((bold as usize) << 1) | (italic as usize)
+}
+
+/// 이름별 선계산 색인 — 슬롯 값은 (metric, bold_fallback).
+///
+/// [#4149] 글자 측정마다 find_metric 이 호출되어 600 엔트리 선형 스캔
+/// (문자열 비교 × 최대 3단 폴백)이 캐럿 rect 질의 지연의 주요 원인이었다.
+/// 이름이 테이블에 있으면 3단(이름만 매칭)이 항상 성공하므로 슬롯에 Option 이
+/// 필요 없고, 조회 실패 = 이름 부재 = 기존 None 과 동일하다.
+///
+/// 키를 (name, bold, italic) 튜플 대신 이름 단독으로 두는 이유: 튜플 키는
+/// &'static str 수명 때문에 임의 사용자 폰트명(&str)으로 borrow 조회가 불가능하다.
+static METRIC_INDEX: OnceLock<HashMap<&'static str, [(&'static FontMetric, bool); 4]>> =
+    OnceLock::new();
+
+fn metric_index() -> &'static HashMap<&'static str, [(&'static FontMetric, bool); 4]> {
+    METRIC_INDEX.get_or_init(|| {
+        // 선형 스캔의 "테이블 첫 매칭 우선" 계약 재현: 테이블 순서대로 순회하며
+        // (name, bold, italic) 조합별 첫 엔트리와 이름 첫 등장 엔트리만 기록한다.
+        struct FirstSeen {
+            exact: [Option<&'static FontMetric>; 4],
+            first: &'static FontMetric,
+        }
+        let mut seen: HashMap<&'static str, FirstSeen> = HashMap::new();
+        for m in FONT_METRICS.iter() {
+            let entry = seen.entry(m.name).or_insert(FirstSeen {
+                exact: [None; 4],
+                first: m,
+            });
+            let idx = metric_slot_index(m.bold, m.italic);
+            if entry.exact[idx].is_none() {
+                entry.exact[idx] = Some(m);
+            }
+        }
+        // 슬롯 선주입 순서 = legacy 폴백 사다리와 동일:
+        // 1단 정확 매칭 → 2단 bold 매칭(italic 무시) → 3단 이름만 첫 엔트리.
+        seen.into_iter()
+            .map(|(name, fs)| {
+                let mut slots = [(fs.first, false); 4];
+                for bold in [false, true] {
+                    for italic in [false, true] {
+                        slots[metric_slot_index(bold, italic)] =
+                            if let Some(m) = fs.exact[metric_slot_index(bold, italic)] {
+                                (m, false)
+                            } else if let Some(m) = fs.exact[metric_slot_index(bold, false)] {
+                                (m, false)
+                            } else {
+                                // bold 요청이었으면 Faux Bold 보정 표시 (legacy 3단과 동일)
+                                (fs.first, bold)
+                            };
+                    }
+                }
+                (name, slots)
+            })
+            .collect()
+    })
+}
+
 pub fn find_metric(name: &str, bold: bool, italic: bool) -> Option<MetricMatch> {
+    let name = resolve_metric_alias(name);
+    let slots = metric_index().get(name)?;
+    let (metric, bold_fallback) = slots[metric_slot_index(bold, italic)];
+    Some(MetricMatch {
+        metric,
+        bold_fallback,
+    })
+}
+
+/// 기존 선형 스캔 구현 — 색인 등가성 검증 전용으로 보존 (수정 금지).
+#[cfg(test)]
+fn legacy_find_metric(name: &str, bold: bool, italic: bool) -> Option<MetricMatch> {
     let name = resolve_metric_alias(name);
     // 정확한 매칭 (name + bold + italic)
     if let Some(m) = FONT_METRICS
@@ -46229,5 +46304,125 @@ mod tests {
         let m = find_metric("함초롬바탕", false, false);
         assert!(m.is_some(), "함초롬바탕 기존 매핑 회귀");
         assert_eq!(m.unwrap().metric.name, "HCR Batang");
+    }
+
+    #[test]
+    fn index_matches_legacy_linear_scan_exhaustively() {
+        // [#4149] O(1) 색인 도입 계약: legacy 선형 스캔(3단 폴백 사다리)과
+        // 결과가 100% 동일해야 한다. FONT_METRICS 전체 name + 알려진 alias
+        // 전체 + 테이블에 없는 임의 이름 × (bold, italic) 4조합 전수 비교.
+        let mut names: Vec<&str> = FONT_METRICS.iter().map(|m| m.name).collect();
+        // resolve_metric_alias 좌변 전체 (별칭 추가 시 여기도 갱신).
+        names.extend([
+            "함초롬돋움",
+            "한컴돋움",
+            "돋움",
+            "함초롬바탕",
+            "한컴바탕",
+            "바탕",
+            "맑은 고딕",
+            "나눔고딕",
+            "나눔명조",
+            "바탕체",
+            "굴림",
+            "궁서",
+            "굴림체",
+            "돋움체",
+            "궁서체",
+            "D2Coding",
+            "D2 Coding",
+            "고운바탕",
+            "Gowun Batang",
+            "고운돋움",
+            "Gowun Dodum",
+            "Pretendard",
+            "프리텐다드",
+            "HY중고딕",
+            "HY견고딕",
+            "HY헤드라인M",
+            "HY견명조",
+            "HY신명조",
+            "HY그래픽",
+            "HY궁서",
+            "한양신명조",
+            "한양중고딕",
+            "한양견명조",
+            "한양견고딕",
+            "휴먼명조",
+            "신명조",
+            "HY수평선B",
+            "HY수평선M",
+            "HY울릉도B",
+            "HY울릉도M",
+            "HY태백B",
+            "HY동녘B",
+            "HY동녘M",
+            "HY각헤드라인M",
+            "본한글",
+            "본한글vf",
+            "본한글 Medium",
+            "본한글M",
+            "본고딕",
+            "본고딕vf",
+            "Source Han Sans",
+            "Source Han Sans K",
+            "Source Han Sans KR",
+            "SourceHanSans",
+            "SourceHanSansKR",
+            "SourceHanSansK",
+            "Noto Sans CJK KR",
+            "본명조",
+            "본명조vf",
+            "본명조M",
+            "Source Han Serif",
+            "Source Han Serif K",
+            "Source Han Serif KR",
+            "SourceHanSerif",
+            "SourceHanSerifKR",
+            "SourceHanSerifK",
+            "Noto Serif CJK KR",
+        ]);
+        // 테이블에 없는 임의 사용자 폰트명 — 기존과 동일하게 None 이어야 한다.
+        names.extend([
+            "NoSuchFont-Regular",
+            "가상의사용자폰트",
+            "Comic Sans MS",
+            "",
+        ]);
+
+        for name in names {
+            for bold in [false, true] {
+                for italic in [false, true] {
+                    let new = find_metric(name, bold, italic);
+                    let old = legacy_find_metric(name, bold, italic);
+                    match (new, old) {
+                        (None, None) => {}
+                        (Some(n), Some(o)) => {
+                            assert!(
+                                std::ptr::eq(n.metric, o.metric),
+                                "metric 불일치: {name:?} bold={bold} italic={italic} \
+                                 (new={}/b{}/i{}, old={}/b{}/i{})",
+                                n.metric.name,
+                                n.metric.bold,
+                                n.metric.italic,
+                                o.metric.name,
+                                o.metric.bold,
+                                o.metric.italic,
+                            );
+                            assert_eq!(
+                                n.bold_fallback, o.bold_fallback,
+                                "bold_fallback 불일치: {name:?} bold={bold} italic={italic}"
+                            );
+                        }
+                        (n, o) => panic!(
+                            "Some/None 불일치: {name:?} bold={bold} italic={italic} \
+                             new={} old={}",
+                            n.is_some(),
+                            o.is_some()
+                        ),
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
`recompose_stored_single_line_if_overflowing` 가드는 페이지 빌드마다 셀의 모든 저장 단일줄 문단 실폭을 재측정한다(#4167 프로파일 ~30%). 판정 입력(텍스트·char_shapes·셀 내폭)이 불변이면 결과도 불변이므로 `Paragraph` 에 `AtomicU64` memo((f32 폭 bits<<1)|overflowed)를 두고 측정만 생략한다 — overflowed 문단의 fresh 재래핑은 매 빌드 유지(절단 렌더 #4138 계열 방어 불변). Sync 요구(`Arc<Vec<Paragraph>>` 경유 Send 단언)로 Cell 불가 — Atomic 선택.

무효화는 텍스트/char_shapes 변이 전 경로 전수 배선: 모델 프리미티브 8곳 + `reflow_line_segs` 수렴점 + 직접 대입 우회 5곳(셀 인라인 컨트롤 삭제 가족·빈 필드 제거·클립보드 구조 제거·표 계산식·필드 안내문 수술). 셀 그림 삭제 경로는 적대 리뷰가 실명령 재현으로 확정한 무효화 누락(stale verdict → 과폭 절단 렌더)의 수정이다. 실측: `build_page_tree` 17.6ms → 13.7ms (#4246 위 누적). 가드 회귀 핀(#2287/2430/2525/2527/4138) 전부 통과. 기록: `mydocs/plans/task_m100_4169.md`, `mydocs/working/task_m100_4169_stage1.md`.

**시리즈 2/4**: #4246 → 본 PR → #4167 Stage 1 → Stage 2. 본 레이어 고유 diff: [task_m100_4168...task_m100_4169 비교](https://github.com/humdrum00001010/rhwp/compare/task_m100_4168_font_metric_index...task_m100_4169_overflow_memo) — #4246 merge 후 자동 축소.

Closes #4169

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---
**재검증 (2026-08-08)**: 전 레이어를 최신 `devel`(e64c853) 위로 rebase 후 ci.yml 전 단계를 로컬 완주 — fmt / scripts-tests 6종 / clippy / `cargo build --workspace` + workspace all-targets clippy / wasm32 check / **`cargo nextest run --cargo-profile release-test`** (스택 상단 5,345/5,345 pass) / Native Skia 3종 / wasm-pack dev + binding tests / tsc ci-unit / studio suite(802/802) — 6개 레이어 전부 ALL-PASS. 종전 Lint 실패 원인(workspace all-targets clippy 미실행으로 놓친 테스트 코드 1건)은 수정 완료. nextest 프로세스 격리 하에서 #4181 fixture 는 전 레이어 무재시도 안정.
