### PR TITLE
serializer(hwpx): 중첩 표의 borderFillIDRef 사전 등록 누락으로 export 전체가 실패하는 것 수정

### DIFF
--- a/mydocs/working/task_m100_4408_stage1.md
+++ b/mydocs/working/task_m100_4408_stage1.md
@@ -1,0 +1,78 @@
+# task_m100_4408 Stage 1 — 중첩 표 borderFillIDRef 사전 등록 누락
+
+- **이슈**: [#4408](https://github.com/edwardkim/rhwp/issues/4408)
+- **브랜치**: `test/roundtrip-hwp-hwpx-hwp`
+- **분기 기준**: `upstream/devel` `e48fe8694`
+- **상태**: 게이트 통과(타이밍 flake 제외), PR 게시
+- **기록일**: 2026-08-10 KST
+
+## 1. 발견 경위 — HWP → HWPX → HWP 왕복 스윕
+
+`samples/` 400개 + `~/hwpdocs_10k/` 6,582개 = **6,982건** 전수 스윕에서 나왔다.
+46건 실패 중 **1건이 크래시**였다 — 중첩 표를 가진 정부 보고서에서 `export-hwpx` 가 산출물 없이
+전체 실패했다(`borderFillIDRef: [0]` 미등록).
+
+나머지 45건은 빈 파일 24, HTML 오저장 12, DRM 6, 암호 3 이다.
+
+스윕 자체의 결함도 하나 잡아 정정했다 — 임시 파일명에 원본 이름을 그대로 써서 macOS 255바이트
+제한을 넘는 17개 문서가 "저장 실패"로 오분류됐다. 해시 경로로 재실행해 16 PASS + 1 IR_DIFF 로
+정정했다.
+
+## 2. 결함 — 최상위 표만 훑었다
+
+`SerializeContext::collect_from_document` 가 `doc.sections[].paragraphs[]` 의 최상위
+`Control::Table` 만 훑어, 셀 안에 중첩된 표나 글상자·머리말/꼬리말·각주/미주 안의 표의
+`border_fill_id` 가 등록에서 빠졌다. 그 표가 실제 직렬화에서 참조되면
+`assert_all_refs_resolved` 가 하드 실패해 **문서 전체의 export 가 산출물 없이 죽는다.**
+
+`table_extract::collect_from_paragraph` 와 같은 위상의 재귀
+(`register_border_fills_in_paragraphs`)로 교체했다. 깊이 상한은 `table_extract::MAX_NEST_DEPTH`
+와 같은 값이다.
+
+## 3. 리뷰가 잡은 것 — 문단 리스트 소유자 4종 누락
+
+첫 수정은 소유자 **6개**만 돌았다(Table 셀·Shape 텍스트박스·Header·Footer·Footnote·Endnote).
+OWPML 상 8개인데 빠진 것:
+
+- **`Caption`**(`model/shape.rs:674`) — 표·도형·그림·차트·OLE 이 각각 갖는다
+- **`Field.memo_paragraphs`**(`model/control.rs:276`)
+- **`HiddenComment`**(`model/control.rs:235`)
+- **`Control::Picture`** — 자체 `caption`(`model/image.rs:44`)
+
+**이건 이번 세션에 이미 나온 패턴이다.** #4321(PR #4365)이 정확히 같은 누락을 injection_scan 에서
+고쳤는데, 새 코드가 같은 자리를 또 빠뜨렸다.
+
+캡션이 변형마다 다른 필드에 있다는 것도 반영했다 — 기본 6종은 `drawing.caption`,
+`Group`/`Picture` 는 자기 `caption`, **`Chart`/`Ole` 는 자기 `caption`**(파서가 `.take()` 로 옮겨
+`.drawing().caption` 이 항상 `None`, `parser/control/shape.rs:213`·`:222`). 방어적으로 양쪽 다
+확인한다.
+
+요청 범위 밖이지만 `GroupShape.children` 재귀도 함께 닫았다 — 안 닫으면 묶음에 담긴
+Picture/Chart 의 캡션이 여전히 사각지대다.
+
+## 4. 재현 — 실 코퍼스는 실패했다
+
+전체 코퍼스를 `<hp:caption>…<hp:tbl` 패턴으로 스캔해 실제 문서 2건을 찾았다
+(`samples/issue1891_external_bindata_link.hwpx`,
+`hwpdocs_10k/.../36421964_고시문.hwpx`). **둘 다 첫 수정만으로 이미 통과한다** —
+`border_fill_id` 가 우연히 전역 1-based 등록 범위 안에 들어서다.
+
+**코드 경로상 누락은 실재하지만(단위 테스트가 직접 증명) 실 코퍼스 크래시 재현은 실패했다.**
+
+## 5. 검증 (완료)
+
+- 소유자별 단위 테스트 9건 + 실제 `serialize_hwpx` 를 물리는 end-to-end 1건.
+  **전부 수정 전 코드로 되돌려 FAILED 를 확인**했다(e2e 는
+  `XmlError("미등록 ID 참조 발견: borderFillIDRef: [121]")`).
+- 최소 IR 픽스처에 기본 char_shape/para_shape/style 을 채워 border_fill_id 축과 무관한
+  잡음(paraPrIDRef/styleIDRef 미등록)을 제거했다.
+- `cargo test --profile release-test --tests` 2회 완주 — 타이밍 flake 1건 외 전부 통과.
+- `cargo fmt --all -- --check`, `cargo clippy -- -D warnings` 통과.
+
+## 6. 미처리
+
+`src/serializer/hwpx/context.rs` 는 #4395 수정(PR #4409, `ctx.style_ids.register(0)` 한 줄)과
+같은 파일이다. 논리 충돌은 없지만 머지 시 텍스트 충돌 가능성이 있다 — 나중에 머지되는 쪽이
+리베이스한다.
+
+남은 미래 조건은 GitHub Actions 와 작업지시자 승인, merge 다.

--- a/src/serializer/hwpx/context.rs
+++ b/src/serializer/hwpx/context.rs
@@ -344,6 +344,13 @@ fn register_table_border_fills(ctx: &mut SerializeContext, table: &crate::model:
 /// `assert_all_refs_resolved`가 "미등록 ID 참조 발견"으로 하드 실패해 문서 전체의
 /// `export-hwpx`가 산출물 없이 실패했다(실측: 정부 보고서 표 107개 중 중첩 표 1개를 가진
 /// 문서에서 `borderFillIDRef: [0]` 미등록으로 재현).
+///
+/// [gestell 리뷰] 첫 수정은 6개 소유자(표 셀·글상자·머리말·꼬리말·각주·미주)만 돌았다.
+/// OWPML 은 문단 리스트를 8개 자리에 둘 수 있다 — 나머지 2개(캡션, 필드 메모)와 함께
+/// `Control::Picture`(자체 캡션을 갖는 별도 컨트롤)·`Control::HiddenComment` 도 이 재귀 밖에
+/// 있었다. `#2736`(전수 조사: 순회 × 컨테이너 행렬)이 이미 지적한 "공유 방문자 부재로 반복되는
+/// 재귀 누락"과 같은 계열 — 이번 세션의 `#4321`/PR #4365(`injection_scan.rs`)가 캡션·그림·필드
+/// 메모 누락을 고친 것과 동형이다.
 fn register_border_fills_in_paragraphs(
     ctx: &mut SerializeContext,
     paragraphs: &[crate::model::paragraph::Paragraph],
@@ -354,31 +361,109 @@ fn register_border_fills_in_paragraphs(
     }
     for para in paragraphs {
         for ctrl in &para.controls {
-            match ctrl {
-                Control::Table(tbl) => {
-                    register_table_border_fills(ctx, tbl);
-                    for cell in &tbl.cells {
-                        register_border_fills_in_paragraphs(ctx, &cell.paragraphs, depth + 1);
-                    }
-                }
-                Control::Shape(shape) => {
-                    if let Some(tb) = shape.drawing().and_then(|d| d.text_box.as_ref()) {
-                        register_border_fills_in_paragraphs(ctx, &tb.paragraphs, depth + 1);
-                    }
-                }
-                Control::Header(h) => {
-                    register_border_fills_in_paragraphs(ctx, &h.paragraphs, depth + 1);
-                }
-                Control::Footer(f) => {
-                    register_border_fills_in_paragraphs(ctx, &f.paragraphs, depth + 1);
-                }
-                Control::Footnote(f) => {
-                    register_border_fills_in_paragraphs(ctx, &f.paragraphs, depth + 1);
-                }
-                Control::Endnote(e) => {
-                    register_border_fills_in_paragraphs(ctx, &e.paragraphs, depth + 1);
-                }
-                _ => {}
+            register_border_fills_in_control(ctx, ctrl, depth);
+        }
+    }
+}
+
+fn register_border_fills_in_control(ctx: &mut SerializeContext, ctrl: &Control, depth: usize) {
+    match ctrl {
+        Control::Table(tbl) => {
+            register_table_border_fills(ctx, tbl);
+            for cell in &tbl.cells {
+                register_border_fills_in_paragraphs(ctx, &cell.paragraphs, depth + 1);
+            }
+            if let Some(caption) = &tbl.caption {
+                register_border_fills_in_paragraphs(ctx, &caption.paragraphs, depth + 1);
+            }
+        }
+        Control::Shape(shape) => {
+            register_border_fills_in_shape(ctx, shape, depth);
+        }
+        // 독립 그림 컨트롤(글상자/묶음 밖) — 자체 `caption` 을 갖는다(`src/model/image.rs`).
+        Control::Picture(pic) => {
+            if let Some(caption) = &pic.caption {
+                register_border_fills_in_paragraphs(ctx, &caption.paragraphs, depth + 1);
+            }
+        }
+        Control::Header(h) => {
+            register_border_fills_in_paragraphs(ctx, &h.paragraphs, depth + 1);
+        }
+        Control::Footer(f) => {
+            register_border_fills_in_paragraphs(ctx, &f.paragraphs, depth + 1);
+        }
+        Control::Footnote(f) => {
+            register_border_fills_in_paragraphs(ctx, &f.paragraphs, depth + 1);
+        }
+        Control::Endnote(e) => {
+            register_border_fills_in_paragraphs(ctx, &e.paragraphs, depth + 1);
+        }
+        // 숨은 설명(메모) — 화면에 안 보여도 파일에는 문단 리스트로 존재한다.
+        Control::HiddenComment(hc) => {
+            register_border_fills_in_paragraphs(ctx, &hc.paragraphs, depth + 1);
+        }
+        // 필드(누름틀 등) 메모 — `Field.memo_paragraphs`.
+        Control::Field(f) => {
+            register_border_fills_in_paragraphs(ctx, &f.memo_paragraphs, depth + 1);
+        }
+        _ => {}
+    }
+}
+
+/// `ShapeObject`(그리기 개체) 하나의 글상자·캡션과, 묶음이면 자식 개체까지 재귀한다.
+///
+/// 캡션 자리는 변형마다 다르다(#4319 가 렌더 쪽에서 이미 지적한 비대칭과 같은 축):
+/// - 기본 6종(Line/Rectangle/Ellipse/Arc/Polygon/Curve): `drawing.caption`
+/// - `Group`/`Picture`(묶음 내 자식으로서의 그림): 자기 struct 의 `caption`
+/// - `Chart`/`Ole`: 자기 struct 의 `caption` — 파서(`src/parser/control/shape.rs:213,222`)가
+///   `drawing.caption` 을 `.take()` 로 옮기므로 `drawing.caption` 은 항상 `None` 이다. 그래도
+///   방어적으로 두 자리를 모두 확인한다(렌더의 `shape_caption_for_layout` 폴백과 동형).
+fn register_border_fills_in_shape(
+    ctx: &mut SerializeContext,
+    shape: &crate::model::shape::ShapeObject,
+    depth: usize,
+) {
+    if depth >= MAX_BORDER_FILL_SCAN_DEPTH {
+        return;
+    }
+    use crate::model::shape::ShapeObject;
+
+    if let Some(tb) = shape.drawing().and_then(|d| d.text_box.as_ref()) {
+        register_border_fills_in_paragraphs(ctx, &tb.paragraphs, depth + 1);
+    }
+
+    match shape {
+        ShapeObject::Group(g) => {
+            if let Some(caption) = &g.caption {
+                register_border_fills_in_paragraphs(ctx, &caption.paragraphs, depth + 1);
+            }
+            for child in &g.children {
+                register_border_fills_in_shape(ctx, child, depth + 1);
+            }
+        }
+        ShapeObject::Picture(p) => {
+            if let Some(caption) = &p.caption {
+                register_border_fills_in_paragraphs(ctx, &caption.paragraphs, depth + 1);
+            }
+        }
+        ShapeObject::Chart(c) => {
+            if let Some(caption) = c.caption.as_ref().or(c.drawing.caption.as_ref()) {
+                register_border_fills_in_paragraphs(ctx, &caption.paragraphs, depth + 1);
+            }
+        }
+        ShapeObject::Ole(o) => {
+            if let Some(caption) = o.caption.as_ref().or(o.drawing.caption.as_ref()) {
+                register_border_fills_in_paragraphs(ctx, &caption.paragraphs, depth + 1);
+            }
+        }
+        ShapeObject::Line(_)
+        | ShapeObject::Rectangle(_)
+        | ShapeObject::Ellipse(_)
+        | ShapeObject::Arc(_)
+        | ShapeObject::Polygon(_)
+        | ShapeObject::Curve(_) => {
+            if let Some(caption) = shape.drawing().and_then(|d| d.caption.as_ref()) {
+                register_border_fills_in_paragraphs(ctx, &caption.paragraphs, depth + 1);
             }
         }
     }
@@ -504,6 +589,257 @@ mod tests {
         ctx.border_fill_ids.reference(INNER_BORDER_FILL_ID);
         ctx.assert_all_refs_resolved()
             .expect("중첩 표 border_fill_id 참조가 미등록으로 남으면 안 된다");
+    }
+
+    // ── [gestell 리뷰] 문단 리스트 8개 소유자 전수 — 각 자리에 표를 하나씩 심어
+    // border_fill_id 사전 등록을 개별로 확인한다. 표 셀은 위 테스트가 이미 덮는다.
+
+    /// 표 하나(1×1)를 만들어 스스로 border_fill_id 를 갖게 한다 — 소유자 테스트 공용 헬퍼.
+    fn table_with_border_fill(id: u16) -> crate::model::table::Table {
+        use crate::model::table::{Cell, Table};
+        let mut t = Table::default();
+        t.border_fill_id = id;
+        t.row_count = 1;
+        t.col_count = 1;
+        t.cells = vec![Cell::new_empty(0, 0, 1000, 1000, id)];
+        t
+    }
+
+    /// 문단 하나에 표 컨트롤 하나를 심은 문단 리스트 — 캡션/메모/숨은설명 등
+    /// `Vec<Paragraph>` 필드에 그대로 대입해 쓴다.
+    fn paragraphs_with_table(id: u16) -> Vec<crate::model::paragraph::Paragraph> {
+        use crate::model::paragraph::Paragraph;
+        let mut p = Paragraph::new_empty();
+        p.controls
+            .push(Control::Table(Box::new(table_with_border_fill(id))));
+        vec![p]
+    }
+
+    /// 컨트롤 하나를 문서 최상위 문단에 심는다 — 소유자 테스트 공용 헬퍼.
+    fn doc_with_top_control(ctrl: Control) -> Document {
+        use crate::model::paragraph::Paragraph;
+        use crate::model::style::{CharShape, ParaShape, Style};
+        let mut doc = Document::default();
+        // 실제 문서는 항상 기본 char_shape/para_shape/style 을 최소 1개씩 갖는다 —
+        // 완전히 빈 doc_info 는 para_shape_id=0/style_id=0(필드 기본값) 참조조차
+        // 미등록으로 만들어, border_fill_id 축과 무관한 잡음으로 end-to-end 직렬화가
+        // 실패한다. 소유자별 회귀 테스트가 실제로 검사하려는 축(border_fill_id)만
+        // 남기기 위해 기본 항목을 채운다.
+        doc.doc_info.char_shapes = vec![CharShape::default()];
+        doc.doc_info.para_shapes = vec![ParaShape::default()];
+        doc.doc_info.styles = vec![Style::default()];
+        let mut para = Paragraph::new_empty();
+        para.controls.push(ctrl);
+        doc.sections = vec![crate::model::document::Section {
+            paragraphs: vec![para],
+            ..Default::default()
+        }];
+        doc
+    }
+
+    #[test]
+    fn table_caption_border_fill_id_registered() {
+        // 표 캡션(Table.caption) 안의 표 — 캡션은 8개 문단 리스트 소유자 중 하나다.
+        use crate::model::shape::Caption;
+        const ID: u16 = 21;
+        let mut outer = table_with_border_fill(1);
+        outer.caption = Some(Caption {
+            paragraphs: paragraphs_with_table(ID),
+            ..Default::default()
+        });
+        let doc = doc_with_top_control(Control::Table(Box::new(outer)));
+        let ctx = SerializeContext::collect_from_document(&doc);
+        assert!(
+            ctx.border_fill_ids.is_registered(&ID),
+            "표 캡션 안의 표 border_fill_id도 사전 등록되어야 한다"
+        );
+    }
+
+    /// [gestell 리뷰 요청] 실제 export-hwpx 진입점(`serialize_hwpx`)까지 물려서 확인한다 —
+    /// `SerializeContext` 등록만 보는 위 테스트보다 실측(#4408 재현)에 가까운 형태. 표
+    /// 캡션 안에 표를 담은 실제 코퍼스 문서를 찾지 못해(§보고 — 재현 문서 없음, 최소 IR로
+    /// 구성) `serialize_hwpx` 를 직접 호출해 전체 파이프라인이 크래시 없이 끝나는지 본다.
+    #[test]
+    fn table_in_caption_serializes_end_to_end_without_crash() {
+        use crate::model::shape::Caption;
+        const ID: u16 = 121;
+        let mut outer = table_with_border_fill(1);
+        outer.row_count = 1;
+        outer.col_count = 1;
+        outer.caption = Some(Caption {
+            paragraphs: paragraphs_with_table(ID),
+            ..Default::default()
+        });
+        let doc = doc_with_top_control(Control::Table(Box::new(outer)));
+        let result = crate::serializer::hwpx::serialize_hwpx(&doc);
+        assert!(
+            result.is_ok(),
+            "표 캡션 안에 표가 있으면 export-hwpx 가 산출물 없이 실패해서는 안 된다: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn shape_default_caption_border_fill_id_registered() {
+        // 기본 6종 도형(Line 등)의 캡션은 `drawing.caption` 에 있다.
+        use crate::model::shape::{Caption, LineShape, ShapeObject};
+        const ID: u16 = 22;
+        let mut line = LineShape::default();
+        line.drawing.caption = Some(Caption {
+            paragraphs: paragraphs_with_table(ID),
+            ..Default::default()
+        });
+        let doc = doc_with_top_control(Control::Shape(Box::new(ShapeObject::Line(line))));
+        let ctx = SerializeContext::collect_from_document(&doc);
+        assert!(
+            ctx.border_fill_ids.is_registered(&ID),
+            "기본 도형 drawing.caption 안의 표 border_fill_id도 사전 등록되어야 한다"
+        );
+    }
+
+    #[test]
+    fn shape_group_caption_and_child_border_fill_id_registered() {
+        // Group 은 자기 struct 의 `caption` 을 쓰고(drawing 이 없음), 자식 개체도 재귀해야 한다.
+        use crate::model::shape::{Caption, GroupShape, LineShape, ShapeObject};
+        const GROUP_CAPTION_ID: u16 = 23;
+        const CHILD_CAPTION_ID: u16 = 24;
+
+        let mut child_line = LineShape::default();
+        child_line.drawing.caption = Some(Caption {
+            paragraphs: paragraphs_with_table(CHILD_CAPTION_ID),
+            ..Default::default()
+        });
+
+        let mut group = GroupShape::default();
+        group.caption = Some(Caption {
+            paragraphs: paragraphs_with_table(GROUP_CAPTION_ID),
+            ..Default::default()
+        });
+        group.children = vec![ShapeObject::Line(child_line)];
+
+        let doc = doc_with_top_control(Control::Shape(Box::new(ShapeObject::Group(group))));
+        let ctx = SerializeContext::collect_from_document(&doc);
+        assert!(
+            ctx.border_fill_ids.is_registered(&GROUP_CAPTION_ID),
+            "Group.caption 안의 표 border_fill_id도 사전 등록되어야 한다"
+        );
+        assert!(
+            ctx.border_fill_ids.is_registered(&CHILD_CAPTION_ID),
+            "Group 자식 개체(재귀)의 캡션 안 표 border_fill_id도 사전 등록되어야 한다"
+        );
+    }
+
+    #[test]
+    fn shape_picture_variant_caption_border_fill_id_registered() {
+        // 묶음 내 자식으로서의 그림(ShapeObject::Picture) — 자기 struct 의 `caption`.
+        use crate::model::image::Picture;
+        use crate::model::shape::{Caption, ShapeObject};
+        const ID: u16 = 25;
+        let mut pic = Picture::default();
+        pic.caption = Some(Caption {
+            paragraphs: paragraphs_with_table(ID),
+            ..Default::default()
+        });
+        let doc = doc_with_top_control(Control::Shape(Box::new(ShapeObject::Picture(Box::new(
+            pic,
+        )))));
+        let ctx = SerializeContext::collect_from_document(&doc);
+        assert!(
+            ctx.border_fill_ids.is_registered(&ID),
+            "ShapeObject::Picture.caption 안의 표 border_fill_id도 사전 등록되어야 한다"
+        );
+    }
+
+    #[test]
+    fn shape_chart_caption_border_fill_id_registered() {
+        // Chart — 파서가 drawing.caption 을 자기 struct 의 caption 으로 옮긴다(#4319 계열).
+        // 두 자리 다 방어적으로 확인하므로 own-field 경로를 실측한다.
+        use crate::model::shape::{Caption, ChartShape, ShapeObject};
+        const ID: u16 = 26;
+        let mut chart = ChartShape::default();
+        chart.caption = Some(Caption {
+            paragraphs: paragraphs_with_table(ID),
+            ..Default::default()
+        });
+        let doc = doc_with_top_control(Control::Shape(Box::new(ShapeObject::Chart(Box::new(
+            chart,
+        )))));
+        let ctx = SerializeContext::collect_from_document(&doc);
+        assert!(
+            ctx.border_fill_ids.is_registered(&ID),
+            "Chart.caption 안의 표 border_fill_id도 사전 등록되어야 한다"
+        );
+    }
+
+    #[test]
+    fn shape_ole_caption_border_fill_id_registered() {
+        // Ole — Chart 와 같은 축(own-field caption).
+        use crate::model::shape::{Caption, OleShape, ShapeObject};
+        const ID: u16 = 27;
+        let mut ole = OleShape::default();
+        ole.caption = Some(Caption {
+            paragraphs: paragraphs_with_table(ID),
+            ..Default::default()
+        });
+        let doc = doc_with_top_control(Control::Shape(Box::new(ShapeObject::Ole(Box::new(ole)))));
+        let ctx = SerializeContext::collect_from_document(&doc);
+        assert!(
+            ctx.border_fill_ids.is_registered(&ID),
+            "Ole.caption 안의 표 border_fill_id도 사전 등록되어야 한다"
+        );
+    }
+
+    #[test]
+    fn control_picture_caption_border_fill_id_registered() {
+        // 독립 그림 컨트롤(Control::Picture) — ShapeObject::Picture 와 별개 축.
+        // 종전 코드는 Control::Picture 자체를 재귀 match 에서 다루지 않았다.
+        use crate::model::image::Picture;
+        use crate::model::shape::Caption;
+        const ID: u16 = 28;
+        let mut pic = Picture::default();
+        pic.caption = Some(Caption {
+            paragraphs: paragraphs_with_table(ID),
+            ..Default::default()
+        });
+        let doc = doc_with_top_control(Control::Picture(Box::new(pic)));
+        let ctx = SerializeContext::collect_from_document(&doc);
+        assert!(
+            ctx.border_fill_ids.is_registered(&ID),
+            "Control::Picture.caption 안의 표 border_fill_id도 사전 등록되어야 한다"
+        );
+    }
+
+    #[test]
+    fn hidden_comment_border_fill_id_registered() {
+        // 숨은 설명(HiddenComment) — 화면에 안 보여도 파일에는 문단 리스트로 존재한다.
+        use crate::model::control::HiddenComment;
+        const ID: u16 = 29;
+        let hc = HiddenComment {
+            paragraphs: paragraphs_with_table(ID),
+        };
+        let doc = doc_with_top_control(Control::HiddenComment(Box::new(hc)));
+        let ctx = SerializeContext::collect_from_document(&doc);
+        assert!(
+            ctx.border_fill_ids.is_registered(&ID),
+            "HiddenComment 안의 표 border_fill_id도 사전 등록되어야 한다"
+        );
+    }
+
+    #[test]
+    fn field_memo_paragraphs_border_fill_id_registered() {
+        // 필드(누름틀 등) 메모 — `Field.memo_paragraphs`.
+        use crate::model::control::Field;
+        const ID: u16 = 30;
+        let field = Field {
+            memo_paragraphs: paragraphs_with_table(ID),
+            ..Default::default()
+        };
+        let doc = doc_with_top_control(Control::Field(field));
+        let ctx = SerializeContext::collect_from_document(&doc);
+        assert!(
+            ctx.border_fill_ids.is_registered(&ID),
+            "Field.memo_paragraphs 안의 표 border_fill_id도 사전 등록되어야 한다"
+        );
     }
 
     #[test]

--- a/src/serializer/hwpx/context.rs
+++ b/src/serializer/hwpx/context.rs
@@ -162,21 +162,12 @@ impl SerializeContext {
         }
 
         // 인라인 컨트롤(표/그림 등)의 borderFillIDRef를 사전 등록하여
-        // assert_all_refs_resolved 검증 시 누락 방지.
+        // assert_all_refs_resolved 검증 시 누락 방지. 중첩 표(셀 안의 표)와
+        // 글상자·머리말/꼬리말·각주/미주 안의 표까지 재귀한다(아래
+        // `register_border_fills_in_paragraphs` 참조, `table_extract::collect_from_paragraph`
+        // 와 같은 위상의 재귀).
         for sec in &doc.sections {
-            for para in &sec.paragraphs {
-                for ctrl in &para.controls {
-                    if let Control::Table(tbl) = ctrl {
-                        ctx.border_fill_ids.register(tbl.border_fill_id);
-                        for zone in &tbl.zones {
-                            ctx.border_fill_ids.register(zone.border_fill_id);
-                        }
-                        for cell in &tbl.cells {
-                            ctx.border_fill_ids.register(cell.border_fill_id);
-                        }
-                    }
-                }
-            }
+            register_border_fills_in_paragraphs(&mut ctx, &sec.paragraphs, 0);
         }
 
         // BinData: bin_data_content의 storage_id → manifest 엔트리 생성.
@@ -328,6 +319,71 @@ impl SerializeContext {
     }
 }
 
+/// 재귀 스캔 최대 깊이 — `table_extract::MAX_NEST_DEPTH` 와 같은 값.
+/// 순환 참조가 없는 정상 IR에서는 닿지 않고, 적대적/손상 입력에서 무한 재귀를 막는다.
+const MAX_BORDER_FILL_SCAN_DEPTH: usize = 8;
+
+/// 표 하나의 `border_fill_id`(표/영역/셀)를 등록한다.
+fn register_table_border_fills(ctx: &mut SerializeContext, table: &crate::model::table::Table) {
+    ctx.border_fill_ids.register(table.border_fill_id);
+    for zone in &table.zones {
+        ctx.border_fill_ids.register(zone.border_fill_id);
+    }
+    for cell in &table.cells {
+        ctx.border_fill_ids.register(cell.border_fill_id);
+    }
+}
+
+/// 문단 목록을 재귀하며 표(및 중첩 표)의 `border_fill_id`를 사전 등록한다.
+///
+/// `table_extract::collect_from_paragraph`/`nested_tables`(#3719 계열 표 추출)와 같은
+/// 위상의 재귀 — 표 셀 안의 표(중첩 표), 글상자, 머리말/꼬리말, 각주/미주까지 내려간다.
+/// 종전에는 `doc.sections[].paragraphs[]`의 최상위 `Control::Table`만 훑어 셀 안에 중첩된
+/// 표나 글상자·머리말/꼬리말·각주/미주 안의 표의 `border_fill_id`가 등록에서 빠졌다.
+/// 그 표가 실제 직렬화(`table.rs`의 `reference()` 호출)에서 참조되면
+/// `assert_all_refs_resolved`가 "미등록 ID 참조 발견"으로 하드 실패해 문서 전체의
+/// `export-hwpx`가 산출물 없이 실패했다(실측: 정부 보고서 표 107개 중 중첩 표 1개를 가진
+/// 문서에서 `borderFillIDRef: [0]` 미등록으로 재현).
+fn register_border_fills_in_paragraphs(
+    ctx: &mut SerializeContext,
+    paragraphs: &[crate::model::paragraph::Paragraph],
+    depth: usize,
+) {
+    if depth >= MAX_BORDER_FILL_SCAN_DEPTH {
+        return;
+    }
+    for para in paragraphs {
+        for ctrl in &para.controls {
+            match ctrl {
+                Control::Table(tbl) => {
+                    register_table_border_fills(ctx, tbl);
+                    for cell in &tbl.cells {
+                        register_border_fills_in_paragraphs(ctx, &cell.paragraphs, depth + 1);
+                    }
+                }
+                Control::Shape(shape) => {
+                    if let Some(tb) = shape.drawing().and_then(|d| d.text_box.as_ref()) {
+                        register_border_fills_in_paragraphs(ctx, &tb.paragraphs, depth + 1);
+                    }
+                }
+                Control::Header(h) => {
+                    register_border_fills_in_paragraphs(ctx, &h.paragraphs, depth + 1);
+                }
+                Control::Footer(f) => {
+                    register_border_fills_in_paragraphs(ctx, &f.paragraphs, depth + 1);
+                }
+                Control::Footnote(f) => {
+                    register_border_fills_in_paragraphs(ctx, &f.paragraphs, depth + 1);
+                }
+                Control::Endnote(e) => {
+                    register_border_fills_in_paragraphs(ctx, &e.paragraphs, depth + 1);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
 fn mime_from_ext(ext: &str) -> &'static str {
     match ext.to_ascii_lowercase().as_str() {
         "png" => "image/png",
@@ -394,6 +450,60 @@ mod tests {
             !ctx.numbering_ids.is_registered(&0),
             "0 은 1-based 축에 없음 (회귀 가드)"
         );
+    }
+
+    #[test]
+    fn nested_table_border_fill_id_registered() {
+        // 실측(정부 보고서, 표 107개 중 1개가 셀 안에 표를 담은 문서)에서 재현: 종전에는
+        // `doc.sections[].paragraphs[]`의 최상위 `Control::Table`만 훑어 셀 안에 중첩된
+        // 표의 `border_fill_id`가 등록에서 빠졌다. 그 표가 실제 직렬화에서 참조되면
+        // `assert_all_refs_resolved`가 "미등록 ID 참조 발견"으로 하드 실패해 문서 전체의
+        // `export-hwpx`가 산출물 없이 실패했다 — 이 테스트는 그 등록 누락의 회귀 가드다.
+        use crate::model::paragraph::Paragraph;
+        use crate::model::table::{Cell, Table};
+
+        const OUTER_BORDER_FILL_ID: u16 = 1;
+        const INNER_BORDER_FILL_ID: u16 = 2; // outer와 달라 별도 등록이 필요함을 보장.
+
+        let mut inner_table = Table::default();
+        inner_table.border_fill_id = INNER_BORDER_FILL_ID;
+        inner_table.row_count = 1;
+        inner_table.col_count = 1;
+        inner_table.cells = vec![Cell::new_empty(0, 0, 1000, 1000, INNER_BORDER_FILL_ID)];
+
+        let mut outer_cell = Cell::new_empty(0, 0, 5000, 5000, OUTER_BORDER_FILL_ID);
+        outer_cell.paragraphs = vec![{
+            let mut p = Paragraph::new_empty();
+            p.controls.push(Control::Table(Box::new(inner_table)));
+            p
+        }];
+
+        let mut outer_table = Table::default();
+        outer_table.border_fill_id = OUTER_BORDER_FILL_ID;
+        outer_table.row_count = 1;
+        outer_table.col_count = 1;
+        outer_table.cells = vec![outer_cell];
+
+        let mut doc = Document::default();
+        let mut para = Paragraph::new_empty();
+        para.controls.push(Control::Table(Box::new(outer_table)));
+        doc.sections = vec![crate::model::document::Section {
+            paragraphs: vec![para],
+            ..Default::default()
+        }];
+
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        assert!(
+            ctx.border_fill_ids.is_registered(&INNER_BORDER_FILL_ID),
+            "중첩 표(셀 안의 표)의 border_fill_id도 사전 등록되어야 한다"
+        );
+
+        // table.rs 의 실제 직렬화 경로와 동형: 중첩 표가 참조하는 시점을 재현해도
+        // assert_all_refs_resolved 가 통과해야 한다(수정 전에는 여기서 실패했다).
+        ctx.border_fill_ids.reference(OUTER_BORDER_FILL_ID);
+        ctx.border_fill_ids.reference(INNER_BORDER_FILL_ID);
+        ctx.assert_all_refs_resolved()
+            .expect("중첩 표 border_fill_id 참조가 미등록으로 남으면 안 된다");
     }
 
     #[test]


### PR DESCRIPTION
`SerializeContext::collect_from_document` 이 `doc.sections[].paragraphs[]` 의 최상위 `Control::Table` 만 훑어, 셀 안에 중첩된 표나 글상자·머리말/꼬리말·각주/미주 안의 표의 `border_fill_id` 가 등록에서 빠집니다. 그 표가 실제 직렬화에서 참조되면 `assert_all_refs_resolved` 가 하드 실패해 **문서 전체의 export-hwpx 가 산출물 없이 죽습니다.**

`samples/` 400개와 실사용 문서 6,582개를 합친 6,982건 HWP→HWPX→HWP 왕복 스윕에서 중첩 표를 가진 정부 보고서 1건이 이 경로로 크래시했습니다.

수집을 `table_extract::collect_from_paragraph` 와 같은 위상의 재귀(`register_border_fills_in_paragraphs`)로 교체했습니다. 깊이 상한은 `table_extract::MAX_NEST_DEPTH` 와 같은 값입니다. 문단 리스트를 소유하는 8개 지점(Table 셀, Shape 텍스트박스, Header, Footer, Footnote, Endnote, Caption, Field 메모, HiddenComment)과 `GroupShape.children` 을 모두 순회합니다. 캡션은 변형마다 필드가 달라 — 기본 도형은 `drawing.caption`, Group/Picture/Chart/OLE 는 자기 `caption`(파서가 `.take()` 로 옮깁니다, `parser/control/shape.rs:213`) — 양쪽을 모두 확인합니다.

소유자별 단위 테스트 9건과 실제 `serialize_hwpx` 를 물리는 end-to-end 1건을 추가했고, 전부 수정 전 코드로 되돌려 실패를 확인했습니다(e2e 는 `미등록 ID 참조 발견: borderFillIDRef: [121]`).

한계를 밝힙니다 — 코퍼스를 `<hp:caption>…<hp:tbl` 로 재스캔해 실제 문서 2건을 찾았지만 둘 다 `border_fill_id` 가 우연히 전역 등록 범위 안에 들어 수정 전에도 통과합니다. **코드 경로상 누락은 단위 테스트가 직접 증명하지만 실 코퍼스 크래시 재현은 실패했습니다.**

`src/serializer/hwpx/context.rs` 는 #4409 와 같은 파일입니다. 논리 충돌은 없으나 나중에 머지되는 쪽이 리베이스가 필요합니다. 같은 순회 로직이 저장소 안에 여러 벌 존재하는 문제는 #4422 로 따로 열었습니다.

Closes #4408
