### PR TITLE
studio: 거대 분할 표 셀 Enter 의 stale deferred pagination 무계산 취소

### DIFF
--- a/mydocs/plans/task_m100_4138_lift.md
+++ b/mydocs/plans/task_m100_4138_lift.md
@@ -1,0 +1,24 @@
+# 수행계획 — task_m100_4138_lift
+
+- **이슈**: [#4138](https://github.com/edwardkim/rhwp/issues/4138)
+- **브랜치**: `task_m100_4138_stale_lineseg_rewrap`
+- **기준**: `upstream/devel` `e64c85312`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+셀 나누기 뒤 원본 셀에 남는 stale line_segs(옛 폭 기준)가 셀 경계 절단 렌더와 vpos 사다리 붕괴를
+일으키는 결함(#4138)을 재래핑 + 사다리 단조 재구축으로 고친다.
+
+## 2. 변경 경계
+
+- 셀 나누기 경로에서 영향 셀 문단의 line_segs 를 현재 폭 기준으로 재래핑하고 vpos 사다리를
+  단조 재구축한다. 최종 보고서 동반(mydocs/report/task_m100_4138_report.md) — 분할 전후 시각
+  증적은 CONTRIBUTING 규약에 따라 PR 본문 첨부.
+
+## 검증 게이트
+
+- 레이어 회귀 테스트 + `cargo nextest run --cargo-profile release-test` 전체
+- fmt / clippy(root+workspace all-targets) / wasm32 check / Native Skia 3종 / studio suite
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/plans/task_m100_4146_cell_enter_latency.md
+++ b/mydocs/plans/task_m100_4146_cell_enter_latency.md
@@ -1,0 +1,22 @@
+# 수행계획 — task_m100_4146_cell_enter_latency
+
+- **이슈**: [#4146](https://github.com/edwardkim/rhwp/issues/4146)
+- **브랜치**: `task_m100_4146_cell_enter_latency`
+- **기준**: `upstream/devel` `e64c85312`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+거대 분할 표 셀의 Enter(문단 분리) 후 전체 fragment 재조판으로 인한 지연(#4146)을 stale deferred pagination 의 무계산 취소와 split 완료 소유 이전으로 해소한다.
+
+## 2. 변경 경계
+
+- 3단계 리프트: 기준선 probe(테스트) → stale deferred pagination 무계산 취소(perf) → split 완료 소유를 command effects 선언으로 이전(fix) + 셀 Enter pagination 계약 e2e.
+- pagination 결과 계약 불변 — e2e 가 실브라우저 검증 보고 포함.
+
+## 검증 게이트
+
+- 레이어 자체 회귀 테스트 + `cargo nextest run --cargo-profile release-test` 전체
+- fmt / clippy(root+workspace all-targets) / wasm32 check / Native Skia 3종 / studio suite
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/plans/task_m100_4179_host_para_pages.md
+++ b/mydocs/plans/task_m100_4179_host_para_pages.md
@@ -1,0 +1,22 @@
+# 수행계획 — task_m100_4179_host_para_pages
+
+- **이슈**: [#4179](https://github.com/edwardkim/rhwp/issues/4179)
+- **브랜치**: `task_m100_4179_host_para_pages`
+- **기준**: `upstream/devel` `e64c85312`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+텍스트 있는 표 호스트 문단의 getCursorRect 가 후보 전 페이지를 비캐시 렌더 트리로 빌드하는 O(pages) 경로(#4126 미커버 자매 케이스, 115쪽 문서 열기 2.5s 실측)를 pagination 메타데이터만으로 제거한다.
+
+## 2. 변경 경계
+
+- 순수-중간 연속 컷(cont=true && end_cut 비어있지 않음) 페이지를 후보에서 제외 — 렌더 트리 빌드 없이 판정.
+- 기존 캐럿 좌표 출력 불변(회귀 테스트 tests/issue_4179_cursor_rect_text_host_para_pages.rs 동봉).
+
+## 검증 게이트
+
+- 레이어 자체 회귀 테스트 + `cargo nextest run --cargo-profile release-test` 전체
+- fmt / clippy(root+workspace all-targets) / wasm32 check / Native Skia 3종 / studio suite
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/plans/task_m100_4180_caret_meta_on_save.md
+++ b/mydocs/plans/task_m100_4180_caret_meta_on_save.md
@@ -1,0 +1,22 @@
+# 수행계획 — task_m100_4180_caret_meta_on_save
+
+- **이슈**: [#4180](https://github.com/edwardkim/rhwp/issues/4180)
+- **브랜치**: `task_m100_4180_caret_meta_on_save`
+- **기준**: `upstream/devel` `e64c85312`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+문서 캐럿 메타데이터(DOCUMENT_PROPERTIES)가 마지막 본문 편집 위치를 기록해 열기 시 캐럿이 엉뚱한 페이지로 복원되는 결함(#4180, 실측: 마지막 페이지)을 저장 시점 캐럿 기록으로 바로잡는다.
+
+## 2. 변경 경계
+
+- 본문 편집마다의 메타 갱신을 제거하고 저장 경로에서 현재 캐럿을 스탬프.
+- 라운드트립 회귀 테스트 tests/issue_4180_caret_stamp_roundtrip.rs 동봉.
+
+## 검증 게이트
+
+- 레이어 자체 회귀 테스트 + `cargo nextest run --cargo-profile release-test` 전체
+- fmt / clippy(root+workspace all-targets) / wasm32 check / Native Skia 3종 / studio suite
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/report/assets/task_m100_4031_stage1_baseline.log
+++ b/mydocs/report/assets/task_m100_4031_stage1_baseline.log
@@ -1,0 +1,246 @@
+test issue_4031_profile_cold_enter_split ... RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=1135.149 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=1152.706 invalidate_ms=0.000 normalize_ms=0.054 setup_ms=0.150 measure_ms=16.235 typeset_ms=1136.108 postprocess_ms=0.158 cleanup_ms=0.000 other_ms=0.000
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=1114.503 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=1129.953 invalidate_ms=0.000 normalize_ms=0.027 setup_ms=0.001 measure_ms=15.117 typeset_ms=1114.647 postprocess_ms=0.160 cleanup_ms=0.000 other_ms=0.000
+RHWP_4031_COLD_ENTER run=1 format=hwp pos=top stroke=1 split_ms=1130.165 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=1109.254 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=1124.344 invalidate_ms=0.000 normalize_ms=0.027 setup_ms=0.001 measure_ms=14.768 typeset_ms=1109.392 postprocess_ms=0.155 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=1 format=hwp pos=top stroke=2 split_ms=1124.480 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=1157.190 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=1172.493 invalidate_ms=0.000 normalize_ms=0.029 setup_ms=0.001 measure_ms=14.987 typeset_ms=1157.327 postprocess_ms=0.149 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=1 format=hwp pos=top stroke=3 split_ms=1172.602 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=1176.758 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=1192.233 invalidate_ms=0.000 normalize_ms=0.047 setup_ms=0.001 measure_ms=15.083 typeset_ms=1176.891 postprocess_ms=0.210 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=1 format=hwp pos=bottom stroke=1 split_ms=1192.323 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=1513.882 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=1529.575 invalidate_ms=0.000 normalize_ms=0.029 setup_ms=0.001 measure_ms=15.218 typeset_ms=1514.032 postprocess_ms=0.295 cleanup_ms=0.000 other_ms=0.000
+RHWP_4031_COLD_ENTER run=1 format=hwp pos=bottom stroke=2 split_ms=1529.676 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=2206.500 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=2229.945 invalidate_ms=0.000 normalize_ms=0.064 setup_ms=0.001 measure_ms=22.739 typeset_ms=2206.758 postprocess_ms=0.381 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=1 format=hwp pos=bottom stroke=3 split_ms=2230.145 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=2512.469 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=2546.318 invalidate_ms=0.000 normalize_ms=0.032 setup_ms=0.001 measure_ms=33.461 typeset_ms=2512.653 postprocess_ms=0.170 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=2211.009 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=2238.053 invalidate_ms=0.000 normalize_ms=0.033 setup_ms=0.001 measure_ms=26.541 typeset_ms=2211.165 postprocess_ms=0.312 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=1 format=hwpx pos=top stroke=1 split_ms=2238.300 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=2364.477 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=2394.326 invalidate_ms=0.000 normalize_ms=0.072 setup_ms=0.001 measure_ms=29.377 typeset_ms=2364.682 postprocess_ms=0.193 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=1 format=hwpx pos=top stroke=2 split_ms=2394.499 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=2389.590 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=2415.668 invalidate_ms=0.000 normalize_ms=0.035 setup_ms=0.001 measure_ms=25.296 typeset_ms=2389.783 postprocess_ms=0.552 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=1 format=hwpx pos=top stroke=3 split_ms=2415.832 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3087.792 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3132.592 invalidate_ms=0.000 normalize_ms=0.046 setup_ms=0.001 measure_ms=44.111 typeset_ms=3088.064 postprocess_ms=0.368 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=1 format=hwpx pos=bottom stroke=1 split_ms=3132.864 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3222.037 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3263.597 invalidate_ms=0.000 normalize_ms=0.048 setup_ms=0.001 measure_ms=40.974 typeset_ms=3222.277 postprocess_ms=0.294 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=1 format=hwpx pos=bottom stroke=2 split_ms=3263.848 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=2830.295 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=2871.095 invalidate_ms=0.000 normalize_ms=0.053 setup_ms=0.001 measure_ms=40.058 typeset_ms=2830.569 postprocess_ms=0.411 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=1 format=hwpx pos=bottom stroke=3 split_ms=2871.452 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3217.675 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3253.404 invalidate_ms=0.000 normalize_ms=0.039 setup_ms=0.001 measure_ms=35.073 typeset_ms=3217.893 postprocess_ms=0.396 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3091.344 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3135.035 invalidate_ms=0.000 normalize_ms=0.053 setup_ms=0.001 measure_ms=43.074 typeset_ms=3091.613 postprocess_ms=0.293 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwp pos=top stroke=1 split_ms=3135.697 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=2955.441 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=2987.933 invalidate_ms=0.000 normalize_ms=0.046 setup_ms=0.001 measure_ms=31.837 typeset_ms=2955.666 postprocess_ms=0.382 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwp pos=top stroke=2 split_ms=2988.143 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3385.913 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3425.929 invalidate_ms=0.000 normalize_ms=0.088 setup_ms=0.001 measure_ms=39.368 typeset_ms=3386.178 postprocess_ms=0.292 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwp pos=top stroke=3 split_ms=3426.215 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=4508.896 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=4553.841 invalidate_ms=0.000 normalize_ms=0.045 setup_ms=0.001 measure_ms=44.171 typeset_ms=4509.220 postprocess_ms=0.403 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwp pos=bottom stroke=1 split_ms=4553.996 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3629.987 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3679.158 invalidate_ms=0.000 normalize_ms=0.145 setup_ms=0.001 measure_ms=48.284 typeset_ms=3630.267 postprocess_ms=0.459 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwp pos=bottom stroke=2 split_ms=3679.854 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3377.585 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3421.682 invalidate_ms=0.000 normalize_ms=0.089 setup_ms=0.001 measure_ms=43.295 typeset_ms=3377.837 postprocess_ms=0.458 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwp pos=bottom stroke=3 split_ms=3421.907 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3154.384 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3193.042 invalidate_ms=0.000 normalize_ms=0.045 setup_ms=0.001 measure_ms=38.012 typeset_ms=3154.644 postprocess_ms=0.338 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3346.045 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3388.341 invalidate_ms=0.000 normalize_ms=0.045 setup_ms=0.001 measure_ms=41.659 typeset_ms=3346.311 postprocess_ms=0.323 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwpx pos=top stroke=1 split_ms=3388.866 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3563.865 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3607.000 invalidate_ms=0.000 normalize_ms=0.045 setup_ms=0.001 measure_ms=42.478 typeset_ms=3564.142 postprocess_ms=0.333 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwpx pos=top stroke=2 split_ms=3607.183 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3543.100 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3585.960 invalidate_ms=0.001 normalize_ms=0.054 setup_ms=0.001 measure_ms=42.172 typeset_ms=3543.367 postprocess_ms=0.364 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwpx pos=top stroke=3 split_ms=3586.267 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3632.780 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3677.789 invalidate_ms=0.000 normalize_ms=0.084 setup_ms=0.001 measure_ms=44.040 typeset_ms=3633.139 postprocess_ms=0.523 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwpx pos=bottom stroke=1 split_ms=3677.985 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3548.271 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3593.051 invalidate_ms=0.000 normalize_ms=0.047 setup_ms=0.001 measure_ms=44.150 typeset_ms=3548.552 postprocess_ms=0.300 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwpx pos=bottom stroke=2 split_ms=3593.266 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3419.122 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3462.334 invalidate_ms=0.000 normalize_ms=0.048 setup_ms=0.001 measure_ms=42.530 typeset_ms=3419.372 postprocess_ms=0.382 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwpx pos=bottom stroke=3 split_ms=3462.565 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3590.355 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3634.349 invalidate_ms=0.000 normalize_ms=0.074 setup_ms=0.002 measure_ms=43.106 typeset_ms=3590.612 postprocess_ms=0.554 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3656.751 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3712.761 invalidate_ms=0.000 normalize_ms=0.046 setup_ms=0.001 measure_ms=55.309 typeset_ms=3657.035 postprocess_ms=0.369 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwp pos=top stroke=1 split_ms=3713.325 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3472.448 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3516.820 invalidate_ms=0.000 normalize_ms=0.125 setup_ms=0.001 measure_ms=43.626 typeset_ms=3472.692 postprocess_ms=0.374 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwp pos=top stroke=2 split_ms=3517.066 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3430.464 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3471.363 invalidate_ms=0.000 normalize_ms=0.158 setup_ms=0.001 measure_ms=39.939 typeset_ms=3430.717 postprocess_ms=0.546 cleanup_ms=0.001 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwp pos=top stroke=3 split_ms=3471.620 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3373.806 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3422.260 invalidate_ms=0.001 normalize_ms=0.055 setup_ms=0.001 measure_ms=47.645 typeset_ms=3374.146 postprocess_ms=0.412 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwp pos=bottom stroke=1 split_ms=3422.475 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3305.783 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3344.789 invalidate_ms=0.000 normalize_ms=0.058 setup_ms=0.001 measure_ms=38.317 typeset_ms=3306.020 postprocess_ms=0.392 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwp pos=bottom stroke=2 split_ms=3344.984 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3304.301 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3341.802 invalidate_ms=0.000 normalize_ms=0.046 setup_ms=0.001 measure_ms=36.940 typeset_ms=3304.525 postprocess_ms=0.288 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwp pos=bottom stroke=3 split_ms=3342.056 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3321.755 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3362.560 invalidate_ms=0.000 normalize_ms=0.050 setup_ms=0.001 measure_ms=40.055 typeset_ms=3322.062 postprocess_ms=0.390 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3387.796 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3430.544 invalidate_ms=0.000 normalize_ms=0.045 setup_ms=0.001 measure_ms=41.975 typeset_ms=3388.126 postprocess_ms=0.396 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwpx pos=top stroke=1 split_ms=3431.125 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3331.908 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3372.911 invalidate_ms=0.000 normalize_ms=0.048 setup_ms=0.001 measure_ms=40.308 typeset_ms=3332.162 postprocess_ms=0.391 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwpx pos=top stroke=2 split_ms=3373.184 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3391.193 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3436.056 invalidate_ms=0.001 normalize_ms=0.047 setup_ms=0.001 measure_ms=44.175 typeset_ms=3391.524 postprocess_ms=0.308 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwpx pos=top stroke=3 split_ms=3436.255 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3307.573 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3356.569 invalidate_ms=0.000 normalize_ms=0.047 setup_ms=0.001 measure_ms=48.041 typeset_ms=3307.990 postprocess_ms=0.489 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwpx pos=bottom stroke=1 split_ms=3356.743 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3482.419 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3523.462 invalidate_ms=0.001 normalize_ms=0.050 setup_ms=0.001 measure_ms=40.138 typeset_ms=3482.735 postprocess_ms=0.536 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwpx pos=bottom stroke=2 split_ms=3523.660 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3410.816 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3454.843 invalidate_ms=0.000 normalize_ms=0.051 setup_ms=0.001 measure_ms=43.439 typeset_ms=3411.050 postprocess_ms=0.301 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwpx pos=bottom stroke=3 split_ms=3455.049 pages=116
+test issue_4031_profile_pending_enter_flush_vs_skip ... RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3323.068 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3364.132 invalidate_ms=0.000 normalize_ms=0.048 setup_ms=0.001 measure_ms=40.278 typeset_ms=3323.329 postprocess_ms=0.474 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3306.317 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3364.082 invalidate_ms=0.000 normalize_ms=0.048 setup_ms=0.001 measure_ms=57.010 typeset_ms=3306.653 postprocess_ms=0.368 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3417.623 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3463.183 invalidate_ms=0.000 normalize_ms=0.045 setup_ms=0.001 measure_ms=44.802 typeset_ms=3418.039 postprocess_ms=0.295 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3282.990 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3326.130 invalidate_ms=0.000 normalize_ms=0.050 setup_ms=0.001 measure_ms=42.465 typeset_ms=3283.255 postprocess_ms=0.359 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=0 pages=115 total_ms=0.057 invalidate_ms=0.000 normalize_ms=0.048 setup_ms=0.001 measure_ms=0.000 typeset_ms=0.000 postprocess_ms=0.000 cleanup_ms=0.000 other_ms=0.007
+RHWP_4031_PENDING_ENTER run=1 format=hwp flush_ms=3423.262 split_after_flush_ms=3364.793 skip_flush_split_ms=3326.781 post_flush_ms=0.119 post_flush_state=fallback pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3468.177 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3509.643 invalidate_ms=0.000 normalize_ms=0.044 setup_ms=0.001 measure_ms=40.731 typeset_ms=3468.455 postprocess_ms=0.410 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=4087.947 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=4125.660 invalidate_ms=0.000 normalize_ms=0.044 setup_ms=0.001 measure_ms=36.991 typeset_ms=4088.223 postprocess_ms=0.399 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3572.172 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3621.881 invalidate_ms=0.000 normalize_ms=0.047 setup_ms=0.001 measure_ms=49.092 typeset_ms=3572.427 postprocess_ms=0.310 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3466.067 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3513.502 invalidate_ms=0.000 normalize_ms=0.046 setup_ms=0.001 measure_ms=46.689 typeset_ms=3466.357 postprocess_ms=0.407 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=0 pages=115 total_ms=0.053 invalidate_ms=0.000 normalize_ms=0.046 setup_ms=0.001 measure_ms=0.000 typeset_ms=0.000 postprocess_ms=0.000 cleanup_ms=0.000 other_ms=0.006
+RHWP_4031_PENDING_ENTER run=1 format=hwpx flush_ms=4467.391 split_after_flush_ms=4126.162 skip_flush_split_ms=3514.203 post_flush_ms=0.088 post_flush_state=fallback pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3624.103 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3667.648 invalidate_ms=0.001 normalize_ms=0.046 setup_ms=0.001 measure_ms=42.889 typeset_ms=3624.344 postprocess_ms=0.366 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3789.095 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3831.648 invalidate_ms=0.000 normalize_ms=0.046 setup_ms=0.001 measure_ms=41.888 typeset_ms=3789.382 postprocess_ms=0.330 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3532.381 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3575.061 invalidate_ms=0.003 normalize_ms=0.048 setup_ms=0.001 measure_ms=41.959 typeset_ms=3532.653 postprocess_ms=0.395 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3781.462 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3829.803 invalidate_ms=0.000 normalize_ms=0.045 setup_ms=0.001 measure_ms=47.351 typeset_ms=3781.833 postprocess_ms=0.571 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=0 pages=115 total_ms=0.077 invalidate_ms=0.000 normalize_ms=0.062 setup_ms=0.001 measure_ms=0.000 typeset_ms=0.000 postprocess_ms=0.000 cleanup_ms=0.000 other_ms=0.012
+RHWP_4031_PENDING_ENTER run=2 format=hwp flush_ms=3576.308 split_after_flush_ms=3832.298 skip_flush_split_ms=3830.315 post_flush_ms=0.116 post_flush_state=fallback pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3570.271 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3614.633 invalidate_ms=0.000 normalize_ms=0.040 setup_ms=0.001 measure_ms=43.744 typeset_ms=3570.533 postprocess_ms=0.313 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3454.651 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3501.414 invalidate_ms=0.000 normalize_ms=0.044 setup_ms=0.001 measure_ms=45.969 typeset_ms=3454.961 postprocess_ms=0.438 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3710.193 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3754.328 invalidate_ms=0.000 normalize_ms=0.040 setup_ms=0.001 measure_ms=43.400 typeset_ms=3710.434 postprocess_ms=0.451 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3431.008 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3476.681 invalidate_ms=0.000 normalize_ms=0.085 setup_ms=0.001 measure_ms=44.931 typeset_ms=3431.264 postprocess_ms=0.398 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=0 pages=115 total_ms=0.077 invalidate_ms=0.000 normalize_ms=0.067 setup_ms=0.001 measure_ms=0.000 typeset_ms=0.000 postprocess_ms=0.000 cleanup_ms=0.000 other_ms=0.008
+RHWP_4031_PENDING_ENTER run=2 format=hwpx flush_ms=3709.714 split_after_flush_ms=3502.048 skip_flush_split_ms=3477.336 post_flush_ms=0.160 post_flush_state=fallback pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3683.786 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3727.717 invalidate_ms=0.000 normalize_ms=0.065 setup_ms=0.001 measure_ms=42.969 typeset_ms=3684.263 postprocess_ms=0.418 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3606.567 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3649.177 invalidate_ms=0.000 normalize_ms=0.076 setup_ms=0.001 measure_ms=41.786 typeset_ms=3606.856 postprocess_ms=0.456 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3808.164 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3857.117 invalidate_ms=0.000 normalize_ms=0.089 setup_ms=0.001 measure_ms=48.306 typeset_ms=3808.400 postprocess_ms=0.319 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3789.438 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3837.077 invalidate_ms=0.000 normalize_ms=0.051 setup_ms=0.001 measure_ms=46.763 typeset_ms=3789.796 postprocess_ms=0.465 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=0 pages=115 total_ms=0.081 invalidate_ms=0.000 normalize_ms=0.066 setup_ms=0.001 measure_ms=0.000 typeset_ms=0.000 postprocess_ms=0.000 cleanup_ms=0.000 other_ms=0.014
+RHWP_4031_PENDING_ENTER run=3 format=hwp flush_ms=3530.568 split_after_flush_ms=3649.802 skip_flush_split_ms=3837.687 post_flush_ms=0.123 post_flush_state=fallback pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3876.625 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3925.103 invalidate_ms=0.000 normalize_ms=0.089 setup_ms=0.002 measure_ms=46.645 typeset_ms=3876.936 postprocess_ms=1.429 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3751.432 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3795.055 invalidate_ms=0.000 normalize_ms=0.090 setup_ms=0.001 measure_ms=42.765 typeset_ms=3751.742 postprocess_ms=0.455 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3388.771 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3427.509 invalidate_ms=0.000 normalize_ms=0.058 setup_ms=0.001 measure_ms=37.920 typeset_ms=3389.139 postprocess_ms=0.390 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3398.924 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3452.009 invalidate_ms=0.001 normalize_ms=0.074 setup_ms=0.001 measure_ms=51.839 typeset_ms=3399.732 postprocess_ms=0.360 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=0 pages=115 total_ms=0.077 invalidate_ms=0.000 normalize_ms=0.066 setup_ms=0.001 measure_ms=0.000 typeset_ms=0.000 postprocess_ms=0.000 cleanup_ms=0.000 other_ms=0.010
+RHWP_4031_PENDING_ENTER run=3 format=hwpx flush_ms=3858.122 split_after_flush_ms=3795.592 skip_flush_split_ms=3452.857 post_flush_ms=0.106 post_flush_state=fallback pages=115

--- a/mydocs/report/task_m100_4138_report.md
+++ b/mydocs/report/task_m100_4138_report.md
@@ -1,0 +1,74 @@
+---
+kind: report
+status: active
+last_verified: 2026-08-07
+---
+
+# Task #4138 최종 보고서 — 셀 나누기 stale line_segs·vpos 사다리 붕괴 수정
+
+Issue: #4138 (외부 리포트 "glyph truncation")
+브랜치: `fix/issue-4138-split-cell-stale-linesegs`
+단계 문서: [task_m100_4138_stage1.md](../working/task_m100_4138_stage1.md)
+
+## 결론
+
+`Table::split_cell*` 가 셀 폭을 바꾼 뒤 저장 line_segs 를 방치해 생기던 2단 결함
+(옛 폭 줄의 셀 경계 잘림 + vpos 사다리 역행의 hard break 오판으로 인한 페이지
+과소 적재)을, 분할 3형제 전부에 stale 셀 재래핑 + 셀 단위 vpos 사다리 단조
+재구축을 배선해 수정했다. 수정 후 렌더는 이슈 첨부 한컴 기대 이미지와 1.1.2
+문단 기준 줄 단위로 일치한다.
+
+## 원인 사슬
+
+1. `split_table_cell_into_native`(src/document_core/commands/table_ops.rs) →
+   `Table::split_cell_into`(src/model/table.rs)가 셀 폭 44790→22395 변경, 저장
+   line_segs 재계산 생략. 새 sibling 셀도 원본 line_segs 클론.
+2. 렌더러 `LayoutEngine::layout_paragraph`(src/renderer/paragraph_layout.rs)는 저장
+   줄을 그대로 그림 → 옛 폭(44508) 줄이 새 셀 클립 경계에서 잘림.
+3. per-para `reflow_cell_paragraph` 만 배선하면 `reflow_line_segs` 가 문단 vpos
+   원점을 보존한 채 내부 줄만 재래핑 → 줄 수 증가 문단 뒤로 사다리 역행 →
+   컷 기계가 RowBreak hard break 로 오판 → 페이지 과소 적재(118→222쪽).
+
+## 수정 내용 (commit `fix(core): #4138 …`)
+
+- `reflow_stale_cells_after_split`(table_ops.rs): 저장 seg 폭 > 셀 폭(패딩 때문에
+  정상 seg 는 항상 셀 폭 미만이므로 초과 = 확정 stale)인 셀의 전 문단 재래핑 후
+  셀 사다리 재구축. `split_table_cell_native` / `split_table_cell_into_native` /
+  `split_table_cells_in_range_native` 전부에 배선.
+- `rebuild_table_cell_vpos_ladder_native` + `apply_cell_vpos_ladder`(text_editing.rs):
+  `recalculate_cell_paragraph_vpos` 의 적용 루프를 분리 공유. 텍스트 편집 경로는
+  기존대로 RowBreak reset 앞에서 정지, 전체 재래핑 직후 경로는 끝까지 재배치.
+- undo: 분할은 studio snapshot undo(`save/restore_snapshot_native` 가 Document 통째
+  복원)라 구 line_segs 자동 복원 — 코어 추가 작업 불요.
+
+## 실측
+
+| 구성 | stale | 사다리 역행 | 쪽수 |
+| --- | --- | --- | --- |
+| 수정 전 | 2,498문단/4,321seg | — | 118 |
+| reflow만 | 0 | 발생 | 222 |
+| 본 수정 | 0 | 0 | 195 |
+
+성능(RHWP_2424_PROFILE): 본 수정 추가 비용 ≈0.1s. 분할 호출 3.43s 중 3.33s 는
+분할 후 195쪽 거대 표 전체 재조판(`typeset_block_table_inner`, ~17ms/쪽) — Task #8
+(fragment 단위 증분 재조판) 대상과 동일 병목이므로 본 과제 범위 밖.
+
+## 검증
+
+- 회귀: `tests/issue_4138_split_cell_stale_linesegs.rs` — stale 0 + 사다리 단조 +
+  195쪽 핀, into/범위 분할 2경로. red→green(원복 시 stale 2,498/118쪽) 확인.
+- 인접 focused 20 tests green (1073/1750/2158/2299/3236/3593/3595/3637 —
+  2158/2299/3593 은 분리한 `apply_cell_vpos_ladder` 경유 reset-preserve 의미론 핀).
+- 시각 증적: `mydocs/pr/assets/pr_4138_{presplit,before,after}_p{0,1}.png` —
+  before 는 이슈 "실제" 스크린샷 재현, after 는 한컴 기대 이미지와 1.1.2 줄바꿈
+  일치(1.1.1 은 1개 줄바꿈 근소 차이 — 작업지시자 판정 대상).
+- PR #4122 merge(`accebdb20`) 후 devel 에 cherry-pick(`148bff3ef`)해 재검증 —
+  전체 게이트(fmt/clippy/release-test/native-skia 3종/wasm-pack) 결과는 stage1
+  문서 검증 기록에 기재.
+
+## 미해결 (후속)
+
+- (a) 중첩 표 host 문단의 잔존 stale seg — 한컴의 분할 시 중첩 표 리스케일 여부
+  오라클 미확인(이슈 이미지 범위 밖). 테스트에서 계약 밖으로 명시 제외.
+- 분할 후 전체 문서 쪽수(195)의 한컴 실측 대조 — 한컴 편집기 환경 필요.
+- 병합(폭 확대) 경로의 reflow 부재 — 별도 이슈 후보.

--- a/mydocs/working/task_m100_4031_stage1.md
+++ b/mydocs/working/task_m100_4031_stage1.md
@@ -1,0 +1,111 @@
+# Task M100 #4031 Stage 1 완료보고서 — 거대 셀 Enter 지연 기준선과 red contract
+
+## 1. 목적
+
+이슈 #4031(pending pagination 중 Enter의 중복 full pagination 제거) Stage 1: 최신
+`upstream/devel@9f564bbe`에서 115쪽 거대 셀 문서의 cold Enter와 pending Enter 전 구간을
+분해 계측하고, "pending cell Enter = full flush 1 + full pagination 1" 중복 계약을 수치로
+고정한다. flow 보드 Task #8(거대 셀 Enter 지연 해소)의 1단계 실측이기도 하다.
+
+## 2. 환경과 방법
+
+- macOS(Darwin 25.1.0), arm64, Rust release-test profile
+- fixture: `samples/issue1949_giant_cell_nested_tables_perf.hwp/.hwpx` (115쪽, 2,507문단 거대 셀)
+- probe: `tests/issue_4031_enter_latency_probe.rs` (신규, `#[ignore]` local-only)
+  - cold: 새 load 뒤 셀 상단(문단 5)·하단(끝-8) 각 3연타 `split_paragraph_in_cell_native`
+  - pending: 56회 deferred insert 잔여 상태에서
+    시나리오 A = `flush_deferred_pagination()` → split (현행 studio before-navigation 경로),
+    시나리오 B = flush 생략(`cancel_deferred_pagination`) → split → 사후 flush 비용 확인
+- `RHWP_2424_PROFILE=1`로 pagination subphase·block-table·continuation cursor timer 동시 기록
+- `RHWP_4031_REPEATS=3`, timing assertion 없음. page count 정합만 단언
+
+명령:
+
+```bash
+CARGO_TARGET_DIR=... cargo test --profile release-test --test issue_4031_enter_latency_probe --no-run
+RHWP_2424_PROFILE=1 RHWP_4031_REPEATS=3 cargo test --profile release-test \
+  --test issue_4031_enter_latency_probe -- --ignored --nocapture --test-threads=1
+```
+
+측정 중 dev 서버 등 배경 부하로 run 2부터 절대값이 약 3배까지 드리프트했다(run 1 첫
+값 1130ms는 #2424 Stage A 기준선 1058ms와 정합). 따라서 아래에서 절대값은 run 1을,
+구조 결론(패스 수·fragment 수·비율)은 36개 전 표본을 근거로 삼는다.
+
+## 3. cold Enter — 키 1회가 전체 표 재조판을 소유한다
+
+run 1 기준(ms):
+
+| 형식 | 상단 3연타 | 하단 3연타 |
+|---|---|---|
+| HWP | 1130 / 1124 / 1173 | 1192 / 1530 / 2230 |
+| HWPX | 2238 / 2394 / 2416 | 3133 / 3264 / 2871 |
+
+36개 전 표본에서 예외 없이:
+
+1. split 1회 = `paginate_pass` 정확히 1회. `RHWP_2424_PAGINATION_PROFILE`에서
+   typeset_ms가 total의 98.5~99.2% (measure 15~44ms, invalidate/normalize/postprocess < 1ms).
+2. `RHWP_2424_CONTINUATION_CURSOR fragments=115~116`: 편집 위치가 셀 상단이든 하단이든
+   block-table continuation이 **115~116개 fragment 전부를 매번 처음부터 drain**한다.
+   상한·하한 어디를 편집해도 비용이 같다 — fragment 증분 재개 부재(보드 Task #8 이론 3)의
+   직접 증거다.
+3. 셀 편집은 `para_offset = 0`이라 기존 CONVERGENCE(수렴 재사용) 기계가 아예 시도되지
+   않는다. 본문 문단 offset 기반이므로 셀 내부 편집에는 적용 불가.
+
+## 4. pending Enter — flush 1 + pagination 1 중복 (red contract)
+
+3회 × HWP/HWPX(ms, 같은 배경 부하 아래 상대 비교):
+
+| run | 형식 | A: flush | A: split | A 합계 | B: skip-flush split | B: 사후 flush |
+|---|---|---:|---:|---:|---:|---:|
+| 1 | HWP | 3423 | 3365 | 6788 | 3327 | 0.119 |
+| 1 | HWPX | 4467 | 4126 | 8593 | 3514 | 0.088 |
+| 2 | HWP | 3576 | 3832 | 7409 | 3830 | 0.116 |
+| 2 | HWPX | 3710 | 3502 | 7212 | 3477 | 0.160 |
+| 3 | HWP | 3531 | 3650 | 7180 | 3838 | 0.123 |
+| 3 | HWPX | 3858 | 3796 | 7654 | 3453 | 0.106 |
+
+1. 현행 경로(A)는 **full pagination 2회**로 단일 split의 약 2배다. flush가 계산한 분할 전
+   pagination은 split 직후 통째로 폐기된다 — #4031 배경 그대로.
+2. flush를 생략한 B는 split의 `paginate_if_needed()` 1회로 수렴하며, 최종 page count가
+   A와 **완전 일치**했다(전 회 단언 통과).
+3. B의 사후 `flush_deferred_pagination()`은 0.088~0.160ms의 사실상 no-op이다
+   (`status=fallback`, dirty 구역 없음). 즉 split의 동기 pagination이 deferred descriptor를
+   소비한 뒤에는 잔여 barrier 비용이 없다 — Stage 2 cancellation 계약의 native 불변식이
+   이미 성립한다. `cancel_deferred_pagination()`/`cancelDeferredPagination`도 이미 노출돼 있다.
+
+## 5. 코드 경로 확정 (Stage 2 입력)
+
+- direct Enter: `input-handler-keyboard.ts` keydown 상단
+  `PAGINATION_BOUNDARY_KEYS.has('Enter')` → `flushDeferredPaginationIfNeeded('before-navigation')`
+  → 같은 함수 하단 `case 'Enter'` → (셀이면) `SplitParagraphInCellCommand` →
+  `splitParagraphInCell*` → native `paginate_if_needed()` 재차 full pagination.
+- flush 지점(547행)과 `case 'Enter'`(1215행)는 **같은 keydown 함수 스코프**다. admission
+  판정을 지역 변수로 전달할 수 있어 인스턴스 상태 누수 없이 구현 가능하다.
+- `SplitParagraphInCellCommand`는 `consumeTextMutationEffects`를 구현하지 않아 실행 후
+  `deferredPaginationPending`이 자동 해소되지 않는다 → 성공한 split이 pagination을
+  소유했음을 반영하는 명시적 상태 전이가 필요하다.
+- IME 경로: `input-handler-text.ts` `processPendingNav`의 `code === 'Enter'`는 **조합 확정만
+  하고 문단 분할이 없다**(169~171행). 구조 명령이 뒤따르지 않으므로 이 flush는 최신
+  모델의 유일한 pagination barrier다 — 중복이 아예 없고, 취소하면 오히려 pagination이
+  runner 완주까지 표류한다. Stage 2 admission은 direct keydown 경로에만 연다(fail-closed).
+  IME 경로의 flush 비용 자체는 fragment 증분 재개(후속)의 몫이다.
+
+## 6. 다음 단계 판정
+
+1. Stage 2(이 브랜치): direct cell Enter 한정 command-aware admission —
+   flush 대신 runner/timer 취소 + `wasm.cancelDeferredPagination()`, 성공한 split이
+   pagination·cursor geometry invalidation을 소유, 실패 시 기존 full-flush로 fail-closed.
+   기대 효과: pending Enter 약 2×→1×(cold Enter와 동급).
+2. cold Enter 자체(~1초, wasm은 그 이상)는 §3의 fragment 전량 drain이 지배 항이다.
+   해소는 보드 Task #8 본체인 "편집 행이 속한 fragment부터 재개, 상위 fragment 재사용"
+   증분 재조판이며 PR #4122(canonical cell unit + 재귀 cursor) 병합 후 착수한다(별도 후속).
+3. Stage A probe는 before/after 비교가 끝날 때까지 진단 자산으로 유지한다.
+
+## 7. 검증
+
+| 게이트 | 결과 |
+|---|---|
+| probe `--no-run` 빌드 | 통과 |
+| probe 2 tests × 3 repeats (HWP/HWPX) | 2 passed, 0 failed (236.39s) |
+| page count 정합 단언 (A=B, 전 회) | 통과 |
+| `cargo fmt --all -- --check` | 커밋 전 확인 |

--- a/mydocs/working/task_m100_4031_stage1.md
+++ b/mydocs/working/task_m100_4031_stage1.md
@@ -51,6 +51,8 @@ run 1 기준(ms):
 3. 셀 편집은 `para_offset = 0`이라 기존 CONVERGENCE(수렴 재사용) 기계가 아예 시도되지
    않는다. 본문 문단 offset 기반이므로 셀 내부 편집에는 적용 불가.
 
+raw profile은 `mydocs/report/assets/task_m100_4031_stage1_baseline.log`에 보존한다.
+
 ## 4. pending Enter — flush 1 + pagination 1 중복 (red contract)
 
 3회 × HWP/HWPX(ms, 같은 배경 부하 아래 상대 비교):

--- a/mydocs/working/task_m100_4031_stage2.md
+++ b/mydocs/working/task_m100_4031_stage2.md
@@ -1,0 +1,64 @@
+# Task M100 #4031 Stage 2 완료보고서 — 셀 Enter command-aware cancellation
+
+## 1. 구현
+
+Stage 1(§5)에서 확정한 경로에 최소 변경 3점을 넣었다.
+
+### 1.1 admission — `isCommittedCellEnterSplit` (input-handler-keyboard.ts)
+
+이 keydown이 같은 함수 하단 `case 'Enter'`에서 `SplitParagraphInCellCommand`로 확정
+실행되는 좁은 조건만 통과시킨다. flush 지점과 `case 'Enter'` 사이의 조기 분기 전부를
+배제한다: modifier(Shift/Ctrl/Meta/Alt), IME 조합, form mode, 머리말/꼬리말, 각주,
+그림/표 객체 선택, 블록/셀 선택 모드, 선택 영역(deleteSelection 선행 방지), 그리고
+`isInCell()`. 하나라도 확신할 수 없으면 false → 기존 full flush로 fail-closed.
+
+`Enter`는 `PAGINATION_BOUNDARY_KEYS`에서 제거하지 않았다(구현 원칙 1·2). 판정 결과는
+같은 keydown 함수 스코프의 지역 상수 `committedCellEnterSplit`로 전달해 인스턴스 상태
+누수가 없다.
+
+### 1.2 계산 없는 취소와 소유 완료 (input-handler.ts)
+
+- `cancelDeferredPaginationForOwnedMutation()`: idle flush timer 취소 + runner 취소
+  (`runner.cancel()`이 전진 중이면 `wasm.cancelDeferredPagination()`까지 수행).
+  `wasm.flushDeferredPagination()`을 호출하지 않는 것이 flush 경로와의 유일한 차이.
+  `deferredPaginationPending`은 유지 — split 실패 시 다음 boundary flush가 기존 barrier
+  의미론으로 복구한다(fail-closed).
+- `completePaginationOwnedBySyncMutation()`: 성공한 native split의 `paginate_if_needed()`가
+  최신 revision을 계산했음을 반영 — pending 해소 + focused cell cursor geometry invalidate.
+  이후 boundary flush는 Stage 1 §4-3에서 실측한 대로 0.1ms no-op으로 수렴한다.
+
+### 1.3 배선 (input-handler-keyboard.ts)
+
+- boundary key 지점: admitted면 취소, 아니면 기존
+  `flushDeferredPaginationIfNeeded('before-navigation')`.
+- `case 'Enter'`의 inCell 분기: split 성공 시 `completePaginationOwnedBySyncMutation()`,
+  예외 시 `flushDeferredPaginationIfNeeded('cell-enter-split-fallback')` 후 rethrow.
+  완료/복귀 모두 `committedCellEnterSplit`가 참일 때만 수행한다.
+
+### 1.4 IME 경로는 의도적으로 비대상
+
+`processPendingNav`의 `code === 'Enter'`는 조합 확정만 하고 structural command가 없다
+(stage1 §5). 그 flush는 최신 모델의 유일한 pagination barrier이므로 유지한다. 취소하면
+115쪽 문서에서 idle auto-flush 상한 밖이라 pagination이 runner 완주까지 표류한다.
+이슈의 "direct와 IME를 같은 계약으로"는 "admission을 증명한 경우에만 flush를 생략"이라는
+같은 규칙의 적용이며, IME 경로는 admission(구조 명령 확정)이 성립하지 않는다.
+
+## 2. 검증
+
+| 게이트 | 결과 |
+|---|---|
+| `tests/cell-enter-owned-pagination.test.ts` (신규 5 계약) | 5 passed |
+| Studio `npm test` 전체 | 768 passed, 0 failed |
+| `npx tsc --noEmit` | 신규 오류 0 (기존 `@wasm/rhwp.js` 미빌드 오류만) |
+| production wasm + browser 실측 | Stage 3에서 수행 |
+
+계약 테스트 5종: ① boundary flush의 admitted/비admitted 분기, ② admission guard 전수,
+③ split 성공→소유 완료·실패→fallback 순서, ④ 소유 취소의 pending 유지(fail-closed)와
+완료 선언의 pending 해소, ⑤ IME 경로 flush 보존.
+
+## 3. 기대 효과 (Stage 1 native 실측 기준)
+
+pending cell Enter = full pagination 2회 → 1회. 시나리오 B 실측으로 최종 page count가
+flush-then-split과 완전 일치하고 사후 flush가 0.1ms no-op임을 확인했다. 브라우저
+전 구간(direct/IME × HWP/HWPX × 3회)과 acceptance criteria(중앙값 cold 110% 이내 등)는
+Stage 3에서 production wasm으로 측정한다.

--- a/mydocs/working/task_m100_4031_stage2.md
+++ b/mydocs/working/task_m100_4031_stage2.md
@@ -16,26 +16,37 @@ Stage 1(§5)에서 확정한 경로에 최소 변경 3점을 넣었다.
 같은 keydown 함수 스코프의 지역 상수 `committedCellEnterSplit`로 전달해 인스턴스 상태
 누수가 없다.
 
-### 1.2 계산 없는 취소와 소유 완료 (input-handler.ts)
+### 1.2 계산 없는 취소 (input-handler.ts)
 
-- `cancelDeferredPaginationForOwnedMutation()`: idle flush timer 취소 + runner 취소
-  (`runner.cancel()`이 전진 중이면 `wasm.cancelDeferredPagination()`까지 수행).
-  `wasm.flushDeferredPagination()`을 호출하지 않는 것이 flush 경로와의 유일한 차이.
-  `deferredPaginationPending`은 유지 — split 실패 시 다음 boundary flush가 기존 barrier
-  의미론으로 복구한다(fail-closed).
-- `completePaginationOwnedBySyncMutation()`: 성공한 native split의 `paginate_if_needed()`가
-  최신 revision을 계산했음을 반영 — pending 해소 + focused cell cursor geometry invalidate.
-  이후 boundary flush는 Stage 1 §4-3에서 실측한 대로 0.1ms no-op으로 수렴한다.
+`cancelDeferredPaginationForOwnedMutation()`: idle flush timer 취소 + runner 취소
+(`runner.cancel()`이 전진 중이면 `wasm.cancelDeferredPagination()`까지 수행).
+`wasm.flushDeferredPagination()`을 호출하지 않는 것이 flush 경로와의 유일한 차이.
+`deferredPaginationPending`은 유지 — split 실패 시 다음 boundary flush가 기존 barrier
+의미론으로 복구한다(fail-closed).
 
-### 1.3 배선 (input-handler-keyboard.ts)
+### 1.3 완료 소유 — command effects 선언 (command.ts)
+
+`SplitParagraphInCellCommand.execute`가 native split 성공 뒤
+`IMMEDIATE_TEXT_MUTATION_EFFECTS`(paginationCompleted)를 선언한다. 기존
+`executeOperation → prepareTextMutationBeforeCursor` effects 경로가 pending 해소·runner
+취소·focused cursor geometry invalidation을 수행하므로, 직후 `afterEdit`의
+`before-full-edit` flush가 no-op 판정(shouldFlush=false)으로 wasm 호출 없이 끝난다.
+예외 시 effects는 `NO_TEXT_MUTATION_EFFECTS`로 남아 아무것도 해소하지 않는다.
+
+처음에는 keydown에서 명시적 완료 메서드를 호출했으나, e2e가 split 직후 `afterEdit`의
+`before-full-edit` flush 1회(native no-op이지만 wasm 호출)를 검출했다 — 완료 선언이
+executeOperation의 refresh보다 늦었기 때문이다. effects 선언은 이 순서 문제를 기존
+계약 안에서 해소하며 undo/redo·비admitted 경로에도 동일하게 정합적이다.
+
+### 1.4 배선 (input-handler-keyboard.ts)
 
 - boundary key 지점: admitted면 취소, 아니면 기존
   `flushDeferredPaginationIfNeeded('before-navigation')`.
-- `case 'Enter'`의 inCell 분기: split 성공 시 `completePaginationOwnedBySyncMutation()`,
-  예외 시 `flushDeferredPaginationIfNeeded('cell-enter-split-fallback')` 후 rethrow.
-  완료/복귀 모두 `committedCellEnterSplit`가 참일 때만 수행한다.
+- `case 'Enter'`의 inCell 분기: 예외 시
+  `flushDeferredPaginationIfNeeded('cell-enter-split-fallback')` 후 rethrow.
+  fallback은 `committedCellEnterSplit`가 참일 때만 수행한다.
 
-### 1.4 IME 경로는 의도적으로 비대상
+### 1.5 IME 경로는 의도적으로 비대상
 
 `processPendingNav`의 `code === 'Enter'`는 조합 확정만 하고 structural command가 없다
 (stage1 §5). 그 flush는 최신 모델의 유일한 pagination barrier이므로 유지한다. 취소하면
@@ -47,14 +58,17 @@ Stage 1(§5)에서 확정한 경로에 최소 변경 3점을 넣었다.
 
 | 게이트 | 결과 |
 |---|---|
-| `tests/cell-enter-owned-pagination.test.ts` (신규 5 계약) | 5 passed |
-| Studio `npm test` 전체 | 768 passed, 0 failed |
-| `npx tsc --noEmit` | 신규 오류 0 (기존 `@wasm/rhwp.js` 미빌드 오류만) |
-| production wasm + browser 실측 | Stage 3에서 수행 |
+| `tests/cell-enter-owned-pagination.test.ts` (신규 6 계약) | 6 passed |
+| Studio `npm test` 전체 | 769 passed, 0 failed |
+| `npx tsc --noEmit` (wasm pkg 빌드 후) | 통과 |
+| `npm run build` (tsc + vite build) | 통과 |
+| `cargo clippy --profile release-test --test issue_4031_enter_latency_probe -- -D warnings` | 통과 |
+| production wasm + headless Chrome e2e | §4 |
 
-계약 테스트 5종: ① boundary flush의 admitted/비admitted 분기, ② admission guard 전수,
-③ split 성공→소유 완료·실패→fallback 순서, ④ 소유 취소의 pending 유지(fail-closed)와
-완료 선언의 pending 해소, ⑤ IME 경로 flush 보존.
+계약 테스트 6종: ① boundary flush의 admitted/비admitted 분기, ② admission guard 전수,
+③ split 성공→effects 완료 선언·실패→fallback, ④ effects paginationCompleted의
+pending 해소·runner 취소·geometry invalidation, ⑤ 소유 취소의 pending 유지(fail-closed),
+⑥ IME 경로 flush 보존.
 
 ## 3. 기대 효과 (Stage 1 native 실측 기준)
 

--- a/mydocs/working/task_m100_4031_stage3.md
+++ b/mydocs/working/task_m100_4031_stage3.md
@@ -1,0 +1,56 @@
+# Task M100 #4031 Stage 3 완료보고서 — production wasm 실브라우저 검증
+
+## 1. 방법
+
+- production wasm(`wasm-pack build --target web --out-dir pkg`) + 이 worktree 전용
+  Vite(포트 7710) + headless Chrome(puppeteer)
+- 신규 e2e `rhwp-studio/e2e/cell-enter-pagination-issue4031.test.mjs`
+  (`npm run e2e:issue-4031-cell-enter`, `VITE_URL`·`CHROME_PATH` 환경 변수)
+- HWP/HWPX 각각: 115쪽 로드 → 거대 셀(문단 5, offset 130)로 이동 → 실키 `111` 입력으로
+  pending deferred pagination 생성 → 실키 Enter → 계약 단언 → 사후 flush oracle →
+  실키 `1` + ArrowDown으로 barrier 대조군 단언
+
+## 2. 결과
+
+| 형식 | Enter dispatch | `wasm.flushDeferredPagination` | split | 사후 flush oracle | ArrowDown barrier |
+|---|---:|---:|---:|---|---:|
+| HWP | 1015ms | 0회 | 1회 | pages 불변(fallback no-op) | flush 1회 |
+| HWPX | 1813ms | 0회 | 1회 | pages 불변(fallback no-op) | flush 1회 |
+
+추가 단언 전부 통과: pending 해소, 셀 문단 수 +1, 분할점 offset 133(삽입 3자 반영),
+caret은 새 문단 시작(cellParaIndex+1, offset 0).
+
+acceptance criteria 대응:
+
+- admitted pending cell Enter의 pre-navigation full flush 0회 ✓ (총 wasm flush 호출 0회)
+- structural full pagination 1회(split 소유) ✓
+- pending Enter가 cold Enter와 같은 단일 pagination 구조로 수렴(Stage 1의 2×→1×) ✓
+- 문자열·문단 split·caret·쪽수 정합 ✓, 사후 flush oracle pages 불변 ✓
+- 비Enter boundary key(ArrowDown)의 기존 barrier 유지 ✓
+- IME 예약 Enter 경로 flush 보존은 unit 계약(⑥)으로 고정
+
+## 3. 최초 구현에서 잡힌 결함
+
+첫 e2e 실행이 admitted Enter에서 wasm flush 1회를 검출했다: keydown의 명시적 완료
+호출이 `executeOperation` 내부 refresh(`afterEdit`의 `before-full-edit` flush)보다 늦어
+pending이 남아 있었다. `SplitParagraphInCellCommand`가
+`IMMEDIATE_TEXT_MUTATION_EFFECTS`를 선언하는 방식으로 교체해 기존 effects 경로가
+refresh 이전에 pending을 해소하도록 했다(stage2 §1.3). 재실행에서 0회 확인.
+
+## 4. 게이트 요약
+
+| 게이트 | 결과 |
+|---|---|
+| e2e HWP/HWPX 계약 전부 | 통과 |
+| Studio `npm test` | 769 passed |
+| `npx tsc --noEmit` / `npm run build` | 통과 |
+| e2e MANIFEST 검사 (`check_e2e_manifest.py`) | 이상 없음 |
+| `cargo fmt`·`clippy`(probe) | 통과 |
+
+## 5. 남은 후속
+
+- cold Enter 자체(~1s wasm)는 fragment 전량 drain이 지배 항 — 보드 Task #8 본체
+  "편집 행 fragment부터 재개" 증분 재조판으로 해소하며 PR #4122 병합 후 착수
+  (stage1 §6-2).
+- 브라우저 direct/IME × 3회 반복 중앙값 리포트는 PR 리뷰 시점에 위 e2e를 반복 실행해
+  첨부할 수 있다(계약 단언은 이미 자동화).

--- a/mydocs/working/task_m100_4138_stage1.md
+++ b/mydocs/working/task_m100_4138_stage1.md
@@ -129,6 +129,9 @@ Issue: [#4138](https://github.com/edwardkim/rhwp/issues/4138) (외부 리포트:
   의미론을 직접 핀하는 스위트.
 - `cargo fmt --check`: 본 과제 변경 파일 clean (잔여 diff 는 타 세션의 임시 프로브
   `tests/tmp_bold_probe.rs` 뿐 — 본 과제 밖).
-- release-test 전체·clippy 전체는 PR CI 성격이므로 작업지시자 승인 후 실행 예정
-  (`pr_review` 게이트 규칙). 시각 증적(분할 전후 렌더 비교)은 studio 브라우저 경로로
-  후속 확보 예정 — 분할 op 이 CLI 미노출이라 네이티브 export 로는 재현 불가.
+- 전체 게이트 (2026-08-07, 작업지시자 완주 지시로 실행 — merge 된 #4122 포함
+  devel 기준 rebase 커밋, 격리 worktree): fmt PASS · clippy(-D warnings) PASS ·
+  release-test `--tests` PASS(**5,350 passed / 0 failed**, 473 targets) ·
+  native-skia 3종 PASS · wasm-pack build PASS.
+- 시각 증적: `render_page_svg_native` 로 네이티브 확보 (위 "시각 증적" 절) —
+  studio 브라우저 경로 불요했음. studio wasm 도 재빌드해 실기 확인 경로 제공.

--- a/mydocs/working/task_m100_4138_stage1.md
+++ b/mydocs/working/task_m100_4138_stage1.md
@@ -1,0 +1,134 @@
+---
+kind: working
+status: active
+last_verified: 2026-08-07
+---
+
+# Task #4138 Stage 1 — 셀 나누기 후 stale line_segs·vpos 사다리 붕괴 수정
+
+Issue: [#4138](https://github.com/edwardkim/rhwp/issues/4138) (외부 리포트: glyph truncation)
+브랜치: `fix/issue-4138-split-cell-stale-linesegs` (기준: `upstream/devel` 9f564bbee)
+
+## 증상과 원인 (2단)
+
+재현: `samples/issue1949_giant_cell_nested_tables_perf.hwp` 에서 셀 나누기(2행 셀을 1×2 분할).
+
+1. **glyph truncation** — `split_table_cell_into_native`(src/document_core/commands/table_ops.rs)가
+   `Table::split_cell_into`(src/model/table.rs)로 셀 폭을 44790→22395 로 바꾸면서 저장
+   line_segs 재계산을 생략한다. 렌더러(`LayoutEngine::layout_paragraph`,
+   src/renderer/paragraph_layout.rs)는 저장 줄을 그대로 그리므로 옛 폭(seg 폭 44508) 기준
+   줄이 새 셀 클립 경계에서 잘린다. 실측: 분할 뒤 4,321 seg 전부 stale, 새 sibling 셀도
+   원본 line_segs 를 클론해 같은 폭을 물려받음.
+2. **페이지 과소 적재** — 1에 per-para reflow 만 배선하면 `reflow_line_segs` 가 각 문단의
+   vpos 원점을 보존한 채 내부 줄만 다시 싸므로(4,321→7,484 seg), 줄 수가 늘어난 문단 뒤에서
+   사다리가 역행한다(실측: para[5] 끝 22920 뒤 para[6] 시작 17160). 컷 기계는 저장 vpos
+   역행을 RowBreak hard break 신호로 읽어 페이지를 과소 적재한다(118→222쪽; 한컴 오라클
+   기대 이미지는 1.1.1 뒤에 1.1.2 가 같은 쪽에 이어짐).
+
+## 수정
+
+- `reflow_stale_cells_after_split`(table_ops.rs, 신규): 저장 seg 폭이 셀 폭을 넘는
+  셀(= 옛 폭 기준 stale — seg 폭은 항상 패딩만큼 셀 폭보다 작게 계산되므로 초과는 확정
+  증거)을 골라 전 문단을 `reflow_cell_paragraph` 로 재래핑한 뒤, 셀 단위로 vpos 사다리를
+  단조 재구축한다. `resize_table_cells_native` 의 reflow 계약을 분할 3형제 전부에 적용:
+  - `split_table_cell_native` (병합 셀 복원 분할)
+  - `split_table_cell_into_native` (N×M 분할)
+  - `split_table_cells_in_range_native` (범위 분할)
+- `rebuild_table_cell_vpos_ladder_native`(text_editing.rs, 신규): 셀 문단 전 구간을 정지
+  없이 재배치한다. `recalculate_cell_paragraph_vpos` 는 저장 vpos 역행을 RowBreak 조각
+  경계 신호로 존중해 그 앞에서 멈추지만, 셀 폭이 바뀌어 모든 문단을 재래핑한 직후에는
+  저장 경계 자체가 옛 폭 기준이라 신호가 아니다. 간격 계산(문단 간격 boundary_gaps +
+  줄간격)은 기존 적용 루프를 `apply_cell_vpos_ladder` 로 분리해 텍스트 편집 경로와
+  공유한다 — 초기 실험의 ad-hoc 누적 커서(간격 무시)를 대체.
+
+## undo 대칭 (남은 항목 c — 해소)
+
+셀 나누기는 studio 에서 스냅샷 undo 로 라우팅된다. 증거 체인:
+`table:cell-split`(rhwp-studio/src/command/commands/table.ts, `kind: 'snapshot'`) →
+`SnapshotCommand`(rhwp-studio/src/engine/command.ts) → `save_snapshot_native` /
+`restore_snapshot_native`(src/document_core/commands/document.rs)가 `Document` 전체를
+클론·복원한다. line_segs 는 `Document` 안에 있으므로 undo 시 구 line_segs 가 자동
+복원된다. 코어 측 추가 작업 불요.
+
+## 실측 (native release, 동일 표본 1×2 분할)
+
+| 구성 | stale | 사다리 역행 | 쪽수 |
+| --- | --- | --- | --- |
+| 수정 전 | 2,498문단 / 4,321seg | — | 118 |
+| reflow만 | 0 | 발생 | 222 |
+| reflow + 사다리 재구축(본 수정) | 0 | 0 | 195 |
+
+- 195쪽이 한컴 실측 쪽수와 일치하는지는 **미확인** (남은 항목 — 오라클 필요).
+- 회귀 테스트: `tests/issue_4138_split_cell_stale_linesegs.rs` 2건 green,
+  수정 원복 시 stale 2,498 로 red 확인(red→green).
+
+## 성능 계측 (남은 항목 d — 원인 규명, 본 수정 밖으로 판정)
+
+`RHWP_2424_PROFILE=1` + 임시 프로브 실측 (native release):
+
+| 단계 | 시간 |
+| --- | --- |
+| 파싱 + 초기 페이지네이션(115쪽) | 1.12s (`typeset_ms=1095`) |
+| 분할 호출 전체 | 3.43s |
+| ├ 분할 후 재조판(195쪽) | 3.33s (`typeset_ms=3308`, `RHWP_2424_BLOCK_TABLE_PROFILE`) |
+| └ reflow + 사다리 재구축 + recompose (**본 수정이 추가한 비용**) | **≈0.10s** |
+
+과제 설명의 "3.97s 성능 주의"는 본 수정의 reflow 가 아니라 **분할 뒤 195쪽 거대 표
+전체 재조판**(`typeset_block_table_inner`, 쪽수 비례 ~17ms/쪽)이다. 이는 Task #8
+(거대 셀 fragment 단위 증분 재조판)의 대상과 동일한 병목이므로 이 과제에서 더
+최적화하지 않는다.
+
+## 오라클 대조 (2026-08-07, issue #4138 첨부 이미지)
+
+이슈의 한컴 기대 이미지(분할 후)와 본 수정 후 렌더(0쪽)를 대조했다:
+
+- 기대 이미지: 분할된 왼쪽 셀에서 1.1.1·1.1.2 본문이 좁은 폭으로 완전히 재래핑되고
+  1.1.2 가 1.1.1 과 같은 쪽에 이어진다. 실제(결함) 이미지: 1.1.2 줄이 옛 폭으로
+  그려져 셀 경계에서 잘린다("치수는 ㅈ", "해양수ㅅ").
+- 본 수정 후 렌더는 1.1.2 문단의 줄바꿈 위치가 기대 이미지와 줄 단위로 일치한다
+  ("각 부재 치수는 / 직접강도 계산에 따라 결정하며, / 계산에 사용되는 자료와 그 결과
+  / 를 해양수산부장관에 제출하여야 …"). 1.1.1 은 1개 줄바꿈 위치가 근소하게 다르다
+  (기대 "모두 만족/하여야" vs 렌더 "모두 만/족하여야") — 최종 판정은 거버넌스에 따라
+  작업지시자 권위.
+- 첨부 이미지는 중첩 표 영역을 포함하지 않아 (a)의 중첩 표 리스케일 여부는 이
+  오라클로 판정 불가 — 계속 미해결.
+
+## 시각 증적 (mydocs/pr/assets/)
+
+`HwpDocument::render_page_svg_native` 로 생성 (0–1쪽), qlmanage 로 PNG 변환:
+
+- `pr_4138_presplit_p0.{svg,png}` — 분할 전 원본
+- `pr_4138_before_p{0,1}.{svg,png}` — 분할 후, 수정 원복(HEAD~1 소스) — 잘림 재현
+- `pr_4138_after_p{0,1}.{svg,png}` — 분할 후, 본 수정 — 기대 이미지와 정합
+
+## 남은 항목
+
+- (a) 중첩 표 host 문단의 잔존 stale seg: `reflow_line_segs` 는 텍스트 없이 컨트롤만
+  호스팅하는 문단에서 원본 seg 폭 template 을 보존한다. 한컴이 분할 시 중첩 표를
+  리스케일하는지 오라클 확인 필요(이슈 첨부 이미지 범위 밖). 회귀 테스트는 이 문단들을
+  계약 밖으로 명시 제외.
+- (f) PR #4122(#4069 canonical cell unit·frame 경계 reset 해석) 2026-08-07 **merge 됨**
+  (`accebdb20`) — 본 브랜치를 merge 후 devel 로 rebase(cherry-pick `148bff3ef`)하고
+  회귀 테스트·게이트를 재실행해 재검증 (검증 기록 참조).
+- 후속 후보: `merge_table_cells` / 폭이 **넓어지는** 방향(병합)은 seg 폭 < 셀 폭이라
+  본 판별(초과 검사)에 걸리지 않고, 병합 경로에도 reflow 배선이 없다 — 줄이 좁게 남는
+  cosmetic 결함. 별도 이슈로 분리 검토.
+- 한컴 실측 쪽수(분할 후 전체 문서) 대조는 한컴 편집기 환경 필요 — 작업지시자 판정
+  대상으로 이관.
+
+## 검증 기록
+
+- `cargo test --release --test issue_4138_split_cell_stale_linesegs` — 2 passed (4.7s)
+- red 확인: table_ops.rs 수정만 stash 후 동일 테스트 → stale 2,498 로 FAILED, pop 복원
+- 인접 focused (release, 전부 green — 20 tests):
+  issue_1073_nested_table_split(3) · issue_1750_split_guard_spacing_before(1) ·
+  issue_2158_hwpx_vpos_reset_preserve(2) · issue_2299_edit_vpos_reset_preserve(8) ·
+  issue_3236_split_single_cell_table(1) · issue_3593_cell_para_vpos_anchor(2) ·
+  issue_3595_nested_split_row_identity(2) · issue_3637_split_cell_nested_table_vpos(1)
+  — 2158/2299/3593 은 이번에 분리한 `apply_cell_vpos_ladder` 경유 reset-preserve
+  의미론을 직접 핀하는 스위트.
+- `cargo fmt --check`: 본 과제 변경 파일 clean (잔여 diff 는 타 세션의 임시 프로브
+  `tests/tmp_bold_probe.rs` 뿐 — 본 과제 밖).
+- release-test 전체·clippy 전체는 PR CI 성격이므로 작업지시자 승인 후 실행 예정
+  (`pr_review` 게이트 규칙). 시각 증적(분할 전후 렌더 비교)은 studio 브라우저 경로로
+  후속 확보 예정 — 분할 op 이 CLI 미노출이라 네이티브 export 로는 재현 불가.

--- a/mydocs/working/task_m100_4146_cell_enter_latency_stage1.md
+++ b/mydocs/working/task_m100_4146_cell_enter_latency_stage1.md
@@ -1,0 +1,13 @@
+---
+kind: working
+status: completed
+issue: 4146
+last_verified: 2026-08-08
+---
+
+# Task #4146 Stage 1
+
+## 구현·검증
+
+- integration 검증 트리에서 커밋 4개 리프트(936574fbe→b4ea54350→b2e9a1da3→8d2a1b802, #4031 스테이지 명명) — probe/perf/fix/e2e.
+- 검증: 레이어 전체 게이트 ALL-PASS. 브라우저 실측(선행 세션): 셀 Enter 지연 해소, Enter 경로 계약 e2e 녹색.

--- a/mydocs/working/task_m100_4179_host_para_pages_stage1.md
+++ b/mydocs/working/task_m100_4179_host_para_pages_stage1.md
@@ -1,0 +1,13 @@
+---
+kind: working
+status: completed
+issue: 4179
+last_verified: 2026-08-08
+---
+
+# Task #4179 Stage 1
+
+## 구현·검증
+
+- integration 검증 트리에서 커밋 리프트(원 커밋 d530e0f16) — 컷 메타 기반 후보 제외 + 전용 회귀 테스트.
+- 검증: 레이어 전체 게이트(별첨 게이트 로그) — nextest 전체·Skia·studio 포함 ALL-PASS. 실측 효과: 115쪽 문서 열기 경로의 O(pages) 빌드 소멸(#4145 계열 개선과 합산).

--- a/mydocs/working/task_m100_4180_caret_meta_on_save_stage1.md
+++ b/mydocs/working/task_m100_4180_caret_meta_on_save_stage1.md
@@ -1,0 +1,13 @@
+---
+kind: working
+status: completed
+issue: 4180
+last_verified: 2026-08-08
+---
+
+# Task #4180 Stage 1
+
+## 구현·검증
+
+- integration 검증 트리에서 커밋 리프트(원 커밋 d59e6f7ff) — 저장 시점 스탬프 + 라운드트립 회귀.
+- 검증: 레이어 전체 게이트 ALL-PASS (nextest·Skia·studio 포함).

--- a/rhwp-studio/e2e/MANIFEST.md
+++ b/rhwp-studio/e2e/MANIFEST.md
@@ -19,6 +19,7 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `body-outside-click-fallback.test.mjs` | 진단 | hold | 보류 ② 본문 외곽 클릭 fallback 결함 — 가설 (b) master page 글상자 hit 확정 e2e | hwpctl_Action_Table__v1.1.hwp | 수동 | legacy-name · 보류② 이슈 종속 |
 | `canvas-render-diff.test.mjs` | 상시 | active | Browser canvas visual diff between the legacy PageRenderTree path  | — | npm+CI |  |
 | `canvaskit-font-coverage.test.mjs` | 상시 | active | CanvasKit 번들 폰트와 exact TTC GlyphRun 등록/픽셀 replay 검증 | — | npm+CI |  |
+| `cell-enter-pagination-issue4031.test.mjs` | 상시 | active | Issue #4031 — pending 중 셀 Enter의 pre-navigation full flush 0회·split 1회·barrier 대조군 계약 | issue1949_giant_cell_nested_tables_perf.hwp/.hwpx | npm e2e:issue-4031-cell-enter |  |
 | `command-palette.test.mjs` | 상시 | active | /커맨드 팔레트 | — | 수동 |  |
 | `copy-paste.test.mjs` | 상시 | active | 텍스트 블럭 복사/붙여넣기 버그 (Task 227) | — | 수동 |  |
 | `debug-pagination.mjs` | 진단 | active | E2E 디버그: 50줄 입력 후 페이지네이션 확인 | — | 수동 | 수동 디버그 |

--- a/rhwp-studio/e2e/cell-enter-pagination-issue4031.test.mjs
+++ b/rhwp-studio/e2e/cell-enter-pagination-issue4031.test.mjs
@@ -1,0 +1,302 @@
+/**
+ * Issue #4031 — pending pagination 중 셀 Enter의 중복 full pagination 제거 계약.
+ *
+ * 115쪽 거대 표 셀(HWP/HWPX)에서:
+ *  1. deferred insert로 pending pagination을 만든 뒤 direct Enter를 실키로 보낸다.
+ *     admitted 경로 계약: pre-navigation `wasm.flushDeferredPagination` 0회,
+ *     `splitParagraphInCell` 1회, 이후 pending 해소·caret은 새 문단 시작.
+ *  2. 사후 flush oracle: split의 동기 pagination이 최신이므로 page count 불변.
+ *  3. barrier 대조군: pending 중 ArrowDown은 기존 full flush 1회를 유지한다.
+ *
+ * 실행 (repo root에서 wasm-pack build 후):
+ *   cd rhwp-studio && npm run e2e:issue-4031-cell-enter
+ */
+
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  closeBrowser,
+  closePage,
+  createPage,
+  launchBrowser,
+  loadApp,
+  setTestCase,
+} from './helpers.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+const TARGET = Object.freeze({
+  sectionIndex: 0,
+  paragraphIndex: 5,
+  charOffset: 130,
+  parentParaIndex: 0,
+  controlIndex: 2,
+  cellIndex: 2,
+  cellParaIndex: 5,
+  cellPath: [{ controlIndex: 2, cellIndex: 2, cellParaIndex: 5 }],
+});
+
+const SAMPLES = Object.freeze({
+  hwp: path.join(REPO_ROOT, 'samples/issue1949_giant_cell_nested_tables_perf.hwp'),
+  hwpx: path.join(REPO_ROOT, 'samples/issue1949_giant_cell_nested_tables_perf.hwpx'),
+});
+
+function waitTwoRafs(page) {
+  return page.evaluate(
+    () =>
+      new Promise((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
+}
+
+function clickBlockingModalChoice(page) {
+  return page.evaluate(() => {
+    const allowed = new Set(['그대로 보기', '대체 글꼴로 보기']);
+    const buttons = Array.from(document.querySelectorAll('button'));
+    const button = buttons.find((candidate) => {
+      const label = candidate.textContent?.trim() ?? '';
+      const style = getComputedStyle(candidate);
+      return allowed.has(label) && style.display !== 'none' && style.visibility !== 'hidden';
+    });
+    if (!button) return null;
+    const label = button.textContent?.trim() ?? '';
+    button.click();
+    return label;
+  });
+}
+
+async function openDocumentThroughApp(page, format) {
+  const bytes = readFileSync(SAMPLES[format]);
+  const fileName = path.basename(SAMPLES[format]);
+  const encoded = bytes.toString('base64');
+  const requestId = `issue4031-${format}-${crypto.randomUUID()}`;
+
+  await page.evaluate(({ base64, name, id }) => {
+    const binary = atob(base64);
+    const payload = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) {
+      payload[index] = binary.charCodeAt(index);
+    }
+    window.__issue4031LoadResult = null;
+    const off = window.__eventBus.on('open-document-bytes:done', (result) => {
+      if (result?.requestId !== id) return;
+      off();
+      window.__issue4031LoadResult = result;
+    });
+    window.__eventBus.emit('open-document-bytes', {
+      bytes: payload,
+      fileName: name,
+      fileHandle: null,
+      skipUnsavedGuard: true,
+      requestId: id,
+    });
+  }, { base64: encoded, name: fileName, id: requestId });
+
+  const deadline = Date.now() + 90_000;
+  let result = null;
+  while (Date.now() < deadline) {
+    await clickBlockingModalChoice(page);
+    result = await page.evaluate(() => window.__issue4031LoadResult);
+    if (result) break;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  assert.ok(result, `${format}: open-document-bytes:done timeout`);
+  assert.equal(result.ok, true, `${format}: document load failed: ${result.error ?? 'unknown'}`);
+  await page.evaluate(() => document.fonts.ready);
+  await waitTwoRafs(page);
+
+  const pageCount = await page.evaluate(() => window.__wasm.pageCount);
+  assert.equal(pageCount, 115, `${format}: expected 115 pages`);
+}
+
+async function moveToTarget(page, target = TARGET) {
+  const state = await page.evaluate((pos) => {
+    const input = window.__inputHandler;
+    input.cursor.clearSelection();
+    input.cursor.moveTo(pos);
+    input.cursor.resetPreferredX();
+    input.updateCaret();
+    input.focus();
+    return {
+      position: input.cursor.getPosition(),
+      focused: document.activeElement === input.textarea,
+    };
+  }, target);
+  assert.equal(state.focused, true, 'hidden textarea was not focused');
+  assert.equal(state.position.cellParaIndex, target.cellParaIndex, 'target cell paragraph mismatch');
+  return state;
+}
+
+async function installCounters(page) {
+  await page.evaluate(() => {
+    const wasm = window.__wasm;
+    const counts = { flush: 0, cancel: 0, split: 0, splitByPath: 0 };
+    window.__issue4031Counts = counts;
+    if (!window.__issue4031Wrapped) {
+      window.__issue4031Wrapped = true;
+      for (const [method, key] of [
+        ['flushDeferredPagination', 'flush'],
+        ['cancelDeferredPagination', 'cancel'],
+        ['splitParagraphInCell', 'split'],
+        ['splitParagraphInCellByPath', 'splitByPath'],
+      ]) {
+        const original = wasm[method].bind(wasm);
+        wasm[method] = (...args) => {
+          window.__issue4031Counts[key] += 1;
+          return original(...args);
+        };
+      }
+    }
+  });
+}
+
+function resetCounters(page) {
+  return page.evaluate(() => {
+    window.__issue4031Counts = { flush: 0, cancel: 0, split: 0, splitByPath: 0 };
+  });
+}
+
+function readState(page) {
+  return page.evaluate((target) => {
+    const wasm = window.__wasm;
+    const input = window.__inputHandler;
+    return {
+      counts: { ...window.__issue4031Counts },
+      pending: input.hasDeferredPaginationPending(),
+      pageCount: wasm.pageCount,
+      cursor: input.cursor.getPosition(),
+      cellParaCount: wasm.getCellParagraphCount(
+        target.sectionIndex,
+        target.parentParaIndex,
+        target.controlIndex,
+        target.cellIndex,
+      ),
+      targetParaLength: wasm.getCellParagraphLength(
+        target.sectionIndex,
+        target.parentParaIndex,
+        target.controlIndex,
+        target.cellIndex,
+        target.cellParaIndex,
+      ),
+    };
+  }, TARGET);
+}
+
+async function runFormat(browser, format) {
+  setTestCase(`issue4031-${format}`);
+  const page = await createPage(browser, 1280, 900);
+  try {
+    await loadApp(page);
+    await openDocumentThroughApp(page, format);
+    await moveToTarget(page);
+    await installCounters(page);
+
+    const before = await readState(page);
+    assert.equal(before.pending, false, `${format}: unexpected pending before typing`);
+
+    // 1) deferred insert 3회로 pending pagination을 만든다 (실키 경로).
+    await page.keyboard.type('111', { delay: 30 });
+    await waitTwoRafs(page);
+    const pendingState = await readState(page);
+    assert.equal(pendingState.pending, true, `${format}: typing did not defer pagination`);
+    assert.equal(
+      pendingState.targetParaLength,
+      before.targetParaLength + 3,
+      `${format}: deferred inserts missing from model`,
+    );
+
+    // 2) direct Enter — admitted 경로 계약.
+    await resetCounters(page);
+    const enterStarted = Date.now();
+    await page.keyboard.press('Enter');
+    await waitTwoRafs(page);
+    const enterElapsedMs = Date.now() - enterStarted;
+    const after = await readState(page);
+
+    assert.equal(
+      after.counts.flush,
+      0,
+      `${format}: admitted cell Enter must not run pre-navigation full flush`,
+    );
+    assert.equal(
+      after.counts.split + after.counts.splitByPath,
+      1,
+      `${format}: exactly one cell paragraph split must run`,
+    );
+    assert.equal(after.pending, false, `${format}: pending must be cleared by owned completion`);
+    assert.equal(
+      after.cellParaCount,
+      before.cellParaCount + 1,
+      `${format}: cell paragraph count must grow by one`,
+    );
+    assert.equal(
+      after.targetParaLength,
+      TARGET.charOffset + 3,
+      `${format}: split point must sit after the three inserted digits`,
+    );
+    assert.equal(
+      after.cursor.cellParaIndex,
+      TARGET.cellParaIndex + 1,
+      `${format}: caret must land on the new paragraph`,
+    );
+    assert.equal(after.cursor.charOffset, 0, `${format}: caret must land at offset 0`);
+
+    // 3) 사후 flush oracle — split이 최신 revision을 계산했으므로 page count 불변.
+    const oracle = await page.evaluate(() => {
+      const result = window.__wasm.flushDeferredPagination();
+      return { status: result.status, pageCount: window.__wasm.pageCount };
+    });
+    assert.equal(
+      oracle.pageCount,
+      after.pageCount,
+      `${format}: post-split flush must not change page count`,
+    );
+
+    // 4) barrier 대조군 — pending 중 ArrowDown은 기존 full flush를 유지한다.
+    await page.keyboard.type('1', { delay: 30 });
+    await waitTwoRafs(page);
+    const navPending = await page.evaluate(() =>
+      window.__inputHandler.hasDeferredPaginationPending(),
+    );
+    assert.equal(navPending, true, `${format}: control typing did not defer pagination`);
+    await resetCounters(page);
+    await page.keyboard.press('ArrowDown');
+    await waitTwoRafs(page);
+    const navState = await readState(page);
+    assert.equal(
+      navState.counts.flush,
+      1,
+      `${format}: non-Enter boundary key must keep the full-flush barrier`,
+    );
+    assert.equal(navState.pending, false, `${format}: barrier flush must clear pending`);
+
+    console.log(
+      `[issue4031] ${format}: enter_elapsed_ms=${enterElapsedMs} ` +
+        `flush=0 split=1 pages=${after.pageCount} oracle=${oracle.status} barrier_flush=1 — OK`,
+    );
+  } finally {
+    await closePage(page);
+  }
+}
+
+async function main() {
+  const browser = await launchBrowser();
+  try {
+    for (const format of ['hwp', 'hwpx']) {
+      await runFormat(browser, format);
+    }
+    console.log('[issue4031] all formats passed');
+  } finally {
+    await closeBrowser(browser);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -24,6 +24,7 @@
     "e2e:issue-2214": "node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless",
     "e2e:issue-3815": "node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless --continuous-only",
     "e2e:issue-3137-perf": "node e2e/probe-input-perf-issue3137.mjs --mode=headless",
+    "e2e:issue-4031-cell-enter": "node e2e/cell-enter-pagination-issue4031.test.mjs --mode=headless",
     "e2e:issue-2809": "node e2e/issue-2809-split-alignment.test.mjs --mode=headless",
     "e2e:issue-4159": "node e2e/issue-4159-terminal-nested-bottom-border-canvas2d.test.mjs --mode=headless",
     "e2e:issue-536": "node e2e/issue-536-boxed-pua-canvas2d.test.mjs --mode=headless",

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -500,18 +500,29 @@ export class WasmBridge {
     return this._fileName === '새 문서.hwp';
   }
 
+  /**
+   * [#4180] 바이트 생산 직전 호출되는 훅 — 저장 시점 캐럿 스탬핑용 (main.ts 가 등록).
+   * 편집별 스탬핑은 "마지막 본문 편집 위치"를 남겨 열기 캐럿이 엉뚱한 페이지로
+   * 복원됐다. 저장/autosave/비교/히스토리 등 모든 export 경로가 이 브리지 메서드를
+   * 지나므로 여기가 단일 지점이다.
+   */
+  onBeforeExport: (() => void) | null = null;
+
   exportHwp(): Uint8Array {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    this.onBeforeExport?.();
     return this.doc.exportHwp();
   }
 
   exportHwpWithPassword(password: string): Uint8Array {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    this.onBeforeExport?.();
     return this.doc.exportHwpWithPassword(password);
   }
 
   exportHwpx(): Uint8Array {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    this.onBeforeExport?.();
     return this.doc.exportHwpx();
   }
 
@@ -1536,6 +1547,16 @@ export class WasmBridge {
       return JSON.parse(this.doc.getCaretPosition());
     } catch {
       return null;
+    }
+  }
+
+  /** [#4180] 저장 시점 캐럿 스탬핑 — 범위 밖 위치는 wasm 쪽에서 무시된다. */
+  setCaretPosition(sec: number, para: number, charOffset: number): void {
+    if (!this.doc) return;
+    try {
+      this.doc.setCaretPosition(sec, para, charOffset);
+    } catch {
+      // 저장을 막지 않는다
     }
   }
 

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -1458,10 +1458,12 @@ export class MergeParagraphInFootnoteCommand implements EditCommand {
 export class SplitParagraphInCellCommand implements EditCommand {
   readonly type = 'splitParagraphInCell';
   readonly timestamp = Date.now();
+  private lastMutationEffects: TextMutationEffects = NO_TEXT_MUTATION_EFFECTS;
 
   constructor(private position: DocumentPosition) {}
 
   execute(wasm: WasmBridge): DocumentPosition {
+    this.lastMutationEffects = NO_TEXT_MUTATION_EFFECTS;
     const pos = this.position;
     const sec = pos.sectionIndex;
     const ppi = pos.parentParaIndex!;
@@ -1471,7 +1473,16 @@ export class SplitParagraphInCellCommand implements EditCommand {
     } else {
       wasm.splitParagraphInCell(sec, ppi, pos.controlIndex!, pos.cellIndex!, cpi, pos.charOffset);
     }
+    // [#4031] 네이티브 split은 paginate_if_needed()로 최신 revision을 동기 계산한다.
+    // 이 선언이 pending deferred 상태를 해소해 직후 before-full-edit flush가 no-op이 된다.
+    this.lastMutationEffects = IMMEDIATE_TEXT_MUTATION_EFFECTS;
     return cellParagraphPosition(pos, cpi + 1, 0);
+  }
+
+  consumeTextMutationEffects(): TextMutationEffects {
+    const effects = this.lastMutationEffects;
+    this.lastMutationEffects = NO_TEXT_MUTATION_EFFECTS;
+    return effects;
   }
 
   undo(wasm: WasmBridge): DocumentPosition {

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -1251,9 +1251,10 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
         this.executeOperation({ kind: 'command', command: new InsertLineBreakCommand(this.cursor.getPosition()) });
       } else if (inCell) {
         try {
+          // [#4031] 성공한 split은 IMMEDIATE_TEXT_MUTATION_EFFECTS를 선언해
+          // executeOperation의 effects 경로가 pending 해소·runner 취소·geometry
+          // invalidation(완료 소유)을 수행한다.
           this.executeOperation({ kind: 'command', command: new SplitParagraphInCellCommand(this.cursor.getPosition()) });
-          // [#4031] 성공한 native split이 최신 revision pagination을 소유했다.
-          if (committedCellEnterSplit) this.completePaginationOwnedBySyncMutation();
         } catch (err) {
           // [#4031] structural command 실패 — 기존 full-flush barrier로 fail-closed 복귀.
           if (committedCellEnterSplit) this.flushDeferredPaginationIfNeeded('cell-enter-split-fallback', false);

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -40,6 +40,27 @@ const SUBMODE_GLOBAL_COMMANDS = new Set([
   'edit:goto',
 ]);
 
+/**
+ * [#4031] 이 keydown이 아래 switch의 `case 'Enter'`에서 `SplitParagraphInCellCommand`로
+ * 확정 실행되는 좁은 조건인지 판정한다. 목록은 flush 지점과 `case 'Enter'` 사이의 모든
+ * 조기 분기(모드 가드·단축키 라우팅·선택 삭제)를 보수적으로 배제한다 — 하나라도
+ * 확신할 수 없으면 false를 돌려 기존 before-navigation full flush로 fail-closed한다.
+ */
+function isCommittedCellEnterSplit(this: any, e: KeyboardEvent): boolean {
+  return e.key === 'Enter'
+    && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey
+    && !this.isComposing
+    && !this.isFormMode?.()
+    && !this.cursor.isInHeaderFooter()
+    && !this.cursor.isInFootnote()
+    && !this.cursor.isInPictureObjectSelection()
+    && !this.cursor.isInTableObjectSelection()
+    && !this.cursor.isInBlockSelectionMode()
+    && !this.cursor.isInCellSelectionMode()
+    && !this.cursor.hasSelection()
+    && this.cursor.isInCell();
+}
+
 function dispatchSubmodeGlobalShortcut(this: any, e: KeyboardEvent): boolean {
   if (!this.dispatcher) return false;
   const commandId = matchShortcut(e, defaultShortcuts);
@@ -544,8 +565,17 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
     return;
   }
 
+  // [#4031] 셀 Enter는 `SplitParagraphInCellCommand`의 동기 full pagination이 확정이라,
+  // 곧 폐기될 분할 전 pagination을 flush로 완주하는 대신 stale deferred job만 취소한다.
+  // admission 미충족 시 기존 full barrier 그대로다.
+  const committedCellEnterSplit = PAGINATION_BOUNDARY_KEYS.has(e.key)
+    && isCommittedCellEnterSplit.call(this, e);
   if (PAGINATION_BOUNDARY_KEYS.has(e.key)) {
-    this.flushDeferredPaginationIfNeeded('before-navigation', false);
+    if (committedCellEnterSplit) {
+      this.cancelDeferredPaginationForOwnedMutation();
+    } else {
+      this.flushDeferredPaginationIfNeeded('before-navigation', false);
+    }
   }
 
   // ─── 머리말/꼬리말 편집 모드 키보드 처리 ──────────────────
@@ -1220,7 +1250,15 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
         // Shift+Enter: 강제 줄바꿈 (문단 유지, 줄만 바꿈)
         this.executeOperation({ kind: 'command', command: new InsertLineBreakCommand(this.cursor.getPosition()) });
       } else if (inCell) {
-        this.executeOperation({ kind: 'command', command: new SplitParagraphInCellCommand(this.cursor.getPosition()) });
+        try {
+          this.executeOperation({ kind: 'command', command: new SplitParagraphInCellCommand(this.cursor.getPosition()) });
+          // [#4031] 성공한 native split이 최신 revision pagination을 소유했다.
+          if (committedCellEnterSplit) this.completePaginationOwnedBySyncMutation();
+        } catch (err) {
+          // [#4031] structural command 실패 — 기존 full-flush barrier로 fail-closed 복귀.
+          if (committedCellEnterSplit) this.flushDeferredPaginationIfNeeded('cell-enter-split-fallback', false);
+          throw err;
+        }
       } else {
         this.executeOperation({ kind: 'command', command: new SplitParagraphCommand(this.cursor.getPosition()) });
       }

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2801,6 +2801,30 @@ export class InputHandler {
     }
   }
 
+  /**
+   * [#4031] 동기 full pagination을 소유하는 structural command(셀 Enter 분할)가 확정된
+   * 경로에서, 곧 폐기될 stale deferred job을 계산 완료 없이 취소한다.
+   * `wasm.flushDeferredPagination()`을 호출하지 않는 것이 flush 경로와의 유일한 차이다.
+   * runner.cancel()이 전진 중인 WASM resumable job까지 취소한다.
+   * `deferredPaginationPending`은 유지한다 — mutation이 실패하면 다음 boundary flush가
+   * 기존 barrier 의미론으로 복구하도록 fail-closed로 남긴다.
+   */
+  cancelDeferredPaginationForOwnedMutation(): void {
+    this.cancelDeferredPaginationFlush();
+    this.deferredPaginationRunner.cancel();
+  }
+
+  /**
+   * [#4031] 성공한 native mutation의 `paginate_if_needed()`가 최신 revision을 계산했음을
+   * studio 상태에 반영한다. 이후 boundary flush는 no-op으로 수렴한다.
+   */
+  completePaginationOwnedBySyncMutation(): void {
+    this.cancelDeferredPaginationFlush();
+    this.deferredPaginationRunner.cancel();
+    this.deferredPaginationPending = false;
+    this.cursor.invalidateFocusedCellCursorGeometry();
+  }
+
   /** raw IME/iOS 텍스트 입력처럼 command를 거치지 않는 경로의 갱신 라우터. */
   private afterTextInputEdit(
     beforePos: DocumentPosition,

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2814,17 +2814,6 @@ export class InputHandler {
     this.deferredPaginationRunner.cancel();
   }
 
-  /**
-   * [#4031] 성공한 native mutation의 `paginate_if_needed()`가 최신 revision을 계산했음을
-   * studio 상태에 반영한다. 이후 boundary flush는 no-op으로 수렴한다.
-   */
-  completePaginationOwnedBySyncMutation(): void {
-    this.cancelDeferredPaginationFlush();
-    this.deferredPaginationRunner.cancel();
-    this.deferredPaginationPending = false;
-    this.cursor.invalidateFocusedCellCursorGeometry();
-  }
-
   /** raw IME/iOS 텍스트 입력처럼 command를 거치지 않는 경로의 갱신 라우터. */
   private afterTextInputEdit(
     beforePos: DocumentPosition,

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -402,6 +402,18 @@ async function initialize(): Promise<void> {
     );
     inputHandler.setEditMode(editMode);
 
+    // [#4180] 저장 시점 캐럿 스탬핑 — 셀/글상자 캐럿은 현행 캐럿 필드(list_id 를
+    // 구역 인덱스로 쓰는 rhwp 관례)로 표현 불가 → 호스트 문단 시작으로 강등.
+    wasm.onBeforeExport = () => {
+      const p = inputHandler?.getCursorPosition();
+      if (!p) return;
+      wasm.setCaretPosition(
+        p.sectionIndex,
+        p.parentParaIndex ?? p.paragraphIndex,
+        p.parentParaIndex !== undefined ? 0 : p.charOffset,
+      );
+    };
+
     toolbar = new Toolbar(document.getElementById('style-bar')!, wasm, eventBus, dispatcher);
     toolbar.setEnabled(false);
 

--- a/rhwp-studio/tests/cell-enter-owned-pagination.test.ts
+++ b/rhwp-studio/tests/cell-enter-owned-pagination.test.ts
@@ -78,29 +78,71 @@ test('admission helper는 case Enter까지의 모든 조기 분기를 배제한�
   }
 });
 
-test('성공한 셀 split이 pagination 완료를 소유하고 실패는 full flush로 복귀한다', () => {
+test('성공한 셀 split이 effects로 pagination 완료를 선언하고 실패는 full flush로 복귀한다', () => {
+  const command = source('src/engine/command.ts');
+  const splitClass = sliceBetween(
+    command,
+    'export class SplitParagraphInCellCommand',
+    'export class MergeParagraphInCellCommand',
+  );
+  const wasmCallIdx = splitClass.indexOf('wasm.splitParagraphInCell(');
+  const effectsIdx = splitClass.indexOf('this.lastMutationEffects = IMMEDIATE_TEXT_MUTATION_EFFECTS');
+  assert.notEqual(wasmCallIdx, -1, 'splitParagraphInCell wasm 호출이 없다');
+  assert.ok(
+    effectsIdx > wasmCallIdx,
+    '완료 선언(IMMEDIATE effects)은 native split 성공 뒤에만 세팅되어야 한다(예외 시 NO 유지)',
+  );
+  assert.ok(
+    splitClass.includes('consumeTextMutationEffects()'),
+    'split command는 effects를 executeOperation에 전달해야 한다',
+  );
+
   const keyboard = source('src/engine/input-handler-keyboard.ts');
   const enterCase = sliceBetween(keyboard, "case 'Enter': {", "case 'ArrowLeft':");
-  const successIdx = enterCase.indexOf('this.completePaginationOwnedBySyncMutation()');
   const splitIdx = enterCase.indexOf('new SplitParagraphInCellCommand');
   const fallbackIdx = enterCase.indexOf(
     "this.flushDeferredPaginationIfNeeded('cell-enter-split-fallback', false)",
   );
   assert.notEqual(splitIdx, -1, 'SplitParagraphInCellCommand 실행이 없다');
-  assert.ok(successIdx > splitIdx, '완료 선언은 split 실행 뒤에 와야 한다');
   assert.ok(fallbackIdx > splitIdx, 'catch fallback full flush가 없다');
   assert.ok(
     enterCase.includes('if (committedCellEnterSplit)'),
-    '완료/복귀는 admission이 확정된 경우에만 수행해야 한다',
+    'fallback 복귀는 admission이 확정된 경우에만 수행해야 한다',
   );
 });
 
-test('소유 취소는 pending을 유지하고 완료 선언만 pending을 해소한다', () => {
+test('effects의 paginationCompleted가 pending 해소·runner 취소·geometry invalidation을 소유한다', () => {
+  const handler = source('src/engine/input-handler.ts');
+  const prepare = sliceBetween(
+    handler,
+    'private prepareTextMutationBeforeCursor(',
+    'private completeResumablePagination(',
+  );
+  const completedBlock = sliceBetween(
+    prepare,
+    'if (effects.paginationCompleted) {',
+    '}',
+  );
+  assert.ok(
+    completedBlock.includes('this.deferredPaginationRunner.cancel()'),
+    'paginationCompleted는 runner를 취소해야 한다',
+  );
+  assert.ok(
+    completedBlock.includes('this.deferredPaginationPending = false'),
+    'paginationCompleted는 pending을 해소해야 한다',
+  );
+  assert.ok(
+    prepare.includes('this.cursor.invalidateFocusedCellCursorGeometry()'),
+    'effects 경로는 focused cursor geometry를 invalidate해야 한다',
+  );
+});
+
+test('소유 취소는 pending을 유지한다 (fail-closed)', () => {
   const handler = source('src/engine/input-handler.ts');
   const cancel = sliceBetween(
     handler,
     'cancelDeferredPaginationForOwnedMutation(): void {',
-    'completePaginationOwnedBySyncMutation(): void {',
+    '/** raw IME/iOS 텍스트 입력처럼',
   );
   assert.ok(
     !cancel.includes('flushDeferredPagination()'),
@@ -113,20 +155,6 @@ test('소유 취소는 pending을 유지하고 완료 선언만 pending을 해�
   assert.ok(
     cancel.includes('this.deferredPaginationRunner.cancel()'),
     '소유 취소는 scheduled/stepping runner job을 취소해야 한다',
-  );
-
-  const complete = sliceBetween(
-    handler,
-    'completePaginationOwnedBySyncMutation(): void {',
-    'afterTextInputEdit(',
-  );
-  assert.ok(
-    complete.includes('this.deferredPaginationPending = false'),
-    '완료 선언은 pending을 해소해야 한다',
-  );
-  assert.ok(
-    complete.includes('this.cursor.invalidateFocusedCellCursorGeometry()'),
-    '완료 선언은 cursor geometry를 invalidate해야 한다',
   );
 });
 

--- a/rhwp-studio/tests/cell-enter-owned-pagination.test.ts
+++ b/rhwp-studio/tests/cell-enter-owned-pagination.test.ts
@@ -1,0 +1,146 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [#4031] pending pagination 중 셀 Enter의 중복 full pagination 제거 계약.
+//
+// 계약: admission이 확정된 셀 Enter는 before-navigation full flush 대신
+// 계산 없는 취소(cancelDeferredPaginationForOwnedMutation)를 쓰고, 성공한
+// SplitParagraphInCellCommand가 pagination 완료를 소유한다. 실패나 admission
+// 불충족은 기존 full-flush barrier로 fail-closed한다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+function sliceBetween(text: string, startNeedle: string, endNeedle: string): string {
+  const start = text.indexOf(startNeedle);
+  assert.notEqual(start, -1, `"${startNeedle}" not found`);
+  const end = text.indexOf(endNeedle, start);
+  assert.notEqual(end, -1, `"${endNeedle}" not found after "${startNeedle}"`);
+  return text.slice(start, end);
+}
+
+test('boundary key flush는 admitted 셀 Enter에서만 계산 없는 취소로 대체된다', () => {
+  const keyboard = source('src/engine/input-handler-keyboard.ts');
+  const block = sliceBetween(
+    keyboard,
+    'const committedCellEnterSplit = PAGINATION_BOUNDARY_KEYS.has(e.key)',
+    '// ─── 머리말/꼬리말 편집 모드 키보드 처리',
+  );
+  assert.ok(
+    block.includes('isCommittedCellEnterSplit.call(this, e)'),
+    'admission은 committed cell Enter 판정 helper를 거쳐야 한다',
+  );
+  assert.ok(
+    block.includes('this.cancelDeferredPaginationForOwnedMutation()'),
+    'admitted 경로는 계산 없는 취소를 호출해야 한다',
+  );
+  assert.ok(
+    block.includes("this.flushDeferredPaginationIfNeeded('before-navigation', false)"),
+    '비admitted boundary key는 기존 before-navigation full flush를 유지해야 한다',
+  );
+  assert.ok(
+    !block.includes('wasm.flushDeferredPagination'),
+    'admitted 경로에 직접 full flush가 있으면 안 된다',
+  );
+});
+
+test('admission helper는 case Enter까지의 모든 조기 분기를 배제한다', () => {
+  const keyboard = source('src/engine/input-handler-keyboard.ts');
+  const helper = sliceBetween(
+    keyboard,
+    'function isCommittedCellEnterSplit',
+    'function dispatchSubmodeGlobalShortcut',
+  );
+  for (const guard of [
+    "e.key === 'Enter'",
+    '!e.shiftKey',
+    '!e.ctrlKey',
+    '!e.metaKey',
+    '!e.altKey',
+    '!this.isComposing',
+    '!this.isFormMode?.()',
+    '!this.cursor.isInHeaderFooter()',
+    '!this.cursor.isInFootnote()',
+    '!this.cursor.isInPictureObjectSelection()',
+    '!this.cursor.isInTableObjectSelection()',
+    '!this.cursor.isInBlockSelectionMode()',
+    '!this.cursor.isInCellSelectionMode()',
+    '!this.cursor.hasSelection()',
+    'this.cursor.isInCell()',
+  ]) {
+    assert.ok(helper.includes(guard), `admission guard 누락: ${guard}`);
+  }
+});
+
+test('성공한 셀 split이 pagination 완료를 소유하고 실패는 full flush로 복귀한다', () => {
+  const keyboard = source('src/engine/input-handler-keyboard.ts');
+  const enterCase = sliceBetween(keyboard, "case 'Enter': {", "case 'ArrowLeft':");
+  const successIdx = enterCase.indexOf('this.completePaginationOwnedBySyncMutation()');
+  const splitIdx = enterCase.indexOf('new SplitParagraphInCellCommand');
+  const fallbackIdx = enterCase.indexOf(
+    "this.flushDeferredPaginationIfNeeded('cell-enter-split-fallback', false)",
+  );
+  assert.notEqual(splitIdx, -1, 'SplitParagraphInCellCommand 실행이 없다');
+  assert.ok(successIdx > splitIdx, '완료 선언은 split 실행 뒤에 와야 한다');
+  assert.ok(fallbackIdx > splitIdx, 'catch fallback full flush가 없다');
+  assert.ok(
+    enterCase.includes('if (committedCellEnterSplit)'),
+    '완료/복귀는 admission이 확정된 경우에만 수행해야 한다',
+  );
+});
+
+test('소유 취소는 pending을 유지하고 완료 선언만 pending을 해소한다', () => {
+  const handler = source('src/engine/input-handler.ts');
+  const cancel = sliceBetween(
+    handler,
+    'cancelDeferredPaginationForOwnedMutation(): void {',
+    'completePaginationOwnedBySyncMutation(): void {',
+  );
+  assert.ok(
+    !cancel.includes('flushDeferredPagination()'),
+    '소유 취소는 wasm full flush를 호출하면 안 된다',
+  );
+  assert.ok(
+    !cancel.includes('deferredPaginationPending = false'),
+    '소유 취소는 fail-closed를 위해 pending을 유지해야 한다',
+  );
+  assert.ok(
+    cancel.includes('this.deferredPaginationRunner.cancel()'),
+    '소유 취소는 scheduled/stepping runner job을 취소해야 한다',
+  );
+
+  const complete = sliceBetween(
+    handler,
+    'completePaginationOwnedBySyncMutation(): void {',
+    'afterTextInputEdit(',
+  );
+  assert.ok(
+    complete.includes('this.deferredPaginationPending = false'),
+    '완료 선언은 pending을 해소해야 한다',
+  );
+  assert.ok(
+    complete.includes('this.cursor.invalidateFocusedCellCursorGeometry()'),
+    '완료 선언은 cursor geometry를 invalidate해야 한다',
+  );
+});
+
+test('IME 종료 후 예약 Enter 경로의 barrier flush는 유지된다', () => {
+  // processPendingNav의 Enter는 조합 확정만 하고 structural command가 없으므로
+  // 이 flush가 최신 모델의 유일한 pagination barrier다 (stage1 §5).
+  const text = source('src/engine/input-handler-text.ts');
+  const pendingNav = sliceBetween(
+    text,
+    'function processPendingNav',
+    'function tryDeleteBodyFootnoteAtCursor',
+  );
+  assert.ok(
+    pendingNav.includes("this.flushDeferredPaginationIfNeeded('before-navigation', false)"),
+    'processPendingNav의 before-navigation flush가 제거되면 안 된다',
+  );
+});

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -696,6 +696,8 @@ impl DocumentCore {
         table.local_resize_cell_widths.clear();
         table.local_resize_cell_heights.clear();
 
+        self.reflow_stale_cells_after_split(section_idx, parent_para_idx, control_idx);
+
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);
         self.paginate_if_needed();
@@ -736,6 +738,8 @@ impl DocumentCore {
         table.local_resize_cell_widths.clear();
         table.local_resize_cell_heights.clear();
 
+        self.reflow_stale_cells_after_split(section_idx, parent_para_idx, control_idx);
+
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);
         self.paginate_if_needed();
@@ -749,6 +753,62 @@ impl DocumentCore {
             "\"cellCount\":{}",
             cell_count
         )))
+    }
+
+    /// [#4138] 셀 나누기 뒤 stale 저장 line_segs 재계산 + vpos 사다리 재구축.
+    ///
+    /// `Table::split_cell*` 는 셀 폭·배치만 바꾸고 저장 line_segs 는 그대로 두므로,
+    /// 렌더러(LayoutEngine::layout_paragraph)가 옛 폭 기준 줄을 그대로 그려 새(더
+    /// 좁은) 셀 클립 경계에서 glyph 가 잘린다. 대상 판별: 저장 seg 폭이 셀 폭을
+    /// 넘으면 stale 로 확정한다 — seg 폭은 항상 패딩만큼 셀 폭보다 작게 계산되므로
+    /// 초과는 옛 폭의 증거다 (`resize_table_cells_native` 의 reflow 계약을 분할에도
+    /// 적용; 분할이 만든 새 셀은 원본 line_segs 를 클론하므로 같은 판별에 걸린다).
+    ///
+    /// per-para reflow 는 각 문단의 vpos 원점을 보존한 채 내부 줄만 다시 싸므로,
+    /// 줄 수가 늘어난 문단 뒤에서 사다리가 역행하고(실측: para[5] 끝 22920 뒤
+    /// para[6] 시작 17160) 컷 기계가 이를 RowBreak hard break 로 오판해 페이지를
+    /// 과소 적재한다. 재래핑한 셀은 사다리를 처음부터 단조 재구축한다.
+    fn reflow_stale_cells_after_split(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+    ) {
+        let stale_cells: Vec<(usize, usize)> = {
+            let para = &self.document.sections[section_idx].paragraphs[parent_para_idx];
+            let Some(Control::Table(table)) = para.controls.get(control_idx) else {
+                return;
+            };
+            table
+                .cells
+                .iter()
+                .enumerate()
+                .filter(|(_, cell)| {
+                    cell.paragraphs
+                        .iter()
+                        .flat_map(|p| p.line_segs.iter())
+                        .any(|ls| (ls.segment_width as i64) > (cell.width as i64))
+                })
+                .map(|(ci, cell)| (ci, cell.paragraphs.len()))
+                .collect()
+        };
+        for (cell_idx, para_count) in stale_cells {
+            for cell_para_idx in 0..para_count {
+                self.reflow_cell_paragraph(
+                    section_idx,
+                    parent_para_idx,
+                    control_idx,
+                    cell_idx,
+                    cell_para_idx,
+                );
+            }
+            self.rebuild_table_cell_vpos_ladder_native(
+                section_idx,
+                parent_para_idx,
+                control_idx,
+                cell_idx,
+            );
+        }
     }
 
     /// 범위 내 셀들을 각각 N줄 × M칸으로 분할한다 (네이티브).
@@ -785,6 +845,8 @@ impl DocumentCore {
         // 인덱스 배치를 바꾸므로 local_resize_cell_widths/heights가 stale해진다. 함께 비운다.
         table.local_resize_cell_widths.clear();
         table.local_resize_cell_heights.clear();
+
+        self.reflow_stale_cells_after_split(section_idx, parent_para_idx, control_idx);
 
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -976,17 +976,7 @@ impl DocumentCore {
         } else {
             (para.controls.len() as u32) * 8
         };
-        self.document.doc_properties.caret_list_id = section_idx as u32;
-        self.document.doc_properties.caret_para_id = para_idx as u32;
-        self.document.doc_properties.caret_char_pos = caret_utf16_pos;
-        if let Some(ref mut raw) = self.document.doc_info.raw_stream {
-            let _ = crate::serializer::doc_info::surgical_update_caret(
-                raw,
-                section_idx as u32,
-                para_idx as u32,
-                caret_utf16_pos,
-            );
-        }
+        self.stamp_caret(section_idx as u32, para_idx as u32, caret_utf16_pos);
 
         if deleted_count > 0 {
             self.event_log.push(DocumentEvent::TextDeleted {
@@ -1009,6 +999,59 @@ impl DocumentCore {
             "\"charOffset\":{},\"documentPaginationPending\":{},\"flowChanged\":{}",
             new_offset, !flow_changed, flow_changed
         )))
+    }
+
+    /// char index → 캐럿 utf16 위치 (문단 끝 이상이면 끝 위치). 편집 경로 스탬핑과
+    /// `set_caret_position_native` 가 같은 계산을 공유한다 — reader
+    /// (`utf16_pos_to_char_idx`, cursor_nav.rs) 의 대칭.
+    fn caret_utf16_at(para: &Paragraph, char_idx: usize) -> u32 {
+        if char_idx < para.char_offsets.len() {
+            para.char_offsets[char_idx]
+        } else if !para.char_offsets.is_empty() {
+            let last = para.char_offsets.len() - 1;
+            let last_char = para.text.chars().nth(last);
+            para.char_offsets[last]
+                + last_char
+                    .map(|ch| if (ch as u32) > 0xFFFF { 2 } else { 1 })
+                    .unwrap_or(1)
+        } else {
+            (para.controls.len() as u32) * 8
+        }
+    }
+
+    /// [#4180] 문서 캐럿 메타데이터 스탬핑의 유일한 쓰기 지점 — doc_properties
+    /// (재직렬화 경로)와 raw_stream(passthrough 경로) 양쪽에 반영한다.
+    pub(crate) fn stamp_caret(&mut self, sec: u32, para: u32, caret_utf16: u32) {
+        self.document.doc_properties.caret_list_id = sec;
+        self.document.doc_properties.caret_para_id = para;
+        self.document.doc_properties.caret_char_pos = caret_utf16;
+        // DocInfo raw_stream 내 캐럿 위치만 surgical update (전체 재직렬화 방지)
+        if let Some(ref mut raw) = self.document.doc_info.raw_stream {
+            let _ = crate::serializer::doc_info::surgical_update_caret(raw, sec, para, caret_utf16);
+        }
+    }
+
+    /// [#4180] 저장 직전 UI 캐럿 반영 (한컴 의미론: 저장 시점 캐럿).
+    ///
+    /// 편집별 스탬핑은 "마지막 본문 편집 위치"를 남겨 열기 캐럿이 엉뚱한 페이지로
+    /// 복원됐다 — 저장 흐름이 이 함수로 현재 캐럿을 덮어쓴다. 범위 밖 위치는
+    /// 무시한다 (저장을 막지 않는다).
+    pub(crate) fn set_caret_position_native(
+        &mut self,
+        section_idx: usize,
+        para_idx: usize,
+        char_idx: usize,
+    ) {
+        let Some(para) = self
+            .document
+            .sections
+            .get(section_idx)
+            .and_then(|s| s.paragraphs.get(para_idx))
+        else {
+            return;
+        };
+        let caret_utf16 = Self::caret_utf16_at(para, char_idx);
+        self.stamp_caret(section_idx as u32, para_idx as u32, caret_utf16);
     }
 
     pub fn insert_text_native(
@@ -1141,19 +1184,7 @@ impl DocumentCore {
             // 텍스트 없이 컨트롤만 있는 경우
             (para.controls.len() as u32) * 8
         };
-        self.document.doc_properties.caret_list_id = section_idx as u32;
-        self.document.doc_properties.caret_para_id = para_idx as u32;
-        self.document.doc_properties.caret_char_pos = caret_utf16_pos;
-
-        // DocInfo raw_stream 내 캐럿 위치만 surgical update (전체 재직렬화 방지)
-        if let Some(ref mut raw) = self.document.doc_info.raw_stream {
-            let _ = crate::serializer::doc_info::surgical_update_caret(
-                raw,
-                section_idx as u32,
-                para_idx as u32,
-                caret_utf16_pos,
-            );
-        }
+        self.stamp_caret(section_idx as u32, para_idx as u32, caret_utf16_pos);
 
         self.event_log.push(DocumentEvent::TextInserted {
             section: section_idx,
@@ -1267,19 +1298,7 @@ impl DocumentCore {
         } else {
             (para.controls.len() as u32) * 8
         };
-        self.document.doc_properties.caret_list_id = section_idx as u32;
-        self.document.doc_properties.caret_para_id = para_idx as u32;
-        self.document.doc_properties.caret_char_pos = caret_utf16_pos;
-
-        // DocInfo raw_stream 내 캐럿 위치만 surgical update (전체 재직렬화 방지)
-        if let Some(ref mut raw) = self.document.doc_info.raw_stream {
-            let _ = crate::serializer::doc_info::surgical_update_caret(
-                raw,
-                section_idx as u32,
-                para_idx as u32,
-                caret_utf16_pos,
-            );
-        }
+        self.stamp_caret(section_idx as u32, para_idx as u32, caret_utf16_pos);
 
         self.event_log.push(DocumentEvent::TextDeleted {
             section: section_idx,

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -4482,6 +4482,83 @@ impl DocumentCore {
         )))
     }
 
+    /// [#4179] 본문 텍스트 매칭 스캔용 후보 페이지 — `find_pages_for_paragraph` 에서
+    /// 호스트 문단 텍스트가 원리적으로 렌더될 수 없는 페이지를 뺀다.
+    ///
+    /// 분할 표 호스트 문단의 본문 텍스트는 표 시작 페이지(cont=false, 표 앞/옆 줄)
+    /// 또는 표가 끝까지 소비된 페이지(end_cut 빈 Vec, 표 뒤 줄)에만 렌더된다.
+    /// 순수-중간 연속 컷(cont=true && end_cut 비어있지 않음)은 표가 페이지 바닥까지
+    /// 이어져 텍스트 줄이 배치될 수 없다 — 실측: dump-pages 와 render tree 전수 대조.
+    /// #4127 의 문단 단위 스킵을 페이지 단위로 일반화한 것으로, 제외 근거가 같아
+    /// 스캔 순서·결과 좌표는 불변이다. 필터가 후보를 전부 비우면(어울림 폴백 등
+    /// 예상 밖 구성) 원본 후보로 폴백한다 — #4128 과 같은 보수 계약.
+    pub(crate) fn find_text_scan_pages_for_paragraph(
+        &self,
+        section_idx: usize,
+        para_idx: usize,
+    ) -> Result<Vec<u32>, HwpError> {
+        use crate::renderer::pagination::PageItem;
+
+        let pages = self.find_pages_for_paragraph(section_idx, para_idx)?;
+        let global_offset: u32 = self.pagination[..section_idx]
+            .iter()
+            .map(|pr| pr.pages.len() as u32)
+            .sum();
+        let pr = &self.pagination[section_idx];
+
+        let page_can_render_para_text = |global_page: u32| -> bool {
+            let Some(page) = global_page
+                .checked_sub(global_offset)
+                .and_then(|local| pr.pages.get(local as usize))
+            else {
+                // 다른 구역 페이지(어울림 폴백 등) — 판정 불가면 후보 유지
+                return true;
+            };
+            for col in &page.column_contents {
+                for item in &col.items {
+                    match item {
+                        PageItem::PartialTable {
+                            para_index,
+                            is_continuation,
+                            end_cut,
+                            ..
+                        } if *para_index == para_idx => {
+                            if !*is_continuation || end_cut.is_empty() {
+                                return true;
+                            }
+                        }
+                        PageItem::FullParagraph { para_index }
+                        | PageItem::PartialParagraph { para_index, .. }
+                        | PageItem::Table { para_index, .. }
+                        | PageItem::Shape { para_index, .. }
+                            if *para_index == para_idx =>
+                        {
+                            return true;
+                        }
+                        _ => {}
+                    }
+                }
+                for wp in &col.wrap_around_paras {
+                    if wp.para_index == para_idx || wp.table_para_index == para_idx {
+                        return true;
+                    }
+                }
+            }
+            false
+        };
+
+        let filtered: Vec<u32> = pages
+            .iter()
+            .copied()
+            .filter(|&gp| page_can_render_para_text(gp))
+            .collect();
+        if filtered.is_empty() {
+            Ok(pages)
+        } else {
+            Ok(filtered)
+        }
+    }
+
     /// [#4128] 셀 내부 위치가 실제로 렌더되는 페이지만 반환한다.
     ///
     /// `find_pages_for_paragraph` 는 `para_index` 만 매칭해 표가 걸친 모든 페이지를

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -54,6 +54,33 @@ fn recalculate_cell_paragraph_vpos(
         })
         .unwrap_or(paragraphs.len());
 
+    apply_cell_vpos_ladder(
+        paragraphs,
+        start_para,
+        stop_para,
+        styles,
+        dpi,
+        is_hwp3_variant,
+    );
+}
+
+/// [#4138] `[start_para, stop_para)` 구간의 셀 문단 vpos 사다리를 문단 간격·줄간격
+/// 계산으로 재배치한다. `recalculate_cell_paragraph_vpos` 의 적용 루프를 분리한 것으로,
+/// 호출자가 정지 지점(stop_para)을 결정한다 — 텍스트 편집 경로는 RowBreak 조각 경계를
+/// 존중해 그 앞에서 멈추고, 셀 폭 변경 후 전체 재래핑 경로는 저장 경계 자체가 옛 폭
+/// 기준이므로 끝까지 재배치한다.
+fn apply_cell_vpos_ladder(
+    paragraphs: &mut [Paragraph],
+    start_para: usize,
+    stop_para: usize,
+    styles: &ResolvedStyleSet,
+    dpi: f64,
+    is_hwp3_variant: bool,
+) {
+    if paragraphs.is_empty() || start_para >= paragraphs.len() {
+        return;
+    }
+
     let boundary_gaps: Vec<i32> = paragraphs
         .windows(2)
         .map(|pair| {
@@ -2258,6 +2285,43 @@ impl DocumentCore {
             paragraphs,
             start_para,
             ignore_reset_at,
+            styles,
+            dpi,
+            is_hwp3_variant,
+        );
+    }
+
+    /// [#4138] 표 셀의 vpos 사다리를 처음부터 끝까지 단조 재구축한다.
+    ///
+    /// `recalculate_cell_paragraph_vpos` 는 저장 vpos 역행을 RowBreak 조각 경계
+    /// 신호로 존중해 그 앞에서 멈춘다. 셀 폭이 바뀌어 **모든** 문단을 재래핑한
+    /// 직후에는 저장 경계 자체가 옛 폭 기준이라 더 이상 신호가 아니므로, 정지
+    /// 없이 전 구간을 재배치한다. 간격 계산은 텍스트 편집 경로와 동일하다.
+    pub(crate) fn rebuild_table_cell_vpos_ladder_native(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+        cell_idx: usize,
+    ) {
+        let styles = &self.styles;
+        let dpi = self.dpi;
+        let is_hwp3_variant = self.document.layout_profile().hwp3_layout();
+        let Some(Control::Table(table)) = self.document.sections[section_idx].paragraphs
+            [parent_para_idx]
+            .controls
+            .get_mut(control_idx)
+        else {
+            return;
+        };
+        let Some(cell) = table.cells.get_mut(cell_idx) else {
+            return;
+        };
+        let stop_para = cell.paragraphs.len();
+        apply_cell_vpos_ladder(
+            &mut cell.paragraphs,
+            0,
+            stop_para,
             styles,
             dpi,
             is_hwp3_variant,

--- a/src/document_core/queries/cursor_rect.rs
+++ b/src/document_core/queries/cursor_rect.rs
@@ -264,8 +264,9 @@ impl DocumentCore {
         };
         use crate::renderer::render_tree::{RenderNode, RenderNodeType};
 
-        // 문단이 포함된 페이지 찾기
-        let pages = self.find_pages_for_paragraph(section_idx, para_idx)?;
+        // 문단이 포함된 페이지 찾기 — [#4179] 텍스트가 렌더될 수 없는
+        // 순수-중간 연속 컷 페이지는 후보에서 제외 (스캔 순서·결과 좌표 불변)
+        let pages = self.find_text_scan_pages_for_paragraph(section_idx, para_idx)?;
 
         let footnote_marker_positions: Vec<(usize, usize)> = self
             .get_render_paragraph_ref(section_idx, para_idx)

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -2881,6 +2881,17 @@ impl HwpDocument {
         self.get_caret_position_native().map_err(|e| e.into())
     }
 
+    /// [#4180] 저장 직전 UI 캐럿을 문서 캐럿 메타데이터에 반영한다
+    /// (한컴 의미론: 저장 시점 캐럿). 범위 밖 위치는 무시 — 저장을 막지 않는다.
+    #[wasm_bindgen(js_name = setCaretPosition)]
+    pub fn set_caret_position(&mut self, section_idx: u32, para_idx: u32, char_offset: u32) {
+        self.set_caret_position_native(
+            section_idx as usize,
+            para_idx as usize,
+            char_offset as usize,
+        );
+    }
+
     /// 표의 행/열/셀 수를 반환한다.
     ///
     /// 반환: JSON `{"rowCount":N,"colCount":N,"cellCount":N}`

--- a/tests/fixtures/overflow_cell_baseline.tsv
+++ b/tests/fixtures/overflow_cell_baseline.tsv
@@ -1,6 +1,7 @@
 2025 행정업무운영 편람(최종).hwp	53
 2025 행정업무운영 편람(최종).hwpx	96
 86712_regulatory_analysis.hwp	27
+basic/issue2007_nested_cell_pagination_42065.hwp	11
 hwpctl_ParameterSetID_Item_v1.2.hwp	49
 hwpx_sample2.hwp	3
 hwpx_sample2.hwpx	3

--- a/tests/issue_4031_enter_latency_probe.rs
+++ b/tests/issue_4031_enter_latency_probe.rs
@@ -1,0 +1,207 @@
+//! Issue #4031 Stage 1 local-only Enter latency probe.
+//!
+//! 거대 셀(115쪽 분할 표) 문서에서 셀 내부 Enter(문단 분할) 1회의 동기 전 구간을
+//! 분해 계측한다. `RHWP_2424_PROFILE=1`과 함께 실행하면 pagination subphase와
+//! block-table timer가 stderr에 함께 출력된다. timing assertion은 두지 않는다.
+//!
+//! - cold Enter: pending 없는 상태의 split 1회 소유 비용(분할+reflow+vpos+full pagination)
+//! - pending Enter(현행 studio 경로): deferred insert 잔여 → full flush → split
+//! - pending Enter(목표 계약): flush 없이 split 1회의 `paginate_if_needed()`로 수렴
+
+use std::fs;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use rhwp::wasm_api::HwpDocument;
+use serde_json::Value;
+
+const FIXTURES: [(&str, &str); 2] = [
+    ("hwp", "samples/issue1949_giant_cell_nested_tables_perf.hwp"),
+    (
+        "hwpx",
+        "samples/issue1949_giant_cell_nested_tables_perf.hwpx",
+    ),
+];
+
+/// 2424 probe와 같은 giant-cell 좌표: section 0 / parent para 0 / control 2 / cell 2.
+const SECTION: usize = 0;
+const PARENT_PARA: usize = 0;
+const CONTROL: usize = 2;
+const CELL: usize = 2;
+/// 2424 probe가 편집한 셀 문단과 오프셋(문단 길이 130 이상 보장).
+const TOP_CELL_PARA: usize = 5;
+const TOP_OFFSET: usize = 130;
+
+fn load(relative: &str) -> HwpDocument {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(relative);
+    let bytes = fs::read(&path).unwrap_or_else(|error| panic!("read {relative}: {error}"));
+    HwpDocument::from_bytes(&bytes).unwrap_or_else(|error| panic!("load {relative}: {error}"))
+}
+
+fn repeats() -> usize {
+    std::env::var("RHWP_4031_REPEATS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(3)
+        .clamp(1, 20)
+}
+
+fn ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1000.0
+}
+
+/// cold Enter — pending pagination 없는 상태에서 연속 split의 소유 비용.
+///
+/// 셀 상단(문단 5)과 하단 부근에서 각각 3연타를 계측해 편집 위치와 무관하게
+/// full pagination이 지배 항인지(=fragment 증분 재개 부재) 확인한다.
+#[test]
+#[ignore = "local performance diagnostic; run explicitly with RHWP_2424_PROFILE=1"]
+fn issue_4031_profile_cold_enter_split() {
+    for run in 1..=repeats() {
+        for (format, relative) in FIXTURES {
+            let mut doc = load(relative);
+            assert_eq!(doc.page_count(), 115, "{format}: initial page count");
+            let cell_para_count = doc
+                .get_cell_paragraph_count_native(SECTION, PARENT_PARA, CONTROL, CELL)
+                .expect("giant cell paragraph count");
+            let bottom_para = cell_para_count.saturating_sub(8);
+
+            for (label, base_para, base_offset) in [
+                ("top", TOP_CELL_PARA, TOP_OFFSET),
+                ("bottom", bottom_para, 0),
+            ] {
+                for stroke in 0..3 {
+                    // Enter 연타: 첫 분할 뒤 캐럿은 새 문단 시작(offset 0)에 있다.
+                    let (para, offset) = if stroke == 0 {
+                        (base_para, base_offset)
+                    } else {
+                        (base_para + stroke, 0)
+                    };
+                    let started = Instant::now();
+                    let raw = doc
+                        .split_paragraph_in_cell_native(
+                            SECTION,
+                            PARENT_PARA,
+                            CONTROL,
+                            CELL,
+                            para,
+                            offset,
+                            None,
+                        )
+                        .expect("cell paragraph split");
+                    let elapsed = started.elapsed();
+                    let result: Value = serde_json::from_str(&raw).expect("split result JSON");
+                    assert_eq!(result["ok"].as_bool(), Some(true), "{format}: split ok");
+                    eprintln!(
+                        "RHWP_4031_COLD_ENTER run={run} format={format} pos={label} stroke={} split_ms={:.3} pages={}",
+                        stroke + 1,
+                        ms(elapsed),
+                        doc.page_count(),
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// pending Enter — 현행 studio 경로 재현: 56회 deferred insert 잔여 상태에서
+/// `flushDeferredPagination`(before-navigation barrier) 뒤 split.
+/// 이어서 같은 초기 상태에서 flush 생략(목표 계약) split을 계측해
+/// 최종 page count 정합과 flush 중복분을 수치로 고정한다.
+#[test]
+#[ignore = "local performance diagnostic; run explicitly with RHWP_2424_PROFILE=1"]
+fn issue_4031_profile_pending_enter_flush_vs_skip() {
+    for run in 1..=repeats() {
+        for (format, relative) in FIXTURES {
+            // 시나리오 A — 현행: flush 1회 + split의 full pagination 1회.
+            let mut doc_a = load(relative);
+            for inserted in 0..56 {
+                doc_a
+                    .insert_text_in_cell_native_deferred_pagination(
+                        SECTION,
+                        PARENT_PARA,
+                        CONTROL,
+                        CELL,
+                        TOP_CELL_PARA,
+                        TOP_OFFSET + inserted,
+                        "1",
+                    )
+                    .expect("sequential deferred cell insert");
+            }
+            let flush_started = Instant::now();
+            doc_a
+                .flush_deferred_pagination()
+                .expect("before-navigation full flush");
+            let flush_elapsed = flush_started.elapsed();
+            let split_started = Instant::now();
+            doc_a
+                .split_paragraph_in_cell_native(
+                    SECTION,
+                    PARENT_PARA,
+                    CONTROL,
+                    CELL,
+                    TOP_CELL_PARA,
+                    TOP_OFFSET,
+                    None,
+                )
+                .expect("cell paragraph split after flush");
+            let split_a_elapsed = split_started.elapsed();
+            let pages_a = doc_a.page_count();
+
+            // 시나리오 B — 목표 계약: flush 생략, split의 paginate_if_needed 1회로 수렴.
+            let mut doc_b = load(relative);
+            for inserted in 0..56 {
+                doc_b
+                    .insert_text_in_cell_native_deferred_pagination(
+                        SECTION,
+                        PARENT_PARA,
+                        CONTROL,
+                        CELL,
+                        TOP_CELL_PARA,
+                        TOP_OFFSET + inserted,
+                        "1",
+                    )
+                    .expect("sequential deferred cell insert");
+            }
+            doc_b.cancel_deferred_pagination();
+            let split_b_started = Instant::now();
+            doc_b
+                .split_paragraph_in_cell_native(
+                    SECTION,
+                    PARENT_PARA,
+                    CONTROL,
+                    CELL,
+                    TOP_CELL_PARA,
+                    TOP_OFFSET,
+                    None,
+                )
+                .expect("cell paragraph split without flush");
+            let split_b_elapsed = split_b_started.elapsed();
+            let pages_b = doc_b.page_count();
+
+            // split의 동기 pagination이 deferred 목표를 소비했으므로 잔여 flush는 즉시 완료여야 한다.
+            let post_flush_started = Instant::now();
+            let post_flush: Value = serde_json::from_str(
+                &doc_b
+                    .flush_deferred_pagination()
+                    .expect("post-split flush must be trivial"),
+            )
+            .expect("post flush JSON");
+            let post_flush_elapsed = post_flush_started.elapsed();
+
+            assert_eq!(
+                pages_a, pages_b,
+                "{format}: flush-then-split and skip-flush split must converge to same page count",
+            );
+            eprintln!(
+                "RHWP_4031_PENDING_ENTER run={run} format={format} flush_ms={:.3} split_after_flush_ms={:.3} \
+                 skip_flush_split_ms={:.3} post_flush_ms={:.3} post_flush_state={} pages={pages_a}",
+                ms(flush_elapsed),
+                ms(split_a_elapsed),
+                ms(split_b_elapsed),
+                ms(post_flush_elapsed),
+                post_flush["status"].as_str().unwrap_or("unknown"),
+            );
+        }
+    }
+}

--- a/tests/issue_4138_split_cell_stale_linesegs.rs
+++ b/tests/issue_4138_split_cell_stale_linesegs.rs
@@ -1,0 +1,138 @@
+//! Issue #4138: 셀 나누기 후 stale line_segs·vpos 사다리 붕괴로 인한
+//! glyph truncation + 잘못된 페이지네이션 회귀 가드.
+//!
+//! 재현 문서: `samples/issue1949_giant_cell_nested_tables_perf.hwp`
+//! (3×1 RowBreak 표가 PartialTable continuation 으로 115쪽에 걸침).
+//!
+//! 결함 2단:
+//! 1. `Table::split_cell_into` 가 셀 폭을 절반으로 바꾸면서 저장 line_segs 를
+//!    그대로 둔다 → 렌더러가 옛 폭(44508) 기준 줄을 새 셀(22395) 클립 경계에
+//!    그대로 그려 glyph 가 잘린다. (수정 전 실측: 4,321 seg 전부 stale)
+//! 2. per-para reflow 만 배선하면 각 문단의 vpos 원점이 보존된 채 줄 수만
+//!    늘어나 사다리가 역행하고, 컷 기계가 이를 RowBreak hard break 로 오판해
+//!    페이지를 과소 적재한다. (실측: 118→222쪽)
+//!
+//! 정정: `reflow_stale_cells_after_split`(table_ops.rs) — stale 셀 재래핑 후
+//! `rebuild_table_cell_vpos_ladder_native` 로 사다리를 단조 재구축한다.
+
+use std::fs;
+use std::path::Path;
+
+use rhwp::model::control::Control;
+use rhwp::model::table::Table;
+
+const SAMPLE: &str = "samples/issue1949_giant_cell_nested_tables_perf.hwp";
+/// 대상 표: (section 0, 문단 0, control 2). 분할 대상 셀: (row 2, col 0).
+const CTRL_IDX: usize = 2;
+const TARGET_ROW: u16 = 2;
+
+fn load() -> rhwp::wasm_api::HwpDocument {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = fs::read(&path).expect("read sample");
+    rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse")
+}
+
+fn target_table(doc: &rhwp::wasm_api::HwpDocument) -> &Table {
+    match &doc.document().sections[0].paragraphs[0].controls[CTRL_IDX] {
+        Control::Table(t) => t,
+        other => panic!("controls[{CTRL_IDX}] 이 표가 아님: {other:?}"),
+    }
+}
+
+/// 저장 seg 폭이 셀 폭을 넘는(=옛 폭 기준 stale) 문단 수.
+///
+/// 텍스트 없이 컨트롤만 호스팅하는 문단은 제외한다: `reflow_line_segs` 는 이
+/// 문단에서 원본 seg 폭 template 을 보존하고, 중첩 표 자체를 분할 시 리스케일할지는
+/// 한컴 오라클 미확인(#4138 미해결 항목 (a))이라 이 가드의 계약 밖이다.
+fn stale_text_paras(table: &Table) -> usize {
+    table
+        .cells
+        .iter()
+        .flat_map(|cell| {
+            cell.paragraphs
+                .iter()
+                .filter(|p| !(p.text.is_empty() && !p.controls.is_empty()))
+                .map(move |p| (cell.width, p))
+        })
+        .filter(|(cell_width, p)| {
+            p.line_segs
+                .iter()
+                .any(|ls| (ls.segment_width as i64) > (*cell_width as i64))
+        })
+        .count()
+}
+
+/// 분할 대상 행 셀들의 vpos 사다리 역행 수 (0 이어야 단조).
+fn ladder_regressions(table: &Table, row: u16) -> usize {
+    let mut regressions = 0usize;
+    for cell in table.cells.iter().filter(|c| c.row == row) {
+        let mut prev_end: i64 = i64::MIN;
+        for p in &cell.paragraphs {
+            if let (Some(first), Some(last)) = (p.line_segs.first(), p.line_segs.last()) {
+                if (first.vertical_pos as i64) < prev_end {
+                    regressions += 1;
+                }
+                prev_end = last.vertical_pos as i64;
+            }
+        }
+    }
+    regressions
+}
+
+/// 셀 나누기(1×2) 뒤: stale seg 0, 사다리 단조, 페이지 흐름 복원.
+#[test]
+fn split_cell_into_reflows_stale_segs_and_rebuilds_ladder() {
+    let mut doc = load();
+    assert_eq!(doc.page_count(), 115, "issue1949 기준 쪽수 핀");
+
+    doc.split_table_cell_into_native(0, 0, CTRL_IDX, TARGET_ROW, 0, 1, 2, false, false)
+        .expect("split_cell_into 1×2");
+
+    let table = target_table(&doc);
+    let stale = stale_text_paras(table);
+    assert_eq!(
+        stale, 0,
+        "#4138 회귀: 분할 뒤 옛 폭 기준 stale line_segs 문단이 {stale}개 남음 \
+         (수정 원복 시 실측 2,498문단/4,321seg). glyph 가 셀 클립 경계에서 잘린다."
+    );
+
+    let regressions = ladder_regressions(table, TARGET_ROW);
+    assert_eq!(
+        regressions, 0,
+        "#4138 회귀: 재래핑된 셀의 vpos 사다리가 {regressions}회 역행. \
+         컷 기계가 hard break 로 오판해 페이지를 과소 적재한다."
+    );
+
+    // 실측 거동 핀 (한컴 정답 쪽수는 미확인 — #4138 미해결 항목).
+    // 수정 원복 시 118쪽(stale 줄로 과소 계산), 사다리 재구축 생략 시 222쪽(과소 적재).
+    let pages = doc.page_count();
+    assert_eq!(
+        pages, 195,
+        "#4138 회귀: 분할 뒤 쪽수 {pages} (기대 195). 118 이면 reflow 누락, \
+         222 이면 vpos 사다리 재구축 누락."
+    );
+}
+
+/// 범위 분할 경로(`split_table_cells_in_range_native`)도 같은 계약을 따른다.
+#[test]
+fn split_cells_in_range_reflows_stale_segs() {
+    let mut doc = load();
+
+    doc.split_table_cells_in_range_native(
+        0, 0, CTRL_IDX, TARGET_ROW, 0, TARGET_ROW, 0, 1, 2, false,
+    )
+    .expect("split_cells_in_range 1×2");
+
+    let table = target_table(&doc);
+    assert_eq!(
+        stale_text_paras(table),
+        0,
+        "#4138 회귀(범위 분할): stale line_segs 잔존"
+    );
+    assert_eq!(
+        ladder_regressions(table, TARGET_ROW),
+        0,
+        "#4138 회귀(범위 분할): vpos 사다리 역행"
+    );
+    assert_eq!(doc.page_count(), 195, "#4138 회귀(범위 분할): 쪽수 불일치");
+}

--- a/tests/issue_4179_cursor_rect_text_host_para_pages.rs
+++ b/tests/issue_4179_cursor_rect_text_host_para_pages.rs
@@ -1,0 +1,56 @@
+//! Issue #4179: 텍스트가 있는 표 호스트 문단에서 `getCursorRect` 가 후보 페이지
+//! 전부의 render tree 를 지어보던 회귀 가드 — #4126(빈 문단) 미커버 자매 케이스.
+//!
+//! 재현: `samples/issue1949_giant_cell_nested_tables_perf.hwp` 의 호스트 문단(0,0)에
+//! 텍스트를 삽입하면 그 텍스트는 분할 표 뒤 = 마지막 페이지에만 렌더된다. 캐럿을
+//! 그 텍스트 끝에 두고 rect 를 질의하면 #4127 가드(텍스트 0자 한정)가 미발동,
+//! 페이지 루프가 후보 115쪽을 순서대로 빌드하다 마지막 후보에서야 히트한다
+//! (studio 실측: 열기 시 단일 long task 2.56s, native 재현 2.54s).
+//!
+//! 정정: `find_text_scan_pages_for_paragraph` 가 pagination 메타데이터만으로
+//! 순수-중간 연속 컷(cont=true && end_cut 비어있지 않음) 페이지를 후보에서 뺀다 —
+//! 텍스트는 표 시작 페이지(cont=false) 또는 표 소진 페이지(end_cut=[])에만 렌더
+//! 가능하다. 115 후보 → 2. 스캔 순서·결과 좌표 불변.
+//!
+//! 판별은 #4126 과 같은 작업량 카운터 상한 — 카운터는 프로세스 누적이므로
+//! 이 파일에는 테스트를 1개만 둔다.
+
+use std::fs;
+use std::path::Path;
+
+use rhwp::diagnostics::perf_counters;
+
+#[test]
+fn text_host_para_cursor_rect_builds_few_page_trees() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("samples/issue1949_giant_cell_nested_tables_perf.hwp");
+    let bytes = fs::read(&path).expect("read sample");
+    let mut doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse");
+    assert_eq!(doc.page_count(), 115, "issue1949 기준 쪽수 핀");
+
+    // "(1)" 변형 재현: 호스트 문단에 타이핑 — 별도 체크인 픽스처 불필요.
+    // 실물 "(1)" 파일의 캐럿 메타데이터가 (0,0,7) = 이 텍스트의 끝이었다 (#4180).
+    doc.insert_text(0, 0, 0, "rhwp pe")
+        .expect("호스트 문단 텍스트 삽입");
+    assert_eq!(doc.page_count(), 115, "삽입 후 쪽수 불변 핀");
+
+    perf_counters::reset();
+    let rect = doc
+        .get_cursor_rect(0, 0, 7)
+        .expect("텍스트 있는 호스트 문단 캐럿 rect");
+
+    // 스킵이 결과를 바꾸지 않는다는 계약: 표 뒤 텍스트의 캐럿은 마지막 페이지(114).
+    assert!(
+        rect.contains("\"pageIndex\":114"),
+        "표 뒤 텍스트 캐럿은 마지막 페이지에 렌더되어야 함: {rect}"
+    );
+
+    let builds = perf_counters::page_tree_builds();
+    // 필터 후 후보 = 표 시작 페이지(cont=false) + 표 소진 페이지(end_cut=[]) = 2.
+    // 수정 원복 시 후보 115쪽 전부를 빌드해 이 상한을 크게 넘는다 (실측 ~115회).
+    assert!(
+        builds <= 3,
+        "#4179 회귀: 텍스트 있는 호스트 문단 캐럿 배치가 page tree 를 {builds}회 빌드 \
+         (기대 ≤3). find_text_scan_pages_for_paragraph 필터가 무력화됐는지 확인."
+    );
+}

--- a/tests/issue_4180_caret_stamp_roundtrip.rs
+++ b/tests/issue_4180_caret_stamp_roundtrip.rs
@@ -1,0 +1,48 @@
+//! Issue #4180: 문서 캐럿 메타데이터가 "마지막 본문 편집 위치"가 아니라
+//! **저장 시점 캐럿**이어야 한다는 계약 (한컴 의미론).
+//!
+//! 신고 재현: 호스트 문단에 타이핑 후 저장된 파일이 캐럿 (0,0,7) 을 갖고,
+//! 열기 시 그 텍스트가 렌더되는 마지막 페이지로 캐럿이 복원됐다. 편집별
+//! 스탬핑이 남긴 위치를 저장 흐름의 `setCaretPosition` 이 덮어써야 한다.
+
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn set_caret_position_roundtrips_through_save() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("samples/issue1949_giant_cell_nested_tables_perf.hwp");
+    let bytes = fs::read(&path).expect("read sample");
+    let mut doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse");
+
+    // 편집별 스탬핑이 (0,0,7) 을 남긴다 — 신고 파일과 같은 상태
+    doc.insert_text(0, 0, 0, "rhwp pe").expect("insert");
+    assert_eq!(
+        doc.get_caret_position().expect("caret after edit"),
+        r#"{"sectionIndex":0,"paragraphIndex":0,"charOffset":7}"#,
+        "편집 스탬핑 전제 확인"
+    );
+
+    // 저장 시점 캐럿이 편집 스탬프를 이긴다 — 신고 버그의 회귀 계약
+    doc.set_caret_position(0, 0, 3);
+    let saved = doc.export_hwp().expect("export");
+
+    let doc2 = rhwp::wasm_api::HwpDocument::from_bytes(&saved).expect("reload");
+    assert_eq!(
+        doc2.get_caret_position().expect("caret after reload"),
+        r#"{"sectionIndex":0,"paragraphIndex":0,"charOffset":3}"#,
+        "저장→재열기 후 캐럿은 set 값이어야 함 (편집 위치 7 이 아니라 3)"
+    );
+}
+
+#[test]
+fn set_caret_position_out_of_range_is_ignored() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("samples/issue1949_giant_cell_nested_tables_perf.hwp");
+    let bytes = fs::read(&path).expect("read sample");
+    let mut doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse");
+
+    let before = doc.get_caret_position().expect("caret before");
+    doc.set_caret_position(99, 0, 0); // 존재하지 않는 구역 — 무시가 계약
+    assert_eq!(doc.get_caret_position().expect("caret after"), before);
+}


### PR DESCRIPTION
거대 분할 표 셀에서 Enter 후 전체 fragment 재조판이 키 지연을 만들었다. 기준선 probe → stale deferred pagination 무계산 취소 → split 완료 소유를 command effects 로 이전, 셀 Enter pagination 계약 e2e 와 실브라우저 검증 보고 동반.

**시리즈 4/4** (integration 검증 트리 리프트, merge 순서: #4138 → #4179 → #4180 → 본 PR). 검증: ci.yml 전 매트릭스 로컬 ALL-PASS (nextest release-test 전체·workspace all-targets clippy·Skia 3종·studio suite 포함).

Closes #4146

🤖 Generated with [Claude Code](https://claude.com/claude-code)