### PR TITLE
feat(tools): load/save 한글 오라클 전수검사 하네스 (loadsave_sweep) 등재 (#4678)

### DIFF
--- a/tools/loadsave_sweep/README.md
+++ b/tools/loadsave_sweep/README.md
@@ -1,0 +1,87 @@
+# loadsave_sweep — 한글 오라클 대조 load/save 전수검사 하네스
+
+rhwp 의 HWP/HWPX **불러오기·저장하기**에 누락·오류가 있는지, 설치된 한글(2018/2022/2024)을
+오라클로 삼아 전수검사한다. 판정자는 문서가 아니라 **설치된 한글**이다.
+
+## 원리 — 경로 매트릭스가 곧 진단
+
+문서마다 rhwp 저장 경로 두 갈래를 만들고, 한글이 원본과 산출물에서 각각 무엇을 보는지 대조한다.
+
+| 입력 | route | rhwp 명령 | 검증 대상 |
+|---|---|---|---|
+| .hwp | h2h | `convert` | hwp 파싱 + hwp 저장 |
+| .hwp | h2x | `export-hwpx` | hwp 파싱 + hwpx 저장 |
+| .hwpx | x2h | `convert` | hwpx 파싱 + hwp 저장 |
+| .hwpx | x2x | `export-hwpx` | hwpx 파싱 + hwpx 저장 |
+
+한 입력의 **두 산출이 모두** 나쁘면 불러오기(파서) 쪽, **한쪽만** 나쁘면 그 저장 축 쪽이다.
+
+측정값(모두 같은 한글 버전이 같은 코드 경로로 추출 — 비교가 공평하다):
+
+- 본문 텍스트 (`GetTextFile("TEXT")`) → 텍스트 누락/변형
+- 컨트롤 집계 (HeadCtrl 체인 CtrlID 카운트) → 표·그림 등 개체 누락
+- 페이지 수 → 레이아웃 붕괴 신호 (참고)
+- Open 성공 여부 → 저장 치명 결함
+
+## 실행 절차
+
+전제: 클린 devel 에서 새로 빌드한 `rhwp.exe` (기존 target/release 재사용 금지 —
+출처 불명 exe 가 유령 회귀를 만든 전례가 있다), Python 3.12, 한글 2018/2022/2024 설치,
+`FilePathCheckerModule` HKCU 등록.
+
+```powershell
+$S = 'D:\loadsave_sweep'   # 스윕 루트 (D: 여유 확인 — 산출물이 코퍼스의 ~2배)
+$T = 'D:\rhwp\tools\loadsave_sweep'
+$PY = "$env:LOCALAPPDATA\Programs\Python\Python312\python.exe"
+
+# 0. 마스터 목록 (파일럿은 --take-hwp 20 --take-hwpx 20)
+& $PY $T\make_lists.py --root D:\hwpdocs_10k_share --out $S\master.tsv
+
+# 1. Phase A — rhwp 변환 매트릭스 (COM 불필요, 병렬, 재개 가능)
+& $PY $T\rhwp_phase.py --master $S\master.tsv --out $S\s1 --rhwp $S\rhwp_devel.exe --jobs 6
+
+# 2. Phase B — 한글 2022 오라클 패스 (단일 워커, 장시간, 재개 가능)
+powershell -NoProfile -ExecutionPolicy Bypass -File $T\oracle_run.ps1 `
+  -HwpVersion 2022 -TaskPath $S\s1\oracle_tasks.tsv -OutDir $S\s1\oracle_2022 -HideWindow
+
+# 3. 판정
+& $PY $T\judge.py --master $S\master.tsv --phase-a $S\s1\phase_a.ndjson `
+  --oracle $S\s1\oracle_2022\result.tsv --texts $S\s1\oracle_2022\texts --out $S\s1\oracle_2022\verdicts
+
+# 4. 반드시: COM 기본 버전 복원
+powershell -NoProfile -File D:\rhwp\tools\hangul_version_oracle\restore_com_default.ps1
+```
+
+### 2단계 (2018/2024 확대)
+
+1단계(2022 전수)의 실패군 + 등간격 표본으로 축소 master 를 만들어 같은 절차를 반복한다.
+Phase A 산출물은 버전 무관이므로 재사용 — Phase B 만 `-HwpVersion 2018` / `2024` 로
+다시 돌린다 (`-OutDir` 을 버전별로 분리). **2018 은 `-HideWindow` 금지** (Open 데드락).
+
+## 규약과 함정 (기존 오라클 인프라에서 상속)
+
+- **동시 실행 금지**: 한글 COM 판정은 머신 전체에서 한 번에 하나. 워커도 하나.
+- **버전 선택은 HKCU CLSID 오버라이드** — supervisor 가 걸고 시작 전에 실제 major 를
+  검증한다. 키를 **삭제하지 말 것**(로그오프까지 오버라이드 무력화). 끝나면
+  `restore_com_default.ps1`.
+- 워커는 heartbeat 를 쓰고 supervisor 가 정지(stall)를 감지해 Hwp.exe 를 죽인다.
+  강제종료 직후 첫 Open 은 수 분 블록될 수 있어 warmup 으로 흡수한다.
+- **유령 성공 주의**: 대화상자 자동거부로 "빈 문서 열기 성공"이 나올 수 있다.
+  judge 가 원본 텍스트 0자+1쪽을 `origSuspect` 로 표시한다 — 전수에서 이 비율이 높으면
+  보안 모듈 등록 상태부터 의심할 것.
+- 모든 산출은 재개 가능: Phase A 는 NDJSON 저널, Phase B 는 result.tsv 의 key 로 이어 쓴다.
+
+## 산출물
+
+```
+<S>/master.tsv                 docid \t format \t abspath
+<S>/s1/conv/                   rhwp 변환 산출물 (<docid>.<route>.hwp|hwpx)
+<S>/s1/phase_a.ndjson          Phase A 저널 (exit 0/3/4/FAIL/TIMEOUT + rhwp 자기검증)
+<S>/s1/oracle_tasks.tsv        Phase B 작업 목록 (key \t path)
+<S>/s1/oracle_<ver>/result.tsv key, status, pages, textLen, textSha, ctrls, fileBytes, err
+<S>/s1/oracle_<ver>/texts/     한글이 추출한 본문 텍스트 (판정·삼각측량용)
+<S>/s1/oracle_<ver>/verdicts/  verdicts.tsv + summary.md
+```
+
+판정 어휘: `CONVERT_FAIL` > `OPEN_FAIL` > `MEASURE_FAIL` > `TEXT_MISMATCH` > `CTRL_DIFF` >
+`PAGE_DIFF` > `OK`. 원본이 안 열리는 문서는 `ORACLE_ORIG_FAIL` 로 모수에서 제외.

--- a/tools/loadsave_sweep/classify_mismatch.py
+++ b/tools/loadsave_sweep/classify_mismatch.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""TEXT_MISMATCH 를 원인군으로 분류한다.
+
+U+2007(FIGURE SPACE, COM 추출에서 &#8199;) 삽입이 파일럿에서 지배적이었다 —
+양쪽에서 &#8199; 와 U+2007 을 제거했을 때 같아지면 그 군으로 묶는다.
+공백류 전체를 무시하면 같아지는 군, 그래도 다른 군(실질 텍스트 차이)을 나눈다.
+
+사용: python classify_mismatch.py --verdicts <verdicts.tsv> --texts <texts dir>
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+FIGSP = re.compile(r"&#8199;| ")
+ANYSP = re.compile(r"&#\d+;|\s+")
+
+
+def norm(raw: bytes) -> str:
+    s = raw.decode("utf-8", "replace")
+    s = s.replace("\r\n", "\n").replace("\r", "\n")
+    return "\n".join(line.rstrip() for line in s.split("\n")).rstrip("\n")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--verdicts", required=True)
+    ap.add_argument("--texts", required=True)
+    ap.add_argument("--out", help="분류 결과 TSV (기본: verdicts 옆 mismatch_classes.tsv)")
+    args = ap.parse_args()
+
+    texts = Path(args.texts)
+    rows = Path(args.verdicts).read_text(encoding="utf-8").splitlines()
+    header = rows[0].split("\t")
+    idx = {h: i for i, h in enumerate(header)}
+
+    classes: Counter = Counter()
+    by_route: dict[str, Counter] = {}
+    out_rows = []
+    for line in rows[1:]:
+        c = line.split("\t")
+        if "TEXT_MISMATCH" not in c[idx["verdict"]]:
+            continue
+        docid, route = c[idx["docid"]], c[idx["route"]]
+        a = texts / f"{docid}.orig.txt"
+        b = texts / f"{docid}.{route}.txt"
+        if not a.is_file() or not b.is_file():
+            cls = "text-missing"
+        else:
+            ta, tb = norm(a.read_bytes()), norm(b.read_bytes())
+            if FIGSP.sub("", ta) == FIGSP.sub("", tb):
+                cls = "figure-space-only"
+            elif ANYSP.sub("", ta) == ANYSP.sub("", tb):
+                cls = "whitespace-only"
+            elif len(ANYSP.sub("", tb)) < len(ANYSP.sub("", ta)):
+                cls = "content-loss"
+            else:
+                cls = "content-diff"
+        classes[cls] += 1
+        by_route.setdefault(route, Counter())[cls] += 1
+        out_rows.append(f"{docid}\t{route}\t{cls}")
+
+    out = Path(args.out) if args.out else Path(args.verdicts).with_name("mismatch_classes.tsv")
+    out.write_text("\n".join(out_rows) + "\n", encoding="utf-8")
+    print("전체:", dict(classes))
+    for r in sorted(by_route):
+        print(f"  {r}: {dict(by_route[r])}")
+    print(f"-> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/loadsave_sweep/judge.py
+++ b/tools/loadsave_sweep/judge.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""판정기 — Phase A 저널과 Phase B 오라클 측정을 합쳐 문서×경로별 판정을 낸다.
+
+판정 어휘 (경로 하나에 여러 개 겹칠 수 있다 · 심각도 순):
+    CONVERT_FAIL      rhwp 가 변환 자체를 못 함 (FAIL/TIMEOUT/SPAWN_FAIL)
+    OPEN_FAIL         rhwp 산출물을 한글이 못 엶  ← 저장하기 치명 결함
+    MEASURE_FAIL      한글이 열었지만 측정 중 오류 (판정 불가)
+    TEXT_MISMATCH     본문 텍스트 불일치            ← 텍스트 누락/변형
+    CTRL_DIFF         컨트롤 집계 불일치 (표·그림 등) ← 개체 누락
+    PAGE_DIFF         페이지 수 불일치               ← 레이아웃 신호 (참고)
+    OK                위 어느 것도 아님
+
+원본이 한글에서 안 열리는 문서(ORACLE_ORIG_FAIL)는 판정 모수에서 제외해 따로 센다.
+rhwp 자기검증(exit 3/4)은 selfVerify 열에 참고로 싣는다 — 오라클 판정과 독립이다.
+
+원본 유령 성공 의심(원본 텍스트 0자 + 페이지 1)은 origSuspect 열로 표시한다. 보안 모듈
+미등록 등으로 대화상자가 자동 거부되면 "빈 문서를 연 성공"이 나온다(메모리: 빈 PDF 사례).
+
+사용:
+    python judge.py --master master.tsv --phase-a <out>/phase_a.ndjson \
+        --oracle <oracle_out>/result.tsv --texts <oracle_out>/texts --out <oracle_out>/verdicts
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+ROUTES = {"hwp": ["h2h", "h2x"], "hwpx": ["x2h", "x2x"]}
+CONVERT_OK = ("OK", "VERIFY_DIFF", "PAGE_DIFF")
+
+
+def norm_text(raw: bytes) -> str:
+    s = raw.decode("utf-8", "replace")
+    s = s.replace("\r\n", "\n").replace("\r", "\n")
+    # 행말 공백과 문서 끝 공백만 무시한다 — 본문 문자·순서는 그대로 비교한다.
+    return "\n".join(line.rstrip() for line in s.split("\n")).rstrip("\n")
+
+
+def first_diff(a: str, b: str) -> str:
+    la, lb = a.split("\n"), b.split("\n")
+    for i, (x, y) in enumerate(zip(la, lb)):
+        if x != y:
+            return f"line {i}: orig={x[:60]!r} var={y[:60]!r}"
+    if len(la) != len(lb):
+        i = min(len(la), len(lb))
+        longer = la if len(la) > len(lb) else lb
+        side = "orig" if len(la) > len(lb) else "var"
+        return f"line {i}: {side} extra {abs(len(la)-len(lb))} lines, first={longer[i][:60]!r}"
+    return "?"
+
+
+def parse_ctrls(s: str) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for part in s.split(","):
+        if ":" in part:
+            k, v = part.rsplit(":", 1)
+            try:
+                out[k] = int(v)
+            except ValueError:
+                pass
+    return out
+
+
+def ctrl_diff_str(a: dict[str, int], b: dict[str, int]) -> str:
+    keys = sorted(set(a) | set(b))
+    return ",".join(f"{k}:{a.get(k, 0)}->{b.get(k, 0)}" for k in keys if a.get(k, 0) != b.get(k, 0))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--master", required=True)
+    ap.add_argument("--phase-a", required=True)
+    ap.add_argument("--oracle", required=True, help="oracle result.tsv")
+    ap.add_argument("--texts", required=True)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    docs = []
+    for line in Path(args.master).read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            docid, fmt, src = line.split("\t", 2)
+            docs.append({"docid": docid, "format": fmt, "src": src})
+
+    phase_a: dict[tuple[str, str], dict] = {}
+    for line in Path(args.phase_a).read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        r = json.loads(line)
+        if r.get("kind") == "meta":
+            continue
+        phase_a[(r["docid"], r["route"])] = r  # 뒤 레코드(재실행)가 앞을 덮는다
+
+    oracle: dict[str, dict] = {}
+    for line in Path(args.oracle).read_text(encoding="utf-8").splitlines():
+        cols = line.rstrip("\n").split("\t")
+        if len(cols) < 8 or cols[0] == "__VERSION_MISMATCH__":
+            continue
+        oracle[cols[0]] = {
+            "status": cols[1], "pages": int(cols[2]), "textLen": int(cols[3]),
+            "textSha": cols[4], "ctrls": cols[5], "fileBytes": int(cols[6]), "err": cols[7],
+        }
+
+    texts_dir = Path(args.texts)
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    def load_text(key: str) -> str | None:
+        p = texts_dir / f"{key}.txt"
+        if not p.is_file():
+            return None
+        return norm_text(p.read_bytes())
+
+    rows = []
+    counts: dict[str, Counter] = defaultdict(Counter)
+    n_orig_fail = 0
+    n_orig_missing = 0
+    n_orig_suspect = 0
+
+    for doc in docs:
+        docid, fmt = doc["docid"], doc["format"]
+        orig = oracle.get(f"{docid}.orig")
+        if orig is None:
+            n_orig_missing += 1
+            continue  # Phase B 미도달 (부분 실행) — 모수에서 제외
+        if orig["status"] != "OK":
+            n_orig_fail += 1
+            rows.append([docid, fmt, "-", "ORACLE_ORIG_FAIL", "", "", "", "", orig["err"][:200], doc["src"]])
+            continue
+        orig_suspect = orig["textLen"] == 0 and orig["pages"] <= 1
+        if orig_suspect:
+            n_orig_suspect += 1
+        orig_text = None  # 필요할 때만 읽는다
+        orig_ctrls = parse_ctrls(orig["ctrls"])
+
+        for route in ROUTES[fmt]:
+            a = phase_a.get((docid, route))
+            verdicts = []
+            detail = ""
+            self_verify = ""
+            pages_str = ""
+            len_delta = ""
+            if a is None or a["status"] not in CONVERT_OK:
+                verdicts.append("CONVERT_FAIL")
+                detail = (a or {}).get("status", "NO_JOURNAL") + ": " + (a or {}).get("stderr", "")[:200]
+            else:
+                if a["status"] != "OK":
+                    self_verify = a["status"]  # rhwp 자기검증 exit 3/4 — 참고 데이터
+                var = oracle.get(f"{docid}.{route}")
+                if var is None:
+                    verdicts.append("MEASURE_FAIL")
+                    detail = "no oracle row (phase B incomplete?)"
+                elif var["status"] != "OK":
+                    verdicts.append("OPEN_FAIL")
+                    detail = var["err"][:200]
+                else:
+                    pages_str = f"{orig['pages']}->{var['pages']}"
+                    len_delta = str(var["textLen"] - orig["textLen"])
+                    if var["textSha"] != orig["textSha"]:
+                        if orig_text is None:
+                            orig_text = load_text(f"{docid}.orig")
+                        var_text = load_text(f"{docid}.{route}")
+                        if orig_text is None or var_text is None:
+                            verdicts.append("MEASURE_FAIL")
+                            detail = "text file missing"
+                        elif orig_text != var_text:
+                            verdicts.append("TEXT_MISMATCH")
+                            detail = first_diff(orig_text, var_text)[:300]
+                    cd = ctrl_diff_str(orig_ctrls, parse_ctrls(var["ctrls"]))
+                    if cd:
+                        verdicts.append("CTRL_DIFF")
+                        detail = (detail + " | " if detail else "") + cd[:200]
+                    if var["pages"] != orig["pages"]:
+                        verdicts.append("PAGE_DIFF")
+            verdict = ";".join(verdicts) if verdicts else "OK"
+            counts[route][verdicts[0] if verdicts else "OK"] += 1
+            rows.append([docid, fmt, route, verdict, self_verify, pages_str, len_delta,
+                         "SUSPECT" if orig_suspect else "", detail, doc["src"]])
+
+    header = ["docid", "format", "route", "verdict", "selfVerify", "pages", "textLenDelta",
+              "origSuspect", "detail", "src"]
+    verdict_path = out_dir / "verdicts.tsv"
+    with verdict_path.open("w", encoding="utf-8", newline="\n") as f:
+        f.write("\t".join(header) + "\n")
+        for r in rows:
+            f.write("\t".join(str(c) for c in r) + "\n")
+
+    # 요약
+    lines = ["# load/save 스윕 판정 요약", ""]
+    total_judged = sum(sum(c.values()) for c in counts.values())
+    lines.append(f"- 문서: {len(docs)} (원본 오라클 실패 {n_orig_fail}, Phase B 미도달 {n_orig_missing}, "
+                 f"원본 유령성공 의심 {n_orig_suspect})")
+    lines.append(f"- 판정된 (문서×경로): {total_judged}")
+    lines.append("")
+    lines.append("| route | OK | CONVERT_FAIL | OPEN_FAIL | TEXT_MISMATCH | CTRL_DIFF | PAGE_DIFF | MEASURE_FAIL |")
+    lines.append("|---|---|---|---|---|---|---|---|")
+    for route in ("h2h", "h2x", "x2h", "x2x"):
+        c = counts[route]
+        lines.append(f"| {route} | {c['OK']} | {c['CONVERT_FAIL']} | {c['OPEN_FAIL']} | "
+                     f"{c['TEXT_MISMATCH']} | {c['CTRL_DIFF']} | {c['PAGE_DIFF']} | {c['MEASURE_FAIL']} |")
+    lines.append("")
+    lines.append("(표의 셀은 첫 번째(최고 심각도) 판정 기준. 겹친 판정 전체는 verdicts.tsv 의 verdict 열.)")
+    bad = [r for r in rows if r[3] not in ("OK", "ORACLE_ORIG_FAIL")]
+    if bad:
+        lines.append("")
+        lines.append(f"## 결함 상위 예시 ({min(len(bad), 20)}/{len(bad)})")
+        sev = {"CONVERT_FAIL": 0, "OPEN_FAIL": 1, "MEASURE_FAIL": 2, "TEXT_MISMATCH": 3,
+               "CTRL_DIFF": 4, "PAGE_DIFF": 5}
+        bad.sort(key=lambda r: sev.get(r[3].split(";")[0], 9))
+        for r in bad[:20]:
+            lines.append(f"- `{r[0]}.{r[2]}` [{r[3]}] {r[8][:160]} — {Path(r[9]).name}")
+    summary_path = out_dir / "summary.md"
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print("\n".join(lines))
+    print(f"\n[judge] {verdict_path}")
+    print(f"[judge] {summary_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/loadsave_sweep/make_lists.py
+++ b/tools/loadsave_sweep/make_lists.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""코퍼스를 스캔해 스윕 마스터 목록(master.tsv)을 만든다.
+
+행 형식: docid \t format(hwp|hwpx) \t abspath
+docid 는 정렬된 relpath 순서의 5자리 순번 — 모든 후속 산출물(변환본·텍스트·판정)이
+이 id 로 연결되므로, 같은 코퍼스 루트라면 재실행해도 id 가 변하지 않는다.
+
+파일럿 표본은 --take-hwp/--take-hwpx 로 뽑는다. 앞에서 N개가 아니라 등간격 추출이라
+코퍼스 전체의 다양성이 표본에 실린다.
+
+    python make_lists.py --root D:\\hwpdocs_10k_share --out master.tsv
+    python make_lists.py --root D:\\hwpdocs_10k_share --out pilot.tsv --take-hwp 20 --take-hwpx 20
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def spaced_sample(items: list, n: int) -> list:
+    if n <= 0 or n >= len(items):
+        return items
+    step = len(items) / n
+    return [items[int(i * step)] for i in range(n)]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--take-hwp", type=int, default=0, help="hwp 등간격 표본 수 (0=전체)")
+    ap.add_argument("--take-hwpx", type=int, default=0, help="hwpx 등간격 표본 수 (0=전체)")
+    args = ap.parse_args()
+
+    root = Path(args.root)
+    if not root.is_dir():
+        print(f"root not found: {root}", file=sys.stderr)
+        return 2
+
+    # docid 는 전체 코퍼스의 정렬 순서에서 나온다 — 표본을 떠도 id 가 전수 목록과 일치해,
+    # 파일럿에서 발견한 문서를 전수 스윕 결과에서 같은 id 로 찾을 수 있다.
+    by_fmt: dict[str, list[tuple[str, str, str]]] = {"hwp": [], "hwpx": []}
+    all_files = sorted(
+        (p for p in root.rglob("*") if p.is_file() and p.suffix.lower() in (".hwp", ".hwpx")),
+        key=lambda p: str(p.relative_to(root)).lower(),
+    )
+    for i, p in enumerate(all_files):
+        fmt = p.suffix.lower().lstrip(".")
+        by_fmt[fmt].append((f"{i:05d}", fmt, str(p)))
+
+    rows = spaced_sample(by_fmt["hwp"], args.take_hwp) + spaced_sample(by_fmt["hwpx"], args.take_hwpx)
+    rows.sort(key=lambda r: r[0])
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("w", encoding="utf-8", newline="\n") as f:
+        for docid, fmt, path in rows:
+            f.write(f"{docid}\t{fmt}\t{path}\n")
+    print(f"{out}: {len(rows)} rows (hwp {sum(1 for r in rows if r[1]=='hwp')}, "
+          f"hwpx {sum(1 for r in rows if r[1]=='hwpx')})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/loadsave_sweep/make_stage2.py
+++ b/tools/loadsave_sweep/make_stage2.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""2단계(버전 확대) 대상 목록 생성 — 1단계 실패군 전체 + OK군 등간격 표본.
+
+실패군: verdict 가 OK/ORACLE_ORIG_FAIL 이 아닌 (문서×경로)가 하나라도 있는 문서.
+단, 코퍼스 자체 문제(DRM·암호·비지원 포맷의 CONVERT_FAIL)만 있는 문서는 제외 —
+다른 한글 버전으로 열어도 rhwp 판정이 달라질 수 없다.
+
+산출: stage2 master(문서 목록) + 해당 문서의 oracle_tasks 부분집합.
+
+사용:
+    python make_stage2.py --master master.tsv --verdicts <v.tsv> --phase-a <a.ndjson> \
+        --tasks oracle_tasks.tsv --out-master stage2.tsv --out-tasks stage2_tasks.tsv --sample-ok 400
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+CORPUS_ERR = ("DRM", "암호", "UNSUPPORTED")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--master", required=True)
+    ap.add_argument("--verdicts", required=True)
+    ap.add_argument("--phase-a", required=True)
+    ap.add_argument("--tasks", required=True)
+    ap.add_argument("--out-master", required=True)
+    ap.add_argument("--out-tasks", required=True)
+    ap.add_argument("--sample-ok", type=int, default=400)
+    args = ap.parse_args()
+
+    stderr_by_key: dict[tuple[str, str], str] = {}
+    for l in open(args.phase_a, encoding="utf-8"):
+        if l.strip():
+            r = json.loads(l)
+            if r.get("kind") != "meta":
+                stderr_by_key[(r["docid"], r["route"])] = r.get("stderr", "")
+
+    defect: set[str] = set()
+    ok_docs: set[str] = set()
+    for x in csv.DictReader(open(args.verdicts, encoding="utf-8"), delimiter="\t"):
+        v = x["verdict"]
+        if v in ("OK", "ORACLE_ORIG_FAIL"):
+            ok_docs.add(x["docid"])
+            continue
+        if v == "CONVERT_FAIL":
+            e = stderr_by_key.get((x["docid"], x["route"]), "")
+            if any(t in e for t in CORPUS_ERR):
+                continue  # 코퍼스 문제 — 버전 확대 무의미
+        defect.add(x["docid"])
+    ok_docs -= defect
+
+    rows = []
+    picked = set(defect)
+    ok_sorted = sorted(ok_docs)
+    if args.sample_ok > 0 and ok_sorted:
+        step = max(len(ok_sorted) / args.sample_ok, 1)
+        picked |= {ok_sorted[int(i * step)] for i in range(min(args.sample_ok, len(ok_sorted)))}
+
+    n = 0
+    with open(args.out_master, "w", encoding="utf-8", newline="\n") as f:
+        for line in open(args.master, encoding="utf-8"):
+            if line.split("\t", 1)[0] in picked:
+                f.write(line)
+                n += 1
+    m = 0
+    with open(args.out_tasks, "w", encoding="utf-8", newline="\n") as f:
+        for line in open(args.tasks, encoding="utf-8"):
+            if line.split(".", 1)[0] in picked:
+                f.write(line)
+                m += 1
+    print(f"defect docs: {len(defect)}, ok-sample: {len(picked) - len(defect)}, "
+          f"master rows: {n}, oracle tasks: {m}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/loadsave_sweep/oracle_run.ps1
+++ b/tools/loadsave_sweep/oracle_run.ps1
@@ -1,0 +1,175 @@
+# Phase B supervisor: run one full load/save oracle pass under a chosen Hangul version.
+#
+# Direct adaptation of tools/hangul_version_oracle/page_oracle_run.ps1 (same CLSID override,
+# override probe, heartbeat watch, stall-kill, worker restart). Differences: the worker is
+# oracle_worker.ps1, the list is a key<TAB>path task file from rhwp_phase.py, and extracted
+# body texts land in <OutDir>\texts for the judge.
+#
+# Run restore_com_default.ps1 (tools/hangul_version_oracle/) when all passes are done.
+# Guide: mydocs/manual/verification/hangul_version_oracle.md
+[CmdletBinding()]
+param(
+  # Hangul release year as installed under Hnc\Office <year>, e.g. 2018 / 2022 / 2024.
+  [Parameter(Mandatory = $true)][string]$HwpVersion,
+  [Parameter(Mandatory = $true)][string]$TaskPath,
+  [Parameter(Mandatory = $true)][string]$OutDir,
+  [int]$StallSeconds = 300,
+  [int]$RecycleEvery = 200,
+  [int]$WarmupDocs = 5,
+  # Hangul 2018 deadlocks in Open() when hidden -- only pass this on 2022+.
+  [switch]$HideWindow
+)
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$CLSID = '{2291CF00-64A1-4877-A9B4-68CFE89612D6}'
+
+function Resolve-HwpExe([string]$version) {
+  $roots = @(${env:ProgramFiles(x86)}, $env:ProgramFiles) | Where-Object { $_ }
+  foreach ($r in $roots) {
+    $glob = Join-Path $r "Hnc\Office $version\HOffice*\Bin\Hwp.exe"
+    $hit = Get-Item -Path $glob -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($hit) { return $hit.FullName }
+  }
+  throw "Hangul $version not found under Program Files\Hnc"
+}
+
+$exePath = Resolve-HwpExe $HwpVersion
+$productVersion = (Get-Item -LiteralPath $exePath).VersionInfo.ProductVersion
+$expectMajor = [int](($productVersion -split '[.,]')[0].Trim())
+Write-Output "[sup] Hangul $HwpVersion -> $exePath (ProductVersion $productVersion, major $expectMajor)"
+
+foreach ($base in "HKCU:\Software\Classes\CLSID\$CLSID\LocalServer32", "HKCU:\Software\Classes\Wow6432Node\CLSID\$CLSID\LocalServer32") {
+  New-Item -Path $base -Force | Out-Null
+  Set-ItemProperty -Path $base -Name '(default)' -Value "$exePath -Automation"
+}
+Write-Output "[sup] COM CLSID override set (HKCU)"
+
+# A leftover Hwp.exe defeats the override: COM attaches to the already-running instance.
+$stale = @(Get-Process Hwp -ErrorAction SilentlyContinue)
+if ($stale.Count -gt 0) {
+  Write-Output "[sup] terminating $($stale.Count) leftover Hwp.exe process(es)"
+  $stale | Stop-Process -Force -ErrorAction SilentlyContinue
+  Start-Sleep -Seconds 2
+}
+
+# Prove the override took effect BEFORE spending a pass on it.
+Write-Output "[sup] verifying COM hands out major $expectMajor ..."
+$probeMajor = 0
+try {
+  $probe = New-Object -ComObject HWPFrame.HwpObject
+  $probeVersion = $probe.Version
+  $probeMajor = [int](($probeVersion -split '[.,]')[0].Trim())
+  try { $probe.Quit() } catch { }
+  [System.Runtime.InteropServices.Marshal]::ReleaseComObject($probe) | Out-Null
+} catch {
+  throw "COM activation failed: $($_.Exception.Message)"
+}
+Get-Process Hwp -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+if ($probeMajor -ne $expectMajor) {
+  Write-Output "[sup] got major $probeMajor ($probeVersion), expected $expectMajor"
+  throw @"
+COM did not honour the HKCU override.
+  1. Close every Hwp.exe (a UI instance may have respawned).
+  2. Never DELETE the HKCU CLSID key -- COM then ignores HKCU until logoff.
+     Use tools/hangul_version_oracle/restore_com_default.ps1 to clean up after a run.
+"@
+}
+Write-Output "[sup] verified: COM hands out major $probeMajor ($probeVersion)"
+
+if (-not (Test-Path $OutDir)) { New-Item -ItemType Directory -Force -Path $OutDir | Out-Null }
+$all = Get-Content -LiteralPath $TaskPath -Encoding UTF8 | Where-Object { $_.Trim().Length -gt 0 }
+Write-Output "[sup] tasks: $($all.Count) opens (single worker -- concurrent Hangul instances corrupt measurements)"
+
+$state = @{
+  Out = Join-Path $OutDir 'result.tsv'
+  HB = Join-Path $OutDir 'hb.txt'
+  Texts = Join-Path $OutDir 'texts'
+  Total = $all.Count
+  Proc = $null
+  Restarts = 0
+}
+
+function Start-Worker {
+  $wargs = @(
+    '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', (Join-Path $here 'oracle_worker.ps1'),
+    '-TaskPath', $TaskPath, '-OutPath', $state.Out, '-HeartbeatPath', $state.HB,
+    '-ExpectMajor', $expectMajor, '-TextDir', $state.Texts,
+    '-RecycleEvery', $RecycleEvery, '-WarmupDocs', $WarmupDocs
+  )
+  if ($HideWindow) { $wargs += '-HideWindow' }
+  $state.Proc = Start-Process -FilePath 'powershell.exe' -ArgumentList $wargs -PassThru -WindowStyle Hidden
+  Write-Output "[sup] worker started (pid $($state.Proc.Id))"
+}
+
+function Get-DoneCount($path) {
+  if (-not (Test-Path -LiteralPath $path)) { return 0 }
+  # FileShare.ReadWrite: the worker holds the TSV open for append; a plain read throws and
+  # progress would report 0 forever (see page_oracle_run.ps1).
+  try {
+    $fs = New-Object System.IO.FileStream($path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+    try {
+      $sr = New-Object System.IO.StreamReader($fs, (New-Object System.Text.UTF8Encoding($false)))
+      try {
+        $n = 0
+        while ($null -ne $sr.ReadLine()) { $n++ }
+        return $n
+      } finally { $sr.Dispose() }
+    } finally { $fs.Dispose() }
+  } catch { return 0 }
+}
+
+Start-Worker
+
+$t0 = Get-Date
+$lastReport = Get-Date
+while ($true) {
+  Start-Sleep -Seconds 10
+  $nowMs = [int64]([datetime]::UtcNow - [datetime]'1970-01-01').TotalMilliseconds
+  $alive = $false
+  $d = Get-DoneCount $state.Out
+  $running = $false
+  if ($null -ne $state.Proc) {
+    try { $running = -not (Get-Process -Id $state.Proc.Id -ErrorAction Stop).HasExited } catch { $running = $false }
+  }
+  if ($running) {
+    $alive = $true
+    if (Test-Path -LiteralPath $state.HB) {
+      $parts = ([System.IO.File]::ReadAllText($state.HB, [System.Text.Encoding]::UTF8)) -split '\|'
+      if ($parts.Count -ge 3) {
+        $age = ($nowMs - [int64]$parts[1]) / 1000.0
+        if ($age -gt $StallSeconds) {
+          $hp = [int]$parts[0]
+          Write-Output ("[sup] worker stalled {0:N0}s on '{1}' -> killing Hwp pid {2}" -f $age, $parts[2], $hp)
+          if ($hp -gt 0) { try { Stop-Process -Id $hp -Force -ErrorAction SilentlyContinue } catch { } }
+          if ($age -gt ($StallSeconds * 2)) {
+            try { Stop-Process -Id $state.Proc.Id -Force -ErrorAction SilentlyContinue } catch { }
+          }
+        }
+      }
+    }
+  } else {
+    # A version assert failure is fatal for the whole pass -- restarting just repeats it.
+    if ((Test-Path -LiteralPath $state.Out) -and (Select-String -LiteralPath $state.Out -SimpleMatch '__VERSION_MISMATCH__' -Quiet)) {
+      Write-Error "[sup] worker could not obtain Hangul major $expectMajor. Close every Hwp.exe and rerun."
+      exit 3
+    }
+    if ($d -lt $state.Total -and $state.Restarts -lt 30) {
+      $state.Restarts++
+      Write-Output "[sup] worker exited early ($d/$($state.Total)) -> restart #$($state.Restarts)"
+      Start-Worker
+      $alive = $true
+    }
+  }
+  if (((Get-Date) - $lastReport).TotalSeconds -ge 60) {
+    $el = ((Get-Date) - $t0).TotalMinutes
+    $rate = if ($el -gt 0) { $d / $el } else { 0 }
+    Write-Output ("[sup] {0}/{1} done, {2:N1} min elapsed, {3:N1} opens/min" -f $d, $state.Total, $el, $rate)
+    $lastReport = Get-Date
+  }
+  if (-not $alive) { break }
+}
+
+$d = Get-DoneCount $state.Out
+Write-Output ("[sup] PASS {0} COMPLETE: {1}/{2} records, {3:N1} min" -f $HwpVersion, $d, $state.Total, ((Get-Date) - $t0).TotalMinutes)
+Write-Output "[sup] reminder: run tools/hangul_version_oracle/restore_com_default.ps1 when all passes are done."

--- a/tools/loadsave_sweep/oracle_worker.ps1
+++ b/tools/loadsave_sweep/oracle_worker.ps1
@@ -1,0 +1,215 @@
+# Phase B worker: open each task file (original or rhwp output) in Hangul via COM and
+# record what Hangul sees: page count, body text (saved to TextDir, sha in the TSV), and
+# a control census (CtrlID counts). The judge compares <docid>.orig against <docid>.<route>.
+#
+# Task list format: "key<TAB>abspath" per line, key = <docid>.<orig|h2h|h2x|x2h|x2x>.
+# Output TSV columns: key, status, pages, textLen, textSha, ctrls, fileBytes, err
+#
+# COM discipline (heartbeat / stall recovery / warmup / two-attempt retry) is inherited from
+# tools/hangul_version_oracle/page_oracle_worker.ps1 -- see that file and
+# mydocs/manual/verification/hangul_version_oracle.md for the rationale of each rule.
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)][string]$TaskPath,
+  [Parameter(Mandatory = $true)][string]$OutPath,
+  [Parameter(Mandatory = $true)][string]$HeartbeatPath,
+  [Parameter(Mandatory = $true)][int]$ExpectMajor,
+  [Parameter(Mandatory = $true)][string]$TextDir,
+  [int]$RecycleEvery = 200,
+  [int]$WarmupDocs = 5,
+  # Hangul 2018 (major 10) deadlocks in Open() when the window is hidden -- keep visible there.
+  [switch]$HideWindow
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+if (-not (Test-Path -LiteralPath $TextDir)) { New-Item -ItemType Directory -Force -Path $TextDir | Out-Null }
+
+$tasks = @()
+foreach ($ln in (Get-Content -LiteralPath $TaskPath -Encoding UTF8 | Where-Object { $_.Trim().Length -gt 0 })) {
+  $i = $ln.IndexOf("`t")
+  if ($i -gt 0) { $tasks += , @($ln.Substring(0, $i), $ln.Substring($i + 1)) }
+}
+
+# Resume: skip keys already present in the output TSV.
+$done = New-Object 'System.Collections.Generic.HashSet[string]'
+if (Test-Path -LiteralPath $OutPath) {
+  foreach ($ln in [System.IO.File]::ReadAllLines($OutPath, [System.Text.Encoding]::UTF8)) {
+    $i = $ln.IndexOf("`t")
+    if ($i -gt 0) { $null = $done.Add($ln.Substring(0, $i)) }
+  }
+}
+
+$enc = New-Object System.Text.UTF8Encoding($false)
+$writer = New-Object System.IO.StreamWriter($OutPath, $true, $enc)
+$writer.AutoFlush = $true
+$sha256 = [System.Security.Cryptography.SHA256]::Create()
+
+$script:hwp = $null
+$script:hwpPid = 0
+
+function Get-HwpMajor([string]$version) {
+  $match = [System.Text.RegularExpressions.Regex]::Match($version, '^\s*(\d+)')
+  if (-not $match.Success) { throw "cannot parse Hangul version: $version" }
+  return [int]$match.Groups[1].Value
+}
+
+function New-HwpInstance {
+  $mutex = New-Object System.Threading.Mutex($false, 'Global\rhwp_hwp_spawn')
+  $null = $mutex.WaitOne()
+  try {
+    $before = @(Get-Process Hwp -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
+    $h = New-Object -ComObject HWPFrame.HwpObject
+    # Auto-answer Hangul message boxes; the default (0) blocks forever waiting for a human.
+    $null = $h.SetMessageBoxMode(0x00020000)
+    try { $null = $h.RegisterModule("FilePathCheckDLL", "FilePathCheckerModule") } catch { }
+    if ($HideWindow) {
+      try { $h.XHwpWindows.Item(0).Visible = $false } catch { }
+    }
+    $newPid = 0
+    for ($i = 0; $i -lt 100; $i++) {
+      $after = @(Get-Process Hwp -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
+      $diff = @($after | Where-Object { $before -notcontains $_ })
+      if ($diff.Count -ge 1) { $newPid = $diff[0]; break }
+      Start-Sleep -Milliseconds 100
+    }
+    # Re-verify on every instance: a recycle must not silently pick up another Hangul version.
+    $v = $h.Version
+    if ((Get-HwpMajor $v) -ne $ExpectMajor) {
+      throw "version mismatch: expected major $ExpectMajor, got $v"
+    }
+    $script:hwp = $h
+    $script:hwpPid = $newPid
+  } finally {
+    $mutex.ReleaseMutex()
+    $mutex.Dispose()
+  }
+}
+
+function Close-HwpInstance {
+  if ($null -ne $script:hwp) {
+    try { $script:hwp.Quit() } catch { }
+    try { [System.Runtime.InteropServices.Marshal]::ReleaseComObject($script:hwp) | Out-Null } catch { }
+    $script:hwp = $null
+  }
+  if ($script:hwpPid -gt 0) {
+    try { Stop-Process -Id $script:hwpPid -Force -ErrorAction SilentlyContinue } catch { }
+    $script:hwpPid = 0
+  }
+}
+
+function Write-Heartbeat([string]$current) {
+  $ms = [int64]([datetime]::UtcNow - [datetime]'1970-01-01').TotalMilliseconds
+  try { [System.IO.File]::WriteAllText($HeartbeatPath, "$($script:hwpPid)|$ms|$current", $enc) } catch { }
+}
+
+Write-Heartbeat "startup"
+try {
+  New-HwpInstance
+} catch {
+  $writer.WriteLine("__VERSION_MISMATCH__`tERR`t0`t0`t`t`t0`t$($_.Exception.Message)")
+  $writer.Dispose()
+  Close-HwpInstance
+  exit 3
+}
+Write-Heartbeat "ready ver=$($script:hwp.Version)"
+
+function Start-Warmup {
+  # Absorb the first-Open() block that follows a force-killed instance (see page_oracle_worker).
+  if ($WarmupDocs -le 0 -or $tasks.Count -eq 0) { return }
+  $warmFile = $tasks[0][1]
+  for ($w = 1; $w -le $WarmupDocs; $w++) {
+    Write-Heartbeat "warmup $w/$WarmupDocs"
+    try {
+      $null = $script:hwp.Open($warmFile, "", "forceopen:true")
+      try { $null = $script:hwp.Clear(1) } catch { }
+      Write-Heartbeat "warmup ok after $w"
+      return
+    } catch {
+      try { $null = $script:hwp.Clear(1) } catch {
+        Close-HwpInstance
+        try { New-HwpInstance } catch { }
+      }
+    }
+  }
+  Write-Heartbeat "warmup exhausted after $WarmupDocs"
+}
+Start-Warmup
+
+$n = 0
+foreach ($t in $tasks) {
+  $key = $t[0]; $path = $t[1]
+  if ($done.Contains($key)) { continue }
+
+  $fileBytes = 0
+  try { $fileBytes = (Get-Item -LiteralPath $path).Length } catch { }
+
+  # Two attempts: the first document after a stall-kill fails on the dead instance and must be
+  # re-measured on its replacement, or resume treats the ERR row as done and loses it for good.
+  $status = 'OK'; $pages = -1; $textLen = -1; $textSha = ''; $ctrls = ''; $err = ''
+  for ($attempt = 1; $attempt -le 2; $attempt++) {
+    Write-Heartbeat $key
+    $status = 'OK'; $pages = -1; $textLen = -1; $textSha = ''; $ctrls = ''; $err = ''
+    try {
+      $null = $script:hwp.Open($path, "", "forceopen:true")
+      $pages = [int]$script:hwp.PageCount
+
+      # Body text as Hangul sees it. CP949-external chars arrive as &#N; escapes -- symmetric
+      # between orig and variant under the same Hangul version, so comparisons stay fair.
+      $text = [string]$script:hwp.GetTextFile("TEXT", "")
+      if ($null -eq $text) { $text = '' }
+      $textLen = $text.Length
+      $bytes = [System.Text.Encoding]::UTF8.GetBytes($text)
+      $textSha = ([System.BitConverter]::ToString($sha256.ComputeHash($bytes)) -replace '-', '').ToLowerInvariant()
+      [System.IO.File]::WriteAllBytes((Join-Path $TextDir "$key.txt"), $bytes)
+
+      # Control census: walk the HeadCtrl chain and count CtrlIDs (tbl, gso, ...). Whatever the
+      # chain covers, it covers identically for orig and variant -- the comparison is fair.
+      $counts = @{}
+      try {
+        $c = $script:hwp.HeadCtrl
+        $guard = 0
+        while ($null -ne $c -and $guard -lt 500000) {
+          $id = [string]$c.CtrlID
+          if ($counts.ContainsKey($id)) { $counts[$id]++ } else { $counts[$id] = 1 }
+          $c = $c.Next
+          $guard++
+        }
+        $ctrls = (($counts.GetEnumerator() | Sort-Object Name | ForEach-Object { "$($_.Name):$($_.Value)" }) -join ',')
+      } catch {
+        $ctrls = ''
+        $msg = $_.Exception.Message -replace "[`t`r`n]", ' '
+        $err = "ctrl-walk: $msg"
+      }
+
+      try { $null = $script:hwp.Clear(1) } catch { }
+      break
+    } catch {
+      $status = 'ERR'
+      $err = ($_.Exception.Message -replace "[`t`r`n]", ' ')
+      $replaced = $false
+      try { $null = $script:hwp.Clear(1) } catch {
+        Close-HwpInstance
+        try { New-HwpInstance; $replaced = $true } catch { }
+      }
+      # Only retry when the instance itself died and was replaced. A failure the live instance
+      # shrugged off is document-specific and would just repeat.
+      if (-not $replaced) { break }
+    }
+  }
+  $writer.WriteLine("$key`t$status`t$pages`t$textLen`t$textSha`t$ctrls`t$fileBytes`t$err")
+
+  $n++
+  if ($RecycleEvery -gt 0 -and ($n % $RecycleEvery) -eq 0) {
+    Close-HwpInstance
+    Start-Sleep -Milliseconds 300
+    New-HwpInstance
+    Write-Heartbeat "recycled after $n"
+  }
+}
+
+$writer.Dispose()
+Close-HwpInstance
+Write-Heartbeat "finished"
+exit 0

--- a/tools/loadsave_sweep/rhwp_phase.py
+++ b/tools/loadsave_sweep/rhwp_phase.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Phase A — rhwp 변환 매트릭스 실행기 (COM 불필요, 병렬 가능).
+
+master.tsv 의 각 문서에 대해 rhwp 저장 경로 두 갈래를 실행한다:
+
+    hwp  입력:  convert → <docid>.h2h.hwp     export-hwpx → <docid>.h2x.hwpx
+    hwpx 입력:  convert → <docid>.x2h.hwp     export-hwpx → <docid>.x2x.hwpx
+
+경로 매트릭스가 곧 진단이다 — 한 입력의 두 산출이 모두 나쁘면 불러오기(parse) 쪽,
+한쪽만 나쁘면 그 저장 축 쪽이다.
+
+`--verify`/`--verify-pages` 를 함께 걸어 rhwp 의 자기검증 판정(exit 3/4)도 데이터로
+수확한다. exit 3/4 는 산출물을 남기므로 Phase B 측정 대상에 포함된다.
+
+산출:
+    <out>/conv/<docid>.<route>.hwp|hwpx   변환 산출물
+    <out>/phase_a.ndjson                  저널 (재실행 시 완료 건 재개-생략)
+    <out>/oracle_tasks.tsv                Phase B 작업 목록 (key \t abspath, 문서별 orig→routes 순)
+
+사용:
+    python rhwp_phase.py --master master.tsv --out D:\\sweep\\s1 --rhwp <rhwp.exe> [--jobs 6]
+"""
+from __future__ import annotations
+
+import argparse
+import concurrent.futures as cf
+import hashlib
+import json
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+EXIT_STATUS = {0: "OK", 3: "VERIFY_DIFF", 4: "PAGE_DIFF"}
+
+
+def read_master(path: Path) -> list[dict]:
+    rows = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        docid, fmt, src = line.split("\t", 2)
+        rows.append({"docid": docid, "format": fmt, "src": src})
+    return rows
+
+
+def routes_for(fmt: str) -> list[tuple[str, str, str]]:
+    # (route, subcommand, 출력 확장자)
+    if fmt == "hwp":
+        return [("h2h", "convert", ".hwp"), ("h2x", "export-hwpx", ".hwpx")]
+    return [("x2h", "convert", ".hwp"), ("x2x", "export-hwpx", ".hwpx")]
+
+
+def run_one(rhwp: str, doc: dict, route: str, sub: str, ext: str,
+            conv_dir: Path, timeout: int, verify: bool) -> dict:
+    out_path = conv_dir / f"{doc['docid']}.{route}{ext}"
+    cmd = [rhwp, sub, doc["src"], str(out_path)]
+    if verify:
+        cmd += ["--verify", "--verify-pages"]
+    t0 = time.monotonic()
+    rec = {"docid": doc["docid"], "format": doc["format"], "route": route,
+           "src": doc["src"], "output": str(out_path)}
+    try:
+        p = subprocess.run(cmd, capture_output=True, timeout=timeout)
+        rec["exit"] = p.returncode
+        rec["status"] = EXIT_STATUS.get(p.returncode, "FAIL")
+        tail = p.stderr.decode("utf-8", "replace").strip().splitlines()[-3:]
+        if rec["status"] != "OK" and tail:
+            rec["stderr"] = " | ".join(tail)[:500]
+    except subprocess.TimeoutExpired:
+        rec["exit"] = -1
+        rec["status"] = "TIMEOUT"
+    except OSError as e:
+        rec["exit"] = -1
+        rec["status"] = "SPAWN_FAIL"
+        rec["stderr"] = str(e)
+    rec["ms"] = int((time.monotonic() - t0) * 1000)
+    rec["bytes"] = out_path.stat().st_size if out_path.is_file() else 0
+    # exit 3/4 라도 산출물이 있으면 Phase B 가 측정한다. 산출물 없는 "성공"은 없다.
+    if rec["status"] in ("OK", "VERIFY_DIFF", "PAGE_DIFF") and rec["bytes"] == 0:
+        rec["status"] = "FAIL"
+        rec.setdefault("stderr", "exit ok but output missing/empty")
+    return rec
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--master", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--rhwp", required=True)
+    ap.add_argument("--jobs", type=int, default=6)
+    ap.add_argument("--timeout", type=int, default=180, help="한 변환 호출의 초 상한")
+    ap.add_argument("--no-verify", action="store_true",
+                    help="--verify/--verify-pages 자기검증 생략 (속도 우선)")
+    args = ap.parse_args()
+
+    out_dir = Path(args.out)
+    conv_dir = out_dir / "conv"
+    conv_dir.mkdir(parents=True, exist_ok=True)
+    journal_path = out_dir / "phase_a.ndjson"
+
+    rhwp = str(Path(args.rhwp).resolve())
+    exe_sha = hashlib.sha256(Path(rhwp).read_bytes()).hexdigest()
+
+    docs = read_master(Path(args.master))
+
+    # 재개: 저널에 이미 있고 산출물 상태가 저널과 일치하는 (docid, route) 는 건너뛴다.
+    done: dict[tuple[str, str], dict] = {}
+    if journal_path.is_file():
+        for line in journal_path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            r = json.loads(line)
+            if r.get("kind") == "meta":
+                if r.get("exeSha") != exe_sha:
+                    print(f"[phase-a] 경고: 저널의 exe({r.get('exeSha','?')[:12]})와 현재 "
+                          f"exe({exe_sha[:12]})가 다르다 — 섞인 저널은 판정 출처를 오염시킨다. "
+                          f"새 --out 디렉터리를 쓰거나 저널을 지우고 전체 재실행할 것.",
+                          file=sys.stderr)
+                    return 2
+                continue
+            done[(r["docid"], r["route"])] = r
+
+    lock = threading.Lock()
+    journal = journal_path.open("a", encoding="utf-8", newline="\n")
+    if not done:
+        journal.write(json.dumps({"kind": "meta", "exe": rhwp, "exeSha": exe_sha,
+                                  "master": str(args.master)}, ensure_ascii=False) + "\n")
+        journal.flush()
+
+    tasks = []
+    for doc in docs:
+        for route, sub, ext in routes_for(doc["format"]):
+            key = (doc["docid"], route)
+            prev = done.get(key)
+            if prev and (prev["status"] not in ("OK", "VERIFY_DIFF", "PAGE_DIFF")
+                         or Path(prev["output"]).is_file()):
+                continue
+            tasks.append((doc, route, sub, ext))
+
+    total = len(tasks)
+    print(f"[phase-a] {len(docs)} docs, {total} conversions to run "
+          f"({len(done)} already journaled), jobs={args.jobs}")
+
+    n_done = 0
+    t0 = time.monotonic()
+
+    def work(t):
+        doc, route, sub, ext = t
+        return run_one(rhwp, doc, route, sub, ext, conv_dir, args.timeout, not args.no_verify)
+
+    with cf.ThreadPoolExecutor(max_workers=args.jobs) as ex:
+        for rec in ex.map(work, tasks):
+            with lock:
+                journal.write(json.dumps(rec, ensure_ascii=False) + "\n")
+                journal.flush()
+                done[(rec["docid"], rec["route"])] = rec
+                n_done += 1
+                if n_done % 200 == 0:
+                    rate = n_done / max(time.monotonic() - t0, 1e-9) * 60
+                    print(f"[phase-a] {n_done}/{total} ({rate:.0f}/min)")
+    journal.close()
+
+    # Phase B 작업 목록 — 문서별로 orig 다음에 그 문서의 산출물이 오도록 묶는다.
+    # (COM 워커의 시간 지역성 + 웨이브 단위 삭제·재개를 쉽게 한다)
+    n_meas, n_conv_fail = 0, 0
+    tasks_path = out_dir / "oracle_tasks.tsv"
+    with tasks_path.open("w", encoding="utf-8", newline="\n") as f:
+        for doc in docs:
+            f.write(f"{doc['docid']}.orig\t{doc['src']}\n")
+            n_meas += 1
+            for route, _sub, _ext in routes_for(doc["format"]):
+                rec = done.get((doc["docid"], route))
+                if rec and rec["status"] in ("OK", "VERIFY_DIFF", "PAGE_DIFF"):
+                    f.write(f"{doc['docid']}.{route}\t{rec['output']}\n")
+                    n_meas += 1
+                else:
+                    n_conv_fail += 1
+    print(f"[phase-a] done. oracle tasks: {n_meas} opens, convert failures: {n_conv_fail}")
+    print(f"[phase-a] journal: {journal_path}")
+    print(f"[phase-a] tasks:   {tasks_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 변경 요약

rhwp 의 HWP/HWPX **불러오기·저장하기 누락/오류를 설치된 한글을 오라클로 전수검사**하는
하네스 `tools/loadsave_sweep/` 를 등재한다 (#4678 DoD 항목). 판정자는 문서가 아니라
설치된 한글이다 — 같은 한글 버전이 원본과 rhwp 산출물에서 각각 추출한 본문 텍스트·
컨트롤 집계·페이지 수를 대조하므로 비교가 공평하다.

- 경로 매트릭스(h2h/h2x/x2h/x2x)가 곧 진단: 한 입력의 두 산출이 모두 나쁘면 불러오기
  축, 한쪽만 나쁘면 그 저장 축
- Phase A(`rhwp_phase.py`): rhwp 변환 매트릭스 — COM 불필요·병렬·NDJSON 저널 재개,
  `--verify`/`--verify-pages` 자기검증(exit 3/4)을 데이터로 수확, exe sha 출처 고정
- Phase B(`oracle_run.ps1`+`oracle_worker.ps1`): `tools/hangul_version_oracle/` 의
  검증된 supervisor/worker 규약 이식 — HKCU CLSID 오버라이드+실버전 사전 검증,
  heartbeat/stall-kill, warmup(강제종료 후 첫 Open 블록 흡수), 2회 재시도, key 재개
- 판정(`judge.py`): CONVERT_FAIL > OPEN_FAIL > MEASURE_FAIL > TEXT_MISMATCH >
  CTRL_DIFF > PAGE_DIFF, 원본 유령성공(빈 문서 열기 성공) 의심 표시
- 원인 분류(`classify_mismatch.py`) · 2단계 대상 생성(`make_stage2.py`) · 절차/함정 README

## 관련 이슈

refs #4678 (총괄 — 이슈는 2단계 확대까지 유지, 본 PR 은 "하네스 PR 등재" DoD 항목),
결함 산출: #4675 · #4676 · #4677

## 테스트

- [ ] `cargo test` 통과 — 해당 없음 (Rust 무변경, tools/ Python·PowerShell 만 추가)
- [ ] `cargo clippy -- -D warnings` 통과 — 해당 없음 (동일)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음 (렌더링 무변경)
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [x] Python 3.12 `py_compile` 3종 + PowerShell `Parser::ParseFile` 2종 구문 검증 통과
- [x] **전 구성요소 실측 완주 검증**: 파일럿 40건 → 1단계 전수 10,000건
  (Phase A 20,000 변환 ≈ 5분 / Phase B 한글 2022 COM 29,896 opens ≈ 177분 /
  판정 20,000건) — 결과 수치와 데이터 위치는 #4678 본문
- [x] 재개 규약 실측: Phase A 저널 재개(중단 후 재실행), Phase B supervisor 의
  worker 재시작·stall-kill 경로가 전수 실행 중 실제 동작

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 없음 (제품 코드 무변경, 독립 실행 도구)
- 재현·측정: #4678 의 실측 규모 참조 (10k 코퍼스, 분당 160~440 opens)

## 스크린샷

해당 없음 (CLI/COM 도구).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
