### PR TITLE
[로드맵] 트랙 L L6 — 자가검증 계획 템플릿(planner) 세트 (#4718)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -919,6 +919,10 @@ jobs:
       - name: Validate adoption spine contract
         run: python3 -m unittest scripts/tests/test_adoption_spine.py
 
+      # [#4718] 계획 템플릿 형식 계약 — 자가검증 계획 시작점이 스키마를 지키는지.
+      - name: Validate planner templates
+        run: python3 -m unittest scripts/tests/test_planner_templates.py
+
       - name: Clippy
         run: cargo clippy -- -D warnings
 

--- a/mydocs/manual/planner_templates/README.md
+++ b/mydocs/manual/planner_templates/README.md
@@ -1,0 +1,73 @@
+---
+kind: guide
+status: active
+canonical: mydocs/manual/planner_templates/README.md
+last_verified: 2026-08-13
+---
+
+# 계획 템플릿 — 자가검증 편집을 시작점으로
+
+`rhwp run <계획.json>` 이 받는 편집 계획서의 **재사용 가능한 시작점**이다. 에이전트가
+매번 맨 계획을 짜는 대신, 검증 조건을 이미 품은 템플릿에서 출발한다 — 그래서 계획을
+세우면 자연히 증명이 남는다([AGENTS.md 작업 증빙](../../../AGENTS.md#작업-증빙--에이전트-기본-경로-권장)의
+AW-L1 영수증 축).
+
+## 템플릿
+
+| 파일 | 무엇을 | 지목 방식 |
+|---|---|---|
+| [`set_cell.plan.json`](set_cell.plan.json) | 표 칸 기록 | `table·row·col`(0 기준) |
+| [`replace_text.plan.json`](replace_text.plan.json) | 본문 문자열 치환 | `find`(0건이면 선검증 거부) |
+| [`fill_fields.plan.json`](fill_fields.plan.json) | 누름틀 채우기(메일머지) | `필드이름` 또는 `이름[순번]` |
+| [`set_checkbox.plan.json`](set_checkbox.plan.json) | 빈 체크박스 표시 | `occurrence`(0 기준 □ 순번) |
+
+`<...>` 는 채울 자리다. 지목 대상은 실측으로 찾는다: `rhwp fields <문서>`(필드),
+`rhwp export-tables <문서>`(표 좌표), `rhwp search <문서> <문자열>`(치환 대상 존재).
+
+## 쓰는 법 — 계획이 곧 증명이 되게
+
+```bash
+# 1) 템플릿을 복사해 <...> 를 채운다 → my.plan.json
+# 2) 먼저 선검증만 (디스크 무변경)
+rhwp run my.plan.json --dry-run --json
+
+# 3) 실행 (전 step 인메모리 적용 → 단언 통과 시에만 한 번 저장)
+rhwp run my.plan.json --json
+
+# 4) AW-L1 영수증 — 같은 계획을 캡슐과 함께 남긴다(제3자 재현 검증 가능)
+rhwp replay my.plan.json --capsule work.capsule.json --json
+```
+
+`run` 대신 `replay --capsule` 로 실행하면 입력·계획·산출 3해시가 캡슐 하나에 고정돼
+[작업 증빙 사다리](../../../AGENTS.md#작업-증빙--에이전트-기본-경로-권장)의 첫 단(영수증)이
+된다. 연속 작업은 `--parent 이전.capsule.json` 으로 잇는다(계보).
+
+## 자가검증 — 단언(assertions)
+
+각 템플릿은 `assertions.notFoundEmpty: true` 를 기본으로 든다 — 지목한 대상이 하나도
+빠지지 않았음을 요구한다(없는 대상은 실행 전에 `invalid` 로 거절되므로 구조적으로
+보장된다). "성공했다고 보고했는데 산출물이 깨진" 상태를 계획이 스스로 막는다.
+
+**더 강한 검증(옵션)** `assertions.verify: true` — 저장 직전 산출 바이트를 다시 읽어
+인메모리 IR 과 대조하고, 차이가 있으면 `exit 3` 이며 **디스크는 무변경**이다. 이는
+편집이 저장 왕복(save→reload)을 바이트로 견디는 경우에만 통과한다 — 견디지 못하는
+문서·편집에서는 실패하는데, 그것이 곧 저장 충실도 갭을 드러내는 쓸모다(무조건 켜지
+않고, 왕복 안정성이 확인된 워크플로에서 켠다).
+
+## 경합 유실 차단(옵션) — preconditions
+
+계획 수립과 실행 사이에 다른 에이전트/사람이 문서를 바꿀 수 있다. `preconditions`
+축을 더하면 그 유실을 차단한다:
+
+```json
+"preconditions": { "inputSha256": "<원본 SHA-256 64자리>" }
+```
+
+실행 시점의 실제 해시와 다르면 아무것도 적용하지 않고 `preconditionFailed` 로 거절한다.
+해시는 `rhwp-agent fingerprint <문서>` 또는 `sha256sum` 으로 얻는다.
+
+## 판(version) 규약
+
+계획 문법 판번호는 `planVersion: "1.0"`(스키마 판번호와 별개 — `rhwp export-plan-schema`
+의 `planSchemaVersion` 은 1.1). 실행기는 `"1.0"` 만 받는다. 스텝·단언·전제 형식의
+단일 출처는 `rhwp export-plan-schema` 다.

--- a/mydocs/manual/planner_templates/fill_fields.plan.json
+++ b/mydocs/manual/planner_templates/fill_fields.plan.json
@@ -1,0 +1,9 @@
+{
+  "planVersion": "1.0",
+  "input": "<서식.hwp>",
+  "output": "<채운.hwp>",
+  "steps": [
+    { "action": "fill_fields", "data": { "<필드이름>": "<채울 값>", "<동명필드[0]>": "<값>" } }
+  ],
+  "assertions": { "notFoundEmpty": true }
+}

--- a/mydocs/manual/planner_templates/replace_text.plan.json
+++ b/mydocs/manual/planner_templates/replace_text.plan.json
@@ -1,0 +1,9 @@
+{
+  "planVersion": "1.0",
+  "input": "<원본.hwp>",
+  "output": "<산출.hwp>",
+  "steps": [
+    { "action": "replace_text", "find": "<찾을 문자열>", "replace": "<바꿀 값>", "caseSensitive": true }
+  ],
+  "assertions": { "notFoundEmpty": true }
+}

--- a/mydocs/manual/planner_templates/set_cell.plan.json
+++ b/mydocs/manual/planner_templates/set_cell.plan.json
@@ -1,0 +1,9 @@
+{
+  "planVersion": "1.0",
+  "input": "<원본.hwp>",
+  "output": "<산출.hwp>",
+  "steps": [
+    { "action": "set_cell", "table": 0, "row": 0, "col": 0, "text": "<칸에 넣을 값>" }
+  ],
+  "assertions": { "notFoundEmpty": true }
+}

--- a/mydocs/manual/planner_templates/set_checkbox.plan.json
+++ b/mydocs/manual/planner_templates/set_checkbox.plan.json
@@ -1,0 +1,9 @@
+{
+  "planVersion": "1.0",
+  "input": "<원본.hwp>",
+  "output": "<산출.hwp>",
+  "steps": [
+    { "action": "set_checkbox", "occurrence": 0 }
+  ],
+  "assertions": { "notFoundEmpty": true }
+}

--- a/scripts/tests/test_planner_templates.py
+++ b/scripts/tests/test_planner_templates.py
@@ -1,0 +1,65 @@
+"""[#4718] 계획 템플릿 계약 — mydocs/manual/planner_templates/*.plan.json.
+
+템플릿은 에이전트가 복사해 쓰는 시작점이다. 형식이 깨진 템플릿은 조용히
+에이전트를 헛돌게 하므로, 매 CI 마다 **계획 스키마 형식**을 지킨다. 바이너리
+없이 커밋된 JSON 만 본다 — `rhwp export-plan-schema` 의 형식과 대조한다.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATES = REPO_ROOT / "mydocs" / "manual" / "planner_templates"
+
+#: 계획 스텝의 action 과 그 필수 필드(export-plan-schema $defs 와 일치).
+STEP_REQUIRED = {
+    "set_cell": ("table", "row", "col", "text"),
+    "replace_text": ("find", "replace"),
+    "fill_fields": ("data",),
+    "set_checkbox": ("occurrence",),
+}
+
+
+def template_files():
+    return sorted(TEMPLATES.glob("*.plan.json"))
+
+
+class PlannerTemplateTests(unittest.TestCase):
+    def test_templates_exist(self):
+        self.assertGreaterEqual(len(template_files()), 4,
+                                "계획 템플릿이 줄었다면 이관 사고를 의심하라")
+
+    def test_every_template_is_a_valid_plan(self):
+        for path in template_files():
+            with self.subTest(template=path.name):
+                plan = json.loads(path.read_text(encoding="utf-8"))
+                # 계획서 필수 키
+                for key in ("planVersion", "input", "output", "steps"):
+                    self.assertIn(key, plan, f"{path.name}: 필수 키 {key} 없음")
+                self.assertEqual(plan["planVersion"], "1.0",
+                                 f"{path.name}: planVersion 은 '1.0'")
+                self.assertTrue(plan["steps"], f"{path.name}: steps 가 비었다")
+                for i, step in enumerate(plan["steps"]):
+                    action = step.get("action")
+                    self.assertIn(action, STEP_REQUIRED,
+                                  f"{path.name} step{i}: 미지 action {action}")
+                    for field in STEP_REQUIRED[action]:
+                        self.assertIn(field, step,
+                                      f"{path.name} step{i}: {action} 에 {field} 없음")
+
+    def test_every_template_carries_a_self_verification_assertion(self):
+        """계획이 스스로 검증 조건을 들고 다니게 — 템플릿은 단언을 뺀 채 배포하지 않는다."""
+        for path in template_files():
+            with self.subTest(template=path.name):
+                plan = json.loads(path.read_text(encoding="utf-8"))
+                assertions = plan.get("assertions", {})
+                self.assertTrue(
+                    assertions.get("notFoundEmpty") or assertions.get("verify"),
+                    f"{path.name}: assertions.notFoundEmpty(또는 verify)가 없다")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 무엇을 / 왜

트랙 L L6. 에이전트가 `rhwp run <계획.json>` 으로 편집을 선언할 때, 검증 조건을 이미 품은 **재사용 시작점**에서 출발하게 한다 — 계획을 세우면 자연히 증명이 남는다(AW-L1 영수증). 이슈 #4718.

## 산출물

`mydocs/manual/planner_templates/` — 4개 스텝의 자가검증 계획 템플릿 + README + 형식 계약 테스트.

| 템플릿 | 스텝 |
|---|---|
| `set_cell.plan.json` | 표 칸 기록 |
| `replace_text.plan.json` | 본문 치환 |
| `fill_fields.plan.json` | 누름틀 채우기 |
| `set_checkbox.plan.json` | 체크박스 표시 |

각 템플릿은 `assertions.notFoundEmpty` 를 기본으로 든다 — "성공 보고했는데 산출물 깨짐"을 구조적으로 막는다. README 는 대상 실측(`fields`/`export-tables`/`search`) → 채움 → `run` → **`replay --capsule` 로 영수증** 흐름과, 옵션 `verify`·`preconditions.inputSha256` 를 안내한다.

## 검증

```
계획 템플릿 계약:  3 passed, 8 subtests (스키마 형식·자가검증 단언, 바이너리 불요)
CI 배선:          "Validate planner templates" 스텝 추가
문서 메타데이터:  이상 없음 · 마크다운 링크 5 passed
run <template> --dry-run: 실제 실행 확인(set_cell 채운 예시로 preview 1항목 통과)
```

## 정직

`verify:true` 는 편집이 저장 왕복(save→reload)을 바이트로 견디는 경우에만 통과한다 — 실측상 일부 문서·편집에서 실패하며, 그것이 곧 저장 충실도 갭을 드러내는 쓸모다. 그래서 템플릿 기본은 `notFoundEmpty` 이고 `verify` 는 왕복 안정성이 확인된 워크플로에서 켜는 옵션으로 안내한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
