### PR TITLE
renderer: 읽는 쪽이 없는 RenderNode.dirty 플래그와 관측자 API 제거

### DIFF
--- a/mydocs/working/task_m100_4431_stage1.md
+++ b/mydocs/working/task_m100_4431_stage1.md
@@ -1,0 +1,66 @@
+# task_m100_4431 Stage 1 — RenderNode.dirty 죽은 플래그 제거
+
+- **이슈**: [#4431](https://github.com/edwardkim/rhwp/issues/4431)
+- **브랜치**: `fix/issue-4431-render-node-dead-dirty`
+- **분기 기준**: `upstream/devel` `9f5911e86` (0 behind)
+- **상태**: 게이트 통과, PR 게시
+- **기록일**: 2026-08-10 KST
+
+## 1. 이슈 주장 중 틀린 것을 먼저 정정한다
+
+이슈 본문은 `RenderNode` 가 `Serialize` 를 파생하고 `dirty` 에 `skip_serializing_if` 가 없으니
+**모든 노드가 `"dirty":true` 를 싣고 wasm 경계를 넘는다**고 적었다. **아니다.**
+
+파생은 있지만 실제로 쓰이는 JSON 경로는 손으로 쓴 `write_json`(`render_tree.rs:187`,
+`to_json` `:181`)이고 이 함수는 `dirty` 를 방출하지 않는다. `serde_json::to_string` 이나
+`serde_wasm_bindgen` 으로 트리를 내보내는 호출부도 `src/` 안에 없다.
+
+실측으로 확인했다 — `export-render-tree` 로 393쪽 문서를 내보낸 JSON **5,729,677바이트,
+노드 61,389개**에 `"dirty"` 가 **0건**이다.
+
+**바이트 절감은 0이다.** 이슈에 코멘트로 정정하고 제목도 고쳤다.
+
+## 2. 남는 근거 — 관측자 없는 관측자 패턴
+
+읽는 쪽이 없다는 것은 맞다. 다만 "아무도 안 건드린다"도 정확하지 않았다 — **쓰는 쪽은
+프로덕션에 있었다.**
+
+- 쓰기: `src/document_core/queries/rendering.rs:6004-6005` 의 `line_node.invalidate()`,
+  `tree.root.invalidate()`
+- 읽기: `has_dirty_nodes`(`render_tree.rs:173`), `RenderTree::has_dirty_nodes`(`:1548`) —
+  **프로덕션 호출부 없음**
+
+값이 어디로도 흘러가지 않는 막다른 플래그다. 지운다.
+
+## 3. 지운 것
+
+`RenderNode.dirty` 필드, `invalidate`, `mark_clean`, `mark_clean_recursive`,
+`has_dirty_nodes`, `RenderTree::has_dirty_nodes`, 그리고 이들만 검증하던
+`test_render_node_dirty_flag`. 유일한 프로덕션 쓰기 두 줄도 함께 제거했다.
+
+총 59줄 삭제, 추가 0줄.
+
+## 4. 검증
+
+동작이 바뀌지 않으므로 red→green 쌍이 없다. **호출부가 없다는 것은 컴파일이 증명한다** —
+필드와 함수를 지우고도 전 크레이트가 빌드되면 그것이 증거다.
+
+- `cargo fmt --all -- --check` exit 0
+- `cargo clippy --all-targets -- -D warnings` exit 0
+- `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests` exit 0 —
+  `test result: ok` 블록 **502개, FAILED 0건**
+
+렌더러 범위이므로 `local_validation.md` §4.3 추가 게이트도 실행했다.
+
+- `cargo test --profile release-test --features skia --lib` exit 0
+- `cargo test --profile release-test --features skia --test issue_2225_missing_picture_placeholder` exit 0
+- `cargo test --profile release-test --features skia --test render_p37_direct_pdf_export` exit 0
+- `wasm-pack build --target web` 성공
+
+**시각 증거는 별도로 만들지 않았다.** 이 변경이 렌더 출력에 닿을 수 있는 유일한 경로가
+`write_json` 인데 그 함수가 `dirty` 를 애초에 방출하지 않음을 소스와 실측 양쪽으로 확인했고,
+Skia 3종이 실제 래스터 경로를 통과했다. 출력 바이트가 달라질 수 있는 자리가 없다.
+
+## 5. 미처리
+
+GitHub Actions, 작업지시자 승인, merge.

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -6001,8 +6001,6 @@ impl DocumentCore {
                 return None;
             }
             line_node.children = replacement_nodes;
-            line_node.invalidate();
-            tree.root.invalidate();
         }
 
         if let Some(variants) = self

--- a/src/renderer/layout/tests.rs
+++ b/src/renderer/layout/tests.rs
@@ -469,7 +469,6 @@ fn test_build_page_with_paragraph() {
         0,
         &[],
     );
-    assert!(tree.needs_render());
 
     // Body 노드 찾기
     let body = tree

--- a/src/renderer/render_tree.rs
+++ b/src/renderer/render_tree.rs
@@ -111,8 +111,6 @@ pub struct RenderNode {
     pub layer: Option<RenderLayerInfo>,
     /// 자식 노드 목록
     pub children: Vec<RenderNode>,
-    /// 변경 여부 플래그 (dirty flag for observer pattern)
-    pub dirty: bool,
     /// 가시성
     pub visible: bool,
     /// 문단 부호·투명 테두리처럼 편집 화면에서만 보여야 하는 보조 표시.
@@ -128,7 +126,6 @@ impl RenderNode {
             bbox,
             layer: None,
             children: Vec::new(),
-            dirty: true,
             visible: true,
             editor_only: false,
         }
@@ -149,32 +146,6 @@ impl RenderNode {
     pub fn with_editor_only(mut self) -> Self {
         self.editor_only = true;
         self
-    }
-
-    /// dirty 플래그 설정 (변경된 노드만 재렌더링)
-    pub fn invalidate(&mut self) {
-        self.dirty = true;
-    }
-
-    /// 렌더링 완료 후 dirty 플래그 초기화
-    pub fn mark_clean(&mut self) {
-        self.dirty = false;
-    }
-
-    /// 이 노드와 모든 자식의 dirty 플래그 초기화
-    pub fn mark_clean_recursive(&mut self) {
-        self.dirty = false;
-        for child in &mut self.children {
-            child.mark_clean_recursive();
-        }
-    }
-
-    /// dirty 노드가 있는지 확인
-    pub fn has_dirty_nodes(&self) -> bool {
-        if self.dirty {
-            return true;
-        }
-        self.children.iter().any(|c| c.has_dirty_nodes())
     }
 
     /// 렌더 트리를 JSON 문자열로 직렬화한다.
@@ -1543,16 +1514,6 @@ impl PageRenderTree {
         self.frame.next_id()
     }
 
-    /// dirty 노드 존재 여부
-    pub fn needs_render(&self) -> bool {
-        self.root.has_dirty_nodes()
-    }
-
-    /// 전체 트리를 clean으로 마킹
-    pub fn mark_all_clean(&mut self) {
-        self.root.mark_clean_recursive();
-    }
-
     /// 한컴 PDF가 현대 글리프로 인쇄하는 닫힌 레거시 제품명 어휘를 최종 화면
     /// 문자열에만 투영한다.
     ///
@@ -1747,11 +1708,8 @@ mod tests {
     #[test]
     fn test_page_render_tree() {
         let mut tree = PageRenderTree::new(0, 793.7, 1122.5);
-        assert!(tree.needs_render());
         assert_eq!(tree.next_id(), 1);
         assert_eq!(tree.next_id(), 2);
-        tree.mark_all_clean();
-        assert!(!tree.needs_render());
     }
 
     #[test]
@@ -1839,20 +1797,6 @@ mod tests {
         };
         assert_eq!(pua_old_hangul.text, "\u{f53a}글");
         assert_eq!(pua_old_hangul.display_text.as_deref(), Some("ᄒᆞᆫ글"));
-    }
-
-    #[test]
-    fn test_render_node_dirty_flag() {
-        let mut node = RenderNode::new(
-            0,
-            RenderNodeType::Body { clip_rect: None },
-            BoundingBox::new(0.0, 0.0, 100.0, 100.0),
-        );
-        assert!(node.dirty);
-        node.mark_clean();
-        assert!(!node.dirty);
-        node.invalidate();
-        assert!(node.dirty);
     }
 
     #[test]


### PR DESCRIPTION
`RenderNode.dirty` 는 쓰기만 있고 읽는 쪽이 없습니다. `rendering.rs:6004-6005` 가 `invalidate()` 를 두 번 부르지만, `has_dirty_nodes` 와 `RenderTree::has_dirty_nodes` 는 자기 테스트 밖 호출부가 없습니다. 값이 어디로도 흘러가지 않는 막다른 플래그라 필드와 네 함수, 해당 테스트, 그리고 유일한 프로덕션 쓰기 두 줄을 함께 제거합니다. 59줄 삭제, 추가 0줄.

**이슈에 제가 적은 근거 하나가 틀렸으므로 밝힙니다.** "`Serialize` 파생에 `skip_serializing_if` 가 없어 모든 노드가 `\"dirty\":true` 를 싣고 wasm 경계를 넘는다"고 썼는데 사실이 아닙니다. 실제로 쓰이는 JSON 경로는 손으로 쓴 `write_json`(`render_tree.rs:187`)이고 이 함수는 `dirty` 를 방출하지 않습니다. `serde_json::to_string` 으로 트리를 내보내는 호출부도 없습니다. 393쪽 문서를 `export-render-tree` 로 내보낸 JSON 5,729,677바이트 / 노드 61,389개에 `"dirty"` 가 0건입니다. **바이트 절감은 없습니다.** 이슈에 정정 코멘트를 남기고 제목도 고쳤습니다.

동작이 바뀌지 않으므로 red→green 쌍이 없습니다. 호출부가 없다는 것은 컴파일이 증명합니다 — 지우고도 전 크레이트가 빌드됩니다.

`cargo test --profile release-test --tests` exit 0, `test result: ok` 블록 502개, FAILED 0건. fmt·clippy clean. 렌더러 범위라 Skia 3종(`--features skia --lib`, `issue_2225_missing_picture_placeholder`, `render_p37_direct_pdf_export`) 전부 exit 0, `wasm-pack build --target web` 성공.

시각 증거는 만들지 않았습니다 — 렌더 출력에 닿을 수 있는 유일한 경로인 `write_json` 이 `dirty` 를 애초에 방출하지 않음을 소스와 실측으로 확인했고, Skia 3종이 실제 래스터 경로를 통과했습니다. 출력 바이트가 달라질 자리가 없습니다.

Closes #4431