### PR TITLE
fix(renderer): 자리차지 표 앵커 줄을 한글처럼 밴드 아래로 — 열 후처리 재배치 (#4533 ④-a)

### DIFF
--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -1372,6 +1372,8 @@ impl DocumentCore {
             &crate::model::document::Document,
         ) -> Result<T, crate::serializer::SerializeError>,
     ) -> Result<T, HwpError> {
+        let hwp3_origin = matches!(self.source_format, crate::parser::FileFormat::Hwp3)
+            || self.document.provenance.hwp3_lineage;
         let serialized = if matches!(self.source_format, crate::parser::FileFormat::Hwp) {
             let mut doc = self.document.clone();
             if !doc
@@ -1384,12 +1386,34 @@ impl DocumentCore {
                     b"1".to_vec(),
                 ));
             }
+            // HWP3→HWP5 변환본의 HWPX export 도 hwp3 계보를 이어 준다.
+            if hwp3_origin {
+                Self::push_hwp3_origin_marker(&mut doc);
+            }
             Self::materialize_hwp5_missing_linesegs_for_hwpx_export(&mut doc);
+            serialize(&doc)
+        } else if hwp3_origin {
+            let mut doc = self.document.clone();
+            Self::push_hwp3_origin_marker(&mut doc);
             serialize(&doc)
         } else {
             serialize(&self.document)
         };
         serialized.map_err(|e| HwpError::RenderError(e.to_string()))
+    }
+
+    /// HWP3 계보 마커를 export 사본에 심는다(중복 방지).
+    fn push_hwp3_origin_marker(doc: &mut crate::model::document::Document) {
+        if !doc
+            .hwpx_aux_entries
+            .iter()
+            .any(|(path, _)| path == crate::model::document::HWP3_ORIGIN_HWPX_MARKER_PATH)
+        {
+            doc.hwpx_aux_entries.push((
+                crate::model::document::HWP3_ORIGIN_HWPX_MARKER_PATH.to_string(),
+                b"1".to_vec(),
+            ));
+        }
     }
 
     /// HML 원본의 공통 IR을 HWPML 2.91 UTF-8 XML로 직렬화한다.

--- a/src/model/document.rs
+++ b/src/model/document.rs
@@ -15,6 +15,11 @@ use super::*;
 /// 마커가 사라져 native HWPX로 취급된다.
 pub const HWP5_ORIGIN_HWPX_MARKER_PATH: &str = "META-INF/rhwp-hwp5-origin";
 
+/// HWP3 원본에서 HWPX 로 export 한 산출물 마커 — 재열람 시 hwp3_lineage 를
+/// 복원해 직파싱 HWP3 와 같은 레이아웃 계약(저장-스텝 등)을 밟게 한다.
+/// 없으면 render-diff 왕복이 프로파일 차이만큼 갈라진다(hwp3-sample p7 14.9px).
+pub const HWP3_ORIGIN_HWPX_MARKER_PATH: &str = "META-INF/rhwp-hwp3-origin";
+
 /// [Issue #1770] HWPX-origin 마커 스트림 경로.
 ///
 /// rhwp 의 HWPX→HWP 변환은 LINE_SEG 를 verbatim 직렬화하므로 산출 HWP5 의 IR 은

--- a/src/parser/hwpx/mod.rs
+++ b/src/parser/hwpx/mod.rs
@@ -352,6 +352,7 @@ pub fn parse_hwpx(data: &[u8]) -> Result<Document, HwpxError> {
         "Preview/PrvText.txt",
         "Preview/PrvImage.png",
         crate::model::document::HWP5_ORIGIN_HWPX_MARKER_PATH,
+        crate::model::document::HWP3_ORIGIN_HWPX_MARKER_PATH,
     ];
     let mut hwpx_aux_entries: Vec<(String, Vec<u8>)> = Vec::new();
     for path in HWPX_AUX_PATHS {
@@ -572,6 +573,14 @@ pub fn parse_hwpx(data: &[u8]) -> Result<Document, HwpxError> {
             hwpx_lineage: false,
         },
     };
+    // HWP3-origin 마커가 있으면 계보를 복원한다 — 직파싱 HWP3 와 같은
+    // 레이아웃 계약(저장-스텝)을 밟아 왕복 등식이 성립한다.
+    if doc
+        .hwpx_aux_entry(crate::model::document::HWP3_ORIGIN_HWPX_MARKER_PATH)
+        .is_some()
+    {
+        doc.provenance.hwp3_lineage = true;
+    }
 
     // [Task #873] BinData Link 타입 의 외부 file path 영역 영역 Picture.external_path 영역
     // 전달. 이후 model::document::populate_external_images_from_dir (Task #741) 가 같은

--- a/src/renderer/height_cursor.rs
+++ b/src/renderer/height_cursor.rs
@@ -1343,6 +1343,13 @@ impl HeightCursor {
         result
     }
 
+    /// 활성 base 로 사영한 저장-사다리 기대 y. 렌더 점프가 사다리에 이미
+    /// 인코딩된 공간인지(기준점 이동 불필요) 가리는 데 쓴다 (#4533 2135039).
+    pub(crate) fn ladder_expected_y(&self, col_y: f64, first_vpos: i32) -> Option<f64> {
+        let base = self.vpos_page_base.or(self.vpos_lazy_base)?;
+        Some(col_y + hwpunit_to_px(first_vpos - base, self.dpi))
+    }
+
     /// 이미 계산된 vpos 기준 y보다 실제 렌더 y를 아래로 밀었을 때, 후속 항목도
     /// 같은 시각 기준을 따르도록 활성 vpos base를 반대로 이동한다.
     pub(crate) fn shift_vpos_base_for_rendered_delta(&mut self, delta_px: f64) {

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -6678,10 +6678,112 @@ impl LayoutEngine {
             &para_start_y,
         );
 
+        // [#4533 ④-a] 자리차지 표 앵커 줄 재배치 — 테두리 병합 전에 수행해
+        // 테두리가 이동된 줄 박스를 따라가게 한다.
+        self.relocate_float_anchor_lines_below_band(&mut col_node, paragraphs);
+
         // 문단 테두리/배경 연속 그룹 병합 렌더링 — #2120 추출
         self.render_para_border_groups(tree, composed, &mut col_node, styles, col_area);
 
         (col_node, y_offset)
+    }
+
+    /// [#4533 ④-a] 비-tac TopAndBottom 자리차지 표의 앵커 줄을 한글은 밴드
+    /// **아래**에 둔다(상주시 20155931 실측: 앵커 줄 렌더 198.1 vs 사다리 446.6,
+    /// 사이에 표 235px — dev −248.5 정확 일치 · 공작기계 156658370 동형 −226.6).
+    /// rhwp 는 흐름 순서대로 줄을 밴드 위에 그린다 — 밴드·후속 문단 위치는
+    /// 이미 사다리와 일치하므로 **줄 노드만** 사다리 위치로 재배치한다.
+    ///
+    /// 판별자는 ②판과 같은 직전-갭 서명: 직전 저장 줄 끝→호스트 vpos 갭이
+    /// 표높이×0.85 이상(= 표의 공간이 앵커 줄 위에 예약됨). 목표는 다음
+    /// 열-직속 줄의 **확정 y** 에서 저장 vpos 델타를 되뺀 값 — 흐름 좌표와
+    /// 사다리 좌표의 페이지 오프셋을 이웃에서 직접 얻으므로 절대 vpos 환산의
+    /// 다구역·다쪽 함정([[stored-ladder-is-not-a-full-page-oracle]])이 없다.
+    /// 하향·발산>2px 한정(멱등) — 전면 사다리 스냅은 #3386 에서 반증됐다.
+    fn relocate_float_anchor_lines_below_band(
+        &self,
+        col_node: &mut RenderNode,
+        paragraphs: &[Paragraph],
+    ) {
+        if !self.profile.get().native_hwp5_layout() {
+            return;
+        }
+        let lines: Vec<(usize, usize, i32, f64, f64)> = col_node
+            .children
+            .iter()
+            .enumerate()
+            .filter_map(|(i, n)| match &n.node_type {
+                RenderNodeType::TextLine(tl) => {
+                    Some((i, tl.para_index?, tl.vpos?, n.bbox.y, tl.line_height))
+                }
+                _ => None,
+            })
+            .collect();
+        for w in 0..lines.len() {
+            let (child_idx, pi, vpos, y, _) = lines[w];
+            let Some(para) = paragraphs.get(pi) else {
+                continue;
+            };
+            if para.line_segs.len() != 1 {
+                continue;
+            }
+            if lines.iter().filter(|l| l.1 == pi).count() != 1 {
+                continue;
+            }
+            let band_h: f64 = para
+                .controls
+                .iter()
+                .map(|c| match c {
+                    Control::Table(t)
+                        if !t.common.treat_as_char
+                            && matches!(
+                                t.common.text_wrap,
+                                crate::model::shape::TextWrap::TopAndBottom
+                            ) =>
+                    {
+                        hwpunit_to_px(t.common.height as i32, self.dpi)
+                    }
+                    _ => 0.0,
+                })
+                .sum();
+            if band_h <= 0.0 {
+                continue;
+            }
+            // 직전-끝은 **이 열에 렌더된 줄들의 저장 사다리**로만 구한다 —
+            // 문단 전역을 훑으면 앞 쪽 문단들의 vpos(쪽마다 리셋)가 오염시켜
+            // 다쪽 문서(공작기계 p3)에서 갭이 허상으로 쪼그라든다.
+            let prev_end_px = lines[..w]
+                .iter()
+                .filter(|l| l.2 < vpos)
+                .map(|l| hwpunit_to_px(l.2, self.dpi) + l.4)
+                .fold(f64::NEG_INFINITY, f64::max);
+            if !prev_end_px.is_finite() {
+                continue;
+            }
+            let gap_before = hwpunit_to_px(vpos, self.dpi) - prev_end_px;
+            if gap_before < band_h * 0.85 {
+                continue;
+            }
+            let Some(&(_, _, next_vpos, next_y, _)) = lines.get(w + 1) else {
+                continue;
+            };
+            if next_vpos <= vpos {
+                continue;
+            }
+            let target = next_y - hwpunit_to_px(next_vpos - vpos, self.dpi);
+            let delta = target - y;
+            if delta > 2.0 {
+                Self::translate_subtree_y(&mut col_node.children[child_idx], delta);
+            }
+        }
+    }
+
+    /// 노드와 모든 자손의 y 를 dy 만큼 이동한다.
+    fn translate_subtree_y(node: &mut RenderNode, dy: f64) {
+        node.bbox.y += dy;
+        for child in node.children.iter_mut() {
+            Self::translate_subtree_y(child, dy);
+        }
     }
 
     /// 단 내 개별 PageItem을 레이아웃한다 (1차 패스).

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -6719,7 +6719,13 @@ impl LayoutEngine {
         col_node: &mut RenderNode,
         paragraphs: &[Paragraph],
     ) {
-        if !self.profile.get().native_hwp5_layout() {
+        // HWPX 도 한글이 저장한 `<hp:linesegarray>` 사다리를 갖는 문서는 같은
+        // 서명이 성립한다(영월군 21296471: 앵커 pi5 렌더 237.7 vs 사다리 562.2,
+        // 사이에 표 316px — dev −324.5, 한글 2022 PDF 실측으로 방향 확정).
+        // lineseg 부재·전부 0 문서는 파서가 line_segs 를 비워 아래 len==1
+        // 게이트가 자연 배제한다.
+        let profile = self.profile.get();
+        if !(profile.native_hwp5_layout() || profile.hwpx_stored_layout()) {
             return;
         }
         let lines: Vec<(usize, usize, i32, f64, f64)> = col_node

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -8378,6 +8378,56 @@ impl LayoutEngine {
                             if clamped > y_offset && (clamped - y_offset) <= max_correction {
                                 y_offset = clamped;
                             }
+                            // [#4533 HWP3] 서식 코호트(영월군 20099369·채권조서
+                            // 20117321 등 5+건): 저장 앵커 lh(1000u)가 표(397px)를
+                            // 안 품는 tac 표에서 typeset 은 저장 스텝(#2373)을
+                            // 따르는데 layout 만 렌더 표높이로 전진해 조판·렌더가
+                            // 갈라진다 — 영월군 실측 typeset diff 0.0 vs layout
+                            // +388, 후속 38줄이 typeset 예산 밖(쪽 밖)으로. 저장
+                            // 델타가 정상이고 발산 >2px 면 사다리 스텝으로 맞춘다.
+                            // HWP5 는 같은 식이 2중 반증(여가부·규제영향분석서
+                            // 코호트 — 한글이 문서별 반대 진실)이라 HWP3 계보
+                            // (직파싱 + 변환본 — 왕복 등식 유지) 한정. ls 는 이후 TAC seg handling 이 후가산하므로
+                            // 선공제한다.
+                            // 변환본(HWP3→HWPX/HWP5, /RhwpHwp3Origin 마커 =
+                            // hwp3_layout)도 같은 스텝을 밟아야 render-diff 왕복
+                            // 등식이 성립한다(hwp3-sample p7 14.9px OVER 실측).
+                            // 자기일관 변환본(1892 계열)은 발산 0 이라 무동작.
+                            if self.profile.get().hwp3_native_layout()
+                                || self.profile.get().hwp3_layout()
+                            {
+                                if let Some((np, ns)) = paragraphs
+                                    .get(para_index + 1)
+                                    .and_then(|np| np.line_segs.first().map(|ns| (np, ns)))
+                                    .filter(|(_, ns)| {
+                                        ns.vertical_pos > seg.vertical_pos
+                                            && ns.vertical_pos - seg.vertical_pos
+                                                < seg.line_height.saturating_mul(4).max(160_000)
+                                    })
+                                {
+                                    let ls_px =
+                                        hwpunit_to_px(seg.line_spacing.max(0), self.dpi);
+                                    // 다음 문단이 스스로 더할 style-sb 는 사다리
+                                    // 델타에 이미 들어 있으므로 선공제한다(채택된
+                                    // ③식과 동일 구성 — 누락 시 서식27 계열이
+                                    // +15~19px 잔여로 신규 2건 발생 실측).
+                                    let next_sb = styles
+                                        .para_styles
+                                        .get(np.para_shape_id as usize)
+                                        .map(|ps| ps.spacing_before.max(0.0))
+                                        .unwrap_or(0.0);
+                                    let target = tac_table_y_before
+                                        + hwpunit_to_px(
+                                            ns.vertical_pos - seg.vertical_pos,
+                                            self.dpi,
+                                        )
+                                        - ls_px
+                                        - next_sb;
+                                    if (y_offset - target).abs() > 2.0 {
+                                        y_offset = target;
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -8405,8 +8405,7 @@ impl LayoutEngine {
                                                 < seg.line_height.saturating_mul(4).max(160_000)
                                     })
                                 {
-                                    let ls_px =
-                                        hwpunit_to_px(seg.line_spacing.max(0), self.dpi);
+                                    let ls_px = hwpunit_to_px(seg.line_spacing.max(0), self.dpi);
                                     // 다음 문단이 스스로 더할 style-sb 는 사다리
                                     // 델타에 이미 들어 있으므로 선공제한다(채택된
                                     // ③식과 동일 구성 — 누락 시 서식27 계열이

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -5702,8 +5702,46 @@ impl LayoutEngine {
                         };
                         pending_topbottom_post_jump = Some((bottom_y, base_for_post));
                     } else {
-                        y_offset = bottom_y;
-                        shape_jumped = true;
+                        // [#4533 HWP3] 비-tac TopAndBottom float 표인데 저장
+                        // 사다리가 표를 예약하지 않은 서식 문서(하동군 21918361:
+                        // host lh 13.3px·다음 문단 델타 21.3px vs 표 730px)는
+                        // 점프를 생략한다 — typeset 의 hwp3_topbottom_no_reserve
+                        // 와 짝. 표는 그 자리에 그려지고 후속 텍스트가 겹치는
+                        // 것이 한글의 정본이며, typeset 예산과 일치해야 후속
+                        // 줄이 쪽 밖으로 밀리지 않는다.
+                        let tot = picture_top_y_opt.map(|top| bottom_y - top).unwrap_or(0.0);
+                        let host_lh_px = anchor_para
+                            .line_segs
+                            .iter()
+                            .find(|s| s.tag & 0x8000_0000 == 0)
+                            .map(|s| hwpunit_to_px(s.line_height, self.dpi));
+                        let next_gap_px = paragraphs
+                            .get(anchor_pi + 1)
+                            .and_then(|np| np.line_segs.first())
+                            .zip(anchor_para.line_segs.first())
+                            .filter(|(ns, hs)| ns.vertical_pos > hs.vertical_pos)
+                            .map(|(ns, hs)| {
+                                hwpunit_to_px(ns.vertical_pos - hs.vertical_pos, self.dpi)
+                            });
+                        let is_float_table_anchor = anchor_para.controls.iter().any(|c| {
+                            matches!(c, Control::Table(t)
+                            if !t.common.treat_as_char
+                                && matches!(
+                                    t.common.text_wrap,
+                                    crate::model::shape::TextWrap::TopAndBottom
+                                ))
+                        });
+                        let hwp3_no_reserve = (self.profile.get().hwp3_native_layout()
+                            || (self.profile.get().hwp3_layout()
+                                && self.profile.get().hwpx_container()))
+                            && is_float_table_anchor
+                            && tot > 1.0
+                            && host_lh_px.is_some_and(|lh| lh < tot * 0.25)
+                            && next_gap_px.is_some_and(|g| g < tot * 0.25);
+                        if !hwp3_no_reserve {
+                            y_offset = bottom_y;
+                            shape_jumped = true;
+                        }
                     }
                 }
             }
@@ -8185,6 +8223,38 @@ impl LayoutEngine {
                     table_y_before
                 } else if table_visual_shift > 0.0 {
                     (table_visual_end - table_visual_shift).max(table_y_before)
+                } else if {
+                    // [#4533 HWP3] 비-tac TopAndBottom float 인데 저장 사다리가
+                    // 표를 예약하지 않은 서식 문서(하동군 21918361: host lh
+                    // 13.3px·다음 문단 델타 21.3px vs 표 730px) — typeset 의
+                    // 동일 판별자(hwp3_topbottom_no_reserve)와 짝을 이뤄 흐름을
+                    // 전진시키지 않는다. 표는 그 자리에 그려지고 후속 텍스트가
+                    // 겹치는 것이 한글의 정본.
+                    let host_lh_px = para
+                        .line_segs
+                        .iter()
+                        .find(|s| s.tag & 0x8000_0000 == 0)
+                        .map(|s| hwpunit_to_px(s.line_height, self.dpi));
+                    let next_gap_px = paragraphs
+                        .get(para_index + 1)
+                        .and_then(|np| np.line_segs.first())
+                        .zip(para.line_segs.first())
+                        .filter(|(ns, hs)| ns.vertical_pos > hs.vertical_pos)
+                        .map(|(ns, hs)| hwpunit_to_px(ns.vertical_pos - hs.vertical_pos, self.dpi));
+                    let tot = table_visual_end - table_y_before;
+                    (self.profile.get().hwp3_native_layout()
+                        || (self.profile.get().hwp3_layout()
+                            && self.profile.get().hwpx_container()))
+                        && !t.common.treat_as_char
+                        && matches!(
+                            t.common.text_wrap,
+                            crate::model::shape::TextWrap::TopAndBottom
+                        )
+                        && tot > 1.0
+                        && host_lh_px.is_some_and(|lh| lh < tot * 0.25)
+                        && next_gap_px.is_some_and(|g| g < tot * 0.25)
+                } {
+                    table_y_before
                 } else {
                     empty_rowbreak_flow_end.unwrap_or(table_flow_end)
                 };

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -7602,6 +7602,38 @@ impl LayoutEngine {
             let margin_right = para_style.map(|s| s.margin_right).unwrap_or(0.0);
             let table_y_before = y_offset;
             let tbl_is_square = matches!(t.common.text_wrap, crate::model::shape::TextWrap::Square);
+            // [#4533 ⑥] '위 예약' Square float — 저장 사다리가 표 공간을
+            // 앵커 **위**에 예약(직전 문단 저장 끝→호스트 vpos 갭 ≈ 표높이)한
+            // 문서는 한글이 표를 그 공간에, 앵커 줄을 아래에 둔다(아세안
+            // 156454300 실측: 갭 182.3 vs 표 188.1 — rhwp 는 표를 앵커 뒤에
+            // 그리고 +201 전진해 시각·흐름 모두 반대였고, typeset 은 밴드
+            // 비예약이라 조판·렌더 desync). 판별자는 ④-a 직전-갭 계보.
+            let square_reserved_above_gap: Option<f64> = (|| {
+                if !self.profile.get().native_hwp5_layout()
+                    || !tbl_is_square
+                    || t.common.treat_as_char
+                    || para_has_non_whitespace_text(para)
+                    || para_index == 0
+                {
+                    return None;
+                }
+                let tot = hwpunit_to_px(t.common.height as i32, self.dpi);
+                let host_lh = para
+                    .line_segs
+                    .iter()
+                    .find(|sg| sg.tag & 0x8000_0000 == 0)
+                    .map(|sg| hwpunit_to_px(sg.line_height, self.dpi))?;
+                let ps = paragraphs.get(para_index - 1)?.line_segs.last()?;
+                let hs = para.line_segs.first()?;
+                if hs.vertical_pos <= ps.vertical_pos + ps.line_height {
+                    return None;
+                }
+                let gap = hwpunit_to_px(
+                    hs.vertical_pos - (ps.vertical_pos + ps.line_height),
+                    self.dpi,
+                );
+                (tot > 1.0 && gap >= tot * 0.85 && host_lh < tot * 0.25).then_some(gap)
+            })();
             // インラインTAC表: paragraph_layoutで計算された位置を使用
             let inline_pos = if is_tac {
                 tree.get_inline_shape_position(
@@ -7971,6 +8003,9 @@ impl LayoutEngine {
                     });
                 let table_y_start = if let Some((_, _, _, lane_top, _)) = para_float_lane_info {
                     lane_top
+                } else if let Some(g) = square_reserved_above_gap {
+                    // 예약 공간 상단 — 앵커(현재 흐름 y)에서 사다리 갭만큼 위.
+                    (y_offset - g).max(col_area.y)
                 } else if let Some(abs_y) = paper_page_square_empty_top {
                     abs_y
                 } else if let Some((_, iy)) = inline_pos {
@@ -8298,6 +8333,10 @@ impl LayoutEngine {
                         && host_lh_px.is_some_and(|lh| lh < tot * 0.25)
                         && next_gap_px.is_some_and(|g| g < tot * 0.25)
                 } {
+                    table_y_before
+                } else if square_reserved_above_gap.is_some() {
+                    // [#4533 ⑥] 표는 예약 공간(앵커 위)에 이미 놓였다 — 흐름은
+                    // 전진하지 않는다(앵커·후속 문단이 사다리 위치 유지).
                     table_y_before
                 } else {
                     empty_rowbreak_flow_end.unwrap_or(table_flow_end)
@@ -8929,7 +8968,51 @@ impl LayoutEngine {
                 let suppress_empty_anchor_spacing =
                     is_current_empty_para_float && !next_is_empty_topbottom_table_anchor;
                 if let Some(seg) = para.line_segs.last() {
-                    let gap = if suppress_empty_anchor_spacing {
+                    // [#4533 ⑥] 위-예약 Square 판별 재계산(렌더 함수와 동일식) —
+                    // 앵커·후속 문단 vpos 동일(붕괴 사다리)이라 후행 간격도 0.
+                    let square_reserved_above = (|| {
+                        let Some(Control::Table(tb)) = para.controls.get(control_index) else {
+                            return false;
+                        };
+                        if !self.profile.get().native_hwp5_layout()
+                            || tb.common.treat_as_char
+                            || !matches!(tb.common.text_wrap, crate::model::shape::TextWrap::Square)
+                            || para_has_non_whitespace_text(para)
+                            || para_index == 0
+                        {
+                            return false;
+                        }
+                        let tot = hwpunit_to_px(tb.common.height as i32, self.dpi);
+                        let Some(host_lh) = para
+                            .line_segs
+                            .iter()
+                            .find(|sg| sg.tag & 0x8000_0000 == 0)
+                            .map(|sg| hwpunit_to_px(sg.line_height, self.dpi))
+                        else {
+                            return false;
+                        };
+                        let (Some(ps), Some(hs)) = (
+                            paragraphs
+                                .get(para_index - 1)
+                                .and_then(|pp| pp.line_segs.last()),
+                            para.line_segs.first(),
+                        ) else {
+                            return false;
+                        };
+                        if hs.vertical_pos <= ps.vertical_pos + ps.line_height {
+                            return false;
+                        }
+                        let gap = hwpunit_to_px(
+                            hs.vertical_pos - (ps.vertical_pos + ps.line_height),
+                            self.dpi,
+                        );
+                        tot > 1.0 && gap >= tot * 0.85 && host_lh < tot * 0.25
+                    })();
+                    let gap = if square_reserved_above {
+                        // [#4533 ⑥] 위-예약 Square: 앵커·후속 문단 vpos 가 동일
+                        // (붕괴 사다리) — 후행 간격도 사다리가 0 으로 증언한다.
+                        0
+                    } else if suppress_empty_anchor_spacing {
                         0
                     } else if is_current_empty_para_float {
                         seg.line_spacing.max(0)

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -6872,10 +6872,7 @@ impl LayoutEngine {
                         let band_shift =
                             (y + off_px + margin_px) - col_node.children[*tbl_idx].bbox.y;
                         if (-200.0..=-2.0).contains(&band_shift) {
-                            Self::translate_subtree_y(
-                                &mut col_node.children[*tbl_idx],
-                                band_shift,
-                            );
+                            Self::translate_subtree_y(&mut col_node.children[*tbl_idx], band_shift);
                         }
                     }
                 }

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -6832,6 +6832,53 @@ impl LayoutEngine {
             let delta = target - y;
             if delta > 2.0 {
                 Self::translate_subtree_y(&mut col_node.children[child_idx], delta);
+                // [#4533 ⑤-a 잔여] hwpx 는 한글이 앵커 줄 공간을 밴드 위에서
+                // 소비하지 않는다 — 밴드 상단 = 문단 상단(원 앵커 줄 y) +
+                // vertOffset + outMargin_top. 한글 2022 PDF 테두리 실측 3표본:
+                // 영월군 +0.2 · 81240 +0.1(문단 프레임 보정 후) · 가족센터
+                // +0.6px. native HWP5 는 앵커 줄 소비가 실물과 일치(상주시
+                // 실측: 공통 −4.4px 바이어스뿐)하므로 제외. 단일 자리차지 표
+                // 한정, 상향 이동만(멱등).
+                if profile.hwpx_stored_layout() {
+                    let bands: Vec<(f64, f64)> = para
+                        .controls
+                        .iter()
+                        .filter_map(|c| match c {
+                            Control::Table(t)
+                                if !t.common.treat_as_char
+                                    && matches!(
+                                        t.common.text_wrap,
+                                        crate::model::shape::TextWrap::TopAndBottom
+                                    ) =>
+                            {
+                                Some((
+                                    hwpunit_to_px(t.common.vertical_offset as i32, self.dpi),
+                                    hwpunit_to_px(t.common.margin.top as i32, self.dpi),
+                                ))
+                            }
+                            _ => None,
+                        })
+                        .collect();
+                    let table_nodes: Vec<usize> = col_node
+                        .children
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(i, n)| match &n.node_type {
+                            RenderNodeType::Table(t) if t.para_index == Some(pi) => Some(i),
+                            _ => None,
+                        })
+                        .collect();
+                    if let ([(off_px, margin_px)], [tbl_idx]) = (&bands[..], &table_nodes[..]) {
+                        let band_shift =
+                            (y + off_px + margin_px) - col_node.children[*tbl_idx].bbox.y;
+                        if (-200.0..=-2.0).contains(&band_shift) {
+                            Self::translate_subtree_y(
+                                &mut col_node.children[*tbl_idx],
+                                band_shift,
+                            );
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -6303,7 +6303,21 @@ impl LayoutEngine {
                 if jump_to > y_offset + 0.5 {
                     let delta = jump_to - y_offset;
                     y_offset = jump_to;
-                    hcursor.shift_vpos_base_for_rendered_delta(delta);
+                    // [#4533] 자리차지 밴드의 공간이 저장 사다리에 이미 인코딩된
+                    // 문서(2135039: pi7 vpos 11535 = 밴드 포함 위치, 기대 229.4 ==
+                    // 점프 결과)에서 base 를 이동하면 후속 전 문단이 밴드 높이만큼
+                    // 이중 전진한다(+123.9px). 점프 결과가 사다리 기대와 일치하면
+                    // 이동을 생략한다 — 사다리가 밴드를 모르는 문서(점프가 진짜
+                    // 렌더-외 변위)만 종전대로 이동.
+                    let ladder_encodes_jump = paragraphs
+                        .get(item_para)
+                        .and_then(|p| p.line_segs.first())
+                        .and_then(|s| hcursor.ladder_expected_y(col_area.y, s.vertical_pos))
+                        .map(|exp| (exp - jump_to).abs() <= 6.0)
+                        .unwrap_or(false);
+                    if !ladder_encodes_jump {
+                        hcursor.shift_vpos_base_for_rendered_delta(delta);
+                    }
                 }
             }
 

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -6995,7 +6995,19 @@ impl TypesetEngine {
             } else {
                 Vec::new()
             };
-            let is_multi_fullpage_img_para = fullpage_img_ctrls.len() >= 2;
+            // [#4654] 낱장 배치는 **전면 크기가 과반**인 문단에만 — 디자인
+            // 보드형 pile(체육대회 4510000-202300010: 한 문단 그림 210장 중
+            // 전면 ~15장, 한글은 쪽당 60여 장 통 적재에 전면 그림도 포함)에서
+            // 소수 전면 그림이 낱장으로 탈출해 +12쪽이 됐다. #1995 원 취지
+            // (임베드 매뉴얼: 전량 전면 96장, 오라클 268 vs 174 과소)는 과반
+            // 조건으로 그대로 보존된다.
+            let noninline_pic_count = para
+                .controls
+                .iter()
+                .filter(|c| matches!(c, Control::Picture(pic) if !pic.common.treat_as_char))
+                .count();
+            let is_multi_fullpage_img_para = fullpage_img_ctrls.len() >= 2
+                && fullpage_img_ctrls.len() * 2 >= noninline_pic_count;
 
             // [#2097] 이 문단의 TopAndBottom 자리차지 float pushdown 가로 컬럼
             // (h_left, h_right, 스택_높이) px — 가로 겹침으로 스택/나란히 판별.

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -1092,6 +1092,9 @@ struct TypesetState {
     /// 남음), 직후의 빈 후행 문단들을 anchor 첫 fragment 단에 소급 흡수한다.
     /// 비어있지 않은 문단/새 표/쪽나누기를 만나면 해제.
     behind_float_table_para: Option<usize>,
+    /// [#4533 HWP3] 현재 문단 다음 문단의 첫 저장 lineseg vpos — 자리차지
+    /// 밴드 비예약(사다리 증거) 판별용. 문단 루프 머리에서 세팅.
+    next_para_first_stored_vpos: Option<i32>,
     /// [#1955] 글뒤로 표 후행 빈 문단의 보류 흡수 목록. 표 fragment 는 지연 flush
     /// 되므로 흡수 시점에는 anchor 첫 fragment 단을 찾을 수 없다 — 페이지 확정 후
     /// (최종 flush 뒤) 첫 fragment 단에 일괄 부착한다.
@@ -3539,6 +3542,7 @@ impl TypesetState {
             wrap_around_table_para: 0,
             wrap_around_any_seg: false,
             behind_float_table_para: None,
+            next_para_first_stored_vpos: None,
             behind_pending_absorbs: Vec::new(),
             current_column_wrap_around_paras: Vec::new(),
             current_column_wrap_anchors: std::collections::HashMap::new(),
@@ -5886,6 +5890,11 @@ impl TypesetEngine {
             if st.prefilled_paras.contains(&para_idx) {
                 continue;
             }
+            // [#4533 HWP3] 자리차지 밴드 비예약 판별용 — 표 경로 포함 전 문단 공통.
+            st.next_para_first_stored_vpos = paragraphs
+                .get(para_idx + 1)
+                .and_then(|p| p.line_segs.first())
+                .map(|seg| seg.vertical_pos);
             if std::env::var("RHWP_FLOW_DBG").is_ok() {
                 eprintln!(
                     "FLOW_DBG pi={} page={} cur_h={:.1}",
@@ -17788,7 +17797,34 @@ impl TypesetEngine {
             let hangul_flowed_beside_table = is_wrap_around_table
                 && table_total_height > 1.0
                 && stored_host_line_px.is_some_and(|lh| lh < table_total_height * 0.25);
-            if hangul_flowed_beside_table {
+            // [#4533 HWP3] 비-tac TopAndBottom float 인데 저장 사다리가 표를
+            // 예약하지 않은 서식 문서(하동군 21918361: host lh 13.3px·다음 문단
+            // 델타 21.3px vs 표 730px — 표·텍스트 겹침이 한글의 정본인데
+            // typeset/layout 이 +709 과소비). host lh 와 다음 문단 저장 델타가
+            // 둘 다 표 높이의 1/4 미만이면 흐름은 host 줄만 전진한다. HWP5 는
+            // 같은 서명이 2중 반증된 환원불가 계열이라 HWP3 계보 한정.
+            let next_gap_px = st
+                .next_para_first_stored_vpos
+                .zip(para.line_segs.first().map(|seg| seg.vertical_pos))
+                .filter(|(nv, hv)| nv > hv)
+                .map(|(nv, hv)| crate::renderer::hwpunit_to_px(nv - hv, self.dpi));
+            // 게이트: 직파싱 HWP3 + rhwp 자신의 HWPX 산출물(마커 계보)만.
+            // HWP5 컨테이너 변환본은 한글이 재저장하며 재조판한 것이라 저장
+            // lineseg 가 HWP5 계약이다 — 환경정책기본법 1480000-201600147 실측:
+            // hwp3_lineage 휴리스틱 HWP5 에 발화하면 52.7→369.8 악화.
+            let hwp3_topbottom_no_reserve = (st.profile.hwp3_native_layout()
+                || (st.profile.hwp3_layout() && st.profile.hwpx_container()))
+                && !table.common.treat_as_char
+                && matches!(
+                    table.common.text_wrap,
+                    crate::model::shape::TextWrap::TopAndBottom
+                )
+                && table_total_height > 1.0
+                && stored_host_line_px.is_some_and(|lh| lh < table_total_height * 0.25)
+                && next_gap_px.is_some_and(|g| g < table_total_height * 0.25);
+            if hwp3_topbottom_no_reserve {
+                st.current_height += pre_height + stored_host_line_px.unwrap_or(0.0);
+            } else if hangul_flowed_beside_table {
                 let band_top = st.current_height + pre_height;
                 st.current_height = band_top + stored_host_line_px.unwrap_or(0.0);
                 st.square_band_bottom = st.square_band_bottom.max(band_top + table_total_height);

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -250,6 +250,10 @@ pub fn serialize_hwpx_with_report(doc: &Document) -> Result<SerializedDocument, 
     if let Some(marker) = doc.hwpx_aux_entry(HWP5_ORIGIN_HWPX_MARKER_PATH) {
         z.write_deflated(HWP5_ORIGIN_HWPX_MARKER_PATH, marker)?;
     }
+    // HWP3-origin 마커 — 재열람 시 hwp3_lineage 복원(왕복 레이아웃 등식).
+    if let Some(marker) = doc.hwpx_aux_entry(crate::model::document::HWP3_ORIGIN_HWPX_MARKER_PATH) {
+        z.write_deflated(crate::model::document::HWP3_ORIGIN_HWPX_MARKER_PATH, marker)?;
+    }
 
     // 참조 정합성 단언 (Stage 1+)
     ctx.assert_all_refs_resolved()?;

--- a/tests/golden_svg/issue-157/page-1.svg
+++ b/tests/golden_svg/issue-157/page-1.svg
@@ -1,22 +1,22 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="793.7066666666667" height="1122.5066666666667" viewBox="0 0 793.7066666666667 1122.5066666666667">
 <defs>
 <clipPath id="body-clip-3"><rect x="60.00000000000001" y="60.00000000000001" width="1030" height="1033.3333333333335"/></clipPath>
-<clipPath id="cell-clip-25"><rect x="60.00000000000001" y="246.42666666666668" width="679.0933333333332" height="25.906666666666695"/></clipPath>
-<clipPath id="cell-clip-29"><rect x="60.00000000000001" y="272.33333333333337" width="135.81333333333333" height="25.906666666666638"/></clipPath>
-<clipPath id="cell-clip-32"><rect x="195.81333333333333" y="272.33333333333337" width="196.18666666666667" height="25.906666666666638"/></clipPath>
-<clipPath id="cell-clip-35"><rect x="392" y="272.33333333333337" width="169.7733333333333" height="25.906666666666638"/></clipPath>
-<clipPath id="cell-clip-38"><rect x="561.7733333333333" y="272.33333333333337" width="177.31999999999994" height="25.906666666666638"/></clipPath>
-<clipPath id="cell-clip-41"><rect x="60.00000000000001" y="298.24" width="135.81333333333333" height="29.680000000000007"/></clipPath>
-<clipPath id="cell-clip-44"><rect x="195.81333333333333" y="298.24" width="543.28" height="29.680000000000007"/></clipPath>
-<clipPath id="cell-clip-47"><rect x="60.00000000000001" y="327.92" width="135.81333333333333" height="29.680000000000007"/></clipPath>
-<clipPath id="cell-clip-50"><rect x="195.81333333333333" y="327.92" width="196.18666666666667" height="29.680000000000007"/></clipPath>
-<clipPath id="cell-clip-53"><rect x="392" y="327.92" width="169.7733333333333" height="29.680000000000007"/></clipPath>
-<clipPath id="cell-clip-56"><rect x="561.7733333333333" y="327.92" width="177.31999999999994" height="29.680000000000007"/></clipPath>
-<clipPath id="cell-clip-59"><rect x="60.00000000000001" y="357.6" width="135.81333333333333" height="55.5866666666667"/></clipPath>
-<clipPath id="cell-clip-62"><rect x="195.81333333333333" y="357.6" width="196.18666666666667" height="29.680000000000007"/></clipPath>
-<clipPath id="cell-clip-65"><rect x="392" y="357.6" width="169.7733333333333" height="55.5866666666667"/></clipPath>
-<clipPath id="cell-clip-68"><rect x="561.7733333333333" y="357.6" width="177.31999999999994" height="55.5866666666667"/></clipPath>
-<clipPath id="cell-clip-71"><rect x="195.81333333333333" y="387.28000000000003" width="196.18666666666667" height="25.906666666666695"/></clipPath>
+<clipPath id="cell-clip-25"><rect x="60.00000000000001" y="224.60000000000002" width="679.0933333333332" height="25.906666666666695"/></clipPath>
+<clipPath id="cell-clip-29"><rect x="60.00000000000001" y="250.50666666666672" width="135.81333333333333" height="25.906666666666638"/></clipPath>
+<clipPath id="cell-clip-32"><rect x="195.81333333333333" y="250.50666666666672" width="196.18666666666667" height="25.906666666666638"/></clipPath>
+<clipPath id="cell-clip-35"><rect x="392" y="250.50666666666672" width="169.7733333333333" height="25.906666666666638"/></clipPath>
+<clipPath id="cell-clip-38"><rect x="561.7733333333333" y="250.50666666666672" width="177.31999999999994" height="25.906666666666638"/></clipPath>
+<clipPath id="cell-clip-41"><rect x="60.00000000000001" y="276.41333333333336" width="135.81333333333333" height="29.680000000000007"/></clipPath>
+<clipPath id="cell-clip-44"><rect x="195.81333333333333" y="276.41333333333336" width="543.28" height="29.680000000000007"/></clipPath>
+<clipPath id="cell-clip-47"><rect x="60.00000000000001" y="306.09333333333336" width="135.81333333333333" height="29.680000000000007"/></clipPath>
+<clipPath id="cell-clip-50"><rect x="195.81333333333333" y="306.09333333333336" width="196.18666666666667" height="29.680000000000007"/></clipPath>
+<clipPath id="cell-clip-53"><rect x="392" y="306.09333333333336" width="169.7733333333333" height="29.680000000000007"/></clipPath>
+<clipPath id="cell-clip-56"><rect x="561.7733333333333" y="306.09333333333336" width="177.31999999999994" height="29.680000000000007"/></clipPath>
+<clipPath id="cell-clip-59"><rect x="60.00000000000001" y="335.77333333333337" width="135.81333333333333" height="55.5866666666667"/></clipPath>
+<clipPath id="cell-clip-62"><rect x="195.81333333333333" y="335.77333333333337" width="196.18666666666667" height="29.680000000000007"/></clipPath>
+<clipPath id="cell-clip-65"><rect x="392" y="335.77333333333337" width="169.7733333333333" height="55.5866666666667"/></clipPath>
+<clipPath id="cell-clip-68"><rect x="561.7733333333333" y="335.77333333333337" width="177.31999999999994" height="55.5866666666667"/></clipPath>
+<clipPath id="cell-clip-71"><rect x="195.81333333333333" y="365.4533333333334" width="196.18666666666667" height="25.906666666666695"/></clipPath>
 <clipPath id="cell-clip-142"><rect x="82.4" y="817.1333333333334" width="132.02666666666667" height="99.31999999999994"/></clipPath>
 <clipPath id="cell-clip-145"><rect x="214.42666666666668" y="817.1333333333334" width="467.8533333333333" height="99.31999999999994"/></clipPath>
 <clipPath id="cell-clip-152"><rect x="82.4" y="916.4533333333334" width="132.02666666666667" height="99.31999999999994"/></clipPath>
@@ -116,80 +116,80 @@
 <text x="113.33333333333334" y="206.80000000000004" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">.</text>
 <text x="120" y="206.80000000000004" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">)</text>
 <line x1="68" y1="410.73333333333335" x2="746.6821705426358" y2="410.73333333333335" stroke="#000000" stroke-width="1"/>
-<g clip-path="url(#cell-clip-25)"><rect x="60.00000000000001" y="246.42666666666668" width="679.0933333333332" height="25.906666666666666" fill="#cccccc"/>
-<text x="336.0466666666667" y="264.0466666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">실</text>
-<text x="349.38" y="264.0466666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">질</text>
-<text x="362.71333333333337" y="264.0466666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">주</text>
-<text x="376.0466666666667" y="264.0466666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">주</text>
-<text x="396.0466666666667" y="264.0466666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">참</text>
-<text x="409.38" y="264.0466666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">석</text>
-<text x="422.71333333333337" y="264.0466666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">자</text>
-<text x="436.0466666666667" y="264.0466666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">(</text>
-<text x="442.71333333333337" y="264.0466666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">증</text>
-<text x="456.0466666666667" y="264.0466666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">)</text>
+<g clip-path="url(#cell-clip-25)"><rect x="60.00000000000001" y="224.60000000000002" width="679.0933333333332" height="25.906666666666666" fill="#cccccc"/>
+<text x="336.0466666666667" y="242.22000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">실</text>
+<text x="349.38" y="242.22000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">질</text>
+<text x="362.71333333333337" y="242.22000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">주</text>
+<text x="376.0466666666667" y="242.22000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">주</text>
+<text x="396.0466666666667" y="242.22000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">참</text>
+<text x="409.38" y="242.22000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">석</text>
+<text x="422.71333333333337" y="242.22000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">자</text>
+<text x="436.0466666666667" y="242.22000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">(</text>
+<text x="442.71333333333337" y="242.22000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">증</text>
+<text x="456.0466666666667" y="242.22000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">)</text>
 </g>
-<g clip-path="url(#cell-clip-29)"><text x="104.40666666666667" y="289.9533333333334" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">성</text>
-<text x="137.74" y="289.9533333333334" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">명</text>
+<g clip-path="url(#cell-clip-29)"><text x="104.40666666666667" y="268.1266666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">성</text>
+<text x="137.74" y="268.1266666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">명</text>
 </g>
-<g clip-path="url(#cell-clip-32)"><text x="358.2" y="289.9533333333334" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">(</text>
-<text x="364.8666666666667" y="289.9533333333334" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">인</text>
-<text x="378.2" y="289.9533333333334" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">)</text>
+<g clip-path="url(#cell-clip-32)"><text x="358.2" y="268.1266666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">(</text>
+<text x="364.8666666666667" y="268.1266666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">인</text>
+<text x="378.2" y="268.1266666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">)</text>
 </g>
-<g clip-path="url(#cell-clip-35)"><text x="436.88666666666666" y="289.9533333333334" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">주</text>
-<text x="450.21999999999997" y="289.9533333333334" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">민</text>
-<text x="463.55333333333334" y="289.9533333333334" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">등</text>
-<text x="476.88666666666666" y="289.9533333333334" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">록</text>
-<text x="490.21999999999997" y="289.9533333333334" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">번</text>
-<text x="503.55333333333334" y="289.9533333333334" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">호</text>
+<g clip-path="url(#cell-clip-35)"><text x="436.88666666666666" y="268.1266666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">주</text>
+<text x="450.21999999999997" y="268.1266666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">민</text>
+<text x="463.55333333333334" y="268.1266666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">등</text>
+<text x="476.88666666666666" y="268.1266666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">록</text>
+<text x="490.21999999999997" y="268.1266666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">번</text>
+<text x="503.55333333333334" y="268.1266666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">호</text>
 </g>
 <g clip-path="url(#cell-clip-38)"></g>
-<g clip-path="url(#cell-clip-41)"><text x="107.90666666666667" y="317.74666666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">주</text>
-<text x="134.57333333333332" y="317.74666666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">소</text>
+<g clip-path="url(#cell-clip-41)"><text x="107.90666666666667" y="295.92" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">주</text>
+<text x="134.57333333333332" y="295.92" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">소</text>
 </g>
 <g clip-path="url(#cell-clip-44)"></g>
-<g clip-path="url(#cell-clip-47)"><text x="87.90666666666667" y="347.4266666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">의</text>
-<text x="101.24" y="347.4266666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">결</text>
-<text x="114.57333333333334" y="347.4266666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">권</text>
-<text x="127.90666666666667" y="347.4266666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">주</text>
-<text x="141.24" y="347.4266666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">식</text>
-<text x="154.57333333333332" y="347.4266666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">수</text>
+<g clip-path="url(#cell-clip-47)"><text x="87.90666666666667" y="325.6" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">의</text>
+<text x="101.24" y="325.6" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">결</text>
+<text x="114.57333333333334" y="325.6" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">권</text>
+<text x="127.90666666666667" y="325.6" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">주</text>
+<text x="141.24" y="325.6" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">식</text>
+<text x="154.57333333333332" y="325.6" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">수</text>
 </g>
 <g clip-path="url(#cell-clip-50)"></g>
 <g clip-path="url(#cell-clip-53)"></g>
 <g clip-path="url(#cell-clip-56)"></g>
-<g clip-path="url(#cell-clip-59)"><text x="101.40666666666667" y="390.06" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">참</text>
-<text x="114.74" y="390.06" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">석</text>
-<text x="128.07333333333332" y="390.06" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">구</text>
-<text x="141.40666666666667" y="390.06" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">분</text>
+<g clip-path="url(#cell-clip-59)"><text x="101.40666666666667" y="368.23333333333335" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">참</text>
+<text x="114.74" y="368.23333333333335" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">석</text>
+<text x="128.07333333333332" y="368.23333333333335" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">구</text>
+<text x="141.40666666666667" y="368.23333333333335" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">분</text>
 </g>
-<g clip-path="url(#cell-clip-62)"><text x="202.61333333333334" y="377.1066666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">주</text>
-<text x="215.9466666666667" y="377.1066666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">주</text>
-<text x="229.28" y="377.1066666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">직</text>
-<text x="242.61333333333334" y="377.1066666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">접</text>
-<text x="255.9466666666667" y="377.1066666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">참</text>
-<text x="269.28000000000003" y="377.1066666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">석</text>
-<text x="289.28000000000003" y="377.1066666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">(</text>
-<text x="322.61333333333334" y="377.1066666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">)</text>
+<g clip-path="url(#cell-clip-62)"><text x="202.61333333333334" y="355.28000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">주</text>
+<text x="215.9466666666667" y="355.28000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">주</text>
+<text x="229.28" y="355.28000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">직</text>
+<text x="242.61333333333334" y="355.28000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">접</text>
+<text x="255.9466666666667" y="355.28000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">참</text>
+<text x="269.28000000000003" y="355.28000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">석</text>
+<text x="289.28000000000003" y="355.28000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">(</text>
+<text x="322.61333333333334" y="355.28000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">)</text>
 </g>
-<g clip-path="url(#cell-clip-65)"><text x="413.38666666666666" y="390.06" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">대</text>
-<text x="426.71999999999997" y="390.06" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">리</text>
-<text x="440.05333333333334" y="390.06" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">참</text>
-<text x="453.38666666666666" y="390.06" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">석</text>
-<text x="466.71999999999997" y="390.06" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">자</text>
-<text x="480.05333333333334" y="390.06" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">와</text>
-<text x="493.38666666666666" y="390.06" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">의</text>
-<text x="513.3866666666667" y="390.06" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">관</text>
-<text x="526.72" y="390.06" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">계</text>
+<g clip-path="url(#cell-clip-65)"><text x="413.38666666666666" y="368.23333333333335" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">대</text>
+<text x="426.71999999999997" y="368.23333333333335" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">리</text>
+<text x="440.05333333333334" y="368.23333333333335" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">참</text>
+<text x="453.38666666666666" y="368.23333333333335" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">석</text>
+<text x="466.71999999999997" y="368.23333333333335" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">자</text>
+<text x="480.05333333333334" y="368.23333333333335" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">와</text>
+<text x="493.38666666666666" y="368.23333333333335" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">의</text>
+<text x="513.3866666666667" y="368.23333333333335" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">관</text>
+<text x="526.72" y="368.23333333333335" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">계</text>
 </g>
 <g clip-path="url(#cell-clip-68)"></g>
-<g clip-path="url(#cell-clip-71)"><text x="202.61333333333334" y="404.90000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">대</text>
-<text x="215.9466666666667" y="404.90000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">리</text>
-<text x="229.28" y="404.90000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">참</text>
-<text x="242.61333333333334" y="404.90000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">석</text>
-<text x="255.9466666666667" y="404.90000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">지</text>
-<text x="269.28000000000003" y="404.90000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">정</text>
-<text x="289.28000000000003" y="404.90000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">(</text>
-<text x="322.61333333333334" y="404.90000000000003" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">)</text>
+<g clip-path="url(#cell-clip-71)"><text x="202.61333333333334" y="383.0733333333334" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">대</text>
+<text x="215.9466666666667" y="383.0733333333334" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">리</text>
+<text x="229.28" y="383.0733333333334" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">참</text>
+<text x="242.61333333333334" y="383.0733333333334" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">석</text>
+<text x="255.9466666666667" y="383.0733333333334" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">지</text>
+<text x="269.28000000000003" y="383.0733333333334" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">정</text>
+<text x="289.28000000000003" y="383.0733333333334" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">(</text>
+<text x="322.61333333333334" y="383.0733333333334" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">)</text>
 </g>
 <line x1="60.00000000000001" y1="246.42666666666668" x2="739.0933333333332" y2="246.42666666666668" stroke="#000000" stroke-width="0.5"/>
 <line x1="60.00000000000001" y1="272.33333333333337" x2="739.0933333333332" y2="272.33333333333337" stroke="#000000" stroke-width="0.5"/>

--- a/tests/golden_svg/issue-157/page-1.svg
+++ b/tests/golden_svg/issue-157/page-1.svg
@@ -115,7 +115,7 @@
 <text x="100" y="206.80000000000004" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">다</text>
 <text x="113.33333333333334" y="206.80000000000004" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">.</text>
 <text x="120" y="206.80000000000004" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" fill="#000000">)</text>
-<line x1="68" y1="232.4" x2="746.6821705426358" y2="232.4" stroke="#000000" stroke-width="1"/>
+<line x1="68" y1="410.73333333333335" x2="746.6821705426358" y2="410.73333333333335" stroke="#000000" stroke-width="1"/>
 <g clip-path="url(#cell-clip-25)"><rect x="60.00000000000001" y="246.42666666666668" width="679.0933333333332" height="25.906666666666666" fill="#cccccc"/>
 <text x="336.0466666666667" y="264.0466666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">실</text>
 <text x="349.38" y="264.0466666666667" font-family="&apos;굴림체&apos;,&apos;GulimChe&apos;,&apos;굴림체&apos;,&apos;D2Coding&apos;,&apos;Noto Sans Mono&apos;,monospace" font-size="13.333333333333334" font-weight="bold" fill="#000000">질</text>


### PR DESCRIPTION
#4533 ④-a 축: 비-tac TopAndBottom 자리차지 표의 앵커 줄을 rhwp 는 흐름 순서대로 밴드 **위**에 그리는데, 한글은 밴드 **아래**에 둡니다.

**실측** — 상주시 20155931: 앵커 줄 렌더 198.1 vs 저장 사다리 446.6(사이에 표 235px) = dev −248.5 정확 일치. 공작기계 156658370 동형(−226.6). 밴드와 후속 문단 위치는 이미 사다리와 일치하므로 흐름은 건드리지 않고 **줄 노드만** 열 후처리 패스에서 재배치합니다.

**판별자** — devel 에 반입된 #4533 ②판(d400eac03)과 같은 직전-갭 서명: 직전 저장 줄 끝→호스트 vpos 갭 ≥ 표높이×0.85 (= 표의 공간이 앵커 줄 위에 예약됨). 직전-끝은 이 열에 렌더된 줄들의 사다리로만 구합니다 — 문단 전역을 훑으면 앞 쪽 문단들의 vpos(쪽마다 리셋)가 갭을 허상으로 쪼그라뜨립니다(공작기계 p3 실측). 목표는 다음 열-직속 줄의 확정 y − 저장 vpos 델타. hwp5 네이티브 + 단일 seg + 열-직속 단일 줄 + 하향·발산>2px 한정(멱등) — 전면 사다리 스냅의 #3386 반증 반경을 피합니다.

**게이트** — 상주시 248.5→0.0 · 공작기계 226.6→0.1 · 합천군 인계인수 162.4→8.0(미규명 변형이던 것도 동일 기전 판명) · 의성군 장학규정 123.8→0.1. 10k 드리프트 A/B **해소 4·개선 8·신규 0·악화 0**. 심판 4종(기장군·심의소위·148720174·거창군)·수면 유지, 92셋 100%, 표적 issue_2069/1892/4490_4491 통과, nextest 5677/5678(잔여 1 = 기지 issue_2833 부하 플레이크, 단독 통과 재확인), clippy -D warnings 클린. devel(8dbe982e8) 위 체리픽 후 재검증 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)