### PR TITLE
serializer(hwpx): 암묵적 기본 탭을 널 마커로 방출해 TabDef 무력화 해소

### DIFF
--- a/mydocs/working/task_m100_4403_stage1.md
+++ b/mydocs/working/task_m100_4403_stage1.md
@@ -1,0 +1,70 @@
+# task_m100_4403 Stage 1 — 암묵적 기본 탭이 HWPX 왕복에서 TabDef를 무시하던 결함
+
+- **이슈**: [#4403](https://github.com/edwardkim/rhwp/issues/4403)
+- **브랜치**: `fix/issue-4403-hwpx-tab-marker`
+- **분기 기준**: `upstream/devel` `e48fe8694`
+- **상태**: 전체 게이트 통과, PR 게시
+- **기록일**: 2026-08-10 KST
+
+## 1. 재현 — 픽셀로 쟀다
+
+`rhwp export-hwpx samples/SO-SUEOP.hwp` → `ir-diff` 로 이슈 그대로 재현했다. 문단 0.19
+"I.소설의 이해\t3" 에서 `tab_ext count: A=0 vs B=1`.
+
+`render-diff --via hwpx` 실측: **46쪽 중 9쪽 임계 초과, 최대 변위 470px**(1쪽 목차).
+`export-render-tree` 로 좌표를 직접 대조해 목차 쪽번호 "3" 의 x 가 원본 674.3px →
+왕복 후 670.9px 로 이동함을 확인했다.
+
+## 2. 한컴 기본 탭 4000 HWPUNIT 은 맞았다
+
+이슈가 상수를 의심했는데 **상수는 정확했다.** OWPML 스키마(`secPr@tabStopVal` = "기본 탭 간격"),
+코드 내 [Finding 14] 의 실제 한컴 생성 HWPX 픽스처 실측, HWP5 스펙 정오표 세 곳에서 확인했다.
+
+문제는 상수가 아니라 **탭 정지를 계산하지 않는 것**이었다.
+
+## 3. 진짜 원인 — tab_extended 하나가 TabDef 전체를 무력화한다
+
+문단의 실제 `TabDef`(`tab_def_id=3`, `tabs=[pos=85032(300mm) type=1(RIGHT) fill=3]`)가 무시되고,
+`render_hp_t_content` 가 방출한 `width="4000"` 이 재적재 시 렌더러(`text_measurement.rs`)에
+**"실제 계산된 탭 폭"으로 신뢰되어** `total + width` 로 문단 정렬과 무관하게 고정 거리만 전진한다.
+
+`TabDef` 를 파서가 채우는지도 확인했다 — **채운다.** HWP5(`doc_info.rs::parse_tab_def`)·
+HWPX(`header.rs`) 모두 `doc_info.tab_defs` 를 채우고 `ParaShape.tab_def_id` 가 정확히 참조한다.
+선행 문제는 없었다.
+
+## 4. 구현 — HWP5가 이미 푼 방식을 이식
+
+직렬화기가 진짜 픽셀 위치를 계산하는 근본 수정은 문단 레이아웃(폰트 메트릭·커서 위치) 접근이
+필요해 범위가 크다는 이슈의 판단이 맞았다.
+
+대신 HWP5 바이너리가 **동일 문제(#1892)를 이미 푼 방식**(데이터-없음 널 마커)을 HWPX 에 이식했다:
+
+- 직렬화기 폴백을 `width="4000"` → `width="0"`(`TAB_NO_DATA_WIDTH_MARKER`). 폭 0 인 탭은 실제로
+  나올 수 없어 시각 효과가 없는 안전한 마커다.
+- 파서 두 경로(`read_text_content_with_tabs`, `parse_paragraph`)에 `is_tab_no_data_marker`
+  (width=0 **및** leader=0·type=1 정확 일치) 추가 — 마커면 `tab_extended` 에 싣지 않아 렌더러가
+  원본과 동일하게 `find_next_tab_stop`/TabDef 경로로 돌아간다.
+
+## 5. 실측 검증
+
+- `ir-diff`: `tab_ext count: A=0 vs B=1` → **차이 0건**
+- `render-diff --via hwpx`: 9쪽 임계 초과(최대 470px) → **4쪽**(26,43,44,45 — 수정 전에도 이미
+  초과였던 탭 무관 기존 결함, 새로 생기지 않음), 최대 271px. **목차 페이지(1,8,19,22,34) 완전 clean**
+- 목차 쪽번호 x: 670.9px → **674.3px(원본과 정확히 일치)**
+- `samples/hwp3-sample11.hwp`, `hwp3-sample19.hwp`: tab_ext 차이 0건
+
+## 6. 범위 밖
+
+- 직렬화기의 정밀 픽셀 위치 계산 — width=0 센티널만으로 실측 회귀(470px)가 해소돼 필요성이 줄었다.
+- `fill_lines` 가 `tab_stops` 를 못 받는 결함 — PR #4380(#4324)에서 이미 별개로 기록했다.
+- **부수 발견**: `secPr` 의 `tabStop`(모델 `default_tab_spacing`, 실측 8000) vs `tabStopVal`
+  (=4000, 스키마상 "기본 탭 간격") 불일치. 파서가 `tabStop` 을 읽는데 스키마 문서상 기본 탭 간격은
+  `tabStopVal` 쪽으로 보인다. 이번 범위 밖이라 후속 이슈 후보로 남긴다.
+
+## 7. 검증 (완료)
+
+- 회귀 테스트 2건 신설, 기존 2건 값 갱신. **수정 전 실패 확인**했다.
+- `cargo test --profile release-test --tests` 통과.
+- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` 통과.
+
+남은 미래 조건은 GitHub Actions 와 작업지시자 승인, merge 다.

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -593,7 +593,12 @@ fn parse_paragraph(
                     }
                     b"tab" => {
                         text_parts.push("\t".to_string());
-                        para.tab_extended.push(parse_tab_extension(ce));
+                        // "데이터 없음" 마커(width=0, #4403)는 tab_extended 에 싣지 않는다 —
+                        // 렌더러가 TabDef 기준으로 다시 계산하도록 원본처럼 비워 둔다.
+                        let ext = parse_tab_extension(ce);
+                        if !is_tab_no_data_marker(&ext) {
+                            para.tab_extended.push(ext);
+                        }
                     }
                     b"lineseg" => {
                         // 단독 lineseg (linesegarray 밖에 나올 경우)
@@ -1616,7 +1621,12 @@ fn read_text_content_with_tabs(
                     b"lineBreak" | b"columnBreak" => text.push('\n'),
                     b"tab" => {
                         text.push('\t');
-                        tab_ext_buf.push(parse_tab_extension(ce));
+                        // "데이터 없음" 마커(width=0, #4403)는 tab_extended 에 싣지 않는다 —
+                        // 렌더러가 TabDef 기준으로 다시 계산하도록 원본처럼 비워 둔다.
+                        let ext = parse_tab_extension(ce);
+                        if !is_tab_no_data_marker(&ext) {
+                            tab_ext_buf.push(ext);
+                        }
                     }
                     b"nbSpace" => text.push('\u{00A0}'),
                     b"fwSpace" => text.push('\u{2007}'),
@@ -1650,6 +1660,18 @@ fn parse_tab_extension(e: &quick_xml::events::BytesStart) -> [u16; 7] {
     ext[2] = (tab_type << 8) | leader;
 
     ext
+}
+
+/// `<hp:tab width="0" leader="0" type="1"/>` — 서식기(`serializer/hwpx/section.rs`
+/// `TAB_NO_DATA_WIDTH_MARKER`)가 `tab_extended` 항목이 없던 "암묵적 기본 탭"을 내보낼 때
+/// 쓰는 정확한 마커다(#4403). 실제 탭은 폭 0 이 나올 수 없으므로(시각적으로 아무 효과가 없어
+/// 한컴도 만들지 않는다) 안전한 신호로 쓴다. `leader`/`type` 까지 우리 서식기의 고정 폴백값과
+/// 정확히 일치할 때만 마커로 인정해, width=0 인 (극히 드문) 진짜 캡처 데이터를 오인해 버리지
+/// 않도록 한다. 이 마커를 만나면 `tab_extended` 에 항목을 추가하지 않아, 렌더러가 문단의 실제
+/// `TabDef`/커서 위치 기준 `find_next_tab_stop` 으로 탭 정지를 다시 계산하게 한다 — HWP5
+/// 바이너리 파서의 동형 널 마커 스킵(`parser/body_text.rs` `is_null_ext`, #1892)과 같은 규약.
+fn is_tab_no_data_marker(ext: &[u16; 7]) -> bool {
+    ext[0] == 0 && ext[2] == 0x0100
 }
 
 // ─── Table ───
@@ -7234,6 +7256,34 @@ mod tests {
         let para = &section.paragraphs[0];
         assert_eq!(para.text, "A\t(페이지 표기)");
         assert_eq!(para.tab_extended, vec![[17283, 0, 0x0203, 0, 0, 0, 9]]);
+    }
+
+    #[test]
+    fn test_parse_hwpx_tab_width_zero_marker_not_recorded_as_ext() {
+        // #4403: 직렬화기가 "데이터 없음" 마커(width=0)로 내보낸 암묵적 기본 탭은
+        // 재적재 시 tab_extended 항목을 만들면 안 된다 — 만들면 렌더러가 그 폭을
+        // 실제 계산값으로 신뢰해(`total + width`) 문단의 진짜 TabDef(예: 우측 정렬)를
+        // 무시하고 커서 위치와 무관한 고정 거리만 전진시킨다. width=0 은 실제 탭에서
+        // 나올 수 없는 값(폭 0인 탭은 시각 효과가 없음)이라 안전한 마커다. 탭 문자(\t)
+        // 자체는 그대로 보존해야 한다.
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:t>I.소설의 이해<hp:tab width="0" leader="0" type="1"/>3</hp:t>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let para = &section.paragraphs[0];
+        assert_eq!(para.text, "I.소설의 이해\t3");
+        assert!(
+            para.tab_extended.is_empty(),
+            "width=0 마커는 tab_extended 에 실리면 안 됨: {:?}",
+            para.tab_extended
+        );
     }
 
     #[test]

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -590,10 +590,13 @@ mod tests {
         let mut sec0 = archive.by_name("Contents/section0.xml").expect("section0");
         let mut xml = String::new();
         std::io::Read::read_to_string(&mut sec0, &mut xml).expect("read");
-        // Stage 2.3 (ref_mixed 기반): 혼합 콘텐츠 + tab 속성 포함
+        // Stage 2.3 (ref_mixed 기반): 혼합 콘텐츠 + tab 속성 포함.
+        // [#4403] tab_extended 데이터 없는 암묵적 기본 탭은 "데이터 없음" 마커
+        // (width=0)로 방출한다 — 고정 상수(옛 4000)를 emit 하면 재적재 시 렌더러가
+        // 그 폭을 실제 계산값으로 신뢰해 문단의 진짜 TabDef 를 무시한다.
         assert!(
             xml.contains(
-                r#"<hp:t>A<hp:tab width="4000" leader="0" type="1"/>B<hp:lineBreak/>C</hp:t>"#
+                r#"<hp:t>A<hp:tab width="0" leader="0" type="1"/>B<hp:lineBreak/>C</hp:t>"#
             ),
             "mixed content not rendered: {}",
             xml

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -454,8 +454,29 @@ fn replace_footnote_shape(xml: &str, sd: &SectionDef) -> String {
 
 /// 레퍼런스 기준 줄 레이아웃 파라미터.
 const VERT_STEP: u32 = 1600; // vertsize(1000) + spacing(600)
-/// 탭 기본 폭 (한컴이 열면서 재계산하지만 초기값으로 필요).
-const TAB_DEFAULT_WIDTH: u32 = 4000;
+
+/// 탭 확장 데이터(`tab_extended`)가 없는 "암묵적 기본 탭"을 위한 `<hp:tab width>` 마커.
+///
+/// OWPML `<hp:tab>` 은 구조상 `width`/`leader`/`type` 이 모두 필수라 값 없음을 표현할 수
+/// 없다(#4403). 예전에는 여기 고정 상수 `TAB_DEFAULT_WIDTH = 4000`(한컴 실제 기본 탭 간격,
+/// `secPr@tabStopVal` 실측·HWP5 스펙 "기본 탭 간격" 필드와 일치 — 상수 자체는 정확했다)을
+/// 채웠는데, 렌더러(`renderer/layout/text_measurement.rs` 인라인 탭 처리)는 `tab_extended`
+/// 항목이 있으면 그 `width` 를 "이 탭의 실제 계산된 전진량"으로 신뢰해 커서 위치에 그대로 더한다
+/// (`total + width`) — 탭 앞 텍스트 폭이나 문단의 실제 `TabDef`(좌/우/가운데 정렬, 커스텀 위치)
+/// 를 무시한다. 그 결과 재적재 후 탭 뒤 텍스트가 원래와 다른 위치에 그려진다: 목차처럼 "제목 +
+/// 탭 + 쪽번호"인 문단에서 원본은 문단의 우측 정렬 `TabDef` 로 쪽번호가 우측 끝에 정렬되는데,
+/// 라운드트립 후에는 이 탭이 명시적 LEFT 로 굳어져 제목 바로 뒤에 고정 거리만큼만 전진한다
+/// (실측: `samples/SO-SUEOP.hwp` 자기 라운드트립 `render-diff`, 목차 페이지 최대 변위 470px).
+///
+/// `width=0` 은 실제 탭에서 나올 수 없는 값이다(폭 0인 탭은 시각적으로 아무 효과가 없어 한컴도
+/// 만들지 않는다) — 그래서 "원본에 계산된 탭 폭 데이터가 없었다"는 마커로 안전하게 쓴다.
+/// HWPX 파서(`parser/hwpx/section.rs`)는 `width=0` 인 `<hp:tab>` 을 만나면 `tab_extended`
+/// 항목을 만들지 않고 비워 둔다 — HWP5 바이너리 직렬화기의 동형 널 마커(`serializer/body_text.rs`,
+/// #1892)와 같은 규약이다. 그러면 렌더러는 이 문단의 실제 `TabDef`/커서 위치 기준으로
+/// `find_next_tab_stop` 을 통해 탭 정지를 다시 계산해, 원본과 같은 경로를 탄다. 한컴 앱 자신도
+/// 이 값을 열 때 재계산하는 것으로 보여(주석 원문 "한컴이 열면서 재계산하지만 초기값으로 필요"),
+/// `width=0` 은 실제 한컴에서 다시 열 때도 안전하다.
+const TAB_NO_DATA_WIDTH_MARKER: u32 = 0;
 
 /// Stage 2 진입점. `ctx` 는 Stage 3+ 에서 파라미터 검증에 사용.
 pub fn write_section(
@@ -639,7 +660,9 @@ pub(crate) fn render_paragraph_parts(
 /// `<hp:t>...</hp:t>` 본문 생성 — 탭/소프트브레이크/XML escape 포함.
 ///
 /// `tab_extended`: IR의 탭 확장 정보 목록. `tab_idx`를 통해 탭 문자마다 순서대로 참조.
-/// 항목이 없으면 폴백(width=TAB_DEFAULT_WIDTH, leader=0, type=1)을 사용.
+/// 항목이 없으면 "데이터 없음" 마커(width=`TAB_NO_DATA_WIDTH_MARKER`=0, leader=0, type=1)를
+/// 방출한다(#4403) — 파서가 이를 인식해 `tab_extended` 를 만들지 않아야 렌더러가 실제 `TabDef`
+/// 기준으로 탭 정지를 다시 계산한다.
 pub(crate) fn render_hp_t_content(
     text: &str,
     tab_extended: &[[u16; 7]],
@@ -655,7 +678,7 @@ pub(crate) fn render_hp_t_content(
                     *tab_idx += 1;
                     (ext[0] as u32, ext[2] & 0x00ff, (ext[2] >> 8) & 0x00ff)
                 } else {
-                    (TAB_DEFAULT_WIDTH, 0u16, 1u16)
+                    (TAB_NO_DATA_WIDTH_MARKER, 0u16, 1u16)
                 };
                 t_xml.push_str(&format!(
                     r#"<hp:tab width="{}" leader="{}" type="{}"/>"#,
@@ -3133,6 +3156,45 @@ mod tests {
         );
     }
 
+    /// #4403: `tab_extended` 항목이 없던 "암묵적 기본 탭"은 HWPX 라운드트립(직렬화→재파싱)
+    /// 후에도 `tab_extended` 가 비어 있어야 한다. 예전에는 폴백으로 고정 상수
+    /// `width="4000"` 를 방출해 재파싱 시 `tab_extended` 항목이 새로 생겼다 — 렌더러는
+    /// 그 항목이 있으면 폭을 "실제 계산된 값"으로 신뢰해(`total + width`) 문단의 진짜
+    /// `TabDef`(예: 목차의 우측 정렬 쪽번호 탭)를 무시하고 커서 위치와 무관한 고정 거리만
+    /// 전진시킨다(실측: `samples/SO-SUEOP.hwp` 자기 라운드트립 목차 페이지 최대 변위 470px).
+    /// 지금은 "데이터 없음" 마커(`width="0"`)를 방출하고, 파서가 그 마커를 인식해
+    /// `tab_extended` 항목을 만들지 않는다 — 렌더러가 실제 `TabDef` 기준으로 탭 정지를
+    /// 다시 계산하게 한다.
+    #[test]
+    fn issue4403_implicit_tab_stays_empty_after_hwpx_roundtrip() {
+        use crate::parser::hwpx::section::parse_hwpx_section;
+
+        let mut para = Paragraph::default();
+        para.text = "I.소설의 이해\t3".to_string();
+        assert!(
+            para.tab_extended.is_empty(),
+            "전제: 원본은 tab_extended 데이터가 없는 암묵적 기본 탭"
+        );
+        let (doc, section) = make_doc_with_paragraph(para);
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+
+        assert!(
+            xml.contains(r#"<hp:tab width="0" leader="0" type="1"/>"#),
+            "데이터 없음 탭은 width=0 마커로 방출돼야 함: {}",
+            &xml[..600.min(xml.len())]
+        );
+
+        let reparsed = parse_hwpx_section(&xml).unwrap();
+        let reparsed_para = &reparsed.paragraphs[0];
+        assert_eq!(reparsed_para.text, "I.소설의 이해\t3");
+        assert!(
+            reparsed_para.tab_extended.is_empty(),
+            "width=0 마커 재파싱 후 tab_extended 는 비어 있어야 함(원본과 동일): {:?}",
+            reparsed_para.tab_extended
+        );
+    }
+
     /// [#2779] 각주 코드 2(가장 오른쪽 단)는 각주 전용 토큰이 있으나, 미주에는 스키마상
     /// 대응 토큰이 없어 기본값 END_OF_DOCUMENT 로 강등한다(주석 참조).
     #[test]
@@ -4603,7 +4665,7 @@ mod tests {
         assert_eq!(
             xml,
             concat!(
-                r#"<hp:run charPrIDRef="1"><hp:t>a<hp:tab width="4000" leader="0" type="1"/></hp:t></hp:run>"#,
+                r#"<hp:run charPrIDRef="1"><hp:t>a<hp:tab width="0" leader="0" type="1"/></hp:t></hp:run>"#,
                 r#"<hp:run charPrIDRef="2"><hp:t>b<hp:lineBreak/>c</hp:t></hp:run>"#
             )
         );


### PR DESCRIPTION
## 무엇을

암묵적 기본 탭이 HWPX 왕복에서 문단의 실제 `TabDef` 를 무력화하던 것을 고친다. 목차 쪽번호가
어긋나는 등 **최대 470px 변위**를 만들던 결함이다.

## 왜

`render_hp_t_content` 의 폴백이 `width="4000"` 을 방출하고, 재적재 시 렌더러
(`text_measurement.rs`)가 이를 **"실제 계산된 탭 폭"으로 신뢰**해 `total + width` 로 고정 거리만
전진한다. 그 결과 문단의 실제 `TabDef`(예: `tabs=[pos=85032(300mm) type=1(RIGHT) fill=3]`)가
통째로 무시된다.

**4000 HWPUNIT 상수 자체는 맞다** — OWPML `secPr@tabStopVal`("기본 탭 간격"), 실제 한컴 생성
HWPX 픽스처 실측, HWP5 스펙 정오표 세 곳에서 확인했다. 문제는 상수가 아니라 **탭 정지를 계산하지
않는 것**이다.

`TabDef` 를 파서가 채우는지도 확인했다 — 채운다(HWP5 `doc_info.rs::parse_tab_def`, HWPX
`header.rs`). 선행 문제는 없다.

## 어떻게 — HWP5 가 이미 푼 방식을 이식

직렬화기가 진짜 픽셀 위치를 계산하는 근본 수정은 문단 레이아웃 접근이 필요해 범위가 크다.
대신 HWP5 바이너리가 **동일 문제(#1892)를 이미 푼** 데이터-없음 널 마커를 HWPX 에 이식했다:

- 직렬화기 폴백을 `width="4000"` → `width="0"`. 폭 0 인 탭은 실제로 나올 수 없어 시각 효과가 없다.
- 파서 두 경로에 `is_tab_no_data_marker`(width=0 **및** leader=0·type=1 정확 일치) 추가 — 마커면
  `tab_extended` 에 싣지 않아 렌더러가 원본과 같이 `find_next_tab_stop`/TabDef 경로로 돌아간다.

## 실측

| | 수정 전 | 수정 후 |
|---|---|---|
| `ir-diff` tab_ext | `A=0 vs B=1` | **차이 0건** |
| `render-diff --via hwpx` | 46쪽 중 **9쪽 임계 초과**, 최대 470px | **4쪽**, 최대 271px |
| 목차 쪽번호 x 좌표 | 670.9px | **674.3px** (원본과 정확히 일치) |

남은 4쪽(26,43,44,45)은 **수정 전에도 이미 임계를 넘던** 탭 무관 기존 결함이다 — 새로 생기지
않았다. 목차 페이지(1,8,19,22,34)는 완전히 clean 해졌다.

`samples/hwp3-sample11.hwp`, `hwp3-sample19.hwp` 도 tab_ext 차이 0건.

## 검증

- 회귀 테스트 2건 신설, 기존 2건 값 갱신(width=4000→0). **수정 전 실패를 확인**했다.
- `cargo test --profile release-test --tests` 통과.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` 통과.

## 범위 밖

- 직렬화기의 정밀 픽셀 위치 계산 — 널 마커만으로 실측 회귀가 해소돼 필요성이 줄었다.
- `fill_lines` 가 `tab_stops` 를 못 받는 결함 — PR #4380(#4324)에서 이미 별개로 기록했다.
- **부수 발견**: `secPr` 의 `tabStop`(모델 `default_tab_spacing`, 실측 8000) vs
  `tabStopVal`(=4000, 스키마상 "기본 탭 간격") 불일치. 파서가 `tabStop` 을 읽는데 스키마 문서상
  기본 탭 간격은 `tabStopVal` 쪽으로 보인다. 후속 이슈 후보다.

Closes #4403
