### PR TITLE
feat(mcp): --stats 옵트인 관측성 1단계 — 도구별 호출/오류 수 stderr 요약

### DIFF
--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -67,6 +67,10 @@ pub fn run(args: &[String]) -> i32 {
     // [#3629] 직무 프로필: tools/list 자체를 역할 세트로 필터 — 호스트 설정 한 줄로
     // '행정서식 전용 서버'를 등록한다. 단일 출처는 agent_profiles::PROFILES.
     let mut profile: Option<&'static crate::agent_profiles::AgentProfile> = None;
+    // [트랙 H R80] 옵트인 관측성 1단계 — 기본은 꺼짐, 문서 내용·경로·인자 값은
+    // 절대 수집하지 않는다(mydocs/tech/agent_architecture/observability_contract.md
+    // §3). 도구명별 호출 수·오류 수만 센다.
+    let mut stats = false;
     let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
@@ -86,6 +90,7 @@ pub fn run(args: &[String]) -> i32 {
                     }
                 }
             }
+            "--stats" => stats = true,
             other => {
                 eprintln!("알 수 없는 옵션: {other}");
                 return crate::EXIT_USAGE;
@@ -112,6 +117,10 @@ pub fn run(args: &[String]) -> i32 {
         Some(p) => crate::agent_profiles::allows_session_tool(p, name),
     };
     let mut sessions = Sessions::new();
+    // 도구명 → (호출 수, 오류 수). 키는 서버가 정의한 유한 집합(도구명)뿐이고
+    // 값은 정수 계수뿐이다 — 문서 내용·경로·인자 값은 이 맵에 절대 담지 않는다.
+    let mut call_stats: std::collections::HashMap<String, (u64, u64)> =
+        std::collections::HashMap::new();
 
     for line in stdin.lock().lines() {
         let line = match line {
@@ -203,7 +212,25 @@ pub fn run(args: &[String]) -> i32 {
                 }),
             ),
             "tools/call" => {
-                match handle_tool_call(&params, &tool_defs, &session_allows, &mut sessions) {
+                let result = handle_tool_call(&params, &tool_defs, &session_allows, &mut sessions);
+                if stats {
+                    // 도구명은 params.name(호출자가 요청한 그대로) — 없으면
+                    // "(무명)"으로 집계해 파싱 실패까지 계수에 잡히게 한다.
+                    let tool_name = params
+                        .get("name")
+                        .and_then(|n| n.as_str())
+                        .unwrap_or("(무명)");
+                    let is_error = match &result {
+                        Err(_) => true,
+                        Ok(v) => v.get("isError").and_then(|b| b.as_bool()).unwrap_or(false),
+                    };
+                    let entry = call_stats.entry(tool_name.to_string()).or_insert((0, 0));
+                    entry.0 += 1;
+                    if is_error {
+                        entry.1 += 1;
+                    }
+                }
+                match result {
                     Ok(result) => ok_response(id, result),
                     Err(e) => error_response(id, INVALID_PARAMS, &e),
                 }
@@ -225,7 +252,29 @@ pub fn run(args: &[String]) -> i32 {
         };
         write_msg(&stdout, &response);
     }
+    if stats {
+        write_stats_summary(&call_stats);
+    }
     crate::EXIT_OK
+}
+
+/// [트랙 H R80 1단계] 도구명별 호출 수·오류 수를 stderr 로 한 번 요약한다.
+///
+/// stdout 은 JSON-RPC 프로토콜 전용이라(INV-04) 통계는 여기로만 나간다. 문서
+/// 내용·경로·인자 값·오류 메시지 원문은 이 함수에도, `call_stats` 자체에도
+/// 들어오지 않는다 — 애초에 도구명과 정수 계수만 쌓았기 때문이다.
+fn write_stats_summary(call_stats: &std::collections::HashMap<String, (u64, u64)>) {
+    if call_stats.is_empty() {
+        eprintln!("mcp-serve --stats: 도구 호출 없음");
+        return;
+    }
+    let mut names: Vec<&String> = call_stats.keys().collect();
+    names.sort();
+    eprintln!("mcp-serve --stats: 도구별 호출 수/오류 수");
+    for name in names {
+        let (calls, errors) = call_stats[name];
+        eprintln!("  {name}: {calls}회 호출, 오류 {errors}건");
+    }
 }
 
 fn write_msg(stdout: &std::io::Stdout, msg: &serde_json::Value) {

--- a/tests/mcp_server_contract.rs
+++ b/tests/mcp_server_contract.rs
@@ -9,7 +9,7 @@
 //! `hwp_doc_text` 가 재파싱 없이 핸들에서 읽으며, `hwp_close` 가 해제한다.
 #![cfg(not(target_arch = "wasm32"))]
 
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 
@@ -787,4 +787,142 @@ fn resources_read_unknown_uri_returns_resource_not_found() {
     );
     let r = s.request("resources/read", serde_json::json!({}));
     assert_eq!(r["error"]["code"], -32602, "{r}");
+}
+
+// ── R80 1단계: --stats 옵트인 관측성 ────────────────────────────────────
+//
+// mydocs/tech/agent_architecture/observability_contract.md 의 §3(금지 목록)을
+// 계약 테스트로 고정한다 — INV-07("무동작 플래그 금지")에 따라 플래그와
+// 계약 테스트가 같은 PR 로 들어간다.
+
+/// `--stats` 없는 `mcp-serve` 는 §1 그대로 — 계측 0, 추가 stderr 출력 0.
+#[test]
+fn mcp_serve_without_stats_flag_emits_nothing_extra_on_stderr() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("mcp-serve")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("rhwp mcp-serve 실행 실패");
+    {
+        let mut stdin = child.stdin.take().expect("stdin");
+        let mut stdout = BufReader::new(child.stdout.take().expect("stdout"));
+        writeln!(
+            stdin,
+            r#"{{"jsonrpc":"2.0","id":1,"method":"initialize","params":{{"protocolVersion":"2025-06-18","capabilities":{{}},"clientInfo":{{"name":"contract-test","version":"0"}}}}}}"#
+        )
+        .expect("초기화 쓰기 실패");
+        stdin.flush().expect("flush");
+        let mut line = String::new();
+        stdout.read_line(&mut line).expect("초기화 응답 읽기 실패");
+        // stdin 을 닫아 서버가 EOF 로 정상 종료하게 한다.
+    }
+    let status = child.wait().expect("서버 종료 대기 실패");
+    assert!(status.success(), "서버가 비정상 종료했습니다: {status:?}");
+    let mut stderr_out = String::new();
+    child
+        .stderr
+        .take()
+        .expect("stderr")
+        .read_to_string(&mut stderr_out)
+        .expect("stderr 읽기 실패");
+    assert!(
+        stderr_out.is_empty(),
+        "--stats 없이도 stderr 에 출력이 났습니다: {stderr_out:?}"
+    );
+}
+
+/// `--stats` 는 도구명별 호출 수·오류 수만 stderr 로 낸다 — 문서 내용·경로·
+/// 인자 값은 계약(§3)에 따라 절대 새어 나가면 안 된다.
+#[test]
+fn mcp_serve_stats_summarizes_call_counts_without_leaking_document_data() {
+    let p = sample(SAMPLE);
+    // 존재하지 않는 경로 — 오류 호출을 만들면서, 통계에 새면 안 될 "민감한
+    // 경로 성분"의 대역으로도 쓴다(경로는 계약 §3 상 준식별자로 금지 항목).
+    let bogus_path = "/no/such/문서-극비-누설되면-안됨-72d9f3.hwp";
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("mcp-serve")
+        .arg("--stats")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("rhwp mcp-serve --stats 실행 실패");
+    {
+        let mut stdin = child.stdin.take().expect("stdin");
+        let mut stdout = BufReader::new(child.stdout.take().expect("stdout"));
+        let mut line = String::new();
+
+        writeln!(
+            stdin,
+            r#"{{"jsonrpc":"2.0","id":1,"method":"initialize","params":{{"protocolVersion":"2025-06-18","capabilities":{{}},"clientInfo":{{"name":"contract-test","version":"0"}}}}}}"#
+        )
+        .expect("초기화 쓰기 실패");
+        stdin.flush().expect("flush");
+        stdout.read_line(&mut line).expect("초기화 응답 읽기 실패");
+
+        // 성공 호출 1건 — 실제 문서 경로를 실어 보낸다(통계에 새면 안 됨).
+        let ok_call = serde_json::json!({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": {"name": "hwp_info", "arguments": {"path": p.to_str().unwrap()}}
+        });
+        writeln!(stdin, "{ok_call}").expect("hwp_info 성공 호출 쓰기 실패");
+        stdin.flush().expect("flush");
+        line.clear();
+        stdout.read_line(&mut line).expect("hwp_info 성공 응답 읽기 실패");
+
+        // 오류 호출 1건(같은 도구, 존재하지 않는 경로) — isError:true 경로를
+        // 태워 오류 수 집계와 "경로는 절대 안 샌다"를 같은 호출로 검증한다.
+        let err_call = serde_json::json!({
+            "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+            "params": {"name": "hwp_info", "arguments": {"path": bogus_path}}
+        });
+        writeln!(stdin, "{err_call}").expect("hwp_info 오류 호출 쓰기 실패");
+        stdin.flush().expect("flush");
+        line.clear();
+        let n = stdout.read_line(&mut line).expect("hwp_info 오류 응답 읽기 실패");
+        assert!(n > 0, "서버가 오류 호출 후 응답 없이 종료했습니다");
+        let resp: serde_json::Value = serde_json::from_str(line.trim()).expect("응답 JSON 파싱 실패");
+        assert_eq!(
+            resp["result"]["isError"], true,
+            "존재하지 않는 경로는 isError:true 여야 합니다: {resp}"
+        );
+
+        // stdin 을 닫아 서버가 EOF 로 정상 종료하며 통계를 stderr 로 낸다.
+    }
+    let status = child.wait().expect("서버 종료 대기 실패");
+    assert!(status.success(), "서버가 비정상 종료했습니다: {status:?}");
+    let mut stderr_out = String::new();
+    child
+        .stderr
+        .take()
+        .expect("stderr")
+        .read_to_string(&mut stderr_out)
+        .expect("stderr 읽기 실패");
+
+    assert!(
+        stderr_out.contains("mcp-serve --stats"),
+        "--stats 요약 머리글이 없습니다: {stderr_out:?}"
+    );
+    assert!(
+        stderr_out.contains("hwp_info"),
+        "hwp_info 호출이 도구명으로 집계되지 않았습니다: {stderr_out:?}"
+    );
+    assert!(
+        stderr_out.contains("2회 호출") && stderr_out.contains("오류 1건"),
+        "호출 수 2·오류 수 1 이 집계되지 않았습니다: {stderr_out:?}"
+    );
+
+    // §3 금지 목록 — 문서 경로는 성공·오류 어느 쪽이든 stderr 에 어떤
+    // 형태로도 나타나면 안 된다.
+    assert!(
+        !stderr_out.contains(p.to_str().unwrap()),
+        "성공 호출의 문서 경로가 --stats 출력에 샜습니다: {stderr_out:?}"
+    );
+    assert!(
+        !stderr_out.contains(bogus_path) && !stderr_out.contains("극비-누설되면-안됨"),
+        "오류 호출의 문서 경로가 --stats 출력에 샜습니다: {stderr_out:?}"
+    );
 }


### PR DESCRIPTION
## 요약

트랙 H(MCP) R80 1단계 구현: `mcp-serve`가 지금까지 호출을 전혀 기록하지 않아 무엇이 얼마나 불리는지, 어디서 오류가 나는지 볼 수 없었습니다.

## 설계

`mydocs/tech/agent_architecture/observability_contract.md` §5 설계대로:
- **기본은 꺼짐** — `--stats` 없으면 계측 0, stderr 출력 0(회귀 시험으로 고정).
- **`--stats`는 도구명별 (호출 수, 오류 수)만** `HashMap<String,(u64,u64)>`로 집계합니다. 단일 스레드 stdin 루프 안이라 원자성 기구 불필요, 의존성 0 유지.
- 서버 종료 시점(stdin EOF 후 `EXIT_OK` 직전)에 stderr로 한 번 요약합니다. stdout은 JSON-RPC 프로토콜 전용이라(INV-04) stderr로만 냅니다.
- 오류는 `handle_tool_call`의 `Err`(JSON-RPC 오류)와 `Ok(isError:true)` 양쪽을 셉니다.

계약 §3(금지 목록 — 문서 내용·파일 경로·필드/인자 값·오류 메시지 원문·핸들 이력)은 애초에 도구명과 정수 계수만 쌓아서 구조적으로 지킵니다.

## 검증

INV-07(무동작 플래그 금지)에 따라 플래그와 계약 테스트를 같은 PR로 넣었습니다 — `tests/mcp_server_contract.rs`에 2건 추가:
- `--stats` 없이는 stderr 출력이 전혀 없음을 확인.
- `--stats`로 성공 1건+오류 1건(존재하지 않는 경로) 호출 후, 도구명별 집계(2회 호출·오류 1건)는 나오되 실제 문서 경로 문자열은 성공·오류 양쪽 다 stderr 어디에도 나타나지 않음을 확인.

`tests/mcp_server_contract.rs` 전체 24개 통과(신규 2건 포함).

Issue: 로드맵 #3907 트랙 H R80, 계약 문서 `mydocs/tech/agent_architecture/observability_contract.md` §5 1단계
