### PR TITLE
renderer: leading 컨트롤-전용 줄 스킵 판정을 first_text_line 공유 함수로 추출

### DIFF
--- a/mydocs/plans/task_m100_4312_text_start_line_dedup.md
+++ b/mydocs/plans/task_m100_4312_text_start_line_dedup.md
@@ -1,0 +1,37 @@
+# 수행계획 — task_m100_4312_text_start_line_dedup
+
+- **이슈**: [#4312](https://github.com/edwardkim/rhwp/issues/4312)
+- **브랜치**: `task_m100_4312_text_start_line_dedup`
+- **기준**: `upstream/devel` `f62f7503f`
+- **작성 시각**: 2026-08-09 KST
+
+## 1. 목표
+
+문단의 "실제 텍스트가 있으면 leading 컨트롤-전용 줄을 건너뛰고 텍스트 줄부터 그린다" 판정
+(`has_real_text` + `.position()` 패턴)이 `layout.rs:6560`과 `typeset.rs:13519`(scratch 측정
+경로, #4277 지목 지점)에 독립적으로 재구현되어 있어 sep20/20 pi=936 회귀(측정 127.7px vs
+렌더 101.3px)를 냈다. "첫 텍스트 줄 인덱스" 판정을 `ComposedParagraph`만 입력받는 순수 함수
+하나로 추출해 두 지점이 공유하도록 한다.
+
+## 2. 변경 경계
+
+- `src/renderer/composer.rs`: `pub(crate) fn first_text_line(composed: &ComposedParagraph) ->
+  Option<usize>` 신설 — 기존 두 곳의 동일 클로저를 그대로 옮긴 것으로 새 로직 없음.
+- `src/renderer/layout.rs:6568`, `src/renderer/typeset.rs:13530-13539`: 각자 재구현한 클로저를
+  `first_text_line` 호출로 교체. 주변 게이트(`has_real_text`, `is_wrap_host`, end_line 계산)는
+  사이트별로 그대로 유지 — 이번 슬라이스는 "첫 텍스트 줄 찾기" 클로저 자체만 공유한다.
+- 범위 밖: `layout.rs:8458`, `9723` 등 `text_end_line`도 함께 계산하고 공백 문자 처리가 다른
+  변형은 술어가 미묘하게 달라(#4312 이슈 본문) 이번 PR에서 건드리지 않는다.
+- `#4277`(scratch RenderNode 재사용 제거) 본체는 이 PR의 범위가 아니다 — 이 PR은 그 작업의
+  선행 정리다.
+
+## 검증 게이트
+
+- `cargo test --profile release-test --lib lineseg_compare`
+- `cargo test --profile release-test --test issue_1082_endnote_multicolumn_drift --test
+  issue_1375_endnote_rewind_column_overflow` (sep20/sep2020 fixture 포함)
+- `cargo test --profile release-test --tests` 전체
+- `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings`
+- Native Skia 3종 / `wasm-pack build --target web --out-dir pkg`
+
+원격 push, PR 생성, 이슈 comment·close는 별도 승인 전 수행하지 않는다.

--- a/mydocs/working/task_m100_4312_text_start_line_dedup_stage1.md
+++ b/mydocs/working/task_m100_4312_text_start_line_dedup_stage1.md
@@ -1,0 +1,22 @@
+---
+kind: working
+status: completed
+issue: 4312
+last_verified: 2026-08-09
+---
+
+# Task #4312 Stage 1
+
+## 구현·검증
+
+- `composer::first_text_line(&ComposedParagraph) -> Option<usize>` 신설. `layout.rs:6568`과
+  `typeset.rs:13519`(`measure_endnote_para_advance` scratch 경로)의 동일 클로저를 그대로 이동 —
+  새 로직 없음. 사이트별 게이트(`has_real_text`, `is_wrap_host`, end_line 계산)는 변경 없이 유지.
+  범위 밖(`layout.rs:8458`/`9723` 등 술어가 다른 변형)은 이번 슬라이스에서 건드리지 않았다.
+- 검증: `cargo test --profile release-test --lib lineseg_compare`(9/9) +
+  `issue_1082_endnote_multicolumn_drift`·`issue_1375_endnote_rewind_column_overflow`
+  (sep20/sep2020 fixture 포함, 7/7) → `cargo test --profile release-test --tests` 전체
+  (495 바이너리, 5,486 passed, 0 failed) → `cargo fmt --check` → `cargo clippy --all-targets
+  -- -D warnings` → Native Skia 3종(58+2+4 passed) → `wasm-pack build --target web` 전부 통과.
+- 순수 추출(behavior-preserving) — 클로저 본문 무변경, 호출 지점만 통합했으므로 회귀 위험은
+  각 사이트의 기존 회귀 스위트(sep20/sep2020 fixture)로 충분히 커버된다.

--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -342,6 +342,19 @@ pub fn compose_paragraph(para: &Paragraph) -> ComposedParagraph {
     composed
 }
 
+/// 컴포즈드 줄 목록에서 첫 "텍스트 포함 줄"(런에 텍스트 성격 문자가 있는 줄)의 인덱스.
+/// 실제 텍스트가 있는 문단은 leading 컨트롤-전용 줄(수식 객체마커 ￼ 등)을 건너뛰고 이
+/// 줄부터 그린다 — `LayoutEngine::layout_column_item`(실제 렌더)과
+/// `TypesetEngine::measure_endnote_para_advance`(측정 전용)가 이 판정을 공유한다.
+/// 종전엔 각자 재구현해 sep20/20(pi=936, 측정 127.7px vs 렌더 101.3px)에서 갈라졌다(#4312).
+pub(crate) fn first_text_line(composed: &ComposedParagraph) -> Option<usize> {
+    composed.lines.iter().position(|line| {
+        line.runs
+            .iter()
+            .any(|r| r.text.chars().any(|c| c > '\u{001F}' && c != '\u{FFFC}'))
+    })
+}
+
 /// Hanyang-PUA 옛한글 코드포인트·한컴 PUA와 legacy 제품명을 렌더링용 텍스트로 변환한다.
 ///
 /// 한컴 자체 폰트 (함초롬바탕 LVT 등) 는 PUA 영역에 옛한글 글리프를 직접

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -3,7 +3,9 @@
 //! 페이지 분할 결과를 받아 각 요소의 정확한 위치와 크기를 계산하고
 //! 렌더 트리(PageRenderTree)를 생성한다.
 
-use super::composer::{compose_paragraph, effective_text_for_metrics, ComposedParagraph};
+use super::composer::{
+    compose_paragraph, effective_text_for_metrics, first_text_line, ComposedParagraph,
+};
 use super::float_placement::{
     horizontal_range, is_para_topbottom_float, native_empty_host_rowbreak_line_advance_hu,
     signed_hwpunit, FloatLaneSet, FloatPlacementContext,
@@ -6565,11 +6567,7 @@ impl LayoutEngine {
                         if has_real_text {
                             if let Some(comp) = comp {
                                 // 컨트롤 전용 줄(runs가 모두 제어문자)을 건너뛰고 텍스트 줄부터 렌더링
-                                let text_start_line = comp.lines.iter().position(|line| {
-                                    line.runs.iter().any(|r| {
-                                        r.text.chars().any(|c| c > '\u{001F}' && c != '\u{FFFC}')
-                                    })
-                                });
+                                let text_start_line = first_text_line(comp);
                                 if let Some(start_line) = text_start_line {
                                     para_start_y.insert(*para_index, y_offset);
                                     y_offset = self.layout_partial_paragraph(

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -14,7 +14,7 @@ use crate::model::header_footer::HeaderFooterApply;
 use crate::model::page::{ColumnDef, ColumnType, PageDef};
 use crate::model::paragraph::{ColumnBreakType, LineSeg, Paragraph};
 use crate::model::shape::CaptionDirection;
-use crate::renderer::composer::{compose_paragraph, ComposedParagraph};
+use crate::renderer::composer::{compose_paragraph, first_text_line, ComposedParagraph};
 use crate::renderer::float_placement::{
     horizontal_range, is_page_bottom_fixed_float, is_para_topbottom_float,
     native_empty_host_rowbreak_line_advance_hu, signed_hwpunit, FloatLaneSet,
@@ -13511,11 +13511,11 @@ impl TypesetEngine {
         use crate::renderer::page_layout::LayoutRect;
         use crate::renderer::render_tree::{PageRenderTree, RenderNode, RenderNodeType};
 
-        // 렌더 `layout_column_item` 의 FullParagraph 텍스트 경로 정합(layout.rs has_real_text):
-        // 실제 텍스트가 있는 para 는 **leading 컨트롤-전용 줄**(수식 객체마커 ￼ 등)을 건너뛰고
-        // `text_start_line` 부터 그린다. scratch 가 start_line=0 으로 그 줄을 포함하면 수식 다줄
-        // para 가 +수십px 과대 측정된다(sep20/20 pi=936: 127.7 vs 렌더 101.3). 객체-전용 para
-        // (TAC 그림 등)는 0 부터(렌더도 동일). Partial 은 항목 지정 줄 범위 그대로.
+        // 렌더 `layout_column_item` 의 FullParagraph 텍스트 경로 정합: 실제 텍스트가 있는 para 는
+        // **leading 컨트롤-전용 줄**(수식 객체마커 ￼ 등)을 건너뛰고 첫 텍스트 줄부터 그린다.
+        // `composer::first_text_line` 로 판정을 공유해(#4312) 재구현 divergence(sep20/20
+        // pi=936: 측정 127.7 vs 렌더 101.3)를 구조적으로 막는다. 객체-전용 para(TAC 그림 등)는
+        // 0 부터(렌더도 동일). Partial 은 항목 지정 줄 범위 그대로.
         let (start_line, end_line) = match item {
             PageItem::PartialParagraph {
                 start_line,
@@ -13528,15 +13528,7 @@ impl TypesetEngine {
                     .chars()
                     .any(|c| c > '\u{001F}' && c != '\u{FFFC}' && !c.is_whitespace());
                 let start = if has_real_text {
-                    item_composed
-                        .lines
-                        .iter()
-                        .position(|line| {
-                            line.runs
-                                .iter()
-                                .any(|r| r.text.chars().any(|c| c > '\u{001F}' && c != '\u{FFFC}'))
-                        })
-                        .unwrap_or(0)
+                    first_text_line(item_composed).unwrap_or(0)
                 } else {
                     0
                 };


### PR DESCRIPTION
## 요약

문단의 "실제 텍스트가 있으면 leading 컨트롤-전용 줄(런이 전부 제어문자인 줄 — 수식 객체마커
등)을 건너뛰고 텍스트 줄부터 그린다"는 판정이 `layout.rs:6568`(실제 렌더)과
`typeset.rs:13519`(`measure_endnote_para_advance`의 scratch 측정 경로 — #4277이 지목한 지점)에
독립적으로 재구현되어 있었다. 손으로 맞춰 유지하는 구조라 실제로 어긋난 전례가 있다 — #4277
진단에 인용된 sep20/20 pi=936 회귀(측정 127.7px vs 렌더 101.3px, ~26px 괴리)가 바로 이 두
복사본이 갈라지며 난 결과다.

"첫 텍스트 줄 인덱스" 판정을 `ComposedParagraph`만 입력받는 순수 함수
(`composer::first_text_line`)로 추출해 두 지점이 공유하도록 했다.

Closes #4312.

## 관련 이슈 — #4277 (이 PR은 닫지 않음)

이 PR은 **#4277을 닫지 않는다.** #4277이 지목한 결함(측정 전용 경로가 실제로 쓰이지 않을
`PageRenderTree`/`RenderNode` scratch 트리를 만들어 버리는 것 — `layout_partial_paragraph`의
RenderNode 의존)은 이 PR이 건드리지 않은 채 그대로 남아 있다.

이 PR은 그 본체 리팩터의 **선행 정리**일 뿐이다 — 본체 작업(RenderNode 생성 없이 컨트롤
배치·측정 로직을 공유하는 sink 추상화)에서 "동작이 같다"를 검증해야 할 재구현 지점이 하나
(첫 텍스트 줄 판정) 줄어든다.

## 변경 내용

- `src/renderer/composer.rs`: `pub(crate) fn first_text_line(composed: &ComposedParagraph) ->
  Option<usize>` 신설 — 기존 두 곳의 동일 클로저를 그대로 옮긴 것으로 새 로직 없음.
- `src/renderer/layout.rs:6568`, `src/renderer/typeset.rs:13519`: 재구현 클로저를
  `first_text_line` 호출로 교체. 주변 게이트(`has_real_text`, `is_wrap_host`, end_line 계산)는
  사이트별로 그대로 유지 — 이번 슬라이스는 "첫 텍스트 줄 찾기" 클로저 자체만 공유한다.
- 범위 밖(의도적 제외): `layout.rs:8458`, `9723` 등 `text_end_line`도 함께 계산하고 공백 문자
  처리가 다른 변형은 술어가 미묘하게 달라 상호 검증이 더 필요하므로 이번 PR에서 건드리지 않았다.

순수 추출(behavior-preserving) — 클로저 본문 무변경, 호출 지점만 통합.

## 검증

- `cargo test --profile release-test --lib lineseg_compare` — 9/9 pass
- `cargo test --profile release-test --test issue_1082_endnote_multicolumn_drift --test
  issue_1375_endnote_rewind_column_overflow` (sep20/sep2020 fixture 포함) — 7/7 pass
- `cargo test --profile release-test --tests` 전체 — 495 바이너리, 5,486 passed, 0 failed
- `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` — clean
- Native Skia 3종 — 58+2+4 passed
- `wasm-pack build --target web --out-dir pkg` — 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)
