### PR TITLE
core: 셀 합치기 후 병합 셀 문단을 새 폭으로 재배치

### DIFF
--- a/mydocs/working/task_m100_4323_stage1.md
+++ b/mydocs/working/task_m100_4323_stage1.md
@@ -1,0 +1,55 @@
+# task_m100_4323 Stage 1 — 셀 합치기 후 병합 셀 문단 재배치
+
+- **이슈**: [#4323](https://github.com/edwardkim/rhwp/issues/4323)
+- **PR**: [#4363](https://github.com/edwardkim/rhwp/pull/4363)
+- **브랜치**: `fix/issue-4323-merge-cell-reflow`
+- **분기 기준**: `upstream/devel` `e48fe8694`
+- **상태**: 로컬 전체 검증 통과, PR 게시
+- **기록일**: 2026-08-09 KST
+
+## 1. 결함
+
+셀을 합치면 주 셀 폭이 흡수된 셀들만큼 넓어진다. 그런데 `merge_table_cells_native`
+(`table_ops.rs:637`)는 `recompose_section` 과 `paginate_if_needed` 만 부르고
+`reflow_cell_paragraph` 를 부르지 않았다.
+
+`compose` 는 저장된 `line_segs` 를 그대로 쓰므로, 병합 셀 텍스트가 **합치기 전 좁은 폭 그대로**
+줄바꿈된 채 남는다.
+
+## 2. 형제 명령과의 대조
+
+폭을 바꾸는 형제는 모두 부른다:
+
+| 명령 | 위치 | reflow 호출 |
+|---|---|---|
+| `set_table_column_widths_native` | `table_ops.rs:2211-2234` | 있음 |
+| `resize_table_cells_native` | `:2172` 부근 | 있음 |
+| `merge_table_cells_native` | `:637` | **없음** |
+
+`split_table_cell_native` 는 별도 헬퍼 `reflow_stale_cells_after_split` 를 쓰는데, 그건 "너무
+넓어진 세그먼트만" 거르는 필터라 폭이 **넓어지는** 병합에는 그대로 쓸 수 없다.
+
+## 3. 구현 — 형제와 같은 규약
+
+`recompose_section` 호출 직전에 병합 결과 셀의 모든 문단에 대해 `reflow_cell_paragraph` 를 부른다.
+호출 순서(reflow → `raw_stream = None` → `recompose_section` → `paginate_if_needed`)는 형제와
+동일하다.
+
+한 가지만 다르다 — `Table::merge_cells` 가 병합 뒤 `sort_by_key((row, col))` 로 셀을 재정렬하므로
+옛 인덱스가 무효다. 주 셀을 `(row == start_row && col == start_col)` 로 다시 찾는다. 새 방식을
+발명한 것이 아니라 병합의 인덱스 재배치 특성에 맞춘 조회 방식 차이다.
+
+형제가 전체 셀을 도는 것과 달리 주 셀 하나만 도는데, 병합에서는 흡수된 셀이 제거되고 나머지 폭은
+바뀌지 않으므로 최소이자 정확하다. `table.dirty = true` 는 이미 세우고 있어 인접 결함이 없다.
+
+## 4. 검증 (완료)
+
+- `tests/issue_4323_merge_cell_reflow.rs` 신설 2건. 좁은 폭(4200 HWPUNIT) 1×3 표 첫 셀에 42자를
+  넣어 14줄을 만들고 (0,0)~(0,2) 병합(폭 3배) 후 줄 수 감소를 확인, 병합 범위 밖 셀 불변도 확인.
+- 수정 전 코드에서 `14 -> 14` 로 실패함을 확인했다.
+- 인접 회귀(`issue_4138_split_cell_stale_linesegs`, `issue_2342_cell_merge_para_meta`,
+  `issue_2724_passthrough_invalidation_guard`) 통과.
+- `cargo test --profile release-test --tests` 전체 통과.
+- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` 통과.
+
+남은 미래 조건은 GitHub Actions 와 작업지시자 승인, merge 다.

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -660,6 +660,34 @@ impl DocumentCore {
         table.local_resize_cell_widths.clear();
         table.local_resize_cell_heights.clear();
 
+        // 주 셀 폭이 흡수된 셀들만큼 넓어졌으므로 문단들을 새 폭으로 재배치(line_segs
+        // 재계산)한다. set_table_column_widths_native/resize_table_cells_native와 동일 규약
+        // — 폭을 바꾸는 명령은 모두 recompose_section 전에 reflow_cell_paragraph 를 부른다.
+        // 병합 후 주 셀은 sort_by_key(row, col) 재정렬을 거치므로 인덱스가 아니라
+        // (row, col)로 다시 찾는다.
+        let reflow_cell: Option<(usize, usize)> = {
+            let para = &self.document.sections[section_idx].paragraphs[parent_para_idx];
+            if let Some(Control::Table(t)) = para.controls.get(control_idx) {
+                t.cells
+                    .iter()
+                    .position(|c| c.row == start_row && c.col == start_col)
+                    .map(|idx| (idx, t.cells[idx].paragraphs.len()))
+            } else {
+                None
+            }
+        };
+        if let Some((cell_idx, para_count)) = reflow_cell {
+            for cell_para_idx in 0..para_count {
+                self.reflow_cell_paragraph(
+                    section_idx,
+                    parent_para_idx,
+                    control_idx,
+                    cell_idx,
+                    cell_para_idx,
+                );
+            }
+        }
+
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);
         self.paginate_if_needed();

--- a/tests/issue_4323_merge_cell_reflow.rs
+++ b/tests/issue_4323_merge_cell_reflow.rs
@@ -1,0 +1,170 @@
+//! Issue #4323: 셀 합치기 후 병합 셀 텍스트가 합치기 전 폭으로 줄바꿈된다 (reflow 누락).
+//!
+//! `merge_table_cells_native`(`table_ops.rs`)는 `Table::merge_cells`로 주 셀의 폭을
+//! 넓힌 뒤 `recompose_section` + `paginate_if_needed`만 호출하고 `reflow_cell_paragraph`를
+//! 부르지 않았다. 폭을 바꾸는 형제 명령인 `set_table_column_widths_native`/
+//! `resize_table_cells_native`는 둘 다 부른다 — 셀 합치기만 규약에서 빠져 있었다.
+//!
+//! 결과: 셀 상자만 넓어지고 저장된 `line_segs`는 합치기 전 좁은 폭 기준 그대로 남아
+//! 각 줄 오른쪽이 비고 행 높이도 줄지 않는다.
+//!
+//! 재현: 1×3 표, 좁은 폭의 첫 셀에 줄바꿈이 필요한 긴 텍스트를 넣고 (0,0)~(0,2)를
+//! 합친 뒤 문단의 line_segs 줄 수가 합치기 전보다 줄어드는지(재래핑됐는지) 확인한다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+use rhwp::model::table::Table;
+
+/// 좁은 폭(HWPUNIT) 3열짜리 1×3 표를 가진 빈 문서. 반환값은 표가 놓인 본문 문단 인덱스.
+///
+/// `create_table_ex_native`의 `col_widths_hu`는 `treat_as_char=false` 경로
+/// (`create_table_native`)에서는 적용되지 않으므로(편집 영역 폭을 열 수로 균등
+/// 분배), 생성 후 `set_table_column_widths_native`로 명시적으로 좁혀 폭을 고정한다.
+fn doc_with_narrow_table(col_width: u32) -> (DocumentCore, usize) {
+    let mut core = DocumentCore::new_empty();
+    core.create_blank_document_native().expect("blank document");
+    core.create_table_ex_native(0, 0, 0, 1, 3, false, None, None)
+        .expect("1x3 table");
+
+    let para_idx = core.document().sections[0]
+        .paragraphs
+        .iter()
+        .position(|p| p.controls.iter().any(|c| matches!(c, Control::Table(_))))
+        .expect("표가 놓인 문단");
+    let ctrl_idx = table_control_idx(&core, para_idx);
+    core.set_table_column_widths_native(0, para_idx, ctrl_idx, vec![col_width; 3])
+        .expect("좁은 열 폭 지정");
+    (core, para_idx)
+}
+
+fn table_control_idx(core: &DocumentCore, para_idx: usize) -> usize {
+    core.document().sections[0].paragraphs[para_idx]
+        .controls
+        .iter()
+        .position(|c| matches!(c, Control::Table(_)))
+        .expect("표 컨트롤")
+}
+
+fn target_table(core: &DocumentCore, para_idx: usize, ctrl_idx: usize) -> &Table {
+    match &core.document().sections[0].paragraphs[para_idx].controls[ctrl_idx] {
+        Control::Table(t) => t,
+        other => panic!("controls[{ctrl_idx}] 이 표가 아님: {other:?}"),
+    }
+}
+
+/// (row, col) 위치의 셀 인덱스.
+fn cell_idx_at(table: &Table, row: u16, col: u16) -> usize {
+    table
+        .cells
+        .iter()
+        .position(|c| c.row == row && c.col == col)
+        .unwrap_or_else(|| panic!("({row},{col}) 셀을 찾을 수 없음"))
+}
+
+/// 셀 합치기 후 주 셀 문단이 새 폭으로 재래핑되어 줄 수가 줄어든다.
+#[test]
+fn merge_table_cells_reflows_widened_primary_cell() {
+    // 한 글자(전각) 당 대략 1000 HWPUNIT 안팎으로 잡고, 좁은 열 폭에서
+    // 여러 줄로 감기게 충분히 긴 한글 문자열을 준비한다.
+    let narrow_col_width: u32 = 4200;
+    let long_text: String = "가나다라마바사아자차카타파하".repeat(3); // 42자
+
+    let (mut core, para_idx) = doc_with_narrow_table(narrow_col_width);
+    let ctrl_idx = table_control_idx(&core, para_idx);
+
+    let cell0 = cell_idx_at(target_table(&core, para_idx, ctrl_idx), 0, 0);
+    core.insert_text_in_cell_native(0, para_idx, ctrl_idx, cell0, 0, 0, &long_text)
+        .expect("긴 텍스트 삽입");
+
+    let before_table = target_table(&core, para_idx, ctrl_idx);
+    let before_cell = &before_table.cells[cell0];
+    let before_width = before_cell.width;
+    let before_lines = before_cell.paragraphs[0].line_segs.len();
+    assert!(
+        before_lines > 1,
+        "재현 전제 실패: 좁은 폭({before_width})에서 줄바꿈이 일어나지 않음 \
+         (line_segs={before_lines}). 텍스트를 더 늘리거나 폭을 더 좁혀야 함."
+    );
+
+    // (0,0)~(0,2) 병합 — 주 셀 폭이 3배로 넓어진다.
+    core.merge_table_cells_native(0, para_idx, ctrl_idx, 0, 0, 0, 2)
+        .expect("셀 병합 (0,0)~(0,2)");
+
+    let after_table = target_table(&core, para_idx, ctrl_idx);
+    let after_cell_idx = cell_idx_at(after_table, 0, 0);
+    let after_cell = &after_table.cells[after_cell_idx];
+    assert_eq!(
+        after_cell.width,
+        before_width * 3,
+        "병합 후 주 셀 폭이 3배가 되어야 함"
+    );
+
+    let after_lines = after_cell.paragraphs[0].line_segs.len();
+    assert!(
+        after_lines < before_lines,
+        "#4323 회귀: 병합 후 주 셀 폭이 {}(->{})로 넓어졌는데도 line_segs 줄 수가 \
+         {before_lines}->{after_lines}로 줄지 않음 — reflow_cell_paragraph 가 호출되지 \
+         않아 합치기 전 좁은 폭 기준 줄바꿈이 그대로 남아 있다.",
+        before_width,
+        after_cell.width,
+    );
+
+    // 재래핑된 각 줄의 segment_width 는 새 셀 내부 폭(패딩 차감) 이하여야 하고,
+    // 옛 좁은 폭(before_width) 근처에 멈춰 있으면 안 된다 — stale 값 회귀 가드.
+    for seg in &after_cell.paragraphs[0].line_segs {
+        assert!(
+            (seg.segment_width as i64) <= after_cell.width as i64,
+            "재래핑된 세그먼트 폭({})이 새 셀 폭({})을 넘음",
+            seg.segment_width,
+            after_cell.width
+        );
+    }
+    let widened_at_least_one = after_cell.paragraphs[0]
+        .line_segs
+        .iter()
+        .any(|seg| (seg.segment_width as i64) > (before_width as i64));
+    assert!(
+        widened_at_least_one,
+        "#4323 회귀: 재래핑 후에도 모든 줄 세그먼트 폭이 옛 좁은 폭({before_width}) 이하 \
+         — reflow 가 실제로 새 폭을 반영하지 않음"
+    );
+}
+
+/// 형제 셀(합치기 범위 밖)의 line_segs 는 병합에 영향받지 않는다.
+#[test]
+fn merge_table_cells_does_not_touch_untouched_cell() {
+    let narrow_col_width: u32 = 4200;
+    let long_text: String = "가나다라마바사아자차카타파하".repeat(3);
+
+    let (mut core, para_idx) = doc_with_narrow_table(narrow_col_width);
+    let ctrl_idx = table_control_idx(&core, para_idx);
+
+    // 4행 3열이 아니라 1행 3열 표라서 병합은 (0,0)~(0,1)만 하고 (row0,col2)는 그대로 둔다.
+    let table = target_table(&core, para_idx, ctrl_idx);
+    let cell0 = cell_idx_at(table, 0, 0);
+    let cell2 = cell_idx_at(table, 0, 2);
+    core.insert_text_in_cell_native(0, para_idx, ctrl_idx, cell0, 0, 0, &long_text)
+        .expect("cell0 텍스트 삽입");
+    core.insert_text_in_cell_native(0, para_idx, ctrl_idx, cell2, 0, 0, &long_text)
+        .expect("cell2 텍스트 삽입");
+
+    let before_table = target_table(&core, para_idx, ctrl_idx);
+    let before_cell2_lines = before_table.cells[cell_idx_at(before_table, 0, 2)].paragraphs[0]
+        .line_segs
+        .len();
+
+    core.merge_table_cells_native(0, para_idx, ctrl_idx, 0, 0, 0, 1)
+        .expect("셀 병합 (0,0)~(0,1)");
+
+    let after_table = target_table(&core, para_idx, ctrl_idx);
+    let after_cell2 = &after_table.cells[cell_idx_at(after_table, 0, 2)];
+    assert_eq!(
+        after_cell2.width, narrow_col_width,
+        "병합 범위 밖 셀의 폭은 그대로여야 함"
+    );
+    assert_eq!(
+        after_cell2.paragraphs[0].line_segs.len(),
+        before_cell2_lines,
+        "병합 범위 밖 셀의 줄 수는 그대로여야 함"
+    );
+}


### PR DESCRIPTION
## 무엇을

`merge_table_cells_native` 가 셀 합치기 후 병합 셀 문단의 `line_segs` 를 재계산하도록 한다.

## 왜

셀을 합치면 주 셀 폭이 흡수된 셀들만큼 넓어진다. 그런데 이 명령은 `recompose_section` 과
`paginate_if_needed` 만 부르고 `reflow_cell_paragraph` 를 부르지 않았다 — `compose` 는 저장된
`line_segs` 를 그대로 쓰므로, 병합 셀 텍스트가 **합치기 전 좁은 폭 그대로** 줄바꿈된 채 남는다.

폭을 바꾸는 형제 명령들은 모두 부른다:

- `set_table_column_widths_native` (`table_ops.rs:2211-2234`)
- `resize_table_cells_native` (`:2172` 부근)

`split_table_cell_native` 는 별도 헬퍼 `reflow_stale_cells_after_split` 를 쓰는데, 그건
"너무 넓어진 세그먼트만" 거르는 필터라 폭이 **넓어지는** 병합에는 그대로 쓸 수 없다.

## 어떻게

형제 명령과 같은 규약으로, `recompose_section` 호출 직전에 병합 결과 셀의 모든 문단에 대해
`reflow_cell_paragraph` 를 부른다.

한 가지만 다르다 — `Table::merge_cells` 가 병합 뒤 `sort_by_key((row, col))` 로 셀을 재정렬하므로
옛 인덱스가 무효다. 주 셀을 `(row == start_row && col == start_col)` 로 다시 찾는다. 호출 순서와
시점 규약은 형제와 동일하다.

## 검증

- `tests/issue_4323_merge_cell_reflow.rs` 신설 2건. 좁은 폭(4200 HWPUNIT) 1×3 표 첫 셀에 42자를
  넣어 14줄을 만들고 (0,0)~(0,2) 병합(폭 3배) 후 줄 수가 줄어드는지, 병합 범위 밖 셀은 그대로인지
  확인한다. 수정 전 코드에서 `14 -> 14` 로 실패하는 것을 확인했다.
- `cargo test --profile release-test --tests` 전체 통과.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` 통과.

Closes #4323
