### PR TITLE
core(hwpx): 단별 폭(hp:colSz) 읽기·쓰기 추가 + i16 오버플로 saturate

### DIFF
--- a/mydocs/working/task_m100_4387_stage1.md
+++ b/mydocs/working/task_m100_4387_stage1.md
@@ -1,0 +1,79 @@
+# task_m100_4387 Stage 1 — HWPX 단별 폭(hp:colSz) 읽기·쓰기
+
+- **이슈**: [#4387](https://github.com/edwardkim/rhwp/issues/4387)
+- **브랜치**: `fix/issue-4387-hwpx-colsz`
+- **분기 기준**: `upstream/devel` `e48fe8694`
+- **상태**: 로컬 검증 통과, PR 게시
+- **기록일**: 2026-08-10 KST
+
+## 1. 결함 — 스키마에 있는데 양쪽 다 미구현
+
+OWPML `ColumnDefType`(`ParaList XML schema.xml:1415`)은 `colLine` 다음 자식으로 `colSz` 를
+정의한다 — `minOccurs=0 maxOccurs=255`, 속성 `width`(`xs:positiveInteger`)/`gap`
+(`xs:nonNegativeInteger`), 문서화 *"sameSize가 false일 때, 각 단의 크기 및 사이간격"*.
+
+IR 에도 자리가 있다 — `ColumnDef.widths`/`gaps`/`proportional_widths`(`model/page.rs:134-138`).
+
+그런데 `colSz` 문자열이 HWPX 파서·직렬화기 **어디에도 없었다**(grep 0건).
+
+## 2. 소비자 확인 — 채우는 것이 의미 있다
+
+리뷰에서 "아무도 안 읽으면 채워도 무의미하다"는 반증 가능성을 먼저 확인했다.
+
+`renderer/page_layout.rs::calculate_column_areas` 가 실제로 읽는다:
+- `:194` `if !column_def.same_width && column_def.widths.len() >= col_count`
+- `:199-217` `proportional_widths` 면 비례 계산, `:232-234` 아니면 절대 HWPUNIT
+- `main.rs` CLI 덤프도 같은 필드를 출력한다
+
+**반증 실패 — 이슈는 진짜였다.**
+
+## 3. 왕복 재현
+
+Document IR 을 직접 구성해(`serialize_hwpx` → zip 추출 → `parse_hwpx`) 불균등 2단
+(4000/6000 HWPUNIT, gap 500/0)을 왕복시켰다. 수정 전에는 `sameSz="0"` 만 방출되고
+`<hp:colSz>` 가 전혀 없어 폭이 사라졌다. 샘플 파일은 건드리지 않고 IR API 로 합성했다.
+
+## 4. 구현
+
+- **파서** — `parse_col_sz()` 신설, `parse_col_pr_with_children` 의 `Event::Empty`/`Event::Start`
+  **양쪽** 분기에 연결.
+- **직렬화기** — `render_col_pr_ctrl` 이 `sameSz="false"` 이고 `widths` 가 비어 있지 않을 때
+  `colLine` **뒤**(스키마 `xs:sequence` 순서)에 단별 `<hp:colSz>` 를 방출.
+- `proportional_widths` 는 건드리지 않았다 — HWPX 는 절대 HWPUNIT 이라 기본값 `false` 가 정답이고,
+  HWP5 바이너리 파서만 비례값(합계 32768)이라 `true` 로 켠다.
+
+## 5. 리뷰가 잡은 것 — i16 오버플로
+
+`ColumnDef.widths`/`gaps` 는 `Vec<HwpUnit16>` 이고 `HwpUnit16 = i16`(`model/mod.rs:28`), 최대
+**32767**. 스키마의 `width` 는 `xs:positiveInteger` 로 **상한이 없다.** A4 본문 폭이 ~48000
+HWPUNIT 이라 2단이면 들어가지만 1단·비대칭·A3 에서는 넘친다.
+
+**재현**: `parse_i16`(`parser/hwpx/utils.rs:54`)은 `parse::<i16>().unwrap_or(0)` 이다.
+`"40000".parse::<i16>()` 은 패닉도 wrap 도 아닌 `PosOverflow` 에러이고, `unwrap_or(0)` 이 그것을
+삼켜 **무경고 0-폴백**한다 — `widths=[0, 13000]`, 단이 통째로 사라진다. 스키마 위반 음수
+(`gap="-7"`)는 그대로 통과해 `page_layout.rs:232` 의 `as i32` 에서 음수 폭이 된다.
+
+**조치**: `parse_col_sz` 전용 `parse_hwpunit16_saturating` — i64 로 먼저 파싱 후 `HwpUnit16` 범위로
+clamp, 잘렸을 때만 경고. `gap` 은 스키마상 `nonNegativeInteger` 라 `.max(0)` 하한 추가.
+결과: `width="40000"` → `32767`(0 이 아니라 단이 살아남음), `gap="-7"` → `0`.
+
+공용 `parse_i16` 은 건드리지 않았다 — `section.rs` 전역에서 쓰여 blast radius 가 크고, 이번 문제는
+HWPX 가 절대 HWPUNIT 을 처음 담기 시작한 `colSz` 에 국한된다.
+
+**`HwpUnit16` 타입 확장은 하지 않았다** — HWP5 바이너리 경로와 `table.rs::row_sizes` 등 전 IR 에
+파급되므로 이번 범위를 넘는다. 근본 해결이 필요하면 별도 이슈로 추적한다.
+
+## 6. 검증 (완료)
+
+- 회귀 테스트 3건 — 왕복 보존, 정상 범위 개별 폭·간격, **오버플로/음수 gap 이 0-소실이 아니라
+  saturate** 확인. `git diff > patch` → `checkout --` → 실행으로 **수정 전 실패를 확인**했다
+  (`colSz 요소가 방출돼야 함(#4387)`). `git stash` 는 쓰지 않았다(워크트리 간 공유 사고 회피).
+- `cargo test --profile release-test --tests --no-fail-fast` — 496개 바이너리 중 495개 ok.
+- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` 통과.
+
+**flake 1건**: `document_core::text_security::tests::scan_cost_stays_linear_as_input_grows` 가
+실패했다. 이 변경과 무관한 파일의 **벽시계 타이밍 비율 단언**이고, 실행 당시 이 머신의 load
+average 가 120~130(16코어)이었다. 같은 라운드 초반 부하가 낮을 때는 통과했다. `issue4387_*` 3건은
+전부 통과했다.
+
+남은 미래 조건은 GitHub Actions 와 작업지시자 승인, merge 다.

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -1401,7 +1401,7 @@ fn parse_col_pr(e: &quick_xml::events::BytesStart) -> ColumnDef {
     cd
 }
 
-/// <hp:colPr> 요소의 속성과 자식 <hp:colLine> 파싱 → ColumnDef
+/// <hp:colPr> 요소의 속성과 자식 <hp:colLine>/<hp:colSz> 파싱 → ColumnDef
 fn parse_col_pr_with_children(
     e: &quick_xml::events::BytesStart,
     reader: &mut Reader<&[u8]>,
@@ -1414,6 +1414,7 @@ fn parse_col_pr_with_children(
                 let cname = ce.name();
                 match local_name(cname.as_ref()) {
                     b"colLine" => parse_col_line(ce, &mut cd),
+                    b"colSz" => parse_col_sz(ce, &mut cd),
                     _ => {}
                 }
             }
@@ -1424,6 +1425,10 @@ fn parse_col_pr_with_children(
                     b"colLine" => {
                         parse_col_line(ce, &mut cd);
                         skip_element(reader, b"colLine")?;
+                    }
+                    b"colSz" => {
+                        parse_col_sz(ce, &mut cd);
+                        skip_element(reader, b"colSz")?;
                     }
                     _ => {
                         let tag = local.to_vec();
@@ -1454,6 +1459,27 @@ fn parse_col_line(e: &quick_xml::events::BytesStart, cd: &mut ColumnDef) {
             _ => {}
         }
     }
+}
+
+/// <hp:colSz width="..." gap="..."/> 파싱 → ColumnDef.widths/gaps (#4387).
+///
+/// `sameSz="false"` 일 때 단 개수만큼(최대 255) 반복되는 요소로, 단별 절대
+/// HWPUNIT 너비·뒤 간격을 담는다 (`mydocs/manual/OWPML SCHEMA/ParaList XML
+/// schema.xml:1415` ColumnDefType). HWPX 는 절대값이므로 `proportional_widths`
+/// 는 건드리지 않는다 — `ColumnDef::default()` 의 `false` 가 이미 정답이다
+/// (HWP 5.0 바이너리 파서(body_text.rs)만 비례값이라 true 로 켠다).
+fn parse_col_sz(e: &quick_xml::events::BytesStart, cd: &mut ColumnDef) {
+    let mut width: HwpUnit16 = 0;
+    let mut gap: HwpUnit16 = 0;
+    for attr in e.attributes().flatten() {
+        match attr.key.as_ref() {
+            b"width" => width = parse_i16(&attr),
+            b"gap" => gap = parse_i16(&attr),
+            _ => {}
+        }
+    }
+    cd.widths.push(width);
+    cd.gaps.push(gap);
 }
 
 fn parse_hwpx_line_type(value: &str) -> u8 {

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -1468,18 +1468,57 @@ fn parse_col_line(e: &quick_xml::events::BytesStart, cd: &mut ColumnDef) {
 /// schema.xml:1415` ColumnDefType). HWPX 는 절대값이므로 `proportional_widths`
 /// 는 건드리지 않는다 — `ColumnDef::default()` 의 `false` 가 이미 정답이다
 /// (HWP 5.0 바이너리 파서(body_text.rs)만 비례값이라 true 로 켠다).
+///
+/// [#4387 후속] 스키마상 `width` 는 `xs:positiveInteger`(상한 없음)인데
+/// `ColumnDef.widths/gaps: Vec<HwpUnit16>` 은 i16(최대 32767 HWPUNIT ≈
+/// 115.6mm)이다. A3 등 큰 용지나 비대칭 다단(예: 35000+13000)처럼 실측치가
+/// i16 범위를 넘으면 공용 `parse_i16`(무경고 0-폴백)이 조용히 0으로 떨어뜨려
+/// 단이 통째로 사라진다 — IR 폭 확장은 HWP5 바이너리 경로까지 파급이 커
+/// 이번 범위를 넘으므로, 대신 saturating 클램프로 "조용한 소실/부호反전"을
+/// "포화값으로 잘림 + 경고"로 좁힌다. 근본 해결(IR 타입 확장)은 별도 이슈로
+/// 추적한다.
 fn parse_col_sz(e: &quick_xml::events::BytesStart, cd: &mut ColumnDef) {
     let mut width: HwpUnit16 = 0;
     let mut gap: HwpUnit16 = 0;
     for attr in e.attributes().flatten() {
         match attr.key.as_ref() {
-            b"width" => width = parse_i16(&attr),
-            b"gap" => gap = parse_i16(&attr),
+            b"width" => width = parse_hwpunit16_saturating(&attr, "colSz@width"),
+            // gap 은 스키마상 xs:nonNegativeInteger — 음수 폴백 없이 0 이상만 허용.
+            b"gap" => gap = parse_hwpunit16_saturating(&attr, "colSz@gap").max(0),
             _ => {}
         }
     }
     cd.widths.push(width);
     cd.gaps.push(gap);
+}
+
+/// XML 정수 속성을 `HwpUnit16`(i16)로 saturating 변환한다.
+///
+/// 공용 `parse_i16`(utils.rs)은 `str::parse::<i16>()` 오버플로 시 무경고
+/// `unwrap_or(0)`이라 `positiveInteger` 등 무제한 스키마 값이 i16 범위를 넘으면
+/// 조용히 0이 된다(#4387 후속 — colSz 처럼 HWPX 가 절대 HWPUNIT 을 그대로
+/// 담는 자리에서 실측 재현됨). i64 로 먼저 파싱해 i16 범위로 clamp 하고,
+/// 실제로 잘렸을 때만 stderr 경고를 남긴다(section.rs 의 다른 속성 파서들과
+/// 달리 이 값은 손실 시 단이 통째로 사라지는 시각적 결함으로 이어져 무음
+/// 폴백이 특히 위험하다).
+fn parse_hwpunit16_saturating(
+    attr: &quick_xml::events::attributes::Attribute,
+    field: &str,
+) -> HwpUnit16 {
+    let raw = attr_str(attr);
+    match raw.parse::<i64>() {
+        Ok(v) => {
+            let clamped = v.clamp(HwpUnit16::MIN as i64, HwpUnit16::MAX as i64) as HwpUnit16;
+            if clamped as i64 != v {
+                eprintln!(
+                    "경고: {} 값 {} 이(가) HwpUnit16 범위를 초과해 {} 로 잘렸습니다",
+                    field, v, clamped
+                );
+            }
+            clamped
+        }
+        Err(_) => 0,
+    }
 }
 
 fn parse_hwpx_line_type(value: &str) -> u8 {
@@ -8698,6 +8737,77 @@ mod tests {
         assert_eq!(cd.separator_type, 1);
         assert_eq!(cd.separator_width, 1);
         assert_eq!(cd.separator_color, 0x00000000);
+    }
+
+    #[test]
+    fn issue4387_col_sz_parses_individual_widths_and_gaps() {
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ctrl>
+        <hp:colPr type="NEWSPAPER" layout="LEFT" colCount="2" sameSz="0" sameGap="0">
+          <hp:colSz width="4000" gap="500"/>
+          <hp:colSz width="6000" gap="0"/>
+        </hp:colPr>
+      </hp:ctrl>
+      <hp:t>A</hp:t>
+    </hp:run>
+  </hp:p>
+</hs:sec>"##;
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::ColumnDef(cd) = &section.paragraphs[0].controls[0] else {
+            panic!("expected ColumnDef control");
+        };
+        assert!(!cd.same_width);
+        assert_eq!(
+            cd.widths,
+            vec![4000, 6000],
+            "단별 너비가 파싱돼야 함(#4387)"
+        );
+        assert_eq!(cd.gaps, vec![500, 0], "단별 간격이 파싱돼야 함(#4387)");
+        assert!(!cd.proportional_widths, "HWPX colSz 는 절대 HWPUNIT");
+    }
+
+    /// [#4387 후속] `colSz@width` 는 스키마상 `xs:positiveInteger`(상한 없음)인데
+    /// `ColumnDef.widths` 는 `Vec<i16>`(최대 32767). A3 등 큰 용지·비대칭 다단에서
+    /// 나올 수 있는 40000(≈141mm) 처럼 i16 범위를 넘는 값을 공용 `parse_i16` 로
+    /// 파싱하면 `str::parse::<i16>()` 오버플로 에러를 `unwrap_or(0)` 이 삼켜
+    /// widths=[0, 13000] 처럼 무경고 0-폴백됐다(단이 통째로 사라짐 — 수정 전
+    /// 코드로 직접 재현·확인). saturating 클램프로 i16::MAX 로 잘리는지
+    /// 확인한다 — 0 이 되면 안 된다.
+    #[test]
+    fn issue4387_col_sz_width_overflow_saturates_not_zeroes() {
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ctrl>
+        <hp:colPr type="NEWSPAPER" layout="LEFT" colCount="2" sameSz="0" sameGap="0">
+          <hp:colSz width="40000" gap="500"/>
+          <hp:colSz width="13000" gap="-7"/>
+        </hp:colPr>
+      </hp:ctrl>
+      <hp:t>A</hp:t>
+    </hp:run>
+  </hp:p>
+</hs:sec>"##;
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::ColumnDef(cd) = &section.paragraphs[0].controls[0] else {
+            panic!("expected ColumnDef control");
+        };
+        assert_eq!(
+            cd.widths[0],
+            i16::MAX,
+            "i16 범위를 넘는 width 는 0 이 아니라 i16::MAX 로 saturate 해야 함"
+        );
+        assert_eq!(cd.widths[1], 13000, "범위 내 값은 그대로 보존돼야 함");
+        assert_eq!(
+            cd.gaps[1], 0,
+            "음수 gap(스키마상 nonNegativeInteger 위반)은 0 으로 클램프돼야 함"
+        );
     }
 
     #[test]

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -575,6 +575,83 @@ mod tests {
         );
     }
 
+    /// #4387: 불균등 다단(단별 개별 너비/간격, `sameSz="false"`)이 HWPX 왕복에서
+    /// 균등 폭으로 저하되지 않아야 한다. `<hp:colSz>` 미방출/미파싱 시
+    /// `ColumnDef.widths`/`gaps` 가 비어 렌더러(page_layout.rs
+    /// calculate_column_areas) 가 same_width=false 조건을 만족 못 하고 균등
+    /// 분할 분기로 폴백한다.
+    #[test]
+    fn issue4387_unequal_column_widths_roundtrip() {
+        use crate::model::control::Control;
+        use crate::model::document::Section;
+        use crate::model::page::{ColumnDef, ColumnType};
+        use crate::model::paragraph::Paragraph;
+
+        let mut cd = ColumnDef::default();
+        cd.column_type = ColumnType::Normal;
+        cd.column_count = 2;
+        cd.same_width = false;
+        cd.widths = vec![4000, 6000];
+        cd.gaps = vec![500, 0];
+
+        let mut para = Paragraph::default();
+        para.text = "x".to_string();
+        para.controls.push(Control::ColumnDef(cd));
+
+        let mut section = Section::default();
+        section.paragraphs.push(para);
+        let mut doc = Document::default();
+        doc.sections.push(section);
+
+        let bytes = serialize_hwpx(&doc).expect("serialize unequal columns");
+
+        // 직렬화된 XML에 단별 colSz 가 실제로 들어갔는지 ZIP에서 추출해 확인.
+        let cursor = std::io::Cursor::new(&bytes);
+        let mut archive = zip::ZipArchive::new(cursor).expect("valid zip");
+        let mut sec0 = archive.by_name("Contents/section0.xml").expect("section0");
+        let mut xml = String::new();
+        sec0.read_to_string(&mut xml).expect("read");
+        assert!(
+            xml.contains(r#"sameSz="0""#),
+            "sameSz=false 가 방출돼야 함: {}",
+            &xml[..900.min(xml.len())]
+        );
+        assert!(
+            xml.contains(r#"<hp:colSz width="4000" gap="500"/>"#)
+                && xml.contains(r#"<hp:colSz width="6000" gap="0"/>"#),
+            "colSz 요소가 방출돼야 함(#4387): {}",
+            &xml[..900.min(xml.len())]
+        );
+        drop(sec0);
+
+        // 왕복 확인: 다시 파싱했을 때 개별 너비/간격이 그대로 복원돼야 한다.
+        let parsed = parse_hwpx(&bytes).expect("parse back");
+        let p0 = &parsed.sections[0].paragraphs[0];
+        let cd2 = p0
+            .controls
+            .iter()
+            .find_map(|c| match c {
+                Control::ColumnDef(cd) => Some(cd),
+                _ => None,
+            })
+            .expect("ColumnDef control roundtrips");
+        assert!(!cd2.same_width);
+        assert_eq!(
+            cd2.widths,
+            vec![4000, 6000],
+            "단별 너비가 왕복에서 보존돼야 함(#4387)"
+        );
+        assert_eq!(
+            cd2.gaps,
+            vec![500, 0],
+            "단별 간격이 왕복에서 보존돼야 함(#4387)"
+        );
+        assert!(
+            !cd2.proportional_widths,
+            "HWPX colSz 는 절대 HWPUNIT — 비례값 플래그가 켜지면 안 됨"
+        );
+    }
+
     #[test]
     fn tab_and_linebreak_emitted_inline() {
         let mut doc = Document::default();

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -1601,7 +1601,7 @@ fn generated_field_parameters(field: &Field) -> Option<String> {
 }
 
 /// 셀·글상자 subList 인라인 `<hp:ctrl><hp:colPr .../></hp:ctrl>` (#1379 3단계).
-/// `parse_col_pr` / `parse_col_line`(parser/hwpx/section.rs)의 역매핑.
+/// `parse_col_pr` / `parse_col_line` / `parse_col_sz`(parser/hwpx/section.rs)의 역매핑.
 fn render_col_pr_ctrl(cd: &ColumnDef) -> String {
     let col_type = match cd.column_type {
         ColumnType::Distribute => "BalancedNewspaper",
@@ -1616,14 +1616,28 @@ fn render_col_pr_ctrl(cd: &ColumnDef) -> String {
         r#"<hp:ctrl><hp:colPr id="" type="{}" layout="{}" colCount="{}" sameSz="{}" sameGap="{}""#,
         col_type, layout, cd.column_count, cd.same_width as u8, cd.spacing,
     );
-    if cd.separator_type != 0 {
+    // [#4387] sameSz="false"(단 너비 개별 지정)일 때 <hp:colSz>(단별 너비·간격,
+    // ColumnDefType 스키마상 colLine 다음 자식)를 방출한다. 미방출 시 HWPX
+    // 왕복에서 불균등 단 너비가 사라지고 렌더러(page_layout.rs
+    // calculate_column_areas)가 균등 분할로 저하한다.
+    let mut col_sz_xml = String::new();
+    if !cd.same_width {
+        for (i, w) in cd.widths.iter().enumerate() {
+            let gap = cd.gaps.get(i).copied().unwrap_or(0);
+            col_sz_xml.push_str(&format!(r#"<hp:colSz width="{}" gap="{}"/>"#, w, gap));
+        }
+    }
+    if cd.separator_type != 0 || !col_sz_xml.is_empty() {
         out.push('>');
-        out.push_str(&format!(
-            r#"<hp:colLine type="{}" width="{} mm" color="{}"/>"#,
-            col_line_type_str(cd.separator_type),
-            line_width_mm(cd.separator_width),
-            super::shape::color_to_hex(cd.separator_color),
-        ));
+        if cd.separator_type != 0 {
+            out.push_str(&format!(
+                r#"<hp:colLine type="{}" width="{} mm" color="{}"/>"#,
+                col_line_type_str(cd.separator_type),
+                line_width_mm(cd.separator_width),
+                super::shape::color_to_hex(cd.separator_color),
+            ));
+        }
+        out.push_str(&col_sz_xml);
         out.push_str("</hp:colPr></hp:ctrl>");
     } else {
         out.push_str("/></hp:ctrl>");


### PR DESCRIPTION
## 무엇을

HWPX 경로가 단별 폭(`<hp:colSz>`)을 읽지도 쓰지도 않던 것을 고친다. 불균등 다단이 왕복에서 균등
분할로 저하되던 손실이다.

## 왜

OWPML `ColumnDefType`(`ParaList XML schema.xml:1415`)이 `colLine` 다음 자식으로 `colSz` 를
정의한다 — `maxOccurs=255`, `width`(`xs:positiveInteger`)/`gap`(`xs:nonNegativeInteger`),
*"sameSize가 false일 때, 각 단의 크기 및 사이간격"*.

IR 에도 자리가 있다(`ColumnDef.widths`/`gaps`). 그런데 `colSz` 문자열이 HWPX 파서·직렬화기
**어디에도 없었다** — 읽기·쓰기 양쪽 미구현이라 HWPX↔HWPX 왕복에서도 손실된다.

**소비자가 있는지 먼저 확인했다** — `renderer/page_layout.rs::calculate_column_areas` 가
`:194` 에서 `!same_width && widths.len() >= col_count` 로 분기해 개별 폭을 실제로 쓴다
(`:199-217` 비례, `:232-234` 절대). 채우는 것이 의미 있다.

## 어떻게

- **파서** — `parse_col_sz()` 신설, `parse_col_pr_with_children` 의 `Event::Empty`/`Event::Start`
  양쪽 분기에 연결.
- **직렬화기** — `sameSz="false"` 이고 `widths` 가 비어 있지 않을 때 `colLine` **뒤**(스키마
  `xs:sequence` 순서)에 단별 `<hp:colSz>` 방출.
- `proportional_widths` 는 건드리지 않았다 — HWPX 는 절대 HWPUNIT 이라 기본값 `false` 가 정답이고
  HWP5 바이너리만 비례값(합계 32768)이라 `true` 를 켠다.

## 리뷰에서 잡은 i16 오버플로 (두 번째 커밋)

`ColumnDef.widths` 는 `Vec<HwpUnit16>`(`= i16`, 최대 32767)인데 스키마 `width` 는 상한이 없다.
A4 본문 폭이 ~48000 HWPUNIT 이라 2단은 들어가지만 1단·비대칭·A3 는 넘친다.

**재현** — `parse_i16` 은 `parse::<i16>().unwrap_or(0)` 이고, `"40000".parse::<i16>()` 은
`PosOverflow` 에러다. `unwrap_or(0)` 이 그것을 삼켜 **무경고 0-폴백**한다:

```
<hp:colSz width="40000" gap="500"/><hp:colSz width="13000" gap="0"/>
→ widths=[0, 13000]      단이 통째로 사라진다
```

스키마 위반 음수(`gap="-7"`)는 그대로 통과해 `page_layout.rs:232` 의 `as i32` 에서 음수 폭이 된다.

**조치** — `parse_col_sz` 전용 saturating 클램프 + 경고. `width="40000"` → `32767`(0 이 아니라
단이 살아남음), `gap="-7"` → `0`.

공용 `parse_i16` 은 건드리지 않았다 — `section.rs` 전역에서 쓰여 blast radius 가 크고, 이번 문제는
HWPX 가 절대 HWPUNIT 을 처음 담기 시작한 `colSz` 에 국한된다.

**`HwpUnit16` 타입 확장은 하지 않았다** — HWP5 바이너리 경로와 `table.rs::row_sizes` 등 전 IR 에
파급되므로 범위를 넘는다. 근본 해결이 필요하면 별도 이슈로 분리한다.

## 검증

- 회귀 테스트 3건 — 불균등 2단 왕복 보존, 정상 범위, **오버플로·음수 gap 이 0-소실이 아니라
  saturate**. `git diff > patch` → `checkout --` → 실행으로 수정 전 실패를 확인했다.
- `cargo test --profile release-test --tests --no-fail-fast` — 496개 바이너리 중 495개 ok.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` 통과.

**flake 1건** — `document_core::text_security::tests::scan_cost_stays_linear_as_input_grows`.
이 변경과 무관한 파일의 벽시계 타이밍 비율 단언이고, 실행 당시 이 머신 load average 가
120~130(16코어)이었다. 같은 라운드 초반 부하가 낮을 때는 통과했다. `issue4387_*` 3건은 전부 통과.

## 같은 계열

#4386 은 HML 이 다단 정의(`COLDEF`) 자체를 잃는 문제다. 이건 HWPX 가 단별 폭을 잃는 것 —
두 driver 가 각각 다른 층위에서 다단을 놓치고 있었다.

Closes #4387
