### PR TITLE
core: 원본 스트림 경로 상수를 model 로 옮겨 parser→document_core 의존을 없앤다

### DIFF
--- a/mydocs/working/task_m100_4435_stage1.md
+++ b/mydocs/working/task_m100_4435_stage1.md
@@ -1,0 +1,50 @@
+# task_m100_4435 Stage 1 — 원본 스트림 경로 상수의 의존 방향 정정
+
+- **이슈**: [#4435](https://github.com/edwardkim/rhwp/issues/4435)
+- **브랜치**: `fix/issue-4435-origin-path-constants`
+- **분기 기준**: `upstream/devel` `9f5911e86` (0 behind)
+- **상태**: 게이트 통과, PR 게시
+- **기록일**: 2026-08-10 KST
+
+## 1. 결함
+
+`HWPX_ORIGIN_STREAM_PATH` 와 `HWP3_ORIGIN_STREAM_PATH` 가
+`src/document_core/converters/hwpx_to_hwp.rs` 에 정의돼 있는데 소비자가 파서였다
+(`src/parser/mod.rs:362`, `:547`). 즉 `parser` 가 `document_core::converters` 에 의존했다.
+
+파서는 바이트를 공통 IR 로 바꾸는 가장 아래 층이고 `document_core::converters` 는 그 위에서
+IR 을 정렬하는 층이다. 방향이 거꾸로다.
+
+## 2. 조사 — 상수는 순수한 이름이었다
+
+옮기기 전에 전 소비처를 뽑았다. 세 상수 모두 `hwpx_aux_entry` / `raw_streams` 의 경로 문자열
+비교에만 쓰이고, 정의 모듈의 로직을 전제하지 않는다. **상수만 옮기면 되는 경우가 맞았다.**
+
+형제 상수 `HWP5_ORIGIN_HWPX_MARKER_PATH` 는 이미 `src/model/document.rs:16` 에 있었다.
+셋을 같은 자리로 모았다 — `:16`, `:26`, `:42`.
+
+## 3. gestell — 잔여 결합이 남았는가
+
+`#4400` 에서 같은 함정이 있었다(옮긴 함수의 형제를 남겨 두어 헬퍼 가시성을 넓혀야 했다).
+여기서는 재수출·별칭·가시성 확대 없이 정의 위치만 바뀌었다. 옛 경로에 남은 이름이 없다.
+
+이관 후 `src/parser/` 에 남은 `document_core` 참조는 **하나뿐이고 `#[cfg(test)]` 안**이다 —
+`src/parser/hwp3/mod.rs:5678` 의 `test_hwp3_save_as_hwp5_roundtrip` 이
+`DocumentCore` 를 써서 왕복을 검증한다. 통합 성격의 테스트가 상위 층을 부르는 것은 의존
+방향 문제가 아니라 테스트 배치 문제라 이번 범위에서 손대지 않았다.
+
+**프로덕션 파서 코드에는 `document_core` 참조가 남아 있지 않다.**
+
+## 4. 검증
+
+동작이 바뀌지 않으므로 red→green 쌍이 없다. 비회귀와 구조적 증명으로 답한다.
+
+- `cargo fmt --all -- --check` exit 0
+- `cargo clippy --all-targets -- -D warnings` exit 0
+- `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests` exit 0 —
+  `test result: ok` 블록 **502개, FAILED 0건**
+- 구조적 증명: 위 3절의 grep 결과.
+
+## 5. 미처리
+
+GitHub Actions, 작업지시자 승인, merge.

--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -20,7 +20,9 @@ use std::collections::BTreeSet;
 
 use crate::model::bin_data::{BinDataContent, BinDataStatus, BinDataType};
 use crate::model::control::Control;
-use crate::model::document::{Document, HwpVersion, Section, SectionDef};
+use crate::model::document::{
+    Document, HwpVersion, Section, SectionDef, HWP3_ORIGIN_STREAM_PATH, HWPX_ORIGIN_STREAM_PATH,
+};
 use crate::model::image::Picture;
 use crate::model::paragraph::Paragraph;
 use crate::model::shape::{common_obj_offsets, ShapeObject, TextBox};
@@ -2059,32 +2061,6 @@ fn adapt_cell_list_attr(cell: &mut Cell, report: &mut AdapterReport) {
         report.cells_list_attr_bit16_set += 1;
     }
 }
-
-/// [Issue #1770] HWPX-origin 마커 스트림 경로.
-///
-/// rhwp 의 HWPX→HWP 변환은 LINE_SEG 를 verbatim 직렬화하므로 산출 HWP5 의 IR 은
-/// HWPX 시멘틱 그대로다. 재파스 시 이 마커로 `Document::is_hwpx_variant` 를 세워
-/// pagination/렌더의 `is_hwpx_source` 분기(RowBreak 분할 tolerance 등)를 HWPX 로
-/// 해석한다 — 같은 IR 이 같은 쪽수(roundtrip 자기정합, 2953495 4→5쪽 divergence 해소).
-/// 한컴은 미지의 루트 스트림을 무시하고(열림 계약 게이트로 검증), 한컴에서 재저장하면
-/// 마커가 사라지며 그 문서는 진짜 native HWP5 가 되므로 시멘틱이 자기일관적이다.
-pub const HWPX_ORIGIN_STREAM_PATH: &str = "/RhwpHwpxOrigin";
-
-/// [#3707] HWP3 출처 마커. `RhwpHwpxOrigin` 과 같은 방식이다.
-///
-/// HWP3 파싱은 `apply_hwp3_origin_fixup` 으로 `margin_bottom` 에서 1600 HU(21.3px)를
-/// 빼 한글97 의 마지막 줄 tolerance 를 모방한다. 그 보정은 IR 에만 있고 저장 파일의
-/// 여백은 원본 그대로다(그래야 한컴이 보는 기하가 원본과 같다). 그런데 재파싱 때
-/// 보정을 다시 걸지 판단하는 조건이 **문단 대비 모양 비율**이라, 저장하며 문단마다
-/// 모양이 생성돼 비율이 임계를 넘으면 보정이 사라진다(실측: ps 0.707 · cs 1.115 vs
-/// 임계 0.05 / 0.15).
-///
-/// 그 21.3px 만큼 미주 단 가용이 줄어 단 전환이 일찍 걸리고, 2단 미주의 왼쪽 단이
-/// 조기에 닫혀 미주가 다음 쪽으로 밀린다(SO-SUEOP 44쪽). 한컴은 원본·왕복본 모두
-/// 두 단을 고르게 채우므로 보정이 유지되는 쪽이 정답지와 맞는다.
-///
-/// 저장 여백을 줄이는 대신 **출처만 기록**해 재파싱이 보정을 결정론적으로 되건다.
-pub const HWP3_ORIGIN_STREAM_PATH: &str = "/RhwpHwp3Origin";
 
 /// `source_format` 검사 후 어댑터를 호출하는 보조 함수.
 ///

--- a/src/model/document.rs
+++ b/src/model/document.rs
@@ -15,6 +15,32 @@ use super::*;
 /// 마커가 사라져 native HWPX로 취급된다.
 pub const HWP5_ORIGIN_HWPX_MARKER_PATH: &str = "META-INF/rhwp-hwp5-origin";
 
+/// [Issue #1770] HWPX-origin 마커 스트림 경로.
+///
+/// rhwp 의 HWPX→HWP 변환은 LINE_SEG 를 verbatim 직렬화하므로 산출 HWP5 의 IR 은
+/// HWPX 시멘틱 그대로다. 재파스 시 이 마커로 `Document::is_hwpx_variant` 를 세워
+/// pagination/렌더의 `is_hwpx_source` 분기(RowBreak 분할 tolerance 등)를 HWPX 로
+/// 해석한다 — 같은 IR 이 같은 쪽수(roundtrip 자기정합, 2953495 4→5쪽 divergence 해소).
+/// 한컴은 미지의 루트 스트림을 무시하고(열림 계약 게이트로 검증), 한컴에서 재저장하면
+/// 마커가 사라지며 그 문서는 진짜 native HWP5 가 되므로 시멘틱이 자기일관적이다.
+pub const HWPX_ORIGIN_STREAM_PATH: &str = "/RhwpHwpxOrigin";
+
+/// [#3707] HWP3 출처 마커. `RhwpHwpxOrigin` 과 같은 방식이다.
+///
+/// HWP3 파싱은 `apply_hwp3_origin_fixup` 으로 `margin_bottom` 에서 1600 HU(21.3px)를
+/// 빼 한글97 의 마지막 줄 tolerance 를 모방한다. 그 보정은 IR 에만 있고 저장 파일의
+/// 여백은 원본 그대로다(그래야 한컴이 보는 기하가 원본과 같다). 그런데 재파싱 때
+/// 보정을 다시 걸지 판단하는 조건이 **문단 대비 모양 비율**이라, 저장하며 문단마다
+/// 모양이 생성돼 비율이 임계를 넘으면 보정이 사라진다(실측: ps 0.707 · cs 1.115 vs
+/// 임계 0.05 / 0.15).
+///
+/// 그 21.3px 만큼 미주 단 가용이 줄어 단 전환이 일찍 걸리고, 2단 미주의 왼쪽 단이
+/// 조기에 닫혀 미주가 다음 쪽으로 밀린다(SO-SUEOP 44쪽). 한컴은 원본·왕복본 모두
+/// 두 단을 고르게 채우므로 보정이 유지되는 쪽이 정답지와 맞는다.
+///
+/// 저장 여백을 줄이는 대신 **출처만 기록**해 재파싱이 보정을 결정론적으로 되건다.
+pub const HWP3_ORIGIN_STREAM_PATH: &str = "/RhwpHwp3Origin";
+
 /// 파서가 모델링하지 않는 원시 레코드 (라운드트립 보존용)
 #[derive(Debug, Clone, Default)]
 pub struct RawRecord {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -359,7 +359,7 @@ fn parse_hwp_with_cfb(
     // is_hwpx_source 분기를 HWPX 로 해석해야 roundtrip 쪽수가 자기정합한다.
     let is_hwpx_variant = extra_streams
         .iter()
-        .any(|(p, _)| p == crate::document_core::converters::hwpx_to_hwp::HWPX_ORIGIN_STREAM_PATH);
+        .any(|(p, _)| p == crate::model::document::HWPX_ORIGIN_STREAM_PATH);
 
     let mut doc = Document {
         header: model_header,
@@ -544,7 +544,7 @@ fn apply_hwp3_origin_fixup(doc: &mut Document) {
     if doc
         .extra_streams
         .iter()
-        .any(|(p, _)| p == crate::document_core::converters::hwpx_to_hwp::HWP3_ORIGIN_STREAM_PATH)
+        .any(|(p, _)| p == crate::model::document::HWP3_ORIGIN_STREAM_PATH)
     {
         for section in doc.sections.iter_mut() {
             let pd = &mut section.section_def.page_def;

--- a/tests/issue_1770_hwpx_origin_marker.rs
+++ b/tests/issue_1770_hwpx_origin_marker.rs
@@ -44,7 +44,7 @@ fn convert_hwp_pagination_matches_hwpx_source() {
 /// 중복 없이 유지된다.
 #[test]
 fn convert_hwp_carries_origin_marker_idempotently() {
-    use rhwp::document_core::converters::hwpx_to_hwp::HWPX_ORIGIN_STREAM_PATH;
+    use rhwp::model::document::HWPX_ORIGIN_STREAM_PATH;
 
     let mut hwpx = load(SAMPLE);
     let round1 = hwpx.export_hwp_with_adapter().expect("convert r1");


### PR DESCRIPTION
`HWPX_ORIGIN_STREAM_PATH` 와 `HWP3_ORIGIN_STREAM_PATH` 가 `document_core/converters/hwpx_to_hwp.rs` 에 정의돼 있는데, 소비자는 파서입니다(`parser/mod.rs:362`, `:547`). 파서가 `document_core::converters` 에 의존하고 있었습니다 — 바이트를 IR 로 바꾸는 아래 층이 IR 을 정렬하는 위 층에 의존하는 셈입니다.

형제 상수 `HWP5_ORIGIN_HWPX_MARKER_PATH` 는 이미 `model/document.rs` 에 있었으므로 셋을 그리로 모았습니다.

옮기기 전에 전 소비처를 뽑아 확인했습니다 — 세 상수 모두 경로 문자열 비교에만 쓰이고 정의 모듈의 로직을 전제하지 않아, 상수만 옮기면 되는 경우였습니다. 재수출·별칭·가시성 확대 없이 정의 위치만 바뀌었습니다.

이관 후 `src/parser/` 에 남은 `document_core` 참조는 하나뿐이고 `#[cfg(test)]` 안입니다(`hwp3/mod.rs:5678` 의 왕복 테스트가 `DocumentCore` 를 씁니다). 통합 성격 테스트가 상위 층을 부르는 것은 의존 방향이 아니라 테스트 배치 문제라 손대지 않았습니다. **프로덕션 파서 코드에는 남아 있지 않습니다.**

동작이 바뀌지 않으므로 red→green 쌍이 없습니다. 비회귀로 답합니다 — `cargo test --profile release-test --tests` exit 0, `test result: ok` 블록 502개, FAILED 0건. fmt·clippy clean.

Closes #4435