### PR TITLE
fix: #4089 Windows Docker WASM 빌드 격리

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,15 +34,40 @@ services:
         UID: ${UID:-1000}
         GID: ${GID:-1000}
     env_file: .env.docker
+    # Docker Desktop의 Windows bind mount는 Cargo가 쓰는 hard link를 보장하지 않는다.
+    # named volume에는 빌드 cache를 보존하고, host에 노출되는 pkg만 /app에 남긴다. (#4089)
+    user: "0:0"
+    environment:
+      CARGO_TARGET_DIR: /build-target
+      HOST_UID: ${UID:-1000}
+      HOST_GID: ${GID:-1000}
     volumes:
       - .:/app
       - cargo-cache:/home/builder/.cargo/registry
       - cargo-bin:/home/builder/.cargo/bin
       - wasm-pack-cache:/home/builder/.cache/.wasm-pack
+      - wasm-target:/build-target
     working_dir: /app
-    command: wasm-pack build --target web
+    command:
+      - sh
+      - -ec
+      - |
+        finish() {
+          status=$?
+          if [ -d pkg ]; then
+            chown -R "$${HOST_UID}:$${HOST_GID}" pkg || exit 1
+          fi
+          exit "$${status}"
+        }
+        trap 'exit 129' HUP
+        trap 'exit 130' INT
+        trap 'exit 143' TERM
+        trap finish EXIT
+        rm -f pkg/*-opt.wasm
+        wasm-pack build --target web
 
 volumes:
   cargo-cache:
   cargo-bin:
   wasm-pack-cache:
+  wasm-target:

--- a/mydocs/manual/dev_environment_guide.md
+++ b/mydocs/manual/dev_environment_guide.md
@@ -101,9 +101,35 @@ cargo nextest run \
 
 Rust 또는 WASM 경계가 바뀌면 저장소 루트에서 `pkg/`를 갱신한다.
 
-```bash
-wasm-pack build --target web --out-dir pkg
+Windows·macOS·Linux 공통 표준 경로는 Docker의 `wasm` 서비스다. 최초 한 번만 `.env.docker`가
+없을 때 예제를 복사하고, 이후에는 기존 파일을 덮어쓰지 않는다.
+
+```powershell
+if (-not (Test-Path .env.docker)) {
+    Copy-Item .env.docker.example .env.docker
+}
+docker compose --env-file .env.docker run --rm wasm
 ```
+
+이 서비스는 Cargo target을 named volume에 유지한다. 특히 Windows Docker Desktop의 `/app/target`
+bind mount는 hard-link를 지원하지 않아 Cargo가 실패할 수 있으므로, host `target/`을 강제로
+재사용하지 않는다. 빌드 시작 시에는 이전에 중단된 wasm-pack이 남긴 `pkg/*-opt.wasm`만 제거한다.
+이 파일을 남기면 wasm-pack이 임시 최적화 결과를 다시 입력으로 열거해 무한 실행 또는
+`*-opt.wasm-opt.wasm` 실패로 이어질 수 있다. (#4089)
+
+Docker를 사용할 수 없는 호스트에서 원인을 분리하는 **진단용** 네이티브 경로는 아래와 같다.
+`--no-opt` 결과는 최적화된 배포 산출물을 대체하지 않는다.
+
+```powershell
+Remove-Item -Force -ErrorAction SilentlyContinue pkg\*-opt.wasm
+$env:CARGO_TARGET_DIR = 'target\pr-review'
+wasm-pack build --target web --out-dir pkg --no-opt
+Remove-Item Env:CARGO_TARGET_DIR
+```
+
+네이티브 `wasm-pack build`를 최적화까지 포함해 반복 검증해야 하면 먼저 표준 Docker 경로를
+복구한다. Windows에서는 이전의 직접 최적화 명령을 반복 실행하지 않으며, 위 진단으로
+`pkg/` 잔재와 wasm-opt만 분리해 확인한다.
 
 TypeScript와 CSS는 Vite가 다시 읽지만 Rust 변경은 위 빌드가 끝나야 브라우저에 반영된다.
 

--- a/mydocs/orders/20260814.md
+++ b/mydocs/orders/20260814.md
@@ -1,5 +1,16 @@
 # 오늘 할일 - 2026년 8월 14일
 
+## Issue #4089 - Windows Docker WASM 산출물 격리
+
+- `planet6897`의 열린 이슈 20건을 전수 분류한 결과, 명확한 단일 재현과 Windows Docker 검증이
+  가능한 #4089을 선택했다. GitHub App의 assignee mutation은 403이었으나 저장소 절차에 따라
+  인증된 `gh`로 `jangster77`를 assignee로 지정해 세션 잠금을 확보했다.
+- `codex/issue-4089-wasm-docker`는 최신 `upstream/devel@c121f6185`에서 시작한다. named Cargo
+  target volume, stale `*-opt.wasm` 정리, host 산출물 ownership 복원과 개발 가이드 정합만
+  다루며 renderer·parser 이슈는 섞지 않는다.
+- 상세 범위와 검증은 [수행계획](../plans/task_m100_4089.md)에 기록한다. 구현·Windows Docker
+  재현이 끝난 뒤 PR 생성 전 focused 검증 근거를 이 항목과 stage 문서에 보강한다.
+
 ## Issue #3211 - Windows 한컴 인라인 제어문 LineSeg 재조판
 
 - Windows Hancom Office 2022에서 #3211 HWP 두 샘플의 페이지 지문이 모두 23쪽·468문단으로

--- a/mydocs/orders/20260814.md
+++ b/mydocs/orders/20260814.md
@@ -12,6 +12,10 @@
   없고 네이티브 `wasm-pack`도 고정판 0.15.0이 아닌 0.14.0이어서, 컨테이너 실행·릴리스 WASM
   검증은 기록하지 않는다. 상세 구현과 검증 한계는 [수행계획](../plans/task_m100_4089.md)과
   [Stage 1](../working/task_m100_4089_stage1.md)에 남겼다.
+- [PR #4746](https://github.com/edwardkim/rhwp/pull/4746)을 `devel` 대상으로 열었다. self-review
+  기록과 clean merge simulation은 [PR review](../pr/archives/pr_4746_review.md)에 남겼다. 최신
+  code/review head의 CI와 Docker Desktop Windows 실실행을 확인하고 작업지시자가 승인하기 전에는
+  merge·#4089 종료를 진행하지 않는다.
 
 ## Issue #3211 - Windows 한컴 인라인 제어문 LineSeg 재조판
 

--- a/mydocs/orders/20260814.md
+++ b/mydocs/orders/20260814.md
@@ -8,8 +8,10 @@
 - `codex/issue-4089-wasm-docker`는 최신 `upstream/devel@c121f6185`에서 시작한다. named Cargo
   target volume, stale `*-opt.wasm` 정리, host 산출물 ownership 복원과 개발 가이드 정합만
   다루며 renderer·parser 이슈는 섞지 않는다.
-- 상세 범위와 검증은 [수행계획](../plans/task_m100_4089.md)에 기록한다. 구현·Windows Docker
-  재현이 끝난 뒤 PR 생성 전 focused 검증 근거를 이 항목과 stage 문서에 보강한다.
+- Compose 정적 계약 4건과 `git diff --check`는 통과했다. 현재 host에는 Docker CLI·`.env.docker`가
+  없고 네이티브 `wasm-pack`도 고정판 0.15.0이 아닌 0.14.0이어서, 컨테이너 실행·릴리스 WASM
+  검증은 기록하지 않는다. 상세 구현과 검증 한계는 [수행계획](../plans/task_m100_4089.md)과
+  [Stage 1](../working/task_m100_4089_stage1.md)에 남겼다.
 
 ## Issue #3211 - Windows 한컴 인라인 제어문 LineSeg 재조판
 

--- a/mydocs/orders/20260814.md
+++ b/mydocs/orders/20260814.md
@@ -16,6 +16,9 @@
   기록과 clean merge simulation은 [PR review](../pr/archives/pr_4746_review.md)에 남겼다. 최신
   code/review head의 CI와 Docker Desktop Windows 실실행을 확인하고 작업지시자가 승인하기 전에는
   merge·#4089 종료를 진행하지 않는다.
+- update branch가 `devel@be7dabdd1`을 반영한 최신 code head `43117ad3`에서 Build & Test,
+  Native Skia, CodeQL을 포함한 CI가 통과했다. #4089 구성 계약 4/4과 diff 검사도 새 head에서
+  재확인했다. review-only 기록 push 뒤 최신 aggregate와 Docker 실실행 확인은 남아 있다.
 ## PR #4745 - Studio 개발용 핫패치 경계 보강
 
 - [PR #4745](https://github.com/edwardkim/rhwp/pull/4745)는 `#4635`, `#4643`을 함께 처리한다.

--- a/mydocs/plans/task_m100_4089.md
+++ b/mydocs/plans/task_m100_4089.md
@@ -1,0 +1,49 @@
+# Task #4089 수행계획 — Windows Docker WASM 산출물 격리
+
+- **Issue**: [#4089](https://github.com/edwardkim/rhwp/issues/4089)
+- **Branch**: `codex/issue-4089-wasm-docker`
+- **Base**: `upstream/devel` `c121f6185`
+- **작성일**: 2026-08-14 KST
+
+## 전수 조사와 선택
+
+`planet6897`가 연 열린 이슈 20건을 확인했다. #4680·#4678·#4677·#4599는 대규모
+코퍼스/캠페인이고, #4744·#4568·#4492·#4092·#4068·#4062·#4024·#3932·#3925·#3746·#3386·
+#2985·#2668·#2148은 renderer·parser 또는 한컴 기준 자료의 별도 재현이 필요한 범위다.
+
+#4089만은 중단된 WASM 빌드의 `*-opt.wasm` 잔재와 Windows Docker Desktop bind mount의
+hard-link 제약이라는 원인이 명확하고, `docker-compose.yml`과 개발 가이드만으로 독립 보정할 수
+있다. 열린 PR은 발견되지 않았고, 작업 시작 전에 `jangster77`를 assignee로 지정했다.
+
+## 구현 범위
+
+1. `wasm` 서비스의 Cargo target을 named volume으로 옮겨 Windows bind mount의 hard-link 실패를
+   피하고 실행 간 캐시를 유지한다.
+2. 빌드 시작 시 이전 `*-opt.wasm` 잔재만 제거해 wasm-pack이 임시 최적화 결과를 입력으로 다시
+   열거하지 않게 한다.
+3. root로 실행해야 하는 named-volume 쓰기와 host `pkg/` 산출물 소유권을 분리해, 종료 상태와
+   무관하게 산출물 ownership을 compose의 `UID`/`GID`로 복원한다.
+4. 개발 가이드에서 Docker를 기본 WASM 경로로 안내하고, Windows 네이티브의 임시 파일 주의와
+   `--no-opt` 진단 우회를 문서화한다.
+
+## 비범위
+
+- wasm-pack upstream의 파일 열거 구현, CI workflow, Rust/WASM API와 `pkg/` 생성물은 변경하지
+  않는다.
+- #4089와 별개의 renderer·parser·HWP3·Hancom RPC 이슈를 함께 닫지 않는다.
+
+## 검증
+
+- `docker compose --env-file .env.docker config`로 interpolation과 volume 구성을 검사한다.
+- Windows PowerShell에서 표준 `docker compose --env-file .env.docker run --rm wasm`을 두 번
+  순차 실행해 첫 빌드와 named target cache 재사용을 확인한다. 중단 잔재는 ignore된 `pkg/`의
+  `*-opt.wasm` 한 파일로 재현한 뒤, 다음 실행에서 제거되는지 확인한다.
+- `git diff --check`와 변경된 Markdown 링크를 확인한다. 긴 PR CI 성격의 Cargo 전체 검증은
+  실행하지 않는다.
+
+## 완료 조건
+
+- Windows Docker Desktop에서도 표준 WASM 명령이 target hard-link 오류 없이 종료한다.
+- 잔재 `*-opt.wasm`이 다음 실행 전 제거되고 재귀 `-opt.wasm-opt.wasm`이 생기지 않는다.
+- 호스트 `pkg/` 산출물이 compose의 지정 UID/GID로 반환되며, PR은 `devel` 대상으로 #4089만
+  참조한다.

--- a/mydocs/pr/archives/pr_4746_review.md
+++ b/mydocs/pr/archives/pr_4746_review.md
@@ -60,12 +60,30 @@ render/fixture 시각 증적 보조 경로는 적용하지 않는다. Docker run
 진행 중이다. 최신 head의 CI 결과는 merge 직전에 다시 확인해야 하며, 후보 뒤 review-only commit의
 aggregate도 별도로 성공해야 한다.
 
+## 기준선 갱신과 최신 CI
+
+초기 review 기록 뒤 GitHub update branch가 `devel@be7dabdd1`을 source branch에 병합해 새 head
+`43117ad38414680549c6e0595fd1e8fd62e7eda6`을 만들었다. 이 merge는 #4745의 변경을 기준선으로
+가져온 것이며, #4089의 고유 diff는 최신 `upstream/devel...HEAD`에서 다시 분리해 확인했다. 이전
+`b1ce261a` head의 진행 중 CI는 최종 근거로 재사용하지 않았다.
+
+- 최신 head에서 `python scripts\\tests\\test_docker_wasm_compose.py`를 다시 실행해 4/4 통과했고,
+  `git diff --check upstream/devel...HEAD`도 통과했다.
+- [CI run 31736384129](https://github.com/edwardkim/rhwp/actions/runs/31736384129)의 Build & Test,
+  Lint, frontend package, Native Skia, 모든 default-feature shard가 성공했다. frontend unit과
+  WASM Build의 skip은 preflight 분류에 따른 정상 상태다.
+- [CodeQL run 31736383870](https://github.com/edwardkim/rhwp/actions/runs/31736383870)의 Rust,
+  JavaScript/TypeScript, Python 분석과 aggregate가 성공했다.
+
+이 commit은 review·오늘할일만 갱신한다. `43117ad3`의 녹색 code candidate 뒤에 단일 review-only
+commit으로 이어지므로, push 뒤에는 최신 head의 preflight/Build & Test aggregate를 다시 확인한다.
+
 ## 위험과 권고
 
 Compose 실행은 root로 named volume을 초기화하되 `pkg/`만 사용자 UID/GID로 반환한다. 실제 Docker
 Desktop Windows host에서 표준 명령을 두 번 순차 실행해 hard-link 회피와 cache 재사용을 확인하기 전에는
 runtime 보장을 주장하지 않는다.
 
-**권고: 보류.** 현재 변경 범위와 merge simulation에는 차단 문제가 없지만, 최신 code candidate와
-trailing review 기록의 GitHub Actions 성공, Docker Desktop Windows 실실행 확인, 그리고 작업지시자
-승인이 모두 갖춰진 뒤에만 merge 판단으로 전환한다. #4089은 merge 및 검증 완료 전까지 닫지 않는다.
+**권고: 보류.** 최신 code candidate의 GitHub CI는 성공했다. 다만 review-only trailing head의
+aggregate, Docker Desktop Windows 실실행 확인, 그리고 작업지시자 승인이 모두 갖춰진 뒤에만 merge
+판단으로 전환한다. #4089은 merge 및 검증 완료 전까지 닫지 않는다.

--- a/mydocs/pr/archives/pr_4746_review.md
+++ b/mydocs/pr/archives/pr_4746_review.md
@@ -1,0 +1,71 @@
+---
+kind: pr-review
+status: active
+issue: 4089
+pr: 4746
+---
+
+# PR #4746 리뷰 — Windows Docker WASM 빌드 격리
+
+## 라우팅과 접수
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, local_validation.md, review_only_fast_pass.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+  collaborator_self_merge.md, intake_and_review.md, local_validation.md,
+  review_only_fast_pass.md
+current head: a9dcecdac16d2a713e25fe0e15463d51e5d59608 (문서 작성 시점 참고값)
+```
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4746](https://github.com/edwardkim/rhwp/pull/4746) |
+| 작성자 | `jangster77` (collaborator) |
+| 대상 / head | `devel` ← `codex/issue-4089-wasm-docker` |
+| 코드 후보 | `a9dcecdac` — `fix: #4089 Windows Docker WASM 빌드 격리` |
+| 규모 | 6 files, +208 / -3, 2 commits (작성 시점) |
+| mergeable | `MERGEABLE`, `mergeStateStatus=BLOCKED` (CI 진행 중인 작성 시점 참고값) |
+| 관련 이슈 | [#4089](https://github.com/edwardkim/rhwp/issues/4089), assignee `jangster77`, OPEN |
+
+작업지시자의 collaborator self-review 지시에 따라 외부 reviewer를 요청하지 않았다. 이 문서는
+자체 검토 기록이며 GitHub approval이나 merge 권한 행사를 뜻하지 않는다.
+
+## 변경과 범위 판정
+
+`docker-compose.yml`의 `wasm` 서비스는 Cargo target을 `wasm-target:/build-target` named volume으로
+옮긴다. 중단된 wasm-pack의 `pkg/*-opt.wasm`만 build 전 제거하고, HUP/INT/TERM·일반 종료 시
+`pkg/` ownership을 compose `UID`/`GID`로 복원한다. 개발 가이드는 Docker 표준 경로와 Windows
+네이티브 `--no-opt` 진단 경계를 설명하며, Python 계약 테스트가 이 구성을 고정한다.
+
+Rust renderer·WASM API·frontend 출력·fixture·golden·CI workflow는 변경하지 않았다. 따라서
+render/fixture 시각 증적 보조 경로는 적용하지 않는다. Docker runtime과 `wasm-pack` 실행 경로는
+바뀌므로 문서만 변경한 PR은 아니며, trailing review 기록을 push한 뒤에는 code 후보 `a9dcecdac`의
+최신 GitHub CI와 fast-pass 조건을 분리해 확인한다.
+
+## 검증과 자체 검토
+
+- `python scripts\\tests\\test_docker_wasm_compose.py`를 실행해 4/4 통과했다. named target volume,
+  stale `*-opt.wasm` 정리 순서, signal/EXIT ownership 복원, Docker 우선 가이드와 `--no-opt`
+  진단 경계를 확인했다.
+- `git diff --check upstream/devel...a9dcecdac`를 실행해 통과했다.
+- `upstream/devel@c121f6185`에서 `a9dcecdac`을 `--no-commit --no-ff`로 merge simulation했다.
+  자동 병합 뒤 `git diff --check`가 통과했고, merge를 abort한 뒤 임시 `pr4746-merge-test` branch를
+  삭제했다.
+- 이 Windows host에는 Docker CLI와 `.env.docker`가 없고, host `wasm-pack`은 정책 고정판 0.15.0이
+  아닌 0.14.0이다. 따라서 실제 Docker Compose build, named-volume cache 재사용, optimized WASM
+  산출물은 통과로 기록하지 않는다.
+
+코드 후보 SHA에서 CI preflight는 성공했고 CI lint/frontend-package와 CodeQL은 문서 작성 시점에
+진행 중이다. 최신 head의 CI 결과는 merge 직전에 다시 확인해야 하며, 후보 뒤 review-only commit의
+aggregate도 별도로 성공해야 한다.
+
+## 위험과 권고
+
+Compose 실행은 root로 named volume을 초기화하되 `pkg/`만 사용자 UID/GID로 반환한다. 실제 Docker
+Desktop Windows host에서 표준 명령을 두 번 순차 실행해 hard-link 회피와 cache 재사용을 확인하기 전에는
+runtime 보장을 주장하지 않는다.
+
+**권고: 보류.** 현재 변경 범위와 merge simulation에는 차단 문제가 없지만, 최신 code candidate와
+trailing review 기록의 GitHub Actions 성공, Docker Desktop Windows 실실행 확인, 그리고 작업지시자
+승인이 모두 갖춰진 뒤에만 merge 판단으로 전환한다. #4089은 merge 및 검증 완료 전까지 닫지 않는다.

--- a/mydocs/working/task_m100_4089_stage1.md
+++ b/mydocs/working/task_m100_4089_stage1.md
@@ -1,0 +1,44 @@
+# Task #4089 Stage 1 — Windows Docker WASM 산출물 격리
+
+- Issue: [#4089](https://github.com/edwardkim/rhwp/issues/4089)
+- Base: `upstream/devel` `c121f6185`
+- Branch: `codex/issue-4089-wasm-docker`
+- 측정일: 2026-08-14 KST
+
+## 구현
+
+`wasm` compose 서비스는 이제 `/build-target` named volume을 `CARGO_TARGET_DIR`로 사용한다.
+따라서 Windows Docker Desktop의 `/app/target` bind mount hard-link 제약과 분리되며, volume은
+컨테이너 실행 사이에 Cargo 산출물을 보존한다.
+
+서비스는 root로 named volume을 쓸 수 있게 실행하되, EXIT trap으로 `pkg/` 전체를
+`HOST_UID`/`HOST_GID`로 되돌린다. 이 trap은 wasm-pack 성공·실패·중단 시에도 실행된다. 빌드
+직전에는 이전 중단이 남긴 `pkg/*-opt.wasm`만 제거한다. 소스·정상 WASM 산출물·CI workflow는
+삭제하거나 변경하지 않는다.
+
+개발 가이드는 Docker를 표준 경로로 승격하고, Windows 네이티브 실행은 `--no-opt` 진단 전용으로
+제한했다. 이를 통해 stale `*-opt.wasm`을 다시 입력으로 집는 루프를 피하면서도 Docker가 없는
+호스트에서 Rust→WASM 컴파일과 wasm-opt를 분리할 수 있다.
+
+## 로컬 검증
+
+- `python scripts\\tests\\test_docker_wasm_compose.py` — 4/4 통과. named target volume,
+  stale `*-opt.wasm` 정리 순서, exit 시 ownership 복원, Docker 우선/`--no-opt` 진단 문서의
+  정적 계약을 확인했다.
+- `git diff --check` — 통과.
+- `wasm-pack --version` — 이 Windows host는 `0.14.0`이고 저장소 고정판은 `0.15.0`이다.
+  따라서 네이티브 wasm-pack 실행 결과를 릴리스 검증으로 기록하지 않았다.
+- `docker`/`docker compose` — 실행 파일이 없고 `.env.docker`도 없어서 컨테이너 실행은
+  수행하지 못했다. `.env.docker`의 값을 읽거나 새 파일을 만들지 않았다.
+
+## 후속 검증 경계
+
+PR CI 또는 Docker Desktop이 있는 Windows host에서 아래 표준 명령을 두 번 순차 실행해 named
+target cache 재사용과 stale file 정리를 실제로 확인해야 한다.
+
+```powershell
+docker compose --env-file .env.docker run --rm wasm
+```
+
+이 Stage는 #4089만 다룬다. renderer·parser·Hancom 기준 이슈는 닫지 않으며, 이 이슈도 merge와
+실행 검증 전에는 종료하지 않는다.

--- a/scripts/tests/test_docker_wasm_compose.py
+++ b/scripts/tests/test_docker_wasm_compose.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_PATH = ROOT / "docker-compose.yml"
+GUIDE_PATH = ROOT / "mydocs" / "manual" / "dev_environment_guide.md"
+
+
+class DockerWasmComposeContractTests(unittest.TestCase):
+    """#4089: Windows Docker WASM cache와 stale wasm-opt 방지 계약."""
+
+    def setUp(self) -> None:
+        self.compose = COMPOSE_PATH.read_text(encoding="utf-8")
+        self.guide = GUIDE_PATH.read_text(encoding="utf-8")
+
+    def test_wasm_target_is_a_named_volume_outside_the_host_mount(self) -> None:
+        self.assertIn("CARGO_TARGET_DIR: /build-target", self.compose)
+        self.assertIn("- wasm-target:/build-target", self.compose)
+        self.assertIn("  wasm-target:\n", self.compose)
+        self.assertNotIn("CARGO_TARGET_DIR: /app/target", self.compose)
+
+    def test_stale_wasm_opt_is_removed_before_build(self) -> None:
+        cleanup = self.compose.index("rm -f pkg/*-opt.wasm")
+        build = self.compose.index("wasm-pack build --target web")
+        self.assertLess(cleanup, build)
+
+    def test_host_pkg_ownership_is_restored_even_after_a_failed_build(self) -> None:
+        self.assertIn("user: \"0:0\"", self.compose)
+        self.assertIn("HOST_UID: ${UID:-1000}", self.compose)
+        self.assertIn("HOST_GID: ${GID:-1000}", self.compose)
+        self.assertIn("trap 'exit 130' INT", self.compose)
+        self.assertIn("trap 'exit 143' TERM", self.compose)
+        self.assertIn("trap finish EXIT", self.compose)
+        self.assertIn('chown -R "$${HOST_UID}:$${HOST_GID}" pkg', self.compose)
+
+    def test_guide_makes_docker_primary_and_no_opt_diagnostic_only(self) -> None:
+        docker = self.guide.index("docker compose --env-file .env.docker run --rm wasm")
+        native = self.guide.index("wasm-pack build --target web --out-dir pkg --no-opt")
+        self.assertLess(docker, native)
+        self.assertIn("진단용", self.guide)
+        self.assertIn("최적화된 배포 산출물을 대체하지 않는다", self.guide)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경

- Windows Docker Desktop bind mount와 분리된 `wasm-target` named volume으로 Cargo target을 유지했습니다.
- 중단된 빌드의 `pkg/*-opt.wasm`만 다음 실행 전에 제거하고, 종료·INT·TERM 뒤에도 `pkg/` ownership을 복원합니다.
- Docker 표준 경로와 네이티브 `--no-opt` 진단 경계를 개발 가이드 및 회귀 계약으로 고정했습니다.

## 검증

- `python scripts\tests\test_docker_wasm_compose.py` — 4/4 통과
- `git diff --check upstream/devel...HEAD` — 통과
- 현재 Windows host에는 Docker CLI·`.env.docker`가 없고 host `wasm-pack`은 고정판 0.15.0이 아닌 0.14.0이어서, 실제 Compose 실행 및 최적화 WASM 빌드는 수행하지 않았습니다.

관련: #4089

구현 범위·한계: `mydocs/plans/task_m100_4089.md`, `mydocs/working/task_m100_4089_stage1.md`