### PR TITLE
perf/fix: humdrum00001010 표 편집·렌더 성능 통합

### DIFF
--- a/mydocs/orders/20260808.md
+++ b/mydocs/orders/20260808.md
@@ -1,5 +1,24 @@
 # 오늘 할 일 - 2026년 8월 8일
 
+## PR #4265 - humdrum00001010 표 편집·렌더 성능 통합
+
+- 최신 `upstream/devel` `e919655a` 위 `review/humdrum00001010-20260808`에 @humdrum00001010의
+  #4246, #4247, #4248, #4249, #4250, #4251, #4258, #4259, #4260, #4261, #4262를 누적했다.
+  #4248/#4249의 단독 PR 충돌은 같은 성능 stack의 순서 의존성으로, 통합 PR에서는 두 변경을 함께
+  적용해 해소한다.
+- 통합 검증에서 중첩 표 border clip 때문에 #4248 fast path의 `cellBounds`가 legacy보다 좁아지는 KTX
+  형상을 발견했다. 메인터너 보정 `da2d9ae75`는 대상 셀의 필요한 후속 문단만 compose하며 기존 giant-cell
+  window를 유지한다. KTX parity와 giant-cell latency가 함께 통과했다.
+- 전체 `release-test --tests`, focused Rust, Studio focused 27건·전체 813건, production build, WASM build,
+  실제 HWP/HWPX 셀 Enter Chromium E2E를 통과했다. Native Skia 3종은 준비 우선 지시로 중단했으므로
+  통과로 기록하지 않으며 #4265 Full CI를 merge 전 조건으로 둔다.
+- [통합 PR #4265](https://github.com/edwardkim/rhwp/pull/4265)의 최신 Full CI·CodeQL·Render Diff와
+  mergeability를 확인한 뒤, review·오늘할일 trailing commit을 같은 branch에 push해 최신 문서 gate를
+  확인한다. 작업지시자 승인 뒤 merge하면 원 PR 11개와 closing keyword 이슈를 후속 처리한다.
+
+상세 근거: [통합 검토](../pr/archives/pr_4265_review.md),
+[통합·메인터너 보정 기록](../pr/archives/pr_4265_review_impl.md).
+
 ## PR #4253 - kevin9327 연작 27건 통합 및 계약 보정
 
 - [PR #4253](https://github.com/edwardkim/rhwp/pull/4253)는 #4186~#4244 중 기여자가 CI workflow를

--- a/mydocs/orders/20260808.md
+++ b/mydocs/orders/20260808.md
@@ -10,11 +10,13 @@
   형상을 발견했다. 메인터너 보정 `da2d9ae75`는 대상 셀의 필요한 후속 문단만 compose하며 기존 giant-cell
   window를 유지한다. KTX parity와 giant-cell latency가 함께 통과했다.
 - 전체 `release-test --tests`, focused Rust, Studio focused 27건·전체 813건, production build, WASM build,
-  실제 HWP/HWPX 셀 Enter Chromium E2E를 통과했다. Native Skia 3종은 준비 우선 지시로 중단했으므로
-  통과로 기록하지 않으며 #4265 Full CI를 merge 전 조건으로 둔다.
-- [통합 PR #4265](https://github.com/edwardkim/rhwp/pull/4265)의 최신 Full CI·CodeQL·Render Diff와
-  mergeability를 확인한 뒤, review·오늘할일 trailing commit을 같은 branch에 push해 최신 문서 gate를
-  확인한다. 작업지시자 승인 뒤 merge하면 원 PR 11개와 closing keyword 이슈를 후속 처리한다.
+  실제 HWP/HWPX 셀 Enter Chromium E2E를 통과했다. 로컬 Native Skia 3종은 준비 우선 지시로 중단했지만,
+  `557bb8526`의 GitHub Full CI Native Skia job은 성공했다.
+- [통합 PR #4265](https://github.com/edwardkim/rhwp/pull/4265)의 [CI](https://github.com/edwardkim/rhwp/actions/runs/31256100624),
+  [CodeQL](https://github.com/edwardkim/rhwp/actions/runs/31256100547),
+  [Render Diff](https://github.com/edwardkim/rhwp/actions/runs/31256100556)가 성공했다. 이 결과 기록
+  문서 commit의 최신 docs-only gate와 mergeability를 확인한 뒤 작업지시자 승인에 따라 merge하면, 원 PR
+  11개와 closing keyword 이슈를 후속 처리한다.
 
 상세 근거: [통합 검토](../pr/archives/pr_4265_review.md),
 [통합·메인터너 보정 기록](../pr/archives/pr_4265_review_impl.md).

--- a/mydocs/plans/task_m100_4138_lift.md
+++ b/mydocs/plans/task_m100_4138_lift.md
@@ -1,0 +1,24 @@
+# 수행계획 — task_m100_4138_lift
+
+- **이슈**: [#4138](https://github.com/edwardkim/rhwp/issues/4138)
+- **브랜치**: `task_m100_4138_stale_lineseg_rewrap`
+- **기준**: `upstream/devel` `e64c85312`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+셀 나누기 뒤 원본 셀에 남는 stale line_segs(옛 폭 기준)가 셀 경계 절단 렌더와 vpos 사다리 붕괴를
+일으키는 결함(#4138)을 재래핑 + 사다리 단조 재구축으로 고친다.
+
+## 2. 변경 경계
+
+- 셀 나누기 경로에서 영향 셀 문단의 line_segs 를 현재 폭 기준으로 재래핑하고 vpos 사다리를
+  단조 재구축한다. 최종 보고서 동반(mydocs/report/task_m100_4138_report.md) — 분할 전후 시각
+  증적은 CONTRIBUTING 규약에 따라 PR 본문 첨부.
+
+## 검증 게이트
+
+- 레이어 회귀 테스트 + `cargo nextest run --cargo-profile release-test` 전체
+- fmt / clippy(root+workspace all-targets) / wasm32 check / Native Skia 3종 / studio suite
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/plans/task_m100_4146_cell_enter_latency.md
+++ b/mydocs/plans/task_m100_4146_cell_enter_latency.md
@@ -1,0 +1,22 @@
+# 수행계획 — task_m100_4146_cell_enter_latency
+
+- **이슈**: [#4146](https://github.com/edwardkim/rhwp/issues/4146)
+- **브랜치**: `task_m100_4146_cell_enter_latency`
+- **기준**: `upstream/devel` `e64c85312`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+거대 분할 표 셀의 Enter(문단 분리) 후 전체 fragment 재조판으로 인한 지연(#4146)을 stale deferred pagination 의 무계산 취소와 split 완료 소유 이전으로 해소한다.
+
+## 2. 변경 경계
+
+- 3단계 리프트: 기준선 probe(테스트) → stale deferred pagination 무계산 취소(perf) → split 완료 소유를 command effects 선언으로 이전(fix) + 셀 Enter pagination 계약 e2e.
+- pagination 결과 계약 불변 — e2e 가 실브라우저 검증 보고 포함.
+
+## 검증 게이트
+
+- 레이어 자체 회귀 테스트 + `cargo nextest run --cargo-profile release-test` 전체
+- fmt / clippy(root+workspace all-targets) / wasm32 check / Native Skia 3종 / studio suite
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/plans/task_m100_4151.md
+++ b/mydocs/plans/task_m100_4151.md
@@ -1,0 +1,38 @@
+# 수행계획 — task_m100_4151
+
+- **이슈**: [#4151](https://github.com/edwardkim/rhwp/issues/4151)
+- **브랜치**: `task_m100_4151_cell_block_toggle_sync`
+- **기준**: `upstream/devel` `5a4f26d0d` (#4119 셀 블록 직접 서식 배선 병합 이후)
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+셀 블록(F5) 선택에 굵게/기울임을 적용하면 서식은 적용되지만 ① 툴바 눌림 상태가 갱신되지 않고
+② 같은 버튼 재클릭이 해제가 아니라 재적용되는 #4151 두 증상을 고친다.
+
+## 2. 변경 경계
+
+- 토글 방향 기준과 툴바 상태 방출 기준을 **같은 단일 함수**(블록 첫 셀 첫 글자)로 통일한다 —
+  두 기준이 갈리면 두 번째 클릭 방향과 버튼 표시가 어긋난다.
+- upstream #4119 의 빈 셀 블록 의미(전 셀 Ctrl+클릭 제외 시 앵커 셀 fallback 금지)를 보존한다 —
+  빈 블록에서는 앵커 셀이 없으므로 토글 방향은 커서 기준 폴백(적용 자체는 조기 종료).
+- 뮤테이션 표면 원장(mutation-routing-guard) 수는 불변 — 추가분은 조회·이벤트 방출뿐.
+
+## 3. 구현·래칫 순서
+
+1. `getCharPropertiesAtCellBlockAnchor` — 블록 첫 셀 첫 글자 서식 단일 기준.
+2. `applyToggleFormat`: 셀 블록 모드에서 커서 위치 대신 블록 앵커 기준으로 `!current[prop]`
+   방향 산출 (커서 조회는 블록 밖(호스트 문단 등)을 읽어 방금 적용한 서식이 안 보임 — 원인).
+3. `applyCharFormatToCellBlock`: 적용 직후 앵커 셀 기준 `cursor-format-changed` 방출 —
+   텍스트 선택 경로의 "적용 → 상태 재조회·방출" 후처리 계약을 블록 경로에도.
+4. 소스 계약 테스트 3종(#4151) — red→green: 수정 원복 시 실패 확인.
+
+## 4. 검증 게이트
+
+- `tests/cell-block-format.test.ts` (기존 #4119 계약 + 신규 #4151 3종)
+- `tests/mutation-routing-guard.test.ts` (원장 불변)
+- tsc ci-unit / `npm run test` 전체
+- 실브라우저 왕복(:7701, hwp_table_test_saved 2셀 블록): 1클릭 적용+버튼 활성, 2클릭 해제 —
+  wasm 문서 상태 직접 확인
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/plans/task_m100_4163_resize_observer_noise.md
+++ b/mydocs/plans/task_m100_4163_resize_observer_noise.md
@@ -1,0 +1,22 @@
+# 수행계획 — task_m100_4163_resize_observer_noise
+
+- **이슈**: [#4163](https://github.com/edwardkim/rhwp/issues/4163)
+- **브랜치**: `task_m100_4163_resize_observer_noise`
+- **기준**: `upstream/devel` `e64c85312`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+ResizeObserver 루프 경고가 uncaught error 로 보고되는 잡음(#4163)을 제거한다 — 관찰 콜백의 프레임 내 재레이아웃 루프 차단 + 잔여 합성 오류 억제.
+
+## 2. 변경 경계
+
+- viewport-manager 한 파일: 콜백 변이를 매크로태스크로 프레임 경계 너머로 이연, 전용 window error 리스너로 해당 메시지만 stopImmediatePropagation.
+- 다른 리스너 등록 시점(부트 초기 수집기)은 영향 밖 — 진단 수집기 잔존 가능성을 기록.
+
+## 검증 게이트
+
+- 레이어 자체 회귀 테스트 + `cargo nextest run --cargo-profile release-test` 전체
+- fmt / clippy(root+workspace all-targets) / wasm32 check / Native Skia 3종 / studio suite
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/plans/task_m100_4167.md
+++ b/mydocs/plans/task_m100_4167.md
@@ -1,0 +1,63 @@
+# 수행계획 — task_m100_4167
+
+- **이슈**: [#4167](https://github.com/edwardkim/rhwp/issues/4167)
+- **브랜치**: Stage 1 `task_m100_4167_cursor_rect_fast_path`, Stage 2 `task_m100_4167_units_fp_skip`
+  (stack: `task_m100_4169_overflow_memo` 위)
+- **기준**: `upstream/devel` `5a4f26d0d`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+거대 셀 문서(`samples/issue1949_giant_cell_nested_tables_perf.hwp`) IME 타이핑의 캐럿 rect
+질의 60ms/키를 제거한다. 실측 원인 2계층:
+
+- **Stage 1**: `get_cursor_rect_in_cell_native`가 rect 하나를 얻으려고 uncached
+  `build_page_tree`로 페이지 렌더 트리 전체를 재빌드 — 질의의 98%, 그중 99.7%가
+  `layout_partial_table_cells` 전체 셀 재레이아웃.
+- **Stage 2**: deferred 편집마다 편집 셀의 memoized `cell_units`가 전량 evict 되어, 편집 직후
+  첫 질의가 2,507개 문단 전량 recompose(native 11.2ms)를 지불 — IME 조합은 매 업데이트가
+  편집→질의라 매 키가 이 비용을 문다.
+
+## 2. 변경 경계
+
+- **Stage 1 fast path 는 legacy 와 rect JSON 패리티가 계약** — 독립 산식 재구현이 아니라
+  production `layout_partial_table`를 대상 셀만 방출하는 프로브로 재사용해 패리티를 구성적으로
+  보장한다. 저장 line_segs 는 신뢰하지 않는다(무편집 문단의 ~16%가 재계산과 다름 — #4149 실측);
+  렌더러가 그리는 composed 줄을 lazy 로 대상 창 문단에만 적용한다.
+- 불확실 케이스 전부 폴백(Ok(None) → 기존 경로): 캡션 센티널·다중 컬럼·zone/wrap/미주·통페이지
+  표·treat_as_char·반복 제목행·auto counter 개체·rowspan>1·windowed 증명 실패·run 미발견.
+  fast path 는 탈출구 있는 최적화지 제2의 진실원천이 아니다.
+- **Stage 2 는 units 지문(units 산출이 읽는 입력만: 줄 수·vpos·높이·synthetic tag 비트·
+  controls 수·공백 클래스)이 불변일 때만 eviction 을 생략** — 지문이 변하는 편집(재래핑·스페이서
+  클래스 전이)은 종전대로 evict. `text_start`/`segment_width`는 제자리 타이핑에도 변하지만
+  units 산출이 읽지 않으므로 제외(코드 전수 grep 근거).
+- 기존 #2214/#2424 국소 무효화 인프라의 계약 변경은 "무조건 evict → 지문 변화 시에만 evict"로
+  한정하고 갱신 이력을 테스트 주석에 남긴다.
+
+## 3. 구현·래칫 순서 (Stage 1)
+
+1. 기존 본문을 `cursor_rect_in_cell_via_page_tree`로 추출(패리티 기준), fast→legacy 폴백 래퍼.
+2. 셀 기하: pagination `PartialTable` 메타 + memoized `cell_units` + `measured_tables` +
+   `PageContent.layout` col_area — 페이지 트리 없이.
+3. 프로브: `layout_partial_table`에 대상 셀 필터·컷 창 순회·캐럿 문단 이후 중단 파라미터.
+   셀 방출 루프의 셀-간 캐리 부재(기존 계약)로 생략이 좌표를 바꾸지 않는다.
+4. 차등 패리티 테스트: 3개 실문서 × 전 셀 × 문단축 × offset {0, len/2, len}, fast=Some 인
+   모든 지점에서 legacy JSON 완전 일치 + 거대 문서 적중률 100% 어서션.
+
+## 3'. 구현·래칫 순서 (Stage 2)
+
+1. `cell_paragraph_units_fingerprint` — units 입력만 해시.
+2. 편집 관문 2곳(셀 insert/replace·delete impl)에서 reflow 전후 지문 캡처,
+   `invalidate_cell_units_after_text_edit`에 불변 플래그 전달, 불변이면 eviction 생략.
+3. 회귀: 지문 민감도 매트릭스(불변: text_start/segment_width/원본 tag 잔여 비트, 변화: 줄 수·
+   높이·synthetic·스페이서 클래스), 실문서 계약(텍스트 문단 타이핑 불변·스페이서 전이 변화),
+   #2214 기대값을 지문 조건부로 갱신(이력 주석).
+
+## 4. 검증 게이트
+
+- 패리티 차등 테스트 + `--lib cursor_rect` + 캐럿 관련 통합 테스트 전부
+- `--lib` 전체 무회귀 / fmt / clippy / wasm32 check / Native Skia 3종 / wasm-pack build
+- 실측: Stage 1 후 캐럿 질의 17.5ms → 0.61ms (quiescent), Stage 2 후 deferred 편집 직후
+  find_pages 11.2ms → ~6µs; 브라우저 IME 조합 업데이트 58~62ms → 5.8~11.5ms
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/plans/task_m100_4168.md
+++ b/mydocs/plans/task_m100_4168.md
@@ -1,0 +1,40 @@
+# 수행계획 — task_m100_4168
+
+- **이슈**: [#4168](https://github.com/edwardkim/rhwp/issues/4168)
+- **브랜치**: `task_m100_4168_font_metric_index`
+- **기준**: `upstream/devel` `5a4f26d0d`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+`find_metric`(src/renderer/font_metrics_data.rs)의 폰트 메트릭 테이블 선형 스캔을 1회 선계산
+색인(O(1) 조회)으로 바꾼다. #4167 프로파일에서 거대 셀 문서 IME 키스트로크 60ms 중
+~16%(1,052/6,765 샘플)가 이 함수의 문자열 비교 폴백 사다리에 귀속됐다.
+
+## 2. 변경 경계
+
+- `find_metric`의 **결과는 100% 동일**해야 한다 — 3단 폴백 사다리(정확 매칭 → bold-only →
+  이름 첫 엔트리 + `bold_fallback=bold`)의 첫-매칭 우선순위와 기벽(bold-italic 엔트리만 있는
+  bold 요청의 `bold_fallback=true`)까지 그대로.
+- `resolve_metric_alias` 처리 위치·의미 유지 (#259 alias 매핑 계약).
+- 임의 사용자 폰트명(비-static `&str`) 조회 유지 — 이름 단독 키 + (bold,italic) 4-슬롯
+  배열 선계산으로 `Borrow<str>` 조회를 보존한다 (tuple 키는 수명 제약으로 불가).
+- 다른 파일은 건드리지 않는다.
+
+## 3. 구현·래칫 순서
+
+1. 기존 선형 스캔을 `legacy_find_metric`(cfg(test))으로 원문 보존.
+2. `OnceLock<HashMap<&'static str, [(&'static FontMetric, bool); 4]>>` 색인 — 테이블 순서
+   1회 순회로 조합별/이름별 첫 엔트리를 기록한 뒤 legacy 사다리 순서로 슬롯을 채운다.
+3. 전수 등가성 테스트: FONT_METRICS 전체 이름 + alias LHS 전체 + 미등록 이름 × 4조합에서
+   metric 포인터 동일성 + `bold_fallback` 일치.
+
+## 4. 검증 게이트
+
+- `cargo test --profile release-test --lib font_metrics` (기존 + 신규 등가성)
+- fmt / clippy / `cargo check --target wasm32-unknown-unknown --lib`
+- `cargo test --profile release-test --tests` 전체 무회귀
+- 실측: `issue4149_adjacent_giant_cell_cursor_rect_latency_decomposition`으로 캐럿 질의
+  before/after (기대 ~17-20% 감소)
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/plans/task_m100_4169.md
+++ b/mydocs/plans/task_m100_4169.md
@@ -1,0 +1,43 @@
+# 수행계획 — task_m100_4169
+
+- **이슈**: [#4169](https://github.com/edwardkim/rhwp/issues/4169)
+- **브랜치**: `task_m100_4169_overflow_memo` (stack: `task_m100_4168_font_metric_index` 위)
+- **기준**: `upstream/devel` `5a4f26d0d`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+`recompose_stored_single_line_if_overflowing`(src/renderer/composer.rs)의 과밀 판정을 문단별로
+메모해, 판정 입력이 안 바뀐 문단의 `estimate_composed_line_width` 재측정을 생략한다. #4167
+프로파일에서 캐럿 질의당 페이지 빌드 비용의 ~30%(1,945/6,765 샘플)가 이 가드의 무변경 재측정
+이었다 — 거대 셀 문서는 셀 문단 대부분이 단일줄이라 사실상 페이지 전 텍스트를 빌드마다 재측정한다.
+
+## 2. 변경 경계
+
+- **무효화 누락 = 가드가 막던 절단 렌더(#4138 계열) 회귀와 동일한 결함** — 텍스트/char_shapes
+  변이 전 경로(프리미티브 우회 직접 대입 포함) 전수 무효화가 계약이다.
+- overflowed=true 문단의 fresh 재래핑 동작은 유지한다(측정만 생략) — 재래핑 생략은 절단 렌더 회귀.
+- `Paragraph`는 Sync 요구(`Arc<Vec<Paragraph>>` 경유 `DocumentCore` Send 단언) — `Cell` 불가,
+  `AtomicU64` 패킹 사용. serde 미보유 확인, `ir_field_sweep` 철저 구조분해에 명시 제외.
+- 파일 저장 포맷에 새지 않는다 (HWP/HWPX 저장기는 필드 명시 기록).
+
+## 3. 구현·래칫 순서
+
+1. `Paragraph.single_line_overflow_memo: AtomicU64` (0=미판정, (f32 폭 bits<<1)|overflowed) +
+   수동 Clone.
+2. 가드에서 memo 히트 시 측정 생략, over 판정은 그대로 소비. 폭 키 불일치·미판정 시 실측 후 기록.
+3. 무효화 전수 배선: 모델 프리미티브 8곳(insert/delete/split/merge/char_shape 계열) +
+   `reflow_line_segs` 수렴점 + 직접 대입 우회(표 계산식, clear_initial_field_texts,
+   `rebuild_char_offsets` 수렴점, 셀 인라인 컨트롤 삭제의 `reflow_paragraph_line_segs_after_control_delete`,
+   클립보드 구조 제거) — 마지막 세 경로는 적대 리뷰 CONFIRMED 결함/동류 누락의 수정이다.
+4. 회귀 테스트: 메모 히트 시 측정 1회 증명, 폭 변경 재판정, over=true 재래핑 유지, 뮤테이션
+   경로별 무효화, 셀 그림 삭제 실명령 재현.
+
+## 4. 검증 게이트
+
+- `cargo test --profile release-test --lib composer` / `--lib issue4149` / `--lib object_ops`
+- 기존 가드 회귀 핀: issue_2287/2430/2525/2527/4138 계열
+- fmt / clippy / wasm32 check / `release-test --tests` 전체
+- 실측: 캐럿 질의 ≈17.2ms → ≈14.3ms (#4168 위 누적)
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/plans/task_m100_4179_host_para_pages.md
+++ b/mydocs/plans/task_m100_4179_host_para_pages.md
@@ -1,0 +1,22 @@
+# 수행계획 — task_m100_4179_host_para_pages
+
+- **이슈**: [#4179](https://github.com/edwardkim/rhwp/issues/4179)
+- **브랜치**: `task_m100_4179_host_para_pages`
+- **기준**: `upstream/devel` `e64c85312`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+텍스트 있는 표 호스트 문단의 getCursorRect 가 후보 전 페이지를 비캐시 렌더 트리로 빌드하는 O(pages) 경로(#4126 미커버 자매 케이스, 115쪽 문서 열기 2.5s 실측)를 pagination 메타데이터만으로 제거한다.
+
+## 2. 변경 경계
+
+- 순수-중간 연속 컷(cont=true && end_cut 비어있지 않음) 페이지를 후보에서 제외 — 렌더 트리 빌드 없이 판정.
+- 기존 캐럿 좌표 출력 불변(회귀 테스트 tests/issue_4179_cursor_rect_text_host_para_pages.rs 동봉).
+
+## 검증 게이트
+
+- 레이어 자체 회귀 테스트 + `cargo nextest run --cargo-profile release-test` 전체
+- fmt / clippy(root+workspace all-targets) / wasm32 check / Native Skia 3종 / studio suite
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/plans/task_m100_4180_caret_meta_on_save.md
+++ b/mydocs/plans/task_m100_4180_caret_meta_on_save.md
@@ -1,0 +1,22 @@
+# 수행계획 — task_m100_4180_caret_meta_on_save
+
+- **이슈**: [#4180](https://github.com/edwardkim/rhwp/issues/4180)
+- **브랜치**: `task_m100_4180_caret_meta_on_save`
+- **기준**: `upstream/devel` `e64c85312`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+문서 캐럿 메타데이터(DOCUMENT_PROPERTIES)가 마지막 본문 편집 위치를 기록해 열기 시 캐럿이 엉뚱한 페이지로 복원되는 결함(#4180, 실측: 마지막 페이지)을 저장 시점 캐럿 기록으로 바로잡는다.
+
+## 2. 변경 경계
+
+- 본문 편집마다의 메타 갱신을 제거하고 저장 경로에서 현재 캐럿을 스탬프.
+- 라운드트립 회귀 테스트 tests/issue_4180_caret_stamp_roundtrip.rs 동봉.
+
+## 검증 게이트
+
+- 레이어 자체 회귀 테스트 + `cargo nextest run --cargo-profile release-test` 전체
+- fmt / clippy(root+workspace all-targets) / wasm32 check / Native Skia 3종 / studio suite
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/plans/task_m100_ime_reanchor.md
+++ b/mydocs/plans/task_m100_ime_reanchor.md
@@ -1,0 +1,37 @@
+# 수행계획 — task_m100_ime_reanchor
+
+- **이슈**: [#4245](https://github.com/edwardkim/rhwp/issues/4245) (#4150 IME 조합 계열 후속)
+- **브랜치**: `task_m100_ime_reanchor_guard` (stack: `task_m100_4151_cell_block_toggle_sync` 위)
+- **기준**: `upstream/devel` `5a4f26d0d`
+- **작성 시각**: 2026-08-08 KST
+
+## 1. 목표
+
+IME 조합 업데이트의 raw replace(`input-handler-text.ts` 조합 분기)가 wasm 의 deferred replace
+범위 가드에 거부되면 예외가 `onInput` 밖으로 던져져 핸들러가 죽고, 조합 추적
+(compositionAnchor/Length)이 낡은 값으로 wedge 되어 이후 모든 조합 업데이트가 연쇄 실패한다.
+거부를 잡아 조합을 현재 캐럿에 재정박해 입력 스트림을 잇는다.
+
+## 2. 변경 경계
+
+- 정상 경로 무변경 — 가드 거부(외부 변이로 앵커·길이가 낡은 경합) 시에만 복구 분기.
+- 복구는 "현재 캐럿 재정박 + 이번 조합 텍스트 재삽입" — 그것도 실패하면 이번 업데이트만
+  버리고 로그(다음 캐럿 이동에서 자연 동기화).
+- `onCompositionEnd`는 raw 뮤테이션이 없어(command 기록만) 변경 불요 — 확인 완료.
+
+## 3. 구현·래칫 순서
+
+1. 조합 분기의 `replaceTextAtRaw`를 try/catch — 거부 시 warn + `compositionAnchor`를 현재
+   캐럿으로 재정박, `compositionLength=0`, 재삽입 시도.
+2. 소스 계약 테스트: 조합 replace 가 try 블록 안에 있고, catch 가 현재 캐럿 기준 재정박 +
+   길이 리셋을 수행.
+3. 실브라우저 강제 트립: `compositionLength` 오염 후 조합 업데이트 → uncaught 없음·복구·
+   최종 텍스트 정합·undo 완전 복원 확인.
+
+## 4. 검증 게이트
+
+- `tests/composition-replace-reanchor.test.ts` 2종
+- tsc ci-unit / `npm run test` 전체
+- 실브라우저(:7701) 강제 트립 시나리오
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/pr/archives/pr_4246_review.md
+++ b/mydocs/pr/archives/pr_4246_review.md
@@ -1,0 +1,33 @@
+---
+kind: pr_review
+status: accepted-for-integrated-merge
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-08
+---
+
+# PR #4246 검토 - 폰트 메트릭 조회 선계산 색인
+
+## 대상과 범위
+
+| 항목 | 값 |
+| --- | --- |
+| 원 PR / 작성자 | [#4246](https://github.com/edwardkim/rhwp/pull/4246) / @humdrum00001010 |
+| contributor 원 head | `c5a246c438d6e6b04d3325dcc643c27fc4be792f` |
+| base / 규모 | `devel`, 3개 파일, +317/-0 |
+| 관련 이슈 | [#4168](https://github.com/edwardkim/rhwp/issues/4168) |
+| 작성 시점 원격 상태 | `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN` |
+
+`find_metric`의 반복 선형 탐색을 `OnceLock` 기반 이름·굵기·기울임 색인으로 바꾼다. legacy 탐색은
+테스트 전용 오라클로 남기며, 첫 매칭 우선순위와 bold fallback 의미를 바꾸지 않는다. 렌더 결과가 아니라
+메트릭 조회 비용만 줄이는 변경이다.
+
+## 검증과 판단
+
+- 원 head의 `Build & Test`가 통과했다.
+- 최신 `devel` `e919655a` 위 누적 통합에서 `cargo fmt --check`와
+  `cargo test --profile release-test --tests`가 종료 코드 0으로 통과했다.
+- renderer/layout 영향이므로 통합 PR #4265의 Full CI와 Native Skia 결과를 merge 전 최신 head에서 다시
+  확인한다. 로컬 Native Skia 재실행은 이 문서 작성 시점에 아직 완료하지 않았다.
+
+**통합 수용 권고.** 적용 순서는 #4246 → #4247 → #4248 → #4249이며, 이후 fast-path가 이 색인의
+메트릭 측정 경로를 재사용한다.

--- a/mydocs/pr/archives/pr_4247_review.md
+++ b/mydocs/pr/archives/pr_4247_review.md
@@ -1,0 +1,31 @@
+---
+kind: pr_review
+status: accepted-for-integrated-merge
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-08
+---
+
+# PR #4247 검토 - 단일줄 과밀 판정 memo
+
+## 대상과 범위
+
+| 항목 | 값 |
+| --- | --- |
+| 원 PR / 작성자 | [#4247](https://github.com/edwardkim/rhwp/pull/4247) / @humdrum00001010 |
+| contributor 원 head | `376b10611a275607701e8eaf61d6608af42db241` |
+| base / 규모 | `devel`, 16개 파일, +853/-7 |
+| 관련 이슈 | [#4169](https://github.com/edwardkim/rhwp/issues/4169) |
+| 작성 시점 원격 상태 | `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN` |
+
+저장된 단일줄 문단의 과밀 여부를 `AtomicU64` memo로 보관해 입력이 불변인 재측정을 피한다. 텍스트,
+문자 모양, 셀 폭을 바꾸는 모든 편집 경로에서 무효화하고, 이미 과밀인 문단의 fresh 재래핑은 유지한다.
+
+## 검증과 판단
+
+- 원 head의 `Build & Test`가 통과했다.
+- 통합 후보에서 `overflow_cell_baseline`은 275.56초에, 전체 `release-test --tests`는 종료 코드 0으로
+  통과했다. 과밀 판단 memo가 overflow-cell 기준선을 숨기지 않았음을 확인했다.
+- renderer/layout 영향의 Native Skia 3종은 #4265 최신 Full CI의 결과를 merge 전에 다시 확인한다.
+
+**통합 수용 권고.** #4246의 메트릭 색인 뒤에 적용하며, #4248/#4249의 셀 캐럿 fast path와 같은
+문단 측정·무효화 계약을 공유한다.

--- a/mydocs/pr/archives/pr_4248_review.md
+++ b/mydocs/pr/archives/pr_4248_review.md
@@ -1,0 +1,36 @@
+---
+kind: pr_review
+status: accepted-with-maintainer-correction
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-08
+---
+
+# PR #4248 검토 - 셀 캐럿 rect fast path
+
+## 대상과 범위
+
+| 항목 | 값 |
+| --- | --- |
+| 원 PR / 작성자 | [#4248](https://github.com/edwardkim/rhwp/pull/4248) / @humdrum00001010 |
+| contributor 원 head | `a35d980d0a9c8da3dc45aa56b8471c4c319bee11` |
+| base / 규모 | `devel`, 24개 파일, +2,505/-188 |
+| 관련 이슈 | [#4167](https://github.com/edwardkim/rhwp/issues/4167) |
+| 작성 시점 원격 상태 | `mergeable=CONFLICTING`, `mergeStateStatus=DIRTY`; #4249와 같은 stack이므로 통합 PR에서 해소한다. |
+
+전체 페이지 트리 대신 production partial-table compose를 대상 셀에만 적용해 셀 캐럿 rect를 계산한다.
+불확실 형상은 기존 전체 경로로 fallback해 정합을 우선한다.
+
+## 메인터너 보정
+
+통합 검증에서 KTX fixture의 뒤 문단 중첩 표 border clip이 바깥 셀 `cellBounds`를 넓히는 형상을
+fast path가 생략했다. `da2d9ae75`는 해당 셀에 뒤 문단의 직접 표 control이 있으면 종료 문단만 셀 끝으로
+확장한다. 기존 분할 셀 `window_paras`는 유지하므로 거대 셀을 전량 compose하지 않는다.
+
+## 검증과 판단
+
+- 원 head의 `Build & Test`가 통과했다.
+- KTX parity는 `3/371`, giant-cell warm latency는 fast `6.185ms`, legacy `92.136ms/call`로 통과했다.
+- 전체 fast-path parity 3건과 `cargo test --profile release-test --tests`가 통과했다.
+
+**메인터너 보정 포함 통합 수용 권고.** 원 PR의 현재 단독 충돌은 #4249가 후속 stack이기 때문이며,
+#4265에서는 두 변경과 보정을 함께 적용한다.

--- a/mydocs/pr/archives/pr_4249_review.md
+++ b/mydocs/pr/archives/pr_4249_review.md
@@ -1,0 +1,30 @@
+---
+kind: pr_review
+status: accepted-for-integrated-merge
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-08
+---
+
+# PR #4249 검토 - units 지문 불변 시 eviction 생략
+
+## 대상과 범위
+
+| 항목 | 값 |
+| --- | --- |
+| 원 PR / 작성자 | [#4249](https://github.com/edwardkim/rhwp/pull/4249) / @humdrum00001010 |
+| contributor 원 head | `d5a13e5713f75b0d4e5096b9eccd2fd34e1585fc` |
+| base / 규모 | `devel`, 25개 파일, +2,832/-195 |
+| 관련 이슈 | [#4167](https://github.com/edwardkim/rhwp/issues/4167) |
+| 작성 시점 원격 상태 | `mergeable=CONFLICTING`, `mergeStateStatus=DIRTY`; #4248 후속 stack이므로 통합 PR에서 해소한다. |
+
+deferred 셀 편집 전후의 units 입력 지문을 비교해, 레이아웃 단위가 불변이면 `cell_units` eviction을
+생략한다. 재래핑·spacer 전이처럼 지문이 바뀌는 경우는 기존 eviction 경로를 유지한다.
+
+## 검증과 판단
+
+- 원 head의 `Build & Test`가 통과했다.
+- 통합 후보에서 `issue4167` focused 검증과 전체 `release-test --tests`가 통과했다.
+- #4248의 parity와 latency 검증도 함께 통과해 cache 재사용이 캐럿 rect 결과를 바꾸지 않았음을 확인했다.
+
+**통합 수용 권고.** #4248 직후에만 적용한다. 단독 PR 충돌은 선행 fast-path stack의 merge 순서를
+반영한 것이며 구현 결함으로 분류하지 않는다.

--- a/mydocs/pr/archives/pr_4250_review.md
+++ b/mydocs/pr/archives/pr_4250_review.md
@@ -1,0 +1,30 @@
+---
+kind: pr_review
+status: accepted-for-integrated-merge
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-08
+---
+
+# PR #4250 검토 - 셀 블록 서식 토글과 툴바 동기화
+
+## 대상과 범위
+
+| 항목 | 값 |
+| --- | --- |
+| 원 PR / 작성자 | [#4250](https://github.com/edwardkim/rhwp/pull/4250) / @humdrum00001010 |
+| contributor 원 head | `1a54aa3960afd82857b62b687f3391db982b615a` |
+| base / 규모 | `devel`, 4개 파일, +133/-2 |
+| 관련 이슈 | [#4151](https://github.com/edwardkim/rhwp/issues/4151) |
+| 작성 시점 원격 상태 | `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN` |
+
+F5 셀 블록 서식에서 토글 방향과 툴바 상태를 블록 앵커의 첫 글자에서 읽어 공유한다. 빈 블록의
+조기 종료 의미는 유지한다.
+
+## 검증과 판단
+
+- 원 head의 `Build & Test`가 통과했다.
+- 통합 후보의 `cell-block-format.test.ts`를 포함한 Studio focused 27건과 전체 `npm test` 813건이
+  통과했다. production build도 통과했다.
+- renderer 출력 자체를 바꾸지 않는 Studio interaction 변경이므로 PDF visual sweep은 적용하지 않았다.
+
+**통합 수용 권고.** #4251의 IME 재정박과 입력 handler 접점은 있으나 기능상 독립된 순서로 누적했다.

--- a/mydocs/pr/archives/pr_4251_review.md
+++ b/mydocs/pr/archives/pr_4251_review.md
@@ -1,0 +1,31 @@
+---
+kind: pr_review
+status: accepted-for-integrated-merge
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-08
+---
+
+# PR #4251 검토 - IME 조합 replace 거부 뒤 캐럿 재정박
+
+## 대상과 범위
+
+| 항목 | 값 |
+| --- | --- |
+| 원 PR / 작성자 | [#4251](https://github.com/edwardkim/rhwp/pull/4251) / @humdrum00001010 |
+| contributor 원 head | `ec61a349fadb15ab68c4eccccf3cd013a2a458ec` |
+| base / 규모 | `devel`, 8개 파일, +260/-4 |
+| 관련 이슈 | [#4245](https://github.com/edwardkim/rhwp/issues/4245), [#4150](https://github.com/edwardkim/rhwp/issues/4150) |
+| 작성 시점 원격 상태 | `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN` |
+
+deferred replace가 오래된 조합 범위를 거부할 때 예외를 입력 handler 밖으로 전파하지 않는다. 현재
+캐럿에 조합 상태를 재정박하고 삽입을 재시도하며, 재시도도 실패하면 해당 업데이트만 버린다.
+
+## 검증과 판단
+
+- 원 head의 `Build & Test`가 통과했다.
+- 통합 후보에서 `composition-replace-reanchor.test.ts`를 포함한 Studio focused 27건과 전체
+  `npm test` 813건이 통과했다.
+- #4261의 실제 HWP/HWPX 셀 Enter Chromium E2E도 두 형식 모두 115쪽, Enter flush 0, split 1로
+  통과해 인접 입력·pagination 경로가 함께 유지됨을 확인했다.
+
+**통합 수용 권고.** 통합 PR 본문의 closing keyword에는 #4245와 #4150을 모두 포함한다.

--- a/mydocs/pr/archives/pr_4258_review.md
+++ b/mydocs/pr/archives/pr_4258_review.md
@@ -1,0 +1,29 @@
+---
+kind: pr_review
+status: accepted-for-integrated-merge
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-08
+---
+
+# PR #4258 검토 - 셀 나누기 뒤 stale line_segs 재래핑
+
+## 대상과 범위
+
+| 항목 | 값 |
+| --- | --- |
+| 원 PR / 작성자 | [#4258](https://github.com/edwardkim/rhwp/pull/4258) / @humdrum00001010 |
+| contributor 원 head | `2e1ad89f2393c68f50ebe2dfcb9a2d44ea4dd73b` |
+| base / 규모 | `devel`, 7개 파일, +500/-0 |
+| 관련 이슈 | [#4138](https://github.com/edwardkim/rhwp/issues/4138) |
+| 작성 시점 원격 상태 | `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN` |
+
+표 셀 분할 뒤 이전 폭 기준 `line_segs`가 남는 문제를 현재 폭으로 재래핑하고, vpos 사다리를
+단조롭게 재구축한다. #4259 → #4260 → #4261의 선행 pagination stack이다.
+
+## 검증과 판단
+
+- 원 head의 `Build & Test`가 통과했다.
+- `issue_4138_split_cell_stale_linesegs` 2건과 전체 `release-test --tests`가 통과했다.
+- renderer/layout 변경이므로 #4265의 최신 Full CI 및 Native Skia 결과를 merge 전에 확인한다.
+
+**통합 수용 권고.** 적용 순서는 #4258 → #4259 → #4260 → #4261이다.

--- a/mydocs/pr/archives/pr_4259_review.md
+++ b/mydocs/pr/archives/pr_4259_review.md
@@ -1,0 +1,29 @@
+---
+kind: pr_review
+status: accepted-for-integrated-merge
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-08
+---
+
+# PR #4259 검토 - 텍스트 표 호스트 문단 캐럿 질의 페이지 좁히기
+
+## 대상과 범위
+
+| 항목 | 값 |
+| --- | --- |
+| 원 PR / 작성자 | [#4259](https://github.com/edwardkim/rhwp/pull/4259) / @humdrum00001010 |
+| contributor 원 head | `2b19680d8c27ad10ea660b52a00c816ab6948dbc` |
+| base / 규모 | `devel`, 11개 파일, +671/-2 |
+| 관련 이슈 | [#4179](https://github.com/edwardkim/rhwp/issues/4179), [#4145](https://github.com/edwardkim/rhwp/issues/4145) |
+| 작성 시점 원격 상태 | `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN` |
+
+텍스트가 있는 표 호스트 문단의 캐럿 질의에서, pagination 메타데이터만으로 연속 중간 페이지를 후보에서
+제외한다. 해석 불가능한 경우에는 기존 넓은 탐색 경로를 보존한다.
+
+## 검증과 판단
+
+- 원 head의 `Build & Test`가 통과했다.
+- `issue_4179_cursor_rect_text_host_para_pages`와 전체 `release-test --tests`가 통과했다.
+- #4248 fast path와 조합한 cursor query 경로를 통합 후보에서 검증했다.
+
+**통합 수용 권고.** 통합 PR의 closing keyword에는 #4179와 #4145를 모두 포함한다.

--- a/mydocs/pr/archives/pr_4260_review.md
+++ b/mydocs/pr/archives/pr_4260_review.md
@@ -1,0 +1,30 @@
+---
+kind: pr_review
+status: accepted-for-integrated-merge
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-08
+---
+
+# PR #4260 검토 - 저장 시점 캐럿 메타데이터
+
+## 대상과 범위
+
+| 항목 | 값 |
+| --- | --- |
+| 원 PR / 작성자 | [#4260](https://github.com/edwardkim/rhwp/pull/4260) / @humdrum00001010 |
+| contributor 원 head | `0d2bf6042ef44dbb30d0e5eb1522a3518d73989d` |
+| base / 규모 | `devel`, 17개 파일, +854/-39 |
+| 관련 이슈 | [#4180](https://github.com/edwardkim/rhwp/issues/4180) |
+| 작성 시점 원격 상태 | `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN` |
+
+마지막 편집 위치가 아닌 실제 저장 시점의 캐럿을 메타데이터에 기록해, 재열기 때 캐럿이 다른 쪽으로
+복원되는 문제를 막는다.
+
+## 검증과 판단
+
+- 원 head의 `Build & Test`가 통과했다.
+- `issue_4180_caret_stamp_roundtrip`과 전체 `release-test --tests`가 통과했다.
+- HWP/HWPX 저장·Studio 입력 경로가 함께 바뀌므로 #4265 최신 Full CI와 package gate를 merge 전에
+  다시 확인한다.
+
+**통합 수용 권고.** #4258·#4259 이후, #4261 이전의 pagination·저장 stack으로 누적했다.

--- a/mydocs/pr/archives/pr_4261_review.md
+++ b/mydocs/pr/archives/pr_4261_review.md
@@ -1,0 +1,32 @@
+---
+kind: pr_review
+status: accepted-for-integrated-merge
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-08
+---
+
+# PR #4261 검토 - 거대 분할 셀 Enter 지연 제거
+
+## 대상과 범위
+
+| 항목 | 값 |
+| --- | --- |
+| 원 PR / 작성자 | [#4261](https://github.com/edwardkim/rhwp/pull/4261) / @humdrum00001010 |
+| contributor 원 head | `59aef443c37e804ae2cf18e5c5d4e80cedc566bd` |
+| base / 규모 | `devel`, 31개 파일, +2,132/-41 |
+| 관련 이슈 | [#4146](https://github.com/edwardkim/rhwp/issues/4146) |
+| 작성 시점 원격 상태 | `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN` |
+
+거대 분할 표 셀에서 Enter 후 남은 deferred pagination을 계산 없이 취소하고, split 완료 소유를 command
+effects로 옮긴다. probe와 실제 browser E2E를 함께 추가한다.
+
+## 검증과 판단
+
+- 원 head의 `Build & Test`가 통과했다.
+- Studio focused 27건, 전체 `npm test` 813건, production build가 통과했다.
+- 실제 Chromium E2E에서 HWP/HWPX 모두 115쪽, Enter flush 0, split 1, ArrowDown barrier flush 1을
+  확인했다.
+- 전체 `release-test --tests`와 WASM build가 통과했다.
+
+**통합 수용 권고.** #4258 → #4259 → #4260 이후에만 적용해 stale line segment와 저장 캐럿 계약을
+먼저 확정한다.

--- a/mydocs/pr/archives/pr_4262_review.md
+++ b/mydocs/pr/archives/pr_4262_review.md
@@ -1,0 +1,31 @@
+---
+kind: pr_review
+status: accepted-for-integrated-merge
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-08
+---
+
+# PR #4262 검토 - ResizeObserver 루프 경고 격리
+
+## 대상과 범위
+
+| 항목 | 값 |
+| --- | --- |
+| 원 PR / 작성자 | [#4262](https://github.com/edwardkim/rhwp/pull/4262) / @humdrum00001010 |
+| contributor 원 head | `72113876e681bf56d9dc1c0afb04d2b662fe9392` |
+| base / 규모 | `devel`, 11개 파일, +330/-6 |
+| 관련 이슈 | [#4163](https://github.com/edwardkim/rhwp/issues/4163) |
+| 작성 시점 원격 상태 | `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN` |
+
+관찰 콜백의 프레임 내 변이를 매크로태스크로 이연하고, 대형 문서 초기 렌더의 무해한 ResizeObserver
+루프 경고가 window error로 합성되지 않게 전용 경로에서 격리한다.
+
+## 검증과 판단
+
+- 원 head의 `Build & Test`가 통과했다.
+- 통합 후보에서 Studio 전체 `npm test` 813건과 production build가 통과했다.
+- renderer/layout 결과가 아니라 browser error surface를 다루는 변경이므로 기준 PDF visual sweep은
+  적용하지 않았다.
+
+**통합 수용 권고.** #4250·#4251의 Studio 입력 변경과 함께 누적했으며, 최종 #4265 Full CI의
+frontend package gate를 merge 전에 확인한다.

--- a/mydocs/pr/archives/pr_4265_review.md
+++ b/mydocs/pr/archives/pr_4265_review.md
@@ -41,13 +41,14 @@ last_verified: 2026-08-08
 | Studio | focused 27건, `npm test` 813 passed, production build 통과 |
 | WASM | `wasm-pack build --target web --out-dir pkg` 통과 |
 | 실제 브라우저 | HWP/HWPX 셀 Enter E2E 각각 115쪽, Enter flush 0, split 1, ArrowDown barrier flush 1 |
+| GitHub Full CI | [CI 31256100624](https://github.com/edwardkim/rhwp/actions/runs/31256100624), [CodeQL 31256100547](https://github.com/edwardkim/rhwp/actions/runs/31256100547), [Render Diff 31256100556](https://github.com/edwardkim/rhwp/actions/runs/31256100556)가 `557bb8526`에서 성공. Native Skia, slow shard, regular shard 1/3·2/3·3/3, Build & Test를 포함한다. |
 
-Native Skia 3종은 시작했지만 작업지시자 지시로 통합 PR 준비를 우선해 중단했다. 따라서 로컬 통과로
-기록하지 않으며, #4265 최신 code head의 Full CI 결과를 merge 전 필수 조건으로 둔다.
+Native Skia 3종은 로컬에서는 작업지시자 지시로 중단했으므로 로컬 통과로 기록하지 않았다. 대신
+`557bb8526`의 GitHub Full CI Native Skia job이 성공해 원격 필수 게이트를 충족했다.
 
 ## 최종 권고
 
-**메인터너 보정 포함 통합 수용 권고.** 최신 #4265 code head의 Full CI·CodeQL·Render Diff가 모두
-성공하고 `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN`을 다시 확인한 뒤, 이 review·오늘할일
-trailing commit의 최신 gate와 작업지시자 merge 승인을 확인한다. merge 뒤 원 PR 11개는 통합 PR 링크와
-기여 credit을 남긴 뒤 close하고, closing keyword 대상 이슈의 실제 종료 상태를 확인한다.
+**메인터너 보정 포함 통합 수용 권고.** `557bb8526`의 Full CI·CodeQL·Render Diff는 성공했다.
+이 결과 기록 commit의 최신 docs-only gate, `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN`, 그리고
+작업지시자 merge 승인을 확인한다. merge 뒤 원 PR 11개는 통합 PR 링크와 기여 credit을 남긴 뒤 close하고,
+closing keyword 대상 이슈의 실제 종료 상태를 확인한다.

--- a/mydocs/pr/archives/pr_4265_review.md
+++ b/mydocs/pr/archives/pr_4265_review.md
@@ -1,0 +1,53 @@
+---
+kind: pr_review
+status: accepted-with-maintainer-correction
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-08
+---
+
+# PR #4265 검토 - humdrum00001010 표 편집·렌더 성능 통합
+
+## 대상과 변경 경계
+
+| 항목 | 값 |
+| --- | --- |
+| 통합 PR / 작성자 | [#4265](https://github.com/edwardkim/rhwp/pull/4265) / @jangster77 |
+| 가시성 검토 브랜치 | `review/humdrum00001010-20260808` |
+| 기준 `devel` | `e919655a78d5928cdf7236152fce04d6aa6f6377` |
+| 통합 code head | `da2d9ae751b42a1eb04690f5c19bba5752d1c1d3` |
+| 원 PR | #4246, #4247, #4248, #4249, #4250, #4251, #4258, #4259, #4260, #4261, #4262 |
+| 원 작성자 | @humdrum00001010 |
+| 통합 규모 | 63개 파일, +5,326/-248 |
+
+통합은 표 셀 조판·캐럿 질의의 비용을 줄이고, 셀 분할 뒤 line segment 정합, 저장 캐럿, IME 조합,
+셀 블록 서식과 거대 셀 Enter 상호작용을 함께 보정한다. 개별 변경 범위와 원 source head는
+[#4246](pr_4246_review.md)부터 [#4262](pr_4262_review.md)까지의 개별 review에 분리해 기록했다.
+
+## 메인터너 보정
+
+#4248의 KTX nested-table 형상에서 fast path가 뒤 문단 border clip을 생략해 `cellBounds`가 legacy보다
+좁아졌다. `da2d9ae75`는 대상 셀에만 필요한 후속 문단 compose를 허용하고, 기존 `window_paras` 제한은
+유지한다. 따라서 KTX 결과 정합과 giant-cell latency 계약을 동시에 유지한다.
+
+## 완료한 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| 원 PR source 상태 | 11개 원 head의 `Build & Test` 통과를 재확인했다. #4248/#4249 단독 PR의 현재 충돌은 stack 의존성으로 통합에서 해소한다. |
+| 공백 검사 | `git diff --check upstream/devel...HEAD` 통과 |
+| Rust 전체 | `CARGO_TARGET_DIR=target/review-humdrum00001010-20260808 CARGO_INCREMENTAL=0 cargo test --profile release-test --tests` 종료 코드 0 |
+| #4248 보정 | KTX parity `3/371`, giant-cell warm latency fast `6.185ms`, legacy `92.136ms/call`, 전체 parity 3건 통과 |
+| focused Rust | #4167, #4138, #4179, #4180 관련 focused test 통과 |
+| Studio | focused 27건, `npm test` 813 passed, production build 통과 |
+| WASM | `wasm-pack build --target web --out-dir pkg` 통과 |
+| 실제 브라우저 | HWP/HWPX 셀 Enter E2E 각각 115쪽, Enter flush 0, split 1, ArrowDown barrier flush 1 |
+
+Native Skia 3종은 시작했지만 작업지시자 지시로 통합 PR 준비를 우선해 중단했다. 따라서 로컬 통과로
+기록하지 않으며, #4265 최신 code head의 Full CI 결과를 merge 전 필수 조건으로 둔다.
+
+## 최종 권고
+
+**메인터너 보정 포함 통합 수용 권고.** 최신 #4265 code head의 Full CI·CodeQL·Render Diff가 모두
+성공하고 `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN`을 다시 확인한 뒤, 이 review·오늘할일
+trailing commit의 최신 gate와 작업지시자 merge 승인을 확인한다. merge 뒤 원 PR 11개는 통합 PR 링크와
+기여 credit을 남긴 뒤 close하고, closing keyword 대상 이슈의 실제 종료 상태를 확인한다.

--- a/mydocs/pr/archives/pr_4265_review_impl.md
+++ b/mydocs/pr/archives/pr_4265_review_impl.md
@@ -46,6 +46,7 @@ fast path가 전량 compose로 퇴행하지 않게 했다.
 
 ## 원격 처리 전 조건
 
-1. PR #4265 최신 code head의 Full CI, CodeQL, Render Diff와 mergeable 상태를 확인한다.
-2. 이 review·오늘할일 trailing 문서 commit을 push한 뒤 최신 head의 docs-only gate를 다시 확인한다.
+1. code head `da2d9ae75`와 첫 trailing review head `557bb8526`의 Full CI, CodeQL, Render Diff가
+   모두 성공했음을 확인했다. Native Skia, slow shard, regular shard 1/3·2/3·3/3도 포함한다.
+2. 이 CI 결과 기록을 반영한 마지막 문서 commit을 push한 뒤 최신 head의 docs-only gate를 다시 확인한다.
 3. 작업지시자 승인 뒤에만 #4265를 merge하고, 원 PR·연결 이슈를 통합 반영 사실과 함께 후속 처리한다.

--- a/mydocs/pr/archives/pr_4265_review_impl.md
+++ b/mydocs/pr/archives/pr_4265_review_impl.md
@@ -1,0 +1,51 @@
+---
+kind: review-implementation
+status: completed-local
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-08
+---
+
+# PR #4265 통합·메인터너 보정 기록
+
+## 통합 기준과 적용 순서
+
+최신 `upstream/devel` `e919655a78d5928cdf7236152fce04d6aa6f6377` 위의
+`review/humdrum00001010-20260808`에서 원 contributor 변경을 다음 순서로 누적했다.
+
+| 순서 | 원 PR | 통합 code commit | 역할 |
+| --- | --- | --- | --- |
+| 1 | #4246 | `751796949` | 폰트 메트릭 색인 |
+| 2 | #4247 | `e0a21d3c4` | 단일줄 과밀 memo |
+| 3 | #4248 | `9dce61bb9` | 셀 캐럿 rect fast path |
+| 4 | #4249 | `d30d60004` | units 지문 기반 eviction 생략 |
+| 5 | #4250 | `dd372b805` | 셀 블록 서식 동기화 |
+| 6 | #4251 | `abb5a1485` | IME 조합 재정박 |
+| 7 | #4262 | `4f0fd7df2` | ResizeObserver 경고 격리 |
+| 8 | #4258 | `bf803bf53` | split 셀 stale line_segs 재래핑 |
+| 9 | #4259 | `7519a7061` | 표 호스트 문단 캐럿 질의 좁히기 |
+| 10 | #4260 | `ebca79fb1` | 저장 시점 캐럿 메타데이터 |
+| 11 | #4261 | `277b40222`, `3fadc9b42` | 거대 셀 Enter pagination 지연 제거 |
+
+원 source의 stage 보고·계획 commit도 각 code commit 직후에 보존했다. 원 contributor branch는 rewrite하지
+않았고, #4248/#4249의 단독 충돌은 서로 의존하는 stack을 하나의 통합 branch에서 유지해 해소했다.
+
+## 메인터너 보정
+
+`da2d9ae75`는 #4248의 부분 셀 compose가 뒤 문단 중첩 표의 border clip 확장을 누락하는 문제를 고친다.
+KTX fixture에서 `cellBounds`가 legacy보다 좁아지는 것을 재현한 뒤, 대상 셀에 뒤 문단의 직접 표 control이
+있을 때만 compose 종료 지점을 셀 끝으로 확장했다. 분할 셀의 기존 문단 창은 그대로 유지해 giant-cell
+fast path가 전량 compose로 퇴행하지 않게 했다.
+
+## 롤백 경계
+
+- #4246~#4249는 동일한 셀 캐럿 성능 stack이므로 부분 롤백하지 않는다.
+- #4258~#4261은 split 셀·캐럿·저장·Enter pagination 순서를 공유하므로 역순으로만 되돌린다.
+- #4250, #4251, #4262는 Studio 입력 및 browser error surface 축이며 Rust stack과 독립적으로 롤백할 수 있다.
+- `da2d9ae75`는 #4248 fast path와 함께 유지한다. 이를 단독으로 되돌리면 KTX 중첩 표 `cellBounds` parity가
+  다시 깨진다.
+
+## 원격 처리 전 조건
+
+1. PR #4265 최신 code head의 Full CI, CodeQL, Render Diff와 mergeable 상태를 확인한다.
+2. 이 review·오늘할일 trailing 문서 commit을 push한 뒤 최신 head의 docs-only gate를 다시 확인한다.
+3. 작업지시자 승인 뒤에만 #4265를 merge하고, 원 PR·연결 이슈를 통합 반영 사실과 함께 후속 처리한다.

--- a/mydocs/report/assets/task_m100_4031_stage1_baseline.log
+++ b/mydocs/report/assets/task_m100_4031_stage1_baseline.log
@@ -1,0 +1,246 @@
+test issue_4031_profile_cold_enter_split ... RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=1135.149 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=1152.706 invalidate_ms=0.000 normalize_ms=0.054 setup_ms=0.150 measure_ms=16.235 typeset_ms=1136.108 postprocess_ms=0.158 cleanup_ms=0.000 other_ms=0.000
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=1114.503 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=1129.953 invalidate_ms=0.000 normalize_ms=0.027 setup_ms=0.001 measure_ms=15.117 typeset_ms=1114.647 postprocess_ms=0.160 cleanup_ms=0.000 other_ms=0.000
+RHWP_4031_COLD_ENTER run=1 format=hwp pos=top stroke=1 split_ms=1130.165 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=1109.254 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=1124.344 invalidate_ms=0.000 normalize_ms=0.027 setup_ms=0.001 measure_ms=14.768 typeset_ms=1109.392 postprocess_ms=0.155 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=1 format=hwp pos=top stroke=2 split_ms=1124.480 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=1157.190 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=1172.493 invalidate_ms=0.000 normalize_ms=0.029 setup_ms=0.001 measure_ms=14.987 typeset_ms=1157.327 postprocess_ms=0.149 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=1 format=hwp pos=top stroke=3 split_ms=1172.602 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=1176.758 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=1192.233 invalidate_ms=0.000 normalize_ms=0.047 setup_ms=0.001 measure_ms=15.083 typeset_ms=1176.891 postprocess_ms=0.210 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=1 format=hwp pos=bottom stroke=1 split_ms=1192.323 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=1513.882 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=1529.575 invalidate_ms=0.000 normalize_ms=0.029 setup_ms=0.001 measure_ms=15.218 typeset_ms=1514.032 postprocess_ms=0.295 cleanup_ms=0.000 other_ms=0.000
+RHWP_4031_COLD_ENTER run=1 format=hwp pos=bottom stroke=2 split_ms=1529.676 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=2206.500 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=2229.945 invalidate_ms=0.000 normalize_ms=0.064 setup_ms=0.001 measure_ms=22.739 typeset_ms=2206.758 postprocess_ms=0.381 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=1 format=hwp pos=bottom stroke=3 split_ms=2230.145 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=2512.469 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=2546.318 invalidate_ms=0.000 normalize_ms=0.032 setup_ms=0.001 measure_ms=33.461 typeset_ms=2512.653 postprocess_ms=0.170 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=2211.009 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=2238.053 invalidate_ms=0.000 normalize_ms=0.033 setup_ms=0.001 measure_ms=26.541 typeset_ms=2211.165 postprocess_ms=0.312 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=1 format=hwpx pos=top stroke=1 split_ms=2238.300 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=2364.477 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=2394.326 invalidate_ms=0.000 normalize_ms=0.072 setup_ms=0.001 measure_ms=29.377 typeset_ms=2364.682 postprocess_ms=0.193 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=1 format=hwpx pos=top stroke=2 split_ms=2394.499 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=2389.590 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=2415.668 invalidate_ms=0.000 normalize_ms=0.035 setup_ms=0.001 measure_ms=25.296 typeset_ms=2389.783 postprocess_ms=0.552 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=1 format=hwpx pos=top stroke=3 split_ms=2415.832 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3087.792 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3132.592 invalidate_ms=0.000 normalize_ms=0.046 setup_ms=0.001 measure_ms=44.111 typeset_ms=3088.064 postprocess_ms=0.368 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=1 format=hwpx pos=bottom stroke=1 split_ms=3132.864 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3222.037 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3263.597 invalidate_ms=0.000 normalize_ms=0.048 setup_ms=0.001 measure_ms=40.974 typeset_ms=3222.277 postprocess_ms=0.294 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=1 format=hwpx pos=bottom stroke=2 split_ms=3263.848 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=2830.295 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=2871.095 invalidate_ms=0.000 normalize_ms=0.053 setup_ms=0.001 measure_ms=40.058 typeset_ms=2830.569 postprocess_ms=0.411 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=1 format=hwpx pos=bottom stroke=3 split_ms=2871.452 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3217.675 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3253.404 invalidate_ms=0.000 normalize_ms=0.039 setup_ms=0.001 measure_ms=35.073 typeset_ms=3217.893 postprocess_ms=0.396 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3091.344 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3135.035 invalidate_ms=0.000 normalize_ms=0.053 setup_ms=0.001 measure_ms=43.074 typeset_ms=3091.613 postprocess_ms=0.293 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwp pos=top stroke=1 split_ms=3135.697 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=2955.441 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=2987.933 invalidate_ms=0.000 normalize_ms=0.046 setup_ms=0.001 measure_ms=31.837 typeset_ms=2955.666 postprocess_ms=0.382 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwp pos=top stroke=2 split_ms=2988.143 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3385.913 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3425.929 invalidate_ms=0.000 normalize_ms=0.088 setup_ms=0.001 measure_ms=39.368 typeset_ms=3386.178 postprocess_ms=0.292 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwp pos=top stroke=3 split_ms=3426.215 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=4508.896 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=4553.841 invalidate_ms=0.000 normalize_ms=0.045 setup_ms=0.001 measure_ms=44.171 typeset_ms=4509.220 postprocess_ms=0.403 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwp pos=bottom stroke=1 split_ms=4553.996 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3629.987 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3679.158 invalidate_ms=0.000 normalize_ms=0.145 setup_ms=0.001 measure_ms=48.284 typeset_ms=3630.267 postprocess_ms=0.459 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwp pos=bottom stroke=2 split_ms=3679.854 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3377.585 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3421.682 invalidate_ms=0.000 normalize_ms=0.089 setup_ms=0.001 measure_ms=43.295 typeset_ms=3377.837 postprocess_ms=0.458 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwp pos=bottom stroke=3 split_ms=3421.907 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3154.384 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3193.042 invalidate_ms=0.000 normalize_ms=0.045 setup_ms=0.001 measure_ms=38.012 typeset_ms=3154.644 postprocess_ms=0.338 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3346.045 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3388.341 invalidate_ms=0.000 normalize_ms=0.045 setup_ms=0.001 measure_ms=41.659 typeset_ms=3346.311 postprocess_ms=0.323 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwpx pos=top stroke=1 split_ms=3388.866 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3563.865 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3607.000 invalidate_ms=0.000 normalize_ms=0.045 setup_ms=0.001 measure_ms=42.478 typeset_ms=3564.142 postprocess_ms=0.333 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwpx pos=top stroke=2 split_ms=3607.183 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3543.100 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3585.960 invalidate_ms=0.001 normalize_ms=0.054 setup_ms=0.001 measure_ms=42.172 typeset_ms=3543.367 postprocess_ms=0.364 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwpx pos=top stroke=3 split_ms=3586.267 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3632.780 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3677.789 invalidate_ms=0.000 normalize_ms=0.084 setup_ms=0.001 measure_ms=44.040 typeset_ms=3633.139 postprocess_ms=0.523 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwpx pos=bottom stroke=1 split_ms=3677.985 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3548.271 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3593.051 invalidate_ms=0.000 normalize_ms=0.047 setup_ms=0.001 measure_ms=44.150 typeset_ms=3548.552 postprocess_ms=0.300 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwpx pos=bottom stroke=2 split_ms=3593.266 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3419.122 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3462.334 invalidate_ms=0.000 normalize_ms=0.048 setup_ms=0.001 measure_ms=42.530 typeset_ms=3419.372 postprocess_ms=0.382 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=2 format=hwpx pos=bottom stroke=3 split_ms=3462.565 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3590.355 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3634.349 invalidate_ms=0.000 normalize_ms=0.074 setup_ms=0.002 measure_ms=43.106 typeset_ms=3590.612 postprocess_ms=0.554 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3656.751 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3712.761 invalidate_ms=0.000 normalize_ms=0.046 setup_ms=0.001 measure_ms=55.309 typeset_ms=3657.035 postprocess_ms=0.369 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwp pos=top stroke=1 split_ms=3713.325 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3472.448 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3516.820 invalidate_ms=0.000 normalize_ms=0.125 setup_ms=0.001 measure_ms=43.626 typeset_ms=3472.692 postprocess_ms=0.374 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwp pos=top stroke=2 split_ms=3517.066 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3430.464 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3471.363 invalidate_ms=0.000 normalize_ms=0.158 setup_ms=0.001 measure_ms=39.939 typeset_ms=3430.717 postprocess_ms=0.546 cleanup_ms=0.001 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwp pos=top stroke=3 split_ms=3471.620 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3373.806 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3422.260 invalidate_ms=0.001 normalize_ms=0.055 setup_ms=0.001 measure_ms=47.645 typeset_ms=3374.146 postprocess_ms=0.412 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwp pos=bottom stroke=1 split_ms=3422.475 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3305.783 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3344.789 invalidate_ms=0.000 normalize_ms=0.058 setup_ms=0.001 measure_ms=38.317 typeset_ms=3306.020 postprocess_ms=0.392 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwp pos=bottom stroke=2 split_ms=3344.984 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3304.301 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3341.802 invalidate_ms=0.000 normalize_ms=0.046 setup_ms=0.001 measure_ms=36.940 typeset_ms=3304.525 postprocess_ms=0.288 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwp pos=bottom stroke=3 split_ms=3342.056 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3321.755 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3362.560 invalidate_ms=0.000 normalize_ms=0.050 setup_ms=0.001 measure_ms=40.055 typeset_ms=3322.062 postprocess_ms=0.390 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3387.796 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3430.544 invalidate_ms=0.000 normalize_ms=0.045 setup_ms=0.001 measure_ms=41.975 typeset_ms=3388.126 postprocess_ms=0.396 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwpx pos=top stroke=1 split_ms=3431.125 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3331.908 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3372.911 invalidate_ms=0.000 normalize_ms=0.048 setup_ms=0.001 measure_ms=40.308 typeset_ms=3332.162 postprocess_ms=0.391 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwpx pos=top stroke=2 split_ms=3373.184 pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3391.193 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3436.056 invalidate_ms=0.001 normalize_ms=0.047 setup_ms=0.001 measure_ms=44.175 typeset_ms=3391.524 postprocess_ms=0.308 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwpx pos=top stroke=3 split_ms=3436.255 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3307.573 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3356.569 invalidate_ms=0.000 normalize_ms=0.047 setup_ms=0.001 measure_ms=48.041 typeset_ms=3307.990 postprocess_ms=0.489 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwpx pos=bottom stroke=1 split_ms=3356.743 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3482.419 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3523.462 invalidate_ms=0.001 normalize_ms=0.050 setup_ms=0.001 measure_ms=40.138 typeset_ms=3482.735 postprocess_ms=0.536 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwpx pos=bottom stroke=2 split_ms=3523.660 pages=116
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=116 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3410.816 pages_added=115
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=116 total_ms=3454.843 invalidate_ms=0.000 normalize_ms=0.051 setup_ms=0.001 measure_ms=43.439 typeset_ms=3411.050 postprocess_ms=0.301 cleanup_ms=0.000 other_ms=0.001
+RHWP_4031_COLD_ENTER run=3 format=hwpx pos=bottom stroke=3 split_ms=3455.049 pages=116
+test issue_4031_profile_pending_enter_flush_vs_skip ... RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3323.068 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3364.132 invalidate_ms=0.000 normalize_ms=0.048 setup_ms=0.001 measure_ms=40.278 typeset_ms=3323.329 postprocess_ms=0.474 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3306.317 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3364.082 invalidate_ms=0.000 normalize_ms=0.048 setup_ms=0.001 measure_ms=57.010 typeset_ms=3306.653 postprocess_ms=0.368 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3417.623 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3463.183 invalidate_ms=0.000 normalize_ms=0.045 setup_ms=0.001 measure_ms=44.802 typeset_ms=3418.039 postprocess_ms=0.295 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3282.990 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3326.130 invalidate_ms=0.000 normalize_ms=0.050 setup_ms=0.001 measure_ms=42.465 typeset_ms=3283.255 postprocess_ms=0.359 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=0 pages=115 total_ms=0.057 invalidate_ms=0.000 normalize_ms=0.048 setup_ms=0.001 measure_ms=0.000 typeset_ms=0.000 postprocess_ms=0.000 cleanup_ms=0.000 other_ms=0.007
+RHWP_4031_PENDING_ENTER run=1 format=hwp flush_ms=3423.262 split_after_flush_ms=3364.793 skip_flush_split_ms=3326.781 post_flush_ms=0.119 post_flush_state=fallback pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3468.177 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3509.643 invalidate_ms=0.000 normalize_ms=0.044 setup_ms=0.001 measure_ms=40.731 typeset_ms=3468.455 postprocess_ms=0.410 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=4087.947 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=4125.660 invalidate_ms=0.000 normalize_ms=0.044 setup_ms=0.001 measure_ms=36.991 typeset_ms=4088.223 postprocess_ms=0.399 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3572.172 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3621.881 invalidate_ms=0.000 normalize_ms=0.047 setup_ms=0.001 measure_ms=49.092 typeset_ms=3572.427 postprocess_ms=0.310 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3466.067 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3513.502 invalidate_ms=0.000 normalize_ms=0.046 setup_ms=0.001 measure_ms=46.689 typeset_ms=3466.357 postprocess_ms=0.407 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=0 pages=115 total_ms=0.053 invalidate_ms=0.000 normalize_ms=0.046 setup_ms=0.001 measure_ms=0.000 typeset_ms=0.000 postprocess_ms=0.000 cleanup_ms=0.000 other_ms=0.006
+RHWP_4031_PENDING_ENTER run=1 format=hwpx flush_ms=4467.391 split_after_flush_ms=4126.162 skip_flush_split_ms=3514.203 post_flush_ms=0.088 post_flush_state=fallback pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3624.103 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3667.648 invalidate_ms=0.001 normalize_ms=0.046 setup_ms=0.001 measure_ms=42.889 typeset_ms=3624.344 postprocess_ms=0.366 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3789.095 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3831.648 invalidate_ms=0.000 normalize_ms=0.046 setup_ms=0.001 measure_ms=41.888 typeset_ms=3789.382 postprocess_ms=0.330 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3532.381 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3575.061 invalidate_ms=0.003 normalize_ms=0.048 setup_ms=0.001 measure_ms=41.959 typeset_ms=3532.653 postprocess_ms=0.395 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3781.462 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3829.803 invalidate_ms=0.000 normalize_ms=0.045 setup_ms=0.001 measure_ms=47.351 typeset_ms=3781.833 postprocess_ms=0.571 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=0 pages=115 total_ms=0.077 invalidate_ms=0.000 normalize_ms=0.062 setup_ms=0.001 measure_ms=0.000 typeset_ms=0.000 postprocess_ms=0.000 cleanup_ms=0.000 other_ms=0.012
+RHWP_4031_PENDING_ENTER run=2 format=hwp flush_ms=3576.308 split_after_flush_ms=3832.298 skip_flush_split_ms=3830.315 post_flush_ms=0.116 post_flush_state=fallback pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3570.271 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3614.633 invalidate_ms=0.000 normalize_ms=0.040 setup_ms=0.001 measure_ms=43.744 typeset_ms=3570.533 postprocess_ms=0.313 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3454.651 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3501.414 invalidate_ms=0.000 normalize_ms=0.044 setup_ms=0.001 measure_ms=45.969 typeset_ms=3454.961 postprocess_ms=0.438 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3710.193 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3754.328 invalidate_ms=0.000 normalize_ms=0.040 setup_ms=0.001 measure_ms=43.400 typeset_ms=3710.434 postprocess_ms=0.451 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3431.008 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3476.681 invalidate_ms=0.000 normalize_ms=0.085 setup_ms=0.001 measure_ms=44.931 typeset_ms=3431.264 postprocess_ms=0.398 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=0 pages=115 total_ms=0.077 invalidate_ms=0.000 normalize_ms=0.067 setup_ms=0.001 measure_ms=0.000 typeset_ms=0.000 postprocess_ms=0.000 cleanup_ms=0.000 other_ms=0.008
+RHWP_4031_PENDING_ENTER run=2 format=hwpx flush_ms=3709.714 split_after_flush_ms=3502.048 skip_flush_split_ms=3477.336 post_flush_ms=0.160 post_flush_state=fallback pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3683.786 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3727.717 invalidate_ms=0.000 normalize_ms=0.065 setup_ms=0.001 measure_ms=42.969 typeset_ms=3684.263 postprocess_ms=0.418 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3606.567 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3649.177 invalidate_ms=0.000 normalize_ms=0.076 setup_ms=0.001 measure_ms=41.786 typeset_ms=3606.856 postprocess_ms=0.456 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3808.164 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3857.117 invalidate_ms=0.000 normalize_ms=0.089 setup_ms=0.001 measure_ms=48.306 typeset_ms=3808.400 postprocess_ms=0.319 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3789.438 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3837.077 invalidate_ms=0.000 normalize_ms=0.051 setup_ms=0.001 measure_ms=46.763 typeset_ms=3789.796 postprocess_ms=0.465 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=0 pages=115 total_ms=0.081 invalidate_ms=0.000 normalize_ms=0.066 setup_ms=0.001 measure_ms=0.000 typeset_ms=0.000 postprocess_ms=0.000 cleanup_ms=0.000 other_ms=0.014
+RHWP_4031_PENDING_ENTER run=3 format=hwp flush_ms=3530.568 split_after_flush_ms=3649.802 skip_flush_split_ms=3837.687 post_flush_ms=0.123 post_flush_state=fallback pages=115
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3876.625 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3925.103 invalidate_ms=0.000 normalize_ms=0.089 setup_ms=0.002 measure_ms=46.645 typeset_ms=3876.936 postprocess_ms=1.429 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3751.432 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3795.055 invalidate_ms=0.000 normalize_ms=0.090 setup_ms=0.001 measure_ms=42.765 typeset_ms=3751.742 postprocess_ms=0.455 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3388.771 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=initial sections=1 dirty_sections=1 pages=115 total_ms=3427.509 invalidate_ms=0.000 normalize_ms=0.058 setup_ms=0.001 measure_ms=37.920 typeset_ms=3389.139 postprocess_ms=0.390 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_CONTINUATION_CURSOR section=0 para=0 control=2 fragments=115 steps=1 budget=18446744073709551615 final_row=3 rows=3
+RHWP_2424_BLOCK_TABLE_PROFILE section=0 para=0 control=2 rows=3 elapsed_ms=3398.924 pages_added=114
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=1 pages=115 total_ms=3452.009 invalidate_ms=0.001 normalize_ms=0.074 setup_ms=0.001 measure_ms=51.839 typeset_ms=3399.732 postprocess_ms=0.360 cleanup_ms=0.000 other_ms=0.001
+RHWP_2424_PAGINATION_PROFILE mode=incremental sections=1 dirty_sections=0 pages=115 total_ms=0.077 invalidate_ms=0.000 normalize_ms=0.066 setup_ms=0.001 measure_ms=0.000 typeset_ms=0.000 postprocess_ms=0.000 cleanup_ms=0.000 other_ms=0.010
+RHWP_4031_PENDING_ENTER run=3 format=hwpx flush_ms=3858.122 split_after_flush_ms=3795.592 skip_flush_split_ms=3452.857 post_flush_ms=0.106 post_flush_state=fallback pages=115

--- a/mydocs/report/task_m100_4138_report.md
+++ b/mydocs/report/task_m100_4138_report.md
@@ -1,0 +1,74 @@
+---
+kind: report
+status: active
+last_verified: 2026-08-07
+---
+
+# Task #4138 최종 보고서 — 셀 나누기 stale line_segs·vpos 사다리 붕괴 수정
+
+Issue: #4138 (외부 리포트 "glyph truncation")
+브랜치: `fix/issue-4138-split-cell-stale-linesegs`
+단계 문서: [task_m100_4138_stage1.md](../working/task_m100_4138_stage1.md)
+
+## 결론
+
+`Table::split_cell*` 가 셀 폭을 바꾼 뒤 저장 line_segs 를 방치해 생기던 2단 결함
+(옛 폭 줄의 셀 경계 잘림 + vpos 사다리 역행의 hard break 오판으로 인한 페이지
+과소 적재)을, 분할 3형제 전부에 stale 셀 재래핑 + 셀 단위 vpos 사다리 단조
+재구축을 배선해 수정했다. 수정 후 렌더는 이슈 첨부 한컴 기대 이미지와 1.1.2
+문단 기준 줄 단위로 일치한다.
+
+## 원인 사슬
+
+1. `split_table_cell_into_native`(src/document_core/commands/table_ops.rs) →
+   `Table::split_cell_into`(src/model/table.rs)가 셀 폭 44790→22395 변경, 저장
+   line_segs 재계산 생략. 새 sibling 셀도 원본 line_segs 클론.
+2. 렌더러 `LayoutEngine::layout_paragraph`(src/renderer/paragraph_layout.rs)는 저장
+   줄을 그대로 그림 → 옛 폭(44508) 줄이 새 셀 클립 경계에서 잘림.
+3. per-para `reflow_cell_paragraph` 만 배선하면 `reflow_line_segs` 가 문단 vpos
+   원점을 보존한 채 내부 줄만 재래핑 → 줄 수 증가 문단 뒤로 사다리 역행 →
+   컷 기계가 RowBreak hard break 로 오판 → 페이지 과소 적재(118→222쪽).
+
+## 수정 내용 (commit `fix(core): #4138 …`)
+
+- `reflow_stale_cells_after_split`(table_ops.rs): 저장 seg 폭 > 셀 폭(패딩 때문에
+  정상 seg 는 항상 셀 폭 미만이므로 초과 = 확정 stale)인 셀의 전 문단 재래핑 후
+  셀 사다리 재구축. `split_table_cell_native` / `split_table_cell_into_native` /
+  `split_table_cells_in_range_native` 전부에 배선.
+- `rebuild_table_cell_vpos_ladder_native` + `apply_cell_vpos_ladder`(text_editing.rs):
+  `recalculate_cell_paragraph_vpos` 의 적용 루프를 분리 공유. 텍스트 편집 경로는
+  기존대로 RowBreak reset 앞에서 정지, 전체 재래핑 직후 경로는 끝까지 재배치.
+- undo: 분할은 studio snapshot undo(`save/restore_snapshot_native` 가 Document 통째
+  복원)라 구 line_segs 자동 복원 — 코어 추가 작업 불요.
+
+## 실측
+
+| 구성 | stale | 사다리 역행 | 쪽수 |
+| --- | --- | --- | --- |
+| 수정 전 | 2,498문단/4,321seg | — | 118 |
+| reflow만 | 0 | 발생 | 222 |
+| 본 수정 | 0 | 0 | 195 |
+
+성능(RHWP_2424_PROFILE): 본 수정 추가 비용 ≈0.1s. 분할 호출 3.43s 중 3.33s 는
+분할 후 195쪽 거대 표 전체 재조판(`typeset_block_table_inner`, ~17ms/쪽) — Task #8
+(fragment 단위 증분 재조판) 대상과 동일 병목이므로 본 과제 범위 밖.
+
+## 검증
+
+- 회귀: `tests/issue_4138_split_cell_stale_linesegs.rs` — stale 0 + 사다리 단조 +
+  195쪽 핀, into/범위 분할 2경로. red→green(원복 시 stale 2,498/118쪽) 확인.
+- 인접 focused 20 tests green (1073/1750/2158/2299/3236/3593/3595/3637 —
+  2158/2299/3593 은 분리한 `apply_cell_vpos_ladder` 경유 reset-preserve 의미론 핀).
+- 시각 증적: `mydocs/pr/assets/pr_4138_{presplit,before,after}_p{0,1}.png` —
+  before 는 이슈 "실제" 스크린샷 재현, after 는 한컴 기대 이미지와 1.1.2 줄바꿈
+  일치(1.1.1 은 1개 줄바꿈 근소 차이 — 작업지시자 판정 대상).
+- PR #4122 merge(`accebdb20`) 후 devel 에 cherry-pick(`148bff3ef`)해 재검증 —
+  전체 게이트(fmt/clippy/release-test/native-skia 3종/wasm-pack) 결과는 stage1
+  문서 검증 기록에 기재.
+
+## 미해결 (후속)
+
+- (a) 중첩 표 host 문단의 잔존 stale seg — 한컴의 분할 시 중첩 표 리스케일 여부
+  오라클 미확인(이슈 이미지 범위 밖). 테스트에서 계약 밖으로 명시 제외.
+- 분할 후 전체 문서 쪽수(195)의 한컴 실측 대조 — 한컴 편집기 환경 필요.
+- 병합(폭 확대) 경로의 reflow 부재 — 별도 이슈 후보.

--- a/mydocs/working/task_m100_4031_stage1.md
+++ b/mydocs/working/task_m100_4031_stage1.md
@@ -1,0 +1,111 @@
+# Task M100 #4031 Stage 1 완료보고서 — 거대 셀 Enter 지연 기준선과 red contract
+
+## 1. 목적
+
+이슈 #4031(pending pagination 중 Enter의 중복 full pagination 제거) Stage 1: 최신
+`upstream/devel@9f564bbe`에서 115쪽 거대 셀 문서의 cold Enter와 pending Enter 전 구간을
+분해 계측하고, "pending cell Enter = full flush 1 + full pagination 1" 중복 계약을 수치로
+고정한다. flow 보드 Task #8(거대 셀 Enter 지연 해소)의 1단계 실측이기도 하다.
+
+## 2. 환경과 방법
+
+- macOS(Darwin 25.1.0), arm64, Rust release-test profile
+- fixture: `samples/issue1949_giant_cell_nested_tables_perf.hwp/.hwpx` (115쪽, 2,507문단 거대 셀)
+- probe: `tests/issue_4031_enter_latency_probe.rs` (신규, `#[ignore]` local-only)
+  - cold: 새 load 뒤 셀 상단(문단 5)·하단(끝-8) 각 3연타 `split_paragraph_in_cell_native`
+  - pending: 56회 deferred insert 잔여 상태에서
+    시나리오 A = `flush_deferred_pagination()` → split (현행 studio before-navigation 경로),
+    시나리오 B = flush 생략(`cancel_deferred_pagination`) → split → 사후 flush 비용 확인
+- `RHWP_2424_PROFILE=1`로 pagination subphase·block-table·continuation cursor timer 동시 기록
+- `RHWP_4031_REPEATS=3`, timing assertion 없음. page count 정합만 단언
+
+명령:
+
+```bash
+CARGO_TARGET_DIR=... cargo test --profile release-test --test issue_4031_enter_latency_probe --no-run
+RHWP_2424_PROFILE=1 RHWP_4031_REPEATS=3 cargo test --profile release-test \
+  --test issue_4031_enter_latency_probe -- --ignored --nocapture --test-threads=1
+```
+
+측정 중 dev 서버 등 배경 부하로 run 2부터 절대값이 약 3배까지 드리프트했다(run 1 첫
+값 1130ms는 #2424 Stage A 기준선 1058ms와 정합). 따라서 아래에서 절대값은 run 1을,
+구조 결론(패스 수·fragment 수·비율)은 36개 전 표본을 근거로 삼는다.
+
+## 3. cold Enter — 키 1회가 전체 표 재조판을 소유한다
+
+run 1 기준(ms):
+
+| 형식 | 상단 3연타 | 하단 3연타 |
+|---|---|---|
+| HWP | 1130 / 1124 / 1173 | 1192 / 1530 / 2230 |
+| HWPX | 2238 / 2394 / 2416 | 3133 / 3264 / 2871 |
+
+36개 전 표본에서 예외 없이:
+
+1. split 1회 = `paginate_pass` 정확히 1회. `RHWP_2424_PAGINATION_PROFILE`에서
+   typeset_ms가 total의 98.5~99.2% (measure 15~44ms, invalidate/normalize/postprocess < 1ms).
+2. `RHWP_2424_CONTINUATION_CURSOR fragments=115~116`: 편집 위치가 셀 상단이든 하단이든
+   block-table continuation이 **115~116개 fragment 전부를 매번 처음부터 drain**한다.
+   상한·하한 어디를 편집해도 비용이 같다 — fragment 증분 재개 부재(보드 Task #8 이론 3)의
+   직접 증거다.
+3. 셀 편집은 `para_offset = 0`이라 기존 CONVERGENCE(수렴 재사용) 기계가 아예 시도되지
+   않는다. 본문 문단 offset 기반이므로 셀 내부 편집에는 적용 불가.
+
+## 4. pending Enter — flush 1 + pagination 1 중복 (red contract)
+
+3회 × HWP/HWPX(ms, 같은 배경 부하 아래 상대 비교):
+
+| run | 형식 | A: flush | A: split | A 합계 | B: skip-flush split | B: 사후 flush |
+|---|---|---:|---:|---:|---:|---:|
+| 1 | HWP | 3423 | 3365 | 6788 | 3327 | 0.119 |
+| 1 | HWPX | 4467 | 4126 | 8593 | 3514 | 0.088 |
+| 2 | HWP | 3576 | 3832 | 7409 | 3830 | 0.116 |
+| 2 | HWPX | 3710 | 3502 | 7212 | 3477 | 0.160 |
+| 3 | HWP | 3531 | 3650 | 7180 | 3838 | 0.123 |
+| 3 | HWPX | 3858 | 3796 | 7654 | 3453 | 0.106 |
+
+1. 현행 경로(A)는 **full pagination 2회**로 단일 split의 약 2배다. flush가 계산한 분할 전
+   pagination은 split 직후 통째로 폐기된다 — #4031 배경 그대로.
+2. flush를 생략한 B는 split의 `paginate_if_needed()` 1회로 수렴하며, 최종 page count가
+   A와 **완전 일치**했다(전 회 단언 통과).
+3. B의 사후 `flush_deferred_pagination()`은 0.088~0.160ms의 사실상 no-op이다
+   (`status=fallback`, dirty 구역 없음). 즉 split의 동기 pagination이 deferred descriptor를
+   소비한 뒤에는 잔여 barrier 비용이 없다 — Stage 2 cancellation 계약의 native 불변식이
+   이미 성립한다. `cancel_deferred_pagination()`/`cancelDeferredPagination`도 이미 노출돼 있다.
+
+## 5. 코드 경로 확정 (Stage 2 입력)
+
+- direct Enter: `input-handler-keyboard.ts` keydown 상단
+  `PAGINATION_BOUNDARY_KEYS.has('Enter')` → `flushDeferredPaginationIfNeeded('before-navigation')`
+  → 같은 함수 하단 `case 'Enter'` → (셀이면) `SplitParagraphInCellCommand` →
+  `splitParagraphInCell*` → native `paginate_if_needed()` 재차 full pagination.
+- flush 지점(547행)과 `case 'Enter'`(1215행)는 **같은 keydown 함수 스코프**다. admission
+  판정을 지역 변수로 전달할 수 있어 인스턴스 상태 누수 없이 구현 가능하다.
+- `SplitParagraphInCellCommand`는 `consumeTextMutationEffects`를 구현하지 않아 실행 후
+  `deferredPaginationPending`이 자동 해소되지 않는다 → 성공한 split이 pagination을
+  소유했음을 반영하는 명시적 상태 전이가 필요하다.
+- IME 경로: `input-handler-text.ts` `processPendingNav`의 `code === 'Enter'`는 **조합 확정만
+  하고 문단 분할이 없다**(169~171행). 구조 명령이 뒤따르지 않으므로 이 flush는 최신
+  모델의 유일한 pagination barrier다 — 중복이 아예 없고, 취소하면 오히려 pagination이
+  runner 완주까지 표류한다. Stage 2 admission은 direct keydown 경로에만 연다(fail-closed).
+  IME 경로의 flush 비용 자체는 fragment 증분 재개(후속)의 몫이다.
+
+## 6. 다음 단계 판정
+
+1. Stage 2(이 브랜치): direct cell Enter 한정 command-aware admission —
+   flush 대신 runner/timer 취소 + `wasm.cancelDeferredPagination()`, 성공한 split이
+   pagination·cursor geometry invalidation을 소유, 실패 시 기존 full-flush로 fail-closed.
+   기대 효과: pending Enter 약 2×→1×(cold Enter와 동급).
+2. cold Enter 자체(~1초, wasm은 그 이상)는 §3의 fragment 전량 drain이 지배 항이다.
+   해소는 보드 Task #8 본체인 "편집 행이 속한 fragment부터 재개, 상위 fragment 재사용"
+   증분 재조판이며 PR #4122(canonical cell unit + 재귀 cursor) 병합 후 착수한다(별도 후속).
+3. Stage A probe는 before/after 비교가 끝날 때까지 진단 자산으로 유지한다.
+
+## 7. 검증
+
+| 게이트 | 결과 |
+|---|---|
+| probe `--no-run` 빌드 | 통과 |
+| probe 2 tests × 3 repeats (HWP/HWPX) | 2 passed, 0 failed (236.39s) |
+| page count 정합 단언 (A=B, 전 회) | 통과 |
+| `cargo fmt --all -- --check` | 커밋 전 확인 |

--- a/mydocs/working/task_m100_4031_stage1.md
+++ b/mydocs/working/task_m100_4031_stage1.md
@@ -51,6 +51,8 @@ run 1 기준(ms):
 3. 셀 편집은 `para_offset = 0`이라 기존 CONVERGENCE(수렴 재사용) 기계가 아예 시도되지
    않는다. 본문 문단 offset 기반이므로 셀 내부 편집에는 적용 불가.
 
+raw profile은 `mydocs/report/assets/task_m100_4031_stage1_baseline.log`에 보존한다.
+
 ## 4. pending Enter — flush 1 + pagination 1 중복 (red contract)
 
 3회 × HWP/HWPX(ms, 같은 배경 부하 아래 상대 비교):

--- a/mydocs/working/task_m100_4031_stage2.md
+++ b/mydocs/working/task_m100_4031_stage2.md
@@ -1,0 +1,64 @@
+# Task M100 #4031 Stage 2 완료보고서 — 셀 Enter command-aware cancellation
+
+## 1. 구현
+
+Stage 1(§5)에서 확정한 경로에 최소 변경 3점을 넣었다.
+
+### 1.1 admission — `isCommittedCellEnterSplit` (input-handler-keyboard.ts)
+
+이 keydown이 같은 함수 하단 `case 'Enter'`에서 `SplitParagraphInCellCommand`로 확정
+실행되는 좁은 조건만 통과시킨다. flush 지점과 `case 'Enter'` 사이의 조기 분기 전부를
+배제한다: modifier(Shift/Ctrl/Meta/Alt), IME 조합, form mode, 머리말/꼬리말, 각주,
+그림/표 객체 선택, 블록/셀 선택 모드, 선택 영역(deleteSelection 선행 방지), 그리고
+`isInCell()`. 하나라도 확신할 수 없으면 false → 기존 full flush로 fail-closed.
+
+`Enter`는 `PAGINATION_BOUNDARY_KEYS`에서 제거하지 않았다(구현 원칙 1·2). 판정 결과는
+같은 keydown 함수 스코프의 지역 상수 `committedCellEnterSplit`로 전달해 인스턴스 상태
+누수가 없다.
+
+### 1.2 계산 없는 취소와 소유 완료 (input-handler.ts)
+
+- `cancelDeferredPaginationForOwnedMutation()`: idle flush timer 취소 + runner 취소
+  (`runner.cancel()`이 전진 중이면 `wasm.cancelDeferredPagination()`까지 수행).
+  `wasm.flushDeferredPagination()`을 호출하지 않는 것이 flush 경로와의 유일한 차이.
+  `deferredPaginationPending`은 유지 — split 실패 시 다음 boundary flush가 기존 barrier
+  의미론으로 복구한다(fail-closed).
+- `completePaginationOwnedBySyncMutation()`: 성공한 native split의 `paginate_if_needed()`가
+  최신 revision을 계산했음을 반영 — pending 해소 + focused cell cursor geometry invalidate.
+  이후 boundary flush는 Stage 1 §4-3에서 실측한 대로 0.1ms no-op으로 수렴한다.
+
+### 1.3 배선 (input-handler-keyboard.ts)
+
+- boundary key 지점: admitted면 취소, 아니면 기존
+  `flushDeferredPaginationIfNeeded('before-navigation')`.
+- `case 'Enter'`의 inCell 분기: split 성공 시 `completePaginationOwnedBySyncMutation()`,
+  예외 시 `flushDeferredPaginationIfNeeded('cell-enter-split-fallback')` 후 rethrow.
+  완료/복귀 모두 `committedCellEnterSplit`가 참일 때만 수행한다.
+
+### 1.4 IME 경로는 의도적으로 비대상
+
+`processPendingNav`의 `code === 'Enter'`는 조합 확정만 하고 structural command가 없다
+(stage1 §5). 그 flush는 최신 모델의 유일한 pagination barrier이므로 유지한다. 취소하면
+115쪽 문서에서 idle auto-flush 상한 밖이라 pagination이 runner 완주까지 표류한다.
+이슈의 "direct와 IME를 같은 계약으로"는 "admission을 증명한 경우에만 flush를 생략"이라는
+같은 규칙의 적용이며, IME 경로는 admission(구조 명령 확정)이 성립하지 않는다.
+
+## 2. 검증
+
+| 게이트 | 결과 |
+|---|---|
+| `tests/cell-enter-owned-pagination.test.ts` (신규 5 계약) | 5 passed |
+| Studio `npm test` 전체 | 768 passed, 0 failed |
+| `npx tsc --noEmit` | 신규 오류 0 (기존 `@wasm/rhwp.js` 미빌드 오류만) |
+| production wasm + browser 실측 | Stage 3에서 수행 |
+
+계약 테스트 5종: ① boundary flush의 admitted/비admitted 분기, ② admission guard 전수,
+③ split 성공→소유 완료·실패→fallback 순서, ④ 소유 취소의 pending 유지(fail-closed)와
+완료 선언의 pending 해소, ⑤ IME 경로 flush 보존.
+
+## 3. 기대 효과 (Stage 1 native 실측 기준)
+
+pending cell Enter = full pagination 2회 → 1회. 시나리오 B 실측으로 최종 page count가
+flush-then-split과 완전 일치하고 사후 flush가 0.1ms no-op임을 확인했다. 브라우저
+전 구간(direct/IME × HWP/HWPX × 3회)과 acceptance criteria(중앙값 cold 110% 이내 등)는
+Stage 3에서 production wasm으로 측정한다.

--- a/mydocs/working/task_m100_4031_stage2.md
+++ b/mydocs/working/task_m100_4031_stage2.md
@@ -16,26 +16,37 @@ Stage 1(§5)에서 확정한 경로에 최소 변경 3점을 넣었다.
 같은 keydown 함수 스코프의 지역 상수 `committedCellEnterSplit`로 전달해 인스턴스 상태
 누수가 없다.
 
-### 1.2 계산 없는 취소와 소유 완료 (input-handler.ts)
+### 1.2 계산 없는 취소 (input-handler.ts)
 
-- `cancelDeferredPaginationForOwnedMutation()`: idle flush timer 취소 + runner 취소
-  (`runner.cancel()`이 전진 중이면 `wasm.cancelDeferredPagination()`까지 수행).
-  `wasm.flushDeferredPagination()`을 호출하지 않는 것이 flush 경로와의 유일한 차이.
-  `deferredPaginationPending`은 유지 — split 실패 시 다음 boundary flush가 기존 barrier
-  의미론으로 복구한다(fail-closed).
-- `completePaginationOwnedBySyncMutation()`: 성공한 native split의 `paginate_if_needed()`가
-  최신 revision을 계산했음을 반영 — pending 해소 + focused cell cursor geometry invalidate.
-  이후 boundary flush는 Stage 1 §4-3에서 실측한 대로 0.1ms no-op으로 수렴한다.
+`cancelDeferredPaginationForOwnedMutation()`: idle flush timer 취소 + runner 취소
+(`runner.cancel()`이 전진 중이면 `wasm.cancelDeferredPagination()`까지 수행).
+`wasm.flushDeferredPagination()`을 호출하지 않는 것이 flush 경로와의 유일한 차이.
+`deferredPaginationPending`은 유지 — split 실패 시 다음 boundary flush가 기존 barrier
+의미론으로 복구한다(fail-closed).
 
-### 1.3 배선 (input-handler-keyboard.ts)
+### 1.3 완료 소유 — command effects 선언 (command.ts)
+
+`SplitParagraphInCellCommand.execute`가 native split 성공 뒤
+`IMMEDIATE_TEXT_MUTATION_EFFECTS`(paginationCompleted)를 선언한다. 기존
+`executeOperation → prepareTextMutationBeforeCursor` effects 경로가 pending 해소·runner
+취소·focused cursor geometry invalidation을 수행하므로, 직후 `afterEdit`의
+`before-full-edit` flush가 no-op 판정(shouldFlush=false)으로 wasm 호출 없이 끝난다.
+예외 시 effects는 `NO_TEXT_MUTATION_EFFECTS`로 남아 아무것도 해소하지 않는다.
+
+처음에는 keydown에서 명시적 완료 메서드를 호출했으나, e2e가 split 직후 `afterEdit`의
+`before-full-edit` flush 1회(native no-op이지만 wasm 호출)를 검출했다 — 완료 선언이
+executeOperation의 refresh보다 늦었기 때문이다. effects 선언은 이 순서 문제를 기존
+계약 안에서 해소하며 undo/redo·비admitted 경로에도 동일하게 정합적이다.
+
+### 1.4 배선 (input-handler-keyboard.ts)
 
 - boundary key 지점: admitted면 취소, 아니면 기존
   `flushDeferredPaginationIfNeeded('before-navigation')`.
-- `case 'Enter'`의 inCell 분기: split 성공 시 `completePaginationOwnedBySyncMutation()`,
-  예외 시 `flushDeferredPaginationIfNeeded('cell-enter-split-fallback')` 후 rethrow.
-  완료/복귀 모두 `committedCellEnterSplit`가 참일 때만 수행한다.
+- `case 'Enter'`의 inCell 분기: 예외 시
+  `flushDeferredPaginationIfNeeded('cell-enter-split-fallback')` 후 rethrow.
+  fallback은 `committedCellEnterSplit`가 참일 때만 수행한다.
 
-### 1.4 IME 경로는 의도적으로 비대상
+### 1.5 IME 경로는 의도적으로 비대상
 
 `processPendingNav`의 `code === 'Enter'`는 조합 확정만 하고 structural command가 없다
 (stage1 §5). 그 flush는 최신 모델의 유일한 pagination barrier이므로 유지한다. 취소하면
@@ -47,14 +58,17 @@ Stage 1(§5)에서 확정한 경로에 최소 변경 3점을 넣었다.
 
 | 게이트 | 결과 |
 |---|---|
-| `tests/cell-enter-owned-pagination.test.ts` (신규 5 계약) | 5 passed |
-| Studio `npm test` 전체 | 768 passed, 0 failed |
-| `npx tsc --noEmit` | 신규 오류 0 (기존 `@wasm/rhwp.js` 미빌드 오류만) |
-| production wasm + browser 실측 | Stage 3에서 수행 |
+| `tests/cell-enter-owned-pagination.test.ts` (신규 6 계약) | 6 passed |
+| Studio `npm test` 전체 | 769 passed, 0 failed |
+| `npx tsc --noEmit` (wasm pkg 빌드 후) | 통과 |
+| `npm run build` (tsc + vite build) | 통과 |
+| `cargo clippy --profile release-test --test issue_4031_enter_latency_probe -- -D warnings` | 통과 |
+| production wasm + headless Chrome e2e | §4 |
 
-계약 테스트 5종: ① boundary flush의 admitted/비admitted 분기, ② admission guard 전수,
-③ split 성공→소유 완료·실패→fallback 순서, ④ 소유 취소의 pending 유지(fail-closed)와
-완료 선언의 pending 해소, ⑤ IME 경로 flush 보존.
+계약 테스트 6종: ① boundary flush의 admitted/비admitted 분기, ② admission guard 전수,
+③ split 성공→effects 완료 선언·실패→fallback, ④ effects paginationCompleted의
+pending 해소·runner 취소·geometry invalidation, ⑤ 소유 취소의 pending 유지(fail-closed),
+⑥ IME 경로 flush 보존.
 
 ## 3. 기대 효과 (Stage 1 native 실측 기준)
 

--- a/mydocs/working/task_m100_4031_stage3.md
+++ b/mydocs/working/task_m100_4031_stage3.md
@@ -1,0 +1,56 @@
+# Task M100 #4031 Stage 3 완료보고서 — production wasm 실브라우저 검증
+
+## 1. 방법
+
+- production wasm(`wasm-pack build --target web --out-dir pkg`) + 이 worktree 전용
+  Vite(포트 7710) + headless Chrome(puppeteer)
+- 신규 e2e `rhwp-studio/e2e/cell-enter-pagination-issue4031.test.mjs`
+  (`npm run e2e:issue-4031-cell-enter`, `VITE_URL`·`CHROME_PATH` 환경 변수)
+- HWP/HWPX 각각: 115쪽 로드 → 거대 셀(문단 5, offset 130)로 이동 → 실키 `111` 입력으로
+  pending deferred pagination 생성 → 실키 Enter → 계약 단언 → 사후 flush oracle →
+  실키 `1` + ArrowDown으로 barrier 대조군 단언
+
+## 2. 결과
+
+| 형식 | Enter dispatch | `wasm.flushDeferredPagination` | split | 사후 flush oracle | ArrowDown barrier |
+|---|---:|---:|---:|---|---:|
+| HWP | 1015ms | 0회 | 1회 | pages 불변(fallback no-op) | flush 1회 |
+| HWPX | 1813ms | 0회 | 1회 | pages 불변(fallback no-op) | flush 1회 |
+
+추가 단언 전부 통과: pending 해소, 셀 문단 수 +1, 분할점 offset 133(삽입 3자 반영),
+caret은 새 문단 시작(cellParaIndex+1, offset 0).
+
+acceptance criteria 대응:
+
+- admitted pending cell Enter의 pre-navigation full flush 0회 ✓ (총 wasm flush 호출 0회)
+- structural full pagination 1회(split 소유) ✓
+- pending Enter가 cold Enter와 같은 단일 pagination 구조로 수렴(Stage 1의 2×→1×) ✓
+- 문자열·문단 split·caret·쪽수 정합 ✓, 사후 flush oracle pages 불변 ✓
+- 비Enter boundary key(ArrowDown)의 기존 barrier 유지 ✓
+- IME 예약 Enter 경로 flush 보존은 unit 계약(⑥)으로 고정
+
+## 3. 최초 구현에서 잡힌 결함
+
+첫 e2e 실행이 admitted Enter에서 wasm flush 1회를 검출했다: keydown의 명시적 완료
+호출이 `executeOperation` 내부 refresh(`afterEdit`의 `before-full-edit` flush)보다 늦어
+pending이 남아 있었다. `SplitParagraphInCellCommand`가
+`IMMEDIATE_TEXT_MUTATION_EFFECTS`를 선언하는 방식으로 교체해 기존 effects 경로가
+refresh 이전에 pending을 해소하도록 했다(stage2 §1.3). 재실행에서 0회 확인.
+
+## 4. 게이트 요약
+
+| 게이트 | 결과 |
+|---|---|
+| e2e HWP/HWPX 계약 전부 | 통과 |
+| Studio `npm test` | 769 passed |
+| `npx tsc --noEmit` / `npm run build` | 통과 |
+| e2e MANIFEST 검사 (`check_e2e_manifest.py`) | 이상 없음 |
+| `cargo fmt`·`clippy`(probe) | 통과 |
+
+## 5. 남은 후속
+
+- cold Enter 자체(~1s wasm)는 fragment 전량 drain이 지배 항 — 보드 Task #8 본체
+  "편집 행 fragment부터 재개" 증분 재조판으로 해소하며 PR #4122 병합 후 착수
+  (stage1 §6-2).
+- 브라우저 direct/IME × 3회 반복 중앙값 리포트는 PR 리뷰 시점에 위 e2e를 반복 실행해
+  첨부할 수 있다(계약 단언은 이미 자동화).

--- a/mydocs/working/task_m100_4138_stage1.md
+++ b/mydocs/working/task_m100_4138_stage1.md
@@ -129,6 +129,9 @@ Issue: [#4138](https://github.com/edwardkim/rhwp/issues/4138) (외부 리포트:
   의미론을 직접 핀하는 스위트.
 - `cargo fmt --check`: 본 과제 변경 파일 clean (잔여 diff 는 타 세션의 임시 프로브
   `tests/tmp_bold_probe.rs` 뿐 — 본 과제 밖).
-- release-test 전체·clippy 전체는 PR CI 성격이므로 작업지시자 승인 후 실행 예정
-  (`pr_review` 게이트 규칙). 시각 증적(분할 전후 렌더 비교)은 studio 브라우저 경로로
-  후속 확보 예정 — 분할 op 이 CLI 미노출이라 네이티브 export 로는 재현 불가.
+- 전체 게이트 (2026-08-07, 작업지시자 완주 지시로 실행 — merge 된 #4122 포함
+  devel 기준 rebase 커밋, 격리 worktree): fmt PASS · clippy(-D warnings) PASS ·
+  release-test `--tests` PASS(**5,350 passed / 0 failed**, 473 targets) ·
+  native-skia 3종 PASS · wasm-pack build PASS.
+- 시각 증적: `render_page_svg_native` 로 네이티브 확보 (위 "시각 증적" 절) —
+  studio 브라우저 경로 불요했음. studio wasm 도 재빌드해 실기 확인 경로 제공.

--- a/mydocs/working/task_m100_4138_stage1.md
+++ b/mydocs/working/task_m100_4138_stage1.md
@@ -1,0 +1,134 @@
+---
+kind: working
+status: active
+last_verified: 2026-08-07
+---
+
+# Task #4138 Stage 1 — 셀 나누기 후 stale line_segs·vpos 사다리 붕괴 수정
+
+Issue: [#4138](https://github.com/edwardkim/rhwp/issues/4138) (외부 리포트: glyph truncation)
+브랜치: `fix/issue-4138-split-cell-stale-linesegs` (기준: `upstream/devel` 9f564bbee)
+
+## 증상과 원인 (2단)
+
+재현: `samples/issue1949_giant_cell_nested_tables_perf.hwp` 에서 셀 나누기(2행 셀을 1×2 분할).
+
+1. **glyph truncation** — `split_table_cell_into_native`(src/document_core/commands/table_ops.rs)가
+   `Table::split_cell_into`(src/model/table.rs)로 셀 폭을 44790→22395 로 바꾸면서 저장
+   line_segs 재계산을 생략한다. 렌더러(`LayoutEngine::layout_paragraph`,
+   src/renderer/paragraph_layout.rs)는 저장 줄을 그대로 그리므로 옛 폭(seg 폭 44508) 기준
+   줄이 새 셀 클립 경계에서 잘린다. 실측: 분할 뒤 4,321 seg 전부 stale, 새 sibling 셀도
+   원본 line_segs 를 클론해 같은 폭을 물려받음.
+2. **페이지 과소 적재** — 1에 per-para reflow 만 배선하면 `reflow_line_segs` 가 각 문단의
+   vpos 원점을 보존한 채 내부 줄만 다시 싸므로(4,321→7,484 seg), 줄 수가 늘어난 문단 뒤에서
+   사다리가 역행한다(실측: para[5] 끝 22920 뒤 para[6] 시작 17160). 컷 기계는 저장 vpos
+   역행을 RowBreak hard break 신호로 읽어 페이지를 과소 적재한다(118→222쪽; 한컴 오라클
+   기대 이미지는 1.1.1 뒤에 1.1.2 가 같은 쪽에 이어짐).
+
+## 수정
+
+- `reflow_stale_cells_after_split`(table_ops.rs, 신규): 저장 seg 폭이 셀 폭을 넘는
+  셀(= 옛 폭 기준 stale — seg 폭은 항상 패딩만큼 셀 폭보다 작게 계산되므로 초과는 확정
+  증거)을 골라 전 문단을 `reflow_cell_paragraph` 로 재래핑한 뒤, 셀 단위로 vpos 사다리를
+  단조 재구축한다. `resize_table_cells_native` 의 reflow 계약을 분할 3형제 전부에 적용:
+  - `split_table_cell_native` (병합 셀 복원 분할)
+  - `split_table_cell_into_native` (N×M 분할)
+  - `split_table_cells_in_range_native` (범위 분할)
+- `rebuild_table_cell_vpos_ladder_native`(text_editing.rs, 신규): 셀 문단 전 구간을 정지
+  없이 재배치한다. `recalculate_cell_paragraph_vpos` 는 저장 vpos 역행을 RowBreak 조각
+  경계 신호로 존중해 그 앞에서 멈추지만, 셀 폭이 바뀌어 모든 문단을 재래핑한 직후에는
+  저장 경계 자체가 옛 폭 기준이라 신호가 아니다. 간격 계산(문단 간격 boundary_gaps +
+  줄간격)은 기존 적용 루프를 `apply_cell_vpos_ladder` 로 분리해 텍스트 편집 경로와
+  공유한다 — 초기 실험의 ad-hoc 누적 커서(간격 무시)를 대체.
+
+## undo 대칭 (남은 항목 c — 해소)
+
+셀 나누기는 studio 에서 스냅샷 undo 로 라우팅된다. 증거 체인:
+`table:cell-split`(rhwp-studio/src/command/commands/table.ts, `kind: 'snapshot'`) →
+`SnapshotCommand`(rhwp-studio/src/engine/command.ts) → `save_snapshot_native` /
+`restore_snapshot_native`(src/document_core/commands/document.rs)가 `Document` 전체를
+클론·복원한다. line_segs 는 `Document` 안에 있으므로 undo 시 구 line_segs 가 자동
+복원된다. 코어 측 추가 작업 불요.
+
+## 실측 (native release, 동일 표본 1×2 분할)
+
+| 구성 | stale | 사다리 역행 | 쪽수 |
+| --- | --- | --- | --- |
+| 수정 전 | 2,498문단 / 4,321seg | — | 118 |
+| reflow만 | 0 | 발생 | 222 |
+| reflow + 사다리 재구축(본 수정) | 0 | 0 | 195 |
+
+- 195쪽이 한컴 실측 쪽수와 일치하는지는 **미확인** (남은 항목 — 오라클 필요).
+- 회귀 테스트: `tests/issue_4138_split_cell_stale_linesegs.rs` 2건 green,
+  수정 원복 시 stale 2,498 로 red 확인(red→green).
+
+## 성능 계측 (남은 항목 d — 원인 규명, 본 수정 밖으로 판정)
+
+`RHWP_2424_PROFILE=1` + 임시 프로브 실측 (native release):
+
+| 단계 | 시간 |
+| --- | --- |
+| 파싱 + 초기 페이지네이션(115쪽) | 1.12s (`typeset_ms=1095`) |
+| 분할 호출 전체 | 3.43s |
+| ├ 분할 후 재조판(195쪽) | 3.33s (`typeset_ms=3308`, `RHWP_2424_BLOCK_TABLE_PROFILE`) |
+| └ reflow + 사다리 재구축 + recompose (**본 수정이 추가한 비용**) | **≈0.10s** |
+
+과제 설명의 "3.97s 성능 주의"는 본 수정의 reflow 가 아니라 **분할 뒤 195쪽 거대 표
+전체 재조판**(`typeset_block_table_inner`, 쪽수 비례 ~17ms/쪽)이다. 이는 Task #8
+(거대 셀 fragment 단위 증분 재조판)의 대상과 동일한 병목이므로 이 과제에서 더
+최적화하지 않는다.
+
+## 오라클 대조 (2026-08-07, issue #4138 첨부 이미지)
+
+이슈의 한컴 기대 이미지(분할 후)와 본 수정 후 렌더(0쪽)를 대조했다:
+
+- 기대 이미지: 분할된 왼쪽 셀에서 1.1.1·1.1.2 본문이 좁은 폭으로 완전히 재래핑되고
+  1.1.2 가 1.1.1 과 같은 쪽에 이어진다. 실제(결함) 이미지: 1.1.2 줄이 옛 폭으로
+  그려져 셀 경계에서 잘린다("치수는 ㅈ", "해양수ㅅ").
+- 본 수정 후 렌더는 1.1.2 문단의 줄바꿈 위치가 기대 이미지와 줄 단위로 일치한다
+  ("각 부재 치수는 / 직접강도 계산에 따라 결정하며, / 계산에 사용되는 자료와 그 결과
+  / 를 해양수산부장관에 제출하여야 …"). 1.1.1 은 1개 줄바꿈 위치가 근소하게 다르다
+  (기대 "모두 만족/하여야" vs 렌더 "모두 만/족하여야") — 최종 판정은 거버넌스에 따라
+  작업지시자 권위.
+- 첨부 이미지는 중첩 표 영역을 포함하지 않아 (a)의 중첩 표 리스케일 여부는 이
+  오라클로 판정 불가 — 계속 미해결.
+
+## 시각 증적 (mydocs/pr/assets/)
+
+`HwpDocument::render_page_svg_native` 로 생성 (0–1쪽), qlmanage 로 PNG 변환:
+
+- `pr_4138_presplit_p0.{svg,png}` — 분할 전 원본
+- `pr_4138_before_p{0,1}.{svg,png}` — 분할 후, 수정 원복(HEAD~1 소스) — 잘림 재현
+- `pr_4138_after_p{0,1}.{svg,png}` — 분할 후, 본 수정 — 기대 이미지와 정합
+
+## 남은 항목
+
+- (a) 중첩 표 host 문단의 잔존 stale seg: `reflow_line_segs` 는 텍스트 없이 컨트롤만
+  호스팅하는 문단에서 원본 seg 폭 template 을 보존한다. 한컴이 분할 시 중첩 표를
+  리스케일하는지 오라클 확인 필요(이슈 첨부 이미지 범위 밖). 회귀 테스트는 이 문단들을
+  계약 밖으로 명시 제외.
+- (f) PR #4122(#4069 canonical cell unit·frame 경계 reset 해석) 2026-08-07 **merge 됨**
+  (`accebdb20`) — 본 브랜치를 merge 후 devel 로 rebase(cherry-pick `148bff3ef`)하고
+  회귀 테스트·게이트를 재실행해 재검증 (검증 기록 참조).
+- 후속 후보: `merge_table_cells` / 폭이 **넓어지는** 방향(병합)은 seg 폭 < 셀 폭이라
+  본 판별(초과 검사)에 걸리지 않고, 병합 경로에도 reflow 배선이 없다 — 줄이 좁게 남는
+  cosmetic 결함. 별도 이슈로 분리 검토.
+- 한컴 실측 쪽수(분할 후 전체 문서) 대조는 한컴 편집기 환경 필요 — 작업지시자 판정
+  대상으로 이관.
+
+## 검증 기록
+
+- `cargo test --release --test issue_4138_split_cell_stale_linesegs` — 2 passed (4.7s)
+- red 확인: table_ops.rs 수정만 stash 후 동일 테스트 → stale 2,498 로 FAILED, pop 복원
+- 인접 focused (release, 전부 green — 20 tests):
+  issue_1073_nested_table_split(3) · issue_1750_split_guard_spacing_before(1) ·
+  issue_2158_hwpx_vpos_reset_preserve(2) · issue_2299_edit_vpos_reset_preserve(8) ·
+  issue_3236_split_single_cell_table(1) · issue_3593_cell_para_vpos_anchor(2) ·
+  issue_3595_nested_split_row_identity(2) · issue_3637_split_cell_nested_table_vpos(1)
+  — 2158/2299/3593 은 이번에 분리한 `apply_cell_vpos_ladder` 경유 reset-preserve
+  의미론을 직접 핀하는 스위트.
+- `cargo fmt --check`: 본 과제 변경 파일 clean (잔여 diff 는 타 세션의 임시 프로브
+  `tests/tmp_bold_probe.rs` 뿐 — 본 과제 밖).
+- release-test 전체·clippy 전체는 PR CI 성격이므로 작업지시자 승인 후 실행 예정
+  (`pr_review` 게이트 규칙). 시각 증적(분할 전후 렌더 비교)은 studio 브라우저 경로로
+  후속 확보 예정 — 분할 op 이 CLI 미노출이라 네이티브 export 로는 재현 불가.

--- a/mydocs/working/task_m100_4146_cell_enter_latency_stage1.md
+++ b/mydocs/working/task_m100_4146_cell_enter_latency_stage1.md
@@ -1,0 +1,13 @@
+---
+kind: working
+status: completed
+issue: 4146
+last_verified: 2026-08-08
+---
+
+# Task #4146 Stage 1
+
+## 구현·검증
+
+- integration 검증 트리에서 커밋 4개 리프트(936574fbe→b4ea54350→b2e9a1da3→8d2a1b802, #4031 스테이지 명명) — probe/perf/fix/e2e.
+- 검증: 레이어 전체 게이트 ALL-PASS. 브라우저 실측(선행 세션): 셀 Enter 지연 해소, Enter 경로 계약 e2e 녹색.

--- a/mydocs/working/task_m100_4151_stage1.md
+++ b/mydocs/working/task_m100_4151_stage1.md
@@ -1,0 +1,30 @@
+---
+kind: working
+status: completed
+issue: 4151
+last_verified: 2026-08-08
+---
+
+# Task #4151 Stage 1 - 셀 블록 서식 토글 방향·툴바 동기화
+
+## 구현
+
+- `getCharPropertiesAtCellBlockAnchor`(블록 첫 셀 첫 글자) 단일 기준 신설 — 토글 방향과
+  툴바 상태 방출이 공유한다.
+- `applyToggleFormat`: 셀 블록 모드에서 `getCharPropertiesAtCursor()`(블록 밖을 읽음 — 재적용
+  원인) 대신 블록 앵커 기준. 빈 블록(전 셀 제외)은 앵커가 없어 커서 폴백 — `applyCharFormat`이
+  빈 블록에서 조기 종료하므로 방향은 무해(upstream #4119 빈 블록 의미 보존).
+- `applyCharFormatToCellBlock`: 적용 직후 앵커 셀 기준 `cursor-format-changed` 방출(try/catch,
+  실패 시 다음 캐럿 이동에서 자연 동기화).
+
+## 검증 결과
+
+- 신규 #4151 소스 계약 테스트 3종: 토글 방향 블록 분기 존재/앵커 함수 사용, 적용 후 방출이
+  executeOperation 뒤에 앵커 기준으로 존재, 앵커 기준이 첫 셀 첫 글자 — red 증명: 수정 전
+  파일(HEAD)에서 3종 전부 FAIL 확인 후 green.
+- `tests/cell-block-format.test.ts` + `tests/mutation-routing-guard.test.ts`: 27 passed / 0.
+- 실브라우저(:7701, hwp_table_test_saved 2×2 표, 셀 0-1 블록): pre bold=false·버튼 비활성 →
+  1클릭 두 셀 bold=true·버튼 즉시 활성·블록 유지 → 2클릭 두 셀 bold=false·버튼 비활성 —
+  wasm getCellCharPropertiesAt 로 문서 상태 직접 검증.
+- 참고: upstream #4119 의 빈 블록 의미 변화와의 병합은 rebase 시 수동 해소 — 빈 블록 길이
+  가드를 토글 방향 폴백에 추가.

--- a/mydocs/working/task_m100_4163_resize_observer_noise_stage1.md
+++ b/mydocs/working/task_m100_4163_resize_observer_noise_stage1.md
@@ -1,0 +1,13 @@
+---
+kind: working
+status: completed
+issue: 4163
+last_verified: 2026-08-08
+---
+
+# Task #4163 Stage 1
+
+## 구현·검증
+
+- integration 검증 트리의 미커밋 수정 리프트(rAF 가 같은 렌더링 프레임 안이라 루프를 못 벗어남을 실측 — setTimeout 0 이연 채택).
+- 검증: tsc ci-unit 무오류, studio suite 783/783, 레이어 전체 게이트 ALL-PASS 예정.

--- a/mydocs/working/task_m100_4167_stage1.md
+++ b/mydocs/working/task_m100_4167_stage1.md
@@ -1,0 +1,48 @@
+---
+kind: working
+status: completed
+issue: 4167
+last_verified: 2026-08-08
+---
+
+# Task #4167 Stage 1 - 셀 캐럿 rect fast path (페이지 트리 미빌드)
+
+## 구현
+
+- `get_cursor_rect_in_cell_native`를 fast→legacy 폴백 래퍼로 재구성, 기존 본문은
+  `cursor_rect_in_cell_via_page_tree`로 추출해 패리티 기준으로 삼았다.
+- fast path 는 "재구현"이 아니라 **생략 프로브** — production `layout_partial_table`를
+  대상 셀 하나만 방출하도록 재사용한다(`PartialTableCellProbe`/`ProbeCutPlan`/
+  `CellComposedStore` lazy compose). 셀 방출 루프는 셀-간 캐리가 없어(코드 명시 계약)
+  생략이 좌표를 바꾸지 않는다 — 패리티가 구성적으로 보장되는 부분을 최대화했다.
+- 셀 bbox/페이지 원점: pagination `PartialTable` 메타(행 범위·유닛 컷) + memoized
+  `cell_units` + `measured_tables` + `PageContent.layout` col_area. 컬럼 선두 아이템 +
+  단일 컬럼 + zone/wrap/미주 부재 게이트로 `y = col_area.y` 확정.
+- 줄 찾기: 저장 line_segs 불신(#4149 — 무편집 ~16% divergence) — production compose 경로
+  그대로(compose→recompose_for_cell_width→overflow 가드)를 컷 창 문단에만 lazy 적용,
+  캐럿 문단 이후 중단(Top 정렬 게이트로 안전).
+- 폴백 12종(캡션 센티널/다중컬럼/zone/wrap/미주/통페이지 표/TAC/반복 제목행/auto counter
+  개체(표 포인터 키 메모)/rowspan>1/windowed 증명 실패/run 미발견) — 전부 legacy 전체 경로로.
+
+## 검증 결과
+
+- 패리티(fast=Some 전 지점 legacy JSON `assert_eq!`): 거대 문서 **185/185 (100%)**,
+  hwp_table_test_saved 40/222, KTX 3/371 (저적중 원인은 컬럼 선두 PartialTable 전용 게이트 —
+  폴백 시 출력은 정의상 legacy 동일).
+- `--lib cursor_rect` 16 passed, 캐럿 전반 84 passed, getCursorRect 사용 통합 테스트 전부
+  (issue_1951/2164/2214/4126/4128/table_vpos_01/850/2069/1071/1308) pass, **전체 lib 3303/0**.
+- 적대 리뷰(별도 세션): ① 캐시 무효화 전수 추적(clear 호출자 2곳 — full paginate·deferred
+  commit) 반박 실패, ② 프로브-전량 동치(셀-간 mutable 필드 한 줄씩 검사 + 줄 경계 ±1 offset
+  11,962지점 차등) 반박 실패, ③ **편집 직후 일관성(최유망 각도)**: legacy 도 같은
+  `self.pagination` stale 메타를 읽는 대칭 구조 — deferred insert 직후 861지점·delete 직후
+  50지점·paginate 후 34지점 전부 일치, ④ 패리티 그리드 구멍 공격(추가 실문서 3종 — 다단+미주
+  0/259 게이트 정상, 보건소 208/286=73% 적중 — 전부 일치), ⑤ 게이트 역손실 +0.6%(노이즈).
+  CONFIRMED 0건.
+- 실측: `get_cursor_rect_in_cell_native` 17.5ms → **0.61ms** (약 28배), 웜 지연 어서션
+  `issue4149_fast_path_giant_cell_warm_latency_beats_legacy` 0.619ms/call.
+- 계측 재현물: `issue4149_adjacent_giant_cell_cursor_rect_latency_decomposition`(페이즈 분해),
+  `issue4149_adjacent_cursor_rect_profile_loop`(--ignored, macOS sample 용),
+  `issue4149_cell_lineseg_roundtrip_survey`(저장 line_segs 신뢰성 — composed 사용 설계 근거).
+- 알려진 한계: 세로쓰기 셀 실물 샘플 미확보(구조상 windowed 는 `text_direction != 0` 게이트
+  차단, Uncut 은 전량 compose 와 문자 그대로 동일 경로). 향후 게이트 완화 시
+  `reset_numbering_state` + replay 가 전제조건.

--- a/mydocs/working/task_m100_4167_stage2.md
+++ b/mydocs/working/task_m100_4167_stage2.md
@@ -1,0 +1,39 @@
+---
+kind: working
+status: completed
+issue: 4167
+last_verified: 2026-08-08
+---
+
+# Task #4167 Stage 2 - deferred 편집의 cell_units 지문 보존
+
+## 구현
+
+- Stage 1 이후 잔존 병목: deferred 셀 편집마다 `invalidate_cell_units_after_text_edit`가
+  편집 셀의 memoized units 를 전량 evict → 편집 직후 첫 캐럿 질의가 2,507문단 전량
+  recompose(native 11.2ms, `compose_paragraph` 지배)를 지불. IME 조합은 매 업데이트가
+  편집→질의라 매 키가 이 비용을 문다.
+- `LayoutEngine::cell_paragraph_units_fingerprint` — units 산출이 읽는 문단 입력만 해시:
+  line_segs (개수, vertical_pos, line_height, tag 의 synthetic 비트(bit 31)만), controls 수,
+  공백/빈 문단 클래스. `text_start`·`segment_width`는 제자리 타이핑에도 매 키 변하지만
+  units 산출이 읽지 않아 제외(전 구간 grep 근거). 원본 로드 tag 잔여 비트(예: 0x100000)는
+  reflow 미재방출로 첫 편집에서 무의미하게 지문을 바꿔 마스킹.
+- 편집 관문 2곳(셀 replace/insert impl·delete)에서 reflow 전후 지문 캡처 →
+  `invalidate_cell_units_after_text_edit(unit_fingerprint_unchanged)` — 불변이면 eviction
+  생략(캐시 벡터가 항등 유효), 변하면 종전대로 셀 단위 제거.
+
+## 검증 결과
+
+- 신규: `issue4167_fingerprint_unchanged_edit_retains_cell_units`(보존/제거 양분기),
+  `issue4167_units_fingerprint_sensitivity`(불변: text_start/segment_width/원본 tag 잔여 비트 —
+  변화: 줄 수/높이/synthetic/스페이서 클래스), `issue4167_units_fingerprint_doc_contract`
+  (실문서: 텍스트 문단 제자리 삽입 불변 — 공백 스페이서에 글자 삽입은 클래스 전이로 변화).
+- `issue2214_deferred_insert_uses_scoped_cache_eviction` 기대값을 "무조건 evict"에서
+  "지문 변화 시에만 evict"로 갱신(이력 주석 포함) — 실측상 두 phase 의 최종 삽입 모두 지문
+  불변이라 보존이 정답. #2214 나머지 8개 테스트 불변 pass.
+- 계측: `issue4149_deferred_edit_first_cursor_query_decomposition` — 편집 직후 find_pages
+  **11.2ms → 5.8~11.8µs**, 편집 직후 rect 질의 전체 ~0.66ms. 브라우저(wasm 재빌드 후) IME
+  조합 업데이트 58~62ms(기준) → 17~24ms(Stage 1까지) → **5.8~11.5ms**(Stage 2 포함),
+  일반 삽입 warm 1.6~6.8ms — 전 키스트로크 16ms 프레임 예산 안.
+- 전체 lib: **3,308 passed / 0 failed** (당시 트리 기준; 스택 재구성 후 레이어 게이트에서 재검증).
+- 진단 부산물: `issue4149_deferred_units_rebuild_profile_loop`(--ignored, sample 용).

--- a/mydocs/working/task_m100_4168_stage1.md
+++ b/mydocs/working/task_m100_4168_stage1.md
@@ -1,0 +1,41 @@
+---
+kind: working
+status: completed
+issue: 4168
+last_verified: 2026-08-08
+---
+
+# Task #4168 Stage 1 - find_metric 선계산 색인
+
+## 구현
+
+- `find_metric`을 `OnceLock` 선계산 색인 조회로 교체했다. 색인은
+  `HashMap<&'static str, [(metric, bold_fallback); 4]>` — 이름 단독 키라 임의 `&str`
+  조회(`Borrow<str>`)가 유지되고, (bold,italic) 4조합 슬롯을 legacy 3단 폴백 사다리와
+  같은 우선순위(정확 → bold-only(italic 요청 한정) → 이름 첫 엔트리 + `bold_fallback=bold`)로
+  선주입했다.
+- 기존 선형 스캔은 `legacy_find_metric`(cfg(test))으로 바이트 단위 보존해 등가성 오라클로
+  쓴다. `resolve_metric_alias`는 종전대로 조회 진입부에서 적용된다.
+
+## 검증 결과
+
+- 신규 `index_matches_legacy_linear_scan_exhaustively`: FONT_METRICS 600개 이름 전체 +
+  alias 좌변 67개 전체 + 미등록 이름(빈 문자열 포함) × bold/italic 4조합 전수에서 metric
+  포인터 동일성 + `bold_fallback` 일치 — pass.
+- `cargo test --profile release-test --lib font_metrics`: 8 passed / 0 failed.
+- 적대 리뷰(별도 세션): 테이블 중복 트리플 0건 확인, alias 양방향 누락 0, NFD 자모·NUL·
+  30,000자 장문 등 ~3,600 이름 × 4조합 공격 전수 일치, 16스레드 최초 사용 경합 3회 통과,
+  wasm32 check 통과 — 반박 실패(등가성 결함 0건).
+- 실측(거대 셀 문서, release-test): `build_page_tree` ≈20.7ms → ≈17.2ms, 캐럿 질의
+  ≈21.5ms → ≈17.2ms (프로파일 귀속 ~16%와 부합).
+- 알려진 후속: `src/tools/font_metric_gen.rs` 생성기가 구식 선형 스캔을 방출한다(선재
+  드리프트) — 재생성 시 본 색인·테스트가 소실되므로 생성기 갱신을 별도 이슈로 권고.
+
+## 부수 발견 — #4181
+
+게이트 실행 중 `tests/issue_2007_nested_cell_pagination`(p15-16)이 이 레이어에서 비결정
+실패함을 발견, 원인 격리 결과 **devel 선재의 힙 할당 순서 민감성**으로 확정했다(#4181):
+의미 무변경 대조군(색인 빌드만 하고 legacy 스캔 사용, 캐시 value 8바이트 확장) 둘 다 동일
+플레이크를 재현하고, 색인 결과 등가성은 전수·10회 프로세스 반복으로 증명됨. 본 레이어
+게이트는 해당 바이너리를 직렬 재시도로 통과 확인(3회 내 pass)하고 나머지 전 게이트는
+결정적 통과. #4181 해소 전까지 이 fixture 의 실패는 회귀 신호로 오독하지 말 것.

--- a/mydocs/working/task_m100_4169_stage1.md
+++ b/mydocs/working/task_m100_4169_stage1.md
@@ -1,0 +1,41 @@
+---
+kind: working
+status: completed
+issue: 4169
+last_verified: 2026-08-08
+---
+
+# Task #4169 Stage 1 - 단일줄 과밀 판정 memo
+
+## 구현
+
+- `Paragraph.single_line_overflow_memo: AtomicU64` — 0=미판정, `(f32 폭 bits << 1)|overflowed`
+  패킹, Relaxed. `Cell`은 `RenderNormalizedSection.paragraphs: Arc<Vec<Paragraph>>` 경유
+  `DocumentCore` Send 단언이 `Paragraph: Sync`를 요구해 컴파일 불가 — Atomic 선택 근거.
+  Clone은 수동 impl(파생 캐시를 텍스트와 함께 원자적으로 복제 — undo 스냅샷 정합).
+- 가드는 memo 히트 시 `estimate_composed_line_width` 측정만 생략하고, overflowed=true의
+  fresh 재래핑은 매 빌드 그대로 수행한다.
+- 무효화 배선(전수): 모델 프리미티브 8곳(insert_text_at/delete_text_at/split_at/merge_from/
+  apply_char_shape_range/set_single_char_shape/replace_style_char_shape_preserving_overrides/
+  shift_for_inline_control_insert), `reflow_line_segs` 수렴점, 직접 대입 우회 5곳 —
+  table_ops 표 계산식 셀 기록, document.rs clear_initial_field_texts,
+  object_ops/common.rs `reflow_paragraph_line_segs_after_control_delete` 서두(셀 인라인
+  그림/도형/수식/각주 삭제 가족 일괄 — 적대 리뷰 CONFIRMED 결함 수정),
+  field_query.rs `rebuild_char_offsets` 서두(빈 필드 제거 분기 — 감사 중 발견한 동류 누락),
+  clipboard.rs `strip_structural_controls_for_text_clipboard`(clip 사본이 다중 문단 붙여넣기로
+  문서에 스플라이스될 수 있음).
+
+## 검증 결과
+
+- `--lib composer`: 81 passed / 0 failed (신규 5: 메모 히트 측정 생략 증명, over=true 재래핑
+  유지, 폭 키 불일치 재판정, fit 판정 메모, 뮤테이션 경로 무효화).
+- `--lib issue4149`: 신규 `issue4149_cell_picture_delete_clears_single_line_overflow_memo`
+  (실명령 경로: stale verdict 주입 → 그림 삭제 → 미판정 어서션, 결함 분기 branch-1 통과) 포함 pass.
+- `--lib object_ops`: 59 passed / 0 failed. 기존 가드 회귀 핀 issue_2287(2)/2430(2)/2525(1)/
+  2527(3)/4138(2) 전부 pass.
+- 적대 리뷰: 무효화 누락 사냥에서 셀 그림 삭제 CONFIRMED 1건(위 수정 반영). undo/redo 스냅샷
+  클론 정합·f32 폭 키 정밀도(ulp vs 최소 리사이즈 3자리 차)·단일 스레드 TOCTOU 불가·ls==1
+  왕복 무해 — 반박 실패. 관찰: 향후 in-place CharShape 편집 API 도입 시 폭 단독 키가 구멍이
+  된다(현재 사이트 없음 확인).
+- 실측(거대 셀 문서, release-test): `build_page_tree` 17.6ms → 13.7ms (−22%), 캐럿 질의
+  ≈17.2 → ≈14.3ms.

--- a/mydocs/working/task_m100_4179_host_para_pages_stage1.md
+++ b/mydocs/working/task_m100_4179_host_para_pages_stage1.md
@@ -1,0 +1,13 @@
+---
+kind: working
+status: completed
+issue: 4179
+last_verified: 2026-08-08
+---
+
+# Task #4179 Stage 1
+
+## 구현·검증
+
+- integration 검증 트리에서 커밋 리프트(원 커밋 d530e0f16) — 컷 메타 기반 후보 제외 + 전용 회귀 테스트.
+- 검증: 레이어 전체 게이트(별첨 게이트 로그) — nextest 전체·Skia·studio 포함 ALL-PASS. 실측 효과: 115쪽 문서 열기 경로의 O(pages) 빌드 소멸(#4145 계열 개선과 합산).

--- a/mydocs/working/task_m100_4180_caret_meta_on_save_stage1.md
+++ b/mydocs/working/task_m100_4180_caret_meta_on_save_stage1.md
@@ -1,0 +1,13 @@
+---
+kind: working
+status: completed
+issue: 4180
+last_verified: 2026-08-08
+---
+
+# Task #4180 Stage 1
+
+## 구현·검증
+
+- integration 검증 트리에서 커밋 리프트(원 커밋 d59e6f7ff) — 저장 시점 스탬프 + 라운드트립 회귀.
+- 검증: 레이어 전체 게이트 ALL-PASS (nextest·Skia·studio 포함).

--- a/mydocs/working/task_m100_ime_reanchor_stage1.md
+++ b/mydocs/working/task_m100_ime_reanchor_stage1.md
@@ -1,0 +1,30 @@
+---
+kind: working
+status: completed
+issue: 4245
+last_verified: 2026-08-08
+---
+
+# Task ime_reanchor Stage 1 - 조합 replace 거부 시 재정박 복구
+
+## 구현
+
+- `input-handler-text.ts` 조합 분기(`onInput`)의 `replaceTextAtRaw(anchor, compositionLength,
+  text)`를 try/catch 로 보호. wasm 의 deferred replace 범위 가드가 거부하면(외부 변이로
+  앵커·길이가 낡은 경합) warn 후 조합을 현재 캐럿에 재정박(`compositionAnchor` 갱신,
+  `compositionLength=0`)하고 이번 조합 텍스트를 새로 삽입해 입력 스트림을 잇는다. 재삽입도
+  실패하면 이번 업데이트만 버린다.
+- 동기: 종전에는 거부가 uncaught 로 `onInput` 전체를 죽여 조합 추적이 낡은 값으로 wedge —
+  이후 모든 조합 업데이트 연쇄 실패. `onCompositionEnd`는 raw 뮤테이션이 없어(command 기록만)
+  대상 아님을 확인.
+
+## 검증 결과
+
+- 소스 계약 테스트 2종(`composition-replace-reanchor.test.ts`): try 보호 존재, catch 의
+  재정박(현재 캐럿 기준 + 길이 리셋) — pass.
+- 실브라우저 강제 트립(:7701, 거대 셀 문서): 조합 중 `compositionLength=9999` 오염 →
+  다음 업데이트에서 uncaught 없이 복구(재정박 앵커·compLen=1), 이어지는 업데이트·compositionend
+  정상, 최종 텍스트 정합(+1), undo 로 원문 완전 복원.
+- 발견 경위: 겹친 합성 테스트 배터리(도구 타임아웃 후 페이지에서 계속 실행)가 조합 스트림
+  2개를 인터리브해 가드 트립을 유발 — 실사용 IME 는 조합을 겹칠 수 없어 사용자 도달 경로는
+  아니나, 가드 거부가 uncaught 인 취약성 자체는 실재해 방어를 추가.

--- a/rhwp-studio/e2e/MANIFEST.md
+++ b/rhwp-studio/e2e/MANIFEST.md
@@ -19,6 +19,7 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `body-outside-click-fallback.test.mjs` | 진단 | hold | 보류 ② 본문 외곽 클릭 fallback 결함 — 가설 (b) master page 글상자 hit 확정 e2e | hwpctl_Action_Table__v1.1.hwp | 수동 | legacy-name · 보류② 이슈 종속 |
 | `canvas-render-diff.test.mjs` | 상시 | active | Browser canvas visual diff between the legacy PageRenderTree path  | — | npm+CI |  |
 | `canvaskit-font-coverage.test.mjs` | 상시 | active | CanvasKit 번들 폰트와 exact TTC GlyphRun 등록/픽셀 replay 검증 | — | npm+CI |  |
+| `cell-enter-pagination-issue4031.test.mjs` | 상시 | active | Issue #4031 — pending 중 셀 Enter의 pre-navigation full flush 0회·split 1회·barrier 대조군 계약 | issue1949_giant_cell_nested_tables_perf.hwp/.hwpx | npm e2e:issue-4031-cell-enter |  |
 | `command-palette.test.mjs` | 상시 | active | /커맨드 팔레트 | — | 수동 |  |
 | `copy-paste.test.mjs` | 상시 | active | 텍스트 블럭 복사/붙여넣기 버그 (Task 227) | — | 수동 |  |
 | `debug-pagination.mjs` | 진단 | active | E2E 디버그: 50줄 입력 후 페이지네이션 확인 | — | 수동 | 수동 디버그 |

--- a/rhwp-studio/e2e/cell-enter-pagination-issue4031.test.mjs
+++ b/rhwp-studio/e2e/cell-enter-pagination-issue4031.test.mjs
@@ -1,0 +1,302 @@
+/**
+ * Issue #4031 — pending pagination 중 셀 Enter의 중복 full pagination 제거 계약.
+ *
+ * 115쪽 거대 표 셀(HWP/HWPX)에서:
+ *  1. deferred insert로 pending pagination을 만든 뒤 direct Enter를 실키로 보낸다.
+ *     admitted 경로 계약: pre-navigation `wasm.flushDeferredPagination` 0회,
+ *     `splitParagraphInCell` 1회, 이후 pending 해소·caret은 새 문단 시작.
+ *  2. 사후 flush oracle: split의 동기 pagination이 최신이므로 page count 불변.
+ *  3. barrier 대조군: pending 중 ArrowDown은 기존 full flush 1회를 유지한다.
+ *
+ * 실행 (repo root에서 wasm-pack build 후):
+ *   cd rhwp-studio && npm run e2e:issue-4031-cell-enter
+ */
+
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  closeBrowser,
+  closePage,
+  createPage,
+  launchBrowser,
+  loadApp,
+  setTestCase,
+} from './helpers.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+const TARGET = Object.freeze({
+  sectionIndex: 0,
+  paragraphIndex: 5,
+  charOffset: 130,
+  parentParaIndex: 0,
+  controlIndex: 2,
+  cellIndex: 2,
+  cellParaIndex: 5,
+  cellPath: [{ controlIndex: 2, cellIndex: 2, cellParaIndex: 5 }],
+});
+
+const SAMPLES = Object.freeze({
+  hwp: path.join(REPO_ROOT, 'samples/issue1949_giant_cell_nested_tables_perf.hwp'),
+  hwpx: path.join(REPO_ROOT, 'samples/issue1949_giant_cell_nested_tables_perf.hwpx'),
+});
+
+function waitTwoRafs(page) {
+  return page.evaluate(
+    () =>
+      new Promise((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
+}
+
+function clickBlockingModalChoice(page) {
+  return page.evaluate(() => {
+    const allowed = new Set(['그대로 보기', '대체 글꼴로 보기']);
+    const buttons = Array.from(document.querySelectorAll('button'));
+    const button = buttons.find((candidate) => {
+      const label = candidate.textContent?.trim() ?? '';
+      const style = getComputedStyle(candidate);
+      return allowed.has(label) && style.display !== 'none' && style.visibility !== 'hidden';
+    });
+    if (!button) return null;
+    const label = button.textContent?.trim() ?? '';
+    button.click();
+    return label;
+  });
+}
+
+async function openDocumentThroughApp(page, format) {
+  const bytes = readFileSync(SAMPLES[format]);
+  const fileName = path.basename(SAMPLES[format]);
+  const encoded = bytes.toString('base64');
+  const requestId = `issue4031-${format}-${crypto.randomUUID()}`;
+
+  await page.evaluate(({ base64, name, id }) => {
+    const binary = atob(base64);
+    const payload = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) {
+      payload[index] = binary.charCodeAt(index);
+    }
+    window.__issue4031LoadResult = null;
+    const off = window.__eventBus.on('open-document-bytes:done', (result) => {
+      if (result?.requestId !== id) return;
+      off();
+      window.__issue4031LoadResult = result;
+    });
+    window.__eventBus.emit('open-document-bytes', {
+      bytes: payload,
+      fileName: name,
+      fileHandle: null,
+      skipUnsavedGuard: true,
+      requestId: id,
+    });
+  }, { base64: encoded, name: fileName, id: requestId });
+
+  const deadline = Date.now() + 90_000;
+  let result = null;
+  while (Date.now() < deadline) {
+    await clickBlockingModalChoice(page);
+    result = await page.evaluate(() => window.__issue4031LoadResult);
+    if (result) break;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  assert.ok(result, `${format}: open-document-bytes:done timeout`);
+  assert.equal(result.ok, true, `${format}: document load failed: ${result.error ?? 'unknown'}`);
+  await page.evaluate(() => document.fonts.ready);
+  await waitTwoRafs(page);
+
+  const pageCount = await page.evaluate(() => window.__wasm.pageCount);
+  assert.equal(pageCount, 115, `${format}: expected 115 pages`);
+}
+
+async function moveToTarget(page, target = TARGET) {
+  const state = await page.evaluate((pos) => {
+    const input = window.__inputHandler;
+    input.cursor.clearSelection();
+    input.cursor.moveTo(pos);
+    input.cursor.resetPreferredX();
+    input.updateCaret();
+    input.focus();
+    return {
+      position: input.cursor.getPosition(),
+      focused: document.activeElement === input.textarea,
+    };
+  }, target);
+  assert.equal(state.focused, true, 'hidden textarea was not focused');
+  assert.equal(state.position.cellParaIndex, target.cellParaIndex, 'target cell paragraph mismatch');
+  return state;
+}
+
+async function installCounters(page) {
+  await page.evaluate(() => {
+    const wasm = window.__wasm;
+    const counts = { flush: 0, cancel: 0, split: 0, splitByPath: 0 };
+    window.__issue4031Counts = counts;
+    if (!window.__issue4031Wrapped) {
+      window.__issue4031Wrapped = true;
+      for (const [method, key] of [
+        ['flushDeferredPagination', 'flush'],
+        ['cancelDeferredPagination', 'cancel'],
+        ['splitParagraphInCell', 'split'],
+        ['splitParagraphInCellByPath', 'splitByPath'],
+      ]) {
+        const original = wasm[method].bind(wasm);
+        wasm[method] = (...args) => {
+          window.__issue4031Counts[key] += 1;
+          return original(...args);
+        };
+      }
+    }
+  });
+}
+
+function resetCounters(page) {
+  return page.evaluate(() => {
+    window.__issue4031Counts = { flush: 0, cancel: 0, split: 0, splitByPath: 0 };
+  });
+}
+
+function readState(page) {
+  return page.evaluate((target) => {
+    const wasm = window.__wasm;
+    const input = window.__inputHandler;
+    return {
+      counts: { ...window.__issue4031Counts },
+      pending: input.hasDeferredPaginationPending(),
+      pageCount: wasm.pageCount,
+      cursor: input.cursor.getPosition(),
+      cellParaCount: wasm.getCellParagraphCount(
+        target.sectionIndex,
+        target.parentParaIndex,
+        target.controlIndex,
+        target.cellIndex,
+      ),
+      targetParaLength: wasm.getCellParagraphLength(
+        target.sectionIndex,
+        target.parentParaIndex,
+        target.controlIndex,
+        target.cellIndex,
+        target.cellParaIndex,
+      ),
+    };
+  }, TARGET);
+}
+
+async function runFormat(browser, format) {
+  setTestCase(`issue4031-${format}`);
+  const page = await createPage(browser, 1280, 900);
+  try {
+    await loadApp(page);
+    await openDocumentThroughApp(page, format);
+    await moveToTarget(page);
+    await installCounters(page);
+
+    const before = await readState(page);
+    assert.equal(before.pending, false, `${format}: unexpected pending before typing`);
+
+    // 1) deferred insert 3회로 pending pagination을 만든다 (실키 경로).
+    await page.keyboard.type('111', { delay: 30 });
+    await waitTwoRafs(page);
+    const pendingState = await readState(page);
+    assert.equal(pendingState.pending, true, `${format}: typing did not defer pagination`);
+    assert.equal(
+      pendingState.targetParaLength,
+      before.targetParaLength + 3,
+      `${format}: deferred inserts missing from model`,
+    );
+
+    // 2) direct Enter — admitted 경로 계약.
+    await resetCounters(page);
+    const enterStarted = Date.now();
+    await page.keyboard.press('Enter');
+    await waitTwoRafs(page);
+    const enterElapsedMs = Date.now() - enterStarted;
+    const after = await readState(page);
+
+    assert.equal(
+      after.counts.flush,
+      0,
+      `${format}: admitted cell Enter must not run pre-navigation full flush`,
+    );
+    assert.equal(
+      after.counts.split + after.counts.splitByPath,
+      1,
+      `${format}: exactly one cell paragraph split must run`,
+    );
+    assert.equal(after.pending, false, `${format}: pending must be cleared by owned completion`);
+    assert.equal(
+      after.cellParaCount,
+      before.cellParaCount + 1,
+      `${format}: cell paragraph count must grow by one`,
+    );
+    assert.equal(
+      after.targetParaLength,
+      TARGET.charOffset + 3,
+      `${format}: split point must sit after the three inserted digits`,
+    );
+    assert.equal(
+      after.cursor.cellParaIndex,
+      TARGET.cellParaIndex + 1,
+      `${format}: caret must land on the new paragraph`,
+    );
+    assert.equal(after.cursor.charOffset, 0, `${format}: caret must land at offset 0`);
+
+    // 3) 사후 flush oracle — split이 최신 revision을 계산했으므로 page count 불변.
+    const oracle = await page.evaluate(() => {
+      const result = window.__wasm.flushDeferredPagination();
+      return { status: result.status, pageCount: window.__wasm.pageCount };
+    });
+    assert.equal(
+      oracle.pageCount,
+      after.pageCount,
+      `${format}: post-split flush must not change page count`,
+    );
+
+    // 4) barrier 대조군 — pending 중 ArrowDown은 기존 full flush를 유지한다.
+    await page.keyboard.type('1', { delay: 30 });
+    await waitTwoRafs(page);
+    const navPending = await page.evaluate(() =>
+      window.__inputHandler.hasDeferredPaginationPending(),
+    );
+    assert.equal(navPending, true, `${format}: control typing did not defer pagination`);
+    await resetCounters(page);
+    await page.keyboard.press('ArrowDown');
+    await waitTwoRafs(page);
+    const navState = await readState(page);
+    assert.equal(
+      navState.counts.flush,
+      1,
+      `${format}: non-Enter boundary key must keep the full-flush barrier`,
+    );
+    assert.equal(navState.pending, false, `${format}: barrier flush must clear pending`);
+
+    console.log(
+      `[issue4031] ${format}: enter_elapsed_ms=${enterElapsedMs} ` +
+        `flush=0 split=1 pages=${after.pageCount} oracle=${oracle.status} barrier_flush=1 — OK`,
+    );
+  } finally {
+    await closePage(page);
+  }
+}
+
+async function main() {
+  const browser = await launchBrowser();
+  try {
+    for (const format of ['hwp', 'hwpx']) {
+      await runFormat(browser, format);
+    }
+    console.log('[issue4031] all formats passed');
+  } finally {
+    await closeBrowser(browser);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -24,6 +24,7 @@
     "e2e:issue-2214": "node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless",
     "e2e:issue-3815": "node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless --continuous-only",
     "e2e:issue-3137-perf": "node e2e/probe-input-perf-issue3137.mjs --mode=headless",
+    "e2e:issue-4031-cell-enter": "node e2e/cell-enter-pagination-issue4031.test.mjs --mode=headless",
     "e2e:issue-2809": "node e2e/issue-2809-split-alignment.test.mjs --mode=headless",
     "e2e:issue-4159": "node e2e/issue-4159-terminal-nested-bottom-border-canvas2d.test.mjs --mode=headless",
     "e2e:issue-536": "node e2e/issue-536-boxed-pua-canvas2d.test.mjs --mode=headless",

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -500,18 +500,29 @@ export class WasmBridge {
     return this._fileName === '새 문서.hwp';
   }
 
+  /**
+   * [#4180] 바이트 생산 직전 호출되는 훅 — 저장 시점 캐럿 스탬핑용 (main.ts 가 등록).
+   * 편집별 스탬핑은 "마지막 본문 편집 위치"를 남겨 열기 캐럿이 엉뚱한 페이지로
+   * 복원됐다. 저장/autosave/비교/히스토리 등 모든 export 경로가 이 브리지 메서드를
+   * 지나므로 여기가 단일 지점이다.
+   */
+  onBeforeExport: (() => void) | null = null;
+
   exportHwp(): Uint8Array {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    this.onBeforeExport?.();
     return this.doc.exportHwp();
   }
 
   exportHwpWithPassword(password: string): Uint8Array {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    this.onBeforeExport?.();
     return this.doc.exportHwpWithPassword(password);
   }
 
   exportHwpx(): Uint8Array {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    this.onBeforeExport?.();
     return this.doc.exportHwpx();
   }
 
@@ -1536,6 +1547,16 @@ export class WasmBridge {
       return JSON.parse(this.doc.getCaretPosition());
     } catch {
       return null;
+    }
+  }
+
+  /** [#4180] 저장 시점 캐럿 스탬핑 — 범위 밖 위치는 wasm 쪽에서 무시된다. */
+  setCaretPosition(sec: number, para: number, charOffset: number): void {
+    if (!this.doc) return;
+    try {
+      this.doc.setCaretPosition(sec, para, charOffset);
+    } catch {
+      // 저장을 막지 않는다
     }
   }
 

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -1458,10 +1458,12 @@ export class MergeParagraphInFootnoteCommand implements EditCommand {
 export class SplitParagraphInCellCommand implements EditCommand {
   readonly type = 'splitParagraphInCell';
   readonly timestamp = Date.now();
+  private lastMutationEffects: TextMutationEffects = NO_TEXT_MUTATION_EFFECTS;
 
   constructor(private position: DocumentPosition) {}
 
   execute(wasm: WasmBridge): DocumentPosition {
+    this.lastMutationEffects = NO_TEXT_MUTATION_EFFECTS;
     const pos = this.position;
     const sec = pos.sectionIndex;
     const ppi = pos.parentParaIndex!;
@@ -1471,7 +1473,16 @@ export class SplitParagraphInCellCommand implements EditCommand {
     } else {
       wasm.splitParagraphInCell(sec, ppi, pos.controlIndex!, pos.cellIndex!, cpi, pos.charOffset);
     }
+    // [#4031] 네이티브 split은 paginate_if_needed()로 최신 revision을 동기 계산한다.
+    // 이 선언이 pending deferred 상태를 해소해 직후 before-full-edit flush가 no-op이 된다.
+    this.lastMutationEffects = IMMEDIATE_TEXT_MUTATION_EFFECTS;
     return cellParagraphPosition(pos, cpi + 1, 0);
+  }
+
+  consumeTextMutationEffects(): TextMutationEffects {
+    const effects = this.lastMutationEffects;
+    this.lastMutationEffects = NO_TEXT_MUTATION_EFFECTS;
+    return effects;
   }
 
   undo(wasm: WasmBridge): DocumentPosition {

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -1251,9 +1251,10 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
         this.executeOperation({ kind: 'command', command: new InsertLineBreakCommand(this.cursor.getPosition()) });
       } else if (inCell) {
         try {
+          // [#4031] 성공한 split은 IMMEDIATE_TEXT_MUTATION_EFFECTS를 선언해
+          // executeOperation의 effects 경로가 pending 해소·runner 취소·geometry
+          // invalidation(완료 소유)을 수행한다.
           this.executeOperation({ kind: 'command', command: new SplitParagraphInCellCommand(this.cursor.getPosition()) });
-          // [#4031] 성공한 native split이 최신 revision pagination을 소유했다.
-          if (committedCellEnterSplit) this.completePaginationOwnedBySyncMutation();
         } catch (err) {
           // [#4031] structural command 실패 — 기존 full-flush barrier로 fail-closed 복귀.
           if (committedCellEnterSplit) this.flushDeferredPaginationIfNeeded('cell-enter-split-fallback', false);

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -40,6 +40,27 @@ const SUBMODE_GLOBAL_COMMANDS = new Set([
   'edit:goto',
 ]);
 
+/**
+ * [#4031] 이 keydown이 아래 switch의 `case 'Enter'`에서 `SplitParagraphInCellCommand`로
+ * 확정 실행되는 좁은 조건인지 판정한다. 목록은 flush 지점과 `case 'Enter'` 사이의 모든
+ * 조기 분기(모드 가드·단축키 라우팅·선택 삭제)를 보수적으로 배제한다 — 하나라도
+ * 확신할 수 없으면 false를 돌려 기존 before-navigation full flush로 fail-closed한다.
+ */
+function isCommittedCellEnterSplit(this: any, e: KeyboardEvent): boolean {
+  return e.key === 'Enter'
+    && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey
+    && !this.isComposing
+    && !this.isFormMode?.()
+    && !this.cursor.isInHeaderFooter()
+    && !this.cursor.isInFootnote()
+    && !this.cursor.isInPictureObjectSelection()
+    && !this.cursor.isInTableObjectSelection()
+    && !this.cursor.isInBlockSelectionMode()
+    && !this.cursor.isInCellSelectionMode()
+    && !this.cursor.hasSelection()
+    && this.cursor.isInCell();
+}
+
 function dispatchSubmodeGlobalShortcut(this: any, e: KeyboardEvent): boolean {
   if (!this.dispatcher) return false;
   const commandId = matchShortcut(e, defaultShortcuts);
@@ -544,8 +565,17 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
     return;
   }
 
+  // [#4031] 셀 Enter는 `SplitParagraphInCellCommand`의 동기 full pagination이 확정이라,
+  // 곧 폐기될 분할 전 pagination을 flush로 완주하는 대신 stale deferred job만 취소한다.
+  // admission 미충족 시 기존 full barrier 그대로다.
+  const committedCellEnterSplit = PAGINATION_BOUNDARY_KEYS.has(e.key)
+    && isCommittedCellEnterSplit.call(this, e);
   if (PAGINATION_BOUNDARY_KEYS.has(e.key)) {
-    this.flushDeferredPaginationIfNeeded('before-navigation', false);
+    if (committedCellEnterSplit) {
+      this.cancelDeferredPaginationForOwnedMutation();
+    } else {
+      this.flushDeferredPaginationIfNeeded('before-navigation', false);
+    }
   }
 
   // ─── 머리말/꼬리말 편집 모드 키보드 처리 ──────────────────
@@ -1220,7 +1250,15 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
         // Shift+Enter: 강제 줄바꿈 (문단 유지, 줄만 바꿈)
         this.executeOperation({ kind: 'command', command: new InsertLineBreakCommand(this.cursor.getPosition()) });
       } else if (inCell) {
-        this.executeOperation({ kind: 'command', command: new SplitParagraphInCellCommand(this.cursor.getPosition()) });
+        try {
+          this.executeOperation({ kind: 'command', command: new SplitParagraphInCellCommand(this.cursor.getPosition()) });
+          // [#4031] 성공한 native split이 최신 revision pagination을 소유했다.
+          if (committedCellEnterSplit) this.completePaginationOwnedBySyncMutation();
+        } catch (err) {
+          // [#4031] structural command 실패 — 기존 full-flush barrier로 fail-closed 복귀.
+          if (committedCellEnterSplit) this.flushDeferredPaginationIfNeeded('cell-enter-split-fallback', false);
+          throw err;
+        }
       } else {
         this.executeOperation({ kind: 'command', command: new SplitParagraphCommand(this.cursor.getPosition()) });
       }

--- a/rhwp-studio/src/engine/input-handler-text.ts
+++ b/rhwp-studio/src/engine/input-handler-text.ts
@@ -484,7 +484,7 @@ export function onInput(this: any, e?: InputEvent): void {
   // IME 조합 중: 이전 조합 텍스트 삭제 → 현재 조합 텍스트 삽입 (실시간 렌더링)
   // Undo 스택에는 기록하지 않음 (compositionend에서 한 번에 기록)
   if (this.isComposing && this.compositionAnchor) {
-    const anchor = this.compositionAnchor;
+    let anchor = this.compositionAnchor;
     const beforePageIndex = this.cursor.getRect()?.pageIndex;
     if (!this.canInsertTextInFormMode?.(anchor)) {
       this.textarea.value = '';
@@ -492,7 +492,25 @@ export function onInput(this: any, e?: InputEvent): void {
     }
     this.resetRawTextMutationEffects();
 
-    this.replaceTextAtRaw(anchor, this.compositionLength, text);
+    try {
+      this.replaceTextAtRaw(anchor, this.compositionLength, text);
+    } catch (err) {
+      // wasm 의 deferred replace 범위 가드가 거부하면(외부 변이로 앵커·길이가 낡은
+      // 경합) 여기서 던진 채 두면 onInput 전체가 죽어 조합 추적이 낡은 값으로
+      // wedge 된다. 조합을 현재 캐럿에 재정박하고 이번 조합 텍스트를 새로 삽입해
+      // 입력 스트림을 잇는다 — 실패분은 다음 캐럿 이동에서 자연 동기화된다.
+      console.warn('[InputHandler] 조합 replace 거부 — 현재 캐럿에 재정박:', err);
+      anchor = { ...this.cursor.getPosition() };
+      this.compositionAnchor = anchor;
+      this.compositionLength = 0;
+      try {
+        this.replaceTextAtRaw(anchor, 0, text);
+      } catch (err2) {
+        console.warn('[InputHandler] 조합 재정박 삽입 실패 — 이번 업데이트 무시:', err2);
+        this.textarea.value = '';
+        return;
+      }
+    }
     // 다음 조합 업데이트의 삭제 count는 scalar 단위다.
     this.compositionLength = charCount(text);
     if (text) this._lastCompositionText = text;

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -1892,14 +1892,33 @@ export class InputHandler {
         return { ...cursorBefore };
       },
     });
+    // [#4151] 블록 적용 경로는 텍스트 선택 경로의 "적용 → 상태 재조회·방출" 후처리를 타지
+    // 않아 툴바 눌림 상태가 이전 값으로 남는다. 적용 직후 앵커 셀 기준으로 방출해 동기화한다.
+    try {
+      this.eventBus.emit('cursor-format-changed', this.getCharPropertiesAtCellBlockAnchor(block));
+    } catch {
+      // 문서 상태 경합 시 다음 캐럿 이동에서 자연 동기화
+    }
+  }
+
+  /** [#4151] 셀 블록 서식의 토글 방향·툴바 상태 기준: 블록 첫 셀의 첫 글자 서식. */
+  private getCharPropertiesAtCellBlockAnchor(block: SelectedCellBlock): CharProperties {
+    return this.wasm.getCellCharPropertiesAt(block.sec, block.ppi, block.ci, block.cellIndices[0], 0, 0);
   }
 
   /** 토글 서식 적용 (상호 배타 처리 포함) */
   private applyToggleFormat(prop: 'bold' | 'italic' | 'underline' | 'strikethrough' | 'emboss' | 'engrave' | 'outline' | 'superscript' | 'subscript'): void {
     if (!this.hasFormatTargetSelection()) return;
-    // 셀 블록에서는 커서가 있는 앵커 셀의 현재 값이 토글 방향을 정한다. 칸마다 값이 다를 때
+    // 셀 블록에서는 앵커 셀 텍스트의 현재 값이 토글 방향을 정한다. 칸마다 값이 다를 때
     // 블록 전체를 한 방향으로 맞추려면 기준이 하나여야 하고, 텍스트 선택도 같은 기준이다.
-    const current = this.getCharPropertiesAtCursor();
+    // [#4151] 커서 위치 조회는 셀 블록 모드에서 블록 밖(호스트 문단 등)을 읽어 방금 적용한
+    // 서식이 보이지 않는다 — 두 번째 클릭이 해제가 아니라 재적용이 되는 원인. 블록 모드에선
+    // 블록 첫 셀의 첫 글자 서식을 기준으로 삼는다. 빈 블록(전 셀 Ctrl+클릭 제외)은 앵커
+    // 셀이 없으므로 커서 기준 폴백 — applyCharFormat 이 어차피 빈 블록에서 조기 종료한다.
+    const toggleBlock = this.getSelectedCellBlock();
+    const current = toggleBlock && toggleBlock.cellIndices.length > 0
+      ? this.getCharPropertiesAtCellBlockAnchor(toggleBlock)
+      : this.getCharPropertiesAtCursor();
 
     if (prop === 'emboss') {
       const newVal = !current.emboss;

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2820,6 +2820,30 @@ export class InputHandler {
     }
   }
 
+  /**
+   * [#4031] 동기 full pagination을 소유하는 structural command(셀 Enter 분할)가 확정된
+   * 경로에서, 곧 폐기될 stale deferred job을 계산 완료 없이 취소한다.
+   * `wasm.flushDeferredPagination()`을 호출하지 않는 것이 flush 경로와의 유일한 차이다.
+   * runner.cancel()이 전진 중인 WASM resumable job까지 취소한다.
+   * `deferredPaginationPending`은 유지한다 — mutation이 실패하면 다음 boundary flush가
+   * 기존 barrier 의미론으로 복구하도록 fail-closed로 남긴다.
+   */
+  cancelDeferredPaginationForOwnedMutation(): void {
+    this.cancelDeferredPaginationFlush();
+    this.deferredPaginationRunner.cancel();
+  }
+
+  /**
+   * [#4031] 성공한 native mutation의 `paginate_if_needed()`가 최신 revision을 계산했음을
+   * studio 상태에 반영한다. 이후 boundary flush는 no-op으로 수렴한다.
+   */
+  completePaginationOwnedBySyncMutation(): void {
+    this.cancelDeferredPaginationFlush();
+    this.deferredPaginationRunner.cancel();
+    this.deferredPaginationPending = false;
+    this.cursor.invalidateFocusedCellCursorGeometry();
+  }
+
   /** raw IME/iOS 텍스트 입력처럼 command를 거치지 않는 경로의 갱신 라우터. */
   private afterTextInputEdit(
     beforePos: DocumentPosition,

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2833,17 +2833,6 @@ export class InputHandler {
     this.deferredPaginationRunner.cancel();
   }
 
-  /**
-   * [#4031] 성공한 native mutation의 `paginate_if_needed()`가 최신 revision을 계산했음을
-   * studio 상태에 반영한다. 이후 boundary flush는 no-op으로 수렴한다.
-   */
-  completePaginationOwnedBySyncMutation(): void {
-    this.cancelDeferredPaginationFlush();
-    this.deferredPaginationRunner.cancel();
-    this.deferredPaginationPending = false;
-    this.cursor.invalidateFocusedCellCursorGeometry();
-  }
-
   /** raw IME/iOS 텍스트 입력처럼 command를 거치지 않는 경로의 갱신 라우터. */
   private afterTextInputEdit(
     beforePos: DocumentPosition,

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -402,6 +402,18 @@ async function initialize(): Promise<void> {
     );
     inputHandler.setEditMode(editMode);
 
+    // [#4180] 저장 시점 캐럿 스탬핑 — 셀/글상자 캐럿은 현행 캐럿 필드(list_id 를
+    // 구역 인덱스로 쓰는 rhwp 관례)로 표현 불가 → 호스트 문단 시작으로 강등.
+    wasm.onBeforeExport = () => {
+      const p = inputHandler?.getCursorPosition();
+      if (!p) return;
+      wasm.setCaretPosition(
+        p.sectionIndex,
+        p.parentParaIndex ?? p.paragraphIndex,
+        p.parentParaIndex !== undefined ? 0 : p.charOffset,
+      );
+    };
+
     toolbar = new Toolbar(document.getElementById('style-bar')!, wasm, eventBus, dispatcher);
     toolbar.setEnabled(false);
 

--- a/rhwp-studio/src/view/viewport-manager.ts
+++ b/rhwp-studio/src/view/viewport-manager.ts
@@ -20,6 +20,7 @@ export class ViewportManager {
   private zoom = 1.0;
   private container: HTMLElement | null = null;
   private resizeObserver: ResizeObserver | null = null;
+  private resizeAnimationFrame: number | null = null;
   private scrollAnimationFrame: number | null = null;
   private zoomAnimationFrame: number | null = null;
   private zoomAnimationTimestamp: number | null = null;
@@ -29,6 +30,7 @@ export class ViewportManager {
   private onScrollBound: () => void;
   private onWheelBound: (e: WheelEvent) => void;
   private onZoomAnimationFrameBound: (timestamp: number) => void;
+  private onResizeObserverErrorBound: (e: ErrorEvent) => void;
   private eventBus: EventBus;
 
   constructor(eventBus: EventBus) {
@@ -36,6 +38,7 @@ export class ViewportManager {
     this.onScrollBound = this.onScroll.bind(this);
     this.onWheelBound = this.onWheel.bind(this);
     this.onZoomAnimationFrameBound = this.onZoomAnimationFrame.bind(this);
+    this.onResizeObserverErrorBound = this.onResizeObserverError.bind(this);
   }
 
   /** 스크롤 컨테이너에 연결한다 */
@@ -45,9 +48,26 @@ export class ViewportManager {
     container.addEventListener('scroll', this.onScrollBound, { passive: true });
     container.addEventListener('wheel', this.onWheelBound, { passive: false });
 
+    // 크로미움은 이 경고를 실제 스크립트 예외가 아니라 window `error` 이벤트로 합성
+    // 보고한다. 아래 콜백이 동기 DOM 변이를 하지 않아도(매크로태스크로 미룸) 대형
+    // 문서 초기 렌더처럼 같은 프레임에 다른 요소들이 대량으로 리사이즈되면 여전히
+    // 뜰 수 있는, 기능에 영향 없는 잡음이라 uncaught error 로 새지 않게 막는다.
+    window.addEventListener('error', this.onResizeObserverErrorBound);
+
     this.resizeObserver = new ResizeObserver(() => {
-      this.updateViewportSize();
-      this.eventBus.emit('viewport-resize', this.viewportWidth, this.viewportHeight);
+      if (this.resizeAnimationFrame !== null) return;
+
+      // 리스너가 레이아웃을 다시 계산해 컨테이너 크기가 같은 프레임에 또 바뀌면
+      // "ResizeObserver loop completed with undelivered notifications"가 발생한다.
+      // rAF 는 **같은 렌더링 프레임 안**(레이아웃·RO 전달 이전)에 실행되므로 이 루프를
+      // 벗어나지 못한다 — 실측으로 경고가 계속 발생했다. 매크로태스크(setTimeout 0)로
+      // 프레임 경계를 넘겨 변이를 다음 프레임의 관찰 사이클로 미룬다.
+      this.resizeAnimationFrame = window.setTimeout(() => {
+        this.resizeAnimationFrame = null;
+        if (!this.container) return;
+        this.updateViewportSize();
+        this.eventBus.emit('viewport-resize', this.viewportWidth, this.viewportHeight);
+      }, 0);
     });
     this.resizeObserver.observe(container);
     this.updateViewportSize();
@@ -61,12 +81,25 @@ export class ViewportManager {
     }
     this.resizeObserver?.disconnect();
     this.resizeObserver = null;
+    window.removeEventListener('error', this.onResizeObserverErrorBound);
+    if (this.resizeAnimationFrame !== null) {
+      clearTimeout(this.resizeAnimationFrame);
+      this.resizeAnimationFrame = null;
+    }
     if (this.scrollAnimationFrame !== null) {
       cancelAnimationFrame(this.scrollAnimationFrame);
       this.scrollAnimationFrame = null;
     }
     this.cancelZoomAnimation();
     this.container = null;
+  }
+
+  /** ResizeObserver 잡음 window error 를 uncaught 로 전파하지 않도록 막는다. */
+  private onResizeObserverError(e: ErrorEvent): void {
+    if (e.message?.includes('ResizeObserver loop')) {
+      e.stopImmediatePropagation();
+      e.preventDefault();
+    }
   }
 
   private onScroll(): void {

--- a/rhwp-studio/tests/cell-block-format.test.ts
+++ b/rhwp-studio/tests/cell-block-format.test.ts
@@ -199,6 +199,50 @@ test('빈 셀 블록 글자 서식은 history 없이 no-op 이다', () => {
     '모든 셀 제외 시 글자 서식이 no-op으로 끝나지 않는다');
 });
 
+test('[#4151] 토글 방향은 셀 블록 모드에서 블록 앵커 셀의 서식을 읽는다', () => {
+  // 커서 위치 조회(getCharPropertiesAtCursor)는 셀 블록 모드에서 블록 밖(호스트 문단 등)을
+  // 읽어 방금 적용한 서식이 보이지 않는다 — current[prop] 이 이전 값에 머물러 !current[prop]
+  // 이 항상 같은 방향이 되고, 두 번째 클릭이 해제가 아니라 재적용이 된다.
+  const ih = source('src/engine/input-handler.ts');
+  const start = ih.indexOf('private applyToggleFormat(');
+  assert.notEqual(start, -1, 'applyToggleFormat 을 찾지 못했다');
+  const body = ih.slice(start, ih.indexOf('\n  }\n', start));
+  assert.match(body, /this\.getSelectedCellBlock\(\)/,
+    '토글 방향 산출에 셀 블록 분기가 없다');
+  assert.match(body,
+    /\?\s*this\.getCharPropertiesAtCellBlockAnchor\(\w+\)\s*\n?\s*:\s*this\.getCharPropertiesAtCursor\(\)/,
+    '셀 블록 모드에서 블록 앵커 셀 대신 커서 위치의 서식으로 토글 방향을 정한다');
+});
+
+test('[#4151] 셀 블록 적용 직후 cursor-format-changed 를 앵커 셀 기준으로 방출한다', () => {
+  // 텍스트 선택 경로는 적용 후 emitCursorFormatState 로 툴바 눌림 상태를 재조회·방출하지만,
+  // 셀 블록 경로는 이 후처리가 없으면 툴바가 이전 상태로 남는다. emitCursorFormatState 는
+  // 커서 위치 기준이라 블록에는 오답 — 앵커 셀 서식을 직접 방출해야 한다.
+  const ih = source('src/engine/input-handler.ts');
+  const start = ih.indexOf('private applyCharFormatToCellBlock');
+  assert.notEqual(start, -1, 'applyCharFormatToCellBlock 이 없다');
+  const body = ih.slice(start, ih.indexOf('\n  }\n', start));
+  const applyAt = body.indexOf('this.executeOperation(');
+  const emitAt = body.indexOf("this.eventBus.emit('cursor-format-changed'");
+  assert.notEqual(emitAt, -1, '적용 후 cursor-format-changed 방출이 없다');
+  assert.ok(applyAt !== -1 && applyAt < emitAt, '상태 방출이 서식 적용보다 앞에 있다');
+  assert.match(body,
+    /emit\('cursor-format-changed',\s*this\.getCharPropertiesAtCellBlockAnchor\(block\)\)/,
+    '방출 값이 블록 앵커 셀 서식이 아니다');
+});
+
+test('[#4151] 앵커 셀 서식 기준은 블록 첫 셀의 첫 글자다', () => {
+  // 토글 방향(applyToggleFormat)과 툴바 상태 방출이 같은 기준을 공유해야 두 번째 클릭의
+  // 해제 방향과 버튼 표시가 일치한다. 기준 조회는 이 함수 한 곳에만 둔다.
+  const ih = source('src/engine/input-handler.ts');
+  const start = ih.indexOf('private getCharPropertiesAtCellBlockAnchor');
+  assert.notEqual(start, -1, 'getCharPropertiesAtCellBlockAnchor 가 없다');
+  const body = ih.slice(start, ih.indexOf('\n  }\n', start));
+  assert.match(body,
+    /getCellCharPropertiesAt\(block\.sec, block\.ppi, block\.ci, block\.cellIndices\[0\], 0, 0\)/,
+    '앵커 기준이 블록 첫 셀의 첫 글자가 아니다');
+});
+
 test('모양 붙여넣기도 같은 셀 산출 함수를 쓴다', () => {
   // 같은 블록을 대상으로 하는 두 경로가 필터를 각자 갖고 있으면 한쪽만 고쳐진다.
   const ih = source('src/engine/input-handler.ts');

--- a/rhwp-studio/tests/cell-enter-owned-pagination.test.ts
+++ b/rhwp-studio/tests/cell-enter-owned-pagination.test.ts
@@ -78,29 +78,71 @@ test('admission helper는 case Enter까지의 모든 조기 분기를 배제한�
   }
 });
 
-test('성공한 셀 split이 pagination 완료를 소유하고 실패는 full flush로 복귀한다', () => {
+test('성공한 셀 split이 effects로 pagination 완료를 선언하고 실패는 full flush로 복귀한다', () => {
+  const command = source('src/engine/command.ts');
+  const splitClass = sliceBetween(
+    command,
+    'export class SplitParagraphInCellCommand',
+    'export class MergeParagraphInCellCommand',
+  );
+  const wasmCallIdx = splitClass.indexOf('wasm.splitParagraphInCell(');
+  const effectsIdx = splitClass.indexOf('this.lastMutationEffects = IMMEDIATE_TEXT_MUTATION_EFFECTS');
+  assert.notEqual(wasmCallIdx, -1, 'splitParagraphInCell wasm 호출이 없다');
+  assert.ok(
+    effectsIdx > wasmCallIdx,
+    '완료 선언(IMMEDIATE effects)은 native split 성공 뒤에만 세팅되어야 한다(예외 시 NO 유지)',
+  );
+  assert.ok(
+    splitClass.includes('consumeTextMutationEffects()'),
+    'split command는 effects를 executeOperation에 전달해야 한다',
+  );
+
   const keyboard = source('src/engine/input-handler-keyboard.ts');
   const enterCase = sliceBetween(keyboard, "case 'Enter': {", "case 'ArrowLeft':");
-  const successIdx = enterCase.indexOf('this.completePaginationOwnedBySyncMutation()');
   const splitIdx = enterCase.indexOf('new SplitParagraphInCellCommand');
   const fallbackIdx = enterCase.indexOf(
     "this.flushDeferredPaginationIfNeeded('cell-enter-split-fallback', false)",
   );
   assert.notEqual(splitIdx, -1, 'SplitParagraphInCellCommand 실행이 없다');
-  assert.ok(successIdx > splitIdx, '완료 선언은 split 실행 뒤에 와야 한다');
   assert.ok(fallbackIdx > splitIdx, 'catch fallback full flush가 없다');
   assert.ok(
     enterCase.includes('if (committedCellEnterSplit)'),
-    '완료/복귀는 admission이 확정된 경우에만 수행해야 한다',
+    'fallback 복귀는 admission이 확정된 경우에만 수행해야 한다',
   );
 });
 
-test('소유 취소는 pending을 유지하고 완료 선언만 pending을 해소한다', () => {
+test('effects의 paginationCompleted가 pending 해소·runner 취소·geometry invalidation을 소유한다', () => {
+  const handler = source('src/engine/input-handler.ts');
+  const prepare = sliceBetween(
+    handler,
+    'private prepareTextMutationBeforeCursor(',
+    'private completeResumablePagination(',
+  );
+  const completedBlock = sliceBetween(
+    prepare,
+    'if (effects.paginationCompleted) {',
+    '}',
+  );
+  assert.ok(
+    completedBlock.includes('this.deferredPaginationRunner.cancel()'),
+    'paginationCompleted는 runner를 취소해야 한다',
+  );
+  assert.ok(
+    completedBlock.includes('this.deferredPaginationPending = false'),
+    'paginationCompleted는 pending을 해소해야 한다',
+  );
+  assert.ok(
+    prepare.includes('this.cursor.invalidateFocusedCellCursorGeometry()'),
+    'effects 경로는 focused cursor geometry를 invalidate해야 한다',
+  );
+});
+
+test('소유 취소는 pending을 유지한다 (fail-closed)', () => {
   const handler = source('src/engine/input-handler.ts');
   const cancel = sliceBetween(
     handler,
     'cancelDeferredPaginationForOwnedMutation(): void {',
-    'completePaginationOwnedBySyncMutation(): void {',
+    '/** raw IME/iOS 텍스트 입력처럼',
   );
   assert.ok(
     !cancel.includes('flushDeferredPagination()'),
@@ -113,20 +155,6 @@ test('소유 취소는 pending을 유지하고 완료 선언만 pending을 해�
   assert.ok(
     cancel.includes('this.deferredPaginationRunner.cancel()'),
     '소유 취소는 scheduled/stepping runner job을 취소해야 한다',
-  );
-
-  const complete = sliceBetween(
-    handler,
-    'completePaginationOwnedBySyncMutation(): void {',
-    'afterTextInputEdit(',
-  );
-  assert.ok(
-    complete.includes('this.deferredPaginationPending = false'),
-    '완료 선언은 pending을 해소해야 한다',
-  );
-  assert.ok(
-    complete.includes('this.cursor.invalidateFocusedCellCursorGeometry()'),
-    '완료 선언은 cursor geometry를 invalidate해야 한다',
   );
 });
 

--- a/rhwp-studio/tests/cell-enter-owned-pagination.test.ts
+++ b/rhwp-studio/tests/cell-enter-owned-pagination.test.ts
@@ -1,0 +1,146 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [#4031] pending pagination 중 셀 Enter의 중복 full pagination 제거 계약.
+//
+// 계약: admission이 확정된 셀 Enter는 before-navigation full flush 대신
+// 계산 없는 취소(cancelDeferredPaginationForOwnedMutation)를 쓰고, 성공한
+// SplitParagraphInCellCommand가 pagination 완료를 소유한다. 실패나 admission
+// 불충족은 기존 full-flush barrier로 fail-closed한다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+function sliceBetween(text: string, startNeedle: string, endNeedle: string): string {
+  const start = text.indexOf(startNeedle);
+  assert.notEqual(start, -1, `"${startNeedle}" not found`);
+  const end = text.indexOf(endNeedle, start);
+  assert.notEqual(end, -1, `"${endNeedle}" not found after "${startNeedle}"`);
+  return text.slice(start, end);
+}
+
+test('boundary key flush는 admitted 셀 Enter에서만 계산 없는 취소로 대체된다', () => {
+  const keyboard = source('src/engine/input-handler-keyboard.ts');
+  const block = sliceBetween(
+    keyboard,
+    'const committedCellEnterSplit = PAGINATION_BOUNDARY_KEYS.has(e.key)',
+    '// ─── 머리말/꼬리말 편집 모드 키보드 처리',
+  );
+  assert.ok(
+    block.includes('isCommittedCellEnterSplit.call(this, e)'),
+    'admission은 committed cell Enter 판정 helper를 거쳐야 한다',
+  );
+  assert.ok(
+    block.includes('this.cancelDeferredPaginationForOwnedMutation()'),
+    'admitted 경로는 계산 없는 취소를 호출해야 한다',
+  );
+  assert.ok(
+    block.includes("this.flushDeferredPaginationIfNeeded('before-navigation', false)"),
+    '비admitted boundary key는 기존 before-navigation full flush를 유지해야 한다',
+  );
+  assert.ok(
+    !block.includes('wasm.flushDeferredPagination'),
+    'admitted 경로에 직접 full flush가 있으면 안 된다',
+  );
+});
+
+test('admission helper는 case Enter까지의 모든 조기 분기를 배제한다', () => {
+  const keyboard = source('src/engine/input-handler-keyboard.ts');
+  const helper = sliceBetween(
+    keyboard,
+    'function isCommittedCellEnterSplit',
+    'function dispatchSubmodeGlobalShortcut',
+  );
+  for (const guard of [
+    "e.key === 'Enter'",
+    '!e.shiftKey',
+    '!e.ctrlKey',
+    '!e.metaKey',
+    '!e.altKey',
+    '!this.isComposing',
+    '!this.isFormMode?.()',
+    '!this.cursor.isInHeaderFooter()',
+    '!this.cursor.isInFootnote()',
+    '!this.cursor.isInPictureObjectSelection()',
+    '!this.cursor.isInTableObjectSelection()',
+    '!this.cursor.isInBlockSelectionMode()',
+    '!this.cursor.isInCellSelectionMode()',
+    '!this.cursor.hasSelection()',
+    'this.cursor.isInCell()',
+  ]) {
+    assert.ok(helper.includes(guard), `admission guard 누락: ${guard}`);
+  }
+});
+
+test('성공한 셀 split이 pagination 완료를 소유하고 실패는 full flush로 복귀한다', () => {
+  const keyboard = source('src/engine/input-handler-keyboard.ts');
+  const enterCase = sliceBetween(keyboard, "case 'Enter': {", "case 'ArrowLeft':");
+  const successIdx = enterCase.indexOf('this.completePaginationOwnedBySyncMutation()');
+  const splitIdx = enterCase.indexOf('new SplitParagraphInCellCommand');
+  const fallbackIdx = enterCase.indexOf(
+    "this.flushDeferredPaginationIfNeeded('cell-enter-split-fallback', false)",
+  );
+  assert.notEqual(splitIdx, -1, 'SplitParagraphInCellCommand 실행이 없다');
+  assert.ok(successIdx > splitIdx, '완료 선언은 split 실행 뒤에 와야 한다');
+  assert.ok(fallbackIdx > splitIdx, 'catch fallback full flush가 없다');
+  assert.ok(
+    enterCase.includes('if (committedCellEnterSplit)'),
+    '완료/복귀는 admission이 확정된 경우에만 수행해야 한다',
+  );
+});
+
+test('소유 취소는 pending을 유지하고 완료 선언만 pending을 해소한다', () => {
+  const handler = source('src/engine/input-handler.ts');
+  const cancel = sliceBetween(
+    handler,
+    'cancelDeferredPaginationForOwnedMutation(): void {',
+    'completePaginationOwnedBySyncMutation(): void {',
+  );
+  assert.ok(
+    !cancel.includes('flushDeferredPagination()'),
+    '소유 취소는 wasm full flush를 호출하면 안 된다',
+  );
+  assert.ok(
+    !cancel.includes('deferredPaginationPending = false'),
+    '소유 취소는 fail-closed를 위해 pending을 유지해야 한다',
+  );
+  assert.ok(
+    cancel.includes('this.deferredPaginationRunner.cancel()'),
+    '소유 취소는 scheduled/stepping runner job을 취소해야 한다',
+  );
+
+  const complete = sliceBetween(
+    handler,
+    'completePaginationOwnedBySyncMutation(): void {',
+    'afterTextInputEdit(',
+  );
+  assert.ok(
+    complete.includes('this.deferredPaginationPending = false'),
+    '완료 선언은 pending을 해소해야 한다',
+  );
+  assert.ok(
+    complete.includes('this.cursor.invalidateFocusedCellCursorGeometry()'),
+    '완료 선언은 cursor geometry를 invalidate해야 한다',
+  );
+});
+
+test('IME 종료 후 예약 Enter 경로의 barrier flush는 유지된다', () => {
+  // processPendingNav의 Enter는 조합 확정만 하고 structural command가 없으므로
+  // 이 flush가 최신 모델의 유일한 pagination barrier다 (stage1 §5).
+  const text = source('src/engine/input-handler-text.ts');
+  const pendingNav = sliceBetween(
+    text,
+    'function processPendingNav',
+    'function tryDeleteBodyFootnoteAtCursor',
+  );
+  assert.ok(
+    pendingNav.includes("this.flushDeferredPaginationIfNeeded('before-navigation', false)"),
+    'processPendingNav의 before-navigation flush가 제거되면 안 된다',
+  );
+});

--- a/rhwp-studio/tests/composition-replace-reanchor.test.ts
+++ b/rhwp-studio/tests/composition-replace-reanchor.test.ts
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [#4149 계열 방어] IME 조합 업데이트의 raw replace 는 wasm 의 deferred replace 범위
+// 가드에 거부될 수 있다(외부 변이로 앵커·길이가 낡은 경합). 거부가 onInput 밖으로
+// 던져지면 핸들러가 죽고 조합 추적(compositionAnchor/Length)이 낡은 값으로 wedge 되어
+// 이후 모든 조합 업데이트가 연쇄 실패한다. 조합 분기는 반드시 거부를 잡아 현재 캐럿에
+// 재정박해야 한다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const source = readFileSync(join(rootDir, 'src/engine/input-handler-text.ts'), 'utf8');
+
+function compositionBranch(): string {
+  const start = source.indexOf('if (this.isComposing && this.compositionAnchor) {');
+  assert.notEqual(start, -1, '조합 분기를 찾지 못했다');
+  const end = source.indexOf('// iOS 폴백', start);
+  return source.slice(start, end === -1 ? start + 3000 : end);
+}
+
+test('조합 업데이트의 raw replace 는 try/catch 로 보호된다', () => {
+  const branch = compositionBranch();
+  const tryAt = branch.indexOf('try {');
+  const replaceAt = branch.indexOf('this.replaceTextAtRaw(anchor, this.compositionLength, text)');
+  assert.notEqual(replaceAt, -1, '조합 replace 호출이 없다');
+  assert.ok(tryAt !== -1 && tryAt < replaceAt,
+    '조합 replace 가 try 블록 밖에 있다 — 가드 거부가 onInput 을 죽인다');
+});
+
+test('거부 시 조합을 현재 캐럿에 재정박하고 길이를 리셋한다', () => {
+  const branch = compositionBranch();
+  assert.match(branch, /catch[\s\S]*?this\.compositionAnchor = anchor/,
+    '재정박(compositionAnchor 갱신)이 없다');
+  assert.match(branch, /catch[\s\S]*?this\.compositionLength = 0/,
+    '재정박 시 조합 길이 리셋이 없다');
+  assert.match(branch, /catch[\s\S]*?this\.cursor\.getPosition\(\)/,
+    '재정박 기준이 현재 캐럿이 아니다');
+});

--- a/src/diagnostics/ir_field_sweep.rs
+++ b/src/diagnostics/ir_field_sweep.rs
@@ -519,6 +519,8 @@ fn sweep_paragraph(base: &str, a: &Paragraph, b: &Paragraph, out: &mut Vec<Field
         has_para_text,
         tab_extended,
         numbering_restart,
+        // [#4149] 파생 캐시 — IR 비교 대상 아님 (직렬화·저장 경로에도 미포함).
+        single_line_overflow_memo: _,
     } = a;
 
     macro_rules! f {

--- a/src/document_core/commands/clipboard.rs
+++ b/src/document_core/commands/clipboard.rs
@@ -60,6 +60,10 @@ fn recompute_clipboard_control_mask(para: &Paragraph) -> u32 {
 }
 
 fn strip_structural_controls_for_text_clipboard(para: &mut Paragraph) {
+    // [#4149] clip 사본이지만 다중 문단 붙여넣기에서 중간 문단이 통째로 문서에
+    // 스플라이스되어 렌더 입력이 될 수 있다 — 컨트롤 제거로 compose 입력이
+    // 바뀌므로 단일줄 과밀 memo 를 무효화한다.
+    para.invalidate_single_line_overflow_memo();
     let old_controls = std::mem::take(&mut para.controls);
     let old_records = std::mem::take(&mut para.ctrl_data_records);
     let mut index_map = vec![None; old_controls.len()];

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -1983,7 +1983,11 @@ impl DocumentCore {
                     }
                 }
             }
-            let _ = any_removed;
+            if any_removed {
+                // [#4149] text/char_shapes 직접 수술 — 단일줄 과밀 memo 무효화
+                // (process_table 경유로 셀 문단에도 적용된다).
+                para.invalidate_single_line_overflow_memo();
+            }
         }
 
         fn process_table(table: &mut crate::model::table::Table) {

--- a/src/document_core/commands/object_ops/common.rs
+++ b/src/document_core/commands/object_ops/common.rs
@@ -47,6 +47,12 @@ impl DocumentCore {
         styles: &crate::renderer::style_resolver::ResolvedStyleSet,
         dpi: f64,
     ) {
+        // [#4149] 컨트롤 삭제는 char_offsets −8 시프트로 compose 입력을 바꾼다 —
+        // 높이만 조정하고 reflow_line_segs 를 타지 않는 분기(남은 컨트롤/빈 문단)도
+        // 포함해 단일줄 과밀 memo 를 무효화한다. 삽입 쌍둥이
+        // `shift_for_inline_control_insert` 와 대칭 (셀 그림/도형/수식/각주 삭제
+        // 가족이 전부 이 함수로 수렴).
+        para.invalidate_single_line_overflow_memo();
         // 남은 컨트롤 중 가장 큰 높이 계산
         let max_remaining_ctrl_height = para
             .controls

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -3328,6 +3328,8 @@ impl DocumentCore {
                         cell_para.text = text;
                         let new_len = cell_para.text.chars().count();
                         cell_para.char_offsets = (0..new_len).map(|i| i as u32).collect();
+                        // [#4149] 원시 text 대입 — 단일줄 과밀 memo 무효화.
+                        cell_para.invalidate_single_line_overflow_memo();
                     }
                 }
             }

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -696,6 +696,8 @@ impl DocumentCore {
         table.local_resize_cell_widths.clear();
         table.local_resize_cell_heights.clear();
 
+        self.reflow_stale_cells_after_split(section_idx, parent_para_idx, control_idx);
+
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);
         self.paginate_if_needed();
@@ -736,6 +738,8 @@ impl DocumentCore {
         table.local_resize_cell_widths.clear();
         table.local_resize_cell_heights.clear();
 
+        self.reflow_stale_cells_after_split(section_idx, parent_para_idx, control_idx);
+
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);
         self.paginate_if_needed();
@@ -749,6 +753,62 @@ impl DocumentCore {
             "\"cellCount\":{}",
             cell_count
         )))
+    }
+
+    /// [#4138] 셀 나누기 뒤 stale 저장 line_segs 재계산 + vpos 사다리 재구축.
+    ///
+    /// `Table::split_cell*` 는 셀 폭·배치만 바꾸고 저장 line_segs 는 그대로 두므로,
+    /// 렌더러(LayoutEngine::layout_paragraph)가 옛 폭 기준 줄을 그대로 그려 새(더
+    /// 좁은) 셀 클립 경계에서 glyph 가 잘린다. 대상 판별: 저장 seg 폭이 셀 폭을
+    /// 넘으면 stale 로 확정한다 — seg 폭은 항상 패딩만큼 셀 폭보다 작게 계산되므로
+    /// 초과는 옛 폭의 증거다 (`resize_table_cells_native` 의 reflow 계약을 분할에도
+    /// 적용; 분할이 만든 새 셀은 원본 line_segs 를 클론하므로 같은 판별에 걸린다).
+    ///
+    /// per-para reflow 는 각 문단의 vpos 원점을 보존한 채 내부 줄만 다시 싸므로,
+    /// 줄 수가 늘어난 문단 뒤에서 사다리가 역행하고(실측: para[5] 끝 22920 뒤
+    /// para[6] 시작 17160) 컷 기계가 이를 RowBreak hard break 로 오판해 페이지를
+    /// 과소 적재한다. 재래핑한 셀은 사다리를 처음부터 단조 재구축한다.
+    fn reflow_stale_cells_after_split(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+    ) {
+        let stale_cells: Vec<(usize, usize)> = {
+            let para = &self.document.sections[section_idx].paragraphs[parent_para_idx];
+            let Some(Control::Table(table)) = para.controls.get(control_idx) else {
+                return;
+            };
+            table
+                .cells
+                .iter()
+                .enumerate()
+                .filter(|(_, cell)| {
+                    cell.paragraphs
+                        .iter()
+                        .flat_map(|p| p.line_segs.iter())
+                        .any(|ls| (ls.segment_width as i64) > (cell.width as i64))
+                })
+                .map(|(ci, cell)| (ci, cell.paragraphs.len()))
+                .collect()
+        };
+        for (cell_idx, para_count) in stale_cells {
+            for cell_para_idx in 0..para_count {
+                self.reflow_cell_paragraph(
+                    section_idx,
+                    parent_para_idx,
+                    control_idx,
+                    cell_idx,
+                    cell_para_idx,
+                );
+            }
+            self.rebuild_table_cell_vpos_ladder_native(
+                section_idx,
+                parent_para_idx,
+                control_idx,
+                cell_idx,
+            );
+        }
     }
 
     /// 범위 내 셀들을 각각 N줄 × M칸으로 분할한다 (네이티브).
@@ -785,6 +845,8 @@ impl DocumentCore {
         // 인덱스 배치를 바꾸므로 local_resize_cell_widths/heights가 stale해진다. 함께 비운다.
         table.local_resize_cell_widths.clear();
         table.local_resize_cell_heights.clear();
+
+        self.reflow_stale_cells_after_split(section_idx, parent_para_idx, control_idx);
 
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -6307,4 +6307,154 @@ mod tests {
             );
         }
     }
+
+    /// [#4149] 셀 문단 편집의 단일 관문 reflow_cell_paragraph / _by_path 를 지나면
+    /// 단일줄 과밀 판정 memo 가 미판정으로 돌아가야 한다 (reflow_line_segs 수렴점).
+    #[test]
+    fn issue4149_reflow_cell_paragraph_clears_single_line_overflow_memo() {
+        use crate::model::control::Control;
+        use crate::model::paragraph::SingleLineOverflowMemo;
+        use crate::model::table::{Cell, Table};
+
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+
+        let mut cell_para = Paragraph::default();
+        cell_para.text = "ABCDE".to_string();
+        cell_para.char_count = 6;
+        cell_para.char_offsets = vec![0, 1, 2, 3, 4];
+        cell_para.char_shapes = vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 0,
+        }];
+        let key = SingleLineOverflowMemo::width_key(123.0);
+        cell_para.single_line_overflow_memo.set(key, true);
+        assert!(!cell_para.single_line_overflow_memo.is_unjudged());
+
+        let table = Table {
+            cells: vec![Cell {
+                width: 8000, // 내폭 > 0 이어야 관문이 reflow_line_segs 까지 진행
+                paragraphs: vec![cell_para],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        core.document.sections[0].paragraphs[0]
+            .controls
+            .push(Control::Table(Box::new(table)));
+        let ctrl_idx = core.document.sections[0].paragraphs[0].controls.len() - 1;
+
+        // flat 관문
+        core.reflow_cell_paragraph(0, 0, ctrl_idx, 0, 0);
+        let memo_after = |core: &DocumentCore| {
+            let Control::Table(t) = &core.document.sections[0].paragraphs[0].controls[ctrl_idx]
+            else {
+                panic!("expected table");
+            };
+            t.cells[0].paragraphs[0]
+                .single_line_overflow_memo
+                .is_unjudged()
+        };
+        assert!(
+            memo_after(&core),
+            "reflow_cell_paragraph 경유 후 memo 는 미판정이어야 함"
+        );
+
+        // path 관문도 동일하게 비워야 한다.
+        {
+            let Control::Table(t) = &mut core.document.sections[0].paragraphs[0].controls[ctrl_idx]
+            else {
+                panic!("expected table");
+            };
+            t.cells[0].paragraphs[0]
+                .single_line_overflow_memo
+                .set(key, true);
+        }
+        core.reflow_cell_paragraph_by_path(0, 0, &[(ctrl_idx, 0, 0)], 0);
+        assert!(
+            memo_after(&core),
+            "reflow_cell_paragraph_by_path 경유 후 memo 는 미판정이어야 함"
+        );
+    }
+
+    /// [#4149 적대 리뷰] 셀 문단 인라인 그림 삭제가 char_offsets 를 −8 시프트하며
+    /// compose 입력을 바꾸는데, 남은 그림 height>0 분기
+    /// (reflow_paragraph_line_segs_after_control_delete branch 1)는 reflow_line_segs
+    /// 를 타지 않아 memo 무효화가 누락됐었다 — stale Some(false) verdict 가
+    /// 재래핑을 억제하면 과폭 절단 렌더. 실명령 경로로 무효화를 고정한다.
+    #[test]
+    fn issue4149_cell_picture_delete_clears_single_line_overflow_memo() {
+        use crate::model::control::Control;
+        use crate::model::image::Picture;
+        use crate::model::paragraph::{LineSeg, SingleLineOverflowMemo};
+        use crate::model::table::{Cell, Table};
+
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+
+        // 저장 ls==1 + 인라인 그림 2개 + 넓은 char run 셀 문단 (리뷰어 시나리오).
+        let mut cell_para = Paragraph::default();
+        cell_para.text = "가나다라마바사아".to_string();
+        let n = cell_para.text.chars().count() as u32;
+        // 그림 2개(8×2 code unit)가 텍스트 앞에 배치된 오프셋 구조.
+        cell_para.char_offsets = (0..n).map(|i| 16 + i).collect();
+        cell_para.char_count = n + 16 + 1;
+        cell_para.char_shapes = vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 0,
+        }];
+        cell_para.line_segs = vec![LineSeg {
+            text_start: 0,
+            line_height: 800,
+            baseline_distance: 640,
+            ..Default::default()
+        }];
+        let mut pic = Picture::default();
+        pic.common.width = 1000;
+        pic.common.height = 1000; // 남은 그림 height>0 → branch 1 (높이 조정만)
+        cell_para
+            .controls
+            .push(Control::Picture(Box::new(pic.clone())));
+        cell_para.controls.push(Control::Picture(Box::new(pic)));
+        cell_para.ctrl_data_records = vec![None, None];
+
+        // 렌더 1회로 설정된 판정을 모사 — 삭제 후 fresh 실측과 모순일 수 있는
+        // stale verdict.
+        let stale_key = SingleLineOverflowMemo::width_key(321.0);
+        cell_para.single_line_overflow_memo.set(stale_key, false);
+
+        let table = Table {
+            cells: vec![Cell {
+                width: 8000,
+                paragraphs: vec![cell_para],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        core.document.sections[0].paragraphs[0]
+            .controls
+            .push(Control::Table(Box::new(table)));
+        let ctrl_idx = core.document.sections[0].paragraphs[0].controls.len() - 1;
+
+        let path_json = format!(
+            r#"[{{"controlIdx":{},"cellIdx":0,"cellParaIdx":0}}]"#,
+            ctrl_idx
+        );
+        core.delete_cell_picture_control_by_path_native(0, 0, &path_json, 0)
+            .expect("셀 그림 삭제");
+
+        let Control::Table(t) = &core.document.sections[0].paragraphs[0].controls[ctrl_idx] else {
+            panic!("expected table");
+        };
+        let para = &t.cells[0].paragraphs[0];
+        assert_eq!(para.controls.len(), 1, "그림 1개가 삭제돼야 함");
+        assert!(
+            para.single_line_overflow_memo.get(stale_key).is_none(),
+            "인라인 그림 삭제 후 stale verdict 가 남으면 재래핑 억제 → 과폭 절단 렌더"
+        );
+        assert!(
+            para.single_line_overflow_memo.is_unjudged(),
+            "삭제 직후 memo 는 미판정 상태여야 함 (다음 렌더에서 fresh 재판정)"
+        );
+    }
 }

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -54,6 +54,33 @@ fn recalculate_cell_paragraph_vpos(
         })
         .unwrap_or(paragraphs.len());
 
+    apply_cell_vpos_ladder(
+        paragraphs,
+        start_para,
+        stop_para,
+        styles,
+        dpi,
+        is_hwp3_variant,
+    );
+}
+
+/// [#4138] `[start_para, stop_para)` 구간의 셀 문단 vpos 사다리를 문단 간격·줄간격
+/// 계산으로 재배치한다. `recalculate_cell_paragraph_vpos` 의 적용 루프를 분리한 것으로,
+/// 호출자가 정지 지점(stop_para)을 결정한다 — 텍스트 편집 경로는 RowBreak 조각 경계를
+/// 존중해 그 앞에서 멈추고, 셀 폭 변경 후 전체 재래핑 경로는 저장 경계 자체가 옛 폭
+/// 기준이므로 끝까지 재배치한다.
+fn apply_cell_vpos_ladder(
+    paragraphs: &mut [Paragraph],
+    start_para: usize,
+    stop_para: usize,
+    styles: &ResolvedStyleSet,
+    dpi: f64,
+    is_hwp3_variant: bool,
+) {
+    if paragraphs.is_empty() || start_para >= paragraphs.len() {
+        return;
+    }
+
     let boundary_gaps: Vec<i32> = paragraphs
         .windows(2)
         .map(|pair| {
@@ -2288,6 +2315,43 @@ impl DocumentCore {
             paragraphs,
             start_para,
             ignore_reset_at,
+            styles,
+            dpi,
+            is_hwp3_variant,
+        );
+    }
+
+    /// [#4138] 표 셀의 vpos 사다리를 처음부터 끝까지 단조 재구축한다.
+    ///
+    /// `recalculate_cell_paragraph_vpos` 는 저장 vpos 역행을 RowBreak 조각 경계
+    /// 신호로 존중해 그 앞에서 멈춘다. 셀 폭이 바뀌어 **모든** 문단을 재래핑한
+    /// 직후에는 저장 경계 자체가 옛 폭 기준이라 더 이상 신호가 아니므로, 정지
+    /// 없이 전 구간을 재배치한다. 간격 계산은 텍스트 편집 경로와 동일하다.
+    pub(crate) fn rebuild_table_cell_vpos_ladder_native(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+        cell_idx: usize,
+    ) {
+        let styles = &self.styles;
+        let dpi = self.dpi;
+        let is_hwp3_variant = self.document.layout_profile().hwp3_layout();
+        let Some(Control::Table(table)) = self.document.sections[section_idx].paragraphs
+            [parent_para_idx]
+            .controls
+            .get_mut(control_idx)
+        else {
+            return;
+        };
+        let Some(cell) = table.cells.get_mut(cell_idx) else {
+            return;
+        };
+        let stop_para = cell.paragraphs.len();
+        apply_cell_vpos_ladder(
+            &mut cell.paragraphs,
+            0,
+            stop_para,
             styles,
             dpi,
             is_hwp3_variant,

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -976,17 +976,7 @@ impl DocumentCore {
         } else {
             (para.controls.len() as u32) * 8
         };
-        self.document.doc_properties.caret_list_id = section_idx as u32;
-        self.document.doc_properties.caret_para_id = para_idx as u32;
-        self.document.doc_properties.caret_char_pos = caret_utf16_pos;
-        if let Some(ref mut raw) = self.document.doc_info.raw_stream {
-            let _ = crate::serializer::doc_info::surgical_update_caret(
-                raw,
-                section_idx as u32,
-                para_idx as u32,
-                caret_utf16_pos,
-            );
-        }
+        self.stamp_caret(section_idx as u32, para_idx as u32, caret_utf16_pos);
 
         if deleted_count > 0 {
             self.event_log.push(DocumentEvent::TextDeleted {
@@ -1009,6 +999,59 @@ impl DocumentCore {
             "\"charOffset\":{},\"documentPaginationPending\":{},\"flowChanged\":{}",
             new_offset, !flow_changed, flow_changed
         )))
+    }
+
+    /// char index → 캐럿 utf16 위치 (문단 끝 이상이면 끝 위치). 편집 경로 스탬핑과
+    /// `set_caret_position_native` 가 같은 계산을 공유한다 — reader
+    /// (`utf16_pos_to_char_idx`, cursor_nav.rs) 의 대칭.
+    fn caret_utf16_at(para: &Paragraph, char_idx: usize) -> u32 {
+        if char_idx < para.char_offsets.len() {
+            para.char_offsets[char_idx]
+        } else if !para.char_offsets.is_empty() {
+            let last = para.char_offsets.len() - 1;
+            let last_char = para.text.chars().nth(last);
+            para.char_offsets[last]
+                + last_char
+                    .map(|ch| if (ch as u32) > 0xFFFF { 2 } else { 1 })
+                    .unwrap_or(1)
+        } else {
+            (para.controls.len() as u32) * 8
+        }
+    }
+
+    /// [#4180] 문서 캐럿 메타데이터 스탬핑의 유일한 쓰기 지점 — doc_properties
+    /// (재직렬화 경로)와 raw_stream(passthrough 경로) 양쪽에 반영한다.
+    pub(crate) fn stamp_caret(&mut self, sec: u32, para: u32, caret_utf16: u32) {
+        self.document.doc_properties.caret_list_id = sec;
+        self.document.doc_properties.caret_para_id = para;
+        self.document.doc_properties.caret_char_pos = caret_utf16;
+        // DocInfo raw_stream 내 캐럿 위치만 surgical update (전체 재직렬화 방지)
+        if let Some(ref mut raw) = self.document.doc_info.raw_stream {
+            let _ = crate::serializer::doc_info::surgical_update_caret(raw, sec, para, caret_utf16);
+        }
+    }
+
+    /// [#4180] 저장 직전 UI 캐럿 반영 (한컴 의미론: 저장 시점 캐럿).
+    ///
+    /// 편집별 스탬핑은 "마지막 본문 편집 위치"를 남겨 열기 캐럿이 엉뚱한 페이지로
+    /// 복원됐다 — 저장 흐름이 이 함수로 현재 캐럿을 덮어쓴다. 범위 밖 위치는
+    /// 무시한다 (저장을 막지 않는다).
+    pub(crate) fn set_caret_position_native(
+        &mut self,
+        section_idx: usize,
+        para_idx: usize,
+        char_idx: usize,
+    ) {
+        let Some(para) = self
+            .document
+            .sections
+            .get(section_idx)
+            .and_then(|s| s.paragraphs.get(para_idx))
+        else {
+            return;
+        };
+        let caret_utf16 = Self::caret_utf16_at(para, char_idx);
+        self.stamp_caret(section_idx as u32, para_idx as u32, caret_utf16);
     }
 
     pub fn insert_text_native(
@@ -1141,19 +1184,7 @@ impl DocumentCore {
             // 텍스트 없이 컨트롤만 있는 경우
             (para.controls.len() as u32) * 8
         };
-        self.document.doc_properties.caret_list_id = section_idx as u32;
-        self.document.doc_properties.caret_para_id = para_idx as u32;
-        self.document.doc_properties.caret_char_pos = caret_utf16_pos;
-
-        // DocInfo raw_stream 내 캐럿 위치만 surgical update (전체 재직렬화 방지)
-        if let Some(ref mut raw) = self.document.doc_info.raw_stream {
-            let _ = crate::serializer::doc_info::surgical_update_caret(
-                raw,
-                section_idx as u32,
-                para_idx as u32,
-                caret_utf16_pos,
-            );
-        }
+        self.stamp_caret(section_idx as u32, para_idx as u32, caret_utf16_pos);
 
         self.event_log.push(DocumentEvent::TextInserted {
             section: section_idx,
@@ -1267,19 +1298,7 @@ impl DocumentCore {
         } else {
             (para.controls.len() as u32) * 8
         };
-        self.document.doc_properties.caret_list_id = section_idx as u32;
-        self.document.doc_properties.caret_para_id = para_idx as u32;
-        self.document.doc_properties.caret_char_pos = caret_utf16_pos;
-
-        // DocInfo raw_stream 내 캐럿 위치만 surgical update (전체 재직렬화 방지)
-        if let Some(ref mut raw) = self.document.doc_info.raw_stream {
-            let _ = crate::serializer::doc_info::surgical_update_caret(
-                raw,
-                section_idx as u32,
-                para_idx as u32,
-                caret_utf16_pos,
-            );
-        }
+        self.stamp_caret(section_idx as u32, para_idx as u32, caret_utf16_pos);
 
         self.event_log.push(DocumentEvent::TextDeleted {
             section: section_idx,

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -4512,6 +4512,83 @@ impl DocumentCore {
         )))
     }
 
+    /// [#4179] 본문 텍스트 매칭 스캔용 후보 페이지 — `find_pages_for_paragraph` 에서
+    /// 호스트 문단 텍스트가 원리적으로 렌더될 수 없는 페이지를 뺀다.
+    ///
+    /// 분할 표 호스트 문단의 본문 텍스트는 표 시작 페이지(cont=false, 표 앞/옆 줄)
+    /// 또는 표가 끝까지 소비된 페이지(end_cut 빈 Vec, 표 뒤 줄)에만 렌더된다.
+    /// 순수-중간 연속 컷(cont=true && end_cut 비어있지 않음)은 표가 페이지 바닥까지
+    /// 이어져 텍스트 줄이 배치될 수 없다 — 실측: dump-pages 와 render tree 전수 대조.
+    /// #4127 의 문단 단위 스킵을 페이지 단위로 일반화한 것으로, 제외 근거가 같아
+    /// 스캔 순서·결과 좌표는 불변이다. 필터가 후보를 전부 비우면(어울림 폴백 등
+    /// 예상 밖 구성) 원본 후보로 폴백한다 — #4128 과 같은 보수 계약.
+    pub(crate) fn find_text_scan_pages_for_paragraph(
+        &self,
+        section_idx: usize,
+        para_idx: usize,
+    ) -> Result<Vec<u32>, HwpError> {
+        use crate::renderer::pagination::PageItem;
+
+        let pages = self.find_pages_for_paragraph(section_idx, para_idx)?;
+        let global_offset: u32 = self.pagination[..section_idx]
+            .iter()
+            .map(|pr| pr.pages.len() as u32)
+            .sum();
+        let pr = &self.pagination[section_idx];
+
+        let page_can_render_para_text = |global_page: u32| -> bool {
+            let Some(page) = global_page
+                .checked_sub(global_offset)
+                .and_then(|local| pr.pages.get(local as usize))
+            else {
+                // 다른 구역 페이지(어울림 폴백 등) — 판정 불가면 후보 유지
+                return true;
+            };
+            for col in &page.column_contents {
+                for item in &col.items {
+                    match item {
+                        PageItem::PartialTable {
+                            para_index,
+                            is_continuation,
+                            end_cut,
+                            ..
+                        } if *para_index == para_idx => {
+                            if !*is_continuation || end_cut.is_empty() {
+                                return true;
+                            }
+                        }
+                        PageItem::FullParagraph { para_index }
+                        | PageItem::PartialParagraph { para_index, .. }
+                        | PageItem::Table { para_index, .. }
+                        | PageItem::Shape { para_index, .. }
+                            if *para_index == para_idx =>
+                        {
+                            return true;
+                        }
+                        _ => {}
+                    }
+                }
+                for wp in &col.wrap_around_paras {
+                    if wp.para_index == para_idx || wp.table_para_index == para_idx {
+                        return true;
+                    }
+                }
+            }
+            false
+        };
+
+        let filtered: Vec<u32> = pages
+            .iter()
+            .copied()
+            .filter(|&gp| page_can_render_para_text(gp))
+            .collect();
+        if filtered.is_empty() {
+            Ok(pages)
+        } else {
+            Ok(filtered)
+        }
+    }
+
     /// [#4128] 셀 내부 위치가 실제로 렌더되는 페이지만 반환한다.
     ///
     /// `find_pages_for_paragraph` 는 `para_index` 만 매칭해 표가 걸친 모든 페이지를

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -1461,6 +1461,8 @@ impl DocumentCore {
             crate::renderer::layout::LayoutEngine::paragraph_contributes_to_table_nested_text_flag(
                 cell_para,
             );
+        let units_fp_before =
+            crate::renderer::layout::LayoutEngine::cell_paragraph_units_fingerprint(cell_para);
         let deleted_count = if delete_count > 0 {
             cell_para.delete_text_at(char_offset, delete_count)
         } else {
@@ -1531,6 +1533,18 @@ impl DocumentCore {
                 ),
             )
         };
+        let units_fp_unchanged = self
+            .get_cell_paragraph_ref(
+                section_idx,
+                parent_para_idx,
+                control_idx,
+                cell_idx,
+                cell_para_idx,
+            )
+            .is_some_and(|p| {
+                crate::renderer::layout::LayoutEngine::cell_paragraph_units_fingerprint(p)
+                    == units_fp_before
+            });
         let cell_flow_changed = flow_advance_before != flow_advance_after;
         let new_offset = char_offset + new_chars_count;
         let focused_after = if focused_target_is_table_cell {
@@ -1561,6 +1575,7 @@ impl DocumentCore {
                         table,
                         local_contribution_before,
                         local_contribution_after,
+                        units_fp_unchanged,
                     );
                 }
             }
@@ -1798,6 +1813,8 @@ impl DocumentCore {
             crate::renderer::layout::LayoutEngine::paragraph_contributes_to_table_nested_text_flag(
                 cell_para,
             );
+        let units_fp_before =
+            crate::renderer::layout::LayoutEngine::cell_paragraph_units_fingerprint(cell_para);
         let deleted_count = cell_para.delete_text_at(char_offset, count);
 
         // 부모 컨트롤 dirty 마킹 (표 또는 글상자)
@@ -1839,6 +1856,18 @@ impl DocumentCore {
                 ),
             )
         };
+        let units_fp_unchanged = self
+            .get_cell_paragraph_ref(
+                section_idx,
+                parent_para_idx,
+                control_idx,
+                cell_idx,
+                cell_para_idx,
+            )
+            .is_some_and(|p| {
+                crate::renderer::layout::LayoutEngine::cell_paragraph_units_fingerprint(p)
+                    == units_fp_before
+            });
         let cell_flow_changed = flow_advance_before != flow_advance_after;
         let focused_after = if focused_target_is_table_cell {
             self.get_cell_paragraph_ref(
@@ -1869,6 +1898,7 @@ impl DocumentCore {
                         table,
                         local_contribution_before,
                         local_contribution_after,
+                        units_fp_unchanged,
                     );
                 }
             }

--- a/src/document_core/queries/cursor_rect.rs
+++ b/src/document_core/queries/cursor_rect.rs
@@ -54,6 +54,130 @@ fn clamp_cursor_to_cell_bounds(
     (clamped_x, clamped_y, clamped_height, overflowed)
 }
 
+/// [#4149] fast path 의 페이지 단위 결과.
+enum FastCellRectOutcome {
+    /// legacy 와 동일한 JSON 을 확정 — 즉시 반환.
+    Hit(String),
+    /// 이 페이지에는 대상 (cell_para, offset) run 이 없음 — 다음 후보 페이지로.
+    NoHit,
+    /// 확신 불가 — 전체 legacy 폴백.
+    Unsupported,
+}
+
+/// 셀 캐럿 TextRun 히트 — legacy 페이지 트리 탐색과 [#4149] fast path 프로브가
+/// 공유한다 (매칭 규칙이 갈리면 패리티가 깨진다).
+struct CellCursorHit {
+    page_index: u32,
+    x: f64,
+    y: f64,
+    height: f64,
+}
+
+/// 렌더 노드 트리에서 대상 셀의 bbox 를 찾는다 (legacy/fast 공유).
+fn find_table_cell_bounds_in_node(
+    node: &crate::renderer::render_tree::RenderNode,
+    parent_para: usize,
+    ctrl_idx: usize,
+    c_idx: usize,
+) -> Option<CellCursorBounds> {
+    use crate::renderer::render_tree::RenderNodeType;
+    if let RenderNodeType::Table(ref table) = node.node_type {
+        let matches_table =
+            table.para_index == Some(parent_para) && table.control_index == Some(ctrl_idx);
+        if matches_table {
+            for child in &node.children {
+                if let RenderNodeType::TableCell(ref cell) = child.node_type {
+                    if cell.model_cell_index == Some(c_idx as u32) {
+                        return Some(CellCursorBounds {
+                            x: child.bbox.x,
+                            y: child.bbox.y,
+                            w: child.bbox.width,
+                            h: child.bbox.height,
+                        });
+                    }
+                }
+            }
+        }
+    }
+    for child in &node.children {
+        if let Some(bounds) = find_table_cell_bounds_in_node(child, parent_para, ctrl_idx, c_idx) {
+            return Some(bounds);
+        }
+    }
+    None
+}
+
+/// 렌더 노드 트리에서 (cell_para, offset) 캐럿 TextRun 을 찾는다 (legacy/fast 공유).
+fn find_cursor_in_cell_node(
+    node: &crate::renderer::render_tree::RenderNode,
+    parent_para: usize,
+    ctrl_idx: usize,
+    c_idx: usize,
+    cp_idx: usize,
+    offset: usize,
+    page_index: u32,
+) -> Option<CellCursorHit> {
+    use crate::renderer::layout::compute_char_positions;
+    use crate::renderer::render_tree::RenderNodeType;
+    if let RenderNodeType::TextRun(ref text_run) = node.node_type {
+        let matches_cell = text_run.cell_context.as_ref().map_or(false, |ctx| {
+            // path.len()==1 가드가 없으면 중첩 표 *내부* 셀의 run 도
+            // 매칭된다: 내부 run 의 path[0] 은 그 중첩 표를 품은 바깥 셀과
+            // 정확히 같기 때문이다. 같은 파일의 cell_context_matches 가
+            // path 길이 일치를 계약으로 명시한다.
+            ctx.parent_para_index == parent_para
+                && ctx.path.len() == 1
+                && ctx.path[0].control_index == ctrl_idx
+                && ctx.path[0].cell_index == c_idx
+                && ctx.path[0].cell_para_index == cp_idx
+        });
+        if matches_cell {
+            let char_start = text_run.char_start.unwrap_or(0);
+            let char_count = effective_char_count(text_run);
+
+            if offset >= char_start && offset <= char_start + char_count {
+                let local_offset = offset - char_start;
+                let positions = if text_run.char_overlap.is_some() && char_count == 1 {
+                    vec![0.0, node.bbox.width]
+                } else {
+                    compute_char_positions(&text_run.text, &text_run.style)
+                };
+                let x_in_run = if local_offset < positions.len() {
+                    positions[local_offset]
+                } else if !positions.is_empty() {
+                    *positions.last().unwrap()
+                } else {
+                    0.0
+                };
+                // 베이스라인 기반 캐럿 y 계산 (본문과 동일)
+                let font_size = text_run.style.font_size;
+                let ascent = font_size * 0.8;
+                let caret_y = node.bbox.y + text_run.baseline - ascent;
+                return Some(CellCursorHit {
+                    page_index,
+                    x: node.bbox.x + x_in_run,
+                    y: caret_y,
+                    height: font_size,
+                });
+            }
+        }
+    }
+    for child in &node.children {
+        if let Some(hit) = find_cursor_in_cell_node(
+            child,
+            parent_para,
+            ctrl_idx,
+            c_idx,
+            cp_idx,
+            offset,
+            page_index,
+        ) {
+            return Some(hit);
+        }
+    }
+    None
+}
+
 fn format_cursor_rect_json(
     page_index: u32,
     x: f64,
@@ -2585,7 +2709,12 @@ impl DocumentCore {
         }
     }
 
-    /// 표 셀 내부 커서의 픽셀 좌표를 반환한다 (네이티브)
+    /// 표 셀 내부 커서의 픽셀 좌표를 반환한다 (네이티브).
+    ///
+    /// [#4149] 페이지 트리 없이 rect 를 구하는 fast path 를 먼저 시도한다.
+    /// fast path 는 확신이 없는 모든 경우 `None` 을 돌려주고, 그 경우 종전
+    /// 페이지 트리 경로(`cursor_rect_in_cell_via_page_tree`)로 폴백한다 —
+    /// fast path 는 탈출구 있는 최적화지 제2의 진실원천이 아니다.
     pub fn get_cursor_rect_in_cell_native(
         &self,
         section_idx: usize,
@@ -2595,7 +2724,37 @@ impl DocumentCore {
         cell_para_idx: usize,
         char_offset: usize,
     ) -> Result<String, HwpError> {
-        use crate::renderer::layout::compute_char_positions;
+        if let Some(json) = self.cursor_rect_in_cell_fast(
+            section_idx,
+            parent_para_idx,
+            control_idx,
+            cell_idx,
+            cell_para_idx,
+            char_offset,
+        )? {
+            return Ok(json);
+        }
+        self.cursor_rect_in_cell_via_page_tree(
+            section_idx,
+            parent_para_idx,
+            control_idx,
+            cell_idx,
+            cell_para_idx,
+            char_offset,
+        )
+    }
+
+    /// [#4149] 종전 legacy 경로 — 페이지 트리를 빌드해 캐럿 rect 를 찾는다.
+    /// fast path 의 패리티 기준(진실원천)이며, 차등 테스트가 직접 호출한다.
+    pub(crate) fn cursor_rect_in_cell_via_page_tree(
+        &self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+        cell_idx: usize,
+        cell_para_idx: usize,
+        char_offset: usize,
+    ) -> Result<String, HwpError> {
         use crate::renderer::render_tree::{RenderNode, RenderNodeType};
 
         // 표 캡션은 cell_index=65534 센티널로 렌더 트리에도 동일하게 저장됨
@@ -2609,118 +2768,11 @@ impl DocumentCore {
             Some((cell_para_idx, char_offset)),
         )?;
 
-        struct CursorHit {
-            page_index: u32,
-            x: f64,
-            y: f64,
-            height: f64,
-        }
-
-        fn find_table_cell_bounds(
-            node: &RenderNode,
-            parent_para: usize,
-            ctrl_idx: usize,
-            c_idx: usize,
-        ) -> Option<CellCursorBounds> {
-            if let RenderNodeType::Table(ref table) = node.node_type {
-                let matches_table =
-                    table.para_index == Some(parent_para) && table.control_index == Some(ctrl_idx);
-                if matches_table {
-                    for child in &node.children {
-                        if let RenderNodeType::TableCell(ref cell) = child.node_type {
-                            if cell.model_cell_index == Some(c_idx as u32) {
-                                return Some(CellCursorBounds {
-                                    x: child.bbox.x,
-                                    y: child.bbox.y,
-                                    w: child.bbox.width,
-                                    h: child.bbox.height,
-                                });
-                            }
-                        }
-                    }
-                }
-            }
-            for child in &node.children {
-                if let Some(bounds) = find_table_cell_bounds(child, parent_para, ctrl_idx, c_idx) {
-                    return Some(bounds);
-                }
-            }
-            None
-        }
-
-        fn find_cursor_in_cell(
-            node: &RenderNode,
-            parent_para: usize,
-            ctrl_idx: usize,
-            c_idx: usize,
-            cp_idx: usize,
-            offset: usize,
-            page_index: u32,
-        ) -> Option<CursorHit> {
-            if let RenderNodeType::TextRun(ref text_run) = node.node_type {
-                let matches_cell = text_run.cell_context.as_ref().map_or(false, |ctx| {
-                    // path.len()==1 가드가 없으면 중첩 표 *내부* 셀의 run 도
-                    // 매칭된다: 내부 run 의 path[0] 은 그 중첩 표를 품은 바깥 셀과
-                    // 정확히 같기 때문이다. 같은 파일의 cell_context_matches 가
-                    // path 길이 일치를 계약으로 명시한다.
-                    ctx.parent_para_index == parent_para
-                        && ctx.path.len() == 1
-                        && ctx.path[0].control_index == ctrl_idx
-                        && ctx.path[0].cell_index == c_idx
-                        && ctx.path[0].cell_para_index == cp_idx
-                });
-                if matches_cell {
-                    let char_start = text_run.char_start.unwrap_or(0);
-                    let char_count = effective_char_count(text_run);
-
-                    if offset >= char_start && offset <= char_start + char_count {
-                        let local_offset = offset - char_start;
-                        let positions = if text_run.char_overlap.is_some() && char_count == 1 {
-                            vec![0.0, node.bbox.width]
-                        } else {
-                            compute_char_positions(&text_run.text, &text_run.style)
-                        };
-                        let x_in_run = if local_offset < positions.len() {
-                            positions[local_offset]
-                        } else if !positions.is_empty() {
-                            *positions.last().unwrap()
-                        } else {
-                            0.0
-                        };
-                        // 베이스라인 기반 캐럿 y 계산 (본문과 동일)
-                        let font_size = text_run.style.font_size;
-                        let ascent = font_size * 0.8;
-                        let caret_y = node.bbox.y + text_run.baseline - ascent;
-                        return Some(CursorHit {
-                            page_index,
-                            x: node.bbox.x + x_in_run,
-                            y: caret_y,
-                            height: font_size,
-                        });
-                    }
-                }
-            }
-            for child in &node.children {
-                if let Some(hit) = find_cursor_in_cell(
-                    child,
-                    parent_para,
-                    ctrl_idx,
-                    c_idx,
-                    cp_idx,
-                    offset,
-                    page_index,
-                ) {
-                    return Some(hit);
-                }
-            }
-            None
-        }
-
         for &page_num in &pages {
             let tree = self.build_page_tree(page_num)?;
             let cell_bounds =
-                find_table_cell_bounds(&tree.root, parent_para_idx, control_idx, cell_idx);
-            if let Some(hit) = find_cursor_in_cell(
+                find_table_cell_bounds_in_node(&tree.root, parent_para_idx, control_idx, cell_idx);
+            if let Some(hit) = find_cursor_in_cell_node(
                 &tree.root,
                 parent_para_idx,
                 control_idx,
@@ -2751,7 +2803,7 @@ impl DocumentCore {
             .unwrap_or(pages[0]);
         let tree = self.build_page_tree(first_page)?;
         let first_page_cell_bounds =
-            find_table_cell_bounds(&tree.root, parent_para_idx, control_idx, cell_idx);
+            find_table_cell_bounds_in_node(&tree.root, parent_para_idx, control_idx, cell_idx);
 
         fn find_cell_run(
             node: &RenderNode,
@@ -2869,6 +2921,381 @@ impl DocumentCore {
             "셀 커서 위치를 찾을 수 없습니다: sec={}, parentPara={}, ctrl={}, cell={}, cellPara={}, offset={}",
             section_idx, parent_para_idx, control_idx, cell_idx, cell_para_idx, char_offset
         )))
+    }
+
+    /// [#4149] 페이지 트리 없이 셀 캐럿 rect 를 구하는 fast path.
+    ///
+    /// `Ok(Some(json))` 은 legacy 와 동일한 JSON 임이 계약이다 (차등 테스트가 검증).
+    /// 조금이라도 불확실한 모든 경우 `Ok(None)` — 호출자가 legacy 로 폴백한다.
+    ///
+    /// 구조: 후보 페이지(#4128 좁히기)마다, 그 페이지의 유일한 컬럼 선두
+    /// PartialTable 조각을 전량 빌드와 동일한 입력으로 재현하되 대상 셀 하나만
+    /// 방출하는 프로브(`PartialTableCellProbe`)를 돌리고, legacy 와 같은 매칭
+    /// 함수로 캐럿 run 을 찾는다. 좌표 산식은 전부 production 코드 재사용 —
+    /// 프로브는 "생략"만 하고 "변형"은 하지 않는다.
+    pub(crate) fn cursor_rect_in_cell_fast(
+        &self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+        cell_idx: usize,
+        cell_para_idx: usize,
+        char_offset: usize,
+    ) -> Result<Option<String>, HwpError> {
+        use crate::model::control::Control;
+
+        // 캡션 센티널(65534)·비표 컨트롤은 legacy 전용
+        if cell_idx == 65534 {
+            return Ok(None);
+        }
+        let is_table = self
+            .document
+            .sections
+            .get(section_idx)
+            .and_then(|s| s.paragraphs.get(parent_para_idx))
+            .and_then(|p| p.controls.get(control_idx))
+            .is_some_and(|c| matches!(c, Control::Table(_)));
+        if !is_table {
+            return Ok(None);
+        }
+
+        // 후보 페이지 — legacy 와 동일 소스·순서. (셀 units 메모가 여기서 예열되므로
+        // 폴백 시에도 이 비용은 legacy 가 재사용한다.)
+        let pages = self.find_pages_for_cell_position(
+            section_idx,
+            parent_para_idx,
+            control_idx,
+            cell_idx,
+            Some((cell_para_idx, char_offset)),
+        )?;
+        let sec_offset: u32 = self
+            .pagination
+            .iter()
+            .take(section_idx)
+            .map(|p| p.pages.len() as u32)
+            .sum();
+        let sec_len = self
+            .pagination
+            .get(section_idx)
+            .map(|p| p.pages.len() as u32)
+            .unwrap_or(0);
+
+        for &page_num in &pages {
+            if page_num < sec_offset || page_num >= sec_offset + sec_len {
+                return Ok(None);
+            }
+            match self.cursor_rect_in_cell_fast_on_page(
+                section_idx,
+                parent_para_idx,
+                control_idx,
+                cell_idx,
+                cell_para_idx,
+                char_offset,
+                page_num,
+            )? {
+                FastCellRectOutcome::Hit(json) => return Ok(Some(json)),
+                // legacy 도 이 페이지 트리에서 캐럿 run 을 못 찾고 다음 후보로 넘어간다
+                FastCellRectOutcome::NoHit => continue,
+                FastCellRectOutcome::Unsupported => return Ok(None),
+            }
+        }
+        // 모든 후보에서 미발견 → legacy 의 빈 셀 fallback 경로가 진실원천
+        Ok(None)
+    }
+
+    /// [#4149] 한 후보 페이지에 대한 fast path 시도.
+    #[allow(clippy::too_many_arguments)]
+    fn cursor_rect_in_cell_fast_on_page(
+        &self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+        cell_idx: usize,
+        cell_para_idx: usize,
+        char_offset: usize,
+        page_num: u32,
+    ) -> Result<FastCellRectOutcome, HwpError> {
+        use crate::model::control::Control;
+        use crate::renderer::layout::{layout_rect_to_bbox, PartialTableCellProbe, ProbeCutPlan};
+        use crate::renderer::pagination::PageItem;
+        use crate::renderer::render_tree::{PageRenderTree, RenderNode, RenderNodeType};
+        use FastCellRectOutcome::{Hit, NoHit, Unsupported};
+
+        let Ok((page_content, paragraphs, _composed)) = self.find_page(page_num) else {
+            // 후보 페이지 해석 실패 — legacy 가 같은 상황을 자체 처리한다
+            return Ok(Unsupported);
+        };
+        if page_content.section_index != section_idx {
+            return Ok(Unsupported);
+        }
+        // ── 페이지 게이트: 단일 컬럼 + 컬럼 선두가 대상 표의 PartialTable 조각 ──
+        // (선두가 아니면 앞 항목들의 흐름 y·vpos 보정을 재현해야 해서 확신 불가)
+        if page_content.column_contents.len() != 1 {
+            return Ok(Unsupported);
+        }
+        let col = &page_content.column_contents[0];
+        if col.zone_layout.is_some()
+            || col.zone_y_offset != 0.0
+            || col.endnote_flow
+            || col.start_height < -0.5
+            || !col.wrap_around_paras.is_empty()
+            || !col.wrap_anchors.is_empty()
+        {
+            return Ok(Unsupported);
+        }
+        let Some(PageItem::PartialTable {
+            para_index,
+            control_index,
+            start_row,
+            end_row,
+            is_continuation,
+            start_cut,
+            end_cut,
+            is_block_split,
+        }) = col.items.first()
+        else {
+            return Ok(Unsupported);
+        };
+        if *para_index != parent_para_idx || *control_index != control_idx {
+            return Ok(Unsupported);
+        }
+        // host 문단 앵커의 Shape/Table 아이템은 shape_reserved 사전 점프를 만들 수
+        // 있다 — 보수적 폴백
+        if col.items.iter().any(|it| {
+            matches!(it,
+                PageItem::Shape { para_index, .. } | PageItem::Table { para_index, .. }
+                    if *para_index == parent_para_idx)
+        }) {
+            return Ok(Unsupported);
+        }
+        let Some(pr) = self.pagination.get(section_idx) else {
+            return Ok(Unsupported);
+        };
+        // 미주 병합 슬라이스(combined) 재현을 피한다 — 값은 같지만 표면을 줄인다
+        if !pr.endnote_paragraphs.is_empty() {
+            return Ok(Unsupported);
+        }
+
+        // ── 모델 게이트 (legacy build 와 동일한 렌더 정규화본 기준) ──
+        let Some(host_para) = paragraphs.get(parent_para_idx) else {
+            return Ok(Unsupported);
+        };
+        let Some(Control::Table(table)) = host_para.controls.get(control_idx) else {
+            return Ok(Unsupported);
+        };
+        if table.common.treat_as_char || table.caption.is_some() {
+            return Ok(Unsupported);
+        }
+        let Some(cell) = table.cells.get(cell_idx) else {
+            return Ok(Unsupported);
+        };
+        if cell.paragraphs.get(cell_para_idx).is_none() {
+            return Ok(Unsupported);
+        }
+        // 반복 제목행 사본으로 그려질 수 있는 셀은 컷 창 모델 밖
+        let cell_row = cell.row as usize;
+        let cell_end_row = cell_row + (cell.row_span as usize).max(1);
+        if *is_continuation && table.repeat_header && cell_end_row <= *start_row {
+            return Ok(Unsupported);
+        }
+
+        // ── 좌표계 프라이밍 — build_page_tree/build_single_column 과 동일 상태.
+        // (memoized cell_units 등 포인터-키 캐시가 동일 값으로 채워지도록, 상태
+        // 의존 게이트·컷 계획보다 먼저 프라이밍한다.)
+        self.layout_engine
+            .set_show_transparent_borders(self.show_transparent_borders);
+        self.layout_engine.set_clip_enabled(self.clip_enabled);
+        self.layout_engine
+            .set_show_control_codes(self.show_control_codes);
+        self.layout_engine
+            .set_layout_profile(self.document.layout_profile());
+        self.layout_engine.set_hwp3_origin_flow_spacing_before(
+            super::rendering::uses_hwp3_origin_flow_spacing_before(&self.document),
+        );
+        self.layout_engine
+            .set_active_field(self.active_field.as_ref().map(|af| {
+                (
+                    af.section_idx,
+                    af.para_idx,
+                    af.control_idx,
+                    af.cell_path.clone(),
+                )
+            }));
+        self.layout_engine
+            .set_hidden_header_footer(&self.hidden_header_footer);
+        let total_pages: u32 = self.pagination.iter().map(|p| p.pages.len() as u32).sum();
+        self.layout_engine.set_total_pages(total_pages);
+        self.layout_engine.set_file_name(&self.file_name);
+        self.layout_engine
+            .set_hidden_empty_paras(&pr.hidden_empty_paras);
+        self.layout_engine
+            .set_pre_emitted_host_paras(&pr.pre_emitted_host_paras);
+        self.layout_engine
+            .set_pre_emitted_host_heights(&pr.pre_emitted_host_heights);
+        let layout = &page_content.layout;
+        self.layout_engine.prime_column_layout_env(layout);
+
+        // ── 상태 의존 게이트: auto counter 소비(개요/번호·AutoNumber·캡션 번호)가
+        // 표 서브트리에 있으면 이전 페이지 replay 없이는 번호가 어긋난다 ──
+        if self
+            .layout_engine
+            .table_subtree_blocks_cursor_probe(table, &self.styles)
+        {
+            return Ok(Unsupported);
+        }
+
+        // ── 컷 계획: 이 조각에서 대상 셀의 컷 창과 창 문단 범위 ──
+        let plan = self.layout_engine.partial_table_cell_probe_plan(
+            table,
+            cell,
+            *start_row,
+            *end_row,
+            start_cut,
+            end_cut,
+            *is_block_split,
+            &self.styles,
+            cell_para_idx,
+        );
+        // 전량 compose 를 허용하는 셀 크기 상한 — 정확성이 아니라 fast path 의
+        // 존재 이유(속도)를 지키는 게이트다.
+        const FULL_COMPOSE_MAX: usize = 64;
+        let n_paras = cell.paragraphs.len();
+        let (windowed, window_paras) = match plan {
+            ProbeCutPlan::Unsupported => return Ok(Unsupported),
+            ProbeCutPlan::Uncut => {
+                if n_paras > FULL_COMPOSE_MAX {
+                    return Ok(Unsupported);
+                }
+                (false, (0, n_paras.saturating_sub(1)))
+            }
+            ProbeCutPlan::Cut {
+                window_paras,
+                split_proven,
+                target_in_window,
+            } => {
+                if !target_in_window {
+                    // 창 밖 문단은 이 페이지에 cell_para 매칭 run 이 없다 —
+                    // legacy 도 이 페이지에서 못 찾고 다음 후보로 간다.
+                    return Ok(NoHit);
+                }
+                if n_paras <= FULL_COMPOSE_MAX {
+                    (false, window_paras)
+                } else {
+                    // windowed 사전 증명:
+                    //  (a) line_segs>=2 문단 존재 → shrink 패딩 축소 조기탈출과 동일
+                    //  (b) Top 정렬 확정 — split 증명 또는 원래 valign 이 Top
+                    //  (c) 가로쓰기 (세로쓰기는 전량 슬라이스 필요)
+                    let any_multiline = cell.paragraphs.iter().any(|p| p.line_segs.len() >= 2);
+                    let top_ok = split_proven
+                        || matches!(cell.vertical_align, crate::model::table::VerticalAlign::Top);
+                    if !any_multiline || !top_ok || cell.text_direction != 0 {
+                        return Ok(Unsupported);
+                    }
+                    (true, window_paras)
+                }
+            }
+        };
+
+        // ── 컬럼 선두 흐름 y 재현: 게이트로 보장된 조건에서 y = col_area.y ──
+        // (build_single_column: start_shift=0, body_wide_reserved 없음(단일 컬럼),
+        //  shape_reserved 앵커 없음(게이트), 첫 아이템은 HeightCursor.vpos_adjust 가
+        //  prev 부재로 항등)
+        let zone_layout = layout; // col.zone_layout None 게이트 통과
+        let col_area_idx = col.column_index as usize;
+        let col_area = if col_area_idx < zone_layout.column_areas.len() {
+            zone_layout.column_areas[col_area_idx]
+        } else {
+            zone_layout.body_area
+        };
+        let y_offset = col_area.y;
+
+        // layout_partial_table_item 의 지오메트리 입력 재현 (host 텍스트 방출은
+        // 캐럿과 무관 — pt_y_start 는 host 렌더 유무와 관계없이 y_offset)
+        let (pt_margin_left, pt_margin_right) = {
+            let ps = self
+                .styles
+                .para_styles
+                .get(host_para.para_shape_id as usize);
+            let ml = ps.map(|s| s.margin_left).unwrap_or(0.0);
+            let ind = ps.map(|s| s.indent).unwrap_or(0.0);
+            let mr = ps.map(|s| s.margin_right).unwrap_or(0.0);
+            (if ind > 0.0 { ml + ind } else { ml }, mr)
+        };
+        let pt_mt = self.measured_tables.get(section_idx).and_then(|v| {
+            v.iter()
+                .find(|mt| mt.para_index == parent_para_idx && mt.control_index == control_idx)
+        });
+        let outline_num_id = self
+            .document
+            .sections
+            .get(section_idx)
+            .map(|s| s.section_def.outline_numbering_id)
+            .unwrap_or(0);
+
+        // ── 대상 셀 하나만 방출하는 프로브 레이아웃 ──
+        let mut scratch_tree = PageRenderTree::new(
+            page_content.page_index,
+            layout.page_width,
+            layout.page_height,
+        );
+        let col_id = scratch_tree.next_id();
+        let mut scratch_col = RenderNode::new(
+            col_id,
+            RenderNodeType::Column(col.column_index),
+            layout_rect_to_bbox(&col_area),
+        );
+        let probe = PartialTableCellProbe {
+            cell_idx,
+            stop_after_para: cell_para_idx,
+            windowed,
+            window_paras,
+        };
+        self.layout_engine.layout_partial_table(
+            &mut scratch_tree,
+            &mut scratch_col,
+            paragraphs,
+            parent_para_idx,
+            control_idx,
+            section_idx,
+            &self.styles,
+            outline_num_id,
+            &col_area,
+            y_offset,
+            &self.document.bin_data_content,
+            *start_row,
+            *end_row,
+            *is_continuation,
+            start_cut,
+            end_cut,
+            *is_block_split,
+            pt_margin_left,
+            pt_margin_right,
+            pt_mt,
+            false,
+            Some(&probe),
+        );
+
+        // legacy 와 동일한 매칭 함수로 캐럿·셀 bbox 탐색
+        let cell_bounds =
+            find_table_cell_bounds_in_node(&scratch_col, parent_para_idx, control_idx, cell_idx);
+        if let Some(hit) = find_cursor_in_cell_node(
+            &scratch_col,
+            parent_para_idx,
+            control_idx,
+            cell_idx,
+            cell_para_idx,
+            char_offset,
+            page_num,
+        ) {
+            return Ok(Hit(format_cursor_rect_json(
+                hit.page_index,
+                hit.x,
+                hit.y,
+                hit.height,
+                cell_bounds,
+            )));
+        }
+        Ok(NoHit)
     }
 
     // ─── 컨테이너 렌더 범위 조회 ──────────────────────────────
@@ -5880,5 +6307,319 @@ mod tests {
                 Err(e) => println!("DUMP {cpi} {off} ERR {e}"),
             }
         }
+    }
+
+    // ─── [#4149] 셀 캐럿 fast path 차등(패리티) 테스트 ─────────────────────
+    //
+    // 합격 기준: fast path 가 Some 을 돌려준 모든 지점에서 legacy
+    // (`cursor_rect_in_cell_via_page_tree`) JSON 과 완전 일치. fast 가 None 인
+    // 지점은 wrapper 가 legacy 로 폴백하므로 정의상 동일 출력이다.
+
+    /// 샘플의 모든 최상위 표 × 셀 × (스텝된) 문단 × offset {0, len/2, len} 그리드에서
+    /// fast/legacy 차등 검증. (fast_some, checked) 를 반환한다.
+    fn issue4149_assert_fast_parity(sample: &str, max_points: usize) -> (usize, usize) {
+        let p = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(sample);
+        let bytes = std::fs::read(&p).expect("read sample");
+        let core = crate::document_core::DocumentCore::from_bytes(&bytes).expect("parse");
+        let doc = core.document();
+
+        // 그리드 수집 (모든 섹션의 최상위 표)
+        let mut points: Vec<(usize, usize, usize, usize, usize, usize)> = Vec::new();
+        for (si, sec) in doc.sections.iter().enumerate() {
+            for (pi, para) in sec.paragraphs.iter().enumerate() {
+                for (ci, ctrl) in para.controls.iter().enumerate() {
+                    let crate::model::control::Control::Table(ref t) = ctrl else {
+                        continue;
+                    };
+                    for (cell_i, cell) in t.cells.iter().enumerate() {
+                        let n = cell.paragraphs.len();
+                        if n == 0 {
+                            continue;
+                        }
+                        let step = (n / 80).max(1);
+                        let mut cpi = 0usize;
+                        while cpi < n {
+                            let len = cell.paragraphs[cpi].text.chars().count();
+                            points.push((si, pi, ci, cell_i, cpi, 0));
+                            if len > 0 {
+                                points.push((si, pi, ci, cell_i, cpi, len / 2));
+                                points.push((si, pi, ci, cell_i, cpi, len));
+                            }
+                            cpi += step;
+                        }
+                    }
+                }
+            }
+        }
+        // 결정적 상한 (전수에 가깝게, 러닝타임 폭주만 차단)
+        if points.len() > max_points {
+            let step = points.len().div_ceil(max_points);
+            points = points.into_iter().step_by(step).collect();
+        }
+
+        let mut fast_some = 0usize;
+        let mut checked = 0usize;
+        for &(si, pi, ci, cell_i, cpi, off) in &points {
+            checked += 1;
+            // fast 의 에러는 legacy 도 같은 좁히기에서 에러 — 폴백 경로로 취급
+            let fast = core
+                .cursor_rect_in_cell_fast(si, pi, ci, cell_i, cpi, off)
+                .unwrap_or_default();
+            let Some(fast_json) = fast else { continue };
+            fast_some += 1;
+            let legacy = core
+                .cursor_rect_in_cell_via_page_tree(si, pi, ci, cell_i, cpi, off)
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "{sample} (s{si} p{pi} c{ci} cell{cell_i} cp{cpi} off{off}): \
+                         fast=Some 인데 legacy 에러 {e}"
+                    )
+                });
+            assert_eq!(
+                fast_json, legacy,
+                "{sample} 패리티 불일치 (s{si} p{pi} c{ci} cell{cell_i} cp{cpi} off{off})"
+            );
+        }
+        eprintln!(
+            "#4149 {}: fast 적중 {} / 검사 {} ({:.1}%)",
+            sample,
+            fast_some,
+            checked,
+            fast_some as f64 * 100.0 / checked.max(1) as f64
+        );
+        (fast_some, checked)
+    }
+
+    /// [#4149 진단] fast path 게이트 단계별 통과 여부 — 수동 실행.
+    #[test]
+    #[ignore = "게이트 진단 — 수동 실행"]
+    fn issue4149_diag_fast_path_gates() {
+        use crate::model::control::Control;
+        use crate::renderer::layout::ProbeCutPlan;
+        use crate::renderer::pagination::PageItem;
+        let (core, host_pi, host_ci, cell_idx) = issue4128_fixture();
+        let pages = core
+            .find_pages_for_cell_position(0, host_pi, host_ci, cell_idx, Some((6, 5)))
+            .expect("pages");
+        eprintln!("pages={pages:?}");
+        let page_num = pages[0];
+        let (page_content, paragraphs, _c) = core.find_page(page_num).expect("find_page");
+        eprintln!(
+            "cols={} zone={:?} zoff={} endnote={} start_h={} wrapA={} wrapAnch={}",
+            page_content.column_contents.len(),
+            page_content.column_contents[0].zone_layout.is_some(),
+            page_content.column_contents[0].zone_y_offset,
+            page_content.column_contents[0].endnote_flow,
+            page_content.column_contents[0].start_height,
+            page_content.column_contents[0].wrap_around_paras.len(),
+            page_content.column_contents[0].wrap_anchors.len(),
+        );
+        let col = &page_content.column_contents[0];
+        eprintln!("items0 = {:?}", col.items.first());
+        let host_anchor = col.items.iter().any(|it| {
+            matches!(it,
+                PageItem::Shape { para_index, .. } | PageItem::Table { para_index, .. }
+                    if *para_index == host_pi)
+        });
+        eprintln!("host_anchor_items = {host_anchor}");
+        let pr = &core.pagination[0];
+        eprintln!("endnote_paras = {}", pr.endnote_paragraphs.len());
+        let host = &paragraphs[host_pi];
+        let Control::Table(ref table) = host.controls[host_ci] else {
+            panic!()
+        };
+        eprintln!(
+            "tac={} caption={} repeat_header={}",
+            table.common.treat_as_char,
+            table.caption.is_some(),
+            table.repeat_header
+        );
+        let blocked = core
+            .layout_engine
+            .table_subtree_blocks_cursor_probe(table, &core.styles);
+        eprintln!("subtree_blocked = {blocked}");
+        if blocked {
+            // 차단 원인 탐색 (스캔 로직 복제 + 보고)
+            fn why(
+                paras: &[crate::model::paragraph::Paragraph],
+                styles: &crate::renderer::style_resolver::ResolvedStyleSet,
+                depth: usize,
+            ) -> Option<String> {
+                use crate::model::style::HeadType;
+                for (i, p) in paras.iter().enumerate() {
+                    let head = styles
+                        .para_styles
+                        .get(p.para_shape_id as usize)
+                        .map(|s| s.head_type)
+                        .unwrap_or(HeadType::None);
+                    if matches!(head, HeadType::Outline | HeadType::Number) {
+                        return Some(format!("d{depth} p{i} head={head:?}"));
+                    }
+                    for (ci, c) in p.controls.iter().enumerate() {
+                        match c {
+                            Control::AutoNumber(_) => {
+                                return Some(format!("d{depth} p{i} c{ci} AutoNumber"))
+                            }
+                            Control::NewNumber(_) => {
+                                return Some(format!("d{depth} p{i} c{ci} NewNumber"))
+                            }
+                            Control::Table(t) => {
+                                if t.caption.is_some() {
+                                    return Some(format!("d{depth} p{i} c{ci} nested caption"));
+                                }
+                                for (cei, cell) in t.cells.iter().enumerate() {
+                                    if let Some(w) = why(&cell.paragraphs, styles, depth + 1) {
+                                        return Some(format!(
+                                            "d{depth} p{i} c{ci} cell{cei} → {w}"
+                                        ));
+                                    }
+                                }
+                            }
+                            Control::Shape(s) => {
+                                use crate::model::shape::ShapeObject;
+                                match &**s {
+                                    ShapeObject::Rectangle(_)
+                                    | ShapeObject::Ellipse(_)
+                                    | ShapeObject::Polygon(_)
+                                    | ShapeObject::Curve(_)
+                                    | ShapeObject::Line(_)
+                                    | ShapeObject::Arc(_) => {}
+                                    other => {
+                                        return Some(format!(
+                                            "d{depth} p{i} c{ci} shape variant {:?}",
+                                            std::mem::discriminant(other)
+                                        ))
+                                    }
+                                }
+                            }
+                            Control::Picture(pic) => {
+                                if pic.caption.is_some() {
+                                    return Some(format!("d{depth} p{i} c{ci} picture caption"));
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                None
+            }
+            for (cei, cell) in table.cells.iter().enumerate() {
+                if let Some(w) = why(&cell.paragraphs, &core.styles, 0) {
+                    eprintln!("blocked by: cell{cei} → {w}");
+                    break;
+                }
+            }
+        }
+        if let Some(PageItem::PartialTable {
+            start_row,
+            end_row,
+            start_cut,
+            end_cut,
+            is_block_split,
+            ..
+        }) = col.items.first()
+        {
+            let cell = &table.cells[cell_idx];
+            let plan = core.layout_engine.partial_table_cell_probe_plan(
+                table,
+                cell,
+                *start_row,
+                *end_row,
+                start_cut,
+                end_cut,
+                *is_block_split,
+                &core.styles,
+                6,
+            );
+            match plan {
+                ProbeCutPlan::Unsupported => eprintln!("plan=Unsupported"),
+                ProbeCutPlan::Uncut => eprintln!("plan=Uncut (n={})", cell.paragraphs.len()),
+                ProbeCutPlan::Cut {
+                    window_paras,
+                    split_proven,
+                    target_in_window,
+                } => eprintln!(
+                    "plan=Cut window={window_paras:?} split_proven={split_proven} in_window={target_in_window} any_multiline={} valign={:?} dir={}",
+                    cell.paragraphs.iter().any(|p| p.line_segs.len() >= 2),
+                    cell.vertical_align,
+                    cell.text_direction
+                ),
+            }
+        }
+        let fast = core
+            .cursor_rect_in_cell_fast(0, host_pi, host_ci, cell_idx, 6, 5)
+            .expect("fast");
+        eprintln!("fast = {fast:?}");
+    }
+
+    /// [#4149] 거대 셀 분할 표 — fast path 의 주 대상. 적중률이 유의미해야 한다.
+    #[test]
+    fn issue4149_fast_path_parity_giant_cell() {
+        let (fast_some, checked) = issue4149_assert_fast_parity(
+            "samples/issue1949_giant_cell_nested_tables_perf.hwp",
+            400,
+        );
+        assert!(checked > 50, "그리드 {}점 — 샘플 전제 확인 필요", checked);
+        // 거대 문서에서 대부분 적중해야 fast path 가 의미 있다.
+        assert!(
+            fast_some * 2 > checked,
+            "적중 {}/{} — 거대 셀 문서에서 과반 적중 실패",
+            fast_some,
+            checked
+        );
+    }
+
+    /// [#4149] KTX.hwp — 일반 표 문서. 패리티만 요구 (적중률은 보고).
+    #[test]
+    fn issue4149_fast_path_parity_ktx() {
+        issue4149_assert_fast_parity("samples/KTX.hwp", 400);
+    }
+
+    /// [#4149] hwp_table_test_saved.hwp — 저장 왕복 표 문서. 패리티만 요구.
+    #[test]
+    fn issue4149_fast_path_parity_table_saved() {
+        issue4149_assert_fast_parity("samples/hwp_table_test_saved.hwp", 400);
+    }
+
+    /// [#4149] fast path 웜 지연 실측 — 브라우저 IME 시나리오(같은 좌표 반복 질의)에서
+    /// 페이지 트리 재빌드(~17ms) 없이 1ms 미만이어야 한다. 콜드 1회(유닛 메모 예열)는
+    /// 측정에서 제외한다.
+    #[test]
+    fn issue4149_fast_path_giant_cell_warm_latency_beats_legacy() {
+        use std::time::Instant;
+        let (core, host_pi, host_ci, cell_idx) = issue4128_fixture();
+        // 브라우저 실측 좌표와 동일 (ppi0 ci2 cell2 para6 off5) — 픽스처가 같은 셀을 고른다.
+        let warmup = core.get_cursor_rect_in_cell_native(0, host_pi, host_ci, cell_idx, 6, 5);
+        assert!(warmup.is_ok(), "웜업 실패: {:?}", warmup.err());
+        // fast path 적중 확인 — 미적중이면 이 테스트는 legacy 지연을 재는 셈이 된다.
+        let fast = core
+            .cursor_rect_in_cell_fast(0, host_pi, host_ci, cell_idx, 6, 5)
+            .expect("fast");
+        assert!(fast.is_some(), "perf 대상 좌표에서 fast path 미적중");
+
+        // 절대 벽시계 기준은 러너 속도에 종속돼 CI 에서 거짓 실패한다(실측: 로컬
+        // 0.6ms/CI 1ms+). 같은 프로세스에서 legacy 대비 배율로 판정한다 — fast 의
+        // 핵심 주장은 "페이지 트리 재빌드 회피"이므로 배율이 기계 무관 신호다.
+        let iters = 10;
+        let t = Instant::now();
+        for _ in 0..iters {
+            let _ = core
+                .get_cursor_rect_in_cell_native(0, host_pi, host_ci, cell_idx, 6, 5)
+                .expect("rect");
+        }
+        let fast_ms = t.elapsed().as_secs_f64() * 1000.0 / iters as f64;
+        let t = Instant::now();
+        for _ in 0..iters {
+            let _ = core
+                .cursor_rect_in_cell_via_page_tree(0, host_pi, host_ci, cell_idx, 6, 5)
+                .expect("legacy rect");
+        }
+        let legacy_ms = t.elapsed().as_secs_f64() * 1000.0 / iters as f64;
+        eprintln!("#4149 웜 지연: fast {fast_ms:.3}ms vs legacy {legacy_ms:.3}ms/call");
+        assert!(
+            fast_ms * 4.0 < legacy_ms,
+            "fast path 웜 지연 {fast_ms:.3}ms 가 legacy {legacy_ms:.3}ms 의 1/4 미만이 아니다 \
+             — 페이지 트리 재빌드 회피가 회귀했는지 확인 (로컬 실측 약 28배)"
+        );
     }
 }

--- a/src/document_core/queries/cursor_rect.rs
+++ b/src/document_core/queries/cursor_rect.rs
@@ -3093,6 +3093,19 @@ impl DocumentCore {
         if cell.paragraphs.get(cell_para_idx).is_none() {
             return Ok(Unsupported);
         }
+        // 프로브는 보통 캐럿 문단까지만 셀을 방출한다. 그러나 뒤 문단의 중첩 표는
+        // 모든 셀 렌더 후 수행되는 border clip 확장으로 바깥 셀 bbox를 넓힐 수 있다.
+        // `cellBounds`도 공개 JSON 계약이므로, 이 형상에서는 대상 셀만 끝까지
+        // 렌더해 같은 후처리를 재현한다. 다른 셀과 페이지 트리는 여전히 생략한다.
+        let needs_full_cell_for_bounds = cell
+            .paragraphs
+            .iter()
+            .skip(cell_para_idx.saturating_add(1))
+            .any(|para| {
+                para.controls
+                    .iter()
+                    .any(|control| matches!(control, Control::Table(_)))
+            });
         // 반복 제목행 사본으로 그려질 수 있는 셀은 컷 창 모델 밖
         let cell_row = cell.row as usize;
         let cell_end_row = cell_row + (cell.row_span as usize).max(1);
@@ -3247,7 +3260,16 @@ impl DocumentCore {
         );
         let probe = PartialTableCellProbe {
             cell_idx,
-            stop_after_para: cell_para_idx,
+            stop_after_para: if needs_full_cell_for_bounds {
+                n_paras - 1
+            } else {
+                cell_para_idx
+            },
+            // 큰 분할 셀의 현재 쪽은 `window_paras` 밖 문단을 원래부터 그리지
+            // 않는다. 창을 전량으로 넓히면 cellBounds는 맞지만 모든 문단을
+            // compose해 fast path의 지연 시간 계약을 잃는다. 종료 문단까지만
+            // 순회를 열되 기존 창을 유지하면, 이 조각의 중첩 표 border만
+            // 후처리에 참여해 legacy와 같은 clip을 만든다.
             windowed,
             window_paras,
         };

--- a/src/document_core/queries/cursor_rect.rs
+++ b/src/document_core/queries/cursor_rect.rs
@@ -388,8 +388,9 @@ impl DocumentCore {
         };
         use crate::renderer::render_tree::{RenderNode, RenderNodeType};
 
-        // 문단이 포함된 페이지 찾기
-        let pages = self.find_pages_for_paragraph(section_idx, para_idx)?;
+        // 문단이 포함된 페이지 찾기 — [#4179] 텍스트가 렌더될 수 없는
+        // 순수-중간 연속 컷 페이지는 후보에서 제외 (스캔 순서·결과 좌표 불변)
+        let pages = self.find_text_scan_pages_for_paragraph(section_idx, para_idx)?;
 
         let footnote_marker_positions: Vec<(usize, usize)> = self
             .get_render_paragraph_ref(section_idx, para_idx)

--- a/src/document_core/queries/field_query.rs
+++ b/src/document_core/queries/field_query.rs
@@ -1421,6 +1421,9 @@ fn remove_field_in_para(para: &mut Paragraph, char_offset: usize) -> Result<(), 
 /// 원본 char_offsets에서 컨트롤 배치 패턴을 보존하면서,
 /// 텍스트 길이 변경(필드 값 삽입)에 맞게 오프셋을 재계산한다.
 pub(crate) fn rebuild_char_offsets(para: &mut Paragraph) {
+    // [#4149] 호출부는 방금 text/controls 수술을 마친 상태다 (필드 제거·필드값
+    // 기입·클립보드 트림 등, 셀 문단 포함) — 단일줄 과밀 memo 무효화의 수렴점.
+    para.invalidate_single_line_overflow_memo();
     let text_chars: Vec<char> = para.text.chars().collect();
     let text_len = text_chars.len();
 

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -470,7 +470,7 @@ fn uses_hwp3_origin_page_tolerance(document: &Document) -> bool {
     para_shape_ratio < 0.05 && char_shape_ratio < 0.15
 }
 
-fn uses_hwp3_origin_flow_spacing_before(document: &Document) -> bool {
+pub(crate) fn uses_hwp3_origin_flow_spacing_before(document: &Document) -> bool {
     // HWP3-origin HWP5 변환본은 parser 단계에서 ParaShape spacing 계열을 절반으로
     // 정규화하므로, 본문 흐름 계산에서는 원래 spacing_before를 복원한다.
     // 원본 HWP3는 HWP3 parser가 만든 spacing 값을 기준으로 삼아 여기서 재확대하지 않는다.

--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -56,6 +56,80 @@ pub struct Paragraph {
     /// None = 앞 번호 목록에 이어 (기본)
     /// Some(NumberingRestart) = 이전 번호 이어 / 새 번호 시작
     pub numbering_restart: Option<NumberingRestart>,
+    /// [#4149] 셀 단일줄 과밀 판정 memo — `recompose_stored_single_line_if_overflowing`
+    /// 전용 파생 캐시. 판정 입력은 (text, char_shapes, 셀 내폭)뿐이다. 제약:
+    /// - 직렬화 금지: `Paragraph` 는 serde derive 가 없고 HWP/HWPX 저장기는 필드를
+    ///   명시 기록하므로 파일로 새지 않는다. 새 직렬화 경로를 추가하면 이 필드를 제외할 것.
+    /// - 스레드: `DocumentCore` 의 `Send` 단언이 `Arc<Vec<Paragraph>>`
+    ///   (document_core/mod.rs render normalization 캐시) 경유로 `Paragraph: Sync` 를
+    ///   요구한다 — `Cell` 불가, `AtomicU64` 패킹 사용.
+    /// - text/char_shapes 를 바꾸는 모든 경로는 `invalidate_single_line_overflow_memo`
+    ///   호출 필수 (Clone 은 memo 를 함께 복제하지만, 복제본도 자기 상태 기준으로
+    ///   유효하므로 안전 — 이후 변이 시 무효화 규약은 동일하게 적용).
+    pub single_line_overflow_memo: SingleLineOverflowMemo,
+}
+
+/// [#4149] 단일줄 과밀 판정 memo 저장소 — `AtomicU64` 1개에 (폭 키, 판정) 패킹.
+///
+/// 인코딩: `0` = 미판정. 그 외 `(width_key as u64) << 1 | overflowed`.
+/// `width_key` 는 셀 내폭의 `f32` 비트 — guard 가 내폭 > 0 을 보장하므로 키가 0 이
+/// 될 수 없어 유효 인코딩은 sentinel `0` 과 충돌하지 않는다. 폭이 바뀌면(셀 크기
+/// 조정) 키 불일치로 자연 재판정된다. f32 축약의 키 충돌은 인접 ulp 폭(상대 ~2⁻²⁴)
+/// 뿐이라 ×1.8 임계 판정에 영향이 없다.
+///
+/// `Relaxed` 순서로 충분하다 — 값은 (문단, 폭)의 결정적 함수라 경합 시 최악이
+/// 중복 측정일 뿐 오답이 없다.
+#[derive(Debug, Default)]
+pub struct SingleLineOverflowMemo(std::sync::atomic::AtomicU64);
+
+impl SingleLineOverflowMemo {
+    /// 셀 내폭(px) → memo 폭 키.
+    #[inline]
+    pub fn width_key(cell_inner_width_px: f64) -> u32 {
+        (cell_inner_width_px as f32).to_bits()
+    }
+
+    /// 저장된 판정 조회 — 폭 키가 일치할 때만 `Some(overflowed)`.
+    #[inline]
+    pub fn get(&self, width_key: u32) -> Option<bool> {
+        let v = self.0.load(std::sync::atomic::Ordering::Relaxed);
+        if v != 0 && (v >> 1) as u32 == width_key {
+            Some(v & 1 == 1)
+        } else {
+            None
+        }
+    }
+
+    /// 판정 저장. `width_key == 0`(내폭 ≤ 0)은 sentinel 과 겹치므로 저장하지 않는다.
+    #[inline]
+    pub fn set(&self, width_key: u32, overflowed: bool) {
+        if width_key == 0 {
+            return;
+        }
+        let v = ((width_key as u64) << 1) | (overflowed as u64);
+        self.0.store(v, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// 미판정 상태로 되돌린다.
+    #[inline]
+    pub fn clear(&self) {
+        self.0.store(0, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// 미판정 여부 (invalidation 검증용).
+    #[inline]
+    pub fn is_unjudged(&self) -> bool {
+        self.0.load(std::sync::atomic::Ordering::Relaxed) == 0
+    }
+}
+
+impl Clone for SingleLineOverflowMemo {
+    fn clone(&self) -> Self {
+        // 파생 캐시 복제 — 복제본도 자기 (text, char_shapes) 기준으로 유효하다.
+        Self(std::sync::atomic::AtomicU64::new(
+            self.0.load(std::sync::atomic::Ordering::Relaxed),
+        ))
+    }
 }
 
 /// 문단 스코프 메타데이터 — 문단 병합의 역연산(undo)에서 복원해야 하는 값들.
@@ -497,6 +571,12 @@ impl Paragraph {
         }
     }
 
+    /// [#4149] 단일줄 과밀 판정 memo 무효화 — text/char_shapes 를 바꾸는 경로 필수.
+    #[inline]
+    pub fn invalidate_single_line_overflow_memo(&self) {
+        self.single_line_overflow_memo.clear();
+    }
+
     /// 문자의 UTF-16 코드 유닛 수를 반환한다.
     fn char_utf16_len(c: char) -> u32 {
         if (c as u32) > 0xFFFF {
@@ -519,6 +599,8 @@ impl Paragraph {
         if self.char_offsets.is_empty() {
             return;
         }
+        // [#4149] 인라인 컨트롤 삽입은 char_shapes 경계를 옮긴다 — memo 무효화 (보수적).
+        self.invalidate_single_line_overflow_memo();
         let text_len = self.text.chars().count();
         let safe_offset = char_offset.min(text_len);
         // 컨트롤이 삽입되는 UTF-16 위치 — char_offsets 시프트 전에 계산한다.
@@ -567,6 +649,8 @@ impl Paragraph {
         if new_text.is_empty() {
             return char_offset.min(self.text.chars().count());
         }
+        // [#4149] text 변이 — 단일줄 과밀 memo 무효화.
+        self.invalidate_single_line_overflow_memo();
 
         let text_chars: Vec<char> = self.text.chars().collect();
         let text_len = text_chars.len();
@@ -720,6 +804,9 @@ impl Paragraph {
             return 0;
         }
 
+        // [#4149] text 변이 — 단일줄 과밀 memo 무효화.
+        self.invalidate_single_line_overflow_memo();
+
         // 실제 삭제할 문자 수 (범위 클램핑)
         let actual_count = count.min(text_len - char_offset);
         let del_end = char_offset + actual_count;
@@ -850,6 +937,9 @@ impl Paragraph {
     /// 분할의 시맨틱이다. 병합의 역연산으로 쓰는 호출부는 `apply_meta` 로 사라진
     /// 문단의 원래 값을 되돌려야 한다 (Task #2342).
     pub fn split_at(&mut self, char_offset: usize) -> Paragraph {
+        // [#4149] 분할은 양쪽 text 를 모두 바꾼다 — 앞 절반 memo 무효화.
+        // 새 절반은 아래 구성에서 미판정(None)으로 시작한다.
+        self.invalidate_single_line_overflow_memo();
         let control_positions = self.split_logical_control_positions();
         let split_pos = self.split_text_pos_for_logical_offset(char_offset, &control_positions);
         let text_chars: Vec<char> = self.text.chars().collect();
@@ -1101,6 +1191,8 @@ impl Paragraph {
             has_para_text: new_has_para_text,
             tab_extended: Vec::new(),
             numbering_restart: None,
+            // [#4149] 분할 산출 문단은 미판정으로 시작한다.
+            single_line_overflow_memo: SingleLineOverflowMemo::default(),
         }
     }
 
@@ -1113,6 +1205,8 @@ impl Paragraph {
         if other.text.is_empty() && other.controls.is_empty() {
             return self.text.chars().count();
         }
+        // [#4149] 병합은 text/char_shapes 를 바꾼다 — memo 무효화 (미판정 재시작).
+        self.invalidate_single_line_overflow_memo();
 
         let self_text_len = self.text.chars().count();
 
@@ -1451,6 +1545,8 @@ impl Paragraph {
         if start_char_offset >= end_char_offset || self.char_offsets.is_empty() {
             return;
         }
+        // [#4149] char_shapes 변이 — 단일줄 과밀 memo 무효화.
+        self.invalidate_single_line_overflow_memo();
         if self.char_shapes.is_empty() {
             self.char_shapes.push(CharShapeRef {
                 start_pos: 0,
@@ -1574,6 +1670,8 @@ impl Paragraph {
 
     /// 문단의 글자 모양을 단일 CharShapeRef로 초기화한다.
     pub fn set_single_char_shape(&mut self, char_shape_id: u32) {
+        // [#4149] char_shapes 변이 — 단일줄 과밀 memo 무효화.
+        self.invalidate_single_line_overflow_memo();
         self.char_shapes.clear();
         self.char_shapes.push(CharShapeRef {
             start_pos: 0,
@@ -1601,6 +1699,8 @@ impl Paragraph {
         }
 
         if replaced {
+            // [#4149] char_shapes 변이 — 단일줄 과밀 memo 무효화.
+            self.invalidate_single_line_overflow_memo();
             self.merge_adjacent_char_shapes();
         }
     }

--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -9,7 +9,7 @@ use super::style_resolver::{detect_lang_category, ResolvedStyleSet};
 use super::{px_to_hwpunit, TextStyle};
 use crate::model::control::Control;
 use crate::model::document::Section;
-use crate::model::paragraph::{CharShapeRef, LineSeg, Paragraph};
+use crate::model::paragraph::{CharShapeRef, LineSeg, Paragraph, SingleLineOverflowMemo};
 
 /// 글자겹침(CharOverlap) 렌더링 정보
 #[derive(Debug, Clone, serde::Serialize)]
@@ -1528,11 +1528,28 @@ pub fn recompose_stored_single_line_if_overflowing(
     // `stored_lines_overflow`(#2525)와 동일하게 ×1.8 로 좁혀 정당한 장평/자간·
     // 패딩 발산 범위(≤~1.5×)를 넘는 부실 저장만 재래핑한다. #2291 원 타깃
     // (76자 1-lineseg = ~7.6× 초과, 절단 해소)은 임계 위라 계속 재래핑.
-    let over = composed
-        .lines
-        .first()
-        .map(|l| estimate_composed_line_width(l, styles) > cell_inner_width_px * 1.8)
-        .unwrap_or(false);
+    //
+    // [#4149] 판정 memo — 같은 (문단 text·char_shapes, 셀 내폭)이면 판정이 결정적
+    // 인데, 페이지 트리 재빌드마다 estimate_composed_line_width 재측정이 반복돼
+    // 거대 셀 문서의 캐럿 rect 질의당 ~30% 를 차지했다. 폭 키(f32 bits 패킹)로
+    // 판정만 memo 하고(측정 생략), over=true 의 fresh 재래핑 자체는 매 빌드 그대로
+    // 수행한다 — 재래핑 결과는 composed 에만 반영되고 저장 line_segs 는 안 바뀌므로
+    // 재래핑을 생략하면 절단 렌더 회귀. text/char_shapes 변경 경로는
+    // `invalidate_single_line_overflow_memo` 로 비운다 (셀 크기 조정은 키 불일치로
+    // 자연 재판정).
+    let width_key = SingleLineOverflowMemo::width_key(cell_inner_width_px);
+    let over = match para.single_line_overflow_memo.get(width_key) {
+        Some(memoized) => memoized,
+        None => {
+            let measured = composed
+                .lines
+                .first()
+                .map(|l| estimate_composed_line_width(l, styles) > cell_inner_width_px * 1.8)
+                .unwrap_or(false);
+            para.single_line_overflow_memo.set(width_key, measured);
+            measured
+        }
+    };
     if std::env::var("RHWP_DIAG_CELLREWRAP").is_ok() && over {
         if let Some(l) = composed.lines.first() {
             for run in &l.runs {

--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -1093,6 +1093,9 @@ pub(crate) fn reflow_line_segs(
     styles: &ResolvedStyleSet,
     dpi: f64,
 ) {
+    // [#4149] 셀 편집의 단일 관문(reflow_cell_paragraph[_by_path])과 서식 적용
+    // (formatting.rs) 이 모두 여기로 수렴한다 — 단일줄 과밀 memo 무효화.
+    para.invalidate_single_line_overflow_memo();
     // 기존 LineSeg에서 dimension 값 보존 (원본 HWP 호환성 유지)
     let seg_width_hwp = px_to_hwpunit(available_width_px, dpi);
     let orig = para.line_segs.first().cloned();

--- a/src/renderer/composer/tests.rs
+++ b/src/renderer/composer/tests.rs
@@ -1388,3 +1388,198 @@ fn test_kbu1_line_start_forbidden_retraction() {
         "retraction 후 char_start 는 '다' 위치"
     );
 }
+
+// ───────────────────── [#4149] 셀 단일줄 과밀 판정 memo ─────────────────────
+
+/// 가드 전제(저장 단일 lineseg, 비합성 tag)를 만족하는 문단.
+fn issue4149_guard_para(text: &str) -> Paragraph {
+    let n = text.chars().count();
+    Paragraph {
+        text: text.to_string(),
+        char_offsets: (0..n as u32).collect(),
+        char_count: n as u32 + 1,
+        char_shapes: vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 0,
+        }],
+        // 저장 단일 lineseg (tag=0 → TAG_IMPLEMENTATION_PROPERTY 미설정 = 비합성).
+        line_segs: vec![LineSeg {
+            text_start: 0,
+            line_height: 800,
+            baseline_distance: 640,
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+/// 첫 판정이 memo 되고, memo hit 에도 over=true 의 fresh 재래핑은 매 빌드 수행된다 —
+/// 재래핑 결과는 composed 에만 반영되고 저장 line_segs 는 안 바뀌므로 생략하면
+/// 절단 렌더 회귀(#2291).
+#[test]
+fn issue4149_overflow_judgment_memoized_and_rewrap_still_runs_on_hit() {
+    let styles = crate::renderer::style_resolver::ResolvedStyleSet::default();
+    let para = issue4149_guard_para(&"가".repeat(60));
+    let width = 50.0; // 60자 실폭 ≫ 50×1.8
+    let key = crate::model::paragraph::SingleLineOverflowMemo::width_key(width);
+    assert!(para.single_line_overflow_memo.is_unjudged());
+
+    let mut composed = compose_paragraph(&para);
+    assert_eq!(composed.lines.len(), 1);
+    recompose_stored_single_line_if_overflowing(&mut composed, &para, width, &styles);
+    assert!(
+        composed.lines.len() > 1,
+        "과밀 저장 단일줄은 fresh 재래핑돼야 함"
+    );
+    assert_eq!(
+        para.single_line_overflow_memo.get(key),
+        Some(true),
+        "판정이 (폭 키, over) 로 memo 돼야 함"
+    );
+
+    // 두 번째 페이지 빌드 (memo hit): 측정 생략, 재래핑은 수행.
+    let mut composed2 = compose_paragraph(&para);
+    assert_eq!(composed2.lines.len(), 1);
+    recompose_stored_single_line_if_overflowing(&mut composed2, &para, width, &styles);
+    assert!(
+        composed2.lines.len() > 1,
+        "memo hit 에도 재래핑은 수행돼야 함 (절단 렌더 회귀 방지)"
+    );
+}
+
+/// memo hit 시 실폭 측정(estimate_composed_line_width)이 생략됨을 모순 memo 로
+/// 증명한다 — 실측이면 over=true 로 재래핑될 문단에 over=false memo 를 주입했을 때
+/// 재래핑이 일어나지 않으면 측정이 생략된 것이다 (= 같은 문단 2회 판정에 측정 1회).
+#[test]
+fn issue4149_memo_hit_skips_width_measurement() {
+    let styles = crate::renderer::style_resolver::ResolvedStyleSet::default();
+    let para = issue4149_guard_para(&"가".repeat(60));
+    let width = 50.0;
+    let key = crate::model::paragraph::SingleLineOverflowMemo::width_key(width);
+    para.single_line_overflow_memo.set(key, false); // 실측(true)과 모순인 memo
+
+    let mut composed = compose_paragraph(&para);
+    recompose_stored_single_line_if_overflowing(&mut composed, &para, width, &styles);
+    assert_eq!(
+        composed.lines.len(),
+        1,
+        "memo hit 시 재측정 없이 판정을 재사용해야 함"
+    );
+    assert_eq!(
+        para.single_line_overflow_memo.get(key),
+        Some(false),
+        "hit 경로는 memo 를 덮어쓰지 않아야 함"
+    );
+}
+
+/// 폭이 바뀌면(셀 크기 조정) 키 불일치로 자연 재판정된다.
+#[test]
+fn issue4149_width_change_re_judges_via_key_mismatch() {
+    let styles = crate::renderer::style_resolver::ResolvedStyleSet::default();
+    let para = issue4149_guard_para(&"가".repeat(60));
+    let narrow = 50.0;
+    // 넓은 폭에서의 기존 판정(over=false)이 남아 있는 상태.
+    para.single_line_overflow_memo.set(
+        crate::model::paragraph::SingleLineOverflowMemo::width_key(5000.0),
+        false,
+    );
+
+    let mut composed = compose_paragraph(&para);
+    recompose_stored_single_line_if_overflowing(&mut composed, &para, narrow, &styles);
+    assert!(
+        composed.lines.len() > 1,
+        "폭 키 불일치 시 재측정으로 과밀을 다시 잡아야 함"
+    );
+    assert_eq!(
+        para.single_line_overflow_memo.get(
+            crate::model::paragraph::SingleLineOverflowMemo::width_key(narrow)
+        ),
+        Some(true)
+    );
+}
+
+/// 정합(비과밀) 판정도 memo 되고 재래핑은 일어나지 않는다.
+#[test]
+fn issue4149_fit_judgment_memoized_false_without_rewrap() {
+    let styles = crate::renderer::style_resolver::ResolvedStyleSet::default();
+    let para = issue4149_guard_para("가나다");
+    let width = 5000.0;
+    let mut composed = compose_paragraph(&para);
+    recompose_stored_single_line_if_overflowing(&mut composed, &para, width, &styles);
+    assert_eq!(
+        composed.lines.len(),
+        1,
+        "정합 단일줄은 재래핑하지 않아야 함"
+    );
+    assert_eq!(
+        para.single_line_overflow_memo.get(
+            crate::model::paragraph::SingleLineOverflowMemo::width_key(width)
+        ),
+        Some(false)
+    );
+}
+
+/// text/char_shapes 를 바꾸는 모든 경로에서 memo 가 미판정으로 돌아간다.
+/// (셀 편집의 단일 관문 reflow_cell_paragraph[_by_path]는 reflow_line_segs 로
+/// 수렴한다 — document_core 관문 자체는 text_editing.rs 테스트에서 검증.)
+#[test]
+fn issue4149_memo_invalidated_by_mutation_paths() {
+    let styles = crate::renderer::style_resolver::ResolvedStyleSet::default();
+    let key = crate::model::paragraph::SingleLineOverflowMemo::width_key(500.0);
+    let prime = |p: &Paragraph| p.single_line_overflow_memo.set(key, true);
+    let mut para = issue4149_guard_para("가나다라마");
+
+    prime(&para);
+    para.insert_text_at(1, "X");
+    assert!(
+        para.single_line_overflow_memo.is_unjudged(),
+        "insert_text_at 후 미판정"
+    );
+
+    prime(&para);
+    para.delete_text_at(0, 1);
+    assert!(
+        para.single_line_overflow_memo.is_unjudged(),
+        "delete_text_at 후 미판정"
+    );
+
+    prime(&para);
+    para.apply_char_shape_range(0, 2, 7);
+    assert!(
+        para.single_line_overflow_memo.is_unjudged(),
+        "apply_char_shape_range 후 미판정"
+    );
+
+    prime(&para);
+    para.set_single_char_shape(0);
+    assert!(
+        para.single_line_overflow_memo.is_unjudged(),
+        "set_single_char_shape 후 미판정"
+    );
+
+    prime(&para);
+    reflow_line_segs(&mut para, 300.0, &styles, 96.0);
+    assert!(
+        para.single_line_overflow_memo.is_unjudged(),
+        "reflow_line_segs(셀 편집 관문의 수렴점) 후 미판정"
+    );
+
+    prime(&para);
+    let new_half = para.split_at(2);
+    assert!(
+        para.single_line_overflow_memo.is_unjudged(),
+        "split_at 앞 절반 미판정"
+    );
+    assert!(
+        new_half.single_line_overflow_memo.is_unjudged(),
+        "split_at 산출 문단은 미판정으로 시작"
+    );
+
+    prime(&para);
+    let other = issue4149_guard_para("바사");
+    para.merge_from(&other);
+    assert!(
+        para.single_line_overflow_memo.is_unjudged(),
+        "merge_from 후 미판정"
+    );
+}

--- a/src/renderer/font_metrics_data.rs
+++ b/src/renderer/font_metrics_data.rs
@@ -3,6 +3,9 @@
 //! font-metric-gen 도구로 TTF 파일에서 추출.
 //! 수동 편집 금지.
 
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
 #[derive(Debug)]
 pub struct HangulMetric {
     pub cho_groups: u8,
@@ -155,7 +158,79 @@ fn resolve_metric_alias(name: &str) -> &str {
     }
 }
 
+/// (bold, italic) → 색인 슬롯 번호. 조합이 4개뿐이라 이름당 배열로 선계산한다.
+fn metric_slot_index(bold: bool, italic: bool) -> usize {
+    ((bold as usize) << 1) | (italic as usize)
+}
+
+/// 이름별 선계산 색인 — 슬롯 값은 (metric, bold_fallback).
+///
+/// [#4149] 글자 측정마다 find_metric 이 호출되어 600 엔트리 선형 스캔
+/// (문자열 비교 × 최대 3단 폴백)이 캐럿 rect 질의 지연의 주요 원인이었다.
+/// 이름이 테이블에 있으면 3단(이름만 매칭)이 항상 성공하므로 슬롯에 Option 이
+/// 필요 없고, 조회 실패 = 이름 부재 = 기존 None 과 동일하다.
+///
+/// 키를 (name, bold, italic) 튜플 대신 이름 단독으로 두는 이유: 튜플 키는
+/// &'static str 수명 때문에 임의 사용자 폰트명(&str)으로 borrow 조회가 불가능하다.
+static METRIC_INDEX: OnceLock<HashMap<&'static str, [(&'static FontMetric, bool); 4]>> =
+    OnceLock::new();
+
+fn metric_index() -> &'static HashMap<&'static str, [(&'static FontMetric, bool); 4]> {
+    METRIC_INDEX.get_or_init(|| {
+        // 선형 스캔의 "테이블 첫 매칭 우선" 계약 재현: 테이블 순서대로 순회하며
+        // (name, bold, italic) 조합별 첫 엔트리와 이름 첫 등장 엔트리만 기록한다.
+        struct FirstSeen {
+            exact: [Option<&'static FontMetric>; 4],
+            first: &'static FontMetric,
+        }
+        let mut seen: HashMap<&'static str, FirstSeen> = HashMap::new();
+        for m in FONT_METRICS.iter() {
+            let entry = seen.entry(m.name).or_insert(FirstSeen {
+                exact: [None; 4],
+                first: m,
+            });
+            let idx = metric_slot_index(m.bold, m.italic);
+            if entry.exact[idx].is_none() {
+                entry.exact[idx] = Some(m);
+            }
+        }
+        // 슬롯 선주입 순서 = legacy 폴백 사다리와 동일:
+        // 1단 정확 매칭 → 2단 bold 매칭(italic 무시) → 3단 이름만 첫 엔트리.
+        seen.into_iter()
+            .map(|(name, fs)| {
+                let mut slots = [(fs.first, false); 4];
+                for bold in [false, true] {
+                    for italic in [false, true] {
+                        slots[metric_slot_index(bold, italic)] =
+                            if let Some(m) = fs.exact[metric_slot_index(bold, italic)] {
+                                (m, false)
+                            } else if let Some(m) = fs.exact[metric_slot_index(bold, false)] {
+                                (m, false)
+                            } else {
+                                // bold 요청이었으면 Faux Bold 보정 표시 (legacy 3단과 동일)
+                                (fs.first, bold)
+                            };
+                    }
+                }
+                (name, slots)
+            })
+            .collect()
+    })
+}
+
 pub fn find_metric(name: &str, bold: bool, italic: bool) -> Option<MetricMatch> {
+    let name = resolve_metric_alias(name);
+    let slots = metric_index().get(name)?;
+    let (metric, bold_fallback) = slots[metric_slot_index(bold, italic)];
+    Some(MetricMatch {
+        metric,
+        bold_fallback,
+    })
+}
+
+/// 기존 선형 스캔 구현 — 색인 등가성 검증 전용으로 보존 (수정 금지).
+#[cfg(test)]
+fn legacy_find_metric(name: &str, bold: bool, italic: bool) -> Option<MetricMatch> {
     let name = resolve_metric_alias(name);
     // 정확한 매칭 (name + bold + italic)
     if let Some(m) = FONT_METRICS
@@ -46229,5 +46304,125 @@ mod tests {
         let m = find_metric("함초롬바탕", false, false);
         assert!(m.is_some(), "함초롬바탕 기존 매핑 회귀");
         assert_eq!(m.unwrap().metric.name, "HCR Batang");
+    }
+
+    #[test]
+    fn index_matches_legacy_linear_scan_exhaustively() {
+        // [#4149] O(1) 색인 도입 계약: legacy 선형 스캔(3단 폴백 사다리)과
+        // 결과가 100% 동일해야 한다. FONT_METRICS 전체 name + 알려진 alias
+        // 전체 + 테이블에 없는 임의 이름 × (bold, italic) 4조합 전수 비교.
+        let mut names: Vec<&str> = FONT_METRICS.iter().map(|m| m.name).collect();
+        // resolve_metric_alias 좌변 전체 (별칭 추가 시 여기도 갱신).
+        names.extend([
+            "함초롬돋움",
+            "한컴돋움",
+            "돋움",
+            "함초롬바탕",
+            "한컴바탕",
+            "바탕",
+            "맑은 고딕",
+            "나눔고딕",
+            "나눔명조",
+            "바탕체",
+            "굴림",
+            "궁서",
+            "굴림체",
+            "돋움체",
+            "궁서체",
+            "D2Coding",
+            "D2 Coding",
+            "고운바탕",
+            "Gowun Batang",
+            "고운돋움",
+            "Gowun Dodum",
+            "Pretendard",
+            "프리텐다드",
+            "HY중고딕",
+            "HY견고딕",
+            "HY헤드라인M",
+            "HY견명조",
+            "HY신명조",
+            "HY그래픽",
+            "HY궁서",
+            "한양신명조",
+            "한양중고딕",
+            "한양견명조",
+            "한양견고딕",
+            "휴먼명조",
+            "신명조",
+            "HY수평선B",
+            "HY수평선M",
+            "HY울릉도B",
+            "HY울릉도M",
+            "HY태백B",
+            "HY동녘B",
+            "HY동녘M",
+            "HY각헤드라인M",
+            "본한글",
+            "본한글vf",
+            "본한글 Medium",
+            "본한글M",
+            "본고딕",
+            "본고딕vf",
+            "Source Han Sans",
+            "Source Han Sans K",
+            "Source Han Sans KR",
+            "SourceHanSans",
+            "SourceHanSansKR",
+            "SourceHanSansK",
+            "Noto Sans CJK KR",
+            "본명조",
+            "본명조vf",
+            "본명조M",
+            "Source Han Serif",
+            "Source Han Serif K",
+            "Source Han Serif KR",
+            "SourceHanSerif",
+            "SourceHanSerifKR",
+            "SourceHanSerifK",
+            "Noto Serif CJK KR",
+        ]);
+        // 테이블에 없는 임의 사용자 폰트명 — 기존과 동일하게 None 이어야 한다.
+        names.extend([
+            "NoSuchFont-Regular",
+            "가상의사용자폰트",
+            "Comic Sans MS",
+            "",
+        ]);
+
+        for name in names {
+            for bold in [false, true] {
+                for italic in [false, true] {
+                    let new = find_metric(name, bold, italic);
+                    let old = legacy_find_metric(name, bold, italic);
+                    match (new, old) {
+                        (None, None) => {}
+                        (Some(n), Some(o)) => {
+                            assert!(
+                                std::ptr::eq(n.metric, o.metric),
+                                "metric 불일치: {name:?} bold={bold} italic={italic} \
+                                 (new={}/b{}/i{}, old={}/b{}/i{})",
+                                n.metric.name,
+                                n.metric.bold,
+                                n.metric.italic,
+                                o.metric.name,
+                                o.metric.bold,
+                                o.metric.italic,
+                            );
+                            assert_eq!(
+                                n.bold_fallback, o.bold_fallback,
+                                "bold_fallback 불일치: {name:?} bold={bold} italic={italic}"
+                            );
+                        }
+                        (n, o) => panic!(
+                            "Some/None 불일치: {name:?} bold={bold} italic={italic} \
+                             new={} old={}",
+                            n.is_some(),
+                            o.is_some()
+                        ),
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -1968,6 +1968,10 @@ pub struct LayoutEngine {
     /// `cell_units_uncached` 안에서 계산되어 52,694 셀 표에서 O(셀²)(≈28억) 로 폭증했다.
     /// `cell_units_cache` 와 동일 조판 경계에서 clear 한다.
     table_nested_text_flag_cache: std::cell::RefCell<std::collections::HashMap<usize, bool>>,
+    /// [#4149] 셀 커서 fast path 프로브 차단 스캔(개요/번호 문단·AutoNumber 컨트롤
+    /// 보유 여부)의 표 포인터 키 메모 — 거대 표 서브트리 재스캔 방지.
+    /// `cell_units_cache` 와 동일 조판 경계에서 clear 한다.
+    cursor_probe_block_cache: std::cell::RefCell<std::collections::HashMap<usize, bool>>,
     /// Issue #2214 test-only: cache miss가 실제 table-wide scan으로 이어진 횟수.
     #[cfg(test)]
     table_nested_text_flag_scan_count: std::cell::Cell<usize>,
@@ -1985,6 +1989,8 @@ mod utils;
 
 pub(crate) use paragraph_layout::ensure_min_baseline;
 pub(crate) use table_layout::border_style_has_diagonal;
+// [#4149] 셀 커서 fast path 프로브 (document_core::queries::cursor_rect 전용)
+pub(crate) use table_partial::{PartialTableCellProbe, ProbeCutPlan};
 pub(crate) use text_measurement::{
     compute_char_positions, estimate_text_width, estimate_text_width_unrounded,
     extract_tab_leaders_with_extended, find_next_tab_stop, is_cjk_char, is_halfwidth_cjk_quote,
@@ -2048,6 +2054,7 @@ impl LayoutEngine {
             hwpx_page_preview: std::cell::RefCell::new(None),
             cell_units_cache: std::cell::RefCell::new(std::collections::HashMap::new()),
             table_nested_text_flag_cache: std::cell::RefCell::new(std::collections::HashMap::new()),
+            cursor_probe_block_cache: std::cell::RefCell::new(std::collections::HashMap::new()),
             #[cfg(test)]
             table_nested_text_flag_scan_count: std::cell::Cell::new(0),
         }
@@ -2058,6 +2065,7 @@ impl LayoutEngine {
     pub fn clear_layout_caches(&self) {
         self.cell_units_cache.borrow_mut().clear();
         self.table_nested_text_flag_cache.borrow_mut().clear();
+        self.cursor_probe_block_cache.borrow_mut().clear();
     }
 
     pub(crate) fn set_render_normalization_overlay(
@@ -5067,6 +5075,25 @@ impl LayoutEngine {
         }
     }
 
+    /// 단(column) 콘텐츠 레이아웃 전에 페이지 좌표계 상태를 채운다.
+    /// build_single_column 과 [#4149] 셀 커서 fast path 프로브가 공유한다 —
+    /// 프로브가 전량 빌드와 동일한 좌표계(용지 폭/본문 영역)에서 동작해야
+    /// cell_units 메모 등 포인터-키 캐시가 동일 값으로 채워진다.
+    pub(crate) fn prime_column_layout_env(&self, layout: &PageLayoutInfo) {
+        // 현재 페이지 용지 너비 설정 (표 HorzRelTo::Paper 위치 계산용)
+        self.current_paper_width.set(layout.page_width);
+        // [#3637] 쪽 높이도 여기서 채운다. 바탕쪽 분기(위)에서만 채우면 바탕쪽 없는
+        // 문서에서 0 으로 남아 셀 넘침 진단이 통째로 침묵한다.
+        self.current_page_height.set(layout.page_height);
+        // 현재 페이지 본문 영역 설정 (표 HorzRelTo::Page / VertRelTo::Page 계산용 — Task #347)
+        let ba = &layout.body_area;
+        self.current_body_area
+            .set((ba.x, ba.y, ba.width, ba.height));
+
+        // 문단 테두리 범위 수집 초기화
+        self.para_border_ranges.borrow_mut().clear();
+    }
+
     fn build_single_column(
         &self,
         tree: &mut PageRenderTree,
@@ -5092,18 +5119,7 @@ impl LayoutEngine {
             layout_rect_to_bbox(col_area),
         );
 
-        // 현재 페이지 용지 너비 설정 (표 HorzRelTo::Paper 위치 계산용)
-        self.current_paper_width.set(layout.page_width);
-        // [#3637] 쪽 높이도 여기서 채운다. 바탕쪽 분기(위)에서만 채우면 바탕쪽 없는
-        // 문서에서 0 으로 남아 셀 넘침 진단이 통째로 침묵한다.
-        self.current_page_height.set(layout.page_height);
-        // 현재 페이지 본문 영역 설정 (표 HorzRelTo::Page / VertRelTo::Page 계산용 — Task #347)
-        let ba = &layout.body_area;
-        self.current_body_area
-            .set((ba.x, ba.y, ba.width, ba.height));
-
-        // 문단 테두리 범위 수집 초기화
-        self.para_border_ranges.borrow_mut().clear();
+        self.prime_column_layout_env(layout);
 
         // TopAndBottom 글상자/표/이미지의 앵커 문단별 예약 높이 목록
         let mut shape_reserved = self.calculate_shape_reserved_heights(
@@ -8573,6 +8589,7 @@ impl LayoutEngine {
             pt_margin_right,
             pt_mt,
             false,
+            None,
         );
         if render_deferred_rowbreak_host_text_after {
             if let Some(para) = paragraphs.get(para_index) {

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -7160,6 +7160,34 @@ impl LayoutEngine {
         flag
     }
 
+    /// [#4167] 문단의 cell-units 기여 지문 — 편집이 units 를 실제로 바꿨는지 판별용.
+    ///
+    /// units 산출이 읽는 문단 입력만 포함한다: line_segs 의 (vertical_pos, line_height,
+    /// tag) 수열(개수 포함), controls 수, 공백/빈 문단 클래스. `text_start` 와
+    /// `segment_width` 는 제자리 타이핑에도 매 키 변하지만 units 산출이 읽지 않으므로
+    /// 제외한다(위 `cell_units_uncached` 전 구간 grep 근거). 인접 문단 결합(직전 끝
+    /// seg·직후 첫 seg 참조)도 이 지문에 담긴 경계 seg 로 판별된다 — 지문 불변이면
+    /// 이웃 기여도 불변이다.
+    pub(crate) fn cell_paragraph_units_fingerprint(
+        para: &crate::model::paragraph::Paragraph,
+    ) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        para.line_segs.len().hash(&mut h);
+        for seg in &para.line_segs {
+            seg.vertical_pos.hash(&mut h);
+            seg.line_height.hash(&mut h);
+            // units 산출이 tag 에서 읽는 비트는 synthetic 판별(bit 31)뿐이다. 원본
+            // 로드 tag 의 여타 비트(예: 0x100000)는 reflow 가 재방출하지 않아 첫
+            // 편집에서 무의미하게 지문을 바꾸므로 마스킹한다.
+            (seg.tag & crate::model::paragraph::LineSeg::TAG_IMPLEMENTATION_PROPERTY).hash(&mut h);
+        }
+        para.controls.len().hash(&mut h);
+        para.text.is_empty().hash(&mut h);
+        para.text.trim().is_empty().hash(&mut h);
+        h.finish()
+    }
+
     /// [Issue #2214/#2424] 텍스트 편집 뒤 edited cell의 memoized units를 국소 무효화한다.
     ///
     /// cached owner flag가 false인데 edited paragraph가 false→true가 된 경우에만
@@ -7173,6 +7201,7 @@ impl LayoutEngine {
         owner_table: &crate::model::table::Table,
         local_before: bool,
         local_after: bool,
+        unit_fingerprint_unchanged: bool,
     ) {
         let edited_cell_key = edited_cell as *const crate::model::table::Cell as usize;
         let owner_table_key = owner_table as *const crate::model::table::Table as usize;
@@ -7210,6 +7239,12 @@ impl LayoutEngine {
             return;
         }
 
+        // [#4167] 편집 문단의 units 기여 지문이 불변이면(제자리 타이핑 — 줄 수·높이
+        // 불변) 캐시된 units 벡터 전체가 그대로 유효하다 — 거대 셀(수천 문단)의
+        // 전량 recompose(11ms/키)를 생략한다. 지문이 다르면 종전대로 셀 단위 제거.
+        if unit_fingerprint_unchanged {
+            return;
+        }
         self.cell_units_cache.borrow_mut().remove(&edited_cell_key);
         if local_became_true && cached_owner_flag.is_none() {
             // cell_units entry가 있으면 owner flag도 먼저 warm된다는 현재 cache invariant에
@@ -12508,6 +12543,7 @@ mod row_cut_tests {
                     sibling_before,
                     target_shape_before,
                     owner_flag_before,
+                    target_units_fp_before,
                 ) = {
                     let table = owner_table(&core);
                     let target = &table.cells[2];
@@ -12530,6 +12566,7 @@ mod row_cut_tests {
                                 .any(|control| matches!(control, Control::Table(_))),
                         ),
                         uncached_table_flag(table),
+                        LayoutEngine::cell_paragraph_units_fingerprint(target_para),
                     )
                 };
                 assert!(
@@ -12603,11 +12640,29 @@ mod row_cut_tests {
                 let table_scan_count = core.layout_engine.table_nested_text_flag_scan_count.get();
                 let target_recomputed = !std::sync::Arc::ptr_eq(&target_before, &target_after);
                 let sibling_reused = std::sync::Arc::ptr_eq(&sibling_before, &sibling_after);
-                let desired = membership == (false, true, true)
-                    && target_recomputed
-                    && sibling_reused
-                    && owner_flag_after == owner_flag_before
-                    && table_scan_count == 0;
+                // [#4167 갱신 이력] 기대값을 "무조건 evict"에서 "units 지문 변화 시에만
+                // evict"로 변경. 제자리 1자 삽입은 units 지문(줄 수·높이·vpos·synthetic·
+                // 공백 클래스) 불변이라 캐시 항등 보존이 정답이 됐다 — 재계산해도 동일
+                // 벡터가 나옴은 issue4167_units_fingerprint_doc_contract 가 고정한다.
+                // 실측상 두 phase 의 최종 삽입 모두 지문 불변(재래핑 없음)이며, 지문이
+                // 변하는 편집의 evict 계약은 issue4167_fingerprint_unchanged_edit_
+                // retains_cell_units 의 false 분기가 고정한다.
+                let target_units_fp_after =
+                    LayoutEngine::cell_paragraph_units_fingerprint(&target.paragraphs[5]);
+                let fp_stable = target_units_fp_after == target_units_fp_before;
+                let desired = if fp_stable {
+                    membership == (true, true, true)
+                        && !target_recomputed
+                        && sibling_reused
+                        && owner_flag_after == owner_flag_before
+                        && table_scan_count == 0
+                } else {
+                    membership == (false, true, true)
+                        && target_recomputed
+                        && sibling_reused
+                        && owner_flag_after == owner_flag_before
+                        && table_scan_count == 0
+                };
                 eprintln!(
                     "#2214 {label}: membership={membership:?} target_recomputed={target_recomputed} sibling_reused={sibling_reused} owner_flag={owner_flag_before}->{owner_flag_after} table_scans={table_scan_count}"
                 );
@@ -12871,6 +12926,7 @@ mod row_cut_tests {
             &edited_table,
             false,
             false,
+            false,
         );
 
         let cell_cache = eng.cell_units_cache.borrow();
@@ -12930,7 +12986,13 @@ mod row_cut_tests {
         eng.table_nested_text_flag_scan_count.set(0);
 
         owner_table.cells[0].paragraphs[0].insert_text_at(0, "x");
-        eng.invalidate_cell_units_after_text_edit(&owner_table.cells[0], &owner_table, false, true);
+        eng.invalidate_cell_units_after_text_edit(
+            &owner_table.cells[0],
+            &owner_table,
+            false,
+            true,
+            false,
+        );
 
         assert!(eng.cell_units_cache.borrow().is_empty());
         assert_eq!(
@@ -13006,6 +13068,7 @@ mod row_cut_tests {
             &edited_table,
             false,
             true,
+            false,
         );
 
         let membership = {
@@ -13111,6 +13174,7 @@ mod row_cut_tests {
             &edited_table,
             false,
             true,
+            false,
         );
 
         let membership = {
@@ -13189,7 +13253,13 @@ mod row_cut_tests {
 
         owner_table.cells[0].paragraphs[0].text.clear();
         owner_table.cells[0].paragraphs[0].char_count = 0;
-        eng.invalidate_cell_units_after_text_edit(&owner_table.cells[0], &owner_table, true, false);
+        eng.invalidate_cell_units_after_text_edit(
+            &owner_table.cells[0],
+            &owner_table,
+            true,
+            false,
+            false,
+        );
 
         assert!(
             owner_table.cells.iter().all(|cell| {
@@ -13227,6 +13297,86 @@ mod row_cut_tests {
             eng.table_nested_text_flag_scan_count.get(),
             1,
             "owner table must be rescanned once after deletion"
+        );
+    }
+
+    /// [#4167] 지문 불변 편집(제자리 타이핑)은 memoized cell units 를 보존한다.
+    #[test]
+    fn issue4167_fingerprint_unchanged_edit_retains_cell_units() {
+        let eng = LayoutEngine::new(96.0);
+        let styles = ResolvedStyleSet::default();
+        let owner_table = table(vec![cell(0, 0, vec![text_para(3, 0)])]);
+        let _ = eng.cell_units(&owner_table.cells[0], &owner_table, &styles);
+        let key = &owner_table.cells[0] as *const crate::model::table::Cell as usize;
+        assert!(eng.cell_units_cache.borrow().contains_key(&key), "warmed");
+
+        eng.invalidate_cell_units_after_text_edit(
+            &owner_table.cells[0],
+            &owner_table,
+            true,
+            true,
+            true,
+        );
+        assert!(
+            eng.cell_units_cache.borrow().contains_key(&key),
+            "지문 불변이면 entry 를 보존해야 한다 — 제거되면 거대 셀 타이핑마다 전량 recompose (#4167)"
+        );
+
+        eng.invalidate_cell_units_after_text_edit(
+            &owner_table.cells[0],
+            &owner_table,
+            true,
+            true,
+            false,
+        );
+        assert!(
+            !eng.cell_units_cache.borrow().contains_key(&key),
+            "지문 변경이면 종전대로 제거해야 한다"
+        );
+    }
+
+    /// [#4167] units 지문은 units 산출이 읽는 입력에만 반응한다.
+    #[test]
+    fn issue4167_units_fingerprint_sensitivity() {
+        let base = text_para(3, 0);
+        let fp = LayoutEngine::cell_paragraph_units_fingerprint;
+
+        // 불변이어야 하는 변이: text_start·segment_width 시프트, synthetic 외 tag 비트
+        let mut typed = base.clone();
+        for seg in &mut typed.line_segs {
+            seg.text_start += 1;
+            seg.segment_width += 120;
+            seg.tag |= 0x0010_0000; // 원본 로드 tag 잔여 비트 — units 미소비
+        }
+        assert_eq!(
+            fp(&base),
+            fp(&typed),
+            "제자리 타이핑 급 변이는 지문 불변이어야 한다"
+        );
+
+        // 변해야 하는 변이: 줄 수, 줄 높이, synthetic 비트, 공백 클래스
+        let mut grown = base.clone();
+        grown.line_segs.push(grown.line_segs[0].clone());
+        assert_ne!(fp(&base), fp(&grown), "줄 수 변화는 지문이 변해야 한다");
+
+        let mut taller = base.clone();
+        taller.line_segs[1].line_height += 240;
+        assert_ne!(fp(&base), fp(&taller), "줄 높이 변화는 지문이 변해야 한다");
+
+        let mut synthetic = base.clone();
+        synthetic.line_segs[1].tag |= crate::model::paragraph::LineSeg::TAG_IMPLEMENTATION_PROPERTY;
+        assert_ne!(
+            fp(&base),
+            fp(&synthetic),
+            "synthetic 비트는 지문이 변해야 한다"
+        );
+
+        let mut spacer = base.clone();
+        spacer.text = "   ".to_string();
+        assert_ne!(
+            fp(&base),
+            fp(&spacer),
+            "공백 스페이서 클래스 전이는 지문이 변해야 한다"
         );
     }
 }

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -1470,8 +1470,9 @@ pub(super) struct CellUnit {
     /// 반드시 보존한다. 문단 사이 reset의 orphan/sliver 완화 계약과 구분한다.
     stored_frame_break_before: bool,
     vpos_gap_before: bool,
-    /// 이 유닛이 속한 문단 인덱스 (셀 내).
-    para_idx: usize,
+    /// 이 유닛이 속한 문단 인덱스 (셀 내). [#4149] 커서 프로브 계획이 창 문단
+    /// 범위를 계산할 때 형제 모듈(table_partial)에서 읽는다.
+    pub(super) para_idx: usize,
     /// 이 유닛이 visible 일 때 기여하는 문단 내 줄 범위 `[vis_start, vis_end)`.
     /// 텍스트 줄 유닛 = `(li, li+1)`, 중첩/빈 atom = `(0, line_count.max(1))`.
     vis_start: usize,

--- a/src/renderer/layout/table_partial.rs
+++ b/src/renderer/layout/table_partial.rs
@@ -1,6 +1,6 @@
 //! 페이지 분할 표 레이아웃 (layout_partial_table)
 
-use super::super::composer::compose_paragraph;
+use super::super::composer::{compose_paragraph, ComposedParagraph};
 use super::super::height_measurer::MeasuredTable;
 use super::super::page_layout::LayoutRect;
 use super::super::render_tree::*;
@@ -200,6 +200,115 @@ fn expand_cell_clip_to_new_source_bounded_children(
 }
 
 // 표 수평 정렬 보조 타입은 table_layout.rs에 통합됨
+
+/// [#4149] 셀 커서 fast path 프로브 — 부분 표 조각 레이아웃을 대상 셀 하나로 제한한다.
+///
+/// 계약: 방출되는 노드의 좌표는 전량 레이아웃과 완전 동일해야 한다 — 프로브는
+/// "생략"만 하고 "변형"은 하지 않는다 (셀 방출 루프는 셀-간 캐리가 없음이 근거).
+pub(crate) struct PartialTableCellProbe {
+    /// 대상 셀 인덱스 — 이 셀만 방출한다.
+    pub(crate) cell_idx: usize,
+    /// 이 문단까지 방출 후 중단한다 (캐럿 문단 — 이후 문단은 캐럿 탐색에 불필요하고
+    /// 앞 문단의 y 에도 영향이 없다).
+    pub(crate) stop_after_para: usize,
+    /// true 면 컷 창 문단(`window_paras`)만 순회·compose 한다. 사전 게이트가
+    /// (a) 컷 존재, (b) shrink 조기탈출(다중줄 문단 존재), (c) effective Top 정렬을
+    /// 증명한 경우에만 true 가 된다.
+    pub(crate) windowed: bool,
+    /// `windowed` 일 때 컷 창에 유닛이 있는 문단 범위 [lo, hi] (inclusive).
+    /// 범위 밖 문단은 컷 창에 유닛이 없어 전량 레이아웃에서도 skip 됨이 증명된다.
+    pub(crate) window_paras: (usize, usize),
+}
+
+/// [#4149] 셀 문단 compose 저장소 — windowed 프로브에서만 lazy.
+///
+/// Lazy 슬롯의 compose 결과는 Eager 경로와 동일한 변환 순서
+/// (compose → recompose_for_cell_width → recompose_stored_single_line_if_overflowing)를
+/// 문단 단위로 적용한다. windowed 프로브 게이트가 shrink 를 조기탈출로 증명하므로
+/// Lazy 에서 inner_width 는 Eager 와 동일하다.
+enum CellComposedStore {
+    Eager(Vec<ComposedParagraph>),
+    Lazy(Vec<Option<ComposedParagraph>>),
+}
+
+impl CellComposedStore {
+    fn get(
+        &mut self,
+        cpi: usize,
+        cell: &crate::model::table::Cell,
+        inner_width: f64,
+        styles: &ResolvedStyleSet,
+    ) -> &ComposedParagraph {
+        match self {
+            CellComposedStore::Eager(v) => &v[cpi],
+            CellComposedStore::Lazy(slots) => {
+                if slots[cpi].is_none() {
+                    let para = &cell.paragraphs[cpi];
+                    let mut comp = compose_paragraph(para);
+                    crate::renderer::composer::recompose_for_cell_width(
+                        &mut comp,
+                        para,
+                        inner_width,
+                        styles,
+                    );
+                    if cell.text_direction == 0 {
+                        crate::renderer::composer::recompose_stored_single_line_if_overflowing(
+                            &mut comp,
+                            para,
+                            inner_width,
+                            styles,
+                        );
+                    }
+                    slots[cpi] = Some(comp);
+                }
+                slots[cpi].as_ref().unwrap()
+            }
+        }
+    }
+
+    /// 전량 슬라이스가 필요한 경로(세로쓰기 등)를 위한 완전 구성.
+    fn materialize(
+        &mut self,
+        cell: &crate::model::table::Cell,
+        inner_width: f64,
+        styles: &ResolvedStyleSet,
+    ) {
+        if matches!(self, CellComposedStore::Lazy(_)) {
+            let mut v = Vec::with_capacity(cell.paragraphs.len());
+            for cpi in 0..cell.paragraphs.len() {
+                v.push(self.get(cpi, cell, inner_width, styles).clone());
+            }
+            *self = CellComposedStore::Eager(v);
+        }
+    }
+
+    /// Eager 전제 슬라이스 접근 — windowed 프로브 게이트 밖에서만 호출된다.
+    fn eager_slice(&self) -> &[ComposedParagraph] {
+        match self {
+            CellComposedStore::Eager(v) => v,
+            CellComposedStore::Lazy(_) => {
+                unreachable!("windowed 프로브에서 전량 compose 접근 금지")
+            }
+        }
+    }
+}
+
+/// [#4149] 프로브 사전 계획 결과.
+pub(crate) enum ProbeCutPlan {
+    /// 프로브로 다룰 수 없는 조합 (rowspan 셀, 빈 창 등) — legacy 폴백.
+    Unsupported,
+    /// 이 조각에서 셀이 컷되지 않음 (전체 가시). 소형 셀 한정 전량 프로브 가능.
+    Uncut,
+    /// 컷 존재. `window_paras` = 창에 유닛이 있는 문단 범위 [lo, hi] (inclusive).
+    Cut {
+        window_paras: (usize, usize),
+        /// 전량 레이아웃의 `cell_was_split` 이 true 임이 증명됨 (s>0 문단 존재
+        /// 또는 창 밖 미가시 문단의 compose 줄 수 ≥ 1).
+        split_proven: bool,
+        /// 대상 문단이 창 안에 있는가 — 밖이면 이 페이지에 대상 문단 run 이 없다.
+        target_in_window: bool,
+    },
+}
 
 /// [Task #1025] `row` 를 포함하는 rowspan 블록 범위 `[b_start, b_end)`.
 /// rs>1 셀이 겹치는 행을 전이적으로 확장한다(겹침 없으면 `[row, row+1)`).
@@ -406,6 +515,200 @@ impl LayoutEngine {
         ord >= su && (ord < eu || (ord == eu && at_line_start))
     }
 
+    /// [#4149] 커서 fast path 의 프로브 사전 계획 — 이 PartialTable 조각에서 `cell` 의
+    /// 컷 창과 창 문단 범위를 계산한다. 분할 게이트 판정은
+    /// `layout_partial_table_cells` 의 셀 방출 판정과 동일 산식 — 드리프트 금지.
+    /// memoize 된 `cell_units` 만 사용하며 render tree 를 짓지 않는다.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn partial_table_cell_probe_plan(
+        &self,
+        table: &crate::model::table::Table,
+        cell: &crate::model::table::Cell,
+        start_row: usize,
+        end_row: usize,
+        start_cut: &[usize],
+        end_cut: &[usize],
+        is_block_split: bool,
+        styles: &ResolvedStyleSet,
+        target_para: usize,
+    ) -> ProbeCutPlan {
+        // rowspan 셀은 straddle 높이-컷 경로(is_rowbreak_straddle)가 얽혀 보수적 폴백.
+        if cell.row_span > 1 {
+            return ProbeCutPlan::Unsupported;
+        }
+        let cell_row = cell.row as usize;
+        let cell_end_row = cell_row + (cell.row_span as usize).max(1);
+        // 분할 게이트 — layout_partial_table_cells 와 동일 판정
+        let split_start_block = if is_block_split && !start_cut.is_empty() {
+            Some(rowspan_block_range(table, start_row))
+        } else {
+            None
+        };
+        let split_end_block = if is_block_split && !end_cut.is_empty() {
+            Some(rowspan_block_range(table, end_row.saturating_sub(1)))
+        } else {
+            None
+        };
+        let is_split_start_row = if is_block_split {
+            split_start_block.is_some_and(|(s, e)| cell_row < e && cell_end_row > s)
+        } else {
+            !start_cut.is_empty() && cell_row == start_row
+        };
+        let is_split_end_row = if is_block_split {
+            split_end_block.is_some_and(|(s, e)| cell_row < e && cell_end_row > s)
+        } else {
+            !end_cut.is_empty() && cell_row == end_row.saturating_sub(1)
+        };
+        if !(is_split_start_row || is_split_end_row) {
+            // row_span==1 이므로 is_rowbreak_straddle(rowspan>1 전제) 도달 불가 — 전체 가시.
+            return ProbeCutPlan::Uncut;
+        }
+        let (su, eu) = cell_cut_window(
+            table,
+            cell,
+            is_block_split,
+            is_split_start_row,
+            split_start_block,
+            is_split_end_row,
+            split_end_block,
+            start_cut,
+            end_cut,
+            None,
+        );
+        let units = self.cell_units(cell, table, styles);
+        let lo = su.min(units.len());
+        let hi = eu.min(units.len()).max(lo);
+        if lo >= hi {
+            return ProbeCutPlan::Unsupported;
+        }
+        let mut pmin = usize::MAX;
+        let mut pmax = 0usize;
+        for u in &units[lo..hi] {
+            pmin = pmin.min(u.para_idx);
+            pmax = pmax.max(u.para_idx);
+        }
+        if pmin == usize::MAX || pmax >= cell.paragraphs.len() {
+            return ProbeCutPlan::Unsupported;
+        }
+        // cell_was_split 증명 — 전량 레이아웃의 `s != 0 || e != total` 판정과 동치인
+        // 충분조건만 취한다:
+        //   (a) 어떤 문단의 가시 시작줄 s > 0, 또는
+        //   (b) 창 밖 미가시 문단((0,0))의 compose 줄 수 ≥ 1 (recompose 는 줄을
+        //       늘리기만 하므로 pre-recompose ≥ 1 ⇒ post ≥ 1 > 0 = e).
+        let ranges = self.cell_line_ranges_from_cut(cell, table, styles, su, eu);
+        let mut split_proven = ranges.iter().any(|&(s, _)| s > 0);
+        if !split_proven {
+            for (i, &(s, e)) in ranges.iter().enumerate() {
+                if s == 0 && e == 0 && (i < pmin || i > pmax) {
+                    if compose_paragraph(&cell.paragraphs[i]).lines.is_empty() {
+                        continue;
+                    }
+                    split_proven = true;
+                    break;
+                }
+            }
+        }
+        ProbeCutPlan::Cut {
+            window_paras: (pmin, pmax),
+            split_proven,
+            target_in_window: (pmin..=pmax).contains(&target_para),
+        }
+    }
+
+    /// [#4149] 표 서브트리(호스트 표 + 중첩 표/글상자/캡션)가 프로브를 차단하는
+    /// 상태 의존 요소를 갖는지 — 표 포인터 키 메모.
+    ///
+    /// 차단 근거: (a) 개요/번호 문단은 auto counter 를 소비하는데 프로브는 이전
+    /// 페이지 replay 없이 셀 하나만 레이아웃하므로 번호가 어긋난다.
+    /// (b) AutoNumber/NewNumber 컨트롤·캡션 자동번호도 동일. (c) 묶음 개체는 내부
+    /// 글상자 유무를 싸게 판정할 수 없어 보수적으로 차단.
+    pub(crate) fn table_subtree_blocks_cursor_probe(
+        &self,
+        table: &crate::model::table::Table,
+        styles: &ResolvedStyleSet,
+    ) -> bool {
+        fn paras_block(paras: &[Paragraph], styles: &ResolvedStyleSet) -> bool {
+            use crate::model::style::HeadType;
+            for p in paras {
+                let head = styles
+                    .para_styles
+                    .get(p.para_shape_id as usize)
+                    .map(|s| s.head_type)
+                    .unwrap_or(HeadType::None);
+                if matches!(head, HeadType::Outline | HeadType::Number) {
+                    return true;
+                }
+                for c in &p.controls {
+                    match c {
+                        Control::AutoNumber(_) | Control::NewNumber(_) => return true,
+                        Control::Table(t) => {
+                            // 캡션은 존재 자체가 아니라 auto counter 소비 요소
+                            // (개요/번호 헤드·AutoNumber)를 가질 때만 차단한다 —
+                            // layout_caption 은 apply_auto_numbers_to_composed 로만
+                            // counter 를 만진다.
+                            if let Some(cap) = t.caption.as_ref() {
+                                if paras_block(&cap.paragraphs, styles) {
+                                    return true;
+                                }
+                            }
+                            for cell in &t.cells {
+                                if paras_block(&cell.paragraphs, styles) {
+                                    return true;
+                                }
+                            }
+                        }
+                        Control::Shape(s) => {
+                            use crate::model::shape::ShapeObject;
+                            let drawing = match &**s {
+                                ShapeObject::Rectangle(sh) => Some(&sh.drawing),
+                                ShapeObject::Ellipse(sh) => Some(&sh.drawing),
+                                ShapeObject::Polygon(sh) => Some(&sh.drawing),
+                                ShapeObject::Curve(sh) => Some(&sh.drawing),
+                                ShapeObject::Line(_) | ShapeObject::Arc(_) => None,
+                                // Group/Chart/Ole 등은 내부 글상자·캡션을 싸게 확인할 수
+                                // 없어 보수적으로 차단한다.
+                                _ => return true,
+                            };
+                            if let Some(d) = drawing {
+                                if let Some(cap) = d.caption.as_ref() {
+                                    if paras_block(&cap.paragraphs, styles) {
+                                        return true;
+                                    }
+                                }
+                                if let Some(tb) = d.text_box.as_ref() {
+                                    if paras_block(&tb.paragraphs, styles) {
+                                        return true;
+                                    }
+                                }
+                            }
+                        }
+                        Control::Picture(pic) => {
+                            if let Some(cap) = pic.caption.as_ref() {
+                                if paras_block(&cap.paragraphs, styles) {
+                                    return true;
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            false
+        }
+        let key = table as *const crate::model::table::Table as usize;
+        if let Some(&cached) = self.cursor_probe_block_cache.borrow().get(&key) {
+            return cached;
+        }
+        let blocked = table
+            .cells
+            .iter()
+            .any(|c| paras_block(&c.paragraphs, styles));
+        self.cursor_probe_block_cache
+            .borrow_mut()
+            .insert(key, blocked);
+        blocked
+    }
+
     /// [#2029 추출] 부분 표의 셀 방출 루프 — 셀 geometry/배경/반복 헤더와 셀
     /// 문단 배치를 `table_node.children` 에 방출한다. 셀-간 캐리 없음(실측 muts 0,
     /// 외부 sink = table_node 단일) — 원본 무변경 이동.
@@ -442,8 +745,14 @@ impl LayoutEngine {
         v_edges: &mut Vec<Vec<Option<BorderLine>>>,
         measured_table: Option<&MeasuredTable>,
         clamp_header_negative_para_offset: bool,
+        probe: Option<&PartialTableCellProbe>,
     ) {
         for (cell_idx, cell) in table.cells.iter().enumerate() {
+            // [#4149] 프로브: 대상 셀만 방출. 셀 방출 루프는 셀-간 캐리가 없어
+            // (실측 muts 0, 외부 sink = table_node 단일) 생략이 대상 셀 좌표를 바꾸지 않는다.
+            if probe.is_some_and(|p| p.cell_idx != cell_idx) {
+                continue;
+            }
             let cell_row = cell.row as usize;
             let cell_col = cell.col as usize;
             if cell_col >= col_count || cell_row >= row_count {
@@ -594,51 +903,64 @@ impl LayoutEngine {
             let (mut pad_left, mut pad_right, pad_top, pad_bottom) =
                 self.resolve_cell_padding(cell, table);
 
-            // 셀 내 문단 구성
-            let mut composed_paras: Vec<_> = cell
-                .paragraphs
-                .iter()
-                .map(|p| compose_paragraph(p))
-                .collect();
+            // [#4149] windowed 프로브면 창 문단만 lazy compose. 그 외에는 종전과
+            // 동일한 순서로 전량 compose → shrink → recompose.
+            let probe_windowed = probe.is_some_and(|p| p.windowed);
+            let mut composed_store: CellComposedStore;
+            if probe_windowed {
+                // shrink 생략 근거: 프로브 사전 게이트가 line_segs>=2 문단 존재를
+                // 증명했고, shrunk_cell_horizontal_padding 은 그 경우 composed 를
+                // 읽지 않고 패딩을 그대로 반환한다 (조기 탈출과 동일 결과).
+                composed_store = CellComposedStore::Lazy(vec![None; cell.paragraphs.len()]);
+            } else {
+                // 셀 내 문단 구성
+                let mut composed_paras: Vec<_> = cell
+                    .paragraphs
+                    .iter()
+                    .map(|p| compose_paragraph(p))
+                    .collect();
 
-            // 텍스트 오버플로우 시 좌우 패딩 축소
-            let (new_pl, new_pr) = self.shrink_cell_padding_for_overflow(
-                pad_left,
-                pad_right,
-                cell_w,
-                &composed_paras,
-                &cell.paragraphs,
-                styles,
-                cell.apply_inner_margin,
-            );
-            pad_left = new_pl;
-            pad_right = new_pr;
+                // 텍스트 오버플로우 시 좌우 패딩 축소
+                let (new_pl, new_pr) = self.shrink_cell_padding_for_overflow(
+                    pad_left,
+                    pad_right,
+                    cell_w,
+                    &composed_paras,
+                    &cell.paragraphs,
+                    styles,
+                    cell.apply_inner_margin,
+                );
+                pad_left = new_pl;
+                pad_right = new_pr;
+
+                let inner_width_for_recompose = (cell_w - pad_left - pad_right).max(0.0);
+                // [Task #671] line_segs 비어 있는 셀 paragraph 의 단일 ComposedLine 압축
+                // 결과를 셀 가용 너비 (inner_width) 에 맞춰 다중 ComposedLine 으로 재분할.
+                for (cpi, para) in cell.paragraphs.iter().enumerate() {
+                    if let Some(comp) = composed_paras.get_mut(cpi) {
+                        crate::renderer::composer::recompose_for_cell_width(
+                            comp,
+                            para,
+                            inner_width_for_recompose,
+                            styles,
+                        );
+                        // [#2291] 부실 저장(ls==1·실폭 초과) 재분할 — 가로쓰기 셀 한정.
+                        if cell.text_direction == 0 {
+                            crate::renderer::composer::recompose_stored_single_line_if_overflowing(
+                                comp,
+                                para,
+                                inner_width_for_recompose,
+                                styles,
+                            );
+                        }
+                    }
+                }
+                composed_store = CellComposedStore::Eager(composed_paras);
+            }
 
             let inner_x = cell_x + pad_left;
             let inner_width = (cell_w - pad_left - pad_right).max(0.0);
             let inner_height = (cell_h - pad_top - pad_bottom).max(0.0);
-
-            // [Task #671] line_segs 비어 있는 셀 paragraph 의 단일 ComposedLine 압축
-            // 결과를 셀 가용 너비 (inner_width) 에 맞춰 다중 ComposedLine 으로 재분할.
-            for (cpi, para) in cell.paragraphs.iter().enumerate() {
-                if let Some(comp) = composed_paras.get_mut(cpi) {
-                    crate::renderer::composer::recompose_for_cell_width(
-                        comp,
-                        para,
-                        inner_width,
-                        styles,
-                    );
-                    // [#2291] 부실 저장(ls==1·실폭 초과) 재분할 — 가로쓰기 셀 한정.
-                    if cell.text_direction == 0 {
-                        crate::renderer::composer::recompose_stored_single_line_if_overflowing(
-                            comp,
-                            para,
-                            inner_width,
-                            styles,
-                        );
-                    }
-                }
-            }
 
             // 분할 행: [Task #993/#1025] start_cut/end_cut(유닛 컷)으로 표시할 줄 범위 계산.
             // 블록 분할이면 블록-셀 (row,col) 인덱스, 그 외는 행내 row_span==1 col 인덱스.
@@ -705,9 +1027,14 @@ impl LayoutEngine {
             // 셀 내 텍스트 높이 (분할 행이면 줄 범위 내만 계산)
             // spacing_before: 셀 첫 문단 제외, spacing_after: 셀 마지막 문단 제외
             let split_para_count = cell.paragraphs.len();
-            let total_content_height = if let Some(ref ranges) = line_ranges {
+            // [#4149] windowed 프로브: 아래에서 effective_align 이 Top 으로 확정되므로
+            // (cell_was_split=true 사전 증명) total_content_height 는 미사용 — 0 고정.
+            let total_content_height = if probe_windowed {
+                0.0
+            } else if let Some(ref ranges) = line_ranges {
                 let mut total = 0.0;
-                for (pi, ((comp, para), &(start, end))) in composed_paras
+                for (pi, ((comp, para), &(start, end))) in composed_store
+                    .eager_slice()
                     .iter()
                     .zip(cell.paragraphs.iter())
                     .zip(ranges.iter())
@@ -762,7 +1089,7 @@ impl LayoutEngine {
                         .unwrap_or(0);
                     let vpos_h = hwpunit_to_px(last_seg_end, self.dpi);
                     let line_h = self.calc_composed_paras_content_height(
-                        &composed_paras,
+                        composed_store.eager_slice(),
                         &cell.paragraphs,
                         styles,
                     );
@@ -776,7 +1103,7 @@ impl LayoutEngine {
                         .max(self.calc_cell_wrap_objects_bottom_height(&cell.paragraphs))
                 } else {
                     self.calc_composed_paras_content_height(
-                        &composed_paras,
+                        composed_store.eager_slice(),
                         &cell.paragraphs,
                         styles,
                     )
@@ -791,15 +1118,25 @@ impl LayoutEngine {
             // 그대로 visible 처리한다면 (= 실제 split 적용 안 받은 cell, 예: inner-table-01.hwp
             // cell[10] '사업개요' 라벨) 원본 cell.vertical_align 을 사용한다. split 적용으로
             // line 일부가 잘린 cell 만 Top 강제.
-            let cell_was_split = cut_units.is_some_and(|(start_unit, end_unit)| {
-                let unit_len = self.cell_units(cell, table, styles).len();
-                start_unit > 0 || end_unit < unit_len
-            }) || line_ranges.as_ref().is_some_and(|ranges| {
-                ranges.iter().enumerate().any(|(i, &(s, e))| {
-                    let total = composed_paras.get(i).map(|c| c.lines.len()).unwrap_or(0);
-                    s != 0 || e != total
+            let cell_was_split = if probe_windowed {
+                // [#4149] windowed 프로브 사전 게이트가 증명한 값 (s>0 문단 존재 또는
+                // 창 밖 미가시 문단의 compose 줄 수 ≥ 1) — 전량 판정과 동치.
+                true
+            } else {
+                cut_units.is_some_and(|(start_unit, end_unit)| {
+                    let unit_len = self.cell_units(cell, table, styles).len();
+                    start_unit > 0 || end_unit < unit_len
+                }) || line_ranges.as_ref().is_some_and(|ranges| {
+                    ranges.iter().enumerate().any(|(i, &(s, e))| {
+                        let total = composed_store
+                            .eager_slice()
+                            .get(i)
+                            .map(|c| c.lines.len())
+                            .unwrap_or(0);
+                        s != 0 || e != total
+                    })
                 })
-            });
+            };
             // [#4042] 쪽 경계로 실제 잘리는 셀은 세로 가운데/아래 정렬이 성립하지 않는다.
             // 한컴 조판 규칙: 용지 시작 y 에서 아래로 흐르며 쪽 경계에 닿으면 자른다 —
             // 가시 슬라이스(inner_height)보다 콘텐츠가 큰 셀은 위에서부터 흘러야 하며,
@@ -840,6 +1177,9 @@ impl LayoutEngine {
 
             // 세로쓰기 셀: 별도 레이아웃 경로 (가로 레이아웃 루프 대신)
             if cell.text_direction != 0 {
+                // [#4149] 프로브가 세로쓰기 셀을 대상으로 삼는 일은 게이트로 막지만,
+                // 방어적으로 전량 구성 후 동일 경로를 태운다 (좌표 동일).
+                composed_store.materialize(cell, inner_width, styles);
                 let vert_inner_area = LayoutRect {
                     x: inner_x,
                     y: cell_y + pad_top,
@@ -849,7 +1189,7 @@ impl LayoutEngine {
                 self.layout_vertical_cell_text(
                     tree,
                     &mut cell_node,
-                    &composed_paras,
+                    composed_store.eager_slice(),
                     &cell.paragraphs,
                     styles,
                     &vert_inner_area,
@@ -922,7 +1262,7 @@ impl LayoutEngine {
                 }
                 last_idx
             } else {
-                composed_paras.len().saturating_sub(1)
+                cell.paragraphs.len().saturating_sub(1)
             };
 
             let mut para_y = text_y_start;
@@ -949,11 +1289,29 @@ impl LayoutEngine {
             } else {
                 0
             };
-            for (cp_idx, (composed, para)) in composed_paras
-                .iter()
-                .zip(cell.paragraphs.iter())
-                .enumerate()
-            {
+            // [#4149] windowed 프로브: 컷 창에 유닛이 없는 문단은 아래 skip 판정의
+            // 네 조건(line_ranges·mixed·nested·non-inline)이 모두 창 유닛에서만
+            // 유도되므로 전량 레이아웃에서도 반드시 skip 된다 — 순회 자체를 생략한다.
+            // stop_after_para 이후 문단은 캐럿 문단의 좌표에 영향이 없어 중단한다.
+            let (loop_start, loop_end_excl) = match probe {
+                Some(p) if p.windowed => {
+                    let (lo, hi) = p.window_paras;
+                    let end = hi
+                        .saturating_add(1)
+                        .min(cell.paragraphs.len())
+                        .min(p.stop_after_para.saturating_add(1));
+                    (lo.min(end), end)
+                }
+                Some(p) => (
+                    0,
+                    cell.paragraphs
+                        .len()
+                        .min(p.stop_after_para.saturating_add(1)),
+                ),
+                None => (0, cell.paragraphs.len()),
+            };
+            for cp_idx in loop_start..loop_end_excl {
+                let para = &cell.paragraphs[cp_idx];
                 // 분할 행이면 해당 문단의 줄 범위 적용
                 let (start_line, end_line) = if let Some(ref ranges) = line_ranges {
                     if cp_idx < ranges.len() {
@@ -962,7 +1320,13 @@ impl LayoutEngine {
                         (0, 0) // 범위 밖 문단은 렌더링하지 않음
                     }
                 } else {
-                    (0, composed.lines.len())
+                    (
+                        0,
+                        composed_store
+                            .get(cp_idx, cell, inner_width, styles)
+                            .lines
+                            .len(),
+                    )
                 };
                 let mixed_nested_split = cut_units.and_then(|(su, eu)| {
                     self.mixed_nested_split_from_cut(cell, table, styles, su, eu, cp_idx)
@@ -1003,6 +1367,9 @@ impl LayoutEngine {
                 {
                     continue;
                 }
+
+                // [#4149] 가시 문단만 여기 도달 — lazy 슬롯은 이 시점에 compose 된다.
+                let composed = composed_store.get(cp_idx, cell, inner_width, styles);
 
                 if preserve_linear_single_cell_vpos {
                     let target_seg = para
@@ -1973,6 +2340,8 @@ impl LayoutEngine {
                                             0.0,
                                             None,
                                             clamp_header_negative_para_offset,
+                                            // [#4149] 프로브는 최외곽 표에만 적용한다.
+                                            None,
                                         );
                                         // [#3820/issue2007 p14] recursive cut은 현재 호출의
                                         // source 범위를 제한하지만 parent flow_height는 기존
@@ -2029,7 +2398,7 @@ impl LayoutEngine {
 
                 if has_table_ctrl && mixed_nested_split.is_none() {
                     // LINE_SEG vpos 기반으로 para_y 보정.
-                    let is_last_para = cp_idx + 1 == composed_paras.len();
+                    let is_last_para = cp_idx + 1 == cell.paragraphs.len();
                     if !is_last_para {
                         if let Some(next_para) = cell.paragraphs.get(cp_idx + 1) {
                             if let Some(next_seg) = next_para.line_segs.first() {
@@ -2137,6 +2506,7 @@ impl LayoutEngine {
         host_margin_right: f64,
         measured_table: Option<&MeasuredTable>,
         clamp_header_negative_para_offset: bool,
+        probe: Option<&PartialTableCellProbe>,
     ) -> f64 {
         let para = match paragraphs.get(para_index) {
             Some(p) => p,
@@ -2192,6 +2562,7 @@ impl LayoutEngine {
             host_margin_right,
             measured_table,
             clamp_header_negative_para_offset,
+            probe,
         )
     }
 
@@ -2223,6 +2594,7 @@ impl LayoutEngine {
         host_margin_right: f64,
         measured_table: Option<&MeasuredTable>,
         clamp_header_negative_para_offset: bool,
+        probe: Option<&PartialTableCellProbe>,
     ) -> f64 {
         let PartialTableHostContext {
             paragraphs,
@@ -2759,6 +3131,7 @@ impl LayoutEngine {
             &mut v_edges,
             measured_table,
             clamp_header_negative_para_offset,
+            probe,
         );
 
         // 엣지 기반 테두리 렌더링

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -2881,6 +2881,17 @@ impl HwpDocument {
         self.get_caret_position_native().map_err(|e| e.into())
     }
 
+    /// [#4180] 저장 직전 UI 캐럿을 문서 캐럿 메타데이터에 반영한다
+    /// (한컴 의미론: 저장 시점 캐럿). 범위 밖 위치는 무시 — 저장을 막지 않는다.
+    #[wasm_bindgen(js_name = setCaretPosition)]
+    pub fn set_caret_position(&mut self, section_idx: u32, para_idx: u32, char_offset: u32) {
+        self.set_caret_position_native(
+            section_idx as usize,
+            para_idx as usize,
+            char_offset as usize,
+        );
+    }
+
     /// 표의 행/열/셀 수를 반환한다.
     ///
     /// 반환: JSON `{"rowCount":N,"colCount":N,"cellCount":N}`

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -27854,3 +27854,235 @@ fn split_rejects_corrupted_cell_row_span_overflow_before_mutation() {
     assert_eq!(table.cells[0].row, u16::MAX - 2);
     assert_eq!(table.cells[0].row_span, 3);
 }
+
+/// [#4149 조사] Enter→Delete 왕복(내용 무변경 복원)이 셀 문단의 저장 line_segs 를
+/// 보존하는지 계측한다. 두 원천을 분리한다:
+///
+///   A) 무편집 divergence — 로드 직후 저장 segs vs `reflow_cell_paragraph` 재계산.
+///      다르면 그 문단은 "한 번이라도 건드리는 순간" 한컴 원본 줄바꿈 증거를 잃는
+///      잠재 모집단이다.
+///   B) 왕복 실측 — split→merge(내용 복원) 전후 저장 segs 대조. 불변식
+///      "무변경 편집 왕복은 레이아웃 보존" 위반의 직접 증거.
+///
+/// 구조상 왕복 결과는 reflow 결과와 같아야 하므로 B의 변경 집합은 A의 divergence
+/// 집합과 일치할 것으로 기대한다 — 일치하면 원인은 왕복 경로가 아니라 "reflow 가
+/// 원본 줄바꿈과 다르다"로 좁혀진다. 요약은 --nocapture 로 출력.
+#[test]
+fn issue4149_cell_lineseg_roundtrip_survey() {
+    let path = "samples/issue1949_giant_cell_nested_tables_perf.hwp";
+    let bytes = std::fs::read(path).expect("issue1949 샘플 읽기");
+
+    // (ppi, ci, cell, para) — 최외곽 표, 다줄(>=2 segs), UTF-16 4자 이상
+    fn survey(doc: &HwpDocument) -> Vec<(usize, usize, usize, usize)> {
+        let mut out = Vec::new();
+        for (ppi, para) in doc.document.sections[0].paragraphs.iter().enumerate() {
+            for (ci, ctrl) in para.controls.iter().enumerate() {
+                if let Control::Table(t) = ctrl {
+                    for (cell_idx, cell) in t.cells.iter().enumerate() {
+                        for (cp, p) in cell.paragraphs.iter().enumerate() {
+                            if p.line_segs.len() >= 2 && p.text.encode_utf16().count() >= 4 {
+                                out.push((ppi, ci, cell_idx, cp));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+    fn cell_para<'a>(doc: &'a HwpDocument, t: (usize, usize, usize, usize)) -> &'a Paragraph {
+        match &doc.document.sections[0].paragraphs[t.0].controls[t.1] {
+            Control::Table(tbl) => &tbl.cells[t.2].paragraphs[t.3],
+            _ => panic!("표가 아님"),
+        }
+    }
+    // 줄바꿈 증거(text_start 수열)와 기하(vpos/width)를 분리해 본다
+    fn breaks(p: &Paragraph) -> Vec<u32> {
+        p.line_segs.iter().map(|s| s.text_start).collect()
+    }
+    fn geom(p: &Paragraph) -> Vec<(i32, i32, i32)> {
+        p.line_segs
+            .iter()
+            .map(|s| (s.vertical_pos, s.segment_width, s.line_height))
+            .collect()
+    }
+
+    // ── A) 무편집: 저장 segs vs reflow 재계산 ─────────────────────────────
+    let mut doc_a = HwpDocument::from_bytes(&bytes).expect("파싱");
+    let targets = survey(&doc_a);
+    assert!(!targets.is_empty(), "다줄 셀 문단이 없으면 계측 무의미");
+    let (mut a_same, mut a_breaks, mut a_geom_only) = (0usize, 0usize, 0usize);
+    let mut a_break_examples = Vec::new();
+    let mut a_divergent = std::collections::HashSet::new();
+    for &t in &targets {
+        let before = (breaks(cell_para(&doc_a, t)), geom(cell_para(&doc_a, t)));
+        doc_a.reflow_cell_paragraph(0, t.0, t.1, t.2, t.3);
+        let after = (breaks(cell_para(&doc_a, t)), geom(cell_para(&doc_a, t)));
+        if before.0 != after.0 {
+            a_breaks += 1;
+            a_divergent.insert(t);
+            if a_break_examples.len() < 3 {
+                a_break_examples.push((t, before.0.clone(), after.0.clone()));
+            }
+        } else if before.1 != after.1 {
+            a_geom_only += 1;
+            a_divergent.insert(t);
+        } else {
+            a_same += 1;
+        }
+    }
+    println!(
+        "[#4149-A] 무편집 다줄 셀 문단 {}개: 보존 {} / 줄바꿈 divergence {} / 기하만 {}",
+        targets.len(),
+        a_same,
+        a_breaks,
+        a_geom_only
+    );
+    for (t, b, a) in &a_break_examples {
+        println!(
+            "[#4149-A] 예시 ppi{} ci{} cell{} para{}: 저장 {:?} → 재계산 {:?}",
+            t.0, t.1, t.2, t.3, b, a
+        );
+    }
+
+    // ── B) 왕복: split(중간)→merge 전후 저장 segs ────────────────────────
+    let mut doc_b = HwpDocument::from_bytes(&bytes).expect("파싱");
+    let roundtrip_targets: Vec<_> = targets.iter().copied().take(12).collect();
+    let (mut b_same, mut b_breaks, mut b_geom_only) = (0usize, 0usize, 0usize);
+    let mut b_matches_a = true;
+    for &t in &roundtrip_targets {
+        let p = cell_para(&doc_b, t);
+        let text_before = p.text.clone();
+        let (bk_before, gm_before) = (breaks(p), geom(p));
+        let mid = (text_before.encode_utf16().count() / 2).max(1);
+        doc_b
+            .split_paragraph_in_cell_native(0, t.0, t.1, t.2, t.3, mid, None)
+            .expect("split");
+        doc_b
+            .merge_paragraph_in_cell_native(0, t.0, t.1, t.2, t.3 + 1)
+            .expect("merge");
+        let p = cell_para(&doc_b, t);
+        assert_eq!(
+            p.text, text_before,
+            "왕복 후 텍스트 복원은 전제 (ppi{} cell{})",
+            t.0, t.2
+        );
+        let changed = if bk_before != breaks(p) {
+            b_breaks += 1;
+            true
+        } else if gm_before != geom(p) {
+            b_geom_only += 1;
+            true
+        } else {
+            b_same += 1;
+            false
+        };
+        if changed != a_divergent.contains(&t) {
+            b_matches_a = false;
+            println!(
+                "[#4149-B] 예외: ppi{} ci{} cell{} para{} — 왕복 변경={} vs A divergence={}",
+                t.0,
+                t.1,
+                t.2,
+                t.3,
+                changed,
+                a_divergent.contains(&t)
+            );
+        }
+    }
+    println!(
+        "[#4149-B] Enter→Delete 왕복 {}개: 보존 {} / 줄바꿈 변경 {} / 기하만 변경 {}",
+        roundtrip_targets.len(),
+        b_same,
+        b_breaks,
+        b_geom_only
+    );
+    println!(
+        "[#4149-B] 왕복 변경 집합 == A divergence 집합: {} — true 면 왕복 자체는 reflow 를 \
+         충실히 따르고, 원인은 reflow vs 한컴 원본 줄바꿈 차이로 좁혀진다",
+        b_matches_a
+    );
+}
+
+/// [조사] 거대 셀 문서 타이핑 지연의 진짜 병목 분해 — getCursorRectInCell 60ms 의
+/// 내부 귀속. 브라우저 트레이스(조합 업데이트마다 getCursorRectInCell 56~60ms)의
+/// wasm 안쪽을 페이즈별로 실측한다:
+///   1) find_pages_for_cell_position (페이지 좁히기)
+///   2) build_page_tree (uncached — LayoutEngine::build_render_tree 포함)
+///   3) get_cursor_rect_in_cell_native 전체
+///   4) 거대 표가 없는 쪽의 build_page_tree (차등 — 표 레이아웃 귀속 증거)
+#[test]
+fn issue4149_adjacent_giant_cell_cursor_rect_latency_decomposition() {
+    use std::time::Instant;
+    let bytes =
+        std::fs::read("samples/issue1949_giant_cell_nested_tables_perf.hwp").expect("샘플 읽기");
+    let mut doc = HwpDocument::from_bytes(&bytes).expect("파싱");
+    let pages = doc.page_count();
+    println!("[cursor-rect] 총 {pages}쪽");
+
+    // 캐럿 좌표: 브라우저 실측과 동일 (ppi0 ci2 cell2 para6 off5)
+    let t = Instant::now();
+    let cand = doc
+        .find_pages_for_cell_position(0, 0, 2, 2, Some((6, 5)))
+        .expect("페이지 좁히기");
+    println!(
+        "[cursor-rect] 1) find_pages_for_cell_position={:?} → {:?}",
+        t.elapsed(),
+        cand
+    );
+
+    let target_page = cand[0];
+    for i in 0..3 {
+        let t = Instant::now();
+        let _ = doc.build_page_tree(target_page).expect("페이지 트리");
+        println!(
+            "[cursor-rect] 2) build_page_tree(p{target_page}) #{i}={:?}",
+            t.elapsed()
+        );
+    }
+    // find_page(구성 조회)만 분리 — 나머지가 LayoutEngine::build_render_tree 귀속
+    for i in 0..2 {
+        let t = Instant::now();
+        let _ = doc.find_page(target_page).expect("find_page");
+        println!(
+            "[cursor-rect] 2b) find_page(p{target_page}) #{i}={:?}",
+            t.elapsed()
+        );
+    }
+    // 차등: 마지막 쪽 (다른 내용 구성)
+    let last = pages - 1;
+    let t = Instant::now();
+    let _ = doc.build_page_tree(last).expect("페이지 트리");
+    println!(
+        "[cursor-rect] 4) build_page_tree(p{last})={:?}",
+        t.elapsed()
+    );
+
+    for i in 0..3 {
+        let t = Instant::now();
+        let _ = doc
+            .get_cursor_rect_in_cell_native(0, 0, 2, 2, 6, 5)
+            .expect("커서 rect");
+        println!(
+            "[cursor-rect] 3) get_cursor_rect_in_cell_native #{i}={:?}",
+            t.elapsed()
+        );
+    }
+}
+
+/// [조사] 프로파일링용 핫루프 — macOS `sample` 로 build_render_tree 내부 귀속.
+/// `--ignored` 로만 실행.
+#[test]
+#[ignore]
+fn issue4149_adjacent_cursor_rect_profile_loop() {
+    let bytes =
+        std::fs::read("samples/issue1949_giant_cell_nested_tables_perf.hwp").expect("샘플 읽기");
+    let mut doc = HwpDocument::from_bytes(&bytes).expect("파싱");
+    let _ = doc.page_count();
+    let _ = doc.find_pages_for_cell_position(0, 0, 2, 2, Some((6, 5)));
+    eprintln!("[profile-loop] 시작 pid={}", std::process::id());
+    for _ in 0..600 {
+        let _ = doc.get_cursor_rect_in_cell_native(0, 0, 2, 2, 6, 5);
+    }
+    eprintln!("[profile-loop] 끝");
+}

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -28086,3 +28086,104 @@ fn issue4149_adjacent_cursor_rect_profile_loop() {
     }
     eprintln!("[profile-loop] 끝");
 }
+
+/// [조사] deferred 편집 직후 첫 캐럿 질의 ~20ms 의 귀속 — find_pages vs 나머지.
+#[test]
+fn issue4149_deferred_edit_first_cursor_query_decomposition() {
+    use std::time::Instant;
+    let bytes =
+        std::fs::read("samples/issue1949_giant_cell_nested_tables_perf.hwp").expect("샘플 읽기");
+    let mut doc = HwpDocument::from_bytes(&bytes).expect("파싱");
+    let _ = doc.page_count();
+    // 웜업
+    let _ = doc.get_cursor_rect_in_cell_native(0, 0, 2, 2, 6, 5);
+    let t = Instant::now();
+    let _ = doc.get_cursor_rect_in_cell_native(0, 0, 2, 2, 6, 5);
+    println!("[deferred-q] 웜 질의={:?}", t.elapsed());
+
+    // cp29: 다줄 텍스트 문단 (조사 실측 [0,46,84,...]) — 실타이핑 대표 사례.
+    // cp6(공백 스페이서)은 삽입이 spacer 클래스를 바꿔 정당 evict 되는 반례다.
+    doc.insert_text_in_cell_deferred_pagination(0, 0, 2, 2, 29, 5, "X")
+        .expect("deferred insert");
+    let t = Instant::now();
+    let pages = doc
+        .find_pages_for_cell_position(0, 0, 2, 2, Some((29, 6)))
+        .expect("pages");
+    println!(
+        "[deferred-q] 편집 직후 find_pages={:?} → {:?}",
+        t.elapsed(),
+        pages
+    );
+    let t = Instant::now();
+    let _ = doc.get_cursor_rect_in_cell_native(0, 0, 2, 2, 29, 6);
+    println!("[deferred-q] 편집 직후 rect(질의1)={:?}", t.elapsed());
+    let t = Instant::now();
+    let _ = doc.get_cursor_rect_in_cell_native(0, 0, 2, 2, 29, 6);
+    println!("[deferred-q] rect(질의2)={:?}", t.elapsed());
+}
+
+/// [조사] deferred 편집 후 cell_units 재계산 11ms 의 내부 귀속 — sample 용 핫루프.
+#[test]
+#[ignore]
+fn issue4149_deferred_units_rebuild_profile_loop() {
+    let bytes =
+        std::fs::read("samples/issue1949_giant_cell_nested_tables_perf.hwp").expect("샘플 읽기");
+    let mut doc = HwpDocument::from_bytes(&bytes).expect("파싱");
+    let _ = doc.page_count();
+    let _ = doc.get_cursor_rect_in_cell_native(0, 0, 2, 2, 6, 5);
+    eprintln!("[units-loop] 시작 pid={}", std::process::id());
+    for i in 0..400 {
+        let ch = if i % 2 == 0 { "X" } else { "" };
+        if ch.is_empty() {
+            let _ = doc.delete_text_in_cell_deferred_pagination(0, 0, 2, 2, 6, 5, 1);
+        } else {
+            let _ = doc.insert_text_in_cell_deferred_pagination(0, 0, 2, 2, 6, 5, ch);
+        }
+        let _ = doc.find_pages_for_cell_position(0, 0, 2, 2, Some((6, 5)));
+    }
+    eprintln!("[units-loop] 끝");
+}
+
+/// [#4167] units 지문의 실문서 계약: 텍스트 문단 제자리 타이핑은 지문 불변(캐시
+/// 보존 → find_pages µs 급), 공백 스페이서 문단에 글자 삽입은 클래스 전이로 지문
+/// 변경(정당 evict). cp6 은 공백 5자 스페이서, cp29 는 다줄 텍스트 문단이다.
+#[test]
+fn issue4167_units_fingerprint_doc_contract() {
+    use crate::renderer::layout::LayoutEngine;
+    let bytes =
+        std::fs::read("samples/issue1949_giant_cell_nested_tables_perf.hwp").expect("샘플 읽기");
+    let mut doc = HwpDocument::from_bytes(&bytes).expect("파싱");
+    let _ = doc.page_count();
+    let para = |doc: &HwpDocument, cp: usize| -> Paragraph {
+        match &doc.document.sections[0].paragraphs[0].controls[2] {
+            Control::Table(t) => t.cells[2].paragraphs[cp].clone(),
+            _ => panic!("표가 아님"),
+        }
+    };
+
+    // 텍스트 문단: 삽입 전후 지문 불변 (원본 tag 잔여 비트는 마스킹됨)
+    let text_before = para(&doc, 29);
+    doc.insert_text_in_cell_deferred_pagination(0, 0, 2, 2, 29, 5, "X")
+        .expect("insert");
+    let text_after = para(&doc, 29);
+    assert_eq!(
+        LayoutEngine::cell_paragraph_units_fingerprint(&text_before),
+        LayoutEngine::cell_paragraph_units_fingerprint(&text_after),
+        "텍스트 문단 제자리 삽입은 units 지문 불변이어야 한다 (#4167 스킵 전제)"
+    );
+
+    // 스페이서 문단: 삽입이 trim-empty 클래스를 바꿔 지문 변경
+    let spacer_before = para(&doc, 6);
+    assert!(
+        spacer_before.text.trim().is_empty(),
+        "cp6 은 공백 스페이서 전제"
+    );
+    doc.insert_text_in_cell_deferred_pagination(0, 0, 2, 2, 6, 5, "X")
+        .expect("insert");
+    let spacer_after = para(&doc, 6);
+    assert_ne!(
+        LayoutEngine::cell_paragraph_units_fingerprint(&spacer_before),
+        LayoutEngine::cell_paragraph_units_fingerprint(&spacer_after),
+        "스페이서 → 텍스트 전이는 지문이 변해 evict 되어야 한다"
+    );
+}

--- a/tests/fixtures/overflow_cell_baseline.tsv
+++ b/tests/fixtures/overflow_cell_baseline.tsv
@@ -1,6 +1,7 @@
 2025 행정업무운영 편람(최종).hwp	53
 2025 행정업무운영 편람(최종).hwpx	96
 86712_regulatory_analysis.hwp	27
+basic/issue2007_nested_cell_pagination_42065.hwp	11
 hwpctl_ParameterSetID_Item_v1.2.hwp	49
 hwpx_sample2.hwp	3
 hwpx_sample2.hwpx	3

--- a/tests/issue_4031_enter_latency_probe.rs
+++ b/tests/issue_4031_enter_latency_probe.rs
@@ -1,0 +1,207 @@
+//! Issue #4031 Stage 1 local-only Enter latency probe.
+//!
+//! 거대 셀(115쪽 분할 표) 문서에서 셀 내부 Enter(문단 분할) 1회의 동기 전 구간을
+//! 분해 계측한다. `RHWP_2424_PROFILE=1`과 함께 실행하면 pagination subphase와
+//! block-table timer가 stderr에 함께 출력된다. timing assertion은 두지 않는다.
+//!
+//! - cold Enter: pending 없는 상태의 split 1회 소유 비용(분할+reflow+vpos+full pagination)
+//! - pending Enter(현행 studio 경로): deferred insert 잔여 → full flush → split
+//! - pending Enter(목표 계약): flush 없이 split 1회의 `paginate_if_needed()`로 수렴
+
+use std::fs;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use rhwp::wasm_api::HwpDocument;
+use serde_json::Value;
+
+const FIXTURES: [(&str, &str); 2] = [
+    ("hwp", "samples/issue1949_giant_cell_nested_tables_perf.hwp"),
+    (
+        "hwpx",
+        "samples/issue1949_giant_cell_nested_tables_perf.hwpx",
+    ),
+];
+
+/// 2424 probe와 같은 giant-cell 좌표: section 0 / parent para 0 / control 2 / cell 2.
+const SECTION: usize = 0;
+const PARENT_PARA: usize = 0;
+const CONTROL: usize = 2;
+const CELL: usize = 2;
+/// 2424 probe가 편집한 셀 문단과 오프셋(문단 길이 130 이상 보장).
+const TOP_CELL_PARA: usize = 5;
+const TOP_OFFSET: usize = 130;
+
+fn load(relative: &str) -> HwpDocument {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(relative);
+    let bytes = fs::read(&path).unwrap_or_else(|error| panic!("read {relative}: {error}"));
+    HwpDocument::from_bytes(&bytes).unwrap_or_else(|error| panic!("load {relative}: {error}"))
+}
+
+fn repeats() -> usize {
+    std::env::var("RHWP_4031_REPEATS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(3)
+        .clamp(1, 20)
+}
+
+fn ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1000.0
+}
+
+/// cold Enter — pending pagination 없는 상태에서 연속 split의 소유 비용.
+///
+/// 셀 상단(문단 5)과 하단 부근에서 각각 3연타를 계측해 편집 위치와 무관하게
+/// full pagination이 지배 항인지(=fragment 증분 재개 부재) 확인한다.
+#[test]
+#[ignore = "local performance diagnostic; run explicitly with RHWP_2424_PROFILE=1"]
+fn issue_4031_profile_cold_enter_split() {
+    for run in 1..=repeats() {
+        for (format, relative) in FIXTURES {
+            let mut doc = load(relative);
+            assert_eq!(doc.page_count(), 115, "{format}: initial page count");
+            let cell_para_count = doc
+                .get_cell_paragraph_count_native(SECTION, PARENT_PARA, CONTROL, CELL)
+                .expect("giant cell paragraph count");
+            let bottom_para = cell_para_count.saturating_sub(8);
+
+            for (label, base_para, base_offset) in [
+                ("top", TOP_CELL_PARA, TOP_OFFSET),
+                ("bottom", bottom_para, 0),
+            ] {
+                for stroke in 0..3 {
+                    // Enter 연타: 첫 분할 뒤 캐럿은 새 문단 시작(offset 0)에 있다.
+                    let (para, offset) = if stroke == 0 {
+                        (base_para, base_offset)
+                    } else {
+                        (base_para + stroke, 0)
+                    };
+                    let started = Instant::now();
+                    let raw = doc
+                        .split_paragraph_in_cell_native(
+                            SECTION,
+                            PARENT_PARA,
+                            CONTROL,
+                            CELL,
+                            para,
+                            offset,
+                            None,
+                        )
+                        .expect("cell paragraph split");
+                    let elapsed = started.elapsed();
+                    let result: Value = serde_json::from_str(&raw).expect("split result JSON");
+                    assert_eq!(result["ok"].as_bool(), Some(true), "{format}: split ok");
+                    eprintln!(
+                        "RHWP_4031_COLD_ENTER run={run} format={format} pos={label} stroke={} split_ms={:.3} pages={}",
+                        stroke + 1,
+                        ms(elapsed),
+                        doc.page_count(),
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// pending Enter — 현행 studio 경로 재현: 56회 deferred insert 잔여 상태에서
+/// `flushDeferredPagination`(before-navigation barrier) 뒤 split.
+/// 이어서 같은 초기 상태에서 flush 생략(목표 계약) split을 계측해
+/// 최종 page count 정합과 flush 중복분을 수치로 고정한다.
+#[test]
+#[ignore = "local performance diagnostic; run explicitly with RHWP_2424_PROFILE=1"]
+fn issue_4031_profile_pending_enter_flush_vs_skip() {
+    for run in 1..=repeats() {
+        for (format, relative) in FIXTURES {
+            // 시나리오 A — 현행: flush 1회 + split의 full pagination 1회.
+            let mut doc_a = load(relative);
+            for inserted in 0..56 {
+                doc_a
+                    .insert_text_in_cell_native_deferred_pagination(
+                        SECTION,
+                        PARENT_PARA,
+                        CONTROL,
+                        CELL,
+                        TOP_CELL_PARA,
+                        TOP_OFFSET + inserted,
+                        "1",
+                    )
+                    .expect("sequential deferred cell insert");
+            }
+            let flush_started = Instant::now();
+            doc_a
+                .flush_deferred_pagination()
+                .expect("before-navigation full flush");
+            let flush_elapsed = flush_started.elapsed();
+            let split_started = Instant::now();
+            doc_a
+                .split_paragraph_in_cell_native(
+                    SECTION,
+                    PARENT_PARA,
+                    CONTROL,
+                    CELL,
+                    TOP_CELL_PARA,
+                    TOP_OFFSET,
+                    None,
+                )
+                .expect("cell paragraph split after flush");
+            let split_a_elapsed = split_started.elapsed();
+            let pages_a = doc_a.page_count();
+
+            // 시나리오 B — 목표 계약: flush 생략, split의 paginate_if_needed 1회로 수렴.
+            let mut doc_b = load(relative);
+            for inserted in 0..56 {
+                doc_b
+                    .insert_text_in_cell_native_deferred_pagination(
+                        SECTION,
+                        PARENT_PARA,
+                        CONTROL,
+                        CELL,
+                        TOP_CELL_PARA,
+                        TOP_OFFSET + inserted,
+                        "1",
+                    )
+                    .expect("sequential deferred cell insert");
+            }
+            doc_b.cancel_deferred_pagination();
+            let split_b_started = Instant::now();
+            doc_b
+                .split_paragraph_in_cell_native(
+                    SECTION,
+                    PARENT_PARA,
+                    CONTROL,
+                    CELL,
+                    TOP_CELL_PARA,
+                    TOP_OFFSET,
+                    None,
+                )
+                .expect("cell paragraph split without flush");
+            let split_b_elapsed = split_b_started.elapsed();
+            let pages_b = doc_b.page_count();
+
+            // split의 동기 pagination이 deferred 목표를 소비했으므로 잔여 flush는 즉시 완료여야 한다.
+            let post_flush_started = Instant::now();
+            let post_flush: Value = serde_json::from_str(
+                &doc_b
+                    .flush_deferred_pagination()
+                    .expect("post-split flush must be trivial"),
+            )
+            .expect("post flush JSON");
+            let post_flush_elapsed = post_flush_started.elapsed();
+
+            assert_eq!(
+                pages_a, pages_b,
+                "{format}: flush-then-split and skip-flush split must converge to same page count",
+            );
+            eprintln!(
+                "RHWP_4031_PENDING_ENTER run={run} format={format} flush_ms={:.3} split_after_flush_ms={:.3} \
+                 skip_flush_split_ms={:.3} post_flush_ms={:.3} post_flush_state={} pages={pages_a}",
+                ms(flush_elapsed),
+                ms(split_a_elapsed),
+                ms(split_b_elapsed),
+                ms(post_flush_elapsed),
+                post_flush["status"].as_str().unwrap_or("unknown"),
+            );
+        }
+    }
+}

--- a/tests/issue_4138_split_cell_stale_linesegs.rs
+++ b/tests/issue_4138_split_cell_stale_linesegs.rs
@@ -1,0 +1,138 @@
+//! Issue #4138: 셀 나누기 후 stale line_segs·vpos 사다리 붕괴로 인한
+//! glyph truncation + 잘못된 페이지네이션 회귀 가드.
+//!
+//! 재현 문서: `samples/issue1949_giant_cell_nested_tables_perf.hwp`
+//! (3×1 RowBreak 표가 PartialTable continuation 으로 115쪽에 걸침).
+//!
+//! 결함 2단:
+//! 1. `Table::split_cell_into` 가 셀 폭을 절반으로 바꾸면서 저장 line_segs 를
+//!    그대로 둔다 → 렌더러가 옛 폭(44508) 기준 줄을 새 셀(22395) 클립 경계에
+//!    그대로 그려 glyph 가 잘린다. (수정 전 실측: 4,321 seg 전부 stale)
+//! 2. per-para reflow 만 배선하면 각 문단의 vpos 원점이 보존된 채 줄 수만
+//!    늘어나 사다리가 역행하고, 컷 기계가 이를 RowBreak hard break 로 오판해
+//!    페이지를 과소 적재한다. (실측: 118→222쪽)
+//!
+//! 정정: `reflow_stale_cells_after_split`(table_ops.rs) — stale 셀 재래핑 후
+//! `rebuild_table_cell_vpos_ladder_native` 로 사다리를 단조 재구축한다.
+
+use std::fs;
+use std::path::Path;
+
+use rhwp::model::control::Control;
+use rhwp::model::table::Table;
+
+const SAMPLE: &str = "samples/issue1949_giant_cell_nested_tables_perf.hwp";
+/// 대상 표: (section 0, 문단 0, control 2). 분할 대상 셀: (row 2, col 0).
+const CTRL_IDX: usize = 2;
+const TARGET_ROW: u16 = 2;
+
+fn load() -> rhwp::wasm_api::HwpDocument {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = fs::read(&path).expect("read sample");
+    rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse")
+}
+
+fn target_table(doc: &rhwp::wasm_api::HwpDocument) -> &Table {
+    match &doc.document().sections[0].paragraphs[0].controls[CTRL_IDX] {
+        Control::Table(t) => t,
+        other => panic!("controls[{CTRL_IDX}] 이 표가 아님: {other:?}"),
+    }
+}
+
+/// 저장 seg 폭이 셀 폭을 넘는(=옛 폭 기준 stale) 문단 수.
+///
+/// 텍스트 없이 컨트롤만 호스팅하는 문단은 제외한다: `reflow_line_segs` 는 이
+/// 문단에서 원본 seg 폭 template 을 보존하고, 중첩 표 자체를 분할 시 리스케일할지는
+/// 한컴 오라클 미확인(#4138 미해결 항목 (a))이라 이 가드의 계약 밖이다.
+fn stale_text_paras(table: &Table) -> usize {
+    table
+        .cells
+        .iter()
+        .flat_map(|cell| {
+            cell.paragraphs
+                .iter()
+                .filter(|p| !(p.text.is_empty() && !p.controls.is_empty()))
+                .map(move |p| (cell.width, p))
+        })
+        .filter(|(cell_width, p)| {
+            p.line_segs
+                .iter()
+                .any(|ls| (ls.segment_width as i64) > (*cell_width as i64))
+        })
+        .count()
+}
+
+/// 분할 대상 행 셀들의 vpos 사다리 역행 수 (0 이어야 단조).
+fn ladder_regressions(table: &Table, row: u16) -> usize {
+    let mut regressions = 0usize;
+    for cell in table.cells.iter().filter(|c| c.row == row) {
+        let mut prev_end: i64 = i64::MIN;
+        for p in &cell.paragraphs {
+            if let (Some(first), Some(last)) = (p.line_segs.first(), p.line_segs.last()) {
+                if (first.vertical_pos as i64) < prev_end {
+                    regressions += 1;
+                }
+                prev_end = last.vertical_pos as i64;
+            }
+        }
+    }
+    regressions
+}
+
+/// 셀 나누기(1×2) 뒤: stale seg 0, 사다리 단조, 페이지 흐름 복원.
+#[test]
+fn split_cell_into_reflows_stale_segs_and_rebuilds_ladder() {
+    let mut doc = load();
+    assert_eq!(doc.page_count(), 115, "issue1949 기준 쪽수 핀");
+
+    doc.split_table_cell_into_native(0, 0, CTRL_IDX, TARGET_ROW, 0, 1, 2, false, false)
+        .expect("split_cell_into 1×2");
+
+    let table = target_table(&doc);
+    let stale = stale_text_paras(table);
+    assert_eq!(
+        stale, 0,
+        "#4138 회귀: 분할 뒤 옛 폭 기준 stale line_segs 문단이 {stale}개 남음 \
+         (수정 원복 시 실측 2,498문단/4,321seg). glyph 가 셀 클립 경계에서 잘린다."
+    );
+
+    let regressions = ladder_regressions(table, TARGET_ROW);
+    assert_eq!(
+        regressions, 0,
+        "#4138 회귀: 재래핑된 셀의 vpos 사다리가 {regressions}회 역행. \
+         컷 기계가 hard break 로 오판해 페이지를 과소 적재한다."
+    );
+
+    // 실측 거동 핀 (한컴 정답 쪽수는 미확인 — #4138 미해결 항목).
+    // 수정 원복 시 118쪽(stale 줄로 과소 계산), 사다리 재구축 생략 시 222쪽(과소 적재).
+    let pages = doc.page_count();
+    assert_eq!(
+        pages, 195,
+        "#4138 회귀: 분할 뒤 쪽수 {pages} (기대 195). 118 이면 reflow 누락, \
+         222 이면 vpos 사다리 재구축 누락."
+    );
+}
+
+/// 범위 분할 경로(`split_table_cells_in_range_native`)도 같은 계약을 따른다.
+#[test]
+fn split_cells_in_range_reflows_stale_segs() {
+    let mut doc = load();
+
+    doc.split_table_cells_in_range_native(
+        0, 0, CTRL_IDX, TARGET_ROW, 0, TARGET_ROW, 0, 1, 2, false,
+    )
+    .expect("split_cells_in_range 1×2");
+
+    let table = target_table(&doc);
+    assert_eq!(
+        stale_text_paras(table),
+        0,
+        "#4138 회귀(범위 분할): stale line_segs 잔존"
+    );
+    assert_eq!(
+        ladder_regressions(table, TARGET_ROW),
+        0,
+        "#4138 회귀(범위 분할): vpos 사다리 역행"
+    );
+    assert_eq!(doc.page_count(), 195, "#4138 회귀(범위 분할): 쪽수 불일치");
+}

--- a/tests/issue_4179_cursor_rect_text_host_para_pages.rs
+++ b/tests/issue_4179_cursor_rect_text_host_para_pages.rs
@@ -1,0 +1,56 @@
+//! Issue #4179: 텍스트가 있는 표 호스트 문단에서 `getCursorRect` 가 후보 페이지
+//! 전부의 render tree 를 지어보던 회귀 가드 — #4126(빈 문단) 미커버 자매 케이스.
+//!
+//! 재현: `samples/issue1949_giant_cell_nested_tables_perf.hwp` 의 호스트 문단(0,0)에
+//! 텍스트를 삽입하면 그 텍스트는 분할 표 뒤 = 마지막 페이지에만 렌더된다. 캐럿을
+//! 그 텍스트 끝에 두고 rect 를 질의하면 #4127 가드(텍스트 0자 한정)가 미발동,
+//! 페이지 루프가 후보 115쪽을 순서대로 빌드하다 마지막 후보에서야 히트한다
+//! (studio 실측: 열기 시 단일 long task 2.56s, native 재현 2.54s).
+//!
+//! 정정: `find_text_scan_pages_for_paragraph` 가 pagination 메타데이터만으로
+//! 순수-중간 연속 컷(cont=true && end_cut 비어있지 않음) 페이지를 후보에서 뺀다 —
+//! 텍스트는 표 시작 페이지(cont=false) 또는 표 소진 페이지(end_cut=[])에만 렌더
+//! 가능하다. 115 후보 → 2. 스캔 순서·결과 좌표 불변.
+//!
+//! 판별은 #4126 과 같은 작업량 카운터 상한 — 카운터는 프로세스 누적이므로
+//! 이 파일에는 테스트를 1개만 둔다.
+
+use std::fs;
+use std::path::Path;
+
+use rhwp::diagnostics::perf_counters;
+
+#[test]
+fn text_host_para_cursor_rect_builds_few_page_trees() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("samples/issue1949_giant_cell_nested_tables_perf.hwp");
+    let bytes = fs::read(&path).expect("read sample");
+    let mut doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse");
+    assert_eq!(doc.page_count(), 115, "issue1949 기준 쪽수 핀");
+
+    // "(1)" 변형 재현: 호스트 문단에 타이핑 — 별도 체크인 픽스처 불필요.
+    // 실물 "(1)" 파일의 캐럿 메타데이터가 (0,0,7) = 이 텍스트의 끝이었다 (#4180).
+    doc.insert_text(0, 0, 0, "rhwp pe")
+        .expect("호스트 문단 텍스트 삽입");
+    assert_eq!(doc.page_count(), 115, "삽입 후 쪽수 불변 핀");
+
+    perf_counters::reset();
+    let rect = doc
+        .get_cursor_rect(0, 0, 7)
+        .expect("텍스트 있는 호스트 문단 캐럿 rect");
+
+    // 스킵이 결과를 바꾸지 않는다는 계약: 표 뒤 텍스트의 캐럿은 마지막 페이지(114).
+    assert!(
+        rect.contains("\"pageIndex\":114"),
+        "표 뒤 텍스트 캐럿은 마지막 페이지에 렌더되어야 함: {rect}"
+    );
+
+    let builds = perf_counters::page_tree_builds();
+    // 필터 후 후보 = 표 시작 페이지(cont=false) + 표 소진 페이지(end_cut=[]) = 2.
+    // 수정 원복 시 후보 115쪽 전부를 빌드해 이 상한을 크게 넘는다 (실측 ~115회).
+    assert!(
+        builds <= 3,
+        "#4179 회귀: 텍스트 있는 호스트 문단 캐럿 배치가 page tree 를 {builds}회 빌드 \
+         (기대 ≤3). find_text_scan_pages_for_paragraph 필터가 무력화됐는지 확인."
+    );
+}

--- a/tests/issue_4180_caret_stamp_roundtrip.rs
+++ b/tests/issue_4180_caret_stamp_roundtrip.rs
@@ -1,0 +1,48 @@
+//! Issue #4180: 문서 캐럿 메타데이터가 "마지막 본문 편집 위치"가 아니라
+//! **저장 시점 캐럿**이어야 한다는 계약 (한컴 의미론).
+//!
+//! 신고 재현: 호스트 문단에 타이핑 후 저장된 파일이 캐럿 (0,0,7) 을 갖고,
+//! 열기 시 그 텍스트가 렌더되는 마지막 페이지로 캐럿이 복원됐다. 편집별
+//! 스탬핑이 남긴 위치를 저장 흐름의 `setCaretPosition` 이 덮어써야 한다.
+
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn set_caret_position_roundtrips_through_save() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("samples/issue1949_giant_cell_nested_tables_perf.hwp");
+    let bytes = fs::read(&path).expect("read sample");
+    let mut doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse");
+
+    // 편집별 스탬핑이 (0,0,7) 을 남긴다 — 신고 파일과 같은 상태
+    doc.insert_text(0, 0, 0, "rhwp pe").expect("insert");
+    assert_eq!(
+        doc.get_caret_position().expect("caret after edit"),
+        r#"{"sectionIndex":0,"paragraphIndex":0,"charOffset":7}"#,
+        "편집 스탬핑 전제 확인"
+    );
+
+    // 저장 시점 캐럿이 편집 스탬프를 이긴다 — 신고 버그의 회귀 계약
+    doc.set_caret_position(0, 0, 3);
+    let saved = doc.export_hwp().expect("export");
+
+    let doc2 = rhwp::wasm_api::HwpDocument::from_bytes(&saved).expect("reload");
+    assert_eq!(
+        doc2.get_caret_position().expect("caret after reload"),
+        r#"{"sectionIndex":0,"paragraphIndex":0,"charOffset":3}"#,
+        "저장→재열기 후 캐럿은 set 값이어야 함 (편집 위치 7 이 아니라 3)"
+    );
+}
+
+#[test]
+fn set_caret_position_out_of_range_is_ignored() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("samples/issue1949_giant_cell_nested_tables_perf.hwp");
+    let bytes = fs::read(&path).expect("read sample");
+    let mut doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse");
+
+    let before = doc.get_caret_position().expect("caret before");
+    doc.set_caret_position(99, 0, 0); // 존재하지 않는 구역 — 무시가 계약
+    assert_eq!(doc.get_caret_position().expect("caret after"), before);
+}


### PR DESCRIPTION
## 통합 대상

- #4246: 폰트 메트릭 조회 색인화 (#4168)
- #4247: 저장 단일줄 과밀 판정 memo (#4169)
- #4248, #4249: 셀 캐럿 rect fast path와 units 지문 불변 eviction 생략 (#4167)
- #4250: 셀 블록 서식 토글 방향과 툴바 상태 동기화 (#4151)
- #4251: IME 조합 replace 거부 뒤 캐럿 재정박 (#4245)
- #4258: 셀 나누기 뒤 stale line_segs 재래핑 (#4138)
- #4259: 텍스트 있는 표 호스트 문단 캐럿 질의 최적화 (#4179)
- #4260: 저장 시점 캐럿 메타데이터 기록 (#4180)
- #4261: 거대 분할 표 셀 Enter의 deferred pagination 지연 제거 (#4146)
- #4262: ResizeObserver 루프 경고 격리 (#4163)

## 메인터너 보정

#4248의 부분 셀 compose는 뒤 문단의 중첩 표 border clip이 바깥 셀의 `cellBounds`를 넓히는 형상을 생략했다.
KTX 회귀 fixture에서 fast path와 legacy 결과가 달라지는 것을 재현했고, 해당 셀만 끝까지 compose하되 기존
분할 셀 window를 유지하도록 보정했다. 거대 셀의 fast-path 지연 계약은 유지한다.

## 완료한 로컬 검증

- `cargo fmt --check`
- `cargo test --profile release-test --tests`
- #4167 fast-path parity, giant-cell warm latency, #4138, #4179, #4180 focused Rust 검증
- `wasm-pack build --target web --out-dir pkg`
- `rhwp-studio`의 `npm test` 813 passed, production build
- 실제 Chromium HWP/HWPX 셀 Enter E2E: 두 형식 모두 115쪽, Enter flush 0, split 1, ArrowDown barrier flush 1

로컬 Native Skia 3종은 통합 PR 준비 우선 지시로 중단했으나, 최신 GitHub Full CI에서 Native Skia와
slow shard, regular shard 1/3·2/3·3/3, Build & Test가 모두 성공했다.

Closes #4168
Closes #4169
Closes #4167
Closes #4151
Closes #4245
Closes #4150
Closes #4138
Closes #4179
Closes #4145
Closes #4180
Closes #4146
Closes #4163