### PR TITLE
fix(studio): 개발용 핫패치 경계를 보강한다

### DIFF
--- a/mydocs/orders/20260814.md
+++ b/mydocs/orders/20260814.md
@@ -1,5 +1,18 @@
 # 오늘 할일 - 2026년 8월 14일
 
+## PR #4745 - Studio 개발용 핫패치 경계 보강
+
+- [PR #4745](https://github.com/edwardkim/rhwp/pull/4745)는 `#4635`, `#4643`을 함께 처리한다.
+  개발용 적용 요청 결과를 단일 상수로 통합하고, dynamic import/devtools 연결 실패를 일반 Studio
+  WASM 초기화와 분리했다. CanvasView 생성 순서 오류는 개발 콘솔에서 확인할 수 있다.
+- 더는 소비자가 없는 투명선 이벤트와 주석 구독을 제거했고, 번들 감시 표지의 도메인 이름 오탐과
+  agent runtime 문서의 낡은 Cargo.toml 줄 참조를 정리했다.
+- Studio 단위 테스트 922건, production build, 번들 감시 4건, foreground Vite HTTP 200과
+  `git diff --check`를 통과했다. 상세 판단은 [PR #4745 review](../pr/archives/pr_4745_review.md)에
+  보존한다.
+- 최신 trailing 문서 head의 GitHub Actions·CodeQL·Render Diff·mergeability와 작업지시자 승인 전에는
+  merge하지 않는다.
+
 ## Issue #3211 - Windows 한컴 인라인 제어문 LineSeg 재조판
 
 - Windows Hancom Office 2022에서 #3211 HWP 두 샘플의 페이지 지문이 모두 23쪽·468문단으로

--- a/mydocs/plans/task_m100_4635_4643_hotpatch_boundary.md
+++ b/mydocs/plans/task_m100_4635_4643_hotpatch_boundary.md
@@ -1,0 +1,43 @@
+# Task #4635, #4643 수행계획 - Studio 개발용 핫패치 경계 정리
+
+- Issue: [#4635](https://github.com/edwardkim/rhwp/issues/4635), [#4643](https://github.com/edwardkim/rhwp/issues/4643)
+- Branch: `task_m100_4635_4643-hotpatch-20260814`
+- Base: `upstream/devel` `c121f6185`
+- 작성일: 2026-08-14 KST
+
+## 문제와 범위
+
+Studio의 개발 전용 렌더 코드 교체 경로에는 엔진 결과 코드와 계수 제어 흐름이 서로 다른
+리터럴을 쓰는 지점, WASM 초기화 순서가 틀렸을 때 조용히 비활성화되는 지점, 동적 import 실패가
+앱 초기화를 중단시키는 지점이 남아 있다. 이전 자동 셀 투명선 기능에서 남은 주석 구독과 실제
+구독자가 없는 이벤트 발행도 함께 정리한다.
+
+이번 작업은 개발 전용 런타임의 실패 관측성과 소스 계약만 다룬다. 렌더러 계산, HWP/HWPX 파서,
+WASM 공개 ABI, 사용자 문서의 출력은 변경하지 않는다.
+
+## 구현 경계
+
+1. 적용 요청 결과 코드 `patch-dispatched`를 진단 표와 누적 계수가 공유하는 상수로 만든다.
+2. CanvasView가 WASM 초기화 전에 생성된 경우 개발 콘솔에 기동 순서 원인을 남긴다.
+3. 개발 전용 런타임 동적 import 또는 devtools 연결 실패는 경고를 남기고 일반 Studio 초기화를
+   계속 진행하게 한다.
+4. 더는 소비자가 없는 `transparent-borders-changed` 이벤트 발행과 그 주석 처리된 구독 흔적을
+   제거한다.
+5. 프로덕션 번들 감시 표지에서는 이미 도메인 이름이 된 `rebuildDerivedState`를 제외하고, 문서의
+   Cargo.toml 줄 참조를 현재 위치로 바로잡는다.
+
+## 검증 계획
+
+- `npm --prefix rhwp-studio test`로 개발 런타임 결과 코드·누적 계약과 초기화 경계 source contract를
+  확인한다.
+- `npm --prefix rhwp-studio run build`와 `node --test scripts/frontend-studio-dist.test.mjs`로
+  번들 감시와 빌드 산출물을 확인한다.
+- `npm --prefix rhwp-studio test`로 Studio 단위 테스트 전체를 실행한다.
+- `git diff --check`와 TypeScript 컴파일을 포함한 build 성공을 확인한다.
+
+## 완료 조건
+
+- 코드 계수와 진단 표가 같은 적용 요청 결과 상수를 소비한다.
+- 개발용 초기화 순서와 동적 import 실패가 조용히 사라지지 않으며, 일반 Studio 초기화를 막지 않는다.
+- 사용하지 않는 이벤트와 주석 처리된 구독이 소스에 남지 않는다.
+- 번들 감시가 개발 전용 표지를 검사하되 일반 도메인 메서드 이름을 오탐하지 않는다.

--- a/mydocs/pr/archives/pr_4745_review.md
+++ b/mydocs/pr/archives/pr_4745_review.md
@@ -1,0 +1,53 @@
+# PR #4745 검토 기록 - Studio 개발용 핫패치 경계 보강
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4745](https://github.com/edwardkim/rhwp/pull/4745) |
+| 제목 | `fix(studio): 개발용 핫패치 경계를 보강한다` |
+| 작성자 | `jangster77` |
+| base | `devel` |
+| 초기 code head | `125b49b2c3fb7a966fe4ecd9704b83842b78b0d1` |
+| 규모 | 12 files, +192/-30 (문서 포함) |
+| 작성 시점 상태 | `MERGEABLE`, CI·CodeQL·Render Diff preflight 진행 중 |
+
+## 라우팅
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, local_validation.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+collaborator_self_merge.md, intake_and_review.md, local_validation.md
+current head: 125b49b2c3fb7a966fe4ecd9704b83842b78b0d1 (문서 작성 시점의 code candidate)
+```
+
+`gh pr edit --add-reviewer jangster77`는 GitHub CLI가 요청과 무관한 deprecated Projects classic
+GraphQL 필드를 조회하면서 실패했다. 외부 reviewer를 추정해 요청하지 않았고, 이 PR은 collaborator
+자체 검토 기록과 최신 required check를 근거로 판단한다.
+
+## 관련 이슈와 변경 범위
+
+- `#4635`: 주석 처리된 자동 투명선 구독과 소비자 없는 이벤트 발행을 제거했다. 번들 감시에서는
+  개발 전용 식별자가 아닌 `rebuildDerivedState`를 표지 목록에서 제외하고 문서 줄 참조를 고쳤다.
+- `#4643`: 적용 요청 결과를 진단 표와 누적 계수가 공유하는 상수로 만들었다. 개발용 dynamic import와
+  devtools 연결 실패는 경고 뒤 일반 WASM 초기화를 계속하며, CanvasView 생성 순서가 틀리면 원인을
+  개발 콘솔에 남긴다.
+- 렌더러, 페이지네이션, HWP/HWPX fixture, WASM 공개 ABI와 CI workflow는 변경하지 않았다.
+
+## 로컬 검증
+
+- `npm --prefix rhwp-studio test`를 실행해 922/922건 통과했다.
+- `npm --prefix rhwp-studio run build`를 실행해 TypeScript 검사와 Vite production build를 통과했다.
+- `node --test scripts/frontend-studio-dist.test.mjs`를 실행해 4/4건 통과했다.
+- `npm --prefix rhwp-studio run dev -- --host 0.0.0.0 --port 7702`를 foreground로 기동하고,
+  `http://127.0.0.1:7702/`와 `/src/main.ts`가 모두 HTTP 200인 것을 확인한 뒤 종료했다.
+- `git diff --check`를 통과했다.
+
+Studio 개발용 런타임·도구·문서만 변경했으므로 Cargo 전체 회귀, Native Skia, WASM 재빌드와
+PDF/SVG 시각 대조는 적용 대상이 아니다.
+
+## 권고
+
+로컬 검증상 차단 이슈는 없다. 문서 trailing commit이 포함된 최신 PR head에서 GitHub Actions,
+CodeQL, Render Diff와 mergeability를 다시 확인하고, 작업지시자 승인 후에만 merge한다.

--- a/mydocs/tech/agent_runtime/README.md
+++ b/mydocs/tech/agent_runtime/README.md
@@ -31,7 +31,7 @@ rhwp의 공식 실행 진입로인 CLI와 MCP는 같은 실행 파일 관문을 
 
 | 진입로 | 전제 | 근거 |
 | --- | --- | --- |
-| CLI | `rhwp` 실행 파일이 `PATH` 에 있다 | `Cargo.toml:17-19` `[[bin]] name = "rhwp"` |
+| CLI | `rhwp` 실행 파일이 `PATH` 에 있다 | `Cargo.toml:20-22` `[[bin]] name = "rhwp"` |
 | MCP | 호스트가 `rhwp mcp-serve` 를 자식으로 띄운다 | `src/mcp_serve.rs` 가 stdio JSON-RPC 서버 |
 
 둘 다 **바이너리를 구한 뒤에야** 시작된다. 임의 실행 파일 반입이 막힌 샌드박스나

--- a/mydocs/tech/agent_runtime/surface_spec.md
+++ b/mydocs/tech/agent_runtime/surface_spec.md
@@ -44,7 +44,7 @@ last_verified: 2026-08-03
 
 | 진입로 | 전제 | 근거 |
 | --- | --- | --- |
-| CLI | `rhwp` 실행 파일이 `PATH` 에 있다 | `Cargo.toml:17-19` `[[bin]] name = "rhwp"` |
+| CLI | `rhwp` 실행 파일이 `PATH` 에 있다 | `Cargo.toml:20-22` `[[bin]] name = "rhwp"` |
 | MCP | 호스트가 `rhwp mcp-serve` 를 자식으로 띄운다 | `src/mcp_serve.rs` 전체가 stdio JSON-RPC 서버 |
 
 둘 다 **바이너리를 구한 뒤에야** 시작된다. 샌드박스 안 에이전트 — 임의 실행 파일
@@ -52,7 +52,7 @@ last_verified: 2026-08-03
 
 ### 1.2 WASM 표면은 이미 있다. 그런데 에이전트용이 아니다
 
-rhwp 는 이미 WASM 으로 컴파일된다(`Cargo.toml:13-15` `crate-type = ["rlib","cdylib"]`,
+rhwp 는 이미 WASM 으로 컴파일된다(`Cargo.toml:13-18` `crate-type = ["rlib","cdylib"]`,
 `wasm-pack build --target web`). 규모 실측: `src/wasm_api.rs` **7,621줄**,
 `wasm_bindgen` **372회**, 명시 `js_name` export **364개**(`get*` 121, `set*` 42,
 `render*` 14). 이름 분포가 성격을 말한다 — `renderPageToCanvasFilteredWithProfile`
@@ -75,7 +75,7 @@ $ grep -c schemaVersion src/main.rs       →  112
 - 봉투 생성기(`structure_json_value` `src/main.rs:6793`, `tables_json_value` `:6810`,
   `fields_json_value` `:6826`, `search_json_value` `:6893`, `info_json_value` `:6993`,
   `extract_data_json_value` `:9956`)가 **전부 `src/main.rs` 안에 있다.**
-- `src/main.rs` 는 `[[bin]]` 이고(`Cargo.toml:17-19`) WASM 빌드는 `--lib` 만 간다
+- `src/main.rs` 는 `[[bin]]` 이고(`Cargo.toml:20-22`) WASM 빌드는 `--lib` 만 간다
   (`.github/workflows/ci.yml:816` `cargo check --target wasm32-unknown-unknown --lib`).
 - 즉 **`src/wasm_api.rs` 는 봉투 생성기를 볼 수 없다.**
 

--- a/mydocs/working/task_m100_4635_4643_stage1.md
+++ b/mydocs/working/task_m100_4635_4643_stage1.md
@@ -1,0 +1,40 @@
+# Task #4635, #4643 Stage 1 - Studio 개발용 핫패치 경계 보정
+
+- Issue: [#4635](https://github.com/edwardkim/rhwp/issues/4635), [#4643](https://github.com/edwardkim/rhwp/issues/4643)
+- Base: `upstream/devel` `c121f6185`
+- Branch: `task_m100_4635_4643-hotpatch-20260814`
+- 작성일: 2026-08-14 KST
+
+## 구현 계획
+
+개발 전용 렌더 코드 교체의 `patch-dispatched` 결과 코드를 상수로 소유하게 하고 진단 표와
+누적 계수가 모두 그 상수를 사용하게 한다. WASM bridge는 개발 전용 런타임 import 또는 devtools
+연결이 실패해도 경고만 남기고 초기화를 완료한다. CanvasView는 bridge 초기화가 끝나지 않아 교체
+능력을 받지 못했을 때 같은 원인을 경고한다.
+
+더는 소비자가 없는 투명선 이벤트 발행과 주석 구독을 제거한다. 번들 감시에서는 도메인 이름이 된
+`rebuildDerivedState`를 개발용 표지 목록에서 빼고, Cargo.toml 줄 참조 네 곳을 현재 위치로 고친다.
+
+## 검증 결과
+
+`patch-dispatched` 적용 결과를 진단 표와 누적 계수가 함께 쓰는 exported 상수로 옮겼다.
+WasmBridge의 개발용 runtime import와 devtools 연결은 `try/catch`로 감싸 일반 WASM 초기화를
+계속 진행하게 했고, CanvasView는 초기화 순서가 틀린 경우 개발 콘솔에 원인을 남긴다.
+
+더는 소비자가 없는 `transparent-borders-changed`의 emit과 주석 구독을 제거했다. 프로덕션 번들
+감시에서는 도메인 메서드 `rebuildDerivedState`를 표지 목록에서 제외했고, agent runtime 문서의
+Cargo.toml 줄 참조 네 곳을 현재 위치로 갱신했다.
+
+다음 검증을 순차 실행했다.
+
+- `npm --prefix rhwp-studio test` - 922/922 통과, 실패 0건, 약 8.94초.
+- `npm --prefix rhwp-studio run build` - `tsc`와 Vite production build 통과. CanvasKit의 browser
+  externalization 및 chunk-size 안내만 있었고 build 실패는 없었다.
+- `node --test scripts/frontend-studio-dist.test.mjs` - 4/4 통과. 개발 전용 runtime 표지와
+  프로덕션 번들 누출 부재를 확인했다.
+- `npm --prefix rhwp-studio run dev -- --host 0.0.0.0 --port 7702` - foreground Vite가 준비된 뒤
+  `curl`로 `http://127.0.0.1:7702/`, `/src/main.ts` 모두 HTTP 200을 확인하고 종료했다.
+- `git diff --check` - 통과.
+
+렌더러, 페이지네이션, HWP/HWPX fixture와 WASM 공개 ABI는 변경하지 않았으므로 시각 기준 PDF
+대조와 Cargo 전체 회귀는 이번 Stage의 변경 범위에 적용하지 않았다.

--- a/rhwp-studio/src/command/commands/view.ts
+++ b/rhwp-studio/src/command/commands/view.ts
@@ -276,7 +276,6 @@ export const viewCommands: CommandDef[] = [
       document.querySelectorAll('[data-cmd="view:border-transparent"]').forEach(el => {
         el.classList.toggle('active', next);
       });
-      services.eventBus.emit('transparent-borders-changed', next);
       services.eventBus.emit('document-view-changed');
     },
   },

--- a/rhwp-studio/src/core/subsecond-runtime.ts
+++ b/rhwp-studio/src/core/subsecond-runtime.ts
@@ -117,6 +117,8 @@ export type SubsecondPatchAccumulationOptions = {
 
 const RECONNECT_MIN_MS = 250;
 const RECONNECT_MAX_MS = 4_000;
+/** 엔진이 점프 테이블 수신까지 수락했음을 뜻하는 결과 코드의 단일 소유자. */
+export const PATCH_DISPATCHED_OUTCOME = 'patch-dispatched';
 /**
  * 이 시간보다 오래 붙어 있었던 연결만 "살아 있었다"고 보고 백오프를 되돌린다.
  * 재연결 상한과 우연히 같은 값이지만 다른 개념이다 — 상한을 바꾼다고 같이 바뀌면 안 된다.
@@ -195,7 +197,7 @@ export class SubsecondPatchAccumulation {
  * 번들까지 따라온다.
  */
 const SUBSECOND_OUTCOMES: Record<string, SubsecondDiagnostic | undefined> = {
-  'patch-dispatched': {
+  [PATCH_DISPATCHED_OUTCOME]: {
     level: 'info',
     message:
       '점프 테이블을 subsecond 에 넘겼다. wasm 에서 적용은 비동기라 성공 여부는 여기서 알 수 없다 — ' +
@@ -246,6 +248,11 @@ const SUBSECOND_OUTCOMES: Record<string, SubsecondDiagnostic | undefined> = {
  * 엔진 소스에서 읽은 목록과 맞대 볼 수 있고, 어긋남이 테스트 실패가 된다.
  */
 export const SUBSECOND_OUTCOME_CODES: readonly string[] = Object.keys(SUBSECOND_OUTCOMES);
+
+/** 적용 요청 결과만 누적 계수와 전역 오류 귀속의 기준으로 삼는다. */
+export function isPatchDispatchedOutcome(outcome: string): boolean {
+  return outcome === PATCH_DISPATCHED_OUTCOME;
+}
 
 /** 신호 하나를 개발자가 읽을 한 줄로 만든다. */
 export function describeSubsecondSignal(signal: SubsecondSignal): SubsecondDiagnostic {
@@ -439,7 +446,7 @@ export function connectSubsecondDevtools(
     socket.onmessage = event => {
       if (typeof event.data !== 'string') return;
       const outcome = applyMessage(event.data);
-      if (outcome === 'patch-dispatched') {
+      if (isPatchDispatchedOutcome(outcome)) {
         dispatchedPatches += 1;
         patchAccumulation.recordApplied();
       }

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -300,19 +300,26 @@ export class WasmBridge {
     wasmModule: { memory?: WebAssembly.Memory },
   ): Promise<void> {
     if (!import.meta.env.DEV) return;
-    const runtime = await import('./subsecond-runtime');
-    this.renderCodeReload = runtime.createRenderCodeReload(wasmExports, () => this.doc);
-    if (!disconnectSubsecondDevtools) {
-      disconnectSubsecondDevtools = runtime.connectSubsecondDevtools(
-        wasmExports as unknown as SubsecondWasmExports,
-        {
-          patchAccumulation: new runtime.SubsecondPatchAccumulation({
-            // subsecond 세션에서는 이 모듈이 dx 가 만든 glue(`target/rhwp-subsecond-vite/`)로
-            // 바뀐다. 타입은 언제나 `pkg/rhwp.d.ts` 를 보므로 memory 부재는 타입으로 못 걸러진다.
-            measureHeapBytes: () => wasmModule.memory?.buffer.byteLength ?? null,
-          }),
-        },
-      );
+    try {
+      const runtime = await import('./subsecond-runtime');
+      const renderCodeReload = runtime.createRenderCodeReload(wasmExports, () => this.doc);
+      const disconnect = disconnectSubsecondDevtools
+        ? null
+        : runtime.connectSubsecondDevtools(
+          wasmExports as unknown as SubsecondWasmExports,
+          {
+            patchAccumulation: new runtime.SubsecondPatchAccumulation({
+              // subsecond 세션에서는 이 모듈이 dx 가 만든 glue(`target/rhwp-subsecond-vite/`)로
+              // 바뀐다. 타입은 언제나 `pkg/rhwp.d.ts` 를 보므로 memory 부재는 타입으로 못 걸러진다.
+              measureHeapBytes: () => wasmModule.memory?.buffer.byteLength ?? null,
+            }),
+          },
+        );
+      this.renderCodeReload = renderCodeReload;
+      if (disconnect) disconnectSubsecondDevtools = disconnect;
+    } catch (error) {
+      // 개발 편의 기능의 준비 실패가 문서 편집기의 WASM 초기화 전체를 막으면 안 된다.
+      console.warn('[WasmBridge] 개발용 렌더 코드 교체를 시작하지 못했습니다:', error);
     }
   }
 

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -486,7 +486,7 @@ export class InputHandler {
   private formOverlay: HTMLElement | null = null;
 
   // [Task #394] 셀 진입 자동 ON 로직 비활성화 — checkTransparentBordersTransition 와 동시 주석 처리.
-  // 되돌리려면 아래 3 개 변수 + 호출 지점 + 메서드 본체 + 이벤트 핸들러의 주석을 동시에 해제.
+  // 되돌리려면 아래 3 개 변수 + 호출 지점 + 메서드 본체의 주석을 동시에 해제.
   // // 투명선 자동 활성화 상태
   // private wasInCell = false;
   // private manualTransparentBorders = false;
@@ -689,13 +689,6 @@ export class InputHandler {
     eventBus.on('open-document-bytes', () => {
       this.clearTableResizeRuntimeCache();
     });
-
-    // [Task #394] 셀 진입 자동 ON 로직 비활성화 — manual 추적 불필요.
-    // transparent-borders-changed 이벤트 자체는 view.ts 에서 emit 되므로 보존됨 (다른 구독자가 사용 가능).
-    // // 투명선 수동 토글 상태 추적
-    // eventBus.on('transparent-borders-changed', (show) => {
-    //   this.manualTransparentBorders = show as boolean;
-    // });
 
     // Toolbar에서 서식 적용 요청 수신 (글꼴명, 크기, 색상 — 커맨드 시스템 미경유)
     eventBus.on('format-char', (props) => {

--- a/rhwp-studio/src/view/canvas-view.ts
+++ b/rhwp-studio/src/view/canvas-view.ts
@@ -131,7 +131,12 @@ export class CanvasView {
   private startRenderCodeReloadWatch(): void {
     if (!import.meta.env.DEV) return;
     const renderCodeReload = this.wasm.getRenderCodeReload();
-    if (!renderCodeReload) return;
+    if (!renderCodeReload) {
+      console.warn(
+        '[CanvasView] 개발용 렌더 코드 교체가 준비되지 않았습니다. CanvasView는 await wasm.initialize() 뒤에 생성해야 합니다.',
+      );
+      return;
+    }
     void import('@/core/subsecond-runtime')
       .then(({ RenderCodeReloadWatcher }) => {
         if (this.disposed) return;

--- a/rhwp-studio/tests/subsecond-boundary-contract.test.ts
+++ b/rhwp-studio/tests/subsecond-boundary-contract.test.ts
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+function method(sourceText: string, startToken: string, endToken: string): string {
+  const start = sourceText.indexOf(startToken);
+  const end = sourceText.indexOf(endToken, start);
+  assert.ok(start >= 0 && end > start, `${startToken} 범위를 찾을 수 있어야 한다`);
+  return sourceText.slice(start, end);
+}
+
+test('개발용 런타임 import 실패는 Studio WASM 초기화를 중단시키지 않는다', () => {
+  const bridge = method(
+    source('src/core/wasm-bridge.ts'),
+    '  private async startRenderCodeReload(',
+    '\n  /**\n   * 렌더 코드 교체 능력.',
+  );
+
+  assert.match(bridge, /try \{[\s\S]*await import\('\.\/subsecond-runtime'\)/);
+  assert.match(
+    bridge,
+    /catch \(error\) \{[\s\S]*console\.warn\('\[WasmBridge\] 개발용 렌더 코드 교체를 시작하지 못했습니다:'/,
+  );
+});
+
+test('CanvasView는 초기화 순서가 틀린 개발용 교체 구성을 조용히 끄지 않는다', () => {
+  const canvasView = method(
+    source('src/view/canvas-view.ts'),
+    '  private startRenderCodeReloadWatch(): void {',
+    '\n  /** 문서 로드 후 호출',
+  );
+
+  assert.match(
+    canvasView,
+    /if \(!renderCodeReload\) \{[\s\S]*console\.warn\([\s\S]*await wasm\.initialize\(\)[\s\S]*return;/,
+  );
+});
+
+test('비활성화된 자동 투명선 경로의 고아 이벤트를 남기지 않는다', () => {
+  assert.doesNotMatch(source('src/engine/input-handler.ts'), /transparent-borders-changed/);
+  assert.doesNotMatch(source('src/command/commands/view.ts'), /transparent-borders-changed/);
+});

--- a/rhwp-studio/tests/subsecond-runtime.test.ts
+++ b/rhwp-studio/tests/subsecond-runtime.test.ts
@@ -495,6 +495,25 @@ test('the studio describes exactly the outcome codes the engine declares', async
   );
 });
 
+test('applied patch outcome has one source shared by diagnostics and accumulation', async () => {
+  const {
+    PATCH_DISPATCHED_OUTCOME,
+    SUBSECOND_OUTCOME_CODES,
+    isPatchDispatchedOutcome,
+  } = await loadRuntime();
+
+  assert.ok(
+    ENGINE_OUTCOME_CODES.includes(PATCH_DISPATCHED_OUTCOME),
+    '누적 계수가 쓰는 적용 결과는 엔진의 DevtoolsMessageOutcome::code()에 있어야 한다',
+  );
+  assert.ok(
+    SUBSECOND_OUTCOME_CODES.includes(PATCH_DISPATCHED_OUTCOME),
+    '누적 계수가 쓰는 적용 결과는 Studio 진단 표에도 있어야 한다',
+  );
+  assert.equal(isPatchDispatchedOutcome(PATCH_DISPATCHED_OUTCOME), true);
+  assert.equal(isPatchDispatchedOutcome('not-hot-reload'), false);
+});
+
 test('every devserver outcome reaches a reporter instead of being discarded', async () => {
   const { socket, signals, disconnect } = await connectWithSignals(message => message);
 

--- a/scripts/frontend-studio-dist.test.mjs
+++ b/scripts/frontend-studio-dist.test.mjs
@@ -27,7 +27,6 @@ const HOTPATCH_MARKERS = [
   'subsecondProbe',
   'applySubsecondDevtoolsMessage',
   'getRenderCodeRevision',
-  'rebuildDerivedState',
 ];
 
 /**


### PR DESCRIPTION
## 해결 범위

Closes #4635
Closes #4643

- 개발용 `patch-dispatched` 결과 코드를 진단 표와 누적 계수가 공유하는 단일 상수로 정리했다.
- 개발용 runtime 동적 import 또는 devtools 연결 실패가 일반 Studio WASM 초기화를 중단시키지 않게 경고 후 계속 진행하도록 했다.
- CanvasView가 `await wasm.initialize()` 이전에 만들어졌을 때 개발 콘솔에 기동 순서 원인을 남긴다.
- 소비자가 없는 `transparent-borders-changed` 이벤트와 주석 처리된 구독을 제거했다.
- 번들 감시 표지에서 일반 도메인 메서드 `rebuildDerivedState`를 제외하고, agent runtime 문서의 Cargo.toml 줄 참조를 현재 위치로 갱신했다.

## 검증

- `npm --prefix rhwp-studio test` - 922/922 통과.
- `npm --prefix rhwp-studio run build` - `tsc`와 Vite production build 통과.
- `node --test scripts/frontend-studio-dist.test.mjs` - 4/4 통과.
- `npx vite --host 0.0.0.0 --port 7702` foreground 기동 뒤 루트와 `/src/main.ts` HTTP 200 확인.
- `git diff --check` 통과.

렌더러, 페이지네이션, HWP/HWPX fixture와 WASM 공개 ABI는 변경하지 않았다.
