### PR TITLE
fix(security): 입력 경계와 WMF 초기화를 보강

### DIFF
--- a/mydocs/orders/20260814.md
+++ b/mydocs/orders/20260814.md
@@ -1,0 +1,18 @@
+# 오늘 할 일 - 2026년 8월 14일
+
+## PR #4743 - 입력 경계와 WMF 초기화 안전성
+
+- 최신 `upstream/devel@d871bb8ce` 위 branch
+  `task_m100_4290_4292_4624-security-20260814`에서 #4290, #4292, #4624를 함께 보강한
+  [PR #4743](https://github.com/edwardkim/rhwp/pull/4743)을 생성했다.
+- HWP5 polygon/curve의 oversized positive point-count를 남은 좌표 payload로 제한하고, numbering
+  start `0`의 underflow를 포화 뺄셈으로 막았다. WMF charset/codepage table은 unsafe `static mut` 대신
+  immutable `OnceLock`으로 초기화한다.
+- focused 세 회귀, format, clippy, diff check를 통과했다. release-test nextest 전체는 5,935 run 중
+  5,934 passed였고 유일한 #2833 시간 예산 실패는 단독 재실행에서 0.079초에 통과해 변경 경로와 분리했다.
+- 상세 근거는 [PR #4743 review](../pr/archives/pr_4743_review.md), 구현·stage·검증 결과는
+  [계획](../plans/task_m100_4290_4292_4624_security.md),
+  [stage](../working/task_m100_4290_4292_4624_stage1.md),
+  [결과](../report/task_m100_4290_4292_4624_security_report.md)에 보존했다.
+- 최신 trailing docs-only head의 GitHub Full CI·CodeQL·mergeability와 작업지시자 승인 뒤에만
+  merge한다. merge 뒤 #4290·#4292·#4624 종료 상태와 remote branch를 공식 post-merge 절차로 확인한다.

--- a/mydocs/plans/task_m100_4290_4292_4624_security.md
+++ b/mydocs/plans/task_m100_4290_4292_4624_security.md
@@ -1,0 +1,45 @@
+# Task m100_4290_4292_4624 - 입력 경계와 WMF 초기화 안전성
+
+## 대상 이슈
+
+- #4290: HWP5 polygon/curve의 양수 point-count가 payload 길이를 넘어도 반복·할당하는 DoS 위험
+- #4292: 번호 시작값 `0`에서 `start - 1`이 unsigned underflow로 panic하는 문제
+- #4624: WMF charset/codepage table의 `AtomicBool + static mut` 수동 초기화 경쟁
+
+## 범위 결정
+
+- 세 이슈는 untrusted document input 또는 native concurrency soundness의 작은 경계 보강이라는 공통 목적을
+  가진다. renderer fidelity, file format output, public API, fixture corpus는 바꾸지 않는다.
+- #4649는 `upstream/devel` commit `7789998a5`에서 `existsSync`와 회귀 테스트로 이미 해결됐다.
+- #4291은 `upstream/devel`의 recent HWPX container depth guard로 처리됐고, #4730에 남은 paragraph/table/HWP5
+  상호재귀는 별도의 shared-depth 설계가 필요하므로 이 통합 범위에서 제외한다.
+- #4739, #4709, #4668, #4669, #4618은 font/rendering 또는 serializer/fallback semantics와 fixture/visual evidence가
+  필요해 security hardening PR과 섞지 않는다.
+
+## 구현 계획
+
+1. `src/parser/control/shape.rs`에서 polygon/curve의 point count를 count field 뒤 남은 point-byte 수로 clamp하고,
+   `i32::MAX` count와 짧은 payload가 실제 point 수만 소비하는 unit test를 둔다.
+2. `src/renderer/layout/utils.rs`에서 numbering offset 계산을 `saturating_sub`로 바꾸고, start value `0` 및
+   advanced counter의 format test를 추가한다.
+3. `src/wmf/parser/constants/enums/character_set.rs`의 two `static mut` table을 `OnceLock` immutable table로
+   교체한다. 여러 native thread가 production table을 동시에 조회하는 regression test로 mapping과
+   synchronization contract를 확인한다.
+4. focused Rust tests, formatter, clippy, `target/pr-review`를 재사용하는 release-test nextest 전체 회귀를 순차
+   실행한다. source/test Rust 변경이므로 GitHub Full CI도 PR의 최신 head에서 확인한다.
+
+## 성공 기준
+
+- oversized positive point count가 payload에 존재하는 point보다 더 많은 loop/allocation을 만들지 않는다.
+- start value `0` numbering format이 panic 없이 deterministic result를 낸다.
+- production WMF lookup path에 unsafe mutable static과 manual initialized flag가 남지 않는다.
+- focused tests와 release-test 전체 nextest가 통과하고 diff/format/clippy 오류가 없다.
+
+## 위험과 비범위
+
+- payload truncate semantics는 현재의 `unwrap_or(0)` fallback을 넓히지 않는다. count를 physical point bytes로
+  제한하는 것만 수행한다.
+- `OnceLock` conversion은 existing BTreeMap mapping entries와 return lifetime을 유지한다. mapping 값이나 charset
+  precedence는 바꾸지 않는다.
+- table grid allocation(#4287)과 generic recursive parsing(#4730 residual)은 distinct call-graph review가
+  필요하므로 이 PR에서 수정하지 않는다.

--- a/mydocs/pr/archives/pr_4743_review.md
+++ b/mydocs/pr/archives/pr_4743_review.md
@@ -1,0 +1,84 @@
+---
+kind: pr-review
+status: local-review-complete
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-14
+---
+
+# PR #4743 검토 - 입력 경계와 WMF 초기화 안전성
+
+| 항목 | 기록 |
+| --- | --- |
+| PR | [#4743](https://github.com/edwardkim/rhwp/pull/4743) |
+| 작성자 | `jangster77` collaborator self PR |
+| 관련 이슈 | [#4290](https://github.com/edwardkim/rhwp/issues/4290), [#4292](https://github.com/edwardkim/rhwp/issues/4292), [#4624](https://github.com/edwardkim/rhwp/issues/4624) |
+| base / code candidate | `devel` / `2967509f0b92725a163fff4ade844e0e97e9457f` |
+| 변경 규모 | 7 files, +302 / -55 |
+| 문서 작성 시점 상태 | `MERGEABLE`, `BLOCKED` 참고값. 최신 head CI와 merge 전 상태 재확인이 필요하다. |
+| 검토 방식 | collaborator self review. 별도 외부 reviewer request는 만들지 않았으며 작업지시자 승인 전 merge하지 않는다. |
+
+## 라우팅
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, local_validation.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+collaborator_self_merge.md, intake_and_review.md, local_validation.md,
+visual_fixture_evidence.md
+current code candidate: 2967509f0b92725a163fff4ade844e0e97e9457f
+```
+
+최신 `upstream/devel` `d871bb8ce` 위 `task_m100_4290_4292_4624-security-20260814` branch에서
+code candidate를 만들고 upstream에 게시했다. 구현·로컬 검증 후 Open PR #4743을 생성한 뒤 이
+검토 기록과 오늘할일을 같은 source branch의 trailing docs-only commit으로 추가한다.
+
+## 변경 검토
+
+- #4290은 polygon과 curve의 unsigned 양수 count가 실제 point payload를 초과하면 EOF의 기본값을
+  반복 push하던 경로를 막는다. count를 남은 `INT32 x/y` 쌍 수로 clamp하므로 정상 payload의 기존
+  parse 순서와 truncated payload의 fallback 의미를 넓히지 않는다.
+- #4292는 `start - 1` 대신 `saturating_sub(1)`을 사용한다. malformed `start=0`이 panic하지 않고
+  deterministic number string을 만들며, 양수 start의 기존 산술은 바뀌지 않는다.
+- #4624는 manual atomic flag와 `static mut BTreeMap`을 immutable `OnceLock`으로 교체한다. 기존 map
+  17개 codepage mapping과 symbol table 내용을 그대로 보존하고 unsafe shared mutation을 제거한다.
+
+`src/renderer/layout/utils.rs`는 바뀌지만 이 변경은 start `0` malformed numbering의 text token 경계만
+다룬다. 페이지 geometry, typeset, paint, fixture, 기준 PDF, golden은 바꾸지 않는다. unit test가 실제
+사용자-visible token `1.`을 확인하므로 이번 안전성 PR에서는 visual sweep을 선택하지 않았다.
+
+## 완료한 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| #4290 HWP5 huge positive point-count focused test | 1 passed |
+| #4292 start=0 numbering focused test | 1 passed, `1.` 확인 |
+| #4624 production WMF table 16-thread focused test | 1 passed, HANGUL `949` / GREEK `1253` 확인 |
+| release-test nextest 전체 | 5,935 run 중 5,934 passed, 37 skipped, 7 slow; #2833 성능 test 1건만 병렬 시간 예산 실패 |
+| #2833 단독 재실행 | 1 passed, 0.079초; 이번 변경과 무관한 일시적 병렬 측정 변동으로 분리 |
+| `cargo fmt --check` | 통과 |
+| `cargo clippy --target-dir target/pr-review --all-targets -- -D warnings` | 통과 |
+| `git diff --check` | 통과 |
+
+문서 링크 검증의 첫 `python scripts/check_markdown_links.py ...` 호출은 이 Ubuntu host에 `python`
+alias가 없어 exit 127로 시작되지 않았다. 같은 저장소 script를 `python3`로 재실행해 문서 자체의
+검증 결과와 분리했다. `python3 scripts/check_markdown_links.py`는 변경 문서 5개의 내부 상대 링크를
+모두 통과했다.
+
+Cargo는 고정 `target/pr-review`를 재사용했고 `CARGO_INCREMENTAL=0`을 지정하지 않았다. source·test
+Rust 변경이 있으므로 이 review 기록을 포함한 최신 PR head의 GitHub Full CI와 CodeQL은 merge 전
+필수 조건이다.
+
+## 이슈 선별과 비범위
+
+- #4649는 upstream commit `7789998a5`에서 이미 해결되어 중복 수정하지 않았다.
+- #4291은 최근 HWPX container guard가 반영됐고, 남은 #4730의 shared recursive-depth 설계는 별도
+  issue로 유지한다.
+- #4739, #4709, #4668, #4669, #4618은 font/rendering, serializer 또는 fallback 계약 검증을 요구하므로
+  이번 input hardening PR에 섞지 않았다.
+
+## 판정
+
+**self-review 수용 후보.** 로컬 코드·focused 검증·lint에서 이번 변경의 blocker는 발견하지 못했다.
+다만 최신 trailing docs-only head의 GitHub Actions, CodeQL, mergeability와 작업지시자 승인 전에는
+merge하지 않는다. merge 뒤에는 PR 본문의 `Closes #4290`, `Closes #4292`, `Closes #4624`에 따른
+이슈 종료 상태와 branch 정리를 post-merge 절차로 확인한다.

--- a/mydocs/report/task_m100_4290_4292_4624_security_report.md
+++ b/mydocs/report/task_m100_4290_4292_4624_security_report.md
@@ -1,0 +1,35 @@
+# Task m100_4290_4292_4624 결과 - 입력 경계와 WMF 초기화 안전성
+
+## 완료 범위
+
+- #4290: HWP5 polygon/curve point-count를 남은 좌표 payload 바이트 수로 제한했다.
+- #4292: numbering start value `0`에서 unsigned underflow가 나지 않도록 `saturating_sub`를 적용했다.
+- #4624: WMF symbol/codepage table의 `AtomicBool + static mut` 수동 lazy initialization을 immutable `OnceLock`으로 교체했다.
+
+## 구현 결과
+
+| 이슈 | 변경 | 회귀 보장 |
+| --- | --- | --- |
+| #4290 | 양수 count를 `remaining / 8`로 clamp | `i32::MAX` count와 좌표 한 쌍이 실제 한 점만 읽는지 확인 |
+| #4292 | `(start - 1) + counter`를 `start.saturating_sub(1) + counter`로 교체 | start `0`, counter `1`이 `1.`을 생성하는지 확인 |
+| #4624 | 두 전역 table을 `OnceLock<BTreeMap<...>>`로 교체 | 16개 native thread가 production lookup을 동시에 수행해도 HANGUL `949`, GREEK `1253` 매핑을 유지하는지 확인 |
+
+## 이슈 선별 및 제외
+
+- #4649는 upstream commit `7789998a5`에서 이미 해결됐다.
+- #4291은 최근 HWPX container depth guard로 반영됐으며 남은 #4730의 generic recursive call graph는 별도 설계 과제다.
+- #4739, #4709, #4668, #4669, #4618은 fidelity, font, serializer 또는 fallback 계약 검증이 필요해 이번 안전성 PR에서 제외했다.
+
+## 검증 결과
+
+- focused tests: #4290, #4292, #4624 각각 통과.
+- 전체 명령: `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast`.
+  - 5,935개 중 5,934개 통과, 37 skipped, 7 slow.
+  - 유일한 실패 `issue_2833_hml_adapter_row_sizes::inflated_row_count_does_not_slow_down_parsing`는 0.573초의 병렬 실행 시간 예산 실패였다.
+  - 같은 `target/pr-review`에서 단독 재실행은 0.079초, 1 passed로 통과했다. 변경 경로와 무관한 일시적 성능 측정 변동으로 판정했다.
+- `cargo fmt --check`, `cargo clippy --target-dir target/pr-review --all-targets -- -D warnings`, `git diff --check` 통과.
+
+## 후속
+
+- generic parser recursion의 shared depth 계약은 #4730에서 별도로 다룬다.
+- 이번 PR은 input hardening과 native initialization soundness만 포함하며 format fidelity 기준이나 공개 API를 바꾸지 않는다.

--- a/mydocs/working/task_m100_4290_4292_4624_stage1.md
+++ b/mydocs/working/task_m100_4290_4292_4624_stage1.md
@@ -1,0 +1,92 @@
+# Task m100_4290_4292_4624 Stage 1 - 보안 경계 보강 구현
+
+## 목표
+
+HWP5 shape point-count, numbering start value, WMF charset table initialization의 known unsafe boundary를
+작은 코드 변경과 direct regression test로 보강한다.
+
+## 시작 상태
+
+- base: `upstream/devel` `d871bb8ce`.
+- active visibility branch: `task_m100_4290_4292_4624-security-20260814`.
+- #4290은 polygon/curve parser에서 negative count만 0으로 처리하며 positive count는 payload byte length로
+  제한하지 않는다.
+- #4292는 `expand_numbering_format`의 `(start - 1) + counter_val`에서 start `0` panic 가능성이 있다.
+- #4624는 charset/codepage table을 `AtomicBool`과 `static mut BTreeMap`으로 lazy initialize한다.
+
+## 수정 대상과 검증
+
+| 대상 | 수정 | 검증 |
+| --- | --- | --- |
+| `src/parser/control/shape.rs` | physical point byte bound와 huge-positive-count test | shape module unit test |
+| `src/renderer/layout/utils.rs`, `src/renderer/layout/tests.rs` | saturating numbering offset와 zero-start test | renderer layout lib test |
+| `src/wmf/parser/constants/enums/character_set.rs` | `OnceLock` immutable initialization와 concurrent lookup test | WMF module test |
+
+## 성공 기준
+
+- 기존 valid point parsing과 charset/codepage mapping은 유지한다.
+- malformed count/start value가 panic, unbounded loop, unsafe shared mutation을 유발하지 않는다.
+- focused tests 뒤 release-test nextest, fmt, diff check, clippy가 순차로 통과한다.
+
+## 검증 기록
+
+### 1. HWP5 point-count 경계 단위 테스트 - 보정 전 실패
+
+- 명령: `cargo test --profile release-test --target-dir target/pr-review --lib oversized_positive_point_counts_are_bounded_by_payload_coordinates -- --nocapture`
+- 결과: 실패 (컴파일 오류 `E0369`).
+- 원인: 새 회귀 테스트가 `model::Point`에 없는 `PartialEq`를 가정해 `Vec<Point>` 전체를 비교했다.
+- 조치: production 모델의 trait 범위를 넓히지 않고, 생성된 점 개수와 `x`/`y` 좌표를 직접 검증하도록 테스트를 보정했다.
+
+### 2. HWP5 point-count 경계 단위 테스트 - 통과
+
+- 명령: `cargo test --profile release-test --target-dir target/pr-review --lib oversized_positive_point_counts_are_bounded_by_payload_coordinates -- --nocapture`
+- 결과: 통과. 1 passed, 0 failed.
+- 확인: `i32::MAX` count와 좌표 한 쌍만 든 polygon/curve payload가 각각 한 점만 읽고 종료됐으며 curve segment type도 생성하지 않았다.
+
+### 3. numbering start=0 단위 테스트 - 통과
+
+- 명령: `cargo test --profile release-test --target-dir target/pr-review --lib test_expand_numbering_format_zero_start_number_does_not_underflow -- --nocapture`
+- 결과: 통과. 1 passed, 0 failed.
+- 확인: `start=0`, 첫 counter `1`에서 unsigned underflow 없이 `1.`이 생성됐다.
+
+### 4. WMF charset/codepage 동시 초기화 단위 테스트 - 통과
+
+- 명령: `cargo test --profile release-test --target-dir target/pr-review --lib charset_tables_can_initialize_concurrently -- --nocapture`
+- 결과: 통과. 1 passed, 0 failed.
+- 확인: 16개 동시 lookup에서 `OnceLock` 기반 symbol/codepage table이 한 번만 초기화됐고 HANGUL `949`, GREEK `1253` 매핑을 유지했다. 최종 보정에서는 local fixture가 아니라 production static table을 직접 조회한다.
+
+### 5. 형식 및 diff 사전 점검 - 통과
+
+- 명령: `cargo fmt`, `git diff --check`.
+- 결과: 통과.
+- 확인: formatter가 적용된 뒤 공백 오류나 충돌 표식 없이 다음 전체 회귀 검증을 시작할 수 있는 상태다.
+
+### 6. release-test 전체 integration 회귀 - 관련 범위 통과, 기존 실패 1건 확인 필요
+
+- 명령: `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast`
+- 결과: 5,935 run 중 5,934 passed, 1 failed, 37 skipped, 7 slow.
+- 이번 변경 회귀: #4290 point-count, #4292 numbering, #4624 WMF 관련 focused test를 포함해 통과했다.
+- 실패: `rhwp::issue_2833_hml_adapter_row_sizes inflated_row_count_does_not_slow_down_parsing` (0.573초). HWP5 shape parser, numbering helper, WMF charset table과 다른 HML adapter 경로이므로 단독 재현으로 기준선/환경 요인을 분리한다.
+- 장기 baseline: `overflow_cell_lines_do_not_grow`는 490.752초 후 통과했고 nextest의 SLOW 표식은 실패가 아니다.
+
+### 7. #2833 HML adapter 실패 단독 재현 - 통과
+
+- 명령: `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --test issue_2833_hml_adapter_row_sizes inflated_row_count_does_not_slow_down_parsing --no-fail-fast`
+- 결과: 통과. 1 passed, 0 failed, 0 skipped (0.079초).
+- 판정: 전체 병렬 회귀의 시간 예산 측정이 일시적으로 흔들린 결과이며, 이번 세 파일의 입력 경계/초기화 변경이 HML adapter parse 성능 실패를 재현하지 않는다.
+
+### 8. format 및 lint 최종 점검 - 통과
+
+- 명령: `cargo fmt --check && cargo clippy --target-dir target/pr-review --all-targets -- -D warnings`
+- 결과: 통과. clippy 경고 0건.
+
+### 9. WMF production static 동시 초기화 재검증 - 통과
+
+- 명령: `cargo test --profile release-test --target-dir target/pr-review --lib charset_tables_can_initialize_concurrently -- --nocapture`
+- 결과: 통과. 1 passed, 0 failed.
+- 확인: 최종 회귀 테스트는 builder용 local fixture가 아니라 production `symbol_charset_table()` 및 `codepage_table()`를 16개 스레드에서 직접 조회한다.
+
+### 10. 최종 형식, lint, diff 점검 - 통과
+
+- 명령: `cargo fmt --check && cargo clippy --target-dir target/pr-review --all-targets -- -D warnings && git diff --check`
+- 결과: 통과. formatter 차이 0건, clippy 경고 0건, diff 공백 오류 0건.

--- a/src/parser/control/shape.rs
+++ b/src/parser/control/shape.rs
@@ -1072,7 +1072,13 @@ fn parse_arc_shape_data(data: &[u8], arc: &mut ArcShape) {
 fn parse_polygon_shape_data(data: &[u8], poly: &mut PolygonShape) {
     let mut r = ByteReader::new(data);
     let cnt_raw = r.read_i32().unwrap_or(0);
-    let cnt = if cnt_raw < 0 { 0 } else { cnt_raw as usize };
+    // 점 하나는 INT32 좌표 두 개(8 bytes)다. count field가 payload보다 큰 경우
+    // EOF 뒤의 0을 반복해서 push하지 않도록 실제 좌표 바이트 수로 제한한다. (#4290)
+    let cnt = if cnt_raw < 0 {
+        0
+    } else {
+        (cnt_raw as usize).min(r.remaining() / 8)
+    };
     poly.points.clear();
     for _ in 0..cnt {
         let x = r.read_i32().unwrap_or(0);
@@ -1095,7 +1101,14 @@ fn parse_curve_shape_data(data: &[u8], curve: &mut CurveShape) {
     // 값이 되어 아래 루프가 사실상 종료되지 않는(수십억 회) DoS 를 유발한다.
     // 캐스팅 전에 음수를 0(빈 곡선)으로 처리한다. (#3012 다각형과 동일 클래스)
     let cnt_raw = r.read_i32().unwrap_or(0);
-    let cnt = if cnt_raw < 0 { 0 } else { cnt_raw as usize };
+    // 점 하나는 INT32 좌표 두 개(8 bytes)다. segment/padding이 잘린 기존
+    // fallback semantics는 유지하되, fabricated positive count로 무한 loop나
+    // 과대 Vec allocation이 생기지 않게 좌표 바이트 수를 상한으로 쓴다. (#4290)
+    let cnt = if cnt_raw < 0 {
+        0
+    } else {
+        (cnt_raw as usize).min(r.remaining() / 8)
+    };
     curve.points.clear();
     for _ in 0..cnt {
         let x = r.read_i32().unwrap_or(0);
@@ -1204,6 +1217,32 @@ mod task195_tests {
             "음수 count는 빈 세그먼트 목록으로 처리되어야 함: {}",
             curve.segment_types.len()
         );
+    }
+
+    #[test]
+    fn oversized_positive_point_counts_are_bounded_by_payload_coordinates() {
+        let mut polygon_data = Vec::new();
+        polygon_data.extend_from_slice(&i32::MAX.to_le_bytes());
+        polygon_data.extend_from_slice(&10i32.to_le_bytes());
+        polygon_data.extend_from_slice(&20i32.to_le_bytes());
+
+        let mut polygon = PolygonShape::default();
+        parse_polygon_shape_data(&polygon_data, &mut polygon);
+        assert_eq!(polygon.points.len(), 1);
+        assert_eq!(polygon.points[0].x, 10);
+        assert_eq!(polygon.points[0].y, 20);
+
+        let mut curve_data = Vec::new();
+        curve_data.extend_from_slice(&i32::MAX.to_le_bytes());
+        curve_data.extend_from_slice(&30i32.to_le_bytes());
+        curve_data.extend_from_slice(&40i32.to_le_bytes());
+
+        let mut curve = CurveShape::default();
+        parse_curve_shape_data(&curve_data, &mut curve);
+        assert_eq!(curve.points.len(), 1);
+        assert_eq!(curve.points[0].x, 30);
+        assert_eq!(curve.points[0].y, 40);
+        assert!(curve.segment_types.is_empty());
     }
 
     #[test]

--- a/src/renderer/layout/tests.rs
+++ b/src/renderer/layout/tests.rs
@@ -1608,6 +1608,40 @@ fn test_expand_numbering_format_hangul() {
 }
 
 #[test]
+fn test_expand_numbering_format_zero_start_number_does_not_underflow() {
+    let numbering = Numbering {
+        raw_data: None,
+        heads: [NumberingHead {
+            number_format: 0,
+            ..Default::default()
+        }; 7],
+        level_formats: [
+            "^1.".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+        ],
+        start_number: 0,
+        level_start_numbers: [0, 1, 1, 1, 1, 1, 1],
+        raw_para_heads: None,
+    };
+    let counters = [1, 0, 0, 0, 0, 0, 0];
+
+    let result = expand_numbering_format(
+        "^1.",
+        &counters,
+        &numbering,
+        &numbering.level_start_numbers,
+        0,
+    );
+
+    assert_eq!(result, "1.");
+}
+
+#[test]
 fn test_expand_numbering_format_level_path() {
     // ^n/^N: 레벨 경로 자동코드 (#2145). 재현 문서는 전 수준 "^N".
     let numbering = Numbering {

--- a/src/renderer/layout/utils.rs
+++ b/src/renderer/layout/utils.rs
@@ -156,7 +156,7 @@ pub(crate) fn expand_numbering_format(
         let counter_val = counters[idx];
         let start = start_numbers[idx];
         let num = if counter_val > 0 {
-            (start - 1) + counter_val
+            start.saturating_sub(1) + counter_val
         } else {
             start
         };

--- a/src/wmf/parser/constants/enums/character_set.rs
+++ b/src/wmf/parser/constants/enums/character_set.rs
@@ -59,19 +59,16 @@ impl From<CharacterSet> for &'static encoding_rs::Encoding {
     }
 }
 
-static SYMBOL_CHARSET_TABLE_INITIALIZED: core::sync::atomic::AtomicBool =
-    core::sync::atomic::AtomicBool::new(false);
-static mut SYMBOL_CHARSET_TABLE: BTreeMap<u8, char> = BTreeMap::new();
+static SYMBOL_CHARSET_TABLE: std::sync::OnceLock<BTreeMap<u8, char>> = std::sync::OnceLock::new();
+
+pub(in crate::wmf::parser) fn symbol_charset_table() -> &'static BTreeMap<u8, char> {
+    SYMBOL_CHARSET_TABLE.get_or_init(build_symbol_charset_table)
+}
 
 #[rustfmt::skip]
-pub(in crate::wmf::parser) fn symbol_charset_table(
-) -> &'static BTreeMap<u8, char> {
-    if !SYMBOL_CHARSET_TABLE_INITIALIZED.load(core::sync::atomic::Ordering::Acquire) {
-        SYMBOL_CHARSET_TABLE_INITIALIZED.store(true, core::sync::atomic::Ordering::Release);
-
-        unsafe {
-            // via: https://en.wikipedia.org/wiki/Symbol_(typeface)
-            SYMBOL_CHARSET_TABLE = BTreeMap::from_iter([
+fn build_symbol_charset_table() -> BTreeMap<u8, char> {
+    // via: https://en.wikipedia.org/wiki/Symbol_(typeface)
+    BTreeMap::from_iter([
                 // 2x
                 (0x20, ' '), (0x21, '!'), (0x22, '∀'), (0x23, '#'),
                 (0x24, '∃'), (0x25, '%'), (0x26, '&'), (0x27, '∍'),
@@ -132,52 +129,57 @@ pub(in crate::wmf::parser) fn symbol_charset_table(
                 (0xF5, '⌡'), (0xF6, '⎞'), (0xF7, '⎟'), (0xF8, '⎠'),
                 (0xF9, '⎤'), (0xFA, '⎥'), (0xFB, '⎦'), (0xFC, '⎫'),
                 (0xFD, '⎬'), (0xFE, '⎭'),
-            ]);
-        }
-    }
-
-    // SAFETY: Mutable access is not possible after state has been
-    // initialized.
-    #[allow(clippy::deref_addrof)]
-    unsafe { &*&raw const SYMBOL_CHARSET_TABLE }
+    ])
 }
 
-static CODEPAGE_TABLE_INITIALIZED: core::sync::atomic::AtomicBool =
-    core::sync::atomic::AtomicBool::new(false);
-static mut CODEPAGE_TABLE: BTreeMap<CharacterSet, u16> = BTreeMap::new();
+static CODEPAGE_TABLE: std::sync::OnceLock<BTreeMap<CharacterSet, u16>> =
+    std::sync::OnceLock::new();
 
 fn codepage_table() -> &'static BTreeMap<CharacterSet, u16> {
-    if !CODEPAGE_TABLE_INITIALIZED.load(core::sync::atomic::Ordering::Acquire) {
-        CODEPAGE_TABLE_INITIALIZED.store(true, core::sync::atomic::Ordering::Release);
+    CODEPAGE_TABLE.get_or_init(build_codepage_table)
+}
 
-        unsafe {
-            // via: https://en.wikipedia.org/wiki/Code_page
-            CODEPAGE_TABLE = BTreeMap::from_iter([
-                (CharacterSet::ANSI_CHARSET, 1252),
-                (CharacterSet::SYMBOL_CHARSET, 42),
-                (CharacterSet::SHIFTJIS_CHARSET, 932),
-                (CharacterSet::HANGUL_CHARSET, 949),
-                (CharacterSet::JOHAB_CHARSET, 1361),
-                (CharacterSet::GB2312_CHARSET, 936),
-                (CharacterSet::CHINESEBIG5_CHARSET, 950),
-                (CharacterSet::GREEK_CHARSET, 1253),
-                (CharacterSet::TURKISH_CHARSET, 1254),
-                (CharacterSet::VIETNAMESE_CHARSET, 1258),
-                (CharacterSet::HEBREW_CHARSET, 1255),
-                (CharacterSet::ARABIC_CHARSET, 1256),
-                (CharacterSet::BALTIC_CHARSET, 1257),
-                (CharacterSet::RUSSIAN_CHARSET, 1251),
-                (CharacterSet::THAI_CHARSET, 874),
-                (CharacterSet::EASTEUROPE_CHARSET, 1250),
-                (CharacterSet::OEM_CHARSET, 437),
-            ]);
-        }
-    }
+fn build_codepage_table() -> BTreeMap<CharacterSet, u16> {
+    // via: https://en.wikipedia.org/wiki/Code_page
+    BTreeMap::from_iter([
+        (CharacterSet::ANSI_CHARSET, 1252),
+        (CharacterSet::SYMBOL_CHARSET, 42),
+        (CharacterSet::SHIFTJIS_CHARSET, 932),
+        (CharacterSet::HANGUL_CHARSET, 949),
+        (CharacterSet::JOHAB_CHARSET, 1361),
+        (CharacterSet::GB2312_CHARSET, 936),
+        (CharacterSet::CHINESEBIG5_CHARSET, 950),
+        (CharacterSet::GREEK_CHARSET, 1253),
+        (CharacterSet::TURKISH_CHARSET, 1254),
+        (CharacterSet::VIETNAMESE_CHARSET, 1258),
+        (CharacterSet::HEBREW_CHARSET, 1255),
+        (CharacterSet::ARABIC_CHARSET, 1256),
+        (CharacterSet::BALTIC_CHARSET, 1257),
+        (CharacterSet::RUSSIAN_CHARSET, 1251),
+        (CharacterSet::THAI_CHARSET, 874),
+        (CharacterSet::EASTEUROPE_CHARSET, 1250),
+        (CharacterSet::OEM_CHARSET, 437),
+    ])
+}
 
-    // SAFETY: Mutable access is not possible after state has been
-    // initialized.
-    #[allow(clippy::deref_addrof)]
-    unsafe {
-        &*&raw const CODEPAGE_TABLE
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn charset_tables_can_initialize_concurrently() {
+        std::thread::scope(|scope| {
+            for _ in 0..16 {
+                scope.spawn(|| {
+                    let symbols = symbol_charset_table();
+                    assert_eq!(symbols.get(&0x41), Some(&'Α'));
+
+                    let codepages = codepage_table();
+                    assert_eq!(codepages.len(), 17);
+                    assert_eq!(codepages.get(&CharacterSet::HANGUL_CHARSET), Some(&949));
+                    assert_eq!(codepages.get(&CharacterSet::GREEK_CHARSET), Some(&1253));
+                });
+            }
+        });
     }
 }


### PR DESCRIPTION
## 목적

신뢰할 수 없는 문서 입력의 작은 경계 결함과 WMF native 초기화 경쟁을 함께 보강합니다.

Closes #4290
Closes #4292
Closes #4624

## 변경

- HWP5 polygon/curve의 양수 point-count를 남은 좌표 payload byte 수로 제한했습니다.
- numbering start value가 `0`인 malformed 문서에서도 underflow 없이 번호를 확장하도록 했습니다.
- WMF symbol/codepage table을 `AtomicBool + static mut`에서 immutable `OnceLock`으로 교체했습니다.
- 세 경로 각각의 회귀 테스트와 한국어 계획·stage·결과 기록을 추가했습니다.

## 검증

- focused #4290/#4292/#4624 단위 테스트 통과
- `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast`: 5,935개 중 5,934개 통과, 37 skipped, 7 slow
  - 유일한 실패 `issue_2833_hml_adapter_row_sizes::inflated_row_count_does_not_slow_down_parsing`는 병렬 실행 시간 예산 측정이었고, 같은 target 디렉터리 단독 재실행은 0.079초에 통과했습니다.
- `cargo fmt --check`, `cargo clippy --target-dir target/pr-review --all-targets -- -D warnings`, `git diff --check` 통과

## 범위 제외

#4730의 generic recursive parser depth, font/rendering fidelity, serializer/fallback semantics는 별도 fixture와 설계 검토가 필요해 포함하지 않았습니다.