### PR TITLE
feat(harness): #4389 스코어카드 — 주장마다 실행 명령 (러너 6/6 실측, 공개 재현 원칙)

### DIFF
--- a/mydocs/pr/pr_4390_review.md
+++ b/mydocs/pr/pr_4390_review.md
@@ -12,8 +12,9 @@ last_verified: 2026-08-10
 **메인터너 보정 뒤 조건부 수용 권고.** contributor 변경은 문서에 적은 하네스 성질 여섯 가지를
 `tools/harness_proofs.py` 한 명령으로 실행해 PASS/FAIL로 판정하는 공개 스코어카드를 추가한다.
 검토에서 P2의 문서 계약은 정확히 68개 명령인데 실행 판정은 50개 이상만 요구해, 최대 18개 명령이
-사라져도 거짓 PASS가 되는 차단점을 확인했다. 원 contributor history 위의 별도 보정 commit으로
-정확한 68개 계약과 focused 회귀 테스트를 추가했다.
+사라져도 거짓 PASS가 되는 차단점을 확인했다. 첫 보정 뒤에도 중복 이름 68개와 null 계약 객체가
+통과하고, P5는 `untrustedContent:false`·빈 `untrustedFields`도 키만 있으면 통과했다. 원 contributor
+history 위의 별도 보정 commit들로 명령·계약 객체·출처 표지의 실제 의미와 음성 회귀를 고정했다.
 
 local candidate는 검증을 통과했지만 아직 원격에 push되지 않았다. Python 실행 코드와 test가
 바뀌었으므로 review-only fast-pass를 적용하지 않는다. 최신 candidate의 GitHub checks,
@@ -32,7 +33,7 @@ mergeability 재확인과 작업지시자의 push·review·merge 승인이 최�
 | source merge 상태 | `MERGEABLE`, `CLEAN`; merge 전 최신 상태 재확인 필요 |
 | source checks | source head 기준 required checks 성공; local correction에는 원격 CI 없음 |
 | 가시성 branch | `review/kevin9327-20260810-pr4390` |
-| local code candidate | `48a80dc09a9a876165292777546ec124f195a82a` |
+| local code candidate | `bc93618d678d29522ab22873322b2962a9eb736b` |
 | 기준 devel | `e48fe86947fbf9a44b1b98c7037150751af541ab` |
 
 기준 devel은 contributor source head의 조상이고, 가시성 branch는 source 뒤에 메인터너 commit만
@@ -52,9 +53,10 @@ mergeability 재확인과 작업지시자의 push·review·merge 승인이 최�
 ## 발견한 차단점과 메인터너 보정
 
 문서는 P2를 "68개 명령의 계약 전수 자기서술"로 고정했지만 원 runner는
-`n_cmd >= 50`만 확인했다. 명령이 68개에서 50개까지 줄어도 PASS가 되므로 스코어카드가 주장하는
-전수 검증을 수행하지 못했다. 기존 detail도 두 계약 필드의 개별 상태가 아니라 전체 `ok`만
-출력해 실패 원인을 구분하기 어려웠다.
+`n_cmd >= 50`만 확인했다. 첫 보정으로 개수는 정확해졌지만 `commands` 원소와 이름을 보지 않아 같은
+이름 68개도 통과했고, `exitCodes:null`·`jsonContract:null`도 키 존재만으로 통과했다. P5도 문서 파생
+값이 있는 `info` 봉투에서 `untrustedContent`가 `true`이고 `untrustedFields`가 비어 있지 않아야 한다는
+의미 대신 두 키의 존재만 확인했다.
 
 메인터너 보정 `48a80dc09a9a876165292777546ec124f195a82a`은 다음을 추가했다.
 
@@ -62,17 +64,27 @@ mergeability 재확인과 작업지시자의 push·review·merge 승인이 최�
 - detail에 실제·기대 명령 수와 `exitCodes`, `jsonContract` 존재 여부를 각각 출력한다.
 - `tools/test_harness_proofs.py`에서 68개 성공, 67·69개 실패, 계약 필드 누락 실패를 고정한다.
 
+후속 보정 `bc93618d678d29522ab22873322b2962a9eb736b`은 남은 false-PASS를 닫았다.
+
+- 68개 원소가 모두 object이고 비어 있지 않은 고유 `name`을 갖는지 확인한다.
+- `exitCodes`는 object이며 핵심 0·1·2 의미가 비어 있지 않은 문자열인지, `jsonContract`는 object이며
+  `stdout`·`schemaPolicy` 의미가 비어 있지 않은 문자열인지 확인한다.
+- P5는 `untrustedContent is True`, 비어 있지 않은 문자열 경로 배열 `untrustedFields`를 함께 요구한다.
+- 중복 이름, 비-object 원소, null·빈 계약, `untrustedContent:false`, 빈·잘못된 출처 경로를 음성 회귀로
+  고정한다.
+
 실행 단계와 rollback 경계는 [구현·검토 계획](pr_4390_review_impl.md)에 기록했다.
 
 ## 완료한 로컬 검증
 
 | 명령 | 결과 |
 | --- | --- |
-| `python -m unittest tools.test_harness_proofs -v` | 3 / 3 통과 |
+| `python -m unittest tools.test_harness_proofs -v` | 8 / 8 통과 |
 | `python -m py_compile tools/harness_proofs.py tools/test_harness_proofs.py` | 통과 |
 | `python tools/harness_proofs.py --json` | 6 / 6 통과 |
-| P2 실물 detail | `commands=68 (expected=68), exitCodes=True, jsonContract=True` |
-| `git diff --check origin/pr/4390..48a80dc0` | 통과 |
+| P2 실물 detail | `commands=68 (expected=68, unique names), exitCodes=['0', '1', '2'], jsonContract=['stdout', 'schemaPolicy']` |
+| P5 실물 detail | `untrustedContent=True, untrustedFields=['title', 'fonts[]']` |
+| `git diff --check origin/pr/4390..bc93618d` | 통과 |
 
 실물 proof에는 같은 검토 사이클에서 새로 빌드한 #4330 debug `rhwp`를 지정했다. #4390에는 Rust
 변경이 없고 해당 binary가 실제 68-command capabilities를 제공해 수정된 runner의 green 경로와

--- a/mydocs/pr/pr_4390_review.md
+++ b/mydocs/pr/pr_4390_review.md
@@ -1,0 +1,92 @@
+---
+kind: pr_review
+status: maintainer-review
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-10
+---
+
+# PR #4390 검토 — 실행 가능한 에이전트 하네스 스코어카드
+
+## 결론
+
+**메인터너 보정 뒤 조건부 수용 권고.** contributor 변경은 문서에 적은 하네스 성질 여섯 가지를
+`tools/harness_proofs.py` 한 명령으로 실행해 PASS/FAIL로 판정하는 공개 스코어카드를 추가한다.
+검토에서 P2의 문서 계약은 정확히 68개 명령인데 실행 판정은 50개 이상만 요구해, 최대 18개 명령이
+사라져도 거짓 PASS가 되는 차단점을 확인했다. 원 contributor history 위의 별도 보정 commit으로
+정확한 68개 계약과 focused 회귀 테스트를 추가했다.
+
+local candidate는 검증을 통과했지만 아직 원격에 push되지 않았다. Python 실행 코드와 test가
+바뀌었으므로 review-only fast-pass를 적용하지 않는다. 최신 candidate의 GitHub checks,
+mergeability 재확인과 작업지시자의 push·review·merge 승인이 최종 수용 조건이다.
+
+## 메타데이터
+
+| 항목 | 2026-08-10 검토 시점 참고값 |
+| --- | --- |
+| PR | [#4390](https://github.com/edwardkim/rhwp/pull/4390) |
+| 관련 이슈 | [#4389](https://github.com/edwardkim/rhwp/issues/4389) |
+| 작성자 | `kevin9327` |
+| base / draft | `devel` / 아님 |
+| contributor source head | `02ce6d0b3840acb5c1b2569ee9154dc32832c789` |
+| source 규모 | 2 files, +221 / -0, 2 commits |
+| source merge 상태 | `MERGEABLE`, `CLEAN`; merge 전 최신 상태 재확인 필요 |
+| source checks | source head 기준 required checks 성공; local correction에는 원격 CI 없음 |
+| 가시성 branch | `review/kevin9327-20260810-pr4390` |
+| local code candidate | `48a80dc09a9a876165292777546ec124f195a82a` |
+| 기준 devel | `e48fe86947fbf9a44b1b98c7037150751af541ab` |
+
+기준 devel은 contributor source head의 조상이고, 가시성 branch는 source 뒤에 메인터너 commit만
+선형으로 추가했다. contributor commit을 amend·rebase하지 않았다.
+
+## contributor 변경 범위
+
+- `mydocs/tech/agent_roadmap/harness_scorecard.md`에 실행 가능한 성질 6종과 계약·PR로 검증되는
+  성질 4종을 구분해 기록했다.
+- `tools/harness_proofs.py`가 capabilities 결정론, 명령 표면, 오류 exit/stdout, 신뢰 경계,
+  explain 결정론을 실제 CLI로 실행하고 표 또는 JSON 결과를 출력한다.
+- 후속 문서 commit은 미병합 문서 상대 링크를 GitHub PR 참조로 바꿨다.
+
+변경은 Python 검증 도구와 문서뿐이다. Rust renderer, layout, paint, WASM 출력, sample·golden은
+바뀌지 않으므로 시각 sweep 대상이 아니다.
+
+## 발견한 차단점과 메인터너 보정
+
+문서는 P2를 "68개 명령의 계약 전수 자기서술"로 고정했지만 원 runner는
+`n_cmd >= 50`만 확인했다. 명령이 68개에서 50개까지 줄어도 PASS가 되므로 스코어카드가 주장하는
+전수 검증을 수행하지 못했다. 기존 detail도 두 계약 필드의 개별 상태가 아니라 전체 `ok`만
+출력해 실패 원인을 구분하기 어려웠다.
+
+메인터너 보정 `48a80dc09a9a876165292777546ec124f195a82a`은 다음을 추가했다.
+
+- `EXPECTED_COMMAND_COUNT = 68`과 `command_surface_contract()`로 정확한 명령 수를 판정한다.
+- detail에 실제·기대 명령 수와 `exitCodes`, `jsonContract` 존재 여부를 각각 출력한다.
+- `tools/test_harness_proofs.py`에서 68개 성공, 67·69개 실패, 계약 필드 누락 실패를 고정한다.
+
+실행 단계와 rollback 경계는 [구현·검토 계획](pr_4390_review_impl.md)에 기록했다.
+
+## 완료한 로컬 검증
+
+| 명령 | 결과 |
+| --- | --- |
+| `python -m unittest tools.test_harness_proofs -v` | 3 / 3 통과 |
+| `python -m py_compile tools/harness_proofs.py tools/test_harness_proofs.py` | 통과 |
+| `python tools/harness_proofs.py --json` | 6 / 6 통과 |
+| P2 실물 detail | `commands=68 (expected=68), exitCodes=True, jsonContract=True` |
+| `git diff --check origin/pr/4390..48a80dc0` | 통과 |
+
+실물 proof에는 같은 검토 사이클에서 새로 빌드한 #4330 debug `rhwp`를 지정했다. #4390에는 Rust
+변경이 없고 해당 binary가 실제 68-command capabilities를 제공해 수정된 runner의 green 경로와
+나머지 다섯 proof를 검증했다. exact #4390 checkout에서 Rust binary를 별도로 재빌드하지 않았다.
+
+## 잔여 위험과 최종 조건
+
+- local Python·test·review commit에는 원격 CI가 없다. 최신 head의 required checks가 새로 성공해야 한다.
+- 추가한 `tools/test_harness_proofs.py`는 focused 명령으로 검증했지만 기존 전체 CI가 모든 `tools/test_*.py`
+  를 자동 discover한다고 가정하지 않는다. merge 전 CI log와 focused 명령 결과를 함께 확인한다.
+- exact #4390 checkout binary를 별도로 빌드하지 않은 범위는 source에 Rust diff가 없다는 사실과 실제
+  68-command binary proof로 제한했다. 이후 source에 Rust 변경이 추가되면 proof를 새 head binary로
+  다시 실행해야 한다.
+- push 직전 원 PR source head와 local branch의 시작 SHA가 여전히 같은지 재확인해야 한다.
+- GitHub push, review/comment, merge 권한은 부여되지 않았다.
+
+위 조건과 작업지시자 승인을 충족하면 merge를 권고한다. 하나라도 충족하지 않으면 보류한다.

--- a/mydocs/pr/pr_4390_review_impl.md
+++ b/mydocs/pr/pr_4390_review_impl.md
@@ -14,11 +14,13 @@ last_verified: 2026-08-10
 | 1 | `8aa039997d8f8bc1444c0ab42d1efb99ee666ac1` | contributor | harness scorecard와 6-proof runner 추가 |
 | 2 | `02ce6d0b3840acb5c1b2569ee9154dc32832c789` | contributor | 미병합 문서 링크 정정, 원 PR source head |
 | 3 | `48a80dc09a9a876165292777546ec124f195a82a` | maintainer | 정확한 68-command 판정과 회귀 테스트 |
-| 4 | 이 문서 commit | maintainer | active review·실행 기록; runner 동작 변경 없음 |
+| 4 | `7d73d692471d46c0e60f206b8a820129332069bf` | maintainer | 1차 active review·실행 기록 |
+| 5 | `bc93618d678d29522ab22873322b2962a9eb736b` | maintainer | 명령·계약·출처 표지 의미 검증과 음성 회귀 |
+| 6 | 이 문서 commit | maintainer | 후속 검증·잔여 위험 기록; runner 동작 변경 없음 |
 
 가시성 branch `review/kevin9327-20260810-pr4390`은 정확한 source head에서 시작했다. 메인터너
-보정은 `tools/harness_proofs.py`와 신규 `tools/test_harness_proofs.py`에 한정되며 contributor
-commit은 재작성하지 않았다.
+보정은 `tools/harness_proofs.py`와 신규 `tools/test_harness_proofs.py`에 한정되며 contributor와 기존
+메인터너 commit은 재작성하지 않았다.
 
 ## 단계
 
@@ -33,11 +35,14 @@ commit은 재작성하지 않았다.
 - exact command count와 계약 필드 판정을 순수 helper로 분리했다.
 - 성공·과소·과다·필드 누락을 검증하는 표준 라이브러리 `unittest` 3건을 추가했다.
 - `48a80dc09a9a876165292777546ec124f195a82a`로 별도 commit해 contributor attribution을 보존했다.
+- 후속 검토에서 확인한 duplicate/null false-PASS와 P5 키 존재 false-PASS를 순수 helper 의미 검증으로
+  닫고, 성공·음성 회귀 8건을 `bc93618d678d29522ab22873322b2962a9eb736b`로 추가했다.
 
 ### Stage 3 — focused 검증과 active 기록 (완료)
 
-- Python unit test 3건, py_compile, 실제 harness proof 6건, correction diff check를 통과했다.
-- 실물 P2가 실제 68과 기대 68, 두 계약 필드의 개별 `True`를 출력함을 확인했다.
+- Python unit test 8건, py_compile, 실제 harness proof 6건, correction diff check를 통과했다.
+- 실물 P2가 고유 이름 68개와 핵심 exit/JSON 계약을, P5가 `true`와 실제 비어 있지 않은 경로를
+  출력함을 확인했다.
 - `pr_4390_review.md`와 이 구현 기록을 code·test commit 뒤의 별도 문서 commit으로 남긴다.
 - 렌더 경로 변경이 없어 시각 검증은 선택하지 않았다.
 
@@ -59,9 +64,9 @@ commit은 재작성하지 않았다.
 ## rollback
 
 - 아직 push 전이므로 원격 contributor history에는 영향이 없다.
-- 보정 방향을 취소해도 contributor commit을 amend·rebase하지 않는다. 가시성 branch에서 문서 commit과
-  code·test correction을 역순으로 새 `git revert` commit으로 되돌리거나, 작업지시자 승인 뒤 로컬
-  branch를 폐기한다.
+- 보정 방향을 취소해도 contributor나 기존 메인터너 commit을 amend·rebase하지 않는다. 가시성 branch에서
+  trailing 문서, `bc93618d`, `7d73d692`, `48a80dc0`을 이력 역순의 새 `git revert` commit으로 되돌리거나,
+  작업지시자 승인 뒤 로컬 branch를 폐기한다.
 - push 뒤 문제가 발견되면 force-push나 history rewrite 대신 correction·문서 commit을 역순으로
   revert하고 최신 CI를 다시 받는다.
 

--- a/mydocs/pr/pr_4390_review_impl.md
+++ b/mydocs/pr/pr_4390_review_impl.md
@@ -1,0 +1,69 @@
+---
+kind: review-implementation
+status: completed-local-pending-push-approval
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-10
+---
+
+# PR #4390 메인터너 보정 구현·검토 계획
+
+## history와 변경 경계
+
+| 순서 | commit | 소유 | 상태·내용 |
+| --- | --- | --- | --- |
+| 1 | `8aa039997d8f8bc1444c0ab42d1efb99ee666ac1` | contributor | harness scorecard와 6-proof runner 추가 |
+| 2 | `02ce6d0b3840acb5c1b2569ee9154dc32832c789` | contributor | 미병합 문서 링크 정정, 원 PR source head |
+| 3 | `48a80dc09a9a876165292777546ec124f195a82a` | maintainer | 정확한 68-command 판정과 회귀 테스트 |
+| 4 | 이 문서 commit | maintainer | active review·실행 기록; runner 동작 변경 없음 |
+
+가시성 branch `review/kevin9327-20260810-pr4390`은 정확한 source head에서 시작했다. 메인터너
+보정은 `tools/harness_proofs.py`와 신규 `tools/test_harness_proofs.py`에 한정되며 contributor
+commit은 재작성하지 않았다.
+
+## 단계
+
+### Stage 1 — source 고정과 차단점 확인 (완료)
+
+- `origin/pr/4390`을 `02ce6d0b3840acb5c1b2569ee9154dc32832c789`로 고정했다.
+- `origin/devel` `e48fe86947fbf9a44b1b98c7037150751af541ab`이 source의 조상임을 확인했다.
+- scorecard의 정확한 68개 주장과 runner의 `>= 50` 판정을 대조해 false-PASS 범위를 확인했다.
+
+### Stage 2 — 메인터너 code·test 보정 (완료)
+
+- exact command count와 계약 필드 판정을 순수 helper로 분리했다.
+- 성공·과소·과다·필드 누락을 검증하는 표준 라이브러리 `unittest` 3건을 추가했다.
+- `48a80dc09a9a876165292777546ec124f195a82a`로 별도 commit해 contributor attribution을 보존했다.
+
+### Stage 3 — focused 검증과 active 기록 (완료)
+
+- Python unit test 3건, py_compile, 실제 harness proof 6건, correction diff check를 통과했다.
+- 실물 P2가 실제 68과 기대 68, 두 계약 필드의 개별 `True`를 출력함을 확인했다.
+- `pr_4390_review.md`와 이 구현 기록을 code·test commit 뒤의 별도 문서 commit으로 남긴다.
+- 렌더 경로 변경이 없어 시각 검증은 선택하지 않았다.
+
+### Stage 4 — 원격 후보 갱신과 CI (승인 대기)
+
+1. 작업지시자가 별도로 push를 승인한다.
+2. push 직전 GitHub PR head·contributor source branch SHA·local source 시작 SHA의 일치를 확인한다.
+3. LFS 대상 사전 판독과 dry-run을 거쳐 maintainer code·test·문서 commit을 contributor source branch에
+   선형으로 push한다.
+4. code·test 보정이 포함됐으므로 review-only fast-pass를 쓰지 않고 최신 head의 required checks를 기다린다.
+5. CI가 신규 Python test를 자동 실행하지 않으면 focused unittest와 harness proof를 merge 근거에 명시한다.
+
+### Stage 5 — review·merge·후속 처리 (별도 승인 대기)
+
+- 최신 head의 required checks와 mergeability를 다시 확인한다.
+- 작업지시자 승인 뒤에만 GitHub review/comment와 merge를 수행한다.
+- merge 뒤 기록 archive, devel 반영, 관련 이슈 상태와 branch/worktree 정리는 merge 후속 절차를 따른다.
+
+## rollback
+
+- 아직 push 전이므로 원격 contributor history에는 영향이 없다.
+- 보정 방향을 취소해도 contributor commit을 amend·rebase하지 않는다. 가시성 branch에서 문서 commit과
+  code·test correction을 역순으로 새 `git revert` commit으로 되돌리거나, 작업지시자 승인 뒤 로컬
+  branch를 폐기한다.
+- push 뒤 문제가 발견되면 force-push나 history rewrite 대신 correction·문서 commit을 역순으로
+  revert하고 최신 CI를 다시 받는다.
+
+이 계획은 로컬 보정과 검증만 승인된 상태를 기록한다. push, GitHub review/comment, merge, close 권한을
+포함하지 않는다.

--- a/mydocs/tech/agent_roadmap/harness_scorecard.md
+++ b/mydocs/tech/agent_roadmap/harness_scorecard.md
@@ -1,0 +1,52 @@
+---
+kind: investigation
+status: active
+canonical: mydocs/tech/agent_roadmap/harness_scorecard.md
+last_verified: 2026-08-10
+---
+
+# 하네스 스코어카드 — 주장마다 실행 명령 (#4389)
+
+이번 주 업계 소식은 에이전트 하네스가 "관리형 플랫폼"으로 옮겨가는 흐름을
+보여준다(대형 프레임워크의 하네스 GA 등 — 접속 2026-08-10:
+[InfoQ](https://www.infoq.com/news/2026/08/agent-framework-harness-ga/),
+[8개 SDK 지형](https://www.morphllm.com/ai-agent-framework)). 관리형 런타임의
+공통 성질은 하나다 — **검증은 운영자만 할 수 있다.**
+
+이 저장소는 반대편에 선다: **모든 하네스 성질 주장에 실행 명령이 달리고,
+제3자가 클론 후 명령 하나로 전수 검증한다.** 비교는 실명 서열이 아니라 이
+원리 하나로만 한다(전 조사 문서 공통 규율).
+
+```bash
+python tools/harness_proofs.py        # 6개 성질 실검증 — 하나라도 깨지면 exit 1
+```
+
+## 실검증 6종 (러너가 지금 판정 — 2026-08-10 로컬 실측 6/6 PASS)
+
+| # | 성질 | 검증 명령 |
+|---|---|---|
+| P1 | **자기서술 결정론** — capabilities 2회 호출이 바이트까지 동일(모델·시각 무개입) | `rhwp capabilities` ×2 비교 |
+| P2 | **명령 표면 전수 자기서술** — 68개 명령의 계약(exitCodes·jsonContract) 동봉 | `rhwp capabilities` |
+| P3 | **사용법 오류 사전** — 미지 옵션 = exit 2 + stdout 0바이트(반쪽 JSON 금지) | `rhwp info … --nope --json` |
+| P4 | **실패 stdout 순수성** — 런타임 실패도 stdout 무오염(exit 1 + 0바이트) | `rhwp info no_such.hwp --json` |
+| P5 | **출처 표지 S1** — 문서 파생 값의 신뢰 경계를 봉투가 스스로 밝힘 | `rhwp info <doc> --json` |
+| P6 | **explain 결정론** — 서술이 생성 문장이 아니라 조립(드리프트 가드 가능 조건) | `rhwp explain <doc> --json` ×2 |
+
+## 계약 테스트·PR 로 검증되는 4종 (러너 밖 — 거짓 PASS 를 만들지 않는다)
+
+| # | 성질 | 검증 경로 |
+|---|---|---|
+| C1 | **CAS 편집 유실 차단** — 계획 `preconditions.inputSha256`·`edit --expect-sha256`, 불일치=실행 0·저장 0 | `tests/run_plan_cas_contract.rs` 6본 · [PR #4381](https://github.com/edwardkim/rhwp/pull/4381) |
+| C2 | **변이 자기검증 저널** — 워크스페이스에서 변이마다 본문 SHA-256 전/후 자동 기록 | `tests/mcp_workspace_contract.rs` · [PR #4361](https://github.com/edwardkim/rhwp/pull/4361) |
+| C3 | **소비자 버전 대사** — `capabilities.schemaRegistry` 로 전 계약 축 기계 대조 | `tests/schema_registry_contract.rs` 4본 · [PR #4330](https://github.com/edwardkim/rhwp/pull/4330) |
+| C4 | **공개 판정 실험** — 무안내 30분 첫 유효 산출, 측정 대장 공개 | [#4355](https://github.com/edwardkim/rhwp/issues/4355) · 프로토콜 [PR #4356](https://github.com/edwardkim/rhwp/pull/4356) |
+
+## 운영 규약
+
+1. 새 하네스 성질 주장은 **이 표에 행이 생겨야 주장이 된다** — 러너 검사 또는
+   계약 테스트·PR 링크 없는 주장은 싣지 않는다.
+2. C행이 devel 에 착지하면 가능한 것부터 러너(P행)로 승격한다.
+3. 러너는 CI 편입 후보다(R12 CI 상시화와 합류) — 편입 전까지는 로컬·PR 실측을
+   문서에 남긴다.
+4. 신간·업계 대사는 [trend_harness_2026w32.md](trend_harness_2026w32.md) 계열이
+   담당하고, 이 문서는 **검증 가능한 성질의 대장**만 유지한다.

--- a/mydocs/tech/agent_roadmap/harness_scorecard.md
+++ b/mydocs/tech/agent_roadmap/harness_scorecard.md
@@ -48,5 +48,6 @@ python tools/harness_proofs.py        # 6개 성질 실검증 — 하나라도 �
 2. C행이 devel 에 착지하면 가능한 것부터 러너(P행)로 승격한다.
 3. 러너는 CI 편입 후보다(R12 CI 상시화와 합류) — 편입 전까지는 로컬·PR 실측을
    문서에 남긴다.
-4. 신간·업계 대사는 [trend_harness_2026w32.md](trend_harness_2026w32.md) 계열이
-   담당하고, 이 문서는 **검증 가능한 성질의 대장**만 유지한다.
+4. 신간·업계 대사는 `trend_harness_2026w32.md` 계열([PR
+   #4385](https://github.com/edwardkim/rhwp/pull/4385) 리뷰 중 — 상대 링크는
+   착지 후)이 담당하고, 이 문서는 **검증 가능한 성질의 대장**만 유지한다.

--- a/tools/harness_proofs.py
+++ b/tools/harness_proofs.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 SAMPLE = ROOT / "samples" / "basic" / "issue2007_nested_cell_pagination_42065.hwp"
+EXPECTED_COMMAND_COUNT = 68
 
 
 def find_binary() -> str:
@@ -51,6 +52,26 @@ def run(bin_path: str, args: list, timeout: int = 120):
     )
 
 
+def command_surface_contract(caps: object) -> tuple[bool, str]:
+    if not isinstance(caps, dict):
+        return False, f"capabilities JSON 형식 오류: object가 아님 ({type(caps).__name__})"
+
+    commands = caps.get("commands")
+    n_cmd = len(commands) if isinstance(commands, list) else None
+    has_exit_codes = "exitCodes" in caps
+    has_json_contract = "jsonContract" in caps
+    ok = (
+        n_cmd == EXPECTED_COMMAND_COUNT
+        and has_exit_codes
+        and has_json_contract
+    )
+    detail = (
+        f"commands={n_cmd!r} (expected={EXPECTED_COMMAND_COUNT}), "
+        f"exitCodes={has_exit_codes}, jsonContract={has_json_contract}"
+    )
+    return ok, detail
+
+
 def proofs(bin_path: str) -> list:
     results = []
 
@@ -73,14 +94,12 @@ def proofs(bin_path: str) -> list:
     # P2 자기서술 규모 — 명령 표면이 기계 계약으로 전수 서술된다.
     try:
         caps = json.loads(a.stdout)
-        n_cmd = len(caps.get("commands", []))
-        ok = n_cmd >= 50 and "exitCodes" in caps and "jsonContract" in caps
-        detail = f"commands={n_cmd}, exitCodes/jsonContract 존재={ok}"
+        ok, detail = command_surface_contract(caps)
     except Exception as e:  # noqa: BLE001 - 판정용 러너
         ok, detail = False, f"JSON 파싱 실패: {e}"
     record(
         "P2",
-        "명령 표면 전수 자기서술 — capabilities 가 50+ 명령의 계약을 싣는다",
+        f"명령 표면 전수 자기서술 — capabilities 가 정확히 {EXPECTED_COMMAND_COUNT}개 명령의 계약을 싣는다",
         "rhwp capabilities | jq '.commands|length'",
         ok,
         detail,

--- a/tools/harness_proofs.py
+++ b/tools/harness_proofs.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""[#4389] 하네스 성질 실검증 러너 — 주장마다 실행, 판정은 PASS/FAIL.
+
+이 저장소의 에이전트 하네스가 문서로 주장하는 성질을 **제3자가 명령 하나로
+직접 검증**한다. 폐쇄 런타임의 "믿어 달라"와 반대편에 서는 실물이다.
+
+사용법::
+
+    python tools/harness_proofs.py                 # 표 출력, 하나라도 FAIL 이면 exit 1
+    python tools/harness_proofs.py --json          # 기계용 JSON
+    RHWP_BIN=path/to/rhwp python tools/harness_proofs.py   # 바이너리 지정
+
+바이너리 탐색: RHWP_BIN → target/release/rhwp → target/debug/rhwp → PATH.
+검증 6종은 전부 devel 머지본만으로 돈다(미머지 성질은 스코어카드 문서가 계약
+테스트·PR 링크로 안내한다 — 이 러너는 거짓 PASS 를 만들지 않는다).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SAMPLE = ROOT / "samples" / "basic" / "issue2007_nested_cell_pagination_42065.hwp"
+
+
+def find_binary() -> str:
+    exe = ".exe" if os.name == "nt" else ""
+    env = os.environ.get("RHWP_BIN", "").strip()
+    candidates = [env] if env else []
+    candidates += [
+        str(ROOT / "target" / "release" / f"rhwp{exe}"),
+        str(ROOT / "target" / "debug" / f"rhwp{exe}"),
+    ]
+    for c in candidates:
+        if c and Path(c).is_file():
+            return c
+    which = shutil.which("rhwp")
+    if which:
+        return which
+    sys.exit("rhwp 바이너리를 찾지 못했습니다 — RHWP_BIN 지정 또는 cargo build")
+
+
+def run(bin_path: str, args: list, timeout: int = 120):
+    return subprocess.run(
+        [bin_path, *args], capture_output=True, timeout=timeout, cwd=ROOT
+    )
+
+
+def proofs(bin_path: str) -> list:
+    results = []
+
+    def record(pid: str, claim: str, command: str, ok: bool, detail: str) -> None:
+        results.append(
+            {"id": pid, "claim": claim, "command": command, "pass": bool(ok), "detail": detail}
+        )
+
+    # P1 결정론 — 같은 호출은 바이트까지 같다 (자기서술에 모델·시각이 끼지 않는다).
+    a = run(bin_path, ["capabilities"])
+    b = run(bin_path, ["capabilities"])
+    record(
+        "P1",
+        "자기서술 결정론 — capabilities 2회 호출의 stdout 이 바이트 동일",
+        "rhwp capabilities (×2 비교)",
+        a.returncode == 0 and a.stdout == b.stdout and len(a.stdout) > 1000,
+        f"exit={a.returncode}, bytes={len(a.stdout)}, identical={a.stdout == b.stdout}",
+    )
+
+    # P2 자기서술 규모 — 명령 표면이 기계 계약으로 전수 서술된다.
+    try:
+        caps = json.loads(a.stdout)
+        n_cmd = len(caps.get("commands", []))
+        ok = n_cmd >= 50 and "exitCodes" in caps and "jsonContract" in caps
+        detail = f"commands={n_cmd}, exitCodes/jsonContract 존재={ok}"
+    except Exception as e:  # noqa: BLE001 - 판정용 러너
+        ok, detail = False, f"JSON 파싱 실패: {e}"
+    record(
+        "P2",
+        "명령 표면 전수 자기서술 — capabilities 가 50+ 명령의 계약을 싣는다",
+        "rhwp capabilities | jq '.commands|length'",
+        ok,
+        detail,
+    )
+
+    # P3 종료코드 사전 — 미지 옵션은 exit 2, stdout 은 0바이트(반쪽 JSON 금지).
+    c = run(bin_path, ["info", str(SAMPLE), "--nope", "--json"])
+    record(
+        "P3",
+        "사용법 오류 사전 — 미지 옵션은 exit 2 + stdout 0바이트",
+        "rhwp info <sample> --nope --json",
+        c.returncode == 2 and c.stdout == b"",
+        f"exit={c.returncode}, stdout_bytes={len(c.stdout)}",
+    )
+
+    # P4 실패 stdout 순수성 — 런타임 실패도 stdout 을 오염시키지 않는다.
+    d = run(bin_path, ["info", "no_such_file_hopefully.hwp", "--json"])
+    record(
+        "P4",
+        "실패 경로 stdout 순수성 — 없는 파일 info 는 exit 1 + stdout 0바이트",
+        "rhwp info no_such_file.hwp --json",
+        d.returncode == 1 and d.stdout == b"",
+        f"exit={d.returncode}, stdout_bytes={len(d.stdout)}",
+    )
+
+    # P5 출처 표지 — 문서 파생 값을 싣는 봉투는 신뢰 경계를 스스로 밝힌다.
+    e = run(bin_path, ["info", str(SAMPLE), "--json"])
+    try:
+        env = json.loads(e.stdout)
+        ok = "untrustedContent" in env and "untrustedFields" in env
+        detail = f"untrustedContent={env.get('untrustedContent')!r}"
+    except Exception as ex:  # noqa: BLE001
+        ok, detail = False, f"JSON 파싱 실패: {ex}"
+    record(
+        "P5",
+        "출처 표지 S1 — 봉투가 untrustedContent/untrustedFields 를 스스로 싣는다",
+        "rhwp info <sample> --json",
+        e.returncode == 0 and ok,
+        detail,
+    )
+
+    # P6 설명 결정론 — explain 도 2회 동일(생성 문장 아님이 드리프트 가드의 전제).
+    f1 = run(bin_path, ["explain", str(SAMPLE), "--json"])
+    f2 = run(bin_path, ["explain", str(SAMPLE), "--json"])
+    record(
+        "P6",
+        "explain 결정론 — 같은 문서, 같은 서술(바이트 동일)",
+        "rhwp explain <sample> --json (×2 비교)",
+        f1.returncode == 0 and f1.stdout == f2.stdout and len(f1.stdout) > 100,
+        f"exit={f1.returncode}, identical={f1.stdout == f2.stdout}",
+    )
+
+    return results
+
+
+def main() -> None:
+    # Windows cp949 콘솔에서도 스스로 깨지지 않는다 (#4106 선례).
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8", errors="replace")
+    as_json = "--json" in sys.argv
+    bin_path = find_binary()
+    results = proofs(bin_path)
+    passed = sum(1 for r in results if r["pass"])
+    if as_json:
+        print(
+            json.dumps(
+                {"binary": bin_path, "passed": passed, "total": len(results), "proofs": results},
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+    else:
+        print(f"하네스 성질 실검증 — {bin_path}")
+        for r in results:
+            mark = "PASS" if r["pass"] else "FAIL"
+            print(f"  [{mark}] {r['id']} {r['claim']}")
+            print(f"         $ {r['command']}")
+            print(f"         {r['detail']}")
+        print(f"판정: {passed}/{len(results)}")
+    sys.exit(0 if passed == len(results) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/harness_proofs.py
+++ b/tools/harness_proofs.py
@@ -27,6 +27,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 SAMPLE = ROOT / "samples" / "basic" / "issue2007_nested_cell_pagination_42065.hwp"
 EXPECTED_COMMAND_COUNT = 68
+REQUIRED_EXIT_CODES = ("0", "1", "2")
+REQUIRED_JSON_CONTRACT_FIELDS = ("stdout", "schemaPolicy")
 
 
 def find_binary() -> str:
@@ -57,17 +59,65 @@ def command_surface_contract(caps: object) -> tuple[bool, str]:
         return False, f"capabilities JSON 형식 오류: object가 아님 ({type(caps).__name__})"
 
     commands = caps.get("commands")
-    n_cmd = len(commands) if isinstance(commands, list) else None
-    has_exit_codes = "exitCodes" in caps
-    has_json_contract = "jsonContract" in caps
-    ok = (
-        n_cmd == EXPECTED_COMMAND_COUNT
-        and has_exit_codes
-        and has_json_contract
+    if not isinstance(commands, list):
+        return False, f"commands 형식 오류: array가 아님 ({type(commands).__name__})"
+    if len(commands) != EXPECTED_COMMAND_COUNT:
+        return (
+            False,
+            f"commands={len(commands)} (expected={EXPECTED_COMMAND_COUNT})",
+        )
+
+    names = []
+    for index, command in enumerate(commands):
+        if not isinstance(command, dict):
+            return False, f"commands[{index}] 형식 오류: object가 아님"
+        name = command.get("name")
+        if not isinstance(name, str) or not name.strip():
+            return False, f"commands[{index}].name 형식 오류: 비어 있거나 문자열이 아님"
+        names.append(name)
+    if len(set(names)) != len(names):
+        duplicate = next(name for name in names if names.count(name) > 1)
+        return False, f"commands[].name 중복: {duplicate!r}"
+
+    exit_codes = caps.get("exitCodes")
+    if not isinstance(exit_codes, dict):
+        return False, f"exitCodes 형식 오류: object가 아님 ({type(exit_codes).__name__})"
+    for code in REQUIRED_EXIT_CODES:
+        meaning = exit_codes.get(code)
+        if not isinstance(meaning, str) or not meaning.strip():
+            return False, f"exitCodes[{code!r}] 의미가 비어 있거나 문자열이 아님"
+
+    json_contract = caps.get("jsonContract")
+    if not isinstance(json_contract, dict):
+        return False, f"jsonContract 형식 오류: object가 아님 ({type(json_contract).__name__})"
+    for field in REQUIRED_JSON_CONTRACT_FIELDS:
+        meaning = json_contract.get(field)
+        if not isinstance(meaning, str) or not meaning.strip():
+            return False, f"jsonContract[{field!r}] 의미가 비어 있거나 문자열이 아님"
+
+    return (
+        True,
+        f"commands={len(commands)} (expected={EXPECTED_COMMAND_COUNT}, unique names), "
+        f"exitCodes={list(REQUIRED_EXIT_CODES)}, "
+        f"jsonContract={list(REQUIRED_JSON_CONTRACT_FIELDS)}",
     )
+
+
+def provenance_marker_contract(envelope: object) -> tuple[bool, str]:
+    if not isinstance(envelope, dict):
+        return False, f"info JSON 형식 오류: object가 아님 ({type(envelope).__name__})"
+
+    untrusted_content = envelope.get("untrustedContent")
+    untrusted_fields = envelope.get("untrustedFields")
+    fields_ok = (
+        isinstance(untrusted_fields, list)
+        and len(untrusted_fields) > 0
+        and all(isinstance(field, str) and field.strip() for field in untrusted_fields)
+    )
+    ok = untrusted_content is True and fields_ok
     detail = (
-        f"commands={n_cmd!r} (expected={EXPECTED_COMMAND_COUNT}), "
-        f"exitCodes={has_exit_codes}, jsonContract={has_json_contract}"
+        f"untrustedContent={untrusted_content!r}, "
+        f"untrustedFields={untrusted_fields!r}"
     )
     return ok, detail
 
@@ -129,8 +179,7 @@ def proofs(bin_path: str) -> list:
     e = run(bin_path, ["info", str(SAMPLE), "--json"])
     try:
         env = json.loads(e.stdout)
-        ok = "untrustedContent" in env and "untrustedFields" in env
-        detail = f"untrustedContent={env.get('untrustedContent')!r}"
+        ok, detail = provenance_marker_contract(env)
     except Exception as ex:  # noqa: BLE001
         ok, detail = False, f"JSON 파싱 실패: {ex}"
     record(

--- a/tools/test_harness_proofs.py
+++ b/tools/test_harness_proofs.py
@@ -1,0 +1,49 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("harness_proofs.py")
+SPEC = importlib.util.spec_from_file_location("harness_proofs", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+HARNESS_PROOFS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(HARNESS_PROOFS)
+
+
+def capabilities(command_count: int) -> dict:
+    return {
+        "commands": [{} for _ in range(command_count)],
+        "exitCodes": {},
+        "jsonContract": {},
+    }
+
+
+class CommandSurfaceContractTests(unittest.TestCase):
+    def test_exact_documented_command_count_passes(self) -> None:
+        ok, detail = HARNESS_PROOFS.command_surface_contract(
+            capabilities(HARNESS_PROOFS.EXPECTED_COMMAND_COUNT)
+        )
+
+        self.assertTrue(ok, detail)
+        self.assertIn("expected=68", detail)
+
+    def test_missing_or_extra_commands_fail(self) -> None:
+        for count in (67, 69):
+            with self.subTest(count=count):
+                ok, detail = HARNESS_PROOFS.command_surface_contract(capabilities(count))
+
+                self.assertFalse(ok, detail)
+                self.assertIn(f"commands={count}", detail)
+
+    def test_contract_fields_remain_required(self) -> None:
+        caps = capabilities(HARNESS_PROOFS.EXPECTED_COMMAND_COUNT)
+        del caps["jsonContract"]
+
+        ok, detail = HARNESS_PROOFS.command_surface_contract(caps)
+
+        self.assertFalse(ok, detail)
+        self.assertIn("jsonContract=False", detail)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_harness_proofs.py
+++ b/tools/test_harness_proofs.py
@@ -12,9 +12,12 @@ SPEC.loader.exec_module(HARNESS_PROOFS)
 
 def capabilities(command_count: int) -> dict:
     return {
-        "commands": [{} for _ in range(command_count)],
-        "exitCodes": {},
-        "jsonContract": {},
+        "commands": [{"name": f"command-{i}"} for i in range(command_count)],
+        "exitCodes": {"0": "success", "1": "runtime failure", "2": "usage error"},
+        "jsonContract": {
+            "stdout": "JSON data only",
+            "schemaPolicy": "additive fields only",
+        },
     }
 
 
@@ -35,14 +38,67 @@ class CommandSurfaceContractTests(unittest.TestCase):
                 self.assertFalse(ok, detail)
                 self.assertIn(f"commands={count}", detail)
 
-    def test_contract_fields_remain_required(self) -> None:
-        caps = capabilities(HARNESS_PROOFS.EXPECTED_COMMAND_COUNT)
-        del caps["jsonContract"]
+    def test_commands_require_objects_nonempty_unique_names(self) -> None:
+        cases = []
+        not_object = capabilities(HARNESS_PROOFS.EXPECTED_COMMAND_COUNT)
+        not_object["commands"][0] = "command-0"
+        cases.append((not_object, "commands[0]"))
+        empty_name = capabilities(HARNESS_PROOFS.EXPECTED_COMMAND_COUNT)
+        empty_name["commands"][0]["name"] = "  "
+        cases.append((empty_name, "commands[0].name"))
+        duplicate = capabilities(HARNESS_PROOFS.EXPECTED_COMMAND_COUNT)
+        duplicate["commands"][-1]["name"] = duplicate["commands"][0]["name"]
+        cases.append((duplicate, "중복"))
 
-        ok, detail = HARNESS_PROOFS.command_surface_contract(caps)
+        for caps, expected_detail in cases:
+            with self.subTest(expected_detail=expected_detail):
+                ok, detail = HARNESS_PROOFS.command_surface_contract(caps)
+                self.assertFalse(ok, detail)
+                self.assertIn(expected_detail, detail)
+
+    def test_exit_codes_require_an_object_with_core_meanings(self) -> None:
+        for value in (None, {}, {"0": "", "1": "runtime failure", "2": "usage error"}):
+            with self.subTest(value=value):
+                caps = capabilities(HARNESS_PROOFS.EXPECTED_COMMAND_COUNT)
+                caps["exitCodes"] = value
+                ok, detail = HARNESS_PROOFS.command_surface_contract(caps)
+                self.assertFalse(ok, detail)
+                self.assertIn("exitCodes", detail)
+
+    def test_json_contract_requires_an_object_with_core_meanings(self) -> None:
+        for value in (None, {}, {"stdout": "JSON data only", "schemaPolicy": ""}):
+            with self.subTest(value=value):
+                caps = capabilities(HARNESS_PROOFS.EXPECTED_COMMAND_COUNT)
+                caps["jsonContract"] = value
+                ok, detail = HARNESS_PROOFS.command_surface_contract(caps)
+                self.assertFalse(ok, detail)
+                self.assertIn("jsonContract", detail)
+
+
+class ProvenanceMarkerContractTests(unittest.TestCase):
+    def test_document_derived_envelope_requires_true_and_nonempty_paths(self) -> None:
+        ok, detail = HARNESS_PROOFS.provenance_marker_contract(
+            {"untrustedContent": True, "untrustedFields": ["title", "metadata.author"]}
+        )
+
+        self.assertTrue(ok, detail)
+
+    def test_false_untrusted_content_is_rejected(self) -> None:
+        ok, detail = HARNESS_PROOFS.provenance_marker_contract(
+            {"untrustedContent": False, "untrustedFields": ["title"]}
+        )
 
         self.assertFalse(ok, detail)
-        self.assertIn("jsonContract=False", detail)
+        self.assertIn("untrustedContent=False", detail)
+
+    def test_empty_or_malformed_untrusted_fields_are_rejected(self) -> None:
+        for fields in ([], [""], [None], "title"):
+            with self.subTest(fields=fields):
+                ok, detail = HARNESS_PROOFS.provenance_marker_contract(
+                    {"untrustedContent": True, "untrustedFields": fields}
+                )
+                self.assertFalse(ok, detail)
+                self.assertIn("untrustedFields", detail)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 변경 요약

**하네스 스코어카드 — 주장마다 실행 명령.** 이번 주 업계 하네스 소식(관리형 GA — 검증은 운영자만 가능)의 반대편에 서는 실물입니다: 이 저장소의 하네스 성질은 제3자가 클론 후 `python tools/harness_proofs.py` 한 줄로 전수 검증합니다.

- 러너 실검증 6종(자기서술·explain 결정론 2회 바이트 동일 / 명령 68개 전수 자기서술 / exit 사전 / 실패 stdout 0바이트 / 출처 표지) — **로컬 실측 6/6 PASS**(release 바이너리). 실패 시 exit 1 이라 CI 게이트로도 편입 가능(R12 합류 후보).
- 스코어카드 문서: 러너 6행 + **계약 테스트·PR 링크로 검증되는 4행**(CAS #4381 · 변이 저널 #4361 · schemaRegistry #4330 · 공개 실험 #4355) — 미머지 성질에 거짓 PASS 를 만들지 않는 분리.
- 운영 규약: "표에 행이 없으면 주장이 아니다" — 이후 모든 하네스 성질 주장의 관문.
- 비교 프레임은 실명 서열 없이 원리 하나(폐쇄 검증 vs 공개 재현)만 — 전 조사 문서 규율 승계.

## 관련 이슈

closes #4389

## 테스트

- [x] 러너 자체가 검증: 6/6 PASS 실측(위) · 문서 메타데이터·상대 링크 이상 없음 · git diff --check 통과
- [ ] cargo / SVG / WASM — 해당 없음(파이썬 도구+문서)

## 성능 영향 및 측정 결과

- 해당 없음

## 스크린샷

- 러너 출력이 곧 증적(PR 본문·커밋에 기록)
