### PR TITLE
renderer: SVG editor_only 판정을 RenderProfile 하나로 통일

### DIFF
--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -2,7 +2,7 @@
 kind: canonical
 status: active
 canonical: mydocs/manual/cli_commands.md
-last_verified: 2026-08-08
+last_verified: 2026-08-09
 ---
 
 # rhwp CLI 명령어 매뉴얼
@@ -126,8 +126,13 @@ HWP/HWPX → SVG.
 - `--embed-fonts` — 폰트 서브셋 임베딩(사용 글자만 base64)
 - `--embed-fonts=full` — 폰트 전체 임베딩
 - `--font-path <경로>` — 폰트 탐색 경로(여러 번 지정 가능)
-- `--profile <프로필>` — layer 출력 프로필(공통 옵션 참조). 생략 시 기존
-  (legacy) 경로 — 인쇄 등가 억제 동작.
+- `--profile <프로필>` — layer 출력 프로필(공통 옵션 참조). 생략 시 기존(legacy) 경로
+  (`render_page_svg_native` → `SvgRenderer` 직행, paint 계층 미경유)다.
+  **legacy 경로는 인쇄 등가 출력이 아니다** — 기본값이 `RenderProfile::Screen` 과 같아
+  `editor_only` 노드(빈 누름틀 안내문 등)를 편집 화면처럼 표시한다. 그림 미지정
+  placeholder만 예외로 항상 억제된다(#2225). 인쇄 등가 산출물이 필요하면 이 옵션으로
+  `--profile print`(또는 `high-quality`)를 명시한다 — 두 경로의 배경과 `editor_only`
+  판정 통합은 #4379.
   **제약**: `--font-style`/`--embed-fonts` 와 함께 사용할 수 없다(오류 종료).
 
 ### `export-png <파일> [옵션]` *(native-skia feature 필요)*

--- a/mydocs/working/task_m100_4379_stage1.md
+++ b/mydocs/working/task_m100_4379_stage1.md
@@ -1,0 +1,80 @@
+# task_m100_4379 Stage 1 — SVG editor_only 판정을 RenderProfile 로 통일
+
+- **이슈**: [#4379](https://github.com/edwardkim/rhwp/issues/4379)
+- **PR**: [#4394](https://github.com/edwardkim/rhwp/pull/4394)
+- **브랜치**: `fix/issue-4379-svg-render-path-consolidation`
+- **분기 기준**: `upstream/devel` `e48fe8694`
+- **상태**: 로컬 전체 검증 + Skia 3종 + wasm-pack 통과, PR 게시
+- **기록일**: 2026-08-09 KST
+
+## 1. 발견 경위
+
+#4326(PR #4374)의 시각 증적을 검증하다 나왔다. `rhwp export-svg` 를 옵션 없이 돌려 82페이지 바이트
+동일을 얻고 "시각 증적"이라 적었는데, **옵션 없는 `export-svg` 가 paint 계층을 거치지 않는 legacy
+경로**임을 뒤늦게 확인했다. 표현이 실제보다 넓었다.
+
+그 확인 과정에서 SVG 출력 경로가 두 벌이고 같은 판정이 각자 다르게 구현돼 있음이 드러났다.
+
+## 2. 결함
+
+| | legacy | layer |
+|---|---|---|
+| 파이프라인 | `build_page_tree` → `SvgRenderer::render_tree` | `build_page_layer_tree_with_profile` → `SvgLayerRenderer` |
+| paint 계층 | 미경유 | 경유 |
+| `editor_only` 판정 | `svg.rs:271` `!self.show_editor_only_nodes`(bool, 기본 `true`) | `paint/builder.rs:75` `!profile.shows_editor_visuals()` |
+
+`svg.rs` 주석이 이중성을 자인하고 있었다 — *"LayerBuilder 는 이미 `editor_only` 를 프로필로
+걸러내지만 SVG 렌더러는 렌더 트리를 직접 순회해 그 계약 밖에 있었다."*
+
+**둘 다 프로덕션에서 살아 있다**: studio 화면 SVG(`main.ts:1468`) → legacy, PDF 내보내기
+(`file.ts:461`) → layer, CLI `export-svg` 기본 → legacy.
+
+경로 선택이 `RHWP_RENDER_PATH` 환경변수인데, `wasm32-unknown-unknown` 에는 프로세스 환경이 없어
+`std::env::var` 가 항상 `Err` 다 — **브라우저에서는 이 함수로 layer 경로에 도달할 수 없다.**
+
+## 3. 두 경로가 같아야 하는 범위 — 먼저 정의했다
+
+전부 같아야 하는 것이 아니다.
+
+- **같아야 함**(같은 `RenderProfile` 에서) — `editor_only` 게이트 판정, 콘텐츠 노드
+  (TextRun/Image/Table/Shape/Equation) 렌더 결과
+- **달라도 됨**(의도적 직교 축) — `show_paragraph_marks`/`show_control_codes`(인스턴스 플래그,
+  프로필과 무관), `debug_overlay`(legacy 전용), `--font-style`/`--embed-fonts`(legacy 전용, CLI 가
+  이미 `--profile` 과 상호 배타로 강제)
+
+## 4. 구현
+
+`SvgRenderer.show_editor_only_nodes: bool` → `profile: RenderProfile`. 게이트가
+`paint/builder.rs:75` 와 **문자 그대로 같은 술어**를 부른다. 기본값 `Screen` 이
+`shows_editor_visuals() == true` 로 종전 bool 기본값과 동치라 기존 호출부 동작은 불변이다.
+
+env 게이트를 `#[cfg(not(target_arch = "wasm32"))]` 로 감쌌다 — 장식이 아니라 **사실 표시**다.
+주석에 그 이유를 남겼다. env var 자체는 유지했다(제거하면 `main.rs`/`wasm_api.rs`/기존 A/B 디버그
+워크플로까지 건드려야 해 범위 밖).
+
+`cli_commands.md` 의 `export-svg --profile` 설명을 정정했다 — "생략 시 인쇄 등가 억제"는 부정확하다.
+missing-picture 만 억제되고 다른 `editor_only` 장식은 기본 표시된다.
+
+## 5. 재분기 방지 장치
+
+`svg_layer.rs::editor_only_gate_matches_across_legacy_and_layer_paths_for_every_profile` 신설.
+`RenderProfile` 4종 각각에서 일반 콘텐츠 노드와 `editor_only` 노드를 함께 놓고 두 경로 출력이 바이트
+단위로 같은지, 표시 여부가 `shows_editor_visuals()` 와 일치하는지 고정한다.
+
+## 6. 범위 밖
+
+`PlaceholderKind::MissingPicture` 억제는 `svg.rs`/`skia/renderer.rs`/`web_canvas.rs` 에 각각
+재구현돼 있다. `editor_only` 로 통합하려면 노드 생성 시점(`picture_footnote.rs`)에
+`.with_editor_only()` 를 걸어야 하는데, 그러면 **편집 캔버스가 항상 보여야 하는 것**과 **프로필로
+갈려야 하는 것**의 경계를 재검증해야 한다.
+
+경로 선택을 호출부 명시 인자로 완전히 대체하는 것도 범위 밖이다.
+
+## 7. 검증 (완료)
+
+- `cargo test --profile release-test --tests` 전체 통과(497 바이너리, 5500 테스트).
+- Native Skia 3종 통과, `wasm-pack build --target web` 성공.
+- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` 통과. wasm32 타깃 check/clippy
+  도 0 error, 신규 경고 0.
+
+남은 미래 조건은 GitHub Actions 와 작업지시자 승인, merge 다.

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -947,7 +947,17 @@ impl DocumentCore {
         self.layout_engine.take_overflow_cell_lines()
     }
 
+    /// [Issue #4379] `RHWP_RENDER_PATH=layer-svg` 는 legacy/layer 두 SVG 경로를 A/B 대조하는
+    /// **네이티브 전용** 디버그 스위치다. `#[cfg(not(target_arch = "wasm32"))]` 로 감싼 이유는
+    /// 장식이 아니라 사실 표시다 — wasm32-unknown-unknown(rhwp-studio 브라우저 빌드)에는
+    /// 프로세스 환경변수가 없어 `std::env::var` 가 항상 `Err` 를 반환하므로, 이 함수를 거쳐서는
+    /// wasm 에서 layer 경로에 절대 도달할 수 없다(`renderPageSvg` → 항상 legacy). studio 가
+    /// 실제로 인쇄 등가 SVG 를 원하면 이 함수를 우회해 `render_page_svg_layer_with_profile_native`
+    /// (`renderPageSvgWithProfile`) 를 직접 불러야 한다 — PDF 내보내기(`file.ts:461`)가 이미
+    /// 그렇게 한다. 이 cfg 분기는 "네이티브 디버그 스위치이지 프로덕션 경로 선택 API 가 아니다"를
+    /// 코드로 드러낸다.
     pub fn render_page_svg_native(&self, page_num: u32) -> Result<String, HwpError> {
+        #[cfg(not(target_arch = "wasm32"))]
         if matches!(
             std::env::var("RHWP_RENDER_PATH").ok().as_deref(),
             Some("layer-svg")

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -86,15 +86,19 @@ pub struct SvgRenderer {
     pub debug_overlay: bool,
     /// 편집 화면 전용 missing-picture placeholder 표시 여부.
     pub show_missing_picture_placeholder: bool,
-    /// [#3375] `editor_only` 노드(빈 누름틀 안내문 등) 표시 여부.
+    /// [#3375/#4379] `editor_only` 노드(빈 누름틀 안내문 등) 표시 판정의 단일 권위.
     ///
-    /// 한컴은 편집 화면에서만 보여 주는 요소를 인쇄·PDF 에서는 내보내지 않는다. paint
-    /// LayerBuilder 는 이미 `editor_only` 를 프로필로 걸러내지만 SVG 렌더러는 렌더 트리를
-    /// 직접 순회해 그 계약 밖에 있었다.
+    /// 한컴은 편집 화면에서만 보여 주는 요소를 인쇄·PDF 에서는 내보내지 않는다. 이 판정은
+    /// paint `LayerBuilder`(`paint/builder.rs`)의 `node.editor_only && !profile.shows_editor_visuals()`
+    /// 와 **같은 술어**(`RenderProfile::shows_editor_visuals`)를 호출한다 — 예전에는 이 필드가
+    /// 독립된 bool(`show_editor_only_nodes`)이라 두 경로가 각자 기본값을 들고 있었고, 한쪽만
+    /// 고치면 조용히 갈라질 수 있었다(#4379).
     ///
-    /// 기본값은 **표시(true)** 다 — 프로필 개념이 없는 legacy 경로(편집 화면 렌더)는 종전대로
-    /// 트리를 그대로 그린다. 프로필을 아는 layer 경로만 `shows_editor_visuals()` 로 내린다.
-    pub show_editor_only_nodes: bool,
+    /// 기본값은 `RenderProfile::Screen`(`shows_editor_visuals() == true`) — 프로필 개념이
+    /// 없던 legacy 경로(편집 화면 렌더)가 종전대로 트리를 그대로 그리던 동작과 동일하다.
+    /// 프로필을 아는 layer 경로(`svg_layer.rs`)는 이 필드를 자신의 `RenderProfile` 로 그대로
+    /// 대입한다.
+    pub profile: crate::paint::RenderProfile,
     /// 디버그 오버레이용: 문단별 경계 수집 (pi → bbox)
     overlay_para_bounds: std::collections::HashMap<usize, OverlayBounds>,
     /// 디버그 오버레이용: 표 경계 수집
@@ -177,7 +181,7 @@ impl SvgRenderer {
             show_control_codes: false,
             debug_overlay: false,
             show_missing_picture_placeholder: false,
-            show_editor_only_nodes: true,
+            profile: crate::paint::RenderProfile::Screen,
             overlay_para_bounds: std::collections::HashMap::new(),
             overlay_table_bounds: Vec::new(),
             overlay_image_bounds: Vec::new(),
@@ -266,9 +270,9 @@ impl SvgRenderer {
         if !node.visible {
             return;
         }
-        // [#3375] 편집 화면 전용 요소는 인쇄 등가 profile 에서 내보내지 않는다
-        // (paint LayerBuilder 의 `editor_only` 계약과 동형).
-        if node.editor_only && !self.show_editor_only_nodes {
+        // [#3375/#4379] 편집 화면 전용 요소는 인쇄 등가 profile 에서 내보내지 않는다 —
+        // paint LayerBuilder(`paint/builder.rs:75`)와 같은 술어를 호출한다.
+        if node.editor_only && !self.profile.shows_editor_visuals() {
             return;
         }
 

--- a/src/renderer/svg_layer.rs
+++ b/src/renderer/svg_layer.rs
@@ -242,7 +242,9 @@ impl LayerRenderer for SvgLayerRenderer {
         self.renderer.show_control_codes = tree.output_options.show_control_codes;
         self.renderer.debug_overlay = tree.output_options.debug_overlay;
         self.renderer.show_missing_picture_placeholder = tree.profile.shows_editor_visuals();
-        self.renderer.show_editor_only_nodes = tree.profile.shows_editor_visuals();
+        // [#4379] `profile` 자체를 그대로 넘긴다 — legacy 렌더러의 editor_only 판정이
+        // paint LayerBuilder 와 같은 `RenderProfile::shows_editor_visuals` 호출로 수렴한다.
+        self.renderer.profile = tree.profile;
         let render_tree = self.build_render_tree(tree);
         self.renderer.render_tree(&render_tree);
         Ok(())
@@ -388,6 +390,82 @@ mod tests {
 
         assert!(screen.output().contains("stroke-dasharray=\"6 3\""));
         assert!(!print.output().contains("stroke-dasharray=\"6 3\""));
+    }
+
+    /// [Issue #4379] `editor_only` 표시 판정은 legacy(`SvgRenderer::profile`)와 layer
+    /// (`LayerBuilder`/`paint/builder.rs:75`) 양쪽이 같은 `RenderProfile::shows_editor_visuals`
+    /// 술어를 호출해야 한다. 이 대조 테스트가 "같은 입력에 같은 결과" 계약의 최소 범위다 —
+    /// 프로필 4종 전부에서 두 경로의 SVG 출력이 바이트 단위로 같고, editor_only 콘텐츠의
+    /// 표시 여부가 `shows_editor_visuals()` 와 일치해야 한다. 한쪽 기본값만 바뀌면 이 테스트가
+    /// 잡는다(#4374 PR 리뷰에서 이 두 경로의 차이를 "시각 증적"으로 오해한 사고가 계기).
+    #[test]
+    fn editor_only_gate_matches_across_legacy_and_layer_paths_for_every_profile() {
+        for profile in [
+            RenderProfile::FastPreview,
+            RenderProfile::Screen,
+            RenderProfile::Print,
+            RenderProfile::HighQuality,
+        ] {
+            let mut render_tree = PageRenderTree::new(0, 100.0, 80.0);
+            render_tree.root.node_type = RenderNodeType::Page(PageNode {
+                page_index: 0,
+                width: 100.0,
+                height: 80.0,
+                section_index: 0,
+            });
+            // 항상 보여야 하는 일반 콘텐츠 — 프로필과 무관.
+            render_tree.root.children.push(RenderNode::new(
+                40,
+                RenderNodeType::Rectangle(RectangleNode::new(
+                    0.0,
+                    ShapeStyle {
+                        fill_color: Some(0x00112233),
+                        ..Default::default()
+                    },
+                    None,
+                )),
+                BoundingBox::new(0.0, 0.0, 20.0, 20.0),
+            ));
+            // 편집 화면 전용 장식(예: 투명 테두리 안내선) — editor_only 로만 표시를 가른다.
+            render_tree.root.children.push(
+                RenderNode::new(
+                    41,
+                    RenderNodeType::Rectangle(RectangleNode::new(
+                        0.0,
+                        ShapeStyle {
+                            fill_color: Some(0x00445566),
+                            ..Default::default()
+                        },
+                        None,
+                    )),
+                    BoundingBox::new(40.0, 0.0, 20.0, 20.0),
+                )
+                .with_editor_only(),
+            );
+
+            let mut legacy = SvgRenderer::new();
+            legacy.profile = profile;
+            legacy.render_tree(&render_tree);
+
+            let layer_tree = LayerBuilder::new(profile).build(&render_tree);
+            let mut layer = SvgLayerRenderer::new();
+            layer.render_page(&layer_tree).unwrap();
+
+            assert_eq!(
+                layer.output(),
+                legacy.output(),
+                "profile={profile:?} 에서 legacy/layer SVG 출력이 갈림"
+            );
+
+            let shows_editor_only = profile.shows_editor_visuals();
+            assert_eq!(
+                legacy.output().contains("665544"),
+                shows_editor_only,
+                "profile={profile:?}: editor_only 장식 표시 여부가 shows_editor_visuals()={shows_editor_only} 와 다름"
+            );
+            // 일반 콘텐츠는 모든 프로필에서 보여야 한다.
+            assert!(legacy.output().contains("332211"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## 무엇을

SVG 출력의 `editor_only` 표시 판정을 `RenderProfile::shows_editor_visuals()` 하나로 통일하고,
경로 선택 환경변수가 WASM 에서 무의미하다는 사실을 코드에 드러낸다.

## 왜

SVG 출력 경로가 두 벌인데 **같은 판정이 각자 다른 메커니즘·다른 기본값**으로 구현돼 있었다.

| | legacy | layer |
|---|---|---|
| 파이프라인 | `build_page_tree` → `SvgRenderer::render_tree` | `build_page_layer_tree_with_profile` → `SvgLayerRenderer` |
| paint 계층 | 미경유 | 경유 |
| `editor_only` 판정 | `svg.rs:271` `!self.show_editor_only_nodes` (bool) | `paint/builder.rs:75` `!profile.shows_editor_visuals()` |

`svg.rs` 의 주석이 이중성을 자인하고 있었다 — *"LayerBuilder 는 이미 `editor_only` 를 프로필로
걸러내지만 SVG 렌더러는 렌더 트리를 직접 순회해 그 계약 밖에 있었다."*

두 경로 모두 프로덕션에서 살아 있다:

- studio 화면 SVG — `main.ts:1468` `wasm.renderPageSvg(page)` → **legacy**
- PDF 내보내기 — `command/commands/file.ts:461` `renderPageSvgWithProfile(i, 'print')` → **layer**
- CLI `export-svg` — 기본 legacy, `--profile` 주면 layer

## 어떻게

**판정 통일.** `SvgRenderer.show_editor_only_nodes: bool` 을 `profile: RenderProfile` 로 바꾸고,
게이트가 `paint/builder.rs:75` 와 **문자 그대로 같은 술어**를 부르게 했다:

```rust
if node.editor_only && !self.profile.shows_editor_visuals() {
```

기본값 `RenderProfile::Screen` 은 `shows_editor_visuals() == true` 로 종전 bool 기본값과 동치라,
기존 호출부 동작은 바뀌지 않는다. `SvgLayerRenderer` 는 자신의 프로필을 그대로 대입한다.

**env 게이트 사실 표시.** `render_page_svg_native` 의 `RHWP_RENDER_PATH` 분기를
`#[cfg(not(target_arch = "wasm32"))]` 로 감쌌다. 장식이 아니라 사실 표시다 —
`wasm32-unknown-unknown` 에는 프로세스 환경이 없어 `std::env::var` 가 항상 `Err` 이므로,
**브라우저에서는 이 함수를 거쳐 layer 경로에 도달할 수 없다.** studio 가 인쇄 등가 SVG 를
원하면 `renderPageSvgWithProfile` 을 직접 불러야 하고, PDF 내보내기가 이미 그렇게 한다.

env var 자체는 유지했다 — 제거하면 `main.rs`/`wasm_api.rs`/기존 A/B 디버그 워크플로까지 건드려야
해서 범위 밖이다.

## 두 경로가 같아야 하는 범위

전부 같아야 하는 것이 아니다. 이번에 경계를 정했다:

- **같아야 함** (같은 `RenderProfile` 에서) — `editor_only` 게이트 판정, 콘텐츠 노드
  (TextRun/Image/Table/Shape/Equation) 렌더 결과
- **달라도 됨** (의도적 직교 축) — `show_paragraph_marks`/`show_control_codes`(인스턴스별 플래그,
  프로필과 무관), `debug_overlay`(legacy 전용 디버그), `--font-style`/`--embed-fonts`(legacy 전용,
  CLI 가 이미 `--profile` 과 상호 배타로 강제)

## 검증

- **대조 테스트 신설** — `svg_layer.rs::editor_only_gate_matches_across_legacy_and_layer_paths_for_every_profile`.
  `RenderProfile` 4종 각각에서 일반 콘텐츠 노드와 `editor_only` 노드를 함께 놓고 legacy·layer 출력이
  바이트 단위로 같은지, 표시 여부가 `shows_editor_visuals()` 와 일치하는지 고정한다. 두 경로가 다시
  갈라지면 여기서 잡힌다.
- `cargo test --profile release-test --tests` 전체 통과 (497 바이너리, 5500 테스트).
- Native Skia 3종 통과, `wasm-pack build --target web` 성공.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` 통과.
  wasm32 타깃 `cargo check`/`clippy` 도 0 error, 신규 경고 0.
- `mydocs/manual/cli_commands.md` 의 `export-svg --profile` 설명 정정 — "생략 시 인쇄 등가 억제"는
  부정확했다. missing-picture 만 억제되고 다른 `editor_only` 장식은 기본 표시된다.

## 범위 밖

`PlaceholderKind::MissingPicture` 억제는 `svg.rs`/`skia/renderer.rs`/`web_canvas.rs` 에 각각
재구현돼 있다. `editor_only` 로 통합하려면 노드 생성 시점(`picture_footnote.rs`)에
`.with_editor_only()` 를 걸어야 하는데, 그러면 **편집 캔버스가 항상 보여야 하는 것**과
**프로필로 갈려야 하는 것**의 경계를 다시 검증해야 한다. 별도 작업으로 분리한다.

경로 선택을 호출부 명시 인자로 완전히 대체하는 것도 범위 밖이다 — 이번엔 "네이티브 디버그
스위치이지 프로덕션 경로 선택 API 가 아니다"를 코드에 드러내는 데 그쳤다.

Closes #4379


