### PR TITLE
docs: PR #4274 검토 기록 보존

### DIFF
--- a/mydocs/orders/20260810.md
+++ b/mydocs/orders/20260810.md
@@ -1,5 +1,17 @@
 # 오늘 할일 - 2026년 8월 10일
 
+## PR #4274 - 웹한글컨트롤 호환 층과 Windows Oracle 이식성 보정
+
+- [PR #4274](https://github.com/edwardkim/rhwp/pull/4274)는 `devel`에 merge commit
+  `92100edbf6bb1dade47af1342a49b089a6ed2e1c`으로 병합됐다.
+- 최신 head의 GitHub Full CI, CodeQL, Canvas visual diff, Native Skia와 Build & Test가
+  모두 성공했다. Windows Hancom 2022 Oracle에서도 82개 시나리오 3,519/3,519 호출이 일치했다.
+- 메인터너 보정은 Windows 절대경로 제거, package gate의 종료 대기, 저장 질문 차단,
+  code page 독립 Oracle 계약을 포함한다.
+- [구현·검증 기록](../pr/archives/pr_4274_review_impl.md)을 archive로 보존했다.
+- 그림 삽입 좌표 결함을 다룬 [issue #4347](https://github.com/edwardkim/rhwp/issues/4347)은
+  병합 결과 확인 뒤 close한다. 표 분할 전제를 반증한 issue #4359는 이미 closed 상태다.
+
 ## PR #4445 - humdrum00001010 기여 20건 누적 통합
 
 - [PR #4445](https://github.com/edwardkim/rhwp/pull/4445)를 최신

--- a/mydocs/pr/archives/pr_4274_review_impl.md
+++ b/mydocs/pr/archives/pr_4274_review_impl.md
@@ -1,11 +1,22 @@
 ---
 kind: pr-review-implementation
-status: in-progress
+status: completed
 canonical: mydocs/manual/pr_review_workflow.md
-last_verified: 2026-08-09
+last_verified: 2026-08-10
 ---
 
-# PR #4274 Windows 시나리오 이식성 메인터너 보정 계획
+# PR #4274 Windows 시나리오 이식성 메인터너 보정 및 검증 기록
+
+## 병합 확정
+
+- [PR #4274](https://github.com/edwardkim/rhwp/pull/4274)는 2026-08-10에 merge commit
+  `92100edbf6bb1dade47af1342a49b089a6ed2e1c`으로 `devel`에 병합됐다.
+- 최신 head `d69bf7dc1`의 GitHub Full CI, CodeQL, Canvas visual diff, Native Skia와
+  Build & Test가 모두 성공했다.
+- 메인터너 보정은 다른 Windows 작업자에서도 Oracle gate를 재현할 수 있게 경로를
+  `{repo}`·`{out}` 토큰으로 고정하고, Hancom 종료 대기와 저장 질문 차단을 추가한 것이다.
+- 최종 Windows Hancom 2022 검증에서 82개 시나리오 3,519/3,519 호출이 일치했고, 실행 뒤
+  `Hwp.exe`·`HwpFrame.exe` 잔류와 저장 확인 대화상자는 없었다.
 
 ## 근거
 


### PR DESCRIPTION
## 목적

병합된 [PR #4274](https://github.com/edwardkim/rhwp/pull/4274)의 메인터너 보정·검증 기록을 archive로 보존한다.

## 변경

- `mydocs/pr/pr_4274_review_impl.md`를 archive로 이동하고 완료 상태, merge SHA, 최신 CI와 Windows Oracle 검증 결과를 확정했다.
- `mydocs/orders/20260810.md`에 병합 결과와 관련 issue 후속처리 상태를 기록했다.

## 검증

- `python3 scripts/check_markdown_links.py mydocs/pr/archives/pr_4274_review_impl.md mydocs/orders/20260810.md`
- `python3 scripts/check_document_metadata.py mydocs/pr/archives/pr_4274_review_impl.md`
- `git diff --check`
