### PR TITLE
ci: 완료된 stale run 취소 오류를 재조회로 처리

### DIFF
--- a/.github/workflows/cancel-stale-pr-runs.yml
+++ b/.github/workflows/cancel-stale-pr-runs.yml
@@ -123,9 +123,9 @@ jobs:
                   },
                 );
               } catch (error) {
-                // 목록을 읽은 뒤 API를 호출하는 사이 대상이 스스로 끝나면 GitHub가 409을
-                // 돌려준다. 다시 조회해 completed임을 확인한 경우만 정상 경과로 취급한다.
-                if (error.status !== 409) throw error;
+                // 대상이 취소되거나 스스로 끝난 뒤 GitHub API가 409뿐 아니라 5xx를
+                // 반환할 수 있다. 응답 코드를 성공으로 간주하지 말고, 대상 run을 다시
+                // 읽어 실제로 completed인 경우만 정상 경과로 취급한다.
                 const { data: currentRun } = await github.rest.actions.getWorkflowRun({
                   owner,
                   repo,
@@ -133,7 +133,7 @@ jobs:
                 });
                 if (currentRun.status !== 'completed') throw error;
                 core.info(
-                  `Skip stale run ${run.id} (${run.name}): already completed (${currentRun.conclusion ?? 'unknown'}).`,
+                  `Skip stale run ${run.id} (${run.name}): already completed after force-cancel error ${error.status ?? 'unknown'} (${currentRun.conclusion ?? 'unknown'}).`,
                 );
                 continue;
               }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -825,6 +825,7 @@ jobs:
       - name: Validate workflow contracts
         run: |
           python3 -m unittest scripts/tests/test_cache_sweep_workflow.py
+          python3 -m unittest scripts/tests/test_cancel_stale_pr_runs_workflow.py
           python3 -m unittest scripts/tests/test_codeql_workflow.py
           python3 -m unittest scripts/tests/test_docker_publish_workflow.py
           python3 -m unittest scripts/tests/test_release_installers_workflow.py

--- a/mydocs/orders/20260811.md
+++ b/mydocs/orders/20260811.md
@@ -7,6 +7,17 @@
 | [#3790](https://github.com/edwardkim/rhwp/issues/3790) | Stage 5B CodeQL 언어별 선택 실행 | 진행중 | Draft PR #4519 최신 devel 반영·reviewer `edwardkim` 지정·검토 기록 완료; 최종 full CI·CodeQL 확인 대기 |
 | [#4586](https://github.com/edwardkim/rhwp/issues/4586) | gym T12 HWPX 형식·판정 계약 보정 | PR #4598 self-review | T12 focused 2/2, release-test 5,763/5,763와 initial code candidate Full CI 통과; review-only 기록 push 준비 |
 
+## PR #4609 - stale run 취소 완료 race 보정
+
+- [PR #4609](https://github.com/edwardkim/rhwp/pull/4609)은 [#4608](https://github.com/edwardkim/rhwp/issues/4608)을
+  해결한다. GitHub `force-cancel`이 500을 반환해도 대상 run이 실제 `completed`이면 정상 경과로 처리하고,
+  active 대상 또는 재조회 실패는 계속 오류로 남긴다.
+- code candidate `81603f81d`에서 stale run workflow contract 4건, CI impact workflow contract 27건과
+  `git diff --check`를 통과했다. Rust·renderer·WASM 구현은 변경하지 않아 전체 Cargo 회귀와 시각 검증은
+  범위 밖이다.
+- [검토 기록](../pr/archives/pr_4609_review.md)을 같은 PR diff에 포함한다. 최신 head의 Full CI와 CodeQL이
+  통과하면 작업지시자 승인 뒤 merge하고 issue close 상태와 branch 정리를 수행한다.
+
 ## PR #4602 - Subsecond 핫패치 4개 원 PR 통합
 
 - [PR #4602](https://github.com/edwardkim/rhwp/pull/4602)는 [#4576](https://github.com/edwardkim/rhwp/issues/4576),

--- a/mydocs/pr/archives/pr_4609_review.md
+++ b/mydocs/pr/archives/pr_4609_review.md
@@ -1,0 +1,54 @@
+---
+kind: pr-review
+status: pending-ci
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-11
+---
+
+# PR #4609 리뷰 - 완료된 stale run 취소 오류 재조회
+
+## 라우팅과 접수
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, local_validation.md
+```
+
+| 항목 | 문서 작성 시점 참고값 |
+| --- | --- |
+| PR | [#4609](https://github.com/edwardkim/rhwp/pull/4609) |
+| 관련 이슈 | [#4608](https://github.com/edwardkim/rhwp/issues/4608) |
+| 작성자 | `jangster77` |
+| base | `devel` / `14cb775cdad4b013bbe00fc2872dcb8eba13806b` |
+| code candidate | `81603f81d04cd83b0903396cabe3b64e58e0fae8` |
+| trailing review head | 이 문서와 오늘할일을 포함한 후속 docs-only commit |
+| 변경 범위 | stale run 취소 workflow, CI contract 배선, Python workflow contract test |
+| reviewer request | 작성자와 self-review 담당이 같아 비어 있음 |
+
+## 변경 판단
+
+[PR #4602 stale cancel job](https://github.com/edwardkim/rhwp/actions/runs/31494843278/job/93789854722)은 이전
+run을 실제로 취소했지만 GitHub REST endpoint가 같은 요청에 500을 반환해 housekeeping workflow가 실패했다.
+
+이 PR은 오류 상태 코드를 성공으로 허용하지 않는다. `force-cancel` 오류 뒤 대상 workflow run을 다시 읽고,
+실제 상태가 `completed`일 때만 정상 경과로 기록한다. 대상이 아직 active이거나 재조회 자체가 실패하면 원래
+오류를 계속 전파하므로 실제 stale run 정리 실패는 숨기지 않는다.
+
+정적 contract test가 기존 `409` 단독 예외를 금지하고, 재조회·active 상태 오류 전파·completed 기록 순서를
+검증한다. 해당 test는 CI Lint job의 workflow contract 단계에 배선했다.
+
+## 완료한 검증
+
+- `python3 -m unittest scripts/tests/test_cancel_stale_pr_runs_workflow.py scripts/tests/test_workflow_contract_wiring.py`:
+  4건 통과.
+- `python3 -m unittest scripts/tests/test_ci_impact_workflow.py`: 27건 통과.
+- `git diff --check`: 통과.
+
+Rust, renderer, WASM 구현과 sample은 변경하지 않았다. 따라서 전체 Cargo 회귀와 시각 검증은 범위 밖이며,
+workflow 변경의 실제 event·권한 경계 검증은 최신 PR head의 GitHub Actions가 담당한다.
+
+## 최종 권고
+
+**현재는 CI 대기.** 최신 head의 Full CI와 CodeQL이 통과하고 작업지시자가 승인하면 수용한다. merge 뒤에는
+[#4608](https://github.com/edwardkim/rhwp/issues/4608)의 자동 close 상태와 integration branch 정리를
+`post_merge.md` 절차로 확인한다.

--- a/scripts/tests/test_cancel_stale_pr_runs_workflow.py
+++ b/scripts/tests/test_cancel_stale_pr_runs_workflow.py
@@ -1,0 +1,36 @@
+"""stale PR run 취소 workflow의 완료 race 처리 계약을 검증한다."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github/workflows/cancel-stale-pr-runs.yml"
+
+
+class CancelStalePrRunsWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_force_cancel_error_rechecks_completed_target(self):
+        """500 등 응답 코드가 아니라 대상 run의 실제 완료 상태로 race를 판정한다."""
+        body = self.workflow
+        self.assertNotIn("if (error.status !== 409) throw error;", body)
+
+        catch_start = body.index("} catch (error) {")
+        reread = body.index("github.rest.actions.getWorkflowRun", catch_start)
+        active_failure = body.index(
+            "if (currentRun.status !== 'completed') throw error;", reread
+        )
+        completed_notice = body.index("already completed after force-cancel error", active_failure)
+
+        self.assertLess(catch_start, reread)
+        self.assertLess(reread, active_failure)
+        self.assertLess(active_failure, completed_notice)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

Closes #4608.

stale PR run을 force-cancel한 뒤 대상이 실제로 `completed`됐어도 GitHub REST API가 `500 Failed to cancel workflow run`을 반환하는 race를 처리한다.

- 오류 상태 코드를 성공으로 허용하지 않는다.
- force-cancel 오류 뒤 대상 run을 재조회한다.
- 대상이 `completed`일 때만 정상 경과로 기록한다.
- 대상이 active이거나 재조회가 실패하면 기존처럼 오류를 전파한다.
- workflow 계약 테스트를 추가하고 Lint의 contract gate에 배선한다.

## 근거

[PR #4602 stale cancel job](https://github.com/edwardkim/rhwp/actions/runs/31494843278/job/93789854722)에서 이전 run `31494777677`이 실제 `cancelled` 상태가 됐지만, 같은 force-cancel 요청은 500을 반환해 housekeeping workflow가 실패했다.

## 로컬 검증

- `python3 -m unittest scripts/tests/test_cancel_stale_pr_runs_workflow.py scripts/tests/test_workflow_contract_wiring.py`
- `python3 -m unittest scripts/tests/test_ci_impact_workflow.py`
- `git diff --check`

workflow 변경이므로 최신 head의 GitHub Actions가 실제 event·권한 경계에서 이 계약을 다시 검증한다.
