### PR TITLE
[스킬] rhwp-work-receipt — 검증 사다리 실행 규약 (영수증·감사·계보)

### DIFF
--- a/.claude/skills/rhwp-work-receipt/SKILL.md
+++ b/.claude/skills/rhwp-work-receipt/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: rhwp-work-receipt
+description: rhwp 검증 사다리(작업 영수증·감사·계보)로 에이전트 노동을 증명 가능하게 만듭니다. replay 로 영수증(입력·계획·산출 SHA-256 3종) 발급과 제3자 재현 검증, --capsule/--parent 로 작업 캡슐과 해시 체인 구축, audit 로 캡슐 폴더 전수 재현율 회계, lineage 로 연대기(부모 산출=자식 입력) 무결 판정까지 수행합니다. 트리거 — 사용자가 "이 작업 증명해/영수증 남겨", "타인 산출물 재현 검증", "작업 캡슐/체인 만들어", "캡슐 폴더 감사", "계보 검증", "재현율", "rhwp replay/audit/lineage" 등을 요청할 때.
+---
+
+# rhwp-work-receipt — 검증 사다리 실행 규약 Skill
+
+## 목적
+
+에이전트가 한 일을 **말이 아니라 재실행으로** 증명한다. 사다리 3단을 상황에
+맞게 고른다:
+
+| 단 | 명령 | 증명하는 것 | 언제 |
+|---|---|---|---|
+| 영수증 | `rhwp replay` | 작업 **하나**가 사실 (3해시) | 산출물 하나를 넘기거나 받을 때 |
+| 감사 | `rhwp audit` | 캡슐 **폴더**의 재현율 회계 | 축적된 작업을 조직 단위로 재검증할 때 |
+| 계보 | `rhwp lineage` | 작업 **역사**의 무결 (해시 체인) | 여러 작업이 이어질 때 (이전 산출 = 다음 입력) |
+
+전제는 **결정론**이다 — 같은 계획은 같은 바이트를 낸다(저장소 실측 고정).
+그래서 "재실행해서 해시가 같다"가 증명이 된다.
+
+## 판정 규약 (모든 단 공통)
+
+- 판정은 예외가 아니라 **봉투 데이터**다: `reproduced`·`reproducedRate`·
+  `valid`·`brokenAt`. 재현 실패·깨진 체인 = **exit 3** (도구 고장 아님).
+- IO 실패 exit 1, 사용법 exit 2. 실패 경로 stdout 은 0바이트다.
+
+## 절차 1 — 단건 영수증 (발급 → 제3자 검증)
+
+```bash
+# 발급(attest): 계획을 임시 산출로 재실행해 3해시 영수증. 사용자 경로는 건드리지 않는다.
+rhwp replay --plan-json '{"planVersion":"1.0","input":"원본.hwp","output":"산출.hwp","steps":[…]}' --json
+# → { inputSha256, planSha256, outputSha256, toolVersion, steps, mode:"attest" }
+
+# 제3자 검증(verify): 상대가 주장한 산출 해시를 재현으로 대조.
+rhwp replay --plan-json '<같은 계획>' --expect-output-sha256 <상대가 준 64hex> --json
+# → reproduced:true(exit 0) / false(exit 3 — 주장 기각, 근거는 봉투)
+```
+
+함정: `--plan-json` 대신 계획 파일 경로 위치 인자도 된다. `output` 경로는
+영수증 발급 중 **생성되지 않는다**(임시 재실행) — 실산출이 필요하면 `rhwp run`
+을 따로 실행하라.
+
+## 절차 2 — 작업 캡슐과 해시 체인
+
+```bash
+# 캡슐: 계획+영수증의 자기완결 교환 파일 (제3자가 이것만 받으면 재현 가능).
+rhwp replay --plan-json '<계획A>' --capsule a.capsule.json --json
+
+# 체인: 다음 작업의 입력이 이전 작업의 실산출일 때, --parent 로 부모를 지목.
+rhwp run planA.json --json                     # 실산출 O1 생성
+rhwp replay --plan-json '<계획B: input=O1>' --capsule b.capsule.json --parent a.capsule.json --json
+```
+
+함정 실록:
+- **캡슐은 발급 후 불변이다.** 에디터·포맷터로 열어 저장하는 순간 부모 해시
+  대조가 깨진다 — 의도된 동작이다(변조 검출). 수정하려면 재발급하라.
+- `--parent` 의 상대 경로는 **캡슐 파일 기준**으로 저장·해석된다(호출 cwd
+  아님). 같은 폴더에 두는 것이 가장 단순하다.
+- `--capsule` 과 `--parent` 가 같은 파일을 가리키면 거부된다(부모 덮어쓰기 방지).
+
+## 절차 3 — 폴더 감사 (재현율 회계)
+
+```bash
+rhwp audit <캡슐 폴더> --json
+# → { total, reproduced, reproducedRate, failed:[{capsule, 기대/실측 해시 또는 사유}] }
+```
+
+- 대상은 폴더 직속 `*.capsule.json` (비재귀). 0개면 exit 2.
+- `failed` 가 하나라도 있으면 exit 3 — **회계는 봉투로 읽고**, 실패 캡슐만
+  절차 1의 verify 로 개별 추적하라.
+
+## 절차 4 — 계보 검증 (연대기 무결)
+
+```bash
+rhwp lineage b.capsule.json --json          # 머리(최신) 캡슐에서 뿌리까지 거슬러 판정
+rhwp lineage b.capsule.json --deep --json   # 링크마다 재실행 재현까지 (비용: 링크 수)
+```
+
+링크 판정 3축: `parentOk`(부모 파일이 발급 당시 그대로인가) ·
+`lineageOk`(**부모 산출 해시 == 자식 입력 해시** — 연대기의 정의) ·
+`reproduced`(`--deep`). 하나라도 false 면 `brokenAt` 이 어느 캡슐인지 가리키고
+exit 3. 머리 캡슐 없음은 exit 1(IO)이다.
+
+## 권장 흐름 (요청별)
+
+- "이 편집 증명해 줘" → 절차 1 발급 → 영수증 JSON 을 산출물과 함께 전달.
+- "받은 작업이 진짜인지 확인" → 절차 1 verify (계획과 주장 해시를 요구하라).
+- "작업들을 이어서 기록" → 절차 2 체인 → 마지막에 절차 4 로 전체 판정.
+- "쌓인 캡슐 전수 점검" → 절차 3 → 실패분만 개별 verify.
+
+## 경계 (정직)
+
+- 캡슐·영수증은 **누가** 했는지는 증명하지 않는다 — 귀속(서명) 축은 4년 축
+  구현(#4511) 착지 후 이 스킬의 2부로 확장된다.
+- 영수증의 `toolVersion` 이 다르면 재현 불일치가 날 수 있다 — 판정 전에 버전
+  부터 대조하라.

--- a/mydocs/working/task_m100_4528_stage1.md
+++ b/mydocs/working/task_m100_4528_stage1.md
@@ -1,0 +1,15 @@
+# task_m100_4528 stage1 — rhwp-work-receipt 스킬 (검증 사다리 실행 규약)
+
+- 이슈: #4528 / 브랜치: task_m100_4528 (base devel)
+- 산출물: .claude/skills/rhwp-work-receipt/SKILL.md
+
+## 설계
+
+- devel 실재 명령만 참조(replay·audit·lineage·run) — 서명 계열(4년 축 #4511)은
+  머지 후 2부로 확장한다고 경계 절에 명시. 표류 가드(#4508/#4510)가 이 스킬의
+  명령 실재를 상시 보호하는 구조(가드 규약 준수: frontmatter name=폴더명·
+  description 상세·실행 참조 다수).
+- 절차 4종(단건 영수증→캡슐·체인→폴더 감사→계보 검증) + 요청별 권장 흐름 +
+  함정 실록(캡슐 불변·--parent 상대경로는 캡슐 기준·부모 덮어쓰기 거부·
+  attest 는 output 경로 미생성).
+- 판정 규약 공통 절: exit 3 = 봉투 데이터, 실패 stdout 0바이트.


### PR DESCRIPTION
## 요약 ([스킬] · 신규 1스킬)

닫는 이슈: #4528. devel 에 통합된 검증 사다리 1~3단(영수증 `replay`·감사 `audit`·계보 `lineage`)을 에이전트가 **언제 어떤 순서로** 쓰는지의 실행 규약 스킬입니다. 스킬은 유입의 첫 관문인데, 사다리는 지금 스킬 표면에 없었습니다.

## 구성

- **단 선택표**: 하나 증명=영수증 / 폴더 회계=감사 / 역사 무결=계보 — 결정론 전제 명시.
- **절차 4종**: 발급(attest)→제3자 검증(verify, 주장 기각은 exit 3 데이터) → 캡슐·`--parent` 해시 체인 → 폴더 감사(재현율 회계, 실패분 개별 추적 흐름) → 계보 3축 판정(`--deep` 비용 포함).
- **함정 실록**: 캡슐 발급 후 불변(재직렬화=변조 검출, 의도된 동작) · `--parent` 상대경로는 캡슐 파일 기준 · 부모 덮어쓰기 거부 · attest 는 output 경로를 만들지 않음(실산출은 `run`).
- **경계(정직)**: 귀속(누가)은 증명하지 않음 — 4년 축 #4511 착지 후 이 스킬의 2부로 확장.

## 가드 연동

표류 가드(#4508 / PR #4510)의 규약을 준수합니다: frontmatter name=폴더명, 상세 description, 실재 명령만 참조(2단 검증 대상 없음 — replay·audit·lineage·run 전부 devel 실재). 가드가 머지되면 이 스킬의 명령 표류를 CI 가 상시 감시합니다.

처리결과: `mydocs/working/task_m100_4528_stage1.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
