### PR TITLE
core: HWP5 저장이 미기입 누름틀 안내문을 복원하지 않던 결함 수정

### DIFF
--- a/mydocs/working/task_m100_4402_stage1.md
+++ b/mydocs/working/task_m100_4402_stage1.md
@@ -1,0 +1,55 @@
+# task_m100_4402 Stage 1 — HWP5 저장이 미기입 누름틀 안내문을 복원하지 않는다
+
+- **이슈**: [#4402](https://github.com/edwardkim/rhwp/issues/4402)
+- **브랜치**: `fix/issue-4402-hwp5-guide-residue`
+- **분기 기준**: `upstream/devel` (0 behind)
+- **상태**: 게이트 전부 통과, PR 게시
+- **기록일**: 2026-08-10 KST
+
+## 1. 결함
+
+누름틀(필드)에 아직 아무것도 입력하지 않으면 본문에는 안내문이 남아 있다. HWP5 로 저장하면
+이 안내문(`guide_residue`)이 복원되지 않는다. HWPX 축은 #3545 에서 이미 해소됐고 **HWP5 축만
+남아 있었다.**
+
+## 2. 검증 — 수정 전 4건 RED
+
+```
+form_02_survives_hwp_to_hwpx_to_hwp5_roundtrip
+  form-02.hwp 안내문이 HWP→HWPX→HWP5 왕복에서 소실/중복됐다  left: 0  right: 1
+initial_guide_text_save_reload_save_fixed_point
+  저장→재적재→재저장 고정점에서 안내문이 소실/중복됐다
+hwp_to_hwpx_to_hwp5_roundtrip_preserves_guide_text
+sibling_field_edit_forces_reserialize_and_guide_text_survives
+  다른 필드(작성자) 편집으로 재구성된 저장본에서 회사명의 안내문이 소실/중복됐다
+test result: FAILED. 3 passed; 4 failed
+```
+
+같은 파일의 나머지 3건은 수정 전에도 통과한다 — `raw_stream` 통과 경로가 깨지지 않았음을
+확인하는 비회귀 가드라서 그렇다. 즉 결함 범위가 재직렬화 경로에 한정됨을 함께 보인 것이다.
+
+## 3. 게이트 (완료)
+
+- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` 통과.
+- `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests` — 바이너리 **498개, 0 failed**.
+  합계 **5,506 passed / 0 failed / 35 ignored**. `test result: FAILED` grep 0건.
+
+## 4. 새 코드에 남긴 미검증 경로
+
+`shift_char_shapes_for_residues`(`src/serializer/body_text.rs` 신규, ~850행)는 잔여물 삽입
+위치의 동률 `char_shapes` 그룹에 `residue.char_shape_id` 와 일치하는 항목이 **없을 때** 그룹
+전체를 민다. 즉 필드 자기 스타일 항목이 필드 경계에 정확히 놓이지 않고 그보다 앞에 있는 경우다.
+
+**시험한 실제 샘플 3건은 전부 정확히 일치해서 이 폴백 경로를 타지 않는다.** 재현 사례를 찾지
+못했으므로 이 분기는 미검증 상태다. 실물에서 걸리면 전용 픽스처가 필요하다.
+
+## 5. 이 작업에서 고치지 않은 것
+
+`parse_paragraph`(`src/parser/hwpx/section.rs:492`, `:496`)가 `SectionDef` 를 항상 먼저 push 해
+HWP5 원본의 `[ColumnDef, SectionDef]` 순서를 왕복에서 뒤집는다. `samples/field-01-memo.hwp`
+문단 0.0·1.0·2.0 에서 `ctrl[0] A=cold vs B=secd` 로 관측된다. **이 수정 전후 모두 재현되므로
+기존 결함이고, 범위 밖이라 손대지 않았다** — [#4433](https://github.com/edwardkim/rhwp/issues/4433).
+
+## 6. 미처리
+
+GitHub Actions, 작업지시자 승인, merge.

--- a/src/serializer/body_text.rs
+++ b/src/serializer/body_text.rs
@@ -238,12 +238,18 @@ fn serialize_paragraph_with_msb(
 
     // PARA_TEXT를 먼저 직렬화하여 실제 char_count를 계산한다.
     // char_count가 PARA_TEXT code unit 수와 불일치하면 한컴이 파일 손상으로 판단한다.
+    //
+    // [#4402] `serialize_para_text` 는 미기입 누름틀의 안내문 잔재(`Field.guide_residue`)를
+    // 함께 되살리고, 그로 인해 벌어진 위치들을 `residue_shifts` 로 돌려준다 — 아래
+    // PARA_CHAR_SHAPE 가 그 시프트를 반영해야 텍스트 버퍼와 서식 경계가 어긋나지 않는다.
     let has_content = !para.text.is_empty() || !para.controls.is_empty();
-    let text_data = if has_content || (para.has_para_text && para.char_count > 1) {
-        Some(serialize_para_text(para))
-    } else {
-        None
-    };
+    let (text_data, residue_shifts): (Option<Vec<u8>>, Vec<GuideResidueShift>) =
+        if has_content || (para.has_para_text && para.char_count > 1) {
+            let result = serialize_para_text(para);
+            (Some(result.bytes), result.residue_shifts)
+        } else {
+            (None, Vec::new())
+        };
 
     // char_count 재계산: PARA_TEXT가 있으면 code unit 수, 없으면 모델 값 사용
     let actual_char_count = if let Some(ref td) = text_data {
@@ -279,7 +285,15 @@ fn serialize_paragraph_with_msb(
 
     // PARA_CHAR_SHAPE (항상 출력 — HWP 필수)
     {
-        let data = serialize_para_char_shape(effective_char_shapes);
+        let shifted_char_shapes;
+        let char_shapes_for_record: &[CharShapeRef] = if residue_shifts.is_empty() {
+            effective_char_shapes
+        } else {
+            shifted_char_shapes =
+                shift_char_shapes_for_residues(effective_char_shapes, &residue_shifts);
+            &shifted_char_shapes
+        };
+        let data = serialize_para_char_shape(char_shapes_for_record);
         records.push(Record {
             tag_id: tags::HWPTAG_PARA_CHAR_SHAPE,
             level: base_level + 1,
@@ -445,15 +459,87 @@ fn push_extended_ctrl(code_units: &mut Vec<u16>, ctrl_code: u16, ctrl_id: u32) {
 /// 테스트용 public wrapper
 #[cfg(test)]
 pub fn test_serialize_para_text(para: &Paragraph) -> Vec<u8> {
-    serialize_para_text(para)
+    serialize_para_text(para).bytes
 }
 
-fn serialize_para_text(para: &Paragraph) -> Vec<u8> {
+/// [#4402] `serialize_para_text` 가 되살린 안내문 잔재 1건의 위치 정보.
+///
+/// `position` 은 삽입 **이전** 좌표계 — 즉 적재 시 삭제 수술이 남긴, 지금 `para.char_shapes`/
+/// `para.char_offsets` 가 쓰는 collapsed 좌표 — 기준 UTF-16 code unit 위치다.
+/// `PARA_CHAR_SHAPE` 를 되살린 텍스트 폭만큼 뒤로 미는 데 쓴다
+/// (`shift_char_shapes_for_residues`).
+struct GuideResidueShift {
+    position: u32,
+    width: u32,
+    char_shape_id: u32,
+}
+
+struct ParaTextResult {
+    bytes: Vec<u8>,
+    /// 문단 안에서 되살린 안내문 잔재들 — 위치 오름차순.
+    residue_shifts: Vec<GuideResidueShift>,
+}
+
+/// [#4402] HWP5 저장에서도 미기입 누름틀 안내문을 되살릴지 판정한다.
+///
+/// `#3545` 가 HWPX 저장(`emit_guide_residue`, `src/serializer/hwpx/section.rs`)에 붙인 것과
+/// 동일한 게이트 — 값이 채워진 필드(start != end)와 사용자가 비운 필드(dirty bit 15)는
+/// 건너뛴다. 중복 주입·사용자가 비운 값의 부활을 막는다.
+fn guide_residue_for<'a>(
+    para: &'a Paragraph,
+    fr: &crate::model::paragraph::FieldRange,
+) -> Option<&'a crate::model::control::GuideResidue> {
+    if fr.start_char_idx != fr.end_char_idx {
+        return None;
+    }
+    let Some(Control::Field(f)) = para.controls.get(fr.control_idx) else {
+        return None;
+    };
+    if f.is_dirty() {
+        return None;
+    }
+    let residue = f.guide_residue.as_ref()?;
+    if residue.text.is_empty() {
+        return None;
+    }
+    Some(residue)
+}
+
+/// 안내문 텍스트를 UTF-16 code unit 으로 인코딩해 `code_units` 에 밀어 넣고, 되돌린 폭과
+/// 위치를 `residue_shifts` 에 기록한다 (`shift_char_shapes_for_residues` 가 소비한다).
+///
+/// `position` 은 삽입 시점 기준 아직 시프트를 반영하지 않은 현재 좌표.
+fn push_guide_residue(
+    code_units: &mut Vec<u16>,
+    residue_shifts: &mut Vec<GuideResidueShift>,
+    residue: &crate::model::control::GuideResidue,
+    position: u32,
+) {
+    let start_len = code_units.len();
+    for c in residue.text.chars() {
+        let mut buf = [0u16; 2];
+        for cu in c.encode_utf16(&mut buf) {
+            code_units.push(*cu);
+        }
+    }
+    let width = (code_units.len() - start_len) as u32;
+    if width == 0 {
+        return;
+    }
+    residue_shifts.push(GuideResidueShift {
+        position,
+        width,
+        char_shape_id: residue.char_shape_id,
+    });
+}
+
+fn serialize_para_text(para: &Paragraph) -> ParaTextResult {
     let mut code_units: Vec<u16> = Vec::new();
     let text_chars: Vec<char> = para.text.chars().collect();
     let mut ctrl_idx = 0;
     let mut prev_end: u32 = 0;
     let mut tab_idx: usize = 0; // TAB 확장 데이터 인덱스
+    let mut residue_shifts: Vec<GuideResidueShift> = Vec::new();
 
     // field_ranges에서 FIELD_END 삽입 정보를 수집
     // 두 종류로 분류:
@@ -467,6 +553,13 @@ fn serialize_para_text(para: &Paragraph) -> Vec<u8> {
     let mut trailing_end_after_ctrl: HashMap<usize, Vec<FieldEndMarker>> = HashMap::new();
     // trailing FIELD_END 중 FIELD_BEGIN이 이미 본문에 배치된 경우 (orphan)
     let mut trailing_orphan_ends: Vec<u32> = Vec::new();
+    // [#4402] empty_field_ends/trailing_end_after_ctrl 과 같은 키로 안내문 잔재를 매핑 —
+    // 자기 FIELD_END 직전에 되살린다. mismatch(orphan) 경로는 #3545 와 동일하게 제외한다
+    // (슬롯 위치 추정이 이미 무너진 퇴화 경로라 주입이 개선이라 단정할 수 없다).
+    let mut empty_field_residues: BTreeMap<usize, Vec<&crate::model::control::GuideResidue>> =
+        BTreeMap::new();
+    let mut trailing_residues: HashMap<usize, Vec<&crate::model::control::GuideResidue>> =
+        HashMap::new();
 
     // [#4.6] 위치별 방출 순서를 명시하기 위한 두 갈래.
     //
@@ -495,11 +588,18 @@ fn serialize_para_text(para: &Paragraph) -> Vec<u8> {
         } else {
             FieldEndMarker::default()
         };
+        let residue = guide_residue_for(para, fr);
         if fr.end_char_idx < text_len && fr.start_char_idx == fr.end_char_idx {
             empty_field_ends
                 .entry(fr.end_char_idx)
                 .or_default()
                 .push(marker);
+            if let Some(residue) = residue {
+                empty_field_residues
+                    .entry(fr.end_char_idx)
+                    .or_default()
+                    .push(residue);
+            }
         } else if fr.end_char_idx < text_len {
             field_ends.entry(fr.end_char_idx).or_default().push(marker);
         } else {
@@ -509,6 +609,12 @@ fn serialize_para_text(para: &Paragraph) -> Vec<u8> {
                 .entry(fr.control_idx)
                 .or_default()
                 .push(marker);
+            if let Some(residue) = residue {
+                trailing_residues
+                    .entry(fr.control_idx)
+                    .or_default()
+                    .push(residue);
+            }
         }
     }
 
@@ -604,6 +710,13 @@ fn serialize_para_text(para: &Paragraph) -> Vec<u8> {
         }
 
         // ④ 빈 필드(시작==끝)의 FIELD_END — 자기 BEGIN 직후.
+        // [#4402] 안내문 잔재는 자기 FIELD_END 바로 앞에 되살린다 (HWPX
+        // `emit_field_end_at` 과 동일 순서 — BEGIN 뒤, END 앞).
+        if let Some(residues) = empty_field_residues.get(&i) {
+            for &residue in residues {
+                push_guide_residue(&mut code_units, &mut residue_shifts, residue, prev_end);
+            }
+        }
         if let Some(markers) = empty_field_ends.get(&i) {
             for &marker in markers {
                 push_field_end_ctrl(&mut code_units, marker);
@@ -660,14 +773,27 @@ fn serialize_para_text(para: &Paragraph) -> Vec<u8> {
 
     // 남은 컨트롤 배치 + trailing FIELD_END 인터리빙
     // FIELD_BEGIN 컨트롤 직후에 대응하는 FIELD_END를 삽입하여 올바른 순서를 보장한다.
+    //
+    // [#4402] 이 구간은 본디 위치 예산(offset/prev_end 갭 채우기)을 추적하지 않지만,
+    // `char_shapes` 시프트 계산은 절대 위치가 필요하다 — `prev_end` 를 그대로 이어 써서
+    // (메인 루프가 끝난 시점 값에서 시작) 8 code unit 씩 전진시킨다.
     while ctrl_idx < para.controls.len() {
         let (ctrl_code, ctrl_id) = control_char_code_and_id(&para.controls[ctrl_idx]);
         push_extended_ctrl(&mut code_units, ctrl_code, ctrl_id);
+        prev_end += 8;
+
+        // 이 컨트롤(FIELD_BEGIN)에 대응하는 안내문 잔재 — 자기 FIELD_END 바로 앞.
+        if let Some(residues) = trailing_residues.get(&ctrl_idx) {
+            for &residue in residues {
+                push_guide_residue(&mut code_units, &mut residue_shifts, residue, prev_end);
+            }
+        }
 
         // 이 컨트롤(FIELD_BEGIN)에 대응하는 trailing FIELD_END 삽입
         if let Some(end_markers) = trailing_end_after_ctrl.remove(&ctrl_idx) {
             for marker in end_markers {
                 push_field_end_ctrl(&mut code_units, marker);
+                prev_end += 8;
             }
         }
 
@@ -676,6 +802,10 @@ fn serialize_para_text(para: &Paragraph) -> Vec<u8> {
 
     // orphan trailing FIELD_END: FIELD_BEGIN이 본문 갭에서 이미 배치된 경우
     // (trailing_end_after_ctrl에 남아있는 항목 = ctrl_idx가 이미 소진된 컨트롤)
+    //
+    // [#4402] 이 경로의 안내문 잔재는 의도적으로 되살리지 않는다 — 슬롯 위치 추정이
+    // 이미 무너진 mismatch/퇴화 경로라 주입이 개선이라 단정할 수 없다는 #3545 의
+    // HWPX 축 판단(`emit_guide_residue` 는 이 경로를 다루지 않는다)을 그대로 따른다.
     for end_markers in trailing_end_after_ctrl.values() {
         for &marker in end_markers {
             push_field_end_ctrl(&mut code_units, marker);
@@ -690,7 +820,73 @@ fn serialize_para_text(para: &Paragraph) -> Vec<u8> {
     for cu in &code_units {
         bytes.extend_from_slice(&cu.to_le_bytes());
     }
-    bytes
+    residue_shifts.sort_by_key(|s| s.position);
+    ParaTextResult {
+        bytes,
+        residue_shifts,
+    }
+}
+
+/// [#4402] `PARA_CHAR_SHAPE` 에 되살린 안내문 잔재 폭을 반영해 `start_pos` 를 민다.
+///
+/// HWP5 의 char_shape 는 (HWPX 의 런별 `charPrIDRef` 와 달리) 문단 텍스트 버퍼 안 절대
+/// UTF-16 위치를 가리키는 표다. `serialize_para_text` 가 삽입한 잔재 폭만큼 그 뒤 항목을
+/// 밀어주지 않으면 이후 모든 서식 경계가 어긋난다.
+///
+/// 적재 시 삭제 수술(`document_core::commands::document`)은 (a) 삭제 범위 **안**의 경계를
+/// 삭제 시작점(`u_start`)으로 접고 (b) 삭제 범위 **뒤**의 경계는 `u_start` 로 감산해 옮긴다 —
+/// 둘 다 결과적으로 `u_start` 에 위치가 겹칠 수 있다(zero-width). `residue.char_shape_id` 는
+/// 삭제 **전** 좌표에서 `u_start` 이하 마지막 항목(= 잔재 자신의 서식)을 가리키므로, 같은
+/// 위치에 묶인 항목들 중 그 id 를 가진 것까지는 그대로 두고(잔재가 시작하는 지점) 그 뒤부터
+/// 미는 것이 되돌리기의 역연산이다. 그 id 를 못 찾으면(잔재 자신의 항목이 `u_start` 보다
+/// 앞에 있던 축퇴 경로) 묶음 전체가 삭제 범위 뒤에서 온 것으로 보고 첫 항목부터 민다.
+fn shift_char_shapes_for_residues(
+    char_shapes: &[CharShapeRef],
+    residue_shifts: &[GuideResidueShift],
+) -> Vec<CharShapeRef> {
+    if residue_shifts.is_empty() {
+        return char_shapes.to_vec();
+    }
+    let mut result = Vec::with_capacity(char_shapes.len());
+    let mut shift: u32 = 0;
+    let mut next = 0usize;
+    let mut i = 0usize;
+    while i < char_shapes.len() {
+        while next < residue_shifts.len()
+            && residue_shifts[next].position < char_shapes[i].start_pos
+        {
+            shift += residue_shifts[next].width;
+            next += 1;
+        }
+        if next < residue_shifts.len() && residue_shifts[next].position == char_shapes[i].start_pos
+        {
+            let pos = char_shapes[i].start_pos;
+            let mut j = i;
+            while j < char_shapes.len() && char_shapes[j].start_pos == pos {
+                j += 1;
+            }
+            let residue = &residue_shifts[next];
+            let anchor = (i..j).find(|&k| char_shapes[k].char_shape_id == residue.char_shape_id);
+            let shift_from = anchor.map(|a| a + 1).unwrap_or(i);
+            for (k, cs) in char_shapes.iter().enumerate().take(j).skip(i) {
+                let extra = if k < shift_from { 0 } else { residue.width };
+                result.push(CharShapeRef {
+                    start_pos: pos + shift + extra,
+                    char_shape_id: cs.char_shape_id,
+                });
+            }
+            shift += residue.width;
+            next += 1;
+            i = j;
+            continue;
+        }
+        result.push(CharShapeRef {
+            start_pos: char_shapes[i].start_pos + shift,
+            char_shape_id: char_shapes[i].char_shape_id,
+        });
+        i += 1;
+    }
+    result
 }
 
 /// PARA_CHAR_SHAPE 직렬화

--- a/tests/issue_4402_hwp5_guide_residue_roundtrip.rs
+++ b/tests/issue_4402_hwp5_guide_residue_roundtrip.rs
@@ -1,0 +1,188 @@
+//! [Issue #4402] HWP5 저장 경로가 미기입 누름틀 안내문(`Field.guide_residue`)을
+//! 복원하지 않는다 — HWPX 축만 #3545 로 해소.
+//!
+//! `#3545` 는 이 결함을 HWPX 축에서 고쳤다: 적재 정규화(`clear_initial_field_texts`,
+//! `document_core::commands::document`)가 미기입 누름틀(ClickHere, 수정됨 표식 bit 15 == 0)의
+//! 안내문 본문을 `para.text` 에서 지우고 `Field.guide_residue`(`char_shape_id` 동반)에
+//! 보관한 뒤, HWPX 저장기(`emit_guide_residue`, `serializer/hwpx/section.rs`)가 그 잔재를
+//! 저장 시점에 되살린다. HWP5 저장 경로(`serialize_para_text`,
+//! `serializer/body_text.rs`)에는 그 배선이 없어, HWP5 로 저장(또는 HWP→HWPX→HWP5 왕복,
+//! HWPX 원본을 HWP5 로 `convert`)만 해도 안내문이 **파일에서 영구 소실**됐다.
+//!
+//! 재현: `samples/form-01.hwp` (HWP5 네이티브, ClickHere 필드 `myMsg01` 안내문
+//! "여기에 입력" 이 본문 run 으로 실재)를 로드 → 저장 → raw 파서(정규화를 거치지 않는
+//! `parser::parse_hwp`)로 재파싱하면, 수정 전에는 안내문 텍스트가 파일 어디에도 없다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+const SAMPLE: &str = "samples/form-01.hwp";
+const FIELD: &str = "myMsg01";
+/// `samples/form-01.hwp` 의 `myMsg01` 안내문. 본문 텍스트도 이 값과 같다(초기 상태).
+const GUIDE: &str = "여기에 입력";
+
+fn sample_bytes() -> Vec<u8> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    std::fs::read(&path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"))
+}
+
+fn load(bytes: &[u8]) -> rhwp::wasm_api::HwpDocument {
+    rhwp::wasm_api::HwpDocument::from_bytes(bytes).expect("parse")
+}
+
+fn field_value(doc: &rhwp::wasm_api::HwpDocument, name: &str) -> String {
+    let json = doc.get_field_list();
+    let v: serde_json::Value = serde_json::from_str(&json).expect("field list JSON");
+    let fields = v["fields"]
+        .as_array()
+        .or_else(|| v.as_array())
+        .expect("fields 배열");
+    fields
+        .iter()
+        .find(|f| f["name"] == name)
+        .map(|f| f["value"].as_str().unwrap_or("").to_string())
+        .unwrap_or_else(|| panic!("필드 {name} 없음"))
+}
+
+/// 저장본을 **정규화를 거치지 않는** raw 파서로 다시 읽어, 실제 파일 바이트 수준에서
+/// 안내문이 살아있는지 확인한다 — `rhwp ir-diff` 가 이 결함을 발견한 것과 같은 층위다.
+/// `document_core` 를 거친 값 API(`field_value`)는 항상 정규화되어 빈 값이라 이 결함을
+/// 가리지 못한다(왕복해서 재적재해도 다시 지워지므로).
+fn raw_paragraph_texts(bytes: &[u8]) -> Vec<String> {
+    let doc = rhwp::parser::parse_hwp(bytes).expect("raw parse");
+    doc.sections
+        .iter()
+        .flat_map(|s| s.paragraphs.iter().map(|p| p.text.clone()))
+        .collect()
+}
+
+fn count_guide_occurrences(texts: &[String]) -> usize {
+    texts.iter().filter(|t| t.contains(GUIDE)).count()
+}
+
+/// 무회귀: 값 API 계약(정규화)은 그대로 유지된다 — 안내문 복원은 IR 이 아니라 저장 바이트
+/// 층위에서만 일어나야 한다.
+#[test]
+fn initial_state_still_normalized_on_load() {
+    let doc = load(&sample_bytes());
+    assert_eq!(
+        field_value(&doc, FIELD),
+        "",
+        "초기 상태 안내문 잔재는 로드 시 정규화되어야 한다"
+    );
+}
+
+/// 저장 축(직접 저장, 편집 없음): `export_hwp` 는 편집이 전혀 없으면 `section.raw_stream`
+/// 원본 바이트를 통째로 복사하는 지름길을 탄다(`serialize_section`) — 이 경로는
+/// `serialize_para_text` 를 아예 거치지 않으므로 이 결함을 가리지 못한다(안내문이 원본에
+/// 이미 있으니 통과해 버린다). 이 테스트는 그 지름길이 계속 성립하는지 확인하는 무회귀
+/// 가드일 뿐, 이 이슈의 회귀 판정에는 아래 `hwp_to_hwpx_to_hwp5_roundtrip_*` /
+/// `sibling_field_edit_*` 테스트를 본다(둘 다 `raw_stream` 이 무효화되어 실제
+/// `serialize_para_text` 경로를 태운다).
+#[test]
+fn initial_guide_text_survives_hwp5_save_no_edit_raw_passthrough() {
+    let mut doc = load(&sample_bytes());
+    let saved = doc.export_hwp().expect("export_hwp");
+    let texts = raw_paragraph_texts(&saved);
+    assert_eq!(
+        count_guide_occurrences(&texts),
+        1,
+        "초기 상태 누름틀의 안내문이 HWP5 저장본에서 소실/중복됐다: {texts:?}"
+    );
+}
+
+/// 저장 축(핵심 재현): **다른** 필드를 채우는 편집이 `section.raw_stream` 을 무효화해
+/// (`wasm_api::set_field_value_by_name_api` 는 대상 필드를 찾을 때까지 훑는 모든 섹션의
+/// `raw_stream` 을 지운다) `export_hwp` 가 `serialize_para_text` 로 진짜 재구성하게
+/// 강제한다 — 실물 서식(일부 필드는 채우고 일부는 비워 둔 채 저장)과 같은 조건이다.
+/// 대상 누름틀(회사명) 자신은 건드리지 않으므로 dirty 표식도 안 선다.
+///
+/// 수정 전 실패: 회사명 문단의 안내문 "여기에 입력" 이 저장본 어디에도 없다(0회).
+#[test]
+fn sibling_field_edit_forces_reserialize_and_guide_text_survives() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("samples/field-01-memo.hwp");
+    let bytes = std::fs::read(&path).expect("read samples/field-01-memo.hwp");
+    let mut doc = load(&bytes);
+    // 회사명은 그대로 두고 작성자만 채운다 — raw_stream 무효화 유발 + 회사명 dirty 회피.
+    doc.set_field_value_by_name_api("작성자", "홍길동")
+        .expect("set_field_value_by_name(작성자)");
+    let saved = doc.export_hwp().expect("export_hwp");
+    let texts = raw_paragraph_texts(&saved);
+    assert_eq!(
+        count_guide_occurrences(&texts),
+        1,
+        "다른 필드(작성자) 편집으로 재구성된 HWP5 저장본에서 회사명의 안내문이 소실/중복됐다: {texts:?}"
+    );
+}
+
+/// HWP → HWPX → HWP5 왕복 (이슈가 실측으로 제시한 경로). #3545 가 hop1(HWP→HWPX)은 이미
+/// 고쳤으므로, 이 테스트의 실질 관심사는 hop2(HWPX→HWP5)다. HWPX 경유는 raw_stream 이
+/// 없어 편집 여부와 무관하게 항상 `serialize_para_text` 를 태운다.
+#[test]
+fn hwp_to_hwpx_to_hwp5_roundtrip_preserves_guide_text() {
+    let doc = load(&sample_bytes());
+    let hwpx = doc.export_hwpx().expect("export_hwpx (hop1)");
+    let mut reloaded_from_hwpx = load(&hwpx);
+    let hwp5 = reloaded_from_hwpx.export_hwp().expect("export_hwp (hop2)");
+    let texts = raw_paragraph_texts(&hwp5);
+    assert_eq!(
+        count_guide_occurrences(&texts),
+        1,
+        "HWP→HWPX→HWP5 왕복에서 안내문이 소실/중복됐다: {texts:?}"
+    );
+}
+
+/// 고정점: HWPX 경유 저장 → 재적재(정규화) → 다시 HWPX 경유 저장에서도 안내문이 1회
+/// 유지되고, 값 API 는 빈 값을 유지한다(정규화 계약 불변). 두 hop 모두 raw_stream 이
+/// 없는 HWPX 를 거치므로 편집 여부와 무관하게 `serialize_para_text` 를 태운다.
+#[test]
+fn initial_guide_text_save_reload_save_fixed_point() {
+    let doc = load(&sample_bytes());
+    let hwpx1 = doc.export_hwpx().expect("export_hwpx 1");
+    let mut reloaded = load(&hwpx1);
+    assert_eq!(
+        field_value(&reloaded, FIELD),
+        "",
+        "재적재 후에도 필드 값 API 는 빈 값이어야 한다 (정규화 계약 유지)"
+    );
+    let saved2 = reloaded.export_hwp().expect("export_hwp 2");
+    let texts = raw_paragraph_texts(&saved2);
+    assert_eq!(
+        count_guide_occurrences(&texts),
+        1,
+        "저장→재적재→재저장 고정점에서 안내문이 소실/중복됐다: {texts:?}"
+    );
+}
+
+/// 무회귀 가드: 값을 채운 필드는 실값 run 만 방출한다 — 잔재 복원이 중복 주입되면 안 된다.
+#[test]
+fn filled_field_not_duplicated() {
+    let mut doc = load(&sample_bytes());
+    doc.set_field_value_by_name_api(FIELD, GUIDE)
+        .expect("set_field_value_by_name");
+    let saved = doc.export_hwp().expect("export_hwp");
+    let texts = raw_paragraph_texts(&saved);
+    assert_eq!(
+        count_guide_occurrences(&texts),
+        1,
+        "채운 필드의 값이 중복 주입됐다: {texts:?}"
+    );
+}
+
+/// 두 번째 실물 샘플(form-02.hwp) — 단일 픽스처 우연 적합 배제. HWP→HWPX→HWP5 왕복으로
+/// raw_stream 지름길 없이 `serialize_para_text` 를 강제한다.
+#[test]
+fn form_02_survives_hwp_to_hwpx_to_hwp5_roundtrip() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("samples/form-02.hwp");
+    let bytes = std::fs::read(&path).expect("read samples/form-02.hwp");
+    let doc = load(&bytes);
+    let hwpx = doc.export_hwpx().expect("export_hwpx (hop1)");
+    let mut reloaded_from_hwpx = load(&hwpx);
+    let hwp5 = reloaded_from_hwpx.export_hwp().expect("export_hwp (hop2)");
+    let texts = raw_paragraph_texts(&hwp5);
+    assert_eq!(
+        count_guide_occurrences(&texts),
+        1,
+        "form-02.hwp 안내문이 HWP→HWPX→HWP5 왕복에서 소실/중복됐다: {texts:?}"
+    );
+}


### PR DESCRIPTION
누름틀에 아직 입력하지 않았을 때 본문에 남는 안내문이 HWP5 저장에서 복원되지 않습니다. HWPX 축은 #3545 로 이미 해소됐고 HWP5 축만 남아 있었습니다.

수정 전 회귀 테스트 4건이 실패하는 것을 확인했습니다 — 왕복, 저장→재적재→재저장 고정점, 형제 필드 편집으로 재직렬화가 강제된 경우까지. 같은 파일의 나머지 3건은 수정 전에도 통과하는데, `raw_stream` 통과 경로를 지키는 비회귀 가드라서 그렇습니다. 결함이 재직렬화 경로에 한정됨을 함께 보여 줍니다.

`cargo test --profile release-test --tests` 바이너리 498개, 합계 5,506 passed / 0 failed / 35 ignored. fmt·clippy clean.

한 가지 미검증 경로를 밝힙니다. 새로 추가한 `shift_char_shapes_for_residues` 는 삽입 위치의 동률 `char_shapes` 그룹에 `residue.char_shape_id` 와 일치하는 항목이 없으면 그룹 전체를 밉니다. 시험한 실제 샘플 3건은 전부 정확히 일치해 이 폴백을 타지 않으므로, 이 분기는 실물로 검증되지 않았습니다.

작업 중 발견했지만 범위 밖이라 손대지 않은 것 — `parse_paragraph`(`src/parser/hwpx/section.rs:492`, `:496`)가 `SectionDef` 를 항상 먼저 push 해 HWP5 원본의 `[ColumnDef, SectionDef]` 순서를 왕복에서 뒤집습니다. 이 수정 전후 모두 재현되는 기존 결함이라 #4433 으로 열었습니다.

Closes #4402