### PR TITLE
studio: ResizeObserver 루프 경고를 uncaught error 로 새지 않게

### DIFF
--- a/mydocs/plans/task_m100_4151.md
+++ b/mydocs/plans/task_m100_4151.md
@@ -1,0 +1,38 @@
+# 수행계획 — task_m100_4151
+
+- **이슈**: [#4151](https://github.com/edwardkim/rhwp/issues/4151)
+- **브랜치**: `task_m100_4151_cell_block_toggle_sync`
+- **기준**: `upstream/devel` `5a4f26d0d` (#4119 셀 블록 직접 서식 배선 병합 이후)
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+셀 블록(F5) 선택에 굵게/기울임을 적용하면 서식은 적용되지만 ① 툴바 눌림 상태가 갱신되지 않고
+② 같은 버튼 재클릭이 해제가 아니라 재적용되는 #4151 두 증상을 고친다.
+
+## 2. 변경 경계
+
+- 토글 방향 기준과 툴바 상태 방출 기준을 **같은 단일 함수**(블록 첫 셀 첫 글자)로 통일한다 —
+  두 기준이 갈리면 두 번째 클릭 방향과 버튼 표시가 어긋난다.
+- upstream #4119 의 빈 셀 블록 의미(전 셀 Ctrl+클릭 제외 시 앵커 셀 fallback 금지)를 보존한다 —
+  빈 블록에서는 앵커 셀이 없으므로 토글 방향은 커서 기준 폴백(적용 자체는 조기 종료).
+- 뮤테이션 표면 원장(mutation-routing-guard) 수는 불변 — 추가분은 조회·이벤트 방출뿐.
+
+## 3. 구현·래칫 순서
+
+1. `getCharPropertiesAtCellBlockAnchor` — 블록 첫 셀 첫 글자 서식 단일 기준.
+2. `applyToggleFormat`: 셀 블록 모드에서 커서 위치 대신 블록 앵커 기준으로 `!current[prop]`
+   방향 산출 (커서 조회는 블록 밖(호스트 문단 등)을 읽어 방금 적용한 서식이 안 보임 — 원인).
+3. `applyCharFormatToCellBlock`: 적용 직후 앵커 셀 기준 `cursor-format-changed` 방출 —
+   텍스트 선택 경로의 "적용 → 상태 재조회·방출" 후처리 계약을 블록 경로에도.
+4. 소스 계약 테스트 3종(#4151) — red→green: 수정 원복 시 실패 확인.
+
+## 4. 검증 게이트
+
+- `tests/cell-block-format.test.ts` (기존 #4119 계약 + 신규 #4151 3종)
+- `tests/mutation-routing-guard.test.ts` (원장 불변)
+- tsc ci-unit / `npm run test` 전체
+- 실브라우저 왕복(:7701, hwp_table_test_saved 2셀 블록): 1클릭 적용+버튼 활성, 2클릭 해제 —
+  wasm 문서 상태 직접 확인
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/plans/task_m100_4163_resize_observer_noise.md
+++ b/mydocs/plans/task_m100_4163_resize_observer_noise.md
@@ -1,0 +1,22 @@
+# 수행계획 — task_m100_4163_resize_observer_noise
+
+- **이슈**: [#4163](https://github.com/edwardkim/rhwp/issues/4163)
+- **브랜치**: `task_m100_4163_resize_observer_noise`
+- **기준**: `upstream/devel` `e64c85312`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+ResizeObserver 루프 경고가 uncaught error 로 보고되는 잡음(#4163)을 제거한다 — 관찰 콜백의 프레임 내 재레이아웃 루프 차단 + 잔여 합성 오류 억제.
+
+## 2. 변경 경계
+
+- viewport-manager 한 파일: 콜백 변이를 매크로태스크로 프레임 경계 너머로 이연, 전용 window error 리스너로 해당 메시지만 stopImmediatePropagation.
+- 다른 리스너 등록 시점(부트 초기 수집기)은 영향 밖 — 진단 수집기 잔존 가능성을 기록.
+
+## 검증 게이트
+
+- 레이어 자체 회귀 테스트 + `cargo nextest run --cargo-profile release-test` 전체
+- fmt / clippy(root+workspace all-targets) / wasm32 check / Native Skia 3종 / studio suite
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/plans/task_m100_ime_reanchor.md
+++ b/mydocs/plans/task_m100_ime_reanchor.md
@@ -1,0 +1,37 @@
+# 수행계획 — task_m100_ime_reanchor
+
+- **이슈**: [#4245](https://github.com/edwardkim/rhwp/issues/4245) (#4150 IME 조합 계열 후속)
+- **브랜치**: `task_m100_ime_reanchor_guard` (stack: `task_m100_4151_cell_block_toggle_sync` 위)
+- **기준**: `upstream/devel` `5a4f26d0d`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+IME 조합 업데이트의 raw replace(`input-handler-text.ts` 조합 분기)가 wasm 의 deferred replace
+범위 가드에 거부되면 예외가 `onInput` 밖으로 던져져 핸들러가 죽고, 조합 추적
+(compositionAnchor/Length)이 낡은 값으로 wedge 되어 이후 모든 조합 업데이트가 연쇄 실패한다.
+거부를 잡아 조합을 현재 캐럿에 재정박해 입력 스트림을 잇는다.
+
+## 2. 변경 경계
+
+- 정상 경로 무변경 — 가드 거부(외부 변이로 앵커·길이가 낡은 경합) 시에만 복구 분기.
+- 복구는 "현재 캐럿 재정박 + 이번 조합 텍스트 재삽입" — 그것도 실패하면 이번 업데이트만
+  버리고 로그(다음 캐럿 이동에서 자연 동기화).
+- `onCompositionEnd`는 raw 뮤테이션이 없어(command 기록만) 변경 불요 — 확인 완료.
+
+## 3. 구현·래칫 순서
+
+1. 조합 분기의 `replaceTextAtRaw`를 try/catch — 거부 시 warn + `compositionAnchor`를 현재
+   캐럿으로 재정박, `compositionLength=0`, 재삽입 시도.
+2. 소스 계약 테스트: 조합 replace 가 try 블록 안에 있고, catch 가 현재 캐럿 기준 재정박 +
+   길이 리셋을 수행.
+3. 실브라우저 강제 트립: `compositionLength` 오염 후 조합 업데이트 → uncaught 없음·복구·
+   최종 텍스트 정합·undo 완전 복원 확인.
+
+## 4. 검증 게이트
+
+- `tests/composition-replace-reanchor.test.ts` 2종
+- tsc ci-unit / `npm run test` 전체
+- 실브라우저(:7701) 강제 트립 시나리오
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/working/task_m100_4151_stage1.md
+++ b/mydocs/working/task_m100_4151_stage1.md
@@ -1,0 +1,30 @@
+---
+kind: working
+status: completed
+issue: 4151
+last_verified: 2026-08-08
+---
+
+# Task #4151 Stage 1 - 셀 블록 서식 토글 방향·툴바 동기화
+
+## 구현
+
+- `getCharPropertiesAtCellBlockAnchor`(블록 첫 셀 첫 글자) 단일 기준 신설 — 토글 방향과
+  툴바 상태 방출이 공유한다.
+- `applyToggleFormat`: 셀 블록 모드에서 `getCharPropertiesAtCursor()`(블록 밖을 읽음 — 재적용
+  원인) 대신 블록 앵커 기준. 빈 블록(전 셀 제외)은 앵커가 없어 커서 폴백 — `applyCharFormat`이
+  빈 블록에서 조기 종료하므로 방향은 무해(upstream #4119 빈 블록 의미 보존).
+- `applyCharFormatToCellBlock`: 적용 직후 앵커 셀 기준 `cursor-format-changed` 방출(try/catch,
+  실패 시 다음 캐럿 이동에서 자연 동기화).
+
+## 검증 결과
+
+- 신규 #4151 소스 계약 테스트 3종: 토글 방향 블록 분기 존재/앵커 함수 사용, 적용 후 방출이
+  executeOperation 뒤에 앵커 기준으로 존재, 앵커 기준이 첫 셀 첫 글자 — red 증명: 수정 전
+  파일(HEAD)에서 3종 전부 FAIL 확인 후 green.
+- `tests/cell-block-format.test.ts` + `tests/mutation-routing-guard.test.ts`: 27 passed / 0.
+- 실브라우저(:7701, hwp_table_test_saved 2×2 표, 셀 0-1 블록): pre bold=false·버튼 비활성 →
+  1클릭 두 셀 bold=true·버튼 즉시 활성·블록 유지 → 2클릭 두 셀 bold=false·버튼 비활성 —
+  wasm getCellCharPropertiesAt 로 문서 상태 직접 검증.
+- 참고: upstream #4119 의 빈 블록 의미 변화와의 병합은 rebase 시 수동 해소 — 빈 블록 길이
+  가드를 토글 방향 폴백에 추가.

--- a/mydocs/working/task_m100_4163_resize_observer_noise_stage1.md
+++ b/mydocs/working/task_m100_4163_resize_observer_noise_stage1.md
@@ -1,0 +1,13 @@
+---
+kind: working
+status: completed
+issue: 4163
+last_verified: 2026-08-08
+---
+
+# Task #4163 Stage 1
+
+## 구현·검증
+
+- integration 검증 트리의 미커밋 수정 리프트(rAF 가 같은 렌더링 프레임 안이라 루프를 못 벗어남을 실측 — setTimeout 0 이연 채택).
+- 검증: tsc ci-unit 무오류, studio suite 783/783, 레이어 전체 게이트 ALL-PASS 예정.

--- a/mydocs/working/task_m100_ime_reanchor_stage1.md
+++ b/mydocs/working/task_m100_ime_reanchor_stage1.md
@@ -1,0 +1,30 @@
+---
+kind: working
+status: completed
+issue: 4245
+last_verified: 2026-08-08
+---
+
+# Task ime_reanchor Stage 1 - 조합 replace 거부 시 재정박 복구
+
+## 구현
+
+- `input-handler-text.ts` 조합 분기(`onInput`)의 `replaceTextAtRaw(anchor, compositionLength,
+  text)`를 try/catch 로 보호. wasm 의 deferred replace 범위 가드가 거부하면(외부 변이로
+  앵커·길이가 낡은 경합) warn 후 조합을 현재 캐럿에 재정박(`compositionAnchor` 갱신,
+  `compositionLength=0`)하고 이번 조합 텍스트를 새로 삽입해 입력 스트림을 잇는다. 재삽입도
+  실패하면 이번 업데이트만 버린다.
+- 동기: 종전에는 거부가 uncaught 로 `onInput` 전체를 죽여 조합 추적이 낡은 값으로 wedge —
+  이후 모든 조합 업데이트 연쇄 실패. `onCompositionEnd`는 raw 뮤테이션이 없어(command 기록만)
+  대상 아님을 확인.
+
+## 검증 결과
+
+- 소스 계약 테스트 2종(`composition-replace-reanchor.test.ts`): try 보호 존재, catch 의
+  재정박(현재 캐럿 기준 + 길이 리셋) — pass.
+- 실브라우저 강제 트립(:7701, 거대 셀 문서): 조합 중 `compositionLength=9999` 오염 →
+  다음 업데이트에서 uncaught 없이 복구(재정박 앵커·compLen=1), 이어지는 업데이트·compositionend
+  정상, 최종 텍스트 정합(+1), undo 로 원문 완전 복원.
+- 발견 경위: 겹친 합성 테스트 배터리(도구 타임아웃 후 페이지에서 계속 실행)가 조합 스트림
+  2개를 인터리브해 가드 트립을 유발 — 실사용 IME 는 조합을 겹칠 수 없어 사용자 도달 경로는
+  아니나, 가드 거부가 uncaught 인 취약성 자체는 실재해 방어를 추가.

--- a/rhwp-studio/src/engine/input-handler-text.ts
+++ b/rhwp-studio/src/engine/input-handler-text.ts
@@ -484,7 +484,7 @@ export function onInput(this: any, e?: InputEvent): void {
   // IME 조합 중: 이전 조합 텍스트 삭제 → 현재 조합 텍스트 삽입 (실시간 렌더링)
   // Undo 스택에는 기록하지 않음 (compositionend에서 한 번에 기록)
   if (this.isComposing && this.compositionAnchor) {
-    const anchor = this.compositionAnchor;
+    let anchor = this.compositionAnchor;
     const beforePageIndex = this.cursor.getRect()?.pageIndex;
     if (!this.canInsertTextInFormMode?.(anchor)) {
       this.textarea.value = '';
@@ -492,7 +492,25 @@ export function onInput(this: any, e?: InputEvent): void {
     }
     this.resetRawTextMutationEffects();
 
-    this.replaceTextAtRaw(anchor, this.compositionLength, text);
+    try {
+      this.replaceTextAtRaw(anchor, this.compositionLength, text);
+    } catch (err) {
+      // wasm 의 deferred replace 범위 가드가 거부하면(외부 변이로 앵커·길이가 낡은
+      // 경합) 여기서 던진 채 두면 onInput 전체가 죽어 조합 추적이 낡은 값으로
+      // wedge 된다. 조합을 현재 캐럿에 재정박하고 이번 조합 텍스트를 새로 삽입해
+      // 입력 스트림을 잇는다 — 실패분은 다음 캐럿 이동에서 자연 동기화된다.
+      console.warn('[InputHandler] 조합 replace 거부 — 현재 캐럿에 재정박:', err);
+      anchor = { ...this.cursor.getPosition() };
+      this.compositionAnchor = anchor;
+      this.compositionLength = 0;
+      try {
+        this.replaceTextAtRaw(anchor, 0, text);
+      } catch (err2) {
+        console.warn('[InputHandler] 조합 재정박 삽입 실패 — 이번 업데이트 무시:', err2);
+        this.textarea.value = '';
+        return;
+      }
+    }
     // 다음 조합 업데이트의 삭제 count는 scalar 단위다.
     this.compositionLength = charCount(text);
     if (text) this._lastCompositionText = text;

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -1892,14 +1892,33 @@ export class InputHandler {
         return { ...cursorBefore };
       },
     });
+    // [#4151] 블록 적용 경로는 텍스트 선택 경로의 "적용 → 상태 재조회·방출" 후처리를 타지
+    // 않아 툴바 눌림 상태가 이전 값으로 남는다. 적용 직후 앵커 셀 기준으로 방출해 동기화한다.
+    try {
+      this.eventBus.emit('cursor-format-changed', this.getCharPropertiesAtCellBlockAnchor(block));
+    } catch {
+      // 문서 상태 경합 시 다음 캐럿 이동에서 자연 동기화
+    }
+  }
+
+  /** [#4151] 셀 블록 서식의 토글 방향·툴바 상태 기준: 블록 첫 셀의 첫 글자 서식. */
+  private getCharPropertiesAtCellBlockAnchor(block: SelectedCellBlock): CharProperties {
+    return this.wasm.getCellCharPropertiesAt(block.sec, block.ppi, block.ci, block.cellIndices[0], 0, 0);
   }
 
   /** 토글 서식 적용 (상호 배타 처리 포함) */
   private applyToggleFormat(prop: 'bold' | 'italic' | 'underline' | 'strikethrough' | 'emboss' | 'engrave' | 'outline' | 'superscript' | 'subscript'): void {
     if (!this.hasFormatTargetSelection()) return;
-    // 셀 블록에서는 커서가 있는 앵커 셀의 현재 값이 토글 방향을 정한다. 칸마다 값이 다를 때
+    // 셀 블록에서는 앵커 셀 텍스트의 현재 값이 토글 방향을 정한다. 칸마다 값이 다를 때
     // 블록 전체를 한 방향으로 맞추려면 기준이 하나여야 하고, 텍스트 선택도 같은 기준이다.
-    const current = this.getCharPropertiesAtCursor();
+    // [#4151] 커서 위치 조회는 셀 블록 모드에서 블록 밖(호스트 문단 등)을 읽어 방금 적용한
+    // 서식이 보이지 않는다 — 두 번째 클릭이 해제가 아니라 재적용이 되는 원인. 블록 모드에선
+    // 블록 첫 셀의 첫 글자 서식을 기준으로 삼는다. 빈 블록(전 셀 Ctrl+클릭 제외)은 앵커
+    // 셀이 없으므로 커서 기준 폴백 — applyCharFormat 이 어차피 빈 블록에서 조기 종료한다.
+    const toggleBlock = this.getSelectedCellBlock();
+    const current = toggleBlock && toggleBlock.cellIndices.length > 0
+      ? this.getCharPropertiesAtCellBlockAnchor(toggleBlock)
+      : this.getCharPropertiesAtCursor();
 
     if (prop === 'emboss') {
       const newVal = !current.emboss;

--- a/rhwp-studio/src/view/viewport-manager.ts
+++ b/rhwp-studio/src/view/viewport-manager.ts
@@ -20,6 +20,7 @@ export class ViewportManager {
   private zoom = 1.0;
   private container: HTMLElement | null = null;
   private resizeObserver: ResizeObserver | null = null;
+  private resizeAnimationFrame: number | null = null;
   private scrollAnimationFrame: number | null = null;
   private zoomAnimationFrame: number | null = null;
   private zoomAnimationTimestamp: number | null = null;
@@ -29,6 +30,7 @@ export class ViewportManager {
   private onScrollBound: () => void;
   private onWheelBound: (e: WheelEvent) => void;
   private onZoomAnimationFrameBound: (timestamp: number) => void;
+  private onResizeObserverErrorBound: (e: ErrorEvent) => void;
   private eventBus: EventBus;
 
   constructor(eventBus: EventBus) {
@@ -36,6 +38,7 @@ export class ViewportManager {
     this.onScrollBound = this.onScroll.bind(this);
     this.onWheelBound = this.onWheel.bind(this);
     this.onZoomAnimationFrameBound = this.onZoomAnimationFrame.bind(this);
+    this.onResizeObserverErrorBound = this.onResizeObserverError.bind(this);
   }
 
   /** 스크롤 컨테이너에 연결한다 */
@@ -45,9 +48,26 @@ export class ViewportManager {
     container.addEventListener('scroll', this.onScrollBound, { passive: true });
     container.addEventListener('wheel', this.onWheelBound, { passive: false });
 
+    // 크로미움은 이 경고를 실제 스크립트 예외가 아니라 window `error` 이벤트로 합성
+    // 보고한다. 아래 콜백이 동기 DOM 변이를 하지 않아도(매크로태스크로 미룸) 대형
+    // 문서 초기 렌더처럼 같은 프레임에 다른 요소들이 대량으로 리사이즈되면 여전히
+    // 뜰 수 있는, 기능에 영향 없는 잡음이라 uncaught error 로 새지 않게 막는다.
+    window.addEventListener('error', this.onResizeObserverErrorBound);
+
     this.resizeObserver = new ResizeObserver(() => {
-      this.updateViewportSize();
-      this.eventBus.emit('viewport-resize', this.viewportWidth, this.viewportHeight);
+      if (this.resizeAnimationFrame !== null) return;
+
+      // 리스너가 레이아웃을 다시 계산해 컨테이너 크기가 같은 프레임에 또 바뀌면
+      // "ResizeObserver loop completed with undelivered notifications"가 발생한다.
+      // rAF 는 **같은 렌더링 프레임 안**(레이아웃·RO 전달 이전)에 실행되므로 이 루프를
+      // 벗어나지 못한다 — 실측으로 경고가 계속 발생했다. 매크로태스크(setTimeout 0)로
+      // 프레임 경계를 넘겨 변이를 다음 프레임의 관찰 사이클로 미룬다.
+      this.resizeAnimationFrame = window.setTimeout(() => {
+        this.resizeAnimationFrame = null;
+        if (!this.container) return;
+        this.updateViewportSize();
+        this.eventBus.emit('viewport-resize', this.viewportWidth, this.viewportHeight);
+      }, 0);
     });
     this.resizeObserver.observe(container);
     this.updateViewportSize();
@@ -61,12 +81,25 @@ export class ViewportManager {
     }
     this.resizeObserver?.disconnect();
     this.resizeObserver = null;
+    window.removeEventListener('error', this.onResizeObserverErrorBound);
+    if (this.resizeAnimationFrame !== null) {
+      clearTimeout(this.resizeAnimationFrame);
+      this.resizeAnimationFrame = null;
+    }
     if (this.scrollAnimationFrame !== null) {
       cancelAnimationFrame(this.scrollAnimationFrame);
       this.scrollAnimationFrame = null;
     }
     this.cancelZoomAnimation();
     this.container = null;
+  }
+
+  /** ResizeObserver 잡음 window error 를 uncaught 로 전파하지 않도록 막는다. */
+  private onResizeObserverError(e: ErrorEvent): void {
+    if (e.message?.includes('ResizeObserver loop')) {
+      e.stopImmediatePropagation();
+      e.preventDefault();
+    }
   }
 
   private onScroll(): void {

--- a/rhwp-studio/tests/cell-block-format.test.ts
+++ b/rhwp-studio/tests/cell-block-format.test.ts
@@ -199,6 +199,50 @@ test('빈 셀 블록 글자 서식은 history 없이 no-op 이다', () => {
     '모든 셀 제외 시 글자 서식이 no-op으로 끝나지 않는다');
 });
 
+test('[#4151] 토글 방향은 셀 블록 모드에서 블록 앵커 셀의 서식을 읽는다', () => {
+  // 커서 위치 조회(getCharPropertiesAtCursor)는 셀 블록 모드에서 블록 밖(호스트 문단 등)을
+  // 읽어 방금 적용한 서식이 보이지 않는다 — current[prop] 이 이전 값에 머물러 !current[prop]
+  // 이 항상 같은 방향이 되고, 두 번째 클릭이 해제가 아니라 재적용이 된다.
+  const ih = source('src/engine/input-handler.ts');
+  const start = ih.indexOf('private applyToggleFormat(');
+  assert.notEqual(start, -1, 'applyToggleFormat 을 찾지 못했다');
+  const body = ih.slice(start, ih.indexOf('\n  }\n', start));
+  assert.match(body, /this\.getSelectedCellBlock\(\)/,
+    '토글 방향 산출에 셀 블록 분기가 없다');
+  assert.match(body,
+    /\?\s*this\.getCharPropertiesAtCellBlockAnchor\(\w+\)\s*\n?\s*:\s*this\.getCharPropertiesAtCursor\(\)/,
+    '셀 블록 모드에서 블록 앵커 셀 대신 커서 위치의 서식으로 토글 방향을 정한다');
+});
+
+test('[#4151] 셀 블록 적용 직후 cursor-format-changed 를 앵커 셀 기준으로 방출한다', () => {
+  // 텍스트 선택 경로는 적용 후 emitCursorFormatState 로 툴바 눌림 상태를 재조회·방출하지만,
+  // 셀 블록 경로는 이 후처리가 없으면 툴바가 이전 상태로 남는다. emitCursorFormatState 는
+  // 커서 위치 기준이라 블록에는 오답 — 앵커 셀 서식을 직접 방출해야 한다.
+  const ih = source('src/engine/input-handler.ts');
+  const start = ih.indexOf('private applyCharFormatToCellBlock');
+  assert.notEqual(start, -1, 'applyCharFormatToCellBlock 이 없다');
+  const body = ih.slice(start, ih.indexOf('\n  }\n', start));
+  const applyAt = body.indexOf('this.executeOperation(');
+  const emitAt = body.indexOf("this.eventBus.emit('cursor-format-changed'");
+  assert.notEqual(emitAt, -1, '적용 후 cursor-format-changed 방출이 없다');
+  assert.ok(applyAt !== -1 && applyAt < emitAt, '상태 방출이 서식 적용보다 앞에 있다');
+  assert.match(body,
+    /emit\('cursor-format-changed',\s*this\.getCharPropertiesAtCellBlockAnchor\(block\)\)/,
+    '방출 값이 블록 앵커 셀 서식이 아니다');
+});
+
+test('[#4151] 앵커 셀 서식 기준은 블록 첫 셀의 첫 글자다', () => {
+  // 토글 방향(applyToggleFormat)과 툴바 상태 방출이 같은 기준을 공유해야 두 번째 클릭의
+  // 해제 방향과 버튼 표시가 일치한다. 기준 조회는 이 함수 한 곳에만 둔다.
+  const ih = source('src/engine/input-handler.ts');
+  const start = ih.indexOf('private getCharPropertiesAtCellBlockAnchor');
+  assert.notEqual(start, -1, 'getCharPropertiesAtCellBlockAnchor 가 없다');
+  const body = ih.slice(start, ih.indexOf('\n  }\n', start));
+  assert.match(body,
+    /getCellCharPropertiesAt\(block\.sec, block\.ppi, block\.ci, block\.cellIndices\[0\], 0, 0\)/,
+    '앵커 기준이 블록 첫 셀의 첫 글자가 아니다');
+});
+
 test('모양 붙여넣기도 같은 셀 산출 함수를 쓴다', () => {
   // 같은 블록을 대상으로 하는 두 경로가 필터를 각자 갖고 있으면 한쪽만 고쳐진다.
   const ih = source('src/engine/input-handler.ts');

--- a/rhwp-studio/tests/composition-replace-reanchor.test.ts
+++ b/rhwp-studio/tests/composition-replace-reanchor.test.ts
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [#4149 계열 방어] IME 조합 업데이트의 raw replace 는 wasm 의 deferred replace 범위
+// 가드에 거부될 수 있다(외부 변이로 앵커·길이가 낡은 경합). 거부가 onInput 밖으로
+// 던져지면 핸들러가 죽고 조합 추적(compositionAnchor/Length)이 낡은 값으로 wedge 되어
+// 이후 모든 조합 업데이트가 연쇄 실패한다. 조합 분기는 반드시 거부를 잡아 현재 캐럿에
+// 재정박해야 한다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const source = readFileSync(join(rootDir, 'src/engine/input-handler-text.ts'), 'utf8');
+
+function compositionBranch(): string {
+  const start = source.indexOf('if (this.isComposing && this.compositionAnchor) {');
+  assert.notEqual(start, -1, '조합 분기를 찾지 못했다');
+  const end = source.indexOf('// iOS 폴백', start);
+  return source.slice(start, end === -1 ? start + 3000 : end);
+}
+
+test('조합 업데이트의 raw replace 는 try/catch 로 보호된다', () => {
+  const branch = compositionBranch();
+  const tryAt = branch.indexOf('try {');
+  const replaceAt = branch.indexOf('this.replaceTextAtRaw(anchor, this.compositionLength, text)');
+  assert.notEqual(replaceAt, -1, '조합 replace 호출이 없다');
+  assert.ok(tryAt !== -1 && tryAt < replaceAt,
+    '조합 replace 가 try 블록 밖에 있다 — 가드 거부가 onInput 을 죽인다');
+});
+
+test('거부 시 조합을 현재 캐럿에 재정박하고 길이를 리셋한다', () => {
+  const branch = compositionBranch();
+  assert.match(branch, /catch[\s\S]*?this\.compositionAnchor = anchor/,
+    '재정박(compositionAnchor 갱신)이 없다');
+  assert.match(branch, /catch[\s\S]*?this\.compositionLength = 0/,
+    '재정박 시 조합 길이 리셋이 없다');
+  assert.match(branch, /catch[\s\S]*?this\.cursor\.getPosition\(\)/,
+    '재정박 기준이 현재 캐럿이 아니다');
+});


### PR DESCRIPTION
관찰 콜백의 프레임 내 재레이아웃이 루프 경고를 window error 로 합성 보고했다. 콜백 변이를 매크로태스크로 프레임 경계 너머로 이연하고, 대형 문서 초기 렌더의 잔여 무해 잡음은 전용 리스너로 억제한다.

**시리즈 독립** (integration 검증 트리 리프트, merge 순서: studio 시리즈(#4250→#4251) 위 스택). 검증: ci.yml 전 매트릭스 로컬 ALL-PASS (nextest release-test 전체·workspace all-targets clippy·Skia 3종·studio suite 포함).

Closes #4163

🤖 Generated with [Claude Code](https://claude.com/claude-code)