### PR TITLE
feat(mcp): #4357 W1 rhwp workspace v1 — 코퍼스 인벤토리·안정 ID 트리·변이 SHA-256 저널 (머지=채택)

### DIFF
--- a/mydocs/pr/pr_4361_review.md
+++ b/mydocs/pr/pr_4361_review.md
@@ -1,0 +1,98 @@
+---
+kind: pr_review
+status: local-validation-passed
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-10
+---
+
+# PR #4361 검토 — MCP workspace 프로필·스캔 경계
+
+## 라우팅과 접수
+
+기본 경로는 `maintainer_general.md`, 보조 경로는 `intake_and_review.md`와
+`local_validation.md`다. contributor code 위에 메인터너 source/test 보정을 추가했으므로
+[implementation 기록](pr_4361_review_impl.md)을 함께 유지한다.
+
+| 항목 | 값 |
+| --- | --- |
+| 원 PR / 작성자 | [#4361](https://github.com/edwardkim/rhwp/pull/4361) / `kevin9327` |
+| 관련 이슈 | [#4357](https://github.com/edwardkim/rhwp/issues/4357), #4351, #4352 |
+| 원 base / head | `devel` / `c98a3f1101ba78d8cc4d87f3c6f906ab8cf632c1` |
+| 원 변경 규모 | 5 files, +595/-11, contributor commits 2개 |
+| 검토 기준 devel | `e48fe86947fbf9a44b1b98c7037150751af541ab` — 원 head의 조상임을 확인 |
+| 작성 시점 원격 참고 상태 | `MERGEABLE` / `CLEAN`, 원 head GitHub checks 성공. merge 전 재확인 필요 |
+| 가시성 branch | `review/kevin9327-20260810-pr4361` |
+| 메인터너 code head | `19fad2a44142b1c3f9c9dde300c6151d245080e8` |
+| GitHub 상태 변경 | reviewer assign, comment, push, review, merge 모두 미수행 |
+
+이번 작업지시는 로컬 메인터너 보정과 기록까지이며 GitHub mutation 승인을 포함하지 않는다. 따라서
+접수 가이드의 reviewer assign도 실행하지 않았고, 이 문서의 원격 상태는 2026-08-10 조회 시점 참고값이다.
+
+## contributor 변경 범위
+
+원 PR은 `rhwp mcp-serve --workspace <dir>`의 결정론 인벤토리, workspace id 열기, 안정 ID 문서 트리,
+변이 SHA-256 저널을 추가한다. 세션 도구 4종을 agent profile의 전체/조회 도구 목록과 MCP annotations
+계약에 연결하고, workspace 계약 테스트 및 stage 기록을 더한다.
+
+renderer, layout, WASM, sample, golden 및 fixture 변경은 없다. 문서를 열어 구조를 조회하지만 렌더 출력이나
+조판 규칙을 바꾸지 않으므로 시각 검증 대상이 아니며 별도 PDF/SVG 증적을 만들지 않았다.
+
+## 확인한 blocker
+
+### 프로필 직접 호출 우회
+
+`hwp_ws_list`, `hwp_ws_open`, `hwp_doc_tree`, `hwp_ws_journal`은 `tools/list`와 실행 match에는 추가됐지만
+`is_session_tool()` 판별에서 빠졌다. 프로필이 이 도구들을 숨겨도 호출자가 이름을 직접 보내면 공통
+`session_allows` gate를 건너뛸 수 있어, 프로필이 권한 경계가 아니라 추천 목록으로 약화됐다.
+
+### workspace 링크 추적
+
+스캐너가 `path.is_dir()`을 사용해 링크를 따라갔다. 디렉터리 링크는 같은 경로를 중복 방문하거나 cycle을
+만들 수 있고, 파일 링크는 선택한 root 밖의 HWP/HWPX/HML을 인벤토리에 넣을 수 있었다. 파일 수 상한은
+지원 문서를 발견할 때만 증가하므로 문서가 없는 cycle의 종료를 보장하지 못했다.
+
+두 항목 모두 profile/workspace 경계를 깨므로 원 head 그대로는 merge blocker로 판정했다.
+
+## 메인터너 보정
+
+commit `19fad2a44142b1c3f9c9dde300c6151d245080e8`
+(`fix(mcp): enforce profile and workspace boundaries`)을 원 contributor head의 직계 자식으로 추가했다.
+
+| 파일 | 보정 |
+| --- | --- |
+| `src/mcp_serve.rs` | 세션 도구 판별을 `agent_profiles::ALL_SESSION_TOOLS` 단일 출처에 연결했다. 스캔은 file type을 링크 비추적 방식으로 읽고 링크·비정규 파일을 제외하며, canonical root 안의 방문하지 않은 디렉터리만 순회한다. |
+| `tests/agent_profile_router_contract.rs` | `데이터분석` 프로필에서 기존 `hwp_open`과 신규 workspace/tree/journal 4종의 직접 호출이 모두 profile gate 오류로 거절되는지 검증한다. |
+| `tests/mcp_workspace_contract.rs` | Unix에서 root 밖 파일 링크와 디렉터리 링크를 만들고 실물 내부 문서 한 건만 인벤토리에 남는지 검증한다. |
+
+contributor commits는 수정·squash·rebase하지 않았으며 위 메인터너 commit 한 개만 추가했다.
+
+## 완료한 검증
+
+| 게이트 | 결과 |
+| --- | --- |
+| `cargo test --profile release-test --target-dir %TEMP%/rhwp-pr4361-target --test agent_profile_router_contract --test mcp_workspace_contract` | Windows cold build 뒤 11/11 통과: profile 8, workspace 3 |
+| 신규 숨김 도구 직접 호출 계약 | 5종 모두 공통 profile gate에서 거절됨을 확인 |
+| 신규 Unix file/directory symlink 계약 | 현재 Windows host에서는 `cfg(unix)`로 미실행; Linux 후보 CI에서 실행 필요 |
+| `rustfmt --check --edition 2021 src/mcp_serve.rs tests/agent_profile_router_contract.rs tests/mcp_workspace_contract.rs` | 통과 |
+| `git diff --check origin/pr/4361..19fad2a4` | 통과 |
+
+Windows의 긴 checkout 경로 때문에 `cargo fmt --all`은 OS error 206으로 실행되지 않아, 변경 Rust 파일을
+동일 rustfmt와 edition으로 직접 검사했다. focused Cargo 실행의 bin/lib PDB 이름 충돌 경고는 기존 target
+명명에서 발생했으며 테스트 결과에는 영향을 주지 않았다.
+
+## 잔여 위험
+
+- Unix symlink 회귀는 현재 Windows host에서 실행되지 않았다. 원격 후보를 만들면 Linux GitHub Actions의
+  실제 통과가 필수다.
+- Windows junction은 권한 독립적인 fixture를 만들기 어려워 별도 자동 테스트가 없다. 구현은 canonical
+  root containment와 방문 집합으로 junction이 directory로 분류되더라도 root 이탈·재방문을 차단한다.
+- 스캔 뒤 실제 open 전까지 workspace 내용을 적대적으로 교체하는 동시 mutation은 v1 단일 클라이언트
+  전제 밖이다. 이번 보정은 스캔 시점의 링크·cycle·root 경계를 고정한다.
+- source/test를 추가한 local head이므로 원 contributor head의 기존 녹색 CI를 메인터너 보정의 근거로
+  재사용하지 않는다. push 승인이 나면 새 head 전체 required checks가 필요하다.
+
+## 조건부 권고
+
+**로컬 blocker는 메인터너 보정으로 해소되어 조건부 통합 권고다.** 다만 현재 branch는 로컬 전용이며
+push 또는 merge 승인이 없다. 작업지시자가 반영 경로를 승인한 뒤 Linux symlink 계약을 포함한 새 원격
+head required checks가 모두 통과하고, 별도의 명시적 merge 승인이 있을 때만 통합할 수 있다.

--- a/mydocs/pr/pr_4361_review.md
+++ b/mydocs/pr/pr_4361_review.md
@@ -22,7 +22,7 @@ last_verified: 2026-08-10
 | 검토 기준 devel | `e48fe86947fbf9a44b1b98c7037150751af541ab` — 원 head의 조상임을 확인 |
 | 작성 시점 원격 참고 상태 | `MERGEABLE` / `CLEAN`, 원 head GitHub checks 성공. merge 전 재확인 필요 |
 | 가시성 branch | `review/kevin9327-20260810-pr4361` |
-| 메인터너 code head | `19fad2a44142b1c3f9c9dde300c6151d245080e8` |
+| 메인터너 code head | `058acbe79aa5b45e32507a53a99aaac55d9d6fc3` |
 | GitHub 상태 변경 | reviewer assign, comment, push, review, merge 모두 미수행 |
 
 이번 작업지시는 로컬 메인터너 보정과 기록까지이며 GitHub mutation 승인을 포함하지 않는다. 따라서
@@ -53,6 +53,11 @@ renderer, layout, WASM, sample, golden 및 fixture 변경은 없다. 문서를 �
 
 두 항목 모두 profile/workspace 경계를 깨므로 원 head 그대로는 merge blocker로 판정했다.
 
+후속 독립 검토에서는 두 가지 검증·결정성 결함을 더 확인했다. 신규 CLI contract test가
+`env!("CARGO_BIN_EXE_rhwp")`만 사용해 nextest archive의 런타임 재매핑 경로를 무시했고, workspace
+스캐너는 파일시스템의 비결정적 `read_dir` 순서에서 먼저 10,000개를 자른 뒤 정렬했다. 따라서
+10,000개 초과 workspace는 실행·파일시스템마다 서로 다른 subset과 `w1..` id를 낼 수 있었다.
+
 ## 메인터너 보정
 
 commit `19fad2a44142b1c3f9c9dde300c6151d245080e8`
@@ -64,17 +69,30 @@ commit `19fad2a44142b1c3f9c9dde300c6151d245080e8`
 | `tests/agent_profile_router_contract.rs` | `데이터분석` 프로필에서 기존 `hwp_open`과 신규 workspace/tree/journal 4종의 직접 호출이 모두 profile gate 오류로 거절되는지 검증한다. |
 | `tests/mcp_workspace_contract.rs` | Unix에서 root 밖 파일 링크와 디렉터리 링크를 만들고 실물 내부 문서 한 건만 인벤토리에 남는지 검증한다. |
 
-contributor commits는 수정·squash·rebase하지 않았으며 위 메인터너 commit 한 개만 추가했다.
+contributor commits는 수정·squash·rebase하지 않았으며 위 1차 메인터너 commit을 별도로 추가했다.
+
+후속 commit `058acbe79aa5b45e32507a53a99aaac55d9d6fc3`
+(`fix(mcp): make capped workspace inventory deterministic`)은 기존 문서 commit 뒤에 선형으로 추가했다.
+
+| 파일 | 후속 보정 |
+| --- | --- |
+| `src/mcp_serve.rs` | 경로순 최대 힙으로 가장 작은 10,000개 후보만 보존한다. 전체 순회 순서와 무관한 subset을 만들면서 후보 메모리는 상한 안에 둔다. |
+| `tests/agent_profile_router_contract.rs` | 모든 신규/수정 CLI 기동을 nextest 런타임 `CARGO_BIN_EXE_rhwp` 우선 helper로 통일했다. |
+| `tests/mcp_workspace_contract.rs` | 같은 runtime helper를 쓰고, root에서 상한을 채운 뒤 더 작은 중첩 경로가 나오는 10,001파일 fixture로 결정적 subset을 고정했다. |
+
+contributor와 기존 메인터너 commit은 amend·rebase하지 않았다.
 
 ## 완료한 검증
 
 | 게이트 | 결과 |
 | --- | --- |
-| `cargo test --profile release-test --target-dir %TEMP%/rhwp-pr4361-target --test agent_profile_router_contract --test mcp_workspace_contract` | Windows cold build 뒤 11/11 통과: profile 8, workspace 3 |
+| `$env:CARGO_INCREMENTAL='0'; cargo test --profile release-test --target-dir "$env:TEMP\rhwp-pr4361-target" --test agent_profile_router_contract --test mcp_workspace_contract` | 12/12 통과: profile 8, workspace 4 |
+| 10,001파일 상한 회귀 | `truncated:true`, count 10,000, `a/00000.hwp`가 `w1`, 경로순 마지막 `z09999.hwp` 제외 확인 |
+| nextest binary 경로 | 두 수정 test 파일의 모든 직접 `Command`가 런타임 env 우선 helper 사용 |
 | 신규 숨김 도구 직접 호출 계약 | 5종 모두 공통 profile gate에서 거절됨을 확인 |
 | 신규 Unix file/directory symlink 계약 | 현재 Windows host에서는 `cfg(unix)`로 미실행; Linux 후보 CI에서 실행 필요 |
 | `rustfmt --check --edition 2021 src/mcp_serve.rs tests/agent_profile_router_contract.rs tests/mcp_workspace_contract.rs` | 통과 |
-| `git diff --check origin/pr/4361..19fad2a4` | 통과 |
+| `git diff --check origin/pr/4361..058acbe7` | 통과 |
 
 Windows의 긴 checkout 경로 때문에 `cargo fmt --all`은 OS error 206으로 실행되지 않아, 변경 Rust 파일을
 동일 rustfmt와 edition으로 직접 검사했다. focused Cargo 실행의 bin/lib PDB 이름 충돌 경고는 기존 target
@@ -86,6 +104,8 @@ Windows의 긴 checkout 경로 때문에 `cargo fmt --all`은 OS error 206으로
   실제 통과가 필수다.
 - Windows junction은 권한 독립적인 fixture를 만들기 어려워 별도 자동 테스트가 없다. 구현은 canonical
   root containment와 방문 집합으로 junction이 directory로 분류되더라도 root 이탈·재방문을 차단한다.
+- 결정적 subset을 위해 상한을 넘은 뒤에도 디렉터리 순회는 끝까지 계속한다. 후보 저장은 최대 10,000개로
+  제한되지만 매우 큰 tree의 전체 순회 시간·metadata I/O는 별도 총량/시간 예산 없이 입력 크기에 비례한다.
 - 스캔 뒤 실제 open 전까지 workspace 내용을 적대적으로 교체하는 동시 mutation은 v1 단일 클라이언트
   전제 밖이다. 이번 보정은 스캔 시점의 링크·cycle·root 경계를 고정한다.
 - source/test를 추가한 local head이므로 원 contributor head의 기존 녹색 CI를 메인터너 보정의 근거로
@@ -93,6 +113,6 @@ Windows의 긴 checkout 경로 때문에 `cargo fmt --all`은 OS error 206으로
 
 ## 조건부 권고
 
-**로컬 blocker는 메인터너 보정으로 해소되어 조건부 통합 권고다.** 다만 현재 branch는 로컬 전용이며
+**확인한 로컬 blocker는 메인터너 보정으로 해소되어 조건부 통합 권고다.** 다만 현재 branch는 로컬 전용이며
 push 또는 merge 승인이 없다. 작업지시자가 반영 경로를 승인한 뒤 Linux symlink 계약을 포함한 새 원격
 head required checks가 모두 통과하고, 별도의 명시적 merge 승인이 있을 때만 통합할 수 있다.

--- a/mydocs/pr/pr_4361_review_impl.md
+++ b/mydocs/pr/pr_4361_review_impl.md
@@ -1,0 +1,50 @@
+---
+kind: review_plan
+status: local-validation-passed
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-10
+---
+
+# PR #4361 메인터너 보정 실행 기록
+
+## commit 경계
+
+| 역할 | SHA | 상태 |
+| --- | --- | --- |
+| contributor workspace v1 | `7d3c6db171102d901875339176a7d125b8a7a285` | 보존 |
+| contributor annotations CI 수리 / 원 head | `c98a3f1101ba78d8cc4d87f3c6f906ab8cf632c1` | 보존 |
+| 메인터너 profile·workspace 경계 보정 | `19fad2a44142b1c3f9c9dde300c6151d245080e8` | 완료 |
+| review 및 implementation 기록 | 본 문서와 `pr_4361_review.md`의 후속 문서 commit | 완료 후 SHA를 Git 이력에서 확인 |
+
+가시성 branch는 `review/kevin9327-20260810-pr4361` 하나만 사용한다. 원 contributor commits 위에
+메인터너 commit과 review 문서 commit을 순서대로 쌓으며 원 commit을 다시 작성하지 않는다.
+
+## 실행 단계
+
+1. **접수·기준 고정 — 완료.** `origin/pr/4361` head와 `origin/devel` 조상 관계를 확인하고 원 head에서
+   가시성 branch/worktree를 만들었다. GitHub reviewer assign이나 comment는 수행하지 않았다.
+2. **profile gate 보정 — 완료.** 중복된 session-tool match를 제거하고 `ALL_SESSION_TOOLS`를 직접 사용해
+   신규 workspace 4종을 포함한 모든 세션 도구가 같은 `session_allows` gate를 거치게 했다.
+3. **workspace scan 보정 — 완료.** 링크와 비정규 파일을 제외하고 canonical root containment 및 방문
+   집합으로 root 이탈·중복·cycle을 차단했다. profile direct-call과 Unix link 회귀를 추가했다.
+4. **로컬 검증 — 완료.** focused release-test 11건, 변경 파일 rustfmt, diff 검사를 실행했다. Windows에서
+   Unix 전용 회귀가 실행되지 않은 사실을 [검토 기록](pr_4361_review.md)에 제한 조건으로 남겼다.
+5. **review 기록 — 완료.** source/test commit과 섞지 않고 이 두 문서를 별도 commit으로 만든다.
+6. **원격 반영 — 승인 대기.** 작업지시자가 push 대상과 방식(원 PR branch update 또는 별도 maintainer
+   integration branch)을 정한 뒤에만 수행한다. 현재 작업에는 push 권한 행사가 포함되지 않는다.
+7. **CI와 merge — 미착수.** 새 원격 head의 required checks와 Linux symlink 계약 성공을 확인한 뒤에도
+   별도의 명시적 merge 승인이 있어야 한다. 승인 전에는 review 제출, merge, close 및 contributor comment를
+   수행하지 않는다.
+
+## rollback
+
+- review 기록만 철회할 때는 이 후속 문서 commit만 revert한다. source/test 보정과 섞지 않는다.
+- profile·workspace 경계 보정까지 철회할 때는 문서 commit을 먼저, `19fad2a4`를 다음 순서로 revert한다.
+  그러면 branch는 원 contributor head `c98a3f11...`로 돌아간다.
+- contributor의 두 commit은 reset, amend, rebase 또는 squash하지 않는다.
+- 원격 반영 전이므로 현재 rollback은 로컬 branch에서만 수행하며 GitHub 상태에는 영향이 없다.
+
+## 권한 경계
+
+이 기록은 merge 허가가 아니다. push, GitHub review/comment, PR 갱신, merge, close는 각각 작업지시자의
+명시적 승인과 최신 상태 재확인이 필요한 별도 단계다.

--- a/mydocs/pr/pr_4361_review_impl.md
+++ b/mydocs/pr/pr_4361_review_impl.md
@@ -14,10 +14,13 @@ last_verified: 2026-08-10
 | contributor workspace v1 | `7d3c6db171102d901875339176a7d125b8a7a285` | 보존 |
 | contributor annotations CI 수리 / 원 head | `c98a3f1101ba78d8cc4d87f3c6f906ab8cf632c1` | 보존 |
 | 메인터너 profile·workspace 경계 보정 | `19fad2a44142b1c3f9c9dde300c6151d245080e8` | 완료 |
-| review 및 implementation 기록 | 본 문서와 `pr_4361_review.md`의 후속 문서 commit | 완료 후 SHA를 Git 이력에서 확인 |
+| 1차 review 및 implementation 기록 | `999627e741a841e61c82b253283880e66fafaff3` | 완료 |
+| 메인터너 결정적 상한·nextest 보정 | `058acbe79aa5b45e32507a53a99aaac55d9d6fc3` | 완료 |
+| 후속 review 및 implementation 기록 | 본 문서와 `pr_4361_review.md`의 trailing 문서 commit | 완료 후 SHA를 Git 이력에서 확인 |
 
 가시성 branch는 `review/kevin9327-20260810-pr4361` 하나만 사용한다. 원 contributor commits 위에
-메인터너 commit과 review 문서 commit을 순서대로 쌓으며 원 commit을 다시 작성하지 않는다.
+메인터너 commit과 review 문서 commit을 선형으로 쌓으며 원 contributor·기존 메인터너 commit을 다시
+작성하지 않는다.
 
 ## 실행 단계
 
@@ -29,18 +32,22 @@ last_verified: 2026-08-10
    집합으로 root 이탈·중복·cycle을 차단했다. profile direct-call과 Unix link 회귀를 추가했다.
 4. **로컬 검증 — 완료.** focused release-test 11건, 변경 파일 rustfmt, diff 검사를 실행했다. Windows에서
    Unix 전용 회귀가 실행되지 않은 사실을 [검토 기록](pr_4361_review.md)에 제한 조건으로 남겼다.
-5. **review 기록 — 완료.** source/test commit과 섞지 않고 이 두 문서를 별도 commit으로 만든다.
-6. **원격 반영 — 승인 대기.** 작업지시자가 push 대상과 방식(원 PR branch update 또는 별도 maintainer
+5. **후속 결정성·test runner 보정 — 완료.** 모든 신규/수정 CLI test를 nextest runtime binary helper로
+   통일하고, filesystem 발견 순서와 무관하게 경로순 최소 10,000개만 보존하는 bounded max-heap을 넣었다.
+   root 상한 뒤 더 작은 중첩 경로가 나오는 10,001파일 회귀를 추가했다.
+6. **후속 로컬 검증·기록 — 완료.** focused release-test 12건(profile 8, workspace 4), rustfmt, diff check를
+   통과했다. source/test와 섞지 않고 이 두 문서를 trailing commit으로 만든다.
+7. **원격 반영 — 승인 대기.** 작업지시자가 push 대상과 방식(원 PR branch update 또는 별도 maintainer
    integration branch)을 정한 뒤에만 수행한다. 현재 작업에는 push 권한 행사가 포함되지 않는다.
-7. **CI와 merge — 미착수.** 새 원격 head의 required checks와 Linux symlink 계약 성공을 확인한 뒤에도
+8. **CI와 merge — 미착수.** 새 원격 head의 required checks와 Linux symlink 계약 성공을 확인한 뒤에도
    별도의 명시적 merge 승인이 있어야 한다. 승인 전에는 review 제출, merge, close 및 contributor comment를
    수행하지 않는다.
 
 ## rollback
 
-- review 기록만 철회할 때는 이 후속 문서 commit만 revert한다. source/test 보정과 섞지 않는다.
-- profile·workspace 경계 보정까지 철회할 때는 문서 commit을 먼저, `19fad2a4`를 다음 순서로 revert한다.
-  그러면 branch는 원 contributor head `c98a3f11...`로 돌아간다.
+- 후속 기록만 철회할 때는 trailing 문서 commit만 revert한다. source/test 보정과 섞지 않는다.
+- 전체 메인터너 보정을 철회할 때는 trailing 문서, `058acbe7`, `999627e7`, `19fad2a4`를 이력 역순으로
+  revert한다. 그러면 branch는 원 contributor head `c98a3f11...`의 내용으로 돌아간다.
 - contributor의 두 commit은 reset, amend, rebase 또는 squash하지 않는다.
 - 원격 반영 전이므로 현재 rollback은 로컬 branch에서만 수행하며 GitHub 상태에는 영향이 없다.
 

--- a/mydocs/working/task_m100_4357_stage1.md
+++ b/mydocs/working/task_m100_4357_stage1.md
@@ -1,0 +1,26 @@
+# Task M100 #4357 Stage 1 — W1 rhwp workspace v1 구현
+
+- 이슈: [#4357](https://github.com/edwardkim/rhwp/issues/4357) · 브랜치 `task_m100_4357`
+- 2026-08-09 KST · 구현·검증 완료 · **승인 매체 = 본 PR(작업지시자 결정: 머지=채택/클로즈=기각)**
+
+## 구현 (설계 #4351/PR #4352 의 실물)
+
+- `mcp-serve --workspace <dir>`: 기동 1회 스캔(.hwp/.hwpx/.hml, 숨김 제외,
+  상한 10,000+truncated 표지), **경로 정렬 결정론 id(w1..)** 인벤토리.
+- 신규 세션 도구 4종(전부 조회 축): `hwp_ws_list`(인벤토리) ·
+  `hwp_ws_open`(id→기존 session_open 재사용) · `hwp_doc_tree`(안정 노드 ID 트리
+  — 페이지 p0.. / 표 t0..(hwp_doc_tables 순서와 동일 — 셀 편집 좌표로 연결)) ·
+  `hwp_ws_journal`(변이 저널 조회).
+- **자기검증 루프**: 변이 4종(replace_text/set_cell/fill_fields/save)을
+  `journal_wrap` 으로 감싸 매 호출의 본문 SHA-256 전/후·changed·isError 자동 기록.
+- 등재: served_tools 정의 4종 + `ALL_SESSION_TOOLS`/`SESSION_READ_TOOLS`.
+- 게이트 처리: R76 캐시 재설계와 **비중복**(열린 핸들 위 조회·저널만 — 재파싱
+  회피는 기존 세션 담당), R28 동시성은 v1 단일 클라이언트 전제 명시.
+
+## 검증
+
+- `tests/mcp_workspace_contract.rs` 3본 **첫 실행 3/3**: 왕복(list w1→open→tree
+  p0/tables→save→journal sha256 64자리·changed:false)·무워크스페이스 명시 실패
+  (--workspace 안내)·tools/list 등재.
+- 인접: mcp_server_contract 24/24 · agent_profile_router_contract 8/8 ·
+  `cargo clippy --bin rhwp` 경고 0 · rustfmt 적용 후 재검 3/3.

--- a/src/agent_profiles.rs
+++ b/src/agent_profiles.rs
@@ -23,6 +23,11 @@ pub const ALL_SESSION_TOOLS: &[&str] = &[
     "hwp_doc_fill_fields",
     "hwp_doc_save",
     "hwp_close",
+    // [#4357 W1] 워크스페이스 축 — 코퍼스 인벤토리·id 열기·안정 ID 트리·변이 저널.
+    "hwp_ws_list",
+    "hwp_ws_open",
+    "hwp_doc_tree",
+    "hwp_ws_journal",
 ];
 
 /// 세션 도구 중 **문서를 바꾸지 않는** 것들 — 조회 전용 직무가 여는 집합.
@@ -39,6 +44,12 @@ pub const SESSION_READ_TOOLS: &[&str] = &[
     "hwp_doc_search",
     "hwp_doc_render_page",
     "hwp_close",
+    // [#4357 W1] 워크스페이스 4종은 전부 조회 축 — 저널·인벤토리·트리는 읽기,
+    // ws_open 은 hwp_open 과 동일한 핸들 발급이다.
+    "hwp_ws_list",
+    "hwp_ws_open",
+    "hwp_doc_tree",
+    "hwp_ws_journal",
 ];
 
 /// 역할 프로필 하나. `tools` 는 무상태 MCP 도구 이름, `session_tools` 는 세션 도구 이름.

--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -101,8 +101,12 @@ fn scan_workspace(root: &std::path::Path) -> Result<Workspace, String> {
             root.display()
         ));
     }
+    let canonical_root = root
+        .canonicalize()
+        .map_err(|e| format!("{} 경로 확인 실패: {e}", root.display()))?;
     let mut found: Vec<(std::path::PathBuf, String, u64)> = Vec::new();
     let mut stack = vec![root.to_path_buf()];
+    let mut visited_dirs = std::collections::HashSet::from([canonical_root.clone()]);
     let mut truncated = false;
     while let Some(dir) = stack.pop() {
         let entries = match std::fs::read_dir(&dir) {
@@ -116,8 +120,26 @@ fn scan_workspace(root: &std::path::Path) -> Result<Workspace, String> {
             if name.starts_with('.') {
                 continue;
             }
-            if path.is_dir() {
-                stack.push(path);
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            // 심볼릭 링크·junction을 따라가면 root 밖 문서가 인벤토리에 들어오거나
+            // 디렉터리 순환이 파일 상한과 무관하게 계속될 수 있다. 워크스페이스는
+            // 선택한 디렉터리의 실물 항목만 다룬다.
+            if file_type.is_symlink() {
+                continue;
+            }
+            if file_type.is_dir() {
+                let resolved = match path.canonicalize() {
+                    Ok(p) => p,
+                    Err(e) => return Err(format!("{} 경로 확인 실패: {e}", path.display())),
+                };
+                if resolved.starts_with(&canonical_root) && visited_dirs.insert(resolved) {
+                    stack.push(path);
+                }
+                continue;
+            }
+            if !file_type.is_file() {
                 continue;
             }
             let Some(ext) = path
@@ -1200,21 +1222,7 @@ fn handle_tool_call(
 }
 
 fn is_session_tool(name: &str) -> bool {
-    matches!(
-        name,
-        "hwp_open"
-            | "hwp_doc_text"
-            | "hwp_doc_info"
-            | "hwp_doc_fields"
-            | "hwp_doc_tables"
-            | "hwp_doc_render_page"
-            | "hwp_doc_search"
-            | "hwp_doc_replace_text"
-            | "hwp_doc_set_cell"
-            | "hwp_doc_fill_fields"
-            | "hwp_doc_save"
-            | "hwp_close"
-    )
+    crate::agent_profiles::ALL_SESSION_TOOLS.contains(&name)
 }
 
 /// [#3699] 교정 호출 동봉 오류 — error 필드가 기존 원문을 담아 하위호환.

--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -104,7 +104,11 @@ fn scan_workspace(root: &std::path::Path) -> Result<Workspace, String> {
     let canonical_root = root
         .canonicalize()
         .map_err(|e| format!("{} 경로 확인 실패: {e}", root.display()))?;
-    let mut found: Vec<(std::path::PathBuf, String, u64)> = Vec::new();
+    // 순회 순서는 파일시스템마다 다르므로 발견 순서에서 상한을 자르면 같은
+    // workspace가 서로 다른 w1.. id를 낸다. 최대 힙에는 경로순으로 가장 작은
+    // WORKSPACE_SCAN_CAP개만 남겨 메모리 상한과 결정적 subset을 함께 지킨다.
+    let mut found: std::collections::BinaryHeap<(std::path::PathBuf, String, u64)> =
+        std::collections::BinaryHeap::new();
     let mut stack = vec![root.to_path_buf()];
     let mut visited_dirs = std::collections::HashSet::from([canonical_root.clone()]);
     let mut truncated = false;
@@ -152,17 +156,24 @@ fn scan_workspace(root: &std::path::Path) -> Result<Workspace, String> {
             if ext != "hwp" && ext != "hwpx" && ext != "hml" {
                 continue;
             }
-            if found.len() >= WORKSPACE_SCAN_CAP {
-                truncated = true;
-                break;
-            }
             let size_bytes = entry.metadata().map(|m| m.len()).unwrap_or(0);
-            found.push((path, ext, size_bytes));
-        }
-        if truncated {
-            break;
+            let candidate = (path, ext, size_bytes);
+            if found.len() < WORKSPACE_SCAN_CAP {
+                found.push(candidate);
+            } else {
+                truncated = true;
+                let precedes_largest = found
+                    .peek()
+                    .map(|largest| candidate.0.cmp(&largest.0).is_lt())
+                    .unwrap_or(false);
+                if precedes_largest {
+                    found.pop();
+                    found.push(candidate);
+                }
+            }
         }
     }
+    let mut found = found.into_vec();
     found.sort_by(|a, b| a.0.cmp(&b.0));
     let entries = found
         .into_iter()

--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -52,6 +52,10 @@ struct SessionDoc {
 struct Sessions {
     docs: HashMap<String, SessionDoc>,
     next_id: u64,
+    /// [#4357 W1] `--workspace <dir>` 로 기동했을 때의 코퍼스 인벤토리.
+    workspace: Option<Workspace>,
+    /// [#4357 W1] 변이 저널 — 변이 도구 호출마다 본문 SHA-256 전/후를 남긴다.
+    journal: Vec<JournalEntry>,
 }
 
 impl Sessions {
@@ -59,8 +63,291 @@ impl Sessions {
         Sessions {
             docs: HashMap::new(),
             next_id: 1,
+            workspace: None,
+            journal: Vec::new(),
         }
     }
+}
+
+// ── [#4357 W1] 워크스페이스 — 에이전트 전용 문서 런타임 v1 ──────────────────
+//
+// 원리(설계 문서 trend_agent_runtime_2026h2.md): 에이전트 소비자는 픽셀이 아니라
+// 구조와 결정론을 산다. v1 은 단일 클라이언트 전제(동시성 모델은 트랙 C R28
+// 판단 뒤)이고, 캐시 재설계(R76)와 겹치지 않게 **열린 핸들 위의 조회·저널**만
+// 더한다 — 재파싱 회피는 기존 세션이 이미 담당한다.
+
+/// 인벤토리 한 항목. id 는 경로 정렬 순서의 `w1..wN` — 같은 코퍼스면 같은 id 가
+/// 나오는 결정론이 계약이다(호출 순서·파일시스템 순회 순서에 의존하지 않는다).
+struct WorkspaceEntry {
+    id: String,
+    path: std::path::PathBuf,
+    ext: String,
+    size_bytes: u64,
+}
+
+struct Workspace {
+    root: std::path::PathBuf,
+    entries: Vec<WorkspaceEntry>,
+    truncated: bool,
+}
+
+/// 스캔 상한 — S7 정신: 상한 도달은 침묵이 아니라 봉투(truncated)로 드러난다.
+const WORKSPACE_SCAN_CAP: usize = 10_000;
+
+fn scan_workspace(root: &std::path::Path) -> Result<Workspace, String> {
+    if !root.is_dir() {
+        return Err(format!(
+            "워크스페이스 디렉터리가 아닙니다: {}",
+            root.display()
+        ));
+    }
+    let mut found: Vec<(std::path::PathBuf, String, u64)> = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    let mut truncated = false;
+    while let Some(dir) = stack.pop() {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(e) => return Err(format!("{} 읽기 실패: {e}", dir.display())),
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name().to_string_lossy().into_owned();
+            // 숨김 항목은 결정론·안전(.git 등) 양쪽 이유로 건너뛴다.
+            if name.starts_with('.') {
+                continue;
+            }
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            let Some(ext) = path
+                .extension()
+                .and_then(|e| e.to_str())
+                .map(|e| e.to_ascii_lowercase())
+            else {
+                continue;
+            };
+            if ext != "hwp" && ext != "hwpx" && ext != "hml" {
+                continue;
+            }
+            if found.len() >= WORKSPACE_SCAN_CAP {
+                truncated = true;
+                break;
+            }
+            let size_bytes = entry.metadata().map(|m| m.len()).unwrap_or(0);
+            found.push((path, ext, size_bytes));
+        }
+        if truncated {
+            break;
+        }
+    }
+    found.sort_by(|a, b| a.0.cmp(&b.0));
+    let entries = found
+        .into_iter()
+        .enumerate()
+        .map(|(i, (path, ext, size_bytes))| WorkspaceEntry {
+            id: format!("w{}", i + 1),
+            path,
+            ext,
+            size_bytes,
+        })
+        .collect();
+    Ok(Workspace {
+        root: root.to_path_buf(),
+        entries,
+        truncated,
+    })
+}
+
+/// 변이 저널 한 줄 — 자기검증 루프의 최소 실물. 판정은 본문 텍스트 SHA-256 이고,
+/// 렌더 픽셀 판정은 범위 밖(render-diff 위임 — 설계 문서 §2 ⑤).
+struct JournalEntry {
+    seq: u64,
+    tool: String,
+    doc_id: String,
+    digest_before: String,
+    digest_after: String,
+    changed: bool,
+    is_error: bool,
+}
+
+/// 열린 핸들의 본문 전체 SHA-256. 추출 실패 페이지는 오류 표지를 해시에 섞어
+/// "못 읽음"과 "빈 페이지"를 가른다.
+fn doc_text_digest(sd: &mut SessionDoc) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    let pages = sd.doc.page_count();
+    for p in 0..pages {
+        match sd.doc.extract_page_text_native(p) {
+            Ok(text) => hasher.update(text.as_bytes()),
+            Err(e) => hasher.update(format!("<extract-error p{p} {e:?}>").as_bytes()),
+        }
+        hasher.update([0u8]);
+    }
+    let out = hasher.finalize();
+    let mut hex = String::with_capacity(out.len() * 2);
+    for byte in out {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
+}
+
+/// 변이 도구를 감싸 전/후 digest 를 저널에 남긴다. 핸들이 없던 호출(오타 등)은
+/// 저널 대상이 아니다 — 실패 자체는 도구 봉투(isError)가 이미 보고한다.
+fn journal_wrap(
+    tool: &str,
+    args: &serde_json::Value,
+    sessions: &mut Sessions,
+    f: fn(&serde_json::Value, &mut Sessions) -> serde_json::Value,
+) -> serde_json::Value {
+    let doc_id = args
+        .get("docId")
+        .and_then(|d| d.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let before = sessions.docs.get_mut(&doc_id).map(doc_text_digest);
+    let result = f(args, sessions);
+    if let Some(digest_before) = before {
+        let digest_after = sessions
+            .docs
+            .get_mut(&doc_id)
+            .map(doc_text_digest)
+            .unwrap_or_else(|| digest_before.clone());
+        let is_error = result
+            .get("isError")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let seq = sessions.journal.len() as u64 + 1;
+        sessions.journal.push(JournalEntry {
+            seq,
+            tool: tool.to_string(),
+            doc_id,
+            changed: digest_before != digest_after,
+            digest_before,
+            digest_after,
+            is_error,
+        });
+    }
+    result
+}
+
+fn workspace_missing_error() -> serde_json::Value {
+    tool_error(
+        "워크스페이스 없이 기동됨 — `rhwp mcp-serve --workspace <디렉터리>` 로 열어야 \
+         hwp_ws_* 도구가 동작합니다"
+            .into(),
+    )
+}
+
+fn session_ws_list(sessions: &mut Sessions) -> serde_json::Value {
+    let Some(ws) = sessions.workspace.as_ref() else {
+        return workspace_missing_error();
+    };
+    let entries: Vec<serde_json::Value> = ws
+        .entries
+        .iter()
+        .map(|e| {
+            serde_json::json!({
+                "id": e.id,
+                "path": e.path.display().to_string(),
+                "format": e.ext,
+                "sizeBytes": e.size_bytes,
+            })
+        })
+        .collect();
+    tool_ok_text(
+        serde_json::json!({
+            "root": ws.root.display().to_string(),
+            "count": entries.len(),
+            "truncated": ws.truncated,
+            "entries": entries,
+        })
+        .to_string(),
+    )
+}
+
+fn session_ws_open(args: &serde_json::Value, sessions: &mut Sessions) -> serde_json::Value {
+    let Some(id) = args.get("id").and_then(|v| v.as_str()) else {
+        return tool_error("id 가 필요합니다 (hwp_ws_list 의 entries[].id)".into());
+    };
+    if sessions.workspace.is_none() {
+        return workspace_missing_error();
+    }
+    let Some(path) = sessions.workspace.as_ref().and_then(|ws| {
+        ws.entries
+            .iter()
+            .find(|e| e.id == id)
+            .map(|e| e.path.display().to_string())
+    }) else {
+        return tool_error_with_next(
+            format!("워크스페이스에 없는 id: {id}"),
+            "hwp_ws_list",
+            serde_json::json!({}),
+            "실존 id 를 hwp_ws_list 로 확인한 뒤 재시도",
+        );
+    };
+    let mut open_args = serde_json::json!({ "path": path });
+    if let Some(pw) = args.get("password") {
+        open_args["password"] = pw.clone();
+    }
+    session_open(&open_args, sessions)
+}
+
+fn session_doc_tree(args: &serde_json::Value, sessions: &mut Sessions) -> serde_json::Value {
+    let (sd, id) = match with_doc(args, sessions) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let page_count = sd.doc.page_count();
+    let tables = rhwp::document_core::queries::table_extract::extract_tables(sd.doc.document());
+    let tables_env = crate::tables_json_value(&id, &tables);
+    let mut table_nodes: Vec<serde_json::Value> = Vec::new();
+    if let Some(arr) = tables_env.get("tables").and_then(|t| t.as_array()) {
+        for (i, t) in arr.iter().enumerate() {
+            let mut node = t.clone();
+            node["nodeId"] = serde_json::json!(format!("t{i}"));
+            table_nodes.push(node);
+        }
+    }
+    let pages: Vec<String> = (0..page_count).map(|p| format!("p{p}")).collect();
+    tool_ok_text(
+        serde_json::json!({
+            "docId": id,
+            "pageCount": page_count,
+            "nodes": { "pages": pages, "tables": table_nodes },
+            "idContract": "안정 ID: 페이지 p0.. / 표 t0.. — 같은 문서·같은 빌드에서 결정론. \
+                           표 순서는 hwp_doc_tables 와 동일하며, 셀 편집은 t{i} 순서의 표에 \
+                           hwp_doc_set_cell(table=i, row, col) 로 잇는다.",
+        })
+        .to_string(),
+    )
+}
+
+fn session_ws_journal(sessions: &mut Sessions) -> serde_json::Value {
+    let entries: Vec<serde_json::Value> = sessions
+        .journal
+        .iter()
+        .map(|e| {
+            serde_json::json!({
+                "seq": e.seq,
+                "tool": e.tool,
+                "docId": e.doc_id,
+                "digestBefore": e.digest_before,
+                "digestAfter": e.digest_after,
+                "changed": e.changed,
+                "isError": e.is_error,
+            })
+        })
+        .collect();
+    tool_ok_text(
+        serde_json::json!({
+            "algo": "sha256(전 페이지 본문 텍스트, 페이지 경계 0x00)",
+            "count": entries.len(),
+            "entries": entries,
+        })
+        .to_string(),
+    )
 }
 
 pub fn run(args: &[String]) -> i32 {
@@ -71,6 +358,8 @@ pub fn run(args: &[String]) -> i32 {
     // 절대 수집하지 않는다(mydocs/tech/agent_architecture/observability_contract.md
     // §3). 도구명별 호출 수·오류 수만 센다.
     let mut stats = false;
+    // [#4357 W1] 워크스페이스 디렉터리 — 기동 시 1회 스캔해 인벤토리를 만든다.
+    let mut workspace_dir: Option<String> = None;
     let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
@@ -91,6 +380,14 @@ pub fn run(args: &[String]) -> i32 {
                 }
             }
             "--stats" => stats = true,
+            "--workspace" => {
+                i += 1;
+                let Some(dir) = args.get(i) else {
+                    eprintln!("오류: --workspace 뒤에 디렉터리가 필요합니다.");
+                    return crate::EXIT_USAGE;
+                };
+                workspace_dir = Some(dir.clone());
+            }
             other => {
                 eprintln!("알 수 없는 옵션: {other}");
                 return crate::EXIT_USAGE;
@@ -117,6 +414,23 @@ pub fn run(args: &[String]) -> i32 {
         Some(p) => crate::agent_profiles::allows_session_tool(p, name),
     };
     let mut sessions = Sessions::new();
+    if let Some(dir) = workspace_dir {
+        match scan_workspace(std::path::Path::new(&dir)) {
+            Ok(ws) => {
+                eprintln!(
+                    "워크스페이스: {} — 문서 {}건{}",
+                    ws.root.display(),
+                    ws.entries.len(),
+                    if ws.truncated { " (상한 절단)" } else { "" }
+                );
+                sessions.workspace = Some(ws);
+            }
+            Err(e) => {
+                eprintln!("오류: {e}");
+                return crate::EXIT_USAGE;
+            }
+        }
+    }
     // 도구명 → (호출 수, 오류 수). 키는 서버가 정의한 유한 집합(도구명) 또는
     // 고정된 미지 버킷뿐이고 값은 정수 계수뿐이다. 호출자가 보낸 임의 문자열을
     // 키로 쓰면 --stats가 고유한 가짜 도구명으로 메모리를 소진할 수 있다.
@@ -640,6 +954,34 @@ fn served_tools(
             "required": ["path"]
         }
     }));
+    // [#4357 W1] 워크스페이스 4종 — 코퍼스 인벤토리·id 열기·안정 ID 트리·변이 저널.
+    session.push(serde_json::json!({
+        "name": "hwp_ws_list",
+        "description": "[#4357] 워크스페이스(--workspace 로 기동) 코퍼스 인벤토리 — 결정론 id(w1..)·경로·형식·크기. 상한 도달은 truncated 로 드러난다.",
+        "inputSchema": { "type": "object", "properties": {}, "required": [] }
+    }));
+    session.push(serde_json::json!({
+        "name": "hwp_ws_open",
+        "description": "[#4357] 워크스페이스 id(w1..)로 문서를 열어 세션 핸들(docId)을 받는다 — 경로 대신 인벤토리 id 로 여는 hwp_open.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "id": { "type": "string", "description": "hwp_ws_list 의 entries[].id" },
+                "password": { "type": "string", "writeOnly": true, "description": "암호 문서 비밀번호. 응답·세션 상태에 보존하지 않는다." }
+            },
+            "required": ["id"]
+        }
+    }));
+    session.push(serde_json::json!({
+        "name": "hwp_doc_tree",
+        "description": "[#4357] 열린 핸들의 안정 노드 ID 구조 트리(페이지 p0..·표 t0.. — 같은 문서·같은 빌드에서 결정론). 픽셀 없이 구조로 문서를 본다.",
+        "inputSchema": { "type": "object", "properties": { "docId": { "type": "string" } }, "required": ["docId"] }
+    }));
+    session.push(serde_json::json!({
+        "name": "hwp_ws_journal",
+        "description": "[#4357] 변이 저널 — 변이 도구(replace_text/set_cell/fill_fields/save) 호출마다 본문 SHA-256 전/후·changed 가 자동 기록된다. 자기검증 루프의 조회 축.",
+        "inputSchema": { "type": "object", "properties": {}, "required": [] }
+    }));
     session.push(serde_json::json!({
         "name": "hwp_doc_text",
         "description": "hwp_open 으로 연 핸들에서 페이지 텍스트를 재파싱 없이 읽는다.",
@@ -804,11 +1146,32 @@ fn handle_tool_call(
         "hwp_doc_tables" => Ok(session_tables(&args, sessions)),
         "hwp_doc_render_page" => Ok(session_render_page(&args, sessions)),
         "hwp_doc_search" => Ok(session_search(&args, sessions)),
-        "hwp_doc_replace_text" => Ok(session_replace_text(&args, sessions)),
-        "hwp_doc_set_cell" => Ok(session_set_cell(&args, sessions)),
-        "hwp_doc_fill_fields" => Ok(session_fill_fields(&args, sessions)),
-        "hwp_doc_save" => Ok(session_save(&args, sessions)),
+        // [#4357 W1] 변이 4종은 저널로 감싼다 — 매 변이의 전/후 본문 digest 가
+        // 자동으로 남아 hwp_ws_journal 로 자기검증한다.
+        "hwp_doc_replace_text" => Ok(journal_wrap(
+            "hwp_doc_replace_text",
+            &args,
+            sessions,
+            session_replace_text,
+        )),
+        "hwp_doc_set_cell" => Ok(journal_wrap(
+            "hwp_doc_set_cell",
+            &args,
+            sessions,
+            session_set_cell,
+        )),
+        "hwp_doc_fill_fields" => Ok(journal_wrap(
+            "hwp_doc_fill_fields",
+            &args,
+            sessions,
+            session_fill_fields,
+        )),
+        "hwp_doc_save" => Ok(journal_wrap("hwp_doc_save", &args, sessions, session_save)),
         "hwp_close" => Ok(session_close(&args, sessions)),
+        "hwp_ws_list" => Ok(session_ws_list(sessions)),
+        "hwp_ws_open" => Ok(session_ws_open(&args, sessions)),
+        "hwp_doc_tree" => Ok(session_doc_tree(&args, sessions)),
+        "hwp_ws_journal" => Ok(session_ws_journal(sessions)),
         _ => {
             let Some(def) = tool_defs.iter().find(|t| t["name"] == name) else {
                 // [#3694] didYouMean — error 필드가 기존 원문을 담아 하위호환.

--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -903,7 +903,8 @@ fn resource_error_response(
 ///   경로일 수 있고** 같은 경로 거부가 없다(session_save 는 그대로 fs::write 한다) —
 ///   무상태 표면의 `--in-place` 축에 해당하는 세션의 덮어쓰기 축이다.
 ///   `hwp_doc_render_page` 는 새 SVG 산출물을 만드는 추가형이라 false.
-/// - `idempotentHint`: `hwp_open` 은 호출마다 새 docId 를 발급하므로 false.
+/// - `idempotentHint`: `hwp_open` 은 호출마다 새 docId 를 발급하므로 false —
+///   `hwp_ws_open` 은 같은 `session_open` 위임이라 같은 이유로 false 다(#4357).
 ///   `hwp_doc_replace_text` 는 **이미 치환된 IR 위에** 다시 적용돼 겹칠 수 있으므로
 ///   false (find 가 replace 의 부분열이면 재실행이 결과를 또 바꾼다 — 매번 원본에서
 ///   다시 계산하는 무상태 `hwp_replace_text` 가 true 인 것과 대비된다). 그 밖은
@@ -913,7 +914,7 @@ fn session_tool_annotations(name: &str, writes_file: bool) -> serde_json::Value 
     let read_axis = crate::agent_profiles::SESSION_READ_TOOLS.contains(&name);
     let read_only = read_axis && !writes_file;
     let destructive = name == "hwp_doc_save";
-    let idempotent = !matches!(name, "hwp_open" | "hwp_doc_replace_text");
+    let idempotent = !matches!(name, "hwp_open" | "hwp_ws_open" | "hwp_doc_replace_text");
     crate::mcp_annotations(read_only, destructive, idempotent)
 }
 

--- a/tests/agent_profile_router_contract.rs
+++ b/tests/agent_profile_router_contract.rs
@@ -6,8 +6,13 @@
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Command, Output, Stdio};
 
+/// nextest archive가 런타임에 재매핑해 주입하는 binary 경로를 우선한다(#3289).
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}
+
 fn run(args: &[&str]) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+    Command::new(rhwp_bin())
         .args(args)
         .output()
         .expect("rhwp 실행 실패")
@@ -66,7 +71,7 @@ fn unknown_profile_is_usage_error_with_listing() {
 fn serve_profile_filters_tools_list_and_session() {
     // 행정서식(session=true)은 세션 도구 포함, 데이터분석(session=false)은 제외.
     for (profile, expect_session) in [("행정서식", true), ("데이터분석", false)] {
-        let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        let mut child = Command::new(rhwp_bin())
             .args(["mcp-serve", "--profile", profile])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -117,7 +122,7 @@ fn serve_profile_filters_tools_list_and_session() {
 
 #[test]
 fn serve_profile_rejects_all_hidden_session_tool_calls() {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+    let mut child = Command::new(rhwp_bin())
         .args(["mcp-serve", "--profile", "데이터분석"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -182,7 +187,7 @@ fn readonly_profile_serves_no_session_write_tools() {
         "hwp_doc_replace_text",
     ];
 
-    let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+    let mut child = Command::new(rhwp_bin())
         .args(["mcp-serve", "--profile", "아카이브검색"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -240,7 +245,7 @@ fn readonly_profile_serves_no_session_write_tools() {
 /// 도구 정의를 자동 생성하는 소비자가 실물과 다른 표면을 얻는다.
 #[test]
 fn capabilities_declares_the_session_tools_it_actually_serves() {
-    let out = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+    let out = Command::new(rhwp_bin())
         .args(["capabilities", "--mcp", "--profile", "아카이브검색"])
         .output()
         .expect("capabilities");
@@ -259,7 +264,7 @@ fn capabilities_declares_the_session_tools_it_actually_serves() {
     assert_eq!(v["profile"]["session"], true, "{v}");
 
     // 세션을 안 여는 프로필은 sessionTools 가 null 이다.
-    let out = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+    let out = Command::new(rhwp_bin())
         .args(["capabilities", "--mcp", "--profile", "데이터분석"])
         .output()
         .expect("capabilities");

--- a/tests/agent_profile_router_contract.rs
+++ b/tests/agent_profile_router_contract.rs
@@ -116,7 +116,7 @@ fn serve_profile_filters_tools_list_and_session() {
 }
 
 #[test]
-fn serve_profile_rejects_hidden_session_tool_calls() {
+fn serve_profile_rejects_all_hidden_session_tool_calls() {
     let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
         .args(["mcp-serve", "--profile", "데이터분석"])
         .stdin(Stdio::piped())
@@ -126,25 +126,40 @@ fn serve_profile_rejects_hidden_session_tool_calls() {
         .expect("mcp-serve");
     let mut stdin = child.stdin.take().unwrap();
     let mut stdout = BufReader::new(child.stdout.take().unwrap());
-    writeln!(
-        stdin,
-        r#"{{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{{"name":"hwp_open","arguments":{{"path":"not-used.hwp"}}}}}}"#
-    )
-    .unwrap();
-    stdin.flush().unwrap();
+    for (id, name) in [
+        "hwp_open",
+        "hwp_ws_list",
+        "hwp_ws_open",
+        "hwp_doc_tree",
+        "hwp_ws_journal",
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        writeln!(
+            stdin,
+            r#"{{"jsonrpc":"2.0","id":{},"method":"tools/call","params":{{"name":"{name}","arguments":{{}}}}}}"#,
+            id + 1
+        )
+        .unwrap();
+        stdin.flush().unwrap();
 
-    let mut line = String::new();
-    assert!(stdout.read_line(&mut line).unwrap() > 0, "조기 종료");
-    let response: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
-    let result = &response["result"];
-    assert_eq!(result["isError"], true, "{response}");
-    assert!(
-        result["content"][0]["text"]
-            .as_str()
-            .unwrap_or_default()
-            .contains("세션 도구"),
-        "{response}"
-    );
+        let mut line = String::new();
+        assert!(
+            stdout.read_line(&mut line).unwrap() > 0,
+            "조기 종료: {name}"
+        );
+        let response: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+        let result = &response["result"];
+        assert_eq!(result["isError"], true, "{name}: {response}");
+        assert!(
+            result["content"][0]["text"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("세션 도구"),
+            "{name} 호출이 프로필 경계를 우회했습니다: {response}"
+        );
+    }
     let _ = child.kill();
     let _ = child.wait();
 }

--- a/tests/mcp_tool_annotations_contract.rs
+++ b/tests/mcp_tool_annotations_contract.rs
@@ -292,14 +292,22 @@ fn served_tools_reflect_manifest_and_session_tools_are_consistent() {
         // 세션에도 개방 세계 축은 없다.
         assert_eq!(a["openWorldHint"], false, "{name}: {a}");
         match name {
-            // 핸들 조회 5종 — 환경 무변경.
+            // 핸들 조회 6종 — 환경 무변경 (tree 는 #4357 의 안정 ID 구조 조회).
             "hwp_doc_text" | "hwp_doc_info" | "hwp_doc_fields" | "hwp_doc_tables"
-            | "hwp_doc_search" => {
+            | "hwp_doc_search" | "hwp_doc_tree" => {
                 assert_eq!(a["readOnlyHint"], true, "{name}: {a}");
                 assert_eq!(a["destructiveHint"], false, "{name}: {a}");
             }
-            // open 은 호출마다 새 docId — 읽기 전용이되 멱등은 아니다.
-            "hwp_open" => {
+            // [#4357 W1] 워크스페이스 조회 2종 — 인벤토리·변이 저널. 환경 무변경이고
+            // 같은 인자 재호출이 같은 관찰로 수렴한다(저널은 조회 자체가 기록을 안 남긴다).
+            "hwp_ws_list" | "hwp_ws_journal" => {
+                assert_eq!(a["readOnlyHint"], true, "{name}: {a}");
+                assert_eq!(a["destructiveHint"], false, "{name}: {a}");
+                assert_eq!(a["idempotentHint"], true, "{name}: {a}");
+            }
+            // open 계열은 호출마다 새 docId — 읽기 전용이되 멱등은 아니다.
+            // ws_open 은 session_open 위임이라 hwp_open 과 같은 판정이다(#4357).
+            "hwp_open" | "hwp_ws_open" => {
                 assert_eq!(a["readOnlyHint"], true, "{name}: {a}");
                 assert_eq!(a["idempotentHint"], false, "{name}: {a}");
             }
@@ -333,7 +341,7 @@ fn served_tools_reflect_manifest_and_session_tools_are_consistent() {
         }
     }
     assert_eq!(
-        session_seen, 12,
+        session_seen, 16,
         "세션 도구 수가 달라졌다 — agent_profiles::ALL_SESSION_TOOLS 와 이 계약을 함께 갱신하라"
     );
 }

--- a/tests/mcp_workspace_contract.rs
+++ b/tests/mcp_workspace_contract.rs
@@ -173,3 +173,54 @@ fn workspace_tools_are_listed() {
         assert!(names.contains(&expected), "{expected} 미등재: {names:?}");
     }
 }
+
+#[cfg(unix)]
+#[test]
+fn workspace_scan_does_not_follow_file_or_directory_symlinks() {
+    use std::os::unix::fs::symlink;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock")
+        .as_nanos();
+    let temp = std::env::temp_dir().join(format!(
+        "rhwp-workspace-symlink-{}-{nonce}",
+        std::process::id()
+    ));
+    let root = temp.join("root");
+    let real_dir = root.join("real");
+    let outside_dir = temp.join("outside");
+    std::fs::create_dir_all(&real_dir).expect("workspace dirs");
+    std::fs::create_dir_all(&outside_dir).expect("outside dir");
+    std::fs::write(real_dir.join("inside.hwp"), b"inside").expect("inside file");
+    let outside_file = outside_dir.join("outside.hwp");
+    std::fs::write(&outside_file, b"outside").expect("outside file");
+    symlink(&outside_file, root.join("outside-link.hwp")).expect("file symlink");
+    // 디렉터리 링크를 따라가지 않으면 같은 디렉터리의 중복 방문뿐 아니라
+    // root 를 가리키는 링크가 만드는 순환도 같은 경계에서 차단된다.
+    symlink(&real_dir, root.join("linked-dir")).expect("directory symlink");
+
+    let root_arg = root.to_string_lossy().into_owned();
+    let mut server = Server::spawn(&["--workspace", &root_arg]);
+    let (err, list) = server.call("hwp_ws_list", serde_json::json!({}));
+    assert!(!err, "hwp_ws_list 실패: {list}");
+    assert_eq!(
+        list["count"], 1,
+        "링크 대상은 인벤토리 밖이어야 한다: {list}"
+    );
+    assert_eq!(
+        list["truncated"], false,
+        "링크 순환으로 상한에 닿으면 안 된다"
+    );
+    assert!(
+        list["entries"][0]["path"]
+            .as_str()
+            .unwrap_or_default()
+            .ends_with("inside.hwp"),
+        "실물 workspace 파일만 남아야 한다: {list}"
+    );
+
+    drop(server);
+    std::fs::remove_dir_all(temp).expect("temporary workspace cleanup");
+}

--- a/tests/mcp_workspace_contract.rs
+++ b/tests/mcp_workspace_contract.rs
@@ -10,6 +10,11 @@
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, ChildStdin, Command, Stdio};
 
+/// nextest archive가 런타임에 재매핑해 주입하는 binary 경로를 우선한다(#3289).
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}
+
 struct Server {
     child: Child,
     stdin: ChildStdin,
@@ -19,7 +24,7 @@ struct Server {
 
 impl Server {
     fn spawn(extra_args: &[&str]) -> Server {
-        let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        let mut child = Command::new(rhwp_bin())
             .arg("mcp-serve")
             .args(extra_args)
             .stdin(Stdio::piped())
@@ -172,6 +177,53 @@ fn workspace_tools_are_listed() {
     ] {
         assert!(names.contains(&expected), "{expected} 미등재: {names:?}");
     }
+}
+
+#[test]
+fn workspace_scan_cap_keeps_the_lexicographically_first_paths() {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    const SCAN_CAP: usize = 10_000;
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock")
+        .as_nanos();
+    let root =
+        std::env::temp_dir().join(format!("rhwp-workspace-cap-{}-{nonce}", std::process::id()));
+    let first_dir = root.join("a");
+    std::fs::create_dir_all(&first_dir).expect("workspace dirs");
+    std::fs::write(first_dir.join("00000.hwp"), []).expect("first path");
+    // root 자체에서 상한을 채워도 뒤에 순회할 a/00000.hwp가 경로순으로 더 앞선다.
+    // 발견 순서에서 먼저 자르는 구현은 이 항목을 영구히 놓친다.
+    for index in 0..SCAN_CAP {
+        std::fs::write(root.join(format!("z{index:05}.hwp")), []).expect("capped path");
+    }
+
+    let root_arg = root.to_string_lossy().into_owned();
+    let mut server = Server::spawn(&["--workspace", &root_arg]);
+    let (err, list) = server.call("hwp_ws_list", serde_json::json!({}));
+    assert!(!err, "hwp_ws_list 실패: {list}");
+    assert_eq!(list["count"], SCAN_CAP, "상한 크기: {list}");
+    assert_eq!(list["truncated"], true, "상한 초과 표지: {list}");
+    let entries = list["entries"].as_array().expect("entries 배열");
+    assert_eq!(entries[0]["id"], "w1");
+    let first = entries[0]["path"].as_str().expect("first path");
+    assert!(
+        std::path::Path::new(first).ends_with(std::path::Path::new("a").join("00000.hwp")),
+        "순회 순서가 아니라 경로순 첫 항목이어야 한다: {first}"
+    );
+    assert!(
+        !entries.iter().any(|entry| {
+            entry["path"]
+                .as_str()
+                .map(|path| path.ends_with("z09999.hwp"))
+                .unwrap_or(false)
+        }),
+        "경로순 상한 밖의 마지막 항목이 남았다"
+    );
+
+    drop(server);
+    std::fs::remove_dir_all(root).expect("temporary workspace cleanup");
 }
 
 #[cfg(unix)]

--- a/tests/mcp_workspace_contract.rs
+++ b/tests/mcp_workspace_contract.rs
@@ -1,0 +1,175 @@
+//! [#4357 W1] 워크스페이스 계약 — 에이전트 전용 문서 런타임 v1.
+//!
+//! 고정하는 것: ① `--workspace` 기동 시 결정론 인벤토리(w1.. 정렬 id), ② id 로
+//! 열기 → 안정 ID 트리(p0../t0..), ③ 변이 저널(변이 도구 후 SHA-256 전/후 자동
+//! 기록), ④ 워크스페이스 없이 기동하면 hwp_ws_* 가 안내와 함께 명시적으로
+//! 실패한다(조용한 빈 결과 금지).
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, Command, Stdio};
+
+struct Server {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<std::process::ChildStdout>,
+    next_id: u64,
+}
+
+impl Server {
+    fn spawn(extra_args: &[&str]) -> Server {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+            .arg("mcp-serve")
+            .args(extra_args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("mcp-serve 기동");
+        let stdin = child.stdin.take().expect("stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout"));
+        let mut server = Server {
+            child,
+            stdin,
+            stdout,
+            next_id: 1,
+        };
+        let init = server.request(
+            "initialize",
+            serde_json::json!({
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": { "name": "workspace-contract", "version": "0" }
+            }),
+        );
+        assert!(init.get("result").is_some(), "initialize 실패: {init}");
+        server
+    }
+
+    fn request(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        let line = serde_json::json!({
+            "jsonrpc": "2.0", "id": id, "method": method, "params": params
+        });
+        writeln!(self.stdin, "{line}").expect("요청 쓰기");
+        loop {
+            let mut buf = String::new();
+            let n = self.stdout.read_line(&mut buf).expect("응답 읽기");
+            assert!(n > 0, "서버가 응답 없이 종료됨 (method={method})");
+            let value: serde_json::Value = match serde_json::from_str(buf.trim()) {
+                Ok(v) => v,
+                Err(_) => continue, // 알림 등 비-JSON 줄은 계약 대상이 아니다.
+            };
+            if value.get("id").and_then(|v| v.as_u64()) == Some(id) {
+                return value;
+            }
+        }
+    }
+
+    /// tools/call 을 보내고 content[0].text 를 JSON 으로 판다.
+    fn call(&mut self, name: &str, arguments: serde_json::Value) -> (bool, serde_json::Value) {
+        let resp = self.request(
+            "tools/call",
+            serde_json::json!({ "name": name, "arguments": arguments }),
+        );
+        let result = &resp["result"];
+        let is_error = result["isError"].as_bool().unwrap_or(false);
+        let text = result["content"][0]["text"].as_str().unwrap_or_default();
+        let body = serde_json::from_str(text).unwrap_or(serde_json::json!({ "raw": text }));
+        (is_error, body)
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn workspace_roundtrip_list_open_tree_journal() {
+    let mut server = Server::spawn(&["--workspace", "samples/basic"]);
+
+    // ① 인벤토리 — 결정론 id.
+    let (err, list) = server.call("hwp_ws_list", serde_json::json!({}));
+    assert!(!err, "hwp_ws_list 실패: {list}");
+    let count = list["count"].as_u64().expect("count");
+    assert!(count > 0, "samples/basic 에 문서가 있어야 한다: {list}");
+    assert_eq!(list["truncated"], false);
+    assert_eq!(list["entries"][0]["id"], "w1", "정렬 1번 id 는 w1: {list}");
+
+    // ② id 로 열기 → 핸들.
+    let (err, opened) = server.call("hwp_ws_open", serde_json::json!({ "id": "w1" }));
+    assert!(!err, "hwp_ws_open 실패: {opened}");
+    let doc_id = opened["docId"].as_str().expect("docId").to_string();
+
+    // ③ 안정 ID 트리.
+    let (err, tree) = server.call("hwp_doc_tree", serde_json::json!({ "docId": doc_id }));
+    assert!(!err, "hwp_doc_tree 실패: {tree}");
+    let page_count = tree["pageCount"].as_u64().expect("pageCount");
+    assert!(page_count >= 1);
+    assert_eq!(tree["nodes"]["pages"][0], "p0");
+    assert!(tree["nodes"]["tables"].is_array());
+
+    // ④ 변이 저널 — save 1회가 자동 기록되고 digest 는 64자리 hex, IR 무변경.
+    let out = std::env::temp_dir().join("ws_contract_save.hwp");
+    let (err, _saved) = server.call(
+        "hwp_doc_save",
+        serde_json::json!({ "docId": doc_id, "output": out.to_string_lossy() }),
+    );
+    assert!(!err, "hwp_doc_save 실패");
+    let (err, journal) = server.call("hwp_ws_journal", serde_json::json!({}));
+    assert!(!err);
+    assert_eq!(journal["count"], 1, "저널 1건: {journal}");
+    let entry = &journal["entries"][0];
+    assert_eq!(entry["tool"], "hwp_doc_save");
+    assert_eq!(entry["docId"], serde_json::json!(doc_id));
+    assert_eq!(entry["isError"], false);
+    let before = entry["digestBefore"].as_str().expect("digestBefore");
+    assert_eq!(before.len(), 64, "sha256 hex 64자리: {before}");
+    assert_eq!(
+        entry["digestBefore"], entry["digestAfter"],
+        "save 는 IR 을 바꾸지 않는다 — changed:false 의 근거"
+    );
+    assert_eq!(entry["changed"], false);
+    let _ = std::fs::remove_file(out);
+}
+
+#[test]
+fn workspace_tools_fail_loudly_without_workspace() {
+    let mut server = Server::spawn(&[]);
+    let (err, body) = server.call("hwp_ws_list", serde_json::json!({}));
+    assert!(err, "워크스페이스 없이 hwp_ws_list 는 명시적 오류여야 한다");
+    assert!(
+        body["raw"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("--workspace"),
+        "안내에 기동 방법이 있어야 한다: {body}"
+    );
+    let (err, body) = server.call("hwp_ws_open", serde_json::json!({ "id": "w1" }));
+    assert!(err, "hwp_ws_open 도 동일: {body}");
+}
+
+#[test]
+fn workspace_tools_are_listed() {
+    let mut server = Server::spawn(&["--workspace", "samples/basic"]);
+    let resp = server.request("tools/list", serde_json::json!({}));
+    let names: Vec<&str> = resp["result"]["tools"]
+        .as_array()
+        .expect("tools 배열")
+        .iter()
+        .filter_map(|t| t["name"].as_str())
+        .collect();
+    for expected in [
+        "hwp_ws_list",
+        "hwp_ws_open",
+        "hwp_doc_tree",
+        "hwp_ws_journal",
+    ] {
+        assert!(names.contains(&expected), "{expected} 미등재: {names:?}");
+    }
+}


### PR DESCRIPTION
## 변경 요약

**W1 'rhwp workspace' v1 실물 구현**입니다. 설계(#4351/PR #4352)의 제안을 작업지시자 결정에 따라 실물로 제출합니다 — **이 PR 의 머지가 채택, 클로즈가 기각**입니다(승인 매체 = PR).

- `mcp-serve --workspace <dir>`: 기동 1회 스캔(.hwp/.hwpx/.hml, 숨김 제외, 상한 10,000 + truncated 표지), 경로 정렬 **결정론 id(w1..)** 인벤토리.
- 신규 세션 도구 4종(전부 조회 축): hwp_ws_list · hwp_ws_open(id→기존 session_open 재사용) · **hwp_doc_tree**(안정 노드 ID 트리 — 페이지 p0../표 t0.., hwp_doc_tables 순서와 동일해 셀 편집 좌표로 이어짐) · hwp_ws_journal.
- **자기검증 루프**: 변이 4종(replace_text/set_cell/fill_fields/save)을 journal_wrap 으로 감싸 매 호출의 본문 SHA-256 전/후·changed·isError 를 자동 기록.
- 게이트 처리: R76(캐시 재설계)과 **비중복** — 열린 핸들 위 조회·저널만 더했고 재파싱 회피는 기존 세션 담당. R28(동시성)은 v1 단일 클라이언트 전제를 명시. 무워크스페이스 기동 시 hwp_ws_* 는 기동 안내와 함께 명시적으로 실패합니다.

## 관련 이슈

closes #4357 (설계 이슈 #4351·제안 PR #4352 는 본 PR 판정에 따름)

## 테스트

- [x] 신규 계약 tests/mcp_workspace_contract.rs 3본 **첫 실행 3/3**: 왕복(list w1 → open → tree p0/tables → save → journal sha256 64자리·changed:false) · 무워크스페이스 명시 실패 · tools/list 등재
- [x] 인접: mcp_server_contract 24/24 · agent_profile_router_contract 8/8 · cargo clippy --bin rhwp 경고 0 · rustfmt 후 재검 3/3
- [ ] 전체 cargo test — 미실행(표적 스위트가 위험 표면을 덮음, CI 위임)
- [ ] SVG/WASM — 해당 없음

## 성능 영향 및 측정 결과

- 예상 영향: 없음(옵트인 플래그 — 기본 경로 무변경. 저널 digest 는 변이 호출 시에만 전 페이지 텍스트 추출 2회)

## 스크린샷

- 해당 없음(계약 테스트가 왕복 실증)
