### PR TITLE
fix(renderer): 저장 조각이 여백을 담지 못할 때 폭 음수·상자 밖 시작 차단 (#4690)

### DIFF
--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -3370,8 +3370,31 @@ impl LayoutEngine {
             // 일반 HWP3/HWP5의 저장 segment 계약은 다르므로 기존 여백 처리를 유지한다.
             let hwp3_password_stored_segment_line_box =
                 uses_stored_segment_geometry && self.profile.get().hwp3_password_layout();
+            // [#4690] 저장 cs/sw 조각이 문단 여백을 담지 못하면 여백을 적용하지 않는다.
+            //
+            // 이 경로의 `effective_col_x/w` 는 이미 저장 `cs`/`sw` 가 정한 줄 상자다. 그
+            // 상자가 좁은데 `margin_left + line_indent + margin_right` 를 그대로 얹으면
+            // 줄이 상자 오른쪽 밖에서 시작하고 폭이 음수가 된다 — 그 줄의 글자는 정상적으로
+            // 그려질 수 없다(30098 p3 pi48 L1: x=721.2 폭 −1.6, 문서 전체 18줄. 저장
+            // 사다리 값은 x=679.7 폭 38.4). 여백이 담기지 않는다는 것 자체가 그 조각을
+            // 완성된 line box 로 읽어야 한다는 신호이므로, 암호 HWP3 경로와 같은 처리를
+            // 한다.
+            //
+            // 이 가드는 **여백이 상자를 넘칠 때만** 발동한다. 여백이 들어가는 정상 어울림
+            // 줄은 종전대로 둔다 — `line_indent` 를 이 경로에서 일괄로 빼면 wrap 텍스트가
+            // 그림 영역으로 침범한다(#1230 `exam_science` pi=21). 저장 cs 가 내어쓰기를
+            // 대체한다는 해석도 성립하지 않는다: 정답지 `pdf/exam_kor-2022.pdf`
+            // (Hwp 2022 12.0.0.4426) p5 에서 첫/마지막 lineseg 의 cs 가 둘 다 1130 으로
+            // 같은 문단인데도 한/글은 이어지는 줄을 `|indent|` 만큼 들여 그린다
+            // (99.12pt ↔ 110.4pt = 132.16px ↔ 147.20px @96dpi). 즉 cs 는 그 줄의 확정
+            // 시작점이 아니라 문단 왼쪽 여백이다.
+            let stored_segment_line_box_cannot_hold_margins = uses_stored_segment_geometry
+                && !hwp3_password_stored_segment_line_box
+                && styled_margin_left + margin_right >= effective_col_w;
             let (effective_margin_left, effective_margin_right) =
-                if hwp3_password_stored_segment_line_box {
+                if hwp3_password_stored_segment_line_box
+                    || stored_segment_line_box_cannot_hold_margins
+                {
                     (0.0, 0.0)
                 } else {
                     (


### PR DESCRIPTION
> **범위 축소(2026-08-13)**: 원래 이 PR 은 #4088(injection 오탐)과 #4690 을 함께 담았습니다.
> #4088 은 [PR #4700](https://github.com/edwardkim/rhwp/pull/4700) 이 같은 이슈를 이슈 본문의
> 2·3안(목적격 인접·활용형 제외)으로 더 견고하게 고치고 있어, 중복을 피하려고 이 PR 에서
> 들어냈습니다. 지금은 **#4690 하나만** 담습니다.

#4690 — 쪽 경계의 저장 조각(`LINE_SEG.cs`/`sw`)이 문단 여백을 담지 못할 때, 줄이 상자
오른쪽 밖에서 시작하고 **폭이 음수**가 되는 결함을 막습니다.

## 이슈 본문의 수정 방향은 채택하지 않았습니다

본문은 "`cs > 0` 인 이어지는 줄에는 내어쓰기를 적용하지 않는다"를 제안하는데, 저장소 안의
한/글 PDF 정답지가 반증합니다 — 상세는
[#4690 코멘트](https://github.com/edwardkim/rhwp/issues/4690#issuecomment-5275059015).

`pdf/exam_kor-2022.pdf`(Hwp 2022, `samples/exam_kor.hwp` 산출) p5 에서 첫/마지막 lineseg 의
`cs` 가 **둘 다 1130 으로 같은** 문단인데도 한/글은 이어지는 줄을 `|indent|` 만큼 들여
그립니다(99.12pt ↔ 110.4pt = 132.16px ↔ 147.20px @96dpi). rhwp 현행 출력이 정답지와
0.1px 안에서 일치하므로, **`cs` 는 그 줄의 시작점이 아니라 문단 왼쪽 여백**입니다.
같은 결과가 한글 2018·한컴독스 산출에서도 재현됩니다.

제안 규칙을 그대로 구현하면 `issue_617_exam_kor_page5` 골든이 깨지고(147.3 → 132.24),
어울림 경로로 좁혀도 `exam_science` pi=21 의 wrap 텍스트가 그림을 침범해 #1230 이 깨집니다.

## 그래서 정답지 없이도 틀린 하드 신호만 고쳤습니다

저장 조각이 `margin_left + line_indent + margin_right` 를 담지 못하는데도 여백을 얹으면
줄이 상자 밖에서 시작하고 폭이 음수가 됩니다 — 그 줄의 글자는 정상적으로 그려질 수 없습니다.
여백이 상자를 넘칠 때만 발동하며, 처리는 암호 HWP3 경로가 이미 쓰는 것과 같습니다.

| | before | after |
|---|---|---|
| 30098 폭 음수 줄 | 18 | **0** |
| 30098 p3 pi48 L1 | x=721.2 폭 −1.6 | **x=679.7 폭 38.4** (저장 사다리 값) |
| 264문서 표본에서 이동한 줄 | — | **0** (퇴화 케이스에서만 발동) |

30213 형(일반 내어쓰기 이어지는 줄)은 손대지 않았으므로 이 PR 로 #4690 은 닫히지 않습니다.

## 검증

| 게이트 | 결과 |
|---|---|
| `cargo fmt --check` · `clippy --all-targets -- -D warnings` | 통과 |
| `cargo test --profile release-test --lib` | 3587 passed / 0 failed |
| `cargo test --profile release-test --tests` (전체) | 통과 (실패 0) |
| `svg_snapshot` · `overflow_cell_baseline` | 8/8 · 통과 |
| 한글 2022 정답지 오라클(`exam_kor`) | before/after 동일 — 대조 1224줄, 불일치 6줄(변경과 무관한 기존 편차) |
| 10k 코퍼스 264문서 하드 신호 스윕 | 악화 0 |

renderer 변경이므로 Native Skia 3종·WASM 빌드 게이트는 메인테이너 환경 확인이 필요합니다.
