### PR TITLE
renderer: constrain font lookup candidates

### DIFF
--- a/mydocs/orders/20260812.md
+++ b/mydocs/orders/20260812.md
@@ -4,25 +4,8 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 | --- | --- | --- | --- |
-| [PR #4645](https://github.com/edwardkim/rhwp/pull/4645) | SVG 폰트 파일 탐색 후보 경계 | Open PR, CI 생성 대기 | focused 2건 통과; 로컬 전체 검증은 host 디스크 부족으로 중단 |
 | [#4601](https://github.com/edwardkim/rhwp/issues/4601) | v0.8.3 릴리즈 | PR #4612 self-review | code candidate CI 성공, trailing review-only fast-pass 대기 |
 | [#4029](https://github.com/edwardkim/rhwp/issues/4029) | cold-cache release CI 복구 | PR #4581 merge·devel CI 성공 | 운영 기록 fast-pass 뒤 main release-grade CI 재검증 |
-
-## PR #4645 - SVG 폰트 파일 탐색 후보 경계
-
-- `upstream/main@45af1773b`와 `upstream/devel@193e26b7f`에서 SVG 폰트 파일 후보가
-  설정된 탐색 디렉터리에 직접 결합되는 동일 동작을 확인했다.
-- 최신 `upstream/devel@193e26b7f`에서 격리 worktree와 작업 branch를 만들었다.
-- 파일 탐색 후보를 단일 일반 파일명으로 제한하고, 정상 파일명과 탐색 루트 직접 자식
-  조회를 고정하는 회귀 테스트 2건을 추가했다.
-- focused Rust test 2건, `rustfmt --check`, `git diff --check`를 통과했다. release-test
-  전체 검증은 host 디스크 공간 부족으로 compile 단계에서 중단돼 PASS로 기록하지 않는다.
-- 원본 저장소 branch push와 reviewer request는 fork 계정 권한 부족으로 거부됐다. 같은
-  branch를 fork에 push해 [PR #4645](https://github.com/edwardkim/rhwp/pull/4645)를
-  `devel` 대상 Open PR로 만들었고, [검토 기록](../pr/archives/pr_4645_review.md)을
-  trailing docs-only commit으로 포함한다.
-- 최신 PR head의 GitHub Actions, 권한 있는 reviewer 확인과 작업지시자의 별도 merge
-  승인을 남은 조건으로 둔다.
 
 ## Issue #4601 - v0.8.3 릴리즈
 

--- a/mydocs/orders/20260812.md
+++ b/mydocs/orders/20260812.md
@@ -4,8 +4,25 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 | --- | --- | --- | --- |
+| [PR #4645](https://github.com/edwardkim/rhwp/pull/4645) | SVG 폰트 파일 탐색 후보 경계 | Open PR, CI 생성 대기 | focused 2건 통과; 로컬 전체 검증은 host 디스크 부족으로 중단 |
 | [#4601](https://github.com/edwardkim/rhwp/issues/4601) | v0.8.3 릴리즈 | PR #4612 self-review | code candidate CI 성공, trailing review-only fast-pass 대기 |
 | [#4029](https://github.com/edwardkim/rhwp/issues/4029) | cold-cache release CI 복구 | PR #4581 merge·devel CI 성공 | 운영 기록 fast-pass 뒤 main release-grade CI 재검증 |
+
+## PR #4645 - SVG 폰트 파일 탐색 후보 경계
+
+- `upstream/main@45af1773b`와 `upstream/devel@193e26b7f`에서 SVG 폰트 파일 후보가
+  설정된 탐색 디렉터리에 직접 결합되는 동일 동작을 확인했다.
+- 최신 `upstream/devel@193e26b7f`에서 격리 worktree와 작업 branch를 만들었다.
+- 파일 탐색 후보를 단일 일반 파일명으로 제한하고, 정상 파일명과 탐색 루트 직접 자식
+  조회를 고정하는 회귀 테스트 2건을 추가했다.
+- focused Rust test 2건, `rustfmt --check`, `git diff --check`를 통과했다. release-test
+  전체 검증은 host 디스크 공간 부족으로 compile 단계에서 중단돼 PASS로 기록하지 않는다.
+- 원본 저장소 branch push와 reviewer request는 fork 계정 권한 부족으로 거부됐다. 같은
+  branch를 fork에 push해 [PR #4645](https://github.com/edwardkim/rhwp/pull/4645)를
+  `devel` 대상 Open PR로 만들었고, [검토 기록](../pr/archives/pr_4645_review.md)을
+  trailing docs-only commit으로 포함한다.
+- 최신 PR head의 GitHub Actions, 권한 있는 reviewer 확인과 작업지시자의 별도 merge
+  승인을 남은 조건으로 둔다.
 
 ## Issue #4601 - v0.8.3 릴리즈
 

--- a/mydocs/pr/archives/pr_4645_review.md
+++ b/mydocs/pr/archives/pr_4645_review.md
@@ -1,0 +1,92 @@
+---
+kind: pr-review
+status: pending-ci
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-12
+---
+
+# PR #4645 self-review — SVG 폰트 파일 탐색 후보 경계
+
+## 결론
+
+**CI 확인 전 수용 보류.** [PR #4645](https://github.com/edwardkim/rhwp/pull/4645)는
+SVG 폰트 파일 탐색 후보를 단일 일반 파일명으로 제한하고, 정상 파일명과 기존 별칭의
+탐색 순서는 유지한다. 변경은 두 함수와 두 회귀 테스트에 한정됐으며 self-review에서
+별도 blocking finding은 발견하지 않았다.
+
+focused test는 통과했지만 로컬 release-test 전체 검증은 host 디스크 공간 부족으로
+compile 단계에서 중단됐다. 최신 PR head의 GitHub Actions 성공, reviewer 확인과
+작업지시자의 명시적 merge 승인을 최종 조건으로 둔다.
+
+## 검토 경로
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, local_validation.md,
+           visual_fixture_evidence.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+                  collaborator_self_merge.md, intake_and_review.md,
+                  local_validation.md, visual_fixture_evidence.md
+devel base: 193e26b7ffb05adf5bb2c9e4cb752a9a707310dc
+code candidate: 3d74dfd98d61f53a0e4390c6785d5bddef635ad0
+trailing review head: 이 문서와 오늘할일을 포함할 후속 docs-only commit
+```
+
+변경이 작고 conflict 해결이나 보정 단계가 없으므로 `pr_4645_review_impl.md`는 추가하지
+않는다.
+
+## 메타데이터
+
+| 항목 | 문서 작성 시점 참고값 |
+| --- | --- |
+| PR | [#4645](https://github.com/edwardkim/rhwp/pull/4645) |
+| 관련 이슈 | 별도 공개 이슈 없음 |
+| 작성자 | `humdrum00001010` |
+| reviewer | `edwardkim` 요청을 시도했으나 fork 계정 권한 부족으로 미지정 |
+| base / head | `devel` / `humdrum00001010:renderer/font-lookup-candidate-boundary-33` |
+| code candidate | `3d74dfd98d61f53a0e4390c6785d5bddef635ad0` |
+| 규모 | 2 files, +50 / -0 |
+| 상태 | Open, non-draft, MERGEABLE / BLOCKED; checks 생성 대기 |
+
+원본 저장소 작업 branch push도 권한 부족으로 거부돼 같은 branch를 fork에 push하고
+`devel` 대상 PR을 만들었다. reviewer request도 같은 권한 경계에서 거부됐으며, 이를
+우회하는 GitHub 상태 변경은 수행하지 않았다.
+
+## 변경 범위와 소유권
+
+`src/renderer/svg.rs::find_font_file_with_weight`가 글꼴 별칭과 확장자로 만든 후보를
+설정된 탐색 디렉터리에 결합한다. 따라서 후보가 파일명 하나인지 판정하는 책임도 이
+결합 직전의 SVG 폰트 파일 탐색 경계에 둔다.
+
+`is_plain_font_file_name`은 상대 `Component::Normal` 하나만 허용한다. 정상 파일명과
+공백이 있는 파일명은 유지하고, 다중 경로 성분은 후보에서 제외한다. parser, document
+model, 공통 폰트 조달 순서와 다른 renderer backend는 변경하지 않는다.
+
+## 완료한 로컬 검증
+
+| 게이트 | 결과 |
+| --- | --- |
+| focused Rust unit | `cargo test --lib renderer::svg::tests::font_ -- --nocapture`: 2 passed |
+| formatting | `rustfmt --edition 2021 --check src/renderer/svg.rs src/renderer/svg/tests.rs`: 통과 |
+| whitespace | `git diff --check`: 통과 |
+| release-test 전체 | compile 중 host disk `No space left on device`로 중단, PASS로 기록하지 않음 |
+
+검증은 다른 작업과 겹치지 않는 Cargo slot에서 task 전용 target을 사용했다. 실패 뒤 실행
+중인 Cargo가 없음을 확인하고 task 전용 target만 정리해 약 1.4 GiB를 회수했으며, shared
+target과 다른 작업 산출물은 삭제하지 않았다. 이후 Cargo는 재실행하지 않았다.
+
+## 렌더·시각 영향
+
+변경 파일은 `src/renderer` 아래지만 geometry, layout, paint, SVG 요소·속성 또는 정상
+글꼴 파일의 출력 바이트를 바꾸지 않는다. 새 sample, golden, 기준 PDF도 없다. 따라서
+별도 visual sweep과 review asset은 만들지 않았고, 정상 파일명 허용과 탐색 루트 직접
+자식 조회를 focused test로 고정했다.
+
+## 최종 권고
+
+다음 조건이 모두 충족될 때 수용 후보로 다시 판정한다.
+
+1. 이 review 문서와 오늘할일을 포함한 trailing docs-only commit을 같은 PR branch에 push한다.
+2. 최신 PR head의 GitHub Actions와 required check가 성공한다.
+3. 권한 있는 reviewer가 변경을 확인한다.
+4. 작업지시자의 별도 merge 승인을 받는다.

--- a/mydocs/pr/archives/pr_4645_review.md
+++ b/mydocs/pr/archives/pr_4645_review.md
@@ -5,35 +5,40 @@ canonical: mydocs/manual/pr_review_workflow.md
 last_verified: 2026-08-12
 ---
 
-# PR #4645 self-review — SVG 폰트 파일 탐색 후보 경계
+# PR #4645 review — SVG 폰트 파일 탐색 후보 경계
 
 ## 결론
 
-**CI 확인 전 수용 보류.** [PR #4645](https://github.com/edwardkim/rhwp/pull/4645)는
-SVG 폰트 파일 탐색 후보를 단일 일반 파일명으로 제한하고, 정상 파일명과 기존 별칭의
-탐색 순서는 유지한다. 변경은 두 함수와 두 회귀 테스트에 한정됐으며 self-review에서
-별도 blocking finding은 발견하지 않았다.
+**현재는 Draft 유지 및 CI 확인 전 수용 보류.** 최초 변경은 문서 유래 후보의 경로 성분
+검사를 파일 탐색 leaf 안에 두고 private helper만 시험했다. Gestell 재검토에서 그 위치와
+검증 범위가 부적절하다는 지적을 받아, 후보 계획을 SVG 렌더러의 해석 단계로 올리고 public
+문서 렌더 경로의 회귀 테스트를 추가했다.
 
-focused test는 통과했지만 로컬 release-test 전체 검증은 host 디스크 공간 부족으로
-compile 단계에서 중단됐다. 최신 PR head의 GitHub Actions 성공, reviewer 확인과
-작업지시자의 명시적 merge 승인을 최종 조건으로 둔다.
+수정 뒤 독립 Gestell 재검토는 `PASS`다. 다만 코드와 테스트가 새 head에 추가되었으므로
+`CONTRIBUTING.md`의 전체 `release-test` 및 Clippy와 최신 GitHub required check는 아직 이
+문서의 PASS 근거가 아니다. 해당 gate가 현재 head에서 끝나기 전에는 Ready 전환이나 merge를
+권고하지 않는다.
 
 ## 검토 경로
 
 ```text
-base route: collaborator_self_merge.md
+base route: collaborator_external_pr.md
 modifiers: intake_and_review.md, local_validation.md,
-           visual_fixture_evidence.md
+           visual_fixture_evidence.md, rework_and_exceptions.md
 loaded documents: pr_review_workflow.md, pr_review/README.md,
-                  collaborator_self_merge.md, intake_and_review.md,
-                  local_validation.md, visual_fixture_evidence.md
-devel base: 193e26b7ffb05adf5bb2c9e4cb752a9a707310dc
-code candidate: 3d74dfd98d61f53a0e4390c6785d5bddef635ad0
-trailing review head: 이 문서와 오늘할일을 포함할 후속 docs-only commit
+                  collaborator_external_pr.md, intake_and_review.md,
+                  local_validation.md, visual_fixture_evidence.md,
+                  rework_and_exceptions.md, CONTRIBUTING.md
+source head before correction: 8b26078163021dcb9ecb0d93c2aa4b00fe100ab6
+corrected code head: ca97299c36c9185df75e97c08b6bdfc2140cca7c
+current upstream/devel checked: 525cf8e8ed9fa030d1db417fda5070668b2df240
+merge simulation: clean (`git merge-tree --write-tree upstream/devel HEAD`)
+trailing review head: 이 review 기록을 포함하는 docs-only commit
 ```
 
-변경이 작고 conflict 해결이나 보정 단계가 없으므로 `pr_4645_review_impl.md`는 추가하지
-않는다.
+`upstream/devel`은 source branch의 조상이 아니지만 merge tree가 충돌 없이 생성됐다. 이
+사실은 current-base의 전체 CI를 생략하는 근거가 아니며, source branch를 임의 rebase 또는
+force-push하지 않았다.
 
 ## 메타데이터
 
@@ -42,51 +47,72 @@ trailing review head: 이 문서와 오늘할일을 포함할 후속 docs-only c
 | PR | [#4645](https://github.com/edwardkim/rhwp/pull/4645) |
 | 관련 이슈 | 별도 공개 이슈 없음 |
 | 작성자 | `humdrum00001010` |
-| reviewer | `edwardkim` 요청을 시도했으나 fork 계정 권한 부족으로 미지정 |
 | base / head | `devel` / `humdrum00001010:renderer/font-lookup-candidate-boundary-33` |
-| code candidate | `3d74dfd98d61f53a0e4390c6785d5bddef635ad0` |
-| 규모 | 2 files, +50 / -0 |
-| 상태 | Open, non-draft, MERGEABLE / BLOCKED; checks 생성 대기 |
-
-원본 저장소 작업 branch push도 권한 부족으로 거부돼 같은 branch를 fork에 push하고
-`devel` 대상 PR을 만들었다. reviewer request도 같은 권한 경계에서 거부됐으며, 이를
-우회하는 GitHub 상태 변경은 수행하지 않았다.
+| source head (보정 전) | `8b26078163021dcb9ecb0d93c2aa4b00fe100ab6` |
+| 보정 code head | `ca97299c36c9185df75e97c08b6bdfc2140cca7c` |
+| 원격 상태 | Open Draft, `MERGEABLE` / `BLOCKED`; 완료된 check는 `cancel-stale-runs`뿐 |
+| maintainer 수정 권한 | `maintainerCanModify: true` |
 
 ## 변경 범위와 소유권
 
-`src/renderer/svg.rs::find_font_file_with_weight`가 글꼴 별칭과 확장자로 만든 후보를
-설정된 탐색 디렉터리에 결합한다. 따라서 후보가 파일명 하나인지 판정하는 책임도 이
-결합 직전의 SVG 폰트 파일 탐색 경계에 둔다.
+문서의 `Font.name`은 parser와 style resolver를 거쳐 SVG의 `font_family`가 된다. `Full`과
+`Subset` 임베딩은 그 family에서 별칭과 확장자 후보를 만들고, 설정된 font root에 결합한 뒤
+바이트를 읽어 data URI에 넣는다.
 
-`is_plain_font_file_name`은 상대 `Component::Normal` 하나만 허용한다. 정상 파일명과
-공백이 있는 파일명은 유지하고, 다중 경로 성분은 후보에서 제외한다. parser, document
-model, 공통 폰트 조달 순서와 다른 renderer backend는 변경하지 않는다.
+따라서 다음 두 책임을 분리했다.
+
+1. `plan_svg_font_file_lookup`은 renderer 정책이다. 문서 유래 family, 별칭, known filename,
+   extension, bold 여부와 검색 root를 모아 `FontFileLookupPlan`을 만든다. 여기서만
+   `FontFileName::from_document_candidate`가 하나의 `Component::Normal`인 파일명으로
+   검증한다.
+2. `find_font_file`은 기계적 filesystem loop다. 이미 검증된 `FontFileName`만 받아 root와
+   결합해 존재하는 직접 자식 파일을 찾는다. 문서 문자열을 다시 해석하거나 후보 정책을
+   선택하지 않는다.
+
+따라서 `nested/Face`나 `../Face` 같은 문서 이름은 계획 단계에서 후보가 되지 않으며, 정상
+직접 자식 filename 및 기존 alias 우선순위는 유지한다. parser, document model, 공통
+`font_paths` 조달 순서와 다른 renderer backend는 변경하지 않았다.
+
+## 회귀 테스트
+
+새 [`tests/issue_4645_font_lookup_boundary.rs`](../../../tests/issue_4645_font_lookup_boundary.rs)는
+실제 HML fixture를 face 이름만 바꿔 `DocumentCore::from_bytes`로 연 뒤 public
+`render_page_svg_with_fonts(0, FontEmbedMode::Full, &[root])`를 호출한다.
+
+- root의 `nested/<stem>.ttf` sentinel은 document face가 `nested/<stem>`일 때 SVG data URI에
+  나타나지 않아야 한다.
+- 같은 root의 `<stem>.ttf` direct-child sentinel은 document face가 `<stem>`일 때 SVG data URI에
+  나타나야 한다.
+
+이렇게 parser → style resolver → SVG candidate planning → filesystem read → SVG data URI를 한
+테스트에서 확인한다. private helper를 직접 호출하는 단위 테스트는 mechanism 보조 검증으로만
+남겼다.
 
 ## 완료한 로컬 검증
 
 | 게이트 | 결과 |
 | --- | --- |
-| focused Rust unit | `cargo test --lib renderer::svg::tests::font_ -- --nocapture`: 2 passed |
-| formatting | `rustfmt --edition 2021 --check src/renderer/svg.rs src/renderer/svg/tests.rs`: 통과 |
+| public E2E | `cargo test --profile release-test --test issue_4645_font_lookup_boundary -- --nocapture`: 1 passed |
+| candidate plan unit | `cargo test --profile release-test --lib renderer::svg::tests::font_file_candidates_are_single_path_components -- --nocapture`: 1 passed |
+| planned lookup unit | `cargo test --profile release-test --lib renderer::svg::tests::planned_font_lookup_does_not_descend_below_search_roots -- --nocapture`: 1 passed |
+| existing bold control | `cargo test --profile release-test --lib renderer::svg::tests::full_font_embed_uses_real_bold_face_when_document_uses_bold -- --nocapture`: 1 passed |
+| formatting | `cargo fmt --all -- --check`: 통과 |
 | whitespace | `git diff --check`: 통과 |
-| release-test 전체 | compile 중 host disk `No space left on device`로 중단, PASS로 기록하지 않음 |
-
-검증은 다른 작업과 겹치지 않는 Cargo slot에서 task 전용 target을 사용했다. 실패 뒤 실행
-중인 Cargo가 없음을 확인하고 task 전용 target만 정리해 약 1.4 GiB를 회수했으며, shared
-target과 다른 작업 산출물은 삭제하지 않았다. 이후 Cargo는 재실행하지 않았다.
+| Gestell | 독립 adversarial 재검토: `PASS` |
+| `release-test` 전체 | 이 코드 head 기준 결과 대기 — 성공으로 기록하지 않음 |
+| Clippy | 이 코드 head 기준 결과 대기 — 성공으로 기록하지 않음 |
 
 ## 렌더·시각 영향
 
-변경 파일은 `src/renderer` 아래지만 geometry, layout, paint, SVG 요소·속성 또는 정상
-글꼴 파일의 출력 바이트를 바꾸지 않는다. 새 sample, golden, 기준 PDF도 없다. 따라서
-별도 visual sweep과 review asset은 만들지 않았고, 정상 파일명 허용과 탐색 루트 직접
-자식 조회를 focused test로 고정했다.
+레이아웃, geometry, paint, sample, golden은 변경하지 않는다. 보안 경계의 사용자-visible 결과는
+`@font-face` data URI의 유무이므로, 위 public SVG 경로 테스트가 이 PR의 결정적 출력 증적이다.
+정상 direct-child font의 data URI와 nested sentinel 부재를 함께 확인해 기존 정상 임베딩을
+막지 않았음을 고정했다. 별도 한컴 PDF/overlay asset은 이 변경 주장과 직접 관련이 없어 만들지
+않았다.
 
-## 최종 권고
+## 최종 조건
 
-다음 조건이 모두 충족될 때 수용 후보로 다시 판정한다.
-
-1. 이 review 문서와 오늘할일을 포함한 trailing docs-only commit을 같은 PR branch에 push한다.
-2. 최신 PR head의 GitHub Actions와 required check가 성공한다.
-3. 권한 있는 reviewer가 변경을 확인한다.
-4. 작업지시자의 별도 merge 승인을 받는다.
+1. 이 review 문서까지 포함한 최신 PR head에서 `CONTRIBUTING.md`의 전체 `release-test`와
+   Clippy가 성공한다.
+2. 최신 GitHub required check가 성공한다.
+3. Draft 해제 및 merge는 작업지시자의 별도 승인 뒤에만 진행한다.

--- a/mydocs/pr/archives/pr_4645_review.md
+++ b/mydocs/pr/archives/pr_4645_review.md
@@ -9,15 +9,15 @@ last_verified: 2026-08-12
 
 ## 결론
 
-**현재는 Draft 유지 및 CI 확인 전 수용 보류.** 최초 변경은 문서 유래 후보의 경로 성분
+**현재는 Draft 유지 및 최신 GitHub check 확인 전 수용 보류.** 최초 변경은 문서 유래 후보의 경로 성분
 검사를 파일 탐색 leaf 안에 두고 private helper만 시험했다. Gestell 재검토에서 그 위치와
 검증 범위가 부적절하다는 지적을 받아, 후보 계획을 SVG 렌더러의 해석 단계로 올리고 public
 문서 렌더 경로의 회귀 테스트를 추가했다.
 
-수정 뒤 독립 Gestell 재검토는 `PASS`다. 다만 코드와 테스트가 새 head에 추가되었으므로
-`CONTRIBUTING.md`의 전체 `release-test` 및 Clippy와 최신 GitHub required check는 아직 이
-문서의 PASS 근거가 아니다. 해당 gate가 현재 head에서 끝나기 전에는 Ready 전환이나 merge를
-권고하지 않는다.
+수정 뒤 독립 Gestell 재검토는 `PASS`다. `CONTRIBUTING.md`의 로컬 Rust gate도 code/test와
+review 기록이 들어간 `4bb2f0a48`에서 끝까지 성공했다. 아직 완료되지 않은 최종 조건은 최신
+GitHub required check와 작업지시자의 별도 상태 변경 승인뿐이다. 그 전에는 Ready 전환이나
+merge를 권고하지 않는다.
 
 ## 검토 경로
 
@@ -31,9 +31,10 @@ loaded documents: pr_review_workflow.md, pr_review/README.md,
                   rework_and_exceptions.md, CONTRIBUTING.md
 source head before correction: 8b26078163021dcb9ecb0d93c2aa4b00fe100ab6
 corrected code head: ca97299c36c9185df75e97c08b6bdfc2140cca7c
+local full-gate head: 4bb2f0a48e1042dd0c031d3d33cf543b6e938de1
 current upstream/devel checked: 525cf8e8ed9fa030d1db417fda5070668b2df240
 merge simulation: clean (`git merge-tree --write-tree upstream/devel HEAD`)
-trailing review head: 이 review 기록을 포함하는 docs-only commit
+trailing review head: 이 완료 기록을 포함하는 docs-only commit
 ```
 
 `upstream/devel`은 source branch의 조상이 아니지만 merge tree가 충돌 없이 생성됐다. 이
@@ -98,9 +99,9 @@ force-push하지 않았다.
 | existing bold control | `cargo test --profile release-test --lib renderer::svg::tests::full_font_embed_uses_real_bold_face_when_document_uses_bold -- --nocapture`: 1 passed |
 | formatting | `cargo fmt --all -- --check`: 통과 |
 | whitespace | `git diff --check`: 통과 |
+| 전체 Rust tests | `cargo test --profile release-test --tests`: 통과 (exit 0) |
+| Clippy | `cargo clippy -- -D warnings`: 통과 (exit 0) |
 | Gestell | 독립 adversarial 재검토: `PASS` |
-| `release-test` 전체 | 이 코드 head 기준 결과 대기 — 성공으로 기록하지 않음 |
-| Clippy | 이 코드 head 기준 결과 대기 — 성공으로 기록하지 않음 |
 
 ## 렌더·시각 영향
 
@@ -112,7 +113,5 @@ force-push하지 않았다.
 
 ## 최종 조건
 
-1. 이 review 문서까지 포함한 최신 PR head에서 `CONTRIBUTING.md`의 전체 `release-test`와
-   Clippy가 성공한다.
-2. 최신 GitHub required check가 성공한다.
-3. Draft 해제 및 merge는 작업지시자의 별도 승인 뒤에만 진행한다.
+1. 최신 GitHub required check가 성공한다.
+2. Draft 해제 및 merge는 작업지시자의 별도 승인 뒤에만 진행한다.

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -3677,6 +3677,15 @@ fn korean_gothic_substitute(font_name: &str) -> Option<&'static str> {
     }
 }
 
+/// Whether a generated font candidate is a single, relative file name.
+#[cfg(not(target_arch = "wasm32"))]
+fn is_plain_font_file_name(name: &str) -> bool {
+    use std::path::Component;
+
+    let mut components = std::path::Path::new(name).components();
+    matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none()
+}
+
 /// 폰트명으로 TTF/OTF 파일을 탐색한다.
 #[cfg(not(target_arch = "wasm32"))]
 fn find_font_file_with_weight(
@@ -3723,6 +3732,9 @@ fn find_font_file_with_weight(
                 files.push(sub.to_string());
             }
         }
+        // Candidate names originate in document font metadata. Keep the filesystem
+        // lookup boundary to one file name before joining it to a configured root.
+        files.retain(|candidate| is_plain_font_file_name(candidate));
         files
     };
 

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -3677,26 +3677,52 @@ fn korean_gothic_substitute(font_name: &str) -> Option<&'static str> {
     }
 }
 
-/// Whether a generated font candidate is a single, relative file name.
+/// 파일시스템 탐색에 넘기는 하나의 폰트 파일명.
+///
+/// 문서 메타데이터에서 유래한 후보는 SVG 폰트 해석 단계에서만
+/// 이 형식으로 바뀐다. 파일시스템 루프는 이 타입의 후보만
+/// 설정된 검색 루트에 결합한다.
 #[cfg(not(target_arch = "wasm32"))]
-fn is_plain_font_file_name(name: &str) -> bool {
-    use std::path::Component;
+#[derive(Clone, Debug)]
+struct FontFileName(String);
 
-    let mut components = std::path::Path::new(name).components();
-    matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none()
+#[cfg(not(target_arch = "wasm32"))]
+impl FontFileName {
+    fn from_document_candidate(candidate: String) -> Option<Self> {
+        use std::path::Component;
+
+        if candidate.contains(['/', '\\', '\0']) {
+            return None;
+        }
+        let mut components = std::path::Path::new(&candidate).components();
+        (matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none())
+            .then_some(Self(candidate))
+    }
+
+    fn as_path(&self) -> &std::path::Path {
+        std::path::Path::new(&self.0)
+    }
 }
 
-/// 폰트명으로 TTF/OTF 파일을 탐색한다.
+/// SVG 폰트 해석이 선택한 파일명과 탐색 루트.
 #[cfg(not(target_arch = "wasm32"))]
-fn find_font_file_with_weight(
+struct FontFileLookupPlan {
+    candidates: Vec<FontFileName>,
+    search_dirs: Vec<std::path::PathBuf>,
+}
+
+/// 문서 폰트명을 SVG 폰트 해석용 파일 후보로 계획한다.
+///
+/// 별칭·대체 폰트·후보 우선순위는 렌더러 정책이므로 여기서
+/// 선택한다. 이후의 파일시스템 조회는 타입으로 검증된 후보를 읽는 기계적 단계다.
+#[cfg(not(target_arch = "wasm32"))]
+fn plan_svg_font_file_lookup(
     font_name: &str,
     extra_paths: &[std::path::PathBuf],
     bold: bool,
-) -> Option<std::path::PathBuf> {
-    use std::path::Path;
-
-    // 폰트명 → 파일명 후보 생성
-    let candidates: Vec<String> = {
+) -> FontFileLookupPlan {
+    let candidates = {
+        // 폰트명 → 파일명 후보 생성
         let known_files = if bold {
             known_bold_font_filenames(font_name)
         } else {
@@ -3732,10 +3758,10 @@ fn find_font_file_with_weight(
                 files.push(sub.to_string());
             }
         }
-        // Candidate names originate in document font metadata. Keep the filesystem
-        // lookup boundary to one file name before joining it to a configured root.
-        files.retain(|candidate| is_plain_font_file_name(candidate));
         files
+            .into_iter()
+            .filter_map(FontFileName::from_document_candidate)
+            .collect()
     };
 
     // [#2864] 탐색 경로(우선순위 순)는 renderer::font_paths 가 단일 정의한다.
@@ -3743,38 +3769,27 @@ fn find_font_file_with_weight(
     // 종전의 ttfs/hwp·ttfs/windows(로컬 전용)와 /mnt/c/Windows/Fonts(WSL2 전용)는
     // 제거했다. Task #1224 의 고딕 대체(Noto Sans KR ExtraLight)는 최후 탐색인
     // ttfs/opensource 에서 그대로 매칭된다.
-    let search_dirs = crate::renderer::font_paths::search_dirs(extra_paths);
+    FontFileLookupPlan {
+        candidates,
+        search_dirs: crate::renderer::font_paths::search_dirs(extra_paths),
+    }
+}
 
-    for dir in &search_dirs {
+/// 계획된 폰트 파일을 설정된 루트에서 읽는다.
+#[cfg(not(target_arch = "wasm32"))]
+fn find_font_file(plan: &FontFileLookupPlan) -> Option<std::path::PathBuf> {
+    for dir in &plan.search_dirs {
         if !dir.exists() {
             continue;
         }
-        for candidate in &candidates {
-            let path = dir.join(candidate);
+        for candidate in &plan.candidates {
+            let path = dir.join(candidate.as_path());
             if path.exists() {
                 return Some(path);
             }
         }
     }
     None
-}
-
-/// regular face 파일을 찾는다.
-#[cfg(not(target_arch = "wasm32"))]
-fn find_font_file(
-    font_name: &str,
-    extra_paths: &[std::path::PathBuf],
-) -> Option<std::path::PathBuf> {
-    find_font_file_with_weight(font_name, extra_paths, false)
-}
-
-/// 실제 Bold face 파일을 찾는다.
-#[cfg(not(target_arch = "wasm32"))]
-fn find_bold_font_file(
-    font_name: &str,
-    extra_paths: &[std::path::PathBuf],
-) -> Option<std::path::PathBuf> {
-    find_font_file_with_weight(font_name, extra_paths, true)
 }
 
 /// [#2524] 문서 임베디드(BinData) 폰트를 @font-face 로 직접 임베딩한다.
@@ -3836,9 +3851,9 @@ fn append_local_bold_font_face_css(css: &mut String, font_name: &str) {
 fn append_embedded_bold_font_face_css(
     css: &mut String,
     font_name: &str,
-    font_paths: &[std::path::PathBuf],
+    bold_lookup: &FontFileLookupPlan,
 ) {
-    if let Some(font_path) = find_bold_font_file(font_name, font_paths) {
+    if let Some(font_path) = find_font_file(bold_lookup) {
         if let Ok(font_data) = std::fs::read(&font_path) {
             let b64 = base64::engine::general_purpose::STANDARD.encode(&font_data);
             css.push_str(&format!(
@@ -3922,7 +3937,8 @@ pub fn generate_font_style(
                     css.push_str(&line);
                     continue;
                 }
-                if let Some(font_path) = find_font_file(font_name, font_paths) {
+                let regular_lookup = plan_svg_font_file_lookup(font_name, font_paths, false);
+                if let Some(font_path) = find_font_file(&regular_lookup) {
                     if let Ok(font_data) = std::fs::read(&font_path) {
                         // codepoint → glyph ID 변환 (ttf-parser cmap 사용)
                         let mut remapper = subsetter::GlyphRemapper::new();
@@ -3945,8 +3961,12 @@ pub fn generate_font_style(
                                     font_name, b64,
                                 ));
                                 if renderer.font_bold_families().contains(font_name) {
+                                    let bold_lookup =
+                                        plan_svg_font_file_lookup(font_name, font_paths, true);
                                     append_embedded_bold_font_face_css(
-                                        &mut css, font_name, font_paths,
+                                        &mut css,
+                                        font_name,
+                                        &bold_lookup,
                                     );
                                 }
                                 eprintln!(
@@ -3993,7 +4013,8 @@ pub fn generate_font_style(
                     css.push_str(&line);
                     continue;
                 }
-                if let Some(font_path) = find_font_file(font_name, font_paths) {
+                let regular_lookup = plan_svg_font_file_lookup(font_name, font_paths, false);
+                if let Some(font_path) = find_font_file(&regular_lookup) {
                     if let Ok(font_data) = std::fs::read(&font_path) {
                         let b64 = base64::engine::general_purpose::STANDARD.encode(&font_data);
                         css.push_str(&format!(
@@ -4001,7 +4022,9 @@ pub fn generate_font_style(
                             font_name, b64,
                         ));
                         if renderer.font_bold_families().contains(font_name) {
-                            append_embedded_bold_font_face_css(&mut css, font_name, font_paths);
+                            let bold_lookup =
+                                plan_svg_font_file_lookup(font_name, font_paths, true);
+                            append_embedded_bold_font_face_css(&mut css, font_name, &bold_lookup);
                         }
                         eprintln!(
                             "  [font-embed] {} → 전체 {:.1}KB",

--- a/src/renderer/svg/tests.rs
+++ b/src/renderer/svg/tests.rs
@@ -129,6 +129,44 @@ fn legacy_hanyang_faces_have_portable_local_aliases() {
 
 #[cfg(not(target_arch = "wasm32"))]
 #[test]
+fn font_file_candidates_are_single_path_components() {
+    assert!(is_plain_font_file_name("NotoSansKR-Regular.ttf"));
+    assert!(is_plain_font_file_name("Noto Sans KR.otf"));
+
+    let nested = std::path::Path::new("fonts").join("NotoSansKR-Regular.ttf");
+    assert!(!is_plain_font_file_name(
+        nested.to_str().expect("UTF-8 test path")
+    ));
+
+    let parent = std::path::Path::new("..").join("NotoSansKR-Regular.ttf");
+    assert!(!is_plain_font_file_name(
+        parent.to_str().expect("UTF-8 test path")
+    ));
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn font_lookup_does_not_descend_below_search_roots() {
+    let root = std::env::temp_dir().join(format!("rhwp-svg-font-candidate-{}", std::process::id()));
+    let nested = root.join("nested");
+    std::fs::create_dir_all(&nested).expect("temporary nested font directory");
+    std::fs::write(nested.join("DocumentFont.ttf"), b"font").expect("nested test font");
+
+    let font_name = std::path::Path::new("nested").join("DocumentFont");
+    assert!(
+        find_font_file(
+            font_name.to_str().expect("UTF-8 test path"),
+            std::slice::from_ref(&root),
+        )
+        .is_none(),
+        "font lookup must consider direct file names only"
+    );
+
+    std::fs::remove_dir_all(root).expect("remove temporary font directory");
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
 fn style_font_face_css_orders_broken_bitmap_faces_after_outline_fallbacks() {
     let mut renderer = SvgRenderer::new();
     renderer.font_embed_mode = FontEmbedMode::Style;

--- a/src/renderer/svg/tests.rs
+++ b/src/renderer/svg/tests.rs
@@ -130,35 +130,38 @@ fn legacy_hanyang_faces_have_portable_local_aliases() {
 #[cfg(not(target_arch = "wasm32"))]
 #[test]
 fn font_file_candidates_are_single_path_components() {
-    assert!(is_plain_font_file_name("NotoSansKR-Regular.ttf"));
-    assert!(is_plain_font_file_name("Noto Sans KR.otf"));
+    assert!(FontFileName::from_document_candidate("NotoSansKR-Regular.ttf".to_string()).is_some());
+    assert!(FontFileName::from_document_candidate("Noto Sans KR.otf".to_string()).is_some());
 
     let nested = std::path::Path::new("fonts").join("NotoSansKR-Regular.ttf");
-    assert!(!is_plain_font_file_name(
-        nested.to_str().expect("UTF-8 test path")
-    ));
+    assert!(FontFileName::from_document_candidate(
+        nested.to_str().expect("UTF-8 test path").to_string()
+    )
+    .is_none());
 
     let parent = std::path::Path::new("..").join("NotoSansKR-Regular.ttf");
-    assert!(!is_plain_font_file_name(
-        parent.to_str().expect("UTF-8 test path")
-    ));
+    assert!(FontFileName::from_document_candidate(
+        parent.to_str().expect("UTF-8 test path").to_string()
+    )
+    .is_none());
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 #[test]
-fn font_lookup_does_not_descend_below_search_roots() {
+fn planned_font_lookup_does_not_descend_below_search_roots() {
     let root = std::env::temp_dir().join(format!("rhwp-svg-font-candidate-{}", std::process::id()));
     let nested = root.join("nested");
     std::fs::create_dir_all(&nested).expect("temporary nested font directory");
     std::fs::write(nested.join("DocumentFont.ttf"), b"font").expect("nested test font");
 
     let font_name = std::path::Path::new("nested").join("DocumentFont");
+    let lookup = plan_svg_font_file_lookup(
+        font_name.to_str().expect("UTF-8 test path"),
+        std::slice::from_ref(&root),
+        false,
+    );
     assert!(
-        find_font_file(
-            font_name.to_str().expect("UTF-8 test path"),
-            std::slice::from_ref(&root),
-        )
-        .is_none(),
+        find_font_file(&lookup).is_none(),
         "font lookup must consider direct file names only"
     );
 

--- a/tests/issue_4645_font_lookup_boundary.rs
+++ b/tests/issue_4645_font_lookup_boundary.rs
@@ -1,0 +1,82 @@
+//! [#4645] 문서에서 온 face 이름이 SVG full-font embed의 파일 탐색 루트를
+//! 벗어나지 않는지 확인한다.
+//!
+//! 이 테스트는 private lookup helper가 아니라 실제 HML 문서를
+//! `DocumentCore::from_bytes`로 열고, public
+//! `render_page_svg_with_fonts(..., FontEmbedMode::Full, ...)`로 렌더한다.
+//! 따라서 parser → style resolver → SVG font planning → filesystem read 경로를
+//! 함께 고정한다.
+
+use base64::Engine;
+use rhwp::document_core::DocumentCore;
+use rhwp::renderer::svg::FontEmbedMode;
+use std::path::{Path, PathBuf};
+
+const HML_TEMPLATE: &str = include_str!("../samples/hml/formatting_table.hml");
+
+fn document_with_face_name(face_name: &str) -> Vec<u8> {
+    let replacement = format!("Name=\"{face_name}\"");
+    HML_TEMPLATE
+        .replace("Name=\"함초롬돋움\"", &replacement)
+        .replace("Name=\"함초롬바탕\"", &replacement)
+        .into_bytes()
+}
+
+fn render_document_with_face_name(face_name: &str, font_root: &Path) -> String {
+    let core = DocumentCore::from_bytes(&document_with_face_name(face_name))
+        .expect("HML fixture with document-derived font name should parse");
+    core.render_page_svg_with_fonts(0, FontEmbedMode::Full, &[font_root.to_path_buf()])
+        .expect("public SVG font embedding path should render")
+}
+
+fn temporary_font_root() -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time after Unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "rhwp-issue-4645-font-root-{}-{nonce}",
+        std::process::id()
+    ))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn public_svg_embedding_rejects_nested_document_font_candidate_but_embeds_direct_child() {
+    let root = temporary_font_root();
+    let nested_dir = root.join("nested");
+    std::fs::create_dir_all(&nested_dir).expect("create temporary nested font directory");
+
+    let font_stem = format!("RhwpIssue4645Font{}", std::process::id());
+    let nested_bytes = b"nested-font-sentinel";
+    let direct_bytes = b"direct-font-sentinel";
+    std::fs::write(nested_dir.join(format!("{font_stem}.ttf")), nested_bytes)
+        .expect("write nested sentinel font");
+    std::fs::write(root.join(format!("{font_stem}.ttf")), direct_bytes)
+        .expect("write direct-child sentinel font");
+
+    let nested_face = format!("nested/{font_stem}");
+    let nested_svg = render_document_with_face_name(&nested_face, &root);
+    let nested_b64 = base64::engine::general_purpose::STANDARD.encode(nested_bytes);
+    let direct_b64 = base64::engine::general_purpose::STANDARD.encode(direct_bytes);
+    assert!(
+        !nested_svg.contains(&nested_b64),
+        "a document-derived nested candidate must not reach a nested font file"
+    );
+    assert!(
+        !nested_svg.contains(&direct_b64),
+        "rejecting a nested candidate must not reinterpret it as a direct-child file"
+    );
+
+    let direct_svg = render_document_with_face_name(&font_stem, &root);
+    assert!(
+        direct_svg.contains(&direct_b64),
+        "a valid direct-child document font filename must still be embedded"
+    );
+    assert!(
+        !direct_svg.contains(&nested_b64),
+        "the direct-child lookup must not descend into nested directories"
+    );
+
+    std::fs::remove_dir_all(root).expect("remove temporary font directory");
+}


### PR DESCRIPTION
## 변경 요약

SVG 폰트 임베딩의 문서 유래 face 이름을 filesystem 탐색 후보로 바꾸는 정책을 renderer의 후보 계획 단계에 둡니다.

- `FontFileName`은 경로 구분자나 다중 경로 성분이 없는 단일 파일명만 표현합니다.
- `plan_svg_font_file_lookup`은 문서 face, 기존 alias, known filename, 확장자, bold 여부와 검색 root를 조합하고 검증된 `FontFileLookupPlan`을 만듭니다.
- filesystem loop는 계획된 `FontFileName`만 root와 결합합니다. 문서 문자열을 다시 해석하거나 후보 정책을 선택하지 않습니다.

따라서 `nested/Face`와 `../Face` 같은 문서 이름은 nested file을 읽지 못하고, 정상 direct-child 파일명과 기존 alias 우선순위는 유지됩니다.

## 회귀 테스트

`tests/issue_4645_font_lookup_boundary.rs`는 실제 HML을 `DocumentCore::from_bytes`로 열고 public `render_page_svg_with_fonts(..., FontEmbedMode::Full, ...)`를 호출합니다.

- document-derived `nested/<stem>`은 nested sentinel의 SVG data URI를 만들지 않습니다.
- document-derived `<stem>`은 root 직속 sentinel을 여전히 data URI로 임베드합니다.

즉 parser → style resolver → SVG candidate planning → filesystem read → SVG 출력의 end-to-end 경로를 검증합니다.

## 검증

- [x] `cargo test --profile release-test --test issue_4645_font_lookup_boundary -- --nocapture`
- [x] `cargo test --profile release-test --lib renderer::svg::tests::font_file_candidates_are_single_path_components -- --nocapture`
- [x] `cargo test --profile release-test --lib renderer::svg::tests::planned_font_lookup_does_not_descend_below_search_roots -- --nocapture`
- [x] `cargo test --profile release-test --lib renderer::svg::tests::full_font_embed_uses_real_bold_face_when_document_uses_bold -- --nocapture`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo test --profile release-test --tests`
- [x] `cargo clippy -- -D warnings`
- [x] 독립 Gestell 재검토 PASS

## 상태

로컬 CONTRIBUTING gate는 완료했습니다. 최신 GitHub required check와 별도 승인 전까지 PR은 Draft를 유지합니다.
