### PR TITLE
diagnostics: make capped IR sweep paths traversal-stable

### DIFF
--- a/src/diagnostics/ir_field_sweep.rs
+++ b/src/diagnostics/ir_field_sweep.rs
@@ -42,6 +42,9 @@
 //! `Debug` 문자열화는 [`DEBUG_CAP`] 바이트에서 잘린다([`CappedWriter`] 가 `Err` 를
 //! 돌려 파생 `Debug` 를 조기 중단시킨다). 초과분은 비교되지 않으며 이는 명시된 한계다
 //! (문단 텍스트/`char_offsets` 가 큰 문단에서 발생 가능).
+//! 정규화 경로별 건수는 끝까지 집계하되 상세 값 payload만
+//! [`MAX_DIVERGENCE_EXAMPLES`] 개까지 보관한다. 서로 다른 정규화 경로가
+//! [`MAX_DIVERGENCE_PATHS`] 종을 넘으면 일부를 숨기지 않고 스윕 자체가 실패한다.
 //!
 //! ## 범위 밖 (의도)
 //!
@@ -49,6 +52,7 @@
 //! 보존 버퍼라 왕복 후 달라지는 것이 **정상**이다(재직렬화 결과이므로). 바이트 보존은
 //! `hwp5_roundtrip_batch` 의 C2 BinData 지문이 이미 담당한다.
 
+use std::collections::BTreeMap;
 use std::fmt::{Debug, Write as _};
 
 use crate::model::control::Control;
@@ -66,8 +70,17 @@ const MAX_DEPTH: usize = 14;
 /// 발산 보고 시 값 문자열 절단 길이.
 const VALUE_CAP: usize = 160;
 
-/// 문서 1건당 수집 상한 — 심하게 깨진 문서에서 메모리 폭주 방지.
-pub const MAX_DIVERGENCES: usize = 2000;
+/// 문서 1건당 보관할 상세 예시 상한.
+///
+/// 정규화 경로별 건수는 이 상한과 무관하게 끝까지 집계한다. 예시만 제한해야 앞쪽
+/// 발산의 해소가 뒤쪽 경로의 baseline 건수를 흔들지 않는다.
+pub const MAX_DIVERGENCE_EXAMPLES: usize = 2000;
+
+/// 문서 1건에서 허용할 서로 다른 정규화 경로 상한.
+///
+/// 건수 맵 자체의 메모리를 제한한다. 이 상한에 닿으면 일부 경로를 버린 불완전한
+/// 결과를 반환하지 않고 [`IrFieldSweepError::DistinctPathLimitExceeded`] 로 실패한다.
+pub const MAX_DIVERGENCE_PATHS: usize = 2000;
 
 /// 왕복 전후 IR 의 단일 필드 발산.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -90,23 +103,143 @@ impl FieldDivergence {
     /// baseline 을 인덱스가 아니라 이 모양으로 고정해야 문서가 조금 바뀌어도
     /// 래칫이 오작동하지 않는다.
     pub fn normalized_path(&self) -> String {
-        let mut out = String::with_capacity(self.path.len());
-        let mut in_index = false;
-        for ch in self.path.chars() {
-            match ch {
-                '[' => {
-                    in_index = true;
-                    out.push('[');
-                }
-                ']' => {
-                    in_index = false;
-                    out.push(']');
-                }
-                _ if in_index => {}
-                _ => out.push(ch),
+        normalize_path(&self.path)
+    }
+}
+
+fn normalize_path(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    let mut in_index = false;
+    for ch in path.chars() {
+        match ch {
+            '[' => {
+                in_index = true;
+                out.push('[');
             }
+            ']' => {
+                in_index = false;
+                out.push(']');
+            }
+            _ if in_index => {}
+            _ => out.push(ch),
         }
-        out
+    }
+    out
+}
+
+/// 한 문서의 IR 필드 발산 집계.
+///
+/// `counts` 는 정규화 경로별 **완전한** 건수이고, `examples` 는 진단 출력용으로만
+/// [`MAX_DIVERGENCE_EXAMPLES`] 개까지 보관한다. baseline 판정은 반드시
+/// [`Self::counts`] 를 사용해야 한다.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DivergenceReport {
+    counts: BTreeMap<String, usize>,
+    examples: Vec<FieldDivergence>,
+}
+
+impl DivergenceReport {
+    /// 정규화 경로별 완전한 발산 건수.
+    pub fn counts(&self) -> &BTreeMap<String, usize> {
+        &self.counts
+    }
+
+    /// 상세 진단용 예시. 전체 건수가 아니라 제한된 payload다.
+    pub fn examples(&self) -> &[FieldDivergence] {
+        &self.examples
+    }
+
+    /// 모든 정규화 경로의 발산 건수 합계.
+    pub fn total(&self) -> usize {
+        self.counts.values().sum()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.counts.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IrFieldSweepError {
+    Roundtrip(String),
+    DistinctPathLimitExceeded { limit: usize },
+}
+
+impl IrFieldSweepError {
+    pub fn is_capacity_error(&self) -> bool {
+        matches!(self, Self::DistinctPathLimitExceeded { .. })
+    }
+}
+
+impl std::fmt::Display for IrFieldSweepError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Roundtrip(message) => f.write_str(message),
+            Self::DistinctPathLimitExceeded { limit } => write!(
+                f,
+                "IR 필드 스윕 정규화 경로가 문서당 상한 {limit}종을 초과함"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for IrFieldSweepError {}
+
+#[derive(Debug)]
+struct DivergenceCollector {
+    counts: BTreeMap<String, usize>,
+    examples: Vec<FieldDivergence>,
+    path_limit_exceeded: bool,
+}
+
+impl DivergenceCollector {
+    fn new() -> Self {
+        Self {
+            counts: BTreeMap::new(),
+            examples: Vec::new(),
+            path_limit_exceeded: false,
+        }
+    }
+
+    fn record(&mut self, path: &str, left: &str, right: &str) {
+        if self.path_limit_exceeded {
+            return;
+        }
+
+        let normalized = normalize_path(path);
+        if let Some(count) = self.counts.get_mut(&normalized) {
+            *count += 1;
+        } else {
+            if self.counts.len() >= MAX_DIVERGENCE_PATHS {
+                self.path_limit_exceeded = true;
+                return;
+            }
+            self.counts.insert(normalized, 1);
+        }
+
+        if self.examples.len() < MAX_DIVERGENCE_EXAMPLES {
+            self.examples.push(FieldDivergence {
+                path: path.to_string(),
+                left: truncate(left),
+                right: truncate(right),
+            });
+        }
+    }
+
+    fn is_failed(&self) -> bool {
+        self.path_limit_exceeded
+    }
+
+    fn finish(self) -> Result<DivergenceReport, IrFieldSweepError> {
+        if self.path_limit_exceeded {
+            return Err(IrFieldSweepError::DistinctPathLimitExceeded {
+                limit: MAX_DIVERGENCE_PATHS,
+            });
+        }
+        Ok(DivergenceReport {
+            counts: self.counts,
+            examples: self.examples,
+        })
     }
 }
 
@@ -303,20 +436,13 @@ fn truncate(s: &str) -> String {
     format!("{cut}…")
 }
 
-fn push_leaf(path: &str, a: &str, b: &str, out: &mut Vec<FieldDivergence>) {
-    if out.len() >= MAX_DIVERGENCES {
-        return;
-    }
-    out.push(FieldDivergence {
-        path: path.to_string(),
-        left: truncate(a),
-        right: truncate(b),
-    });
+fn push_leaf(path: &str, a: &str, b: &str, out: &mut DivergenceCollector) {
+    out.record(path, a, b);
 }
 
 /// 두 `Debug` 문자열을 구조적으로 비교해 발산 잎을 수집한다.
-fn compare_node(path: &str, a: &str, b: &str, depth: usize, out: &mut Vec<FieldDivergence>) {
-    if a == b || out.len() >= MAX_DIVERGENCES {
+fn compare_node(path: &str, a: &str, b: &str, depth: usize, out: &mut DivergenceCollector) {
+    if a == b || out.is_failed() {
         return;
     }
     if depth >= MAX_DEPTH {
@@ -360,8 +486,8 @@ fn compare_node(path: &str, a: &str, b: &str, depth: usize, out: &mut Vec<FieldD
 }
 
 /// 값 2개를 `Debug` 로 문자열화해 구조 비교한다.
-fn cmp_debug<T: Debug + ?Sized>(path: &str, a: &T, b: &T, out: &mut Vec<FieldDivergence>) {
-    if out.len() >= MAX_DIVERGENCES {
+fn cmp_debug<T: Debug + ?Sized>(path: &str, a: &T, b: &T, out: &mut DivergenceCollector) {
+    if out.is_failed() {
         return;
     }
     let (sa, _) = debug_capped(a);
@@ -370,7 +496,7 @@ fn cmp_debug<T: Debug + ?Sized>(path: &str, a: &T, b: &T, out: &mut Vec<FieldDiv
 }
 
 /// 개수 비교 — 시퀀스는 개수를 먼저 보고해야 zip 이 뒤를 가리지 않는다.
-fn cmp_count(path: &str, a: usize, b: usize, out: &mut Vec<FieldDivergence>) {
+fn cmp_count(path: &str, a: usize, b: usize, out: &mut DivergenceCollector) {
     if a != b {
         push_leaf(&format!("{path}.len"), &a.to_string(), &b.to_string(), out);
     }
@@ -381,12 +507,12 @@ fn cmp_count(path: &str, a: usize, b: usize, out: &mut Vec<FieldDivergence>) {
 // ---------------------------------------------------------------------------
 
 /// 왕복 전후 두 `Document` 의 IR 필드를 전수 비교한다.
-pub fn sweep_documents(a: &Document, b: &Document) -> Vec<FieldDivergence> {
-    let mut out = Vec::new();
+pub fn sweep_documents(a: &Document, b: &Document) -> Result<DivergenceReport, IrFieldSweepError> {
+    let mut out = DivergenceCollector::new();
     sweep_doc_info(&a.doc_info, &b.doc_info, &mut out);
     cmp_count("sections", a.sections.len(), b.sections.len(), &mut out);
     for (i, (sa, sb)) in a.sections.iter().zip(b.sections.iter()).enumerate() {
-        if out.len() >= MAX_DIVERGENCES {
+        if out.is_failed() {
             break;
         }
         let base = format!("sections[{i}]");
@@ -398,10 +524,10 @@ pub fn sweep_documents(a: &Document, b: &Document) -> Vec<FieldDivergence> {
             &mut out,
         );
     }
-    out
+    out.finish()
 }
 
-fn sweep_doc_info(a: &DocInfo, b: &DocInfo, out: &mut Vec<FieldDivergence>) {
+fn sweep_doc_info(a: &DocInfo, b: &DocInfo, out: &mut DivergenceCollector) {
     macro_rules! table {
         ($f:ident) => {{
             let base = concat!("doc_info.", stringify!($f));
@@ -462,7 +588,7 @@ fn sweep_doc_info(a: &DocInfo, b: &DocInfo, out: &mut Vec<FieldDivergence>) {
     );
 }
 
-fn sweep_section_def(base: &str, a: &SectionDef, b: &SectionDef, out: &mut Vec<FieldDivergence>) {
+fn sweep_section_def(base: &str, a: &SectionDef, b: &SectionDef, out: &mut DivergenceCollector) {
     // 원본 보존 버퍼/렌더 파생물은 개수만 (내용 비교는 왕복 의미가 없다).
     cmp_count(
         &format!("{base}.section_def.extra_child_records"),
@@ -485,10 +611,10 @@ fn sweep_section_def(base: &str, a: &SectionDef, b: &SectionDef, out: &mut Vec<F
     cmp_debug(&format!("{base}.section_def"), &sa, &sb, out);
 }
 
-fn sweep_paragraphs(base: &str, a: &[Paragraph], b: &[Paragraph], out: &mut Vec<FieldDivergence>) {
+fn sweep_paragraphs(base: &str, a: &[Paragraph], b: &[Paragraph], out: &mut DivergenceCollector) {
     cmp_count(base, a.len(), b.len(), out);
     for (i, (pa, pb)) in a.iter().zip(b.iter()).enumerate() {
-        if out.len() >= MAX_DIVERGENCES {
+        if out.is_failed() {
             return;
         }
         sweep_paragraph(&format!("{base}[{i}]"), pa, pb, out);
@@ -497,7 +623,7 @@ fn sweep_paragraphs(base: &str, a: &[Paragraph], b: &[Paragraph], out: &mut Vec<
 
 /// 문단 1건 — `..` 없는 철저 구조 분해로 필드 누락을 컴파일 타임에 막는다.
 /// (`Paragraph` 에 필드를 추가하면 여기서 컴파일이 깨진다.)
-fn sweep_paragraph(base: &str, a: &Paragraph, b: &Paragraph, out: &mut Vec<FieldDivergence>) {
+fn sweep_paragraph(base: &str, a: &Paragraph, b: &Paragraph, out: &mut DivergenceCollector) {
     let Paragraph {
         char_count,
         control_mask,
@@ -551,10 +677,10 @@ fn sweep_paragraph(base: &str, a: &Paragraph, b: &Paragraph, out: &mut Vec<Field
     sweep_controls(&format!("{base}.controls"), controls, &b.controls, out);
 }
 
-fn sweep_controls(base: &str, a: &[Control], b: &[Control], out: &mut Vec<FieldDivergence>) {
+fn sweep_controls(base: &str, a: &[Control], b: &[Control], out: &mut DivergenceCollector) {
     cmp_count(base, a.len(), b.len(), out);
     for (i, (ca, cb)) in a.iter().zip(b.iter()).enumerate() {
-        if out.len() >= MAX_DIVERGENCES {
+        if out.is_failed() {
             return;
         }
         sweep_control(&format!("{base}[{i}]"), ca, cb, out);
@@ -565,7 +691,7 @@ fn sweep_controls(base: &str, a: &[Control], b: &[Control], out: &mut Vec<FieldD
 ///
 /// 표는 셀 문단까지 복제하면 비용이 커지므로 철저 구조 분해로 처리하고,
 /// 나머지는 하위 문단만 비워낸 사본을 `Debug` 로 전수 비교한다.
-fn sweep_control(base: &str, a: &Control, b: &Control, out: &mut Vec<FieldDivergence>) {
+fn sweep_control(base: &str, a: &Control, b: &Control, out: &mut DivergenceCollector) {
     use Control::*;
     match (a, b) {
         (Table(ta), Table(tb)) => sweep_table(base, ta, tb, out),
@@ -702,7 +828,7 @@ fn sweep_form(
     base: &str,
     a: &crate::model::control::FormObject,
     b: &crate::model::control::FormObject,
-    out: &mut Vec<FieldDivergence>,
+    out: &mut DivergenceCollector,
 ) {
     let crate::model::control::FormObject {
         form_type,
@@ -751,7 +877,7 @@ fn sweep_caption_paragraphs(
     base: &str,
     a: &Option<crate::model::shape::Caption>,
     b: &Option<crate::model::shape::Caption>,
-    out: &mut Vec<FieldDivergence>,
+    out: &mut DivergenceCollector,
 ) {
     if let (Some(x), Some(y)) = (a, b) {
         sweep_paragraphs(
@@ -764,7 +890,7 @@ fn sweep_caption_paragraphs(
 }
 
 /// 표 — `..` 없는 철저 구조 분해. 필드가 추가되면 컴파일이 깨진다.
-fn sweep_table(base: &str, a: &Table, b: &Table, out: &mut Vec<FieldDivergence>) {
+fn sweep_table(base: &str, a: &Table, b: &Table, out: &mut DivergenceCollector) {
     let Table {
         attr,
         row_count,
@@ -844,7 +970,7 @@ fn sweep_table(base: &str, a: &Table, b: &Table, out: &mut Vec<FieldDivergence>)
     let cells_path = format!("{base}.cells");
     cmp_count(&cells_path, cells.len(), b.cells.len(), out);
     for (i, (ca, cb)) in cells.iter().zip(b.cells.iter()).enumerate() {
-        if out.len() >= MAX_DIVERGENCES {
+        if out.is_failed() {
             return;
         }
         sweep_cell(&format!("{cells_path}[{i}]"), ca, cb, out);
@@ -852,7 +978,7 @@ fn sweep_table(base: &str, a: &Table, b: &Table, out: &mut Vec<FieldDivergence>)
 }
 
 /// 셀 — `..` 없는 철저 구조 분해.
-fn sweep_cell(base: &str, a: &Cell, b: &Cell, out: &mut Vec<FieldDivergence>) {
+fn sweep_cell(base: &str, a: &Cell, b: &Cell, out: &mut DivergenceCollector) {
     let Cell {
         col,
         row,
@@ -904,7 +1030,7 @@ fn sweep_cell(base: &str, a: &Cell, b: &Cell, out: &mut Vec<FieldDivergence>) {
 }
 
 /// 도형 — 하위 문단(글상자·캡션)을 비운 사본으로 속성 전수 비교 후 문단 재귀.
-fn sweep_shape(base: &str, a: &ShapeObject, b: &ShapeObject, out: &mut Vec<FieldDivergence>) {
+fn sweep_shape(base: &str, a: &ShapeObject, b: &ShapeObject, out: &mut DivergenceCollector) {
     let mut x = a.clone();
     let mut y = b.clone();
     strip_shape(&mut x);
@@ -927,7 +1053,7 @@ fn sweep_shape(base: &str, a: &ShapeObject, b: &ShapeObject, out: &mut Vec<Field
         let path = format!("{base}.children");
         cmp_count(&path, ga.children.len(), gb.children.len(), out);
         for (i, (ca, cb)) in ga.children.iter().zip(gb.children.iter()).enumerate() {
-            if out.len() >= MAX_DIVERGENCES {
+            if out.is_failed() {
                 return;
             }
             sweep_shape(&format!("{path}[{i}]"), ca, cb, out);
@@ -1018,13 +1144,16 @@ fn shape_caption(s: &ShapeObject) -> &Option<crate::model::shape::Caption> {
 // ---------------------------------------------------------------------------
 
 /// HWP5 왕복(`parse → serialize → reparse`) 후 IR 필드 전수 스윕.
-pub fn sweep_hwp5_roundtrip(bytes: &[u8]) -> Result<Vec<FieldDivergence>, String> {
+pub fn sweep_hwp5_roundtrip(bytes: &[u8]) -> Result<DivergenceReport, IrFieldSweepError> {
     use crate::parser::parse_document;
     use crate::serializer::serialize_document;
-    let doc1 = parse_document(bytes).map_err(|e| format!("파싱 실패: {e}"))?;
-    let out = serialize_document(&doc1).map_err(|e| format!("직렬화 실패: {e}"))?;
-    let doc2 = parse_document(&out).map_err(|e| format!("재파싱 실패: {e}"))?;
-    Ok(sweep_documents(&doc1, &doc2))
+    let doc1 = parse_document(bytes)
+        .map_err(|e| IrFieldSweepError::Roundtrip(format!("파싱 실패: {e}")))?;
+    let out = serialize_document(&doc1)
+        .map_err(|e| IrFieldSweepError::Roundtrip(format!("직렬화 실패: {e}")))?;
+    let doc2 = parse_document(&out)
+        .map_err(|e| IrFieldSweepError::Roundtrip(format!("재파싱 실패: {e}")))?;
+    sweep_documents(&doc1, &doc2)
 }
 
 /// HWP5 **레코드 재생성** 경로 왕복 후 IR 필드 전수 스윕.
@@ -1038,10 +1167,11 @@ pub fn sweep_hwp5_roundtrip(bytes: &[u8]) -> Result<Vec<FieldDivergence>, String
 /// `section.raw_stream = None` / `doc_info.raw_stream_dirty = true` 로 무효화하고
 /// **레코드를 다시 만드는 경로**로 저장한다. 반복돼 온 1속성 소실은 전부 이 경로에서
 /// 난다. 이 함수는 그 무효화를 그대로 재현해 진짜 저장 경로를 측정한다.
-pub fn sweep_hwp5_rebuild_roundtrip(bytes: &[u8]) -> Result<Vec<FieldDivergence>, String> {
+pub fn sweep_hwp5_rebuild_roundtrip(bytes: &[u8]) -> Result<DivergenceReport, IrFieldSweepError> {
     use crate::parser::parse_document;
     use crate::serializer::serialize_document;
-    let doc1 = parse_document(bytes).map_err(|e| format!("파싱 실패: {e}"))?;
+    let doc1 = parse_document(bytes)
+        .map_err(|e| IrFieldSweepError::Roundtrip(format!("파싱 실패: {e}")))?;
 
     // 편집이 일어난 문서와 동일한 무효화 (document_core/commands 관례).
     let mut edited = doc1.clone();
@@ -1050,28 +1180,29 @@ pub fn sweep_hwp5_rebuild_roundtrip(bytes: &[u8]) -> Result<Vec<FieldDivergence>
         s.raw_stream = None;
     }
 
-    let out = serialize_document(&edited).map_err(|e| format!("직렬화 실패: {e}"))?;
-    let doc2 = parse_document(&out).map_err(|e| format!("재파싱 실패: {e}"))?;
-    Ok(sweep_documents(&doc1, &doc2))
+    let out = serialize_document(&edited)
+        .map_err(|e| IrFieldSweepError::Roundtrip(format!("직렬화 실패: {e}")))?;
+    let doc2 = parse_document(&out)
+        .map_err(|e| IrFieldSweepError::Roundtrip(format!("재파싱 실패: {e}")))?;
+    sweep_documents(&doc1, &doc2)
 }
 
 /// HWPX 왕복(`parse → serialize → reparse`) 후 IR 필드 전수 스윕.
-pub fn sweep_hwpx_roundtrip(bytes: &[u8]) -> Result<Vec<FieldDivergence>, String> {
+pub fn sweep_hwpx_roundtrip(bytes: &[u8]) -> Result<DivergenceReport, IrFieldSweepError> {
     use crate::parser::hwpx::parse_hwpx;
     use crate::serializer::hwpx::serialize_hwpx;
-    let doc1 = parse_hwpx(bytes).map_err(|e| format!("파싱 실패: {e}"))?;
-    let out = serialize_hwpx(&doc1).map_err(|e| format!("직렬화 실패: {e}"))?;
-    let doc2 = parse_hwpx(&out).map_err(|e| format!("재파싱 실패: {e}"))?;
-    Ok(sweep_documents(&doc1, &doc2))
+    let doc1 =
+        parse_hwpx(bytes).map_err(|e| IrFieldSweepError::Roundtrip(format!("파싱 실패: {e}")))?;
+    let out = serialize_hwpx(&doc1)
+        .map_err(|e| IrFieldSweepError::Roundtrip(format!("직렬화 실패: {e}")))?;
+    let doc2 =
+        parse_hwpx(&out).map_err(|e| IrFieldSweepError::Roundtrip(format!("재파싱 실패: {e}")))?;
+    sweep_documents(&doc1, &doc2)
 }
 
-/// 발산 목록을 정규화 경로별 건수로 집계 (baseline 키 단위).
-pub fn tally(divs: &[FieldDivergence]) -> std::collections::BTreeMap<String, usize> {
-    let mut map = std::collections::BTreeMap::new();
-    for d in divs {
-        *map.entry(d.normalized_path()).or_insert(0) += 1;
-    }
-    map
+/// baseline 키 단위의 완전한 발산 건수.
+pub fn tally(report: &DivergenceReport) -> &BTreeMap<String, usize> {
+    report.counts()
 }
 
 #[cfg(test)]
@@ -1114,7 +1245,7 @@ mod tests {
 
     #[test]
     fn compare_node_reports_leaf_path() {
-        let mut out = Vec::new();
+        let mut out = DivergenceCollector::new();
         compare_node(
             "t",
             "T { a: 1, b: S { c: 2 } }",
@@ -1122,52 +1253,61 @@ mod tests {
             0,
             &mut out,
         );
-        assert_eq!(out.len(), 1);
-        assert_eq!(out[0].path, "t.b.c");
-        assert_eq!(out[0].left, "2");
-        assert_eq!(out[0].right, "9");
+        let report = out.finish().unwrap();
+        assert_eq!(report.total(), 1);
+        assert_eq!(report.examples()[0].path, "t.b.c");
+        assert_eq!(report.examples()[0].left, "2");
+        assert_eq!(report.examples()[0].right, "9");
     }
 
     #[test]
     fn compare_node_reports_seq_length_and_common_prefix() {
-        let mut out = Vec::new();
+        let mut out = DivergenceCollector::new();
         compare_node("v", "[1, 2, 3]", "[1, 9]", 0, &mut out);
+        let report = out.finish().unwrap();
         // 길이 발산 1건 + 인덱스 1 값 발산 1건
-        let paths: Vec<&str> = out.iter().map(|d| d.path.as_str()).collect();
+        let paths: Vec<&str> = report.examples().iter().map(|d| d.path.as_str()).collect();
         assert!(paths.contains(&"v.len"), "길이 발산 누락: {paths:?}");
         assert!(paths.contains(&"v[1]"), "값 발산 누락: {paths:?}");
     }
 
     #[test]
     fn compare_node_unwraps_matching_some() {
-        let mut out = Vec::new();
+        let mut out = DivergenceCollector::new();
         compare_node("c", "Some(S { x: 1 })", "Some(S { x: 2 })", 0, &mut out);
-        assert_eq!(out.len(), 1);
-        assert_eq!(out[0].path, "c.x", "Some 은 경로에 투명해야 함");
+        let report = out.finish().unwrap();
+        assert_eq!(report.total(), 1);
+        assert_eq!(
+            report.examples()[0].path,
+            "c.x",
+            "Some 은 경로에 투명해야 함"
+        );
     }
 
     #[test]
     fn compare_node_some_vs_none_is_leaf() {
-        let mut out = Vec::new();
+        let mut out = DivergenceCollector::new();
         compare_node("c", "Some(S { x: 1 })", "None", 0, &mut out);
-        assert_eq!(out.len(), 1);
-        assert_eq!(out[0].path, "c");
-        assert_eq!(out[0].right, "None");
+        let report = out.finish().unwrap();
+        assert_eq!(report.total(), 1);
+        assert_eq!(report.examples()[0].path, "c");
+        assert_eq!(report.examples()[0].right, "None");
     }
 
     #[test]
     fn compare_node_different_variant_is_leaf() {
-        let mut out = Vec::new();
+        let mut out = DivergenceCollector::new();
         compare_node("s", "Line { a: 1 }", "Rectangle { a: 1 }", 0, &mut out);
-        assert_eq!(out.len(), 1);
-        assert_eq!(out[0].path, "s");
+        let report = out.finish().unwrap();
+        assert_eq!(report.total(), 1);
+        assert_eq!(report.examples()[0].path, "s");
     }
 
     #[test]
     fn identical_values_produce_nothing() {
-        let mut out = Vec::new();
+        let mut out = DivergenceCollector::new();
         compare_node("x", "T { a: 1 }", "T { a: 1 }", 0, &mut out);
-        assert!(out.is_empty());
+        assert!(out.finish().unwrap().is_empty());
     }
 
     #[test]
@@ -1200,20 +1340,28 @@ mod tests {
 
     #[test]
     fn tally_groups_by_normalized_path() {
-        let divs = vec![
-            FieldDivergence {
-                path: "sections[0].paragraphs[1].text".into(),
-                left: "a".into(),
-                right: "b".into(),
-            },
-            FieldDivergence {
-                path: "sections[0].paragraphs[9].text".into(),
-                left: "a".into(),
-                right: "b".into(),
-            },
-        ];
-        let t = tally(&divs);
+        let mut collector = DivergenceCollector::new();
+        collector.record("sections[0].paragraphs[1].text", "a", "b");
+        collector.record("sections[0].paragraphs[9].text", "a", "b");
+        let report = collector.finish().unwrap();
+        let t = tally(&report);
         assert_eq!(t.get("sections[].paragraphs[].text"), Some(&2));
+    }
+
+    #[test]
+    fn distinct_path_limit_fails_closed() {
+        let mut collector = DivergenceCollector::new();
+        for index in 0..MAX_DIVERGENCE_PATHS {
+            collector.record(&format!("field_{index}"), "left", "right");
+        }
+        collector.record("one_path_too_many", "left", "right");
+
+        assert_eq!(
+            collector.finish(),
+            Err(IrFieldSweepError::DistinctPathLimitExceeded {
+                limit: MAX_DIVERGENCE_PATHS
+            })
+        );
     }
 
     /// 실제 IR 타입 위에서 동작하는지 — 표 속성 1개만 바꾸면 그 경로만 나와야 한다.
@@ -1239,8 +1387,9 @@ mod tests {
             t.row_count = 3;
         }
 
-        let divs = sweep_documents(&doc_a, &doc_b);
-        assert_eq!(divs.len(), 1, "예상 밖 발산: {divs:?}");
+        let report = sweep_documents(&doc_a, &doc_b).unwrap();
+        let divs = report.examples();
+        assert_eq!(report.total(), 1, "예상 밖 발산: {report:?}");
         assert_eq!(
             divs[0].path,
             "sections[0].paragraphs[0].controls[0].row_count"
@@ -1264,6 +1413,6 @@ mod tests {
             ..Default::default()
         });
         let copy = doc.clone();
-        assert!(sweep_documents(&doc, &copy).is_empty());
+        assert!(sweep_documents(&doc, &copy).unwrap().is_empty());
     }
 }

--- a/tests/fixtures/ir_field_sweep_baseline.tsv
+++ b/tests/fixtures/ir_field_sweep_baseline.tsv
@@ -1,13 +1,14 @@
+# rhwp-ir-field-sweep-baseline-v2 complete-normalized-path-counts
 lane	sample	path	count
 hwp5rb	143E433F503322BD33.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	24
 hwp5rb	156457624_210622 7월부터 해외직구 구매대행업체 등록제 시행.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	1
 hwp5rb	156636617_240617 2024년 5월 월간 수출입 현황(확정치).hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	1330
 hwp5rb	2010-01-06.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	120
 hwp5rb	2022년 국립국어원 업무계획.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	244
-hwp5rb	2025 행정업무운영 편람(최종).hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	1503
+hwp5rb	2025 행정업무운영 편람(최종).hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	3754
 hwp5rb	2025 행정업무운영 편람(최종).hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].char_count	1
 hwp5rb	2025 행정업무운영 편람(최종).hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].control_mask	1
-hwp5rb	2025 행정업무운영 편람(최종).hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	477
+hwp5rb	2025 행정업무운영 편람(최종).hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	754
 hwp5rb	2025 행정업무운영 편람(최종).hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	18
 hwp5rb	20250130-hongbo.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	18
 hwp5rb	20250130-hongbo_saved.hwp	doc_info.bullet_count	1
@@ -79,8 +80,8 @@ hwp5rb	HWP5-nopassword-123456.hwp	sections[].paragraphs[].line_segs[].vertical_p
 hwp5rb	KTX.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	280
 hwp5rb	KTX.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	3
 hwp5rb	[2027] 온새미로 1 본교재.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	115
-hwp5rb	aift.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	1887
-hwp5rb	aift.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	113
+hwp5rb	aift.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	2299
+hwp5rb	aift.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	164
 hwp5rb	basic/BlogForm_BookReview.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	4
 hwp5rb	basic/BlogForm_MovieReview.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	1
 hwp5rb	basic/BlogForm_Recipe.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	1
@@ -140,11 +141,12 @@ hwp5rb	hwp-img-001.hwp	sections[].paragraphs[].controls[].cells[].list_header_wi
 hwp5rb	hwp-multi-001.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	289
 hwp5rb	hwp-multi-002.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	16
 hwp5rb	hwp3-sample-hwp5.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	72
-hwp5rb	hwp3-sample10-hwp5.hwp	sections[].paragraphs[].char_count	78
-hwp5rb	hwp3-sample10-hwp5.hwp	sections[].paragraphs[].char_offsets.n	34
-hwp5rb	hwp3-sample10-hwp5.hwp	sections[].paragraphs[].char_offsets[]	1751
-hwp5rb	hwp3-sample10-hwp5.hwp	sections[].paragraphs[].control_mask	78
-hwp5rb	hwp3-sample10-hwp5.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	59
+hwp5rb	hwp3-sample10-hwp5.hwp	sections[].paragraphs[].char_count	290
+hwp5rb	hwp3-sample10-hwp5.hwp	sections[].paragraphs[].char_offsets.n	1248
+hwp5rb	hwp3-sample10-hwp5.hwp	sections[].paragraphs[].char_offsets[]	7143
+hwp5rb	hwp3-sample10-hwp5.hwp	sections[].paragraphs[].control_mask	290
+hwp5rb	hwp3-sample10-hwp5.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	91
+hwp5rb	hwp3-sample10-hwp5.hwp	sections[].paragraphs[].line_segs[].vertical_pos	54
 hwp5rb	hwp3-sample11-hwp5.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	163
 hwp5rb	hwp3-sample11-hwp5.hwp	sections[].paragraphs[].controls[].children[].children[].children[].children[].children[].children[].children[].children[].children[][].drawing.fill.solid	192
 hwp5rb	hwp3-sample11-hwp5.hwp	sections[].paragraphs[].controls[].children[].children[].children[].children[].children[].children[].children[].children[][].drawing.fill.solid	128
@@ -157,19 +159,21 @@ hwp5rb	hwp3-sample11-hwp5.hwp	sections[].paragraphs[].controls[].children[].chil
 hwp5rb	hwp3-sample11-hwp5.hwp	sections[].paragraphs[].controls[].children[][].drawing.fill.solid	39
 hwp5rb	hwp3-sample11-hwp5.hwp	sections[].paragraphs[].controls[][].drawing.fill.solid	3
 hwp5rb	hwp3-sample11-hwp5.hwp	sections[].paragraphs[].line_segs[].vertical_pos	12
-hwp5rb	hwp3-sample16-hwp5-2010.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	1370
+hwp5rb	hwp3-sample16-hwp5-2010.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	2697
 hwp5rb	hwp3-sample16-hwp5-2010.hwp	sections[].paragraphs[].controls[][].drawing.fill.solid	3
-hwp5rb	hwp3-sample16-hwp5-2010.hwp	sections[].paragraphs[].line_segs[].vertical_pos	627
-hwp5rb	hwp3-sample16-hwp5-2018.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	1330
-hwp5rb	hwp3-sample16-hwp5-2018.hwp	sections[].paragraphs[].line_segs[].vertical_pos	670
-hwp5rb	hwp3-sample16-hwp5-2022.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	1369
+hwp5rb	hwp3-sample16-hwp5-2010.hwp	sections[].paragraphs[].line_segs[].vertical_pos	926
+hwp5rb	hwp3-sample16-hwp5-2018.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	2697
+hwp5rb	hwp3-sample16-hwp5-2018.hwp	sections[].paragraphs[].controls[][].drawing.fill.solid	3
+hwp5rb	hwp3-sample16-hwp5-2018.hwp	sections[].paragraphs[].line_segs[].vertical_pos	1106
+hwp5rb	hwp3-sample16-hwp5-2022.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	2697
 hwp5rb	hwp3-sample16-hwp5-2022.hwp	sections[].paragraphs[].controls[][].drawing.fill.solid	3
-hwp5rb	hwp3-sample16-hwp5-2022.hwp	sections[].paragraphs[].line_segs[].vertical_pos	628
-hwp5rb	hwp3-sample16-hwp5-2024.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	1330
-hwp5rb	hwp3-sample16-hwp5-2024.hwp	sections[].paragraphs[].line_segs[].vertical_pos	670
-hwp5rb	hwp3-sample16-hwp5.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	1370
+hwp5rb	hwp3-sample16-hwp5-2022.hwp	sections[].paragraphs[].line_segs[].vertical_pos	927
+hwp5rb	hwp3-sample16-hwp5-2024.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	2697
+hwp5rb	hwp3-sample16-hwp5-2024.hwp	sections[].paragraphs[].controls[][].drawing.fill.solid	3
+hwp5rb	hwp3-sample16-hwp5-2024.hwp	sections[].paragraphs[].line_segs[].vertical_pos	1106
+hwp5rb	hwp3-sample16-hwp5.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	2697
 hwp5rb	hwp3-sample16-hwp5.hwp	sections[].paragraphs[].controls[][].drawing.fill.solid	3
-hwp5rb	hwp3-sample16-hwp5.hwp	sections[].paragraphs[].line_segs[].vertical_pos	627
+hwp5rb	hwp3-sample16-hwp5.hwp	sections[].paragraphs[].line_segs[].vertical_pos	926
 hwp5rb	hwp3-sample19-hwp5.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	1
 hwp5rb	hwp_table_test-m.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	56
 hwp5rb	hwp_table_test.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	46
@@ -225,7 +229,7 @@ hwp5rb	issue2004_cell_image_stack.hwp	sections[].paragraphs[].control_mask	1
 hwp5rb	issue2004_cell_image_stack.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	121
 hwp5rb	issue2020/(250813) (보도자료) 2025년 7월중 가계대출 동향.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	40
 hwp5rb	issue2020/passport_application_lawgo.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	26
-hwp5rb	issue2063_huge_cellbreak_table.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	2000
+hwp5rb	issue2063_huge_cellbreak_table.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	52678
 hwp5rb	issue2164/의견제출서(양식).hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	10
 hwp5rb	issue2217/20200830.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	128
 hwp5rb	issue2217/20200830.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].control_mask	1
@@ -286,7 +290,7 @@ hwp5rb	table-vpos-01.hwp	sections[].paragraphs[].char_count	1
 hwp5rb	table-vpos-01.hwp	sections[].paragraphs[].control_mask	1
 hwp5rb	table-vpos-01.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	36
 hwp5rb	table-vpos-01.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	11
-hwp5rb	table_scattered_header_rowbreak.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	2000
+hwp5rb	table_scattered_header_rowbreak.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	3901
 hwp5rb	tac-case-001.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	4
 hwp5rb	tac-img-02.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	1871
 hwp5rb	tac-img-02.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	28
@@ -294,7 +298,7 @@ hwp5rb	tac-verify/scenario-b-after.hwp	sections[].paragraphs[].controls[].cells[
 hwp5rb	tac-verify/scenario-b-before.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	1
 hwp5rb	task-001.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	1
 hwp5rb	task1700/byeolpyo1_uujeong_wrap_singlepage.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	19
-hwp5rb	task1700/myeonjeok_wrap_10page.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	2000
+hwp5rb	task1700/myeonjeok_wrap_10page.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	2025
 hwp5rb	task1705/wrap_empty_para_anchor_page.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	26
 hwp5rb	task1706/empty_para_between_tac_tables.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	32
 hwp5rb	task1718/table_giant_cell_overfill.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	1
@@ -310,11 +314,12 @@ hwp5rb	task1749/saved_bounds_cumulative_vpos.hwp	sections[].paragraphs[].char_co
 hwp5rb	task1749/saved_bounds_cumulative_vpos.hwp	sections[].paragraphs[].control_mask	1
 hwp5rb	task1749/saved_bounds_cumulative_vpos.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	32
 hwp5rb	task1749/saved_bounds_cumulative_vpos.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	52
-hwp5rb	task1753/deferred_takeplace_fill_ahead.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	2000
+hwp5rb	task1753/deferred_takeplace_fill_ahead.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	2161
 hwp5rb	task1763/cell_trailing_ls_expand.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	111
 hwp5rb	task1765/merged_cell_trailing_ls.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	37
-hwp5rb	task2070/1130000-201900011_D0150004-1-002_2017년기준 시장구조조사.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	1973
+hwp5rb	task2070/1130000-201900011_D0150004-1-002_2017년기준 시장구조조사.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	3212
 hwp5rb	task2070/1130000-201900011_D0150004-1-002_2017년기준 시장구조조사.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	27
+hwp5rb	task2070/1130000-201900011_D0150004-1-002_2017년기준 시장구조조사.hwp	sections[].paragraphs[].controls[].paragraphs[].controls[].cells[].list_header_width_ref	7
 hwp5rb	task2097/1730000_selection_report.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	31
 hwp5rb	task2097/18095317_eogu_geumji.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	140
 hwp5rb	task2097/18095317_eogu_geumji.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	10
@@ -324,8 +329,8 @@ hwp5rb	task2097/21217935_simsa_jipyo.hwp	sections[].paragraphs[].controls[].cell
 hwp5rb	task2097/3080901_pii_ledger.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	30
 hwp5rb	task2137/156618554_petfood_press.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	15
 hwp5rb	task2146/21761835_jeonjik_exemption_table.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	286
-hwp5rb	task2287/1342000_edu_curriculum_map.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	1843
-hwp5rb	task2287/1342000_edu_curriculum_map.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	157
+hwp5rb	task2287/1342000_edu_curriculum_map.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	16626
+hwp5rb	task2287/1342000_edu_curriculum_map.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	216
 hwp5rb	task2319/20544835_jinan_apt_form.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	92
 hwp5rb	task2322/20862337_cheongyang_voucher_form.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	22
 hwp5rb	task2322/20862337_cheongyang_voucher_form.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	109
@@ -359,36 +364,40 @@ hwpx	143E433F503322BD33.hwpx	sections[].paragraphs[].controls[].text_box.paragra
 hwpx	143E433F503322BD33.hwpx	sections[].paragraphs[].raw_header_extra[]	22
 hwpx	2024년 1분기 해외직접투자 보도자료 ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_x	1
 hwpx	2024년 1분기 해외직접투자 보도자료 ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_y	1
-hwpx	2024년 1분기 해외직접투자 보도자료 ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1864
-hwpx	2024년 1분기 해외직접투자 보도자료 ff.hwpx	sections[].paragraphs[].raw_header_extra[]	134
+hwpx	2024년 1분기 해외직접투자 보도자료 ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	4144
+hwpx	2024년 1분기 해외직접투자 보도자료 ff.hwpx	sections[].paragraphs[].raw_header_extra[]	299
 hwpx	2024년 2분기 해외직접투자 보도자료ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_x	1
 hwpx	2024년 2분기 해외직접투자 보도자료ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_y	1
-hwpx	2024년 2분기 해외직접투자 보도자료ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1869
-hwpx	2024년 2분기 해외직접투자 보도자료ff.hwpx	sections[].paragraphs[].raw_header_extra[]	129
+hwpx	2024년 2분기 해외직접투자 보도자료ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	4389
+hwpx	2024년 2분기 해외직접투자 보도자료ff.hwpx	sections[].paragraphs[].raw_header_extra[]	311
 hwpx	2024년 연간 해외직접투자 보도자료 _ ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_x	1
 hwpx	2024년 연간 해외직접투자 보도자료 _ ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_y	1
-hwpx	2024년 연간 해외직접투자 보도자료 _ ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1880
-hwpx	2024년 연간 해외직접투자 보도자료 _ ff.hwpx	sections[].paragraphs[].raw_header_extra[]	118
-hwpx	2025년 1분기 해외직접투자 보도자료f.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1859
+hwpx	2024년 연간 해외직접투자 보도자료 _ ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	4865
+hwpx	2024년 연간 해외직접투자 보도자료 _ ff.hwpx	sections[].paragraphs[].raw_header_extra[]	292
+hwpx	2025년 1분기 해외직접투자 보도자료f.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	4156
 hwpx	2025년 1분기 해외직접투자 보도자료f.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].controls[].shape_attr.offset_x	2
 hwpx	2025년 1분기 해외직접투자 보도자료f.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].controls[].shape_attr.offset_y	2
 hwpx	2025년 1분기 해외직접투자 보도자료f.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].raw_header_extra[]	2
-hwpx	2025년 1분기 해외직접투자 보도자료f.hwpx	sections[].paragraphs[].raw_header_extra[]	135
-hwpx	2025년 2분기 해외직접투자 (최종).hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1868
-hwpx	2025년 2분기 해외직접투자 (최종).hwpx	sections[].paragraphs[].raw_header_extra[]	132
+hwpx	2025년 1분기 해외직접투자 보도자료f.hwpx	sections[].paragraphs[].raw_header_extra[]	317
+hwpx	2025년 2분기 해외직접투자 (최종).hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	4409
+hwpx	2025년 2분기 해외직접투자 (최종).hwpx	sections[].paragraphs[].raw_header_extra[]	317
 hwpx	2026_oss_rst.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	16
 hwpx	2026_oss_rst.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	221
 hwpx	2026_oss_rst.hwpx	sections[].paragraphs[].raw_header_extra[]	19
-hwpx	[2027] 온새미로 1 본교재.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	359
+hwpx	[2027] 온새미로 1 본교재.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	464
 hwpx	[2027] 온새미로 1 본교재.hwpx	sections[].paragraphs[].controls[].shape_attr.offset_x	1
 hwpx	[2027] 온새미로 1 본교재.hwpx	sections[].paragraphs[].controls[].shape_attr.offset_y	1
-hwpx	[2027] 온새미로 1 본교재.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].raw_header_extra[]	18
-hwpx	[2027] 온새미로 1 본교재.hwpx	sections[].paragraphs[].raw_header_extra[]	1621
+hwpx	[2027] 온새미로 1 본교재.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].raw_header_extra[]	21
+hwpx	[2027] 온새미로 1 본교재.hwpx	sections[].paragraphs[].raw_header_extra[]	2011
 hwpx	aift.hwpx	sections[].paragraphs[].controls[]	4
-hwpx	aift.hwpx	sections[].paragraphs[].controls[].caption.paragraphs[].raw_header_extra[]	2
-hwpx	aift.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	149
-hwpx	aift.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1479
-hwpx	aift.hwpx	sections[].paragraphs[].raw_header_extra[]	366
+hwpx	aift.hwpx	sections[].paragraphs[].controls[].caption.paragraphs[].raw_header_extra[]	32
+hwpx	aift.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	961
+hwpx	aift.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	14538
+hwpx	aift.hwpx	sections[].paragraphs[].controls[].memo_paragraphs[].raw_header_extra[]	4
+hwpx	aift.hwpx	sections[].paragraphs[].controls[].paragraphs[].raw_header_extra[]	3
+hwpx	aift.hwpx	sections[].paragraphs[].controls[].shape_attr.offset_x	4
+hwpx	aift.hwpx	sections[].paragraphs[].controls[].shape_attr.offset_y	2
+hwpx	aift.hwpx	sections[].paragraphs[].raw_header_extra[]	2536
 hwpx	basic-table-01.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	11
 hwpx	basic-table-01.hwpx	sections[].paragraphs[].raw_header_extra[]	5
 hwpx	blank_hwpx.hwpx	sections[].paragraphs[].raw_header_extra[]	4
@@ -433,17 +442,18 @@ hwpx	exam-kor-4p.hwpx	sections[].paragraphs[].controls[].shape_attr.offset_x	2
 hwpx	exam-kor-4p.hwpx	sections[].paragraphs[].controls[].shape_attr.offset_y	7
 hwpx	exam-kor-4p.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].raw_header_extra[]	12
 hwpx	exam-kor-4p.hwpx	sections[].paragraphs[].raw_header_extra[]	287
+hwpx	exam_kor.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	111
 hwpx	exam_kor.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_x	2
 hwpx	exam_kor.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_y	2
-hwpx	exam_kor.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].text_box.paragraphs[].raw_header_extra[]	7
-hwpx	exam_kor.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	335
+hwpx	exam_kor.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].text_box.paragraphs[].raw_header_extra[]	10
+hwpx	exam_kor.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	675
 hwpx	exam_kor.hwpx	sections[].paragraphs[].controls[].list_attr	1
 hwpx	exam_kor.hwpx	sections[].paragraphs[].controls[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	3
 hwpx	exam_kor.hwpx	sections[].paragraphs[].controls[].paragraphs[].raw_header_extra[]	2
-hwpx	exam_kor.hwpx	sections[].paragraphs[].controls[].shape_attr.offset_x	4
-hwpx	exam_kor.hwpx	sections[].paragraphs[].controls[].shape_attr.offset_y	11
-hwpx	exam_kor.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].raw_header_extra[]	41
-hwpx	exam_kor.hwpx	sections[].paragraphs[].raw_header_extra[]	1592
+hwpx	exam_kor.hwpx	sections[].paragraphs[].controls[].shape_attr.offset_x	14
+hwpx	exam_kor.hwpx	sections[].paragraphs[].controls[].shape_attr.offset_y	19
+hwpx	exam_kor.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].raw_header_extra[]	47
+hwpx	exam_kor.hwpx	sections[].paragraphs[].raw_header_extra[]	2021
 hwpx	exam_social-p1.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	76
 hwpx	exam_social-p1.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].text_box.paragraphs[].raw_header_extra[]	4
 hwpx	exam_social-p1.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	166
@@ -493,15 +503,15 @@ hwpx	hwpx-centered-cell-vpos-after-tac-shape.hwpx	sections[].paragraphs[].contro
 hwpx	hwpx-centered-cell-vpos-after-tac-shape.hwpx	sections[].paragraphs[].raw_header_extra[]	15
 hwpx	hwpx-h-01.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_x	1
 hwpx	hwpx-h-01.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_y	1
-hwpx	hwpx-h-01.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1864
-hwpx	hwpx-h-01.hwpx	sections[].paragraphs[].raw_header_extra[]	134
-hwpx	hwpx-h-02.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1868
-hwpx	hwpx-h-02.hwpx	sections[].paragraphs[].raw_header_extra[]	132
-hwpx	hwpx-h-03.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1859
+hwpx	hwpx-h-01.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	4144
+hwpx	hwpx-h-01.hwpx	sections[].paragraphs[].raw_header_extra[]	299
+hwpx	hwpx-h-02.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	4409
+hwpx	hwpx-h-02.hwpx	sections[].paragraphs[].raw_header_extra[]	317
+hwpx	hwpx-h-03.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	4156
 hwpx	hwpx-h-03.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].controls[].shape_attr.offset_x	2
 hwpx	hwpx-h-03.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].controls[].shape_attr.offset_y	2
 hwpx	hwpx-h-03.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].raw_header_extra[]	2
-hwpx	hwpx-h-03.hwpx	sections[].paragraphs[].raw_header_extra[]	135
+hwpx	hwpx-h-03.hwpx	sections[].paragraphs[].raw_header_extra[]	317
 hwpx	hy-001.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	41
 hwpx	hy-001.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].raw_header_extra[]	2
 hwpx	hy-001.hwpx	sections[].paragraphs[].raw_header_extra[]	59
@@ -544,15 +554,15 @@ hwpx	issue_241.hwpx	sections[].paragraphs[].controls[].shape_attr.offset_y	1
 hwpx	issue_241.hwpx	sections[].paragraphs[].raw_header_extra[]	15
 hwpx	k-water-rfp.hwpx	sections[].paragraphs[].controls[]	2
 hwpx	k-water-rfp.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_y	1
-hwpx	k-water-rfp.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	30
+hwpx	k-water-rfp.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	102
 hwpx	k-water-rfp.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_x	2
 hwpx	k-water-rfp.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_y	3
-hwpx	k-water-rfp.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1351
+hwpx	k-water-rfp.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	2447
 hwpx	k-water-rfp.hwpx	sections[].paragraphs[].controls[].list_attr	2
 hwpx	k-water-rfp.hwpx	sections[].paragraphs[].controls[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	2
 hwpx	k-water-rfp.hwpx	sections[].paragraphs[].controls[].paragraphs[].raw_header_extra[]	7
 hwpx	k-water-rfp.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].raw_header_extra[]	3
-hwpx	k-water-rfp.hwpx	sections[].paragraphs[].raw_header_extra[]	597
+hwpx	k-water-rfp.hwpx	sections[].paragraphs[].raw_header_extra[]	682
 hwpx	landscape-001.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	65
 hwpx	landscape-001.hwpx	sections[].paragraphs[].raw_header_extra[]	4
 hwpx	local-font-nanumsquare-bold.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	28
@@ -560,8 +570,9 @@ hwpx	local-font-nanumsquare-bold.hwpx	sections[].paragraphs[].controls[].shape_a
 hwpx	local-font-nanumsquare-bold.hwpx	sections[].paragraphs[].controls[].shape_attr.offset_y	1
 hwpx	local-font-nanumsquare-bold.hwpx	sections[].paragraphs[].raw_header_extra[]	15
 hwpx	math-001.hwpx	sections[].paragraphs[].raw_header_extra[]	29
-hwpx	mel-001.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1975
-hwpx	mel-001.hwpx	sections[].paragraphs[].raw_header_extra[]	25
+hwpx	mel-001.hwpx	sections[].paragraphs[].controls[].caption.paragraphs[].raw_header_extra[]	6
+hwpx	mel-001.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	3997
+hwpx	mel-001.hwpx	sections[].paragraphs[].raw_header_extra[]	765
 hwpx	pagenation-001.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_x	1
 hwpx	pagenation-001.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_y	1
 hwpx	pagenation-001.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	215
@@ -571,12 +582,12 @@ hwpx	pagenation-001.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[
 hwpx	pagenation-001.hwpx	sections[].paragraphs[].raw_header_extra[]	36
 hwpx	para-001.hwpx	sections[].paragraphs[].raw_header_extra[]	80
 hwpx	para-unit-01.hwpx	sections[].paragraphs[].raw_header_extra[]	27
-hwpx	pr-1674.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	156
+hwpx	pr-1674.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	216
 hwpx	pr-1674.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_y	1
 hwpx	pr-1674.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].text_box.paragraphs[].raw_header_extra[]	5
-hwpx	pr-1674.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1403
-hwpx	pr-1674.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].raw_header_extra[]	24
-hwpx	pr-1674.hwpx	sections[].paragraphs[].raw_header_extra[]	411
+hwpx	pr-1674.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	3144
+hwpx	pr-1674.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].raw_header_extra[]	44
+hwpx	pr-1674.hwpx	sections[].paragraphs[].raw_header_extra[]	966
 hwpx	ref/ref_empty.hwpx	sections[].paragraphs[].raw_header_extra[]	4
 hwpx	ref/ref_mixed.hwpx	sections[].paragraphs[].raw_header_extra[]	7
 hwpx	ref/ref_table.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	5

--- a/tests/ir_field_sweep_baseline.rs
+++ b/tests/ir_field_sweep_baseline.rs
@@ -12,6 +12,10 @@
 //! 걸고, 그 결과를 baseline 파일로 **동결**한다. 목적은 "지금 전부 무손실"이 아니라
 //! **"오늘보다 나빠지면 즉시 실패"** 다.
 //!
+//! baseline v2는 정규화 경로별 **완전한 건수**만 받는다. 상세 예시 payload 상한과
+//! 건수 집계를 분리하므로, 앞 경로의 개선이 뒤 경로의 기존 발산을 새 회귀처럼
+//! 재배치하지 않는다. schema marker가 없는 예전 전역-cap baseline은 거부한다.
+//!
 //! ## 왜 baseline(래칫) 인가
 //!
 //! 스윕은 첫날부터 빨갛다(실측 결과는 이슈 #2740 §4). 첫날 빨간 게이트는 결국
@@ -41,19 +45,21 @@
 //!
 //! ## 진단
 //!
-//! `RHWP_IR_SWEEP_DETAIL="샘플명조각;다른조각"` 을 주면 해당 샘플의 발산을
-//! 경로·값까지 전부 출력한다 — 잔여 항목 분류용.
+//! `RHWP_IR_SWEEP_DETAIL="샘플명조각;다른조각"` 을 주면 해당 샘플의 완전한
+//! 경로별 건수와 상한 이내의 경로·값 예시를 출력한다 — 잔여 항목 분류용.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use rhwp::diagnostics::ir_field_sweep::{
     sweep_hwp5_rebuild_roundtrip, sweep_hwp5_roundtrip, sweep_hwpx_roundtrip, tally,
-    FieldDivergence,
+    DivergenceReport,
 };
 use rhwp::parser::{detect_format, parse_document, FileFormat};
 
 const BASELINE: &str = "tests/fixtures/ir_field_sweep_baseline.tsv";
+const BASELINE_SCHEMA: &str = "# rhwp-ir-field-sweep-baseline-v2 complete-normalized-path-counts";
+const BASELINE_HEADER: &str = "lane\tsample\tpath\tcount";
 const HWP5_ROOT: &str = "samples";
 const HWPX_ROOT: &str = "samples/hwpx";
 
@@ -135,16 +141,25 @@ fn detail_filter() -> Option<Vec<String>> {
     (!parts.is_empty()).then_some(parts)
 }
 
-fn print_detail(lane: &str, rel: &str, divs: &[FieldDivergence]) {
+fn print_detail(lane: &str, rel: &str, report: &DivergenceReport) {
     let Some(filters) = detail_filter() else {
         return;
     };
     if !filters.iter().any(|f| rel.contains(f.as_str())) {
         return;
     }
-    println!("--- [{lane}] {rel} — 발산 {}건 ---", divs.len());
-    for d in divs {
+    println!("--- [{lane}] {rel} — 발산 {}건 ---", report.total());
+    println!("  [정규화 경로별 완전한 건수]");
+    for (path, count) in report.counts() {
+        println!("  {count}\t{path}");
+    }
+    println!("  [상세 예시]");
+    for d in report.examples() {
         println!("  {d}");
+    }
+    let omitted = report.total().saturating_sub(report.examples().len());
+    if omitted > 0 {
+        println!("  ... 상세 예시 상한 이후 {omitted}건 생략");
     }
 }
 
@@ -160,10 +175,10 @@ fn sweep_corpus(size_filter: &dyn Fn(u64) -> bool) -> (Baseline, usize, usize) {
     let mut swept = 0usize;
     let mut skipped = 0usize;
 
-    let mut record = |lane: &str, rel: &str, divs: &[FieldDivergence]| {
-        print_detail(lane, rel, divs);
-        for (p, n) in tally(divs) {
-            acc.insert((lane.to_string(), rel.to_string(), p), n);
+    let mut record = |lane: &str, rel: &str, report: &DivergenceReport| {
+        print_detail(lane, rel, report);
+        for (p, n) in tally(report) {
+            acc.insert((lane.to_string(), rel.to_string(), p.clone()), *n);
         }
     };
 
@@ -179,16 +194,22 @@ fn sweep_corpus(size_filter: &dyn Fn(u64) -> bool) -> (Baseline, usize, usize) {
             continue;
         }
         match sweep_hwp5_roundtrip(&bytes) {
-            Ok(divs) => {
+            Ok(report) => {
                 swept += 1;
-                record("hwp5", &rel, &divs);
+                record("hwp5", &rel, &report);
+            }
+            Err(error) if error.is_capacity_error() => {
+                panic!("[hwp5] {rel}: {error}")
             }
             Err(_) => skipped += 1,
         }
         match sweep_hwp5_rebuild_roundtrip(&bytes) {
-            Ok(divs) => {
+            Ok(report) => {
                 swept += 1;
-                record("hwp5rb", &rel, &divs);
+                record("hwp5rb", &rel, &report);
+            }
+            Err(error) if error.is_capacity_error() => {
+                panic!("[hwp5rb] {rel}: {error}")
             }
             Err(_) => skipped += 1,
         }
@@ -203,9 +224,12 @@ fn sweep_corpus(size_filter: &dyn Fn(u64) -> bool) -> (Baseline, usize, usize) {
             continue;
         };
         match sweep_hwpx_roundtrip(&bytes) {
-            Ok(divs) => {
+            Ok(report) => {
                 swept += 1;
-                record("hwpx", &rel, &divs);
+                record("hwpx", &rel, &report);
+            }
+            Err(error) if error.is_capacity_error() => {
+                panic!("[hwpx] {rel}: {error}")
             }
             Err(_) => skipped += 1,
         }
@@ -214,38 +238,59 @@ fn sweep_corpus(size_filter: &dyn Fn(u64) -> bool) -> (Baseline, usize, usize) {
     (acc, swept, skipped)
 }
 
-fn load_baseline() -> Baseline {
-    let text = std::fs::read_to_string(BASELINE)
-        .unwrap_or_else(|e| panic!("baseline 읽기 실패 {BASELINE}: {e}"));
+fn parse_baseline(text: &str, source: &str) -> Result<Baseline, String> {
+    let mut lines = text.lines();
+    let schema = lines
+        .next()
+        .ok_or_else(|| format!("baseline 이 비어 있음: {source}"))?;
+    if schema != BASELINE_SCHEMA {
+        return Err(format!(
+            "baseline schema 불일치: {source}: {schema:?} (기대: {BASELINE_SCHEMA:?})"
+        ));
+    }
+    let header = lines
+        .next()
+        .ok_or_else(|| format!("baseline 헤더 없음: {source}"))?;
+    if header != BASELINE_HEADER {
+        return Err(format!(
+            "baseline 헤더 불일치: {source}: {header:?} (기대: {BASELINE_HEADER:?})"
+        ));
+    }
+
     let mut map = Baseline::new();
-    for (i, line) in text.lines().enumerate() {
-        if i == 0 || line.trim().is_empty() {
-            continue; // 헤더/빈 줄
+    for (i, line) in lines.enumerate() {
+        let line_no = i + 3;
+        if line.trim().is_empty() {
+            continue;
         }
         let cols: Vec<&str> = line.split('\t').collect();
-        assert!(
-            cols.len() == 4,
-            "baseline {BASELINE} {}행 열 수 이상: {line}",
-            i + 1
-        );
+        if cols.len() != 4 {
+            return Err(format!("baseline {source} {line_no}행 열 수 이상: {line}"));
+        }
         let count: usize = cols[3]
             .trim()
             .parse()
-            .unwrap_or_else(|_| panic!("baseline {BASELINE} {}행 건수 파싱 실패", i + 1));
-        map.insert(
-            (
-                cols[0].to_string(),
-                cols[1].to_string(),
-                cols[2].to_string(),
-            ),
-            count,
+            .map_err(|_| format!("baseline {source} {line_no}행 건수 파싱 실패"))?;
+        let key = (
+            cols[0].to_string(),
+            cols[1].to_string(),
+            cols[2].to_string(),
         );
+        if map.insert(key, count).is_some() {
+            return Err(format!("baseline {source} {line_no}행 키 중복: {line}"));
+        }
     }
-    map
+    Ok(map)
+}
+
+fn load_baseline() -> Baseline {
+    let text = std::fs::read_to_string(BASELINE)
+        .unwrap_or_else(|e| panic!("baseline 읽기 실패 {BASELINE}: {e}"));
+    parse_baseline(&text, BASELINE).unwrap_or_else(|e| panic!("{e}"))
 }
 
 fn write_dump(path: &str, rows: &Baseline) {
-    let mut s = String::from("lane\tsample\tpath\tcount\n");
+    let mut s = format!("{BASELINE_SCHEMA}\n{BASELINE_HEADER}\n");
     for ((lane, sample, p), n) in rows {
         s.push_str(&format!("{lane}\t{sample}\t{p}\t{n}\n"));
     }
@@ -253,6 +298,43 @@ fn write_dump(path: &str, rows: &Baseline) {
         let _ = std::fs::create_dir_all(parent);
     }
     std::fs::write(path, s).unwrap_or_else(|e| panic!("덤프 쓰기 실패 {path}: {e}"));
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct BaselineDelta {
+    regressions: Vec<String>,
+    improvements: usize,
+}
+
+fn compare_baseline(current: &Baseline, baseline: &Baseline, full: bool) -> BaselineDelta {
+    let mut regressions = Vec::new();
+    let mut improvements = 0usize;
+
+    for (key, &now) in current {
+        let was = baseline.get(key).copied().unwrap_or(0);
+        if now > was {
+            regressions.push(format!(
+                "  [{}] {} — {} : {was} → {now}",
+                key.0, key.1, key.2
+            ));
+        } else if now < was {
+            improvements += 1;
+        }
+    }
+    // baseline 에 있었는데 이번에 사라진 경로도 개선이다 (빠른 부분집합에서는
+    // 대상 밖 샘플이 많으므로 전체 모드에서만 센다).
+    if full {
+        for key in baseline.keys() {
+            if !current.contains_key(key) {
+                improvements += 1;
+            }
+        }
+    }
+
+    BaselineDelta {
+        regressions,
+        improvements,
+    }
 }
 
 /// 회귀 관문 — baseline 대비 **증가분**만 실패시킨다.
@@ -289,40 +371,21 @@ fn ir_field_sweep_does_not_regress() {
     assert!(swept > 0, "스윕 대상 샘플이 없음");
 
     let baseline = load_baseline();
-    let mut regressions = Vec::new();
-    let mut improvements = 0usize;
+    let delta = compare_baseline(&current, &baseline, full);
 
-    for (key, &now) in &current {
-        let was = baseline.get(key).copied().unwrap_or(0);
-        if now > was {
-            regressions.push(format!(
-                "  [{}] {} — {} : {was} → {now}",
-                key.0, key.1, key.2
-            ));
-        } else if now < was {
-            improvements += 1;
-        }
-    }
-    // baseline 에 있었는데 이번에 사라진 경로도 개선이다 (빠른 부분집합에서는
-    // 대상 밖 샘플이 많으므로 전체 모드에서만 센다).
-    if full {
-        for key in baseline.keys() {
-            if !current.contains_key(key) {
-                improvements += 1;
-            }
-        }
-    }
-
-    if improvements > 0 {
-        println!("개선 {improvements}건 — baseline 재생성 권장 (RHWP_IR_SWEEP_DUMP={BASELINE})");
+    if delta.improvements > 0 {
+        println!(
+            "개선 {}건 — baseline 재생성 권장 (RHWP_IR_SWEEP_DUMP={BASELINE})",
+            delta.improvements
+        );
     }
 
     assert!(
-        regressions.is_empty(),
+        delta.regressions.is_empty(),
         "IR 필드 왕복 발산이 baseline 보다 늘었다 ({}건). 직렬화기가 필드를 잃고 있다는 뜻이므로 \
          원인을 고치거나, 의도된 정규화라면 baseline 을 갱신하고 사유를 PR 에 남겨라:\n{}",
-        regressions.len(),
-        regressions.join("\n")
+        delta.regressions.len(),
+        delta.regressions.join("\n")
     );
 }
 
@@ -345,4 +408,35 @@ fn baseline_samples_exist() {
         missing.len(),
         missing.join("\n")
     );
+}
+
+#[test]
+fn legacy_capped_baseline_schema_is_rejected() {
+    let legacy = "lane\tsample\tpath\tcount\nhwpx\tfixture.hwpx\tpath\t1\n";
+    let error = parse_baseline(legacy, "legacy.tsv").unwrap_err();
+    assert!(
+        error.contains("schema 불일치"),
+        "old capped counts must not be read as complete: {error}"
+    );
+}
+
+#[test]
+fn later_path_regression_is_not_offset_by_earlier_improvement() {
+    let early = (
+        "hwpx".to_string(),
+        "fixture.hwpx".to_string(),
+        "early.path".to_string(),
+    );
+    let later = (
+        "hwpx".to_string(),
+        "fixture.hwpx".to_string(),
+        "later.path".to_string(),
+    );
+    let baseline = Baseline::from([(early.clone(), 1), (later.clone(), 2000)]);
+    let current = Baseline::from([(later, 2001)]);
+
+    let delta = compare_baseline(&current, &baseline, true);
+    assert_eq!(delta.improvements, 1);
+    assert_eq!(delta.regressions.len(), 1);
+    assert!(delta.regressions[0].contains("later.path : 2000 → 2001"));
 }

--- a/tests/issue_4441_ir_sweep_stable_cap.rs
+++ b/tests/issue_4441_ir_sweep_stable_cap.rs
@@ -1,0 +1,88 @@
+use rhwp::diagnostics::ir_field_sweep::{sweep_documents, MAX_DIVERGENCE_EXAMPLES};
+use rhwp::model::document::{Document, Section};
+use rhwp::model::paragraph::Paragraph;
+
+const EARLY_PATH: &str = "doc_info.bullet_count";
+const LATER_PATH: &str = "sections[].paragraphs[].text";
+
+fn sweep_fixture(
+    early_divergence: bool,
+    later_divergences: usize,
+) -> rhwp::diagnostics::ir_field_sweep::DivergenceReport {
+    let paragraph_count = MAX_DIVERGENCE_EXAMPLES + 1;
+    assert!(later_divergences <= paragraph_count);
+
+    let source_paragraphs = (0..paragraph_count)
+        .map(|_| Paragraph {
+            text: "source".to_string(),
+            ..Default::default()
+        })
+        .collect();
+    let roundtrip_paragraphs = (0..paragraph_count)
+        .map(|index| Paragraph {
+            text: if index < later_divergences {
+                "roundtrip".to_string()
+            } else {
+                "source".to_string()
+            },
+            ..Default::default()
+        })
+        .collect();
+
+    let mut source = Document::default();
+    source.sections.push(Section {
+        paragraphs: source_paragraphs,
+        ..Default::default()
+    });
+
+    let mut roundtrip = Document::default();
+    roundtrip.doc_info.bullet_count = u32::from(early_divergence);
+    roundtrip.sections.push(Section {
+        paragraphs: roundtrip_paragraphs,
+        ..Default::default()
+    });
+
+    sweep_documents(&source, &roundtrip).expect("synthetic sweep must fit the path budget")
+}
+
+#[test]
+fn early_improvement_does_not_redistribute_saturated_later_path_count() {
+    let before = sweep_fixture(true, MAX_DIVERGENCE_EXAMPLES);
+    let after = sweep_fixture(false, MAX_DIVERGENCE_EXAMPLES);
+
+    assert_eq!(before.counts().get(EARLY_PATH), Some(&1));
+    assert_eq!(after.counts().get(EARLY_PATH), None);
+    assert_eq!(
+        before.counts().get(LATER_PATH),
+        Some(&MAX_DIVERGENCE_EXAMPLES)
+    );
+    assert_eq!(
+        after.counts().get(LATER_PATH),
+        before.counts().get(LATER_PATH)
+    );
+
+    assert_eq!(before.total(), MAX_DIVERGENCE_EXAMPLES + 1);
+    assert_eq!(
+        before.examples().len(),
+        MAX_DIVERGENCE_EXAMPLES,
+        "payload examples remain bounded while counts stay complete"
+    );
+}
+
+#[test]
+fn later_path_regression_remains_visible_after_early_improvement() {
+    let baseline = sweep_fixture(true, MAX_DIVERGENCE_EXAMPLES);
+    let regressed = sweep_fixture(false, MAX_DIVERGENCE_EXAMPLES + 1);
+
+    assert_eq!(baseline.counts().get(EARLY_PATH), Some(&1));
+    assert_eq!(regressed.counts().get(EARLY_PATH), None);
+    assert_eq!(
+        baseline.counts().get(LATER_PATH),
+        Some(&MAX_DIVERGENCE_EXAMPLES)
+    );
+    assert_eq!(
+        regressed.counts().get(LATER_PATH),
+        Some(&(MAX_DIVERGENCE_EXAMPLES + 1)),
+        "a genuine later-path increase must not be hidden by the early improvement"
+    );
+}


### PR DESCRIPTION
## 변경 요약

- IR field sweep의 정규화 경로별 발산 건수를 상세 예시 2,000개 상한과 분리해 끝까지 집계합니다.
- 문서당 서로 다른 경로 2,000종 상한은 유지하되, 초과 시 일부 결과를 숨기지 않고 typed error로 실패시킵니다.
- baseline을 `complete-normalized-path-counts` v2 스키마로 전환하고, 오래된 traversal-capped 파일을 명시적으로 거부합니다.
- 앞쪽 경로 개선이 뒤쪽 기존 발산을 새 회귀로 재배치하지 않고, 실제 뒤쪽 증가분은 계속 실패하는 합성 회귀를 추가했습니다.

이 변경은 baseline을 느슨하게 하지 않습니다. 공개 sample 전체를 새 collector로 다시 생성한 결과는 597행 / 112,314건에서 607행 / 244,812건으로 늘었고, 10개 새 경로(+197)와 64개 기존 경로 증가(+132,301), 감소·삭제 0건입니다. 종전 전역 상한에 가려졌던 값을 완전한 경로별 건수로 처음 드러낸 일회성 스키마 migration입니다.

## 관련 이슈

Closes #4441

Related: #3277, #3279, #2740, #4433

## 테스트

- [x] `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests` 통과
- [x] `cargo clippy --profile release-test --all-targets -- -D warnings` 통과
- [x] diagnostics units 18/18, #4441 integration 2/2, baseline schema/ratchet focused tests 통과
- [x] complete v2 sweep: 815 swept / 3 skipped, 607 paths, 244,812 divergences, capacity error 0
- [x] 관련 SVG snapshot integration tests는 전체 release suite에서 통과
- [x] 웹(WASM) 렌더링 확인 해당 없음 — native diagnostics/test gate만 변경
- [x] capability 카탈로그 해당 없음 — agent/skill 파일 변경 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: diagnostics sweep에서 건수 집계를 끝까지 수행하므로 제한된 추가 비용이 있습니다. production renderer/serializer 경로에는 영향이 없습니다.
- 재현·측정: release-test complete dump 1회가 22.6초였습니다. 상세 payload는 기존처럼 2,000개로 제한되고, 경로 map은 문서당 2,000종에서 fail-closed하며 이번 공개 sweep의 관측 최대는 20종이었습니다.

## 스크린샷

해당 없음. 진단 collector와 baseline gate 변경입니다.
