### PR TITLE
core/renderer: 레이아웃 재귀의 페인트 트리 결합 분리 + 미사용 함수 제거

### DIFF
--- a/src/document_core/commands/header_footer_ops.rs
+++ b/src/document_core/commands/header_footer_ops.rs
@@ -736,11 +736,6 @@ impl DocumentCore {
         Ok(format!("{{\"ok\":true,\"hidden\":{}}}", hidden))
     }
 
-    /// 특정 페이지의 머리말/꼬리말이 감추기 상태인지 확인한다.
-    pub fn is_header_footer_hidden(&self, page_num: u32, is_header: bool) -> bool {
-        self.hidden_header_footer.contains(&(page_num, is_header))
-    }
-
     /// 머리말/꼬리말 문단 리플로우
     fn reflow_hf_paragraph(
         &mut self,

--- a/src/document_core/commands/object_ops/table.rs
+++ b/src/document_core/commands/object_ops/table.rs
@@ -1162,15 +1162,6 @@ impl DocumentCore {
         }
         (0, 0)
     }
-    /// 표의 모든 셀 bbox를 반환한다 (네이티브).
-    pub(crate) fn get_table_cell_bboxes_native(
-        &self,
-        section_idx: usize,
-        parent_para_idx: usize,
-        control_idx: usize,
-    ) -> Result<String, HwpError> {
-        self.get_table_cell_bboxes_from_page(section_idx, parent_para_idx, control_idx, 0)
-    }
     /// page_hint부터 탐색하여 표의 셀 bbox를 반환한다 (네이티브).
     /// page_hint에서 못 찾으면 앞쪽도 탐색한다 (페이지 분할된 표 대응).
     pub(crate) fn get_table_cell_bboxes_from_page(

--- a/src/document_core/helpers.rs
+++ b/src/document_core/helpers.rs
@@ -147,35 +147,11 @@ pub(crate) fn find_control_text_positions(para: &Paragraph) -> Vec<usize> {
 /// `find_control_text_positions()` 는 HWP/HWPX record stream 의 raw text position 을 보존한다.
 /// 반면 커서 이동은 `SectionDef`, `ColumnDef` 같은 구조 컨트롤을 건너뛰고,
 /// Shape/Table/Picture/Equation/Footnote/Endnote 같은 인라인 개체만 한 글자 폭으로 센다.
+///
+/// 알고리즘 본체는 [`Paragraph::logical_control_positions`] 로 이동했으며, 본 함수는
+/// 기존 호출 경로를 유지하기 위한 thin wrapper 다.
 pub(crate) fn find_logical_control_positions(para: &Paragraph) -> Vec<usize> {
-    if para.text.is_empty() && para.char_offsets.is_empty() {
-        let mut inline_seen = 0usize;
-        let mut positions = Vec::with_capacity(para.controls.len());
-
-        for ctrl in &para.controls {
-            positions.push(inline_seen);
-            if is_logical_inline_control(ctrl) {
-                inline_seen += 1;
-            }
-        }
-
-        return positions;
-    }
-
-    let text_positions = find_control_text_positions(para);
-    let text_len = para.text.chars().count();
-    let mut inline_seen = 0usize;
-    let mut positions = Vec::with_capacity(para.controls.len());
-
-    for (ci, ctrl) in para.controls.iter().enumerate() {
-        let text_pos = text_positions.get(ci).copied().unwrap_or(text_len);
-        positions.push(text_pos + inline_seen);
-        if is_logical_inline_control(ctrl) {
-            inline_seen += 1;
-        }
-    }
-
-    positions
+    para.logical_control_positions()
 }
 
 /// ShapeObject에서 TextBox를 추출하는 헬퍼

--- a/src/document_core/helpers.rs
+++ b/src/document_core/helpers.rs
@@ -9,18 +9,11 @@ use crate::model::path::PathSegment;
 use crate::model::style::BorderLineType;
 
 pub(crate) fn is_treat_as_char_object_control(ctrl: &Control) -> bool {
-    match ctrl {
-        Control::Shape(shape) => shape.common().treat_as_char,
-        Control::Table(table) => table.common.treat_as_char,
-        Control::Picture(picture) => picture.common.treat_as_char,
-        Control::Equation(equation) => equation.common.treat_as_char,
-        _ => false,
-    }
+    ctrl.is_treat_as_char_object()
 }
 
 fn is_logical_inline_control(ctrl: &Control) -> bool {
-    is_treat_as_char_object_control(ctrl)
-        || matches!(ctrl, Control::Footnote(_) | Control::Endnote(_))
+    ctrl.is_logical_inline()
 }
 
 /// 문단의 탐색 가능한 텍스트 길이를 반환한다.

--- a/src/document_core/queries/cursor_rect.rs
+++ b/src/document_core/queries/cursor_rect.rs
@@ -3019,7 +3019,7 @@ impl DocumentCore {
         use crate::model::control::Control;
         use crate::renderer::layout::{layout_rect_to_bbox, PartialTableCellProbe, ProbeCutPlan};
         use crate::renderer::pagination::PageItem;
-        use crate::renderer::render_tree::{PageRenderTree, RenderNode, RenderNodeType};
+        use crate::renderer::render_tree::{LayoutFrame, RenderNode, RenderNodeType};
         use FastCellRectOutcome::{Hit, NoHit, Unsupported};
 
         let Ok((page_content, paragraphs, _composed)) = self.find_page(page_num) else {
@@ -3247,12 +3247,13 @@ impl DocumentCore {
             .unwrap_or(0);
 
         // ── 대상 셀 하나만 방출하는 프로브 레이아웃 ──
-        let mut scratch_tree = PageRenderTree::new(
+        // [#4277] 캐럿 rect 프로브도 paint 트리가 아니라 흐름 상태만 만든다.
+        let mut scratch_frame = LayoutFrame::new(
             page_content.page_index,
             layout.page_width,
             layout.page_height,
         );
-        let col_id = scratch_tree.next_id();
+        let col_id = scratch_frame.next_id();
         let mut scratch_col = RenderNode::new(
             col_id,
             RenderNodeType::Column(col.column_index),
@@ -3274,7 +3275,7 @@ impl DocumentCore {
             window_paras,
         };
         self.layout_engine.layout_partial_table(
-            &mut scratch_tree,
+            &mut scratch_frame,
             &mut scratch_col,
             paragraphs,
             parent_para_idx,
@@ -4499,13 +4500,6 @@ impl DocumentCore {
             offset += count;
         }
         (0, 0)
-    }
-
-    /// 해당 페이지에서 활성화된 머리말/꼬리말의 apply_to 값을 반환한다.
-    fn get_active_hf_apply_to(&self, _section_idx: usize, page_num: u32, is_header: bool) -> u8 {
-        self.get_active_hf_info(page_num, is_header)
-            .map(|(_, apply_to)| apply_to)
-            .unwrap_or(0)
     }
 
     /// 해당 페이지에서 활성화된 머리말/꼬리말의 (source_section_index, apply_to)를 반환한다.

--- a/src/document_core/queries/injection_scan.rs
+++ b/src/document_core/queries/injection_scan.rs
@@ -967,14 +967,6 @@ impl Scope {
             Scope::HiddenComment => "hiddenComment",
         }
     }
-
-    /// `--include-fields` 로만 열리는 영역인가.
-    pub fn requires_include_fields(self) -> bool {
-        matches!(
-            self,
-            Scope::FieldName | Scope::FieldGuide | Scope::FieldCommand | Scope::HiddenComment
-        )
-    }
 }
 
 /// 주소가 붙은 신호 1건 — 봉투에 그대로 실린다.

--- a/src/model/control.rs
+++ b/src/model/control.rs
@@ -60,6 +60,29 @@ pub enum Control {
     Unknown(UnknownControl),
 }
 
+impl Control {
+    /// 개체가 글자처럼 취급(treat_as_char)되는가.
+    ///
+    /// 텍스트 흐름 안에서 한 글자 폭을 차지하는 개체 판정의 기반이다.
+    pub fn is_treat_as_char_object(&self) -> bool {
+        match self {
+            Control::Shape(shape) => shape.common().treat_as_char,
+            Control::Table(table) => table.common.treat_as_char,
+            Control::Picture(picture) => picture.common.treat_as_char,
+            Control::Equation(equation) => equation.common.treat_as_char,
+            _ => false,
+        }
+    }
+
+    /// 편집/커서 이동에서 논리적으로 한 글자 폭을 차지하는 컨트롤인가.
+    ///
+    /// `treat_as_char` 개체에 각주·미주를 더한 것. `SectionDef`/`ColumnDef` 같은
+    /// 구조 컨트롤은 흐름에서 자리를 차지하지 않으므로 제외된다.
+    pub fn is_logical_inline(&self) -> bool {
+        self.is_treat_as_char_object() || matches!(self, Control::Footnote(_) | Control::Endnote(_))
+    }
+}
+
 /// [#2727] `Equation::attr` 의 bit 0 — 수식이 차지하는 범위.
 ///
 /// set = 줄 단위 (HWPX `lineMode="LINE"`), clear = 글자 단위 (`lineMode="CHAR"`).

--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -1529,23 +1529,12 @@ impl Paragraph {
     /// 보존한다. 반면 커서 이동은 `SectionDef`, `ColumnDef` 같은 구조 컨트롤을 건너뛰고,
     /// Shape/Table/Picture/Equation/Footnote/Endnote 같은 인라인 개체만 한 글자 폭으로 센다.
     pub fn logical_control_positions(&self) -> Vec<usize> {
-        fn is_logical_inline_control(ctrl: &Control) -> bool {
-            match ctrl {
-                Control::Shape(shape) => shape.common().treat_as_char,
-                Control::Table(table) => table.common.treat_as_char,
-                Control::Picture(picture) => picture.common.treat_as_char,
-                Control::Equation(equation) => equation.common.treat_as_char,
-                Control::Footnote(_) | Control::Endnote(_) => true,
-                _ => false,
-            }
-        }
-
         if self.text.is_empty() && self.char_offsets.is_empty() {
             let mut inline_seen = 0usize;
             let mut positions = Vec::with_capacity(self.controls.len());
             for ctrl in &self.controls {
                 positions.push(inline_seen);
-                if is_logical_inline_control(ctrl) {
+                if ctrl.is_logical_inline() {
                     inline_seen += 1;
                 }
             }
@@ -1559,7 +1548,7 @@ impl Paragraph {
         for (ci, ctrl) in self.controls.iter().enumerate() {
             let text_pos = text_positions.get(ci).copied().unwrap_or(text_len);
             positions.push(text_pos + inline_seen);
-            if is_logical_inline_control(ctrl) {
+            if ctrl.is_logical_inline() {
                 inline_seen += 1;
             }
         }

--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -1523,6 +1523,49 @@ impl Paragraph {
         positions
     }
 
+    /// 편집/커서 이동용 control position 을 반환한다.
+    ///
+    /// [`Self::control_text_positions`] 는 HWP/HWPX record stream 의 raw text position 을
+    /// 보존한다. 반면 커서 이동은 `SectionDef`, `ColumnDef` 같은 구조 컨트롤을 건너뛰고,
+    /// Shape/Table/Picture/Equation/Footnote/Endnote 같은 인라인 개체만 한 글자 폭으로 센다.
+    pub fn logical_control_positions(&self) -> Vec<usize> {
+        fn is_logical_inline_control(ctrl: &Control) -> bool {
+            match ctrl {
+                Control::Shape(shape) => shape.common().treat_as_char,
+                Control::Table(table) => table.common.treat_as_char,
+                Control::Picture(picture) => picture.common.treat_as_char,
+                Control::Equation(equation) => equation.common.treat_as_char,
+                Control::Footnote(_) | Control::Endnote(_) => true,
+                _ => false,
+            }
+        }
+
+        if self.text.is_empty() && self.char_offsets.is_empty() {
+            let mut inline_seen = 0usize;
+            let mut positions = Vec::with_capacity(self.controls.len());
+            for ctrl in &self.controls {
+                positions.push(inline_seen);
+                if is_logical_inline_control(ctrl) {
+                    inline_seen += 1;
+                }
+            }
+            return positions;
+        }
+
+        let text_positions = self.control_text_positions();
+        let text_len = self.text.chars().count();
+        let mut inline_seen = 0usize;
+        let mut positions = Vec::with_capacity(self.controls.len());
+        for (ci, ctrl) in self.controls.iter().enumerate() {
+            let text_pos = text_positions.get(ci).copied().unwrap_or(text_len);
+            positions.push(text_pos + inline_seen);
+            if is_logical_inline_control(ctrl) {
+                inline_seen += 1;
+            }
+        }
+        positions
+    }
+
     /// `char_offsets` 중 UTF-16 위치 `utf16_pos` 이상인 첫 번째 codepoint 의
     /// 인덱스를 반환한다. 모든 entry 가 작으면 `char_offsets.len()` (텍스트 끝).
     ///

--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -184,7 +184,7 @@ fn synthesize_marker_paragraph(para: &Paragraph) -> Option<Paragraph> {
     // 쉼표/고정탭/일반 글자가 한 줄에 섞인 문단은 [0,0,2,2,4] 같은 raw
     // position 자체가 편집자가 입력한 순서다. 여기에 \u{FFFC}를 재합성하면
     // TAC가 쉼표/탭 뒤로 밀려 순서가 깨진다.
-    let raw_positions = find_control_text_positions(para);
+    let raw_positions = para.control_text_positions();
     let raw_inline_positions: Vec<usize> = para
         .controls
         .iter()
@@ -1129,12 +1129,6 @@ fn identify_inline_controls(para: &Paragraph) -> Vec<InlineControl> {
     result
 }
 
-/// char_offsets 갭을 분석하여 각 컨트롤의 텍스트 내 삽입 위치를 결정한다.
-/// → document_core::helpers::find_control_text_positions 으로 위임
-fn find_control_text_positions(para: &Paragraph) -> Vec<usize> {
-    crate::document_core::find_control_text_positions(para)
-}
-
 fn is_render_inline_control(ctrl: &Control) -> bool {
     match ctrl {
         Control::Picture(pic) => pic.common.treat_as_char,
@@ -1159,7 +1153,7 @@ fn find_render_inline_control_positions(para: &Paragraph) -> Vec<usize> {
         return positions;
     }
 
-    find_control_text_positions(para)
+    para.control_text_positions()
 }
 
 /// CharOverlap 컨트롤의 글자를 조합된 텍스트에 올바른 위치로 삽입한다.
@@ -1186,7 +1180,7 @@ fn inject_char_overlap_text(composed: &mut ComposedParagraph, para: &Paragraph) 
     }
 
     // 모든 컨트롤의 텍스트 위치 결정
-    let control_positions = find_control_text_positions(para);
+    let control_positions = para.control_text_positions();
 
     // CharOverlap별 (텍스트위치, 런) 수집
     let mut insertions: Vec<(usize, ComposedTextRun)> = Vec::new();

--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -1025,10 +1025,6 @@ fn char_level_break_hwp(
     (results, lw, line_max_fs)
 }
 
-/// 문단의 line_segs를 텍스트 내용과 컬럼 너비에 맞게 재계산한다.
-///
-/// 텍스트 편집(삽입/삭제) 후 호출하여 줄 바꿈을 재배치한다.
-/// `available_width_px`는 문단 여백을 제외한 사용 가능 너비(px)이다.
 fn inline_control_line_height_hwp(para: &Paragraph) -> Option<i32> {
     para.controls
         .iter()
@@ -1087,6 +1083,10 @@ fn apply_inline_control_line_height(seg: &mut LineSeg, height_hwp: i32) {
     }
 }
 
+/// 문단의 line_segs를 텍스트 내용과 컬럼 너비에 맞게 재계산한다.
+///
+/// 텍스트 편집(삽입/삭제) 후 호출하여 줄 바꿈을 재배치한다.
+/// `available_width_px`는 문단 여백을 제외한 사용 가능 너비(px)이다.
 pub(crate) fn reflow_line_segs(
     para: &mut Paragraph,
     available_width_px: f64,
@@ -1099,7 +1099,6 @@ pub(crate) fn reflow_line_segs(
     // 기존 LineSeg에서 dimension 값 보존 (원본 HWP 호환성 유지)
     let seg_width_hwp = px_to_hwpunit(available_width_px, dpi);
     let orig = para.line_segs.first().cloned();
-    let has_valid_orig = orig.as_ref().map(|ls| ls.line_height > 0).unwrap_or(false);
 
     // ParaPr의 줄간격 설정 (합성 LineSeg에서 line_spacing 계산에 사용)
     let para_style = styles.para_styles.get(para.para_shape_id as usize);

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -315,7 +315,7 @@ fn receipt_seal_line_text(
 }
 
 fn push_tac_receipt_seal_line(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     col_node: &mut RenderNode,
     section_index: usize,
     para_index: usize,
@@ -403,7 +403,7 @@ fn tac_receipt_post_f081c_line(
         return None;
     }
 
-    let positions = crate::document_core::find_control_text_positions(para);
+    let positions = para.control_text_positions();
     let table_pos = *positions.get(control_index)?;
     let text_chars: Vec<char> = para.text.chars().collect();
     if table_pos >= text_chars.len() {
@@ -440,7 +440,7 @@ fn tac_receipt_post_f081c_line(
 
 #[allow(clippy::too_many_arguments)]
 fn push_tac_post_f081c_line(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     col_node: &mut RenderNode,
     section_index: usize,
     para_index: usize,
@@ -1635,7 +1635,7 @@ fn force_para_end_on_last_run(col_node: &mut RenderNode) {
 
 /// 빈 TopAndBottom 표 host 문단의 조판부호를 표 시작 위치에 직접 그린다.
 fn push_empty_para_end_mark(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     col_node: &mut RenderNode,
     para: &Paragraph,
     styles: &ResolvedStyleSet,
@@ -2611,7 +2611,7 @@ impl LayoutEngine {
         // 단별 콘텐츠 레이아웃
         let mut paper_images: Vec<RenderNode> = Vec::new();
         self.build_columns(
-            &mut tree,
+            tree.frame_mut(),
             &mut body_node,
             &mut paper_images,
             page_content,
@@ -2756,7 +2756,7 @@ impl LayoutEngine {
             .unwrap_or(false);
         let mut footer_node = if !hide_footer {
             self.build_footer(
-                &mut tree,
+                tree.frame_mut(),
                 page_content,
                 footer_paragraphs,
                 composed,
@@ -2794,7 +2794,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_header_footer_paragraphs(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         area_node: &mut RenderNode,
         hf_paragraphs: &[Paragraph],
         _composed: &[ComposedParagraph],
@@ -3175,7 +3175,7 @@ impl LayoutEngine {
         para: &Paragraph,
         an_type: crate::model::control::AutoNumberType,
     ) -> Vec<usize> {
-        let ctrl_positions = crate::document_core::helpers::find_control_text_positions(para);
+        let ctrl_positions = para.control_text_positions();
         let text_chars: Vec<char> = para.text.chars().collect();
         let mut positions = Vec::new();
         let mut search_from = 0usize;
@@ -3509,21 +3509,35 @@ impl LayoutEngine {
                     )
                 };
 
-                let top_nodes = create_border_line_nodes(tree, &borders[2], bx, by, bx + bw, by);
+                let top_nodes =
+                    create_border_line_nodes(tree.frame_mut(), &borders[2], bx, by, bx + bw, by);
                 for n in top_nodes {
                     tree.root.children.push(n);
                 }
-                let bottom_nodes =
-                    create_border_line_nodes(tree, &borders[3], bx, by + bh, bx + bw, by + bh);
+                let bottom_nodes = create_border_line_nodes(
+                    tree.frame_mut(),
+                    &borders[3],
+                    bx,
+                    by + bh,
+                    bx + bw,
+                    by + bh,
+                );
                 for n in bottom_nodes {
                     tree.root.children.push(n);
                 }
-                let left_nodes = create_border_line_nodes(tree, &borders[0], bx, by, bx, by + bh);
+                let left_nodes =
+                    create_border_line_nodes(tree.frame_mut(), &borders[0], bx, by, bx, by + bh);
                 for n in left_nodes {
                     tree.root.children.push(n);
                 }
-                let right_nodes =
-                    create_border_line_nodes(tree, &borders[1], bx + bw, by, bx + bw, by + bh);
+                let right_nodes = create_border_line_nodes(
+                    tree.frame_mut(),
+                    &borders[1],
+                    bx + bw,
+                    by,
+                    bx + bw,
+                    by + bh,
+                );
                 for n in right_nodes {
                     tree.root.children.push(n);
                 }
@@ -3671,7 +3685,7 @@ impl LayoutEngine {
                                         height: paper_area.height,
                                     };
                                     self.layout_shape(
-                                        tree,
+                                        tree.frame_mut(),
                                         target_node,
                                         &mp.paragraphs,
                                         pi,
@@ -3720,7 +3734,7 @@ impl LayoutEngine {
                                     positioned.common.horz_align = HorzAlign::Left;
                                     positioned.common.vert_align = VertAlign::Top;
                                     self.layout_picture(
-                                        tree,
+                                        tree.frame_mut(),
                                         target_node,
                                         &positioned,
                                         &pic_area,
@@ -3741,7 +3755,7 @@ impl LayoutEngine {
                                     // 바탕쪽 표: PAPER 기준은 paper_area, PAGE 기준은 위에서 설정한
                                     // current_body_area를 통해 본문 영역으로 계산된다.
                                     self.layout_table(
-                                        tree,
+                                        tree.frame_mut(),
                                         target_node,
                                         t,
                                         section_index,
@@ -3791,7 +3805,7 @@ impl LayoutEngine {
                             }
                         }
                         mp_y_offset = self.layout_paragraph(
-                            tree,
+                            tree.frame_mut(),
                             &mut mp_node,
                             para,
                             Some(&comp),
@@ -3827,7 +3841,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_header_footer_picture(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         area_node: &mut RenderNode,
         pic: &crate::model::image::Picture,
         area: &LayoutRect,
@@ -3944,7 +3958,7 @@ impl LayoutEngine {
                                 kind: crate::renderer::render_tree::HeaderFooterKind::Header,
                             };
                             self.layout_header_footer_paragraphs(
-                                tree,
+                                tree.frame_mut(),
                                 &mut header_node,
                                 &header.paragraphs,
                                 composed,
@@ -4045,7 +4059,7 @@ impl LayoutEngine {
     /// 꼬리말 영역 노드를 생성하여 반환한다.
     fn build_footer(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         page_content: &PageContent,
         paragraphs: &[Paragraph],
         composed: &[ComposedParagraph],
@@ -4152,7 +4166,7 @@ impl LayoutEngine {
             );
 
             self.layout_footnote_area(
-                tree,
+                tree.frame_mut(),
                 &mut fn_node,
                 &page_content.footnotes,
                 paragraphs,
@@ -4310,7 +4324,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn build_columns(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         body_node: &mut RenderNode,
         paper_images: &mut Vec<RenderNode>,
         page_content: &PageContent,
@@ -4639,7 +4653,7 @@ impl LayoutEngine {
     /// zone_layout 기준 + y 범위 인자로 단 구분선을 그린다.
     fn emit_zone_column_separators(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         body_node: &mut RenderNode,
         zone_layout: &PageLayoutInfo,
         y_start: f64,
@@ -4762,10 +4776,11 @@ impl LayoutEngine {
             active_master_page: None,
             extra_master_pages: Vec::new(),
         };
-        let mut tree = PageRenderTree::new(0, col_area.width, col_area.y + col_area.height);
+        // [#4277] 높이 측정 전용 — paint 트리가 아니라 흐름 상태만 만든다.
+        let mut frame = LayoutFrame::new(0, col_area.width, col_area.y + col_area.height);
         let mut paper_images: Vec<RenderNode> = Vec::new();
         let (_node, y_offset) = self.build_single_column(
-            &mut tree,
+            &mut frame,
             &mut paper_images,
             &col_content,
             &page_content,
@@ -4791,7 +4806,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn render_para_border_groups(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         composed: &[ComposedParagraph],
         col_node: &mut RenderNode,
         styles: &ResolvedStyleSet,
@@ -5096,7 +5111,7 @@ impl LayoutEngine {
 
     fn build_single_column(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         paper_images: &mut Vec<RenderNode>,
         col_content: &ColumnContent,
         page_content: &PageContent,
@@ -6411,7 +6426,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_column_item(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         col_node: &mut RenderNode,
         paper_images: &mut Vec<RenderNode>,
         para_start_y: &mut std::collections::HashMap<usize, f64>,
@@ -6916,7 +6931,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_endnote_separator_item(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         col_node: &mut RenderNode,
         col_area: &LayoutRect,
         mut y_offset: f64,
@@ -6971,7 +6986,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_table_control_block(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         col_node: &mut RenderNode,
         paper_images: &mut Vec<RenderNode>,
         para_start_y: &mut std::collections::HashMap<usize, f64>,
@@ -7852,7 +7867,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_table_item(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         col_node: &mut RenderNode,
         paper_images: &mut Vec<RenderNode>,
         para_start_y: &mut std::collections::HashMap<usize, f64>,
@@ -8393,7 +8408,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_partial_table_item(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         col_node: &mut RenderNode,
         para_start_y: &mut std::collections::HashMap<usize, f64>,
         para_index: usize,
@@ -8738,7 +8753,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_shape_item(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         col_node: &mut RenderNode,
         paper_images: &mut Vec<RenderNode>,
         para_start_y: &mut std::collections::HashMap<usize, f64>,
@@ -9640,7 +9655,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_wrap_around_paras(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         col_node: &mut RenderNode,
         paragraphs: &[Paragraph],
         composed: &[ComposedParagraph],
@@ -9950,7 +9965,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_column_shapes_pass(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         col_node: &mut RenderNode,
         paper_images: &mut Vec<RenderNode>,
         col_content: &ColumnContent,
@@ -10251,9 +10266,7 @@ impl LayoutEngine {
         col_area: &LayoutRect,
         control_index: usize,
     ) -> f64 {
-        use crate::document_core::find_control_text_positions;
-
-        let positions = find_control_text_positions(para);
+        let positions = para.control_text_positions();
         let ctrl_text_pos = positions.get(control_index).copied().unwrap_or(0);
 
         // margin_left를 미리 계산 (text_pos=0 early return에도 사용)

--- a/src/renderer/layout/border_rendering.rs
+++ b/src/renderer/layout/border_rendering.rs
@@ -268,7 +268,7 @@ pub(crate) fn collect_cell_borders(
 /// 이중선/삼중선의 교차점 렌더링을 깔끔하게 처리한다.
 /// row_col_x: 행별 열 누적 위치 (셀별 독립 너비 지원)
 pub(crate) fn render_edge_borders(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     h_edges: &[Vec<Option<BorderLine>>],
     v_edges: &[Vec<Option<BorderLine>>],
     row_col_x: &[Vec<f64>],
@@ -385,7 +385,7 @@ pub(crate) fn render_edge_borders(
 /// 투명 테두리를 빨간색 점선 Line 노드로 생성한다.
 /// 엣지 그리드에서 None 슬롯(투명 테두리)을 찾아 연속 구간을 병합한다.
 pub(crate) fn render_transparent_borders(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     h_edges: &[Vec<Option<BorderLine>>],
     v_edges: &[Vec<Option<BorderLine>>],
     row_col_x: &[Vec<f64>],
@@ -478,7 +478,7 @@ pub(crate) fn render_transparent_borders(
 /// 테두리선 Line 노드 생성 (이중선/삼중선 지원)
 /// None 타입이면 빈 벡터 반환
 pub(crate) fn create_border_line_nodes(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     border: &BorderLine,
     x1: f64,
     y1: f64,
@@ -589,7 +589,7 @@ pub(crate) fn create_border_line_nodes(
 /// 평행선 노드 생성 (이중선/삼중선용)
 /// lines: &[(offset, width)] — offset은 선 중심의 수직 이동량
 fn create_parallel_lines(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     color: u32,
     x1: f64,
     y1: f64,
@@ -637,7 +637,7 @@ fn create_parallel_lines(
 
 /// 임의 방향 평행선 노드 생성 (대각선 이중선/삼중선용)
 fn create_parallel_lines_perpendicular(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     color: u32,
     x1: f64,
     y1: f64,
@@ -691,7 +691,7 @@ fn create_parallel_lines_perpendicular(
 
 /// 단일선 노드 생성
 fn create_single_line(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     color: u32,
     width: f64,
     dash: StrokeDash,
@@ -725,7 +725,7 @@ fn create_single_line(
 }
 
 fn create_editor_only_line(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     color: u32,
     width: f64,
     dash: StrokeDash,
@@ -765,7 +765,7 @@ fn border_line_type_from_code(code: u8) -> BorderLineType {
 }
 
 fn create_diagonal_line_nodes(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     line_type: BorderLineType,
     color: u32,
     width_index: u8,
@@ -865,7 +865,7 @@ fn create_diagonal_line_nodes(
 }
 
 fn create_crooked_diagonal_line_nodes(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     line_type: BorderLineType,
     color: u32,
     width_index: u8,
@@ -978,7 +978,7 @@ fn border_line_type_to_dash(lt: BorderLineType) -> Option<StrokeDash> {
 ///   bit 10: BackSlash 대각선 꺾은선
 ///   bit 13: 중심선
 pub(crate) fn render_cell_diagonal(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     border_style: &ResolvedBorderStyle,
     cell_x: f64,
     cell_y: f64,
@@ -1172,7 +1172,7 @@ mod tests {
 
     #[test]
     fn render_hwpx_vertical_center_line_as_horizontal_bar() {
-        let mut tree = PageRenderTree::new(0, 200.0, 100.0);
+        let mut tree = LayoutFrame::new(0, 200.0, 100.0);
         let nodes = render_cell_diagonal(
             &mut tree,
             &center_line_style(CenterLine::Vertical),
@@ -1193,7 +1193,7 @@ mod tests {
 
     #[test]
     fn render_hwpx_horizontal_center_line_as_vertical_bar() {
-        let mut tree = PageRenderTree::new(0, 200.0, 100.0);
+        let mut tree = LayoutFrame::new(0, 200.0, 100.0);
         let nodes = render_cell_diagonal(
             &mut tree,
             &center_line_style(CenterLine::Horizontal),
@@ -1213,7 +1213,7 @@ mod tests {
 
     #[test]
     fn render_cross_center_line_creates_vertical_and_horizontal_lines() {
-        let mut tree = PageRenderTree::new(0, 200.0, 100.0);
+        let mut tree = LayoutFrame::new(0, 200.0, 100.0);
         let nodes = render_cell_diagonal(
             &mut tree,
             &center_line_style(CenterLine::Cross),
@@ -1238,7 +1238,7 @@ mod tests {
 
     #[test]
     fn render_nonzero_diagonal_shape_codes_as_basic_x() {
-        let mut tree = PageRenderTree::new(0, 200.0, 100.0);
+        let mut tree = LayoutFrame::new(0, 200.0, 100.0);
         let nodes = render_cell_diagonal(
             &mut tree,
             &diagonal_style((0b111 << 2) | (0b111 << 5)),
@@ -1263,7 +1263,7 @@ mod tests {
 
     #[test]
     fn render_slash_crooked_with_backslash_as_bent_backslash() {
-        let mut tree = PageRenderTree::new(0, 200.0, 100.0);
+        let mut tree = LayoutFrame::new(0, 200.0, 100.0);
         let nodes = render_cell_diagonal(
             &mut tree,
             &diagonal_style((2 << 8) | (0b010 << 5)),
@@ -1293,7 +1293,7 @@ mod tests {
 
     #[test]
     fn render_thick_slim_diagonal_as_parallel_lines() {
-        let mut tree = PageRenderTree::new(0, 200.0, 100.0);
+        let mut tree = LayoutFrame::new(0, 200.0, 100.0);
         let mut style = diagonal_style(0b010 << 2);
         style.diagonal.diagonal_type = 10;
         style.diagonal.width = 13;

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -1165,7 +1165,7 @@ fn needs_word_distribution(
 fn collect_shape_marker_labels(show_ctrl: bool, para: Option<&Paragraph>) -> Vec<(usize, String)> {
     if show_ctrl {
         if let Some(ref pa) = para {
-            let ctrl_positions = crate::document_core::helpers::find_logical_control_positions(pa);
+            let ctrl_positions = pa.logical_control_positions();
             pa.controls
                 .iter()
                 .enumerate()
@@ -1214,7 +1214,7 @@ fn collect_shape_marker_labels(show_ctrl: bool, para: Option<&Paragraph>) -> Vec
 impl LayoutEngine {
     pub(crate) fn layout_inline_table_paragraph(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         col_node: &mut RenderNode,
         para: &Paragraph,
         composed: Option<&ComposedParagraph>,
@@ -1964,7 +1964,7 @@ impl LayoutEngine {
     /// 문단 전체를 레이아웃하여 단 노드에 추가
     pub(crate) fn layout_paragraph(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         col_node: &mut RenderNode,
         para: &Paragraph,
         composed: Option<&ComposedParagraph>,
@@ -2001,7 +2001,7 @@ impl LayoutEngine {
     /// 문단 일부를 레이아웃하여 단 노드에 추가
     pub(crate) fn layout_partial_paragraph(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         col_node: &mut RenderNode,
         para: &Paragraph,
         composed: Option<&ComposedParagraph>,
@@ -2111,7 +2111,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn place_unmatched_line_tac_pictures(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         line_node: &mut RenderNode,
         comp_line: &ComposedLine,
         para: Option<&Paragraph>,
@@ -2192,7 +2192,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn place_empty_line_tac_forms(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         line_node: &mut RenderNode,
         comp_line: &ComposedLine,
         para: Option<&Paragraph>,
@@ -2253,7 +2253,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn place_empty_line_inline_equations(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         line_node: &mut RenderNode,
         comp_line: &ComposedLine,
         composed: &ComposedParagraph,
@@ -2530,7 +2530,7 @@ impl LayoutEngine {
 
     pub(crate) fn layout_composed_paragraph(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         col_node: &mut RenderNode,
         composed: &ComposedParagraph,
         styles: &ResolvedStyleSet,
@@ -4319,7 +4319,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn emit_line_runs(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         line_node: &mut RenderNode,
         col_node: &mut RenderNode,
         comp_line: &crate::renderer::composer::ComposedLine,
@@ -5485,7 +5485,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_click_here_and_bookmark_markers(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         line_node: &mut RenderNode,
         p: &Paragraph,
         comp_line: &crate::renderer::composer::ComposedLine,
@@ -5739,7 +5739,7 @@ impl LayoutEngine {
 
         // 책갈피 조판부호 마커
         if ctrl_codes {
-            let ctrl_positions = crate::document_core::helpers::find_logical_control_positions(p);
+            let ctrl_positions = p.logical_control_positions();
             for (ci, ctrl) in p.controls.iter().enumerate() {
                 if let Control::Bookmark(_bm) = ctrl {
                     let char_pos = ctrl_positions.get(ci).copied().unwrap_or(0);
@@ -6133,7 +6133,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_empty_runs_line(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         line_node: &mut RenderNode,
         comp_line: &crate::renderer::composer::ComposedLine,
         composed: &ComposedParagraph,
@@ -6308,7 +6308,7 @@ impl LayoutEngine {
     /// 원본 문단 데이터로 레이아웃 (ComposedParagraph 없는 경우 fallback)
     pub(crate) fn layout_raw_paragraph(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         col_node: &mut RenderNode,
         para: &Paragraph,
         col_area: &LayoutRect,
@@ -6622,7 +6622,7 @@ pub(crate) fn calc_sibling_topandbottom_reserved_hu(
 /// `layout_picture_full` 가 본문/머리말/꼬리말 path 의 진입점 helper 인 것과 짝.
 #[allow(clippy::too_many_arguments)]
 fn make_picture_image_node(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     pic: &crate::model::image::Picture,
     section_index: usize,
     para_index: usize,

--- a/src/renderer/layout/picture_footnote.rs
+++ b/src/renderer/layout/picture_footnote.rs
@@ -56,7 +56,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_picture(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         parent_node: &mut RenderNode,
         picture: &crate::model::image::Picture,
         container: &LayoutRect,
@@ -93,7 +93,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_picture_full(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         parent_node: &mut RenderNode,
         picture: &crate::model::image::Picture,
         container: &LayoutRect,
@@ -389,7 +389,7 @@ impl LayoutEngine {
     /// 본문 그림(Picture) 개체를 레이아웃하고 업데이트된 y_offset을 반환한다.
     pub(crate) fn layout_body_picture(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         parent_node: &mut RenderNode,
         picture: &crate::model::image::Picture,
         container: &LayoutRect,
@@ -704,7 +704,7 @@ impl LayoutEngine {
     /// 캡션을 레이아웃한다.
     pub(crate) fn layout_caption(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         parent_node: &mut RenderNode,
         caption: &Caption,
         styles: &ResolvedStyleSet,
@@ -780,7 +780,7 @@ impl LayoutEngine {
 
     fn layout_caption_topbottom_pictures(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         parent_node: &mut RenderNode,
         para: &Paragraph,
         caption_area: &LayoutRect,
@@ -925,7 +925,7 @@ impl LayoutEngine {
     /// 각주 영역 레이아웃 (구분선 + 각주 문단들)
     pub(crate) fn layout_footnote_area(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         fn_node: &mut RenderNode,
         footnotes: &[FootnoteRef],
         paragraphs: &[Paragraph],
@@ -1080,7 +1080,7 @@ impl LayoutEngine {
     /// base_cs_id: 번호 스타일 결정용 기본 char_shape_id (문단의 char_shapes[0])
     pub(crate) fn layout_footnote_paragraph_with_number(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         parent: &mut RenderNode,
         composed: &ComposedParagraph,
         styles: &ResolvedStyleSet,
@@ -1225,7 +1225,7 @@ impl LayoutEngine {
     /// 마지막 TextLine의 마지막 TextRun 우측에 윗첨자 번호를 추가한다.
     pub(crate) fn add_footnote_superscripts(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         parent: &mut RenderNode,
         para: &Paragraph,
         _styles: &ResolvedStyleSet,
@@ -1241,8 +1241,8 @@ impl LayoutEngine {
         }
 
         // 각주/미주의 (번호, 텍스트 위치) 수집 — ComposedParagraph에서 미리 계산된 위치 사용
-        // 폴백: find_control_text_positions로 직접 계산
-        let ctrl_positions = crate::document_core::helpers::find_control_text_positions(para);
+        // 폴백: control_text_positions로 직접 계산
+        let ctrl_positions = para.control_text_positions();
         let mut footnotes: Vec<(String, usize)> = Vec::new();
         for (ci, ctrl) in para.controls.iter().enumerate() {
             let marker_text = match ctrl {
@@ -1553,7 +1553,7 @@ impl LayoutEngine {
     /// border_attr의 bit 0~5가 선 종류, border_width가 두께 (0이면 기본 0.1mm)
     pub(crate) fn render_picture_border(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         parent: &mut RenderNode,
         picture: &crate::model::image::Picture,
         x: f64,

--- a/src/renderer/layout/shape_layout.rs
+++ b/src/renderer/layout/shape_layout.rs
@@ -119,7 +119,7 @@ fn should_suppress_group_child_construction_stroke(drawing: &DrawingObjAttr) -> 
 }
 
 fn push_placeholder_render_node(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     parent: &mut RenderNode,
     bbox: BoundingBox,
     fill_color: u32,
@@ -140,7 +140,7 @@ fn push_placeholder_render_node(
 }
 
 fn push_ole_placeholder_render_node(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     parent: &mut RenderNode,
     bbox: BoundingBox,
     fill_color: u32,
@@ -167,7 +167,7 @@ fn push_ole_placeholder_render_node(
 }
 
 fn push_raw_svg_render_node(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     parent: &mut RenderNode,
     bbox: BoundingBox,
     svg: String,
@@ -182,7 +182,7 @@ fn push_raw_svg_render_node(
 }
 
 fn push_ole_raw_svg_render_node(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     parent: &mut RenderNode,
     bbox: BoundingBox,
     svg: String,
@@ -205,7 +205,7 @@ fn push_ole_raw_svg_render_node(
 }
 
 fn push_ole_empty_para_end_anchor(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     parent: &mut RenderNode,
     anchor_x: f64,
     anchor_y: f64,
@@ -441,7 +441,7 @@ fn reflow_matrix_textbox_para(
 impl LayoutEngine {
     fn push_hwpx_hmapsi_preview_clip_node(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         parent: &mut RenderNode,
         bbox: BoundingBox,
         cfb_data: &[u8],
@@ -454,10 +454,11 @@ impl LayoutEngine {
         {
             return false;
         }
-        let (page_width, page_height) = match &tree.root.node_type {
-            RenderNodeType::Page(page) if page.page_index == 0 => (page.width, page.height),
-            _ => return false,
-        };
+        // [#4277] 페이지 기하는 프레임에서 읽는다 — 페인트 root 를 거치지 않는다.
+        if tree.page_index() != 0 {
+            return false;
+        }
+        let (page_width, page_height) = tree.page_size();
         let preview = self.hwpx_page_preview.borrow();
         let Some(preview) = preview.as_ref() else {
             return false;
@@ -607,7 +608,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_shape(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         parent: &mut RenderNode,
         paragraphs: &[Paragraph],
         para_index: usize,
@@ -928,7 +929,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_group_child_affine(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         parent: &mut RenderNode,
         child: &crate::model::shape::ShapeObject,
         group_origin_x: f64,
@@ -1129,7 +1130,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_shape_object(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         parent: &mut RenderNode,
         shape: &crate::model::shape::ShapeObject,
         base_x: f64,
@@ -1173,7 +1174,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_shape_object_with_group_origin(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         parent: &mut RenderNode,
         shape: &crate::model::shape::ShapeObject,
         base_x: f64,
@@ -2178,7 +2179,7 @@ impl LayoutEngine {
     /// 도형의 이미지 채우기를 자식 이미지 노드로 추가한다.
     pub(crate) fn add_image_fill_node(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         parent: &mut RenderNode,
         drawing: &crate::model::shape::DrawingObjAttr,
         base_x: f64,
@@ -2265,7 +2266,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_textbox_content(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         shape_node: &mut RenderNode,
         drawing: &crate::model::shape::DrawingObjAttr,
         base_x: f64,
@@ -3116,7 +3117,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_vertical_textbox_text_with_paras(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         shape_node: &mut RenderNode,
         paragraphs: &[Paragraph],
         text_box: &crate::model::shape::TextBox,

--- a/src/renderer/layout/table_cell_content.rs
+++ b/src/renderer/layout/table_cell_content.rs
@@ -29,7 +29,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_vertical_cell_text(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         cell_node: &mut RenderNode,
         composed_paras: &[ComposedParagraph],
         paragraphs: &[Paragraph],
@@ -319,7 +319,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_cell_shape(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         cell_node: &mut RenderNode,
         shape: &crate::model::shape::ShapeObject,
         inner_area: &LayoutRect,
@@ -416,7 +416,7 @@ impl LayoutEngine {
     /// enclosing_ctx: (section_index, body_para_index, 상위 경로, 표의 컨트롤 인덱스)
     pub(crate) fn layout_embedded_table(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         parent: &mut RenderNode,
         table: &crate::model::table::Table,
         styles: &ResolvedStyleSet,

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -387,7 +387,7 @@ const NESTED_FRAGMENT_FRAME_INSET_EPSILON_PX: f64 = 0.05;
 const NESTED_FRAGMENT_FRAME_TARGET_EPSILON_PX: f64 = 0.05;
 
 fn push_fragment_border_line(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     table_node: &mut RenderNode,
     x1: f64,
     y1: f64,
@@ -462,7 +462,7 @@ fn reconstructs_clipped_fragment_bottom(table_node: &RenderNode) -> bool {
 /// frame was emitted (issue2007 p11/p14).  Prefer moving that exact source
 /// line inward; add a line only when the source did not retain one.
 fn ensure_fragment_horizontal_frame_inside_clip(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     table_node: &mut RenderNode,
     table_left: f64,
     table_right: f64,
@@ -753,7 +753,7 @@ fn suppress_future_nested_table_border_residue(node: &mut RenderNode, clip_botto
 /// this helper intentionally accepts the ancestor clip rather than requiring
 /// the table itself to own it (42065 p10-p14).
 fn reconstruct_nested_table_fragment_frame(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     table_node: &mut RenderNode,
     clip_top: f64,
     clip_bottom: f64,
@@ -891,7 +891,7 @@ fn reconstruct_nested_table_fragment_frame(
 /// repair first, while this pass reaches the real bordered table below an
 /// unbordered RowBreak wrapper.
 fn reconstruct_nested_table_descendant_fragment_frames(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     node: &mut RenderNode,
     clip_top: f64,
     clip_bottom: f64,
@@ -923,7 +923,7 @@ fn reconstruct_nested_table_descendant_fragment_frames(
 /// with current-page content, and the small source-spacer translation is
 /// limited to the direct siblings following a suppressed residual tail.
 fn repair_clipped_nested_table_fragment_frame(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     node: &mut RenderNode,
     suppress_bottom_text_residue: bool,
     repair_unclipped_hwpx_top_residue: bool,
@@ -1155,7 +1155,7 @@ fn repair_clipped_nested_table_fragment_frame(
 /// only delegates to the direct-child-table helper above, so it cannot widen a
 /// continuation's vertical viewport or reveal a future-page text tail.
 pub(super) fn extend_completed_nested_table_border_clips(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     node: &mut RenderNode,
     suppress_bottom_text_residue: bool,
     repair_unclipped_hwpx_top_residue: bool,
@@ -1284,7 +1284,7 @@ fn has_independent_col_row_y(col_row_y: &[Vec<f64>], row_y: &[f64]) -> bool {
 }
 
 fn render_cell_box_borders(
-    tree: &mut PageRenderTree,
+    tree: &mut LayoutFrame,
     bs: &ResolvedBorderStyle,
     x: f64,
     y: f64,
@@ -2006,7 +2006,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_table(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         col_node: &mut RenderNode,
         table: &crate::model::table::Table,
         section_index: usize,
@@ -3770,7 +3770,7 @@ impl LayoutEngine {
     /// 셀 배경 렌더링 (fill_color + pattern + gradient)
     pub(crate) fn render_cell_background(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         cell_node: &mut RenderNode,
         border_style: Option<&crate::renderer::style_resolver::ResolvedBorderStyle>,
         cell_x: f64,
@@ -4083,7 +4083,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_horizontal_cell_paragraphs(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         table_node: &mut RenderNode,
         cell_node: &mut RenderNode,
         cell: &crate::model::table::Cell,
@@ -5629,7 +5629,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_table_cells(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         table_node: &mut RenderNode,
         table: &crate::model::table::Table,
         section_index: usize,
@@ -5978,8 +5978,9 @@ impl LayoutEngine {
             // viewport를 포함한 채 호출될 수 있다. 렌더 트리의 page bbox는 실제
             // SVG/Canvas clip이므로, 그 밖으로 나간 셀은 그 logical viewport 안에
             // 있더라도 Center/Bottom 기준으로 배치하면 안 된다.
-            let page_view_top = tree.root.bbox.y;
-            let page_view_bottom = tree.root.bbox.y + tree.root.bbox.height;
+            let page_bbox = tree.page_bbox();
+            let page_view_top = page_bbox.y;
+            let page_view_bottom = page_bbox.y + page_bbox.height;
             let cell_intersects_page_viewport =
                 cell_y < page_view_bottom - 0.5 && cell_y + cell_h > page_view_top + 0.5;
             let cell_clipped_by_page_viewport = depth > 0

--- a/src/renderer/layout/table_partial.rs
+++ b/src/renderer/layout/table_partial.rs
@@ -715,7 +715,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_partial_table_cells(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         table_node: &mut RenderNode,
         table: &crate::model::table::Table,
         para_index: usize,
@@ -2497,7 +2497,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_partial_table(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         col_node: &mut RenderNode,
         paragraphs: &[Paragraph],
         para_index: usize,
@@ -2588,7 +2588,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_partial_table_resolved(
         &self,
-        tree: &mut PageRenderTree,
+        tree: &mut LayoutFrame,
         col_node: &mut RenderNode,
         outer_table: &crate::model::table::Table,
         host: PartialTableHostContext<'_>,

--- a/src/renderer/render_tree.rs
+++ b/src/renderer/render_tree.rs
@@ -1318,64 +1318,48 @@ pub struct EquationNode {
 /// 튜플 목록. 섹션 단위(셀 외부)는 빈 Vec.
 pub type InlineShapeKey = (usize, usize, usize, Vec<(usize, usize, usize)>);
 
-/// 한 페이지의 렌더 트리
-#[derive(Debug, Clone, Serialize)]
-pub struct PageRenderTree {
-    /// 루트 노드
-    pub root: RenderNode,
+/// 레이아웃 재귀가 들고 다니는 흐름 상태 (paint 출력 아님).
+///
+/// [#4277] 레이아웃 재귀는 `PageRenderTree` 를 **출력**으로 쓰지 않는다 — 노드는 호출자가
+/// 넘긴 `col_node` 에 붙고, 트리에서 실제로 쓰이던 건 id 카운터와 인라인 Shape 좌표
+/// 레지스트리(둘 다 `#[serde(skip)]`, 즉 직렬화되는 산출물이 아님)뿐이었다. 그 둘을 여기로
+/// 분리해, 높이만 필요한 측정 호출부가 paint 트리를 만들지 않고도 재귀에 진입할 수 있게 한다.
+#[derive(Debug, Clone)]
+pub struct LayoutFrame {
     /// 다음 노드 ID 카운터
-    #[serde(skip)]
     next_id: NodeId,
     /// 인라인 Shape 좌표 맵: (section, para, control, cell_path) → (x, y)
-    #[serde(skip)]
     inline_shape_positions: std::collections::HashMap<InlineShapeKey, (f64, f64)>,
+    /// 페이지 인덱스. 재귀가 페인트 root 의 `PageNode` 에서 읽던 값 (#4277).
+    page_index: u32,
+    /// 페이지 bbox. 재귀가 페인트 root 의 bbox 에서 읽던 값 — 레이아웃 도중 불변이다.
+    page_bbox: BoundingBox,
 }
 
-/// `clip_overlapping_same_bin_images` 전용 대략적 replay plane 분류.
-///
-/// `src/paint/replay_order.rs` (`paint_op_replay_plane_with_layer`,
-/// `cap_master_page_plane`) 가 실제 페인트 backend 에서 적용하는 재생 순서는
-/// Background → BehindText → Flow → InFrontOfText 로, **트리 순서와 무관하게
-/// plane 별로 별도 재생**된다. 즉 트리 순서상 `BehindText` 개체가 `Flow`
-/// 개체보다 뒤에 있어도 실제로는 `BehindText` 가 먼저(더 아래에) 그려진다.
-/// clip 함수는 "트리 순서 = z 순서(먼저 그려짐 = 아래)"를 가정하므로, plane
-/// 이 다른 페어는 이 가정이 성립하지 않아 clip 방향을 잘못 판단할 수 있다
-/// (아래에 깔릴 그림이 아니라 위에 그려질 그림이 잘리는 역방향 clip).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ClipReplayPlane {
-    BehindText,
-    Flow,
-    InFrontOfText,
-}
-
-impl ClipReplayPlane {
-    fn from_text_wrap(wrap: Option<TextWrap>) -> Self {
-        match wrap {
-            Some(TextWrap::BehindText) => Self::BehindText,
-            Some(TextWrap::InFrontOfText) => Self::InFrontOfText,
-            _ => Self::Flow,
-        }
-    }
-}
-
-impl PageRenderTree {
-    /// 새 페이지 렌더 트리 생성
+impl LayoutFrame {
+    /// 새 흐름 상태. id 는 root(0) 다음부터 발급한다.
     pub fn new(page_index: u32, width: f64, height: f64) -> Self {
-        let root = RenderNode::new(
-            0,
-            RenderNodeType::Page(PageNode {
-                page_index,
-                width,
-                height,
-                section_index: 0,
-            }),
-            BoundingBox::new(0.0, 0.0, width, height),
-        );
         Self {
-            root,
             next_id: 1,
             inline_shape_positions: std::collections::HashMap::new(),
+            page_index,
+            page_bbox: BoundingBox::new(0.0, 0.0, width, height),
         }
+    }
+
+    /// 페이지 인덱스
+    pub fn page_index(&self) -> u32 {
+        self.page_index
+    }
+
+    /// 페이지 bbox (실제 clip 기준)
+    pub fn page_bbox(&self) -> BoundingBox {
+        self.page_bbox
+    }
+
+    /// 페이지 폭/높이
+    pub fn page_size(&self) -> (f64, f64) {
+        (self.page_bbox.width, self.page_bbox.height)
     }
 
     /// `CellContext` 를 InlineShapeKey 의 cell_path 부분으로 변환.
@@ -1439,6 +1423,109 @@ impl PageRenderTree {
         let id = self.next_id;
         self.next_id += 1;
         id
+    }
+}
+
+/// 한 페이지의 렌더 트리
+#[derive(Debug, Clone, Serialize)]
+pub struct PageRenderTree {
+    /// 루트 노드
+    pub root: RenderNode,
+    /// 레이아웃 흐름 상태 (id 카운터 + 인라인 Shape 레지스트리). 직렬화 대상 아님.
+    #[serde(skip)]
+    pub(crate) frame: LayoutFrame,
+}
+
+/// `clip_overlapping_same_bin_images` 전용 대략적 replay plane 분류.
+///
+/// `src/paint/replay_order.rs` (`paint_op_replay_plane_with_layer`,
+/// `cap_master_page_plane`) 가 실제 페인트 backend 에서 적용하는 재생 순서는
+/// Background → BehindText → Flow → InFrontOfText 로, **트리 순서와 무관하게
+/// plane 별로 별도 재생**된다. 즉 트리 순서상 `BehindText` 개체가 `Flow`
+/// 개체보다 뒤에 있어도 실제로는 `BehindText` 가 먼저(더 아래에) 그려진다.
+/// clip 함수는 "트리 순서 = z 순서(먼저 그려짐 = 아래)"를 가정하므로, plane
+/// 이 다른 페어는 이 가정이 성립하지 않아 clip 방향을 잘못 판단할 수 있다
+/// (아래에 깔릴 그림이 아니라 위에 그려질 그림이 잘리는 역방향 clip).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClipReplayPlane {
+    BehindText,
+    Flow,
+    InFrontOfText,
+}
+
+impl ClipReplayPlane {
+    fn from_text_wrap(wrap: Option<TextWrap>) -> Self {
+        match wrap {
+            Some(TextWrap::BehindText) => Self::BehindText,
+            Some(TextWrap::InFrontOfText) => Self::InFrontOfText,
+            _ => Self::Flow,
+        }
+    }
+}
+
+impl PageRenderTree {
+    /// 새 페이지 렌더 트리 생성
+    pub fn new(page_index: u32, width: f64, height: f64) -> Self {
+        let root = RenderNode::new(
+            0,
+            RenderNodeType::Page(PageNode {
+                page_index,
+                width,
+                height,
+                section_index: 0,
+            }),
+            BoundingBox::new(0.0, 0.0, width, height),
+        );
+        Self {
+            root,
+            frame: LayoutFrame::new(page_index, width, height),
+        }
+    }
+
+    /// 레이아웃 흐름 상태 가변 참조 — 재귀 진입 시 `&mut tree.frame` 으로 넘긴다.
+    pub(crate) fn frame_mut(&mut self) -> &mut LayoutFrame {
+        &mut self.frame
+    }
+
+    /// 인라인 Shape 좌표 등록 (셀 컨텍스트 포함).
+    /// [Task #1151 v4] 셀 안인 경우 InlineShapeKey 의 para 는 호출자가 전달한
+    /// cell paragraph idx 가 아닌 **outer paragraph idx** (`cell_ctx.parent_para_index`)
+    /// 로 정규화한다. cursor_rect 의 hit-test 가 `section.paragraphs.get(pi)` 로
+    /// outer paragraph 에서 table → cell → cell paragraph 경로로 resolve 하기 위해
+    /// 정합 필요.
+    pub fn set_inline_shape_position(
+        &mut self,
+        sec: usize,
+        para: usize,
+        ctrl: usize,
+        cell_ctx: Option<&crate::renderer::layout::CellContext>,
+        x: f64,
+        y: f64,
+    ) {
+        self.frame
+            .set_inline_shape_position(sec, para, ctrl, cell_ctx, x, y);
+    }
+
+    /// 인라인 Shape 좌표 조회 (셀 컨텍스트 포함). `LayoutFrame` 위임.
+    pub fn get_inline_shape_position(
+        &self,
+        sec: usize,
+        para: usize,
+        ctrl: usize,
+        cell_ctx: Option<&crate::renderer::layout::CellContext>,
+    ) -> Option<(f64, f64)> {
+        self.frame
+            .get_inline_shape_position(sec, para, ctrl, cell_ctx)
+    }
+
+    /// 인라인 Shape 좌표 전체 참조 (hitTest용)
+    pub fn inline_shape_positions(&self) -> &std::collections::HashMap<InlineShapeKey, (f64, f64)> {
+        self.frame.inline_shape_positions()
+    }
+
+    /// 새 노드 ID 할당
+    pub fn next_id(&mut self) -> NodeId {
+        self.frame.next_id()
     }
 
     /// dirty 노드 존재 여부

--- a/src/renderer/render_tree.rs
+++ b/src/renderer/render_tree.rs
@@ -1324,6 +1324,21 @@ pub type InlineShapeKey = (usize, usize, usize, Vec<(usize, usize, usize)>);
 /// 넘긴 `col_node` 에 붙고, 트리에서 실제로 쓰이던 건 id 카운터와 인라인 Shape 좌표
 /// 레지스트리(둘 다 `#[serde(skip)]`, 즉 직렬화되는 산출물이 아님)뿐이었다. 그 둘을 여기로
 /// 분리해, 높이만 필요한 측정 호출부가 paint 트리를 만들지 않고도 재귀에 진입할 수 있게 한다.
+///
+/// # 불변식 — 페이지 기하는 `PageRenderTree.root` 와 반드시 일치해야 한다
+///
+/// `page_index`/`page_bbox` 는 재귀가 예전에 `root.node_type` 의 `PageNode` 와 `root.bbox`
+/// 에서 직접 읽던 값의 사본이다. `PageRenderTree::new` 가 프레임을 같은 인자로 만들므로
+/// 생성 시점에는 항상 일치하고, 레이아웃 도중에는 양쪽 다 변경되지 않는다.
+///
+/// **두 곳을 갈라놓지 말 것.** `root.bbox`/`root.node_type` 를 나중에 바꾸면서 프레임을
+/// 갱신하지 않으면 `page_bbox()`/`page_size()` 가 조용히 낡은 값을 준다. 실제로
+/// `svg_layer.rs` 의 layer→render 변환은 `root.bbox` 만 덮어쓰는데, 그 트리는 레이아웃
+/// 재귀에 들어가지 않으므로 오늘은 무해하다 — 그 전제가 깨지면 이 불변식도 깨진다.
+///
+/// 또한 프레임은 **항상 하나의 페이지를 나타낸다**. 종전 코드가 `root` 가 `PageNode` 인지
+/// 런타임에 확인하던 자리(`shape_layout.rs` 의 hmapsi 미리보기 게이트)는, 프레임이 페이지
+/// 기하 없이는 생성될 수 없다는 이 구성 불변식으로 대체됐다.
 #[derive(Debug, Clone)]
 pub struct LayoutFrame {
     /// 다음 노드 ID 카운터

--- a/src/renderer/svg_layer.rs
+++ b/src/renderer/svg_layer.rs
@@ -35,7 +35,7 @@ impl SvgLayerRenderer {
         &self.renderer
     }
 
-    fn build_render_tree(&mut self, tree: &PageLayerTree) -> PageRenderTree {
+    fn render_tree_from_layer_tree(&mut self, tree: &PageLayerTree) -> PageRenderTree {
         let mut render_tree = PageRenderTree::new(0, tree.page_width, tree.page_height);
         render_tree.root.bbox = tree.root.bounds;
         render_tree.root.children = self.expand_children(&tree.root);
@@ -243,7 +243,7 @@ impl LayerRenderer for SvgLayerRenderer {
         self.renderer.debug_overlay = tree.output_options.debug_overlay;
         self.renderer.show_missing_picture_placeholder = tree.profile.shows_editor_visuals();
         self.renderer.show_editor_only_nodes = tree.profile.shows_editor_visuals();
-        let render_tree = self.build_render_tree(tree);
+        let render_tree = self.render_tree_from_layer_tree(tree);
         self.renderer.render_tree(&render_tree);
         Ok(())
     }

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -13509,7 +13509,7 @@ impl TypesetEngine {
     ) -> f64 {
         use crate::renderer::layout::{layout_rect_to_bbox, LayoutEngine};
         use crate::renderer::page_layout::LayoutRect;
-        use crate::renderer::render_tree::{PageRenderTree, RenderNode, RenderNodeType};
+        use crate::renderer::render_tree::{LayoutFrame, RenderNode, RenderNodeType};
 
         // 렌더 `layout_column_item` 의 FullParagraph 텍스트 경로 정합(layout.rs has_real_text):
         // 실제 텍스트가 있는 para 는 **leading 컨트롤-전용 줄**(수식 객체마커 ￼ 등)을 건너뛰고
@@ -13550,16 +13550,20 @@ impl TypesetEngine {
             width: en_col_w,
             height,
         };
+        // [#4277] 페이지네이션 측정은 paint 트리를 만들지 않는다 — 레이아웃 재귀가 실제로
+        // 쓰는 건 흐름 상태(id 카운터 + 인라인 Shape 레지스트리 + 페이지 기하)뿐이므로
+        // `LayoutFrame` 만 만든다. `col_node` 는 방출된 노드를 받는 sink 로만 쓰이고
+        // 높이만 읽은 뒤 버려진다.
         let scratch = LayoutEngine::new(self.dpi);
-        let mut tree = PageRenderTree::new(0, en_col_w, height);
-        let col_id = tree.next_id();
+        let mut frame = LayoutFrame::new(0, en_col_w, height);
+        let col_id = frame.next_id();
         let mut col_node = RenderNode::new(
             col_id,
             RenderNodeType::Column(0),
             layout_rect_to_bbox(&col_area),
         );
         let y_after = scratch.layout_partial_paragraph(
-            &mut tree,
+            &mut frame,
             &mut col_node,
             item_para,
             Some(item_composed),


### PR DESCRIPTION
## 무엇을

레이아웃 재귀가 페인트 트리(`PageRenderTree`)에 결합돼 있던 것을 끊고(#4277 일부), 계측으로
확인된 미사용 함수 4건을 제거한다(#4273).

## 1. 레이아웃 재귀의 페인트 트리 결합 분리 — Part of #4277

`PageRenderTree` 는 직렬화 산출물(`root`)과 흐름 상태(`#[serde(skip)]` 인 `next_id`,
`inline_shape_positions`)를 겸하고 있었다. 레이아웃 재귀가 `tree` 로 실제 호출하는 건
`next_id()` 125회 + `set/get_inline_shape_position()` 21회 뿐이고 `tree.root` 는 건드리지
않는다 — 노드는 인자로 받은 `col_node` 에 붙는다. 재귀의 `&mut PageRenderTree` 는 처음부터
프레임이었다.

- `LayoutFrame` 분리. `PageRenderTree` 는 `root` + `frame` 만 갖고 기존 public 메서드는
  위임하므로 외부 호출부는 무변경.
- 재귀 시그니처 89개 → `&mut LayoutFrame`. root 에 직접 부착하는 페이지 조립 계층 7개는
  `PageRenderTree` 유지.
- 재귀가 페인트 root 에서 페이지 기하를 읽던 2곳을 프레임에서 읽도록 정리
  (`shape_layout.rs` PageNode width/height, `table_layout.rs` page viewport bbox).
  root 가 레이아웃 도중 불변임을 확인한 뒤 미러링했다.
- 측정 경로 scratch `PageRenderTree` 3곳 제거 (`measure_endnote_para_advance`,
  `measure_endnote_column_bottom`, `cursor_rect.rs` 캐럿 프로브). production 에서
  `PageRenderTree::new` 는 `build_render_tree` 한 곳뿐이다.

**성능 이득은 없다 — 구조 변경이다.** #4277 에 기록한 실측대로 `measure_endnote_para_advance`
는 기본 설정에서 호출 0회다(`en_ssot_level()` 기본 `B` < 게이트 `A3`). 안 불리는 코드의
낭비는 낭비가 아니므로, 성능이 아니라 경계 정리로만 평가해 주기 바란다.

**완전 격리는 아니다.** `RenderNode` 는 여전히 재귀를 관통한다(시그니처 70개, production
`RenderNode::new` 130회). 방출된 노드가 되읽히는 지점도 있어(`shape_layout.rs` 의
`children.is_empty()` 가 도형 크기 확장을 게이트하는 등) 노드 방출을 sink 로 추상화하려면
그 지점들의 재표현이 선행돼야 한다 — #4279 범위로 남긴다.

곁들여 정리한 것:

- `find_control_text_positions`/`find_logical_control_positions` 를 `Paragraph` 메서드로
  이관하고 renderer production 호출부 6곳을 직접 호출로 전환 — renderer → document_core
  역참조가 production 기준 0이 된다. `document_core::helpers` 는 기존 경로 유지를 위한 얇은
  위임으로 남긴다.
- `reflow_line_segs` 독스트링이 커밋 82f817b112 에서 무관한 헬퍼 위로 밀려나 있던 것 복구,
  읽히지 않는 지역변수 `has_valid_orig` 제거.
- `svg_layer` private `build_render_tree` → `render_tree_from_layer_tree` 이름 변경
  (`LayoutEngine::build_render_tree` 와 충돌 해소).

## 2. 미사용 함수 제거 — Closes #4273

정의부 외 참조가 0인 4건: `is_header_footer_hidden`, `get_table_cell_bboxes_native`,
`get_active_hf_apply_to`(private), `requires_include_fields`. 제거 후 연쇄 고아를 확인해
`hidden_header_footer` 필드, `get_active_hf_info`, `Scope::label` 은 살아있는 호출부가 있어
유지했다.

## 로컬 검증 (`local_validation.md` 4.3 renderer 범위 전 게이트, rebase 후 재실행)

- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets` 무경고
- `cargo nextest run --cargo-profile release-test --tests` — **5486/5486 pass** (35 skip)
- `wasm-pack build --target web` 성공
- Native Skia 3종: `skia --lib` 58 pass, `issue_2225_missing_picture_placeholder` 2 pass,
  `render_p37_direct_pdf_export` 4 pass

Part of #4277
Closes #4273


---

## 적대 리뷰 결과 (독립 에이전트 3인, gestell/maintenance.md 적용)

### 근거와 함께 clear 된 것

- **페이지 기하 미러링 안전성**: `root.bbox`/`root.node_type` 에 대한 crate 전체 쓰기를
  전수 확인 — `paint/builder.rs`, `svg_layer.rs` 의 해당 쓰기는 전부 `#[cfg(test)]` 이거나
  레이아웃 재귀에 들어가지 않는 새 트리 대상. `root` 를 교체하는 경로 없음. 독립
  `LayoutFrame::new` 3곳은 종전 `PageRenderTree::new` 와 **동일 인자**를 쓰며, 두 읽기
  지점의 값은 비트 단위로 같다.
- **`frame_mut()` aliasing**: 12개 호출부 전부 `tree.root` 파생이 아닌 지역 `RenderNode`
  를 넘긴다. 유일한 재구성(`layout.rs` border-line 블록)도 호출→push 순서를 보존한다.
- **잃은 접근 없음**: 종전 converted 파일의 `tree.root` 사용은 12× `root.children.push`
  (전부 유지된 7개 함수) + 기하 읽기 2곳이 전부.
- **죽은 코드 제거**: `bindings/{Native,csharp,node,python,swift}`, `main.rs`, `wasm_api`,
  tests 를 snake/camel 양쪽으로 전수 grep — 코드 참조 0. `stringify!`/`paste!`/문자열
  디스패치로 도달하는 경로도 없음.

### 지적을 받아 이 PR 에서 고친 것 (커밋 `b3e75f33a`)

- `is_logical_inline_control` 이 `document_core::helpers` 와 이 시리즈가 새로 만든
  `Paragraph::logical_control_positions` 에 두 벌로 갈라져 있었다 — 이 PR 이 다른 곳에서
  내세운 "함께 바뀌면 함께 둔다"를 스스로 어긴 것이라 `Control::is_logical_inline` 으로
  model 에 통합하고 helpers 는 위임만 하게 했다(기존 호출부 17곳 무변경).
- `LayoutFrame` 의 페이지 기하가 `PageRenderTree.root` 의 사본이라는 **불변식을 타입
  문서로 명시**했다. 종전 `shape_layout.rs` 의 "root 가 PageNode 인가" 런타임 검사가
  구성 불변식으로 대체된 사정과, `svg_layer.rs` 가 `root.bbox` 만 덮어쓰는 경로가 오늘
  무해한 이유도 함께 적었다.

### 정직하게 남기는 것

- **커밋 내용과 메시지가 어긋난다.** `get_active_hf_apply_to` 삭제는 `#4273` 커밋
  (`6bc516a70`) 이 아니라 `#4277` 커밋(`4630fd6cc`) 에 들어 있다. 또 `4630fd6cc` 에는
  `#4277` 범위가 아닌 것들(`Paragraph::logical_control_positions` 이관, 죽은 지역변수
  제거, 독스트링 위치 복구)이 함께 있다. 이미 검증·push 된 브랜치라 history 수술 대신
  여기에 기록으로 남긴다 — 리뷰 시 커밋 경계가 아니라 이 설명을 기준으로 봐 주기 바란다.
- **`LayoutFrame` 은 응집된 aggregate 가 아니다.** 세 필드의 수명주기가 서로 다르다:
  `next_id` 는 패스 종료 시 폐기, `inline_shape_positions` 는 레이아웃 후 hit-test 가
  계속 조회, `page_index`/`page_bbox` 는 아예 불변 입력이다. 경계 격리도 양방향 모두
  실패한다 — `render_tree.rs` 가 `renderer::layout::CellContext` 를 import 하고,
  converted 시그니처 67개 이상이 여전히 `&mut RenderNode` 를 받는다. 이 PR 이 끊은 건
  `PageRenderTree` 결합뿐이고 더 큰 `RenderNode` 결합은 남아 있다(#4279).

### 재검증 (리뷰 수정 반영 후)

`cargo fmt --check` clean · `cargo clippy --workspace --all-targets` 무경고 ·
**`cargo nextest --cargo-profile release-test` 5499/5499 pass**
