### PR TITLE
docs(core): 무효화 플래그 kill 범위 규칙 기록 + 전수 감사

### DIFF
--- a/mydocs/tech/rendering_engine_design.md
+++ b/mydocs/tech/rendering_engine_design.md
@@ -2,7 +2,7 @@
 kind: canonical
 status: active
 canonical: mydocs/tech/rendering_engine_design.md
-last_verified: 2026-07-23
+last_verified: 2026-08-09
 ---
 
 # RHWP 렌더링 엔진 아키텍처 설계서
@@ -407,6 +407,12 @@ source에 쓰거나 편집 때 clone 경로를 직접 mirror하지 않는다.
 문단/control/cell 수가 바뀌지 않는 deferred cell text edit은 명시적 path revision을 먼저 올리고
 pagination만 dirty로 표시한다. #2004 compatibility projection이 실제 존재하는 section은 그
 projection만 section revision으로 무효화한 뒤 transient render 전에 source IR에서 다시 만든다.
+
+### kill 범위 규칙 (#4335)
+
+`dirty_sections`/`dirty_paragraphs`/`Table.dirty`류 무효화 플래그의 clear(kill)는 그 플래그를 읽는
+모든 지점(use)의 immediate dominator에서만 수행한다 — 그보다 넓은 범위(예: 처리한 구역 하나만 읽고
+전체 구역을 clear)에서 지우면 아직 소비되지 않은 dirty 정보가 죽어 stale 캐시가 영구히 남는다(#4325).
 
 ### 논리 경로와 lookup
 


### PR DESCRIPTION
## 무엇을

무효화 플래그의 clear(kill) 를 어디에 두어야 하는지 규칙을 canonical 문서에 기록한다.

## 왜

#4325 는 `table.dirty` 를 **문서 범위로 지우고 구역 범위로 소비**해 stale `MeasuredTable` 이
영구히 남는 결함이었다. 코드는 고쳤지만(#4325 PR), 같은 모양의 플래그가 더 있는데 **어느 범위에서
지워야 하는지에 대한 규칙이 없어** 다음 플래그가 같은 실수를 그대로 물려받는다.

같은 파일 안에서도 두 방식이 공존한다 — `rendering.rs:3815` 는 처리한 구역 하나만 지우고,
`:4627`(수정 전)은 전 구역을 쓸었다.

## 규칙

`mydocs/tech/rendering_engine_design.md` §12 "렌더 정규화 derived state 계약" 뒤에 추가:

> 무효화 플래그의 clear(kill)는 그 플래그를 읽는 모든 지점(use)의 immediate dominator 에서만
> 수행한다 — 그보다 넓은 범위에서 지우면 아직 소비되지 않은 dirty 정보가 죽어 stale 캐시가
> 영구히 남는다(#4325).

이 문서를 고른 이유: `mydocs/manual/README.md` 가 "기술 사실·설계 결정은 tech 지도에서 찾는다"고
명시하고, `mydocs/tech/README.md` 가 렌더링 엔진의 canonical 문서로 이 파일을 지정한다. §12 가
이미 `document_epoch`/`section_revisions`/`path_revisions` 와 dirty 무효화 계약을 다루는
자리라 새 문서를 만들지 않았다.

## 전수 감사 결과

플래그 6종 + revision 3단계의 def/use/kill 을 전수 확인했다. **새 위반은 없다** — #4325 의
`table.dirty` 하나뿐이며 그건 별도 PR 에서 고친다.

| 플래그 | 판정 |
|---|---|
| `DocumentCore.dirty_sections` (`mod.rs:163`) | 위반 없음 — kill 두 곳 모두 use 와 같은 idx 스코프 |
| `DocumentCore.dirty_paragraphs` (`mod.rs:169`) | 위반 없음 |
| `Table.dirty` (`model/table.rs:66`) | `rendering.rs:3829` 는 스코프 동치라 정상. `:4627` 이 #4325 위반 |
| `RenderNode.dirty` (`render_tree.rs:115`) | kill 이 프로덕션에 없어 위반 불가 |
| `DocInfo.raw_stream_dirty` (`model/document.rs:190`) | kill 이 프로덕션에 없어 위반 불가 |
| `TypesetState.vpos_ladder_dirty` (`typeset.rs:961`) | 위반 없음 — 단일 조판 패스 내 순차 스칼라 |
| `RenderNormalizationState` revision 3단계 (`mod.rs:110-116`) | 위반 불가 — revision 비교 방식은 이 결함 클래스에 면역 |

`Table.dirty_flag` (`model/table.rs:148`) 는 제외했다 — HWPX `<hp:tc dirty>` 속성의 라운드트립
보존용이지 무효화 플래그가 아니다. 같은 오분류가 더 없는지 필드 선언을 전수 grep 해 확인했다.

## 후속 후보 (이 PR 범위 밖)

- `RenderNode.dirty` 는 `RenderNode::new` 가 항상 `true` 로 세우는데 `has_dirty_nodes`/
  `mark_clean`/`needs_render` 의 프로덕션 호출부가 0건이다. observer 패턴 배선이 죽어 있고,
  `#[serde]` skip 이 없어 모든 노드가 JSON 에 `dirty:true` 를 싣고 나간다.
- `Section.raw_stream` 과 레코드 계층 `raw_data` 는 방향이 반대인(`None`=무효) 같은 부류지만
  `tech/serialization_passthrough_contract.md` 가 별도 계약으로 다룬다.

## 검증

문서 전용 변경이다. `scripts/check_markdown_links.py`, `scripts/check_document_metadata.py`,
`git diff --check` 통과. front matter `last_verified` 갱신.

Closes #4335
