### PR TITLE
core: 셀 캐럿 rect 를 페이지 트리 재빌드 없이 계산하는 fast path

### DIFF
--- a/mydocs/plans/task_m100_4167.md
+++ b/mydocs/plans/task_m100_4167.md
@@ -1,0 +1,63 @@
+# 수행계획 — task_m100_4167
+
+- **이슈**: [#4167](https://github.com/edwardkim/rhwp/issues/4167)
+- **브랜치**: Stage 1 `task_m100_4167_cursor_rect_fast_path`, Stage 2 `task_m100_4167_units_fp_skip`
+  (stack: `task_m100_4169_overflow_memo` 위)
+- **기준**: `upstream/devel` `5a4f26d0d`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+거대 셀 문서(`samples/issue1949_giant_cell_nested_tables_perf.hwp`) IME 타이핑의 캐럿 rect
+질의 60ms/키를 제거한다. 실측 원인 2계층:
+
+- **Stage 1**: `get_cursor_rect_in_cell_native`가 rect 하나를 얻으려고 uncached
+  `build_page_tree`로 페이지 렌더 트리 전체를 재빌드 — 질의의 98%, 그중 99.7%가
+  `layout_partial_table_cells` 전체 셀 재레이아웃.
+- **Stage 2**: deferred 편집마다 편집 셀의 memoized `cell_units`가 전량 evict 되어, 편집 직후
+  첫 질의가 2,507개 문단 전량 recompose(native 11.2ms)를 지불 — IME 조합은 매 업데이트가
+  편집→질의라 매 키가 이 비용을 문다.
+
+## 2. 변경 경계
+
+- **Stage 1 fast path 는 legacy 와 rect JSON 패리티가 계약** — 독립 산식 재구현이 아니라
+  production `layout_partial_table`를 대상 셀만 방출하는 프로브로 재사용해 패리티를 구성적으로
+  보장한다. 저장 line_segs 는 신뢰하지 않는다(무편집 문단의 ~16%가 재계산과 다름 — #4149 실측);
+  렌더러가 그리는 composed 줄을 lazy 로 대상 창 문단에만 적용한다.
+- 불확실 케이스 전부 폴백(Ok(None) → 기존 경로): 캡션 센티널·다중 컬럼·zone/wrap/미주·통페이지
+  표·treat_as_char·반복 제목행·auto counter 개체·rowspan>1·windowed 증명 실패·run 미발견.
+  fast path 는 탈출구 있는 최적화지 제2의 진실원천이 아니다.
+- **Stage 2 는 units 지문(units 산출이 읽는 입력만: 줄 수·vpos·높이·synthetic tag 비트·
+  controls 수·공백 클래스)이 불변일 때만 eviction 을 생략** — 지문이 변하는 편집(재래핑·스페이서
+  클래스 전이)은 종전대로 evict. `text_start`/`segment_width`는 제자리 타이핑에도 변하지만
+  units 산출이 읽지 않으므로 제외(코드 전수 grep 근거).
+- 기존 #2214/#2424 국소 무효화 인프라의 계약 변경은 "무조건 evict → 지문 변화 시에만 evict"로
+  한정하고 갱신 이력을 테스트 주석에 남긴다.
+
+## 3. 구현·래칫 순서 (Stage 1)
+
+1. 기존 본문을 `cursor_rect_in_cell_via_page_tree`로 추출(패리티 기준), fast→legacy 폴백 래퍼.
+2. 셀 기하: pagination `PartialTable` 메타 + memoized `cell_units` + `measured_tables` +
+   `PageContent.layout` col_area — 페이지 트리 없이.
+3. 프로브: `layout_partial_table`에 대상 셀 필터·컷 창 순회·캐럿 문단 이후 중단 파라미터.
+   셀 방출 루프의 셀-간 캐리 부재(기존 계약)로 생략이 좌표를 바꾸지 않는다.
+4. 차등 패리티 테스트: 3개 실문서 × 전 셀 × 문단축 × offset {0, len/2, len}, fast=Some 인
+   모든 지점에서 legacy JSON 완전 일치 + 거대 문서 적중률 100% 어서션.
+
+## 3'. 구현·래칫 순서 (Stage 2)
+
+1. `cell_paragraph_units_fingerprint` — units 입력만 해시.
+2. 편집 관문 2곳(셀 insert/replace·delete impl)에서 reflow 전후 지문 캡처,
+   `invalidate_cell_units_after_text_edit`에 불변 플래그 전달, 불변이면 eviction 생략.
+3. 회귀: 지문 민감도 매트릭스(불변: text_start/segment_width/원본 tag 잔여 비트, 변화: 줄 수·
+   높이·synthetic·스페이서 클래스), 실문서 계약(텍스트 문단 타이핑 불변·스페이서 전이 변화),
+   #2214 기대값을 지문 조건부로 갱신(이력 주석).
+
+## 4. 검증 게이트
+
+- 패리티 차등 테스트 + `--lib cursor_rect` + 캐럿 관련 통합 테스트 전부
+- `--lib` 전체 무회귀 / fmt / clippy / wasm32 check / Native Skia 3종 / wasm-pack build
+- 실측: Stage 1 후 캐럿 질의 17.5ms → 0.61ms (quiescent), Stage 2 후 deferred 편집 직후
+  find_pages 11.2ms → ~6µs; 브라우저 IME 조합 업데이트 58~62ms → 5.8~11.5ms
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/plans/task_m100_4168.md
+++ b/mydocs/plans/task_m100_4168.md
@@ -1,0 +1,40 @@
+# 수행계획 — task_m100_4168
+
+- **이슈**: [#4168](https://github.com/edwardkim/rhwp/issues/4168)
+- **브랜치**: `task_m100_4168_font_metric_index`
+- **기준**: `upstream/devel` `5a4f26d0d`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+`find_metric`(src/renderer/font_metrics_data.rs)의 폰트 메트릭 테이블 선형 스캔을 1회 선계산
+색인(O(1) 조회)으로 바꾼다. #4167 프로파일에서 거대 셀 문서 IME 키스트로크 60ms 중
+~16%(1,052/6,765 샘플)가 이 함수의 문자열 비교 폴백 사다리에 귀속됐다.
+
+## 2. 변경 경계
+
+- `find_metric`의 **결과는 100% 동일**해야 한다 — 3단 폴백 사다리(정확 매칭 → bold-only →
+  이름 첫 엔트리 + `bold_fallback=bold`)의 첫-매칭 우선순위와 기벽(bold-italic 엔트리만 있는
+  bold 요청의 `bold_fallback=true`)까지 그대로.
+- `resolve_metric_alias` 처리 위치·의미 유지 (#259 alias 매핑 계약).
+- 임의 사용자 폰트명(비-static `&str`) 조회 유지 — 이름 단독 키 + (bold,italic) 4-슬롯
+  배열 선계산으로 `Borrow<str>` 조회를 보존한다 (tuple 키는 수명 제약으로 불가).
+- 다른 파일은 건드리지 않는다.
+
+## 3. 구현·래칫 순서
+
+1. 기존 선형 스캔을 `legacy_find_metric`(cfg(test))으로 원문 보존.
+2. `OnceLock<HashMap<&'static str, [(&'static FontMetric, bool); 4]>>` 색인 — 테이블 순서
+   1회 순회로 조합별/이름별 첫 엔트리를 기록한 뒤 legacy 사다리 순서로 슬롯을 채운다.
+3. 전수 등가성 테스트: FONT_METRICS 전체 이름 + alias LHS 전체 + 미등록 이름 × 4조합에서
+   metric 포인터 동일성 + `bold_fallback` 일치.
+
+## 4. 검증 게이트
+
+- `cargo test --profile release-test --lib font_metrics` (기존 + 신규 등가성)
+- fmt / clippy / `cargo check --target wasm32-unknown-unknown --lib`
+- `cargo test --profile release-test --tests` 전체 무회귀
+- 실측: `issue4149_adjacent_giant_cell_cursor_rect_latency_decomposition`으로 캐럿 질의
+  before/after (기대 ~17-20% 감소)
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/plans/task_m100_4169.md
+++ b/mydocs/plans/task_m100_4169.md
@@ -1,0 +1,43 @@
+# 수행계획 — task_m100_4169
+
+- **이슈**: [#4169](https://github.com/edwardkim/rhwp/issues/4169)
+- **브랜치**: `task_m100_4169_overflow_memo` (stack: `task_m100_4168_font_metric_index` 위)
+- **기준**: `upstream/devel` `5a4f26d0d`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+`recompose_stored_single_line_if_overflowing`(src/renderer/composer.rs)의 과밀 판정을 문단별로
+메모해, 판정 입력이 안 바뀐 문단의 `estimate_composed_line_width` 재측정을 생략한다. #4167
+프로파일에서 캐럿 질의당 페이지 빌드 비용의 ~30%(1,945/6,765 샘플)가 이 가드의 무변경 재측정
+이었다 — 거대 셀 문서는 셀 문단 대부분이 단일줄이라 사실상 페이지 전 텍스트를 빌드마다 재측정한다.
+
+## 2. 변경 경계
+
+- **무효화 누락 = 가드가 막던 절단 렌더(#4138 계열) 회귀와 동일한 결함** — 텍스트/char_shapes
+  변이 전 경로(프리미티브 우회 직접 대입 포함) 전수 무효화가 계약이다.
+- overflowed=true 문단의 fresh 재래핑 동작은 유지한다(측정만 생략) — 재래핑 생략은 절단 렌더 회귀.
+- `Paragraph`는 Sync 요구(`Arc<Vec<Paragraph>>` 경유 `DocumentCore` Send 단언) — `Cell` 불가,
+  `AtomicU64` 패킹 사용. serde 미보유 확인, `ir_field_sweep` 철저 구조분해에 명시 제외.
+- 파일 저장 포맷에 새지 않는다 (HWP/HWPX 저장기는 필드 명시 기록).
+
+## 3. 구현·래칫 순서
+
+1. `Paragraph.single_line_overflow_memo: AtomicU64` (0=미판정, (f32 폭 bits<<1)|overflowed) +
+   수동 Clone.
+2. 가드에서 memo 히트 시 측정 생략, over 판정은 그대로 소비. 폭 키 불일치·미판정 시 실측 후 기록.
+3. 무효화 전수 배선: 모델 프리미티브 8곳(insert/delete/split/merge/char_shape 계열) +
+   `reflow_line_segs` 수렴점 + 직접 대입 우회(표 계산식, clear_initial_field_texts,
+   `rebuild_char_offsets` 수렴점, 셀 인라인 컨트롤 삭제의 `reflow_paragraph_line_segs_after_control_delete`,
+   클립보드 구조 제거) — 마지막 세 경로는 적대 리뷰 CONFIRMED 결함/동류 누락의 수정이다.
+4. 회귀 테스트: 메모 히트 시 측정 1회 증명, 폭 변경 재판정, over=true 재래핑 유지, 뮤테이션
+   경로별 무효화, 셀 그림 삭제 실명령 재현.
+
+## 4. 검증 게이트
+
+- `cargo test --profile release-test --lib composer` / `--lib issue4149` / `--lib object_ops`
+- 기존 가드 회귀 핀: issue_2287/2430/2525/2527/4138 계열
+- fmt / clippy / wasm32 check / `release-test --tests` 전체
+- 실측: 캐럿 질의 ≈17.2ms → ≈14.3ms (#4168 위 누적)
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/working/task_m100_4167_stage1.md
+++ b/mydocs/working/task_m100_4167_stage1.md
@@ -1,0 +1,48 @@
+---
+kind: working
+status: completed
+issue: 4167
+last_verified: 2026-08-08
+---
+
+# Task #4167 Stage 1 - 셀 캐럿 rect fast path (페이지 트리 미빌드)
+
+## 구현
+
+- `get_cursor_rect_in_cell_native`를 fast→legacy 폴백 래퍼로 재구성, 기존 본문은
+  `cursor_rect_in_cell_via_page_tree`로 추출해 패리티 기준으로 삼았다.
+- fast path 는 "재구현"이 아니라 **생략 프로브** — production `layout_partial_table`를
+  대상 셀 하나만 방출하도록 재사용한다(`PartialTableCellProbe`/`ProbeCutPlan`/
+  `CellComposedStore` lazy compose). 셀 방출 루프는 셀-간 캐리가 없어(코드 명시 계약)
+  생략이 좌표를 바꾸지 않는다 — 패리티가 구성적으로 보장되는 부분을 최대화했다.
+- 셀 bbox/페이지 원점: pagination `PartialTable` 메타(행 범위·유닛 컷) + memoized
+  `cell_units` + `measured_tables` + `PageContent.layout` col_area. 컬럼 선두 아이템 +
+  단일 컬럼 + zone/wrap/미주 부재 게이트로 `y = col_area.y` 확정.
+- 줄 찾기: 저장 line_segs 불신(#4149 — 무편집 ~16% divergence) — production compose 경로
+  그대로(compose→recompose_for_cell_width→overflow 가드)를 컷 창 문단에만 lazy 적용,
+  캐럿 문단 이후 중단(Top 정렬 게이트로 안전).
+- 폴백 12종(캡션 센티널/다중컬럼/zone/wrap/미주/통페이지 표/TAC/반복 제목행/auto counter
+  개체(표 포인터 키 메모)/rowspan>1/windowed 증명 실패/run 미발견) — 전부 legacy 전체 경로로.
+
+## 검증 결과
+
+- 패리티(fast=Some 전 지점 legacy JSON `assert_eq!`): 거대 문서 **185/185 (100%)**,
+  hwp_table_test_saved 40/222, KTX 3/371 (저적중 원인은 컬럼 선두 PartialTable 전용 게이트 —
+  폴백 시 출력은 정의상 legacy 동일).
+- `--lib cursor_rect` 16 passed, 캐럿 전반 84 passed, getCursorRect 사용 통합 테스트 전부
+  (issue_1951/2164/2214/4126/4128/table_vpos_01/850/2069/1071/1308) pass, **전체 lib 3303/0**.
+- 적대 리뷰(별도 세션): ① 캐시 무효화 전수 추적(clear 호출자 2곳 — full paginate·deferred
+  commit) 반박 실패, ② 프로브-전량 동치(셀-간 mutable 필드 한 줄씩 검사 + 줄 경계 ±1 offset
+  11,962지점 차등) 반박 실패, ③ **편집 직후 일관성(최유망 각도)**: legacy 도 같은
+  `self.pagination` stale 메타를 읽는 대칭 구조 — deferred insert 직후 861지점·delete 직후
+  50지점·paginate 후 34지점 전부 일치, ④ 패리티 그리드 구멍 공격(추가 실문서 3종 — 다단+미주
+  0/259 게이트 정상, 보건소 208/286=73% 적중 — 전부 일치), ⑤ 게이트 역손실 +0.6%(노이즈).
+  CONFIRMED 0건.
+- 실측: `get_cursor_rect_in_cell_native` 17.5ms → **0.61ms** (약 28배), 웜 지연 어서션
+  `issue4149_fast_path_giant_cell_warm_latency_beats_legacy` 0.619ms/call.
+- 계측 재현물: `issue4149_adjacent_giant_cell_cursor_rect_latency_decomposition`(페이즈 분해),
+  `issue4149_adjacent_cursor_rect_profile_loop`(--ignored, macOS sample 용),
+  `issue4149_cell_lineseg_roundtrip_survey`(저장 line_segs 신뢰성 — composed 사용 설계 근거).
+- 알려진 한계: 세로쓰기 셀 실물 샘플 미확보(구조상 windowed 는 `text_direction != 0` 게이트
+  차단, Uncut 은 전량 compose 와 문자 그대로 동일 경로). 향후 게이트 완화 시
+  `reset_numbering_state` + replay 가 전제조건.

--- a/mydocs/working/task_m100_4168_stage1.md
+++ b/mydocs/working/task_m100_4168_stage1.md
@@ -1,0 +1,41 @@
+---
+kind: working
+status: completed
+issue: 4168
+last_verified: 2026-08-08
+---
+
+# Task #4168 Stage 1 - find_metric 선계산 색인
+
+## 구현
+
+- `find_metric`을 `OnceLock` 선계산 색인 조회로 교체했다. 색인은
+  `HashMap<&'static str, [(metric, bold_fallback); 4]>` — 이름 단독 키라 임의 `&str`
+  조회(`Borrow<str>`)가 유지되고, (bold,italic) 4조합 슬롯을 legacy 3단 폴백 사다리와
+  같은 우선순위(정확 → bold-only(italic 요청 한정) → 이름 첫 엔트리 + `bold_fallback=bold`)로
+  선주입했다.
+- 기존 선형 스캔은 `legacy_find_metric`(cfg(test))으로 바이트 단위 보존해 등가성 오라클로
+  쓴다. `resolve_metric_alias`는 종전대로 조회 진입부에서 적용된다.
+
+## 검증 결과
+
+- 신규 `index_matches_legacy_linear_scan_exhaustively`: FONT_METRICS 600개 이름 전체 +
+  alias 좌변 67개 전체 + 미등록 이름(빈 문자열 포함) × bold/italic 4조합 전수에서 metric
+  포인터 동일성 + `bold_fallback` 일치 — pass.
+- `cargo test --profile release-test --lib font_metrics`: 8 passed / 0 failed.
+- 적대 리뷰(별도 세션): 테이블 중복 트리플 0건 확인, alias 양방향 누락 0, NFD 자모·NUL·
+  30,000자 장문 등 ~3,600 이름 × 4조합 공격 전수 일치, 16스레드 최초 사용 경합 3회 통과,
+  wasm32 check 통과 — 반박 실패(등가성 결함 0건).
+- 실측(거대 셀 문서, release-test): `build_page_tree` ≈20.7ms → ≈17.2ms, 캐럿 질의
+  ≈21.5ms → ≈17.2ms (프로파일 귀속 ~16%와 부합).
+- 알려진 후속: `src/tools/font_metric_gen.rs` 생성기가 구식 선형 스캔을 방출한다(선재
+  드리프트) — 재생성 시 본 색인·테스트가 소실되므로 생성기 갱신을 별도 이슈로 권고.
+
+## 부수 발견 — #4181
+
+게이트 실행 중 `tests/issue_2007_nested_cell_pagination`(p15-16)이 이 레이어에서 비결정
+실패함을 발견, 원인 격리 결과 **devel 선재의 힙 할당 순서 민감성**으로 확정했다(#4181):
+의미 무변경 대조군(색인 빌드만 하고 legacy 스캔 사용, 캐시 value 8바이트 확장) 둘 다 동일
+플레이크를 재현하고, 색인 결과 등가성은 전수·10회 프로세스 반복으로 증명됨. 본 레이어
+게이트는 해당 바이너리를 직렬 재시도로 통과 확인(3회 내 pass)하고 나머지 전 게이트는
+결정적 통과. #4181 해소 전까지 이 fixture 의 실패는 회귀 신호로 오독하지 말 것.

--- a/mydocs/working/task_m100_4169_stage1.md
+++ b/mydocs/working/task_m100_4169_stage1.md
@@ -1,0 +1,41 @@
+---
+kind: working
+status: completed
+issue: 4169
+last_verified: 2026-08-08
+---
+
+# Task #4169 Stage 1 - 단일줄 과밀 판정 memo
+
+## 구현
+
+- `Paragraph.single_line_overflow_memo: AtomicU64` — 0=미판정, `(f32 폭 bits << 1)|overflowed`
+  패킹, Relaxed. `Cell`은 `RenderNormalizedSection.paragraphs: Arc<Vec<Paragraph>>` 경유
+  `DocumentCore` Send 단언이 `Paragraph: Sync`를 요구해 컴파일 불가 — Atomic 선택 근거.
+  Clone은 수동 impl(파생 캐시를 텍스트와 함께 원자적으로 복제 — undo 스냅샷 정합).
+- 가드는 memo 히트 시 `estimate_composed_line_width` 측정만 생략하고, overflowed=true의
+  fresh 재래핑은 매 빌드 그대로 수행한다.
+- 무효화 배선(전수): 모델 프리미티브 8곳(insert_text_at/delete_text_at/split_at/merge_from/
+  apply_char_shape_range/set_single_char_shape/replace_style_char_shape_preserving_overrides/
+  shift_for_inline_control_insert), `reflow_line_segs` 수렴점, 직접 대입 우회 5곳 —
+  table_ops 표 계산식 셀 기록, document.rs clear_initial_field_texts,
+  object_ops/common.rs `reflow_paragraph_line_segs_after_control_delete` 서두(셀 인라인
+  그림/도형/수식/각주 삭제 가족 일괄 — 적대 리뷰 CONFIRMED 결함 수정),
+  field_query.rs `rebuild_char_offsets` 서두(빈 필드 제거 분기 — 감사 중 발견한 동류 누락),
+  clipboard.rs `strip_structural_controls_for_text_clipboard`(clip 사본이 다중 문단 붙여넣기로
+  문서에 스플라이스될 수 있음).
+
+## 검증 결과
+
+- `--lib composer`: 81 passed / 0 failed (신규 5: 메모 히트 측정 생략 증명, over=true 재래핑
+  유지, 폭 키 불일치 재판정, fit 판정 메모, 뮤테이션 경로 무효화).
+- `--lib issue4149`: 신규 `issue4149_cell_picture_delete_clears_single_line_overflow_memo`
+  (실명령 경로: stale verdict 주입 → 그림 삭제 → 미판정 어서션, 결함 분기 branch-1 통과) 포함 pass.
+- `--lib object_ops`: 59 passed / 0 failed. 기존 가드 회귀 핀 issue_2287(2)/2430(2)/2525(1)/
+  2527(3)/4138(2) 전부 pass.
+- 적대 리뷰: 무효화 누락 사냥에서 셀 그림 삭제 CONFIRMED 1건(위 수정 반영). undo/redo 스냅샷
+  클론 정합·f32 폭 키 정밀도(ulp vs 최소 리사이즈 3자리 차)·단일 스레드 TOCTOU 불가·ls==1
+  왕복 무해 — 반박 실패. 관찰: 향후 in-place CharShape 편집 API 도입 시 폭 단독 키가 구멍이
+  된다(현재 사이트 없음 확인).
+- 실측(거대 셀 문서, release-test): `build_page_tree` 17.6ms → 13.7ms (−22%), 캐럿 질의
+  ≈17.2 → ≈14.3ms.

--- a/src/diagnostics/ir_field_sweep.rs
+++ b/src/diagnostics/ir_field_sweep.rs
@@ -519,6 +519,8 @@ fn sweep_paragraph(base: &str, a: &Paragraph, b: &Paragraph, out: &mut Vec<Field
         has_para_text,
         tab_extended,
         numbering_restart,
+        // [#4149] 파생 캐시 — IR 비교 대상 아님 (직렬화·저장 경로에도 미포함).
+        single_line_overflow_memo: _,
     } = a;
 
     macro_rules! f {

--- a/src/document_core/commands/clipboard.rs
+++ b/src/document_core/commands/clipboard.rs
@@ -60,6 +60,10 @@ fn recompute_clipboard_control_mask(para: &Paragraph) -> u32 {
 }
 
 fn strip_structural_controls_for_text_clipboard(para: &mut Paragraph) {
+    // [#4149] clip 사본이지만 다중 문단 붙여넣기에서 중간 문단이 통째로 문서에
+    // 스플라이스되어 렌더 입력이 될 수 있다 — 컨트롤 제거로 compose 입력이
+    // 바뀌므로 단일줄 과밀 memo 를 무효화한다.
+    para.invalidate_single_line_overflow_memo();
     let old_controls = std::mem::take(&mut para.controls);
     let old_records = std::mem::take(&mut para.ctrl_data_records);
     let mut index_map = vec![None; old_controls.len()];

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -1983,7 +1983,11 @@ impl DocumentCore {
                     }
                 }
             }
-            let _ = any_removed;
+            if any_removed {
+                // [#4149] text/char_shapes 직접 수술 — 단일줄 과밀 memo 무효화
+                // (process_table 경유로 셀 문단에도 적용된다).
+                para.invalidate_single_line_overflow_memo();
+            }
         }
 
         fn process_table(table: &mut crate::model::table::Table) {

--- a/src/document_core/commands/object_ops/common.rs
+++ b/src/document_core/commands/object_ops/common.rs
@@ -47,6 +47,12 @@ impl DocumentCore {
         styles: &crate::renderer::style_resolver::ResolvedStyleSet,
         dpi: f64,
     ) {
+        // [#4149] 컨트롤 삭제는 char_offsets −8 시프트로 compose 입력을 바꾼다 —
+        // 높이만 조정하고 reflow_line_segs 를 타지 않는 분기(남은 컨트롤/빈 문단)도
+        // 포함해 단일줄 과밀 memo 를 무효화한다. 삽입 쌍둥이
+        // `shift_for_inline_control_insert` 와 대칭 (셀 그림/도형/수식/각주 삭제
+        // 가족이 전부 이 함수로 수렴).
+        para.invalidate_single_line_overflow_memo();
         // 남은 컨트롤 중 가장 큰 높이 계산
         let max_remaining_ctrl_height = para
             .controls

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -3328,6 +3328,8 @@ impl DocumentCore {
                         cell_para.text = text;
                         let new_len = cell_para.text.chars().count();
                         cell_para.char_offsets = (0..new_len).map(|i| i as u32).collect();
+                        // [#4149] 원시 text 대입 — 단일줄 과밀 memo 무효화.
+                        cell_para.invalidate_single_line_overflow_memo();
                     }
                 }
             }

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -6307,4 +6307,154 @@ mod tests {
             );
         }
     }
+
+    /// [#4149] 셀 문단 편집의 단일 관문 reflow_cell_paragraph / _by_path 를 지나면
+    /// 단일줄 과밀 판정 memo 가 미판정으로 돌아가야 한다 (reflow_line_segs 수렴점).
+    #[test]
+    fn issue4149_reflow_cell_paragraph_clears_single_line_overflow_memo() {
+        use crate::model::control::Control;
+        use crate::model::paragraph::SingleLineOverflowMemo;
+        use crate::model::table::{Cell, Table};
+
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+
+        let mut cell_para = Paragraph::default();
+        cell_para.text = "ABCDE".to_string();
+        cell_para.char_count = 6;
+        cell_para.char_offsets = vec![0, 1, 2, 3, 4];
+        cell_para.char_shapes = vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 0,
+        }];
+        let key = SingleLineOverflowMemo::width_key(123.0);
+        cell_para.single_line_overflow_memo.set(key, true);
+        assert!(!cell_para.single_line_overflow_memo.is_unjudged());
+
+        let table = Table {
+            cells: vec![Cell {
+                width: 8000, // 내폭 > 0 이어야 관문이 reflow_line_segs 까지 진행
+                paragraphs: vec![cell_para],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        core.document.sections[0].paragraphs[0]
+            .controls
+            .push(Control::Table(Box::new(table)));
+        let ctrl_idx = core.document.sections[0].paragraphs[0].controls.len() - 1;
+
+        // flat 관문
+        core.reflow_cell_paragraph(0, 0, ctrl_idx, 0, 0);
+        let memo_after = |core: &DocumentCore| {
+            let Control::Table(t) = &core.document.sections[0].paragraphs[0].controls[ctrl_idx]
+            else {
+                panic!("expected table");
+            };
+            t.cells[0].paragraphs[0]
+                .single_line_overflow_memo
+                .is_unjudged()
+        };
+        assert!(
+            memo_after(&core),
+            "reflow_cell_paragraph 경유 후 memo 는 미판정이어야 함"
+        );
+
+        // path 관문도 동일하게 비워야 한다.
+        {
+            let Control::Table(t) = &mut core.document.sections[0].paragraphs[0].controls[ctrl_idx]
+            else {
+                panic!("expected table");
+            };
+            t.cells[0].paragraphs[0]
+                .single_line_overflow_memo
+                .set(key, true);
+        }
+        core.reflow_cell_paragraph_by_path(0, 0, &[(ctrl_idx, 0, 0)], 0);
+        assert!(
+            memo_after(&core),
+            "reflow_cell_paragraph_by_path 경유 후 memo 는 미판정이어야 함"
+        );
+    }
+
+    /// [#4149 적대 리뷰] 셀 문단 인라인 그림 삭제가 char_offsets 를 −8 시프트하며
+    /// compose 입력을 바꾸는데, 남은 그림 height>0 분기
+    /// (reflow_paragraph_line_segs_after_control_delete branch 1)는 reflow_line_segs
+    /// 를 타지 않아 memo 무효화가 누락됐었다 — stale Some(false) verdict 가
+    /// 재래핑을 억제하면 과폭 절단 렌더. 실명령 경로로 무효화를 고정한다.
+    #[test]
+    fn issue4149_cell_picture_delete_clears_single_line_overflow_memo() {
+        use crate::model::control::Control;
+        use crate::model::image::Picture;
+        use crate::model::paragraph::{LineSeg, SingleLineOverflowMemo};
+        use crate::model::table::{Cell, Table};
+
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+
+        // 저장 ls==1 + 인라인 그림 2개 + 넓은 char run 셀 문단 (리뷰어 시나리오).
+        let mut cell_para = Paragraph::default();
+        cell_para.text = "가나다라마바사아".to_string();
+        let n = cell_para.text.chars().count() as u32;
+        // 그림 2개(8×2 code unit)가 텍스트 앞에 배치된 오프셋 구조.
+        cell_para.char_offsets = (0..n).map(|i| 16 + i).collect();
+        cell_para.char_count = n + 16 + 1;
+        cell_para.char_shapes = vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 0,
+        }];
+        cell_para.line_segs = vec![LineSeg {
+            text_start: 0,
+            line_height: 800,
+            baseline_distance: 640,
+            ..Default::default()
+        }];
+        let mut pic = Picture::default();
+        pic.common.width = 1000;
+        pic.common.height = 1000; // 남은 그림 height>0 → branch 1 (높이 조정만)
+        cell_para
+            .controls
+            .push(Control::Picture(Box::new(pic.clone())));
+        cell_para.controls.push(Control::Picture(Box::new(pic)));
+        cell_para.ctrl_data_records = vec![None, None];
+
+        // 렌더 1회로 설정된 판정을 모사 — 삭제 후 fresh 실측과 모순일 수 있는
+        // stale verdict.
+        let stale_key = SingleLineOverflowMemo::width_key(321.0);
+        cell_para.single_line_overflow_memo.set(stale_key, false);
+
+        let table = Table {
+            cells: vec![Cell {
+                width: 8000,
+                paragraphs: vec![cell_para],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        core.document.sections[0].paragraphs[0]
+            .controls
+            .push(Control::Table(Box::new(table)));
+        let ctrl_idx = core.document.sections[0].paragraphs[0].controls.len() - 1;
+
+        let path_json = format!(
+            r#"[{{"controlIdx":{},"cellIdx":0,"cellParaIdx":0}}]"#,
+            ctrl_idx
+        );
+        core.delete_cell_picture_control_by_path_native(0, 0, &path_json, 0)
+            .expect("셀 그림 삭제");
+
+        let Control::Table(t) = &core.document.sections[0].paragraphs[0].controls[ctrl_idx] else {
+            panic!("expected table");
+        };
+        let para = &t.cells[0].paragraphs[0];
+        assert_eq!(para.controls.len(), 1, "그림 1개가 삭제돼야 함");
+        assert!(
+            para.single_line_overflow_memo.get(stale_key).is_none(),
+            "인라인 그림 삭제 후 stale verdict 가 남으면 재래핑 억제 → 과폭 절단 렌더"
+        );
+        assert!(
+            para.single_line_overflow_memo.is_unjudged(),
+            "삭제 직후 memo 는 미판정 상태여야 함 (다음 렌더에서 fresh 재판정)"
+        );
+    }
 }

--- a/src/document_core/queries/cursor_rect.rs
+++ b/src/document_core/queries/cursor_rect.rs
@@ -54,6 +54,130 @@ fn clamp_cursor_to_cell_bounds(
     (clamped_x, clamped_y, clamped_height, overflowed)
 }
 
+/// [#4149] fast path 의 페이지 단위 결과.
+enum FastCellRectOutcome {
+    /// legacy 와 동일한 JSON 을 확정 — 즉시 반환.
+    Hit(String),
+    /// 이 페이지에는 대상 (cell_para, offset) run 이 없음 — 다음 후보 페이지로.
+    NoHit,
+    /// 확신 불가 — 전체 legacy 폴백.
+    Unsupported,
+}
+
+/// 셀 캐럿 TextRun 히트 — legacy 페이지 트리 탐색과 [#4149] fast path 프로브가
+/// 공유한다 (매칭 규칙이 갈리면 패리티가 깨진다).
+struct CellCursorHit {
+    page_index: u32,
+    x: f64,
+    y: f64,
+    height: f64,
+}
+
+/// 렌더 노드 트리에서 대상 셀의 bbox 를 찾는다 (legacy/fast 공유).
+fn find_table_cell_bounds_in_node(
+    node: &crate::renderer::render_tree::RenderNode,
+    parent_para: usize,
+    ctrl_idx: usize,
+    c_idx: usize,
+) -> Option<CellCursorBounds> {
+    use crate::renderer::render_tree::RenderNodeType;
+    if let RenderNodeType::Table(ref table) = node.node_type {
+        let matches_table =
+            table.para_index == Some(parent_para) && table.control_index == Some(ctrl_idx);
+        if matches_table {
+            for child in &node.children {
+                if let RenderNodeType::TableCell(ref cell) = child.node_type {
+                    if cell.model_cell_index == Some(c_idx as u32) {
+                        return Some(CellCursorBounds {
+                            x: child.bbox.x,
+                            y: child.bbox.y,
+                            w: child.bbox.width,
+                            h: child.bbox.height,
+                        });
+                    }
+                }
+            }
+        }
+    }
+    for child in &node.children {
+        if let Some(bounds) = find_table_cell_bounds_in_node(child, parent_para, ctrl_idx, c_idx) {
+            return Some(bounds);
+        }
+    }
+    None
+}
+
+/// 렌더 노드 트리에서 (cell_para, offset) 캐럿 TextRun 을 찾는다 (legacy/fast 공유).
+fn find_cursor_in_cell_node(
+    node: &crate::renderer::render_tree::RenderNode,
+    parent_para: usize,
+    ctrl_idx: usize,
+    c_idx: usize,
+    cp_idx: usize,
+    offset: usize,
+    page_index: u32,
+) -> Option<CellCursorHit> {
+    use crate::renderer::layout::compute_char_positions;
+    use crate::renderer::render_tree::RenderNodeType;
+    if let RenderNodeType::TextRun(ref text_run) = node.node_type {
+        let matches_cell = text_run.cell_context.as_ref().map_or(false, |ctx| {
+            // path.len()==1 가드가 없으면 중첩 표 *내부* 셀의 run 도
+            // 매칭된다: 내부 run 의 path[0] 은 그 중첩 표를 품은 바깥 셀과
+            // 정확히 같기 때문이다. 같은 파일의 cell_context_matches 가
+            // path 길이 일치를 계약으로 명시한다.
+            ctx.parent_para_index == parent_para
+                && ctx.path.len() == 1
+                && ctx.path[0].control_index == ctrl_idx
+                && ctx.path[0].cell_index == c_idx
+                && ctx.path[0].cell_para_index == cp_idx
+        });
+        if matches_cell {
+            let char_start = text_run.char_start.unwrap_or(0);
+            let char_count = effective_char_count(text_run);
+
+            if offset >= char_start && offset <= char_start + char_count {
+                let local_offset = offset - char_start;
+                let positions = if text_run.char_overlap.is_some() && char_count == 1 {
+                    vec![0.0, node.bbox.width]
+                } else {
+                    compute_char_positions(&text_run.text, &text_run.style)
+                };
+                let x_in_run = if local_offset < positions.len() {
+                    positions[local_offset]
+                } else if !positions.is_empty() {
+                    *positions.last().unwrap()
+                } else {
+                    0.0
+                };
+                // 베이스라인 기반 캐럿 y 계산 (본문과 동일)
+                let font_size = text_run.style.font_size;
+                let ascent = font_size * 0.8;
+                let caret_y = node.bbox.y + text_run.baseline - ascent;
+                return Some(CellCursorHit {
+                    page_index,
+                    x: node.bbox.x + x_in_run,
+                    y: caret_y,
+                    height: font_size,
+                });
+            }
+        }
+    }
+    for child in &node.children {
+        if let Some(hit) = find_cursor_in_cell_node(
+            child,
+            parent_para,
+            ctrl_idx,
+            c_idx,
+            cp_idx,
+            offset,
+            page_index,
+        ) {
+            return Some(hit);
+        }
+    }
+    None
+}
+
 fn format_cursor_rect_json(
     page_index: u32,
     x: f64,
@@ -2585,7 +2709,12 @@ impl DocumentCore {
         }
     }
 
-    /// 표 셀 내부 커서의 픽셀 좌표를 반환한다 (네이티브)
+    /// 표 셀 내부 커서의 픽셀 좌표를 반환한다 (네이티브).
+    ///
+    /// [#4149] 페이지 트리 없이 rect 를 구하는 fast path 를 먼저 시도한다.
+    /// fast path 는 확신이 없는 모든 경우 `None` 을 돌려주고, 그 경우 종전
+    /// 페이지 트리 경로(`cursor_rect_in_cell_via_page_tree`)로 폴백한다 —
+    /// fast path 는 탈출구 있는 최적화지 제2의 진실원천이 아니다.
     pub fn get_cursor_rect_in_cell_native(
         &self,
         section_idx: usize,
@@ -2595,7 +2724,37 @@ impl DocumentCore {
         cell_para_idx: usize,
         char_offset: usize,
     ) -> Result<String, HwpError> {
-        use crate::renderer::layout::compute_char_positions;
+        if let Some(json) = self.cursor_rect_in_cell_fast(
+            section_idx,
+            parent_para_idx,
+            control_idx,
+            cell_idx,
+            cell_para_idx,
+            char_offset,
+        )? {
+            return Ok(json);
+        }
+        self.cursor_rect_in_cell_via_page_tree(
+            section_idx,
+            parent_para_idx,
+            control_idx,
+            cell_idx,
+            cell_para_idx,
+            char_offset,
+        )
+    }
+
+    /// [#4149] 종전 legacy 경로 — 페이지 트리를 빌드해 캐럿 rect 를 찾는다.
+    /// fast path 의 패리티 기준(진실원천)이며, 차등 테스트가 직접 호출한다.
+    pub(crate) fn cursor_rect_in_cell_via_page_tree(
+        &self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+        cell_idx: usize,
+        cell_para_idx: usize,
+        char_offset: usize,
+    ) -> Result<String, HwpError> {
         use crate::renderer::render_tree::{RenderNode, RenderNodeType};
 
         // 표 캡션은 cell_index=65534 센티널로 렌더 트리에도 동일하게 저장됨
@@ -2609,118 +2768,11 @@ impl DocumentCore {
             Some((cell_para_idx, char_offset)),
         )?;
 
-        struct CursorHit {
-            page_index: u32,
-            x: f64,
-            y: f64,
-            height: f64,
-        }
-
-        fn find_table_cell_bounds(
-            node: &RenderNode,
-            parent_para: usize,
-            ctrl_idx: usize,
-            c_idx: usize,
-        ) -> Option<CellCursorBounds> {
-            if let RenderNodeType::Table(ref table) = node.node_type {
-                let matches_table =
-                    table.para_index == Some(parent_para) && table.control_index == Some(ctrl_idx);
-                if matches_table {
-                    for child in &node.children {
-                        if let RenderNodeType::TableCell(ref cell) = child.node_type {
-                            if cell.model_cell_index == Some(c_idx as u32) {
-                                return Some(CellCursorBounds {
-                                    x: child.bbox.x,
-                                    y: child.bbox.y,
-                                    w: child.bbox.width,
-                                    h: child.bbox.height,
-                                });
-                            }
-                        }
-                    }
-                }
-            }
-            for child in &node.children {
-                if let Some(bounds) = find_table_cell_bounds(child, parent_para, ctrl_idx, c_idx) {
-                    return Some(bounds);
-                }
-            }
-            None
-        }
-
-        fn find_cursor_in_cell(
-            node: &RenderNode,
-            parent_para: usize,
-            ctrl_idx: usize,
-            c_idx: usize,
-            cp_idx: usize,
-            offset: usize,
-            page_index: u32,
-        ) -> Option<CursorHit> {
-            if let RenderNodeType::TextRun(ref text_run) = node.node_type {
-                let matches_cell = text_run.cell_context.as_ref().map_or(false, |ctx| {
-                    // path.len()==1 가드가 없으면 중첩 표 *내부* 셀의 run 도
-                    // 매칭된다: 내부 run 의 path[0] 은 그 중첩 표를 품은 바깥 셀과
-                    // 정확히 같기 때문이다. 같은 파일의 cell_context_matches 가
-                    // path 길이 일치를 계약으로 명시한다.
-                    ctx.parent_para_index == parent_para
-                        && ctx.path.len() == 1
-                        && ctx.path[0].control_index == ctrl_idx
-                        && ctx.path[0].cell_index == c_idx
-                        && ctx.path[0].cell_para_index == cp_idx
-                });
-                if matches_cell {
-                    let char_start = text_run.char_start.unwrap_or(0);
-                    let char_count = effective_char_count(text_run);
-
-                    if offset >= char_start && offset <= char_start + char_count {
-                        let local_offset = offset - char_start;
-                        let positions = if text_run.char_overlap.is_some() && char_count == 1 {
-                            vec![0.0, node.bbox.width]
-                        } else {
-                            compute_char_positions(&text_run.text, &text_run.style)
-                        };
-                        let x_in_run = if local_offset < positions.len() {
-                            positions[local_offset]
-                        } else if !positions.is_empty() {
-                            *positions.last().unwrap()
-                        } else {
-                            0.0
-                        };
-                        // 베이스라인 기반 캐럿 y 계산 (본문과 동일)
-                        let font_size = text_run.style.font_size;
-                        let ascent = font_size * 0.8;
-                        let caret_y = node.bbox.y + text_run.baseline - ascent;
-                        return Some(CursorHit {
-                            page_index,
-                            x: node.bbox.x + x_in_run,
-                            y: caret_y,
-                            height: font_size,
-                        });
-                    }
-                }
-            }
-            for child in &node.children {
-                if let Some(hit) = find_cursor_in_cell(
-                    child,
-                    parent_para,
-                    ctrl_idx,
-                    c_idx,
-                    cp_idx,
-                    offset,
-                    page_index,
-                ) {
-                    return Some(hit);
-                }
-            }
-            None
-        }
-
         for &page_num in &pages {
             let tree = self.build_page_tree(page_num)?;
             let cell_bounds =
-                find_table_cell_bounds(&tree.root, parent_para_idx, control_idx, cell_idx);
-            if let Some(hit) = find_cursor_in_cell(
+                find_table_cell_bounds_in_node(&tree.root, parent_para_idx, control_idx, cell_idx);
+            if let Some(hit) = find_cursor_in_cell_node(
                 &tree.root,
                 parent_para_idx,
                 control_idx,
@@ -2751,7 +2803,7 @@ impl DocumentCore {
             .unwrap_or(pages[0]);
         let tree = self.build_page_tree(first_page)?;
         let first_page_cell_bounds =
-            find_table_cell_bounds(&tree.root, parent_para_idx, control_idx, cell_idx);
+            find_table_cell_bounds_in_node(&tree.root, parent_para_idx, control_idx, cell_idx);
 
         fn find_cell_run(
             node: &RenderNode,
@@ -2869,6 +2921,381 @@ impl DocumentCore {
             "셀 커서 위치를 찾을 수 없습니다: sec={}, parentPara={}, ctrl={}, cell={}, cellPara={}, offset={}",
             section_idx, parent_para_idx, control_idx, cell_idx, cell_para_idx, char_offset
         )))
+    }
+
+    /// [#4149] 페이지 트리 없이 셀 캐럿 rect 를 구하는 fast path.
+    ///
+    /// `Ok(Some(json))` 은 legacy 와 동일한 JSON 임이 계약이다 (차등 테스트가 검증).
+    /// 조금이라도 불확실한 모든 경우 `Ok(None)` — 호출자가 legacy 로 폴백한다.
+    ///
+    /// 구조: 후보 페이지(#4128 좁히기)마다, 그 페이지의 유일한 컬럼 선두
+    /// PartialTable 조각을 전량 빌드와 동일한 입력으로 재현하되 대상 셀 하나만
+    /// 방출하는 프로브(`PartialTableCellProbe`)를 돌리고, legacy 와 같은 매칭
+    /// 함수로 캐럿 run 을 찾는다. 좌표 산식은 전부 production 코드 재사용 —
+    /// 프로브는 "생략"만 하고 "변형"은 하지 않는다.
+    pub(crate) fn cursor_rect_in_cell_fast(
+        &self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+        cell_idx: usize,
+        cell_para_idx: usize,
+        char_offset: usize,
+    ) -> Result<Option<String>, HwpError> {
+        use crate::model::control::Control;
+
+        // 캡션 센티널(65534)·비표 컨트롤은 legacy 전용
+        if cell_idx == 65534 {
+            return Ok(None);
+        }
+        let is_table = self
+            .document
+            .sections
+            .get(section_idx)
+            .and_then(|s| s.paragraphs.get(parent_para_idx))
+            .and_then(|p| p.controls.get(control_idx))
+            .is_some_and(|c| matches!(c, Control::Table(_)));
+        if !is_table {
+            return Ok(None);
+        }
+
+        // 후보 페이지 — legacy 와 동일 소스·순서. (셀 units 메모가 여기서 예열되므로
+        // 폴백 시에도 이 비용은 legacy 가 재사용한다.)
+        let pages = self.find_pages_for_cell_position(
+            section_idx,
+            parent_para_idx,
+            control_idx,
+            cell_idx,
+            Some((cell_para_idx, char_offset)),
+        )?;
+        let sec_offset: u32 = self
+            .pagination
+            .iter()
+            .take(section_idx)
+            .map(|p| p.pages.len() as u32)
+            .sum();
+        let sec_len = self
+            .pagination
+            .get(section_idx)
+            .map(|p| p.pages.len() as u32)
+            .unwrap_or(0);
+
+        for &page_num in &pages {
+            if page_num < sec_offset || page_num >= sec_offset + sec_len {
+                return Ok(None);
+            }
+            match self.cursor_rect_in_cell_fast_on_page(
+                section_idx,
+                parent_para_idx,
+                control_idx,
+                cell_idx,
+                cell_para_idx,
+                char_offset,
+                page_num,
+            )? {
+                FastCellRectOutcome::Hit(json) => return Ok(Some(json)),
+                // legacy 도 이 페이지 트리에서 캐럿 run 을 못 찾고 다음 후보로 넘어간다
+                FastCellRectOutcome::NoHit => continue,
+                FastCellRectOutcome::Unsupported => return Ok(None),
+            }
+        }
+        // 모든 후보에서 미발견 → legacy 의 빈 셀 fallback 경로가 진실원천
+        Ok(None)
+    }
+
+    /// [#4149] 한 후보 페이지에 대한 fast path 시도.
+    #[allow(clippy::too_many_arguments)]
+    fn cursor_rect_in_cell_fast_on_page(
+        &self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+        cell_idx: usize,
+        cell_para_idx: usize,
+        char_offset: usize,
+        page_num: u32,
+    ) -> Result<FastCellRectOutcome, HwpError> {
+        use crate::model::control::Control;
+        use crate::renderer::layout::{layout_rect_to_bbox, PartialTableCellProbe, ProbeCutPlan};
+        use crate::renderer::pagination::PageItem;
+        use crate::renderer::render_tree::{PageRenderTree, RenderNode, RenderNodeType};
+        use FastCellRectOutcome::{Hit, NoHit, Unsupported};
+
+        let Ok((page_content, paragraphs, _composed)) = self.find_page(page_num) else {
+            // 후보 페이지 해석 실패 — legacy 가 같은 상황을 자체 처리한다
+            return Ok(Unsupported);
+        };
+        if page_content.section_index != section_idx {
+            return Ok(Unsupported);
+        }
+        // ── 페이지 게이트: 단일 컬럼 + 컬럼 선두가 대상 표의 PartialTable 조각 ──
+        // (선두가 아니면 앞 항목들의 흐름 y·vpos 보정을 재현해야 해서 확신 불가)
+        if page_content.column_contents.len() != 1 {
+            return Ok(Unsupported);
+        }
+        let col = &page_content.column_contents[0];
+        if col.zone_layout.is_some()
+            || col.zone_y_offset != 0.0
+            || col.endnote_flow
+            || col.start_height < -0.5
+            || !col.wrap_around_paras.is_empty()
+            || !col.wrap_anchors.is_empty()
+        {
+            return Ok(Unsupported);
+        }
+        let Some(PageItem::PartialTable {
+            para_index,
+            control_index,
+            start_row,
+            end_row,
+            is_continuation,
+            start_cut,
+            end_cut,
+            is_block_split,
+        }) = col.items.first()
+        else {
+            return Ok(Unsupported);
+        };
+        if *para_index != parent_para_idx || *control_index != control_idx {
+            return Ok(Unsupported);
+        }
+        // host 문단 앵커의 Shape/Table 아이템은 shape_reserved 사전 점프를 만들 수
+        // 있다 — 보수적 폴백
+        if col.items.iter().any(|it| {
+            matches!(it,
+                PageItem::Shape { para_index, .. } | PageItem::Table { para_index, .. }
+                    if *para_index == parent_para_idx)
+        }) {
+            return Ok(Unsupported);
+        }
+        let Some(pr) = self.pagination.get(section_idx) else {
+            return Ok(Unsupported);
+        };
+        // 미주 병합 슬라이스(combined) 재현을 피한다 — 값은 같지만 표면을 줄인다
+        if !pr.endnote_paragraphs.is_empty() {
+            return Ok(Unsupported);
+        }
+
+        // ── 모델 게이트 (legacy build 와 동일한 렌더 정규화본 기준) ──
+        let Some(host_para) = paragraphs.get(parent_para_idx) else {
+            return Ok(Unsupported);
+        };
+        let Some(Control::Table(table)) = host_para.controls.get(control_idx) else {
+            return Ok(Unsupported);
+        };
+        if table.common.treat_as_char || table.caption.is_some() {
+            return Ok(Unsupported);
+        }
+        let Some(cell) = table.cells.get(cell_idx) else {
+            return Ok(Unsupported);
+        };
+        if cell.paragraphs.get(cell_para_idx).is_none() {
+            return Ok(Unsupported);
+        }
+        // 반복 제목행 사본으로 그려질 수 있는 셀은 컷 창 모델 밖
+        let cell_row = cell.row as usize;
+        let cell_end_row = cell_row + (cell.row_span as usize).max(1);
+        if *is_continuation && table.repeat_header && cell_end_row <= *start_row {
+            return Ok(Unsupported);
+        }
+
+        // ── 좌표계 프라이밍 — build_page_tree/build_single_column 과 동일 상태.
+        // (memoized cell_units 등 포인터-키 캐시가 동일 값으로 채워지도록, 상태
+        // 의존 게이트·컷 계획보다 먼저 프라이밍한다.)
+        self.layout_engine
+            .set_show_transparent_borders(self.show_transparent_borders);
+        self.layout_engine.set_clip_enabled(self.clip_enabled);
+        self.layout_engine
+            .set_show_control_codes(self.show_control_codes);
+        self.layout_engine
+            .set_layout_profile(self.document.layout_profile());
+        self.layout_engine.set_hwp3_origin_flow_spacing_before(
+            super::rendering::uses_hwp3_origin_flow_spacing_before(&self.document),
+        );
+        self.layout_engine
+            .set_active_field(self.active_field.as_ref().map(|af| {
+                (
+                    af.section_idx,
+                    af.para_idx,
+                    af.control_idx,
+                    af.cell_path.clone(),
+                )
+            }));
+        self.layout_engine
+            .set_hidden_header_footer(&self.hidden_header_footer);
+        let total_pages: u32 = self.pagination.iter().map(|p| p.pages.len() as u32).sum();
+        self.layout_engine.set_total_pages(total_pages);
+        self.layout_engine.set_file_name(&self.file_name);
+        self.layout_engine
+            .set_hidden_empty_paras(&pr.hidden_empty_paras);
+        self.layout_engine
+            .set_pre_emitted_host_paras(&pr.pre_emitted_host_paras);
+        self.layout_engine
+            .set_pre_emitted_host_heights(&pr.pre_emitted_host_heights);
+        let layout = &page_content.layout;
+        self.layout_engine.prime_column_layout_env(layout);
+
+        // ── 상태 의존 게이트: auto counter 소비(개요/번호·AutoNumber·캡션 번호)가
+        // 표 서브트리에 있으면 이전 페이지 replay 없이는 번호가 어긋난다 ──
+        if self
+            .layout_engine
+            .table_subtree_blocks_cursor_probe(table, &self.styles)
+        {
+            return Ok(Unsupported);
+        }
+
+        // ── 컷 계획: 이 조각에서 대상 셀의 컷 창과 창 문단 범위 ──
+        let plan = self.layout_engine.partial_table_cell_probe_plan(
+            table,
+            cell,
+            *start_row,
+            *end_row,
+            start_cut,
+            end_cut,
+            *is_block_split,
+            &self.styles,
+            cell_para_idx,
+        );
+        // 전량 compose 를 허용하는 셀 크기 상한 — 정확성이 아니라 fast path 의
+        // 존재 이유(속도)를 지키는 게이트다.
+        const FULL_COMPOSE_MAX: usize = 64;
+        let n_paras = cell.paragraphs.len();
+        let (windowed, window_paras) = match plan {
+            ProbeCutPlan::Unsupported => return Ok(Unsupported),
+            ProbeCutPlan::Uncut => {
+                if n_paras > FULL_COMPOSE_MAX {
+                    return Ok(Unsupported);
+                }
+                (false, (0, n_paras.saturating_sub(1)))
+            }
+            ProbeCutPlan::Cut {
+                window_paras,
+                split_proven,
+                target_in_window,
+            } => {
+                if !target_in_window {
+                    // 창 밖 문단은 이 페이지에 cell_para 매칭 run 이 없다 —
+                    // legacy 도 이 페이지에서 못 찾고 다음 후보로 간다.
+                    return Ok(NoHit);
+                }
+                if n_paras <= FULL_COMPOSE_MAX {
+                    (false, window_paras)
+                } else {
+                    // windowed 사전 증명:
+                    //  (a) line_segs>=2 문단 존재 → shrink 패딩 축소 조기탈출과 동일
+                    //  (b) Top 정렬 확정 — split 증명 또는 원래 valign 이 Top
+                    //  (c) 가로쓰기 (세로쓰기는 전량 슬라이스 필요)
+                    let any_multiline = cell.paragraphs.iter().any(|p| p.line_segs.len() >= 2);
+                    let top_ok = split_proven
+                        || matches!(cell.vertical_align, crate::model::table::VerticalAlign::Top);
+                    if !any_multiline || !top_ok || cell.text_direction != 0 {
+                        return Ok(Unsupported);
+                    }
+                    (true, window_paras)
+                }
+            }
+        };
+
+        // ── 컬럼 선두 흐름 y 재현: 게이트로 보장된 조건에서 y = col_area.y ──
+        // (build_single_column: start_shift=0, body_wide_reserved 없음(단일 컬럼),
+        //  shape_reserved 앵커 없음(게이트), 첫 아이템은 HeightCursor.vpos_adjust 가
+        //  prev 부재로 항등)
+        let zone_layout = layout; // col.zone_layout None 게이트 통과
+        let col_area_idx = col.column_index as usize;
+        let col_area = if col_area_idx < zone_layout.column_areas.len() {
+            zone_layout.column_areas[col_area_idx]
+        } else {
+            zone_layout.body_area
+        };
+        let y_offset = col_area.y;
+
+        // layout_partial_table_item 의 지오메트리 입력 재현 (host 텍스트 방출은
+        // 캐럿과 무관 — pt_y_start 는 host 렌더 유무와 관계없이 y_offset)
+        let (pt_margin_left, pt_margin_right) = {
+            let ps = self
+                .styles
+                .para_styles
+                .get(host_para.para_shape_id as usize);
+            let ml = ps.map(|s| s.margin_left).unwrap_or(0.0);
+            let ind = ps.map(|s| s.indent).unwrap_or(0.0);
+            let mr = ps.map(|s| s.margin_right).unwrap_or(0.0);
+            (if ind > 0.0 { ml + ind } else { ml }, mr)
+        };
+        let pt_mt = self.measured_tables.get(section_idx).and_then(|v| {
+            v.iter()
+                .find(|mt| mt.para_index == parent_para_idx && mt.control_index == control_idx)
+        });
+        let outline_num_id = self
+            .document
+            .sections
+            .get(section_idx)
+            .map(|s| s.section_def.outline_numbering_id)
+            .unwrap_or(0);
+
+        // ── 대상 셀 하나만 방출하는 프로브 레이아웃 ──
+        let mut scratch_tree = PageRenderTree::new(
+            page_content.page_index,
+            layout.page_width,
+            layout.page_height,
+        );
+        let col_id = scratch_tree.next_id();
+        let mut scratch_col = RenderNode::new(
+            col_id,
+            RenderNodeType::Column(col.column_index),
+            layout_rect_to_bbox(&col_area),
+        );
+        let probe = PartialTableCellProbe {
+            cell_idx,
+            stop_after_para: cell_para_idx,
+            windowed,
+            window_paras,
+        };
+        self.layout_engine.layout_partial_table(
+            &mut scratch_tree,
+            &mut scratch_col,
+            paragraphs,
+            parent_para_idx,
+            control_idx,
+            section_idx,
+            &self.styles,
+            outline_num_id,
+            &col_area,
+            y_offset,
+            &self.document.bin_data_content,
+            *start_row,
+            *end_row,
+            *is_continuation,
+            start_cut,
+            end_cut,
+            *is_block_split,
+            pt_margin_left,
+            pt_margin_right,
+            pt_mt,
+            false,
+            Some(&probe),
+        );
+
+        // legacy 와 동일한 매칭 함수로 캐럿·셀 bbox 탐색
+        let cell_bounds =
+            find_table_cell_bounds_in_node(&scratch_col, parent_para_idx, control_idx, cell_idx);
+        if let Some(hit) = find_cursor_in_cell_node(
+            &scratch_col,
+            parent_para_idx,
+            control_idx,
+            cell_idx,
+            cell_para_idx,
+            char_offset,
+            page_num,
+        ) {
+            return Ok(Hit(format_cursor_rect_json(
+                hit.page_index,
+                hit.x,
+                hit.y,
+                hit.height,
+                cell_bounds,
+            )));
+        }
+        Ok(NoHit)
     }
 
     // ─── 컨테이너 렌더 범위 조회 ──────────────────────────────
@@ -5880,5 +6307,319 @@ mod tests {
                 Err(e) => println!("DUMP {cpi} {off} ERR {e}"),
             }
         }
+    }
+
+    // ─── [#4149] 셀 캐럿 fast path 차등(패리티) 테스트 ─────────────────────
+    //
+    // 합격 기준: fast path 가 Some 을 돌려준 모든 지점에서 legacy
+    // (`cursor_rect_in_cell_via_page_tree`) JSON 과 완전 일치. fast 가 None 인
+    // 지점은 wrapper 가 legacy 로 폴백하므로 정의상 동일 출력이다.
+
+    /// 샘플의 모든 최상위 표 × 셀 × (스텝된) 문단 × offset {0, len/2, len} 그리드에서
+    /// fast/legacy 차등 검증. (fast_some, checked) 를 반환한다.
+    fn issue4149_assert_fast_parity(sample: &str, max_points: usize) -> (usize, usize) {
+        let p = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(sample);
+        let bytes = std::fs::read(&p).expect("read sample");
+        let core = crate::document_core::DocumentCore::from_bytes(&bytes).expect("parse");
+        let doc = core.document();
+
+        // 그리드 수집 (모든 섹션의 최상위 표)
+        let mut points: Vec<(usize, usize, usize, usize, usize, usize)> = Vec::new();
+        for (si, sec) in doc.sections.iter().enumerate() {
+            for (pi, para) in sec.paragraphs.iter().enumerate() {
+                for (ci, ctrl) in para.controls.iter().enumerate() {
+                    let crate::model::control::Control::Table(ref t) = ctrl else {
+                        continue;
+                    };
+                    for (cell_i, cell) in t.cells.iter().enumerate() {
+                        let n = cell.paragraphs.len();
+                        if n == 0 {
+                            continue;
+                        }
+                        let step = (n / 80).max(1);
+                        let mut cpi = 0usize;
+                        while cpi < n {
+                            let len = cell.paragraphs[cpi].text.chars().count();
+                            points.push((si, pi, ci, cell_i, cpi, 0));
+                            if len > 0 {
+                                points.push((si, pi, ci, cell_i, cpi, len / 2));
+                                points.push((si, pi, ci, cell_i, cpi, len));
+                            }
+                            cpi += step;
+                        }
+                    }
+                }
+            }
+        }
+        // 결정적 상한 (전수에 가깝게, 러닝타임 폭주만 차단)
+        if points.len() > max_points {
+            let step = points.len().div_ceil(max_points);
+            points = points.into_iter().step_by(step).collect();
+        }
+
+        let mut fast_some = 0usize;
+        let mut checked = 0usize;
+        for &(si, pi, ci, cell_i, cpi, off) in &points {
+            checked += 1;
+            // fast 의 에러는 legacy 도 같은 좁히기에서 에러 — 폴백 경로로 취급
+            let fast = core
+                .cursor_rect_in_cell_fast(si, pi, ci, cell_i, cpi, off)
+                .unwrap_or_default();
+            let Some(fast_json) = fast else { continue };
+            fast_some += 1;
+            let legacy = core
+                .cursor_rect_in_cell_via_page_tree(si, pi, ci, cell_i, cpi, off)
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "{sample} (s{si} p{pi} c{ci} cell{cell_i} cp{cpi} off{off}): \
+                         fast=Some 인데 legacy 에러 {e}"
+                    )
+                });
+            assert_eq!(
+                fast_json, legacy,
+                "{sample} 패리티 불일치 (s{si} p{pi} c{ci} cell{cell_i} cp{cpi} off{off})"
+            );
+        }
+        eprintln!(
+            "#4149 {}: fast 적중 {} / 검사 {} ({:.1}%)",
+            sample,
+            fast_some,
+            checked,
+            fast_some as f64 * 100.0 / checked.max(1) as f64
+        );
+        (fast_some, checked)
+    }
+
+    /// [#4149 진단] fast path 게이트 단계별 통과 여부 — 수동 실행.
+    #[test]
+    #[ignore = "게이트 진단 — 수동 실행"]
+    fn issue4149_diag_fast_path_gates() {
+        use crate::model::control::Control;
+        use crate::renderer::layout::ProbeCutPlan;
+        use crate::renderer::pagination::PageItem;
+        let (core, host_pi, host_ci, cell_idx) = issue4128_fixture();
+        let pages = core
+            .find_pages_for_cell_position(0, host_pi, host_ci, cell_idx, Some((6, 5)))
+            .expect("pages");
+        eprintln!("pages={pages:?}");
+        let page_num = pages[0];
+        let (page_content, paragraphs, _c) = core.find_page(page_num).expect("find_page");
+        eprintln!(
+            "cols={} zone={:?} zoff={} endnote={} start_h={} wrapA={} wrapAnch={}",
+            page_content.column_contents.len(),
+            page_content.column_contents[0].zone_layout.is_some(),
+            page_content.column_contents[0].zone_y_offset,
+            page_content.column_contents[0].endnote_flow,
+            page_content.column_contents[0].start_height,
+            page_content.column_contents[0].wrap_around_paras.len(),
+            page_content.column_contents[0].wrap_anchors.len(),
+        );
+        let col = &page_content.column_contents[0];
+        eprintln!("items0 = {:?}", col.items.first());
+        let host_anchor = col.items.iter().any(|it| {
+            matches!(it,
+                PageItem::Shape { para_index, .. } | PageItem::Table { para_index, .. }
+                    if *para_index == host_pi)
+        });
+        eprintln!("host_anchor_items = {host_anchor}");
+        let pr = &core.pagination[0];
+        eprintln!("endnote_paras = {}", pr.endnote_paragraphs.len());
+        let host = &paragraphs[host_pi];
+        let Control::Table(ref table) = host.controls[host_ci] else {
+            panic!()
+        };
+        eprintln!(
+            "tac={} caption={} repeat_header={}",
+            table.common.treat_as_char,
+            table.caption.is_some(),
+            table.repeat_header
+        );
+        let blocked = core
+            .layout_engine
+            .table_subtree_blocks_cursor_probe(table, &core.styles);
+        eprintln!("subtree_blocked = {blocked}");
+        if blocked {
+            // 차단 원인 탐색 (스캔 로직 복제 + 보고)
+            fn why(
+                paras: &[crate::model::paragraph::Paragraph],
+                styles: &crate::renderer::style_resolver::ResolvedStyleSet,
+                depth: usize,
+            ) -> Option<String> {
+                use crate::model::style::HeadType;
+                for (i, p) in paras.iter().enumerate() {
+                    let head = styles
+                        .para_styles
+                        .get(p.para_shape_id as usize)
+                        .map(|s| s.head_type)
+                        .unwrap_or(HeadType::None);
+                    if matches!(head, HeadType::Outline | HeadType::Number) {
+                        return Some(format!("d{depth} p{i} head={head:?}"));
+                    }
+                    for (ci, c) in p.controls.iter().enumerate() {
+                        match c {
+                            Control::AutoNumber(_) => {
+                                return Some(format!("d{depth} p{i} c{ci} AutoNumber"))
+                            }
+                            Control::NewNumber(_) => {
+                                return Some(format!("d{depth} p{i} c{ci} NewNumber"))
+                            }
+                            Control::Table(t) => {
+                                if t.caption.is_some() {
+                                    return Some(format!("d{depth} p{i} c{ci} nested caption"));
+                                }
+                                for (cei, cell) in t.cells.iter().enumerate() {
+                                    if let Some(w) = why(&cell.paragraphs, styles, depth + 1) {
+                                        return Some(format!(
+                                            "d{depth} p{i} c{ci} cell{cei} → {w}"
+                                        ));
+                                    }
+                                }
+                            }
+                            Control::Shape(s) => {
+                                use crate::model::shape::ShapeObject;
+                                match &**s {
+                                    ShapeObject::Rectangle(_)
+                                    | ShapeObject::Ellipse(_)
+                                    | ShapeObject::Polygon(_)
+                                    | ShapeObject::Curve(_)
+                                    | ShapeObject::Line(_)
+                                    | ShapeObject::Arc(_) => {}
+                                    other => {
+                                        return Some(format!(
+                                            "d{depth} p{i} c{ci} shape variant {:?}",
+                                            std::mem::discriminant(other)
+                                        ))
+                                    }
+                                }
+                            }
+                            Control::Picture(pic) => {
+                                if pic.caption.is_some() {
+                                    return Some(format!("d{depth} p{i} c{ci} picture caption"));
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                None
+            }
+            for (cei, cell) in table.cells.iter().enumerate() {
+                if let Some(w) = why(&cell.paragraphs, &core.styles, 0) {
+                    eprintln!("blocked by: cell{cei} → {w}");
+                    break;
+                }
+            }
+        }
+        if let Some(PageItem::PartialTable {
+            start_row,
+            end_row,
+            start_cut,
+            end_cut,
+            is_block_split,
+            ..
+        }) = col.items.first()
+        {
+            let cell = &table.cells[cell_idx];
+            let plan = core.layout_engine.partial_table_cell_probe_plan(
+                table,
+                cell,
+                *start_row,
+                *end_row,
+                start_cut,
+                end_cut,
+                *is_block_split,
+                &core.styles,
+                6,
+            );
+            match plan {
+                ProbeCutPlan::Unsupported => eprintln!("plan=Unsupported"),
+                ProbeCutPlan::Uncut => eprintln!("plan=Uncut (n={})", cell.paragraphs.len()),
+                ProbeCutPlan::Cut {
+                    window_paras,
+                    split_proven,
+                    target_in_window,
+                } => eprintln!(
+                    "plan=Cut window={window_paras:?} split_proven={split_proven} in_window={target_in_window} any_multiline={} valign={:?} dir={}",
+                    cell.paragraphs.iter().any(|p| p.line_segs.len() >= 2),
+                    cell.vertical_align,
+                    cell.text_direction
+                ),
+            }
+        }
+        let fast = core
+            .cursor_rect_in_cell_fast(0, host_pi, host_ci, cell_idx, 6, 5)
+            .expect("fast");
+        eprintln!("fast = {fast:?}");
+    }
+
+    /// [#4149] 거대 셀 분할 표 — fast path 의 주 대상. 적중률이 유의미해야 한다.
+    #[test]
+    fn issue4149_fast_path_parity_giant_cell() {
+        let (fast_some, checked) = issue4149_assert_fast_parity(
+            "samples/issue1949_giant_cell_nested_tables_perf.hwp",
+            400,
+        );
+        assert!(checked > 50, "그리드 {}점 — 샘플 전제 확인 필요", checked);
+        // 거대 문서에서 대부분 적중해야 fast path 가 의미 있다.
+        assert!(
+            fast_some * 2 > checked,
+            "적중 {}/{} — 거대 셀 문서에서 과반 적중 실패",
+            fast_some,
+            checked
+        );
+    }
+
+    /// [#4149] KTX.hwp — 일반 표 문서. 패리티만 요구 (적중률은 보고).
+    #[test]
+    fn issue4149_fast_path_parity_ktx() {
+        issue4149_assert_fast_parity("samples/KTX.hwp", 400);
+    }
+
+    /// [#4149] hwp_table_test_saved.hwp — 저장 왕복 표 문서. 패리티만 요구.
+    #[test]
+    fn issue4149_fast_path_parity_table_saved() {
+        issue4149_assert_fast_parity("samples/hwp_table_test_saved.hwp", 400);
+    }
+
+    /// [#4149] fast path 웜 지연 실측 — 브라우저 IME 시나리오(같은 좌표 반복 질의)에서
+    /// 페이지 트리 재빌드(~17ms) 없이 1ms 미만이어야 한다. 콜드 1회(유닛 메모 예열)는
+    /// 측정에서 제외한다.
+    #[test]
+    fn issue4149_fast_path_giant_cell_warm_latency_beats_legacy() {
+        use std::time::Instant;
+        let (core, host_pi, host_ci, cell_idx) = issue4128_fixture();
+        // 브라우저 실측 좌표와 동일 (ppi0 ci2 cell2 para6 off5) — 픽스처가 같은 셀을 고른다.
+        let warmup = core.get_cursor_rect_in_cell_native(0, host_pi, host_ci, cell_idx, 6, 5);
+        assert!(warmup.is_ok(), "웜업 실패: {:?}", warmup.err());
+        // fast path 적중 확인 — 미적중이면 이 테스트는 legacy 지연을 재는 셈이 된다.
+        let fast = core
+            .cursor_rect_in_cell_fast(0, host_pi, host_ci, cell_idx, 6, 5)
+            .expect("fast");
+        assert!(fast.is_some(), "perf 대상 좌표에서 fast path 미적중");
+
+        // 절대 벽시계 기준은 러너 속도에 종속돼 CI 에서 거짓 실패한다(실측: 로컬
+        // 0.6ms/CI 1ms+). 같은 프로세스에서 legacy 대비 배율로 판정한다 — fast 의
+        // 핵심 주장은 "페이지 트리 재빌드 회피"이므로 배율이 기계 무관 신호다.
+        let iters = 10;
+        let t = Instant::now();
+        for _ in 0..iters {
+            let _ = core
+                .get_cursor_rect_in_cell_native(0, host_pi, host_ci, cell_idx, 6, 5)
+                .expect("rect");
+        }
+        let fast_ms = t.elapsed().as_secs_f64() * 1000.0 / iters as f64;
+        let t = Instant::now();
+        for _ in 0..iters {
+            let _ = core
+                .cursor_rect_in_cell_via_page_tree(0, host_pi, host_ci, cell_idx, 6, 5)
+                .expect("legacy rect");
+        }
+        let legacy_ms = t.elapsed().as_secs_f64() * 1000.0 / iters as f64;
+        eprintln!("#4149 웜 지연: fast {fast_ms:.3}ms vs legacy {legacy_ms:.3}ms/call");
+        assert!(
+            fast_ms * 4.0 < legacy_ms,
+            "fast path 웜 지연 {fast_ms:.3}ms 가 legacy {legacy_ms:.3}ms 의 1/4 미만이 아니다 \
+             — 페이지 트리 재빌드 회피가 회귀했는지 확인 (로컬 실측 약 28배)"
+        );
     }
 }

--- a/src/document_core/queries/field_query.rs
+++ b/src/document_core/queries/field_query.rs
@@ -1421,6 +1421,9 @@ fn remove_field_in_para(para: &mut Paragraph, char_offset: usize) -> Result<(), 
 /// 원본 char_offsets에서 컨트롤 배치 패턴을 보존하면서,
 /// 텍스트 길이 변경(필드 값 삽입)에 맞게 오프셋을 재계산한다.
 pub(crate) fn rebuild_char_offsets(para: &mut Paragraph) {
+    // [#4149] 호출부는 방금 text/controls 수술을 마친 상태다 (필드 제거·필드값
+    // 기입·클립보드 트림 등, 셀 문단 포함) — 단일줄 과밀 memo 무효화의 수렴점.
+    para.invalidate_single_line_overflow_memo();
     let text_chars: Vec<char> = para.text.chars().collect();
     let text_len = text_chars.len();
 

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -470,7 +470,7 @@ fn uses_hwp3_origin_page_tolerance(document: &Document) -> bool {
     para_shape_ratio < 0.05 && char_shape_ratio < 0.15
 }
 
-fn uses_hwp3_origin_flow_spacing_before(document: &Document) -> bool {
+pub(crate) fn uses_hwp3_origin_flow_spacing_before(document: &Document) -> bool {
     // HWP3-origin HWP5 변환본은 parser 단계에서 ParaShape spacing 계열을 절반으로
     // 정규화하므로, 본문 흐름 계산에서는 원래 spacing_before를 복원한다.
     // 원본 HWP3는 HWP3 parser가 만든 spacing 값을 기준으로 삼아 여기서 재확대하지 않는다.

--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -56,6 +56,80 @@ pub struct Paragraph {
     /// None = 앞 번호 목록에 이어 (기본)
     /// Some(NumberingRestart) = 이전 번호 이어 / 새 번호 시작
     pub numbering_restart: Option<NumberingRestart>,
+    /// [#4149] 셀 단일줄 과밀 판정 memo — `recompose_stored_single_line_if_overflowing`
+    /// 전용 파생 캐시. 판정 입력은 (text, char_shapes, 셀 내폭)뿐이다. 제약:
+    /// - 직렬화 금지: `Paragraph` 는 serde derive 가 없고 HWP/HWPX 저장기는 필드를
+    ///   명시 기록하므로 파일로 새지 않는다. 새 직렬화 경로를 추가하면 이 필드를 제외할 것.
+    /// - 스레드: `DocumentCore` 의 `Send` 단언이 `Arc<Vec<Paragraph>>`
+    ///   (document_core/mod.rs render normalization 캐시) 경유로 `Paragraph: Sync` 를
+    ///   요구한다 — `Cell` 불가, `AtomicU64` 패킹 사용.
+    /// - text/char_shapes 를 바꾸는 모든 경로는 `invalidate_single_line_overflow_memo`
+    ///   호출 필수 (Clone 은 memo 를 함께 복제하지만, 복제본도 자기 상태 기준으로
+    ///   유효하므로 안전 — 이후 변이 시 무효화 규약은 동일하게 적용).
+    pub single_line_overflow_memo: SingleLineOverflowMemo,
+}
+
+/// [#4149] 단일줄 과밀 판정 memo 저장소 — `AtomicU64` 1개에 (폭 키, 판정) 패킹.
+///
+/// 인코딩: `0` = 미판정. 그 외 `(width_key as u64) << 1 | overflowed`.
+/// `width_key` 는 셀 내폭의 `f32` 비트 — guard 가 내폭 > 0 을 보장하므로 키가 0 이
+/// 될 수 없어 유효 인코딩은 sentinel `0` 과 충돌하지 않는다. 폭이 바뀌면(셀 크기
+/// 조정) 키 불일치로 자연 재판정된다. f32 축약의 키 충돌은 인접 ulp 폭(상대 ~2⁻²⁴)
+/// 뿐이라 ×1.8 임계 판정에 영향이 없다.
+///
+/// `Relaxed` 순서로 충분하다 — 값은 (문단, 폭)의 결정적 함수라 경합 시 최악이
+/// 중복 측정일 뿐 오답이 없다.
+#[derive(Debug, Default)]
+pub struct SingleLineOverflowMemo(std::sync::atomic::AtomicU64);
+
+impl SingleLineOverflowMemo {
+    /// 셀 내폭(px) → memo 폭 키.
+    #[inline]
+    pub fn width_key(cell_inner_width_px: f64) -> u32 {
+        (cell_inner_width_px as f32).to_bits()
+    }
+
+    /// 저장된 판정 조회 — 폭 키가 일치할 때만 `Some(overflowed)`.
+    #[inline]
+    pub fn get(&self, width_key: u32) -> Option<bool> {
+        let v = self.0.load(std::sync::atomic::Ordering::Relaxed);
+        if v != 0 && (v >> 1) as u32 == width_key {
+            Some(v & 1 == 1)
+        } else {
+            None
+        }
+    }
+
+    /// 판정 저장. `width_key == 0`(내폭 ≤ 0)은 sentinel 과 겹치므로 저장하지 않는다.
+    #[inline]
+    pub fn set(&self, width_key: u32, overflowed: bool) {
+        if width_key == 0 {
+            return;
+        }
+        let v = ((width_key as u64) << 1) | (overflowed as u64);
+        self.0.store(v, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// 미판정 상태로 되돌린다.
+    #[inline]
+    pub fn clear(&self) {
+        self.0.store(0, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// 미판정 여부 (invalidation 검증용).
+    #[inline]
+    pub fn is_unjudged(&self) -> bool {
+        self.0.load(std::sync::atomic::Ordering::Relaxed) == 0
+    }
+}
+
+impl Clone for SingleLineOverflowMemo {
+    fn clone(&self) -> Self {
+        // 파생 캐시 복제 — 복제본도 자기 (text, char_shapes) 기준으로 유효하다.
+        Self(std::sync::atomic::AtomicU64::new(
+            self.0.load(std::sync::atomic::Ordering::Relaxed),
+        ))
+    }
 }
 
 /// 문단 스코프 메타데이터 — 문단 병합의 역연산(undo)에서 복원해야 하는 값들.
@@ -497,6 +571,12 @@ impl Paragraph {
         }
     }
 
+    /// [#4149] 단일줄 과밀 판정 memo 무효화 — text/char_shapes 를 바꾸는 경로 필수.
+    #[inline]
+    pub fn invalidate_single_line_overflow_memo(&self) {
+        self.single_line_overflow_memo.clear();
+    }
+
     /// 문자의 UTF-16 코드 유닛 수를 반환한다.
     fn char_utf16_len(c: char) -> u32 {
         if (c as u32) > 0xFFFF {
@@ -519,6 +599,8 @@ impl Paragraph {
         if self.char_offsets.is_empty() {
             return;
         }
+        // [#4149] 인라인 컨트롤 삽입은 char_shapes 경계를 옮긴다 — memo 무효화 (보수적).
+        self.invalidate_single_line_overflow_memo();
         let text_len = self.text.chars().count();
         let safe_offset = char_offset.min(text_len);
         // 컨트롤이 삽입되는 UTF-16 위치 — char_offsets 시프트 전에 계산한다.
@@ -567,6 +649,8 @@ impl Paragraph {
         if new_text.is_empty() {
             return char_offset.min(self.text.chars().count());
         }
+        // [#4149] text 변이 — 단일줄 과밀 memo 무효화.
+        self.invalidate_single_line_overflow_memo();
 
         let text_chars: Vec<char> = self.text.chars().collect();
         let text_len = text_chars.len();
@@ -720,6 +804,9 @@ impl Paragraph {
             return 0;
         }
 
+        // [#4149] text 변이 — 단일줄 과밀 memo 무효화.
+        self.invalidate_single_line_overflow_memo();
+
         // 실제 삭제할 문자 수 (범위 클램핑)
         let actual_count = count.min(text_len - char_offset);
         let del_end = char_offset + actual_count;
@@ -850,6 +937,9 @@ impl Paragraph {
     /// 분할의 시맨틱이다. 병합의 역연산으로 쓰는 호출부는 `apply_meta` 로 사라진
     /// 문단의 원래 값을 되돌려야 한다 (Task #2342).
     pub fn split_at(&mut self, char_offset: usize) -> Paragraph {
+        // [#4149] 분할은 양쪽 text 를 모두 바꾼다 — 앞 절반 memo 무효화.
+        // 새 절반은 아래 구성에서 미판정(None)으로 시작한다.
+        self.invalidate_single_line_overflow_memo();
         let control_positions = self.split_logical_control_positions();
         let split_pos = self.split_text_pos_for_logical_offset(char_offset, &control_positions);
         let text_chars: Vec<char> = self.text.chars().collect();
@@ -1101,6 +1191,8 @@ impl Paragraph {
             has_para_text: new_has_para_text,
             tab_extended: Vec::new(),
             numbering_restart: None,
+            // [#4149] 분할 산출 문단은 미판정으로 시작한다.
+            single_line_overflow_memo: SingleLineOverflowMemo::default(),
         }
     }
 
@@ -1113,6 +1205,8 @@ impl Paragraph {
         if other.text.is_empty() && other.controls.is_empty() {
             return self.text.chars().count();
         }
+        // [#4149] 병합은 text/char_shapes 를 바꾼다 — memo 무효화 (미판정 재시작).
+        self.invalidate_single_line_overflow_memo();
 
         let self_text_len = self.text.chars().count();
 
@@ -1451,6 +1545,8 @@ impl Paragraph {
         if start_char_offset >= end_char_offset || self.char_offsets.is_empty() {
             return;
         }
+        // [#4149] char_shapes 변이 — 단일줄 과밀 memo 무효화.
+        self.invalidate_single_line_overflow_memo();
         if self.char_shapes.is_empty() {
             self.char_shapes.push(CharShapeRef {
                 start_pos: 0,
@@ -1574,6 +1670,8 @@ impl Paragraph {
 
     /// 문단의 글자 모양을 단일 CharShapeRef로 초기화한다.
     pub fn set_single_char_shape(&mut self, char_shape_id: u32) {
+        // [#4149] char_shapes 변이 — 단일줄 과밀 memo 무효화.
+        self.invalidate_single_line_overflow_memo();
         self.char_shapes.clear();
         self.char_shapes.push(CharShapeRef {
             start_pos: 0,
@@ -1601,6 +1699,8 @@ impl Paragraph {
         }
 
         if replaced {
+            // [#4149] char_shapes 변이 — 단일줄 과밀 memo 무효화.
+            self.invalidate_single_line_overflow_memo();
             self.merge_adjacent_char_shapes();
         }
     }

--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -9,7 +9,7 @@ use super::style_resolver::{detect_lang_category, ResolvedStyleSet};
 use super::{px_to_hwpunit, TextStyle};
 use crate::model::control::Control;
 use crate::model::document::Section;
-use crate::model::paragraph::{CharShapeRef, LineSeg, Paragraph};
+use crate::model::paragraph::{CharShapeRef, LineSeg, Paragraph, SingleLineOverflowMemo};
 
 /// 글자겹침(CharOverlap) 렌더링 정보
 #[derive(Debug, Clone, serde::Serialize)]
@@ -1528,11 +1528,28 @@ pub fn recompose_stored_single_line_if_overflowing(
     // `stored_lines_overflow`(#2525)와 동일하게 ×1.8 로 좁혀 정당한 장평/자간·
     // 패딩 발산 범위(≤~1.5×)를 넘는 부실 저장만 재래핑한다. #2291 원 타깃
     // (76자 1-lineseg = ~7.6× 초과, 절단 해소)은 임계 위라 계속 재래핑.
-    let over = composed
-        .lines
-        .first()
-        .map(|l| estimate_composed_line_width(l, styles) > cell_inner_width_px * 1.8)
-        .unwrap_or(false);
+    //
+    // [#4149] 판정 memo — 같은 (문단 text·char_shapes, 셀 내폭)이면 판정이 결정적
+    // 인데, 페이지 트리 재빌드마다 estimate_composed_line_width 재측정이 반복돼
+    // 거대 셀 문서의 캐럿 rect 질의당 ~30% 를 차지했다. 폭 키(f32 bits 패킹)로
+    // 판정만 memo 하고(측정 생략), over=true 의 fresh 재래핑 자체는 매 빌드 그대로
+    // 수행한다 — 재래핑 결과는 composed 에만 반영되고 저장 line_segs 는 안 바뀌므로
+    // 재래핑을 생략하면 절단 렌더 회귀. text/char_shapes 변경 경로는
+    // `invalidate_single_line_overflow_memo` 로 비운다 (셀 크기 조정은 키 불일치로
+    // 자연 재판정).
+    let width_key = SingleLineOverflowMemo::width_key(cell_inner_width_px);
+    let over = match para.single_line_overflow_memo.get(width_key) {
+        Some(memoized) => memoized,
+        None => {
+            let measured = composed
+                .lines
+                .first()
+                .map(|l| estimate_composed_line_width(l, styles) > cell_inner_width_px * 1.8)
+                .unwrap_or(false);
+            para.single_line_overflow_memo.set(width_key, measured);
+            measured
+        }
+    };
     if std::env::var("RHWP_DIAG_CELLREWRAP").is_ok() && over {
         if let Some(l) = composed.lines.first() {
             for run in &l.runs {

--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -1093,6 +1093,9 @@ pub(crate) fn reflow_line_segs(
     styles: &ResolvedStyleSet,
     dpi: f64,
 ) {
+    // [#4149] 셀 편집의 단일 관문(reflow_cell_paragraph[_by_path])과 서식 적용
+    // (formatting.rs) 이 모두 여기로 수렴한다 — 단일줄 과밀 memo 무효화.
+    para.invalidate_single_line_overflow_memo();
     // 기존 LineSeg에서 dimension 값 보존 (원본 HWP 호환성 유지)
     let seg_width_hwp = px_to_hwpunit(available_width_px, dpi);
     let orig = para.line_segs.first().cloned();

--- a/src/renderer/composer/tests.rs
+++ b/src/renderer/composer/tests.rs
@@ -1388,3 +1388,198 @@ fn test_kbu1_line_start_forbidden_retraction() {
         "retraction 후 char_start 는 '다' 위치"
     );
 }
+
+// ───────────────────── [#4149] 셀 단일줄 과밀 판정 memo ─────────────────────
+
+/// 가드 전제(저장 단일 lineseg, 비합성 tag)를 만족하는 문단.
+fn issue4149_guard_para(text: &str) -> Paragraph {
+    let n = text.chars().count();
+    Paragraph {
+        text: text.to_string(),
+        char_offsets: (0..n as u32).collect(),
+        char_count: n as u32 + 1,
+        char_shapes: vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 0,
+        }],
+        // 저장 단일 lineseg (tag=0 → TAG_IMPLEMENTATION_PROPERTY 미설정 = 비합성).
+        line_segs: vec![LineSeg {
+            text_start: 0,
+            line_height: 800,
+            baseline_distance: 640,
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+/// 첫 판정이 memo 되고, memo hit 에도 over=true 의 fresh 재래핑은 매 빌드 수행된다 —
+/// 재래핑 결과는 composed 에만 반영되고 저장 line_segs 는 안 바뀌므로 생략하면
+/// 절단 렌더 회귀(#2291).
+#[test]
+fn issue4149_overflow_judgment_memoized_and_rewrap_still_runs_on_hit() {
+    let styles = crate::renderer::style_resolver::ResolvedStyleSet::default();
+    let para = issue4149_guard_para(&"가".repeat(60));
+    let width = 50.0; // 60자 실폭 ≫ 50×1.8
+    let key = crate::model::paragraph::SingleLineOverflowMemo::width_key(width);
+    assert!(para.single_line_overflow_memo.is_unjudged());
+
+    let mut composed = compose_paragraph(&para);
+    assert_eq!(composed.lines.len(), 1);
+    recompose_stored_single_line_if_overflowing(&mut composed, &para, width, &styles);
+    assert!(
+        composed.lines.len() > 1,
+        "과밀 저장 단일줄은 fresh 재래핑돼야 함"
+    );
+    assert_eq!(
+        para.single_line_overflow_memo.get(key),
+        Some(true),
+        "판정이 (폭 키, over) 로 memo 돼야 함"
+    );
+
+    // 두 번째 페이지 빌드 (memo hit): 측정 생략, 재래핑은 수행.
+    let mut composed2 = compose_paragraph(&para);
+    assert_eq!(composed2.lines.len(), 1);
+    recompose_stored_single_line_if_overflowing(&mut composed2, &para, width, &styles);
+    assert!(
+        composed2.lines.len() > 1,
+        "memo hit 에도 재래핑은 수행돼야 함 (절단 렌더 회귀 방지)"
+    );
+}
+
+/// memo hit 시 실폭 측정(estimate_composed_line_width)이 생략됨을 모순 memo 로
+/// 증명한다 — 실측이면 over=true 로 재래핑될 문단에 over=false memo 를 주입했을 때
+/// 재래핑이 일어나지 않으면 측정이 생략된 것이다 (= 같은 문단 2회 판정에 측정 1회).
+#[test]
+fn issue4149_memo_hit_skips_width_measurement() {
+    let styles = crate::renderer::style_resolver::ResolvedStyleSet::default();
+    let para = issue4149_guard_para(&"가".repeat(60));
+    let width = 50.0;
+    let key = crate::model::paragraph::SingleLineOverflowMemo::width_key(width);
+    para.single_line_overflow_memo.set(key, false); // 실측(true)과 모순인 memo
+
+    let mut composed = compose_paragraph(&para);
+    recompose_stored_single_line_if_overflowing(&mut composed, &para, width, &styles);
+    assert_eq!(
+        composed.lines.len(),
+        1,
+        "memo hit 시 재측정 없이 판정을 재사용해야 함"
+    );
+    assert_eq!(
+        para.single_line_overflow_memo.get(key),
+        Some(false),
+        "hit 경로는 memo 를 덮어쓰지 않아야 함"
+    );
+}
+
+/// 폭이 바뀌면(셀 크기 조정) 키 불일치로 자연 재판정된다.
+#[test]
+fn issue4149_width_change_re_judges_via_key_mismatch() {
+    let styles = crate::renderer::style_resolver::ResolvedStyleSet::default();
+    let para = issue4149_guard_para(&"가".repeat(60));
+    let narrow = 50.0;
+    // 넓은 폭에서의 기존 판정(over=false)이 남아 있는 상태.
+    para.single_line_overflow_memo.set(
+        crate::model::paragraph::SingleLineOverflowMemo::width_key(5000.0),
+        false,
+    );
+
+    let mut composed = compose_paragraph(&para);
+    recompose_stored_single_line_if_overflowing(&mut composed, &para, narrow, &styles);
+    assert!(
+        composed.lines.len() > 1,
+        "폭 키 불일치 시 재측정으로 과밀을 다시 잡아야 함"
+    );
+    assert_eq!(
+        para.single_line_overflow_memo.get(
+            crate::model::paragraph::SingleLineOverflowMemo::width_key(narrow)
+        ),
+        Some(true)
+    );
+}
+
+/// 정합(비과밀) 판정도 memo 되고 재래핑은 일어나지 않는다.
+#[test]
+fn issue4149_fit_judgment_memoized_false_without_rewrap() {
+    let styles = crate::renderer::style_resolver::ResolvedStyleSet::default();
+    let para = issue4149_guard_para("가나다");
+    let width = 5000.0;
+    let mut composed = compose_paragraph(&para);
+    recompose_stored_single_line_if_overflowing(&mut composed, &para, width, &styles);
+    assert_eq!(
+        composed.lines.len(),
+        1,
+        "정합 단일줄은 재래핑하지 않아야 함"
+    );
+    assert_eq!(
+        para.single_line_overflow_memo.get(
+            crate::model::paragraph::SingleLineOverflowMemo::width_key(width)
+        ),
+        Some(false)
+    );
+}
+
+/// text/char_shapes 를 바꾸는 모든 경로에서 memo 가 미판정으로 돌아간다.
+/// (셀 편집의 단일 관문 reflow_cell_paragraph[_by_path]는 reflow_line_segs 로
+/// 수렴한다 — document_core 관문 자체는 text_editing.rs 테스트에서 검증.)
+#[test]
+fn issue4149_memo_invalidated_by_mutation_paths() {
+    let styles = crate::renderer::style_resolver::ResolvedStyleSet::default();
+    let key = crate::model::paragraph::SingleLineOverflowMemo::width_key(500.0);
+    let prime = |p: &Paragraph| p.single_line_overflow_memo.set(key, true);
+    let mut para = issue4149_guard_para("가나다라마");
+
+    prime(&para);
+    para.insert_text_at(1, "X");
+    assert!(
+        para.single_line_overflow_memo.is_unjudged(),
+        "insert_text_at 후 미판정"
+    );
+
+    prime(&para);
+    para.delete_text_at(0, 1);
+    assert!(
+        para.single_line_overflow_memo.is_unjudged(),
+        "delete_text_at 후 미판정"
+    );
+
+    prime(&para);
+    para.apply_char_shape_range(0, 2, 7);
+    assert!(
+        para.single_line_overflow_memo.is_unjudged(),
+        "apply_char_shape_range 후 미판정"
+    );
+
+    prime(&para);
+    para.set_single_char_shape(0);
+    assert!(
+        para.single_line_overflow_memo.is_unjudged(),
+        "set_single_char_shape 후 미판정"
+    );
+
+    prime(&para);
+    reflow_line_segs(&mut para, 300.0, &styles, 96.0);
+    assert!(
+        para.single_line_overflow_memo.is_unjudged(),
+        "reflow_line_segs(셀 편집 관문의 수렴점) 후 미판정"
+    );
+
+    prime(&para);
+    let new_half = para.split_at(2);
+    assert!(
+        para.single_line_overflow_memo.is_unjudged(),
+        "split_at 앞 절반 미판정"
+    );
+    assert!(
+        new_half.single_line_overflow_memo.is_unjudged(),
+        "split_at 산출 문단은 미판정으로 시작"
+    );
+
+    prime(&para);
+    let other = issue4149_guard_para("바사");
+    para.merge_from(&other);
+    assert!(
+        para.single_line_overflow_memo.is_unjudged(),
+        "merge_from 후 미판정"
+    );
+}

--- a/src/renderer/font_metrics_data.rs
+++ b/src/renderer/font_metrics_data.rs
@@ -3,6 +3,9 @@
 //! font-metric-gen 도구로 TTF 파일에서 추출.
 //! 수동 편집 금지.
 
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
 #[derive(Debug)]
 pub struct HangulMetric {
     pub cho_groups: u8,
@@ -155,7 +158,79 @@ fn resolve_metric_alias(name: &str) -> &str {
     }
 }
 
+/// (bold, italic) → 색인 슬롯 번호. 조합이 4개뿐이라 이름당 배열로 선계산한다.
+fn metric_slot_index(bold: bool, italic: bool) -> usize {
+    ((bold as usize) << 1) | (italic as usize)
+}
+
+/// 이름별 선계산 색인 — 슬롯 값은 (metric, bold_fallback).
+///
+/// [#4149] 글자 측정마다 find_metric 이 호출되어 600 엔트리 선형 스캔
+/// (문자열 비교 × 최대 3단 폴백)이 캐럿 rect 질의 지연의 주요 원인이었다.
+/// 이름이 테이블에 있으면 3단(이름만 매칭)이 항상 성공하므로 슬롯에 Option 이
+/// 필요 없고, 조회 실패 = 이름 부재 = 기존 None 과 동일하다.
+///
+/// 키를 (name, bold, italic) 튜플 대신 이름 단독으로 두는 이유: 튜플 키는
+/// &'static str 수명 때문에 임의 사용자 폰트명(&str)으로 borrow 조회가 불가능하다.
+static METRIC_INDEX: OnceLock<HashMap<&'static str, [(&'static FontMetric, bool); 4]>> =
+    OnceLock::new();
+
+fn metric_index() -> &'static HashMap<&'static str, [(&'static FontMetric, bool); 4]> {
+    METRIC_INDEX.get_or_init(|| {
+        // 선형 스캔의 "테이블 첫 매칭 우선" 계약 재현: 테이블 순서대로 순회하며
+        // (name, bold, italic) 조합별 첫 엔트리와 이름 첫 등장 엔트리만 기록한다.
+        struct FirstSeen {
+            exact: [Option<&'static FontMetric>; 4],
+            first: &'static FontMetric,
+        }
+        let mut seen: HashMap<&'static str, FirstSeen> = HashMap::new();
+        for m in FONT_METRICS.iter() {
+            let entry = seen.entry(m.name).or_insert(FirstSeen {
+                exact: [None; 4],
+                first: m,
+            });
+            let idx = metric_slot_index(m.bold, m.italic);
+            if entry.exact[idx].is_none() {
+                entry.exact[idx] = Some(m);
+            }
+        }
+        // 슬롯 선주입 순서 = legacy 폴백 사다리와 동일:
+        // 1단 정확 매칭 → 2단 bold 매칭(italic 무시) → 3단 이름만 첫 엔트리.
+        seen.into_iter()
+            .map(|(name, fs)| {
+                let mut slots = [(fs.first, false); 4];
+                for bold in [false, true] {
+                    for italic in [false, true] {
+                        slots[metric_slot_index(bold, italic)] =
+                            if let Some(m) = fs.exact[metric_slot_index(bold, italic)] {
+                                (m, false)
+                            } else if let Some(m) = fs.exact[metric_slot_index(bold, false)] {
+                                (m, false)
+                            } else {
+                                // bold 요청이었으면 Faux Bold 보정 표시 (legacy 3단과 동일)
+                                (fs.first, bold)
+                            };
+                    }
+                }
+                (name, slots)
+            })
+            .collect()
+    })
+}
+
 pub fn find_metric(name: &str, bold: bool, italic: bool) -> Option<MetricMatch> {
+    let name = resolve_metric_alias(name);
+    let slots = metric_index().get(name)?;
+    let (metric, bold_fallback) = slots[metric_slot_index(bold, italic)];
+    Some(MetricMatch {
+        metric,
+        bold_fallback,
+    })
+}
+
+/// 기존 선형 스캔 구현 — 색인 등가성 검증 전용으로 보존 (수정 금지).
+#[cfg(test)]
+fn legacy_find_metric(name: &str, bold: bool, italic: bool) -> Option<MetricMatch> {
     let name = resolve_metric_alias(name);
     // 정확한 매칭 (name + bold + italic)
     if let Some(m) = FONT_METRICS
@@ -46229,5 +46304,125 @@ mod tests {
         let m = find_metric("함초롬바탕", false, false);
         assert!(m.is_some(), "함초롬바탕 기존 매핑 회귀");
         assert_eq!(m.unwrap().metric.name, "HCR Batang");
+    }
+
+    #[test]
+    fn index_matches_legacy_linear_scan_exhaustively() {
+        // [#4149] O(1) 색인 도입 계약: legacy 선형 스캔(3단 폴백 사다리)과
+        // 결과가 100% 동일해야 한다. FONT_METRICS 전체 name + 알려진 alias
+        // 전체 + 테이블에 없는 임의 이름 × (bold, italic) 4조합 전수 비교.
+        let mut names: Vec<&str> = FONT_METRICS.iter().map(|m| m.name).collect();
+        // resolve_metric_alias 좌변 전체 (별칭 추가 시 여기도 갱신).
+        names.extend([
+            "함초롬돋움",
+            "한컴돋움",
+            "돋움",
+            "함초롬바탕",
+            "한컴바탕",
+            "바탕",
+            "맑은 고딕",
+            "나눔고딕",
+            "나눔명조",
+            "바탕체",
+            "굴림",
+            "궁서",
+            "굴림체",
+            "돋움체",
+            "궁서체",
+            "D2Coding",
+            "D2 Coding",
+            "고운바탕",
+            "Gowun Batang",
+            "고운돋움",
+            "Gowun Dodum",
+            "Pretendard",
+            "프리텐다드",
+            "HY중고딕",
+            "HY견고딕",
+            "HY헤드라인M",
+            "HY견명조",
+            "HY신명조",
+            "HY그래픽",
+            "HY궁서",
+            "한양신명조",
+            "한양중고딕",
+            "한양견명조",
+            "한양견고딕",
+            "휴먼명조",
+            "신명조",
+            "HY수평선B",
+            "HY수평선M",
+            "HY울릉도B",
+            "HY울릉도M",
+            "HY태백B",
+            "HY동녘B",
+            "HY동녘M",
+            "HY각헤드라인M",
+            "본한글",
+            "본한글vf",
+            "본한글 Medium",
+            "본한글M",
+            "본고딕",
+            "본고딕vf",
+            "Source Han Sans",
+            "Source Han Sans K",
+            "Source Han Sans KR",
+            "SourceHanSans",
+            "SourceHanSansKR",
+            "SourceHanSansK",
+            "Noto Sans CJK KR",
+            "본명조",
+            "본명조vf",
+            "본명조M",
+            "Source Han Serif",
+            "Source Han Serif K",
+            "Source Han Serif KR",
+            "SourceHanSerif",
+            "SourceHanSerifKR",
+            "SourceHanSerifK",
+            "Noto Serif CJK KR",
+        ]);
+        // 테이블에 없는 임의 사용자 폰트명 — 기존과 동일하게 None 이어야 한다.
+        names.extend([
+            "NoSuchFont-Regular",
+            "가상의사용자폰트",
+            "Comic Sans MS",
+            "",
+        ]);
+
+        for name in names {
+            for bold in [false, true] {
+                for italic in [false, true] {
+                    let new = find_metric(name, bold, italic);
+                    let old = legacy_find_metric(name, bold, italic);
+                    match (new, old) {
+                        (None, None) => {}
+                        (Some(n), Some(o)) => {
+                            assert!(
+                                std::ptr::eq(n.metric, o.metric),
+                                "metric 불일치: {name:?} bold={bold} italic={italic} \
+                                 (new={}/b{}/i{}, old={}/b{}/i{})",
+                                n.metric.name,
+                                n.metric.bold,
+                                n.metric.italic,
+                                o.metric.name,
+                                o.metric.bold,
+                                o.metric.italic,
+                            );
+                            assert_eq!(
+                                n.bold_fallback, o.bold_fallback,
+                                "bold_fallback 불일치: {name:?} bold={bold} italic={italic}"
+                            );
+                        }
+                        (n, o) => panic!(
+                            "Some/None 불일치: {name:?} bold={bold} italic={italic} \
+                             new={} old={}",
+                            n.is_some(),
+                            o.is_some()
+                        ),
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -1797,6 +1797,10 @@ pub struct LayoutEngine {
     /// `cell_units_uncached` 안에서 계산되어 52,694 셀 표에서 O(셀²)(≈28억) 로 폭증했다.
     /// `cell_units_cache` 와 동일 조판 경계에서 clear 한다.
     table_nested_text_flag_cache: std::cell::RefCell<std::collections::HashMap<usize, bool>>,
+    /// [#4149] 셀 커서 fast path 프로브 차단 스캔(개요/번호 문단·AutoNumber 컨트롤
+    /// 보유 여부)의 표 포인터 키 메모 — 거대 표 서브트리 재스캔 방지.
+    /// `cell_units_cache` 와 동일 조판 경계에서 clear 한다.
+    cursor_probe_block_cache: std::cell::RefCell<std::collections::HashMap<usize, bool>>,
     /// Issue #2214 test-only: cache miss가 실제 table-wide scan으로 이어진 횟수.
     #[cfg(test)]
     table_nested_text_flag_scan_count: std::cell::Cell<usize>,
@@ -1814,6 +1818,8 @@ mod utils;
 
 pub(crate) use paragraph_layout::ensure_min_baseline;
 pub(crate) use table_layout::border_style_has_diagonal;
+// [#4149] 셀 커서 fast path 프로브 (document_core::queries::cursor_rect 전용)
+pub(crate) use table_partial::{PartialTableCellProbe, ProbeCutPlan};
 pub(crate) use text_measurement::{
     compute_char_positions, estimate_text_width, estimate_text_width_unrounded,
     extract_tab_leaders_with_extended, find_next_tab_stop, is_cjk_char, is_halfwidth_cjk_quote,
@@ -1876,6 +1882,7 @@ impl LayoutEngine {
             hwpx_page_preview: std::cell::RefCell::new(None),
             cell_units_cache: std::cell::RefCell::new(std::collections::HashMap::new()),
             table_nested_text_flag_cache: std::cell::RefCell::new(std::collections::HashMap::new()),
+            cursor_probe_block_cache: std::cell::RefCell::new(std::collections::HashMap::new()),
             #[cfg(test)]
             table_nested_text_flag_scan_count: std::cell::Cell::new(0),
         }
@@ -1886,6 +1893,7 @@ impl LayoutEngine {
     pub fn clear_layout_caches(&self) {
         self.cell_units_cache.borrow_mut().clear();
         self.table_nested_text_flag_cache.borrow_mut().clear();
+        self.cursor_probe_block_cache.borrow_mut().clear();
     }
 
     pub(crate) fn set_render_normalization_overlay(
@@ -4884,6 +4892,25 @@ impl LayoutEngine {
         }
     }
 
+    /// 단(column) 콘텐츠 레이아웃 전에 페이지 좌표계 상태를 채운다.
+    /// build_single_column 과 [#4149] 셀 커서 fast path 프로브가 공유한다 —
+    /// 프로브가 전량 빌드와 동일한 좌표계(용지 폭/본문 영역)에서 동작해야
+    /// cell_units 메모 등 포인터-키 캐시가 동일 값으로 채워진다.
+    pub(crate) fn prime_column_layout_env(&self, layout: &PageLayoutInfo) {
+        // 현재 페이지 용지 너비 설정 (표 HorzRelTo::Paper 위치 계산용)
+        self.current_paper_width.set(layout.page_width);
+        // [#3637] 쪽 높이도 여기서 채운다. 바탕쪽 분기(위)에서만 채우면 바탕쪽 없는
+        // 문서에서 0 으로 남아 셀 넘침 진단이 통째로 침묵한다.
+        self.current_page_height.set(layout.page_height);
+        // 현재 페이지 본문 영역 설정 (표 HorzRelTo::Page / VertRelTo::Page 계산용 — Task #347)
+        let ba = &layout.body_area;
+        self.current_body_area
+            .set((ba.x, ba.y, ba.width, ba.height));
+
+        // 문단 테두리 범위 수집 초기화
+        self.para_border_ranges.borrow_mut().clear();
+    }
+
     fn build_single_column(
         &self,
         tree: &mut PageRenderTree,
@@ -4909,18 +4936,7 @@ impl LayoutEngine {
             layout_rect_to_bbox(col_area),
         );
 
-        // 현재 페이지 용지 너비 설정 (표 HorzRelTo::Paper 위치 계산용)
-        self.current_paper_width.set(layout.page_width);
-        // [#3637] 쪽 높이도 여기서 채운다. 바탕쪽 분기(위)에서만 채우면 바탕쪽 없는
-        // 문서에서 0 으로 남아 셀 넘침 진단이 통째로 침묵한다.
-        self.current_page_height.set(layout.page_height);
-        // 현재 페이지 본문 영역 설정 (표 HorzRelTo::Page / VertRelTo::Page 계산용 — Task #347)
-        let ba = &layout.body_area;
-        self.current_body_area
-            .set((ba.x, ba.y, ba.width, ba.height));
-
-        // 문단 테두리 범위 수집 초기화
-        self.para_border_ranges.borrow_mut().clear();
+        self.prime_column_layout_env(layout);
 
         // TopAndBottom 글상자/표/이미지의 앵커 문단별 예약 높이 목록
         let mut shape_reserved = self.calculate_shape_reserved_heights(
@@ -8348,6 +8364,7 @@ impl LayoutEngine {
             pt_margin_right,
             pt_mt,
             false,
+            None,
         );
         if render_deferred_rowbreak_host_text_after {
             if let Some(para) = paragraphs.get(para_index) {

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -458,8 +458,9 @@ pub(super) struct CellUnit {
     /// 반드시 보존한다. 문단 사이 reset의 orphan/sliver 완화 계약과 구분한다.
     stored_frame_break_before: bool,
     vpos_gap_before: bool,
-    /// 이 유닛이 속한 문단 인덱스 (셀 내).
-    para_idx: usize,
+    /// 이 유닛이 속한 문단 인덱스 (셀 내). [#4149] 커서 프로브 계획이 창 문단
+    /// 범위를 계산할 때 형제 모듈(table_partial)에서 읽는다.
+    pub(super) para_idx: usize,
     /// 이 유닛이 visible 일 때 기여하는 문단 내 줄 범위 `[vis_start, vis_end)`.
     /// 텍스트 줄 유닛 = `(li, li+1)`, 중첩/빈 atom = `(0, line_count.max(1))`.
     vis_start: usize,

--- a/src/renderer/layout/table_partial.rs
+++ b/src/renderer/layout/table_partial.rs
@@ -1,6 +1,6 @@
 //! 페이지 분할 표 레이아웃 (layout_partial_table)
 
-use super::super::composer::compose_paragraph;
+use super::super::composer::{compose_paragraph, ComposedParagraph};
 use super::super::height_measurer::MeasuredTable;
 use super::super::page_layout::LayoutRect;
 use super::super::render_tree::*;
@@ -106,6 +106,115 @@ fn expand_terminal_cell_clip_to_nested_table_descendants(
 }
 
 // 표 수평 정렬 보조 타입은 table_layout.rs에 통합됨
+
+/// [#4149] 셀 커서 fast path 프로브 — 부분 표 조각 레이아웃을 대상 셀 하나로 제한한다.
+///
+/// 계약: 방출되는 노드의 좌표는 전량 레이아웃과 완전 동일해야 한다 — 프로브는
+/// "생략"만 하고 "변형"은 하지 않는다 (셀 방출 루프는 셀-간 캐리가 없음이 근거).
+pub(crate) struct PartialTableCellProbe {
+    /// 대상 셀 인덱스 — 이 셀만 방출한다.
+    pub(crate) cell_idx: usize,
+    /// 이 문단까지 방출 후 중단한다 (캐럿 문단 — 이후 문단은 캐럿 탐색에 불필요하고
+    /// 앞 문단의 y 에도 영향이 없다).
+    pub(crate) stop_after_para: usize,
+    /// true 면 컷 창 문단(`window_paras`)만 순회·compose 한다. 사전 게이트가
+    /// (a) 컷 존재, (b) shrink 조기탈출(다중줄 문단 존재), (c) effective Top 정렬을
+    /// 증명한 경우에만 true 가 된다.
+    pub(crate) windowed: bool,
+    /// `windowed` 일 때 컷 창에 유닛이 있는 문단 범위 [lo, hi] (inclusive).
+    /// 범위 밖 문단은 컷 창에 유닛이 없어 전량 레이아웃에서도 skip 됨이 증명된다.
+    pub(crate) window_paras: (usize, usize),
+}
+
+/// [#4149] 셀 문단 compose 저장소 — windowed 프로브에서만 lazy.
+///
+/// Lazy 슬롯의 compose 결과는 Eager 경로와 동일한 변환 순서
+/// (compose → recompose_for_cell_width → recompose_stored_single_line_if_overflowing)를
+/// 문단 단위로 적용한다. windowed 프로브 게이트가 shrink 를 조기탈출로 증명하므로
+/// Lazy 에서 inner_width 는 Eager 와 동일하다.
+enum CellComposedStore {
+    Eager(Vec<ComposedParagraph>),
+    Lazy(Vec<Option<ComposedParagraph>>),
+}
+
+impl CellComposedStore {
+    fn get(
+        &mut self,
+        cpi: usize,
+        cell: &crate::model::table::Cell,
+        inner_width: f64,
+        styles: &ResolvedStyleSet,
+    ) -> &ComposedParagraph {
+        match self {
+            CellComposedStore::Eager(v) => &v[cpi],
+            CellComposedStore::Lazy(slots) => {
+                if slots[cpi].is_none() {
+                    let para = &cell.paragraphs[cpi];
+                    let mut comp = compose_paragraph(para);
+                    crate::renderer::composer::recompose_for_cell_width(
+                        &mut comp,
+                        para,
+                        inner_width,
+                        styles,
+                    );
+                    if cell.text_direction == 0 {
+                        crate::renderer::composer::recompose_stored_single_line_if_overflowing(
+                            &mut comp,
+                            para,
+                            inner_width,
+                            styles,
+                        );
+                    }
+                    slots[cpi] = Some(comp);
+                }
+                slots[cpi].as_ref().unwrap()
+            }
+        }
+    }
+
+    /// 전량 슬라이스가 필요한 경로(세로쓰기 등)를 위한 완전 구성.
+    fn materialize(
+        &mut self,
+        cell: &crate::model::table::Cell,
+        inner_width: f64,
+        styles: &ResolvedStyleSet,
+    ) {
+        if matches!(self, CellComposedStore::Lazy(_)) {
+            let mut v = Vec::with_capacity(cell.paragraphs.len());
+            for cpi in 0..cell.paragraphs.len() {
+                v.push(self.get(cpi, cell, inner_width, styles).clone());
+            }
+            *self = CellComposedStore::Eager(v);
+        }
+    }
+
+    /// Eager 전제 슬라이스 접근 — windowed 프로브 게이트 밖에서만 호출된다.
+    fn eager_slice(&self) -> &[ComposedParagraph] {
+        match self {
+            CellComposedStore::Eager(v) => v,
+            CellComposedStore::Lazy(_) => {
+                unreachable!("windowed 프로브에서 전량 compose 접근 금지")
+            }
+        }
+    }
+}
+
+/// [#4149] 프로브 사전 계획 결과.
+pub(crate) enum ProbeCutPlan {
+    /// 프로브로 다룰 수 없는 조합 (rowspan 셀, 빈 창 등) — legacy 폴백.
+    Unsupported,
+    /// 이 조각에서 셀이 컷되지 않음 (전체 가시). 소형 셀 한정 전량 프로브 가능.
+    Uncut,
+    /// 컷 존재. `window_paras` = 창에 유닛이 있는 문단 범위 [lo, hi] (inclusive).
+    Cut {
+        window_paras: (usize, usize),
+        /// 전량 레이아웃의 `cell_was_split` 이 true 임이 증명됨 (s>0 문단 존재
+        /// 또는 창 밖 미가시 문단의 compose 줄 수 ≥ 1).
+        split_proven: bool,
+        /// 대상 문단이 창 안에 있는가 — 밖이면 이 페이지에 대상 문단 run 이 없다.
+        target_in_window: bool,
+    },
+}
 
 /// [Task #1025] `row` 를 포함하는 rowspan 블록 범위 `[b_start, b_end)`.
 /// rs>1 셀이 겹치는 행을 전이적으로 확장한다(겹침 없으면 `[row, row+1)`).
@@ -312,6 +421,200 @@ impl LayoutEngine {
         ord >= su && (ord < eu || (ord == eu && at_line_start))
     }
 
+    /// [#4149] 커서 fast path 의 프로브 사전 계획 — 이 PartialTable 조각에서 `cell` 의
+    /// 컷 창과 창 문단 범위를 계산한다. 분할 게이트 판정은
+    /// `layout_partial_table_cells` 의 셀 방출 판정과 동일 산식 — 드리프트 금지.
+    /// memoize 된 `cell_units` 만 사용하며 render tree 를 짓지 않는다.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn partial_table_cell_probe_plan(
+        &self,
+        table: &crate::model::table::Table,
+        cell: &crate::model::table::Cell,
+        start_row: usize,
+        end_row: usize,
+        start_cut: &[usize],
+        end_cut: &[usize],
+        is_block_split: bool,
+        styles: &ResolvedStyleSet,
+        target_para: usize,
+    ) -> ProbeCutPlan {
+        // rowspan 셀은 straddle 높이-컷 경로(is_rowbreak_straddle)가 얽혀 보수적 폴백.
+        if cell.row_span > 1 {
+            return ProbeCutPlan::Unsupported;
+        }
+        let cell_row = cell.row as usize;
+        let cell_end_row = cell_row + (cell.row_span as usize).max(1);
+        // 분할 게이트 — layout_partial_table_cells 와 동일 판정
+        let split_start_block = if is_block_split && !start_cut.is_empty() {
+            Some(rowspan_block_range(table, start_row))
+        } else {
+            None
+        };
+        let split_end_block = if is_block_split && !end_cut.is_empty() {
+            Some(rowspan_block_range(table, end_row.saturating_sub(1)))
+        } else {
+            None
+        };
+        let is_split_start_row = if is_block_split {
+            split_start_block.is_some_and(|(s, e)| cell_row < e && cell_end_row > s)
+        } else {
+            !start_cut.is_empty() && cell_row == start_row
+        };
+        let is_split_end_row = if is_block_split {
+            split_end_block.is_some_and(|(s, e)| cell_row < e && cell_end_row > s)
+        } else {
+            !end_cut.is_empty() && cell_row == end_row.saturating_sub(1)
+        };
+        if !(is_split_start_row || is_split_end_row) {
+            // row_span==1 이므로 is_rowbreak_straddle(rowspan>1 전제) 도달 불가 — 전체 가시.
+            return ProbeCutPlan::Uncut;
+        }
+        let (su, eu) = cell_cut_window(
+            table,
+            cell,
+            is_block_split,
+            is_split_start_row,
+            split_start_block,
+            is_split_end_row,
+            split_end_block,
+            start_cut,
+            end_cut,
+            None,
+        );
+        let units = self.cell_units(cell, table, styles);
+        let lo = su.min(units.len());
+        let hi = eu.min(units.len()).max(lo);
+        if lo >= hi {
+            return ProbeCutPlan::Unsupported;
+        }
+        let mut pmin = usize::MAX;
+        let mut pmax = 0usize;
+        for u in &units[lo..hi] {
+            pmin = pmin.min(u.para_idx);
+            pmax = pmax.max(u.para_idx);
+        }
+        if pmin == usize::MAX || pmax >= cell.paragraphs.len() {
+            return ProbeCutPlan::Unsupported;
+        }
+        // cell_was_split 증명 — 전량 레이아웃의 `s != 0 || e != total` 판정과 동치인
+        // 충분조건만 취한다:
+        //   (a) 어떤 문단의 가시 시작줄 s > 0, 또는
+        //   (b) 창 밖 미가시 문단((0,0))의 compose 줄 수 ≥ 1 (recompose 는 줄을
+        //       늘리기만 하므로 pre-recompose ≥ 1 ⇒ post ≥ 1 > 0 = e).
+        let ranges = self.cell_line_ranges_from_cut(cell, table, styles, su, eu);
+        let mut split_proven = ranges.iter().any(|&(s, _)| s > 0);
+        if !split_proven {
+            for (i, &(s, e)) in ranges.iter().enumerate() {
+                if s == 0 && e == 0 && (i < pmin || i > pmax) {
+                    if compose_paragraph(&cell.paragraphs[i]).lines.is_empty() {
+                        continue;
+                    }
+                    split_proven = true;
+                    break;
+                }
+            }
+        }
+        ProbeCutPlan::Cut {
+            window_paras: (pmin, pmax),
+            split_proven,
+            target_in_window: (pmin..=pmax).contains(&target_para),
+        }
+    }
+
+    /// [#4149] 표 서브트리(호스트 표 + 중첩 표/글상자/캡션)가 프로브를 차단하는
+    /// 상태 의존 요소를 갖는지 — 표 포인터 키 메모.
+    ///
+    /// 차단 근거: (a) 개요/번호 문단은 auto counter 를 소비하는데 프로브는 이전
+    /// 페이지 replay 없이 셀 하나만 레이아웃하므로 번호가 어긋난다.
+    /// (b) AutoNumber/NewNumber 컨트롤·캡션 자동번호도 동일. (c) 묶음 개체는 내부
+    /// 글상자 유무를 싸게 판정할 수 없어 보수적으로 차단.
+    pub(crate) fn table_subtree_blocks_cursor_probe(
+        &self,
+        table: &crate::model::table::Table,
+        styles: &ResolvedStyleSet,
+    ) -> bool {
+        fn paras_block(paras: &[Paragraph], styles: &ResolvedStyleSet) -> bool {
+            use crate::model::style::HeadType;
+            for p in paras {
+                let head = styles
+                    .para_styles
+                    .get(p.para_shape_id as usize)
+                    .map(|s| s.head_type)
+                    .unwrap_or(HeadType::None);
+                if matches!(head, HeadType::Outline | HeadType::Number) {
+                    return true;
+                }
+                for c in &p.controls {
+                    match c {
+                        Control::AutoNumber(_) | Control::NewNumber(_) => return true,
+                        Control::Table(t) => {
+                            // 캡션은 존재 자체가 아니라 auto counter 소비 요소
+                            // (개요/번호 헤드·AutoNumber)를 가질 때만 차단한다 —
+                            // layout_caption 은 apply_auto_numbers_to_composed 로만
+                            // counter 를 만진다.
+                            if let Some(cap) = t.caption.as_ref() {
+                                if paras_block(&cap.paragraphs, styles) {
+                                    return true;
+                                }
+                            }
+                            for cell in &t.cells {
+                                if paras_block(&cell.paragraphs, styles) {
+                                    return true;
+                                }
+                            }
+                        }
+                        Control::Shape(s) => {
+                            use crate::model::shape::ShapeObject;
+                            let drawing = match &**s {
+                                ShapeObject::Rectangle(sh) => Some(&sh.drawing),
+                                ShapeObject::Ellipse(sh) => Some(&sh.drawing),
+                                ShapeObject::Polygon(sh) => Some(&sh.drawing),
+                                ShapeObject::Curve(sh) => Some(&sh.drawing),
+                                ShapeObject::Line(_) | ShapeObject::Arc(_) => None,
+                                // Group/Chart/Ole 등은 내부 글상자·캡션을 싸게 확인할 수
+                                // 없어 보수적으로 차단한다.
+                                _ => return true,
+                            };
+                            if let Some(d) = drawing {
+                                if let Some(cap) = d.caption.as_ref() {
+                                    if paras_block(&cap.paragraphs, styles) {
+                                        return true;
+                                    }
+                                }
+                                if let Some(tb) = d.text_box.as_ref() {
+                                    if paras_block(&tb.paragraphs, styles) {
+                                        return true;
+                                    }
+                                }
+                            }
+                        }
+                        Control::Picture(pic) => {
+                            if let Some(cap) = pic.caption.as_ref() {
+                                if paras_block(&cap.paragraphs, styles) {
+                                    return true;
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            false
+        }
+        let key = table as *const crate::model::table::Table as usize;
+        if let Some(&cached) = self.cursor_probe_block_cache.borrow().get(&key) {
+            return cached;
+        }
+        let blocked = table
+            .cells
+            .iter()
+            .any(|c| paras_block(&c.paragraphs, styles));
+        self.cursor_probe_block_cache
+            .borrow_mut()
+            .insert(key, blocked);
+        blocked
+    }
+
     /// [#2029 추출] 부분 표의 셀 방출 루프 — 셀 geometry/배경/반복 헤더와 셀
     /// 문단 배치를 `table_node.children` 에 방출한다. 셀-간 캐리 없음(실측 muts 0,
     /// 외부 sink = table_node 단일) — 원본 무변경 이동.
@@ -349,8 +652,14 @@ impl LayoutEngine {
         v_edges: &mut Vec<Vec<Option<BorderLine>>>,
         measured_table: Option<&MeasuredTable>,
         clamp_header_negative_para_offset: bool,
+        probe: Option<&PartialTableCellProbe>,
     ) {
         for (cell_idx, cell) in table.cells.iter().enumerate() {
+            // [#4149] 프로브: 대상 셀만 방출. 셀 방출 루프는 셀-간 캐리가 없어
+            // (실측 muts 0, 외부 sink = table_node 단일) 생략이 대상 셀 좌표를 바꾸지 않는다.
+            if probe.is_some_and(|p| p.cell_idx != cell_idx) {
+                continue;
+            }
             let cell_row = cell.row as usize;
             let cell_col = cell.col as usize;
             if cell_col >= col_count || cell_row >= row_count {
@@ -501,51 +810,64 @@ impl LayoutEngine {
             let (mut pad_left, mut pad_right, pad_top, pad_bottom) =
                 self.resolve_cell_padding(cell, table);
 
-            // 셀 내 문단 구성
-            let mut composed_paras: Vec<_> = cell
-                .paragraphs
-                .iter()
-                .map(|p| compose_paragraph(p))
-                .collect();
+            // [#4149] windowed 프로브면 창 문단만 lazy compose. 그 외에는 종전과
+            // 동일한 순서로 전량 compose → shrink → recompose.
+            let probe_windowed = probe.is_some_and(|p| p.windowed);
+            let mut composed_store: CellComposedStore;
+            if probe_windowed {
+                // shrink 생략 근거: 프로브 사전 게이트가 line_segs>=2 문단 존재를
+                // 증명했고, shrunk_cell_horizontal_padding 은 그 경우 composed 를
+                // 읽지 않고 패딩을 그대로 반환한다 (조기 탈출과 동일 결과).
+                composed_store = CellComposedStore::Lazy(vec![None; cell.paragraphs.len()]);
+            } else {
+                // 셀 내 문단 구성
+                let mut composed_paras: Vec<_> = cell
+                    .paragraphs
+                    .iter()
+                    .map(|p| compose_paragraph(p))
+                    .collect();
 
-            // 텍스트 오버플로우 시 좌우 패딩 축소
-            let (new_pl, new_pr) = self.shrink_cell_padding_for_overflow(
-                pad_left,
-                pad_right,
-                cell_w,
-                &composed_paras,
-                &cell.paragraphs,
-                styles,
-                cell.apply_inner_margin,
-            );
-            pad_left = new_pl;
-            pad_right = new_pr;
+                // 텍스트 오버플로우 시 좌우 패딩 축소
+                let (new_pl, new_pr) = self.shrink_cell_padding_for_overflow(
+                    pad_left,
+                    pad_right,
+                    cell_w,
+                    &composed_paras,
+                    &cell.paragraphs,
+                    styles,
+                    cell.apply_inner_margin,
+                );
+                pad_left = new_pl;
+                pad_right = new_pr;
+
+                let inner_width_for_recompose = (cell_w - pad_left - pad_right).max(0.0);
+                // [Task #671] line_segs 비어 있는 셀 paragraph 의 단일 ComposedLine 압축
+                // 결과를 셀 가용 너비 (inner_width) 에 맞춰 다중 ComposedLine 으로 재분할.
+                for (cpi, para) in cell.paragraphs.iter().enumerate() {
+                    if let Some(comp) = composed_paras.get_mut(cpi) {
+                        crate::renderer::composer::recompose_for_cell_width(
+                            comp,
+                            para,
+                            inner_width_for_recompose,
+                            styles,
+                        );
+                        // [#2291] 부실 저장(ls==1·실폭 초과) 재분할 — 가로쓰기 셀 한정.
+                        if cell.text_direction == 0 {
+                            crate::renderer::composer::recompose_stored_single_line_if_overflowing(
+                                comp,
+                                para,
+                                inner_width_for_recompose,
+                                styles,
+                            );
+                        }
+                    }
+                }
+                composed_store = CellComposedStore::Eager(composed_paras);
+            }
 
             let inner_x = cell_x + pad_left;
             let inner_width = (cell_w - pad_left - pad_right).max(0.0);
             let inner_height = (cell_h - pad_top - pad_bottom).max(0.0);
-
-            // [Task #671] line_segs 비어 있는 셀 paragraph 의 단일 ComposedLine 압축
-            // 결과를 셀 가용 너비 (inner_width) 에 맞춰 다중 ComposedLine 으로 재분할.
-            for (cpi, para) in cell.paragraphs.iter().enumerate() {
-                if let Some(comp) = composed_paras.get_mut(cpi) {
-                    crate::renderer::composer::recompose_for_cell_width(
-                        comp,
-                        para,
-                        inner_width,
-                        styles,
-                    );
-                    // [#2291] 부실 저장(ls==1·실폭 초과) 재분할 — 가로쓰기 셀 한정.
-                    if cell.text_direction == 0 {
-                        crate::renderer::composer::recompose_stored_single_line_if_overflowing(
-                            comp,
-                            para,
-                            inner_width,
-                            styles,
-                        );
-                    }
-                }
-            }
 
             // 분할 행: [Task #993/#1025] start_cut/end_cut(유닛 컷)으로 표시할 줄 범위 계산.
             // 블록 분할이면 블록-셀 (row,col) 인덱스, 그 외는 행내 row_span==1 col 인덱스.
@@ -612,9 +934,14 @@ impl LayoutEngine {
             // 셀 내 텍스트 높이 (분할 행이면 줄 범위 내만 계산)
             // spacing_before: 셀 첫 문단 제외, spacing_after: 셀 마지막 문단 제외
             let split_para_count = cell.paragraphs.len();
-            let total_content_height = if let Some(ref ranges) = line_ranges {
+            // [#4149] windowed 프로브: 아래에서 effective_align 이 Top 으로 확정되므로
+            // (cell_was_split=true 사전 증명) total_content_height 는 미사용 — 0 고정.
+            let total_content_height = if probe_windowed {
+                0.0
+            } else if let Some(ref ranges) = line_ranges {
                 let mut total = 0.0;
-                for (pi, ((comp, para), &(start, end))) in composed_paras
+                for (pi, ((comp, para), &(start, end))) in composed_store
+                    .eager_slice()
                     .iter()
                     .zip(cell.paragraphs.iter())
                     .zip(ranges.iter())
@@ -669,7 +996,7 @@ impl LayoutEngine {
                         .unwrap_or(0);
                     let vpos_h = hwpunit_to_px(last_seg_end, self.dpi);
                     let line_h = self.calc_composed_paras_content_height(
-                        &composed_paras,
+                        composed_store.eager_slice(),
                         &cell.paragraphs,
                         styles,
                     );
@@ -683,7 +1010,7 @@ impl LayoutEngine {
                         .max(self.calc_cell_wrap_objects_bottom_height(&cell.paragraphs))
                 } else {
                     self.calc_composed_paras_content_height(
-                        &composed_paras,
+                        composed_store.eager_slice(),
                         &cell.paragraphs,
                         styles,
                     )
@@ -698,9 +1025,17 @@ impl LayoutEngine {
             // 그대로 visible 처리한다면 (= 실제 split 적용 안 받은 cell, 예: inner-table-01.hwp
             // cell[10] '사업개요' 라벨) 원본 cell.vertical_align 을 사용한다. split 적용으로
             // line 일부가 잘린 cell 만 Top 강제.
-            let cell_was_split = if let Some(ref ranges) = line_ranges {
+            let cell_was_split = if probe_windowed {
+                // [#4149] windowed 프로브 사전 게이트가 증명한 값 (s>0 문단 존재 또는
+                // 창 밖 미가시 문단의 compose 줄 수 ≥ 1) — 전량 판정과 동치.
+                true
+            } else if let Some(ref ranges) = line_ranges {
                 ranges.iter().enumerate().any(|(i, &(s, e))| {
-                    let total = composed_paras.get(i).map(|c| c.lines.len()).unwrap_or(0);
+                    let total = composed_store
+                        .eager_slice()
+                        .get(i)
+                        .map(|c| c.lines.len())
+                        .unwrap_or(0);
                     s != 0 || e != total
                 })
             } else {
@@ -746,6 +1081,9 @@ impl LayoutEngine {
 
             // 세로쓰기 셀: 별도 레이아웃 경로 (가로 레이아웃 루프 대신)
             if cell.text_direction != 0 {
+                // [#4149] 프로브가 세로쓰기 셀을 대상으로 삼는 일은 게이트로 막지만,
+                // 방어적으로 전량 구성 후 동일 경로를 태운다 (좌표 동일).
+                composed_store.materialize(cell, inner_width, styles);
                 let vert_inner_area = LayoutRect {
                     x: inner_x,
                     y: cell_y + pad_top,
@@ -755,7 +1093,7 @@ impl LayoutEngine {
                 self.layout_vertical_cell_text(
                     tree,
                     &mut cell_node,
-                    &composed_paras,
+                    composed_store.eager_slice(),
                     &cell.paragraphs,
                     styles,
                     &vert_inner_area,
@@ -812,7 +1150,7 @@ impl LayoutEngine {
                 }
                 last_idx
             } else {
-                composed_paras.len().saturating_sub(1)
+                cell.paragraphs.len().saturating_sub(1)
             };
 
             let mut para_y = text_y_start;
@@ -839,11 +1177,29 @@ impl LayoutEngine {
             } else {
                 0
             };
-            for (cp_idx, (composed, para)) in composed_paras
-                .iter()
-                .zip(cell.paragraphs.iter())
-                .enumerate()
-            {
+            // [#4149] windowed 프로브: 컷 창에 유닛이 없는 문단은 아래 skip 판정의
+            // 네 조건(line_ranges·mixed·nested·non-inline)이 모두 창 유닛에서만
+            // 유도되므로 전량 레이아웃에서도 반드시 skip 된다 — 순회 자체를 생략한다.
+            // stop_after_para 이후 문단은 캐럿 문단의 좌표에 영향이 없어 중단한다.
+            let (loop_start, loop_end_excl) = match probe {
+                Some(p) if p.windowed => {
+                    let (lo, hi) = p.window_paras;
+                    let end = hi
+                        .saturating_add(1)
+                        .min(cell.paragraphs.len())
+                        .min(p.stop_after_para.saturating_add(1));
+                    (lo.min(end), end)
+                }
+                Some(p) => (
+                    0,
+                    cell.paragraphs
+                        .len()
+                        .min(p.stop_after_para.saturating_add(1)),
+                ),
+                None => (0, cell.paragraphs.len()),
+            };
+            for cp_idx in loop_start..loop_end_excl {
+                let para = &cell.paragraphs[cp_idx];
                 // 분할 행이면 해당 문단의 줄 범위 적용
                 let (start_line, end_line) = if let Some(ref ranges) = line_ranges {
                     if cp_idx < ranges.len() {
@@ -852,7 +1208,13 @@ impl LayoutEngine {
                         (0, 0) // 범위 밖 문단은 렌더링하지 않음
                     }
                 } else {
-                    (0, composed.lines.len())
+                    (
+                        0,
+                        composed_store
+                            .get(cp_idx, cell, inner_width, styles)
+                            .lines
+                            .len(),
+                    )
                 };
                 let mixed_nested_split = cut_units.and_then(|(su, eu)| {
                     self.mixed_nested_split_from_cut(cell, table, styles, su, eu, cp_idx)
@@ -893,6 +1255,9 @@ impl LayoutEngine {
                 {
                     continue;
                 }
+
+                // [#4149] 가시 문단만 여기 도달 — lazy 슬롯은 이 시점에 compose 된다.
+                let composed = composed_store.get(cp_idx, cell, inner_width, styles);
 
                 if preserve_linear_single_cell_vpos {
                     let target_seg = para
@@ -1647,6 +2012,8 @@ impl LayoutEngine {
                                             0.0,
                                             None,
                                             clamp_header_negative_para_offset,
+                                            // [#4149] 프로브는 최외곽 표 한정 — 중첩 재귀는 전량
+                                            None,
                                         ) - nested_y
                                     } else {
                                         self.layout_table(
@@ -1693,7 +2060,7 @@ impl LayoutEngine {
 
                 if has_table_ctrl && mixed_nested_split.is_none() {
                     // LINE_SEG vpos 기반으로 para_y 보정.
-                    let is_last_para = cp_idx + 1 == composed_paras.len();
+                    let is_last_para = cp_idx + 1 == cell.paragraphs.len();
                     if !is_last_para {
                         if let Some(next_para) = cell.paragraphs.get(cp_idx + 1) {
                             if let Some(next_seg) = next_para.line_segs.first() {
@@ -1801,6 +2168,7 @@ impl LayoutEngine {
         host_margin_right: f64,
         measured_table: Option<&MeasuredTable>,
         clamp_header_negative_para_offset: bool,
+        probe: Option<&PartialTableCellProbe>,
     ) -> f64 {
         let para = match paragraphs.get(para_index) {
             Some(p) => p,
@@ -2331,6 +2699,7 @@ impl LayoutEngine {
             &mut v_edges,
             measured_table,
             clamp_header_negative_para_offset,
+            probe,
         );
 
         // 엣지 기반 테두리 렌더링

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -27854,3 +27854,235 @@ fn split_rejects_corrupted_cell_row_span_overflow_before_mutation() {
     assert_eq!(table.cells[0].row, u16::MAX - 2);
     assert_eq!(table.cells[0].row_span, 3);
 }
+
+/// [#4149 조사] Enter→Delete 왕복(내용 무변경 복원)이 셀 문단의 저장 line_segs 를
+/// 보존하는지 계측한다. 두 원천을 분리한다:
+///
+///   A) 무편집 divergence — 로드 직후 저장 segs vs `reflow_cell_paragraph` 재계산.
+///      다르면 그 문단은 "한 번이라도 건드리는 순간" 한컴 원본 줄바꿈 증거를 잃는
+///      잠재 모집단이다.
+///   B) 왕복 실측 — split→merge(내용 복원) 전후 저장 segs 대조. 불변식
+///      "무변경 편집 왕복은 레이아웃 보존" 위반의 직접 증거.
+///
+/// 구조상 왕복 결과는 reflow 결과와 같아야 하므로 B의 변경 집합은 A의 divergence
+/// 집합과 일치할 것으로 기대한다 — 일치하면 원인은 왕복 경로가 아니라 "reflow 가
+/// 원본 줄바꿈과 다르다"로 좁혀진다. 요약은 --nocapture 로 출력.
+#[test]
+fn issue4149_cell_lineseg_roundtrip_survey() {
+    let path = "samples/issue1949_giant_cell_nested_tables_perf.hwp";
+    let bytes = std::fs::read(path).expect("issue1949 샘플 읽기");
+
+    // (ppi, ci, cell, para) — 최외곽 표, 다줄(>=2 segs), UTF-16 4자 이상
+    fn survey(doc: &HwpDocument) -> Vec<(usize, usize, usize, usize)> {
+        let mut out = Vec::new();
+        for (ppi, para) in doc.document.sections[0].paragraphs.iter().enumerate() {
+            for (ci, ctrl) in para.controls.iter().enumerate() {
+                if let Control::Table(t) = ctrl {
+                    for (cell_idx, cell) in t.cells.iter().enumerate() {
+                        for (cp, p) in cell.paragraphs.iter().enumerate() {
+                            if p.line_segs.len() >= 2 && p.text.encode_utf16().count() >= 4 {
+                                out.push((ppi, ci, cell_idx, cp));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+    fn cell_para<'a>(doc: &'a HwpDocument, t: (usize, usize, usize, usize)) -> &'a Paragraph {
+        match &doc.document.sections[0].paragraphs[t.0].controls[t.1] {
+            Control::Table(tbl) => &tbl.cells[t.2].paragraphs[t.3],
+            _ => panic!("표가 아님"),
+        }
+    }
+    // 줄바꿈 증거(text_start 수열)와 기하(vpos/width)를 분리해 본다
+    fn breaks(p: &Paragraph) -> Vec<u32> {
+        p.line_segs.iter().map(|s| s.text_start).collect()
+    }
+    fn geom(p: &Paragraph) -> Vec<(i32, i32, i32)> {
+        p.line_segs
+            .iter()
+            .map(|s| (s.vertical_pos, s.segment_width, s.line_height))
+            .collect()
+    }
+
+    // ── A) 무편집: 저장 segs vs reflow 재계산 ─────────────────────────────
+    let mut doc_a = HwpDocument::from_bytes(&bytes).expect("파싱");
+    let targets = survey(&doc_a);
+    assert!(!targets.is_empty(), "다줄 셀 문단이 없으면 계측 무의미");
+    let (mut a_same, mut a_breaks, mut a_geom_only) = (0usize, 0usize, 0usize);
+    let mut a_break_examples = Vec::new();
+    let mut a_divergent = std::collections::HashSet::new();
+    for &t in &targets {
+        let before = (breaks(cell_para(&doc_a, t)), geom(cell_para(&doc_a, t)));
+        doc_a.reflow_cell_paragraph(0, t.0, t.1, t.2, t.3);
+        let after = (breaks(cell_para(&doc_a, t)), geom(cell_para(&doc_a, t)));
+        if before.0 != after.0 {
+            a_breaks += 1;
+            a_divergent.insert(t);
+            if a_break_examples.len() < 3 {
+                a_break_examples.push((t, before.0.clone(), after.0.clone()));
+            }
+        } else if before.1 != after.1 {
+            a_geom_only += 1;
+            a_divergent.insert(t);
+        } else {
+            a_same += 1;
+        }
+    }
+    println!(
+        "[#4149-A] 무편집 다줄 셀 문단 {}개: 보존 {} / 줄바꿈 divergence {} / 기하만 {}",
+        targets.len(),
+        a_same,
+        a_breaks,
+        a_geom_only
+    );
+    for (t, b, a) in &a_break_examples {
+        println!(
+            "[#4149-A] 예시 ppi{} ci{} cell{} para{}: 저장 {:?} → 재계산 {:?}",
+            t.0, t.1, t.2, t.3, b, a
+        );
+    }
+
+    // ── B) 왕복: split(중간)→merge 전후 저장 segs ────────────────────────
+    let mut doc_b = HwpDocument::from_bytes(&bytes).expect("파싱");
+    let roundtrip_targets: Vec<_> = targets.iter().copied().take(12).collect();
+    let (mut b_same, mut b_breaks, mut b_geom_only) = (0usize, 0usize, 0usize);
+    let mut b_matches_a = true;
+    for &t in &roundtrip_targets {
+        let p = cell_para(&doc_b, t);
+        let text_before = p.text.clone();
+        let (bk_before, gm_before) = (breaks(p), geom(p));
+        let mid = (text_before.encode_utf16().count() / 2).max(1);
+        doc_b
+            .split_paragraph_in_cell_native(0, t.0, t.1, t.2, t.3, mid, None)
+            .expect("split");
+        doc_b
+            .merge_paragraph_in_cell_native(0, t.0, t.1, t.2, t.3 + 1)
+            .expect("merge");
+        let p = cell_para(&doc_b, t);
+        assert_eq!(
+            p.text, text_before,
+            "왕복 후 텍스트 복원은 전제 (ppi{} cell{})",
+            t.0, t.2
+        );
+        let changed = if bk_before != breaks(p) {
+            b_breaks += 1;
+            true
+        } else if gm_before != geom(p) {
+            b_geom_only += 1;
+            true
+        } else {
+            b_same += 1;
+            false
+        };
+        if changed != a_divergent.contains(&t) {
+            b_matches_a = false;
+            println!(
+                "[#4149-B] 예외: ppi{} ci{} cell{} para{} — 왕복 변경={} vs A divergence={}",
+                t.0,
+                t.1,
+                t.2,
+                t.3,
+                changed,
+                a_divergent.contains(&t)
+            );
+        }
+    }
+    println!(
+        "[#4149-B] Enter→Delete 왕복 {}개: 보존 {} / 줄바꿈 변경 {} / 기하만 변경 {}",
+        roundtrip_targets.len(),
+        b_same,
+        b_breaks,
+        b_geom_only
+    );
+    println!(
+        "[#4149-B] 왕복 변경 집합 == A divergence 집합: {} — true 면 왕복 자체는 reflow 를 \
+         충실히 따르고, 원인은 reflow vs 한컴 원본 줄바꿈 차이로 좁혀진다",
+        b_matches_a
+    );
+}
+
+/// [조사] 거대 셀 문서 타이핑 지연의 진짜 병목 분해 — getCursorRectInCell 60ms 의
+/// 내부 귀속. 브라우저 트레이스(조합 업데이트마다 getCursorRectInCell 56~60ms)의
+/// wasm 안쪽을 페이즈별로 실측한다:
+///   1) find_pages_for_cell_position (페이지 좁히기)
+///   2) build_page_tree (uncached — LayoutEngine::build_render_tree 포함)
+///   3) get_cursor_rect_in_cell_native 전체
+///   4) 거대 표가 없는 쪽의 build_page_tree (차등 — 표 레이아웃 귀속 증거)
+#[test]
+fn issue4149_adjacent_giant_cell_cursor_rect_latency_decomposition() {
+    use std::time::Instant;
+    let bytes =
+        std::fs::read("samples/issue1949_giant_cell_nested_tables_perf.hwp").expect("샘플 읽기");
+    let mut doc = HwpDocument::from_bytes(&bytes).expect("파싱");
+    let pages = doc.page_count();
+    println!("[cursor-rect] 총 {pages}쪽");
+
+    // 캐럿 좌표: 브라우저 실측과 동일 (ppi0 ci2 cell2 para6 off5)
+    let t = Instant::now();
+    let cand = doc
+        .find_pages_for_cell_position(0, 0, 2, 2, Some((6, 5)))
+        .expect("페이지 좁히기");
+    println!(
+        "[cursor-rect] 1) find_pages_for_cell_position={:?} → {:?}",
+        t.elapsed(),
+        cand
+    );
+
+    let target_page = cand[0];
+    for i in 0..3 {
+        let t = Instant::now();
+        let _ = doc.build_page_tree(target_page).expect("페이지 트리");
+        println!(
+            "[cursor-rect] 2) build_page_tree(p{target_page}) #{i}={:?}",
+            t.elapsed()
+        );
+    }
+    // find_page(구성 조회)만 분리 — 나머지가 LayoutEngine::build_render_tree 귀속
+    for i in 0..2 {
+        let t = Instant::now();
+        let _ = doc.find_page(target_page).expect("find_page");
+        println!(
+            "[cursor-rect] 2b) find_page(p{target_page}) #{i}={:?}",
+            t.elapsed()
+        );
+    }
+    // 차등: 마지막 쪽 (다른 내용 구성)
+    let last = pages - 1;
+    let t = Instant::now();
+    let _ = doc.build_page_tree(last).expect("페이지 트리");
+    println!(
+        "[cursor-rect] 4) build_page_tree(p{last})={:?}",
+        t.elapsed()
+    );
+
+    for i in 0..3 {
+        let t = Instant::now();
+        let _ = doc
+            .get_cursor_rect_in_cell_native(0, 0, 2, 2, 6, 5)
+            .expect("커서 rect");
+        println!(
+            "[cursor-rect] 3) get_cursor_rect_in_cell_native #{i}={:?}",
+            t.elapsed()
+        );
+    }
+}
+
+/// [조사] 프로파일링용 핫루프 — macOS `sample` 로 build_render_tree 내부 귀속.
+/// `--ignored` 로만 실행.
+#[test]
+#[ignore]
+fn issue4149_adjacent_cursor_rect_profile_loop() {
+    let bytes =
+        std::fs::read("samples/issue1949_giant_cell_nested_tables_perf.hwp").expect("샘플 읽기");
+    let mut doc = HwpDocument::from_bytes(&bytes).expect("파싱");
+    let _ = doc.page_count();
+    let _ = doc.find_pages_for_cell_position(0, 0, 2, 2, Some((6, 5)));
+    eprintln!("[profile-loop] 시작 pid={}", std::process::id());
+    for _ in 0..600 {
+        let _ = doc.get_cursor_rect_in_cell_native(0, 0, 2, 2, 6, 5);
+    }
+    eprintln!("[profile-loop] 끝");
+}


### PR DESCRIPTION
`get_cursor_rect_in_cell_native`는 rect 하나를 얻으려고 uncached `build_page_tree`로 페이지 렌더 트리 전체를 재빌드했다(질의의 98%, 그중 99.7%가 `layout_partial_table_cells` 전체 셀 재레이아웃 — 거대 셀 문서 20ms/질의, IME 조합마다 발생).

fast path 는 독립 산식 재구현이 아니라 production `layout_partial_table`를 대상 셀만 방출하는 프로브로 재사용한다 — 셀 방출 루프의 셀-간 캐리 부재(기존 계약)로 패리티가 구성적으로 보장된다. 셀 기하는 pagination `PartialTable` 메타 + memoized `cell_units` + `measured_tables`로, 줄은 저장 line_segs 불신(#4149 무편집 ~16% divergence 실측) — production compose 를 컷 창 문단에만 lazy 적용. 불확실 케이스 12종(캡션 센티널/다중컬럼/zone/wrap/미주/통페이지 표/반복 제목행/auto counter 개체/rowspan>1 등)은 전부 legacy 전체 경로 폴백 — 기존 본문은 `cursor_rect_in_cell_via_page_tree`로 추출해 패리티 기준으로 보존했다.

패리티: 실문서 6종 차등(거대 문서 185/185=100% 적중, 줄 경계 ±1 offset 11,962지점, deferred 편집 직후 861지점 포함) 전 지점 legacy JSON 일치. 적대 리뷰 5각도(캐시 무효화 전수 추적·프로브-전량 동치·편집 직후 stale 대칭성·패리티 그리드 확장 공격·게이트 역손실 +0.6%) 반박 실패. 실측: 17.5ms → 0.61ms (quiescent, 약 28배). 기록: `mydocs/plans/task_m100_4167.md`, `mydocs/working/task_m100_4167_stage1.md`.

**시리즈 3/4**: #4246 → #4247 → 본 PR → Stage 2. 본 레이어 고유 diff: [비교 링크](https://github.com/humdrum00001010/rhwp/compare/task_m100_4169_overflow_memo...task_m100_4167_cursor_rect_fast_path).

Part of #4167 (Stage 2 가 완결)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---
**재검증 (2026-08-08)**: 전 레이어를 최신 `devel`(e64c853) 위로 rebase 후 ci.yml 전 단계를 로컬 완주 — fmt / scripts-tests 6종 / clippy / `cargo build --workspace` + workspace all-targets clippy / wasm32 check / **`cargo nextest run --cargo-profile release-test`** (스택 상단 5,345/5,345 pass) / Native Skia 3종 / wasm-pack dev + binding tests / tsc ci-unit / studio suite(802/802) — 6개 레이어 전부 ALL-PASS. 종전 Lint 실패 원인(workspace all-targets clippy 미실행으로 놓친 테스트 코드 1건)은 수정 완료. nextest 프로세스 격리 하에서 #4181 fixture 는 전 레이어 무재시도 안정.
