### PR TITLE
fix(renderer): TAC host 의 동거 개체 float 밴드를 사다리 스냅으로 회복한다

### DIFF
--- a/mydocs/working/task_m100_4639_stage1.md
+++ b/mydocs/working/task_m100_4639_stage1.md
@@ -1,0 +1,41 @@
+# Task #4639 Stage 1 — TAC host 의 동거 개체 float 밴드를 사다리 스냅으로 회복
+
+Issue: #4639 (#4599 캠페인 Phase 3, 사이클 4)
+Branch: `fix/4599-tac-host-sibling-float-snap` (base: devel 572786d02)
+
+## 무엇을
+
+treat_as_char(블록) 표를 품은 문단 직후에는 저장 사다리 보정(vpos_adjust)을 건너뛰는
+규칙(prev_tac_seg_applied — TAC 전진 경로가 다음 흐름을 이미 확정한다는 가정)이 있다.
+그런데 그 host 문단이 **비-TAC 개체 float(그림 등, TopAndBottom/Square·PARA 상대)**를
+함께 앵커하면, TAC 전진은 표 줄만 소비하고 개체 밴드는 흐름에 남는다 — 후속 문단이
+개체 위에 겹쳐 렌더된다. 이 형상에서만 스킵을 해제해 저장 사다리 보정이 후속 문단을
+개체 아래로 스냅하게 했다. hwpx stored layout 한정.
+
+## 실측 근거 (36442008 p1 — #4599 uniform − 군집 대표, 220.8px)
+
+- pi5 = TAC 8×9 표(477.2..688.6) + **전폭 SQUARE 그림(pic, vertOffset=17207HU →
+  706.7..911.3)** 동거 host. TAC 전진 213.2px 뿐 → pi8 '붙임'이 734.2 로 그림 위에
+  겹침.
+- 한글 2022 캐시 PDF: '붙임' 955.2. 저장 사다리: pi6 vpos 62682 → 911.4(그림 하단),
+  pi8 → 955.0 — **사다리·PDF 일치**(이 문서군의 사다리는 신뢰 가능).
+- 수정 후: pi6 911.3 · pi8 955.1 (PDF 와 0.1px) — **CONFIRMED(220.8) → QUIET(0.5)**,
+  페이지 전체 n=46 쌍 maxdev 0.5.
+
+주: 그림이 TopAndBottom 이 아니라 **Square(어울림) 전폭**임을 XML 로 확정하고 게이트에
+Square 를 포함시켰다(전폭 Square = 사실상 상하 배치). 스냅은 저장 좌표를 따르므로
+옆-흐름 Square 문서에서도 사다리가 진실을 말한다.
+
+## 검증 실측
+
+### #4599 backlog 242 재판정 — 개선 1(220.8→0.5 QUIET) / 불변 241 / 악화 0
+
+### hwpx 3418 스윕 (baseline 572786d02 클린 worktree 빌드)
+
+- 판정 이동 1건: 대상 36442008 DRIFT→OK (worst 220.8→0.1)
+- worst +2px 악화 0건 · 전수 Table-diff 변동 0건
+
+### 저장소 게이트
+
+- cargo fmt --check: 통과 · clippy: 경고 0 · cargo test --release 전체: exit 0 ·
+  wasm-pack build --target web: 성공

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -5771,7 +5771,43 @@ impl LayoutEngine {
                 None
             };
             hcursor.prev_item_content_bottom_y = prev_item_content_bottom_y;
-            if !shape_jumped && (!prev_tac_seg_applied || current_is_endnote_question_title) {
+            // [#4639 · #4599 ⑧] TAC-직후 보정 스킵의 예외 — 직전 TAC host 문단이 비-TAC
+            // TopAndBottom Shape/Picture float 를 함께 앵커한 경우, TAC 전진은 표
+            // 줄만 소비하고 그림 밴드는 흐름에 남는다(36442008 p1: 그림
+            // 706.7..911.3 위로 '붙임' 절이 220.8px 겹침 — 한글 2022 캐시 PDF·저장
+            // 사다리 모두 955.2 실측). 이때는 저장 사다리 보정을 허용해 후속
+            // 문단이 그림 밴드 아래로 스냅되게 한다. hwpx stored layout 한정.
+            let prev_tac_host_sibling_float = prev_tac_seg_applied
+                && self.profile.get().hwpx_stored_layout()
+                && tac_seg_applied_para
+                    .or(hcursor.prev_layout_para)
+                    .and_then(|pi| paragraphs.get(pi))
+                    .is_some_and(|p| {
+                        p.controls
+                            .iter()
+                            .any(|c| matches!(c, Control::Table(t) if t.common.treat_as_char))
+                            && p.controls.iter().any(|c| {
+                                let cm = match c {
+                                    Control::Shape(sh) => sh.common(),
+                                    Control::Picture(pic) => &pic.common,
+                                    _ => return false,
+                                };
+                                !cm.treat_as_char
+                                    && matches!(
+                                        cm.text_wrap,
+                                        TextWrap::TopAndBottom | TextWrap::Square
+                                    )
+                                    && matches!(
+                                        cm.vert_rel_to,
+                                        crate::model::shape::VertRelTo::Para
+                                    )
+                            })
+                    });
+            if !shape_jumped
+                && (!prev_tac_seg_applied
+                    || current_is_endnote_question_title
+                    || prev_tac_host_sibling_float)
+            {
                 // [Task #1027 Stage C] inter-item VPOS_CORR 보정을 HeightCursor 에 위임 (동작 동일).
                 // 이전 문단 overlay-shape/분할표 bypass, page/lazy base 산출, sb 차감,
                 // ≤8px 백워드 클램프를 모두 캡슐화 (Stage A/B 함수 결합). 렌더러·페이지네이터 공유.


### PR DESCRIPTION
## 변경 요약

treat_as_char(블록) 표를 품은 문단 직후에는 저장 사다리 보정(vpos_adjust)을 건너뜁니다
(prev_tac_seg_applied — TAC 전진 경로가 다음 흐름을 확정한다는 가정). 그런데 그 host
문단이 **비-TAC 개체 float** 를 함께 앵커하면 TAC 전진은 표 줄만 소비하고 개체 밴드는
흐름에서 증발해, 후속 본문이 개체 위에 겹쳐 렌더됩니다.

실측(36442008 p1, #4599 uniform − 군집 대표): pi5 = TAC 8×9 표(477..689) + 전폭
SQUARE 그림(vertOffset=17207HU → 706.7..911.3) 동거 host. TAC 전진 213.2px 뿐이라
'붙임' 절이 그림 위 734.2 에 겹침(220.8px). 한글 2022 캐시 PDF(955.2)·저장
사다리(955.0)가 모두 그림 아래를 증언.

수정: 직전 TAC host 가 비-TAC Shape/Picture float(TopAndBottom·Square, PARA 상대)를
함께 앵커한 형상에서만 TAC-직후 스킵을 해제해 사다리 보정이 후속 문단을 개체 밴드
아래로 스냅하게 합니다. hwpx stored layout 한정 — 스냅은 저장 좌표를 따르므로
옆-흐름 Square 문서에서도 사다리가 진실을 말합니다.

수정 후: '붙임' 955.1 (PDF 와 0.1px), **CONFIRMED(maxdev 220.8) → QUIET(0.5)**,
페이지 전체 46쌍 정합.

상세 분석·검증: `mydocs/working/task_m100_4639_stage1.md`

## 관련 이슈

closes #4639

관련: #4599 (캠페인 Phase 3 사이클 4) · #4610/#4613/#4622 (사이클 1~3, 독립 변경)

## 테스트

- [x] `cargo test` 통과 — `cargo test --release` 전체 exit 0
- [x] `cargo clippy -- -D warnings` 통과 (경고 0)
- [x] 관련 샘플 파일로 SVG 내보내기 확인 — 좌표 실측: '붙임' 734.2→955.1 [PDF 955.2],
      그 외 페이지 전체 ±0.5px 불변
- [x] 웹(WASM) 렌더링 확인 — `wasm-pack build --target web` 성공
- [ ] 작업 증빙 — 코드 변경. 회귀 산출물 보존: `_oracle_pdf_2022/`
      `sweep3418_cycle4fix_combo.tsv` · `phase1b_cycle4_242.tsv`
- [ ] `.claude/agents/` 등 변경 — 해당 없음

추가 회귀 검증 (#4599 가드레일 3종):

- **backlog 242 PDF 재판정** — 개선 1(대상 220.8→0.5 QUIET) / 불변 241 / 악화 0
- **hwpx 3418 스윕** (baseline 572786d02 클린 worktree 빌드) — 판정 이동 1건(대상
  DRIFT→OK) · worst +2px 악화 0건
- **전수 Table-diff** — 변동 0건

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 — TAC-직후 문단에서 직전 host 컨트롤 스캔 1회(O(컨트롤 수))
- 재현·측정: 3418 문서 dump-extents 결합 스윕 전후 동일 조건 완주

## 스크린샷

비공개 코퍼스 문서라 파일 미첨부 — 좌표 실측 표로 갈음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)