### PR TITLE
feat(install): #4375 설치 채널 잔여 일괄 — binstall·deb·rpm·MSI·스크립트·AUR·server.json (ps1 실전 E2E 실증)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -825,6 +825,7 @@ jobs:
       - name: Validate workflow contracts
         run: |
           python3 -m unittest scripts/tests/test_cache_sweep_workflow.py
+          python3 -m unittest scripts/tests/test_release_installers_workflow.py
           python3 -m unittest scripts/tests/test_review_only_fast_pass_workflows.py
           python3 -m unittest scripts/tests/test_workflow_contract_wiring.py
 

--- a/.github/workflows/release-installers.yml
+++ b/.github/workflows/release-installers.yml
@@ -1,0 +1,114 @@
+name: Release Installers
+
+# Issue #4375 — 설치 채널 잔여 일괄: deb·rpm·MSI 를 릴리스 자산으로 첨부하고,
+# crates.io 게시는 이중 게이트(시크릿 + publish --dry-run) 뒤에서만 시도한다.
+# deb/rpm/MSI 는 GITHUB_TOKEN(contents: write)만 쓴다 — 머지 후 다음 태그부터
+# 자동 첨부(별도 시크릿 불요).
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag name (예: v0.8.2 — 기존 릴리스에 자산 추가)'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.v.outputs.tag }}
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - id: v
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${{ github.ref_name }}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+  linux-packages:
+    name: deb + rpm
+    needs: version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: installers-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: 빌드 + 패키징
+        run: |
+          cargo build --release --bin rhwp
+          cargo install cargo-deb cargo-generate-rpm --locked
+          cargo deb -p rhwp --no-build -o dist/
+          cargo generate-rpm -p . -o dist/
+          ls -la dist/
+      - name: 릴리스에 첨부
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ needs.version.outputs.tag }}" dist/*.deb dist/*.rpm --clobber
+
+  msi:
+    name: Windows MSI (WiX v4)
+    needs: version
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: msi-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: 빌드 + MSI
+        shell: bash
+        run: |
+          cargo build --release --bin rhwp
+          dotnet tool install --global wix
+          wix build contrib/packaging/msi/rhwp.wxs \
+            -d Version=${{ needs.version.outputs.version }} \
+            -d BinPath=target/release/rhwp.exe \
+            -o rhwp-${{ needs.version.outputs.tag }}-x86_64.msi
+      - name: 릴리스에 첨부
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ needs.version.outputs.tag }}" rhwp-*.msi --clobber
+
+  crates-io:
+    name: crates.io (이중 게이트)
+    needs: version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
+      - name: 게이트 ① 시크릿 · ② dry-run
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: |
+          if [[ -z "${CARGO_REGISTRY_TOKEN}" ]]; then
+            echo "::notice title=crates.io 생략::CRATES_IO_TOKEN 미등록 — 게시 안 함. 활성 조건은 mydocs/manual/installer_channels_guide.md §crates.io (패키징 include 정비 선행)."
+            exit 0
+          fi
+          if ! cargo publish -p rhwp --dry-run --locked; then
+            echo "::warning title=crates.io 보류::publish --dry-run 실패 — 패키징 include 정비(임베드 파일 50건·10MB 상한)가 선행입니다. 게시하지 않습니다."
+            exit 0
+          fi
+          cargo publish -p rhwp --locked

--- a/.github/workflows/release-installers.yml
+++ b/.github/workflows/release-installers.yml
@@ -24,17 +24,38 @@ jobs:
     outputs:
       tag: ${{ steps.v.outputs.tag }}
       version: ${{ steps.v.outputs.version }}
+      source_sha: ${{ steps.v.outputs.source_sha }}
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # 수동 재실행은 입력 태그, 태그 push 는 이벤트 ref 자체를 검증한다.
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
       - id: v
         shell: bash
+        env:
+          REQUESTED_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            TAG="${{ github.event.inputs.tag }}"
-          else
-            TAG="${{ github.ref_name }}"
+          set -euo pipefail
+          TAG="$REQUESTED_TAG"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "지원하지 않는 릴리스 태그 형식: $TAG" >&2
+            exit 1
+          fi
+          TAG_SHA="$(git rev-parse --verify "refs/tags/$TAG^{commit}")"
+          HEAD_SHA="$(git rev-parse HEAD)"
+          if [[ "$HEAD_SHA" != "$TAG_SHA" ]]; then
+            echo "checkout 소스가 요청 태그와 다릅니다: HEAD=$HEAD_SHA tag=$TAG_SHA" >&2
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          CARGO_VERSION="$(awk -F '"' '/^version = "/ { print $2; exit }' Cargo.toml)"
+          if [[ "$VERSION" != "$CARGO_VERSION" ]]; then
+            echo "버전 불일치: tag=$VERSION Cargo.toml=$CARGO_VERSION" >&2
+            exit 1
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
   linux-packages:
     name: deb + rpm
@@ -42,6 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.version.outputs.source_sha }}
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -68,6 +91,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.version.outputs.source_sha }}
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -78,13 +103,16 @@ jobs:
           key: msi-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: 빌드 + MSI
         shell: bash
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+          TAG: ${{ needs.version.outputs.tag }}
         run: |
           cargo build --release --bin rhwp
           dotnet tool install --global wix
           wix build contrib/packaging/msi/rhwp.wxs \
-            -d Version=${{ needs.version.outputs.version }} \
+            -d Version="$VERSION" \
             -d BinPath=target/release/rhwp.exe \
-            -o rhwp-${{ needs.version.outputs.tag }}-x86_64.msi
+            -o "rhwp-$TAG-x86_64.msi"
       - name: 릴리스에 첨부
         shell: bash
         env:
@@ -97,6 +125,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.version.outputs.source_sha }}
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
       - name: 게이트 ① 시크릿 · ② dry-run
         shell: bash

--- a/.github/workflows/release-installers.yml
+++ b/.github/workflows/release-installers.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag name (예: v0.8.2 — 기존 릴리스에 자산 추가)'
+        description: 'Stable tag (workflow ref와 같은 commit인 vX.Y.Z 재실행만 허용)'
         required: true
 
 permissions:
@@ -28,8 +28,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # 수동 재실행은 입력 태그, 태그 push 는 이벤트 ref 자체를 검증한다.
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          # workflow에 존재하는 packaging 구현을 사용한다. 수동 입력 tag가 이 ref와
+          # 다른 commit이면 아래 gate가 old-release backfill을 명시적으로 거부한다.
+          ref: ${{ github.ref }}
+          fetch-depth: 0
       - id: v
         shell: bash
         env:
@@ -37,14 +39,15 @@ jobs:
         run: |
           set -euo pipefail
           TAG="$REQUESTED_TAG"
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "지원하지 않는 릴리스 태그 형식: $TAG" >&2
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "installer workflow는 stable vX.Y.Z tag만 지원합니다: $TAG" >&2
             exit 1
           fi
           TAG_SHA="$(git rev-parse --verify "refs/tags/$TAG^{commit}")"
           HEAD_SHA="$(git rev-parse HEAD)"
           if [[ "$HEAD_SHA" != "$TAG_SHA" ]]; then
-            echo "checkout 소스가 요청 태그와 다릅니다: HEAD=$HEAD_SHA tag=$TAG_SHA" >&2
+            echo "과거 release backfill은 지원하지 않습니다: workflow ref HEAD=$HEAD_SHA requested tag=$TAG_SHA" >&2
+            echo "요청 tag와 같은 ref에서 workflow를 다시 실행하세요." >&2
             exit 1
           fi
           VERSION="${TAG#v}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,43 @@ description = "HWP file viewer and editor written in Rust, targeting WebAssembly
 license = "MIT"
 repository = "https://github.com/edwardkim/rhwp"
 
+# [#4375] cargo-binstall — `cargo binstall rhwp` 가 기존 릴리스 자산을 그대로
+# 받도록 자산 이름을 타깃별로 매핑한다(빌드 없는 설치, crates.io 게시와 무관).
+# 아카이브는 rhwp/<bin> 구조(release-binary.yml 패키징 계약).
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/rhwp-v{ version }-linux-x86_64.tar.gz"
+bin-dir = "rhwp/{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/rhwp-v{ version }-macos-x86_64.tar.gz"
+
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/rhwp-v{ version }-macos-aarch64.tar.gz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/v{ version }/rhwp-v{ version }-windows-x86_64.zip"
+pkg-fmt = "zip"
+
+# [#4375] cargo-deb — release-installers.yml 이 .deb 를 릴리스에 첨부한다.
+[package.metadata.deb]
+maintainer = "edwardkim <https://github.com/edwardkim>"
+copyright = "MIT — https://github.com/edwardkim/rhwp/blob/devel/LICENSE"
+extended-description = "HWP/HWPX document engine: parse, edit, render, convert. CLI with machine-readable --json envelopes and a built-in MCP server (rhwp mcp-serve)."
+section = "utils"
+priority = "optional"
+assets = [
+    ["target/release/rhwp", "usr/bin/", "755"],
+    ["README.md", "usr/share/doc/rhwp/README.md", "644"],
+]
+
+# [#4375] cargo-generate-rpm — 동일 잡이 .rpm 을 첨부한다.
+[package.metadata.generate-rpm]
+assets = [
+    { source = "target/release/rhwp", dest = "/usr/bin/rhwp", mode = "755" },
+    { source = "README.md", dest = "/usr/share/doc/rhwp/README.md", mode = "644", doc = true },
+]
+
 [workspace]
 members = [".", "tools/rhwp-subsecond", "bindings/Native", "tools/batch-convert"]
 resolver = "2"

--- a/contrib/install/install.ps1
+++ b/contrib/install/install.ps1
@@ -1,0 +1,53 @@
+# [#4375] rhwp Windows 설치 스크립트 — 릴리스 zip 을 받아 검증·배치한다.
+#
+#   irm https://raw.githubusercontent.com/edwardkim/rhwp/devel/contrib/install/install.ps1 | iex
+#   # 또는: .\install.ps1 -Version v0.8.2 -InstallDir C:\tools\rhwp -NoPath
+#
+# 하는 일: ① 버전 해석(latest→GitHub API) ② zip+SHA256SUMS 다운로드
+# ③ 해시 검증 ④ 해체(rhwp\rhwp.exe) ⑤ 사용자 PATH 등록(옵트아웃 -NoPath).
+param(
+    [string]$Version = "latest",
+    [string]$InstallDir = "$env:LOCALAPPDATA\Programs\rhwp",
+    [switch]$NoPath
+)
+
+$ErrorActionPreference = "Stop"
+$repo = "edwardkim/rhwp"
+
+if ($Version -eq "latest") {
+    $rel = Invoke-RestMethod "https://api.github.com/repos/$repo/releases/latest"
+    $Version = $rel.tag_name
+}
+$asset = "rhwp-$Version-windows-x86_64.zip"
+$base = "https://github.com/$repo/releases/download/$Version"
+
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) "rhwp-install-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+try {
+    Write-Host "다운로드: $base/$asset"
+    Invoke-WebRequest "$base/$asset" -OutFile (Join-Path $tmp $asset)
+    Invoke-WebRequest "$base/SHA256SUMS.txt" -OutFile (Join-Path $tmp "SHA256SUMS.txt")
+
+    $expected = (Get-Content (Join-Path $tmp "SHA256SUMS.txt") | Where-Object { $_ -match [regex]::Escape($asset) }) -split '\s+' | Select-Object -First 1
+    if (-not $expected) { throw "SHA256SUMS.txt 에 $asset 항목이 없습니다" }
+    $actual = (Get-FileHash (Join-Path $tmp $asset) -Algorithm SHA256).Hash.ToLower()
+    if ($actual -ne $expected.ToLower()) { throw "해시 불일치: 기대 $expected / 실제 $actual" }
+    Write-Host "무결성 확인: SHA-256 일치"
+
+    Expand-Archive (Join-Path $tmp $asset) -DestinationPath $tmp -Force
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    Copy-Item (Join-Path $tmp "rhwp\rhwp.exe") (Join-Path $InstallDir "rhwp.exe") -Force
+
+    if (-not $NoPath) {
+        $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+        if ($userPath -notlike "*$InstallDir*") {
+            [Environment]::SetEnvironmentVariable("Path", "$userPath;$InstallDir", "User")
+            Write-Host "사용자 PATH 에 추가됨(새 터미널부터 적용): $InstallDir"
+        }
+    }
+    & (Join-Path $InstallDir "rhwp.exe") --version
+    Write-Host "설치 완료: $InstallDir\rhwp.exe — 첫 확인은 'rhwp capabilities'"
+}
+finally {
+    Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/contrib/install/install.sh
+++ b/contrib/install/install.sh
@@ -4,7 +4,7 @@
 #   curl -fsSL https://raw.githubusercontent.com/edwardkim/rhwp/devel/contrib/install/install.sh | bash
 #   # 또는: ./install.sh v0.8.2 ~/.local/bin
 #
-# ① 버전 해석(latest→GitHub API) ② tar.gz+SHA256SUMS 다운로드 ③ sha256sum -c
+# ① 버전 해석(latest→GitHub API) ② tar.gz+SHA256SUMS 다운로드 ③ SHA-256 검증
 # ④ 해체(rhwp/rhwp) ⑤ 설치 디렉터리 배치(기본 ~/.local/bin, PATH 는 안내만).
 set -euo pipefail
 
@@ -31,7 +31,24 @@ trap 'rm -rf "$TMP"' EXIT
 echo "다운로드: $BASE/$ASSET"
 curl -fsSL -o "$TMP/$ASSET" "$BASE/$ASSET"
 curl -fsSL -o "$TMP/SHA256SUMS.txt" "$BASE/SHA256SUMS.txt"
-( cd "$TMP" && sha256sum -c SHA256SUMS.txt --ignore-missing )
+( cd "$TMP"
+  if ! awk -v asset="$ASSET" '
+      { name = $2; sub(/^\*/, "", name) }
+      name == asset { print; found = 1 }
+      END { if (!found) exit 1 }
+    ' SHA256SUMS.txt > SHA256SUMS.asset.txt; then
+      echo "SHA256SUMS.txt 에 $ASSET 항목이 없습니다" >&2
+      exit 1
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c SHA256SUMS.asset.txt
+elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c SHA256SUMS.asset.txt
+else
+    echo "SHA-256 검증 도구가 없습니다 (sha256sum 또는 shasum 필요)" >&2
+    exit 1
+  fi
+)
 echo "무결성 확인: SHA-256 일치"
 
 tar -xzf "$TMP/$ASSET" -C "$TMP"

--- a/contrib/install/install.sh
+++ b/contrib/install/install.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# [#4375] rhwp Linux/macOS 설치 스크립트 — 릴리스 tar.gz 를 받아 검증·배치한다.
+#
+#   curl -fsSL https://raw.githubusercontent.com/edwardkim/rhwp/devel/contrib/install/install.sh | bash
+#   # 또는: ./install.sh v0.8.2 ~/.local/bin
+#
+# ① 버전 해석(latest→GitHub API) ② tar.gz+SHA256SUMS 다운로드 ③ sha256sum -c
+# ④ 해체(rhwp/rhwp) ⑤ 설치 디렉터리 배치(기본 ~/.local/bin, PATH 는 안내만).
+set -euo pipefail
+
+REPO="edwardkim/rhwp"
+VERSION="${1:-latest}"
+INSTALL_DIR="${2:-$HOME/.local/bin}"
+
+if [[ "$VERSION" == "latest" ]]; then
+    VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+        | grep -m1 '"tag_name"' | cut -d '"' -f 4)
+fi
+
+case "$(uname -s)-$(uname -m)" in
+    Linux-x86_64)  SUFFIX="linux-x86_64"  ;;
+    Darwin-x86_64) SUFFIX="macos-x86_64"  ;;
+    Darwin-arm64)  SUFFIX="macos-aarch64" ;;
+    *) echo "지원하지 않는 플랫폼: $(uname -s)-$(uname -m)" >&2; exit 1 ;;
+esac
+ASSET="rhwp-$VERSION-$SUFFIX.tar.gz"
+BASE="https://github.com/$REPO/releases/download/$VERSION"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+echo "다운로드: $BASE/$ASSET"
+curl -fsSL -o "$TMP/$ASSET" "$BASE/$ASSET"
+curl -fsSL -o "$TMP/SHA256SUMS.txt" "$BASE/SHA256SUMS.txt"
+( cd "$TMP" && sha256sum -c SHA256SUMS.txt --ignore-missing )
+echo "무결성 확인: SHA-256 일치"
+
+tar -xzf "$TMP/$ASSET" -C "$TMP"
+mkdir -p "$INSTALL_DIR"
+install -m 755 "$TMP/rhwp/rhwp" "$INSTALL_DIR/rhwp"
+
+"$INSTALL_DIR/rhwp" --version
+echo "설치 완료: $INSTALL_DIR/rhwp — 첫 확인은 'rhwp capabilities'"
+case ":$PATH:" in
+    *":$INSTALL_DIR:"*) ;;
+    *) echo "주의: $INSTALL_DIR 이 PATH 에 없습니다 — 셸 프로필에 추가하세요." ;;
+esac

--- a/contrib/packaging/aur/PKGBUILD
+++ b/contrib/packaging/aur/PKGBUILD
@@ -1,0 +1,21 @@
+# [#4375] AUR 패키지(rhwp-bin) — 릴리스 바이너리 기반. AUR 등재는 메인테이너(또는
+# 위임자)의 AUR 계정으로 제출한다(절차: installer_channels_guide.md §AUR).
+# 버전 갱신: pkgver 와 sha256sums 를 tools/update_channel_manifests.py 후속 확장으로.
+# Maintainer: edwardkim <https://github.com/edwardkim>
+pkgname=rhwp-bin
+pkgver=0.8.2
+pkgrel=1
+pkgdesc="HWP/HWPX document engine — parse, edit, render, convert (CLI + MCP server)"
+arch=('x86_64')
+url="https://github.com/edwardkim/rhwp"
+license=('MIT')
+provides=('rhwp')
+conflicts=('rhwp')
+source=("$url/releases/download/v$pkgver/rhwp-v$pkgver-linux-x86_64.tar.gz")
+sha256sums=('3225246533eca2b10ec2926228aee0d1cbf0ea6de0553e053ec8d6cb79fa9570')
+
+package() {
+    install -Dm755 "$srcdir/rhwp/rhwp" "$pkgdir/usr/bin/rhwp"
+    install -Dm644 "$srcdir/rhwp/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+    install -Dm644 "$srcdir/rhwp/README.md" "$pkgdir/usr/share/doc/$pkgname/README.md"
+}

--- a/contrib/packaging/msi/rhwp.wxs
+++ b/contrib/packaging/msi/rhwp.wxs
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- [#4375] Windows MSI — release-installers.yml 의 msi 잡이 WiX v4 로 빌드한다.
+     빌드: wix build rhwp.wxs -d Version=X.Y.Z -d BinPath=path\to\rhwp.exe -o rhwp.msi
+     설치 내용: ProgramFiles64\rhwp\rhwp.exe + 시스템 PATH 등재. UpgradeCode 는
+     고정(판올림 MSI 가 이전 설치를 대체하는 열쇠 — 바꾸면 병행 설치가 된다). -->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="rhwp"
+           Manufacturer="edwardkim (rhwp project)"
+           Version="$(var.Version)"
+           UpgradeCode="7b1c2f4e-9a3d-4c8b-b2e5-0d11a4e70001"
+           Language="1042"
+           Scope="perMachine">
+    <MajorUpgrade DowngradeErrorMessage="더 높은 버전이 이미 설치되어 있습니다." />
+    <MediaTemplate EmbedCab="yes" />
+
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="INSTALLFOLDER" Name="rhwp">
+        <Component Id="RhwpBinary" Guid="5d6e7f80-1234-4abc-9def-0d11a4e70002">
+          <File Id="RhwpExe" Source="$(var.BinPath)" Name="rhwp.exe" KeyPath="yes" />
+          <Environment Id="RhwpPath" Name="PATH" Value="[INSTALLFOLDER]"
+                       Permanent="no" Part="last" Action="set" System="yes" />
+        </Component>
+      </Directory>
+    </StandardDirectory>
+
+    <Feature Id="Main" Title="rhwp CLI" Level="1">
+      <ComponentRef Id="RhwpBinary" />
+    </Feature>
+  </Package>
+</Wix>

--- a/mydocs/manual/installer_channels_guide.md
+++ b/mydocs/manual/installer_channels_guide.md
@@ -7,8 +7,9 @@ last_verified: 2026-08-09
 
 # 설치 채널 가이드 2부 — binstall·deb·rpm·MSI·스크립트·AUR·server.json (#4375)
 
-[channel_manifests_guide.md](channel_manifests_guide.md)(scoop·homebrew·winget,
-#4338)의 후속 일괄이다. 채널마다 **활성 조건**과 **검증 상태**를 정직하게 갈라
+1부(scoop·homebrew·winget — `channel_manifests_guide.md`,
+[PR #4339](https://github.com/edwardkim/rhwp/pull/4339) 리뷰 중이라 상대 링크는
+착지 후 잇는다)의 후속 일괄이다. 채널마다 **활성 조건**과 **검증 상태**를 정직하게 갈라
 적는다 — "커밋됨"과 "동작 검증됨"은 다른 등급이다.
 
 ## 채널 매트릭스 (활성 조건·검증 상태)

--- a/mydocs/manual/installer_channels_guide.md
+++ b/mydocs/manual/installer_channels_guide.md
@@ -1,0 +1,47 @@
+---
+kind: guide
+status: active
+canonical: mydocs/manual/installer_channels_guide.md
+last_verified: 2026-08-09
+---
+
+# 설치 채널 가이드 2부 — binstall·deb·rpm·MSI·스크립트·AUR·server.json (#4375)
+
+[channel_manifests_guide.md](channel_manifests_guide.md)(scoop·homebrew·winget,
+#4338)의 후속 일괄이다. 채널마다 **활성 조건**과 **검증 상태**를 정직하게 갈라
+적는다 — "커밋됨"과 "동작 검증됨"은 다른 등급이다.
+
+## 채널 매트릭스 (활성 조건·검증 상태)
+
+| 채널 | 사용자 명령 | 활성 조건 | 검증 상태 |
+|---|---|---|---|
+| cargo-binstall | `cargo binstall rhwp` | **머지 즉시**(기존 릴리스 자산 URL 매핑) | 매핑이 실자산 이름과 일치함을 수동 대조 — binstall 실행은 미검증(로컬 미설치) |
+| deb | 릴리스에서 `.deb` 받아 `dpkg -i` | 다음 `v*` 태그(시크릿 불요) | 워크플로 잡 — CI 실행으로 검증 예정(`workflow_dispatch` 권장) |
+| rpm | `.rpm` → `rpm -i` | 동상 | 동상 |
+| **MSI** | 릴리스에서 `.msi` 실행 | 동상 | wxs 는 WiX v4 스키마로 작성 — 로컬 WiX 부재로 미빌드, dispatch 1회로 검증 권장 |
+| install.sh | `curl … install.sh \| bash` | 머지 즉시 | **로컬 미검증**(이 PC curl TLS 차단) — 구조는 ps1 과 동형 |
+| install.ps1 | `irm … install.ps1 \| iex` | 머지 즉시 | **실전 E2E 검증됨**(v0.8.2 실다운로드→SHA-256 일치→실행, PR 본문 실측) |
+| AUR (rhwp-bin) | `yay -S rhwp-bin` | AUR 계정 제출(메인테이너/위임) | PKGBUILD 실해시 반영 — 제출 전 `makepkg` 검증 필요(리눅스) |
+| crates.io | `cargo install rhwp` | `CRATES_IO_TOKEN` + **패키징 include 정비(선행)** | 이중 게이트(시크릿→`publish --dry-run`) — dry-run 실패 시 게시하지 않고 경고만 |
+| server.json | MCP 공식 레지스트리 제출 | 참조 패키지 게시 후(#4337 pypi/npm·#4372 oci) → #4343 실행 | 스키마 2025-12-11 실검증 후 작성 — 제출은 게시 뒤 |
+
+## crates.io — 왜 바로 안 켜는가 (정직 기록)
+
+`cargo package --list` 실측 13,975 파일. 본체는 `include_str!`/`include_bytes!`
+50건(레시피·llms.txt·지식 지도 등 `mydocs/` 하위 포함)을 임베드하므로,
+crates 패키징은 **include 목록 수술**(소스+임베드 파일 전수, 10MB 상한 확인)이
+선행이다. 그때까지 잡은 dry-run 게이트가 게시를 막고 사유를 로그로 남긴다 —
+체크박스를 위해 깨진 패키지를 올리지 않는다.
+
+## 버전·해시 갱신
+
+scoop·brew·winget 은 `tools/update_channel_manifests.py`(#4338)가 담당한다.
+AUR PKGBUILD 의 pkgver·sha256 갱신을 같은 스크립트로 확장하는 것은 후속(이슈로).
+
+## MSI 설계 메모
+
+- `UpgradeCode` 고정이 판올림 교체의 열쇠 — 변경 금지.
+- PATH 는 시스템 환경변수에 `Part="last"` 로 덧붙인다(제거 시 자동 원복,
+  `Permanent="no"`).
+- 서명(코드사이닝)은 version_policy.md §8 의 서명 도구 결정과 합류 — 미서명
+  MSI 는 SmartScreen 경고가 뜬다는 사실을 릴리스 노트에 명시할 것.

--- a/mydocs/pr/pr_4376_review.md
+++ b/mydocs/pr/pr_4376_review.md
@@ -1,0 +1,76 @@
+---
+kind: pr-review
+status: active
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-10
+---
+
+# PR #4376 검토 - 설치 산출물의 요청 태그 정합
+
+## 검토 경로
+
+기본 경로는 `maintainer_general.md`, 보조 경로는 `intake_and_review.md`,
+`local_validation.md`, `multi_pr_update_branch.md`, `review_only_fast_pass.md`다.
+설치 workflow, package metadata와 install scripts만 바뀐다. renderer/layout, sample, fixture와
+시각 출력 영향은 없다.
+
+## 접수 메타데이터
+
+| 항목 | 접수 시점 참고값 |
+| --- | --- |
+| PR / 작성자 | [#4376](https://github.com/edwardkim/rhwp/pull/4376) / `kevin9327` |
+| 관련 이슈 | [#4375](https://github.com/edwardkim/rhwp/issues/4375) |
+| base / contributor head | `devel` / `12f3950644430d7692baec6587f8a1d149f8cae4` |
+| 규모 | 8 files, +376 / -0, contributor commits 2개 |
+| 상태 | `MERGEABLE` / `CLEAN`, Full CI·CodeQL·Render Diff 성공 |
+| 가시성 branch | `review/kevin9327-20260810-pr4376` |
+| 메인터너 code candidate | `b1bb5a56a15aa06f84ee99eeecdfb208d5cc406b` |
+
+`release-installers.yml`은 tag push와 manual dispatch만 트리거하므로 contributor head에서
+deb/rpm/MSI/crates.io workflow 자체는 실행되지 않았다.
+
+## Contributor 변경 범위
+
+`cc94b1c0e6a5b3972212cbaf1fc8bca102b8be37`은 Cargo packaging metadata,
+deb/rpm/MSI/crates.io workflow, POSIX·PowerShell installer, AUR, MCP registry metadata와
+운영 가이드를 추가했다. `12f3950644430d7692baec6587f8a1d149f8cae4`는 미병합 가이드의
+내부 상대 링크를 PR 링크로 바로잡았다. 두 contributor commit을 그대로 보존했다.
+
+## 원래 차단점
+
+- manual dispatch 입력 tag는 upload 대상 이름에만 쓰고 각 job은 workflow 실행 ref를 checkout했다.
+  따라서 현재 default source로 만든 deb/rpm/MSI나 crate를 과거 release에 덮어쓸 수 있었다.
+- `contrib/install/install.sh`는 Darwin을 지원한다고 선언했지만 stock macOS에 없는
+  `sha256sum`만 호출해 checksum 검증 전에 종료됐다.
+
+## 메인터너 보정
+
+`b1bb5a56a15aa06f84ee99eeecdfb208d5cc406b`
+(`fix(maintainer): #4376 설치 산출물을 요청 태그에 고정`)은 다음을 바꿨다.
+
+- `.github/workflows/release-installers.yml`: 요청 tag checkout, tag/HEAD/Cargo version 검증,
+  검증된 불변 SHA를 모든 packaging/publish job에 전달
+- `contrib/install/install.sh`: 선택 자산의 checksum 행만 추출하고 macOS `shasum -a 256` fallback 제공
+- `scripts/tests/test_release_installers_workflow.py`: immutable source와 portable checksum 계약
+- `.github/workflows/ci.yml`: 새 계약 테스트 배선
+
+## 완료한 로컬 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| `python -m unittest scripts.tests.test_release_installers_workflow scripts.tests.test_workflow_contract_wiring -v` | 5 / 5 통과 |
+| commit의 `contrib/install/install.sh` 출력을 `bash -n`으로 검사 | 통과 |
+| `git diff --check origin/pr/4376..b1bb5a56a15aa06f84ee99eeecdfb208d5cc406b` | 통과 |
+| commit graph | correction commit의 유일한 parent가 contributor head와 일치 |
+
+로컬에는 `actionlint`, macOS, WiX 및 publishing credentials가 없다. 실제 deb/rpm/MSI build,
+macOS installer smoke와 crates.io dry-run은 최신 GitHub-hosted run에서 확인해야 한다.
+
+## 최종 권고
+
+**메인터너 보정 포함 조건부 수용 권고.** 기존 녹색 CI는 installer workflow를 실행하지 않았고,
+새 correction은 workflow/test/script를 바꿨다. push 승인 뒤 correction과 review-doc commit을
+fast-forward로 반영하고 최신 Full CI 및 별도 Release Installers 검증을 확인해야 한다.
+required checks와 mergeability가 성공해도 별도 merge 승인 전에는 publish나 merge를 수행하지 않는다.
+
+실행 및 rollback은 [PR #4376 구현·통합 계획](pr_4376_review_impl.md)을 따른다.

--- a/mydocs/pr/pr_4376_review.md
+++ b/mydocs/pr/pr_4376_review.md
@@ -24,7 +24,7 @@ last_verified: 2026-08-10
 | 규모 | 8 files, +376 / -0, contributor commits 2개 |
 | 상태 | `MERGEABLE` / `CLEAN`, Full CI·CodeQL·Render Diff 성공 |
 | 가시성 branch | `review/kevin9327-20260810-pr4376` |
-| 메인터너 code candidate | `b1bb5a56a15aa06f84ee99eeecdfb208d5cc406b` |
+| 메인터너 code candidate | `d0e63315b34f937d739b1dc0a42c0599af7e4c4c` |
 
 `release-installers.yml`은 tag push와 manual dispatch만 트리거하므로 contributor head에서
 deb/rpm/MSI/crates.io workflow 자체는 실행되지 않았다.
@@ -42,6 +42,8 @@ deb/rpm/MSI/crates.io workflow, POSIX·PowerShell installer, AUR, MCP registry m
   따라서 현재 default source로 만든 deb/rpm/MSI나 crate를 과거 release에 덮어쓸 수 있었다.
 - `contrib/install/install.sh`는 Darwin을 지원한다고 선언했지만 stock macOS에 없는
   `sha256sum`만 호출해 checksum 검증 전에 종료됐다.
+- 입력한 과거 tag를 checkout하면 그 tree에는 새 packaging/MSI source가 없어 backfill 자체가 실패했다.
+- prerelease semver는 WiX MSI의 numeric `Version` 형식과 호환되지 않는데도 허용됐다.
 
 ## 메인터너 보정
 
@@ -54,23 +56,33 @@ deb/rpm/MSI/crates.io workflow, POSIX·PowerShell installer, AUR, MCP registry m
 - `scripts/tests/test_release_installers_workflow.py`: immutable source와 portable checksum 계약
 - `.github/workflows/ci.yml`: 새 계약 테스트 배선
 
+독립 후속 검토 뒤 `d0e63315b34f937d739b1dc0a42c0599af7e4c4c`
+(`fix(maintainer): #4376 installer backfill 범위 제한`)을 추가했다.
+
+- `.github/workflows/release-installers.yml`: packaging 구현은 workflow event ref에서 읽고 요청 stable tag가
+  같은 commit일 때만 허용한다. 과거 release backfill과 prerelease MSI는 명시적으로 거부한다.
+- `scripts/tests/test_release_installers_workflow.py`: stable same-ref 제한을 계약으로 고정한다.
+
 ## 완료한 로컬 검증
 
 | 검증 | 결과 |
 | --- | --- |
 | `python -m unittest scripts.tests.test_release_installers_workflow scripts.tests.test_workflow_contract_wiring -v` | 5 / 5 통과 |
 | commit의 `contrib/install/install.sh` 출력을 `bash -n`으로 검사 | 통과 |
-| `git diff --check origin/pr/4376..b1bb5a56a15aa06f84ee99eeecdfb208d5cc406b` | 통과 |
-| commit graph | correction commit의 유일한 parent가 contributor head와 일치 |
+| `git diff --check origin/pr/4376..d0e63315b34f937d739b1dc0a42c0599af7e4c4c` | 통과 |
+| commit graph | contributor history를 rewrite하지 않고 maintainer code/docs/code를 single-parent로 연결 |
 
-로컬에는 `actionlint`, macOS, WiX 및 publishing credentials가 없다. 실제 deb/rpm/MSI build,
-macOS installer smoke와 crates.io dry-run은 최신 GitHub-hosted run에서 확인해야 한다.
+로컬에는 `actionlint`, macOS, WiX 및 publishing credentials가 없다. 이 workflow에는
+`pull_request` trigger와 macOS job이 없으므로 PR head에서 실제 deb/rpm/MSI build나 macOS installer를
+검증할 수 없다. 이번 보정의 근거는 focused static contract와 POSIX shell syntax까지이며, packaging,
+publish 및 macOS installer E2E는 residual risk다.
 
 ## 최종 권고
 
 **메인터너 보정 포함 조건부 수용 권고.** 기존 녹색 CI는 installer workflow를 실행하지 않았고,
 새 correction은 workflow/test/script를 바꿨다. push 승인 뒤 correction과 review-doc commit을
-fast-forward로 반영하고 최신 Full CI 및 별도 Release Installers 검증을 확인해야 한다.
-required checks와 mergeability가 성공해도 별도 merge 승인 전에는 publish나 merge를 수행하지 않는다.
+fast-forward로 반영하고 최신 Full CI의 static/focused contract를 확인해야 한다. Release Installers와
+macOS installer E2E는 이 PR에서 실행할 수 없으므로 미검증 risk를 명시적으로 수용해야 한다. required
+checks와 mergeability가 성공해도 별도 merge 승인 전에는 publish나 merge를 수행하지 않는다.
 
 실행 및 rollback은 [PR #4376 구현·통합 계획](pr_4376_review_impl.md)을 따른다.

--- a/mydocs/pr/pr_4376_review_impl.md
+++ b/mydocs/pr/pr_4376_review_impl.md
@@ -1,0 +1,38 @@
+---
+kind: pr-review-implementation
+status: active
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-10
+---
+
+# PR #4376 메인터너 보정·통합 계획
+
+## Commit 소유권과 순서
+
+1. `cc94b1c0e6a5b3972212cbaf1fc8bca102b8be37` — contributor의 installer channel 구현
+2. `12f3950644430d7692baec6587f8a1d149f8cae4` — contributor의 guide 링크 보정
+3. `b1bb5a56a15aa06f84ee99eeecdfb208d5cc406b` — maintainer code/test/workflow 보정
+4. 이 문서를 포함하는 별도 trailing review-doc commit
+
+Contributor commits는 재작성하지 않았다. 상세 근거는 [PR #4376 검토 기록](pr_4376_review.md)에 있다.
+
+## 단계
+
+1. **완료:** contributor head와 기존 check를 접수 기준으로 고정하고 installer workflow 미실행을 분리 기록했다.
+2. **완료:** immutable tag source와 portable checksum 보정을 maintainer commit 하나로 추가했다.
+3. **완료:** focused unittest, workflow test 배선, shell syntax, diff와 commit parent를 검증했다.
+4. **대기:** 작업지시자 승인 뒤 correction과 review-doc commit만 source branch에 fast-forward push한다.
+5. **대기:** code/workflow 변경이므로 Full CI fallback을 사용한다. 최신 CI·CodeQL과 별도
+   Release Installers run에서 deb/rpm/MSI, macOS installer 및 crates.io dry-run 결과를 확인한다.
+   credentials가 없는 publish step의 명시적 skip과 build failure를 혼동하지 않는다.
+6. **대기:** required checks, mergeability와 작업지시자의 별도 merge 승인을 모두 확인한다.
+7. **merge 후:** merge SHA, release workflow 상태와 asset 정합을 확인하고 archive/cleanup을 수행한다.
+
+## Rollback
+
+- push 전에는 visibility branch/worktree만 정리한다.
+- push 뒤 merge 전에는 review-doc commit을 먼저 revert하고,
+  `b1bb5a56a15aa06f84ee99eeecdfb208d5cc406b`을 revert한다.
+- merge 뒤에도 역순 revert를 사용한다. contributor commits나 release tag history를 rewrite하지 않는다.
+
+현재 단계에는 push, publish, GitHub review/comment 또는 merge 승인이 없다.

--- a/mydocs/pr/pr_4376_review_impl.md
+++ b/mydocs/pr/pr_4376_review_impl.md
@@ -12,27 +12,30 @@ last_verified: 2026-08-10
 1. `cc94b1c0e6a5b3972212cbaf1fc8bca102b8be37` — contributor의 installer channel 구현
 2. `12f3950644430d7692baec6587f8a1d149f8cae4` — contributor의 guide 링크 보정
 3. `b1bb5a56a15aa06f84ee99eeecdfb208d5cc406b` — maintainer code/test/workflow 보정
-4. 이 문서를 포함하는 별도 trailing review-doc commit
+4. `64ca85abb911b8dcc46dbee6ec8d5ad440eb727c` — 최초 maintainer review-doc commit
+5. `d0e63315b34f937d739b1dc0a42c0599af7e4c4c` — maintainer stable same-ref 후속 보정
+6. 이 갱신을 포함하는 별도 trailing review-doc commit
 
 Contributor commits는 재작성하지 않았다. 상세 근거는 [PR #4376 검토 기록](pr_4376_review.md)에 있다.
 
 ## 단계
 
 1. **완료:** contributor head와 기존 check를 접수 기준으로 고정하고 installer workflow 미실행을 분리 기록했다.
-2. **완료:** immutable tag source와 portable checksum 보정을 maintainer commit 하나로 추가했다.
+2. **완료:** immutable tag source, portable checksum과 stable same-ref 제한을 두 maintainer
+   code commit으로 추가했다.
 3. **완료:** focused unittest, workflow test 배선, shell syntax, diff와 commit parent를 검증했다.
 4. **대기:** 작업지시자 승인 뒤 correction과 review-doc commit만 source branch에 fast-forward push한다.
-5. **대기:** code/workflow 변경이므로 Full CI fallback을 사용한다. 최신 CI·CodeQL과 별도
-   Release Installers run에서 deb/rpm/MSI, macOS installer 및 crates.io dry-run 결과를 확인한다.
-   credentials가 없는 publish step의 명시적 skip과 build failure를 혼동하지 않는다.
+5. **대기:** code/workflow 변경이므로 Full CI fallback을 사용해 최신 CI·CodeQL의 static/focused
+   contract와 required aggregate를 확인한다. `release-installers.yml`은 PR trigger와 macOS job이 없어
+   deb/rpm/MSI, publish 및 macOS installer E2E를 이 단계에서 확인할 수 없으며 residual risk로 남긴다.
 6. **대기:** required checks, mergeability와 작업지시자의 별도 merge 승인을 모두 확인한다.
 7. **merge 후:** merge SHA, release workflow 상태와 asset 정합을 확인하고 archive/cleanup을 수행한다.
 
 ## Rollback
 
 - push 전에는 visibility branch/worktree만 정리한다.
-- push 뒤 merge 전에는 review-doc commit을 먼저 revert하고,
-  `b1bb5a56a15aa06f84ee99eeecdfb208d5cc406b`을 revert한다.
+- push 뒤 merge 전에는 최신 review-doc commit, `d0e63315b34f937d739b1dc0a42c0599af7e4c4c`,
+  최초 review-doc commit과 `b1bb5a56a15aa06f84ee99eeecdfb208d5cc406b`을 역순 revert한다.
 - merge 뒤에도 역순 revert를 사용한다. contributor commits나 release tag history를 rewrite하지 않는다.
 
 현재 단계에는 push, publish, GitHub review/comment 또는 merge 승인이 없다.

--- a/scripts/tests/test_release_installers_workflow.py
+++ b/scripts/tests/test_release_installers_workflow.py
@@ -1,0 +1,43 @@
+"""Installer release workflow and portable installer checksum contracts."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class ReleaseInstallersWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = (
+            ROOT / ".github/workflows/release-installers.yml"
+        ).read_text(encoding="utf-8")
+        cls.installer = (ROOT / "contrib/install/install.sh").read_text(
+            encoding="utf-8"
+        )
+
+    def test_dispatch_resolves_tag_to_an_immutable_validated_source(self) -> None:
+        self.assertIn(
+            "ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}",
+            self.workflow,
+        )
+        self.assertIn("source_sha: ${{ steps.v.outputs.source_sha }}", self.workflow)
+        self.assertEqual(
+            self.workflow.count("ref: ${{ needs.version.outputs.source_sha }}"),
+            3,
+        )
+        self.assertIn('git rev-parse --verify "refs/tags/$TAG^{commit}"', self.workflow)
+        self.assertIn('if [[ "$VERSION" != "$CARGO_VERSION" ]]', self.workflow)
+
+    def test_installer_has_stock_macos_checksum_fallback(self) -> None:
+        self.assertIn("command -v sha256sum", self.installer)
+        self.assertIn("command -v shasum", self.installer)
+        self.assertIn("shasum -a 256 -c SHA256SUMS.asset.txt", self.installer)
+        self.assertNotIn("--ignore-missing", self.installer)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_installers_workflow.py
+++ b/scripts/tests/test_release_installers_workflow.py
@@ -19,17 +19,20 @@ class ReleaseInstallersWorkflowTests(unittest.TestCase):
             encoding="utf-8"
         )
 
-    def test_dispatch_resolves_tag_to_an_immutable_validated_source(self) -> None:
-        self.assertIn(
-            "ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}",
-            self.workflow,
-        )
+    def test_dispatch_requires_the_workflow_ref_to_match_a_stable_tag(self) -> None:
+        self.assertIn("ref: ${{ github.ref }}", self.workflow)
+        self.assertIn("fetch-depth: 0", self.workflow)
         self.assertIn("source_sha: ${{ steps.v.outputs.source_sha }}", self.workflow)
         self.assertEqual(
             self.workflow.count("ref: ${{ needs.version.outputs.source_sha }}"),
             3,
         )
         self.assertIn('git rev-parse --verify "refs/tags/$TAG^{commit}"', self.workflow)
+        self.assertIn(
+            'if [[ ! "$TAG" =~ ^v[0-9]+\\.[0-9]+\\.[0-9]+$ ]]',
+            self.workflow,
+        )
+        self.assertIn("과거 release backfill은 지원하지 않습니다", self.workflow)
         self.assertIn('if [[ "$VERSION" != "$CARGO_VERSION" ]]', self.workflow)
 
     def test_installer_has_stock_macos_checksum_fallback(self) -> None:

--- a/server.json
+++ b/server.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.edwardkim/rhwp",
+  "description": "HWP/HWPX document engine MCP server — read, search, edit, convert and render Korean HWP documents with machine-verifiable envelopes and sessions.",
+  "version": "0.8.2",
+  "websiteUrl": "https://github.com/edwardkim/rhwp",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/edwardkim/rhwp",
+      "version": "0.8.2",
+      "transport": { "type": "stdio" }
+    },
+    {
+      "registryType": "pypi",
+      "identifier": "rhwp",
+      "version": "0.8.2",
+      "transport": { "type": "stdio" }
+    },
+    {
+      "registryType": "npm",
+      "identifier": "@rhwp/node",
+      "version": "0.8.2",
+      "transport": { "type": "stdio" }
+    }
+  ]
+}


### PR DESCRIPTION
## 변경 요약

**설치 채널 잔여 일괄** — 사람·에이전트가 rhwp 를 받는 마지막 관들입니다. 채널별 활성 조건·검증 상태는 가이드 2부(installer_channels_guide.md) 표에 정직 분리했습니다.

| 채널 | 명령 | 활성 |
|---|---|---|
| cargo-binstall | `cargo binstall rhwp` | **머지 즉시**(기존 릴리스 자산 매핑, 4타깃 overrides) |
| deb·rpm·**MSI** | 릴리스 자산 | 다음 태그 자동 첨부(**시크릿 불요** — GITHUB_TOKEN) |
| install.ps1/sh | `irm … \| iex` / `curl … \| bash` | 머지 즉시 |
| AUR(rhwp-bin) | `yay -S rhwp-bin` | 계정 제출(실해시 반영) |
| crates.io | `cargo install rhwp` | **이중 게이트**: 시크릿+`publish --dry-run`(13,975파일·임베드 50건 실측 → include 정비 선행을 로그로 명시, 깨진 패키지를 올리지 않음) |
| server.json | MCP 공식 레지스트리 | **스키마 2025-12-11 실검증** 후 작성 — 제출은 pypi/npm/oci 게시 뒤(#4343) |

### 실증

**install.ps1 실전 E2E(이 PC)**: 실릴리스 v0.8.2 다운로드 → `SHA-256 일치` → `rhwp v0.8.2` 실행 → capabilities 봉투 수신. install.sh 는 로컬 curl TLS 환경 문제로 미검증(동형 구조) 정직 표기, MSI 는 머지 후 `workflow_dispatch` 1회 검증 권장.

## 관련 이슈

closes #4375

## 테스트

- [x] install.ps1 실전 E2E(위) · Cargo.toml 파싱(cargo metadata) OK · server.json JSON 유효 · 문서 메타데이터·상대 링크 검사 이상 없음
- [ ] cargo test / SVG / WASM — 해당 없음(메타데이터·패키징·워크플로 전용, Rust 코드 무변경)

## 성능 영향 및 측정 결과

- 해당 없음

## 스크린샷

- 해당 없음
