### PR TITLE
fix(security): Table::split_cell() 이 span 0 셀을 거르지 않아 0-나누기/인덱스 패닉 (#4280)

### DIFF
--- a/src/model/table.rs
+++ b/src/model/table.rs
@@ -1505,6 +1505,15 @@ impl Table {
         if orig_col_span <= 1 && orig_row_span <= 1 {
             return Err("병합되지 않은 셀은 나눌 수 없습니다".to_string());
         }
+        // [#4280] col_span/row_span은 HML "ColSpan"/"RowSpan"="0" 같은 손상된
+        // 문서에서 0으로 파싱될 수 있다(parser/hml/reader.rs의 parse_attribute는
+        // 속성이 없을 때만 unwrap_or(1)을 적용하고, 명시적 "0"은 그대로 통과시킨다).
+        // span 0이 섞이면 아래 `orig_width / orig_col_span`이 0-나누기로 패닉하거나,
+        // `target_col..target_col+0` 빈 범위로 split_col_widths가 비어
+        // `split_col_widths[0]`에서 index-out-of-bounds로 패닉한다.
+        if orig_col_span == 0 || orig_row_span == 0 {
+            return Err("손상된 셀(span 0)은 나눌 수 없습니다".to_string());
+        }
 
         // 열폭 계산: 다른 행의 col_span==1 셀에서 실제 폭 추출, 없으면 균등 분배
         let col_widths = self.get_column_widths();

--- a/src/model/table/tests.rs
+++ b/src/model/table/tests.rs
@@ -474,6 +474,22 @@ fn test_split_cell_not_merged() {
 }
 
 #[test]
+fn test_split_cell_zero_span_cell_does_not_panic() {
+    // [#4280] 손상된 HML 문서는 <CELL ColSpan="0" .../>처럼 span 0을 실어
+    // 보낼 수 있다(src/parser/hml/reader.rs 참고). split_cell()이 span 0을
+    // 거르지 않으면 orig_width / orig_col_span 0-나누기 또는 빈
+    // split_col_widths[0] 인덱싱으로 패닉했다. 에러로 거부되어야 한다(회귀 방지).
+    let mut table = make_table(2, 2);
+    if let Some(cell) = table.cells.iter_mut().find(|c| c.col == 0 && c.row == 0) {
+        cell.col_span = 0;
+        cell.row_span = 2;
+    }
+
+    let result = table.split_cell(0, 0);
+    assert!(result.is_err());
+}
+
+#[test]
 fn test_split_cell_width_distribution() {
     let mut table = make_table(2, 3);
     // 열 0~1 병합 (폭: 3600 + 3600 = 7200)


### PR DESCRIPTION
## 요약

`Table::split_cell()`(`src/model/table.rs:1490`)이 `col_span`/`row_span`이 **0인 셀**을 걸러내지 못해, 조작된 `.hml` 문서를 열고 정상적인 "셀 나누기" 편집 동작을 하면 패닉합니다.

## 왜 버그인가

`src/parser/hml/reader.rs:906-907`:

```rust
col_span: parse_attribute(element, b"ColSpan")?.unwrap_or(1),
row_span: parse_attribute(element, b"RowSpan")?.unwrap_or(1),
```

`parse_attribute`의 `unwrap_or(1)`은 **속성 자체가 없을 때만** 적용됩니다. 파일에 `ColSpan="0"`이 명시돼 있으면 그 값 0이 그대로 파싱됩니다. `src/parser/hml/adapter.rs:232-233`은 이 값을 검증 없이 IR `Cell`에 그대로 복사합니다.

`split_cell()`의 유일한 거부 조건은:

```rust
if orig_col_span <= 1 && orig_row_span <= 1 {
    return Err("병합되지 않은 셀은 나눌 수 없습니다".to_string());
}
```

**둘 다** 1 이하일 때만 에러입니다. `col_span=0, row_span=2`(또는 반대) 조합은 통과합니다.

이후 (`table.rs:1508-1525`):

```rust
let split_col_widths: Vec<HwpUnit> = {
    let has_real = (target_col..target_col + orig_col_span).all(|c| { ... });
    if has_real {
        (target_col..target_col + orig_col_span).map(|c| col_widths[c as usize]).collect()
    } else {
        let each = orig_width / orig_col_span as u32;
        vec![each; orig_col_span as usize]
    }
};
```

`orig_col_span == 0`이면 두 경로 모두 패닉으로 이어집니다:
- `has_real` 분기: `target_col..target_col` 빈 범위 → `.all()`이 공허하게(vacuously) `true` → `.collect()`가 빈 `Vec` 생성 → 바로 다음 줄 `split_col_widths[0]`(`table.rs:1548`)에서 index-out-of-bounds 패닉.
- 그 외 분기: `orig_width / orig_col_span as u32` = `orig_width / 0` → **정수 0-나누기 패닉**(release/debug 무관하게 항상 발생).

`row_span == 0`이면 대칭적으로 `split_row_heights[0]`(`table.rs:1559`)에서 같은 문제가 생깁니다.

자매 함수 `merge_cells()`는 이미 같은 클래스 문제(HML 손상 span 0)를 대비해 `saturating_add`/`saturating_sub`로 처리돼 있고 회귀 시험(`test_merge_cells_zero_span_cell_does_not_panic`, `table/tests.rs:284`)까지 있지만, `split_cell()`은 대비가 없었습니다.

## 재현 조건

`.hml` 문서의 `<CELL>` 요소에 `ColSpan="0"` (또는 `RowSpan="0"`)을 명시하고, 해당 셀에 대해 "셀 나누기" 편집(`Table::split_cell`, rhwp-studio UI의 분할 동작과 `document_core/commands/table_ops.rs`의 `split_table_cell_native`)을 수행하면 패닉합니다.

## 영향

DoS — 조작된 `.hml` 파일을 열고 정상적인 편집(셀 나누기)만 해도 프로세스/WASM 모듈이 죽습니다.

## 제안 수정

`split_cell()` 시작부에 span 0 거부를 추가:

```rust
if orig_col_span == 0 || orig_row_span == 0 {
    return Err("손상된 셀(span 0)은 나눌 수 없습니다".to_string());
}
```
