### PR TITLE
feat(release): #4336 R63 — PyPI/npm 릴리스 파이프라인 (휠에 바이너리 동봉·설치 스모크·시크릿 게이트, 머지=능력 채택)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -825,6 +825,7 @@ jobs:
       - name: Validate workflow contracts
         run: |
           python3 -m unittest scripts/tests/test_cache_sweep_workflow.py
+          python3 -m unittest scripts/tests/test_release_packages_workflow.py
           python3 -m unittest scripts/tests/test_review_only_fast_pass_workflows.py
           python3 -m unittest scripts/tests/test_workflow_contract_wiring.py
 

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1,0 +1,206 @@
+name: Release Packages
+
+# Issue #4336 (R63) — PyPI/npm 릴리스 파이프라인.
+#
+# 설계 요지:
+# - 휠 4종(플랫폼 바이너리 동봉) + sdist(순수) 를 태그마다 만들고 각 플랫폼에서
+#   설치 스모크(동봉 탐색 2순위로 실행)까지 검증한다 — 여기까지는 시크릿 없이 돈다.
+# - 게시는 시크릿 게이트: PYPI_API_TOKEN / NPM_TOKEN 미등록이면 명시적으로
+#   건너뛴다(로그에 사유). 즉 이 워크플로의 머지는 배포 "능력"의 채택이고,
+#   시크릿 등록이 배포 "실행"의 채택이다 — 결정이 두 단계로 분리돼 있다.
+# - 버전 정합: 태그 = Cargo.toml = 바인딩 패키지 버전 (version_policy.md §6).
+#   tools/set_package_version.py 가 검증·정렬을 담당한다.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag name (예: v0.8.3 — 검증·빌드만, 게시는 시크릿 있을 때)'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  version-gate:
+    name: 버전 정합 게이트
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: 태그 == Cargo.toml 검증
+        id: ver
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${{ github.ref_name }}"
+          fi
+          VERSION="${TAG#v}"
+          python3 tools/set_package_version.py "${VERSION}" --check
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+  build-wheels:
+    name: 휠 ${{ matrix.wheel_tag }}
+    needs: version-gate
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            binary_name: rhwp
+            # ubuntu-latest(24.04) glibc 2.39 — PEP 600 에 따라 정직하게 표기한다.
+            wheel_tag: py3-none-manylinux_2_39_x86_64
+          - target: x86_64-apple-darwin
+            runner: macos-14
+            binary_name: rhwp
+            wheel_tag: py3-none-macosx_10_12_x86_64
+          - target: aarch64-apple-darwin
+            runner: macos-14
+            binary_name: rhwp
+            wheel_tag: py3-none-macosx_11_0_arm64
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            binary_name: rhwp.exe
+            wheel_tag: py3-none-win_amd64
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Ensure Rust target is installed
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ matrix.target }}-cargo-
+
+      - name: Build release binary
+        run: cargo build --release --bin rhwp --target ${{ matrix.target }}
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+
+      - name: 패키지 버전을 태그로 정렬
+        shell: bash
+        run: python tools/set_package_version.py "${{ needs.version-gate.outputs.version }}"
+
+      - name: 휠 빌드 (바이너리 동봉)
+        shell: bash
+        env:
+          RHWP_WHEEL_BUNDLE: target/${{ matrix.target }}/release/${{ matrix.binary_name }}
+          RHWP_WHEEL_TAG: ${{ matrix.wheel_tag }}
+        run: |
+          python -m pip install --upgrade pip build hatchling
+          python -m build --wheel --outdir dist bindings/python
+
+      - name: 설치 스모크 — 동봉 탐색(2순위)으로 실행돼야 한다
+        shell: bash
+        run: |
+          python -m pip install dist/*.whl
+          python - <<'EOF'
+          import os, subprocess
+          assert "RHWP_BIN" not in os.environ, "스모크는 RHWP_BIN 없이 돌아야 동봉 경로를 증명한다"
+          from rhwp._binary import find_binary
+          p = find_binary()
+          assert "_bin" in str(p), f"동봉 경로가 아니라 {p} 가 잡혔다"
+          out = subprocess.run([str(p), "--version"], capture_output=True, text=True, check=True)
+          print("동봉 바이너리:", p)
+          print("버전:", out.stdout.strip() or out.stderr.strip())
+          EOF
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wheel-${{ matrix.wheel_tag }}
+          path: dist/*.whl
+
+  build-sdist:
+    name: sdist (순수)
+    needs: version-gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+      - name: 패키지 버전을 태그로 정렬
+        run: python tools/set_package_version.py "${{ needs.version-gate.outputs.version }}"
+      - name: sdist 빌드
+        run: |
+          python -m pip install --upgrade pip build hatchling
+          python -m build --sdist --outdir dist bindings/python
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  publish-pypi:
+    name: PyPI 게시 (시크릿 게이트)
+    needs: [version-gate, build-wheels, build-sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: dist
+          merge-multiple: true
+      - name: 게시 또는 명시적 생략
+        shell: bash
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          ls -la dist/
+          if [[ -z "${TWINE_PASSWORD}" ]]; then
+            echo "::notice title=PyPI 게시 생략::PYPI_API_TOKEN 미등록 — 빌드·스모크 검증까지만 수행했습니다. 게시를 켜려면 저장소 시크릿에 토큰을 등록하세요 (mydocs/manual/release_packages_guide.md)."
+            exit 0
+          fi
+          python -m pip install --upgrade twine
+          python -m twine upload --non-interactive dist/*
+
+  publish-npm:
+    name: npm @rhwp/node 게시 (시크릿 게이트)
+    needs: version-gate
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bindings/node
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      - name: 패키지 버전을 태그로 정렬
+        working-directory: .
+        run: python3 tools/set_package_version.py "${{ needs.version-gate.outputs.version }}"
+      - name: 빌드 (커밋된 생성 타입 기준 — 드리프트는 node-binding.yml 의 gen:check 가 게이트)
+        run: |
+          npm ci
+          npm run build
+      - name: 게시 또는 명시적 생략
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [[ -z "${NODE_AUTH_TOKEN}" ]]; then
+            echo "::notice title=npm 게시 생략::NPM_TOKEN 미등록 — 빌드 검증까지만 수행했습니다. 게시를 켜려면 저장소 시크릿에 토큰을 등록하세요 (mydocs/manual/release_packages_guide.md)."
+            exit 0
+          fi
+          npm publish --access public

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -30,20 +30,34 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.ver.outputs.version }}
+      source_sha: ${{ steps.ver.outputs.source_sha }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # 수동 재실행도 입력 태그의 소스를 검증한다. 태그 push 는 원래 ref 를 유지한다.
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
       - name: 태그 == Cargo.toml 검증
         id: ver
         shell: bash
+        env:
+          REQUESTED_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            TAG="${{ github.event.inputs.tag }}"
-          else
-            TAG="${{ github.ref_name }}"
+          set -euo pipefail
+          TAG="$REQUESTED_TAG"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "지원하지 않는 릴리스 태그 형식: $TAG" >&2
+            exit 1
+          fi
+          TAG_SHA="$(git rev-parse --verify "refs/tags/$TAG^{commit}")"
+          HEAD_SHA="$(git rev-parse HEAD)"
+          if [[ "$HEAD_SHA" != "$TAG_SHA" ]]; then
+            echo "checkout 소스가 요청 태그와 다릅니다: HEAD=$HEAD_SHA tag=$TAG_SHA" >&2
+            exit 1
           fi
           VERSION="${TAG#v}"
           python3 tools/set_package_version.py "${VERSION}" --check
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "source_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
 
   build-wheels:
     name: 휠 ${{ matrix.wheel_tag }}
@@ -72,6 +86,8 @@ jobs:
             wheel_tag: py3-none-win_amd64
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.version-gate.outputs.source_sha }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
@@ -138,6 +154,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.version-gate.outputs.source_sha }}
       - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
@@ -184,6 +202,8 @@ jobs:
         working-directory: bindings/node
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.version-gate.outputs.source_sha }}
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -31,6 +31,7 @@ jobs:
     outputs:
       version: ${{ steps.ver.outputs.version }}
       source_sha: ${{ steps.ver.outputs.source_sha }}
+      npm_dist_tag: ${{ steps.ver.outputs.npm_dist_tag }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -56,8 +57,14 @@ jobs:
           fi
           VERSION="${TAG#v}"
           python3 tools/set_package_version.py "${VERSION}" --check
+          if [[ "$VERSION" == *-* ]]; then
+            NPM_DIST_TAG=next
+          else
+            NPM_DIST_TAG=latest
+          fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "source_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          echo "npm_dist_tag=${NPM_DIST_TAG}" >> "$GITHUB_OUTPUT"
 
   build-wheels:
     name: 휠 ${{ matrix.wheel_tag }}
@@ -70,19 +77,23 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-latest
             binary_name: rhwp
+            python_arch: x64
             # ubuntu-latest(24.04) glibc 2.39 — PEP 600 에 따라 정직하게 표기한다.
             wheel_tag: py3-none-manylinux_2_39_x86_64
           - target: x86_64-apple-darwin
             runner: macos-14
             binary_name: rhwp
+            python_arch: x64
             wheel_tag: py3-none-macosx_10_12_x86_64
           - target: aarch64-apple-darwin
             runner: macos-14
             binary_name: rhwp
+            python_arch: arm64
             wheel_tag: py3-none-macosx_11_0_arm64
           - target: x86_64-pc-windows-msvc
             runner: windows-latest
             binary_name: rhwp.exe
+            python_arch: x64
             wheel_tag: py3-none-win_amd64
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -114,6 +125,9 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
+          # macos-14 Apple Silicon에서 x86_64 wheel smoke는 Rosetta x64 Python,
+          # arm64 wheel smoke는 native Python supported tags로 설치한다.
+          architecture: ${{ matrix.python_arch }}
 
       - name: 패키지 버전을 태그로 정렬
         shell: bash
@@ -218,9 +232,10 @@ jobs:
       - name: 게시 또는 명시적 생략
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_DIST_TAG: ${{ needs.version-gate.outputs.npm_dist_tag }}
         run: |
           if [[ -z "${NODE_AUTH_TOKEN}" ]]; then
             echo "::notice title=npm 게시 생략::NPM_TOKEN 미등록 — 빌드 검증까지만 수행했습니다. 게시를 켜려면 저장소 시크릿에 토큰을 등록하세요 (mydocs/manual/release_packages_guide.md)."
             exit 0
           fi
-          npm publish --access public
+          npm publish --access public --tag "$NPM_DIST_TAG"

--- a/bindings/python/hatch_build.py
+++ b/bindings/python/hatch_build.py
@@ -1,0 +1,60 @@
+"""[#4336 R63] 휠에 rhwp 바이너리를 동봉하는 hatchling 빌드 훅.
+
+동작 계약:
+
+- 환경변수 두 개가 **함께** 있을 때만 개입한다.
+  - ``RHWP_WHEEL_BUNDLE`` — 동봉할 실행 파일 경로 (``rhwp`` 또는 ``rhwp.exe``)
+  - ``RHWP_WHEEL_TAG`` — 휠 플랫폼 태그 (예: ``py3-none-win_amd64``)
+- 개입 시: 바이너리를 ``rhwp/_bin/`` 로 강제 포함하고 휠 태그를 플랫폼 태그로
+  바꾼다. 런타임 탐색(`src/rhwp/_binary.py`)의 2순위 "패키지 동봉"이 이 자리를
+  이미 계약(`bindings_foundation.md` §3)으로 보고 있으므로 **런타임 코드는
+  무변경**이다.
+- 환경변수가 없으면 아무것도 하지 않는다 — 로컬 `pip install -e` 와 sdist 는
+  지금과 완전히 동일한 순수 패키지다.
+- 하나만 있으면 **즉시 실패**한다. 태그 없는 동봉(잘못된 플랫폼에 설치됨)도,
+  동봉 없는 플랫폼 태그(빈 약속)도 소비자를 속이는 휠이 된다.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+BUNDLE_ENV = "RHWP_WHEEL_BUNDLE"
+TAG_ENV = "RHWP_WHEEL_TAG"
+_ALLOWED_NAMES = ("rhwp", "rhwp.exe")
+
+
+class CustomBuildHook(BuildHookInterface):
+    """휠 대상에서만 동작하는 바이너리 동봉 훅."""
+
+    def initialize(self, version: str, build_data: dict) -> None:  # noqa: ARG002
+        if self.target_name != "wheel":
+            return
+
+        bundle = os.environ.get(BUNDLE_ENV, "").strip()
+        tag = os.environ.get(TAG_ENV, "").strip()
+        if not bundle and not tag:
+            return  # 순수 휠 — 종전과 동일.
+        if not (bundle and tag):
+            raise RuntimeError(
+                f"{BUNDLE_ENV} 와 {TAG_ENV} 는 함께 설정해야 합니다 "
+                f"(현재: BUNDLE={'설정' if bundle else '미설정'}, "
+                f"TAG={'설정' if tag else '미설정'}). 태그 없는 동봉도, 동봉 없는 "
+                f"플랫폼 태그도 소비자를 속이는 휠이 됩니다."
+            )
+
+        path = Path(bundle).expanduser().resolve()
+        if not path.is_file():
+            raise RuntimeError(f"{BUNDLE_ENV} 가 가리키는 파일이 없습니다: {path}")
+        if path.name not in _ALLOWED_NAMES:
+            raise RuntimeError(
+                f"동봉 파일 이름은 {_ALLOWED_NAMES} 중 하나여야 합니다: {path.name} "
+                f"(런타임 탐색 `_binary.binary_name()` 과 일치해야 발견됩니다)"
+            )
+
+        build_data["force_include"][str(path)] = f"rhwp/_bin/{path.name}"
+        build_data["tag"] = tag
+        build_data["pure_python"] = False

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -42,6 +42,12 @@ Issues = "https://github.com/edwardkim/rhwp/issues"
 [tool.hatch.build.targets.wheel]
 packages = ["src/rhwp"]
 
+# [#4336 R63] 릴리스 파이프라인이 환경변수(RHWP_WHEEL_BUNDLE·RHWP_WHEEL_TAG)를
+# 줄 때만 rhwp/_bin/ 에 바이너리를 동봉하고 플랫폼 태그를 단다. 환경변수가
+# 없으면 훅은 아무것도 하지 않는다(로컬 -e 설치·sdist 는 종전과 동일).
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "hatch_build.py"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 # 바이너리가 없는 환경에서도 단위 테스트는 돌아야 한다 — 통합만 건너뛴다.

--- a/mydocs/manual/release_packages_guide.md
+++ b/mydocs/manual/release_packages_guide.md
@@ -1,0 +1,80 @@
+---
+kind: guide
+status: active
+canonical: mydocs/manual/release_packages_guide.md
+last_verified: 2026-08-09
+---
+
+# 패키지 릴리스 가이드 — PyPI 휠·npm (R63, #4336)
+
+`.github/workflows/release-packages.yml` 의 운영 문서다. 이 파이프라인은 **켜기
+전까지 아무것도 게시하지 않는다** — 시크릿이 없으면 빌드·검증까지만 수행하고
+게시 단계를 로그에 사유를 남기며 건너뛴다. 즉:
+
+- **워크플로 머지** = "배포 능력"의 채택 (태그마다 휠·sdist 가 만들어지고 4플랫폼
+  설치 스모크가 검증됨 — 게시는 없음)
+- **시크릿 등록** = "배포 실행"의 채택 (다음 태그부터 실제 게시)
+
+결정 권한은 전부 메인테이너에게 있다.
+
+## 1. 무엇이 만들어지는가
+
+| 산출물 | 내용 |
+|---|---|
+| 플랫폼 휠 4종 | `rhwp-X.Y.Z-py3-none-{manylinux_2_39_x86_64, macosx_10_12_x86_64, macosx_11_0_arm64, win_amd64}.whl` — `rhwp/_bin/` 에 해당 플랫폼 릴리스 바이너리 동봉 |
+| sdist 1종 | 순수 파이썬 — 바이너리 없음, 설치 후 `RHWP_BIN`/`PATH` 탐색(종전과 동일) |
+| npm `@rhwp/node` | 커밋된 생성 타입 기준 빌드본 — 바이너리 미동봉(§5 후속), `RHWP_BIN`/`PATH` 래퍼 |
+
+런타임은 무변경이다 — `src/rhwp/_binary.py` 의 3단 탐색(`RHWP_BIN` → 패키지
+동봉 `_bin/` → `PATH`)은 `bindings_foundation.md` §3 이 이미 고정한 계약이고,
+휠 동봉은 그 2순위 자리를 채울 뿐이다. 동봉은
+`bindings/python/hatch_build.py` 훅이 수행하며, 환경변수
+(`RHWP_WHEEL_BUNDLE`·`RHWP_WHEEL_TAG`)가 **둘 다** 있을 때만 개입한다(하나만
+있으면 즉시 실패 — 태그 없는 동봉도, 동봉 없는 태그도 소비자를 속이는 휠이다).
+
+## 2. 버전 정합 (version_policy.md §6)
+
+태그 `vX.Y.Z` = `Cargo.toml` = 바인딩 패키지 버전. `tools/set_package_version.py`
+가 두 역할을 한다:
+
+- `--check` — version-gate 잡에서 태그와 `Cargo.toml` 불일치 시 전체 중단.
+- 정렬 — 빌드 직전 pyproject·package.json 버전을 태그로 일시 정렬(커밋하지
+  않음 — 저장소의 바인딩 버전은 개발 트리 표지이고, 배포 버전의 원천은 태그다).
+
+## 3. 켜는 절차 (메인테이너)
+
+1. **PyPI**: `rhwp` 패키지명 확보(첫 업로드가 곧 선점) → API 토큰 발급 → 저장소
+   시크릿 `PYPI_API_TOKEN` 등록. 대안: PyPI **Trusted Publishing**(OIDC — 토큰
+   없이 저장소·워크플로를 PyPI 쪽에 등록). 채택 시 publish-pypi 잡을
+   `pypa/gh-action-pypi-publish` 로 바꾸는 후속 커밋이 필요하다.
+2. **npm**: `@rhwp` 스코프는 이미 `@rhwp/core`·`@rhwp/editor` 게시로 확보돼
+   있다 → automation 토큰 발급 → 시크릿 `NPM_TOKEN` 등록.
+3. 다음 `v*` 태그부터 자동 게시된다. 첫 게시는 `workflow_dispatch` 로 기존
+   태그를 지정해 수동으로 돌려보는 것을 권장한다.
+
+## 4. 스모크가 증명하는 것
+
+각 플랫폼 잡이 자기 휠을 실제로 `pip install` 한 뒤 **`RHWP_BIN` 없이**:
+
+1. `find_binary()` 결과가 `_bin` 경로(동봉 2순위)인지 단언
+2. 그 바이너리로 `--version` 실행
+
+로컬 선행 실증(2026-08-09, Windows): 디버그 바이너리 동봉 휠을 깨끗한 venv 에
+설치 → `site-packages/rhwp/_bin/rhwp.exe` 발견 → `rhwp v0.8.2` → 실물 문서
+`rhwp.info()` 17쪽 파싱까지 확인.
+
+## 5. 한계와 후속 (정직 목록)
+
+- **manylinux 하한**: linux 휠은 빌드 러너(ubuntu-latest) glibc 기준
+  `manylinux_2_39` 로 정직 표기 — 구형 배포판은 sdist+`RHWP_BIN` 경로.
+  더 낮은 하한(musl/zig 크로스)은 수요 확인 후 별도 단계.
+- **npm 바이너리 동봉 없음**: `@rhwp/node` 는 래퍼로 먼저 게시한다. esbuild 식
+  플랫폼별 optionalDependencies 동봉과 `npx` MCP 원라인은 후속(R39 연계).
+- **서명 없음**: 게시물 서명은 version_policy.md §8 의 도구 결정 후 이
+  파이프라인에 얹는다(SHA256SUMS 와 병행).
+
+## 6. 롤백
+
+- PyPI: `yank` (설치 차단, 기록 보존) — 삭제보다 yank 를 기본으로.
+- npm: 72시간 내 `npm unpublish`, 이후는 `npm deprecate`.
+- 워크플로 자체를 끄려면 시크릿 제거(게시만 멈춤) 또는 워크플로 disable.

--- a/mydocs/pr/pr_4337_review.md
+++ b/mydocs/pr/pr_4337_review.md
@@ -24,7 +24,7 @@ last_verified: 2026-08-10
 | 규모 | 6 files, +489 / -0, contributor commit 1개 |
 | 상태 | `MERGEABLE` / `CLEAN`, contributor head의 Full CI·CodeQL·Python binding 성공 |
 | 가시성 branch | `review/kevin9327-20260810-pr4337` |
-| 메인터너 code candidate | `13a41d380e3ad117e680872c3d5148df142cfaf6` |
+| 메인터너 code candidate | `5926828dcc0d5c9baf212aa8707d8ed033714f64` |
 
 접수 상태와 녹색 check는 contributor head 기준이다. 새 release workflow는 tag push와
 `workflow_dispatch`만 트리거하므로 그 head에서도 실제 게시 경로는 실행되지 않았다.
@@ -38,10 +38,12 @@ contributor commit은 수정하거나 재작성하지 않았다.
 
 ## 원래 차단점
 
-`workflow_dispatch.tag`는 버전 문자열에만 쓰이고 checkout은 workflow를 실행한 기본 ref를
-사용했다. 따라서 과거 태그를 지정한 수동 실행이 현재 branch 소스를 그 태그 버전으로 빌드·게시할
-수 있었다. 버전 문자열 검사는 Cargo와 일치해도 실제 checkout commit이 해당 태그라는 사실을
-보증하지 못했다.
+- `workflow_dispatch.tag`는 버전 문자열에만 쓰이고 checkout은 workflow를 실행한 기본 ref를
+  사용해, 과거 태그 이름으로 현재 branch source를 게시할 수 있었다.
+- prerelease npm publish에 non-latest dist-tag가 없어 prerelease가 `latest`를 점유하거나 npm에서
+  거절될 수 있었다.
+- x86_64와 arm64 macOS wheel smoke가 같은 Apple Silicon runner의 기본 Python을 사용해,
+  x86_64 wheel이 arm64 Python supported tags에서 설치 거절될 수 있었다.
 
 ## 메인터너 보정
 
@@ -53,24 +55,33 @@ contributor commit은 수정하거나 재작성하지 않았다.
 - `scripts/tests/test_release_packages_workflow.py`: dispatch와 downstream source 선택 계약을 고정한다.
 - `.github/workflows/ci.yml`: 새 workflow 계약 테스트를 lint job에 배선한다.
 
+독립 후속 검토 뒤 `5926828dcc0d5c9baf212aa8707d8ed033714f64`
+(`fix(maintainer): #4337 prerelease 게시와 wheel arch 보호`)을 추가했다.
+
+- `.github/workflows/release-packages.yml`: prerelease npm publish는 `--tag next`, stable은
+  명시적 `latest`를 사용한다. wheel matrix는 artifact target에 맞춰 x64 또는 arm64 Python을 설치한다.
+- `scripts/tests/test_release_packages_workflow.py`: dist-tag와 Python architecture 배선을 고정한다.
+
 ## 완료한 로컬 검증
 
 | 검증 | 결과 |
 | --- | --- |
-| `python -m unittest scripts.tests.test_release_packages_workflow scripts.tests.test_workflow_contract_wiring -v` | 5 / 5 통과 |
-| `git diff --check origin/pr/4337..13a41d380e3ad117e680872c3d5148df142cfaf6` | 통과 |
-| commit graph | correction commit의 유일한 parent가 contributor head와 일치 |
+| `python -m unittest scripts.tests.test_release_packages_workflow scripts.tests.test_workflow_contract_wiring -v` | 7 / 7 통과 |
+| `git diff --check origin/pr/4337..5926828dcc0d5c9baf212aa8707d8ed033714f64` | 통과 |
+| commit graph | contributor history를 rewrite하지 않고 maintainer code/docs/code를 single-parent로 연결 |
 
 Rust source나 renderer를 바꾸지 않아 Cargo·시각 회귀는 로컬 범위에서 생략했다. 로컬 환경에는
-`actionlint`가 없어 GitHub Actions parser와 실제 Linux/macOS/Windows wheel build는 최신 원격
-head의 Full CI에서 확인해야 한다.
+`actionlint`가 없다. 또한 이 release workflow에는 `pull_request` trigger가 없으므로 PR Full CI는
+focused static contract만 실행하며 실제 Linux/macOS/Windows wheel matrix와 npm/PyPI publish E2E를
+검증할 수 없다. x64 Python의 Rosetta 실행을 포함한 release E2E는 잔여 risk다.
 
 ## 최종 권고
 
 **메인터너 보정 포함 조건부 수용 권고.** code/test/workflow 보정이 있으므로 contributor head의
 기존 녹색 결과를 review-only fast-pass로 재사용할 수 없다. 작업지시자가 push를 승인한 뒤 correction
-commit과 이 trailing review 기록을 source branch에 fast-forward로 반영하고, 최신 head의 Full CI,
-required checks와 mergeability를 확인해야 한다. 그 뒤에도 별도의 merge 승인이 있어야 한다.
-현재 기록은 push·review 게시·merge 권한을 부여하지 않는다.
+commit들과 이 trailing review 기록을 source branch에 fast-forward로 반영하고, 최신 head의 Full CI
+static/focused contract, required checks와 mergeability를 확인해야 한다. release publish E2E 미검증
+risk를 명시적으로 수용한 뒤에도 별도의 merge 승인이 있어야 한다. 현재 기록은 push·review 게시·merge
+권한을 부여하지 않는다.
 
 실행 및 rollback 경계는 [PR #4337 구현·통합 계획](pr_4337_review_impl.md)을 따른다.

--- a/mydocs/pr/pr_4337_review.md
+++ b/mydocs/pr/pr_4337_review.md
@@ -1,0 +1,76 @@
+---
+kind: pr-review
+status: active
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-10
+---
+
+# PR #4337 검토 - PyPI/npm 릴리스 소스 고정
+
+## 검토 경로
+
+기본 경로는 `maintainer_general.md`다. 보조 경로는 `intake_and_review.md`,
+`local_validation.md`, `multi_pr_update_branch.md`, `review_only_fast_pass.md`다.
+릴리스 workflow와 바인딩 패키징만 바뀌며 renderer, layout, fixture, sample 변경은 없어
+시각 검증 대상이 아니다.
+
+## 접수 메타데이터
+
+| 항목 | 접수 시점 참고값 |
+| --- | --- |
+| PR / 작성자 | [#4337](https://github.com/edwardkim/rhwp/pull/4337) / `kevin9327` |
+| 관련 이슈 | [#4336](https://github.com/edwardkim/rhwp/issues/4336) |
+| base / contributor head | `devel` / `85fb44bf63e753af6e4c03055f9d96c7b23ffaba` |
+| 규모 | 6 files, +489 / -0, contributor commit 1개 |
+| 상태 | `MERGEABLE` / `CLEAN`, contributor head의 Full CI·CodeQL·Python binding 성공 |
+| 가시성 branch | `review/kevin9327-20260810-pr4337` |
+| 메인터너 code candidate | `13a41d380e3ad117e680872c3d5148df142cfaf6` |
+
+접수 상태와 녹색 check는 contributor head 기준이다. 새 release workflow는 tag push와
+`workflow_dispatch`만 트리거하므로 그 head에서도 실제 게시 경로는 실행되지 않았다.
+
+## Contributor 변경 범위
+
+contributor commit `85fb44bf`는 플랫폼별 Python wheel과 sdist, `@rhwp/node` 패키지
+빌드·게시 workflow를 추가했다. `hatch_build.py`, Python package metadata,
+`tools/set_package_version.py`, 릴리스 가이드와 stage 기록도 함께 추가했다.
+contributor commit은 수정하거나 재작성하지 않았다.
+
+## 원래 차단점
+
+`workflow_dispatch.tag`는 버전 문자열에만 쓰이고 checkout은 workflow를 실행한 기본 ref를
+사용했다. 따라서 과거 태그를 지정한 수동 실행이 현재 branch 소스를 그 태그 버전으로 빌드·게시할
+수 있었다. 버전 문자열 검사는 Cargo와 일치해도 실제 checkout commit이 해당 태그라는 사실을
+보증하지 못했다.
+
+## 메인터너 보정
+
+`13a41d380e3ad117e680872c3d5148df142cfaf6`
+(`fix(maintainer): #4337 릴리스 소스를 요청 태그로 고정`)은 다음을 보정했다.
+
+- `.github/workflows/release-packages.yml`: dispatch는 입력 태그를 checkout하고, tag 형식,
+  tag commit, HEAD와 Cargo version을 검증한다. downstream build는 검증된 불변 SHA를 checkout한다.
+- `scripts/tests/test_release_packages_workflow.py`: dispatch와 downstream source 선택 계약을 고정한다.
+- `.github/workflows/ci.yml`: 새 workflow 계약 테스트를 lint job에 배선한다.
+
+## 완료한 로컬 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| `python -m unittest scripts.tests.test_release_packages_workflow scripts.tests.test_workflow_contract_wiring -v` | 5 / 5 통과 |
+| `git diff --check origin/pr/4337..13a41d380e3ad117e680872c3d5148df142cfaf6` | 통과 |
+| commit graph | correction commit의 유일한 parent가 contributor head와 일치 |
+
+Rust source나 renderer를 바꾸지 않아 Cargo·시각 회귀는 로컬 범위에서 생략했다. 로컬 환경에는
+`actionlint`가 없어 GitHub Actions parser와 실제 Linux/macOS/Windows wheel build는 최신 원격
+head의 Full CI에서 확인해야 한다.
+
+## 최종 권고
+
+**메인터너 보정 포함 조건부 수용 권고.** code/test/workflow 보정이 있으므로 contributor head의
+기존 녹색 결과를 review-only fast-pass로 재사용할 수 없다. 작업지시자가 push를 승인한 뒤 correction
+commit과 이 trailing review 기록을 source branch에 fast-forward로 반영하고, 최신 head의 Full CI,
+required checks와 mergeability를 확인해야 한다. 그 뒤에도 별도의 merge 승인이 있어야 한다.
+현재 기록은 push·review 게시·merge 권한을 부여하지 않는다.
+
+실행 및 rollback 경계는 [PR #4337 구현·통합 계획](pr_4337_review_impl.md)을 따른다.

--- a/mydocs/pr/pr_4337_review_impl.md
+++ b/mydocs/pr/pr_4337_review_impl.md
@@ -13,7 +13,9 @@ Contributor history는 그대로 보존한다.
 
 1. `85fb44bf63e753af6e4c03055f9d96c7b23ffaba` — contributor의 PyPI/npm 릴리스 파이프라인
 2. `13a41d380e3ad117e680872c3d5148df142cfaf6` — maintainer code/test/workflow 보정
-3. 이 문서를 포함하는 별도 trailing review-doc commit — `mydocs/pr/` 두 파일만 변경
+3. `c658cf16f7c1aa436745ce3a8f44c571cb30f4da` — 최초 maintainer review-doc commit
+4. `5926828dcc0d5c9baf212aa8707d8ed033714f64` — maintainer prerelease/architecture 후속 보정
+5. 이 갱신을 포함하는 별도 trailing review-doc commit
 
 보정 commit의 유일한 parent는 contributor head다. contributor commit을 amend, rebase,
 merge 또는 force-push하지 않는다. 검토 근거는 [PR #4337 검토 기록](pr_4337_review.md)에 있다.
@@ -21,12 +23,14 @@ merge 또는 force-push하지 않는다. 검토 근거는 [PR #4337 검토 기�
 ## 단계
 
 1. **완료 - 접수 고정:** contributor head, 규모, merge 상태와 기존 check를 기록했다.
-2. **완료 - 로컬 보정:** dispatch source 고정과 계약 테스트를 하나의 maintainer commit으로 추가했다.
+2. **완료 - 로컬 보정:** dispatch source 고정, prerelease dist-tag와 wheel Python architecture를
+   두 maintainer code commit에 추가했다.
 3. **완료 - 로컬 검증:** focused unittest, workflow test 배선, commit parent와 diff check를 확인했다.
-4. **대기 - push 승인:** 작업지시자 승인 뒤 code correction과 trailing review-doc commit만 PR source에
+4. **대기 - push 승인:** 작업지시자 승인 뒤 maintainer correction과 review-doc commit만 PR source에
    fast-forward push하고 원격 head SHA를 다시 확인한다.
-5. **대기 - Full CI:** code/test/workflow가 바뀌었으므로 fast-pass가 아니라 최신 head의 Full CI,
-   CodeQL 및 branch protection required aggregate를 기다린다. 실제 package matrix도 이 단계에서 확인한다.
+5. **대기 - PR CI:** code/test/workflow가 바뀌었으므로 fast-pass가 아니라 최신 head의 Full CI,
+   CodeQL 및 branch protection required aggregate를 기다린다. 이 PR에서는 release workflow가 직접
+   실행되지 않으므로 package matrix와 publish E2E는 확인할 수 없고 residual risk로 유지한다.
 6. **대기 - 최종 판단:** 최신 mergeability와 check가 모두 녹색이어도 별도 작업지시자 merge 승인 전에는
    GitHub review 게시나 merge를 수행하지 않는다.
 7. **merge 후:** merge SHA를 확인하고 review 기록을 archive로 이동할지 판정한 뒤 branch/worktree를 정리한다.
@@ -34,8 +38,8 @@ merge 또는 force-push하지 않는다. 검토 근거는 [PR #4337 검토 기�
 ## Rollback
 
 - push 전에는 이 visibility branch와 worktree만 정리하면 원 PR에는 영향이 없다.
-- push 뒤 merge 전에는 trailing review-doc commit을 먼저 revert하고, 필요하면
-  `13a41d380e3ad117e680872c3d5148df142cfaf6`을 revert해 contributor head로 되돌린다.
+- push 뒤 merge 전에는 trailing review-doc commit, `5926828dcc0d5c9baf212aa8707d8ed033714f64`,
+  최초 review-doc commit과 `13a41d380e3ad117e680872c3d5148df142cfaf6`을 역순 revert한다.
 - merge 뒤에도 동일한 역순 revert를 사용한다. contributor commit을 rewrite하거나 force-push하지 않는다.
 
 현재 단계에는 push, GitHub review/comment 또는 merge 승인이 없다.

--- a/mydocs/pr/pr_4337_review_impl.md
+++ b/mydocs/pr/pr_4337_review_impl.md
@@ -1,0 +1,41 @@
+---
+kind: pr-review-implementation
+status: active
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-10
+---
+
+# PR #4337 메인터너 보정·통합 계획
+
+## Commit 소유권과 순서
+
+Contributor history는 그대로 보존한다.
+
+1. `85fb44bf63e753af6e4c03055f9d96c7b23ffaba` — contributor의 PyPI/npm 릴리스 파이프라인
+2. `13a41d380e3ad117e680872c3d5148df142cfaf6` — maintainer code/test/workflow 보정
+3. 이 문서를 포함하는 별도 trailing review-doc commit — `mydocs/pr/` 두 파일만 변경
+
+보정 commit의 유일한 parent는 contributor head다. contributor commit을 amend, rebase,
+merge 또는 force-push하지 않는다. 검토 근거는 [PR #4337 검토 기록](pr_4337_review.md)에 있다.
+
+## 단계
+
+1. **완료 - 접수 고정:** contributor head, 규모, merge 상태와 기존 check를 기록했다.
+2. **완료 - 로컬 보정:** dispatch source 고정과 계약 테스트를 하나의 maintainer commit으로 추가했다.
+3. **완료 - 로컬 검증:** focused unittest, workflow test 배선, commit parent와 diff check를 확인했다.
+4. **대기 - push 승인:** 작업지시자 승인 뒤 code correction과 trailing review-doc commit만 PR source에
+   fast-forward push하고 원격 head SHA를 다시 확인한다.
+5. **대기 - Full CI:** code/test/workflow가 바뀌었으므로 fast-pass가 아니라 최신 head의 Full CI,
+   CodeQL 및 branch protection required aggregate를 기다린다. 실제 package matrix도 이 단계에서 확인한다.
+6. **대기 - 최종 판단:** 최신 mergeability와 check가 모두 녹색이어도 별도 작업지시자 merge 승인 전에는
+   GitHub review 게시나 merge를 수행하지 않는다.
+7. **merge 후:** merge SHA를 확인하고 review 기록을 archive로 이동할지 판정한 뒤 branch/worktree를 정리한다.
+
+## Rollback
+
+- push 전에는 이 visibility branch와 worktree만 정리하면 원 PR에는 영향이 없다.
+- push 뒤 merge 전에는 trailing review-doc commit을 먼저 revert하고, 필요하면
+  `13a41d380e3ad117e680872c3d5148df142cfaf6`을 revert해 contributor head로 되돌린다.
+- merge 뒤에도 동일한 역순 revert를 사용한다. contributor commit을 rewrite하거나 force-push하지 않는다.
+
+현재 단계에는 push, GitHub review/comment 또는 merge 승인이 없다.

--- a/mydocs/working/task_m100_4336_stage1.md
+++ b/mydocs/working/task_m100_4336_stage1.md
@@ -1,0 +1,58 @@
+# Task M100 #4336 Stage 1 — R63 PyPI/npm 릴리스 파이프라인
+
+- 이슈: [#4336](https://github.com/edwardkim/rhwp/issues/4336)
+- 기준 브랜치: `upstream/devel`
+- 작업 브랜치: `task_m100_4336`
+- 작성일: 2026-08-09 KST
+- 상태: 구현·로컬 실증 완료
+
+## 핵심 판단
+
+- **런타임 무변경**: `src/rhwp/_binary.py` 가 `RHWP_BIN` → 패키지 동봉(`_bin/`)
+  → `PATH` 3단 탐색을 이미 계약으로 구현(§3, bindings_foundation.md) — 이번
+  작업은 그 2순위 자리를 채우는 빌드 파이프라인만 만든다.
+- **결정의 2단 분리**: 워크플로 머지 = 능력 채택(빌드·스모크만), 시크릿 등록 =
+  실행 채택(실게시). PR 가 곧 결정 매체가 되도록 게시 단계는 시크릿 부재 시
+  `::notice` 사유를 남기고 명시적으로 생략한다.
+- R67(PR #4330) 개념 적층 — 버전 정합(§6)은 `tools/set_package_version.py`
+  `--check` 가 게이트로 수행. 코드 의존이 없어 독립 브랜치로 제출.
+
+## 산출물
+
+- `bindings/python/hatch_build.py` — 환경변수 쌍(`RHWP_WHEEL_BUNDLE`·
+  `RHWP_WHEEL_TAG`)이 있을 때만 동봉+플랫폼 태그. 하나만 있으면 즉시 실패.
+  환경변수 없으면 완전 무개입(로컬 `-e`·sdist 종전과 동일).
+- `bindings/python/pyproject.toml` — 훅 배선 5줄.
+- `tools/set_package_version.py` — 태그↔Cargo 검증(`--check`)·바인딩 버전 정렬.
+- `.github/workflows/release-packages.yml` — version-gate → 휠 4종(각 플랫폼
+  설치 스모크 포함) + sdist → PyPI/npm 게시(시크릿 게이트). 액션은 저장소 관례의
+  핀 SHA 재사용.
+- `mydocs/manual/release_packages_guide.md` — 켜는 절차·한계·롤백.
+
+## 로컬 실증 (Windows, 2026-08-09)
+
+```
+RHWP_WHEEL_BUNDLE=target/debug/rhwp.exe RHWP_WHEEL_TAG=py3-none-win_amd64 \
+  python -m build --wheel → rhwp-0.1.0-py3-none-win_amd64.whl
+깨끗한 venv 에 pip install → RHWP_BIN 없이:
+  BUNDLED: …\site-packages\rhwp\_bin\rhwp.exe   (동봉 2순위로 발견)
+  VERSION: rhwp v0.8.2
+  INFO OK: pages= 17   (실물 문서 rhwp.info() 파싱)
+```
+
+- `tools/set_package_version.py 0.8.2 --check` → 일치(Cargo.toml 대조).
+- 파이썬 스위트 재실행 결과는 아래 검증 절.
+
+## 검증
+
+- 휠 빌드→격리 설치→동봉 탐색→실행→실물 파싱 E2E (위).
+- `python -m pytest` (RHWP_BIN=debug 바이너리) — 294/294 (pyproject 훅 배선이
+  기존 경로에 무영향임을 확인).
+- 문서 메타데이터·상대 링크 검사, `git diff --check`.
+- Rust·렌더 변경 없음 — Cargo·WASM·시각 검증 해당 없음. 워크플로 실행 검증은
+  머지 후 `workflow_dispatch` (기존 태그 지정) 1회를 권장(가이드 §3).
+
+## 한계 (가이드 §5 와 동일)
+
+manylinux_2_39 하한(구형 배포판은 sdist 경로), npm 바이너리 동봉 없음(후속),
+서명 없음(version_policy §8 결정 후 부착).

--- a/scripts/tests/test_release_packages_workflow.py
+++ b/scripts/tests/test_release_packages_workflow.py
@@ -1,0 +1,41 @@
+"""Release package workflow source-selection contract."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github/workflows/release-packages.yml"
+)
+
+
+class ReleasePackagesWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    def test_dispatch_checkout_uses_requested_tag_and_push_keeps_event_ref(self) -> None:
+        self.assertIn(
+            "ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}",
+            self.workflow,
+        )
+        self.assertIn(
+            "REQUESTED_TAG: ${{ github.event_name == 'workflow_dispatch' "
+            "&& inputs.tag || github.ref_name }}",
+            self.workflow,
+        )
+
+    def test_all_package_build_checkouts_use_validated_source_sha(self) -> None:
+        self.assertEqual(
+            self.workflow.count("ref: ${{ needs.version-gate.outputs.source_sha }}"),
+            3,
+        )
+        self.assertIn("source_sha: ${{ steps.ver.outputs.source_sha }}", self.workflow)
+        self.assertIn('git rev-parse --verify "refs/tags/$TAG^{commit}"', self.workflow)
+        self.assertIn('python3 tools/set_package_version.py "${VERSION}" --check', self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_packages_workflow.py
+++ b/scripts/tests/test_release_packages_workflow.py
@@ -36,6 +36,21 @@ class ReleasePackagesWorkflowTests(unittest.TestCase):
         self.assertIn('git rev-parse --verify "refs/tags/$TAG^{commit}"', self.workflow)
         self.assertIn('python3 tools/set_package_version.py "${VERSION}" --check', self.workflow)
 
+    def test_prerelease_npm_publish_never_uses_latest(self) -> None:
+        self.assertIn('if [[ "$VERSION" == *-* ]]', self.workflow)
+        self.assertIn("NPM_DIST_TAG=next", self.workflow)
+        self.assertIn("NPM_DIST_TAG=latest", self.workflow)
+        self.assertIn(
+            "NPM_DIST_TAG: ${{ needs.version-gate.outputs.npm_dist_tag }}",
+            self.workflow,
+        )
+        self.assertIn('npm publish --access public --tag "$NPM_DIST_TAG"', self.workflow)
+
+    def test_wheel_smoke_python_matches_each_artifact_architecture(self) -> None:
+        self.assertEqual(self.workflow.count("python_arch: x64"), 3)
+        self.assertEqual(self.workflow.count("python_arch: arm64"), 1)
+        self.assertIn("architecture: ${{ matrix.python_arch }}", self.workflow)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/set_package_version.py
+++ b/tools/set_package_version.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""[#4336 R63] 바인딩 패키지 버전을 릴리스 태그로 정렬한다.
+
+version_policy.md §6: 태그 `vX.Y.Z` = `CARGO_PKG_VERSION` = 바인딩 패키지 버전.
+릴리스 파이프라인이 빌드 직전에 호출한다 — 저장소에는 커밋하지 않는 일시 정렬이다
+(저장소의 바인딩 버전은 개발 트리 표지일 뿐, 배포 버전의 원천은 태그다).
+
+사용법::
+
+    python tools/set_package_version.py 0.8.3            # python + node 모두
+    python tools/set_package_version.py 0.8.3 --check    # Cargo.toml 과 일치 검증만
+
+``--check`` 는 Cargo.toml 의 version 과 인자가 다르면 exit 1 — 태그를 잘못 찍은
+릴리스가 패키지로 번지기 전에 여기서 멈춘다.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = ROOT / "bindings" / "python" / "pyproject.toml"
+NODE_PKG = ROOT / "bindings" / "node" / "package.json"
+CARGO = ROOT / "Cargo.toml"
+
+SEMVER = re.compile(r"^\d+\.\d+\.\d+(?:[-.+][0-9A-Za-z.-]+)?$")
+
+
+def cargo_version() -> str:
+    m = re.search(r'(?m)^version = "([^"]+)"$', CARGO.read_text(encoding="utf-8"))
+    if not m:
+        sys.exit("Cargo.toml 에서 version 을 찾지 못했습니다")
+    return m.group(1)
+
+
+def set_pyproject(version: str) -> None:
+    text = PYPROJECT.read_text(encoding="utf-8")
+    new, n = re.subn(r'(?m)^version = "[^"]+"$', f'version = "{version}"', text, count=1)
+    if n != 1:
+        sys.exit("pyproject.toml 의 version 줄을 찾지 못했습니다")
+    PYPROJECT.write_text(new, encoding="utf-8")
+
+
+def set_node(version: str) -> None:
+    data = json.loads(NODE_PKG.read_text(encoding="utf-8"))
+    data["version"] = version
+    NODE_PKG.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("version", help="릴리스 버전 (태그에서 v 를 뗀 값)")
+    ap.add_argument("--check", action="store_true", help="Cargo.toml 일치 검증만 수행")
+    args = ap.parse_args()
+
+    if not SEMVER.match(args.version):
+        sys.exit(f"semver 형식이 아닙니다: {args.version}")
+
+    cargo = cargo_version()
+    if args.version != cargo:
+        sys.exit(
+            f"버전 불일치: 인자 {args.version} != Cargo.toml {cargo} — "
+            f"태그와 Cargo.toml 이 갈린 릴리스는 여기서 멈춥니다 (version_policy.md §6)"
+        )
+    if args.check:
+        print(f"일치: {cargo}")
+        return
+
+    set_pyproject(args.version)
+    set_node(args.version)
+    print(f"정렬 완료: pyproject.toml·package.json → {args.version}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 변경 요약

**R63(PyPI/npm 릴리스 파이프라인)** 구현 — `pip install rhwp` 한 줄을 실현하는 배포 경로입니다. **이 PR 자체가 결정 매체입니다**: 게시 단계는 시크릿(`PYPI_API_TOKEN`·`NPM_TOKEN`) 미등록 시 `::notice` 사유와 함께 명시적으로 생략되므로, **머지 = 배포 능력 채택(빌드·스모크 검증만)**, **시크릿 등록 = 배포 실행 채택**으로 결정이 2단 분리됩니다. 계정·패키지명 소유는 전부 메인테이너 몫입니다.

핵심은 **런타임 무변경**입니다 — `src/rhwp/_binary.py` 의 3단 탐색(`RHWP_BIN` → 패키지 동봉 `_bin/` → `PATH`)이 이미 계약(`bindings_foundation.md` §3)으로 구현돼 있어, 이 작업은 그 2순위 자리를 채우는 **빌드 경로만** 만듭니다.

1. `bindings/python/hatch_build.py` — 환경변수 쌍(`RHWP_WHEEL_BUNDLE`·`RHWP_WHEEL_TAG`)이 **함께** 있을 때만 `rhwp/_bin/` 동봉 + 플랫폼 태그. 하나만 있으면 즉시 실패(태그 없는 동봉도, 동봉 없는 태그도 소비자를 속이는 휠). 환경변수 없으면 완전 무개입 — 로컬 `-e`·sdist 는 종전과 동일.
2. `tools/set_package_version.py` — 태그↔`Cargo.toml` 정합 게이트(`--check`) + 바인딩 버전 일시 정렬. #4330 `version_policy.md` §6("태그 = Cargo = 바인딩 패키지 버전")의 기계 적용점(개념 적층 — 코드 의존 없음).
3. `.github/workflows/release-packages.yml` — version-gate → 4플랫폼 휠(release-binary.yml 과 동일 러너·타깃, **각 플랫폼에서 설치 스모크**: `RHWP_BIN` 없이 동봉 2순위 발견 + `--version` 실행) + sdist → PyPI/npm 게시(시크릿 게이트). 액션은 저장소 관례의 핀 SHA 재사용.
4. `mydocs/manual/release_packages_guide.md` — 켜는 절차(PyPI 패키지명 확보·Trusted Publishing 대안·npm `@rhwp` 스코프는 core/editor 게시로 기확보), 스모크 계약, **한계 정직 목록**(linux 휠 `manylinux_2_39` 하한 → 구형 배포판은 sdist 경로, npm 바이너리 동봉은 후속, 서명은 version_policy §8 결정 후 부착), 롤백(yank/deprecate).

### 로컬 실증 (Windows, 2026-08-09)

```
RHWP_WHEEL_BUNDLE=target/debug/rhwp.exe RHWP_WHEEL_TAG=py3-none-win_amd64
  python -m build --wheel  →  rhwp-0.1.0-py3-none-win_amd64.whl
깨끗한 venv 에 pip install 후 RHWP_BIN 없이:
  BUNDLED: …\site-packages\rhwp\_bin\rhwp.exe   ← 동봉 2순위로 발견
  VERSION: rhwp v0.8.2
  INFO OK: pages= 17                            ← 실물 문서 rhwp.info() 파싱
```

## 관련 이슈

closes #4336

## 테스트

- [ ] `cargo test` 통과 — 해당 없음(Rust 코드 무변경 — 패키징·워크플로·문서만)
- [ ] `cargo clippy -- -D warnings` 통과 — 해당 없음(동상)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [x] 휠 E2E 실증(위) · Python `pytest` **294/294**(훅 배선이 기존 경로 무영향 확인) · `set_package_version.py --check` Cargo 대조 통과 · 문서 메타데이터·상대 링크 검사 이상 없음 · `git diff --check` 통과
- 워크플로 실행 검증은 머지 후 `workflow_dispatch`(기존 태그 지정) 1회 권장 — 가이드 §3

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 (릴리스 파이프라인·패키징 전용)
- 재현·측정: 해당 없음

## 스크린샷

해당 없음 (터미널 실증은 위 코드 블록 — 처리 문서 `mydocs/working/task_m100_4336_stage1.md` 에 동일 기록)
