### PR TITLE
[MCP] 축 리소스 2종 — roadmap·gym 을 MCP 리소스로 (트랙 L L4)

### DIFF
--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -813,7 +813,8 @@ const DOC_RESOURCES: &[DocResource] = &[
         uri: "rhwp://docs/gym",
         name: "gym-readme",
         title: "rhwp 에이전트 운동장 (gym)",
-        description: "에이전트가 실문서로 실력을 겨루고 기록으로 남기는 벤치마크 — 과제판·채점·리더보드.",
+        description:
+            "에이전트가 실문서로 실력을 겨루고 기록으로 남기는 벤치마크 — 과제판·채점·리더보드.",
         mime_type: "text/markdown",
         text: include_str!("../gym/README.md"),
     },

--- a/src/mcp_serve.rs
+++ b/src/mcp_serve.rs
@@ -798,6 +798,25 @@ const DOC_RESOURCES: &[DocResource] = &[
         mime_type: "text/markdown",
         text: include_str!("../mydocs/manual/recipes/06_visual_regression_before_after.md"),
     },
+    // [트랙 L L4] 축 리소스 2종 — 프로젝트가 어디로 가는지(로드맵)와 실력을 어떻게
+    // 재는지(gym)를 MCP resources/read 로 직접 읽게 노출한다. 순수 DOC_RESOURCES
+    // 추가이므로 served_resources()/read_resource() 가 자동으로 목록·읽기한다.
+    DocResource {
+        uri: "rhwp://docs/roadmap",
+        name: "roadmap-atlas",
+        title: "rhwp 에이전트 로드맵 아틀라스 (R1~R200)",
+        description: "에이전트-네이티브 로드맵 전 단계의 한 화면 지도 — 무엇을·왜·다음.",
+        mime_type: "text/markdown",
+        text: include_str!("../mydocs/tech/agent_roadmap/atlas_r1_r200.md"),
+    },
+    DocResource {
+        uri: "rhwp://docs/gym",
+        name: "gym-readme",
+        title: "rhwp 에이전트 운동장 (gym)",
+        description: "에이전트가 실문서로 실력을 겨루고 기록으로 남기는 벤치마크 — 과제판·채점·리더보드.",
+        mime_type: "text/markdown",
+        text: include_str!("../gym/README.md"),
+    },
 ];
 
 /// [#3627 잔여] 스키마 리소스 — 본문이 파일이 아니라 **생성기**다.


### PR DESCRIPTION
## 무엇을 / 왜

트랙 L L4. MCP 로 rhwp 를 붙인 에이전트가 **로드맵**(어디로 가는지)과 **운동장**(실력을 어떻게 재는지)을 재파싱 없이 리소스로 직접 읽게 한다 — 채택 축을 MCP 표면에 노출한다.

## 변경 — DOC_RESOURCES 2종 추가(핸들러 무변경)

`src/mcp_serve.rs` 의 `const DOC_RESOURCES` 에 두 항목을 추가(+19줄, 1파일). `served_resources()`·`read_resource()` 가 배열을 순회하므로 **자동 목록·읽기** — dispatch·capabilities·spec-ledger 무변경(serve-methods 그대로).

| URI | 본문(include_str!) |
|---|---|
| `rhwp://docs/roadmap` | `mydocs/tech/agent_roadmap/atlas_r1_r200.md` |
| `rhwp://docs/gym` | `gym/README.md` |

`rhwp://docs/standard`(AWS 표준)은 devel 미착지라 이번엔 제외 — #4716 머지 후 후속.

## 검증 (실측)

```
cargo build --bin rhwp:        Finished (1m32s), exit 0
mcp_resources_contract:        3 passed   (generic every_listed_resource_reads_back 가 신규 2종 자동 커버)
mcp_server_contract:           24 passed
mcp_spec_ledger_contract:      4 passed
런타임 resources/list:         rhwp://docs/roadmap(size 37569)·rhwp://docs/gym(size 15648) 광고
런타임 resources/read:         각 non-empty markdown 반환
```

## 정직·합법성

커밋된 문서의 투영이라 새 진실 0. 리소스는 공개·옵트인(MCP 클라이언트가 목록을 봄). 도구 무관 — 다른 경로를 막지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
