### PR TITLE
renderer: regenerate bundled Noto Sans KR ASCII advances

### DIFF
--- a/src/renderer/composer/tests.rs
+++ b/src/renderer/composer/tests.rs
@@ -887,6 +887,49 @@ fn test_reflow_english_word_wrap() {
     assert_eq!(para.line_segs[1].text_start, 6); // "World" 시작
 }
 
+#[test]
+fn issue_4442_corrected_noto_ascii_advances_change_threshold_wrap_with_kerning_off() {
+    use crate::renderer::layout::{estimate_text_width_unrounded, resolved_to_text_style};
+    use crate::renderer::style_resolver::ResolvedCharStyle;
+
+    let mut styles = make_styles_with_font_size(1000.0);
+    styles.char_styles[0] = ResolvedCharStyle {
+        font_family: "Noto Sans KR".to_string(),
+        font_size: 1000.0,
+        kerning: false,
+        ..Default::default()
+    };
+    let text_style = resolved_to_text_style(&styles, 0, 1);
+    let corrected_width = estimate_text_width_unrounded("AVATAR", &text_style);
+    let prior_table_width = 3416.0;
+    assert_eq!(corrected_width, 3633.0);
+    let threshold = (prior_table_width + corrected_width) / 2.0;
+
+    let mut para = Paragraph {
+        text: "AVATAR".to_string(),
+        char_offsets: (0..6).collect(),
+        char_count: 7,
+        char_shapes: vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 0,
+        }],
+        line_segs: vec![LineSeg {
+            text_start: 0,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    reflow_line_segs(&mut para, threshold, &styles, 96.0);
+
+    assert_eq!(
+        para.line_segs
+            .iter()
+            .map(|line| line.text_start)
+            .collect::<Vec<_>>(),
+        vec![0, 5]
+    );
+}
+
 fn reflow_after_prior_break_line_starts(text: &str, indent_px: f64) -> Vec<u32> {
     let mut styles = make_styles_with_font_size(16.0);
     styles.para_styles[0].indent = indent_px;

--- a/src/renderer/font_metrics_data.rs
+++ b/src/renderer/font_metrics_data.rs
@@ -1613,12 +1613,15 @@ static FONT_11_HANGUL: HangulMetric = HangulMetric {
     widths: &FONT_11_HANGUL_WIDTHS,
 };
 
+// Regenerated with `font-metric-gen` from
+// ttfs/opensource/NotoSansKR-Regular.ttf
+// (SHA-256 6e06a7fe5d696ca719894a23f36bb2b1be8c816a5937cd4ad0f23ca67780dd74).
 static FONT_12_LATIN_0: [u16; 95] = [
-    220, 275, 374, 521, 521, 880, 621, 231, 299, 299, 427, 521, 231, 324, 231, 396, 521, 521, 521,
-    521, 521, 521, 521, 521, 521, 521, 231, 231, 521, 521, 521, 435, 885, 574, 632, 619, 661, 562,
-    518, 661, 698, 257, 503, 607, 508, 770, 696, 714, 598, 714, 589, 569, 573, 694, 532, 842, 519,
-    482, 592, 299, 396, 299, 521, 550, 586, 536, 593, 492, 595, 527, 279, 530, 575, 245, 245, 499,
-    254, 889, 580, 586, 595, 595, 339, 441, 334, 577, 466, 742, 434, 468, 438, 299, 243, 299, 521,
+    224, 323, 474, 555, 555, 921, 680, 278, 338, 338, 467, 555, 278, 347, 278, 392, 555, 555, 555,
+    555, 555, 555, 555, 555, 555, 555, 278, 278, 555, 555, 555, 474, 946, 608, 657, 638, 688, 589,
+    552, 689, 728, 293, 535, 646, 543, 812, 723, 742, 633, 742, 635, 596, 599, 721, 575, 878, 573,
+    531, 603, 338, 392, 338, 555, 559, 606, 563, 618, 510, 620, 554, 325, 564, 607, 275, 275, 552,
+    284, 926, 610, 606, 620, 620, 388, 468, 377, 607, 521, 802, 498, 521, 475, 338, 270, 338, 555,
 ];
 static FONT_12_LATIN_1: [u16; 96] = [
     220, 275, 521, 521, 521, 521, 243, 1000, 586, 815, 368, 429, 521, 324, 433, 586, 336, 1000,
@@ -46184,6 +46187,39 @@ static FONT_METRICS: [FontMetric; 600] = [
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sha2::{Digest, Sha256};
+
+    const NOTO_SANS_KR_REGULAR: &[u8] =
+        include_bytes!("../../ttfs/opensource/NotoSansKR-Regular.ttf");
+
+    #[test]
+    fn issue_4442_noto_sans_kr_ascii_advances_match_tracked_font() {
+        let digest = Sha256::digest(NOTO_SANS_KR_REGULAR);
+        assert_eq!(
+            &digest[..],
+            &[
+                0x6e, 0x06, 0xa7, 0xfe, 0x5d, 0x69, 0x6c, 0xa7, 0x19, 0x89, 0x4a, 0x23, 0xf3, 0x6b,
+                0xb2, 0xb1, 0xbe, 0x8c, 0x81, 0x6a, 0x59, 0x37, 0xcd, 0x4a, 0xd0, 0xf2, 0x3c, 0xa6,
+                0x77, 0x80, 0xdd, 0x74,
+            ]
+        );
+
+        let face = ttf_parser::Face::parse(NOTO_SANS_KR_REGULAR, 0)
+            .expect("tracked bundled font must parse");
+        let metric = find_metric("Noto Sans KR", false, false).expect("shared regular metric");
+        assert_eq!(metric.metric.em_size, face.units_per_em());
+        for ch in ' '..='~' {
+            let glyph = face.glyph_index(ch).expect("printable ASCII glyph");
+            let advance = face
+                .glyph_hor_advance(glyph)
+                .expect("printable ASCII horizontal advance");
+            assert_eq!(
+                metric.metric.get_width(ch),
+                Some(advance),
+                "shared advance for {ch:?}"
+            );
+        }
+    }
 
     #[test]
     fn hy_gothic_medium_maps_correctly() {

--- a/src/renderer/layout/text_measurement.rs
+++ b/src/renderer/layout/text_measurement.rs
@@ -1475,6 +1475,21 @@ pub(crate) fn vertical_substitute_char(c: char) -> Option<char> {
 mod tests {
     use super::*;
 
+    #[test]
+    fn issue_4442_noto_sans_kr_regular_ascii_shared_width_uses_tracked_advances() {
+        let style = TextStyle {
+            font_family: "Noto Sans KR".to_string(),
+            font_size: 1000.0,
+            ..Default::default()
+        };
+
+        assert_eq!(estimate_text_width_unrounded("AVATAR", &style), 3633.0);
+        assert_eq!(
+            compute_char_positions("AVATAR", &style),
+            vec![0.0, 608.0, 1183.0, 1791.0, 2390.0, 2998.0, 3633.0]
+        );
+    }
+
     /// 테스트용 고정 폭 텍스트 측정기
     ///
     /// 모든 문자를 동일한 폭으로 측정한다.


### PR DESCRIPTION
## 변경 요약

- 번들된 `NotoSansKR-Regular.ttf`에서 일반체의 printable ASCII advance 95개를 다시 생성했습니다.
- 글꼴 SHA-256, units-per-em, 모든 ASCII advance를 테스트에서 원본 TTF와 대조합니다.
- 커닝을 끈 공용 측정의 전체 문자 경계와, 기존 폭과 수정 폭 사이 임계값에서 실제 reflow 줄바꿈이 달라지는 계약을 고정했습니다.

이 PR은 기본 advance만 바로잡습니다. 인접 글리프 pair 조정은 #4439의 별도 변경이며, 저장된 `LineSeg`를 만든 쪽이 실제 advance와 커닝 정책을 모두 사용했을 수 있으므로 두 축을 합쳐서 해석하지 않습니다. PR #4315의 전체 stored-versus-reflowed 불일치를 해결한다고 주장하지 않습니다.

## 관련 이슈

Closes #4442

Related: #4439, PR #4315, #2206, #2156

## 테스트

- [x] `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests` 통과
- [x] `cargo clippy --profile release-test --all-targets -- -D warnings` 통과
- [x] `issue_4442` focused tests 3/3 통과 (TTF 전수 advance, 공용 위치 벡터, threshold reflow)
- [x] 전체 release integration suite의 SVG snapshot 테스트 통과
- [ ] 웹(WASM) 렌더링 확인 — 별도 브라우저 실행은 하지 않음; production 변경은 target 분기 없는 정적 advance 표뿐임
- [ ] capability 카탈로그 — agent/skill 파일 변경 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 런타임 비용 영향 없음. Noto Sans KR Regular ASCII의 측정/줄바꿈 결과는 의도적으로 교정됩니다.
- 재현·측정: 성능 수치는 측정하지 않았습니다. 테스트에서 `AVATAR`의 커닝-off 폭이 3416에서 번들 글꼴 기준 3633으로 교정되고, 그 사이 임계 폭에서 production reflow 경계가 바뀌는 것을 확인합니다.

## 스크린샷

해당 없음. 결정적인 글꼴 advance 및 layout/reflow 테스트로 검증했습니다.
