### PR TITLE
test(renderer): #4369 같은 문단 다중 NewNumber 마지막-채택 규칙 고정

### DIFF
--- a/src/renderer/page_number.rs
+++ b/src/renderer/page_number.rs
@@ -280,6 +280,28 @@ mod tests {
         assert!(!a.should_hide_page_number(), "NewNumber 없으면 항상 표시");
     }
 
+    /// [#4369] 같은 문단에 NewNumber Page 컨트롤이 2개(12, 11 순)면 문서
+    /// 순서상 **마지막**(11)이 채택되고 이후 단조 증가한다. HWP5/HWPX 재현
+    /// (5쪽, p3 문단에 newNum 12→11 연속)에서 dump-pages 가 1,2,11,12,13 을
+    /// 내는 계약의 단위 고정.
+    #[test]
+    fn same_paragraph_multiple_new_numbers_last_wins() {
+        let nns = vec![(5usize, 12u16), (5usize, 11u16)];
+        let mut a = PageNumberAssigner::new(&nns, 1);
+
+        let p1 = mk_page(vec![PageItem::FullParagraph { para_index: 0 }]);
+        assert_eq!(a.assign(&p1), 1);
+
+        // NewNumber 2개가 같은 문단에서 함께 트리거 — 마지막(11) 채택
+        let p2 = mk_page(vec![PageItem::FullParagraph { para_index: 5 }]);
+        assert_eq!(a.assign(&p2), 11);
+
+        let p3 = mk_page(vec![PageItem::FullParagraph { para_index: 6 }]);
+        assert_eq!(a.assign(&p3), 12);
+        let p4 = mk_page(vec![PageItem::FullParagraph { para_index: 7 }]);
+        assert_eq!(a.assign(&p4), 13);
+    }
+
     #[test]
     fn multiple_new_numbers_each_consumed_once() {
         // 별첨 시작 시점에 NewNumber=1 이 또 한번 등장하는 케이스


### PR DESCRIPTION
## 요약

한 문단에 「쪽번호 새 번호」 컨트롤이 여러 개일 때의 채택 규칙을 재현으로 실증하고 단위 테스트로 고정합니다. **코드 변경 없음.**

Refs #4369

## 실증 결과

같은 문단에 newNum 12→11 을 연속 배치한 5쪽 합성 문서를 HWPX·HWP5(convert 경유) 양쪽으로 만들어 dump-pages 확인:

- 두 포맷 모두 1, 2, **11**, 12, 13 — 즉 `PageNumberAssigner::assign` 의 문서 순서상 **마지막 컨트롤 채택** 규칙이 정확히 동작한다.
- v0.8.2↔devel 간 수집(typeset.rs/engine.rs)·채택(page_number.rs) 로직 diff 없음(테스트 필드 추가뿐).
- 따라서 이슈의 v0.8.2 관측(p13=12 이후 증가)은 해당 문서의 실제 컨트롤 저장 순서가 11→12 임을 시사한다. 마지막-채택 규칙과 모순되지 않는다.

## 남은 것

- 한컴 실물의 채택 규칙(첫/마지막) 대조는 이 환경에서 불가 — 제보자가 최소 재현 파일을 만들어 주면 대조 가능.
- 표 셀 등 중첩 문단 안의 NewNumber 는 현재 수집되지 않는다(typeset.rs 의 Table 분기 비재귀). 한컴 대조 전이라 이번에 변경하지 않음.