### PR TITLE
renderer: PartialTable 조각의 행 좌표계를 데이터로 고정하고 되추론 제거

### DIFF
--- a/mydocs/working/task_m100_4326_stage1.md
+++ b/mydocs/working/task_m100_4326_stage1.md
@@ -1,0 +1,90 @@
+# task_m100_4326 Stage 1 — PartialTable 행 좌표계를 데이터로 고정
+
+- **이슈**: [#4326](https://github.com/edwardkim/rhwp/issues/4326)
+- **PR**: [#4374](https://github.com/edwardkim/rhwp/pull/4374)
+- **브랜치**: `fix/issue-4326-partial-table-row-coords`
+- **분기 기준**: `upstream/devel` `e48fe8694`
+- **상태**: 로컬 전체 검증 + Skia 3종 + wasm-pack + 시각 증적 통과, PR 게시
+- **기록일**: 2026-08-09 KST
+
+## 1. 결함 — 값으로 되추론했다
+
+투명 1×1 래퍼 안에 든 표는 페이지네이션이 래퍼를 벗기고 **중첩 표의 행**으로 커서를 잡을 수 있다.
+그런데 `PageItem::PartialTable`(`renderer/pagination.rs:488`)은 `start_row`/`end_row`/`start_cut`/
+`end_cut` 만 실을 뿐 **그 값이 어느 좌표계인지 담지 않았다.**
+
+렌더러가 값으로 되추론했다(`layout/table_partial.rs:80` 부근):
+
+```rust
+fn fragment_row_geometry_table(table: &Table, end_row: usize) -> &Table {
+    if end_row <= table.row_count as usize { table } else { transparent_nested_table(table) }
+}
+```
+
+**중첩 표의 진짜 단일 행 조각(`end_row == 1`)은 "바깥 래퍼의 자기 행 0"과 값으로 구분되지 않는다.**
+래퍼를 벗겨야 할 때 안 벗기고, 표가 두 쪽에 중복 인쇄되며 본문 영역을 넘는다.
+
+## 2. 재현
+
+`samples/76076_regulatory_analysis.hwp` para 36(3×3 중첩 표를 감싼 투명 1×1 RowBreak 래퍼),
+`page_def.margin_bottom` +500 HWPUNIT:
+
+```
+수정 전: LAYOUT_OVERFLOW: page=5, type=PartialTable, y=1104.8, bottom=1040.2, overflow=64.5px
+         p5 에 세 행 전부 재출력, p6 에 "현행유지안" 중복 인쇄
+수정 후: overflow 없음. p5 = 제목행만, p6 = 나머지 두 행
+```
+
+`git stash` 로 수정을 껐다 켜서 양방향 확인했다.
+
+## 3. 구현 — 결정 시점에 데이터화
+
+`PageItem::PartialTable` 에 `row_cursor_is_nested: bool` 추가. 값은 페이지네이션 결정 시점에 포인터
+비교로 계산한다(`typeset.rs`, `step_block_table_continuation`):
+
+```rust
+let row_cursor_is_nested = !std::ptr::eq(row_geometry_table, table);
+```
+
+`fragment_row_geometry_table` **삭제**. 플래그를 `PageItem` → `layout_partial_table_item` →
+`layout_partial_table` → `layout_partial_table_resolved` 로 관통 전달하고, 캐럿 fast-path
+(`cursor_rect.rs`)도 같은 필드를 받는다.
+
+**핵심 적대 검증**: `row_geometry_table` 은 `hwp5_single_cell_rowbreak_wrapper` 분기에서 `table`
+**자신**을 대입한다(`typeset.rs:19406-19410`). 따라서 네이티브 RowBreak 래퍼가 자기 프레임을 지켜야
+하는 경로(#1921 p16, #3637 HWP 2020 p7)는 `ptr::eq` 가 참 → 플래그 `false` → 종전 동작 그대로다.
+값 기반 되추론이 구분하지 못하던 것을 결정 자체가 기록한다.
+
+fallback `Paginator`(`pagination/engine.rs`, `RHWP_USE_PAGINATOR=1`)도 같은 이중 표 모델을 공유해
+같은 결함이 잠재해 있어 함께 채웠다.
+
+`PageItem` 은 `#[derive(Debug)]` 뿐이라 필드 추가에 직렬화·캐시 호환성 영향이 없음을 확인했다.
+
+## 4. 시각 증적 — 두 경로 각각
+
+처음에는 옵션 없는 `export-svg` 대조만 하고 "시각 증적"이라 적었는데, 그것이 paint 계층을 거치지
+않는 legacy 경로임이 드러나(→ #4379) 표현을 좁히고 두 경로를 각각 다시 쟀다.
+
+| 경로 | 명령 | 결과 |
+|---|---|---|
+| legacy(렌더 트리 직행) | `export-svg` | 82/82 바이트 동일 |
+| paint 계층 | `export-svg --profile print` | 82/82 바이트 동일 |
+
+baseline 은 `upstream/devel` `e48fe8694`. 무변경 문서에서 렌더 변화가 없다 — 결함은 쪽 기하가
+흔들릴 때만 드러난다.
+
+## 5. 범위 밖
+
+fallback `Paginator` 의 기존 발산(#1921 p11/p36)은 손대지 않았다 — `git stash` 로 이 변경을 뺀
+상태에서도 동일하게 실패하는 사전 결함이다.
+
+## 6. 검증 (완료)
+
+- 회귀 테스트 `tests/issue_4326_partial_table_nested_row_coords.rs` 신설(baseline + margin+500).
+  수정 전 코드에서 실패함을 확인했다.
+- `cargo test --profile release-test --tests` 전체 통과. `table` 필터 635건 통과.
+- Native Skia 3종 통과, `wasm-pack build` 성공.
+- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` 통과.
+- 시각 증적 두 경로(위 4절).
+
+남은 미래 조건은 GitHub Actions 와 작업지시자 승인, merge 다.

--- a/src/document_core/queries/cursor_rect.rs
+++ b/src/document_core/queries/cursor_rect.rs
@@ -3053,6 +3053,7 @@ impl DocumentCore {
             start_cut,
             end_cut,
             is_block_split,
+            row_cursor_is_nested,
         }) = col.items.first()
         else {
             return Ok(Unsupported);
@@ -3291,6 +3292,7 @@ impl DocumentCore {
             start_cut,
             end_cut,
             *is_block_split,
+            *row_cursor_is_nested,
             pt_margin_left,
             pt_margin_right,
             pt_mt,
@@ -6346,6 +6348,7 @@ mod tests {
                         start_cut,
                         end_cut,
                         is_block_split,
+                        ..
                     } = item
                     {
                         if *para_index == host_pi && *control_index == host_ci {

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -6855,6 +6855,7 @@ impl LayoutEngine {
                 start_cut,
                 end_cut,
                 is_block_split,
+                row_cursor_is_nested,
             } => {
                 y_offset = self.layout_partial_table_item(
                     tree,
@@ -6868,6 +6869,7 @@ impl LayoutEngine {
                     start_cut,
                     end_cut,
                     *is_block_split,
+                    *row_cursor_is_nested,
                     &ctx,
                     y_offset,
                 );
@@ -8404,6 +8406,7 @@ impl LayoutEngine {
         start_cut: &[usize],
         end_cut: &[usize],
         is_block_split: bool,
+        row_cursor_is_nested: bool,
         ctx: &ColumnItemCtx,
         mut y_offset: f64,
     ) -> f64 {
@@ -8585,6 +8588,7 @@ impl LayoutEngine {
             start_cut,
             end_cut,
             is_block_split,
+            row_cursor_is_nested,
             pt_margin_left,
             pt_margin_right,
             pt_mt,

--- a/src/renderer/layout/table_partial.rs
+++ b/src/renderer/layout/table_partial.rs
@@ -72,22 +72,6 @@ fn transparent_nested_table(table: &crate::model::table::Table) -> &crate::model
     transparent_nested_table(nested)
 }
 
-/// Resolves the table that owns a `PartialTable` row cursor.
-///
-/// Pagination only names an inner table's rows when a cursor lies outside the
-/// outer wrapper's one-row domain.  Keep a genuine 1×1 outer table intact until
-/// that proof exists; it may own a deliberate visible frame.
-fn fragment_row_geometry_table(
-    table: &crate::model::table::Table,
-    end_row: usize,
-) -> &crate::model::table::Table {
-    if end_row <= table.row_count as usize {
-        table
-    } else {
-        transparent_nested_table(table)
-    }
-}
-
 /// 분할 셀 조각에서 실제로 보이는 첫 줄의 저장 vpos를 찾는다.
 ///
 /// `cell_line_ranges_from_cut`은 문단 중간 줄에서 시작할 수 있다. 문단 첫 줄을
@@ -2347,6 +2331,11 @@ impl LayoutEngine {
                                             &recursive_cut.start_cut,
                                             &recursive_cut.end_cut,
                                             recursive_cut.is_block_split,
+                                            // recursive_cut의 행 cursor는 이미 이 호출의
+                                            // `nested_table` 자신의 행 기준(#4069 재귀
+                                            // 투영)이다. 투명 래퍼 벗기기는 별개 좌표계
+                                            // 판정(#4326)이라 여기서는 항상 false.
+                                            false,
                                             0.0,
                                             0.0,
                                             None,
@@ -2514,6 +2503,7 @@ impl LayoutEngine {
         start_cut: &[usize],
         end_cut: &[usize],
         is_block_split: bool,
+        row_cursor_is_nested: bool,
         host_margin_left: f64,
         host_margin_right: f64,
         measured_table: Option<&MeasuredTable>,
@@ -2571,6 +2561,7 @@ impl LayoutEngine {
             start_cut,
             end_cut,
             is_block_split,
+            row_cursor_is_nested,
             host_margin_left,
             host_margin_right,
             measured_table,
@@ -2604,6 +2595,7 @@ impl LayoutEngine {
         start_cut: &[usize],
         end_cut: &[usize],
         is_block_split: bool,
+        row_cursor_is_nested: bool,
         host_margin_left: f64,
         host_margin_right: f64,
         measured_table: Option<&MeasuredTable>,
@@ -2620,25 +2612,28 @@ impl LayoutEngine {
             host_line_spacing,
         } = host;
 
-        // Pagination can deliberately use the rows of a transparent 1×1 wrapper's
-        // nested table.  The measured-table path has used that effective table since
-        // the wrapper-unwrapping rule was introduced, but a `PartialTable` still
-        // identifies its source by the outer control.  Rendering the outer 1-row
-        // table with an inner-table row cursor made a continuation beginning at row
-        // 1 paint no remaining rows at all (#3637, HWP 2020 p7).
+        // [Issue #4326] Pagination can deliberately use the rows of a transparent
+        // 1×1 wrapper's nested table.  The measured-table path has used that
+        // effective table since the wrapper-unwrapping rule was introduced, but a
+        // `PartialTable` used to identify its source by the outer control alone —
+        // whether `start_row`/`end_row` addressed the outer table's own row domain
+        // or the unwrapped nested table's was reconstructed here from
+        // `end_row <= outer_table.row_count`. That inference collided with a
+        // genuine single-row fragment of the *nested* table (`end_row == 1`),
+        // which is indistinguishable by value from "the outer wrapper's own row 0"
+        // (#4326: `margin_bottom` sweep flips 24/40 values into duplicate-printed,
+        // body-overflowing table fragments). `row_cursor_is_nested` now carries
+        // that coordinate-system decision from pagination as data, so this is a
+        // direct dispatch rather than a second heuristic.
         //
-        // Only unwrap when the fragment cursor is outside the outer table's row
-        // domain.  A genuine 1×1 table containing a nested table can otherwise be
-        // intentionally rendered as its own one-row frame.
-        // A native HWP5 RowBreak wrapper owns its physical clip/frame only
-        // while the partial cursor still names its own outer row.  Once the
-        // cursor is outside that one-row domain, pagination has selected rows
-        // of the transparent nested content table.  Sending that cursor back
-        // through the outer wrapper paints the whole inner table in one page
-        // fragment (#1921 p16).  `fragment_row_geometry_table` preserves the
-        // outer table for its own row domain, so issue2007's native frame path
-        // remains intact.
-        let table = fragment_row_geometry_table(outer_table, end_row);
+        // A native HWP5 RowBreak wrapper owns its physical clip/frame only while
+        // the partial cursor still names its own outer row (#1921 p16, #3637, HWP
+        // 2020 p7); `row_cursor_is_nested == false` preserves that path unchanged.
+        let table = if row_cursor_is_nested {
+            transparent_nested_table(outer_table)
+        } else {
+            outer_table
+        };
 
         if table.cells.is_empty() {
             return y_start;

--- a/src/renderer/page_number.rs
+++ b/src/renderer/page_number.rs
@@ -226,6 +226,7 @@ mod tests {
             start_cut: Vec::new(),
             end_cut: Vec::new(),
             is_block_split: false,
+            row_cursor_is_nested: false,
         }]);
         assert_eq!(a.assign(&p1), 1);
 
@@ -239,6 +240,7 @@ mod tests {
             start_cut: Vec::new(),
             end_cut: Vec::new(),
             is_block_split: false,
+            row_cursor_is_nested: false,
         }]);
         assert_eq!(a.assign(&p2), 2);
     }

--- a/src/renderer/pagination.rs
+++ b/src/renderer/pagination.rs
@@ -506,6 +506,12 @@ pub enum PageItem {
         /// (`advance_row_block_cut`). false 이면 단일 행 `row_span==1` col 인덱스
         /// (`advance_row_cut`, 기존). page-larger 셀 내부 분할에서만 true.
         is_block_split: bool,
+        /// [Issue #4326] `start_row`/`end_row`/`start_cut`/`end_cut`이 가리키는 좌표계.
+        /// true면 투명 1×1 래퍼를 벗긴 중첩 표(측정기·`row_geometry_table`이 실제로 쓰는
+        /// 표) 기준이고, false면 이 항목이 참조하는 바깥 `para_index`/`control_index`
+        /// 표 자신의 행 도메인 기준이다. 렌더러가 값(`end_row <= table.row_count`)으로
+        /// 되추론하던 것을 페이지네이션 결정 시점에 데이터로 고정한다.
+        row_cursor_is_nested: bool,
     },
     /// 그리기 개체
     Shape {
@@ -637,6 +643,7 @@ impl PageItem {
                 start_cut,
                 end_cut,
                 is_block_split,
+                row_cursor_is_nested,
             } => PageItem::PartialTable {
                 para_index: adjust(*para_index),
                 control_index: *control_index,
@@ -646,6 +653,7 @@ impl PageItem {
                 start_cut: start_cut.clone(),
                 end_cut: end_cut.clone(),
                 is_block_split: *is_block_split,
+                row_cursor_is_nested: *row_cursor_is_nested,
             },
             PageItem::Shape {
                 para_index,

--- a/src/renderer/pagination/engine.rs
+++ b/src/renderer/pagination/engine.rs
@@ -2375,6 +2375,13 @@ impl Paginator {
         spacing_before_px: f64,
         _is_tac_table: bool,
     ) {
+        // [Issue #4326] `mt`(MeasuredTable)는 `HeightMeasurer::measure_table_impl`이
+        // 투명 1×1 래퍼를 벗긴 표를 기준으로 만들어질 수 있다 — `row_count`/`row_heights`가
+        // `table`(바깥 컨트롤 표) 자신의 행 수와 다를 수 있다는 뜻이다. 이 함수가 아래에서
+        // 방출하는 모든 PartialTable의 start_row/end_row는 그 `mt` 기준이므로, 같은 unwrap
+        // 규칙(`row_geometry_table`)으로 좌표계를 판정해 PageItem에 데이터로 싣는다.
+        let row_cursor_is_nested =
+            !std::ptr::eq(crate::renderer::typeset::row_geometry_table(table), table);
         let row_count = mt.row_heights.len();
         let cs = mt.cell_spacing;
         let header_row_height = if row_count > 0 {
@@ -2737,6 +2744,7 @@ impl Paginator {
                         start_cut: Vec::new(),
                         end_cut: Vec::new(),
                         is_block_split: false,
+                        row_cursor_is_nested,
                     });
                     // 마지막 부분 표: spacing_after도 포함 (레이아웃과 일치)
                     let mp = measured.get_measured_paragraph(para_idx);
@@ -2756,6 +2764,7 @@ impl Paginator {
                 start_cut: Vec::new(),
                 end_cut: Vec::new(),
                 is_block_split: false,
+                row_cursor_is_nested,
             });
             st.advance_column_or_new_page();
 

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -2659,7 +2659,12 @@ fn is_stored_anchor_picture_table(table: &crate::model::table::Table) -> bool {
 /// 동작한다. 두 경로가 다른 표를 참조하면 행 수가 1 대 N으로 갈라져, 보이지
 /// 않는 래퍼 행 높이가 쪽 소비에 더해진다. `table_layout` 및
 /// `HeightMeasurer::measure_table_impl`의 unwrap 조건과 의도적으로 동일하다.
-fn row_geometry_table(table: &crate::model::table::Table) -> &crate::model::table::Table {
+///
+/// [Issue #4326] fallback `Paginator`(`pagination/engine.rs`)도 같은 unwrap 여부를
+/// `PageItem::PartialTable::row_cursor_is_nested`에 실어야 하므로 crate 내부에 공개한다.
+pub(crate) fn row_geometry_table(
+    table: &crate::model::table::Table,
+) -> &crate::model::table::Table {
     let mut effective = table;
     loop {
         if effective.row_count != 1 || effective.col_count != 1 || effective.cells.len() != 1 {
@@ -12154,6 +12159,7 @@ impl TypesetEngine {
                         start_cut,
                         end_cut,
                         is_block_split,
+                        row_cursor_is_nested,
                     } => lookup_local(*para_index).map(|l| PageItem::PartialTable {
                         para_index: l + 1,
                         control_index: *control_index,
@@ -12163,6 +12169,7 @@ impl TypesetEngine {
                         start_cut: start_cut.clone(),
                         end_cut: end_cut.clone(),
                         is_block_split: *is_block_split,
+                        row_cursor_is_nested: *row_cursor_is_nested,
                     }),
                     PageItem::Shape {
                         para_index,
@@ -20287,6 +20294,11 @@ impl TypesetEngine {
         let row_geometry_table = source.row_geometry_table;
         let mt = source.measured_table;
         let styles = source.styles;
+        // [Issue #4326] 이 continuation이 방출하는 모든 PartialTable의 start_row/end_row/
+        // start_cut/end_cut은 `row_geometry_table` 기준(투명 1×1 래퍼를 벗긴 표일 수
+        // 있다)이다. 렌더러가 `end_row <= table.row_count` 로 값을 되추론하던 것을,
+        // 결정 시점의 이 포인터 비교로 데이터화해 PageItem에 함께 싣는다.
+        let row_cursor_is_nested = !std::ptr::eq(row_geometry_table, table);
         // [#2424 프로파일] fragment 루프 하위 단계 누적 — closure 1회 = fragment 판정 1회.
         // 스캔 두 곳 외의 잔여(배치·각주 큐·커서 전진)는 total−scan−refit 로 산출한다.
         let issue2424_step_enabled =
@@ -20829,6 +20841,7 @@ impl TypesetEngine {
                         start_cut: continuation.start_cut.clone(),
                         end_cut: Vec::new(),
                         is_block_split: start_cut_is_block,
+                        row_cursor_is_nested,
                     });
                     // 마지막 fragment: spacing_after만 포함 (Paginator engine.rs:1051 동일)
                     // host line advance/positive offset은 원 anchor 조각의 계약이며,
@@ -20905,6 +20918,7 @@ impl TypesetEngine {
                 end_cut: split_end_cut.clone(),
                 // [Task #1025] 이번 분할이 블록 분할이거나 start_cut 이 이미 블록 인덱스.
                 is_block_split: split_block_start.is_some() || start_cut_is_block,
+                row_cursor_is_nested,
             });
             // [#2238] 중간 fragment 가시높이 부기 — used_height(flush 시 current_height)
             // 표시용. advance 직후 current_height 가 리셋되므로 흐름/기하 불변.
@@ -22808,6 +22822,7 @@ mod tests {
                 start_cut: Vec::new(),
                 end_cut: Vec::new(),
                 is_block_split: false,
+                row_cursor_is_nested: false,
             }]),
             page_with_items(vec![PageItem::PartialTable {
                 para_index: 7,
@@ -22818,6 +22833,7 @@ mod tests {
                 start_cut: Vec::new(),
                 end_cut: Vec::new(),
                 is_block_split: false,
+                row_cursor_is_nested: false,
             }]),
         ];
 

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -25468,6 +25468,7 @@ fn issue2214_target_cuts(doc: &HwpDocument) -> Vec<Issue2214TargetCut> {
                         start_cut,
                         end_cut,
                         is_block_split,
+                        ..
                     } => Some(Issue2214TargetCut {
                         page_index: page.page_index,
                         start_row: *start_row,

--- a/tests/issue_4326_partial_table_nested_row_coords.rs
+++ b/tests/issue_4326_partial_table_nested_row_coords.rs
@@ -1,0 +1,166 @@
+//! Issue #4326 — 중첩 표 PartialTable 조각의 행 좌표계가 데이터에 없어
+//! 렌더러 되추론이 틀리는 문제 회귀.
+//!
+//! `samples/76076_regulatory_analysis.hwp` para 36은 빈 셀 하나짜리 투명 1×1
+//! RowBreak 래퍼가 3×3 중첩 표(`구분/장점/단점` 제목행 + `현행유지안`/`규제대안`
+//! 본문 2행)를 감싼다. 페이지네이터는 이 래퍼를 벗기고 중첩 표의 행 기준으로
+//! 페이지를 나누지만, 예전에는 그 `PartialTable` 조각이 바깥 컨트롤의
+//! `para_index`/`control_index`로만 식별되고 "이 행 좌표가 바깥 1행 래퍼
+//! 자신의 것인지 벗겨낸 중첩 표의 것인지"는 어디에도 기록되지 않았다.
+//! 렌더러는 `end_row <= table.row_count`로 값을 되추론했는데, 중첩 표의 첫
+//! 행만 담은 조각(`end_row == 1`)이 바깥 1행 래퍼 자신의 행 0과 값으로
+//! 구별되지 않아 잘못 라우팅됐다 — 표 전체가 앞 페이지에 다시 그려지고
+//! (본문 영역을 넘어 꼬리말까지 침범), 뒤 페이지에 마지막 행들이 중복
+//! 인쇄됐다.
+//!
+//! `page_def.margin_bottom`를 조금 늘리면(+500 HWPUNIT, 약 1.8mm) 조각 경계가
+//! 중첩 표의 행 1 바로 앞으로 옮겨가 이 경로를 그대로 재현한다. 이 테스트는
+//! 그 여백에서 앞 쪽에 중첩 표의 행 하나만 담기고, 뒤 쪽에 나머지 행이
+//! 중복 없이 이어지는지 고정한다.
+
+use std::fs;
+use std::path::Path;
+
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+use rhwp::wasm_api::HwpDocument;
+
+const SAMPLE: &str = "samples/76076_regulatory_analysis.hwp";
+const TARGET_PARA: usize = 36;
+
+fn load() -> HwpDocument {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    HwpDocument::from_bytes(&bytes).unwrap_or_else(|e| panic!("parse {SAMPLE}: {e}"))
+}
+
+/// 여백을 조정한 재-페이지네이션 결과. `set_document`는 테스트/네이티브
+/// 전용 API로, IR을 다시 넣고 dirty 표시 + 전체 재페이지네이션까지 수행한다.
+fn load_with_margin_bottom_delta(delta_hu: i32) -> HwpDocument {
+    let mut core = load();
+    let mut doc = core.document().clone();
+    for section in &mut doc.sections {
+        let pd = &mut section.section_def.page_def;
+        pd.margin_bottom = (pd.margin_bottom as i32 + delta_hu).max(0) as u32;
+    }
+    core.set_document(doc);
+    core
+}
+
+fn collect_table_text(node: &RenderNode, para_index: usize, out: &mut String) {
+    if let RenderNodeType::Table(meta) = &node.node_type {
+        if meta.para_index == Some(para_index) {
+            collect_all_text(node, out);
+            return;
+        }
+    }
+    for child in &node.children {
+        collect_table_text(child, para_index, out);
+    }
+}
+
+fn collect_all_text(node: &RenderNode, out: &mut String) {
+    if let RenderNodeType::TextRun(run) = &node.node_type {
+        out.push_str(&run.text);
+    }
+    for child in &node.children {
+        collect_all_text(child, out);
+    }
+}
+
+/// para=36 표 fragment의 렌더 텍스트(공백 제거) — 페이지에 없으면 빈 문자열.
+fn table_fragment_text(doc: &HwpDocument, page: u32) -> String {
+    let tree = doc
+        .build_page_render_tree(page)
+        .unwrap_or_else(|e| panic!("render {SAMPLE} page {page}: {e}"));
+    let mut text = String::new();
+    collect_table_text(&tree.root, TARGET_PARA, &mut text);
+    text.chars().filter(|c| !c.is_whitespace()).collect()
+}
+
+/// [Issue #4326] 여백을 +1.8mm 늘려 조각 경계가 중첩 표의 행 1 앞으로
+/// 옮겨가는 조건(`end_row == 1`이 중첩 표 좌표인 경우)을 직접 재현한다.
+/// 고친 코드는 앞 쪽에 제목행만, 뒤 쪽에 나머지 두 행만 중복 없이 담아야 한다.
+#[test]
+fn nested_wrapper_row_cursor_does_not_duplicate_or_overflow() {
+    let doc = load_with_margin_bottom_delta(500);
+
+    let mut owner_page = None;
+    let mut combined = String::new();
+    for page in 0..doc.page_count() {
+        let text = table_fragment_text(&doc, page);
+        if text.is_empty() {
+            continue;
+        }
+        if owner_page.is_none() {
+            owner_page = Some(page);
+        }
+        combined.push_str(&text);
+    }
+    let first_page = owner_page.expect("para=36 표가 어느 페이지에도 렌더되지 않음");
+    let page_a = table_fragment_text(&doc, first_page);
+    let page_b = table_fragment_text(&doc, first_page + 1);
+
+    // 제목행(구분/장점/단점)은 앞 조각에만 있어야 한다 — 중첩 표는 항상 행0부터 시작.
+    assert!(
+        page_a.contains("구분") && page_a.contains("장점") && page_a.contains("단점"),
+        "표 제목행이 첫 fragment(page {first_page})에 있어야 함: {page_a:?}"
+    );
+    assert!(
+        !page_b.contains("구분"),
+        "표 제목행이 다음 fragment(page {})에 중복되면 안 됨: {page_b:?}",
+        first_page + 1
+    );
+
+    // 본문 두 행("현행유지안"/"규제대안")은 어느 한쪽에만 있어야 한다 —
+    // 고친 코드는 이 여백에서 둘 다 뒤 fragment로 보낸다(제목행만 앞).
+    let row1_in_a = page_a.contains("현행유지안");
+    let row1_in_b = page_b.contains("현행유지안");
+    assert_ne!(
+        row1_in_a, row1_in_b,
+        "'현행유지안' 행이 두 fragment에 걸쳐 중복되거나 누락됨: page_a={page_a:?}, page_b={page_b:?}"
+    );
+    let row2_in_a = page_a.contains("규제대안");
+    let row2_in_b = page_b.contains("규제대안");
+    assert_ne!(
+        row2_in_a, row2_in_b,
+        "'규제대안' 행이 두 fragment에 걸쳐 중복되거나 누락됨: page_a={page_a:?}, page_b={page_b:?}"
+    );
+
+    // [핵심 회귀] 되추론 버그는 앞 fragment에 표 세 행을 통째로(제목+본문 2행)
+    // 다시 그렸다 — 앞 fragment 텍스트 길이가 뒤 fragment와 맞먹거나 넘었다.
+    // 고친 코드는 앞 fragment에 제목행 하나만 담아 훨씬 짧다.
+    assert!(
+        page_a.chars().count() < page_b.chars().count(),
+        "앞 fragment가 뒤 fragment만큼 길다 — 표 전체가 앞 페이지에 다시 그려진 \
+         되추론 버그로 회귀했을 수 있음: page_a={page_a:?} ({} chars), page_b={page_b:?} ({} chars)",
+        page_a.chars().count(),
+        page_b.chars().count()
+    );
+
+    // 각 마커는 문서 전체에서 정확히 한 번만 나타나야 한다(위치 무관 총 중복 검사).
+    for marker in ["구분", "현행유지안", "규제대안"] {
+        let count = combined.matches(marker).count();
+        assert_eq!(
+            count, 1,
+            "'{marker}' 마커가 {count}번 나타남(정확히 1번이어야 함): combined={combined:?}"
+        );
+    }
+}
+
+/// 기준 여백(문서 원본 그대로)에서는 이미 정상이었다 — 회귀 없음을 함께 고정.
+#[test]
+fn nested_wrapper_row_cursor_baseline_margin_stays_correct() {
+    let doc = load_with_margin_bottom_delta(0);
+
+    let mut combined = String::new();
+    for page in 0..doc.page_count() {
+        combined.push_str(&table_fragment_text(&doc, page));
+    }
+    for marker in ["구분", "현행유지안", "규제대안"] {
+        let count = combined.matches(marker).count();
+        assert_eq!(
+            count, 1,
+            "기준 여백에서 '{marker}' 마커가 {count}번 나타남(정확히 1번이어야 함)"
+        );
+    }
+}


### PR DESCRIPTION
## 무엇을

`PartialTable` 조각의 행 좌표가 **바깥 표 기준인지 벗겨낸 중첩 표 기준인지**를 페이지네이션
결정 시점에 데이터로 싣고, 렌더러의 값 기반 되추론을 제거한다.

## 왜

투명 1×1 래퍼 안에 든 표는 페이지네이션이 래퍼를 벗기고 **중첩 표의 행**으로 커서를 잡을 수
있다. 그런데 `PageItem::PartialTable` (`renderer/pagination.rs:488`) 은 `start_row`/`end_row`/
`start_cut`/`end_cut` 만 실을 뿐 그 값이 어느 좌표계인지 담지 않았다.

렌더러가 값으로 되추론했다 (`layout/table_partial.rs:80` 부근):

```rust
fn fragment_row_geometry_table(table: &Table, end_row: usize) -> &Table {
    if end_row <= table.row_count as usize { table } else { transparent_nested_table(table) }
}
```

**중첩 표의 진짜 단일 행 조각(`end_row == 1`)은 "바깥 래퍼의 자기 행 0"과 값으로 구분되지
않는다.** 그래서 래퍼를 벗겨야 할 때 안 벗기고, 표가 두 쪽에 중복 인쇄되며 본문 영역을 넘는다.

## 어떻게

`PageItem::PartialTable` 에 `row_cursor_is_nested: bool` 추가. 결정 시점에 포인터 비교로 계산한다
(`typeset.rs`, `step_block_table_continuation`):

```rust
let row_cursor_is_nested = !std::ptr::eq(row_geometry_table, table);
```

`row_geometry_table` 은 `hwp5_single_cell_rowbreak_wrapper` 분기에서 `table` **자신**을 대입하므로
(`typeset.rs:19406-19410`), 네이티브 RowBreak 래퍼가 자기 프레임을 지켜야 하는 경로(#1921 p16,
#3637 HWP 2020 p7)는 플래그가 `false` 로 나와 종전 동작 그대로다. 값 기반 되추론이 구분하지
못하던 것을 결정 자체가 기록한다.

`fragment_row_geometry_table` 삭제. 플래그를 `PageItem` → `layout_partial_table_item` →
`layout_partial_table` → `layout_partial_table_resolved` 로 관통 전달하고, 캐럿 fast-path
(`cursor_rect.rs`) 도 같은 필드를 받는다.

fallback `Paginator` (`pagination/engine.rs`, `RHWP_USE_PAGINATOR=1`) 도 같은 이중 표 모델을
공유해 같은 결함이 잠재해 있어 함께 채웠다. 이를 위해 `row_geometry_table` 을 `pub(crate)` 로
노출했다.

`#4069` 재귀 nested-cut 호출부는 이미 `nested_table` 자신의 행 좌표라 `false` 고정이다.

## 재현

`samples/76076_regulatory_analysis.hwp` para 36 (3×3 중첩 표를 감싼 투명 1×1 RowBreak 래퍼),
`page_def.margin_bottom` +500 HWPUNIT:

```
수정 전: LAYOUT_OVERFLOW: page=5, type=PartialTable, y=1104.8, bottom=1040.2, overflow=64.5px
         p5 에 세 행 전부 재출력, p6 에 "현행유지안" 중복 인쇄
수정 후: overflow 없음. p5 = 제목행만, p6 = 나머지 두 행. 중복 없음
```

## 검증

- 회귀 테스트 `tests/issue_4326_partial_table_nested_row_coords.rs` 신설(baseline + margin+500).
  수정 전 코드에서 실패하는 것을 확인했다.
- `cargo test --profile release-test --tests` 전체 통과.
- Native Skia 3종 통과 (`skia --lib`, `issue_2225_missing_picture_placeholder`,
  `render_p37_direct_pdf_export`), `wasm-pack build` 통과.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` 통과.
- **시각 증적**: `upstream/devel`(e48fe8694)과 이 head 에서 `samples/76076_regulatory_analysis.hwp`
  (82페이지, 이번 결함의 재현 문서)를 **서로 다른 두 렌더 경로 각각으로** 내보내 대조했다
  (경로가 갈리는 배경은 #4379).
  - `rhwp export-svg`(옵션 없음, **legacy 경로**: `render_page_svg_native` → `build_page_tree` →
    `SvgRenderer::render_tree` 직행, paint 계층 미경유) — 82페이지 전부 바이트 동일.
  - `rhwp export-svg --profile print`(**paint 경로**: `render_page_svg_layer_with_profile_native` →
    `build_page_layer_tree_with_profile` → `SvgLayerRenderer`, 인쇄 등가 프로필) — 82페이지 전부
    바이트 동일.
  두 경로 모두 무변경 문서에서 렌더 변화가 없다(결함은 쪽 기하가 흔들릴 때만 드러난다).
  **정정**: 이전 버전은 이 대조를 "시각 증적"이라 폭넓게 적었으나, legacy 경로(옵션 없는
  `export-svg`)는 인쇄 등가 출력 계약이 아니라 편집 화면 렌더 계약이다(#4379 — `SvgRenderer`의
  `show_editor_only_nodes` 기본값이 `true`). 위 두 결과는 "각 경로에서 head 가 baseline 과 픽셀
  단위로 같다"는 **회귀 부재 증거**이지, 한컴 인쇄 결과와의 시각 일치를 뜻하지 않는다.

## 범위 밖

fallback `Paginator` 의 기존 발산(#1921 p11/p36)은 손대지 않았다 — `git stash` 로 이 변경을 뺀
상태에서도 동일하게 실패하는 사전 결함이다.

Closes #4326

