### PR TITLE
feat(node): #4349 npx 원라인 MCP — rhwp-mcp bin (findBinary 재사용, initialize 왕복 실증)

### DIFF
--- a/bindings/node/bin/rhwp-mcp.cjs
+++ b/bindings/node/bin/rhwp-mcp.cjs
@@ -10,13 +10,46 @@
  */
 'use strict';
 
-const { spawn } = require('node:child_process');
+const { spawn, spawnSync } = require('node:child_process');
+const path = require('node:path');
 
 const SHUTDOWN_GRACE_MS = 5_000;
 
 function fail(message) {
   process.stderr.write(message + '\n');
   process.exit(2);
+}
+
+function childIsRunning(child) {
+  return child.exitCode === null && child.signalCode === null;
+}
+
+function killChild(child, signal) {
+  if (!childIsRunning(child)) return false;
+  try {
+    return child.kill(signal);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 강제 종료를 wrapper가 통제하는 경로에서는 Windows도 direct child만 남기지
+ * 않고 process tree 전체를 닫는다. 외부 TerminateProcess가 wrapper 자체를
+ * 바로 끊는 경우에는 이 함수가 실행되지 않으므로 Job Object의 대체물은 아니다.
+ */
+function forceKillChildTree(child) {
+  if (!childIsRunning(child)) return false;
+  if (process.platform === 'win32' && Number.isInteger(child.pid) && child.pid > 0) {
+    const windowsRoot = process.env.SystemRoot || process.env.windir || 'C:\\Windows';
+    const taskkill = path.join(windowsRoot, 'System32', 'taskkill.exe');
+    const result = spawnSync(taskkill, ['/PID', String(child.pid), '/T', '/F'], {
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    if (result.status === 0) return true;
+  }
+  return killChild(child, 'SIGKILL');
 }
 
 function main() {
@@ -51,28 +84,25 @@ function main() {
   let forceKillTimer;
   const signalHandlers = new Map();
 
-  const childIsRunning = () => child.exitCode === null && child.signalCode === null;
-  const killChild = (signal) => {
-    if (!childIsRunning()) return false;
-    try {
-      return child.kill(signal);
-    } catch {
-      return false;
-    }
-  };
-
   // MCP hosts usually stop stdio servers by closing stdin. If they signal the
   // wrapper PID instead, the real server must receive the same signal rather
   // than surviving as an orphan. A second signal (or the grace timeout) is an
   // explicit request to stop waiting for graceful shutdown.
   const forwardSignal = (signal) => {
     if (shutdownSignal !== undefined) {
-      killChild('SIGKILL');
+      forceKillChildTree(child);
       return;
     }
     shutdownSignal = signal;
-    if (!killChild(signal)) return;
-    forceKillTimer = setTimeout(() => killChild('SIGKILL'), SHUTDOWN_GRACE_MS);
+    // Windows child.kill(signal)은 direct process를 TerminateProcess로 끊어
+    // 손자 프로세스를 남길 수 있다. handler가 실제로 실행된 경로에서는 처음부터
+    // taskkill /T /F로 tree를 닫는다. POSIX는 기존 graceful forwarding을 유지한다.
+    if (process.platform === 'win32') {
+      forceKillChildTree(child);
+      return;
+    }
+    if (!killChild(child, signal)) return;
+    forceKillTimer = setTimeout(() => forceKillChildTree(child), SHUTDOWN_GRACE_MS);
   };
 
   for (const signal of ['SIGINT', 'SIGTERM']) {
@@ -85,7 +115,7 @@ function main() {
   // wrapper alive until the child is reaped; this hook is only a last-resort,
   // synchronous termination request.
   const stopChildOnWrapperExit = () => {
-    killChild('SIGTERM');
+    forceKillChildTree(child);
   };
   process.once('exit', stopChildOnWrapperExit);
 
@@ -107,4 +137,7 @@ function main() {
   });
 }
 
-main();
+// bin을 require하는 Windows process-tree 회귀는 실제 server를 기동하지 않는다.
+module.exports = { forceKillChildTree };
+
+if (require.main === module) main();

--- a/bindings/node/bin/rhwp-mcp.cjs
+++ b/bindings/node/bin/rhwp-mcp.cjs
@@ -12,6 +12,8 @@
 
 const { spawn } = require('node:child_process');
 
+const SHUTDOWN_GRACE_MS = 5_000;
+
 function fail(message) {
   process.stderr.write(message + '\n');
   process.exit(2);
@@ -44,8 +46,65 @@ function main() {
   const child = spawn(binary, ['mcp-serve', ...process.argv.slice(2)], {
     stdio: 'inherit',
   });
-  child.on('error', (err) => fail(`rhwp 실행 실패: ${err.message}`));
-  child.on('exit', (code, signal) => process.exit(signal ? 1 : code == null ? 1 : code));
+
+  let shutdownSignal;
+  let forceKillTimer;
+  const signalHandlers = new Map();
+
+  const childIsRunning = () => child.exitCode === null && child.signalCode === null;
+  const killChild = (signal) => {
+    if (!childIsRunning()) return false;
+    try {
+      return child.kill(signal);
+    } catch {
+      return false;
+    }
+  };
+
+  // MCP hosts usually stop stdio servers by closing stdin. If they signal the
+  // wrapper PID instead, the real server must receive the same signal rather
+  // than surviving as an orphan. A second signal (or the grace timeout) is an
+  // explicit request to stop waiting for graceful shutdown.
+  const forwardSignal = (signal) => {
+    if (shutdownSignal !== undefined) {
+      killChild('SIGKILL');
+      return;
+    }
+    shutdownSignal = signal;
+    if (!killChild(signal)) return;
+    forceKillTimer = setTimeout(() => killChild('SIGKILL'), SHUTDOWN_GRACE_MS);
+  };
+
+  for (const signal of ['SIGINT', 'SIGTERM']) {
+    const handler = () => forwardSignal(signal);
+    signalHandlers.set(signal, handler);
+    process.on(signal, handler);
+  }
+
+  // Covers an explicit process.exit() path. Signal handlers above keep the
+  // wrapper alive until the child is reaped; this hook is only a last-resort,
+  // synchronous termination request.
+  const stopChildOnWrapperExit = () => {
+    killChild('SIGTERM');
+  };
+  process.once('exit', stopChildOnWrapperExit);
+
+  const cleanup = () => {
+    if (forceKillTimer !== undefined) clearTimeout(forceKillTimer);
+    process.removeListener('exit', stopChildOnWrapperExit);
+    for (const [signal, handler] of signalHandlers) {
+      process.removeListener(signal, handler);
+    }
+  };
+
+  child.once('error', (err) => {
+    cleanup();
+    fail(`rhwp 실행 실패: ${err.message}`);
+  });
+  child.once('exit', (code, signal) => {
+    cleanup();
+    process.exitCode = signal ? 1 : code == null ? 1 : code;
+  });
 }
 
 main();

--- a/bindings/node/bin/rhwp-mcp.cjs
+++ b/bindings/node/bin/rhwp-mcp.cjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * [#4349] npx 원라인 MCP — `npx -p @rhwp/node rhwp-mcp` 로 rhwp MCP 서버를 연다.
+ *
+ * 바이너리 탐색은 패키지의 `findBinary()`(RHWP_BIN → 패키지 동봉 → PATH, D-14
+ * 계약)를 **그대로 재사용**한다 — 여기서 탐색을 다시 쓰면 두 규칙이 갈라진다.
+ * 찾으면 `rhwp mcp-serve` 를 stdio 상속으로 실행해 이 프로세스가 곧 MCP
+ * 서버(stdio JSON-RPC)가 된다. 못 찾으면 설치 경로를 안내하고 exit 2(사용법
+ * 오류 계열 — #2707 사전과 정합).
+ */
+'use strict';
+
+const { spawn } = require('node:child_process');
+
+function fail(message) {
+  process.stderr.write(message + '\n');
+  process.exit(2);
+}
+
+function main() {
+  let findBinary;
+  try {
+    ({ findBinary } = require('../dist/index.cjs'));
+  } catch (err) {
+    fail(
+      '@rhwp/node 빌드 산출물(dist)이 없습니다. 저장소 클론이라면 먼저: cd bindings/node && npm ci && npm run build\n' +
+        `원인: ${err && err.message}`
+    );
+  }
+
+  let binary;
+  try {
+    binary = findBinary();
+  } catch (err) {
+    fail(
+      (err && err.message ? err.message + '\n' : '') +
+        'rhwp 실행 파일이 필요합니다 — 설치 1줄:\n' +
+        '  · Releases 바이너리: https://github.com/edwardkim/rhwp/releases/latest\n' +
+        '  · Windows(scoop): scoop install https://raw.githubusercontent.com/edwardkim/rhwp/devel/contrib/packaging/scoop/rhwp.json\n' +
+        '  · 또는 RHWP_BIN=/path/to/rhwp 지정'
+    );
+  }
+
+  const child = spawn(binary, ['mcp-serve', ...process.argv.slice(2)], {
+    stdio: 'inherit',
+  });
+  child.on('error', (err) => fail(`rhwp 실행 실패: ${err.message}`));
+  child.on('exit', (code, signal) => process.exit(signal ? 1 : code == null ? 1 : code));
+}
+
+main();

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -56,7 +56,11 @@
     },
     "./package.json": "./package.json"
   },
+  "bin": {
+    "rhwp-mcp": "bin/rhwp-mcp.cjs"
+  },
   "files": [
+    "bin",
     "dist",
     "README.md",
     "CHANGELOG.md"

--- a/bindings/node/test/mcp-bin.integration.test.ts
+++ b/bindings/node/test/mcp-bin.integration.test.ts
@@ -3,13 +3,30 @@
  *
  * ① 실 바이너리로 initialize JSON-RPC 왕복이 되고(스크립트가 곧 stdio MCP 서버),
  * ② 바이너리 미발견이면 설치 안내와 exit 2 — 조용한 실패 금지.
+ *
+ * **통합 파일인 이유** (vitest.config.ts 의 파일 이름 규칙): ① 은 실 rhwp 바이너리가
+ * 필요하고, bin 스크립트 자체가 소스가 아니라 배포 산출물(`dist/index.cjs`)의
+ * `findBinary` 를 재사용한다 — "바이너리 없이 도는" 단위 프로젝트에서는 이 계약을
+ * 밟을 수 없다. dist 는 npm 배포물에는 항상 있지만 클론·CI 에는 없으므로,
+ * 여기서 한 번 빌드해 실제 배포물과 같은 경로를 검증한다.
  */
-import { spawn } from 'node:child_process';
+import { execSync, spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
-const BIN = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'bin', 'rhwp-mcp.cjs');
+const PKG_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const BIN = path.join(PKG_ROOT, 'bin', 'rhwp-mcp.cjs');
+const DIST_ENTRY = path.join(PKG_ROOT, 'dist', 'index.cjs');
+
+beforeAll(() => {
+  // bin 이 require 하는 배포 산출물이 없으면 만들어 둔다 — 통합 프로젝트의
+  // hookTimeout(120s) 안에서 tsup+tsc 가 끝난다.
+  if (!existsSync(DIST_ENTRY)) {
+    execSync('npm run build', { cwd: PKG_ROOT, stdio: 'inherit' });
+  }
+});
 
 function runOnce(env: NodeJS.ProcessEnv, input?: string): Promise<{ code: number | null; out: string; err: string }> {
   return new Promise((resolve) => {

--- a/bindings/node/test/mcp-bin.integration.test.ts
+++ b/bindings/node/test/mcp-bin.integration.test.ts
@@ -11,7 +11,9 @@
  * 여기서 한 번 빌드해 실제 배포물과 같은 경로를 검증한다.
  */
 import { execSync, spawn } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
@@ -20,6 +22,10 @@ import { beforeAll, describe, expect, it } from 'vitest';
 const PKG_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
 const BIN = path.join(PKG_ROOT, 'bin', 'rhwp-mcp.cjs');
 const DIST_ENTRY = path.join(PKG_ROOT, 'dist', 'index.cjs');
+const require = createRequire(import.meta.url);
+const { forceKillChildTree } = require(BIN) as {
+  forceKillChildTree: (child: ChildProcess) => boolean;
+};
 
 beforeAll(() => {
   // bin 이 require 하는 배포 산출물이 없으면 만들어 둔다 — 통합 프로젝트의
@@ -111,6 +117,80 @@ async function expectSignalForwarded(signal: 'SIGINT' | 'SIGTERM'): Promise<void
   }
 }
 
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`PID ${pid}가 ${timeoutMs}ms 뒤에도 실행 중입니다`);
+}
+
+async function expectWindowsProcessTreeKilled(): Promise<void> {
+  const dir = mkdtempSync(path.join(tmpdir(), 'rhwp-mcp-tree-'));
+  const parentScript = path.join(dir, 'parent.cjs');
+  writeFileSync(
+    parentScript,
+    [
+      "'use strict';",
+      "const { spawn } = require('node:child_process');",
+      "const grandchild = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });",
+      'process.stdout.write(`TREE ${grandchild.pid}\\n`);',
+      'setInterval(() => {}, 1_000);',
+    ].join('\n'),
+  );
+
+  const parent = spawn(process.execPath, [parentScript], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+  let out = '';
+  let err = '';
+  let grandchildPid: number | undefined;
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`process tree 준비 시간 초과: ${out}\n${err}`)), 10_000);
+      parent.stdout.on('data', (chunk) => {
+        out += String(chunk);
+        const match = out.match(/TREE (\d+)/);
+        if (match?.[1] !== undefined) {
+          grandchildPid = Number(match[1]);
+          clearTimeout(timer);
+          resolve();
+        }
+      });
+      parent.stderr.on('data', (chunk) => (err += String(chunk)));
+      parent.once('error', reject);
+    });
+    const exited = new Promise<void>((resolve) => parent.once('exit', () => resolve()));
+
+    expect(forceKillChildTree(parent)).toBe(true);
+    await Promise.race([
+      exited,
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error(`parent 종료 시간 초과: ${out}\n${err}`)), 10_000),
+      ),
+    ]);
+    expect(grandchildPid).toBeDefined();
+    await waitForProcessExit(grandchildPid!, 10_000);
+  } finally {
+    if (parent.exitCode === null && parent.signalCode === null) forceKillChildTree(parent);
+    if (grandchildPid !== undefined) {
+      try {
+        process.kill(grandchildPid, 'SIGKILL');
+      } catch {
+        // tree kill로 이미 종료했다.
+      }
+    }
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 describe('rhwp-mcp bin', () => {
   it('실 바이너리로 initialize 왕복이 된다', async () => {
     const request =
@@ -133,6 +213,12 @@ describe('rhwp-mcp bin', () => {
       await expectSignalForwarded('SIGINT');
       await expectSignalForwarded('SIGTERM');
     },
+    30_000,
+  );
+
+  it.skipIf(process.platform !== 'win32')(
+    'wrapper가 통제하는 강제 종료는 Windows child tree 전체를 닫는다',
+    expectWindowsProcessTreeKilled,
     30_000,
   );
 });

--- a/bindings/node/test/mcp-bin.integration.test.ts
+++ b/bindings/node/test/mcp-bin.integration.test.ts
@@ -11,7 +11,8 @@
  * 여기서 한 번 빌드해 실제 배포물과 같은 경로를 검증한다.
  */
 import { execSync, spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { beforeAll, describe, expect, it } from 'vitest';
@@ -35,13 +36,79 @@ function runOnce(env: NodeJS.ProcessEnv, input?: string): Promise<{ code: number
     let err = '';
     child.stdout.on('data', (d) => {
       out += String(d);
-      // initialize 응답 한 줄이면 충분 — 서버를 종료시킨다.
-      if (out.includes('"jsonrpc"')) child.kill();
+      // initialize 응답 한 줄이면 충분 — stdin EOF 로 서버를 정상 종료시킨다.
+      if (out.includes('"jsonrpc"') && !child.stdin.destroyed) child.stdin.end();
     });
     child.stderr.on('data', (d) => (err += String(d)));
     child.on('exit', (code) => resolve({ code, out, err }));
     if (input !== undefined) child.stdin.write(input);
   });
+}
+
+async function expectSignalForwarded(signal: 'SIGINT' | 'SIGTERM'): Promise<void> {
+  const dir = mkdtempSync(path.join(tmpdir(), 'rhwp-mcp-signal-'));
+  const fakeServer = path.join(dir, 'mcp-serve');
+  writeFileSync(
+    fakeServer,
+    [
+      "'use strict';",
+      'process.stdout.write(`READY ${process.pid}\\n`);',
+      'const stop = (signal) => {',
+      '  process.stdout.write(`FORWARDED ${signal}\\n`, () => process.exit(0));',
+      '};',
+      "process.on('SIGINT', () => stop('SIGINT'));",
+      "process.on('SIGTERM', () => stop('SIGTERM'));",
+      'setInterval(() => {}, 1_000);',
+    ].join('\n'),
+  );
+
+  const wrapper = spawn(process.execPath, [BIN], {
+    cwd: dir,
+    env: { ...process.env, RHWP_BIN: process.execPath },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let out = '';
+  let err = '';
+  let serverPid: number | undefined;
+
+  try {
+    const ready = new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`fake server 준비 시간 초과: ${out}\n${err}`)), 10_000);
+      wrapper.stdout.on('data', (chunk) => {
+        out += String(chunk);
+        const match = out.match(/READY (\d+)/);
+        if (match?.[1] !== undefined) {
+          serverPid = Number(match[1]);
+          clearTimeout(timer);
+          resolve();
+        }
+      });
+      wrapper.stderr.on('data', (chunk) => (err += String(chunk)));
+      wrapper.once('error', reject);
+    });
+    const exited = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+      wrapper.once('exit', (code, exitSignal) => resolve({ code, signal: exitSignal }));
+    });
+
+    await ready;
+    expect(wrapper.kill(signal)).toBe(true);
+    const status = await exited;
+
+    expect(status).toEqual({ code: 0, signal: null });
+    expect(out).toContain(`FORWARDED ${signal}`);
+    expect(serverPid).toBeDefined();
+    expect(() => process.kill(serverPid!, 0)).toThrow();
+  } finally {
+    if (wrapper.exitCode === null && wrapper.signalCode === null) wrapper.kill('SIGKILL');
+    if (serverPid !== undefined) {
+      try {
+        process.kill(serverPid, 'SIGKILL');
+      } catch {
+        // 이미 wrapper가 회수했다.
+      }
+    }
+    rmSync(dir, { recursive: true, force: true });
+  }
 }
 
 describe('rhwp-mcp bin', () => {
@@ -59,4 +126,13 @@ describe('rhwp-mcp bin', () => {
     expect(code).toBe(2);
     expect(err).toContain('releases');
   }, 30_000);
+
+  it.skipIf(process.platform === 'win32')(
+    'SIGINT와 SIGTERM을 실제 서버에 전달하고 자식을 회수한다',
+    async () => {
+      await expectSignalForwarded('SIGINT');
+      await expectSignalForwarded('SIGTERM');
+    },
+    30_000,
+  );
 });

--- a/bindings/node/test/mcp-bin.integration.test.ts
+++ b/bindings/node/test/mcp-bin.integration.test.ts
@@ -58,12 +58,14 @@ async function expectSignalForwarded(signal: 'SIGINT' | 'SIGTERM'): Promise<void
     fakeServer,
     [
       "'use strict';",
-      'process.stdout.write(`READY ${process.pid}\\n`);',
       'const stop = (signal) => {',
       '  process.stdout.write(`FORWARDED ${signal}\\n`, () => process.exit(0));',
       '};',
       "process.on('SIGINT', () => stop('SIGINT'));",
       "process.on('SIGTERM', () => stop('SIGTERM'));",
+      // READY는 signal handler 등록이 끝났다는 barrier다. 먼저 출력하면 CI가
+      // handler 설치 전 신호를 보내 child가 기본 signal 종료하는 race가 생긴다.
+      'process.stdout.write(`READY ${process.pid}\\n`);',
       'setInterval(() => {}, 1_000);',
     ].join('\n'),
   );

--- a/bindings/node/test/mcp-bin.test.ts
+++ b/bindings/node/test/mcp-bin.test.ts
@@ -1,0 +1,45 @@
+/**
+ * [#4349] npx 원라인 MCP bin 계약.
+ *
+ * ① 실 바이너리로 initialize JSON-RPC 왕복이 되고(스크립트가 곧 stdio MCP 서버),
+ * ② 바이너리 미발견이면 설치 안내와 exit 2 — 조용한 실패 금지.
+ */
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const BIN = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'bin', 'rhwp-mcp.cjs');
+
+function runOnce(env: NodeJS.ProcessEnv, input?: string): Promise<{ code: number | null; out: string; err: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [BIN], { env, stdio: ['pipe', 'pipe', 'pipe'] });
+    let out = '';
+    let err = '';
+    child.stdout.on('data', (d) => {
+      out += String(d);
+      // initialize 응답 한 줄이면 충분 — 서버를 종료시킨다.
+      if (out.includes('"jsonrpc"')) child.kill();
+    });
+    child.stderr.on('data', (d) => (err += String(d)));
+    child.on('exit', (code) => resolve({ code, out, err }));
+    if (input !== undefined) child.stdin.write(input);
+  });
+}
+
+describe('rhwp-mcp bin', () => {
+  it('실 바이너리로 initialize 왕복이 된다', async () => {
+    const request =
+      JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'bin-test', version: '0' } } }) + '\n';
+    const { out } = await runOnce(process.env, request);
+    expect(out).toContain('"jsonrpc"');
+    expect(out).toContain('"result"');
+  }, 30_000);
+
+  it('바이너리 미발견이면 설치 안내와 exit 2', async () => {
+    const env = { ...process.env, PATH: '', Path: '', RHWP_BIN: '' };
+    const { code, err } = await runOnce(env);
+    expect(code).toBe(2);
+    expect(err).toContain('releases');
+  }, 30_000);
+});

--- a/mydocs/pr/pr_4350_review.md
+++ b/mydocs/pr/pr_4350_review.md
@@ -22,7 +22,7 @@ last_verified: 2026-08-10
 | 검토 기준 devel | `e48fe86947fbf9a44b1b98c7037150751af541ab` — 원 head의 조상임을 확인 |
 | 작성 시점 원격 참고 상태 | `MERGEABLE` / `CLEAN`, 원 head GitHub checks 성공. merge 전 재확인 필요 |
 | 가시성 branch | `review/kevin9327-20260810-pr4350` |
-| 메인터너 code head | `0d9aa7f177955e22fa654f409043d4e36f35ce61` |
+| 메인터너 code head | `d1dad3c07c4bb5569e3e94e37e3e9b3d31edee28` |
 | GitHub 상태 변경 | reviewer assign, comment, push, review, merge 모두 미수행 |
 
 이번 작업지시는 로컬 메인터너 보정과 기록까지이며 GitHub mutation 승인을 포함하지 않는다. 따라서
@@ -52,10 +52,24 @@ commit `0d9aa7f177955e22fa654f409043d4e36f35ce61`
 
 | 파일 | 보정 |
 | --- | --- |
-| `bindings/node/bin/rhwp-mcp.cjs` | 첫 SIGINT/SIGTERM을 자식에 전달하고 5초 뒤 강제 종료, 두 번째 신호는 즉시 강제 종료한다. 부모의 명시적 exit에도 자식 종료를 시도하고 자식 exit까지 기다려 회수한다. |
+| `bindings/node/bin/rhwp-mcp.cjs` | POSIX 첫 SIGINT/SIGTERM을 자식에 전달하고 5초 뒤 강제 종료, 두 번째 신호는 즉시 강제 종료한다. 정상 경로에서는 자식 exit를 관찰해 부모 종료 코드를 정한다. `exit` hook은 동기 종료 요청만 시도하며 await/reap을 보장하지 않는다. |
 | `bindings/node/test/mcp-bin.integration.test.ts` | initialize 뒤 stdin EOF로 정상 종료한다. POSIX에서는 가짜 server로 SIGINT와 SIGTERM을 각각 전달하고 자식 PID가 사라졌는지 확인한다. |
 
-contributor commits는 수정·squash·rebase하지 않았으며 위 메인터너 commit 한 개만 추가했다.
+contributor commits는 수정·squash·rebase하지 않았으며 위 1차 메인터너 commit을 별도로 추가했다.
+
+후속 조사에서는 Windows의 `child.kill()`이 direct process만 `TerminateProcess`해 손자를 남길 수 있고,
+외부에서 wrapper 자체를 `TerminateProcess`하면 JavaScript signal/exit hook이 아예 실행되지 않는 경계를
+확인했다. 작은 안전 보정이 가능한 wrapper 통제 경로만 후속 commit
+`d1dad3c07c4bb5569e3e94e37e3e9b3d31edee28`
+(`fix(node): terminate Windows MCP child trees`)로 강화했다.
+
+| 파일 | 후속 보정 |
+| --- | --- |
+| `bindings/node/bin/rhwp-mcp.cjs` | Windows에서 JS handler·grace timeout·second signal·explicit exit hook이 실행되는 강제 종료 경로는 동기 `taskkill.exe /PID <pid> /T /F`를 사용한다. POSIX 첫 신호의 graceful forwarding은 유지한다. |
+| `bindings/node/test/mcp-bin.integration.test.ts` | bin을 server 기동 없이 require할 수 있게 내부 helper를 노출하고, Windows에서 parent가 만든 grandchild까지 두 PID가 사라지는지 실제 process tree로 검증한다. |
+
+이 보정은 Job Object가 아니며 외부 abrupt wrapper 종료를 가로채지 않는다는 한계를 코드 주석과 아래
+잔여 위험에 함께 고정했다. contributor와 기존 메인터너 commit은 재작성하지 않았다.
 
 ## 완료한 검증
 
@@ -63,18 +77,24 @@ contributor commits는 수정·squash·rebase하지 않았으며 위 메인터�
 | --- | --- |
 | `node --check bindings/node/bin/rhwp-mcp.cjs` | 통과 |
 | `npm.cmd run typecheck` | 통과 |
-| `npm.cmd exec -- vitest run test/mcp-bin.integration.test.ts --project integration` | 최종 tree에서 2 passed, 1 skipped |
+| `.\node_modules\.bin\vitest.cmd run test\mcp-bin.integration.test.ts --project integration` | filesystem sandbox의 config resolution 거부 뒤 승인된 local rerun에서 3 passed, 1 skipped |
 | 실제 `rhwp.exe` initialize 및 stdin EOF 종료 | Windows 통합 테스트에서 통과 |
 | POSIX SIGINT/SIGTERM 전달·자식 PID 회수 계약 | 테스트를 추가했으나 현재 Windows host에서는 platform skip |
-| `git diff --check origin/pr/4350..0d9aa7f1` | 통과 |
+| Windows wrapper 통제 강제 종료 | 실제 parent·grandchild tree를 만들고 `taskkill /T /F` 뒤 두 PID 종료 확인 |
+| `git diff --check origin/pr/4350..d1dad3c0` | 통과 |
 
 `npm ci`는 89 packages를 설치했고 tracked dependency 파일은 바꾸지 않았다. 설치 과정의 audit 결과
 1 low·1 high는 기존 lock dependency 상태이며 이 보정에서 자동 수정하지 않았다.
 
 ## 잔여 위험
 
-- Windows의 강제 `TerminateProcess`/`taskkill`은 JavaScript signal·exit handler를 실행하지 않을 수 있다.
-  정상 stdin EOF와 console signal 수명은 이번 범위지만, OS 강제 종료 전체를 Job Object 없이 보증하지 않는다.
+- 외부가 wrapper PID 자체를 `TerminateProcess`하거나 `/T` 없는 `taskkill /F`로 끊으면 JavaScript
+  signal·exit handler가 실행되지 않아 이번 tree helper도 호출되지 않는다. wrapper가 죽는 순간 kernel이
+  자식 tree를 닫는 보장은 Windows Job Object/native 연동 없이는 제공하지 않는다.
+- `process.once('exit', ...)` 경로는 동기 tree 종료를 요청하지만 event loop를 재개하거나 자식 exit를
+  await/reap할 수 없다. 따라서 명시적 `process.exit()`·native crash의 완전한 회수 계약으로 주장하지 않는다.
+- Windows 회귀는 wrapper가 직접 호출하는 `forceKillChildTree()`의 parent/grandchild 종료를 입증한다.
+  외부 abrupt wrapper 종료를 재현하거나 보증하는 테스트는 아니다.
 - 현재 host가 Windows라 POSIX 신호 회귀는 실행되지 않았다. 원격 후보를 만들면 Linux GitHub Actions에서
   해당 테스트의 실제 통과가 필수다.
 - source/test를 추가한 local head이므로 원 contributor head의 기존 녹색 CI를 메인터너 보정의 근거로
@@ -82,7 +102,8 @@ contributor commits는 수정·squash·rebase하지 않았으며 위 메인터�
 
 ## 조건부 권고
 
-**로컬 blocker는 메인터너 보정으로 해소되어 조건부 통합 권고다.** 다만 현재 branch는 로컬 전용이며
+**POSIX signal·정상 EOF와 wrapper 통제 Windows 강제 종료에서 확인한 blocker는 해소되어 조건부 통합
+권고다.** 다만 현재 branch는 로컬 전용이며
 push 또는 merge 승인이 없다. 작업지시자가 반영 경로를 승인한 뒤 새 원격 head에서 package integration과
 Linux 신호 회귀를 포함한 required checks가 모두 통과하고, 별도의 명시적 merge 승인이 있을 때만
 통합할 수 있다.

--- a/mydocs/pr/pr_4350_review.md
+++ b/mydocs/pr/pr_4350_review.md
@@ -1,0 +1,88 @@
+---
+kind: pr_review
+status: local-validation-passed
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-10
+---
+
+# PR #4350 검토 — Node MCP wrapper의 자식 프로세스 수명
+
+## 라우팅과 접수
+
+기본 경로는 `maintainer_general.md`, 보조 경로는 `intake_and_review.md`와
+`local_validation.md`다. contributor code 위에 메인터너 source/test 보정을 추가했으므로
+[implementation 기록](pr_4350_review_impl.md)을 함께 유지한다.
+
+| 항목 | 값 |
+| --- | --- |
+| 원 PR / 작성자 | [#4350](https://github.com/edwardkim/rhwp/pull/4350) / `kevin9327` |
+| 관련 이슈 | [#4349](https://github.com/edwardkim/rhwp/issues/4349), #4327, #4337 |
+| 원 base / head | `devel` / `c0592f5f1bfaa156f87f755723c58816ad776931` |
+| 원 변경 규모 | 3 files, +117/-0, contributor commits 2개 |
+| 검토 기준 devel | `e48fe86947fbf9a44b1b98c7037150751af541ab` — 원 head의 조상임을 확인 |
+| 작성 시점 원격 참고 상태 | `MERGEABLE` / `CLEAN`, 원 head GitHub checks 성공. merge 전 재확인 필요 |
+| 가시성 branch | `review/kevin9327-20260810-pr4350` |
+| 메인터너 code head | `0d9aa7f177955e22fa654f409043d4e36f35ce61` |
+| GitHub 상태 변경 | reviewer assign, comment, push, review, merge 모두 미수행 |
+
+이번 작업지시는 로컬 메인터너 보정과 기록까지이며 GitHub mutation 승인을 포함하지 않는다. 따라서
+접수 가이드의 reviewer assign도 실행하지 않았고, 이 문서의 원격 상태는 2026-08-10 조회 시점 참고값이다.
+
+## contributor 변경 범위
+
+원 PR은 `@rhwp/node`에 `rhwp-mcp` bin을 추가한다. wrapper는 패키지의 기존 `findBinary()` 탐색 순서를
+재사용해 `rhwp mcp-serve`를 stdio 상속으로 실행하고, 패키지 manifest와 실제 바이너리 통합 테스트를
+함께 추가한다. 후속 contributor commit은 바이너리가 필요한 테스트를 integration project로 옮기고,
+클론·CI에서 `dist/index.cjs`가 없으면 테스트 준비 단계에서 package build를 수행하게 했다.
+
+renderer, layout, WASM, sample, golden 및 fixture 변경은 없다. 따라서 시각 검증 대상이 아니며 별도
+PDF/SVG/브라우저 증적을 만들지 않았다.
+
+## 확인한 blocker
+
+wrapper는 자식의 `exit`만 부모 종료 코드로 반영하고 `SIGINT`·`SIGTERM`을 전달하지 않았다. MCP host가
+wrapper PID만 종료하면 실제 `rhwp mcp-serve`가 계속 실행될 수 있고, 기존 initialize 테스트도 응답을 받은
+뒤 wrapper만 `kill()`해 같은 누수 가능성을 만들었다. stdio MCP server의 프로세스 수명 계약을 깨므로
+원 head 그대로는 merge blocker로 판정했다.
+
+## 메인터너 보정
+
+commit `0d9aa7f177955e22fa654f409043d4e36f35ce61`
+(`fix(node): reap MCP child on wrapper shutdown`)을 원 contributor head의 직계 자식으로 추가했다.
+
+| 파일 | 보정 |
+| --- | --- |
+| `bindings/node/bin/rhwp-mcp.cjs` | 첫 SIGINT/SIGTERM을 자식에 전달하고 5초 뒤 강제 종료, 두 번째 신호는 즉시 강제 종료한다. 부모의 명시적 exit에도 자식 종료를 시도하고 자식 exit까지 기다려 회수한다. |
+| `bindings/node/test/mcp-bin.integration.test.ts` | initialize 뒤 stdin EOF로 정상 종료한다. POSIX에서는 가짜 server로 SIGINT와 SIGTERM을 각각 전달하고 자식 PID가 사라졌는지 확인한다. |
+
+contributor commits는 수정·squash·rebase하지 않았으며 위 메인터너 commit 한 개만 추가했다.
+
+## 완료한 검증
+
+| 게이트 | 결과 |
+| --- | --- |
+| `node --check bindings/node/bin/rhwp-mcp.cjs` | 통과 |
+| `npm.cmd run typecheck` | 통과 |
+| `npm.cmd exec -- vitest run test/mcp-bin.integration.test.ts --project integration` | 최종 tree에서 2 passed, 1 skipped |
+| 실제 `rhwp.exe` initialize 및 stdin EOF 종료 | Windows 통합 테스트에서 통과 |
+| POSIX SIGINT/SIGTERM 전달·자식 PID 회수 계약 | 테스트를 추가했으나 현재 Windows host에서는 platform skip |
+| `git diff --check origin/pr/4350..0d9aa7f1` | 통과 |
+
+`npm ci`는 89 packages를 설치했고 tracked dependency 파일은 바꾸지 않았다. 설치 과정의 audit 결과
+1 low·1 high는 기존 lock dependency 상태이며 이 보정에서 자동 수정하지 않았다.
+
+## 잔여 위험
+
+- Windows의 강제 `TerminateProcess`/`taskkill`은 JavaScript signal·exit handler를 실행하지 않을 수 있다.
+  정상 stdin EOF와 console signal 수명은 이번 범위지만, OS 강제 종료 전체를 Job Object 없이 보증하지 않는다.
+- 현재 host가 Windows라 POSIX 신호 회귀는 실행되지 않았다. 원격 후보를 만들면 Linux GitHub Actions에서
+  해당 테스트의 실제 통과가 필수다.
+- source/test를 추가한 local head이므로 원 contributor head의 기존 녹색 CI를 메인터너 보정의 근거로
+  재사용하지 않는다. push 승인이 나면 새 head 전체 required checks가 필요하다.
+
+## 조건부 권고
+
+**로컬 blocker는 메인터너 보정으로 해소되어 조건부 통합 권고다.** 다만 현재 branch는 로컬 전용이며
+push 또는 merge 승인이 없다. 작업지시자가 반영 경로를 승인한 뒤 새 원격 head에서 package integration과
+Linux 신호 회귀를 포함한 required checks가 모두 통과하고, 별도의 명시적 merge 승인이 있을 때만
+통합할 수 있다.

--- a/mydocs/pr/pr_4350_review.md
+++ b/mydocs/pr/pr_4350_review.md
@@ -1,6 +1,6 @@
 ---
 kind: pr_review
-status: local-validation-passed
+status: remote-validation-in-progress
 canonical: mydocs/manual/pr_review_workflow.md
 last_verified: 2026-08-10
 ---
@@ -22,11 +22,11 @@ last_verified: 2026-08-10
 | 검토 기준 devel | `e48fe86947fbf9a44b1b98c7037150751af541ab` — 원 head의 조상임을 확인 |
 | 작성 시점 원격 참고 상태 | `MERGEABLE` / `CLEAN`, 원 head GitHub checks 성공. merge 전 재확인 필요 |
 | 가시성 branch | `review/kevin9327-20260810-pr4350` |
-| 메인터너 code head | `d1dad3c07c4bb5569e3e94e37e3e9b3d31edee28` |
-| GitHub 상태 변경 | reviewer assign, comment, push, review, merge 모두 미수행 |
+| 메인터너 code head | `8429ce9f49c6bd48d8a357a419c36a3d053dba82` |
+| GitHub 상태 변경 | reviewer `jangster77` 지정, correction push 수행; comment, review, merge 미수행 |
 
-이번 작업지시는 로컬 메인터너 보정과 기록까지이며 GitHub mutation 승인을 포함하지 않는다. 따라서
-접수 가이드의 reviewer assign도 실행하지 않았고, 이 문서의 원격 상태는 2026-08-10 조회 시점 참고값이다.
+메인터너 correction은 원 contributor branch에 비강제 fast-forward로 push했다. 이 문서의 원격 상태와
+CI 결과는 2026-08-10 조회 시점 참고값이며 merge 권한을 뜻하지 않는다.
 
 ## contributor 변경 범위
 
@@ -71,6 +71,18 @@ contributor commits는 수정·squash·rebase하지 않았으며 위 1차 메인
 이 보정은 Job Object가 아니며 외부 abrupt wrapper 종료를 가로채지 않는다는 한계를 코드 주석과 아래
 잔여 위험에 함께 고정했다. contributor와 기존 메인터너 commit은 재작성하지 않았다.
 
+## 원격 CI에서 확인한 readiness race와 후속 보정
+
+correction push 뒤 GitHub Actions run `31335998868`의 Node integration에서 POSIX signal 회귀 한 건이
+실패했다. 제품 wrapper가 아니라 테스트용 fake server가 signal handler보다 먼저 `READY`를 출력해,
+runner가 그 사이에 신호를 보내면 child가 기본 signal 종료하고 wrapper가 exit 1을 반환하는 fixture
+경쟁이었다.
+
+후속 commit `8429ce9f49c6bd48d8a357a419c36a3d053dba82`
+(`test(node): close signal readiness race`)은 SIGINT·SIGTERM handler 등록 뒤에만 `READY`를 출력한다.
+따라서 readiness 표지는 이제 “server process가 존재한다”뿐 아니라 “두 handler 설치가 끝났다”는
+barrier다. production wrapper 동작은 바꾸지 않았으며 contributor와 기존 메인터너 이력도 보존했다.
+
 ## 완료한 검증
 
 | 게이트 | 결과 |
@@ -81,7 +93,9 @@ contributor commits는 수정·squash·rebase하지 않았으며 위 1차 메인
 | 실제 `rhwp.exe` initialize 및 stdin EOF 종료 | Windows 통합 테스트에서 통과 |
 | POSIX SIGINT/SIGTERM 전달·자식 PID 회수 계약 | 테스트를 추가했으나 현재 Windows host에서는 platform skip |
 | Windows wrapper 통제 강제 종료 | 실제 parent·grandchild tree를 만들고 `taskkill /T /F` 뒤 두 PID 종료 확인 |
-| `git diff --check origin/pr/4350..d1dad3c0` | 통과 |
+| readiness 후속의 `npm.cmd run typecheck`, `node --check` | 통과 |
+| readiness 후속 POSIX focused test | Windows host에서 platform skip; Linux 재실행 대기 |
+| `git diff --check origin/pr/4350..8429ce9f` | 통과 |
 
 `npm ci`는 89 packages를 설치했고 tracked dependency 파일은 바꾸지 않았다. 설치 과정의 audit 결과
 1 low·1 high는 기존 lock dependency 상태이며 이 보정에서 자동 수정하지 않았다.
@@ -95,15 +109,13 @@ contributor commits는 수정·squash·rebase하지 않았으며 위 1차 메인
   await/reap할 수 없다. 따라서 명시적 `process.exit()`·native crash의 완전한 회수 계약으로 주장하지 않는다.
 - Windows 회귀는 wrapper가 직접 호출하는 `forceKillChildTree()`의 parent/grandchild 종료를 입증한다.
   외부 abrupt wrapper 종료를 재현하거나 보증하는 테스트는 아니다.
-- 현재 host가 Windows라 POSIX 신호 회귀는 실행되지 않았다. 원격 후보를 만들면 Linux GitHub Actions에서
-  해당 테스트의 실제 통과가 필수다.
-- source/test를 추가한 local head이므로 원 contributor head의 기존 녹색 CI를 메인터너 보정의 근거로
-  재사용하지 않는다. push 승인이 나면 새 head 전체 required checks가 필요하다.
+- 현재 host가 Windows라 POSIX 신호 회귀는 실행되지 않았다. `8429ce9f` 원격 head의 Linux GitHub
+  Actions에서 해당 테스트의 실제 통과가 필수다.
+- 첫 correction 원격 run은 fixture race로 실패했고 보정 head의 required checks는 다시 실행 중이다.
+  이전 녹색 job이나 실패 전 성공 job을 최신 head의 근거로 재사용하지 않는다.
 
 ## 조건부 권고
 
 **POSIX signal·정상 EOF와 wrapper 통제 Windows 강제 종료에서 확인한 blocker는 해소되어 조건부 통합
-권고다.** 다만 현재 branch는 로컬 전용이며
-push 또는 merge 승인이 없다. 작업지시자가 반영 경로를 승인한 뒤 새 원격 head에서 package integration과
-Linux 신호 회귀를 포함한 required checks가 모두 통과하고, 별도의 명시적 merge 승인이 있을 때만
-통합할 수 있다.
+권고다.** correction은 원격 branch에 반영됐지만, 새 head에서 package integration과 Linux 신호 회귀를
+포함한 required checks가 모두 통과하고 별도의 명시적 merge 승인이 있을 때만 통합할 수 있다.

--- a/mydocs/pr/pr_4350_review_impl.md
+++ b/mydocs/pr/pr_4350_review_impl.md
@@ -14,31 +14,39 @@ last_verified: 2026-08-10
 | contributor 기능 | `621122fce8e6654b1cd365e24d370c476a73edf8` | 보존 |
 | contributor CI 수리 / 원 head | `c0592f5f1bfaa156f87f755723c58816ad776931` | 보존 |
 | 메인터너 프로세스 수명 보정 | `0d9aa7f177955e22fa654f409043d4e36f35ce61` | 완료 |
-| review 및 implementation 기록 | 본 문서와 `pr_4350_review.md`의 후속 문서 commit | 완료 후 SHA를 Git 이력에서 확인 |
+| 1차 review 및 implementation 기록 | `390514add555817919677245bb18dd1aaebfbc0b` | 완료 |
+| 메인터너 Windows process-tree 보정 | `d1dad3c07c4bb5569e3e94e37e3e9b3d31edee28` | 완료 |
+| 후속 review 및 implementation 기록 | 본 문서와 `pr_4350_review.md`의 trailing 문서 commit | 완료 후 SHA를 Git 이력에서 확인 |
 
 가시성 branch는 `review/kevin9327-20260810-pr4350` 하나만 사용한다. 원 contributor commits 위에
-메인터너 commit과 review 문서 commit을 순서대로 쌓으며 원 commit을 다시 작성하지 않는다.
+메인터너 commit과 review 문서 commit을 선형으로 쌓으며 원 contributor·기존 메인터너 commit을 다시
+작성하지 않는다.
 
 ## 실행 단계
 
 1. **접수·기준 고정 — 완료.** `origin/pr/4350` head와 `origin/devel` 조상 관계를 확인하고 원 head에서
    가시성 branch/worktree를 만들었다. GitHub reviewer assign이나 comment는 수행하지 않았다.
-2. **source/test 보정 — 완료.** `rhwp-mcp.cjs`에 signal forwarding, grace timeout, second-signal 강제
-   종료 및 exit cleanup을 추가했다. integration test의 정상 종료를 stdin EOF로 바꾸고 POSIX SIGINT와
-   SIGTERM 자식 회수 회귀를 추가했다.
+2. **source/test 보정 — 완료.** `rhwp-mcp.cjs`에 POSIX signal forwarding, grace timeout,
+   second-signal 강제 종료 및 best-effort exit cleanup을 추가했다. integration test의 정상 종료를
+   stdin EOF로 바꾸고 POSIX SIGINT와 SIGTERM 자식 회수 회귀를 추가했다.
 3. **로컬 검증 — 완료.** Node 구문·TypeScript·focused integration·diff 검사를 실행했다. Windows에서
    POSIX 전용 한 건이 skip된 사실을 [검토 기록](pr_4350_review.md)에 제한 조건으로 남겼다.
-4. **review 기록 — 완료.** source/test commit과 섞지 않고 이 두 문서를 별도 commit으로 만든다.
-5. **원격 반영 — 승인 대기.** 작업지시자가 push 대상과 방식(원 PR branch update 또는 별도 maintainer
+4. **1차 review 기록 — 완료.** source/test commit과 섞지 않고 이 두 문서를 별도 commit으로 만들었다.
+5. **Windows process-tree 조사·보정 — 완료.** direct child `TerminateProcess`가 손자를 남기는 경로는
+   wrapper가 통제할 때 `taskkill /T /F`로 바꿨다. 실제 parent·grandchild 회귀는 통과했다. 외부가 wrapper
+   자체를 abrupt 종료하는 경우는 handler가 실행되지 않으므로 Job Object 없이는 보장하지 않는다.
+6. **후속 검증·기록 — 완료.** Node syntax, TypeScript typecheck, focused integration 3 passed/1 POSIX skipped,
+   diff check를 통과했다. 이 두 문서는 source/test 뒤의 trailing commit으로 만든다.
+7. **원격 반영 — 승인 대기.** 작업지시자가 push 대상과 방식(원 PR branch update 또는 별도 maintainer
    integration branch)을 정한 뒤에만 수행한다. 현재 작업에는 push 권한 행사가 포함되지 않는다.
-6. **CI와 merge — 미착수.** 새 원격 head의 required checks 성공을 확인한 뒤에도 별도의 명시적 merge
+8. **CI와 merge — 미착수.** 새 원격 head의 required checks 성공을 확인한 뒤에도 별도의 명시적 merge
    승인이 있어야 한다. 승인 전에는 review 제출, merge, close 및 contributor comment를 수행하지 않는다.
 
 ## rollback
 
-- review 기록만 철회할 때는 이 후속 문서 commit만 revert한다. source/test 보정과 섞지 않는다.
-- 프로세스 수명 보정까지 철회할 때는 문서 commit을 먼저, `0d9aa7f1`을 다음 순서로 revert한다. 그러면
-  branch는 원 contributor head `c0592f5f...`로 돌아간다.
+- 후속 기록만 철회할 때는 trailing 문서 commit만 revert한다. source/test 보정과 섞지 않는다.
+- 전체 메인터너 보정을 철회할 때는 trailing 문서, `d1dad3c0`, `390514ad`, `0d9aa7f1`을 이력 역순으로
+  revert한다. 그러면 branch는 원 contributor head `c0592f5f...`의 내용으로 돌아간다.
 - contributor의 두 commit은 reset, amend, rebase 또는 squash하지 않는다.
 - 원격 반영 전이므로 현재 rollback은 로컬 branch에서만 수행하며 GitHub 상태에는 영향이 없다.
 

--- a/mydocs/pr/pr_4350_review_impl.md
+++ b/mydocs/pr/pr_4350_review_impl.md
@@ -1,6 +1,6 @@
 ---
 kind: review_plan
-status: local-validation-passed
+status: remote-validation-in-progress
 canonical: mydocs/manual/pr_review_workflow.md
 last_verified: 2026-08-10
 ---
@@ -16,7 +16,9 @@ last_verified: 2026-08-10
 | 메인터너 프로세스 수명 보정 | `0d9aa7f177955e22fa654f409043d4e36f35ce61` | 완료 |
 | 1차 review 및 implementation 기록 | `390514add555817919677245bb18dd1aaebfbc0b` | 완료 |
 | 메인터너 Windows process-tree 보정 | `d1dad3c07c4bb5569e3e94e37e3e9b3d31edee28` | 완료 |
-| 후속 review 및 implementation 기록 | 본 문서와 `pr_4350_review.md`의 trailing 문서 commit | 완료 후 SHA를 Git 이력에서 확인 |
+| 후속 review 및 implementation 기록 | `23a20d32b4576c23962589100c71d8d83c40e500` | 완료 |
+| POSIX fixture readiness race 보정 | `8429ce9f49c6bd48d8a357a419c36a3d053dba82` | 완료 |
+| 원격 CI 후속 기록 | 본 문서와 `pr_4350_review.md`의 trailing 문서 commit | 완료 후 SHA를 Git 이력에서 확인 |
 
 가시성 branch는 `review/kevin9327-20260810-pr4350` 하나만 사용한다. 원 contributor commits 위에
 메인터너 commit과 review 문서 commit을 선형으로 쌓으며 원 contributor·기존 메인터너 commit을 다시
@@ -37,20 +39,24 @@ last_verified: 2026-08-10
    자체를 abrupt 종료하는 경우는 handler가 실행되지 않으므로 Job Object 없이는 보장하지 않는다.
 6. **후속 검증·기록 — 완료.** Node syntax, TypeScript typecheck, focused integration 3 passed/1 POSIX skipped,
    diff check를 통과했다. 이 두 문서는 source/test 뒤의 trailing commit으로 만든다.
-7. **원격 반영 — 승인 대기.** 작업지시자가 push 대상과 방식(원 PR branch update 또는 별도 maintainer
-   integration branch)을 정한 뒤에만 수행한다. 현재 작업에는 push 권한 행사가 포함되지 않는다.
-8. **CI와 merge — 미착수.** 새 원격 head의 required checks 성공을 확인한 뒤에도 별도의 명시적 merge
-   승인이 있어야 한다. 승인 전에는 review 제출, merge, close 및 contributor comment를 수행하지 않는다.
+7. **원격 반영과 CI 관찰 — 진행.** 원 contributor branch에 correction을 비강제 fast-forward push했다.
+   첫 새-head run에서 POSIX signal fixture가 handler 등록 전 `READY`를 출력하는 경쟁을 재현했다.
+8. **CI 후속 보정 — 완료.** handler 두 개를 먼저 등록한 뒤 `READY`를 출력하도록 `8429ce9f`에
+   분리했다. Windows에서는 해당 POSIX test가 skip되므로 TypeScript와 Node 구문을 통과시킨 뒤 Linux
+   원격 재실행을 필수 gate로 유지한다.
+9. **최신 CI와 merge — 진행/별도 승인 대기.** `8429ce9f` head의 required checks를 다시 받는다.
+   성공 뒤에도 별도의 명시적 merge 승인이 있어야 하며, 그 전에는 merge·close를 수행하지 않는다.
 
 ## rollback
 
 - 후속 기록만 철회할 때는 trailing 문서 commit만 revert한다. source/test 보정과 섞지 않는다.
-- 전체 메인터너 보정을 철회할 때는 trailing 문서, `d1dad3c0`, `390514ad`, `0d9aa7f1`을 이력 역순으로
-  revert한다. 그러면 branch는 원 contributor head `c0592f5f...`의 내용으로 돌아간다.
+- 전체 메인터너 보정을 철회할 때는 최신 문서, `8429ce9f`, `23a20d32`, `d1dad3c0`, `390514ad`,
+  `0d9aa7f1`을 이력 역순으로 revert한다. 그러면 branch는 원 contributor head `c0592f5f...`의
+  내용으로 돌아간다.
 - contributor의 두 commit은 reset, amend, rebase 또는 squash하지 않는다.
-- 원격 반영 전이므로 현재 rollback은 로컬 branch에서만 수행하며 GitHub 상태에는 영향이 없다.
+- 원격 반영 뒤이므로 rollback도 force-push 없이 새 revert commit으로 수행하고 최신 CI를 다시 받는다.
 
 ## 권한 경계
 
-이 기록은 merge 허가가 아니다. push, GitHub review/comment, PR 갱신, merge, close는 각각 작업지시자의
-명시적 승인과 최신 상태 재확인이 필요한 별도 단계다.
+이 기록은 merge 허가가 아니다. correction push는 완료했지만 GitHub review/comment, merge, close는
+최신 상태 재확인과 별도 판단이 필요한 단계다.

--- a/mydocs/pr/pr_4350_review_impl.md
+++ b/mydocs/pr/pr_4350_review_impl.md
@@ -1,0 +1,48 @@
+---
+kind: review_plan
+status: local-validation-passed
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-10
+---
+
+# PR #4350 메인터너 보정 실행 기록
+
+## commit 경계
+
+| 역할 | SHA | 상태 |
+| --- | --- | --- |
+| contributor 기능 | `621122fce8e6654b1cd365e24d370c476a73edf8` | 보존 |
+| contributor CI 수리 / 원 head | `c0592f5f1bfaa156f87f755723c58816ad776931` | 보존 |
+| 메인터너 프로세스 수명 보정 | `0d9aa7f177955e22fa654f409043d4e36f35ce61` | 완료 |
+| review 및 implementation 기록 | 본 문서와 `pr_4350_review.md`의 후속 문서 commit | 완료 후 SHA를 Git 이력에서 확인 |
+
+가시성 branch는 `review/kevin9327-20260810-pr4350` 하나만 사용한다. 원 contributor commits 위에
+메인터너 commit과 review 문서 commit을 순서대로 쌓으며 원 commit을 다시 작성하지 않는다.
+
+## 실행 단계
+
+1. **접수·기준 고정 — 완료.** `origin/pr/4350` head와 `origin/devel` 조상 관계를 확인하고 원 head에서
+   가시성 branch/worktree를 만들었다. GitHub reviewer assign이나 comment는 수행하지 않았다.
+2. **source/test 보정 — 완료.** `rhwp-mcp.cjs`에 signal forwarding, grace timeout, second-signal 강제
+   종료 및 exit cleanup을 추가했다. integration test의 정상 종료를 stdin EOF로 바꾸고 POSIX SIGINT와
+   SIGTERM 자식 회수 회귀를 추가했다.
+3. **로컬 검증 — 완료.** Node 구문·TypeScript·focused integration·diff 검사를 실행했다. Windows에서
+   POSIX 전용 한 건이 skip된 사실을 [검토 기록](pr_4350_review.md)에 제한 조건으로 남겼다.
+4. **review 기록 — 완료.** source/test commit과 섞지 않고 이 두 문서를 별도 commit으로 만든다.
+5. **원격 반영 — 승인 대기.** 작업지시자가 push 대상과 방식(원 PR branch update 또는 별도 maintainer
+   integration branch)을 정한 뒤에만 수행한다. 현재 작업에는 push 권한 행사가 포함되지 않는다.
+6. **CI와 merge — 미착수.** 새 원격 head의 required checks 성공을 확인한 뒤에도 별도의 명시적 merge
+   승인이 있어야 한다. 승인 전에는 review 제출, merge, close 및 contributor comment를 수행하지 않는다.
+
+## rollback
+
+- review 기록만 철회할 때는 이 후속 문서 commit만 revert한다. source/test 보정과 섞지 않는다.
+- 프로세스 수명 보정까지 철회할 때는 문서 commit을 먼저, `0d9aa7f1`을 다음 순서로 revert한다. 그러면
+  branch는 원 contributor head `c0592f5f...`로 돌아간다.
+- contributor의 두 commit은 reset, amend, rebase 또는 squash하지 않는다.
+- 원격 반영 전이므로 현재 rollback은 로컬 branch에서만 수행하며 GitHub 상태에는 영향이 없다.
+
+## 권한 경계
+
+이 기록은 merge 허가가 아니다. push, GitHub review/comment, PR 갱신, merge, close는 각각 작업지시자의
+명시적 승인과 최신 상태 재확인이 필요한 별도 단계다.


### PR DESCRIPTION
## 변경 요약

**npx 원라인 MCP** — `.mcp.json` 에 아래 한 줄이면 끝나는 UX 를 1st-party 로 제공합니다(#4327 §3 실측상 서드파티 래퍼만 갖고 있던 공백, #4337 가이드 §5 의 후속 조각):

```jsonc
{ "mcpServers": { "rhwp": { "command": "npx", "args": ["-y", "-p", "@rhwp/node", "rhwp-mcp"] } } }
```

- `bindings/node/bin/rhwp-mcp.cjs` (빌드 불필요 CJS): 패키지의 기존 `findBinary()`(RHWP_BIN→동봉→PATH, D-14 계약)를 **그대로 재사용**해 `rhwp mcp-serve` 를 stdio 상속으로 spawn — 탐색 규칙을 두 벌로 만들지 않습니다. 미발견 시 설치 3경로(releases·scoop raw URL·RHWP_BIN) 안내 + exit 2.
- `package.json` 에 `bin`/`files` 등재(추가 전용 — 기존 코드 무수정). 게시 전에도 저장소 클론에서 `node bindings/node/bin/rhwp-mcp.cjs` 로 동일 동작.

## 관련 이슈

closes #4349

## 테스트

- [ ] cargo / SVG / WASM — 해당 없음(Node bin 전용)
- [x] vitest 2본: **실 바이너리 initialize JSON-RPC 왕복**(jsonrpc/result 수신 후 종료) · 미발견 시 exit 2 + 설치 안내 — 2/2 passed

## 성능 영향 및 측정 결과

- 해당 없음

## 스크린샷

해당 없음
