### PR TITLE
core: table.dirty clear 범위 한정 + 무효화 플래그 kill 범위 규칙

### DIFF
--- a/mydocs/tech/rendering_engine_design.md
+++ b/mydocs/tech/rendering_engine_design.md
@@ -2,7 +2,7 @@
 kind: canonical
 status: active
 canonical: mydocs/tech/rendering_engine_design.md
-last_verified: 2026-07-23
+last_verified: 2026-08-09
 ---
 
 # RHWP 렌더링 엔진 아키텍처 설계서
@@ -407,6 +407,12 @@ source에 쓰거나 편집 때 clone 경로를 직접 mirror하지 않는다.
 문단/control/cell 수가 바뀌지 않는 deferred cell text edit은 명시적 path revision을 먼저 올리고
 pagination만 dirty로 표시한다. #2004 compatibility projection이 실제 존재하는 section은 그
 projection만 section revision으로 무효화한 뒤 transient render 전에 source IR에서 다시 만든다.
+
+### kill 범위 규칙 (#4335)
+
+`dirty_sections`/`dirty_paragraphs`/`Table.dirty`류 무효화 플래그의 clear(kill)는 그 플래그를 읽는
+모든 지점(use)의 immediate dominator에서만 수행한다 — 그보다 넓은 범위(예: 처리한 구역 하나만 읽고
+전체 구역을 clear)에서 지우면 아직 소비되지 않은 dirty 정보가 죽어 stale 캐시가 영구히 남는다(#4325).
 
 ### 논리 경로와 lookup
 

--- a/mydocs/working/task_m100_4325_stage1.md
+++ b/mydocs/working/task_m100_4325_stage1.md
@@ -1,0 +1,78 @@
+# task_m100_4325 Stage 1 — table.dirty clear 범위 한정 + 무효화 플래그 kill 규칙
+
+- **이슈**: [#4325](https://github.com/edwardkim/rhwp/issues/4325), [#4335](https://github.com/edwardkim/rhwp/issues/4335)
+- **PR**: [#4360](https://github.com/edwardkim/rhwp/pull/4360)
+- **브랜치**: `fix/issue-4325-table-dirty-scope`
+- **분기 기준**: `upstream/devel` `e48fe8694`
+- **상태**: 로컬 전체 검증 통과, PR 게시
+- **기록일**: 2026-08-09 KST
+
+## 1. 결함 — 지우는 범위와 소비하는 범위가 어긋났다
+
+`table.dirty` 를 **소비**하는 곳은 구역 범위다. `rendering.rs:4037` 의
+`if !self.dirty_sections[idx] { … continue; }` 가 dirty 아닌 구역의 측정을 건너뛰고, 건너뛴 구역의
+표는 `measure_section_incremental`(`height_measurer.rs:2325`)이 아직 `!table.dirty` 로 소비하지
+않은 상태다.
+
+**지우는** 곳은 문서 범위였다. 같은 패스 끝에서 `for section in &mut self.document.sections` 로
+전 구역의 `table.dirty = false` 를 지웠다 — 방금 건너뛴 구역까지.
+
+## 2. 실측
+
+2구역 문서, 각 구역에 동일한 2×2 표, 스타일 글자모양 36pt:
+
+```
+BEFORE   구역0 h=55.52   구역1 h=55.52
+AFTER    구역0 h=487.52  구역1 h=55.52   ← stale
+재실행·본문편집 후에도 구역1 = 55.52. 그 표를 직접 편집해야만 복구.
+```
+
+셀 텍스트는 새 글꼴로 그려지는데 행 높이는 옛 값이라 `clip: true` 에 글자가 잘리고, 쪽 나눔도 옛
+높이로 계산돼 저장·인쇄·PDF 까지 틀린다.
+
+## 3. 두 선택지 중 (a) 를 골랐다
+
+- **(a)** clear 를 이번 패스에서 재측정한 구역으로 한정 ← **채택**
+- (b) `mark_cell_control_dirty` 가 구역도 함께 dirty 로 만들게 함
+
+(b) 는 `update_style_shapes` 한 호출자의 증상만 가린다. clear 루프 자체가 "건너뛴 구역까지
+지운다"는 결함을 안고 있어, `table.dirty = true` 를 직접 세우는 나머지 사이트 중 구역 dirty 를
+세우지 않는 경로가 추가되면 같은 결함을 물려받는다.
+
+저장소 관례도 (a) 다 — `rendering.rs:3815` 와 `:3826-3832` 가 이미 같은 스코핑을 쓴다.
+
+## 4. 구현
+
+`paginate_pass` 에 `remeasured_sections: Vec<bool>` 를 두고, 측정을 마치는 지점
+(`dirty_sections[idx] = false` 옆)에서 표시한다. 건너뛴 구역은 그 지점에 도달하지 않아 `false` 로
+남는다. 패스 말미 clear 루프가 이 플래그를 보고 건너뛴다.
+
+플래그가 남는 방향은 안전하다 — 다음 패스에서 한 번 더 측정할 뿐 stale 을 읽지 않는다.
+
+**적대 검증**: `paginate_pass` 안에서 `document.sections` 길이를 바꾸는 코드가 없음을 확인해
+`remeasured_sections` 인덱스 범위 초과가 불가능함을 근거로 남겼다.
+
+## 5. #4335 — 같은 결함의 일반형
+
+개별 버그가 아니라 **규칙 부재**였다. 같은 파일 안에서도 두 방식이 공존했다(`:3815` 는 한 구역만,
+`:4627` 은 전 구역).
+
+`mydocs/tech/rendering_engine_design.md` §12 뒤에 규칙을 기록했다 — *"무효화 플래그의 clear 는 그
+플래그를 읽는 모든 지점의 immediate dominator 에서만 수행한다."*
+
+플래그 6종 + revision 3단계를 전수 감사했고 **새 위반은 없었다.** `Table.dirty_flag` 는 HWPX
+`<hp:tc dirty>` 라운드트립 속성이라 제외했다.
+
+후속 후보로 남긴 것: `RenderNode.dirty` 는 `RenderNode::new` 가 항상 `true` 로 세우는데
+`has_dirty_nodes`/`mark_clean`/`needs_render` 의 프로덕션 호출부가 0건이고, `#[serde]` skip 이
+없어 모든 노드가 JSON 에 `dirty:true` 를 싣고 나간다.
+
+## 6. 검증 (완료)
+
+- 회귀 테스트 `issue_4325_style_update_second_section_table_not_left_stale` 신설. 수정 전 코드에서
+  `left: 1207.52` vs `right: 114.19` 로 실패함을 확인했다.
+- `cargo test --profile release-test --tests` 전체 통과.
+- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` 통과.
+- 문서: `check_markdown_links.py`, `check_document_metadata.py`, `git diff --check` 통과.
+
+남은 미래 조건은 GitHub Actions 와 작업지시자 승인, merge 다.

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -4011,6 +4011,10 @@ impl DocumentCore {
             self.dirty_paragraphs.push(None);
         }
         self.dirty_paragraphs.truncate(sec_count);
+        // [#4325] 이번 패스에서 실제로 재측정한 구역만 표시한다. dirty가 아니어서 건너뛴
+        // 구역은 표 dirty 플래그를 지우면 안 된다 — 지우는 범위와 소비하는 범위(측정 스킵)가
+        // 어긋나면 그 구역의 표가 이후 dirty로 마킹돼도 이번 패스의 clear로 소실된다.
+        let mut remeasured_sections = vec![false; sec_count];
 
         // 구역 간 쪽번호 위치/번호 상속
         let mut carry_page_number_pos: Option<crate::model::control::PageNumberPos> = None;
@@ -4580,6 +4584,7 @@ impl DocumentCore {
             }
             self.pagination[idx] = result;
             self.dirty_sections[idx] = false;
+            remeasured_sections[idx] = true;
             // 문단 dirty 비트맵 초기화 (모든 문단 clean)
             let para_count = section.paragraphs.len();
             self.dirty_paragraphs[idx] = Some(vec![false; para_count]);
@@ -4619,8 +4624,14 @@ impl DocumentCore {
             *off = 0;
         }
 
-        // 표 dirty 플래그 초기화
-        for section in &mut self.document.sections {
+        // 표 dirty 플래그 초기화. [#4325] 이번 패스에서 재측정하지 않고 건너뛴 구역은
+        // 제외한다 — 그 구역의 표는 measure_section_incremental이 아직 소비하지 않았으므로
+        // dirty를 여기서 지우면 이후 실제로 재측정될 때 변경 전 MeasuredTable을 그대로
+        // clone하게 된다(issue #4325).
+        for (idx, section) in self.document.sections.iter_mut().enumerate() {
+            if !remeasured_sections[idx] {
+                continue;
+            }
             for para in &mut section.paragraphs {
                 for ctrl in &mut para.controls {
                     if let Control::Table(table) = ctrl {

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -406,6 +406,84 @@ fn issue_1470_style_update_preserves_direct_char_shape() {
     );
 }
 
+/// [#4325] `table.dirty`가 문서 범위로 지워지고 구역 범위로 소비되는 스코프 불일치 회귀.
+///
+/// `updateStyleShapes`는 스타일을 쓰는 모든 구역의 표를 `mark_cell_control_dirty`로
+/// dirty 마킹한 뒤, `0..num_sections`을 돌며 구역별로 `rebuild_section`을 호출한다.
+/// `rebuild_section(0)`이 유발하는 `paginate()` 패스는 아직 `dirty_sections[1]`이
+/// false라 구역 1을 건너뛰지만, 그 패스 끝에서 표 dirty 플래그를 지우는 루프가
+/// 문서 전체 범위였다 — 건너뛴 구역 1의 표까지 dirty가 사라졌다. 이후
+/// `rebuild_section(1)`이 구역 1을 실제로 재측정할 차례가 오면 `table.dirty`가
+/// 이미 false라 `measure_section_incremental`이 변경 전 `MeasuredTable`을 그대로
+/// clone해 구역 1의 표 높이가 영구히 stale로 남았다(원본 편집 전까지 복구 안 됨).
+#[test]
+fn issue_4325_style_update_second_section_table_not_left_stale() {
+    use crate::model::style::{CharShape, ParaShape, Style};
+
+    let mut doc = HwpDocument::create_empty();
+    doc.document.doc_info.char_shapes.push(CharShape {
+        base_size: 1000, // 10pt
+        ..Default::default()
+    });
+    doc.document.doc_info.para_shapes.push(ParaShape::default());
+    doc.document.doc_info.styles.push(Style {
+        local_name: "바탕글".to_string(),
+        english_name: "Normal".to_string(),
+        lang_id: 1042,
+        para_shape_id: 0,
+        char_shape_id: 0,
+        ..Default::default()
+    });
+
+    // 구역 0에 2x2 표 삽입 + 줄바꿈되는 셀 텍스트 (이슈 실측: "같은 표 + 줄바꿈되는 텍스트")
+    doc.create_table_native(0, 0, 0, 2, 2)
+        .expect("표 삽입 (구역0)");
+    let wrap_text = "가".repeat(120);
+    doc.insert_text_in_cell_native(0, 0, 0, 0, 0, 0, &wrap_text)
+        .expect("셀 텍스트 삽입 (구역0)");
+
+    // 구역 1: 구역 0과 완전히 같은 표+텍스트를 가진 구역을 추가한다 (이슈 실측: 2구역 문서).
+    let mut two_section_doc = doc.document.clone();
+    let section0 = two_section_doc.sections[0].clone();
+    two_section_doc.sections.push(section0);
+    doc.set_document(two_section_doc);
+
+    assert_eq!(doc.document.sections.len(), 2, "구역 2개 문서 준비");
+    assert_eq!(doc.measured_tables.len(), 2);
+    assert_eq!(
+        doc.measured_tables[0][0].total_height, doc.measured_tables[1][0].total_height,
+        "복제 직후 두 구역의 표 높이는 같아야 한다 (기준선)"
+    );
+    assert!(
+        doc.dirty_sections.iter().all(|d| !d),
+        "set_document 직후 paginate가 두 구역을 모두 처리해야 한다"
+    );
+    let before_height = doc.measured_tables[0][0].total_height;
+
+    // 스타일 글자모양을 36pt로 일괄 변경 (이슈 실측 시나리오)
+    assert!(
+        doc.update_style_shapes(0, r#"{"fontSize":3600}"#, "{}"),
+        "스타일 글자모양 수정 (36pt)"
+    );
+
+    let after0 = doc.measured_tables[0][0].total_height;
+    let after1 = doc.measured_tables[1][0].total_height;
+
+    assert!(
+        after0 > before_height,
+        "구역0 표 높이는 36pt 반영으로 커져야 한다 (before={before_height}, after0={after0})"
+    );
+    assert_eq!(
+        after0, after1,
+        "issue #4325 회귀: 구역1 표가 구역0과 동일한 표/텍스트인데도 stale MeasuredTable로 \
+         남았다 (before={before_height}, after0={after0}, after1={after1})"
+    );
+    assert_eq!(
+        doc.measured_tables[0][0].row_heights, doc.measured_tables[1][0].row_heights,
+        "issue #4325 회귀: 구역1 표의 행 높이가 구역0과 달라지면 안 된다"
+    );
+}
+
 #[test]
 fn issue_1470_character_style_does_not_replace_para_style() {
     use crate::model::paragraph::CharShapeRef;


### PR DESCRIPTION
## 무엇을

1. `paginate_pass` 가 표 dirty 플래그를 문서 전체 범위로 지우던 것을 **이번 패스에서 실제로
   재측정한 구역**으로 한정한다 (#4325).
2. 그 결함의 일반형을 규칙으로 canonical 문서에 기록하고, 같은 부류 플래그를 전수 감사한다 (#4335).

## 1. table.dirty clear 범위 — #4325

### 왜

`table.dirty` 를 지우는 범위와 소비하는 범위가 어긋나 있었다.

- **소비 — 구역 범위**: `rendering.rs:4037` 의 `if !self.dirty_sections[idx] { … continue; }` 가
  dirty 가 아닌 구역의 측정을 건너뛴다. 건너뛴 구역의 표는 `measure_section_incremental`
  (`height_measurer.rs:2325`) 이 아직 `!table.dirty` 로 소비하지 않은 상태다.
- **지움 — 문서 범위**: 같은 패스 끝에서 `for section in &mut self.document.sections` 로 전
  구역의 `table.dirty = false` 를 지웠다. 방금 건너뛴 구역까지.

그래서 그 구역의 표는 이후 재측정될 때 변경 전 `MeasuredTable` 을 그대로 clone 하고, **직접
편집하기 전까지 영구히 stale 로 남는다.** 셀 텍스트는 새 글꼴로 그려지는데 행 높이는 옛 값이라
`clip: true` 에 글자가 잘리고, 그 구역의 쪽 나눔도 옛 높이로 계산돼 저장·인쇄·PDF 까지 틀린다.

실측(2구역 문서, 스타일 글자모양 36pt):

```
BEFORE   구역0 표 h=55.52   구역1 표 h=55.52
AFTER    구역0 표 h=487.52  구역1 표 h=55.52   ← stale, 재실행·본문편집으로도 안 풀림
```

### 어떻게

`paginate_pass` 에 `remeasured_sections: Vec<bool>` 를 두고, 측정을 마치는 지점
(`self.dirty_sections[idx] = false;` 옆)에서 표시한다. 건너뛴 구역은 도달하지 않으므로 `false`
로 남는다. 패스 말미의 clear 루프가 이 플래그를 보고 건너뛴다.

같은 파일 `rendering.rs:3815` / `:3826-3832` 가 이미 쓰는 스코핑 패턴을 그대로 따랐다.

호출자 쪽(`mark_cell_control_dirty` 가 구역도 함께 dirty 로 만들게 하는 방법)을 고르지 않은
이유는, 그쪽은 `update_style_shapes` 한 호출자의 증상만 가리기 때문이다. clear 루프 자체가
"이번 패스에서 건너뛴 구역까지 지운다" 는 결함을 그대로 안고 있어서, `table.dirty = true` 를
직접 세우는 나머지 사이트 중 구역 dirty 를 세우지 않는 경로가 추가되면 같은 결함을 물려받는다.

플래그가 남는 방향은 안전하다 — 다음 패스에서 한 번 더 측정할 뿐 stale 을 읽지 않는다.

## 2. kill 범위 규칙 + 전수 감사 — #4335

위 결함은 개별 버그가 아니라 **규칙 부재**의 결과다. 같은 파일 안에서도 두 방식이 공존했다 —
`rendering.rs:3815` 는 처리한 구역 하나만 지우고, `:4627`(수정 전)은 전 구역을 쓸었다.

`mydocs/tech/rendering_engine_design.md` §12 뒤에 규칙을 기록했다:

> 무효화 플래그의 clear(kill)는 그 플래그를 읽는 모든 지점(use)의 immediate dominator 에서만
> 수행한다 — 그보다 넓은 범위에서 지우면 아직 소비되지 않은 dirty 정보가 죽어 stale 캐시가
> 영구히 남는다(#4325).

이 문서를 고른 이유: `mydocs/manual/README.md` 가 "기술 사실·설계 결정은 tech 지도에서 찾는다"고
명시하고, `mydocs/tech/README.md` 가 렌더링 엔진의 canonical 문서로 이 파일을 지정한다. §12 가
이미 dirty 무효화 계약을 다루는 자리라 새 문서를 만들지 않았다.

### 전수 감사 — 새 위반 없음

| 플래그 | 판정 |
|---|---|
| `DocumentCore.dirty_sections` (`mod.rs:163`) | 위반 없음 — kill 두 곳 모두 use 와 같은 idx 스코프 |
| `DocumentCore.dirty_paragraphs` (`mod.rs:169`) | 위반 없음 |
| `Table.dirty` (`model/table.rs:66`) | `rendering.rs:3829` 는 스코프 동치라 정상. `:4627` 이 이 PR 에서 고치는 위반 |
| `RenderNode.dirty` (`render_tree.rs:115`) | kill 이 프로덕션에 없어 위반 불가 |
| `DocInfo.raw_stream_dirty` (`model/document.rs:190`) | kill 이 프로덕션에 없어 위반 불가 |
| `TypesetState.vpos_ladder_dirty` (`typeset.rs:961`) | 위반 없음 — 단일 조판 패스 내 순차 스칼라 |
| `RenderNormalizationState` revision 3단계 (`mod.rs:110-116`) | 위반 불가 — revision 비교는 이 결함 클래스에 면역 |

`Table.dirty_flag` (`model/table.rs:148`) 는 제외했다 — HWPX `<hp:tc dirty>` 속성의 라운드트립
보존용이지 무효화 플래그가 아니다. 같은 오분류가 더 없는지 필드 선언을 전수 grep 해 확인했다.

### 후속 후보 (이 PR 범위 밖)

- `RenderNode.dirty` 는 `RenderNode::new` 가 항상 `true` 로 세우는데 `has_dirty_nodes`/
  `mark_clean`/`needs_render` 의 프로덕션 호출부가 0건이다. observer 패턴 배선이 죽어 있고,
  `#[serde]` skip 이 없어 모든 노드가 JSON 에 `dirty:true` 를 싣고 나간다.
- `Section.raw_stream` 과 레코드 계층 `raw_data` 는 방향이 반대인(`None`=무효) 같은 부류지만
  `tech/serialization_passthrough_contract.md` 가 별도 계약으로 다룬다.

## 검증

- 회귀 테스트 `issue_4325_style_update_second_section_table_not_left_stale` 신설. 실측 시나리오
  그대로이며, 수정 전 코드에서 `left: 1207.52` vs `right: 114.19` 로 실패하는 것을 확인했다.
- `cargo test --profile release-test --tests` 전체 통과.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` 통과.
- 문서: `check_markdown_links.py`, `check_document_metadata.py`, `git diff --check` 통과.

Closes #4325
Closes #4335
