### PR TITLE
fix(renderer): Square wrap prefix 분리를 다줄 전폭 꼬리로 확장한다

### DIFF
--- a/mydocs/working/task_m100_4650_stage1.md
+++ b/mydocs/working/task_m100_4650_stage1.md
@@ -1,0 +1,40 @@
+# Task #4650 Stage 1 — Square 표 옆 wrap prefix 분리를 다줄 전폭 꼬리로 확장
+
+Issue: #4650 (#4599 캠페인 Phase 3, 사이클 6)
+Branch: `fix/4599-square-wrap-prefix-split` (base: devel 572786d02)
+
+## 무엇을
+
+반폭 Square(어울림) 표 옆으로 흐르다 전폭으로 복귀하는 문단의 wrap prefix 분리
+(#4090)가 "전폭 꼬리 정확히 한 줄"에만 적용되어, 꼬리가 여러 줄인 문단이 일반 배치로
+떨어지며 prefix 까지 표 하단 아래로 밀렸다. 분리 판별을 "꼬리 전 줄 전폭 + 저장
+seg·조판 줄 1:1"로 확장했다 — prefix 는 wrap 띠(표 옆), 꼬리는 표 아래 전폭.
+
+- `src/renderer/typeset.rs` — `can_split_prefix` 판별 확장 (꼬리 1줄 → 전-전폭 꼬리)
+
+## 실측 근거 (156714641 p1 — #4599 single+/STEP 군집 대표, 204.0px)
+
+- pi12 = 반폭(340.7px) Square 2×1 표. pi13 = 9 seg 문단 — 저장 seg 0..4 가
+  cs=25835·sw=22353(표 옆 우측 절반), 5..8 이 전폭. 저장 사다리가 wrap 형상을 증언.
+- 한글 2022 캐시 PDF: '연구진은…'(prefix 첫 줄) 747.9 — 표 옆.
+- 종전 rhwp: #4090 게이트(꼬리 1줄) 불발 → 일반 배치 → Table 아이템이 흐름을 표
+  하단(952.9)까지 전진시킨 뒤 prefix 를 그 아래에 렌더 (+204.0px).
+- 수정 후: prefix 표 옆, 판정 **CONFIRMED(204.0) → WEAK(9.2)** (매칭 쌍 9→14,
+  잔여는 좁은 seg 의 줄바꿈 미세 차이).
+
+## 검증 실측 (단독 브랜치, base 572786d02)
+
+### #4599 backlog 242 재판정 — 개선 1(204.0→9.2 WEAK) / 불변 241 / 악화 0
+
+### hwpx 3418 스윕 (baseline 572786d02 클린 worktree 빌드)
+
+- 판정 이동 1건: 대상 DRIFT→OK (worst 198.9→10.2)
+- worst +2px 이동 1건: 156492236 +7.5 (30.9→38.4) — **모아찍기(NUP_PDF) 캐시 문서**로
+  오라클 부재. 같은 반폭 Square wrap 템플릿이 분리 경로에 진입하며 사다리 축 ±16px
+  이동(표 이동 포함). Windows 캐시 재생성(기존 목록 등재) 후 재판정 대상으로 기록.
+- 전수 Table-diff 변동 2: 대상(의도) · 156492236(위)
+
+### 저장소 게이트
+
+- cargo fmt --check: 통과 · clippy: 경고 0 · cargo test --release 전체: exit 0 ·
+  wasm-pack build --target web: 성공

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -5625,15 +5625,18 @@ impl TypesetEngine {
                                 && seg.segment_width as i32 == st.wrap_around_sw
                         })
                         .count();
-                    let suffix_is_full_width = para
-                        .line_segs
-                        .get(wrap_prefix_len)
-                        .map(|seg| {
+                    // [#4650 · #4599 ⑩] 종전에는 전폭 꼬리 '정확히 한 줄'만 분리했으나, 반폭
+                    // Square 표 옆 문단이 여러 전폭 꼬리 줄을 갖는 형상(156714641 p1
+                    // pi13: 표 옆 prefix 4줄 + 전폭 꼬리 5줄)이 일반 배치로 떨어져
+                    // prefix 가 표 하단 아래(952.9)로 밀렸다 — 한글 2022 캐시 PDF 는
+                    // 표 옆 747.9. 꼬리 전 줄이 전폭이고 저장 seg 와 조판 줄이 1:1 인
+                    // 경우로 확장한다(#4090 의 안정 형상 판별은 유지).
+                    let suffix_is_full_width =
+                        para.line_segs[wrap_prefix_len..].iter().all(|seg| {
                             seg.column_start == 0
                                 && (seg.segment_width as i32 - st.layout.column_width_hu()).abs()
                                     <= 3_000
-                        })
-                        .unwrap_or(false);
+                        }) && wrap_prefix_len < para.line_segs.len();
                     let col_width = st
                         .layout
                         .column_areas
@@ -5643,7 +5646,7 @@ impl TypesetEngine {
                     let formatted = self.format_paragraph(para, composed, styles, Some(col_width));
                     let can_split_prefix = !is_empty_para
                         && wrap_prefix_len > 0
-                        && wrap_prefix_len + 1 == para.line_segs.len()
+                        && wrap_prefix_len < para.line_segs.len()
                         && suffix_is_full_width
                         && formatted.line_count() == para.line_segs.len();
                     if can_split_prefix {


### PR DESCRIPTION
## 변경 요약

반폭 Square(어울림) 표 옆으로 흐르다 전폭으로 복귀하는 문단의 wrap prefix 분리
(#4090)는 "전폭 꼬리 정확히 한 줄"에만 적용됐습니다. 꼬리가 여러 줄인 문단은 일반
배치로 떨어져, Table 아이템이 흐름을 표 하단까지 전진시킨 뒤 prefix 를 그 아래에
렌더했습니다.

실측(156714641 p1, #4599 single+/STEP 군집 대표): pi13 = 저장 seg 0..4 가
cs=25835·sw=22353(표 옆 우측 절반), 5..8 전폭 — 저장 사다리가 wrap 형상을 증언.
한글 2022 캐시 PDF 는 prefix 첫 줄('연구진은…')을 표 옆 747.9 에 두는데 rhwp 는
952.9 (+204px).

수정: 분리 판별을 "**꼬리 전 줄 전폭** + 저장 seg·조판 줄 1:1"로 확장(#4090 의 안정
형상 게이트 유지). prefix 는 기존 wrap 띠 경로로 표 옆에, 꼬리는 표 아래 전폭으로.

수정 후: **CONFIRMED(maxdev 204.0) → WEAK(9.2)**, 매칭 쌍 9→14 (잔여는 좁은 seg
줄바꿈 미세 차이).

상세 분석·검증: `mydocs/working/task_m100_4650_stage1.md`

## 관련 이슈

closes #4650

관련: #4599 (캠페인 Phase 3 사이클 6) · #4090 (prefix 분리 도입) · Task #855 ·
#4611/#4614/#4623/#4640 (사이클 1~5, 독립 변경)

## 테스트

- [x] `cargo test` 통과 — `cargo test --release` 전체 exit 0
- [x] `cargo clippy -- -D warnings` 통과 (경고 0)
- [x] 관련 샘플 파일로 SVG 내보내기 확인 — 좌표 실측: prefix 952.9→표 옆 747.9 정렬,
      페이지 매칭 14쌍 maxdev 9.2
- [x] 웹(WASM) 렌더링 확인 — `wasm-pack build --target web` 성공
- [ ] 작업 증빙 — 코드 변경. 회귀 산출물 보존: `_oracle_pdf_2022/`
      `sweep3418_cycle6fix_combo.tsv` · `phase1b_cycle6_242.tsv`
- [ ] `.claude/agents/` 등 변경 — 해당 없음

추가 회귀 검증 (#4599 가드레일 3종):

- **backlog 242 PDF 재판정** — 개선 1(대상 204.0→9.2 WEAK) / 불변 241 / 악화 0
- **hwpx 3418 스윕** (baseline 572786d02 클린 worktree 빌드) — 판정 이동 1(대상
  DRIFT→OK, worst 198.9→10.2) · worst +2px 이동 1건: 156492236 +7.5 — **모아찍기
  (2-up) 캐시 문서로 오라클 부재**(같은 반폭 Square wrap 템플릿, 사다리 축 ±16px).
  Windows 캐시 재생성 목록(기존 등재)에서 재판정 예정으로 기록
- **전수 Table-diff** — 변동 2건: 대상(의도) · 156492236(위)

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 — wrap-zone 문단 판별에서 꼬리 seg 슬라이스 스캔 1회
- 재현·측정: 3418 문서 dump-extents 결합 스윕 전후 동일 조건 완주

## 스크린샷

비공개 코퍼스 문서라 파일 미첨부 — 좌표 실측 표로 갈음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)