### PR TITLE
core: 문단 서식의 흐름 영향 술어 도입 + 머리말/꼬리말 stale 스타일 수정

### DIFF
--- a/mydocs/working/task_m100_4324_stage1.md
+++ b/mydocs/working/task_m100_4324_stage1.md
@@ -1,0 +1,78 @@
+# task_m100_4324 Stage 1 — 문단 서식 흐름 영향 술어와 머리말/꼬리말 stale 스타일
+
+- **이슈**: [#4324](https://github.com/edwardkim/rhwp/issues/4324)
+- **PR**: [#4380](https://github.com/edwardkim/rhwp/pull/4380)
+- **브랜치**: `fix/issue-4324-para-flow-predicate`
+- **분기 기준**: `upstream/devel` `e48fe8694`
+- **상태**: 로컬 전체 검증 통과, PR 게시
+- **기록일**: 2026-08-09 KST
+
+## 1. 결함 — 게이트가 줄간격만 봤다
+
+```rust
+if mods.line_spacing.is_some() || mods.line_spacing_type.is_some() {
+```
+
+여백·들여쓰기는 사용 가능 폭을, 줄나눔 단위는 토큰 경계를 바꾸는데 리플로우를 건너뛰어 문단 서식을
+바꿔도 줄바꿈이 변경 전 상태로 남았다.
+
+같은 조건이 세 곳에 있었다 — `apply_para_format_native`(`formatting.rs:1423`),
+`apply_para_format_in_cell_native`(`:1592`), 그리고 **이슈에 없던**
+`apply_para_format_in_hf_native`(`header_footer_ops.rs:857`).
+
+## 2. `ParaShapeMods` 27개 필드 전수 판정
+
+`char_shape_mods_affect_text_flow`(`formatting.rs:16`)의 문단모양 대응물을 그 형태 그대로 만들었다.
+흐름에 영향을 주는 것은 7개다.
+
+| 필드 | 근거 |
+|---|---|
+| `margin_left`/`margin_right` | 호출부가 `available_width = 폭 - margin_left - margin_right` |
+| `indent` | `fill_lines` 의 `eff_w()` 가 첫 줄 유효 폭을 줄인다(`line_breaking.rs:681-696`) |
+| `english_break_unit`/`korean_break_unit` | `tokenize_paragraph`/`fill_lines` 가 토큰 경계를 바꾼다(`:360`, `:375`, `:798`) |
+| `line_spacing`/`line_spacing_type` | 원래 게이트 |
+
+나머지 20개는 `reflow_line_segs`/`fill_lines` 가 읽지 않는다. `alignment` 는 `line_breaking.rs` 에
+참조 0건으로 이미 나뉜 줄 안에서의 배분이고, 문단 테두리는 레이아웃 후 장식이며, 문단 간격·쪽나눔
+휴리스틱은 `rebuild_section` 이 매번 다시 계산하는 단계에서 처리된다.
+
+`tab_def_id` 는 오늘 시점 흐름에 영향이 없다 — `resolve_single_para_style` 이 `default_tab_width` 를
+4000 HWPUNIT 상수로 고정하고 `tab_stops` 를 `fill_lines` 에 넘기지 않는다. 별개 사안으로 #4403 에
+등록했다.
+
+## 3. 리뷰가 잡아낸 두 번째 결함
+
+1번 수정만으로는 **머리말/꼬리말이 동작하지 않았다.**
+
+`apply_para_format_in_hf_native` 는 `find_or_create_para_shape` 로 새 para_shape 를 만든 직후
+(`:848`) `reflow_hf_paragraph` 를 부른다(`:859`). 그 사이 `self.styles` 갱신이 없어,
+`reflow_hf_paragraph` 가 캐시된 `self.styles.para_styles.get(new_id)` 를 읽으면 **`None` → 여백
+0.0 폴백**이다.
+
+재현: 200자 머리말에 `marginLeft:8000` → `before=5 lines, after=5 lines`(변화 없음).
+
+`resolve_styles(&self.document.doc_info, self.dpi)` 로 새로 뽑도록 고쳤다 —
+`reflow_cell_paragraph`(`text_editing.rs`)와 `apply_para_format_native` 가 이미 쓰는 규약이다.
+
+**줄간격 경로도 같은 뿌리라 함께 해소된다.** 종전에도 새 para_shape 가 만들어지면 `reflow_line_segs`
+가 stale 스냅샷에서 `line_spacing` 을 읽어 기본값(`Percent`/160.0)으로 폴백했다. 같은 `styles`
+변수를 공유하므로 한 번의 수정으로 둘 다 닫힌다.
+
+## 4. 게이트가 잡은 세 번째
+
+재게이트에서 `issue_3494_char_count_convention` 규약 가드가 실패했다 — 새로 쓴 테스트 헬퍼가
+`para.char_count = text.chars().count()` 로 대입했는데, 공통 IR 의 `char_count` 는 **문단 종결자를
+포함**한다(`model/paragraph.rs`). `+ 1` 로 고쳤다.
+
+프로덕션이 아니라 **테스트 코드의 규약 위반**을 잡은 사례다.
+
+## 5. 검증 (완료)
+
+- 술어 단위 테스트 2건 + 본문·셀 재현 2건(이슈 실측 규모: 셀 폭 20000 HWPUNIT, `marginLeft:8000`).
+- **행위 테스트** `para_format_margin_change_in_header_reflows_with_correct_width_not_stale_styles`
+  — 구현 전에 먼저 작성해 미수정 코드에서 실패를 확인했고, 수정 후 stale 읽기를 일부러 되돌리니
+  다시 실패하는 것까지 확인했다. 술어 단위 테스트로는 3절 결함이 잡히지 않는다.
+- `cargo test --profile release-test --tests` 전체 통과.
+- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` 통과.
+
+남은 미래 조건은 GitHub Actions 와 작업지시자 승인, merge 다.

--- a/src/document_core/commands/formatting.rs
+++ b/src/document_core/commands/formatting.rs
@@ -22,6 +22,42 @@ fn char_shape_mods_affect_text_flow(mods: &crate::model::style::CharShapeMods) -
         || mods.char_offsets.is_some()
 }
 
+/// [#4324] `ParaShapeMods` 변경이 줄바꿈(LineSeg 재계산)에 영향을 주는지 판정한다.
+/// `char_shape_mods_affect_text_flow`(:16)의 문단모양 대응물 — 형태를 그대로 따른다.
+///
+/// 전수 조사(reflow_line_segs/fill_lines, composer/line_breaking.rs 가 실제로 읽는
+/// 입력만 기준으로 판정, #4324 보고 참고):
+/// - `margin_left`/`margin_right`: 호출부가 `available_width = 폭 - margin_left -
+///   margin_right`로 사용 가능 폭을 좁힌다(:25-46, reflow_cell_paragraph
+///   text_editing.rs:2245-2247).
+/// - `indent`: `fill_lines`의 `eff_w()`가 첫 줄(또는 이어줄) 유효 폭을 들여쓰기만큼
+///   줄인다(line_breaking.rs:681-696).
+/// - `english_break_unit`/`korean_break_unit`: `tokenize_paragraph`/`fill_lines`가 토큰
+///   경계 자체(영어 단어/하이픈/글자, 한글 글자 단위 break 허용)를 바꾼다
+///   (line_breaking.rs:360, 375, 798).
+/// - `line_spacing`/`line_spacing_type`: 원래 게이트 — `reflow_line_segs`가 LineSeg별
+///   `line_spacing` 값을 다시 계산하므로 유지한다.
+///
+/// 나머지 필드(alignment, spacing_before/after, head_type, para_level, widow_orphan,
+/// keep_with_next, keep_lines, page_break_before, font_line_height, single_line,
+/// auto_space_kr_en/num, vertical_align, tab_def_id, numbering_id, border_fill_id,
+/// border_spacing, border_connect, border_ignore_margin)는 `reflow_line_segs`/
+/// `fill_lines`가 읽지 않는다 — 정렬은 이미 배치된 줄 안에서의 렌더링 배분일 뿐이고,
+/// 문단 테두리/배경은 레이아웃 완료 후 장식 사각형으로만 그려지며(layout.rs
+/// render_para_border_groups), 문단 간격·쪽나눔 휴리스틱은 `rebuild_section`이 매번
+/// 다시 계산하는 vpos/페이지네이션 단계에서 처리된다. `tab_def_id`는 현재
+/// `resolve_single_para_style`이 `default_tab_width`를 4000 HWPUNIT 상수로 고정해
+/// 두므로(별개 결함 가능성, 이 이슈 범위 밖) 오늘 시점 코드에서 흐름에 영향이 없다.
+pub(super) fn para_shape_mods_affect_text_flow(mods: &crate::model::style::ParaShapeMods) -> bool {
+    mods.line_spacing.is_some()
+        || mods.line_spacing_type.is_some()
+        || mods.margin_left.is_some()
+        || mods.margin_right.is_some()
+        || mods.indent.is_some()
+        || mods.english_break_unit.is_some()
+        || mods.korean_break_unit.is_some()
+}
+
 fn body_available_width_for_para_shape(
     core: &DocumentCore,
     sec_idx: usize,
@@ -1419,8 +1455,10 @@ impl DocumentCore {
         let new_id = self.document.find_or_create_para_shape(base_id, &mods);
         self.document.sections[sec_idx].paragraphs[para_idx].para_shape_id = new_id;
 
-        // 줄간격 변경 시 LineSeg 재계산 (compose는 LineSeg 값을 그대로 사용하므로)
-        if mods.line_spacing.is_some() || mods.line_spacing_type.is_some() {
+        // 줄바꿈에 영향을 주는 변경 시 LineSeg 재계산 (compose는 LineSeg 값을 그대로
+        // 사용하므로). 줄간격뿐 아니라 여백/들여쓰기/줄나눔 단위도 사용 가능 폭·토큰
+        // 경계를 바꾼다 — [#4324] para_shape_mods_affect_text_flow(:16 부근) 참고.
+        if para_shape_mods_affect_text_flow(&mods) {
             let styles = resolve_styles(&self.document.doc_info, self.dpi);
             let section = &self.document.sections[sec_idx];
             let page_def = &section.section_def.page_def;
@@ -1584,12 +1622,16 @@ impl DocumentCore {
             cell_para.para_shape_id = new_id;
         }
 
-        // 줄간격 변경 시 셀 내 문단 LineSeg 재계산.
+        // 줄바꿈에 영향을 주는 변경 시 셀 내 문단 LineSeg 재계산.
         //
         // [자체 발견] apply_char_format_in_cell_native 와 동일한 결함 — 페이지 본문 단 폭을
         // 셀 리플로우에 썼다. undo 형제 set_cell_para_shape_id_native(:1538)는 이미
         // reflow_cell_paragraph 를 쓴다. 그 헬퍼로 통일해 폭 계산과 dirty 마킹을 함께 맞춘다.
-        if mods.line_spacing.is_some() || mods.line_spacing_type.is_some() {
+        //
+        // [#4324] 게이트가 줄간격만 보고 여백/들여쓰기/줄나눔 단위를 놓쳤다 — 이 값들도
+        // reflow_cell_paragraph 가 계산하는 사용 가능 폭·토큰 경계에 실제로 쓰인다.
+        // para_shape_mods_affect_text_flow(:16 부근)로 판정을 통일한다.
+        if para_shape_mods_affect_text_flow(&mods) {
             self.reflow_cell_paragraph(
                 sec_idx,
                 parent_para_idx,
@@ -2188,10 +2230,10 @@ impl DocumentCore {
 
 #[cfg(test)]
 mod tests {
-    use super::{char_shape_mods_affect_text_flow, DocumentCore};
+    use super::{char_shape_mods_affect_text_flow, para_shape_mods_affect_text_flow, DocumentCore};
     use crate::model::control::Control;
     use crate::model::paragraph::{CharShapeRef, Paragraph};
-    use crate::model::style::CharShapeMods;
+    use crate::model::style::{CharShapeMods, ParaShapeMods};
     use crate::model::table::{Cell, Table};
 
     #[test]
@@ -2216,6 +2258,116 @@ mod tests {
             ..Default::default()
         };
         assert!(!char_shape_mods_affect_text_flow(&mods));
+    }
+
+    /// [#4324] margin/indent/줄나눔 단위 변경도 사용 가능 폭·토큰 경계를 바꾸므로
+    /// 줄간격과 마찬가지로 리플로우가 필요하다.
+    #[test]
+    fn para_margin_indent_and_break_unit_changes_require_text_reflow() {
+        let mods = ParaShapeMods {
+            margin_left: Some(8000),
+            ..Default::default()
+        };
+        assert!(para_shape_mods_affect_text_flow(&mods));
+
+        let mods = ParaShapeMods {
+            margin_right: Some(4000),
+            ..Default::default()
+        };
+        assert!(para_shape_mods_affect_text_flow(&mods));
+
+        let mods = ParaShapeMods {
+            indent: Some(2000),
+            ..Default::default()
+        };
+        assert!(para_shape_mods_affect_text_flow(&mods));
+
+        let mods = ParaShapeMods {
+            english_break_unit: Some(1),
+            ..Default::default()
+        };
+        assert!(para_shape_mods_affect_text_flow(&mods));
+
+        let mods = ParaShapeMods {
+            korean_break_unit: Some(1),
+            ..Default::default()
+        };
+        assert!(para_shape_mods_affect_text_flow(&mods));
+
+        // 기존에 이미 게이트하던 줄간격도 계속 포함해야 한다 (회귀 방지).
+        let mods = ParaShapeMods {
+            line_spacing: Some(150),
+            ..Default::default()
+        };
+        assert!(para_shape_mods_affect_text_flow(&mods));
+        let mods = ParaShapeMods {
+            line_spacing_type: Some(crate::model::style::LineSpacingType::Fixed),
+            ..Default::default()
+        };
+        assert!(para_shape_mods_affect_text_flow(&mods));
+    }
+
+    /// [#4324] 정렬/문단테두리/문단간격/쪽나눔 휴리스틱 등은 `reflow_line_segs`가
+    /// 읽지 않는 입력이다 — 리플로우를 요구하면 안 된다(전수 조사 결과, 판정 근거는
+    /// `para_shape_mods_affect_text_flow` 문서 주석 참고).
+    #[test]
+    fn para_shape_changes_without_flow_impact_do_not_require_text_reflow() {
+        let mods = ParaShapeMods {
+            alignment: Some(crate::model::style::Alignment::Center),
+            ..Default::default()
+        };
+        assert!(!para_shape_mods_affect_text_flow(&mods));
+
+        let mods = ParaShapeMods {
+            spacing_before: Some(1000),
+            spacing_after: Some(1000),
+            ..Default::default()
+        };
+        assert!(!para_shape_mods_affect_text_flow(&mods));
+
+        let mods = ParaShapeMods {
+            widow_orphan: Some(true),
+            keep_with_next: Some(true),
+            keep_lines: Some(true),
+            page_break_before: Some(true),
+            ..Default::default()
+        };
+        assert!(!para_shape_mods_affect_text_flow(&mods));
+
+        let mods = ParaShapeMods {
+            border_fill_id: Some(3),
+            border_spacing: Some([100, 100, 100, 100]),
+            border_connect: Some(true),
+            border_ignore_margin: Some(true),
+            ..Default::default()
+        };
+        assert!(!para_shape_mods_affect_text_flow(&mods));
+
+        let mods = ParaShapeMods {
+            head_type: Some(crate::model::style::HeadType::Number),
+            para_level: Some(1),
+            numbering_id: Some(1),
+            ..Default::default()
+        };
+        assert!(!para_shape_mods_affect_text_flow(&mods));
+
+        // tab_def_id: 현재 resolve_single_para_style이 default_tab_width를 상수로 고정해
+        // 두므로(별개 결함), 오늘 시점 코드 기준으로는 흐름에 영향이 없다.
+        let mods = ParaShapeMods {
+            tab_def_id: Some(2),
+            ..Default::default()
+        };
+        assert!(!para_shape_mods_affect_text_flow(&mods));
+
+        let mods = ParaShapeMods {
+            font_line_height: Some(true),
+            single_line: Some(true),
+            auto_space_kr_en: Some(true),
+            auto_space_kr_num: Some(true),
+            vertical_align: Some(1),
+            ..Default::default()
+        };
+        assert!(!para_shape_mods_affect_text_flow(&mods));
     }
 
     #[test]
@@ -2343,6 +2495,15 @@ mod cell_reflow_width_tests {
     use crate::model::table::{Cell, Table};
 
     fn core_with_narrow_cell(text: &str) -> DocumentCore {
+        // 셀 폭 200 HWPUNIT — 페이지 본문 폭(수만 HWPUNIT)의 1% 미만.
+        core_with_cell(text, 200)
+    }
+
+    /// [#4324] `core_with_narrow_cell`의 셀 폭 파라미터화 버전. 200 HWPUNIT (약 2.7px)
+    /// 는 어떤 텍스트든 이미 1글자/줄로 포화돼 있어 margin/indent를 더 좁혀도 줄 수가
+    /// 늘어나는 걸 관찰할 여지가 없다 — margin 변화 전후 비교 테스트는 더 넓은 폭이
+    /// 필요해 파라미터화한다.
+    fn core_with_cell(text: &str, cell_width: u32) -> DocumentCore {
         let mut doc = Document::default();
 
         let mut cell_para = Paragraph {
@@ -2369,7 +2530,7 @@ mod cell_reflow_width_tests {
             col: 0,
             col_span: 1,
             row_span: 1,
-            width: 200, // 셀 폭 — 페이지 본문 폭(수만 HWPUNIT)의 1% 미만
+            width: cell_width,
             paragraphs: vec![cell_para],
             ..Default::default()
         }];
@@ -2492,6 +2653,86 @@ mod cell_reflow_width_tests {
         assert!(
             line_count > 1,
             "셀 폭(200 HWPUNIT)으로 리플로우했다면 40자가 여러 줄로 나뉘어야 함              (실제 {line_count}줄 — 페이지 본문 폭을 쓰면 1줄로 뭉친다)"
+        );
+    }
+
+    /// [#4324] 재현 테스트 — 여백(marginLeft) 변경 전후 줄바꿈 결과 비교.
+    ///
+    /// 이슈 실측 프로브와 동일한 축척을 쓴다: 셀 폭 20000 HWPUNIT(≈266.7px, 이슈의
+    /// "266.1px" 실측과 정합), `marginLeft: 8000`(≈53.3px 축소, 이슈의 "212.8px" 실측과
+    /// 정합). 고정폭 게이트(line_spacing만 보던 옛 조건)에서는 marginLeft 변경이
+    /// `reflow_cell_paragraph`를 호출하지 않아 LineSeg 경계가 그대로 남는다 — 줄
+    /// 상자만 좁아지고 글자 수는 그대로인 원본 결함을 그대로 재현한다.
+    ///
+    /// 먼저 `reflow_cell_paragraph`를 직접 호출해 "여백 0" 기준선을 실제로 셀 폭으로
+    /// 계산한 뒤, `marginLeft` 적용 전/후의 줄 수를 비교한다.
+    #[test]
+    fn para_format_margin_left_change_triggers_cell_reflow_and_rewraps() {
+        let text = "A".repeat(200);
+        let mut core = core_with_cell(&text, 20000);
+
+        // 기준선: 여백 0 상태에서 실제 셀 폭(20000 HWPUNIT)으로 먼저 리플로우한다.
+        core.reflow_cell_paragraph(0, 0, 0, 0, 0);
+        let before_lines = {
+            let table = match &core.document.sections[0].paragraphs[0].controls[0] {
+                Control::Table(t) => t,
+                _ => panic!("표 컨트롤이어야 함"),
+            };
+            table.cells[0].paragraphs[0].line_segs.len()
+        };
+
+        // 이슈 실측과 동일한 marginLeft(8000)를 적용한다 — 사용 가능 폭이 ≈53.3px 줄어든다.
+        core.apply_para_format_in_cell_native(0, 0, 0, 0, 0, r#"{"marginLeft":8000}"#)
+            .expect("서식 적용이 성공해야 함");
+        let after_lines = {
+            let table = match &core.document.sections[0].paragraphs[0].controls[0] {
+                Control::Table(t) => t,
+                _ => panic!("표 컨트롤이어야 함"),
+            };
+            table.cells[0].paragraphs[0].line_segs.len()
+        };
+
+        assert!(
+            after_lines > before_lines,
+            "marginLeft 적용으로 사용 가능 폭이 줄었으면 줄 수가 늘어야 함 \
+             (before={before_lines}줄, after={after_lines}줄 — 게이트가 marginLeft를 놓치면 \
+             after==before로 남는다)"
+        );
+    }
+
+    /// [#4324] 재현 테스트 — `indent`(들여쓰기) 변경도 marginLeft와 동일하게
+    /// `fill_lines`의 유효 폭을 줄이므로 리플로우를 유발해야 한다.
+    #[test]
+    fn para_format_indent_change_triggers_cell_reflow_and_rewraps() {
+        let text = "A".repeat(200);
+        let mut core = core_with_cell(&text, 20000);
+
+        core.reflow_cell_paragraph(0, 0, 0, 0, 0);
+        let before_lines = {
+            let table = match &core.document.sections[0].paragraphs[0].controls[0] {
+                Control::Table(t) => t,
+                _ => panic!("표 컨트롤이어야 함"),
+            };
+            table.cells[0].paragraphs[0].line_segs.len()
+        };
+
+        // indent는 첫 줄 유효 폭만 줄이므로(line_breaking.rs eff_w), margin과 달리 값이
+        // 작으면 재배치가 뒤 줄로 흡수돼 총 줄 수가 그대로일 수 있다. 셀 폭(20000)에
+        // 근접한 큰 값을 써서 첫 줄이 거의 비워지도록 만들어 확실히 줄 수를 늘린다.
+        core.apply_para_format_in_cell_native(0, 0, 0, 0, 0, r#"{"indent":19000}"#)
+            .expect("서식 적용이 성공해야 함");
+        let after_lines = {
+            let table = match &core.document.sections[0].paragraphs[0].controls[0] {
+                Control::Table(t) => t,
+                _ => panic!("표 컨트롤이어야 함"),
+            };
+            table.cells[0].paragraphs[0].line_segs.len()
+        };
+
+        assert!(
+            after_lines > before_lines,
+            "indent 적용으로 첫 줄 유효 폭이 줄었으면 줄 수가 늘어야 함 \
+             (before={before_lines}줄, after={after_lines}줄)"
         );
     }
 

--- a/src/document_core/commands/header_footer_ops.rs
+++ b/src/document_core/commands/header_footer_ops.rs
@@ -12,6 +12,7 @@ use crate::model::event::DocumentEvent;
 use crate::model::header_footer::{Footer, Header, HeaderFooterApply};
 use crate::model::paragraph::{ParaMeta, Paragraph};
 use crate::renderer::composer::reflow_line_segs;
+use crate::renderer::style_resolver::resolve_styles;
 
 /// applyTo u8 값 → HeaderFooterApply 변환
 fn apply_from_u8(v: u8) -> HeaderFooterApply {
@@ -761,13 +762,21 @@ impl DocumentCore {
             hwpunit_to_px(text_width, self.dpi)
         };
 
+        // [#4324] 호출부(apply_para_format_in_hf_native)가 이 직전에
+        // find_or_create_para_shape 로 새 para_shape 를 만들 수 있다. 캐시된
+        // self.styles 는 직전 rebuild_section 스냅샷이라 그 새 id 를 포함하지 않을 수
+        // 있어(margin_left/right 가 0.0 으로 폴백) 여백을 무시한 폭으로 리플로우해버린다.
+        // formatting.rs 의 reflow_cell_paragraph(twin, text_editing.rs)와 동일하게
+        // doc_info 에서 매번 새로 resolve 한다.
+        let styles = resolve_styles(&self.document.doc_info, self.dpi);
+
         // 문단 여백 적용
         let para_shape_id =
             match self.get_hf_paragraph_ref(section_idx, is_header, apply_to, hf_para_idx) {
                 Some(p) => p.para_shape_id,
                 None => return,
             };
-        let para_style = self.styles.para_styles.get(para_shape_id as usize);
+        let para_style = styles.para_styles.get(para_shape_id as usize);
         let margin_left = para_style.map(|s| s.margin_left).unwrap_or(0.0);
         let margin_right = para_style.map(|s| s.margin_right).unwrap_or(0.0);
         let final_width = (available_width - margin_left - margin_right).max(0.0);
@@ -782,7 +791,7 @@ impl DocumentCore {
                 _ => return,
             };
             if let Some(para) = paragraphs.get_mut(hf_para_idx) {
-                reflow_line_segs(para, final_width, &self.styles, self.dpi);
+                reflow_line_segs(para, final_width, &styles, self.dpi);
             }
         }
     }
@@ -1646,6 +1655,94 @@ mod tests {
             para.controls.len(),
             para.ctrl_data_records.len(),
             "삽입 후 두 배열 길이가 정합해야 한다"
+        );
+    }
+
+    /// [#4324] `reflow_hf_paragraph`가 `self.styles`(직전 rebuild_section 스냅샷)를
+    /// 읽으면, `apply_para_format_in_hf_native`가 그 직전에 `find_or_create_para_shape`로
+    /// 막 만든 새 para_shape_id는 그 스냅샷의 `para_styles` 범위 밖이라
+    /// margin_left/margin_right가 0.0으로 폴백한다 — 여백을 무시한(옛) 폭으로
+    /// 리플로우해버려 이 이슈가 고치려던 결함이 머리말/꼬리말 경로에서 그대로 남는다.
+    ///
+    /// 재현: `rebuild_section`으로 self.styles 스냅샷을 "margin 0, para_shape 1개"
+    /// 상태로 고정한 뒤(직전 명령이 남긴 스냅샷과 같은 전제), marginLeft 적용 전/후의
+    /// 줄 수를 비교한다.
+    #[test]
+    fn para_format_margin_change_in_header_reflows_with_correct_width_not_stale_styles() {
+        use crate::model::document::{Document, Section, SectionDef};
+        use crate::model::page::PageDef;
+        use crate::model::paragraph::CharShapeRef;
+
+        let mut doc = Document::default();
+        let section = Section {
+            section_def: SectionDef {
+                page_def: PageDef {
+                    width: 28504,
+                    height: 84188,
+                    margin_left: 4252,
+                    margin_right: 4252,
+                    margin_top: 5668,
+                    margin_bottom: 4252,
+                    margin_header: 4252,
+                    margin_footer: 4252,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            paragraphs: vec![Paragraph::default()],
+            raw_stream: None,
+        };
+        // text_width = 28504 - 4252 - 4252 = 20000 HWPUNIT (≈266.7px) — formatting.rs의
+        // 셀 재현 테스트와 같은 축척.
+        doc.sections.push(section);
+        let mut core = DocumentCore::new_empty();
+        core.document = doc;
+        core.composed = vec![Vec::new()];
+        core.dirty_sections = vec![true];
+        core.dirty_paragraphs = vec![None];
+
+        core.create_header_footer_native(0, true, 0)
+            .expect("머리말 생성이 성공해야 함");
+
+        let text = "A".repeat(200);
+        {
+            let para = core.get_hf_paragraph_mut(0, true, 0, 0).unwrap();
+            para.text = text.clone();
+            para.char_offsets = (0..text.chars().count() as u32).collect();
+            para.char_count = text.chars().count() as u32;
+            para.char_shapes = vec![CharShapeRef {
+                start_pos: 0,
+                char_shape_id: 0,
+            }];
+            para.has_para_text = true;
+        }
+
+        // self.styles 스냅샷을 지금(margin 0, para_shape 1개) 상태로 고정한다.
+        core.rebuild_section(0);
+
+        // 기준선: 여백 0 상태에서 실제 폭으로 리플로우한 줄 수.
+        core.reflow_hf_paragraph(0, true, 0, 0);
+        let before_lines = core
+            .get_hf_paragraph_ref(0, true, 0, 0)
+            .unwrap()
+            .line_segs
+            .len();
+
+        // marginLeft 적용 — 기존 para_shape(margin 0)와 달라 새 id가 만들어진다.
+        // self.styles가 stale이면 새 id 조회가 None → margin 0 폴백 → 폭이 그대로다.
+        core.apply_para_format_in_hf_native(0, true, 0, 0, r#"{"marginLeft":8000}"#)
+            .expect("서식 적용이 성공해야 함");
+        let after_lines = core
+            .get_hf_paragraph_ref(0, true, 0, 0)
+            .unwrap()
+            .line_segs
+            .len();
+
+        assert!(
+            after_lines > before_lines,
+            "marginLeft 적용으로 사용 가능 폭이 줄었으면 줄 수가 늘어야 함 \
+             (before={before_lines}줄, after={after_lines}줄 — self.styles가 stale이면 \
+             새 para_shape_id 조회가 None이 되어 margin=0으로 폴백, after==before로 남는다)"
         );
     }
 }

--- a/src/document_core/commands/header_footer_ops.rs
+++ b/src/document_core/commands/header_footer_ops.rs
@@ -1,5 +1,6 @@
 //! 머리말/꼬리말 생성·조회·텍스트 편집 관련 native 메서드
 
+use super::formatting::para_shape_mods_affect_text_flow;
 use crate::document_core::helpers::{
     build_tab_def_from_json, json_has_border_keys, json_has_tab_keys, parse_json_i16_array,
     parse_para_shape_mods,
@@ -858,8 +859,12 @@ impl DocumentCore {
             para.para_shape_id = new_id;
         }
 
-        // 줄간격 변경 시 LineSeg 재계산
-        if mods.line_spacing.is_some() || mods.line_spacing_type.is_some() {
+        // 줄바꿈에 영향을 주는 변경 시 LineSeg 재계산.
+        //
+        // [#4324] formatting.rs의 apply_para_format_native/apply_para_format_in_cell_native
+        // 와 동일한 게이트 결함 — 줄간격만 보고 여백/들여쓰기/줄나눔 단위를 놓쳤다.
+        // para_shape_mods_affect_text_flow(formatting.rs:16 부근)로 판정을 통일한다.
+        if para_shape_mods_affect_text_flow(&mods) {
             self.reflow_hf_paragraph(section_idx, is_header, apply_to, hf_para_idx);
         }
 

--- a/src/document_core/commands/header_footer_ops.rs
+++ b/src/document_core/commands/header_footer_ops.rs
@@ -1709,7 +1709,8 @@ mod tests {
             let para = core.get_hf_paragraph_mut(0, true, 0, 0).unwrap();
             para.text = text.clone();
             para.char_offsets = (0..text.chars().count() as u32).collect();
-            para.char_count = text.chars().count() as u32;
+            // 공통 IR 의 char_count 는 문단 종결자를 포함한다 (model/paragraph.rs).
+            para.char_count = text.chars().count() as u32 + 1;
             para.char_shapes = vec![CharShapeRef {
                 start_pos: 0,
                 char_shape_id: 0,


### PR DESCRIPTION
## 무엇을

문단 서식 변경이 줄바꿈에 영향을 주는지 판정하는 술어를 만들고, 세 곳의 좁은 게이트를 그것으로
통일한다. 그 과정에서 드러난 머리말/꼬리말 리플로우의 stale 스타일 결함도 함께 고친다.

## 1. 흐름 영향 술어 — #4324

게이트가 줄간격만 봤다:

```rust
if mods.line_spacing.is_some() || mods.line_spacing_type.is_some() {
```

여백·들여쓰기는 사용 가능 폭을 바꾸고 줄나눔 단위는 토큰 경계를 바꾸는데도 리플로우를 건너뛰어,
문단 서식을 바꿔도 줄바꿈이 **변경 전 상태로 남았다**.

같은 조건이 세 곳에 있었다 — `apply_para_format_native` (`formatting.rs:1423`),
`apply_para_format_in_cell_native` (`:1592`), 그리고 이슈에 없던
`apply_para_format_in_hf_native` (`header_footer_ops.rs:857`).

`char_shape_mods_affect_text_flow` (`formatting.rs:16`) 의 문단모양 대응물
`para_shape_mods_affect_text_flow` 를 그 형태 그대로 만들어 셋을 통일했다.

`ParaShapeMods` 27개 필드를 전수 판정했다. 흐름에 영향을 주는 것은 7개다:

| 필드 | 근거 |
|---|---|
| `margin_left` / `margin_right` | 호출부가 `available_width = 폭 - margin_left - margin_right` 로 쓴다 |
| `indent` | `fill_lines` 의 `eff_w()` 가 첫 줄 유효 폭을 줄인다 (`line_breaking.rs:681-696`) |
| `english_break_unit` / `korean_break_unit` | `tokenize_paragraph`/`fill_lines` 가 토큰 경계 자체를 바꾼다 (`:360`, `:375`, `:798`) |
| `line_spacing` / `line_spacing_type` | 원래 게이트 |

나머지 20개는 `reflow_line_segs`/`fill_lines` 가 읽지 않는다 — `alignment` 는 이미 나뉜 줄 안에서의
배분이고(`line_breaking.rs` 에 참조 0건), 문단 테두리는 레이아웃 후 장식이며, 문단 간격·쪽나눔
휴리스틱은 `rebuild_section` 이 매번 다시 계산하는 단계에서 처리된다.

`tab_def_id` 는 오늘 시점 흐름에 영향이 없다 — `resolve_single_para_style` 이
`default_tab_width` 를 4000 HWPUNIT 상수로 고정하고 `tab_stops` 를 `fill_lines` 에 넘기지 않는다.
별개 결함 가능성이 있으나 이 PR 범위 밖이다.

## 2. 머리말/꼬리말 stale 스타일 — 위 수정이 드러낸 결함

`apply_para_format_in_hf_native` 는 `find_or_create_para_shape` 로 **새 para_shape 를 만든 직후**
(`:848`) `reflow_hf_paragraph` 를 부른다 (`:859`). 그 사이 `self.styles` 갱신이 없다.

`reflow_hf_paragraph` 는 캐시된 `self.styles.para_styles.get(new_id)` 를 읽었다 — 새로 만든 id 는
직전 `rebuild_section` 스냅샷에 없으므로 `None`, 여백이 **0.0 으로 폴백**한다.

즉 1번 수정으로 머리말/꼬리말 여백 리플로우를 추가해도 **여백을 무시한 폭으로 재배치**해
고치려던 버그가 그대로 남는다. 재현 확인: 200자 머리말에 `marginLeft:8000` 적용 →
`before=5 lines, after=5 lines` (변화 없음).

`resolve_styles(&self.document.doc_info, self.dpi)` 로 새로 뽑도록 고쳤다 —
`reflow_cell_paragraph` (`text_editing.rs`) 와 `apply_para_format_native` 가 이미 쓰는 규약이다.

**줄간격 경로도 같은 뿌리라 함께 해소된다.** 종전에도 새 para_shape 가 만들어지면 `reflow_line_segs`
가 stale 스냅샷에서 `line_spacing` 을 읽어 기본값(`Percent`/160.0)으로 폴백했다. 같은 `styles`
변수를 공유하므로 한 번의 수정으로 둘 다 닫힌다.

## 검증

- 술어 단위 테스트 2건 + 본문·셀 재현 테스트 2건 (이슈 실측 규모 그대로: 셀 폭 20000 HWPUNIT,
  `marginLeft:8000`).
- **행위 테스트** `para_format_margin_change_in_header_reflows_with_correct_width_not_stale_styles`
  — 구현 전에 먼저 작성해 미수정 코드에서 실패를 확인했고, 수정 후 stale 읽기를 일부러 되돌리니
  다시 실패하는 것까지 확인했다. 술어 단위 테스트로는 2번 결함이 잡히지 않는다.
- `cargo test --profile release-test --tests` 전체 통과 (`issue_3494_char_count_convention`
  규약 가드 포함).
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` 통과.

Closes #4324
