### PR TITLE
fix(serializer/hwpx): 고정폭 빈칸을 fwSpace 요소로 직렬화 — 한글 텍스트 추출 불일치 1,970건 해소 (#4675)

### DIFF
--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -14,7 +14,6 @@
 //!   - `paragraph.text` 내 `\n` = 소프트 라인브레이크 (`<hp:lineBreak/>`, 같은 문단 내)
 //!   - `paragraph.text` 내 `\t` = 탭 (`<hp:tab width=... leader="0" type="1"/>`)
 //!   - `paragraph.text` 내 `U+2007` = 고정폭 빈칸 (`<hp:fwSpace/>`, #4675)
-//!   - `paragraph.text` 내 `U+00A0` = 묶음 빈칸 (`<hp:nbSpace/>`)
 //!   - `paragraph.para_shape_id` → `<hp:p paraPrIDRef>`
 //!   - `paragraph.style_id` → `<hp:p styleIDRef>`
 //!   - `paragraph.column_type` → `<hp:p pageBreak/columnBreak>`
@@ -691,17 +690,18 @@ pub(crate) fn render_hp_t_content(
                 flush_buf(&mut t_xml, &mut buf);
                 t_xml.push_str("<hp:lineBreak/>");
             }
-            // 고정폭/묶음 빈칸은 요소로 복원한다(#4675). 파서가 <hp:fwSpace/>→U+2007,
-            // <hp:nbSpace/>→U+00A0 으로 읽으므로 리터럴 방출은 표현 강등이다 — 한글은
+            // 고정폭 빈칸은 `<hp:fwSpace/>` 요소로 복원한다(#4675). 파서가
+            // `<hp:fwSpace/>`→U+2007 로 읽으므로 리터럴 방출은 표현 강등이다 — 한글은
             // 요소를 텍스트 추출에 싣지 않지만 리터럴은 문자로 실어, 저장본의 추출
             // 텍스트·재조판이 원본과 달라진다(10k 스윕 figure-space-only 1,970건).
+            //
+            // 한컴 원본 실측(hwpx 300건): U+2007 은 fwSpace 요소 530회 · 리터럴 0회로
+            // **항상 요소**다. 반면 U+00A0 은 nbSpace 요소 15회 · 리터럴 9회로 섞여 있어
+            // 요소로 강제하면 리터럴이던 원본에서 한글 추출 텍스트가 사라진다(실측 23건).
+            // IR 이 두 표기를 구분하지 못하는 한 U+00A0 은 기존대로 리터럴로 둔다.
             '\u{2007}' => {
                 flush_buf(&mut t_xml, &mut buf);
                 t_xml.push_str("<hp:fwSpace/>");
-            }
-            '\u{00A0}' => {
-                flush_buf(&mut t_xml, &mut buf);
-                t_xml.push_str("<hp:nbSpace/>");
             }
             c if (c as u32) < 0x20 => { /* 기타 제어문자 무시 */ }
             c => buf.push(c),
@@ -3363,13 +3363,17 @@ mod tests {
         );
     }
 
-    /// #4675: 고정폭 빈칸(U+2007)·묶음 빈칸(U+00A0)은 리터럴 문자가 아니라
-    /// `<hp:fwSpace/>`/`<hp:nbSpace/>` 요소로 직렬화돼야 한다. 리터럴 방출은 한글의
-    /// 텍스트 추출·재조판 결과를 원본과 다르게 만든다(10k 스윕 1,970건의 지배 원인).
-    /// 왕복(직렬화→재파싱) 후 IR 텍스트는 동일해야 한다 — 파서가 두 요소를 같은
-    /// 코드포인트로 되돌린다.
+    /// #4675: 고정폭 빈칸(U+2007)은 리터럴 문자가 아니라 `<hp:fwSpace/>` 요소로
+    /// 직렬화돼야 한다. 리터럴 방출은 한글의 텍스트 추출·재조판 결과를 원본과 다르게
+    /// 만든다(10k 스윕 TEXT_MISMATCH 의 76%). 왕복(직렬화→재파싱) 후 IR 텍스트는
+    /// 동일해야 한다 — 파서가 요소를 같은 코드포인트로 되돌린다.
+    ///
+    /// 묶음 빈칸(U+00A0)은 **리터럴로 남긴다**. 한컴 원본은 U+2007 을 항상 요소로
+    /// 쓰지만(실측 hwpx 300건: 요소 530 · 리터럴 0), U+00A0 은 요소 15 · 리터럴 9 로
+    /// 섞여 쓴다 — IR 이 두 표기를 구분하지 못하는데 요소로 강제하면 리터럴이던 원본의
+    /// 추출 텍스트에서 NBSP 가 사라진다(한글 2022 오라클 실측 23건).
     #[test]
-    fn issue4675_fixed_width_and_nb_space_serialize_as_elements() {
+    fn issue4675_fixed_width_space_serializes_as_element() {
         use crate::parser::hwpx::section::parse_hwpx_section;
 
         let mut para = Paragraph::default();
@@ -3384,10 +3388,13 @@ mod tests {
             "U+2007 은 전부 fwSpace 요소로 방출돼야 함: {}",
             &xml[..800.min(xml.len())]
         );
-        assert_eq!(xml.matches("<hp:nbSpace/>").count(), 1);
         assert!(
-            !xml.contains('\u{2007}') && !xml.contains('\u{00A0}'),
-            "리터럴 U+2007/U+00A0 이 XML 에 남으면 안 됨"
+            !xml.contains('\u{2007}'),
+            "리터럴 U+2007 이 XML 에 남으면 안 됨"
+        );
+        assert!(
+            xml.contains('\u{00A0}') && !xml.contains("<hp:nbSpace/>"),
+            "U+00A0 은 리터럴 유지 — 요소로 바꾸면 한글 추출에서 사라진다"
         );
 
         let reparsed = parse_hwpx_section(&xml).unwrap();

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -13,6 +13,8 @@
 //!   - `section.paragraphs` 여러 개 = 하드 문단 경계 (`<hp:p>` 여러 개)
 //!   - `paragraph.text` 내 `\n` = 소프트 라인브레이크 (`<hp:lineBreak/>`, 같은 문단 내)
 //!   - `paragraph.text` 내 `\t` = 탭 (`<hp:tab width=... leader="0" type="1"/>`)
+//!   - `paragraph.text` 내 `U+2007` = 고정폭 빈칸 (`<hp:fwSpace/>`, #4675)
+//!   - `paragraph.text` 내 `U+00A0` = 묶음 빈칸 (`<hp:nbSpace/>`)
 //!   - `paragraph.para_shape_id` → `<hp:p paraPrIDRef>`
 //!   - `paragraph.style_id` → `<hp:p styleIDRef>`
 //!   - `paragraph.column_type` → `<hp:p pageBreak/columnBreak>`
@@ -688,6 +690,18 @@ pub(crate) fn render_hp_t_content(
             '\n' => {
                 flush_buf(&mut t_xml, &mut buf);
                 t_xml.push_str("<hp:lineBreak/>");
+            }
+            // 고정폭/묶음 빈칸은 요소로 복원한다(#4675). 파서가 <hp:fwSpace/>→U+2007,
+            // <hp:nbSpace/>→U+00A0 으로 읽으므로 리터럴 방출은 표현 강등이다 — 한글은
+            // 요소를 텍스트 추출에 싣지 않지만 리터럴은 문자로 실어, 저장본의 추출
+            // 텍스트·재조판이 원본과 달라진다(10k 스윕 figure-space-only 1,970건).
+            '\u{2007}' => {
+                flush_buf(&mut t_xml, &mut buf);
+                t_xml.push_str("<hp:fwSpace/>");
+            }
+            '\u{00A0}' => {
+                flush_buf(&mut t_xml, &mut buf);
+                t_xml.push_str("<hp:nbSpace/>");
             }
             c if (c as u32) < 0x20 => { /* 기타 제어문자 무시 */ }
             c => buf.push(c),
@@ -3346,6 +3360,40 @@ mod tests {
             reparsed_para.tab_extended.is_empty(),
             "width=0 마커 재파싱 후 tab_extended 는 비어 있어야 함(원본과 동일): {:?}",
             reparsed_para.tab_extended
+        );
+    }
+
+    /// #4675: 고정폭 빈칸(U+2007)·묶음 빈칸(U+00A0)은 리터럴 문자가 아니라
+    /// `<hp:fwSpace/>`/`<hp:nbSpace/>` 요소로 직렬화돼야 한다. 리터럴 방출은 한글의
+    /// 텍스트 추출·재조판 결과를 원본과 다르게 만든다(10k 스윕 1,970건의 지배 원인).
+    /// 왕복(직렬화→재파싱) 후 IR 텍스트는 동일해야 한다 — 파서가 두 요소를 같은
+    /// 코드포인트로 되돌린다.
+    #[test]
+    fn issue4675_fixed_width_and_nb_space_serialize_as_elements() {
+        use crate::parser::hwpx::section::parse_hwpx_section;
+
+        let mut para = Paragraph::default();
+        para.text = "보\u{2007}도\u{2007}자\u{2007}료\u{00A0}끝".to_string();
+        let (doc, section) = make_doc_with_paragraph(para);
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+
+        assert_eq!(
+            xml.matches("<hp:fwSpace/>").count(),
+            3,
+            "U+2007 은 전부 fwSpace 요소로 방출돼야 함: {}",
+            &xml[..800.min(xml.len())]
+        );
+        assert_eq!(xml.matches("<hp:nbSpace/>").count(), 1);
+        assert!(
+            !xml.contains('\u{2007}') && !xml.contains('\u{00A0}'),
+            "리터럴 U+2007/U+00A0 이 XML 에 남으면 안 됨"
+        );
+
+        let reparsed = parse_hwpx_section(&xml).unwrap();
+        assert_eq!(
+            reparsed.paragraphs[0].text, "보\u{2007}도\u{2007}자\u{2007}료\u{00A0}끝",
+            "요소 왕복 후 IR 텍스트 불변"
         );
     }
 


### PR DESCRIPTION
## 변경 요약

hwpx writer 가 고정폭 빈칸을 리터럴 문자로 내보내던 것을 `<hp:fwSpace/>` 요소로 복원한다.

파서는 OWPML `<hp:fwSpace/>` 를 IR 에서 U+2007 로 표현하는데, writer 가 이를 요소로
되돌리지 않고 리터럴 문자로 직렬화했다. **한글은 요소를 텍스트 추출에 싣지 않지만
리터럴은 문자로 싣기 때문에**, 저장본의 추출 텍스트·재조판·검색 결과가 원본과 달라진다.

한글 2022 오라클 10k 전수(#4678)에서 이 강등 하나가 TEXT_MISMATCH 2,586건 중
**1,970건(76%)** 을 차지해 hwpx 저장 축 결함의 지배 원인이었다.

### 묶음 빈칸(U+00A0)은 왜 그대로 두는가

두 번째 커밋에서 되돌린 부분이다. 처음에는 대칭이라 보고 U+00A0 도 `<hp:nbSpace/>` 로
바꿨으나, 오라클 재측정에서 **23건이 NBSP 를 잃었다**(23/23 전부 이 원인). 한컴 원본의
표기 관례가 두 문자에서 다르기 때문이다 — hwpx 원본 300건 실측:

| 문자 | 요소 표기 | 리터럴 표기 |
|---|---|---|
| U+2007 | 530회 | **0회** |
| U+00A0 | 15회 | 9회 |

IR 은 요소와 리터럴을 같은 코드포인트로 읽어 구분하지 못한다. U+2007 은 원본이 100%
요소이므로 요소가 무손실이지만, U+00A0 은 요소로 강제하면 리터럴이던 원본에서 추출
텍스트가 사라진다. 구분을 IR 에 싣는 것은 별도 과제로 남긴다(이슈에 기록).

## 관련 이슈

closes #4675

## 테스트

- [x] `cargo test` 통과 — `cargo test --lib hwpx` 638 passed / 0 failed,
      통합 `hwpx_roundtrip_baseline`·`hwpx_roundtrip_integration`·`issue_1868_export_hwpx_cli`·
      `hwpx_form_roundtrip` 31 passed / 0 failed
- [x] `cargo clippy --lib -- -D warnings` 통과, 변경 파일 `rustfmt --check` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음 (렌더링 무변경, 직렬화 표기만 변경)
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [x] 회귀 테스트 추가: `issue4675_fixed_width_space_serializes_as_element`
      (요소 방출 + 리터럴 U+2007 부재 + U+00A0 리터럴 유지 + 재파싱 IR 불변)
- [x] **한글 2022 오라클 실측 검증** (아래)

### 오라클 검증 — 동일 2,496문서, 수정 전후 재측정

Phase A 4,992 변환 → Phase B 한글 2022 COM 7,488 opens(42분) → 판정.

| 수정 전 | → 수정 후 | 건수 |
|---|---|---|
| figure-space-only | **OK** | **1,548** |
| figure-space-only | PAGE_DIFF (텍스트 해결, 쪽수 잔존) | 360 |
| figure-space-only | whitespace-only | 43 |
| figure-space-only | CTRL_DIFF | 19 |
| **figure-space-only 합계** | | **1,970 → 0** |

- **새로 나빠진 판정 0건**
- 실물 대조: 원본 `<hp:fwSpace/>` 개수 = 산출 개수, 리터럴 U+2007 = 0
  (02133: 3→3, 00980: 2→2, 08969: 6→6, 00000(hwp 원본): 1)
- NBSP 되돌림 확인: 회귀 3건에서 산출 리터럴 NBSP 개수가 한글 추출 원본 개수와 일치
  (02741: 78, 06870: 80, 08106: 57)

판정 원장: `D:\loadsave_sweep\v4675\oracle_2022\verdicts\`.

### 자기검증(`--verify`)으로는 잡히지 않는 결함이다

수정 전후 h2x VERIFY_DIFF 는 **742건 그대로**다. 파서가 요소와 리터럴을 같은
코드포인트로 읽으므로 재파싱 IR 대조로는 원리적으로 보이지 않는다 — 오라클 대조가
있어야만 드러나는 결함이라 회귀 테스트로 방출 문자열 자체를 고정했다
(#3544 가 `hp:offset` 에서 쓴 것과 같은 규약).

## 성능 영향 및 측정 결과

- 예상 영향: 없음 (문자 하나를 요소 문자열로 치환, 기존 탭/lineBreak 분기와 동일 경로)
- 재현·측정: 미측정 (직렬화 문자열 길이 외 변화 없음)

## 스크린샷

해당 없음 (텍스트 추출 계약 변경, 렌더 무변경).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
