### PR TITLE
docs(J93): 일반 Issue Workflow ③에 assignee=세션잠금 규약 명문화

### DIFF
--- a/mydocs/manual/codex/docs_and_git_workflow.md
+++ b/mydocs/manual/codex/docs_and_git_workflow.md
@@ -79,7 +79,22 @@ mydocs/report/{주제}_{회차}_{YYYYMMDD}.md
 
 1. GitHub Issue 확인 또는 생성 (**신규 등록 전 동일 증상 선행 검색** — 아래)
 2. 열린 PR 확인
-3. 이슈 assignee 지정
+3. 이슈 assignee 지정 — **이 단계가 곧 세션 간 잠금이다.** GitHub 에 별도 잠금
+   기제가 없어, assignee 가 비어 있으면 병렬로 도는 다른 세션이 같은 이슈를
+   합리적으로 "열린 작업"으로 보고 동시에 집는다(실제 재발 사고 기록:
+   [병렬 세션 규약](../../tech/autonomous_maintenance/parallel_session_protocol.md)
+   §4-2). 조사를 시작하기 **전에** 확인·할당한다:
+   ```bash
+   gh issue view <n> --repo edwardkim/rhwp --json assignees -q '.assignees[].login'
+   gh issue edit <n> --repo edwardkim/rhwp --add-assignee @me   # 권한 있는 계정만 성공
+   ```
+   `gh issue edit --add-assignee` 가 403 등으로 실패하면(외부 기여자는 보통
+   실패한다) 코멘트가 대체 잠금이다:
+   ```bash
+   gh issue comment <n> --repo edwardkim/rhwp --body "착수합니다 — <범위>"
+   ```
+   canonical 은 [병렬 세션 규약](../../tech/autonomous_maintenance/parallel_session_protocol.md)
+   §5-1 — 이 단계는 그 규약의 요약이지 대체가 아니다.
 4. 작업 브랜치 생성 또는 전환
 5. 역할별 절차에 따라 오늘할일 또는 PR review 문서 갱신
 6. 계획서 작성

--- a/mydocs/tech/agent_roadmap/track_j_autonomy.md
+++ b/mydocs/tech/agent_roadmap/track_j_autonomy.md
@@ -57,9 +57,14 @@ R94~R99 는 그 위에 얹는 자동화 가설, R100 은 최종 판정 실험이
 - **설계** — canonical 절차의 assignee 지정 단계를 잠금으로 승격한다 — 착수 시
   assignee 를 선점하고, 선점 여부를 착수 전 확인한다. 잠금 매체는 새 데몬이 아니라
   이미 있는 GitHub assignee 필드다(트랙 C 의 비목표 — 잠금 데몬 금지 — 와 일치).
-- **착수 게이트** — 워크플로 문서에 "착수 시 assignee 선점" 명문화.
-- **DoD** — 워크플로 문서가 assignee 선점을 세션 간 잠금으로 명문화하고, 선점 확인이
-  canonical 절차 ③ 에 못박힌다.
+- **착수 게이트** — (없음 — 아래로 충족.) 워크플로 문서에 "착수 시 assignee
+  선점" 명문화.
+- **DoD** — `agent_surface_playbook.md` §2 는 이미 이 규약을 담았다(#4105→#4140).
+  다만 **일반** Issue Workflow(`docs_and_git_workflow.md`, 트랙 A 추가 작업뿐
+  아니라 전 작업 유형이 쓰는 canonical 절차) 는 그때까지 절차 ③을 "이슈 assignee
+  지정"이라고만 적어, 이게 곧 세션 간 잠금이라는 명문화·재확인 명령·외부 기여자
+  대체 경로가 없었다 — 이번에 `docs_and_git_workflow.md` §Issue Workflow ③에
+  직접 보강했다(PR 링크는 머지 후 갱신). `[완료]` 승급은 그 PR 머지 후.
 - **의존** — 트랙 C(협업 canonical 절차).
 
 ## R94 이 지도의 진행률 기계 산출 `[실측]`


### PR DESCRIPTION
agent_surface_playbook.md §2는 이미 이 규약(PR #4105→#4140)을 담았지만, 모든 작업 유형이 쓰는 canonical 문서인 docs_and_git_workflow.md의 Issue Workflow ③은 여전히 "이슈 assignee 지정"이라고만 적혀 있어, 이게 곧 세션 간 잠금이라는 명문화·재확인 명령·외부 기여자 대체 경로(코멘트 잠금)가 없었습니다.

parallel_session_protocol.md §5-1의 절차를 그대로 요약해 canonical 절차 ③에 편입했습니다.

트랙 J R93의 DoD를 이 PR로 충족합니다. 실사고 근거 #3902/#3903, canonical mydocs/tech/autonomous_maintenance/parallel_session_protocol.md