### PR TITLE
ci: stale run 취소에 시스템 CA 사용

### DIFF
--- a/.github/workflows/cancel-stale-pr-runs.yml
+++ b/.github/workflows/cancel-stale-pr-runs.yml
@@ -49,6 +49,9 @@ jobs:
     steps:
       - name: Force-cancel older pull-request runs for this PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          # GitHub-hosted runner의 프록시 CA도 신뢰하되 TLS 검증은 유지한다. #4673
+          NODE_OPTIONS: --use-system-ca
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/mydocs/orders/20260812.md
+++ b/mydocs/orders/20260812.md
@@ -109,3 +109,15 @@
   누적 이행 기록은 `mydocs/pr/archives/`에 보존한다.
 - 원격 통합 PR 생성·CI·merge와 원 PR comment/close는 작업지시자 승인 뒤에만 수행한다. `core-cli`의
   legacy 기준자료 공백은 전체 historic score 재현을 주장하지 않는 후속 정비 항목으로 남긴다.
+
+## Issue #4673 - stale run 취소 runner TLS 보정
+
+- [PR #4670](https://github.com/edwardkim/rhwp/pull/4670)의 stale run 취소 job은 GitHub API 목록 조회 중
+  `DEPTH_ZERO_SELF_SIGNED_CERT`로 실패했다. Studio bridge 변경과 무관한 GitHub-hosted runner의 Node CA
+  신뢰 저장소 문제였으며, 해당 PR의 Build & Test·CodeQL·Render Diff는 성공했다.
+- [PR #4674](https://github.com/edwardkim/rhwp/pull/4674)은 `actions/github-script` step에
+  `NODE_OPTIONS=--use-system-ca`를 적용한다. TLS 검증 비활성화는 사용하지 않고, contract test가 시스템 CA
+  설정 위치와 `NODE_TLS_REJECT_UNAUTHORIZED` 부재를 검증한다.
+- code candidate `92dbeda54`의 CI·CodeQL·Native Skia·nextest shard·Build & Test는 모두 성공했다.
+  archive review를 포함한 trailing docs push의 `synchronize` event에서 실제 `cancel-stale-runs` 성공을
+  확인한 뒤 merge를 판단한다.

--- a/mydocs/pr/archives/pr_4674_review.md
+++ b/mydocs/pr/archives/pr_4674_review.md
@@ -1,0 +1,53 @@
+---
+kind: pr-review
+status: pending-ci
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-12
+---
+
+# PR #4674 검토 - stale run 취소에 시스템 CA 사용
+
+## 라우팅과 접수
+
+```text
+base route: maintainer_general
+modifiers: intake_and_review.md, local_validation.md,
+  review_only_fast_pass.md
+```
+
+| 항목 | 기록 |
+| --- | --- |
+| PR | [#4674](https://github.com/edwardkim/rhwp/pull/4674) |
+| 관련 이슈 | [#4673](https://github.com/edwardkim/rhwp/issues/4673) |
+| code candidate | `92dbeda54f01953b172c04fb88617421ddfc0bef` |
+| 기준선 | `upstream/devel` `7a04b1f72569b1be19309fcd02012cec75cf4784` |
+| 변경 범위 | stale run 취소 workflow와 Python workflow contract test |
+| reviewer request | 작성자 maintainer self-review 경로라 별도 reviewer request 없음 |
+
+## 변경 판단
+
+[PR #4670의 실패 job](https://github.com/edwardkim/rhwp/actions/runs/31571978785/job/94035729608)은
+GitHub API의 stale run 목록 조회 중 `DEPTH_ZERO_SELF_SIGNED_CERT`로 중단됐다. 실패는 Studio bridge
+변경과 무관한 GitHub-hosted runner의 Node TLS 신뢰 저장소 경로였고, 같은 PR의 Build & Test·CodeQL·Render
+Diff는 성공했다.
+
+`actions/github-script` step에 `NODE_OPTIONS=--use-system-ca`를 적용해 시스템 CA 저장소를 사용한다.
+`NODE_TLS_REJECT_UNAUTHORIZED=0`처럼 TLS 검증을 끄는 설정은 사용하지 않으며, 기존 same-repository/fork
+guard와 stale run 완료 race 재조회 규칙도 바꾸지 않는다.
+
+## 완료한 검증
+
+- `python3 -m unittest scripts/tests/test_cancel_stale_pr_runs_workflow.py -v`: 2건 통과.
+- 로컬 Node `v24.15.0`에서 `--use-system-ca` 지원을 확인했다.
+- `git diff --check`: 통과.
+- code candidate의 [CI run](https://github.com/edwardkim/rhwp/actions/runs/31575675269)과
+  [CodeQL run](https://github.com/edwardkim/rhwp/actions/runs/31575675263)은 Full CI·Native Skia·nextest
+  shard·Build & Test까지 모두 통과했다.
+
+Rust 소스는 변경하지 않아 로컬 전체 Cargo 회귀는 실행하지 않았다. workflow 변경이므로 GitHub CI의 full
+lane 결과를 검증 근거로 사용했다.
+
+## trailing docs와 최종 판단
+
+이 문서와 오늘할일은 code candidate가 녹색이 된 뒤 추가한 review-only commit이다. 이 push의 `synchronize`
+이벤트에서 `cancel-stale-runs`가 실제로 시스템 CA 설정으로 성공하는지 확인한 뒤 merge를 판단한다.

--- a/scripts/tests/test_cancel_stale_pr_runs_workflow.py
+++ b/scripts/tests/test_cancel_stale_pr_runs_workflow.py
@@ -31,6 +31,17 @@ class CancelStalePrRunsWorkflowTests(unittest.TestCase):
         self.assertLess(reread, active_failure)
         self.assertLess(active_failure, completed_notice)
 
+    def test_github_script_uses_system_ca_without_disabling_tls_verification(self):
+        """runner/프록시 CA를 신뢰하되 인증서 검증 자체를 끄지 않는다."""
+        body = self.workflow
+        action = body.index("uses: actions/github-script@")
+        system_ca = body.index("NODE_OPTIONS: --use-system-ca", action)
+        script = body.index("script: |", system_ca)
+
+        self.assertLess(action, system_ca)
+        self.assertLess(system_ca, script)
+        self.assertNotIn("NODE_TLS_REJECT_UNAUTHORIZED", body)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #4673

## 원인

[PR #4670의 stale run 취소 job](https://github.com/edwardkim/rhwp/actions/runs/31571978785/job/94035729608)은 GitHub API run 목록 조회 중 `DEPTH_ZERO_SELF_SIGNED_CERT`로 실패했습니다. Studio bridge 변경과 무관한 GitHub-hosted runner의 Node TLS 신뢰 저장소 문제입니다.

## 변경

- `actions/github-script` step에 `NODE_OPTIONS=--use-system-ca`를 적용해 시스템 CA 저장소를 사용합니다.
- `NODE_TLS_REJECT_UNAUTHORIZED=0` 같은 TLS 검증 비활성화는 사용하지 않습니다.
- workflow contract test가 시스템 CA 설정 위치와 TLS 비활성화 부재를 검증합니다.

## 로컬 검증

- `python3 -m unittest scripts/tests/test_cancel_stale_pr_runs_workflow.py -v`: 2건 통과
- `git diff --check`: 통과
- 로컬 Node `v24.15.0`에서 `--use-system-ca` 지원을 확인했습니다.

Rust 소스 변경이 없어 전체 Cargo 회귀는 실행하지 않았습니다. PR head CI와 실제 synchronize 이벤트의 `cancel-stale-runs` 결과를 확인한 뒤 merge를 판단합니다.