### PR TITLE
serializer(hwpx): hp:arc 의 type 속성 왕복 + 표현 불가 컨트롤의 조용한 손실에 경고

### DIFF
--- a/mydocs/working/task_m100_4388_stage1.md
+++ b/mydocs/working/task_m100_4388_stage1.md
@@ -1,0 +1,61 @@
+# task_m100_4388 Stage 1 — HWPX 직렬화의 조용한 컨트롤 손실
+
+- **이슈**: [#4388](https://github.com/edwardkim/rhwp/issues/4388)
+- **브랜치**: `fix/issue-4388-hwpx-silent-drops`
+- **분기 기준**: `upstream/devel` (0 behind)
+- **상태**: 게이트 전부 통과, PR 게시
+- **기록일**: 2026-08-10 KST
+
+## 1. 이슈 진술의 정정
+
+원 이슈는 도형 곡선 속성을 `arcType` 으로 적었으나 OWPML 상 실제 속성명은 **`type`** 이다
+(`ParaList XML schema.xml`). 또 "HWP5 는 왕복이 된다"고 적었는데 확인 결과 HWP5 축도 별개 결함이
+있었다 — 아래 4절.
+
+## 2. 고친 것
+
+1. **`hp:arc` 의 `type` 속성** — 파서가 읽지 않고 직렬화기가 쓰지 않아 곡선/부채꼴 구분이
+   HWPX 왕복에서 사라졌다. `parser/hwpx/section.rs` 와 `serializer/hwpx/section.rs` 양쪽에 추가.
+2. **조용한 손실에 경고** — 직렬화기가 표현할 수 없는 컨트롤을 만나면 아무 말 없이 버렸다.
+   `warn_if_unrepresentable_in_hwpx` 헬퍼를 만들어 두 지점에서 호출한다.
+
+## 3. 리뷰가 잡은 것 — 슬롯 등록과 경고를 분리해야 했다
+
+첫 수정은 `Control::Hyperlink`/`Control::Unknown` 을 `is_hwpx_inline_slot` 에 등록해 손실을
+드러내려 했다. **이것이 무관한 회귀 테스트 `bookmarks_survive_saving_to_hwp5` 를 깨뜨렸다.**
+
+`is_hwpx_inline_slot` 은 소비처가 둘이다 — `render_runs`(HWPX 슬롯 위치 축)와
+`roundtrip::diff_documents`(**포맷 비종속** IR 비교로, `convert`(HWP5 대상) `--verify` 도 그대로
+재사용한다). Hyperlink 를 등록하자 `diff_documents` 가 HWP5 경로의 **기존** 하이퍼링크 손실을
+새로 검출하기 시작했다. HWPX 축 수정이 HWP5 축 테스트를 깬 것이다.
+
+등록을 되돌리고, 경고는 `is_hwpx_inline_slot` 과 무관하게 두 분기
+(`render_control_slot` 의 catch-all, `render_runs` 의 필터 배제 지점) 모두에서 직접 호출하도록
+바꿨다. 재등록을 막는 회귀 가드를 **반대 방향 단언**으로 넣었다 —
+`issue4388_diff_documents_{hyperlink,unknown}_not_compared_as_control` 는 "diff 가 검출하면
+안 된다"를 확인해 누가 다시 등록하면 즉시 RED 다.
+
+## 4. 이 작업에서 고치지 않은 것
+
+`hwp3-sample16.hwp` 의 손실 4건(`s0` 문단 27/32/196/657)은 덤프 결과 **전부
+`Control::Hyperlink`** 였다. `Control::Unknown` 은 이 문서에 하나도 없었다.
+
+원인은 `serializer/body_text.rs:850` 의 `Control::Hyperlink(_) => (0x000B, 0)` 다. `ctrl_id` 가
+0 이라 `serializer/control.rs:177` 이 CTRL_HEADER 를 아예 안 만드는데 본문에는 0x000B 가
+들어간다 — 뒤따르는 컨트롤 짝짓기가 한 칸씩 밀린다.
+
+**HWP5 직렬화기의 기존 결함이고 이 이슈 범위(HWPX 축) 밖이라 손대지 않았다.**
+[#4424](https://github.com/edwardkim/rhwp/issues/4424) 로 따로 열었다. 같은 arm 의
+`Control::Ruby` 는 #4397 이다.
+
+## 5. 검증 (완료)
+
+- `bookmarks_survive_saving_to_hwp5` 2/2 통과.
+- `issue4388_*` 4종(신규 2 + 기존 2 축소) 전부 통과, 경고 stderr 출력 확인.
+- `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests --no-fail-fast` —
+  바이너리 498개 전부 `test result: ok`, **FAILED 0건**.
+- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` 통과.
+
+## 6. 미처리
+
+GitHub Actions, 작업지시자 승인, merge.

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -3543,6 +3543,24 @@ fn parse_connect_line_type_attr(e: &quick_xml::events::BytesStart) -> LinkLineTy
     LinkLineType::StraightNoArrow
 }
 
+/// [#4388] `<hp:arc>` 전용 `type` 속성 (OWPML `CArcType::WriteElement` —
+/// hancom-io/hwpx-owpml-model `ArcType.cpp`) — `g_ArcTypeList`: NORMAL(0)/PIE(1)/CHORD(2).
+/// `ArcShape.arc_type` (0: Arc, 1: CircularSector, 2: Bow) 와 1:1 대응. 같은 이름의
+/// `type` 속성이 `<hp:connectLine>`(연결선 화살표 종류) 등 다른 도형 태그에도 쓰이므로
+/// 반드시 `<hp:arc>` 요소 자체(shape_type == b"arc")에서만 호출한다.
+fn parse_arc_type_attr(e: &quick_xml::events::BytesStart) -> u8 {
+    for attr in e.attributes().flatten() {
+        if attr.key.as_ref() == b"type" {
+            return match attr_str(&attr).to_ascii_uppercase().as_str() {
+                "PIE" => 1,
+                "CHORD" => 2,
+                _ => 0,
+            };
+        }
+    }
+    0
+}
+
 /// shape 내부의 `<hp:fillBrush>` 자식 요소를 파싱하여 Fill을 반환한다.
 fn parse_shape_fill_brush(reader: &mut Reader<&[u8]>) -> Result<Fill, HwpxError> {
     use crate::model::style::{FillType, GradientFill, ImageFill, ImageFillMode, SolidFill};
@@ -3867,6 +3885,13 @@ fn parse_shape_object(
 
     let object_ids = parse_object_element_attrs(e, &mut common, &mut shape_attr);
     let connect_line_type = parse_connect_line_type_attr(e);
+    // [#4388] `<hp:arc>` 전용 `type` 속성 — 다른 태그의 동명 `type` 속성과
+    // 섞이지 않도록 shape_type == b"arc" 로 한정한다.
+    let arc_type = if shape_type == b"arc" {
+        parse_arc_type_attr(e)
+    } else {
+        0
+    };
     let mut connect_start_subject_id = 0_u32;
     let mut connect_start_subject_index = 0_u32;
     let mut connect_end_subject_id = 0_u32;
@@ -4132,11 +4157,13 @@ fn parse_shape_object(
         b"arc" => ShapeObject::Arc(ArcShape {
             common,
             drawing,
-            // [Task #1598] 호 전용 지오메트리(center/축). arc_type 은 태그속성(추후).
+            // [Task #1598] 호 전용 지오메트리(center/축).
+            // [#4388] arc_type 은 `<hp:arc>` 자체의 `type` 속성(NORMAL/PIE/CHORD) —
+            // 태그속성으로 읽는다(hancom-io/hwpx-owpml-model `ArcType.cpp` 확인).
+            arc_type,
             center: e_center,
             axis1: e_axis1,
             axis2: e_axis2,
-            ..Default::default()
         }),
         b"polygon" => ShapeObject::Polygon(PolygonShape {
             common,

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -865,21 +865,27 @@ mod tests {
     fn issue4388_hyperlink_control_drop_is_not_silent() {
         // [#4388] `Control::Hyperlink` 는 HWP3 파서만 생성하는 legacy IR 이며 HWPX 는
         // 대응 표현이 없다(HWPX 는 하이퍼링크를 Field(HYPERLINK) 로 표현). 종전엔
-        // `render_control_slot` 의 catch-all `_ => {}` 로 떨어져 **경고도 없이** 사라졌고,
-        // `--verify` 재파싱 비교도 `is_hwpx_inline_slot` 에 등록돼 있지 않아 이 손실을
-        // 검출하지 못했다(이중 침묵). 수정 전: 두 번째 assert(ParagraphControls 검출)가
-        // RED(빈 diff — 손실을 놓침). 수정 후: 컨트롤은 여전히 드롭되지만(HWPX 로 안전
-        // 하게 변환할 방법이 없음) `is_hwpx_inline_slot` 등록으로 diff 가 손실을 검출한다.
+        // `render_control_slot` 의 catch-all `_ => {}` 로 떨어져 **경고도 없이** 사라졌다.
+        // 이 테스트는 "드롭 자체"만 확인한다 — 드롭이 실제로 조용하지 않은지(stderr
+        // 경고)는 이 코드베이스의 기존 관례상 단위 테스트로 캡처하지 않는다(Table/
+        // Picture/Field 직렬화 실패 eprintln! 도 동일). `warn_if_unrepresentable_in_hwpx`
+        // (section.rs)가 실제 경고를 담당한다.
+        //
+        // [#4388 후속] `--verify` 가 이 손실을 검출해야 한다는 조건은 **되돌렸다** —
+        // `is_hwpx_inline_slot` 에 Hyperlink 를 등록했더니 그 목록을 공유하는
+        // `roundtrip::diff_documents`(포맷 비종속, `convert`(HWP5 대상) `--verify` 도
+        // 재사용)가 HWP5 직렬화기의 기존(이슈 범위 밖) Hyperlink 손실까지 새로
+        // "검출"해 `tests/issue_hwp3_bookmark_native.rs::bookmarks_survive_saving_to_hwp5`
+        // 가 hwp3-sample16.hwp 에서 깨졌다(실측 재현). 그 회귀 가드는
+        // `roundtrip.rs::issue4388_diff_documents_hyperlink_not_compared_as_control` 로
+        // 옮겼다 — "diff 가 검출해야 함"이 아니라 "diff 가 검출하면 안 됨"으로 반전.
         use crate::model::control::{Control, Hyperlink};
         use crate::model::paragraph::CharShapeRef;
         use crate::model::style::CharShape;
-        use crate::serializer::hwpx::roundtrip::IrDifference;
 
         let mut doc = Document::default();
         // char_shapes[0] 을 등록해 char_shape_id=0 참조가 유효하도록 한다(그렇지
-        // 않으면 직렬화가 "미등록 ID 참조" 로 실패). 값도 명시해 빈 char_shapes 문단이
-        // reparse 시 (0,0) 을 합성하는 무관한 사전조건 diff(#1592 인접 관례)가 섞여
-        // 아래 diff 단언이 우연히 통과하지 않도록 한다.
+        // 않으면 직렬화가 "미등록 ID 참조" 로 실패).
         doc.doc_info.char_shapes.push(CharShape::default());
         let mut section = crate::model::document::Section::default();
         let mut para = crate::model::paragraph::Paragraph::default();
@@ -911,21 +917,13 @@ mod tests {
             doc2.sections[0].paragraphs[0].controls
         );
 
-        // 핵심 회귀 방지: --verify 가 쓰는 diff_documents 가 이 손실을 실제로
-        // `ParagraphControls` 차이로 검출해야 한다(단순 "diff 가 비어있지 않다" 는
-        // 무관한 다른 필드의 우연한 diff 로도 통과할 수 있어 불충분). is_hwpx_inline_slot
-        // 에 Hyperlink 를 등록하지 않으면 이 diff 자체가 비어(빈 Vec) 손실을 놓친다 —
-        // #4388 이 지적한 "조용한 손실"의 두 번째 축(직렬화 드롭 + 검증 사각지대).
-        let diff = crate::serializer::hwpx::roundtrip::diff_documents(&doc, &doc2);
-        let has_controls_diff = diff
-            .differences
-            .iter()
-            .any(|d| matches!(d, IrDifference::ParagraphControls { .. }));
+        // [#4388 후속] is_hwpx_inline_slot 미등록 회귀 가드 — 등록하면 mismatch-분기
+        // (render_runs) 가 이 컨트롤을 슬롯으로 취급해 위치 축이 바뀐다.
         assert!(
-            has_controls_diff,
-            "diff_documents(--verify 경로)가 Hyperlink 컨트롤 손실을 ParagraphControls 로 \
-             검출해야 함: {:?}",
-            diff.differences
+            !crate::serializer::hwpx::section::is_hwpx_inline_slot(&Control::Hyperlink(
+                Hyperlink::default()
+            )),
+            "Hyperlink 는 is_hwpx_inline_slot 에 등록되면 안 됨(#4388 후속 회귀 참조)"
         );
     }
 
@@ -936,13 +934,15 @@ mod tests {
         // 파서는 이 변형을 절대 만들지 않는다 — grep 확인), HWP5 PARA_TEXT 는 그 자리를
         // Table/Picture 와 같은 0x000B 확장 컨트롤 문자(8유닛)로 표시한다. HWPX 는 "인식
         // 못 한 컨트롤"을 표현할 수단이 없고 `UnknownControl` 은 ctrl_id 하나만 보존해
-        // 원본 바이트도 없다 — 변환 불가가 맞다. 다만 종전엔 catch-all 로 떨어져
-        // **경고 없이** 사라졌고 `--verify` 도 놓쳤다. Hyperlink 테스트와 동일하게 두
-        // 축(드롭 자체 + verify 검출)을 함께 확인한다.
+        // 원본 바이트도 없다 — 변환 불가가 맞다. 종전엔 catch-all 로 떨어져 **경고
+        // 없이** 사라졌다 — 이제 `warn_if_unrepresentable_in_hwpx` 가 경고한다(stderr
+        // 캡처는 Hyperlink 테스트와 동일한 이유로 이 테스트에서 확인하지 않는다).
+        //
+        // [#4388 후속] Hyperlink 와 동일하게 --verify 검출 요구는 되돌렸다 — 이유와
+        // 회귀 가드는 `roundtrip.rs::issue4388_diff_documents_unknown_not_compared_as_control`.
         use crate::model::control::{Control, UnknownControl};
         use crate::model::paragraph::CharShapeRef;
         use crate::model::style::CharShape;
-        use crate::serializer::hwpx::roundtrip::IrDifference;
 
         let mut doc = Document::default();
         doc.doc_info.char_shapes.push(CharShape::default());
@@ -977,16 +977,11 @@ mod tests {
             doc2.sections[0].paragraphs[0].controls
         );
 
-        let diff = crate::serializer::hwpx::roundtrip::diff_documents(&doc, &doc2);
-        let has_controls_diff = diff
-            .differences
-            .iter()
-            .any(|d| matches!(d, IrDifference::ParagraphControls { .. }));
         assert!(
-            has_controls_diff,
-            "diff_documents(--verify 경로)가 Unknown 컨트롤 손실을 ParagraphControls 로 \
-             검출해야 함: {:?}",
-            diff.differences
+            !crate::serializer::hwpx::section::is_hwpx_inline_slot(&Control::Unknown(
+                UnknownControl::default()
+            )),
+            "Unknown 은 is_hwpx_inline_slot 에 등록되면 안 됨(#4388 후속 회귀 참조)"
         );
     }
 

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -862,6 +862,135 @@ mod tests {
     }
 
     #[test]
+    fn issue4388_hyperlink_control_drop_is_not_silent() {
+        // [#4388] `Control::Hyperlink` 는 HWP3 파서만 생성하는 legacy IR 이며 HWPX 는
+        // 대응 표현이 없다(HWPX 는 하이퍼링크를 Field(HYPERLINK) 로 표현). 종전엔
+        // `render_control_slot` 의 catch-all `_ => {}` 로 떨어져 **경고도 없이** 사라졌고,
+        // `--verify` 재파싱 비교도 `is_hwpx_inline_slot` 에 등록돼 있지 않아 이 손실을
+        // 검출하지 못했다(이중 침묵). 수정 전: 두 번째 assert(ParagraphControls 검출)가
+        // RED(빈 diff — 손실을 놓침). 수정 후: 컨트롤은 여전히 드롭되지만(HWPX 로 안전
+        // 하게 변환할 방법이 없음) `is_hwpx_inline_slot` 등록으로 diff 가 손실을 검출한다.
+        use crate::model::control::{Control, Hyperlink};
+        use crate::model::paragraph::CharShapeRef;
+        use crate::model::style::CharShape;
+        use crate::serializer::hwpx::roundtrip::IrDifference;
+
+        let mut doc = Document::default();
+        // char_shapes[0] 을 등록해 char_shape_id=0 참조가 유효하도록 한다(그렇지
+        // 않으면 직렬화가 "미등록 ID 참조" 로 실패). 값도 명시해 빈 char_shapes 문단이
+        // reparse 시 (0,0) 을 합성하는 무관한 사전조건 diff(#1592 인접 관례)가 섞여
+        // 아래 diff 단언이 우연히 통과하지 않도록 한다.
+        doc.doc_info.char_shapes.push(CharShape::default());
+        let mut section = crate::model::document::Section::default();
+        let mut para = crate::model::paragraph::Paragraph::default();
+        para.text = "ab".to_string();
+        para.char_offsets = vec![0, 9];
+        para.char_count = 11; // (11-1-2)/8 = 1 슬롯 (task1587_ruby_control_roundtrips 와 동일 관례)
+        para.char_shapes = vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 0,
+        }];
+        para.controls.push(Control::Hyperlink(Hyperlink {
+            url: "http://example.com".to_string(),
+            text: "example".to_string(),
+        }));
+        section.paragraphs.push(para);
+        doc.sections.push(section);
+
+        let bytes = serialize_hwpx(&doc).expect("serialize hyperlink");
+        let doc2 = crate::parser::hwpx::parse_hwpx(&bytes).expect("parse");
+
+        let hyperlinks_after: Vec<_> = doc2.sections[0].paragraphs[0]
+            .controls
+            .iter()
+            .filter(|c| matches!(c, Control::Hyperlink(_)))
+            .collect();
+        assert!(
+            hyperlinks_after.is_empty(),
+            "Hyperlink 는 HWPX 로 안전하게 변환할 대응 표현이 없어 드롭되는 것이 현재 계약이다: {:?}",
+            doc2.sections[0].paragraphs[0].controls
+        );
+
+        // 핵심 회귀 방지: --verify 가 쓰는 diff_documents 가 이 손실을 실제로
+        // `ParagraphControls` 차이로 검출해야 한다(단순 "diff 가 비어있지 않다" 는
+        // 무관한 다른 필드의 우연한 diff 로도 통과할 수 있어 불충분). is_hwpx_inline_slot
+        // 에 Hyperlink 를 등록하지 않으면 이 diff 자체가 비어(빈 Vec) 손실을 놓친다 —
+        // #4388 이 지적한 "조용한 손실"의 두 번째 축(직렬화 드롭 + 검증 사각지대).
+        let diff = crate::serializer::hwpx::roundtrip::diff_documents(&doc, &doc2);
+        let has_controls_diff = diff
+            .differences
+            .iter()
+            .any(|d| matches!(d, IrDifference::ParagraphControls { .. }));
+        assert!(
+            has_controls_diff,
+            "diff_documents(--verify 경로)가 Hyperlink 컨트롤 손실을 ParagraphControls 로 \
+             검출해야 함: {:?}",
+            diff.differences
+        );
+    }
+
+    #[test]
+    fn issue4388_unknown_control_drop_is_not_silent() {
+        // [#4388] catch-all 전수 census 중 Hyperlink 와 동형인 두 번째 사례. HWP5/HWP3
+        // 바이너리 파서가 인식하지 못한 ctrl_id 는 `Control::Unknown` 으로 남는데(HWPX
+        // 파서는 이 변형을 절대 만들지 않는다 — grep 확인), HWP5 PARA_TEXT 는 그 자리를
+        // Table/Picture 와 같은 0x000B 확장 컨트롤 문자(8유닛)로 표시한다. HWPX 는 "인식
+        // 못 한 컨트롤"을 표현할 수단이 없고 `UnknownControl` 은 ctrl_id 하나만 보존해
+        // 원본 바이트도 없다 — 변환 불가가 맞다. 다만 종전엔 catch-all 로 떨어져
+        // **경고 없이** 사라졌고 `--verify` 도 놓쳤다. Hyperlink 테스트와 동일하게 두
+        // 축(드롭 자체 + verify 검출)을 함께 확인한다.
+        use crate::model::control::{Control, UnknownControl};
+        use crate::model::paragraph::CharShapeRef;
+        use crate::model::style::CharShape;
+        use crate::serializer::hwpx::roundtrip::IrDifference;
+
+        let mut doc = Document::default();
+        doc.doc_info.char_shapes.push(CharShape::default());
+        let mut section = crate::model::document::Section::default();
+        let mut para = crate::model::paragraph::Paragraph::default();
+        // "a" + 오브젝트 마커(U+FFFC) + "b" — Table/Picture 와 동일한 8유닛 슬롯 관례.
+        para.text = "a\u{fffc}b".to_string();
+        para.char_offsets = vec![0, 1, 9];
+        para.char_count = 11; // 1(a) + 8(obj) + 1(b) + 1(종단 관례) = 11
+        para.char_shapes = vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 0,
+        }];
+        para.controls.push(Control::Unknown(UnknownControl {
+            ctrl_id: 0x1234_5678,
+        }));
+        section.paragraphs.push(para);
+        doc.sections.push(section);
+
+        let bytes = serialize_hwpx(&doc).expect("serialize unknown");
+        let doc2 = crate::parser::hwpx::parse_hwpx(&bytes).expect("parse");
+
+        let unknowns_after: Vec<_> = doc2.sections[0].paragraphs[0]
+            .controls
+            .iter()
+            .filter(|c| matches!(c, Control::Unknown(_)))
+            .collect();
+        assert!(
+            unknowns_after.is_empty(),
+            "Unknown 컨트롤은 HWPX 로 변환할 대응 표현·원본 바이트가 없어 드롭되는 것이 \
+             현재 계약이다: {:?}",
+            doc2.sections[0].paragraphs[0].controls
+        );
+
+        let diff = crate::serializer::hwpx::roundtrip::diff_documents(&doc, &doc2);
+        let has_controls_diff = diff
+            .differences
+            .iter()
+            .any(|d| matches!(d, IrDifference::ParagraphControls { .. }));
+        assert!(
+            has_controls_diff,
+            "diff_documents(--verify 경로)가 Unknown 컨트롤 손실을 ParagraphControls 로 \
+             검출해야 함: {:?}",
+            diff.differences
+        );
+    }
+
+    #[test]
     fn task1591_bookmark_not_hoisted_before_slot() {
         // [#1591] 북마크가 슬롯 컨트롤(표 등) 뒤에 있을 때, 직렬화기가 북마크를 문단
         // 시작으로 hoisting 하면 컨트롤 순서가 뒤바뀐다. [#1591 v2] 슬롯 있는 문단의

--- a/src/serializer/hwpx/roundtrip.rs
+++ b/src/serializer/hwpx/roundtrip.rs
@@ -1846,6 +1846,47 @@ mod tests {
     }
 
     #[test]
+    fn issue4388_diff_documents_hyperlink_not_compared_as_control() {
+        // [#4388 후속] Hyperlink 도 Bookmark 와 동형으로 비교 제외해야 한다.
+        // is_hwpx_inline_slot 에 한때 등록했다가 되돌린 회귀 가드 — 등록하면
+        // `roundtrip::diff_documents`(포맷 비종속, `convert`(HWP5 대상) `--verify` 도
+        // 재사용)가 HWP5 직렬화기의 기존(이슈 범위 밖) Hyperlink ctrl_id=0 고정 손실을
+        // 새로 "검출"해, hwp3-sample16.hwp 를 쓰는
+        // `tests/issue_hwp3_bookmark_native.rs::bookmarks_survive_saving_to_hwp5` 처럼
+        // 하이퍼링크와 무관한 기존 테스트가 깨진다(실측 확인됨). Hyperlink 가
+        // 사라져도 diff 가 비어 있어야 한다 — HWPX 직렬화기 자체의 드롭 경고는
+        // `warn_if_unrepresentable_in_hwpx` 가 별도로 담당(section.rs).
+        use crate::model::control::{Control, Hyperlink};
+
+        let mut a = doc_with_control(Control::Hyperlink(Hyperlink {
+            url: "http://example.com".to_string(),
+            text: "example".to_string(),
+        }));
+        a.sections[0].paragraphs[0].controls.push(picture_control());
+        let b = doc_with_control(picture_control());
+        assert!(
+            diff_documents(&a, &b).is_empty(),
+            "Hyperlink 손실은 diff_documents 비교에서 제외되어야 함(is_hwpx_inline_slot 미등록)"
+        );
+    }
+
+    #[test]
+    fn issue4388_diff_documents_unknown_not_compared_as_control() {
+        // [#4388 후속] Unknown 도 동일 이유로 비교 제외.
+        use crate::model::control::{Control, UnknownControl};
+
+        let mut a = doc_with_control(Control::Unknown(UnknownControl {
+            ctrl_id: 0x1234_5678,
+        }));
+        a.sections[0].paragraphs[0].controls.push(picture_control());
+        let b = doc_with_control(picture_control());
+        assert!(
+            diff_documents(&a, &b).is_empty(),
+            "Unknown 손실은 diff_documents 비교에서 제외되어야 함(is_hwpx_inline_slot 미등록)"
+        );
+    }
+
+    #[test]
     fn diff_documents_same_cell_controls_is_empty() {
         let a = doc_with_control(table_control_with_cell_controls(vec![picture_control()]));
         let b = doc_with_control(table_control_with_cell_controls(vec![picture_control()]));

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -944,7 +944,16 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
                     hidden.push(i);
                     false
                 } else {
-                    is_hwpx_inline_slot(c)
+                    let slot = is_hwpx_inline_slot(c);
+                    // [#4388] Hyperlink/Unknown 은 슬롯이 아니라 여기서 조용히
+                    // 제외된다(Bookmark 와 같은 취급) — is_hwpx_inline_slot 에
+                    // 등록하지 않기로 한 대가로, 이 실제 배제 지점에서 직접
+                    // 경고한다. Bookmark/HiddenComment 등 다른 non-slot 컨트롤은
+                    // 이 헬퍼가 내부적으로 무시한다.
+                    if !slot {
+                        warn_if_unrepresentable_in_hwpx(c);
+                    }
+                    slot
                 };
                 if keep {
                     s.push(c);
@@ -1407,6 +1416,25 @@ fn inferred_control_slot_count(para: &Paragraph) -> usize {
         .saturating_sub(para.orphan_field_ends.len() as u32) as usize
 }
 
+/// HWPX 인라인 슬롯(U+FFFC 오브젝트 위치)을 점유하는 컨트롤인지 판정한다.
+///
+/// 이 목록은 두 곳에서 쓰인다: `render_runs`(이 파일, mismatch-분기 위치 축)와
+/// `roundtrip::diff_documents`(포맷 비종속 IR 비교 — `export-hwpx` **뿐 아니라**
+/// `convert`(HWP5 대상) `--verify` 도 재사용한다).
+///
+/// **[#4388] `Control::Hyperlink`/`Control::Unknown` 은 의도적으로 여기 등록하지
+/// 않는다.** 둘 다 HWP3/HWP5 PARA_TEXT 상에서는 Picture/Table 과 동형인 U+FFFC
+/// 오브젝트 슬롯(위치 점유)이라 처음엔 등록했으나, 등록하면 HWP5 직렬화기가 이미
+/// (이슈 범위 밖으로) Hyperlink 의 ctrl_id 를 0 으로 고정해 버려 CTRL_HEADER 자체를
+/// 안 쓰는 기존 HWP5 경로 손실까지 `diff_documents` 가 새로 "검출"해,
+/// `bookmarks_survive_saving_to_hwp5`(tests/issue_hwp3_bookmark_native.rs) 같이
+/// 하이퍼링크와 무관한 기존 회귀 테스트가 hwp3-sample16.hwp 에서 깨졌다(#4388 후속
+/// 보고, 실측 재현: s0 문단 27/32/196/657 이 전부 Hyperlink). "조용히 버리지
+/// 말라"는 경고 축이지 비교 축이 아니다 — 경고는 `render_control_slot` catch-all과
+/// `render_runs` 의 mismatch-분기 제외 지점(`warn_if_unrepresentable_in_hwpx` 호출)
+/// 두 곳에서 낸다. 회귀 가드: `roundtrip.rs` 의
+/// `issue4388_diff_documents_hyperlink_not_compared_as_control`/
+/// `issue4388_diff_documents_unknown_not_compared_as_control`.
 pub(crate) fn is_hwpx_inline_slot(control: &Control) -> bool {
     matches!(
         control,
@@ -1426,17 +1454,6 @@ pub(crate) fn is_hwpx_inline_slot(control: &Control) -> bool {
             | Control::Header(_)
             | Control::Footer(_)
             | Control::AutoNumber(_)
-            // [#4388] HWP3 유래 Hyperlink 도 Picture/Table 과 동형인 U+FFFC 오브젝트
-            // 슬롯이다(HWP3 파서가 문단 텍스트에 마커 1개를 넣고 controls 에 대응
-            // 컨트롤을 push — src/parser/hwp3/mod.rs). 슬롯으로 등록해야 (a) 다른
-            // 컨트롤과 섞인 문단에서 위치 정합이 일관되고, (b) `--verify` 재파싱
-            // 비교(`diff_paragraph_char_shapes`, roundtrip.rs)가 render_control_slot 의
-            // catch-all 드롭을 검출한다.
-            | Control::Hyperlink(_)
-            // [#4388] HWP5/HWP3 유래 Unknown 도 PARA_TEXT 상에서 0x000B 확장 컨트롤
-            // 문자(Table/Picture 와 동일 char class)로 위치를 점유한다. 슬롯 등록
-            // 이유는 Hyperlink 와 동일 — 위치 정합 + `--verify` 손실 검출.
-            | Control::Unknown(_)
     )
 }
 
@@ -1573,19 +1590,49 @@ fn render_control_slot(out: &mut String, control: &Control, ctx: &mut SerializeC
                 out.push_str(&render_col_pr_ctrl(cd));
             }
         }
-        // [#4388] `Control::Hyperlink` 는 현재 HWP3 파서만 생성하는 legacy IR
-        // 표현이다 (`src/parser/hwp3/mod.rs`) — HWP3 문서의 하이퍼링크는 Picture/
-        // Table 처럼 문단 텍스트에 U+FFFC 마커 1개를 점유하는 "오브젝트형" 슬롯이고,
-        // 표시 텍스트(`text`)는 para.text 가 아니라 컨트롤 자체에 별도 보존된다.
-        // 반면 HWPX 는 하이퍼링크를 `Control::Field(FieldType::Hyperlink)` 로 표현하며
-        // 이는 fieldBegin/fieldEnd 가 문단 텍스트의 실제 글자 범위를 감싸는 인라인
-        // 구조다 — 표시 텍스트가 파라그래프 문자 스트림 안에 있어야 한다는 뜻이라,
-        // 이 컨트롤을 그대로 Field 로 접었다간 문단을 재구성(문자 삽입 + char_shapes/
-        // line_segs 재계산)해야 해 안전하게 변환할 수 없다. 종전엔 catch-all
-        // `_ => {}` 로 떨어져 경고 없이 사라졌다(#4388) — 조용히 버리지 않도록 경고를
-        // 남기고 슬롯만 소비한다(문단 내 후속 컨트롤의 char-offset 정합은 유지, 표시
-        // 텍스트·URL 만 유실). `is_hwpx_inline_slot` 에도 등록해 `--verify` 재파싱
-        // 비교가 이 손실을 실제로 검출하게 한다.
+        // [#4388] Hyperlink/Unknown 은 HWPX 로 옮길 대응 표현이 없어 여기서도
+        // 드롭된다("exact" 슬롯 분기 — 모든 컨트롤이 위치 슬롯인 문단). 경고는
+        // `warn_if_unrepresentable_in_hwpx` 하나로 통일한다(mismatch-분기 제외
+        // 지점, 위쪽 934행 부근과 동일 호출). 이 함수 아래 catch-all 이 처리한다.
+        //
+        // [#4388 census] catch-all `_`(warn 호출 포함)에 실제로 도달하는 나머지
+        // `Control` 변형은 세 가지 — 새 변형을 추가할 때 이 목록을 갱신할 것:
+        //   - `Hyperlink`/`Unknown`: 위 참조. 조용히 버리지 않도록 경고.
+        //   - `SectionDef`: 의도적 무해 no-op. 위치 슬롯 축(hidden 슬롯 정합, 이 함수
+        //     966행 근처 주석)만 소비하고 XML 은 별도 경로(`<hp:secPr>` 섹션 템플릿)가
+        //     방출한다 — 여기서 다시 방출하면 중복이 된다. warn 헬퍼도 이 변형은
+        //     무시한다.
+        //   - `HiddenComment`: **구현 누락으로 확인됨(경고 미부착)**. HWPX 는
+        //     `<hp:hiddenComment>` 네이티브 표현이 있고 파서(`parse_ctrl_hidden_comment`)
+        //     는 이미 sub-paragraph 까지 온전히 읽지만 직렬화기엔 대응 방출 arm 이
+        //     없다. 다만 이 컨트롤은 PARA_TEXT 상 폭이 0(파서가 위치 마커를 push 하지
+        //     않음 — Bookmark 와 동형)이라 실제 문서에서는 `render_runs` 의
+        //     mismatch-분기 필터(위쪽, "제외된 hidden 슬롯 후보" 블록 부근)에서 먼저
+        //     걸러져 이 함수 자체에 거의 도달하지 않는다 — 진짜 수정은 Bookmark 의
+        //     `emit_inorder_bookmarks` 류 zero-width in-order 방출 인프라가 필요한
+        //     별도 작업(그 로직은 #1591/#1627/#1584 이력이 보여주듯 섬세하다) —
+        //     후속 이슈로 분리 권장.
+        c => warn_if_unrepresentable_in_hwpx(c),
+    }
+}
+
+/// [#4388] HWPX 로 옮길 대응 표현이 없어 드롭되는 컨트롤(Hyperlink/Unknown)을
+/// **조용히 버리지 않도록** 경고만 남긴다. 두 호출 지점(이 함수 위쪽
+/// `render_runs` 의 mismatch-분기 제외 시점, `render_control_slot` 의
+/// catch-all)에서 공유한다 — 한 문단의 한 컨트롤은 두 분기 중 하나로만
+/// 소비되므로 중복 경고는 없다.
+///
+/// **`is_hwpx_inline_slot` 에는 등록하지 않는다.** 그 목록은
+/// `roundtrip::diff_documents` 의 IR 비교(포맷 비종속 — `export-hwpx` 뿐 아니라
+/// `convert`(HWP5 대상) `--verify` 도 재사용)에도 쓰이는데, 등록해봤다면 HWP5
+/// 직렬화기가 이슈 범위 밖에서 이미 Hyperlink 의 ctrl_id 를 0 으로 고정해 버려
+/// CTRL_HEADER 자체를 쓰지 않는 기존 HWP5 손실까지 새로 "검출"되어
+/// `tests/issue_hwp3_bookmark_native.rs::bookmarks_survive_saving_to_hwp5`
+/// 처럼 하이퍼링크와 무관한 기존 회귀 테스트가 깨진다(#4388 후속 보고, 실측
+/// 재현: hwp3-sample16.hwp 문단 27/32/196/657 이 전부 Hyperlink). "조용히
+/// 버리지 말라"는 경고 축과 "IR 비교에 넣는다"는 검증 축은 별개다.
+fn warn_if_unrepresentable_in_hwpx(control: &Control) {
+    match control {
         Control::Hyperlink(hl) => {
             eprintln!(
                 "[hwpx] 경고: Hyperlink 컨트롤을 HWPX로 저장할 수 없어 드롭됩니다 \
@@ -1594,16 +1641,6 @@ fn render_control_slot(out: &mut String, control: &Control, ctx: &mut SerializeC
                 hl.url, hl.text
             );
         }
-        // [#4388] `Control::Unknown` 은 HWP5/HWP3 바이너리 파서가 인식하지 못한
-        // ctrl_id(FourCC) 를 보존하는 fallback 이며 HWPX 파서는 절대 만들지 않는다
-        // (grep 확인). HWP5 는 PARA_TEXT 에 0x000B 확장 컨트롤 문자로 위치를 남기고
-        // (Table/Picture 와 같은 char class) CTRL_HEADER 만 최소 보존한다 — 즉 실제
-        // 문서에서도 위치를 점유하는 오브젝트형 슬롯이지만, HWPX 는 "인식 못 한
-        // 컨트롤"을 표현할 제네릭 요소가 없고 원본 바이트도 보존돼 있지 않아
-        // (`UnknownControl` 은 ctrl_id 하나뿐) 변환 자체가 불가능하다. 종전엔
-        // catch-all `_ => {}` 로 떨어져 경고 없이 사라졌다 — 조용히 버리지 않도록
-        // 경고를 남기고 슬롯만 소비한다. `is_hwpx_inline_slot` 에도 등록해
-        // `--verify` 가 이 손실을 검출하게 한다(Hyperlink 와 동형 처리).
         Control::Unknown(u) => {
             eprintln!(
                 "[hwpx] 경고: 인식할 수 없는 컨트롤(ctrl_id=0x{:08X})을 HWPX로 저장할 수 \
@@ -1612,22 +1649,6 @@ fn render_control_slot(out: &mut String, control: &Control, ctx: &mut SerializeC
                 u.ctrl_id
             );
         }
-        // [#4388 census] 여기 도달하는 나머지 `Control` 변형은 두 가지뿐이며 둘 다
-        // 조사·분류를 거쳤다 — 새 변형을 추가할 때 이 목록을 갱신할 것:
-        //   - `SectionDef`: 의도적 무해 no-op. 위치 슬롯 축(hidden 슬롯 정합, 이 함수
-        //     966행 근처 주석)만 소비하고 XML 은 별도 경로(`<hp:secPr>` 섹션 템플릿)가
-        //     방출한다 — 여기서 다시 방출하면 중복이 된다.
-        //   - `HiddenComment`: **구현 누락으로 확인됨(경고 미부착)**. HWPX 는
-        //     `<hp:hiddenComment>` 네이티브 표현이 있고 파서(`parse_ctrl_hidden_comment`)
-        //     는 이미 sub-paragraph 까지 온전히 읽지만 직렬화기엔 대응 방출 arm 이
-        //     없다. 다만 이 컨트롤은 PARA_TEXT 상 폭이 0(파서가 위치 마커를 push 하지
-        //     않음 — Bookmark 와 동형)이라 실제 문서에서는 `render_runs` 의
-        //     mismatch-분기 `is_hwpx_inline_slot` 필터(위쪽, "제외된 hidden 슬롯 후보"
-        //     블록 부근)에서 먼저 걸러져 이 함수 자체에 거의 도달하지 않는다 — 여기
-        //     경고 arm 을 추가해도 사실상 죽은 코드라 붙이지 않았다. 진짜 수정은
-        //     Bookmark 의 `emit_inorder_bookmarks` 류 zero-width in-order 방출
-        //     인프라가 필요한 별도 작업(그 로직은 #1591/#1627/#1584 이력이 보여주듯
-        //     섬세하다) — 후속 이슈로 분리 권장.
         _ => {}
     }
 }

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -1426,6 +1426,17 @@ pub(crate) fn is_hwpx_inline_slot(control: &Control) -> bool {
             | Control::Header(_)
             | Control::Footer(_)
             | Control::AutoNumber(_)
+            // [#4388] HWP3 유래 Hyperlink 도 Picture/Table 과 동형인 U+FFFC 오브젝트
+            // 슬롯이다(HWP3 파서가 문단 텍스트에 마커 1개를 넣고 controls 에 대응
+            // 컨트롤을 push — src/parser/hwp3/mod.rs). 슬롯으로 등록해야 (a) 다른
+            // 컨트롤과 섞인 문단에서 위치 정합이 일관되고, (b) `--verify` 재파싱
+            // 비교(`diff_paragraph_char_shapes`, roundtrip.rs)가 render_control_slot 의
+            // catch-all 드롭을 검출한다.
+            | Control::Hyperlink(_)
+            // [#4388] HWP5/HWP3 유래 Unknown 도 PARA_TEXT 상에서 0x000B 확장 컨트롤
+            // 문자(Table/Picture 와 동일 char class)로 위치를 점유한다. 슬롯 등록
+            // 이유는 Hyperlink 와 동일 — 위치 정합 + `--verify` 손실 검출.
+            | Control::Unknown(_)
     )
 }
 
@@ -1562,6 +1573,61 @@ fn render_control_slot(out: &mut String, control: &Control, ctx: &mut SerializeC
                 out.push_str(&render_col_pr_ctrl(cd));
             }
         }
+        // [#4388] `Control::Hyperlink` 는 현재 HWP3 파서만 생성하는 legacy IR
+        // 표현이다 (`src/parser/hwp3/mod.rs`) — HWP3 문서의 하이퍼링크는 Picture/
+        // Table 처럼 문단 텍스트에 U+FFFC 마커 1개를 점유하는 "오브젝트형" 슬롯이고,
+        // 표시 텍스트(`text`)는 para.text 가 아니라 컨트롤 자체에 별도 보존된다.
+        // 반면 HWPX 는 하이퍼링크를 `Control::Field(FieldType::Hyperlink)` 로 표현하며
+        // 이는 fieldBegin/fieldEnd 가 문단 텍스트의 실제 글자 범위를 감싸는 인라인
+        // 구조다 — 표시 텍스트가 파라그래프 문자 스트림 안에 있어야 한다는 뜻이라,
+        // 이 컨트롤을 그대로 Field 로 접었다간 문단을 재구성(문자 삽입 + char_shapes/
+        // line_segs 재계산)해야 해 안전하게 변환할 수 없다. 종전엔 catch-all
+        // `_ => {}` 로 떨어져 경고 없이 사라졌다(#4388) — 조용히 버리지 않도록 경고를
+        // 남기고 슬롯만 소비한다(문단 내 후속 컨트롤의 char-offset 정합은 유지, 표시
+        // 텍스트·URL 만 유실). `is_hwpx_inline_slot` 에도 등록해 `--verify` 재파싱
+        // 비교가 이 손실을 실제로 검출하게 한다.
+        Control::Hyperlink(hl) => {
+            eprintln!(
+                "[hwpx] 경고: Hyperlink 컨트롤을 HWPX로 저장할 수 없어 드롭됩니다 \
+                 (url={:?}, text={:?}) — HWPX는 하이퍼링크를 Field(HYPERLINK)로 표현하며 \
+                 이 변환은 아직 지원되지 않습니다.",
+                hl.url, hl.text
+            );
+        }
+        // [#4388] `Control::Unknown` 은 HWP5/HWP3 바이너리 파서가 인식하지 못한
+        // ctrl_id(FourCC) 를 보존하는 fallback 이며 HWPX 파서는 절대 만들지 않는다
+        // (grep 확인). HWP5 는 PARA_TEXT 에 0x000B 확장 컨트롤 문자로 위치를 남기고
+        // (Table/Picture 와 같은 char class) CTRL_HEADER 만 최소 보존한다 — 즉 실제
+        // 문서에서도 위치를 점유하는 오브젝트형 슬롯이지만, HWPX 는 "인식 못 한
+        // 컨트롤"을 표현할 제네릭 요소가 없고 원본 바이트도 보존돼 있지 않아
+        // (`UnknownControl` 은 ctrl_id 하나뿐) 변환 자체가 불가능하다. 종전엔
+        // catch-all `_ => {}` 로 떨어져 경고 없이 사라졌다 — 조용히 버리지 않도록
+        // 경고를 남기고 슬롯만 소비한다. `is_hwpx_inline_slot` 에도 등록해
+        // `--verify` 가 이 손실을 검출하게 한다(Hyperlink 와 동형 처리).
+        Control::Unknown(u) => {
+            eprintln!(
+                "[hwpx] 경고: 인식할 수 없는 컨트롤(ctrl_id=0x{:08X})을 HWPX로 저장할 수 \
+                 없어 드롭됩니다 — 원본 컨트롤의 세부 데이터가 보존되지 않아 이 변환은 \
+                 지원되지 않습니다.",
+                u.ctrl_id
+            );
+        }
+        // [#4388 census] 여기 도달하는 나머지 `Control` 변형은 두 가지뿐이며 둘 다
+        // 조사·분류를 거쳤다 — 새 변형을 추가할 때 이 목록을 갱신할 것:
+        //   - `SectionDef`: 의도적 무해 no-op. 위치 슬롯 축(hidden 슬롯 정합, 이 함수
+        //     966행 근처 주석)만 소비하고 XML 은 별도 경로(`<hp:secPr>` 섹션 템플릿)가
+        //     방출한다 — 여기서 다시 방출하면 중복이 된다.
+        //   - `HiddenComment`: **구현 누락으로 확인됨(경고 미부착)**. HWPX 는
+        //     `<hp:hiddenComment>` 네이티브 표현이 있고 파서(`parse_ctrl_hidden_comment`)
+        //     는 이미 sub-paragraph 까지 온전히 읽지만 직렬화기엔 대응 방출 arm 이
+        //     없다. 다만 이 컨트롤은 PARA_TEXT 상 폭이 0(파서가 위치 마커를 push 하지
+        //     않음 — Bookmark 와 동형)이라 실제 문서에서는 `render_runs` 의
+        //     mismatch-분기 `is_hwpx_inline_slot` 필터(위쪽, "제외된 hidden 슬롯 후보"
+        //     블록 부근)에서 먼저 걸러져 이 함수 자체에 거의 도달하지 않는다 — 여기
+        //     경고 arm 을 추가해도 사실상 죽은 코드라 붙이지 않았다. 진짜 수정은
+        //     Bookmark 의 `emit_inorder_bookmarks` 류 zero-width in-order 방출
+        //     인프라가 필요한 별도 작업(그 로직은 #1591/#1627/#1584 이력이 보여주듯
+        //     섬세하다) — 후속 이슈로 분리 권장.
         _ => {}
     }
 }
@@ -2063,7 +2129,32 @@ fn render_shape(shape: &ShapeObject, ctx: &mut SerializeContext) -> String {
         ),
         _ => String::new(),
     };
-    render_common_shape_xml(tag, c, caption, drawing, points, &geom_tail, ctx)
+    // [#4388] `<hp:arc>` 전용 `type` 속성(NORMAL/PIE/CHORD) — OWPML `CArcType` 계약.
+    // 종전엔 이 속성 자체가 방출되지 않아 `arc_type` 이 항상 0(NORMAL)으로 저장됐다.
+    let extra_attrs = match shape {
+        ShapeObject::Arc(a) => format!(r#" type="{}""#, arc_type_hwpx_str(a.arc_type)),
+        _ => String::new(),
+    };
+    render_common_shape_xml(
+        tag,
+        c,
+        caption,
+        drawing,
+        points,
+        &geom_tail,
+        &extra_attrs,
+        ctx,
+    )
+}
+
+/// [#4388] `ArcShape.arc_type` (0: Arc, 1: CircularSector, 2: Bow) →
+/// `<hp:arc>` 의 `type` 속성값. `parse_arc_type_attr` 의 역매핑.
+fn arc_type_hwpx_str(arc_type: u8) -> &'static str {
+    match arc_type {
+        1 => "PIE",
+        2 => "CHORD",
+        _ => "NORMAL",
+    }
 }
 
 fn render_common_shape_xml(
@@ -2073,6 +2164,8 @@ fn render_common_shape_xml(
     drawing: Option<&crate::model::shape::DrawingObjAttr>,
     points: &[crate::model::Point],
     geom_tail: &str,
+    // [#4388] 태그별 부가 속성(현재는 `<hp:arc type="...">` 전용) — 없으면 "".
+    extra_attrs: &str,
     ctx: &mut SerializeContext,
 ) -> String {
     // 도형 좌표계 블록(offset/orgSz/curSz/flip/rotationInfo/renderingInfo) — 누락 시
@@ -2121,7 +2214,7 @@ fn render_common_shape_xml(
         .unwrap_or(c.instance_id);
     let mut out = format!(
         concat!(
-            r#"<hp:{tag} id="{id}" zOrder="{zo}" numberingType="{nt}" textWrap="{tw}" textFlow="{tf}" lock="{lock}" dropcapstyle="None" href="" groupLevel="{gl}" instid="{iid}">"#,
+            r#"<hp:{tag} id="{id}" zOrder="{zo}" numberingType="{nt}" textWrap="{tw}" textFlow="{tf}" lock="{lock}" dropcapstyle="None" href="" groupLevel="{gl}" instid="{iid}"{extra}>"#,
             "{block}",
             "{geometry}",
             r#"<hp:sz width="{w}" height="{h}" widthRelTo="{wrt}" heightRelTo="{hrt}" protect="{prot}"/>"#,
@@ -2129,6 +2222,7 @@ fn render_common_shape_xml(
             r#"<hp:outMargin left="{ml}" right="{mr}" top="{mt}" bottom="{mb}"/>"#,
         ),
         tag = tag,
+        extra = extra_attrs,
         block = shape_block,
         geometry = geometry,
         id = c.instance_id,
@@ -2832,7 +2926,7 @@ mod tests {
         let mut c = CommonObjAttr::default();
         c.text_flow = TextFlow::LargestOnly;
         let mut ctx = SerializeContext::default();
-        let xml = render_common_shape_xml("ellipse", &c, &None, None, &[], "", &mut ctx);
+        let xml = render_common_shape_xml("ellipse", &c, &None, None, &[], "", "", &mut ctx);
         assert!(
             xml.contains(r#"textFlow="LARGEST_ONLY""#),
             "공용 도형 textFlow 이 IR 값이어야 함: {xml}"
@@ -2849,6 +2943,7 @@ mod tests {
             &None,
             None,
             &[],
+            "",
             "",
             &mut ctx,
         );
@@ -2877,7 +2972,8 @@ mod tests {
         let c = CommonObjAttr::default();
         let mut ctx = SerializeContext::default();
 
-        let xml = render_common_shape_xml("polygon", &c, &None, Some(&drawing), &[], "", &mut ctx);
+        let xml =
+            render_common_shape_xml("polygon", &c, &None, Some(&drawing), &[], "", "", &mut ctx);
         assert!(
             xml.contains("<hp:drawText"),
             "polygon 도형이 drawText 를 방출해야 함: {xml}"
@@ -2892,7 +2988,7 @@ mod tests {
             ..Default::default()
         };
         let xml_empty =
-            render_common_shape_xml("polygon", &c, &None, Some(&empty), &[], "", &mut ctx);
+            render_common_shape_xml("polygon", &c, &None, Some(&empty), &[], "", "", &mut ctx);
         assert!(
             !xml_empty.contains("<hp:drawText"),
             "빈 글상자는 drawText 를 방출하지 않아야 함"
@@ -2918,7 +3014,8 @@ mod tests {
         let mut ctx = SerializeContext::default();
 
         for tag in ["ellipse", "arc", "polygon", "curve", "chart"] {
-            let xml = render_common_shape_xml(tag, &c, &None, Some(&drawing), &[], "", &mut ctx);
+            let xml =
+                render_common_shape_xml(tag, &c, &None, Some(&drawing), &[], "", "", &mut ctx);
             assert!(
                 xml.contains(r#"widthRelTo="COLUMN""#),
                 "{tag}: 너비 기준 COLUMN 이 보존되어야 함: {xml}"
@@ -2949,7 +3046,8 @@ mod tests {
         let drawing = DrawingObjAttr::default();
         let mut ctx = SerializeContext::default();
 
-        let xml = render_common_shape_xml("polygon", &c, &None, Some(&drawing), &[], "", &mut ctx);
+        let xml =
+            render_common_shape_xml("polygon", &c, &None, Some(&drawing), &[], "", "", &mut ctx);
         assert!(
             xml.contains(r#"protect="0""#),
             "size_protect=false 여도 protect=\"0\" 속성이 방출되어야 함: {xml}"
@@ -2985,8 +3083,16 @@ mod tests {
                 height_criterion: criterion,
                 ..Default::default()
             };
-            let xml =
-                render_common_shape_xml("polygon", &c, &None, Some(&drawing), &[], "", &mut ctx);
+            let xml = render_common_shape_xml(
+                "polygon",
+                &c,
+                &None,
+                Some(&drawing),
+                &[],
+                "",
+                "",
+                &mut ctx,
+            );
             assert!(
                 xml.contains(&format!(r#"heightRelTo="{expected}""#)),
                 "{criterion:?} → heightRelTo=\"{expected}\" 이어야 함: {xml}"

--- a/tests/issue_4388_arc_type_roundtrip.rs
+++ b/tests/issue_4388_arc_type_roundtrip.rs
@@ -1,0 +1,170 @@
+//! Issue #4388 — `ArcShape.arc_type` 이 HWPX 경로에서 경고 없이 유실되는 결함의 회귀 테스트.
+//!
+//! `src/renderer/layout/shape_layout.rs` 는 `arc.arc_type` 값에 따라 완전히 다른 경로를
+//! 그린다 (0: 열린 호, 1: 부채꼴/PIE, 2: 활/CHORD — `PathCommand` 시퀀스 자체가 갈린다).
+//! 그런데 HWPX 파서는 `<hp:arc>` 요소의 `type` 속성을 읽지 않아(주석: "arc_type 은
+//! 태그속성(추후)") 항상 0(NORMAL/열린 호)으로 고정됐고, 직렬화기도 이 속성 자체를
+//! 방출하지 않았다 — 왕복마다 원본이 PIE/CHORD 였어도 조용히 열린 호로 바뀐다.
+//!
+//! 실제 OWPML 모델(hancom-io/hwpx-owpml-model, Apache-2.0, `Class/Para/ArcType.cpp`
+//! `CArcType::WriteElement`)을 확인한 결과 속성명은 `arcType` 이 아니라 `type` 이다
+//! (`arcType` 은 `<hp:ellipse>` 자신의 동명 속성으로, 서로 다른 요소의 별개 속성이다).
+//! `g_ArcTypeList`: NORMAL=0, PIE=1, CHORD=2 — `ArcShape.arc_type` (0: Arc, 1:
+//! CircularSector, 2: Bow) 와 1:1 대응.
+//!
+//! samples/ 안의 279개 실제 HWPX 표본에는 `<hp:arc>` 요소가 하나도 없어(전부 `<hp:ellipse
+//! arcType="NORMAL">` 뿐) 실측 fixture 로 회귀를 걸 수 없다 — 합성 IR 로 왕복을 검증한다.
+
+use rhwp::model::control::Control;
+use rhwp::model::document::{Document, Section};
+use rhwp::model::paragraph::{CharShapeRef, Paragraph};
+use rhwp::model::shape::{ArcShape, CommonObjAttr, DrawingObjAttr, ShapeObject};
+use rhwp::model::style::CharShape;
+use rhwp::model::Point;
+use rhwp::parser::hwpx::parse_hwpx;
+use rhwp::serializer::hwpx::serialize_hwpx;
+
+fn doc_with_arc(arc_type: u8) -> Document {
+    let arc = ArcShape {
+        common: CommonObjAttr {
+            width: 4000,
+            height: 3000,
+            ..Default::default()
+        },
+        drawing: DrawingObjAttr::default(),
+        arc_type,
+        center: Point { x: 2000, y: 1500 },
+        axis1: Point { x: 4000, y: 1500 },
+        axis2: Point { x: 2000, y: 0 },
+    };
+    let mut para = Paragraph::default();
+    para.text = "\u{fffc}".to_string();
+    para.char_offsets = vec![0];
+    para.char_count = 9; // 8유닛 오브젝트 슬롯 + null 종단 관례(다른 shape 테스트와 동형)
+                         // char_shape_id=0 을 명시 등록한다 — 그렇지 않으면 1차 직렬화는 암묵적 fallback
+                         // 으로 통과하지만(#1592 관례), 재파싱된 문단이 char_shapes=[(0,0)] 를 얻은 뒤
+                         // 2차 직렬화에서 "미등록 ID 참조" 로 실패해 왕복 안정성 확인이 막힌다.
+    para.char_shapes = vec![CharShapeRef {
+        start_pos: 0,
+        char_shape_id: 0,
+    }];
+    para.controls
+        .push(Control::Shape(Box::new(ShapeObject::Arc(arc))));
+
+    let mut section = Section::default();
+    section.paragraphs.push(para);
+    let mut doc = Document::default();
+    doc.doc_info.char_shapes.push(CharShape::default());
+    doc.sections.push(section);
+    doc
+}
+
+/// 첫 `<hp:arc ...>` 여는 태그의 `type` 속성값 추출 (section*.xml 전수 검색).
+fn extract_arc_type_attr(hwpx_bytes: &[u8]) -> Option<String> {
+    let reader = std::io::Cursor::new(hwpx_bytes);
+    let mut zip = zip::ZipArchive::new(reader).ok()?;
+    use std::io::Read;
+    for i in 0..zip.len() {
+        let mut f = zip.by_index(i).ok()?;
+        if !f.name().ends_with(".xml") || !f.name().contains("section") {
+            continue;
+        }
+        let mut xml = String::new();
+        f.read_to_string(&mut xml).ok()?;
+        if let Some(pos) = xml.find("<hp:arc ") {
+            let tag_end = xml[pos..].find('>').map(|e| pos + e)?;
+            let tag = &xml[pos..tag_end];
+            let key = "type=\"";
+            let s = tag.find(key)? + key.len();
+            let rest = &tag[s..];
+            let e = rest.find('"')?;
+            return Some(rest[..e].to_string());
+        }
+    }
+    None
+}
+
+fn first_arc(doc: &Document) -> Option<&ArcShape> {
+    for section in &doc.sections {
+        for para in &section.paragraphs {
+            for ctrl in &para.controls {
+                if let Control::Shape(s) = ctrl {
+                    if let ShapeObject::Arc(a) = s.as_ref() {
+                        return Some(a);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+#[test]
+fn arc_type_normal_roundtrips_and_uses_type_attribute() {
+    let doc = doc_with_arc(0);
+    let bytes = serialize_hwpx(&doc).expect("serialize arc(NORMAL)");
+    let attr = extract_arc_type_attr(&bytes);
+    assert_eq!(
+        attr.as_deref(),
+        Some("NORMAL"),
+        "<hp:arc type=\"NORMAL\"> 이 방출되어야 함 (수정 전엔 type 속성 자체가 없었음)"
+    );
+    let doc2 = parse_hwpx(&bytes).expect("reparse");
+    let arc = first_arc(&doc2).expect("arc control survives");
+    assert_eq!(arc.arc_type, 0, "NORMAL(0) 왕복 보존");
+}
+
+#[test]
+fn arc_type_pie_roundtrips_and_uses_type_attribute() {
+    // arc_type=1 (CircularSector/부채꼴) — OWPML PIE.
+    let doc = doc_with_arc(1);
+    let bytes = serialize_hwpx(&doc).expect("serialize arc(PIE)");
+    let attr = extract_arc_type_attr(&bytes);
+    assert_eq!(
+        attr.as_deref(),
+        Some("PIE"),
+        "<hp:arc type=\"PIE\"> 로 방출되어야 함 — arcType 이 아니라 type 속성"
+    );
+    let doc2 = parse_hwpx(&bytes).expect("reparse");
+    let arc = first_arc(&doc2).expect("arc control survives");
+    assert_eq!(
+        arc.arc_type, 1,
+        "PIE(1) 왕복 보존 — 수정 전엔 파서가 type 속성을 읽지 않아 항상 0 으로 되돌아왔음"
+    );
+}
+
+#[test]
+fn arc_type_chord_roundtrips_and_uses_type_attribute() {
+    // arc_type=2 (Bow/활) — OWPML CHORD.
+    let doc = doc_with_arc(2);
+    let bytes = serialize_hwpx(&doc).expect("serialize arc(CHORD)");
+    let attr = extract_arc_type_attr(&bytes);
+    assert_eq!(
+        attr.as_deref(),
+        Some("CHORD"),
+        "<hp:arc type=\"CHORD\"> 로 방출되어야 함"
+    );
+    let doc2 = parse_hwpx(&bytes).expect("reparse");
+    let arc = first_arc(&doc2).expect("arc control survives");
+    assert_eq!(arc.arc_type, 2, "CHORD(2) 왕복 보존");
+
+    // 2-round 안정성 (geometry roundtrip 테스트(#1598)와 동형 관례).
+    let bytes2 = serialize_hwpx(&doc2).expect("serialize r2");
+    let doc3 = parse_hwpx(&bytes2).expect("reparse r2");
+    let arc3 = first_arc(&doc3).expect("arc control survives r2");
+    assert_eq!(arc3.arc_type, 2, "2-round CHORD 안정");
+}
+
+/// center/axis 지오메트리는 (#1598 로) 이미 왕복하지만, arc_type 이 항상 0 으로
+/// 뭉개지는 게 이 이슈의 핵심 증상이었다 — geometry 는 그대로인데 렌더 결과(열린
+/// 호/부채꼴/활)만 달라지는 조용한 손실임을 명시적으로 못 박는다.
+#[test]
+fn arc_geometry_unaffected_by_arc_type_fix() {
+    let doc = doc_with_arc(1);
+    let bytes = serialize_hwpx(&doc).expect("serialize");
+    let doc2 = parse_hwpx(&bytes).expect("reparse");
+    let arc = first_arc(&doc2).expect("arc control survives");
+    assert_eq!((arc.center.x, arc.center.y), (2000, 1500));
+    assert_eq!((arc.axis1.x, arc.axis1.y), (4000, 1500));
+    assert_eq!((arc.axis2.x, arc.axis2.y), (2000, 0));
+}


### PR DESCRIPTION
HWPX 직렬화기가 표현할 수 없는 컨트롤을 만나면 아무 말 없이 버립니다. 사용자는 저장이 성공한 줄 알고 내용을 잃습니다. 별건으로 `hp:arc` 의 곡선/부채꼴 구분이 왕복에서 사라집니다.

`warn_if_unrepresentable_in_hwpx` 를 추가해 손실 지점에서 경고를 냅니다. `hp:arc` 는 파서와 직렬화기 양쪽에 속성을 추가해 왕복시킵니다.

이슈가 이 속성을 `arcType` 이라 적었는데 OWPML 상 실제 이름은 `type` 입니다. 이슈의 "HWP5 는 왕복이 된다"는 서술도 사실과 다릅니다 — 아래를 봐 주십시오.

**첫 접근을 되돌린 이유를 남깁니다.** 처음에는 `Control::Hyperlink`/`Control::Unknown` 을 `is_hwpx_inline_slot` 에 등록해 손실을 드러냈는데, 이것이 무관한 `bookmarks_survive_saving_to_hwp5` 를 깨뜨렸습니다. `is_hwpx_inline_slot` 은 `render_runs` 뿐 아니라 `roundtrip::diff_documents` 도 씁니다 — 그런데 `diff_documents` 는 포맷 비종속이라 `convert`(HWP5 대상) `--verify` 도 같은 함수를 탑니다. 즉 HWPX 축 등록이 HWP5 경로의 **기존** 하이퍼링크 손실을 새로 검출하게 만든 것이었습니다.

등록을 원복하고, 경고는 `is_hwpx_inline_slot` 과 무관하게 두 분기(`render_control_slot` 의 catch-all, `render_runs` 의 필터 배제 지점)에서 직접 호출합니다. 재등록을 막는 가드를 반대 방향 단언(`issue4388_diff_documents_*_not_compared_as_control`)으로 넣었습니다.

드러난 HWP5 축 결함 — `body_text.rs:850` 의 `Control::Hyperlink(_) => (0x000B, 0)` 이 본문에 0x000B 는 넣고 CTRL_HEADER 는 안 만들어 뒤 컨트롤 짝짓기를 밀어버립니다 — 은 이 PR 범위 밖이라 손대지 않고 #4424 로 열었습니다.

`cargo test --profile release-test --tests --no-fail-fast` 바이너리 498개 전부 통과(FAILED 0), fmt·clippy clean.

Closes #4388