### PR TITLE
fix(security): HWPX charPr/paraPr id 무검증 resize_with 할당 크기를 상한으로 방어 (#4281)

### DIFF
--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -16,6 +16,29 @@ use super::utils::{
 };
 use super::HwpxError;
 
+/// 리소스 테이블(charShapes/paraShapes 등)의 `id` 속성 상한.
+///
+/// [#4281] `id` 는 XML 텍스트에서 `parse_u32`로 그대로 온 값이라, 상한 없이
+/// `resize_with(id + 1, ..)` 하면 `id="2000000000"` 같은 몇 바이트짜리 속성이
+/// 240GB 할당 시도로 이어져 `handle_alloc_error` → abort 로 프로세스가 죽는다.
+/// 같은 패턴이 HML 리소스 테이블(`FONT`/`CHARSHAPE`/`PARASHAPE`/...)에서 이미
+/// `#2743`으로 발견·수정됐다(`HmlLimits::max_resource_id`, 기본값도 65,535).
+/// 정상 문서의 리소스 테이블 길이는 이 상한에 전혀 근접하지 않는다.
+const MAX_RESOURCE_ID: usize = 65_535;
+
+/// `values[index] = value`를 상한 내에서만 수행한다. 초과 시 아무것도
+/// 할당하지 않고 `false`를 반환한다 — 호출부는 해당 리소스를 건너뛴다.
+fn set_indexed<T: Default>(values: &mut Vec<T>, index: usize, value: T) -> bool {
+    if index > MAX_RESOURCE_ID {
+        return false;
+    }
+    if values.len() <= index {
+        values.resize_with(index + 1, T::default);
+    }
+    values[index] = value;
+    true
+}
+
 /// `<hh:strikeout shape="..."/>` 의 shape 값이 실제 렌더링되는 취소선인지
 /// 판정한다 (화이트리스트).
 ///
@@ -847,12 +870,7 @@ fn parse_char_shape(
     // id 가 없는(비정상) 항목만 등장 순서 fallback 으로 push.
     match id {
         Some(idx) => {
-            if doc_info.char_shapes.len() <= idx {
-                doc_info
-                    .char_shapes
-                    .resize_with(idx + 1, CharShape::default);
-            }
-            doc_info.char_shapes[idx] = cs;
+            set_indexed(&mut doc_info.char_shapes, idx, cs);
         }
         None => doc_info.char_shapes.push(cs),
     }
@@ -946,12 +964,7 @@ fn parse_para_shape(
     // 이유로 등장 순서 push 대신 id 로 배치한다.
     match id {
         Some(idx) => {
-            if doc_info.para_shapes.len() <= idx {
-                doc_info
-                    .para_shapes
-                    .resize_with(idx + 1, ParaShape::default);
-            }
-            doc_info.para_shapes[idx] = ps;
+            set_indexed(&mut doc_info.para_shapes, idx, ps);
         }
         None => doc_info.para_shapes.push(ps),
     }
@@ -3582,6 +3595,31 @@ mod tests {
         assert_eq!(
             cs1.base_size, 2000,
             "charPrIDRef=1 은 id=\"1\" 항목이어야 함"
+        );
+    }
+
+    #[test]
+    fn test_char_pr_huge_id_does_not_allocate_unbounded_memory() {
+        // [#4281] id 는 XML 텍스트에서 그대로 온 usize 라, 상한 없이
+        // resize_with(id+1, ..) 하면 몇 백 바이트짜리 파일로 수백 GB 할당을
+        // 시도하다 abort 한다. 상한을 넘는 id 는 조용히 건너뛰어야 한다
+        // (패닉/abort 없이 정상 반환, 해당 id 는 char_shapes 에 채워지지 않음).
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:charProperties itemCnt="1">
+      <hh:charPr id="4000000000" height="1000" textColor="#000000" shadeColor="none" useFontSpace="0" useKerning="0" symMark="NONE">
+        <hh:fontRef hangul="0" latin="0" hanja="0" japanese="0" other="0" symbol="0" user="0"/>
+      </hh:charPr>
+    </hh:charProperties>
+  </hh:refList>
+</hh:head>"##;
+
+        let (doc_info, _) = parse_hwpx_header(xml).unwrap();
+        assert!(
+            doc_info.char_shapes.len() <= 65_536,
+            "상한 초과 id 는 char_shapes 를 부풀리지 않아야 함 (len={})",
+            doc_info.char_shapes.len()
         );
     }
 


### PR DESCRIPTION
## 요약

HWPX `header.xml`의 `<hh:charPr id="...">`/`<hh:paraPr id="...">`의 `id` 속성이 상한 검증 없이 `resize_with(id + 1, Default::default)` 의 할당 크기로 그대로 쓰입니다. 수백 바이트짜리 조작된 문서로 수백 GB 할당을 유발해 프로세스를 abort 시킬 수 있습니다.

## 왜 버그인가

`src/parser/hwpx/header.rs`의 `parse_char_shape`(848행 부근)와 `parse_para_shape`(947행 부근):

```rust
match id {
    Some(idx) => {
        if doc_info.char_shapes.len() <= idx {
            doc_info.char_shapes.resize_with(idx + 1, CharShape::default);
        }
        doc_info.char_shapes[idx] = cs;
    }
    None => doc_info.char_shapes.push(cs),
}
```

`id`는 `parse_u32(&attr) as usize`로 XML 텍스트에서 그대로 옵니다. `parse_u32`(`hwpx/utils.rs:58`)는 숫자가 아닐 때만 `unwrap_or(0)`으로 방어할 뿐 값의 **상한**은 전혀 두지 않습니다. `idx`가 `u32::MAX`(약 42억)까지 갈 수 있으므로 `resize_with`가 수십억 개의 `CharShape`/`ParaShape`(각각 `Default::default()`로 초기화)를 예약하려 시도합니다. 두 함수 모두 `parse_hwpx_header`가 호출하는 `<hh:head>` 메인 파싱 루프(`header.rs:136-140`)에서 직접 도달하므로, `parse_hwpx()` 호출마다 그대로 노출됩니다.

**동일 클래스 버그가 이 저장소에 이미 한 번 발견·수정된 전례가 있습니다.** 커밋 `289dbf8d2`(`fix(parser): HML 리소스 Id 가 무검증으로 할당 크기가 되던 결함`, #2743)가 `src/parser/hml/reader.rs`의 `set_indexed()`(FONT/BORDERFILL/CHARSHAPE/PARASHAPE/TABDEF/STYLE 전체)에 동일 패턴을 `HmlLimits::max_resource_id`(기본 65,535)로 상한을 두고, 초과분은 하드 오류 대신 경고 남기고 건너뛰도록 고쳤습니다. 그 커밋의 실측치가 그대로 적용됩니다: `Id="1000000"`인 382바이트 파일이 힙 114.5MB를 쓰고, `Id="2000000000"`이면 `memory allocation of 240000000120 bytes failed` → abort. HWPX 쪽 `char_shapes`/`para_shapes`는 같은 `resize_with(idx+1, Default::default)` 관용구를 쓰면서 이 상한을 받지 못했습니다.

## 재현 조건

zip 안 `Contents/header.xml`에 다음과 같은 `charPr`(또는 `paraPr`) 하나만 있어도 됩니다(수백 바이트, `MAX_XML_SIZE`(256MB) 상한에는 전혀 근접하지 않음):

```xml
<hh:charPr id="4000000000" height="1000" textColor="#000000" shadeColor="none"
           useFontSpace="0" useKerning="0" symMark="NONE">
  <hh:fontRef hangul="0" latin="0" hanja="0" japanese="0" other="0" symbol="0" user="0"/>
</hh:charPr>
```

## 영향

수백 바이트짜리 `.hwpx` 업로드로 메모리 할당 실패 abort(하드 크래시, catch 불가) 또는 온건한 `id` 값에서도 수 GB 실제 메모리 커밋 — 콘텐츠 검증 이전에 할당/제로잉만으로 증폭되는 전형적 DoS. 신뢰할 수 없는 `.hwpx` 업로드를 처리하는 모든 서비스가 영향을 받습니다.

## 제안 수정

HML `set_indexed()`와 동일한 패턴 — `id`에 상한(예: 기존과 동일한 65,535)을 두고, 초과 시 `resize_with` 없이 건너뛴다.
