### PR TITLE
wasm_api: 편집 중 재도색 경로를 Subsecond 핫패치 경계 뒤로

### DIFF
--- a/mydocs/working/task_m100_4577_stage1.md
+++ b/mydocs/working/task_m100_4577_stage1.md
@@ -1,0 +1,116 @@
+# [#4577] Subsecond 핫패치 렌더 경계 — 처리 결과 (stage 1)
+
+> 이슈: [#4577](https://github.com/edwardkim/rhwp/issues/4577) · 브랜치:
+> `fix/issue-4577-subsecond-boundaries` (base: `upstream/devel`)
+
+## 1. 무엇이 문제였나
+
+`HotFn::current(f)` 는 `f` 하나만 리다이렉트한다. 점프 테이블은 `map.get(&real)` 단일 키
+조회이고(`subsecond-0.7.10/src/lib.rs:919-940`), wasm `apply_patch` 는 `memory.grow`/`funcs.grow`
+로 **덧붙이기만** 한다(`:628-632`). 전이적 재링크가 없으므로 JS 가 부르는 export 마다 경계가
+있어야 그 아래가 새 코드로 돈다.
+
+`upstream/devel` 의 경계는 둘뿐이었고, **타이핑 중 실제로 쓰는 경로**가 그 밖에 있었다.
+
+## 2. 무엇을 했나
+
+### 2.1 경계 목록을 한 곳으로 (`src/wasm_api/subsecond_boundary.rs`, 신규)
+
+`#[cfg(feature = "subsecond-dev")]` 4줄 블록을 export 마다 복사하던 모양을 없앴다. 목록에 한
+항목을 적으면 세 가지가 **한 선언에서** 나온다.
+
+1. dispatcher — `#[cfg]` 분기는 매크로 안에 한 벌만 있다.
+2. `patch_revision()` 의 한 칸 — `getSubsecondPatchRevision` 은 이 함수 하나만 부른다.
+   경계를 더할 때 리비전을 따로 고칠 자리가 없으므로 **놓칠 수 없다.**
+3. `hot_render_exports()` 의 export 이름 — 테스트가 이것으로 검사한다.
+
+반대 방향은 dispatcher 마다 붙인 `#[deny(dead_code)]` 가 막는다. 목록에 올려 놓고 export 를
+배선하지 않으면 빌드가 깨진다(저장소 전역은 `Cargo.toml:208` 에서 `dead_code = "allow"` 라
+국소 deny 가 없으면 조용히 통과한다 — 실측으로 확인했다).
+
+### 2.2 새로 경계 뒤로 들어간 export
+
+| export | 왜 |
+|---|---|
+| `renderPagePatchToCanvasFilteredWithProfile` | 타이핑 중 부분 재도색 페인트. 이슈의 본 증상 |
+| `getPageOverlayImages` | `getLayerPlaneSummary` → 합성·**부분 재도색 자격** 판정 |
+| `getPageFlowImageOps` | 본문 그림 DOM 배치(같은 평면 분류·조상 clip 접기) |
+| `getPageLayerTree` | 이슈에 없던 구멍. `getPageLayerTreeWithProfile` 옆에서 같은 `_impl` 로 가는데 경계를 지나지 않았다. `getLayerPlaneSummaryFromTree`(page-renderer.ts:893) 등 3곳이 쓴다 |
+
+기존 둘(`renderPageToCanvasFilteredWithProfile`, `getPageLayerTreeWithProfile`)은 그대로
+말단에 남는다 — 깔때기(`build_page_layer_tree_with_profile`)로 옮기면 페인트를 잃는다는 이슈의
+판단을 유지했다. 깔때기 경계는 **추가하지 않았다**: 부분 재도색 export 자체가 경계 뒤로
+들어가면서 `PageRenderer` 의 모든 트리 빌드 경로가 이미 경계 아래가 되어, 안쪽에 하나 더 두면
+재도색마다 점프 테이블 조회만 한 번 늘고 새로 덮이는 코드가 없다.
+
+### 2.3 인자 9개 상한 (경계가 없던 진짜 이유)
+
+`subsecond` 는 `HotFunction` 을 인자 9개까지만 구현한다(`impl_hot_function!` 의 `Fn9Marker`).
+`render_page_patch_to_canvas_filtered_with_profile_impl` 은 인자가 10개라 `HotFn::current` 가
+**컴파일되지 않는다.** `x/y/width/height` 를 `BoundingBox` 하나로 접어 7개로 줄였다.
+wasm_bindgen export 의 JS 시그니처는 그대로다.
+
+## 3. 경계 밖에 그대로 둔 것
+
+| export | 이유 |
+|---|---|
+| `getPageSourceImageKeys` | 그림 신원 키만 만든다 — 아래에 페인트도 평면 분류도 없다. 캐시 신원을 핫패치하면 이미 저장된 서명과 비교가 불가능해져 재디코드만 는다 |
+| `getSourceImageBytes` | 결과를 studio 가 키별 object URL 로 메모이즈한다(`FlowImageUrlCache`, digest+generation 키). 핫패치는 신원을 바꾸지 않으므로 다시 들어오지 않는다 — 경계를 두어도 관측되지 않는다 |
+| `getPageInfo` | 이미 계산된 pagination(`find_page`)을 읽고 PageDef 여백을 px 로 환산할 뿐이다. 낡을 수 있는 값(page 크기·단 영역)은 `invalidateSubsecondRenderCaches` 가 비우지 않는 pagination 에서 오므로 경계를 두면 "새 산술 + 옛 페이지네이션" 반만 새 기록이 된다. 목록에서 가장 잦은 질의이기도 하다 |
+| `getCanvasKitReplayPlan(WithProfile)` | `PageRenderer` 가 부르지 않는다 — 소비자는 `e2e/renderer-baseline.mjs:486` 뿐이다. CanvasKit 페인트는 TypeScript 이고 입력 트리는 이미 경계 뒤에서 온다 |
+
+판단은 `src/wasm_api/subsecond_boundary.rs` 의 `DELIBERATELY_COLD_EXPORTS` 에 이유와 함께
+적혀 있고, 테스트가 "경계 목록과 겹치지 않는다 + 이유가 비어 있지 않다"를 지킨다.
+
+## 4. 테스트 — 고치기 전 RED 실측
+
+`every_render_path_export_sits_behind_a_hot_patch_boundary`. 목록에서 새 경계 셋을 뺀
+(= 고치기 전) 트리에서:
+
+```
+thread '...::every_render_path_export_sits_behind_a_hot_patch_boundary' panicked at
+src/wasm_api/subsecond_boundary.rs:211:9:
+이 export 들은 PageRenderer 의 렌더 경로에 있는데 핫패치 경계 뒤에 없다 — 패치를 걸어도
+base 모듈의 옛 코드가 그린다:
+["renderPagePatchToCanvasFilteredWithProfile", "getPageOverlayImages", "getPageFlowImageOps"]
+test result: FAILED. 2 passed; 1 failed
+```
+
+리비전 쪽도 물린다. 생성기가 첫 칸만 쓰도록 일부러 망가뜨리면
+`patch_revision_covers_every_compiled_boundary` 가 `리비전 칸은 16자리 함수 주소여야 한다:
+0000000100b83dcc::` 로 실패한다.
+
+## 5. 검증하지 못한 것
+
+**end-to-end 는 검증하지 않았다.** `dx serve --hot-patch` + 실제 패치로 "표 셀에 한 글자 쳐도
+새 색으로 그려진다"를 확인하려면 구동 환경이 필요하고, 이 작업에서는 돌리지 못했다. 확인한
+것은 컴파일 계약(경계가 붙는다·리비전이 경계 수만큼 나온다·주소가 서로 다르다)까지다.
+
+덧붙여 `subsecond` 의 `HotFn::try_call` 은 `!cfg!(debug_assertions)` 이면 점프 테이블을 아예
+건너뛴다(`lib.rs:412-414`). 핫패치는 debug 빌드에서만 동작한다 — 기존 성질이고 이번 변경과
+무관하다.
+
+## 6. 발견했지만 고치지 않은 것
+
+- `CanvasView.refreshPages()` 는 `getPageInfo` 를 다시 모으지만 `this.pageRenderer` 의
+  `FlowImageUrlCache` 는 digest+generation 이 그대로라 그대로 남는다. 즉 워터마크 bake
+  (`renderer::image_resolver::emitted_image_bytes`, `rendering.rs:1750`)를 고쳐도 본문 그림은
+  옛 바이트를 쓴다. 경계 배치 문제가 아니라 캐시 수명 문제다 (#4579 계열).
+- `body_page_border_outset`(`src/renderer/layout/border_rendering.rs:963`)을 고치면 그려진
+  페이지 테두리는 새 코드, `getPageInfo` 의 `pageBorderLeft/Right/Top/Bottom`
+  (`rendering.rs:2261`)은 옛 코드가 되어 여백 가이드가 어긋난다. 위 3절의 이유로 이번에는
+  경계를 두지 않았다.
+- `cargo check --target wasm32-unknown-unknown` 은 `rhwp` **bin** 타깃에서 깨진다
+  (`src/main.rs:4455`, `:4599` 등 7건). `upstream/devel` 에서도 같으므로 이번 변경과 무관하다.
+  wasm 게이트는 `--lib` 로 돌려야 한다(`wasm-pack build` 가 하는 것과 같다).
+- `rhwp-studio/tests/subsecond-runtime.test.ts` 의 마지막 테스트는 `src/wasm_api.rs` 를 문자열
+  정규식으로 검사한다. `getSubsecondPatchRevision` 이라는 이름이 있는지만 보므로 이번 이슈의
+  구멍(경계가 두 개뿐)을 전혀 보지 못했다. 이번에 추가한 Rust 쪽 소진 테스트가 그 자리를
+  대신하지만, 정규식 테스트 자체는 남겨 두었다(범위 밖).
+
+## 7. 범위
+
+`src/wasm_api.rs` 와 신규 `src/wasm_api/subsecond_boundary.rs` 만 건드렸다.
+`src/document_core/queries/rendering.rs` 는 **읽기만 했다** — #4576 이 같은 두 파일을 고치므로
+충돌 면적을 줄이려고 렌더 본체(`*_native`)는 그대로 두고 wasm_api 층에서만 경계를 붙였다.
+무효화 계약(#4576)·진단(#4578)·수명(#4579)·번들링(#4580)은 손대지 않았다.

--- a/mydocs/working/task_m100_4577_stage1.md
+++ b/mydocs/working/task_m100_4577_stage1.md
@@ -114,3 +114,26 @@ test result: FAILED. 2 passed; 1 failed
 `src/document_core/queries/rendering.rs` 는 **읽기만 했다** — #4576 이 같은 두 파일을 고치므로
 충돌 면적을 줄이려고 렌더 본체(`*_native`)는 그대로 두고 wasm_api 층에서만 경계를 붙였다.
 무효화 계약(#4576)·진단(#4578)·수명(#4579)·번들링(#4580)은 손대지 않았다.
+
+
+## 후속 이슈 (2026-08-11)
+
+- **[#4595](https://github.com/edwardkim/rhwp/issues/4595)** — `FlowImageUrlCache`
+  (`flow-image-url-cache.ts:39`)가 digest+generation 으로 키를 잡아, 패치가 그 값을 바꾸지
+  않으므로 `getSourceImageBytes` 아래 코드(워터마크 굽기 등)에 **어떤 경계 배치로도 닿지
+  않는다.** 이 export 를 일부러 감싸지 않은 이유가 이것이다. 캐시 수명 문제이지 경계 문제가
+  아니다.
+- **[#4596](https://github.com/edwardkim/rhwp/issues/4596)** — `HotFn::try_call` 이
+  `!cfg!(debug_assertions)` 에서 조기 반환하므로(`subsecond lib.rs:411-414`) 핫패치는
+  디버그 빌드에서만 작동한다. `subsecond-dev` feature 와 디버그 프로파일은 별개의 두 조건인데
+  어디에도 적혀 있지 않다.
+
+## 감싸지 않기로 한 것의 파생 결과
+
+`getPageInfo` 를 감싸지 않은 결과로, `body_page_border_outset`
+(`src/renderer/layout/border_rendering.rs:963`)을 고치면 **그려지는 쪽 테두리**(`layout.rs:3735`,
+경계 뒤)와 **여백 안내선**(`rendering.rs:2261` 의 `pageBorder*`, 경계 밖)이 갈린다.
+
+이는 감수한 결과다 — `getPageInfo` 를 감싸면 `self.pagination` 이 낡은 채로 새 여백 산술만
+적용되어 더 나쁜 혼합물이 된다(#4576 이 다루는 축). 두 값이 갈리는 것보다 한쪽만 낡는 것이
+진단하기 쉽다.

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -42,6 +42,9 @@ use crate::renderer::style_resolver::{
 use crate::renderer::svg::SvgRenderer;
 use crate::renderer::DEFAULT_DPI;
 
+/// 어떤 렌더 export 가 Subsecond 핫패치 경계 뒤에 있는지 선언하는 곳 (#4577).
+mod subsecond_boundary;
+
 impl From<HwpError> for JsValue {
     fn from(err: HwpError) -> Self {
         JsValue::from_str(&err.to_string())
@@ -191,8 +194,12 @@ fn render_page_to_canvas_filtered_with_profile_impl(
     Ok(())
 }
 
+/// 부분 재도색 본체.
+///
+/// `patch` 는 page-space 요청 사각형이다 — `x/y/width/height` 를 편 인자로 받으면 이 함수의
+/// 인자가 10개가 되어 `subsecond::HotFn` 이 붙지 못한다(`HotFunction` 은 9개까지). 경계를
+/// 유지하려면 사각형을 한 값으로 접어야 한다.
 #[cfg(target_arch = "wasm32")]
-#[allow(clippy::too_many_arguments)]
 fn render_page_patch_to_canvas_filtered_with_profile_impl(
     document: &HwpDocument,
     page_num: u32,
@@ -200,16 +207,19 @@ fn render_page_patch_to_canvas_filtered_with_profile_impl(
     scale: f64,
     layer_kind: &str,
     profile: &str,
-    x: f64,
-    y: f64,
-    width: f64,
-    height: f64,
+    patch: crate::renderer::render_tree::BoundingBox,
 ) -> Result<(), JsValue> {
     use crate::paint::RenderProfile;
     use crate::renderer::layer_renderer::LayerRenderer;
     use crate::renderer::render_tree::BoundingBox;
     use crate::renderer::web_canvas::WebCanvasRenderer;
 
+    let BoundingBox {
+        x,
+        y,
+        width,
+        height,
+    } = patch;
     if ![x, y, width, height].into_iter().all(f64::is_finite) || width <= 0.0 || height <= 0.0 {
         return Err(JsValue::from_str("invalid page patch rectangle"));
     }
@@ -265,6 +275,21 @@ fn get_page_layer_tree_with_profile_impl(
             profile,
             crate::paint::LayerJsonOptions { omit_image_bytes },
         )
+        .map_err(|error| error.into())
+}
+
+/// 레이어 평면 요약 본체. 합성 판정(`getLayerPlaneSummary`)이 이 결과로 정해지므로 페인트와
+/// 같은 패치 세대를 봐야 한다.
+fn get_page_overlay_images_impl(document: &HwpDocument, page_num: u32) -> Result<String, JsValue> {
+    document
+        .get_page_overlay_images_native(page_num)
+        .map_err(|error| error.into())
+}
+
+/// 본문 그림 배치 본체. 경계 뒤에서 그린 캔버스 위에 DOM `<img>` 로 합성되는 값이다.
+fn get_page_flow_image_ops_impl(document: &HwpDocument, page_num: u32) -> Result<String, JsValue> {
+    document
+        .get_page_flow_image_ops_native(page_num)
         .map_err(|error| error.into())
 }
 
@@ -783,14 +808,7 @@ impl HwpDocument {
         layer_kind: &str,
         profile: &str,
     ) -> Result<(), JsValue> {
-        #[cfg(feature = "subsecond-dev")]
-        {
-            let mut hot =
-                subsecond::HotFn::current(render_page_to_canvas_filtered_with_profile_impl);
-            return hot.call((self, page_num, canvas, scale, layer_kind, profile));
-        }
-        #[cfg(not(feature = "subsecond-dev"))]
-        render_page_to_canvas_filtered_with_profile_impl(
+        subsecond_boundary::render_page_to_canvas_filtered_with_profile(
             self, page_num, canvas, scale, layer_kind, profile,
         )
     }
@@ -814,8 +832,16 @@ impl HwpDocument {
         width: f64,
         height: f64,
     ) -> Result<(), JsValue> {
-        render_page_patch_to_canvas_filtered_with_profile_impl(
-            self, page_num, canvas, scale, layer_kind, profile, x, y, width, height,
+        use crate::renderer::render_tree::BoundingBox;
+
+        subsecond_boundary::render_page_patch_to_canvas_filtered_with_profile(
+            self,
+            page_num,
+            canvas,
+            scale,
+            layer_kind,
+            profile,
+            BoundingBox::new(x, y, width, height),
         )
     }
 
@@ -859,10 +885,12 @@ impl HwpDocument {
     }
 
     /// 페이지 레이어 트리를 JSON 문자열로 반환한다.
+    ///
+    /// screen profile 기본값이므로 `getPageLayerTreeWithProfile` 로 위임한다 — 같은 핫패치
+    /// 경계를 지나야 한다. PageRenderer 가 좁은 질의를 못 쓸 때 되돌아오는 경로다.
     #[wasm_bindgen(js_name = getPageLayerTree)]
     pub fn get_page_layer_tree(&self, page_num: u32) -> Result<String, JsValue> {
-        self.get_page_layer_tree_native(page_num)
-            .map_err(|e| e.into())
+        self.get_page_layer_tree_with_profile(page_num, "screen", Some(false))
     }
 
     /// 페이지 레이어 트리를 profile 별로 반환한다.
@@ -880,25 +908,25 @@ impl HwpDocument {
         omit_image_bytes: Option<bool>,
     ) -> Result<String, JsValue> {
         let omit_image_bytes = omit_image_bytes.unwrap_or(false);
-        #[cfg(feature = "subsecond-dev")]
-        {
-            let mut hot = subsecond::HotFn::current(get_page_layer_tree_with_profile_impl);
-            return hot.call((self, page_num, profile, omit_image_bytes));
-        }
-        #[cfg(not(feature = "subsecond-dev"))]
-        get_page_layer_tree_with_profile_impl(self, page_num, profile, omit_image_bytes)
+        subsecond_boundary::get_page_layer_tree_with_profile(
+            self,
+            page_num,
+            profile,
+            omit_image_bytes,
+        )
     }
 
+    /// 선언된 모든 렌더 경계의 현재 함수 주소.
+    ///
+    /// 경계 목록(`subsecond_boundary`)에서 바로 나오므로 경계를 더할 때 여기를 같이 고칠
+    /// 일이 없다 — 리비전이 경계 하나를 놓쳐 재도색이 안 도는 구멍이 생기지 않는다.
     #[cfg(all(feature = "subsecond-dev", target_arch = "wasm32"))]
     #[cfg_attr(
         feature = "subsecond-dev",
         wasm_bindgen(js_name = getSubsecondPatchRevision)
     )]
     pub fn get_subsecond_patch_revision(&self) -> String {
-        let canvas =
-            crate::subsecond_dev::hot_fn_ptr(render_page_to_canvas_filtered_with_profile_impl);
-        let layers = crate::subsecond_dev::hot_fn_ptr(get_page_layer_tree_with_profile_impl);
-        format!("{canvas:016x}:{layers:016x}")
+        subsecond_boundary::patch_revision()
     }
 
     #[cfg(feature = "subsecond-dev")]
@@ -950,8 +978,7 @@ impl HwpDocument {
     /// 페이지 overlay 이미지 정보만 JSON 문자열로 반환한다.
     #[wasm_bindgen(js_name = getPageOverlayImages)]
     pub fn get_page_overlay_images(&self, page_num: u32) -> Result<String, JsValue> {
-        self.get_page_overlay_images_native(page_num)
-            .map_err(|e| e.into())
+        subsecond_boundary::get_page_overlay_images(self, page_num)
     }
 
     /// 페이지가 그리는 그림들의 신원 키만 작은 JSON 으로 반환한다 (Task #3315).
@@ -967,8 +994,7 @@ impl HwpDocument {
     /// 있고 `sourceImageKey` 로 `getSourceImageBytes` 를 부르면 된다.
     #[wasm_bindgen(js_name = getPageFlowImageOps)]
     pub fn get_page_flow_image_ops(&self, page_num: u32) -> Result<String, JsValue> {
-        self.get_page_flow_image_ops_native(page_num)
-            .map_err(|e| e.into())
+        subsecond_boundary::get_page_flow_image_ops(self, page_num)
     }
 
     /// 그림 신원 키로 바이트를 Uint8Array 로 반환한다 (Task #3315).

--- a/src/wasm_api/subsecond_boundary.rs
+++ b/src/wasm_api/subsecond_boundary.rs
@@ -1,0 +1,310 @@
+//! Subsecond 핫패치가 실제로 도달하는 렌더 경계 (#4577).
+//!
+//! `subsecond::HotFn::current(f)` 는 **`f` 하나만** 점프 테이블로 우회시킨다. 점프 테이블은
+//! `map.get(&real)` 단일 키 조회이고, wasm `apply_patch` 는 메모리와 간접 함수 테이블을
+//! **늘리기만** 할 뿐 이미 있는 슬롯을 다시 묶지 않는다. 즉 **전이적 재링크가 없다** — JS 가
+//! base 모듈의 export 를 직접 부르면 그 아래 호출은 끝까지 옛 코드다.
+//!
+//! 그래서 "무엇이 핫패치되는가"는 export 마다 흩어진 `#[cfg]` 블록이 아니라 아래
+//! `hot_render_boundaries!` **목록 하나**가 정한다. 한 줄을 더하면 세 가지가 함께 생긴다.
+//!
+//! 1. 그 경계의 dispatcher — `#[cfg(feature = "subsecond-dev")]` 분기는 이 파일의 매크로
+//!    안에 **한 벌만** 있다. 복사할 `#[cfg]` 블록이 없으니 빠뜨릴 것도 없다.
+//! 2. `patch_revision()` 의 한 칸 — 새 경계만 건드린 패치가 재도색을 못 부르는 구멍이
+//!    생기지 않는다. `getSubsecondPatchRevision` 은 이 함수 하나만 부른다.
+//! 3. `hot_render_exports()` 의 export 이름 — 아래 테스트가 "이 export 는 경계 뒤에 있어야
+//!    한다"를 기계로 검사한다.
+//!
+//! 반대 방향도 닫혀 있다. dispatcher 마다 `#[deny(dead_code)]` 가 붙으므로 목록에 올려 놓고
+//! export 를 배선하지 않으면 빌드가 깨진다 — 저장소 전역은 `dead_code = "allow"` 라 이
+//! 국소 deny 가 없으면 조용히 통과한다.
+//!
+//! ## 인자 9개 상한
+//!
+//! `subsecond` 는 `HotFunction` 을 인자 9개까지만 구현한다(`impl_hot_function!` 의
+//! `Fn9Marker` 가 마지막이다). `&HwpDocument` 가 첫 자리를 쓰므로 경계 함수가 실제로 받을 수
+//! 있는 인자는 8개다. 부분 재도색은 `x/y/width/height` 를 `BoundingBox` 하나로 접어 이 상한
+//! 안에 들어간다 — 그대로 펴 두면 10개라 `HotFn::current` 가 아예 컴파일되지 않는다.
+
+use wasm_bindgen::JsValue;
+
+use super::HwpDocument;
+#[cfg(target_arch = "wasm32")]
+use crate::renderer::render_tree::BoundingBox;
+#[cfg(target_arch = "wasm32")]
+use web_sys::HtmlCanvasElement;
+
+/// 렌더 경계 목록에서 dispatcher · 패치 리비전 · export 이름표를 함께 만든다.
+///
+/// 항목 문법은 `exports [...] fn <dispatcher>(<인자>) -> <반환> = <패치 대상>;` 이다.
+/// `#[cfg(...)]` 만 항목 앞에 붙일 수 있다 — 설명은 `//` 주석으로 적는다(문서 주석은
+/// 아래 집계 함수의 문장 자리에 붙을 수 없다).
+macro_rules! hot_render_boundaries {
+    (
+        $(
+            $(#[cfg($cfg:meta)])?
+            exports [$($export:literal),+ $(,)?]
+            fn $name:ident($($arg:ident: $ty:ty),* $(,)?) -> $ret:ty = $target:path;
+        )+
+    ) => {
+        $(
+            // 목록에 올려 놓고 export 를 배선하지 않으면 여기서 빌드가 깨진다. 저장소
+            // 전역이 `dead_code = "allow"`(Cargo.toml) 라 이 한 줄이 없으면 조용히 통과한다.
+            $(#[cfg($cfg)])?
+            #[deny(dead_code)]
+            #[inline]
+            pub(crate) fn $name($($arg: $ty),*) -> $ret {
+                #[cfg(feature = "subsecond-dev")]
+                {
+                    let mut hot = subsecond::HotFn::current($target);
+                    return hot.call(($($arg,)*));
+                }
+                #[cfg(not(feature = "subsecond-dev"))]
+                $target($($arg),*)
+            }
+        )+
+
+        /// 이 타깃에서 실제로 컴파일된 경계 수. `patch_revision()` 의 칸 수와 같다.
+        #[cfg(all(test, feature = "subsecond-dev"))]
+        pub(crate) fn compiled_boundary_count() -> usize {
+            let mut count = 0usize;
+            $(
+                $(#[cfg($cfg)])?
+                {
+                    count += 1;
+                }
+            )+
+            count
+        }
+
+        /// 경계 뒤에 있는 wasm export 이름 전부.
+        ///
+        /// 타깃별 `#[cfg]` 를 타지 않는다 — 네이티브 테스트에서도 wasm32 전용 경계가
+        /// 선언되어 있는지 볼 수 있어야 한다.
+        #[cfg(test)]
+        pub(crate) fn hot_render_exports() -> Vec<&'static str> {
+            let mut exports: Vec<&'static str> = Vec::new();
+            $(
+                exports.extend_from_slice(&[$($export),+]);
+            )+
+            exports
+        }
+
+        /// 경계마다 현재 함수 주소를 이어 붙인 패치 리비전.
+        ///
+        /// studio 는 이 문자열이 바뀌면 캐시를 버리고 다시 그린다. 문자열을 해석하지 않고
+        /// 이전 값과 비교만 하므로 칸 수가 늘어도 계약이 깨지지 않는다.
+        #[cfg(feature = "subsecond-dev")]
+        pub(crate) fn patch_revision() -> String {
+            use std::fmt::Write as _;
+
+            let mut revision = String::new();
+            $(
+                $(#[cfg($cfg)])?
+                {
+                    if !revision.is_empty() {
+                        revision.push(':');
+                    }
+                    let _ = write!(
+                        revision,
+                        "{:016x}",
+                        crate::subsecond_dev::hot_fn_ptr($target)
+                    );
+                }
+            )+
+            revision
+        }
+    };
+}
+
+hot_render_boundaries! {
+    // 전체 재도색. 본문·overlay·static plane 을 각각 그린다 — `renderer::web_canvas` 와
+    // `renderer::layer_renderer` 의 페인트 전부가 이 아래에 있다.
+    #[cfg(target_arch = "wasm32")]
+    exports ["renderPageToCanvasFiltered", "renderPageToCanvasFilteredWithProfile"]
+    fn render_page_to_canvas_filtered_with_profile(
+        document: &HwpDocument,
+        page_num: u32,
+        canvas: &HtmlCanvasElement,
+        scale: f64,
+        layer_kind: &str,
+        profile: &str,
+    ) -> Result<(), JsValue> = super::render_page_to_canvas_filtered_with_profile_impl;
+
+    // 타이핑 중 부분 재도색. 같은 페인트 코드를 dirty rect 로만 다시 재생한다. 경계가 없으면
+    // 전체 재도색만 새 코드로 그리고 그 뒤 키 입력마다 자기 줄을 옛 코드로 되돌린다 (#4577).
+    #[cfg(target_arch = "wasm32")]
+    exports ["renderPagePatchToCanvasFilteredWithProfile"]
+    fn render_page_patch_to_canvas_filtered_with_profile(
+        document: &HwpDocument,
+        page_num: u32,
+        canvas: &HtmlCanvasElement,
+        scale: f64,
+        layer_kind: &str,
+        profile: &str,
+        patch: BoundingBox,
+    ) -> Result<(), JsValue> = super::render_page_patch_to_canvas_filtered_with_profile_impl;
+
+    // 레이어 트리 직렬화. `getPageLayerTree` 는 같은 대상의 screen profile 기본값이라 같은
+    // 경계를 쓴다 — PageRenderer 는 overlay 좁은 질의가 안 될 때 이쪽으로 되돌아온다.
+    exports ["getPageLayerTree", "getPageLayerTreeWithProfile"]
+    fn get_page_layer_tree_with_profile(
+        document: &HwpDocument,
+        page_num: u32,
+        profile: &str,
+        omit_image_bytes: bool,
+    ) -> Result<String, JsValue> = super::get_page_layer_tree_with_profile_impl;
+
+    // 레이어 평면 분류. `getLayerPlaneSummary` 를 먹여 static flow 분리 여부, overlay 캔버스
+    // 생성 여부, **부분 재도색 자격 여부**를 정한다. 여기가 옛 코드면 페인트는 새 코드로
+    // 그리고 합성 판정은 옛 코드로 내려 둘이 어긋난다.
+    exports ["getPageOverlayImages"]
+    fn get_page_overlay_images(
+        document: &HwpDocument,
+        page_num: u32,
+    ) -> Result<String, JsValue> = super::get_page_overlay_images_impl;
+
+    // 본문 그림의 DOM 배치. 같은 평면 분류와 조상 clip 접기를 써서 `<img>` 의 bbox 를 낸다.
+    // 이 값은 경계 뒤에서 그린 캔버스 위에 합성되므로 둘의 분류가 갈리면 그림이 어긋난다.
+    exports ["getPageFlowImageOps"]
+    fn get_page_flow_image_ops(
+        document: &HwpDocument,
+        page_num: u32,
+    ) -> Result<String, JsValue> = super::get_page_flow_image_ops_impl;
+}
+
+/// 일부러 경계 밖에 둔 export 와 그 이유. 위 목록과 한 쌍이라 붙여 둔다.
+///
+/// "아직 안 했다"가 아니라 **경계를 두어도 얻는 것이 없거나 오히려 어긋난다**는 판단이다.
+/// 판단이 바뀌면 여기서 빼고 위 `hot_render_boundaries!` 로 옮기면 된다.
+#[cfg(test)]
+const DELIBERATELY_COLD_EXPORTS: &[(&str, &str)] = &[
+    (
+        "getPageSourceImageKeys",
+        "그림 신원 키만 만든다 — 페인트도 평면 분류도 아래에 없다. 캐시 신원을 \
+         핫패치하면 이미 저장된 서명과 비교가 불가능해져 재디코드만 늘어난다.",
+    ),
+    (
+        "getSourceImageBytes",
+        "결과를 studio 가 키별 object URL 로 메모이즈한다(FlowImageUrlCache). 키가 \
+         바뀌기 전에는 다시 들어오지 않으므로 경계를 두어도 관측되지 않는다.",
+    ),
+    (
+        "getPageInfo",
+        "아래에 페인트도 평면 분류도 없다 — 이미 계산된 페이지네이션(`find_page`)을 읽고 \
+         PageDef 여백을 px 로 환산할 뿐이다. 게다가 그중 낡을 수 있는 값(page 크기·단 \
+         영역)은 `invalidateSubsecondRenderCaches` 가 비우지 않는 pagination 에서 오므로 \
+         경계를 두면 '새 여백 산술 + 옛 페이지네이션' 이라는 반만 새 기록이 된다. \
+         한 페이지를 그릴 때마다, 또 `refreshPages()` 마다 문서 전 페이지분이 도는 \
+         이 목록에서 가장 잦은 질의이기도 하다.",
+    ),
+    (
+        "getCanvasKitReplayPlanWithProfile",
+        "PageRenderer 가 부르지 않는다 — 소비자는 e2e 기준선 수집기뿐이다. CanvasKit \
+         페인트는 TypeScript 이고 그 입력 트리는 이미 경계 뒤에서 온다.",
+    ),
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `PageRenderer` 가 한 페이지를 그리는 동안 부르는 wasm export 중 **렌더 결과나 합성
+    /// 판정을 만들어 내는** 것들. 이 목록이 늘어나면 경계도 함께 늘어나야 한다.
+    const RENDER_PATH_EXPORTS_THAT_MUST_BE_HOT: &[(&str, &str)] = &[
+        (
+            "renderPageToCanvasFilteredWithProfile",
+            "page-renderer.ts renderFlowCanvas·applyOverlays — 전체 재도색 페인트",
+        ),
+        (
+            "renderPagePatchToCanvasFilteredWithProfile",
+            "page-renderer.ts renderFocusedPagePatch — 타이핑 중 부분 재도색 페인트",
+        ),
+        (
+            "getPageLayerTree",
+            "page-renderer.ts getLayerPlaneSummaryFromTree·getFlowImagePaintOps 폴백",
+        ),
+        (
+            "getPageLayerTreeWithProfile",
+            "page-renderer.ts renderPageCanvasKit — CanvasKit 백엔드가 재생할 레이어 트리",
+        ),
+        (
+            "getPageOverlayImages",
+            "page-renderer.ts getLayerPlaneSummary — 합성·부분 재도색 자격 판정",
+        ),
+        (
+            "getPageFlowImageOps",
+            "page-renderer.ts getFlowImagePaintOps — 본문 그림 DOM 배치",
+        ),
+    ];
+
+    #[test]
+    fn every_render_path_export_sits_behind_a_hot_patch_boundary() {
+        let hot = hot_render_exports();
+        let missing: Vec<&str> = RENDER_PATH_EXPORTS_THAT_MUST_BE_HOT
+            .iter()
+            .filter(|(export, _)| !hot.contains(export))
+            .map(|(export, _)| *export)
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "이 export 들은 PageRenderer 의 렌더 경로에 있는데 핫패치 경계 뒤에 없다 — \
+             패치를 걸어도 base 모듈의 옛 코드가 그린다: {missing:?}"
+        );
+    }
+
+    #[test]
+    fn each_export_is_declared_by_exactly_one_boundary() {
+        let mut hot = hot_render_exports();
+        let declared = hot.len();
+        hot.sort_unstable();
+        hot.dedup();
+        assert_eq!(
+            declared,
+            hot.len(),
+            "같은 export 가 두 경계에 선언되어 있다 — 어느 쪽으로 배선했는지 알 수 없다"
+        );
+    }
+
+    #[test]
+    fn deliberately_cold_exports_are_not_also_declared_hot() {
+        let hot = hot_render_exports();
+        for (export, reason) in DELIBERATELY_COLD_EXPORTS {
+            assert!(
+                !hot.contains(export),
+                "{export} 는 경계 밖으로 두기로 해 놓고 경계 목록에도 들어 있다"
+            );
+            assert!(
+                !reason.trim().is_empty(),
+                "{export} 를 경계 밖에 두는 이유가 비어 있다"
+            );
+        }
+    }
+
+    /// 리비전은 경계마다 한 칸이어야 한다. 칸이 빠지면 그 경계만 바뀐 패치가 studio 의
+    /// 재도색을 부르지 못한다.
+    #[cfg(feature = "subsecond-dev")]
+    #[test]
+    fn patch_revision_covers_every_compiled_boundary() {
+        let revision = patch_revision();
+        let mut segments: Vec<&str> = revision.split(':').collect();
+        assert_eq!(
+            segments.len(),
+            compiled_boundary_count(),
+            "패치 리비전이 경계 수와 다르다: {revision}"
+        );
+        assert!(
+            segments.iter().all(|segment| segment.len() == 16),
+            "리비전 칸은 16자리 함수 주소여야 한다: {revision}"
+        );
+
+        let probed = segments.len();
+        segments.sort_unstable();
+        segments.dedup();
+        assert_eq!(
+            probed,
+            segments.len(),
+            "두 경계가 같은 주소를 낸다 — 한쪽 패치가 리비전에 나타나지 않는다: {revision}"
+        );
+    }
+}


### PR DESCRIPTION
`HotFn::current(f)` 는 `f` 하나만 리다이렉트합니다 — 점프 테이블이 단일 키 조회이고 wasm `apply_patch` 는 메모리와 간접 테이블을 늘리기만 할 뿐 기존 슬롯을 재바인딩하지 않습니다. 그래서 JS 가 직접 부르는 export 아래는 전부 base 모듈의 정적 호출입니다. 렌더 경계가 둘뿐이었고, **타이핑 중 부분 재도색이 쓰는 export 가 그중에 없었습니다.** 전체 재도색은 새 색으로 그려지는데 한 글자 치면 그 줄만 패치 이전 색으로 되돌아갑니다.

**이슈가 몰랐던 블로커가 있었습니다.** `subsecond` 는 `HotFunction` 을 **9인자까지만** 구현합니다(`lib.rs:948-959`). `render_page_patch_to_canvas_filtered_with_profile_impl` 은 10개라 `HotFn::current` 가 애초에 컴파일되지 않습니다. `x/y/width/height` 를 `BoundingBox` 하나로 묶어 7개로 줄인 것이 경계를 가능하게 한 변경입니다 — JS 시그니처는 그대로입니다.

**이슈에 없던 구멍도 하나 더 찾았습니다.** `getPageLayerTree`(프로파일 없는 형제)가 같은 `_impl` 로 모이면서 경계를 우회하고 있었고, `PageRenderer` 세 곳에서 불립니다 — 그중 `getLayerPlaneSummaryFromTree` 는 `getPageOverlayImages` 가 먹이는 바로 그 결정의 폴백입니다. 기존 `render_page_to_canvas_filtered` → `…_with_profile` 패턴대로 형제에 위임하게 했습니다.

**"다음 사람이 잊지 않게 하는" 형태가 이 이슈의 본체였습니다.** `hot_render_boundaries!` 목록 하나가 항목마다 디스패처·리비전 조각·export 이름 매니페스트를 생성합니다. `get_subsecond_patch_revision` 이 그 생성물이라 **경계와 따로 편집될 자리가 없어졌습니다.** 반대 방향은 각 디스패처의 `#[deny(dead_code)]` 가 막습니다 — 경계를 등록하고 export 배선을 잊으면 빌드가 깨집니다. 이 local deny 가 하중을 받는 이유는 `Cargo.toml:208` 이 크레이트 전역으로 `dead_code = "allow"` 이기 때문이고, 양쪽 상태를 확인했습니다.

**감싸지 않은 넷은 이유를 기록하고 기계로 비중복을 검사합니다.** `getPageSourceImageKeys` 는 식별 키뿐이라 감싸면 저장된 서명이 비교 불가가 되어 재디코드만 삽니다. `getSourceImageBytes` 는 스튜디오가 결과를 캐시해 패치된 본문에 재진입 자체가 없습니다(#4595). `getCanvasKitReplayPlan*` 은 `PageRenderer` 경로에 없습니다. `getPageInfo` 는 감싸면 **낡은 `self.pagination` 위에 새 여백 산술만** 적용되어 더 나쁜 혼합물이 됩니다 — `invalidate_page_tree_cache` 가 pagination 을 지우지 않기 때문이고, 그 축은 #4576 이 다룹니다.

깔때기 경계는 추가하지 않았습니다. 패치 export 자체가 경계 뒤로 들어가면서 `PageRenderer` 경로의 모든 `build_page_layer_tree_with_profile` 호출이 이미 경계 아래이므로, 안쪽 경계는 재도색마다 조회를 하나 더 하고 새로 덮는 것이 없습니다.

RED 는 레지스트리를 기존 두 경계로 줄여 받았습니다 — 생성된 레지스트리에 대한 구조적 테스트이고 소스 정규식이 아닙니다.

```
이 export 들은 PageRenderer 의 렌더 경로에 있는데 핫패치 경계 뒤에 없다:
["renderPagePatchToCanvasFilteredWithProfile", "getPageOverlayImages", "getPageFlowImageOps"]
```

`cargo test --profile release-test --tests` exit 0 — `ok` 블록 535개, **5,762 passed / 0 FAILED**. fmt·clippy clean, Skia 3종 exit 0(58/2/4), `wasm-pack build` exit 0, `cargo check --lib --features subsecond-dev --target wasm32-unknown-unknown` clean.

**검증 한계**: `dx serve --hat-patch` 로 실제 패치가 타이핑한 줄을 다시 그리는 것은 보지 못했습니다. 증명한 것은 컴파일 타임 계약입니다 — 경계가 붙고, 리비전이 컴파일된 경계마다 서로 다른 16자리 조각을 내고, 배선 안 된 경계가 빌드를 깬다는 것.

작업 중 나왔지만 손대지 않은 것은 #4595(이미지 바이트가 어떤 경계로도 안 닿음), #4596(핫패치가 디버그 빌드 전용인데 미기재)로 열었습니다.

**머지 순서**: PR #4584(#4576)와 `src/wasm_api.rs` 를 공유해 충돌합니다. `src/document_core/queries/rendering.rs` 는 읽기만 하고 건드리지 않아 겹침을 한 파일로 줄였습니다. 나중에 머지되는 쪽이 리베이스하면 됩니다.

Closes #4577