### PR TITLE
fix: HWPX→HWP5 변환이 차트를 통째로 잃던 결함 (#4099)

### DIFF
--- a/mydocs/plans/task_m100_4099.md
+++ b/mydocs/plans/task_m100_4099.md
@@ -16,6 +16,7 @@ last_verified: 2026-08-10
   [#4097](https://github.com/edwardkim/rhwp/issues/4097) CFB 루트 CLSID 보존
 - **브랜치**: `task4099`
 - **기준 커밋**: `upstream/devel = 629cd33db`. **이 문서의 모든 라인 번호는 이 커밋 기준이다.**
+  (PR 직전 `9f5911e86` 으로 리베이스했고 근거 파일 무변경을 재확인했다 — §2 와 같은 절차)
 
 ## 1. 배경
 

--- a/mydocs/plans/task_m100_4099.md
+++ b/mydocs/plans/task_m100_4099.md
@@ -1,0 +1,331 @@
+---
+kind: plan
+status: active
+canonical: mydocs/plans/task_m100_4099.md
+last_verified: 2026-08-10
+---
+
+# #4099 계획서 — HWPX→HWP5 변환이 차트를 통째로 잃는 결함 수정
+
+- **Issue**: [#4099](https://github.com/edwardkim/rhwp/issues/4099) — OPEN, assignee 없음,
+  코멘트 0, 관련 PR·브랜치 없음(선점 없음)
+- **관련**: [#3683](https://github.com/edwardkim/rhwp/issues/3683) Track B(B1 수용 기준의 선결),
+  [#4055](https://github.com/edwardkim/rhwp/issues/4055) 스파이크,
+  [#3546](https://github.com/edwardkim/rhwp/issues/3546) HWPX 축 원형 보존,
+  [#4319](https://github.com/edwardkim/rhwp/issues/4319) 차트·OLE 캡션 파싱,
+  [#4097](https://github.com/edwardkim/rhwp/issues/4097) CFB 루트 CLSID 보존
+- **브랜치**: `task4099`
+- **기준 커밋**: `upstream/devel = 629cd33db`. **이 문서의 모든 라인 번호는 이 커밋 기준이다.**
+
+## 1. 배경
+
+`rhwp convert a.hwpx out.hwp` 가 **차트 참조를 끊는다.** `samples/chart/**` 코퍼스 28종 전건이다.
+바이트는 멀쩡히 보존되는데 본문 컨트롤이 그것에 도달하지 못해, rhwp 자신의 `export-svg` 가
+`"OLE 개체 (BinData #60001)"` 회색 상자를 그리고 산출 `.hwp` 에는 DocInfo 미등록 정크 스트림
+`BINEA61.ooxml_chart` 가 생긴다.
+
+`convert --verify` 는 이 결함을 처음부터 exit 3 으로 보고하고 있었다. 아무도
+`samples/chart/` 에 대해 그 명령을 돌리지 않았을 뿐이다 —
+`tests/convert_verify_corpus_ratchet.rs:95` 의 코퍼스가 `read_dir(samples/)` 비재귀라
+`samples/chart/**` 가 통째로 제외돼 있다.
+
+#3683 Track B 의 B1 은 *"편집이 HWPX↔HWP 변환을 넘어서도 살아남는다"* 를 목표로 삼는데,
+이 결함이 있는 동안에는 **변환본에서 차트 자체가 안 보이므로 그 목표를 검증할 수 없다.**
+
+### 1-1. 메커니즘
+
+HWPX 파서는 `<hp:switch><hp:case><hp:chart chartIDRef="Chart/chart1.xml">…</hp:case>`
+`<hp:default><hp:ole binaryItemIDRef="ole1">…</hp:default></hp:switch>` 를 만나면 차트 OleShape 를
+채택하고 `<hp:default>` 의 진짜 OLE 를 `chart_switch_fallback` 에 매단다
+(`parse_switch_chart_or_ole`, `src/parser/hwpx/section.rs`).
+
+| | 값 | 가리키는 것 |
+|---|---|---|
+| 차트 OleShape | `bin_data_id = 60001`, `chart_id_ref = Some(…)` | `BinDataContent{id:60001, ext:"ooxml_chart"}` — **`doc_info.bin_data_list` 에 대응 항목 없음** |
+| `chart_switch_fallback` | `bin_data_id = 1` | `BinData/ole1.ole` — 진짜 CFB, 안에 `OOXMLChartContents` + 레거시 `Contents` + EMF |
+
+HWP5 저장 경로에 `ooxml_chart`·`chart_id_ref`·`60000` 을 아는 코드가 **0건**이라:
+
+1. `src/serializer/control.rs:1912` 가 `60001` 을 그대로 기록 → dangling
+2. `src/serializer/cfb_writer.rs:373` 폴백이 `(60001,"ooxml_chart")` 반환 → `:229` 가 정크 스트림 생성
+3. `src/serializer/hwpx/roundtrip.rs:676-681` `BinDataContentCount expected=2 actual=1` → exit 3
+4. `src/renderer/layout/shape_layout.rs` OLE arm 이 두 렌더 경로를 다 실패해 placeholder
+
+### 1-2. 정답지 — 무엇을 만들어야 하는가
+
+한컴이 만든 `samples/chart/세로막대형/묶은세로막대형.hwp` 의 CFB 는 `BinData/BIN0001.OLE`
+**하나뿐**이고 `.ooxml_chart` 스트림이 없다.
+
+```text
+HwpSummaryInformation 473     BinData/BIN0001.OLE 17645     BodyText/Section0 258
+DocInfo 914                   DocOptions/_LinkDoc 524       FileHeader 256
+PrvImage 11045                PrvText 4                     Scripts/… 2건
+```
+
+#4055 보고서가 **한컴은 HWP5 에서 중첩 `OOXMLChartContents` 를 읽는다**고 실측했다(변종 H-A:
+②만 고쳐도 반영, 레거시 `Contents` 는 안 읽음). 즉 **fallback 브랜치를 채택하면 그것이 곧
+정답지**다.
+
+## 2. 최신 devel 기준 재검증
+
+계획 수립 중 로컬 `devel`(`d634e608b`)이 `upstream/devel` 보다 **475 커밋 뒤처져 있음**을
+발견해, 설계 근거가 유지되는지 전수 재확인했다.
+
+### 2-1. 골격 유효 — 변경 없음
+
+| 근거 | 위치 | 상태 |
+|---|---|---|
+| **변환기 전체** | `src/document_core/converters/hwpx_to_hwp.rs` | **파일 전체 무변경.** `convert_to_hwp_ir`:200 · `normalize_picture_geometry_for_hwp` 호출:205/정의:631 · `materialize_hwp5_bin_data_order` 호출:207/정의:297 · `remap_bin_ref`:587 |
+| 60000+N 주입 | `src/parser/hwpx/mod.rs:517-531` | 동일(라인만 이동) |
+| 정크 스트림 폴백 | `src/serializer/cfb_writer.rs:353-374`, `:229` | 동일. #2550 압축 상한만 위에 추가 |
+| verify 판정 | `src/serializer/hwpx/roundtrip.rs:676-681` | 동일 |
+| `serialize_ole_data` | `src/serializer/control.rs:1903-1917` | 파일 무변경 |
+| `find_bin_data` positional | `src/renderer/layout/utils.rs:22-36` | 동일. `find_bin_data_bytes`(#2550)가 옆에 추가됐을 뿐 |
+| 래칫 비재귀 코퍼스 | `tests/convert_verify_corpus_ratchet.rs:31-36`, `:95-104` | 파일 무변경 |
+| `issue_1251`·`issue_3546`·`issue_3547`·`hwpx_to_hwp_adapter` | — | 전부 무변경 |
+| `samples/chart/` | — | 무변경, 28종 유지 |
+
+### 2-2. 설계를 실제로 건드린 변경 2건
+
+1. **#4319 (`7553410cd`) — 차트·OLE `hp:caption` 파싱 유실 수정.**
+   `parse_common_shape_children` 에 `caption` arm 이 생겨 `<hp:chart>`/`<hp:ole>` 양쪽 다
+   `ole.caption` 이 채워진다. `write_chart_element` 에도 `write_caption`
+   (`src/serializer/hwpx/shape.rs:490`)이 추가됐다.
+   → **fold 의 caption 이월이 "미래 보험"이 아니라 실제 판정 대상이 됐다**(§3-1).
+   실측: 코퍼스 28종에 caption 있는 차트는 **0건**(`hp:chart` 0 / `hp:default>hp:ole` 0)이라
+   회귀 위험은 없으나 사용자 문서에서는 값이 들어온다 → 합성 XML 단위 테스트로 고정한다.
+2. **#4097/#4171 (`23ff5b6f1`) — `mini_cfb::build_cfb_with_root_clsid`(`:101`) 추가.**
+   루트 CLSID 가 보존되고 `ole_root_clsid`/`root_clsid` 헬퍼도 생겼다.
+   → §3-3 의 "CLSID 가 선결 과제라 CFB 합성을 기각한다"는 근거가 **무효**. 기각 결론은
+   유지하되 근거를 교체했다.
+
+## 3. 수정 설계
+
+### 3-1. fold — 차트 OleShape 를 fallback OleShape 로 접는다
+
+`chart_id_ref.is_some() && chart_switch_fallback.is_some()` 인 `OleShape` 에서 **fallback 을
+통째로 채택**한다(move, clone 금지).
+
+```rust
+if let Some(fallback) = ole.chart_switch_fallback.take() {
+    let chart_caption = ole.caption.take();
+    *ole = *fallback;
+    // [#4319] 파서가 hp:chart / hp:default>hp:ole 양쪽의 <hp:caption> 을 읽는다.
+    // 실물은 두 브랜치가 같은 캡션을 중복 기록하므로 어느 쪽을 취해도 같지만,
+    // fallback 에만 없는 경우 캡션이 조용히 사라지지 않게 이월한다.
+    if ole.caption.is_none() {
+        ole.caption = chart_caption;
+    }
+    debug_assert!(ole.chart_id_ref.is_none() && ole.chart_switch_fallback.is_none());
+    debug_assert!(ole.raw_tag_data.is_empty());
+}
+```
+
+**근거는 오라클 실측이다 — "fallback 이 정보 상위집합"이 아니다.**
+`parse_common_shape_children` 은 `extent`/`rotationInfo`/`sz`/`pos`/`outMargin`/`shapeComment`
+\+ (#4319) `caption` arm 만 처리해 `orgSz`/`curSz`/`flip`/`renderingInfo`/`lineShape` 를 IR 에
+싣지 않는다. 모델에 실제로 남는 차이는 다섯이다.
+
+| 필드 | chart | fallback | HWP5 직렬화 반영 |
+|---|---|---|---|
+| `bin_data_id` | 60001 | 1 | **예** |
+| `extent_x/y` | 7200(기본값) | 7200(`hc:extent`) | 예 — 코퍼스 동값 |
+| `drawing.shape_attr.rotate_image` | false | true | 아니오 |
+| `drawing_aspect` | Content(미파싱) | Content(파싱) | 아니오 |
+| `common.instance_id` | **1117817146** | **0** | **예** |
+
+`parse_hp_chart_element` 는 `@id` arm 이 있어 `instance_id = 1117817146`,
+`parse_hp_ole_element` 는 `@id` arm 이 없고 `instid="0"` 만 읽어 `instance_id = 0`.
+**한컴 정답지 `.hwp` 의 GenShape CTRL_HEADER 는 `instance_id = 0` 이다.** 한컴 자신의
+HWPX→HWP5 변환도 fallback 브랜치를 쓴다. 이 실측은 착수 시 재확인하고 T4 로 고정한다.
+
+`raw_tag_data` 는 HWP5 파서 전용(`src/parser/control/shape.rs` 가 유일 대입)이라 양쪽 다
+비어 있다 — `serialize_ole_data` 의 raw 단락(`control.rs:1904`)에 걸릴 위험이 없다.
+
+### 3-2. `ooxml_chart` BinDataContent 제거
+
+`doc.bin_data_content.retain(|c| c.extension != "ooxml_chart")` — **전량 무조건.**
+
+- **cfb_writer 에서 스킵하는 안은 기각한다.** `main.rs` 의 verify 가 어댑터로 in-place 변형된
+  live IR 을 expected 로 쓰므로, 어댑터에서 빼야 `BinDataContentCount` 가 맞아떨어져 수용
+  기준 2 가 정직하게 충족된다. `strip_hwpx_to_hwp_noise` 에 예외를 추가하는 안도 증거력을
+  깎으므로 기각.
+- 모듈 계약이 "HWP 직렬화기 0줄 수정"(`hwpx_to_hwp.rs:7-8`)이다.
+- positional 조회 안전: 파서가 manifest 항목을 먼저 push 하고 `Chart/*.xml` 을 뒤에
+  append 하므로 60001 은 **항상 꼬리**다. `find_bin_data` 의 `get(id-1)` 이 흔들리지 않는다.
+
+### 3-3. fold 불가 케이스 — `chart_switch_fallback == None`
+
+진입로가 **둘**이다. `<hp:chart>` 단독 출현(`section.rs` 의 `b"chart"` arm), 그리고
+`<hp:default>` 없는 case-only switch(`parse_switch_chart_or_ole` 의 `chart.or(ole)` 폴스루).
+코퍼스 0건이다.
+
+`bin_data_id = 0; chart_id_ref = None;` + 카운터 + 경고. 정크와 dangling 만 없애고
+placeholder 는 허용한다.
+
+**mini_cfb 로 OLE CFB 를 합성하는 안은 기각한다 — 단 근거가 바뀌었다.** #4171 이
+`build_cfb_with_root_clsid` 를 넣어 CLSID 선결 과제는 해소됐다. 그럼에도 기각하는 이유는
+(a) 코퍼스 0건 미관측 변형이고, (b) fallback 이 없으니 **참조할 원본 CLSID 가 없어**
+`{4C3DA137-DC90-47B9-9BED-59DAE352A280}` 상수 하드코딩이 필요하며, (c) `OOXMLChartContents`
+하나만 든 CFB 를 한컴이 받아들이는지 **미검증**이기 때문이다(#4055 는 기존 CFB 를 수정했을 뿐
+새로 만들지 않았다). 주석에 이 미래 경로와 필요 조건을 명시한다.
+
+**주의**: `bin_data_id = 0` 은 `"OLE 개체 (BinData #0)"` 을 그려 수용 기준 1 의 검색 문자열에
+매칭된다. 이 경로 테스트는 placeholder 를 허용하고 정크·dangling 만 단언한다.
+
+### 3-4. 파이프라인 위치 — `normalize_picture_geometry_for_hwp` 앞
+
+```text
+normalize_file_header_for_hwp
+normalize_page_border_fills_for_hwp
+fold_hwpx_chart_ole_for_hwp          ← 신규. 도형을 건드리는 첫 패스
+normalize_picture_geometry_for_hwp   (:205)
+normalize_doc_properties_for_hwp
+materialize_hwp5_bin_data_order      (:207)
+normalize_bin_data_for_hwp
+```
+
+- `materialize_hwp5_bin_data_order` 앞이어야 하는 이유: fold 후 fallback 의 `bin_data_id` 가
+  본체로 올라와 remap 이 정상 적용된다. **`chart_switch_fallback` 을 어떤 워커도 방문하지
+  않는다는 잠재 결함이 동시에 해소된다.** `materialize` 의 `content.id > bin_count` 예외
+  분기도 죽은 코드가 된다.
+- `normalize_picture_geometry_for_hwp` 보다도 앞이어야 하는 이유: 그 패스가 바깥 chart
+  OleShape 에 가한 변경이 fold 로 통째로 버려진다. 오늘은 무해하나 조용히 깨질 자리다.
+
+### 3-5. 순회 워커 — 새 전체 복제를 만들지 않는다
+
+`hwpx_to_hwp.rs` 에는 거의 동일한 재귀 워커가 이미 4개 있고, 그중 **가장 완전한 것은
+`normalize_picture_geometry_for_hwp`(`:631`)의 내부 워커**다 — `walk_paragraphs`/`walk_caption`/
+`walk_master_pages`/`walk_drawing`/`walk_shape` 중첩 fn 구조로, 유일하게 `Control::Field` 의
+메모 문단과 `SectionDef.master_pages` 까지 닿고 `pic`/`group`/`chart`/`ole` 의 own caption 을
+전부 훑는다(remap 계열은 못 닿는다).
+
+좁은 타입 `for_each_ole_mut(doc: &mut Document, f: &mut impl FnMut(&mut OleShape))` 를 추가하고
+순회 골격만 그 워커에서 가져온다. doc 주석에 컨테이너 커버리지 표를 남긴다. 범용 visitor 로
+5개 워커를 통합하는 것은 커버리지가 서로 달라 동작 변경 위험이 있는 **별개 리팩터**이므로
+spin-off 이슈로 분리한다.
+
+## 4. 변경 파일
+
+| 파일 | 변경 |
+|---|---|
+| `src/document_core/converters/hwpx_to_hwp.rs` | `AdapterReport` 3필드 · `for_each_ole_mut` · `fold_hwpx_chart_ole_for_hwp` · 파이프라인 삽입. **프로덕션 변경은 이 파일 하나** |
+| `tests/issue_4099_hwpx_chart_to_hwp.rs` | 신규 — T1~T6 |
+| `tests/support/issue_4055_chart_probe.rs` | `append_hwpx_entries` 추가(기존 시그니처 불변) |
+| `tests/convert_verify_corpus_ratchet.rs` | `:95-104` 코퍼스에 `samples/chart` 재귀 병합, `:31-36` 등재 |
+
+재사용 자산: `tests/support/issue_4055_chart_probe.rs` 의 `corpus()`:186 · `all_streams()`:203 ·
+`rewrite_hwpx()`:299 · `root_clsid()`:246, 그리고 `tests/issue_1251_ole_chart_contents.rs:29-40`
+`read_cfb_stream` + `decompress_stream` 패턴.
+
+## 5. 단계
+
+| 단계 | 내용 | 산출 |
+|---|---|---|
+| 0 | devel 최신화, `task4099` 분기, 계획서 커밋 | 이 문서 |
+| 1 | 게이트 먼저 — T1~T4b 작성, 전건 **red** 확인 | `tests/issue_4099_hwpx_chart_to_hwp.rs` |
+| 2 | fold + content 제거 → T1~T4b **green** | `hwpx_to_hwp.rs` |
+| 3 | 합성 문서 T5 (수용 기준 5) | `append_hwpx_entries` + T5 |
+| 4 | 래칫 재귀 병합 (수용 기준 6) — **실측 후** 등재 | `convert_verify_corpus_ratchet.rs` |
+| 5 | 한컴 판정 번들 생성(`#[ignore]`) | `output/issue_4099/` (gitignored) |
+| 6 | **작업지시자 한컴 육안 판정** | 회신 |
+| 7 | 보고서 + spin-off 이슈 등록 | `mydocs/report/task_m100_4099_report.md` |
+
+각 단계 종료 시 커밋한다. 단계 6 은 승인 게이트다.
+
+## 6. 테스트 설계 — 수용 기준 1:1 대응
+
+| T | 수용 기준 | 단언 |
+|---|---|---|
+| **T1** | 1 (렌더) | 코퍼스 28종. in-process `render_page_svg_native(0)`. `!contains("OLE 개체 (BinData #")` + `contains("hwp-ooxml-chart")`. `assert_eq!(checked, 28)` |
+| **T2** | 2 (verify) | 28종. `export_hwp_with_adapter` → 재파싱 → `diff_documents` → `strip_hwpx_to_hwp_noise` → `len() == 0`. 실패 시 diff 전문 출력 |
+| **T3** | 3·4 (CFB·참조) | 28종. `all_streams` 로 `.ooxml_chart` 0건 + `/BinData/BIN0001.OLE` 존재. 재파싱 OLE 의 `bin_data_id` 가 `bin_data_list` 에 `Storage` 로 실재. OLE 페이로드 `[4B size][CFB 매직]`(#3547 축 동승) |
+| **T4** | (근거 고정) | base 1건. `instance_id == 0` · `common.attr == 0x140A_2210` · `extent == (7200,7200)`. 이게 없으면 다음 사람이 "instance_id 를 chart 쪽에서 살려야 하지 않나"로 되돌린다 |
+| **T4b** | 3-1·3-3 경로 | `rewrite_hwpx` 합성 2건: ⑴ `<hp:chart>` 단독 → 정크 0건 · `bin_data_id == 0` · 카운터 1 · verify diff 0, **placeholder 허용**(주석 명시). ⑵ `<hp:chart>` 에만 `<hp:caption>` 이 있는 문서 → fold 후 `ole.caption` 생존(#4319 이월 규칙 고정) |
+| **T5** | 5 (remap) | §6-1 |
+| **T6** | (멱등) | base 1건, `export_hwp_with_adapter()` 2회 바이트 동일 |
+
+### 6-1. T5 — `bin_count > 1` 합성 문서 조립 (런타임, 커밋 금지)
+
+`samples/chart/` 에 파일을 커밋하면 `tests/issue_4055_b1_chart_edit_probe.rs:102`·`:271` 의
+`checked == 56` 하드코딩이 깨지므로 **런타임 zip 조립**으로 만든다.
+
+1. `content.hpf`: 기존 `<opf:item id="ole1" …>` **바로 앞에**
+   `<opf:item id="image1" href="BinData/image1.png" media-type="image/png" isEmbeded="1"/>` 삽입
+   → `bin_data_list = [Embedding/png/sid=1, Storage/OLE/sid=2]`
+2. **section XML 의 `binaryItemIDRef="ole1"` 은 손대지 않는다.** `canonicalize_bin_item_refs`
+   (`src/parser/hwpx/mod.rs`)가 자동으로 `image2` 로 정규화한다 — 손으로 바꾸면 그 정규화가
+   검증에서 빠진다
+3. `Contents/section0.xml`: `</hs:sec>` 직전에 그림 문단 추가. **XML 을 손으로 쓰지 않고**
+   기존 그림 샘플의 `<hp:p>…<hp:pic>…</hp:p>` 를 떼어와 `binaryItemIDRef` 만 치환한다
+   (`hc:imgRect`/`hc:imgClip`/`hp:imgDim` 누락 위험 제거).
+   **차트 문단이 먼저, 그림 문단이 나중** — 반대면 수집 순서가 identity 가 되어 remap 이
+   조기 반환하고 테스트가 아무것도 재지 않는다
+4. `BinData/image1.png` 추가(1×1 PNG 상수) — `append_hwpx_entries`
+5. 로드 직후 조립 검증: `bin_data_list.len()==2`, `ole.bin_data_id==60001`,
+   `fallback.bin_data_id==2`, `pic.bin_data_id==1`
+6. 변환 후: `bin_data_order_materialized == 1` · `ole.bin_data_id == 1` · `pic.bin_data_id == 2` ·
+   `bin_data_list[0]=Storage/OLE/1`, `[1]=Embedding/png/2` · CFB 에 `BIN0001.OLE`+`BIN0002.png`,
+   `.ooxml_chart` 0건 · verify diff 0
+
+**수정 전에는 `bin_data_order_materialized == 0`(조기 반환)으로 실패**한다 — §3-4 의 순서
+판단을 정확히 겨눈다.
+
+## 7. 위험과 대응
+
+| # | 위험 | 대응 |
+|---|---|---|
+| **R1** | **live IR 파괴가 WASM 에서 관측된다.** `wasm_api::exportHwp` 가 in-place 어댑터를 쓴다. fold 후 브라우저 핸들로 곧바로 `exportHwpx` 를 누르면 `chart_id_ref==None` 이라 `hp:ole` 단독이 나가고 `Chart/chart1.xml` 파트가 누락 — **#3546 계약이 HWP 저장 한 번으로 깨진다.** #4319 로 캡션 방출이 붙어 캡션 경로도 함께 영향 | 수용 + spin-off 이슈. `document.rs` 가 같은 부류를 이미 인정한 선례. **PR 본문에 명시** |
+| **R2** | **OLE 레코드 길이: rhwp 26B, 한컴 정답지 30B.** 파서 주석(`src/parser/control/shape.rs`)이 문서화한 실측은 reserved u32 3개인 30B | 이 PR 에서 **고치지 않는다**(`issue_1251` 의 `len==26` 단언과 충돌). 대신 **한컴 판정 번들에 30B 변종을 함께 넣어** 수용 기준 7 실패 시 즉시 이분되게 한다 |
+| **R3** | SHAPE_COMPONENT flip 워드: 정답지 `0x000B0000`, rhwp `0`. fold 와 무관하나 기준 7 실패 시 이분 후보 | 판정 번들에 변종 포함 |
+| **R4** | **래칫 재귀 병합이 한컴 저작 `.hwp` 28건을 처음으로 strict 비교에 넣는다**(`FileFormat::Hwp` 는 노이즈 스트립 없음). `EXPECTED_FAILURES` 가 현재 비어 있어 신규 실패가 CI 적색 | 단계 4 에서 **실측 먼저.** 실패 5건 이하면 근거와 함께 등재, 초과하면 `.hwpx` 28건만 병합하고 `.hwp` 축은 별도 이슈로 분리. 파일명 충돌 없음·크기 상한(1MB) 안·`checked>40` 하한 유지는 사전 확인 완료 |
+| **R5** | `export_hwp_native` 는 어댑터 미경유라 차트가 여전히 깨진다 | 제품 주 경로(convert/edit/save/wasm)는 전부 어댑터 경유. 남은 호출부는 dev 서브커맨드와 테스트. **PR 본문에 한 줄 명시** |
+| **R6** | `HWPX_ORIGIN_STREAM_PATH` / 암호 저장 / WASM 동등성 | **접점 없음** — 확인 완료. origin 마커 소비처는 pagination tolerance 뿐. HWP5 암호 경로는 `/BinData/*` 일괄 암호화라 정크가 줄 뿐. fold 는 `convert_if_hwpx_source` 안이라 CLI·WASM·MCP 가 같은 코드를 탄다 |
+
+## 8. 지키는 계약 — 전건 판정
+
+| 테스트 | 판정 |
+|---|---|
+| `tests/issue_3546_chart_preserved_on_save.rs` | **green, 무수정** — `export_hwpx_native()` 만 호출, 어댑터 미경유 |
+| `tests/issue_3547_ole_size_prefix.rs` | **green, 무수정** — HWPX 왕복 경로 |
+| `tests/issue_1251_ole_chart_contents.rs` 전건 | **green, 무수정** — `:247` 은 bare `<hp:ole>`(`chart_id_ref==None`)라 fold 미적용. `len==26` 도 R2 를 안 건드리므로 유지 |
+| `issue_4055…::editing_only_the_zip_part_diverges_from_the_nested_copy` (`:385`) | **green, 무수정** — `export_hwpx_native()` 만 호출 |
+| `issue_4055…::observation_hwpx_to_hwp_conversion_keeps_the_chart` (`:436`) | **green, 무수정** — ②③④ **바이트** 기준. `after.zip_part==None` 은 재파싱이 `bin_data_list` 를 열거해 원래 정크를 안 읽기 때문이라, 스트림이 사라져도 결과 동일 |
+| `issue_4055…::editing_only_the_zip_part_is_lost_when_converting_to_hwp` (`:472`) | **green, 무수정** — `export_hwpx_native()`(`:489`)를 `export_hwp_with_adapter()`(`:497`)보다 **먼저** 호출한다. 순서가 반대였으면 깨졌다. **호출 순서 의존이 생겼음을 주석으로 남긴다**(R1 의 축소판) |
+| `issue_4055…` `checked == 56`(`:102`, `:271`) | **green** — `samples/chart/` 에 파일을 커밋하지 않는 한 무변 |
+| `tests/hwpx_to_hwp_adapter.rs` 전건 | **green, 무수정** — 샘플에 차트 없음. `AdapterReport` 구조체 리터럴 0건이라 필드 추가 무해 |
+| `tests/convert_verify_corpus_ratchet.rs` | **변경 필요** — R4 |
+
+## 9. 검증
+
+변경 범위 = Rust(변환기 + 테스트). 렌더러·studio 무변경, 신규 fixture 커밋 없음 →
+Skia 3종·wasm 게이트 불필요(`local_validation.md` §4.3). 같은 target 을 공유하는 Cargo 명령은
+하나씩 순차 실행한다.
+
+```bash
+CARGO_INCREMENTAL=0 cargo test --profile release-test --test issue_4099_hwpx_chart_to_hwp
+CARGO_INCREMENTAL=0 cargo test --profile release-test --test convert_verify_corpus_ratchet
+CARGO_INCREMENTAL=0 cargo test --profile release-test --test issue_3546_chart_preserved_on_save \
+  --test issue_1251_ole_chart_contents --test issue_3547_ole_size_prefix \
+  --test issue_4055_b1_chart_edit_probe --test hwpx_to_hwp_adapter
+CARGO_INCREMENTAL=0 cargo test --profile release-test --tests   # 전체, 승인 후
+CARGO_INCREMENTAL=0 cargo fmt --check
+CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings
+```
+
+전체 테스트는 `$TMPDIR/task4099_full_test.log` 로 tee 한다.
+
+수동 재현(수정 전/후 대조):
+
+```bash
+rhwp convert samples/chart/세로막대형/묶은세로막대형.hwpx /tmp/c.hwp --verify   # 전: exit 3 → 후: 0
+rhwp export-svg /tmp/c.hwp -o /tmp/s/ && grep -c "OLE 개체" /tmp/s/*.svg        # 전: 1 → 후: 0
+rhwp dump /tmp/c.hwp | grep OLE                                                 # 전: id=60001 → 후: 1
+```
+
+## 10. 승인 게이트
+
+- 단계 6(한컴 육안 판정) 회신 후 단계 7 진행
+- PR 생성, remote push, 이슈 코멘트는 각각 작업지시자 승인 후
+- spin-off 이슈 3건(`next_bin_data_storage_id` sentinel 오염 / R1 live-IR 파괴 /
+  `hwpx_to_hwp.rs` 5개 워커 통합)은 등록 전 승인

--- a/mydocs/report/task_m100_4099_report.md
+++ b/mydocs/report/task_m100_4099_report.md
@@ -1,0 +1,307 @@
+---
+kind: report
+status: active
+canonical: mydocs/report/task_m100_4099_report.md
+last_verified: 2026-08-10
+---
+
+# #4099 최종 보고 — HWPX→HWP5 변환이 차트를 통째로 잃던 결함
+
+- **Issue**: [#4099](https://github.com/edwardkim/rhwp/issues/4099)
+- **브랜치**: `task4099` (`upstream/devel = 629cd33db` 기준)
+- **계획서**: [`task_m100_4099.md`](../plans/task_m100_4099.md)
+- **검증 환경**: 로컬 Rust 테스트 + 한컴 2022 판정(작업지시자, 2026-08-10)
+
+## 결론 한 줄
+
+**차트 OleShape 를 `<hp:default>` fallback OLE 로 접는다.** 그것이 한컴 자신이 하는 일임을
+정답지 바이트로 확인했고, **변환본의 한컴 렌더가 정답지와 픽셀 단위로 같음**을 확인했다.
+프로덕션 변경은 파일 하나, 함수 둘이다.
+
+## 1. 무엇이 문제였나
+
+HWPX 파서는 `<hp:switch>` 의 `<hp:case>` 브랜치를 채택해 **가상 id** `bin_data_id = 60000+N`
+을 세우고, `<hp:default>` 의 진짜 OLE 를 `chart_switch_fallback` 에 매달아 둔다(#3546 —
+HWPX 저장 시 원형 재방출의 재료). 그 가상 id 는 zip 파트 `Chart/chartN.xml` 을 가리키므로
+**HWP5 에는 대응물이 없다.** 그런데 HWP5 저장 경로에 이 규약을 아는 코드가 **0건**이었다.
+
+| 축 | 결과 |
+|---|---|
+| `serialize_ole_data` | `60001` 을 그대로 기록 → HWP5 DocInfo 에 없는 storage 참조(dangling) |
+| `find_bin_data_info_with_compress` 폴백 | `/BinData/BINEA61.ooxml_chart` **DocInfo 미등록 정크 스트림** 생성 |
+| 재파싱 | 그 스트림을 읽지 않아 `--verify` 가 `bin_data_content count: expected=2 actual=1` → exit 3 |
+| rhwp 자신의 렌더 | `"OLE 개체 (BinData #60001)"` 회색 상자 |
+
+`samples/chart/**` **28종 전건**이다.
+
+### 왜 지금까지 안 잡혔나 — 두 가지가 겹쳤다
+
+**① 바이트는 멀쩡히 보존된다.** 끊어진 것은 참조뿐이다. #4055 스파이크의
+`observation_hwpx_to_hwp_conversion_keeps_the_chart` 는 변환본의 **바이트**를 확인해
+②③④ 보존을 증명하고 "별도 이슈로 낼 결함은 없다"로 마쳤다. 그 판정은 바이트에 대해서는
+지금도 옳다 — 다만 본문 컨트롤이 그것에 도달하지 못한다는 축을 보지 않았다.
+
+**② 게이트가 그 축에서 비어 있었다.** `convert --verify` 는 이 결함을 처음부터 exit 3 으로
+보고하고 있었다. `tests/convert_verify_corpus_ratchet.rs` 의 코퍼스가 `read_dir(samples/)`
+**비재귀**라 `samples/chart/**` 가 통째로 제외돼 있었을 뿐이다. 결함보다 이쪽이 근인에 가깝다.
+
+## 2. 정답지 — 한컴은 무엇을 하는가
+
+`samples/chart/세로막대형/묶은세로막대형` 을 두 포맷으로 놓고 실측했다.
+
+```text
+오라클 .hwp        bin_data_id=1      instance_id=0           attr=0x140A2210  raw=30B
+HWPX chart 브랜치  bin_data_id=60001  instance_id=1117817146  attr=0x140A2210  raw=0B
+HWPX fallback      bin_data_id=1      instance_id=0           attr=0x140A2210  raw=0B
+현재 변환본(수정 전) bin_data_id=60001  instance_id=1117817146                  raw=26B
+```
+
+**`instance_id` 가 유일한 판별자다.** `parse_hp_chart_element` 은 `@id` 를 읽어
+`1117817146`, `parse_hp_ole_element` 은 `@id` arm 이 없고 `instid="0"` 만 읽어 `0` 이 된다.
+오라클이 **0** 이라는 것은 **한컴 자신의 HWPX→HWP5 변환도 fallback 브랜치를 쓴다**는 뜻이다.
+
+정답지 CFB 도 같은 말을 한다 — `BinData/BIN0001.OLE` **하나뿐**이고 `.ooxml_chart` 스트림이
+없다. 그 OLE 안에 한컴이 실제로 읽는 중첩 `OOXMLChartContents` 가 들어 있다(#4055 H-A 변종:
+그 사본만 고쳐도 렌더에 반영됨).
+
+> **설계 근거를 한 번 갈아엎었다.** 처음에는 "fallback 이 정보 상위집합이라 통째로 채택한다"로
+> 적었으나 그것은 **거짓**이다. `parse_common_shape_children` 은 여섯(+#4319 캡션) arm 만
+> 처리해 `orgSz`/`curSz`/`flip`/`renderingInfo`/`lineShape` 를 IR 에 싣지 않는다. XML 상의
+> 상위집합은 모델에 도달하지 못한다. 결론은 유지됐지만 근거는 오라클 실측으로 교체했다.
+> 그래서 `issue4099_folded_ole_matches_hancom_oracle` 로 그 근거 자체를 고정했다 —
+> 없으면 다음 사람이 "instance_id 를 chart 쪽에서 살려야 하지 않나"로 되돌린다.
+
+## 3. 무엇을 고쳤나
+
+프로덕션 변경은 [`hwpx_to_hwp.rs`](../../src/document_core/converters/hwpx_to_hwp.rs) **한 파일**이다.
+
+### 3-1. `fold_hwpx_chart_ole_for_hwp`
+
+`chart_id_ref` 가 있는 `OleShape` 에서 `chart_switch_fallback` 을 **move 로 통째 채택**하고,
+`extension == "ooxml_chart"` 인 `BinDataContent` 를 전량 제거한다.
+
+캡션은 명시적으로 이월한다. #4319(`7553410cd`, 이 작업 착수 전날)가 차트·OLE 캡션 파싱을
+고쳐 양쪽 `<hp:caption>` 이 모두 IR 에 들어오게 됐으므로, chart 쪽에만 있는 캡션은 fallback
+채택으로 조용히 사라진다. 코퍼스 28종은 캡션이 0건이라 **합성 문서로만 잴 수 있는 축**이다.
+
+fallback 이 없는 변형(switch 밖 단독 `<hp:chart>`, `<hp:default>` 없는 case-only switch)은
+코퍼스 0건이다. 접을 대상이 없으므로 참조를 비워 정크와 dangling 을 둘 다 막고 placeholder 로
+남긴다. `mini_cfb` 로 CFB 를 합성하는 길은 #4097 로 도구가 갖춰졌으나, 참조할 원본 CLSID 가
+없어 상수 하드코딩이 필요하고 `OOXMLChartContents` 하나만 든 CFB 를 한컴이 받아들이는지
+미검증이라 주석으로만 남겼다.
+
+### 3-2. 파이프라인 위치 — 도형을 건드리는 첫 패스
+
+```text
+normalize_file_header_for_hwp
+normalize_page_border_fills_for_hwp
+fold_hwpx_chart_ole_for_hwp          ← 신규
+normalize_picture_geometry_for_hwp
+normalize_doc_properties_for_hwp
+materialize_hwp5_bin_data_order
+normalize_bin_data_for_hwp
+```
+
+`materialize_hwp5_bin_data_order` 앞이라야 fold 가 올려놓은 진짜 `bin_data_id` 를 remap 이
+본다. **덤으로 "`chart_switch_fallback` 을 어떤 워커도 방문하지 않는다"는 잠재 결함이 함께
+풀린다** — fold 후에는 그 상자 자체가 없어지기 때문이다.
+`normalize_picture_geometry_for_hwp` 보다도 앞인 이유는, 그 패스가 바깥 차트 OleShape 에 가한
+변경이 fold 로 통째로 버려지기 때문이다(오늘은 무해하나 조용히 깨질 자리다).
+
+### 3-3. 순회 — 네 번째 복제 워커를 만들지 않았다
+
+이 파일에는 거의 같은 재귀 워커가 이미 넷 있다. 좁은 타입 `for_each_ole_mut` 를 두고 골격만
+`normalize_picture_geometry_for_hwp` 쪽에서 가져왔다 — 넷 중 커버리지가 가장 넓어
+`Control::Field` 메모 문단과 `SectionDef.master_pages` 까지 닿는 유일한 워커다(remap 계열은
+못 닿는다). 커버리지 표를 doc 주석에 남겼다. 다섯을 하나로 합치는 것은 커버리지가 서로 달라
+동작이 바뀔 수 있는 별개 리팩터이므로 §7 로 분리했다.
+
+## 4. 수용 기준 대조
+
+| # | 기준 | 결과 |
+|---|---|---|
+| 1 | 코퍼스 28종 렌더에 `"OLE 개체 (BinData #"` 0건 | **충족** — `hwp-ooxml-chart` 렌더 확인, fallback placeholder 도 0건 |
+| 2 | 28종 `convert --verify` exit 0 | **충족** — 전건 diff 0 |
+| 3 | 산출 `.hwp` 에 `BIN*.ooxml_chart` 정크 0건 | **충족** |
+| 4 | OLE `bin_data_id` 가 DocInfo 실재 `storage_id` 를 가리킴 | **충족** — `1`, 오라클과 동일. `Storage` 등록 확인 |
+| 5 | 차트+그림 합성으로 `bin_count > 1` remap 경로 커버 | **충족** — §5-1 |
+| 6 | 이 축이 다시 비지 않게 함 | **충족** — §5-2 |
+| 7 | 한컴에서 변환본을 열어 차트가 보임 | **충족** — 정답지와 렌더 바이트 일치. §6 |
+| 8 | 기존 계약 전건 green | **충족** — §5-3 |
+
+## 5. 검증
+
+### 5-1. `bin_count > 1` — 코퍼스로는 잴 수 없던 경로
+
+코퍼스 28종은 전부 BinData 가 `ole1.ole` 하나뿐이라
+`materialize_hwp5_bin_data_order` 의 `bin_count <= 1` 조기 반환에 걸린다 — **그 remap 은 차트
+문서에서 한 번도 실제로 돌아본 적이 없다.**
+
+차트 hwpx 에 그림을 얹어 런타임에 조립했다(`samples/chart/` 에 커밋하면
+`issue_4055_b1_chart_edit_probe` 의 `checked == 56` 하드코딩이 깨진다). manifest 에 `image1`
+을 `ole1` 앞에 넣어 순번 1(그림)/2(OLE)를 만들고, 그림 문단은 실 코퍼스에서 떼어왔다 —
+XML 을 손으로 쓰면 `hc:imgRect`/`hp:imgClip`/`hp:imgDim` 을 빠뜨리기 쉽다. section XML 의
+`binaryItemIDRef="ole1"` 은 일부러 그대로 뒀다. `canonicalize_bin_item_refs` 가 `image2` 로
+정규화하는 것까지 함께 검증하기 위해서다.
+
+`AdapterReport` 를 직접 단언해 새 경로가 열렸음을 증거로 남겼다.
+
+```text
+합성본        bin_data_order_materialized = 1   ← remap 이 실제로 돌았다
+대조군(코퍼스) bin_data_order_materialized = 0   ← 조기 반환
+```
+
+fold 를 임시로 끄면 `ole.bin_data_id` 가 `60001` 로 남아 red 임을 확인했다.
+
+### 5-2. 래칫 — 게이트가 실효인가
+
+`convert_verify_corpus_ratchet.rs` 의 코퍼스에 `samples/chart` 를 재귀로 합쳤다.
+`samples/` 전체를 재귀로 열지 않은 것은 범위 통제다 — 나머지 하위 68개 디렉터리는 이 이슈의
+축이 아니고, 한꺼번에 넣으면 무관한 신규 실패를 이 PR 에서 등재해야 한다.
+
+| 측정 | 결과 |
+|---|---|
+| 합병 후 신규 실패 | **0건** — `EXPECTED_FAILURES` 등재 불필요 |
+| 한컴 저작 `.hwp` 28건 (노이즈 스트립 없는 strict 비교) | 전건 통과 |
+| **fold 를 끄면** | 4개 조각에서 5+7+5+11 = **28건** 검출 (코퍼스 `.hwpx` 전건) |
+| 파일명 충돌 / 1MB 초과 | 각 0건 → 56건 전부 검사 |
+| 실행 시간 | 15초(4조각 병렬) |
+
+계획 단계의 위험 R4("한컴 저작 `.hwp` 28건이 처음 strict 비교에 들어가 대량 실패할 것")는
+**실현되지 않았다.**
+
+### 5-3. 계약 테스트
+
+| 테스트 | 결과 |
+|---|---|
+| `issue_3546_chart_preserved_on_save` | 2/2 green, 무수정 |
+| `issue_1251_ole_chart_contents` | 10/10 green, 무수정 |
+| `issue_3547_ole_size_prefix` | 1/1 green, 무수정 |
+| `issue_4055_b1_chart_edit_probe` | 9/9 green + 1 ignored, 무수정 |
+| `hwpx_to_hwp_adapter` | 50/50 green, 무수정 |
+| `convert_verify_corpus_ratchet` | 4/4 green (코퍼스 확장) |
+| `issue_4099_hwpx_chart_to_hwp` (신규) | 9/9 green + 1 ignored |
+
+`issue_4055::editing_only_the_zip_part_is_lost_when_converting_to_hwp` 가 green 인 것은
+**호출 순서 덕분이다** — `export_hwpx_native()` 를 `export_hwp_with_adapter()` 보다 먼저
+부른다. 순서가 반대였으면 fold 가 zip 파트를 지워 깨졌을 것이다. 이것이 §7-2 의 축소판이다.
+
+전체 스위트(`cargo test --profile release-test --tests`, 로그 `$TMPDIR/task4099_full_test.log`):
+
+```text
+503개 결과 블록 — 5572 passed, 0 failed, 36 ignored (exit 0)
+```
+
+`cargo fmt --check` 는 `Diff in` 0건(Windows CRLF 로 exit 1 이나 실제 차이 없음),
+`cargo clippy --profile release-test --all-targets -- -D warnings` 통과.
+
+## 6. 한컴 판정 (수용 기준 7) — 통과
+
+`output/issue_4099/` 에 5파일을 냈다(gitignored).
+
+fold 산출본과 정답지의 `BodyText/Section0` 레코드를 **전수 대조**해 변종을 실측으로 골랐다.
+차트 개체 관련 차이는 **정확히 둘**이고, GenShape CTRL_HEADER 46B 는 **바이트까지 같다**.
+
+```text
+[12] CTRL_HEADER(gso)      46B   SAME          ← fold 가 instance_id 포함해 맞췄다
+[13] SHAPE_COMPONENT      196B   @38: 0b→00    ← flip 워드 0x000B_0000
+[14] SHAPE_COMPONENT_OLE   30B→26B             ← 앞 26B 동일, 꼬리 reserved u32 부재
+```
+
+나머지 세 곳(SectionDef CTRL_HEADER 47B/38B, `PAGE_BORDER_FILL` ×2)은 차트와 무관한 기존
+축이다.
+
+두 차이 모두 fold 이전부터 있었고 이 PR 이 만든 것이 아니다. 26B 는
+`issue_1251_ole_chart_contents` 가 고정하고 있어 여기서 바꾸면 그 계약이 깨진다. 그래서
+**고치는 대신 변종으로 함께 냈다.**
+
+### 판정 결과 — A 가 정답지와 **렌더 바이트 일치**
+
+작업지시자가 한컴 2022 로 두 파일을 열어 PDF 로 저장했다. 그 PDF 의 첫 쪽을 144DPI 로
+렌더해 SHA-256 을 비교했다(#4055 가 쓴 방법과 같다 — 메타데이터·타임스탬프를 타지 않는다).
+
+```text
+00-oracle-한컴원본.pdf  78834a582ce0a39f758ec7e763b2b07af72d0be798210f3e340be0e2e6ac5e9a
+A-fold.pdf              78834a582ce0a39f758ec7e763b2b07af72d0be798210f3e340be0e2e6ac5e9a
+                        ^ 동일 (1190x1682 px)
+```
+
+렌더 내용도 확인했다 — 묶은 세로막대형 3계열 × 4항목, 제목·범례·축 눈금이 모두 그려진다.
+"빈 페이지 둘이 우연히 같은" 경우가 아니다.
+
+| 파일 | 내용 | 판정 |
+|---|---|---|
+| `00-oracle-한컴원본.hwp` | 목표 화면 | 기준 |
+| `A-fold.hwp` | 이 PR 산출본 | **통과 — 기준과 렌더 바이트 일치** |
+| `B-fold+ole30.hwp` | OLE 레코드 30B | 불필요 |
+| `C-fold+flip.hwp` | flip `0x000B_0000` | 불필요 |
+| `D-fold+ole30+flip.hwp` | 둘 다 | 불필요 |
+
+### 부수 성과 — 남은 두 레코드 차이는 한컴이 무시한다
+
+A 는 **26B OLE 레코드**와 **flip = 0** 을 가진 채로 정답지와 픽셀까지 같게 그려졌다.
+즉 위 두 차이는 한컴 호환에 영향이 없다. 계획 단계에서 "기준 7 실패 시의 이분 후보"로
+잡아 뒀던 위험 R2·R3 가 **실측으로 해소**됐고, 26→30 을 다루는 별도 PR 도 필요 없다.
+
+`issue_1251_ole_chart_contents` 의 `len == 26` 단언은 그대로 유효하다.
+
+## 7. Spin-off 이슈 초안 (미등록 — 승인 대기)
+
+### 7-1. `next_bin_data_storage_id` 가 차트 sentinel 에 오염된다
+
+`Document::next_bin_data_storage_id` 는 `max(bin_data_content.id, bin_data_list.storage_id) + 1`
+을 채번한다. 차트 문서는 `bin_data_content` 에 **60001** 이 있으므로, 그림을 삽입하면
+`storage_id = 60002` 가 배정된다. 그런데 `materialize_hwp5_bin_data_order` 의 `bin_count` 는
+`bin_data_list.len()`(=2)이고 `push_bin_order` 는 `id > bin_count` 를 버리므로 **그 항목이
+순서 수집에서 조용히 탈락한다.**
+
+#4099 의 fold 로는 안 고쳐진다 — 오염은 **live HWPX IR**(편집 시점)에서 일어나고 fold 는
+HWP 저장 시점이다. 재현은 **저장 전에** 해야 한다.
+
+### 7-2. 어댑터가 live IR 을 파괴해 HWPX 재방출이 깨진다 (R1)
+
+`wasm_api::exportHwp` 는 in-place 어댑터를 쓴다. #4099 의 fold 이후, 브라우저 핸들로 곧바로
+`exportHwpx` 를 누르면 `chart_id_ref == None` 이라 `write_ole_or_chart` 가
+`hp:switch/case/default` 대신 **`hp:ole` 단독**을 방출하고, `bin_data_content` 에서 차트가
+빠져 **`Chart/chart1.xml` 파트가 패키지에서 누락**된다. **#3546 이 세운 "차트 원형 보존"
+계약이 HWP 저장 한 번으로 깨진다.** #4319 로 `write_chart_element` 에 캡션 방출이 붙어 캡션
+경로도 함께 영향받는다.
+
+렌더는 중첩 `OOXMLChartContents` 로 살아남으므로 치명적이지는 않으나, 어댑터의 다른 in-place
+변형과 달리 **이것은 페이로드 삭제**라 종류가 다르다. 후보 수정은
+`export_hwp_with_adapter_snapshot()` 사용(1줄, `Document` clone 1회 비용).
+
+`issue_4055::editing_only_the_zip_part_is_lost_when_converting_to_hwp` 가 지금 green 인 것은
+호출 순서 덕분이며, 그 사실이 이 결함의 축소판이다.
+
+### 7-3. `hwpx_to_hwp.rs` 의 IR 워커 다섯을 하나로 통합
+
+거의 같은 재귀 워커가 다섯이고 커버리지가 제각각이다. 이 표가 근거다.
+
+| 컨테이너 | bin order | bin ref remap | adapt | picture-geometry | for_each_ole_mut |
+|---|---|---|---|---|---|
+| 표 셀 · 그룹 자식 · 머리말/꼬리말/각주/미주/숨은설명 | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `pic`/`group`/`chart`/`ole` own caption | 일부 | 일부 | — | ✓ | ✓ |
+| `Control::Field.memo_paragraphs` | ✗ | ✗ | ✗ | ✓ | ✓ |
+| `Control::SectionDef.master_pages` | ✗ | ✗ | ✗ | ✓ | ✓ |
+
+"한 워커가 컨테이너 하나를 놓쳤다"가 이 파일의 반복 결함이다(코드 주석 다섯 곳이 그 이력을
+적고 있다). 통합은 동작 변경 위험이 있어 별개 작업이어야 한다.
+
+## 8. 이 작업에서 배운 것
+
+**조사 근거 자체가 낡을 수 있다.** 계획 수립 중 로컬 `devel` 이 `upstream/devel` 보다
+**475 커밋** 뒤처진 상태였고, 작업지시자 지적으로 잡았다. 재검증 결과 골격(변환기 전체 무변경,
+60000+N 주입, 정크 폴백, verify 판정, 래칫 비재귀)은 유지됐으나 **두 건이 설계를 바꿨다** —
+#4319 가 캡션 축을 만들었고, #4171 이 fold 불가 경로의 기각 근거를 무효화했다. 계획서에
+기준 커밋 SHA 를 명시하는 관례를 함께 넣었다.
+
+## 9. 산출물
+
+| 경로 | 내용 |
+|---|---|
+| `src/document_core/converters/hwpx_to_hwp.rs` | `fold_hwpx_chart_ole_for_hwp` · `for_each_ole_mut` · `AdapterReport` 3필드 |
+| `tests/issue_4099_hwpx_chart_to_hwp.rs` | 게이트 9건 + 판정 번들 생성기 1건(ignore) |
+| `tests/support/issue_4055_chart_probe.rs` | `append_hwpx_entries` 추가 |
+| `tests/convert_verify_corpus_ratchet.rs` | `samples/chart` 재귀 병합 |
+| `output/issue_4099/` | 한컴 판정 5파일 + `PANJEONG.md` + 작업지시자가 한컴 2022 로 변환한 PDF 2건 + 144DPI PNG 2건 (gitignored) |

--- a/mydocs/report/task_m100_4099_report.md
+++ b/mydocs/report/task_m100_4099_report.md
@@ -8,7 +8,8 @@ last_verified: 2026-08-10
 # #4099 최종 보고 — HWPX→HWP5 변환이 차트를 통째로 잃던 결함
 
 - **Issue**: [#4099](https://github.com/edwardkim/rhwp/issues/4099)
-- **브랜치**: `task4099` (`upstream/devel = 629cd33db` 기준)
+- **브랜치**: `task4099` — 계획·조사는 `upstream/devel = 629cd33db` 기준,
+  PR 직전 `9f5911e86`(+65 커밋) 으로 리베이스
 - **계획서**: [`task_m100_4099.md`](../plans/task_m100_4099.md)
 - **검증 환경**: 로컬 Rust 테스트 + 한컴 2022 판정(작업지시자, 2026-08-10)
 

--- a/mydocs/report/task_m100_4099_report.md
+++ b/mydocs/report/task_m100_4099_report.md
@@ -16,7 +16,8 @@ last_verified: 2026-08-10
 
 **차트 OleShape 를 `<hp:default>` fallback OLE 로 접는다.** 그것이 한컴 자신이 하는 일임을
 정답지 바이트로 확인했고, **변환본의 한컴 렌더가 정답지와 픽셀 단위로 같음**을 확인했다.
-프로덕션 변경은 파일 하나, 함수 둘이다.
+프로덕션 변경은 어댑터 한 파일에 함수 둘, 그리고 그 fold 가 드러낸 저장 의미론 문제를
+막는 `wasm_api` 1줄이다.
 
 ## 1. 무엇이 문제였나
 
@@ -73,7 +74,8 @@ HWPX fallback      bin_data_id=1      instance_id=0           attr=0x140A2210  r
 
 ## 3. 무엇을 고쳤나
 
-프로덕션 변경은 [`hwpx_to_hwp.rs`](../../src/document_core/converters/hwpx_to_hwp.rs) **한 파일**이다.
+결함 자체의 수정은 [`hwpx_to_hwp.rs`](../../src/document_core/converters/hwpx_to_hwp.rs)
+**한 파일**이다(§3-1·3-2·3-4). §3-3 은 그 fold 가 드러낸 별도 축으로, `wasm_api.rs` 1줄이다.
 
 ### 3-1. `fold_hwpx_chart_ole_for_hwp`
 
@@ -108,7 +110,33 @@ normalize_bin_data_for_hwp
 `normalize_picture_geometry_for_hwp` 보다도 앞인 이유는, 그 패스가 바깥 차트 OleShape 에 가한
 변경이 fold 로 통째로 버려지기 때문이다(오늘은 무해하나 조용히 깨질 자리다).
 
-### 3-3. 순회 — 네 번째 복제 워커를 만들지 않았다
+### 3-3. `wasm_api::exportHwp` 를 스냅숏 저장으로 옮겼다
+
+fold 는 IR 에서 `chart_id_ref` 와 `ooxml_chart` 를 **없앤다.** 어댑터가 살아 있는 IR 을
+직접 정규화하므로, HWP 로 한 번 저장한 뒤 같은 핸들로 HWPX 를 내보내면
+`write_ole_or_chart` 가 `hp:switch/case/default` 대신 `hp:ole` 단독을 방출하고
+`Chart/chart1.xml` 파트가 빠진다 — **#3546 계약이 저장 한 번으로 깨진다.** 실측했다.
+
+```text
+[HWP 저장 전]  Chart 파트=1  hp:chart=1  hp:switch=1
+[HWP 저장 후]  Chart 파트=0  hp:chart=0  hp:switch=0   ← 수정 전
+```
+
+**이건 새 종류의 문제가 아니다.** `export_hwp_with_adapter_snapshot` 이 정확히 이 부류를
+위해 이미 있었고(주석: *"저장은 스냅숏이어야 하므로"*), 같은 원인의 다른 증상인 누름틀
+`field_ranges` 어긋남도 거기 적혀 있다. CLI edit 경로만 이관돼 있고 wasm 은 남아 있었다.
+#4099 가 그 미완 이관의 증상을 하나 더 늘렸으므로 여기서 마무리했다.
+
+우회가 아니라 **원인 제거**다 — 저장이라는 읽기 연산이 IR 을 바꾸지 않게 한다. fold 는
+복제본에서 그대로 돌아 HWP 산출물은 동일하다(정크 0, `bin_data_id=1` 확인).
+
+| 측정 | 결과 |
+|---|---|
+| 전체 스위트 회귀 | **0건** — 503 blocks / 5572 passed, 기준선과 완전 동일 |
+| 되돌렸을 때 | T7 red: `(1,1,1) → (0,0,0)` |
+| 비용 | 브라우저 HWP 저장 시 `Document` clone 1회 |
+
+### 3-4. 순회 — 네 번째 복제 워커를 만들지 않았다
 
 이 파일에는 거의 같은 재귀 워커가 이미 넷 있다. 좁은 타입 `for_each_ole_mut` 를 두고 골격만
 `normalize_picture_geometry_for_hwp` 쪽에서 가져왔다 — 넷 중 커버리지가 가장 넓어
@@ -180,7 +208,7 @@ fold 를 임시로 끄면 `ole.bin_data_id` 가 `60001` 로 남아 red 임을 �
 | `issue_4055_b1_chart_edit_probe` | 9/9 green + 1 ignored, 무수정 |
 | `hwpx_to_hwp_adapter` | 50/50 green, 무수정 |
 | `convert_verify_corpus_ratchet` | 4/4 green (코퍼스 확장) |
-| `issue_4099_hwpx_chart_to_hwp` (신규) | 9/9 green + 1 ignored |
+| `issue_4099_hwpx_chart_to_hwp` (신규) | 10/10 green + 1 ignored |
 
 `issue_4055::editing_only_the_zip_part_is_lost_when_converting_to_hwp` 가 green 인 것은
 **호출 순서 덕분이다** — `export_hwpx_native()` 를 `export_hwp_with_adapter()` 보다 먼저
@@ -251,30 +279,38 @@ A 는 **26B OLE 레코드**와 **flip = 0** 을 가진 채로 정답지와 픽�
 
 `Document::next_bin_data_storage_id` 는 `max(bin_data_content.id, bin_data_list.storage_id) + 1`
 을 채번한다. 차트 문서는 `bin_data_content` 에 **60001** 이 있으므로, 그림을 삽입하면
-`storage_id = 60002` 가 배정된다. 그런데 `materialize_hwp5_bin_data_order` 의 `bin_count` 는
-`bin_data_list.len()`(=2)이고 `push_bin_order` 는 `id > bin_count` 를 버리므로 **그 항목이
-순서 수집에서 조용히 탈락한다.**
+`storage_id = 60002` 가 배정된다.
+
+**추론이 아니라 재현했다.** 차트 hwpx 를 열고 `insert_picture_native` 로 그림 하나를 넣었다.
+
+```text
+삽입 후    bin_data_content=[(1,"OLE"), (60001,"ooxml_chart"), (60002,"png")]
+           bin_data_list   =[(1,Storage), (60002,Embedding)]
+HWP  저장  /BinData/BINEA62.png          ← #4099 가 고친 것과 같은 계열의 규격 밖 이름
+HWPX 저장  실패: <hp:pic> binaryItemIDRef 미등록 bin_data_id=3 (BinDataContent 누락)
+           BinData/image1.OLE, BinData/image60002.png
+```
+
+**차트 문서에 그림을 넣으면 HWPX 저장이 아예 깨진다.** HWP 저장은 열리지만 스트림 이름이
+`BINEA62.png`(0xEA62 = 60002)라 규격 밖이다. 덧붙여 `materialize_hwp5_bin_data_order` 의
+`bin_count` 는 `bin_data_list.len()`(=2)이고 `push_bin_order` 는 `id > bin_count` 를 버리므로
+**그 항목이 순서 수집에서도 조용히 탈락한다.**
 
 #4099 의 fold 로는 안 고쳐진다 — 오염은 **live HWPX IR**(편집 시점)에서 일어나고 fold 는
 HWP 저장 시점이다. 재현은 **저장 전에** 해야 한다.
 
-### 7-2. 어댑터가 live IR 을 파괴해 HWPX 재방출이 깨진다 (R1)
+닫힌 [#2038](https://github.com/edwardkim/rhwp/issues/2038)("신규 그림 BinData storage id
+순번 채번 — 기존 id 충돌 시 저장에서 이미지 뒤바뀜/소실")이 이 채번 함수를 만들었고, 그때는
+차트 sentinel 이라는 변수가 없었다. 그 후속이다.
 
-`wasm_api::exportHwp` 는 in-place 어댑터를 쓴다. #4099 의 fold 이후, 브라우저 핸들로 곧바로
-`exportHwpx` 를 누르면 `chart_id_ref == None` 이라 `write_ole_or_chart` 가
-`hp:switch/case/default` 대신 **`hp:ole` 단독**을 방출하고, `bin_data_content` 에서 차트가
-빠져 **`Chart/chart1.xml` 파트가 패키지에서 누락**된다. **#3546 이 세운 "차트 원형 보존"
-계약이 HWP 저장 한 번으로 깨진다.** #4319 로 `write_chart_element` 에 캡션 방출이 붙어 캡션
-경로도 함께 영향받는다.
+> **R1(어댑터 live-IR 파괴)은 spin-off 에서 빠졌다** — 실측 결과 1줄 · 회귀 0 으로
+> 해소돼 §3-3 에서 이 PR 에 담았다. 이 PR 이 만든 증상이므로 이 PR 에서 치우는 것이 맞다.
+>
+> `issue_4055::editing_only_the_zip_part_is_lost_when_converting_to_hwp` 가 계속 green 인
+> 것은 `export_hwpx_native()` 를 `export_hwp_with_adapter()` 보다 먼저 부르는 **호출 순서
+> 덕분**이었다. 순서가 반대였으면 깨졌다. 이제 그 우연에 기대지 않는다.
 
-렌더는 중첩 `OOXMLChartContents` 로 살아남으므로 치명적이지는 않으나, 어댑터의 다른 in-place
-변형과 달리 **이것은 페이로드 삭제**라 종류가 다르다. 후보 수정은
-`export_hwp_with_adapter_snapshot()` 사용(1줄, `Document` clone 1회 비용).
-
-`issue_4055::editing_only_the_zip_part_is_lost_when_converting_to_hwp` 가 지금 green 인 것은
-호출 순서 덕분이며, 그 사실이 이 결함의 축소판이다.
-
-### 7-3. `hwpx_to_hwp.rs` 의 IR 워커 다섯을 하나로 통합
+### 7-2. `hwpx_to_hwp.rs` 의 IR 워커 다섯을 하나로 통합
 
 거의 같은 재귀 워커가 다섯이고 커버리지가 제각각이다. 이 표가 근거다.
 
@@ -301,7 +337,8 @@ HWP 저장 시점이다. 재현은 **저장 전에** 해야 한다.
 | 경로 | 내용 |
 |---|---|
 | `src/document_core/converters/hwpx_to_hwp.rs` | `fold_hwpx_chart_ole_for_hwp` · `for_each_ole_mut` · `AdapterReport` 3필드 |
-| `tests/issue_4099_hwpx_chart_to_hwp.rs` | 게이트 9건 + 판정 번들 생성기 1건(ignore) |
+| `src/wasm_api.rs` | `exportHwp` → `export_hwp_with_adapter_snapshot` (1줄) |
+| `tests/issue_4099_hwpx_chart_to_hwp.rs` | 게이트 10건 + 판정 번들 생성기 1건(ignore) |
 | `tests/support/issue_4055_chart_probe.rs` | `append_hwpx_entries` 추가 |
 | `tests/convert_verify_corpus_ratchet.rs` | `samples/chart` 재귀 병합 |
 | `output/issue_4099/` | 한컴 판정 5파일 + `PANJEONG.md` + 작업지시자가 한컴 2022 로 변환한 PDF 2건 + 144DPI PNG 2건 (gitignored) |

--- a/mydocs/report/task_m100_4099_report.md
+++ b/mydocs/report/task_m100_4099_report.md
@@ -132,7 +132,7 @@ fold 는 IR 에서 `chart_id_ref` 와 `ooxml_chart` 를 **없앤다.** 어댑터
 
 | 측정 | 결과 |
 |---|---|
-| 전체 스위트 회귀 | **0건** — 503 blocks / 5572 passed, 기준선과 완전 동일 |
+| 전체 스위트 회귀 | **0건** — 503 blocks / 5572 passed, 전환 전 기준선과 완전 동일 |
 | 되돌렸을 때 | T7 red: `(1,1,1) → (0,0,0)` |
 | 비용 | 브라우저 HWP 저장 시 `Document` clone 1회 |
 
@@ -217,7 +217,7 @@ fold 를 임시로 끄면 `ole.bin_data_id` 가 `60001` 로 남아 red 임을 �
 전체 스위트(`cargo test --profile release-test --tests`, 로그 `$TMPDIR/task4099_full_test.log`):
 
 ```text
-503개 결과 블록 — 5572 passed, 0 failed, 36 ignored (exit 0)
+503개 결과 블록 — 5573 passed, 0 failed, 36 ignored (exit 0)
 ```
 
 `cargo fmt --check` 는 `Diff in` 0건(Windows CRLF 로 exit 1 이나 실제 차이 없음),
@@ -273,42 +273,103 @@ A 는 **26B OLE 레코드**와 **flip = 0** 을 가진 채로 정답지와 픽�
 
 `issue_1251_ole_chart_contents` 의 `len == 26` 단언은 그대로 유효하다.
 
-## 7. Spin-off 이슈 초안 (미등록 — 승인 대기)
+## 7. 범위 밖으로 남긴 것
 
-### 7-1. `next_bin_data_storage_id` 가 차트 sentinel 에 오염된다
+새 이슈는 열지 않는다. 아래 7-1 은 **이미 등록된 이슈 세 건의 근인**이라 네 번째를 만들면
+중복만 늘어난다. 대신 PR 본문에 이슈 번호를 적어 GitHub 크로스 레퍼런스로 연결한다.
 
-`Document::next_bin_data_storage_id` 는 `max(bin_data_content.id, bin_data_list.storage_id) + 1`
-을 채번한다. 차트 문서는 `bin_data_content` 에 **60001** 이 있으므로, 그림을 삽입하면
-`storage_id = 60002` 가 배정된다.
+### 7-1. HWPX 직렬화기가 `bin_data_id`(위치)를 `storage_id` 로 오해한다
 
-**추론이 아니라 재현했다.** 차트 hwpx 를 열고 `insert_picture_native` 로 그림 하나를 넣었다.
+**이미 열린 이슈 세 건의 근인이다.**
 
-```text
-삽입 후    bin_data_content=[(1,"OLE"), (60001,"ooxml_chart"), (60002,"png")]
-           bin_data_list   =[(1,Storage), (60002,Embedding)]
-HWP  저장  /BinData/BINEA62.png          ← #4099 가 고친 것과 같은 계열의 규격 밖 이름
-HWPX 저장  실패: <hp:pic> binaryItemIDRef 미등록 bin_data_id=3 (BinDataContent 누락)
-           BinData/image1.OLE, BinData/image60002.png
+| 이슈 | 샘플 | 보고된 증상 |
+|---|---|---|
+| [#3893](https://github.com/edwardkim/rhwp/issues/3893) | `pic-crop-01.hwp` | `binaryItemIDRef 미등록 bin_data_id=1` → `controls: expected=[pic] actual=[]` |
+| [#4049](https://github.com/edwardkim/rhwp/issues/4049) | `exam_social.hwp` | `bin_data_id=5, 6 미등록` → 같은 형태 |
+| [#4303](https://github.com/edwardkim/rhwp/issues/4303) | `exam_social.hwp` | **#4049 와 중복** (같은 샘플·id·차이 위치, 본문이 임시 경로만 다름) |
+
+셋 다 자동 스윕이 등재한 것으로 *"자동 수정이 red→green 게이트를 넘지 못해 이슈로만 보고"*
+상태이고 **근인이 규명돼 있지 않다.** 닫힌 [#3526](https://github.com/edwardkim/rhwp/issues/3526)
+(`hwpspec.hwp`)에도 같은 경고(`bin_data_id=37 미등록`)가 있었으나 IR 차이 1149건 중 대부분이
+`char_shapes` 축이라 그쪽으로 닫히면서 이 축은 남은 것으로 보인다. 즉 최소 2026-07-28 부터
+관측됐는데 스윕이 같은 증상을 계속 재등록해 왔다.
+
+#### 근인
+
+HWP5 규격상 `ImageAttr.bin_data_id` 는 **DocInfo BinData 레코드 순번(1-based)** 이고
+`storage_id`(CFB 스트림 이름을 정하는 번호)와 다를 수 있다
+(`mydocs/troubleshootings/bin_data_id_index_mapping.md`). 렌더의 `find_bin_data` 는 이 규약대로
+순번을 먼저 본다. **HWPX 직렬화기만 그 값을 `storage_id` 로 읽는다.**
+
+```rust
+// src/serializer/hwpx/context.rs
+let manifest_id = format!("image{}", bd.id);   // bd = BinDataContent → id 는 storage_id
+ctx.bin_data_map.insert(bd.id, ..);            // 키 = storage_id
+..
+pub fn resolve_bin_id(&self, bin_data_id: u16) -> Option<&str>   // 인자는 컨트롤의 "위치"
 ```
 
-**차트 문서에 그림을 넣으면 HWPX 저장이 아예 깨진다.** HWP 저장은 열리지만 스트림 이름이
-`BINEA62.png`(0xEA62 = 60002)라 규격 밖이다. 덧붙여 `materialize_hwp5_bin_data_order` 의
-`bin_count` 는 `bin_data_list.len()`(=2)이고 `push_bin_order` 는 `id > bin_count` 를 버리므로
-**그 항목이 순서 수집에서도 조용히 탈락한다.**
+두 값이 같은 문서에서는 우연히 맞는다. 어긋나면 `resolve_bin_id` 가 실패하고 호출자가
+**pic 컨트롤을 드롭한 뒤 stderr 경고만 남기고 저장을 성공으로 마친다.**
 
-#4099 의 fold 로는 안 고쳐진다 — 오염은 **live HWPX IR**(편집 시점)에서 일어나고 fold 는
-HWP 저장 시점이다. 재현은 **저장 전에** 해야 한다.
+[#2038](https://github.com/edwardkim/rhwp/issues/2038)(닫힘)이 `next_bin_data_storage_id` 를
+만들며 두 번호를 **의도적으로 분리**했고, 그 본문이 *"`ImageAttr.bin_data_id` 는 기존대로
+순번(위치) 유지 — `find_bin_data` 의 위치 우선 해석과의 정합을 깨지 않음"* 이라고 적고 있다.
+렌더 축만 확인했고 HWPX 직렬화기 축은 보지 않았다.
 
-닫힌 [#2038](https://github.com/edwardkim/rhwp/issues/2038)("신규 그림 BinData storage id
-순번 채번 — 기존 id 충돌 시 저장에서 이미지 뒤바뀜/소실")이 이 채번 함수를 만들었고, 그때는
-차트 sentinel 이라는 변수가 없었다. 그 후속이다.
+#### 영향 범위 — 차트 밖에서도 난다
 
-> **R1(어댑터 live-IR 파괴)은 spin-off 에서 빠졌다** — 실측 결과 1줄 · 회귀 0 으로
-> 해소돼 §3-3 에서 이 PR 에 담았다. 이 PR 이 만든 증상이므로 이 PR 에서 치우는 것이 맞다.
->
-> `issue_4055::editing_only_the_zip_part_is_lost_when_converting_to_hwp` 가 계속 green 인
-> 것은 `export_hwpx_native()` 를 `export_hwp_with_adapter()` 보다 먼저 부르는 **호출 순서
-> 덕분**이었다. 순서가 반대였으면 깨졌다. 이제 그 우연에 기대지 않는다.
+`samples/` 최상위 `.hwp` 를 훑어 `storage_id` 가 순번과 어긋나는 문서를 골랐다.
+
+```text
+검사 83건 / storage_id 불일치 4건 / 그림 완전 소실 2건
+
+· pic-crop-01.hwp         storage_id=[3]            IR그림=2 → hp:pic=0   ← 소실 (#3893)
+· hwp3-sample10-hwp5.hwp  storage_id=[0,0,0]        IR그림=3 → hp:pic=0   ← 소실
+· exam_social.hwp         storage_id=[1,2,3,4,7,8]  bin_data_id=5,6 미등록 (#4049·#4303)
+· table-in-tbox.hwp       storage_id=[6,7,8,1,..]   본문 그림 0개 — 무증상
+```
+
+#### 차트 문서는 같은 근인의 한 변종이다
+
+`Document::next_bin_data_storage_id` 는 `max(bin_data_content.id, bin_data_list.storage_id) + 1`
+을 채번하는데, 차트 문서는 `bin_data_content` 에 sentinel **60001** 이 있어 첫 그림이
+`storage_id = 60002` 를 받는다. 그러면 순번(3)과 갈라져 위와 같은 일이 난다. 현재 HEAD 로
+재현했다.
+
+```text
+삽입 후 IR   content=[(1,"OLE"), (60001,"ooxml_chart"), (60002,"png")]
+             list   =[(1,Storage), (60002,Embedding)]
+
+HWPX 저장    Ok      hp:pic=0   재파싱 Picture 컨트롤 0개   ← 그림이 조용히 사라진다
+HWP  저장    Ok      Picture bin_data_id=[3] / DocInfo storage_id=[1,60002] → dangling
+                     /BinData/BINEA62.png (0xEA62 = 60002)
+대조군(차트 없음)     position_id = 4 == storage_id = 4 → HWPX 저장 정상
+```
+
+**저장은 성공하고 오류도 없다. 그림만 없어진다.** 렌더는 positional 조회 덕에 살아남아
+**화면은 멀쩡한데 저장만 깨지므로** 눈으로는 알아채기 어렵다.
+
+> 이 진단은 두 번 고쳤다. 처음에는 "차트 sentinel 이 근인이고 HWPX 저장이 실패한다"로
+> 적었으나 둘 다 틀렸다 — 저장은 `Ok` 를 반환하고(실패보다 나쁘다, 사용자가 알 수 없다),
+> sentinel 은 근인이 아니라 위치↔storage_id 불일치를 **드러내는 계기**다. 작업지시자가
+> "기존 이슈 중 비슷한 게 있는지 확인해 보라"고 짚어 준 덕에 이미 등록된 세 건에 닿았고,
+> 그 과정에서 범위가 차트 밖으로 넓다는 것이 드러났다.
+
+#### #4099 와의 관계
+
+**이 PR 의 fold 로는 안 고쳐진다.** 오염은 편집 시점의 live IR 에서 일어나고 fold 는 HWP
+저장 시점에 돈다. 재현은 반드시 저장 전에 해야 한다. `bin_count > 1` 회귀 테스트
+(§5-1)의 합성은 매니페스트 순번으로 조립해 이 결함을 비켜 가므로 그대로 재사용할 수 없다.
+
+#### 수정 방향
+
+`resolve_bin_id` 가 위치로 조회하도록 `bin_data_map` 을 순번 키로 바꾸는 것이 규격에 맞는다.
+HWPX 출처 문서는 파서가 `storage_id = i + 1` 로 만들어 두 값이 같으므로 그 축은 무영향이고,
+**HWP→HWPX 축만 달라진다.** 차트 sentinel 은 `next_bin_data_storage_id` 에서 60000+N 대역을
+제외하면 함께 정리된다(그 대역은 네 곳에 매직 넘버로 하드코딩돼 있어 상수화가 선행되면 좋다).
+
+착수 시점은 미정이다.
 
 ### 7-2. `hwpx_to_hwp.rs` 의 IR 워커 다섯을 하나로 통합
 
@@ -326,11 +387,29 @@ HWP 저장 시점이다. 재현은 **저장 전에** 해야 한다.
 
 ## 8. 이 작업에서 배운 것
 
-**조사 근거 자체가 낡을 수 있다.** 계획 수립 중 로컬 `devel` 이 `upstream/devel` 보다
-**475 커밋** 뒤처진 상태였고, 작업지시자 지적으로 잡았다. 재검증 결과 골격(변환기 전체 무변경,
-60000+N 주입, 정크 폴백, verify 판정, 래칫 비재귀)은 유지됐으나 **두 건이 설계를 바꿨다** —
-#4319 가 캡션 축을 만들었고, #4171 이 fold 불가 경로의 기각 근거를 무효화했다. 계획서에
-기준 커밋 SHA 를 명시하는 관례를 함께 넣었다.
+### 8-1. 조사 근거 자체가 낡을 수 있다
+
+계획 수립 중 로컬 `devel` 이 `upstream/devel` 보다 **475 커밋** 뒤처진 상태였고, 작업지시자
+지적으로 잡았다. 재검증 결과 골격(변환기 전체 무변경, 60000+N 주입, 정크 폴백, verify 판정,
+래칫 비재귀)은 유지됐으나 **두 건이 설계를 바꿨다** — #4319 가 캡션 축을 만들었고, #4171 이
+fold 불가 경로의 기각 근거를 무효화했다. 계획서에 기준 커밋 SHA 를 명시하는 관례를 함께 넣었다.
+
+### 8-2. 근인을 찾았다고 새 이슈부터 열면 안 된다
+
+§7-1 을 처음에는 "새로 등록할 spin-off 이슈 초안"으로 썼다. 작업지시자가 *"기존 이슈 중
+비슷한 게 있는지 확인해 보라"* 고 짚어 준 뒤에야 **이미 세 건(#3893·#4049·#4303)이 같은
+증상으로 열려 있고 그중 둘은 서로 중복**이라는 것을 알았다. 그대로 등록했으면 네 번째 중복이
+됐다.
+
+검색이 처음부터 쉬웠던 것도 아니다. "그림 소실", "storage_id 채번" 같은 **내가 이해한 근인**
+으로는 하나도 안 나왔고, **도구가 뱉은 오류 문자열**(`binaryItemIDRef`)로 검색했을 때 한 번에
+나왔다. 자동 스윕이 등재한 이슈는 사람이 요약한 제목이 아니라 CLI 출력을 그대로 담고 있기
+때문이다. `docs_and_git_workflow.md` 가 *"패닉 메시지·오류 문자열은 외부 리포트에 원문 그대로
+실리는 경우가 많아 검색어로 효과적"* 이라고 적어 둔 그대로였다.
+
+그리고 그 검색이 **결함의 범위까지 바꿨다.** 차트 전용인 줄 알았던 것이 실은
+`storage_id ≠ 순번` 인 모든 문서의 문제였고(코퍼스 83건 중 4건, 그중 2건 그림 완전 소실),
+차트 sentinel 은 그것을 드러내는 계기였을 뿐이다.
 
 ## 9. 산출물
 

--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -23,7 +23,7 @@ use crate::model::control::Control;
 use crate::model::document::{Document, HwpVersion, Section, SectionDef};
 use crate::model::image::Picture;
 use crate::model::paragraph::Paragraph;
-use crate::model::shape::{common_obj_offsets, ShapeObject, TextBox};
+use crate::model::shape::{common_obj_offsets, OleShape, ShapeObject, TextBox};
 use crate::model::style::{BorderFill, BorderLineType, Fill, FillType};
 use crate::model::table::{Cell, Table, TablePageBreak};
 use crate::parser::FileFormat;
@@ -112,6 +112,12 @@ pub struct AdapterReport {
     /// 보강되지만 그림은 빠져 있었다(전 코퍼스 실측 80/80 이 개체 종류와 무관하게
     /// 이 비트를 요구).
     pub picture_caption_common_attr_materialized: u32,
+    /// [#4099] HWPX `<hp:chart>` OleShape 를 `<hp:default>` fallback OLE 로 접은 횟수.
+    pub chart_ole_folded_to_fallback: u32,
+    /// [#4099] fallback 이 없어 접지 못하고 참조만 비운 차트 OleShape 수.
+    pub chart_ole_without_fallback: u32,
+    /// [#4099] HWP5 산출에서 제거한 `ooxml_chart` BinDataContent 수.
+    pub chart_bin_data_contents_removed: u32,
 }
 
 impl AdapterReport {
@@ -161,7 +167,10 @@ impl AdapterReport {
                 + self.master_page_autonum_placeholder_removed
                 + self.master_page_line_rendering_size_ratio_materialized
                 + self.master_page_apply_slots_materialized
-                + self.picture_caption_common_attr_materialized)
+                + self.picture_caption_common_attr_materialized
+                + self.chart_ole_folded_to_fallback
+                + self.chart_ole_without_fallback
+                + self.chart_bin_data_contents_removed)
                 > 0
     }
 }
@@ -202,6 +211,10 @@ fn convert_to_hwp_ir(doc: &mut Document, source_is_hwpx: bool) -> AdapterReport 
 
     normalize_file_header_for_hwp(doc, &mut report);
     normalize_page_border_fills_for_hwp(doc);
+    // [#4099] 도형을 건드리는 첫 패스여야 한다 — 뒤 패스가 바깥 차트 OleShape 에 가한
+    // 변경은 fold 로 통째로 버려지고, BinData 순서 materialize 는 fold 가 올려놓은
+    // 진짜 `bin_data_id` 를 봐야 remap 이 맞는다.
+    fold_hwpx_chart_ole_for_hwp(doc, &mut report);
     normalize_picture_geometry_for_hwp(doc, source_is_hwpx);
     normalize_doc_properties_for_hwp(doc, &mut report);
     materialize_hwp5_bin_data_order(doc, &mut report);
@@ -229,6 +242,231 @@ fn convert_to_hwp_ir(doc: &mut Document, source_is_hwpx: bool) -> AdapterReport 
     }
 
     report
+}
+
+/// HWPX 파서가 `Chart/chartN.xml` 파트에 붙이는 확장자 표식
+/// (`parser/hwpx/mod.rs`, Task #195 규약).
+const OOXML_CHART_EXTENSION: &str = "ooxml_chart";
+
+/// 모든 `OleShape` 를 가변으로 방문한다.
+///
+/// 순회 골격은 `normalize_picture_geometry_for_hwp` 에서 가져왔다 — 이 파일의 네 워커
+/// 중 컨테이너 커버리지가 가장 넓은 쪽이다.
+///
+/// | 컨테이너 | bin order(`collect_bin_order_*`) | bin ref remap(`remap_bin_refs_*`) | 이 워커 |
+/// |---|---|---|---|
+/// | 표 셀 · 그룹 자식 · 머리말/꼬리말/각주/미주/숨은설명 | ✓ | ✓ | ✓ |
+/// | `drawing.text_box` · `drawing.caption` | ✓ | ✓ | ✓ |
+/// | `pic`/`group`/`chart`/`ole` own caption | 일부 | 일부 | ✓ |
+/// | `Control::Field.memo_paragraphs` | ✗ | ✗ | ✓ |
+/// | `Control::SectionDef.master_pages` | ✗ | ✗ | ✓ |
+///
+/// 네 워커를 하나의 visitor 로 통합하는 것은 커버리지가 서로 달라 동작이 바뀔 수 있는
+/// 별개 리팩터다 — 여기서는 좁은 타입으로만 골격을 재사용한다.
+///
+/// `chart_switch_fallback` 안쪽은 방문하지 않는다. HWPX 파서는 fallback 안에 또 다른
+/// 차트를 만들지 않고, `fold_hwpx_chart_ole_for_hwp` 가 그 상자를 곧 없앤다.
+fn for_each_ole_mut(doc: &mut Document, f: &mut dyn FnMut(&mut OleShape)) {
+    fn walk_paragraphs(paragraphs: &mut [Paragraph], f: &mut dyn FnMut(&mut OleShape)) {
+        for para in paragraphs {
+            walk_controls(&mut para.controls, f);
+        }
+    }
+
+    fn walk_caption(caption: &mut crate::model::shape::Caption, f: &mut dyn FnMut(&mut OleShape)) {
+        walk_paragraphs(&mut caption.paragraphs, f);
+    }
+
+    fn walk_master_pages(
+        master_pages: &mut [crate::model::header_footer::MasterPage],
+        f: &mut dyn FnMut(&mut OleShape),
+    ) {
+        for master_page in master_pages {
+            walk_paragraphs(&mut master_page.paragraphs, f);
+        }
+    }
+
+    fn walk_drawing(
+        drawing: &mut crate::model::shape::DrawingObjAttr,
+        f: &mut dyn FnMut(&mut OleShape),
+    ) {
+        if let Some(text_box) = &mut drawing.text_box {
+            walk_paragraphs(&mut text_box.paragraphs, f);
+        }
+        if let Some(caption) = &mut drawing.caption {
+            walk_caption(caption, f);
+        }
+    }
+
+    fn walk_shape(shape: &mut ShapeObject, f: &mut dyn FnMut(&mut OleShape)) {
+        match shape {
+            ShapeObject::Picture(pic) => {
+                if let Some(caption) = &mut pic.caption {
+                    walk_caption(caption, f);
+                }
+            }
+            ShapeObject::Group(group) => {
+                for child in &mut group.children {
+                    walk_shape(child, f);
+                }
+                if let Some(caption) = &mut group.caption {
+                    walk_caption(caption, f);
+                }
+            }
+            ShapeObject::Chart(chart) => {
+                walk_drawing(&mut chart.drawing, f);
+                if let Some(caption) = &mut chart.caption {
+                    walk_caption(caption, f);
+                }
+            }
+            ShapeObject::Ole(ole) => {
+                // 캡션·글상자를 먼저 훑는다. `f` 가 fold 로 OleShape 를 통째로
+                // 갈아끼우므로, 뒤에 방문하면 교체된 쪽을 다시 보게 된다.
+                walk_drawing(&mut ole.drawing, f);
+                if let Some(caption) = &mut ole.caption {
+                    walk_caption(caption, f);
+                }
+                f(ole);
+            }
+            _ => {
+                if let Some(drawing) = shape.drawing_mut() {
+                    walk_drawing(drawing, f);
+                }
+            }
+        }
+    }
+
+    fn walk_controls(controls: &mut [Control], f: &mut dyn FnMut(&mut OleShape)) {
+        for control in controls {
+            match control {
+                Control::Picture(pic) => {
+                    if let Some(caption) = &mut pic.caption {
+                        walk_caption(caption, f);
+                    }
+                }
+                Control::Shape(shape) => walk_shape(shape, f),
+                Control::Table(table) => {
+                    for cell in &mut table.cells {
+                        walk_paragraphs(&mut cell.paragraphs, f);
+                    }
+                    if let Some(caption) = &mut table.caption {
+                        walk_caption(caption, f);
+                    }
+                }
+                Control::Header(header) => walk_paragraphs(&mut header.paragraphs, f),
+                Control::Footer(footer) => walk_paragraphs(&mut footer.paragraphs, f),
+                Control::Footnote(footnote) => walk_paragraphs(&mut footnote.paragraphs, f),
+                Control::Endnote(endnote) => walk_paragraphs(&mut endnote.paragraphs, f),
+                Control::HiddenComment(comment) => walk_paragraphs(&mut comment.paragraphs, f),
+                Control::Field(field) => walk_paragraphs(&mut field.memo_paragraphs, f),
+                Control::SectionDef(section_def) => {
+                    walk_master_pages(&mut section_def.master_pages, f)
+                }
+                _ => {}
+            }
+        }
+    }
+
+    for section in doc.sections.iter_mut() {
+        walk_paragraphs(&mut section.paragraphs, f);
+        walk_master_pages(&mut section.section_def.master_pages, f);
+    }
+}
+
+/// [#4099] HWPX 차트를 HWP5 가 참조할 수 있는 OLE 하나로 접는다.
+///
+/// HWPX 파서는 `<hp:switch>` 의 `<hp:case>` 브랜치를 채택해 **가상 id**
+/// `bin_data_id = 60000+N` 을 세우고, `<hp:default>` 의 진짜 OLE 를
+/// `chart_switch_fallback` 에 매달아 둔다(#3546 — HWPX 저장 시 원형 재방출의 재료).
+/// 그 가상 id 는 zip 파트 `Chart/chartN.xml` 을 가리키므로 **HWP5 에는 대응물이 없다.**
+/// 손대지 않으면 세 가지가 한꺼번에 깨진다.
+///
+/// - `serialize_ole_data` 가 `60001` 을 그대로 기록 → HWP5 DocInfo 에 없는 storage 참조
+/// - `find_bin_data_info_with_compress` 폴백이 `/BinData/BINEA61.ooxml_chart` 라는
+///   **DocInfo 미등록 정크 스트림**을 만든다
+/// - 재파싱이 그 스트림을 읽지 않아 `--verify` 가 `bin_data_content count` 로 실패
+///
+/// ## 왜 fallback 을 통째로 채택하는가
+///
+/// 한컴이 저장한 같은 문서의 `.hwp` 를 대조하면 답이 나온다. GenShape CTRL_HEADER 의
+/// `instance_id` 가 **0** 인데, 이는 `<hp:default><hp:ole instid="0">` 의 값이지
+/// `<hp:chart id="1117817146">` 의 값이 아니다 — **한컴 자신의 HWPX→HWP5 변환도
+/// fallback 브랜치를 쓴다.** 그 OLE 가 가리키는 `BinData/ole1.ole` 안에는 한컴이 실제로
+/// 읽는 중첩 `OOXMLChartContents` 가 들어 있다(#4055 실측: 그 사본만 고쳐도 렌더에
+/// 반영된다).
+///
+/// 두 브랜치는 `sz`/`pos`/`outMargin`/`zOrder`/`textWrap` 이 전부 같고, 모델에 남는
+/// 차이는 `bin_data_id`·`instance_id`·`rotate_image`·`drawing_aspect`·`caption` 뿐이다
+/// (`parse_common_shape_children` 이 `orgSz`/`curSz`/`flip`/`lineShape` 를 IR 에 싣지
+/// 않는다). 그중 HWP5 로 나가는 것은 앞의 둘이고 둘 다 fallback 쪽이 정답이다.
+///
+/// ## fallback 이 없으면
+///
+/// `<hp:switch>` 없이 `<hp:chart>` 만 있거나 `<hp:default>` 가 빠진 case-only switch 는
+/// 접을 대상이 없다(코퍼스 0건, 파서 주석도 "아직 보지 못한 변형"). 참조를 비워
+/// 정크 스트림과 dangling 을 둘 다 막고 placeholder 로 남긴다.
+///
+/// 차트 XML 을 `mini_cfb` 로 OLE CFB 에 싸는 길도 있다 — #4097 이
+/// `build_cfb_with_root_clsid` 를 넣어 도구는 갖춰졌다. 다만 참조할 원본 CLSID 가 없어
+/// `{4C3DA137-DC90-47B9-9BED-59DAE352A280}` 를 하드코딩해야 하고, `OOXMLChartContents`
+/// 하나만 든 CFB 를 한컴이 받아들이는지는 미검증이다(#4055 는 기존 CFB 를 수정했을 뿐
+/// 새로 만들지 않았다). 실물 변종이 관측되면 그때 채운다.
+fn fold_hwpx_chart_ole_for_hwp(doc: &mut Document, report: &mut AdapterReport) {
+    let mut folded = 0u32;
+    let mut orphaned = 0u32;
+
+    for_each_ole_mut(doc, &mut |ole: &mut OleShape| {
+        if ole.chart_id_ref.is_none() {
+            return;
+        }
+        match ole.chart_switch_fallback.take() {
+            Some(fallback) => {
+                // [#4319] 파서가 `<hp:chart>` 와 `<hp:default><hp:ole>` 양쪽의
+                // `<hp:caption>` 을 읽는다. 실물은 두 브랜치가 같은 캡션을 중복
+                // 기록하지만, chart 쪽에만 있는 경우 fallback 채택으로 조용히
+                // 사라지지 않게 이월한다.
+                let chart_caption = ole.caption.take();
+                *ole = *fallback;
+                if ole.caption.is_none() {
+                    ole.caption = chart_caption;
+                }
+                debug_assert!(
+                    ole.chart_id_ref.is_none() && ole.chart_switch_fallback.is_none(),
+                    "fallback 브랜치에는 HWPX 차트 표식이 없어야 한다 — 멱등성 계약"
+                );
+                debug_assert!(
+                    ole.raw_tag_data.is_empty(),
+                    "HWPX 출신 OleShape 는 raw_tag_data 가 비어 있어야 한다 \
+                     (비면 serialize_ole_data 가 bin_data_id 필드를 무시한다)"
+                );
+                folded += 1;
+            }
+            None => {
+                ole.bin_data_id = 0;
+                ole.chart_id_ref = None;
+                orphaned += 1;
+            }
+        }
+    });
+
+    // 차트 XML 은 HWP5 에 담을 자리가 없다. 남기면 `cfb_writer` 폴백이 DocInfo 미등록
+    // 정크 스트림을 만들고 `--verify` 가 개수 불일치로 실패한다. 한컴이 읽는 표현은
+    // 중첩 CFB 안의 `OOXMLChartContents` 사본이므로 내용 손실도 없다.
+    let before = doc.bin_data_content.len();
+    doc.bin_data_content
+        .retain(|content| content.extension != OOXML_CHART_EXTENSION);
+    let removed = (before - doc.bin_data_content.len()) as u32;
+
+    if orphaned > 0 {
+        eprintln!(
+            "경고: fallback OLE 가 없는 HWPX 차트 {orphaned}개는 HWP5 로 옮기지 못해 \
+             빈 개체로 남깁니다 (#4099)"
+        );
+    }
+
+    report.chart_ole_folded_to_fallback += folded;
+    report.chart_ole_without_fallback += orphaned;
+    report.chart_bin_data_contents_removed += removed;
 }
 
 /// HWPX embedded BinData를 한컴 HWP 저장 관례에 맞춰 materialize한다.

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -6188,7 +6188,8 @@ impl HwpDocument {
     /// HWP 출처는 어댑터가 no-op 이므로 기존 동작과 동일.
     #[wasm_bindgen(js_name = exportHwp)]
     pub fn export_hwp(&mut self) -> Result<Vec<u8>, JsValue> {
-        self.export_hwp_with_adapter_snapshot().map_err(|e| e.into())
+        self.export_hwp_with_adapter_snapshot()
+            .map_err(|e| e.into())
     }
 
     /// 문서를 HWP5 EncryptVersion 4 비밀번호 문서로 내보낸다.

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -6188,7 +6188,7 @@ impl HwpDocument {
     /// HWP 출처는 어댑터가 no-op 이므로 기존 동작과 동일.
     #[wasm_bindgen(js_name = exportHwp)]
     pub fn export_hwp(&mut self) -> Result<Vec<u8>, JsValue> {
-        self.export_hwp_with_adapter().map_err(|e| e.into())
+        self.export_hwp_with_adapter_snapshot().map_err(|e| e.into())
     }
 
     /// 문서를 HWP5 EncryptVersion 4 비밀번호 문서로 내보낸다.

--- a/tests/convert_verify_corpus_ratchet.rs
+++ b/tests/convert_verify_corpus_ratchet.rs
@@ -57,6 +57,27 @@ fn samples_dir() -> std::path::PathBuf {
     std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("samples")
 }
 
+/// 디렉터리 아래 `.hwp`/`.hwpx` 를 재귀로 모은다 (#4099).
+///
+/// 파일명이 조각 분배와 등재 목록의 키다. `samples/chart/**` 56건은 최상위 355건과
+/// 이름이 겹치지 않고 자기들끼리도 유일함을 확인했다.
+fn collect_recursive(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_recursive(&path, out);
+        } else if matches!(
+            path.extension().and_then(|s| s.to_str()),
+            Some("hwp") | Some("hwpx")
+        ) {
+            out.push(path);
+        }
+    }
+}
+
 /// `convert --verify` 와 같은 판정: 변환 → 재파싱 → IR 비교.
 ///
 /// 비교 강도는 CLI 와 같다 — 포맷을 넘으면 대상 포맷에 자리가 없는 항목을 걷어낸다.
@@ -102,6 +123,17 @@ fn run_partition(part: usize) {
             )
         })
         .collect();
+    // [#4099] 차트 코퍼스를 재귀로 합친다.
+    //
+    // 위 수집은 비재귀라 하위 디렉터리가 통째로 빠진다(디렉터리는 확장자가 없어
+    // 필터에서 탈락한다). 그래서 `samples/chart/**` 28종 × 2포맷이 이 게이트 밖에
+    // 있었고, HWPX→HWP5 변환이 차트 참조를 끊는 결함(#4099)이 `--verify` 로 처음부터
+    // exit 3 를 내고 있었는데도 아무도 보지 못했다.
+    //
+    // `samples/` 전체를 재귀로 열지 않고 `chart` 만 합치는 이유는 범위 통제다 —
+    // 나머지 하위 디렉터리 68개는 이 이슈가 다루는 축이 아니고, 한꺼번에 넣으면
+    // 무관한 신규 실패를 이 PR 에서 등재해야 한다. 필요하면 별도 이슈로 넓힌다.
+    collect_recursive(&samples_dir().join("chart"), &mut entries);
     // 크기 내림차순으로 정렬한 뒤 인덱스로 나눈다 — 큰 문서가 한 조각에 몰리면 그 조각이
     // 전체 벽시계를 지배한다(실측: 이름순 분배 시 42/50/134/191초로 4.5배 편차).
     // 이름을 2차 키로 둬서 크기가 같아도 순서가 결정적이다.

--- a/tests/issue_4099_hwpx_chart_to_hwp.rs
+++ b/tests/issue_4099_hwpx_chart_to_hwp.rs
@@ -328,7 +328,9 @@ fn issue4099_folded_ole_matches_hancom_oracle() {
 /// (`chart_id_ref.is_some() && chart_switch_fallback.is_none()`)에 수렴한다.
 fn synth_chart_without_fallback(hwpx: &[u8]) -> Vec<u8> {
     let xml = read_zip_entry(hwpx, "Contents/section0.xml");
-    let sw_start = xml.find("<hp:switch>").expect("샘플에 <hp:switch> 가 있어야 한다");
+    let sw_start = xml
+        .find("<hp:switch>")
+        .expect("샘플에 <hp:switch> 가 있어야 한다");
     let sw_end = xml.find("</hp:switch>").expect("</hp:switch>") + "</hp:switch>".len();
     let seg = &xml[sw_start..sw_end];
     let c_start = seg.find("<hp:chart").expect("<hp:chart");
@@ -467,8 +469,12 @@ fn synth_chart_plus_picture(chart_hwpx: &[u8]) -> Vec<u8> {
     //    되게 한다. 파서는 이 순번을 그대로 storage_id 로 쓴다.
     let hpf = read_zip_entry(chart_hwpx, "Contents/content.hpf");
     let ole_item = r#"<opf:item id="ole1" href="BinData/ole1.ole" media-type="application/ole" isEmbeded="0"/>"#;
-    assert!(hpf.contains(ole_item), "manifest 의 ole1 항목을 찾지 못했다");
-    let image_item = r#"<opf:item id="image1" href="BinData/image1.png" media-type="image/png" isEmbeded="1"/>"#;
+    assert!(
+        hpf.contains(ole_item),
+        "manifest 의 ole1 항목을 찾지 못했다"
+    );
+    let image_item =
+        r#"<opf:item id="image1" href="BinData/image1.png" media-type="image/png" isEmbeded="1"/>"#;
     let hpf = hpf.replacen(ole_item, &format!("{image_item}{ole_item}"), 1);
 
     // ② 그림 문단 — XML 을 손으로 쓰지 않고 실 코퍼스에서 떼어온다. 파서가 요구하는

--- a/tests/issue_4099_hwpx_chart_to_hwp.rs
+++ b/tests/issue_4099_hwpx_chart_to_hwp.rs
@@ -646,6 +646,165 @@ fn first_picture_bin_data_id(doc: &Document) -> Option<u16> {
 }
 
 // ---------------------------------------------------------------------------
+// 수용 기준 7 — 한컴 판정 번들 (작업지시자 육안 확인용)
+// ---------------------------------------------------------------------------
+
+/// 변환본을 한컴에서 열어 차트가 보이는지 판정할 파일 묶음을 만든다.
+///
+/// ## 왜 변종을 함께 내는가
+///
+/// fold 산출본과 한컴 정답지의 `BodyText/Section0` 레코드를 전수 대조하면 차트 개체와
+/// 관련된 차이가 **정확히 둘**이다(나머지 셋은 SectionDef·PAGE_BORDER_FILL 축이라 이
+/// 이슈와 무관하다). GenShape CTRL_HEADER 46B 는 **바이트까지 같다.**
+///
+/// ```text
+/// [13] SHAPE_COMPONENT  196B  @38: 오라클 0b, 산출본 00   → flip 워드 0x000B_0000
+/// [14] SHAPE_COMPONENT_OLE   오라클 30B, 산출본 26B      → 앞 26B 는 동일, 꼬리 u32 부재
+/// ```
+///
+/// 둘 다 fold 이전부터 있던 축이고 이 PR 이 만든 것이 아니다. 26B 는
+/// `issue_1251_ole_chart_contents` 가 이미 고정하고 있어 여기서 바꾸면 그 계약이 깨진다.
+/// 그래서 **고치는 대신 변종으로 함께 내서**, 기준 7 이 실패했을 때 원인이 fold 인지
+/// 이 두 축인지 한 번에 갈리게 한다.
+///
+/// 판정이 A 에서 통과하면 B·C·D 는 볼 필요가 없다. A 만 실패하고 B 나 D 가 통과하면
+/// 레코드 길이가 원인이므로 별도 PR 로 26→30 을 다룬다.
+#[test]
+#[ignore = "output/ 에 파일을 쓴다 — 한컴 판정 직전에만 실행"]
+fn generate_hancom_judgment_bundle() {
+    use std::io::Write as _;
+
+    let out_dir = manifest("output/issue_4099");
+    std::fs::create_dir_all(&out_dir).expect("출력 디렉터리");
+
+    let hwpx = base_hwpx();
+    let oracle = std::fs::read(manifest(&format!("{BASE_SAMPLE}.hwp"))).expect("오라클");
+
+    let variants: Vec<(&str, Vec<u8>)> = vec![
+        ("00-oracle-한컴원본.hwp", oracle),
+        ("A-fold.hwp", variant(&hwpx, false, false)),
+        ("B-fold+ole30.hwp", variant(&hwpx, true, false)),
+        ("C-fold+flip.hwp", variant(&hwpx, false, true)),
+        ("D-fold+ole30+flip.hwp", variant(&hwpx, true, true)),
+    ];
+
+    let mut rows = String::new();
+    for (name, bytes) in &variants {
+        let path = out_dir.join(name);
+        std::fs::write(&path, bytes).unwrap_or_else(|e| panic!("{name} 쓰기: {e}"));
+        rows.push_str(&format!("| `{name}` | {} B | | |\n", bytes.len()));
+    }
+
+    let mut md = std::fs::File::create(out_dir.join("PANJEONG.md")).expect("판정표");
+    write!(
+        md,
+        "# #4099 한컴 판정 — HWPX→HWP5 변환본에서 차트가 보이는가\n\n\
+         원본: `{BASE_SAMPLE}.hwpx`\n\n\
+         ## 보는 법\n\n\
+         각 파일을 한글에서 연다. 확인할 것은 두 가지다.\n\n\
+         1. **오류·복구 대화상자 없이 열리는가**\n\
+         2. **막대 차트가 그려지는가** (빈 틀·선택 핸들만 보이면 실패)\n\n\
+         `00-oracle` 은 한컴이 직접 저장한 원본이다 — 이것이 목표 화면이다.\n\
+         `A` 가 통과하면 B·C·D 는 볼 필요가 없다.\n\n\
+         ## 변종\n\n\
+         | 파일 | 크기 | 열림 | 차트 보임 |\n|---|---|---|---|\n{rows}\n\
+         ## 변종이 무엇을 가르는가\n\n\
+         fold 산출본과 오라클의 Section0 레코드를 전수 대조하면 차트 개체 관련 차이가\n\
+         둘 남는다. 둘 다 fold 이전부터 있던 축이다.\n\n\
+         - **ole30** — `SHAPE_COMPONENT_OLE` 레코드가 오라클은 30B, rhwp 는 26B.\n\
+           앞 26B 는 바이트가 같고 꼬리 reserved `u32` 하나가 없다.\n\
+           `issue_1251_ole_chart_contents` 가 26B 를 고정하고 있어 이 PR 에서는 바꾸지\n\
+           않았다.\n\
+         - **flip** — `SHAPE_COMPONENT` 의 flip 워드가 오라클은 `0x000B_0000`, rhwp 는 0.\n\n\
+         A 만 실패하고 B 또는 D 가 통과하면 원인이 레코드 길이이므로 별도 PR 로 다룬다.\n\
+         전부 실패하면 fold 방향 자체를 재검토한다.\n"
+    )
+    .expect("판정표 쓰기");
+
+    println!("판정 번들: {}", out_dir.display());
+}
+
+/// fold 산출본에 진단용 변이를 얹는다.
+///
+/// 어댑터는 live IR 을 in-place 로 바꾸므로 한 번 export 해서 fold 를 적용시킨 뒤 IR 을
+/// 만지고 다시 export 한다. 두 번째 호출의 fold 는 멱등이라 no-op 이다.
+fn variant(hwpx: &[u8], ole30: bool, flip: bool) -> Vec<u8> {
+    let mut core = DocumentCore::from_bytes(hwpx).expect("HWPX 로드");
+    let _ = core.export_hwp_with_adapter().expect("fold 적용");
+    if ole30 || flip {
+        let doc = core.document_mut();
+        let ole = first_ole_mut(doc).expect("fold 후 OLE");
+        if flip {
+            // 오라클 실측값 — bit 16·17·19.
+            ole.drawing.shape_attr.flip = 0x000B_0000;
+        }
+        if ole30 {
+            // `serialize_ole_data` 는 `raw_tag_data` 가 있으면 그대로 쓴다.
+            // 26B 인코딩 + 꼬리 reserved u32 = 오라클과 같은 30B.
+            let mut raw = Vec::with_capacity(30);
+            raw.extend_from_slice(&1u32.to_le_bytes());
+            raw.extend_from_slice(&ole.extent_x.to_le_bytes());
+            raw.extend_from_slice(&ole.extent_y.to_le_bytes());
+            raw.extend_from_slice(&ole.bin_data_id.to_le_bytes());
+            raw.extend_from_slice(&[0u8; 14]);
+            debug_assert_eq!(raw.len(), 30);
+            ole.raw_tag_data = raw;
+        }
+    }
+    core.export_hwp_with_adapter().expect("변종 저장")
+}
+
+fn first_ole_mut(doc: &mut Document) -> Option<&mut OleShape> {
+    for section in &mut doc.sections {
+        for para in &mut section.paragraphs {
+            for ctrl in &mut para.controls {
+                if let Control::Shape(shape) = ctrl {
+                    if let ShapeObject::Ole(ole) = shape.as_mut() {
+                        return Some(ole);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// 판정 번들이 의도한 변이를 실제로 담는지 확인한다 — `#[ignore]` 생성기는 CI 에서
+/// 돌지 않으므로, 변이 로직만 따로 붙잡아 둔다.
+#[test]
+fn issue4099_judgment_variants_carry_their_mutations() {
+    let hwpx = base_hwpx();
+
+    let plain = variant(&hwpx, false, false);
+    let ole30 = variant(&hwpx, true, false);
+    let flip = variant(&hwpx, false, true);
+
+    let plain_doc = rhwp::parse_document(&plain).expect("A 재파싱");
+    let plain_ole = first_ole(&plain_doc).expect("A OLE");
+    assert_eq!(plain_ole.raw_tag_data.len(), 26, "현행 인코딩은 26B 다");
+    assert_eq!(plain_ole.drawing.shape_attr.flip, 0);
+
+    let ole30_doc = rhwp::parse_document(&ole30).expect("B 재파싱");
+    let ole30_ole = first_ole(&ole30_doc).expect("B OLE");
+    assert_eq!(
+        ole30_ole.raw_tag_data.len(),
+        30,
+        "B 변종은 오라클과 같은 30B 여야 한다"
+    );
+    assert_eq!(
+        ole30_ole.bin_data_id, 1,
+        "레코드를 늘려도 참조는 그대로여야 한다"
+    );
+
+    let flip_doc = rhwp::parse_document(&flip).expect("C 재파싱");
+    let flip_ole = first_ole(&flip_doc).expect("C OLE");
+    assert_eq!(
+        flip_ole.drawing.shape_attr.flip, 0x000B_0000,
+        "C 변종은 오라클 flip 워드를 실어야 한다"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // T6 — 멱등성
 // ---------------------------------------------------------------------------
 

--- a/tests/issue_4099_hwpx_chart_to_hwp.rs
+++ b/tests/issue_4099_hwpx_chart_to_hwp.rs
@@ -805,6 +805,71 @@ fn issue4099_judgment_variants_carry_their_mutations() {
 }
 
 // ---------------------------------------------------------------------------
+// T7 — HWP 저장이 live IR 을 파괴하지 않는다
+// ---------------------------------------------------------------------------
+
+/// fold 는 IR 에서 `chart_id_ref` 와 `ooxml_chart` 를 **없앤다.** 그래서 어댑터가 살아
+/// 있는 IR 을 직접 정규화하면, HWP 로 한 번 저장한 뒤 같은 핸들로 HWPX 를 내보낼 때
+/// `write_ole_or_chart` 가 `hp:switch/case/default` 대신 `hp:ole` 단독을 방출하고
+/// `Chart/chart1.xml` 파트가 패키지에서 빠진다 — **#3546 이 세운 "차트 원형 보존"
+/// 계약이 저장 한 번으로 깨진다.**
+///
+/// CLI 는 저장 직후 종료하니 관측되지 않지만 브라우저 핸들은 저장 뒤에도 살아 있다.
+/// `export_hwp_with_adapter_snapshot` 이 바로 이 부류를 위해 이미 존재했고
+/// (누름틀 `field_ranges` 어긋남이 같은 원인의 다른 증상이다), CLI edit 경로만 이관돼
+/// 있었다. `wasm_api::exportHwp` 를 그쪽으로 옮겨 원인을 없앴다.
+///
+/// 바이트 동일과 구조를 모두 단언한다 — 훗날 zip 타임스탬프 같은 것이 들어와 바이트
+/// 비교가 무뎌져도 구조 단언은 진짜 회귀를 계속 잡는다.
+#[test]
+fn issue4099_hwp_save_keeps_live_ir_intact_for_hwpx_reexport() {
+    let bytes = base_hwpx();
+    let mut doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("HWPX 로드");
+
+    let before = doc.export_hwpx().expect("HWPX 저장(HWP 저장 전)");
+    let hwp = doc.export_hwp().expect("HWP 저장");
+    let after = doc.export_hwpx().expect("HWPX 저장(HWP 저장 후)");
+
+    let shape = |hwpx: &[u8]| -> (usize, usize, usize) {
+        let names = zip_entry_names(hwpx);
+        let sec = read_zip_entry(hwpx, "Contents/section0.xml");
+        (
+            names.iter().filter(|n| n.starts_with("Chart/")).count(),
+            sec.matches("<hp:chart").count(),
+            sec.matches("<hp:switch").count(),
+        )
+    };
+    assert_eq!(
+        shape(&before),
+        (1, 1, 1),
+        "대조군 전제 — 원본은 Chart 파트와 switch/chart 구조를 갖는다"
+    );
+    assert_eq!(
+        shape(&after),
+        shape(&before),
+        "HWP 저장이 live IR 의 차트 원형을 지웠다 (#3546 계약 위반)"
+    );
+    assert_eq!(
+        before, after,
+        "HWP 저장 전후의 HWPX 재방출은 바이트까지 같아야 한다 — 저장은 읽기 연산이다"
+    );
+
+    // 산출 HWP 는 여전히 fold 결과여야 한다 — 복제본에서 어댑터가 돌았을 뿐이다.
+    let hdoc = rhwp::parse_document(&hwp).expect("HWP 재파싱");
+    assert_eq!(first_ole(&hdoc).expect("OLE").bin_data_id, 1);
+    assert!(!all_streams(&hwp)
+        .iter()
+        .any(|(n, _)| n.to_ascii_lowercase().ends_with(".ooxml_chart")));
+}
+
+fn zip_entry_names(hwpx: &[u8]) -> Vec<String> {
+    let mut z = zip::ZipArchive::new(Cursor::new(hwpx.to_vec())).expect("HWPX zip 열기");
+    (0..z.len())
+        .map(|i| z.by_index(i).expect("zip 엔트리").name().to_string())
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
 // T6 — 멱등성
 // ---------------------------------------------------------------------------
 

--- a/tests/issue_4099_hwpx_chart_to_hwp.rs
+++ b/tests/issue_4099_hwpx_chart_to_hwp.rs
@@ -1,0 +1,460 @@
+//! [Issue #4099] HWPX→HWP5 변환이 차트 참조를 끊는 결함의 회귀 게이트.
+//!
+//! ## 결함
+//!
+//! HWPX 차트는 `<hp:switch>` 의 `<hp:case>` 브랜치로 파싱돼 **가상 id**
+//! `bin_data_id = 60000+N` 을 갖는다(`parser/hwpx/section.rs`, Task #195 규약). 그 id 는
+//! HWPX zip 파트 `Chart/chartN.xml` 을 가리키며 **HWP5 에는 대응물이 없다.**
+//! `<hp:default>` 에 있는 진짜 OLE(`BinData/ole1.ole`, 중첩 CFB)는
+//! `chart_switch_fallback` 에 매달려만 있고 HWP5 저장 경로가 그것을 보지 않는다.
+//!
+//! 결과는 세 갈래다.
+//!
+//! - `serialize_ole_data`(`serializer/control.rs`)가 `60001` 을 그대로 기록 → **dangling**.
+//!   HWP5 DocInfo 의 BinData 는 `storage_id = 1` 하나뿐이다.
+//! - `find_bin_data_info_with_compress`(`serializer/cfb_writer.rs`) 폴백이
+//!   `(60001, "ooxml_chart")` 를 돌려줘 **DocInfo 미등록 정크 스트림**
+//!   `/BinData/BINEA61.ooxml_chart` 가 생긴다(0xEA61 = 60001).
+//! - `bin_data_content` 의 차트 항목이 재파싱에서 사라져 `--verify` 가
+//!   `bin_data_content count: expected=2 actual=1` 로 exit 3 을 낸다.
+//!
+//! **바이트는 멀쩡히 보존된다** — 끊어진 것은 참조뿐이다. 그래서 #4055 스파이크의
+//! 바이트 단언(`observation_hwpx_to_hwp_conversion_keeps_the_chart`)은 통과했고,
+//! rhwp 자신의 렌더가 회색 상자를 그리는 것을 아무도 보지 않았다.
+//!
+//! ## 정답지
+//!
+//! 한컴이 만든 `samples/chart/**/*.hwp` 의 CFB 는 `BinData/BIN0001.OLE` **하나뿐**이고
+//! `.ooxml_chart` 스트림이 없다. GenShape 의 `instance_id` 는 **0** 인데, 이는
+//! `<hp:default><hp:ole>`(instid="0") 의 값이지 `<hp:chart>`(@id="1117817146") 의 값이
+//! 아니다 — **한컴 자신의 HWPX→HWP5 변환도 fallback 브랜치를 채택한다.** 그러므로
+//! 수정 방향은 "차트 OleShape 를 fallback 으로 접는다" 이고, T4 가 그 근거를 고정한다.
+
+#[path = "support/issue_4055_chart_probe.rs"]
+mod chart_probe_support;
+
+use chart_probe_support::{all_streams, corpus, manifest, rewrite_hwpx};
+
+use std::io::{Cursor, Read};
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::bin_data::BinDataType;
+use rhwp::model::control::Control;
+use rhwp::model::document::Document;
+use rhwp::model::shape::{OleShape, ShapeObject};
+use rhwp::parser::cfb_reader::decompress_stream;
+use rhwp::serializer::hwpx::roundtrip::{diff_documents, strip_hwpx_to_hwp_noise, IrDiff};
+
+/// 코퍼스 하한. `samples/chart` 는 28종이고 `issue_3546_chart_preserved_on_save.rs` 도
+/// 같은 방식으로 하한을 건다 — 수집이 조용히 비면 전 단언이 공회전한다.
+const CORPUS_LEN: usize = 28;
+
+const BASE_SAMPLE: &str = "samples/chart/세로막대형/묶은세로막대형";
+
+// ---------------------------------------------------------------------------
+// 공용 헬퍼
+// ---------------------------------------------------------------------------
+
+/// HWPX 바이트를 HWP5 로 변환한다 — CLI `rhwp convert` 와 같은 경로
+/// (`main.rs` → `DocumentCore::export_hwp_with_adapter`).
+fn convert_to_hwp(hwpx: &[u8]) -> Vec<u8> {
+    let mut core = DocumentCore::from_bytes(hwpx).expect("HWPX 로드");
+    core.export_hwp_with_adapter().expect("HWP 변환")
+}
+
+/// `convert --verify` 와 같은 판정 — 변환 후 재파싱해 IR 을 대조한다.
+///
+/// `main.rs` 가 어댑터로 in-place 변형된 live IR 을 expected 로 쓰므로 여기서도
+/// 변환 후의 `core.document()` 를 기준으로 삼는다.
+fn verify_diff(hwpx: &[u8]) -> IrDiff {
+    let mut core = DocumentCore::from_bytes(hwpx).expect("HWPX 로드");
+    let out = core.export_hwp_with_adapter().expect("HWP 변환");
+    let reloaded = DocumentCore::from_bytes(&out).expect("변환본 재파싱");
+    let diff = diff_documents(core.document(), reloaded.document());
+    strip_hwpx_to_hwp_noise(diff)
+}
+
+/// 문서 트리에서 첫 OLE 도형을 찾는다. 코퍼스는 문서당 차트 1개다.
+fn first_ole(doc: &Document) -> Option<&OleShape> {
+    for section in &doc.sections {
+        for para in &section.paragraphs {
+            for ctrl in &para.controls {
+                if let Control::Shape(shape) = ctrl {
+                    if let ShapeObject::Ole(ole) = shape.as_ref() {
+                        return Some(ole);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+fn read_zip_entry(hwpx: &[u8], name: &str) -> String {
+    let mut zip = zip::ZipArchive::new(Cursor::new(hwpx.to_vec())).expect("HWPX zip 열기");
+    let mut entry = zip
+        .by_name(name)
+        .unwrap_or_else(|e| panic!("zip 엔트리 {name}: {e}"));
+    let mut s = String::new();
+    entry.read_to_string(&mut s).expect("엔트리 읽기");
+    s
+}
+
+fn base_hwpx() -> Vec<u8> {
+    std::fs::read(manifest(&format!("{BASE_SAMPLE}.hwpx"))).expect("base HWPX 읽기")
+}
+
+// ---------------------------------------------------------------------------
+// T1 — 수용 기준 1: 변환본 렌더에 placeholder 가 없다
+// ---------------------------------------------------------------------------
+
+/// 이슈 재현 명령(`convert` → `export-svg` → `grep "OLE 개체"`)의 in-process 등가물.
+///
+/// 서브프로세스 대신 `render_page_svg_native` 를 쓴다 — 같은 렌더 경로이고
+/// 실패 시 어느 샘플인지 즉시 나온다.
+#[test]
+fn issue4099_converted_hwp_renders_the_chart() {
+    let paths = corpus();
+    assert!(
+        paths.len() >= CORPUS_LEN,
+        "samples/chart 코퍼스가 예상보다 작다: {}",
+        paths.len()
+    );
+
+    let mut checked = 0usize;
+    for path in &paths {
+        let label = path.file_name().unwrap().to_string_lossy().to_string();
+        let hwpx = std::fs::read(path).unwrap_or_else(|e| panic!("{label}: 읽기 {e}"));
+        let hwp = convert_to_hwp(&hwpx);
+
+        let core = DocumentCore::from_bytes(&hwp).unwrap_or_else(|e| panic!("{label}: 재파싱 {e}"));
+        let svg = core
+            .render_page_svg_native(0)
+            .unwrap_or_else(|e| panic!("{label}: 렌더 {e}"));
+
+        assert!(
+            !svg.contains("OLE 개체 (BinData #"),
+            "{label}: 변환본이 OLE placeholder 를 그린다 — 차트 참조가 끊겼다"
+        );
+        // `hwp-ooxml-chart-fallback` 은 차트 파싱 실패 시의 회색 상자다.
+        // 뒤에 `"` 를 붙여 진짜 차트 <g> 만 센다.
+        assert!(
+            svg.contains("hwp-ooxml-chart\""),
+            "{label}: 변환본에 OOXML 차트가 렌더되지 않았다"
+        );
+        assert!(
+            !svg.contains("hwp-ooxml-chart-fallback"),
+            "{label}: 차트가 fallback placeholder 로 그려졌다"
+        );
+        checked += 1;
+    }
+    assert_eq!(checked, paths.len(), "코퍼스를 전건 검사해야 한다");
+}
+
+// ---------------------------------------------------------------------------
+// T2 — 수용 기준 2: convert --verify 가 통과한다
+// ---------------------------------------------------------------------------
+
+/// 이 축은 결함 발생 시점부터 계속 red 였다. 코퍼스가 래칫에 없었을 뿐이다
+/// (`convert_verify_corpus_ratchet.rs` 의 `read_dir(samples/)` 는 비재귀).
+#[test]
+fn issue4099_convert_verify_passes_for_chart_corpus() {
+    let paths = corpus();
+    assert!(paths.len() >= CORPUS_LEN, "코퍼스 하한");
+
+    let mut checked = 0usize;
+    for path in &paths {
+        let label = path.file_name().unwrap().to_string_lossy().to_string();
+        let hwpx = std::fs::read(path).unwrap_or_else(|e| panic!("{label}: 읽기 {e}"));
+        let diff = verify_diff(&hwpx);
+        assert!(
+            diff.is_empty(),
+            "{label}: convert --verify 차이 {}건\n{}",
+            diff.differences.len(),
+            diff.differences
+                .iter()
+                .map(|d| format!("  [차이] {d}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+        checked += 1;
+    }
+    assert_eq!(checked, paths.len());
+}
+
+// ---------------------------------------------------------------------------
+// T3 — 수용 기준 3·4: 정크 스트림이 없고 OLE 참조가 실재한다
+// ---------------------------------------------------------------------------
+
+#[test]
+fn issue4099_converted_cfb_has_no_junk_and_ole_ref_resolves() {
+    let paths = corpus();
+    assert!(paths.len() >= CORPUS_LEN, "코퍼스 하한");
+
+    let mut checked = 0usize;
+    for path in &paths {
+        let label = path.file_name().unwrap().to_string_lossy().to_string();
+        let hwpx = std::fs::read(path).unwrap_or_else(|e| panic!("{label}: 읽기 {e}"));
+        let hwp = convert_to_hwp(&hwpx);
+
+        // ① 정크 스트림 0건 (수용 기준 3)
+        let streams = all_streams(&hwp);
+        if let Some((junk, _)) = streams
+            .iter()
+            .find(|(n, _)| n.to_ascii_lowercase().ends_with(".ooxml_chart"))
+        {
+            panic!(
+                "{label}: DocInfo 미등록 정크 스트림이 생겼다: {junk} \
+                 (cfb_writer 폴백이 60000+N 을 스토리지 id 로 오해한다)"
+            );
+        }
+        assert!(
+            streams.iter().any(|(n, _)| n == "/BinData/BIN0001.OLE"),
+            "{label}: 한컴 정답지와 같은 /BinData/BIN0001.OLE 이 없다 — 스트림 {:?}",
+            streams.iter().map(|(n, _)| n).collect::<Vec<_>>()
+        );
+
+        // ② OLE 참조가 DocInfo 에 실재 (수용 기준 4)
+        let doc = rhwp::parse_document(&hwp).unwrap_or_else(|e| panic!("{label}: 재파싱 {e:?}"));
+        let ole = first_ole(&doc).unwrap_or_else(|| panic!("{label}: OLE 도형 없음"));
+        assert_eq!(
+            ole.bin_data_id, 1,
+            "{label}: OLE 가 여전히 가상 id 를 가리킨다 (한컴 정답지는 1)"
+        );
+        assert!(
+            doc.doc_info.bin_data_list.iter().any(|b| {
+                u32::from(b.storage_id) == ole.bin_data_id && b.data_type == BinDataType::Storage
+            }),
+            "{label}: bin_data_id={} 가 DocInfo 에 Storage 로 등록돼 있지 않다 — 목록 {:?}",
+            ole.bin_data_id,
+            doc.doc_info
+                .bin_data_list
+                .iter()
+                .map(|b| (b.storage_id, b.data_type))
+                .collect::<Vec<_>>()
+        );
+
+        // ③ OLE 스트림 바이트 규약 — #3547 축 동승 보호
+        let raw = read_cfb_stream(&hwp, "/BinData/BIN0001.OLE");
+        let payload = decompress_stream(&raw).unwrap_or(raw);
+        assert!(payload.len() > 12, "{label}: OLE 페이로드가 너무 짧다");
+        let prefix = u32::from_le_bytes(payload[..4].try_into().unwrap()) as usize;
+        assert_eq!(
+            prefix,
+            payload.len() - 4,
+            "{label}: 4바이트 size prefix 가 CFB 길이를 가리켜야 한다 (#3547)"
+        );
+        assert_eq!(
+            &payload[4..12],
+            &[0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1],
+            "{label}: prefix 뒤가 CFB 매직이어야 한다"
+        );
+        checked += 1;
+    }
+    assert_eq!(checked, paths.len());
+}
+
+fn read_cfb_stream(bytes: &[u8], path: &str) -> Vec<u8> {
+    let mut cfb = cfb::CompoundFile::open(Cursor::new(bytes)).expect("CFB 열기");
+    let mut stream = cfb
+        .open_stream(path)
+        .unwrap_or_else(|e| panic!("스트림 {path}: {e}"));
+    let mut data = Vec::new();
+    stream.read_to_end(&mut data).expect("스트림 읽기");
+    data
+}
+
+// ---------------------------------------------------------------------------
+// T4 — fold 방향의 근거 고정 (한컴 정답지 대조)
+// ---------------------------------------------------------------------------
+
+/// **이 테스트가 없으면 다음 사람이 "instance_id 를 chart 쪽에서 살려야 하지 않나"로
+/// 되돌린다.** 실측값(2026-08-10):
+///
+/// ```text
+/// 오라클 .hwp        bin_data_id=1      instance_id=0           attr=0x140A2210
+/// HWPX chart 브랜치  bin_data_id=60001  instance_id=1117817146  attr=0x140A2210
+/// HWPX fallback      bin_data_id=1      instance_id=0           attr=0x140A2210
+/// ```
+///
+/// `instance_id` 가 유일한 판별자다 — 한컴은 `<hp:chart @id>` 가 아니라
+/// `<hp:default><hp:ole @instid>` 를 쓴다. 따라서 fold 는 fallback 을 통째로 채택해야
+/// 하고, chart 브랜치의 `instance_id` 를 승계하면 오라클과 어긋난다.
+#[test]
+fn issue4099_folded_ole_matches_hancom_oracle() {
+    let hwpx = base_hwpx();
+    let hwp = convert_to_hwp(&hwpx);
+    let doc = rhwp::parse_document(&hwp).expect("변환본 재파싱");
+    let ole = first_ole(&doc).expect("OLE 도형");
+
+    let oracle_bytes = std::fs::read(manifest(&format!("{BASE_SAMPLE}.hwp"))).expect("오라클 읽기");
+    let oracle_doc = rhwp::parse_document(&oracle_bytes).expect("오라클 파싱");
+    let oracle = first_ole(&oracle_doc).expect("오라클 OLE");
+
+    assert_eq!(
+        ole.common.instance_id, oracle.common.instance_id,
+        "instance_id 가 한컴 정답지와 달라졌다 — fallback 브랜치를 채택하지 않았다는 뜻이다 \
+         (chart 브랜치 값은 1117817146, fallback·오라클은 0)"
+    );
+    assert_eq!(ole.common.instance_id, 0, "오라클 실측값");
+    assert_eq!(ole.common.attr, oracle.common.attr);
+    assert_eq!(ole.common.attr, 0x140A_2210, "오라클 실측값");
+    assert_eq!(
+        (ole.extent_x, ole.extent_y),
+        (oracle.extent_x, oracle.extent_y)
+    );
+    assert_eq!((ole.extent_x, ole.extent_y), (7200, 7200));
+    assert_eq!(
+        (
+            ole.drawing.shape_attr.original_width,
+            ole.drawing.shape_attr.original_height
+        ),
+        (7200, 7200)
+    );
+    assert!(
+        ole.chart_id_ref.is_none() && ole.chart_switch_fallback.is_none(),
+        "HWP5 재파싱본에 HWPX 전용 표식이 남아 있을 수 없다"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T4b — fold 불가 경로와 캡션 이월 (코퍼스 0건이라 합성)
+// ---------------------------------------------------------------------------
+
+/// `<hp:switch>` 를 벗겨 `<hp:chart>` 단독으로 만든다 — `section.rs` 의 `b"chart"` arm
+/// 경로("아직 보지 못한 변형. 안전 경로")를 태운다. `<hp:default>` 없는 case-only
+/// switch 도 `parse_switch_chart_or_ole` 의 `chart.or(ole)` 폴스루로 같은 상태
+/// (`chart_id_ref.is_some() && chart_switch_fallback.is_none()`)에 수렴한다.
+fn synth_chart_without_fallback(hwpx: &[u8]) -> Vec<u8> {
+    let xml = read_zip_entry(hwpx, "Contents/section0.xml");
+    let sw_start = xml.find("<hp:switch>").expect("샘플에 <hp:switch> 가 있어야 한다");
+    let sw_end = xml.find("</hp:switch>").expect("</hp:switch>") + "</hp:switch>".len();
+    let seg = &xml[sw_start..sw_end];
+    let c_start = seg.find("<hp:chart").expect("<hp:chart");
+    let c_end = seg.find("</hp:chart>").expect("</hp:chart>") + "</hp:chart>".len();
+    let chart_only = seg[c_start..c_end].to_string();
+    let patched = format!("{}{}{}", &xml[..sw_start], chart_only, &xml[sw_end..]);
+    assert_ne!(patched, xml, "치환이 실제로 일어나야 한다");
+    rewrite_hwpx(
+        hwpx,
+        &[("Contents/section0.xml".to_string(), patched.into_bytes())],
+    )
+}
+
+/// `<hp:chart>` 에만 `<hp:caption>` 을 넣는다(fallback `<hp:ole>` 에는 없음).
+/// #4319 로 파서가 양쪽 캡션을 읽게 됐으므로, fold 가 chart 쪽 캡션을 버리면
+/// 조용히 소실된다. 코퍼스 28종은 캡션이 0건이라 합성해야만 이 축을 잴 수 있다.
+fn synth_chart_with_caption_only_on_chart(hwpx: &[u8]) -> Vec<u8> {
+    let xml = read_zip_entry(hwpx, "Contents/section0.xml");
+    let caption = r#"<hp:caption side="BOTTOM" fullSz="0" width="4000" gap="850" lastWidth="4000"><hp:subList id="" textDirection="HORIZONTAL" lineWrap="BREAK" vertAlign="TOP" linkListIDRef="0" linkListNextIDRef="0" textWidth="0" textHeight="0" hasTextRef="0" hasNumRef="0"><hp:p id="0" paraPrIDRef="0" styleIDRef="0"><hp:run charPrIDRef="0"><hp:t>차트 1. 분기 매출</hp:t></hp:run></hp:p></hp:subList></hp:caption>"#;
+    let close = "</hp:chart>";
+    let at = xml.find(close).expect("</hp:chart>");
+    let patched = format!("{}{}{}", &xml[..at], caption, &xml[at..]);
+    assert_ne!(patched, xml, "치환이 실제로 일어나야 한다");
+    rewrite_hwpx(
+        hwpx,
+        &[("Contents/section0.xml".to_string(), patched.into_bytes())],
+    )
+}
+
+/// fallback 이 없으면 접을 대상이 없다. 그래도 **정크 스트림과 dangling 참조는
+/// 만들지 않는다** — 그 둘이 이 이슈의 실제 피해다.
+///
+/// placeholder 렌더는 **허용**한다. HWP5 에는 평문 차트 XML 을 담을 자리가 없고,
+/// 이 경로에서 OLE CFB 를 합성하려면 참조할 원본 CLSID 가 없어
+/// `{4C3DA137-DC90-47B9-9BED-59DAE352A280}` 를 하드코딩해야 하는데 한컴이 그런 CFB 를
+/// 받아들이는지 미검증이다(#4055 는 기존 CFB 를 수정했을 뿐 새로 만들지 않았다).
+/// 도구는 #4097 의 `mini_cfb::build_cfb_with_root_clsid` 로 이미 갖춰져 있으므로,
+/// 실물 변종이 관측되면 그때 이 자리를 채우면 된다.
+#[test]
+fn issue4099_chart_without_fallback_produces_no_junk_and_no_dangling_ref() {
+    let synth = synth_chart_without_fallback(&base_hwpx());
+
+    // 합성 검증 — 이 전제가 깨지면 아래 단언이 다른 것을 재게 된다.
+    let src = rhwp::parse_document(&synth).expect("합성본 파싱");
+    let src_ole = first_ole(&src).expect("합성본 OLE");
+    assert!(
+        src_ole.chart_id_ref.is_some() && src_ole.chart_switch_fallback.is_none(),
+        "합성이 fallback 없는 차트를 만들어야 한다"
+    );
+
+    let hwp = convert_to_hwp(&synth);
+
+    let streams = all_streams(&hwp);
+    assert!(
+        !streams
+            .iter()
+            .any(|(n, _)| n.to_ascii_lowercase().ends_with(".ooxml_chart")),
+        "fallback 이 없어도 정크 스트림을 만들면 안 된다 — 스트림 {:?}",
+        streams.iter().map(|(n, _)| n).collect::<Vec<_>>()
+    );
+
+    let doc = rhwp::parse_document(&hwp).expect("변환본 재파싱");
+    let ole = first_ole(&doc).expect("변환본 OLE");
+    assert_eq!(
+        ole.bin_data_id, 0,
+        "접을 수 없으면 참조를 비운다 — 없는 storage 를 가리키면 한컴이 오해한다"
+    );
+
+    assert!(
+        verify_diff(&synth).is_empty(),
+        "fold 불가 경로도 --verify 는 통과해야 한다"
+    );
+}
+
+/// fold 는 fallback 을 통째로 채택하므로, chart 쪽에만 있던 캡션은 명시적으로
+/// 이월하지 않으면 사라진다 (#4319 로 파서가 양쪽을 읽게 된 뒤 생긴 축).
+#[test]
+fn issue4099_fold_carries_over_chart_only_caption() {
+    let synth = synth_chart_with_caption_only_on_chart(&base_hwpx());
+
+    // 합성 검증 — chart 에만 캡션, fallback 에는 없음
+    let src = rhwp::parse_document(&synth).expect("합성본 파싱");
+    let src_ole = first_ole(&src).expect("합성본 OLE");
+    let src_caption = src_ole
+        .caption
+        .as_ref()
+        .expect("합성본 chart 브랜치에 캡션이 있어야 한다 (#4319 파서)");
+    assert_eq!(src_caption.paragraphs[0].text, "차트 1. 분기 매출");
+    assert!(
+        src_ole
+            .chart_switch_fallback
+            .as_deref()
+            .expect("fallback")
+            .caption
+            .is_none(),
+        "합성은 fallback 에 캡션을 넣지 않는다"
+    );
+
+    let hwp = convert_to_hwp(&synth);
+    let doc = rhwp::parse_document(&hwp).expect("변환본 재파싱");
+    let ole = first_ole(&doc).expect("변환본 OLE");
+
+    let caption = ole
+        .caption
+        .as_ref()
+        .expect("chart 브랜치에만 있던 캡션이 fold 로 사라졌다 — 이월 규칙 누락");
+    assert_eq!(
+        caption.paragraphs[0].text, "차트 1. 분기 매출",
+        "캡션 내용이 보존돼야 한다"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T6 — 멱등성
+// ---------------------------------------------------------------------------
+
+/// 어댑터는 live IR 을 in-place 로 바꾼다. fold 와 `ooxml_chart` 제거가 2회차에
+/// 다른 결과를 내면 저장 버튼을 두 번 누른 사용자가 다른 파일을 얻는다.
+/// `hwpx_to_hwp_adapter.rs` 의 같은 축은 차트 없는 문서만 재고 있다.
+#[test]
+fn issue4099_adapter_is_idempotent_on_chart_document() {
+    let hwpx = base_hwpx();
+    let mut core = DocumentCore::from_bytes(&hwpx).expect("HWPX 로드");
+    let first = core.export_hwp_with_adapter().expect("1회차");
+    let second = core.export_hwp_with_adapter().expect("2회차");
+    assert_eq!(
+        first, second,
+        "차트 문서에서 어댑터를 두 번 돌리면 같은 바이트가 나와야 한다"
+    );
+}

--- a/tests/issue_4099_hwpx_chart_to_hwp.rs
+++ b/tests/issue_4099_hwpx_chart_to_hwp.rs
@@ -37,6 +37,7 @@ use chart_probe_support::{all_streams, corpus, manifest, rewrite_hwpx};
 
 use std::io::{Cursor, Read};
 
+use rhwp::document_core::converters::hwpx_to_hwp::convert_hwpx_to_hwp_ir;
 use rhwp::document_core::DocumentCore;
 use rhwp::model::bin_data::BinDataType;
 use rhwp::model::control::Control;
@@ -438,6 +439,210 @@ fn issue4099_fold_carries_over_chart_only_caption() {
         caption.paragraphs[0].text, "차트 1. 분기 매출",
         "캡션 내용이 보존돼야 한다"
     );
+}
+
+// ---------------------------------------------------------------------------
+// T5 — 수용 기준 5: bin_count > 1 에서 BinData 순서 remap 과 맞물린다
+// ---------------------------------------------------------------------------
+
+/// 1×1 투명 PNG. 저장소에 바이너리를 커밋하지 않으려고 상수로 둔다
+/// (`insert_image_contract.rs` 가 이미 쓰는 방식).
+const TINY_PNG: &[u8] = &[
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+    0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+    0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+    0x42, 0x60, 0x82,
+];
+
+/// 코퍼스 28종은 **전부 BinData 가 `ole1.ole` 하나**다. 그래서
+/// `materialize_hwp5_bin_data_order` 의 `bin_count <= 1` 조기 반환에 걸려 **remap 이
+/// 한 번도 실제로 돌아본 적이 없다.** 차트와 그림이 함께 있는 문서를 합성해 그 경로를
+/// 덮는다.
+///
+/// `samples/chart/` 에 파일을 커밋하면 `issue_4055_b1_chart_edit_probe.rs` 의
+/// `checked == 56` 하드코딩이 깨지므로 런타임에 조립한다.
+fn synth_chart_plus_picture(chart_hwpx: &[u8]) -> Vec<u8> {
+    // ① manifest — image1 을 ole1 **앞에** 넣어 매니페스트 순번이 1(그림)/2(OLE)가
+    //    되게 한다. 파서는 이 순번을 그대로 storage_id 로 쓴다.
+    let hpf = read_zip_entry(chart_hwpx, "Contents/content.hpf");
+    let ole_item = r#"<opf:item id="ole1" href="BinData/ole1.ole" media-type="application/ole" isEmbeded="0"/>"#;
+    assert!(hpf.contains(ole_item), "manifest 의 ole1 항목을 찾지 못했다");
+    let image_item = r#"<opf:item id="image1" href="BinData/image1.png" media-type="image/png" isEmbeded="1"/>"#;
+    let hpf = hpf.replacen(ole_item, &format!("{image_item}{ole_item}"), 1);
+
+    // ② 그림 문단 — XML 을 손으로 쓰지 않고 실 코퍼스에서 떼어온다. 파서가 요구하는
+    //    hc:imgRect / hp:imgClip / hp:imgDim 을 빠뜨릴 위험을 없앤다. 스타일 참조만
+    //    0 번으로 낮춰 차트 문서의 header.xml 에 없는 id 를 가리키지 않게 한다.
+    let donor = std::fs::read(manifest("samples/hwpx/exam-kor-1p.hwpx")).expect("그림 원본 읽기");
+    let donor_xml = read_zip_entry(&donor, "Contents/section0.xml");
+    let pic_para = extract_shortest_picture_paragraph(&donor_xml)
+        .replace("paraPrIDRef=\"42\"", "paraPrIDRef=\"0\"")
+        .replace("charPrIDRef=\"45\"", "charPrIDRef=\"0\"");
+    assert!(
+        pic_para.contains(r#"binaryItemIDRef="image1""#),
+        "떼어온 그림 문단이 image1 을 참조해야 한다"
+    );
+
+    // ③ 차트 문단이 먼저, 그림 문단이 나중이어야 한다. 반대면 수집 순서가
+    //    identity([1,2])가 되어 remap 이 조기 반환하고 이 테스트가 아무것도 재지 않는다.
+    let xml = read_zip_entry(chart_hwpx, "Contents/section0.xml");
+    let close = "</hs:sec>";
+    let at = xml.rfind(close).expect("</hs:sec>");
+    let xml = format!("{}{}{}", &xml[..at], pic_para, &xml[at..]);
+
+    // ④ section XML 의 `binaryItemIDRef="ole1"` 은 손대지 않는다 —
+    //    `canonicalize_bin_item_refs` 가 숫자 1 ≠ 정규 위치 2 를 보고 `image2` 로
+    //    바꿔 준다. 손으로 바꾸면 그 정규화가 검증에서 빠진다.
+    let patched = rewrite_hwpx(
+        chart_hwpx,
+        &[
+            ("Contents/content.hpf".to_string(), hpf.into_bytes()),
+            ("Contents/section0.xml".to_string(), xml.into_bytes()),
+        ],
+    );
+    chart_probe_support::append_hwpx_entries(
+        &patched,
+        &[("BinData/image1.png".to_string(), TINY_PNG.to_vec())],
+    )
+}
+
+fn extract_shortest_picture_paragraph(section_xml: &str) -> String {
+    let mut best: Option<&str> = None;
+    let mut cursor = 0usize;
+    while let Some(rel) = section_xml[cursor..].find("<hp:p ") {
+        let start = cursor + rel;
+        let Some(rel_end) = section_xml[start..].find("</hp:p>") else {
+            break;
+        };
+        let end = start + rel_end + "</hp:p>".len();
+        let para = &section_xml[start..end];
+        if para.contains("<hp:pic ") && best.is_none_or(|b| para.len() < b.len()) {
+            best = Some(para);
+        }
+        cursor = end;
+    }
+    best.expect("그림 문단을 찾지 못했다").to_string()
+}
+
+#[test]
+fn issue4099_chart_with_picture_survives_bin_data_order_remap() {
+    let synth = synth_chart_plus_picture(&base_hwpx());
+
+    // ── 조립 검증. 이 전제가 깨지면 아래 단언이 다른 것을 재게 된다.
+    let src = rhwp::parse_document(&synth).expect("합성본 파싱");
+    assert_eq!(
+        src.doc_info.bin_data_list.len(),
+        2,
+        "합성이 BinData 2개(그림·OLE)를 만들어야 remap 이 돈다"
+    );
+    let src_ole = first_ole(&src).expect("합성본 OLE");
+    assert_eq!(src_ole.bin_data_id, 60001, "차트는 가상 id 를 갖는다");
+    assert_eq!(
+        src_ole
+            .chart_switch_fallback
+            .as_deref()
+            .expect("fallback")
+            .bin_data_id,
+        2,
+        "fallback 은 매니페스트 2번(ole1)을 가리켜야 한다 — canonicalize_bin_item_refs 결과"
+    );
+    assert_eq!(
+        first_picture_bin_data_id(&src),
+        Some(1),
+        "그림은 매니페스트 1번이다"
+    );
+
+    // ── 어댑터 카운터로 "새 경로가 실제로 열렸는지" 를 직접 못박는다.
+    //    코퍼스 28종은 BinData 가 1개라 `bin_count <= 1` 조기 반환에 걸려 remap 이
+    //    돌지 않는다. 이 합성만이 그 코드를 통과시킨다.
+    let mut ir = rhwp::parse_document(&synth).expect("합성본 IR");
+    let report = convert_hwpx_to_hwp_ir(&mut ir);
+    assert_eq!(report.chart_ole_folded_to_fallback, 1);
+    assert_eq!(report.chart_bin_data_contents_removed, 1);
+    assert_eq!(report.chart_ole_without_fallback, 0);
+    assert_eq!(
+        report.bin_data_order_materialized, 1,
+        "BinData 순서 remap 이 실제로 돌아야 한다 — 이 축은 코퍼스로는 잴 수 없다"
+    );
+
+    let mut base_ir = rhwp::parse_document(&base_hwpx()).expect("base IR");
+    assert_eq!(
+        convert_hwpx_to_hwp_ir(&mut base_ir).bin_data_order_materialized,
+        0,
+        "대조: BinData 1개인 코퍼스 문서는 조기 반환한다 (합성이 새 경로를 연다는 증거)"
+    );
+
+    // ── 변환
+    let mut core = DocumentCore::from_bytes(&synth).expect("합성본 로드");
+    let hwp = core.export_hwp_with_adapter().expect("HWP 변환");
+
+    let doc = rhwp::parse_document(&hwp).expect("변환본 재파싱");
+    let ole = first_ole(&doc).expect("변환본 OLE");
+
+    // 본문 순서(차트→그림) 대로 1,2 가 다시 매겨진다.
+    assert_eq!(
+        ole.bin_data_id, 1,
+        "본문에 먼저 나오는 차트가 BinData 1번을 받아야 한다"
+    );
+    assert_eq!(first_picture_bin_data_id(&doc), Some(2));
+
+    let list: Vec<_> = doc
+        .doc_info
+        .bin_data_list
+        .iter()
+        .map(|b| (b.storage_id, b.data_type, b.extension.clone()))
+        .collect();
+    assert_eq!(
+        list,
+        vec![
+            (1, BinDataType::Storage, Some("OLE".to_string())),
+            (2, BinDataType::Embedding, Some("png".to_string())),
+        ],
+        "DocInfo BinData 가 본문 순서로 재배열돼야 한다"
+    );
+
+    let streams = all_streams(&hwp);
+    let names: Vec<&String> = streams.iter().map(|(n, _)| n).collect();
+    assert!(
+        names.iter().any(|n| *n == "/BinData/BIN0001.OLE"),
+        "스트림 {names:?}"
+    );
+    assert!(
+        names.iter().any(|n| *n == "/BinData/BIN0002.png"),
+        "스트림 {names:?}"
+    );
+    assert!(
+        !names
+            .iter()
+            .any(|n| n.to_ascii_lowercase().ends_with(".ooxml_chart")),
+        "정크 스트림 {names:?}"
+    );
+
+    assert!(
+        verify_diff(&synth).is_empty(),
+        "bin_count>1 경로도 --verify 를 통과해야 한다: {:?}",
+        verify_diff(&synth).differences
+    );
+}
+
+fn first_picture_bin_data_id(doc: &Document) -> Option<u16> {
+    for section in &doc.sections {
+        for para in &section.paragraphs {
+            for ctrl in &para.controls {
+                match ctrl {
+                    Control::Picture(pic) => return Some(pic.image_attr.bin_data_id),
+                    Control::Shape(shape) => {
+                        if let ShapeObject::Picture(pic) = shape.as_ref() {
+                            return Some(pic.image_attr.bin_data_id);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    None
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/support/issue_4055_chart_probe.rs
+++ b/tests/support/issue_4055_chart_probe.rs
@@ -317,6 +317,38 @@ pub(super) fn rewrite_hwpx(original: &[u8], replacements: &[(String, Vec<u8>)]) 
     out.finish().expect("zip finish").into_inner()
 }
 
+/// HWPX zip 에 **없던** 엔트리를 뒤에 덧붙인다. 기존 엔트리는 `raw_copy_file` 로
+/// 그대로 옮긴다.
+///
+/// `rewrite_hwpx` 는 이름이 이미 있는 엔트리만 갈아끼우므로 새 `BinData/*` 를 넣을 수
+/// 없다. 차트 문서에 그림을 얹어 `bin_count > 1` 을 만들려면(#4099 수용 기준 5) 둘 다
+/// 필요하다 — 코퍼스 28종이 전부 BinData 1개라 합성 외에는 그 경로를 밟을 방법이 없다.
+pub(super) fn append_hwpx_entries(original: &[u8], additions: &[(String, Vec<u8>)]) -> Vec<u8> {
+    let mut src =
+        zip::ZipArchive::new(std::io::Cursor::new(original.to_vec())).expect("원본 HWPX 열기");
+    let existing: Vec<String> = (0..src.len())
+        .map(|i| src.by_index(i).expect("zip 엔트리").name().to_string())
+        .collect();
+    for (name, _) in additions {
+        assert!(
+            !existing.contains(name),
+            "{name} 은 이미 있다 — 교체는 rewrite_hwpx 를 쓴다"
+        );
+    }
+
+    let mut out = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    for i in 0..src.len() {
+        let entry = src.by_index(i).expect("zip 엔트리");
+        out.raw_copy_file(entry).expect("raw copy");
+    }
+    for (name, bytes) in additions {
+        out.start_file(name, zip::write::SimpleFileOptions::default())
+            .expect("start_file");
+        out.write_all(bytes).expect("엔트리 쓰기");
+    }
+    out.finish().expect("zip finish").into_inner()
+}
+
 /// HWP5 바깥 CFB 를 다시 쓴다. 지정한 스트림만 갈고 나머지는 바이트 그대로 옮긴다.
 pub(super) fn rewrite_hwp(original: &[u8], replacements: &[(String, Vec<u8>)]) -> Vec<u8> {
     let mut streams = all_streams(original);


### PR DESCRIPTION
fix: HWPX→HWP5 변환이 차트를 통째로 잃던 결함 (#4099)

`rhwp convert a.hwpx out.hwp` 가 차트 참조를 끊습니다. `samples/chart/**` **28종 전건**입니다.
산출 `.hwp` 를 rhwp 자신이 렌더하면 `"OLE 개체 (BinData #60001)"` 회색 상자가 나오고,
CFB 에는 DocInfo 미등록 정크 스트림 `BINEA61.ooxml_chart` 가 생깁니다.

## 무엇이 문제였나

HWPX 파서는 `<hp:switch>` 의 `<hp:case>` 브랜치를 채택해 **가상 id** `bin_data_id = 60000+N`
을 세우고, `<hp:default>` 의 진짜 OLE 를 `chart_switch_fallback` 에 매달아 둡니다
(#3546 — HWPX 저장 시 원형 재방출의 재료). 그 가상 id 는 zip 파트 `Chart/chartN.xml` 을
가리키므로 **HWP5 에는 대응물이 없습니다.** 그런데 HWP5 저장 경로에 이 규약을 아는 코드가
**0건**이었습니다.

| 축 | 결과 |
|---|---|
| `serialize_ole_data` | `60001` 을 그대로 기록 → DocInfo 에 없는 storage 참조 |
| `find_bin_data_info_with_compress` 폴백 | `/BinData/BINEA61.ooxml_chart` 정크 스트림 생성 |
| 재파싱 | `--verify` 가 `bin_data_content count: expected=2 actual=1` → exit 3 |

**바이트는 멀쩡히 보존됩니다.** 끊어진 것은 참조뿐입니다. 그래서 변환본의 바이트를 단언한
#4055 스파이크는 통과했고(그 판정은 지금도 옳습니다), 본문 컨트롤이 그것에 도달하지 못한다는
축을 아무도 보지 않았습니다.

그리고 **`convert --verify` 는 이 결함을 처음부터 exit 3 으로 보고하고 있었습니다.**
`convert_verify_corpus_ratchet.rs` 의 코퍼스가 `read_dir(samples/)` 비재귀라
`samples/chart/**` 가 통째로 빠져 있었을 뿐입니다. 결함보다 이쪽이 근인에 가깝습니다.

## 왜 fallback 을 채택하나 — 오라클 실측

한컴이 저장한 같은 문서의 `.hwp` 와 대조했습니다.

```text
오라클 .hwp        bin_data_id=1      instance_id=0           attr=0x140A2210
HWPX chart 브랜치  bin_data_id=60001  instance_id=1117817146  attr=0x140A2210
HWPX fallback      bin_data_id=1      instance_id=0           attr=0x140A2210
```

`instance_id` 가 유일한 판별자입니다. `parse_hp_chart_element` 은 `@id` 를 읽어
`1117817146`, `parse_hp_ole_element` 은 `@id` arm 이 없고 `instid="0"` 만 읽어 `0` 이 됩니다.
오라클이 **0** 이라는 것은 **한컴 자신의 HWPX→HWP5 변환도 fallback 브랜치를 쓴다**는 뜻입니다.
정답지 CFB 도 같은 말을 합니다 — `BinData/BIN0001.OLE` 하나뿐이고 `.ooxml_chart` 가 없습니다.

`issue4099_folded_ole_matches_hancom_oracle` 이 이 근거 자체를 고정합니다. 없으면 다음 사람이
"`instance_id` 를 chart 쪽에서 살려야 하지 않나"로 되돌립니다.

> 처음에는 "fallback 이 정보 상위집합이라 채택한다"로 적었는데 그것은 **거짓**입니다.
> `parse_common_shape_children` 은 여섯(+#4319 캡션) arm 만 처리해
> `orgSz`/`curSz`/`flip`/`renderingInfo`/`lineShape` 를 IR 에 싣지 않습니다. 결론은 유지됐지만
> 근거를 오라클 실측으로 교체했습니다.

## 변경

**결함 수정은 `hwpx_to_hwp.rs` 한 파일**입니다.

- `fold_hwpx_chart_ole_for_hwp` — `chart_switch_fallback` 을 move 로 통째 채택하고
  `ooxml_chart` `BinDataContent` 를 제거합니다. 캡션은 이월합니다(#4319 로 파서가 chart/ole
  양쪽 `<hp:caption>` 을 읽게 된 뒤 생긴 축이라, chart 쪽에만 있으면 조용히 사라집니다).
- 파이프라인에서 **도형을 건드리는 첫 패스**로 넣었습니다. `materialize_hwp5_bin_data_order`
  앞이라야 fold 가 올려놓은 진짜 `bin_data_id` 를 remap 이 봅니다. 덤으로
  "`chart_switch_fallback` 을 아무 워커도 방문하지 않는다"는 잠재 결함도 함께 풀립니다.
- 순회는 네 번째 복제 워커를 만들지 않고 좁은 타입 `for_each_ole_mut` 로 골격만 재사용했습니다
  (템플릿은 이 파일에서 커버리지가 가장 넓은 `normalize_picture_geometry_for_hwp` 쪽 —
  `Control::Field` 메모 문단과 `SectionDef.master_pages` 까지 닿는 유일한 워커입니다).

**`wasm_api.rs` 1줄은 그 fold 가 드러낸 별도 축**입니다. fold 는 IR 에서 `chart_id_ref` 와
`ooxml_chart` 를 없애므로, 어댑터가 살아 있는 IR 을 직접 정규화하면 HWP 로 한 번 저장한 뒤
같은 핸들로 HWPX 를 내보낼 때 `Chart/chart1.xml` 파트가 빠집니다 — #3546 계약이 저장 한 번에
깨집니다. `export_hwp_with_adapter_snapshot` 이 정확히 이 부류를 위해 이미 있었고(주석:
*"저장은 스냅숏이어야 하므로"*), CLI edit 경로만 이관돼 있었습니다. 우회가 아니라 원인
제거입니다 — 저장이라는 읽기 연산이 IR 을 바꾸지 않게 합니다.

## 검증

**한컴 2022 판정 — 정답지와 렌더 바이트 일치.** 정답지와 변환본을 한컴에서 열어 PDF 로 저장하고
첫 쪽을 144DPI 로 렌더해 대조했습니다(#4055 가 쓴 방법).

```text
00-oracle-한컴원본.pdf  78834a582ce0a39f758ec7e763b2b07af72d0be798210f3e340be0e2e6ac5e9a
A-fold.pdf              78834a582ce0a39f758ec7e763b2b07af72d0be798210f3e340be0e2e6ac5e9a
```

렌더 내용도 확인했습니다 — 묶은 세로막대형 3계열 × 4항목이 제목·범례·축까지 그려집니다.

| # | 수용 기준 | 결과 |
|---|---|---|
| 1 | 28종 렌더에 placeholder 0건 | 충족 |
| 2 | 28종 `convert --verify` 통과 | 충족 |
| 3 | `BIN*.ooxml_chart` 정크 0건 | 충족 |
| 4 | OLE 참조가 DocInfo 에 실재 | 충족 (`1`, 오라클과 동일) |
| 5 | `bin_count>1` remap 경로 커버 | 충족 (합성, `bin_data_order_materialized`=1 / 대조군 0) |
| 6 | 축이 다시 비지 않게 함 | 충족 (fold 를 끄면 래칫이 28건 검출) |
| 7 | 한컴에서 차트가 보임 | 충족 (위) |
| 8 | 기존 계약 전건 green | 충족 |

- 전체 스위트 **5578 passed / 0 failed / 36 ignored** (`upstream/devel 9f5911e86` 리베이스 후 재측정)
- 계약 무수정 green: `issue_3546` 2, `issue_1251` 10, `issue_3547` 1, `issue_4055` 9(+1 ign),
  `hwpx_to_hwp_adapter` 50
- 래칫에 `samples/chart` 재귀 병합 → **신규 실패 0건**(`EXPECTED_FAILURES` 등재 불필요).
  한컴 저작 `.hwp` 28건이 노이즈 스트립 없는 strict 비교에 처음 들어갔는데도 전건 통과했습니다.
- `cargo clippy --all-targets -- -D warnings` 통과

## 리뷰어가 알아야 할 것

**남은 레코드 차이 둘은 한컴이 무시합니다.** fold 산출본과 정답지의 `Section0` 레코드를 전수
대조하면 차트 관련 차이가 둘 남습니다 — `SHAPE_COMPONENT_OLE` 길이(오라클 30B / rhwp 26B,
앞 26B 는 바이트 동일)와 `SHAPE_COMPONENT` flip 워드(`0x000B_0000` / `0`). 판정 번들에 두 축의
변종을 함께 냈는데 **A(둘 다 현행)가 그대로 통과**했으므로 별도 PR 이 필요 없습니다.
`issue_1251` 의 `len == 26` 단언도 그대로 유효합니다. GenShape CTRL_HEADER 46B 는 정답지와
바이트까지 같습니다.

**범위 밖으로 남긴 것 둘** — 보고서 §7 에 상세가 있습니다. 새 이슈는 열지 않았습니다.

**1. HWPX 직렬화기가 `bin_data_id`(위치)를 `storage_id` 로 오해합니다 — #3893 · #4049 · #4303
의 근인입니다.**

조사 중 이 결함을 재현했는데, 찾아보니 **이미 세 건이 같은 증상으로 열려 있었습니다**
(#4049 와 #4303 은 서로 중복입니다 — 같은 샘플·같은 id·같은 차이 위치). 셋 다 자동 스윕이
등재한 것이라 근인이 규명돼 있지 않아, 여기에 적어 둡니다.

HWP5 규격상 `ImageAttr.bin_data_id` 는 **DocInfo 레코드 순번**이고 `storage_id` 와 다를 수
있습니다(`bin_data_id_index_mapping.md`). 렌더의 `find_bin_data` 는 순번을 먼저 보는데
`serializer/hwpx/context.rs` 의 `bin_data_map` 은 **`storage_id` 를 키로** 쌓고
`resolve_bin_id(bin_data_id)` 가 그 키로 조회합니다. 두 값이 어긋나면 pic 컨트롤이 드롭되고
**저장은 `Ok` 로 끝납니다** — 오류 없이 그림만 사라집니다.

#2038 이 두 번호를 의도적으로 분리했을 때 *"`find_bin_data` 의 위치 우선 해석과의 정합을 깨지
않음"* 이라며 렌더 축만 확인했고 이 축은 보지 않았습니다.

차트 문서는 같은 근인의 한 변종입니다 — sentinel `60001` 때문에 `next_bin_data_storage_id` 가
`60002` 를 채번해 순번(3)과 갈라집니다. `samples/` 최상위 `.hwp` 83건을 훑으니 `storage_id` 가
순번과 어긋나는 문서가 4건이고 그중 **2건에서 그림이 완전히 사라집니다**
(`pic-crop-01.hwp` = #3893, `hwp3-sample10-hwp5.hwp`).

이 PR 의 fold 로는 안 고쳐집니다 — 오염은 편집 시점의 live IR 에서 일어납니다.

**2. `hwpx_to_hwp.rs` 의 IR 워커 다섯을 하나로 통합.** 결함이 아니라 부채이고, 커버리지가 서로
달라 통합 자체가 동작 변경 위험을 안습니다.

`export_hwp_native` 는 어댑터 미경유라 이 경로로는 여전히 차트가 깨집니다. 제품 주 경로
(convert/edit/save/wasm)는 전부 어댑터를 타고, 남은 호출부는 dev 서브커맨드와 테스트입니다.

## 커밋

| | |
|---|---|
| `docs(plan)` | 계획서 |
| `fix(converter)` | **fold + `ooxml_chart` 제거** + 게이트 테스트 |
| `test(converter)` | `bin_count>1` 합성 문서 |
| `test(ratchet)` | 래칫 코퍼스에 `samples/chart` 재귀 병합 |
| `test(judgment)` | 한컴 판정 번들 생성기 |
| `fix(wasm)` | **스냅숏 저장 전환** + 회귀 테스트 |
| `docs(report)` ×3 | 보고서 (수용 기준 대조 → snapshot·근인 실측 → §7 정정) |
| `docs` | PR 직전 리베이스 기준 기록 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
