### PR TITLE
core: 클립보드 HTML 셀 border_fill_id 를 1-based 로 보정

### DIFF
--- a/mydocs/working/task_m100_4412_stage1.md
+++ b/mydocs/working/task_m100_4412_stage1.md
@@ -1,0 +1,59 @@
+# task_m100_4412 Stage 1 — 클립보드 셀 border_fill_id 1-based 보정
+
+- **이슈**: [#4412](https://github.com/edwardkim/rhwp/issues/4412)
+- **브랜치**: `fix/issue-4412-clipboard-border-fill`
+- **분기 기준**: `upstream/devel` `e48fe8694`
+- **상태**: 전체 게이트 통과, PR 게시
+- **기록일**: 2026-08-10 KST
+
+## 1. 결함
+
+`clipboard.rs:1660-1661` 이 `styles.border_styles.get(cell.border_fill_id as usize)` 로 **보정 없이**
+조회한다. `border_fill_id` 는 1-based 다.
+
+## 2. 전수 확인 — 유일한 예외였다
+
+`border_fill_id` 로 인덱싱하는 소비처 약 20곳을 전수 조사했다:
+
+`renderer/layout.rs:3328,3441` · `layout/table_layout.rs:1408,2134,2544,2566,2713,5735` ·
+`layout/table_cell_content.rs:533,582` · `layout/paragraph_layout.rs:2637,4706,4944` ·
+`layout/table_partial.rs:885,3113` · `queries/hidden_text.rs:361` ·
+`queries/rendering.rs:2272,2517,5901` · `commands/table_ops.rs:1642`
+
+**예외 없이 모두** `saturating_sub(1)` 또는 `(id - 1)` 을 한다. `clipboard.rs` 만 달랐다.
+
+1-based 근거도 확인했다 — `resolve_border_styles()`(`style_resolver.rs:892-897`)가
+`doc_info.border_fills` 를 0-based 로 그대로 매핑하고, `html_table_import.rs:765` 주석
+*"border_fill_id는 1-based"*, `doc_info.rs` 파서, `parser/hwp3/mod.rs:3922` 주석이 일치한다.
+id=0 은 "없음", id=N 은 `border_fills[N-1]` 이다.
+
+## 3. 재현
+
+`border_fills = [default0, default1, decoy(회색), REAL(#00ff00/#00ffff), decoy2(#ff8c00/#ff00ff)]`,
+`cell.border_fill_id = 4`(REAL) 로 수정 전 코드를 실행하니 **decoy2 색이 한 칸 밀려 출력**됐다.
+
+## 4. `table.border_fill_id` 는 같은 결함이 아니다
+
+`clipboard.rs` 가 표 자체 테두리를 전혀 참조하지 않는 것은 맞다. 하지만
+`layout/table_layout.rs:2708-2760` 의 사용처는 단순 오프바이원이 아니라 **셀이 덮지 않는 표 외곽
+엣지에만 채우는 outer-edge coverage 알고리즘**(행·열별 covered map 구축)이다. 셀 단위 `<td>` CSS
+생성기에 이식하려면 새 기능 포팅이라 성격이 다르다 — 이번 범위에서 제외했다. 필요하면 별도
+이슈로 분리한다.
+
+## 5. 검증 (완료)
+
+- 회귀 테스트 `table_to_html_uses_correct_border_fill_for_1_based_id` 신설. **수정 전 실행에서
+  decoy2 색이 나와 실패를 확인**했고, 수정 후 REAL 색이 나온다.
+- `cargo test --profile release-test --tests` — 497개 블록 전부 ok, **실패 0건**
+  (반복 관측되던 타이밍 flake 도 이번 실행에서는 통과).
+- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` 통과.
+
+## 6. 조사 경위
+
+문서 간 복사·붙여넣기 보존 조사에서 나왔다. 그 조사가 확인한 문서 간 경로는 하나뿐이다 —
+내부 클립보드는 문서를 넘지 못하고(`paste_*_native` 가 `&self.clipboard` 만 읽는다), 실제 경로는
+**Rust → HTML → OS 클립보드 → HTML → Rust** 다.
+
+같은 조사에서 #4413(셀 안 컨트롤 미순회), #4414(도형·필드 소실)가 함께 나왔고 별도 이슈로 분리했다.
+
+남은 미래 조건은 GitHub Actions 와 작업지시자 승인, merge 다.

--- a/src/document_core/commands/clipboard.rs
+++ b/src/document_core/commands/clipboard.rs
@@ -1656,9 +1656,13 @@ impl DocumentCore {
                 // 병합된 셀은 첫 번째 셀만 출력 (rowspan/colspan 은 merge 된 셀 정보)
                 let mut td_style = String::new();
 
-                // 셀 배경/테두리 (BorderFill)
+                // 셀 배경/테두리 (BorderFill) — border_fill_id는 1-based
+                // (styles.border_styles는 0-based). 다른 소비처(예:
+                // renderer/layout/table_layout.rs, document_core/queries/hidden_text.rs)와
+                // 동일하게 -1 보정한다. [#4412]
                 if cell.border_fill_id > 0 {
-                    if let Some(bs) = self.styles.border_styles.get(cell.border_fill_id as usize) {
+                    let idx = (cell.border_fill_id as usize).saturating_sub(1);
+                    if let Some(bs) = self.styles.border_styles.get(idx) {
                         self.apply_border_fill_css(&mut td_style, bs);
                     }
                 }
@@ -2106,6 +2110,87 @@ mod nested_cell_paste_reflow_tests {
             paras[0].line_segs.len() > 1,
             "폭 200 최내곽 셀에 40자를 붙여넣으면 여러 줄로 재래핑돼야 함 (실제 {}줄)",
             paras[0].line_segs.len()
+        );
+    }
+}
+
+/// [#4412] `table_to_html`(문서 간 복사·붙여넣기 HTML 경로)이 `cell.border_fill_id`를
+/// 1-based 보정 없이 `styles.border_styles`(0-based)에 그대로 인덱싱해, 실제 BorderFill보다
+/// 한 칸 뒤(id 기준 +1)의 BorderFill 색상이 붙던 결함의 회귀 테스트.
+#[cfg(test)]
+mod clipboard_border_fill_offset_tests {
+    use crate::document_core::DocumentCore;
+    use crate::model::style::{BorderFill, BorderLine, BorderLineType, Fill, FillType, SolidFill};
+    use crate::model::table::{Cell, Table};
+    use crate::renderer::style_resolver::resolve_styles;
+
+    /// 4방향 동일한 실선 테두리 + 단색 채우기를 갖는 BorderFill을 만든다.
+    fn border_fill(border_color: u32, fill_color: u32) -> BorderFill {
+        let line = BorderLine {
+            line_type: BorderLineType::Solid,
+            width: 2,
+            color: border_color,
+        };
+        BorderFill {
+            borders: [line, line, line, line],
+            fill: Fill {
+                fill_type: FillType::Solid,
+                solid: Some(SolidFill {
+                    background_color: fill_color,
+                    pattern_color: 0,
+                    pattern_type: 0,
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    /// border_fills = [default0, default1, decoy(회색), REAL(녹/청), decoy2(주황/자홍)].
+    /// `cell.border_fill_id = 4`(1-based)는 index 3(REAL)을 가리켜야 하며, 색이 한 칸
+    /// 밀려 index 4(decoy2)를 가리키면 안 된다.
+    #[test]
+    fn table_to_html_uses_correct_border_fill_for_1_based_id() {
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+
+        core.document.doc_info.border_fills = vec![
+            border_fill(0x000000, 0x000000), // index 0 → id 1 (default0)
+            border_fill(0x000000, 0x000000), // index 1 → id 2 (default1)
+            border_fill(0xC0C0C0, 0xC0C0C0), // index 2 → id 3 (decoy, 회색)
+            border_fill(0x00FF00, 0xFFFF00), // index 3 → id 4 (REAL, 테두리#00ff00/배경#00ffff)
+            border_fill(0x008CFF, 0xFF00FF), // index 4 → id 5 (decoy2, 테두리#ff8c00/배경#ff00ff)
+        ];
+        core.styles = resolve_styles(&core.document.doc_info, core.dpi);
+
+        let table = Table {
+            row_count: 1,
+            col_count: 1,
+            cells: vec![Cell {
+                row: 0,
+                col: 0,
+                col_span: 1,
+                row_span: 1,
+                width: 2000,
+                border_fill_id: 4,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let html = core.table_to_html(&table);
+
+        assert!(
+            html.contains("border-left:2.0px solid #00ff00"),
+            "REAL(id=4, index 3)의 테두리색(#00ff00)이 출력되지 않음:\n{html}"
+        );
+        assert!(
+            html.contains("background-color:#00ffff"),
+            "REAL(id=4, index 3)의 배경색(#00ffff)이 출력되지 않음:\n{html}"
+        );
+        assert!(
+            !html.contains("#ff8c00") && !html.contains("#ff00ff"),
+            "decoy2(id=5, index 4)의 색상이 한 칸 밀려 출력됨:\n{html}"
         );
     }
 }


### PR DESCRIPTION
## 무엇을

문서 간 복사·붙여넣기에서 표 셀 테두리·배경이 **한 칸 밀린 서식**으로 붙던 것을 고친다.

## 왜

`clipboard.rs:1660-1661` 이 `border_fill_id` 를 **1-based 보정 없이** 조회했다.

`border_fill_id` 로 인덱싱하는 소비처 약 20곳을 전수 조사한 결과 — `renderer/layout.rs:3328,3441`,
`layout/table_layout.rs:1408,2134,2544,2566,2713,5735`, `layout/table_cell_content.rs:533,582`,
`layout/paragraph_layout.rs:2637,4706,4944`, `layout/table_partial.rs:885,3113`,
`queries/hidden_text.rs:361`, `queries/rendering.rs:2272,2517,5901`,
`commands/table_ops.rs:1642` — **예외 없이 모두** `saturating_sub(1)` 을 한다.
`clipboard.rs` 만 달랐다.

1-based 근거: `resolve_border_styles()`(`style_resolver.rs:892-897`)가 `doc_info.border_fills` 를
0-based 로 그대로 매핑하고, `html_table_import.rs:765` 주석 *"border_fill_id는 1-based"*,
`doc_info.rs` 파서, `parser/hwp3/mod.rs:3922` 주석이 일치한다. id=0 은 "없음", id=N 은
`border_fills[N-1]` 이다.

## 재현

`border_fills = [default0, default1, decoy(회색), REAL(#00ff00/#00ffff), decoy2(#ff8c00/#ff00ff)]`,
`cell.border_fill_id = 4`(REAL):

```
기대: #00ff00 / #00ffff   (REAL)
실제: #ff8c00 / #ff00ff   (decoy2 — 한 칸 뒤)
```

목록의 마지막 항목이면 조용히 테두리 없음이 된다.

## 어떻게

`let idx = (cell.border_fill_id as usize).saturating_sub(1);` — 다른 20곳과 같은 패턴.

## `table.border_fill_id` 는 같은 결함이 아니다

`clipboard.rs` 가 표 자체 테두리를 전혀 참조하지 않는 것은 맞지만,
`layout/table_layout.rs:2708-2760` 의 사용처는 단순 오프바이원이 아니라 **셀이 덮지 않는 표 외곽
엣지에만 채우는 outer-edge coverage 알고리즘**이다. 셀 단위 `<td>` CSS 생성기에 이식하려면 새 기능
포팅이라 성격이 다르다 — 이번 범위에서 제외했다.

## 검증

- 회귀 테스트 신설. **수정 전 실행에서 decoy2 색이 나와 실패를 확인**했다.
- `cargo test --profile release-test --tests` — 497개 블록 전부 ok, **실패 0건**.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` 통과.

## 조사 경위

문서 간 복사·붙여넣기 보존 조사에서 나왔다. 그 조사가 확인한 문서 간 경로는 하나뿐이다 — 내부
클립보드는 문서를 넘지 못하고(`paste_*_native` 가 `&self.clipboard` 만 읽는다), 실제 경로는
**Rust → HTML → OS 클립보드 → HTML → Rust** 다.

같은 조사에서 #4413(셀 안 중첩 표·이미지 소실), #4414(도형이 리터럴 `[도형]` 으로, 필드 소실)가
함께 나왔고 별도 이슈로 분리했다. 반대로 **BinData(이미지 바이너리) 전달과 char/para 스타일 id
재매핑은 정상**임을 확인했다 — 조사 가설이 그 둘에서는 틀렸다.

Closes #4412
