### PR TITLE
core: 클립보드 HTML 내보내기가 표 셀 안의 컨트롤을 순회하도록 + 중첩 표 import 패닉 수정

### DIFF
--- a/mydocs/working/task_m100_4413_stage1.md
+++ b/mydocs/working/task_m100_4413_stage1.md
@@ -61,7 +61,7 @@ nested_table_in_cell_round_trips_through_import ... FAILED (패닉)
 
 ## 5. 이 작업에서 고치지 않은 것
 
-전부 [#4426](https://github.com/edwardkim/rhwp/issues/4426) 으로 열었다.
+전부 [#4426](https://github.com/edwardkim/rhwp/issues/4427) 으로 열었다.
 
 1. `table_to_html`(`clipboard.rs:1705`)이 `table.caption` 을 방출하지 않는다 — 최상위·중첩 모두.
 2. `picture_to_html`(`:1816`)이 `pic.caption` 을 방출하지 않는다.

--- a/mydocs/working/task_m100_4413_stage1.md
+++ b/mydocs/working/task_m100_4413_stage1.md
@@ -1,0 +1,78 @@
+# task_m100_4413 Stage 1 — 문서 간 복사에서 셀 안 중첩 표·이미지 소실
+
+- **이슈**: [#4413](https://github.com/edwardkim/rhwp/issues/4413)
+- **브랜치**: `fix/issue-4413-clipboard-cell-controls`
+- **분기 기준**: `upstream/devel` (0 behind)
+- **상태**: 게이트 전부 통과, PR 게시
+- **기록일**: 2026-08-10 KST
+
+## 1. 결함
+
+클립보드 HTML 내보내기가 셀 내용을 `para.text` 만으로 만든다. `para.controls` 를 보지 않으므로
+**셀 안의 중첩 표와 이미지가 통째로 사라진다.** 사용자는 붙여넣기 결과를 보고서야 안다.
+
+같은 결함이 세 진입점에 있었다 — `export_selection_in_cell_html_native`,
+`export_selection_in_cell_html_by_path_native`(#4272 로 나중에 추가된 두 번째 사례),
+`table_to_html` 의 셀 루프.
+
+## 2. import 쪽은 더 나빴다 — 조용한 손실이 아니라 패닉
+
+`src/document_core/html_table_import.rs:48` 의 `<td>`/`<th>` 내용 경계 추출이 순진한 `.find()` 라
+같은 태그가 중첩되면 **범위를 벗어난 슬라이스로 패닉한다.**
+
+```
+thread panicked at src/document_core/html_table_import.rs:48:46:
+byte index 18 is out of bounds of `<tr><td>inner`
+```
+
+이미 같은 파일에 `<tr>` 경계용으로 쓰는 깊이 추적 헬퍼 `find_closing_tag` 가 있었다. 그것을
+재사용해 닫았다.
+
+## 3. 고친 것
+
+- `cell_paragraph_to_html` 신설 — 텍스트와 `para.controls` 를 함께 처리하고, 위 세 진입점에 연결.
+- 중첩 표 재귀에 `MAX_NEST_DEPTH = 8` — `table_extract`/`explain`/`hidden_text` 와 같은 값·같은 모양.
+- 지원하지 않는 셀 컨트롤 변형은 조용히 사라지는 대신 컨트롤 종류를 밝힌 HTML 주석 경고를 남긴다.
+- `html_table_import.rs` 의 경계 추출을 `find_closing_tag` 로 교체.
+
+## 4. 검증 (완료)
+
+RED 확인은 패치를 떼어내고 했다 — `clipboard.rs`/`html_table_import.rs` 를 `upstream/devel` 로
+되돌리고 테스트만 얹어 돌렸다.
+
+```
+nested_table_in_cell_is_exported_to_html ... FAILED
+  실제 HTML: <html><body>\n<!--StartFragment-->\n<!--EndFragment-->\n</body></html>
+picture_in_cell_is_exported_to_html ... FAILED
+nested_table_in_cell_round_trips_through_import ... FAILED (패닉)
+```
+
+대조군 2건(`internal_clipboard_preserves_nested_table_in_cell_control_group`,
+`body_level_picture_export_via_control_html_was_already_fine`)은 수정 전에도 통과했다 — 결함
+범위가 셀 경로에 한정됨을 확인한 것이다.
+
+- 신규 회귀 테스트 8건, 전부 RED → GREEN.
+- `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests` **exit 0**,
+  `test result:` 블록 497개, `FAILED` 0건. 로그 8,530줄.
+  상습 타이밍 flake 인 `scan_cost_stays_linear_as_input_grows` 도 이번 회차는 통과.
+  (첫 시도에서 `| tail -400` 을 걸어 exit code 가 `tail` 것이 되는 실수를 했고, 파이프 없이 다시
+  돌려 얻은 결과다.)
+- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` 통과.
+
+## 5. 이 작업에서 고치지 않은 것
+
+전부 [#4426](https://github.com/edwardkim/rhwp/issues/4426) 으로 열었다.
+
+1. `table_to_html`(`clipboard.rs:1705`)이 `table.caption` 을 방출하지 않는다 — 최상위·중첩 모두.
+2. `picture_to_html`(`:1816`)이 `pic.caption` 을 방출하지 않는다.
+3. `export_selection_html_native`(`:1315`, 루프 `:1347`)는 여전히 `.controls` 를 안 보는
+   `paragraph_to_html` 을 부른다 — 본문 텍스트 범위 선택이 인라인 앵커를 걸치면 같은 손실.
+4. `picture_to_html` 이 `bin_data_id == 0` 이거나 `BinDataContent` 가 없으면 경고 없이 빈 문자열.
+
+`MAX_NEST_DEPTH = 8` 을 또 한 벌 추가한 것 자체가 #4422(소유자 집합 6벌 중복, 이제 7벌)의
+사례를 하나 늘린 것이다. 이 PR 에서 합치지 않았다 — 합치는 것은 #4422 의 일이다.
+
+## 6. 미처리
+
+GitHub Actions, 작업지시자 승인, merge. `clipboard.rs` 를 #4412(PR #4416)·#4414 와 공유하므로
+머지 순서에 따라 리베이스가 필요하다.

--- a/mydocs/working/task_m100_4413_stage1.md
+++ b/mydocs/working/task_m100_4413_stage1.md
@@ -61,7 +61,7 @@ nested_table_in_cell_round_trips_through_import ... FAILED (패닉)
 
 ## 5. 이 작업에서 고치지 않은 것
 
-전부 [#4426](https://github.com/edwardkim/rhwp/issues/4427) 으로 열었다.
+전부 [#4427](https://github.com/edwardkim/rhwp/issues/4427) 으로 열었다.
 
 1. `table_to_html`(`clipboard.rs:1705`)이 `table.caption` 을 방출하지 않는다 — 최상위·중첩 모두.
 2. `picture_to_html`(`:1816`)이 `pic.caption` 을 방출하지 않는다.

--- a/src/document_core/commands/clipboard.rs
+++ b/src/document_core/commands/clipboard.rs
@@ -16,6 +16,41 @@ use crate::model::paragraph::{FieldRange, LineSeg, Paragraph};
 /// 약 2mm (1mm = 7200/25.4 ≈ 283.46 HWPUNIT). 한컴 정합은 작업지시자 시각 대조로 미세조정.
 const PASTE_CASCADE_STEP_HU: u32 = 567;
 
+/// [#4413] 셀 안 컨트롤을 HTML로 변환하는 재귀(표 안의 표 안의 표…)의 깊이 상한.
+/// `table_extract::MAX_NEST_DEPTH`/`explain::MAX_NEST_DEPTH`/`hidden_text::MAX_NEST_DEPTH`와
+/// 같은 값·형태 — 병적으로 깊은 중첩 문서에서 export 재귀가 스택을 태우지 않게 막는다.
+const MAX_NEST_DEPTH: usize = 8;
+
+/// 셀 HTML 내보내기에서 지원하지 않는 컨트롤을 경고 주석에 남기기 위한 표시 이름.
+/// `Control::Table`/`Control::Picture`는 `control_to_html`이 직접 처리하므로 이 경로를
+/// 타지 않지만, 매치 순서가 바뀌어도 무해한 이름을 반환하도록 모든 변형을 다룬다.
+fn control_kind_label(control: &Control) -> &'static str {
+    match control {
+        Control::SectionDef(_) => "SectionDef",
+        Control::ColumnDef(_) => "ColumnDef",
+        Control::Table(_) => "Table",
+        Control::Shape(_) => "Shape",
+        Control::Picture(_) => "Picture",
+        Control::Header(_) => "Header",
+        Control::Footer(_) => "Footer",
+        Control::Footnote(_) => "Footnote",
+        Control::Endnote(_) => "Endnote",
+        Control::AutoNumber(_) => "AutoNumber",
+        Control::NewNumber(_) => "NewNumber",
+        Control::PageNumberPos(_) => "PageNumberPos",
+        Control::Bookmark(_) => "Bookmark",
+        Control::Hyperlink(_) => "Hyperlink",
+        Control::Ruby(_) => "Ruby",
+        Control::CharOverlap(_) => "CharOverlap",
+        Control::PageHide(_) => "PageHide",
+        Control::HiddenComment(_) => "HiddenComment",
+        Control::Equation(_) => "Equation",
+        Control::Field(_) => "Field",
+        Control::Form(_) => "Form",
+        Control::Unknown(_) => "Unknown",
+    }
+}
+
 /// [#2550] 압축 해제 상한 초과 항목(deflate bomb 포함)에 대한 공통 오류.
 ///
 /// 범위 초과(`범위 초과`)와 같은 `RenderError` 계열이라 호출부 처리 경로가 같다.
@@ -1363,7 +1398,9 @@ impl DocumentCore {
             } else {
                 None
             };
-            html.push_str(&self.paragraph_to_html(cpara, start, end));
+            // [#4413] 이 셀은 본문 직속(depth 0) 표의 셀이므로 그 안 문단에
+            // 붙은 컨트롤(중첩 표·그림 등)은 depth 1부터 검사한다.
+            html.push_str(&self.cell_paragraph_to_html(cpara, start, end, 1));
         }
 
         html.push_str("<!--EndFragment-->\n</body></html>");
@@ -1391,13 +1428,18 @@ impl DocumentCore {
         }
 
         let mut html = String::from("<html><body>\n<!--StartFragment-->\n");
+        // [#4413] path 의 각 항목이 표 중첩 한 단계이므로, 그 안 문단의
+        // 컨트롤은 path.len() 깊이(= 이 셀 자체가 이미 path.len()번 중첩된
+        // 지점)에서부터 검사한다. cell_path 가 1개면 depth 1부터 시작하는
+        // `export_selection_in_cell_html_native`와 같은 규칙이다.
+        let control_depth = path.len();
         for cell_para_idx in start_cell_para_idx..=end_cell_para_idx {
             let mut para_path = path.to_vec();
             para_path.last_mut().unwrap().2 = cell_para_idx;
             let para = self.resolve_paragraph_by_path(section_idx, parent_para_idx, &para_path)?;
             let start = (cell_para_idx == start_cell_para_idx).then_some(start_char_offset);
             let end = (cell_para_idx == end_cell_para_idx).then_some(end_char_offset);
-            html.push_str(&self.paragraph_to_html(para, start, end));
+            html.push_str(&self.cell_paragraph_to_html(para, start, end, control_depth));
         }
         html.push_str("<!--EndFragment-->\n</body></html>");
         Ok(html)
@@ -1419,7 +1461,9 @@ impl DocumentCore {
             .ok_or_else(|| HwpError::RenderError(format!("컨트롤 {} 범위 초과", control_idx)))?;
 
         let mut html = String::from("<html><body>\n<!--StartFragment-->\n");
-        html.push_str(&self.control_to_html(control));
+        // 직접 선택해 내보내는 컨트롤은 문서 안 실제 중첩 위치와 무관하게 새
+        // export 루트로 취급한다 — depth 0부터 MAX_NEST_DEPTH 예산을 새로 받는다.
+        html.push_str(&self.control_to_html(control, 0));
         html.push_str("<!--EndFragment-->\n</body></html>");
         Ok(html)
     }
@@ -1628,16 +1672,37 @@ impl DocumentCore {
     }
 
     /// Control 객체를 HTML로 변환한다.
-    pub(crate) fn control_to_html(&self, control: &Control) -> String {
+    ///
+    /// `depth`는 이 컨트롤을 담은 셀의 표 중첩 깊이(0 = 최상위 표 바로 안)다.
+    /// `Control::Table`이 `depth >= MAX_NEST_DEPTH`이면 재귀를 멈추고 생략
+    /// 사실을 주석으로 남긴다 — `table_extract::MAX_NEST_DEPTH`와 같은 값·형태.
+    /// `Control::Table`/`Control::Picture` 외 변형은 아직 셀 안에서 내보내기를
+    /// 지원하지 않는다 [#4413]. 지원 범위 확장은 #4414 소관이라 여기서는 조용히
+    /// 버리지 않고 어떤 컨트롤이 생략됐는지 HTML 주석 경고로 남긴다.
+    pub(crate) fn control_to_html(&self, control: &Control, depth: usize) -> String {
         match control {
-            Control::Table(table) => self.table_to_html(table),
+            Control::Table(table) => {
+                if depth >= MAX_NEST_DEPTH {
+                    return format!(
+                        "<!-- rhwp: 표 중첩 깊이 상한({})을 넘어 생략됨 -->\n",
+                        MAX_NEST_DEPTH
+                    );
+                }
+                self.table_to_html(table, depth)
+            }
             Control::Picture(pic) => self.picture_to_html(pic),
-            _ => String::new(),
+            other => format!(
+                "<!-- rhwp: 셀 안 {} 컨트롤은 클립보드 HTML 내보내기 미지원 - 경고: 내용 생략됨 -->\n",
+                control_kind_label(other)
+            ),
         }
     }
 
     /// Table 컨트롤을 HTML <table>로 변환한다.
-    pub(crate) fn table_to_html(&self, table: &crate::model::table::Table) -> String {
+    /// `depth`는 이 표 자체의 중첩 깊이(0 = 최상위) — 셀 안 문단의 컨트롤을
+    /// 처리할 때는 `depth + 1`을 넘겨, 그 컨트롤이 표이면 `control_to_html`이
+    /// 상한을 검사한 뒤 그 값으로 재귀한다.
+    pub(crate) fn table_to_html(&self, table: &crate::model::table::Table, depth: usize) -> String {
         use crate::renderer::style_resolver::ResolvedBorderStyle;
 
         let mut html = String::from(
@@ -1679,9 +1744,11 @@ impl DocumentCore {
 
                 html.push_str(&format!("<td {}>\n", td_attrs));
 
-                // 셀 내부 문단들
+                // 셀 내부 문단들 — 텍스트뿐 아니라 문단에 붙은 컨트롤(중첩
+                // 표·그림 등)도 함께 내보낸다 [#4413]. 이 표 자체는 depth이므로
+                // 그 셀 문단의 컨트롤은 depth+1에서 검사한다.
                 for cpara in &cell.paragraphs {
-                    html.push_str(&self.paragraph_to_html(cpara, None, None));
+                    html.push_str(&self.cell_paragraph_to_html(cpara, None, None, depth + 1));
                 }
 
                 html.push_str("</td>\n");
@@ -1690,6 +1757,30 @@ impl DocumentCore {
         }
 
         html.push_str("</table>\n");
+        html
+    }
+
+    /// 셀 안 문단을 HTML로 변환한다 — 텍스트(`paragraph_to_html`)에 더해
+    /// `para.controls`(중첩 표·그림 등)도 순회해 이어붙인다.
+    ///
+    /// [#4413] 셀 내용 내보내기가 `para.controls`를 전혀 보지 않아 표 셀 안의
+    /// 중첩 표·이미지가 경고 없이 통째로 사라지던 결함 수정. `paragraph_to_html`
+    /// 자체는 본문(셀 밖) 선택 내보내기와도 공유하므로 그대로 두고, 셀 전용
+    /// 진입점에서만 컨트롤을 이어붙인다.
+    ///
+    /// `depth`는 이 문단을 담은 셀이 속한 표의 중첩 깊이다 — `control_to_html`에
+    /// 그대로 전달해 `MAX_NEST_DEPTH` 상한을 적용한다.
+    pub(crate) fn cell_paragraph_to_html(
+        &self,
+        para: &Paragraph,
+        start_offset: Option<usize>,
+        end_offset: Option<usize>,
+        depth: usize,
+    ) -> String {
+        let mut html = self.paragraph_to_html(para, start_offset, end_offset);
+        for ctrl in &para.controls {
+            html.push_str(&self.control_to_html(ctrl, depth));
+        }
         html
     }
 
@@ -2106,6 +2197,356 @@ mod nested_cell_paste_reflow_tests {
             paras[0].line_segs.len() > 1,
             "폭 200 최내곽 셀에 40자를 붙여넣으면 여러 줄로 재래핑돼야 함 (실제 {}줄)",
             paras[0].line_segs.len()
+        );
+    }
+}
+
+/// #4413: `paragraph_to_html`이 `para.text`만 읽고 `para.controls`를 보지 않아
+/// 표 셀 안의 중첩 표·이미지가 문서 간 복사에서 통째로 사라지던 결함의 회귀 테스트.
+#[cfg(test)]
+mod cell_control_export_tests {
+    use super::MAX_NEST_DEPTH;
+    use crate::document_core::DocumentCore;
+    use crate::model::control::{Bookmark, Control};
+    use crate::model::document::{Document, Section};
+    use crate::model::image::{ImageAttr, Picture};
+    use crate::model::paragraph::Paragraph;
+    use crate::model::shape::CommonObjAttr;
+    use crate::model::table::{Cell, Table};
+
+    /// 본문 문단 하나에 표 컨트롤(1x1)을 붙이고, 그 유일한 셀의 문단으로
+    /// `outer_cell_para`를 넣는다. 반환값은 (core, parent_para_idx, control_idx, cell_idx).
+    fn core_with_body_table(outer_cell_para: Paragraph) -> (DocumentCore, usize, usize, usize) {
+        let outer_table = Table {
+            row_count: 1,
+            col_count: 1,
+            cells: vec![Cell {
+                row: 0,
+                col: 0,
+                col_span: 1,
+                row_span: 1,
+                width: 5000,
+                paragraphs: vec![outer_cell_para],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let mut body_para = Paragraph::default();
+        body_para
+            .controls
+            .push(Control::Table(Box::new(outer_table)));
+
+        let mut section = Section::default();
+        section.paragraphs.push(body_para);
+        let mut doc = Document::default();
+        doc.sections.push(section);
+
+        let mut core = DocumentCore::new_empty();
+        core.document = doc;
+
+        (core, 0, 0, 0)
+    }
+
+    fn make_inner_table_with_marker(marker: &str) -> Table {
+        let mut inner_para = Paragraph::default();
+        inner_para.text = marker.to_string();
+        inner_para.char_offsets = (0..inner_para.text.chars().count() as u32).collect();
+
+        Table {
+            row_count: 1,
+            col_count: 1,
+            cells: vec![Cell {
+                row: 0,
+                col: 0,
+                col_span: 1,
+                row_span: 1,
+                width: 2000,
+                paragraphs: vec![inner_para],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    /// [적대적 검증 대조군] 내부 클립보드(같은 문서)는 원래 셀의 컨트롤을
+    /// 보존한다 — 이슈 #4413이 명시한 대조군. `copy_selection_in_cell_native`는
+    /// `Paragraph::clone()`으로 셀 문단을 통째로 복사하고, `strip_structural_
+    /// controls_for_text_clipboard`가 SectionDef/ColumnDef만 제거하므로
+    /// `Control::Table`은 그대로 남는다.
+    #[test]
+    fn internal_clipboard_preserves_nested_table_in_cell_control_group() {
+        let mut outer_cell_para = Paragraph::default();
+        outer_cell_para
+            .controls
+            .push(Control::Table(Box::new(make_inner_table_with_marker(
+                "INNERMARK",
+            ))));
+
+        let (mut core, parent_para_idx, control_idx, cell_idx) =
+            core_with_body_table(outer_cell_para);
+
+        core.copy_selection_in_cell_native(0, parent_para_idx, control_idx, cell_idx, 0, 0, 0, 0)
+            .expect("내부 클립보드 복사가 성공해야 함");
+
+        let clip = core.clipboard.as_ref().expect("클립보드가 채워져야 함");
+        assert_eq!(clip.paragraphs.len(), 1);
+        assert!(
+            matches!(clip.paragraphs[0].controls.first(), Some(Control::Table(_))),
+            "내부 클립보드(같은 문서 안 복사)는 중첩 표 컨트롤을 보존해야 함(대조군). 실제 controls: {:?}",
+            clip.paragraphs[0].controls
+        );
+    }
+
+    /// #4413 red→green: 셀 문단에 붙은 `Control::Table`(중첩 표)이 셀 내용 HTML
+    /// 내보내기에서 사라지면 안 된다. 수정 전에는 `export_selection_in_cell_html_native`가
+    /// `paragraph_to_html`만 호출해(controls 미참조) 안쪽 표가 전혀 나타나지 않았다.
+    #[test]
+    fn nested_table_in_cell_is_exported_to_html() {
+        let mut outer_cell_para = Paragraph::default();
+        outer_cell_para
+            .controls
+            .push(Control::Table(Box::new(make_inner_table_with_marker(
+                "INNERMARK",
+            ))));
+
+        let (core, parent_para_idx, control_idx, cell_idx) = core_with_body_table(outer_cell_para);
+
+        let html = core
+            .export_selection_in_cell_html_native(
+                0,
+                parent_para_idx,
+                control_idx,
+                cell_idx,
+                0,
+                0,
+                0,
+                0,
+            )
+            .expect("셀 내용 HTML 내보내기가 성공해야 함");
+
+        assert_eq!(
+            html.matches("<table").count(),
+            1,
+            "셀 안 중첩 표가 <table 하나로 내보내져야 함. 실제 HTML: {html}"
+        );
+        assert!(
+            html.contains("INNERMARK"),
+            "안쪽 표 셀 텍스트가 내보낸 HTML에 있어야 함. 실제 HTML: {html}"
+        );
+    }
+
+    /// #4413 red→green, cellPath 버전(#4272): `export_selection_in_cell_html_by_path_native`도
+    /// 같은 결함을 공유했다 — cellPath 하나짜리 얕은 셀도 컨트롤을 보지 않았다.
+    #[test]
+    fn nested_table_in_cell_by_path_is_exported_to_html() {
+        let mut outer_cell_para = Paragraph::default();
+        outer_cell_para
+            .controls
+            .push(Control::Table(Box::new(make_inner_table_with_marker(
+                "INNERMARK",
+            ))));
+
+        let (core, parent_para_idx, control_idx, cell_idx) = core_with_body_table(outer_cell_para);
+        let path = vec![(control_idx, cell_idx, 0)];
+
+        let html = core
+            .export_selection_in_cell_html_by_path_native(0, parent_para_idx, &path, 0, 0, 0, 0)
+            .expect("cellPath 셀 내용 HTML 내보내기가 성공해야 함");
+
+        assert!(
+            html.contains("<table"),
+            "cellPath 경로로 내보내도 셀 안 중첩 표가 나와야 함. 실제 HTML: {html}"
+        );
+        assert!(
+            html.contains("INNERMARK"),
+            "cellPath 경로로 내보내도 안쪽 표 셀 텍스트가 있어야 함. 실제 HTML: {html}"
+        );
+    }
+
+    /// #4413 red→green: 셀 문단에 붙은 `Control::Picture`(셀 안 이미지)가 셀 내용
+    /// HTML 내보내기에서 사라지면 안 된다.
+    #[test]
+    fn picture_in_cell_is_exported_to_html() {
+        let mut outer_cell_para = Paragraph::default();
+        outer_cell_para
+            .controls
+            .push(Control::Picture(Box::new(Picture {
+                common: CommonObjAttr {
+                    treat_as_char: true,
+                    width: 1000,
+                    height: 1000,
+                    ..Default::default()
+                },
+                image_attr: ImageAttr {
+                    bin_data_id: 1,
+                    ..Default::default()
+                },
+                ..Default::default()
+            })));
+
+        let (mut core, parent_para_idx, control_idx, cell_idx) =
+            core_with_body_table(outer_cell_para);
+        core.document
+            .bin_data_content
+            .push(crate::model::bin_data::BinDataContent {
+                id: 1,
+                data: crate::model::bin_data::BinDataBytes::from_shared(vec![
+                    0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A,
+                ]),
+                extension: "png".to_string(),
+            });
+
+        let html = core
+            .export_selection_in_cell_html_native(
+                0,
+                parent_para_idx,
+                control_idx,
+                cell_idx,
+                0,
+                0,
+                0,
+                0,
+            )
+            .expect("셀 내용 HTML 내보내기가 성공해야 함");
+
+        assert!(
+            html.contains("<img"),
+            "셀 안 이미지가 <img>로 내보내져야 함. 실제 HTML: {html}"
+        );
+    }
+
+    /// [본문 대조군] 본문(셀 밖) 그림은 애초에 문제가 없었다 — 직접 컨트롤을
+    /// 선택해 내보내는 `export_control_html_native` 경로는 셀 순회와 무관하게
+    /// 항상 `control_to_html`을 탔다. 위치(셀 안 vs 본문 직접 선택)에 결함이
+    /// 국한됨을 확정하는 대조군.
+    #[test]
+    fn body_level_picture_export_via_control_html_was_already_fine() {
+        let pic = Picture {
+            common: CommonObjAttr {
+                treat_as_char: true,
+                width: 1000,
+                height: 1000,
+                ..Default::default()
+            },
+            image_attr: ImageAttr {
+                bin_data_id: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut body_para = Paragraph::default();
+        body_para.controls.push(Control::Picture(Box::new(pic)));
+
+        let mut section = Section::default();
+        section.paragraphs.push(body_para);
+        let mut doc = Document::default();
+        doc.sections.push(section);
+        doc.bin_data_content
+            .push(crate::model::bin_data::BinDataContent {
+                id: 1,
+                data: crate::model::bin_data::BinDataBytes::from_shared(vec![
+                    0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A,
+                ]),
+                extension: "png".to_string(),
+            });
+
+        let mut core = DocumentCore::new_empty();
+        core.document = doc;
+
+        let html = core
+            .export_control_html_native(0, 0, &[], 0)
+            .expect("본문 컨트롤 HTML 내보내기가 성공해야 함");
+
+        assert!(
+            html.contains("<img"),
+            "본문에서 직접 선택한 그림은 원래도 <img>로 내보내져야 함. 실제 HTML: {html}"
+        );
+    }
+
+    /// #4413 수정: `Control::Table`/`Control::Picture` 외의 셀 안 컨트롤(예: 책갈피)은
+    /// 아직 지원 대상이 아니다(#4414 소관) — 조용히 버리지 않고 HTML 주석 경고를
+    /// 남겨야 한다.
+    #[test]
+    fn unsupported_cell_control_leaves_warning_comment_not_silent_drop() {
+        let mut outer_cell_para = Paragraph::default();
+        outer_cell_para
+            .controls
+            .push(Control::Bookmark(Bookmark::default()));
+
+        let (core, parent_para_idx, control_idx, cell_idx) = core_with_body_table(outer_cell_para);
+
+        let html = core
+            .export_selection_in_cell_html_native(
+                0,
+                parent_para_idx,
+                control_idx,
+                cell_idx,
+                0,
+                0,
+                0,
+                0,
+            )
+            .expect("셀 내용 HTML 내보내기가 성공해야 함");
+
+        assert!(
+            html.contains("<!--") && html.contains("Bookmark"),
+            "지원하지 않는 셀 컨트롤은 조용히 버리지 말고 어떤 컨트롤이 생략됐는지 \
+             HTML 주석 경고를 남겨야 함. 실제 HTML: {html}"
+        );
+    }
+
+    /// #4413 수정: 표 중첩 HTML 변환 재귀에 `MAX_NEST_DEPTH` 상한이 실제로 걸린다.
+    /// `MAX_NEST_DEPTH + 4`단 깊이로 표를 중첩시키고 최상위에서 내보내면, 가장
+    /// 안쪽(마커 포함) 표는 상한을 넘어 렌더링되지 않고 생략 주석만 남아야 한다.
+    /// 상한이 없으면 병적으로 깊은 중첩 문서에서 export 재귀가 스택을 태울 수 있다.
+    #[test]
+    fn nested_table_recursion_is_capped_at_max_depth() {
+        const LEVELS: usize = MAX_NEST_DEPTH + 4;
+
+        let mut table = make_inner_table_with_marker("DEEPMARK");
+        for _ in 0..LEVELS {
+            let mut wrapper_para = Paragraph::default();
+            wrapper_para.controls.push(Control::Table(Box::new(table)));
+            table = Table {
+                row_count: 1,
+                col_count: 1,
+                cells: vec![Cell {
+                    row: 0,
+                    col: 0,
+                    col_span: 1,
+                    row_span: 1,
+                    width: 2000,
+                    paragraphs: vec![wrapper_para],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            };
+        }
+
+        let mut body_para = Paragraph::default();
+        body_para.controls.push(Control::Table(Box::new(table)));
+
+        let mut section = Section::default();
+        section.paragraphs.push(body_para);
+        let mut doc = Document::default();
+        doc.sections.push(section);
+
+        let mut core = DocumentCore::new_empty();
+        core.document = doc;
+
+        let html = core
+            .export_control_html_native(0, 0, &[], 0)
+            .expect("최상위 표 컨트롤 HTML 내보내기가 성공해야 함");
+
+        assert!(
+            !html.contains("DEEPMARK"),
+            "깊이 상한을 넘는 가장 안쪽 표는 렌더링되면 안 됨. 실제 HTML: {html}"
+        );
+        assert!(
+            html.contains("깊이 상한"),
+            "깊이 상한에 걸리면 생략 사실을 주석으로 남겨야 함. 실제 HTML: {html}"
         );
     }
 }

--- a/src/document_core/html_table_import.rs
+++ b/src/document_core/html_table_import.rs
@@ -122,15 +122,19 @@ impl DocumentCore {
                             _ => 0u8,           // 미지정 → Center (HWP 기본)
                         };
 
-                    // 셀 내용 HTML 추출
+                    // 셀 내용 HTML 추출 — 셀 안에 같은 태그 이름의 중첩 표(예:
+                    // 우리 clipboard export 가 내보내는 중첩 <table>도 셀에
+                    // <td>를 쓴다)가 있으면 얕은 find 는 안쪽 셀의 닫는 태그에서
+                    // 먼저 멈춰 바깥 셀 내용을 잘라먹는다(#4413 왕복 검증 중
+                    // 발견). <tr> 경계 탐색에 이미 쓰는 깊이 추적 헬퍼를 그대로
+                    // 재사용해 같은 태그 이름의 중첩을 건너뛴다.
                     let content_start = cell_abs + gt + 1;
                     let close_tag = format!("</{}>", tag_name);
-                    let content_end =
-                        if let Some(close) = tr_inner_lower[content_start..].find(&close_tag) {
-                            content_start + close
-                        } else {
-                            tr_inner.len()
-                        };
+                    let cell_close = find_closing_tag(tr_inner, cell_abs, tag_name);
+                    let content_end = cell_close
+                        .saturating_sub(close_tag.len())
+                        .max(content_start)
+                        .min(tr_inner.len());
                     let content_html = tr_inner[content_start..content_end].to_string();
 
                     row_cells.push(ParsedCell {
@@ -148,7 +152,9 @@ impl DocumentCore {
                         vertical_align,
                     });
 
-                    td_pos = content_end + close_tag.len();
+                    td_pos = content_end
+                        .saturating_add(close_tag.len())
+                        .min(tr_inner_lower.len());
                 } else {
                     break;
                 }
@@ -1019,5 +1025,79 @@ impl DocumentCore {
         para.controls.push(Control::Picture(Box::new(pic)));
 
         paragraphs.push(para);
+    }
+}
+
+/// #4413: clipboard export가 셀 안 중첩 표를 `<table>`로 내보내도, import 쪽이 셀
+/// 내용(`<td>...</td>`) 경계를 얕은(비-깊이추적) `find`로 잘라내면 안쪽 표에서
+/// 잘못 멈춰 왕복이 깨진다. `<tr>` 경계 탐색에 이미 쓰는 `find_closing_tag` 깊이
+/// 추적을 셀 경계에도 재사용해 중첩 `<td>`를 올바르게 건너뛰는지 검증한다.
+#[cfg(test)]
+mod nested_table_cell_boundary_tests {
+    use crate::document_core::DocumentCore;
+    use crate::model::control::Control;
+    use crate::model::paragraph::Paragraph;
+
+    /// red→green: 바깥 셀 안에 중첩 `<table>`이 있는 HTML을 파싱하면, 바깥 셀은
+    /// "OUTER" 텍스트 문단과 중첩 `Control::Table`(안쪽 셀 텍스트 "INNER") 문단을
+    /// 모두 포함해야 한다. 수정 전에는 셀 내용 추출이 안쪽 `</td>`에서 먼저 멈춰
+    /// 바깥 셀 내용이 잘리고(중첩 표가 통째로 사라지거나 파싱이 깨졌다).
+    #[test]
+    fn nested_table_in_cell_round_trips_through_import() {
+        let mut core = DocumentCore::new_empty();
+        core.document
+            .doc_info
+            .char_shapes
+            .push(crate::model::style::CharShape::default());
+        core.document
+            .doc_info
+            .para_shapes
+            .push(crate::model::style::ParaShape::default());
+        core.document
+            .doc_info
+            .border_fills
+            .push(crate::model::style::BorderFill::default());
+
+        let html =
+            r#"<table><tr><td>OUTER<table><tr><td>INNER</td></tr></table></td></tr></table>"#;
+        let mut paragraphs: Vec<Paragraph> = Vec::new();
+        core.parse_table_html(&mut paragraphs, html);
+
+        assert_eq!(paragraphs.len(), 1, "표 문단 1개가 나와야 함");
+        let outer_table = match &paragraphs[0].controls.first() {
+            Some(Control::Table(t)) => t.as_ref(),
+            other => panic!("Table 컨트롤이어야 함, 실제: {other:?}"),
+        };
+        assert_eq!(outer_table.cells.len(), 1, "바깥 표는 셀 1개");
+
+        let outer_cell_paragraphs = &outer_table.cells[0].paragraphs;
+        let has_outer_text = outer_cell_paragraphs
+            .iter()
+            .any(|p| p.text.contains("OUTER"));
+        assert!(
+            has_outer_text,
+            "바깥 셀 텍스트 'OUTER'가 살아있어야 함. 실제 문단들: {outer_cell_paragraphs:?}"
+        );
+
+        let inner_table = outer_cell_paragraphs.iter().find_map(|p| {
+            p.controls.iter().find_map(|c| match c {
+                Control::Table(t) => Some(t.as_ref()),
+                _ => None,
+            })
+        });
+        let inner_table = inner_table.unwrap_or_else(|| {
+            panic!(
+                "바깥 셀 문단 중 하나에 중첩 Control::Table이 있어야 함. 실제 문단들: {outer_cell_paragraphs:?}"
+            )
+        });
+        assert_eq!(inner_table.cells.len(), 1, "안쪽 표는 셀 1개");
+        assert!(
+            inner_table.cells[0]
+                .paragraphs
+                .iter()
+                .any(|p| p.text.contains("INNER")),
+            "안쪽 셀 텍스트 'INNER'가 살아있어야 함. 실제: {:?}",
+            inner_table.cells[0].paragraphs
+        );
     }
 }


### PR DESCRIPTION
클립보드 HTML 내보내기가 셀 내용을 `para.text` 만으로 만들고 `para.controls` 를 보지 않습니다. 문서 간 복사에서 **셀 안의 중첩 표와 이미지가 통째로 사라집니다.** 같은 결함이 세 진입점에 있었습니다 — `export_selection_in_cell_html_native`, `export_selection_in_cell_html_by_path_native`(#4272 로 뒤에 추가된 두 번째 사례), `table_to_html` 의 셀 루프.

셀 문단 전용 `cell_paragraph_to_html` 을 만들어 세 곳에 연결했습니다. 지원하지 않는 컨트롤 변형은 조용히 사라지는 대신 종류를 밝힌 HTML 주석을 남깁니다.

**받는 쪽은 손실이 아니라 패닉이었습니다.** `html_table_import.rs:48` 의 `<td>`/`<th>` 경계 추출이 순진한 `.find()` 라 같은 태그가 중첩되면 범위를 벗어난 슬라이스로 죽습니다 — `byte index 18 is out of bounds of `<tr><td>inner``. 같은 파일이 `<tr>` 경계용으로 이미 쓰고 있는 깊이 추적 헬퍼 `find_closing_tag` 를 재사용해 닫았습니다.

RED 확인은 패치를 떼어내고 했습니다 — 두 파일을 `upstream/devel` 로 되돌리고 테스트만 얹어 6건 FAILED 를 받았습니다. 대조군 2건은 수정 전에도 통과해 결함 범위가 셀 경로에 한정됨을 함께 확인했습니다.

`CARGO_INCREMENTAL=0 cargo test --profile release-test --tests` exit 0, `test result:` 블록 497개, FAILED 0건. fmt·clippy clean.

중첩 재귀에 `MAX_NEST_DEPTH = 8` 을 두었는데 `table_extract`/`explain`/`hidden_text` 와 같은 값을 또 한 벌 적은 것입니다. 이 PR 에서 합치지 않았습니다 — 순회기 중복 자체는 #4422 의 일입니다. 이 작업에서 발견했지만 고치지 않은 캡션 미방출 등 4건은 #4427 로 열었습니다.

Closes #4413
