### PR TITLE
fix: gym T12 HWPX 형식·판정 계약 보정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -833,6 +833,9 @@ jobs:
           python3 -m unittest scripts/tests/test_setup_action.py
           python3 -m unittest scripts/tests/test_workflow_contract_wiring.py
 
+      - name: Validate gym scorer contracts
+        run: python3 -m unittest scripts/tests/test_gym_score.py
+
       - name: Clippy
         run: cargo clippy -- -D warnings
 

--- a/gym/README.md
+++ b/gym/README.md
@@ -55,6 +55,11 @@ python gym/score.py --agent <너의이름>   # 4) 자가 채점 — 스코어카
 채점 세부는 스코어카드(`scorecard.json`·`report.md`)에 있는 그대로 남는다 —
 실패도 데이터다.
 
+검사의 `expect_exit`은 단일 정상 종료 코드를 뜻한다. `ir-diff`처럼 동일(exit 0)과 차이 검출(exit 3)이
+모두 유효한 판정인 명령은 `expect_exits:[0,3]`으로 선언한다. 채점기는 허용된 종료 코드의 JSON 봉투를
+계속 읽어 `identical` 같은 판정 값을 답안과 비교한다. 허용 목록에 없는 IO·사용법 오류는 판정 전에
+실패한다.
+
 ## 제출 형식
 
 - `submit.kind: "answer"` → `answer.json` 하나 (과제가 요구한 키만).

--- a/gym/baselines/claude-fable-5/T12/answer.json
+++ b/gym/baselines/claude-fable-5/T12/answer.json
@@ -1,3 +1,3 @@
 {
-  "identical": true
+  "identical": false
 }

--- a/gym/baselines/claude-fable-5/T12/verification.json
+++ b/gym/baselines/claude-fable-5/T12/verification.json
@@ -1,0 +1,37 @@
+{
+  "kind": "gymTaskBaseline",
+  "schemaVersion": "1.0",
+  "task": "T12",
+  "source": "samples/field-01.hwp",
+  "sourceSha256": "518cb939079e6e0640a5f813597f744e2528a17ca52ee418929f1c8f4b5380c0",
+  "artifact": "conv.hwpx (gitignored, export-hwpx로 재생성)",
+  "artifactSha256": "41c07ba1a1f00b356b0ca6ccbef986747ae177cfee10f243a6905d82ad698617",
+  "artifactFormat": "hwpx",
+  "answer": {
+    "identical": false
+  },
+  "runner": {
+    "rhwpVersion": "rhwp v0.8.2",
+    "rhwpCommit": "1ac75c0aad1056195c34cac2cc036d2943c5f99d",
+    "capabilitiesSha256": "62aea3df8bc40dd679247c044093e41fc54d1d80396c2b4b5b445ec843ffe27c"
+  },
+  "result": {
+    "pass": true,
+    "checks": [
+      {
+        "name": "HWPX 형식 확인",
+        "op": "value_eq",
+        "ok": true,
+        "expected": "hwpx",
+        "actual": "hwpx"
+      },
+      {
+        "name": "변환물 IR 대조",
+        "op": "answer_eq",
+        "ok": true,
+        "expected": false,
+        "actual": false
+      }
+    ]
+  }
+}

--- a/gym/baselines/claude-fable-5/report.md
+++ b/gym/baselines/claude-fable-5/report.md
@@ -15,8 +15,12 @@
 | T09 원자 계획 실행 | 3 | 통과 | O 1단계 반영 · O 2단계 반영 |
 | T10 결정론 실증 | 3 | 통과 | O 바이트 동일 |
 | T11 보안 스윕 | 2 | 통과 | O 신호 수 일치 |
-| T12 변환 자기검증 | 2 | 통과 | O 변환물 IR 대조 |
+| T12 변환 자기검증 | 2 | 통과 | O HWPX 형식 확인 · O 변환물 IR 대조 |
 | T13 하네스 루프 | 3 | 통과 | O 체인·서명·재현 통합 판정 · O 체인 길이 2 |
 | T14 관문 통과 | 3 | 통과 | O 관문 verdict:allow (재현·계보·서명·앵커 전축) |
 
 채점기: score.py (라이브 오라클) · 바이너리: rhwp.exe
+
+T12는 #4586에서 실제 HWPX로 focused 재실행했다. 전체 1호 선수의 gitignore 산출물을 다시 만들었다고
+가장하지 않고, T12의 입력·산출 해시와 rhwp version/commit/capabilities digest는
+[`T12/verification.json`](T12/verification.json)에 별도로 고정했다.

--- a/gym/baselines/claude-fable-5/scorecard.json
+++ b/gym/baselines/claude-fable-5/scorecard.json
@@ -184,11 +184,18 @@
       "pass": true,
       "checks": [
         {
+          "name": "HWPX 형식 확인",
+          "op": "value_eq",
+          "ok": true,
+          "expected": "hwpx",
+          "actual": "hwpx"
+        },
+        {
           "name": "변환물 IR 대조",
           "op": "answer_eq",
           "ok": true,
-          "expected": true,
-          "actual": true
+          "expected": false,
+          "actual": false
         }
       ]
     },

--- a/gym/score.py
+++ b/gym/score.py
@@ -143,9 +143,15 @@ def eval_check(check, task, sub_dir, answer, bin_path):
             return detail
         args = resolve_args(check["cmd"], task, sub_dir)
         code, env, head = run_cli(bin_path, args)
-        expect_exit = check.get("expect_exit", 0)
-        if code != expect_exit:
-            detail["error"] = f"exit {code} (기대 {expect_exit}): {head}"
+        expect_exits = check.get("expect_exits")
+        if expect_exits is None:
+            expect_exits = [check.get("expect_exit", 0)]
+        if (not isinstance(expect_exits, list) or not expect_exits
+                or any(type(value) is not int for value in expect_exits)):
+            detail["error"] = f"잘못된 expect_exits: {expect_exits!r}"
+            return detail
+        if code not in expect_exits:
+            detail["error"] = f"exit {code} (허용 {expect_exits}): {head}"
             return detail
         if env is None:
             detail["error"] = f"봉투 파싱 실패: {head}"

--- a/gym/tasks/T12.json
+++ b/gym/tasks/T12.json
@@ -3,7 +3,7 @@
   "tier": 2,
   "title": "변환 자기검증",
   "input": "samples/field-01.hwp",
-  "instructions": "입력 HWP 를 HWPX 로 변환해 conv.hwpx 로 제출하라. 변환 명령의 자기검증(verify) 봉투를 읽고 IR 동등 여부를 answer.json 에 {\"identical\": true|false} 로 함께 제출하라. 힌트: rhwp convert <입력> conv.hwpx --verify --json (verify 봉투의 IR 대조 결과를 읽어라).",
+  "instructions": "입력 HWP 를 HWPX 로 변환해 conv.hwpx 로 제출하라. 변환 명령의 자기검증(verify) 봉투를 읽고 IR 동등 여부를 answer.json 에 {\"identical\": true|false} 로 함께 제출하라. 힌트: rhwp export-hwpx <입력> conv.hwpx --verify --json (verify 봉투의 IR 대조 결과를 읽어라).",
   "submit": {
     "kind": "artifact",
     "files": [
@@ -11,6 +11,18 @@
     ]
   },
   "checks": [
+    {
+      "name": "HWPX 형식 확인",
+      "op": "value_eq",
+      "value": "hwpx",
+      "cmd": [
+        "info",
+        "{file:conv.hwpx}",
+        "--json"
+      ],
+      "path": "format",
+      "expect_exit": 0
+    },
     {
       "name": "변환물 IR 대조",
       "op": "answer_eq",
@@ -22,7 +34,10 @@
         "--json"
       ],
       "path": "identical",
-      "expect_exit": 0
+      "expect_exits": [
+        0,
+        3
+      ]
     }
   ]
 }

--- a/mydocs/manual/agent_codex/01_판단트리.md
+++ b/mydocs/manual/agent_codex/01_판단트리.md
@@ -55,7 +55,8 @@ last_verified: 2026-08-11
 ## ④ "다른 형식으로" — 변환·렌더
 
 ```text
-HWP↔HWPX              → convert <입력> <출력> --verify     (40장)
+HWP → HWPX            → export-hwpx <입력> <출력.hwpx> --verify (40장)
+HWPX/배포용 → HWP5     → convert <입력> <출력.hwp> --verify     (40장)
 PDF 발행               → export-pdf                        (40장)
 웹/LLM 소비            → export-markdown / export-doclang  (40장)
 눈으로 확인            → export-svg → (외부) resvg 로 PNG   (40장)

--- a/mydocs/manual/agent_codex/40_변환과_렌더.md
+++ b/mydocs/manual/agent_codex/40_변환과_렌더.md
@@ -20,17 +20,17 @@ generated: tools/gen_agent_codex.py — 수기 수정 금지, 재생성으로 �
 - 봉투 필드: `schemaVersion` · `source` · `output` · `format` · `bytes` · `wasDistribution` · `verify` · `verifyPages` — 정의는 [지식지도 §2-2](../agent_knowledge_map.md)
 - **출처 표지**: 문서 파생 필드 없음 (엔진·에코 값뿐)
 
-실측 표본 — 형식 변환 + 재파싱 자기검증 (exit 0):
+실측 표본 — HWP5 변환 + 재파싱 자기검증 (exit 0):
 
 ```bash
-rhwp convert samples/field-01.hwp <tmp>/conv.hwpx --verify --json
+rhwp convert samples/field-01.hwp <tmp>/conv.hwp --verify --json
 ```
 
 ```json
 {
   "bytes": 473600,
   "format": "hwp5",
-  "output": "<tmp>/conv.hwpx",
+  "output": "<tmp>/conv.hwp",
   "passwordProtected": false,
   "schemaVersion": "1.0",
   "source": "samples/field-01.hwp",

--- a/mydocs/manual/agent_codex/50_검증_사다리.md
+++ b/mydocs/manual/agent_codex/50_검증_사다리.md
@@ -70,7 +70,7 @@ rhwp replay --plan-json '<계획 JSON 인라인>' --json
   "inputSha256": "bebd4ce3691246b0fb3ae332e1d40bc51d9035cddb9fc3d378466b6a8a2b5626",
   "mode": "attest",
   "outputSha256": "db72869c12a1c4149beb7e417c6d86f8c26de5282f7b218a136e974a1f140e58",
-  "planSha256": "b7a684536949fc56dac273bb5752312443deb47956a4733b0978b445aee7d997",
+  "planSha256": "01af0d83782e2d9ecd0b48bcd9c789db50b661632e9e38d887989515d6fc2809",
   "reproduced": null,
   "schemaVersion": "1.0",
   "steps": 1,

--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -941,6 +941,8 @@ rhwp edit sanitize 배포본.hwp -o /tmp/재확인.hwp --json | jq .removedCount
 
 ### `convert <입력.hwp|.hwpx> <출력.hwp> [--verify] [--verify-pages] [--output-password-stdin]`
 배포용(읽기전용) HWP → 편집 가능 HWP 변환. 출력은 항상 `.hwp`.
+- 출력 확장자는 대소문자 무시 `.hwp`만 허용한다. 확장자가 없거나 `.hwpx` 등 다른 확장자면 입력을
+  읽거나 파일을 쓰기 전에 사용법 오류(exit 2)로 거부하고, HWPX 변환에는 `export-hwpx`를 안내한다.
 - `--verify` — 저장 후 산출물을 재파싱하여 어댑터 적용 후 IR과 재로딩 IR 차이를 검출한다.
   차이가 있으면 산출물은 남기고 종료 코드 3으로 실패한다.
 - `--verify-pages` — 저장 전 문서 페이지 수와 저장 후 재로딩 페이지 수를 비교한다.

--- a/mydocs/orders/20260811.md
+++ b/mydocs/orders/20260811.md
@@ -5,7 +5,19 @@
 | Issue | 타스크 | 상태 | 비고 |
 | --- | --- | --- | --- |
 | [#3790](https://github.com/edwardkim/rhwp/issues/3790) | Stage 5B CodeQL 언어별 선택 실행 | 진행중 | Draft PR #4519 최신 devel 반영·reviewer `edwardkim` 지정·검토 기록 완료; 최종 full CI·CodeQL 확인 대기 |
-| [#4586](https://github.com/edwardkim/rhwp/issues/4586) | gym T12 HWPX 형식·판정 계약 보정 | PR 준비 | T12 focused 2/2, release-test 5,763/5,763 통과; 최종 보고서 완료, PR 생성 승인 대기 |
+| [#4586](https://github.com/edwardkim/rhwp/issues/4586) | gym T12 HWPX 형식·판정 계약 보정 | PR #4598 self-review | T12 focused 2/2, release-test 5,763/5,763와 initial code candidate Full CI 통과; review-only 기록 push 준비 |
+
+## PR #4598 - gym T12 HWPX 형식·판정 계약 보정
+
+- [PR #4598](https://github.com/edwardkim/rhwp/pull/4598)을 `devel` 대상 Open PR로 생성했다. assignee
+  `edwardkim`, milestone `v1.0.0`, 변경 범위 기반 labels를 적용했다.
+- 작성자와 self-review 담당이 같은 `edwardkim`이므로 자기 reviewer request와 `APPROVE`는 시도하지
+  않는다. 검토 결과는 최신 head에 `COMMENTED` review로 게시한다.
+- initial code candidate `4f24c73e9`는 로컬 focused·전체 release-test·fmt·clippy·문서 링크 검사와
+  최신 `upstream/devel` merge simulation을 통과했다. GitHub Full CI·CodeQL 3개 언어·Render Diff도
+  모두 성공했으므로 [검토 기록](../pr/archives/pr_4598_review.md)을 trailing review-only commit으로 push한다.
+- 최신 review-only head의 fast-pass·required checks·mergeability와 self-review 게시를 확인한 뒤 별도
+  작업지시자 승인을 받아 merge한다.
 
 ## PR #4525 - stableIndex 문서 경로 정렬 계약
 

--- a/mydocs/orders/20260811.md
+++ b/mydocs/orders/20260811.md
@@ -5,7 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 | --- | --- | --- | --- |
 | [#3790](https://github.com/edwardkim/rhwp/issues/3790) | Stage 5B CodeQL 언어별 선택 실행 | 진행중 | Draft PR #4519 최신 devel 반영·reviewer `edwardkim` 지정·검토 기록 완료; 최종 full CI·CodeQL 확인 대기 |
-| [#4586](https://github.com/edwardkim/rhwp/issues/4586) | gym T12 HWPX 형식·판정 계약 보정 | 최종 검증 승인 대기 | T12 focused 기준선·생성 교본·CLI 문서 정합 완료; release-test 전체 회귀 승인 대기 |
+| [#4586](https://github.com/edwardkim/rhwp/issues/4586) | gym T12 HWPX 형식·판정 계약 보정 | PR 준비 | T12 focused 2/2, release-test 5,763/5,763 통과; 최종 보고서 완료, PR 생성 승인 대기 |
 
 ## PR #4525 - stableIndex 문서 경로 정렬 계약
 

--- a/mydocs/orders/20260811.md
+++ b/mydocs/orders/20260811.md
@@ -5,7 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 | --- | --- | --- | --- |
 | [#3790](https://github.com/edwardkim/rhwp/issues/3790) | Stage 5B CodeQL 언어별 선택 실행 | 진행중 | Draft PR #4519 최신 devel 반영·reviewer `edwardkim` 지정·검토 기록 완료; 최종 full CI·CodeQL 확인 대기 |
-| [#4586](https://github.com/edwardkim/rhwp/issues/4586) | gym T12 HWPX 형식·판정 계약 보정 | Stage 3 승인 대기 | CLI·gym 구현 GREEN: Rust 3/3, Python 4/4, 인접 변환 2건·workflow 배선 3건 통과 |
+| [#4586](https://github.com/edwardkim/rhwp/issues/4586) | gym T12 HWPX 형식·판정 계약 보정 | 최종 검증 승인 대기 | T12 focused 기준선·생성 교본·CLI 문서 정합 완료; release-test 전체 회귀 승인 대기 |
 
 ## PR #4525 - stableIndex 문서 경로 정렬 계약
 

--- a/mydocs/orders/20260811.md
+++ b/mydocs/orders/20260811.md
@@ -5,7 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 | --- | --- | --- | --- |
 | [#3790](https://github.com/edwardkim/rhwp/issues/3790) | Stage 5B CodeQL 언어별 선택 실행 | 진행중 | Draft PR #4519 최신 devel 반영·reviewer `edwardkim` 지정·검토 기록 완료; 최종 full CI·CodeQL 확인 대기 |
-| [#4586](https://github.com/edwardkim/rhwp/issues/4586) | gym T12 HWPX 형식·판정 계약 보정 | Stage 1 진행중 | 계획 승인 완료; `task/4586-gym-t12-hwpx`에서 RED 계약 고정 |
+| [#4586](https://github.com/edwardkim/rhwp/issues/4586) | gym T12 HWPX 형식·판정 계약 보정 | Stage 2 승인 대기 | 최신 devel 재현과 RED 계약 고정 완료: Rust 2 fail/1 pass, Python 3 fail/1 pass |
 
 ## PR #4525 - stableIndex 문서 경로 정렬 계약
 

--- a/mydocs/orders/20260811.md
+++ b/mydocs/orders/20260811.md
@@ -5,7 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 | --- | --- | --- | --- |
 | [#3790](https://github.com/edwardkim/rhwp/issues/3790) | Stage 5B CodeQL 언어별 선택 실행 | 진행중 | Draft PR #4519 최신 devel 반영·reviewer `edwardkim` 지정·검토 기록 완료; 최종 full CI·CodeQL 확인 대기 |
-| [#4586](https://github.com/edwardkim/rhwp/issues/4586) | gym T12 HWPX 형식·판정 계약 보정 | Stage 2 승인 대기 | 최신 devel 재현과 RED 계약 고정 완료: Rust 2 fail/1 pass, Python 3 fail/1 pass |
+| [#4586](https://github.com/edwardkim/rhwp/issues/4586) | gym T12 HWPX 형식·판정 계약 보정 | Stage 3 승인 대기 | CLI·gym 구현 GREEN: Rust 3/3, Python 4/4, 인접 변환 2건·workflow 배선 3건 통과 |
 
 ## PR #4525 - stableIndex 문서 경로 정렬 계약
 

--- a/mydocs/orders/20260811.md
+++ b/mydocs/orders/20260811.md
@@ -5,6 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 | --- | --- | --- | --- |
 | [#3790](https://github.com/edwardkim/rhwp/issues/3790) | Stage 5B CodeQL 언어별 선택 실행 | 진행중 | Draft PR #4519 최신 devel 반영·reviewer `edwardkim` 지정·검토 기록 완료; 최종 full CI·CodeQL 확인 대기 |
+| [#4586](https://github.com/edwardkim/rhwp/issues/4586) | gym T12 HWPX 형식·판정 계약 보정 | Stage 1 진행중 | 계획 승인 완료; `task/4586-gym-t12-hwpx`에서 RED 계약 고정 |
 
 ## PR #4525 - stableIndex 문서 경로 정렬 계약
 

--- a/mydocs/plans/task_m100_4586.md
+++ b/mydocs/plans/task_m100_4586.md
@@ -1,0 +1,96 @@
+# #4586 수행계획서 — gym T12 HWPX 형식·판정 계약 보정
+
+- **Issue**: [#4586](https://github.com/edwardkim/rhwp/issues/4586)
+- **브랜치**: `task/4586-gym-t12-hwpx`
+- **기준 커밋**: `upstream/devel` `d30e5d4af`
+- **착수 상태**: assignee `edwardkim`, 같은 이슈를 가리키는 열린 PR 없음
+
+## 1. 문제와 근인
+
+통합 PR #4574로 들어온 gym T12는 HWP를 HWPX로 변환하라고 지시하면서
+`rhwp convert <입력> conv.hwpx --verify --json`을 힌트로 제시한다. 그러나 `convert`는
+HWPX/배포용 문서를 편집 가능한 **HWP5로 저장하는 명령**이며, 현재 구현은 출력 확장자를 검사하지
+않는다. 그 결과 파일명만 `conv.hwpx`인 HWP5가 생성되고 원본 HWP5와 IR이 같으므로 T12가 만점 처리한다.
+
+실제 HWPX를 만드는 `export-hwpx`는 `samples/field-01.hwp`에서 정상적으로 HWPX를 만들지만 IR 차이를
+판정해 exit 3과 `identical:false`를 반환한다. 현재 채점기는 `expect_exit:0`만 허용하고 종료 코드가
+다르면 봉투를 읽기 전에 실패하므로, 과제 의미에 맞는 정직한 제출은 답을 `false`로 내도 통과할 수 없다.
+
+문제는 세 층이 결합한 계약 결함이다.
+
+1. CLI가 HWP5 산출물에 `.hwpx` 확장자를 허용한다.
+2. T12가 실제 산출 형식을 검증하지 않는다.
+3. 채점기가 정상 판정 종료 코드 3의 JSON 봉투를 소비하지 못한다.
+
+추가로 `tools/gen_agent_codex.py`의 실측 표본도 같은 잘못된 `convert ... conv.hwpx` 명령을 생성해
+사용자 교본에 오류를 재생산하고 있다.
+
+## 2. 목표
+
+- `convert`는 `.hwp` 출력만 허용하고 다른 확장자를 디스크 기록 전에 exit 2로 거부한다.
+- T12는 `export-hwpx`로 실제 HWPX를 만들고 `info.format == "hwpx"`를 별도로 검증한다.
+- 채점 스키마는 기존 `expect_exit`과 호환하면서 `expect_exits:[0,3]`을 지원하고, 허용된 exit 3의
+  JSON 봉투를 계속 읽어 `identical:false`도 정답으로 판정한다.
+- CLI·gym·생성 교본의 잘못된 경로를 각각 독립 래칫으로 고정한다.
+- 수정된 T12 기준 실행의 rhwp version, 코드 commit, capabilities SHA-256을 최종 증적에 기록한다.
+
+## 3. 범위
+
+### 포함
+
+- `src/main.rs`의 단건 `convert` 출력 확장자 선검증
+- CLI 사용법·자기서술·canonical 매뉴얼의 HWP5 출력 계약 정합화
+- `gym/score.py`의 복수 허용 종료 코드 계약
+- `gym/tasks/T12.json`의 명령·형식 검사·판정 계약
+- T12 기준 답안과 스코어카드의 보정
+- `tools/gen_agent_codex.py` 표본 수정과 생성 교본 재생성
+- Rust CLI 계약 테스트와 Python gym 채점기 단위 테스트의 CI 배선
+- `output/4586/`의 로컬 재현 원문과 최종 판정 증적
+
+### 제외
+
+- `export-hwpx`에서 관찰된 IR 차이 11건 또는 독립 `ir-diff` 차이 6건의 포맷 충실도 수정
+- HWPX serializer의 의미 보존 개선
+- gym 전체 task schema의 일반 플러그인화 또는 pack 구조 개편
+- 렌더러·WASM·rhwp-studio 변경과 시각 회귀 검증
+
+실제 HWPX의 IR 차이는 이 이슈에서 **실패가 아니라 판정 데이터**다. 별도 충실도 결함으로 다룰 때는
+새 이슈에서 차이 범주와 정답지를 다시 좁힌다.
+
+## 4. 단계와 승인 게이트
+
+### Stage 1 — RED 계약과 재현 고정
+
+1. `.hwpx` 출력의 `convert`가 exit 2, stdout 0바이트, 산출물 없음이 되어야 한다는 Rust 테스트를
+   먼저 추가하고 현행 코드에서 실패를 확인한다.
+2. exit 3 + `identical:false` 봉투가 정답 `false`와 일치해야 한다는 gym 단위 테스트를 먼저 추가하고
+   현행 채점기에서 실패를 확인한다.
+3. T12의 HWP5 위장 제출 반례와 실제 HWPX 제출을 `output/4586/`에 다시 기록한다.
+
+### Stage 2 — CLI·채점 계약 수정
+
+1. `convert`의 출력 확장자를 대소문자 무시 `.hwp`로 제한한다.
+2. gym 채점기의 `expect_exits`를 구현하고 기존 `expect_exit` 기본 계약을 유지한다.
+3. T12에 실제 HWPX 형식 검사와 exit 0/3 판정 비교를 배선한다.
+4. focused Rust/Python 테스트를 green으로 만든다.
+
+### Stage 3 — 자기서술·기준 실행·문서 정합
+
+1. 생성기 표본을 `conv.hwp`로 고치고 생성 교본을 재생성한다.
+2. 판단 트리와 CLI 매뉴얼을 `convert`와 `export-hwpx`의 책임 경계에 맞춘다.
+3. T12 기준 답안·스코어카드를 보정하고 version/commit/capabilities digest를 기록한다.
+4. 생성기 신선도, 관련 계약 테스트, fmt/clippy와 변경 범위 검증을 수행한다.
+5. 단계 보고서와 최종 보고서를 작성한다.
+
+Stage 1의 RED 분포가 이 계획의 근인과 다르면 구현을 멈추고 계획을 수정한다. 각 단계 완료 뒤
+작업지시자의 판정을 받고 다음 단계로 이동한다.
+
+## 5. 완료 판정
+
+- 이름만 `.hwpx`인 HWP5 제출이 T12를 통과하지 않는다.
+- 실제 HWPX 제출은 `format:hwpx`를 만족하고 `ir-diff`의 true/false 판정을 종료 코드와 무관하게
+  정직하게 비교한다.
+- `convert ... output.hwpx`는 원본 입력의 존재 여부와 무관하게 사용법 오류로 먼저 거부되고 산출물을
+  남기지 않는다.
+- 기존 `.hwp` 출력 `convert`와 `expect_exit` 기반 과제는 회귀하지 않는다.
+- 생성 교본에 `convert ... .hwpx` 표본이 남지 않는다.

--- a/mydocs/plans/task_m100_4586_impl.md
+++ b/mydocs/plans/task_m100_4586_impl.md
@@ -1,0 +1,111 @@
+# #4586 구현계획서 — gym T12 HWPX 형식·판정 계약 보정
+
+- **Issue**: [#4586](https://github.com/edwardkim/rhwp/issues/4586)
+- **수행계획서**: `mydocs/plans/task_m100_4586.md`
+- **브랜치**: `task/4586-gym-t12-hwpx`
+- **기준 커밋**: `d30e5d4af`
+
+## 1. CLI 출력 형식 가드
+
+### `src/main.rs`
+
+`convert_hwp`가 위치 인자 파싱을 끝낸 직후, 입력 파일을 읽기 전에 출력 경로의 확장자를 검사한다.
+
+- 허용: `.hwp`, 대소문자 무시
+- 거부: `.hwpx`, 확장자 없음, 그 밖의 모든 확장자
+- 결과: `EXIT_USAGE`(2), stdout 0바이트, 출력 파일 미생성
+- stderr: `convert`가 HWP5 출력 명령임을 밝히고 HWPX 변환은 `rhwp export-hwpx`를 사용하라고 안내
+
+입력과 출력의 형식 책임을 파일명으로 추정해 변환 분기를 바꾸지 않는다. `convert`는 계속 HWP5만,
+`export-hwpx`는 계속 HWPX만 담당한다. `batch convert`는 기존처럼 `.hwp` 이름을 생성하므로 동작을
+바꾸지 않는다.
+
+### `tests/issue_4586_gym_t12_contract.rs`(신설)
+
+- 공개 fixture `samples/field-01.hwp`로 `.hwpx` 출력 거부를 검증한다.
+- 종료 코드 2, stdout 0바이트, 안내 문자열, 산출물 없음까지 한 계약으로 고정한다.
+- `.HWP` 출력은 성공해 대소문자 호환을 보존한다.
+- 실행 파일은 nextest archive 호환 `rhwp_bin()` 패턴을 사용한다.
+
+## 2. gym 채점 계약
+
+### `gym/score.py`
+
+검사별 허용 종료 코드를 다음 우선순위로 정규화한다.
+
+1. `expect_exits`가 있으면 정수 배열을 허용 집합으로 사용
+2. 없으면 기존 `expect_exit` 단일 값을 사용
+3. 둘 다 없으면 기존 기본값 `0`
+
+실제 종료 코드가 허용 집합에 포함되면 exit 3이어도 JSON 봉투 파싱과 `answer_eq`/`value_eq` 비교를
+계속한다. 허용되지 않은 코드는 기존처럼 오류 세부를 남긴다. 기존 task JSON은 수정 없이 같은 판정을
+유지한다.
+
+### `gym/tasks/T12.json`
+
+- 힌트: `rhwp export-hwpx <입력> conv.hwpx --verify --json`
+- 검사 1: `rhwp info conv.hwpx --json`의 `format`이 `hwpx`
+- 검사 2: `ir-diff`의 `identical`과 answer를 비교하며 `expect_exits:[0,3]`
+
+형식 검사를 먼저 두어 HWP5 위장 제출이 IR 동일성 비교와 무관하게 실패하게 한다.
+
+### `scripts/tests/test_gym_score.py`(신설), `.github/workflows/ci.yml`
+
+표준 `unittest`와 `unittest.mock`으로 다음을 검증한다.
+
+- exit 3 + `identical:false` + answer false는 통과
+- exit 3이 허용 목록에 없으면 실패
+- 기존 `expect_exit:0` 검사는 이전과 동일하게 통과
+- 복수 허용 코드 오류 메시지가 실제·허용 값을 구분해 남음
+
+CI의 workflow contract 단계에 이 테스트를 명시적으로 배선해 테스트 파일만 존재하고 실행되지 않는
+상태를 막는다.
+
+## 3. 기준선과 문서
+
+### gym 기준선
+
+- `gym/baselines/claude-fable-5/T12/answer.json`: 실제 HWPX 비교 결과인 `false`
+- `gym/baselines/claude-fable-5/scorecard.json`과 `report.md`: 수정된 T12 계약 결과로 보정
+- 최종 보고서: 기준 실행에 사용한 rhwp version, 코드 commit, `capabilities` 원문 SHA-256과 재현 명령 기록
+
+기준선의 바이너리 산출물은 `gym/.gitignore` 정책대로 커밋하지 않는다. 재현 가능한 명령과 판정 봉투를
+`output/4586/`에 보존하고 공개 보고서에는 비식별 요약과 해시만 싣는다.
+
+### 자기서술·사용자 문서
+
+- `tools/gen_agent_codex.py`: `convert` 실측 표본 출력을 `conv.hwp`로 수정
+- `mydocs/manual/agent_codex/40_변환과_렌더.md`: 생성기로 재생성, 수기 수정 금지
+- `mydocs/manual/agent_codex/01_판단트리.md`: HWP→HWPX `export-hwpx`, HWPX/배포용→HWP5 `convert`로 분리
+- `mydocs/manual/cli_commands.md`: 잘못된 출력 확장자 거부·exit 2·산출물 없음·대체 명령 명시
+- `gym/README.md`: 복수 판정 종료 코드가 있는 검사 계약을 짧게 설명
+
+## 4. 검증 명령
+
+Stage별 focused 검증은 같은 checkout/target에서 순차 실행한다.
+
+```bash
+cargo test --test issue_4586_gym_t12_contract -- --nocapture
+python3 -m unittest scripts/tests/test_gym_score.py
+cargo test --test output_axis_json_contract convert_json_envelope_with_verify -- --nocapture
+python3 tools/gen_agent_codex.py --check
+cargo test --test agent_codex_contract
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+git diff --check
+```
+
+Rust parser/model/CLI 변경이므로 PR 직전 전체 release-test 회귀는
+`mydocs/manual/pr_review/local_validation.md` §4.3 대상이다. 다만 긴 전체 회귀와 PR CI는 focused 결과를
+공유한 뒤 작업지시자의 별도 승인을 받아 실행한다.
+
+## 5. 증적
+
+`output/4586/`에 다음을 생성한다.
+
+- `red/`: 현행 HWP5 위장 통과와 실제 HWPX 실패 봉투
+- `green/`: `.hwpx` 출력 거부, 실제 HWPX 형식 확인, exit 3의 false 정답 통과 봉투
+- `metadata/`: `rhwp --version`, source commit, `rhwp capabilities` SHA-256
+
+렌더링·레이아웃·WASM 변경이 없으므로 시각 증적과 WASM 빌드는 적용하지 않는다. 최종 보고서에 이 생략
+근거를 명시한다.

--- a/mydocs/pr/archives/pr_4598_review.md
+++ b/mydocs/pr/archives/pr_4598_review.md
@@ -1,0 +1,103 @@
+---
+kind: report
+status: active
+last_verified: 2026-08-11
+---
+
+# PR #4598 검토 — gym T12 HWPX 형식·판정 계약 보정
+
+## 라우팅
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, local_validation.md, review_only_fast_pass.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+  pr_review/collaborator_self_merge.md, pr_review/intake_and_review.md,
+  pr_review/local_validation.md, pr_review/review_only_fast_pass.md
+current head: 4f24c73e97b39d577a398c4e06d535060f5f35de (접수 시점 참고)
+```
+
+## Metadata
+
+| 항목 | 접수 시점 참고값 |
+| --- | --- |
+| PR | [#4598](https://github.com/edwardkim/rhwp/pull/4598) |
+| 작성자·self-review 담당 | `edwardkim` |
+| base / head | `devel` / `task/4586-gym-t12-hwpx` |
+| 관련 이슈 | `Closes #4586` |
+| 규모 | 24개 파일, +937/-26, 6 commits |
+| 상태 | Open, non-draft, `MERGEABLE/BLOCKED` |
+| 1차 트리야지 | assignee `edwardkim`, milestone `v1.0.0`, labels `bug`·`documentation`·`rust`·`hwpx`·`ci`·`github_actions`·`harness`·`cli`·`test`·`python` |
+
+작성자 본인은 GitHub에서 자기 PR의 requested reviewer나 `APPROVE` 대상이 될 수 없다. 작업지시자의
+self-review 지시에 따라 별도 reviewer request 없이 최신 head에 `COMMENTED` review로 검토 결과를
+게시한다.
+
+## 변경 범위
+
+이 PR은 gym T12가 실제 HWPX 대신 HWP5 위장 파일을 만점 처리한 두 계약 결함을 함께 닫는다.
+
+1. `convert`는 HWP5 전용 명령으로 유지하고 `.hwp` 이외 출력 경로를 입력 IO 전에 exit 2로 거부한다.
+2. T12는 `export-hwpx`를 안내하고 `info`의 실제 `format == hwpx`를 먼저 검사한다.
+3. scorer는 기존 `expect_exit`을 보존하면서 복수 `expect_exits`를 지원한다. 허용된 exit 3의 JSON
+   봉투도 `answer_eq`·`value_eq` 판정까지 진행한다.
+4. 실제 HWPX focused 결과 `identical:false`를 기준 답안과 검증 메타데이터에 고정한다.
+5. 생성 Codex 교본, 판단 트리, CLI·gym 문서와 GitHub Actions의 Python 계약 테스트를 정합화한다.
+
+renderer, layout, paint, WASM API와 rhwp-studio는 바뀌지 않았다. HWP/HWPX/PDF fixture도 추가·교체하지
+않았으므로 시각·fixture 증적 보조 경로는 적용하지 않는다.
+
+## Self-review finding
+
+blocking finding은 없다.
+
+- `convert`가 출력 확장자를 보고 명령을 자동 전환하지 않아 HWP5/HWPX 책임 경계가 유지된다.
+- 출력 계약을 입력 IO보다 먼저 검사하고, exit 2·빈 stdout·산출물 없음·대체 명령 안내를 회귀 테스트가
+  함께 고정한다.
+- `expect_exits`는 비어 있지 않은 정수 배열만 허용하며, 없으면 기존 `expect_exit` 단일 값 또는 기본값
+  0으로 되돌아가 기존 과제와 호환된다.
+- T12는 형식 검사를 IR 비교보다 먼저 수행하므로 HWP5 위장 제출은 동등성 값과 무관하게 실패한다.
+- 기준선은 1호 선수 14과제 전체를 다시 실행했다고 가장하지 않고 T12 focused 실행의 version, commit,
+  capabilities·입력·산출 해시를 별도 `verification.json`에 기록한다.
+- 생성기의 plan 출력 경로를 저장소 상대경로로 바꾼 것은 checkout 절대경로가 `planSha256`을 바꾸던 기존
+  비결정성을 제거하며, 연속 `--check` 변경 0으로 확인했다.
+
+전체 회귀의 첫 실행에서 기존 `cli_exit_codes::unreadable_input_reports_runtime_failure`가 한 건 실패했다.
+입력 파일 없음 계약을 검증하면서 `convert` 출력에 `.hwpx`를 주던 잘못된 전제가 원인이었다. 제품 코드를
+완화하지 않고 `convert`에는 실제 `.hwp`, `export-hwpx`에는 실제 `.hwpx` 임시 경로를 분리했으며, 단일
+재검증과 전체 재실행으로 닫았다.
+
+## 검증
+
+- T12 실제 focused 판정: 2/2 checks passed
+- `issue_4586_gym_t12_contract`: 3 passed / 0 failed
+- `scripts/tests/test_gym_score.py`: 5 passed / 0 failed
+- 기존 convert output axis와 #1638 verify 계약: 각 1 passed / 0 failed
+- workflow contract wiring: 3 passed / 0 failed
+- agent Codex contract: 2 passed / 0 failed
+- 생성 교본 검사: 명령 83 · 실측 18 · 계약만 65 · 변경 0
+- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --all -- --check`, `git diff --check`: 통과
+- release-test 전체 재실행: 5,763 passed / 0 failed / 36 skipped / 6 slow, 221.286초
+- 계획·단계·최종 보고서·오늘할일 7개 문서의 내부 Markdown 상대 링크: 이상 없음
+- 최신 `upstream/devel` `a70797db4`와 접수 head의 merge tree `42d1ac45a647eaf08936cf876d651acf7105aa64`:
+  충돌 없음, merge tree `git diff --check` 통과
+- initial code candidate `4f24c73e9`의 [Full CI](https://github.com/edwardkim/rhwp/actions/runs/31487755505),
+  [CodeQL](https://github.com/edwardkim/rhwp/actions/runs/31487755332),
+  [Render Diff](https://github.com/edwardkim/rhwp/actions/runs/31487755346): 모두 성공. CodeQL은
+  JavaScript/TypeScript·Rust·Python 분석을 통과했고 Render Diff는 Canvas visual diff를 통과했다.
+
+전체 회귀는 `cargo-nextest 0.9.137`에서 성공했다. 저장소 권장 `0.9.140`보다 낮다는 경고가 있었지만
+실행과 집계는 정상 완료됐다. 로컬 `actionlint`는 설치되어 있지 않아 실행하지 못했으며, workflow 계약
+테스트와 initial code candidate의 GitHub lint·CI 결과로 보완한다.
+
+렌더 영향이 없어 Native Skia·Docker WASM·브라우저·시각 검증은 적용하지 않았다.
+
+## Review-only 후속과 최종 권고
+
+이 문서와 오늘할일만 initial code candidate 뒤의 single-parent trailing review-only commit으로 추가한다.
+initial candidate의 Full CI가 성공한 뒤 push해 review-only fast-pass A가 같은 PR의 녹색 code candidate를
+재사용할 수 있게 한다.
+
+최신 review-only head의 preflight·required aggregate와 mergeability가 성공하면 blocking finding 없이
+merge를 권고한다. self-review 결과는 `COMMENTED` review로 게시하며 실제 merge는 작업지시자의 별도
+승인을 조건으로 한다.

--- a/mydocs/report/task_m100_4586_report.md
+++ b/mydocs/report/task_m100_4586_report.md
@@ -1,0 +1,124 @@
+# task_m100_4586 최종 보고서 — gym T12 HWPX 형식·판정 계약 보정
+
+- **Issue**: [#4586](https://github.com/edwardkim/rhwp/issues/4586)
+- **계획서**: [수행계획](../plans/task_m100_4586.md) · [구현계획](../plans/task_m100_4586_impl.md)
+- **단계 기록**: [stage1](../working/task_m100_4586_stage1.md) · [stage2](../working/task_m100_4586_stage2.md) · [stage3](../working/task_m100_4586_stage3.md)
+- **브랜치**: `task/4586-gym-t12-hwpx`
+- **기준**: `upstream/devel` `d30e5d4af`
+- **작성일**: 2026-08-11 KST
+
+## 1. 결과
+
+gym T12가 HWPX 변환 과제인데도 `convert ... conv.hwpx`를 안내하고, HWP5 바이트를 `.hwpx` 이름으로
+저장한 제출도 IR 동일성만 맞으면 통과시키던 계약을 바로잡았다.
+
+- `convert`는 HWP5 전용으로 유지하고 `.hwp` 출력만 대소문자 무시로 허용한다.
+- HWPX 변환은 `export-hwpx`만 사용한다.
+- T12는 먼저 산출물의 실제 형식이 `hwpx`인지 검사한다.
+- `ir-diff --json`의 정직한 차이 종료 코드 3도 JSON 봉투를 판정할 수 있게 `expect_exits`를 추가했다.
+- 실제 HWPX 변환의 `identical:false`를 T12 정답으로 고정했다.
+- 생성 교본, 판단 트리, CLI 매뉴얼, gym README와 CI 실행 계약을 같은 규칙으로 정합화했다.
+
+## 2. 원인과 해결
+
+### 2.1 형식 위장
+
+기존 `convert`는 출력 확장자를 검증하지 않고 항상 HWP5 바이트를 썼다. T12 힌트가 출력명을
+`conv.hwpx`로 지정했기 때문에 파일명만 HWPX인 HWP5 문서가 만들어졌다. 채점은 IR 동일성만 비교하여
+이 잘못된 산출물을 통과시켰다.
+
+`convert_hwp`가 입력 파일을 읽기 전에 출력 확장자를 검사하도록 했다. `.hwp` 이외에는 exit 2,
+빈 stdout, 출력 미생성으로 종료하고 `export-hwpx`를 안내한다. 명령의 책임을 파일명에 따라 자동
+전환하지 않았다.
+
+### 2.2 차이를 나타내는 정상 JSON 봉투
+
+`ir-diff --json`은 차이가 있으면 exit 3과 함께 판정 가능한 JSON 봉투를 반환한다. 기존 scorer는
+단일 `expect_exit`만 받아 exit 3 봉투를 값 비교 전에 실패 처리했다.
+
+검사별 `expect_exits` 정수 배열을 추가하고, 허용된 종료 코드이면 JSON 파싱과 `answer_eq`·`value_eq`를
+계속하도록 했다. 기존 `expect_exit`과 기본값 0은 그대로 유지했다.
+
+### 2.3 전체 회귀에서 드러난 기존 픽스처 충돌
+
+첫 전체 회귀는 5,763건 중 `cli_exit_codes::unreadable_input_reports_runtime_failure` 한 건이 실패했다.
+이 테스트는 입력 파일 없음 계약을 검증하면서 `convert` 출력에 `.hwpx`를 사용해 새 출력 확장자 계약이
+먼저 발동했다. 제품 코드를 완화하지 않고 다음처럼 테스트 전제를 분리했다.
+
+- `convert`: 실제 확장자가 `.hwp`인 고유 임시 경로
+- `export-hwpx`: 실제 확장자가 `.hwpx`인 고유 임시 경로
+
+단일 재검증 1/1 통과 후 전체 회귀를 다시 실행해 5,763/5,763 통과를 확인했다.
+
+## 3. 주요 변경
+
+| 영역 | 변경 |
+| --- | --- |
+| `src/main.rs` | `convert`의 `.hwp` 출력 사전 검증과 `export-hwpx` 안내 |
+| `gym/score.py` | 복수 허용 종료 코드 `expect_exits`와 exit 3 봉투 판정 |
+| `gym/tasks/T12.json` | 실제 `export-hwpx`, 형식 검사, IR 차이 판정 |
+| `scripts/tests/test_gym_score.py` | scorer 하위 호환·복수 종료 코드 계약 |
+| `.github/workflows/ci.yml` | gym scorer 계약 테스트 배선 |
+| `tests/issue_4586_gym_t12_contract.rs` | CLI 형식·종료 코드·산출물 계약 |
+| `tests/cli_exit_codes.rs` | 입력 오류 테스트의 출력 형식 전제 분리 |
+| `gym/baselines/claude-fable-5/T12/` | 실제 HWPX 기준 판정과 재현 메타데이터 |
+| `tools/gen_agent_codex.py` 및 생성 문서 | HWP5/HWPX 명령 경계와 결정적 plan 해시 정합 |
+| 사용자 문서 | 판단 트리, CLI 명령, gym 판정 규칙 정합 |
+
+## 4. 기준 실행
+
+T12 focused 실행은 공개 표본 `samples/field-01.hwp`를 실제 HWPX로 변환해 수행했다.
+
+```text
+T12 변환 자기검증: pass, 2/2 checks
+- HWPX 형식 확인: expected hwpx / actual hwpx
+- 변환물 IR 대조: expected false / actual false
+```
+
+| 항목 | 값 |
+| --- | --- |
+| rhwp version | `rhwp v0.8.2` |
+| source commit | `1ac75c0aad1056195c34cac2cc036d2943c5f99d` |
+| capabilities SHA-256 | `62aea3df8bc40dd679247c044093e41fc54d1d80396c2b4b5b445ec843ffe27c` |
+| source SHA-256 | `518cb939079e6e0640a5f813597f744e2528a17ca52ee418929f1c8f4b5380c0` |
+| HWPX SHA-256 | `41c07ba1a1f00b356b0ca6ccbef986747ae177cfee10f243a6905d82ad698617` |
+
+로컬 원문 증적은 gitignore 대상인 `output/4586/`에 보존한다.
+
+## 5. 검증
+
+| 게이트 | 결과 |
+| --- | --- |
+| `issue_4586_gym_t12_contract` | 3 passed / 0 failed |
+| `scripts/tests/test_gym_score.py` | 5 passed / 0 failed |
+| 기존 convert output axis | 1 passed / 0 failed |
+| #1638 convert verify 계약 | 1 passed / 0 failed |
+| workflow contract wiring | 3 passed / 0 failed |
+| agent Codex contract | 2 passed / 0 failed |
+| T12 실제 focused 판정 | 2/2 checks passed |
+| 생성 교본 `--check` | 명령 83 · 실측 18 · 계약만 65 · 변경 0 |
+| `cargo clippy --all-targets -- -D warnings` | 통과, 경고 0 |
+| `cargo fmt --all -- --check` | 통과 |
+| `git diff --check` | 통과 |
+| release-test 전체 회귀 | **5,763 passed / 0 failed / 36 skipped / 6 slow**, 221.286초 |
+
+전체 회귀는 `cargo-nextest 0.9.137`에서 수행했다. 저장소 권장 버전 `0.9.140`보다 낮다는 경고가
+있었지만 실행과 결과 집계는 정상 완료됐다. `actionlint`는 로컬 환경에 설치되어 있지 않아 별도 실행하지
+못했고, workflow 배선 회귀 3건과 GitHub CI에서 최종 확인한다.
+
+렌더러·레이아웃·WASM·rhwp-studio 코드는 변경하지 않았다. 따라서 시각 검증과 Docker WASM 빌드는
+이번 변경의 적용 게이트가 아니다.
+
+## 6. 단계 커밋
+
+| 커밋 | 내용 |
+| --- | --- |
+| `d25375877` | 구현 계획 확정 |
+| `a4e8f8831` | HWPX 형식 계약 RED 고정 |
+| `1ac75c0aa` | CLI·gym HWPX 판정 계약 구현 |
+| `c428b4a04` | T12 기준선·생성 교본·문서 정합 |
+| `db772d92f` | 전체 회귀에서 발견한 CLI 입력 오류 픽스처 보정 |
+
+## 7. 다음 단계
+
+로컬 구현과 필수 검증은 끝났다. 원격 push와 PR 생성은 작업지시자의 별도 승인 후 수행한다.

--- a/mydocs/working/task_m100_4586_stage1.md
+++ b/mydocs/working/task_m100_4586_stage1.md
@@ -1,0 +1,71 @@
+# #4586 Stage 1 완료보고서 — RED 계약과 최신 기준선
+
+- **Issue**: [#4586](https://github.com/edwardkim/rhwp/issues/4586)
+- **브랜치**: `task/4586-gym-t12-hwpx`
+- **기준**: `upstream/devel` `d30e5d4af`
+- **계획 커밋**: `d25375877`
+
+## 1. 최신 devel 재현
+
+`cargo build --bin rhwp`로 최신 기준 바이너리를 만든 뒤 `samples/field-01.hwp`를 다시 측정했다.
+원격 통합 뒤 82개 커밋이 추가됐지만 #4586의 두 현상은 그대로였다.
+
+| 경로 | 실제 형식 | 종료 코드 | 판정 |
+| --- | --- | --- | --- |
+| `convert ... conv.hwpx --verify --json` | HWP5 | 0 | `identical:true`, `diffCount:0` |
+| `export-hwpx ... conv.hwpx --verify --json` | HWPX | 3 | `identical:false`, `diffCount:11` |
+| 독립 `ir-diff` | HWP↔HWPX | 3 | `identical:false`, `diffCount:6` |
+
+원문 봉투와 `file`/`info` 결과는 `output/4586/red/`에 저장했다. 이 폴더는 저장소 정책대로
+gitignore이며 작업지시자가 VS Code에서 확인할 수 있는 로컬 증적이다.
+
+## 2. Rust RED 계약
+
+신설: `tests/issue_4586_gym_t12_contract.rs`
+
+```bash
+cargo test --test issue_4586_gym_t12_contract -- --nocapture
+```
+
+결과: **1 passed / 2 failed**.
+
+- PASS: `.HWP` 대문자 확장자는 유효한 HWP5 출력으로 유지된다.
+- FAIL: 기존 `convert`가 `.hwpx` 출력에 HWP5를 쓰고 exit 0을 반환한다.
+- FAIL: 잘못된 출력 확장자보다 존재하지 않는 입력 IO를 먼저 검사해 exit 1을 반환한다.
+
+두 실패는 구현 뒤 각각 exit 2, stdout 0바이트, `export-hwpx` 안내, 산출물 없음으로 바뀌어야 한다.
+
+## 3. Python RED 계약
+
+신설: `scripts/tests/test_gym_score.py`
+
+```bash
+python3 -m unittest scripts/tests/test_gym_score.py
+```
+
+결과: **1 passed / 3 failed**.
+
+- PASS: 기존 `expect_exit:0` 단일 종료 코드 검사는 그대로 동작한다.
+- FAIL: exit 3 + `identical:false`를 정답 `false`와 비교하지 않고 `기대 0`에서 버린다.
+- FAIL: `expect_exits:[0,3]`을 인식하지 않아 허용 집합 오류에 3이 표시되지 않는다.
+- FAIL: T12가 여전히 `convert`를 안내하며 형식 검사와 `expect_exits`가 없다.
+
+## 4. 판정
+
+RED 분포는 수행계획의 세 근인과 일치한다.
+
+1. CLI 출력 확장자 가드 부재
+2. gym 복수 판정 종료 코드 부재
+3. T12 실제 형식 검사 부재
+
+따라서 설계 변경 없이 Stage 2 구현으로 진행할 수 있다. 실제 HWPX의 IR 차이 11건/6건은 이번
+단계에서도 수정 대상으로 확장하지 않는다.
+
+## 5. 형식 검사
+
+```bash
+cargo fmt --all -- --check
+git diff --check
+```
+
+둘 다 통과했다. 렌더러·레이아웃·WASM 변경이 없어 시각 증적은 적용하지 않았다.

--- a/mydocs/working/task_m100_4586_stage2.md
+++ b/mydocs/working/task_m100_4586_stage2.md
@@ -1,0 +1,77 @@
+# #4586 Stage 2 완료보고서 — CLI·gym 판정 계약 구현
+
+- **Issue**: [#4586](https://github.com/edwardkim/rhwp/issues/4586)
+- **브랜치**: `task/4586-gym-t12-hwpx`
+- **RED 커밋**: `a4e8f8831`
+
+## 1. CLI 출력 가드
+
+`src/main.rs`의 `convert_hwp`가 위치 인자를 파싱한 직후 출력 확장자를 검사한다.
+
+- `.hwp`를 대소문자 무시로 허용한다.
+- `.hwpx`, 확장자 없음, 다른 확장자는 입력 파일을 읽기 전에 exit 2로 거부한다.
+- 사용법 오류의 stdout은 비어 있고 출력 파일을 만들지 않는다.
+- stderr는 `convert`가 `.hwp` 출력임을 밝히고 HWPX 변환에 `export-hwpx`를 안내한다.
+
+입력 형식에 따라 출력 포맷을 추측하거나 명령을 자동 전환하지 않았다. `convert`와 `export-hwpx`의
+책임 경계를 명시적으로 유지한다.
+
+## 2. gym 판정 계약
+
+`gym/score.py`에 검사별 `expect_exits` 배열을 추가했다.
+
+1. `expect_exits`가 있으면 비어 있지 않은 정수 배열인지 검증한다.
+2. 없으면 기존 `expect_exit`을 단일 원소 배열로 바꾼다.
+3. 둘 다 없으면 기존 기본값 0을 사용한다.
+4. 실제 종료 코드가 허용 배열에 있으면 exit 3이어도 JSON 봉투를 파싱하고 값을 비교한다.
+
+기존 task의 `expect_exit` 계약은 수정하지 않고 하위 호환으로 유지했다.
+
+T12는 다음 두 검사를 순서대로 수행한다.
+
+1. `info conv.hwpx --json`의 `format == "hwpx"`
+2. `ir-diff` exit 0/3의 `identical`과 `answer.json` 비교
+
+힌트도 `export-hwpx`로 고쳤다. 따라서 HWP5 위장 제출은 첫 검사에서 실패하고, 실제 HWPX의 정직한
+`identical:false`는 두 번째 검사에서 정상 판정된다.
+
+## 3. CI 배선
+
+`.github/workflows/ci.yml`의 lint job에 `Validate gym scorer contracts` 단계를 추가했다.
+`scripts/tests/test_gym_score.py`가 저장소에만 존재하고 실행되지 않는 상태를 막는다.
+
+## 4. GREEN 검증
+
+```text
+cargo test --test issue_4586_gym_t12_contract -- --nocapture
+  3 passed / 0 failed
+
+python3 -m unittest scripts/tests/test_gym_score.py
+  4 passed / 0 failed
+
+cargo test --test output_axis_json_contract convert_json_envelope_with_verify -- --nocapture
+  1 passed / 0 failed
+
+cargo test --test issue_1638_convert_verify_gate \
+  convert_verify_and_verify_pages_pass_for_hwp_source -- --nocapture
+  1 passed / 0 failed
+
+python3 -m unittest scripts/tests/test_workflow_contract_wiring.py
+  3 passed / 0 failed
+
+cargo fmt --all -- --check
+git diff --check
+  통과
+```
+
+실제 `output/4586/green/export/conv.hwpx`를 T12 검사로 판정한 결과도 두 검사 모두 `ok:true`였다.
+로컬 원문은 `output/4586/green/README.md`에 기록했다.
+
+## 5. Stage 3 잔여
+
+- T12 기준 답안·스코어카드 보정
+- 기준 실행 version/commit/capabilities digest 기록
+- 생성기 `convert` 표본의 `.hwpx` 오류 수정과 생성 교본 재생성
+- 판단 트리·CLI 매뉴얼·gym README 정합
+
+Stage 2에서는 코드·task 계약만 고쳤으며 생성 문서와 기준선은 다음 승인 단계로 분리했다.

--- a/mydocs/working/task_m100_4586_stage3.md
+++ b/mydocs/working/task_m100_4586_stage3.md
@@ -1,0 +1,82 @@
+# #4586 Stage 3 완료보고서 — 기준선·생성 교본·문서 정합
+
+- **Issue**: [#4586](https://github.com/edwardkim/rhwp/issues/4586)
+- **브랜치**: `task/4586-gym-t12-hwpx`
+- **Stage 2 커밋**: `1ac75c0aad1056195c34cac2cc036d2943c5f99d`
+
+## 1. T12 focused 기준 실행
+
+전체 1호 선수의 gitignore 산출물이 저장소에 없으므로 전체 14과제를 다시 실행했다고 가장하지 않았다.
+`samples/field-01.hwp`를 `export-hwpx`로 실제 HWPX로 만들고, 수정된 `gym.score.score_task`로 T12만
+focused 재실행했다.
+
+```text
+T12 변환 자기검증: pass, 2/2 checks
+- HWPX 형식 확인: expected hwpx / actual hwpx
+- 변환물 IR 대조: expected false / actual false
+```
+
+기준 실행 식별자:
+
+| 항목 | 값 |
+| --- | --- |
+| rhwp version | `rhwp v0.8.2` |
+| rhwp source commit | `1ac75c0aad1056195c34cac2cc036d2943c5f99d` |
+| capabilities SHA-256 | `62aea3df8bc40dd679247c044093e41fc54d1d80396c2b4b5b445ec843ffe27c` |
+| source SHA-256 | `518cb939079e6e0640a5f813597f744e2528a17ca52ee418929f1c8f4b5380c0` |
+| HWPX SHA-256 | `41c07ba1a1f00b356b0ca6ccbef986747ae177cfee10f243a6905d82ad698617` |
+
+`gym/baselines/claude-fable-5/T12/verification.json`에 위 식별자와 실제 판정 결과를 고정했다.
+`answer.json`, T12 scorecard slice와 report 행도 `identical:false`·형식 검사 계약으로 보정했다.
+바이너리 산출물은 `gym/.gitignore` 정책대로 커밋하지 않는다.
+
+로컬 원문은 `output/4586/baseline/README.md`에 있다.
+
+## 2. 생성 교본 정합
+
+`tools/gen_agent_codex.py`의 `convert` 표본을 `conv.hwpx`에서 `conv.hwp`로 바꾸고 설명도 HWP5 변환으로
+명시했다. 생성된 `40_변환과_렌더.md`는 실제 `format:hwp5` 봉투와 `.hwp` 경로가 일치한다.
+
+재생성 중 `50_검증_사다리.md`의 `planSha256`이 checkout 절대경로에 따라 달라지는 기존 결함을 발견했다.
+생성기가 "어느 기계에서도 같은 본문"을 약속하므로 다음처럼 함께 보정했다.
+
+- 계획 output을 절대 `{tmp}` 치환 대신 저장소 상대 `target/codex-tmp/plan_out.hwp`로 고정
+- 표시 단계에서 상대 경로도 `<tmp>`로 정규화
+- 새 상대 plan의 SHA-256을 검증 사다리에 재생성
+
+연속 `python3 tools/gen_agent_codex.py --check`에서 변경 0을 확인했다.
+
+## 3. 사용자 문서 정합
+
+- `agent_codex/01_판단트리.md`: HWP→HWPX는 `export-hwpx`, HWPX/배포용→HWP5는 `convert`로 분리
+- `mydocs/manual/cli_commands.md`: `.hwp` 외 출력은 입력 IO 전 exit 2, 산출 없음, `export-hwpx` 안내
+- `gym/README.md`: 단일 `expect_exit`과 복수 판정 `expect_exits` 의미 구분
+- 잘못된 `convert ... conv.hwpx`와 `HWP↔HWPX → convert` 문구 검색 결과 0건
+
+## 4. 검증
+
+```text
+python3 -m unittest scripts/tests/test_gym_score.py
+  5 passed / 0 failed
+
+python3 tools/gen_agent_codex.py --check
+  명령 83 · 실측 18 · 계약만 65 · 변경 0
+
+cargo test --test agent_codex_contract
+  2 passed / 0 failed
+
+cargo clippy --all-targets -- -D warnings
+  통과, 경고 0
+
+cargo fmt --all -- --check
+git diff --check
+  통과
+```
+
+렌더러·레이아웃·WASM 변경이 없어 시각 증적과 WASM 빌드는 적용하지 않는다.
+
+## 5. 다음 게이트
+
+Rust CLI 변경이므로 `mydocs/manual/pr_review/local_validation.md` §4.3에 따라 release-test 전체 회귀를
+남겼다. 장시간 전체 회귀와 PR CI는 별도 작업지시자 승인을 받은 뒤 수행한다. 전체 회귀 뒤 최종 보고서와
+PR 준비 자료를 작성한다.

--- a/scripts/tests/test_gym_score.py
+++ b/scripts/tests/test_gym_score.py
@@ -14,6 +14,7 @@ from unittest import mock
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCORE_PATH = REPO_ROOT / "gym" / "score.py"
 T12_PATH = REPO_ROOT / "gym" / "tasks" / "T12.json"
+T12_BASELINE = REPO_ROOT / "gym" / "baselines" / "claude-fable-5" / "T12"
 
 
 def load_score_module():
@@ -108,6 +109,19 @@ class T12TaskContractTests(unittest.TestCase):
 
         diff_check = checks["변환물 IR 대조"]
         self.assertEqual(diff_check["expect_exits"], [0, 3])
+
+    def test_t12_baseline_records_false_verdict_and_runner_identity(self):
+        answer = json.loads((T12_BASELINE / "answer.json").read_text(encoding="utf-8"))
+        verification = json.loads(
+            (T12_BASELINE / "verification.json").read_text(encoding="utf-8")
+        )
+
+        self.assertEqual(answer, {"identical": False})
+        self.assertEqual(verification["artifactFormat"], "hwpx")
+        self.assertEqual(verification["answer"], answer)
+        self.assertTrue(verification["result"]["pass"])
+        self.assertEqual(len(verification["runner"]["rhwpCommit"]), 40)
+        self.assertEqual(len(verification["runner"]["capabilitiesSha256"]), 64)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_gym_score.py
+++ b/scripts/tests/test_gym_score.py
@@ -1,0 +1,114 @@
+"""[#4586] gym 판정 종료 코드와 T12 HWPX 형식 계약 회귀 테스트."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCORE_PATH = REPO_ROOT / "gym" / "score.py"
+T12_PATH = REPO_ROOT / "gym" / "tasks" / "T12.json"
+
+
+def load_score_module():
+    spec = importlib.util.spec_from_file_location("gym_score_issue_4586_test", SCORE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class ExitVerdictContractTests(unittest.TestCase):
+    def setUp(self):
+        self.score = load_score_module()
+        self.task = {"input": "samples/field-01.hwp"}
+        self.check = {
+            "name": "변환물 IR 대조",
+            "op": "answer_eq",
+            "answer": "identical",
+            "cmd": ["ir-diff", "{input}", "{file:conv.hwpx}", "--json"],
+            "path": "identical",
+            "expect_exits": [0, 3],
+        }
+
+    def test_exit_3_false_verdict_is_compared_instead_of_discarded(self):
+        with tempfile.TemporaryDirectory() as sub_dir, mock.patch.object(
+            self.score,
+            "run_cli",
+            return_value=(3, {"identical": False, "diffCount": 6}, ""),
+        ):
+            detail = self.score.eval_check(
+                self.check,
+                self.task,
+                sub_dir,
+                {"identical": False},
+                "rhwp",
+            )
+
+        self.assertTrue(detail["ok"], detail)
+        self.assertEqual(detail["expected"], False)
+        self.assertEqual(detail["actual"], False)
+
+    def test_exit_outside_allowed_set_is_rejected_with_allowed_values(self):
+        with tempfile.TemporaryDirectory() as sub_dir, mock.patch.object(
+            self.score,
+            "run_cli",
+            return_value=(1, None, ""),
+        ):
+            detail = self.score.eval_check(
+                self.check,
+                self.task,
+                sub_dir,
+                {"identical": False},
+                "rhwp",
+            )
+
+        self.assertFalse(detail["ok"], detail)
+        self.assertIn("0", detail["error"])
+        self.assertIn("3", detail["error"])
+
+    def test_legacy_expect_exit_contract_remains_compatible(self):
+        legacy = dict(self.check)
+        legacy.pop("expect_exits")
+        legacy["expect_exit"] = 0
+        with tempfile.TemporaryDirectory() as sub_dir, mock.patch.object(
+            self.score,
+            "run_cli",
+            return_value=(0, {"identical": True}, ""),
+        ):
+            detail = self.score.eval_check(
+                legacy,
+                self.task,
+                sub_dir,
+                {"identical": True},
+                "rhwp",
+            )
+
+        self.assertTrue(detail["ok"], detail)
+
+
+class T12TaskContractTests(unittest.TestCase):
+    def test_t12_requires_real_hwpx_and_accepts_ir_verdict_exit(self):
+        task = json.loads(T12_PATH.read_text(encoding="utf-8"))
+        self.assertIn("export-hwpx", task["instructions"])
+        self.assertNotIn("rhwp convert", task["instructions"])
+
+        checks = {check["name"]: check for check in task["checks"]}
+        format_check = checks["HWPX 형식 확인"]
+        self.assertEqual(format_check["cmd"][0], "info")
+        self.assertEqual(format_check["path"], "format")
+        self.assertEqual(format_check["value"], "hwpx")
+
+        diff_check = checks["변환물 IR 대조"]
+        self.assertEqual(diff_check["expect_exits"], [0, 3])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/main.rs
+++ b/src/main.rs
@@ -12300,6 +12300,19 @@ fn convert_hwp(args: &[String]) -> i32 {
     let input_path = &positionals[0];
     let output_path = &positionals[1];
 
+    // [#4586] `convert`는 편집 가능한 HWP5를 만드는 명령이다. 출력 이름만
+    // `.hwpx`로 주면 HWP5 바이트가 HWPX처럼 보이고, 후속 도구가 확장자만 믿을 때
+    // 거짓 양성이 된다. 입력 IO보다 먼저 출력 계약을 판정해 잘못된 산출물을 쓰지 않는다.
+    let output_is_hwp = std::path::Path::new(output_path)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("hwp"));
+    if !output_is_hwp {
+        eprintln!("오류: convert 출력 경로는 .hwp 확장자여야 합니다: {output_path}");
+        eprintln!("HWPX로 변환하려면 `rhwp export-hwpx <입력> <출력.hwpx>`를 사용하세요.");
+        return EXIT_USAGE;
+    }
+
     // 입력 파일 읽기
     let data = match fs::read(input_path) {
         Ok(d) => d,

--- a/tests/cli_exit_codes.rs
+++ b/tests/cli_exit_codes.rs
@@ -118,8 +118,12 @@ fn unreadable_input_reports_runtime_failure() {
     let missing = missing.to_str().expect("utf-8 경로").to_string();
     let out_dir = unique_temp_path("runtime-out");
     let out_dir = out_dir.to_str().expect("utf-8 경로").to_string();
-    let out_file = unique_temp_path("runtime-out.hwpx");
-    let out_file = out_file.to_str().expect("utf-8 경로").to_string();
+    let mut hwp_out_file = unique_temp_path("runtime-out");
+    hwp_out_file.set_extension("hwp");
+    let hwp_out_file = hwp_out_file.to_str().expect("utf-8 경로").to_string();
+    let mut hwpx_out_file = unique_temp_path("runtime-out");
+    hwpx_out_file.set_extension("hwpx");
+    let hwpx_out_file = hwpx_out_file.to_str().expect("utf-8 경로").to_string();
 
     for args in [
         vec!["export-svg", &missing, "-o", &out_dir],
@@ -127,8 +131,8 @@ fn unreadable_input_reports_runtime_failure() {
         vec!["export-text", &missing, "-o", &out_dir],
         vec!["export-markdown", &missing, "-o", &out_dir],
         vec!["export-structure", &missing],
-        vec!["convert", &missing, &out_file],
-        vec!["export-hwpx", &missing, &out_file],
+        vec!["convert", &missing, &hwp_out_file],
+        vec!["export-hwpx", &missing, &hwpx_out_file],
     ] {
         assert_code(&args, 1);
     }

--- a/tests/issue_4586_gym_t12_contract.rs
+++ b/tests/issue_4586_gym_t12_contract.rs
@@ -1,0 +1,122 @@
+//! #4586 `convert` 출력 형식과 gym T12의 HWPX 계약 회귀 테스트.
+//!
+//! `convert`는 편집 가능한 HWP5를 만드는 명령이다. 출력 이름만 `.hwpx`로 주어
+//! HWP5를 HWPX처럼 위장하면 gym의 형식·동등성 판정까지 거짓 양성이 되므로,
+//! 디스크를 쓰기 전에 `.hwp` 출력 계약을 강제한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const SAMPLE: &str = "samples/field-01.hwp";
+
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}
+
+fn unique_output(tag: &str, extension: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "rhwp-issue-4586-{}-{nanos}-{tag}.{extension}",
+        std::process::id()
+    ))
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(rhwp_bin())
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn convert_rejects_hwpx_output_without_creating_hwp5_bytes() {
+    let out = unique_output("misnamed", "hwpx");
+    let out_text = out.to_str().expect("utf-8 path").to_string();
+    let args = ["convert", SAMPLE, &out_text, "--verify", "--json"];
+    let output = run(&args);
+    let created = out.exists();
+    let _ = std::fs::remove_file(&out);
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "HWP5를 .hwpx 이름으로 저장하면 안 된다\n{}",
+        describe(&args, &output)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "사용법 오류의 stdout은 비어야 한다\n{}",
+        describe(&args, &output)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(".hwp") && stderr.contains("export-hwpx"),
+        "허용 형식과 대체 명령을 함께 안내해야 한다\n{}",
+        describe(&args, &output)
+    );
+    assert!(
+        !created,
+        "거부된 출력 파일이 남으면 안 된다: {}",
+        out.display()
+    );
+}
+
+#[test]
+fn invalid_convert_output_is_usage_error_before_input_io() {
+    let out = unique_output("preflight", "hwpx");
+    let missing = unique_output("missing-input", "hwp");
+    let missing_text = missing.to_str().expect("utf-8 path").to_string();
+    let out_text = out.to_str().expect("utf-8 path").to_string();
+    let args = ["convert", &missing_text, &out_text, "--json"];
+    let output = run(&args);
+    let _ = std::fs::remove_file(&out);
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "출력 형식 오류는 입력 IO보다 먼저 판정해야 한다\n{}",
+        describe(&args, &output)
+    );
+    assert!(output.stdout.is_empty(), "{}", describe(&args, &output));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("export-hwpx"),
+        "{}",
+        describe(&args, &output)
+    );
+    assert!(!out.exists(), "사용법 오류 뒤 산출물이 없어야 한다");
+}
+
+#[test]
+fn convert_accepts_case_insensitive_hwp_extension() {
+    let sample = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let out = unique_output("uppercase", "HWP");
+    let sample_text = sample.to_str().expect("utf-8 path").to_string();
+    let out_text = out.to_str().expect("utf-8 path").to_string();
+    let args = ["convert", &sample_text, &out_text, "--json"];
+    let output = run(&args);
+    let created = out.exists();
+    let _ = std::fs::remove_file(&out);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "대문자 .HWP도 유효한 HWP5 출력이다\n{}",
+        describe(&args, &output)
+    );
+    assert!(created, "성공한 convert 산출물이 있어야 한다");
+}

--- a/tools/gen_agent_codex.py
+++ b/tools/gen_agent_codex.py
@@ -35,7 +35,8 @@ for stream in (sys.stdout, sys.stderr):
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 OUT_DIR = os.path.join(ROOT, "mydocs", "manual", "agent_codex")
-TMP = os.path.join(ROOT, "target", "codex-tmp")
+TMP_REL = "target/codex-tmp"
+TMP = os.path.join(ROOT, TMP_REL.replace("/", os.sep))
 
 
 def find_bin():
@@ -63,7 +64,8 @@ ODD = "samples/143E433F503322BD33.hwp"
 PLAN_A = {
     "planVersion": "1.0",
     "input": DOC,
-    "output": "{tmp}/plan_out.hwp",
+    # replay의 plan hash가 checkout 절대경로에 의존하지 않게 저장소 상대경로를 쓴다.
+    "output": f"{TMP_REL}/plan_out.hwp",
     "steps": [{"action": "replace_text", "find": "규제", "replace": "코덱스검증"}],
 }
 
@@ -88,7 +90,7 @@ LIVE = {
     "edit redact": (["edit", "redact", FORM, "--dry-run", "--json"], "개인정보 탐지 (dry-run = 읽기 전용 탐지)"),
     "run": (["run", "{plan_a}", "--json"], "계획서 원자 실행 — 선검증 후 단 한 번 저장"),
     "replay": (["replay", "--plan-json", "{plan_a_inline}", "--json"], "작업 영수증 발급(attest) — 3해시"),
-    "convert": (["convert", FORM, "{tmp}/conv.hwpx", "--verify", "--json"], "형식 변환 + 재파싱 자기검증"),
+    "convert": (["convert", FORM, "{tmp}/conv.hwp", "--verify", "--json"], "HWP5 변환 + 재파싱 자기검증"),
     "export-svg": (["export-svg", FORM, "-o", "{tmp}/svg"], "쪽별 SVG 렌더 (매니페스트 봉투)"),
     "export-provenance-map": (["export-provenance-map", "--json"], "어느 필드가 문서에서 오는가의 지도"),
     "export-plan-schema": (["export-plan-schema", "--json"], "run 계획서 JSON Schema"),
@@ -155,7 +157,7 @@ def redact(text):
     ROOT 하위라 **긴 접두사(TMP)를 먼저** 지운다 — 순서가 뒤집히면
     TMP 경로가 <repo>/… 로 바뀌어 <tmp> 표지를 영영 못 얻는다.
     """
-    for base, mark in ((TMP, "<tmp>"), (ROOT, "<repo>")):
+    for base, mark in ((TMP, "<tmp>"), (TMP_REL, "<tmp>"), (ROOT, "<repo>")):
         text = text.replace(base.replace("\\", "/"), mark).replace(base, mark)
     return text
 


### PR DESCRIPTION
## 요약

- gym T12의 HWPX 변환 명령을 `export-hwpx`로 바로잡고 실제 산출물 형식을 먼저 검사합니다.
- `convert`가 `.hwp` 외 출력 경로를 입력 IO 전에 사용법 오류로 거부해 HWP5 바이트를 `.hwpx` 이름으로 저장하지 못하게 합니다.
- gym scorer가 `expect_exits`를 지원해 `ir-diff --json`의 정상적인 차이 종료 코드 3도 JSON 값으로 판정합니다.
- T12 기준선, 생성 Codex 교본, 판단 트리, CLI·gym 문서와 CI 테스트 배선을 같은 계약으로 정합화합니다.

## 원인

기존 T12는 `convert ... conv.hwpx`를 안내했지만 `convert`는 실제로 항상 HWP5를 생성했습니다. 채점 또한 IR 동일성만 확인해 파일명만 HWPX인 HWP5 제출을 통과시켰습니다. 반대로 실제 HWPX의 정직한 `ir-diff` 결과는 exit 3이라는 이유로 JSON 봉투 판정 전에 실패했습니다.

## 사용자 영향

- HWP→HWPX 변환 경로가 `export-hwpx`로 명확해집니다.
- 잘못된 `convert` 출력 확장자는 exit 2, 빈 stdout, 산출물 없음으로 즉시 실패합니다.
- T12는 실제 HWPX이면서 현재 기준 답안인 `identical:false`를 만족해야 통과합니다.
- 기존 단일 `expect_exit` gym 과제는 하위 호환됩니다.

## 검증

- T12 실제 focused 판정: 2/2 checks passed
- `issue_4586_gym_t12_contract`: 3 passed
- `scripts/tests/test_gym_score.py`: 5 passed
- workflow contract wiring: 3 passed
- agent Codex contract: 2 passed
- 생성 교본 검사: 명령 83, 실측 18, 계약만 65, 변경 0
- `cargo clippy --all-targets -- -D warnings`: passed
- `cargo fmt --all -- --check`: passed
- 전체 release-test: 5,763 passed, 36 skipped, 6 slow

렌더러·레이아웃·WASM·rhwp-studio 변경은 없어 시각 검증과 WASM 빌드는 적용 대상이 아닙니다.

Closes #4586
