### PR TITLE
docs(roadmap): 트랙 B R21 — 파서 재귀 깊이 하드닝 (HWPX·HWP5) 등재

### DIFF
--- a/mydocs/tech/agent_roadmap/README.md
+++ b/mydocs/tech/agent_roadmap/README.md
@@ -97,7 +97,7 @@ R61(바인딩 표류)·R76(문서 지능 서버)은 머지 실적이 아니라 �
 | 트랙 | 질문 | 문서 |
 |---|---|---|
 | A (R1~10) | 봉투를 믿을 수 있는가 — L1 무결 | [track_a_envelope.md](track_a_envelope.md) |
-| B (R11~20) | 가드와 보안이 구멍을 먼저 찾는가 — L2 | [track_b_guards_security.md](track_b_guards_security.md) |
+| B (R11~21) | 가드와 보안이 구멍을 먼저 찾는가 — L2 | [track_b_guards_security.md](track_b_guards_security.md) |
 | C (R21~30) | 에이전트 여럿이 안전한가 — L2 동시성 | [track_c_concurrency.md](track_c_concurrency.md) |
 | D (R31~40) | 처음 온 에이전트가 길을 찾는가 — L3 | [track_d_discovery.md](track_d_discovery.md) |
 | E (R41~50) | 실물 문서를 실제로 다루는가 | [track_e_capabilities.md](track_e_capabilities.md) |

--- a/mydocs/tech/agent_roadmap/track_b_guards_security.md
+++ b/mydocs/tech/agent_roadmap/track_b_guards_security.md
@@ -2,10 +2,10 @@
 kind: guide
 status: active
 canonical: mydocs/tech/agent_roadmap/track_b_guards_security.md
-last_verified: 2026-08-04
+last_verified: 2026-08-13
 ---
 
-# 트랙 B — 가드·보안 (R11~R20)
+# 트랙 B — 가드·보안 (R11~R21)
 
 **질문**: 구멍을 사람이 아니라 가드가 먼저 찾는가. 그리고 문서가 에이전트를
 조종하는 경로(보안 축의 정의, `agent_security/threat_model.md`)가 닫혀 있는가.
@@ -178,3 +178,29 @@ last_verified: 2026-08-04
 - **DoD** — `capabilities` 가 명령별 가드 커버리지를 싣고, 그 값이 R10 메타 가드의
   산출과 단일 출처로 묶여 드리프트 가드가 불일치를 잡는다.
 - **의존** — 트랙 A R10(메타 가드가 커버리지를 계산).
+
+## R21 파서 재귀 깊이 하드닝 (HWPX·HWP5) `[실측]`
+
+- **한 줄** — 파일이 정하는 중첩 깊이로 무한 재귀하는 파서 경로에 상한을 둬,
+  악성 문서 하나로 나는 스택 오버플로(패닉과 달리 `catch_unwind` 로 못 잡는 하드
+  크래시)를 막는다.
+- **지금** — 착지: PR #4731 이 HWPX `<hp:container>` 자기재귀에 `MAX_HWPX_CONTAINER_DEPTH
+  =256` 을 얹었다(이슈 #4730 의 발견 1/4, HIGH). 정적 분석으로 같은 버그 클래스의
+  네 경로를 실측했고, 나머지 셋은 후속 슬롯으로 남는다:
+  - **#2 (HIGH)** — 표 중첩 사이클 `parse_paragraph`↔`parse_table`↔`parse_table_cell`
+    (+ drawText 글상자·subList 각주 경유). 공유 깊이 카운터가 전역이어야 우회를 막는다.
+  - **#3 (MED)** — HWP5 `parse_container_children`(`control/shape.rs:815`). `level`(10비트)로
+    암묵 제한되나 wasm(~1MB)·2MB 스레드에서 오버플로 가능.
+  - **#4 (MED)** — HWP5 표 재귀(`control.rs:248`↔`:149`↔`body_text::parse_paragraph_list`).
+    중첩당 ~6 프레임이라 max level 안에서도 2MB 스택(~330겹)을 넘긴다.
+- **설계(보장)** — 상한은 메인테이너가 이미 세운 형제 선례와 **같은 값·같은 방식**
+  이다: HWP3 `MAX_DRAWING_OBJECT_DEPTH=256`(#4285)·HML `HmlLimits::max_depth=256`.
+  새 정책이 아니라 누락된 형제 경로에 기존 정책을 복제한다. 회귀 테스트는 상한
+  초과=거부/정상 깊이=통과를 짝으로 고정한다(가드 과잉 차단 방지). 디버그 프레임이
+  큰 경로는 넉넉한 스택 전용 스레드에서 경계를 결정적으로 시험한다.
+- **착수 게이트** — 없음(발견·재현 완료). #2 는 `parse_paragraph` 계열에 깊이 카운터를
+  관통시키는 범위가 넓어 단독 PR 로 분리한다.
+- **DoD** — 발견 2~4 가 각각 상한 + 회귀 테스트와 함께 머지되고, 발견 크래시는
+  R13 악성 코퍼스·R17 퍼징 CI 의 회귀 케이스로 흘러든다.
+- **의존** — R13(회귀 착지점)·R17(퍼징이 같은 계열 크래시의 상시 유입원). 선례는
+  HWP3 #4285·HML `max_depth`.


### PR DESCRIPTION
## 무엇을 / 왜

트랙 B(가드·보안)에 **R21 — 파서 재귀 깊이 하드닝**을 등재한다. 정적 분석으로
실측한 파서 무한재귀 스택 오버플로 **4경로**를 백로그로 고정해, 다른 에이전트가
이어받을 슬롯을 명시한다.

관련 이슈 #4730 · 착지 PR #4731(발견 1/4).

## 배경

파일이 정하는 중첩 깊이로 무한 재귀하는 파서 경로는 악성 문서 하나로 네이티브
스택을 고갈시켜 프로세스를 죽인다 — 패닉과 달리 `catch_unwind` 로 못 잡는 하드
크래시다. 메인테이너는 이미 이 버그 클래스를 HWP3(`MAX_DRAWING_OBJECT_DEPTH=256`,
#4285)·HML(`max_depth=256`)에서 막았고, 이번에 누락된 형제 경로 넷을 실측했다:

| 발견 | 경로 | 상태 |
|---|---|---|
| 1 (HIGH) | HWPX `<hp:container>` 자기재귀 | **#4731 착지** |
| 2 (HIGH) | HWPX 표 중첩 사이클 (para↔table↔cell) | 후속 |
| 3 (MED) | HWP5 `parse_container_children` | 후속 |
| 4 (MED) | HWP5 표 재귀 | 후속 |

## 변경

- `track_b_guards_security.md` — R21 항목 추가(한 줄/지금/설계/착수 게이트/DoD/의존),
  제목 범위 `R11~20`→`R11~21`, `last_verified` 갱신
- `README.md` — 트랙 B 범위 표기 `R11~20`→`R11~21`

문서 전용 변경. 상한 값·방식은 기존 선례 복제라 새 정책이 아니다. R13 악성 코퍼스·
R17 퍼징 CI 와의 유입 경로도 명시해, 발견 크래시가 회귀로 흘러들 자리를 못박았다.

## 검증

- 문서 메타데이터 검사 통과 · 마크다운 링크 검사 통과(5 passed, 14 subtests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
