### PR TITLE
fix: #4630 WASM32 Clippy gate 정합

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -941,6 +941,10 @@ jobs:
       - name: Clippy
         run: cargo clippy -- -D warnings
 
+      # [#4630] wasm32 전용 cfg 경로의 lint 부채는 네이티브 Clippy로 보이지 않는다.
+      - name: Clippy (WASM32)
+        run: cargo clippy -p rhwp --lib --target wasm32-unknown-unknown -- -D warnings
+
       # [#3664] Native FFI 크레이트가 워크스페이스 밖이라 어느 CI job 도 건드리지
       # 않는 사이 코어 API 변경을 못 따라가 이미 컴파일이 깨져 있었다(C#·Swift 래퍼
       # 동반 무력화). 기본 `cargo clippy` 는 루트 크레이트만 보므로 별도 검사가 필요하다.

--- a/mydocs/orders/20260814.md
+++ b/mydocs/orders/20260814.md
@@ -4,6 +4,9 @@
 
 - #4630을 `jangster77`에게 할당하고 `codex/issue-4630-wasm-clippy`를 최신 `upstream/devel`에서
   시작했다. WASM32 Clippy 부채와 CI gate만 다루며 #4631 CLI target 설계는 범위에서 제외한다.
+- WASM32 전용 16개 Clippy 오류를 동작 보존 보정했고 같은 target에서 gate 통과를 재확인했다.
+  CI Lint에 WASM32 Clippy gate를 추가했으며 상세는 [Stage 1](../working/task_m100_4630_stage1.md)에
+  기록했다.
 
 ## PR #4745 - Studio 개발용 핫패치 경계 보강
 

--- a/mydocs/orders/20260814.md
+++ b/mydocs/orders/20260814.md
@@ -1,5 +1,10 @@
 # 오늘 할일 - 2026년 8월 14일
 
+## Issue #4630 - WASM32 Clippy gate 정합
+
+- #4630을 `jangster77`에게 할당하고 `codex/issue-4630-wasm-clippy`를 최신 `upstream/devel`에서
+  시작했다. WASM32 Clippy 부채와 CI gate만 다루며 #4631 CLI target 설계는 범위에서 제외한다.
+
 ## PR #4745 - Studio 개발용 핫패치 경계 보강
 
 - [PR #4745](https://github.com/edwardkim/rhwp/pull/4745)는 `#4635`, `#4643`을 함께 처리한다.

--- a/mydocs/plans/task_m100_4630.md
+++ b/mydocs/plans/task_m100_4630.md
@@ -1,0 +1,17 @@
+# Task #4630 수행계획 — WASM32 Clippy gate 정합
+
+- Issue: [#4630](https://github.com/edwardkim/rhwp/issues/4630)
+- Branch: `codex/issue-4630-wasm-clippy`
+- Base: `upstream/devel` `be7dabdd1`
+- 작성일: 2026-08-14 KST
+
+## 범위
+
+WASM32 전용 경로에서 `cargo clippy -p rhwp --lib --target wasm32-unknown-unknown -- -D warnings`가
+실패하는 항목을 실제 출력으로 전수 분류해 수정한다. CI Lint job에는 같은 `--lib` 범위의 WASM32
+Clippy gate를 추가한다. #4631의 wasm32 CLI 제외 여부는 이미 문서화된 별도 설계 선택이므로 섞지 않는다.
+
+## 검증
+
+PowerShell에서 `target\pr-review`를 재사용해 wasm32 Clippy, 기존 CI contract test, format과 diff
+check를 순차 실행한다. `CARGO_INCREMENTAL`은 지정하지 않는다.

--- a/mydocs/pr/archives/pr_4747_review.md
+++ b/mydocs/pr/archives/pr_4747_review.md
@@ -1,0 +1,20 @@
+# PR #4747 리뷰 — WASM32 Clippy gate 정합
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, local_validation.md, review_only_fast_pass.md
+current head: 518b0d7d5 (작성 시점 참고값)
+```
+
+PR [#4747](https://github.com/edwardkim/rhwp/pull/4747)은 collaborator `jangster77`의 `devel` 대상
+PR이며 #4630을 참조한다. 작업지시자의 self-review 지시에 따라 외부 reviewer를 요청하지 않았다.
+
+WASM32 Canvas 경로의 Clippy 16건을 동작 보존 형태로 정리하고 CI Lint에 같은 `--lib` scope의
+WASM32 Clippy gate를 추가한다. #4631 CLI target 설계, #4089 Docker 구성, fixture와 renderer output은
+변경하지 않으므로 시각 증적 경로는 적용하지 않는다.
+
+- PowerShell `target\\pr-review`에서 `cargo clippy -p rhwp --lib --target wasm32-unknown-unknown -- -D warnings`는 보정 후 성공했다.
+- `python scripts\\tests\\test_ci_impact_workflow.py`는 27/27 통과했고 `git diff --check`도 통과했다.
+
+**권고: 보류.** 최신 PR head의 CI·CodeQL과 trailing review-only 기록의 aggregate 성공, 작업지시자
+승인 전에는 merge나 #4630 종료를 하지 않는다.

--- a/mydocs/working/task_m100_4630_stage1.md
+++ b/mydocs/working/task_m100_4630_stage1.md
@@ -1,0 +1,20 @@
+# Task #4630 Stage 1 — WASM32 Clippy gate 정합
+
+- Issue: [#4630](https://github.com/edwardkim/rhwp/issues/4630)
+- Base: `upstream/devel` `be7dabdd1`
+- 측정일: 2026-08-14 KST
+
+## 보정
+
+WASM canvas 전용 경로의 unit-return binding 13개, 색상 red channel의 무의미한 shift 2개,
+manual range pattern 1개를 동작 보존 형태로 정리했다. CI Lint에는
+`cargo clippy -p rhwp --lib --target wasm32-unknown-unknown -- -D warnings`를 추가했다.
+
+## 검증
+
+- PowerShell, `target\\pr-review`: WASM32 Clippy 16개 오류 재현 뒤 보정 후 성공.
+- `python scripts\\tests\\test_ci_impact_workflow.py`: 27/27 통과.
+- `git diff --check`: 통과.
+
+`CARGO_INCREMENTAL`은 설정하지 않았다. #4631의 wasm32 CLI 제외 여부와 #4089 Docker 구성은
+변경하지 않는다.

--- a/src/renderer/equation/canvas_render.rs
+++ b/src/renderer/equation/canvas_render.rs
@@ -402,18 +402,8 @@ fn draw_stretch_bracket(
             ctx.begin_path();
             ctx.move_to(mid_x + w * 0.2, y);
             ctx.quadratic_curve_to(mid_x - w * 0.1, y, mid_x - w * 0.1, y + qh);
-            ctx.quadratic_curve_to(
-                mid_x - w * 0.1,
-                y + qh * 2.0,
-                mid_x - w * 0.3,
-                y + qh * 2.0,
-            );
-            ctx.quadratic_curve_to(
-                mid_x - w * 0.1,
-                y + qh * 2.0,
-                mid_x - w * 0.1,
-                y + qh * 3.0,
-            );
+            ctx.quadratic_curve_to(mid_x - w * 0.1, y + qh * 2.0, mid_x - w * 0.3, y + qh * 2.0);
+            ctx.quadratic_curve_to(mid_x - w * 0.1, y + qh * 2.0, mid_x - w * 0.1, y + qh * 3.0);
             ctx.quadratic_curve_to(mid_x - w * 0.1, y + h, mid_x + w * 0.2, y + h);
             ctx.stroke();
         }
@@ -422,18 +412,8 @@ fn draw_stretch_bracket(
             ctx.begin_path();
             ctx.move_to(mid_x - w * 0.2, y);
             ctx.quadratic_curve_to(mid_x + w * 0.1, y, mid_x + w * 0.1, y + qh);
-            ctx.quadratic_curve_to(
-                mid_x + w * 0.1,
-                y + qh * 2.0,
-                mid_x + w * 0.3,
-                y + qh * 2.0,
-            );
-            ctx.quadratic_curve_to(
-                mid_x + w * 0.1,
-                y + qh * 2.0,
-                mid_x + w * 0.1,
-                y + qh * 3.0,
-            );
+            ctx.quadratic_curve_to(mid_x + w * 0.1, y + qh * 2.0, mid_x + w * 0.3, y + qh * 2.0);
+            ctx.quadratic_curve_to(mid_x + w * 0.1, y + qh * 2.0, mid_x + w * 0.1, y + qh * 3.0);
             ctx.quadratic_curve_to(mid_x + w * 0.1, y + h, mid_x - w * 0.2, y + h);
             ctx.stroke();
         }

--- a/src/renderer/equation/canvas_render.rs
+++ b/src/renderer/equation/canvas_render.rs
@@ -355,7 +355,7 @@ fn draw_stretch_bracket(
             ctx.begin_path();
             ctx.set_line_cap("round");
             ctx.move_to(x + w * 0.9, y);
-            let _ = ctx.bezier_curve_to(
+            ctx.bezier_curve_to(
                 x + w * 0.05,
                 y + h * 0.18,
                 x + w * 0.05,
@@ -370,7 +370,7 @@ fn draw_stretch_bracket(
             ctx.begin_path();
             ctx.set_line_cap("round");
             ctx.move_to(x + w * 0.1, y);
-            let _ = ctx.bezier_curve_to(
+            ctx.bezier_curve_to(
                 x + w * 0.95,
                 y + h * 0.18,
                 x + w * 0.95,
@@ -401,40 +401,40 @@ fn draw_stretch_bracket(
             let qh = h / 4.0;
             ctx.begin_path();
             ctx.move_to(mid_x + w * 0.2, y);
-            let _ = ctx.quadratic_curve_to(mid_x - w * 0.1, y, mid_x - w * 0.1, y + qh);
-            let _ = ctx.quadratic_curve_to(
+            ctx.quadratic_curve_to(mid_x - w * 0.1, y, mid_x - w * 0.1, y + qh);
+            ctx.quadratic_curve_to(
                 mid_x - w * 0.1,
                 y + qh * 2.0,
                 mid_x - w * 0.3,
                 y + qh * 2.0,
             );
-            let _ = ctx.quadratic_curve_to(
+            ctx.quadratic_curve_to(
                 mid_x - w * 0.1,
                 y + qh * 2.0,
                 mid_x - w * 0.1,
                 y + qh * 3.0,
             );
-            let _ = ctx.quadratic_curve_to(mid_x - w * 0.1, y + h, mid_x + w * 0.2, y + h);
+            ctx.quadratic_curve_to(mid_x - w * 0.1, y + h, mid_x + w * 0.2, y + h);
             ctx.stroke();
         }
         "}" => {
             let qh = h / 4.0;
             ctx.begin_path();
             ctx.move_to(mid_x - w * 0.2, y);
-            let _ = ctx.quadratic_curve_to(mid_x + w * 0.1, y, mid_x + w * 0.1, y + qh);
-            let _ = ctx.quadratic_curve_to(
+            ctx.quadratic_curve_to(mid_x + w * 0.1, y, mid_x + w * 0.1, y + qh);
+            ctx.quadratic_curve_to(
                 mid_x + w * 0.1,
                 y + qh * 2.0,
                 mid_x + w * 0.3,
                 y + qh * 2.0,
             );
-            let _ = ctx.quadratic_curve_to(
+            ctx.quadratic_curve_to(
                 mid_x + w * 0.1,
                 y + qh * 2.0,
                 mid_x + w * 0.1,
                 y + qh * 3.0,
             );
-            let _ = ctx.quadratic_curve_to(mid_x + w * 0.1, y + h, mid_x - w * 0.2, y + h);
+            ctx.quadratic_curve_to(mid_x + w * 0.1, y + h, mid_x - w * 0.2, y + h);
             ctx.stroke();
         }
         "|" => {
@@ -499,8 +499,8 @@ fn draw_decoration(
             let ty = y + fs * 0.08;
             ctx.begin_path();
             ctx.move_to(mid_x - half_w * 0.6, ty);
-            let _ = ctx.quadratic_curve_to(mid_x - half_w * 0.2, ty - fs * 0.08, mid_x, ty);
-            let _ = ctx.quadratic_curve_to(
+            ctx.quadratic_curve_to(mid_x - half_w * 0.2, ty - fs * 0.08, mid_x, ty);
+            ctx.quadratic_curve_to(
                 mid_x + half_w * 0.2,
                 ty + fs * 0.08,
                 mid_x + half_w * 0.6,

--- a/src/renderer/web_canvas.rs
+++ b/src/renderer/web_canvas.rs
@@ -1684,7 +1684,7 @@ impl WebCanvasRenderer {
         }
 
         let canvas_grad = match grad.gradient_type {
-            2 | 3 | 4 => {
+            2..=4 => {
                 // Radial / Conical / Square → radialGradient
                 let cx = x + w * (grad.center_x as f64 / 100.0);
                 let cy = y + h * (grad.center_y as f64 / 100.0);
@@ -1992,7 +1992,7 @@ impl WebCanvasRenderer {
             } else {
                 1.0
             };
-            let r = (shadow.color >> 0) & 0xFF;
+            let r = shadow.color & 0xFF;
             let g = (shadow.color >> 8) & 0xFF;
             let b = (shadow.color >> 16) & 0xFF;
             let color = format!("rgba({},{},{},{:.2})", r, g, b, opacity);
@@ -2674,7 +2674,7 @@ impl Renderer for WebCanvasRenderer {
             } else {
                 1.0
             };
-            let r = (shadow.color >> 0) & 0xFF;
+            let r = shadow.color & 0xFF;
             let g = (shadow.color >> 8) & 0xFF;
             let b = (shadow.color >> 16) & 0xFF;
             self.ctx
@@ -3437,7 +3437,7 @@ impl WebCanvasRenderer {
         while cx < x2 {
             let next = (cx + wave_w).min(x2);
             let cy = if up { y1 - wave_h } else { y1 + wave_h };
-            let _ = self.ctx.quadratic_curve_to((cx + next) / 2.0, cy, next, y1);
+            self.ctx.quadratic_curve_to((cx + next) / 2.0, cy, next, y1);
             cx = next;
             up = !up;
         }


### PR DESCRIPTION
## 변경

- WASM32 전용 Canvas 경로의 Clippy 16건을 동작 보존 형태로 정리했습니다.
- CI Lint에 `cargo clippy -p rhwp --lib --target wasm32-unknown-unknown -- -D warnings` gate를 추가했습니다.

## 검증

- PowerShell `target\pr-review`: WASM32 Clippy 성공
- `python scripts\tests\test_ci_impact_workflow.py`: 27/27 통과
- `git diff --check`: 통과

관련: #4630