### PR TITLE
fix: 표 캡션 문단 분할/병합이 sentinel 미처리로 즉시 패닉 (#4288)

### DIFF
--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -3672,9 +3672,19 @@ impl DocumentCore {
             .get_mut(control_idx)
         {
             Some(Control::Table(table)) => {
-                table.cells[cell_idx]
-                    .paragraphs
-                    .insert(new_cell_para_idx, new_para);
+                // [#4288] cell_idx == 65534 는 표 캡션 접근 sentinel이다
+                // (get_cell_paragraph_mut와 동일 관례). 이 분기를 빼먹으면
+                // table.cells[65534] 인덱싱으로 패닉한다 — 손상된 문서가 아니라
+                // 캡션 문단에서 Enter(분할)를 누르는 정상 편집 동작만으로도 발생.
+                if cell_idx == 65534 {
+                    if let Some(ref mut cap) = table.caption {
+                        cap.paragraphs.insert(new_cell_para_idx, new_para);
+                    }
+                } else {
+                    table.cells[cell_idx]
+                        .paragraphs
+                        .insert(new_cell_para_idx, new_para);
+                }
                 table.dirty = true;
             }
             Some(Control::Shape(shape)) => {
@@ -3790,9 +3800,20 @@ impl DocumentCore {
             .get_mut(control_idx)
         {
             Some(Control::Table(table)) => {
-                let removed = table.cells[cell_idx].paragraphs.remove(cell_para_idx);
-                removed_meta = removed.capture_meta();
-                merge_point = table.cells[cell_idx].paragraphs[prev_idx].merge_from(&removed);
+                // [#4288] split 쪽과 동일한 캡션 sentinel 결함. cell_idx==65534를
+                // 걸러내지 않으면 table.cells[65534]에서 패닉한다.
+                if cell_idx == 65534 {
+                    let cap = table.caption.as_mut().ok_or_else(|| {
+                        HwpError::RenderError("지정된 표 컨트롤에 캡션이 없습니다".to_string())
+                    })?;
+                    let removed = cap.paragraphs.remove(cell_para_idx);
+                    removed_meta = removed.capture_meta();
+                    merge_point = cap.paragraphs[prev_idx].merge_from(&removed);
+                } else {
+                    let removed = table.cells[cell_idx].paragraphs.remove(cell_para_idx);
+                    removed_meta = removed.capture_meta();
+                    merge_point = table.cells[cell_idx].paragraphs[prev_idx].merge_from(&removed);
+                }
                 table.dirty = true;
             }
             Some(Control::Shape(shape)) => {
@@ -5395,6 +5416,71 @@ mod tests {
         ));
         assert!(!is_focused_table_cell_target(&document, 0, 0, 1, 0, 0));
         assert!(!is_focused_table_cell_target(&document, 0, 0, 0, 1, 0));
+    }
+
+    /// [#4288] cell_idx==TABLE_CAPTION_CELL_SENTINEL(65534)는 표 캡션 접근
+    /// sentinel이다(get_cell_paragraph_mut 등 다른 함수는 이미 처리). split/merge는
+    /// 이 sentinel을 걸러내지 않고 table.cells[65534]를 그대로 인덱싱해 패닉했다 —
+    /// 손상된 문서가 아니라 캡션에서 Enter/Backspace를 누르는 정상 편집만으로 재현.
+    fn table_with_caption(paragraphs: Vec<Paragraph>) -> Document {
+        use crate::model::document::Section;
+        use crate::model::shape::Caption;
+        use crate::model::table::{Cell, Table};
+
+        let table = Table {
+            cells: vec![Cell {
+                paragraphs: vec![Paragraph::default()],
+                ..Default::default()
+            }],
+            caption: Some(Caption {
+                paragraphs,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        Document {
+            sections: vec![Section {
+                paragraphs: vec![Paragraph {
+                    controls: vec![Control::Table(Box::new(table))],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn split_paragraph_in_caption_cell_does_not_panic() {
+        let mut core = DocumentCore::new_empty();
+        core.document = table_with_caption(vec![Paragraph::default()]);
+
+        let result = core.split_paragraph_in_cell_native(
+            0,
+            0,
+            0,
+            crate::document_core::TABLE_CAPTION_CELL_SENTINEL,
+            0,
+            0,
+            None,
+        );
+        assert!(result.is_ok(), "캡션 문단 분할이 패닉 없이 처리되어야 함");
+    }
+
+    #[test]
+    fn merge_paragraph_in_caption_cell_does_not_panic() {
+        let mut core = DocumentCore::new_empty();
+        core.document =
+            table_with_caption(vec![Paragraph::default(), Paragraph::default()]);
+
+        let result = core.merge_paragraph_in_cell_native(
+            0,
+            0,
+            0,
+            crate::document_core::TABLE_CAPTION_CELL_SENTINEL,
+            1,
+        );
+        assert!(result.is_ok(), "캡션 문단 병합이 패닉 없이 처리되어야 함");
     }
 
     /// 본문 문단 병합의 undo 가 사라진 문단의 스코프 메타데이터를 되돌리는지 (Task #2342).


### PR DESCRIPTION
## 요약

표 캡션 문단에서 Enter(분할)나 Backspace(병합)를 누르면 패닉합니다. **손상된 문서가 필요 없는, 정상적인 편집 UI 동작만으로 재현되는 크래시**입니다.

## 왜 버그인가

`cell_idx == 65534`(`TABLE_CAPTION_CELL_SENTINEL`)는 "이 접근은 실제 셀이 아니라 표 캡션"이라는 관례이고, `get_cell_paragraph_mut`(`src/document_core/commands/text_editing.rs:2035`)를 비롯해 `reflow_cell_paragraph`(2179)·`recalculate_cell_paragraph_vpos_native`(2231)·`cell_metrics_for_control`(2274) 등 이 파일의 다른 모든 함수가 이 sentinel을 먼저 분기 처리합니다.

`split_paragraph_in_cell_native`와 `merge_paragraph_in_cell_native`는 이 분기가 없었습니다. 둘 다 검증 단계에서는 `get_cell_paragraph_mut`를 호출해 sentinel을 올바르게 처리하지만(그래서 검증은 통과), 실제 변형 단계에서는 sentinel을 무시하고 진짜 셀 벡터를 직접 인덱싱합니다:

```rust
// split_paragraph_in_cell_native
Some(Control::Table(table)) => {
    table.cells[cell_idx]              // cell_idx가 65534일 수 있음
        .paragraphs
        .insert(new_cell_para_idx, new_para);
    table.dirty = true;
}
```

```rust
// merge_paragraph_in_cell_native
Some(Control::Table(table)) => {
    let removed = table.cells[cell_idx].paragraphs.remove(cell_para_idx); // 패닉
    ...
    merge_point = table.cells[cell_idx].paragraphs[prev_idx].merge_from(&removed); // 여기도
```

`table.cells`가 65535개나 될 리 없으므로 `table.cells[65534]`는 index-out-of-bounds 패닉입니다.

## 재현 조건

두 함수 모두 WASM/UI 편집 진입점에 직결됩니다:
- `wasm_api.rs:1435` `splitParagraphInCell` → `split_paragraph_in_cell_native`
- `wasm_api.rs:1461` `mergeParagraphInCell` → `merge_paragraph_in_cell_native`

**UI 동작**: 캡션이 있는 표(정상 문서, 손상 불필요)의 캡션 텍스트에 커서를 두고 **Enter**(분할) 또는 **캡션 문단 맨 앞에서 Backspace**(병합, 캡션 문단 2개 이상 필요 — 예: Enter 한 번 누른 뒤)를 누르면 에디터가 `cellIdx = 65534`로 두 함수를 호출하고 그대로 패닉합니다.

## 영향

일반 사용자가 표 캡션을 편집하는 흔한 동작만으로 즉시 Rust 패닉(WASM trap / 네이티브는 프로세스 abort). 악성/손상 문서 불필요.

## 제안 수정

`get_cell_paragraph_mut`가 이미 쓰는 것과 같은 방식으로 `cell_idx == 65534`를 먼저 분기해 `table.caption`으로 라우팅한다.
