### PR TITLE
feat(docker): #4354 CLI 이미지 — docker run 한 줄 (ghcr, GITHUB_TOKEN만 — 머지=활성화, PR CI가 빌드 검증)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,7 @@ pkg/
 mydocs/
 .git/
 *.wasm
+samples/
+rhwp-studio/node_modules/
+bindings/node/node_modules/
+Dockerfile.cli

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
 target/
 pkg/
 mydocs/
+# [#4354] rhwp 바이너리가 include_str! 로 임베드하는 에이전트 문서(지식지도·트러블슈팅·레시피 6종)는
+# 빌드 컨텍스트에 있어야 한다 — 없으면 cargo build 가 couldn't read 로 실패한다.
+!mydocs/manual
 .git/
 *.wasm
 samples/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -825,6 +825,7 @@ jobs:
       - name: Validate workflow contracts
         run: |
           python3 -m unittest scripts/tests/test_cache_sweep_workflow.py
+          python3 -m unittest scripts/tests/test_docker_publish_workflow.py
           python3 -m unittest scripts/tests/test_review_only_fast_pass_workflows.py
           python3 -m unittest scripts/tests/test_workflow_contract_wiring.py
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,19 +29,48 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # 수동 실행은 요청 태그, 태그 push/PR 은 해당 이벤트 ref 의 소스를 빌드한다.
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
-      - name: 버전 결정
+      - name: 소스·버전 검증
         id: ver
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.number }}
+          REQUESTED_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            TAG="${{ github.event.inputs.tag }}"
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            TAG="pr-${{ github.event.number }}"
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            VERSION="pr-$PR_NUMBER"
+            PUBLISH_LATEST=false
           else
-            TAG="${{ github.ref_name }}"
+            TAG="$REQUESTED_TAG"
+            if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+              echo "지원하지 않는 릴리스 태그 형식: $TAG" >&2
+              exit 1
+            fi
+            TAG_SHA="$(git rev-parse --verify "refs/tags/$TAG^{commit}")"
+            HEAD_SHA="$(git rev-parse HEAD)"
+            if [[ "$HEAD_SHA" != "$TAG_SHA" ]]; then
+              echo "checkout 소스가 요청 태그와 다릅니다: HEAD=$HEAD_SHA tag=$TAG_SHA" >&2
+              exit 1
+            fi
+            VERSION="${TAG#v}"
+            CARGO_VERSION="$(awk -F '"' '/^version = "/ { print $2; exit }' Cargo.toml)"
+            if [[ "$VERSION" != "$CARGO_VERSION" ]]; then
+              echo "버전 불일치: tag=$VERSION Cargo.toml=$CARGO_VERSION" >&2
+              exit 1
+            fi
+            if [[ "$VERSION" == *-* ]]; then
+              PUBLISH_LATEST=false
+            else
+              PUBLISH_LATEST=true
+            fi
           fi
-          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "publish_latest=$PUBLISH_LATEST" >> "$GITHUB_OUTPUT"
 
       - name: 빌드
         run: docker build -f Dockerfile.cli -t rhwp-cli:local .
@@ -57,10 +86,15 @@ jobs:
         shell: bash
         env:
           VERSION: ${{ steps.ver.outputs.version }}
+          PUBLISH_LATEST: ${{ steps.ver.outputs.publish_latest }}
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
           IMAGE=ghcr.io/${{ github.repository_owner }}/rhwp
           docker tag rhwp-cli:local "$IMAGE:$VERSION"
-          docker tag rhwp-cli:local "$IMAGE:latest"
           docker push "$IMAGE:$VERSION"
-          docker push "$IMAGE:latest"
+          if [[ "$PUBLISH_LATEST" == "true" ]]; then
+            docker tag rhwp-cli:local "$IMAGE:latest"
+            docker push "$IMAGE:latest"
+          else
+            echo "::notice title=latest 유지::prerelease 태그 $VERSION 은 latest 를 갱신하지 않습니다."
+          fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,66 @@
+name: Docker CLI Image
+
+# Issue #4354 — `docker run ghcr.io/edwardkim/rhwp` 한 줄 유입관.
+#
+# 시크릿 불요: ghcr.io 게시는 GITHUB_TOKEN(packages: write)만 쓴다 — 이 워크플로의
+# 머지가 곧 활성화다. PR 이 Dockerfile.cli 를 건드리면 게시 없이 빌드만 검증한다.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+    paths:
+      - 'Dockerfile.cli'
+      - '.github/workflows/docker-publish.yml'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag name (예: v0.8.2)'
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: 이미지 빌드${{ github.event_name == 'pull_request' && ' (검증만)' || ' + ghcr 게시' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: 버전 결정
+        id: ver
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ github.event.inputs.tag }}"
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            TAG="pr-${{ github.event.number }}"
+          else
+            TAG="${{ github.ref_name }}"
+          fi
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: 빌드
+        run: docker build -f Dockerfile.cli -t rhwp-cli:local .
+
+      - name: 스모크 — capabilities 봉투가 나온다
+        run: |
+          docker run --rm rhwp-cli:local capabilities | head -c 200
+          echo
+          docker run --rm rhwp-cli:local --version
+
+      - name: ghcr 로그인·게시 (태그/수동 실행만)
+        if: github.event_name != 'pull_request'
+        shell: bash
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          IMAGE=ghcr.io/${{ github.repository_owner }}/rhwp
+          docker tag rhwp-cli:local "$IMAGE:$VERSION"
+          docker tag rhwp-cli:local "$IMAGE:latest"
+          docker push "$IMAGE:$VERSION"
+          docker push "$IMAGE:latest"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,6 +12,7 @@ on:
   pull_request:
     paths:
       - 'Dockerfile.cli'
+      - '.dockerignore'
       - '.github/workflows/docker-publish.yml'
   workflow_dispatch:
     inputs:
@@ -63,10 +64,12 @@ jobs:
               echo "버전 불일치: tag=$VERSION Cargo.toml=$CARGO_VERSION" >&2
               exit 1
             fi
-            if [[ "$VERSION" == *-* ]]; then
-              PUBLISH_LATEST=false
-            else
+            # latest 는 새 stable tag push에서만 전진시킨다. 수동 재실행은 과거
+            # stable tag를 선택할 수 있으므로 version tag만 다시 게시한다.
+            if [[ "$EVENT_NAME" == "push" && "$VERSION" != *-* ]]; then
               PUBLISH_LATEST=true
+            else
+              PUBLISH_LATEST=false
             fi
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -96,5 +99,5 @@ jobs:
             docker tag rhwp-cli:local "$IMAGE:latest"
             docker push "$IMAGE:latest"
           else
-            echo "::notice title=latest 유지::prerelease 태그 $VERSION 은 latest 를 갱신하지 않습니다."
+            echo "::notice title=latest 유지::prerelease 또는 수동 재실행 $VERSION 은 latest 를 갱신하지 않습니다."
           fi

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,0 +1,25 @@
+# [#4354] CLI 컨테이너 이미지 — `docker run ghcr.io/edwardkim/rhwp` 한 줄 유입관.
+#
+# 루트 Dockerfile(WASM 빌드 환경)과 별개다 — 그쪽은 빌드 도구 상자, 이쪽은
+# 실행 배포물이다. 게시는 .github/workflows/docker-publish.yml 이 GITHUB_TOKEN
+# 만으로 ghcr.io 에 올린다(별도 시크릿 불요 — 머지가 곧 활성화).
+#
+# 사용:
+#   docker run --rm -v "$PWD:/work" ghcr.io/edwardkim/rhwp info /work/문서.hwp --json
+#   docker run --rm -i ghcr.io/edwardkim/rhwp mcp-serve        # stdio MCP 서버
+
+FROM rust:1.93-slim-bookworm AS build
+WORKDIR /src
+# rust-toolchain.toml 이 정확한 툴체인(1.93.1)을 고정한다 — rustup 이 따라간다.
+COPY . .
+RUN cargo build --release --bin rhwp --locked
+
+FROM debian:bookworm-slim
+# 인증서만 — 바이너리는 정적 링크가 아니어도 추가 런타임 의존이 없다(glibc).
+RUN useradd --create-home --uid 10001 rhwp \
+    && mkdir /work && chown rhwp:rhwp /work
+COPY --from=build /src/target/release/rhwp /usr/local/bin/rhwp
+USER rhwp
+WORKDIR /work
+ENTRYPOINT ["rhwp"]
+CMD ["capabilities"]

--- a/mydocs/pr/pr_4372_review.md
+++ b/mydocs/pr/pr_4372_review.md
@@ -23,7 +23,7 @@ Docker CLI packaging과 workflow만 바뀌며 renderer, layout, fixture, sample 
 | 규모 | 3 files, +98 / -0, contributor commits 2개 |
 | 상태 | `MERGEABLE` / `CLEAN`, Full CI·CodeQL·Docker CLI Image build 성공 |
 | 가시성 branch | `review/kevin9327-20260810-pr4372` |
-| 메인터너 code candidate | `71aecd1273864ae42b5b19fa9382aa43c8f0ef77` |
+| 메인터너 code candidate | `1a4f0524af120a7bdc6e8ab8ed4cbddd320291fa` |
 
 ## Contributor 변경 범위
 
@@ -38,6 +38,9 @@ Docker build context에서 누락되지 않도록 `.dockerignore`를 보정했�
   요청 태그와 다른 source를 게시할 수 있었다.
 - tag push 조건 `v*`에는 prerelease도 포함되지만 모든 publish가 `:latest`를 갱신해,
   rc/beta/alpha image가 stable latest를 대체할 수 있었다.
+- 최초 보정 뒤에도 과거 stable tag의 manual dispatch가 `latest`를 과거 image로 되돌릴 수 있었다.
+- `Dockerfile.cli`가 `COPY . .`를 쓰는데 PR trigger paths에 `.dockerignore`가 없어, 실제 build context
+  보정만 바뀌면 Docker image check가 실행되지 않았다.
 
 ## 메인터너 보정
 
@@ -49,13 +52,20 @@ Docker build context에서 누락되지 않도록 `.dockerignore`를 보정했�
 - `scripts/tests/test_docker_publish_workflow.py`: source와 latest 보호 계약
 - `.github/workflows/ci.yml`: 새 계약 테스트 배선
 
+독립 후속 검토 뒤 `1a4f0524af120a7bdc6e8ab8ed4cbddd320291fa`
+(`fix(maintainer): #4372 latest rollback과 dockerignore gate 차단`)을 추가했다.
+
+- `.github/workflows/docker-publish.yml`: `latest`는 stable tag **push**에서만 갱신하고 manual dispatch는
+  version tag만 게시한다. `.dockerignore` 변경도 PR Docker build를 트리거한다.
+- `scripts/tests/test_docker_publish_workflow.py`: stable push 조건과 `.dockerignore` path 계약을 고정한다.
+
 ## 완료한 로컬 검증
 
 | 검증 | 결과 |
 | --- | --- |
-| `python -m unittest scripts.tests.test_docker_publish_workflow scripts.tests.test_workflow_contract_wiring -v` | 5 / 5 통과 |
-| `git diff --check origin/pr/4372..71aecd1273864ae42b5b19fa9382aa43c8f0ef77` | 통과 |
-| commit graph | correction commit의 유일한 parent가 contributor head와 일치 |
+| `python -m unittest scripts.tests.test_docker_publish_workflow scripts.tests.test_workflow_contract_wiring -v` | 6 / 6 통과 |
+| `git diff --check origin/pr/4372..1a4f0524af120a7bdc6e8ab8ed4cbddd320291fa` | 통과 |
+| commit graph | contributor history를 rewrite하지 않고 maintainer code/docs/code를 single-parent로 연결 |
 
 실제 Docker build와 GHCR publish는 로컬에서 재실행하지 않았다. `actionlint`도 로컬에 없어,
 최신 원격 head의 workflow parser, Docker build smoke와 Full CI가 남아 있다.
@@ -63,7 +73,7 @@ Docker build context에서 누락되지 않도록 `.dockerignore`를 보정했�
 ## 최종 권고
 
 **메인터너 보정 포함 조건부 수용 권고.** 기존 contributor head의 녹색 Docker/CI 결과는 새
-workflow code candidate를 검증하지 않는다. push 승인 뒤 correction과 review 기록을 fast-forward로
+workflow code candidate를 검증하지 않는다. push 승인 뒤 corrections와 review 기록을 fast-forward로
 반영하고 최신 head의 Full CI, Docker CLI Image check, required aggregate와 mergeability가 모두
 성공해야 한다. 그 후에도 별도 merge 승인이 필요하며, 현재는 원격 변경 권한이 없다.
 

--- a/mydocs/pr/pr_4372_review.md
+++ b/mydocs/pr/pr_4372_review.md
@@ -1,0 +1,70 @@
+---
+kind: pr-review
+status: active
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-10
+---
+
+# PR #4372 검토 - GHCR 소스와 stable latest 보호
+
+## 검토 경로
+
+기본 경로는 `maintainer_general.md`, 보조 경로는 `intake_and_review.md`,
+`local_validation.md`, `multi_pr_update_branch.md`, `review_only_fast_pass.md`다.
+Docker CLI packaging과 workflow만 바뀌며 renderer, layout, fixture, sample 영향은 없다.
+
+## 접수 메타데이터
+
+| 항목 | 접수 시점 참고값 |
+| --- | --- |
+| PR / 작성자 | [#4372](https://github.com/edwardkim/rhwp/pull/4372) / `kevin9327` |
+| 관련 이슈 | [#4354](https://github.com/edwardkim/rhwp/issues/4354) |
+| base / contributor head | `devel` / `91782d3364b3b8929cac00a4d449e6785d93e6a1` |
+| 규모 | 3 files, +98 / -0, contributor commits 2개 |
+| 상태 | `MERGEABLE` / `CLEAN`, Full CI·CodeQL·Docker CLI Image build 성공 |
+| 가시성 branch | `review/kevin9327-20260810-pr4372` |
+| 메인터너 code candidate | `71aecd1273864ae42b5b19fa9382aa43c8f0ef77` |
+
+## Contributor 변경 범위
+
+`c1d4da0878c94c898a4ebb903c4b9f6b46fc14b2`는 `Dockerfile.cli`과 GHCR publish
+workflow를 추가했다. `91782d3364b3b8929cac00a4d449e6785d93e6a1`은 embedded manual이
+Docker build context에서 누락되지 않도록 `.dockerignore`를 보정했다. 두 commit의 history를
+그대로 유지했다.
+
+## 원래 차단점
+
+- 수동 dispatch의 tag 입력은 image label에만 반영되고 checkout은 workflow 실행 ref를 사용해,
+  요청 태그와 다른 source를 게시할 수 있었다.
+- tag push 조건 `v*`에는 prerelease도 포함되지만 모든 publish가 `:latest`를 갱신해,
+  rc/beta/alpha image가 stable latest를 대체할 수 있었다.
+
+## 메인터너 보정
+
+`71aecd1273864ae42b5b19fa9382aa43c8f0ef77`
+(`fix(maintainer): #4372 배포 소스와 latest 태그를 보호`)은 다음 파일을 바꿨다.
+
+- `.github/workflows/docker-publish.yml`: dispatch tag checkout, tag/HEAD/Cargo 검증,
+  PR event ref 유지, prerelease의 latest publish 차단
+- `scripts/tests/test_docker_publish_workflow.py`: source와 latest 보호 계약
+- `.github/workflows/ci.yml`: 새 계약 테스트 배선
+
+## 완료한 로컬 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| `python -m unittest scripts.tests.test_docker_publish_workflow scripts.tests.test_workflow_contract_wiring -v` | 5 / 5 통과 |
+| `git diff --check origin/pr/4372..71aecd1273864ae42b5b19fa9382aa43c8f0ef77` | 통과 |
+| commit graph | correction commit의 유일한 parent가 contributor head와 일치 |
+
+실제 Docker build와 GHCR publish는 로컬에서 재실행하지 않았다. `actionlint`도 로컬에 없어,
+최신 원격 head의 workflow parser, Docker build smoke와 Full CI가 남아 있다.
+
+## 최종 권고
+
+**메인터너 보정 포함 조건부 수용 권고.** 기존 contributor head의 녹색 Docker/CI 결과는 새
+workflow code candidate를 검증하지 않는다. push 승인 뒤 correction과 review 기록을 fast-forward로
+반영하고 최신 head의 Full CI, Docker CLI Image check, required aggregate와 mergeability가 모두
+성공해야 한다. 그 후에도 별도 merge 승인이 필요하며, 현재는 원격 변경 권한이 없다.
+
+실행 및 rollback은 [PR #4372 구현·통합 계획](pr_4372_review_impl.md)을 따른다.

--- a/mydocs/pr/pr_4372_review_impl.md
+++ b/mydocs/pr/pr_4372_review_impl.md
@@ -12,7 +12,9 @@ last_verified: 2026-08-10
 1. `c1d4da0878c94c898a4ebb903c4b9f6b46fc14b2` — contributor의 Docker CLI/GHCR 구현
 2. `91782d3364b3b8929cac00a4d449e6785d93e6a1` — contributor의 Docker context 보정
 3. `71aecd1273864ae42b5b19fa9382aa43c8f0ef77` — maintainer code/test/workflow 보정
-4. 이 문서를 포함하는 별도 trailing review-doc commit
+4. `a12ac6ce0b00daaf5abdd78f8294fdcd87a25549` — 최초 maintainer review-doc commit
+5. `1a4f0524af120a7bdc6e8ab8ed4cbddd320291fa` — maintainer latest/path 후속 보정
+6. 이 갱신을 포함하는 별도 trailing review-doc commit
 
 Contributor commits는 그대로 두고 maintainer commit만 선형으로 이었다. 검토 판정은
 [PR #4372 검토 기록](pr_4372_review.md)에 있다.
@@ -20,7 +22,8 @@ Contributor commits는 그대로 두고 maintainer commit만 선형으로 이었
 ## 단계
 
 1. **완료:** contributor head와 기존 CI/Docker check를 접수 기준으로 고정했다.
-2. **완료:** tag/source/Cargo 검증과 prerelease latest 보호를 maintainer commit 하나로 추가했다.
+2. **완료:** tag/source/Cargo 검증, stable push 전용 latest 정책과 `.dockerignore` trigger를
+   두 maintainer code commit으로 추가했다.
 3. **완료:** focused contract tests, CI 배선, diff와 single-parent history를 검증했다.
 4. **대기:** 명시적 push 승인 뒤 maintainer correction과 review-doc commit만 source branch에
    fast-forward push하고 원격 head가 예상 SHA인지 확인한다.
@@ -33,8 +36,8 @@ Contributor commits는 그대로 두고 maintainer commit만 선형으로 이었
 ## Rollback
 
 - push 전 rollback은 visibility branch/worktree 제거로 한정된다.
-- push 뒤 merge 전에는 review-doc commit을 먼저 revert한 뒤
-  `71aecd1273864ae42b5b19fa9382aa43c8f0ef77`을 revert한다.
+- push 뒤 merge 전에는 최신 review-doc commit, `1a4f0524af120a7bdc6e8ab8ed4cbddd320291fa`,
+  최초 review-doc commit과 `71aecd1273864ae42b5b19fa9382aa43c8f0ef77`을 역순 revert한다.
 - merge 후에도 역순 revert를 사용하며 contributor history를 rebase, amend 또는 force-push하지 않는다.
 
 현재 작업에는 push나 merge 권한이 포함되지 않는다.

--- a/mydocs/pr/pr_4372_review_impl.md
+++ b/mydocs/pr/pr_4372_review_impl.md
@@ -1,0 +1,40 @@
+---
+kind: pr-review-implementation
+status: active
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-10
+---
+
+# PR #4372 메인터너 보정·통합 계획
+
+## Commit 소유권과 순서
+
+1. `c1d4da0878c94c898a4ebb903c4b9f6b46fc14b2` — contributor의 Docker CLI/GHCR 구현
+2. `91782d3364b3b8929cac00a4d449e6785d93e6a1` — contributor의 Docker context 보정
+3. `71aecd1273864ae42b5b19fa9382aa43c8f0ef77` — maintainer code/test/workflow 보정
+4. 이 문서를 포함하는 별도 trailing review-doc commit
+
+Contributor commits는 그대로 두고 maintainer commit만 선형으로 이었다. 검토 판정은
+[PR #4372 검토 기록](pr_4372_review.md)에 있다.
+
+## 단계
+
+1. **완료:** contributor head와 기존 CI/Docker check를 접수 기준으로 고정했다.
+2. **완료:** tag/source/Cargo 검증과 prerelease latest 보호를 maintainer commit 하나로 추가했다.
+3. **완료:** focused contract tests, CI 배선, diff와 single-parent history를 검증했다.
+4. **대기:** 명시적 push 승인 뒤 maintainer correction과 review-doc commit만 source branch에
+   fast-forward push하고 원격 head가 예상 SHA인지 확인한다.
+5. **대기:** code/workflow 변경이므로 Full CI fallback으로 최신 head의 CI, CodeQL,
+   Docker CLI Image build와 required aggregate를 확인한다.
+6. **대기:** 최신 mergeability와 check가 성공한 뒤 별도 merge 승인을 요청한다. 승인 전에는
+   review 게시, image publish, merge를 수행하지 않는다.
+7. **merge 후:** merge SHA와 GHCR workflow 결과를 확인하고 기록 archive 및 로컬 정리를 수행한다.
+
+## Rollback
+
+- push 전 rollback은 visibility branch/worktree 제거로 한정된다.
+- push 뒤 merge 전에는 review-doc commit을 먼저 revert한 뒤
+  `71aecd1273864ae42b5b19fa9382aa43c8f0ef77`을 revert한다.
+- merge 후에도 역순 revert를 사용하며 contributor history를 rebase, amend 또는 force-push하지 않는다.
+
+현재 작업에는 push나 merge 권한이 포함되지 않는다.

--- a/scripts/tests/test_docker_publish_workflow.py
+++ b/scripts/tests/test_docker_publish_workflow.py
@@ -1,0 +1,36 @@
+"""Docker publish workflow release-source contract."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github/workflows/docker-publish.yml"
+)
+
+
+class DockerPublishWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    def test_dispatch_builds_requested_tag_and_other_events_keep_their_ref(self) -> None:
+        self.assertIn(
+            "ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}",
+            self.workflow,
+        )
+        self.assertIn('git rev-parse --verify "refs/tags/$TAG^{commit}"', self.workflow)
+        self.assertIn('CARGO_VERSION="$(awk -F', self.workflow)
+
+    def test_prerelease_does_not_move_latest(self) -> None:
+        self.assertIn('if [[ "$VERSION" == *-* ]]', self.workflow)
+        self.assertIn("PUBLISH_LATEST: ${{ steps.ver.outputs.publish_latest }}", self.workflow)
+        latest_tag = self.workflow.index('docker tag rhwp-cli:local "$IMAGE:latest"')
+        latest_guard = self.workflow.index('if [[ "$PUBLISH_LATEST" == "true" ]]')
+        self.assertGreater(latest_tag, latest_guard)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_docker_publish_workflow.py
+++ b/scripts/tests/test_docker_publish_workflow.py
@@ -24,8 +24,15 @@ class DockerPublishWorkflowTests(unittest.TestCase):
         self.assertIn('git rev-parse --verify "refs/tags/$TAG^{commit}"', self.workflow)
         self.assertIn('CARGO_VERSION="$(awk -F', self.workflow)
 
-    def test_prerelease_does_not_move_latest(self) -> None:
-        self.assertIn('if [[ "$VERSION" == *-* ]]', self.workflow)
+    def test_dockerignore_changes_run_the_image_build(self) -> None:
+        pull_request = self.workflow.split("  workflow_dispatch:", maxsplit=1)[0]
+        self.assertIn("      - '.dockerignore'", pull_request)
+
+    def test_only_a_stable_tag_push_moves_latest(self) -> None:
+        self.assertIn(
+            'if [[ "$EVENT_NAME" == "push" && "$VERSION" != *-* ]]',
+            self.workflow,
+        )
         self.assertIn("PUBLISH_LATEST: ${{ steps.ver.outputs.publish_latest }}", self.workflow)
         latest_tag = self.workflow.index('docker tag rhwp-cli:local "$IMAGE:latest"')
         latest_guard = self.workflow.index('if [[ "$PUBLISH_LATEST" == "true" ]]')


### PR DESCRIPTION
## 변경 요약

**Docker/ghcr 유입관** — 서버·배치·에이전트 샌드박스에서 `docker run ghcr.io/edwardkim/rhwp info 문서.hwp --json` 한 줄이 열립니다. **이 채널은 별도 시크릿이 필요 없습니다**: ghcr 게시는 GITHUB_TOKEN(packages: write)만 쓰므로 **머지가 곧 활성화**입니다.

- `Dockerfile.cli` — 멀티스테이지(rust:1.93-slim-bookworm 빌드 → bookworm-slim 런타임), 비루트(uid 10001), ENTRYPOINT rhwp / CMD capabilities. **루트 Dockerfile(WASM 빌드 환경)과 완전 분리** — 그쪽은 도구 상자, 이쪽은 배포물.
- `.github/workflows/docker-publish.yml` — v* 태그·수동 실행 시 ghcr 게시(버전+latest). **PR 이 Dockerfile.cli 를 건드리면 게시 없이 빌드+capabilities/--version 스모크만 수행 — 본 PR 의 CI 가 이미지 빌드를 직접 검증합니다.**
- `.dockerignore` — samples/·node_modules 제외 추가(컨텍스트 대폭 절감, 기존 WASM 컴포즈 빌드에도 무해).

MCP 사용: `docker run --rm -i ghcr.io/edwardkim/rhwp mcp-serve" 로 stdio 서버가 그대로 붙습니다(문서 접근은 -v 마운트).

## 관련 이슈

closes #4354

## 테스트

- [x] 본 PR 의 CI(docker-publish PR 경로)가 이미지 빌드+스모크를 수행
- [ ] cargo / SVG / WASM — 해당 없음(패키징 전용, Rust 코드 무변경)
- 로컬 빌드 실증은 완료 시 코멘트로 보강

## 성능 영향 및 측정 결과

- 해당 없음

## 스크린샷

- 해당 없음
