### PR TITLE
ci: CodeQL neutral 요약 check의 review-only 재사용 허용

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -77,6 +77,11 @@ jobs:
               'Analyze (rust)',
             ];
             const allowedConclusions = new Set(['success', 'skipped', 'neutral']);
+            // GitHub Advanced Security can complete the aggregate CodeQL check as
+            // neutral after every language-specific Analyze job has succeeded.
+            // That aggregate is evidence of the same candidate run, not the
+            // language-level verdict; skipped remains fail-closed here.
+            const allowedSecurityConclusions = new Set(['success', 'neutral']);
             const { owner, repo } = context.repo;
 
             function setResult(fastPass, reason, candidateSha = '') {
@@ -252,7 +257,7 @@ jobs:
                   reason: `security-check-not-completed:CodeQL:${securityCheck.status}`,
                 };
               }
-              if (securityCheck.conclusion !== 'success') {
+              if (!allowedSecurityConclusions.has(securityCheck.conclusion)) {
                 return {
                   state: 'failed',
                   reason: `security-check-not-green:CodeQL:${securityCheck.conclusion}`,

--- a/mydocs/manual/pr_review/collaborator_external_pr.md
+++ b/mydocs/manual/pr_review/collaborator_external_pr.md
@@ -2,7 +2,7 @@
 kind: guide
 status: active
 canonical: mydocs/manual/pr_review_workflow.md
-last_verified: 2026-07-25
+last_verified: 2026-08-11
 ---
 
 # Collaborator 매개 외부 PR 처리
@@ -20,6 +20,42 @@ last_verified: 2026-07-25
 
 maintainer_can_modify가 false이면 이 경로를 쓰지 않는다. maintainer 일반 경로 또는 작업지시자가 승인한
 별도 PR 경로로 전환한다.
+
+### 9.1.1 기본 작업공간: `devel` 기반 체리픽 통합 검토
+
+사용자가 VS Code·터미널에서 commit 그래프와 작업 상태를 볼 수 있어야 하는 외부 PR 검토의 기본 경로는,
+사용자가 열어 둔 **주 작업공간**에서 최신 `upstream/devel` 위에 review branch를 만들고 contributor의
+기능 commit을 순서대로 cherry-pick하는 통합 경로다. 기본 작업공간이 clean하면 검토만을 위해 별도
+`git worktree add`를 만들지 않는다. 별도 worktree는 주 작업공간이 dirty여서 격리가 꼭 필요하거나
+작업지시자가 명시적으로 요구한 경우에만 쓴다.
+
+~~~bash
+git status --short --branch
+git fetch upstream devel pull/N/head:refs/remotes/upstream/prN-head
+git switch devel
+git merge --ff-only upstream/devel
+git switch -c review/<contributor>-<yyyymmdd> upstream/devel
+git log --reverse --no-merges --format='%H %s' \
+  upstream/devel..upstream/prN-head
+# 위 목록을 오래된 commit부터 하나씩 적용하고, 각 충돌을 이 branch에서 해결한다.
+git cherry-pick <contributor-commit-sha>
+git diff --check upstream/devel...HEAD
+~~+
+
+- 적용한 원 PR 번호·SHA·cherry-pick 순서와 conflict 보정은 review 문서에 남긴다. 현재 branch는
+  `devel` 위의 contributor 변경과 메인터너 보정을 한 그래프로 보여야 한다.
+- 통합 branch의 code·test 보정은 contributor source를 rewrite하지 않는다. 완료하면 원본 저장소의 임시
+  head branch로 push해 `devel` 대상 통합 PR을 만들고, 그 PR이 merge된 뒤 원 PR은 merge된 통합 PR을
+  링크한 comment와 함께 close한다.
+- PR head가 최신 `devel`과 이미 같은 history를 공유하더라도, integration branch의 기준은 항상
+  `upstream/devel`이다. merge commit은 cherry-pick하지 않고 기능·test·문서 commit만 적용한다.
+- 주 작업공간이 dirty이면 checkout·cherry-pick을 시작하지 않는다. 사용자 변경의 소유와 상태를 먼저
+  확인하고, 작업지시자가 격리를 승인한 경우에만 정확한 worktree 경로를 사용한다.
+
+원 contributor PR head를 그대로 유지하면서 그 source branch에 collaborator commit을 직접 push해야 하는
+경우는 아래 9.3.1의 예외 경로다. 이 경우에도 사용자 가시성이 필요하면 별도 worktree 대신 같은 주
+작업공간에서 source head를 checkout한 `review/<contributor>-<yyyymmdd>` branch를 사용한다. direct source
+경로와 위 체리픽 통합 경로를 한 PR에 섞거나, contributor history를 rebase·amend·force-push하지 않는다.
 
 ## 9.2 문서 경로
 

--- a/mydocs/orders/20260811.md
+++ b/mydocs/orders/20260811.md
@@ -6,6 +6,18 @@
 | --- | --- | --- | --- |
 | [#3790](https://github.com/edwardkim/rhwp/issues/3790) | Stage 5B CodeQL 언어별 선택 실행 | 진행중 | Draft PR #4519 최신 devel 반영·reviewer `edwardkim` 지정·검토 기록 완료; 최종 full CI·CodeQL 확인 대기 |
 
+## PR #4587 - CodeQL neutral 요약의 review-only 재사용
+
+- [PR #4587](https://github.com/edwardkim/rhwp/pull/4587)은 [#4585](https://github.com/edwardkim/rhwp/issues/4585)를
+  해결한다. review-only CodeQL preflight가 GHAS 집계 `CodeQL` check의 `neutral`을 개별 Analyze 성공과
+  함께 허용하도록 보정하되, `skipped`·누락·대기·실패·취소는 계속 full 분석으로 fail-closed 한다.
+- code candidate `725568649`에서 Full CI, CodeQL의 세 language Analyze, Native Skia, lint, 모든
+  default-feature shard가 성공했다. trailing docs-only commit에서 CodeQL preflight가 이 candidate를
+  재사용하고 Analyze job을 skip하는지 확인한다.
+- [검토 기록](../pr/archives/pr_4587_review.md)에 #4525 재현 근거, local workflow contract 23건,
+  GitHub run 결과를 남겼다. 외부 PR 통합 검토는 기본적으로 사용자가 열어 둔 작업공간의 최신 `devel`
+  위 가시성 branch에서 cherry-pick하도록 공식 절차도 보강했다.
+
 ## PR #4525 - stableIndex 문서 경로 정렬 계약
 
 - [PR #4525](https://github.com/edwardkim/rhwp/pull/4525)는 `stableIndex` 정렬 계약을 숫자에서 문서 경로

--- a/mydocs/pr/archives/pr_4587_review.md
+++ b/mydocs/pr/archives/pr_4587_review.md
@@ -1,0 +1,60 @@
+---
+kind: pr-review
+status: pending-fast-pass
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-11
+---
+
+# PR #4587 리뷰 - CodeQL neutral 요약의 review-only 재사용
+
+## 라우팅과 접수
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, local_validation.md,
+  review_only_fast_pass.md
+```
+
+| 항목 | 문서 작성 시점 참고값 |
+| --- | --- |
+| PR | [#4587](https://github.com/edwardkim/rhwp/pull/4587) |
+| 관련 이슈 | [#4585](https://github.com/edwardkim/rhwp/issues/4585) |
+| base | `devel` / `d30e5d4afaaed42ed664f248dd17eed33cca3ae0` |
+| code candidate | `725568649ee231dc87dd98f3906735878296e166` |
+| trailing docs candidate | 이 문서와 오늘할일 commit |
+| 변경 범위 | `.github/workflows/codeql.yml`, workflow 계약 테스트, 외부 PR 통합 검토 절차 |
+
+## 변경 판단
+
+review-only 문서 commit 뒤의 CodeQL preflight는 원 code candidate의 language Analyze job이 모두
+허용 결론이어도, GitHub Advanced Security의 집계 `CodeQL` check가 `neutral`이면 재사용을 거부했다.
+실제 [PR #4525](https://github.com/edwardkim/rhwp/pull/4525)의 trailing docs head에서
+`security-check-not-green:CodeQL:neutral` 때문에 Rust CodeQL이 다시 실행됐다.
+
+이 PR은 language-level Analyze 결과와 집계 summary의 역할을 분리한다. candidate SHA, PR identity,
+실행 시각, 세 language Analyze check는 기존처럼 모두 확인한다. 그 뒤 GHAS summary는 `success` 또는
+`neutral`만 허용한다. `skipped`, 누락, 대기, 실패, 취소 결론은 full CodeQL로 fail-closed 한다.
+
+또한 외부 PR 통합 검토의 기본 작업공간을 최신 `devel` 위의 가시성 review branch로 명시했다. 사용자가
+열어 둔 VS Code 작업공간에서 contributor commit을 cherry-pick하고 메인터너 보정을 같은 그래프로 볼 수
+있으며, 별도 worktree는 주 작업공간이 dirty이거나 작업지시자가 격리를 요구한 경우에만 사용한다.
+
+## 완료한 검증
+
+- `python3 -m unittest scripts.tests.test_codeql_workflow scripts.tests.test_review_only_fast_pass_workflows`:
+  23건 통과. 실행형 preflight harness에서 `neutral` summary 재사용과 `skipped` summary 거부를 확인했다.
+- `python3 scripts/check_markdown_links.py mydocs/manual/pr_review/collaborator_external_pr.md`:
+  내부 Markdown 상대 링크 이상 없음.
+- `git diff --check`: 통과.
+- code candidate `725568649`의 [Full CI](https://github.com/edwardkim/rhwp/actions/runs/31483194140):
+  Build & Test, Native Skia, lint, 모든 default-feature shard 성공.
+- 같은 candidate의 [CodeQL](https://github.com/edwardkim/rhwp/actions/runs/31483193889): 세 language
+  Analyze job 성공. GHAS `CodeQL` summary는 예상대로 `neutral`이며, 이 PR의 허용 대상이다.
+
+renderer·layout·sample·WASM 구현은 바꾸지 않았으므로 Render Diff와 별도 시각 검증은 적용 대상이 아니다.
+
+## 최종 권고
+
+**수용.** 이 trailing docs-only head의 CI·CodeQL preflight가 `725568649`를 재사용하고 heavy worker와
+Analyze job을 skip하면 merge 가능하다. summary의 `neutral`만으로 재사용하지 않고, 개별 Analyze job과
+candidate identity를 계속 검증하므로 security failure를 성공으로 바꾸지 않는다.

--- a/scripts/tests/test_codeql_workflow.py
+++ b/scripts/tests/test_codeql_workflow.py
@@ -63,9 +63,16 @@ class CodeQLWorkflowTests(unittest.TestCase):
         self.assertIn("missing-security-check:CodeQL:${candidateSha}", workflow)
         self.assertIn("security-check-not-completed:CodeQL:${securityCheck.status}", workflow)
         self.assertIn("security-check-not-green:CodeQL:${securityCheck.conclusion}", workflow)
-        self.assertIn("securityCheck.conclusion !== 'success'", workflow)
+        self.assertIn(
+            "const allowedSecurityConclusions = new Set(['success', 'neutral']);",
+            workflow,
+        )
+        self.assertIn(
+            "!allowedSecurityConclusions.has(securityCheck.conclusion)", workflow
+        )
+        self.assertNotIn("securityCheck.conclusion !== 'success'", workflow)
         self.assertLess(
-            workflow.index("securityCheck.conclusion !== 'success'"),
+            workflow.index("!allowedSecurityConclusions.has(securityCheck.conclusion)"),
             workflow.index("return { state: 'green' };"),
         )
 
@@ -83,6 +90,21 @@ class CodeQLWorkflowTests(unittest.TestCase):
         self.assertEqual(outputs["fast_pass"], "true")
         self.assertEqual(outputs["candidate_sha"], "code-candidate")
         self.assertEqual(outputs["reason"], "codeql-checks-green")
+
+    def test_green_analyze_jobs_and_neutral_security_summary_remain_reusable(self) -> None:
+        outputs = self._run_preflight("neutral")
+        self.assertEqual(outputs["fast_pass"], "true")
+        self.assertEqual(outputs["candidate_sha"], "code-candidate")
+        self.assertEqual(outputs["reason"], "codeql-checks-green")
+
+    def test_green_analyze_jobs_cannot_reuse_a_skipped_security_summary(self) -> None:
+        outputs = self._run_preflight("skipped")
+        self.assertEqual(outputs["fast_pass"], "false")
+        self.assertEqual(outputs["candidate_sha"], "code-candidate")
+        self.assertEqual(
+            outputs["reason"],
+            "security-check-not-green:CodeQL:skipped",
+        )
 
     def test_security_check_from_an_earlier_run_attempt_is_not_reused(self) -> None:
         outputs = self._run_preflight(


### PR DESCRIPTION
## 요약

[#4585](https://github.com/edwardkim/rhwp/issues/4585)를 해결한다.

- review-only candidate의 language Analyze jobs가 모두 허용 결론일 때 GHAS `CodeQL` aggregate summary의 `neutral`을 재사용 가능 결론으로 인정한다.
- `skipped`, `failure`, `cancelled`, 누락, 진행 중 summary는 기존처럼 full CodeQL로 fail-closed 한다.
- 외부 PR 통합 검토는 기본적으로 사용자가 열어 둔 주 작업공간의 최신 `devel` 위에서 contributor commit을 cherry-pick해, VS Code와 터미널 그래프에 검토·보정 이력이 보이도록 문서화한다.

## 검증

- `python3 -m unittest scripts.tests.test_codeql_workflow scripts.tests.test_review_only_fast_pass_workflows`
- `python3 scripts/check_markdown_links.py mydocs/manual/pr_review/collaborator_external_pr.md`
- `git diff --check`

Closes #4585
