### PR TITLE
fix(converters): 구역 정의 제어문자를 첫 문단 맨 앞에 — HWP3 저장본 한글 개방 실패 8건 해소 (#4680)

### DIFF
--- a/mydocs/orders/20260812.md
+++ b/mydocs/orders/20260812.md
@@ -109,3 +109,16 @@
   누적 이행 기록은 `mydocs/pr/archives/`에 보존한다.
 - 원격 통합 PR 생성·CI·merge와 원 PR comment/close는 작업지시자 승인 뒤에만 수행한다. `core-cli`의
   legacy 기준자료 공백은 전체 historic score 재현을 주장하지 않는 후속 정비 항목으로 남긴다.
+
+## Issue #4680 - HWP3 선행 구역 정의 제어문자 좌표 보정
+
+- [PR #4687](https://github.com/edwardkim/rhwp/pull/4687)에서 HWP3 저장 시 첫 문단에 삽입하는
+  `SectionDef`/`ColumnDef`의 슬롯 예약이 `char_offsets`만 이동하던 결함을 확인했다.
+- 메인터너 보정 `1cd726ba3`으로 `char_shapes`, `range_tags`, `line_segs.text_start`까지 공통
+  UTF-16 위치 이동 규약으로 묶고 HWPX-to-HWP 변환과 body-text fallback에 함께 적용했다.
+- focused 회귀 6건, release-test nextest 5,785건, fmt, Clippy, diff check를 완료했고 같은 code head의
+  Full CI, CodeQL, Render Diff도 성공했다. 세부 근거는
+  [PR #4687 검토 기록](../pr/archives/pr_4687_review.md)에 보존한다.
+- 이 문서 묶음의 review-only fast-pass와 최신 mergeability를 확인한 뒤 작업지시자 승인에 따라 merge한다.
+  HWP3→HWPX 개방 실패, 0쪽 결과, 본문 보존 문제는 [#4680](https://github.com/edwardkim/rhwp/issues/4680)에
+  계속 남기며 이 PR로 닫지 않는다.

--- a/mydocs/orders/20260812.md
+++ b/mydocs/orders/20260812.md
@@ -54,6 +54,20 @@
   5분 34초, 7분 21초, 5분 41초에 각각 완료됐고, Native Skia·worker 4개·최종 `Build & Test`도 통과했다.
 - [검토 기록](../pr/archives/pr_4581_review.md)을 운영 기록으로 보존한다.
 - 최신 devel을 main에 반영한 뒤 `release/60`으로 cold-cache release-grade 경로를 재검증한다.
+
+## Issue #4680 - HWP3 선행 구역 정의 제어문자 좌표 보정
+
+- [PR #4687](https://github.com/edwardkim/rhwp/pull/4687)에서 HWP3 저장 시 첫 문단에 삽입하는
+  `SectionDef`/`ColumnDef`의 슬롯 예약이 `char_offsets`만 이동하던 결함을 확인했다.
+- 메인터너 보정 `1cd726ba3`으로 `char_shapes`, `range_tags`, `line_segs.text_start`까지 공통
+  UTF-16 위치 이동 규약으로 묶고 HWPX-to-HWP 변환과 body-text fallback에 함께 적용했다.
+- focused 회귀 6건, release-test nextest 5,785건, fmt, Clippy, diff check를 완료했고 같은 code head의
+  Full CI, CodeQL, Render Diff도 성공했다. 세부 근거는
+  [PR #4687 검토 기록](../pr/archives/pr_4687_review.md)에 보존한다.
+- 이 문서 묶음의 review-only fast-pass와 최신 mergeability를 확인한 뒤 작업지시자 승인에 따라 merge한다.
+  HWP3→HWPX 개방 실패, 0쪽 결과, 본문 보존 문제는 [#4680](https://github.com/edwardkim/rhwp/issues/4680)에
+  계속 남기며 이 PR로 닫지 않는다.
+
 ## planet6897 표·사다리·TAC 통합 검토
 
 - 원 PR [#4569](https://github.com/edwardkim/rhwp/pull/4569),
@@ -109,16 +123,3 @@
   누적 이행 기록은 `mydocs/pr/archives/`에 보존한다.
 - 원격 통합 PR 생성·CI·merge와 원 PR comment/close는 작업지시자 승인 뒤에만 수행한다. `core-cli`의
   legacy 기준자료 공백은 전체 historic score 재현을 주장하지 않는 후속 정비 항목으로 남긴다.
-
-## Issue #4680 - HWP3 선행 구역 정의 제어문자 좌표 보정
-
-- [PR #4687](https://github.com/edwardkim/rhwp/pull/4687)에서 HWP3 저장 시 첫 문단에 삽입하는
-  `SectionDef`/`ColumnDef`의 슬롯 예약이 `char_offsets`만 이동하던 결함을 확인했다.
-- 메인터너 보정 `1cd726ba3`으로 `char_shapes`, `range_tags`, `line_segs.text_start`까지 공통
-  UTF-16 위치 이동 규약으로 묶고 HWPX-to-HWP 변환과 body-text fallback에 함께 적용했다.
-- focused 회귀 6건, release-test nextest 5,785건, fmt, Clippy, diff check를 완료했고 같은 code head의
-  Full CI, CodeQL, Render Diff도 성공했다. 세부 근거는
-  [PR #4687 검토 기록](../pr/archives/pr_4687_review.md)에 보존한다.
-- 이 문서 묶음의 review-only fast-pass와 최신 mergeability를 확인한 뒤 작업지시자 승인에 따라 merge한다.
-  HWP3→HWPX 개방 실패, 0쪽 결과, 본문 보존 문제는 [#4680](https://github.com/edwardkim/rhwp/issues/4680)에
-  계속 남기며 이 PR로 닫지 않는다.

--- a/mydocs/pr/archives/pr_4687_review.md
+++ b/mydocs/pr/archives/pr_4687_review.md
@@ -1,0 +1,93 @@
+---
+kind: review
+status: accepted
+pr: 4687
+issue: 4680
+author: planet6897
+base: devel
+---
+
+# PR #4687 검토 기록
+
+## 접수 정보
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4687](https://github.com/edwardkim/rhwp/pull/4687) |
+| 작성자 | `planet6897` (Jaeuk Ryu) |
+| 기준 브랜치 | `devel` |
+| 검토 경로 | collaborator 매개 외부 PR, source head 직접 보정 |
+| 관련 이슈 | [#4680](https://github.com/edwardkim/rhwp/issues/4680) |
+| 원 기여자 code head | `0eb105d99f6a0488b83b2b6e73a41799b4f275d1` |
+| 메인터너 보정 head | `1cd726ba3134a0db3a33c5c10c1ad789f75a9cd2` |
+| 문서 작성 시점 mergeable | `CLEAN` 참고값. merge 직전에 다시 확인 필요 |
+
+### 적용 절차
+
+```text
+base route: collaborator_external_pr.md
+modifiers: intake_and_review.md, local_validation.md, review_only_fast_pass.md, post_merge.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+collaborator_external_pr.md, intake_and_review.md, local_validation.md,
+review_only_fast_pass.md, post_merge.md
+current code candidate: 1cd726ba3134a0db3a33c5c10c1ad789f75a9cd2
+```
+
+`maintainerCanModify=true`을 확인하고, 사용자가 열어 둔 주 작업공간의
+`review/planet6897-4687-20260813` 브랜치에서 contributor source history 위에만 보정을
+추가했다. contributor commit은 rebase, amend, force-push 하지 않았다.
+
+## 변경 검토
+
+원 기여자 변경은 HWP3에서 첫 문단의 `SectionDef`/`ColumnDef` 제어문자가 본문 뒤로 밀리지 않도록
+제어문자 슬롯을 예약한다. 다만 초기 변경은 `char_offsets`만 이동했다. 같은 UTF-16 문단 좌표계인
+`char_shapes`, `range_tags`, `line_segs.text_start`를 그대로 두면 제어문자 뒤의 스타일, 태그, 줄 시작
+좌표가 본문보다 앞선 위치를 가리킨다. 이는 HWP 직렬화 계약을 깨는 P1 결함이었다.
+
+메인터너 보정 `1cd726ba3`은 `Paragraph`에 공통 선행 확장 제어문자 슬롯 예약 API를 추가하고, 기존
+inline 삽입과 동일하게 모든 위치 메타데이터를 이동시켰다. HWPX-to-HWP 변환과 body-text 직렬화
+fallback 모두 이 공통 API를 사용하도록 정리했다. 제어문자를 이미 위한 빈 슬롯이 있는 IR은 재이동하지
+않는다.
+
+변경 범위는 다음 세 파일이다.
+
+- `src/document_core/converters/hwpx_to_hwp.rs`
+- `src/model/paragraph.rs`
+- `src/serializer/body_text.rs`
+
+renderer/layout, fixture, baseline, CI workflow 변경은 없다. 따라서 별도 시각 sweep은 판단 근거로
+선택하지 않았다. 한글 2022 실제 개방 결과는 contributor가 [#4680 진행 코멘트](https://github.com/edwardkim/rhwp/issues/4680)에
+남긴 외부 오라클 증적으로만 참조했고, 이 검토에서 독립적인 Windows COM 재실행 결과라고 주장하지 않는다.
+
+## 검증 결과
+
+다음 검증은 메인터너 보정 후 `target/pr-review`에서 순차로 완료했다.
+
+| 검증 | 결과 |
+| --- | --- |
+| `cargo test --profile release-test --target-dir target/pr-review --lib issue4680 -- --nocapture` | 3 passed |
+| `cargo test --profile release-test --target-dir target/pr-review --lib shift_for_inline_control_insert -- --nocapture` | 2 passed |
+| `cargo test --profile release-test --target-dir target/pr-review --lib test_roundtrip_with_section_def_control -- --nocapture` | 1 passed |
+| `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast` | 5,785 passed, 36 skipped, 7 slow, exit 0 |
+| `cargo fmt --check` | passed |
+| `cargo clippy --all-targets -- -D warnings` | passed |
+| `git diff --check` | passed |
+| 최신 `upstream/devel` merge tree | 충돌 없음 |
+
+동일 code head의 GitHub Actions도 모두 성공했다.
+
+- [Build & Test](https://github.com/edwardkim/rhwp/actions/runs/31622416215): 성공
+- [CodeQL](https://github.com/edwardkim/rhwp/actions/runs/31622415987): Rust, Python, JavaScript/TypeScript 성공
+- [Render Diff](https://github.com/edwardkim/rhwp/actions/runs/31622416016): Canvas visual diff 성공
+
+## 남은 위험과 후속 과제
+
+이번 PR은 HWP3→HWP 저장 시 선행 구역 정의 제어문자 좌표 계약만 해결한다. HWP3→HWPX 개방 실패,
+`03908.h2h`의 0쪽 결과, 본문 보존 불일치는 [#4680](https://github.com/edwardkim/rhwp/issues/4680)에
+계속 남긴다. 이 PR의 merge로 해당 이슈를 닫지 않는다.
+
+## 최종 권고
+
+**수용 및 merge 권고.** 메인터너 보정이 원 변경의 좌표 계약 누락을 해소했고 focused·전체 로컬 회귀와
+동일 code head의 Full CI, CodeQL, Render Diff가 성공했다. 이 문서와 오늘할일만 추가한 trailing
+docs-only head의 preflight/aggregate, 최신 mergeability를 확인한 뒤 작업지시자 승인에 따라 merge한다.

--- a/mydocs/pr/archives/pr_4687_review_impl.md
+++ b/mydocs/pr/archives/pr_4687_review_impl.md
@@ -1,0 +1,42 @@
+---
+kind: implementation-review
+status: completed
+pr: 4687
+issue: 4680
+---
+
+# PR #4687 메인터너 보정 실행 기록
+
+## 목적
+
+HWP3 저장 시 문단 맨 앞에 넣는 `SectionDef`/`ColumnDef` 확장 제어문자의 8 UTF-16 단위 슬롯을
+예약할 때, 관련 문단 위치 메타데이터도 동일하게 이동시킨다.
+
+## 단계와 커밋
+
+| 단계 | 커밋 | 내용 | 결과 |
+| --- | --- | --- | --- |
+| 1 | `0eb105d99` | contributor가 선행 제어문자 슬롯 예약을 구현 | `char_offsets`만 이동하는 좌표 계약 누락 발견 |
+| 2 | `1cd726ba3` | 메인터너가 공통 예약 API, 모든 위치 메타데이터 이동, 변환·fallback 회귀를 추가 | focused/전체 로컬 검증 및 GitHub Full CI 성공 |
+| 3 | 이 문서 커밋 | 개별 검토 기록과 오늘할일을 trailing docs-only로 추가 | fast-pass와 최신 mergeability 확인 후 merge 대상 |
+
+## 보정 범위
+
+1. `Paragraph` 내부의 기존 inline 제어문자 삽입 경로와 선행 예약 경로가 하나의 위치 이동 helper를
+   사용하게 했다.
+2. `char_offsets`, 첫 위치 `0`을 보존하는 `char_shapes`, 모든 `range_tags` 경계,
+   `line_segs.text_start`를 삽입점 이후에만 함께 이동시켰다.
+3. HWPX-to-HWP 변환과 `serialize_para_text` fallback이 동일 예약 API를 호출하게 해 두 경로의
+   동작 차이를 제거했다.
+4. 기존 룸이 있는 IR을 다시 이동하지 않는 성질과 직렬화 후 재파싱 좌표를 회귀로 고정했다.
+
+## 롤백 경계
+
+후속 문제가 확인되면 메인터너 보정 커밋 `1cd726ba3`만 되돌리면 된다. contributor의 원 커밋
+`0eb105d99`은 재작성하지 않는다. 다만 이 경우 원래의 P1 위치 메타데이터 불일치가 다시 발생하므로,
+대체 보정 없이 단독 롤백하지 않는다.
+
+## 완료 판정
+
+코드 보정의 local 및 GitHub 검증은 완료했다. merge 이후에도 [#4680](https://github.com/edwardkim/rhwp/issues/4680)의
+HWP3→HWPX, 0쪽, 본문 보존 잔존 축은 유지한다.

--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -1201,7 +1201,35 @@ fn insert_section_def_control(section: &mut Section, report: &mut AdapterReport)
         0,
         Control::SectionDef(Box::new(section.section_def.clone())),
     );
+    make_room_for_leading_defs(first_para);
     report.section_def_controls_inserted += 1;
+}
+
+/// [#4680] 구역·단 정의 제어문자가 첫 문단 **맨 앞**에 놓이도록 글자 오프셋을 민다.
+///
+/// `serializer::body_text::serialize_para_text` 는 `char_offsets` 의 빈 간격에 제어문자를
+/// 채우고, 간격이 없으면 텍스트를 다 쓴 뒤에 몰아 쓴다. HWP3 파서는 오프셋을 글자 수만으로
+/// 만들어 간격이 하나도 없다 — 그래서 `(별표 2)` 뒤에 secd·cold 가 붙은 문서가 나왔고,
+/// 한글은 그런 문서를 여는 도중 응답이 끊기거나 죽었다(한글 2022 실측). 한컴 산출물은
+/// 언제나 정의 제어문자가 글자보다 앞이다.
+///
+/// 이미 자리가 있는 IR(HWPX 출신 등)은 건드리지 않는다 — 모자란 만큼만 민다.
+fn make_room_for_leading_defs(para: &mut crate::model::paragraph::Paragraph) {
+    let leading_defs = para
+        .controls
+        .iter()
+        .take_while(|c| matches!(c, Control::SectionDef(_) | Control::ColumnDef(_)))
+        .count();
+    // 확장 제어문자 하나가 8 코드유닛을 차지한다.
+    let needed = (leading_defs as u32) * 8;
+    let existing_room = para.char_offsets.first().copied().unwrap_or(0);
+    let shift = needed.saturating_sub(existing_room);
+    if shift == 0 {
+        return;
+    }
+    for off in &mut para.char_offsets {
+        *off += shift;
+    }
 }
 
 fn materialize_following_section_break_type(
@@ -2363,6 +2391,88 @@ pub fn convert_if_hwpx_source(doc: &mut Document, source_format: FileFormat) -> 
 mod tests {
     use super::*;
     use crate::model::paragraph::CharShapeRef;
+
+    /// [#4680] 구역 정의 컨트롤을 첫 문단에 삽입할 때 글자 오프셋 자리를 함께 비워야 한다.
+    ///
+    /// `serialize_para_text` 는 `char_offsets` 의 빈 간격에만 제어문자를 넣고, 간격이 없으면
+    /// 글자를 다 쓴 뒤에 몰아 쓴다. HWP3 파서는 오프셋을 글자 수만으로 만들어 간격이 없어
+    /// 종전에는 `secd`·`cold` 가 본문 글자 **뒤**로 밀렸고, 그 저장본을 한글 2022 로 열면
+    /// 응답이 끊기거나 죽었다(실측 10건 중 5건이 이 수정으로 열린다). 한컴 산출물은 언제나
+    /// 정의 제어문자가 글자보다 앞이다.
+    #[test]
+    fn issue4680_section_def_insert_makes_room_in_char_offsets() {
+        use crate::model::document::{Section, SectionDef};
+        use crate::model::page::PageDef;
+        use crate::model::paragraph::Paragraph;
+
+        // HWP3 파서 산출 모양: 글자 수만큼의 연속 오프셋, 정의 컨트롤은 cold 하나뿐.
+        let mut para = Paragraph {
+            text: "(별표 2)".to_string(),
+            char_offsets: (0..6).collect(),
+            ..Default::default()
+        };
+        para.controls.push(Control::ColumnDef(Default::default()));
+        let mut section = Section {
+            section_def: SectionDef {
+                page_def: PageDef {
+                    width: 59528,
+                    height: 84188,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            paragraphs: vec![para],
+            ..Default::default()
+        };
+
+        let mut report = AdapterReport::default();
+        insert_section_def_control(&mut section, &mut report);
+
+        assert_eq!(report.section_def_controls_inserted, 1);
+        // secd + cold = 확장 제어문자 2개 × 8 코드유닛만큼 앞자리가 비어야 한다.
+        assert_eq!(
+            section.paragraphs[0].char_offsets,
+            vec![16, 17, 18, 19, 20, 21],
+            "정의 컨트롤 2개분(16 코드유닛) 만큼 밀려야 함"
+        );
+    }
+
+    /// [#4680] 자리가 이미 있는 IR(HWPX 출신 등)은 밀지 않는다 — 두 번 밀면 컨트롤과
+    /// 글자 사이에 빈 슬롯이 생겨 오히려 위치가 어긋난다.
+    #[test]
+    fn issue4680_existing_room_is_not_shifted_again() {
+        use crate::model::document::{Section, SectionDef};
+        use crate::model::page::PageDef;
+        use crate::model::paragraph::Paragraph;
+
+        let para = Paragraph {
+            text: "가나".to_string(),
+            // 이미 정의 컨트롤 하나(8 코드유닛)분 자리가 있는 오프셋
+            char_offsets: vec![8, 9],
+            ..Default::default()
+        };
+        let mut section = Section {
+            section_def: SectionDef {
+                page_def: PageDef {
+                    width: 59528,
+                    height: 84188,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            paragraphs: vec![para],
+            ..Default::default()
+        };
+
+        let mut report = AdapterReport::default();
+        insert_section_def_control(&mut section, &mut report);
+
+        assert_eq!(
+            section.paragraphs[0].char_offsets,
+            vec![8, 9],
+            "secd 한 개분 자리가 이미 있으므로 추가 이동 없음"
+        );
+    }
 
     /// [#3676] HWP3 parser가 실제로 만드는 그림/도형/표 캡션과 HiddenComment, 그리고
     /// 공통 adapter가 다루는 바탕쪽 글상자를 모두 건너 문단 직속 그림만 보정하면,

--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -1201,35 +1201,13 @@ fn insert_section_def_control(section: &mut Section, report: &mut AdapterReport)
         0,
         Control::SectionDef(Box::new(section.section_def.clone())),
     );
-    make_room_for_leading_defs(first_para);
-    report.section_def_controls_inserted += 1;
-}
-
-/// [#4680] 구역·단 정의 제어문자가 첫 문단 **맨 앞**에 놓이도록 글자 오프셋을 민다.
-///
-/// `serializer::body_text::serialize_para_text` 는 `char_offsets` 의 빈 간격에 제어문자를
-/// 채우고, 간격이 없으면 텍스트를 다 쓴 뒤에 몰아 쓴다. HWP3 파서는 오프셋을 글자 수만으로
-/// 만들어 간격이 하나도 없다 — 그래서 `(별표 2)` 뒤에 secd·cold 가 붙은 문서가 나왔고,
-/// 한글은 그런 문서를 여는 도중 응답이 끊기거나 죽었다(한글 2022 실측). 한컴 산출물은
-/// 언제나 정의 제어문자가 글자보다 앞이다.
-///
-/// 이미 자리가 있는 IR(HWPX 출신 등)은 건드리지 않는다 — 모자란 만큼만 민다.
-fn make_room_for_leading_defs(para: &mut crate::model::paragraph::Paragraph) {
-    let leading_defs = para
+    let leading_defs = first_para
         .controls
         .iter()
-        .take_while(|c| matches!(c, Control::SectionDef(_) | Control::ColumnDef(_)))
+        .take_while(|control| matches!(control, Control::SectionDef(_) | Control::ColumnDef(_)))
         .count();
-    // 확장 제어문자 하나가 8 코드유닛을 차지한다.
-    let needed = (leading_defs as u32) * 8;
-    let existing_room = para.char_offsets.first().copied().unwrap_or(0);
-    let shift = needed.saturating_sub(existing_room);
-    if shift == 0 {
-        return;
-    }
-    for off in &mut para.char_offsets {
-        *off += shift;
-    }
+    first_para.reserve_leading_extended_control_slots(leading_defs);
+    report.section_def_controls_inserted += 1;
 }
 
 fn materialize_following_section_break_type(
@@ -2390,7 +2368,7 @@ pub fn convert_if_hwpx_source(doc: &mut Document, source_format: FileFormat) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::paragraph::CharShapeRef;
+    use crate::model::paragraph::{CharShapeRef, LineSeg, RangeTag};
 
     /// [#4680] 구역 정의 컨트롤을 첫 문단에 삽입할 때 글자 오프셋 자리를 함께 비워야 한다.
     ///
@@ -2409,6 +2387,31 @@ mod tests {
         let mut para = Paragraph {
             text: "(별표 2)".to_string(),
             char_offsets: (0..6).collect(),
+            char_shapes: vec![
+                CharShapeRef {
+                    start_pos: 0,
+                    char_shape_id: 1,
+                },
+                CharShapeRef {
+                    start_pos: 3,
+                    char_shape_id: 2,
+                },
+            ],
+            range_tags: vec![RangeTag {
+                start: 0,
+                end: 4,
+                tag: 0x0100_0003,
+            }],
+            line_segs: vec![
+                LineSeg {
+                    text_start: 0,
+                    ..Default::default()
+                },
+                LineSeg {
+                    text_start: 3,
+                    ..Default::default()
+                },
+            ],
             ..Default::default()
         };
         para.controls.push(Control::ColumnDef(Default::default()));
@@ -2435,6 +2438,12 @@ mod tests {
             vec![16, 17, 18, 19, 20, 21],
             "정의 컨트롤 2개분(16 코드유닛) 만큼 밀려야 함"
         );
+        assert_eq!(section.paragraphs[0].char_shapes[0].start_pos, 0);
+        assert_eq!(section.paragraphs[0].char_shapes[1].start_pos, 19);
+        assert_eq!(section.paragraphs[0].range_tags[0].start, 16);
+        assert_eq!(section.paragraphs[0].range_tags[0].end, 20);
+        assert_eq!(section.paragraphs[0].line_segs[0].text_start, 0);
+        assert_eq!(section.paragraphs[0].line_segs[1].text_start, 19);
     }
 
     /// [#4680] 자리가 이미 있는 IR(HWPX 출신 등)은 밀지 않는다 — 두 번 밀면 컨트롤과

--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -603,8 +603,6 @@ impl Paragraph {
         if self.char_offsets.is_empty() {
             return;
         }
-        // [#4149] 인라인 컨트롤 삽입은 char_shapes 경계를 옮긴다 — memo 무효화 (보수적).
-        self.invalidate_single_line_overflow_memo();
         let text_len = self.text.chars().count();
         let safe_offset = char_offset.min(text_len);
         // 컨트롤이 삽입되는 UTF-16 위치 — char_offsets 시프트 전에 계산한다.
@@ -623,18 +621,54 @@ impl Paragraph {
         for co in self.char_offsets[safe_offset..].iter_mut() {
             *co += 8;
         }
+        self.shift_position_metadata_for_stream_insertion(insert_pos, 8);
+    }
+
+    /// 선행 확장 제어문자가 들어갈 만큼 첫 텍스트 앞 스트림 좌표를 확보한다.
+    ///
+    /// `SectionDef`·`ColumnDef`처럼 문단 첫 글자보다 앞에 와야 하는 확장 제어문자는 각각
+    /// 8 UTF-16 code unit을 쓴다. 이미 확보된 선행 공간은 보존하고 부족한 만큼만 모든
+    /// 텍스트 좌표를 민다. `char_offsets`와 같은 좌표계를 쓰는 글자모양, range tag,
+    /// 줄 시작도 함께 갱신해야 한다.
+    ///
+    /// 호출 전에 제어문자를 `controls`의 선두에 넣고, 그 연속 개수를 넘긴다.
+    pub(crate) fn reserve_leading_extended_control_slots(&mut self, control_count: usize) {
+        const EXTENDED_CONTROL_CODE_UNITS: u32 = 8;
+
+        let required_room = u32::try_from(control_count)
+            .unwrap_or(u32::MAX)
+            .saturating_mul(EXTENDED_CONTROL_CODE_UNITS);
+        let existing_room = self.char_offsets.first().copied().unwrap_or(0);
+        let shift = required_room.saturating_sub(existing_room);
+        if shift == 0 {
+            return;
+        }
+
+        for offset in &mut self.char_offsets {
+            *offset += shift;
+        }
+        self.shift_position_metadata_for_stream_insertion(existing_room, shift);
+    }
+
+    /// 스트림 삽입으로 이동한 텍스트 좌표와 같은 기준을 쓰는 문단 메타데이터를 갱신한다.
+    fn shift_position_metadata_for_stream_insertion(&mut self, insert_pos: u32, shift: u32) {
+        if shift == 0 {
+            return;
+        }
+        // [#4149] 제어문자 삽입은 char_shapes 경계를 옮긴다 — memo 무효화 (보수적).
+        self.invalidate_single_line_overflow_memo();
         // 문단 시작(pos 0)에 고정된 첫 스타일은 유지(insert_text_at 과 동일).
         for cs in &mut self.char_shapes {
             if cs.start_pos > insert_pos || (cs.start_pos == insert_pos && cs.start_pos > 0) {
-                cs.start_pos += 8;
+                cs.start_pos += shift;
             }
         }
         for rt in &mut self.range_tags {
             if rt.start >= insert_pos {
-                rt.start += 8;
+                rt.start += shift;
             }
             if rt.end >= insert_pos {
-                rt.end += 8;
+                rt.end += shift;
             }
         }
         // [#4347] 줄 시작도 같은 좌표계(UTF-16 code unit)를 쓴다 — 함께 밀지 않으면 저장된
@@ -643,7 +677,7 @@ impl Paragraph {
         // 첫 줄은 문단 시작에 고정한다 — 넣은 컨트롤이 그 줄에 든다(char_shapes 와 같은 규약).
         for seg in &mut self.line_segs {
             if seg.text_start > insert_pos || (seg.text_start == insert_pos && seg.text_start > 0) {
-                seg.text_start += 8;
+                seg.text_start += shift;
             }
         }
     }

--- a/src/serializer/body_text.rs
+++ b/src/serializer/body_text.rs
@@ -61,6 +61,21 @@ pub fn serialize_section(section: &Section) -> Vec<u8> {
                 0,
                 Control::SectionDef(Box::new(section.section_def.clone())),
             );
+            // [#4680] 정의 제어문자가 글자보다 앞에 놓이도록 자리를 비운다 —
+            // 간격이 없으면 `serialize_para_text` 가 텍스트 뒤에 몰아 쓰고, 그런 문서는
+            // 한글이 열다 멎는다. 어댑터의 `make_room_for_leading_defs` 와 같은 계약.
+            let leading_defs = clone
+                .controls
+                .iter()
+                .take_while(|c| matches!(c, Control::SectionDef(_) | Control::ColumnDef(_)))
+                .count();
+            let shift = ((leading_defs as u32) * 8)
+                .saturating_sub(clone.char_offsets.first().copied().unwrap_or(0));
+            if shift > 0 {
+                for off in &mut clone.char_offsets {
+                    *off += shift;
+                }
+            }
             Some(clone)
         }
     });

--- a/src/serializer/body_text.rs
+++ b/src/serializer/body_text.rs
@@ -63,19 +63,13 @@ pub fn serialize_section(section: &Section) -> Vec<u8> {
             );
             // [#4680] 정의 제어문자가 글자보다 앞에 놓이도록 자리를 비운다 —
             // 간격이 없으면 `serialize_para_text` 가 텍스트 뒤에 몰아 쓰고, 그런 문서는
-            // 한글이 열다 멎는다. 어댑터의 `make_room_for_leading_defs` 와 같은 계약.
+            // 한글이 열다 멎는다. 어댑터와 같은 문단 좌표 계약을 적용한다.
             let leading_defs = clone
                 .controls
                 .iter()
                 .take_while(|c| matches!(c, Control::SectionDef(_) | Control::ColumnDef(_)))
                 .count();
-            let shift = ((leading_defs as u32) * 8)
-                .saturating_sub(clone.char_offsets.first().copied().unwrap_or(0));
-            if shift > 0 {
-                for off in &mut clone.char_offsets {
-                    *off += shift;
-                }
-            }
+            clone.reserve_leading_extended_control_slots(leading_defs);
             Some(clone)
         }
     });
@@ -1675,6 +1669,71 @@ mod tests {
         assert_eq!(parsed.paragraphs[0].text, "AB");
         // SectionDef 컨트롤이 파싱되어 section_def에 반영
         assert_eq!(parsed.section_def.default_tab_spacing, 800);
+    }
+
+    #[test]
+    fn issue4680_serializer_fallback_shifts_all_leading_control_coordinates() {
+        use crate::model::page::PageDef;
+
+        let para = Paragraph {
+            text: "AB".to_string(),
+            char_offsets: vec![0, 1],
+            char_shapes: vec![
+                CharShapeRef {
+                    start_pos: 0,
+                    char_shape_id: 1,
+                },
+                CharShapeRef {
+                    start_pos: 1,
+                    char_shape_id: 2,
+                },
+            ],
+            range_tags: vec![RangeTag {
+                start: 0,
+                end: 1,
+                tag: 0x0100_0003,
+            }],
+            line_segs: vec![
+                LineSeg {
+                    text_start: 0,
+                    line_height: 500,
+                    text_height: 400,
+                    ..Default::default()
+                },
+                LineSeg {
+                    text_start: 1,
+                    line_height: 500,
+                    text_height: 400,
+                    ..Default::default()
+                },
+            ],
+            controls: vec![Control::ColumnDef(Default::default())],
+            ..Default::default()
+        };
+        let section = Section {
+            section_def: SectionDef {
+                page_def: PageDef {
+                    width: 59528,
+                    height: 84188,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            paragraphs: vec![para],
+            raw_stream: None,
+        };
+
+        let bytes = serialize_section(&section);
+        let parsed = parse_body_text_section(&bytes).unwrap();
+        let parsed_para = &parsed.paragraphs[0];
+
+        assert_eq!(parsed_para.char_offsets, vec![16, 17]);
+        assert_eq!(parsed_para.char_shapes[0].start_pos, 0);
+        assert_eq!(parsed_para.char_shapes[1].start_pos, 17);
+        assert_eq!(parsed_para.range_tags[0].start, 16);
+        assert_eq!(parsed_para.range_tags[0].end, 17);
+        assert_eq!(parsed_para.line_segs[0].text_start, 0);
+        assert_eq!(parsed_para.line_segs[1].text_start, 17);
     }
 
     /// #4424: `Control::Hyperlink` 는 `control_char_code_and_id` 에서 `(0x000B, 0)` 이라


### PR DESCRIPTION
## 변경 요약

HWP3 문서를 저장한 산출물을 한글 2022 로 열면 **응답이 끊기거나(무한 매달림) 죽던** 결함
10건 중 8건을 없앤다(남은 2건은 이 PR 대상이 아닌 HWPX 저장 경로). 근인은 구역 정의 제어문자의 **위치**다.

`insert_section_def_control` 은 첫 문단에 `secd` 컨트롤을 삽입하면서 `char_offsets` 의
자리는 비우지 않았다. `serialize_para_text` 는 오프셋의 **빈 간격**에만 제어문자를 채우고,
간격이 없으면 글자를 다 쓴 뒤에 몰아 쓴다. HWP3 파서는 오프셋을 글자 수만으로 만들어
(`reset_hwp3_plain_paragraph_text`) 간격이 하나도 없다. 결과:

```
(별표 2) [secd] [cold] <종결자>      ← 종전 rhwp
[secd] [cold] (별표 2) <종결자>      ← 한컴 (언제나 정의가 글자보다 앞)
```

- 삽입 후 선두 정의 컨트롤(`SectionDef`/`ColumnDef`) 수 × 8 코드유닛만큼 오프셋을 민다.
- **모자란 만큼만** 민다 — 이미 자리가 있는 IR(HWPX 출신)은 건드리지 않는다. 두 번 밀면
  컨트롤과 글자 사이에 빈 슬롯이 생겨 오히려 어긋난다(그 경우도 테스트로 고정).
- 직렬화기의 #1915 폴백에도 같은 계약을 적용했다(같은 잠재 결함이 있었다).

## 원인 규명

한글에게 같은 원본을 HWP5 로 저장시킨 파일을 정답지로 삼아 이분했다
(`tools/hwp_open_bisect`). 대조군(정답지 그대로)은 정상 개방, 후보는 재현 확인.

| 정답지에서 가져온 부분 | 결과 |
|---|---|
| DocInfo | 여전히 멎음 |
| `secd` CTRL_HEADER | 여전히 멎음 |
| PARA_HEADER (66) | 여전히 멎음 |
| PARA_CHAR_SHAPE (68) | 여전히 멎음 |
| PARA_LINE_SEG (69) | 여전히 멎음 |
| **PARA_TEXT (67)** | **정상 개방** |

PARA_TEXT 31개 중 다른 것은 첫 문단 **하나뿐**이었고, 그 차이가 위의 순서였다.

가는 길에 배제한 것들(각각 실측): 용지 설정(PAGE_DEF)은 정답지와 완전 동일,
`outline_numbering_id` 가 가리키는 NUMBERING 정의는 실재해 dangling 아님,
`char_count` ↔ PARA_TEXT 코드유닛 수·char_shape 위치 등 구조 불변식 위반 0건.

## 관련 이슈

refs #4680 (이슈는 잔여 5건 때문에 열어 둔다), 전수 근거 #4678

## 테스트

- [x] `cargo test` 통과 — 전체 lib 3,514 passed / 0 failed,
      통합 `hwpx_to_hwp_adapter` 23 · `issue_852_hwpx_to_hwp_contract_streams` 50 ·
      `hwpx_roundtrip_integration` 5 passed
- [x] `cargo clippy --lib -- -D warnings` 통과, 변경 파일 `rustfmt --check` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음 (저장 시 제어문자 위치, 렌더 무변경)
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [x] 회귀 테스트 2건 추가: `issue4680_section_def_insert_makes_room_in_char_offsets`,
      `issue4680_existing_room_is_not_shifted_again`
- [x] **한글 2022 실물 검증** — 아래

### 실물 검증 (한글 2022, 12.0.0.535)

HWP3 원본에서 나온 개방 실패 10건을 이 브랜치 빌드로 재변환해 다시 열었다. 측정은 스윕
하네스(`oracle_run.ps1` — 인스턴스 재사용·heartbeat·stall-kill)로 했다.

| key | 원본 (한글) | 수정 전 | 수정 후 |
|---|---|---|---|
| `04871.h2h` | 1쪽 594자 | 크래시 | **1쪽 592자** |
| `05555.h2h` | 1쪽 264자 | 크래시 | **1쪽 258자** |
| `06109.h2h` | 1쪽 1,532자 | 매달림 | **1쪽 535자** |
| `06136.h2h` | 1쪽 19자 | 매달림 | **1쪽 27자** |
| `06298.h2h` | 1쪽 1,240자 | 크래시 | **1쪽 1,240자** (일치) |
| `06299.h2h` | 1쪽 276자 | 크래시 | **1쪽 276자** (일치) |
| `06309.h2h` | 1쪽 198자 | 크래시 | **1쪽 198자** (일치) |
| `03908.h2h` | 1쪽 90자 | 크래시 | 열리지만 **0쪽 57자** (아래 주석) |
| `03908.h2x` | 1쪽 90자 | 크래시 | 여전히 실패 |
| `07615.h2x` | 264쪽 283,780자 | 크래시 | 여전히 실패 |

**개방 0/10 → 8/10.** 수정 후 산출물의 PARA_TEXT 는 한컴 정답지와 **바이트까지 일치**한다
(06298 기준 차이 31건 → 0건).

남은 2건은 **둘 다 `h2x`(HWPX 저장) 경로**다. 이 PR 이 고친 것은 HWP5 저장 경로의 어댑터라
h2x 는 애초에 대상이 아니며, HWP3→HWPX 는 별개 결함으로 #4680 에서 계속 추적한다.
반대로 **`h2h` 8건은 전부 열린다**(종전 0건).

주의할 점 둘:

- `03908.h2h` 는 열리지만 쪽수가 0 이다. 개방 실패에서는 벗어났으나 정상이라 보기 어려워
  이슈에 남긴다.
- 열린 문서의 글자 수가 원본과 다른 건(특히 `06109` 1,532→535)은 **개방이 아니라 본문
  보존 축**이다 — #4677·#4680 소관이며 이 PR 의 주장 범위 밖이다.

## 성능 영향 및 측정 결과

- 예상 영향: 없음 (첫 문단 오프셋 벡터 한 번 순회)
- 재현·측정: 미측정

## 스크린샷

해당 없음 (파일 개방 가능 여부).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
