### PR TITLE
wasm/studio: attach content-loss reports to explicit saves

### DIFF
--- a/rhwp-studio/e2e/MANIFEST.md
+++ b/rhwp-studio/e2e/MANIFEST.md
@@ -21,6 +21,7 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `canvaskit-font-coverage.test.mjs` | 상시 | active | CanvasKit 번들 폰트와 exact TTC GlyphRun 등록/픽셀 replay 검증 | — | npm+CI |  |
 | `cell-enter-pagination-issue4031.test.mjs` | 상시 | active | Issue #4031 — pending 중 셀 Enter의 pre-navigation full flush 0회·split 1회·barrier 대조군 계약 | issue1949_giant_cell_nested_tables_perf.hwp/.hwpx | npm e2e:issue-4031-cell-enter |  |
 | `command-palette.test.mjs` | 상시 | active | /커맨드 팔레트 | — | 수동 |  |
+| `content-loss-save-issue4430.test.mjs` | 상시 | active | Issue #4430 — serializer 내용 손실 보고의 명시 저장·fallback·암호 저장 및 실패·취소 무알림 계약 | test-image.hwpx | npm e2e:issue-4430-content-loss | fresh WASM 필수 · synthetic 보고서 주입 없음 |
 | `copy-paste.test.mjs` | 상시 | active | 텍스트 블럭 복사/붙여넣기 버그 (Task 227) | — | 수동 |  |
 | `debug-pagination.mjs` | 진단 | active | E2E 디버그: 50줄 입력 후 페이지네이션 확인 | — | 수동 | 수동 디버그 |
 | `debug-table-pos.mjs` | 진단 | active | E2E 디버그: 표 삽입 후 텍스트 위치 확인 | — | 수동 | 수동 디버그 |

--- a/rhwp-studio/e2e/content-loss-save-issue4430.test.mjs
+++ b/rhwp-studio/e2e/content-loss-save-issue4430.test.mjs
@@ -1,0 +1,965 @@
+/**
+ * Issue #4430 — serializer content-loss artifact -> explicit Studio save E2E.
+ *
+ * A tracked public HWPX sample is copied and patched only in browser memory: the
+ * two ZIP entry-name occurrences are changed without changing the compressed
+ * manifest. Five picture owners still reference one now-unreadable resource, so
+ * each real reported export must produce one exact resource-level loss.
+ * This covers the explicit HWP/HWPX serializer-save slice only; auxiliary
+ * byte-only consumers and unrelated warning surfaces remain out of scope.
+ *
+ * Run: npm run e2e:issue-4430-content-loss
+ */
+import {
+  assert,
+  loadApp,
+  runTest,
+  setTestCase,
+  waitForCanvas,
+} from './helpers.mjs';
+
+const SAMPLE_URL = '/samples/test-image.hwpx';
+const SAMPLE_NAME = 'test-image.hwpx';
+const SAMPLE_SIZE = 22_602;
+const ORIGINAL_ENTRY = 'BinData/image1.bmp';
+const MISSING_ENTRY = 'BinData/ghost1.bmp';
+const ORIGINAL_ENTRY_OFFSETS = [4_255, 22_037];
+const NOTICE_PREFIX = '파일은 저장되었지만 일부 내용을 보존하지 못했습니다.';
+const PERSISTENCE_PROBE_MS = 8_500;
+
+const REPORTED_METHODS = [
+  'exportHwpWithReport',
+  'exportHwpWithPasswordAndReport',
+  'exportHwpxWithReport',
+  'exportHwpxWithPasswordAndReport',
+];
+const LEGACY_BYTE_ONLY_METHODS = [
+  'exportHwp',
+  'exportHwpWithPassword',
+  'exportHwpx',
+  'exportHwpxWithPassword',
+];
+
+const EXPECTED = {
+  hwpx: {
+    command: 'file:save-as-hwpx',
+    extension: 'hwpx',
+    mimeType: 'application/hwp+zip',
+    magic: [0x50, 0x4b, 0x03, 0x04],
+    noticeFormat: 'HWPX',
+    report: {
+      schemaVersion: 1,
+      outputFormat: 'hwpx',
+      count: 1,
+      losses: [{
+        code: 'binaryContentEmptied',
+        subject: 'binaryData',
+        path: 'BinData/image1.bmp',
+        reason: 'resourceReadFailedOrLimitExceeded',
+        resourceId: 1,
+      }],
+    },
+  },
+  hwp: {
+    command: 'file:save-as-hwp',
+    extension: 'hwp',
+    mimeType: 'application/x-hwp',
+    magic: [0xd0, 0xcf, 0x11, 0xe0],
+    noticeFormat: 'HWP',
+    report: {
+      schemaVersion: 1,
+      outputFormat: 'hwp',
+      count: 1,
+      losses: [{
+        code: 'binaryContentEmptied',
+        subject: 'binaryData',
+        path: '/BinData/BIN0001.bmp',
+        reason: 'rawPassthroughUnavailable',
+        resourceId: 1,
+      }],
+    },
+  },
+};
+
+function requireCondition(condition, message) {
+  assert(condition, message);
+  if (!condition) throw new Error(message);
+}
+
+function expectedPath(format) {
+  return EXPECTED[format].report.losses[0].path;
+}
+
+function expectedReportedMethod(format, passwordProtected = false) {
+  if (format === 'hwp') {
+    return passwordProtected ? 'exportHwpWithPasswordAndReport' : 'exportHwpWithReport';
+  }
+  return passwordProtected ? 'exportHwpxWithPasswordAndReport' : 'exportHwpxWithReport';
+}
+
+async function loadMemoryPatchedSample(page) {
+  await loadApp(page);
+  const loaded = await page.evaluate(async ({
+    sampleUrl,
+    sampleName,
+    originalEntry,
+    missingEntry,
+  }) => {
+    const response = await fetch(sampleUrl, { cache: 'no-store' });
+    if (!response.ok) throw new Error(`sample fetch failed: HTTP ${response.status}`);
+
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    const original = new TextEncoder().encode(originalEntry);
+    const missing = new TextEncoder().encode(missingEntry);
+    if (original.length !== missing.length) {
+      throw new Error('entry-name replacement must preserve ZIP offsets');
+    }
+
+    const positionsOf = (haystack, needle) => {
+      const positions = [];
+      for (let offset = 0; offset <= haystack.length - needle.length; offset += 1) {
+        let matches = true;
+        for (let i = 0; i < needle.length; i += 1) {
+          if (haystack[offset + i] !== needle[i]) {
+            matches = false;
+            break;
+          }
+        }
+        if (matches) positions.push(offset);
+      }
+      return positions;
+    };
+
+    const originalPositions = positionsOf(bytes, original);
+    if (originalPositions.length !== 2) {
+      throw new Error(`expected exactly two entry names, got ${originalPositions.length}`);
+    }
+    for (const offset of originalPositions) bytes.set(missing, offset);
+
+    const patchedOriginalPositions = positionsOf(bytes, original);
+    const patchedMissingPositions = positionsOf(bytes, missing);
+    if (patchedOriginalPositions.length !== 0 || patchedMissingPositions.length !== 2) {
+      throw new Error('browser-memory entry-name replacement was not exactly two-for-two');
+    }
+
+    const info = window.__wasm?.loadDocument(bytes, sampleName);
+    if (!info) throw new Error('loadDocument returned no document info');
+    await window.__canvasView?.loadDocument?.();
+
+    // A second fetch produces a new ArrayBuffer and proves the served fixture was
+    // not changed by the browser-memory Uint8Array mutation above.
+    const pristineResponse = await fetch(sampleUrl, { cache: 'no-store' });
+    if (!pristineResponse.ok) {
+      throw new Error(`pristine sample fetch failed: HTTP ${pristineResponse.status}`);
+    }
+    const pristine = new Uint8Array(await pristineResponse.arrayBuffer());
+    return {
+      byteLength: bytes.length,
+      originalPositions,
+      patchedOriginalCount: patchedOriginalPositions.length,
+      patchedMissingPositions,
+      pristineOriginalPositions: positionsOf(pristine, original),
+      pristineMissingCount: positionsOf(pristine, missing).length,
+      pageCount: info.pageCount,
+      sourceFormat: window.__wasm?.getSourceFormat?.(),
+    };
+  }, {
+    sampleUrl: SAMPLE_URL,
+    sampleName: SAMPLE_NAME,
+    originalEntry: ORIGINAL_ENTRY,
+    missingEntry: MISSING_ENTRY,
+  });
+
+  requireCondition(loaded.byteLength === SAMPLE_SIZE,
+    `tracked sample size is stable (${loaded.byteLength})`);
+  requireCondition(JSON.stringify(loaded.originalPositions) === JSON.stringify(ORIGINAL_ENTRY_OFFSETS),
+    `exactly two source entry names occur at ${ORIGINAL_ENTRY_OFFSETS.join(', ')}`);
+  requireCondition(loaded.patchedOriginalCount === 0
+      && JSON.stringify(loaded.patchedMissingPositions) === JSON.stringify(ORIGINAL_ENTRY_OFFSETS),
+  'browser-memory copy replaces exactly two equal-length entry names');
+  requireCondition(JSON.stringify(loaded.pristineOriginalPositions) === JSON.stringify(ORIGINAL_ENTRY_OFFSETS)
+      && loaded.pristineMissingCount === 0,
+  'a fresh fetch remains pristine after the in-memory mutation');
+  requireCondition(loaded.sourceFormat === 'hwpx' && loaded.pageCount >= 1,
+    `patched sample loads as HWPX (${loaded.pageCount} pages)`);
+  await waitForCanvas(page, 30_000);
+}
+
+async function installPersistenceHarness(page, options = {}) {
+  const config = {
+    picker: options.picker ?? 'success',
+    anchor: options.anchor ?? 'success',
+    handleName: options.handleName ?? 'issue4430.hwpx',
+  };
+  await page.evaluate(({
+    config,
+    noticePrefix,
+    reportedMethods,
+    legacyByteOnlyMethods,
+  }) => {
+    const state = {
+      events: [],
+      alerts: [],
+      observedNoticeTexts: [],
+      reportedCalls: [],
+      legacyCalls: [],
+      artifacts: [],
+      savedBlob: null,
+      downloadName: '',
+    };
+    window.__issue4430 = state;
+
+    const wasm = window.__wasm;
+    if (!wasm) throw new Error('WasmBridge is unavailable');
+    for (const method of reportedMethods) {
+      const original = wasm[method];
+      if (typeof original !== 'function') {
+        throw new Error(`reported WasmBridge method is unavailable: ${method}`);
+      }
+      wasm[method] = function observeReportedExport(...args) {
+        state.reportedCalls.push({
+          method,
+          argumentCount: args.length,
+          hasNonEmptyPasswordArgument: method.includes('Password')
+            && args.length === 1
+            && typeof args[0] === 'string'
+            && args[0].length > 0,
+        });
+        state.events.push(`reported:${method}:call`);
+        const artifact = original.apply(this, args);
+        const contentLoss = JSON.parse(JSON.stringify(artifact.contentLoss));
+        state.events.push(`reported:${method}:report`);
+        const bytes = artifact.bytes.slice();
+        state.events.push(`reported:${method}:bytes`);
+        state.artifacts.push({ method, contentLoss, bytes });
+        return artifact;
+      };
+    }
+    for (const method of legacyByteOnlyMethods) {
+      const original = wasm[method];
+      if (typeof original !== 'function') {
+        throw new Error(`legacy WasmBridge method is unavailable: ${method}`);
+      }
+      wasm[method] = function observeLegacyExport(...args) {
+        state.legacyCalls.push({ method, argumentCount: args.length });
+        state.events.push(`legacy:${method}`);
+        return original.apply(this, args);
+      };
+    }
+
+    window.alert = (message) => {
+      state.events.push('alert');
+      state.alerts.push(String(message));
+    };
+
+    URL.createObjectURL = (blob) => {
+      state.events.push('objectURL');
+      state.savedBlob = blob;
+      return 'blob:issue4430-captured';
+    };
+    URL.revokeObjectURL = () => {
+      state.events.push('revokeObjectURL');
+    };
+
+    HTMLAnchorElement.prototype.click = function clickIssue4430Anchor() {
+      state.downloadName = this.download;
+      if (config.anchor === 'error') {
+        state.events.push('anchor:throw');
+        throw new Error('issue4430 deterministic anchor failure');
+      }
+      state.events.push('anchor:click');
+    };
+
+    window.showSaveFilePicker = async (pickerOptions) => {
+      if (config.picker === 'abort') {
+        state.events.push('picker:abort');
+        throw new DOMException('issue4430 picker cancelled', 'AbortError');
+      }
+      if (config.picker === 'error') {
+        state.events.push('picker:error');
+        throw new Error('issue4430 deterministic picker failure');
+      }
+
+      state.events.push('picker:success');
+      const handle = {
+        name: config.handleName || pickerOptions?.suggestedName || 'issue4430.hwpx',
+        async createWritable() {
+          state.events.push('writable:create');
+          return {
+            async write(blob) {
+              state.events.push('write');
+              state.savedBlob = blob;
+            },
+            async close() {
+              state.events.push('close');
+            },
+          };
+        },
+      };
+      return handle;
+    };
+
+    const seen = new WeakSet();
+    const recordNotices = () => {
+      for (const node of document.querySelectorAll('#rhwp-toast-container [role="status"]')) {
+        const text = node.textContent || '';
+        if (!text.includes(noticePrefix) || seen.has(node)) continue;
+        seen.add(node);
+        state.events.push('notice');
+        state.observedNoticeTexts.push(text);
+      }
+    };
+    new MutationObserver(recordNotices).observe(document.body, { childList: true, subtree: true });
+    recordNotices();
+  }, {
+    config,
+    noticePrefix: NOTICE_PREFIX,
+    reportedMethods: REPORTED_METHODS,
+    legacyByteOnlyMethods: LEGACY_BYTE_ONLY_METHODS,
+  });
+}
+
+async function resetHarnessObservations(page) {
+  await page.evaluate(() => {
+    const state = window.__issue4430;
+    state.events.length = 0;
+    state.alerts.length = 0;
+    state.observedNoticeTexts.length = 0;
+    state.reportedCalls.length = 0;
+    state.legacyCalls.length = 0;
+    state.artifacts.length = 0;
+    state.savedBlob = null;
+    state.downloadName = '';
+  });
+}
+
+async function harnessSnapshot(page) {
+  return page.evaluate(async ({ noticePrefix }) => {
+    const state = window.__issue4430;
+    const blob = state.savedBlob;
+    let blobBytes = null;
+    let blobInfo = null;
+    if (blob) {
+      blobBytes = new Uint8Array(await blob.arrayBuffer());
+      blobInfo = {
+        type: blob.type,
+        size: blobBytes.length,
+        head: Array.from(blobBytes.slice(0, 8)),
+      };
+    }
+    const artifacts = state.artifacts.map((artifact) => ({
+      method: artifact.method,
+      contentLoss: artifact.contentLoss,
+      byteLength: artifact.bytes.length,
+      persistedBlobMatches: blobBytes === null ? null : artifact.bytes.length === blobBytes.length
+        && artifact.bytes.every((byte, index) => byte === blobBytes[index]),
+    }));
+    const currentNoticeTexts = [...document.querySelectorAll('#rhwp-toast-container [role="status"]')]
+      .map((node) => node.textContent || '')
+      .filter((text) => text.includes(noticePrefix));
+    return {
+      events: [...state.events],
+      alerts: [...state.alerts],
+      observedNoticeTexts: [...state.observedNoticeTexts],
+      currentNoticeTexts,
+      reportedCalls: state.reportedCalls.map((call) => ({ ...call })),
+      legacyCalls: state.legacyCalls.map((call) => ({ ...call })),
+      artifacts,
+      blobInfo,
+      downloadName: state.downloadName,
+      dirty: window.__documentState?.isDirty?.() ?? null,
+    };
+  }, { noticePrefix: NOTICE_PREFIX });
+}
+
+async function markDocumentDirty(page) {
+  await page.evaluate(() => window.__eventBus?.emit('document-changed', 'issue4430-e2e'));
+  await page.waitForFunction(() => window.__documentState?.isDirty?.() === true);
+}
+
+async function markDocumentCleanForNavigation(page) {
+  await page.evaluate(() => window.__documentState?.markClean('issue4430-e2e-navigation'));
+  await page.waitForFunction(() => window.__documentState?.isDirty?.() === false);
+}
+
+async function settleUi(page) {
+  await page.evaluate(() => new Promise((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(resolve, 25)));
+  }));
+}
+
+async function waitForHarnessEvent(page, event) {
+  await page.waitForFunction(
+    (expectedEvent) => window.__issue4430?.events?.includes(expectedEvent),
+    { timeout: 30_000 },
+    event,
+  );
+}
+
+async function waitForNotice(page, path) {
+  await page.waitForFunction(({ noticePrefix, expectedPath }) => {
+    const notices = [...document.querySelectorAll('#rhwp-toast-container [role="status"]')]
+      .filter((node) => (node.textContent || '').includes(noticePrefix)
+        && (node.textContent || '').includes(expectedPath));
+    return notices.length === 1;
+  }, { timeout: 30_000 }, { noticePrefix: NOTICE_PREFIX, expectedPath: path });
+}
+
+async function clickFileCommand(page, command) {
+  const title = await page.$('#menu-bar .menu-item[data-menu="file"] .menu-title');
+  requireCondition(title !== null, 'File menu title exists');
+  await title.click();
+  await title.dispose();
+  await page.waitForSelector('#menu-bar .menu-item[data-menu="file"].open');
+
+  const item = await page.$(`.md-item[data-cmd="${command}"]`);
+  requireCondition(item !== null, `${command} menu item exists`);
+  const disabled = await item.evaluate((element) => element.classList.contains('disabled'));
+  requireCondition(!disabled, `${command} menu item is enabled`);
+  await item.click();
+  await item.dispose();
+}
+
+async function waitForDialog(page, title, hidden = false) {
+  await page.waitForFunction(({ expectedTitle, shouldBeHidden }) => {
+    const exists = [...document.querySelectorAll('.modal-overlay .dialog-wrap')]
+      .some((dialog) => {
+        const titleNode = dialog.querySelector('.dialog-title')?.firstChild;
+        return titleNode?.textContent?.trim() === expectedTitle;
+      });
+    return shouldBeHidden ? !exists : exists;
+  }, { timeout: 10_000 }, { expectedTitle: title, shouldBeHidden: hidden });
+}
+
+async function findDialog(page, title) {
+  const dialogs = await page.$$('.modal-overlay .dialog-wrap');
+  for (const dialog of dialogs) {
+    const dialogTitle = await dialog.$eval(
+      '.dialog-title',
+      (element) => element.firstChild?.textContent?.trim() || '',
+    ).catch(() => '');
+    if (dialogTitle === title) return dialog;
+    await dialog.dispose();
+  }
+  return null;
+}
+
+async function clickDialogButton(page, title, label) {
+  await waitForDialog(page, title);
+  const dialog = await findDialog(page, title);
+  requireCondition(dialog !== null, `${title} dialog exists`);
+  const buttons = await dialog.$$('button');
+  let target = null;
+  for (const button of buttons) {
+    const text = await button.evaluate((element) => element.textContent?.trim() || '');
+    if (text === label) {
+      target = button;
+      break;
+    }
+    await button.dispose();
+  }
+  requireCondition(target !== null, `${title} dialog has ${label} button`);
+  await target.click();
+  await target.dispose();
+  await dialog.dispose();
+}
+
+async function enterSaveAsName(page, fileName, action = 'confirm') {
+  const title = '다른 이름으로 저장';
+  await waitForDialog(page, title);
+  const dialog = await findDialog(page, title);
+  requireCondition(dialog !== null, 'Save As dialog exists');
+  const input = await dialog.$('.dialog-body input[type="text"]');
+  requireCondition(input !== null, 'Save As filename input exists');
+  await input.click();
+  await input.focus();
+  await page.keyboard.press('Home');
+  await page.keyboard.down('Shift');
+  try {
+    await page.keyboard.press('End');
+  } finally {
+    await page.keyboard.up('Shift');
+  }
+  const selection = await input.evaluate((element) => ({
+    start: element.selectionStart,
+    end: element.selectionEnd,
+    length: element.value.length,
+  }));
+  requireCondition(selection.start === 0 && selection.end === selection.length,
+    `Save As keyboard selection spans the full filename (${selection.start}..${selection.end}/${selection.length})`);
+  await page.keyboard.press('Backspace');
+  await page.keyboard.type(fileName);
+  await input.dispose();
+  await dialog.dispose();
+  await clickDialogButton(page, title, action === 'password' ? '암호 설정...' : '확인');
+}
+
+async function enterPasswordAndConfirm(page, password) {
+  const title = '문서 암호 설정';
+  await waitForDialog(page, title);
+  await page.type('#hwp-save-password-input', password);
+  await page.type('#hwp-save-password-confirmation', password);
+  await clickDialogButton(page, title, '확인');
+}
+
+async function dismissLossNotice(page, path) {
+  const notices = await page.$$('#rhwp-toast-container [role="status"]');
+  let clicked = false;
+  for (const notice of notices) {
+    const text = await notice.evaluate((element) => element.textContent || '');
+    if (!text.includes(NOTICE_PREFIX) || !text.includes(path)) {
+      await notice.dispose();
+      continue;
+    }
+    const buttons = await notice.$$('button');
+    for (const button of buttons) {
+      const label = await button.evaluate((element) => element.textContent?.trim() || '');
+      if (label === '확인') {
+        await button.click();
+        clicked = true;
+        await button.dispose();
+        break;
+      }
+      await button.dispose();
+    }
+    await notice.dispose();
+    if (clicked) break;
+  }
+  requireCondition(clicked, 'persistent content-loss notice has an acknowledgement button');
+  await page.waitForFunction(({ noticePrefix, expectedPath }) =>
+    ![...document.querySelectorAll('#rhwp-toast-container [role="status"]')]
+      .some((node) => (node.textContent || '').includes(noticePrefix)
+        && (node.textContent || '').includes(expectedPath)),
+  { timeout: 3_000 }, { noticePrefix: NOTICE_PREFIX, expectedPath: path });
+}
+
+function assertExactReport(report, format) {
+  requireCondition(JSON.stringify(report) === JSON.stringify(EXPECTED[format].report),
+    `${format.toUpperCase()} report has the exact one-resource schema and location`);
+}
+
+function assertBlob(snapshot, format) {
+  const expected = EXPECTED[format];
+  requireCondition(snapshot.blobInfo !== null, `${format.toUpperCase()} persisted blob was captured`);
+  assert(snapshot.blobInfo.type === expected.mimeType,
+    `${format.toUpperCase()} persisted MIME is ${expected.mimeType}`);
+  assert(snapshot.blobInfo.size > 0, `${format.toUpperCase()} persisted bytes are nonempty`);
+  assert(expected.magic.every((byte, index) => snapshot.blobInfo.head[index] === byte),
+    `${format.toUpperCase()} persisted bytes have the expected container magic`);
+}
+
+function assertNoLegacyExport(snapshot, label) {
+  requireCondition(snapshot.legacyCalls.length === 0,
+    `${label}: explicit serializer save never calls a legacy byte-only exporter`);
+}
+
+function assertReportedArtifact(
+  snapshot,
+  format,
+  { passwordProtected = false, comparePersistedBlob = false } = {},
+) {
+  const method = expectedReportedMethod(format, passwordProtected);
+  requireCondition(snapshot.reportedCalls.length === 1,
+    `${format.toUpperCase()} save calls exactly one reported WasmBridge exporter`);
+  const call = snapshot.reportedCalls[0];
+  requireCondition(call.method === method, `${format.toUpperCase()} save calls ${method}`);
+  requireCondition(call.argumentCount === (passwordProtected ? 1 : 0),
+    `${method} receives the expected argument count`);
+  requireCondition(call.hasNonEmptyPasswordArgument === passwordProtected,
+    `${method} records only whether its password argument is present`);
+  assertNoLegacyExport(snapshot, `${format.toUpperCase()} reported export`);
+
+  requireCondition(snapshot.artifacts.length === 1,
+    `${method} returns exactly one observed artifact`);
+  const artifact = snapshot.artifacts[0];
+  requireCondition(artifact.method === method, `${method} owns the observed artifact`);
+  assertEventOrder(snapshot.events, [
+    `reported:${method}:call`,
+    `reported:${method}:report`,
+    `reported:${method}:bytes`,
+  ], `${method} returned artifact lifecycle`);
+  assertExactReport(artifact.contentLoss, format);
+  requireCondition(artifact.byteLength > 0, `${method} returns nonempty bytes`);
+  if (comparePersistedBlob) {
+    requireCondition(artifact.persistedBlobMatches === true,
+      `${method} artifact bytes exactly match the persisted Blob`);
+  }
+}
+
+function assertReportedCallWithoutArtifact(snapshot, format) {
+  const method = expectedReportedMethod(format);
+  requireCondition(snapshot.reportedCalls.length === 1
+      && snapshot.reportedCalls[0].method === method,
+  `failed ${format.toUpperCase()} export enters ${method} exactly once`);
+  requireCondition(snapshot.reportedCalls[0].argumentCount === 0
+      && snapshot.reportedCalls[0].hasNonEmptyPasswordArgument === false,
+  `failed ${format.toUpperCase()} export enters the unprotected reported method without arguments`);
+  requireCondition(snapshot.artifacts.length === 0,
+    `failed ${format.toUpperCase()} export returns no artifact or bytes`);
+  assertNoLegacyExport(snapshot, `failed ${format.toUpperCase()} export`);
+}
+
+function assertNoExporterCall(snapshot, label) {
+  requireCondition(snapshot.reportedCalls.length === 0 && snapshot.artifacts.length === 0,
+    `${label}: no reported artifact is created`);
+  assertNoLegacyExport(snapshot, label);
+}
+
+function assertOneNotice(snapshot, format) {
+  const expected = EXPECTED[format];
+  const path = expected.report.losses[0].path;
+  requireCondition(snapshot.observedNoticeTexts.length === 1,
+    `${format.toUpperCase()} save inserts exactly one content-loss notice`);
+  requireCondition(snapshot.currentNoticeTexts.length === 1,
+    `${format.toUpperCase()} save leaves exactly one persistent content-loss notice`);
+  const text = snapshot.currentNoticeTexts[0];
+  assert(text.includes(`${expected.noticeFormat} ${NOTICE_PREFIX}`),
+    `${format.toUpperCase()} notice names the persisted output format`);
+  assert(text.includes(path), `${format.toUpperCase()} notice names the exact lost resource path`);
+}
+
+function assertNoNotice(snapshot, label) {
+  assert(snapshot.observedNoticeTexts.length === 0 && snapshot.currentNoticeTexts.length === 0,
+    `${label}: no stale or new content-loss notice is shown`);
+}
+
+function assertEventOrder(events, ordered, label) {
+  let previous = -1;
+  for (const event of ordered) {
+    const index = events.indexOf(event);
+    requireCondition(index > previous, `${label}: ${event} occurs in persistence order`);
+    previous = index;
+  }
+}
+
+async function verifyProtectedReopen(page, password, format) {
+  return page.evaluate(({ passwordValue, outputFormat }) => {
+    const state = window.__issue4430;
+    return state.savedBlob.arrayBuffer().then((buffer) => {
+      const bytes = new Uint8Array(buffer);
+      let unprotectedFailed = false;
+      try {
+        window.__wasm.loadDocument(bytes, `plain-reopen.${outputFormat}`);
+      } catch {
+        unprotectedFailed = true;
+      }
+      const info = window.__wasm.loadDocumentWithPassword(
+        bytes,
+        passwordValue,
+        `protected-reopen.${outputFormat}`,
+      );
+      return {
+        unprotectedFailed,
+        pageCount: info.pageCount,
+        localHasPassword: JSON.stringify(localStorage).includes(passwordValue),
+        sessionHasPassword: JSON.stringify(sessionStorage).includes(passwordValue),
+      };
+    });
+  }, { passwordValue: password, outputFormat: format });
+}
+
+await runTest('Issue #4430 content-loss artifact reaches explicit Studio saves', async ({ page }) => {
+  setTestCase('raw DocumentExport lifecycle and exact multiplexed-resource report');
+  await loadMemoryPatchedSample(page);
+  const lifecycle = await page.evaluate(() => {
+    const doc = Reflect.get(window.__wasm, 'doc');
+    if (!doc) throw new Error('raw HwpDocument is unavailable');
+    const exported = doc.exportHwpxWithReport();
+    try {
+      const before = exported.contentLoss();
+      const hasBytesBefore = exported.hasBytes();
+      const bytes = exported.takeBytes();
+      const hasBytesAfter = exported.hasBytes();
+      const after = exported.contentLoss();
+      let secondTakeError = '';
+      try {
+        exported.takeBytes();
+      } catch (error) {
+        secondTakeError = String(error);
+      }
+      return {
+        before: JSON.parse(before),
+        reportStable: before === after,
+        hasBytesBefore,
+        hasBytesAfter,
+        byteLength: bytes.length,
+        secondTakeError,
+      };
+    } finally {
+      exported.free();
+    }
+  });
+  assertExactReport(lifecycle.before, 'hwpx');
+  assert(lifecycle.hasBytesBefore && !lifecycle.hasBytesAfter && lifecycle.byteLength > 0,
+    'takeBytes transfers nonempty bytes exactly once');
+  assert(lifecycle.reportStable, 'contentLoss remains readable and identical after takeBytes');
+  assert(lifecycle.secondTakeError.includes('이미 가져갔습니다'),
+    'a second takeBytes call is an explicit lifecycle error');
+
+  setTestCase('primary save persists, notifies once, then exporter failure has no stale notice');
+  await loadMemoryPatchedSample(page);
+  await installPersistenceHarness(page, {
+    picker: 'success',
+    handleName: 'issue4430-primary.hwpx',
+  });
+  await markDocumentDirty(page);
+  await clickFileCommand(page, 'file:save');
+  await waitForNotice(page, expectedPath('hwpx'));
+  await page.waitForFunction(() => window.__documentState?.isDirty?.() === false);
+  let snapshot = await harnessSnapshot(page);
+  assertEventOrder(snapshot.events, [
+    'reported:exportHwpxWithReport:report',
+    'picker:success',
+    'write',
+    'close',
+    'notice',
+  ], 'primary save');
+  assert(!snapshot.events.includes('anchor:click'), 'primary save does not use download fallback');
+  assertReportedArtifact(snapshot, 'hwpx', { comparePersistedBlob: true });
+  assertBlob(snapshot, 'hwpx');
+  assertOneNotice(snapshot, 'hwpx');
+  assert(snapshot.dirty === false, 'successful primary save marks the document clean');
+
+  await page.evaluate((delay) => new Promise((resolve) => setTimeout(resolve, delay)), PERSISTENCE_PROBE_MS);
+  snapshot = await harnessSnapshot(page);
+  assertOneNotice(snapshot, 'hwpx');
+  await dismissLossNotice(page, expectedPath('hwpx'));
+  await resetHarnessObservations(page);
+  await markDocumentDirty(page);
+
+  try {
+    const originalCallbackIsFunction = await page.evaluate(() => {
+      const state = window.__issue4430;
+      state.originalOnBeforeExport = window.__wasm.onBeforeExport;
+      window.__wasm.onBeforeExport = () => {
+        state.events.push('before-export:throw');
+        throw new Error('issue4430 deterministic exporter failure');
+      };
+      return typeof state.originalOnBeforeExport === 'function';
+    });
+    requireCondition(originalCallbackIsFunction,
+      'export failure probe preserves the installed production onBeforeExport callback');
+    await clickFileCommand(page, 'file:save');
+    await waitForHarnessEvent(page, 'alert');
+    snapshot = await harnessSnapshot(page);
+    assertEventOrder(snapshot.events, [
+      'reported:exportHwpxWithReport:call',
+      'before-export:throw',
+      'alert',
+    ], 'export failure');
+    assert(!snapshot.events.some((event) =>
+      event.startsWith('picker:') || ['write', 'close', 'anchor:click', 'anchor:throw'].includes(event)),
+    'export failure reaches no picker, writable, or download persistence boundary');
+    assertReportedCallWithoutArtifact(snapshot, 'hwpx');
+    assert(snapshot.blobInfo === null, 'export failure produces no persistable Blob');
+    assert(snapshot.alerts.length === 1
+      && snapshot.alerts[0].includes('issue4430 deterministic exporter failure'),
+    'export failure uses the normal save-error alert exactly once');
+    assertNoNotice(snapshot, 'export failure after a reported success');
+    assert(snapshot.dirty === true, 'failed export leaves the document dirty');
+  } finally {
+    await page.evaluate(() => {
+      const state = window.__issue4430;
+      if (!Object.hasOwn(state, 'originalOnBeforeExport')) {
+        throw new Error('original onBeforeExport callback was not preserved');
+      }
+      const original = state.originalOnBeforeExport;
+      window.__wasm.onBeforeExport = original;
+      if (window.__wasm.onBeforeExport !== original) {
+        throw new Error('production onBeforeExport callback was not restored exactly');
+      }
+      delete state.originalOnBeforeExport;
+    });
+  }
+  await markDocumentCleanForNavigation(page);
+
+  setTestCase('picker failure falls back to HWP download and notifies after anchor click');
+  await loadMemoryPatchedSample(page);
+  await installPersistenceHarness(page, { picker: 'error', anchor: 'success' });
+  await markDocumentDirty(page);
+  await clickFileCommand(page, EXPECTED.hwp.command);
+  await enterSaveAsName(page, 'issue4430-fallback', 'confirm');
+  await waitForHarnessEvent(page, 'picker:error');
+  await waitForDialog(page, '다른 이름으로 저장');
+  snapshot = await harnessSnapshot(page);
+  assertNoNotice(snapshot, 'primary picker failure while fallback name is pending');
+  assert(!snapshot.events.includes('anchor:click'), 'fallback download has not started before name confirmation');
+  assertReportedArtifact(snapshot, 'hwp');
+  await enterSaveAsName(page, 'issue4430-fallback', 'confirm');
+  await waitForNotice(page, expectedPath('hwp'));
+  await waitForHarnessEvent(page, 'revokeObjectURL');
+  await page.waitForFunction(() => window.__documentState?.isDirty?.() === false);
+  snapshot = await harnessSnapshot(page);
+  assertEventOrder(snapshot.events, [
+    'reported:exportHwpWithReport:report',
+    'picker:error',
+    'objectURL',
+    'anchor:click',
+    'notice',
+    'revokeObjectURL',
+  ], 'fallback save');
+  requireCondition(snapshot.events.filter((event) => event === 'revokeObjectURL').length === 1,
+    'successful fallback revokes its object URL exactly once after anchor click');
+  assert(snapshot.downloadName === 'issue4430-fallback.hwp',
+    `fallback uses the confirmed HWP filename (expected="issue4430-fallback.hwp", observed=${JSON.stringify(snapshot.downloadName)}, events=${JSON.stringify(snapshot.events)})`);
+  assertReportedArtifact(snapshot, 'hwp', { comparePersistedBlob: true });
+  assertBlob(snapshot, 'hwp');
+  assertOneNotice(snapshot, 'hwp');
+  assert(snapshot.dirty === false, 'successful fallback download marks the document clean');
+  await page.evaluate((delay) => new Promise((resolve) => setTimeout(resolve, delay)), PERSISTENCE_PROBE_MS);
+  snapshot = await harnessSnapshot(page);
+  assertOneNotice(snapshot, 'hwp');
+
+  for (const format of ['hwp', 'hwpx']) {
+    setTestCase(`password-protected ${format.toUpperCase()} save uses reported artifact`);
+    await loadMemoryPatchedSample(page);
+    await installPersistenceHarness(page, {
+      picker: 'success',
+      handleName: `issue4430-protected.${EXPECTED[format].extension}`,
+    });
+    await markDocumentDirty(page);
+    await clickFileCommand(page, EXPECTED[format].command);
+    await enterSaveAsName(page, `issue4430-protected-${format}`, 'password');
+    const password = String.fromCharCode(116, 101, 115, 116, 45, 52, 52, 51, 48);
+    await enterPasswordAndConfirm(page, password);
+    await waitForNotice(page, expectedPath(format));
+    await page.waitForFunction(() => window.__documentState?.isDirty?.() === false);
+    snapshot = await harnessSnapshot(page);
+    const method = expectedReportedMethod(format, true);
+    assertEventOrder(snapshot.events, [
+      `reported:${method}:report`,
+      'picker:success',
+      'write',
+      'close',
+      'notice',
+    ],
+      `protected ${format.toUpperCase()} save`);
+    assertReportedArtifact(snapshot, format, {
+      passwordProtected: true,
+      comparePersistedBlob: true,
+    });
+    assertBlob(snapshot, format);
+    assertOneNotice(snapshot, format);
+    const reopened = await verifyProtectedReopen(page, password, format);
+    assert(reopened.unprotectedFailed, `protected ${format.toUpperCase()} bytes reject ordinary reopen`);
+    assert(reopened.pageCount >= 1, `protected ${format.toUpperCase()} bytes reopen with the entered password`);
+    assert(!reopened.localHasPassword && !reopened.sessionHasPassword,
+      `protected ${format.toUpperCase()} password is not stored in browser storage`);
+  }
+
+  setTestCase('picker cancellation has no fallback, alert, or content-loss notice');
+  await loadMemoryPatchedSample(page);
+  await installPersistenceHarness(page, { picker: 'abort' });
+  await markDocumentDirty(page);
+  await clickFileCommand(page, 'file:save');
+  await waitForHarnessEvent(page, 'picker:abort');
+  await settleUi(page);
+  snapshot = await harnessSnapshot(page);
+  assertEventOrder(snapshot.events, [
+    'reported:exportHwpxWithReport:report',
+    'picker:abort',
+  ], 'picker cancellation');
+  assert(!snapshot.events.some((event) =>
+    ['write', 'close', 'objectURL', 'anchor:click', 'anchor:throw'].includes(event)),
+  'AbortError stops before writable and download fallback boundaries');
+  assertReportedArtifact(snapshot, 'hwpx');
+  assert(snapshot.alerts.length === 0, 'picker cancellation is not reported as a save error');
+  assertNoNotice(snapshot, 'picker cancellation');
+  assert(snapshot.dirty === true, 'picker cancellation leaves the document dirty');
+  await markDocumentCleanForNavigation(page);
+
+  setTestCase('Save As and password-dialog validation/cancellation never notify');
+  await loadMemoryPatchedSample(page);
+  await installPersistenceHarness(page, { picker: 'success', handleName: 'unused.hwp' });
+  await markDocumentDirty(page);
+  await clickFileCommand(page, EXPECTED.hwp.command);
+  await clickDialogButton(page, '다른 이름으로 저장', '취소');
+  await waitForDialog(page, '다른 이름으로 저장', true);
+  await settleUi(page);
+  snapshot = await harnessSnapshot(page);
+  assert(snapshot.events.length === 0 && snapshot.alerts.length === 0,
+    'initial Save As cancellation reaches no exporter persistence or error boundary');
+  assertNoExporterCall(snapshot, 'initial Save As cancellation');
+  assertNoNotice(snapshot, 'initial Save As cancellation');
+  assert(snapshot.dirty === true, 'initial Save As cancellation leaves the document dirty');
+  await markDocumentCleanForNavigation(page);
+
+  await resetHarnessObservations(page);
+  await markDocumentDirty(page);
+  await clickFileCommand(page, EXPECTED.hwpx.command);
+  await enterSaveAsName(page, 'issue4430-password-cancel', 'password');
+  const firstMismatch = String.fromCharCode(97, 108, 112, 104, 97, 49);
+  const secondMismatch = String.fromCharCode(97, 108, 112, 104, 97, 50);
+  await page.type('#hwp-save-password-input', firstMismatch);
+  await page.type('#hwp-save-password-confirmation', secondMismatch);
+  await clickDialogButton(page, '문서 암호 설정', '확인');
+  await page.waitForFunction(() => {
+    const alertNode = document.querySelector('[role="dialog"][aria-label="문서 저장 암호 설정"] [role="alert"]');
+    return alertNode && !alertNode.hidden && alertNode.textContent?.includes('일치하지 않습니다');
+  });
+  snapshot = await harnessSnapshot(page);
+  assert(snapshot.events.length === 0 && snapshot.alerts.length === 0,
+    'password validation failure reaches no exporter or persistence boundary');
+  assertNoExporterCall(snapshot, 'password validation failure');
+  assertNoNotice(snapshot, 'password validation failure');
+  await clickDialogButton(page, '문서 암호 설정', '취소');
+  await waitForDialog(page, '문서 암호 설정', true);
+  await settleUi(page);
+  snapshot = await harnessSnapshot(page);
+  assertNoExporterCall(snapshot, 'password dialog cancellation');
+  assertNoNotice(snapshot, 'password dialog cancellation');
+  assert(snapshot.dirty === true, 'password dialog cancellation leaves the document dirty');
+  await markDocumentCleanForNavigation(page);
+
+  setTestCase('fallback-name cancellation discards the report without download or notice');
+  await loadMemoryPatchedSample(page);
+  await installPersistenceHarness(page, { picker: 'error', anchor: 'success' });
+  await markDocumentDirty(page);
+  await clickFileCommand(page, EXPECTED.hwp.command);
+  await enterSaveAsName(page, 'issue4430-fallback-cancel', 'confirm');
+  await waitForHarnessEvent(page, 'picker:error');
+  await waitForDialog(page, '다른 이름으로 저장');
+  await clickDialogButton(page, '다른 이름으로 저장', '취소');
+  await waitForDialog(page, '다른 이름으로 저장', true);
+  await settleUi(page);
+  snapshot = await harnessSnapshot(page);
+  assertEventOrder(snapshot.events, [
+    'reported:exportHwpWithReport:report',
+    'picker:error',
+  ], 'fallback-name cancellation');
+  assert(!snapshot.events.some((event) =>
+    ['objectURL', 'anchor:click', 'anchor:throw', 'revokeObjectURL'].includes(event)),
+  'fallback-name cancellation reaches neither object URL nor anchor');
+  assertReportedArtifact(snapshot, 'hwp');
+  assert(snapshot.alerts.length === 0, 'fallback-name cancellation is not a save error');
+  assertNoNotice(snapshot, 'fallback-name cancellation after a real reported export');
+  assert(snapshot.dirty === true, 'fallback-name cancellation leaves the document dirty');
+  await markDocumentCleanForNavigation(page);
+
+  setTestCase('anchor failure reports save error but never publishes content-loss notice');
+  await loadMemoryPatchedSample(page);
+  await installPersistenceHarness(page, { picker: 'error', anchor: 'error' });
+  await markDocumentDirty(page);
+  await clickFileCommand(page, 'file:save');
+  await waitForHarnessEvent(page, 'alert');
+  await waitForHarnessEvent(page, 'revokeObjectURL');
+  snapshot = await harnessSnapshot(page);
+  assertEventOrder(snapshot.events, [
+    'reported:exportHwpxWithReport:report',
+    'picker:error',
+    'objectURL',
+    'anchor:throw',
+    'alert',
+    'revokeObjectURL',
+  ],
+    'failed download');
+  requireCondition(snapshot.events.filter((event) => event === 'revokeObjectURL').length === 1,
+    'throwing download revokes its object URL exactly once after anchor failure');
+  assertReportedArtifact(snapshot, 'hwpx', { comparePersistedBlob: true });
+  assert(snapshot.alerts.length === 1
+    && snapshot.alerts[0].includes('issue4430 deterministic anchor failure'),
+  'anchor failure uses the normal save-error alert exactly once');
+  assertNoNotice(snapshot, 'anchor failure after a real reported export');
+  assert(snapshot.dirty === true, 'anchor failure leaves the document dirty');
+  await markDocumentCleanForNavigation(page);
+}, { skipLoadApp: true });

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -21,6 +21,7 @@
     "e2e:clipboard-priority": "node e2e/task-871-clipboard-priority.test.mjs",
     "e2e:drag-autoscroll": "node e2e/drag-selection-autoscroll.test.mjs",
     "e2e:renderer-contract": "node e2e/renderer-contract.test.mjs",
+    "e2e:issue-4430-content-loss": "node e2e/content-loss-save-issue4430.test.mjs --mode=headless",
     "e2e:issue-2214": "node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless",
     "e2e:issue-3815": "node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless --continuous-only",
     "e2e:issue-3137-perf": "node e2e/probe-input-perf-issue3137.mjs --mode=headless",

--- a/rhwp-studio/src/command/commands/file.ts
+++ b/rhwp-studio/src/command/commands/file.ts
@@ -14,9 +14,16 @@ import {
 } from '@/command/save-target';
 import { SAVE_FORMAT_DETAILS } from '@/command/save-format';
 import {
-  exportDocumentForFormat,
-  exportPasswordProtectedDocumentForFormat,
+  exportDocumentWithReportForFormat,
+  exportPasswordProtectedDocumentWithReportForFormat,
+  type SaveExportArtifact,
 } from '@/command/save-document-format';
+import {
+  buildContentLossNotice,
+  persistDownloadWithContentLoss,
+  persistWithContentLoss,
+  type ContentLossReport,
+} from '@/core/export-content-loss';
 import {
   readHmlSaveContext,
   resolveHmlSaveCapability,
@@ -121,17 +128,35 @@ async function chooseSaveAsFormat(services: CommandServices): Promise<SaveFormat
   );
 }
 
-function createSaveBlob(
+interface SavePayload {
+  blob: Blob;
+  contentLoss: ContentLossReport | null;
+}
+
+function createSavePayload(
   services: CommandServices,
   format: SaveFormat,
   password?: string,
-): Blob {
-  const bytes = password === undefined
-    ? exportDocumentForFormat(services.wasm, format)
-    : exportPasswordProtectedDocumentForFormat(services.wasm, requirePasswordSaveFormat(format), password);
-  return new Blob([bytes as unknown as BlobPart], {
-    type: SAVE_FORMAT_DETAILS[format].mimeType,
-  });
+): SavePayload {
+  const artifact: SaveExportArtifact = password === undefined
+    ? exportDocumentWithReportForFormat(services.wasm, format)
+    : exportPasswordProtectedDocumentWithReportForFormat(
+      services.wasm,
+      requirePasswordSaveFormat(format),
+      password,
+    );
+  return {
+    blob: new Blob([artifact.bytes as unknown as BlobPart], {
+      type: SAVE_FORMAT_DETAILS[format].mimeType,
+    }),
+    contentLoss: artifact.contentLoss,
+  };
+}
+
+function showExportContentLoss(report: ContentLossReport): void {
+  const message = buildContentLossNotice(report);
+  if (!message) return;
+  showToast({ message, durationMs: 0, confirmLabel: '확인' });
 }
 
 function requirePasswordSaveFormat(format: SaveFormat): Exclude<SaveFormat, 'hml'> {
@@ -199,8 +224,11 @@ function downloadBlob(blob: Blob, fileName: string): void {
   const anchor = document.createElement('a');
   anchor.href = url;
   anchor.download = fileName;
-  anchor.click();
-  setTimeout(() => URL.revokeObjectURL(url), 1000);
+  try {
+    anchor.click();
+  } finally {
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
 }
 
 async function promptFallbackName(
@@ -247,15 +275,20 @@ async function saveAsFormat(services: CommandServices, format: SaveFormat): Prom
 
     flushDeferredPaginationBeforeExplicitOutput(services, 'save-as');
     const saveName = options.fileName;
-    const blob = createSaveBlob(services, format, password ?? undefined);
+    const payload = createSavePayload(services, format, password ?? undefined);
     const originalHandle = sourceFormat === 'hml' ? services.wasm.currentFileHandle : null;
-    const result = await tryFileSystemSave(
-      services,
-      format,
-      blob,
-      saveName,
-      true,
-      originalHandle,
+    const result = await persistWithContentLoss(
+      payload.contentLoss,
+      () => tryFileSystemSave(
+        services,
+        format,
+        payload.blob,
+        saveName,
+        true,
+        originalHandle,
+      ),
+      (saveResult) => saveResult !== 'cancelled' && saveResult.method !== 'fallback',
+      showExportContentLoss,
     );
     if (result === 'cancelled') return;
     if (result.method !== 'fallback') {
@@ -266,7 +299,11 @@ async function saveAsFormat(services: CommandServices, format: SaveFormat): Prom
     if (!downloadName) return;
     services.wasm.fileName = downloadName;
     services.wasm.requiresPasswordForSave = password !== null;
-    downloadBlob(blob, downloadName);
+    persistDownloadWithContentLoss(
+      payload.contentLoss,
+      () => downloadBlob(payload.blob, downloadName),
+      showExportContentLoss,
+    );
     services.documentState.markClean('save-as');
   } catch (error) {
     reportSaveError('file:save-as', error);
@@ -309,14 +346,19 @@ export async function saveCurrentDocument(services: CommandServices): Promise<Sa
       password = await showHwpSavePasswordDialog(fileNameForFormat(services.wasm.fileName, passwordFormat));
       if (password === null) return 'cancelled';
     }
-    const blob = createSaveBlob(services, target.format, password ?? undefined);
-    const result = await tryFileSystemSave(
-      services,
-      target.format,
-      blob,
-      target.suggestedName,
-      target.forceSaveAs,
-      services.wasm.currentFileHandle,
+    const payload = createSavePayload(services, target.format, password ?? undefined);
+    const result = await persistWithContentLoss(
+      payload.contentLoss,
+      () => tryFileSystemSave(
+        services,
+        target.format,
+        payload.blob,
+        target.suggestedName,
+        target.forceSaveAs,
+        services.wasm.currentFileHandle,
+      ),
+      (saveResult) => saveResult !== 'cancelled' && saveResult.method !== 'fallback',
+      showExportContentLoss,
     );
     if (result === 'cancelled') return 'cancelled';
     if (result.method !== 'fallback') {
@@ -325,7 +367,11 @@ export async function saveCurrentDocument(services: CommandServices): Promise<Sa
     }
     const downloadName = await fallbackNameForCurrentSave(services, target);
     if (!downloadName) return 'cancelled';
-    downloadBlob(blob, downloadName);
+    persistDownloadWithContentLoss(
+      payload.contentLoss,
+      () => downloadBlob(payload.blob, downloadName),
+      showExportContentLoss,
+    );
     services.wasm.requiresPasswordForSave = password !== null;
     services.documentState.markClean('save');
     return 'saved';

--- a/rhwp-studio/src/command/save-document-format.ts
+++ b/rhwp-studio/src/command/save-document-format.ts
@@ -1,4 +1,8 @@
 import type { SaveFormat } from './save-format.ts';
+import type {
+  ContentLossReport,
+  DocumentExportArtifact,
+} from '../core/export-content-loss.ts';
 
 export interface DocumentFormatExporter {
   exportHml(): Uint8Array;
@@ -11,6 +15,24 @@ export interface DocumentFormatPasswordExporter extends DocumentFormatExporter {
   exportHwpxWithPassword(password: string): Uint8Array;
 }
 
+/** 명시적 저장에서 바이트와 같은 직렬화의 내용 손실을 함께 반환하는 표면. */
+export interface ReportedDocumentFormatExporter extends DocumentFormatExporter {
+  exportHwpWithReport(): DocumentExportArtifact;
+  exportHwpxWithReport(): DocumentExportArtifact;
+}
+
+export interface ReportedDocumentFormatPasswordExporter
+  extends ReportedDocumentFormatExporter, DocumentFormatPasswordExporter {
+  exportHwpWithPasswordAndReport(password: string): DocumentExportArtifact;
+  exportHwpxWithPasswordAndReport(password: string): DocumentExportArtifact;
+}
+
+export interface SaveExportArtifact {
+  bytes: Uint8Array;
+  /** HML은 손실을 보고하는 serializer 경계가 없으므로 null이다. */
+  contentLoss: ContentLossReport | null;
+}
+
 export function exportDocumentForFormat(
   exporter: DocumentFormatExporter,
   format: SaveFormat,
@@ -18,6 +40,25 @@ export function exportDocumentForFormat(
   if (format === 'hml') return exporter.exportHml();
   if (format === 'hwpx') return exporter.exportHwpx();
   return exporter.exportHwp();
+}
+
+/**
+ * 사용자 명시 저장용 exporter를 고른다.
+ *
+ * HWP/HWPX는 반드시 reported API를 사용한다. byte-only API는 autosave, embed RPC,
+ * history, compare, hwpctl, digest 같은 보조 소비자의 기존 계약으로 남으며, 이 흐름의
+ * 손실 보고로 간주하지 않는다.
+ */
+export function exportDocumentWithReportForFormat(
+  exporter: ReportedDocumentFormatExporter,
+  format: SaveFormat,
+): SaveExportArtifact {
+  if (format === 'hml') {
+    return { bytes: exporter.exportHml(), contentLoss: null };
+  }
+  return format === 'hwpx'
+    ? exporter.exportHwpxWithReport()
+    : exporter.exportHwpWithReport();
 }
 
 /** HML 이외의 출력 형식에 password serializer를 선택한다. */
@@ -28,4 +69,15 @@ export function exportPasswordProtectedDocumentForFormat(
 ): Uint8Array {
   if (format === 'hwpx') return exporter.exportHwpxWithPassword(password);
   return exporter.exportHwpWithPassword(password);
+}
+
+/** 비밀번호 명시 저장에서도 산출 바이트와 보고서를 한 transaction으로 받는다. */
+export function exportPasswordProtectedDocumentWithReportForFormat(
+  exporter: ReportedDocumentFormatPasswordExporter,
+  format: Exclude<SaveFormat, 'hml'>,
+  password: string,
+): SaveExportArtifact {
+  return format === 'hwpx'
+    ? exporter.exportHwpxWithPasswordAndReport(password)
+    : exporter.exportHwpWithPasswordAndReport(password);
 }

--- a/rhwp-studio/src/core/export-content-loss.ts
+++ b/rhwp-studio/src/core/export-content-loss.ts
@@ -1,0 +1,179 @@
+export const CONTENT_LOSS_SCHEMA_VERSION = 1 as const;
+
+export type SerializedOutputFormat = 'hwp' | 'hwpx';
+export type ContentLossCode =
+  | 'binaryContentEmptied'
+  | 'controlOmitted'
+  | 'metadataReduced';
+export type ContentLossSubject = 'binaryData' | 'control' | 'fieldParameters';
+export type ContentLossReason =
+  | 'resourceReadFailedOrLimitExceeded'
+  | 'storedCompressionMismatch'
+  | 'rawPassthroughUnavailable'
+  | 'unsupportedByOutputFormat';
+
+export interface ContentLossRecord {
+  code: ContentLossCode;
+  subject: ContentLossSubject;
+  path: string;
+  reason: ContentLossReason;
+  resourceId?: number;
+}
+
+export interface ContentLossReport {
+  schemaVersion: typeof CONTENT_LOSS_SCHEMA_VERSION;
+  outputFormat: SerializedOutputFormat;
+  count: number;
+  losses: ContentLossRecord[];
+}
+
+export interface DocumentExportArtifact {
+  bytes: Uint8Array;
+  contentLoss: ContentLossReport;
+}
+
+/** wasm-bindgen이 내보내는 transaction-owned 결과의 최소 표면. */
+export interface WasmDocumentExport {
+  contentLoss(): string;
+  hasBytes(): boolean;
+  takeBytes(): Uint8Array;
+  free(): void;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isContentLossCode(value: unknown): value is ContentLossCode {
+  return value === 'binaryContentEmptied'
+    || value === 'controlOmitted'
+    || value === 'metadataReduced';
+}
+
+function isContentLossSubject(value: unknown): value is ContentLossSubject {
+  return value === 'binaryData' || value === 'control' || value === 'fieldParameters';
+}
+
+function isContentLossReason(value: unknown): value is ContentLossReason {
+  return value === 'resourceReadFailedOrLimitExceeded'
+    || value === 'storedCompressionMismatch'
+    || value === 'rawPassthroughUnavailable'
+    || value === 'unsupportedByOutputFormat';
+}
+
+function parseLoss(value: unknown): ContentLossRecord | null {
+  if (!isRecord(value)
+    || !isContentLossCode(value.code)
+    || !isContentLossSubject(value.subject)
+    || typeof value.path !== 'string'
+    || !isContentLossReason(value.reason)) return null;
+  if (value.resourceId !== undefined
+    && (typeof value.resourceId !== 'number'
+      || !Number.isSafeInteger(value.resourceId)
+      || value.resourceId < 0)) return null;
+  return {
+    code: value.code,
+    subject: value.subject,
+    path: value.path,
+    reason: value.reason,
+    ...(value.resourceId === undefined ? {} : { resourceId: value.resourceId as number }),
+  };
+}
+
+/** 알 수 없거나 오래된 보고서 모양은 조용히 버리지 않고 저장 자체를 실패시킨다. */
+export function parseContentLossReport(value: unknown): ContentLossReport {
+  if (!isRecord(value)
+    || value.schemaVersion !== CONTENT_LOSS_SCHEMA_VERSION
+    || (value.outputFormat !== 'hwp' && value.outputFormat !== 'hwpx')
+    || typeof value.count !== 'number'
+    || !Number.isSafeInteger(value.count)
+    || value.count < 0
+    || !Array.isArray(value.losses)) {
+    throw new Error('내보내기 내용 손실 보고서 형식을 확인할 수 없습니다');
+  }
+
+  const losses = value.losses.map(parseLoss);
+  if (losses.some((loss) => loss === null) || value.count !== losses.length) {
+    throw new Error('내보내기 내용 손실 보고서 항목이 올바르지 않습니다');
+  }
+
+  return {
+    schemaVersion: CONTENT_LOSS_SCHEMA_VERSION,
+    outputFormat: value.outputFormat,
+    count: value.count as number,
+    losses: losses as ContentLossRecord[],
+  };
+}
+
+/**
+ * WASM 결과에서 바이트와 보고서를 한 번에 꺼낸다.
+ *
+ * 보고서는 `takeBytes()` 뒤에도 유효하다는 Rust 계약을 실제 호출 순서로 검증한다.
+ * 어느 단계든 실패하면 artifact를 반환하지 않으며 WASM 소유권은 항상 해제한다.
+ */
+export function consumeWasmDocumentExport(exported: WasmDocumentExport): DocumentExportArtifact {
+  try {
+    if (!exported.hasBytes()) throw new Error('내보내기 결과에 바이트가 없습니다');
+    const bytes = exported.takeBytes();
+    if (exported.hasBytes()) throw new Error('내보내기 바이트 소유권을 옮기지 못했습니다');
+    const contentLoss = parseContentLossReport(JSON.parse(exported.contentLoss()));
+    return { bytes, contentLoss };
+  } finally {
+    exported.free();
+  }
+}
+
+export function runReportedExport(exporter: () => WasmDocumentExport): DocumentExportArtifact {
+  return consumeWasmDocumentExport(exporter());
+}
+
+function subjectLabel(loss: ContentLossRecord): string {
+  switch (loss.subject) {
+    case 'binaryData': return '그림·첨부 데이터';
+    case 'control': return '문서 개체';
+    case 'fieldParameters': return '필드 속성';
+    default: return '문서 내용';
+  }
+}
+
+/** 저장 완료 뒤 사용자에게 보여줄 영속 알림 문구. */
+export function buildContentLossNotice(report: ContentLossReport): string | null {
+  if (report.losses.length === 0) return null;
+  const format = report.outputFormat.toUpperCase();
+  const shown = report.losses.slice(0, 3).map((loss) => {
+    const resource = loss.resourceId === undefined ? '' : ` #${loss.resourceId}`;
+    return `• ${subjectLabel(loss)}${resource}: ${loss.path}`;
+  });
+  const remaining = report.losses.length - shown.length;
+  if (remaining > 0) shown.push(`• 그 밖의 손실 ${remaining}건`);
+  return [
+    `${format} 파일은 저장되었지만 일부 내용을 보존하지 못했습니다.`,
+    ...shown,
+  ].join('\n');
+}
+
+/**
+ * 영속화가 성공한 뒤에만 손실 알림을 전달한다.
+ *
+ * `wasPersisted`가 false인 fallback 선택 단계나 `persist` 예외에서는 알림이 없다.
+ */
+export async function persistWithContentLoss<T>(
+  report: ContentLossReport | null,
+  persist: () => Promise<T>,
+  wasPersisted: (result: T) => boolean,
+  notify: (report: ContentLossReport) => void,
+): Promise<T> {
+  const result = await persist();
+  if (report && report.losses.length > 0 && wasPersisted(result)) notify(report);
+  return result;
+}
+
+/** 동기 download 시작이 성공한 뒤 같은 규칙으로 알린다. */
+export function persistDownloadWithContentLoss(
+  report: ContentLossReport | null,
+  download: () => void,
+  notify: (report: ContentLossReport) => void,
+): void {
+  download();
+  if (report && report.losses.length > 0) notify(report);
+}

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -21,6 +21,19 @@ import {
   parseLocalBodyTextReplaceResult,
   type LocalBodyTextReplaceResult,
 } from './local-text-replace-result';
+import {
+  runReportedExport,
+  type DocumentExportArtifact,
+  type WasmDocumentExport,
+} from './export-content-loss';
+
+/** fresh WASM binding의 reported export 표면. 구버전 모듈은 런타임 가드에서 거부한다. */
+interface ReportedWasmDocument {
+  exportHwpWithReport(): WasmDocumentExport;
+  exportHwpWithPasswordAndReport(password: string): WasmDocumentExport;
+  exportHwpxWithReport(): WasmDocumentExport;
+  exportHwpxWithPasswordAndReport(password: string): WasmDocumentExport;
+}
 
 /**
  * 문단 병합으로 사라진 문단의 스코프 메타데이터 (Task #2342).
@@ -516,10 +529,40 @@ export class WasmBridge {
     return this.doc.exportHwp();
   }
 
+  /**
+   * 명시적 저장용 HWP artifact. 바이트와 content-loss 보고서는 같은 WASM 결과에 속한다.
+   * byte-only `exportHwp()`는 autosave/embed/history/compare/hwpctl/digest 호환 표면이며
+   * 보고서를 전달하지 않는다.
+   */
+  exportHwpWithReport(): DocumentExportArtifact {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    this.onBeforeExport?.();
+    const exportFn = (this.doc as unknown as Partial<ReportedWasmDocument>).exportHwpWithReport;
+    if (typeof exportFn !== 'function') {
+      throw new Error('현재 WASM 빌드는 HWP 내용 손실 보고를 지원하지 않습니다');
+    }
+    return runReportedExport(
+      () => exportFn.call(this.doc) as WasmDocumentExport,
+    );
+  }
+
   exportHwpWithPassword(password: string): Uint8Array {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     this.onBeforeExport?.();
     return this.doc.exportHwpWithPassword(password);
+  }
+
+  exportHwpWithPasswordAndReport(password: string): DocumentExportArtifact {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    this.onBeforeExport?.();
+    const exportFn = (this.doc as unknown as Partial<ReportedWasmDocument>)
+      .exportHwpWithPasswordAndReport;
+    if (typeof exportFn !== 'function') {
+      throw new Error('현재 WASM 빌드는 비밀번호 HWP 내용 손실 보고를 지원하지 않습니다');
+    }
+    return runReportedExport(
+      () => exportFn.call(this.doc, password) as WasmDocumentExport,
+    );
   }
 
   exportHwpx(): Uint8Array {
@@ -528,9 +571,35 @@ export class WasmBridge {
     return this.doc.exportHwpx();
   }
 
+  /** 명시적 저장용 HWPX artifact. byte-only 보조 소비자와 의도적으로 분리한다. */
+  exportHwpxWithReport(): DocumentExportArtifact {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    this.onBeforeExport?.();
+    const exportFn = (this.doc as unknown as Partial<ReportedWasmDocument>).exportHwpxWithReport;
+    if (typeof exportFn !== 'function') {
+      throw new Error('현재 WASM 빌드는 HWPX 내용 손실 보고를 지원하지 않습니다');
+    }
+    return runReportedExport(
+      () => exportFn.call(this.doc) as WasmDocumentExport,
+    );
+  }
+
   exportHwpxWithPassword(password: string): Uint8Array {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     return this.doc.exportHwpxWithPassword(password);
+  }
+
+  exportHwpxWithPasswordAndReport(password: string): DocumentExportArtifact {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    this.onBeforeExport?.();
+    const exportFn = (this.doc as unknown as Partial<ReportedWasmDocument>)
+      .exportHwpxWithPasswordAndReport;
+    if (typeof exportFn !== 'function') {
+      throw new Error('현재 WASM 빌드는 비밀번호 HWPX 내용 손실 보고를 지원하지 않습니다');
+    }
+    return runReportedExport(
+      () => exportFn.call(this.doc, password) as WasmDocumentExport,
+    );
   }
 
   /** HML로 저장 (보존 불가 요소가 있으면 던진다). 현재 WASM 빌드가 지원하지 않으면 던진다. */

--- a/rhwp-studio/tests/export-content-loss.test.ts
+++ b/rhwp-studio/tests/export-content-loss.test.ts
@@ -1,0 +1,236 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import {
+  buildContentLossNotice,
+  consumeWasmDocumentExport,
+  parseContentLossReport,
+  persistDownloadWithContentLoss,
+  persistWithContentLoss,
+  runReportedExport,
+  type ContentLossReport,
+  type WasmDocumentExport,
+} from '../src/core/export-content-loss.ts';
+
+const fileCommandSource = readFileSync(
+  new URL('../src/command/commands/file.ts', import.meta.url),
+  'utf8',
+);
+
+function between(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  assert.notEqual(startIndex, -1, `시작 표식이 있어야 합니다: ${start}`);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  assert.notEqual(endIndex, -1, `끝 표식이 있어야 합니다: ${end}`);
+  return source.slice(startIndex, endIndex);
+}
+
+const lossReport: ContentLossReport = {
+  schemaVersion: 1,
+  outputFormat: 'hwpx',
+  count: 1,
+  losses: [{
+    code: 'binaryContentEmptied',
+    subject: 'binaryData',
+    path: 'BinData/image7.png',
+    reason: 'resourceReadFailedOrLimitExceeded',
+    resourceId: 7,
+  }],
+};
+
+function wasmExport(events: string[]): WasmDocumentExport {
+  let bytes: Uint8Array | null = new Uint8Array([4, 4, 3, 0]);
+  return {
+    hasBytes: () => {
+      events.push('hasBytes');
+      return bytes !== null;
+    },
+    takeBytes: () => {
+      events.push('takeBytes');
+      if (bytes === null) throw new Error('already taken');
+      const owned = bytes;
+      bytes = null;
+      return owned;
+    },
+    contentLoss: () => {
+      events.push('contentLoss');
+      return JSON.stringify(lossReport);
+    },
+    free: () => { events.push('free'); },
+  };
+}
+
+test('WASM artifact는 바이트를 옮긴 뒤에도 같은 보고서를 읽고 반드시 해제한다', () => {
+  const events: string[] = [];
+  const artifact = consumeWasmDocumentExport(wasmExport(events));
+
+  assert.deepEqual(artifact.bytes, new Uint8Array([4, 4, 3, 0]));
+  assert.deepEqual(artifact.contentLoss, lossReport);
+  assert.deepEqual(events, [
+    'hasBytes',
+    'takeBytes',
+    'hasBytes',
+    'contentLoss',
+    'free',
+  ]);
+});
+
+test('보고서 파싱 실패는 바이트만 반환하지 않고 WASM artifact도 해제한다', () => {
+  const events: string[] = [];
+  const exported = wasmExport(events);
+  exported.contentLoss = () => {
+    events.push('contentLoss');
+    return JSON.stringify({ ...lossReport, count: 2 });
+  };
+
+  assert.throws(
+    () => consumeWasmDocumentExport(exported),
+    /보고서 항목이 올바르지 않습니다/,
+  );
+  assert.equal(events.at(-1), 'free');
+});
+
+test('직렬화 실패는 이전 artifact를 재사용하거나 새 보고서를 만들지 않는다', () => {
+  const previousEvents: string[] = [];
+  const previous = runReportedExport(() => wasmExport(previousEvents));
+  let failedArtifact: ReturnType<typeof runReportedExport> | undefined;
+
+  assert.throws(
+    () => {
+      failedArtifact = runReportedExport(() => {
+        throw new Error('serializer failed');
+      });
+    },
+    /serializer failed/,
+  );
+  assert.equal(failedArtifact, undefined);
+  assert.deepEqual(previous.contentLoss, lossReport);
+});
+
+test('영속화 성공 뒤에만 내용 손실 경고를 보인다', async () => {
+  const events: string[] = [];
+  const result = await persistWithContentLoss(
+    lossReport,
+    async () => { events.push('persisted'); return { method: 'save-picker' }; },
+    (saved) => saved.method === 'save-picker',
+    () => { events.push('notified'); },
+  );
+
+  assert.deepEqual(result, { method: 'save-picker' });
+  assert.deepEqual(events, ['persisted', 'notified']);
+});
+
+test('영속화 실패나 fallback 선택에는 stale/new 경고가 없다', async () => {
+  const rejectedEvents: string[] = [];
+  await assert.rejects(
+    persistWithContentLoss(
+      lossReport,
+      async () => { rejectedEvents.push('persist'); throw new Error('write failed'); },
+      () => true,
+      () => { rejectedEvents.push('notify'); },
+    ),
+    /write failed/,
+  );
+  assert.deepEqual(rejectedEvents, ['persist']);
+
+  const fallbackEvents: string[] = [];
+  await persistWithContentLoss(
+    lossReport,
+    async () => { fallbackEvents.push('fallback'); return { method: 'fallback' }; },
+    (saved) => saved.method !== 'fallback',
+    () => { fallbackEvents.push('notify'); },
+  );
+  assert.deepEqual(fallbackEvents, ['fallback']);
+});
+
+test('download 상호작용이 시작된 뒤 영속 경고를 보이며 실패하면 보이지 않는다', () => {
+  const events: string[] = [];
+  persistDownloadWithContentLoss(
+    lossReport,
+    () => { events.push('download'); },
+    () => { events.push('notify'); },
+  );
+  assert.deepEqual(events, ['download', 'notify']);
+
+  const failedEvents: string[] = [];
+  assert.throws(
+    () => persistDownloadWithContentLoss(
+      lossReport,
+      () => { failedEvents.push('download'); throw new Error('blocked'); },
+      () => { failedEvents.push('notify'); },
+    ),
+    /blocked/,
+  );
+  assert.deepEqual(failedEvents, ['download']);
+});
+
+test('Studio fallback 뒤 download 성공은 같은 보고서를 정확히 한 번만 알린다', async () => {
+  const events: string[] = [];
+  let notifications = 0;
+  const notify = () => {
+    notifications += 1;
+    events.push('notify');
+  };
+
+  const result = await persistWithContentLoss(
+    lossReport,
+    async () => { events.push('file-system:fallback'); return { method: 'fallback' as const }; },
+    (saved) => saved.method !== 'fallback',
+    notify,
+  );
+  assert.equal(result.method, 'fallback');
+  persistDownloadWithContentLoss(
+    lossReport,
+    () => { events.push('download:click'); },
+    notify,
+  );
+
+  assert.deepEqual(events, ['file-system:fallback', 'download:click', 'notify']);
+  assert.equal(notifications, 1);
+});
+
+test('Studio 명시 저장은 reported artifact를 primary 저장 뒤 fallback download까지 전달한다', () => {
+  const payloadFactory = between(
+    fileCommandSource,
+    'function createSavePayload',
+    'function showExportContentLoss',
+  );
+  assert.match(payloadFactory, /exportDocumentWithReportForFormat/);
+  assert.match(payloadFactory, /exportPasswordProtectedDocumentWithReportForFormat/);
+  assert.doesNotMatch(payloadFactory, /exportDocumentForFormat\s*\(/);
+  assert.doesNotMatch(payloadFactory, /exportPasswordProtectedDocumentForFormat\s*\(/);
+
+  const explicitSaveBodies = [
+    between(fileCommandSource, 'async function saveAsFormat', 'function reportSaveError'),
+    between(
+      fileCommandSource,
+      'export async function saveCurrentDocument',
+      'async function fallbackNameForCurrentSave',
+    ),
+  ];
+  for (const body of explicitSaveBodies) {
+    const artifactIndex = body.indexOf('createSavePayload(');
+    const primaryIndex = body.indexOf('persistWithContentLoss(');
+    const downloadIndex = body.indexOf('persistDownloadWithContentLoss(');
+    assert.ok(artifactIndex >= 0, 'reported artifact를 만들어야 합니다');
+    assert.ok(primaryIndex > artifactIndex, 'reported artifact를 primary 저장에 전달해야 합니다');
+    assert.ok(downloadIndex > primaryIndex, 'primary fallback 뒤 같은 artifact로 download해야 합니다');
+    assert.match(body, /saveResult\.method !== 'fallback'/);
+    assert.doesNotMatch(body, /exportHwp(?:x)?\s*\(/, '명시 저장이 byte-only WASM API를 우회 호출하면 안 됩니다');
+  }
+
+  const notice = between(
+    fileCommandSource,
+    'function showExportContentLoss',
+    'function requirePasswordSaveFormat',
+  );
+  assert.match(notice, /durationMs:\s*0/);
+  assert.match(notice, /confirmLabel:\s*'확인'/);
+});
+
+test('알림은 출력 형식과 정확한 손실 위치를 사용자 상호작용에 남긴다', () => {
+  const message = buildContentLossNotice(parseContentLossReport(lossReport));
+  assert.match(message ?? '', /HWPX 파일은 저장되었지만/);
+  assert.match(message ?? '', /그림·첨부 데이터 #7: BinData\/image7\.png/);
+});

--- a/rhwp-studio/tests/hwp-password-save.test.ts
+++ b/rhwp-studio/tests/hwp-password-save.test.ts
@@ -35,7 +35,7 @@ test('다른 이름·HWP·HWPX 저장은 공통 대화상자에서 암호 설정
   assert.match(commandSource, /showSaveAs\(/, '파일명을 먼저 받는 대화상자를 열어야 합니다');
   assert.match(commandSource, /allowPassword: format !== 'hml'/, 'HWP/HWPX에만 암호 설정을 노출해야 합니다');
   assert.match(commandSource, /showHwpSavePasswordDialog\(selection\.fileName\)/, '암호 설정을 누르면 암호/확인 대화상자를 열어야 합니다');
-  assert.match(commandSource, /exportPasswordProtectedDocumentForFormat/, '전용 암호 serializer를 선택해야 합니다');
+  assert.match(commandSource, /exportPasswordProtectedDocumentWithReportForFormat/, '내용 손실 보고를 포함한 전용 암호 serializer를 선택해야 합니다');
   assert.match(commandSource, /암호 설정 저장은 HWP 또는 HWPX 형식에서만 지원합니다/, 'HML 암호 저장을 거부해야 합니다');
   assert.match(commandSource, /id: 'file:save-as'/, '다른 이름으로 저장 command를 유지해야 합니다');
   assert.match(commandSource, /saveAsFormat\(services, 'hwp'\)/, 'HWP 저장도 공통 저장 경로를 써야 합니다');
@@ -61,6 +61,8 @@ test('Studio는 암호 문자열을 보관하지 않고 보호 저장 여부만 
   assert.match(bridgeSource, /private _requiresPasswordForSave = false/, 'bridge는 boolean 상태만 보관해야 합니다');
   assert.match(bridgeSource, /exportHwpWithPassword\(password: string\)/, 'HWP password WASM facade가 있어야 합니다');
   assert.match(bridgeSource, /exportHwpxWithPassword\(password: string\)/, 'HWPX password WASM facade가 있어야 합니다');
+  assert.match(bridgeSource, /exportHwpWithPasswordAndReport\(password: string\)/, '명시 HWP 암호 저장은 reported facade를 제공해야 합니다');
+  assert.match(bridgeSource, /exportHwpxWithPasswordAndReport\(password: string\)/, '명시 HWPX 암호 저장은 reported facade를 제공해야 합니다');
 });
 
 test('Studio public WASM 배포물도 암호 저장 binding을 제공한다', () => {

--- a/rhwp-studio/tests/save-document-format.test.ts
+++ b/rhwp-studio/tests/save-document-format.test.ts
@@ -3,8 +3,30 @@ import assert from 'node:assert/strict';
 
 import {
   exportDocumentForFormat,
+  exportDocumentWithReportForFormat,
   exportPasswordProtectedDocumentForFormat,
+  exportPasswordProtectedDocumentWithReportForFormat,
 } from '../src/command/save-document-format.ts';
+import type {
+  ContentLossReport,
+  DocumentExportArtifact,
+} from '../src/core/export-content-loss.ts';
+
+const cleanHwpReport: ContentLossReport = {
+  schemaVersion: 1,
+  outputFormat: 'hwp',
+  count: 0,
+  losses: [],
+};
+
+const cleanHwpxReport: ContentLossReport = {
+  ...cleanHwpReport,
+  outputFormat: 'hwpx',
+};
+
+function artifact(bytes: number, contentLoss: ContentLossReport): DocumentExportArtifact {
+  return { bytes: new Uint8Array([bytes]), contentLoss };
+}
 
 test('선택한 SaveFormat 하나가 대응하는 exporter만 호출한다', () => {
   const calls: string[] = [];
@@ -38,5 +60,55 @@ test('암호 저장은 HWP/HWPX 전용 serializer만 호출한다', () => {
 
   assert.deepEqual(exportPasswordProtectedDocumentForFormat(exporter, 'hwp', 'first'), new Uint8Array([4]));
   assert.deepEqual(exportPasswordProtectedDocumentForFormat(exporter, 'hwpx', 'second'), new Uint8Array([5]));
+  assert.deepEqual(calls, [['hwp', 'first'], ['hwpx', 'second']]);
+});
+
+test('명시 저장은 HWP/HWPX reported exporter를 고르고 HML만 보고서 없음으로 둔다', () => {
+  const calls: string[] = [];
+  const exporter = {
+    exportHml: () => { calls.push('hml'); return new Uint8Array([1]); },
+    exportHwp: () => { throw new Error('byte-only HWP를 호출하면 안 됨'); },
+    exportHwpx: () => { throw new Error('byte-only HWPX를 호출하면 안 됨'); },
+    exportHwpWithReport: () => { calls.push('hwp:reported'); return artifact(2, cleanHwpReport); },
+    exportHwpxWithReport: () => { calls.push('hwpx:reported'); return artifact(3, cleanHwpxReport); },
+  };
+
+  assert.deepEqual(exportDocumentWithReportForFormat(exporter, 'hml'), {
+    bytes: new Uint8Array([1]),
+    contentLoss: null,
+  });
+  assert.deepEqual(exportDocumentWithReportForFormat(exporter, 'hwp'), artifact(2, cleanHwpReport));
+  assert.deepEqual(exportDocumentWithReportForFormat(exporter, 'hwpx'), artifact(3, cleanHwpxReport));
+  assert.deepEqual(calls, ['hml', 'hwp:reported', 'hwpx:reported']);
+});
+
+test('암호 명시 저장도 같은 reported artifact 경계를 사용한다', () => {
+  const calls: Array<[string, string]> = [];
+  const exporter = {
+    exportHml: () => new Uint8Array(),
+    exportHwp: () => new Uint8Array(),
+    exportHwpx: () => new Uint8Array(),
+    exportHwpWithPassword: () => { throw new Error('byte-only HWP를 호출하면 안 됨'); },
+    exportHwpxWithPassword: () => { throw new Error('byte-only HWPX를 호출하면 안 됨'); },
+    exportHwpWithReport: () => artifact(1, cleanHwpReport),
+    exportHwpxWithReport: () => artifact(1, cleanHwpxReport),
+    exportHwpWithPasswordAndReport: (password: string) => {
+      calls.push(['hwp', password]);
+      return artifact(4, cleanHwpReport);
+    },
+    exportHwpxWithPasswordAndReport: (password: string) => {
+      calls.push(['hwpx', password]);
+      return artifact(5, cleanHwpxReport);
+    },
+  };
+
+  assert.deepEqual(
+    exportPasswordProtectedDocumentWithReportForFormat(exporter, 'hwp', 'first'),
+    artifact(4, cleanHwpReport),
+  );
+  assert.deepEqual(
+    exportPasswordProtectedDocumentWithReportForFormat(exporter, 'hwpx', 'second'),
+    artifact(5, cleanHwpxReport),
+  );
   assert.deepEqual(calls, [['hwp', 'first'], ['hwpx', 'second']]);
 });

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -1261,6 +1261,33 @@ impl DocumentCore {
             .map_err(|e| HwpError::RenderError(e.to_string()))
     }
 
+    /// 스냅숏 HWP 저장 바이트와 바로 그 산출물의 내용 손실을 함께 반환한다 (#4430).
+    ///
+    /// 명시적 WASM 저장은 이 경로를 사용한다. 어댑터와 직렬화가 복제본에서 실행되므로
+    /// 성공/실패와 무관하게 live Document IR은 바뀌지 않는다. MCP 등 byte-only 보조
+    /// 소비자는 이 이슈의 보고서 전달 범위 밖이다.
+    pub fn export_hwp_with_adapter_snapshot_with_report(
+        &self,
+    ) -> Result<crate::serializer::SerializedDocument, HwpError> {
+        use crate::document_core::converters::hwpx_to_hwp::convert_if_hwpx_source;
+        let mut snapshot = self.document.clone();
+        let _adapter_report = convert_if_hwpx_source(&mut snapshot, self.source_format);
+        crate::serializer::serialize_document_with_report(&snapshot)
+            .map_err(|error| HwpError::RenderError(error.to_string()))
+    }
+
+    /// 비밀번호 HWP 스냅숏 저장 + 내용 손실 보고 (#4430).
+    pub fn export_hwp_with_adapter_snapshot_with_password_and_report(
+        &self,
+        password: &[u8],
+    ) -> Result<crate::serializer::SerializedDocument, HwpError> {
+        use crate::document_core::converters::hwpx_to_hwp::convert_if_hwpx_source;
+        let mut snapshot = self.document.clone();
+        let _adapter_report = convert_if_hwpx_source(&mut snapshot, self.source_format);
+        crate::serializer::serialize_hwp_with_password_and_report(&snapshot, password)
+            .map_err(|error| HwpError::RenderError(error.to_string()))
+    }
+
     /// HWPX 출처 어댑터를 적용한 뒤 HWP5 EncryptVersion 4 비밀번호 문서로 저장한다.
     ///
     /// 일반 HWP 저장과 마찬가지로 HWPX 출처는 반드시 adapter를 먼저 통과한다. 암호화만
@@ -1315,10 +1342,27 @@ impl DocumentCore {
         self.hwpx_document_for_export(|document| crate::serializer::serialize_hwpx(document))
     }
 
+    /// HWPX 저장 바이트와 바로 그 산출물의 내용 손실을 함께 반환한다 (#4430).
+    pub fn export_hwpx_native_with_report(
+        &self,
+    ) -> Result<crate::serializer::SerializedDocument, HwpError> {
+        self.hwpx_document_for_export(crate::serializer::serialize_hwpx_with_report)
+    }
+
     /// Document IR을 ODF AES-256-CBC 비밀번호 보호 HWPX로 직렬화한다.
     pub fn export_hwpx_native_with_password(&self, password: &[u8]) -> Result<Vec<u8>, HwpError> {
         self.hwpx_document_for_export(|document| {
             crate::serializer::serialize_hwpx_with_password(document, password)
+        })
+    }
+
+    /// 비밀번호 HWPX 저장 바이트 + 내용 손실 보고 (#4430).
+    pub fn export_hwpx_native_with_password_and_report(
+        &self,
+        password: &[u8],
+    ) -> Result<crate::serializer::SerializedDocument, HwpError> {
+        self.hwpx_document_for_export(|document| {
+            crate::serializer::serialize_hwpx_with_password_and_report(document, password)
         })
     }
 

--- a/src/serializer/cfb_writer.rs
+++ b/src/serializer/cfb_writer.rs
@@ -16,14 +16,29 @@ use crate::model::document::{Document, Preview};
 use crate::password_crypto::{encrypt_hwp5_stream, HWP5_ENCRYPT_VERSION};
 
 use super::body_text::serialize_section;
+use super::content_loss::{
+    ContentLoss, ContentLossReason, ContentLossReport, SerializedDocument, SerializedFormat,
+};
 use super::doc_info::serialize_doc_info;
 use super::header::serialize_file_header;
 use super::mini_cfb;
 use super::SerializeError;
 
+#[derive(Clone, Copy)]
+enum ContentLossWarningMode {
+    ReportOnly,
+    LegacyStderr,
+}
+
 /// Document IR을 HWP 5.0 CFB 바이너리로 직렬화
 pub fn serialize_hwp(doc: &Document) -> Result<Vec<u8>, SerializeError> {
-    serialize_hwp_inner(doc, None)
+    let serialized = serialize_hwp_inner(doc, None, ContentLossWarningMode::LegacyStderr)?;
+    Ok(serialized.into_bytes())
+}
+
+/// HWP 직렬화 바이트와 바로 그 산출물의 내용 손실을 함께 반환한다 (#4430).
+pub fn serialize_hwp_with_report(doc: &Document) -> Result<SerializedDocument, SerializeError> {
+    serialize_hwp_inner(doc, None, ContentLossWarningMode::ReportOnly)
 }
 
 /// Document IR을 HWP5 EncryptVersion 4 비밀번호 문서로 직렬화한다.
@@ -34,10 +49,24 @@ pub fn serialize_hwp_with_password(
     doc: &Document,
     password: &[u8],
 ) -> Result<Vec<u8>, SerializeError> {
-    serialize_hwp_inner(doc, Some(password))
+    let serialized =
+        serialize_hwp_inner(doc, Some(password), ContentLossWarningMode::LegacyStderr)?;
+    Ok(serialized.into_bytes())
 }
 
-fn serialize_hwp_inner(doc: &Document, password: Option<&[u8]>) -> Result<Vec<u8>, SerializeError> {
+/// 비밀번호 HWP 바이트와 바로 그 산출물의 내용 손실을 함께 반환한다 (#4430).
+pub fn serialize_hwp_with_password_and_report(
+    doc: &Document,
+    password: &[u8],
+) -> Result<SerializedDocument, SerializeError> {
+    serialize_hwp_inner(doc, Some(password), ContentLossWarningMode::ReportOnly)
+}
+
+fn serialize_hwp_inner(
+    doc: &Document,
+    password: Option<&[u8]>,
+    warning_mode: ContentLossWarningMode,
+) -> Result<SerializedDocument, SerializeError> {
     // 1. FileHeader 직렬화
     // [Task #1768] 배포용/암호화 문서 강하: IR 은 이미 복호화된 평문이고 본 직렬화는
     // ViewText/DISTRIBUTE_DOC_DATA 를 생성하지 않으므로, 플래그를 유지하면 산출물
@@ -100,7 +129,8 @@ fn serialize_hwp_inner(doc: &Document, password: Option<&[u8]>) -> Result<Vec<u8
     let preview = supplement_preview(doc);
 
     // 6. CFB 컨테이너 조립
-    write_hwp_cfb(
+    let mut content_loss = ContentLossReport::new(SerializedFormat::Hwp);
+    let bytes = write_hwp_cfb(
         &header_bytes,
         &doc_info_bytes,
         &section_bytes_list,
@@ -110,7 +140,12 @@ fn serialize_hwp_inner(doc: &Document, password: Option<&[u8]>) -> Result<Vec<u8
         &doc.extra_streams,
         compressed,
         password,
-    )
+        &mut content_loss,
+    )?;
+    if matches!(warning_mode, ContentLossWarningMode::LegacyStderr) {
+        content_loss.write_warnings_to_stderr();
+    }
+    Ok(SerializedDocument::new(bytes, content_loss))
 }
 
 /// PrvText 가 비었거나 placeholder 면 본문 텍스트로 채운다.
@@ -188,6 +223,7 @@ fn write_hwp_cfb(
     extra_streams: &[(String, Vec<u8>)],
     compressed: bool,
     password: Option<&[u8]>,
+    content_loss: &mut ContentLossReport,
 ) -> Result<Vec<u8>, SerializeError> {
     // 스트림 목록 수집
     let mut streams: Vec<(String, Vec<u8>)> = Vec::new();
@@ -247,12 +283,11 @@ fn write_hwp_cfb(
                 Some(_) => {
                     // 상한 초과 + 압축 상태 불일치 — 해제(OOM 위험)도, 그대로 쓰기
                     // (오독)도 안 된다. 렌더·클립보드와 같은 placeholder 로 접는다.
-                    eprintln!(
-                        "경고: BinData {} 압축 해제 상한 {}MB 초과이고 저장 압축 상태가 달라 \
-                         빈 스트림으로 대체합니다 (#2550)",
-                        storage_name,
-                        MAX_BIN_DATA_BYTES / (1024 * 1024)
-                    );
+                    content_loss.record(ContentLoss::binary_content_emptied(
+                        storage_id,
+                        path.clone(),
+                        ContentLossReason::StoredCompressionMismatch,
+                    ));
                     streams.push((path, encrypt_if_password(Vec::new(), password)));
                     continue;
                 }
@@ -262,12 +297,11 @@ fn write_hwp_cfb(
                 // 접는다. 이미 메모리에 있는 `Loaded` 값도 `load_limited()`에서
                 // 길이를 확인했으므로 같은 경로를 탄다.
                 None => {
-                    eprintln!(
-                        "경고: BinData {} 압축 해제 상한 {}MB 초과이고 원본 저장 형태가 없어 \
-                         빈 스트림으로 대체합니다 (#2550)",
-                        storage_name,
-                        MAX_BIN_DATA_BYTES / (1024 * 1024)
-                    );
+                    content_loss.record(ContentLoss::binary_content_emptied(
+                        storage_id,
+                        path.clone(),
+                        ContentLossReason::RawPassthroughUnavailable,
+                    ));
                     streams.push((path, encrypt_if_password(Vec::new(), password)));
                     continue;
                 }

--- a/src/serializer/content_loss.rs
+++ b/src/serializer/content_loss.rs
@@ -1,0 +1,257 @@
+//! 성공한 직렬화가 산출물에 담지 못한 사용자 내용을 보고한다 (#4430).
+//!
+//! 직렬화 실패는 [`super::SerializeError`]이고, 성공했지만 일부 내용을 빈 값으로
+//! 대체하거나 생략한 경우만 이 보고서에 들어간다. 보고서는 문서 세션에 저장하지
+//! 않고 [`SerializedDocument`]가 바이트와 함께 소유한다. 따라서 이전 저장의 보고서가
+//! 다음 저장 실패 뒤에 남거나, 서로 다른 저장 바이트와 뒤섞일 수 없다.
+
+use std::fmt;
+
+/// content-loss JSON 계약 버전.
+pub const CONTENT_LOSS_SCHEMA_VERSION: u32 = 1;
+
+/// 이번 직렬화의 출력 형식.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SerializedFormat {
+    Hwp,
+    Hwpx,
+}
+
+impl fmt::Display for SerializedFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Hwp => f.write_str("HWP"),
+            Self::Hwpx => f.write_str("HWPX"),
+        }
+    }
+}
+
+/// 산출물에서 일어난 손실의 안정 식별자.
+///
+/// 후속 생산자는 같은 보고서 경계를 재사용한다. 예를 들어 표현 불가 컨트롤은
+/// `ControlOmitted`, 필드 파라미터 축소는 `MetadataReduced`를 사용한다.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ContentLossCode {
+    BinaryContentEmptied,
+    ControlOmitted,
+    MetadataReduced,
+}
+
+/// 잃은 내용의 도메인 종류.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ContentLossSubject {
+    BinaryData,
+    Control,
+    FieldParameters,
+}
+
+/// 손실이 필요해진 원인.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ContentLossReason {
+    /// 제한 안에서 자원을 읽을 수 없었다.
+    ResourceReadFailedOrLimitExceeded,
+    /// 원본 저장 바이트는 있지만 대상 스트림의 압축 상태와 달라 통과시킬 수 없었다.
+    StoredCompressionMismatch,
+    /// 제한 안에서 읽지 못했고 원본 저장 바이트도 제공되지 않았다.
+    RawPassthroughUnavailable,
+    /// 대상 형식에 대응 표현이 없다. 후속 컨트롤/메타데이터 생산자용이다.
+    UnsupportedByOutputFormat,
+}
+
+impl fmt::Display for ContentLossReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ResourceReadFailedOrLimitExceeded => {
+                f.write_str("제한 안에서 자원을 읽지 못했거나 크기 상한을 넘음")
+            }
+            Self::StoredCompressionMismatch => {
+                f.write_str("원본 저장 압축 상태가 대상 스트림과 다름")
+            }
+            Self::RawPassthroughUnavailable => {
+                f.write_str("안전하게 통과시킬 원본 저장 바이트가 없음")
+            }
+            Self::UnsupportedByOutputFormat => f.write_str("출력 형식에 대응 표현이 없음"),
+        }
+    }
+}
+
+/// 산출물에서 잃은 내용 한 건.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContentLoss {
+    pub code: ContentLossCode,
+    pub subject: ContentLossSubject,
+    /// 대상 산출물 안의 경로 또는 공통 IR 경로.
+    pub path: String,
+    pub reason: ContentLossReason,
+    /// BinData 손실일 때의 공통 IR 자원 ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource_id: Option<u16>,
+}
+
+impl ContentLoss {
+    pub fn binary_content_emptied(
+        resource_id: u16,
+        path: impl Into<String>,
+        reason: ContentLossReason,
+    ) -> Self {
+        Self {
+            code: ContentLossCode::BinaryContentEmptied,
+            subject: ContentLossSubject::BinaryData,
+            path: path.into(),
+            reason,
+            resource_id: Some(resource_id),
+        }
+    }
+}
+
+impl fmt::Display for ContentLoss {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.code {
+            ContentLossCode::BinaryContentEmptied => write!(
+                f,
+                "{} (BinData ID {}) 내용을 읽을 수 없어 빈 내용으로 저장했습니다 ({})",
+                self.path,
+                self.resource_id.unwrap_or(0),
+                self.reason
+            ),
+            ContentLossCode::ControlOmitted => {
+                write!(f, "{} 컨트롤을 산출물에 담지 못했습니다", self.path)
+            }
+            ContentLossCode::MetadataReduced => {
+                write!(
+                    f,
+                    "{} 메타데이터 일부를 산출물에 담지 못했습니다",
+                    self.path
+                )
+            }
+        }
+    }
+}
+
+/// 한 번의 직렬화에서 발생한 사용자 내용 손실.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentLossReport {
+    output_format: SerializedFormat,
+    losses: Vec<ContentLoss>,
+}
+
+impl ContentLossReport {
+    pub fn new(output_format: SerializedFormat) -> Self {
+        Self {
+            output_format,
+            losses: Vec::new(),
+        }
+    }
+
+    pub fn output_format(&self) -> SerializedFormat {
+        self.output_format
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.losses.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.losses.len()
+    }
+
+    pub fn losses(&self) -> &[ContentLoss] {
+        &self.losses
+    }
+
+    pub fn record(&mut self, loss: ContentLoss) {
+        self.losses.push(loss);
+    }
+
+    /// WASM/Studio 경계를 건너는 canonical JSON DTO.
+    pub fn to_json(&self) -> String {
+        #[derive(serde::Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Dto<'a> {
+            schema_version: u32,
+            output_format: SerializedFormat,
+            count: usize,
+            losses: &'a [ContentLoss],
+        }
+
+        serde_json::to_string(&Dto {
+            schema_version: CONTENT_LOSS_SCHEMA_VERSION,
+            output_format: self.output_format,
+            count: self.losses.len(),
+            losses: &self.losses,
+        })
+        .expect("content-loss DTO contains only serializable fields")
+    }
+
+    /// byte-only 네이티브 API의 기존 경고 채널.
+    ///
+    /// 브라우저는 stderr를 받을 수 없으므로 reported API의 값을 소비해야 한다.
+    pub fn write_warnings_to_stderr(&self) {
+        for loss in &self.losses {
+            eprintln!("경고: {} 저장 중 {loss}", self.output_format);
+        }
+    }
+}
+
+/// 직렬화된 바이트와 바로 그 바이트에서 발생한 손실을 한 생명주기로 묶는다.
+#[derive(Debug)]
+#[must_use = "산출 바이트와 content-loss 보고서를 같은 저장 흐름에서 함께 소비해야 합니다"]
+pub struct SerializedDocument {
+    bytes: Vec<u8>,
+    content_loss: ContentLossReport,
+}
+
+impl SerializedDocument {
+    pub fn new(bytes: Vec<u8>, content_loss: ContentLossReport) -> Self {
+        Self {
+            bytes,
+            content_loss,
+        }
+    }
+
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub fn content_loss(&self) -> &ContentLossReport {
+        &self.content_loss
+    }
+
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+
+    pub fn into_parts(self) -> (Vec<u8>, ContentLossReport) {
+        (self.bytes, self.content_loss)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn report_json_has_stable_schema_and_exact_resource_location() {
+        let mut report = ContentLossReport::new(SerializedFormat::Hwpx);
+        report.record(ContentLoss::binary_content_emptied(
+            7,
+            "BinData/image7.png",
+            ContentLossReason::RawPassthroughUnavailable,
+        ));
+
+        let value: serde_json::Value = serde_json::from_str(&report.to_json()).unwrap();
+        assert_eq!(value["schemaVersion"], 1);
+        assert_eq!(value["outputFormat"], "hwpx");
+        assert_eq!(value["count"], 1);
+        assert_eq!(value["losses"][0]["code"], "binaryContentEmptied");
+        assert_eq!(value["losses"][0]["subject"], "binaryData");
+        assert_eq!(value["losses"][0]["path"], "BinData/image7.png");
+        assert_eq!(value["losses"][0]["resourceId"], 7);
+        assert_eq!(value["losses"][0]["reason"], "rawPassthroughUnavailable");
+    }
+}

--- a/src/serializer/hwpx/context.rs
+++ b/src/serializer/hwpx/context.rs
@@ -19,6 +19,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::model::control::Control;
 use crate::model::document::Document;
+use crate::serializer::content_loss::{ContentLossReport, SerializedFormat};
 use crate::serializer::SerializeError;
 
 /// 양방향 ID 풀 — 등록된 ID와 참조된 ID를 추적한다.
@@ -91,7 +92,7 @@ pub struct ChartPartEntry {
 }
 
 /// 1-pass 스캔으로 구축되는 직렬화 컨텍스트.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct SerializeContext {
     pub char_shape_ids: IdPool<u32>,
     pub para_shape_ids: IdPool<u16>,
@@ -121,6 +122,30 @@ pub struct SerializeContext {
     /// 방출했으므로 중복 방지를 위해 건너뛴다. `write_section` 이 첫 문단 렌더 직전
     /// true 로 설정하고, 첫 본문 ColumnDef 방출 시 `render_control_slot` 이 소거한다.
     pub body_coldef_template_pending: bool,
+    /// 이번 HWPX 산출물에서 발생한 사용자 내용 손실 (#4430).
+    ///
+    /// ID 풀과 마찬가지로 한 번의 직렬화 생명주기에만 속하며, 완료 시 바이트와 함께
+    /// `SerializedDocument`로 이동한다.
+    pub content_loss: ContentLossReport,
+}
+
+impl Default for SerializeContext {
+    fn default() -> Self {
+        Self {
+            char_shape_ids: IdPool::default(),
+            para_shape_ids: IdPool::default(),
+            border_fill_ids: IdPool::default(),
+            tab_pr_ids: IdPool::default(),
+            numbering_ids: IdPool::default(),
+            style_ids: IdPool::default(),
+            bin_data_map: HashMap::new(),
+            chart_entries: Vec::new(),
+            para_id_counter: 0,
+            sub_list_depth: 0,
+            body_coldef_template_pending: false,
+            content_loss: ContentLossReport::new(SerializedFormat::Hwpx),
+        }
+    }
 }
 
 impl SerializeContext {

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -31,6 +31,7 @@ use std::fmt::Write as _;
 
 use crate::model::bin_data::MAX_BIN_DATA_BYTES;
 use crate::model::document::{Document, HWP5_ORIGIN_HWPX_MARKER_PATH};
+use crate::serializer::content_loss::{ContentLoss, ContentLossReason, SerializedDocument};
 
 use super::SerializeError;
 use content::BinDataEntry as ContentBinDataEntry;
@@ -43,6 +44,13 @@ use writer::HwpxZipWriter;
 /// `SerializeContext`가 1-pass 스캔으로 ID 풀을 구성하고, 각 writer가 동일 컨텍스트를
 /// 참조한다. 직렬화 종료 시 `assert_all_refs_resolved()`가 미등록 참조를 단언한다.
 pub fn serialize_hwpx(doc: &Document) -> Result<Vec<u8>, SerializeError> {
+    let serialized = serialize_hwpx_with_report(doc)?;
+    serialized.content_loss().write_warnings_to_stderr();
+    Ok(serialized.into_bytes())
+}
+
+/// HWPX 직렬화 바이트와 바로 그 산출물의 내용 손실을 함께 반환한다 (#4430).
+pub fn serialize_hwpx_with_report(doc: &Document) -> Result<SerializedDocument, SerializeError> {
     use static_assets::*;
 
     // 1-pass: ID 풀 구성
@@ -150,15 +158,17 @@ pub fn serialize_hwpx(doc: &Document) -> Result<Vec<u8>, SerializeError> {
         // 재압축이 필수라 원본 통과 fallback 이 없다. 상한 초과는 [#1917] 이 정한
         // 로드 실패 의미(빈 엔트리 placeholder + pic 컨트롤 보존)를 그대로 따른다 —
         // 여기서 오류로 중단하면 폭탄 문서 하나가 저장 자체를 막는다.
-        let bytes = data.data.load_limited(MAX_BIN_DATA_BYTES).unwrap_or_else(|| {
-            eprintln!(
-                "경고: BinData {}({}) 로드 실패 또는 압축 해제 상한 {}MB 초과 — 빈 엔트리로 대체 (#2550)",
-                entry.bin_data_id,
-                entry.href,
-                MAX_BIN_DATA_BYTES / (1024 * 1024)
-            );
-            Vec::new()
-        });
+        let bytes = match data.data.load_limited(MAX_BIN_DATA_BYTES) {
+            Some(bytes) => bytes,
+            None => {
+                ctx.content_loss.record(ContentLoss::binary_content_emptied(
+                    entry.bin_data_id,
+                    entry.href.clone(),
+                    ContentLossReason::ResourceReadFailedOrLimitExceeded,
+                ));
+                Vec::new()
+            }
+        };
         const CFB_MAGIC: [u8; 8] = [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1];
         let payload: Vec<u8> = if data.extension.eq_ignore_ascii_case("ole")
             && bytes.len() >= 8
@@ -179,6 +189,8 @@ pub fn serialize_hwpx(doc: &Document) -> Result<Vec<u8>, SerializeError> {
     //      원본 content.hpf 가 Chart 파트를 나열하지 않으므로 manifest·3-way
     //      단언 대상 밖이며(collect_from_document 에서 분리), BinData 로 옮기면
     //      한컴이 차트 XML 을 OLE 복합문서로 해석한다.
+    // chart_entries 순회 중에는 ctx를 불변 대여하므로 손실 이벤트를 잠시 분리한다.
+    let mut chart_losses = Vec::new();
     for entry in &ctx.chart_entries {
         let data = doc
             .bin_data_content
@@ -192,19 +204,21 @@ pub fn serialize_hwpx(doc: &Document) -> Result<Vec<u8>, SerializeError> {
             })?;
         // [#2550] 차트 파트도 같은 상한 — bin_data_content 를 공유하므로 폭탄 표면이다.
         // 상한 초과·로드 실패는 위 BinData 엔트리와 같은 빈 파트 placeholder 다.
-        let chart_bytes = data
-            .data
-            .load_limited(MAX_BIN_DATA_BYTES)
-            .unwrap_or_else(|| {
-                eprintln!(
-                    "경고: 차트 BinData {}({}) 로드 실패 또는 압축 해제 상한 {}MB 초과 — 빈 파트로 대체 (#2550)",
+        let chart_bytes = match data.data.load_limited(MAX_BIN_DATA_BYTES) {
+            Some(bytes) => bytes,
+            None => {
+                chart_losses.push(ContentLoss::binary_content_emptied(
                     entry.bin_data_id,
-                    entry.href,
-                    MAX_BIN_DATA_BYTES / (1024 * 1024)
-                );
+                    entry.href.clone(),
+                    ContentLossReason::ResourceReadFailedOrLimitExceeded,
+                ));
                 Vec::new()
-            });
+            }
+        };
         z.write_deflated(&entry.href, &chart_bytes)?;
+    }
+    for loss in chart_losses {
+        ctx.content_loss.record(loss);
     }
 
     // 9. Contents/content.hpf — 항상 동적 경로 + BinData 매니페스트 엔트리
@@ -247,7 +261,8 @@ pub fn serialize_hwpx(doc: &Document) -> Result<Vec<u8>, SerializeError> {
     // 세 집합이 동일해야 한컴이 바인딩 오류 없이 그림을 표시함.
     assert_bin_data_3way(&bin_entries, &zip_bin_entries)?;
 
-    z.finish()
+    let bytes = z.finish()?;
+    Ok(SerializedDocument::new(bytes, ctx.content_loss))
 }
 
 /// Document IR을 한컴 ODF AES-256-CBC 비밀번호 보호 HWPX로 직렬화한다.
@@ -258,8 +273,26 @@ pub fn serialize_hwpx_with_password(
     doc: &Document,
     password: &[u8],
 ) -> Result<Vec<u8>, SerializeError> {
-    let plain = serialize_hwpx(doc)?;
-    crate::password_crypto::encrypt_hwpx_package(&plain, password)
+    let serialized = serialize_hwpx_with_report(doc)?;
+    let (plain, content_loss) = serialized.into_parts();
+    let bytes = encrypt_hwpx_bytes(&plain, password)?;
+    content_loss.write_warnings_to_stderr();
+    Ok(bytes)
+}
+
+/// 비밀번호 HWPX 바이트와 바로 그 산출물의 내용 손실을 함께 반환한다 (#4430).
+pub fn serialize_hwpx_with_password_and_report(
+    doc: &Document,
+    password: &[u8],
+) -> Result<SerializedDocument, SerializeError> {
+    let serialized = serialize_hwpx_with_report(doc)?;
+    let (plain, content_loss) = serialized.into_parts();
+    let bytes = encrypt_hwpx_bytes(&plain, password)?;
+    Ok(SerializedDocument::new(bytes, content_loss))
+}
+
+fn encrypt_hwpx_bytes(plain: &[u8], password: &[u8]) -> Result<Vec<u8>, SerializeError> {
+    crate::password_crypto::encrypt_hwpx_package(plain, password)
         .map_err(|error| SerializeError::CryptoError(error.to_string()))
 }
 

--- a/src/serializer/mod.rs
+++ b/src/serializer/mod.rs
@@ -7,6 +7,7 @@ pub mod body_text;
 pub mod byte_writer;
 pub mod cfb_writer;
 pub(crate) mod char_shape;
+pub mod content_loss;
 pub mod control;
 pub mod doc_info;
 pub mod header;
@@ -15,9 +16,19 @@ pub mod hwpx;
 pub mod mini_cfb;
 pub mod record_writer;
 
-pub use cfb_writer::{serialize_hwp, serialize_hwp_with_password};
+pub use cfb_writer::{
+    serialize_hwp, serialize_hwp_with_password, serialize_hwp_with_password_and_report,
+    serialize_hwp_with_report,
+};
+pub use content_loss::{
+    ContentLoss, ContentLossCode, ContentLossReason, ContentLossReport, ContentLossSubject,
+    SerializedDocument, SerializedFormat,
+};
 pub use hml::serialize_hml;
-pub use hwpx::{serialize_hwpx, serialize_hwpx_with_password};
+pub use hwpx::{
+    serialize_hwpx, serialize_hwpx_with_password, serialize_hwpx_with_password_and_report,
+    serialize_hwpx_with_report,
+};
 
 /// 직렬화 에러 (HWP + HWPX 공용)
 #[derive(Debug)]
@@ -83,6 +94,13 @@ impl DocumentSerializer for HwpxSerializer {
 /// 현재 지원 포맷(HWP)으로 직렬화
 pub fn serialize_document(doc: &Document) -> Result<Vec<u8>, SerializeError> {
     HwpSerializer.serialize(doc)
+}
+
+/// 현재 지원 HWP 형식으로 직렬화하고, 성공한 산출물의 내용 손실을 값으로 돌려준다.
+pub fn serialize_document_with_report(
+    doc: &Document,
+) -> Result<SerializedDocument, SerializeError> {
+    serialize_hwp_with_report(doc)
 }
 
 #[cfg(test)]

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -345,6 +345,50 @@ pub struct HwpDocument {
     core: DocumentCore,
 }
 
+/// 한 번의 문서 내보내기 결과.
+///
+/// 바이트와 content-loss 보고서가 같은 객체에 있어 다른 저장의 상태와 섞이지 않는다.
+/// `takeBytes()`는 Rust 결과의 바이트 소유권을 한 번만 소비하며, 보고서는 그 전후 어느
+/// 순서로든 읽을 수 있다. 바이트를 두 번 꺼내는 것은 명시적 오류다.
+#[wasm_bindgen]
+pub struct DocumentExport {
+    bytes: Option<Vec<u8>>,
+    content_loss_json: String,
+}
+
+impl From<crate::serializer::SerializedDocument> for DocumentExport {
+    fn from(serialized: crate::serializer::SerializedDocument) -> Self {
+        let (bytes, content_loss) = serialized.into_parts();
+        Self {
+            bytes: Some(bytes),
+            content_loss_json: content_loss.to_json(),
+        }
+    }
+}
+
+#[wasm_bindgen]
+impl DocumentExport {
+    /// 이번 산출물의 content-loss 보고서(JSON). `takeBytes()` 뒤에도 읽을 수 있다.
+    #[wasm_bindgen(js_name = contentLoss)]
+    pub fn content_loss(&self) -> String {
+        self.content_loss_json.clone()
+    }
+
+    /// 아직 JS로 옮기지 않은 바이트를 소유하는지 반환한다.
+    #[wasm_bindgen(js_name = hasBytes)]
+    pub fn has_bytes(&self) -> bool {
+        self.bytes.is_some()
+    }
+
+    /// 산출 바이트 소유권을 한 번 꺼낸다.
+    #[wasm_bindgen(js_name = takeBytes)]
+    pub fn take_bytes(&mut self) -> Result<Vec<u8>, JsValue> {
+        self.bytes
+            .take()
+            .ok_or_else(|| JsValue::from_str("이 내보내기 결과의 바이트를 이미 가져갔습니다"))
+    }
+}
+
 impl std::ops::Deref for HwpDocument {
     type Target = DocumentCore;
     fn deref(&self) -> &DocumentCore {
@@ -6073,6 +6117,18 @@ impl HwpDocument {
         self.export_hwp_with_adapter().map_err(|e| e.into())
     }
 
+    /// HWP 바이트와 이번 산출물의 내용 손실을 같은 결과로 반환한다 (#4430).
+    ///
+    /// 명시적 Studio 저장은 이 API를 사용한다. 기존 `exportHwp()`는 호환성을 위해
+    /// byte-only로 유지되며, autosave/embed/history/compare/hwpctl/digest 등 별도
+    /// 소비자는 아직 보고서를 받지 않는다.
+    #[wasm_bindgen(js_name = exportHwpWithReport)]
+    pub fn export_hwp_with_report(&self) -> Result<DocumentExport, JsValue> {
+        self.export_hwp_with_adapter_snapshot_with_report()
+            .map(DocumentExport::from)
+            .map_err(JsValue::from)
+    }
+
     /// 문서를 HWP5 EncryptVersion 4 비밀번호 문서로 내보낸다.
     ///
     /// browser UI는 암호를 저장하지 않고 저장 시점에만 전달한다. HWPX 출처 문서는 일반
@@ -6083,10 +6139,29 @@ impl HwpDocument {
             .map_err(|e| e.into())
     }
 
+    /// 비밀번호 HWP 바이트 + 내용 손실 보고 (#4430).
+    #[wasm_bindgen(js_name = exportHwpWithPasswordAndReport)]
+    pub fn export_hwp_with_password_and_report_wasm(
+        &self,
+        password: &str,
+    ) -> Result<DocumentExport, JsValue> {
+        self.export_hwp_with_adapter_snapshot_with_password_and_report(password.as_bytes())
+            .map(DocumentExport::from)
+            .map_err(JsValue::from)
+    }
+
     /// Document IR을 HWPX(ZIP+XML)로 직렬화하여 반환한다.
     #[wasm_bindgen(js_name = exportHwpx)]
     pub fn export_hwpx(&self) -> Result<Vec<u8>, JsValue> {
         self.export_hwpx_native().map_err(|e| e.into())
+    }
+
+    /// HWPX 바이트와 이번 산출물의 내용 손실을 같은 결과로 반환한다 (#4430).
+    #[wasm_bindgen(js_name = exportHwpxWithReport)]
+    pub fn export_hwpx_with_report(&self) -> Result<DocumentExport, JsValue> {
+        self.export_hwpx_native_with_report()
+            .map(DocumentExport::from)
+            .map_err(JsValue::from)
     }
 
     /// 문서를 ODF AES-256-CBC/PBKDF2 비밀번호 보호 HWPX로 내보낸다.
@@ -6094,6 +6169,17 @@ impl HwpDocument {
     pub fn export_hwpx_with_password_wasm(&self, password: &str) -> Result<Vec<u8>, JsValue> {
         self.export_hwpx_native_with_password(password.as_bytes())
             .map_err(|e| e.into())
+    }
+
+    /// 비밀번호 HWPX 바이트 + 내용 손실 보고 (#4430).
+    #[wasm_bindgen(js_name = exportHwpxWithPasswordAndReport)]
+    pub fn export_hwpx_with_password_and_report_wasm(
+        &self,
+        password: &str,
+    ) -> Result<DocumentExport, JsValue> {
+        self.export_hwpx_native_with_password_and_report(password.as_bytes())
+            .map(DocumentExport::from)
+            .map_err(JsValue::from)
     }
 
     /// HML 원본의 공통 IR을 HWPML 2.91 XML로 직렬화하여 반환한다.

--- a/tests/issue_4430_export_content_loss.rs
+++ b/tests/issue_4430_export_content_loss.rs
@@ -1,0 +1,436 @@
+//! [#4430] 내용 손실은 stderr의 시간적 상태가 아니라 성공한 산출물의 값이다.
+//!
+//! 실제 표 셀 안 그림과 같은 BinData를 여러 중첩 owner가 공유하는 문서를 사용해
+//! HWP→HWPX→HWP, HWPX→HWP→HWPX 경계를 모두 지난다. 첫 저장에서만 정확히 한
+//! 자원 손실이 보고되고, live IR은 바뀌지 않으며, placeholder를 다시 저장하는 두 번째
+//! 경계는 이전 보고서를 되풀이하지 않아야 한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::cmp::Reverse;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::bin_data::{BinDataBytes, BinDataResolver};
+use rhwp::model::control::Control;
+use rhwp::model::paragraph::CharShapeRef;
+use rhwp::serializer::{
+    ContentLossCode, ContentLossReason, ContentLossReport, ContentLossSubject, SerializedFormat,
+};
+use rhwp::wasm_api::{DocumentExport, HwpDocument};
+
+const NESTED_HWP: &str = "samples/pic-in-table-01.hwp";
+const MULTIPLEXED_HWPX: &str = "samples/hwpx_sample2.hwpx";
+
+#[derive(Debug)]
+struct UnreadableResource;
+
+impl BinDataResolver for UnreadableResource {
+    fn resolve(&self, _key: &str) -> Vec<u8> {
+        Vec::new()
+    }
+
+    fn resolve_limited(&self, _key: &str, _max_bytes: usize) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn resolved_len(&self, _key: &str) -> usize {
+        0
+    }
+
+    fn resolved_is_empty(&self, _key: &str) -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PictureOwner {
+    table_depth: usize,
+    caption_depth: usize,
+    resource_id: u16,
+}
+
+fn collect_picture_owners(
+    controls: &[Control],
+    table_depth: usize,
+    caption_depth: usize,
+    out: &mut Vec<PictureOwner>,
+) {
+    for control in controls {
+        match control {
+            Control::Picture(picture) => {
+                out.push(PictureOwner {
+                    table_depth,
+                    caption_depth,
+                    resource_id: picture.image_attr.bin_data_id,
+                });
+                if let Some(caption) = &picture.caption {
+                    for paragraph in &caption.paragraphs {
+                        collect_picture_owners(
+                            &paragraph.controls,
+                            table_depth,
+                            caption_depth + 1,
+                            out,
+                        );
+                    }
+                }
+            }
+            Control::Table(table) => {
+                for cell in &table.cells {
+                    for paragraph in &cell.paragraphs {
+                        collect_picture_owners(
+                            &paragraph.controls,
+                            table_depth + 1,
+                            caption_depth,
+                            out,
+                        );
+                    }
+                }
+                if let Some(caption) = &table.caption {
+                    for paragraph in &caption.paragraphs {
+                        collect_picture_owners(
+                            &paragraph.controls,
+                            table_depth,
+                            caption_depth + 1,
+                            out,
+                        );
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn picture_owners(core: &DocumentCore) -> Vec<PictureOwner> {
+    let mut owners = Vec::new();
+    for section in &core.document().sections {
+        for paragraph in &section.paragraphs {
+            collect_picture_owners(&paragraph.controls, 0, 0, &mut owners);
+        }
+    }
+    owners
+}
+
+type OwnerTopology = BTreeMap<(usize, usize), usize>;
+
+fn owner_topology(core: &DocumentCore, resource_id: u16) -> OwnerTopology {
+    let mut topology = OwnerTopology::new();
+    for owner in picture_owners(core)
+        .into_iter()
+        .filter(|owner| owner.resource_id == resource_id)
+    {
+        *topology
+            .entry((owner.table_depth, owner.caption_depth))
+            .or_default() += 1;
+    }
+    topology
+}
+
+fn select_nested_resource(
+    core: &DocumentCore,
+    minimum_depth: usize,
+    minimum_owners: usize,
+) -> (u16, usize) {
+    let mut counts = BTreeMap::<u16, usize>::new();
+    for owner in picture_owners(core) {
+        if owner.table_depth >= minimum_depth {
+            *counts.entry(owner.resource_id).or_default() += 1;
+        }
+    }
+    let selected = counts
+        .into_iter()
+        .filter(|(_, count)| *count >= minimum_owners)
+        .max_by_key(|(resource_id, count)| (*count, Reverse(*resource_id)))
+        .unwrap_or_else(|| {
+            panic!(
+                "table depth {minimum_depth}에서 {minimum_owners}개 이상 owner가 공유하는 그림 자원이 없음"
+            )
+        });
+    selected
+}
+
+fn find_nested_owner_paragraph(
+    controls: &[Control],
+    resource_id: u16,
+    table_depth: usize,
+    minimum_depth: usize,
+) -> Option<rhwp::model::paragraph::Paragraph> {
+    for control in controls {
+        let Control::Table(table) = control else {
+            continue;
+        };
+        for cell in &table.cells {
+            for paragraph in &cell.paragraphs {
+                if table_depth + 1 >= minimum_depth
+                    && paragraph.controls.iter().any(|control| {
+                        matches!(
+                            control,
+                            Control::Picture(picture)
+                                if picture.image_attr.bin_data_id == resource_id
+                        )
+                    })
+                {
+                    return Some(paragraph.clone());
+                }
+                if let Some(found) = find_nested_owner_paragraph(
+                    &paragraph.controls,
+                    resource_id,
+                    table_depth + 1,
+                    minimum_depth,
+                ) {
+                    return Some(found);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// 이미 유효한 셀 문단 전체를 body로 복제해 control marker/char offset도 함께 보존한다.
+fn add_body_owner_for_nested_resource(
+    core: &mut DocumentCore,
+    resource_id: u16,
+    minimum_depth: usize,
+) {
+    let owner_paragraph = core
+        .document()
+        .sections
+        .iter()
+        .flat_map(|section| section.paragraphs.iter())
+        .find_map(|paragraph| {
+            find_nested_owner_paragraph(&paragraph.controls, resource_id, 0, minimum_depth)
+        })
+        .unwrap_or_else(|| panic!("BinData {resource_id}의 중첩 owner 문단 없음"));
+    let section = core
+        .document_mut()
+        .sections
+        .first_mut()
+        .expect("본문 구역 없음");
+    section.raw_stream = None;
+    section.paragraphs.push(owner_paragraph);
+}
+
+fn replace_with_unreadable_resource(core: &mut DocumentCore, resource_id: u16) -> String {
+    let content = core
+        .document_mut()
+        .bin_data_content
+        .iter_mut()
+        .find(|content| content.id == resource_id)
+        .unwrap_or_else(|| panic!("BinDataContent {resource_id} 없음"));
+    let extension = content.extension.clone();
+    content.data = BinDataBytes::Lazy {
+        resolver: Arc::new(UnreadableResource),
+        key: format!("unreadable-resource-{resource_id}"),
+    };
+    extension
+}
+
+fn assert_nested_resource(
+    core: &DocumentCore,
+    resource_id: u16,
+    expected_topology: &OwnerTopology,
+) {
+    let actual_topology = owner_topology(core, resource_id);
+    assert_eq!(
+        &actual_topology, expected_topology,
+        "BinData {resource_id}의 body/table/caption owner topology가 왕복에서 바뀜"
+    );
+    let content = core
+        .document()
+        .bin_data_content
+        .iter()
+        .find(|content| content.id == resource_id)
+        .unwrap_or_else(|| panic!("왕복 뒤 BinDataContent {resource_id} 없음"));
+    assert!(
+        content.data.is_empty(),
+        "보고된 BinData {resource_id}는 왕복 뒤 빈 placeholder여야 함"
+    );
+}
+
+fn assert_single_loss(
+    report: &ContentLossReport,
+    format: SerializedFormat,
+    resource_id: u16,
+    path: &str,
+    reason: ContentLossReason,
+) {
+    assert_eq!(report.output_format(), format);
+    assert_eq!(
+        report.len(),
+        1,
+        "손실 자원 하나는 owner 수와 무관하게 한 번 보고"
+    );
+    let loss = &report.losses()[0];
+    assert_eq!(loss.code, ContentLossCode::BinaryContentEmptied);
+    assert_eq!(loss.subject, ContentLossSubject::BinaryData);
+    assert_eq!(loss.resource_id, Some(resource_id));
+    assert_eq!(loss.path, path);
+    assert_eq!(loss.reason, reason);
+}
+
+#[test]
+fn hwp_to_hwpx_to_hwp_reports_nested_resource_once_without_mutating_source() {
+    let bytes = std::fs::read(NESTED_HWP).expect("중첩 그림 HWP 읽기");
+    let mut source = DocumentCore::from_bytes(&bytes).expect("중첩 그림 HWP 파싱");
+    let (resource_id, _) = select_nested_resource(&source, 2, 1);
+    add_body_owner_for_nested_resource(&mut source, resource_id, 2);
+    let topology = owner_topology(&source, resource_id);
+    assert!(topology.get(&(0, 0)).copied().unwrap_or(0) >= 1);
+    assert!(topology.keys().any(|(table_depth, _)| *table_depth >= 2));
+    let extension = replace_with_unreadable_resource(&mut source, resource_id);
+    let source_before = format!("{:#?}", source.document());
+
+    let first = source
+        .export_hwpx_native_with_report()
+        .expect("HWP→HWPX reported 저장");
+    assert_single_loss(
+        first.content_loss(),
+        SerializedFormat::Hwpx,
+        resource_id,
+        &format!("BinData/image{resource_id}.{extension}"),
+        ContentLossReason::ResourceReadFailedOrLimitExceeded,
+    );
+    assert_eq!(
+        format!("{:#?}", source.document()),
+        source_before,
+        "reported HWPX 저장은 live HWP IR을 바꾸면 안 됨"
+    );
+
+    let middle = DocumentCore::from_bytes(first.bytes()).expect("중간 HWPX 재파싱");
+    assert_nested_resource(&middle, resource_id, &topology);
+    let second = middle
+        .export_hwp_with_adapter_snapshot_with_report()
+        .expect("HWPX→HWP reported 저장");
+    assert!(
+        second.content_loss().is_empty(),
+        "이미 materialize된 placeholder가 첫 저장의 보고서를 되풀이하면 안 됨"
+    );
+
+    let final_hwp = DocumentCore::from_bytes(second.bytes()).expect("최종 HWP 재파싱");
+    assert_nested_resource(&final_hwp, resource_id, &topology);
+}
+
+#[test]
+fn hwpx_to_hwp_to_hwpx_reports_one_shared_resource_across_many_nested_owners() {
+    let bytes = std::fs::read(MULTIPLEXED_HWPX).expect("multiplexed HWPX 읽기");
+    let mut source = DocumentCore::from_bytes(&bytes).expect("multiplexed HWPX 파싱");
+    let (resource_id, _) = select_nested_resource(&source, 2, 2);
+    add_body_owner_for_nested_resource(&mut source, resource_id, 2);
+    let topology = owner_topology(&source, resource_id);
+    assert!(topology.get(&(0, 0)).copied().unwrap_or(0) >= 1);
+    assert!(topology
+        .iter()
+        .any(|((table_depth, _), count)| *table_depth >= 2 && *count >= 2));
+    let extension = replace_with_unreadable_resource(&mut source, resource_id);
+    let source_before = format!("{:#?}", source.document());
+
+    let first = source
+        .export_hwp_with_adapter_snapshot_with_report()
+        .expect("HWPX→HWP reported 저장");
+    assert_single_loss(
+        first.content_loss(),
+        SerializedFormat::Hwp,
+        resource_id,
+        &format!("/BinData/BIN{resource_id:04X}.{extension}"),
+        ContentLossReason::RawPassthroughUnavailable,
+    );
+    assert_eq!(
+        format!("{:#?}", source.document()),
+        source_before,
+        "snapshot adapter와 HWP 저장은 live HWPX IR을 바꾸면 안 됨"
+    );
+
+    let middle = DocumentCore::from_bytes(first.bytes()).expect("중간 HWP 재파싱");
+    assert_nested_resource(&middle, resource_id, &topology);
+    let second = middle
+        .export_hwpx_native_with_report()
+        .expect("HWP→HWPX reported 저장");
+    assert!(
+        second.content_loss().is_empty(),
+        "한 자원의 여러 owner가 이전 저장의 손실을 중복/재보고하면 안 됨"
+    );
+
+    let final_hwpx = DocumentCore::from_bytes(second.bytes()).expect("최종 HWPX 재파싱");
+    assert_nested_resource(&final_hwpx, resource_id, &topology);
+}
+
+#[test]
+fn password_reported_wasm_exports_keep_report_attached_to_each_encrypted_artifact() {
+    let bytes = std::fs::read(NESTED_HWP).expect("중첩 그림 HWP 읽기");
+    let mut source = HwpDocument::from_bytes(&bytes).expect("중첩 그림 HWP 파싱");
+    let (resource_id, _) = select_nested_resource(&source, 2, 1);
+    add_body_owner_for_nested_resource(&mut source, resource_id, 2);
+    let topology = owner_topology(&source, resource_id);
+    let extension = replace_with_unreadable_resource(&mut source, resource_id);
+    let source_before = format!("{:#?}", source.document());
+    let password = std::process::id().to_string();
+
+    let mut hwp = source
+        .export_hwp_with_password_and_report_wasm(password.as_str())
+        .expect("비밀번호 HWP reported 저장");
+    let hwp_report: serde_json::Value =
+        serde_json::from_str(&hwp.content_loss()).expect("HWP 보고서 JSON");
+    assert_eq!(hwp_report["count"], 1);
+    assert_eq!(hwp_report["losses"][0]["resourceId"], resource_id);
+    assert_eq!(
+        hwp_report["losses"][0]["path"],
+        format!("/BinData/BIN{resource_id:04X}.{extension}")
+    );
+    let hwp_bytes = hwp.take_bytes().expect("암호 HWP 바이트 가져오기");
+    let hwp_reloaded = DocumentCore::from_bytes_with_password(&hwp_bytes, password.as_bytes())
+        .expect("암호 HWP 재파싱");
+    assert_nested_resource(&hwp_reloaded, resource_id, &topology);
+
+    let mut hwpx = source
+        .export_hwpx_with_password_and_report_wasm(password.as_str())
+        .expect("비밀번호 HWPX reported 저장");
+    let hwpx_report: serde_json::Value =
+        serde_json::from_str(&hwpx.content_loss()).expect("HWPX 보고서 JSON");
+    assert_eq!(hwpx_report["count"], 1);
+    assert_eq!(hwpx_report["losses"][0]["resourceId"], resource_id);
+    assert_eq!(
+        hwpx_report["losses"][0]["path"],
+        format!("BinData/image{resource_id}.{extension}")
+    );
+    let hwpx_bytes = hwpx.take_bytes().expect("암호 HWPX 바이트 가져오기");
+    let hwpx_reloaded = DocumentCore::from_bytes_with_password(&hwpx_bytes, password.as_bytes())
+        .expect("암호 HWPX 재파싱");
+    assert_nested_resource(&hwpx_reloaded, resource_id, &topology);
+
+    assert_eq!(
+        format!("{:#?}", source.document()),
+        source_before,
+        "비밀번호 reported 저장도 두 형식 모두 live IR을 바꾸면 안 됨"
+    );
+}
+
+#[test]
+fn document_export_report_survives_byte_take_and_failure_has_no_artifact() {
+    let source = HwpDocument::create_empty();
+    let serialized = source
+        .export_hwpx_native_with_report()
+        .expect("빈 문서 reported 저장");
+    let mut exported: DocumentExport = serialized.into();
+    let report_before_take = exported.content_loss();
+    assert!(exported.has_bytes());
+    let bytes = exported.take_bytes().expect("바이트 한 번 가져오기");
+    assert!(!bytes.is_empty());
+    assert!(!exported.has_bytes());
+    assert_eq!(exported.content_loss(), report_before_take);
+
+    let mut invalid = HwpDocument::create_empty();
+    invalid.document_mut().sections[0].paragraphs[0]
+        .char_shapes
+        .push(CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 42,
+        });
+    let failed = invalid.export_hwpx_native_with_report();
+    assert!(failed.is_err(), "미등록 charShape 참조 저장은 실패해야 함");
+    assert_eq!(
+        exported.content_loss(),
+        report_before_take,
+        "실패한 저장은 이전 artifact 보고서를 변경하거나 새 결과로 가장하면 안 됨"
+    );
+}


### PR DESCRIPTION
## 변경 요약

- HWP/HWPX serializer가 성공한 바이트와 그 바이트에서 발생한 내용 손실을 `SerializedDocument` 하나로 반환하도록 했습니다. 읽을 수 없는 공유 BinData는 소유자 수와 무관하게 자원 단위 한 건으로 보고하고, 기존 byte-only API는 호환성을 유지하면서 native stderr 경고도 보존합니다.
- `DocumentCore` export는 live IR을 바꾸지 않는 snapshot 경계를 사용하고, WASM에는 report를 읽은 뒤 바이트를 한 번 가져가는 `DocumentExport`와 HWP/HWPX·암호 저장 reported API를 추가했습니다. 저장 실패에는 artifact/report가 생기지 않아 이전 결과가 남지 않습니다.
- Studio의 명시적 Save/Save As가 reported API를 사용해 저장·다운로드가 실제로 끝난 뒤에만 지속형 내용 손실 안내를 한 번 표시합니다. picker 취소, exporter 실패, password 취소, download 실패에는 안내를 표시하지 않습니다.

이 PR은 #4430 중 **명시적 HWP/HWPX serializer-save 경로**만 다룹니다. clipboard, autosave, embed/MCP 같은 기존 byte-only 보조 경로와 다른 `eprintln!` 경고 생산자는 이 PR 범위 밖이며, 이 PR로 #4430 전체를 닫지 않습니다.

## 관련 이슈

Part of #4430

- #4388 / PR #4425: 표현 불가 HWPX 컨트롤의 손실 진단 생산자
- #4414, #4413 / PR #4426: clipboard 소유자 순회·손실 경로(이 PR 범위 밖)
- #4396: 후속 field-parameter 축소 진단 생산자

## 테스트

- [x] `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --tests --no-fail-fast` — 5,572/5,572 통과, 35 skip
- [x] `CARGO_INCREMENTAL=0 cargo test --profile release-test --test issue_4430_export_content_loss` — 4/4 통과
- [x] `cargo clippy --profile release-test --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`, commit/worktree diff check, privacy/generated-artifact scan
- [x] `cargo check --target wasm32-unknown-unknown --lib`
- [x] fresh `wasm-pack build --target web --out-dir pkg --dev` 및 generated binding 검사 — 3/3 통과
- [x] Node 22 Studio 전체 unit suite — 834개 중 833 통과, 1 skip, 0 실패
- [x] Node 22 Studio TypeScript/production build 통과
- [x] 현재 rebased HEAD의 실제 Vite dev + headless Chrome Save/Save As E2E — 9/9 cases, 345/345 assertions
- [x] 관련 샘플 파일로 HWP/HWPX 저장·암호 재열기, body + 중첩 table/caption 공유 owner, source IR 비변경 검증
- [x] 웹(WASM) reported export → picker/write 또는 download → persistent notice 순서와 실패/cancel 무통지 검증
- [ ] capability 카탈로그 — agent/skill 변경이 없어 해당 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 미미함. serializer가 이미 순회하는 resource 실패 지점에서만 작은 보고 항목을 누적하며, 정상 저장의 손실 목록은 비어 있습니다.
- 재현·측정: 별도 latency benchmark는 하지 않았습니다. 전체 native/WASM/Studio gate와 실제 브라우저 저장 흐름으로 기능 회귀를 검증했습니다.

## 스크린샷

시각 레이아웃 변경은 없습니다. 실제 브라우저 E2E에서 성공 후 지속형 안내, 실패·취소 시 무통지, 저장 바이트 재열기를 검증했습니다.
