### PR TITLE
fix(#3438): 스타일 저장 실패와 모달 undo 계약 정리

### DIFF
--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -54,6 +54,10 @@
   실제 성공 때만 저장 후속 동작을 실행한다. focused 12건, Studio 전체 875 passed/1 skipped,
   TypeScript·production build, fixture를 연 로컬 Studio F6/Ctrl+Z 스모크를 통과했다. 상세는
   `mydocs/working/task_m100_3438_stage2.md`에 남겼다.
+- 최신 `devel` 기준 [PR #4710](https://github.com/edwardkim/rhwp/pull/4710)을 열고 collaborator
+  `jangster77`의 셀프 검토 코멘트를 제출했다. 외부 reviewer는 요청하지 않았다. code candidate
+  `b3ceeb330`의 검토·검증 기록은 [PR #4710 review](../pr/archives/pr_4710_review.md)에 남겼다.
+  최신 head의 required check, mergeability와 작업지시자 승인 전에는 merge·#3438 종료를 진행하지 않는다.
 
 ## Issue #3414 - 모달 종료 뒤 Ctrl+Z 입력 경로 복원
 

--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -38,3 +38,11 @@
   `local/task_m100_3438`에서 계획했다. 수행·구현 계획서는
   `mydocs/plans/task_m100_3438.md`, `mydocs/plans/task_m100_3438_impl.md`에 기록했다.
 - 이슈는 `jangster77`에 할당해 병렬 세션 잠금을 설정했다. 소스 변경은 계획 승인 뒤에 시작한다.
+- Stage 1에서 `createStyle`의 불가능한 음수 실패 가드를 없애고, 기존 스타일 수정 API의
+  `false`는 snapshot no-op으로, 모양 수정 API의 `false`는 명시 오류로 처리했다. Rust API
+  반환 계약까지 대조하는 Studio 가드를 추가했으며, focused 12건·Studio 전체 870 passed/1 skipped·
+  TypeScript·프로덕션 번들 빌드를 통과했다. 상세는
+  `mydocs/working/task_m100_3438_stage1.md`에 남겼다.
+- 한컴 Office 2018·2022·2024 설치를 확인했다. 앞선 레지스트리 조회가 Assistant만 찾아
+  Office 미설치로 판단한 것은 정정한다. 한컴 2022 실측 선결 항목은 후속 Windows 검증 대상으로
+  유지한다.

--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -46,6 +46,14 @@
 - 한컴 Office 2018·2022·2024 설치를 확인했다. 앞선 레지스트리 조회가 Assistant만 찾아
   Office 미설치로 판단한 것은 정정한다. 한컴 2022 실측 선결 항목은 후속 Windows 검증 대상으로
   유지한다.
+- Stage 2에서 한컴 Office 2022의 새 빈 문서에 `oracle3438`을 입력하고 F6 스타일 대화상자에서
+  Ctrl+Z를 실행했다. 대화상자는 열린 채로 남았고 Escape 뒤 상태 표시줄도 `10글자`를 유지했다.
+  따라서 모달 중 undo 차단은 한컴과 같은 계약이며, `StyleDialog`의 도달 불가
+  `history-jumped` 구독·동기화·해제를 제거했다.
+- 스타일 저장의 `false`·예외는 이제 `StyleEditDialog` 확인 동작도 실패로 반환해 모달을 유지하고,
+  실제 성공 때만 저장 후속 동작을 실행한다. focused 12건, Studio 전체 875 passed/1 skipped,
+  TypeScript·production build, fixture를 연 로컬 Studio F6/Ctrl+Z 스모크를 통과했다. 상세는
+  `mydocs/working/task_m100_3438_stage2.md`에 남겼다.
 
 ## Issue #3414 - 모달 종료 뒤 Ctrl+Z 입력 경로 복원
 

--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -29,3 +29,12 @@
   최신 head Full CI·CodeQL을 확인한다.
 - #4684 merge 뒤 충돌 해소 commit과 메인터너 보정 이유를 남겨 close한다. #4676은 한글 2022
   오라클 재개방 범위까지 완료 조건을 다시 확인한 뒤 close 여부를 결정한다.
+
+## Issue #3438 - 스타일 저장 반환 계약 정리
+
+- `lpaiu-cs`가 등록한 열린 이슈를 Windows 개발 환경에서 분류했다. iOS 전용(#3415), 한컴 Office
+  실측 선결(#3351·#3416 및 #3438의 모달 판정), 메인터너 목표값 결정(#3230)은 이 작업에서 제외한다.
+- #3438의 독립 항목인 `createStyle`/`updateStyle`/`updateStyleShapes` 반환 계약 보정은
+  `local/task_m100_3438`에서 계획했다. 수행·구현 계획서는
+  `mydocs/plans/task_m100_3438.md`, `mydocs/plans/task_m100_3438_impl.md`에 기록했다.
+- 이슈는 `jangster77`에 할당해 병렬 세션 잠금을 설정했다. 소스 변경은 계획 승인 뒤에 시작한다.

--- a/mydocs/plans/task_m100_3438.md
+++ b/mydocs/plans/task_m100_3438.md
@@ -1,0 +1,41 @@
+# Task M100-3438 — 스타일 저장의 실제 실패 반환 계약 반영
+
+## 배경
+
+GitHub Issue #3438은 스타일 대화상자의 도달 불가 코드와 실패 신호 처리를 정리한다.
+이 작업은 한컴 Office 실측이 필요한 모달 중 `history-jumped` 판정은 건드리지 않고, 독립적으로
+검증 가능한 스타일 저장 반환값 처리만 다룬다.
+
+## 초기 판정
+
+- `createStyle()`는 새 스타일 ID를 항상 반환하며 음수 실패값 경로가 없다.
+- `updateStyle()`와 `updateStyleShapes()`는 존재하지 않는 스타일 ID에서 `false`를 반환한다.
+- snapshot 라우터는 operation이 `null`을 반환하면 undo 기록·커서 이동·리프레시를 모두 생략한다.
+
+따라서 생성의 음수 ID 방어는 제거하고, 수정 API의 실제 `false`는 snapshot의 무변경 신호로
+연결한다. 스타일이 성공적으로 수정된 뒤 모양 수정만 실패하는 경우는 API 계약상 같은 ID 유효성에
+의존하므로 예외로 처리해 부분 변경을 정상 완료처럼 표시하지 않는다.
+
+## 범위
+
+1. `StyleEditDialog`의 불가능한 `createStyle()` 음수 검사와 설명을 제거한다.
+2. `updateStyle()` 실패는 `null`을 반환해 snapshot 기록을 취소한다.
+3. `updateStyleShapes()` 실패는 명시적으로 예외 처리한다.
+4. 소스 가드 테스트를 실제 반환 계약과 무변경 처리로 갱신한다.
+
+## 범위 외
+
+- 모달이 열린 동안 Ctrl+Z가 한컴에서 동작하는지에 따른 `history-jumped` 구독 제거 여부
+- 스타일 선택·undo 복원 UX의 변경
+- GitHub issue close, comment, push, PR 생성
+
+## 검증
+
+- `npx tsc --noEmit`
+- `node --test tests/style-undo-routing.test.ts tests/undo-noop-skip.test.ts`
+- `npm test`
+- 브라우저에서 스타일 추가·수정·undo/redo 스모크
+
+## 승인 요청
+
+위 범위로 Stage 1 구현을 진행한다. 승인 전에는 소스 코드를 수정하지 않는다.

--- a/mydocs/plans/task_m100_3438_impl.md
+++ b/mydocs/plans/task_m100_3438_impl.md
@@ -1,0 +1,42 @@
+# 구현 계획서 — Task M100-3438: 스타일 저장 반환 계약 정리
+
+- 이슈: https://github.com/edwardkim/rhwp/issues/3438
+- 수행 계획서: `mydocs/plans/task_m100_3438.md`
+- 작성일: 2026-08-13
+- 브랜치: `local/task_m100_3438`
+
+## 1. 설계
+
+`apply` 콜백의 반환값을 `boolean`으로 바꾼다.
+
+- 새 스타일 생성은 ID를 곧바로 `updateStyleShapes()`에 전달하고 성공을 반환한다.
+- 기존 스타일 수정에서 `updateStyle()`가 `false`이면 `false`를 반환한다.
+- 입력 핸들러가 있는 경로는 `false`를 `null`로 바꿔 `SnapshotCommand`의 no-op 계약을 사용한다.
+- 모양 수정이 요청됐는데 `updateStyleShapes()`가 `false`이면 throw한다. 이는 동일 ID로 앞선
+  수정이 완료된 뒤의 계약 위반이므로 조용한 무변경으로 숨기지 않는다.
+
+## 2. 수정 파일
+
+- `rhwp-studio/src/ui/style-edit-dialog.ts`
+- `rhwp-studio/tests/style-undo-routing.test.ts`
+
+필요하면 공용 no-op 계약을 이미 검증하는
+`rhwp-studio/tests/undo-noop-skip.test.ts`에 style API 계약 가드를 추가한다.
+
+## 3. 단계
+
+1. `apply`의 반환형과 snapshot operation을 실제 bool 계약에 맞춘다.
+2. 생성 음수 ID 가드를 제거하고 업데이트 bool을 검사한다.
+3. 테스트를 갱신해 존재하지 않는 실패 신호를 다시 도입하지 못하게 한다.
+4. TypeScript·focused test·전체 Studio test와 브라우저 스모크를 수행한다.
+
+## 4. 완료 기준
+
+- 불가능한 `newId >= 0` 가드가 없다.
+- `updateStyle()` 실패는 undo 스택에 snapshot을 남기지 않는다.
+- `updateStyleShapes()`의 실패를 무시하지 않는다.
+- Studio 기본 검증과 실제 브라우저 스타일 저장 동작이 통과한다.
+
+## 5. 승인 요청
+
+위 설계대로 구현을 시작한다. 승인 전에는 소스 코드를 수정하지 않는다.

--- a/mydocs/plans/task_m100_3438_stage2.md
+++ b/mydocs/plans/task_m100_3438_stage2.md
@@ -1,0 +1,37 @@
+# Task M100-3438 Stage 2 — 한컴 모달 undo 판정과 도달 불가 구독 제거
+
+## 한컴 2022 기준 판정
+
+Windows의 한컴 Office 2022 새 빈 문서에서 `oracle3438`을 입력한 뒤 F6 스타일 대화상자를 열고
+Ctrl+Z를 눌렀다. 대화상자는 열린 채로 남았고, Escape로 닫은 뒤 상태 표시줄은 `10글자`였다.
+즉 한컴도 모달이 열린 동안 undo를 실행하지 않는다.
+
+따라서 rhwp-studio의 `ModalDialog`가 modal capture 단계에서 Ctrl+Z를 편집기로 전달하지 않는 것은
+한컴과 같은 계약이다. `StyleDialog`가 열린 동안 `history-jumped`가 발생할 수 없으므로 관련 구독,
+동기화 메서드, 해제 핸들과 이를 고정한 소스 가드를 제거한다.
+
+## 함께 보강할 저장 실패 처리
+
+Stage 1의 반환 계약 처리는 유지하되, 실제 `false` 또는 예외면 `StyleEditDialog`의 확인 동작도
+`false`를 반환해 대화상자를 닫지 않는다. 입력 핸들러 경로의 snapshot rollback과 services 미주입
+fallback의 결과 처리를 같은 성공 여부로 묶어 실패를 정상 저장으로 표시하지 않는다.
+
+## 범위
+
+1. `StyleDialog`의 도달 불가 `history-jumped` 구독·동기화·해제를 제거한다.
+2. `StyleEditDialog.onConfirm()`이 유효성 검사 및 저장 실패 때 modal을 유지하게 한다.
+3. 가드 테스트를 실제 한컴 모달 계약과 WASM bool 실패 계약에 맞춰 갱신한다.
+
+## 범위 외
+
+- 모든 모달에서 Ctrl+Z를 허용하도록 `ModalDialog`의 capture 정책을 바꾸는 일
+- 한컴 2022가 아닌 버전의 동작을 한컴 2022 결과로 일반화하는 일
+- remote push, PR 생성, issue close
+
+## 검증
+
+- `node --test tests/style-undo-routing.test.ts tests/undo-noop-skip.test.ts`
+- `npx.cmd tsc --noEmit`
+- `npm.cmd test`
+- `npm.cmd run build`
+- 로컬 Studio에서 F6 스타일 대화상자 중 Ctrl+Z가 편집기를 바꾸지 않고, 닫은 뒤 Ctrl+Z가 동작하는지 확인

--- a/mydocs/plans/task_m100_3438_stage2_impl.md
+++ b/mydocs/plans/task_m100_3438_stage2_impl.md
@@ -1,0 +1,21 @@
+# 구현 계획서 — Task M100-3438 Stage 2
+
+- 이슈: [#3438](https://github.com/edwardkim/rhwp/issues/3438)
+- 수행 계획서: `mydocs/plans/task_m100_3438_stage2.md`
+- 기준 branch: `local/task_m100_3438`
+- 기준 devel: `d15b63eb46552ac61da24ad4a1b0c56208f71544`
+
+## 구현 순서
+
+1. `style-dialog.ts`에서 `historyJumpOff`, 생성자 구독, `syncAfterHistoryJump()`, `hide()` 해제를
+   제거한다. `services`와 `eventBus`는 삭제·적용 경로에서 계속 쓰므로 유지한다.
+2. `style-edit-dialog.ts`의 `onConfirm()`을 boolean으로 만들어 입력 검증, `updateStyle=false`,
+   `updateStyleShapes=false`, 예외에서 `false`를 반환한다. 성공한 저장 때만 `onSave`를 호출한다.
+3. `style-undo-routing.test.ts`에서 모달 중 `history-jumped` 소비가 없고 저장 실패가 modal을 유지하는
+   구조를 검사한다.
+
+## 안전성
+
+`SnapshotCommand`는 operation 예외 시 before snapshot으로 rollback한다. 따라서 기존 스타일 메타 수정
+뒤 모양 수정이 실패해도 InputHandler 경로에서는 부분 변경을 남기지 않는다. services 미주입 경로는
+새 mutation routing을 만들지 않고, bool/예외 실패를 성공 후처리로 취급하지 않는다.

--- a/mydocs/pr/archives/pr_4710_review.md
+++ b/mydocs/pr/archives/pr_4710_review.md
@@ -1,0 +1,81 @@
+---
+kind: review
+status: self-review-ci-pending
+pr: 4710
+issue: 3438
+author: jangster77
+base: devel
+---
+
+# PR #4710 검토 기록
+
+## 접수 정보
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4710](https://github.com/edwardkim/rhwp/pull/4710) |
+| 작성자 | `jangster77` |
+| 관련 이슈 | [#3438](https://github.com/edwardkim/rhwp/issues/3438) |
+| head / base | `task_m100_3438` / `devel` |
+| code candidate | `b3ceeb3303ad033218237a61e4d24dea8a8d7227` |
+| 변경 규모 | 10 files, +320 / -56 |
+| 문서 작성 시점 상태 | `MERGEABLE`, `BLOCKED` 참고값 — CI·CodeQL·Render Diff preflight 실행 중 |
+| 검토 | `jangster77` collaborator 셀프 검토 코멘트 제출 완료 (`PRR_kwDORyECHM8AAAABJYyrLA`, `1d95af512`) |
+
+### 적용 절차
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, local_validation.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+collaborator_self_merge.md, intake_and_review.md, local_validation.md,
+visual_fixture_evidence.md, docs_and_git_workflow.md
+current code candidate: b3ceeb3303ad033218237a61e4d24dea8a8d7227
+```
+
+최신 `upstream/devel` `d15b63eb46552ac61da24ad4a1b0c56208f71544` 위에서
+`task_m100_3438`을 만들고 `upstream`에 게시했다. 구현이 완료된 상태이므로 draft가 아닌 PR로
+열었다. 작업지시자 지시에 따라 external reviewer request는 만들지 않고 collaborator 셀프
+검토를 제출했다. merge와 이슈 종료는 최신 head의 필수 CI, mergeability와 작업지시자 승인 조건을
+다시 확인한 뒤에만 진행한다.
+
+## 변경 검토
+
+한컴 Office 2022의 새 빈 문서에서 F6 스타일 대화상자 중 Ctrl+Z가 문서 undo를 실행하지 않는 것을
+확인했다. Studio `ModalDialog`도 capture 단계에서 같은 입력 계약을 적용하므로, `StyleDialog`에서
+도달할 수 없는 `history-jumped` 구독·동기화·해제 핸들을 제거한 것은 적절하다. 일반적인
+스타일 추가·편집 뒤 `refresh()` 경로와 삭제 snapshot 경로는 유지한다.
+
+`StyleEditDialog`는 새 스타일 생성 API가 실패용 음수 ID를 반환하지 않는 실제 계약을 따르며,
+기존 ID를 갱신하는 `updateStyle`·`updateStyleShapes`의 `false`는 각각 no-op 또는 rollback 경로로
+처리한다. `onConfirm()`은 validation, `false`, 예외에서 `false`를 반환해 `ModalDialog`가 닫히지
+않도록 하고, 저장 성공 때만 `onSave`와 document-changed 후속 동작을 실행한다.
+
+renderer/layout, HWP/HWPX fixture, golden, 기준 PDF, Canvas 출력은 변경하지 않았다. formal visual
+fixture evidence는 merge 판단 보조 경로로 선택하지 않았고, 실제 Studio 브라우저와 한컴 UI의 F6
+입력 동작을 기능 검증으로 실행했다.
+
+## 완료한 검증
+
+다음 검증은 code candidate에서 Windows PowerShell로 완료했다.
+
+| 검증 | 결과 |
+| --- | --- |
+| 한컴 Office 2022 새 문서 F6 → Ctrl+Z | 스타일 모달 유지, Escape 뒤 `10글자` 유지 |
+| `node --test tests/style-undo-routing.test.ts tests/undo-noop-skip.test.ts` | 12 passed |
+| `npx.cmd tsc --noEmit` | 통과 |
+| `npm.cmd test` | 875 passed, 1 skipped, 0 failed |
+| `npm.cmd run build` | 통과 (기존 Vite 경고만 발생) |
+| 로컬 Studio fixture F6 → Ctrl+Z | 스타일 모달 유지 |
+| 로컬 Studio 모달 닫기 → Ctrl+Z | textarea 포커스 유지, console error/warning 없음 |
+| `git diff --check upstream/devel...b3ceeb3303ad033218237a61e4d24dea8a8d7227` | 통과 |
+
+이 검토 기록과 오늘할일은 code candidate 뒤에 추가하는 docs-only 후속 commit이다. 따라서 실제
+merge 전에는 이 문서를 포함한 최신 PR head의 GitHub Actions와 mergeability를 다시 확인한다.
+
+## 최종 조건과 권고
+
+코드 검토와 로컬 검증에서 blocker는 발견하지 못했다. 문서 작성 시점에는 필수 CI가 실행 중이므로
+**현재는 merge 보류**다. 최신 PR head의 CI 성공, 셀프 검토의 유효성, 최신 mergeability와
+작업지시자 승인이 모두 확인되면 수용·merge를 진행하고, merge 뒤 `Closes #3438`에 따른 이슈 종료
+상태와 후속 정리를 post-merge 절차로 확인한다.

--- a/mydocs/working/task_m100_3438_stage1.md
+++ b/mydocs/working/task_m100_3438_stage1.md
@@ -1,0 +1,44 @@
+# Task M100-3438 Stage 1 — 스타일 저장의 실제 반환 계약 반영
+
+- Issue: #3438
+- 브랜치: `local/task_m100_3438`
+- 기준: `upstream/devel` (`8e81cbd996b66f873d21b74085a9dcee78ae3901`)
+- 완료일: 2026-08-13
+
+## 범위
+
+#3438의 두 항목 중 한컴 2022 실측 없이도 독립적으로 판정 가능한 스타일 저장 반환 계약만
+처리했다. 모달이 열린 상태에서의 Ctrl+Z 동작과 `history-jumped` 구독 제거 여부는 변경하지
+않았다.
+
+## 변경
+
+- `StyleEditDialog`의 `createStyle()` 음수 ID 실패 가정을 제거했다. Rust 구현은 새 스타일을
+  추가한 뒤 그 ID를 반환하며 음수 실패 경로가 없다.
+- 기존 스타일 수정에서 `updateStyle()`이 `false`이면 snapshot operation이 `null`을 반환하게
+  했다. 결과적으로 undo 기록, 커서 이동, 리프레시가 모두 생략된다.
+- `updateStyleShapes()`의 실재하는 `false` 반환값을 검사하고, 생성·수정 뒤 모양 적용 실패는
+  예외로 드러낸다.
+- Studio 소스 가드는 다이얼로그 배선뿐 아니라 `src/wasm_api.rs`의 세 API 반환 계약도 직접
+  대조한다.
+
+## 검증
+
+| 명령 | 결과 |
+| --- | --- |
+| `node --test tests/style-undo-routing.test.ts tests/undo-noop-skip.test.ts` | 12 passed |
+| `npx.cmd tsc --noEmit` | 통과 |
+| `npm.cmd test` | 870 passed, 1 skipped, 0 failed |
+| `npm.cmd run build` | 통과 |
+
+초기 TypeScript 검사에서 설치본 `node_modules`에 `@noble/hashes`가 빠진 것을 확인해
+`npm.cmd ci`로 잠금 파일 기준 의존성만 복구했다. 추적 파일 변경은 없다.
+
+세션의 브라우저 연결을 사용할 수 없어 실제 Studio UI 스모크는 수행하지 못했다. 이를
+자동화 테스트 통과로 대체해 기록하지 않는다.
+
+## 한컴 환경 정정
+
+Windows 설치 경로에서 한컴 Office 2018·2022·2024의 `Hwp.exe`를 확인했다. 앞선 레지스트리
+조회가 Assistant 항목만 찾아 한컴 Office가 없다고 판단한 것은 잘못이었다. 한컴 2022 실측이
+선결인 #3438 모달 판정, #3351, #3416은 후속 Windows 검증 대상으로 유지한다.

--- a/mydocs/working/task_m100_3438_stage2.md
+++ b/mydocs/working/task_m100_3438_stage2.md
@@ -1,0 +1,47 @@
+# Task M100-3438 Stage 2 — 한컴 모달 undo 판정과 저장 실패 모달 유지
+
+- Issue: #3438
+- 브랜치: `local/task_m100_3438`
+- 기준: `upstream/devel`의 #3414 병합 뒤 `d15b63eb46552ac61da24ad4a1b0c56208f71544`
+- 완료일: 2026-08-13
+
+## 한컴 Office 2022 오라클
+
+새 빈 문서에 `oracle3438`을 입력해 상태 표시줄 `10글자`를 확인한 뒤 F6 스타일 대화상자를 열었다.
+대화상자가 열린 상태에서 Ctrl+Z를 누르면 창은 열린 채로 남았으며, Escape로 닫은 뒤에도 상태
+표시줄은 `10글자`였다. 이 테스트 문서는 저장하지 않고 닫았다.
+
+따라서 한컴 Office 2022는 스타일 모달 중 undo를 실행하지 않는다. Studio의 모달 capture 정책도
+같은 계약이므로, 스타일 모달 중 발생할 수 없다고 가정되는 `history-jumped` 구독과 목록 동기화,
+해제 핸들을 제거했다.
+
+## 구현
+
+- `StyleEditDialog.onConfirm()`은 유효성 검사 실패, WASM `false`, 예외 때 `false`를 반환한다.
+  `ModalDialog`는 이 결과에서 모달을 닫지 않는다.
+- 입력 핸들러 snapshot은 저장 성공일 때만 위치를 반환한다. 실패는 no-op으로 남고, 모양 갱신의
+  예외는 기존 snapshot rollback 경로로 전달된다.
+- services 미주입 fallback도 동일한 `saved` 결과를 사용해 실패를 document-changed 성공으로
+  알리지 않는다.
+
+## 검증
+
+| 항목 | 결과 |
+| --- | --- |
+| 한컴 Office 2022 F6 → Ctrl+Z | 모달 유지, Escape 뒤 `10글자` 유지 |
+| `node --test tests/style-undo-routing.test.ts tests/undo-noop-skip.test.ts` | 12 passed |
+| `npx.cmd tsc --noEmit` | 통과 |
+| `npm.cmd test` | 875 passed, 1 skipped, 0 failed |
+| `npm.cmd run build` | 통과 (기존 Vite 경고만 출력) |
+| 로컬 Studio fixture F6 → Ctrl+Z | 스타일 모달 유지 |
+| 로컬 Studio 스타일 모달 닫기 → Ctrl+Z | 입력 textarea 포커스 유지, console error/warning 없음 |
+| `git diff --check` | 통과 |
+
+로컬 Studio 검증은 `rhwp-studio/public/samples/shift-return.hwp`를 URL 입력 경로로 열어 수행했다.
+원본 fixture는 저장하거나 변경하지 않았다.
+
+## 범위 외
+
+- `ModalDialog`의 Ctrl+Z capture 정책을 전역적으로 바꾸는 일
+- 한컴 Office 2022 결과를 다른 한컴 버전으로 일반화하는 일
+- remote push, PR 생성, issue close

--- a/rhwp-studio/src/ui/style-dialog.ts
+++ b/rhwp-studio/src/ui/style-dialog.ts
@@ -60,18 +60,12 @@ export class StyleDialog extends ModalDialog {
   onEditRequest?: (styleId: number) => void;
   onAddRequest?: () => void;
 
-  /** [Task #3387] undo/redo 후 목록 무효화 구독 해제 핸들 (열려 있는 동안만). */
-  private historyJumpOff?: () => void;
-
   constructor(
     private wasm: WasmBridge,
     private eventBus: EventBus,
     private services?: CommandServices,
   ) {
     super('스타일', 560);
-    // undo/redo 는 스타일 목록을 되돌리므로 열려 있는 목록이 stale 이 된다
-    // (#2341 이 연 history-jumped 를 find-dialog 와 같은 방식으로 구독).
-    this.historyJumpOff = this.eventBus.on('history-jumped', () => this.syncAfterHistoryJump());
   }
 
   protected createBody(): HTMLElement {
@@ -308,32 +302,11 @@ export class StyleDialog extends ModalDialog {
     this.updateInfo();
   }
 
-  /**
-   * undo/redo 뒤 표시 전체를 문서 현재 상태로 다시 맞춘다 (Task #3387).
-   *
-   * 목록만 다시 읽으면 `현재 커서 위치 스타일` 라벨이 되돌아가기 전 값으로 남는다 —
-   * 히스토리 점프는 캐럿이 놓인 문단의 `style_id` 자체가 바뀌는 자리다(스타일 삭제
-   * undo 는 그 문단을 원래 스타일로 되돌린다). 편집·추가 뒤 호출되는 `refresh` 와
-   * 달리 선택까지 캐럿 기준으로 다시 잡는다.
-   */
-  private syncAfterHistoryJump(): void {
-    this.loadStyles();
-    const currentId = this.services?.getInputHandler()?.getCurrentStyleId();
-    if (typeof currentId === 'number') {
-      this.setCurrentStyleId(currentId);
-    } else {
-      this.updateInfo();
-    }
-  }
-
   protected onConfirm(): void {
     this.onApply?.(this.selectedId);
   }
 
   override hide(): void {
-    // 닫힌 뒤에도 구독이 남으면 사라진 목록을 갱신하려 든다 (find-dialog 동형).
-    this.historyJumpOff?.();
-    this.historyJumpOff = undefined;
     super.hide();
     this.onClose?.();
   }

--- a/rhwp-studio/src/ui/style-edit-dialog.ts
+++ b/rhwp-studio/src/ui/style-edit-dialog.ts
@@ -298,7 +298,7 @@ export class StyleEditDialog extends ModalDialog {
     // [Task #3387] 스타일 정의와 글자/문단 모양은 **두 번의 뮤테이션**이다. 따로 기록하면
     // undo 가 두 번 필요하고 그 사이에 모양만 빠진 스타일이 남는다 — #2366 계산식과 동형으로
     // 한 스냅샷 안에서 둘을 끝낸다.
-    const apply = (wasm: WasmBridge): void => {
+    const apply = (wasm: WasmBridge): boolean => {
       if (this.addMode) {
         const baseParaShapeId = this.baseInfo.paraProps?.paraShapeId;
         const baseCharShapeId = this.baseInfo.charProps?.charShapeId;
@@ -307,18 +307,25 @@ export class StyleEditDialog extends ModalDialog {
           ...(typeof baseParaShapeId === 'number' ? { baseParaShapeId } : {}),
           ...(typeof baseCharShapeId === 'number' ? { baseCharShapeId } : {}),
         }));
-        // 의미상 실패(음수 ID)면 throw 해 무변 스냅샷 엔트리를 막는다.
-        if (!(newId >= 0)) throw new Error('[StyleEditDialog] 스타일 생성 실패');
         if (this.charModsJson !== '{}' || this.paraModsJson !== '{}') {
-          wasm.updateStyleShapes(newId, this.charModsJson, this.paraModsJson);
+          if (!wasm.updateStyleShapes(newId, this.charModsJson, this.paraModsJson)) {
+            throw new Error('[StyleEditDialog] 생성한 스타일의 모양 적용 실패');
+          }
         }
+        return true;
       } else {
-        wasm.updateStyle(this.styleInfo.id, JSON.stringify({
+        if (!wasm.updateStyle(this.styleInfo.id, JSON.stringify({
           name, englishName, nextStyleId,
-        }));
-        if (this.charModsJson !== '{}' || this.paraModsJson !== '{}') {
-          wasm.updateStyleShapes(this.styleInfo.id, this.charModsJson, this.paraModsJson);
+        }))) {
+          // style ID가 이미 사라진 경우에는 실제 뮤테이션이 없으므로 snapshot도 남기지 않는다.
+          return false;
         }
+        if (this.charModsJson !== '{}' || this.paraModsJson !== '{}') {
+          if (!wasm.updateStyleShapes(this.styleInfo.id, this.charModsJson, this.paraModsJson)) {
+            throw new Error('[StyleEditDialog] 스타일 모양 적용 실패');
+          }
+        }
+        return true;
       }
     };
 
@@ -328,11 +335,12 @@ export class StyleEditDialog extends ModalDialog {
         ih.executeOperation({
           kind: 'snapshot',
           operationType: this.addMode ? 'createStyle' : 'updateStyle',
-          operation: (wasm) => { apply(wasm); return ih.getPosition(); },
+          operation: (wasm) => apply(wasm) ? ih.getPosition() : null,
         });
       } else {
-        apply(this.wasm);
-        this.eventBus.emit('document-changed');
+        if (apply(this.wasm)) {
+          this.eventBus.emit('document-changed');
+        }
       }
       this.onSave?.();
     } catch (err) {

--- a/rhwp-studio/src/ui/style-edit-dialog.ts
+++ b/rhwp-studio/src/ui/style-edit-dialog.ts
@@ -280,7 +280,7 @@ export class StyleEditDialog extends ModalDialog {
     }
   }
 
-  protected onConfirm(): void {
+  protected onConfirm(): boolean {
     const name = this.nameInput.value.trim();
     const englishName = this.enNameInput.value.trim();
     const styleType = this.typePara?.checked ? 0 : (this.styleInfo.type ?? 0);
@@ -288,11 +288,11 @@ export class StyleEditDialog extends ModalDialog {
 
     if (!name) {
       alert('스타일 이름을 입력하세요.');
-      return;
+      return false;
     }
     if (name.length > MAX_STYLE_NAME_LEN || englishName.length > MAX_STYLE_NAME_LEN) {
       alert(`스타일 이름/영문 이름은 ${MAX_STYLE_NAME_LEN}자를 넘을 수 없습니다.`);
-      return;
+      return false;
     }
 
     // [Task #3387] 스타일 정의와 글자/문단 모양은 **두 번의 뮤테이션**이다. 따로 기록하면
@@ -331,20 +331,28 @@ export class StyleEditDialog extends ModalDialog {
 
     try {
       const ih = this.services?.getInputHandler();
+      let saved = false;
       if (ih) {
         ih.executeOperation({
           kind: 'snapshot',
           operationType: this.addMode ? 'createStyle' : 'updateStyle',
-          operation: (wasm) => apply(wasm) ? ih.getPosition() : null,
+          operation: (wasm) => {
+            saved = apply(wasm);
+            return saved ? ih.getPosition() : null;
+          },
         });
       } else {
-        if (apply(this.wasm)) {
+        saved = apply(this.wasm);
+        if (saved) {
           this.eventBus.emit('document-changed');
         }
       }
+      if (!saved) return false;
       this.onSave?.();
+      return true;
     } catch (err) {
       console.warn('[StyleEditDialog] 저장 실패:', err);
+      return false;
     }
   }
 

--- a/rhwp-studio/tests/style-undo-routing.test.ts
+++ b/rhwp-studio/tests/style-undo-routing.test.ts
@@ -57,7 +57,7 @@ test('스타일 다이얼로그는 services 를 받고 history-jumped 로 목록
   assert.match(slice(dialog, 'override hide', '\n  }'), /this\.historyJumpOff\?\.\(\)/, '닫을 때 구독 해제');
 });
 
-test('스타일 생성·수정은 모양 적용까지 한 스냅샷으로 원자화된다', () => {
+test('스타일 생성·수정은 모양 적용까지 한 스냅샷으로 원자화되고 실제 실패 신호만 처리한다', () => {
   const dialog = source('src/ui/style-edit-dialog.ts');
   const save = slice(dialog, 'const apply = (wasm: WasmBridge)', 'override show()');
 
@@ -77,8 +77,31 @@ test('스타일 생성·수정은 모양 적용까지 한 스냅샷으로 원자
     1,
     '스냅샷은 하나여야 한다(2뮤테이션 원자화)',
   );
-  assert.match(applyFn, /throw new Error\('\[StyleEditDialog\] 스타일 생성 실패'\)/, '실패 시 무변 엔트리 차단');
+  // createStyle 는 항상 새 ID를 반환한다. 존재하지 않는 음수 실패값을 다시 가정하면 안 된다.
+  assert.doesNotMatch(applyFn, /newId >= 0|스타일 생성 실패/, 'createStyle의 존재하지 않는 실패 신호를 검사하지 않음');
+  // 반면 기존 style ID를 받는 두 API는 false를 반환하므로, 실패를 무시하면 스냅샷에
+  // 무변 엔트리가 남거나 부분 변경을 성공처럼 처리하게 된다.
+  assert.match(applyFn, /if \(!wasm\.updateStyle\(this\.styleInfo\.id/, 'updateStyle false를 확인');
+  assert.match(applyFn, /if \(!wasm\.updateStyleShapes\(/, 'updateStyleShapes false를 확인');
+  assert.match(
+    save,
+    /operation: \(wasm\) => apply\(wasm\) \? ih\.getPosition\(\) : null/,
+    'updateStyle false는 snapshot no-op으로 전달',
+  );
   assert.match(save, /this\.eventBus\.emit\('document-changed'\)/, '미주입 fallback 유지');
+});
+
+test('스타일 WASM 반환 계약은 생성 성공 ID와 기존 ID 갱신 실패를 구분한다', () => {
+  const wasmApi = source('../src/wasm_api.rs');
+  const updateStyle = slice(wasmApi, 'pub fn update_style', '\n    /// 스타일의 CharShape/ParaShape를 수정한다.');
+  const updateStyleShapes = slice(wasmApi, 'pub fn update_style_shapes', '\n    /// 새 스타일을 생성한다.');
+  const createStyle = slice(wasmApi, 'pub fn create_style', '\n    /// 스타일을 삭제한다.');
+
+  assert.match(updateStyle, /None => return false/, '없는 기존 스타일은 updateStyle=false');
+  assert.match(updateStyleShapes, /None => return false/, '없는 기존 스타일은 updateStyleShapes=false');
+  assert.match(createStyle, /styles\.push\(new_style\)/, 'createStyle은 새 스타일을 추가');
+  assert.match(createStyle, /\n\s*new_id\n/, 'createStyle은 추가한 ID를 반환');
+  assert.doesNotMatch(createStyle, /return -\d+/, 'createStyle은 음수 실패 ID를 계약으로 두지 않음');
 });
 
 test('스타일 다이얼로그 생성 지점이 services 를 넘긴다', () => {

--- a/rhwp-studio/tests/style-undo-routing.test.ts
+++ b/rhwp-studio/tests/style-undo-routing.test.ts
@@ -38,23 +38,14 @@ test('스타일 삭제는 snapshot 으로 기록된다', () => {
   assert.match(handleDelete, /this\.eventBus\.emit\('document-changed'\)/, '미주입 fallback 유지');
 });
 
-test('스타일 다이얼로그는 services 를 받고 history-jumped 로 목록을 무효화한다', () => {
+test('스타일 다이얼로그는 모달 중 도달 불가한 history-jumped 를 구독하지 않는다', () => {
   const dialog = source('src/ui/style-dialog.ts');
 
   assert.match(dialog, /private services\?: CommandServices/, 'services 주입');
-  // undo/redo 는 스타일 목록을 되돌리므로 열려 있는 목록이 stale 이 된다 (#2341).
-  assert.match(
-    dialog,
-    /this\.eventBus\.on\('history-jumped', \(\) => this\.syncAfterHistoryJump\(\)\)/,
-    'history-jumped 구독으로 표시 갱신',
-  );
-  // 목록만 다시 읽으면 `현재 커서 위치 스타일` 라벨이 되돌아가기 전 값으로 남는다 —
-  // 히스토리 점프는 캐럿 문단의 style_id 자체가 바뀌는 자리다.
-  const sync = slice(dialog, 'private syncAfterHistoryJump', '\n  }');
-  assert.match(sync, /getInputHandler\(\)\?\.getCurrentStyleId\(\)/, '캐럿 기준으로 현재 스타일 재조회');
-  assert.match(sync, /this\.setCurrentStyleId\(currentId\)/, '라벨·선택·정보 패널까지 갱신');
-  // 닫힌 뒤 구독이 남으면 사라진 목록을 갱신하려 든다.
-  assert.match(slice(dialog, 'override hide', '\n  }'), /this\.historyJumpOff\?\.\(\)/, '닫을 때 구독 해제');
+  // 한컴 2022도 F6 스타일 대화상자 중 Ctrl+Z를 문서에 전달하지 않는다. rhwp의 모달
+  // capture 계약도 같으므로 이 다이얼로그가 소비할 history-jumped 자체가 없다 (#3438).
+  assert.doesNotMatch(dialog, /history-jumped|historyJumpOff|syncAfterHistoryJump/,
+    '도달 불가한 구독·동기화·해제 코드를 두지 않음');
 });
 
 test('스타일 생성·수정은 모양 적용까지 한 스냅샷으로 원자화되고 실제 실패 신호만 처리한다', () => {
@@ -85,9 +76,13 @@ test('스타일 생성·수정은 모양 적용까지 한 스냅샷으로 원자
   assert.match(applyFn, /if \(!wasm\.updateStyleShapes\(/, 'updateStyleShapes false를 확인');
   assert.match(
     save,
-    /operation: \(wasm\) => apply\(wasm\) \? ih\.getPosition\(\) : null/,
+    /operation: \(wasm\) => \{\s*saved = apply\(wasm\);\s*return saved \? ih\.getPosition\(\) : null;/,
     'updateStyle false는 snapshot no-op으로 전달',
   );
+  assert.match(save, /let saved = false/, '실제 저장 성공 여부를 확인');
+  assert.match(save, /if \(!saved\) return false/, 'false 반환은 모달을 닫지 않음');
+  assert.match(save, /catch \(err\) \{[\s\S]*?return false;/, '예외도 모달을 닫지 않음');
+  assert.match(save, /this\.onSave\?\.\(\);\s*return true;/, '성공한 저장 때만 후속 새로고침');
   assert.match(save, /this\.eventBus\.emit\('document-changed'\)/, '미주입 fallback 유지');
 });
 


### PR DESCRIPTION
## 변경 내용

- 한컴 Office 2022의 F6 스타일 모달에서 Ctrl+Z가 실행되지 않는 동작을 실측하고, Studio의 도달 불가 `history-jumped` 구독·동기화·해제를 제거했습니다.
- 스타일 생성/수정의 WASM 반환 계약을 실제 구현과 맞췄습니다.
- 저장이 `false`를 반환하거나 예외가 발생하면 스타일 편집 모달을 유지하고 성공 후속 처리·snapshot 기록을 만들지 않도록 보강했습니다.

## 원인과 영향

스타일 모달에서 실행될 수 없는 undo 이력을 구독하고 있었고, 저장 실패가 확인 동작의 성공처럼 처리될 여지가 있었습니다. 이제 한컴 2022와 같은 모달 입력 계약을 따르며, 실패한 저장은 사용자에게 열린 모달로 남습니다.

## 검증

- `node --test tests/style-undo-routing.test.ts tests/undo-noop-skip.test.ts` — 12 passed
- `npx.cmd tsc --noEmit`
- `npm.cmd test` — 875 passed, 1 skipped
- `npm.cmd run build`
- 한컴 Office 2022 새 문서 F6/Ctrl+Z 오라클 및 로컬 Studio fixture F6/Ctrl+Z 스모크

Closes #3438
