### PR TITLE
core(hml): COLDEF(다단 정의) 파싱 추가 + 저장 경로 대응

### DIFF
--- a/mydocs/working/task_m100_4386_stage1.md
+++ b/mydocs/working/task_m100_4386_stage1.md
@@ -1,0 +1,74 @@
+# task_m100_4386 Stage 1 — HML COLDEF(다단 정의) 조용한 드롭
+
+- **이슈**: [#4386](https://github.com/edwardkim/rhwp/issues/4386)
+- **브랜치**: `fix/issue-4386-hml-coldef`
+- **분기 기준**: `upstream/devel` `e48fe8694`
+- **상태**: 전체 게이트 통과, PR 게시
+- **기록일**: 2026-08-10 KST
+
+## 1. 결함 — "지원함"으로 표시돼 경고를 피했다
+
+`COLDEF` 는 `reader.rs` 전체에서 미지원 판정의 **허용 목록** 한 곳에만 등장했다
+(`is_unsupported_inline` 의 `"CHAR" | "SECDEF" | "COLDEF" | ...`). `capture_start` 에는 처리
+분기가 없어 `_ => Ok(())` 로 떨어졌다.
+
+즉 **"지원한다"고 표시돼 경고 대상에서 빠지면서 실제로는 버려졌다.**
+
+`Control::ColumnDef` 는 죽은 필드가 아니다 — `renderer/mod.rs:751` 과 `renderer/layout.rs` 8곳이
+다단 레이아웃을 구동한다. HWPX 파서는 같은 것을 정상적으로 읽는다(`hwpx/section.rs:496`).
+
+## 2. 재현 — fixture 가 왜 못 잡았나
+
+`samples/hml/` 실물 3개가 전부 `COLDEF Count="1"` 이라 드롭돼도 결과가 같다. `aligns.hml` 의
+실제 `SECDEF`/`PAGEDEF`/`COLDEF` 구조를 그대로 따라 `Count="2"` 합성 HML 을 만들고
+`rhwp export-svg` 로 렌더링했다:
+
+- 수정 전: 800자가 x=113~672(전체 폭) **한 단**에 몰림 (72자/줄)
+- 수정 후: x<390(컬럼1)과 x≥390(컬럼2)로 **1435/1435 글리프씩 균등 분할**
+
+## 3. 부작용을 스스로 잡았다
+
+리더만 고치니 `Control::ColumnDef` 가 새로 생겨 **기존에 통과하던 HML 저장 경로가 전면
+막혔다** — `preflight.rs` 의 `_ => unsupported(...)` 폴백에 걸려 19개 테스트가 새로 깨졌다(모든
+HML 문서에 COLDEF 가 있다).
+
+`serializer/hml/body.rs` 에 `write_column_def`(역방향 직렬화)와 `preflight.rs` 에
+`validate_column_def`(widths/gaps/separator 등 왕복 불가 필드가 기본값이 아니면 export 차단)를
+추가해 해결했다. `hml_serializer` 31/31 통과.
+
+## 4. 미확인 후보 12종 — 전부 확인했다
+
+`FOOTNOTESHAPE`/`ENDNOTESHAPE`/`NOTELINE`/`NOTENUMBERING`/`NOTEPLACEMENT`/`NOTESPACING`/
+`PAGEBORDERFILL`/`BEGINNUMBER`/`CARETPOS`/`LAYOUTCOMPATIBILITY`/`COMPATIBLEDOCUMENT`/
+`NUMBERINGLIST` — **전부 `reader.rs` 에 이름이 한 번도 등장하지 않는다**(grep 0건).
+
+그중 9종(`FOOTNOTESHAPE`~`CARETPOS`)은 실물 `samples/hml/aligns.hml` 의 `SECDEF`/`DOCSETTING`
+안에 **실제로 존재하는데도** 부모가 HEAD/BODY/TAIL 이 아니라 `warn_if_unsupported` 의 5개 조건
+어디에도 안 걸려 조용히 드롭됨을 확인했다. 나머지 3종은 실물 fixture 에 없어 위치를 실물로
+확인하지 못했지만 코드 경로상 같은 논리다.
+
+**고치지 않고 보고만 한다** — 별도 작업이다.
+
+## 5. 사고 — 공유 stash race
+
+`git stash`/`pop` 으로 수정 전 실패를 확인하려다 내 변경 6개 파일이 사라지고 다른 에이전트의
+변경이 대신 적용됐다. `refs/stash` 가 모든 worktree 공유라 생긴 일이다. 대화 기록의 diff 로
+6개 파일을 재구성했고 복구본과 byte-for-byte 동일함을 확인했다. 이후
+`git diff > patch && git checkout -- <files> && test && git apply patch` 방식으로 전환했다.
+
+## 6. 검증 (완료)
+
+- 회귀 테스트 `coldef_with_two_columns_populates_column_def_control_without_warning` 신설.
+  **수정 전 실패를 확인**했다(`COLDEF must produce a Control::ColumnDef, not be silently dropped`).
+- 기존 `maps_real_hwpml_291_formatting_table_fixture_without_losing_inline_order` 값 갱신 —
+  COLDEF 가 이제 `Control::ColumnDef` 로 채워지고 `char_offsets` 가 8 밀리는 것이 정확한 동작이다
+  (주석으로 이유 명시). `samples/` 실물 fixture 파일 자체는 건드리지 않았다.
+- `cargo test --profile release-test --tests --no-fail-fast` 통과.
+- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` 통과.
+
+## 7. 범위 밖
+
+`SECDEF` 자체의 속성(`SpaceColumns`/`TabStop`/`CharGrid` 등)이 전혀 캡처되지 않는 것을 발견했으나
+이슈 범위 밖이라 보고만 한다.
+
+남은 미래 조건은 GitHub Actions 와 작업지시자 승인, merge 다.

--- a/src/parser/hml/adapter.rs
+++ b/src/parser/hml/adapter.rs
@@ -130,6 +130,7 @@ fn into_control(source: HmlControl) -> Result<Control, HmlError> {
         HmlControl::Equation(equation) => Ok(into_equation(equation)),
         HmlControl::Rectangle(rectangle) => into_rectangle(rectangle),
         HmlControl::Table(table) => into_table(table),
+        HmlControl::ColumnDef(column_def) => Ok(Control::ColumnDef(column_def)),
     }
 }
 

--- a/src/parser/hml/reader.rs
+++ b/src/parser/hml/reader.rs
@@ -1,7 +1,7 @@
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 
-use crate::model::page::PageDef;
+use crate::model::page::{ColumnDef, ColumnDirection, ColumnType, PageDef};
 use crate::model::paragraph::{CharShapeRef, ColumnBreakType};
 use crate::model::shape::{
     CommonObjAttr, HorzAlign, HorzRelTo, ShapeComponentAttr, TextWrap, VertAlign, VertRelTo,
@@ -112,6 +112,7 @@ pub(crate) enum HmlControl {
     Equation(HmlEquation),
     Rectangle(HmlRectangle),
     Table(HmlTable),
+    ColumnDef(ColumnDef),
 }
 
 #[derive(Debug, Default)]
@@ -442,6 +443,7 @@ impl<'a> ReadState<'a> {
             }
             "SCRIPT" => self.start_equation_script(element),
             "RECTANGLE" => self.start_rectangle(element),
+            "COLDEF" => self.capture_col_def(element),
             "SHAPEOBJECT" => self.capture_shape_object(element),
             "SHAPECOMPONENT" => self.capture_shape_component(element),
             "LINESHAPE" => self.capture_line_shape(element),
@@ -884,6 +886,33 @@ impl<'a> ReadState<'a> {
             rectangle.y_coords[index] = parse_attribute(element, *key)?.unwrap_or(0);
         }
         self.rectangles.push(rectangle);
+        Ok(())
+    }
+
+    /// [#4386] `TEXT` 직계 `COLDEF`(다단 정의) → `Control::ColumnDef`.
+    ///
+    /// `COLDEF`는 `RECTANGLE`/`TABLE`/`EQUATION`과 달리 자식 요소가 없는 빈 태그라
+    /// (`<COLDEF .../>`, 실물 관찰: `samples/hml/aligns.hml`) 시작·종료를 나눠 스테이징할
+    /// 필요가 없다 — 속성만으로 완성된 `ColumnDef`를 만들어 그 자리에서 바로
+    /// `controls`에 넣는다. 다른 인라인 컨트롤과 마찬가지로 원본 텍스트 스트림에서
+    /// 8-utf16 자리를 차지하므로 `reserve_control_slot`으로 `raw_pos`를 맞춘다.
+    ///
+    /// HWPX `hwpx/section.rs::parse_col_pr`가 같은 IR 필드를 채우는 방식을 참고했다:
+    /// `SameGap`(간격 수치)→`spacing`, `SameSize`(bool)→`same_width`. HML은 간격을
+    /// `SECDEF`가 아니라 `COLDEF` 자신의 `SameGap`에 싣는다(HWPX의 `sameGap`과 동형).
+    fn capture_col_def(&mut self, element: &BytesStart<'_>) -> Result<(), HmlError> {
+        self.reserve_control_slot()?;
+        let column_def = ColumnDef {
+            column_type: parse_column_type(attribute(element, b"Type")?.as_deref()),
+            column_count: parse_attribute(element, b"Count")?.unwrap_or(1),
+            direction: parse_column_direction(attribute(element, b"Layout")?.as_deref()),
+            same_width: parse_bool_attribute(element, b"SameSize")?,
+            spacing: parse_attribute(element, b"SameGap")?.unwrap_or(0),
+            ..Default::default()
+        };
+        self.current_paragraph()?
+            .controls
+            .push(HmlControl::ColumnDef(column_def));
         Ok(())
     }
 
@@ -1592,6 +1621,29 @@ fn parse_alignment(value: Option<&str>) -> Alignment {
         Some("Distribute") => Alignment::Distribute,
         Some("Split") => Alignment::Split,
         _ => Alignment::Justify,
+    }
+}
+
+/// [#4386] `COLDEF@Type`. 실물(`samples/hml/aligns.hml` 등)에서 관찰된 값은
+/// `"Newspaper"`(신문형=일반 흐름) 뿐이다. `Distribute`/`Parallel`은 HWPX
+/// `colPr@type`(`BalancedNewspaper`/`Parallel`)과 이 파일의 다른 속성들(예:
+/// `parse_alignment`의 `"Distribute"`)이 이미 따르는 PascalCase 열거값 표기 관례를
+/// 그대로 적용한 것으로, 실물로 확인되지 않았다 — 문서 밖 값은 전부 `Normal`로 접는다.
+fn parse_column_type(value: Option<&str>) -> ColumnType {
+    match value {
+        Some("Distribute") => ColumnType::Distribute,
+        Some("Parallel") => ColumnType::Parallel,
+        _ => ColumnType::Normal,
+    }
+}
+
+/// [#4386] `COLDEF@Layout`. 실물 관찰값은 `"Left"`뿐이다. HWPX
+/// `colPr@layout`(`"RIGHT"` → `RightToLeft`)과 동일한 fallback 방향으로 `"Right"`를
+/// `RightToLeft`에 매핑한다.
+fn parse_column_direction(value: Option<&str>) -> ColumnDirection {
+    match value {
+        Some("Right") => ColumnDirection::RightToLeft,
+        _ => ColumnDirection::LeftToRight,
     }
 }
 

--- a/src/serializer/hml/body.rs
+++ b/src/serializer/hml/body.rs
@@ -1,6 +1,6 @@
 use crate::model::control::{Control, Equation};
 use crate::model::document::{Document, Section};
-use crate::model::page::PageDef;
+use crate::model::page::{ColumnDef, ColumnDirection, ColumnType, PageDef};
 use crate::model::paragraph::{ColumnBreakType, Paragraph};
 use crate::model::shape::{
     CommonObjAttr, HorzAlign, HorzRelTo, RectangleShape, ShapeObject, TextWrap, VertAlign,
@@ -249,6 +249,7 @@ fn write_control_run(
         Control::Equation(equation) => write_equation(writer, equation),
         Control::Table(table) => write_table(writer, table, path),
         Control::Shape(shape) => write_shape(writer, shape, path),
+        Control::ColumnDef(column_def) => write_column_def(writer, column_def),
         _ => Err(unsupported_ir(
             path,
             "HML reader가 매핑하지 않는 컨트롤입니다",
@@ -274,6 +275,42 @@ fn write_equation(writer: &mut XmlWriter, equation: &Equation) -> Result<(), Hml
     writer.close("SCRIPT");
     writer.close("EQUATION");
     Ok(())
+}
+
+/// [#4386] `Control::ColumnDef` → `COLDEF`. reader.rs의 `capture_col_def`가 읽는
+/// `Count`/`Layout`/`SameGap`/`SameSize`/`Type` 다섯 속성만 왕복한다(HML 실물에서 관찰된
+/// 전부). `widths`/`gaps`/`separator_*`/`raw_attr`는 `validate_column_def`(preflight)가
+/// 기본값이 아니면 미리 export를 막으므로 여기서는 항상 무시해도 안전하다.
+fn write_column_def(writer: &mut XmlWriter, column_def: &ColumnDef) -> Result<(), HmlExportError> {
+    writer.empty(
+        "COLDEF",
+        &[
+            ("Count", column_def.column_count.to_string()),
+            (
+                "Layout",
+                column_direction_name(column_def.direction).to_string(),
+            ),
+            ("SameGap", column_def.spacing.to_string()),
+            ("SameSize", column_def.same_width.to_string()),
+            ("Type", column_type_name(column_def.column_type).to_string()),
+        ],
+    );
+    Ok(())
+}
+
+fn column_type_name(column_type: ColumnType) -> &'static str {
+    match column_type {
+        ColumnType::Normal => "Newspaper",
+        ColumnType::Distribute => "Distribute",
+        ColumnType::Parallel => "Parallel",
+    }
+}
+
+fn column_direction_name(direction: ColumnDirection) -> &'static str {
+    match direction {
+        ColumnDirection::LeftToRight => "Left",
+        ColumnDirection::RightToLeft => "Right",
+    }
 }
 
 fn write_shape(

--- a/src/serializer/hml/preflight.rs
+++ b/src/serializer/hml/preflight.rs
@@ -1,5 +1,6 @@
 use crate::model::control::Control;
 use crate::model::document::Document;
+use crate::model::page::ColumnDef;
 use crate::model::paragraph::{ColumnBreakType, Paragraph};
 use crate::model::shape::{
     CommonObjAttr, RectangleShape, ShapeComponentAttr, ShapeObject, TextBox,
@@ -318,6 +319,9 @@ fn validate_paragraph(paragraph: &Paragraph, path: &str, blockers: &mut Vec<HmlS
                     "shape kind is not mapped by the HML reader",
                 )),
             },
+            Control::ColumnDef(column_def) => {
+                validate_column_def(column_def, &format!("{control_path}/COLDEF"), blockers)
+            }
             _ => blockers.push(unsupported(
                 control_path,
                 "control kind is not mapped by the HML reader",
@@ -375,6 +379,26 @@ fn validate_equation(
         equation.unknown != 0 || !equation.raw_ctrl_data.is_empty(),
         path,
         "equation binary-only fields are not represented by HML EQUATION",
+        blockers,
+    );
+}
+
+/// [#4386] `COLDEF`은 `Count`/`Layout`/`SameGap`/`SameSize`/`Type`만 왕복한다(HML
+/// 실물에서 관찰된 속성 전부). `widths`/`gaps`(단별 개별 폭·간격) 및
+/// `separator_*`/`raw_attr`(단 구분선, HWPX `colLine`에 대응)는 HML `COLDEF`에 실을
+/// 자리가 없다 — 이 필드들이 기본값이 아니면 조용히 잘라내는 대신 export를 막는다.
+fn validate_column_def(column_def: &ColumnDef, path: &str, blockers: &mut Vec<HmlSaveBlocker>) {
+    let default = ColumnDef::default();
+    push_if(
+        !column_def.widths.is_empty()
+            || !column_def.gaps.is_empty()
+            || column_def.proportional_widths != default.proportional_widths
+            || column_def.separator_type != default.separator_type
+            || column_def.separator_width != default.separator_width
+            || column_def.separator_color != default.separator_color
+            || column_def.raw_attr != default.raw_attr,
+        path,
+        "column per-column widths/gaps/separator fields are not represented by HML COLDEF",
         blockers,
     );
 }

--- a/tests/hml_parser.rs
+++ b/tests/hml_parser.rs
@@ -375,6 +375,48 @@ fn inline_controls_preserve_text_offsets_and_unsupported_paths() {
     }
 }
 
+/// [#4386] `COLDEF Count="2"` 이상인 다단 정의는 `Control::ColumnDef`로 채워져야 한다.
+/// 종전엔 `is_unsupported_inline`의 허용 목록에만 있고 `capture_start`에 처리 분기가
+/// 없어, 경고 없이 조용히 드롭되고 렌더러가 항상 단일 단으로 그렸다(모든 fixture가
+/// `Count="1"`이라 우연히 통과했다). 속성 값(`Layout`/`SameGap`/`SameSize`/`Type`)은
+/// `samples/hml/aligns.hml`의 실물 `COLDEF Count="1" Layout="Left" SameGap="0"
+/// SameSize="true" Type="Newspaper"` 관찰값을 그대로 따른다.
+#[test]
+fn coldef_with_two_columns_populates_column_def_control_without_warning() {
+    let xml = br#"<HWPML Version="2.91"><HEAD/><BODY><SECTION><P ParaShape="0" Style="0"><TEXT CharShape="0"><SECDEF CharGrid="0"><PAGEDEF GutterType="LeftOnly" Height="84188" Landscape="0" Width="59528"><PAGEMARGIN Bottom="4252" Footer="4252" Gutter="0" Header="4252" Left="8504" Right="8504" Top="5668"/></PAGEDEF></SECDEF><COLDEF Count="2" Layout="Left" SameGap="850" SameSize="true" Type="Newspaper"/><CHAR>two columns</CHAR></TEXT></P></SECTION></BODY><TAIL/></HWPML>"#;
+    let parsed = parse_hml(xml).expect("multi-column HML should parse");
+    let paragraph = &parsed.document.sections[0].paragraphs[0];
+
+    let column_def = paragraph
+        .controls
+        .iter()
+        .find_map(|control| match control {
+            Control::ColumnDef(column_def) => Some(column_def),
+            _ => None,
+        })
+        .expect("COLDEF must produce a Control::ColumnDef, not be silently dropped");
+    assert_eq!(column_def.column_count, 2);
+    assert!(column_def.same_width);
+    assert_eq!(column_def.spacing, 850);
+    assert_eq!(
+        column_def.column_type,
+        rhwp::model::page::ColumnType::Normal
+    );
+    assert_eq!(
+        column_def.direction,
+        rhwp::model::page::ColumnDirection::LeftToRight
+    );
+
+    assert!(
+        !parsed
+            .warnings
+            .iter()
+            .any(|warning| warning.xml_path.ends_with("/COLDEF")),
+        "COLDEF must not be reported as a generic unsupported element: {:?}",
+        parsed.warnings
+    );
+}
+
 #[test]
 fn does_not_detect_malformed_utf8_as_hml() {
     let mut bytes = HML_29.as_bytes().to_vec();
@@ -720,7 +762,11 @@ fn maps_real_hwpml_291_formatting_table_fixture_without_losing_inline_order() {
 
     assert_eq!(paragraphs.len(), 2);
     assert_eq!(paragraphs[0].text, "123456");
-    assert_eq!(paragraphs[0].char_offsets, [0, 1, 2, 11, 12, 13]);
+    // [#4386] paragraphs[0]는 SECDEF 다음에 COLDEF(Count="1")를 갖고 있다. COLDEF가
+    // 더는 조용히 드롭되지 않고 인라인 컨트롤 자리(8 raw unit)를 반영하므로, "123"의
+    // 시작 위치가 종전 0이 아니라 COLDEF 뒤인 8로 옮겨간다. paragraphs[1]에는
+    // SECDEF/COLDEF가 없어 그대로 [0, 1, 2, 11, 12, 13]이다(표 컨트롤 자리만 반영).
+    assert_eq!(paragraphs[0].char_offsets, [8, 9, 10, 19, 20, 21]);
     assert_eq!(paragraphs[1].text, "abcefg");
     assert_eq!(paragraphs[1].char_offsets, [0, 1, 2, 11, 12, 13]);
     assert_eq!(parsed.document.doc_info.char_shapes[5].base_size, 1600);
@@ -730,8 +776,16 @@ fn maps_real_hwpml_291_formatting_table_fixture_without_losing_inline_order() {
     );
     assert_eq!(parsed.document.doc_info.styles[17].local_name, "차례 3");
 
-    let Control::Shape(shape) = &paragraphs[0].controls[0] else {
-        panic!("first inline control should be a shape");
+    // [#4386] paragraphs[0]의 첫 인라인 컨트롤은 이제 COLDEF에서 만들어진
+    // Control::ColumnDef다(SECDEF 다음, RECTANGLE 앞의 원문 순서 그대로). Count="1"
+    // 이라 렌더링 결과는 종전과 같지만, 더는 조용히 사라지지 않고 순서대로 채워진다.
+    let Control::ColumnDef(column_def) = &paragraphs[0].controls[0] else {
+        panic!("first inline control should be the COLDEF-derived ColumnDef");
+    };
+    assert_eq!(column_def.column_count, 1);
+
+    let Control::Shape(shape) = &paragraphs[0].controls[1] else {
+        panic!("second inline control should be a shape");
     };
     let ShapeObject::Rectangle(rectangle) = shape.as_ref() else {
         panic!("fixture shape should be a rectangle");

--- a/tests/hml_serializer.rs
+++ b/tests/hml_serializer.rs
@@ -231,6 +231,14 @@ fn assert_control_equivalent(after: &Control, before: &Control) {
             };
             assert_rectangle_equivalent(after, before);
         }
+        // [#4386] COLDEF는 이제 Control::ColumnDef로 왕복한다.
+        (Control::ColumnDef(after), Control::ColumnDef(before)) => {
+            assert_eq!(after.column_type, before.column_type);
+            assert_eq!(after.column_count, before.column_count);
+            assert_eq!(after.direction, before.direction);
+            assert_eq!(after.same_width, before.same_width);
+            assert_eq!(after.spacing, before.spacing);
+        }
         _ => panic!("fixture control kind changed during HML round-trip"),
     }
 }


### PR DESCRIPTION
## 무엇을

HML 파서가 `<COLDEF>`(다단 정의)를 경고 없이 버려 **다단 문서가 단일 단으로 열리던** 결함을
고친다.

## 왜

`COLDEF` 는 `reader.rs` 전체에서 미지원 판정의 **허용 목록** 한 곳에만 등장했다
(`is_unsupported_inline` 의 `"CHAR" | "SECDEF" | "COLDEF" | ...`). `capture_start` 에는 처리 분기가
없어 `_ => Ok(())` 로 떨어졌다.

**"지원한다"고 표시돼 경고 대상에서 빠지면서 실제로는 버려졌다.**

`Control::ColumnDef` 는 죽은 필드가 아니다 — `renderer/mod.rs:751` 과 `renderer/layout.rs` 8곳이
다단 레이아웃을 구동한다. HWPX 파서는 같은 것을 정상적으로 읽는다(`hwpx/section.rs:496`) — 포맷별
범위 차이가 아니라 HML 경로만 빠진 것이다.

## 재현 — fixture 가 왜 못 잡았나

`samples/hml/` 실물 3개가 전부 `COLDEF Count="1"` 이라 드롭돼도 결과가 같다. `aligns.hml` 의 실제
구조를 그대로 따라 `Count="2"` 합성 HML 을 만들고 `export-svg` 로 렌더링했다:

- **수정 전**: 800자가 x=113~672(전체 폭) **한 단**에 몰림
- **수정 후**: x<390 / x≥390 으로 **1435/1435 글리프 균등 분할**

## 어떻게

`capture_start` 에 `COLDEF` 분기 + `capture_col_def`(Count/Layout/SameGap/SameSize/Type →
`ColumnDef`, `reserve_control_slot` 로 8-unit 위치 예약) + 타입 헬퍼 2개.
`HmlControl::ColumnDef` variant 와 `adapter.rs::into_control` 도 추가.

## 부작용을 함께 잡았다

리더만 고치니 `Control::ColumnDef` 가 새로 생겨 **기존에 통과하던 HML 저장이 전면 막혔다** —
`preflight.rs` 의 `_ => unsupported(...)` 폴백에 걸려 19개 테스트가 새로 깨졌다(모든 HML 문서에
COLDEF 가 있다).

`serializer/hml/body.rs` 에 `write_column_def`(역방향 직렬화)와 `preflight.rs` 에
`validate_column_def`(왕복 불가 필드가 기본값이 아니면 export 차단)를 추가해 해결했다.

## 미확인 후보 12종 — 전부 확인, 고치지 않음

이슈가 나열한 `PAGEBORDERFILL`·`FOOTNOTESHAPE` 등 12종이 **전부 `reader.rs` 에 이름조차 없다**
(grep 0건). 그중 9종은 실물 `aligns.hml` 의 `SECDEF`/`DOCSETTING` 안에 **실제로 존재하는데도**
부모가 HEAD/BODY/TAIL 이 아니라 `warn_if_unsupported` 의 5개 조건 어디에도 안 걸려 조용히 드롭됨을
확인했다. 별도 작업이다.

## 검증

- 회귀 테스트 신설. **수정 전 실패를 확인**했다.
- 기존 fixture 테스트 값 갱신 — COLDEF 가 `Control::ColumnDef` 로 채워지고 `char_offsets` 가 8
  밀리는 것이 정확한 동작이다(주석으로 이유 명시). `samples/` 실물 파일은 건드리지 않았다.
- `hml_parser` 38/38, `hml_serializer` 31/31.
- `cargo test --profile release-test --tests --no-fail-fast` 통과.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` 통과.

## 같은 계열

#4387(PR #4411)은 HWPX 가 **단별 폭**(`hp:colSz`)을 잃는 문제다. 이건 HML 이 **다단 정의 자체**를
잃는 것 — 두 driver 가 각각 다른 층위에서 다단을 놓치고 있었다.

## 범위 밖

`SECDEF` 자체의 속성(`SpaceColumns`/`TabStop`/`CharGrid` 등)이 전혀 캡처되지 않는 것을 발견했으나
이슈 범위 밖이라 보고만 한다.

Closes #4386
