### PR TITLE
subsecond: 핫패치 실패가 층마다 침묵하던 것을 드러낸다

### DIFF
--- a/mydocs/README.md
+++ b/mydocs/README.md
@@ -58,7 +58,7 @@ front matter는 `mydocs/manual`, `mydocs/tech`, `mydocs/troubleshootings`의 모
 | [PR 리뷰·통합 워크플로](manual/pr_review_workflow.md) | canonical | active | `manual/pr_review_workflow.md` | 2026-08-07 |
 | [PR review 조건별 가이드](manual/pr_review/README.md) | guide | active | `manual/pr_review_workflow.md` | 2026-07-25 |
 | [에이전트 capability 카탈로그](manual/agent_capability_registry.md) | canonical | active | `manual/agent_capability_registry.md` | 2026-07-26 |
-| [개발 환경 가이드](manual/dev_environment_guide.md) | guide | active | `manual/dev_environment_guide.md` | 2026-08-08 |
+| [개발 환경 가이드](manual/dev_environment_guide.md) | guide | active | `manual/dev_environment_guide.md` | 2026-08-11 |
 | [온보딩 가이드](manual/onboarding_guide.md) | guide | active | `manual/README.md` | 2026-07-17 |
 | [배포 가이드](manual/publish_guide.md) | guide | active | `manual/publish_guide.md` | 2026-07-17 |
 | [Hyper-Waterfall 문서 체계](manual/hyper_waterfall_docs_guide.md) | guide | active | `manual/codex/docs_and_git_workflow.md` | 2026-07-17 |

--- a/mydocs/manual/dev_environment_guide.md
+++ b/mydocs/manual/dev_environment_guide.md
@@ -2,7 +2,7 @@
 kind: guide
 status: active
 canonical: mydocs/manual/dev_environment_guide.md
-last_verified: 2026-08-08
+last_verified: 2026-08-11
 ---
 
 # 개발 환경 가이드
@@ -124,6 +124,55 @@ npx vite --host 0.0.0.0 --port 7700
 
 해당 포트가 이미 사용 중이면 기존 서버를 확인하거나 다른 포트를 지정한다. 브라우저 검증 절차는
 [시각 검증 문서 지도](verification/README.md)와 각 E2E 가이드를 따른다.
+
+## Subsecond 핫패치 (개발 전용, unix 호스트 전용)
+
+Rust 를 고쳐도 WASM 재빌드 없이 실행 중인 브라우저에 반영하는 개발 전용 경로다. 기본 빌드에는
+들어가지 않는다 — 루트 `Cargo.toml` 의 `subsecond-dev` feature 뒤에 있고, 그 feature 로 빌드해야
+`applySubsecondDevtoolsMessage` 같은 export 가 생긴다.
+
+```bash
+cd rhwp-studio
+npm run subsecond:install   # dioxus-cli 0.7.10 을 target/dioxus-cli 에 고정 설치
+npm run subsecond:serve     # 별도 터미널: dx serve --hot-patch (127.0.0.1:7711)
+npm run dev:subsecond       # RHWP_SUBSECOND=1 vite
+```
+
+### 지원 플랫폼 — unix 호스트에서만 동작한다
+
+`tools/rhwp-subsecond/build.rs` 는 `dx` 가 찾는 `deps/librhwp-dioxus.rlib` 별칭을 **심링크**로
+만든다. 이 별칭의 대상(`librhwp.rlib`)은 이 빌드 스크립트가 끝난 뒤에야 생기므로 복사로 대체할 수
+없고, 심링크 생성은 `#[cfg(unix)]` 뒤에 있다. 따라서 **Windows 호스트에서는 핫패치가 동작하지
+않는다.** WSL 안에서 빌드하면 unix 경로이므로 동작한다.
+
+이때 겉으로 드러나는 증상은 "아무 일도 일어나지 않음"이다 — `subsecond:install` 성공,
+`dx serve` 정상 출력, Vite 기동, `/_dioxus` 소켓 연결, 데브서버의 `HotReload` 수신까지 모두 정상이고
+화면만 바뀌지 않는다. 그래서 unix 가 아닌 호스트에서 wasm32 대상으로 빌드하면 빌드 스크립트가
+`cargo:warning` 한 줄을 남긴다.
+
+### 실패를 어디서 읽는가
+
+핫패치는 층이 여럿이라 "안 바뀐다"는 증상만으로는 어느 층이 멈췄는지 알 수 없다. 층별 신호는 다음과
+같다.
+
+| 층 | 실패 신호 | 보는 곳 |
+|---|---|---|
+| 별칭 심링크 (`build.rs`) | `cargo:warning=rhwp-subsecond: …` | `subsecond:serve` 터미널 |
+| `dx` 패치 링크 | dx 오류 출력 | `subsecond:serve` 터미널 |
+| 메시지 판정 (`src/subsecond_dev.rs`) | `[subsecond] …` 진단 | 브라우저 콘솔 |
+| wasm 패치 적용 (subsecond 크레이트 내부) | Rust panic + 전역 오류 경고 | 브라우저 콘솔 |
+
+마지막 층에는 구조적인 한계가 있다. wasm32 에서 `subsecond::apply_patch` 는 patch wasm 의
+fetch/compile/instantiate future 를 띄우고 **즉시** `Ok(())` 를 돌려주므로(subsecond 0.7.10
+`src/lib.rs:551`, `:690`), 적용 성공 여부는 `applySubsecondDevtoolsMessage` 의 반환값이 될 수 없다.
+그래서 그 반환값은 `patch-dispatched`("넘겼다")까지만 말하고 "적용됐다"고 말하지 않는다. future
+안의 실패는 전부 `.unwrap()`/`panic!`(`lib.rs:578-582`)이라 다음 두 곳으로만 나온다.
+
+- `console_error_panic_hook`(기본 feature)이 남기는 `console.error` 의 Rust panic 메시지
+- panic 이 wasm trap 이 되어 microtask 경계를 넘은 전역 `error`/`unhandledrejection` 이벤트 —
+  `rhwp-studio/src/core/subsecond-runtime.ts` 가 이를 듣고 "패치를 넘긴 뒤 오류가 도달했다"로 보고한다
+
+브라우저 콘솔의 `[subsecond]` 진단은 개발 빌드에서만 나온다(`import.meta.env.DEV`).
 
 ## OS별 참고
 

--- a/mydocs/working/task_m100_4578_stage1.md
+++ b/mydocs/working/task_m100_4578_stage1.md
@@ -125,3 +125,27 @@ RED 를 먼저 확인했다.
   프로덕션 번들 격리는 위 grep 으로 실측했다.
 - build.rs: 끊긴 별칭 상태에서 `cargo check --target wasm32` 출력에 경고 0건, 별칭을 지우고
   다시 빌드해도 재생성 안 됨 → 수정 후 경고가 뜨고 별칭이 재생성된다.
+
+
+## 후속 이슈 (2026-08-11)
+
+- **[#4588](https://github.com/edwardkim/rhwp/issues/4588)** — `subsecond-dev` 를 켜면
+  clippy(`wasm_api.rs:886` `needless_return`)와 `--lib` 없는 wasm32 check(CLI 바이너리
+  7개 오류)가 깨진다. **둘 다 깨끗한 `upstream/devel` 에서 동일하게 재현**되는 기존 상태다.
+- **[#4589](https://github.com/edwardkim/rhwp/issues/4589)** — 결과 코드 계약이
+  `DevtoolsMessageOutcome::code()`(Rust)와 `SUBSECOND_OUTCOMES`(TS) 양쪽에 따로 적혀
+  있고 빌드 시점 동기화 검사가 없다. 결합이 문자열 데이터뿐이라 경계 자체는 옳은 모양이라,
+  "값싼 드리프트 검사가 있는가"가 질문이다.
+
+## 새 베이스 재검증 (2026-08-11)
+
+작업 중 `upstream/devel` 이 전진해(#4525 머지) 브랜치를 `d30e5d4af` 위로 다시 올렸다.
+cherry-pick 4건 깨끗, 0 behind, diff 는 7파일로 이 이슈 범위 그대로다.
+
+- `cargo fmt --all -- --check` exit 0
+- `cargo clippy --all-targets -- -D warnings` exit 0
+- `cargo test -p rhwp --features subsecond-dev --lib subsecond_dev` exit 0
+- `cargo check --lib --features subsecond-dev --target wasm32-unknown-unknown` exit 0
+- `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests` exit 0 —
+  `test result: ok` 블록 **536개, FAILED 0건**
+- studio `npx tsc --noEmit` exit 0, `npm test` **840 tests / 839 pass / 0 fail / 1 skip**

--- a/mydocs/working/task_m100_4578_stage1.md
+++ b/mydocs/working/task_m100_4578_stage1.md
@@ -1,0 +1,127 @@
+---
+kind: working
+status: active
+canonical: mydocs/manual/dev_environment_guide.md
+last_verified: 2026-08-11
+---
+
+# Task #4578 Stage 1 — 핫패치 네 층의 침묵을 깬다
+
+이슈가 지목한 침묵은 넷이고, 그중 하나는 **구조적으로 보고할 수 없는 것**이었다. 파이프라인은
+그대로 두고 신호만 낸다.
+
+## 1. 보고할 수 없는 `bool` — 없앴다
+
+`src/subsecond_dev.rs`
+
+`apply_subsecond_devtools_message` 의 `bool` 은 두 가지를 동시에 거짓말했다.
+
+- 다섯 거절 사유를 전부 `false` 하나로 접었다.
+- `true` 는 wasm32 에서 **구조적으로** 참일 수 없었다. `subsecond::apply_patch` 는 wasm32 에서
+  patch wasm 의 fetch/compile/instantiate future 를 띄우고 즉시 `Ok(())` 를 돌려주므로
+  (subsecond 0.7.10 `src/lib.rs:551`, `:690`), 적용 성공은 이 함수가 돌아온 **뒤에** 결정된다.
+
+두 선택지 중 "진실을 보고하게 만든다"는 불가능하다 — 값이 정해지는 시점이 반환 시점보다 뒤다.
+future 를 기다리려면 `Promise` 를 돌려주는 다른 함수가 되어야 하고 그건 파이프라인 재설계다.
+그래서 **거짓말하는 `bool` 을 없애는 쪽**을 골랐다. 반환값은
+`DevtoolsMessageOutcome::code()` 문자열이고, 성공값의 이름은 `patch-dispatched` —
+"넘겼다"까지만 말하고 "적용됐다"고 말하지 않는다. 없는 정보를 지어내는 대신 **없다는 사실을
+값의 이름과 문서로 드러낸다.**
+
+### wasm 실패는 어디로 나가는가 (조사 결과)
+
+이슈는 "unhandled promise rejection"이라고 적었는데, 실제 경로는 둘이고 대개는 rejection 이
+아니다.
+
+- future 안의 실패는 전부 `.unwrap()`/`panic!`(subsecond `lib.rs:578-582`)이다.
+- 이 panic 은 먼저 `console_error_panic_hook` 을 통과한다. 이 hook 은 루트 `Cargo.toml` 의
+  **기본 feature**이고 `src/lib.rs:38` 의 `#[wasm_bindgen(start)]` 로 자동 설치되므로, panic
+  **메시지 자체는 `console.error` 로 나온다** — 완전한 침묵은 아니었다. 다만 그 메시지에는
+  subsecond·핫패치라는 단어가 없어 "왜 화면이 안 바뀌나"와 연결되지 않는다.
+- panic 은 abort → wasm trap 이 되어 호출자에게 던져진다. 이 future 를 돌리는 것은
+  `wasm_bindgen_futures::spawn_local` 이 직접 돌리는 것이 아니라 js-sys 0.3 의 마이크로태스크 큐다
+  (`js-sys/src/futures/queue.rs:63-74`). 현대 브라우저에는 `queueMicrotask` 가 있으므로 trap 은
+  **`queueMicrotask` 콜백에서 던져진 예외** — HTML 명세상 uncaught exception 으로 보고되어
+  전역 `error` 이벤트가 된다. `queueMicrotask` 가 없는 폴백 경로에서만 promise reaction 이
+  되어 `unhandledrejection` 이 된다.
+
+**결론: 잡을 수는 있다. 단, 전역에서만, 그리고 귀속은 불가능하다.** 그래서 스튜디오는 두 이벤트를
+모두 듣되, "이 오류가 패치 탓이다"라고 단정하지 않고 "패치를 넘긴 뒤에 도달했다"는 사실과 다음에
+볼 곳만 말한다. 이미 abort 된 뒤라 복구 개념도 없다.
+
+## 2. 반환값을 읽지 않던 호출부
+
+`rhwp-studio/src/core/subsecond-runtime.ts`
+
+`applyMessage(event.data);` 가 결과를 버렸다. 이제 결과 코드를 표(`SUBSECOND_OUTCOMES`)로 옮겨
+수준별로 보고한다.
+
+| 코드 | 수준 | 이유 |
+|---|---|---|
+| `patch-dispatched` | info | 넘겼다는 사실은 "안 바뀐다"를 진단할 때 필요하다 |
+| `not-hot-reload` | debug | 데브서버 정상 제어 트래픽 — 경고로 올리면 소음이다 |
+| 나머지 다섯 | warn | 전부 서로 다른 문구 + 다음에 볼 곳 |
+| 표에 없는 값 | warn | 옛 번들(불리언 판)이 로드된 경우까지 드러낸다 |
+
+프로덕션 격리는 두 겹이다. (1) `applySubsecondDevtoolsMessage` 자체가 `subsecond-dev` feature
+빌드에만 있어 프로덕션 런타임은 이 경로에 오지 않는다. (2) 기본 출력이 `import.meta.env.DEV`
+뒤에 있어 Vite 가 프로덕션 번들에서 분기를 통째로 제거한다.
+
+**(2)는 처음에 성립하지 않았다.** 첫 구현은 메시지 경로에서 곧바로 완성된 문구를 넘겼는데,
+그러면 문구 표가 항상 살아 있는 코드에서 참조되어 `import.meta.env.DEV` 가 지운 것은
+`console` 호출뿐이었다. `npm run build` 산출물을 실제로 grep 해서 확인했다.
+
+```
+$ grep -c "점프 테이블을 subsecond" dist/assets/index-*.js   # 1  ← 프로덕션에 들어갔다
+$ grep -c "\[subsecond\]"           dist/assets/index-*.js   # 0  ← 콘솔 호출만 지워졌다
+```
+
+그래서 메시지 경로가 넘기는 것을 **사실만 담은 신호**(`SubsecondSignal`)로 바꾸고, 문구 생성은
+`describeSubsecondSignal` 로 미뤘다. 이 함수는 DEV 가드 안쪽에서만 참조되므로 프로덕션에서는
+아무 데서도 참조되지 않아 표와 함께 사라진다. 재측정 결과는 다음과 같다.
+
+```
+$ grep -c "점프 테이블을 subsecond" dist/assets/index-*.js   # 0
+$ grep -c "건을 넘긴 뒤"            dist/assets/index-*.js   # 0
+$ grep -c "읽지 못한 결과 값"       dist/assets/index-*.js   # 0
+$ grep -c "subsecond:serve"        dist/assets/index-*.js   # 0
+$ grep -c "_dioxus"                dist/assets/index-*.js   # 1  ← 메시지 경로는 그대로 있다
+$ grep -c "patch-dispatched"       dist/assets/index-*.js   # 1
+```
+
+**#4579 와의 경계**: 같은 파일을 건드리지만 rAF 워처와 소켓 재접속 로직은 그대로다. 소켓
+생명주기 쪽 변경은 disposer 에 전역 리스너 해제 두 줄을 더한 것뿐이다.
+
+## 3. `tools/rhwp-subsecond/build.rs` 의 네 가지 조용한 실패
+
+| 지점 | 종전 | 지금 |
+|---|---|---|
+| `#[cfg(unix)]` | 비-unix 에서 함수 자체가 없음 | `cargo:warning` — unix 전용 이유와 WSL 대안 |
+| `ancestors().nth(3)` | 조용히 `return` | `cargo:warning` + 실제 OUT_DIR 출력 |
+| `alias.exists()` | 심링크를 따라가 끊긴 별칭을 "없음"으로 읽음 → `symlink()` EEXIST → `let _` 가 삼킴 | `symlink_metadata()` 로 링크 자체를 보고, 생성 실패는 `cargo:warning` |
+| `rerun-if-changed=build.rs` 뿐 | `deps/` 정리 후 별칭이 영영 복구 안 됨 | 별칭 경로 자체를 추적 — 사라지면 다음 빌드에서 재생성 |
+
+끊긴 별칭 자체는 경고하지 않는다. 대상 rlib 은 이 스크립트가 끝난 뒤에 생기고 `cargo check` 만
+돌면 아예 생기지 않으므로, "끊김"은 정상 상태이기도 하다. 여기서 경고하면 wasm 대상
+`cargo check` 마다 거짓 경고가 난다.
+
+비-unix 를 심링크 대신 복사로 지원하지 않은 이유: 별칭 대상(`librhwp.rlib`)은 이 빌드 스크립트가
+끝난 뒤 rustc 가 만든다. 복사할 원본이 아직 없다. 지원은 진단이 아니라 기능이므로 이 작업 범위
+밖이고, 대신 제약을 말한다.
+
+## 4. 문서
+
+`mydocs/manual/dev_environment_guide.md` 에 "Subsecond 핫패치 (개발 전용, unix 호스트 전용)"
+절을 넣었다. 실행 절차, 플랫폼 제약과 그 이유, **층별 실패 신호를 어디서 읽는지**(표), 그리고
+마지막 층의 구조적 한계를 적었다.
+
+## 검증
+
+RED 를 먼저 확인했다.
+
+- Rust: 새 테스트 5건이 `E0277 can't compare bool with &str` 외 6개 오류로 컴파일 실패 →
+  구현 후 5 passed.
+- Studio: 새 테스트 4건이 **어서션 수준**으로 실패(`0 !== 5` 등) → 구현 후 9/9 통과.
+  프로덕션 번들 격리는 위 grep 으로 실측했다.
+- build.rs: 끊긴 별칭 상태에서 `cargo check --target wasm32` 출력에 경고 0건, 별칭을 지우고
+  다시 빌드해도 재생성 안 됨 → 수정 후 경고가 뜨고 별칭이 재생성된다.

--- a/rhwp-studio/src/core/subsecond-runtime.ts
+++ b/rhwp-studio/src/core/subsecond-runtime.ts
@@ -5,8 +5,31 @@ export interface SubsecondRenderCapabilities {
 }
 
 export interface SubsecondWasmExports {
-  applySubsecondDevtoolsMessage?: (message: string) => boolean;
+  /**
+   * 데브서버 메시지 한 건을 처리하고 `src/subsecond_dev.rs` 의
+   * `DevtoolsMessageOutcome::code()` 식별자를 돌려준다. `'patch-dispatched'` 는
+   * "점프 테이블을 subsecond 에 넘겼다" 까지만 뜻한다 — 아래
+   * {@link SUBSECOND_OUTCOMES} 주석 참고.
+   */
+  applySubsecondDevtoolsMessage?: (message: string) => string;
 }
+
+/**
+ * 보고할 신호. **사실만** 담고 문구는 담지 않는다.
+ *
+ * 문구를 여기 넣으면 메시지 경로에서 참조되어 프로덕션 번들까지 따라온다(실측: 진단 문구가
+ * `dist/assets/index-*.js` 에 그대로 들어갔다). 문구 생성은 개발 빌드에서만 살아남는
+ * {@link describeSubsecondSignal} 로 미룬다.
+ */
+export type SubsecondSignal =
+  | { kind: 'outcome'; code: string }
+  | { kind: 'global-failure'; eventType: string; reason: string; dispatchedPatches: number };
+
+/** 개발자에게 남길 한 줄. */
+export type SubsecondDiagnostic = {
+  level: 'debug' | 'info' | 'warn';
+  message: string;
+};
 
 type AnimationFrameScheduler = {
   requestAnimationFrame(callback: FrameRequestCallback): number;
@@ -19,15 +42,125 @@ type WebSocketConnection = {
   close(): void;
 };
 
+/** 전역 오류·거부 이벤트를 듣는 대상. 기본값은 `window` 이고 테스트가 대체한다. */
+type FailureEventTarget = {
+  addEventListener(type: string, listener: (event: Event) => void): void;
+  removeEventListener(type: string, listener: (event: Event) => void): void;
+};
+
 type SubsecondDevtoolsOptions = {
   location?: Pick<Location, 'protocol' | 'host'>;
   createWebSocket?: (url: string) => WebSocketConnection;
   setTimeout?: (callback: () => void, delay: number) => number;
   clearTimeout?: (id: number) => void;
+  reportSignal?: (signal: SubsecondSignal) => void;
+  errorEvents?: FailureEventTarget;
 };
 
 const RECONNECT_MIN_MS = 250;
 const RECONNECT_MAX_MS = 4_000;
+
+/**
+ * `DevtoolsMessageOutcome::code()` → 그 결과가 뜻하는 것과 **다음에 볼 곳**.
+ *
+ * `'patch-dispatched'` 가 성공을 뜻하지 않는 이유: wasm32 의 `subsecond::apply_patch` 는
+ * patch wasm 의 fetch/compile/instantiate future 를 띄우고 즉시 `Ok(())` 를 돌려주며
+ * (subsecond 0.7.10 `src/lib.rs:551`, `:690`), future 안의 실패는 전부 `.unwrap()`/`panic!`
+ * (`lib.rs:578-582`)이라 반환값이 되지 못한다. 그 실패를 붙잡는 곳이 전역 오류 청취다.
+ *
+ * 이 표는 {@link describeSubsecondSignal} 에서만 참조된다. 메시지 경로에서 참조하면 프로덕션
+ * 번들까지 따라온다.
+ */
+const SUBSECOND_OUTCOMES: Record<string, SubsecondDiagnostic | undefined> = {
+  'patch-dispatched': {
+    level: 'info',
+    message:
+      '점프 테이블을 subsecond 에 넘겼다. wasm 에서 적용은 비동기라 성공 여부는 여기서 알 수 없다 — ' +
+      '화면이 그대로면 이어지는 경고와 콘솔의 Rust panic 메시지를 본다.',
+  },
+  'not-hot-reload': {
+    level: 'debug',
+    message: 'HotReload 가 아닌 데브서버 메시지다. 정상 제어 트래픽이므로 조치할 것이 없다.',
+  },
+  'not-json': {
+    level: 'warn',
+    message:
+      '데브서버가 JSON 이 아닌 텍스트 프레임을 보냈다. `npm run subsecond:install` 이 고정한 ' +
+      'dioxus-cli 0.7.10 이 아닌 dx 가 떠 있는지 `npm run subsecond:serve` 터미널에서 확인한다.',
+  },
+  'foreign-build-id': {
+    level: 'warn',
+    message:
+      '다른 build_id 를 향한 패치라 무시했다. 스튜디오는 `/_dioxus?build_id=0` 으로만 접속하므로 ' +
+      'dx serve 가 다른 빌드를 감시하고 있는지 확인한다.',
+  },
+  'missing-jump-table': {
+    level: 'warn',
+    message:
+      'HotReload 에 jump_table 이 없다. dx 가 패치 링크에 실패하면 이 모양이 되므로 ' +
+      '`npm run subsecond:serve` 터미널의 링크 오류부터 본다 (호스트가 unix 가 아니면 항상 실패한다).',
+  },
+  'undeserializable-jump-table': {
+    level: 'warn',
+    message:
+      'jump_table 을 subsecond 0.7.10 의 JumpTable 로 읽지 못했다. dx 와 크레이트 버전이 어긋났는지 ' +
+      '루트 `Cargo.toml` 의 `subsecond = "=0.7.10"` 과 dx 버전을 대조한다.',
+  },
+  'patch-rejected': {
+    level: 'warn',
+    message:
+      'apply_patch 가 오류를 돌려줬다. wasm 빌드에서는 나올 수 없는 값이므로 ' +
+      '이 번들이 정말 wasm32 용인지(`src/subsecond_dev.rs` 의 DevtoolsMessageOutcome 문서) 확인한다.',
+  },
+};
+
+/** 신호 하나를 개발자가 읽을 한 줄로 만든다. */
+export function describeSubsecondSignal(signal: SubsecondSignal): SubsecondDiagnostic {
+  if (signal.kind === 'global-failure') {
+    return {
+      level: 'warn',
+      message:
+        `패치 ${signal.dispatchedPatches}건을 넘긴 뒤 처리되지 않은 ${signal.eventType} 가 도달했다: ` +
+        `${signal.reason}. 핫패치와 무관한 오류일 수도 있지만, subsecond 의 wasm apply_patch 는 ` +
+        '실패를 반환값으로 돌려주지 않으므로 이 이벤트가 유일한 신호일 수 있다. ' +
+        '다음: 콘솔의 Rust panic 메시지 → Network 탭의 `/wasm/librhwp-subsecond-patch-*.wasm` 응답 → ' +
+        '`npm run subsecond:serve` 터미널의 링크 오류.',
+    };
+  }
+  return (
+    SUBSECOND_OUTCOMES[signal.code] ?? {
+      level: 'warn',
+      message:
+        `읽지 못한 결과 값 ${JSON.stringify(signal.code)}. ` +
+        '`src/subsecond_dev.rs` 의 DevtoolsMessageOutcome::code() 와 이 표가 어긋났거나, ' +
+        '옛 WASM 번들(불리언을 돌려주던 판)이 로드돼 있다 — `npm run subsecond:sync` 를 다시 돌린다.',
+    }
+  );
+}
+
+/** 전역 오류 이벤트에서 사람이 읽을 원인 문자열을 뽑는다. */
+function readFailureReason(event: Event): string {
+  const candidate =
+    (event as PromiseRejectionEvent).reason ??
+    (event as ErrorEvent).error ??
+    (event as ErrorEvent).message;
+  if (candidate === undefined || candidate === null) return '(원인 없음)';
+  return candidate instanceof Error ? `${candidate.name}: ${candidate.message}` : String(candidate);
+}
+
+/**
+ * 기본 진단 출력.
+ *
+ * 프로덕션 번들에서 Vite 가 `import.meta.env.DEV` 를 `false` 로 치환하므로 이 함수 본문이
+ * 통째로 죽고, 그 결과 {@link describeSubsecondSignal} 과 진단 문구 표도 아무 데서도 참조되지
+ * 않아 번들에서 사라진다(`dist/assets/index-*.js` 에서 실측). 런타임으로도
+ * `applySubsecondDevtoolsMessage` 는 `subsecond-dev` 빌드에만 존재해 여기까지 오지 않는다.
+ */
+function reportToDevConsole(signal: SubsecondSignal): void {
+  if (!import.meta.env.DEV) return;
+  const { level, message } = describeSubsecondSignal(signal);
+  console[level](`[subsecond] ${message}`);
+}
 
 export class SubsecondRevisionWatcher {
   private frameId: number | null = null;
@@ -102,6 +235,8 @@ export function connectSubsecondDevtools(
   const createWebSocket = options.createWebSocket ?? (url => new WebSocket(url));
   const scheduleTimeout = options.setTimeout ?? ((callback, delay) => window.setTimeout(callback, delay));
   const cancelTimeout = options.clearTimeout ?? (id => window.clearTimeout(id));
+  const report = options.reportSignal ?? reportToDevConsole;
+  const errorEvents = options.errorEvents ?? window;
   const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
   const url = `${protocol}//${location.host}/_dioxus?build_id=0`;
 
@@ -109,14 +244,32 @@ export function connectSubsecondDevtools(
   let socket: WebSocketConnection | null = null;
   let reconnectTimer: number | null = null;
   let reconnectDelay = RECONNECT_MIN_MS;
+  let dispatchedPatches = 0;
+
+  // wasm 의 apply_patch 실패는 반환값이 아니라 panic → trap 으로만 나간다. trap 은 microtask
+  // 경계에서 전역 `error`(queueMicrotask 경로) 또는 `unhandledrejection`(promise 폴백 경로)이
+  // 되므로 양쪽을 모두 듣는다. 어느 오류가 패치 탓인지는 알 수 없으니 단정하지 않고,
+  // "패치를 넘긴 뒤였다" 는 사실과 다음에 볼 곳만 말한다.
+  const onGlobalFailure = (event: Event): void => {
+    if (dispatchedPatches === 0) return;
+    report({
+      kind: 'global-failure',
+      eventType: event.type,
+      reason: readFailureReason(event),
+      dispatchedPatches,
+    });
+  };
+  errorEvents.addEventListener('error', onGlobalFailure);
+  errorEvents.addEventListener('unhandledrejection', onGlobalFailure);
 
   const connect = (): void => {
     if (!active) return;
     socket = createWebSocket(url);
     socket.onmessage = event => {
-      if (typeof event.data === 'string') {
-        applyMessage(event.data);
-      }
+      if (typeof event.data !== 'string') return;
+      const outcome = applyMessage(event.data);
+      if (outcome === 'patch-dispatched') dispatchedPatches += 1;
+      report({ kind: 'outcome', code: outcome });
     };
     socket.onclose = event => {
       if (!active || event.code === 1001) return;
@@ -132,6 +285,8 @@ export function connectSubsecondDevtools(
 
   return () => {
     active = false;
+    errorEvents.removeEventListener('error', onGlobalFailure);
+    errorEvents.removeEventListener('unhandledrejection', onGlobalFailure);
     if (reconnectTimer !== null) {
       cancelTimeout(reconnectTimer);
       reconnectTimer = null;

--- a/rhwp-studio/tests/subsecond-runtime.test.ts
+++ b/rhwp-studio/tests/subsecond-runtime.test.ts
@@ -189,7 +189,7 @@ test('devtools websocket forwards patch messages and reconnects without reloadin
     {
       applySubsecondDevtoolsMessage(message: string) {
         applied.push(message);
-        return true;
+        return 'patch-dispatched';
       },
     },
     {
@@ -200,6 +200,8 @@ test('devtools websocket forwards patch messages and reconnects without reloadin
         return scheduled.length;
       },
       clearTimeout: () => {},
+      reportSignal: () => {},
+      errorEvents: new FakeErrorEvents(),
     },
   );
 
@@ -216,6 +218,182 @@ test('devtools websocket forwards patch messages and reconnects without reloadin
 
   disconnect?.();
   assert.equal(sockets[1]?.closed, true);
+});
+
+class DiagnosticSocket {
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  closed = false;
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+class FakeErrorEvents {
+  private readonly listeners = new Map<string, Set<(event: Event) => void>>();
+
+  addEventListener = (type: string, listener: (event: Event) => void): void => {
+    const bucket = this.listeners.get(type) ?? new Set<(event: Event) => void>();
+    bucket.add(listener);
+    this.listeners.set(type, bucket);
+  };
+
+  removeEventListener = (type: string, listener: (event: Event) => void): void => {
+    this.listeners.get(type)?.delete(listener);
+  };
+
+  emit(type: string, event: Record<string, unknown>): void {
+    [...(this.listeners.get(type) ?? [])].forEach(listener =>
+      listener({ type, ...event } as unknown as Event),
+    );
+  }
+
+  count(type: string): number {
+    return this.listeners.get(type)?.size ?? 0;
+  }
+}
+
+type CapturedSignal = Record<string, unknown>;
+
+/** 신호 수집기를 물린 devtools 소켓 하나를 세운다. */
+async function connectWithSignals(outcomeFor: (message: string) => string): Promise<{
+  socket: DiagnosticSocket;
+  signals: CapturedSignal[];
+  errorEvents: FakeErrorEvents;
+  disconnect: () => void;
+}> {
+  const { connectSubsecondDevtools } = await loadRuntime();
+  const socket = new DiagnosticSocket();
+  const signals: CapturedSignal[] = [];
+  const errorEvents = new FakeErrorEvents();
+  const disconnect = connectSubsecondDevtools(
+    { applySubsecondDevtoolsMessage: outcomeFor },
+    {
+      location: { protocol: 'http:', host: 'localhost:7701' },
+      createWebSocket: () => socket,
+      setTimeout: () => 0,
+      clearTimeout: () => {},
+      reportSignal: signal => signals.push(signal as CapturedSignal),
+      errorEvents,
+    },
+  );
+  assert.equal(typeof disconnect, 'function');
+  return { socket, signals, errorEvents, disconnect: disconnect as () => void };
+}
+
+const REJECTION_CODES = [
+  'not-json',
+  'foreign-build-id',
+  'missing-jump-table',
+  'undeserializable-jump-table',
+  'patch-rejected',
+];
+
+test('every devserver outcome reaches a reporter instead of being discarded', async () => {
+  const { socket, signals, disconnect } = await connectWithSignals(message => message);
+
+  [...REJECTION_CODES, 'not-hot-reload', 'patch-dispatched'].forEach(code =>
+    socket.onmessage?.({ data: code } as MessageEvent),
+  );
+  socket.onmessage?.({ data: new Uint8Array([1]) } as unknown as MessageEvent);
+
+  assert.deepEqual(
+    signals,
+    [...REJECTION_CODES, 'not-hot-reload', 'patch-dispatched'].map(code => ({
+      kind: 'outcome',
+      code,
+    })),
+    '결과는 한 건도 삼켜지지 않고, 이진 프레임은 결과를 만들지 않는다',
+  );
+
+  disconnect();
+});
+
+test('each outcome is rendered as its own line that names where to look next', async () => {
+  const { describeSubsecondSignal } = await loadRuntime();
+
+  const rejections = REJECTION_CODES.map(code =>
+    describeSubsecondSignal({ kind: 'outcome', code }),
+  );
+  assert.deepEqual(
+    rejections.map(diagnostic => diagnostic.level),
+    REJECTION_CODES.map(() => 'warn'),
+  );
+  const messages = rejections.map(diagnostic => diagnostic.message);
+  assert.equal(
+    new Set(messages).size,
+    REJECTION_CODES.length,
+    `다섯 사유는 서로 다른 문구로 구별돼야 한다: ${JSON.stringify(messages)}`,
+  );
+  messages.forEach(message =>
+    assert.ok(message.length > 40, `다음에 볼 곳까지 말해야 한다: ${message}`),
+  );
+
+  assert.equal(
+    describeSubsecondSignal({ kind: 'outcome', code: 'not-hot-reload' }).level,
+    'debug',
+    '데브서버 정상 트래픽을 경고로 올리면 소음이 된다',
+  );
+  assert.equal(
+    describeSubsecondSignal({ kind: 'outcome', code: 'patch-dispatched' }).level,
+    'info',
+  );
+});
+
+test('an outcome the runtime does not know is surfaced instead of ignored', async () => {
+  const { describeSubsecondSignal } = await loadRuntime();
+
+  const unknown = describeSubsecondSignal({
+    kind: 'outcome',
+    code: true as unknown as string,
+  });
+
+  assert.equal(unknown.level, 'warn');
+  assert.ok(unknown.message.includes('true'), `읽지 못한 값을 그대로 보여야 한다: ${unknown.message}`);
+});
+
+test('a global failure after a dispatched patch is reported, and one before it is not attributed', async () => {
+  const { describeSubsecondSignal } = await loadRuntime();
+  const { socket, signals, errorEvents, disconnect } = await connectWithSignals(
+    message => message,
+  );
+
+  errorEvents.emit('error', { message: '패치와 무관한 오류' });
+  assert.deepEqual(signals, [], '패치를 넘기기 전 오류는 핫패치 탓으로 돌리지 않는다');
+
+  socket.onmessage?.({ data: 'patch-dispatched' } as MessageEvent);
+  signals.length = 0;
+
+  errorEvents.emit('error', { error: new Error('unreachable') });
+  errorEvents.emit('unhandledrejection', { reason: 'patch fetch 404' });
+
+  assert.deepEqual(
+    signals,
+    [
+      {
+        kind: 'global-failure',
+        eventType: 'error',
+        reason: 'Error: unreachable',
+        dispatchedPatches: 1,
+      },
+      {
+        kind: 'global-failure',
+        eventType: 'unhandledrejection',
+        reason: 'patch fetch 404',
+        dispatchedPatches: 1,
+      },
+    ],
+    'trap 과 rejection 양쪽 경로를 모두 잡는다',
+  );
+
+  const rendered = describeSubsecondSignal(signals[1] as never);
+  assert.equal(rendered.level, 'warn');
+  assert.ok(rendered.message.includes('patch fetch 404'), rendered.message);
+
+  disconnect();
+  assert.equal(errorEvents.count('error'), 0, 'disconnect 는 전역 청취를 남기지 않는다');
+  assert.equal(errorEvents.count('unhandledrejection'), 0);
 });
 
 test('repository exposes a feature-gated dx adapter without changing normal WASM builds', () => {

--- a/src/subsecond_dev.rs
+++ b/src/subsecond_dev.rs
@@ -12,28 +12,94 @@ pub fn subsecond_probe() -> u32 {
     hot.call(())
 }
 
-#[wasm_bindgen(js_name = applySubsecondDevtoolsMessage)]
-pub fn apply_subsecond_devtools_message(message: &str) -> bool {
+/// 데브서버 메시지 한 건을 처리하고 **이 함수가 실제로 관찰한 것**을 담는다.
+///
+/// 종전 반환값은 `bool` 하나였다. 그 값은 다섯 가지 거절 사유를 전부 `false` 로 접었고,
+/// 더 나쁘게는 `true` 가 wasm32 에서 보고할 수 없는 것을 광고했다.
+///
+/// # wasm32 에서 구조적으로 보고할 수 없는 것
+///
+/// `subsecond::apply_patch` 는 wasm32 에서 patch wasm 의 fetch/compile/instantiate future 를
+/// 띄우고 **즉시** `Ok(())` 를 돌려준다(subsecond 0.7.10 `src/lib.rs:551`, `:690`). 그래서
+/// [`Self::PatchDispatched`] 는 "점프 테이블을 subsecond 에 넘겼다"까지만 뜻하며 "패치가
+/// 화면에 반영됐다"는 뜻이 **아니다**. future 안의 실패는 전부 `.unwrap()`/`panic!`
+/// (`lib.rs:578-582`)이라 이 반환값이 될 수 없다. 그 실패는 두 곳으로만 나간다.
+///
+/// 1. `crate::init_panic_hook` 이 등록한 `console_error_panic_hook` 의 `console.error`
+///    (기본 feature이므로 dx 빌드에도 들어간다).
+/// 2. panic 이 abort → wasm trap 이 되어 microtask 경계를 넘는 전역 오류 이벤트.
+///
+/// 브라우저 쪽에서 2번을 잡아 "패치를 넘긴 뒤 무언가 터졌다"로 잇는 곳은
+/// `rhwp-studio/src/core/subsecond-runtime.ts` 다. 어느 쪽도 이 함수의 반환값이 될 수 없으므로
+/// 여기서는 **없는 정보를 지어내지 않고** 성공값의 이름으로 그 한계를 드러낸다.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DevtoolsMessageOutcome {
+    /// 텍스트 프레임이 JSON 이 아니다.
+    NotJson,
+    /// JSON 이지만 `HotReload` 가 아니다. 데브서버의 정상 제어 트래픽이 여기 들어온다.
+    NotHotReload,
+    /// 다른 빌드를 향한 패치다. 스튜디오는 `build_id=0` 으로만 접속한다.
+    ForeignBuildId,
+    /// `HotReload` 에 `jump_table` 이 없다.
+    MissingJumpTable,
+    /// `jump_table` 이 `subsecond::JumpTable` 로 역직렬화되지 않는다.
+    UndeserializableJumpTable,
+    /// `apply_patch` 가 오류를 돌려줬다. **네이티브에서만 나온다** — 위 문단 참고.
+    PatchRejected(String),
+    /// 점프 테이블을 `apply_patch` 에 넘겼다. 적용 완료가 아니다.
+    PatchDispatched,
+}
+
+impl DevtoolsMessageOutcome {
+    /// JS 로 넘기는 안정된 식별자.
+    ///
+    /// [`Self::PatchRejected`] 의 상세 문자열은 싣지 않는다. 그 변형은 wasm32 에서 나올 수
+    /// 없어 JS 소비자가 볼 일이 없고, 네이티브 소비자는 이 열거형을 직접 읽는다.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::NotJson => "not-json",
+            Self::NotHotReload => "not-hot-reload",
+            Self::ForeignBuildId => "foreign-build-id",
+            Self::MissingJumpTable => "missing-jump-table",
+            Self::UndeserializableJumpTable => "undeserializable-jump-table",
+            Self::PatchRejected(_) => "patch-rejected",
+            Self::PatchDispatched => "patch-dispatched",
+        }
+    }
+}
+
+/// 메시지를 판정하고, 패치면 `apply_patch` 에 넘긴다.
+pub fn dispatch_devtools_message(message: &str) -> DevtoolsMessageOutcome {
+    use DevtoolsMessageOutcome as Outcome;
+
     let Ok(message) = serde_json::from_str::<Value>(message) else {
-        return false;
+        return Outcome::NotJson;
     };
     let Some(hot_reload) = message.get("HotReload") else {
-        return false;
+        return Outcome::NotHotReload;
     };
     if hot_reload
         .get("for_build_id")
         .and_then(Value::as_u64)
         .is_some_and(|build_id| build_id != 0)
     {
-        return false;
+        return Outcome::ForeignBuildId;
     }
     let Some(jump_table) = hot_reload.get("jump_table") else {
-        return false;
+        return Outcome::MissingJumpTable;
     };
     let Ok(jump_table) = serde_json::from_value::<JumpTable>(jump_table.clone()) else {
-        return false;
+        return Outcome::UndeserializableJumpTable;
     };
-    unsafe { subsecond::apply_patch(jump_table).is_ok() }
+    match unsafe { subsecond::apply_patch(jump_table) } {
+        Ok(()) => Outcome::PatchDispatched,
+        Err(error) => Outcome::PatchRejected(error.to_string()),
+    }
+}
+
+#[wasm_bindgen(js_name = applySubsecondDevtoolsMessage)]
+pub fn apply_subsecond_devtools_message(message: &str) -> String {
+    dispatch_devtools_message(message).code().to_owned()
 }
 
 pub fn link_wasm_exports() {
@@ -52,16 +118,85 @@ where
 mod tests {
     use super::*;
 
+    /// 유효한 `JumpTable` 을 담은 `HotReload` 프레임. `lib` 은 존재하지 않는 경로라
+    /// 네이티브의 `apply_patch` 는 dlopen 단계에서 오류를 돌려주고 아무것도 detour 하지 않는다.
+    const UNLOADABLE_PATCH: &str = r#"{"HotReload":{"for_build_id":0,"jump_table":{
+        "lib":"/nonexistent/rhwp-subsecond-patch.dylib","map":{},
+        "aslr_reference":0,"new_base_address":0,"ifunc_count":0}}}"#;
+
     #[test]
     fn probe_calls_the_current_function_body() {
         assert_eq!(subsecond_probe(), 41);
     }
 
     #[test]
-    fn ignores_non_patch_devserver_messages() {
-        assert!(!apply_subsecond_devtools_message(
-            r#"{"HotPatchStart":null}"#
-        ));
-        assert!(!apply_subsecond_devtools_message("not json"));
+    fn every_rejected_message_names_its_own_reason() {
+        let reasons = [
+            ("not json", "not-json"),
+            (r#"{"HotPatchStart":null}"#, "not-hot-reload"),
+            (
+                r#"{"HotReload":{"for_build_id":7,"jump_table":{}}}"#,
+                "foreign-build-id",
+            ),
+            (r#"{"HotReload":{"for_build_id":0}}"#, "missing-jump-table"),
+            (
+                r#"{"HotReload":{"jump_table":{"lib":42}}}"#,
+                "undeserializable-jump-table",
+            ),
+        ];
+        for (message, expected) in reasons {
+            assert_eq!(
+                apply_subsecond_devtools_message(message),
+                expected,
+                "{message}"
+            );
+        }
+    }
+
+    /// 다섯 거절 사유는 서로 구별돼야 한다 — 종전 `bool` 은 전부 `false` 로 접었다.
+    #[test]
+    fn rejection_reasons_are_distinguishable_from_each_other() {
+        let codes: Vec<String> = [
+            "not json",
+            r#"{"HotPatchStart":null}"#,
+            r#"{"HotReload":{"for_build_id":7,"jump_table":{}}}"#,
+            r#"{"HotReload":{"for_build_id":0}}"#,
+            r#"{"HotReload":{"jump_table":{"lib":42}}}"#,
+        ]
+        .into_iter()
+        .map(apply_subsecond_devtools_message)
+        .collect();
+        let mut unique = codes.clone();
+        unique.sort();
+        unique.dedup();
+        assert_eq!(unique.len(), codes.len(), "{codes:?}");
+    }
+
+    /// 네이티브에서만 도달하는 가지. wasm32 에서는 `apply_patch` 가 오류를 돌려줄 수 없다
+    /// ([`DevtoolsMessageOutcome`] 문서 참고).
+    #[test]
+    fn a_patch_that_cannot_be_loaded_reports_the_loader_error() {
+        let DevtoolsMessageOutcome::PatchRejected(error) =
+            dispatch_devtools_message(UNLOADABLE_PATCH)
+        else {
+            panic!("네이티브 apply_patch 는 없는 라이브러리를 거절해야 한다");
+        };
+        assert!(
+            error.contains("/nonexistent/rhwp-subsecond-patch.dylib"),
+            "{error}"
+        );
+        assert_eq!(
+            apply_subsecond_devtools_message(UNLOADABLE_PATCH),
+            "patch-rejected"
+        );
+    }
+
+    /// 성공값은 "적용됐다" 가 아니라 "넘겼다" 를 뜻해야 한다.
+    #[test]
+    fn the_success_code_does_not_claim_the_patch_was_applied() {
+        assert_eq!(
+            DevtoolsMessageOutcome::PatchDispatched.code(),
+            "patch-dispatched"
+        );
     }
 }

--- a/tools/rhwp-subsecond/build.rs
+++ b/tools/rhwp-subsecond/build.rs
@@ -1,5 +1,19 @@
+//! `dx --hot-patch` 가 찾는 rlib 별칭을 만든다.
+//!
+//! 이 스크립트가 조용히 실패하면 그 결과는 "핫패치가 아무 말 없이 안 먹는다"로만 나타난다 —
+//! `dx serve` 도, 브라우저 소켓도, 데브서버의 `HotReload` 도 전부 정상으로 보인다. 그래서
+//! 실패하는 가지는 전부 `cargo:warning` 으로 무엇이 막혔는지와 다음에 볼 곳을 남긴다.
+//! 플랫폼 제약과 층별 신호는 `mydocs/manual/dev_environment_guide.md` 의
+//! "Subsecond 핫패치" 절에 있다.
+
 #[cfg(unix)]
 use std::path::PathBuf;
+
+/// `dx` 가 찾는 이름.
+const ALIAS_NAME: &str = "librhwp-dioxus.rlib";
+/// 별칭이 가리키는 실제 rlib. 이 스크립트가 끝난 뒤 rustc 가 만들므로 복사로 대체할 수 없다.
+#[cfg(unix)]
+const TARGET_NAME: &str = "librhwp.rlib";
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
@@ -10,6 +24,14 @@ fn main() {
 
     #[cfg(unix)]
     create_dioxus_rlib_alias();
+
+    #[cfg(not(unix))]
+    println!(
+        "cargo:warning=rhwp-subsecond: 이 호스트는 unix 가 아니라 `{ALIAS_NAME}` 별칭을 만들지 않는다. \
+         별칭 대상은 이 빌드 스크립트가 끝난 뒤에 생기므로 복사로 대체할 수 없고 심링크가 필요하다. \
+         핫패치는 동작하지 않으며, dx serve·소켓·HotReload 는 모두 정상으로 보이고 화면만 바뀌지 않는다. \
+         WSL 안에서 빌드하거나 일반 wasm-pack 경로를 쓴다 — mydocs/manual/dev_environment_guide.md 의 'Subsecond 핫패치' 절."
+    );
 }
 
 #[cfg(unix)]
@@ -17,17 +39,70 @@ fn create_dioxus_rlib_alias() {
     use std::os::unix::fs::symlink;
 
     let Some(out_dir) = std::env::var_os("OUT_DIR").map(PathBuf::from) else {
+        println!(
+            "cargo:warning=rhwp-subsecond: OUT_DIR 이 없어 `{ALIAS_NAME}` 별칭을 만들지 못했다. \
+             cargo 없이 build.rs 를 직접 실행했다면 무시해도 되고, 아니면 핫패치는 동작하지 않는다."
+        );
         return;
     };
-    let Some(profile_dir) = out_dir.ancestors().nth(3) else {
-        return;
-    };
-    let deps_dir = profile_dir.join("deps");
-    let alias = deps_dir.join("librhwp-dioxus.rlib");
 
-    if alias.exists() || std::fs::create_dir_all(&deps_dir).is_err() {
+    // OUT_DIR 은 `<profile>/build/<pkg>-<hash>/out` 이므로 프로파일 디렉터리는 위로 3단계다.
+    let Some(profile_dir) = out_dir.ancestors().nth(3) else {
+        println!(
+            "cargo:warning=rhwp-subsecond: OUT_DIR `{}` 에서 프로파일 디렉터리를 찾지 못했다(위로 3단계 필요). \
+             cargo 의 target 레이아웃이 바뀌었을 수 있다. `{ALIAS_NAME}` 별칭 없이 진행하므로 핫패치는 동작하지 않는다.",
+            out_dir.display()
+        );
+        return;
+    };
+
+    let deps_dir = profile_dir.join("deps");
+    let alias = deps_dir.join(ALIAS_NAME);
+
+    // 별칭 자체를 추적한다. build.rs 만 추적하면 `deps/` 가 정리돼 별칭이 사라져도 이 스크립트가
+    // 다시 돌지 않아 별칭이 영영 복구되지 않는다. 없는 경로는 cargo 가 "변경됨"으로 보므로
+    // 별칭이 사라진 다음 빌드에서 이 스크립트가 다시 돈다.
+    println!("cargo:rerun-if-changed={}", alias.display());
+
+    // `Path::exists()` 는 심링크를 따라가므로 끊긴 별칭을 "없음" 으로 읽는다. 그러면 아래
+    // `symlink()` 가 EEXIST 로 실패하고, 그 실패마저 조용히 버려졌다. 링크 자체의 상태를 본다.
+    //
+    // 끊긴 별칭은 경고하지 않는다 — 대상 rlib 은 이 스크립트가 끝난 뒤에 생기고,
+    // `cargo check` 만 돌면 아예 생기지 않으므로 "끊김" 은 정상 상태이기도 하다.
+    match std::fs::symlink_metadata(&alias) {
+        Ok(metadata) if metadata.is_symlink() => return,
+        Ok(_) => {
+            println!(
+                "cargo:warning=rhwp-subsecond: `{}` 이 심링크가 아닌 실제 파일이라 손대지 않는다. \
+                 핫패치가 낡은 rlib 을 물 수 있으니 이 파일을 지우고 다시 빌드한다.",
+                alias.display()
+            );
+            return;
+        }
+        Err(error) if error.kind() != std::io::ErrorKind::NotFound => {
+            println!(
+                "cargo:warning=rhwp-subsecond: `{}` 의 상태를 읽지 못했다: {error}. 핫패치는 동작하지 않는다.",
+                alias.display()
+            );
+            return;
+        }
+        Err(_) => {}
+    }
+
+    if let Err(error) = std::fs::create_dir_all(&deps_dir) {
+        println!(
+            "cargo:warning=rhwp-subsecond: `{}` 를 만들지 못해 `{ALIAS_NAME}` 별칭을 건너뛴다: {error}. \
+             핫패치는 동작하지 않는다.",
+            deps_dir.display()
+        );
         return;
     }
 
-    let _ = symlink("librhwp.rlib", alias);
+    if let Err(error) = symlink(TARGET_NAME, &alias) {
+        println!(
+            "cargo:warning=rhwp-subsecond: `{}` → `{TARGET_NAME}` 심링크를 만들지 못했다: {error}. \
+             핫패치는 동작하지 않는다.",
+            alias.display()
+        );
+    }
 }


### PR DESCRIPTION
핫패치가 실패해도 "바뀐 것이 없음"과 구별되지 않습니다. Windows 에서는 기능이 한 번도 작동한 적 없는데 `subsecond:install`·`dx serve`·소켓 연결·메시지 처리가 전부 성공을 보고합니다.

**보고할 수 없는 것을 광고하던 `bool` 을 없앴습니다.** wasm32 에서 `apply_patch` 는 fetch/compile/instantiate future 를 띄우고 `Ok(())` 를 즉시 돌려줍니다 — 값이 함수가 반환된 *뒤에* 정해집니다. 진실을 보고하게 만들려면 다른 함수에서 `Promise` 를 돌려줘야 하는데 그건 재설계라 하지 않았습니다. 대신 `DevtoolsMessageOutcome::code()` 로 일곱 이름을 내보내고, 성공 이름을 **`patch-dispatched`** 로 두었습니다 — "applied" 가 아닙니다. 알 수 없다는 사실을 이름에 명시했습니다.

**이슈에 제가 적은 메커니즘이 틀려서 정정합니다.** "unhandled promise rejection 으로 나간다"고 썼는데, js-sys 는 spawn 된 task 를 `queueMicrotask` 콜백 안에서 폴링하므로(`js-sys-0.3.102/src/futures/queue.rs:63-74`) wasm trap 은 **uncaught exception → 전역 `error` 이벤트**로 나옵니다. `unhandledrejection` 은 `queueMicrotask` 가 없을 때의 폴백 경로뿐입니다. 양쪽을 모두 듣습니다. 그리고 패닉 메시지 자체는 이미 콘솔에 닿고 있었습니다 — `console_error_panic_hook` 이 default feature 입니다. 없던 것은 그것을 subsecond 와, 또 "화면이 안 바뀐다"와 이어 주는 연결이었습니다.

Rust 는 이미 abort 한 뒤라 인과를 주장하지 않습니다. 사실만 보고하고("N건을 넘긴 뒤 전역 오류가 왔다, 무관할 수 있다"), 다음에 볼 곳을 순서대로 줍니다 — 콘솔의 Rust 패닉 → Network 탭의 패치 wasm → `subsecond:serve` 터미널. `preventDefault` 하지 않아 아무것도 삼키지 않습니다.

`build.rs` 의 네 가지 조용한 실패(비-unix, 경로 유도 실패, 끊긴 심링크 재시도, 재생성 안 됨)에 `cargo:warning` 을 달았습니다. 실제로 나오는 것을 확인했고, 이 호스트에서 못 타는 비-unix 분기는 `cfg` 를 바꿔 직접 컴파일해 문구를 확인했습니다.

**프로덕션 유출은 제 첫 구현이 냈고, 측정해서 잡았습니다.** `import.meta.env.DEV` 가 `console` 호출만 없애고 산문 테이블은 번들에 남았습니다(`grep "점프 테이블을 subsecond" dist/…` → 1). 소켓 경로가 사실만 담은 신호를 내고 산문은 DEV 가드 안에서만 만들도록 재구성한 뒤 다시 쟀습니다 — 산문 문자열 넷 전부 **0**, 대조군(`_dioxus`, `patch-dispatched`)은 1로 남습니다.

`cargo test --profile release-test --tests` exit 0 — `ok` 블록 536개, **FAILED 0**. fmt·clippy·feature 게이트·wasm32 `--lib` check 전부 exit 0. 스튜디오 `tsc` exit 0, `npm test` **840 / 839 pass / 0 fail**.

RED 는 Rust 는 컴파일 오류 6건, 스튜디오는 `subsecond-runtime.ts` 를 `upstream/devel` 로 되돌려 **단언 수준 실패 4건**으로 확인했습니다. 기존 소스 텍스트 정규식 단언은 건드리지 않았고 새로 추가하지도 않았습니다.

작업 중 나왔지만 기존 상태라 손대지 않은 것은 #4588(`subsecond-dev` 를 켜면 clippy 와 wasm32 check 가 깨짐 — 깨끗한 devel 에서 동일 재현), #4589(결과 코드 계약이 양 언어에 따로 적힘)로 열었습니다.

`subsecond-runtime.ts` 변경은 메시지 처리 경로와 기존 disposer 의 `removeEventListener` 두 줄로 한정했습니다 — `SubsecondRevisionWatcher`·rAF 루프·재연결 백오프·소켓 URL 은 건드리지 않아 #4579 와 깨끗하게 갈립니다.

Closes #4578