### PR TITLE
core(hwpx): Chart·OLE 캡션 파싱·재방출 유실 수정

### DIFF
--- a/mydocs/working/task_m100_4319_stage1.md
+++ b/mydocs/working/task_m100_4319_stage1.md
@@ -1,0 +1,62 @@
+# task_m100_4319 Stage 1 — HWPX Chart·OLE 캡션 파싱 유실
+
+- **이슈**: [#4319](https://github.com/edwardkim/rhwp/issues/4319)
+- **브랜치**: `fix/issue-4319-chart-ole-caption`
+- **분기 기준**: `upstream/devel` `e48fe8694`
+- **상태**: 로컬 검증 통과(타이밍 flake 1건 제외), PR 게시
+- **기록일**: 2026-08-10 KST
+
+## 1. 결함 — 파서가 캡션을 아예 안 읽는다
+
+`parse_hp_chart_element`/`parse_hp_ole_element` 가 공유하는 `parse_common_shape_children` 에
+`<hp:caption>` 처리가 **하나도 없었다.** `drawing.caption` 조차 채워진 적이 없다 — 렌더 쪽
+`shape_layout.rs` 의 폴백이 암시하던 것과 달랐다.
+
+## 2. 게이트가 왜 못 잡았나 — 비교기는 멀쩡했다
+
+이게 이슈의 핵심 질문이었다. 답은 **비교기가 아니라 파서**다.
+
+`roundtrip.rs::shape_caption` 은 이미 `Chart(x) => &x.caption, Ole(x) => &x.caption` 을 올바로
+읽고, `diff_documents`/`IrDifference::ObjectCaption` 이 모든 `ShapeObject` 변형의 캡션을 균일하게
+비교한다. **비교기는 처음부터 정상이었다.**
+
+진짜 원인은 파서가 그 필드를 처음 파싱부터 `None` 으로 남겨, 왕복 전후 비교가 `None == None` 으로
+항상 같았던 것이다. 비교기 코드를 건드리지 않고 IR 수준 테스트 2건
+(`issue4319_ole/chart_caption_loss_in_gate`)으로 이를 증명했다 — #1403 이 남긴 커버리지 공백을
+메운다.
+
+## 3. 두 번째 결함 — 독립적으로 격리했다
+
+파서를 고쳐도 **저장에서 다시 사라졌다.** `write_chart_element`(`<hp:chart>` 재방출 경로, #3546)가
+`write_caption` 을 아예 부르지 않았다 — `write_ole` 는 이미 부른다.
+
+직렬화기 수정만 되돌려 `issue4319_chart_caption_roundtrips` 는 실패하고
+`issue4319_ole_caption_roundtrips` 는 통과하는 것을 확인해 **파서 공백과 별개 결함**임을 격리했다.
+
+## 4. 구현
+
+- `parse_common_shape_children` 에 `caption_out` 파라미터 + `caption` match arm 추가.
+- 두 호출부가 `ole.caption = ole.drawing.caption.take()` 로 정규화 — HWP5 파서
+  (`parser/control/shape.rs:213`, `:222`)와 정확히 같은 형태다.
+- `write_chart_element` 에 `ctx` 를 넘기고 `write_caption` 호출 추가.
+
+## 5. 재현 — 합성 XML
+
+`~/hwpdocs_10k/` 3,418개 `.hwpx` 를 스캔했으나 `<hp:chart>` 1건, `<hp:ole>` 8건,
+`<hp:caption>` 109건이 있는데 **동시 출현이 0건**이었다. 실물 재현이 불가능해, OWPML
+`AbstractShapeObjectType`(caption 이 정식 자식, `OLEType` 이 상속)과 실제 코퍼스의 `<hp:pic>`
+캡션 블록을 구조 템플릿으로 써서 스키마 유효 XML 을 만들고 실제 `parse_hwpx_section()` 에
+통과시켰다 — 조작이 아니라 진짜 코드 경로 재현이다.
+
+## 6. 검증 (완료)
+
+- 회귀 테스트 4건. `git diff`/`checkout --` 방식으로 **수정 전 실패를 각각 확인**했다
+  (`git stash` 는 워크트리 간 공유 사고 때문에 쓰지 않았다).
+- `cargo test --profile release-test --tests` — 3379 passed, 1 failed.
+- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` 통과.
+
+**flake 1건**: `document_core::text_security::tests::scan_cost_stays_linear_as_input_grows` —
+이 변경과 무관한 파일의 벽시계 타이밍 비율 단언이다. 단독 재실행에서 통과했다. 실행 당시 이 머신
+load average 가 120~130(16코어, 다수 에이전트 동시 빌드)이었다.
+
+남은 미래 조건은 GitHub Actions 와 작업지시자 승인, merge 다.

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -6115,7 +6115,15 @@ fn parse_hp_chart_element(
 
     let mut extent: Option<(i32, i32)> = None;
     let mut shape_attr = ShapeComponentAttr::default();
-    parse_common_shape_children(reader, &mut common, b"chart", &mut extent, &mut shape_attr)?;
+    let mut caption: Option<crate::model::shape::Caption> = None;
+    parse_common_shape_children(
+        reader,
+        &mut common,
+        b"chart",
+        &mut extent,
+        &mut shape_attr,
+        &mut caption,
+    )?;
     if numbering_type_picture {
         common.hwp5_gen_shape_attr_bit28 = true;
     }
@@ -6135,6 +6143,12 @@ fn parse_hp_chart_element(
     ole.extent_x = if ext_x > 0 { ext_x } else { 7200 };
     ole.extent_y = if ext_y > 0 { ext_y } else { 7200 };
     apply_hwpx_ole_shape_component_contract(&mut ole);
+    // [#4319] HWP5 파서(parser/control/shape.rs:213)와 동형 정규화 — drawing.caption
+    // 에 남기지 않고 OleShape 자신의 caption 필드로 옮긴다. 게이트(shape_caption,
+    // serializer/hwpx/roundtrip.rs)는 `x.caption` 만 보므로 정규화하지 않으면
+    // drawing.caption 잔류가 라운드트립 비교에서 보이지 않는다.
+    ole.drawing.caption = caption;
+    ole.caption = ole.drawing.caption.take();
     Ok(Some(Control::Shape(Box::new(ShapeObject::Ole(Box::new(
         ole,
     ))))))
@@ -6215,7 +6229,15 @@ fn parse_hp_ole_element(
 
     let mut extent: Option<(i32, i32)> = None;
     let mut shape_attr = ShapeComponentAttr::default();
-    parse_common_shape_children(reader, &mut common, b"ole", &mut extent, &mut shape_attr)?;
+    let mut caption: Option<crate::model::shape::Caption> = None;
+    parse_common_shape_children(
+        reader,
+        &mut common,
+        b"ole",
+        &mut extent,
+        &mut shape_attr,
+        &mut caption,
+    )?;
     if numbering_type_picture {
         common.hwp5_gen_shape_attr_bit28 = true;
     }
@@ -6231,6 +6253,10 @@ fn parse_hp_ole_element(
     ole.extent_x = if ext_x > 0 { ext_x } else { 7200 };
     ole.extent_y = if ext_y > 0 { ext_y } else { 7200 };
     apply_hwpx_ole_shape_component_contract(&mut ole);
+    // [#4319] HWP5 파서(parser/control/shape.rs:222)와 동형 정규화 — 차트와 동일한
+    // 이유로 drawing.caption 이 아니라 ole.caption 에 남겨야 게이트가 검출한다.
+    ole.drawing.caption = caption;
+    ole.caption = ole.drawing.caption.take();
     Ok(Some(Control::Shape(Box::new(ShapeObject::Ole(Box::new(
         ole,
     ))))))
@@ -6278,6 +6304,12 @@ fn parse_common_shape_children(
     // [#3546] `<hp:rotationInfo>` 수집용. 종전 미파싱으로 저장 시 기본값으로
     // 되쓰여 rotateimage="1" 등 원본 값이 뒤집혔다(#2726 sz 기준 유실과 동형).
     shape_attr_out: &mut ShapeComponentAttr,
+    // [#4319] `<hp:caption>` 수집용. 종전엔 이 공용 자식 파서(차트·OLE 전용)에
+    // caption arm 이 없어 캡션 subList 가 파싱 단계에서 완전히 유실됐다 —
+    // 도형(parse_shape_object)·묶음(parse_container)·그림(parse_picture) 은 모두
+    // 캡션을 읽지만 차트·OLE 만 빠져 있었다. HWP5 파서(parser/control/shape.rs:213,
+    // 222)와 동형으로 drawing.caption 에 채운 뒤 호출자가 `.caption` 으로 정규화한다.
+    caption_out: &mut Option<crate::model::shape::Caption>,
 ) -> Result<(), HwpxError> {
     let mut buf = Vec::new();
     loop {
@@ -6403,6 +6435,11 @@ fn parse_common_shape_children(
                     // shape comment 사라짐).
                     b"shapeComment" => {
                         common.description = read_dutmal_text(reader, b"shapeComment")?;
+                    }
+                    // [#4319] 캡션 — 미적재 시 라운드트립에서 캡션 subList 소실(다른
+                    // 도형 변형과 동형, parse_shape_object/parse_container 참고).
+                    b"caption" => {
+                        *caption_out = Some(parse_table_caption(ce, reader)?);
                     }
                     _ => {}
                 }
@@ -8791,6 +8828,104 @@ mod tests {
         assert!(
             ole.common.locked,
             "lock=\"1\" 이 common.locked 에 보존돼야 한다"
+        );
+    }
+
+    // ---------- #4319: 차트·OLE 캡션 파싱 ----------
+
+    /// [#4319] `<hp:chart>` 내부 `<hp:caption>` — 종전엔 공용 자식 파서
+    /// (`parse_common_shape_children`, 차트·OLE 전용)에 caption arm 이 없어
+    /// 캡션 subList 가 파싱 단계에서 완전히 유실됐다(표/도형/묶음/그림은 모두
+    /// 캡션을 읽지만 차트·OLE 만 빠져 있었다). 캡션 구조는 실 코퍼스 hp:pic
+    /// 캡션 실측(outMargin 뒤·shapeComment 앞, side/fullSz/width/gap/lastWidth
+    /// 속성 + subList/p/run/t)과 OWPML AbstractShapeObjectType 스키마
+    /// (sz→pos→outMargin→caption→shapeComment 순서, hp:chart/hp:ole 모두 이
+    /// 타입을 상속)를 그대로 따른다.
+    #[test]
+    fn issue4319_chart_caption_parses_into_caption_field() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:chart id="1" zOrder="0" numberingType="NONE" textWrap="SQUARE" textFlow="BOTH_SIDES" chartIDRef="Chart/chart1.xml" instid="1">
+        <hp:sz width="4000" height="3000" widthRelTo="ABSOLUTE" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="PARA"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+        <hp:caption side="BOTTOM" fullSz="0" width="4000" gap="850" lastWidth="4000">
+          <hp:subList id="" textDirection="HORIZONTAL" lineWrap="BREAK" vertAlign="TOP" linkListIDRef="0" linkListNextIDRef="0" textWidth="0" textHeight="0" hasTextRef="0" hasNumRef="0">
+            <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+              <hp:run charPrIDRef="0"><hp:t>그림 1. 매출 추이</hp:t></hp:run>
+            </hp:p>
+          </hp:subList>
+        </hp:caption>
+      </hp:chart>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Ole(ole) = shape.as_ref() else {
+            panic!("expected chart (modeled as OLE) shape");
+        };
+        let caption = ole
+            .caption
+            .as_ref()
+            .expect("<hp:caption> 이 ole.caption 에 적재돼야 한다 (#4319)");
+        assert_eq!(caption.paragraphs.len(), 1);
+        assert_eq!(caption.paragraphs[0].text, "그림 1. 매출 추이");
+        assert!(
+            ole.drawing.caption.is_none(),
+            "HWP5 파서와 동형 정규화 — drawing.caption 은 비어 있어야 한다 \
+             (shape_caption 게이트는 x.caption 만 본다)"
+        );
+    }
+
+    /// [#4319] `<hp:ole>` 내부 `<hp:caption>` — chart 와 동일한 결함, 동일한 수정.
+    #[test]
+    fn issue4319_ole_caption_parses_into_caption_field() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="1" zOrder="0" numberingType="NONE" textWrap="SQUARE" textFlow="BOTH_SIDES" binaryItemIDRef="ole1" instid="1">
+        <hp:sz width="4000" height="3000" widthRelTo="ABSOLUTE" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="PARA"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+        <hp:caption side="BOTTOM" fullSz="0" width="4000" gap="850" lastWidth="4000">
+          <hp:subList id="" textDirection="HORIZONTAL" lineWrap="BREAK" vertAlign="TOP" linkListIDRef="0" linkListNextIDRef="0" textWidth="0" textHeight="0" hasTextRef="0" hasNumRef="0">
+            <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+              <hp:run charPrIDRef="0"><hp:t>수식 1. 표준편차 계산</hp:t></hp:run>
+            </hp:p>
+          </hp:subList>
+        </hp:caption>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Ole(ole) = shape.as_ref() else {
+            panic!("expected OLE shape");
+        };
+        let caption = ole
+            .caption
+            .as_ref()
+            .expect("<hp:caption> 이 ole.caption 에 적재돼야 한다 (#4319)");
+        assert_eq!(caption.paragraphs.len(), 1);
+        assert_eq!(caption.paragraphs[0].text, "수식 1. 표준편차 계산");
+        assert!(
+            ole.drawing.caption.is_none(),
+            "HWP5 파서와 동형 정규화 — drawing.caption 은 비어 있어야 한다"
         );
     }
 }

--- a/src/serializer/hwpx/roundtrip.rs
+++ b/src/serializer/hwpx/roundtrip.rs
@@ -2455,6 +2455,130 @@ mod tests {
         }
     }
 
+    // ---------- #4319: 차트·OLE 캡션 (게이트 동승) ----------
+    //
+    // #1403 은 pic/line/group 캡션 소실 검출을 고정했지만 Chart/Ole 는 빠졌다.
+    // shape_caption() 자체는 이미 `Chart(x) => &x.caption, Ole(x) => &x.caption`
+    // 로 올바른 필드를 보므로(비교기는 문제 없음), 아래 두 테스트는 그 사실을
+    // 고정한다. 진짜 결함은 HWPX 파서가 `<hp:chart>`/`<hp:ole>` 의 `<hp:caption>`
+    // 을 애초에 파싱하지 않아 `x.caption` 이 원본 파싱 시점부터 항상 None 이었다는
+    // 것 — 그러면 저장 전/후 IR 비교(diff_documents)는 None==None 이라 손실이
+    // 보이지 않는다(이 파일의 게이트가 비교하는 두 IR 모두 같은 파서를 거치므로).
+    // 아래 issue4319_*_caption_roundtrips 는 실제 파서·직렬화기를 왕복시켜
+    // 그 손실 자체(및 재발 방지 수정)를 고정한다.
+
+    #[test]
+    fn issue4319_ole_caption_loss_in_gate() {
+        // OLE 개체(OleShape.caption) 경로 — #1403 에 빠졌던 변형을 채운다.
+        let mut oa = crate::model::shape::OleShape::default();
+        oa.caption = Some(caption_with_paras(1));
+        let ob = crate::model::shape::OleShape::default();
+        let a = doc_with_control(crate::model::control::Control::Shape(Box::new(
+            crate::model::shape::ShapeObject::Ole(Box::new(oa)),
+        )));
+        let b = doc_with_control(crate::model::control::Control::Shape(Box::new(
+            crate::model::shape::ShapeObject::Ole(Box::new(ob)),
+        )));
+        let diff = diff_documents(&a, &b);
+        assert_eq!(diff.differences.len(), 1, "{:?}", diff.differences);
+        match &diff.differences[0] {
+            IrDifference::ObjectCaption { path, detail, .. } => {
+                assert_eq!(path, "/ctrl[0]shape.caption");
+                assert_eq!(detail, "missing: expected=Some actual=None");
+            }
+            other => panic!("ObjectCaption 여야 함: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn issue4319_chart_caption_loss_in_gate() {
+        // HWPX 차트는 OleShape(chart_id_ref=Some) 로 모델링된다 — chart_id_ref 유무와
+        // 무관하게 같은 shape_caption() 분기(Ole)를 타는지 고정.
+        let mut oa = crate::model::shape::OleShape::default();
+        oa.chart_id_ref = Some("Chart/chart1.xml".to_string());
+        oa.caption = Some(caption_with_paras(1));
+        let mut ob = crate::model::shape::OleShape::default();
+        ob.chart_id_ref = Some("Chart/chart1.xml".to_string());
+        let a = doc_with_control(crate::model::control::Control::Shape(Box::new(
+            crate::model::shape::ShapeObject::Ole(Box::new(oa)),
+        )));
+        let b = doc_with_control(crate::model::control::Control::Shape(Box::new(
+            crate::model::shape::ShapeObject::Ole(Box::new(ob)),
+        )));
+        let diff = diff_documents(&a, &b);
+        assert_eq!(diff.differences.len(), 1, "{:?}", diff.differences);
+        match &diff.differences[0] {
+            IrDifference::ObjectCaption { path, detail, .. } => {
+                assert_eq!(path, "/ctrl[0]shape.caption");
+                assert_eq!(detail, "missing: expected=Some actual=None");
+            }
+            other => panic!("ObjectCaption 여야 함: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn issue4319_ole_caption_roundtrips() {
+        // 실제 파서·직렬화기 왕복(serialize_hwpx → parse_hwpx) — 종전엔
+        // parse_hp_ole_element 에 caption arm 이 없어 재파싱 후 캡션이 사라졌다
+        // (write_ole 자체는 이미 캡션을 써 왔다 — 파서만 못 읽었다).
+        let mut cap = caption_with_paras(1);
+        cap.paragraphs[0].text = "OLE 캡션".to_string();
+        cap.paragraphs[0].char_shapes = to_refs(&[(0, 0)]);
+        let mut ole = crate::model::shape::OleShape::default();
+        ole.caption = Some(cap);
+        let mut a = roundtrip_doc_with_control(crate::model::control::Control::Shape(Box::new(
+            crate::model::shape::ShapeObject::Ole(Box::new(ole)),
+        )));
+        a.sections[0].paragraphs[0].char_shapes = to_refs(&[(0, 0)]);
+        let out = serialize_hwpx(&a).expect("serialize");
+        let b = parse_hwpx(&out).expect("reparse");
+        let diff = diff_documents(&a, &b);
+        assert!(diff.is_empty(), "{:?}", diff.differences);
+        match &b.sections[0].paragraphs[1].controls[0] {
+            crate::model::control::Control::Shape(s) => match s.as_ref() {
+                crate::model::shape::ShapeObject::Ole(o2) => {
+                    let c2 = o2.caption.as_ref().expect("캡션 보존 (#4319)");
+                    assert_eq!(c2.paragraphs[0].text, "OLE 캡션");
+                }
+                other => panic!("Ole 여야 함: {other:?}"),
+            },
+            other => panic!("Shape 여야 함: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn issue4319_chart_caption_roundtrips() {
+        // hp:chart 재방출 경로(write_chart_element/parse_hp_chart_element) 왕복 —
+        // 파서 수정만으로는 부족하다: write_chart_element 는 종전 write_caption 호출이
+        // 없어 파서를 고쳐도 저장 시 다시 유실됐다(hp:ole 방출 경로와 달리 hp:chart
+        // 재방출 경로만 캡션을 안 썼다). 두 수정이 함께 있어야 왕복이 무손실이다.
+        let mut cap = caption_with_paras(1);
+        cap.paragraphs[0].text = "차트 캡션".to_string();
+        cap.paragraphs[0].char_shapes = to_refs(&[(0, 0)]);
+        let mut ole = crate::model::shape::OleShape::default();
+        ole.chart_id_ref = Some("Chart/chart1.xml".to_string());
+        ole.bin_data_id = 60001;
+        ole.caption = Some(cap);
+        let mut a = roundtrip_doc_with_control(crate::model::control::Control::Shape(Box::new(
+            crate::model::shape::ShapeObject::Ole(Box::new(ole)),
+        )));
+        a.sections[0].paragraphs[0].char_shapes = to_refs(&[(0, 0)]);
+        let out = serialize_hwpx(&a).expect("serialize");
+        let b = parse_hwpx(&out).expect("reparse");
+        let diff = diff_documents(&a, &b);
+        assert!(diff.is_empty(), "{:?}", diff.differences);
+        match &b.sections[0].paragraphs[1].controls[0] {
+            crate::model::control::Control::Shape(s) => match s.as_ref() {
+                crate::model::shape::ShapeObject::Ole(o2) => {
+                    let c2 = o2.caption.as_ref().expect("캡션 보존 (#4319)");
+                    assert_eq!(c2.paragraphs[0].text, "차트 캡션");
+                }
+                other => panic!("Ole(chart) 여야 함: {other:?}"),
+            },
+            other => panic!("Shape 여야 함: {other:?}"),
+        }
+    }
+
     // ---------- #1392: shapeComment(객체 설명) 게이트 동승 ----------
 
     #[test]

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -449,7 +449,7 @@ fn write_chart_switch<W: Write>(
                 "hp:case",
                 &[("hp:required-namespace", OOXML_CHART_REQUIRED_NS)],
             )?;
-            write_chart_element(w, ole, chart_id_ref)?;
+            write_chart_element(w, ole, chart_id_ref, ctx)?;
             end_tag(w, "hp:case")?;
             start_tag(w, "hp:default")?;
             write_ole(w, fallback, ctx)?;
@@ -457,7 +457,7 @@ fn write_chart_switch<W: Write>(
             end_tag(w, "hp:switch")?;
             Ok(())
         }
-        None => write_chart_element(w, ole, chart_id_ref),
+        None => write_chart_element(w, ole, chart_id_ref, ctx),
     }
 }
 
@@ -465,6 +465,7 @@ fn write_chart_element<W: Write>(
     w: &mut Writer<W>,
     ole: &OleShape,
     chart_id_ref: &str,
+    ctx: &mut SerializeContext,
 ) -> Result<(), SerializeError> {
     let c = &ole.common;
     let id_str = c.instance_id.to_string();
@@ -486,6 +487,12 @@ fn write_chart_element<W: Write>(
     write_sz(w, c)?;
     write_pos(w, c)?;
     write_out_margin(w, c)?;
+    // [#4319] 캡션 — 종전엔 hp:chart 재방출 경로에만 write_caption 호출이 없어
+    // 파서를 고쳐도(ole.caption 정상 적재) 저장 시 다시 유실됐다(hp:ole 방출
+    // 경로인 write_ole 는 이미 캡션을 쓴다 — 그쪽과 동형으로 맞춘다).
+    if let Some(cap) = &ole.caption {
+        write_caption(w, cap, ctx)?;
+    }
     end_tag(w, "hp:chart")?;
     Ok(())
 }


### PR DESCRIPTION
## 무엇을

HWPX 파서가 Chart·OLE 의 `<hp:caption>` 을 아예 읽지 않던 것과, `<hp:chart>` 재방출 경로가 캡션을
쓰지 않던 것을 고친다.

## 왜

`parse_hp_chart_element`/`parse_hp_ole_element` 가 공유하는 `parse_common_shape_children` 에
`<hp:caption>` 처리가 **하나도 없었다.** `drawing.caption` 조차 채워진 적이 없다.

## 게이트가 왜 못 잡았나 — 비교기는 멀쩡했다

이슈의 핵심 질문이었고, 답은 **비교기가 아니라 파서**다.

`roundtrip.rs::shape_caption` 은 이미 `Chart(x) => &x.caption, Ole(x) => &x.caption` 을 올바로
읽고, `diff_documents`/`IrDifference::ObjectCaption` 이 모든 `ShapeObject` 변형의 캡션을 균일하게
비교한다. **처음부터 정상이었다.**

진짜 원인은 파서가 그 필드를 첫 파싱부터 `None` 으로 남겨, 왕복 전후 비교가 항상
`None == None` 이었던 것이다. 비교기 코드를 건드리지 않고 IR 수준 테스트 2건으로 증명했다 —
#1403 이 남긴 커버리지 공백을 메운다.

## 두 번째 결함 — 독립적으로 격리했다

파서를 고쳐도 **저장에서 다시 사라졌다.** `write_chart_element`(#3546 의 `<hp:chart>` 재방출)가
`write_caption` 을 아예 부르지 않았다 — `write_ole` 는 이미 부른다.

직렬화기 수정만 되돌려 `issue4319_chart_caption_roundtrips` 는 실패하고
`issue4319_ole_caption_roundtrips` 는 통과하는 것을 확인해 **파서 공백과 별개 결함**임을 격리했다.

## 어떻게

- `parse_common_shape_children` 에 `caption_out` 파라미터 + `caption` arm.
- 두 호출부가 `ole.caption = ole.drawing.caption.take()` 로 정규화 — HWP5 파서
  (`parser/control/shape.rs:213`, `:222`)와 같은 형태다.
- `write_chart_element` 에 `ctx` 를 넘기고 `write_caption` 호출 추가.

## 재현 — 실물이 없어 합성했다

`~/hwpdocs_10k/` 3,418개 `.hwpx` 스캔 결과 `<hp:chart>` 1건, `<hp:ole>` 8건, `<hp:caption>`
109건인데 **동시 출현 0건**이었다. 실물 재현이 불가능해 OWPML `AbstractShapeObjectType`
(caption 이 정식 자식, `OLEType` 이 상속)과 실제 코퍼스의 `<hp:pic>` 캡션 블록을 구조 템플릿으로
써서 스키마 유효 XML 을 만들고 **실제 `parse_hwpx_section()`** 에 통과시켰다.

## 검증

- 회귀 테스트 4건. `git diff`/`checkout --` 로 **수정 전 실패를 각각 확인**했다.
- `cargo test --profile release-test --tests` — 3379 passed, 1 failed.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` 통과.

**flake 1건** — `document_core::text_security::tests::scan_cost_stays_linear_as_input_grows`.
이 변경과 무관한 파일의 벽시계 타이밍 비율 단언이고, **단독 재실행에서 통과**했다. 실행 당시 이
머신 load average 가 120~130(16코어)이었다.

Closes #4319
