### PR TITLE
fix(tools): ladder-drift 검출기의 개체 줄 누수 위양성을 가드한다 (#4533 ④-c)

### DIFF
--- a/tools/verify_ladder_drift.py
+++ b/tools/verify_ladder_drift.py
@@ -35,11 +35,16 @@ LINE_RE = re.compile(
     r"^(\s*)TextLine\s+y=\s*([0-9.]+)\.\.\s*[0-9.]+\s+h=\s*([0-9.]+)\s.*?pi=(\d+)\s+line=(\d+)\s+vpos=(-?\d+)"
 )
 PAGE_RE = re.compile(r"^Page\s")
-NODE_RE = re.compile(r"^(\s*)([A-Za-z]\w*)\s")
+# dump-extents 는 미분류 노드를 전부 "기타"로 인쇄한다 — `[A-Za-z]` 앵커는 이 라벨을
+# 스택에 못 올려 글상자·도형류 FOREIGN 가드가 사문화됐다(#4533 ④-c: 통계청 156667809
+# ·근무성적 113424·누리과정 위양성의 실체). 모든 노드 행은 ` y=` 를 가지므로 그걸 앵커로 쓴다.
+NODE_RE = re.compile(r"^(\s*)(\S+)\s+y=")
 # 이 컨테이너 아래 줄은 본문 흐름 좌표계가 아니다 — 셀·글상자·도형·머리/꼬리말·각주.
+# "기타" = dump-extents 의 미분류 컨테이너(글상자·도형·이미지 등 전부).
 FOREIGN = {
     "Table", "TableCell", "Header", "Footer", "FootnoteArea", "TextBox",
     "Shape", "Group", "Rect", "Ellipse", "Path", "Equation", "MasterPage", "Image",
+    "기타",
 }
 HU_PER_PX = 75.0
 
@@ -97,7 +102,22 @@ def analyze(exe: Path, path: Path, threshold: float):
             if line == 0 and pi not in cols.setdefault(col, {}):
                 cols[col][pi] = (y, vpos)
         for col, first in cols.items():
-            ordered = [(pi, y, v) for pi, (y, v) in sorted(first.items()) if v > 0]
+            # 렌더 y 순서에서 pi 가 역행하는 줄 = 본문 흐름이 아니라 개체에 붙어
+            # 로컬 vpos 를 단 채 Column 직속으로 노출된 누수(그림 캡션 등 — #4533
+            # ④-c 환경위성 156489219 p5: pi43 줄 뒤 y 527 에 pi0 vpos=500). 조상
+            # 가드로는 못 거른다(렌더 트리가 실제로 Column 직속) — pi 역행으로 거른다.
+            max_pi = -1
+            leaked = set()
+            for pi, (y, v) in sorted(first.items(), key=lambda kv: kv[1][0]):
+                if pi < max_pi:
+                    leaked.add(pi)
+                else:
+                    max_pi = pi
+            ordered = [
+                (pi, y, v)
+                for pi, (y, v) in sorted(first.items())
+                if v > 0 and pi not in leaked
+            ]
             # vpos 되돌아감 = 쪽 중간 리베이스(구역/리스트 재시작) 신호 — 분절을 갈라
             # 각자의 중앙값으로 판정한다. 리베이스된 블록은 자기 기준으로 자기일관이라
             # 조용해지고, 같은 분절 안의 상대 이동(진짜 결함)만 남는다.


### PR DESCRIPTION
## 요약

`tools/verify_ladder_drift.py`(PR #4526)의 위양성 4건(#4533 ④-c·⑤-c)의 실체를 규명하고 가드 2종을 추가한다.

1. **'기타' 조상 사각**: dump-extents 는 미분류 노드(글상자·도형·이미지 등)를 전부 `기타`로 인쇄하는데, NODE_RE 의 `[A-Za-z]` 앵커가 이 라벨을 조상 스택에 못 올려 TextBox·Shape 등 FOREIGN 가드가 사문화돼 있었다. 글상자 내부 줄(로컬 vpos)이 본문 흐름으로 계상 — 통계청 156667809(+756.7px)·근무성적평가 113424(+476.9px)·누리과정(+460.2px) 위양성의 근인. 모든 노드 행이 ` y=` 를 갖는 점을 앵커로 쓰고 `기타`를 FOREIGN 에 편입.
2. **Column 직속 누수**: 렌더 트리가 개체 부속 줄을 실제로 Column 직속으로 내보내는 경우(환경위성 156489219 p5 그림 캡션 pi0, +446.3px)는 조상 가드로 못 거른다 — 렌더 y 순서에서 pi 가 역행하는 줄을 스킵.

## 실측

- 위양성 4건(통계청·근무성적·환경위성·누리과정) 전부 침묵 (worst 5.6~13.6px)
- 실결함 5건(영월군 −324.5 · 상주시 −248.5 · 공작기계 −226.6 · 국제우편 −123.9 · 공공주택 +807.2) 편차 불변 유지
- 가드 적용판으로 hwpx 3418건 클린 devel 스윕 → DRIFT 244건 백로그 확보 (#4533 코멘트 참조)

Issue: #4533 (④-c/⑤-c 검출기 FP 후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)