### PR TITLE
fix(renderer): 공백-전용 TAC 캐리어 문단을 저장 vpos 로 페인트 변위한다

### DIFF
--- a/mydocs/working/task_m100_4610_stage1.md
+++ b/mydocs/working/task_m100_4610_stage1.md
@@ -1,0 +1,100 @@
+# Task #4610 Stage 1 — 공백-전용 TAC 캐리어 문단 페인트 변위
+
+Issue: #4610 (#4599 캠페인 Phase 3, ④ 계열 1차 사이클)
+Branch: `fix/4610-whitespace-tac-carrier-paint-y` (base: devel 572786d02)
+
+## 무엇을
+
+서울시 결재문서 템플릿에서 공백 텍스트만으로 treat_as_char 표(문서번호란 1×2 등)를
+실어 나르는 문단이, 선행 문단이 앵커한 자리차지(TopAndBottom) 표에 밀려 표 하단
+아래로 렌더되던 결함을 고쳤다. 렌더 y 만 저장 lineseg vpos 위치(표 위 틈)로 되돌리고
+흐름 전진량은 보존하는 페인트 변위 계약을 추가했다.
+
+- `src/renderer/layout.rs` — 게이트 `whitespace_tac_carrier_stored_paint_y` +
+  FullParagraph 두 배치 경로(일반 `layout_paragraph` / `layout_inline_table_paragraph`)에
+  페인트-흐름 분리 적용
+- `src/renderer/layout/tests.rs` — 게이트 단위 테스트 7종
+
+## 왜 (실측 근거)
+
+야간방호일지 36374873 p1 — #4599 Phase 1b CONFIRMED 최대 편차(821.6px) 대표:
+
+- 한글 2022 캐시 PDF: 문서번호 1×2 표가 결재란(3×4 TAC) 아래·본표(13×8 자리차지) 위
+  틈 y≈265.6 에 위치. 저장 lineseg(pi4 seg0 vpos=13575 → y 256.6)도 같은 위치 증언.
+- 종전 rhwp: 자리차지 표가 흐름 커서를 표 하단(≈1064)까지 밀어 pi4 전체가 y≈1085
+  → 문서번호 표 821px 하방. 꼬리 문단(pi5~7)은 PDF 와 정합(frame +2.1px)이므로
+  흐름 전진은 유지해야 한다 — 페인트 변위로 좁힌 이유.
+
+한글 2022 의 실제 규칙은 TopAndBottom 자리차지 표 뒤의 줄 단위 band-flow(틈에 들어가는
+줄은 틈에 배치)이지만, 전면 도입은 #3386 전면 스냅 반증 이력과 같은 회귀 위험이 있어
+시각 결함의 실체(공백-전용 TAC 캐리어)로 서명-한정했다.
+
+## 게이트 (서명-한정·방향-한정)
+
+1. hwpx stored layout 프로파일
+2. 공백-전용 문단 (시각 문자는 있으나 비공백 문자 없음)
+3. 컨트롤이 treat_as_char 표 정확히 1개 (float host·그림/도형 문단 제외)
+4. 모든 lineseg 저장-태그 (합성 사다리 제외)
+5. 문단-내 세그 간 간격 > 7500HU(100px) — 저장 당시 레이아웃의 개체 밴드 증거.
+   낡은 세대 사다리(#4599 QUIET 47 의 문단 간격 누락류, 13.3px 스케일)는 이런
+   거대 간격을 만들지 않는다.
+6. TAC 가 첫 줄에 탑승 (comp.tac_controls[0].pos < seg1.text_start)
+7. 후방 변위만: 흐름 − 저장 y ≥ 세그 간 간격 × 0.5
+
+## 검증 실측
+
+### 대상 문서 (야간방호일지 36374873)
+
+| 항목 | 종전 | 수정 후 | 오라클 |
+|---|---|---|---|
+| 문서번호 1×2 표 y | 1079.5 | **263.1** | PDF 265.6 / 사다리 256.6+om |
+| pi5~7 (붙임 꼬리) | 1146.8/1168.1/1189.5 | 동일 (불변) | PDF frame +2.1 정합 |
+| phase1b 판정 | CONFIRMED maxdev 821.6 | **WEAK maxdev 5.2** (n=19 동일) | |
+
+### 게이트 단위 테스트
+
+`cargo test --release --lib whitespace_tac_carrier` — **7 passed / 0 failed** (되돌림
+정위치 / 프로파일·본문 텍스트·float host·소간격(낡은 사다리)·전방 변위·합성 세그 거부)
+
+### hwpx 3418 스윕 (baseline 클린 devel 572786d02 vs 수정판)
+
+`sweep_combo.py`(vld_guarded 판정 + 표 지오메트리 서명, 캠페인 홈에 보존) — baseline 은
+worktree 클린 빌드(가드레일: 기존 바이너리 재사용 금지 준수).
+
+- 판정 분포 동일: DRIFT 244 / OK 2561 / SKIP 604 / ERR 9 (전후 완전 일치, 이동 0건)
+- worst_px +2px 초과 악화 **0건**, 개선 0건
+- 야간방호일지가 DRIFT 로 남는 것은 예상 동작 — 검출기는 렌더 vs 저장 사다리를 재는데
+  비가시 공백 줄(pi3)은 흐름 유지를 위해 이동하지 않았다. 실물 판정은 PDF 대조가 정본
+  (CONFIRMED→WEAK).
+
+산출물: `_oracle_pdf_2022/sweep3418_5727_base_combo.tsv` · `sweep3418_4610fix_combo.tsv`
+
+### 전수 Table-diff (표 지오메트리 서명 비교)
+
+전 3418 문서의 모든 Table 노드 y/x/h/w 서명 비교 — **변동 1건: 야간방호일지 36374873**
+(의도된 수정 대상). 그 외 표 이동 문서 없음.
+
+### #4599 Phase 1b 재판정 (backlog 242)
+
+`phase1b_confirm.py` 를 수정 바이너리로 재실행 (입력·판정 규약 동일):
+
+- **이동 1건**: 야간방호일지 36374873 CONFIRMED(maxdev 821.6) → WEAK(5.2)
+- **불변 241건**, 비CONFIRMED→CONFIRMED 0건, maxdev +15px 이상 증가 0건
+
+서명-한정 게이트가 의도대로 대상 형상에만 개입함을 확인. SWAP 형상 군집의 나머지
+CONFIRMED 는 하위 형상이 달라(비공백 캐리어 등) 별도 사이클 대상.
+
+### 시각 증적 (SVG 전후)
+
+`export-svg -p 0` — 1×2 문서번호 표 테두리 요소(x=79.36): baseline y=**1079.49** →
+수정 y=**263.07** (PDF 실측 265.6 과 2.5px 이내, 문서 전역 frame +2.1px 감안 시 정합).
+꼬리 문단 요소들의 y 는 전후 동일.
+
+### 저장소 게이트
+
+- cargo fmt --check: 통과 (변경 파일 포맷 적용 후 무출력)
+- cargo clippy --release: 경고 0
+- cargo test --release 전체: exit 0 (lib 3505 passed / 0 failed / 13 ignored,
+  통합 테스트 타깃 전부 ok)
+- wasm-pack build --target web: 성공 (exit 0)
+- 시각 증적: SVG 전후 비교 (위 절)

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -798,6 +798,75 @@ fn para_has_non_whitespace_text(para: &Paragraph) -> bool {
         .any(|c| c > '\u{001F}' && c != '\u{FFFC}' && !c.is_whitespace())
 }
 
+/// [#4610 · #4599 ④] 결재문서 템플릿의 공백-전용 TAC 캐리어 문단 페인트 변위.
+///
+/// 선행 문단이 앵커한 자리차지 표가 흐름 커서를 표 하단까지 밀어낸 뒤에 오는,
+/// 공백 텍스트만으로 treat_as_char 표(문서번호란 등)를 실어 나르는 문단은 한글
+/// 2022 가 첫 줄을 표 위 틈의 저장 vpos 위치에 그대로 둔다 (야간방호일지
+/// 36374873 p1 pi4: 1×2 표 저장 vpos 13575 → y 256.6, 한글 PDF 실측 265.6 —
+/// 종전 rhwp 는 1085 로 821px 하방). 저장 사다리가 문단 안에서 100px 이상의
+/// 세그 간 간격(=저장 당시 레이아웃의 개체 밴드 증거)을 남긴 경우로 한정해
+/// 렌더 y 만 저장 위치로 되돌린다 — 흐름 전진은 호출부가 보존한다. 낡은
+/// 세대의 사다리(#4599 QUIET 47 의 문단 간격 누락류)는 문단-내 거대 간격을
+/// 만들지 않으므로 이 게이트에 걸리지 않는다.
+fn whitespace_tac_carrier_stored_paint_y(
+    hwpx_stored_layout: bool,
+    para: &Paragraph,
+    composed: Option<&ComposedParagraph>,
+    col_area_y: f64,
+    flow_y: f64,
+    dpi: f64,
+) -> Option<f64> {
+    if !hwpx_stored_layout || !para_has_visible_text(para) || para_has_non_whitespace_text(para) {
+        return None;
+    }
+    // 컨트롤은 treat_as_char 표 1개뿐이어야 한다 — float host·그림/도형 문단 제외.
+    let mut tac_tables = 0usize;
+    for ctrl in &para.controls {
+        match ctrl {
+            Control::Table(t) if t.common.treat_as_char => tac_tables += 1,
+            _ => return None,
+        }
+    }
+    if tac_tables != 1 {
+        return None;
+    }
+    let segs = &para.line_segs;
+    if segs.len() < 2
+        || segs
+            .iter()
+            .any(|s| s.tag & crate::model::paragraph::LineSeg::TAG_IMPLEMENTATION_PROPERTY != 0)
+    {
+        return None;
+    }
+    let (s0, s1) = (&segs[0], &segs[1]);
+    if s0.vertical_pos < 0 {
+        return None;
+    }
+    // 문단 내 저장 세그 간 간격 — 저장 당시 레이아웃의 개체 밴드 증거 (>100px).
+    let intra_gap_hu = s1.vertical_pos as i64 - s0.vertical_pos as i64 - s0.line_height as i64;
+    if intra_gap_hu < 7500 {
+        return None;
+    }
+    // TAC 는 첫 줄에 타야 한다 (공백 전용 문단이라 char/UTF-16 인덱스 동일).
+    if let Some(comp) = composed {
+        if comp
+            .tac_controls
+            .first()
+            .is_some_and(|(pos, _, _)| *pos >= s1.text_start as usize)
+        {
+            return None;
+        }
+    }
+    let stored_y = col_area_y + hwpunit_to_px(s0.vertical_pos, dpi);
+    let intra_gap_px = hwpunit_to_px(intra_gap_hu as i32, dpi);
+    // 방향-한정: 흐름이 저장 위치보다 저장 간격 절반 이상 아래로 밀렸을 때만 되돌린다.
+    if stored_y < col_area_y - 0.5 || flow_y - stored_y < intra_gap_px * 0.5 {
+        return None;
+    }
+    Some(stored_y)
+}
+
 fn repeats_native_empty_host_rowbreak_fragment_margin(
     native_hwp5_layout: bool,
     paragraphs: &[Paragraph],
@@ -6950,19 +7019,35 @@ impl LayoutEngine {
                         );
                         para_start_y.insert(*para_index, y_offset);
                         let para_flow_start = y_offset;
-                        y_offset = self.layout_inline_table_paragraph(
+                        // [#4610 · #4599 ④] 공백-전용 TAC 캐리어 문단의 페인트 변위 —
+                        // 렌더 y 만 저장 vpos 로 되돌리고 흐름 전진량은 보존한다.
+                        let paint_y = whitespace_tac_carrier_stored_paint_y(
+                            self.profile.get().hwpx_stored_layout(),
+                            para,
+                            composed.get(*para_index),
+                            col_area.y,
+                            y_offset,
+                            self.dpi,
+                        )
+                        .unwrap_or(y_offset);
+                        let inline_flow_end = self.layout_inline_table_paragraph(
                             tree,
                             col_node,
                             para,
                             composed.get(*para_index),
                             styles,
                             col_area,
-                            y_offset,
+                            paint_y,
                             page_content.section_index,
                             *para_index,
                             bin_data_content,
                             measured_tables,
                         );
+                        y_offset = if paint_y < para_flow_start {
+                            para_flow_start + (inline_flow_end - paint_y).max(0.0)
+                        } else {
+                            inline_flow_end
+                        };
                         // [#4532 기전 2호] 저장 lineseg 한 줄(표를 품는 거대 lh)을
                         // 재래핑이 여러 줄로 쪼개면 줄마다 lh 를 상속해 흐름이 배로
                         // 붊(사천시 21606965: 401.1px = 사다리 206.4 의 2배). 채택된
@@ -7019,20 +7104,37 @@ impl LayoutEngine {
                         let final_comp = numbered_comp.as_ref().or(comp);
 
                         para_start_y.insert(*para_index, y_offset);
-                        y_offset = self.layout_paragraph(
+                        // [#4610 · #4599 ④] 공백-전용 TAC 캐리어 문단은 렌더 y 만 저장 vpos 로
+                        // 되돌리고(paint 변위) 흐름 전진량은 변위 전과 동일하게 보존한다
+                        // — 후속 문단(야간방호일지 pi5~7, PDF 실측 정합)은 움직이지 않는다.
+                        let paint_y = whitespace_tac_carrier_stored_paint_y(
+                            self.profile.get().hwpx_stored_layout(),
+                            para,
+                            final_comp,
+                            col_area.y,
+                            y_offset,
+                            self.dpi,
+                        )
+                        .unwrap_or(y_offset);
+                        let flow_end = self.layout_paragraph(
                             tree,
                             col_node,
                             para,
                             final_comp,
                             styles,
                             col_area,
-                            y_offset,
+                            paint_y,
                             page_content.section_index,
                             *para_index,
                             multi_col_width,
                             Some(bin_data_content),
                             ctx.wrap_anchors.get(para_index),
                         );
+                        y_offset = if paint_y < y_offset {
+                            y_offset + (flow_end - paint_y).max(0.0)
+                        } else {
+                            flow_end
+                        };
                     }
                     // TAC Shape 높이 보정: 문단에 TAC Shape(개체묶기 등)가 있으면
                     // Shape 높이가 문단 텍스트 높이보다 클 수 있으므로 y_offset을 보정.

--- a/src/renderer/layout/tests.rs
+++ b/src/renderer/layout/tests.rs
@@ -2921,3 +2921,115 @@ fn collect_top_level_table_spans_domain() {
          (중첩 표 999·비가시 표 555 는 제외)"
     );
 }
+
+// ── [#4610 · #4599 ④] 공백-전용 TAC 캐리어 문단 페인트 변위 게이트 ──
+
+/// 야간방호일지 36374873 p1 pi4 형상: 공백 텍스트 + TAC 표 1개 + 저장 세그 2개가
+/// 문단 안에서 개체 밴드만큼(>100px) 벌어진 캐리어.
+fn whitespace_tac_carrier_para() -> Paragraph {
+    Paragraph {
+        text: " \u{FFFC} ".repeat(4),
+        controls: vec![Control::Table(Box::new(Table {
+            common: CommonObjAttr {
+                treat_as_char: true,
+                width: 19_000,
+                height: 1_800,
+                ..Default::default()
+            },
+            ..Default::default()
+        }))],
+        line_segs: vec![
+            LineSeg {
+                vertical_pos: 13_575,
+                line_height: 2_414,
+                text_start: 0,
+                ..Default::default()
+            },
+            LineSeg {
+                vertical_pos: 67_877,
+                line_height: 1_000,
+                text_start: 6,
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn whitespace_tac_carrier_paint_y_rewinds_to_stored_vpos() {
+    let para = whitespace_tac_carrier_para();
+    // 흐름 커서가 선행 자리차지 표 하단(1064px)까지 밀린 상태 — 저장 위치로 되돌린다.
+    let got = whitespace_tac_carrier_stored_paint_y(true, &para, None, 75.6, 1064.0, 96.0);
+    let expected = 75.6 + 13_575.0 / 75.0;
+    assert!((got.unwrap() - expected).abs() < 0.1, "got {got:?}");
+}
+
+#[test]
+fn whitespace_tac_carrier_paint_y_requires_hwpx_stored_profile() {
+    let para = whitespace_tac_carrier_para();
+    assert_eq!(
+        whitespace_tac_carrier_stored_paint_y(false, &para, None, 75.6, 1064.0, 96.0),
+        None
+    );
+}
+
+#[test]
+fn whitespace_tac_carrier_paint_y_rejects_substantive_text_host() {
+    let mut para = whitespace_tac_carrier_para();
+    para.text = "본문 텍스트".into();
+    assert_eq!(
+        whitespace_tac_carrier_stored_paint_y(true, &para, None, 75.6, 1064.0, 96.0),
+        None
+    );
+}
+
+#[test]
+fn whitespace_tac_carrier_paint_y_rejects_float_host_para() {
+    // 자리차지(비-TAC) 표를 함께 앵커한 host 문단은 기존 float 계약 소관 — 제외.
+    let mut para = whitespace_tac_carrier_para();
+    para.controls.push(Control::Table(Box::new(Table {
+        common: CommonObjAttr {
+            treat_as_char: false,
+            text_wrap: TextWrap::TopAndBottom,
+            ..Default::default()
+        },
+        ..Default::default()
+    })));
+    assert_eq!(
+        whitespace_tac_carrier_stored_paint_y(true, &para, None, 75.6, 1064.0, 96.0),
+        None
+    );
+}
+
+#[test]
+fn whitespace_tac_carrier_paint_y_rejects_small_intra_gap() {
+    // 낡은 세대 사다리(문단 간격 누락류)는 문단-내 거대 간격을 만들지 않는다 —
+    // 세그 간 간격이 100px(7500HU) 미만이면 무동작.
+    let mut para = whitespace_tac_carrier_para();
+    para.line_segs[1].vertical_pos = 13_575 + 2_414 + 7_000;
+    assert_eq!(
+        whitespace_tac_carrier_stored_paint_y(true, &para, None, 75.6, 1064.0, 96.0),
+        None
+    );
+}
+
+#[test]
+fn whitespace_tac_carrier_paint_y_rejects_forward_displacement() {
+    // 방향-한정: 흐름이 저장 위치보다 아래로 충분히 밀렸을 때만 되돌린다.
+    let para = whitespace_tac_carrier_para();
+    assert_eq!(
+        whitespace_tac_carrier_stored_paint_y(true, &para, None, 75.6, 200.0, 96.0),
+        None
+    );
+}
+
+#[test]
+fn whitespace_tac_carrier_paint_y_rejects_synthetic_segs() {
+    let mut para = whitespace_tac_carrier_para();
+    para.line_segs[0].tag |= crate::model::paragraph::LineSeg::TAG_IMPLEMENTATION_PROPERTY;
+    assert_eq!(
+        whitespace_tac_carrier_stored_paint_y(true, &para, None, 75.6, 1064.0, 96.0),
+        None
+    );
+}


### PR DESCRIPTION
## 변경 요약

서울시 결재문서 템플릿에서, 선행 문단이 앵커한 자리차지(TopAndBottom) 표가 흐름 커서를
표 하단까지 밀어내면 공백 텍스트만으로 treat_as_char 표를 실어 나르는 문단(문서번호란
1×2 등)이 표 아래로 렌더되던 결함을 고칩니다.

- 실측: 야간방호일지 36374873 p1 — 문서번호 표가 **821px 하방** (한글 2022 캐시 PDF
  y≈265.6, 저장 lineseg vpos=13575 → y 256.6 동일 증언; 종전 rhwp 1085).
- 수정: `whitespace_tac_carrier_stored_paint_y` 게이트(서명-한정·방향-한정 — hwpx stored
  layout · 공백-전용 문단 · TAC 표 1개 · 전 세그 저장-태그 · 문단-내 세그 간 간격
  >7500HU(저장 당시 개체 밴드 증거) · 후방 변위)가 성립할 때만 **렌더 y 를 저장 vpos
  위치로 되돌리고 흐름 전진량은 보존**합니다. PDF 정합이 확인된 후속 문단(pi5~7)은
  움직이지 않습니다.
- 낡은 세대 사다리(#4599 QUIET 47, 문단 간격 누락 13.3px 스케일)는 문단-내 거대 간격을
  만들지 않아 게이트에 걸리지 않습니다.

수정 후: 문서번호 표 y 263.1 (PDF 265.6, 전역 frame +2.1px 감안 시 정합),
phase1b PDF 대조 **CONFIRMED(maxdev 821.6) → WEAK(5.2)**.

상세 분석·검증 실측: `mydocs/working/task_m100_4610_stage1.md`

## 관련 이슈

closes #4610

관련: #4599 (hwpx 사다리 드리프트 캠페인 Phase 3, ④ 계열 1차 사이클) · #4533

## 테스트

- [x] `cargo test` 통과 — `cargo test --release` 전체 exit 0 (lib 3505 passed / 0 failed,
      게이트 단위 테스트 7종 포함)
- [x] `cargo clippy -- -D warnings` 통과 (경고 0)
- [x] 관련 샘플 파일로 SVG 내보내기 확인 — 1×2 표 테두리(x=79.36) y 1079.49→263.07,
      꼬리 문단 요소 전후 동일
- [x] 웹(WASM) 렌더링 확인 (해당하는 경우) — `wasm-pack build --target web` 성공
- [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부 — 코드 변경으로 문서 편집 캡슐 해당 없음.
      대신 회귀 스윕 산출물을 캠페인 데이터 홈(`_oracle_pdf_2022/`)에 보존:
      `sweep3418_5727_base_combo.tsv` · `sweep3418_4610fix_combo.tsv` · `phase1b_fix4610_242.tsv`
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시 — 해당 없음

추가 회귀 검증 (#4599 가드레일 3종):

- hwpx 3418 스윕 (baseline: devel 572786d02 클린 worktree 빌드) — 판정 이동 0건,
  worst +2px 초과 악화 0건
- 전수 Table-diff (전 문서 Table 노드 y/x/h/w 서명) — 변동 1건: 수정 대상 문서뿐
- #4599 backlog 242 PDF 재판정 — 개선 1(대상) / 불변 241 / 악화 0

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 — 문단당 O(controls+line_segs) 조기-반환 게이트 1회 추가
- 재현·측정: 3418 문서 dump-extents 결합 스윕 전후 동일 조건 완주 (판정·좌표 무변동)

## 스크린샷

SVG 좌표 증적으로 갈음 (문서번호 표 x=79.36 요소: y 1079.49 → 263.07). 대상 문서는
비공개 코퍼스(서울시 결재문서 샘플)라 파일 자체는 첨부하지 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)