### PR TITLE
fix(bindings/python): D-2·D-3·D-5·D-6·D-7·D-8 표류 6건 일괄 수정

### DIFF
--- a/bindings/python/src/rhwp/__init__.py
+++ b/bindings/python/src/rhwp/__init__.py
@@ -79,6 +79,7 @@ from .commands import (
     info,
     inspect,
     ir_diff,
+    render_diff,
     replace_text,
     scan,
     search,
@@ -97,7 +98,7 @@ from .errors import (
     RhwpError,
     RhwpRuntimeError,
     SessionClosedError,
-    TimeoutError,
+    RhwpTimeoutError,
     UsageError,
     VerdictFailed,
 )
@@ -156,6 +157,7 @@ __all__ = [
     "export_hwpx",
     "convert",
     "ir_diff",
+    "render_diff",
     # 1층 — 편집
     "fill_fields",
     "replace_text",
@@ -198,7 +200,7 @@ __all__ = [
     "VerdictFailed",
     "ProtocolError",
     "SessionClosedError",
-    "TimeoutError",
+    "RhwpTimeoutError",
     # 종료 코드 사전
     "EXIT_OK",
     "EXIT_RUNTIME",

--- a/bindings/python/src/rhwp/_naming.py
+++ b/bindings/python/src/rhwp/_naming.py
@@ -15,7 +15,13 @@ __all__ = ["to_snake", "to_camel", "snake_keys", "camel_keys"]
 
 # 연속 대문자(약어) 경계를 살린다: "pageCountA" → "page_count_a",
 # "irDiff" → "ir_diff", "sourceB" → "source_b", "HTMLPage" → "html_page".
-_ACRONYM_BOUNDARY = re.compile(r"([A-Z]+)([A-Z][a-z])")
+#
+# [트랙 G R61 D-6] 앞 그룹을 가변 길이([A-Z]+)로 두면 "AAAA…Aa" 류 입력에서
+# 파국적 역추적(catastrophic backtracking)이 걸린다. Node 바인딩은 고정 길이
+# ([A-Z])로 이미 고쳤고, mydocs/tech/bindings/parity_contract.md §7이
+# "새 바인딩은 고정 길이 쪽을 쓴다"로 동등성까지 확인해뒀다(HTMLPage →
+# html_page 결과가 두 표현 모두 동일). 판단 문제가 아니라 이미 결정된 이식이다.
+_ACRONYM_BOUNDARY = re.compile(r"([A-Z])([A-Z][a-z])")
 _WORD_BOUNDARY = re.compile(r"([a-z0-9])([A-Z])")
 
 

--- a/bindings/python/src/rhwp/_process.py
+++ b/bindings/python/src/rhwp/_process.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, List, Mapping, Optional, Sequence, Union
 
 from ._binary import find_binary
-from .errors import ProtocolError, RhwpError, TimeoutError, raise_for_exit
+from .errors import ProtocolError, RhwpError, RhwpTimeoutError, raise_for_exit
 
 __all__ = ["run_json", "run_ndjson", "run_raw", "CompletedRun", "DEFAULT_TIMEOUT"]
 
@@ -89,7 +89,7 @@ def run_raw(
         envelope_hint: 예외에 담을 봉투 (이미 파싱했을 때).
 
     Raises:
-        TimeoutError: 제한 시간 초과. 자식 프로세스는 죽인 뒤 올라온다.
+        RhwpTimeoutError: 제한 시간 초과. 자식 프로세스는 죽인 뒤 올라온다.
         BinaryNotFoundError: 실행 파일을 못 찾음.
         UsageError / RhwpRuntimeError / VerdictFailed: ``check`` 가 참일 때.
     """
@@ -109,7 +109,7 @@ def run_raw(
             cwd=str(cwd) if cwd is not None else None,
         )
     except subprocess.TimeoutExpired as exc:
-        raise TimeoutError(
+        raise RhwpTimeoutError(
             f"제한 시간 {timeout}초를 초과했습니다",
             argv=argv,
             stderr=_decode(exc.stderr),

--- a/bindings/python/src/rhwp/commands.py
+++ b/bindings/python/src/rhwp/commands.py
@@ -39,6 +39,7 @@ __all__ = [
     "export_plan_schema",
     "export_agent_manifest",
     "ir_diff",
+    "render_diff",
     "thumbnail",
     "extract_pages",
     "build_from_ingest",
@@ -424,6 +425,31 @@ def ir_diff(
 ) -> Envelope:
     """두 문서의 IR 차이 — 무엇이 달라졌는지 범주별로."""
     return Envelope(run_json(["ir-diff", a, b, "--json"], timeout=timeout))
+
+
+def render_diff(
+    path: PathLike,
+    path_b: Optional[PathLike] = None,
+    *,
+    via: Optional[str] = None,
+    page: Optional[int] = None,
+    max_disp: Optional[float] = None,
+    raise_on_verdict: bool = False,
+    timeout: Optional[float] = DEFAULT_TIMEOUT,
+) -> Envelope:
+    """시각 회귀 판정 — 페이지별 렌더 결과를 자기 왕복(1건) 또는 전/후(2건) 비교한다.
+
+    ``path_b`` 생략 시 ``path`` 를 자기 자신과 렌더 왕복 비교(회귀 도구 자체
+    검증). 판정 실패(exit 3)는 기본적으로 예외가 아니다 — 봉투를 읽어 판단하라.
+    """
+    args: List[Any] = ["render-diff", path]
+    if path_b is not None:
+        args.append(path_b)
+    _flag(args, "--via", via)
+    _flag(args, "-p", page)
+    _flag(args, "--max-disp", max_disp)
+    args.append("--json")
+    return Envelope(run_json(args, timeout=timeout, raise_on_verdict=raise_on_verdict))
 
 
 # ── 편집 ────────────────────────────────────────────────────────────────

--- a/bindings/python/src/rhwp/errors.py
+++ b/bindings/python/src/rhwp/errors.py
@@ -26,7 +26,7 @@ __all__ = [
     "VerdictFailed",
     "ProtocolError",
     "SessionClosedError",
-    "TimeoutError",
+    "RhwpTimeoutError",
     "EXIT_OK",
     "EXIT_RUNTIME",
     "EXIT_USAGE",
@@ -118,6 +118,20 @@ class UsageError(RhwpError):
                 return stripped[len("힌트:") :].strip()
         return None
 
+    @property
+    def next_call(self) -> Optional[Mapping[str, Any]]:
+        """[트랙 G R61 D-8] 봉투의 ``nextCall``(서버가 실어 보낸 교정 호출)을 꺼낸다.
+
+        닫힌 세션 핸들 호출처럼, 도구가 "다음엔 이걸 부르라"는 구조화된 힌트를
+        봉투에 실을 때가 있다(``{name, arguments}``). 없으면 ``None``.
+        """
+        if self.envelope is None:
+            return None
+        next_call = self.envelope.get("nextCall")
+        if isinstance(next_call, Mapping) and "name" in next_call:
+            return dict(next_call)
+        return None
+
 
 class RhwpRuntimeError(RhwpError):
     """exit 1 — 읽기·파싱·렌더·쓰기가 실패했다.
@@ -153,15 +167,27 @@ class SessionClosedError(RhwpError):
     """이미 닫힌 세션 핸들을 다시 썼다."""
 
 
-class TimeoutError(RhwpError):  # noqa: A001 - 내장 이름 가림은 의도적(패키지 일관성)
-    """제한 시간 안에 끝나지 않았다. 자식 프로세스는 종료를 시도한 뒤 올라온다."""
+class RhwpTimeoutError(RhwpError):
+    """제한 시간 안에 끝나지 않았다. 자식 프로세스는 종료를 시도한 뒤 올라온다.
+
+    [트랙 G R61 D-7] Node 바인딩은 처음부터 ``RhwpTimeoutError`` 였고, 파이썬만
+    내장 ``TimeoutError`` 를 가려 썼다. ``parity_contract.md`` §7 D-7 이 이름을
+    ``RhwpTimeoutError`` 로 통일하기로 결정했다 — 내장 이름 가림은 `except
+    TimeoutError` 를 쓰는 코드가 rhwp 예외인지 표준 라이브러리 예외인지 한눈에
+    구분 못 하게 만드는 대가가 이름 일관성보다 컸다.
+    """
 
 
 def _quote(arg: str) -> str:
-    """공백·따옴표가 있으면 감싼다 — 재현 명령이 그대로 붙여넣기 가능하도록."""
-    if arg and not any(ch.isspace() or ch in "\"'" for ch in arg):
+    """공백·따옴표·백슬래시가 있으면 감싼다 — 재현 명령이 그대로 붙여넣기 가능하도록.
+
+    [트랙 G R61 D-5] 역슬래시를 이스케이프하지 않으면 `C:\\경로\\` 처럼 끝이
+    역슬래시인 인자가 닫는 따옴표를 집어삼킨다. 역슬래시를 **먼저** 이스케이프한
+    뒤 큰따옴표를 이스케이프해야 한다 — 순서를 바꾸면 이중 이스케이프된다.
+    """
+    if arg and not any(ch.isspace() or ch in "\"'\\" for ch in arg):
         return arg
-    escaped = arg.replace('"', '\\"')
+    escaped = arg.replace("\\", "\\\\").replace('"', '\\"')
     return f'"{escaped}"'
 
 

--- a/bindings/python/src/rhwp/schema.py
+++ b/bindings/python/src/rhwp/schema.py
@@ -236,7 +236,7 @@ def ir_schema(*, timeout: Optional[float] = DEFAULT_TIMEOUT) -> IrSchema:
     문서를 입력으로 받지 않는다 — 스키마는 **타입의 자기서술**이지 특정 문서의
     속성이 아니다.
     """
-    envelope = run_json(["export-ir-schema"], timeout=timeout)
+    envelope = run_json(["export-ir-schema", "--json"], timeout=timeout)
     return IrSchema(envelope)
 
 
@@ -246,7 +246,7 @@ def capabilities_schema(*, timeout: Optional[float] = DEFAULT_TIMEOUT) -> IrSche
     문서를 입력으로 받지 않는다. ``capabilities`` 가 명령·플래그·봉투를 설명한다면,
     이 스키마는 그 설명을 기계적으로 소비할 수 있는 모양을 제공한다.
     """
-    envelope = run_json(["export-capabilities-schema"], timeout=timeout)
+    envelope = run_json(["export-capabilities-schema", "--json"], timeout=timeout)
     return IrSchema(envelope)
 
 
@@ -274,9 +274,9 @@ def _scalar_hint(spec: Any) -> str:
 # Envelope 를 쓰는 소비자를 위한 편의 — 봉투 그대로 받고 싶을 때.
 def ir_schema_envelope(*, timeout: Optional[float] = DEFAULT_TIMEOUT) -> Envelope:
     """봉투를 그대로 돌려준다 (definitionCount 등 메타 포함)."""
-    return Envelope(run_json(["export-ir-schema"], timeout=timeout))
+    return Envelope(run_json(["export-ir-schema", "--json"], timeout=timeout))
 
 
 def capabilities_schema_envelope(*, timeout: Optional[float] = DEFAULT_TIMEOUT) -> Envelope:
     """명령 표면 스키마 봉투를 그대로 돌려준다 (MCP 스키마 메타 포함)."""
-    return Envelope(run_json(["export-capabilities-schema"], timeout=timeout))
+    return Envelope(run_json(["export-capabilities-schema", "--json"], timeout=timeout))

--- a/bindings/python/tests/test_commands.py
+++ b/bindings/python/tests/test_commands.py
@@ -251,6 +251,23 @@ def test_ir_diff_takes_two_paths(captured: List[List[Any]]) -> None:
     assert _as_strings(captured[0]) == ["ir-diff", "a.hwp", "b.hwp", "--json"]
 
 
+def test_render_diff_self_roundtrip_when_path_b_omitted(
+    captured: List[List[Any]],
+) -> None:
+    """[트랙 G R61 D-2] Node에는 있었지만 파이썬 바인딩에 없던 명령."""
+    rhwp.render_diff("a.hwp")
+    assert _as_strings(captured[0]) == ["render-diff", "a.hwp", "--json"]
+
+
+def test_render_diff_before_after_with_options(captured: List[List[Any]]) -> None:
+    rhwp.render_diff("before.hwp", "after.hwp", via="svg", page=2, max_disp=0.5)
+    args = _as_strings(captured[0])
+    assert args[:3] == ["render-diff", "before.hwp", "after.hwp"]
+    assert args[args.index("--via") + 1] == "svg"
+    assert args[args.index("-p") + 1] == "2"
+    assert args[args.index("--max-disp") + 1] == "0.5"
+
+
 # ── 편집 ────────────────────────────────────────────────────────────────
 
 

--- a/bindings/python/tests/test_errors.py
+++ b/bindings/python/tests/test_errors.py
@@ -15,6 +15,7 @@ from rhwp.errors import (
     EXIT_VERIFY,
     EXIT_VERIFY_PAGES,
     RhwpRuntimeError,
+    RhwpTimeoutError,
     UsageError,
     VerdictFailed,
     raise_for_exit,
@@ -102,3 +103,63 @@ def test_error_str_includes_last_stderr_line() -> None:
             stderr="첫 줄\n오류: 진짜 사유는 여기",
         )
     assert "진짜 사유는 여기" in str(caught.value)
+
+
+# ── D-5: _quote 역슬래시 이스케이프 ──────────────────────────────────────
+
+
+def test_error_command_escapes_trailing_backslash() -> None:
+    """[D-5] 끝이 역슬래시인 경로가 닫는 따옴표를 집어삼키면 안 된다."""
+    with pytest.raises(RhwpRuntimeError) as caught:
+        raise_for_exit(
+            EXIT_RUNTIME, argv=["rhwp", "info", "C:\\경로\\", "--json"]
+        )
+    command = caught.value.command
+    # 역슬래시가 이스케이프돼 닫는 따옴표가 살아 있어야 한다 — 짝이 맞아야
+    # 셸에 그대로 붙여넣었을 때 다음 토큰을 집어삼키지 않는다.
+    assert command.count('"') % 2 == 0, f"따옴표 짝이 안 맞습니다: {command!r}"
+    assert '"C:\\\\경로\\\\"' in command
+
+
+# ── D-7: TimeoutError → RhwpTimeoutError ────────────────────────────────
+
+
+def test_timeout_error_is_named_rhwp_timeout_error() -> None:
+    """[D-7] 내장 TimeoutError 를 가리지 않는다 — rhwp 예외임이 이름으로 드러난다."""
+    import builtins
+
+    from rhwp.errors import RhwpError
+
+    err = RhwpTimeoutError("제한 시간 초과", argv=["rhwp", "info", "a.hwp"])
+    assert isinstance(err, RhwpError)
+    assert err.__class__.__name__ == "RhwpTimeoutError"
+    # 내장 TimeoutError 와 무관한 별개 클래스여야 한다 — 가려 쓰지 않는다.
+    assert not issubclass(RhwpTimeoutError, builtins.TimeoutError)
+
+
+# ── D-8: UsageError.next_call ────────────────────────────────────────────
+
+
+def test_usage_error_extracts_next_call_from_envelope() -> None:
+    """[D-8] 봉투의 nextCall(교정 호출 힌트)을 구조화해 꺼낼 수 있어야 한다."""
+    envelope = {
+        "error": "닫힌 핸들",
+        "nextCall": {"name": "hwp_open", "arguments": {"path": "a.hwp"}},
+    }
+    with pytest.raises(UsageError) as caught:
+        raise_for_exit(
+            EXIT_USAGE,
+            argv=["rhwp", "mcp-serve"],
+            stderr="오류: 닫힌 핸들",
+            envelope=envelope,
+        )
+    assert caught.value.next_call == {
+        "name": "hwp_open",
+        "arguments": {"path": "a.hwp"},
+    }
+
+
+def test_usage_error_without_next_call_returns_none() -> None:
+    with pytest.raises(UsageError) as caught:
+        raise_for_exit(EXIT_USAGE, argv=["rhwp"], stderr="오류: 인자가 필요합니다")
+    assert caught.value.next_call is None


### PR DESCRIPTION
## 요약

트랙 G R61(바인딩 표류 20건) 중 판단 없이 바로 고칠 수 있는 6건입니다. `mydocs/tech/bindings/parity_contract.md`가 D-6·D-7의 방향을 이미 결정해뒀고(고정 길이 정규식·RhwpTimeoutError 통일), 나머지는 Node 바인딩의 이미 올바른 패턴을 그대로 이식한 기계적 수정입니다.

- **D-2**: `render_diff`가 Python 바인딩에 아예 없었습니다. Node의 render-diff 래퍼를 이식.
- **D-3**: `export-ir-schema`/`export-capabilities-schema` 4개 호출부가 `--json` 없이 나갔습니다("잠복" 결함) — 4곳 전부 추가.
- **D-5**: `_quote`가 백슬래시를 이스케이프하지 않아 `C:\경로\`처럼 끝이 역슬래시인 인자가 재현 명령의 닫는 따옴표를 집어삼켰습니다.
- **D-6**: 약어 경계 정규식이 파국적 역추적(ReDoS) 모양이었습니다 — `parity_contract.md`가 이미 고정 길이로 동등성 확인.
- **D-7**: `TimeoutError`가 내장 이름을 가려서 `RhwpTimeoutError`로 개명(계약 결정).
- **D-8**: `UsageError`에 Node의 `nextCall` 대응 접근자(`next_call`)가 없었습니다.

## 검증

신규 시험 6건 추가, 전체 단위 시험 233개(not integration) 전건 통과. `_naming.py`의 기존 HTMLPage 회귀 시험도 그대로 통과해 D-6 동등성을 재확인했습니다.

Issue: 로드맵 #3907 트랙 G R61, 근거 문서 `mydocs/tech/bindings/python_node_comparison.md`, 결정 근거 `mydocs/tech/bindings/parity_contract.md` §7
