### PR TITLE
fix(security): HWP3 그리기 개체 트리 파싱 재귀 깊이 상한 추가 (#4285)

### DIFF
--- a/src/parser/hwp3/drawing.rs
+++ b/src/parser/hwp3/drawing.rs
@@ -611,6 +611,7 @@ pub fn parse_drawing_object_tree(
         doc_border_fills,
         doc_tab_defs,
         pic_name_to_id,
+        0,
     )?;
 
     if root_nodes.is_empty() {
@@ -628,6 +629,14 @@ pub fn parse_drawing_object_tree(
     }
 }
 
+/// [#4285] `has_child`(connection_info bit 1)는 파일에서 그대로 온 값이라,
+/// 재귀 깊이에 상한이 없으면 중첩된 Container 객체 체인 하나로 네이티브
+/// 스택을 고갈시켜 프로세스를 죽일 수 있다(패닉과 달리 catch_unwind로 못
+/// 잡음). 최소 92바이트짜리 Container 객체를 수만 겹 중첩해도
+/// HWP3_MAX_RECORD_SIZE(256MiB) 안에 들어간다. HmlLimits::max_depth와 같은
+/// 취지로 상한을 둔다.
+const MAX_DRAWING_OBJECT_DEPTH: u32 = 256;
+
 fn parse_shape_list(
     cursor: &mut std::io::Cursor<&[u8]>,
     doc_char_shapes: &mut Vec<crate::model::style::CharShape>,
@@ -635,7 +644,16 @@ fn parse_shape_list(
     doc_border_fills: &mut Vec<crate::model::style::BorderFill>,
     doc_tab_defs: &mut Vec<crate::model::style::TabDef>,
     pic_name_to_id: &mut HashMap<String, u16>,
+    depth: u32,
 ) -> Result<Vec<ShapeObject>, Hwp3Error> {
+    if depth > MAX_DRAWING_OBJECT_DEPTH {
+        return Err(Hwp3Error::ParseError {
+            message: format!(
+                "Drawing object nesting exceeds {} levels",
+                MAX_DRAWING_OBJECT_DEPTH
+            ),
+        });
+    }
     let mut list = Vec::new();
     loop {
         let raw_obj =
@@ -661,6 +679,7 @@ fn parse_shape_list(
                 doc_border_fills,
                 doc_tab_defs,
                 pic_name_to_id,
+                depth + 1,
             )?;
             if let ShapeObject::Group(ref mut g) = node {
                 g.children = children;
@@ -1110,6 +1129,67 @@ mod hypertext_bookmark_underread_tests {
             cursor.position(),
             hypertext_len,
             "하이퍼텍스트 정보 파싱이 책갈피 필드를 32바이트로 소비하지 않음"
+        );
+    }
+}
+
+#[cfg(test)]
+mod drawing_object_recursion_depth_tests {
+    use super::*;
+    use std::io::Cursor;
+
+    /// object_type=0(Container)에 connection_info=0x0002(has_child, no
+    /// sibling)만 실은 최소 92바이트 공통 헤더를 만든다.
+    fn container_block() -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&0u32.to_le_bytes()); // header_length
+        buf.extend_from_slice(&0u16.to_le_bytes()); // object_type = 0 (Container)
+        buf.extend_from_slice(&0x0002u16.to_le_bytes()); // connection_info: has_child, !has_sibling
+        buf.extend_from_slice(&[0u8; 8]); // relative_pos
+        buf.extend_from_slice(&[0u8; 8]); // object_size
+        buf.extend_from_slice(&[0u8; 8]); // absolute_pos
+        buf.extend_from_slice(&[0u8; 16]); // bounds
+        buf.extend_from_slice(&[0u8; 32]); // basic_attr: line_style..pattern_color
+        buf.extend_from_slice(&[0u8; 8]); // basic_attr: textbox_margin
+        buf.extend_from_slice(&0u32.to_le_bytes()); // basic_attr: options
+        buf
+    }
+
+    // [#4285] has_child 는 파일에서 그대로 온 값이라 재귀 깊이 상한이 없으면
+    // Container 객체를 깊이 중첩한 파일 하나로 네이티브 스택을 고갈시켜
+    // 프로세스를 죽인다(catch_unwind로 못 잡음). MAX_DRAWING_OBJECT_DEPTH를
+    // 넘는 중첩이 패닉/abort 대신 파싱 오류로 거부되는지 확인한다.
+    #[test]
+    fn deeply_nested_container_chain_is_rejected_not_stack_overflowed() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&24u32.to_le_bytes()); // frame header_length (<=24: 하이퍼텍스트 없음)
+        buf.extend_from_slice(&0u32.to_le_bytes()); // z_order
+        buf.extend_from_slice(&1u32.to_le_bytes()); // object_count
+        buf.extend_from_slice(&[0u8; 16]); // bounds
+
+        for _ in 0..(MAX_DRAWING_OBJECT_DEPTH as usize + 4) {
+            buf.extend_from_slice(&container_block());
+        }
+
+        let mut doc_char_shapes = Vec::new();
+        let mut doc_para_shapes = Vec::new();
+        let mut doc_border_fills = Vec::new();
+        let mut doc_tab_defs = Vec::new();
+        let mut pic_name_to_id = HashMap::new();
+
+        let mut cursor = Cursor::new(buf.as_slice());
+        let result = parse_drawing_object_tree(
+            &mut cursor,
+            &mut doc_char_shapes,
+            &mut doc_para_shapes,
+            &mut doc_border_fills,
+            &mut doc_tab_defs,
+            &mut pic_name_to_id,
+        );
+
+        assert!(
+            result.is_err(),
+            "상한을 넘는 중첩은 패닉 대신 오류로 거부되어야 함"
         );
     }
 }


### PR DESCRIPTION
## 요약

HWP3 그리기 개체(GSO) 트리를 파싱하는 `parse_shape_list()`(`src/parser/hwp3/drawing.rs`)가 재귀 깊이 상한 없이 자기 자신을 호출합니다. 중첩된 Container 객체 체인 하나로 네이티브 콜스택을 고갈시켜 프로세스를 죽일 수 있습니다.

## 왜 버그인가

```rust
fn parse_shape_list(cursor: &mut std::io::Cursor<&[u8]>, ...) -> Result<Vec<ShapeObject>, Hwp3Error> {
    let mut list = Vec::new();
    loop {
        let raw_obj = Hwp3DrawingObject::read(&mut *cursor)?;
        let (mut node, connection_info) = map_to_shape_object(raw_obj, ...)?;
        let has_sibling = (connection_info & 0x01) != 0;
        let has_child = (connection_info & 0x02) != 0;

        if has_child {
            let children = parse_shape_list(cursor, ...)?;  // <-- 상한 없는 재귀
            ...
        }
        list.push(node);
        if !has_sibling { break; }
    }
    Ok(list)
}
```

`connection_info`(bit 0 = has_sibling, bit 1 = has_child)는 `Hwp3DrawingObjectCommonHeader`(공통 헤더)에서 파일 바이트 그대로 읽힙니다. `has_child` 비트가 설 때마다 상한·깊이 카운터·반복 재작성 없이 재귀합니다. 이 저장소의 다른 곳은 일관되게 깊이/크기 상한을 둡니다(`HmlLimits::max_depth`, `hwp3/mod.rs`의 `HWP3_MAX_RECORD_SIZE`/`check_record_count`) — `src/parser/hwp3/` 전체에서 "깊이" 가드가 있는 곳은 이 함수뿐 없습니다.

**도달 경로**: `hwp3/mod.rs`가 `Hwp3SpecialChar::Picture`(특수문자 코드 11, `pic_type == 3` "그리기 개체")를 파싱할 때, `HWP3_MAX_RECORD_SIZE`(256MiB)까지의 `ext_buf`를 읽어 `parse_drawing_object_tree()`를 호출하고, 이 함수가 `parse_shape_list()`를 호출합니다.

## 재현 조건

최소 Container 객체(`object_type == 0`)는 정확히 92바이트(48바이트 공통 헤더 프리픽스 + 44바이트 `Hwp3DrawingObjectBasicAttr`, 회전/그라디언트/비트맵 서브속성 없음)면 되고, 재귀에 추가 payload가 필요 없습니다 — 각 객체에 `connection_info = 0x0002`(has_child, no sibling)만 설정하면 됩니다. 이런 블록을 수만 겹 체이닝하면(예: ~5만 단계 ≈ 4.6MB, 256MiB 레코드 상한에 여유 있게 들어감) I/O 오류를 반환하기 전에 콜스택이 먼저 고갈됩니다.

## 영향

Rust 스택 오버플로는 `catch_unwind`로 못 잡습니다 — 호스트 애플리케이션의 패닉 캐칭 래퍼와 무관하게 프로세스 전체가 abort/crash 합니다(Linux SIGSEGV, Windows 스택 오버플로 예외). 신뢰할 수 없는 `.hwp`(HWP3) 파일을 파싱하는 모든 서비스가, 특수문자로 삽입된 깊게 중첩된 그리기 개체("컨테이너") 체인이 든 조작된 문서 하나로 죽을 수 있습니다.

## 제안 수정

`parse_shape_list()`에 깊이 카운터를 실어(또는 진짜 재귀 대신 명시적 스택 기반 worklist로), `src/parser/hml/reader.rs`의 `HmlLimits::max_depth` 패턴처럼 상한(예: 256)을 넘으면 `Hwp3Error::ParseError`를 반환한다.
