### PR TITLE
fix(renderer): 단일 단 전면 개체 줄에서 저장 vpos-reset 존중 (#4092)

### DIFF
--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -15364,7 +15364,8 @@ impl TypesetEngine {
         // (다음 줄 vpos==0 이고 현재 줄 bottom 이 본문 안이면 현재 쪽 유지) 가 모든 줄을 한
         // 쪽에 쌓아 버린다. 이 문단만 hwp_authoritative 를 끄고 줄별 fit 분할(쪽당 1장)로
         // 되돌린다. 게이트는 formatter 의 stacked_tac_picture_heights 와 동일 의미.
-        let is_tac_picture_stack = para_is_treat_as_char_picture_only(para)
+        let tac_picture_only_para = para_is_treat_as_char_picture_only(para);
+        let is_tac_picture_stack = tac_picture_only_para
             && line_count >= 2
             && fmt
                 .line_heights
@@ -15530,7 +15531,25 @@ impl TypesetEngine {
                 // line_segs[li].vertical_pos == 0 (li>0) 은 HWP 가 해당 line 을
                 // 다음 단/페이지 최상단에 배치하도록 인코딩한 신호.
                 // 다단 한정 적용 — 단일 단은 partial-table split 회귀 (issue #418) 차단 위해 미적용.
-                if st.col_count > 1
+                //
+                // [#4092] 단일 단이라도 **전면 개체 줄**은 이 신호를 존중한다. 한 문단에
+                // 전면 그림이 여럿 든 형상에서, 한컴은 줄마다 reset 을 기록해 쪽마다
+                // 하나씩 두는데 rhwp 는 그 신호를 버리고 한 쪽에 쌓았다(HPV 코호트
+                // pi=970: 본문 895.8px 에 763~770px 짜리 줄 6개 = 4,654px, 문서 전체
+                // 246쪽 ↔ 한글 235쪽).
+                //
+                // 조건은 문단이 아니라 **그 줄**에 건다 — 같은 문단이라도 첫 줄은
+                // 199.7px 라 `is_tac_picture_stack`(모든 줄이 절반 초과)은 거짓이다.
+                // #418 의 partial-table 회귀는 여기에 닿지 않는다:
+                // `para_is_treat_as_char_picture_only` 가 TAC 그림 외 콘텐츠를 배제하므로
+                // 표가 든 문단은 애초에 해당하지 않는다.
+                let tac_picture_full_page_line = tac_picture_only_para
+                    && fmt
+                        .line_heights
+                        .get(li)
+                        .map(|h| *h > st.base_available_height() * 0.5)
+                        .unwrap_or(false);
+                if (st.col_count > 1 || tac_picture_full_page_line)
                     && li > cursor_line
                     && para
                         .line_segs


### PR DESCRIPTION
#4092 — 단일 단에서 줄별 `vpos-reset` 을 무시해 전면 그림이 한 쪽에 쌓이는 문제.
기준선 `upstream/devel@55eb2860b`. 상세 측정은
[#4092 코멘트](https://github.com/edwardkim/rhwp/issues/4092#issuecomment-5275177650)에 있습니다.

## 수정

`typeset.rs` 줄 분할 루프의 vpos-reset 강제 분리 가드는 다단(`col_count > 1`) 한정이었습니다
(#418 partial-table 회귀 차단). 이 가드를 전면 개방하지 않고, 이슈가 제시한 세 조건
(전면 개체 줄 · 저장 reset 기록 · 표 분할 아님)을 그대로 겁니다.

저장소에 이미 있는 `is_tac_picture_stack` 이 같은 취지지만 **모든 줄**이 본문 가용의 절반을
넘을 것을 요구해, 첫 줄이 199.7px 인 pi=970 에서는 거짓입니다. 같은 정의를 **그 줄**에만 겁니다.

#418 은 닿지 않습니다 — `para_is_treat_as_char_picture_only` 가 TAC 그림 외 콘텐츠를
배제하므로 표가 든 문단은 해당하지 않습니다.

## 해소

수정 전, 본문 895.8px 인 쪽에 이렇게 그렸습니다:

```
page=191  TextLine y=  409.6..1175.0  h=765.4  pi=970 line=1   ← 초과 52.5px
page=192  TextLine y= 1658.3..2428.6  h=770.3  pi=970 line=4
page=192  TextLine y= 2436.6..3205.1  h=768.5  pi=970 line=5
```

y=1658~3205px 는 어떤 쪽에도 없는 좌표라 그 그림들은 보이지 않습니다. 수정 후
`PartialParagraph pi=970` 이 9조각으로 갈려 쪽마다 하나씩 들어갑니다.

## 트레이드오프 — 쪽수는 반대로 갑니다

대상 문서 쪽수가 **246 → 260** 이 되어 한글 정답 235 에서 더 멀어집니다(Δ+11 → Δ+25).
그럼에도 이 문단의 분리는 맞다고 판단했습니다:

- 저장 `LINE_SEG.lh = 57272`(763.6px)는 한/글이 쓴 값이고, 본문 895.8px 에 763px 줄 둘은
  물리적으로 못 들어갑니다 — 한/글도 이 문단은 쪽마다 하나였을 수밖에 없습니다
- 수정 전 246쪽에는 보이지 않는 콘텐츠가 들어 있었습니다. 기존 Δ+11 은 손실을 가린 수치입니다

이 문서의 쪽수 초과를 만드는 주 원인은 별개 축으로 보이며, 그래서 이 PR 로 #4092 를 닫지
않습니다(`closes` 미사용).

## 검증

| 게이트 | 결과 |
|---|---|
| `cargo fmt --check` | 통과 |
| `cargo clippy --all-targets -- -D warnings` | 통과 (경고 0) |
| `cargo test --profile release-test --lib` | 3587 passed / 0 failed |
| `cargo test --profile release-test --tests` | 전체 통과 (한컴 정답 36쪽을 잠근 `issue_554` 포함) |
| 10k 코퍼스 264문서 쪽수 변동 | **0건** |

발동 범위가 좁아 코퍼스 회귀는 관측되지 않았습니다. renderer 변경이므로 Native Skia 3종·WASM
빌드 게이트는 메인테이너 환경 확인이 필요합니다.
