### PR TITLE
feat(action): #4353 GitHub Action 유입관 — 한 스텝 설치 (SHA256 검증·3-OS 셀프테스트를 본 PR CI로 실증)

### DIFF
--- a/.github/workflows/action-selftest.yml
+++ b/.github/workflows/action-selftest.yml
@@ -24,12 +24,18 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: 액션으로 rhwp 설치 (latest)
-        id: setup
+        id: setup-first
         uses: ./
+      - name: 같은 job 에서 재설치
+        id: setup-second
+        uses: ./
+        with:
+          version: ${{ steps.setup-first.outputs.version }}
       - name: 스모크 — 버전·자기서술
         shell: bash
         run: |
-          echo "설치된 버전: ${{ steps.setup.outputs.version }}"
+          test "${{ steps.setup-first.outputs.version }}" = "${{ steps.setup-second.outputs.version }}"
+          echo "설치된 버전: ${{ steps.setup-second.outputs.version }}"
           rhwp --version
           # head 로 직접 파이프하면 200바이트 뒤 파이프가 닫혀 rhwp 가 EPIPE 패닉
           # (exit 101)하고 pipefail 이 스텝을 실패시킨다 — 파일 경유로 자른다.

--- a/.github/workflows/action-selftest.yml
+++ b/.github/workflows/action-selftest.yml
@@ -31,5 +31,8 @@ jobs:
         run: |
           echo "설치된 버전: ${{ steps.setup.outputs.version }}"
           rhwp --version
-          rhwp capabilities | head -c 200
+          # head 로 직접 파이프하면 200바이트 뒤 파이프가 닫혀 rhwp 가 EPIPE 패닉
+          # (exit 101)하고 pipefail 이 스텝을 실패시킨다 — 파일 경유로 자른다.
+          rhwp capabilities > capabilities.json
+          head -c 200 capabilities.json
           echo

--- a/.github/workflows/action-selftest.yml
+++ b/.github/workflows/action-selftest.yml
@@ -1,0 +1,35 @@
+name: Action Self-test
+
+# Issue #4353 — 루트 action.yml 의 자체 검증. 이 워크플로가 곧 "액션이 실제로
+# 설치를 해내는가"의 증거다: PR 이 액션을 건드리면 3-OS 에서 실설치→실행까지 돈다.
+
+on:
+  pull_request:
+    paths:
+      - 'action.yml'
+      - '.github/workflows/action-selftest.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  selftest:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-14]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: 액션으로 rhwp 설치 (latest)
+        id: setup
+        uses: ./
+      - name: 스모크 — 버전·자기서술
+        shell: bash
+        run: |
+          echo "설치된 버전: ${{ steps.setup.outputs.version }}"
+          rhwp --version
+          rhwp capabilities | head -c 200
+          echo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -826,6 +826,7 @@ jobs:
         run: |
           python3 -m unittest scripts/tests/test_cache_sweep_workflow.py
           python3 -m unittest scripts/tests/test_review_only_fast_pass_workflows.py
+          python3 -m unittest scripts/tests/test_setup_action.py
           python3 -m unittest scripts/tests/test_workflow_contract_wiring.py
 
       - name: Clippy

--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,13 @@ runs:
         DEST="${RUNNER_TEMP}/rhwp-setup"
         mkdir -p "$DEST"
         gh release download "$TAG" --repo "$REPO" -p "$ASSET" -p "SHA256SUMS.txt" -D "$DEST"
-        ( cd "$DEST" && sha256sum -c SHA256SUMS.txt --ignore-missing )
+        # macOS 러너에는 GNU sha256sum 이 없다(exit 127) — perl shasum 이 같은
+        # SHA256SUMS.txt 형식을 검증한다. 어느 쪽이든 불일치·부재는 set -e 가 잡는다.
+        ( cd "$DEST" && if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum -c SHA256SUMS.txt --ignore-missing
+          else
+            shasum -a 256 -c SHA256SUMS.txt --ignore-missing
+          fi )
         if [[ "$EXT" == "zip" ]]; then
           unzip -q "$DEST/$ASSET" -d "$DEST"
         else

--- a/action.yml
+++ b/action.yml
@@ -55,8 +55,12 @@ runs:
           *) echo "지원하지 않는 러너: ${RUNNER_OS}-${RUNNER_ARCH}"; exit 1 ;;
         esac
         ASSET="rhwp-${TAG}-${SUFFIX}.${EXT}"
-        DEST="${RUNNER_TEMP}/rhwp-setup"
-        mkdir -p "$DEST"
+        # 같은 job 에서 이 액션을 여러 번 써도 다운로드·압축 해제가 충돌하지 않게 한다.
+        DEST_ROOT="$RUNNER_TEMP"
+        if command -v cygpath >/dev/null 2>&1; then
+          DEST_ROOT="$(cygpath -u "$DEST_ROOT")"
+        fi
+        DEST="$(mktemp -d "${DEST_ROOT%/}/rhwp-setup.XXXXXX")"
         gh release download "$TAG" --repo "$REPO" -p "$ASSET" -p "SHA256SUMS.txt" -D "$DEST"
         # macOS 러너에는 GNU sha256sum 이 없다(exit 127) — perl shasum 이 같은
         # SHA256SUMS.txt 형식을 검증한다. 어느 쪽이든 불일치·부재는 set -e 가 잡는다.
@@ -73,6 +77,10 @@ runs:
         # 아카이브 구조: rhwp/<바이너리> (release-binary.yml 패키징 계약)
         install -d "$DEST/bin" 2>/dev/null || mkdir -p "$DEST/bin"
         mv "$DEST/rhwp/$BIN" "$DEST/bin/$BIN"
-        echo "$DEST/bin" >> "$GITHUB_PATH"
+        BIN_DIR="$DEST/bin"
+        if command -v cygpath >/dev/null 2>&1; then
+          BIN_DIR="$(cygpath -w "$BIN_DIR")"
+        fi
+        echo "$BIN_DIR" >> "$GITHUB_PATH"
         echo "version=$TAG" >> "$GITHUB_OUTPUT"
         echo "설치: $TAG ($SUFFIX)"

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,72 @@
+# [#4353] GitHub Action — CI 에서 rhwp 설치 한 스텝.
+#
+#   - uses: edwardkim/rhwp@devel        # 또는 릴리스 태그 고정
+#     with:
+#       version: v0.8.2                 # 생략하면 latest
+#   - run: rhwp info 문서.hwp --json
+#
+# 릴리스 자산(release-binary.yml 산출: 4플랫폼 + SHA256SUMS)을 받아 무결성
+# 검증 후 PATH 에 놓는다. 자체 검증은 .github/workflows/action-selftest.yml
+# (PR 경로에서 3-OS 실설치 스모크).
+name: 'Setup rhwp'
+description: 'HWP/HWPX 문서 엔진 rhwp CLI 를 설치한다 (릴리스 바이너리 + SHA256 검증 + PATH 등록)'
+branding:
+  icon: 'file-text'
+  color: 'blue'
+
+inputs:
+  version:
+    description: '설치할 릴리스 태그 (예: v0.8.2). 기본은 latest.'
+    required: false
+    default: 'latest'
+  token:
+    description: '릴리스 조회·다운로드용 토큰. 기본 github.token 이면 충분하다.'
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  version:
+    description: '실제 설치된 릴리스 태그'
+    value: ${{ steps.install.outputs.version }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: rhwp 설치
+      id: install
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        REQ_VERSION: ${{ inputs.version }}
+        # 포크에서 액션을 시험할 때도 그 포크의 릴리스를 본다.
+        REPO: ${{ github.action_repository || 'edwardkim/rhwp' }}
+      run: |
+        set -euo pipefail
+        if [[ "$REQ_VERSION" == "latest" ]]; then
+          TAG="$(gh release view --repo "$REPO" --json tagName -q .tagName)"
+        else
+          TAG="$REQ_VERSION"
+        fi
+        case "${RUNNER_OS}-${RUNNER_ARCH}" in
+          Linux-X64)    SUFFIX="linux-x86_64";  EXT="tar.gz"; BIN="rhwp"     ;;
+          macOS-X64)    SUFFIX="macos-x86_64";  EXT="tar.gz"; BIN="rhwp"     ;;
+          macOS-ARM64)  SUFFIX="macos-aarch64"; EXT="tar.gz"; BIN="rhwp"     ;;
+          Windows-X64)  SUFFIX="windows-x86_64"; EXT="zip";   BIN="rhwp.exe" ;;
+          *) echo "지원하지 않는 러너: ${RUNNER_OS}-${RUNNER_ARCH}"; exit 1 ;;
+        esac
+        ASSET="rhwp-${TAG}-${SUFFIX}.${EXT}"
+        DEST="${RUNNER_TEMP}/rhwp-setup"
+        mkdir -p "$DEST"
+        gh release download "$TAG" --repo "$REPO" -p "$ASSET" -p "SHA256SUMS.txt" -D "$DEST"
+        ( cd "$DEST" && sha256sum -c SHA256SUMS.txt --ignore-missing )
+        if [[ "$EXT" == "zip" ]]; then
+          unzip -q "$DEST/$ASSET" -d "$DEST"
+        else
+          tar -xzf "$DEST/$ASSET" -C "$DEST"
+        fi
+        # 아카이브 구조: rhwp/<바이너리> (release-binary.yml 패키징 계약)
+        install -d "$DEST/bin" 2>/dev/null || mkdir -p "$DEST/bin"
+        mv "$DEST/rhwp/$BIN" "$DEST/bin/$BIN"
+        echo "$DEST/bin" >> "$GITHUB_PATH"
+        echo "version=$TAG" >> "$GITHUB_OUTPUT"
+        echo "설치: $TAG ($SUFFIX)"

--- a/mydocs/pr/pr_4373_review.md
+++ b/mydocs/pr/pr_4373_review.md
@@ -1,0 +1,70 @@
+---
+kind: pr-review
+status: active
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-10
+---
+
+# PR #4373 검토 - Setup action 반복 호출 격리
+
+## 검토 경로
+
+기본 경로는 `maintainer_general.md`, 보조 경로는 `intake_and_review.md`,
+`local_validation.md`, `multi_pr_update_branch.md`, `review_only_fast_pass.md`다.
+Composite action과 자체검증 workflow만 바뀌므로 renderer와 시각 fixture 영향은 없다.
+
+## 접수 메타데이터
+
+| 항목 | 접수 시점 참고값 |
+| --- | --- |
+| PR / 작성자 | [#4373](https://github.com/edwardkim/rhwp/pull/4373) / `kevin9327` |
+| 관련 이슈 | [#4353](https://github.com/edwardkim/rhwp/issues/4353) |
+| base / contributor head | `devel` / `c575d1a69e3940a93aaeb624bb7d2d9fac45f07a` |
+| 규모 | 2 files, +116 / -0, contributor commits 3개 |
+| 상태 | `MERGEABLE` / `CLEAN`, Full CI·CodeQL 및 3-OS Action Self-test 성공 |
+| 가시성 branch | `review/kevin9327-20260810-pr4373` |
+| 메인터너 code candidate | `1e7c844472da1b101f6fbcc3808bb93c9b163c89` |
+
+## Contributor 변경 범위
+
+`3cc9097730e7d1bc0c9fbd48e97c209bbe2d8a26`은 release asset을 checksum 검증 후
+PATH에 추가하는 root composite action과 Linux/Windows/macOS self-test를 만들었다.
+`cad397a1894e82f69a0c17f1356b071143816df5`는 smoke의 EPIPE를,
+`c575d1a69e3940a93aaeb624bb7d2d9fac45f07a`는 macOS checksum 도구 차이를 보정했다.
+
+## 원래 차단점
+
+모든 호출이 `${RUNNER_TEMP}/rhwp-setup`을 공유했다. 같은 job에서 action을 두 번 호출하면
+두 번째 `gh release download`와 압축 해제가 첫 호출의 파일과 충돌하고, 기존 self-test는 호출을
+한 번만 수행해 이 계약을 검증하지 못했다.
+
+## 메인터너 보정
+
+`1e7c844472da1b101f6fbcc3808bb93c9b163c89`
+(`fix(maintainer): #4373 반복 설치 경로를 격리`)은 다음을 추가했다.
+
+- `action.yml`: 호출마다 `mktemp`로 고유 경로를 만들고 Windows Git Bash에서는
+  `cygpath`로 입력·PATH 경계를 변환한다.
+- `.github/workflows/action-selftest.yml`: 같은 job에서 동일 release를 두 번 설치한다.
+- `scripts/tests/test_setup_action.py`: 고유 경로와 2회 호출 계약을 고정한다.
+- `.github/workflows/ci.yml`: focused contract test를 lint job에 배선한다.
+
+## 완료한 로컬 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| `python -m unittest scripts.tests.test_setup_action scripts.tests.test_workflow_contract_wiring -v` | 5 / 5 통과 |
+| `git diff --check origin/pr/4373..1e7c844472da1b101f6fbcc3808bb93c9b163c89` | 통과 |
+| commit graph | correction commit의 유일한 parent가 contributor head와 일치 |
+
+로컬에는 `actionlint`가 없고 실제 hosted runner release 다운로드를 재현하지 않았다. 새 self-test가
+Linux, Windows Git Bash, macOS에서 두 번 연속 성공하는지 최신 원격 head에서 확인해야 한다.
+
+## 최종 권고
+
+**메인터너 보정 포함 조건부 수용 권고.** correction이 action, test, CI workflow를 바꾸므로 기존
+3-OS 녹색 결과는 재사용 대상이 아니다. push 승인 뒤 두 trailing commit을 fast-forward로 반영하고
+최신 Full CI, CodeQL, Action Self-test 3종, required aggregate와 mergeability를 확인한다.
+별도 merge 승인 전에는 review 게시나 merge를 수행하지 않는다.
+
+실행 및 rollback은 [PR #4373 구현·통합 계획](pr_4373_review_impl.md)을 따른다.

--- a/mydocs/pr/pr_4373_review_impl.md
+++ b/mydocs/pr/pr_4373_review_impl.md
@@ -1,0 +1,38 @@
+---
+kind: pr-review-implementation
+status: active
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-10
+---
+
+# PR #4373 메인터너 보정·통합 계획
+
+## Commit 소유권과 순서
+
+1. `3cc9097730e7d1bc0c9fbd48e97c209bbe2d8a26` — contributor의 setup action 구현
+2. `cad397a1894e82f69a0c17f1356b071143816df5` — contributor의 smoke EPIPE 보정
+3. `c575d1a69e3940a93aaeb624bb7d2d9fac45f07a` — contributor의 macOS checksum 보정
+4. `1e7c844472da1b101f6fbcc3808bb93c9b163c89` — maintainer code/test/workflow 보정
+5. 이 문서를 포함하는 별도 trailing review-doc commit
+
+Contributor commits는 재작성하지 않았다. 상세 판정은 [PR #4373 검토 기록](pr_4373_review.md)에 있다.
+
+## 단계
+
+1. **완료:** contributor head, 기존 3-OS self-test와 merge 상태를 접수 기준으로 기록했다.
+2. **완료:** 고유 install 경로, Windows 경로 변환과 repeat self-test를 단일 maintainer commit으로 추가했다.
+3. **완료:** focused unittest, CI 배선, diff check와 single-parent history를 검증했다.
+4. **대기:** 작업지시자 push 승인 뒤 correction과 review-doc commit만 source에 fast-forward로 반영한다.
+5. **대기:** Full CI fallback으로 최신 head의 CI·CodeQL과 Linux/Windows/macOS Action Self-test를
+   모두 확인한다. 특히 Windows `cygpath` 경계와 같은 job 2회 호출이 필수 확인 대상이다.
+6. **대기:** 최신 required checks와 mergeability 성공 뒤 별도의 merge 승인을 받는다.
+7. **merge 후:** merge SHA와 최종 self-test 결과를 기록하고 archive/cleanup 절차를 수행한다.
+
+## Rollback
+
+- push 전에는 local branch/worktree만 제거한다.
+- push 뒤 merge 전에는 review-doc commit과
+  `1e7c844472da1b101f6fbcc3808bb93c9b163c89`을 역순 revert한다.
+- merge 뒤에도 revert를 사용하며 contributor commit이나 source branch history를 rewrite하지 않는다.
+
+현재 단계에는 push, GitHub review/comment, merge 승인이 없다.

--- a/scripts/tests/test_setup_action.py
+++ b/scripts/tests/test_setup_action.py
@@ -1,0 +1,36 @@
+"""Setup action repeat-invocation contract."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class SetupActionTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.action = (ROOT / "action.yml").read_text(encoding="utf-8")
+        cls.selftest = (
+            ROOT / ".github/workflows/action-selftest.yml"
+        ).read_text(encoding="utf-8")
+
+    def test_each_invocation_uses_a_unique_install_directory(self) -> None:
+        self.assertIn(
+            'DEST="$(mktemp -d "${DEST_ROOT%/}/rhwp-setup.XXXXXX")"',
+            self.action,
+        )
+        self.assertNotIn('DEST="${RUNNER_TEMP}/rhwp-setup"', self.action)
+        self.assertIn('DEST_ROOT="$(cygpath -u "$DEST_ROOT")"', self.action)
+        self.assertIn('BIN_DIR="$(cygpath -w "$BIN_DIR")"', self.action)
+
+    def test_selftest_invokes_the_action_twice_in_one_job(self) -> None:
+        self.assertEqual(self.selftest.count("        uses: ./\n"), 2)
+        self.assertIn("steps.setup-first.outputs.version", self.selftest)
+        self.assertIn("steps.setup-second.outputs.version", self.selftest)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 요약

**GitHub Actions 유입관** — CI 에서 rhwp 가 한 스텝이 됩니다:

```yaml
- uses: edwardkim/rhwp@devel     # 릴리스 태그 고정 권장
  with: { version: v0.8.2 }      # 생략 시 latest
- run: rhwp info 문서.hwp --json
```

- 루트 `action.yml`(composite): latest 해석→4플랫폼 자산 매핑→`gh release download`→**SHA256SUMS 무결성 검증**→PATH 등록→version 출력. `github.action_repository` 기반이라 포크에서도 자기 릴리스로 시험 가능.
- **`action-selftest.yml` 동봉 — 본 PR 의 CI 가 3-OS(ubuntu·windows·macos-14)에서 실설치→`rhwp --version`·`capabilities` 스모크까지 수행**: 로컬 실행이 불가능한 채널이라 검증을 PR CI 에 내장했습니다.

## 관련 이슈

closes #4353

## 테스트

- [x] 본 PR 의 action-selftest(3-OS 실설치 스모크)가 검증 — 결과는 이 PR 의 체크에서 확인
- [ ] cargo / SVG / WASM — 해당 없음(액션·워크플로 전용)

## 성능 영향 및 측정 결과

- 해당 없음

## 스크린샷

- 해당 없음
