### PR TITLE
파이썬 바인딩: verifyPages 접근자·페이지네이션 인자·cwd 옵션·공개 API 노출 정합 (D-10,12,13,14,15,18)

### DIFF
--- a/bindings/python/docs/TROUBLESHOOTING.md
+++ b/bindings/python/docs/TROUBLESHOOTING.md
@@ -308,9 +308,9 @@ rhwp.export_pdf("큰문서.hwp", out="a.pdf", timeout=None)   # 무제한
 `batch` 는 전 레코드를 모은다. 스트리밍이 필요하면 저수준 API 를 쓴다.
 
 ```python
-from rhwp._process import iter_ndjson
+import rhwp
 
-for record in iter_ndjson(["batch", "info", "--json"], stdin=paths_text):
+for record in rhwp.iter_ndjson(["batch", "info", "--json"], stdin=paths_text):
     handle(record)     # 나오는 대로 처리
 ```
 

--- a/bindings/python/src/rhwp/__init__.py
+++ b/bindings/python/src/rhwp/__init__.py
@@ -48,9 +48,9 @@ if plan.check().ok:      # 디스크 무변경 검사
 
 from __future__ import annotations
 
-from ._binary import ENV_VAR, clear_cache, find_binary
+from ._binary import BUNDLED_DIR, ENV_VAR, binary_name, clear_cache, find_binary
 from ._naming import to_camel, to_snake
-from ._process import CompletedRun, run_json, run_ndjson, run_raw
+from ._process import CompletedRun, iter_ndjson, run_json, run_ndjson, run_raw
 from .commands import (
     batch,
     build_from_ingest,
@@ -100,8 +100,10 @@ from .errors import (
     TimeoutError,
     UsageError,
     VerdictFailed,
+    is_known_exit_code,
+    raise_for_exit,
 )
-from .models import Envelope, VerifyReport
+from .models import Envelope, VerifyPagesReport, VerifyReport
 from .plan import Plan, PlanResult, run_plan
 from .schema import (
     FieldDef,
@@ -126,6 +128,8 @@ __all__ = [
     "ENV_VAR",
     "find_binary",
     "clear_cache",
+    "binary_name",
+    "BUNDLED_DIR",
     # 1층 — 조회
     "info",
     "export_text",
@@ -183,10 +187,12 @@ __all__ = [
     # 모델
     "Envelope",
     "VerifyReport",
+    "VerifyPagesReport",
     # 저수준
     "run_json",
     "run_ndjson",
     "run_raw",
+    "iter_ndjson",
     "CompletedRun",
     "to_snake",
     "to_camel",
@@ -205,4 +211,6 @@ __all__ = [
     "EXIT_USAGE",
     "EXIT_VERIFY",
     "EXIT_VERIFY_PAGES",
+    "raise_for_exit",
+    "is_known_exit_code",
 ]

--- a/bindings/python/src/rhwp/_binary.py
+++ b/bindings/python/src/rhwp/_binary.py
@@ -21,7 +21,7 @@ from typing import List, Optional
 
 from .errors import BinaryNotFoundError
 
-__all__ = ["find_binary", "clear_cache", "binary_name", "BUNDLED_DIR"]
+__all__ = ["find_binary", "clear_cache", "binary_name", "BUNDLED_DIR", "ENV_VAR"]
 
 #: 환경변수 이름 — 문서 §3 고정.
 ENV_VAR = "RHWP_BIN"

--- a/bindings/python/src/rhwp/_process.py
+++ b/bindings/python/src/rhwp/_process.py
@@ -20,7 +20,14 @@ from typing import Any, Dict, Iterator, List, Mapping, Optional, Sequence, Union
 from ._binary import find_binary
 from .errors import ProtocolError, RhwpError, TimeoutError, raise_for_exit
 
-__all__ = ["run_json", "run_ndjson", "run_raw", "CompletedRun", "DEFAULT_TIMEOUT"]
+__all__ = [
+    "run_json",
+    "run_ndjson",
+    "run_raw",
+    "iter_ndjson",
+    "CompletedRun",
+    "DEFAULT_TIMEOUT",
+]
 
 #: 기본 제한 시간(초). 대형 문서 렌더가 수십 초 걸릴 수 있어 넉넉히 잡는다.
 #: ``None`` 을 넘기면 무제한.

--- a/bindings/python/src/rhwp/commands.py
+++ b/bindings/python/src/rhwp/commands.py
@@ -74,14 +74,41 @@ def info(path: PathLike, *, timeout: Optional[float] = DEFAULT_TIMEOUT) -> Envel
     return Envelope(run_json(["info", path, "--json"], timeout=timeout))
 
 
-def export_text(path: PathLike, *, timeout: Optional[float] = DEFAULT_TIMEOUT) -> Envelope:
-    """쪽별 평문 추출."""
-    return Envelope(run_json(["export-text", path, "--json"], timeout=timeout))
+def export_text(
+    path: PathLike,
+    *,
+    page: Optional[int] = None,
+    max_chars: Optional[int] = None,
+    timeout: Optional[float] = DEFAULT_TIMEOUT,
+) -> Envelope:
+    """쪽별 평문 추출.
+
+    [트랙 G R61 D-12] ``page``/``max_chars`` 는 CLI 에 있었지만 이 래퍼에는
+    없었다(Node 바인딩엔 있었음). ``page`` 로 특정 쪽만, ``max_chars`` 로
+    쪽당 상한을 준다(기본은 무제한 — #3787 S7).
+    """
+    args: List[Any] = ["export-text", path]
+    _flag(args, "-p", page)
+    _flag(args, "--max-chars", max_chars)
+    args.append("--json")
+    return Envelope(run_json(args, timeout=timeout))
 
 
-def export_structure(path: PathLike, *, timeout: Optional[float] = DEFAULT_TIMEOUT) -> Envelope:
-    """문서 구조(제목 계층·절)."""
-    return Envelope(run_json(["export-structure", path, "--json"], timeout=timeout))
+def export_structure(
+    path: PathLike,
+    *,
+    mode: Optional[str] = None,
+    timeout: Optional[float] = DEFAULT_TIMEOUT,
+) -> Envelope:
+    """문서 구조(제목 계층·절).
+
+    [트랙 G R61 D-12] ``mode``(``auto``/``outline``/``clause``)가 CLI 에 있었지만
+    이 래퍼에는 없었다.
+    """
+    args: List[Any] = ["export-structure", path]
+    _flag(args, "--mode", mode)
+    args.append("--json")
+    return Envelope(run_json(args, timeout=timeout))
 
 
 def export_tables(path: PathLike, *, timeout: Optional[float] = DEFAULT_TIMEOUT) -> Envelope:
@@ -140,12 +167,17 @@ def digest(
     *,
     sections: bool = False,
     pages: Optional[str] = None,
+    max_chars: Optional[int] = None,
     timeout: Optional[float] = DEFAULT_TIMEOUT,
 ) -> Envelope:
-    """요약용 청킹 — 주소를 보존한 절 단위 또는 쪽 범위 창."""
+    """요약용 청킹 — 주소를 보존한 절 단위 또는 쪽 범위 창.
+
+    [트랙 G R61 D-12] ``max_chars``가 CLI 에 있었지만 이 래퍼에는 없었다.
+    """
     args: List[Any] = ["digest", path]
     _switch(args, "--sections", sections)
     _flag(args, "--pages", pages)
+    _flag(args, "--max-chars", max_chars)
     args.append("--json")
     return Envelope(run_json(args, timeout=timeout))
 
@@ -420,10 +452,23 @@ def convert(
 
 
 def ir_diff(
-    a: PathLike, b: PathLike, *, timeout: Optional[float] = DEFAULT_TIMEOUT
+    a: PathLike,
+    b: PathLike,
+    *,
+    section: Optional[int] = None,
+    paragraph: Optional[int] = None,
+    timeout: Optional[float] = DEFAULT_TIMEOUT,
 ) -> Envelope:
-    """두 문서의 IR 차이 — 무엇이 달라졌는지 범주별로."""
-    return Envelope(run_json(["ir-diff", a, b, "--json"], timeout=timeout))
+    """두 문서의 IR 차이 — 무엇이 달라졌는지 범주별로.
+
+    [트랙 G R61 D-12] ``section``/``paragraph``(``-s``/``-p`` — 특정 구역·
+    문단으로 좁혀서 비교)가 CLI 에 있었지만 이 래퍼에는 없었다.
+    """
+    args: List[Any] = ["ir-diff", a, b]
+    _flag(args, "-s", section)
+    _flag(args, "-p", paragraph)
+    args.append("--json")
+    return Envelope(run_json(args, timeout=timeout))
 
 
 # ── 편집 ────────────────────────────────────────────────────────────────

--- a/bindings/python/src/rhwp/errors.py
+++ b/bindings/python/src/rhwp/errors.py
@@ -33,6 +33,7 @@ __all__ = [
     "EXIT_VERIFY",
     "EXIT_VERIFY_PAGES",
     "raise_for_exit",
+    "is_known_exit_code",
 ]
 
 #: 성공.
@@ -163,6 +164,16 @@ def _quote(arg: str) -> str:
         return arg
     escaped = arg.replace('"', '\\"')
     return f'"{escaped}"'
+
+
+def is_known_exit_code(code: int) -> bool:
+    """[트랙 G R61 D-18] 이 바인딩이 아는 종료 코드(0/1/2/3/4)인지.
+
+    Node 바인딩의 ``isKnownExitCode`` 를 그대로 이식했다. 모르는 코드를
+    미리 걸러내고 싶은 호출자(로깅·재시도 판단)를 위한 것 — 실제 처리는
+    :func:`raise_for_exit` 가 한다.
+    """
+    return code in (EXIT_OK, EXIT_RUNTIME, EXIT_USAGE, EXIT_VERIFY, EXIT_VERIFY_PAGES)
 
 
 def raise_for_exit(

--- a/bindings/python/src/rhwp/models.py
+++ b/bindings/python/src/rhwp/models.py
@@ -117,6 +117,17 @@ class Envelope(Mapping[str, Any]):
         return VerifyReport(value) if isinstance(value, Mapping) else None
 
     @property
+    def verify_pages(self) -> Optional["VerifyPagesReport"]:
+        """[트랙 G R61 D-10] `--verify-pages` 보고가 있으면 :class:`VerifyPagesReport`,
+        미요청이면 ``None``.
+
+        :attr:`verify` 와 같은 규약이다 — ``None`` 은 "검증 안 함"이지 "검증 실패"가
+        아니다.
+        """
+        value = self._raw.get("verifyPages")
+        return VerifyPagesReport(value) if isinstance(value, Mapping) else None
+
+    @property
     def changed_pages(self) -> Optional[List[int]]:
         """편집이 바꾼 쪽 목록(0 기준). 확정 불가·무산출이면 ``None``.
 
@@ -159,6 +170,33 @@ class VerifyReport(Envelope):
 
     def __bool__(self) -> bool:
         """``if result.verify:`` 가 "통과했나"로 읽히도록."""
+        return self.identical
+
+
+class VerifyPagesReport(Envelope):
+    """`verifyPages` 하위 봉투 — `--verify-pages` 요청 시 저장 전/후 쪽수 비교."""
+
+    __slots__ = ()
+
+    @property
+    def before(self) -> Optional[int]:
+        """저장 전(메모리 IR) 쪽수."""
+        value = self._raw.get("before")
+        return None if value is None else int(value)
+
+    @property
+    def after(self) -> Optional[int]:
+        """저장 후 재파싱한 쪽수."""
+        value = self._raw.get("after")
+        return None if value is None else int(value)
+
+    @property
+    def identical(self) -> bool:
+        """저장 전후 쪽수가 같은가. 이 값이 판정의 전부다."""
+        return bool(self._raw.get("identical", False))
+
+    def __bool__(self) -> bool:
+        """``if result.verify_pages:`` 가 "통과했나"로 읽히도록."""
         return self.identical
 
 

--- a/bindings/python/src/rhwp/session.py
+++ b/bindings/python/src/rhwp/session.py
@@ -49,7 +49,21 @@ class Session:
     한 서버에서 열고 싶을 때만 직접 만든다.
     """
 
-    def __init__(self, *, profile: Optional[str] = None, timeout: Optional[float] = 300.0) -> None:
+    def __init__(
+        self,
+        *,
+        profile: Optional[str] = None,
+        timeout: Optional[float] = 300.0,
+        cwd: Optional[PathLike] = None,
+    ) -> None:
+        # [트랙 G R61 D-14] Node 바인딩엔 세션 자식 프로세스의 작업 디렉터리를
+        # 지정하는 cwd 옵션이 있었지만 파이썬엔 없었다 — 상대 경로 인자를 쓰는
+        # 호출자는 파이썬 프로세스 자신의 cwd 에 암묵 의존했다.
+        #
+        # 주의: self._timeout 은 여기서 저장만 하고 아직 어디서도 소비하지 않는다
+        # (요청-응답 왕복에 실제 제한 시간을 걸려면 stdout 읽기를 별도 스레드로
+        # 옮겨야 하는 더 큰 변경이 필요하다 — 별도 후속 작업으로 남긴다. 지금은
+        # 응답이 없으면 무기한 블록한다).
         self._timeout = timeout
         self._next_id = 0
         self._lock = threading.Lock()
@@ -67,6 +81,7 @@ class Session:
                 encoding="utf-8",
                 errors="replace",
                 bufsize=1,  # 줄 단위 — JSON-RPC 프레임이 줄이다.
+                cwd=str(cwd) if cwd is not None else None,
             )
         except OSError as exc:
             raise RhwpError(f"mcp-serve 기동에 실패했습니다: {exc}", argv=argv) from exc

--- a/bindings/python/tests/test_binary.py
+++ b/bindings/python/tests/test_binary.py
@@ -100,3 +100,16 @@ def test_refresh_bypasses_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
 def test_binary_name_matches_platform() -> None:
     expected = "rhwp.exe" if sys.platform == "win32" else "rhwp"
     assert _binary.binary_name() == expected
+
+
+def test_env_var_is_in_module_all() -> None:
+    """[트랙 G R61 D-15] ENV_VAR 가 __all__ 에 없었다(import 는 됐지만 메타데이터 누락)."""
+    assert "ENV_VAR" in _binary.__all__
+
+
+def test_binary_name_and_bundled_dir_exported_at_package_root() -> None:
+    """[트랙 G R61 D-15] binary_name/BUNDLED_DIR 가 패키지 루트에 노출되지 않았다."""
+    import rhwp
+
+    assert rhwp.binary_name is _binary.binary_name
+    assert rhwp.BUNDLED_DIR == _binary.BUNDLED_DIR

--- a/bindings/python/tests/test_commands.py
+++ b/bindings/python/tests/test_commands.py
@@ -51,9 +51,24 @@ def test_export_text_builds_command(captured: List[List[Any]]) -> None:
     assert _as_strings(captured[0]) == ["export-text", "a.hwp", "--json"]
 
 
+def test_export_text_page_and_max_chars(captured: List[List[Any]]) -> None:
+    """[트랙 G R61 D-12] page/max_chars 가 CLI 에 있었지만 래퍼에 없었다."""
+    rhwp.export_text("a.hwp", page=2, max_chars=500)
+    args = _as_strings(captured[0])
+    assert args[args.index("-p") + 1] == "2"
+    assert args[args.index("--max-chars") + 1] == "500"
+
+
 def test_export_structure_builds_command(captured: List[List[Any]]) -> None:
     rhwp.export_structure("a.hwp")
     assert _as_strings(captured[0]) == ["export-structure", "a.hwp", "--json"]
+
+
+def test_export_structure_mode(captured: List[List[Any]]) -> None:
+    """[트랙 G R61 D-12] mode 가 CLI 에 있었지만 래퍼에 없었다."""
+    rhwp.export_structure("a.hwp", mode="outline")
+    args = _as_strings(captured[0])
+    assert args[args.index("--mode") + 1] == "outline"
 
 
 def test_export_tables_builds_command(captured: List[List[Any]]) -> None:
@@ -97,6 +112,13 @@ def test_digest_flags(captured: List[List[Any]]) -> None:
     args = _as_strings(captured[0])
     assert "--sections" in args
     assert args[args.index("--pages") + 1] == "1-3"
+
+
+def test_digest_max_chars(captured: List[List[Any]]) -> None:
+    """[트랙 G R61 D-12] max_chars 가 CLI 에 있었지만 래퍼에 없었다."""
+    rhwp.digest("a.hwp", max_chars=300)
+    args = _as_strings(captured[0])
+    assert args[args.index("--max-chars") + 1] == "300"
 
 
 def test_digest_without_options(captured: List[List[Any]]) -> None:
@@ -249,6 +271,14 @@ def test_convert_verify_flag(captured: List[List[Any]]) -> None:
 def test_ir_diff_takes_two_paths(captured: List[List[Any]]) -> None:
     rhwp.ir_diff("a.hwp", "b.hwp")
     assert _as_strings(captured[0]) == ["ir-diff", "a.hwp", "b.hwp", "--json"]
+
+
+def test_ir_diff_section_and_paragraph(captured: List[List[Any]]) -> None:
+    """[트랙 G R61 D-12] section/paragraph(-s/-p) 가 CLI 에 있었지만 래퍼에 없었다."""
+    rhwp.ir_diff("a.hwp", "b.hwp", section=1, paragraph=3)
+    args = _as_strings(captured[0])
+    assert args[args.index("-s") + 1] == "1"
+    assert args[args.index("-p") + 1] == "3"
 
 
 # ── 편집 ────────────────────────────────────────────────────────────────

--- a/bindings/python/tests/test_errors.py
+++ b/bindings/python/tests/test_errors.py
@@ -102,3 +102,22 @@ def test_error_str_includes_last_stderr_line() -> None:
             stderr="첫 줄\n오류: 진짜 사유는 여기",
         )
     assert "진짜 사유는 여기" in str(caught.value)
+
+
+# ── D-18: raise_for_exit/is_known_exit_code 패키지 루트 노출 ──────────────
+
+
+def test_raise_for_exit_exported_at_package_root() -> None:
+    """[D-18] errors.__all__ 엔 있었지만 __init__.py 가 실제로 임포트하지 않았다."""
+    import rhwp
+
+    assert rhwp.raise_for_exit is raise_for_exit
+
+
+def test_is_known_exit_code() -> None:
+    """[D-18] Node의 isKnownExitCode 대응이 파이썬엔 없었다."""
+    from rhwp.errors import is_known_exit_code
+
+    for code in (EXIT_OK, EXIT_RUNTIME, EXIT_USAGE, EXIT_VERIFY, EXIT_VERIFY_PAGES):
+        assert is_known_exit_code(code)
+    assert not is_known_exit_code(42)

--- a/bindings/python/tests/test_models.py
+++ b/bindings/python/tests/test_models.py
@@ -73,6 +73,25 @@ def test_verify_reparse_error_is_surfaced() -> None:
     assert report.reparse_error == "손상"
 
 
+def test_verify_pages_property_distinguishes_absent_from_failed() -> None:
+    """[트랙 G R61 D-10] verify 와 대칭인 verifyPages 접근자가 없었다."""
+    from rhwp.models import VerifyPagesReport
+
+    not_requested = Envelope({"output": "a.hwp", "verifyPages": None})
+    assert not_requested.verify_pages is None
+
+    failed = Envelope({"verifyPages": {"before": 5, "after": 4, "identical": False}})
+    report = failed.verify_pages
+    assert isinstance(report, VerifyPagesReport)
+    assert report.before == 5
+    assert report.after == 4
+    assert report.identical is False
+    assert not report  # __bool__ 이 판정을 대변한다
+
+    passed = Envelope({"verifyPages": {"before": 5, "after": 5, "identical": True}})
+    assert bool(passed.verify_pages)
+
+
 def test_changed_pages_distinguishes_unknown_from_empty() -> None:
     """``None``(모름)과 ``[]``(바뀐 쪽 없음)은 다른 결론이다."""
     unknown = Envelope({"changedPages": None})

--- a/bindings/python/tests/test_process.py
+++ b/bindings/python/tests/test_process.py
@@ -108,3 +108,12 @@ def test_boolean_argument_is_rejected() -> None:
 def test_path_arguments_are_stringified(tmp_path: Path) -> None:
     result = run_raw(["ok", tmp_path], check=False)
     assert str(tmp_path) in result.argv
+
+
+def test_iter_ndjson_is_exported_at_package_root() -> None:
+    """[트랙 G R61 D-13] iter_ndjson 이 __all__ 에 없어 공개 API가 아니었다."""
+    import rhwp
+    from rhwp import _process
+
+    assert "iter_ndjson" in _process.__all__
+    assert rhwp.iter_ndjson is _process.iter_ndjson

--- a/bindings/python/tests/test_session.py
+++ b/bindings/python/tests/test_session.py
@@ -267,3 +267,47 @@ def test_profile_is_passed_to_server(normal_server: Path) -> None:
         assert session is not None
     finally:
         session.close()
+
+
+def test_cwd_is_passed_to_subprocess(
+    normal_server: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """[트랙 G R61 D-14] Node 바인딩엔 세션 cwd 옵션이 있었지만 파이썬엔 없었다."""
+    import subprocess as subprocess_module
+
+    captured_kwargs: dict = {}
+    real_popen = subprocess_module.Popen
+
+    def fake_popen(argv, **kwargs):  # type: ignore[no-untyped-def]
+        captured_kwargs.update(kwargs)
+        return real_popen(argv, **kwargs)
+
+    monkeypatch.setattr(subprocess_module, "Popen", fake_popen)
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+
+    session = Session(cwd=work_dir)
+    try:
+        assert captured_kwargs.get("cwd") == str(work_dir)
+    finally:
+        session.close()
+
+
+def test_cwd_defaults_to_none(normal_server: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """cwd 를 안 주면 부모 프로세스의 cwd 를 그대로 물려받아야 한다(기존 동작 불변)."""
+    import subprocess as subprocess_module
+
+    captured_kwargs: dict = {}
+    real_popen = subprocess_module.Popen
+
+    def fake_popen(argv, **kwargs):  # type: ignore[no-untyped-def]
+        captured_kwargs.update(kwargs)
+        return real_popen(argv, **kwargs)
+
+    monkeypatch.setattr(subprocess_module, "Popen", fake_popen)
+
+    session = Session()
+    try:
+        assert captured_kwargs.get("cwd") is None
+    finally:
+        session.close()


### PR DESCRIPTION
## 요약

트랙 G R61(바인딩 표류 20건) 중 나머지 6건입니다. `mydocs/tech/bindings/python_node_comparison.md`가 기록한 파이썬↔Node 드리프트를 Node의 이미 올바른 패턴을 그대로 이식해 기계적으로 맞췄습니다.

- **D-10**: `Envelope.verify_pages` / `VerifyPagesReport` 추가 — 기존 `verify` 접근자와 동일하게 "미요청(`None`)"과 "실패"를 구분합니다. `verifyPages`를 담는 명령 결과를 지금까지는 raw 딕셔너리로 파싱해야 했습니다.
- **D-12**: `export_text`/`export_structure`/`digest`/`ir_diff`가 Node 바인딩엔 있던 `page`/`max_chars`/`mode`/`section`/`paragraph` 인자를 못 받아, CLI가 지원하는 기능 일부가 파이썬 바인딩에서 아예 불가능했습니다.
- **D-13**: `_process.iter_ndjson`이 `__all__`에 없어 공개 API가 아니었습니다(import는 되지만 문서화된 진입점이 아님).
- **D-14(부분)**: `Session(cwd=...)` 추가 — Node 바인딩엔 있던 옵션이 파이썬엔 없어, 상대 경로 인자를 쓰는 호출자가 세션 작업 디렉터리를 바꿀 방법이 없었습니다. (`Session._timeout`을 실제로 강제하는 나머지 절반은 백그라운드 리더 스레드가 필요한 더 큰 구조 변경이라 이번엔 보류했고, `session.py` 주석에 왜 보류했는지 남겼습니다.)
- **D-15**: `_binary.ENV_VAR`가 `__all__`에 없고, `binary_name`/`BUNDLED_DIR`가 패키지 루트(`rhwp.*`)에 노출되지 않았습니다.
- **D-18**: `errors.raise_for_exit`이 `__all__`엔 있었지만 `__init__.py`가 실제로 임포트하지 않아 `rhwp.raise_for_exit`가 없었습니다. Node의 `isKnownExitCode` 대응인 `is_known_exit_code`도 파이썬엔 없어 추가했습니다.

`TROUBLESHOOTING.md`의 `iter_ndjson` 예제도 private 모듈(`rhwp._process`) 직접 임포트 방식이던 걸 공개 API(`rhwp.iter_ndjson`) 사용으로 고쳤습니다.

## 검증

`python -m pytest tests/ -q -m "not integration"`: 239 passed, 40 deselected. 신규 시험 12건 추가, 기존 시험 회귀 없음.

Issue: 로드맵 #3907 트랙 G R61, 근거 문서 `mydocs/tech/bindings/python_node_comparison.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)