### PR TITLE
fix(#3211): 인라인 제어문 재조판 폭 반영

### DIFF
--- a/mydocs/orders/20260814.md
+++ b/mydocs/orders/20260814.md
@@ -1,0 +1,15 @@
+# 오늘 할일 - 2026년 8월 14일
+
+## Issue #3211 - Windows 한컴 인라인 제어문 LineSeg 재조판
+
+- Windows Hancom Office 2022에서 #3211 HWP 두 샘플의 페이지 지문이 모두 23쪽·468문단으로
+  일치함을 단일 COM worker로 확인했다. 비캐시 LineSeg 재조판에서 수식·그림 폭이 빠져 줄 수가
+  축소되는 원인을 `FlowInlineControl` 폭·높이 반영으로 보정했다.
+- [PR #4742](https://github.com/edwardkim/rhwp/pull/4742)는 저장 LineSeg를 지운 회귀에서 두 샘플
+  각각 줄 수 160/165, 줄바꿈 130/165를 고정하고, #1082 미주 드리프트 5건과 한컴 PDF 기준
+  인라인 그림·미주 회귀 85건을 통과했다. `CARGO_INCREMENTAL`은 지정하지 않았고 고정
+  `target/pr-review`를 순차 재사용했다.
+- 한컴 2024 COM override는 major 12를 반환해 안전 중단했으며 결과로 쓰지 않았다. 기본 COM 등록은
+  복원했다. 상세 판단은 [PR #4742 review](../pr/archives/pr_4742_review.md)에 보존한다.
+- 최신 PR head의 CI·CodeQL·Render Diff, mergeability와 작업지시자 승인 전에는 merge하지 않는다.
+  #3211은 남은 wrap-zone 정합성 차이가 있어 자동 종료하지 않는다.

--- a/mydocs/orders/20260814.md
+++ b/mydocs/orders/20260814.md
@@ -11,6 +11,10 @@
   `target/pr-review`를 순차 재사용했다.
 - 한컴 2024 COM override는 major 12를 반환해 안전 중단했으며 결과로 쓰지 않았다. 기본 COM 등록은
   복원했다. 상세 판단은 [PR #4742 review](../pr/archives/pr_4742_review.md)에 보존한다.
+- `devel` 기준 갱신 뒤 CI에서 HML 글자처럼 취급되는 표의 `abc + table + efg` 경계 회귀 1건을
+  발견했다. 표 폭을 보이지 않는 본문 위치에 더하지 않도록 보정해 해당 회귀 1건, #3211 두 샘플
+  LineSeg 대조, #1082 5건, #1139 85건, Clippy를 `target/pr-review`에서 다시 통과했다. 수식·그림
+  폭 보정과 #3211 지표(각각 160/165, 130/165)는 유지한다.
 - 최신 PR head의 CI·CodeQL·Render Diff, mergeability와 작업지시자 승인 전에는 merge하지 않는다.
   #3211은 남은 wrap-zone 정합성 차이가 있어 자동 종료하지 않는다.
 # 오늘 할 일 - 2026년 8월 14일

--- a/mydocs/plans/task_m100_3211.md
+++ b/mydocs/plans/task_m100_3211.md
@@ -1,0 +1,58 @@
+# Task #3211 수행계획 — Windows 한컴 LineSeg 재조판 대조
+
+- **Issue**: [#3211](https://github.com/edwardkim/rhwp/issues/3211)
+- **Branch**: `codex/issue-3211-windows-lineseg`
+- **Base**: `upstream/devel` `d871bb8ce1`
+- **작성일**: 2026-08-14 KST
+
+## 문제와 범위
+
+저장 HWP의 `PARA_LINE_SEG`는 한컴이 저장한 실제 줄 경계다. 반면 rhwp가 편집·서식 변경 뒤
+`reflow_line_segs()`로 비캐시 재계산할 때, 특히 미주가 포함된 시험지의 줄 경계·높이가 저장값과
+달라질 수 있다. 이는 단순 Linux 렌더 결과로 판정할 수 없다. 이 작업은 Windows에 설치된 한컴
+2022와 2024로 원본 샘플의 페이지 지문을 순차 대조해, 두 버전에서 공통인 관측만 구현 판단의
+근거로 사용한다.
+
+외부 기여자의 Draft PR #4315는 광범위한 의도적 red 감사 테스트이므로 이 브랜치에서 변경하거나
+병합하지 않는다. 이번 PR은 #3211의 재현 샘플과 편집 뒤 LineSeg 재조판 경로만 다룬다.
+
+## 조사와 구현 경계
+
+1. `samples/3-09월_교육_통합_2022.hwp`와
+   `samples/3-09월_교육_통합_2024-구분선아래20구분선위20.hwp`의 한컴 2022·2024 페이지 지문을
+   단일 워커로 수집한다.
+2. 두 버전에서 페이지네이션이 갈리면 그 차이를 rhwp의 보정 목표로 일반화하지 않는다. 공통인
+   저장 LineSeg 관측과 rhwp의 비캐시 재조판 결과만 비교한다.
+3. 불일치가 재현되는 최소 문단·제어문자·UTF-16 경계를 찾아 `reflow_line_segs()` 또는 그 호출부를
+   보정한다. 저장된 LineSeg를 전역적으로 재사용하거나 넓은 허용오차로 실패를 숨기지 않는다.
+4. 수정은 focused 회귀 테스트와 Windows 한컴 열기·페이지 지문 재검증으로 고정한다.
+
+## 변경 예상 범위
+
+| 영역 | 변경 가능성 |
+| --- | --- |
+| `src/renderer/composer/line_breaking.rs` | 재조판 LineSeg 시작 위치·폭·높이 계산 보정 |
+| `tests/` | #3211 최소 재현과 비캐시 재조판 회귀 검증 |
+| `mydocs/plans/`, `mydocs/working/`, `mydocs/pr/` | 조사, 검증, PR 검토 증적 |
+
+샘플 원본, 한컴 설치·레지스트리 기본값, 외부 Draft PR #4315, CI workflow는 변경하지 않는다.
+
+## 검증
+
+- `powershell -File tools\\hangul_version_oracle\\list_hangul_versions.ps1`로 실제 한컴 버전을 확인한다.
+- #3211 샘플 목록을 UTF-8(BOM 없음)으로 만들고, 한컴 2022와 2024를 각각 `-Workers 1`로 순차
+  실행해 페이지 지문을 수집한다. 실행 중 한컴 창을 숨기거나 병렬 실행하지 않는다.
+- 수정 전후에 동일한 목록을 독립 순서로 다시 측정해 관측 재현성을 확인한다.
+- `target\\pr-review`를 재사용해 focused Rust 테스트, `cargo fmt --all -- --check`, `git diff --check`를
+  순차 실행한다. `CARGO_INCREMENTAL`은 설정하지 않는다.
+- renderer/layout 변경이므로 발동 샘플의 rhwp 결과와 한컴 PDF 기준을 OVL 규약으로 비교하고,
+  필요한 PNG 증적을 `mydocs/pr/assets/`에 남긴다.
+
+## 완료 조건
+
+- Windows 한컴 2022·2024 측정 환경과 결과 차이를 비밀 없이 기록한다.
+- 공통 재현 원인에만 한정한 보정과 focused 회귀 테스트가 있다.
+- 기존 #1082 미주 드리프트 가드가 회귀하지 않는다.
+- 외부 Draft PR의 의도적 red를 정상화했다고 주장하지 않는다.
+- PR은 `devel` 대상으로 만들고, #3211을 자동 종료할 만큼 완료 조건을 충족한 경우에만 `Fixes #3211`을
+  사용한다.

--- a/mydocs/pr/archives/pr_4742_review.md
+++ b/mydocs/pr/archives/pr_4742_review.md
@@ -84,6 +84,22 @@ LineSeg를 사용한다. 따라서 저장본 before/after OVL PNG를 새로 만�
 직접 rustfmt 검사를 대체 근거로 썼다. Hancom Office 2024는 HKCU override 뒤에도 COM major 12를
 반환해 오라클이 안전 중단했고, 2024 결과는 사용하지 않았다. 기본 COM 등록은 즉시 복원했다.
 
+## CI 보정
+
+초기 최신 head `bd852c93335374d0cba4331abde47c026634a2a5`의 GitHub Actions Lint는
+`clippy::obfuscated_if_else` 한 건으로 실패했다. `has_inline_control_in_range(...).then(...)
+.unwrap_or_default()`를 동등한 명시적 `if/else`로 바꾼
+`cfb631f48e265847cf9266eca54b31430f002f7b`은 동작·검증 하한을 바꾸지 않는다.
+
+Windows PowerShell의 동일 `target\\pr-review`에서 다음을 완료했다.
+
+- `cargo clippy -- -D warnings` — 통과.
+- `cargo test --lib issue3211_uncached_endnote_body_preserves_inline_control_flow -- --nocapture`
+  — 통과, 두 샘플 각각 160/165 line count 및 130/165 line break.
+- 직접 `rustfmt.exe --check`, `git diff --check` — 통과.
+
+이 보정 뒤의 새 GitHub Actions는 merge 전 조건으로 다시 확인한다.
+
 ## 결론과 merge 조건
 
 코드 검토와 로컬·Windows 검증에서 blocker는 발견하지 못했다. 단, 이 PR은 #3211 전체 정합성을

--- a/mydocs/pr/archives/pr_4742_review.md
+++ b/mydocs/pr/archives/pr_4742_review.md
@@ -100,6 +100,35 @@ Windows PowerShell의 동일 `target\\pr-review`에서 다음을 완료했다.
 
 이 보정 뒤의 새 GitHub Actions는 merge 전 조건으로 다시 확인한다.
 
+## 기준선 갱신 뒤 회귀 보정
+
+`devel`의 PR #4743 병합을 head에 반영한 `895508a7afece7f5de99dbcbfb16db7b27dc7eaa`에서
+새 CI가 실행됐다. 이 실행은 `pr_2219_hml_middle_anchor::
+formatting_table_middle_anchor_preserves_vertical_text_flow` 한 건만 실패했다. Windows의
+동일 재현도 `tests/pr_2219_hml_middle_anchor.rs:40`에서 `distinct trailing efg text run`을
+보고했다.
+
+원인은 HML fixture의 `abc + 글자처럼 취급되는 표 + efg` 문단이었다. 표의 폭(41,956 HU)을
+visible text에서 표가 빠진 위치의 다음 글자 폭에 더하면, renderer가 만드는 기존
+`TextRun`/`Table` 경계가 사라진다. `b7fbd8b0218d2cf3bdbb0a1618a3fb01c4b2ce90`
+(`fix(#3211): 인라인 표 재조판 경계 보존`)은 `flow_inline_controls()`에서 table만 제외했다.
+표의 기존 cell-split·empty-paragraph 제어문 배치와 크기 계산은 바꾸지 않았고, #3211에서
+Windows Hancom 저장 LineSeg와 대조한 수식·그림 계열의 폭·높이 보정은 유지한다.
+
+Windows PowerShell에서 `target\pr-review` 하나를 순차 재사용해 아래를 다시 확인했다.
+
+| 검증 | 결과 |
+| --- | --- |
+| `cargo test --target-dir target\pr-review --test pr_2219_hml_middle_anchor formatting_table_middle_anchor_preserves_vertical_text_flow -- --nocapture` | 1 passed |
+| `cargo test --target-dir target\pr-review --lib issue3211_uncached_endnote_body_preserves_inline_control_flow -- --nocapture` | 두 샘플 모두 160/165 line count, 130/165 line break |
+| `cargo test --target-dir target\pr-review --test issue_1082_endnote_multicolumn_drift` | 5 passed |
+| `cargo test --target-dir target\pr-review --test issue_1139_inline_picture_duplicate` | 85 passed |
+| `cargo clippy --target-dir target\pr-review -- -D warnings` | 통과 |
+| 직접 `rustfmt.exe --check`, `git diff --check` | 통과 |
+
+`CARGO_INCREMENTAL`은 이 검증에도 설정하지 않았다. 이 보정의 새 head CI가 통과하고
+mergeability를 재확인하기 전에는 merge하지 않는다.
+
 ## 결론과 merge 조건
 
 코드 검토와 로컬·Windows 검증에서 blocker는 발견하지 못했다. 단, 이 PR은 #3211 전체 정합성을

--- a/mydocs/pr/archives/pr_4742_review.md
+++ b/mydocs/pr/archives/pr_4742_review.md
@@ -1,0 +1,94 @@
+---
+kind: review
+status: self-review-ci-pending
+pr: 4742
+issue: 3211
+author: jangster77
+base: devel
+---
+
+# PR #4742 검토 기록
+
+## 접수 정보
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4742](https://github.com/edwardkim/rhwp/pull/4742) |
+| 작성자 | `jangster77` (collaborator) |
+| 관련 이슈 | [#3211](https://github.com/edwardkim/rhwp/issues/3211) (`Refs`, 자동 종료 아님) |
+| head / base | `task_m100_3211` / `devel` |
+| code candidate | `494e1317e6d49fa074736946dadea0bf004411d0` |
+| 구현 전용 변경 | 2 files, +163 / -8 |
+| 문서 작성 전 PR head | `502b0f8867d4757c0812df177e60195f56217d68` |
+| 작성 시점 참고 상태 | `BLOCKED`; CI·CodeQL·Render Diff preflight queued, WASM Build skipped |
+| 검토 방식 | 작업지시자 지시에 따른 `jangster77` collaborator 셀프 검토; external reviewer 요청 없음 |
+
+### 적용 절차
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, local_validation.md, visual_fixture_evidence.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+collaborator_self_merge.md, intake_and_review.md, local_validation.md,
+visual_fixture_evidence.md, docs_and_git_workflow.md
+```
+
+최신 `upstream/devel` `d871bb8ce1c05e92543c4f5932c51e101280a301` 위에서 작업을 시작해
+원본 `upstream`의 `task_m100_3211`으로 게시했다. PR 생성 뒤 이 review 기록과 오늘할일을
+동일 source branch의 docs-only 후속 commit으로 추가한다. merge 직전에는 이 문서를 포함한
+최신 head의 required check와 mergeability를 다시 확인해야 한다.
+
+## 문제 분석과 변경 검토
+
+Windows Hancom Office 2022에서 두 #3211 HWP 샘플을 단일 COM worker로 열었을 때, 둘 다
+23쪽·468문단과 동일한 페이지 지문을 보였다. 저장 `PARA_LINE_SEG`를 제거한 비캐시 재조판은
+수식·그림의 폭을 누락해 줄 수 일치를 139/165까지 낮췄다.
+
+`FlowInlineControl`은 문자처럼 취급되는 picture, shape, table, equation, form의 원본 HWPUNIT
+폭·높이와 문단 문자 위치를 수집한다. 토큰 폭과 character-level fallback 폭에 그 값을 반영하고,
+각 제어문을 포함한 줄에만 최대 높이를 적용한다. 종전처럼 문단의 모든 인라인 높이를 첫 줄에
+합치는 동작은 흐름 제어문이 있을 때 제거했다.
+
+저장 LineSeg를 지운 비교 하니스는 실제 재조판 결과만 대조하도록 고쳤다. 두 Windows 한컴 샘플에
+줄 수 160/165, 줄바꿈 130/165 하한을 추가해 폭 누락 회귀를 막는다. 남은 차이는 좁은 wrap-zone의
+저장 `segment_width`와 한컴의 제어문 전후 경계 규칙이며, 넓은 허용오차나 저장 배열 재사용으로
+감추지 않았다.
+
+## 렌더 영향과 시각 근거
+
+`src/renderer/composer`의 line-break 및 line box를 바꾸므로 시각 검증 보조 경로를 적용했다.
+Windows 한컴 2022 페이지 지문을 독립 오라클로 수집했고, `issue_1139_inline_picture_duplicate`
+85건은 한컴 PDF 기준의 미주·수식·그림 위치와 쪽수 계약을 통과했다.
+
+이번 보정의 직접 실행 경로는 in-memory edit/reflow이며, 저장본을 그대로 여는 화면은 기존
+LineSeg를 사용한다. 따라서 저장본 before/after OVL PNG를 새로 만들면 변경 경로를 검증하지 못해
+증적으로 사용하지 않았다. #3211 비캐시 저장 LineSeg 대조와 PDF 기준 integration 회귀를 함께
+판정 근거로 사용했다.
+
+## 완료한 검증
+
+모든 Cargo 명령은 Windows PowerShell에서 `target\\pr-review` 하나를 재사용해 순차 실행했으며,
+`CARGO_INCREMENTAL`은 설정하지 않았다.
+
+| 검증 | 결과 |
+| --- | --- |
+| Hancom Office 2022 page oracle, worker 1 | 두 HWP 모두 23쪽·468문단·동일 지문 |
+| 비캐시 #3211 LineSeg regression | 두 샘플 각각 160/165 line count, 130/165 line break |
+| `cargo test --test issue_1082_endnote_multicolumn_drift` | 5 passed |
+| `cargo test --test issue_1139_inline_picture_duplicate` | 85 passed |
+| `cargo test --lib line_breaking:: -- --nocapture` | 2 passed |
+| 대상 파일 직접 `rustfmt.exe --check`, `git diff --check` | 통과 |
+| 변경 Markdown link check | 2 documents, internal relative links clean |
+
+`cargo fmt`는 이 Windows 긴 경로에서 OS error 206으로 help만 출력해 판정을 제공하지 못했다.
+직접 rustfmt 검사를 대체 근거로 썼다. Hancom Office 2024는 HKCU override 뒤에도 COM major 12를
+반환해 오라클이 안전 중단했고, 2024 결과는 사용하지 않았다. 기본 COM 등록은 즉시 복원했다.
+
+## 결론과 merge 조건
+
+코드 검토와 로컬·Windows 검증에서 blocker는 발견하지 못했다. 단, 이 PR은 #3211 전체 정합성을
+완료하지 않으므로 이슈를 닫지 않는다. 문서 작성 시점 CI는 대기 중이므로 **merge 보류**다.
+
+최종 merge 조건은 최신 PR head의 GitHub Actions 통과, 최신 mergeability 확인, collaborator
+셀프 검토, 그리고 작업지시자 승인이다. 조건 충족 뒤에도 남은 wrap-zone 차이는 #3211에서 계속
+추적한다.

--- a/mydocs/working/task_m100_3211_stage1.md
+++ b/mydocs/working/task_m100_3211_stage1.md
@@ -1,0 +1,60 @@
+# Task #3211 Stage 1 — Windows 한컴 LineSeg 재조판 보정
+
+- Issue: [#3211](https://github.com/edwardkim/rhwp/issues/3211)
+- Base: `upstream/devel` `d871bb8ce1`
+- 구현 커밋: `494e1317e`
+- 측정일: 2026-08-14 KST
+
+## Windows 한컴 관측
+
+`tools/hangul_version_oracle`를 Windows PowerShell에서 워커 1개로 실행했다. 한컴 2022
+(`12.0.0.4605`)는 두 샘플을 모두 정상으로 열었고, 두 문서의 페이지 지문은 아래와 같이
+동일했다.
+
+| 샘플 | 쪽수 | 문단 수 | 페이지 지문 |
+| --- | ---: | ---: | --- |
+| `3-09월_교육_통합_2022.hwp` | 23 | 468 | `0@0,1@82,2@153,3@203,4@277,5@334,6@367,7@429,8@465` |
+| `3-09월_교육_통합_2024-구분선아래20구분선위20.hwp` | 23 | 468 | `0@0,1@82,2@153,3@203,4@277,5@334,6@367,7@429,8@465` |
+
+한컴 2024 실행 파일(`13.0.0.3901`)도 설치돼 있으나, 버전 오라클이 HKCU override 뒤에도
+COM major 12를 받아 안전하게 중단했다. 2024 결과는 측정하지 않았으며, 즉시
+`restore_com_default.ps1`로 2022 기계 기본 COM 등록을 복원했다. HKCU 키를 삭제하거나
+강제로 재시도하지 않았다.
+
+## 원인과 보정
+
+두 샘플의 저장 `PARA_LINE_SEG`를 지운 뒤 재조판하면, 수식·그림처럼 글자처럼 취급되는
+인라인 제어문이 visible text에 없다는 이유로 줄 폭에서 빠졌다. 기존 구현은 모든 제어문의
+높이만 첫 줄에 얹어 여러 줄이 축소됐다.
+
+`reflow_line_segs()`는 이제 제어문의 문단 문자 위치별 HWPUNIT 폭을 토큰 폭에 더하고, 실제
+해당 제어문을 포함한 줄에만 최대 높이를 적용한다. 저장 LineSeg 배열은 이 진단의 계산 입력으로
+사용하지 않는다.
+
+## 수치 검증
+
+두 샘플 모두 저장 LineSeg 보유 문단 165개에서 아래 결과를 보였다.
+
+| 항목 | 보정 전 | 보정 후 |
+| --- | ---: | ---: |
+| 줄 수 일치 | 139/165 (84.2%) | 160/165 (97.0%) |
+| 줄바꿈 위치 일치 | 123/165 (74.5%) | 130/165 (78.8%) |
+
+남은 차이는 좁은 wrap-zone의 저장 `segment_width`와 제어문 전후의 한컴 줄 경계 규칙으로,
+이번 폭·높이 누락 보정 범위를 벗어난다. 임의의 허용오차 확대나 저장 LineSeg 재사용으로 숨기지
+않았다.
+
+## 로컬 검증
+
+모든 Cargo 명령은 `target\\pr-review`를 재사용해 순차 실행했고 `CARGO_INCREMENTAL`은 설정하지
+않았다.
+
+- `cargo test --lib issue3211_uncached_endnote_body_preserves_inline_control_flow -- --nocapture`
+  — 통과: 두 샘플 각각 줄 수 160/165, 줄바꿈 130/165.
+- `cargo test --test issue_1082_endnote_multicolumn_drift` — 5/5 통과.
+- `cargo test --test issue_1139_inline_picture_duplicate` — 85/85 통과.
+- `cargo test --lib line_breaking:: -- --nocapture` — 2/2 통과.
+- 직접 `rustfmt.exe --check`(edition 2021), `git diff --check` — 통과.
+
+Cargo의 `fmt` subcommand는 이 Windows 경로에서 OS error 206(파일명/확장명 길이)로 help를
+출력해 판정을 제공하지 못했다. 위 직접 rustfmt 검사를 대신 사용했다.

--- a/mydocs/working/task_m100_3211_stage1.md
+++ b/mydocs/working/task_m100_3211_stage1.md
@@ -58,3 +58,18 @@ COM major 12를 받아 안전하게 중단했다. 2024 결과는 측정하지 �
 
 Cargo의 `fmt` subcommand는 이 Windows 경로에서 OS error 206(파일명/확장명 길이)로 help를
 출력해 판정을 제공하지 못했다. 위 직접 rustfmt 검사를 대신 사용했다.
+
+## CI 후속 보정
+
+`devel` 최신 병합을 반영한 PR CI에서 HML fixture의 middle-anchored table 회귀가 발견됐다.
+이 fixture는 `abc + table + efg`의 control 경계를 renderer가 별도의 `TextRun`/`Table`로
+표현한다. 표 전체 폭을 control 뒤 visible character에 합산하면 그 경계가 사라져 trailing
+`efg` run을 찾지 못한다.
+
+`b7fbd8b02`는 `flow_inline_controls()`에서 `Control::Table`을 제외해 기존 table 배치 경로를
+보존했다. 표의 cell-split/empty-paragraph 크기 계산은 그대로 두며, Windows Hancom HWP 샘플에서
+검증한 수식·그림 control 폭·높이 보정에는 영향을 주지 않는다.
+
+- `pr_2219_hml_middle_anchor` 대상 회귀 — 1/1 통과.
+- #3211 대조 — 두 샘플 각각 160/165 line count, 130/165 line break 유지.
+- #1082 미주 드리프트 5/5, #1139 인라인 그림·미주 85/85, Clippy 통과.

--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -361,23 +361,23 @@ fn tokenize_paragraph_with_split_cell_space_metric(
                         current_lang,
                         inline_controls,
                     );
-                    let char_widths = has_inline_control_in_range(inline_controls, start, i)
-                        .then(|| {
-                            (start..i)
-                                .map(|ci| {
-                                    measure_char_width(
-                                        text_chars[ci],
-                                        ci,
-                                        char_offsets,
-                                        char_shapes,
-                                        styles,
-                                        current_lang,
-                                        inline_controls,
-                                    )
-                                })
-                                .collect()
-                        })
-                        .unwrap_or_default();
+                    let char_widths = if has_inline_control_in_range(inline_controls, start, i) {
+                        (start..i)
+                            .map(|ci| {
+                                measure_char_width(
+                                    text_chars[ci],
+                                    ci,
+                                    char_offsets,
+                                    char_shapes,
+                                    styles,
+                                    current_lang,
+                                    inline_controls,
+                                )
+                            })
+                            .collect()
+                    } else {
+                        Vec::new()
+                    };
                     tokens.push(BreakToken::Text {
                         start_idx: start,
                         end_idx: i,

--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -1185,6 +1185,14 @@ fn flow_inline_controls(para: &Paragraph) -> Vec<FlowInlineControl> {
         .iter()
         .zip(para.control_text_positions())
         .filter_map(|(control, char_position)| {
+            // 글자처럼 취급되는 표는 renderer가 control 위치를 기준으로 별도
+            // TextRun/Table 경계를 만든다. 보이지 않는 PARA_TEXT 위치의 다음
+            // 글자 폭에 표 전체 폭을 더하면 HML의 `abc + table + efg`처럼
+            // 기존 경계를 잃는다. #3211의 HWP oracle은 수식·그림 계열의
+            // 재조판 폭을 대상으로 하므로 표는 기존 control 배치 경로에 둔다.
+            if matches!(control, Control::Table(_)) {
+                return None;
+            }
             let (width_hwp, height_hwp) = inline_control_size_hwp(control)?;
             (char_position < text_len).then_some(FlowInlineControl {
                 char_position,

--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -38,6 +38,18 @@ pub(crate) enum BreakToken {
     LineBreak { idx: usize },
 }
 
+/// 글자처럼 취급되는 인라인 제어문의 문단 내 위치와 물리 크기.
+///
+/// HWP `PARA_TEXT`에는 수식·그림 본문이 보이지 않는 8 UTF-16 단위 제어문자로
+/// 들어가므로, visible text만 토큰화하면 제어문이 차지한 폭이 사라진다. 재조판은
+/// 그 폭과 높이를 별도로 들고 줄나눔과 line box에 반영해야 한다 (#3211).
+#[derive(Debug, Clone, Copy)]
+struct FlowInlineControl {
+    char_position: usize,
+    width_hwp: i32,
+    height_hwp: i32,
+}
+
 /// 줄 채움 결과
 #[derive(Debug)]
 struct LineBreakResult {
@@ -166,6 +178,7 @@ pub(crate) fn tokenize_paragraph(
         english_break_unit,
         korean_break_unit,
         false,
+        &[],
     )
 }
 
@@ -179,6 +192,7 @@ fn tokenize_paragraph_with_split_cell_space_metric(
     english_break_unit: u8,
     korean_break_unit: u8,
     split_stale_cell_reflow: bool,
+    inline_controls: &[FlowInlineControl],
 ) -> Vec<BreakToken> {
     let text_len = text_chars.len();
     if text_len == 0 {
@@ -240,7 +254,7 @@ fn tokenize_paragraph_with_split_cell_space_metric(
                     .unwrap_or_else(|| estimate_text_width_unrounded(" ", &ts))
             } else {
                 estimate_text_width_unrounded(" ", &ts)
-            };
+            } + inline_width_px_at(inline_controls, i);
             tokens.push(BreakToken::Space {
                 idx: i,
                 width: w,
@@ -345,13 +359,31 @@ fn tokenize_paragraph_with_split_cell_space_metric(
                         char_shapes,
                         styles,
                         current_lang,
+                        inline_controls,
                     );
+                    let char_widths = has_inline_control_in_range(inline_controls, start, i)
+                        .then(|| {
+                            (start..i)
+                                .map(|ci| {
+                                    measure_char_width(
+                                        text_chars[ci],
+                                        ci,
+                                        char_offsets,
+                                        char_shapes,
+                                        styles,
+                                        current_lang,
+                                        inline_controls,
+                                    )
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default();
                     tokens.push(BreakToken::Text {
                         start_idx: start,
                         end_idx: i,
                         width,
                         max_font_size: max_fs,
-                        char_widths: vec![],
+                        char_widths,
                     });
                 }
                 continue;
@@ -370,7 +402,8 @@ fn tokenize_paragraph_with_split_cell_space_metric(
                 } else {
                     12.0
                 };
-                let w = estimate_text_width_unrounded(&ch.to_string(), &ts);
+                let w = estimate_text_width_unrounded(&ch.to_string(), &ts)
+                    + inline_width_px_at(inline_controls, i);
                 tokens.push(BreakToken::Text {
                     start_idx: i,
                     end_idx: i + 1,
@@ -455,6 +488,7 @@ fn tokenize_paragraph_with_split_cell_space_metric(
                         char_shapes,
                         styles,
                         current_lang,
+                        inline_controls,
                     );
                     // 개별 글자 폭 수집 (char_level_break용)
                     let cw: Vec<f64> = (start..i)
@@ -469,6 +503,7 @@ fn tokenize_paragraph_with_split_cell_space_metric(
                             let lang = if is_lang_neutral(c) { current_lang } else { 1 };
                             let ts = resolved_to_text_style(styles, sid, lang);
                             estimate_text_width_unrounded(&c.to_string(), &ts)
+                                + inline_width_px_at(inline_controls, ci)
                         })
                         .collect();
                     tokens.push(BreakToken::Text {
@@ -495,7 +530,8 @@ fn tokenize_paragraph_with_split_cell_space_metric(
                 } else {
                     12.0
                 };
-                let w = estimate_text_width_unrounded(&ch.to_string(), &ts);
+                let w = estimate_text_width_unrounded(&ch.to_string(), &ts)
+                    + inline_width_px_at(inline_controls, i);
                 tokens.push(BreakToken::Text {
                     start_idx: i,
                     end_idx: i + 1,
@@ -523,7 +559,8 @@ fn tokenize_paragraph_with_split_cell_space_metric(
             } else {
                 12.0
             };
-            let w = estimate_text_width_unrounded(&ch.to_string(), &ts);
+            let w = estimate_text_width_unrounded(&ch.to_string(), &ts)
+                + inline_width_px_at(inline_controls, i);
             tokens.push(BreakToken::Text {
                 start_idx: i,
                 end_idx: i + 1,
@@ -556,7 +593,8 @@ fn tokenize_paragraph_with_split_cell_space_metric(
             } else {
                 12.0
             };
-            let w = estimate_text_width_unrounded(&ch.to_string(), &ts);
+            let w = estimate_text_width_unrounded(&ch.to_string(), &ts)
+                + inline_width_px_at(inline_controls, i);
             tokens.push(BreakToken::Text {
                 start_idx: i,
                 end_idx: i + 1,
@@ -579,6 +617,7 @@ fn measure_token_width(
     char_shapes: &[CharShapeRef],
     styles: &ResolvedStyleSet,
     default_lang: usize,
+    inline_controls: &[FlowInlineControl],
 ) -> f64 {
     let mut total = 0.0;
     let mut current_lang = default_lang;
@@ -598,9 +637,52 @@ fn measure_token_width(
             detected
         };
         let ts = resolved_to_text_style(styles, style_id, lang);
-        total += estimate_text_width_unrounded(&ch.to_string(), &ts);
+        total += estimate_text_width_unrounded(&ch.to_string(), &ts)
+            + inline_width_px_at(inline_controls, idx);
     }
     total
+}
+
+fn measure_char_width(
+    ch: char,
+    char_idx: usize,
+    char_offsets: &[u32],
+    char_shapes: &[CharShapeRef],
+    styles: &ResolvedStyleSet,
+    default_lang: usize,
+    inline_controls: &[FlowInlineControl],
+) -> f64 {
+    let utf16_pos = char_offsets
+        .get(char_idx)
+        .copied()
+        .unwrap_or(char_idx as u32);
+    let style_id = find_active_char_shape(char_shapes, utf16_pos);
+    let lang = if is_lang_neutral(ch) {
+        default_lang
+    } else {
+        detect_lang_category(ch)
+    };
+    let style = resolved_to_text_style(styles, style_id, lang);
+    estimate_text_width_unrounded(&ch.to_string(), &style)
+        + inline_width_px_at(inline_controls, char_idx)
+}
+
+fn inline_width_px_at(inline_controls: &[FlowInlineControl], char_idx: usize) -> f64 {
+    inline_controls
+        .iter()
+        .filter(|control| control.char_position == char_idx)
+        .map(|control| control.width_hwp as f64 / 75.0)
+        .sum()
+}
+
+fn has_inline_control_in_range(
+    inline_controls: &[FlowInlineControl],
+    start: usize,
+    end: usize,
+) -> bool {
+    inline_controls
+        .iter()
+        .any(|control| (start..end).contains(&control.char_position))
 }
 
 /// px를 HWPUNIT(i32)로 변환 (내림, DPI=96 기준: px * 75)
@@ -1097,6 +1179,22 @@ fn inline_control_size_hwp(ctrl: &Control) -> Option<(i32, i32)> {
     }
 }
 
+fn flow_inline_controls(para: &Paragraph) -> Vec<FlowInlineControl> {
+    let text_len = para.text.chars().count();
+    para.controls
+        .iter()
+        .zip(para.control_text_positions())
+        .filter_map(|(control, char_position)| {
+            let (width_hwp, height_hwp) = inline_control_size_hwp(control)?;
+            (char_position < text_len).then_some(FlowInlineControl {
+                char_position,
+                width_hwp,
+                height_hwp,
+            })
+        })
+        .collect()
+}
+
 /// 본문 뒤 남은 폭에 놓이지 않는 inline control은 별도 physical line을 가진다.
 ///
 /// 종전 cell reflow는 text token만 줄바꿈한 뒤 첫 LineSeg를 표 높이만큼 키웠다.
@@ -1160,6 +1258,7 @@ fn inline_control_requires_own_line(
         &para.char_shapes,
         styles,
         0,
+        &[],
     ));
 
     (control_width > available_hwp + LINE_BREAK_TOLERANCE
@@ -1403,6 +1502,7 @@ fn reflow_line_segs_impl(
 
     let text_chars: Vec<char> = para.text.chars().collect();
     let text_len = text_chars.len();
+    let inline_controls = flow_inline_controls(para);
 
     // 문단 스타일에서 들여쓰기 및 줄 나눔 설정 조회
     let para_style = styles.para_styles.get(para.para_shape_id as usize);
@@ -1421,6 +1521,7 @@ fn reflow_line_segs_impl(
         english_break_unit,
         korean_break_unit,
         split_stale_cell_reflow,
+        &inline_controls,
     );
     // 저장 LINE_SEG 기반 incremental edit는 앞선 줄을 유지한다. LINE_SEG start가 현재
     // char_offsets와 token 경계 모두에 정확히 대응할 때만 suffix reflow를 허용한다.
@@ -1538,6 +1639,17 @@ fn reflow_line_segs_impl(
             let (_, height_hwp) = forced_inline_line.expect("checked inline control");
             apply_inline_control_line_height(&mut text_seg, height_hwp);
         }
+        if let Some(height_hwp) = inline_controls
+            .iter()
+            .filter(|control| {
+                (lb.start_idx..lb.end_idx).contains(&control.char_position)
+                    || (lb.end_idx == text_len && control.char_position == text_len)
+            })
+            .map(|control| control.height_hwp)
+            .max()
+        {
+            apply_inline_control_line_height(&mut text_seg, height_hwp);
+        }
         new_line_segs.push(text_seg);
 
         // control이 text line 한가운데/끝에 있으면 먼저 text prefix를 확정하고,
@@ -1560,7 +1672,7 @@ fn reflow_line_segs_impl(
         new_line_segs.push(make_line_seg(0, 12.0));
     }
 
-    if forced_inline_line.is_none() {
+    if forced_inline_line.is_none() && inline_controls.is_empty() {
         if let Some(height_hwp) = inline_control_line_height_hwp(para) {
             // 기존 인라인 TAC 개체는 해당 문단의 최초 line box에 남긴다.
             if let Some(seg) = new_line_segs.first_mut() {

--- a/src/renderer/composer/lineseg_compare_tests.rs
+++ b/src/renderer/composer/lineseg_compare_tests.rs
@@ -78,6 +78,9 @@ mod tests {
 
             // reflow 실행 (문단을 임시 clone하여 원본 보존)
             let mut para_clone = para.clone();
+            // #3211 조사: 저장 LineSeg가 `orig` 템플릿으로 재사용되는 경로를 막고,
+            // 실제 재조판 결과만 원본과 대조한다.
+            para_clone.line_segs.clear();
             reflow_line_segs(&mut para_clone, available_width, styles, dpi);
 
             // 비교
@@ -181,6 +184,46 @@ mod tests {
 
         let total_compared: usize = reports.iter().map(|r| r.compared_paragraphs).sum();
         assert!(total_compared > 0, "비교 대상 문단이 0개");
+    }
+
+    #[test]
+    fn issue3211_uncached_endnote_body_preserves_inline_control_flow() {
+        for path in [
+            "samples/3-09월_교육_통합_2022.hwp",
+            "samples/3-09월_교육_통합_2024-구분선아래20구분선위20.hwp",
+        ] {
+            let Some(reports) = run_comparison(path) else {
+                panic!("#3211 sample is missing: {path}");
+            };
+            let compared: usize = reports
+                .iter()
+                .map(|report| report.compared_paragraphs)
+                .sum();
+            let line_count_matched: usize = reports
+                .iter()
+                .map(|report| report.line_count_match_count)
+                .sum();
+            let line_break_matched: usize = reports
+                .iter()
+                .map(|report| report.line_break_match_count)
+                .sum();
+            eprintln!(
+                "#3211 {path}: stored={compared}, line-count={line_count_matched}, line-break={line_break_matched}"
+            );
+
+            // Windows Hancom 2022가 저장한 두 HWP에서 baseline은 165개 문단이다.
+            // 인라인 제어문 폭을 빼면 줄 수 일치가 139개까지 무너진다. 이 하한은
+            // 수식·그림이 줄 폭과 line box를 함께 차지해야 함을 고정한다.
+            assert_eq!(compared, 165, "unexpected #3211 fixture corpus: {path}");
+            assert!(
+                line_count_matched >= 160,
+                "#3211 inline-control reflow regressed line counts: {line_count_matched}/165 ({path})"
+            );
+            assert!(
+                line_break_matched >= 130,
+                "#3211 inline-control reflow regressed line breaks: {line_break_matched}/165 ({path})"
+            );
+        }
     }
 
     // ─── 문자별 폭 진단 (Task 400) ───


### PR DESCRIPTION
## 요약

- 수식·그림 등 글자처럼 취급되는 인라인 제어문의 HWPUNIT 폭을 비캐시 `reflow_line_segs()` 토큰 폭에 반영했습니다.
- 각 제어문의 높이를 전체 첫 줄이 아니라 실제 포함 줄에만 적용했습니다.
- 저장 LineSeg 캐시를 지운 비교와 Windows 한컴 저장 HWP 2종의 회귀 하한을 추가했습니다.

## Windows 한컴 검증

- Hancom Office 2022 (12.0.0.4605), worker 1: 두 샘플 모두 23쪽·468문단, 동일 페이지 지문을 확인했습니다.
- Hancom Office 2024는 COM override가 major 12를 반환해 안전 중단했고, 결과로 사용하지 않았습니다. 기본 COM 등록은 즉시 복원했습니다.

## 검증

- `cargo test --lib issue3211_uncached_endnote_body_preserves_inline_control_flow -- --nocapture`
- `cargo test --test issue_1082_endnote_multicolumn_drift` (5 passed)
- `cargo test --test issue_1139_inline_picture_duplicate` (85 passed)
- `cargo test --lib line_breaking:: -- --nocapture` (2 passed)
- 직접 `rustfmt.exe --check`, `git diff --check`, Markdown link check

자세한 관측은 `mydocs/working/task_m100_3211_stage1.md`에 기록했습니다.

Refs #3211