### PR TITLE
docs(readme): #4331 설치 절 신설 — 릴리스 바이너리 도달 1줄 (존재하는 배포물을 문서에 잇는다)

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ if plan.check().ok:
 ```bash
 tar xzf rhwp-v*-linux-x86_64.tar.gz          # windows 는 zip 해제
 sha256sum -c SHA256SUMS.txt --ignore-missing # 무결성 확인 (선택)
-./rhwp capabilities                          # 첫 확인 — 전 명령 기계 계약 자기서술
+./rhwp/rhwp capabilities                     # 첫 확인 — 전 명령 기계 계약 자기서술
 ```
 
 PATH 에 두면 아래 MCP 절의 `"command": "rhwp"` 와 파이썬 절의 `RHWP_BIN` 이

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ document.getElementById('viewer').innerHTML = doc.renderPageSvg(0);
 
 ```bash
 pip install -e bindings/python      # PyPI 배포 전
-export RHWP_BIN=$(pwd)/target/release/rhwp
+export RHWP_BIN=$(pwd)/target/release/rhwp   # 또는 릴리스 바이너리 경로 (아래 "설치" 절 — 소스 빌드 불필요)
 ```
 
 ```python
@@ -221,6 +221,22 @@ if plan.check().ok:
 [요리책](bindings/python/docs/COOKBOOK.md) ·
 [문제 해결](bindings/python/docs/TROUBLESHOOTING.md) ·
 [이주 가이드](bindings/python/docs/MIGRATION.md)
+
+## 설치 — 빌드 없이 CLI·MCP 쓰기
+
+빌드 도구 없이 CLI(그리고 아래 MCP 서버)를 바로 쓰려면
+[Releases](https://github.com/edwardkim/rhwp/releases/latest)에서 플랫폼 바이너리를
+받으세요 — 매 릴리스에 linux x86_64 · macOS(x86_64/aarch64) · windows x86_64
+4종과 무결성 검증용 `SHA256SUMS.txt` 가 첨부됩니다.
+
+```bash
+tar xzf rhwp-v*-linux-x86_64.tar.gz          # windows 는 zip 해제
+sha256sum -c SHA256SUMS.txt --ignore-missing # 무결성 확인 (선택)
+./rhwp capabilities                          # 첫 확인 — 전 명령 기계 계약 자기서술
+```
+
+PATH 에 두면 아래 MCP 절의 `"command": "rhwp"` 와 파이썬 절의 `RHWP_BIN` 이
+그대로 동작합니다. 설치 관리자 등재(winget·scoop·brew)는 로드맵에서 추적합니다.
 
 ## Quick Start (소스 빌드)
 
@@ -269,6 +285,9 @@ MCP 호스트가 HWP/HWPX 를 읽고·검색하고·채우고·변환한다:
 // .mcp.json
 { "mcpServers": { "rhwp": { "command": "rhwp", "args": ["mcp-serve"] } } }
 ```
+
+`rhwp` 실행 파일은 위 "설치" 절의 릴리스 바이너리면 충분하다 — 소스 빌드 없이
+바로 동작한다.
 
 첫 호출 3종 (조사 → 위치 → 채움):
 

--- a/mydocs/pr/pr_4332_review.md
+++ b/mydocs/pr/pr_4332_review.md
@@ -16,7 +16,7 @@ last_verified: 2026-08-10
 | 원 PR head | `5237006d60b9f136383ae1279336df2c194712a6` |
 | 기준 devel | `e48fe86947fbf9a44b1b98c7037150751af541ab` |
 | 가시성 브랜치 | `review/kevin9327-20260810-pr4332` |
-| 원 변경 규모 | `README.md` 1파일, contributor 커밋 1개 |
+| 원 변경 규모 | `README.md`, `mydocs/working/task_m100_4331_stage1.md` 2파일, `+52/-1`, contributor 커밋 1개 |
 
 원 변경은 릴리스 아카이브 다운로드와 첫 실행 예제를 루트 README에 추가한다. 실행 코드,
 renderer, fixture, baseline은 바꾸지 않으므로 visual sweep 대상은 아니다.

--- a/mydocs/pr/pr_4332_review.md
+++ b/mydocs/pr/pr_4332_review.md
@@ -1,0 +1,51 @@
+---
+kind: pr_review
+status: active
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-10
+---
+
+# PR #4332 검토 — 릴리스 바이너리 설치 진입점
+
+## 메타데이터와 범위
+
+| 항목 | 값 |
+| --- | --- |
+| 원 PR / 작성자 | [#4332](https://github.com/edwardkim/rhwp/pull/4332) / @kevin9327 |
+| base | `devel` |
+| 원 PR head | `5237006d60b9f136383ae1279336df2c194712a6` |
+| 기준 devel | `e48fe86947fbf9a44b1b98c7037150751af541ab` |
+| 가시성 브랜치 | `review/kevin9327-20260810-pr4332` |
+| 원 변경 규모 | `README.md` 1파일, contributor 커밋 1개 |
+
+원 변경은 릴리스 아카이브 다운로드와 첫 실행 예제를 루트 README에 추가한다. 실행 코드,
+renderer, fixture, baseline은 바꾸지 않으므로 visual sweep 대상은 아니다.
+
+## 발견한 차단 결함과 메인터너 보정
+
+`.github/workflows/release-binary.yml`은 `dist/rhwp` 디렉터리 자체를 tar/zip에 넣는다. 따라서
+압축 해제 뒤 최상위 `rhwp`는 실행 파일이 아니라 디렉터리다. 원 예제의
+`./rhwp capabilities`는 POSIX에서 디렉터리를 실행하려 해 실패한다.
+
+메인터너 보정은 실제 아카이브 구조에 맞춰 첫 실행 경로를 `./rhwp/rhwp capabilities`로
+수정한다. contributor 커밋은 rewrite하지 않고 원 head 뒤의 single-parent 후속 커밋으로
+추가한다.
+
+## 완료한 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| 릴리스 workflow의 POSIX 패키징 명령 대조 | `tar ... -C dist rhwp`로 최상위 `rhwp/` 확인 |
+| Windows 패키징 명령 대조 | `Compress-Archive -Path dist/rhwp` 확인 |
+| README 명령 경로 계약 검사 | 압축 해제 뒤 `rhwp/rhwp`를 실행하도록 확인 |
+| Markdown 상대 링크 검사 | 변경 README와 review 문서 통과 |
+| `git diff --check origin/pr/4332..HEAD` | 통과 |
+| 시각·Cargo 검증 | 생략. 문서 명령 한 줄과 review 기록만 변경 |
+
+## 리스크와 권고
+
+- 실제 GitHub release 자산을 내려받는 네트워크 E2E는 로컬에서 실행하지 않았다.
+- push 뒤 최신 head의 required checks와 mergeability를 다시 확인한다.
+- merge는 작업지시자의 별도 승인 전에는 수행하지 않는다.
+
+**최신 head CI 통과와 실제 release 자산 구조 재확인 후 조건부 merge 권고.**

--- a/mydocs/pr/pr_4332_review_impl.md
+++ b/mydocs/pr/pr_4332_review_impl.md
@@ -1,0 +1,29 @@
+---
+kind: pr_review_impl
+status: active
+canonical: mydocs/pr/pr_4332_review.md
+last_verified: 2026-08-10
+---
+
+# PR #4332 메인터너 보정 실행 기록
+
+## 커밋 경계
+
+| 구분 | SHA / 내용 |
+| --- | --- |
+| contributor source | `5237006d60b9f136383ae1279336df2c194712a6` |
+| maintainer docs correction | 이 문서, review 기록, README 실행 경로 보정 커밋 |
+
+## 단계
+
+1. 원 PR head와 실제 release workflow의 tar/zip 구조를 대조했다.
+2. README의 첫 실행 경로만 실제 압축 해제 구조와 일치하도록 보정했다.
+3. 대상 Markdown 링크와 whitespace를 검사한다.
+4. push 직전 source SHA, LFS 비대상, dry-run을 재확인한다.
+5. push 뒤 required checks와 mergeability를 확인한다.
+6. merge는 작업지시자의 별도 승인 전에는 수행하지 않는다.
+
+## rollback
+
+문제가 생기면 이 trailing 메인터너 커밋만 revert한다. contributor commit은 amend, rebase 또는
+force-push하지 않는다.

--- a/mydocs/pr/pr_4332_review_impl.md
+++ b/mydocs/pr/pr_4332_review_impl.md
@@ -12,7 +12,9 @@ last_verified: 2026-08-10
 | 구분 | SHA / 내용 |
 | --- | --- |
 | contributor source | `5237006d60b9f136383ae1279336df2c194712a6` |
-| maintainer docs correction | 이 문서, review 기록, README 실행 경로 보정 커밋 |
+| maintainer docs correction | `c89eeb7f` — README 실행 경로와 최초 review 기록 |
+| maintainer review follow-up | `b1ba5071` — 원 contributor 변경 규모 정정 |
+| maintainer record closure | 이 문서의 trailing 기록 정합 커밋 |
 
 ## 단계
 
@@ -25,5 +27,5 @@ last_verified: 2026-08-10
 
 ## rollback
 
-문제가 생기면 이 trailing 메인터너 커밋만 revert한다. contributor commit은 amend, rebase 또는
-force-push하지 않는다.
+문제가 생기면 record closure, `b1ba5071`, `c89eeb7f`를 역순 revert한다. contributor commit은
+amend, rebase 또는 force-push하지 않는다.

--- a/mydocs/working/task_m100_4331_stage1.md
+++ b/mydocs/working/task_m100_4331_stage1.md
@@ -1,0 +1,32 @@
+# Task M100 #4331 Stage 1 — 루트 README 릴리스 바이너리 도달 경로 신설
+
+- 이슈: [#4331](https://github.com/edwardkim/rhwp/issues/4331)
+- 기준 브랜치: `upstream/devel`
+- 작업 브랜치: `task_m100_4331`
+- 작성일: 2026-08-09 KST
+- 상태: 문서 전용, 검증 완료
+
+## 배경 (실측)
+
+#4327 §4: `release-binary.yml`(#612)이 매 릴리스에 4플랫폼 바이너리+SHA256SUMS 를
+첨부 중(v0.8.2 다운로드 1,300+)인데, 루트 README 설치 안내는 npm(웹 축)·소스
+빌드·docker 뿐이라 Releases 로 가는 경로가 문서에 없었다. MCP 절 `"command":
+"rhwp"` 와 파이썬 절 `RHWP_BIN` 이 전제하는 실행 파일 획득 경로가 소스 빌드로만
+이어지는 상태. 트랙 D R38 문서(PR #4328 갱신)가 이 조각을 "채널 등재와 독립적인
+선행 조각"으로 분리 명시했다.
+
+## 변경 (README.md 3곳, 최소 범위)
+
+1. "Quick Start (소스 빌드)" 앞에 **"설치 — 빌드 없이 CLI·MCP 쓰기"** 절 신설:
+   Releases 최신 링크, 4플랫폼 자산·SHA256SUMS 안내, 해제→검증→`rhwp capabilities`
+   첫 명령 3줄, PATH 배치가 MCP·파이썬 절의 전제를 채운다는 연결, 설치 관리자
+   등재는 로드맵 추적 중임을 명시.
+2. 파이썬 절 `RHWP_BIN` 줄에 대안 주석 1줄(릴리스 바이너리 경로 — 소스 빌드
+   불필요).
+3. MCP 절 `.mcp.json` 스니펫 아래에 획득 경로 연결 2줄.
+
+## 검증
+
+- `python scripts/check_markdown_links.py` — 이상 없음.
+- `git diff --check` — 통과.
+- 코드·렌더·워크플로 무변경(문서 전용). Cargo·WASM·시각 검증 해당 없음.


### PR DESCRIPTION
## 변경 요약

**존재하는 릴리스 바이너리를 문서에 잇는 문서 전용 PR**입니다 (#4327 §4 실측 → 트랙 D R38 의 "채널 등재와 독립적인 선행 조각").

`release-binary.yml`(#612)이 매 릴리스에 4플랫폼 바이너리 + SHA256SUMS 를 첨부 중이고 v0.8.2 자산 다운로드가 1,300+ 인데, 루트 README 의 설치 안내는 npm(웹 축)·소스 빌드·docker 뿐이어서 [Releases](https://github.com/edwardkim/rhwp/releases) 로 가는 경로가 문서에 없었습니다. 그 결과 "AI 에이전트에서 쓰기 (MCP)" 절의 `"command": "rhwp"` 와 "파이썬에서 쓰기" 절의 `RHWP_BIN` 이 전제하는 실행 파일 획득 경로가 **소스 빌드로만** 이어졌습니다 — 빌드 도구 없는 사용자·에이전트가 막히는 지점입니다.

변경 3곳 (README.md, 최소 범위):

1. "Quick Start (소스 빌드)" 앞에 **"설치 — 빌드 없이 CLI·MCP 쓰기"** 절 신설 — Releases 최신 링크, 4플랫폼 자산·`SHA256SUMS.txt` 안내, 해제→검증→`rhwp capabilities` 3줄, PATH 배치가 MCP·파이썬 절의 전제를 채운다는 연결, 설치 관리자 등재(winget·scoop·brew)는 로드맵 추적 중 명시.
2. 파이썬 절 `RHWP_BIN` 줄에 릴리스 바이너리 대안 주석 1줄(소스 빌드 불필요).
3. MCP 절 `.mcp.json` 스니펫 아래 획득 경로 연결 2줄.

처리 문서: `mydocs/working/task_m100_4331_stage1.md`

## 관련 이슈

closes #4331

## 테스트

- [ ] `cargo test` 통과 — 해당 없음(문서 전용, 코드·워크플로 무변경)
- [ ] `cargo clippy -- -D warnings` 통과 — 해당 없음(동상)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [x] `scripts/check_markdown_links.py` 526건 이상 없음 · `git diff --check` 통과

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 (문서 전용)
- 재현·측정: 해당 없음

## 스크린샷

해당 없음 (렌더 무관 문서 변경)
