### PR TITLE
fix(bindings/python): export_hwpx/convert 의 -o 플래그를 CLI 실제 계약(위치 인자)으로 수정

### DIFF
--- a/bindings/python/src/rhwp/commands.py
+++ b/bindings/python/src/rhwp/commands.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
 from ._process import DEFAULT_TIMEOUT, run_json, run_ndjson
+from .errors import EXIT_USAGE, UsageError
 from .models import Envelope
 
 __all__ = [
@@ -392,11 +393,15 @@ def export_hwpx(
 ) -> Envelope:
     """HWP → HWPX 변환.
 
+    ``out`` 은 CLI 의 **위치 인자**다(``export-hwpx <입력> [출력] ...`` — 플래그가
+    아니다). 생략하면 CLI 가 자체 기본 경로를 쓴다.
+
     ``verify=True`` 면 봉투에 ``verify.identical`` 이 담긴다. 판정 실패(exit 3)는
     기본적으로 예외가 아니다 — 봉투를 읽어 판단하라.
     """
     args: List[Any] = ["export-hwpx", path]
-    _flag(args, "-o", out)
+    if out is not None:
+        args.append(out)
     _switch(args, "--verify", verify)
     _switch(args, "--verify-pages", verify_pages)
     args.append("--json")
@@ -411,9 +416,23 @@ def convert(
     raise_on_verdict: bool = False,
     timeout: Optional[float] = DEFAULT_TIMEOUT,
 ) -> Envelope:
-    """HWPX → HWP 변환."""
-    args: List[Any] = ["convert", path]
-    _flag(args, "-o", out)
+    """HWPX → HWP 변환.
+
+    ``out`` 은 CLI 의 **위치 인자**이고(``convert <입력> <출력> ...``), 여기서는
+    **필수**다 — 기본 산출 경로가 없어서, 빠뜨리면 CLI 가 사용법 오류로 끝난다.
+    프로세스를 띄우기 전에 여기서 같은 판정을 내려 무엇이 빠졌는지 이름으로
+    알린다(Node 바인딩의 ``convert`` 와 같은 계약).
+
+    Raises:
+        UsageError: ``out`` 을 주지 않았을 때.
+    """
+    if out is None:
+        raise UsageError(
+            "convert 는 산출 경로가 필요합니다 — out 인자를 지정하세요",
+            argv=["convert", str(path), "--json"],
+            exit_code=EXIT_USAGE,
+        )
+    args: List[Any] = ["convert", path, out]
     _switch(args, "--verify", verify)
     args.append("--json")
     return Envelope(run_json(args, timeout=timeout, raise_on_verdict=raise_on_verdict))

--- a/bindings/python/tests/test_commands.py
+++ b/bindings/python/tests/test_commands.py
@@ -233,10 +233,18 @@ def test_export_hwpx_verify_flags(captured: List[List[Any]]) -> None:
     assert "--verify-pages" in args
 
 
+def test_export_hwpx_out_is_positional_not_a_flag(captured: List[List[Any]]) -> None:
+    # [트랙 G R61 D-1] CLI 는 `export-hwpx <입력> [출력] ...` — 위치 인자다.
+    # `-o` 플래그로 조립하면 CLI 가 알 수 없는 옵션으로 거부한다(exit 2).
+    rhwp.export_hwpx("a.hwp", out="b.hwpx")
+    assert _as_strings(captured[0]) == ["export-hwpx", "a.hwp", "b.hwpx", "--json"]
+
+
 def test_export_hwpx_without_verify(captured: List[List[Any]]) -> None:
     rhwp.export_hwpx("a.hwp")
     args = _as_strings(captured[0])
     assert "--verify" not in args
+    assert "-o" not in args
 
 
 def test_convert_verify_flag(captured: List[List[Any]]) -> None:
@@ -244,6 +252,21 @@ def test_convert_verify_flag(captured: List[List[Any]]) -> None:
     args = _as_strings(captured[0])
     assert args[0] == "convert"
     assert "--verify" in args
+
+
+def test_convert_out_is_positional_not_a_flag(captured: List[List[Any]]) -> None:
+    # [트랙 G R61 D-1] 같은 결함이 convert 에도 있었다 — `convert <입력> <출력> ...`.
+    rhwp.convert("a.hwpx", out="b.hwp")
+    assert _as_strings(captured[0]) == ["convert", "a.hwpx", "b.hwp", "--json"]
+
+
+def test_convert_without_out_raises_usage_error(captured: List[List[Any]]) -> None:
+    # [트랙 G R61 D-1] convert 는 산출 경로가 필수다(기본 경로 없음) — Node
+    # 바인딩(assertDryRunSupported 와 같은 계열의 선검증)과 동일하게, 프로세스를
+    # 띄우기도 전에 UsageError 로 무엇이 빠졌는지 이름으로 알려야 한다.
+    with pytest.raises(rhwp.UsageError):
+        rhwp.convert("a.hwpx")
+    assert captured == []  # 프로세스를 아예 안 띄웠다
 
 
 def test_ir_diff_takes_two_paths(captured: List[List[Any]]) -> None:


### PR DESCRIPTION
## 요약

트랙 G(바인딩) R61(바인딩 표류 20건) 중 D-1(치명 등급): Python 바인딩의 `export_hwpx`/`convert`가 산출 경로를 `-o <경로>` **플래그**로 조립했지만, CLI는 **위치 인자**입니다(`export-hwpx <입력> [출력] ...`, `convert <입력> <출력> ...`).

## 왜 버그인가

`src/main.rs`의 사용법 문자열과 `capabilities` JSON 예시 둘 다 위치 인자임을 확인했습니다:
```
export-hwpx <입력.hwp|입력.hwpx> [출력.hwpx] [--verify] [--verify-pages]
```

Python 바인딩은:
```python
args: List[Any] = ["export-hwpx", path]
_flag(args, "-o", out)  # → ["export-hwpx", path, "-o", out] — CLI가 "알 수 없는 옵션"으로 exit 2
```

즉 `rhwp.export_hwpx(path, out=...)`/`rhwp.convert(path, out=...)`는 `out`을 넘기는 **모든 호출자에게 즉사**였습니다.

Node 바인딩(`bindings/node/src/commands.ts`)은 이미 올바르게 위치 인자로 조립하고, `convert`는 `out` 필수를 프로세스 실행 전에 `UsageError`로 거릅니다. 같은 계약을 Python 쪽에 맞췄습니다.

## 변경

- `export_hwpx`: `out`은 선택 — 있으면 위치 인자로 추가.
- `convert`: `out`은 필수 — 없으면 프로세스를 띄우기 전에 `UsageError(exit_code=EXIT_USAGE)`.
- 기존 회귀 시험은 `--verify` 존재만 확인했을 뿐 `out`의 실제 조립 형태(위치 vs 플래그)를 검증하지 않아 이 결함을 못 잡았습니다 — 전체 argv를 그대로 대조하는 시험 2건 + `convert`의 `UsageError` 시험 1건을 추가했습니다.

## 검증

`bindings/python` 단위 시험 230개 전건 통과(신규 3건 포함).

Issue: 로드맵 #3907 트랙 G R61, 근거 문서 `mydocs/tech/bindings/python_node_comparison.md` D-1
