### PR TITLE
fix(renderer): #4516 꼬리말 마지막 줄 justify 공백-없음 자간 살포 억제

### DIFF
--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -1009,6 +1009,7 @@ fn compute_line_extra_spacing(
     alignment: Alignment,
     in_cell: bool,
     needs_justify: bool,
+    justify_spaces_only: bool,
     needs_distribute: bool,
     has_tabs: bool,
     suppress_cell_overflow_spacing: bool,
@@ -1172,7 +1173,12 @@ fn compute_line_extra_spacing(
         } else if total_char_count > 1 {
             // 양쪽 정렬이지만 공백 없음 (일본어/숫자 등):
             let slack = available_width - total_text_width;
-            if leader_dashes > 0 && slack > 0.0 {
+            if justify_spaces_only && slack > 0.0 {
+                // [#4516] 머리말/꼬리말 예외로만 justify 된 마지막 줄은 한컴처럼
+                // **공백만** 벌린다. 공백 없는 줄(영문 문서번호 등)에 양수 slack 을
+                // 자간으로 살포하면 글자가 전체 폭으로 흩어지므로 자연 폭 유지.
+                (0.0, 0.0, 0.0)
+            } else if leader_dashes > 0 && slack > 0.0 {
                 (0.0, 0.0, slack / leader_dashes as f64)
             } else if suppress_cell_overflow_spacing && slack < 0.0 {
                 // 셀의 좁은 내부 폭은 줄바꿈 기준일 뿐, 숫자/문자를 수평 압축하지 않는다.
@@ -3697,6 +3703,12 @@ impl LayoutEngine {
                 has_forced_break,
             );
             let needs_distribute = alignment == Alignment::Distribute;
+            // [#4516] 머리말/꼬리말 마지막 줄 예외로만 성립한 justify 는 공백에만
+            // 배분한다 (공백 없는 줄은 자연 폭 유지).
+            let justify_spaces_only = needs_justify
+                && alignment == Alignment::Justify
+                && is_last_line_of_para
+                && is_header_footer_para;
 
             let has_tabs = comp_line.runs.iter().any(|r| r.text.contains('\t'));
             // 자간은 **그려지는 글자**에 나눠 붙으므로 폭(`total_text_width`)과 같은
@@ -3729,6 +3741,7 @@ impl LayoutEngine {
                     alignment,
                     cell_ctx.is_some(),
                     needs_justify,
+                    justify_spaces_only,
                     needs_distribute,
                     has_tabs,
                     suppress_cell_overflow_spacing,
@@ -6925,6 +6938,7 @@ mod issue_2809_split_alignment_tests {
             false,
             false,
             false,
+            false,
             5,
             30.0,
             90.0,
@@ -6958,6 +6972,7 @@ mod issue_2809_split_alignment_tests {
             false,
             false,
             false,
+            false,
             5,
             total_text_width,
             90.0,
@@ -6975,6 +6990,62 @@ mod issue_2809_split_alignment_tests {
         assert!((advance + trailing_ink_overhang - 90.0).abs() < 0.001);
         assert_eq!(extra_char, 0.0);
         assert_eq!(extra_dash, 0.0);
+    }
+
+    /// [#4516] 머리말/꼬리말 예외로만 justify 된 마지막 줄: 공백 없는 영문
+    /// 문서번호에 양수 slack 을 자간으로 살포하지 않는다 (자연 폭 유지).
+    #[test]
+    fn footer_last_line_justify_without_spaces_keeps_natural_width() {
+        let line = ComposedLine {
+            runs: vec![ComposedTextRun {
+                text: "RVT-QI-02-03".to_string(),
+                ..Default::default()
+            }],
+            line_height: 1120,
+            baseline_distance: 952,
+            segment_width: 48188,
+            column_start: 0,
+            line_spacing: 560,
+            has_line_break: false,
+            char_start: 0,
+        };
+        // 꼬리말 마지막 줄 예외 (justify_spaces_only = true): 분배 없음
+        let (extra_word, extra_char, extra_dash) = compute_line_extra_spacing(
+            &line,
+            &ResolvedStyleSet::default(),
+            Alignment::Justify,
+            false,
+            true,
+            true,
+            false,
+            false,
+            false,
+            12,
+            62.5,
+            481.8,
+            40.0,
+        );
+        assert_eq!(extra_word, 0.0);
+        assert_eq!(extra_char, 0.0);
+        assert_eq!(extra_dash, 0.0);
+
+        // 본문 중간 줄 justify (justify_spaces_only = false): 기존 자간 분배 유지
+        let (_, extra_char_mid, _) = compute_line_extra_spacing(
+            &line,
+            &ResolvedStyleSet::default(),
+            Alignment::Justify,
+            false,
+            true,
+            false,
+            false,
+            false,
+            false,
+            12,
+            62.5,
+            481.8,
+            40.0,
+        );
+        assert!(extra_char_mid > 0.0);
     }
 }
 


### PR DESCRIPTION
## 요약

머리말/꼬리말 예외(task 1692)로만 justify 된 마지막 줄에서 내부 공백이 0인 줄(영문 문서번호 등)에 양수 slack 을 자간으로 살포해 문단 전체 폭으로 흩어지던 결함을 수정합니다.

Closes #4516

## 원인

- `needs_word_distribution` 은 머리말/꼬리말 문단이면 마지막 줄에도 Justify 배분을 허용한다 (task 1692, 한컴처럼 공백을 벌리기 위함).
- 그런데 `compute_line_extra_spacing` 의 공백-없음 분기는 slack 을 전 글자 자간으로 균등 분배하므로, `RVT-QI-02-03` 같은 공백 없는 줄이 전폭(≈482pt)으로 흩어진다.
- v0.8.2 에서는 배분 자간을 SVG textLength 에서 분리하는 4ca011cd5 이전이라 글리프 자체도 늘어났다 (이슈의 R=41.55pt = 자연폭 6.08 + 배분자간 34.9).

## 수정

`compute_line_extra_spacing` 에 `justify_spaces_only` 를 추가해, 머리말/꼬리말 마지막 줄 예외로 성립한 justify 는 공백에만 배분하고 공백-없음 분기의 양수 slack 분배를 건너뛴다. 음수 slack(오버플로 압축)·dash leader·본문 중간 줄 동작은 불변.

## 검증

- 이슈 XML 그대로 합성한 재현 HWPX: 수정 전 x 75.6→663.7(전폭 살포) → 수정 후 75.6→141.6(자연 폭)
- 단위 테스트 `footer_last_line_justify_without_spaces_keeps_natural_width` 추가
- 예외의 원 사례 SO-SUEOP 회귀 `cargo test --test issue_1692` 11개 통과
- 전체 `cargo test --lib` 3471 통과, clippy 무경고