### PR TITLE
parser: bound thumbnail decompression output

### DIFF
--- a/mydocs/orders/20260812.md
+++ b/mydocs/orders/20260812.md
@@ -6,18 +6,6 @@
 | --- | --- | --- | --- |
 | [#4601](https://github.com/edwardkim/rhwp/issues/4601) | v0.8.3 릴리즈 | PR #4612 self-review | code candidate CI 성공, trailing review-only fast-pass 대기 |
 | [#4029](https://github.com/edwardkim/rhwp/issues/4029) | cold-cache release CI 복구 | PR #4581 merge·devel CI 성공 | 운영 기록 fast-pass 뒤 main release-grade CI 재검증 |
-| — | 썸네일 출력 상한 정렬 | PR #4646 Open, CI 대기 | core·Chrome·Firefox·Safari 경로 정합 |
-
-## PR #4646 - 썸네일 출력 상한 정렬
-
-- `devel@193e26b7f`에서 core와 Chrome·Firefox·Safari의 썸네일 추출 경로에 같은 10 MiB
-  출력 상한을 적용했다.
-- 브라우저 확장은 공통 bounded stream collector를 사용하고, 선언 크기와 실제 출력 크기가
-  다르면 결합 버퍼를 만들지 않는다.
-- Rust focused test 4건, service-worker test 118건, fmt, clippy, JavaScript·Safari build script
-  구문 검사와 `git diff --check`가 통과했다.
-- [PR #4646](https://github.com/edwardkim/rhwp/pull/4646)은 Open/non-draft이며 최신 head의
-  GitHub Actions와 review를 기다린다. merge는 수행하지 않는다.
 
 ## Issue #4601 - v0.8.3 릴리즈
 

--- a/mydocs/orders/20260812.md
+++ b/mydocs/orders/20260812.md
@@ -6,6 +6,18 @@
 | --- | --- | --- | --- |
 | [#4601](https://github.com/edwardkim/rhwp/issues/4601) | v0.8.3 릴리즈 | PR #4612 self-review | code candidate CI 성공, trailing review-only fast-pass 대기 |
 | [#4029](https://github.com/edwardkim/rhwp/issues/4029) | cold-cache release CI 복구 | PR #4581 merge·devel CI 성공 | 운영 기록 fast-pass 뒤 main release-grade CI 재검증 |
+| — | 썸네일 출력 상한 정렬 | PR #4646 Open, CI 대기 | core·Chrome·Firefox·Safari 경로 정합 |
+
+## PR #4646 - 썸네일 출력 상한 정렬
+
+- `devel@193e26b7f`에서 core와 Chrome·Firefox·Safari의 썸네일 추출 경로에 같은 10 MiB
+  출력 상한을 적용했다.
+- 브라우저 확장은 공통 bounded stream collector를 사용하고, 선언 크기와 실제 출력 크기가
+  다르면 결합 버퍼를 만들지 않는다.
+- Rust focused test 4건, service-worker test 118건, fmt, clippy, JavaScript·Safari build script
+  구문 검사와 `git diff --check`가 통과했다.
+- [PR #4646](https://github.com/edwardkim/rhwp/pull/4646)은 Open/non-draft이며 최신 head의
+  GitHub Actions와 review를 기다린다. merge는 수행하지 않는다.
 
 ## Issue #4601 - v0.8.3 릴리즈
 

--- a/mydocs/pr/archives/pr_4646_review.md
+++ b/mydocs/pr/archives/pr_4646_review.md
@@ -5,88 +5,86 @@ canonical: mydocs/manual/pr_review_workflow.md
 last_verified: 2026-08-12
 ---
 
-# PR #4646 리뷰 - 썸네일 출력 상한 정렬
+# PR #4646 리뷰 - 썸네일 출력 상한을 소비자 경계에 배치
 
 ## 결론
 
-**CI 대기 후 수용 권고.** [PR #4646](https://github.com/edwardkim/rhwp/pull/4646)은
-HWPX 썸네일 추출의 출력 상한을 기존 브라우저 미리보기 정책과 같은 10 MiB로 정렬한다.
-core와 세 브라우저 확장 경로가 선언 크기와 실제 stream 출력을 모두 확인하며, 브라우저
-구현은 하나의 공통 collector를 사용한다.
+**Draft 유지, 최신 head의 전체 Contributor 게이트 대기.**
+[PR #4646](https://github.com/edwardkim/rhwp/pull/4646)는 HWP/HWPX 문서 열기와
+브라우저 썸네일 소비자에서 10 MiB 상한을 선택하고, 그 아래 CFB·ZIP·stream
+도우미에는 호출자가 정한 상한만 전달하도록 보정했다.
 
-renderer, layout, paint, sample과 fixture는 바꾸지 않으므로 시각 검증 대상이 아니다. 최신
-head의 Full CI와 CodeQL이 성공하고 review 조건을 충족한 뒤 수용한다. merge는 이 기록의
-범위가 아니다.
+상한을 넘는 `PrvImage`는 선택적 미리보기로 취급한다. 따라서 본문 파싱은 계속
+성공하고, HWP 미리보기 이미지는 생략되며 HWPX contract 스트림은 기존 blank
+fallback을 사용한다. 10 MiB 이하의 정상 미리보기 바이트는 종전처럼 보존한다.
+
+renderer, layout, paint, fixture는 바꾸지 않았으므로 시각 검증 대상이 아니다.
+독립 Gestell 검토는 정책 소유 경계와 정상 문서 호환성에 blocking finding 없음을
+확인했다. 다만 이번 코드 head에 대한 `CONTRIBUTING.md` 전체 게이트는 아직
+순차 실행 대기 상태이므로, 성공 전에는 수용·ready·merge를 권고하지 않는다.
 
 ## 검토 경로
 
 ```text
-base route: collaborator_self_merge.md
-modifiers: intake_and_review.md, local_validation.md
+base route: collaborator_external_pr.md
+modifiers: intake_and_review.md, rework_and_exceptions.md, local_validation.md
 loaded documents: pr_review_workflow.md, pr_review/README.md,
-                  collaborator_self_merge.md, intake_and_review.md,
-                  local_validation.md
-devel base: 193e26b7ffb05adf5bb2c9e4cb752a9a707310dc
-code candidate: da8930952420b9a4b2de15ad78b98431af9e85ab
-trailing review head: 이 문서와 오늘할일을 포함할 후속 docs-only commit
+                  collaborator_external_pr.md, intake_and_review.md,
+                  rework_and_exceptions.md, local_validation.md
+upstream/devel at review: 525cf8e8ed9fa030d1db417fda5070668b2df240
+original remote head: 7bed2bed4f173fded30d80279935617b13c7c84e
+corrected code candidate: b9cd4953f0bc7f6ccd971193b15d542c19a37754
+trailing review head: this docs-only commit
 ```
 
-## 메타데이터
-
-| 항목 | 문서 작성 시점 참고값 |
-| --- | --- |
-| PR | [#4646](https://github.com/edwardkim/rhwp/pull/4646) |
-| 공개 issue 참조 | 없음 |
-| 작성자 | `humdrum00001010` |
-| base / head | `devel` / `humdrum00001010:parser/thumbnail-output-limit-20260812` |
-| code candidate | `da8930952420b9a4b2de15ad78b98431af9e85ab` |
-| 규모 | 10 files, +242 / -50 |
-| 상태 | Open, non-draft, MERGEABLE / BLOCKED; checks 미보고 |
-| reviewer request | `edwardkim` 요청은 현재 계정 권한 부족으로 반영되지 않음 |
-
-원본 저장소 작업 branch push도 현재 계정 권한으로 403이어서 같은 commit을 fork branch에
-push하고 `devel` 대상 PR을 만들었다. 이 권한 제약은 code candidate 내용과 base 정합에는
-영향이 없다.
+`git merge-tree --write-tree upstream/devel b9cd4953`는 clean tree
+`d1852472aa9f0730aa9218831e2cd36c921d08e0`를 만들었고,
+`git diff --check upstream/devel...b9cd4953`도 통과했다. 이 기록은
+collaborator source branch의 정정이며 contributor history를 재작성하지 않는다.
 
 ## 변경 판단
 
-- Rust 경로는 ZIP central-directory의 비압축 크기를 먼저 확인하고, `Read::take(max + 1)`로
-  실제 read 결과도 다시 제한한다.
-- Chrome과 Firefox는 같은 shared script를 symlink로 소비한다. Safari는 background보다 먼저
-  같은 script를 로드하고 build 산출물에도 복사한다.
-- shared collector는 선언 크기가 상한 밖이면 reader를 열지 않고, stream이 선언 크기를
-  초과하면 즉시 취소한다. 크기가 일치할 때만 최종 `Uint8Array`를 만든다.
-- 기존 CFB 썸네일 경로의 10 MiB 정책도 같은 상수를 사용해 경로별 숫자 드리프트를 막는다.
+### 정책을 선택하는 end-to-end 소비자
 
-제품 출력이나 조판은 바뀌지 않는다. 허용 범위 안의 정상 썸네일은 종전과 같은 이미지
-파싱 경로로 전달되고, 상한 밖 또는 크기 불일치 입력만 썸네일 없음으로 처리한다.
+- Rust HWP 문서 열기: `parse_hwp_with_cfb`가 `extract_preview`에 10 MiB를 전달한다.
+- Rust HWPX 문서 열기: `parse_hwpx`가 `Preview/PrvImage.png` 보존과 HWP contract
+  변환에 같은 상한을 전달한다.
+- Rust 썸네일 전용 공개 API: `extract_thumbnail_only`가 HWP/HWPX 양쪽에 상한을
+  전달한다.
+- Chrome·Firefox·Safari: 각 `extractThumbnailFromUrl`이 10 MiB를 선택하여 CFB/ZIP
+  추출기에 전달한다. Safari의 content-script 메시지는 이 공개 소비자로만 진입한다.
 
-## merge simulation
+### 정책을 선택하지 않는 기계적 도우미
 
-후속 review commit을 push한 뒤 `upstream/devel`을 다시 fetch했으며 기준선은 계속
-`193e26b7ffb05adf5bb2c9e4cb752a9a707310dc`였다. `git merge-tree --write-tree
-upstream/devel HEAD` 결과 `ab6902fa84bee30b3ccd39a7eca0936b631b5b3b`는 같은 시점의
-`HEAD^{tree}`와 일치했다. current base 기준 conflict와 추가 conflict resolution은 없고,
-`git diff --check upstream/devel...HEAD`도 통과했다.
+- `CfbReader::read_preview_image_limited(max_bytes)`, Rust ZIP thumbnail reader,
+  HWPX contract 추출, `HwpxReader::read_file_bytes_limited` 호출은 모두 전달받은
+  상한만 검사한다.
+- Chrome·Firefox·Safari 공용 `readExactStreamLimited(readable, declaredSize,
+  maxBytes)`는 썸네일 숫자를 보유하지 않는다. 선언 크기, 실제 stream 길이, 그리고
+  호출자 상한의 일치만 검사한다.
 
-## 완료한 검증
+따라서 generic HWPX 바이트 reader의 기존 BinData 기본 정책을 이 PR 범위에서
+바꾸지 않으면서도, 모든 `Preview/PrvImage.png` 소비 경로는 명시적인 10 MiB
+경로를 사용한다.
 
-| 게이트 | 결과 |
-| --- | --- |
-| `cargo fmt --check` | 통과 |
-| `cargo test --lib thumbnail_ -- --nocapture` | 4 passed, 3,509 filtered |
-| `cargo clippy --all-targets -- -D warnings` | 통과 |
-| service-worker 공식 test 명령 | 118 passed |
-| JS 구문 검사 / `bash -n rhwp-safari/build.sh` | 통과 |
-| `git diff --check` | 통과 |
+## 회귀 근거
 
-디스크 제약과 다중 작업의 Cargo 순차 게이트에 따라 로컬 release-test 전체와 확장 package build는
-중복 실행하지 않았다. 최신 PR head의 Full CI가 Rust 전체 회귀와 frontend package lane을 담당한다.
-Safari Xcode 산출물은 변경하지 않았으며, shared script의 manifest 순서와 build 복사는 결정적
-contract test와 구문 검사로 확인했다.
+| 범위 | 명령 / 확인 | 결과 |
+| --- | --- | --- |
+| Rust 문서 열기 | `cargo test --lib document_open_` | 4 passed — HWP/HWPX의 정상 미리보기 보존 및 초과 미리보기에서 문서 열기 지속 |
+| Rust 썸네일 경로 | `cargo test --lib thumbnail_` | 7 passed — 선언 크기 초과·실제 길이 불일치 거부 포함 |
+| 브라우저 공개 소비자 | `node --test rhwp-shared/sw/thumbnail-decompression.test.js` | 6 passed — Chrome `extractThumbnailFromUrl`로 정상 HWPX thumbnail과 초과 선언 크기 확인 |
+| 정적/형식 검사 | `node --check` (Chrome, Firefox, Safari, shared), `cargo fmt --all -- --check`, `git diff --check` | 통과 |
+| 독립 설계 검토 | terra-max Gestell adversarial review | PASS — 정책 선택은 소비자 경계, 하위 도우미는 명시 상한만 적용 |
 
-## 최종 권고
+전체 `cargo test --profile release-test --tests`와 `cargo clippy -- -D warnings`는
+코드 정정 후 최신 head에서 별도로 순차 실행해야 한다. 이전 head의 성공 기록을
+이 code candidate의 통과 근거로 재사용하지 않는다.
 
-blocking code finding은 없다. 이 review 문서와 오늘할일만 추가한 trailing commit을 fork의 같은
-PR branch에 push한 뒤, 최신 head의 required checks와 mergeability를 다시 확인한다. reviewer 지정은
-권한 있는 maintainer가 수행해야 하며, 별도 승인 전에는 merge하지 않는다.
+## 다음 확인
+
+1. 최신 head에서 `CONTRIBUTING.md`의 전체 Rust gate를 순차 실행한다.
+2. GitHub가 새 head의 required check를 게시한 뒤 Draft 상태와 mergeability를 다시
+   확인한다.
+3. 별도 승인 전에는 Draft 해제, reviewer 지정, merge, advisory 상태 변경을 하지
+   않는다.

--- a/mydocs/pr/archives/pr_4646_review.md
+++ b/mydocs/pr/archives/pr_4646_review.md
@@ -1,0 +1,84 @@
+---
+kind: pr-review
+status: pending-ci
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-12
+---
+
+# PR #4646 리뷰 - 썸네일 출력 상한 정렬
+
+## 결론
+
+**CI 대기 후 수용 권고.** [PR #4646](https://github.com/edwardkim/rhwp/pull/4646)은
+HWPX 썸네일 추출의 출력 상한을 기존 브라우저 미리보기 정책과 같은 10 MiB로 정렬한다.
+core와 세 브라우저 확장 경로가 선언 크기와 실제 stream 출력을 모두 확인하며, 브라우저
+구현은 하나의 공통 collector를 사용한다.
+
+renderer, layout, paint, sample과 fixture는 바꾸지 않으므로 시각 검증 대상이 아니다. 최신
+head의 Full CI와 CodeQL이 성공하고 review 조건을 충족한 뒤 수용한다. merge는 이 기록의
+범위가 아니다.
+
+## 검토 경로
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, local_validation.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+                  collaborator_self_merge.md, intake_and_review.md,
+                  local_validation.md
+devel base: 193e26b7ffb05adf5bb2c9e4cb752a9a707310dc
+code candidate: da8930952420b9a4b2de15ad78b98431af9e85ab
+trailing review head: 이 문서와 오늘할일을 포함할 후속 docs-only commit
+```
+
+## 메타데이터
+
+| 항목 | 문서 작성 시점 참고값 |
+| --- | --- |
+| PR | [#4646](https://github.com/edwardkim/rhwp/pull/4646) |
+| 공개 issue 참조 | 없음 |
+| 작성자 | `humdrum00001010` |
+| base / head | `devel` / `humdrum00001010:parser/thumbnail-output-limit-20260812` |
+| code candidate | `da8930952420b9a4b2de15ad78b98431af9e85ab` |
+| 규모 | 10 files, +242 / -50 |
+| 상태 | Open, non-draft, MERGEABLE / BLOCKED; checks 미보고 |
+| reviewer request | `edwardkim` 요청은 현재 계정 권한 부족으로 반영되지 않음 |
+
+원본 저장소 작업 branch push도 현재 계정 권한으로 403이어서 같은 commit을 fork branch에
+push하고 `devel` 대상 PR을 만들었다. 이 권한 제약은 code candidate 내용과 base 정합에는
+영향이 없다.
+
+## 변경 판단
+
+- Rust 경로는 ZIP central-directory의 비압축 크기를 먼저 확인하고, `Read::take(max + 1)`로
+  실제 read 결과도 다시 제한한다.
+- Chrome과 Firefox는 같은 shared script를 symlink로 소비한다. Safari는 background보다 먼저
+  같은 script를 로드하고 build 산출물에도 복사한다.
+- shared collector는 선언 크기가 상한 밖이면 reader를 열지 않고, stream이 선언 크기를
+  초과하면 즉시 취소한다. 크기가 일치할 때만 최종 `Uint8Array`를 만든다.
+- 기존 CFB 썸네일 경로의 10 MiB 정책도 같은 상수를 사용해 경로별 숫자 드리프트를 막는다.
+
+제품 출력이나 조판은 바뀌지 않는다. 허용 범위 안의 정상 썸네일은 종전과 같은 이미지
+파싱 경로로 전달되고, 상한 밖 또는 크기 불일치 입력만 썸네일 없음으로 처리한다.
+
+## 완료한 검증
+
+| 게이트 | 결과 |
+| --- | --- |
+| `cargo fmt --check` | 통과 |
+| `cargo test --lib thumbnail_ -- --nocapture` | 4 passed, 3,509 filtered |
+| `cargo clippy --all-targets -- -D warnings` | 통과 |
+| service-worker 공식 test 명령 | 118 passed |
+| JS 구문 검사 / `bash -n rhwp-safari/build.sh` | 통과 |
+| `git diff --check` | 통과 |
+
+디스크 제약과 다중 작업의 Cargo 순차 게이트에 따라 로컬 release-test 전체와 확장 package build는
+중복 실행하지 않았다. 최신 PR head의 Full CI가 Rust 전체 회귀와 frontend package lane을 담당한다.
+Safari Xcode 산출물은 변경하지 않았으며, shared script의 manifest 순서와 build 복사는 결정적
+contract test와 구문 검사로 확인했다.
+
+## 최종 권고
+
+blocking code finding은 없다. 이 review 문서와 오늘할일만 추가한 trailing commit을 fork의 같은
+PR branch에 push한 뒤, 최신 head의 required checks와 mergeability를 다시 확인한다. reviewer 지정은
+권한 있는 maintainer가 수행해야 하며, 별도 승인 전에는 merge하지 않는다.

--- a/mydocs/pr/archives/pr_4646_review.md
+++ b/mydocs/pr/archives/pr_4646_review.md
@@ -9,7 +9,7 @@ last_verified: 2026-08-12
 
 ## 결론
 
-**Draft 유지, 최신 head의 전체 Contributor 게이트 대기.**
+**Draft 유지, GitHub 원격 check 완료 대기.**
 [PR #4646](https://github.com/edwardkim/rhwp/pull/4646)는 HWP/HWPX 문서 열기와
 브라우저 썸네일 소비자에서 10 MiB 상한을 선택하고, 그 아래 CFB·ZIP·stream
 도우미에는 호출자가 정한 상한만 전달하도록 보정했다.
@@ -20,8 +20,9 @@ fallback을 사용한다. 10 MiB 이하의 정상 미리보기 바이트는 종�
 
 renderer, layout, paint, fixture는 바꾸지 않았으므로 시각 검증 대상이 아니다.
 독립 Gestell 검토는 정책 소유 경계와 정상 문서 호환성에 blocking finding 없음을
-확인했다. 다만 이번 코드 head에 대한 `CONTRIBUTING.md` 전체 게이트는 아직
-순차 실행 대기 상태이므로, 성공 전에는 수용·ready·merge를 권고하지 않는다.
+확인했다. `b7c501101`에서 `CONTRIBUTING.md`의 전체 Rust gate는 순차 실행하여
+통과했다. 다만 현재 GitHub CI·CodeQL workflow에는 아직 진행 중인 job이 있으므로,
+원격 check가 끝나기 전에는 수용·ready·merge를 권고하지 않는다.
 
 ## 검토 경로
 
@@ -34,6 +35,7 @@ loaded documents: pr_review_workflow.md, pr_review/README.md,
 upstream/devel at review: 525cf8e8ed9fa030d1db417fda5070668b2df240
 original remote head: 7bed2bed4f173fded30d80279935617b13c7c84e
 corrected code candidate: b9cd4953f0bc7f6ccd971193b15d542c19a37754
+full local gate head: b7c501101ea33aac2b2f17a975a79862f7ce3a85
 trailing review head: this docs-only commit
 ```
 
@@ -74,17 +76,20 @@ collaborator source branch의 정정이며 contributor history를 재작성하�
 | Rust 문서 열기 | `cargo test --lib document_open_` | 4 passed — HWP/HWPX의 정상 미리보기 보존 및 초과 미리보기에서 문서 열기 지속 |
 | Rust 썸네일 경로 | `cargo test --lib thumbnail_` | 7 passed — 선언 크기 초과·실제 길이 불일치 거부 포함 |
 | 브라우저 공개 소비자 | `node --test rhwp-shared/sw/thumbnail-decompression.test.js` | 6 passed — Chrome `extractThumbnailFromUrl`로 정상 HWPX thumbnail과 초과 선언 크기 확인 |
-| 정적/형식 검사 | `node --check` (Chrome, Firefox, Safari, shared), `cargo fmt --all -- --check`, `git diff --check` | 통과 |
+| 정적/형식 검사 | `node --check` (Chrome, Firefox, Safari, shared) | 통과 |
 | 독립 설계 검토 | terra-max Gestell adversarial review | PASS — 정책 선택은 소비자 경계, 하위 도우미는 명시 상한만 적용 |
+| Contributor 형식 gate | `cargo fmt --all -- --check` | `b7c501101`에서 통과 |
+| Contributor 전체 Rust 회귀 | `cargo test --profile release-test --tests` | `b7c501101`에서 exit 0으로 통과 |
+| Contributor lint gate | `cargo clippy -- -D warnings` | `b7c501101`에서 통과 |
+| 최종 diff 검사 | `git diff --check` | `b7c501101`에서 통과 |
 
-전체 `cargo test --profile release-test --tests`와 `cargo clippy -- -D warnings`는
-코드 정정 후 최신 head에서 별도로 순차 실행해야 한다. 이전 head의 성공 기록을
-이 code candidate의 통과 근거로 재사용하지 않는다.
+위 Contributor gate는 코드와 직전 review 기록을 포함한 정확한 `b7c501101` head에서
+순차 실행했다. 이전 head의 성공 기록을 이 code candidate의 통과 근거로 재사용하지
+않았다.
 
 ## 다음 확인
 
-1. 최신 head에서 `CONTRIBUTING.md`의 전체 Rust gate를 순차 실행한다.
-2. GitHub가 새 head의 required check를 게시한 뒤 Draft 상태와 mergeability를 다시
+1. 현재 GitHub CI·CodeQL의 진행 중 job과 새 head의 required check를 완료 뒤 다시
    확인한다.
-3. 별도 승인 전에는 Draft 해제, reviewer 지정, merge, advisory 상태 변경을 하지
+2. 별도 승인 전에는 Draft 해제, reviewer 지정, merge, advisory 상태 변경을 하지
    않는다.

--- a/mydocs/pr/archives/pr_4646_review.md
+++ b/mydocs/pr/archives/pr_4646_review.md
@@ -61,6 +61,14 @@ push하고 `devel` 대상 PR을 만들었다. 이 권한 제약은 code candidat
 제품 출력이나 조판은 바뀌지 않는다. 허용 범위 안의 정상 썸네일은 종전과 같은 이미지
 파싱 경로로 전달되고, 상한 밖 또는 크기 불일치 입력만 썸네일 없음으로 처리한다.
 
+## merge simulation
+
+후속 review commit을 push한 뒤 `upstream/devel`을 다시 fetch했으며 기준선은 계속
+`193e26b7ffb05adf5bb2c9e4cb752a9a707310dc`였다. `git merge-tree --write-tree
+upstream/devel HEAD` 결과 `ab6902fa84bee30b3ccd39a7eca0936b631b5b3b`는 같은 시점의
+`HEAD^{tree}`와 일치했다. current base 기준 conflict와 추가 conflict resolution은 없고,
+`git diff --check upstream/devel...HEAD`도 통과했다.
+
 ## 완료한 검증
 
 | 게이트 | 결과 |

--- a/rhwp-chrome/sw/thumbnail-decompression.js
+++ b/rhwp-chrome/sw/thumbnail-decompression.js
@@ -1,0 +1,1 @@
+../../rhwp-shared/sw/thumbnail-decompression.js

--- a/rhwp-chrome/sw/thumbnail-extractor.js
+++ b/rhwp-chrome/sw/thumbnail-extractor.js
@@ -338,7 +338,7 @@ async function extractPrvImageFromZipAsync(data) {
 
       if (compMethod === 0) {
         // 비압축 (stored)
-        if (uncompSize > data.length - dataStart) return null;
+        if (compSize !== uncompSize || uncompSize > data.length - dataStart) return null;
         const imageData = data.subarray(dataStart, dataStart + uncompSize);
         return parseImageData(imageData);
       } else if (compMethod === 8) {

--- a/rhwp-chrome/sw/thumbnail-extractor.js
+++ b/rhwp-chrome/sw/thumbnail-extractor.js
@@ -6,13 +6,11 @@
 import { fetchDocumentWithPolicy, validateDocumentFetchUrl } from './fetch-security.js';
 import './thumbnail-decompression.js';
 
-const {
-  MAX_THUMBNAIL_BYTES,
-  readThumbnailStreamLimited,
-} = globalThis.rhwpThumbnailDecompression;
+const { readExactStreamLimited } = globalThis.rhwpBoundedStream;
 
 const THUMBNAIL_CACHE = new Map();
 const CACHE_MAX_SIZE = 100;
+const THUMBNAIL_OUTPUT_LIMIT_BYTES = 10 * 1024 * 1024;
 
 /**
  * URL에서 HWP 파일을 fetch하여 PrvImage 썸네일을 추출한다.
@@ -38,8 +36,8 @@ export async function extractThumbnailFromUrl(url, options = {}) {
     // HWP(CFB) 또는 HWPX(ZIP) 감지
     const isZip = data.length >= 4 && data[0] === 0x50 && data[1] === 0x4B;
     const result = isZip
-      ? await extractPrvImageFromZipAsync(data)
-      : extractPrvImage(data);
+      ? await extractPrvImageFromZipAsync(data, THUMBNAIL_OUTPUT_LIMIT_BYTES)
+      : extractPrvImage(data, THUMBNAIL_OUTPUT_LIMIT_BYTES);
     if (result) {
       // 캐시 저장 (LRU)
       if (THUMBNAIL_CACHE.size >= CACHE_MAX_SIZE) {
@@ -64,7 +62,7 @@ export async function extractThumbnailFromUrl(url, options = {}) {
  *
  * 디렉토리 섹터도 FAT 체인으로 연결될 수 있으므로 체인 전체를 순회한다.
  */
-function extractPrvImage(data) {
+function extractPrvImage(data, maxBytes) {
   // CFB 매직 넘버 확인
   if (data.length < 512) return null;
   if (data[0] !== 0xD0 || data[1] !== 0xCF || data[2] !== 0x11 || data[3] !== 0xE0) return null;
@@ -115,7 +113,7 @@ function extractPrvImage(data) {
       const startSector = readU32LE(data, entryOffset + 116);
       const streamSize  = readU32LE(data, entryOffset + 120);
 
-      if (streamSize === 0 || streamSize > MAX_THUMBNAIL_BYTES) continue;
+      if (streamSize === 0 || streamSize > maxBytes) continue;
 
       let streamData;
       if (streamSize < miniStreamCutoff && miniStreamData) {
@@ -293,7 +291,7 @@ function parseImageData(data) {
  *
  * ZIP End of Central Directory → Central Directory → 로컬 파일 헤더 → 데이터
  */
-async function extractPrvImageFromZipAsync(data) {
+async function extractPrvImageFromZipAsync(data, maxBytes) {
   // End of Central Directory 찾기 (ZIP 파일 끝에서 역방향 탐색)
   let eocdOffset = -1;
   for (let i = data.length - 22; i >= 0 && i >= data.length - 65558; i--) {
@@ -327,7 +325,7 @@ async function extractPrvImageFromZipAsync(data) {
 
     // Preview/PrvImage 확인
     if (name.startsWith('Preview/PrvImage')) {
-      if (uncompSize === 0 || uncompSize > MAX_THUMBNAIL_BYTES) return null;
+      if (uncompSize === 0 || uncompSize > maxBytes) return null;
 
       // 로컬 파일 헤더에서 실제 데이터 위치 계산
       if (localHeaderOffset + 30 >= data.length) break;
@@ -348,7 +346,11 @@ async function extractPrvImageFromZipAsync(data) {
           const ds = new DecompressionStream('raw');
           const writer = ds.writable.getWriter();
           const write = writer.write(compressed).then(() => writer.close());
-          const decompressed = await readThumbnailStreamLimited(ds.readable, uncompSize);
+          const decompressed = await readExactStreamLimited(
+            ds.readable,
+            uncompSize,
+            maxBytes,
+          );
           const writeSucceeded = await write.then(() => true, () => false);
           if (!decompressed || !writeSucceeded) return null;
           return parseImageData(decompressed);

--- a/rhwp-chrome/sw/thumbnail-extractor.js
+++ b/rhwp-chrome/sw/thumbnail-extractor.js
@@ -4,6 +4,12 @@
 // 전체 HWP 파싱 없이 썸네일만 빠르게 얻을 수 있다.
 
 import { fetchDocumentWithPolicy, validateDocumentFetchUrl } from './fetch-security.js';
+import './thumbnail-decompression.js';
+
+const {
+  MAX_THUMBNAIL_BYTES,
+  readThumbnailStreamLimited,
+} = globalThis.rhwpThumbnailDecompression;
 
 const THUMBNAIL_CACHE = new Map();
 const CACHE_MAX_SIZE = 100;
@@ -109,7 +115,7 @@ function extractPrvImage(data) {
       const startSector = readU32LE(data, entryOffset + 116);
       const streamSize  = readU32LE(data, entryOffset + 120);
 
-      if (streamSize === 0 || streamSize > 10 * 1024 * 1024) continue;
+      if (streamSize === 0 || streamSize > MAX_THUMBNAIL_BYTES) continue;
 
       let streamData;
       if (streamSize < miniStreamCutoff && miniStreamData) {
@@ -321,14 +327,18 @@ async function extractPrvImageFromZipAsync(data) {
 
     // Preview/PrvImage 확인
     if (name.startsWith('Preview/PrvImage')) {
+      if (uncompSize === 0 || uncompSize > MAX_THUMBNAIL_BYTES) return null;
+
       // 로컬 파일 헤더에서 실제 데이터 위치 계산
       if (localHeaderOffset + 30 >= data.length) break;
       const localNameLen = readU16LE(data, localHeaderOffset + 26);
       const localExtraLen = readU16LE(data, localHeaderOffset + 28);
       const dataStart = localHeaderOffset + 30 + localNameLen + localExtraLen;
+      if (dataStart > data.length || compSize > data.length - dataStart) return null;
 
       if (compMethod === 0) {
         // 비압축 (stored)
+        if (uncompSize > data.length - dataStart) return null;
         const imageData = data.subarray(dataStart, dataStart + uncompSize);
         return parseImageData(imageData);
       } else if (compMethod === 8) {
@@ -337,22 +347,10 @@ async function extractPrvImageFromZipAsync(data) {
           const compressed = data.slice(dataStart, dataStart + compSize);
           const ds = new DecompressionStream('raw');
           const writer = ds.writable.getWriter();
-          writer.write(compressed);
-          writer.close();
-          const reader = ds.readable.getReader();
-          const chunks = [];
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            chunks.push(value);
-          }
-          const totalLen = chunks.reduce((s, c) => s + c.length, 0);
-          const decompressed = new Uint8Array(totalLen);
-          let offset = 0;
-          for (const chunk of chunks) {
-            decompressed.set(chunk, offset);
-            offset += chunk.length;
-          }
+          const write = writer.write(compressed).then(() => writer.close());
+          const decompressed = await readThumbnailStreamLimited(ds.readable, uncompSize);
+          const writeSucceeded = await write.then(() => true, () => false);
+          if (!decompressed || !writeSucceeded) return null;
           return parseImageData(decompressed);
         } catch {
           return null;

--- a/rhwp-firefox/sw/thumbnail-decompression.js
+++ b/rhwp-firefox/sw/thumbnail-decompression.js
@@ -1,0 +1,1 @@
+../../rhwp-shared/sw/thumbnail-decompression.js

--- a/rhwp-firefox/sw/thumbnail-extractor.js
+++ b/rhwp-firefox/sw/thumbnail-extractor.js
@@ -338,7 +338,7 @@ async function extractPrvImageFromZipAsync(data) {
 
       if (compMethod === 0) {
         // 비압축 (stored)
-        if (uncompSize > data.length - dataStart) return null;
+        if (compSize !== uncompSize || uncompSize > data.length - dataStart) return null;
         const imageData = data.subarray(dataStart, dataStart + uncompSize);
         return parseImageData(imageData);
       } else if (compMethod === 8) {

--- a/rhwp-firefox/sw/thumbnail-extractor.js
+++ b/rhwp-firefox/sw/thumbnail-extractor.js
@@ -6,13 +6,11 @@
 import { fetchDocumentWithPolicy, validateDocumentFetchUrl } from './fetch-security.js';
 import './thumbnail-decompression.js';
 
-const {
-  MAX_THUMBNAIL_BYTES,
-  readThumbnailStreamLimited,
-} = globalThis.rhwpThumbnailDecompression;
+const { readExactStreamLimited } = globalThis.rhwpBoundedStream;
 
 const THUMBNAIL_CACHE = new Map();
 const CACHE_MAX_SIZE = 100;
+const THUMBNAIL_OUTPUT_LIMIT_BYTES = 10 * 1024 * 1024;
 
 /**
  * URL에서 HWP 파일을 fetch하여 PrvImage 썸네일을 추출한다.
@@ -38,8 +36,8 @@ export async function extractThumbnailFromUrl(url, options = {}) {
     // HWP(CFB) 또는 HWPX(ZIP) 감지
     const isZip = data.length >= 4 && data[0] === 0x50 && data[1] === 0x4B;
     const result = isZip
-      ? await extractPrvImageFromZipAsync(data)
-      : extractPrvImage(data);
+      ? await extractPrvImageFromZipAsync(data, THUMBNAIL_OUTPUT_LIMIT_BYTES)
+      : extractPrvImage(data, THUMBNAIL_OUTPUT_LIMIT_BYTES);
     if (result) {
       // 캐시 저장 (LRU)
       if (THUMBNAIL_CACHE.size >= CACHE_MAX_SIZE) {
@@ -64,7 +62,7 @@ export async function extractThumbnailFromUrl(url, options = {}) {
  *
  * 디렉토리 섹터도 FAT 체인으로 연결될 수 있으므로 체인 전체를 순회한다.
  */
-function extractPrvImage(data) {
+function extractPrvImage(data, maxBytes) {
   // CFB 매직 넘버 확인
   if (data.length < 512) return null;
   if (data[0] !== 0xD0 || data[1] !== 0xCF || data[2] !== 0x11 || data[3] !== 0xE0) return null;
@@ -115,7 +113,7 @@ function extractPrvImage(data) {
       const startSector = readU32LE(data, entryOffset + 116);
       const streamSize  = readU32LE(data, entryOffset + 120);
 
-      if (streamSize === 0 || streamSize > MAX_THUMBNAIL_BYTES) continue;
+      if (streamSize === 0 || streamSize > maxBytes) continue;
 
       let streamData;
       if (streamSize < miniStreamCutoff && miniStreamData) {
@@ -293,7 +291,7 @@ function parseImageData(data) {
  *
  * ZIP End of Central Directory → Central Directory → 로컬 파일 헤더 → 데이터
  */
-async function extractPrvImageFromZipAsync(data) {
+async function extractPrvImageFromZipAsync(data, maxBytes) {
   // End of Central Directory 찾기 (ZIP 파일 끝에서 역방향 탐색)
   let eocdOffset = -1;
   for (let i = data.length - 22; i >= 0 && i >= data.length - 65558; i--) {
@@ -327,7 +325,7 @@ async function extractPrvImageFromZipAsync(data) {
 
     // Preview/PrvImage 확인
     if (name.startsWith('Preview/PrvImage')) {
-      if (uncompSize === 0 || uncompSize > MAX_THUMBNAIL_BYTES) return null;
+      if (uncompSize === 0 || uncompSize > maxBytes) return null;
 
       // 로컬 파일 헤더에서 실제 데이터 위치 계산
       if (localHeaderOffset + 30 >= data.length) break;
@@ -348,7 +346,11 @@ async function extractPrvImageFromZipAsync(data) {
           const ds = new DecompressionStream('raw');
           const writer = ds.writable.getWriter();
           const write = writer.write(compressed).then(() => writer.close());
-          const decompressed = await readThumbnailStreamLimited(ds.readable, uncompSize);
+          const decompressed = await readExactStreamLimited(
+            ds.readable,
+            uncompSize,
+            maxBytes,
+          );
           const writeSucceeded = await write.then(() => true, () => false);
           if (!decompressed || !writeSucceeded) return null;
           return parseImageData(decompressed);

--- a/rhwp-firefox/sw/thumbnail-extractor.js
+++ b/rhwp-firefox/sw/thumbnail-extractor.js
@@ -4,6 +4,12 @@
 // 전체 HWP 파싱 없이 썸네일만 빠르게 얻을 수 있다.
 
 import { fetchDocumentWithPolicy, validateDocumentFetchUrl } from './fetch-security.js';
+import './thumbnail-decompression.js';
+
+const {
+  MAX_THUMBNAIL_BYTES,
+  readThumbnailStreamLimited,
+} = globalThis.rhwpThumbnailDecompression;
 
 const THUMBNAIL_CACHE = new Map();
 const CACHE_MAX_SIZE = 100;
@@ -109,7 +115,7 @@ function extractPrvImage(data) {
       const startSector = readU32LE(data, entryOffset + 116);
       const streamSize  = readU32LE(data, entryOffset + 120);
 
-      if (streamSize === 0 || streamSize > 10 * 1024 * 1024) continue;
+      if (streamSize === 0 || streamSize > MAX_THUMBNAIL_BYTES) continue;
 
       let streamData;
       if (streamSize < miniStreamCutoff && miniStreamData) {
@@ -321,14 +327,18 @@ async function extractPrvImageFromZipAsync(data) {
 
     // Preview/PrvImage 확인
     if (name.startsWith('Preview/PrvImage')) {
+      if (uncompSize === 0 || uncompSize > MAX_THUMBNAIL_BYTES) return null;
+
       // 로컬 파일 헤더에서 실제 데이터 위치 계산
       if (localHeaderOffset + 30 >= data.length) break;
       const localNameLen = readU16LE(data, localHeaderOffset + 26);
       const localExtraLen = readU16LE(data, localHeaderOffset + 28);
       const dataStart = localHeaderOffset + 30 + localNameLen + localExtraLen;
+      if (dataStart > data.length || compSize > data.length - dataStart) return null;
 
       if (compMethod === 0) {
         // 비압축 (stored)
+        if (uncompSize > data.length - dataStart) return null;
         const imageData = data.subarray(dataStart, dataStart + uncompSize);
         return parseImageData(imageData);
       } else if (compMethod === 8) {
@@ -337,22 +347,10 @@ async function extractPrvImageFromZipAsync(data) {
           const compressed = data.slice(dataStart, dataStart + compSize);
           const ds = new DecompressionStream('raw');
           const writer = ds.writable.getWriter();
-          writer.write(compressed);
-          writer.close();
-          const reader = ds.readable.getReader();
-          const chunks = [];
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            chunks.push(value);
-          }
-          const totalLen = chunks.reduce((s, c) => s + c.length, 0);
-          const decompressed = new Uint8Array(totalLen);
-          let offset = 0;
-          for (const chunk of chunks) {
-            decompressed.set(chunk, offset);
-            offset += chunk.length;
-          }
+          const write = writer.write(compressed).then(() => writer.close());
+          const decompressed = await readThumbnailStreamLimited(ds.readable, uncompSize);
+          const writeSucceeded = await write.then(() => true, () => false);
+          if (!decompressed || !writeSucceeded) return null;
           return parseImageData(decompressed);
         } catch {
           return null;

--- a/rhwp-safari/build.sh
+++ b/rhwp-safari/build.sh
@@ -26,7 +26,7 @@ cp -R "$CHROME_DIST" "$DIST"
 
 # 3. Safari 전용 소스 문법 검사 + 복사
 echo "[3/6] JS 문법 검사..."
-for jsfile in "$ROOT"/rhwp-shared/security/file-signature.js "$SRC"/background.js "$SRC"/content-script.js "$SRC"/options.js; do
+for jsfile in "$ROOT"/rhwp-shared/security/file-signature.js "$ROOT"/rhwp-shared/sw/thumbnail-decompression.js "$SRC"/background.js "$SRC"/content-script.js "$SRC"/options.js; do
   if ! node --check "$jsfile" 2>&1; then
     echo "오류: $jsfile 문법 오류 발견. 빌드 중단."
     exit 1
@@ -37,6 +37,7 @@ done
 echo "[4/6] Safari 전용 소스 적용..."
 cp "$SRC/background.js" "$DIST/background.js"
 cp "$ROOT/rhwp-shared/security/file-signature.js" "$DIST/file-signature.js"
+cp "$ROOT/rhwp-shared/sw/thumbnail-decompression.js" "$DIST/thumbnail-decompression.js"
 cp "$SRC/content-script.js" "$DIST/content-script.js"
 cp "$SRC/manifest.json" "$DIST/manifest.json"
 cp "$SRC/options.html" "$DIST/options.html"

--- a/rhwp-safari/src/background.js
+++ b/rhwp-safari/src/background.js
@@ -433,7 +433,7 @@ async function extractPrvImageFromZip(data) {
       const ds = locOff + 30 + lnLen + leLen;
       if (ds > data.length || compSz > data.length - ds) return null;
       if (comp === 0) {
-        if (uncSz > data.length - ds) return null;
+        if (compSz !== uncSz || uncSz > data.length - ds) return null;
         return _parseImage(data.subarray(ds, ds + uncSz));
       }
       if (comp === 8) {

--- a/rhwp-safari/src/background.js
+++ b/rhwp-safari/src/background.js
@@ -326,6 +326,10 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 const THUMBNAIL_CACHE = new Map();
 const CACHE_MAX_SIZE = 100;
+const {
+  MAX_THUMBNAIL_BYTES,
+  readThumbnailStreamLimited,
+} = globalThis.rhwpThumbnailDecompression;
 
 async function extractThumbnailFromUrl(url) {
   if (THUMBNAIL_CACHE.has(url)) return THUMBNAIL_CACHE.get(url);
@@ -371,7 +375,7 @@ function extractPrvImageFromCFB(data) {
     if (name !== 'PrvImage') continue;
     const startSector = _u32(data, eo + 116);
     const streamSize = _u32(data, eo + 120);
-    if (streamSize === 0 || streamSize > 10 * 1024 * 1024) continue;
+    if (streamSize === 0 || streamSize > MAX_THUMBNAIL_BYTES) continue;
     const fatSectors = [];
     for (let j = 0; j < 109; j++) {
       const fs = _u32(data, 76 + j * 4);
@@ -422,23 +426,24 @@ async function extractPrvImageFromZip(data) {
     const locOff = _u32(data, off + 42);
     const name = new TextDecoder().decode(data.subarray(off + 46, off + 46 + nLen));
     if (name.startsWith('Preview/PrvImage')) {
+      if (uncSz === 0 || uncSz > MAX_THUMBNAIL_BYTES) return null;
+      if (locOff + 30 >= data.length) return null;
       const lnLen = _u16(data, locOff + 26);
       const leLen = _u16(data, locOff + 28);
       const ds = locOff + 30 + lnLen + leLen;
-      if (comp === 0) return _parseImage(data.subarray(ds, ds + uncSz));
+      if (ds > data.length || compSz > data.length - ds) return null;
+      if (comp === 0) {
+        if (uncSz > data.length - ds) return null;
+        return _parseImage(data.subarray(ds, ds + uncSz));
+      }
       if (comp === 8) {
         try {
           const dec = new DecompressionStream('raw');
           const w = dec.writable.getWriter();
-          w.write(data.slice(ds, ds + compSz));
-          w.close();
-          const r = dec.readable.getReader();
-          const chunks = [];
-          while (true) { const { done, value } = await r.read(); if (done) break; chunks.push(value); }
-          const total = chunks.reduce((s, c) => s + c.length, 0);
-          const buf = new Uint8Array(total);
-          let o = 0;
-          for (const c of chunks) { buf.set(c, o); o += c.length; }
+          const write = w.write(data.slice(ds, ds + compSz)).then(() => w.close());
+          const buf = await readThumbnailStreamLimited(dec.readable, uncSz);
+          const writeSucceeded = await write.then(() => true, () => false);
+          if (!buf || !writeSucceeded) return null;
           return _parseImage(buf);
         } catch { return null; }
       }

--- a/rhwp-safari/src/background.js
+++ b/rhwp-safari/src/background.js
@@ -326,10 +326,8 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 const THUMBNAIL_CACHE = new Map();
 const CACHE_MAX_SIZE = 100;
-const {
-  MAX_THUMBNAIL_BYTES,
-  readThumbnailStreamLimited,
-} = globalThis.rhwpThumbnailDecompression;
+const { readExactStreamLimited } = globalThis.rhwpBoundedStream;
+const THUMBNAIL_OUTPUT_LIMIT_BYTES = 10 * 1024 * 1024;
 
 async function extractThumbnailFromUrl(url) {
   if (THUMBNAIL_CACHE.has(url)) return THUMBNAIL_CACHE.get(url);
@@ -345,7 +343,9 @@ async function extractThumbnailFromUrl(url) {
     const data = new Uint8Array(buffer);
 
     const isZip = data.length >= 4 && data[0] === 0x50 && data[1] === 0x4B;
-    const result = isZip ? await extractPrvImageFromZip(data) : extractPrvImageFromCFB(data);
+    const result = isZip
+      ? await extractPrvImageFromZip(data, THUMBNAIL_OUTPUT_LIMIT_BYTES)
+      : extractPrvImageFromCFB(data, THUMBNAIL_OUTPUT_LIMIT_BYTES);
     if (result) {
       if (THUMBNAIL_CACHE.size >= CACHE_MAX_SIZE) {
         THUMBNAIL_CACHE.delete(THUMBNAIL_CACHE.keys().next().value);
@@ -356,7 +356,7 @@ async function extractThumbnailFromUrl(url) {
   } catch { return null; }
 }
 
-function extractPrvImageFromCFB(data) {
+function extractPrvImageFromCFB(data, maxBytes) {
   if (data.length < 512 || data[0] !== 0xD0 || data[1] !== 0xCF || data[2] !== 0x11 || data[3] !== 0xE0) return null;
   const sectorSize = 1 << (data[30] | (data[31] << 8));
   const dirStartSector = _u32(data, 48);
@@ -375,7 +375,7 @@ function extractPrvImageFromCFB(data) {
     if (name !== 'PrvImage') continue;
     const startSector = _u32(data, eo + 116);
     const streamSize = _u32(data, eo + 120);
-    if (streamSize === 0 || streamSize > MAX_THUMBNAIL_BYTES) continue;
+    if (streamSize === 0 || streamSize > maxBytes) continue;
     const fatSectors = [];
     for (let j = 0; j < 109; j++) {
       const fs = _u32(data, 76 + j * 4);
@@ -406,7 +406,7 @@ function extractPrvImageFromCFB(data) {
   return null;
 }
 
-async function extractPrvImageFromZip(data) {
+async function extractPrvImageFromZip(data, maxBytes) {
   let eocd = -1;
   for (let i = data.length - 22; i >= 0 && i >= data.length - 65558; i--) {
     if (data[i] === 0x50 && data[i+1] === 0x4B && data[i+2] === 0x05 && data[i+3] === 0x06) { eocd = i; break; }
@@ -426,7 +426,7 @@ async function extractPrvImageFromZip(data) {
     const locOff = _u32(data, off + 42);
     const name = new TextDecoder().decode(data.subarray(off + 46, off + 46 + nLen));
     if (name.startsWith('Preview/PrvImage')) {
-      if (uncSz === 0 || uncSz > MAX_THUMBNAIL_BYTES) return null;
+      if (uncSz === 0 || uncSz > maxBytes) return null;
       if (locOff + 30 >= data.length) return null;
       const lnLen = _u16(data, locOff + 26);
       const leLen = _u16(data, locOff + 28);
@@ -441,7 +441,7 @@ async function extractPrvImageFromZip(data) {
           const dec = new DecompressionStream('raw');
           const w = dec.writable.getWriter();
           const write = w.write(data.slice(ds, ds + compSz)).then(() => w.close());
-          const buf = await readThumbnailStreamLimited(dec.readable, uncSz);
+          const buf = await readExactStreamLimited(dec.readable, uncSz, maxBytes);
           const writeSucceeded = await write.then(() => true, () => false);
           if (!buf || !writeSucceeded) return null;
           return _parseImage(buf);

--- a/rhwp-safari/src/manifest.json
+++ b/rhwp-safari/src/manifest.json
@@ -18,7 +18,7 @@
     "default_title": "__MSG_actionTitle__"
   },
   "background": {
-    "scripts": ["file-signature.js", "background.js"],
+    "scripts": ["file-signature.js", "thumbnail-decompression.js", "background.js"],
     "persistent": false
   },
   "content_scripts": [

--- a/rhwp-shared/security/file-signature.test.js
+++ b/rhwp-shared/security/file-signature.test.js
@@ -28,6 +28,10 @@ const safariBackground = fs.readFileSync(
   new URL('rhwp-safari/src/background.js', repositoryRoot),
   'utf8',
 );
+const safariThumbnailDecompression = fs.readFileSync(
+  new URL('rhwp-shared/sw/thumbnail-decompression.js', repositoryRoot),
+  'utf8',
+);
 const safariBuildScript = fs.readFileSync(
   new URL('rhwp-safari/build.sh', repositoryRoot),
   'utf8',
@@ -99,9 +103,14 @@ test('HTML, JSON, 빈 Version HWPML은 HML로 허용하지 않는다', () => {
   }
 });
 
-test('Safari가 공용 문서 판별기를 background보다 먼저 적재하고 dist로 복사한다', () => {
-  assert.deepEqual(safariManifest.background.scripts, ['file-signature.js', 'background.js']);
+test('Safari가 공용 helper를 background보다 먼저 적재하고 dist로 복사한다', () => {
+  assert.deepEqual(safariManifest.background.scripts, [
+    'file-signature.js',
+    'thumbnail-decompression.js',
+    'background.js',
+  ]);
   assert.match(safariBuildScript, /cp "\$ROOT\/rhwp-shared\/security\/file-signature\.js" "\$DIST\/file-signature\.js"/);
+  assert.match(safariBuildScript, /cp "\$ROOT\/rhwp-shared\/sw\/thumbnail-decompression\.js" "\$DIST\/thumbnail-decompression\.js"/);
   assert.match(safariBackground, /verifyDocumentSignature\(buf\)/);
 
   const listeners = {};
@@ -122,6 +131,9 @@ test('Safari가 공용 문서 판별기를 background보다 먼저 적재하고 
   };
   vm.createContext(safariContext);
   vm.runInContext(source, safariContext, { filename: 'file-signature.js' });
+  vm.runInContext(safariThumbnailDecompression, safariContext, {
+    filename: 'thumbnail-decompression.js',
+  });
   vm.runInContext(safariBackground, safariContext, { filename: 'background.js' });
 
   assert.equal(typeof listeners.message, 'function');

--- a/rhwp-shared/sw/thumbnail-decompression.js
+++ b/rhwp-shared/sw/thumbnail-decompression.js
@@ -1,0 +1,50 @@
+// Browser extension thumbnail decompression policy shared by Chrome, Firefox, and Safari.
+'use strict';
+
+(() => {
+  const MAX_THUMBNAIL_BYTES = 10 * 1024 * 1024;
+
+  async function readThumbnailStreamLimited(readable, declaredSize) {
+    if (!Number.isSafeInteger(declaredSize)
+        || declaredSize <= 0
+        || declaredSize > MAX_THUMBNAIL_BYTES) {
+      return null;
+    }
+
+    const reader = readable.getReader();
+    const chunks = [];
+    let total = 0;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        const chunk = value instanceof Uint8Array ? value : new Uint8Array(value);
+        if (chunk.byteLength > declaredSize - total) {
+          await reader.cancel();
+          return null;
+        }
+        chunks.push(chunk);
+        total += chunk.byteLength;
+      }
+    } catch {
+      return null;
+    }
+
+    if (total !== declaredSize) return null;
+
+    const output = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      output.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return output;
+  }
+
+  globalThis.rhwpThumbnailDecompression = Object.freeze({
+    MAX_THUMBNAIL_BYTES,
+    readThumbnailStreamLimited,
+  });
+})();

--- a/rhwp-shared/sw/thumbnail-decompression.js
+++ b/rhwp-shared/sw/thumbnail-decompression.js
@@ -1,13 +1,13 @@
-// Browser extension thumbnail decompression policy shared by Chrome, Firefox, and Safari.
+// Bounded stream reader shared by Chrome, Firefox, and Safari thumbnail consumers.
 'use strict';
 
 (() => {
-  const MAX_THUMBNAIL_BYTES = 10 * 1024 * 1024;
-
-  async function readThumbnailStreamLimited(readable, declaredSize) {
+  async function readExactStreamLimited(readable, declaredSize, maxBytes) {
     if (!Number.isSafeInteger(declaredSize)
         || declaredSize <= 0
-        || declaredSize > MAX_THUMBNAIL_BYTES) {
+        || !Number.isSafeInteger(maxBytes)
+        || maxBytes <= 0
+        || declaredSize > maxBytes) {
       return null;
     }
 
@@ -43,8 +43,7 @@
     return output;
   }
 
-  globalThis.rhwpThumbnailDecompression = Object.freeze({
-    MAX_THUMBNAIL_BYTES,
-    readThumbnailStreamLimited,
+  globalThis.rhwpBoundedStream = Object.freeze({
+    readExactStreamLimited,
   });
 })();

--- a/rhwp-shared/sw/thumbnail-decompression.test.js
+++ b/rhwp-shared/sw/thumbnail-decompression.test.js
@@ -72,12 +72,17 @@ test('all thumbnail consumers use the shared output policy', async () => {
     const source = await readFile(sourceUrl, 'utf8');
     assert.match(source, /MAX_THUMBNAIL_BYTES/);
     assert.match(source, /readThumbnailStreamLimited/);
+    assert.match(source, /compSize !== uncompSize|compSz !== uncSz/);
   }
 
   const rustSource = await readFile(new URL('../../src/parser/mod.rs', import.meta.url), 'utf8');
   assert.match(
     rustSource,
     /pub const MAX_THUMBNAIL_BYTES: usize = 10 \* 1024 \* 1024;/,
+  );
+  assert.match(
+    rustSource,
+    /read_preview_image_limited\(MAX_THUMBNAIL_BYTES\)/,
   );
 
   const safariManifest = JSON.parse(

--- a/rhwp-shared/sw/thumbnail-decompression.test.js
+++ b/rhwp-shared/sw/thumbnail-decompression.test.js
@@ -4,10 +4,8 @@ import { test } from 'node:test';
 
 await import('./thumbnail-decompression.js');
 
-const {
-  MAX_THUMBNAIL_BYTES,
-  readThumbnailStreamLimited,
-} = globalThis.rhwpThumbnailDecompression;
+const { readExactStreamLimited } = globalThis.rhwpBoundedStream;
+const THUMBNAIL_OUTPUT_LIMIT_BYTES = 10 * 1024 * 1024;
 
 function streamOf(...chunks) {
   return new ReadableStream({
@@ -18,16 +16,17 @@ function streamOf(...chunks) {
   });
 }
 
-test('thumbnail decompression accepts output matching its declared size', async () => {
-  const output = await readThumbnailStreamLimited(
+test('bounded stream reader accepts output matching its explicit allowance', async () => {
+  const output = await readExactStreamLimited(
     streamOf(Uint8Array.of(1, 2), Uint8Array.of(3, 4)),
+    4,
     4,
   );
 
   assert.deepEqual(output, Uint8Array.of(1, 2, 3, 4));
 });
 
-test('thumbnail decompression rejects a declared size above the shared limit', async () => {
+test('bounded stream reader rejects a declared size above its caller allowance', async () => {
   let readerRequests = 0;
   const readable = {
     getReader() {
@@ -37,7 +36,7 @@ test('thumbnail decompression rejects a declared size above the shared limit', a
   };
 
   assert.equal(
-    await readThumbnailStreamLimited(readable, MAX_THUMBNAIL_BYTES + 1),
+    await readExactStreamLimited(readable, 5, 4),
     null,
   );
   assert.equal(
@@ -47,22 +46,117 @@ test('thumbnail decompression rejects a declared size above the shared limit', a
   );
 });
 
-test('thumbnail decompression rejects streamed output beyond the shared limit', async () => {
-  const first = new Uint8Array(MAX_THUMBNAIL_BYTES);
-  const output = await readThumbnailStreamLimited(
-    streamOf(first, Uint8Array.of(1)),
-    MAX_THUMBNAIL_BYTES,
+test('bounded stream reader rejects streamed output beyond declared size', async () => {
+  const output = await readExactStreamLimited(
+    streamOf(Uint8Array.of(1, 2), Uint8Array.of(3)),
+    2,
+    4,
   );
 
   assert.equal(output, null);
 });
 
-test('thumbnail decompression rejects output that disagrees with ZIP metadata', async () => {
-  const output = await readThumbnailStreamLimited(streamOf(Uint8Array.of(1, 2, 3)), 2);
+test('bounded stream reader rejects output that disagrees with ZIP metadata', async () => {
+  const output = await readExactStreamLimited(streamOf(Uint8Array.of(1, 2, 3)), 2, 4);
   assert.equal(output, null);
 });
 
-test('all thumbnail consumers use the shared output policy', async () => {
+function pushU16(bytes, value) {
+  bytes.push(value & 0xff, (value >>> 8) & 0xff);
+}
+
+function pushU32(bytes, value) {
+  bytes.push(
+    value & 0xff,
+    (value >>> 8) & 0xff,
+    (value >>> 16) & 0xff,
+    (value >>> 24) & 0xff,
+  );
+}
+
+function storedPreviewZip(payload, declaredSize = payload.byteLength) {
+  const name = new TextEncoder().encode('Preview/PrvImage.png');
+  const local = [];
+  pushU32(local, 0x04034b50);
+  pushU16(local, 20);
+  pushU16(local, 0);
+  pushU16(local, 0);
+  pushU16(local, 0);
+  pushU16(local, 0);
+  pushU32(local, 0);
+  pushU32(local, payload.byteLength);
+  pushU32(local, declaredSize);
+  pushU16(local, name.byteLength);
+  pushU16(local, 0);
+  local.push(...name, ...payload);
+
+  const centralOffset = local.length;
+  const central = [];
+  pushU32(central, 0x02014b50);
+  pushU16(central, 20);
+  pushU16(central, 20);
+  pushU16(central, 0);
+  pushU16(central, 0);
+  pushU16(central, 0);
+  pushU16(central, 0);
+  pushU32(central, 0);
+  pushU32(central, payload.byteLength);
+  pushU32(central, declaredSize);
+  pushU16(central, name.byteLength);
+  pushU16(central, 0);
+  pushU16(central, 0);
+  pushU16(central, 0);
+  pushU16(central, 0);
+  pushU32(central, 0);
+  pushU32(central, 0);
+  central.push(...name);
+
+  const end = [];
+  pushU32(end, 0x06054b50);
+  pushU16(end, 0);
+  pushU16(end, 0);
+  pushU16(end, 1);
+  pushU16(end, 1);
+  pushU32(end, central.length);
+  pushU32(end, centralOffset);
+  pushU16(end, 0);
+  return Uint8Array.from([...local, ...central, ...end]);
+}
+
+function pngPreview() {
+  const png = new Uint8Array(24);
+  png.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  png.set([0, 0, 0, 1], 16);
+  png.set([0, 0, 0, 1], 20);
+  return png;
+}
+
+test('Chrome public thumbnail consumer preserves a valid preview and rejects oversized metadata', { concurrency: false }, async () => {
+  const { extractThumbnailFromUrl } = await import('../../rhwp-chrome/sw/thumbnail-extractor.js');
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => new Response(
+    String(url).endsWith('oversized.hwpx')
+      ? storedPreviewZip(new Uint8Array(), THUMBNAIL_OUTPUT_LIMIT_BYTES + 1)
+      : storedPreviewZip(pngPreview()),
+  );
+
+  try {
+    const valid = await extractThumbnailFromUrl('https://example.test/valid.hwpx');
+    assert.equal(valid?.mime, 'image/png');
+    assert.equal(valid?.width, 1);
+    assert.equal(valid?.height, 1);
+    assert.match(valid?.dataUri || '', /^data:image\/png;base64,/);
+
+    assert.equal(
+      await extractThumbnailFromUrl('https://example.test/oversized.hwpx'),
+      null,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('thumbnail consumers choose their output policy at the public boundary', async () => {
   const sourceUrls = [
     new URL('../../rhwp-chrome/sw/thumbnail-extractor.js', import.meta.url),
     new URL('../../rhwp-firefox/sw/thumbnail-extractor.js', import.meta.url),
@@ -70,10 +164,14 @@ test('all thumbnail consumers use the shared output policy', async () => {
   ];
   for (const sourceUrl of sourceUrls) {
     const source = await readFile(sourceUrl, 'utf8');
-    assert.match(source, /MAX_THUMBNAIL_BYTES/);
-    assert.match(source, /readThumbnailStreamLimited/);
+    assert.match(source, /THUMBNAIL_OUTPUT_LIMIT_BYTES = 10 \* 1024 \* 1024/);
+    assert.match(source, /readExactStreamLimited/);
     assert.match(source, /compSize !== uncompSize|compSz !== uncSz/);
   }
+
+  const helperSource = await readFile(new URL('./thumbnail-decompression.js', import.meta.url), 'utf8');
+  assert.doesNotMatch(helperSource, /THUMBNAIL_OUTPUT_LIMIT_BYTES|MAX_THUMBNAIL_BYTES/);
+  assert.match(helperSource, /readExactStreamLimited\(readable, declaredSize, maxBytes\)/);
 
   const rustSource = await readFile(new URL('../../src/parser/mod.rs', import.meta.url), 'utf8');
   assert.match(
@@ -82,7 +180,7 @@ test('all thumbnail consumers use the shared output policy', async () => {
   );
   assert.match(
     rustSource,
-    /read_preview_image_limited\(MAX_THUMBNAIL_BYTES\)/,
+    /extract_preview\(&mut cfb, MAX_THUMBNAIL_BYTES\)/,
   );
 
   const safariManifest = JSON.parse(

--- a/rhwp-shared/sw/thumbnail-decompression.test.js
+++ b/rhwp-shared/sw/thumbnail-decompression.test.js
@@ -1,0 +1,96 @@
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+
+await import('./thumbnail-decompression.js');
+
+const {
+  MAX_THUMBNAIL_BYTES,
+  readThumbnailStreamLimited,
+} = globalThis.rhwpThumbnailDecompression;
+
+function streamOf(...chunks) {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+}
+
+test('thumbnail decompression accepts output matching its declared size', async () => {
+  const output = await readThumbnailStreamLimited(
+    streamOf(Uint8Array.of(1, 2), Uint8Array.of(3, 4)),
+    4,
+  );
+
+  assert.deepEqual(output, Uint8Array.of(1, 2, 3, 4));
+});
+
+test('thumbnail decompression rejects a declared size above the shared limit', async () => {
+  let readerRequests = 0;
+  const readable = {
+    getReader() {
+      readerRequests += 1;
+      throw new Error('must not start reading');
+    },
+  };
+
+  assert.equal(
+    await readThumbnailStreamLimited(readable, MAX_THUMBNAIL_BYTES + 1),
+    null,
+  );
+  assert.equal(
+    readerRequests,
+    0,
+    'oversized metadata must be rejected before decompression starts',
+  );
+});
+
+test('thumbnail decompression rejects streamed output beyond the shared limit', async () => {
+  const first = new Uint8Array(MAX_THUMBNAIL_BYTES);
+  const output = await readThumbnailStreamLimited(
+    streamOf(first, Uint8Array.of(1)),
+    MAX_THUMBNAIL_BYTES,
+  );
+
+  assert.equal(output, null);
+});
+
+test('thumbnail decompression rejects output that disagrees with ZIP metadata', async () => {
+  const output = await readThumbnailStreamLimited(streamOf(Uint8Array.of(1, 2, 3)), 2);
+  assert.equal(output, null);
+});
+
+test('all thumbnail consumers use the shared output policy', async () => {
+  const sourceUrls = [
+    new URL('../../rhwp-chrome/sw/thumbnail-extractor.js', import.meta.url),
+    new URL('../../rhwp-firefox/sw/thumbnail-extractor.js', import.meta.url),
+    new URL('../../rhwp-safari/src/background.js', import.meta.url),
+  ];
+  for (const sourceUrl of sourceUrls) {
+    const source = await readFile(sourceUrl, 'utf8');
+    assert.match(source, /MAX_THUMBNAIL_BYTES/);
+    assert.match(source, /readThumbnailStreamLimited/);
+  }
+
+  const rustSource = await readFile(new URL('../../src/parser/mod.rs', import.meta.url), 'utf8');
+  assert.match(
+    rustSource,
+    /pub const MAX_THUMBNAIL_BYTES: usize = 10 \* 1024 \* 1024;/,
+  );
+
+  const safariManifest = JSON.parse(
+    await readFile(new URL('../../rhwp-safari/src/manifest.json', import.meta.url), 'utf8'),
+  );
+  assert.deepEqual(
+    safariManifest.background.scripts.slice(-2),
+    ['thumbnail-decompression.js', 'background.js'],
+  );
+
+  const safariBuild = await readFile(
+    new URL('../../rhwp-safari/build.sh', import.meta.url),
+    'utf8',
+  );
+  assert.match(safariBuild, /thumbnail-decompression\.js/);
+});

--- a/src/parser/cfb_reader.rs
+++ b/src/parser/cfb_reader.rs
@@ -246,8 +246,8 @@ impl CfbReader {
 
     /// 미리보기 이미지 스트림을 `max_bytes` 바이트까지만 읽는다.
     ///
-    /// 썸네일 전용 소비자는 전체 문서를 파싱하지 않으므로, 디렉터리의 선언 크기와 실제
-    /// stream read 양쪽에서 상한을 확인한다.
+    /// 호출자가 정한 상한에 대해, 디렉터리의 선언 크기와 실제 stream read 양쪽을
+    /// 확인한다.
     pub fn read_preview_image_limited(&mut self, max_bytes: usize) -> Option<Vec<u8>> {
         let declared_size = usize::try_from(self.compound.entry("/PrvImage").ok()?.len()).ok()?;
         if declared_size == 0 || declared_size > max_bytes {

--- a/src/parser/cfb_reader.rs
+++ b/src/parser/cfb_reader.rs
@@ -244,6 +244,26 @@ impl CfbReader {
         }
     }
 
+    /// 미리보기 이미지 스트림을 `max_bytes` 바이트까지만 읽는다.
+    ///
+    /// 썸네일 전용 소비자는 전체 문서를 파싱하지 않으므로, 디렉터리의 선언 크기와 실제
+    /// stream read 양쪽에서 상한을 확인한다.
+    pub fn read_preview_image_limited(&mut self, max_bytes: usize) -> Option<Vec<u8>> {
+        let declared_size = usize::try_from(self.compound.entry("/PrvImage").ok()?.len()).ok()?;
+        if declared_size == 0 || declared_size > max_bytes {
+            return None;
+        }
+
+        let mut stream = self.compound.open_stream("/PrvImage").ok()?;
+        let mut data = Vec::new();
+        stream
+            .by_ref()
+            .take((max_bytes as u64).saturating_add(1))
+            .read_to_end(&mut data)
+            .ok()?;
+        (data.len() == declared_size).then_some(data)
+    }
+
     /// 미리보기 텍스트 스트림 읽기 (PrvText)
     ///
     /// UTF-16LE 인코딩된 미리보기 텍스트를 반환한다.

--- a/src/parser/hwpx/contract_streams.rs
+++ b/src/parser/hwpx/contract_streams.rs
@@ -62,7 +62,10 @@ pub(super) struct ContractStreams {
 ///
 /// HWPX 에 동등 파일이 없으면 해당 스트림은 생략. cfb_writer 가 한컴 정답지
 /// 와 비교하여 추가 fallback (HwpSummary / DocOptions/_LinkDoc) 가 필요.
-pub(super) fn extract_contract_streams(reader: &mut HwpxReader) -> ContractStreams {
+pub(super) fn extract_contract_streams(
+    reader: &mut HwpxReader,
+    max_preview_image_bytes: usize,
+) -> ContractStreams {
     let mut streams = Vec::new();
 
     // PrvText.txt (UTF-8) → /PrvText (UTF-16 LE, HWP5 spec).
@@ -75,7 +78,7 @@ pub(super) fn extract_contract_streams(reader: &mut HwpxReader) -> ContractStrea
 
     // PrvImage.png → /PrvImage (PNG passthrough). 미존재 시 blank2010 fallback.
     let prv_image = reader
-        .read_file_bytes("Preview/PrvImage.png")
+        .read_file_bytes_limited("Preview/PrvImage.png", max_preview_image_bytes)
         .unwrap_or_else(|_| FALLBACK_PRV_IMAGE.to_vec());
     streams.push(("/PrvImage".to_string(), prv_image));
 

--- a/src/parser/hwpx/mod.rs
+++ b/src/parser/hwpx/mod.rs
@@ -355,7 +355,12 @@ pub fn parse_hwpx(data: &[u8]) -> Result<Document, HwpxError> {
     ];
     let mut hwpx_aux_entries: Vec<(String, Vec<u8>)> = Vec::new();
     for path in HWPX_AUX_PATHS {
-        if let Ok(bytes) = reader.read_file_bytes(path) {
+        let entry = if *path == "Preview/PrvImage.png" {
+            reader.read_file_bytes_limited(path, super::MAX_THUMBNAIL_BYTES)
+        } else {
+            reader.read_file_bytes(path)
+        };
+        if let Ok(bytes) = entry {
             hwpx_aux_entries.push((path.to_string(), bytes));
         }
     }
@@ -553,7 +558,8 @@ pub fn parse_hwpx(data: &[u8]) -> Result<Document, HwpxError> {
     // _LinkDoc, Scripts/JScriptVersion) 은 Stage 2.2 의 blank2010.hwp
     // fallback 으로 보강. cfb_writer (`src/serializer/cfb_writer.rs:155`)
     // 가 Document::extra_streams 를 그대로 OLE 스트림으로 작성.
-    let contract = contract_streams::extract_contract_streams(&mut reader);
+    let contract =
+        contract_streams::extract_contract_streams(&mut reader, super::MAX_THUMBNAIL_BYTES);
 
     let mut doc = Document {
         header: model_header,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1397,7 +1397,7 @@ pub fn extract_thumbnail_only(data: &[u8]) -> Option<ThumbnailResult> {
     } else {
         // HWP: CFB 컨테이너에서 /PrvImage 스트림 읽기
         let mut cfb = cfb_reader::CfbReader::open(data).ok()?;
-        cfb.read_preview_image()?
+        cfb.read_preview_image_limited(MAX_THUMBNAIL_BYTES)?
     };
     let format = detect_image_format(&image_data);
 
@@ -1463,11 +1463,14 @@ pub fn extract_thumbnail_only(data: &[u8]) -> Option<ThumbnailResult> {
 /// 브라우저 확장의 CFB/HWPX 썸네일 정책과 같은 10 MiB를 사용한다.
 pub const MAX_THUMBNAIL_BYTES: usize = 10 * 1024 * 1024;
 
-fn read_thumbnail_limited<R: std::io::Read>(reader: &mut R, max_bytes: usize) -> Option<Vec<u8>> {
+fn read_thumbnail_limited<R: std::io::Read>(
+    reader: &mut R,
+    expected_bytes: usize,
+) -> Option<Vec<u8>> {
     let mut buf = Vec::new();
-    let mut limited = std::io::Read::take(&mut *reader, (max_bytes as u64).saturating_add(1));
+    let mut limited = std::io::Read::take(&mut *reader, (expected_bytes as u64).saturating_add(1));
     std::io::Read::read_to_end(&mut limited, &mut buf).ok()?;
-    (buf.len() <= max_bytes).then_some(buf)
+    (buf.len() == expected_bytes).then_some(buf)
 }
 
 /// HWPX(ZIP)에서 Preview/PrvImage.png 추출
@@ -1487,16 +1490,11 @@ fn extract_thumbnail_from_hwpx(data: &[u8]) -> Option<Vec<u8>> {
     })?;
 
     let mut file = archive.by_name(&entry_name).ok()?;
-    if file.size() > MAX_THUMBNAIL_BYTES as u64 {
+    let declared_size = usize::try_from(file.size()).ok()?;
+    if declared_size == 0 || declared_size > MAX_THUMBNAIL_BYTES {
         return None;
     }
-    let buf = read_thumbnail_limited(&mut file, MAX_THUMBNAIL_BYTES)?;
-
-    if buf.is_empty() {
-        None
-    } else {
-        Some(buf)
-    }
+    read_thumbnail_limited(&mut file, declared_size)
 }
 
 /// 썸네일 추출 결과
@@ -1999,6 +1997,27 @@ mod tests {
     }
 
     #[test]
+    fn thumbnail_limited_read_rejects_truncated_stream() {
+        let mut input = std::io::Cursor::new(vec![0u8; 7]);
+        assert!(read_thumbnail_limited(&mut input, 8).is_none());
+    }
+
+    #[test]
+    fn cfb_thumbnail_rejects_declared_output_above_limit() {
+        use std::io::Write;
+
+        let mut compound = cfb::CompoundFile::create(std::io::Cursor::new(Vec::new())).unwrap();
+        {
+            let mut image = compound.create_stream("/PrvImage").unwrap();
+            image
+                .write_all(&vec![0u8; MAX_THUMBNAIL_BYTES + 1])
+                .unwrap();
+        }
+
+        assert!(extract_thumbnail_only(&compound.into_inner().into_inner()).is_none());
+    }
+
+    #[test]
     fn hwpx_thumbnail_rejects_declared_output_above_limit() {
         use std::io::Write;
 
@@ -2019,6 +2038,40 @@ mod tests {
         }
 
         assert!(extract_thumbnail_only(&archive.into_inner()).is_none());
+    }
+
+    #[test]
+    fn hwpx_thumbnail_rejects_declared_actual_size_mismatch() {
+        use std::io::Write;
+
+        let mut archive = std::io::Cursor::new(Vec::new());
+        {
+            let mut writer = zip::ZipWriter::new(&mut archive);
+            writer
+                .start_file(
+                    "Preview/PrvImage.png",
+                    zip::write::SimpleFileOptions::default()
+                        .compression_method(zip::CompressionMethod::Stored),
+                )
+                .unwrap();
+            writer.write_all(&[1, 2, 3]).unwrap();
+            writer.finish().unwrap();
+        }
+
+        let mut bytes = archive.into_inner();
+        for (signature, size_offset) in [
+            ([0x50, 0x4B, 0x03, 0x04], 22),
+            ([0x50, 0x4B, 0x01, 0x02], 24),
+        ] {
+            let header = bytes
+                .windows(signature.len())
+                .position(|window| window == signature)
+                .unwrap();
+            bytes[header + size_offset..header + size_offset + 4]
+                .copy_from_slice(&4u32.to_le_bytes());
+        }
+
+        assert!(extract_thumbnail_only(&bytes).is_none());
     }
 
     fn document_with_number_controls(controls: Vec<crate::model::control::Control>) -> Document {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1458,9 +1458,20 @@ pub fn extract_thumbnail_only(data: &[u8]) -> Option<ThumbnailResult> {
     })
 }
 
+/// 미리보기 이미지 하나의 최대 압축 해제 크기.
+///
+/// 브라우저 확장의 CFB/HWPX 썸네일 정책과 같은 10 MiB를 사용한다.
+pub const MAX_THUMBNAIL_BYTES: usize = 10 * 1024 * 1024;
+
+fn read_thumbnail_limited<R: std::io::Read>(reader: &mut R, max_bytes: usize) -> Option<Vec<u8>> {
+    let mut buf = Vec::new();
+    let mut limited = std::io::Read::take(&mut *reader, (max_bytes as u64).saturating_add(1));
+    std::io::Read::read_to_end(&mut limited, &mut buf).ok()?;
+    (buf.len() <= max_bytes).then_some(buf)
+}
+
 /// HWPX(ZIP)에서 Preview/PrvImage.png 추출
 fn extract_thumbnail_from_hwpx(data: &[u8]) -> Option<Vec<u8>> {
-    use std::io::Read;
     let cursor = std::io::Cursor::new(data);
     let mut archive = zip::ZipArchive::new(cursor).ok()?;
 
@@ -1476,8 +1487,10 @@ fn extract_thumbnail_from_hwpx(data: &[u8]) -> Option<Vec<u8>> {
     })?;
 
     let mut file = archive.by_name(&entry_name).ok()?;
-    let mut buf = Vec::new();
-    file.read_to_end(&mut buf).ok()?;
+    if file.size() > MAX_THUMBNAIL_BYTES as u64 {
+        return None;
+    }
+    let buf = read_thumbnail_limited(&mut file, MAX_THUMBNAIL_BYTES)?;
 
     if buf.is_empty() {
         None
@@ -1978,6 +1991,35 @@ fn load_bin_data_content(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn thumbnail_limited_read_rejects_streamed_overflow() {
+        let mut input = std::io::Cursor::new(vec![0u8; 9]);
+        assert!(read_thumbnail_limited(&mut input, 8).is_none());
+    }
+
+    #[test]
+    fn hwpx_thumbnail_rejects_declared_output_above_limit() {
+        use std::io::Write;
+
+        let mut archive = std::io::Cursor::new(Vec::new());
+        {
+            let mut writer = zip::ZipWriter::new(&mut archive);
+            writer
+                .start_file(
+                    "Preview/PrvImage.png",
+                    zip::write::SimpleFileOptions::default()
+                        .compression_method(zip::CompressionMethod::Deflated),
+                )
+                .unwrap();
+            writer
+                .write_all(&vec![0u8; MAX_THUMBNAIL_BYTES + 1])
+                .unwrap();
+            writer.finish().unwrap();
+        }
+
+        assert!(extract_thumbnail_only(&archive.into_inner()).is_none());
+    }
 
     fn document_with_number_controls(controls: Vec<crate::model::control::Control>) -> Document {
         let mut paragraph = crate::model::paragraph::Paragraph::default();

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -315,7 +315,9 @@ fn parse_hwp_with_cfb(
     )?;
 
     // 5-7. 미리보기, BinData, 추가 스트림
-    let preview = extract_preview(&mut cfb);
+    // Preview is optional document metadata.  A malformed or disproportionately
+    // large thumbnail must not prevent the actual document from opening.
+    let preview = extract_preview(&mut cfb, MAX_THUMBNAIL_BYTES);
     let bin_data_content = load_bin_data_content(
         &mut cfb,
         raw_data,
@@ -1369,8 +1371,8 @@ fn drm_format_name(data: &[u8]) -> &'static str {
 }
 
 /// 미리보기 데이터 추출 (PrvImage, PrvText)
-fn extract_preview(cfb: &mut cfb_reader::CfbReader) -> Option<Preview> {
-    let image_data = cfb.read_preview_image();
+fn extract_preview(cfb: &mut cfb_reader::CfbReader, max_thumbnail_bytes: usize) -> Option<Preview> {
+    let image_data = cfb.read_preview_image_limited(max_thumbnail_bytes);
     let text = cfb.read_preview_text();
 
     // 둘 다 없으면 None 반환
@@ -1393,7 +1395,7 @@ fn extract_preview(cfb: &mut cfb_reader::CfbReader) -> Option<Preview> {
 pub fn extract_thumbnail_only(data: &[u8]) -> Option<ThumbnailResult> {
     let image_data = if detect_format(data) == FileFormat::Hwpx {
         // HWPX: ZIP 컨테이너에서 Preview/PrvImage.png 읽기
-        extract_thumbnail_from_hwpx(data)?
+        extract_thumbnail_from_hwpx(data, MAX_THUMBNAIL_BYTES)?
     } else {
         // HWP: CFB 컨테이너에서 /PrvImage 스트림 읽기
         let mut cfb = cfb_reader::CfbReader::open(data).ok()?;
@@ -1460,13 +1462,18 @@ pub fn extract_thumbnail_only(data: &[u8]) -> Option<ThumbnailResult> {
 
 /// 미리보기 이미지 하나의 최대 압축 해제 크기.
 ///
-/// 브라우저 확장의 CFB/HWPX 썸네일 정책과 같은 10 MiB를 사용한다.
+/// HWP/HWPX 문서 열기와 브라우저 썸네일 소비자가 선택하는 10 MiB 상한이다.
 pub const MAX_THUMBNAIL_BYTES: usize = 10 * 1024 * 1024;
 
 fn read_thumbnail_limited<R: std::io::Read>(
     reader: &mut R,
     expected_bytes: usize,
+    max_bytes: usize,
 ) -> Option<Vec<u8>> {
+    if expected_bytes == 0 || expected_bytes > max_bytes {
+        return None;
+    }
+
     let mut buf = Vec::new();
     let mut limited = std::io::Read::take(&mut *reader, (expected_bytes as u64).saturating_add(1));
     std::io::Read::read_to_end(&mut limited, &mut buf).ok()?;
@@ -1474,7 +1481,7 @@ fn read_thumbnail_limited<R: std::io::Read>(
 }
 
 /// HWPX(ZIP)에서 Preview/PrvImage.png 추출
-fn extract_thumbnail_from_hwpx(data: &[u8]) -> Option<Vec<u8>> {
+fn extract_thumbnail_from_hwpx(data: &[u8], max_bytes: usize) -> Option<Vec<u8>> {
     let cursor = std::io::Cursor::new(data);
     let mut archive = zip::ZipArchive::new(cursor).ok()?;
 
@@ -1491,10 +1498,7 @@ fn extract_thumbnail_from_hwpx(data: &[u8]) -> Option<Vec<u8>> {
 
     let mut file = archive.by_name(&entry_name).ok()?;
     let declared_size = usize::try_from(file.size()).ok()?;
-    if declared_size == 0 || declared_size > MAX_THUMBNAIL_BYTES {
-        return None;
-    }
-    read_thumbnail_limited(&mut file, declared_size)
+    read_thumbnail_limited(&mut file, declared_size, max_bytes)
 }
 
 /// 썸네일 추출 결과
@@ -1990,16 +1994,105 @@ fn load_bin_data_content(
 mod tests {
     use super::*;
 
+    fn png_preview() -> Vec<u8> {
+        let mut png = vec![0; 24];
+        png[..8].copy_from_slice(b"\x89PNG\r\n\x1a\n");
+        png[16..20].copy_from_slice(&1u32.to_be_bytes());
+        png[20..24].copy_from_slice(&1u32.to_be_bytes());
+        png
+    }
+
+    fn hwp_with_preview(image: Vec<u8>) -> Vec<u8> {
+        let mut document = Document::default();
+        document.preview = Some(Preview {
+            image: Some(PreviewImage {
+                format: PreviewImageFormat::Png,
+                data: image,
+            }),
+            text: None,
+        });
+        crate::serializer::serialize_document(&document).expect("serialize HWP preview fixture")
+    }
+
+    fn hwpx_with_preview(image: Vec<u8>) -> Vec<u8> {
+        let mut document = Document::default();
+        document
+            .hwpx_aux_entries
+            .push(("Preview/PrvImage.png".to_string(), image));
+        crate::serializer::hwpx::serialize_hwpx(&document).expect("serialize HWPX preview fixture")
+    }
+
     #[test]
     fn thumbnail_limited_read_rejects_streamed_overflow() {
         let mut input = std::io::Cursor::new(vec![0u8; 9]);
-        assert!(read_thumbnail_limited(&mut input, 8).is_none());
+        assert!(read_thumbnail_limited(&mut input, 8, 8).is_none());
     }
 
     #[test]
     fn thumbnail_limited_read_rejects_truncated_stream() {
         let mut input = std::io::Cursor::new(vec![0u8; 7]);
-        assert!(read_thumbnail_limited(&mut input, 8).is_none());
+        assert!(read_thumbnail_limited(&mut input, 8, 8).is_none());
+    }
+
+    #[test]
+    fn document_open_preserves_small_hwp_thumbnail() {
+        let image = png_preview();
+        let document = parse_document(&hwp_with_preview(image.clone()))
+            .expect("document opens with a valid thumbnail");
+
+        assert_eq!(
+            document
+                .preview
+                .as_ref()
+                .and_then(|preview| preview.image.as_ref())
+                .map(|preview| preview.data.as_slice()),
+            Some(image.as_slice())
+        );
+    }
+
+    #[test]
+    fn document_open_omits_oversized_hwp_thumbnail() {
+        let document = parse_document(&hwp_with_preview(vec![0; MAX_THUMBNAIL_BYTES + 1]))
+            .expect("document still opens when its optional thumbnail is oversized");
+
+        assert!(document
+            .preview
+            .as_ref()
+            .and_then(|preview| preview.image.as_ref())
+            .is_none());
+    }
+
+    #[test]
+    fn document_open_preserves_small_hwpx_thumbnail() {
+        let image = png_preview();
+        let document = parse_document(&hwpx_with_preview(image.clone()))
+            .expect("document opens with a valid HWPX thumbnail");
+
+        assert_eq!(
+            document.hwpx_aux_entry("Preview/PrvImage.png"),
+            Some(image.as_slice())
+        );
+        assert_eq!(
+            document
+                .extra_streams
+                .iter()
+                .find(|(path, _)| path == "/PrvImage")
+                .map(|(_, data)| data.as_slice()),
+            Some(image.as_slice())
+        );
+    }
+
+    #[test]
+    fn document_open_omits_oversized_hwpx_thumbnail() {
+        let document = parse_document(&hwpx_with_preview(vec![0; MAX_THUMBNAIL_BYTES + 1]))
+            .expect("document still opens when its optional HWPX thumbnail is oversized");
+
+        assert!(document.hwpx_aux_entry("Preview/PrvImage.png").is_none());
+        assert!(document
+            .extra_streams
+            .iter()
+            .find(|(path, _)| path == "/PrvImage")
+            .is_some_and(|(_, data)| data.len() < MAX_THUMBNAIL_BYTES));
     }
 
     #[test]


### PR DESCRIPTION
## 변경

- HWP/HWPX의 정식 문서 열기, 썸네일 전용 API, Chrome·Firefox·Safari의 `extractThumbnailFromUrl`에서 10 MiB 썸네일 출력 상한을 선택합니다.
- CFB·ZIP·HWPX reader와 shared stream collector는 상한을 자체 선택하지 않고, 호출자가 전달한 한도·선언 크기·실제 출력만 검사합니다.
- 10 MiB를 넘는 `PrvImage`는 선택적 미리보기로 생략합니다. 문서 본문 열기는 계속되고, HWPX contract는 기존 blank fallback을 사용합니다.

## 검증

- `cargo test --lib document_open_` — 4 passed
- `cargo test --lib thumbnail_` — 7 passed
- `node --test rhwp-shared/sw/thumbnail-decompression.test.js` — 6 passed
- `cargo fmt --all -- --check` — 통과
- `cargo test --profile release-test --tests` — 통과
- `cargo clippy -- -D warnings` — 통과
- Chrome·Firefox·Safari·shared JS syntax check와 `git diff --check` — 통과
- terra-max Gestell adversarial review — PASS

전체 Rust gate는 정확한 code/review head `b7c501101ea33aac2b2f17a975a79862f7ce3a85`에서 순차 실행했습니다. 이후 `e83353608c4514e5c3aa041c2f5b59aa28e0d382`는 검증 기록만 갱신한 docs-only commit입니다.

## 상태

로컬 CONTRIBUTING gate는 완료했습니다. 최신 GitHub required check와 별도 승인 전까지 PR은 Draft를 유지합니다.
