### PR TITLE
fix(renderer): #4370 끝 앵커 tac 인라인 표 남은 폭 초과 시 wrap

### DIFF
--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -63,7 +63,9 @@ fn should_wrap_middle_anchored_table(
     table_footprint: f64,
     line_width: f64,
 ) -> bool {
-    control_position.is_some_and(|position| position > 0 && position < text_len)
+    // [#4370] 끝 앵커(position == text_len)도 포함한다 — 본문 텍스트 뒤에 붙은
+    // tac 표가 남은 줄 폭에 안 들어가면 페이지 우측 밖으로 방출되던 결함.
+    control_position.is_some_and(|position| position > 0 && position <= text_len)
         && occupied_width > 1.0
         && occupied_width + table_footprint > line_width + 0.5
 }
@@ -6859,6 +6861,57 @@ pub(crate) struct ParaInlineState {
     pub line_top_y: f64,
     /// 현재 line 의 최대 picture height (line wrap 임계 + 다음 line advance 용)
     pub line_height: f64,
+}
+
+#[cfg(test)]
+mod issue_4370_tac_table_wrap_tests {
+    use super::should_wrap_middle_anchored_table;
+
+    /// [#4370] 끝 앵커(텍스트 마지막 문자 뒤) tac 표도 남은 폭 초과 시 wrap 된다.
+    #[test]
+    fn end_anchored_table_wraps_when_exceeding_line_width() {
+        assert!(should_wrap_middle_anchored_table(
+            Some(25),
+            25,
+            300.0,
+            480.0,
+            567.0
+        ));
+    }
+
+    #[test]
+    fn end_anchored_table_stays_inline_when_it_fits() {
+        assert!(!should_wrap_middle_anchored_table(
+            Some(25),
+            25,
+            300.0,
+            200.0,
+            567.0
+        ));
+    }
+
+    /// 문단 선두 앵커(position == 0)는 점유 폭이 없으므로 wrap 하지 않는다.
+    #[test]
+    fn leading_anchor_never_wraps() {
+        assert!(!should_wrap_middle_anchored_table(
+            Some(0),
+            25,
+            0.0,
+            480.0,
+            567.0
+        ));
+    }
+
+    #[test]
+    fn middle_anchor_wrap_preserved() {
+        assert!(should_wrap_middle_anchored_table(
+            Some(10),
+            20,
+            120.0,
+            480.0,
+            567.0
+        ));
+    }
 }
 
 #[cfg(test)]

--- a/tests/issue_4370_bottom_overflow_reflow.rs
+++ b/tests/issue_4370_bottom_overflow_reflow.rs
@@ -1,0 +1,100 @@
+//! Issue #4370 후속: 페이지 하단 공간 부족 문단의 다음 쪽 리플로 회귀 가드.
+//!
+//! v0.7.6 은 페이지 하단 공간이 부족한 문단(연속 2개 문단, 그리고 페이지에 걸친
+//! 문단의 꼬리 줄)을 다음 쪽으로 리플로하지 않고 페이지 높이 밖 y 좌표에 그대로
+//! 방출해 내용이 시각적으로 소실됐고, v0.8.2 에서 수정이 확인됐다(이슈 리포트
+//! 실측: y=1137~1157 > 페이지 높이 1122.5). 재현 문서가 비공개라 합성 문서
+//! (빈 문서 + 여러 쪽을 채우는 장문 문단들)로 같은 불변식을 고정한다:
+//!
+//! 1. 어떤 페이지에서도 본문 텍스트의 y 좌표가 물리 페이지 높이를 넘지 않는다.
+//! 2. 넘치는 내용은 소실되지 않고 다음 쪽에 실제로 배치된다(2쪽 이상 + 마지막
+//!    쪽에도 텍스트 존재).
+
+use rhwp::wasm_api::HwpDocument;
+
+/// SVG 의 `height="..."` 속성값(물리 페이지 높이 px).
+fn svg_height(svg: &str) -> f64 {
+    let i = svg.find("height=\"").expect("svg height attr") + "height=\"".len();
+    let rest = &svg[i..];
+    let end = rest.find('"').expect("height close");
+    rest[..end].parse().expect("height f64")
+}
+
+/// SVG 내 모든 `<text ... y="...">` 의 최대 y 좌표(px). 없으면 None.
+fn max_text_y(svg: &str) -> Option<f64> {
+    let mut max: Option<f64> = None;
+    let mut rest = svg;
+    while let Some(open) = rest.find("<text") {
+        let after = &rest[open..];
+        let tag_end = after.find('>').map(|g| open + g).unwrap_or(rest.len());
+        let tag = &rest[open..tag_end];
+        if let Some(yi) = tag.find(" y=\"") {
+            let yrest = &tag[yi + 4..];
+            if let Some(ye) = yrest.find('"') {
+                if let Ok(y) = yrest[..ye].parse::<f64>() {
+                    max = Some(max.map_or(y, |m: f64| m.max(y)));
+                }
+            }
+        }
+        rest = &rest[tag_end..];
+    }
+    max
+}
+
+/// 빈 문서에 장문 문단 `para_count` 개를 만든다. 각 문단은 여러 줄로 wrap 되는
+/// 길이라 전체가 한 페이지를 확실히 넘긴다.
+fn build_multi_page_doc(para_count: usize) -> HwpDocument {
+    let mut doc = HwpDocument::create_empty();
+    for _ in 1..para_count {
+        doc.split_paragraph(0, 0, 0, None).expect("split paragraph");
+    }
+    let line = "하단 리플로 가드 문단 본문 텍스트 ".repeat(8);
+    for i in 0..para_count {
+        doc.insert_text(0, i as u32, 0, &line)
+            .unwrap_or_else(|e| panic!("insert_text para {i}: {e:?}"));
+    }
+    doc
+}
+
+#[test]
+fn bottom_short_paragraphs_reflow_to_next_page_not_clipped() {
+    let doc = build_multi_page_doc(30);
+    let pages = doc.page_count();
+    assert!(
+        pages >= 2,
+        "합성 문서가 2쪽 이상이어야 리플로 경로를 검증한다: {pages}쪽"
+    );
+
+    for page in 0..pages {
+        let svg = doc
+            .render_page_svg_native(page)
+            .unwrap_or_else(|e| panic!("render page {page}: {e:?}"));
+        let h = svg_height(&svg);
+        if let Some(max_y) = max_text_y(&svg) {
+            assert!(
+                max_y <= h,
+                "page {page}: text max_y={max_y:.1} 가 페이지 높이 {h:.1} 초과 — \
+                 하단 공간 부족 문단이 리플로되지 않고 페이지 밖으로 방출됨 (v0.7.6 회귀)"
+            );
+            // 마지막 쪽 이전 페이지는 하단 근처까지 실제로 채워져 있어야
+            // 이 가드가 공허하지 않다(리플로 압력이 걸린 상태의 검증임을 보장).
+            if page + 1 < pages {
+                assert!(
+                    max_y >= h * 0.6,
+                    "page {page}: max_y={max_y:.1} 로 페이지가 하단({:.1} 이상)까지 \
+                     채워지지 않아 리플로 경로가 검증되지 않음",
+                    h * 0.6
+                );
+            }
+        }
+    }
+
+    // 넘친 내용이 소실되지 않고 마지막 쪽까지 실제 배치됐는지 확인한다.
+    let last_svg = doc
+        .render_page_svg_native(pages - 1)
+        .expect("render last page");
+    assert!(
+        max_text_y(&last_svg).is_some(),
+        "마지막 쪽({pages})에 텍스트가 없다 — 넘친 문단이 다음 쪽으로 이월되지 않음"
+    );
+}


### PR DESCRIPTION
## 요약

본문 텍스트 **뒤에**(끝 앵커) 붙은 treat_as_char 인라인 표가 남은 줄 폭에 안 들어갈 때 wrap 없이 페이지 우측 밖으로 방출·잘리던 결함을 수정합니다.

Closes #4370

## 원인

`should_wrap_middle_anchored_table` 의 `position < text_len` 조건이 끝 앵커(표가 문단 마지막 문자 뒤에 부착, position == text_len)를 wrap 후보에서 제외했다. 이슈의 두 케이스(ls ts=58 공백 문단 끝, ls ts=50 본문 뒤)가 모두 이 형태다.

## 수정

조건을 `position <= text_len` 으로 완화해 끝 앵커를 포함한다. 선두 앵커(position == 0)와 폭이 남는 경우는 기존대로 wrap 하지 않는다.

## 검증

- 합성 재현(본문 25자 + 끝 앵커 1×1 tac 표 36000HU, body 42520HU): 수정 전 표 우변 x=895.3 으로 viewBox 793.7 초과 → 수정 후 다음 줄 x 115.3~595.3 배치
- 중간 앵커 wrap 동작 불변 (동일 재현본에서 확인)
- 단위 테스트 4건 추가 (끝 앵커 초과 wrap / 폭 내 인라인 유지 / 선두 앵커 제외 / 중간 앵커 보존)
- tac 계열 회귀 6종(issue_1070/1285/1898/2220/3738/2319) 통과, `cargo test --lib` 3471 통과

## 남은 것 (이슈 후속)

- 한컴 실물 wrap 대조는 재현 문서 미제공으로 미수행 — 표가 단독 줄이면 들어가는 크기라는 제보 전제 하에 wrap 이 맞다고 판단.
- ~~이슈에 언급된 v0.7.6 하단 오버플로 리플로 회귀 가드는 별도 건.~~ → 본 PR에 포함:
  `tests/issue_4370_bottom_overflow_reflow.rs` — 합성 다쪽 문서(빈 문서 + 장문 문단 30개)로
  ① 어떤 페이지에서도 본문 텍스트 y가 페이지 높이를 넘지 않고 ② 넘친 내용이 소실 없이
  다음 쪽에 배치되며 ③ 마지막 쪽 이전 페이지는 하단 60% 이상 채워져 리플로 압력이 실재함을 고정.
