### PR TITLE
renderer: 캡션 높이 산식을 렌더·측정 공유 함수로 통일

### DIFF
--- a/mydocs/working/task_m100_4320_stage1.md
+++ b/mydocs/working/task_m100_4320_stage1.md
@@ -1,0 +1,63 @@
+# task_m100_4320 Stage 1 — 캡션 높이 산식 통일
+
+- **이슈**: [#4320](https://github.com/edwardkim/rhwp/issues/4320)
+- **PR**: [#4382](https://github.com/edwardkim/rhwp/pull/4382)
+- **브랜치**: `fix/issue-4320-caption-height-dedup`
+- **분기 기준**: `upstream/devel` `e48fe8694`
+- **상태**: 로컬 전체 검증 + 코퍼스 대조 통과, PR 게시
+- **기록일**: 2026-08-09 KST
+
+## 1. 결함 — 같은 값을 두 곳에서 다르게 계산했다
+
+| | 함수 | 산식 |
+|---|---|---|
+| 렌더 | `LayoutEngine::calculate_caption_height`(`layout/picture_footnote.rs:661`) | `max(line_seg 기반, compose 재계산)` |
+| 측정 | `HeightMeasurer::measure_caption`(`height_measurer.rs:2445`) | `line_segs` 단순 합산 |
+
+측정 쪽에는 `compose_paragraph` 호출이 아예 없다(grep 0건).
+
+## 2. 권위 판정 — 렌더 쪽
+
+`git log` 로 렌더 쪽 compose 폴백이 들어온 커밋 `2d973021c`("fix: account for caption line segment
+height")를 찾았다. `samples/rowbreak-problem-pages.hwpx` 에서 compose 재계산 높이가 실제 한컴
+레이아웃(저장 `line_segs`)보다 작게 나와 캡션이 다음 요소와 겹치는 회귀를 고친 커밋이고, 그 가드가
+`tests/issue_rowbreak_chart_overlap.rs::rowbreak_page2_chart_starts_below_title_line` 로 지금도
+남아 있다.
+
+즉 렌더 쪽은 **실제 한컴 출력(오버랩 없음)에 맞춰 검증된 산식**이고, 측정 쪽은 그 보정이 없다.
+
+## 3. 구현
+
+렌더 쪽 로직을 `composer::caption_height_px(caption, dpi)` 로 **그대로** 옮기고 양쪽이 호출하게
+했다. 새 로직은 없다. `calculate_caption_height` 시그니처는 불변이라 7개 호출부 무영향.
+
+## 4. 측정 경로 동작 변경 — 코퍼스 대조로 확인
+
+이 변경은 **측정 경로의 값을 바꾼다**(`line_segs` 합산 → `max(line_seg, composed)`). 다문단 캡션에서
+문단별 `max` 와 합의 차이가 페이지 수를 바꿀 수 있어, release-test 만으로는 부족하다.
+
+`upstream/devel`(e48fe8694)과 이 head 로 `samples/` 681개 문서의 페이지 수를 대조했다:
+
+```
+same=678  diff=0  err=3
+```
+
+**차이 0건.** err 3건은 전부 암호 문서로 양쪽 동일하게 페이지 수를 얻지 못했다(회귀 아님).
+
+## 5. 범위 밖
+
+`line_seg_height` 는 문단별 `max` 이고 `composed_height` 는 문단별 합(`+=`)인 내부 비대칭이 원래
+렌더 쪽에 있었고 공유 함수에도 그대로 남아 있다. `2d973021c` 검증 당시 이 형태로 회귀가 잡혔으므로
+동작을 바꾸지 않고 옮겼다. 위 대조에서 페이지 수 차이가 0건이라 실제 영향은 관측되지 않는다.
+
+두 산식이 실제로 다른 값을 내는 문서 사례는 찾지 못했다.
+
+## 6. 검증 (완료)
+
+- `issue_rowbreak_chart_overlap` 20/20, 캡션 통합 8개 파일 12/12, `--lib caption` 63/63,
+  `--lib lineseg_compare` 9/9.
+- `cargo test --profile release-test --tests` 전체 통과.
+- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` 통과.
+- 코퍼스 페이지 수 대조 681건(위 4절).
+
+남은 미래 조건은 GitHub Actions 와 작업지시자 승인, merge 다.

--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -6,10 +6,11 @@
 
 use super::layout::{estimate_text_width, resolved_to_text_style};
 use super::style_resolver::{detect_lang_category, ResolvedStyleSet};
-use super::{px_to_hwpunit, TextStyle};
+use super::{hwpunit_to_px, px_to_hwpunit, TextStyle};
 use crate::model::control::Control;
 use crate::model::document::Section;
 use crate::model::paragraph::{CharShapeRef, LineSeg, Paragraph, SingleLineOverflowMemo};
+use crate::model::shape::Caption;
 
 /// 글자겹침(CharOverlap) 렌더링 정보
 #[derive(Debug, Clone, serde::Serialize)]
@@ -340,6 +341,55 @@ pub fn compose_paragraph(para: &Paragraph) -> ComposedParagraph {
     convert_pua_display_text(&mut composed);
 
     composed
+}
+
+/// 캡션(문단 목록)의 총 높이를 px 로 계산한다.
+///
+/// 렌더(`calculate_caption_height`)와 측정(`measure_caption`)이 각자 재구현하며 갈라졌던
+/// 산식을 통일한 것이다(#4320). 저장된 `line_segs` 는 한컴이 실제로 배치한 레이아웃 값이므로
+/// `compose_paragraph` 재계산 높이의 하한으로 쓴다 — `line_segs`가 있어도 폰트 대체 등으로
+/// 재계산 높이가 더 작게 나오면 실제보다 낮게 예약되어 다음 요소가 겹친다
+/// (`2d973021c`가 `samples/rowbreak-problem-pages.hwpx`에서 고친 오버랩이 이 경우다).
+/// `line_segs`가 비어 있으면(레이아웃 전/미저장 캡션) `compose_paragraph`로만 계산한다.
+pub fn caption_height_px(caption: &Option<Caption>, dpi: f64) -> f64 {
+    let caption = match caption {
+        Some(c) => c,
+        None => return 0.0,
+    };
+
+    if caption.paragraphs.is_empty() {
+        return 0.0;
+    }
+
+    // line_segs가 비어 컴포즈로 대체할 때 쓰는 기본 줄 높이(HWPUNIT).
+    const DEFAULT_LINE_HEIGHT_HWPUNIT: i32 = 400;
+
+    let mut line_seg_height = 0.0f64;
+    let mut composed_height = 0.0f64;
+    for para in &caption.paragraphs {
+        if let (Some(first), Some(last)) = (para.line_segs.first(), para.line_segs.last()) {
+            let para_top = first.vertical_pos.min(0);
+            let para_bottom = last.vertical_pos + last.line_height;
+            line_seg_height = line_seg_height.max(hwpunit_to_px(para_bottom - para_top, dpi));
+        }
+
+        let composed = compose_paragraph(para);
+        if composed.lines.is_empty() {
+            composed_height += hwpunit_to_px(DEFAULT_LINE_HEIGHT_HWPUNIT, dpi); // 기본 줄 높이
+        } else {
+            for (i, line) in composed.lines.iter().enumerate() {
+                let line_h = hwpunit_to_px(line.line_height, dpi);
+                let spacing = if i < composed.lines.len() - 1 {
+                    hwpunit_to_px(line.line_spacing, dpi)
+                } else {
+                    0.0 // 마지막 줄은 line_spacing 제외
+                };
+                composed_height += line_h + spacing;
+            }
+        }
+    }
+
+    line_seg_height.max(composed_height)
 }
 
 /// Hanyang-PUA 옛한글 코드포인트·한컴 PUA와 legacy 제품명을 렌더링용 텍스트로 변환한다.

--- a/src/renderer/height_measurer.rs
+++ b/src/renderer/height_measurer.rs
@@ -2442,35 +2442,12 @@ impl HeightMeasurer {
     }
 
     /// 캡션의 높이를 측정한다.
+    ///
+    /// 산식은 `composer::caption_height_px`가 단일 정의다(#4320) — 렌더 쪽
+    /// `LayoutEngine::calculate_caption_height`도 같은 함수를 호출해 compose 폴백
+    /// 유무로 측정·렌더 결과가 갈라지지 않는다.
     fn measure_caption(&self, caption: &Option<Caption>) -> f64 {
-        let caption = match caption {
-            Some(c) => c,
-            None => return 0.0,
-        };
-
-        if caption.paragraphs.is_empty() {
-            return 0.0;
-        }
-
-        let mut total_height = 0.0;
-        for para in &caption.paragraphs {
-            if para.line_segs.is_empty() {
-                total_height += hwpunit_to_px(400, self.dpi); // 기본 줄 높이
-            } else {
-                for (i, seg) in para.line_segs.iter().enumerate() {
-                    let line_h = hwpunit_to_px(seg.line_height, self.dpi);
-                    // 마지막 줄은 line_spacing 제외
-                    let spacing = if i < para.line_segs.len() - 1 {
-                        hwpunit_to_px(seg.line_spacing, self.dpi)
-                    } else {
-                        0.0
-                    };
-                    total_height += line_h + spacing;
-                }
-            }
-        }
-
-        total_height
+        super::composer::caption_height_px(caption, self.dpi)
     }
 }
 

--- a/src/renderer/layout/picture_footnote.rs
+++ b/src/renderer/layout/picture_footnote.rs
@@ -658,47 +658,15 @@ impl LayoutEngine {
     }
 
     /// 캡션의 총 높이를 계산한다.
+    ///
+    /// 산식은 `composer::caption_height_px`가 단일 정의다(#4320) — height_measurer 의
+    /// `measure_caption`도 같은 함수를 호출한다.
     pub(crate) fn calculate_caption_height(
         &self,
         caption: &Option<Caption>,
         _styles: &ResolvedStyleSet,
     ) -> f64 {
-        let caption = match caption {
-            Some(c) => c,
-            None => return 0.0,
-        };
-
-        if caption.paragraphs.is_empty() {
-            return 0.0;
-        }
-
-        let mut line_seg_height = 0.0f64;
-        let mut composed_height = 0.0f64;
-        for para in &caption.paragraphs {
-            if let (Some(first), Some(last)) = (para.line_segs.first(), para.line_segs.last()) {
-                let para_top = first.vertical_pos.min(0);
-                let para_bottom = last.vertical_pos + last.line_height;
-                line_seg_height =
-                    line_seg_height.max(hwpunit_to_px(para_bottom - para_top, self.dpi));
-            }
-
-            let composed = compose_paragraph(para);
-            if composed.lines.is_empty() {
-                composed_height += hwpunit_to_px(400, self.dpi); // 기본 줄 높이
-            } else {
-                for (i, line) in composed.lines.iter().enumerate() {
-                    let line_h = hwpunit_to_px(line.line_height, self.dpi);
-                    let spacing = if i < composed.lines.len() - 1 {
-                        hwpunit_to_px(line.line_spacing, self.dpi)
-                    } else {
-                        0.0 // 마지막 줄은 line_spacing 제외
-                    };
-                    composed_height += line_h + spacing;
-                }
-            }
-        }
-
-        line_seg_height.max(composed_height)
+        super::super::composer::caption_height_px(caption, self.dpi)
     }
 
     /// 캡션을 레이아웃한다.


### PR DESCRIPTION
## 무엇을

캡션 높이 산식이 렌더와 측정에 두 벌로 갈라져 있던 것을 `composer::caption_height_px` 하나로
통일한다.

## 왜

같은 값을 두 곳에서 다르게 계산했다.

| | 함수 | 산식 |
|---|---|---|
| 렌더 | `LayoutEngine::calculate_caption_height` (`layout/picture_footnote.rs:661`) | `max(line_seg 기반, compose_paragraph 재계산)` |
| 측정 | `HeightMeasurer::measure_caption` (`height_measurer.rs:2445`) | `line_segs` 단순 합산 (compose 폴백 없음) |

측정 쪽에는 `compose_paragraph` 호출이 아예 없다(grep 0건).

## 어느 쪽이 권위인가

렌더 쪽(A)이다. `git log` 로 A 의 compose 폴백이 들어온 커밋을 찾았다 — `2d973021c`
("fix: account for caption line segment height"). `samples/rowbreak-problem-pages.hwpx` 에서
`compose_paragraph` 재계산 높이가 실제 한컴 레이아웃(저장 `line_segs`)보다 작게 나와 캡션이 다음
요소와 겹치는 회귀를 고친 커밋이고, 그 가드가
`tests/issue_rowbreak_chart_overlap.rs::rowbreak_page2_chart_starts_below_title_line` 로 지금도
남아 있다.

즉 A 는 실제 한컴 출력(오버랩 없음)에 맞춰 검증된 산식이고, B 는 그 보정이 없다.

## 어떻게

A 의 로직을 `composer::caption_height_px(caption, dpi)` 로 **그대로** 옮기고 양쪽이 호출하게
했다. 새 로직은 없다. `calculate_caption_height` 의 시그니처는 그대로라 7개 호출부는 무변경이다.

## 검증

- `issue_rowbreak_chart_overlap` 20/20 (오버랩 회귀 가드), 캡션 통합 테스트 8개 파일 12/12,
  `--lib caption` 63/63, `--lib lineseg_compare` 9/9.
- `cargo test --profile release-test --tests` 전체 통과.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` 통과.
- **코퍼스 대조**: 측정 경로의 값이 바뀌므로(`line_segs` 합산 → `max(line_seg, composed)`)
  페이지 수가 달라질 수 있다. `upstream/devel`(e48fe8694)과 이 head 로 `samples/` 681개 문서의
  페이지 수를 대조했다 — **678건 동일, 차이 0건**. 나머지 3건은 암호 문서로 양쪽 모두 페이지 수를
  얻지 못했다(동일 실패, 회귀 아님).

## 범위 밖

`line_seg_height` 는 문단별 `max` 이고 `composed_height` 는 문단별 합(`+=`)인 내부 비대칭이 A 에
있었고 공유 함수에도 그대로 남아 있다. 다문단 캡션에서 이론상 정확하지 않지만, `2d973021c` 검증
당시 이 형태로 회귀가 잡혔으므로 동작을 바꾸지 않고 그대로 옮겼다. 위 코퍼스 대조에서 페이지 수
차이가 0건인 것으로 보아 실제 영향은 관측되지 않는다. 별도 사안이다.

두 산식이 실제로 다른 값을 내는 문서 사례는 찾지 못했다. 통합 자체는 산식이 하나뿐이 되므로
재현이 필요하지 않지만, 향후 drift 방지용 전용 fixture 는 이번 범위 밖이다.

Closes #4320
