### PR TITLE
studio: IME 조합 오버레이 stale 좌표 및 HF/FN 재정박 offset 수정

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,8 @@
+# 로컬 전체 회귀에서 매우 긴 baseline을 먼저 시작한다. nextest는 테스트별로
+# 별도 프로세스를 실행하므로, 이 우선순위는 다른 Cargo 실행을 병렬로 띄우지 않고도
+# 긴 작업을 전체 실행 시간과 겹치게 한다.
+nextest-version = { required = "0.9.91", recommended = "0.9.140" }
+
+[[profile.default.overrides]]
+filter = "binary(overflow_cell_baseline)"
+priority = 100

--- a/mydocs/manual/pr_review/local_validation.md
+++ b/mydocs/manual/pr_review/local_validation.md
@@ -2,7 +2,7 @@
 kind: guide
 status: active
 canonical: mydocs/manual/pr_review_workflow.md
-last_verified: 2026-08-08
+last_verified: 2026-08-09
 ---
 
 # 로컬 사전 검증
@@ -12,17 +12,78 @@ PR별 review 문서에 남긴다. 같은 checkout·target·Cargo cache를 공유
 **반드시 하나가 끝난 뒤 다음 명령을 실행**한다.
 
 모든 PR review Cargo 실행에는 CARGO_INCREMENTAL=0을 사용한다. 이전 review의 debug incremental 비대화가
-검증 시간과 디스크 상태를 왜곡하지 않게 하기 위함이다.
+검증 시간과 디스크 상태를 왜곡하지 않게 하기 위함이다. 다만 Cargo의 일반 컴파일 산출물까지 매번 버릴
+이유는 없으므로, 전체 회귀는 host마다 고정한 `target/pr-review`를 재사용한다. Cargo가 소스·feature·compiler
+변경을 판별해 필요한 unit만 다시 빌드한다.
 
-Cargo 검증을 시작하기 전에는 target 하위 directory와 실행 중인 Cargo/Rust 작업을 확인한다. 이전 review의
-정확한 전용 target만 [merge 후속 처리](post_merge.md#771-검토-전용-target)의 정리 기준에 따라 처리하며,
-shared target/debug, target/release, target/release-test, target/wasm32-unknown-unknown와 다른 작업의
-산출물은 삭제 대상으로 가정하지 않는다.
+`target/pr-review`는 **이동하거나 이름을 바꾸지 않는다**. 일부 통합 테스트의 `CARGO_BIN_EXE_*` fallback은
+컴파일 당시 절대 target 경로를 가질 수 있어, 빌드 뒤 directory를 옮기면 실행 파일을 찾지 못한다. 최초
+생성부터 최종 경로를 지정하고, 다음 review도 같은 경로를 사용한다.
+
+Cargo 검증을 시작하기 전에는 target 하위 directory와 실행 중인 Cargo/Rust 작업을 확인한다.
+`target/pr-review`와 shared target/debug, target/release, target/release-test,
+target/wasm32-unknown-unknown, 다른 작업의 산출물은 삭제 대상으로 가정하지 않는다.
 
 ~~~bash
 find target -mindepth 1 -maxdepth 1 -type d -exec du -sh {} \;
 pgrep -alf '(^|/)(cargo|rustc|wasm-pack)( |$)' || true
 ~~~
+
+### 고정 review target과 실행 환경
+
+전체 Rust 회귀의 기본 명령은 다음과 같다. 같은 `target/pr-review`를 사용하는 Cargo 계열 명령은 반드시
+앞 명령의 종료를 확인한 뒤 실행한다.
+
+~~~bash
+CARGO_INCREMENTAL=0 cargo nextest run \
+  --cargo-profile release-test \
+  --target-dir target/pr-review \
+  --tests --test-threads 12 --no-fail-fast
+~~~
+
+2026-08-09 Linux 검증 호스트(`ubuntu-ted`, Intel Xeon E5640 16 vCPU, RAM 15 GiB)에서 이 명령의 fixed
+target cold run은 build 포함 17분 42초였다. 같은 target을 그대로 쓴 warm run은 compile 0.96초·전체 8분
+27초였고, 최신 priority 설정을 포함한 재검증은 compile 0.75초·5,470/5,470 통과·전체 7분 56초였다.
+test 자체의 실행 시간은 host 부하에 따라 달라지므로, 이 수치는 재컴파일 제거 효과와 해당 시점의 측정값을
+분리해 읽는다.
+
+macOS도 POSIX 명령은 동일하다. 다만 `--test-threads 12`는 12 이상 논리 CPU와 충분한 RAM이 있는 host의
+측정값이다. CPU·RAM이 더 작은 host에서는 `sysctl -n hw.ncpu`와 `sysctl -n hw.memsize`를 확인하고 thread
+수를 논리 CPU 이하로 낮춘다.
+
+Windows는 cargo-nextest가 설치되어 있고 PowerShell 또는 cmd에서 Windows 경로만 일관되게 사용하면 같은
+방식으로 가능하다. 2026-08-09 `win10-ted`의 cmd 환경(4 logical CPU, RAM 8 GiB)에서
+`cargo-nextest 0.9.140`과 `target\\pr-review`를 실제로 검증했다. 긴
+`overflow_cell_baseline` 선택 실행은 cold build 포함 18분 55초(build 12분 27초, test 363.036초), 같은
+target을 재사용한 warm 실행은 6분 11초(build 2.74초, test 359.563초)로 통과했다. Windows 전체 `--tests`
+실행 명령도 아래와 같지만, 이 확인에서는 target 재사용을 직접 검증할 수 있는 장시간 baseline만 실행했다.
+이 host에서는 4 thread를 상한으로 쓴다.
+
+~~~powershell
+Set-Location 'C:\\Users\\admin\\Desktop\\rhwp\\rhwp'
+$env:CARGO_INCREMENTAL = '0'
+cargo nextest run `
+  --cargo-profile release-test `
+  --target-dir target/pr-review `
+  --tests --test-threads 4 --no-fail-fast
+~~~
+
+PowerShell의 `target/pr-review`는 Windows에서 정상 경로로 해석된다. WSL 경로와 Windows 경로, 또는 서로
+다른 shell의 환경 변수 문법을 같은 명령에 섞지 않는다.
+
+### 장시간 baseline의 조기 실행
+
+`overflow_cell_baseline::overflow_cell_lines_do_not_grow`는 samples 전수를 자체 worker로 검사해 60초를
+넘길 수 있다. `.config/nextest.toml`은 이 binary에 `priority = 100`을 적용한다. nextest는 개별 테스트를
+별도 프로세스로 스케줄하므로, 동일한 nextest run의 시작 시점에 이 long-running baseline을 먼저 배치하면서도
+별도 Cargo 프로세스·별도 target을 병렬로 열지 않는다. `SLOW` 행은 시작 로그가 아니라 60초 경과 알림이므로
+출력 순서만으로 시작 순서를 판단하지 않는다. 2026-08-09 전체 run에서 이 baseline은 시작 뒤 다른 3,923개
+테스트 완료와 겹쳐 실행됐고, 최종 472.343초에 통과했다.
+
+이 설정은 OS thread를 추가하는 방식이 아니라 nextest의 test-process 우선순위 lane이다. 해당 baseline은
+내부 worker를 이미 사용하므로, host마다 고정 `threads-required`를 강제하면 작은 Windows host나 CI runner의
+전체 병렬도를 오히려 낮출 수 있다. 새로 60초 이상으로 반복 확인된 baseline은 실행 시간 근거와 함께 같은
+override에 추가한다. 임의의 모든 느린 테스트를 정적 목록으로 넣지 않는다.
 
 ## 4.1 PR branch fetch
 

--- a/mydocs/manual/pr_review/post_merge.md
+++ b/mydocs/manual/pr_review/post_merge.md
@@ -2,7 +2,7 @@
 kind: guide
 status: active
 canonical: mydocs/manual/pr_review_workflow.md
-last_verified: 2026-07-25
+last_verified: 2026-08-09
 ---
 
 # Merge 후속 처리
@@ -238,15 +238,17 @@ contributor fork의 head는 위 `upstream` 조회 대상이 아니다. PR metada
 
 ### 7.7.1 검토 전용 target
 
-CARGO_TARGET_DIR=target/<review-name>처럼 이번 review만을 위해 만든 exact target 하위 directory는
-branch·worktree 정리 뒤에만 정리한다. shared target/debug, target/release, target/release-test,
-target/wasm32-unknown-unknown와 사용자·다른 도구 산출물은 삭제 대상으로 가정하지 않는다.
+PR review Cargo 검증의 고정 경로 `target/pr-review`는 branch·worktree 정리 뒤에도 보존한다. 이 경로는
+다음 review의 일반 컴파일 산출물을 재사용하는 shared review cache이며, 빌드 뒤 이동하면 통합 테스트에
+박힌 절대 실행 경로가 깨질 수 있다. shared target/debug, target/release, target/release-test,
+target/wasm32-unknown-unknown와 사용자·다른 도구 산출물도 삭제 대상으로 가정하지 않는다.
 
 ~~~bash
 find target -mindepth 1 -maxdepth 1 -type d -exec du -sh {} \;
 pgrep -alf '(^|/)(cargo|rustc|wasm-pack)( |$)' || true
 ~~~
 
-실행 중인 Cargo/Rust가 그 directory를 쓰면 유지한다. 현재 review 전용임을 확인한 정확한 하위 경로만
-제거하거나 복구 가능한 환경에서는 휴지통으로 이동한다. 이후 남은 target 하위 경로를 확인하고, 정리한
-정확한 이름과 보존한 shared 경로를 최종 상태에 기록한다.
+실행 중인 Cargo/Rust가 있으면 해당 target을 유지한다. `target/pr-review`는 정리하지 않고, 종료된 과거
+`target/review-*`처럼 고정 cache와 구별되는 exact legacy review directory만 소유·미사용을 확인한 뒤
+제거하거나 복구 가능한 환경에서는 휴지통으로 이동한다. 이후 남은 target 하위 경로와 보존한
+`target/pr-review`를 최종 상태에 기록한다.

--- a/mydocs/manual/pr_review_workflow.md
+++ b/mydocs/manual/pr_review_workflow.md
@@ -2,7 +2,7 @@
 kind: canonical
 status: active
 canonical: mydocs/manual/pr_review_workflow.md
-last_verified: 2026-08-08
+last_verified: 2026-08-09
 ---
 
 # PR 리뷰 · 통합 워크플로우 매뉴얼
@@ -85,6 +85,10 @@ current head: <작성 시점 참고 SHA 또는 재확인 필요>
 문서만 읽어야 누락과 불필요한 절차를 함께 줄일 수 있다.
 
 ## 3. 병렬 실행과 순차 게이트
+
+같은 checkout의 Cargo 검토 명령은 `target/pr-review`를 공유해 **순차 실행**한다. 긴 baseline은 별도
+Cargo 명령을 동시에 띄우지 말고 `.config/nextest.toml`의 nextest priority로 같은 run 안에서 먼저
+스케줄한다. 이는 고정 target cache의 재사용과 실행 중 산출물의 무결성을 함께 보장한다.
 
 ### 3.1 GitHub Actions의 실제 병렬 구조
 
@@ -188,8 +192,9 @@ fast-pass 또는 Full CI aggregate 성공은 여전히 merge 직전 다시 확�
 
 공유 상태를 바꾸거나 선행 결과가 필요한 작업은 아래 순서를 지킨다.
 
-- 하나의 checkout, target, Cargo cache를 공유하는 cargo test, cargo clippy, cargo build, wasm-pack은
-  순차 실행한다. 로컬 검증을 CI처럼 병렬화하지 않는다.
+- 하나의 checkout, `target/pr-review`, Cargo cache를 공유하는 cargo test, cargo clippy, cargo build,
+  wasm-pack은 순차 실행한다. 로컬 검증을 CI처럼 여러 Cargo 실행으로 병렬화하지 않는다. 장시간 테스트는
+  `.config/nextest.toml`의 우선순위로 같은 nextest 실행 안에서 먼저 시작한다.
 - branch fetch 이후의 merge simulation, cherry-pick, conflict resolution, commit, push, update branch,
   merge와 stale run force-cancel은 대상 SHA를 확인한 뒤 순차로 실행한다.
 - 실제 GitHub review/comment, issue close, PR close는 승인과 선행 조건이 갖춰진 뒤에만 게시한다.

--- a/mydocs/orders/20260808.md
+++ b/mydocs/orders/20260808.md
@@ -256,3 +256,28 @@
 
 상세 근거: [PR #4257 검토](../pr/archives/pr_4257_review.md),
 [Stage 63 최종 게이트](../working/task_m100_3820_stage63_final_pr_gate.md).
+
+## PR #4266 - #4150 IME 조합 오버레이 stale 좌표 + HF/FN 재정박 offset
+
+- 로컬 `integration/all-works`(#4180/#4179 등 다른 이슈와 미커밋 무관 변경이 섞인 통합 branch)에서
+  IME 조합 관련 커밋 2개(`e6a20f92d`, `c03ee47a0`)만 최신 `upstream/devel` 위 별도 worktree로
+  cherry-pick해 분리했다. 원 branch를 그대로 push하면 185커밋 뒤처진 base와 무관한 이슈가 같은
+  PR에 섞이기 때문이다.
+- 1차 커밋은 `compositionAnchorRect` 캐시를 제거해 같은 페이지 안 reflow 뒤 조합 오버레이가 옛
+  좌표에 겹쳐 그려지던 결함(#4150)을 고치고, 조합 replace가 wasm deferred replace 범위 가드에
+  거부될 때 `onInput` 밖으로 예외가 던져져 조합 추적이 wedge되던 경로를 try/catch로 방어한다.
+  검토 중 이 catch 재정박이 머리말/꼬리말·각주 모드에서 `cursor.getPosition()`의 stale 본문
+  offset을 그대로 쓰는 회귀를 발견했고, 2차 커밋이 `onCompositionStart`와 동일한
+  `hfCharOffset`/`fnCharOffset` override로 고쳤다 — mock `this`로 `onInput`을 직접 호출해 HF/FN/
+  본문 3가지 모드의 재정박 offset을 검증하는 행위 테스트를 추가했다(수정 전 fail, 수정 후 pass
+  확인).
+- cherry-pick한 code head `c03ee47a0`에서 `npx tsc --noEmit`, `node --test`(805/805 pass),
+  `git diff --check`를 통과했다. Rust/wasm 변경이 없어 기존 `pkg/`를 재사용했고 fresh
+  `wasm-pack build`는 생략했다.
+- `upstream`에는 직접 push 권한이 없어(403) fork(`origin`)로 push하고 `edwardkim/rhwp` devel 대상
+  Open PR을 생성했다. 본문에 `Closes #4150`을 명시했으나 저장소 기본 branch가 `main`이라 devel
+  merge로는 자동 종료를 보장하지 않는다. 최근 동일 작성자 PR과 같이 `jangster77` reviewer 지정을
+  시도했으나 권한 부족으로 실패해 작업지시자가 수동 지정해야 한다.
+- 최신 head의 required CI 성공과 reviewer 지정·승인 확인 뒤 merge를 진행한다.
+
+상세 근거: [PR #4266 검토](../pr/archives/pr_4266_review.md).

--- a/mydocs/orders/20260809.md
+++ b/mydocs/orders/20260809.md
@@ -1,0 +1,15 @@
+# 오늘 할 일 - 2026년 8월 9일
+
+## PR #4266 - IME 조합 오버레이 재정박 및 고정 review target 검증
+
+- contributor code head `f2a95a669`의 `compositionAnchorRect` 제거와 deferred replacement 이후 HF/FN
+  char offset 재정박을 최신 `upstream/devel` `c391dbbdc`에 merge simulation했다. 충돌 없이
+  `git diff --check`가 통과했고, TypeScript와 Studio 전체 test 814건도 통과했다.
+- source code head의 CI preflight, Frontend package gates, CodeQL, Canvas visual diff와 Build & Test
+  aggregate는 성공했다. studio 전용 변경이므로 Rust-heavy job은 의도적으로 skipped였다.
+- 로컬 review Cargo cache는 host별 `target/pr-review`로 고정한다. Linux 16 vCPU/15 GiB에서 전체
+  nextest 5,470/5,470이 7분 56초에 통과했고, Windows 4 vCPU/8 GiB에서도 동일 target을 재사용한
+  long-baseline warm 실행이 6분 11초에 통과했다. `overflow_cell_baseline`은 nextest priority로 같은
+  run 시작 시점에 배치하며, 별도 Cargo 실행을 병렬로 열지 않는다.
+- 메인터너 config·검토 기록을 contributor source branch에 trailing commit으로 반영한 뒤 최신 CI와
+  mergeability를 확인한다. 상세 근거는 [PR #4266 검토](../pr/archives/pr_4266_review.md)에 남긴다.

--- a/mydocs/pr/archives/pr_4266_review.md
+++ b/mydocs/pr/archives/pr_4266_review.md
@@ -1,0 +1,99 @@
+---
+kind: pr_review
+status: ci-pending
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-08
+---
+
+# PR #4266 검토 — #4150 IME 조합 오버레이 stale 좌표 + HF/FN 재정박 offset
+
+## 결론
+
+**Open PR 생성, 로컬 TypeScript·전체 studio 테스트·`git diff --check` 통과.** 커밋 1(`e6a20f92d`)은
+IME 조합 중 같은 페이지 안 reflow가 일어나면 조합 오버레이가 옛 좌표에 그려져 실제 캔버스 텍스트와
+겹치던 결함(#4150)을 `compositionAnchorRect` 캐시 제거로 고치고, 조합 replace가 wasm deferred replace
+범위 가드에 거부될 때 `onInput` 밖으로 예외가 던져져 조합 추적이 wedge되던 경로를 try/catch로 방어한다.
+커밋 2(`c03ee47a0`)는 이 리뷰 과정에서 발견한 회귀 — 위 catch 재정박이 머리말/꼬리말·각주 모드에서
+`cursor.getPosition()`의 stale 본문 offset을 그대로 썼던 것 — 을 `onCompositionStart`와 동일한
+`hfCharOffset`/`fnCharOffset` override로 고쳤다.
+
+## 검토 경로
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, local_validation.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+                  collaborator_self_merge.md, intake_and_review.md,
+                  local_validation.md
+devel base: e919655a7 (upstream/devel HEAD at PR 생성 시점)
+validated code head: c03ee47a0142154c737c3a7c7a6da857fb4de764
+```
+
+원 후보는 `integration/all-works`(로컬, #4180/#4179 등 다른 이슈 커밋과 커밋되지 않은 무관한 변경이
+섞인 통합 branch)에서 나왔다. 그 branch를 그대로 push하면 base가 크게 뒤처지고(분기 이후 devel
+185커밋 진행) 무관한 이슈가 같은 PR에 섞이므로, `e6a20f92d`/`c03ee47a0` 두 커밋만 최신
+`upstream/devel` 위 별도 worktree에 cherry-pick해 이 PR로 분리했다. cherry-pick은 두 커밋 모두
+conflict 없이 적용됐다(`input-handler.ts` auto-merge).
+
+별도 `review_impl` 문서는 만들지 않았다. 단일 이슈의 2-커밋 fix이고 실행 순서·rollback 경계가 이 문서
+하나로 충분히 명확하다.
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4266](https://github.com/edwardkim/rhwp/pull/4266) |
+| 관련 이슈 | #4150 |
+| 작성자 | `humdrum00001010` (fork 기반 — `upstream` 직접 push 권한 없음, 403 확인 후 `origin` fork로 push) |
+| reviewer | 최근 동일 작성자 PR(#4259–#4262)과 동일하게 `jangster77` 지정 시도 — 권한 부족으로 `gh pr edit --add-reviewer` 실패(`RequestReviewsByLogin` 권한 없음). 작업지시자가 수동으로 지정 필요 |
+| 대상 / head | `devel` / `humdrum00001010:task_m100_4150` (fork branch) |
+| 생성 상태 | open, non-draft |
+| 생성 시점 규모 | 5 files, +253 / -87, 2 commits |
+| 생성 시점 merge 상태 | mergeable, `BLOCKED` — CI 진행 중 참고값 |
+
+위 head·규모·merge 상태는 PR 생성 직후 참고값이다. merge 직전에 다시 확인한다.
+
+## 렌더 영향 판정
+
+시각·fixture 증적 보조 경로는 적용하지 않는다. 조합 블랙박스 오버레이(`caret-renderer.ts`의 `compEl`)는
+canvas paint가 아니라 절대좌표 DOM 엘리먼트 위치 계산이고, 이 PR은 `src/renderer`, `wasm_api.rs`,
+golden/fixture, HWP/HWPX sample을 전혀 건드리지 않는다.
+
+## 로컬 검증
+
+cherry-pick한 code head(`c03ee47a0`)를 최신 `upstream/devel` 기준 별도 worktree에서 검증했다.
+Rust/wasm 변경이 없는 rhwp-studio 전용 PR이라 [4.3 표](../../manual/pr_review/local_validation.md#43-변경-범위별-기본-검증)의
+"rhwp-studio만 변경" 행을 따랐다.
+
+| 검증 | 결과 |
+| --- | --- |
+| `npx tsc --noEmit` | PASS |
+| `node --test tests/*.test.ts ../npm/editor/tests/*.test.mjs` | 805/805 pass |
+| `git diff --check` (devel..HEAD) | PASS |
+| 새 행위 테스트 회귀 확인 | `composition-hf-fn-reanchor.runner.mjs`를 수정 전 소스로 되돌려 재실행 → HF 케이스에서 의도대로 fail(`expected 0, actual 1`), 원복 후 재실행 → pass. `git diff`로 원복 무결성 확인 |
+
+wasm 타입 선언은 이 worktree에 fresh `wasm-pack build`를 새로 돌리지 않고, 이 PR과 무관한 Rust 소스로
+만든 기존 `pkg/`(원 checkout, 오늘자 빌드)를 복사해 재사용했다 — 이 PR이 `.rs` 파일을 전혀 바꾸지 않아
+API 표면이 같으므로 `tsc` 타입체크 목적에는 안전하다고 판단했다. 실제 IME 조합(OS 후보창)을 통한
+수동 재현은 자동화 범위 밖이라 생략했고, 대신 `:7701` 실행 중인 dev 서버에서 synthetic
+compositionstart/update/end 이벤트로 골든 패스 무오류를 확인했다(이전 리뷰 기록).
+
+## 발견한 문제
+
+없음. `e6a20f92d`(1차 커밋) 리뷰에서 지적한 HF/FN 재정박 offset 결함은 `c03ee47a0`(2차 커밋)이
+`onCompositionStart`와 동일 규약으로 정확히 고쳤고, 그 수정을 검증하는 행위 테스트가 수정 전 상태에서
+실패함을 직접 확인했다.
+
+## GitHub Actions와 남은 게이트
+
+- PR 생성 직후 `CI preflight`/`CodeQL preflight`/`Render Diff preflight`는 성공, `Frontend package gates`
+  등 나머지는 진행 중이었다(참고값, 재확인 필요).
+- `mergeStateStatus: BLOCKED`는 CI 진행 중 참고값이며 최신 head의 required check 전체 성공을 merge
+  직전에 다시 확인해야 한다.
+- reviewer 지정은 권한 부족으로 실패했다 — 작업지시자가 GitHub에서 직접 `jangster77`(또는 다른
+  reviewer)을 지정해야 한다.
+
+## 최종 권고
+
+로컬 TypeScript·전체 테스트·diff 검사는 통과했다. 최신 head의 required CI 성공과 reviewer 지정·승인
+확인 후 merge를 권고한다.

--- a/mydocs/pr/archives/pr_4266_review.md
+++ b/mydocs/pr/archives/pr_4266_review.md
@@ -1,15 +1,15 @@
 ---
 kind: pr_review
-status: ci-pending
+status: maintainer-review
 canonical: mydocs/manual/pr_review_workflow.md
-last_verified: 2026-08-08
+last_verified: 2026-08-09
 ---
 
 # PR #4266 검토 — #4150 IME 조합 오버레이 stale 좌표 + HF/FN 재정박 offset
 
 ## 결론
 
-**Open PR 생성, 로컬 TypeScript·전체 studio 테스트·`git diff --check` 통과.** 커밋 1(`e6a20f92d`)은
+**수용 권고.** 커밋 1(`e6a20f92d`)은
 IME 조합 중 같은 페이지 안 reflow가 일어나면 조합 오버레이가 옛 좌표에 그려져 실제 캔버스 텍스트와
 겹치던 결함(#4150)을 `compositionAnchorRect` 캐시 제거로 고치고, 조합 replace가 wasm deferred replace
 범위 가드에 거부될 때 `onInput` 밖으로 예외가 던져져 조합 추적이 wedge되던 경로를 try/catch로 방어한다.
@@ -17,17 +17,25 @@ IME 조합 중 같은 페이지 안 reflow가 일어나면 조합 오버레이�
 `cursor.getPosition()`의 stale 본문 offset을 그대로 썼던 것 — 을 `onCompositionStart`와 동일한
 `hfCharOffset`/`fnCharOffset` override로 고쳤다.
 
+2026-08-09 메인터너 재검토에서 최신 `upstream/devel`과의 merge simulation, TypeScript·Studio 전체 test,
+그리고 고정 `target/pr-review` 전체 Rust 회귀를 다시 확인했다. contributor 코드 head의 CI는 모두 성공했고,
+후속 메인터너 보정은 review target 재사용과 장시간 baseline 우선 실행을 위한 nextest config·검토 문서뿐이다.
+
 ## 검토 경로
 
 ```text
-base route: collaborator_self_merge.md
+base route: collaborator_external_pr.md
 modifiers: intake_and_review.md, local_validation.md
 loaded documents: pr_review_workflow.md, pr_review/README.md,
-                  collaborator_self_merge.md, intake_and_review.md,
+                  collaborator_external_pr.md, intake_and_review.md,
                   local_validation.md
 devel base: e919655a7 (upstream/devel HEAD at PR 생성 시점) → 59b31e5ce (rebase 뒤 최신)
 validated code head: c03ee47a0142154c737c3a7c7a6da857fb4de764 (rebase 전) → a68667af4/241d2f91e/0d1e95ea0 (rebase 후, 아래 참고)
 ```
+
+메인터너 재검토 기준: `upstream/devel` `c391dbbdc`, contributor code head
+`f2a95a6693212b19b9ac210b4424a356daf4b6a9`, merge simulation
+`e771871c0`. simulation은 local 검토 전용이며 contributor source branch에 push하지 않는다.
 
 원 후보는 `integration/all-works`(로컬, #4180/#4179 등 다른 이슈 커밋과 커밋되지 않은 무관한 변경이
 섞인 통합 branch)에서 나왔다. 그 branch를 그대로 push하면 base가 크게 뒤처지고(분기 이후 devel
@@ -112,7 +120,22 @@ compositionstart/update/end 이벤트로 골든 패스 무오류를 확인했다
 - reviewer 지정은 권한 부족으로 실패했다 — 작업지시자가 GitHub에서 직접 `jangster77`(또는 다른
   reviewer)을 지정해야 한다.
 
+### 2026-08-09 메인터너 재검토 결과
+
+| 검증 | 결과 |
+| --- | --- |
+| 최신 `upstream/devel` merge simulation | clean, `git diff --check` 통과 |
+| `rhwp-studio` TypeScript | `npx tsc --noEmit` PASS (2.682초) |
+| Studio 전체 test | `node --test tests/*.test.ts ../npm/editor/tests/*.test.mjs` 814/814 PASS (5.999초) |
+| Linux 고정 review target | `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast`: 5,470/5,470 PASS, 35 skipped, 7분 56초 |
+| Windows 고정 review target | cmd에서 `overflow_cell_baseline` cold 18분 55초, warm 6분 11초, 모두 PASS |
+
+원 code head `f2a95a669`의 CI preflight, Frontend package gates, CodeQL(JavaScript/TypeScript·Python·Rust),
+Canvas visual diff와 Build & Test aggregate는 성공했다. Rust-heavy job은 studio 전용 변경이라 preflight가
+의도적으로 skip했다. nextest config 보정이 추가된 새 head에서는 해당 config 변경을 포함한 최신 CI를 다시
+확인한다.
+
 ## 최종 권고
 
-로컬 TypeScript·전체 테스트·diff 검사는 통과했다. 최신 head의 required CI 성공과 reviewer 지정·승인
-확인 후 merge를 권고한다.
+contributor의 IME 재정박 수정은 수용한다. 메인터너 nextest config·검토 기록을 source branch에 trailing
+commit으로 반영한 뒤, 그 최신 head의 required CI 성공과 reviewer 지정·승인을 확인해 merge를 권고한다.

--- a/mydocs/pr/archives/pr_4266_review.md
+++ b/mydocs/pr/archives/pr_4266_review.md
@@ -25,8 +25,8 @@ modifiers: intake_and_review.md, local_validation.md
 loaded documents: pr_review_workflow.md, pr_review/README.md,
                   collaborator_self_merge.md, intake_and_review.md,
                   local_validation.md
-devel base: e919655a7 (upstream/devel HEAD at PR 생성 시점)
-validated code head: c03ee47a0142154c737c3a7c7a6da857fb4de764
+devel base: e919655a7 (upstream/devel HEAD at PR 생성 시점) → 59b31e5ce (rebase 뒤 최신)
+validated code head: c03ee47a0142154c737c3a7c7a6da857fb4de764 (rebase 전) → a68667af4/241d2f91e/0d1e95ea0 (rebase 후, 아래 참고)
 ```
 
 원 후보는 `integration/all-works`(로컬, #4180/#4179 등 다른 이슈 커밋과 커밋되지 않은 무관한 변경이
@@ -37,6 +37,24 @@ conflict 없이 적용됐다(`input-handler.ts` auto-merge).
 
 별도 `review_impl` 문서는 만들지 않았다. 단일 이슈의 2-커밋 fix이고 실행 순서·rollback 경계가 이 문서
 하나로 충분히 명확하다.
+
+## rebase — #4245와의 conflict 해소
+
+PR 생성 뒤 `mergeable: CONFLICTING`이 됐다. 원인은 같은 날 별도 세션이 처리한
+[이슈 #4245](https://github.com/edwardkim/rhwp/issues/4245)(`studio: IME 조합 replace가 wasm
+범위 가드에 거부되면 uncaught로 조합 추적이 wedge된다`, "관련: #4150 조합 계열"로 명시)가
+[PR #4265](https://github.com/edwardkim/rhwp/pull/4265) 통합에 실려 이미 `upstream/devel`에
+merge된 것이었다. `#4245`의 커밋(`abb5a1485`)은 `onInput`의 같은 catch 블록을 고치지만
+**이 PR에서 발견해 고친 HF/FN `charOffset` override가 없는 이전 버전**이었고, `compositionAnchorRect`
+캐시 제거(#4150의 핵심 시각 결함 수정)는 포함하지 않았다.
+
+`git rebase upstream/devel`을 실행한 결과 수동 conflict 마커 없이 자동 3-way merge로 정리됐다 —
+devel의 `#4245` 커밋과 이 PR의 1차 커밋이 텍스트상 동일한 초기 patch였기 때문에, git이 이를 이미
+적용된 변경으로 인식하고 2차 커밋(HF/FN override)만 그 위에 얹었다. rebase 뒤
+`input-handler-text.ts`의 catch 블록을 직접 읽어 HF/FN override가 살아있는지 확인했다(아래
+로컬 검증 재실행 결과도 새 head 기준으로 갱신). 이 PR은 `#4245`와 중복이 아니라 `#4245`가
+놓친 시각 결함(#4150 본 증상)과 `#4245`가 devel에 남긴 HF/FN offset 버그를 함께 고치는
+상위 집합이다.
 
 ## 메타데이터
 
@@ -61,16 +79,17 @@ golden/fixture, HWP/HWPX sample을 전혀 건드리지 않는다.
 
 ## 로컬 검증
 
-cherry-pick한 code head(`c03ee47a0`)를 최신 `upstream/devel` 기준 별도 worktree에서 검증했다.
+최초 cherry-pick code head(`c03ee47a0`)를 검증한 뒤, `upstream/devel` rebase(위 절)로 head가
+`0d1e95ea0`(code 변경은 `a68667af4`/`241d2f91e`)로 바뀌어 새 head 기준으로 전부 재실행했다.
 Rust/wasm 변경이 없는 rhwp-studio 전용 PR이라 [4.3 표](../../manual/pr_review/local_validation.md#43-변경-범위별-기본-검증)의
 "rhwp-studio만 변경" 행을 따랐다.
 
-| 검증 | 결과 |
-| --- | --- |
-| `npx tsc --noEmit` | PASS |
-| `node --test tests/*.test.ts ../npm/editor/tests/*.test.mjs` | 805/805 pass |
-| `git diff --check` (devel..HEAD) | PASS |
-| 새 행위 테스트 회귀 확인 | `composition-hf-fn-reanchor.runner.mjs`를 수정 전 소스로 되돌려 재실행 → HF 케이스에서 의도대로 fail(`expected 0, actual 1`), 원복 후 재실행 → pass. `git diff`로 원복 무결성 확인 |
+| 검증 | rebase 전 (`c03ee47a0`) | rebase 후 (`0d1e95ea0`) |
+| --- | --- | --- |
+| `npx tsc --noEmit` | PASS | PASS |
+| `node --test tests/*.test.ts ../npm/editor/tests/*.test.mjs` | 805/805 pass | 814/814 pass (devel에 병합된 다른 PR 테스트 포함) |
+| `git diff --check` (devel..HEAD) | PASS | PASS |
+| 새 행위 테스트 회귀 확인 | `composition-hf-fn-reanchor.runner.mjs`를 수정 전 소스로 되돌려 재실행 → HF 케이스에서 의도대로 fail(`expected 0, actual 1`), 원복 후 재실행 → pass. `git diff`로 원복 무결성 확인 | rebase 후 파일을 직접 읽어 HF/FN override가 살아있음을 확인(위 절) — 소스 되돌리기 재실행은 rebase 전 결과를 재사용 |
 
 wasm 타입 선언은 이 worktree에 fresh `wasm-pack build`를 새로 돌리지 않고, 이 PR과 무관한 Rust 소스로
 만든 기존 `pkg/`(원 checkout, 오늘자 빌드)를 복사해 재사용했다 — 이 PR이 `.rs` 파일을 전혀 바꾸지 않아

--- a/rhwp-studio/src/engine/input-handler-text.ts
+++ b/rhwp-studio/src/engine/input-handler-text.ts
@@ -384,12 +384,10 @@ export function onCompositionStart(this: any): void {
     this.textarea.value = '';
     this.isComposing = false;
     this.compositionAnchor = null;
-    this.clearCompositionAnchorRect();
     this.compositionLength = 0;
     return;
   }
 
-  this.captureCompositionAnchorRect(basePos);
   this.isComposing = true;
   if (this.cursor.isInHeaderFooter()) {
     // 머리말/꼬리말 모드에서는 hfCharOffset을 anchor의 charOffset으로 사용
@@ -409,7 +407,6 @@ export function onCompositionEnd(this: any): void {
 
   this.isComposing = false;
   this.compositionAnchor = null;
-  this.clearCompositionAnchorRect();
   this.compositionLength = 0;
   this.textarea.value = '';
   this.caret.hideComposition();

--- a/rhwp-studio/src/engine/input-handler-text.ts
+++ b/rhwp-studio/src/engine/input-handler-text.ts
@@ -497,7 +497,15 @@ export function onInput(this: any, e?: InputEvent): void {
       // wedge 된다. 조합을 현재 캐럿에 재정박하고 이번 조합 텍스트를 새로 삽입해
       // 입력 스트림을 잇는다 — 실패분은 다음 캐럿 이동에서 자연 동기화된다.
       console.warn('[InputHandler] 조합 replace 거부 — 현재 캐럿에 재정박:', err);
-      anchor = { ...this.cursor.getPosition() };
+      // 머리말/꼬리말·각주 모드에서는 cursor.getPosition()이 진입 전 본문 위치로
+      // 고정돼 있고 실제 오프셋은 hfCharOffset/fnCharOffset에 있다(onCompositionStart와
+      // 동일 규약). 이 override 없이 그대로 쓰면 insertTextAtRaw/deleteTextAt이 정확한
+      // hfParaIdx/hfSectionIdx에 엉뚱한 본문 charOffset을 실어 보낸다.
+      anchor = this.cursor.isInHeaderFooter()
+        ? { ...this.cursor.getPosition(), charOffset: this.cursor.hfCharOffset }
+        : this.cursor.isInFootnote()
+          ? { ...this.cursor.getPosition(), charOffset: this.cursor.fnCharOffset }
+          : { ...this.cursor.getPosition() };
       this.compositionAnchor = anchor;
       this.compositionLength = 0;
       try {

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -471,8 +471,6 @@ export class InputHandler {
   // IME 조합 상태
   private isComposing = false;
   private compositionAnchor: DocumentPosition | null = null;
-  /** 조합 시작 시점의 exact 좌표. 조합 갱신마다 같은 anchor를 다시 탐색하지 않는다. */
-  private compositionAnchorRect: CursorRect | null = null;
   private compositionLength = 0; // 문서에 삽입된 조합 텍스트 길이
   private _lastCompositionText = '';
   private _lastComposedText = '';
@@ -2572,22 +2570,6 @@ export class InputHandler {
     _text.onCompositionStart.call(this);
   }
 
-  /** 현재 cursor가 조합 anchor와 같을 때 시작 좌표를 안전하게 보존한다. */
-  private captureCompositionAnchorRect(anchor: DocumentPosition): void {
-    const current = this.cursor.getPosition();
-    const rect = this.cursor.getRect();
-    this.compositionAnchorRect = rect && CursorState.comparePositions(current, anchor) === 0
-      ? {
-          ...rect,
-          cellBounds: rect.cellBounds ? { ...rect.cellBounds } : undefined,
-        }
-      : null;
-  }
-
-  private clearCompositionAnchorRect(): void {
-    this.compositionAnchorRect = null;
-  }
-
   /** IME 조합 완료 — 조합 텍스트를 Command로 기록 */
   private onCompositionEnd(): void {
     _text.onCompositionEnd.call(this);
@@ -2684,9 +2666,6 @@ export class InputHandler {
       this.cursor.invalidateFocusedCellCursorGeometry();
       this.lastCellKey = null;
       this.protectedCellHitCache = null;
-      if (this.isComposing) {
-        this.compositionAnchorRect = null;
-      }
       this.eventBus.emit('document-mutated', 'input-handler-cell-overflow');
       this.eventBus.emit('document-changed', 'cell-overflow-pagination');
       this.cursor.moveTo(this.cursor.getPosition());
@@ -2766,9 +2745,6 @@ export class InputHandler {
     this.deferredPaginationPending = false;
     this.lastCellKey = null;
     this.protectedCellHitCache = null;
-    if (this.isComposing) {
-      this.compositionAnchorRect = null;
-    }
     this.eventBus.emit('document-mutated', 'input-handler-resumable-pagination');
     this.eventBus.emit('document-changed', 'deferred-pagination-complete');
     const position = this.cursor.getPosition();
@@ -2806,9 +2782,6 @@ export class InputHandler {
       this.wasm.flushDeferredPagination();
       this.deferredPaginationPending = false;
       this.cursor.invalidateFocusedCellCursorGeometry();
-      if (this.isComposing) {
-        this.compositionAnchorRect = null;
-      }
       if (emitChange) {
         this.eventBus.emit('document-changed', `deferred-pagination-flush:${reason}`);
       }
@@ -2917,39 +2890,33 @@ export class InputHandler {
       if (this.isComposing && this.compositionAnchor && this.compositionLength > 0) {
         try {
           const anchor = this.compositionAnchor;
-          let startRect = this.compositionAnchorRect;
-          if (!startRect) {
-            if (this.cursor.isInHeaderFooter()) {
-              const isHeader = this.cursor.headerFooterMode === 'header';
-              startRect = this.wasm.getCursorRectInHeaderFooter(
-                this.cursor.hfSectionIdx, isHeader, this.cursor.hfApplyTo,
-                this.cursor.hfParaIdx, anchor.charOffset, this.cursor.getRect()?.pageIndex ?? 0,
-              )!;
-            } else if (this.cursor.isInFootnote()) {
-              startRect = this.wasm.getCursorRectInFootnote(
-                this.cursor.fnPageNum, this.cursor.fnFootnoteIndex,
-                this.cursor.fnInnerParaIdx, anchor.charOffset,
-              )!;
-            } else if ((anchor.cellPath?.length ?? 0) > 1 && anchor.parentParaIndex !== undefined) {
-              startRect = this.wasm.getCursorRectByPath(
-                anchor.sectionIndex, anchor.parentParaIndex,
-                JSON.stringify(anchor.cellPath), anchor.charOffset,
-              );
-            } else if (anchor.parentParaIndex !== undefined) {
-              startRect = this.wasm.getCursorRectInCell(
-                anchor.sectionIndex, anchor.parentParaIndex,
-                anchor.controlIndex!, anchor.cellIndex!,
-                anchor.cellParaIndex!, anchor.charOffset,
-              );
-            } else {
-              startRect = this.wasm.getCursorRect(
-                anchor.sectionIndex, anchor.paragraphIndex, anchor.charOffset,
-              );
-            }
-            this.compositionAnchorRect = {
-              ...startRect,
-              cellBounds: startRect.cellBounds ? { ...startRect.cellBounds } : undefined,
-            };
+          let startRect: CursorRect;
+          if (this.cursor.isInHeaderFooter()) {
+            const isHeader = this.cursor.headerFooterMode === 'header';
+            startRect = this.wasm.getCursorRectInHeaderFooter(
+              this.cursor.hfSectionIdx, isHeader, this.cursor.hfApplyTo,
+              this.cursor.hfParaIdx, anchor.charOffset, this.cursor.getRect()?.pageIndex ?? 0,
+            )!;
+          } else if (this.cursor.isInFootnote()) {
+            startRect = this.wasm.getCursorRectInFootnote(
+              this.cursor.fnPageNum, this.cursor.fnFootnoteIndex,
+              this.cursor.fnInnerParaIdx, anchor.charOffset,
+            )!;
+          } else if ((anchor.cellPath?.length ?? 0) > 1 && anchor.parentParaIndex !== undefined) {
+            startRect = this.wasm.getCursorRectByPath(
+              anchor.sectionIndex, anchor.parentParaIndex,
+              JSON.stringify(anchor.cellPath), anchor.charOffset,
+            );
+          } else if (anchor.parentParaIndex !== undefined) {
+            startRect = this.wasm.getCursorRectInCell(
+              anchor.sectionIndex, anchor.parentParaIndex,
+              anchor.controlIndex!, anchor.cellIndex!,
+              anchor.cellParaIndex!, anchor.charOffset,
+            );
+          } else {
+            startRect = this.wasm.getCursorRect(
+              anchor.sectionIndex, anchor.paragraphIndex, anchor.charOffset,
+            );
           }
           const charWidth = rect.x - startRect.x;
           const text = this.textarea.value || '';
@@ -3472,7 +3439,6 @@ export class InputHandler {
     this.resetRawTextMutationEffects();
     this.isComposing = false;
     this.compositionAnchor = null;
-    this.compositionAnchorRect = null;
     this.compositionLength = 0;
     this._lastCompositionText = '';
     this._lastComposedText = '';
@@ -3517,7 +3483,6 @@ export class InputHandler {
     this.resetRawTextMutationEffects();
     this.isComposing = false;
     this.compositionAnchor = null;
-    this.compositionAnchorRect = null;
     this.compositionLength = 0;
     this._lastCompositionText = '';
     this._lastComposedText = '';

--- a/rhwp-studio/tests/composition-replace-reanchor.test.ts
+++ b/rhwp-studio/tests/composition-replace-reanchor.test.ts
@@ -1,8 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import * as nodeModule from 'node:module';
 
 // [#4149 계열 방어] IME 조합 업데이트의 raw replace 는 wasm 의 deferred replace 범위
 // 가드에 거부될 수 있다(외부 변이로 앵커·길이가 낡은 경합). 거부가 onInput 밖으로
@@ -37,4 +39,30 @@ test('거부 시 조합을 현재 캐럿에 재정박하고 길이를 리셋한�
     '재정박 시 조합 길이 리셋이 없다');
   assert.match(branch, /catch[\s\S]*?this\.cursor\.getPosition\(\)/,
     '재정박 기준이 현재 캐럿이 아니다');
+});
+
+// [#4150 리뷰] 위 두 테스트는 소스 정규식이라 "catch 가 있고 getPosition() 을 쓴다"만
+// 확인하고, 머리말/꼬리말·각주 모드에서 getPosition() 이 진입 전 stale 본문 위치를
+// 돌려준다는 사실은 잡지 못했다. onInput 을 mock this 로 직접 호출해 재정박이 실제로
+// hfCharOffset/fnCharOffset 을 쓰는지 행위로 검증한다.
+
+function transformTypesSupported(): boolean {
+  return process.allowedNodeEnvironmentFlags.has('--experimental-transform-types')
+    && typeof (nodeModule as { registerHooks?: unknown }).registerHooks === 'function';
+}
+
+test('조합 replace 거부 재정박은 머리말/꼬리말·각주 모드에서 stale 본문 offset 대신 hf/fnCharOffset 을 쓴다', (t) => {
+  if (!transformTypesSupported()) {
+    t.skip('현재 Node 가 --experimental-transform-types / registerHooks 미지원 — 행위 테스트 skip');
+    return;
+  }
+  const runner = join(rootDir, 'tests', 'support', 'composition-hf-fn-reanchor.runner.mjs');
+  const res = spawnSync(
+    process.execPath,
+    ['--experimental-transform-types', '--no-warnings', runner],
+    { encoding: 'utf8' },
+  );
+  assert.equal(res.status, 0,
+    `러너가 비정상 종료했습니다.\n--- stdout ---\n${res.stdout}\n--- stderr ---\n${res.stderr}`);
+  assert.match(res.stdout, /COMPOSITION_HF_FN_REANCHOR_OK/, '행위 검증 성공 마커가 있어야 함');
 });

--- a/rhwp-studio/tests/input-edit-invalidation.test.ts
+++ b/rhwp-studio/tests/input-edit-invalidation.test.ts
@@ -106,33 +106,27 @@ test('raw IME/iOS 입력은 flow effect를 cursor lookup 전에 소비하고 ref
   );
 });
 
-test('IME 조합 caret은 시작 시 보존한 anchor 좌표를 재사용한다', () => {
+test('IME 조합 caret은 매 갱신마다 anchor의 현재 위치를 다시 조회한다', () => {
+  // [#4150] 조합 시작 좌표를 compositionAnchorRect 필드에 캐시하고 조합 갱신마다
+  // 재사용하던 이전 구현은, 캐시를 무효화해야 하는 호출부(afterPageLocalEdit) 중
+  // 하나가 누락되면서 같은 페이지 안 reflow(줄바꿈) 뒤에도 옛 좌표에 조합
+  // 오버레이가 그려져 실제 캔버스 텍스트와 겹쳤다(issue #4150). 캐시 자체를
+  // 없애고 anchor의 실제 위치를 매번 다시 조회하면, 무효화를 잊는 호출부가
+  // 늘어나도 이 버그 계열이 재발할 수 없다.
   const inputHandlerSource = readFileSync(new URL('../src/engine/input-handler.ts', import.meta.url), 'utf8');
   const textSource = readFileSync(new URL('../src/engine/input-handler-text.ts', import.meta.url), 'utf8');
 
-  assert.match(inputHandlerSource, /private compositionAnchorRect: CursorRect \| null = null;/);
-  assert.match(
+  assert.doesNotMatch(
     inputHandlerSource,
-    /private captureCompositionAnchorRect\(anchor: DocumentPosition\): void \{[\s\S]*?CursorState\.comparePositions\(current, anchor\) === 0[\s\S]*?cellBounds: rect\.cellBounds \? \{ \.\.\.rect\.cellBounds \} : undefined,[\s\S]*?\}/,
-    '조합 시작 좌표는 현재 logical cursor와 anchor가 정확히 같을 때만 캐시해야 한다',
-  );
-  assert.match(textSource, /this\.captureCompositionAnchorRect\(basePos\);\s*this\.isComposing = true;/);
-  assert.match(
-    inputHandlerSource,
-    /let startRect = this\.compositionAnchorRect;\s*if \(!startRect\) \{[\s\S]*?this\.wasm\.getCursorRectInCell\(/,
-    '캐시가 없을 때만 기존 exact anchor lookup으로 fallback해야 한다',
+    /compositionAnchorRect/,
+    '조합 anchor 좌표는 캐시하지 않는다 — 캐시가 있으면 무효화를 잊는 호출부가 재발할 수 있다',
   );
   assert.match(
     inputHandlerSource,
-    /this\.compositionAnchorRect = \{\s*\.\.\.startRect,\s*cellBounds: startRect\.cellBounds \? \{ \.\.\.startRect\.cellBounds \} : undefined,\s*\};/,
-    'fallback exact lookup 결과도 이후 조합 갱신에서 재사용해야 한다',
+    /let startRect: CursorRect;\s*if \(this\.cursor\.isInHeaderFooter\(\)\) \{[\s\S]*?this\.wasm\.getCursorRectInCell\(/,
+    '조합 caret 갱신마다 anchor의 exact 위치를 다시 조회해야 한다(캐시 히트 분기가 없어야 함)',
   );
-  assert.match(
-    inputHandlerSource,
-    /private completeResumablePagination\([\s\S]*?if \(this\.isComposing\) \{\s*this\.compositionAnchorRect = null;\s*\}[\s\S]*?this\.cursor\.moveTo\(position\);/,
-    'shadow pagination commit은 이전 공개 레이아웃의 anchor 좌표를 폐기해야 한다',
-  );
-  assert.match(textSource, /this\.compositionAnchor = null;\s*this\.clearCompositionAnchorRect\(\);/);
+  assert.doesNotMatch(textSource, /captureCompositionAnchorRect|clearCompositionAnchorRect/);
 });
 
 test('raw 셀 입력은 command와 같은 typed mutation helper를 사용한다', () => {
@@ -309,7 +303,6 @@ test('문서 전환은 deferred·IME·iOS 입력 세션 상태를 격리한다',
   assert.match(deactivateSource, /this\.deferredPaginationRunner\.cancel\(\);/);
   assert.match(deactivateSource, /this\.deferredPaginationPending = false;/);
   assert.match(deactivateSource, /this\.resetRawTextMutationEffects\(\);/);
-  assert.match(deactivateSource, /this\.compositionAnchorRect = null;/);
   assert.match(deactivateSource, /this\._lastComposedText = '';/);
   assert.match(deactivateSource, /this\._iosAnchor = null;/);
   assert.match(deactivateSource, /this\._iosRequiresFullRefresh = false;/);

--- a/rhwp-studio/tests/support/composition-hf-fn-reanchor.runner.mjs
+++ b/rhwp-studio/tests/support/composition-hf-fn-reanchor.runner.mjs
@@ -1,0 +1,117 @@
+// [#4150 리뷰] onInput의 조합 replace 거부 재정박이 머리말/꼬리말·각주 모드에서 잘못된
+// charOffset을 wasm에 넘기지 않는지, 실제 onInput 함수를 mock this로 직접 호출해 검증한다.
+// input-handler-text.ts는 command.ts(파라미터 프로퍼티 사용)를 import하므로 기본 test
+// 러너(strip-only)로는 로드할 수 없어 --experimental-transform-types 로 spawn한다
+// (pending-char-shape.runner.mjs 와 동일 패턴).
+import { registerHooks } from 'node:module';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import assert from 'node:assert/strict';
+
+const studioDir = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const srcDir = join(studioDir, 'src');
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier.startsWith('@/')) {
+      const abs = join(srcDir, specifier.slice(2));
+      const withTs = abs.endsWith('.ts') ? abs : abs + '.ts';
+      return { url: pathToFileURL(withTs).href, shortCircuit: true };
+    }
+    if ((specifier.startsWith('./') || specifier.startsWith('../')) && !/\.[cm]?[tj]s$/.test(specifier)) {
+      const parent = context.parentURL ? dirname(fileURLToPath(context.parentURL)) : srcDir;
+      return { url: pathToFileURL(join(parent, specifier + '.ts')).href, shortCircuit: true };
+    }
+    return nextResolve(specifier, context);
+  },
+});
+
+const { onInput } = await import(pathToFileURL(join(srcDir, 'engine', 'input-handler-text.ts')).href);
+
+/** onInput의 조합 분기를 한 번 실행하고, 재정박 시도(실패 후 재시도) 시 넘긴 anchor를 돌려준다. */
+function runOnceAndCaptureRetryAnchor(cursorOverrides) {
+  const anchors = [];
+  const setHfCalls = [];
+  const setFnCalls = [];
+  const moveToCalls = [];
+
+  const cursor = {
+    getRect: () => ({ pageIndex: 0 }),
+    isInHeaderFooter: () => false,
+    isInFootnote: () => false,
+    getPosition: () => ({ sectionIndex: 0, paragraphIndex: 7, charOffset: 42 }), // 진입 전 stale 본문 위치
+    hfCharOffset: 5,
+    hfParaIdx: 2,
+    setHfCursorPosition: (paraIdx, offset) => setHfCalls.push({ paraIdx, offset }),
+    fnCharOffset: 9,
+    fnInnerParaIdx: 3,
+    setFnCursorPosition: (paraIdx, offset) => setFnCalls.push({ paraIdx, offset }),
+    moveTo: (pos) => moveToCalls.push(pos),
+    ...cursorOverrides,
+  };
+
+  let replaceCallCount = 0;
+  const fakeThis = {
+    active: true,
+    textarea: { value: '가' },
+    isComposing: true,
+    compositionAnchor: { sectionIndex: 0, paragraphIndex: 0, charOffset: 999 },
+    compositionLength: 0,
+    cursor,
+    canInsertTextInFormMode: () => true,
+    resetRawTextMutationEffects: () => {},
+    consumeRawTextMutationBeforeCursor: () => false,
+    afterTextInputEdit: () => {},
+    replaceTextAtRaw: (anchor) => {
+      replaceCallCount++;
+      if (replaceCallCount === 1) throw new Error('deferred replace 범위 가드 거부(테스트 시뮬레이션)');
+      anchors.push({ ...anchor });
+    },
+  };
+
+  const realWarn = console.warn;
+  console.warn = () => {};
+  try {
+    onInput.call(fakeThis, undefined);
+  } finally {
+    console.warn = realWarn;
+  }
+
+  assert.equal(replaceCallCount, 2, 'replaceTextAtRaw 는 실패 후 정확히 한 번 재시도해야 한다');
+  assert.equal(anchors.length, 1, '재시도 anchor 를 캡처하지 못했다');
+  return { retryAnchor: anchors[0], setHfCalls, setFnCalls, moveToCalls };
+}
+
+// ── 1. 머리말/꼬리말 모드: 재정박 anchor 는 hfCharOffset 을 써야 한다 ──────────
+{
+  const { retryAnchor, setHfCalls } = runOnceAndCaptureRetryAnchor({
+    isInHeaderFooter: () => true,
+  });
+  assert.equal(retryAnchor.charOffset, 5,
+    `HF 모드 재정박은 hfCharOffset(5)을 써야 하는데 ${retryAnchor.charOffset} 을 썼다 ` +
+    '(cursor.getPosition()의 stale 본문 charOffset 42 를 그대로 쓰면 이 값이 된다)');
+  assert.equal(setHfCalls.length, 1, 'HF 커서 갱신이 한 번 호출돼야 한다');
+  assert.equal(setHfCalls[0].offset, 5 + 1, 'HF 커서는 재정박 offset(5) + 삽입 길이(1) 여야 한다');
+}
+
+// ── 2. 각주 모드: 재정박 anchor 는 fnCharOffset 을 써야 한다 ──────────────────
+{
+  const { retryAnchor, setFnCalls } = runOnceAndCaptureRetryAnchor({
+    isInFootnote: () => true,
+  });
+  assert.equal(retryAnchor.charOffset, 9,
+    `FN 모드 재정박은 fnCharOffset(9)을 써야 하는데 ${retryAnchor.charOffset} 을 썼다`);
+  assert.equal(setFnCalls.length, 1, 'FN 커서 갱신이 한 번 호출돼야 한다');
+  assert.equal(setFnCalls[0].offset, 9 + 1, 'FN 커서는 재정박 offset(9) + 삽입 길이(1) 여야 한다');
+}
+
+// ── 3. 본문 모드: getPosition() 을 그대로 쓴다(override 없음) ────────────────
+{
+  const { retryAnchor, moveToCalls } = runOnceAndCaptureRetryAnchor({});
+  assert.equal(retryAnchor.charOffset, 42, '본문 모드는 getPosition() 의 charOffset 을 그대로 써야 한다');
+  assert.equal(retryAnchor.paragraphIndex, 7);
+  assert.equal(moveToCalls.length, 1, '본문 커서 이동이 한 번 호출돼야 한다');
+  assert.equal(moveToCalls[0].charOffset, 42 + 1);
+}
+
+console.log('COMPOSITION_HF_FN_REANCHOR_OK');


### PR DESCRIPTION
## 변경 요약

IME 조합 중 같은 페이지 안 reflow가 일어나면 조합 오버레이가 옛 좌표에 그려져 실제 캔버스
텍스트와 겹치던 결함을 고친다. `compositionAnchorRect` 캐시를 완전히 제거하고 조합 caret을
갱신할 때마다 anchor의 exact 위치를 다시 조회해, 캐시 무효화를 호출부마다 챙겨야 하는 구조 자체를
없애 이 버그 계열이 재발할 수 없게 했다. 또한 조합 replace가 wasm의 deferred replace 범위 가드에
거부될 때(외부 변이로 앵커·길이가 낡은 경합) `onInput` 밖으로 예외가 던져져 조합 추적이 wedge
되던 경로를 try/catch로 방어하고 현재 캐럿에 재정박한다.

리뷰 중 이 재정박 로직이 머리말/꼬리말·각주 모드에서 `cursor.getPosition()`의 stale 본문 offset을
override 없이 그대로 쓰는 회귀를 발견해, `onCompositionStart`와 동일한
`hfCharOffset`/`fnCharOffset` override로 2번째 커밋에서 고쳤다.

## 관련 이슈

Closes #4150 

## 테스트

- [x] `npx tsc --noEmit` 통과
- [x] `node --test tests/*.test.ts ../npm/editor/tests/*.test.mjs` — 805/805 pass
- [ ] `cargo test` — Rust 변경 없어 생략
- [ ] `cargo clippy -- -D warnings` — Rust 변경 없어 생략
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 렌더러 변경 없어 해당 없음
- [x] 웹(WASM) 렌더링 확인 — dev 서버에서 synthetic composition 이벤트로 무오류 확인. 실제 IME
      후보창을 통한 수동 재현은 자동화 범위 밖이라 별도 mock `this` 기반 행위 테스트
      (`composition-hf-fn-reanchor.runner.mjs`)로 재정박 offset을 검증했다(수정 전 fail, 수정 후 pass 확인).
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 — 해당 없음

## 스크린샷

DOM 오버레이 좌표 계산 변경이라 스크린샷 비교 대상은 아니다. 위 행위 테스트로 대체 검증했다.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
