### PR TITLE
serializer: pin opaque table CTRL_DATA item pairs

### DIFF
--- a/mydocs/tech/hwp_ctrl_data.md
+++ b/mydocs/tech/hwp_ctrl_data.md
@@ -2,7 +2,7 @@
 kind: reference
 status: active
 canonical: mydocs/tech/hwp_spec_errata.md
-last_verified: 2026-07-28
+last_verified: 2026-08-10
 ---
 
 # HWPTAG_CTRL_DATA 분석 (hwplib 크로스 체크)
@@ -78,11 +78,43 @@ offset  size  설명
 - **호환 근거**: #3507 — 동일 payload를 두 번 쓰면 rhwp 재로드는 성공하지만 macOS 한컴 Viewer와
   Windows 한글 2024가 파일 손상으로 거부한다.
 
-### 4. Table (tbl) ⚪ raw round-trip 보존
+### 4. Table (tbl) ✅ raw round-trip + 제한된 HWPX→HWP materialization
 
 - hwplib: `ForControlTable.java` → CtrlData 읽기
 - 표의 부가 메타데이터
-- **현재 영향**: 없음
+- HWP5 파서의 canonical owner는 해당 control index의 `Paragraph.ctrl_data_records`다.
+  serializer는 payload를 해석하거나 item id를 다시 배정하지 않고 raw bytes를 출력한다.
+- HWPX→HWP adapter는 `3×2 + repeat_header + RowBreak` 조건에서만 다음 104바이트
+  table-layout payload를 materialize한다.
+
+```text
+ParameterSet 0x021B
+  item 0x0242 (ParameterSet)
+    ParameterSet 0x0242
+      Integer4 items:
+        (0x4000, 3826), (0x4001, 1048), (0x4002, 28346),
+        (0x4003, 8475), (0x4004, 708),  (0x4005, 0),
+        (0x4006, 2),    (0x4007, 9),    (0x4008, 0),
+        (0x4009, 59528),(0x400A, 84188)
+```
+
+- 위 item id는 이 opaque payload에서 함께 관찰된 정확한 값이다. `0x4000 + index`를
+  범용 할당 규칙이나 확장 가능한 사설 namespace로 취급하지 않는다. 인접 ID에 새 의미를
+  배정하지 말고, 새 payload는 독립된 바이너리 근거와 실제 소비자를 먼저 확정한다.
+- **근거와 한계**: #1064와 #1099에서 같은 104바이트 payload가 관찰됐지만, 당시 결과에는
+  다른 HWP5 저장 계약도 함께 작용했다. #4438의 합성 exact/item-id 역순/CTRL_DATA 없음
+  단일 변화축은 외부 reader에서 모두 열리고 Save As됐다. exact와 item-id 역순 입력은 같은
+  2쪽 구조를 렌더링했고, CTRL_DATA가 없으면 1쪽이었다. 저장 출력은 각 입력의 11개
+  `(item_id, value)` 결합을 유지한 채 item record 순서를 반전했으며, 없음 입력은 계속
+  CTRL_DATA가 없었다. 따라서 이 fixture에서는 payload 존재가 관찰된 layout에 영향을 주지만
+  item-id 치환만으로는 차이가 관찰되지 않았다. 이는 개별 item의 일반 의미·무시 여부,
+  namespace 또는 다른 문서의 호환성을 확정하지 않으므로, adapter가 재현하는 opaque bytes와
+  rhwp 내부 보존 경계만 계약으로 삼는다.
+- source IR 불변이 필요한 저장 경계는
+  `DocumentCore::export_hwp_with_adapter_snapshot()`으로 adapter를 `Document` 복제본에만
+  적용한다. 현재 세션 저장 경로가 이 API를 소비하며, materialized raw bytes와 출처 marker는
+  저장 snapshot에만 존재한다. 반대로 `export_hwp_with_adapter()`는 live IR을 정규화하는
+  in-place API이므로 source-nonmutation 계약으로 해석하지 않는다.
 
 ### 5. Picture ($pic) ⚪ raw round-trip 보존
 
@@ -111,7 +143,7 @@ offset  size  설명
 | 새 Bookmark CTRL_DATA 생성 | ✅ `build_bookmark_ctrl_data()` |
 | Bookmark 삭제/이름변경 시 동기화 | ✅ |
 | 기타 컨트롤 구조적 파싱 | ⚪ 불필요 (raw 보존으로 충분) |
-| 새 컨트롤 생성 시 CTRL_DATA 생성 | ⚠️ Bookmark만 구현, 기타 미구현 |
+| 새 컨트롤 생성 시 CTRL_DATA 생성 | ⚠️ Bookmark와 위 제한된 table-layout 계약만 구현, 기타 미구현 |
 | SectionDef exact duplicate 방어 | ✅ 첫 중첩 header 전의 첫 직접 자식은 단일 owner, legacy 이중 소유 IR은 serializer에서 1회 출력 |
 
 ## 향후 고도화 대상

--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -1803,12 +1803,28 @@ fn table_requires_layout_ctrl_data(table: &Table) -> bool {
         && matches!(table.page_break, TablePageBreak::RowBreak)
 }
 
-fn build_table_layout_ctrl_data() -> Vec<u8> {
-    // 한컴 HWPX→HWP 변환본에서 3x2 선택지 표 뒤에 붙는 Table CTRL_DATA.
-    // 공식 5.0 문서에는 의미가 정리되어 있지 않지만, #1064/#1099 정답지 모두
-    // 같은 104바이트 ParameterSet(0x021b → 0x0242)을 사용한다.
-    const VALUES: [u32; 11] = [3826, 1048, 28346, 8475, 708, 0, 2, 9, 0, 59528, 84188];
+// #1064/#1099에서 같은 104바이트 payload가 관찰됐다. #4438: 이 11쌍은 하나의
+// opaque table-layout payload에서 관찰된 정확한 계약이지, 개별 item의 의미 표가 아니다.
+// 외부 소비자가 각 item을 해석하는지는 확인되지 않았으므로 호환 의미를 추정하지 않는다.
+// 0x4000부터의 연속값을 일반 item-id 할당 범위로 해석하거나 다음 ID를 발명하지 않는다.
+// 새 의미를 추가하려면 이 배열을 연장하지 말고 독립된 바이너리 근거와 소비자를 먼저 확정한다.
+const TABLE_LAYOUT_CTRL_DATA_I4_ITEMS: [(u16, u32); 11] = [
+    (0x4000, 3826),
+    (0x4001, 1048),
+    (0x4002, 28346),
+    (0x4003, 8475),
+    (0x4004, 708),
+    (0x4005, 0),
+    (0x4006, 2),
+    (0x4007, 9),
+    (0x4008, 0),
+    (0x4009, 59528),
+    (0x400a, 84188),
+];
 
+fn build_table_layout_ctrl_data() -> Vec<u8> {
+    // HWPX→HWP adapter가 특정 3x2 선택지 표 뒤에 materialize하는 104바이트 raw 계약.
+    // serializer는 이 payload를 해석하거나 재번호화하지 않고 ctrl_data_records에서 복사한다.
     let mut data = Vec::with_capacity(104);
     data.extend_from_slice(&0x021b_u16.to_le_bytes());
     data.extend_from_slice(&1_u16.to_le_bytes());
@@ -1816,10 +1832,10 @@ fn build_table_layout_ctrl_data() -> Vec<u8> {
     data.extend_from_slice(&0x0242_u16.to_le_bytes());
     data.extend_from_slice(&0x8000_u16.to_le_bytes());
     data.extend_from_slice(&0x0242_u16.to_le_bytes());
-    data.extend_from_slice(&(VALUES.len() as u16).to_le_bytes());
+    data.extend_from_slice(&(TABLE_LAYOUT_CTRL_DATA_I4_ITEMS.len() as u16).to_le_bytes());
     data.extend_from_slice(&0_u16.to_le_bytes());
-    for (idx, value) in VALUES.iter().enumerate() {
-        data.extend_from_slice(&(0x4000_u16 + idx as u16).to_le_bytes());
+    for &(item_id, value) in &TABLE_LAYOUT_CTRL_DATA_I4_ITEMS {
+        data.extend_from_slice(&item_id.to_le_bytes());
         data.extend_from_slice(&0x0004_u16.to_le_bytes());
         data.extend_from_slice(&value.to_le_bytes());
     }
@@ -3285,6 +3301,89 @@ mod tests {
         let mut second = AdapterReport::new();
         adapt_paragraph(&mut para, &mut second);
         assert_eq!(second.table_layout_ctrl_data_materialized, 0);
+    }
+
+    #[test]
+    fn table_layout_ctrl_data_item_ids_are_an_explicit_observed_contract() {
+        assert_eq!(
+            TABLE_LAYOUT_CTRL_DATA_I4_ITEMS,
+            [
+                (0x4000, 3826),
+                (0x4001, 1048),
+                (0x4002, 28346),
+                (0x4003, 8475),
+                (0x4004, 708),
+                (0x4005, 0),
+                (0x4006, 2),
+                (0x4007, 9),
+                (0x4008, 0),
+                (0x4009, 59528),
+                (0x400a, 84188),
+            ]
+        );
+
+        let payload = build_table_layout_ctrl_data();
+        assert_eq!(payload.len(), 104);
+        for (index, &(item_id, value)) in TABLE_LAYOUT_CTRL_DATA_I4_ITEMS.iter().enumerate() {
+            let offset = 16 + index * 8;
+            assert_eq!(
+                &payload[offset..offset + 2],
+                &item_id.to_le_bytes(),
+                "item[{index}] id"
+            );
+            assert_eq!(
+                &payload[offset + 2..offset + 4],
+                &0x0004_u16.to_le_bytes(),
+                "item[{index}] type"
+            );
+            assert_eq!(
+                &payload[offset + 4..offset + 8],
+                &value.to_le_bytes(),
+                "item[{index}] value"
+            );
+        }
+    }
+
+    #[test]
+    fn table_layout_ctrl_data_materializes_for_nested_cell_owner() {
+        let mut nested_paragraph = Paragraph::default();
+        nested_paragraph
+            .controls
+            .push(Control::Table(Box::new(Table {
+                row_count: 3,
+                col_count: 2,
+                page_break: TablePageBreak::RowBreak,
+                repeat_header: true,
+                ..Default::default()
+            })));
+
+        let mut paragraph = Paragraph::default();
+        paragraph.controls.push(Control::Table(Box::new(Table {
+            row_count: 1,
+            col_count: 1,
+            cells: vec![Cell {
+                col_span: 1,
+                row_span: 1,
+                paragraphs: vec![nested_paragraph],
+                ..Default::default()
+            }],
+            ..Default::default()
+        })));
+
+        let mut report = AdapterReport::new();
+        adapt_paragraph(&mut paragraph, &mut report);
+
+        assert_eq!(report.table_layout_ctrl_data_materialized, 1);
+        assert!(paragraph.ctrl_data_records[0].is_none());
+        let Control::Table(outer) = &paragraph.controls[0] else {
+            panic!("expected outer table");
+        };
+        let nested_owner = &outer.cells[0].paragraphs[0];
+        assert_eq!(nested_owner.ctrl_data_records.len(), 1);
+        assert_eq!(
+            nested_owner.ctrl_data_records[0].as_deref(),
+            Some(build_table_layout_ctrl_data().as_slice())
+        );
     }
 
     #[test]

--- a/tests/issue_4438_table_ctrl_data_item_ids.rs
+++ b/tests/issue_4438_table_ctrl_data_item_ids.rs
@@ -1,0 +1,491 @@
+//! [#4438] HWPX -> HWP 표 layout CTRL_DATA의 item id와 저장 snapshot 계약.
+//!
+//! 이 payload는 일반적인 item-id 할당 규칙이 아니라, 변환 경계에서만 재현하는
+//! 고정된 104바이트 HWP5 저장 계약이다. 장기 수명의 호출자는 adapter를 원본 IR이
+//! 아닌 snapshot에 적용해야 한다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+use rhwp::model::document::Document;
+use rhwp::model::paragraph::Paragraph;
+use rhwp::model::table::{Cell, Table, TablePageBreak};
+use rhwp::parser::cfb_reader::CfbReader;
+use rhwp::parser::record::Record;
+use rhwp::parser::tags;
+
+const TABLE_LAYOUT_CTRL_DATA: [u8; 104] = [
+    0x1b, 0x02, 0x01, 0x00, 0x00, 0x00, 0x42, 0x02, 0x00, 0x80, 0x42, 0x02, 0x0b, 0x00, 0x00, 0x00,
+    0x00, 0x40, 0x04, 0x00, 0xf2, 0x0e, 0x00, 0x00, 0x01, 0x40, 0x04, 0x00, 0x18, 0x04, 0x00, 0x00,
+    0x02, 0x40, 0x04, 0x00, 0xba, 0x6e, 0x00, 0x00, 0x03, 0x40, 0x04, 0x00, 0x1b, 0x21, 0x00, 0x00,
+    0x04, 0x40, 0x04, 0x00, 0xc4, 0x02, 0x00, 0x00, 0x05, 0x40, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x06, 0x40, 0x04, 0x00, 0x02, 0x00, 0x00, 0x00, 0x07, 0x40, 0x04, 0x00, 0x09, 0x00, 0x00, 0x00,
+    0x08, 0x40, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x09, 0x40, 0x04, 0x00, 0x88, 0xe8, 0x00, 0x00,
+    0x0a, 0x40, 0x04, 0x00, 0xdc, 0x48, 0x01, 0x00,
+];
+
+const NON_SEQUENTIAL_ITEM_IDS: [u16; 11] = [
+    0x401a, 0x4001, 0x4f20, 0x0201, 0x7777, 0x1337, 0x4010, 0x0007, 0x3555, 0x6abc, 0x400a,
+];
+
+fn top_level_table_ctrl_data(document: &Document) -> Vec<&[u8]> {
+    document
+        .sections
+        .iter()
+        .flat_map(|section| &section.paragraphs)
+        .flat_map(|paragraph| {
+            paragraph
+                .controls
+                .iter()
+                .enumerate()
+                .filter_map(|(control_index, control)| {
+                    matches!(control, Control::Table(_))
+                        .then(|| paragraph.ctrl_data_records.get(control_index))
+                        .flatten()
+                        .and_then(Option::as_deref)
+                })
+        })
+        .collect()
+}
+
+fn nested_cell_table_ctrl_data(document: &Document) -> Vec<&[u8]> {
+    document
+        .sections
+        .iter()
+        .flat_map(|section| &section.paragraphs)
+        .flat_map(|paragraph| &paragraph.controls)
+        .filter_map(|control| match control {
+            Control::Table(table) => Some(table.as_ref()),
+            _ => None,
+        })
+        .flat_map(|table| &table.cells)
+        .flat_map(|cell| &cell.paragraphs)
+        .flat_map(|paragraph| {
+            paragraph
+                .controls
+                .iter()
+                .enumerate()
+                .filter_map(|(control_index, control)| {
+                    matches!(control, Control::Table(_))
+                        .then(|| paragraph.ctrl_data_records.get(control_index))
+                        .flatten()
+                        .and_then(Option::as_deref)
+                })
+        })
+        .collect()
+}
+
+fn top_level_adapter_policy_discriminators(
+    document: &Document,
+) -> Vec<(u16, u16, bool, TablePageBreak)> {
+    document
+        .sections
+        .iter()
+        .flat_map(|section| &section.paragraphs)
+        .flat_map(|paragraph| &paragraph.controls)
+        .filter_map(|control| match control {
+            Control::Table(table) => Some((
+                table.row_count,
+                table.col_count,
+                table.repeat_header,
+                table.page_break,
+            )),
+            _ => None,
+        })
+        .collect()
+}
+
+fn table_layout_payload_with_ids(item_ids: [u16; 11]) -> Vec<u8> {
+    let mut payload = TABLE_LAYOUT_CTRL_DATA.to_vec();
+    for (index, item_id) in item_ids.into_iter().enumerate() {
+        let offset = 16 + index * 8;
+        payload[offset..offset + 2].copy_from_slice(&item_id.to_le_bytes());
+    }
+    payload
+}
+
+fn replace_first_top_level_table_ctrl_data(core: &mut DocumentCore, payload: Vec<u8>) {
+    for section in &mut core.document_mut().sections {
+        for paragraph in &mut section.paragraphs {
+            if let Some(control_index) = paragraph
+                .controls
+                .iter()
+                .position(|control| matches!(control, Control::Table(_)))
+            {
+                paragraph.align_ctrl_data_records();
+                paragraph.ctrl_data_records[control_index] = Some(payload);
+                section.raw_stream = None;
+                return;
+            }
+        }
+    }
+    panic!("synthetic document must contain a top-level table");
+}
+
+fn section0_records(hwp: &[u8]) -> Vec<Record> {
+    let parsed = DocumentCore::from_bytes(hwp).expect("HWP header parse");
+    let compressed = parsed.document().header.compressed;
+    let distribution = parsed.document().header.distribution;
+    let mut cfb = CfbReader::open(hwp).expect("HWP CFB open");
+    let section = cfb
+        .read_body_text_section(0, compressed, distribution)
+        .expect("BodyText/Section0 read");
+    Record::read_all(&section).expect("BodyText records")
+}
+
+fn first_table_ctrl_data_record(hwp: &[u8]) -> (Record, Record) {
+    let records = section0_records(hwp);
+    let header_index = records
+        .iter()
+        .position(|record| {
+            record.tag_id == tags::HWPTAG_CTRL_HEADER
+                && record.data.starts_with(&tags::CTRL_TABLE.to_le_bytes())
+        })
+        .expect("table CTRL_HEADER");
+    (
+        records[header_index].clone(),
+        records
+            .get(header_index + 1)
+            .expect("record after table CTRL_HEADER")
+            .clone(),
+    )
+}
+
+fn synthetic_hwpx_source() -> DocumentCore {
+    // 이 합성 표는 현재 adapter predicate를 격리하는 policy fixture다. 모든 3x2 표의
+    // 보편적인 HWP5 의미를 주장하는 근거로 사용하지 않는다.
+    let input = std::fs::read("samples/hwpx/blank_hwpx.hwpx").expect("HWPX fixture");
+    let mut core = DocumentCore::from_bytes(&input).expect("HWPX parse");
+    let paragraph = core.document_mut().sections[0]
+        .paragraphs
+        .first_mut()
+        .expect("fixture body paragraph");
+    paragraph.controls.push(Control::Table(Box::new(Table {
+        row_count: 3,
+        col_count: 2,
+        page_break: TablePageBreak::RowBreak,
+        repeat_header: true,
+        ..Default::default()
+    })));
+    paragraph.align_ctrl_data_records();
+    core
+}
+
+fn synthetic_nested_hwpx_source() -> DocumentCore {
+    let input = std::fs::read("samples/hwpx/blank_hwpx.hwpx").expect("HWPX fixture");
+    let mut core = DocumentCore::from_bytes(&input).expect("HWPX parse");
+    let mut nested_paragraph = Paragraph::default();
+    nested_paragraph
+        .controls
+        .push(Control::Table(Box::new(Table {
+            row_count: 3,
+            col_count: 2,
+            page_break: TablePageBreak::RowBreak,
+            repeat_header: true,
+            ..Default::default()
+        })));
+    nested_paragraph.align_ctrl_data_records();
+
+    let paragraph = core.document_mut().sections[0]
+        .paragraphs
+        .first_mut()
+        .expect("fixture body paragraph");
+    paragraph.controls.push(Control::Table(Box::new(Table {
+        row_count: 1,
+        col_count: 1,
+        cells: vec![Cell {
+            col_span: 1,
+            row_span: 1,
+            paragraphs: vec![nested_paragraph],
+            ..Default::default()
+        }],
+        ..Default::default()
+    })));
+    paragraph.align_ctrl_data_records();
+    core
+}
+
+#[test]
+fn snapshot_export_emits_exact_table_ctrl_data_without_mutating_source_ir() {
+    let core = synthetic_hwpx_source();
+
+    let source_projection_before = core.export_hwpx_native().expect("source HWPX projection");
+    let source_payloads_before = top_level_table_ctrl_data(core.document())
+        .into_iter()
+        .map(<[u8]>::to_vec)
+        .collect::<Vec<_>>();
+    let source_extra_streams_before = core.document().extra_streams.clone();
+
+    let hwp = core
+        .export_hwp_with_adapter_snapshot()
+        .expect("snapshot HWP export");
+
+    assert_eq!(
+        top_level_table_ctrl_data(core.document())
+            .into_iter()
+            .map(<[u8]>::to_vec)
+            .collect::<Vec<_>>(),
+        source_payloads_before,
+        "adapter materialization must stay in the export snapshot"
+    );
+    assert_eq!(
+        core.document().extra_streams,
+        source_extra_streams_before,
+        "the HWPX-origin marker must also stay in the export snapshot"
+    );
+    assert_eq!(
+        core.export_hwpx_native()
+            .expect("source HWPX projection after snapshot export"),
+        source_projection_before,
+        "snapshot HWP export must leave the complete serialized HWPX projection unchanged"
+    );
+
+    let reloaded = DocumentCore::from_bytes(&hwp).expect("exported HWP reload");
+    let emitted = top_level_table_ctrl_data(reloaded.document());
+    assert_eq!(emitted.len(), 1, "synthetic table CTRL_DATA count");
+    for payload in emitted {
+        assert_eq!(payload, TABLE_LAYOUT_CTRL_DATA);
+    }
+}
+
+#[test]
+fn nested_cell_owner_survives_snapshot_and_hwp_raw_regeneration() {
+    let source = synthetic_nested_hwpx_source();
+    let source_projection_before = source
+        .export_hwpx_native()
+        .expect("nested source HWPX projection");
+    assert!(nested_cell_table_ctrl_data(source.document()).is_empty());
+
+    let first_hwp = source
+        .export_hwp_with_adapter_snapshot()
+        .expect("nested snapshot HWP export");
+    assert!(
+        nested_cell_table_ctrl_data(source.document()).is_empty(),
+        "nested adapter payload must stay out of the live HWPX source"
+    );
+    assert_eq!(
+        source
+            .export_hwpx_native()
+            .expect("nested HWPX projection after snapshot export"),
+        source_projection_before,
+        "nested snapshot export changed the complete serialized HWPX source projection"
+    );
+
+    let mut parsed_hwp = DocumentCore::from_bytes(&first_hwp).expect("nested HWP reload");
+    assert_eq!(
+        nested_cell_table_ctrl_data(parsed_hwp.document()),
+        vec![TABLE_LAYOUT_CTRL_DATA.as_slice()],
+        "HWP parser must attach the exact payload to the nested table owner"
+    );
+    let first_placements = section0_records(&first_hwp)
+        .windows(2)
+        .filter(|records| {
+            records[0].tag_id == tags::HWPTAG_CTRL_HEADER
+                && records[0].data.starts_with(&tags::CTRL_TABLE.to_le_bytes())
+                && records[1].tag_id == tags::HWPTAG_CTRL_DATA
+                && records[1].data == TABLE_LAYOUT_CTRL_DATA
+        })
+        .map(|records| (records[0].level, records[1].level))
+        .collect::<Vec<_>>();
+    assert_eq!(first_placements.len(), 1, "nested exact payload placement");
+    assert_eq!(first_placements[0].1, first_placements[0].0 + 1);
+
+    for section in &mut parsed_hwp.document_mut().sections {
+        section.raw_stream = None;
+    }
+    let nested_payloads_before = nested_cell_table_ctrl_data(parsed_hwp.document())
+        .into_iter()
+        .map(<[u8]>::to_vec)
+        .collect::<Vec<_>>();
+    let regenerated_hwp = parsed_hwp
+        .export_hwp_native()
+        .expect("nested HWP raw regeneration");
+    assert_eq!(
+        nested_cell_table_ctrl_data(parsed_hwp.document())
+            .into_iter()
+            .map(<[u8]>::to_vec)
+            .collect::<Vec<_>>(),
+        nested_payloads_before,
+        "nested HWP serialization changed the source owner payload"
+    );
+    let regenerated = DocumentCore::from_bytes(&regenerated_hwp).expect("regenerated HWP reload");
+    assert_eq!(
+        nested_cell_table_ctrl_data(regenerated.document()),
+        vec![TABLE_LAYOUT_CTRL_DATA.as_slice()]
+    );
+    let regenerated_placements = section0_records(&regenerated_hwp)
+        .windows(2)
+        .filter(|records| {
+            records[0].tag_id == tags::HWPTAG_CTRL_HEADER
+                && records[0].data.starts_with(&tags::CTRL_TABLE.to_le_bytes())
+                && records[1].tag_id == tags::HWPTAG_CTRL_DATA
+                && records[1].data == TABLE_LAYOUT_CTRL_DATA
+        })
+        .map(|records| (records[0].level, records[1].level))
+        .collect::<Vec<_>>();
+    assert_eq!(regenerated_placements, first_placements);
+}
+
+/// HWP 전용 raw payload의 owner는 parser가 채운 `ctrl_data_records`이고, serializer는
+/// item id를 해석하거나 연속 번호로 다시 쓰지 않는다. 첫 HWP는 비연속 ID를 가진 parser
+/// 입력을 만들고, 두 번째 HWP가 실제 parser -> model -> serializer 보존 경계다.
+#[test]
+fn hwp_parser_model_serializer_preserves_non_sequential_opaque_item_ids() {
+    let seed_hwp = synthetic_hwpx_source()
+        .export_hwp_with_adapter_snapshot()
+        .expect("seed HWP export");
+    let opaque_payload = table_layout_payload_with_ids(NON_SEQUENTIAL_ITEM_IDS);
+
+    let mut seed_model = DocumentCore::from_bytes(&seed_hwp).expect("seed HWP reload");
+    replace_first_top_level_table_ctrl_data(&mut seed_model, opaque_payload.clone());
+    let parser_input = seed_model
+        .export_hwp_native()
+        .expect("non-sequential parser input export");
+    let (input_header, input_data) = first_table_ctrl_data_record(&parser_input);
+    assert_eq!(input_data.tag_id, tags::HWPTAG_CTRL_DATA);
+    assert_eq!(input_data.level, input_header.level + 1);
+    assert_eq!(input_data.data, opaque_payload);
+
+    let mut parsed = DocumentCore::from_bytes(&parser_input).expect("opaque HWP parse");
+    assert_eq!(
+        top_level_table_ctrl_data(parsed.document()),
+        vec![opaque_payload.as_slice()],
+        "HWP parser must retain the opaque payload in the table control slot"
+    );
+    for section in &mut parsed.document_mut().sections {
+        section.raw_stream = None;
+    }
+    let source_payloads_before = top_level_table_ctrl_data(parsed.document())
+        .into_iter()
+        .map(<[u8]>::to_vec)
+        .collect::<Vec<_>>();
+    let source_streams_before = parsed.document().extra_streams.clone();
+
+    let reserialized = parsed
+        .export_hwp_native()
+        .expect("parser-owned opaque HWP reserialize");
+    assert_eq!(
+        top_level_table_ctrl_data(parsed.document())
+            .into_iter()
+            .map(<[u8]>::to_vec)
+            .collect::<Vec<_>>(),
+        source_payloads_before,
+        "HWP serialization must not rewrite the source model payload"
+    );
+    assert_eq!(parsed.document().extra_streams, source_streams_before);
+
+    let (output_header, output_data) = first_table_ctrl_data_record(&reserialized);
+    assert_eq!(output_data.tag_id, tags::HWPTAG_CTRL_DATA);
+    assert_eq!(output_data.level, output_header.level + 1);
+    assert_eq!(output_data.data, opaque_payload);
+    let reloaded = DocumentCore::from_bytes(&reserialized).expect("reserialized HWP reload");
+    assert_eq!(
+        top_level_table_ctrl_data(reloaded.document()),
+        vec![opaque_payload.as_slice()]
+    );
+}
+
+/// Multiplexed IR 경계의 불변식은 포맷별로 나눈다.
+///
+/// - HWP5 구간: opaque CTRL_DATA 104바이트가 exact해야 한다.
+/// - HWPX/HWP5 공통 구간: 표의 row/column/repeat/page-break semantic이 같아야 한다.
+/// - snapshot export: 어느 방향에서도 호출자의 live IR을 바꾸지 않아야 한다.
+///
+/// CFB와 ZIP은 서로 다른 container이므로 전체 출력 bytes 동일성은 계약이 아니다.
+#[test]
+fn adapter_policy_boundaries_preserve_format_specific_invariants() {
+    let hwpx_source = synthetic_hwpx_source();
+    let expected_discriminators = top_level_adapter_policy_discriminators(hwpx_source.document());
+    let hwpx_projection_before = hwpx_source
+        .export_hwpx_native()
+        .expect("initial HWPX projection");
+
+    // HWPX model -> adapter snapshot -> HWP serializer -> HWP parser/model.
+    let hwp_bytes = hwpx_source
+        .export_hwp_with_adapter_snapshot()
+        .expect("first HWP snapshot export");
+    assert_eq!(
+        top_level_adapter_policy_discriminators(hwpx_source.document()),
+        expected_discriminators,
+        "HWP snapshot export changed the HWPX source model"
+    );
+    assert_eq!(
+        hwpx_source
+            .export_hwpx_native()
+            .expect("HWPX projection after HWP snapshot export"),
+        hwpx_projection_before,
+        "HWP snapshot export changed the complete serialized source projection"
+    );
+    let hwp_model = DocumentCore::from_bytes(&hwp_bytes).expect("first HWP reload");
+    assert_eq!(
+        top_level_adapter_policy_discriminators(hwp_model.document()),
+        expected_discriminators
+    );
+    assert_eq!(
+        top_level_table_ctrl_data(hwp_model.document()),
+        vec![TABLE_LAYOUT_CTRL_DATA.as_slice()]
+    );
+
+    // HWP parser/model -> HWPX serializer -> HWPX parser/model.
+    let hwp_payloads_before = top_level_table_ctrl_data(hwp_model.document())
+        .into_iter()
+        .map(<[u8]>::to_vec)
+        .collect::<Vec<_>>();
+    let hwp_extra_streams_before = hwp_model.document().extra_streams.clone();
+    let second_hwpx_bytes = hwp_model.export_hwpx_native().expect("HWPX export");
+    assert_eq!(
+        top_level_table_ctrl_data(hwp_model.document())
+            .into_iter()
+            .map(<[u8]>::to_vec)
+            .collect::<Vec<_>>(),
+        hwp_payloads_before,
+        "HWPX export changed the HWP source model"
+    );
+    assert_eq!(
+        hwp_model.document().extra_streams,
+        hwp_extra_streams_before,
+        "HWPX export changed HWP source streams"
+    );
+    let second_hwpx_model =
+        DocumentCore::from_bytes(&second_hwpx_bytes).expect("second HWPX reload");
+    assert_eq!(
+        top_level_adapter_policy_discriminators(second_hwpx_model.document()),
+        expected_discriminators
+    );
+
+    // HWPX parser/model -> adapter snapshot -> HWP serializer/parser again.
+    let second_hwpx_discriminators_before =
+        top_level_adapter_policy_discriminators(second_hwpx_model.document());
+    let second_hwpx_projection_before = second_hwpx_model
+        .export_hwpx_native()
+        .expect("second HWPX source projection");
+    let second_hwpx_streams_before = second_hwpx_model.document().extra_streams.clone();
+    let second_hwp_bytes = second_hwpx_model
+        .export_hwp_with_adapter_snapshot()
+        .expect("second HWP snapshot export");
+    assert_eq!(
+        top_level_adapter_policy_discriminators(second_hwpx_model.document()),
+        second_hwpx_discriminators_before,
+        "second HWP snapshot export changed the HWPX source model"
+    );
+    assert_eq!(
+        second_hwpx_model.document().extra_streams,
+        second_hwpx_streams_before,
+        "second HWP snapshot export changed HWPX source streams"
+    );
+    assert_eq!(
+        second_hwpx_model
+            .export_hwpx_native()
+            .expect("second HWPX projection after HWP export"),
+        second_hwpx_projection_before,
+        "second snapshot HWP export changed the complete HWPX source projection"
+    );
+    let second_hwp_model = DocumentCore::from_bytes(&second_hwp_bytes).expect("second HWP reload");
+    assert_eq!(
+        top_level_adapter_policy_discriminators(second_hwp_model.document()),
+        expected_discriminators
+    );
+    assert_eq!(
+        top_level_table_ctrl_data(second_hwp_model.document()),
+        vec![TABLE_LAYOUT_CTRL_DATA.as_slice()]
+    );
+}


### PR DESCRIPTION
## 변경 요약

- 특정 table-layout CTRL_DATA를 `0x4000 + index` 산술 규칙이 아니라, 관찰된 11개 `(item_id, value)` 쌍의 명시적 opaque 계약으로 고정했습니다.
- HWP parser→IR→serializer raw 보존, HWPX adapter snapshot/source nonmutation, 중첩 table-cell owner, 두 cross-format 방향을 결정적 테스트로 고정했습니다.
- canonical / item-id 역순 / CTRL_DATA 없음의 단일 변화축을 외부 데스크톱 reader에서 Open→render→Save As하고, 관찰 범위와 비결론을 canonical CTRL_DATA 문서에 기록했습니다.

외부 check에서 세 변형은 모두 열리고 저장됐습니다. payload가 있는 두 변형은 2쪽, 없는 변형은 1쪽이었고, ID만 역순으로 바꾼 두 캔버스 차이는 34/280,000 pixels였습니다. 저장 출력은 각 입력의 11개 `(item_id, value)` 결합을 보존하고 record 순서만 바꿨습니다. 이 결과는 이 fixture에서 payload 존재가 layout에 영향을 준다는 근거이지만, 개별 ID의 일반 의미·무시 여부·namespace 또는 다른 문서 호환성을 확정하지 않습니다.

## 관련 이슈

Closes #4438

Related: #1064, #1099, #4396

## 테스트

- [x] `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests` 통과 (code-identical predecessor)
- [x] `cargo clippy -- -D warnings` 통과 (code-identical predecessor)
- [x] 최종 evidence amend 후 focused integration 4/4, focused unit 4/4 통과
- [x] `cargo fmt --all -- --check`, Markdown link check, diff check 통과
- [x] repo-derived 세 변형의 외부 Open→render→Save As 및 3/3 재파싱 확인
- [x] 웹(WASM) 렌더링 확인 해당 없음 — HWP adapter/raw contract 변경
- [x] capability 카탈로그 해당 없음 — agent/skill 파일 변경 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 없음. 동일한 104바이트 payload를 명시적 쌍 배열에서 생성합니다.
- 재현·측정: 성능 측정 대상이 아닙니다.

## 스크린샷

PR에는 로컬 데스크톱 캡처를 포함하지 않습니다. 위 세 변형의 페이지 수, canvas pixel 비교, 저장 stream pair 보존을 집계해 기록했습니다.
