### PR TITLE
renderer: 인라인 개체 흐름 높이의 정의를 조판·렌더 공용 하나로

### DIFF
--- a/mydocs/working/task_m100_4333_stage1.md
+++ b/mydocs/working/task_m100_4333_stage1.md
@@ -1,0 +1,166 @@
+# task_m100_4333 Stage 1 — 인라인 도형 높이 정의 통일
+
+- **이슈**: [#4333](https://github.com/edwardkim/rhwp/issues/4333)
+- **브랜치**: `fix/issue-4333-height-measure-inline-shape`
+- **분기 기준**: `upstream/devel` `a70797db4`
+- **상태**: 정의 통일 완료(동작 중립 확인), 이슈가 지목한 발산 자체는 미해소 — 아래 6절
+- **기록일**: 2026-08-11 KST
+
+## 1. 실측 — 이슈의 수치는 재현되지만, 발산의 방향이 반대다
+
+`samples/` 352개 문서에서 `PaginationResult` 기준 **단 최상단 문단**만 골라
+`HeightMeasurer::measure_section` 과 scratch `LayoutEngine::layout_partial_paragraph` 를 대조했다.
+이슈 본문의 인라인 도형 수치(n=142, 발산 126, 88.7%, 평균 62.4px, 최대 739.3px)가 그대로 재현된다.
+
+여기에 **production 페이지네이션이 실제로 쓰는 정의**를 한 열 더 넣었다.
+`DocumentCore::paginate_pass`(`document_core/queries/rendering.rs:4260`)는 기본 경로에서
+`TypesetEngine::typeset_section_with_variant` 를 호출하고, 그 높이 정의는
+`TypesetEngine::format_paragraph`(`renderer/typeset.rs:14318`)다.
+`Paginator::paginate_with_measured_opts`(= `MeasuredSection.paragraphs` 소비자)는
+`RHWP_USE_PAGINATOR=1` 일 때만 쓰인다(`rendering.rs:4180`).
+
+| 종류 | n | 발산(>1px) | 비율 | 평균\|차\| | 최대\|차\| |
+|---|---:|---:|---:|---:|---:|
+| **measure vs render** — Shape tac=true | 142 | 126 | 88.7% | 62.39px | 739.32px |
+| **typeset(=조판) vs render** — Shape tac=true | 142 | 126 | 88.7% | 62.39px | 739.32px |
+
+발산 126행 전부에서 `measured == typeset` 이 **소수점까지 일치**한다. 즉 이슈가 "정의가 두 벌"
+이라고 지목한 두 값(측정·조판)은 인라인 도형에서 서로 어긋나지 않는다. 어긋나는 쪽은 렌더다.
+
+## 2. 발산의 원인 — 한 줄
+
+최악 사례 `samples/2025 행정업무운영 편람(최종).hwp` 구역4 문단67 (739.32px):
+
+```
+seg[0] vpos=0 lh=55449 ls=0 th=55449          ← 저장 줄 높이 = 55449HU = 739.32px
+ctrl[0] Shape tac=true common.h=55449 current_h=55449
+measured.total_height = 739.32   typeset.total_height = 739.32   render = 0.00
+```
+
+`RHWP_DEBUG_PARA_TAC` 계측:
+
+```
+TAC_ADV pi=67 line_idx=0 y=0.0 raw_lh=739.3 lh=0.0 ls=0.0 whitespace=true
+```
+
+`raw_lh=739.3` 이 `lh=0.0` 이 되는 지점은
+**`src/renderer/layout/paragraph_layout.rs:3228` `let font_lh = max_fs * 1.2;`** 이다.
+
+- 이 분기의 게이트(`:3214-3217`)는 `has_tac_shape && !empty_tac_guide_has_explicit_shape_height
+  && (cell_ctx.is_none() || max_fs > 0.0) && raw_lh > max_fs * 1.5` 다.
+- `max_fs` 는 그 줄의 run 에서만 계산된다(`:3100-3111`, 문자모양 폴백 없음). 도형만 있는 줄은
+  run 이 없어 `max_fs == 0` → `font_lh == 0`.
+- 탈출구 `empty_tac_guide_has_explicit_shape_height`(`:3197-3209`)는
+  `shape_attr().current_height > common().height`(엄격 부등호)를 요구한다. 위 문단은 둘이
+  55449 로 같아 발동하지 않는다.
+
+발산 행의 "일정한 32px 격차"도 같은 기제다 — 예: 구역10 문단21 은 `lh=[32.0] ls=[6.67]` 인데
+렌더 20.0 = `ls + sa`, 즉 `lh` 32.0 이 통째로 0 이 된 값이다.
+
+## 3. 그런데 렌더의 실제 흐름 위치는 그 0 을 쓰지 않는다
+
+`build_single_column` 은 항목 사이에 `HeightCursor::vpos_adjust`(`renderer/layout.rs:5778`)로
+저장 vpos 사다리에 스냅한다. 그래서 `layout_partial_paragraph` 의 고립 advance 는 본문 흐름에서의
+문단 높이가 아니다.
+
+이를 실험으로 확인했다. `:3228` 붕괴를 제거하면(도형 전용 줄이 저장 줄 높이를 유지) —
+
+- 인라인 도형 발산: 126/142(88.7%) → **8/142(5.6%)**, 최대 739.32 → 19.61px
+- `samples/` 355개 문서 **페이지 수 변화 0건**
+- 그러나 `tests/issue_1116.rs` 의 한컴 PDF 핀 2건이 깨진다
+  (`sample16_hwp5_page3_heading_positions_follow_lineseg_vpos`: 기대 y≈337.2 → 실제 347.63,
+  `sample16_hwp5_2022_page3_bcp_tail_glyph_stays_on_hancom_line`: 881.35 → 891.75).
+  두 건 모두 정확히 **+10.4px**, `hwp3-sample16-hwp5.hwp` 구역0 문단71 도형 줄의 후행 줄간격
+  (780HU)이다. 그 문단은 저장 사다리 delta(16304−5760=10544HU=140.59px)가 측정값과 정확히 같아
+  붕괴를 없애면 advance 가 정답이 되는데, 그 뒤 `vpos_adjust` 의 후방 스냅 클램프가 `spacing_before`
+  만큼의 초과를 되돌리지 못한다.
+
+즉 렌더의 문단 높이는 `layout_partial_paragraph` 단독이 아니라
+`vpos_adjust ∘ layout_partial_paragraph` 의 합성이고, 붕괴와 스냅이 **짝으로** 한컴 정합을 이루고
+있다(`:3219-3227` 주석이 그 사실을 스스로 기록한다). 한쪽만 떼면 정합이 깨진다.
+그래서 이 변경은 **채택하지 않았다** — 되돌리는 데 필요한 것은 보상 기계의 재교정이고, 그건
+이 이슈 범위 밖이다.
+
+## 4. 실제로 있던 "정의 두 벌" — 인라인 도형의 흐름 높이
+
+발산과 별개로, 같은 속성의 **정의식이 진짜로 두 벌**인 지점이 조판·렌더 경계에 있었다.
+
+```
+renderer/typeset.rs:2002           tac_picture_or_shape_height_px  → Shape: common().height
+renderer/layout/paragraph_layout.rs:694  tac_picture_or_shape_height_px  → Shape: max(common.height, current_height)
+```
+
+이름까지 같은 두 함수가 도형에서 다른 값을 냈다. `samples/` 의 인라인 도형 868개 중
+**354개(38개 문서)** 가 `current_height != common.height` 라 사장된 차이가 아니다.
+같은 `max(...)` 식은 추가로 다섯 곳에 복제돼 있었다
+(`paragraph_layout.rs:300/5320/6373`, `composer/line_breaking.rs:1065/1087`,
+`document_core/commands/object_ops/picture.rs:821`, `renderer/layout.rs:10641`).
+
+**조치**
+
+1. `ShapeObject::flow_height_hu()`(`model/shape.rs`) — 유일 정의.
+2. `renderer::tac_object_flow_height_px()` — 글자처럼 취급 개체(그림/도형)의 흐름 높이 px.
+   조판·렌더가 공유. typeset 쪽 사본 삭제.
+3. `renderer::line_owning_tac_object_height_px()` — "이 줄은 인라인 개체가 소유한 줄인가"
+   술어. `format_paragraph`(조판)와 `layout_composed_paragraph`(렌더)에 각각 있던 동일 술어를
+   하나로.
+4. `paragraph_layout.rs:3197` 의 `current_height > common.height` 대리 지표를
+   `flow_height_hu() > common().height` 로 표기(동치, 단일 정의 경유).
+
+정의 유일성 확인:
+
+```
+$ grep -rn "shape_attr()\.current_height" --include="*.rs" src/
+src/model/shape.rs:476:        (self.common().height as i32).max(self.shape_attr().current_height as i32)
+```
+
+(그 외 `shape_attr.current_height` 히트는 전부 `Picture` 타입 — 별도 정의
+`renderer/layout/utils.rs:65 effective_picture_size` — 또는 파서·직렬화·편집 명령의 필드 접근이다.)
+
+## 5. 동작 중립 확인
+
+조판 쪽 도형 산식이 `common().height` → `flow_height_hu()` 로 **바뀌므로** 페이지네이션에
+영향이 갈 수 있다. 실측:
+
+- `samples/` 355개 문서 페이지 수 대조(`upstream/devel a70797db4` vs head): **차이 0건**
+- 코퍼스 발산표: 변경 전후 동일 (Shape tac=true 126/142, 최대 739.32px — 3절 참조)
+- 인라인 도형을 담은 5쪽 PNG 렌더 전후 **바이트 동일**
+  (`draw-group.hwp p0`, `hwp3-sample16-hwp5.hwp p2`,
+  `2025 행정업무운영 편람(최종).hwp p163·p290`, `3-09월_교육_통합_2022.hwp p10`)
+
+## 6. 미해소 — 이슈 본체
+
+이슈의 목표(`force_breaks` 되먹임 재가동을 위한 "측정 통일")는 이 Stage 로 달성되지 않았다.
+남은 사실을 그대로 기록한다.
+
+- 인라인 도형 발산 88.7% 는 **측정↔조판 사이가 아니라 렌더의 줄높이 붕괴**(`:3228`)다.
+  측정과 조판은 이미 소수점까지 같다.
+- 이슈가 지목한 `height_measurer.rs` 에 `shape_attr()/current_height` 인지 경로를 추가하는 것은
+  방향이 반대다 — 측정은 이미 저장 `LINE_SEG.line_height` 로 도형 높이를 담고 있고, 그 값이
+  저장 vpos 사다리 delta 와 일치한다(문단71: 140.59px = 10544HU).
+- 붕괴 제거는 3절대로 `vpos_adjust` 보상 기계 재교정을 동반해야 한다. 별도 이슈로 분리한다.
+- 이중 계상 재확인: `PageItem::Shape` 방출(`typeset.rs:6355-6385`)은 `st.current_height` 를
+  올리지 않고, `pushdown_h`(`typeset.rs:6435`)는 `!treat_as_char && TopAndBottom && VertRelTo::Para`
+  게이트라 떠 있는 도형 전용이다. 인라인 도형은 어느 쪽으로도 예산을 두 번 먹지 않는다.
+- 떠 있는 쪽 1건(`textbox-under-image.hwp` 구역0 문단0, 21.33px)은 손대지 않았다. 빈 문단 기본값
+  폴백(`height_measurer.rs:860`) vs 렌더의 `para_has_visible_textless_float_shape_item` 로,
+  기제가 다르다.
+
+## 7. 검증 (완료)
+
+- `cargo fmt --all -- --check` 통과
+- `cargo clippy --all-targets -- -D warnings` 통과
+- `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests` — `ok` 블록 535, 통과 5760,
+  FAILED 0
+- `cargo test --profile release-test --features native-skia skia --lib` — 58 passed
+- `--test issue_2225_missing_picture_placeholder` — 2 passed
+- `--test render_p37_direct_pdf_export` — 4 passed
+- `wasm-pack build --target web --out-dir pkg` 성공
+- 신규 회귀 시험 `typeset_and_render_agree_on_inline_shape_flow_height`
+  (`renderer/typeset.rs`) — 수정 전 RED 실증:
+
+  ```
+  assertion `left == right` failed
+    left: 32.0            (조판: common.height 2400HU)
+   right: 54.21333333333333  (렌더: current_height 4066HU)
+  ```

--- a/mydocs/working/task_m100_4333_stage1.md
+++ b/mydocs/working/task_m100_4333_stage1.md
@@ -168,7 +168,7 @@ src/model/shape.rs:476:        (self.common().height as i32).max(self.shape_attr
 
 ## 후속 이슈 (2026-08-11)
 
-- **[#4604](https://github.com/edwardkim/rhwp/issues/4604)** — 문단 높이가
+- **[#4604(닫힘)](https://github.com/edwardkim/rhwp/issues/4604)** — 문단 높이가
   `measure_paragraph`(`height_measurer.rs:619`)와 `format_paragraph`(`typeset.rs:14318`)
   두 정의로 남아 있다. 이번에 인라인 도형 축만 통일했고, `treat_as_char == false` 인
   Picture 는 여전히 25/102 대 7/102 로 갈린다.
@@ -176,8 +176,15 @@ src/model/shape.rs:476:        (self.common().height as i32).max(self.shape_attr
   `MeasuredSection.paragraphs` 가 프로덕션 페이지네이션에서 죽어 있다. 이 계열에서 수정 위치를
   **두 번** 오도했다(`has_picture` 술어, 분해안 2). `has_picture`/`picture_height` 도
   읽는 곳이 0건이다.
-- **[#4606](https://github.com/edwardkim/rhwp/issues/4606)** — 도형과 무관한 PlainText
+- **[#4606(닫힘)](https://github.com/edwardkim/rhwp/issues/4606)** — 도형과 무관한 PlainText
   문단에도 발산이 288/5128(5.6%, 최대 18.88px) 남아 있다. 도형 발산에 가려 있던 기저선.
 
 `textbox-under-image.hwp` 구역0 문단0 의 float 측 1건(21.33px)은 #4333 본문이 이미 별개
 기제로 적어 두어 새로 열지 않았다.
+
+
+## 정정 (2026-08-12)
+
+Stage 2 실측으로 #4604·#4606 은 **"고치지 않는다"로 닫혔다.** 근거는
+`task_m100_4333_stage2.md` 와 각 이슈 코멘트에 있다.
+#4605 는 PR #4621 이 처리한다.

--- a/mydocs/working/task_m100_4333_stage1.md
+++ b/mydocs/working/task_m100_4333_stage1.md
@@ -164,3 +164,20 @@ src/model/shape.rs:476:        (self.common().height as i32).max(self.shape_attr
     left: 32.0            (조판: common.height 2400HU)
    right: 54.21333333333333  (렌더: current_height 4066HU)
   ```
+
+
+## 후속 이슈 (2026-08-11)
+
+- **[#4604](https://github.com/edwardkim/rhwp/issues/4604)** — 문단 높이가
+  `measure_paragraph`(`height_measurer.rs:619`)와 `format_paragraph`(`typeset.rs:14318`)
+  두 정의로 남아 있다. 이번에 인라인 도형 축만 통일했고, `treat_as_char == false` 인
+  Picture 는 여전히 25/102 대 7/102 로 갈린다.
+- **[#4605](https://github.com/edwardkim/rhwp/issues/4605)** —
+  `MeasuredSection.paragraphs` 가 프로덕션 페이지네이션에서 죽어 있다. 이 계열에서 수정 위치를
+  **두 번** 오도했다(`has_picture` 술어, 분해안 2). `has_picture`/`picture_height` 도
+  읽는 곳이 0건이다.
+- **[#4606](https://github.com/edwardkim/rhwp/issues/4606)** — 도형과 무관한 PlainText
+  문단에도 발산이 288/5128(5.6%, 최대 18.88px) 남아 있다. 도형 발산에 가려 있던 기저선.
+
+`textbox-under-image.hwp` 구역0 문단0 의 float 측 1건(21.33px)은 #4333 본문이 이미 별개
+기제로 적어 두어 새로 열지 않았다.

--- a/mydocs/working/task_m100_4333_stage2.md
+++ b/mydocs/working/task_m100_4333_stage2.md
@@ -1,0 +1,409 @@
+# task_m100_4333 Stage 2 — 높이 정의 사슬(#4620·#4619·#4604·#4606·#4333) 측정과 판정
+
+- **이슈**: [#4333](https://github.com/edwardkim/rhwp/issues/4333) (우산),
+  [#4620](https://github.com/edwardkim/rhwp/issues/4620),
+  [#4619](https://github.com/edwardkim/rhwp/issues/4619),
+  [#4604](https://github.com/edwardkim/rhwp/issues/4604),
+  [#4606](https://github.com/edwardkim/rhwp/issues/4606)
+- **분기 기준**: `upstream/devel` `96e52a01b` (게이트 실행 시점 `298c2c1b2` → 리베이스;
+  그 사이 5개 커밋은 CI workflow·문서·python 스크립트로 **Rust 소스 변경 0**)
+- **선행**: Stage 1 은 PR [#4607](https://github.com/edwardkim/rhwp/pull/4607) (미병합)
+- **상태**: 코드 변경은 #4333 의 주석 오기 정정 1건. 나머지 넷은 측정으로 판정했고
+  #4620 은 닫을 근거, #4619·#4604·#4606 은 보류 근거를 남긴다.
+- **기록일**: 2026-08-12 KST
+
+## 0. 요약
+
+| 이슈 | 판정 | 근거 |
+| --- | --- | --- |
+| #4620 | **닫는다** — 소비자가 이미 다른 값을 쓴다 | 4절 |
+| #4619 | **보류** — 코퍼스 재현 0건 + 순진한 이식은 확정 회귀 | 5절 |
+| #4604 | **통일하지 않는다** — 문단 축의 두 정의는 살아 있는 소비자가 하나뿐 | 6절 |
+| #4606 | **기저선 5.6% 의 97.1% 는 계측 기준의 산물** — 실제 기저선은 0.2% | 7절 |
+| #4333 | 주석 오기만 정정, 누적 정의는 보류 | 3절·8절 |
+
+## 1. 계측 기준 — AC 축이 어디서 무의미해지는가
+
+이 사슬에서 두 번 반복된 실패 모드는 **문단 진행이 아닌 하위 단계를 재는 것**이다
+(#4333 두 번째 코멘트). Stage 2 의 표는 세 값을 같은 입력으로 비교한다.
+
+| 기호 | 정의 | 위치 |
+| --- | --- | --- |
+| **A** | `HeightMeasurer::measure_paragraph` 의 `total_height` | `renderer/height_measurer.rs:619` |
+| **B** | `TypesetEngine::format_paragraph` 의 `total_height` | `renderer/typeset.rs:14318` |
+| **C** | scratch `LayoutEngine::layout_partial_paragraph` 의 고립 advance | `renderer/layout/paragraph_layout.rs:2130` |
+
+**C 는 모든 축에서 렌더의 문단 진행이 아니다.** 렌더의 문단 진행은
+`layout_column_item`(`renderer/layout.rs:6720`)이 정하고, 다음 경우에 C 를 넘어선다.
+
+- `Control::Shape` + `treat_as_char` — TAC-Shape 높이 바닥값(`layout.rs:7037-7076`)이 진행을 지배한다.
+- `treat_as_char == false` 인 Picture/Shape — 개체는 별도 `PageItem::Shape` 로 예산을 먹는다.
+- 표 — 별도 `PageItem::Table`.
+
+따라서 **C 가 뜻을 갖는 축은 PlainText·Equation·Picture(tac=true) 뿐이다.** 나머지 축의
+AC 발산은 계측 산물이지 결함이 아니다. 이 구분 없이 "측정을 렌더에 맞춘다"를 실행하면
+#4333 이 이미 두 번 밟은 함정을 세 번째로 밟는다.
+
+또 하나: `layout_partial_paragraph` 는 `is_column_top = (y - col_area.y).abs() < 1.0`
+(`paragraph_layout.rs:2778`)일 때 `spacing_before` 를 한컴 정합 규칙으로 잘라낸다
+(`:2771-2809`). scratch 를 `y_start = col_area.y` 로 돌리면 **모든 문단이 단 최상단으로
+계측**된다. 아래 표는 두 기준을 모두 싣는다.
+
+## 2. 축별 발산표 (352개 문서, 170,870 문단)
+
+`samples/*.hwp|*.hwpx` 355개 중 352개 파싱 성공(암호 3건 제외). 문단은 컨트롤 우선순위로
+배타 분류했다(Table > Picture tac=true > Picture tac=false > Shape tac=true >
+Shape tac=false > Equation > 기타 컨트롤 > PlainText=컨트롤 없음). 발산 임계 1.0px.
+
+| 축 | n | AB 발산 | % | AB 최대 | AC 발산(단 최상단) | % | AC 발산(단 중간) | % | AC 최대(단 중간) | AC 유효? |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | :--: |
+| PlainText | 158,161 | 509 | 0.3% | 20.00 | 8,545 | 5.4% | **252** | **0.2%** | 40.00 | 예 |
+| Equation | 4,198 | **0** | 0.0% | 0.00 | 14 | 0.3% | **0** | **0.0%** | 0.00 | 예 |
+| Picture tac=true | 525 | 4 | 0.8% | 280.29 | 18 | 3.4% | **2** | **0.4%** | 3.11 | 예 |
+| Shape tac=true | 822 | **0** | 0.0% | 0.00 | 402 | 48.9% | 367 | 44.6% | 739.32 | 아니오 (바닥값) |
+| Picture tac=false | 402 | 42 | 10.4% | 238.93 | 73 | 18.2% | 73 | 18.2% | 655.84 | 아니오 (별도 item) |
+| Shape tac=false | 96 | 36 | 37.5% | 25.87 | 19 | 19.8% | 2 | 2.1% | 803.99 | 아니오 (별도 item) |
+| Table | 5,018 | 35 | 0.7% | 227.81 | 1,634 | 32.6% | 306 | 6.1% | 645.39 | 아니오 (별도 item) |
+| 기타 컨트롤 | 1,648 | 6 | 0.4% | 33.60 | 547 | 33.2% | 24 | 1.5% | 33.60 | 혼재 |
+
+AB 는 두 값이 모두 `(para, composed, styles, col_w)` 의 순수 함수라 기준 y 에 불변이다.
+
+## 3. #4333 — 접힘과 바닥값의 짝, 그리고 주석 오기
+
+`paragraph_layout.rs:3233` 의 옛 주석이 짝의 나머지 반쪽을 "reserved/skip-advance 보상
+기계"로 지목했다. **실제 보상자는 `layout_column_item` 의 TAC-Shape 높이 바닥값**
+(`layout.rs:7037-7076`)이다. 이번 실행에서 직접 재확인했다.
+
+`samples/hwp3-sample16-hwp5.hwp` 구역0 문단71:
+
+```
+$ RHWP_DEBUG_PARA_TAC=all RHWP_DEBUG_TAC_CURSOR=1 rhwp export-svg …
+  TAC_ADV    pi=71 line_idx=0 y=163.8 raw_lh=130.2 lh=0.0 ls=10.4 whitespace=true
+  TAC_CURSOR FullPara pi=71 y_in=163.8 y_out=294.0 dy=130.2 was_tac=false
+```
+
+줄 루프의 진행은 `lh + ls = 10.4` 인데 문단 진행은 `130.2` 다 — 바닥값
+`para_start + max(seg_lh, shape_max_h) = 163.8 + 130.2 = 294.0` 이 물었다. 접힘을
+없애면 루프 진행이 `raw_lh + ls = 140.6` 이 되어 바닥값을 넘고, 문단은 정확히
+`LineSeg.line_spacing`(10.4px) 만큼 밀린다 — `tests/issue_1116.rs` 의 한컴 PDF 핀
+둘이 깨지는 값이다(#4333 두 번째 코멘트 실측).
+
+`HeightCursor::vpos_adjust` 는 보상자가 **아니다.** 같은 문서에서:
+
+```
+$ RHWP_VPOS_DEBUG=1 rhwp export-svg …
+  VPOS_CORR_SKIP: pi=72 prev_pi=71 y_in=293.97 lazy_base_corrected=-852 lazy_base=-72
+```
+
+`lazy_base < 0` 이라 `height_cursor.rs:294` 에서 조기 반환한다. 오기가 앞선 조사를
+이쪽으로 보냈다. **이번 커밋은 이 주석만 사실로 바꾼다** — 동작 변경 없음.
+
+남은 과제(누적 정의)는 8절.
+
+## 4. #4620 — 닫는다. `TextLine` 높이 0.0 을 읽는 소비자가 없다
+
+### 재현은 된다
+
+`export-render-tree` 로 `2025 행정업무운영 편람(최종).hwp` 를 뜨면 이슈가 인용한 노드가
+그대로 나온다(쪽 색인 163).
+
+```json
+{"type":"TextLine","bbox":{"x":113.4,"y":886.7,"w":529.1,"h":0.0},"pi":67,
+ "children":[{"type":"TextRun","bbox":{"x":637.8,"y":147.4,"w":0.0,"h":0.0},"text":"","pi":67}]}
+```
+
+`h` 는 `RenderNode.bbox.height` 의 직렬화이고(`render_tree.rs:246`), 그 값은
+`TextLineNode.line_height` 와 같은 변수에서 온다(`paragraph_layout.rs:3517`·`:3538`).
+
+### 그런데 소비자 셋 다 다른 값을 쓴다
+
+- **캐럿** — 인라인 개체 자리의 캐럿은 `TextLine` 이 아니라 **개체 자신의 렌더 bbox** 에서
+  나온다(`document_core/queries/cursor_rect.rs:660-696`, `control_bboxes`).
+  `TextLine` 을 읽는 경로(`find_para_line`, `:1210-1236`)는 TextRun 이 하나도 안 잡힌
+  빈 문단 폴백이다.
+- **히트테스트** — `hit_test_native`(`cursor_rect.rs:1508`)의 `RunInfo.bbox_h` 는 전적으로
+  `TextRun`/`TableCell`/`TextBox` 에서 채워진다. `TextLine` 을 읽지 않는다.
+- **줄 선택** — `cursor_nav.rs:2070` 이 `TextLine` 의 `bbox.height` 를 `CursorHit.h` 에
+  담지만, 선택 사각형의 y·h 는 **항상 left_hit** 에서 온다(`cursor_nav.rs:2310`,
+  주석이 그렇게 적어 뒀다). `TextLine` 쪽 값은 우측 끝 x 폴백으로만 쓰이고 버려진다.
+
+### 실측 — 접힘 대상 681건, 0 높이 캐럿 0건
+
+텍스트가 없고 `treat_as_char` 그림/도형만 있는 문단 전수(코퍼스 1,120건)에 대해
+`get_cursor_rect_native(sec, pi, 0)` 을 돌렸다. 접힘 게이트가 요구하는 `Control::Shape`
+보유 문단은 **681건**이다.
+
+```
+TAC-only paragraphs: 1120, zero-height caret: 0, nonzero: 1120
+  of which TAC-Shape (접힘 게이트 대상): 681, min caret height: 12
+```
+
+**0 높이 캐럿은 한 건도 없다.** 이슈 본문의 "확인이 먼저다" 절이 지정한 종료 조건
+("관측되지 않으면 소비자들이 이미 다른 값을 쓰고 있다는 뜻이므로 그 사실을 기록하고
+닫는다")에 해당한다.
+
+### 게다가 이슈가 말한 "안전한 수정"은 안전하지 않다
+
+이슈는 "노드의 `h` 만 채우고 진행량 계산은 그대로 두면 안전하다"고 적었다. 그렇지 않다 —
+`bbox.height` 는 진행량으로 되먹임된다.
+
+- `paragraph_layout.rs:3631` — 미주 문단의 렌더 진행:
+  `line_flow_height.max(max_fs).max(line_node.bbox.height)`
+- `layout/picture_footnote.rs:1279`·`:1305` — 각주 위첨자 y 배치가 줄 bbox 높이를 읽는다
+
+즉 `h` 를 채우면 미주 흐름과 각주 마커가 함께 움직인다. 관측된 결함이 없는 상태에서
+기하가 움직이는 변경은 순수 위험이다.
+
+## 5. #4619 — 보류. 재현 0건, 순진한 이식은 확정 회귀
+
+### 재현 탐색
+
+`layout_column_item` 의 `PartialParagraph` arm 에 임시 계측을 넣고 코퍼스 355개 문서를
+**레이아웃 경로로**(`export-svg`) 전수 렌더했다. (`dump-pages` 는 레이아웃을 돌리지
+않으므로 이 탐색에 쓸 수 없다 — 첫 시도가 그래서 0건이었다.)
+
+`treat_as_char` Shape 를 담은 문단이 `PartialParagraph` 로 나오는 경우는 **문서 2개,
+조각 5개**뿐이고, **전부 텍스트가 있는 문단**이다(`text_empty=false`).
+
+```
+21_언어_기출_편집가능본.hwp sec0 pi=181 start=0 end=8   y_in=1240.64 dy=197.93 seg_lh=18.89 would_floor=+18.89 frag_runs=[1,1,1,1,1,2,2,2]
+21_언어_기출_편집가능본.hwp sec0 pi=181 start=8 end=13  y_in=209.76  dy=121.07 seg_lh=18.89 would_floor=+18.89 frag_runs=[1,5,2,1,1]
+21_언어_기출_편집가능본.hwp sec0 pi=238 start=0 end=5   y_in=1313.28 dy=125.29 seg_lh=18.89 would_floor=+18.89 frag_runs=[2,1,1,1,1]
+21_언어_기출_편집가능본.hwp sec0 pi=238 start=5 end=26  y_in=209.76  dy=508.48 seg_lh=18.89 would_floor=+18.89 frag_runs=[1,2,3,1,3,4,1,2,3,…]
+HWP5-nopassword-123456.hwp  sec0 pi=258 start=0 end=1  y_in=978.77  dy=25.12  seg_lh=17.12 would_floor=+17.12 frag_runs=[3]
+HWP5-nopassword-123456.hwp  sec0 pi=258 start=1 end=3  y_in=132.27  dy=46.45  seg_lh=17.12 would_floor=+17.12 frag_runs=[3,3]
+```
+
+모든 조각에서 **실제 진행(dy)이 바닥값보다 크다.** 즉 `FullParagraph` 의 바닥값을 그대로
+옮겨도 다섯 조각 전부 무동작이다. 이슈가 든 전제(도형만 있는 문단이 쪽 경계에 쪼개짐)는
+코퍼스에 없다 — 모든 조각의 모든 줄에 run 이 있어 `max_fs > 0` 이고 접힘이 발동하지 않는다.
+
+### 순진한 이식은 확정 회귀다
+
+`FullParagraph` 의 바닥값은 시작점을 이렇게 잡는다.
+
+```rust
+let para_start = *para_start_y.get(para_index).unwrap_or(&y_offset);   // layout.rs:7065
+```
+
+`layout_column_item` 안에서 `para_start_y` 에 문단을 등록하는 곳은 `FullParagraph`
+arm 셋(`layout.rs:6773`·`:6797`·`:6848`·`:6903`·`:6951`·`:7021`)뿐이고, 그 밖의 등록은
+`layout_table_item`(`:8386`)·`layout_shape_item`(`:9285`) 안에 있다.
+**`PartialParagraph` arm 은 등록하지 않는다.** 같은 코드를 PP 에 복사하면 `unwrap_or` 가
+**레이아웃이 끝난 뒤의** `y_offset` 을 집어, `shape_bottom = y_offset + effective_h` 가
+항상 `y_offset` 보다 커진다 — 즉 모든 PP 조각이 매번 `effective_h + spacing_after` 만큼
+밀린다. 옳은 앵커는 `pp_y_in`(`layout.rs:7167-7185`)이다.
+
+### 옳은 이식은 #4333 의 남은 과제와 같은 것을 요구한다
+
+바닥값은 `seg_lh = max(모든 line_segs)` 를 쓴다. 조각에 대해 이 값을 쓰면 **도형이 다른
+조각에 있을 때도** 그 높이를 주장한다 — 위 pi=181 은 도형이 줄 2(조각 0..8)에 있는데
+조각 8..13 도 같은 `seg_lh` 를 본다. 조각별로 옳으려면 "이 조각이 그 도형 줄을 소유하는가"
+와 줄별 높이가 필요하고, 그것이 바로 8절의 누적 정의다.
+
+**결론**: 재현이 없고, 순진한 수정은 회귀이며, 옳은 수정은 #4333 의 선행 작업을 요구한다.
+#4619 는 독립적으로 고칠 수 있는 결함이 아니라 #4333 의 한 면이다.
+
+## 6. #4604 — 통일하지 않는다. 문단 축에는 살아 있는 소비자가 하나뿐이다
+
+### 축별 판정
+
+- **Equation (0/4,198)·Shape tac=true (0/822)** — 이미 소수점까지 같다. 손댈 것이 없다.
+- **PlainText (509/158,161, 0.3%, 최대 20.00)** — 관측 가능한 규모가 아니다.
+- **Picture tac=true/false, Table** — 큰 행들의 기제가 하나다. **조판은 별도
+  `PageItem` 으로 예산을 먹는 줄과 중복 예약된 인라인 개체 줄을 0 으로 두고, 측정은
+  그대로 남긴다.** 줄별 값을 나란히 찍으면 바로 보인다.
+
+  ```
+  Picture tac=true  중간진도보고서 pi463   A lh=[266.96, 266.96]  B lh=[266.96, 0.0]
+  Picture tac=true  투명도0-50.hwp pi0     A lh=[103.11, 103.11]  B lh=[103.11, 0.0]
+  Picture tac=false pic2.hwp pi0           A lh=[37.33 ×8]        B lh=[0, 37.33, 0, 37.33, …]
+  Picture tac=false hwp3-sample16 pi0      A lh=[26.67] ls=[16.0] B lh=[0.0] ls=[0.0]
+  Table             중간진도보고서 pi428   A lh=[214.48, 13.33]   B lh=[0.0, 13.33]
+  ```
+
+  조판 쪽 0 은 `format_paragraph` 의 `prev_line_reserved_tac_picture_height`
+  (`typeset.rs:14494`)와 블록 개체 제외 규칙이다. 같은 개체를 문단 높이와 별도
+  `PageItem` 에 **두 번** 넣으면 페이지네이션이 깨지므로 조판 쪽이 구성상 맞다.
+
+  반대 방향도 한 건 있다 — `2022년 국립국어원 업무계획.hwp` pi586 은 줄별 값이
+  양쪽 동일(`lh=[1.33, 46.4] ls=[0.8, 10.4]`)인데 `A=0.00 B=58.93` 이다. 측정 쪽
+  `has_table && line_segs.len() >= 2` 의 vpos 클램프(`height_measurer.rs:888-903`,
+  `vpos_h.min(sum)`)가 문단 전체를 0 으로 접는다. 이쪽은 측정이 과잉 삭제한다.
+
+  이 클램프와 `clickhere_adjustment`(`:908-940`) 때문에
+  **`MeasuredParagraph.total_height` 는 자기 자신의 `sb + Σlh + Σls + sa` 와 다르다.**
+  `dump_page_items_json`(`rendering.rs:5262-5271`)은 `"total"` 을 그 합으로 다시
+  만들므로, 같은 문단에 대해 진단이 내는 값과 `total_height` 가 어긋난다.
+
+### 왜 "통일"이 답이 아닌가
+
+`MeasuredSection.paragraphs` 는 **프로덕션 페이지네이션이 읽지 않는다.**
+`DocumentCore::paginate_pass` 가 `TypesetEngine::typeset_section_with_variant` 에 넘기는
+것은 `measured.tables` 뿐이다(`document_core/queries/rendering.rs:4300`).
+`Paginator::paginate_with_measured_opts`(= `.paragraphs` 의 소비자)는
+`RHWP_USE_PAGINATOR=1` 폴백과 구역 0개 문서에서만 돈다(`:4212`).
+
+즉 문단 높이 축에서 두 정의는 **살아 있는 소비자를 각각 갖고 있지 않다.** 한쪽은
+프로덕션이고 다른 쪽은 폴백·진단이다. 여기서 "공유 함수 추출"을 하면 둘 중 하나다.
+
+1. 프로덕션(`format_paragraph`)을 폴백에 맞춘다 → 한컴 핀이 걸린 경로를 진단값 쪽으로
+   움직인다. 명백히 잘못된 방향이다.
+2. 폴백을 프로덕션에 맞춘다 → 그것은 통일이 아니라 **두 번째 정의를 지우는 일**이고,
+   이미 #4605/PR #4621 이 그 방향으로 가고 있다.
+
+따라서 #4604 의 옳은 후속은 "정의를 합친다"가 아니라 "`fallback_paragraphs` 소비자를
+`format_paragraph` 로 옮기거나 걷어낸다"이며, 그 전에는 축별 표를 기저선으로 남긴다.
+
+## 7. #4606 — 기저선 5.6% 의 97.1% 는 계측 기준의 산물이다
+
+이슈의 `288/5128 (5.6%)` 를 전수(158,161 PlainText 문단)로 다시 재면 **8,545건(5.4%)**
+으로 비율이 재현된다. 잔차의 모양을 분해하니 한 가지가 지배한다.
+
+| 잔차 `r = A − C` | 건수 | 비율 |
+| --- | ---: | ---: |
+| `spacing_before` | 8,293 | **97.1%** |
+| `ls_last` | 3 | 0.0% |
+| `sb + ls_last` | 1 | 0.0% |
+| 그 외 | 248 | 2.9% |
+
+원인은 결함이 아니라 **한컴 정합 규칙**이다. `layout_partial_paragraph` 는
+`is_column_top`(`paragraph_layout.rs:2778`)일 때 `spacing_before` 를 잘라내거나 저장
+`LineSeg.vertical_pos` 로 클램프한다(`:2771-2809`, Task #853/#1811 의 한컴 PDF 근거가
+주석에 있다). scratch 계측은 `y_start = col_area.y` 로 돌아 **모든 문단이 단 최상단**으로
+잡혔다.
+
+`y_start` 를 단 중간으로 옮긴 대조 실행:
+
+| 축 | AC 발산(단 최상단) | AC 발산(단 중간) |
+| --- | ---: | ---: |
+| PlainText | 8,545 (5.4%), 최대 75.57 | **252 (0.2%), 최대 40.00** |
+| Equation | 14 (0.3%) | **0 (0.0%)** |
+| Picture tac=true | 18 (3.4%) | **2 (0.4%), 최대 3.11** |
+
+#4606 의 원 표본(Stage 1) 자체가 "`PaginationResult` 기준 **단 최상단 문단**"이었다.
+즉 그 5.6% 는 그 모집단에 대해 **참이지만 설계대로**다 — 단 최상단이라서 렌더가 트림한
+것이고, 트림은 한컴 PDF 근거로 들어간 규칙이다.
+
+**PlainText 기저선의 실체는 5.6% 가 아니라 0.2% 다.** 그리고 없어진 97% 는
+"측정이 틀렸다"가 아니라 "측정은 문단이 어느 단의 어느 위치에 앉을지 모른다" 이다 —
+그건 페이지네이션의 **출력**이므로 측정 입력이 될 수 없다. 두 정의가 남아 있는 구조적
+이유가 이것이고, 이 축에서는 렌더가 한컴 쪽이다.
+
+남은 0.2%(252건)는 `sb`·`ls` 로 설명되지 않는다. 최대 표본:
+
+```
+hwp3-sample4-hwp5.hwp sec0 pi29  r=40.00  A=60.00 C=20.00
+  sb=0.00 sa=0.00 ls_last=6.67  nlines_measured=3 nlines_comp=3 nsegs=3
+```
+
+줄 수는 3으로 같은데 진행이 20px 대 60px 다 — 줄별 진행(공백 줄 skip_advance 계열)의
+차이로 보이며, 이것이 #4606 이 기록할 만한 진짜 기저선이다. 관측(쪽수) 영향은 없다.
+
+## 8. #4333 에 남는 것
+
+바닥값을 양방향 스냅으로 바꾸면 핀도 지키고 지표도 닫히지만, `seg_lh` 가
+`line_segs` 에 대한 `max` 이지 `sum` 이 아니라 여러 줄에 걸친 TAC 도형이 잘린다.
+조판 쪽에는 그 부류를 위한 누적 정의가 있다 —
+`stacked_tac_picture_heights`(`typeset.rs:14469-14492`), 게이트는
+`para_is_treat_as_char_picture_only && tacs.len() >= 2 && lines.len() == tacs.len() &&
+모든 char_start 동일 && 모든 높이 > 8px` 다. **렌더 쪽 대응물을 먼저 만들어야 하고,
+5절이 보인 대로 #4619 도 같은 것을 요구한다.** 그 전에는 접힘도 바닥값도 건드리지 않는다.
+
+이번 실행에서 그 대응물을 만들지 않았다. 가장 많이 pin 이 걸린 경로에 좁은 특례를 넣는
+대신, 판단에 필요한 사실(1절의 AC 유효 축, 5절의 앵커 위험, 8절의 게이트)을 남긴다.
+
+## 9. 발견했지만 손대지 않은 것
+
+이 다섯 이슈의 범위 밖이라 고치지 않았다. 각각 별도 이슈 후보다.
+
+1. **TAC-Shape 바닥값만 도형 흐름 높이의 정의가 다르다** —
+   `layout_column_item` 의 `shape_max_h`(`renderer/layout.rs:7058`)는
+   `s.common().height` 만 쓰는데, 같은 속성을 렌더의 다른 자리들
+   (`paragraph_layout.rs:696`, `composer/line_breaking.rs:1087`, `layout.rs:10641`)은
+   `max(common.height, shape_attr.current_height)` 로 쓴다. PR #4607 이 후자를
+   `ShapeObject::flow_height_hu()` 하나로 모으지만 **`layout.rs:7058` 은 건드리지
+   않는다.** #4607 병합 후에도 정의가 둘로 남고, 남는 쪽이 하필 문단 진행을 지배하는
+   자리다.
+2. **`para_is_treat_as_char_picture_only` 두 정의가 정반대 답을 낸다** —
+   `renderer/height_cursor.rs:45` 는 `para.text.trim().is_empty()`,
+   `renderer/typeset.rs:1370` 은 `!para_has_visible_text(para)`(`typeset.rs:1192`,
+   `\u{FFFC}` 를 제외)다. 표준적인 도형-전용 문단(`text == "\u{FFFC}"`)에서 전자는
+   `false`, 후자는 `true` 다. 이 술어가 8절의 `stacked_tac_picture_heights` 를 연다.
+3. **같은 이름의 함수 둘이 여전히 다른 식이다** —
+   `tac_picture_or_shape_height_px` 가 `paragraph_layout.rs:691`(max)과
+   `typeset.rs:2002`(common.height)에 각각 있다. PR #4607 이 정리 대상으로 삼았다.
+4. **측정 표 바닥값이 조판·페이지네이터에 복제돼 있다** —
+   `typeset.rs:16865-16871` 과 `pagination/engine.rs:918-922` 가 같은
+   `effective_h = seg_lh.max(mt_h)` 를 각자 계산한다.
+5. **`MeasuredParagraph.total_height` 가 자기 줄 벡터의 합과 다르다** —
+   `height_measurer.rs:888-903`(`has_table` vpos 클램프)과 `:909-940`
+   (`clickhere_adjustment`) 때문이다. `dump_page_items_json`
+   (`rendering.rs:5262-5271`)은 `"total"` 을 `sb + Σlh + Σls + sa` 로 다시 만들어
+   같은 문단에 대해 다른 값을 낸다.
+6. **`dump-pages` 가 프로덕션이 안 읽는 높이를 보고한다** —
+   `rendering.rs:5257-5258` 이 `measured.get_measured_paragraph(...)` 로 `height` 를
+   만든다. 이 계열에서 수정 위치를 두 번 오도한 값이 그대로 진단 표면에 노출돼 있다.
+7. **무동작 삼항** — `document_core/queries/cursor_rect.rs:4409`,
+   `if child.bbox.height > 0.0 { 12.0 } else { 12.0 }`. 두 가지가 같아 조건이
+   아무 일도 하지 않는다.
+8. **인라인 개체 옆 캐럿 높이가 개체 크기와 무관한 상수 12.0 이다** —
+   `cursor_rect.rs:676`(`let fallback_h = 12.0;`). 739px 도형 줄에서도 12px 다.
+   #4620 이 주장한 0 은 아니지만 한컴과는 어긋난다.
+
+## 10. 검증
+
+| 게이트 | 결과 |
+| --- | --- |
+| `cargo fmt --all -- --check` | exit 0 |
+| `cargo clippy --all-targets -- -D warnings` | exit 0 |
+| `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests` | exit 0 — `ok` 블록 **536**, **5,766 passed / 0 failed** |
+| `cargo test --profile release-test --test issue_1116` | exit 0 — **13 passed / 0 failed** |
+| `--features native-skia skia --lib` | exit 0 — 58 passed |
+| `--features native-skia --test issue_2225_missing_picture_placeholder` | exit 0 — 2 passed |
+| `--features native-skia --test render_p37_direct_pdf_export` | exit 0 — 4 passed |
+| `wasm-pack build --target web --out-dir pkg` | exit 0 |
+
+리베이스 뒤 `96e52a01b` 기준으로 `fmt`·`clippy`·`issue_1116`(13 passed)을 다시 확인했다.
+전체 회귀는 재실행하지 않았다 — 그 사이 upstream 델타에 Rust 소스 변경이 없다.
+
+`issue_1116` 13건에는 #4333 이 지목한 한컴 PDF 핀 둘이 그대로 들어 있다 —
+`sample16_hwp5_page3_heading_positions_follow_lineseg_vpos`,
+`sample16_hwp5_2022_page3_bcp_tail_glyph_stays_on_hancom_line`.
+
+Native Skia 통합 시험 둘은 `--features native-skia` 없이 돌리면 각각 1건/0건만 잡힌다
+(나머지가 feature 게이트 뒤에 있다). §4.3 의 명령 그대로 feature 를 붙여 재실행한 값이 위 표다.
+
+**기하 무변경**: 이번 커밋의 코드 변경은 주석 한 블록뿐이다. 기계적 증거:
+
+```
+$ git diff upstream/devel..HEAD -- '*.rs' | grep -E "^[+-]" \
+    | grep -vE "^(\+\+\+|---)" | grep -vE "^[+-]\s*//" | wc -l
+0
+```
+
+주석이 아닌 Rust 줄이 0 이다. 따라서 쪽수 스윕·시각 대조는 대상이 아니다.
+
+**RED 증명**: 주석 정정에는 걸 수 있는 테스트가 없다 — 지어내지 않았다. 이 주석이
+문서화하는 불변식(접힘 없이는 바닥값이 지배하지 않는다)의 실질적 가드는 이미
+`tests/issue_1116.rs` 의 한컴 핀 둘이고, 정정한 주석이 이제 그 가드를 정확히 지목한다.
+
+## 11. 계측 재현 방법
+
+이번 측정에 쓴 스크래치는 **커밋하지 않았다**(단정 없는 테스트를 저장소에 남기지 않는다).
+재현 절차만 남긴다.
+
+1. **축별 발산표(2절)** — `renderer::typeset::tests` 안에 `#[ignore]` 테스트를 두고
+   `samples/*` 전수에 대해 `DocumentCore::from_bytes` → 구역별
+   `(section.paragraphs, doc.composed[idx], doc.styles)` 와
+   `PageLayoutInfo::from_page_def(page_def, find_initial_column_def(paras), dpi)` 의
+   첫 단 폭으로 A/B/C 를 계산한다. C 는 `measure_endnote_para_advance`
+   (`typeset.rs:14121-14197`)와 같은 방식으로 scratch `LayoutEngine` +
+   `LayoutFrame` 을 쓴다. 단 최상단/단 중간은 `y_start` 를 `col_area.y` 로
+   두느냐 `+100.0` 으로 두느냐로 가른다.
+2. **#4619 재현 탐색(5절)** — `layout_column_item` 의 `PartialParagraph` arm 에
+   env 게이트 `eprintln!` 을 넣고 `rhwp export-svg` 로 코퍼스를 전수 렌더한다.
+   `dump-pages` 로는 레이아웃이 돌지 않는다.
+3. **#4620 캐럿 실측(4절)** — `examples/` 스크래치에서 `parse_document` 로 문단을 훑어
+   텍스트 없는 TAC 문단만 골라 `HwpDocument::get_cursor_rect_native(sec, pi, 0)` 의
+   `height` 를 집계한다.

--- a/mydocs/working/task_m100_4333_stage2.md
+++ b/mydocs/working/task_m100_4333_stage2.md
@@ -407,3 +407,36 @@ $ git diff upstream/devel..HEAD -- '*.rs' | grep -E "^[+-]" \
 3. **#4620 캐럿 실측(4절)** — `examples/` 스크래치에서 `parse_document` 로 문단을 훑어
    텍스트 없는 TAC 문단만 골라 `HwpDocument::get_cursor_rect_native(sec, pi, 0)` 의
    `height` 를 집계한다.
+
+
+## 후속 이슈 (2026-08-12)
+
+작업 중 발견했지만 배정된 다섯 이슈 밖이라 **고치지 않고** 이슈로 분리했다.
+
+- **[#4625](https://github.com/edwardkim/rhwp/issues/4625)** — TAC-Shape 바닥값
+  (`layout.rs:7058`)만 `common().height` 를 쓴다. **문단 진행을 실제로 지배하는 쪽**이
+  나머지 셋(`max(common.height, current_height)`)과 다른 식이고, PR #4607 의 통일 대상에서
+  빠져 있다.
+- **[#4626](https://github.com/edwardkim/rhwp/issues/4626)** —
+  `para_is_treat_as_char_picture_only` 두 정의가 도형만 있는 문단(`text == "\u{FFFC}"`)에
+  **반대 답**을 낸다. 이 술어가 `stacked_tac_picture_heights` 를 게이트하므로 **#4333 의
+  남은 작업을 시작하려면 이것이 선행 조건**이다.
+- **[#4627](https://github.com/edwardkim/rhwp/issues/4627)** — 표 바닥값
+  `effective_h = seg_lh.max(mt_h)` 가 `typeset.rs` 와 `pagination/engine.rs` 두 곳에 있다.
+- **[#4628](https://github.com/edwardkim/rhwp/issues/4628)** — 진단 출력이 프로덕션과 다른
+  높이를 말한다. `total_height` 가 자기 구성요소 합과 불일치하고, `dump-pages` 가 폴백 경로
+  값을 표시 없이 보고한다. **이 값이 이 사슬에서 조사를 두 번 오도했다.**
+- **[#4629](https://github.com/edwardkim/rhwp/issues/4629)** — 인라인 개체 캐럿 높이가
+  개체 크기와 무관한 상수 12.0. #4620 이 주장한 0 을 검증하다 나온 **진짜** 문제다.
+
+## 배정 이슈 넷을 닫은 근거
+
+- **#4620** — 소비자가 아무도 `TextLine.h` 를 안 읽는다(1,120건 전수, 캐럿 최솟값 12.0,
+  0 은 0건). 게다가 채우면 미주 진행·각주 마커 배치가 움직여 **해롭다**.
+- **#4619** — TAC-Shape 문단이 `PartialParagraph` 에 닿는 것은 문서 2개/조각 5개뿐이고
+  전부 실제 진행이 이미 바닥값을 넘어 이식이 no-op 이다. 게다가 `para_start_y` 미등록으로
+  순진한 이식은 확실한 회귀다. **#4333 의 한 단면으로 접었다.**
+- **#4604** — 문단 축에 살아 있는 소비자가 둘이 아니다. 통일은 프로덕션을 진단용에 맞추거나
+  두 번째 정의를 지우는 것뿐이고, 후자는 #4605(PR #4621)의 방향이다.
+- **#4606** — 5.6% 중 97.1% 가 `spacing_before` 이고, 렌더의 단 최상단 trim 은 한컴 정합을
+  위한 **설계**다. 단 중간 대조 실험에서 5.4% → **0.2%**.

--- a/src/document_core/commands/object_ops/picture.rs
+++ b/src/document_core/commands/object_ops/picture.rs
@@ -816,11 +816,7 @@ impl DocumentCore {
     fn tac_control_height_for_empty_picture_para(ctrl: &Control) -> Option<i32> {
         match ctrl {
             Control::Picture(pic) if pic.common.treat_as_char => Some(pic.common.height as i32),
-            Control::Shape(shape) if shape.common().treat_as_char => {
-                let common_h = shape.common().height as i32;
-                let current_h = shape.shape_attr().current_height as i32;
-                Some(common_h.max(current_h))
-            }
+            Control::Shape(shape) if shape.common().treat_as_char => Some(shape.flow_height_hu()),
             Control::Table(table) if table.common.treat_as_char => Some(table.common.height as i32),
             Control::Equation(eq) if eq.common.treat_as_char => Some(eq.common.height as i32),
             _ => None,

--- a/src/model/shape.rs
+++ b/src/model/shape.rs
@@ -466,6 +466,16 @@ impl ShapeObject {
         }
     }
 
+    /// 도형이 줄 흐름에서 차지하는 세로 범위 (HWPUNIT).
+    ///
+    /// 저장 프레임(`common.height`)과 개체 요소의 실제 표시 높이
+    /// (`shape_attr.current_height`)는 어긋날 수 있다 — 한글은 둘 중 큰 값을
+    /// 조판 높이로 쓴다. 조판·측정·렌더가 각자 이 식을 다시 쓰면 같은 속성에
+    /// 정의가 여러 벌 생기므로(#4333) 이 메서드가 유일한 정의다.
+    pub fn flow_height_hu(&self) -> i32 {
+        (self.common().height as i32).max(self.shape_attr().current_height as i32)
+    }
+
     /// 개체 요소 속성 가변 참조 반환
     pub fn shape_attr_mut(&mut self) -> &mut ShapeComponentAttr {
         match self {

--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -1060,11 +1060,7 @@ fn inline_control_line_height_hwp(para: &Paragraph) -> Option<i32> {
         .iter()
         .filter_map(|ctrl| match ctrl {
             Control::Picture(pic) if pic.common.treat_as_char => Some(pic.common.height as i32),
-            Control::Shape(shape) if shape.common().treat_as_char => {
-                let common_h = shape.common().height as i32;
-                let current_h = shape.shape_attr().current_height as i32;
-                Some(common_h.max(current_h))
-            }
+            Control::Shape(shape) if shape.common().treat_as_char => Some(shape.flow_height_hu()),
             Control::Table(table) if table.common.treat_as_char => Some(table.common.height as i32),
             Control::Equation(eq) if eq.common.treat_as_char => Some(eq.common.height as i32),
             Control::Form(form) => Some(form.height as i32),
@@ -1079,14 +1075,10 @@ fn inline_control_size_hwp(ctrl: &Control) -> Option<(i32, i32)> {
         Control::Picture(pic) if pic.common.treat_as_char => {
             (pic.common.width as i32, pic.common.height as i32)
         }
-        Control::Shape(shape) if shape.common().treat_as_char => {
-            let common = shape.common();
-            let shape_attr = shape.shape_attr();
-            (
-                (common.width as i32).max(shape_attr.current_width as i32),
-                (common.height as i32).max(shape_attr.current_height as i32),
-            )
-        }
+        Control::Shape(shape) if shape.common().treat_as_char => (
+            (shape.common().width as i32).max(shape.shape_attr().current_width as i32),
+            shape.flow_height_hu(),
+        ),
         Control::Table(table) if table.common.treat_as_char => {
             let width = table.get_column_widths().iter().sum::<u32>() as i32;
             (width, table.common.height as i32)

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -10636,9 +10636,7 @@ impl LayoutEngine {
                         self.compute_tac_pic_x(para, comp, styles, col_area, control_index);
                     let inline_x =
                         base_x + hwpunit_to_px(signed_hwpunit(common.horizontal_offset), self.dpi);
-                    let shape_attr = shape.shape_attr();
-                    let shape_h = hwpunit_to_px(common.height as i32, self.dpi)
-                        .max(hwpunit_to_px(shape_attr.current_height as i32, self.dpi));
+                    let shape_h = hwpunit_to_px(shape.flow_height_hu(), self.dpi);
                     let inline_y = self
                         .compute_tac_picture_shape_y(para, comp, styles, para_y, shape_h)
                         + hwpunit_to_px(signed_hwpunit(common.vertical_offset), self.dpi);

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -287,27 +287,6 @@ fn has_para_topbottom_float_affecting_column(
     .unwrap_or(false)
 }
 
-fn tac_picture_or_shape_height_for_line(
-    para: Option<&Paragraph>,
-    raw_line_height: f64,
-    dpi: f64,
-) -> Option<f64> {
-    let para = para?;
-    para.controls.iter().find_map(|ctrl| {
-        let height_hu = match ctrl {
-            Control::Picture(pic) if pic.common.treat_as_char => pic.common.height as i32,
-            Control::Shape(shape) if shape.common().treat_as_char => shape.flow_height_hu(),
-            _ => return None,
-        };
-        let height = hwpunit_to_px(height_hu, dpi);
-        if height > 8.0 && raw_line_height + 4.0 >= height && raw_line_height <= height + 8.0 {
-            Some(height)
-        } else {
-            None
-        }
-    })
-}
-
 fn is_treat_as_char_equation_control(ctrl: Option<&Control>) -> bool {
     matches!(ctrl, Some(Control::Equation(eq)) if eq.common.treat_as_char)
 }
@@ -684,15 +663,6 @@ fn repeated_empty_tac_line_offset(
     }
 }
 
-fn tac_picture_or_shape_height_px(ctrl: &Control, dpi: f64) -> Option<f64> {
-    let height_hu = match ctrl {
-        Control::Picture(pic) if pic.common.treat_as_char => pic.common.height as i32,
-        Control::Shape(shape) if shape.common().treat_as_char => shape.flow_height_hu(),
-        _ => return None,
-    };
-    Some(hwpunit_to_px(height_hu, dpi))
-}
-
 fn note_number_format_from_hwp_code(code: u8) -> NumFmt {
     match code {
         0 => NumFmt::Digit,
@@ -780,7 +750,7 @@ fn line_tac_picture_or_shape_height(
         .find_map(|(_, _, ci)| {
             para.controls
                 .get(*ci)
-                .and_then(|ctrl| tac_picture_or_shape_height_px(ctrl, dpi))
+                .and_then(|ctrl| crate::renderer::tac_object_flow_height_px(ctrl, dpi))
         })
 }
 
@@ -3194,19 +3164,19 @@ impl LayoutEngine {
                         })
                     })
                     .unwrap_or(false);
+            // 도형의 흐름 높이가 저장 프레임이 아니라 `current_height` 에서 오는 줄은
+            // 저장 줄 높이를 그대로 둔다 (아래 baseline 정렬 축소 제외).
             let empty_tac_guide_has_explicit_shape_height = empty_tac_guide_line
-                && para
-                    .map(|p| {
-                        line_tac_offsets.iter().any(|(_, _, ci)| {
-                            p.controls.get(*ci).is_some_and(|ctrl| match ctrl {
-                                Control::Shape(shape) if shape.common().treat_as_char => {
-                                    shape.flow_height_hu() > shape.common().height as i32
-                                }
-                                _ => false,
-                            })
+                && para.is_some_and(|p| {
+                    line_tac_offsets.iter().any(|(_, _, ci)| {
+                        p.controls.get(*ci).is_some_and(|ctrl| match ctrl {
+                            Control::Shape(shape) if shape.common().treat_as_char => {
+                                shape.flow_height_hu() > shape.common().height as i32
+                            }
+                            _ => false,
                         })
                     })
-                    .unwrap_or(false);
+                });
             let (line_height, baseline) = if text_before_picture_line {
                 let font_lh = max_fs.max(1.0);
                 let font_bl = max_fs * 0.85;
@@ -4270,8 +4240,9 @@ impl LayoutEngine {
                 && !text_before_picture_line
                 && current_line_reserved_tac_picture_height.is_none()
             {
-                current_line_reserved_tac_picture_height =
-                    tac_picture_or_shape_height_for_line(para, raw_lh, self.dpi);
+                current_line_reserved_tac_picture_height = para.and_then(|p| {
+                    crate::renderer::line_owning_tac_object_height_px(p, raw_lh, self.dpi)
+                });
                 if current_line_reserved_tac_picture_height.is_none()
                     && has_treat_as_char_picture_or_shape(para)
                     && max_fs > 0.0

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -3192,9 +3192,26 @@ impl LayoutEngine {
                 // raw_lh > 0*1.5 가 항상 참이라 font_lh=0 으로 퇴화해, 셀 내부
                 // tac 묶음 전용 문단의 저장 lh(예: 3401HU)가 소실되고 후속 블록이
                 // 통째로 당겨졌다 (3114781 p2 −33pt, 한글 2022 오라클 정합 확인).
-                // 본문(cell_ctx 없음)은 reserved/skip-advance 보상 기계가 이 축소값을
-                // 전제로 한컴 정합을 이미 이루고 있어(sample16 issue_1116 한컴 핀)
-                // 종전 동작을 유지한다.
+                // 본문(cell_ctx 없음)에서 max_fs=0 인 도형-전용 줄이 lh=0 으로 접히는 것은
+                // **의도된 짝**이다. 짝의 나머지 반쪽은 `layout_column_item` 의 TAC-Shape
+                // 높이 바닥값(`renderer/layout.rs:7037-7076`,
+                // `para_start + max(seg_lh, shape_max_h)`)이다 — 접힘이 줄 루프의 진행을
+                // 바닥값 아래로 눌러, 문단 진행을 바닥값이 지배하게 만든다. 한컴에 맞춰진
+                // 숫자는 그 바닥값(꼬리 줄간격을 포함하지 않는 값)이지 이 줄의 lh 가 아니다.
+                //
+                // 실측 (`samples/hwp3-sample16-hwp5.hwp` 구역0 문단71,
+                // `RHWP_DEBUG_PARA_TAC` + `RHWP_DEBUG_TAC_CURSOR`):
+                //   TAC_ADV    pi=71 raw_lh=130.2 lh=0.0 ls=10.4   ← 루프 내 진행은 10.4
+                //   TAC_CURSOR FullPara pi=71 dy=130.2            ← 바닥값이 문 결과
+                // 접힘만 없애면 루프 진행이 raw_lh+ls=140.6 으로 바닥값 130.2 를 넘어
+                // 문단이 정확히 `LineSeg.line_spacing`(10.4px) 만큼 밀리고,
+                // `tests/issue_1116.rs` 의 한컴 PDF 대조 핀 둘이 그만큼 깨진다.
+                //
+                // 보상자는 `HeightCursor::vpos_adjust` 가 **아니다** — 그 함수는 이 문단
+                // 다음 항목(pi=72)에서 `lazy_base < 0` 으로 조기 반환한다
+                // (`RHWP_VPOS_DEBUG` → `VPOS_CORR_SKIP: pi=72 ... lazy_base=-72`).
+                // 이 자리의 옛 주석이 "reserved/skip-advance 보상 기계"를 지목해 앞선
+                // 조사를 `vpos_adjust` 로 잘못 보냈다 (#4333).
                 let font_lh = max_fs * 1.2; // 폰트 크기의 120%
                 let font_bl = max_fs * 0.85;
                 (font_lh, ensure_min_baseline(font_bl, max_fs))

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -296,11 +296,7 @@ fn tac_picture_or_shape_height_for_line(
     para.controls.iter().find_map(|ctrl| {
         let height_hu = match ctrl {
             Control::Picture(pic) if pic.common.treat_as_char => pic.common.height as i32,
-            Control::Shape(shape) if shape.common().treat_as_char => {
-                let common_h = shape.common().height as i32;
-                let current_h = shape.shape_attr().current_height as i32;
-                common_h.max(current_h)
-            }
+            Control::Shape(shape) if shape.common().treat_as_char => shape.flow_height_hu(),
             _ => return None,
         };
         let height = hwpunit_to_px(height_hu, dpi);
@@ -691,11 +687,7 @@ fn repeated_empty_tac_line_offset(
 fn tac_picture_or_shape_height_px(ctrl: &Control, dpi: f64) -> Option<f64> {
     let height_hu = match ctrl {
         Control::Picture(pic) if pic.common.treat_as_char => pic.common.height as i32,
-        Control::Shape(shape) if shape.common().treat_as_char => {
-            let common_h = shape.common().height as i32;
-            let current_h = shape.shape_attr().current_height as i32;
-            common_h.max(current_h)
-        }
+        Control::Shape(shape) if shape.common().treat_as_char => shape.flow_height_hu(),
         _ => return None,
     };
     Some(hwpunit_to_px(height_hu, dpi))
@@ -3208,7 +3200,7 @@ impl LayoutEngine {
                         line_tac_offsets.iter().any(|(_, _, ci)| {
                             p.controls.get(*ci).is_some_and(|ctrl| match ctrl {
                                 Control::Shape(shape) if shape.common().treat_as_char => {
-                                    shape.shape_attr().current_height > shape.common().height
+                                    shape.flow_height_hu() > shape.common().height as i32
                                 }
                                 _ => false,
                             })
@@ -5316,9 +5308,7 @@ impl LayoutEngine {
                     if let Some(p) = para {
                         if let Some(Control::Shape(shape)) = p.controls.get(tac_ci) {
                             let common = shape.common();
-                            let shape_h_hu = (common.height as i32)
-                                .max(shape.shape_attr().current_height as i32);
-                            let shape_h = hwpunit_to_px(shape_h_hu, self.dpi);
+                            let shape_h = hwpunit_to_px(shape.flow_height_hu(), self.dpi);
                             if raw_lh + 4.0 >= shape_h {
                                 current_line_reserved_tac_picture_height = Some(shape_h);
                             }
@@ -6369,9 +6359,7 @@ impl LayoutEngine {
                         // #476 의 fallback 차단 분기로 박스가 누락된다.
                         if let Control::Shape(shape) = ctrl {
                             let common = shape.common();
-                            let shape_h_hu = (common.height as i32)
-                                .max(shape.shape_attr().current_height as i32);
-                            let shape_h = hwpunit_to_px(shape_h_hu, self.dpi);
+                            let shape_h = hwpunit_to_px(shape.flow_height_hu(), self.dpi);
                             let shape_y = (vars.y + vars.baseline - shape_h).max(vars.y);
                             tree.set_inline_shape_position(
                                 vars.section_index,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -973,6 +973,42 @@ pub(crate) fn first_seg_vpos_is_anchor(
         .is_some_and(|seg| cell_para_index == 0 || seg.vertical_pos > 0)
 }
 
+/// 글자처럼 취급되는(`treat_as_char`) 그림·도형이 줄 흐름에서 차지하는 높이(px).
+///
+/// 조판(`typeset`)과 렌더(`layout`)가 각자 이 식을 들고 있었고, 도형 쪽 정의가
+/// 서로 달랐다 — 렌더는 [`ShapeObject::flow_height_hu`], 조판은 저장 프레임만.
+/// 같은 속성의 정의는 하나여야 하므로(#4333) 두 경로가 이 함수를 공유한다.
+#[inline]
+pub(crate) fn tac_object_flow_height_px(
+    ctrl: &crate::model::control::Control,
+    dpi: f64,
+) -> Option<f64> {
+    use crate::model::control::Control;
+    let height_hu = match ctrl {
+        Control::Picture(pic) if pic.common.treat_as_char => pic.common.height as i32,
+        Control::Shape(shape) if shape.common().treat_as_char => shape.flow_height_hu(),
+        _ => return None,
+    };
+    Some(hwpunit_to_px(height_hu, dpi))
+}
+
+/// 저장 줄 높이가 문단의 인라인 개체 하나로 설명될 때, 그 개체의 흐름 높이(px).
+///
+/// "이 줄은 인라인 개체가 소유한 줄인가" 를 묻는 술어다. 조판과 렌더가 같은 줄에
+/// 같은 답을 내지 않으면 그 줄의 예약 높이가 갈리므로(#4333) 정의는 하나다.
+pub(crate) fn line_owning_tac_object_height_px(
+    para: &crate::model::paragraph::Paragraph,
+    raw_line_height: f64,
+    dpi: f64,
+) -> Option<f64> {
+    para.controls
+        .iter()
+        .filter_map(|ctrl| tac_object_flow_height_px(ctrl, dpi))
+        .find(|height| {
+            *height > 8.0 && raw_line_height + 4.0 >= *height && raw_line_height <= *height + 8.0
+        })
+}
+
 /// 셀의 저장 vpos 흐름이 문단 위치를 구분해 담고 있는지 ("사다리" 온전성).
 ///
 /// 셀 안 문단이 전부 `vpos == 0` 으로 저장된 문서(중첩 표 안쪽 셀에서 흔하다)에서는

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -1999,15 +1999,6 @@ fn line_has_tac_control(para: &Paragraph, comp: &ComposedParagraph, line_idx: us
     !tac_control_indices_for_line(para, comp, line_idx).is_empty()
 }
 
-fn tac_picture_or_shape_height_px(ctrl: &Control, dpi: f64) -> Option<f64> {
-    let height_hu = match ctrl {
-        Control::Picture(pic) if pic.common.treat_as_char => pic.common.height as i32,
-        Control::Shape(shape) if shape.common().treat_as_char => shape.common().height as i32,
-        _ => return None,
-    };
-    Some(hwpunit_to_px(height_hu, dpi))
-}
-
 fn line_tac_picture_or_shape_height(
     para: &Paragraph,
     comp: &ComposedParagraph,
@@ -2019,7 +2010,7 @@ fn line_tac_picture_or_shape_height(
         .find_map(|ci| {
             para.controls
                 .get(*ci)
-                .and_then(|ctrl| tac_picture_or_shape_height_px(ctrl, dpi))
+                .and_then(|ctrl| crate::renderer::tac_object_flow_height_px(ctrl, dpi))
         })
 }
 
@@ -9201,7 +9192,7 @@ impl TypesetEngine {
                 en_para
                     .controls
                     .iter()
-                    .filter_map(|ctrl| tac_picture_or_shape_height_px(ctrl, dpi))
+                    .filter_map(|ctrl| crate::renderer::tac_object_flow_height_px(ctrl, dpi))
                     .reduce(f64::max)
             } else {
                 None
@@ -10699,7 +10690,7 @@ impl TypesetEngine {
                                         .controls
                                         .iter()
                                         .filter_map(|ctrl| {
-                                            tac_picture_or_shape_height_px(ctrl, dpi)
+                                            crate::renderer::tac_object_flow_height_px(ctrl, dpi)
                                         })
                                         .reduce(f64::max)
                                 })
@@ -14481,7 +14472,9 @@ impl TypesetEngine {
                         .map(|(_, _, ci)| {
                             para.controls
                                 .get(*ci)
-                                .and_then(|c| tac_picture_or_shape_height_px(c, self.dpi))
+                                .and_then(|c| {
+                                    crate::renderer::tac_object_flow_height_px(c, self.dpi)
+                                })
                                 .unwrap_or(0.0)
                         })
                         .collect();
@@ -14532,23 +14525,8 @@ impl TypesetEngine {
                 let max_fs = crate::renderer::composed_line_max_font_size(line, para, styles);
                 let text_before_picture_line =
                     text_line_is_picture_lead_in(para, comp, line_idx, raw_lh, max_fs, self.dpi);
-                let tac_picture_height = para.controls.iter().find_map(|ctrl| {
-                    let height_hu = match ctrl {
-                        Control::Picture(pic) if pic.common.treat_as_char => {
-                            pic.common.height as i32
-                        }
-                        Control::Shape(shape) if shape.common().treat_as_char => {
-                            shape.common().height as i32
-                        }
-                        _ => return None,
-                    };
-                    let height = hwpunit_to_px(height_hu, self.dpi);
-                    if height > 8.0 && raw_lh + 4.0 >= height && raw_lh <= height + 8.0 {
-                        Some(height)
-                    } else {
-                        None
-                    }
-                });
+                let tac_picture_height =
+                    crate::renderer::line_owning_tac_object_height_px(para, raw_lh, self.dpi);
                 let tac_picture_height = if text_before_picture_line {
                     None
                 } else {
@@ -22903,6 +22881,71 @@ mod tests {
             margin_gutter: 0,
             ..Default::default()
         }
+    }
+
+    /// [#4333] 인라인(글자처럼) 도형의 흐름 높이는 조판과 렌더가 같은 정의를 써야 한다.
+    ///
+    /// 조판은 저장 프레임(`common.height`)만, 렌더는 프레임과 개체 표시 높이
+    /// (`shape_attr.current_height`) 중 큰 값을 썼다. samples/ 의 인라인 도형 868개
+    /// 가운데 354개(38개 문서)가 둘이 다르므로, 두 정의가 갈리면 그 줄의 예약 높이가
+    /// 조판과 렌더에서 달라진다. 두 경로가 `ShapeObject::flow_height_hu` 하나를 보는지
+    /// 확인한다 — 매직 넘버가 아니라 **두 정의가 같다**를 단언한다.
+    #[test]
+    fn typeset_and_render_agree_on_inline_shape_flow_height() {
+        use crate::model::shape::{RectangleShape, ShapeObject};
+
+        let dpi = 96.0;
+        let shape = ShapeObject::Rectangle(RectangleShape {
+            common: CommonObjAttr {
+                width: 20000,
+                height: 2400,
+                treat_as_char: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let mut shape = shape;
+        shape.shape_attr_mut().current_height = 4066;
+        let expected = crate::renderer::hwpunit_to_px(shape.flow_height_hu(), dpi);
+        assert!(
+            expected > crate::renderer::hwpunit_to_px(shape.common().height as i32, dpi),
+            "표본 전제: 개체 표시 높이가 저장 프레임보다 크다"
+        );
+
+        let para = Paragraph {
+            text: "\u{FFFC}".to_string(),
+            char_count: 1,
+            controls: vec![Control::Shape(Box::new(shape))],
+            ..Default::default()
+        };
+        let comp = ComposedParagraph {
+            lines: vec![crate::renderer::composer::ComposedLine {
+                runs: Vec::new(),
+                line_height: 4066,
+                baseline_distance: 0,
+                segment_width: 20000,
+                column_start: 0,
+                line_spacing: 0,
+                has_line_break: false,
+                char_start: 0,
+            }],
+            para_style_id: 0,
+            inline_controls: Vec::new(),
+            numbering_text: None,
+            tac_controls: vec![(0, 20000, 0)],
+            footnote_positions: Vec::new(),
+            tab_extended: Vec::new(),
+        };
+
+        // 조판(페이지네이션)이 이 줄에 예약하는 인라인 개체 높이.
+        let typeset_reserved = line_tac_picture_or_shape_height(&para, &comp, 0, dpi)
+            .expect("조판이 인라인 도형 줄을 인식해야 한다");
+        // 렌더가 인라인 도형을 배치할 때 쓰는 높이(같은 단일 정의).
+        let render_reserved = crate::renderer::tac_object_flow_height_px(&para.controls[0], dpi)
+            .expect("렌더가 인라인 도형 높이를 산출해야 한다");
+
+        assert_eq!(typeset_reserved, render_reserved);
+        assert_eq!(typeset_reserved, expected);
     }
 
     fn make_paragraph_with_height(line_height: i32) -> Paragraph {


### PR DESCRIPTION
이름이 같고 식이 다른 함수가 조판과 렌더에 각각 있었습니다.

```
typeset.rs:2002           tac_picture_or_shape_height_px → Shape: common().height
paragraph_layout.rs:694   tac_picture_or_shape_height_px → Shape: max(common.height, current_height)
```

`samples/` 의 인라인 도형 868개 중 **354개(38개 문서)** 가 `current_height != common.height` 라 두 답이 실제로 다릅니다. `max(...)` 사본이 다섯 벌 더 있었고, "이 줄이 인라인 개체에 속하는가" 술어도 중복이었습니다.

`ShapeObject::flow_height_hu()` 를 단일 정의로 두고 사본 7개를 대체한 뒤(동작 무변경), `renderer::tac_object_flow_height_px` 와 `renderer::line_owning_tac_object_height_px` 를 조판·렌더가 함께 쓰도록 하고 조판 쪽 사본을 지웠습니다.

```
$ grep -rn "shape_attr()\.current_height" --include="*.rs" src/
src/model/shape.rs:476:  (self.common().height as i32).max(self.shape_attr().current_height as i32)
```

한 곳입니다. 나머지 `shape_attr.current_height` 는 `Picture` 타입(자체 정의, `layout/utils.rs:65`)이거나 파서·직렬화기·편집 커맨드의 필드 접근입니다. `src/model/shape.rs` 는 `renderer` 에서 아무것도 import 하지 않습니다.

**#4333 을 닫지 않습니다 — 이슈의 진단이 틀렸고 코멘트로 정정했습니다.** 본문은 "측정용 높이 vs 렌더용 높이"가 갈린다고 했는데, 세 번째 열을 재보니 **측정과 조판은 소수점까지 일치**하고(발산 126행 전부) 0 을 내는 것은 렌더 쪽 한 줄입니다 — `paragraph_layout.rs:3228` 의 `let font_lh = max_fs * 1.2;` 로, `max_fs` 가 줄 run 에서만 나와 도형만 있는 줄은 0 이 됩니다. 그리고 프로덕션 페이지네이션은 `MeasuredSection.paragraphs` 를 **읽지 않습니다**(`rendering.rs:4260` vs `RHWP_USE_PAGINATOR` 폴백 `:4180`) — 이슈의 분해안 2 는 읽히지 않는 함수를 고치는 일이라 폐기했습니다.

렌더 쪽 수정도 구현해 재봤습니다 — 발산 126/142 → 8/142, 최대 739.32 → 19.61px, 쪽수 전부 불변. 그런데 `tests/issue_1116.rs` 의 한컴 PDF 대조 pin 둘이 정확히 **+10.4px** 로 깨집니다. `build_single_column` 의 `HeightCursor::vpos_adjust`(`layout.rs:5778`) 스냅과 이 접힘이 **짝으로 보정**돼 있어(`:3219-3227` 주석), 한쪽만 없애면 지표를 얻고 오라클을 잃습니다. 그래서 내지 않고 #4333 에 남겼습니다.

`cargo test --profile release-test --tests` exit 0 — `ok` 블록 536개, **5,763 passed / 0 FAILED**. fmt·clippy clean, Skia 3종(58/2/4), `wasm-pack build` OK.

**쪽수 스윕 355개 문서, `upstream/devel` 대비 차이 0.** 시각 증거는 인라인 도형이 있는 5쪽을 전후로 렌더해 **sha256 동일**을 확인했습니다(`draw-group_p0`, `sample16_p2`, `pyeonram_p163`, `pyeonram_p290`, `edu2022_p10`).

RED 는 조판 쪽 옛 헬퍼를 되돌려 받았습니다 — `left: 32.0`(common.height 2400HU) vs `right: 54.21`(current_height 4066HU).

이중 계상은 재검증했습니다 — `PageItem::Shape` 방출은 `st.current_height` 를 올리지 않고, `pushdown_h` 는 float 전용 게이트입니다. 쪽수가 어느 방향으로도 안 움직인 것이 그 확인입니다.

작업 중 나왔지만 손대지 않은 것은 #4604(문단 높이 두 정의의 나머지 축), #4605(`MeasuredSection.paragraphs` 가 죽어 수정 위치를 두 번 오도), #4606(PlainText 기저 발산 5.6%)로 열었습니다.

Refs #4333

---

## 추가 (2026-08-12) — 높이 정의 사슬 정리를 이 PR 에 얹었습니다

#4620·#4619·#4604·#4606 을 실측으로 판정한 결과 **넷 다 "고치지 않는다"** 로 닫혔고, 코드 변경은 주석 하나뿐이라 단독 PR 대신 같은 파일·같은 이슈를 다루는 이 PR 에 합쳤습니다.

**주석 정정** — `paragraph_layout.rs` 의 접힘 주석이 짝을 이루는 보정자를 "reserved/skip-advance 보상 기계"라고 적어 뒀는데, 실제 보정자는 `layout_column_item` 의 TAC-Shape 바닥값(`layout.rs:7037-7076`)입니다. **이 오기가 조사를 두 번 잘못된 곳으로 보냈습니다.**

**넷을 닫은 근거**

- **#4620** — 소비자가 아무도 `TextLine.h` 를 안 읽습니다. 텍스트 없는 인라인 개체 문단 **1,120건 전수**(줄이 접히는 유일한 부류인 TAC Shape 681건 포함)에서 캐럿 최솟값 12.0, **0 은 0건**. 캐럿은 개체 자신의 렌더 bbox 에서, 히트테스트는 `TextLine` 을 안 읽고, 선택 높이는 `left_hit` 에서 옵니다. **게다가 채우면 해롭습니다** — `bbox.height` 가 미주 진행과 각주 마커 배치를 먹입니다.
- **#4619** — 355개 문서 재스윕(첫 스윕은 `dump-pages` 가 레이아웃을 안 돌려 무효였습니다) 결과 TAC-Shape 문단이 `PartialParagraph` 에 닿는 것은 **문서 2개/조각 5개**뿐이고 전부 실제 진행이 이미 바닥값을 넘어 이식이 no-op 입니다. 게다가 `PartialParagraph` arm 은 `para_start_y` 를 등록하지 않아 순진한 이식은 **확실한 회귀**입니다. #4333 의 한 단면으로 접었습니다.
- **#4604** — 문단 축에 **살아 있는 소비자가 둘이 아닙니다.** `paginate_pass` 는 `measured.tables` 만 넘기고 `MeasuredSection.paragraphs` 는 폴백만 읽습니다. AB 발산이 큰 행들은 조판이 자기 `PageItem` 을 갖는 개체의 줄을 0 으로 만들고 중복 예약을 제거하는 것으로, **구성상 옳습니다** — 이중 예산이면 페이지네이션이 깨집니다.
- **#4606** — 5.6% 중 **97.1%가 `spacing_before`** 이고, 렌더의 단 최상단 trim 은 한컴 정합을 위한 **설계**입니다(측정기는 단 소속이 페이지네이션의 출력이라 구조적으로 못 합니다). 단 중간 대조 실험에서 PlainText **5.4% → 0.2%**, Equation **0.3% → 0.0%**. 진짜 기저선은 0.2%(252건)입니다.

**#4333 은 계속 열어 둡니다.** 남은 과제는 `stacked_tac_picture_heights` 의 렌더 쪽 대응물을 만드는 것인데, 그 술어 자체가 두 정의로 갈려 있어(#4626) **그것이 선행 조건**입니다.

**재구성 후 게이트 재실행** — 71 커밋 위로 올린 뒤 전부 다시 돌렸습니다. `release-test` `ok` 블록 **536개 / FAILED 0**, fmt·clippy clean, Skia 3종 exit 0(58/2/4), **`issue_1116` 13 passed / 0 failed**(두 pin 포함). 비주석 Rust diff 가 0이라 기하는 움직일 수 없어 쪽수 스윕·시각 비교는 해당 없습니다.

작업 중 발견했지만 배정 범위 밖이라 **고치지 않고** 이슈로 낸 것: #4625(TAC 바닥값만 다른 식을 쓰고 이 PR 의 통일 대상에서 빠짐), #4626(#4333 의 선행 조건), #4627, #4628, #4629.
