### PR TITLE
feat(packaging): #4338 R38 — 설치 채널 매니페스트 3종 (scoop 즉시 설치·homebrew·winget) + 1커맨드 갱신

### DIFF
--- a/contrib/packaging/homebrew/rhwp.rb
+++ b/contrib/packaging/homebrew/rhwp.rb
@@ -1,0 +1,32 @@
+# [#4338 R38] Homebrew formula — 탭 위치는 메인테이너 결정 사항
+# (mydocs/manual/channel_manifests_guide.md §3). 버전·sha256 갱신은
+# tools/update_channel_manifests.py 가 수행한다.
+class Rhwp < Formula
+  desc "HWP/HWPX document engine — parse, edit, render, convert (CLI + MCP server)"
+  homepage "https://github.com/edwardkim/rhwp"
+  version "0.8.2"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/edwardkim/rhwp/releases/download/v0.8.2/rhwp-v0.8.2-macos-aarch64.tar.gz"
+      sha256 "2833431bed6034a0af03f7d889f1a41603e61b4bda5e16c93d2fc58efee5b5ea"
+    else
+      url "https://github.com/edwardkim/rhwp/releases/download/v0.8.2/rhwp-v0.8.2-macos-x86_64.tar.gz"
+      sha256 "7f53cb75dc3ff2a8c3d3178caaa0d3bffb396e7a768d215a747254e79471cbbd"
+    end
+  end
+
+  on_linux do
+    url "https://github.com/edwardkim/rhwp/releases/download/v0.8.2/rhwp-v0.8.2-linux-x86_64.tar.gz"
+    sha256 "3225246533eca2b10ec2926228aee0d1cbf0ea6de0553e053ec8d6cb79fa9570"
+  end
+
+  def install
+    bin.install "rhwp"
+  end
+
+  test do
+    assert_match "rhwp", shell_output("#{bin}/rhwp --version")
+  end
+end

--- a/contrib/packaging/scoop/rhwp.json
+++ b/contrib/packaging/scoop/rhwp.json
@@ -1,0 +1,19 @@
+{
+    "version": "0.8.2",
+    "description": "HWP/HWPX document engine — parse, edit, render, convert (CLI + MCP server)",
+    "homepage": "https://github.com/edwardkim/rhwp",
+    "license": "MIT",
+    "url": "https://github.com/edwardkim/rhwp/releases/download/v0.8.2/rhwp-v0.8.2-windows-x86_64.zip",
+    "hash": "d99b952ce2322d59530b86453a7314ebe18e86bdea165d2b75ef0b2af39ec6de",
+    "extract_dir": "rhwp",
+    "bin": "rhwp.exe",
+    "checkver": {
+        "github": "https://github.com/edwardkim/rhwp"
+    },
+    "autoupdate": {
+        "url": "https://github.com/edwardkim/rhwp/releases/download/v$version/rhwp-v$version-windows-x86_64.zip",
+        "hash": {
+            "url": "https://github.com/edwardkim/rhwp/releases/download/v$version/SHA256SUMS.txt"
+        }
+    }
+}

--- a/contrib/packaging/winget/Edwardkim.rhwp.installer.yaml
+++ b/contrib/packaging/winget/Edwardkim.rhwp.installer.yaml
@@ -1,0 +1,15 @@
+# [#4338 R38] winget 설치 매니페스트 — portable(zip) 배포.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: Edwardkim.rhwp
+PackageVersion: 0.8.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: rhwp\rhwp.exe
+    PortableCommandAlias: rhwp
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/edwardkim/rhwp/releases/download/v0.8.2/rhwp-v0.8.2-windows-x86_64.zip
+    InstallerSha256: D99B952CE2322D59530B86453A7314EBE18E86BDEA165D2B75EF0B2AF39EC6DE
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/contrib/packaging/winget/Edwardkim.rhwp.locale.ko-KR.yaml
+++ b/contrib/packaging/winget/Edwardkim.rhwp.locale.ko-KR.yaml
@@ -1,0 +1,23 @@
+# [#4338 R38] winget 기본 로케일 매니페스트.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: Edwardkim.rhwp
+PackageVersion: 0.8.2
+PackageLocale: ko-KR
+Publisher: edwardkim
+PublisherUrl: https://github.com/edwardkim
+PackageName: rhwp
+PackageUrl: https://github.com/edwardkim/rhwp
+License: MIT
+LicenseUrl: https://github.com/edwardkim/rhwp/blob/main/LICENSE
+ShortDescription: HWP/HWPX 문서 엔진 — 파싱·편집·렌더·변환 (CLI + MCP 서버)
+Description: 한글 HWP/HWPX/HWP3/HML 문서를 읽고 편집·렌더링·변환하는 Rust 문서 엔진의 CLI. 모든 명령이 기계 계약(--json 봉투)을 제공하고, MCP 서버(rhwp mcp-serve)를 내장해 AI 에이전트 호스트에 바로 연결된다.
+Moniker: rhwp
+Tags:
+  - hwp
+  - hwpx
+  - korean
+  - document
+  - cli
+  - mcp
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/contrib/packaging/winget/Edwardkim.rhwp.yaml
+++ b/contrib/packaging/winget/Edwardkim.rhwp.yaml
@@ -1,0 +1,8 @@
+# [#4338 R38] winget 버전 매니페스트 — microsoft/winget-pkgs 제출 원본.
+# 제출 시 저장소 경로는 manifests/e/Edwardkim/rhwp/0.8.2/ 형태가 된다.
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: Edwardkim.rhwp
+PackageVersion: 0.8.2
+DefaultLocale: ko-KR
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/mydocs/manual/channel_manifests_guide.md
+++ b/mydocs/manual/channel_manifests_guide.md
@@ -1,0 +1,73 @@
+---
+kind: guide
+status: active
+canonical: mydocs/manual/channel_manifests_guide.md
+last_verified: 2026-08-09
+---
+
+# 설치 채널 매니페스트 가이드 — scoop·homebrew·winget (R38, #4338)
+
+`contrib/packaging/` 의 매니페스트 3종과 갱신 스크립트의 운영 문서다. 목표는
+R38("설치 1줄")의 채널 축 — 릴리스 바이너리는 이미 존재하므로(#4327 §4), 남은
+것은 각 설치 관리자에 그 바이너리를 잇는 매니페스트다.
+
+**정직 고지**: 채널별 심사·CI 의 세부 요건은 **제출 시점에 해당 채널 문서로
+검증**해야 한다(§5 미검증 목록). 이 저장소의 매니페스트는 제출 원본이며, 여기서
+검증하는 것은 자산 URL·해시의 실물 일치와 갱신 멱등성까지다.
+
+## 1. scoop (Windows) — 머지 즉시 사용 가능
+
+scoop 은 버킷 등재 없이도 매니페스트 raw URL 로 바로 설치할 수 있다:
+
+```
+scoop install https://raw.githubusercontent.com/edwardkim/rhwp/devel/contrib/packaging/scoop/rhwp.json
+```
+
+- `extract_dir: rhwp` — 아카이브가 `rhwp/` 폴더를 담는 구조(release-binary.yml)
+  를 반영한다.
+- `autoupdate` 절이 있어 공식 버킷(main/extras) 제출 시 자동 갱신 대상이 된다.
+  버킷 제출은 후속(§5).
+
+## 2. winget (Windows) — microsoft/winget-pkgs 제출 원본
+
+`contrib/packaging/winget/` 의 3종(version·installer·defaultLocale)이 제출
+단위다. portable(zip) 형식으로 `rhwp\rhwp.exe` 를 `rhwp` 별칭으로 노출한다.
+
+제출 절차(요지): winget-pkgs 포크 →
+`manifests/e/Edwardkim/rhwp/<버전>/` 에 3파일 복사 → PR. `wingetcreate` 또는
+저장소 검증 도구(`winget validate`)로 사전 검증을 권장한다. 스키마 버전
+(1.6.0)·필드 요건은 제출 시점에 winget-pkgs 문서 기준으로 재확인한다.
+
+## 3. homebrew (macOS·linux) — 탭 위치는 메인테이너 결정
+
+`contrib/packaging/homebrew/rhwp.rb` 는 3자산(mac arm/intel·linux)을 덮는다.
+brew 는 "탭(= Formula/ 를 담은 git 저장소)"이 필요하므로 두 경로 중 하나를
+메인테이너가 고른다:
+
+1. **전용 `homebrew-rhwp` 저장소 신설(권장)** — `brew tap edwardkim/rhwp` 가
+   관례대로 동작. 이 파일을 그 저장소 `Formula/rhwp.rb` 로 복사.
+2. 본 저장소 루트에 `Formula/` 추가 — 추가 저장소가 없지만
+   `brew tap edwardkim/rhwp https://github.com/edwardkim/rhwp` 로 전체 저장소를
+   클론하게 된다(무거움).
+
+homebrew-core 제출은 인지도 요건이 있어 후속으로 둔다(§5).
+
+## 4. 릴리스 시 갱신 — 1커맨드
+
+```
+gh release download vX.Y.Z -p SHA256SUMS.txt
+python tools/update_channel_manifests.py X.Y.Z SHA256SUMS.txt
+```
+
+`--check` 는 변경 없이 멱등 검증만 한다(현재 커밋본이 해당 버전 기준 최신인지).
+릴리스 워크플로에 이 갱신을 자동 커밋으로 얹을지는 후속 판단(자동 커밋은 보호
+브랜치 정책과 얽힌다).
+
+## 5. 미검증·후속 목록 (정직)
+
+- winget-pkgs 심사 세부(스키마 최신판·모니커 충돌·설치 검증 VM) — 제출 시 확인.
+- scoop 공식 버킷(main/extras) 등재 기준 — 제출 시 확인.
+- homebrew-core 인지도 요건(스타·다운로드) — 탭 운영 후 재평가.
+- 서명: 현재 무결성은 SHA256SUMS 기반. version_policy.md §8 의 서명 도구 결정
+  후 매니페스트·검증 절차에 반영.
+- linux 추가 채널(AUR·nix 등)은 수요 신호 확인 후.

--- a/mydocs/working/task_m100_4338_stage1.md
+++ b/mydocs/working/task_m100_4338_stage1.md
@@ -1,0 +1,25 @@
+# Task M100 #4338 Stage 1 — R38 설치 채널 매니페스트 (scoop·homebrew·winget)
+
+- 이슈: [#4338](https://github.com/edwardkim/rhwp/issues/4338)
+- 기준 브랜치: `upstream/devel` · 작업 브랜치: `task_m100_4338`
+- 작성일: 2026-08-09 KST · 상태: 문서·매니페스트 전용, 검증 완료
+
+## 산출물
+
+- `contrib/packaging/scoop/rhwp.json` — v0.8.2 실물 해시·`extract_dir: rhwp`
+  (아카이브 구조 실측 반영)·autoupdate 절. 머지 즉시 raw URL 설치 가능.
+- `contrib/packaging/homebrew/rhwp.rb` — 3자산(mac arm/intel·linux). 탭 경로는
+  메인테이너 결정 사항으로 가이드 §3 에 두 안 제시.
+- `contrib/packaging/winget/` 3종 — portable zip, `rhwp\rhwp.exe` → `rhwp` 별칭.
+- `tools/update_channel_manifests.py` — SHA256SUMS 로 5개 매니페스트 일괄
+  갱신 + `--check` 멱등 검증.
+- `mydocs/manual/channel_manifests_guide.md` — 채널별 설치·제출·갱신 절차와
+  **미검증 요건 정직 목록**(§5).
+
+## 검증
+
+- 갱신 스크립트 멱등 실증: `update_channel_manifests.py 0.8.2 SHA256SUMS.txt
+  --check` → "5개 매니페스트가 v0.8.2 기준 최신" (실물 릴리스 자산 해시 대조).
+- scoop JSON 파싱 유효성 확인. 문서 메타데이터·상대 링크 검사 이상 없음.
+- 코드·워크플로 무변경 — Cargo·WASM·시각 검증 해당 없음. 채널 심사 세부 요건은
+  제출 시점 검증(가이드 §5 명시).

--- a/tools/update_channel_manifests.py
+++ b/tools/update_channel_manifests.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""[#4338 R38] 설치 채널 매니페스트(scoop·homebrew·winget)의 버전·해시 일괄 갱신.
+
+사용법::
+
+    # 릴리스 자산의 SHA256SUMS.txt 를 받아서:
+    #   gh release download vX.Y.Z -p SHA256SUMS.txt
+    python tools/update_channel_manifests.py X.Y.Z SHA256SUMS.txt
+    python tools/update_channel_manifests.py X.Y.Z SHA256SUMS.txt --check  # 멱등 검증
+
+``--check`` 는 파일을 바꾸지 않고, 현재 커밋본이 주어진 버전·해시로 재생성한
+결과와 다르면 exit 1 — 릴리스 후 매니페스트 갱신을 잊은 상태를 잡는다.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PKG = ROOT / "contrib" / "packaging"
+
+ASSETS = {
+    "linux": "rhwp-v{v}-linux-x86_64.tar.gz",
+    "mac_arm": "rhwp-v{v}-macos-aarch64.tar.gz",
+    "mac_x64": "rhwp-v{v}-macos-x86_64.tar.gz",
+    "windows": "rhwp-v{v}-windows-x86_64.zip",
+}
+
+
+def parse_sums(path: Path, version: str) -> dict:
+    """SHA256SUMS.txt → {키: 해시}. 네 자산이 전부 있어야 한다."""
+    table = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        parts = line.split()
+        if len(parts) == 2:
+            table[parts[1]] = parts[0]
+    out = {}
+    for key, pattern in ASSETS.items():
+        name = pattern.format(v=version)
+        if name not in table:
+            sys.exit(f"SHA256SUMS 에 {name} 이 없습니다 — 태그와 파일이 맞는지 확인하세요")
+        out[key] = table[name]
+    return out
+
+
+def sub_all(text: str, pairs: list, path: str) -> str:
+    for pattern, repl in pairs:
+        text, n = re.subn(pattern, repl, text)
+        if n == 0:
+            sys.exit(f"{path}: 패턴 미발견 — 매니페스트 구조가 바뀌었으면 이 스크립트를 함께 고치세요\n  {pattern}")
+    return text
+
+
+def render(version: str, sums: dict) -> dict:
+    """경로 → 갱신된 본문."""
+    v = version
+    out = {}
+
+    scoop = PKG / "scoop" / "rhwp.json"
+    out[scoop] = sub_all(
+        scoop.read_text(encoding="utf-8"),
+        [
+            (r'"version": "[^"]+"', f'"version": "{v}"'),
+            (r'download/v[0-9][^/]*/rhwp-v[0-9][^-]*-windows', f"download/v{v}/rhwp-v{v}-windows"),
+            (r'"hash": "[0-9a-f]{64}"', f'"hash": "{sums["windows"]}"'),
+        ],
+        str(scoop),
+    )
+
+    brew = PKG / "homebrew" / "rhwp.rb"
+    text = brew.read_text(encoding="utf-8")
+    text = sub_all(
+        text,
+        [(r'version "[^"]+"', f'version "{v}"'),
+         (r"download/v[0-9][^/]*/", f"download/v{v}/"),
+         (r"rhwp-v[0-9][^-]*-", f"rhwp-v{v}-")],
+        str(brew),
+    )
+    for key, marker in (("mac_arm", "macos-aarch64"), ("mac_x64", "macos-x86_64"), ("linux", "linux-x86_64")):
+        # url 줄 다음의 sha256 줄을 자산별로 짝지어 치환한다.
+        pattern = rf'({re.escape(marker)}\.tar\.gz"\s*\n\s*sha256 ")[0-9a-f]{{64}}'
+        text, n = re.subn(pattern, rf"\g<1>{sums[key]}", text)
+        if n != 1:
+            sys.exit(f"{brew}: {marker} sha256 치환 실패 (매치 {n}건)")
+    out[brew] = text
+
+    for name in ("Edwardkim.rhwp.yaml", "Edwardkim.rhwp.installer.yaml", "Edwardkim.rhwp.locale.ko-KR.yaml"):
+        p = PKG / "winget" / name
+        pairs = [(r"PackageVersion: [0-9][^\s]*", f"PackageVersion: {v}")]
+        if "installer" in name:
+            pairs += [
+                (r"download/v[0-9][^/]*/rhwp-v[0-9][^-]*-windows", f"download/v{v}/rhwp-v{v}-windows"),
+                (r"InstallerSha256: [0-9A-F]{64}", f"InstallerSha256: {sums['windows'].upper()}"),
+            ]
+        out[p] = sub_all(p.read_text(encoding="utf-8"), pairs, str(p))
+
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("version", help="릴리스 버전 (v 없이)")
+    ap.add_argument("sums", type=Path, help="해당 릴리스의 SHA256SUMS.txt 경로")
+    ap.add_argument("--check", action="store_true", help="변경 없이 멱등 검증만")
+    args = ap.parse_args()
+
+    sums = parse_sums(args.sums, args.version)
+    rendered = render(args.version, sums)
+
+    drift = [str(p) for p, text in rendered.items() if p.read_text(encoding="utf-8") != text]
+    if args.check:
+        if drift:
+            sys.exit("매니페스트가 낡았습니다 (재생성과 다름):\n  " + "\n  ".join(drift))
+        print(f"멱등 확인: {len(rendered)}개 매니페스트가 v{args.version} 기준 최신")
+        return
+
+    for p, text in rendered.items():
+        p.write_text(text, encoding="utf-8")
+    print(f"갱신 완료: {len(rendered)}개 매니페스트 → v{args.version}" + (f" (변경 {len(drift)}건)" if drift else " (변경 없음)"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 변경 요약

**R38 잔여 — 설치 관리자 채널 매니페스트 실물**입니다 (#4327 §4 → 트랙 D R38). 릴리스 바이너리는 이미 존재하므로, 각 설치 관리자에 그 바이너리를 잇는 매니페스트가 이 PR 의 내용입니다.

- **scoop** (`contrib/packaging/scoop/rhwp.json`) — **머지 즉시 설치 가능**: `scoop install <raw URL>`. v0.8.2 실물 sha256, 아카이브 구조(`rhwp/` 폴더) 실측 반영(`extract_dir`), 공식 버킷 제출 대비 autoupdate 절 포함.
- **homebrew** (`contrib/packaging/homebrew/rhwp.rb`) — mac arm/intel·linux 3자산. 탭 경로는 메인테이너 결정 사항으로 가이드 §3 에 2안(전용 homebrew-rhwp 저장소 권장 / 루트 Formula) 제시.
- **winget** (`contrib/packaging/winget/` 3종) — Edwardkim.rhwp portable zip 매니페스트(version·installer·defaultLocale), microsoft/winget-pkgs 제출 원본.
- **갱신 1커맨드** (`tools/update_channel_manifests.py`) — 릴리스의 SHA256SUMS.txt 로 5개 매니페스트 버전·해시 일괄 갱신 + `--check` 멱등 게이트. **v0.8.2 실물 해시로 멱등 실증 완료**("5개 매니페스트가 v0.8.2 기준 최신").
- **가이드** (`mydocs/manual/channel_manifests_guide.md`) — 채널별 설치·제출·갱신 절차와 **미검증 요건 정직 목록**(§5: winget 심사 세부·scoop 공식 버킷 기준·homebrew-core 요건·서명은 version_policy §8 결정 후).

## 관련 이슈

closes #4338

## 테스트

- [ ] `cargo test` / `cargo clippy` — 해당 없음(코드·워크플로 무변경, 매니페스트·스크립트·문서만)
- [ ] SVG / WASM — 해당 없음
- [x] `update_channel_manifests.py 0.8.2 SHA256SUMS.txt --check` 멱등 통과(실물 릴리스 자산 해시 대조) · scoop JSON 파싱 유효 · 문서 메타데이터·상대 링크 검사 이상 없음 · `git diff --check` 통과

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음
- 재현·측정: 해당 없음

## 스크린샷

해당 없음
