### PR TITLE
studio: 셀 블록 서식의 토글 방향·툴바 상태를 블록 앵커 기준으로 동기화

### DIFF
--- a/mydocs/plans/task_m100_4151.md
+++ b/mydocs/plans/task_m100_4151.md
@@ -1,0 +1,38 @@
+# 수행계획 — task_m100_4151
+
+- **이슈**: [#4151](https://github.com/edwardkim/rhwp/issues/4151)
+- **브랜치**: `task_m100_4151_cell_block_toggle_sync`
+- **기준**: `upstream/devel` `5a4f26d0d` (#4119 셀 블록 직접 서식 배선 병합 이후)
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+셀 블록(F5) 선택에 굵게/기울임을 적용하면 서식은 적용되지만 ① 툴바 눌림 상태가 갱신되지 않고
+② 같은 버튼 재클릭이 해제가 아니라 재적용되는 #4151 두 증상을 고친다.
+
+## 2. 변경 경계
+
+- 토글 방향 기준과 툴바 상태 방출 기준을 **같은 단일 함수**(블록 첫 셀 첫 글자)로 통일한다 —
+  두 기준이 갈리면 두 번째 클릭 방향과 버튼 표시가 어긋난다.
+- upstream #4119 의 빈 셀 블록 의미(전 셀 Ctrl+클릭 제외 시 앵커 셀 fallback 금지)를 보존한다 —
+  빈 블록에서는 앵커 셀이 없으므로 토글 방향은 커서 기준 폴백(적용 자체는 조기 종료).
+- 뮤테이션 표면 원장(mutation-routing-guard) 수는 불변 — 추가분은 조회·이벤트 방출뿐.
+
+## 3. 구현·래칫 순서
+
+1. `getCharPropertiesAtCellBlockAnchor` — 블록 첫 셀 첫 글자 서식 단일 기준.
+2. `applyToggleFormat`: 셀 블록 모드에서 커서 위치 대신 블록 앵커 기준으로 `!current[prop]`
+   방향 산출 (커서 조회는 블록 밖(호스트 문단 등)을 읽어 방금 적용한 서식이 안 보임 — 원인).
+3. `applyCharFormatToCellBlock`: 적용 직후 앵커 셀 기준 `cursor-format-changed` 방출 —
+   텍스트 선택 경로의 "적용 → 상태 재조회·방출" 후처리 계약을 블록 경로에도.
+4. 소스 계약 테스트 3종(#4151) — red→green: 수정 원복 시 실패 확인.
+
+## 4. 검증 게이트
+
+- `tests/cell-block-format.test.ts` (기존 #4119 계약 + 신규 #4151 3종)
+- `tests/mutation-routing-guard.test.ts` (원장 불변)
+- tsc ci-unit / `npm run test` 전체
+- 실브라우저 왕복(:7701, hwp_table_test_saved 2셀 블록): 1클릭 적용+버튼 활성, 2클릭 해제 —
+  wasm 문서 상태 직접 확인
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/working/task_m100_4151_stage1.md
+++ b/mydocs/working/task_m100_4151_stage1.md
@@ -1,0 +1,30 @@
+---
+kind: working
+status: completed
+issue: 4151
+last_verified: 2026-08-08
+---
+
+# Task #4151 Stage 1 - 셀 블록 서식 토글 방향·툴바 동기화
+
+## 구현
+
+- `getCharPropertiesAtCellBlockAnchor`(블록 첫 셀 첫 글자) 단일 기준 신설 — 토글 방향과
+  툴바 상태 방출이 공유한다.
+- `applyToggleFormat`: 셀 블록 모드에서 `getCharPropertiesAtCursor()`(블록 밖을 읽음 — 재적용
+  원인) 대신 블록 앵커 기준. 빈 블록(전 셀 제외)은 앵커가 없어 커서 폴백 — `applyCharFormat`이
+  빈 블록에서 조기 종료하므로 방향은 무해(upstream #4119 빈 블록 의미 보존).
+- `applyCharFormatToCellBlock`: 적용 직후 앵커 셀 기준 `cursor-format-changed` 방출(try/catch,
+  실패 시 다음 캐럿 이동에서 자연 동기화).
+
+## 검증 결과
+
+- 신규 #4151 소스 계약 테스트 3종: 토글 방향 블록 분기 존재/앵커 함수 사용, 적용 후 방출이
+  executeOperation 뒤에 앵커 기준으로 존재, 앵커 기준이 첫 셀 첫 글자 — red 증명: 수정 전
+  파일(HEAD)에서 3종 전부 FAIL 확인 후 green.
+- `tests/cell-block-format.test.ts` + `tests/mutation-routing-guard.test.ts`: 27 passed / 0.
+- 실브라우저(:7701, hwp_table_test_saved 2×2 표, 셀 0-1 블록): pre bold=false·버튼 비활성 →
+  1클릭 두 셀 bold=true·버튼 즉시 활성·블록 유지 → 2클릭 두 셀 bold=false·버튼 비활성 —
+  wasm getCellCharPropertiesAt 로 문서 상태 직접 검증.
+- 참고: upstream #4119 의 빈 블록 의미 변화와의 병합은 rebase 시 수동 해소 — 빈 블록 길이
+  가드를 토글 방향 폴백에 추가.

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -1892,14 +1892,33 @@ export class InputHandler {
         return { ...cursorBefore };
       },
     });
+    // [#4151] 블록 적용 경로는 텍스트 선택 경로의 "적용 → 상태 재조회·방출" 후처리를 타지
+    // 않아 툴바 눌림 상태가 이전 값으로 남는다. 적용 직후 앵커 셀 기준으로 방출해 동기화한다.
+    try {
+      this.eventBus.emit('cursor-format-changed', this.getCharPropertiesAtCellBlockAnchor(block));
+    } catch {
+      // 문서 상태 경합 시 다음 캐럿 이동에서 자연 동기화
+    }
+  }
+
+  /** [#4151] 셀 블록 서식의 토글 방향·툴바 상태 기준: 블록 첫 셀의 첫 글자 서식. */
+  private getCharPropertiesAtCellBlockAnchor(block: SelectedCellBlock): CharProperties {
+    return this.wasm.getCellCharPropertiesAt(block.sec, block.ppi, block.ci, block.cellIndices[0], 0, 0);
   }
 
   /** 토글 서식 적용 (상호 배타 처리 포함) */
   private applyToggleFormat(prop: 'bold' | 'italic' | 'underline' | 'strikethrough' | 'emboss' | 'engrave' | 'outline' | 'superscript' | 'subscript'): void {
     if (!this.hasFormatTargetSelection()) return;
-    // 셀 블록에서는 커서가 있는 앵커 셀의 현재 값이 토글 방향을 정한다. 칸마다 값이 다를 때
+    // 셀 블록에서는 앵커 셀 텍스트의 현재 값이 토글 방향을 정한다. 칸마다 값이 다를 때
     // 블록 전체를 한 방향으로 맞추려면 기준이 하나여야 하고, 텍스트 선택도 같은 기준이다.
-    const current = this.getCharPropertiesAtCursor();
+    // [#4151] 커서 위치 조회는 셀 블록 모드에서 블록 밖(호스트 문단 등)을 읽어 방금 적용한
+    // 서식이 보이지 않는다 — 두 번째 클릭이 해제가 아니라 재적용이 되는 원인. 블록 모드에선
+    // 블록 첫 셀의 첫 글자 서식을 기준으로 삼는다. 빈 블록(전 셀 Ctrl+클릭 제외)은 앵커
+    // 셀이 없으므로 커서 기준 폴백 — applyCharFormat 이 어차피 빈 블록에서 조기 종료한다.
+    const toggleBlock = this.getSelectedCellBlock();
+    const current = toggleBlock && toggleBlock.cellIndices.length > 0
+      ? this.getCharPropertiesAtCellBlockAnchor(toggleBlock)
+      : this.getCharPropertiesAtCursor();
 
     if (prop === 'emboss') {
       const newVal = !current.emboss;

--- a/rhwp-studio/tests/cell-block-format.test.ts
+++ b/rhwp-studio/tests/cell-block-format.test.ts
@@ -199,6 +199,50 @@ test('빈 셀 블록 글자 서식은 history 없이 no-op 이다', () => {
     '모든 셀 제외 시 글자 서식이 no-op으로 끝나지 않는다');
 });
 
+test('[#4151] 토글 방향은 셀 블록 모드에서 블록 앵커 셀의 서식을 읽는다', () => {
+  // 커서 위치 조회(getCharPropertiesAtCursor)는 셀 블록 모드에서 블록 밖(호스트 문단 등)을
+  // 읽어 방금 적용한 서식이 보이지 않는다 — current[prop] 이 이전 값에 머물러 !current[prop]
+  // 이 항상 같은 방향이 되고, 두 번째 클릭이 해제가 아니라 재적용이 된다.
+  const ih = source('src/engine/input-handler.ts');
+  const start = ih.indexOf('private applyToggleFormat(');
+  assert.notEqual(start, -1, 'applyToggleFormat 을 찾지 못했다');
+  const body = ih.slice(start, ih.indexOf('\n  }\n', start));
+  assert.match(body, /this\.getSelectedCellBlock\(\)/,
+    '토글 방향 산출에 셀 블록 분기가 없다');
+  assert.match(body,
+    /\?\s*this\.getCharPropertiesAtCellBlockAnchor\(\w+\)\s*\n?\s*:\s*this\.getCharPropertiesAtCursor\(\)/,
+    '셀 블록 모드에서 블록 앵커 셀 대신 커서 위치의 서식으로 토글 방향을 정한다');
+});
+
+test('[#4151] 셀 블록 적용 직후 cursor-format-changed 를 앵커 셀 기준으로 방출한다', () => {
+  // 텍스트 선택 경로는 적용 후 emitCursorFormatState 로 툴바 눌림 상태를 재조회·방출하지만,
+  // 셀 블록 경로는 이 후처리가 없으면 툴바가 이전 상태로 남는다. emitCursorFormatState 는
+  // 커서 위치 기준이라 블록에는 오답 — 앵커 셀 서식을 직접 방출해야 한다.
+  const ih = source('src/engine/input-handler.ts');
+  const start = ih.indexOf('private applyCharFormatToCellBlock');
+  assert.notEqual(start, -1, 'applyCharFormatToCellBlock 이 없다');
+  const body = ih.slice(start, ih.indexOf('\n  }\n', start));
+  const applyAt = body.indexOf('this.executeOperation(');
+  const emitAt = body.indexOf("this.eventBus.emit('cursor-format-changed'");
+  assert.notEqual(emitAt, -1, '적용 후 cursor-format-changed 방출이 없다');
+  assert.ok(applyAt !== -1 && applyAt < emitAt, '상태 방출이 서식 적용보다 앞에 있다');
+  assert.match(body,
+    /emit\('cursor-format-changed',\s*this\.getCharPropertiesAtCellBlockAnchor\(block\)\)/,
+    '방출 값이 블록 앵커 셀 서식이 아니다');
+});
+
+test('[#4151] 앵커 셀 서식 기준은 블록 첫 셀의 첫 글자다', () => {
+  // 토글 방향(applyToggleFormat)과 툴바 상태 방출이 같은 기준을 공유해야 두 번째 클릭의
+  // 해제 방향과 버튼 표시가 일치한다. 기준 조회는 이 함수 한 곳에만 둔다.
+  const ih = source('src/engine/input-handler.ts');
+  const start = ih.indexOf('private getCharPropertiesAtCellBlockAnchor');
+  assert.notEqual(start, -1, 'getCharPropertiesAtCellBlockAnchor 가 없다');
+  const body = ih.slice(start, ih.indexOf('\n  }\n', start));
+  assert.match(body,
+    /getCellCharPropertiesAt\(block\.sec, block\.ppi, block\.ci, block\.cellIndices\[0\], 0, 0\)/,
+    '앵커 기준이 블록 첫 셀의 첫 글자가 아니다');
+});
+
 test('모양 붙여넣기도 같은 셀 산출 함수를 쓴다', () => {
   // 같은 블록을 대상으로 하는 두 경로가 필터를 각자 갖고 있으면 한쪽만 고쳐진다.
   const ih = source('src/engine/input-handler.ts');


### PR DESCRIPTION
셀 블록(F5)에 굵게를 적용하면 서식은 적용되지만 툴바 눌림 상태가 갱신되지 않고, 같은 버튼 재클릭이 해제가 아니라 재적용됐다(#4119 검증 중 발견). 토글 방향이 커서 위치 조회(블록 밖 호스트 문단을 읽음)에 의존해 방금 적용한 서식이 보이지 않았고, 블록 적용 경로에 텍스트 선택 경로의 '적용 → 상태 재조회·방출' 후처리가 없었다.

블록 첫 셀 첫 글자를 단일 기준(`getCharPropertiesAtCellBlockAnchor`)으로 토글 방향과 `cursor-format-changed` 방출이 공유한다. 빈 블록(전 셀 Ctrl+클릭 제외)은 #4119 의미대로 앵커 fallback 없이 조기 종료 — 방향 산출만 커서 폴백. 소스 계약 테스트 3종 red→green(HEAD 에서 3종 FAIL 확인), 실브라우저 왕복 검증(1클릭 적용+버튼 활성, 2클릭 해제 — wasm 문서 상태 직접 확인), studio 전체 suite green, mutation 원장 불변. 기록: `mydocs/plans/task_m100_4151.md`, `mydocs/working/task_m100_4151_stage1.md`.

**시리즈 1/2** (Rust 성능 스택 #4246~#4249 와 무의존): 본 PR → #4245 재정박 가드.

Closes #4151

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---
**재검증 (2026-08-08)**: 전 레이어를 최신 `devel`(e64c853) 위로 rebase 후 ci.yml 전 단계를 로컬 완주 — fmt / scripts-tests 6종 / clippy / `cargo build --workspace` + workspace all-targets clippy / wasm32 check / **`cargo nextest run --cargo-profile release-test`** (스택 상단 5,345/5,345 pass) / Native Skia 3종 / wasm-pack dev + binding tests / tsc ci-unit / studio suite(802/802) — 6개 레이어 전부 ALL-PASS. 종전 Lint 실패 원인(workspace all-targets clippy 미실행으로 놓친 테스트 코드 1건)은 수정 완료. nextest 프로세스 격리 하에서 #4181 fixture 는 전 레이어 무재시도 안정.
