### PR TITLE
fix(bindings/python): Plan.check() 가 --dry-run 미지원 바이너리에서 조용히 실행되던 결함 방어

### DIFF
--- a/bindings/python/src/rhwp/plan.py
+++ b/bindings/python/src/rhwp/plan.py
@@ -190,7 +190,14 @@ class Plan:
 
         위반이 있으면 예외가 아니라 ``result.violations`` 로 돌려준다. 계획을
         고쳐서 다시 검사하는 것이 정상 흐름이기 때문이다.
+
+        연결된 ``rhwp`` 바이너리가 계획 ``--dry-run`` 을 지원하는지 실행 전에
+        확인한다(:func:`_assert_dry_run_supported`). 확인 없이 넘기면, 옛
+        바이너리가 ``dryRun`` 필드를 무시하고 **진짜로 실행**해도 호출자는
+        "검사만 했다"고 믿게 된다 — 검사인 줄 알고 문서가 조용히 편집되는
+        사고를 막는 게이트다(Node 바인딩 ``assertDryRunSupported`` 와 동일 계약).
         """
+        _assert_dry_run_supported(timeout=timeout)
         return _execute(self.to_dict(dry_run=True), timeout=timeout)
 
     def run(self, *, timeout: Optional[float] = DEFAULT_TIMEOUT) -> PlanResult:
@@ -200,6 +207,49 @@ class Plan:
     def __repr__(self) -> str:  # pragma: no cover - 표현만
         actions = ", ".join(s["action"] for s in self._steps)
         return f"Plan({self._input} → {self._output}: [{actions}])"
+
+
+# [트랙 G R61 D-4] 세션·프로세스 생애 동안 한 번만 물으면 되는 정적 사실이라
+# 모듈 전역 캐시로 둔다 — Node 바인딩의 `dryRunSupport` 모듈 캐시와 동일 계약.
+_dry_run_support: Optional[bool] = None
+
+
+def clear_plan_capability_cache() -> None:
+    """``--dry-run`` 지원 여부 캐시를 비운다. 테스트 격리용."""
+    global _dry_run_support
+    _dry_run_support = None
+
+
+def _assert_dry_run_supported(*, timeout: Optional[float]) -> None:
+    """연결된 ``rhwp`` 가 계획 ``--dry-run`` 을 실제로 지원하는지 확인한다.
+
+    :meth:`Plan.check` 는 ``dryRun: true`` 를 실어 보내지만, 이 필드를 모르는
+    옛 바이너리(#3759 이전)는 조용히 무시하고 **진짜로 실행**할 수 있다 — 호출자는
+    "검사만 했다"고 믿지만 문서가 실제로 편집된다. ``capabilities()`` 로 ``run``
+    명령의 ``flags`` 에 ``--dry-run`` 이 실제로 선언돼 있는지 물어, 없으면 실행
+    전에 :class:`~rhwp.errors.RhwpError` 로 막는다(Node 바인딩
+    ``assertDryRunSupported`` 와 동일 계약).
+    """
+    global _dry_run_support
+    if _dry_run_support is None:
+        from .commands import capabilities
+
+        caps = capabilities(timeout=timeout)
+        supported = False
+        for command in caps.raw.get("commands", []):
+            if isinstance(command, Mapping) and command.get("name") == "run":
+                supported = "--dry-run" in command.get("flags", [])
+                break
+        _dry_run_support = supported
+
+    if not _dry_run_support:
+        from .errors import RhwpError
+
+        raise RhwpError(
+            "이 rhwp 는 계획 --dry-run 을 지원하지 않습니다(#3759 이전 버전으로 보입니다). "
+            "check() 를 실행으로 대체하지 않습니다 — 검사인 줄 알고 문서가 편집되면 안 됩니다. "
+            "rhwp 를 갱신하거나, 위험을 감수한다면 run() 을 명시적으로 부르세요."
+        )
 
 
 def _execute(plan: Mapping[str, Any], *, timeout: Optional[float]) -> PlanResult:

--- a/bindings/python/tests/test_plan.py
+++ b/bindings/python/tests/test_plan.py
@@ -6,9 +6,20 @@
 
 from __future__ import annotations
 
+from typing import Any, List
+
 import pytest
 
-from rhwp.plan import Plan, PlanResult
+import rhwp
+import rhwp.commands
+import rhwp.plan
+from rhwp.plan import Plan, PlanResult, clear_plan_capability_cache
+
+
+@pytest.fixture(autouse=True)
+def _reset_dry_run_cache() -> None:
+    # [트랙 G R61 D-4] _dry_run_support 는 모듈 전역 캐시라 시험 간 오염을 막는다.
+    clear_plan_capability_cache()
 
 
 def test_builder_produces_contract_shaped_plan() -> None:
@@ -146,3 +157,93 @@ def test_run_result_exposes_steps_and_verify() -> None:
     verify = result.verify
     assert verify is not None and verify.identical
     assert result.changed_pages == [0]
+
+
+# ── check() 의 --dry-run 지원 게이트 (트랙 G R61 D-4) ─────────────────────
+
+
+def _fake_capabilities(*, supports_dry_run: bool):  # type: ignore[no-untyped-def]
+    def fake_run_json(args, **kwargs):  # type: ignore[no-untyped-def]
+        flags = ["--json", "--plan-json"]
+        if supports_dry_run:
+            flags.append("--dry-run")
+        return {
+            "schemaVersion": "1.0",
+            "commands": [{"name": "run", "flags": flags}],
+        }
+
+    return fake_run_json
+
+
+def test_check_proceeds_when_binary_declares_dry_run_support(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[List[Any]] = []
+
+    def fake_capabilities_run_json(args, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(list(args))
+        return _fake_capabilities(supports_dry_run=True)(args, **kwargs)
+
+    def fake_plan_run_json(args, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(list(args))
+        return {"schemaVersion": "1.0", "dryRun": True, "invalid": [], "preview": []}
+
+    monkeypatch.setattr(rhwp.commands, "run_json", fake_capabilities_run_json)
+    monkeypatch.setattr(rhwp.plan, "run_json", fake_plan_run_json)
+
+    result = Plan("a.hwp", "b.hwp").fill_fields({"이름": "값"}).check()
+    assert result.is_dry_run
+    assert len(calls) == 2  # capabilities 1회 + run --plan-json 1회
+
+
+def test_check_raises_and_does_not_execute_when_dry_run_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # [D-4] 옛 바이너리(#3759 이전)는 dryRun 필드를 무시하고 진짜로 실행할 수
+    # 있다 — 확인 없이 넘기면 "검사만 한 줄" 알았던 호출이 문서를 편집한다.
+    plan_run_json_calls: List[List[Any]] = []
+
+    monkeypatch.setattr(
+        rhwp.commands, "run_json", _fake_capabilities(supports_dry_run=False)
+    )
+
+    def fake_plan_run_json(args, **kwargs):  # type: ignore[no-untyped-def]
+        plan_run_json_calls.append(list(args))
+        return {"schemaVersion": "1.0"}
+
+    monkeypatch.setattr(rhwp.plan, "run_json", fake_plan_run_json)
+
+    with pytest.raises(rhwp.RhwpError, match="dry-run"):
+        Plan("a.hwp", "b.hwp").fill_fields({"이름": "값"}).check()
+
+    assert plan_run_json_calls == []  # 프로세스를 아예 안 띄웠다
+
+
+def test_check_caches_capability_lookup_across_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    capability_calls: List[List[Any]] = []
+
+    def fake_capabilities_run_json(args, **kwargs):  # type: ignore[no-untyped-def]
+        capability_calls.append(list(args))
+        return _fake_capabilities(supports_dry_run=True)(args, **kwargs)
+
+    monkeypatch.setattr(rhwp.commands, "run_json", fake_capabilities_run_json)
+    monkeypatch.setattr(
+        rhwp.plan,
+        "run_json",
+        lambda args, **kwargs: {
+            "schemaVersion": "1.0",
+            "dryRun": True,
+            "invalid": [],
+            "preview": [],
+        },
+    )
+
+    Plan("a.hwp", "b.hwp").fill_fields({"이름": "값"}).check()
+    Plan("a.hwp", "b.hwp").fill_fields({"이름": "값2"}).check()
+    assert len(capability_calls) == 1  # 두 번째 호출은 캐시를 쓴다
+
+    clear_plan_capability_cache()
+    Plan("a.hwp", "b.hwp").fill_fields({"이름": "값3"}).check()
+    assert len(capability_calls) == 2  # 캐시를 비우면 다시 묻는다


### PR DESCRIPTION
## 요약

트랙 G(바인딩) R61 D-4(안전 등급): `Plan.check()`가 `dryRun:true`를 실은 계획서를 실행 전 지원 여부 확인 없이 그대로 보냈습니다. `#3759` 이전 바이너리처럼 `dryRun` 필드를 모르는 rhwp는 이를 조용히 무시하고 **진짜로 실행**할 수 있습니다 — 호출자는 "검사만 했다"고 믿지만 문서가 실제로 편집됩니다.

## 수정

Node 바인딩(`bindings/node/src/plan.ts`)은 이미 `assertDryRunSupported`로 `capabilities()`를 확인해 이 사고를 막습니다. 같은 계약을 Python에 이식했습니다 — `capabilities()`에서 `run` 명령의 `flags`에 `--dry-run`이 실제로 선언돼 있는지 확인하고, 없으면 `RhwpError`로 실행 전에 거부합니다. 세션·프로세스 생애 동안 한 번만 물으면 되는 정적 사실이라 모듈 전역 캐시를 두고(`clear_plan_capability_cache`로 시험 격리), Node의 `dryRunSupport` 캐시와 동일 계약을 맞췄습니다.

기존 `test_plan.py`는 이 게이트를 전혀 다루지 않았습니다(빌더 문법 검사만 커버) — 지원/미지원/캐시 3가지 경로를 회귀 시험으로 추가했습니다. 미지원 경로는 실제 실행 프로세스가 호출되지 않았음까지 확인합니다.

## 검증

`bindings/python` 단위 시험 230개 전건 통과(신규 3건 포함).

Issue: 로드맵 #3907 트랙 G R61, 근거 문서 `mydocs/tech/bindings/python_node_comparison.md` D-4
