### PR TITLE
serializer: CTRL_HEADER attr 비트 조립을 document_core 에서 serializer 로 이관

### DIFF
--- a/mydocs/working/task_m100_4400_stage1.md
+++ b/mydocs/working/task_m100_4400_stage1.md
@@ -145,3 +145,29 @@ cargo test --test issue_3552_table_common_attr_save --test hwpx_to_hwp_adapter \
   --test issue_2724_passthrough_invalidation_guard --test issue_1061_equation_serialize
 CARGO_INCREMENTAL=0 cargo test --profile release-test --tests
 ```
+
+
+## 후속 — gestell 리뷰가 이동을 미완으로 판정했다 (2026-08-10)
+
+`pack_common_attr_bits` 만 옮긴 첫 커밋은 gestell 의 total-independence 기준
+(양방향 import 0)에 미달이었다.
+
+같은 CTRL_HEADER attr 비트 마스크(`0x01 | (0x03 << 3) | (0x03 << 8)`)를 직접 들고 있는
+`sync_anchor_bits` 가 `document_core/converters/common_obj_attr_writer.rs` 에 남았고,
+그것을 먹이려고 `vert_rel_to_to_bits`/`horz_rel_to_to_bits` 를 `pub(crate)` 로 넓혀야
+했다. **그 넓힘 자체가 잔여물이다.**
+
+두 번째 커밋에서 `sync_anchor_bits` 를 `serializer/control.rs:2118` 로 함께 옮기고 두
+헬퍼를 private 으로 되돌렸다. 이제 `common_obj_attr_writer.rs` 의 `serializer::control`
+import 는 `pack_common_attr_bits` 하나뿐이다(`:15`).
+
+`pack_common_attr_bits` 가 `pub(crate)` 인 것은 별개로 정당하다 — 모듈 밖 호출자가
+넷이다(`hwpx_to_hwp.rs` 3곳, `object_ops/common.rs`, 그리고 `serialize_common_obj_attr`
+자신의 `attr==0` 폴백).
+
+## 게이트 (새 `upstream/devel` `9f5911e86` 위에서 재실행)
+
+- `cargo fmt --all -- --check` exit 0
+- `cargo clippy --all-targets -- -D warnings` exit 0
+- `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests` exit 0 —
+  `test result: ok` 블록 **502개, FAILED 0건**

--- a/mydocs/working/task_m100_4400_stage1.md
+++ b/mydocs/working/task_m100_4400_stage1.md
@@ -1,0 +1,147 @@
+# Task M100-4400 Stage 1 — HWP5 바이트 배치 지식 누출 조사, 5번 항목만 정리
+
+## 배경
+
+이슈 #4400: "HWP5 바이너리 바이트 배치 지식이 렌더러와 편집 커맨드로 새어 나왔다." 다섯 항목이
+제기되었다. 이 stage는 다섯 항목을 적대적으로 검증하고, 그중 가장 작고 안전하다고 판단한 **5번**
+(직렬화기가 `document_core::converters`를 import하는 역방향 의존)만 고쳤다. **1~4번은 손대지
+않았다** — 조사 후 반증(1번)했거나, 확인은 됐지만 이번 stage 범위 밖으로 남겼다(2·3번, 5번의
+마커 상수 잔여분).
+
+## 1단계 판정
+
+| # | 내용 | 판정 |
+|---|---|---|
+| 1 | 렌더러가 `raw_table_ctrl_height_px`로 CTRL_HEADER height 직접 디코딩 (`typeset.rs:441`) | **반증 — 시도했다가 되돌림.** 아래 "되돌린 시도" 절 참고 |
+| 2 | `section_has_zero_high_attr_rowbreak_table`이 `raw_table_record_attr` 상위 바이트 검사 (`typeset.rs:3097`) | **확인됨 — 안 고침.** `table.attr`는 `CommonObjAttr.attr`의 동기화 값이라 실제로는 다른 필드다. `raw_table_record_attr`의 상위 바이트(및 대부분 비트)는 IR에 전혀 모델링돼 있지 않다. IR 표현력 부족이 원인인 진짜 누출 — 별도 이슈 대상 |
+| 3 | 편집 커맨드가 PARA_HEADER 꼬리(`raw_header_extra`) 손조립 | **확인됨 — 안 고침.** 5개 파일 8곳 이상에서 중복. 부가 발견: `raw_header_extra[0..2]`/`[4..6]` 쓰기는 `serializer/body_text.rs:404`가 "건너뜀"이라 명시하고 실제로 안 읽는 죽은 코드다. 별도 이슈 대상 |
+| 4 | 도형 편집마다 `pack_common_attr_bits` 재계산 (`object_ops/common.rs`) | **반증 — 정당한 설계.** `CommonObjAttr.attr`가 CTRL_HEADER attr의 passthrough 소스라, 편집이 decomposed 필드만 바꾸면 attr가 stale해지는 걸 막는 필수 동기화다(`serialization_passthrough_contract.md`가 경고하는 것과 같은 성격). 유일한 잔여 문제는 함수 위치 — 5번과 동일 사안으로 수렴 |
+| 5 | 직렬화기가 `document_core::converters` import | **확인됨 — 이번 stage에서 고침(부분).** 아래 "적용한 변경" 참고. 마커 상수(`parser/mod.rs:362,547` ↔ `hwpx_to_hwp.rs:2074,2090`) 잔여분은 범위 밖으로 남김 |
+
+## 적용한 변경 — 5번(부분)
+
+`pack_common_attr_bits`(+ 8개 `_to_bits` 헬퍼)를
+`document_core/converters/common_obj_attr_writer.rs` → `src/serializer/control.rs`로 이동했다.
+
+근거: 이 함수는 `CommonObjAttr` enum 필드로부터 CTRL_HEADER attr u32 비트를 합성하는, 본질적으로
+직렬화 로직이다. `document_core/converters/mod.rs` 자신의 모듈 헌장("잘 작동하는 직렬화기 어깨
+위에 서자 — 직렬화기 자체를 수정하지 않고 IR만 정렬한다")과 정면 모순이었고, 정작 진짜
+직렬화기(`serializer/control.rs`, `serializer/hml/preflight.rs`)가 이걸 역으로 import하고
+있었다.
+
+호출부 4곳은 import 경로만 바꿨다: `converters/hwpx_to_hwp.rs`(3곳),
+`converters/common_obj_attr_writer.rs`의 `serialize_common_obj_attr`/`sync_anchor_bits`,
+`commands/object_ops/common.rs`. 로직은 바꾸지 않았다.
+
+커밋: `a62fffc15` (브랜치 `worktree-agent-a1cd33b0a5c6dfbd6`)
+
+### 자기검증에서 나온 잔여 결함 (미해결로 기록)
+
+gestell 방법론(`~/.claude/skills/gestell/references/maintenance.md`)의 "total
+independence — zero imports, either direction" 기준으로 재검토한 결과, 이 이동은
+**완전하지 않다**:
+
+- `document_core/converters/common_obj_attr_writer.rs`에 남은 `sync_anchor_bits`는
+  `pack_common_attr_bits`와 **같은 종류의 CTRL_HEADER attr 비트 지식**을 다룬다 —
+  자체적으로 `0x01 | (0x03 << 3) | (0x03 << 8)` 같은 비트 마스크 리터럴을 하드코딩하고,
+  이제 `serializer::control::{vert_rel_to_to_bits, horz_rel_to_to_bits}`를 `pub(crate)`로
+  가져다 쓴다. `pack_common_attr_bits`를 옮긴 것과 같은 잣대(직렬화 로직이 document_core에
+  있으면 안 된다)를 적용하면 `sync_anchor_bits`도 이동 대상이었는데 이번 stage에서는
+  안 옮겼다.
+- 그 결과 `document_core → serializer` 방향 import가 여전히 3개(`pack_common_attr_bits`,
+  `vert_rel_to_to_bits`, `horz_rel_to_to_bits`) 남아 있다. `pack_common_attr_bits` 1개는
+  `serialize_common_obj_attr`(IR 필드 backfill이라는 이 모듈의 정당한 역할)의 최소 의존이라
+  방어 가능하지만, 나머지 2개는 `sync_anchor_bits`를 옮기지 않아서 생긴 잔여 결합이다.
+- `vert_rel_to_to_bits`/`horz_rel_to_to_bits`를 `pub(crate)`로 넓힌 것도 이 잔여 결합
+  때문이다 — `sync_anchor_bits`가 옮겨졌다면 이 둘은 `serializer::control` 안에서 완전히
+  private로 남을 수 있었다.
+
+후속 조치 후보(이번 stage에서는 안 함): `sync_anchor_bits`도 `serializer/control.rs`로
+옮기고, `document_core/commands/object_ops/picture.rs`의 호출 3곳(478, 679, 740행)이 새
+경로를 import하도록 바꾼다. 그러면 `common_obj_attr_writer.rs`에는 `serialize_common_obj_attr`
+하나(및 그 1개의 방어 가능한 `pack_common_attr_bits` 의존)만 남는다.
+
+## 되돌린 시도 — 1번
+
+처음에는 1번(`raw_table_ctrl_height_px`가 CTRL_HEADER height 바이트를 직접 파싱)을 정적
+분석만으로 "안전한 leak"이라 판단해 실제로 고쳤다 — `table.common.height`가 `Table`의 모든
+뮤테이터(`update_ctrl_dimensions` 등)에서 `raw_ctrl_data`와 항상 함께 갱신되는 "의도된
+dual"임을 `model/table.rs:795` 주석과 여러 호출부에서 확인했고, 같은 파일 안에 이미 정확히
+같은 원칙을 쓰는 선례(`get_table_vertical_offset`, #178)도 있었기 때문이다.
+
+그런데 `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests`를 실제로 돌리자
+**즉시 회귀**했다:
+
+```
+thread 'issue_2007_saved_frame_tail_nested_table_starts_before_next_frame' (119037489) panicked at tests/issue_2007_nested_cell_pagination.rs:191:5:
+16쪽이 이해관계자 협의 저장 프레임에서 재개하지 않았다
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+failures:
+    issue_2007_saved_frame_tail_nested_table_starts_before_next_frame
+
+test result: FAILED. 5 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.09s
+error: test failed, to rerun pass `--test issue_2007_nested_cell_pagination`
+```
+
+`git diff`를 되돌리면(원래 raw-byte 읽기 복원) 통과, 다시 적용하면 실패 — red/green으로
+직접 인과관계를 증명했다. 실 문서 fixture(`samples/basic/issue2007_nested_cell_pagination_42065.hwp`)
+파싱 직후에는 `table.common.height`와 raw 바이트가 모든 표에서 일치함을 별도 진단
+바이너리(임시, 이후 삭제)로 확인했으므로, 렌더링 파이프라인 어딘가(정확한 지점은 특정하지
+못함 — `height_measurer.rs`의 "stretched"/"target_body_height" 계열 로직이 유력 후보)에서
+`table.common.height`만 동적으로 바뀌는 실재 경로가 있다는 뜻이다. 즉 raw 우선 읽기는 leak이
+아니라 그 mutation을 우회해 "원래 선언된" 높이를 되찾는 필수 로직이었다. **이 시도는
+커밋하지 않고 코드를 원상복구했다** — `git diff upstream/devel..HEAD -- src/renderer/typeset.rs`
+는 비어 있다.
+
+## 회귀 없음 근거 (red→green 짝이 없는 이유)
+
+실제로 커밋한 5번(부분) 변경은 **로직을 한 글자도 바꾸지 않는 순수 코드 이동**이다.
+고친 버그가 없으므로 이 변경에 대한 전용 red→green 회귀 테스트는 없다 — 새 회귀 테스트를
+작성하지 않았다.
+
+대신 사용한 비회귀(non-regression) 논거:
+
+1. `document_core::converters::common_obj_attr_writer` 유닛테스트 15개 — 무변경 통과
+2. `serializer::control` 유닛테스트 25개 — 무변경 통과
+3. `issue_3552_table_common_attr_save`, `hwpx_to_hwp_adapter`, `issue_1916`,
+   `issue_1916_tbl_common_attr`, `issue_2724_passthrough_invalidation_guard`,
+   `issue_1061_equation_serialize` — 전부 무변경 통과
+4. `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` — 클린
+5. `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests` 전체 스위트(497개
+   `test result: ok` 블록, 0 FAILED) 완주 — 한 차례(`--no-fail-fast`) 실행에서는
+   `issue_2007_nested_cell_pagination.rs`의 다른 서브테스트가 실패했으나, 그 파일만 단독
+   격리 실행하면 항상 6/6 통과했다. 두 번의 전체 실행에서 같은 파일의 *서로 다른*
+   서브테스트가 실패한 것 자체가 "이 변경에 결정론적으로 연동된 회귀"가 아니라 동시 실행
+   부하(다중 worktree 경합) 하 flaky라는 근거다 — 이번 변경은 페이지네이션 로직을 전혀
+   건드리지 않는다.
+
+## 미해결 — 4가지 (별도 이슈로 분리 예정)
+
+1. `section_has_zero_high_attr_rowbreak_table` — `src/renderer/typeset.rs:3097` (항목 2:
+   raw 상위 비트에 대응하는 IR 필드가 없음)
+2. `table.common.height`를 렌더링 파이프라인 어딘가에서 동적으로 바꾸는 미확인 지점 — 정확한
+   위치를 특정하지 못함(항목 1을 반증하는 과정에서 실재를 증명했으나 원인 함수는 못 찾음)
+3. PARA_HEADER 꼬리 손조립(항목 3) — `html_table_import.rs:655,657`,
+   `commands/object_ops/table.rs:593-594,627-628`, `commands/object_ops/shape.rs:1169-1170`,
+   `commands/table_ops.rs:371-372`, `commands/text_editing.rs:732-733`
+4. `HWPX_ORIGIN_STREAM_PATH`/`HWP3_ORIGIN_STREAM_PATH`(`converters/hwpx_to_hwp.rs:2074,2090`)를
+   `parser/mod.rs:362,547`가 역으로 import — `model/document.rs`의 `HWP5_ORIGIN_HWPX_MARKER_PATH`와
+   통일 필요(항목 5의 잔여분)
+
+그 외 이번 자기검증에서 새로 발견한 것 — 위 "자기검증에서 나온 잔여 결함" 절 참고
+(`sync_anchor_bits`가 옮겨지지 않아 남은 `document_core → serializer` import 2개).
+
+## 검증
+
+```
+cargo build --lib
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test --lib document_core::converters::common_obj_attr_writer
+cargo test --lib serializer::control::
+cargo test --test issue_3552_table_common_attr_save --test hwpx_to_hwp_adapter \
+  --test issue_1916_tbl_common_attr --test issue_1916 \
+  --test issue_2724_passthrough_invalidation_guard --test issue_1061_equation_serialize
+CARGO_INCREMENTAL=0 cargo test --profile release-test --tests
+```

--- a/src/document_core/commands/object_ops/common.rs
+++ b/src/document_core/commands/object_ops/common.rs
@@ -25,8 +25,8 @@ impl DocumentCore {
         | (1 << 26)
         | (1 << 28);
     pub(crate) fn sync_common_obj_attr_known_bits(c: &mut crate::model::shape::CommonObjAttr) {
-        let packed =
-            crate::document_core::converters::common_obj_attr_writer::pack_common_attr_bits(c);
+        // [#4400] pack_common_attr_bits 는 serializer 소유로 이동했다.
+        let packed = crate::serializer::control::pack_common_attr_bits(c);
         c.attr = (c.attr & !Self::COMMON_OBJ_ATTR_KNOWN_MASK)
             | (packed & Self::COMMON_OBJ_ATTR_KNOWN_MASK);
     }

--- a/src/document_core/commands/object_ops/picture.rs
+++ b/src/document_core/commands/object_ops/picture.rs
@@ -475,9 +475,7 @@ impl DocumentCore {
             let now_tac = pic.common.treat_as_char;
             // tac 토글이 enum 에만 반영되고 packed attr 이 낡으면 직렬화가 옛 앵커를
             // 되살린다 — 여기서 즉시 동기화 (migrate 경로는 rel_to 갱신 후 재동기화).
-            crate::document_core::converters::common_obj_attr_writer::sync_anchor_bits(
-                &mut pic.common,
-            );
+            crate::serializer::control::sync_anchor_bits(&mut pic.common);
             (
                 caption_created,
                 had_caption && pic.caption.is_none(),
@@ -676,9 +674,7 @@ impl DocumentCore {
             let now_tac = pic.common.treat_as_char;
             // 본문 setter 와 같은 이유로 여기서도 packed attr 을 동기화한다 —
             // 머리말/꼬리말 경로도 같은 tac 토글 마이그레이션을 수행한다 (Issue #3781).
-            crate::document_core::converters::common_obj_attr_writer::sync_anchor_bits(
-                &mut pic.common,
-            );
+            crate::serializer::control::sync_anchor_bits(&mut pic.common);
             if !was_tac && now_tac {
                 if let crate::model::control::Control::Picture(pic_box) =
                     &mut inner_para.controls[inner_control_idx]
@@ -737,7 +733,7 @@ impl DocumentCore {
         pic.common.vertical_offset = 0;
         // stale packed attr 동기화 — 없으면 바이너리 왕복에서 Paper 앵커 부활
         // (treatAsChar=1 + PAPER 모순 → 한글 렌더 깨짐, Issue #3781 실측).
-        crate::document_core::converters::common_obj_attr_writer::sync_anchor_bits(&mut pic.common);
+        crate::serializer::control::sync_anchor_bits(&mut pic.common);
 
         let picture_height_hu = pic.common.height as i32;
         let baseline = (picture_height_hu as f64 * 0.85).round() as i32;

--- a/src/document_core/converters/common_obj_attr_writer.rs
+++ b/src/document_core/converters/common_obj_attr_writer.rs
@@ -9,9 +9,10 @@
 use crate::model::shape::CommonObjAttr;
 use crate::serializer::byte_writer::ByteWriter;
 // [#4400] 비트 팩킹은 본질적으로 직렬화 로직이라 `src/serializer/control.rs` 로 옮겼다 —
-// 직렬화기가 `document_core::converters` 를 참조하는 역방향 의존을 없앤다. 이 어댑터와
-// `sync_anchor_bits` 는 그 pub(crate) 함수를 그대로 가져다 쓴다.
-use crate::serializer::control::{horz_rel_to_to_bits, pack_common_attr_bits, vert_rel_to_to_bits};
+// 직렬화기가 `document_core::converters` 를 참조하는 역방향 의존을 없앤다. `sync_anchor_bits`도
+// 같은 이유로 함께 옮겼으므로(gestell 자기검증), 이 어댑터가 필요로 하는 건
+// `attr==0`(HWPX 출처 시뮬레이션) 합성 폴백 하나뿐이다.
+use crate::serializer::control::pack_common_attr_bits;
 
 /// `CommonObjAttr` 을 CTRL_HEADER ctrl_data 영역 바이트로 직렬화.
 ///
@@ -62,30 +63,6 @@ pub fn serialize_common_obj_attr(common: &CommonObjAttr) -> Vec<u8> {
     }
 
     w.into_bytes()
-}
-
-/// tac/rel_to 마이그레이션 후 stale packed `attr` 동기화.
-///
-/// 배경 (Issue #3781 실측): `insert_picture_native` 가 `attr` 비트를 seed 하고
-/// `migrate_picture_floating_to_inline` 은 **enum 필드만** 갱신한다. 직렬화는
-/// `attr != 0` 이면 packed 값을 우선하므로(라운드트립 보존 계약), 마이그레이션된
-/// 그림이 HWP 바이너리 왕복에서 floating(Paper) 앵커로 되살아나
-/// `treatAsChar=1 + vertRelTo=PAPER` 모순 산출물이 된다 (한글 렌더 깨짐).
-/// 앵커 관련 비트(tac bit0 · vert_rel 3-4 · horz_rel 8-9)만 enum 에서 재기입하고,
-/// criterion/wrap/flow 등 나머지 비트는 보존한다 (전체 재패킹은 enum 미동기
-/// 필드의 정보 손실 위험).
-pub(crate) fn sync_anchor_bits(common: &mut CommonObjAttr) {
-    if common.attr == 0 {
-        return; // 직렬화가 pack_common_attr_bits 로 전량 재패킹 — 손댈 것 없음.
-    }
-    let mut a = common.attr;
-    a &= !(0x01 | (0x03 << 3) | (0x03 << 8));
-    if common.treat_as_char {
-        a |= 0x01;
-    }
-    a |= (vert_rel_to_to_bits(common.vert_rel_to) & 0x03) << 3;
-    a |= (horz_rel_to_to_bits(common.horz_rel_to) & 0x03) << 8;
-    common.attr = a;
 }
 
 #[cfg(test)]
@@ -321,53 +298,5 @@ mod tests {
         let bytes = serialize_common_obj_attr(&original);
         let parsed = parse_common_obj_attr(&bytes);
         assert_eq!(parsed.text_flow, TextFlow::BothSides);
-    }
-}
-
-#[cfg(test)]
-mod sync_anchor_bits_tests {
-    use super::*;
-    use crate::model::shape::{HorzRelTo, VertRelTo};
-
-    /// Issue #3781 실측 회귀: insert 가 seed 한 floating attr
-    /// ((4<<15)|(2<<18) — tac=0·rel=Paper) 위에서 inline 마이그레이션(enum 갱신) 후
-    /// sync 하면 tac/rel 비트만 Para 로 바뀌고 criterion 비트는 보존된다.
-    #[test]
-    fn sync_anchor_bits_updates_stale_floating_seed() {
-        let mut common = CommonObjAttr {
-            attr: (4 << 15) | (2 << 18),
-            treat_as_char: false,
-            vert_rel_to: VertRelTo::Paper,
-            horz_rel_to: HorzRelTo::Paper,
-            ..Default::default()
-        };
-        // 마이그레이션이 하는 일 (enum 갱신).
-        common.treat_as_char = true;
-        common.vert_rel_to = VertRelTo::Para;
-        common.horz_rel_to = HorzRelTo::Para;
-        sync_anchor_bits(&mut common);
-        assert_eq!(common.attr & 0x01, 0x01, "tac bit");
-        assert_eq!((common.attr >> 3) & 0x03, 2, "vert_rel_to = Para");
-        assert_eq!(
-            (common.attr >> 8) & 0x03,
-            3,
-            "horz_rel_to = Para (Paper0/Page1/Column2/Para3)"
-        );
-        assert_eq!((common.attr >> 15) & 0x07, 4, "width criterion 보존");
-        assert_eq!((common.attr >> 18) & 0x03, 2, "height criterion 보존");
-    }
-
-    /// attr=0(합성 경로) 은 무접촉 — 직렬화가 전량 재패킹한다.
-    #[test]
-    fn sync_anchor_bits_leaves_zero_attr_untouched() {
-        let mut common = CommonObjAttr {
-            attr: 0,
-            treat_as_char: true,
-            vert_rel_to: VertRelTo::Para,
-            horz_rel_to: HorzRelTo::Para,
-            ..Default::default()
-        };
-        sync_anchor_bits(&mut common);
-        assert_eq!(common.attr, 0);
     }
 }

--- a/src/document_core/converters/common_obj_attr_writer.rs
+++ b/src/document_core/converters/common_obj_attr_writer.rs
@@ -6,10 +6,12 @@
 //! 본 모듈은 [`crate::parser::control::shape::parse_common_obj_attr`] 의 역방향이며,
 //! 라운드트립 테스트로 검증한다.
 
-use crate::model::shape::{
-    CommonObjAttr, HorzAlign, HorzRelTo, SizeCriterion, TextFlow, TextWrap, VertAlign, VertRelTo,
-};
+use crate::model::shape::CommonObjAttr;
 use crate::serializer::byte_writer::ByteWriter;
+// [#4400] 비트 팩킹은 본질적으로 직렬화 로직이라 `src/serializer/control.rs` 로 옮겼다 —
+// 직렬화기가 `document_core::converters` 를 참조하는 역방향 의존을 없앤다. 이 어댑터와
+// `sync_anchor_bits` 는 그 pub(crate) 함수를 그대로 가져다 쓴다.
+use crate::serializer::control::{horz_rel_to_to_bits, pack_common_attr_bits, vert_rel_to_to_bits};
 
 /// `CommonObjAttr` 을 CTRL_HEADER ctrl_data 영역 바이트로 직렬화.
 ///
@@ -62,59 +64,6 @@ pub fn serialize_common_obj_attr(common: &CommonObjAttr) -> Vec<u8> {
     w.into_bytes()
 }
 
-/// `CommonObjAttr` 의 enum 필드들로부터 attr u32 비트를 합성한다.
-///
-/// 비트 레이아웃 (parser/control/shape.rs 의 역방향):
-/// - bit 0: treat_as_char
-/// - bit 2: affect_line_spacing (줄 간격에 영향 — [#2784], 스펙 표 70)
-/// - bit 3-4: vert_rel_to (Paper=0, Page=1, Para=2)
-/// - bit 5-7: vert_align
-/// - bit 8-9: horz_rel_to
-/// - bit 10-12: horz_align
-/// - bit 13: flow_with_text (HWPX object contract)
-/// - bit 14: allow_overlap (HWPX object contract)
-/// - bit 15-17: width_criterion
-/// - bit 18-19: height_criterion
-/// - bit 21-23: text_wrap
-/// - bit 24-25: text_flow
-/// - bit 20: size protect when VertRelTo is Para
-/// - bit 26: HWPX GenShape storage high bit 후보
-/// - bit 28: HWPX GenShape numbering category high bit 후보
-pub(crate) fn pack_common_attr_bits(common: &CommonObjAttr) -> u32 {
-    let mut a: u32 = 0;
-    if common.treat_as_char {
-        a |= 0x01;
-    }
-    // [#2784] affectLSpacing — 개체 공통 속성 attr bit 2 (스펙 표 70).
-    if common.affect_line_spacing {
-        a |= 1 << 2;
-    }
-    a |= (vert_rel_to_to_bits(common.vert_rel_to) & 0x03) << 3;
-    a |= (vert_align_to_bits(common.vert_align) & 0x07) << 5;
-    a |= (horz_rel_to_to_bits(common.horz_rel_to) & 0x03) << 8;
-    a |= (horz_align_to_bits(common.horz_align) & 0x07) << 10;
-    if common.flow_with_text {
-        a |= 1 << 13;
-    }
-    if common.allow_overlap {
-        a |= 1 << 14;
-    }
-    if common.size_protect {
-        a |= 1 << 20;
-    }
-    a |= (width_criterion_to_bits(common.width_criterion) & 0x07) << 15;
-    a |= (height_criterion_to_bits(common.height_criterion) & 0x03) << 18;
-    a |= (text_wrap_to_bits(common.text_wrap) & 0x07) << 21;
-    a |= (text_flow_to_bits(common.text_flow) & 0x03) << 24;
-    if common.hwp5_gen_shape_attr_bit26 {
-        a |= 1 << 26;
-    }
-    if common.hwp5_gen_shape_attr_bit28 {
-        a |= 1 << 28;
-    }
-    a
-}
-
 /// tac/rel_to 마이그레이션 후 stale packed `attr` 동기화.
 ///
 /// 배경 (Issue #3781 실측): `insert_picture_native` 가 `attr` 비트를 seed 하고
@@ -139,87 +88,12 @@ pub(crate) fn sync_anchor_bits(common: &mut CommonObjAttr) {
     common.attr = a;
 }
 
-fn vert_rel_to_to_bits(v: VertRelTo) -> u32 {
-    match v {
-        VertRelTo::Paper => 0,
-        VertRelTo::Page => 1,
-        VertRelTo::Para => 2,
-    }
-}
-
-fn vert_align_to_bits(v: VertAlign) -> u32 {
-    match v {
-        VertAlign::Top => 0,
-        VertAlign::Center => 1,
-        VertAlign::Bottom => 2,
-        VertAlign::Inside => 3,
-        VertAlign::Outside => 4,
-    }
-}
-
-fn horz_rel_to_to_bits(v: HorzRelTo) -> u32 {
-    match v {
-        HorzRelTo::Paper => 0,
-        HorzRelTo::Page => 1,
-        HorzRelTo::Column => 2,
-        HorzRelTo::Para => 3,
-    }
-}
-
-fn horz_align_to_bits(v: HorzAlign) -> u32 {
-    match v {
-        HorzAlign::Left => 0,
-        HorzAlign::Center => 1,
-        HorzAlign::Right => 2,
-        HorzAlign::Inside => 3,
-        HorzAlign::Outside => 4,
-    }
-}
-
-fn width_criterion_to_bits(v: SizeCriterion) -> u32 {
-    match v {
-        SizeCriterion::Paper => 0,
-        SizeCriterion::Page => 1,
-        SizeCriterion::Column => 2,
-        SizeCriterion::Para => 3,
-        SizeCriterion::Absolute => 4,
-    }
-}
-
-fn height_criterion_to_bits(v: SizeCriterion) -> u32 {
-    match v {
-        SizeCriterion::Paper => 0,
-        SizeCriterion::Page => 1,
-        // height 는 Absolute 만 의미 있음 (parser bit 18-19, 2비트만 사용)
-        _ => 2,
-    }
-}
-
-fn text_wrap_to_bits(v: TextWrap) -> u32 {
-    // hwplib 기준: 0=어울림(Square), 1=자리차지(TopAndBottom), 2=글뒤로(BehindText), 3=글앞으로(InFrontOfText)
-    // Tight/Through 는 HWP 5.0 에 직접 매핑이 없어 Square 로 폴백.
-    match v {
-        TextWrap::Square => 0,
-        TextWrap::Tight => 0,
-        TextWrap::Through => 0,
-        TextWrap::TopAndBottom => 1,
-        TextWrap::BehindText => 2,
-        TextWrap::InFrontOfText => 3,
-    }
-}
-
-fn text_flow_to_bits(v: TextFlow) -> u32 {
-    match v {
-        TextFlow::BothSides => 0,
-        TextFlow::LeftOnly => 1,
-        TextFlow::RightOnly => 2,
-        TextFlow::LargestOnly => 3,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::shape::{
+        HorzAlign, HorzRelTo, SizeCriterion, TextFlow, TextWrap, VertAlign, VertRelTo,
+    };
     use crate::model::Padding;
     use crate::parser::control::parse_common_obj_attr;
 

--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -28,8 +28,11 @@ use crate::model::style::{BorderFill, BorderLineType, Fill, FillType};
 use crate::model::table::{Cell, Table, TablePageBreak};
 use crate::parser::FileFormat;
 
-use super::common_obj_attr_writer::{pack_common_attr_bits, serialize_common_obj_attr};
+use super::common_obj_attr_writer::serialize_common_obj_attr;
 use super::hwpx_master_page_slots::materialize_hwp5_master_page_slots;
+// [#4400] bit packing 은 serializer 소유 — document_core::converters 는 더 이상 이 로직을
+// 직접 갖지 않는다.
+use crate::serializer::control::pack_common_attr_bits;
 
 /// 어댑터 실행 보고서.
 ///

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -6,7 +6,6 @@
 use super::body_text::serialize_paragraph_list;
 use super::byte_writer::{char_to_wchar, ByteWriter};
 
-use crate::document_core::converters::common_obj_attr_writer::pack_common_attr_bits;
 use crate::model::control::*;
 use crate::model::document::SectionDef;
 use crate::model::footnote::FootnoteShape;
@@ -16,8 +15,9 @@ use crate::model::image::{ImageEffect, Picture};
 use crate::model::page::{ColumnDef, ColumnDirection, ColumnType, PageBorderFill, PageDef};
 use crate::model::paragraph::Paragraph;
 use crate::model::shape::{
-    Caption, CaptionDirection, CaptionVertAlign, CommonObjAttr, DrawingObjAttr, HorzRelTo,
-    OleShape, ShapeComponentAttr, ShapeObject, TextFlow, TextWrap, VertRelTo,
+    Caption, CaptionDirection, CaptionVertAlign, CommonObjAttr, DrawingObjAttr, HorzAlign,
+    HorzRelTo, OleShape, ShapeComponentAttr, ShapeObject, SizeCriterion, TextFlow, TextWrap,
+    VertAlign, VertRelTo,
 };
 use crate::model::style::{Fill, FillType, ImageFillMode, ShapeBorderLine};
 use crate::model::table::{Cell, Table, TablePageBreak, VerticalAlign};
@@ -2035,6 +2035,147 @@ fn serialize_common_obj_attr(common: &CommonObjAttr) -> Vec<u8> {
         w.write_bytes(&common.raw_extra).unwrap();
     }
     w.into_bytes()
+}
+
+/// `CommonObjAttr` 의 enum 필드들로부터 attr u32 비트를 합성한다.
+///
+/// [#4400] `document_core/converters/common_obj_attr_writer.rs` 에서 이 파일로 이동했다.
+/// CTRL_HEADER attr 비트 레이아웃을 아는 것은 본질적으로 직렬화 로직이고, 이 파일의
+/// `serialize_common_obj_attr`(및 `document_core::converters::common_obj_attr_writer::
+/// serialize_common_obj_attr` 어댑터)가 유일한 소비 목적이다 — 직렬화기가 도리어
+/// `document_core` 를 참조하는 역방향 의존을 없앤다. `document_core` 쪽에서 필요한
+/// 호출(패스스루 무효화에 준하는 attr 동기화, `sync_anchor_bits`)은 이 pub(crate)
+/// 함수를 그대로 가져다 쓴다.
+///
+/// 비트 레이아웃 (parser/control/shape.rs 의 역방향):
+/// - bit 0: treat_as_char
+/// - bit 2: affect_line_spacing (줄 간격에 영향 — [#2784], 스펙 표 70)
+/// - bit 3-4: vert_rel_to (Paper=0, Page=1, Para=2)
+/// - bit 5-7: vert_align
+/// - bit 8-9: horz_rel_to
+/// - bit 10-12: horz_align
+/// - bit 13: flow_with_text (HWPX object contract)
+/// - bit 14: allow_overlap (HWPX object contract)
+/// - bit 15-17: width_criterion
+/// - bit 18-19: height_criterion
+/// - bit 21-23: text_wrap
+/// - bit 24-25: text_flow
+/// - bit 20: size protect when VertRelTo is Para
+/// - bit 26: HWPX GenShape storage high bit 후보
+/// - bit 28: HWPX GenShape numbering category high bit 후보
+pub(crate) fn pack_common_attr_bits(common: &CommonObjAttr) -> u32 {
+    let mut a: u32 = 0;
+    if common.treat_as_char {
+        a |= 0x01;
+    }
+    // [#2784] affectLSpacing — 개체 공통 속성 attr bit 2 (스펙 표 70).
+    if common.affect_line_spacing {
+        a |= 1 << 2;
+    }
+    a |= (vert_rel_to_to_bits(common.vert_rel_to) & 0x03) << 3;
+    a |= (vert_align_to_bits(common.vert_align) & 0x07) << 5;
+    a |= (horz_rel_to_to_bits(common.horz_rel_to) & 0x03) << 8;
+    a |= (horz_align_to_bits(common.horz_align) & 0x07) << 10;
+    if common.flow_with_text {
+        a |= 1 << 13;
+    }
+    if common.allow_overlap {
+        a |= 1 << 14;
+    }
+    if common.size_protect {
+        a |= 1 << 20;
+    }
+    a |= (width_criterion_to_bits(common.width_criterion) & 0x07) << 15;
+    a |= (height_criterion_to_bits(common.height_criterion) & 0x03) << 18;
+    a |= (text_wrap_to_bits(common.text_wrap) & 0x07) << 21;
+    a |= (text_flow_to_bits(common.text_flow) & 0x03) << 24;
+    if common.hwp5_gen_shape_attr_bit26 {
+        a |= 1 << 26;
+    }
+    if common.hwp5_gen_shape_attr_bit28 {
+        a |= 1 << 28;
+    }
+    a
+}
+
+/// [#4400] `document_core::converters::common_obj_attr_writer::sync_anchor_bits` 가
+/// 앵커 비트(tac/vert_rel/horz_rel)만 재기입할 때도 이 두 헬퍼가 필요해 `pub(crate)`.
+pub(crate) fn vert_rel_to_to_bits(v: VertRelTo) -> u32 {
+    match v {
+        VertRelTo::Paper => 0,
+        VertRelTo::Page => 1,
+        VertRelTo::Para => 2,
+    }
+}
+
+fn vert_align_to_bits(v: VertAlign) -> u32 {
+    match v {
+        VertAlign::Top => 0,
+        VertAlign::Center => 1,
+        VertAlign::Bottom => 2,
+        VertAlign::Inside => 3,
+        VertAlign::Outside => 4,
+    }
+}
+
+pub(crate) fn horz_rel_to_to_bits(v: HorzRelTo) -> u32 {
+    match v {
+        HorzRelTo::Paper => 0,
+        HorzRelTo::Page => 1,
+        HorzRelTo::Column => 2,
+        HorzRelTo::Para => 3,
+    }
+}
+
+fn horz_align_to_bits(v: HorzAlign) -> u32 {
+    match v {
+        HorzAlign::Left => 0,
+        HorzAlign::Center => 1,
+        HorzAlign::Right => 2,
+        HorzAlign::Inside => 3,
+        HorzAlign::Outside => 4,
+    }
+}
+
+fn width_criterion_to_bits(v: SizeCriterion) -> u32 {
+    match v {
+        SizeCriterion::Paper => 0,
+        SizeCriterion::Page => 1,
+        SizeCriterion::Column => 2,
+        SizeCriterion::Para => 3,
+        SizeCriterion::Absolute => 4,
+    }
+}
+
+fn height_criterion_to_bits(v: SizeCriterion) -> u32 {
+    match v {
+        SizeCriterion::Paper => 0,
+        SizeCriterion::Page => 1,
+        // height 는 Absolute 만 의미 있음 (parser bit 18-19, 2비트만 사용)
+        _ => 2,
+    }
+}
+
+fn text_wrap_to_bits(v: TextWrap) -> u32 {
+    // hwplib 기준: 0=어울림(Square), 1=자리차지(TopAndBottom), 2=글뒤로(BehindText), 3=글앞으로(InFrontOfText)
+    // Tight/Through 는 HWP 5.0 에 직접 매핑이 없어 Square 로 폴백.
+    match v {
+        TextWrap::Square => 0,
+        TextWrap::Tight => 0,
+        TextWrap::Through => 0,
+        TextWrap::TopAndBottom => 1,
+        TextWrap::BehindText => 2,
+        TextWrap::InFrontOfText => 3,
+    }
+}
+
+fn text_flow_to_bits(v: TextFlow) -> u32 {
+    match v {
+        TextFlow::BothSides => 0,
+        TextFlow::LeftOnly => 1,
+        TextFlow::RightOnly => 2,
+        TextFlow::LargestOnly => 3,
+    }
 }
 
 /// SHAPE_COMPONENT 데이터 직렬화 (ShapeComponentAttr만 — Picture, Group용)

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -2039,13 +2039,13 @@ fn serialize_common_obj_attr(common: &CommonObjAttr) -> Vec<u8> {
 
 /// `CommonObjAttr` 의 enum 필드들로부터 attr u32 비트를 합성한다.
 ///
-/// [#4400] `document_core/converters/common_obj_attr_writer.rs` 에서 이 파일로 이동했다.
-/// CTRL_HEADER attr 비트 레이아웃을 아는 것은 본질적으로 직렬화 로직이고, 이 파일의
-/// `serialize_common_obj_attr`(및 `document_core::converters::common_obj_attr_writer::
-/// serialize_common_obj_attr` 어댑터)가 유일한 소비 목적이다 — 직렬화기가 도리어
-/// `document_core` 를 참조하는 역방향 의존을 없앤다. `document_core` 쪽에서 필요한
-/// 호출(패스스루 무효화에 준하는 attr 동기화, `sync_anchor_bits`)은 이 pub(crate)
-/// 함수를 그대로 가져다 쓴다.
+/// [#4400] `document_core/converters/common_obj_attr_writer.rs` 에서 이 파일로 이동했다
+/// (`sync_anchor_bits`도 같은 이유로 함께 옮겼다 — 아래 참고). CTRL_HEADER attr 비트
+/// 레이아웃을 아는 것은 본질적으로 직렬화 로직이고, 이 파일의 `serialize_common_obj_attr`
+/// (및 `document_core::converters::common_obj_attr_writer::serialize_common_obj_attr`
+/// 어댑터)가 유일한 소비 목적이다 — 직렬화기가 도리어 `document_core` 를 참조하는
+/// 역방향 의존을 없앤다. `document_core` 쪽에서 필요한 호출(패스스루 무효화에 준하는
+/// attr 동기화)은 이 pub(crate) 함수와 `sync_anchor_bits`를 그대로 가져다 쓴다.
 ///
 /// 비트 레이아웃 (parser/control/shape.rs 의 역방향):
 /// - bit 0: treat_as_char
@@ -2098,9 +2098,38 @@ pub(crate) fn pack_common_attr_bits(common: &CommonObjAttr) -> u32 {
     a
 }
 
-/// [#4400] `document_core::converters::common_obj_attr_writer::sync_anchor_bits` 가
-/// 앵커 비트(tac/vert_rel/horz_rel)만 재기입할 때도 이 두 헬퍼가 필요해 `pub(crate)`.
-pub(crate) fn vert_rel_to_to_bits(v: VertRelTo) -> u32 {
+/// tac/rel_to 마이그레이션 후 stale packed `attr` 동기화.
+///
+/// [#4400] `document_core/converters/common_obj_attr_writer.rs` 에서 `pack_common_attr_bits`와
+/// 함께 이 파일로 이동했다 — 같은 CTRL_HEADER attr 비트 지식(같은 마스크 상수, 같은
+/// `vert_rel_to_to_bits`/`horz_rel_to_to_bits`)을 다루는 동종 로직을 한쪽만 옮기면
+/// `document_core`에 직렬화 지식이 남고, 그걸 지탱하려고 헬퍼를 `pub(crate)`로 넓혀야
+/// 했다(gestell 자기검증에서 지적된 "총체적 독립성 미달"). 이 함수까지 옮기면 그 넓힘이
+/// 필요 없어진다 — 아래 두 헬퍼를 다시 private으로 좁힌 이유다.
+///
+/// 배경 (Issue #3781 실측): `insert_picture_native` 가 `attr` 비트를 seed 하고
+/// `migrate_picture_floating_to_inline` 은 **enum 필드만** 갱신한다. 직렬화는
+/// `attr != 0` 이면 packed 값을 우선하므로(라운드트립 보존 계약), 마이그레이션된
+/// 그림이 HWP 바이너리 왕복에서 floating(Paper) 앵커로 되살아나
+/// `treatAsChar=1 + vertRelTo=PAPER` 모순 산출물이 된다 (한글 렌더 깨짐).
+/// 앵커 관련 비트(tac bit0 · vert_rel 3-4 · horz_rel 8-9)만 enum 에서 재기입하고,
+/// criterion/wrap/flow 등 나머지 비트는 보존한다 (전체 재패킹은 enum 미동기
+/// 필드의 정보 손실 위험).
+pub(crate) fn sync_anchor_bits(common: &mut CommonObjAttr) {
+    if common.attr == 0 {
+        return; // 직렬화가 pack_common_attr_bits 로 전량 재패킹 — 손댈 것 없음.
+    }
+    let mut a = common.attr;
+    a &= !(0x01 | (0x03 << 3) | (0x03 << 8));
+    if common.treat_as_char {
+        a |= 0x01;
+    }
+    a |= (vert_rel_to_to_bits(common.vert_rel_to) & 0x03) << 3;
+    a |= (horz_rel_to_to_bits(common.horz_rel_to) & 0x03) << 8;
+    common.attr = a;
+}
+
+fn vert_rel_to_to_bits(v: VertRelTo) -> u32 {
     match v {
         VertRelTo::Paper => 0,
         VertRelTo::Page => 1,
@@ -2118,7 +2147,7 @@ fn vert_align_to_bits(v: VertAlign) -> u32 {
     }
 }
 
-pub(crate) fn horz_rel_to_to_bits(v: HorzRelTo) -> u32 {
+fn horz_rel_to_to_bits(v: HorzRelTo) -> u32 {
     match v {
         HorzRelTo::Paper => 0,
         HorzRelTo::Page => 1,

--- a/src/serializer/control/tests.rs
+++ b/src/serializer/control/tests.rs
@@ -1205,3 +1205,52 @@ fn char_overlap_256_char_shape_ids_no_wraparound() {
         "u8 카운트 wraparound 로 charshape ID 전량 소실"
     );
 }
+
+/// [#4400] `document_core/converters/common_obj_attr_writer.rs`의 `sync_anchor_bits_tests`에서
+/// `sync_anchor_bits` 본체와 함께 이 파일로 이동했다.
+mod sync_anchor_bits_tests {
+    use super::*;
+    use crate::model::shape::{CommonObjAttr, HorzRelTo, VertRelTo};
+
+    /// Issue #3781 실측 회귀: insert 가 seed 한 floating attr
+    /// ((4<<15)|(2<<18) — tac=0·rel=Paper) 위에서 inline 마이그레이션(enum 갱신) 후
+    /// sync 하면 tac/rel 비트만 Para 로 바뀌고 criterion 비트는 보존된다.
+    #[test]
+    fn sync_anchor_bits_updates_stale_floating_seed() {
+        let mut common = CommonObjAttr {
+            attr: (4 << 15) | (2 << 18),
+            treat_as_char: false,
+            vert_rel_to: VertRelTo::Paper,
+            horz_rel_to: HorzRelTo::Paper,
+            ..Default::default()
+        };
+        // 마이그레이션이 하는 일 (enum 갱신).
+        common.treat_as_char = true;
+        common.vert_rel_to = VertRelTo::Para;
+        common.horz_rel_to = HorzRelTo::Para;
+        sync_anchor_bits(&mut common);
+        assert_eq!(common.attr & 0x01, 0x01, "tac bit");
+        assert_eq!((common.attr >> 3) & 0x03, 2, "vert_rel_to = Para");
+        assert_eq!(
+            (common.attr >> 8) & 0x03,
+            3,
+            "horz_rel_to = Para (Paper0/Page1/Column2/Para3)"
+        );
+        assert_eq!((common.attr >> 15) & 0x07, 4, "width criterion 보존");
+        assert_eq!((common.attr >> 18) & 0x03, 2, "height criterion 보존");
+    }
+
+    /// attr=0(합성 경로) 은 무접촉 — 직렬화가 전량 재패킹한다.
+    #[test]
+    fn sync_anchor_bits_leaves_zero_attr_untouched() {
+        let mut common = CommonObjAttr {
+            attr: 0,
+            treat_as_char: true,
+            vert_rel_to: VertRelTo::Para,
+            horz_rel_to: HorzRelTo::Para,
+            ..Default::default()
+        };
+        sync_anchor_bits(&mut common);
+        assert_eq!(common.attr, 0);
+    }
+}

--- a/src/serializer/hml/preflight.rs
+++ b/src/serializer/hml/preflight.rs
@@ -356,8 +356,8 @@ fn validate_equation(
         blockers,
     );
     let common = &equation.common;
-    let packed_attr =
-        crate::document_core::converters::common_obj_attr_writer::pack_common_attr_bits(common);
+    // [#4400] pack_common_attr_bits 는 serializer 소유로 이동했다.
+    let packed_attr = crate::serializer::control::pack_common_attr_bits(common);
     let omitted = !matches!(common.attr, 0) && common.attr != packed_attr
         || common.vertical_offset != 0
         || common.horizontal_offset != 0


### PR DESCRIPTION
`pack_common_attr_bits` 와 `sync_anchor_bits` 가 `document_core/converters/common_obj_attr_writer.rs` 에서 HWP5 CTRL_HEADER 의 attr 비트 배치를 직접 조립하고 있었습니다. 그 모듈의 헌장은 "IR 을 정렬한다, 직렬화기를 재구현하지 않는다" 인데 바이트 배치 지식이 그 안에 들어와 있습니다. 둘 다 `serializer/control.rs` 로 옮깁니다.

**첫 커밋만으로는 부족했고, 리뷰가 그것을 잡았습니다.** `pack_common_attr_bits` 만 옮기고 같은 비트 마스크(`0x01 | (0x03 << 3) | (0x03 << 8)`)를 들고 있는 `sync_anchor_bits` 를 남겨 두자, 그것을 먹이려고 `vert_rel_to_to_bits`/`horz_rel_to_to_bits` 를 `pub(crate)` 로 넓혀야 했습니다. 그 넓힘 자체가 잔여물입니다. 두 번째 커밋에서 `sync_anchor_bits` 도 옮기고 두 헬퍼를 private 으로 되돌렸습니다. 이제 `common_obj_attr_writer.rs` 의 `serializer::control` import 는 `pack_common_attr_bits` 하나뿐입니다.

`pack_common_attr_bits` 의 `pub(crate)` 는 별개로 정당합니다 — 모듈 밖 호출자가 넷입니다(`hwpx_to_hwp.rs` 3곳, `object_ops/common.rs`, `serialize_common_obj_attr` 자신의 `attr==0` 폴백).

동작이 바뀌지 않으므로 red→green 쌍이 없습니다. 대신 비회귀로 답합니다 — `cargo test --profile release-test --tests` exit 0, `test result: ok` 블록 502개, FAILED 0건. fmt·clippy clean.

**#4400 을 닫지 않습니다.** 이슈의 다섯 항목 중 5번만 처리했습니다. 나머지에 대해 조사한 것은 이슈에 코멘트로 남겼습니다 — 특히 1번은 접근법 자체가 틀렸습니다. "렌더러가 raw 바이트 대신 `table.common.height` 를 읽게 한다"를 구현했더니 기존 테스트 `issue_2007_saved_frame_tail_nested_table_starts_before_next_frame` 이 잡았고, 이는 파이프라인 어딘가가 그 필드를 변형하고 있으며 렌더러가 raw 를 읽는 것이 그 변형을 우회하는 역할을 하고 있다는 뜻입니다. 쓰기 지점은 특정하지 못했습니다.

작업 중 나왔지만 범위 밖이라 손대지 않은 것은 #4435 로 열었습니다 — `parser` 가 `document_core::converters` 의 원본 스트림 경로 상수에 의존합니다.

Refs #4400