### PR TITLE
serializer(hwpx): styleIDRef=0 을 스타일 목록과 무관하게 항상 등록

### DIFF
--- a/src/serializer/hwpx/context.rs
+++ b/src/serializer/hwpx/context.rs
@@ -160,6 +160,14 @@ impl SerializeContext {
         for (idx, _) in doc.doc_info.styles.iter().enumerate() {
             ctx.style_ids.register(idx as u16);
         }
+        // [#1933 보강] style 0 은 `effective_style_id`/`write_styles` 계약상 "항상
+        // 등록됨" 취급이다 — `<hh:styles>` 블록 자체가 없는(styles 비어있는) 정상
+        // HWPX 도 파라그래프가 암묵적 기본 style 0을 참조할 수 있고, `write_styles`
+        // 는 그 경우 블록을 그대로 생략한다(header.rs). 종전에는 `doc_info.styles`
+        // 가 비어 있으면 0도 등록되지 않아, 있는 그대로 되돌려 쓰는 정상적인
+        // round-trip이 `assert_all_refs_resolved` 에서 "미등록 styleIDRef: [0]" 로
+        // 하드 실패했다(예: styles 블록이 없는 샘플의 HWPX 자기 왕복).
+        ctx.style_ids.register(0);
 
         // 인라인 컨트롤(표/그림 등)의 borderFillIDRef를 사전 등록하여
         // assert_all_refs_resolved 검증 시 누락 방지.
@@ -358,6 +366,22 @@ mod tests {
         let doc = Document::default();
         let ctx = SerializeContext::collect_from_document(&doc);
         ctx.assert_all_refs_resolved().expect("empty doc must pass");
+    }
+
+    /// [Issue #4395] `doc_info.styles` 가 비어 있어도(=`<hh:styles>` 블록 없음) style id 0 은
+    /// 항상 등록된 것으로 취급해야 한다 — `effective_style_id`(아래)의 기존 계약이자,
+    /// `write_styles`(header.rs)가 빈 목록일 때 블록 자체를 생략하는 정상 동작과 짝을 이룬다.
+    /// 수정 전에는 `doc.doc_info.styles` 순회로만 등록해서 목록이 비면 0 도 미등록으로 남아,
+    /// styleIDRef=0 을 참조하는 문단이 있는 문서(예: `samples/task2156/width_ladder.hwpx`)의
+    /// 저장 자체가 "미등록 ID 참조 발견: styleIDRef: [0]" 로 하드 실패했다.
+    #[test]
+    fn style_zero_always_registered_without_explicit_style_list() {
+        let doc = Document::default();
+        assert!(doc.doc_info.styles.is_empty());
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        ctx.style_ids.reference(0);
+        ctx.assert_all_refs_resolved()
+            .expect("style 0 must always be registered, even with an empty style list (#4395)");
     }
 
     #[test]

--- a/tests/issue_4395_style_zero_hwpx_export.rs
+++ b/tests/issue_4395_style_zero_hwpx_export.rs
@@ -1,0 +1,49 @@
+//! Issue #4395: HWPX 문서에 `<hh:styles>` 블록이 없으면(스타일 목록이 비어 있으면) 문단이
+//! 참조하는 암묵적 기본 `styleIDRef="0"` 이 재직렬화 자기검증에서 "미등록 ID 참조"로 하드
+//! 실패했다 — HWP5 를 거치지 않는 순수 HWPX 자기 왕복(`parse_hwpx` → `serialize_hwpx`)에서도,
+//! HWPX→HWP→HWPX 왕복에서도 동일하게 실패했다.
+//!
+//! `src/serializer/hwpx/header.rs`의 `write_styles` 는 `doc_info.styles` 가 비어 있으면
+//! `<hh:styles>` 블록 자체를 생략한다(정상 동작). 하지만
+//! `src/serializer/hwpx/context.rs`의 `SerializeContext::collect_from_document` 는 그 목록을
+//! 순회해서만 style id 를 등록했으므로, 목록이 비면 0 도 등록되지 않았다.
+//! `effective_style_id`(같은 파일)의 주석은 "0(항상 등록됨)"이라고 명시하는데 그 불변식이
+//! 실제로 보장되지 않았던 것 — `samples/task2156/width_ladder.hwpx` 등 스타일 목록이 없는
+//! 최소 픽스처가 전부 이 경로로 저장 자체가 불가능했다.
+
+use std::fs;
+
+use rhwp::parser::hwpx::parse_hwpx;
+use rhwp::serializer::hwpx::serialize_hwpx;
+
+/// 스타일 목록이 없는 실제 픽스처가 순수 HWPX 자기 왕복(HWP5 미경유)에서도 저장돼야 한다.
+#[test]
+fn hwpx_without_style_list_serializes_without_error() {
+    let path = "samples/task2156/width_ladder.hwpx";
+    let data = fs::read(path).unwrap_or_else(|e| panic!("{path} 읽기 실패: {e}"));
+    let doc = parse_hwpx(&data).expect("HWPX 파싱 실패");
+
+    assert!(
+        doc.doc_info.styles.is_empty(),
+        "이 픽스처는 <hh:styles> 가 없다는 전제로 작성된 회귀 테스트다"
+    );
+
+    serialize_hwpx(&doc).unwrap_or_else(|e| {
+        panic!("스타일 목록이 비어 있어도 styleIDRef=0 참조는 항상 유효해야 한다 (#4395): {e}")
+    });
+}
+
+/// 같은 픽스처 3종에서 재확인 — 전부 같은 근본 원인(#4395)으로 실패했었다.
+#[test]
+fn other_style_zero_fixtures_serialize_without_error() {
+    for path in [
+        "samples/task2169/anchor_ladder.hwpx",
+        "samples/task2070/hy_ladder3.hwpx",
+        "samples/task2169/empty_ladder.hwpx",
+    ] {
+        let data = fs::read(path).unwrap_or_else(|e| panic!("{path} 읽기 실패: {e}"));
+        let doc = parse_hwpx(&data).unwrap_or_else(|e| panic!("{path} 파싱 실패: {e}"));
+        serialize_hwpx(&doc)
+            .unwrap_or_else(|e| panic!("{path}: 미등록 styleIDRef=0 회귀 (#4395): {e}"));
+    }
+}


### PR DESCRIPTION
## 무엇을

`<hh:styles>` 블록이 없는 정상 HWPX 를 다시 저장할 때 `styleIDRef=0` 참조가 자기검증에서 하드
실패하던 것을 고친다.

## 왜

`SerializeContext::collect_from_document` 는 `doc.doc_info.styles` 를 순회하며 style id 를
등록했다. 목록이 **비어 있으면 0 도 등록되지 않는다.**

그런데 style 0 은 다른 두 계약에서 "항상 등록됨"으로 취급된다:

- `effective_style_id` — 문단이 암묵적 기본 style 0 을 참조할 수 있다
- `write_styles`(`header.rs`) — 목록이 비면 `<hh:styles>` 블록 자체를 생략한다

즉 **스타일 블록 없이 문단이 style 0 을 참조하는 문서는 정상**인데, 저장 시
`assert_all_refs_resolved` 가 `미등록 ID 참조 발견: styleIDRef: [0]` 로 실패해 **산출물 없이
저장 자체가 죽었다.**

출력 XML 은 항상 정상이었다 — 순수 내부 자기검증 버그다.

## 어떻게

`ctx.style_ids.register(0)` 한 줄. `doc_info.styles` 순회와 무관하게 0 을 항상 등록한다.
`effective_style_id`/`write_styles` 의 기존 계약을 등록 쪽에도 맞춘 것이다.

## 검증

- 유닛 테스트 `style_zero_always_registered_without_explicit_style_list` 신설 — 빈
  `Document::default()` 로 `styleIDRef=0` 을 참조해 통과하는지 고정한다.
- 통합 테스트 2건(실제 fixture 4개, 예: `samples/task2156/width_ladder.hwpx`).
- **수정 전 실패 확인** — fix 라인을 일시 주석 처리해 FAILED 를 확인하고 복원 후 PASS 를 확인했다.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`,
  `cargo test --profile release-test --tests` 전체 통과.

## 발견 경위

HWPX → HWP → HWPX 라운드트립 코퍼스 스윕(`samples/` 281 + 실문서 3,418 = 3,699건)에서 나왔다.
`samples/` 13건이 이 경로로 저장에 실패했고 실문서에서는 0건이었다 — 스타일 블록 없는 HWPX 가
실무 문서에는 드물고 fixture 에 몰려 있다.

Closes #4395

## 게이트 주석

`cargo test --profile release-test --tests` 첫 실행에서 `text_security` 의 타이밍 테스트
`scan_cost_stays_linear_as_input_grows` 가 1건 실패했다. 이 PR 의 변경(HWPX 직렬화기 한 줄)과
무관한 부하성 flake 로 판단했다 — 단독 재실행 시 통과했고, 같은 실행의 나머지 3,374건은 전부
통과했다. 실패 당시 같은 머신에서 다수의 cargo 빌드가 동시에 돌고 있었다.
