### PR TITLE
docs(roadmap): #4351 동향 W1 — 에이전트 전용 런타임 실측과 rhwp workspace 설계 제안

### DIFF
--- a/mydocs/pr/pr_4352_review.md
+++ b/mydocs/pr/pr_4352_review.md
@@ -1,0 +1,79 @@
+---
+kind: pr_review
+status: active
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-10
+---
+
+# PR #4352 검토 — Kitesurf 상태 수명과 W1 지속성 경계
+
+## 라우팅
+
+base route: `maintainer_general.md`
+
+modifiers: `intake_and_review.md`, `local_validation.md`,
+`multi_pr_update_branch.md`, `review_only_fast_pass.md`
+
+loaded documents: `pr_review_workflow.md`, `pr_review/README.md`,
+`pr_review/maintainer_general.md`, `pr_review/intake_and_review.md`,
+`pr_review/local_validation.md`, `pr_review/multi_pr_update_branch.md`,
+`pr_review/review_only_fast_pass.md`
+
+## 메타데이터와 적용 경계
+
+| 항목 | 값 |
+| --- | --- |
+| 원 PR / 작성자 | [#4352](https://github.com/edwardkim/rhwp/pull/4352) / @kevin9327 |
+| base | `devel` |
+| 원 PR head | `440b4a472dc58f0d7c1c9af0525e520c321003c3` |
+| 기준 devel | `e48fe86947fbf9a44b1b98c7037150751af541ab` |
+| 가시성 브랜치 | `review/kevin9327-20260810-pr4352` |
+| 원 변경 규모 | 조사 문서 1파일, `+70/-0`, contributor 커밋 1개 |
+
+원 변경은 Kitesurf 동향을 W1 `rhwp workspace` 제안에 사상한다. 메인터너 보정은
+해당 조사 문서와 이 review·구현 기록만 바꾸며 source, test, workflow, fixture,
+baseline에는 영향이 없다. contributor commit은 amend, rebase, squash하지 않고 원
+head 뒤에 single-parent 문서 commit만 추가한다.
+
+## 발견한 차단 결함
+
+원 문서는 Kitesurf를 V8 isolate에 "상주"하는 런타임으로 설명하고 자원 절감이 상주
+workspace의 비용 근거인 것처럼 연결했다. 그러나
+[Cloudflare 공식 기술 글](https://blog.cloudflare.com/kitesurf/)의 상태 모델은 한
+task의 수명에 묶인 ephemeral 세션이며 가능한 한 stateless다. 장기 인증 상태를
+유지하는 persistent browsing session은 이 모델의 대상이 아니다.
+
+성능 서술도 교환비를 빠뜨렸다. Cloudflare의 Chrome 대비 스크린샷/HTML 추출
+측정은 CPU 3.1배/3.8배, 메모리 4.7배/7.0배 절감을 보고하지만 wall time은
+1.8배/1.7배 느리다. 따라서 자원 절감을 지연 단축이나 persistent workspace의
+검증으로 전용하면 안 된다.
+
+## 메인터너 보정
+
+- Kitesurf를 task-scoped ephemeral/stateless 격리로 정정하고 task 종료 시 상태가
+  폐기된다는 경계를 적었다.
+- CPU·메모리 절감과 wall-time 1.7~1.8배 지연을 한 측정 문맥에 함께 기록했다.
+- W1을 열린 문서·안정 ID·색인·저널을 보존하는 persistent workspace로 분리했다.
+  Kitesurf와 공유하는 것은 사람용 표면 제거와 구조화된 에이전트 계약이라는 원리뿐이다.
+- W1에 상태 소유권, 재시작 복구, 입력 digest 변화 시 무효화 계약과 별도 벤치마크가
+  필요함을 명시했다.
+
+## 완료한 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| Cloudflare 공식 출처 대조 | task 수명의 ephemeral/stateless 세션, persistent session 한계, CPU·메모리·wall-time 수치를 대조해 반영 |
+| 대상 문구 계약 검사 | 공식 URL, `ephemeral`, `stateless`, `persistent workspace`, 3.1/3.8·4.7/7.0·1.8/1.7 수치가 모두 존재하고 기존 "상주 실행" 문구가 제거됨 |
+| Markdown 상대 링크 검사 | 조사 문서와 review·구현 기록의 저장소 내부 링크 통과 |
+| `python scripts/check_document_metadata.py` | 통과. 문서 522개의 front matter·canonical 관계 이상 없음 |
+| `git diff --check origin/pr/4352..HEAD` | 통과 |
+| Cargo·시각 검증 | 생략. `mydocs` 아래 Markdown만 변경하며 실행 코드·렌더 출력 영향 없음 |
+
+## 리스크와 권고
+
+- 수치는 Cloudflare가 고른 두 workload의 Chrome 대비 결과다. rhwp W1의 성능
+  예측치로 해석하지 않는다.
+- 최신 PR head의 required checks와 mergeability는 실제 push 뒤 다시 확인해야 한다.
+- 이 로컬 보정은 remote에 push하거나 GitHub 상태를 바꾸지 않았다.
+
+**정정된 상태 모델과 성능 교환비를 유지하는 조건으로 merge 후보에 둘 수 있다.**

--- a/mydocs/pr/pr_4352_review.md
+++ b/mydocs/pr/pr_4352_review.md
@@ -29,6 +29,8 @@ loaded documents: `pr_review_workflow.md`, `pr_review/README.md`,
 | 기준 devel | `e48fe86947fbf9a44b1b98c7037150751af541ab` |
 | 가시성 브랜치 | `review/kevin9327-20260810-pr4352` |
 | 원 변경 규모 | 조사 문서 1파일, `+70/-0`, contributor 커밋 1개 |
+| 1차 메인터너 보정 | `1901ab81d6a44e68bd45b01e7baf4ef9908d8fdc` — `docs(roadmap): correct #4352 Kitesurf state model` |
+| 후속 근거 한정 | `7062c5495bad5b529973554eca1675c1c7de77d1` — `docs(roadmap): qualify #4352 Kitesurf evidence` |
 
 원 변경은 Kitesurf 동향을 W1 `rhwp workspace` 제안에 사상한다. 메인터너 보정은
 해당 조사 문서와 이 review·구현 기록만 바꾸며 source, test, workflow, fixture,
@@ -48,11 +50,23 @@ task의 수명에 묶인 ephemeral 세션이며 가능한 한 stateless다. 장�
 1.8배/1.7배 느리다. 따라서 자원 절감을 지연 단축이나 persistent workspace의
 검증으로 전용하면 안 된다.
 
+1차 메인터너 보정 뒤 독립 재검토에서 세 가지 범위 오류를 더 확인했다. 발표일은
+2026-08-06이고 공식 글이 2026-08-07 수정됐는데 이를 08-07 발표로 적었다. 성능
+수치는 일반 브라우징 전체가 아니라 14-URL quick-action corpus에서 Kitesurf와
+Chromium warm pool을 비교한 값이다. 또한 "약 10분보다 오래"를 임계값처럼
+썼지만 공식 예시는 **10분짜리 인증 세션처럼 persistent state가 필요한 작업**을
+가리킨다.
+
 ## 메인터너 보정
 
 - Kitesurf를 task-scoped ephemeral/stateless 격리로 정정하고 task 종료 시 상태가
   폐기된다는 경계를 적었다.
 - CPU·메모리 절감과 wall-time 1.7~1.8배 지연을 한 측정 문맥에 함께 기록했다.
+- 발표 2026-08-06과 공식 글 수정 2026-08-07을 구분했다.
+- CPU 3.1/3.8배, 메모리 4.7/7.0배 절감과 wall time 1.8/1.7배 지연을
+  14-URL quick-action corpus 대 Chromium warm pool 조건으로 한정했다.
+- 10분을 상태 지속 임계값으로 쓰지 않고, persistent state가 필요한 10분짜리 인증
+  세션을 공식 글의 예시로 기록했다.
 - W1을 열린 문서·안정 ID·색인·저널을 보존하는 persistent workspace로 분리했다.
   Kitesurf와 공유하는 것은 사람용 표면 제거와 구조화된 에이전트 계약이라는 원리뿐이다.
 - W1에 상태 소유권, 재시작 복구, 입력 digest 변화 시 무효화 계약과 별도 벤치마크가
@@ -62,8 +76,9 @@ task의 수명에 묶인 ephemeral 세션이며 가능한 한 stateless다. 장�
 
 | 검증 | 결과 |
 | --- | --- |
-| Cloudflare 공식 출처 대조 | task 수명의 ephemeral/stateless 세션, persistent session 한계, CPU·메모리·wall-time 수치를 대조해 반영 |
-| 대상 문구 계약 검사 | 공식 URL, `ephemeral`, `stateless`, `persistent workspace`, 3.1/3.8·4.7/7.0·1.8/1.7 수치가 모두 존재하고 기존 "상주 실행" 문구가 제거됨 |
+| Cloudflare 공식 출처 대조 | 발표 2026-08-06/수정 08-07, task 수명의 ephemeral/stateless 세션과 persistent-state 예시를 반영 |
+| benchmark 범위 검사 | `14개 URL의 quick-action corpus`, `Chromium warm pool`, CPU 3.1/3.8·메모리 4.7/7.0·wall 1.8/1.7이 같은 문맥에 존재 |
+| stale 문구 제거 검사 | 08-07 발표, "약 10분보다 오래", V8 isolate "상주 실행" 문구가 없음 |
 | Markdown 상대 링크 검사 | 조사 문서와 review·구현 기록의 저장소 내부 링크 통과 |
 | `python scripts/check_document_metadata.py` | 통과. 문서 522개의 front matter·canonical 관계 이상 없음 |
 | `git diff --check origin/pr/4352..HEAD` | 통과 |
@@ -71,8 +86,10 @@ task의 수명에 묶인 ephemeral 세션이며 가능한 한 stateless다. 장�
 
 ## 리스크와 권고
 
-- 수치는 Cloudflare가 고른 두 workload의 Chrome 대비 결과다. rhwp W1의 성능
-  예측치로 해석하지 않는다.
+- 수치는 Cloudflare가 고른 14-URL quick-action corpus와 Chromium warm pool의 두
+  action 결과다. cold-start, 장기 browsing, rhwp W1의 성능 예측치로 해석하지 않는다.
+- 10분은 session lifetime 임계값이 아니다. persistent state 필요 여부가 상태 모델을
+  가르는 조건이다.
 - 최신 PR head의 required checks와 mergeability는 실제 push 뒤 다시 확인해야 한다.
 - 이 로컬 보정은 remote에 push하거나 GitHub 상태를 바꾸지 않았다.
 

--- a/mydocs/pr/pr_4352_review_impl.md
+++ b/mydocs/pr/pr_4352_review_impl.md
@@ -12,19 +12,22 @@ last_verified: 2026-08-10
 | 구분 | SHA / 내용 |
 | --- | --- |
 | contributor source | `440b4a472dc58f0d7c1c9af0525e520c321003c3` |
-| maintainer correction | Kitesurf 상태·성능 정정, W1 persistent 경계, review·구현 기록 |
+| first maintainer correction | `1901ab81d6a44e68bd45b01e7baf4ef9908d8fdc` — `docs(roadmap): correct #4352 Kitesurf state model` |
+| follow-up docs correction | `7062c5495bad5b529973554eca1675c1c7de77d1` — `docs(roadmap): qualify #4352 Kitesurf evidence` |
+| trailing review update | 이 문서를 포함한 `docs(pr): update #4352 follow-up evidence` commit |
 
 ## 실행 내용
 
-1. 원 PR head와 Cloudflare 공식 기술 글의 architecture, session lifetime, benchmark
-   표를 대조했다.
-2. Kitesurf의 task-scoped ephemeral/stateless 모델과 W1의 persistent workspace를
-   분리하고, CPU·메모리 절감과 wall-time 지연을 함께 기록했다.
-3. 대상 Markdown 링크, 필수 출처·수치·상태 문구와 whitespace를 검사했다.
-4. 원 head가 보정 branch의 조상이고 후속 범위가 single-parent이며 merge commit이
-   없음을 확인했다.
+1. 원 PR head와 Cloudflare 공식 기술 글의 announcement/edit date, architecture,
+   session lifetime, benchmark corpus와 baseline을 대조했다.
+2. 1차 보정 `1901ab81...`을 보존하고 그 뒤에 14-URL quick-action corpus,
+   Chromium warm pool, 10분짜리 persistent-state 예시를 정정한 docs commit을 더했다.
+3. 대상 Markdown 링크, 필수 출처·날짜·수치·조건 문구와 whitespace를 검사했다.
+4. 이 review update를 docs correction 뒤의 별도 single-parent commit으로 추가하고,
+   원 head부터 merge commit 없는 선형 history인지 확인했다.
 
 ## rollback
 
-문제가 생기면 원 source 뒤의 이 trailing 메인터너 commit만 revert한다. contributor
-commit은 amend, rebase, reset 또는 force-push하지 않는다.
+후속 한정에 문제가 생기면 trailing review update와 `7062c549...`를 역순으로
+revert한다. 메인터너 보정 전체를 제거해야 할 때만 그 뒤 `1901ab81...`도 revert한다.
+contributor source는 amend, rebase, reset 또는 force-push하지 않는다.

--- a/mydocs/pr/pr_4352_review_impl.md
+++ b/mydocs/pr/pr_4352_review_impl.md
@@ -1,0 +1,30 @@
+---
+kind: pr_review_impl
+status: active
+canonical: mydocs/pr/pr_4352_review.md
+last_verified: 2026-08-10
+---
+
+# PR #4352 메인터너 보정 실행 기록
+
+## 커밋 경계
+
+| 구분 | SHA / 내용 |
+| --- | --- |
+| contributor source | `440b4a472dc58f0d7c1c9af0525e520c321003c3` |
+| maintainer correction | Kitesurf 상태·성능 정정, W1 persistent 경계, review·구현 기록 |
+
+## 실행 내용
+
+1. 원 PR head와 Cloudflare 공식 기술 글의 architecture, session lifetime, benchmark
+   표를 대조했다.
+2. Kitesurf의 task-scoped ephemeral/stateless 모델과 W1의 persistent workspace를
+   분리하고, CPU·메모리 절감과 wall-time 지연을 함께 기록했다.
+3. 대상 Markdown 링크, 필수 출처·수치·상태 문구와 whitespace를 검사했다.
+4. 원 head가 보정 branch의 조상이고 후속 범위가 single-parent이며 merge commit이
+   없음을 확인했다.
+
+## rollback
+
+문제가 생기면 원 source 뒤의 이 trailing 메인터너 commit만 revert한다. contributor
+commit은 amend, rebase, reset 또는 force-push하지 않는다.

--- a/mydocs/tech/agent_roadmap/trend_agent_runtime_2026h2.md
+++ b/mydocs/tech/agent_roadmap/trend_agent_runtime_2026h2.md
@@ -1,0 +1,70 @@
+---
+kind: investigation
+status: active
+canonical: mydocs/tech/agent_roadmap/trend_agent_runtime_2026h2.md
+last_verified: 2026-08-09
+---
+
+# 동향: 에이전트 전용 런타임 — 웹의 선례와 rhwp workspace 제안 (W1, #4351)
+
+[trend_survey_2026h2.md](trend_survey_2026h2.md) 의 후속 동향 1건이다. 같은
+5관문(출처 실재·3판정·논지 기여·게이트 서술·캡)을 지나며, **제안이고 채택·번호
+부여는 메인테이너 몫**이다. 이번 캡은 1건(W1)이다.
+
+## 1. 동향 실측 — "사람용 표면을 제거한 런타임"이 실물이 됐다
+
+Cloudflare 가 2026-08-07 **에이전트 전용 브라우저 엔진 Kitesurf** 를 발표했다.
+요지(전부 아래 출처에서 확인):
+
+- 사람용 브라우저의 표면(탭·테마·확장·시각 장식)을 제거하고, 에이전트가 실제로
+  쓰는 것만 남겼다 — 구조 읽기·추출, 폼 채우기, 스크린샷(그라운딩), JS 실행,
+  내비게이션.
+- Chromium 없이 **Rust 로 새로 구현**, V8 isolate(Workers) 상주 실행. 메모리
+  3~7배·CPU 약 3배 절감, Web Platform Tests 215,000+ 통과. 베타 무료, 오픈소스
+  계획 언급.
+- 한계도 공개: 비디오·WebGL 미지원, 복잡 페이지는 여전히 Chromium 필요.
+
+출처(접속 2026-08-09):
+[TechCrunch](https://techcrunch.com/2026/08/07/cloudflare-launches-kitesurf-a-browser-built-for-ai-agents/) ·
+[MarkTechPost](https://www.marktechpost.com/2026/08/06/cloudflare-introduces-kitesurf-an-agent-first-web-browser-that-runs-entirely-in-v8-isolates-on-cloudflare-workers/) ·
+[Mac Observer](https://www.macobserver.com/news/cloudflare-launches-kitesurf-browser-exclusively-for-ai-agents/)
+
+**원리 추출**(실명 비교가 아니라 원리로): ① 에이전트 소비자는 픽셀이 아니라
+**구조와 결정론**을 산다. ② 사람 표면을 빼면 자원·기동 시간이 크게 줄어 상주가
+싸진다. ③ "무엇을 못 하는지"의 공개가 신뢰 표면이다.
+
+## 2. rhwp 에의 사상(寫像) — 웹의 Kitesurf = 문서의 workspace
+
+rhwp 의 "사람용 표면"은 studio(웹 에디터)다. 에이전트 축은 이미 CLI `--json`·
+`mcp-serve` 세션(R71)·자기서술을 갖고 있으나, **상주 런타임으로서의 결합**이
+비어 있다. 제안 W1:
+
+### W1 `rhwp workspace` — 에이전트 전용 문서 런타임 (설계 제안)
+
+- **한 줄** — 문서 N 개를 한 상주 프로세스에 열고, 픽셀 대신 **안정 노드 ID
+  구조 트리**로 보고, 같은 ID 로 행동하고, 매 변이를 스스로 검증한다.
+- **모양** — ① 워크스페이스: `mcp-serve` 확장(예: `--workspace <dir>`)으로 다중
+  핸들 + 코퍼스 색인. ② 뷰: 문서→구역→쪽→블록/표/셀/필드의 안정 ID 트리 —
+  a11y 트리의 문서판(`export-structure` 를 "상주·증분·안정 ID"로 승격). ③ 액션:
+  기존 편집 표면을 노드 ID 주소로 라우팅. ④ 신뢰 루프: 매 변이 후 자동
+  digest/verify 대조 + 저널(트랙 C 지문 체인과 접합). ⑤ 한계 공개: 렌더 픽셀이
+  필요한 판정(시각 회귀)은 범위 밖 — render-diff 로 위임한다고 명시.
+- **3판정: 부분** — 세션 3종·digest·verify·export-structure·프로파일이 전부
+  실재한다. 공백은 결합(상주 멀티 문서 + 안정 ID + 자동 검증 루프)이지 부품이
+  아니다. 신규 축이 아니라 **R76(문서 지능 서버)·R71·트랙 C 의 합류점**이다.
+- **착수 게이트** — ① R76 의 판단("증분 재파싱 불가 전제에서 무엇을 캐시하나")과
+  **같은 질문이므로 합류한다** — 별도 답을 만들면 드리프트다. ② 트랙 C R28(세션
+  동시성 모델) 판단. ③ 메인테이너 채택(표면 신설이므로).
+- **왜 1등 논지에 닿나** — HWP 도메인에 이 표면은 존재하지 않는다(#4327 §2·§3:
+  경쟁 도구들은 변환·COM 자동화 층위). 웹에서 같은 원리가 대형 사업자의 실물로
+  검증된 직후가, 문서 도메인에서 같은 자리를 선점할 시점이다. 엔진·세션·계약은
+  이미 있고 남은 것은 결합이라 비용이 낮다.
+- **DoD(채택 시)** — 에이전트가 워크스페이스를 열어 ID 트리로 문서를 찾고, ID
+  액션으로 편집하고, 자동 verify 저널이 남는 왕복 1개가 계약 테스트로 고정된다.
+
+## 3. 하지 않는 것
+
+- "OS"·범용 런타임 주장 — 문서 도메인 밖은 범위가 아니다(비목표를 명시하는 것
+  자체가 §1 원리 ③이다).
+- R76 과 별개의 캐시 설계 — 게이트 ① 대로 합류만 한다.
+- 이 문서에서의 구현 착수 — 채택 전 구현 금지(로드맵 운영 규칙 1).

--- a/mydocs/tech/agent_roadmap/trend_agent_runtime_2026h2.md
+++ b/mydocs/tech/agent_roadmap/trend_agent_runtime_2026h2.md
@@ -13,8 +13,8 @@ last_verified: 2026-08-10
 
 ## 1. 동향 실측 — "사람용 표면을 제거한 런타임"이 실물이 됐다
 
-Cloudflare 가 2026-08-07 **에이전트 전용 브라우저 엔진 Kitesurf** 를 발표했다.
-요지(전부 아래 출처에서 확인):
+Cloudflare 가 2026-08-06 **에이전트 전용 브라우저 엔진 Kitesurf** 를 발표했고,
+공식 기술 글은 2026-08-07 수정됐다. 요지(전부 아래 출처에서 확인):
 
 - 사람용 브라우저의 표면(탭·테마·확장·시각 장식)을 제거하고, 에이전트가 실제로
   쓰는 것만 남겼다 — 구조 읽기·추출, 폼 채우기, 스크린샷(그라운딩), JS 실행,
@@ -22,12 +22,15 @@ Cloudflare 가 2026-08-07 **에이전트 전용 브라우저 엔진 Kitesurf** �
 - Chromium 없이 **Rust 로 새로 구현**했고 V8 isolate(Workers)에서 실행한다. 다만
   isolate는 상주 브라우저가 아니라 **한 task의 수명에 묶인 ephemeral 세션**이며,
   서비스는 가능한 한 stateless로 유지한다. task가 끝나면 세션도 폐기된다.
-- Cloudflare의 Chrome 대비 측정에서 스크린샷/HTML 추출은 CPU를 각각 3.1배/3.8배,
-  메모리를 4.7배/7.0배 적게 썼다. 그 대신 wall time은 각각 1.8배/1.7배
-  **느렸다**. 자원 절감은 지연 단축과 같은 주장이 아니다.
+- Cloudflare의 성능 표는 **14개 URL의 quick-action corpus**에서 Kitesurf와 이미
+  떠 있는 **Chromium warm pool**을 비교한 결과다. 이 조건에서 스크린샷/HTML
+  추출은 CPU를 각각 3.1배/3.8배, 메모리를 4.7배/7.0배 적게 썼다. 그 대신 wall
+  time은 각각 1.8배/1.7배 **느렸다**. 자원 절감은 지연 단축, cold-start 비교,
+  일반 브라우징 workload 전체에 대한 주장과 같지 않다.
 - 한계도 공개했다. 비디오·WebGL은 미지원이고 복잡 페이지는 여전히 Chromium이
-  필요하다. 인증 상태를 약 10분보다 오래 이어 가는 persistent browsing session도
-  이 task-scoped 모델의 대상이 아니다.
+  필요하다. **10분짜리 인증 세션처럼 persistent state가 필요한 작업**도 이
+  task-scoped 모델의 대상이 아니다. 10분은 상태 지속 여부를 가르는 임계값이
+  아니라 공식 글이 든 작업 예시다.
 
 출처(접속 2026-08-10):
 [Cloudflare 공식 기술 글](https://blog.cloudflare.com/kitesurf/) ·
@@ -36,9 +39,10 @@ Cloudflare 가 2026-08-07 **에이전트 전용 브라우저 엔진 Kitesurf** �
 [Mac Observer](https://www.macobserver.com/news/cloudflare-launches-kitesurf-browser-exclusively-for-ai-agents/)
 
 **원리 추출**(실명 비교가 아니라 원리로): ① 에이전트 소비자는 픽셀이 아니라
-**구조와 결정론**을 산다. ② 사람 표면과 장기 상태를 빼면 task 단위 격리의 CPU·
-메모리 비용을 줄일 수 있지만 wall time 지연이라는 교환비가 남는다. ③ "무엇을 못
-하는지"와 상태 수명을 함께 공개하는 것이 신뢰 표면이다.
+**구조와 결정론**을 산다. ② 14-URL quick-action 실측은 task 단위 격리의 CPU·
+메모리 절감과 wall-time 지연 교환비를 보여 주지만, warm Chromium 이외 조건으로
+일반화할 수 없다. ③ "무엇을 못 하는지"와 상태 수명을 함께 공개하는 것이 신뢰
+표면이다.
 
 ## 2. rhwp 에의 사상(寫像) — 웹의 Kitesurf = 문서의 workspace
 

--- a/mydocs/tech/agent_roadmap/trend_agent_runtime_2026h2.md
+++ b/mydocs/tech/agent_roadmap/trend_agent_runtime_2026h2.md
@@ -2,7 +2,7 @@
 kind: investigation
 status: active
 canonical: mydocs/tech/agent_roadmap/trend_agent_runtime_2026h2.md
-last_verified: 2026-08-09
+last_verified: 2026-08-10
 ---
 
 # 동향: 에이전트 전용 런타임 — 웹의 선례와 rhwp workspace 제안 (W1, #4351)
@@ -19,36 +19,49 @@ Cloudflare 가 2026-08-07 **에이전트 전용 브라우저 엔진 Kitesurf** �
 - 사람용 브라우저의 표면(탭·테마·확장·시각 장식)을 제거하고, 에이전트가 실제로
   쓰는 것만 남겼다 — 구조 읽기·추출, 폼 채우기, 스크린샷(그라운딩), JS 실행,
   내비게이션.
-- Chromium 없이 **Rust 로 새로 구현**, V8 isolate(Workers) 상주 실행. 메모리
-  3~7배·CPU 약 3배 절감, Web Platform Tests 215,000+ 통과. 베타 무료, 오픈소스
-  계획 언급.
-- 한계도 공개: 비디오·WebGL 미지원, 복잡 페이지는 여전히 Chromium 필요.
+- Chromium 없이 **Rust 로 새로 구현**했고 V8 isolate(Workers)에서 실행한다. 다만
+  isolate는 상주 브라우저가 아니라 **한 task의 수명에 묶인 ephemeral 세션**이며,
+  서비스는 가능한 한 stateless로 유지한다. task가 끝나면 세션도 폐기된다.
+- Cloudflare의 Chrome 대비 측정에서 스크린샷/HTML 추출은 CPU를 각각 3.1배/3.8배,
+  메모리를 4.7배/7.0배 적게 썼다. 그 대신 wall time은 각각 1.8배/1.7배
+  **느렸다**. 자원 절감은 지연 단축과 같은 주장이 아니다.
+- 한계도 공개했다. 비디오·WebGL은 미지원이고 복잡 페이지는 여전히 Chromium이
+  필요하다. 인증 상태를 약 10분보다 오래 이어 가는 persistent browsing session도
+  이 task-scoped 모델의 대상이 아니다.
 
-출처(접속 2026-08-09):
+출처(접속 2026-08-10):
+[Cloudflare 공식 기술 글](https://blog.cloudflare.com/kitesurf/) ·
 [TechCrunch](https://techcrunch.com/2026/08/07/cloudflare-launches-kitesurf-a-browser-built-for-ai-agents/) ·
 [MarkTechPost](https://www.marktechpost.com/2026/08/06/cloudflare-introduces-kitesurf-an-agent-first-web-browser-that-runs-entirely-in-v8-isolates-on-cloudflare-workers/) ·
 [Mac Observer](https://www.macobserver.com/news/cloudflare-launches-kitesurf-browser-exclusively-for-ai-agents/)
 
 **원리 추출**(실명 비교가 아니라 원리로): ① 에이전트 소비자는 픽셀이 아니라
-**구조와 결정론**을 산다. ② 사람 표면을 빼면 자원·기동 시간이 크게 줄어 상주가
-싸진다. ③ "무엇을 못 하는지"의 공개가 신뢰 표면이다.
+**구조와 결정론**을 산다. ② 사람 표면과 장기 상태를 빼면 task 단위 격리의 CPU·
+메모리 비용을 줄일 수 있지만 wall time 지연이라는 교환비가 남는다. ③ "무엇을 못
+하는지"와 상태 수명을 함께 공개하는 것이 신뢰 표면이다.
 
 ## 2. rhwp 에의 사상(寫像) — 웹의 Kitesurf = 문서의 workspace
 
 rhwp 의 "사람용 표면"은 studio(웹 에디터)다. 에이전트 축은 이미 CLI `--json`·
-`mcp-serve` 세션(R71)·자기서술을 갖고 있으나, **상주 런타임으로서의 결합**이
-비어 있다. 제안 W1:
+`mcp-serve` 세션(R71)·자기서술을 갖고 있으나, **문서 상태를 지속하는 런타임으로서의
+결합**이 비어 있다. Kitesurf와 W1은 사람용 표면을 덜어 내고 구조화된 에이전트
+계약을 준다는 원리만 공유한다. Kitesurf가 task 종료와 함께 상태를 버리는
+ephemeral/stateless 모델인 반면, W1은 열린 문서·안정 ID·색인·저널을 세션 너머까지
+보존하려는 **persistent workspace**다. 따라서 Kitesurf는 W1의 지속성 선례가 아니며,
+W1은 상태 소유권·복구·무효화를 별도로 증명해야 한다. 제안 W1:
 
 ### W1 `rhwp workspace` — 에이전트 전용 문서 런타임 (설계 제안)
 
-- **한 줄** — 문서 N 개를 한 상주 프로세스에 열고, 픽셀 대신 **안정 노드 ID
+- **한 줄** — 문서 N 개를 persistent workspace에 열고, 픽셀 대신 **안정 노드 ID
   구조 트리**로 보고, 같은 ID 로 행동하고, 매 변이를 스스로 검증한다.
 - **모양** — ① 워크스페이스: `mcp-serve` 확장(예: `--workspace <dir>`)으로 다중
   핸들 + 코퍼스 색인. ② 뷰: 문서→구역→쪽→블록/표/셀/필드의 안정 ID 트리 —
   a11y 트리의 문서판(`export-structure` 를 "상주·증분·안정 ID"로 승격). ③ 액션:
   기존 편집 표면을 노드 ID 주소로 라우팅. ④ 신뢰 루프: 매 변이 후 자동
   digest/verify 대조 + 저널(트랙 C 지문 체인과 접합). ⑤ 한계 공개: 렌더 픽셀이
-  필요한 판정(시각 회귀)은 범위 밖 — render-diff 로 위임한다고 명시.
+  필요한 판정(시각 회귀)은 범위 밖 — render-diff 로 위임한다고 명시. ⑥ 상태
+  경계: 열린 핸들·색인·저널의 저장 위치, 재시작 복구, 입력 digest 변화 시 무효화를
+  계약으로 고정한다. Kitesurf의 task 종료 폐기 모델을 이 항목에 복사하지 않는다.
 - **3판정: 부분** — 세션 3종·digest·verify·export-structure·프로파일이 전부
   실재한다. 공백은 결합(상주 멀티 문서 + 안정 ID + 자동 검증 루프)이지 부품이
   아니다. 신규 축이 아니라 **R76(문서 지능 서버)·R71·트랙 C 의 합류점**이다.
@@ -58,7 +71,8 @@ rhwp 의 "사람용 표면"은 studio(웹 에디터)다. 에이전트 축은 이
 - **왜 1등 논지에 닿나** — HWP 도메인에 이 표면은 존재하지 않는다(#4327 §2·§3:
   경쟁 도구들은 변환·COM 자동화 층위). 웹에서 같은 원리가 대형 사업자의 실물로
   검증된 직후가, 문서 도메인에서 같은 자리를 선점할 시점이다. 엔진·세션·계약은
-  이미 있고 남은 것은 결합이라 비용이 낮다.
+  이미 있고 남은 것은 결합이다. 단, Kitesurf의 CPU·메모리 절감치를 W1의 속도나
+  지속성 근거로 전용하지 않는다. W1 비용은 별도 상태·복구 벤치마크로 판정한다.
 - **DoD(채택 시)** — 에이전트가 워크스페이스를 열어 ID 트리로 문서를 찾고, ID
   액션으로 편집하고, 자동 verify 저널이 남는 왕복 1개가 계약 테스트로 고정된다.
 


### PR DESCRIPTION
## 변경 요약

**동향 제안 문서 1편** — 2026-08-07 Cloudflare 의 에이전트 전용 브라우저 엔진(Kitesurf) 발표를 출처 3건으로 실측 기록하고(사람 표면 제거·Rust 재구현·상주 경량화·한계 공개), 그 원리를 문서 도메인에 사상한 **W1 `rhwp workspace`(에이전트 전용 문서 런타임)** 를 설계 제안합니다: 상주 멀티 문서 워크스페이스 + 안정 노드 ID 구조 트리(a11y 트리의 문서판) + ID 액션 + 매 변이 자동 verify·저널.

- **3판정: 부분** — 세션·digest·verify·export-structure 부품은 전부 실재, 공백은 결합. 신규 축이 아니라 **R76(문서 지능 서버)·R71·트랙 C 의 합류점**으로 명시.
- **착수 게이트**: R76 캐시 판단과 합류(별도 답 금지 — 드리프트 방지) · R28 동시성 · **메인테이너 채택**. 채택 전 구현 금지 관례(로드맵 운영 규칙 1) 준수, trend_survey T-패턴 승계, 캡 1건.
- 신설 파일 1개 — 열린 PR 들과 무충돌.

## 관련 이슈

closes #4351

## 테스트

- [ ] cargo / SVG / WASM — 해당 없음(문서 전용)
- [x] 문서 메타데이터·Markdown 상대 링크 검사 이상 없음 · `git diff --check` 통과

## 성능 영향 및 측정 결과

- 해당 없음

## 스크린샷

해당 없음
