### PR TITLE
feat(studio): 옵트인 플랫 스킨 + 테마 토큰·스킨 제작 가이드

### DIFF
--- a/mydocs/manual/README.md
+++ b/mydocs/manual/README.md
@@ -40,6 +40,7 @@ last_verified: 2026-08-07
 | 품질 지표와 리팩터링 검토 | [코드 품질 대시보드](dashboard.md) | [SOLID 채점 기준](solid_scoring_guide.md) |
 | release 준비와 배포 | [배포 가이드](publish_guide.md) | [개발 환경 가이드](dev_environment_guide.md) |
 | rhwp-studio UI 명칭·CSS 접두어 | [rhwp-studio UI 명칭과 CSS 접두어](rhwp_studio_ui_conventions.md) | [개발 환경 가이드](dev_environment_guide.md) |
+| rhwp-studio 테마 토큰·스킨 제작 | [rhwp-studio 테마 토큰과 스킨 제작](rhwp_studio_theming.md) | [rhwp-studio UI 명칭과 CSS 접두어](rhwp_studio_ui_conventions.md) |
 
 ## 문서 경계
 

--- a/mydocs/manual/rhwp_studio_theming.md
+++ b/mydocs/manual/rhwp_studio_theming.md
@@ -1,0 +1,85 @@
+---
+kind: reference
+status: active
+canonical: mydocs/manual/rhwp_studio_theming.md
+last_verified: 2026-08-13
+---
+
+# rhwp-studio 테마 토큰과 스킨 제작
+
+rhwp-studio의 색·형태 값은 전부 `src/styles/base.css`의 CSS 변수(토큰)로 구동된다.
+이 문서는 토큰 계층, 테마 적용 파이프라인, 그리고 새 스킨을 추가할 때 지켜야 할
+규칙을 정의한다.
+
+## 테마 축은 두 개다
+
+| 축 | 설정 키 | root 속성 | 값 |
+| --- | --- | --- | --- |
+| 모드 (밝기) | `theme.mode` | `data-theme-effective` | `light` \| `dark` (`system`은 OS 설정으로 해석) |
+| 스킨 (룩) | `theme.skin` | `data-theme-skin` | 기본 스킨은 속성 없음, 옵트인 스킨은 스킨명 (예: `flat`) |
+
+두 축은 독립이다. 스킨은 밝기 축을 침범하지 않아야 하며(아래 다크 가드 규칙),
+다크 팔레트는 `:root[data-theme-effective="dark"]`가 항상 소유한다.
+
+## 토큰 계층
+
+`base.css`의 `:root` 블록이 유일한 토큰 정의 지점이다 (약 170여 개).
+
+1. **원시 토큰** — 실제 값이 정의되는 곳.
+   - 표면·경계·텍스트·상호작용: `--ui-*` (예: `--ui-bg`, `--ui-border-subtle`, `--ui-hover`)
+   - 액센트: `--accent-*` (`--accent-primary` 등)
+   - 문서 작업 영역: `--doc-*` (`--doc-workspace`, `--doc-paper`, `--doc-shadow`)
+   - 눈금자: `--ruler-*`
+   - 형태: `--radius-*`, `--shadow-*`, `--space-*`, `--font-size-*`, `--control-height-*`
+   - UI 크롬 글꼴: `--font-family-ui` — 메뉴·툴바 등 크롬 전용이며 **문서 본문 렌더링
+     글꼴과 무관하다**. 스킨이 재정의할 수 있는 토큰이다 (플랫 스킨은 시스템에 설치된
+     Pretendard 를 우선 사용하고, 글꼴 파일은 번들하지 않는다).
+2. **시맨틱 별칭** — 원시 토큰을 참조하는 이름 (예: `--color-primary: var(--accent-primary)`,
+   `--color-surface: var(--ui-surface)`). 컴포넌트 CSS가 역할 이름으로 소비할 수 있게 한다.
+
+소비 규칙: 컴포넌트/영역 CSS는 **토큰만 참조**하고 색을 하드코딩하지 않는다.
+(canvas에 그리는 코드는 `cssVar()` 헬퍼로 토큰을 읽는다 — 예: `src/view/ruler.ts`.)
+
+## 적용 파이프라인
+
+1. `public/theme-init.js` — 페이지 렌더 전에 `rhwp-settings`를 읽어
+   `data-theme-mode` / `data-theme-effective` / `data-theme-skin`을 세팅한다 (FOUC 방지,
+   확장 CSP 때문에 외부 파일 + 동기 로드 유지).
+2. `src/core/theme.ts` — 런타임 전환. `applyTheme()`가 위 dataset을 갱신하고
+   `syncThemeMenu()`가 메뉴 체크 상태(`data-theme-mode-choice` / `data-theme-skin-choice`)를
+   동기화한다.
+3. `src/core/user-settings.ts` — `theme.mode` / `theme.skin` 저장과 정규화.
+4. CSS cascade — 기본 팔레트(`:root`) → 다크(`:root[data-theme-effective="dark"]`) →
+   스킨 파일(마지막 import). 동일 특이도에서는 후행 로드가 이기므로 스킨의 색 변수는
+   반드시 다크 가드를 건다(아래).
+
+## 새 스킨 추가 체크리스트
+
+`styles/theme-flat.css`(플랫 스킨)를 참조 구현으로 삼는다.
+
+1. `src/styles/theme-<name>.css`를 만들고 `src/style.css` 마지막에 import 한다.
+2. **모든 규칙을 `[data-theme-skin="<name>"]` 아래에 스코프한다.** 속성이 없으면
+   파일 전체가 비활성이어야 한다 (기본 스킨 = 무속성).
+3. **색 변수 재정의는 라이트 가드를 건다**:
+   `:root[data-theme-skin="<name>"]:not([data-theme-effective="dark"]) { … }`.
+   가드 없는 `:root[data-theme-skin]` 블록에는 형태 토큰(`--radius-*`, `--shadow-*`)만
+   허용한다. 다크까지 재정의하는 스킨이라면
+   `:root[data-theme-skin="<name>"][data-theme-effective="dark"]` 블록을 별도로 둔다.
+4. 표면 규칙(배경·보더)은 **토큰 참조만** 사용한다 — 다크에서 색이 자동으로 따라온다.
+5. 배선: `user-settings.ts`의 `ThemeSkin` 유니온·정규화, `theme.ts`, 보기 > 테마 메뉴에
+   `menuitemradio` + `data-theme-skin-choice` 항목, `theme-init.js`의 스킨 판독을 갱신한다.
+6. UI 명칭·접두어는 [rhwp-studio UI 명칭과 CSS 접두어](rhwp_studio_ui_conventions.md)를
+   따르고, 새 DOM을 추가하지 않는 것을 기본으로 한다.
+7. `tests/theme-skin.test.ts`의 정적 검사(스코프·다크 가드)와
+   `tests/user-settings.test.ts`의 설정 왕복 테스트를 통과해야 한다.
+
+## 관련 파일
+
+| 역할 | 파일 |
+| --- | --- |
+| 토큰 정의 | `rhwp-studio/src/styles/base.css` |
+| 스킨 참조 구현 | `rhwp-studio/src/styles/theme-flat.css` |
+| FOUC 방지 초기화 | `rhwp-studio/public/theme-init.js` |
+| 런타임 전환 | `rhwp-studio/src/core/theme.ts` |
+| 설정 저장 | `rhwp-studio/src/core/user-settings.ts` |
+| 스킨 규칙 테스트 | `rhwp-studio/tests/theme-skin.test.ts` |

--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -16,3 +16,17 @@
   최신 head Full CI·CodeQL을 확인한다.
 - #4684 merge 뒤 충돌 해소 commit과 메인터너 보정 이유를 남겨 close한다. #4676은 한글 2022
   오라클 재개방 범위까지 완료 조건을 다시 확인한 뒤 close 여부를 결정한다.
+
+## PR #4714 - Studio 옵트인 플랫 스킨과 테마 제작 가이드
+
+- @keepYaoung의 플랫 스킨은 기본 UI를 바꾸지 않는 `theme.skin=flat` opt-in 경로로, 초기 FOUC
+  방지·런타임 전환·보기 메뉴 radio 상태를 함께 배선한다. 다크 모드에서는 라이트 팔레트를 덮지 않는다.
+- 메인터너 보정 `31d474e1d`는 `package.json` 변경 없이 삭제된 Linux native binding의
+  `glibc`/`musl` lockfile 조건만 최신 `devel` 값으로 복원했다. 스킨 기능과 contributor history는
+  변경하지 않았다.
+- latest code head에서 Studio 테스트 890건, production build, `npm ci --dry-run`, 최신 `devel`
+  merge simulation을 통과했고, GitHub Frontend package gates·CodeQL·Canvas visual diff도 성공했다.
+- 세부 판단은 [PR #4714 review](../pr/archives/pr_4714_review.md)와
+  [메인터너 보정 기록](../pr/archives/pr_4714_review_impl.md)에 보존한다. trailing docs-only head의
+  fast-pass aggregate와 최신 mergeability 확인 뒤 작업지시자 승인에 따라 merge하고, PR comment와
+  branch 정리를 post-merge 절차로 처리한다.

--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -16,17 +16,3 @@
   최신 head Full CI·CodeQL을 확인한다.
 - #4684 merge 뒤 충돌 해소 commit과 메인터너 보정 이유를 남겨 close한다. #4676은 한글 2022
   오라클 재개방 범위까지 완료 조건을 다시 확인한 뒤 close 여부를 결정한다.
-
-## PR #4714 - Studio 옵트인 플랫 스킨과 테마 제작 가이드
-
-- @keepYaoung의 플랫 스킨은 기본 UI를 바꾸지 않는 `theme.skin=flat` opt-in 경로로, 초기 FOUC
-  방지·런타임 전환·보기 메뉴 radio 상태를 함께 배선한다. 다크 모드에서는 라이트 팔레트를 덮지 않는다.
-- 메인터너 보정 `31d474e1d`는 `package.json` 변경 없이 삭제된 Linux native binding의
-  `glibc`/`musl` lockfile 조건만 최신 `devel` 값으로 복원했다. 스킨 기능과 contributor history는
-  변경하지 않았다.
-- latest code head에서 Studio 테스트 890건, production build, `npm ci --dry-run`, 최신 `devel`
-  merge simulation을 통과했고, GitHub Frontend package gates·CodeQL·Canvas visual diff도 성공했다.
-- 세부 판단은 [PR #4714 review](../pr/archives/pr_4714_review.md)와
-  [메인터너 보정 기록](../pr/archives/pr_4714_review_impl.md)에 보존한다. trailing docs-only head의
-  fast-pass aggregate와 최신 mergeability 확인 뒤 작업지시자 승인에 따라 merge하고, PR comment와
-  branch 정리를 post-merge 절차로 처리한다.

--- a/mydocs/pr/archives/pr_4714_review.md
+++ b/mydocs/pr/archives/pr_4714_review.md
@@ -73,5 +73,7 @@ Rust source 변경이 없고 정확한 code candidate의 GitHub CI가 위 범위
 
 ## 최종 권고
 
-메인터너 lockfile 보정과 code candidate CI를 확인했다. 이 trailing review-only 기록의 fast-pass aggregate와
-merge 직전 최신 head 상태를 다시 확인한 뒤, 작업지시자 승인에 따라 merge한다.
+메인터너 lockfile 보정과 code candidate CI를 확인했다. source branch의 오래된 오늘할일 파일은 최신
+`devel`의 같은 날짜 기록과 충돌하므로, 최신 `devel` 병합을 문서만을 위해 강제하지 않고 archive review만
+trailing docs-only 기록으로 남긴다. 해당 head의 fast-pass aggregate와 merge 직전 최신 상태를 다시 확인한
+뒤, 작업지시자 승인에 따라 merge한다.

--- a/mydocs/pr/archives/pr_4714_review.md
+++ b/mydocs/pr/archives/pr_4714_review.md
@@ -1,0 +1,77 @@
+---
+kind: review
+status: active
+canonical: mydocs/pr/archives/pr_4714_review.md
+last_verified: 2026-08-13
+---
+
+# PR #4714 검토 기록 - 옵트인 플랫 스킨과 테마 제작 가이드
+
+## PR 정보
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4714](https://github.com/edwardkim/rhwp/pull/4714) |
+| 작성자 | @keepYaoung (기존 기여자, #4699 merge 이력) |
+| 대상 브랜치 | `devel` |
+| code candidate | `31d474e1db91e27de9177bb7b1564b3ac48e2556` |
+| 작성 시점 참고 상태 | `mergeable=CLEAN`, `MERGEABLE` |
+| 변경 규모 | 12개 파일, +379/-22, contributor 3 commit + 메인터너 1 commit |
+| 관련 논의 | [Discussions #4706](https://github.com/edwardkim/rhwp/discussions/4706) |
+
+PR 본문에는 issue closing keyword가 없으므로, merge 뒤 수동으로 close할 GitHub issue는 없다.
+
+## 변경 범위와 판단
+
+- `theme.skin` (`default`/`flat`)을 사용자 설정에 저장하고, 초기 `theme-init.js`와 런타임
+  `theme.ts`가 같은 `data-theme-skin` 계약으로 적용한다.
+- 보기 메뉴에 스킨 라디오 항목과 접근성 체크 상태 동기화를 추가한다.
+- 플랫 CSS는 스킨 속성 아래로만 범위를 제한하고, 색 팔레트는 다크 모드를 덮지 않도록 라이트 가드를 둔다.
+- 토큰 계층과 새 스킨 등록 절차를 manual에 추가한다.
+
+이번 변경은 Studio UI chrome CSS와 설정 배선만 바꾼다. 문서 Canvas 렌더러, pagination, HWP/HWPX
+serializer는 바꾸지 않으므로 PDF visual sweep은 필요하지 않다. 대신 실제 Studio 브라우저 동작을 확인했다.
+
+## 메인터너 보정
+
+contributor 변경에는 `package.json` 변경 없이 `package-lock.json`의 Linux native binding `libc`
+조건 30줄이 제거돼 있었다. 이 메타데이터가 없으면 glibc/musl 선택 범위가 불필요하게 넓어진다.
+
+- `31d474e1d` `build(studio): Linux 네이티브 바인딩 libc 조건 복원`
+- `@rolldown/binding-*`와 `lightningcss-*`의 `glibc`/`musl` 조건을 최신 `devel` 값으로 정확히 복원했다.
+- 보정은 lockfile 외 기능 코드·테스트·문서를 바꾸지 않았고 contributor commit을 rewrite하지 않았다.
+
+## 검증
+
+### 로컬
+
+- 최신 `upstream/devel` 병합 시뮬레이션은 충돌 없이 통과했고 `git diff --check`도 통과했다.
+- current-base merge simulation에서 `npm test` 890건을 실행해 모두 통과했다.
+- current-base merge simulation에서 `npm run build` (`tsc && vite build`)를 통과했다.
+- 보정 뒤 `npm ci --ignore-scripts --dry-run`을 통과했고, lockfile은 `devel`의 native binding
+  `libc` 메타데이터와 일치한다.
+- headless Chromium에서 저장된 `flat`/`light` 설정의 초기 dataset 적용, 메뉴 radio 체크 상태와
+  localStorage 왕복을 확인했다. 작업지시자는 foreground Vite에서 실제 메뉴·스킨 표시를 직접 확인했다.
+
+### GitHub Actions
+
+code candidate `31d474e1d`의 최신 PR head에서 다음을 확인했다.
+
+- CI run `31691756020`: Frontend package gates 성공(6분 6초), Build & Test aggregate 성공.
+- CodeQL run `31691755844`: JavaScript/TypeScript 분석 성공(2분 43초), Python/Rust 선택 경로 성공.
+- Render Diff run `31691755778`: Canvas visual diff 성공(5분 54초).
+
+Rust source 변경이 없고 정확한 code candidate의 GitHub CI가 위 범위를 완료했으므로, 전체 Cargo 회귀는
+중복 실행하지 않았다.
+
+## 위험과 후속
+
+- 플랫 스킨은 opt-in이며 기본 스킨은 `data-theme-skin` 속성을 제거해 기존 CSS가 그대로 적용된다.
+- 다크 전용 스킨 팔레트는 아직 제공하지 않는다. 새 스킨은
+  [테마 토큰과 스킨 제작 가이드](../../manual/rhwp_studio_theming.md)의 다크 가드 규칙을 따라야 한다.
+- 이 PR은 discussion 제안을 구현한 것이며 별도 issue close 대상은 없다.
+
+## 최종 권고
+
+메인터너 lockfile 보정과 code candidate CI를 확인했다. 이 trailing review-only 기록의 fast-pass aggregate와
+merge 직전 최신 head 상태를 다시 확인한 뒤, 작업지시자 승인에 따라 merge한다.

--- a/mydocs/pr/archives/pr_4714_review_impl.md
+++ b/mydocs/pr/archives/pr_4714_review_impl.md
@@ -35,9 +35,10 @@ last_verified: 2026-08-13
 3. lockfile 보정 commit을 만들고 `GIT_LFS_SKIP_PUSH=1` dry-run을 통과했다.
 4. 승인 뒤 contributor source branch에 `31d474e1d`를 push했다.
 5. 최신 code head의 Frontend package gates, CodeQL, Canvas visual diff와 aggregate 성공을 확인했다.
-6. 이 archive review·오늘할일을 trailing docs-only commit으로 추가한 뒤 fast-pass aggregate와
-   mergeable 상태를 다시 확인한다.
-7. 작업지시자 승인에 따라 merge한 뒤 PR comment, `devel` 동기화, review branch 정리를 수행한다.
+6. archive review를 trailing docs-only commit으로 추가한다. source branch의 오늘할일 파일은 최신
+   `devel`의 같은 날짜 기록과 충돌하므로, 문서만을 위해 최신 `devel` 병합을 강제하지 않는다.
+7. fast-pass aggregate와 mergeable 상태를 다시 확인한다.
+8. 작업지시자 승인에 따라 merge한 뒤 PR comment, `devel` 동기화, review branch 정리를 수행한다.
 
 ## 되돌리기 범위
 

--- a/mydocs/pr/archives/pr_4714_review_impl.md
+++ b/mydocs/pr/archives/pr_4714_review_impl.md
@@ -1,0 +1,45 @@
+---
+kind: implementation-record
+status: active
+canonical: mydocs/pr/archives/pr_4714_review_impl.md
+last_verified: 2026-08-13
+---
+
+# PR #4714 메인터너 보정 및 처리 기록
+
+## 목적
+
+옵트인 플랫 스킨의 기능 변경은 유지하면서, 의존성 선언 변경 없이 삭제된 Linux native binding의
+`libc` lockfile 조건만 복원한다. contributor source history를 재작성하지 않고 동일 PR head 위에
+메인터너 commit을 추가한다.
+
+## 적용 순서
+
+| 순서 | SHA | 내용 |
+| --- | --- | --- |
+| 1 | `cfd6505ed` | 플랫 스킨, 설정 배선, 메뉴와 정적 테스트 추가 |
+| 2 | `406171db5` | 테마 토큰·스킨 제작 가이드 추가 |
+| 3 | `b63d2f3aa` | submenu clipping 수정 |
+| 4 | `31d474e1d` | 메인터너: Linux `glibc`/`musl` lockfile 조건 복원 |
+
+## 보정 근거
+
+`package.json`에 의존성 변경이 없는데 `package-lock.json`에서 native optional package의 `libc`
+필드만 삭제됐다. 이 변경은 기능 범위와 무관하며 Linux별 optional binary 선택을 넓힌다.
+`31d474e1d`는 최신 `devel`의 동일 메타데이터를 복원해 설치 결정성을 유지한다.
+
+## 실행 단계
+
+1. contributor remote ref, PR head, visibility review branch가 `b63d2f3aa`로 같은지 확인했다.
+2. `maintainerCanModify=true`와 LFS 비대상(`package-lock.json`)을 확인했다.
+3. lockfile 보정 commit을 만들고 `GIT_LFS_SKIP_PUSH=1` dry-run을 통과했다.
+4. 승인 뒤 contributor source branch에 `31d474e1d`를 push했다.
+5. 최신 code head의 Frontend package gates, CodeQL, Canvas visual diff와 aggregate 성공을 확인했다.
+6. 이 archive review·오늘할일을 trailing docs-only commit으로 추가한 뒤 fast-pass aggregate와
+   mergeable 상태를 다시 확인한다.
+7. 작업지시자 승인에 따라 merge한 뒤 PR comment, `devel` 동기화, review branch 정리를 수행한다.
+
+## 되돌리기 범위
+
+보정 자체의 회귀가 확인되면 contributor 기능 commit이 아니라 `31d474e1d`만 revert한다. 스킨 기능의
+문제가 확인되면 해당 기능을 별도 후속 PR에서 다루며, contributor commit을 rebase·amend·force-push하지 않는다.

--- a/rhwp-studio/index.html
+++ b/rhwp-studio/index.html
@@ -96,6 +96,9 @@
               <div class="md-item" role="menuitemradio" data-cmd="view:theme-system" data-theme-mode-choice="system"><span class="md-icon"></span><span class="md-label">시스템 설정</span></div>
               <div class="md-item" role="menuitemradio" data-cmd="view:theme-light" data-theme-mode-choice="light"><span class="md-icon"></span><span class="md-label">밝게</span></div>
               <div class="md-item" role="menuitemradio" data-cmd="view:theme-dark" data-theme-mode-choice="dark"><span class="md-icon"></span><span class="md-label">어둡게</span></div>
+              <div class="md-sep"></div>
+              <div class="md-item" role="menuitemradio" data-cmd="view:skin-default" data-theme-skin-choice="default"><span class="md-icon"></span><span class="md-label">기본 스킨</span></div>
+              <div class="md-item" role="menuitemradio" data-cmd="view:skin-flat" data-theme-skin-choice="flat"><span class="md-icon"></span><span class="md-label">플랫 스킨</span></div>
             </div>
           </div>
           <div class="md-sep"></div>

--- a/rhwp-studio/package-lock.json
+++ b/rhwp-studio/package-lock.json
@@ -1913,9 +1913,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1933,9 +1930,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1953,9 +1947,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1973,9 +1964,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1993,9 +1981,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2013,9 +1998,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4940,9 +4922,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4964,9 +4943,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4988,9 +4964,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5012,9 +4985,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/rhwp-studio/package-lock.json
+++ b/rhwp-studio/package-lock.json
@@ -1828,6 +1828,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1845,6 +1848,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1947,6 +1953,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1964,6 +1973,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1981,6 +1993,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1998,6 +2013,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4817,6 +4835,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4838,6 +4859,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4859,6 +4883,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4880,6 +4907,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/rhwp-studio/public/theme-init.js
+++ b/rhwp-studio/public/theme-init.js
@@ -8,13 +8,16 @@
   const root = document.documentElement;
   const isThemeMode = (value) => value === 'system' || value === 'light' || value === 'dark';
   let mode = 'system';
+  let skin = 'default';
   try {
     const settings = JSON.parse(localStorage.getItem('rhwp-settings') || '{}');
     const storedMode = settings && settings.theme && settings.theme.mode;
     if (isThemeMode(storedMode)) mode = storedMode;
+    if (settings && settings.theme && settings.theme.skin === 'flat') skin = 'flat';
   } catch {
     mode = 'system';
   }
+  if (skin !== 'default') root.dataset.themeSkin = skin;
   const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
   const effective = mode === 'dark' || (mode === 'system' && prefersDark) ? 'dark' : 'light';
   const scheme = `only ${effective}`;

--- a/rhwp-studio/src/command/commands/view.ts
+++ b/rhwp-studio/src/command/commands/view.ts
@@ -1,6 +1,6 @@
 import type { CommandDef } from '../types';
-import { setThemeMode, syncThemeMenu, type EffectiveTheme } from '../../core/theme';
-import { userSettings, type ThemeMode } from '../../core/user-settings';
+import { setThemeMode, setThemeSkin, syncThemeMenu, type EffectiveTheme } from '../../core/theme';
+import { userSettings, type ThemeMode, type ThemeSkin } from '../../core/user-settings';
 import { GridSettingsDialog } from '../../ui/grid-settings-dialog';
 import {
   type GridOffsetMm,
@@ -34,6 +34,19 @@ function themeModeCommand(mode: ThemeMode, label: string): CommandDef {
       const effective: EffectiveTheme = setThemeMode(mode);
       syncThemeMenu(mode);
       services.eventBus.emit('theme-changed', { mode, effective });
+      services.eventBus.emit('document-view-changed');
+    },
+  };
+}
+
+function themeSkinCommand(skin: ThemeSkin, label: string): CommandDef {
+  return {
+    id: `view:skin-${skin}`,
+    label,
+    execute(services) {
+      const effective: EffectiveTheme = setThemeSkin(skin);
+      syncThemeMenu();
+      services.eventBus.emit('theme-changed', { mode: userSettings.getThemeSettings().mode, effective });
       services.eventBus.emit('document-view-changed');
     },
   };
@@ -204,6 +217,8 @@ export const viewCommands: CommandDef[] = [
   themeModeCommand('system', '시스템 설정'),
   themeModeCommand('light', '밝게'),
   themeModeCommand('dark', '어둡게'),
+  themeSkinCommand('default', '기본 스킨'),
+  themeSkinCommand('flat', '플랫 스킨'),
   // ─── 보기 메뉴: 표시/숨기기 ─────────────────────────
   {
     id: 'view:form-mode',

--- a/rhwp-studio/src/core/theme.ts
+++ b/rhwp-studio/src/core/theme.ts
@@ -1,4 +1,4 @@
-import { userSettings, type ThemeMode } from './user-settings';
+import { userSettings, type ThemeMode, type ThemeSkin } from './user-settings';
 
 export type EffectiveTheme = 'light' | 'dark';
 
@@ -34,14 +34,25 @@ export function getEffectiveTheme(mode: ThemeMode = getThemeMode()): EffectiveTh
   return prefersDark() ? 'dark' : 'light';
 }
 
+export function getThemeSkin(): ThemeSkin {
+  return userSettings.getThemeSettings().skin;
+}
+
 export function applyTheme(mode: ThemeMode = getThemeMode()): EffectiveTheme {
   const effective = getEffectiveTheme(mode);
   const root = document.documentElement;
   root.dataset.themeMode = mode;
   root.dataset.themeEffective = effective;
+  applyThemeSkin(root);
   syncBrowserColorScheme(root, effective);
   syncThemeColorMeta(root);
   return effective;
+}
+
+/** 스킨을 root data 속성으로 반영한다. 기본 스킨은 속성을 제거해 CSS 미적용 상태로 둔다. */
+function applyThemeSkin(root: HTMLElement, skin: ThemeSkin = getThemeSkin()): void {
+  if (skin === 'default') delete root.dataset.themeSkin;
+  else root.dataset.themeSkin = skin;
 }
 
 export function setThemeMode(mode: ThemeMode): EffectiveTheme {
@@ -49,9 +60,20 @@ export function setThemeMode(mode: ThemeMode): EffectiveTheme {
   return applyTheme(mode);
 }
 
-export function syncThemeMenu(mode: ThemeMode = getThemeMode()): void {
+export function setThemeSkin(skin: ThemeSkin): EffectiveTheme {
+  userSettings.setThemeSkin(skin);
+  // 스킨 변경 후 theme-color meta 등 파생 값도 함께 갱신한다.
+  return applyTheme();
+}
+
+export function syncThemeMenu(mode: ThemeMode = getThemeMode(), skin: ThemeSkin = getThemeSkin()): void {
   for (const item of document.querySelectorAll<HTMLElement>('[data-theme-mode-choice]')) {
     const active = item.dataset.themeModeChoice === mode;
+    item.classList.toggle('active', active);
+    item.setAttribute('aria-checked', String(active));
+  }
+  for (const item of document.querySelectorAll<HTMLElement>('[data-theme-skin-choice]')) {
+    const active = item.dataset.themeSkinChoice === skin;
     item.classList.toggle('active', active);
     item.setAttribute('aria-checked', String(active));
   }

--- a/rhwp-studio/src/core/user-settings.ts
+++ b/rhwp-studio/src/core/user-settings.ts
@@ -30,10 +30,15 @@ export interface FontSettings {
 /** 앱 UI 테마 설정값 */
 export type ThemeMode = 'system' | 'light' | 'dark';
 
+/** 앱 UI 스킨 설정값 — 'flat' 은 옵트인 플랫 스킨(theme-flat.css) */
+export type ThemeSkin = 'default' | 'flat';
+
 /** 앱 UI 테마 설정 */
 export interface ThemeSettings {
   /** 사용자가 선택한 테마 모드 */
   mode: ThemeMode;
+  /** 사용자가 선택한 스킨 */
+  skin: ThemeSkin;
 }
 
 /** 대화상자 UI 설정 */
@@ -131,6 +136,7 @@ function defaultSettings(): AppSettings {
     },
     theme: {
       mode: 'system',
+      skin: 'default',
     },
     dialog: {
       picturePropsKeepRatio: true,
@@ -152,6 +158,10 @@ function defaultSettings(): AppSettings {
 
 function normalizeThemeMode(value: unknown): ThemeMode {
   return value === 'light' || value === 'dark' || value === 'system' ? value : 'system';
+}
+
+function normalizeThemeSkin(value: unknown): ThemeSkin {
+  return value === 'flat' ? value : 'default';
 }
 
 function normalizeBoolean(value: unknown, fallback: boolean): boolean {
@@ -192,6 +202,7 @@ class UserSettingsService {
           ...defaults.theme,
           ...(parsed.theme ?? {}),
           mode: normalizeThemeMode(parsed.theme?.mode),
+          skin: normalizeThemeSkin(parsed.theme?.skin),
         },
         dialog: {
           ...defaults.dialog,
@@ -279,6 +290,12 @@ class UserSettingsService {
   /** 테마 모드 설정 */
   setThemeMode(mode: ThemeMode): void {
     this.data.theme.mode = normalizeThemeMode(mode);
+    this.save();
+  }
+
+  /** 스킨 설정 */
+  setThemeSkin(skin: ThemeSkin): void {
+    this.data.theme.skin = normalizeThemeSkin(skin);
     this.save();
   }
 

--- a/rhwp-studio/src/style.css
+++ b/rhwp-studio/src/style.css
@@ -23,6 +23,7 @@
 @import './styles/command-palette.css';
 @import './styles/compare-dialog.css';
 @import './styles/responsive.css';
+@import './styles/theme-flat.css';
 
 /* ── 브리지 창 제어 (chrome-v1) ──────────────────────────────
    표시만 끈다. 커맨드 레지스트리와 단축키는 그대로 살아 있어 외부 JS 제어가 계속 동작한다. */

--- a/rhwp-studio/src/styles/theme-flat.css
+++ b/rhwp-studio/src/styles/theme-flat.css
@@ -57,7 +57,7 @@
   --ruler-marker: #2b7de9;
 }
 
-/* 라운드/그림자: 색이 아닌 형태 값이므로 라이트·다크 공통 적용 */
+/* 라운드/그림자/UI 글꼴: 색이 아닌 형태 값이므로 라이트·다크 공통 적용 */
 :root[data-theme-skin="flat"] {
   --radius-sm: 4px;
   --radius-md: 6px;
@@ -65,6 +65,10 @@
   --shadow-dropdown: 0 4px 16px rgba(15, 30, 60, 0.12);
   --shadow-dialog: 0 8px 28px rgba(15, 30, 60, 0.16);
   --shadow-light: 0 2px 8px rgba(15, 30, 60, 0.1);
+  /* UI 크롬 글꼴만 바꾼다 — 문서 본문 렌더링 글꼴과 무관한 토큰이다.
+     Pretendard 는 번들하지 않고, 사용자 시스템에 설치된 경우에만 우선 사용한다. */
+  --font-family-ui: 'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont,
+    '맑은 고딕', 'Malgun Gothic', 'Segoe UI', sans-serif;
 }
 
 /* ── 크롬 표면: 변수 참조라 다크 모드에서도 안전 ───────── */

--- a/rhwp-studio/src/styles/theme-flat.css
+++ b/rhwp-studio/src/styles/theme-flat.css
@@ -105,12 +105,14 @@
   border-top: 1px solid var(--ui-border-subtle);
 }
 
-/* ── 메뉴 드롭다운: 라운드 카드 ────────────────────────── */
-[data-theme-skin="flat"] #menu-bar .menu-dropdown {
+/* ── 메뉴 드롭다운: 라운드 카드 ──────────────────────────
+ * 주의: .md-sub-panel 이 드롭다운 밖(left: 100%)에 absolute 로 뜨므로
+ * 여기에 overflow: hidden 을 걸면 서브메뉴가 잘려 보이지 않는다. */
+[data-theme-skin="flat"] #menu-bar .menu-dropdown,
+[data-theme-skin="flat"] #menu-bar .md-sub-panel {
   border: 1px solid var(--ui-border-subtle);
   border-radius: var(--radius-lg);
   padding: 4px;
-  overflow: hidden;
 }
 
 [data-theme-skin="flat"] #menu-bar .md-item {

--- a/rhwp-studio/src/styles/theme-flat.css
+++ b/rhwp-studio/src/styles/theme-flat.css
@@ -1,0 +1,114 @@
+/* 플랫 스킨 (옵트인) — 보기 > 테마 > "플랫 스킨"
+ *
+ * theme-init.js / core/theme.ts 가 설정(theme.skin)에 따라 root 에
+ * `data-theme-skin="flat"` 을 붙일 때만 적용된다. 기본 스킨은 속성이 없어
+ * 이 파일 전체가 비활성이다.
+ *
+ * - 변수 팔레트는 라이트 전용으로 재정의한다. 다크 모드에서는
+ *   `:not([data-theme-effective="dark"])` 가드로 비활성화되어 base.css 의
+ *   다크 팔레트가 그대로 유지된다 (동일 특이도 후행 로드로 다크를 덮는 사고 방지).
+ * - 표면/라운딩 규칙은 변수만 참조하므로 다크에서도 형태(플랫 보더·라운딩)만
+ *   적용되고 색은 다크 팔레트를 따른다.
+ * - 새 DOM/접두어 없이 기존 명칭(#menu-bar, #icon-toolbar, #style-bar,
+ *   #status-bar — rhwp_studio_ui_conventions.md)만 스타일링한다.
+ */
+
+:root[data-theme-skin="flat"]:not([data-theme-effective="dark"]) {
+  /* 표면: 회색 크롬 → 화이트 */
+  --ui-bg: #ffffff;
+  --ui-bg-light: #ffffff;
+  --ui-surface-raised: #ffffff;
+  --ui-surface-muted: #f1f3f6;
+  --ui-toolbar-bg-start: #ffffff;
+  --ui-toolbar-bg-end: #ffffff;
+
+  /* 경계선: 옅은 쿨그레이 */
+  --ui-border: #dde2e8;
+  --ui-border-light: #e3e7ec;
+  --ui-border-subtle: #e9ecf1;
+  --ui-border-strong: #ccd3db;
+
+  /* 상호작용: 옅은 블루 틴트 */
+  --ui-hover: #f1f4f8;
+  --ui-hover-strong: #e9f0fb;
+  --ui-active: #e0ebfa;
+  --ui-selected: #e8f1fe;
+  --ui-menu-open: #1b72e8;
+  --ui-menu-open-border: #1b72e8;
+
+  /* 액센트 블루 */
+  --accent-primary: #2b7de9;
+  --accent-strong: #1b66cf;
+  --accent-light: #4a94f0;
+  --accent-hover: #a8c8f5;
+  --accent-subtle: #5b90e0;
+  --focus-ring: #2b7de9;
+  --ui-link: #1b66cf;
+
+  /* 문서 작업 영역 */
+  --doc-workspace: #eef0f4;
+  --doc-shadow: rgba(20, 35, 60, 0.1);
+
+  /* 눈금자 */
+  --ruler-bg: #f7f8fa;
+  --ruler-body: #ffffff;
+  --ruler-tick: #8a93a0;
+  --ruler-text: #6b7480;
+  --ruler-marker: #2b7de9;
+}
+
+/* 라운드/그림자: 색이 아닌 형태 값이므로 라이트·다크 공통 적용 */
+:root[data-theme-skin="flat"] {
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --shadow-dropdown: 0 4px 16px rgba(15, 30, 60, 0.12);
+  --shadow-dialog: 0 8px 28px rgba(15, 30, 60, 0.16);
+  --shadow-light: 0 2px 8px rgba(15, 30, 60, 0.1);
+}
+
+/* ── 크롬 표면: 변수 참조라 다크 모드에서도 안전 ───────── */
+[data-theme-skin="flat"] #menu-bar {
+  background: var(--ui-surface);
+  border-bottom: 1px solid var(--ui-border-subtle);
+}
+
+[data-theme-skin="flat"] #icon-toolbar {
+  background: var(--ui-surface);
+  border-top: none;
+  border-bottom: 1px solid var(--ui-border-subtle);
+}
+
+[data-theme-skin="flat"] #icon-toolbar .tb-btn {
+  border-radius: var(--radius-md);
+}
+
+[data-theme-skin="flat"] #icon-toolbar .tb-btn:hover {
+  background: var(--ui-hover-strong);
+}
+
+[data-theme-skin="flat"] #icon-toolbar .tb-sep {
+  background: var(--ui-border-subtle);
+}
+
+[data-theme-skin="flat"] #style-bar {
+  background: var(--ui-surface);
+  border-bottom: 1px solid var(--ui-border-subtle);
+}
+
+[data-theme-skin="flat"] #status-bar {
+  background: var(--ui-surface);
+  border-top: 1px solid var(--ui-border-subtle);
+}
+
+/* ── 메뉴 드롭다운: 라운드 카드 ────────────────────────── */
+[data-theme-skin="flat"] #menu-bar .menu-dropdown {
+  border: 1px solid var(--ui-border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 4px;
+  overflow: hidden;
+}
+
+[data-theme-skin="flat"] #menu-bar .md-item {
+  border-radius: var(--radius-md);
+}

--- a/rhwp-studio/tests/theme-skin.test.ts
+++ b/rhwp-studio/tests/theme-skin.test.ts
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+test('플랫 스킨 CSS의 모든 규칙은 data-theme-skin="flat" 스코프 아래에 있다', () => {
+  const css = source('src/styles/theme-flat.css');
+  const selectors = css
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('}')
+    .map((block) => block.split('{')[0]?.trim())
+    .filter((selector): selector is string => !!selector);
+
+  assert.ok(selectors.length > 0, '규칙이 최소 1개는 있어야 한다');
+  for (const selector of selectors) {
+    assert.match(
+      selector,
+      /\[data-theme-skin="flat"\]/,
+      `옵트인 스코프가 없는 셀렉터: ${selector}`,
+    );
+  }
+});
+
+test('플랫 스킨의 라이트 팔레트는 다크 모드를 덮지 않도록 가드된다', () => {
+  const css = source('src/styles/theme-flat.css');
+  assert.match(css, /:root\[data-theme-skin="flat"\]:not\(\[data-theme-effective="dark"\]\)/);
+  // 색 변수 재정의는 다크 가드 블록에만 존재해야 한다 — 가드 없는 :root 단독 블록의
+  // 변수는 형태 값(radius/shadow)만 허용한다.
+  const ungardedRoot = css.match(/:root\[data-theme-skin="flat"\]\s*\{([\s\S]*?)\}/);
+  if (ungardedRoot) {
+    assert.doesNotMatch(ungardedRoot[1], /--ui-bg|--accent-primary|--ruler-bg/);
+  }
+});
+
+test('보기 메뉴는 스킨 선택 항목을 노출하고 FOUC 방지 스크립트가 스킨을 읽는다', () => {
+  const html = source('index.html');
+  assert.match(html, /data-cmd="view:skin-default"[^>]*data-theme-skin-choice="default"/);
+  assert.match(html, /data-cmd="view:skin-flat"[^>]*data-theme-skin-choice="flat"/);
+
+  const themeInit = source('public/theme-init.js');
+  assert.match(themeInit, /theme\.skin === 'flat'/);
+  assert.match(themeInit, /themeSkin = skin/);
+});

--- a/rhwp-studio/tests/user-settings.test.ts
+++ b/rhwp-studio/tests/user-settings.test.ts
@@ -231,3 +231,43 @@ test('복구용 자동저장 설정은 rhwp-settings에 저장된다', () => {
     (globalThis as { localStorage?: Storage }).localStorage = originalStorage;
   }
 });
+
+test('스킨 설정은 rhwp-settings에 저장되고 잘못된 값은 default로 정규화된다', () => {
+  const originalStorage = (globalThis as { localStorage?: Storage }).localStorage;
+  const store = new Map<string, string>();
+  const mockStorage = {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+  } as Storage;
+
+  (globalThis as { localStorage?: Storage }).localStorage = mockStorage;
+  try {
+    userSettings.setThemeSkin('flat');
+    assert.equal(userSettings.getThemeSettings().skin, 'flat');
+    const stored = JSON.parse(store.get('rhwp-settings') ?? '{}');
+    assert.equal(stored.theme.skin, 'flat');
+
+    // 저장소에 없던 잘못된 값은 setter 정규화로 default가 된다.
+    userSettings.setThemeSkin('neon' as never);
+    assert.equal(userSettings.getThemeSettings().skin, 'default');
+  } finally {
+    userSettings.setThemeSkin('default');
+    (globalThis as { localStorage?: Storage }).localStorage = originalStorage;
+  }
+});


### PR DESCRIPTION
## 제안

[Discussions #4706](https://github.com/edwardkim/rhwp/discussions/4706)에서 제안했던 플랫 스킨을 **옵트인**으로 구현한 PR입니다. 기본값은 기존 모습 그대로이며, 보기 > 테마 > "플랫 스킨"으로 켤 수 있습니다.

**라이브 데모** (이 브랜치 그대로 배포): https://keepyaoung.github.io/rhwp/ — 기본은 순정 UI이고, 보기 > 테마 > 플랫 스킨으로 전환해 보실 수 있습니다.

## 구현

- **순수 CSS 스킨**: `styles/theme-flat.css` — base.css 변수 팔레트 재정의 중심. 모든 규칙이 `[data-theme-skin="flat"]` 스코프 아래에 있어 속성이 없으면(기본 스킨) 파일 전체가 비활성입니다.
- **다크 모드 보존**: 색 변수는 `:not([data-theme-effective="dark"])` 가드로 라이트에만 적용됩니다. 동일 특이도 후행 로드가 다크 팔레트를 덮는 사고를 막기 위한 구조이며, 표면 규칙은 토큰 참조만 사용해 다크에서도 안전합니다.
- **설정/배선**: `theme.skin`(`'default' | 'flat'`)을 rhwp-settings에 저장하고, `theme-init.js`(FOUC 방지)와 `core/theme.ts`가 `data-theme-skin`으로 반영합니다. 보기 > 테마 서브메뉴에 `menuitemradio` 항목과 체크 동기화를 추가했습니다.
- **UI 크롬 글꼴**: 플랫 스킨은 `--font-family-ui`에 Pretendard를 우선 스택으로 지정합니다. 시스템에 설치된 경우에만 사용하고 글꼴 파일은 번들하지 않으며, 문서 본문 렌더링 글꼴과는 무관한 토큰입니다.
- **문서화**: `mydocs/manual/rhwp_studio_theming.md` — 토큰 계층(원시 → 시맨틱), 테마 두 축(mode/skin)과 적용 파이프라인, 새 스킨 추가 체크리스트를 reference로 정리하고 manual 지도에 등록했습니다.

## 검증

- 단위 테스트 9건 통과: 스킨 설정 저장/정규화(`user-settings.test.ts`), CSS 옵트인 스코프·다크 가드 정적 검사, 메뉴 노출·FOUC 스크립트 검사(`theme-skin.test.ts`)
- `tsc` 기준 변경 파일 관련 오류 0건
- 포크 Pages(devel + 이 브랜치) 브라우저 실측: 기본=순정 팔레트 → 플랫 전환(`data-theme-skin=flat`, 설정 저장, 메뉴 체크) → **다크+플랫에서 다크 팔레트 유지**(#7fa8ff/#25292f) → 기본 복귀까지 왕복 확인

피드백 주시면 반영하겠습니다.