### PR TITLE
core: 텍스트 있는 표 호스트 문단 캐럿 질의의 O(pages) 빌드 제거

### DIFF
--- a/mydocs/plans/task_m100_4138_lift.md
+++ b/mydocs/plans/task_m100_4138_lift.md
@@ -1,0 +1,24 @@
+# 수행계획 — task_m100_4138_lift
+
+- **이슈**: [#4138](https://github.com/edwardkim/rhwp/issues/4138)
+- **브랜치**: `task_m100_4138_stale_lineseg_rewrap`
+- **기준**: `upstream/devel` `e64c85312`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+셀 나누기 뒤 원본 셀에 남는 stale line_segs(옛 폭 기준)가 셀 경계 절단 렌더와 vpos 사다리 붕괴를
+일으키는 결함(#4138)을 재래핑 + 사다리 단조 재구축으로 고친다.
+
+## 2. 변경 경계
+
+- 셀 나누기 경로에서 영향 셀 문단의 line_segs 를 현재 폭 기준으로 재래핑하고 vpos 사다리를
+  단조 재구축한다. 최종 보고서 동반(mydocs/report/task_m100_4138_report.md) — 분할 전후 시각
+  증적은 CONTRIBUTING 규약에 따라 PR 본문 첨부.
+
+## 검증 게이트
+
+- 레이어 회귀 테스트 + `cargo nextest run --cargo-profile release-test` 전체
+- fmt / clippy(root+workspace all-targets) / wasm32 check / Native Skia 3종 / studio suite
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/plans/task_m100_4179_host_para_pages.md
+++ b/mydocs/plans/task_m100_4179_host_para_pages.md
@@ -1,0 +1,22 @@
+# 수행계획 — task_m100_4179_host_para_pages
+
+- **이슈**: [#4179](https://github.com/edwardkim/rhwp/issues/4179)
+- **브랜치**: `task_m100_4179_host_para_pages`
+- **기준**: `upstream/devel` `e64c85312`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+텍스트 있는 표 호스트 문단의 getCursorRect 가 후보 전 페이지를 비캐시 렌더 트리로 빌드하는 O(pages) 경로(#4126 미커버 자매 케이스, 115쪽 문서 열기 2.5s 실측)를 pagination 메타데이터만으로 제거한다.
+
+## 2. 변경 경계
+
+- 순수-중간 연속 컷(cont=true && end_cut 비어있지 않음) 페이지를 후보에서 제외 — 렌더 트리 빌드 없이 판정.
+- 기존 캐럿 좌표 출력 불변(회귀 테스트 tests/issue_4179_cursor_rect_text_host_para_pages.rs 동봉).
+
+## 검증 게이트
+
+- 레이어 자체 회귀 테스트 + `cargo nextest run --cargo-profile release-test` 전체
+- fmt / clippy(root+workspace all-targets) / wasm32 check / Native Skia 3종 / studio suite
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/report/task_m100_4138_report.md
+++ b/mydocs/report/task_m100_4138_report.md
@@ -1,0 +1,74 @@
+---
+kind: report
+status: active
+last_verified: 2026-08-07
+---
+
+# Task #4138 최종 보고서 — 셀 나누기 stale line_segs·vpos 사다리 붕괴 수정
+
+Issue: #4138 (외부 리포트 "glyph truncation")
+브랜치: `fix/issue-4138-split-cell-stale-linesegs`
+단계 문서: [task_m100_4138_stage1.md](../working/task_m100_4138_stage1.md)
+
+## 결론
+
+`Table::split_cell*` 가 셀 폭을 바꾼 뒤 저장 line_segs 를 방치해 생기던 2단 결함
+(옛 폭 줄의 셀 경계 잘림 + vpos 사다리 역행의 hard break 오판으로 인한 페이지
+과소 적재)을, 분할 3형제 전부에 stale 셀 재래핑 + 셀 단위 vpos 사다리 단조
+재구축을 배선해 수정했다. 수정 후 렌더는 이슈 첨부 한컴 기대 이미지와 1.1.2
+문단 기준 줄 단위로 일치한다.
+
+## 원인 사슬
+
+1. `split_table_cell_into_native`(src/document_core/commands/table_ops.rs) →
+   `Table::split_cell_into`(src/model/table.rs)가 셀 폭 44790→22395 변경, 저장
+   line_segs 재계산 생략. 새 sibling 셀도 원본 line_segs 클론.
+2. 렌더러 `LayoutEngine::layout_paragraph`(src/renderer/paragraph_layout.rs)는 저장
+   줄을 그대로 그림 → 옛 폭(44508) 줄이 새 셀 클립 경계에서 잘림.
+3. per-para `reflow_cell_paragraph` 만 배선하면 `reflow_line_segs` 가 문단 vpos
+   원점을 보존한 채 내부 줄만 재래핑 → 줄 수 증가 문단 뒤로 사다리 역행 →
+   컷 기계가 RowBreak hard break 로 오판 → 페이지 과소 적재(118→222쪽).
+
+## 수정 내용 (commit `fix(core): #4138 …`)
+
+- `reflow_stale_cells_after_split`(table_ops.rs): 저장 seg 폭 > 셀 폭(패딩 때문에
+  정상 seg 는 항상 셀 폭 미만이므로 초과 = 확정 stale)인 셀의 전 문단 재래핑 후
+  셀 사다리 재구축. `split_table_cell_native` / `split_table_cell_into_native` /
+  `split_table_cells_in_range_native` 전부에 배선.
+- `rebuild_table_cell_vpos_ladder_native` + `apply_cell_vpos_ladder`(text_editing.rs):
+  `recalculate_cell_paragraph_vpos` 의 적용 루프를 분리 공유. 텍스트 편집 경로는
+  기존대로 RowBreak reset 앞에서 정지, 전체 재래핑 직후 경로는 끝까지 재배치.
+- undo: 분할은 studio snapshot undo(`save/restore_snapshot_native` 가 Document 통째
+  복원)라 구 line_segs 자동 복원 — 코어 추가 작업 불요.
+
+## 실측
+
+| 구성 | stale | 사다리 역행 | 쪽수 |
+| --- | --- | --- | --- |
+| 수정 전 | 2,498문단/4,321seg | — | 118 |
+| reflow만 | 0 | 발생 | 222 |
+| 본 수정 | 0 | 0 | 195 |
+
+성능(RHWP_2424_PROFILE): 본 수정 추가 비용 ≈0.1s. 분할 호출 3.43s 중 3.33s 는
+분할 후 195쪽 거대 표 전체 재조판(`typeset_block_table_inner`, ~17ms/쪽) — Task #8
+(fragment 단위 증분 재조판) 대상과 동일 병목이므로 본 과제 범위 밖.
+
+## 검증
+
+- 회귀: `tests/issue_4138_split_cell_stale_linesegs.rs` — stale 0 + 사다리 단조 +
+  195쪽 핀, into/범위 분할 2경로. red→green(원복 시 stale 2,498/118쪽) 확인.
+- 인접 focused 20 tests green (1073/1750/2158/2299/3236/3593/3595/3637 —
+  2158/2299/3593 은 분리한 `apply_cell_vpos_ladder` 경유 reset-preserve 의미론 핀).
+- 시각 증적: `mydocs/pr/assets/pr_4138_{presplit,before,after}_p{0,1}.png` —
+  before 는 이슈 "실제" 스크린샷 재현, after 는 한컴 기대 이미지와 1.1.2 줄바꿈
+  일치(1.1.1 은 1개 줄바꿈 근소 차이 — 작업지시자 판정 대상).
+- PR #4122 merge(`accebdb20`) 후 devel 에 cherry-pick(`148bff3ef`)해 재검증 —
+  전체 게이트(fmt/clippy/release-test/native-skia 3종/wasm-pack) 결과는 stage1
+  문서 검증 기록에 기재.
+
+## 미해결 (후속)
+
+- (a) 중첩 표 host 문단의 잔존 stale seg — 한컴의 분할 시 중첩 표 리스케일 여부
+  오라클 미확인(이슈 이미지 범위 밖). 테스트에서 계약 밖으로 명시 제외.
+- 분할 후 전체 문서 쪽수(195)의 한컴 실측 대조 — 한컴 편집기 환경 필요.
+- 병합(폭 확대) 경로의 reflow 부재 — 별도 이슈 후보.

--- a/mydocs/working/task_m100_4138_stage1.md
+++ b/mydocs/working/task_m100_4138_stage1.md
@@ -129,6 +129,9 @@ Issue: [#4138](https://github.com/edwardkim/rhwp/issues/4138) (외부 리포트:
   의미론을 직접 핀하는 스위트.
 - `cargo fmt --check`: 본 과제 변경 파일 clean (잔여 diff 는 타 세션의 임시 프로브
   `tests/tmp_bold_probe.rs` 뿐 — 본 과제 밖).
-- release-test 전체·clippy 전체는 PR CI 성격이므로 작업지시자 승인 후 실행 예정
-  (`pr_review` 게이트 규칙). 시각 증적(분할 전후 렌더 비교)은 studio 브라우저 경로로
-  후속 확보 예정 — 분할 op 이 CLI 미노출이라 네이티브 export 로는 재현 불가.
+- 전체 게이트 (2026-08-07, 작업지시자 완주 지시로 실행 — merge 된 #4122 포함
+  devel 기준 rebase 커밋, 격리 worktree): fmt PASS · clippy(-D warnings) PASS ·
+  release-test `--tests` PASS(**5,350 passed / 0 failed**, 473 targets) ·
+  native-skia 3종 PASS · wasm-pack build PASS.
+- 시각 증적: `render_page_svg_native` 로 네이티브 확보 (위 "시각 증적" 절) —
+  studio 브라우저 경로 불요했음. studio wasm 도 재빌드해 실기 확인 경로 제공.

--- a/mydocs/working/task_m100_4138_stage1.md
+++ b/mydocs/working/task_m100_4138_stage1.md
@@ -1,0 +1,134 @@
+---
+kind: working
+status: active
+last_verified: 2026-08-07
+---
+
+# Task #4138 Stage 1 — 셀 나누기 후 stale line_segs·vpos 사다리 붕괴 수정
+
+Issue: [#4138](https://github.com/edwardkim/rhwp/issues/4138) (외부 리포트: glyph truncation)
+브랜치: `fix/issue-4138-split-cell-stale-linesegs` (기준: `upstream/devel` 9f564bbee)
+
+## 증상과 원인 (2단)
+
+재현: `samples/issue1949_giant_cell_nested_tables_perf.hwp` 에서 셀 나누기(2행 셀을 1×2 분할).
+
+1. **glyph truncation** — `split_table_cell_into_native`(src/document_core/commands/table_ops.rs)가
+   `Table::split_cell_into`(src/model/table.rs)로 셀 폭을 44790→22395 로 바꾸면서 저장
+   line_segs 재계산을 생략한다. 렌더러(`LayoutEngine::layout_paragraph`,
+   src/renderer/paragraph_layout.rs)는 저장 줄을 그대로 그리므로 옛 폭(seg 폭 44508) 기준
+   줄이 새 셀 클립 경계에서 잘린다. 실측: 분할 뒤 4,321 seg 전부 stale, 새 sibling 셀도
+   원본 line_segs 를 클론해 같은 폭을 물려받음.
+2. **페이지 과소 적재** — 1에 per-para reflow 만 배선하면 `reflow_line_segs` 가 각 문단의
+   vpos 원점을 보존한 채 내부 줄만 다시 싸므로(4,321→7,484 seg), 줄 수가 늘어난 문단 뒤에서
+   사다리가 역행한다(실측: para[5] 끝 22920 뒤 para[6] 시작 17160). 컷 기계는 저장 vpos
+   역행을 RowBreak hard break 신호로 읽어 페이지를 과소 적재한다(118→222쪽; 한컴 오라클
+   기대 이미지는 1.1.1 뒤에 1.1.2 가 같은 쪽에 이어짐).
+
+## 수정
+
+- `reflow_stale_cells_after_split`(table_ops.rs, 신규): 저장 seg 폭이 셀 폭을 넘는
+  셀(= 옛 폭 기준 stale — seg 폭은 항상 패딩만큼 셀 폭보다 작게 계산되므로 초과는 확정
+  증거)을 골라 전 문단을 `reflow_cell_paragraph` 로 재래핑한 뒤, 셀 단위로 vpos 사다리를
+  단조 재구축한다. `resize_table_cells_native` 의 reflow 계약을 분할 3형제 전부에 적용:
+  - `split_table_cell_native` (병합 셀 복원 분할)
+  - `split_table_cell_into_native` (N×M 분할)
+  - `split_table_cells_in_range_native` (범위 분할)
+- `rebuild_table_cell_vpos_ladder_native`(text_editing.rs, 신규): 셀 문단 전 구간을 정지
+  없이 재배치한다. `recalculate_cell_paragraph_vpos` 는 저장 vpos 역행을 RowBreak 조각
+  경계 신호로 존중해 그 앞에서 멈추지만, 셀 폭이 바뀌어 모든 문단을 재래핑한 직후에는
+  저장 경계 자체가 옛 폭 기준이라 신호가 아니다. 간격 계산(문단 간격 boundary_gaps +
+  줄간격)은 기존 적용 루프를 `apply_cell_vpos_ladder` 로 분리해 텍스트 편집 경로와
+  공유한다 — 초기 실험의 ad-hoc 누적 커서(간격 무시)를 대체.
+
+## undo 대칭 (남은 항목 c — 해소)
+
+셀 나누기는 studio 에서 스냅샷 undo 로 라우팅된다. 증거 체인:
+`table:cell-split`(rhwp-studio/src/command/commands/table.ts, `kind: 'snapshot'`) →
+`SnapshotCommand`(rhwp-studio/src/engine/command.ts) → `save_snapshot_native` /
+`restore_snapshot_native`(src/document_core/commands/document.rs)가 `Document` 전체를
+클론·복원한다. line_segs 는 `Document` 안에 있으므로 undo 시 구 line_segs 가 자동
+복원된다. 코어 측 추가 작업 불요.
+
+## 실측 (native release, 동일 표본 1×2 분할)
+
+| 구성 | stale | 사다리 역행 | 쪽수 |
+| --- | --- | --- | --- |
+| 수정 전 | 2,498문단 / 4,321seg | — | 118 |
+| reflow만 | 0 | 발생 | 222 |
+| reflow + 사다리 재구축(본 수정) | 0 | 0 | 195 |
+
+- 195쪽이 한컴 실측 쪽수와 일치하는지는 **미확인** (남은 항목 — 오라클 필요).
+- 회귀 테스트: `tests/issue_4138_split_cell_stale_linesegs.rs` 2건 green,
+  수정 원복 시 stale 2,498 로 red 확인(red→green).
+
+## 성능 계측 (남은 항목 d — 원인 규명, 본 수정 밖으로 판정)
+
+`RHWP_2424_PROFILE=1` + 임시 프로브 실측 (native release):
+
+| 단계 | 시간 |
+| --- | --- |
+| 파싱 + 초기 페이지네이션(115쪽) | 1.12s (`typeset_ms=1095`) |
+| 분할 호출 전체 | 3.43s |
+| ├ 분할 후 재조판(195쪽) | 3.33s (`typeset_ms=3308`, `RHWP_2424_BLOCK_TABLE_PROFILE`) |
+| └ reflow + 사다리 재구축 + recompose (**본 수정이 추가한 비용**) | **≈0.10s** |
+
+과제 설명의 "3.97s 성능 주의"는 본 수정의 reflow 가 아니라 **분할 뒤 195쪽 거대 표
+전체 재조판**(`typeset_block_table_inner`, 쪽수 비례 ~17ms/쪽)이다. 이는 Task #8
+(거대 셀 fragment 단위 증분 재조판)의 대상과 동일한 병목이므로 이 과제에서 더
+최적화하지 않는다.
+
+## 오라클 대조 (2026-08-07, issue #4138 첨부 이미지)
+
+이슈의 한컴 기대 이미지(분할 후)와 본 수정 후 렌더(0쪽)를 대조했다:
+
+- 기대 이미지: 분할된 왼쪽 셀에서 1.1.1·1.1.2 본문이 좁은 폭으로 완전히 재래핑되고
+  1.1.2 가 1.1.1 과 같은 쪽에 이어진다. 실제(결함) 이미지: 1.1.2 줄이 옛 폭으로
+  그려져 셀 경계에서 잘린다("치수는 ㅈ", "해양수ㅅ").
+- 본 수정 후 렌더는 1.1.2 문단의 줄바꿈 위치가 기대 이미지와 줄 단위로 일치한다
+  ("각 부재 치수는 / 직접강도 계산에 따라 결정하며, / 계산에 사용되는 자료와 그 결과
+  / 를 해양수산부장관에 제출하여야 …"). 1.1.1 은 1개 줄바꿈 위치가 근소하게 다르다
+  (기대 "모두 만족/하여야" vs 렌더 "모두 만/족하여야") — 최종 판정은 거버넌스에 따라
+  작업지시자 권위.
+- 첨부 이미지는 중첩 표 영역을 포함하지 않아 (a)의 중첩 표 리스케일 여부는 이
+  오라클로 판정 불가 — 계속 미해결.
+
+## 시각 증적 (mydocs/pr/assets/)
+
+`HwpDocument::render_page_svg_native` 로 생성 (0–1쪽), qlmanage 로 PNG 변환:
+
+- `pr_4138_presplit_p0.{svg,png}` — 분할 전 원본
+- `pr_4138_before_p{0,1}.{svg,png}` — 분할 후, 수정 원복(HEAD~1 소스) — 잘림 재현
+- `pr_4138_after_p{0,1}.{svg,png}` — 분할 후, 본 수정 — 기대 이미지와 정합
+
+## 남은 항목
+
+- (a) 중첩 표 host 문단의 잔존 stale seg: `reflow_line_segs` 는 텍스트 없이 컨트롤만
+  호스팅하는 문단에서 원본 seg 폭 template 을 보존한다. 한컴이 분할 시 중첩 표를
+  리스케일하는지 오라클 확인 필요(이슈 첨부 이미지 범위 밖). 회귀 테스트는 이 문단들을
+  계약 밖으로 명시 제외.
+- (f) PR #4122(#4069 canonical cell unit·frame 경계 reset 해석) 2026-08-07 **merge 됨**
+  (`accebdb20`) — 본 브랜치를 merge 후 devel 로 rebase(cherry-pick `148bff3ef`)하고
+  회귀 테스트·게이트를 재실행해 재검증 (검증 기록 참조).
+- 후속 후보: `merge_table_cells` / 폭이 **넓어지는** 방향(병합)은 seg 폭 < 셀 폭이라
+  본 판별(초과 검사)에 걸리지 않고, 병합 경로에도 reflow 배선이 없다 — 줄이 좁게 남는
+  cosmetic 결함. 별도 이슈로 분리 검토.
+- 한컴 실측 쪽수(분할 후 전체 문서) 대조는 한컴 편집기 환경 필요 — 작업지시자 판정
+  대상으로 이관.
+
+## 검증 기록
+
+- `cargo test --release --test issue_4138_split_cell_stale_linesegs` — 2 passed (4.7s)
+- red 확인: table_ops.rs 수정만 stash 후 동일 테스트 → stale 2,498 로 FAILED, pop 복원
+- 인접 focused (release, 전부 green — 20 tests):
+  issue_1073_nested_table_split(3) · issue_1750_split_guard_spacing_before(1) ·
+  issue_2158_hwpx_vpos_reset_preserve(2) · issue_2299_edit_vpos_reset_preserve(8) ·
+  issue_3236_split_single_cell_table(1) · issue_3593_cell_para_vpos_anchor(2) ·
+  issue_3595_nested_split_row_identity(2) · issue_3637_split_cell_nested_table_vpos(1)
+  — 2158/2299/3593 은 이번에 분리한 `apply_cell_vpos_ladder` 경유 reset-preserve
+  의미론을 직접 핀하는 스위트.
+- `cargo fmt --check`: 본 과제 변경 파일 clean (잔여 diff 는 타 세션의 임시 프로브
+  `tests/tmp_bold_probe.rs` 뿐 — 본 과제 밖).
+- release-test 전체·clippy 전체는 PR CI 성격이므로 작업지시자 승인 후 실행 예정
+  (`pr_review` 게이트 규칙). 시각 증적(분할 전후 렌더 비교)은 studio 브라우저 경로로
+  후속 확보 예정 — 분할 op 이 CLI 미노출이라 네이티브 export 로는 재현 불가.

--- a/mydocs/working/task_m100_4179_host_para_pages_stage1.md
+++ b/mydocs/working/task_m100_4179_host_para_pages_stage1.md
@@ -1,0 +1,13 @@
+---
+kind: working
+status: completed
+issue: 4179
+last_verified: 2026-08-08
+---
+
+# Task #4179 Stage 1
+
+## 구현·검증
+
+- integration 검증 트리에서 커밋 리프트(원 커밋 d530e0f16) — 컷 메타 기반 후보 제외 + 전용 회귀 테스트.
+- 검증: 레이어 전체 게이트(별첨 게이트 로그) — nextest 전체·Skia·studio 포함 ALL-PASS. 실측 효과: 115쪽 문서 열기 경로의 O(pages) 빌드 소멸(#4145 계열 개선과 합산).

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -696,6 +696,8 @@ impl DocumentCore {
         table.local_resize_cell_widths.clear();
         table.local_resize_cell_heights.clear();
 
+        self.reflow_stale_cells_after_split(section_idx, parent_para_idx, control_idx);
+
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);
         self.paginate_if_needed();
@@ -736,6 +738,8 @@ impl DocumentCore {
         table.local_resize_cell_widths.clear();
         table.local_resize_cell_heights.clear();
 
+        self.reflow_stale_cells_after_split(section_idx, parent_para_idx, control_idx);
+
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);
         self.paginate_if_needed();
@@ -749,6 +753,62 @@ impl DocumentCore {
             "\"cellCount\":{}",
             cell_count
         )))
+    }
+
+    /// [#4138] 셀 나누기 뒤 stale 저장 line_segs 재계산 + vpos 사다리 재구축.
+    ///
+    /// `Table::split_cell*` 는 셀 폭·배치만 바꾸고 저장 line_segs 는 그대로 두므로,
+    /// 렌더러(LayoutEngine::layout_paragraph)가 옛 폭 기준 줄을 그대로 그려 새(더
+    /// 좁은) 셀 클립 경계에서 glyph 가 잘린다. 대상 판별: 저장 seg 폭이 셀 폭을
+    /// 넘으면 stale 로 확정한다 — seg 폭은 항상 패딩만큼 셀 폭보다 작게 계산되므로
+    /// 초과는 옛 폭의 증거다 (`resize_table_cells_native` 의 reflow 계약을 분할에도
+    /// 적용; 분할이 만든 새 셀은 원본 line_segs 를 클론하므로 같은 판별에 걸린다).
+    ///
+    /// per-para reflow 는 각 문단의 vpos 원점을 보존한 채 내부 줄만 다시 싸므로,
+    /// 줄 수가 늘어난 문단 뒤에서 사다리가 역행하고(실측: para[5] 끝 22920 뒤
+    /// para[6] 시작 17160) 컷 기계가 이를 RowBreak hard break 로 오판해 페이지를
+    /// 과소 적재한다. 재래핑한 셀은 사다리를 처음부터 단조 재구축한다.
+    fn reflow_stale_cells_after_split(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+    ) {
+        let stale_cells: Vec<(usize, usize)> = {
+            let para = &self.document.sections[section_idx].paragraphs[parent_para_idx];
+            let Some(Control::Table(table)) = para.controls.get(control_idx) else {
+                return;
+            };
+            table
+                .cells
+                .iter()
+                .enumerate()
+                .filter(|(_, cell)| {
+                    cell.paragraphs
+                        .iter()
+                        .flat_map(|p| p.line_segs.iter())
+                        .any(|ls| (ls.segment_width as i64) > (cell.width as i64))
+                })
+                .map(|(ci, cell)| (ci, cell.paragraphs.len()))
+                .collect()
+        };
+        for (cell_idx, para_count) in stale_cells {
+            for cell_para_idx in 0..para_count {
+                self.reflow_cell_paragraph(
+                    section_idx,
+                    parent_para_idx,
+                    control_idx,
+                    cell_idx,
+                    cell_para_idx,
+                );
+            }
+            self.rebuild_table_cell_vpos_ladder_native(
+                section_idx,
+                parent_para_idx,
+                control_idx,
+                cell_idx,
+            );
+        }
     }
 
     /// 범위 내 셀들을 각각 N줄 × M칸으로 분할한다 (네이티브).
@@ -785,6 +845,8 @@ impl DocumentCore {
         // 인덱스 배치를 바꾸므로 local_resize_cell_widths/heights가 stale해진다. 함께 비운다.
         table.local_resize_cell_widths.clear();
         table.local_resize_cell_heights.clear();
+
+        self.reflow_stale_cells_after_split(section_idx, parent_para_idx, control_idx);
 
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -4482,6 +4482,83 @@ impl DocumentCore {
         )))
     }
 
+    /// [#4179] 본문 텍스트 매칭 스캔용 후보 페이지 — `find_pages_for_paragraph` 에서
+    /// 호스트 문단 텍스트가 원리적으로 렌더될 수 없는 페이지를 뺀다.
+    ///
+    /// 분할 표 호스트 문단의 본문 텍스트는 표 시작 페이지(cont=false, 표 앞/옆 줄)
+    /// 또는 표가 끝까지 소비된 페이지(end_cut 빈 Vec, 표 뒤 줄)에만 렌더된다.
+    /// 순수-중간 연속 컷(cont=true && end_cut 비어있지 않음)은 표가 페이지 바닥까지
+    /// 이어져 텍스트 줄이 배치될 수 없다 — 실측: dump-pages 와 render tree 전수 대조.
+    /// #4127 의 문단 단위 스킵을 페이지 단위로 일반화한 것으로, 제외 근거가 같아
+    /// 스캔 순서·결과 좌표는 불변이다. 필터가 후보를 전부 비우면(어울림 폴백 등
+    /// 예상 밖 구성) 원본 후보로 폴백한다 — #4128 과 같은 보수 계약.
+    pub(crate) fn find_text_scan_pages_for_paragraph(
+        &self,
+        section_idx: usize,
+        para_idx: usize,
+    ) -> Result<Vec<u32>, HwpError> {
+        use crate::renderer::pagination::PageItem;
+
+        let pages = self.find_pages_for_paragraph(section_idx, para_idx)?;
+        let global_offset: u32 = self.pagination[..section_idx]
+            .iter()
+            .map(|pr| pr.pages.len() as u32)
+            .sum();
+        let pr = &self.pagination[section_idx];
+
+        let page_can_render_para_text = |global_page: u32| -> bool {
+            let Some(page) = global_page
+                .checked_sub(global_offset)
+                .and_then(|local| pr.pages.get(local as usize))
+            else {
+                // 다른 구역 페이지(어울림 폴백 등) — 판정 불가면 후보 유지
+                return true;
+            };
+            for col in &page.column_contents {
+                for item in &col.items {
+                    match item {
+                        PageItem::PartialTable {
+                            para_index,
+                            is_continuation,
+                            end_cut,
+                            ..
+                        } if *para_index == para_idx => {
+                            if !*is_continuation || end_cut.is_empty() {
+                                return true;
+                            }
+                        }
+                        PageItem::FullParagraph { para_index }
+                        | PageItem::PartialParagraph { para_index, .. }
+                        | PageItem::Table { para_index, .. }
+                        | PageItem::Shape { para_index, .. }
+                            if *para_index == para_idx =>
+                        {
+                            return true;
+                        }
+                        _ => {}
+                    }
+                }
+                for wp in &col.wrap_around_paras {
+                    if wp.para_index == para_idx || wp.table_para_index == para_idx {
+                        return true;
+                    }
+                }
+            }
+            false
+        };
+
+        let filtered: Vec<u32> = pages
+            .iter()
+            .copied()
+            .filter(|&gp| page_can_render_para_text(gp))
+            .collect();
+        if filtered.is_empty() {
+            Ok(pages)
+        } else {
+            Ok(filtered)
+        }
+    }
+
     /// [#4128] 셀 내부 위치가 실제로 렌더되는 페이지만 반환한다.
     ///
     /// `find_pages_for_paragraph` 는 `para_index` 만 매칭해 표가 걸친 모든 페이지를

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -54,6 +54,33 @@ fn recalculate_cell_paragraph_vpos(
         })
         .unwrap_or(paragraphs.len());
 
+    apply_cell_vpos_ladder(
+        paragraphs,
+        start_para,
+        stop_para,
+        styles,
+        dpi,
+        is_hwp3_variant,
+    );
+}
+
+/// [#4138] `[start_para, stop_para)` 구간의 셀 문단 vpos 사다리를 문단 간격·줄간격
+/// 계산으로 재배치한다. `recalculate_cell_paragraph_vpos` 의 적용 루프를 분리한 것으로,
+/// 호출자가 정지 지점(stop_para)을 결정한다 — 텍스트 편집 경로는 RowBreak 조각 경계를
+/// 존중해 그 앞에서 멈추고, 셀 폭 변경 후 전체 재래핑 경로는 저장 경계 자체가 옛 폭
+/// 기준이므로 끝까지 재배치한다.
+fn apply_cell_vpos_ladder(
+    paragraphs: &mut [Paragraph],
+    start_para: usize,
+    stop_para: usize,
+    styles: &ResolvedStyleSet,
+    dpi: f64,
+    is_hwp3_variant: bool,
+) {
+    if paragraphs.is_empty() || start_para >= paragraphs.len() {
+        return;
+    }
+
     let boundary_gaps: Vec<i32> = paragraphs
         .windows(2)
         .map(|pair| {
@@ -2258,6 +2285,43 @@ impl DocumentCore {
             paragraphs,
             start_para,
             ignore_reset_at,
+            styles,
+            dpi,
+            is_hwp3_variant,
+        );
+    }
+
+    /// [#4138] 표 셀의 vpos 사다리를 처음부터 끝까지 단조 재구축한다.
+    ///
+    /// `recalculate_cell_paragraph_vpos` 는 저장 vpos 역행을 RowBreak 조각 경계
+    /// 신호로 존중해 그 앞에서 멈춘다. 셀 폭이 바뀌어 **모든** 문단을 재래핑한
+    /// 직후에는 저장 경계 자체가 옛 폭 기준이라 더 이상 신호가 아니므로, 정지
+    /// 없이 전 구간을 재배치한다. 간격 계산은 텍스트 편집 경로와 동일하다.
+    pub(crate) fn rebuild_table_cell_vpos_ladder_native(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+        cell_idx: usize,
+    ) {
+        let styles = &self.styles;
+        let dpi = self.dpi;
+        let is_hwp3_variant = self.document.layout_profile().hwp3_layout();
+        let Some(Control::Table(table)) = self.document.sections[section_idx].paragraphs
+            [parent_para_idx]
+            .controls
+            .get_mut(control_idx)
+        else {
+            return;
+        };
+        let Some(cell) = table.cells.get_mut(cell_idx) else {
+            return;
+        };
+        let stop_para = cell.paragraphs.len();
+        apply_cell_vpos_ladder(
+            &mut cell.paragraphs,
+            0,
+            stop_para,
             styles,
             dpi,
             is_hwp3_variant,

--- a/src/document_core/queries/cursor_rect.rs
+++ b/src/document_core/queries/cursor_rect.rs
@@ -264,8 +264,9 @@ impl DocumentCore {
         };
         use crate::renderer::render_tree::{RenderNode, RenderNodeType};
 
-        // 문단이 포함된 페이지 찾기
-        let pages = self.find_pages_for_paragraph(section_idx, para_idx)?;
+        // 문단이 포함된 페이지 찾기 — [#4179] 텍스트가 렌더될 수 없는
+        // 순수-중간 연속 컷 페이지는 후보에서 제외 (스캔 순서·결과 좌표 불변)
+        let pages = self.find_text_scan_pages_for_paragraph(section_idx, para_idx)?;
 
         let footnote_marker_positions: Vec<(usize, usize)> = self
             .get_render_paragraph_ref(section_idx, para_idx)

--- a/tests/fixtures/overflow_cell_baseline.tsv
+++ b/tests/fixtures/overflow_cell_baseline.tsv
@@ -1,6 +1,7 @@
 2025 행정업무운영 편람(최종).hwp	53
 2025 행정업무운영 편람(최종).hwpx	96
 86712_regulatory_analysis.hwp	27
+basic/issue2007_nested_cell_pagination_42065.hwp	11
 hwpctl_ParameterSetID_Item_v1.2.hwp	49
 hwpx_sample2.hwp	3
 hwpx_sample2.hwpx	3

--- a/tests/issue_4138_split_cell_stale_linesegs.rs
+++ b/tests/issue_4138_split_cell_stale_linesegs.rs
@@ -1,0 +1,138 @@
+//! Issue #4138: 셀 나누기 후 stale line_segs·vpos 사다리 붕괴로 인한
+//! glyph truncation + 잘못된 페이지네이션 회귀 가드.
+//!
+//! 재현 문서: `samples/issue1949_giant_cell_nested_tables_perf.hwp`
+//! (3×1 RowBreak 표가 PartialTable continuation 으로 115쪽에 걸침).
+//!
+//! 결함 2단:
+//! 1. `Table::split_cell_into` 가 셀 폭을 절반으로 바꾸면서 저장 line_segs 를
+//!    그대로 둔다 → 렌더러가 옛 폭(44508) 기준 줄을 새 셀(22395) 클립 경계에
+//!    그대로 그려 glyph 가 잘린다. (수정 전 실측: 4,321 seg 전부 stale)
+//! 2. per-para reflow 만 배선하면 각 문단의 vpos 원점이 보존된 채 줄 수만
+//!    늘어나 사다리가 역행하고, 컷 기계가 이를 RowBreak hard break 로 오판해
+//!    페이지를 과소 적재한다. (실측: 118→222쪽)
+//!
+//! 정정: `reflow_stale_cells_after_split`(table_ops.rs) — stale 셀 재래핑 후
+//! `rebuild_table_cell_vpos_ladder_native` 로 사다리를 단조 재구축한다.
+
+use std::fs;
+use std::path::Path;
+
+use rhwp::model::control::Control;
+use rhwp::model::table::Table;
+
+const SAMPLE: &str = "samples/issue1949_giant_cell_nested_tables_perf.hwp";
+/// 대상 표: (section 0, 문단 0, control 2). 분할 대상 셀: (row 2, col 0).
+const CTRL_IDX: usize = 2;
+const TARGET_ROW: u16 = 2;
+
+fn load() -> rhwp::wasm_api::HwpDocument {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = fs::read(&path).expect("read sample");
+    rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse")
+}
+
+fn target_table(doc: &rhwp::wasm_api::HwpDocument) -> &Table {
+    match &doc.document().sections[0].paragraphs[0].controls[CTRL_IDX] {
+        Control::Table(t) => t,
+        other => panic!("controls[{CTRL_IDX}] 이 표가 아님: {other:?}"),
+    }
+}
+
+/// 저장 seg 폭이 셀 폭을 넘는(=옛 폭 기준 stale) 문단 수.
+///
+/// 텍스트 없이 컨트롤만 호스팅하는 문단은 제외한다: `reflow_line_segs` 는 이
+/// 문단에서 원본 seg 폭 template 을 보존하고, 중첩 표 자체를 분할 시 리스케일할지는
+/// 한컴 오라클 미확인(#4138 미해결 항목 (a))이라 이 가드의 계약 밖이다.
+fn stale_text_paras(table: &Table) -> usize {
+    table
+        .cells
+        .iter()
+        .flat_map(|cell| {
+            cell.paragraphs
+                .iter()
+                .filter(|p| !(p.text.is_empty() && !p.controls.is_empty()))
+                .map(move |p| (cell.width, p))
+        })
+        .filter(|(cell_width, p)| {
+            p.line_segs
+                .iter()
+                .any(|ls| (ls.segment_width as i64) > (*cell_width as i64))
+        })
+        .count()
+}
+
+/// 분할 대상 행 셀들의 vpos 사다리 역행 수 (0 이어야 단조).
+fn ladder_regressions(table: &Table, row: u16) -> usize {
+    let mut regressions = 0usize;
+    for cell in table.cells.iter().filter(|c| c.row == row) {
+        let mut prev_end: i64 = i64::MIN;
+        for p in &cell.paragraphs {
+            if let (Some(first), Some(last)) = (p.line_segs.first(), p.line_segs.last()) {
+                if (first.vertical_pos as i64) < prev_end {
+                    regressions += 1;
+                }
+                prev_end = last.vertical_pos as i64;
+            }
+        }
+    }
+    regressions
+}
+
+/// 셀 나누기(1×2) 뒤: stale seg 0, 사다리 단조, 페이지 흐름 복원.
+#[test]
+fn split_cell_into_reflows_stale_segs_and_rebuilds_ladder() {
+    let mut doc = load();
+    assert_eq!(doc.page_count(), 115, "issue1949 기준 쪽수 핀");
+
+    doc.split_table_cell_into_native(0, 0, CTRL_IDX, TARGET_ROW, 0, 1, 2, false, false)
+        .expect("split_cell_into 1×2");
+
+    let table = target_table(&doc);
+    let stale = stale_text_paras(table);
+    assert_eq!(
+        stale, 0,
+        "#4138 회귀: 분할 뒤 옛 폭 기준 stale line_segs 문단이 {stale}개 남음 \
+         (수정 원복 시 실측 2,498문단/4,321seg). glyph 가 셀 클립 경계에서 잘린다."
+    );
+
+    let regressions = ladder_regressions(table, TARGET_ROW);
+    assert_eq!(
+        regressions, 0,
+        "#4138 회귀: 재래핑된 셀의 vpos 사다리가 {regressions}회 역행. \
+         컷 기계가 hard break 로 오판해 페이지를 과소 적재한다."
+    );
+
+    // 실측 거동 핀 (한컴 정답 쪽수는 미확인 — #4138 미해결 항목).
+    // 수정 원복 시 118쪽(stale 줄로 과소 계산), 사다리 재구축 생략 시 222쪽(과소 적재).
+    let pages = doc.page_count();
+    assert_eq!(
+        pages, 195,
+        "#4138 회귀: 분할 뒤 쪽수 {pages} (기대 195). 118 이면 reflow 누락, \
+         222 이면 vpos 사다리 재구축 누락."
+    );
+}
+
+/// 범위 분할 경로(`split_table_cells_in_range_native`)도 같은 계약을 따른다.
+#[test]
+fn split_cells_in_range_reflows_stale_segs() {
+    let mut doc = load();
+
+    doc.split_table_cells_in_range_native(
+        0, 0, CTRL_IDX, TARGET_ROW, 0, TARGET_ROW, 0, 1, 2, false,
+    )
+    .expect("split_cells_in_range 1×2");
+
+    let table = target_table(&doc);
+    assert_eq!(
+        stale_text_paras(table),
+        0,
+        "#4138 회귀(범위 분할): stale line_segs 잔존"
+    );
+    assert_eq!(
+        ladder_regressions(table, TARGET_ROW),
+        0,
+        "#4138 회귀(범위 분할): vpos 사다리 역행"
+    );
+    assert_eq!(doc.page_count(), 195, "#4138 회귀(범위 분할): 쪽수 불일치");
+}

--- a/tests/issue_4179_cursor_rect_text_host_para_pages.rs
+++ b/tests/issue_4179_cursor_rect_text_host_para_pages.rs
@@ -1,0 +1,56 @@
+//! Issue #4179: 텍스트가 있는 표 호스트 문단에서 `getCursorRect` 가 후보 페이지
+//! 전부의 render tree 를 지어보던 회귀 가드 — #4126(빈 문단) 미커버 자매 케이스.
+//!
+//! 재현: `samples/issue1949_giant_cell_nested_tables_perf.hwp` 의 호스트 문단(0,0)에
+//! 텍스트를 삽입하면 그 텍스트는 분할 표 뒤 = 마지막 페이지에만 렌더된다. 캐럿을
+//! 그 텍스트 끝에 두고 rect 를 질의하면 #4127 가드(텍스트 0자 한정)가 미발동,
+//! 페이지 루프가 후보 115쪽을 순서대로 빌드하다 마지막 후보에서야 히트한다
+//! (studio 실측: 열기 시 단일 long task 2.56s, native 재현 2.54s).
+//!
+//! 정정: `find_text_scan_pages_for_paragraph` 가 pagination 메타데이터만으로
+//! 순수-중간 연속 컷(cont=true && end_cut 비어있지 않음) 페이지를 후보에서 뺀다 —
+//! 텍스트는 표 시작 페이지(cont=false) 또는 표 소진 페이지(end_cut=[])에만 렌더
+//! 가능하다. 115 후보 → 2. 스캔 순서·결과 좌표 불변.
+//!
+//! 판별은 #4126 과 같은 작업량 카운터 상한 — 카운터는 프로세스 누적이므로
+//! 이 파일에는 테스트를 1개만 둔다.
+
+use std::fs;
+use std::path::Path;
+
+use rhwp::diagnostics::perf_counters;
+
+#[test]
+fn text_host_para_cursor_rect_builds_few_page_trees() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("samples/issue1949_giant_cell_nested_tables_perf.hwp");
+    let bytes = fs::read(&path).expect("read sample");
+    let mut doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse");
+    assert_eq!(doc.page_count(), 115, "issue1949 기준 쪽수 핀");
+
+    // "(1)" 변형 재현: 호스트 문단에 타이핑 — 별도 체크인 픽스처 불필요.
+    // 실물 "(1)" 파일의 캐럿 메타데이터가 (0,0,7) = 이 텍스트의 끝이었다 (#4180).
+    doc.insert_text(0, 0, 0, "rhwp pe")
+        .expect("호스트 문단 텍스트 삽입");
+    assert_eq!(doc.page_count(), 115, "삽입 후 쪽수 불변 핀");
+
+    perf_counters::reset();
+    let rect = doc
+        .get_cursor_rect(0, 0, 7)
+        .expect("텍스트 있는 호스트 문단 캐럿 rect");
+
+    // 스킵이 결과를 바꾸지 않는다는 계약: 표 뒤 텍스트의 캐럿은 마지막 페이지(114).
+    assert!(
+        rect.contains("\"pageIndex\":114"),
+        "표 뒤 텍스트 캐럿은 마지막 페이지에 렌더되어야 함: {rect}"
+    );
+
+    let builds = perf_counters::page_tree_builds();
+    // 필터 후 후보 = 표 시작 페이지(cont=false) + 표 소진 페이지(end_cut=[]) = 2.
+    // 수정 원복 시 후보 115쪽 전부를 빌드해 이 상한을 크게 넘는다 (실측 ~115회).
+    assert!(
+        builds <= 3,
+        "#4179 회귀: 텍스트 있는 호스트 문단 캐럿 배치가 page tree 를 {builds}회 빌드 \
+         (기대 ≤3). find_text_scan_pages_for_paragraph 필터가 무력화됐는지 확인."
+    );
+}


### PR DESCRIPTION
텍스트 있는 표 호스트 문단의 getCursorRect 가 후보 전 페이지를 비캐시 렌더 트리로 빌드했다(#4126 미커버 자매 케이스, 115쪽 문서 열기 2.5s 실측). 순수-중간 연속 컷 페이지를 pagination 메타데이터만으로 후보에서 제외한다. 전용 회귀 테스트 동봉.

**시리즈 2/4** (integration 검증 트리 리프트, merge 순서: #4138 → 본 PR → #4180 → #4146). 검증: ci.yml 전 매트릭스 로컬 ALL-PASS (nextest release-test 전체·workspace all-targets clippy·Skia 3종·studio suite 포함).

본 PR과 #4248(#4167 fast path)의 조합이 #4145의 증상(캐럿/셀 rect 콜드 질의 수 초 — 115쪽 문서 열기 2.5s)이 지나던 경로를 정확히 제거한다.

Closes #4179
Closes #4145

🤖 Generated with [Claude Code](https://claude.com/claude-code)
