### PR TITLE
feat(python): #4340 U1 — rhwp.integrations 동봉 (LangChain·LlamaIndex 쪽 단위 로더, 선택 의존성)

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -180,3 +180,21 @@ pytest tests/ -q -m "not integration"     # 바이너리 없이 단위만
 ## 라이선스
 
 MIT — rhwp 본체와 동일합니다.
+
+## 프레임워크 로더 (선택 의존성, #4340)
+
+RAG 파이프라인에 쪽 단위로 꽂는 어댑터를 동봉한다 — 본체는 여전히 의존성 0 이고,
+어댑터가 각 프레임워크를 사용 시점에 지연 임포트한다(미설치면 설치 힌트 예외).
+
+```python
+# pip install langchain-core
+from rhwp.integrations.langchain import RHWPLoader
+docs = RHWPLoader("공문.hwp").load()   # 쪽마다 Document — metadata: source/format/page/total_pages
+
+# pip install llama-index-core
+from rhwp.integrations.llama_index import RHWPReader
+docs = RHWPReader().load_data("공문.hwp")
+```
+
+쪽 번호(`page`)는 1-기반 위치 번호다 — 검색 결과를 "몇 쪽"으로 되짚는 인용
+근거가 공공 문서 활용의 상수라서, 로더가 결정론적으로 부여한다.

--- a/bindings/python/src/rhwp/integrations/__init__.py
+++ b/bindings/python/src/rhwp/integrations/__init__.py
@@ -1,0 +1,12 @@
+"""[#4340 U1] 프레임워크 통합 어댑터 — 선택 의존성.
+
+이 하위 패키지는 rhwp 를 RAG·에이전트 프레임워크에 꽂는 어댑터를 담는다:
+
+- :mod:`rhwp.integrations.langchain` — ``RHWPLoader`` (LangChain 문서 로더)
+- :mod:`rhwp.integrations.llama_index` — ``RHWPReader`` (LlamaIndex 리더)
+
+**여기서는 아무것도 임포트하지 않는다.** 본 패키지의 "런타임 의존성 0" 계약을
+지키기 위해 각 어댑터는 자기 프레임워크를 **사용 시점에** 지연 임포트하고,
+미설치면 설치 힌트를 담은 ``ImportError`` 를 낸다 — 어댑터의 존재가 rhwp 설치를
+무겁게 만들면 안 된다.
+"""

--- a/bindings/python/src/rhwp/integrations/langchain.py
+++ b/bindings/python/src/rhwp/integrations/langchain.py
@@ -1,0 +1,96 @@
+"""[#4340 U1] LangChain 문서 로더 — HWP/HWPX 를 쪽 단위 Document 로.
+
+사용법::
+
+    pip install rhwp langchain-core
+
+    from rhwp.integrations.langchain import RHWPLoader
+
+    docs = RHWPLoader("공문.hwp").load()          # 쪽마다 Document 하나
+    docs = RHWPLoader("공문.hwp", per_page=False).load()  # 문서 전체 하나
+
+데이터 계약(실측, #4340): ``export-text --json`` 봉투의 ``pages[] = {page, text}``
+를 그대로 소비한다. metadata 는 ``{source, format, page, total_pages}`` — 쪽
+번호가 있어야 검색 결과를 "몇 쪽" 으로 되짚을 수 있다(발췌 근거 요구는 공공
+문서 RAG 의 상수다).
+
+의존성: ``langchain-core`` 만 지연 임포트한다(미설치면 설치 힌트를 담은
+``ImportError``). 모듈 임포트 자체는 프레임워크 없이 성공한다.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Union
+
+from .. import commands
+
+__all__ = ["RHWPLoader"]
+
+PathLike = Union[str, Path]
+
+_INSTALL_HINT = (
+    "rhwp.integrations.langchain 은 langchain-core 가 필요합니다.\n"
+    "  pip install langchain-core\n"
+    "(rhwp 본체는 프레임워크 없이 동작합니다 — 이 어댑터만 선택 의존성입니다.)"
+)
+
+
+def _document_cls() -> Any:
+    """``langchain_core.documents.Document`` 를 지연 임포트한다."""
+    try:
+        module = importlib.import_module("langchain_core.documents")
+    except ImportError as exc:  # pragma: no cover - 힌트 경로는 테스트가 모킹으로 고정
+        raise ImportError(_INSTALL_HINT) from exc
+    return module.Document
+
+
+class RHWPLoader:
+    """HWP/HWPX → LangChain ``Document`` 로더.
+
+    LangChain ``BaseLoader`` 프로토콜(``load``/``lazy_load``)을 구현한다.
+    기반 클래스를 상속하지 않는 이유는 하나다 — 상속하면 이 모듈의 임포트가
+    프레임워크 설치를 요구하게 되고, 선택 의존성 원칙이 깨진다.
+    """
+
+    def __init__(
+        self,
+        path: PathLike,
+        *,
+        per_page: bool = True,
+        timeout: Optional[float] = commands.DEFAULT_TIMEOUT,
+    ) -> None:
+        self._path = Path(path)
+        self._per_page = per_page
+        self._timeout = timeout
+
+    def lazy_load(self) -> Iterator[Any]:
+        """쪽 단위(기본) 또는 문서 단위로 ``Document`` 를 낸다."""
+        document = _document_cls()
+        meta = commands.info(self._path, timeout=self._timeout)
+        base: Dict[str, Any] = {
+            "source": str(self._path),
+            "format": meta["format"],
+            "total_pages": meta["pageCount"],
+        }
+        envelope = commands.export_text(self._path, timeout=self._timeout)
+        pages = envelope["pages"]
+        if self._per_page:
+            # 쪽 번호는 배열 위치로 1-기반 부여한다. 실측(#4340): 봉투의
+            # pages[].page 는 전체 내보내기에서 0-기반, -p 지정에서 1-기반으로
+            # 일관되지 않아, 인용용 번호는 위치에서 결정론적으로 만든다.
+            for number, page in enumerate(pages, start=1):
+                yield document(
+                    page_content=page["text"],
+                    metadata={**base, "page": number},
+                )
+        else:
+            yield document(
+                page_content="".join(page["text"] for page in pages),
+                metadata=base,
+            )
+
+    def load(self) -> List[Any]:
+        """``lazy_load`` 를 전부 소진한 리스트."""
+        return list(self.lazy_load())

--- a/bindings/python/src/rhwp/integrations/llama_index.py
+++ b/bindings/python/src/rhwp/integrations/llama_index.py
@@ -1,0 +1,76 @@
+"""[#4340 U1] LlamaIndex 리더 — HWP/HWPX 를 쪽 단위 Document 로.
+
+사용법::
+
+    pip install rhwp llama-index-core
+
+    from rhwp.integrations.llama_index import RHWPReader
+
+    docs = RHWPReader().load_data("공문.hwp")
+
+계약은 :mod:`rhwp.integrations.langchain` 과 동형이다 — 같은 ``pages[]`` 실측
+봉투, 같은 metadata(``source``/``format``/``page``/``total_pages``), 같은 선택
+의존성 원칙(지연 임포트 + 미설치 시 설치 힌트 ``ImportError``).
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+from .. import commands
+
+__all__ = ["RHWPReader"]
+
+PathLike = Union[str, Path]
+
+_INSTALL_HINT = (
+    "rhwp.integrations.llama_index 는 llama-index-core 가 필요합니다.\n"
+    "  pip install llama-index-core\n"
+    "(rhwp 본체는 프레임워크 없이 동작합니다 — 이 어댑터만 선택 의존성입니다.)"
+)
+
+
+def _document_cls() -> Any:
+    """``llama_index.core.schema.Document`` 를 지연 임포트한다."""
+    try:
+        module = importlib.import_module("llama_index.core.schema")
+    except ImportError as exc:  # pragma: no cover - 힌트 경로는 테스트가 모킹으로 고정
+        raise ImportError(_INSTALL_HINT) from exc
+    return module.Document
+
+
+class RHWPReader:
+    """HWP/HWPX → LlamaIndex ``Document`` 리더 (``load_data`` 프로토콜)."""
+
+    def __init__(self, *, per_page: bool = True) -> None:
+        self._per_page = per_page
+
+    def load_data(
+        self,
+        file: PathLike,
+        extra_info: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = commands.DEFAULT_TIMEOUT,
+    ) -> List[Any]:
+        document = _document_cls()
+        path = Path(file)
+        meta = commands.info(path, timeout=timeout)
+        base: Dict[str, Any] = {
+            "source": str(path),
+            "format": meta["format"],
+            "total_pages": meta["pageCount"],
+            **(extra_info or {}),
+        }
+        envelope = commands.export_text(path, timeout=timeout)
+        pages = envelope["pages"]
+        if self._per_page:
+            # 쪽 번호는 배열 위치로 1-기반 부여 — langchain 어댑터와 동일 사유.
+            return [
+                document(text=page["text"], metadata={**base, "page": number})
+                for number, page in enumerate(pages, start=1)
+            ]
+        return [
+            document(text="".join(page["text"] for page in pages), metadata=base)
+        ]

--- a/bindings/python/tests/test_integrations.py
+++ b/bindings/python/tests/test_integrations.py
@@ -1,0 +1,70 @@
+"""[#4340 U1] 프레임워크 통합 어댑터 계약.
+
+세 가지를 고정한다: ① 어댑터 모듈 임포트는 프레임워크 없이 성공한다(선택
+의존성), ② 미설치면 설치 힌트를 담은 ImportError 가 난다, ③ 설치돼 있으면
+실물 문서에서 쪽 단위 Document 계약(개수·metadata)이 지켜진다.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+SAMPLE = (
+    Path(__file__).resolve().parents[3]
+    / "samples"
+    / "basic"
+    / "issue2007_nested_cell_pagination_42065.hwp"
+)
+
+
+def test_import_needs_no_framework() -> None:
+    """어댑터 모듈 임포트 자체는 프레임워크 미설치여도 성공해야 한다."""
+    for name in ("rhwp.integrations.langchain", "rhwp.integrations.llama_index"):
+        importlib.import_module(name)
+
+
+def test_missing_framework_raises_install_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """미설치 경로: pip 설치 힌트를 담은 ImportError — 조용한 실패 금지."""
+    from rhwp.integrations import langchain as lc
+
+    def boom(name: str) -> object:
+        raise ImportError(f"No module named {name!r}")
+
+    monkeypatch.setattr(lc.importlib, "import_module", boom)
+    with pytest.raises(ImportError, match="pip install langchain-core"):
+        lc.RHWPLoader(SAMPLE).load()
+
+
+@pytest.mark.integration
+def test_langchain_loader_yields_page_documents() -> None:
+    """실물 문서 → 쪽수만큼 Document, metadata 계약(source/format/page/total_pages)."""
+    pytest.importorskip("langchain_core")
+    from rhwp.integrations.langchain import RHWPLoader
+
+    docs = RHWPLoader(SAMPLE).load()
+    assert len(docs) == 17  # 실측 쪽수 (rhwp info)
+    first = docs[0]
+    assert first.metadata["page"] == 1
+    assert first.metadata["total_pages"] == 17
+    assert first.metadata["format"] == "hwp5"
+    assert first.metadata["source"].endswith(".hwp")
+    assert any(doc.page_content.strip() for doc in docs)
+
+    whole = RHWPLoader(SAMPLE, per_page=False).load()
+    assert len(whole) == 1
+    assert "page" not in whole[0].metadata
+    assert whole[0].page_content == "".join(d.page_content for d in docs)
+
+
+@pytest.mark.integration
+def test_llama_index_reader_matches_contract() -> None:
+    pytest.importorskip("llama_index.core")
+    from rhwp.integrations.llama_index import RHWPReader
+
+    docs = RHWPReader().load_data(SAMPLE, extra_info={"corpus": "unit"})
+    assert len(docs) == 17
+    assert docs[0].metadata["corpus"] == "unit"
+    assert docs[0].metadata["page"] == 1

--- a/mydocs/working/task_m100_4340_stage1.md
+++ b/mydocs/working/task_m100_4340_stage1.md
@@ -1,0 +1,25 @@
+# Task M100 #4340 Stage 1 — U1 1단계: rhwp.integrations (LangChain·LlamaIndex)
+
+- 이슈: [#4340](https://github.com/edwardkim/rhwp/issues/4340)
+- 기준: `upstream/devel` · 브랜치 `task_m100_4340` · 2026-08-09 KST · 구현·검증 완료
+
+## 산출물
+- `src/rhwp/integrations/{__init__,langchain,llama_index}.py` — 쪽 단위 Document
+  로더/리더. 선택 의존성 원칙: 모듈 임포트는 프레임워크 무요구, 사용 시점 지연
+  임포트 + 미설치 시 pip 힌트 ImportError. 본체 "런타임 의존성 0" 유지.
+- `tests/test_integrations.py` 4본 — 무의존 임포트·미설치 힌트(모킹)·실물 17쪽
+  계약(langchain)·llama(importorskip, CI 스킵).
+- python README 에 사용 절 추가.
+
+## 실측·판단 기록
+- export-text 봉투 `pages[]` 실측: 전체 내보내기 `page` 0-기반(0..16), `-p N`
+  지정 시 1-기반 에코 — **봉투 내부 비일관 관찰**. 로더는 인용용 쪽 번호를
+  배열 위치 기반 1-기반으로 결정론 부여(코드 주석·README 명시). 상류 봉투
+  정합 여부 판단은 메인테이너 몫으로 PR 본문에 관찰만 남김.
+- metadata 계약: source/format/page/total_pages (+llama extra_info 병합).
+
+## 검증
+- `pytest` 전체: **297 passed, 1 skipped**(llama 미설치 스킵) — 신규 4본 포함,
+  기존 294 무회귀. langchain-core 는 로컬 설치로 실통합 검증.
+- 프레임워크 미설치 CI 에서는 통합 2본이 명시 스킵되고 나머지 green 이어야
+  한다(무의존 임포트 테스트가 그 계약을 고정).


### PR DESCRIPTION
## 변경 요약

**U1(#4327 §7) 1단계** — 파이썬 바인딩에 LangChain·LlamaIndex 어댑터(`rhwp.integrations`)를 동봉합니다. 근거는 수요 실측(#4327 §2): 실사용 선택의 결정타가 "프레임워크 공식 통합"이었고, 표준 RAG ETL 의 HWP 공백과 `parse hwp python` 검색 도달 0 이 그 파이의 크기입니다. `pip install rhwp langchain-core` 두 줄이면 공문서 RAG 에 HWP 가 꽂힙니다(외부 저장소 공식 등재는 R63 착지 후 2단계).

- `rhwp/integrations/langchain.py` — `RHWPLoader`(`lazy_load`/`load`): 쪽마다 `Document`, metadata `{source, format, page, total_pages}`. `per_page=False` 로 문서 단위.
- `rhwp/integrations/llama_index.py` — `RHWPReader.load_data`(+`extra_info` 병합), 동형 계약.
- **선택 의존성 원칙**: 모듈 임포트는 프레임워크를 요구하지 않고(지연 임포트), 미설치면 pip 힌트를 담은 `ImportError`. 본체 "런타임 의존성 0" 계약 유지 — 기반 클래스를 상속하지 않는 이유를 코드에 명시.
- 테스트 4본: 무의존 임포트 · 미설치 힌트(모킹) · 실물 문서 17쪽 계약(langchain) · llama(`importorskip`).

### 실측 관찰 1건 (판단은 메인테이너 몫)

`export-text --json` 봉투의 `pages[].page` 가 **전체 내보내기에서는 0-기반(0..16), `-p N` 지정 시에는 1-기반 에코**로 비일관합니다. 로더는 인용용 쪽 번호를 배열 위치 기반 1-기반으로 결정론 부여해 이 비일관을 소비자에게 노출하지 않지만, 봉투 자체의 정합 여부는 별도 판단 대상으로 관찰만 남깁니다.

## 관련 이슈

closes #4340

## 테스트

- [ ] `cargo test` / `cargo clippy` — 해당 없음(파이썬 바인딩 전용)
- [ ] SVG / WASM — 해당 없음
- [x] `pytest` 전체 **297 passed, 1 skipped**(llama 미설치 스킵) — 기존 294 무회귀 + 신규 4본. langchain-core 로컬 설치로 실통합(17쪽 Document·metadata 계약) 검증
- 프레임워크 미설치 CI 에서는 통합 2본이 명시 스킵되고 나머지가 green — 무의존 임포트 테스트가 그 계약을 고정

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 (신규 선택 모듈)
- 재현·측정: 해당 없음

## 스크린샷

해당 없음
