### PR TITLE
refactor: 개발용 핫패치 경계를 정리

### DIFF
--- a/mydocs/manual/dev_environment_guide.md
+++ b/mydocs/manual/dev_environment_guide.md
@@ -247,9 +247,9 @@ curl -fsS -o /dev/null -w 'vite-wasm=%{http_code}\n' http://127.0.0.1:7700/wasm/
 
 1. 브라우저에서 `http://<host-ip>:7700/`을 열고 `WASM 로딩 중...` 화면이 끝난 뒤에 검증한다. 개발
    모드의 `window.__wasm` 객체는 초기화 전에 먼저 만들어질 수 있으므로, 객체 존재 여부나
-   `getRenderCodeReload()?.isAvailable()`만으로 준비 완료를 판별하지
-   않는다. (능력 객체는 개발 빌드에서만 채워진다 — 프로덕션 번들에서는 언제나 `null` 이다. #4580)
-2. `src/wasm_api/subsecond_boundary.rs`의 `hot_render_boundaries!` 목록에 배선된 렌더 경계 안의 Rust
+   `getWasmModuleExports()`만으로 준비 완료를 판별하지 않는다. 개발용 런타임은 `main.ts`가
+   `await wasm.initialize()`와 `CanvasView` 생성 뒤에만 동적으로 시작한다. (#4636, #4641)
+2. `src/wasm_api/render_patch_boundary.rs`의 `hot_render_boundaries!` 목록에 배선된 렌더 경계 안의 Rust
    변경을 저장하고 터미널 1의 rebuild/patch 메시지를 확인한다. 목록 밖의 export, 타입 레이아웃 또는
    초기화 경로 변경은 hot-patch 대상이 아니며 전체 rebuild/새로고침이 필요할 수 있다.
 3. 브라우저 콘솔에서 `[subsecond]` 진단과 Rust panic, 전역 오류를 확인한다. 화면 재도색은

--- a/mydocs/orders/20260814.md
+++ b/mydocs/orders/20260814.md
@@ -30,6 +30,21 @@
   폭 보정과 #3211 지표(각각 160/165, 130/165)는 유지한다.
 - 최신 PR head의 CI·CodeQL·Render Diff, mergeability와 작업지시자 승인 전에는 merge하지 않는다.
   #3211은 남은 wrap-zone 정합성 차이가 있어 자동 종료하지 않는다.
+
+## PR #4748 - Studio 개발용 핫패치 경계 정리
+
+- [PR #4748](https://github.com/edwardkim/rhwp/pull/4748)은 #4636, #4641, #4642를 하나의 경계
+  정리로 처리한다. 개발용 소켓·감시자는 `subsecond-runtime.ts`의 단일 realm 수명으로 모으고,
+  `main.ts`의 DEV 동적 import만 이를 시작한다.
+- WasmBridge와 CanvasView에서 개발 전용 상태·이벤트를 제거하고, 패치 리비전은 현재 화면의
+  `refreshPages()`를 직접 호출한다. 배포 `dist`의 중첩 JavaScript chunk도 검사한다.
+- Rust는 `render_patch_boundary`에서만 적용된 패치 함수 주소를 읽도록 도메인 경계를 좁혔다.
+  공개 WASM 인자와 문서 레이아웃 결과는 변경하지 않았다.
+- Studio unit 923건, production build, 번들 계약 5건, headless Chrome 재도색 E2E, Rust 경계
+  unit/feature/wasm32 build, `git diff --check`를 완료했다. 상세 판단은
+  [PR #4748 review](../pr/archives/pr_4748_review.md)에 보존한다.
+- 최신 trailing 문서 head의 GitHub Actions·CodeQL·Render Diff·mergeability와 작업지시자 승인 전에는
+  merge하지 않는다.
 # 오늘 할 일 - 2026년 8월 14일
 
 ## PR #4743 - 입력 경계와 WMF 초기화 안전성

--- a/mydocs/plans/task_m100_4636_4641_4642_hotpatch_boundary.md
+++ b/mydocs/plans/task_m100_4636_4641_4642_hotpatch_boundary.md
@@ -1,0 +1,42 @@
+# Task #4636, #4641, #4642 수행계획 - 개발용 핫패치 경계 소유권 정리
+
+- Issue: [#4636](https://github.com/edwardkim/rhwp/issues/4636), [#4641](https://github.com/edwardkim/rhwp/issues/4641), [#4642](https://github.com/edwardkim/rhwp/issues/4642)
+- Branch: `task_m100_4636_4641_4642-hotpatch-boundary-20260814`
+- Base: `upstream/devel` `be7dabdd170117d6022656063b0482f04361bfcb`
+- 작성일: 2026-08-14 KST
+
+## 문제와 범위
+
+개발 전용 렌더 코드 교체의 소켓과 감시자가 `WasmBridge`, `CanvasView`, `subsecond-runtime`에
+나뉘어 있어 일반 Studio 클래스의 멤버가 프로덕션 번들에 남는다. Rust 쪽도 기능이 꺼진 일반
+빌드에서 벤더 이름 모듈을 컴파일하고, 공용 helper가 벤더 trait 제네릭을 노출한다.
+
+이번 PR은 이 세 이슈의 공통 경계만 고친다. 핫패치 기능 자체, WASM의 JavaScript 공개 시그니처,
+렌더러 계산과 문서 포맷 동작은 바꾸지 않는다.
+
+## 구현 계획
+
+1. `main.ts`의 DEV 동적 import가 소켓·패치 계수·리비전 감시를 시작하고, `CanvasView`는 일반
+   화면 재도색만 소유하게 한다.
+2. `WasmBridge`의 개발 전용 메서드와 상태를 제거하고, 개발 런타임에 필요한 일반 wasm export와
+   선형 메모리 조회만 빌려준다.
+3. 프로덕션 번들 검사가 `dist/assets` 직계 파일만 보지 않고 배포 `dist` 아래의 모든 JavaScript를
+   재귀적으로 검사하게 한다.
+4. Rust 모듈을 도메인 이름 `render_patch_boundary`로 바꾸고, `HotFunction` 제네릭 helper를
+   제거한다. 현재 함수 주소는 점프 테이블을 반영하는 `HotFn::current(...).ptr_address()`를
+   경계 구현 안에서 직접 사용한다.
+
+## 검증 계획
+
+- `npm --prefix rhwp-studio test`
+- `npm --prefix rhwp-studio run build`
+- `node --test scripts/frontend-studio-dist.test.mjs`
+- `cargo test --profile release-test --target-dir target/pr-review --lib wasm_api::render_patch_boundary`
+- `git diff --check`
+
+## 완료 조건
+
+- 일반 Studio 클래스와 프로덕션 번들에 개발용 소켓·감시자·벤더 식별자가 남지 않는다.
+- 배포 산출물의 중첩 JavaScript chunk도 번들 감시 대상이다.
+- Rust의 일반 모듈명과 공용 helper가 벤더 trait 계약을 노출하지 않으며, 패치 리비전은 적용된
+  함수 주소를 계속 반영한다.

--- a/mydocs/pr/archives/pr_4748_review.md
+++ b/mydocs/pr/archives/pr_4748_review.md
@@ -1,0 +1,80 @@
+# PR #4748 검토 기록 - 개발용 핫패치 경계 정리
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4748](https://github.com/edwardkim/rhwp/pull/4748) |
+| 제목 | `refactor: 개발용 핫패치 경계를 정리` |
+| 작성자 | `jangster77` (collaborator) |
+| base | `devel` |
+| code candidate | `6c51110474d505d2e9eff9353b4a4e2c2d01c4b0` |
+| 규모 | 구현 commit 기준 13 files, +307/-183 |
+| 작성 시점 참고 상태 | `MERGEABLE`, GitHub Actions·CodeQL·Render Diff 진행 중 |
+| 검토 방식 | collaborator self-merge 후보. 동일 collaborator가 작성자이므로 외부 reviewer를 추정해 요청하지 않았고, 작업지시자 승인과 최신 required check를 최종 조건으로 둔다. |
+
+## 라우팅
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, local_validation.md, visual_fixture_evidence.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+collaborator_self_merge.md, intake_and_review.md, local_validation.md,
+visual_fixture_evidence.md
+current head: 6c51110474d505d2e9eff9353b4a4e2c2d01c4b0 (문서 작성 시점의 code candidate)
+```
+
+최신 `upstream/devel` `be7dabdd170117d6022656063b0482f04361bfcb` 위에서 branch를 만들었고,
+`git merge-base --is-ancestor upstream/devel HEAD`가 통과했다. 이 review 및 오늘할일 commit은
+동일 source branch에 trailing 문서 commit으로 추가한다. merge 직전에는 이 문서를 포함한 최신 PR head의
+required check와 mergeability를 다시 확인해야 한다.
+
+## 관련 이슈와 변경 범위
+
+- [#4636](https://github.com/edwardkim/rhwp/issues/4636): 개발용 소켓·감시자·패치 수명 소유를
+  `subsecond-runtime.ts`로 옮기고, `main.ts`의 DEV 동적 import에서만 시작하도록 정리했다.
+- [#4641](https://github.com/edwardkim/rhwp/issues/4641): `WasmBridge`와 `CanvasView`에서 개발 전용
+  상태·메서드·이벤트를 제거했다. 코드 리비전 변경은 현재 CanvasView의 `refreshPages()`를 직접 호출한다.
+  production `dist` 아래 중첩 JavaScript chunk도 재귀 검사하도록 번들 계약을 보강했다.
+- [#4642](https://github.com/edwardkim/rhwp/issues/4642): Rust 경계 모듈을
+  `render_patch_boundary`로 도메인화하고, 공용 `HotFunction` 제네릭 helper를 제거했다. 적용된
+  함수 주소는 경계 macro 안에서 `HotFn::current(...).ptr_address()`로 읽으며, 입력 `BoundingBox`도
+  즉시 분해·재조립하지 않고 직접 검증·클리핑한다.
+
+WASM의 JavaScript 공개 인자와 문서 포맷, 레이아웃 계산, 페이지네이션 계약은 바꾸지 않았다.
+
+## 렌더 영향과 브라우저 검증
+
+`src/wasm_api.rs`와 Studio Canvas 갱신 경로를 수정했으므로 시각·fixture 보조 경로를 적용했다.
+이번 변경은 레이아웃 또는 paint 계산이 아니라 개발 시 코드 교체 뒤의 재도색 소유권을 옮기는 범위다.
+따라서 HWP 2020 PDF 기준 대조나 페이지별 visual sweep을 merge 판단에 사용하지 않았다.
+
+대신 headless Chrome에서 기존 차트 E2E를 실행했다. 차트 A/B는 각각 유채색 픽셀 비율
+1.824%/2.697%로 비공백이었고, 두 캔버스의 픽셀 차이는 4.71%였다. 동일 문서에서
+`refreshPages()`를 다시 호출한 뒤에도 B의 유채색 비율은 2.697%로 유지됐다. 이 결과는 개발용
+리비전 갱신이 일반 문서 revision 이벤트 없이 현재 화면을 다시 그리는 경로를 확인한 것이다.
+임시 산출물 `output/e2e/issue-1456/`은 이 PR의 레이아웃 fidelity 근거가 아니므로 증적 asset으로
+commit하지 않았다.
+
+## 완료한 로컬 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| `npm --prefix rhwp-studio test -- --runInBand` | 923/923 통과, 약 8.7초 |
+| `npm --prefix rhwp-studio run build` | TypeScript 검사와 Vite production build 통과. CanvasKit externalization 및 chunk-size 안내만 발생 |
+| `node --test scripts/frontend-studio-dist.test.mjs` | 5/5 통과. 중첩 JavaScript 산출물과 개발용 표지 누출을 확인 |
+| `node rhwp-studio/e2e/issue-1456-chart-rerender.test.mjs --mode=headless` | 차트 A/B 비공백·비재사용, 동일 문서 `refreshPages()` 재도색을 통과 |
+| `cargo test --profile release-test --target-dir target/pr-review --lib render_patch_boundary -- --nocapture` | 3/3 통과 |
+| `cargo test --profile release-test --target-dir target/pr-review --features subsecond-dev --lib render_patch_boundary -- --nocapture` | 4/4 통과 |
+| `cargo build --profile release-test --target-dir target/pr-review --target wasm32-unknown-unknown --features subsecond-dev --lib` | 통과 |
+| `git diff --check` | 통과 |
+
+`wasm-pack 0.15.0`으로 `--out-dir`을 지정한 development build는 stable Cargo가 아직 지원하지 않는
+`--artifact-dir` 인자로 변환되어 Rust 컴파일 전에 중단됐다. 이는 코드 실패가 아니라 현재
+wasm-pack/Cargo 조합의 도구 호환성 문제이며, 동등한 wasm32 Cargo build는 통과했다.
+
+## 권고
+
+로컬 검토에서 차단 이슈는 발견하지 못했다. PR 본문의 `Closes #4636`, `Closes #4641`, `Closes #4642`는
+merge 후 실제 종료 상태를 다시 확인한다. 이 trailing 문서 commit을 포함한 최신 PR head의 GitHub Actions,
+CodeQL, Render Diff, mergeability가 모두 통과하고 작업지시자가 승인할 때만 merge한다.

--- a/mydocs/pr/archives/pr_4748_review_impl.md
+++ b/mydocs/pr/archives/pr_4748_review_impl.md
@@ -1,0 +1,28 @@
+# PR #4748 구현 검토 - 개발용 핫패치 경계 정리
+
+## 대상과 code candidate
+
+| 이슈 | 구현 범위 | code candidate |
+| --- | --- | --- |
+| #4636 | DEV 동적 import와 realm 단위 런타임 수명 | `6c51110474d505d2e9eff9353b4a4e2c2d01c4b0` |
+| #4641 | WasmBridge/CanvasView의 개발 전용 소유 제거와 배포 chunk 재귀 검사 | 동일 |
+| #4642 | Rust 렌더 패치 경계 도메인화·공용 vendor helper 제거·BBox 값 보존 | 동일 |
+
+## 적용 순서와 rollback 경계
+
+1. `subsecond-runtime.ts`가 realm마다 단 하나의 소켓·감시자를 만들고 stop closure로 정리한다.
+   `main.ts`는 DEV 동적 import 성공 뒤에만 이를 시작하며, 실패해도 일반 Studio 초기화를 중단하지 않는다.
+2. `WasmBridge`는 WASM export와 선형 메모리 조회만 제공하고, `CanvasView`는 일반 화면 갱신만 소유한다.
+   코드 리비전 알림은 `canvasView?.refreshPages()`를 직접 호출한다.
+3. deployment `dist` 하위 모든 JavaScript를 검사해 중첩 chunk가 검사 밖으로 빠지지 않게 한다.
+4. Rust의 경계 모듈을 `render_patch_boundary`로 바꾸고, 적용된 함수 주소를 boundary macro 내부에서만
+   읽는다. 이 코드는 점프 테이블의 현재 주소를 읽어야 하므로 일반 함수 포인터 cast로 되돌리지 않는다.
+
+rollback이 필요하면 이 PR의 단일 code commit을 되돌린다. 문서 trailing commit은 런타임 동작을 바꾸지
+않으므로 별도로 되돌릴 필요가 없다.
+
+## 검증과 후속 조건
+
+Studio 단위·번들·headless 재도색 검증과 Rust 경계 unit/feature/wasm32 검증을 모두 완료했다. 전체
+layout fidelity 변경이 아니므로 PDF 기준 visual sweep은 이번 PR의 판정 근거가 아니다. 최신 PR head의
+GitHub Actions, CodeQL, Render Diff가 통과하고 작업지시자 승인 뒤에만 merge한다.

--- a/mydocs/working/task_m100_4636_4641_4642_stage1.md
+++ b/mydocs/working/task_m100_4636_4641_4642_stage1.md
@@ -1,0 +1,53 @@
+# Task #4636, #4641, #4642 Stage 1 - 개발용 핫패치 경계 구현
+
+- Issue: [#4636](https://github.com/edwardkim/rhwp/issues/4636), [#4641](https://github.com/edwardkim/rhwp/issues/4641), [#4642](https://github.com/edwardkim/rhwp/issues/4642)
+- Base: `upstream/devel` `be7dabdd170117d6022656063b0482f04361bfcb`
+- Branch: `task_m100_4636_4641_4642-hotpatch-boundary-20260814`
+- 작성일: 2026-08-14 KST
+
+## 구현 계획
+
+개발용 렌더 교체의 소켓과 감시자를 `subsecond-runtime.ts`의 단일 realm 수명 함수로 모으고,
+`main.ts`가 DEV 동적 import로만 시작한다. `WasmBridge`와 `CanvasView`에서는 개발 전용 상태,
+메서드, 이벤트 분기를 제거한다. 프로덕션 산출물 감시는 중첩 chunk까지 검사한다.
+
+Rust는 실제 핫패치 경계 모듈을 `render_patch_boundary`로 이름 바꾸고, `subsecond_dev`에 있던
+`HotFunction` 제네릭 helper를 없앤다. 적용된 함수 주소를 읽는 코드는 경계 매크로 안에 남겨
+패치 리비전의 의미를 유지한다.
+
+## 검증 결과
+
+`WasmBridge`와 `CanvasView`에서 개발용 소켓·감시자·이벤트 수명 소유를 제거했다. `main.ts`가
+WASM 초기화와 `CanvasView` 생성 뒤 DEV 동적 import로 `subsecond-runtime`의 단일 realm 런타임을
+시작하며, 렌더 코드 리비전이 바뀌면 문서 리비전 재선택 없이 현재 뷰를 직접 재도색한다.
+
+`render_patch_boundary.rs`는 기존 `subsecond_boundary.rs`를 도메인 이름으로 바꾼 것이다.
+`subsecond_dev`의 `HotFunction` 제네릭 helper는 제거했고, 경계 매크로에서
+`HotFn::current(target).ptr_address()`를 직접 쓴다. 일반 함수 포인터 캐스팅은 적용된 점프 테이블을
+무시해 리비전이 바뀌지 않으므로 사용하지 않았다.
+
+프로덕션 번들 검사는 `dist/assets` 직계 JavaScript만 읽던 방식을 `dist` 아래 모든 `.js`/`.mjs`
+파일 재귀 순회로 바꾸고, 중첩 산출물 fixture도 추가했다.
+
+다음 검증을 순차 실행했다.
+
+- `npm --prefix rhwp-studio test -- --runInBand` - 923/923 통과, 실패 0건, 약 8.7초.
+- `npm --prefix rhwp-studio run build` - TypeScript와 Vite production build 통과. CanvasKit browser
+  externalization 및 500kB chunk-size 안내만 있었고 실패는 없었다.
+- `node --test scripts/frontend-studio-dist.test.mjs` - 5/5 통과. 중첩 JavaScript 산출물 검사와
+  개발용 표지·벤더 이름 누출 부재를 확인했다.
+- `cargo test --profile release-test --target-dir target/pr-review --lib render_patch_boundary -- --nocapture`
+  - 3/3 통과.
+- `cargo test --profile release-test --target-dir target/pr-review --features subsecond-dev --lib render_patch_boundary -- --nocapture`
+  - 4/4 통과. `patch_revision`이 feature 경계 수와 맞는지 확인했다.
+- `CARGO_TARGET_DIR=target/pr-review wasm-pack build --target web --dev --features subsecond-dev --out-dir /tmp/rhwp-wasm-hotpatch-boundary`
+  - 미실행 처리. 현재 `wasm-pack 0.15.0`이 `--out-dir`를 stable Cargo에서 사용할 수 없는
+    `--artifact-dir`로 변환해 빌드 전에 실패했다. 코드 컴파일 오류가 아니다.
+- `cargo build --profile release-test --target-dir target/pr-review --target wasm32-unknown-unknown --features subsecond-dev --lib`
+  - 통과. `wasm32` 전용 부분 재도색 본체와 feature-gated 경계 매크로를 직접 컴파일했다.
+- `git diff --check` - 통과.
+
+WASM JavaScript 공개 인자(`x/y/width/height`)는 wasm-bindgen 호환 표면이고, 내부에서는
+`BoundingBox` 값 하나로 경계에 전달된다. 본체도 이 값을 다시 분해하지 않고 필드를 직접 검증·클리핑한다.
+새 `BoundingBox`는 페이지와의 교집합 클립을 표현하는 값일 뿐, 입력 사각형을 다시 조립하는 왕복이 아니다.
+렌더 계산과 문서 포맷 결과는 이번 Stage의 변경 범위 밖이다.

--- a/rhwp-studio/src/core/subsecond-runtime.ts
+++ b/rhwp-studio/src/core/subsecond-runtime.ts
@@ -84,6 +84,11 @@ type AnimationFrameScheduler = {
   cancelAnimationFrame(id: number): void;
 };
 
+export type DevelopmentRenderRuntimeOptions = {
+  measureHeapBytes?: () => number | null;
+  scheduler?: AnimationFrameScheduler;
+};
+
 type WebSocketConnection = {
   onmessage: ((event: MessageEvent) => void) | null;
   onclose: ((event: CloseEvent) => void) | null;
@@ -390,10 +395,53 @@ export class RenderCodeReloadWatcher {
 }
 
 /**
+ * 개발용 렌더 교체 런타임을 한 realm에 하나만 연결한다.
+ *
+ * 소켓·패치 계수·리비전 감시는 모두 이 개발 전용 모듈에 둔다. `WasmBridge`나 `CanvasView`는
+ * 문서 편집과 화면 수명만 소유해야 하므로 클래스 멤버로 이 능력을 노출하지 않는다 (#4636, #4641).
+ * 호출자는 DEV 동적 import를 한 `main.ts`뿐이며, 반환된 해제 함수는 미래의 Studio 인스턴스 교체
+ * 경로를 위한 유일한 정리선이다.
+ */
+let stopDevelopmentRenderRuntime: (() => void) | null = null;
+
+export function startDevelopmentRenderRuntime(
+  exports: object,
+  currentDocument: () => object | null,
+  onPatched: (revision: string) => void,
+  options: DevelopmentRenderRuntimeOptions = {},
+): (() => void) | null {
+  if (stopDevelopmentRenderRuntime) return stopDevelopmentRenderRuntime;
+
+  const capabilities = createRenderCodeReload(exports, currentDocument);
+  if (!capabilities.isAvailable()) return null;
+
+  const disconnectDevtools = connectSubsecondDevtools(
+    exports as SubsecondWasmExports,
+    {
+      patchAccumulation: new SubsecondPatchAccumulation({
+        measureHeapBytes: options.measureHeapBytes,
+      }),
+    },
+  );
+  const watcher = new RenderCodeReloadWatcher(capabilities, onPatched, options.scheduler);
+  if (!watcher.start()) {
+    disconnectDevtools?.();
+    return null;
+  }
+
+  stopDevelopmentRenderRuntime = () => {
+    watcher.stop();
+    disconnectDevtools?.();
+    stopDevelopmentRenderRuntime = null;
+  };
+  return stopDevelopmentRenderRuntime;
+}
+
+/**
  * dx devserver 소켓에 붙어 도착한 패치를 wasm 에 넘긴다.
  *
  * 돌려주는 해제 함수는 소켓과 재연결 타이머를 함께 내린다. 스튜디오에서는 realm 이 끝날 때까지
- * 부를 시점이 없고(문서 닫기·뷰 폐기가 없다) 호출부는 `wasm-bridge.ts` 의 중복 연결 guard 하나뿐이지만,
+ * 부를 시점이 없고(문서 닫기·뷰 폐기가 없다) 호출부는 이 모듈의 realm 단위 소유자 하나뿐이지만,
  * 소켓을 연 곳이 내리는 방법을 함께 돌려주는 형태는 유지한다 — 테스트와 이후 종료 경로의 유일한 해제선이다.
  */
 export function connectSubsecondDevtools(

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -202,19 +202,6 @@ export interface DeferredPaginationResult {
 
 import { fontFamilyChainForDisplay } from './font-substitution';
 import type { FileSystemFileHandleLike } from '@/command/file-system-access';
-// [#4580] **값 import 는 금지다.** `subsecond-runtime` 은 개발 전용 벤더 런타임이고, 정적으로
-// 엮이는 순간 `import.meta.env.DEV` 로 감싸도 프로덕션 번들에서 빠지지 않는다. 타입만 가져오고
-// 실물은 아래 `startRenderCodeReload()` 의 DEV 분기에서 동적으로 부른다.
-import type {
-  RenderCodeReload,
-  SubsecondWasmExports,
-} from './subsecond-runtime';
-
-/**
- * devtools 소켓의 해제 함수 — realm 하나에 소켓 하나이므로 중복 연결 guard 로도 쓴다.
- * 스튜디오에는 realm 종료 이전의 해제 시점이 없어 실제로 호출되지는 않는다.
- */
-let disconnectSubsecondDevtools: (() => void) | null = null;
 
 /**
  * CSS font 문자열에서 font-family를 추출하여 폰트 치환을 적용한다.
@@ -269,8 +256,8 @@ export class WasmBridge {
   private _documentDigest: string | null = null;
   /** 같은 바이트를 다시 열어도 구분되는 문서 인스턴스 세대. */
   private _documentGeneration = 0;
-  /** 개발 빌드에서만 채워지는 렌더 코드 교체 능력 — 아래 `startRenderCodeReload()` 참고. */
-  private renderCodeReload: RenderCodeReload | null = null;
+  /** 개발 진단에서만 읽는 wasm 선형 메모리. 일반 wasm-glue에는 없을 수 있다. */
+  private wasmLinearMemory: WebAssembly.Memory | null = null;
   /** [#3313] 외부 연결 그림 비동기 주입 완료 훅 — 주입 성공(>0)시에만 호출된다.
    * 첫 렌더 이후에 fetch 가 끝나면 뷰가 재갱신 없이는 이미지를 표시하지 못하므로,
    * main 쪽에서 뷰 갱신을 배선한다 (dirty 마킹 없는 뷰 전용 경로여야 함). */
@@ -281,55 +268,29 @@ export class WasmBridge {
     installCanvasFontSubstitution();
     this.installMeasureTextWidth();
     // @wasm path alias는 개발 glue를 가리킬 수 있어 init 반환값을 unknown으로 추론한다.
-    // wasm-bindgen의 InitOutput memory만 선택적으로 읽고, subsecond glue의 memory 부재는 허용한다.
+    // wasm-bindgen의 InitOutput memory만 선택적으로 읽고, 개발 glue의 memory 부재는 허용한다.
     const wasmModule = await init() as { memory?: WebAssembly.Memory };
-    await this.startRenderCodeReload(wasmModule);
+    this.wasmLinearMemory = wasmModule.memory ?? null;
     this.initialized = true;
     console.log(`[WasmBridge] WASM 초기화 완료 (rhwp ${version()})`);
   }
 
   /**
-   * 렌더 코드 교체(핫패치) 지원을 개발 빌드에서만 배선한다 (#4580).
+   * WASM 모듈 export namespace를 내부 런타임에 빌려준다.
    *
-   * `import.meta.env.DEV` 는 빌드 시점에 리터럴로 접히므로 프로덕션 번들에서는 이 본문 전체가
-   * 죽은 코드로 지워지고, 그 안에서만 참조되는 `subsecond-runtime` 모듈은 아예 모듈 그래프에
-   * 들어오지 않는다. 능력 구현도 그 모듈이 갖고 있어야 한다 — 여기 메서드로 두면 호출부가
-   * 없어도 트리셰이킹되지 않아 벤더 export 이름이 그대로 실려 나간다.
+   * 문서 핸들처럼 소유권을 넘기지 않는다. 개발 전용 렌더 런타임만 이 값을 받아 feature export
+   * 존재 여부를 확인하며, 소켓·감시자·재도색 수명은 `main.ts`가 소유한다 (#4636, #4641).
    */
-  private async startRenderCodeReload(
-    wasmModule: { memory?: WebAssembly.Memory },
-  ): Promise<void> {
-    if (!import.meta.env.DEV) return;
-    try {
-      const runtime = await import('./subsecond-runtime');
-      const renderCodeReload = runtime.createRenderCodeReload(wasmExports, () => this.doc);
-      const disconnect = disconnectSubsecondDevtools
-        ? null
-        : runtime.connectSubsecondDevtools(
-          wasmExports as unknown as SubsecondWasmExports,
-          {
-            patchAccumulation: new runtime.SubsecondPatchAccumulation({
-              // subsecond 세션에서는 이 모듈이 dx 가 만든 glue(`target/rhwp-subsecond-vite/`)로
-              // 바뀐다. 타입은 언제나 `pkg/rhwp.d.ts` 를 보므로 memory 부재는 타입으로 못 걸러진다.
-              measureHeapBytes: () => wasmModule.memory?.buffer.byteLength ?? null,
-            }),
-          },
-        );
-      this.renderCodeReload = renderCodeReload;
-      if (disconnect) disconnectSubsecondDevtools = disconnect;
-    } catch (error) {
-      // 개발 편의 기능의 준비 실패가 문서 편집기의 WASM 초기화 전체를 막으면 안 된다.
-      console.warn('[WasmBridge] 개발용 렌더 코드 교체를 시작하지 못했습니다:', error);
-    }
+  getWasmModuleExports(): object {
+    return wasmExports;
   }
 
   /**
-   * 렌더 코드 교체 능력. 개발 빌드가 아니거나 교체를 지원하지 않는 wasm 이면 `null` 이다 —
-   * 프로덕션 번들에서는 위 배선이 통째로 지워지므로 언제나 `null` 이다. 개발 콘솔에서는
-   * `__wasm.getRenderCodeReload()?.isAvailable()` 로 확인한다.
+   * 현재 wasm 선형 메모리 크기(byte). glue가 이를 노출하지 않으면 `null` 이다.
+   * 개발 전용 패치 세션 경고에만 쓰며, 수명/용량 판정의 기준으로 사용하지 않는다.
    */
-  getRenderCodeReload(): RenderCodeReload | null {
-    return this.renderCodeReload;
+  getWasmLinearMemoryBytes(): number | null {
+    return this.wasmLinearMemory?.buffer.byteLength ?? null;
   }
 
   /** WASM 렌더러가 호출하는 텍스트 폭 측정 함수를 등록한다 */

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -131,6 +131,31 @@ let rendererInitialized = false;
 let extensionViewerSettings: ExtensionViewerSettings = {
   disableExternalWebFonts: false,
 };
+/** DEV 동적 런타임의 realm 단위 해제선. 현재 Studio에는 뷰 교체 경로가 없어 호출하지 않는다. */
+let stopDevelopmentRenderRuntime: (() => void) | null = null;
+
+/**
+ * 개발 전용 렌더 교체를 앱 조립점에서만 시작한다 (#4636, #4641).
+ *
+ * `WasmBridge`는 wasm 초기화와 문서 소유만, `CanvasView`는 화면 수명만 맡는다. 개발 소켓과
+ * 리비전 감시는 여기서 DEV 동적 import로만 만들고 문서 리비전이 아닌 렌더 코드가 바뀌면 현재
+ * 뷰를 직접 다시 그린다. 이 함수 전체는 production build에서 제거돼 runtime chunk도 남지 않는다.
+ */
+async function startDevelopmentRenderRuntime(): Promise<void> {
+  if (!import.meta.env.DEV || stopDevelopmentRenderRuntime || !canvasView) return;
+  try {
+    const runtime = await import('@/core/subsecond-runtime');
+    stopDevelopmentRenderRuntime = runtime.startDevelopmentRenderRuntime(
+      wasm.getWasmModuleExports(),
+      () => wasm.borrowDocumentHandle(),
+      () => canvasView?.refreshPages(),
+      { measureHeapBytes: () => wasm.getWasmLinearMemoryBytes() },
+    );
+  } catch (error) {
+    // 개발 편의 기능 실패가 문서 편집기 초기화를 막으면 안 된다.
+    console.warn('[main] 개발용 렌더 코드 교체를 시작하지 못했습니다:', error);
+  }
+}
 
 
 // ─── UI chrome 프로파일 (#4564) ─────────────────────────────
@@ -507,6 +532,7 @@ async function initialize(): Promise<void> {
       eventBus,
       rendererSession,
     );
+    await startDevelopmentRenderRuntime();
 
     // [#3313] 외부 연결 그림(HWP3 pic_type=0)의 비동기 주입이 첫 렌더 이후에 끝나면
     // 화면이 이전 프레임(그림 없는 상태)에 머무른다. 주입 완료 시 뷰 문서를 다시

--- a/rhwp-studio/src/view/canvas-view.ts
+++ b/rhwp-studio/src/view/canvas-view.ts
@@ -22,24 +22,9 @@ import {
   type ZoomAnchor,
   type ZoomPageBox,
 } from './zoom-anchor.ts';
-// [#4580] **값 import 는 금지다** — 개발 전용 벤더 런타임이라 정적으로 엮이면 프로덕션 번들에
-// 그대로 실린다. 실물은 `startRenderCodeReloadWatch()` 의 DEV 분기에서 동적으로 부른다.
-import type { RenderCodeReloadWatcher } from '@/core/subsecond-runtime';
 
 const TEXT_EDIT_STATIC_LAYER_VERIFY_DELAY_MS = 800;
 const AUTO_RENDERER_RESELECTION_DELAY_MS = 300;
-
-/**
- * `document-view-changed` 의 발생원 — 문서 리비전은 그대로고 **화면용 파생물을 만드는 코드**가
- * 교체됐다는 뜻이다.
- *
- * [#4580] 발생원과 그것을 보는 쪽이 같은 이름을 쓰게 하는 유일한 장치다. 예전에는 아래 두 자리가
- * `'subsecond-renderer'` 라는 리터럴을 각자 적고 있어 컴파일 타임 연결이 0이었다 — 한쪽만 고치면
- * 컴파일은 통과한 채 재도색이 조용히 `refreshPagesForRevision()` 으로 격하됐다. 이름에서 벤더도
- * 뺐다: 이 사건의 내용은 "렌더 코드가 다시 로드됐다"이지 어느 도구가 그랬는지가 아니다.
- * 다른 모듈이 이 발생원을 쏘게 되면 리터럴을 새로 적지 말고 이 상수를 export 한다.
- */
-const RENDER_CODE_RELOADED = 'render-code-reloaded';
 
 type DeferredPrefetchTask =
   | { kind: 'idle'; id: number }
@@ -56,7 +41,6 @@ export class CanvasView {
   private pageRenderer: PageRenderer;
   private viewportManager: ViewportManager;
   private coordinateSystem: CoordinateSystem;
-  private renderCodeReloadWatcher: RenderCodeReloadWatcher | null = null;
 
   private scrollContent: HTMLElement;
   private pages: PageInfo[] = [];
@@ -86,7 +70,6 @@ export class CanvasView {
     this.pageRenderer = new PageRenderer(wasm);
     this.viewportManager = new ViewportManager(eventBus);
     this.coordinateSystem = new CoordinateSystem(this.virtualScroll);
-    this.startRenderCodeReloadWatch();
 
     this.scrollContent = container.querySelector('#scroll-content')!;
     this.viewportManager.attachTo(container);
@@ -108,47 +91,11 @@ export class CanvasView {
       eventBus.on('document-changed', () => {
         void this.refreshPagesForMutation();
       }),
-      eventBus.on('document-view-changed', (source) => {
-        if (source === RENDER_CODE_RELOADED) {
-          // 문서 리비전은 그대로다 — 렌더러 재선택 없이 곧바로 다시 그린다.
-          this.refreshPages();
-          return;
-        }
+      eventBus.on('document-view-changed', () => {
         void this.refreshPagesForRevision();
       }),
       eventBus.on('grid-view-changed', () => this.refreshGridOverlays()),
     );
-  }
-
-  /**
-   * 렌더 코드 교체 감시자를 개발 빌드에서만 시작한다 (#4580).
-   *
-   * `import.meta.env.DEV` 는 빌드 시점 리터럴이라 프로덕션 번들에서는 이 본문이 통째로 지워지고,
-   * 그때만 참조되는 `subsecond-runtime` 모듈도 모듈 그래프에서 빠진다. 생성자는 동기라 동적
-   * import 를 기다릴 수 없으므로 모듈이 도착한 뒤에 배선하고, 그 사이에 뷰가 정리됐으면 시작하지
-   * 않는다.
-   */
-  private startRenderCodeReloadWatch(): void {
-    if (!import.meta.env.DEV) return;
-    const renderCodeReload = this.wasm.getRenderCodeReload();
-    if (!renderCodeReload) {
-      console.warn(
-        '[CanvasView] 개발용 렌더 코드 교체가 준비되지 않았습니다. CanvasView는 await wasm.initialize() 뒤에 생성해야 합니다.',
-      );
-      return;
-    }
-    void import('@/core/subsecond-runtime')
-      .then(({ RenderCodeReloadWatcher }) => {
-        if (this.disposed) return;
-        this.renderCodeReloadWatcher = new RenderCodeReloadWatcher(
-          renderCodeReload,
-          () => this.eventBus.emit('document-view-changed', RENDER_CODE_RELOADED),
-        );
-        this.renderCodeReloadWatcher.start();
-      })
-      .catch((error) => {
-        console.error('[CanvasView] 렌더 코드 교체 감시자를 불러오지 못했습니다:', error);
-      });
   }
 
   /** 문서 로드 후 호출 — 페이지 정보 수집 및 가상 스크롤 초기화 */
@@ -1001,13 +948,12 @@ export class CanvasView {
    * #4579 가 같은 이유로 배선을 거절했다.
    *
    * 이 메서드와 `disposed` 가드들이 살아나는 시점은 하나뿐이다: 문서 닫기나 뷰 교체 기능이
-   * 생길 때. 그때 이것이 유일한 해제선이고, `wasm-bridge.ts` 의 `disconnectSubsecondDevtools`
-   * 도 같은 자리에서 불려야 한다. 그 전까지 호출부를 지어내지 않는다.
+   * 생길 때. 개발용 렌더 런타임은 `main.ts`가 realm 단위로 소유하므로, 그 새 수명 경로에서
+   * 반환된 해제 함수를 함께 부른다. 그 전까지 호출부를 지어내지 않는다.
    */
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
-    this.renderCodeReloadWatcher?.stop();
     this.rendererSelectionEpoch += 1;
     this.documentLoadPrepared = false;
     this.cancelAutoRendererReselection();

--- a/rhwp-studio/tests/subsecond-boundary-contract.test.ts
+++ b/rhwp-studio/tests/subsecond-boundary-contract.test.ts
@@ -10,38 +10,27 @@ function source(path: string): string {
   return readFileSync(join(rootDir, path), 'utf8');
 }
 
-function method(sourceText: string, startToken: string, endToken: string): string {
-  const start = sourceText.indexOf(startToken);
-  const end = sourceText.indexOf(endToken, start);
-  assert.ok(start >= 0 && end > start, `${startToken} 범위를 찾을 수 있어야 한다`);
-  return sourceText.slice(start, end);
-}
+test('개발용 런타임 import 실패는 Studio 초기화를 중단시키지 않는다', () => {
+  const main = source('src/main.ts');
 
-test('개발용 런타임 import 실패는 Studio WASM 초기화를 중단시키지 않는다', () => {
-  const bridge = method(
-    source('src/core/wasm-bridge.ts'),
-    '  private async startRenderCodeReload(',
-    '\n  /**\n   * 렌더 코드 교체 능력.',
-  );
-
-  assert.match(bridge, /try \{[\s\S]*await import\('\.\/subsecond-runtime'\)/);
+  assert.match(main, /if \(!import\.meta\.env\.DEV \|\| stopDevelopmentRenderRuntime \|\| !canvasView\) return;/);
+  assert.match(main, /try \{[\s\S]*await import\('@\/core\/subsecond-runtime'\)/);
   assert.match(
-    bridge,
-    /catch \(error\) \{[\s\S]*console\.warn\('\[WasmBridge\] 개발용 렌더 코드 교체를 시작하지 못했습니다:'/,
+    main,
+    /catch \(error\) \{[\s\S]*console\.warn\('\[main\] 개발용 렌더 코드 교체를 시작하지 못했습니다:'/,
   );
+  const canvasViewCreatedAt = main.indexOf('canvasView = new CanvasView(');
+  const runtimeStartedAt = main.indexOf('await startDevelopmentRenderRuntime();', canvasViewCreatedAt);
+  assert.ok(canvasViewCreatedAt >= 0 && runtimeStartedAt > canvasViewCreatedAt);
 });
 
-test('CanvasView는 초기화 순서가 틀린 개발용 교체 구성을 조용히 끄지 않는다', () => {
-  const canvasView = method(
-    source('src/view/canvas-view.ts'),
-    '  private startRenderCodeReloadWatch(): void {',
-    '\n  /** 문서 로드 후 호출',
-  );
+test('일반 Studio 클래스는 개발용 소켓과 감시자를 소유하지 않는다', () => {
+  const bridge = source('src/core/wasm-bridge.ts');
+  const canvasView = source('src/view/canvas-view.ts');
 
-  assert.match(
-    canvasView,
-    /if \(!renderCodeReload\) \{[\s\S]*console\.warn\([\s\S]*await wasm\.initialize\(\)[\s\S]*return;/,
-  );
+  assert.doesNotMatch(bridge, /subsecond-runtime|startRenderCodeReload|getRenderCodeReload|disconnectSubsecondDevtools/);
+  assert.doesNotMatch(canvasView, /subsecond-runtime|startRenderCodeReloadWatch|renderCodeReloadWatcher|render-code-reloaded/);
+  assert.match(source('src/main.ts'), /\(\) => canvasView\?\.refreshPages\(\)/);
 });
 
 test('비활성화된 자동 투명선 경로의 고아 이벤트를 남기지 않는다', () => {

--- a/rhwp-studio/tests/subsecond-runtime.test.ts
+++ b/rhwp-studio/tests/subsecond-runtime.test.ts
@@ -343,6 +343,48 @@ test('render capabilities stay silent on a plain WASM build and follow the curre
   assert.equal(hotpatch.getRenderCodeRevision(), null, '문서를 닫으면 다시 리비전이 없다');
 });
 
+test('development render runtime owns one watcher and releases it for a later realm setup', async () => {
+  const { startDevelopmentRenderRuntime } = await loadRuntime();
+  const frames = new FakeAnimationFrames();
+  let revision = 'baseline';
+  let rebuilds = 0;
+  const repaints: string[] = [];
+  const document = {
+    getRenderCodeRevision: () => revision,
+    rebuildDerivedState: () => {
+      rebuilds += 1;
+    },
+  };
+  const exports = { subsecondProbe: () => 41 };
+  const options = {
+    scheduler: {
+      requestAnimationFrame: frames.request,
+      cancelAnimationFrame: frames.cancel,
+    },
+  };
+
+  const stop = startDevelopmentRenderRuntime(exports, () => document, next => repaints.push(next), options);
+  assert.ok(stop, '개발 빌드는 한 realm 수명 감시자를 시작해야 한다');
+  assert.equal(
+    startDevelopmentRenderRuntime(exports, () => document, () => {}, options),
+    stop,
+    '중복 시작은 같은 realm 소유자를 돌려줘야 한다',
+  );
+  frames.flush();
+  revision = 'patched';
+  frames.flush();
+  assert.equal(rebuilds, 1);
+  assert.deepEqual(repaints, ['patched']);
+
+  stop();
+  assert.equal(frames.pendingCount, 0, '해제선은 감시 프레임을 남기면 안 된다');
+
+  const nextStop = startDevelopmentRenderRuntime(exports, () => document, () => {}, options);
+  assert.ok(nextStop, '해제 뒤 다음 Studio realm은 새 감시자를 시작할 수 있어야 한다');
+  assert.notEqual(nextStop, stop);
+  nextStop();
+});
+
 test('devtools websocket forwards patch messages and reconnects without reloading', async () => {
   const { connectSubsecondDevtools } = await loadRuntime();
   const sockets: FakeWebSocket[] = [];

--- a/scripts/frontend-studio-dist.test.mjs
+++ b/scripts/frontend-studio-dist.test.mjs
@@ -1,12 +1,12 @@
 import assert from 'node:assert/strict';
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 const ROOT = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
-const STUDIO_ASSETS = path.join(ROOT, 'rhwp-studio/dist/assets');
+const STUDIO_DIST = path.join(ROOT, 'rhwp-studio/dist');
 const HOTPATCH_RUNTIME = path.join(ROOT, 'rhwp-studio/src/core/subsecond-runtime.ts');
 
 /**
@@ -43,18 +43,26 @@ const VENDOR_NAMES = ['subsecond', 'Subsecond', 'dioxus', 'Dioxus'];
 const BUNDLE_SENTINEL = 'document-view-changed';
 const BUILD_INSTRUCTION = '먼저 `npm --prefix rhwp-studio run build`';
 
-function readStudioBundle(studioAssets = STUDIO_ASSETS) {
+function readStudioBundle(studioDist = STUDIO_DIST) {
   assert.ok(
-    existsSync(studioAssets),
-    `${studioAssets} 가 없다 — ${BUILD_INSTRUCTION}`,
+    existsSync(studioDist),
+    `${studioDist} 가 없다 — ${BUILD_INSTRUCTION}`,
   );
 
-  const files = readdirSync(studioAssets).filter((file) => file.endsWith('.js'));
+  const files = [];
+  const visit = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const file = path.join(directory, entry.name);
+      if (entry.isDirectory()) visit(file);
+      else if (entry.isFile() && /\.m?js$/.test(entry.name)) files.push(file);
+    }
+  };
+  visit(studioDist);
   assert.ok(
     files.length > 0,
-    `${studioAssets} 에 자바스크립트 번들이 없다 — ${BUILD_INSTRUCTION}`,
+    `${studioDist} 에 자바스크립트 번들이 없다 — ${BUILD_INSTRUCTION}`,
   );
-  return files.map((file) => readFileSync(path.join(studioAssets, file), 'utf8')).join('\n');
+  return files.sort().map((file) => readFileSync(file, 'utf8')).join('\n');
 }
 
 function countOccurrences(haystack, needle) {
@@ -80,15 +88,28 @@ test('hot-patch markers still name something in the development-only runtime', (
 
 test('studio bundle test gives build guidance when the assets directory is absent', () => {
   const temporaryRoot = mkdtempSync(path.join(tmpdir(), 'rhwp-studio-dist-test-'));
-  const missingAssets = path.join(temporaryRoot, 'assets');
+  const missingDist = path.join(temporaryRoot, 'dist');
 
   try {
     assert.throws(
-      () => readStudioBundle(missingAssets),
+      () => readStudioBundle(missingDist),
       (error) =>
         error instanceof assert.AssertionError &&
-        error.message === `${missingAssets} 가 없다 — ${BUILD_INSTRUCTION}`,
+        error.message === `${missingDist} 가 없다 — ${BUILD_INSTRUCTION}`,
     );
+  } finally {
+    rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+});
+
+test('studio bundle reader includes JavaScript below nested deliverable directories', () => {
+  const temporaryRoot = mkdtempSync(path.join(tmpdir(), 'rhwp-studio-dist-test-'));
+  const nested = path.join(temporaryRoot, 'assets', 'nested');
+
+  try {
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(path.join(nested, 'runtime.js'), 'nested-deliverable-marker');
+    assert.match(readStudioBundle(temporaryRoot), /nested-deliverable-marker/);
   } finally {
     rmSync(temporaryRoot, { recursive: true, force: true });
   }

--- a/src/subsecond_dev.rs
+++ b/src/subsecond_dev.rs
@@ -1,5 +1,5 @@
 use serde_json::Value;
-use subsecond::{HotFn, HotFunction, JumpTable};
+use subsecond::{HotFn, JumpTable};
 use wasm_bindgen::prelude::*;
 
 fn probe_value() -> u32 {
@@ -105,13 +105,6 @@ pub fn apply_subsecond_devtools_message(message: &str) -> String {
 pub fn link_wasm_exports() {
     let _ = crate::version();
     let _ = subsecond_probe();
-}
-
-pub(crate) fn hot_fn_ptr<Args, Marker, Function>(function: Function) -> u64
-where
-    Function: HotFunction<Args, Marker>,
-{
-    HotFn::current(function).ptr_address().0
 }
 
 #[cfg(test)]

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -42,8 +42,8 @@ use crate::renderer::style_resolver::{
 use crate::renderer::svg::SvgRenderer;
 use crate::renderer::DEFAULT_DPI;
 
-/// 어떤 렌더 export 가 Subsecond 핫패치 경계 뒤에 있는지 선언하는 곳 (#4577).
-mod subsecond_boundary;
+/// 어떤 렌더 export가 교체 가능한 경계 뒤에 있는지 선언하는 곳 (#4577, #4642).
+mod render_patch_boundary;
 
 impl From<HwpError> for JsValue {
     fn from(err: HwpError) -> Self {
@@ -214,13 +214,12 @@ fn render_page_patch_to_canvas_filtered_with_profile_impl(
     use crate::renderer::render_tree::BoundingBox;
     use crate::renderer::web_canvas::WebCanvasRenderer;
 
-    let BoundingBox {
-        x,
-        y,
-        width,
-        height,
-    } = patch;
-    if ![x, y, width, height].into_iter().all(f64::is_finite) || width <= 0.0 || height <= 0.0 {
+    if ![patch.x, patch.y, patch.width, patch.height]
+        .into_iter()
+        .all(f64::is_finite)
+        || patch.width <= 0.0
+        || patch.height <= 0.0
+    {
         return Err(JsValue::from_str("invalid page patch rectangle"));
     }
 
@@ -241,10 +240,10 @@ fn render_page_patch_to_canvas_filtered_with_profile_impl(
         ));
     }
 
-    let left = x.max(0.0).min(tree.page_width);
-    let top = y.max(0.0).min(tree.page_height);
-    let right = (x + width).max(left).min(tree.page_width);
-    let bottom = (y + height).max(top).min(tree.page_height);
+    let left = patch.x.max(0.0).min(tree.page_width);
+    let top = patch.y.max(0.0).min(tree.page_height);
+    let right = (patch.x + patch.width).max(left).min(tree.page_width);
+    let bottom = (patch.y + patch.height).max(top).min(tree.page_height);
     if right <= left || bottom <= top {
         return Err(JsValue::from_str(
             "page patch rectangle does not intersect the page",
@@ -808,7 +807,7 @@ impl HwpDocument {
         layer_kind: &str,
         profile: &str,
     ) -> Result<(), JsValue> {
-        subsecond_boundary::render_page_to_canvas_filtered_with_profile(
+        render_patch_boundary::render_page_to_canvas_filtered_with_profile(
             self, page_num, canvas, scale, layer_kind, profile,
         )
     }
@@ -834,7 +833,7 @@ impl HwpDocument {
     ) -> Result<(), JsValue> {
         use crate::renderer::render_tree::BoundingBox;
 
-        subsecond_boundary::render_page_patch_to_canvas_filtered_with_profile(
+        render_patch_boundary::render_page_patch_to_canvas_filtered_with_profile(
             self,
             page_num,
             canvas,
@@ -908,7 +907,7 @@ impl HwpDocument {
         omit_image_bytes: Option<bool>,
     ) -> Result<String, JsValue> {
         let omit_image_bytes = omit_image_bytes.unwrap_or(false);
-        subsecond_boundary::get_page_layer_tree_with_profile(
+        render_patch_boundary::get_page_layer_tree_with_profile(
             self,
             page_num,
             profile,
@@ -921,9 +920,9 @@ impl HwpDocument {
     /// 소비자는 이 문자열을 해석하지 않고 이전 값과 비교만 한다. 오늘 그 값을 바꾸는 것은
     /// Subsecond 핫패치뿐이지만, 이름은 그 사실이 아니라 소비자가 알아야 하는 것을 말한다 —
     /// 벤더가 바뀌어도 "렌더 코드의 리비전"이라는 질문은 그대로다 (#4580). 벤더를 아는 곳은
-    /// 몸통이 부르는 `subsecond_boundary` 하나다.
+    /// 몸통이 부르는 `render_patch_boundary` 하나다.
     ///
-    /// 값은 경계 목록(`subsecond_boundary`)에서 바로 나오므로 경계를 더할 때 여기를 같이 고칠
+    /// 값은 경계 목록(`render_patch_boundary`)에서 바로 나오므로 경계를 더할 때 여기를 같이 고칠
     /// 일이 없다 — 리비전이 경계 하나를 놓쳐 재도색이 안 도는 구멍이 생기지 않는다.
     ///
     /// 아래 재구성과 **한 쌍이다.** 리비전이 바뀐 것을 보고 재구성을 부르는 것이 TS 계약
@@ -933,7 +932,7 @@ impl HwpDocument {
     #[cfg(all(feature = "subsecond-dev", target_arch = "wasm32"))]
     #[wasm_bindgen(js_name = getRenderCodeRevision)]
     pub fn get_render_code_revision(&self) -> String {
-        subsecond_boundary::patch_revision()
+        render_patch_boundary::patch_revision()
     }
 
     /// 바이트는 그대로인데 화면용으로 파생해 둔 것이 더는 원본과 대응하지 않을 때 다시 만든다.
@@ -996,7 +995,7 @@ impl HwpDocument {
     /// 페이지 overlay 이미지 정보만 JSON 문자열로 반환한다.
     #[wasm_bindgen(js_name = getPageOverlayImages)]
     pub fn get_page_overlay_images(&self, page_num: u32) -> Result<String, JsValue> {
-        subsecond_boundary::get_page_overlay_images(self, page_num)
+        render_patch_boundary::get_page_overlay_images(self, page_num)
     }
 
     /// 페이지가 그리는 그림들의 신원 키만 작은 JSON 으로 반환한다 (Task #3315).
@@ -1012,7 +1011,7 @@ impl HwpDocument {
     /// 있고 `sourceImageKey` 로 `getSourceImageBytes` 를 부르면 된다.
     #[wasm_bindgen(js_name = getPageFlowImageOps)]
     pub fn get_page_flow_image_ops(&self, page_num: u32) -> Result<String, JsValue> {
-        subsecond_boundary::get_page_flow_image_ops(self, page_num)
+        render_patch_boundary::get_page_flow_image_ops(self, page_num)
     }
 
     /// 그림 신원 키로 바이트를 Uint8Array 로 반환한다 (Task #3315).

--- a/src/wasm_api/render_patch_boundary.rs
+++ b/src/wasm_api/render_patch_boundary.rs
@@ -1,6 +1,6 @@
-//! Subsecond 핫패치가 실제로 도달하는 렌더 경계 (#4577).
+//! 교체 가능한 렌더 코드가 실제로 도달하는 경계 (#4577, #4642).
 //!
-//! `subsecond::HotFn::current(f)` 는 **`f` 하나만** 점프 테이블로 우회시킨다. 점프 테이블은
+//! 개발 feature의 `HotFn::current(f)` 는 **`f` 하나만** 점프 테이블로 우회시킨다. 점프 테이블은
 //! `map.get(&real)` 단일 키 조회이고, wasm `apply_patch` 는 메모리와 간접 함수 테이블을
 //! **늘리기만** 할 뿐 이미 있는 슬롯을 다시 묶지 않는다. 즉 **전이적 재링크가 없다** — JS 가
 //! base 모듈의 export 를 직접 부르면 그 아래 호출은 끝까지 옛 코드다.
@@ -21,7 +21,7 @@
 //!
 //! ## 인자 9개 상한
 //!
-//! `subsecond` 는 `HotFunction` 을 인자 9개까지만 구현한다(`impl_hot_function!` 의
+//! 개발용 교체 런타임은 인자 9개까지만 구현한다(`impl_hot_function!` 의
 //! `Fn9Marker` 가 마지막이다). `&HwpDocument` 가 첫 자리를 쓰므로 경계 함수가 실제로 받을 수
 //! 있는 인자는 8개다. 부분 재도색은 `x/y/width/height` 를 `BoundingBox` 하나로 접어 이 상한
 //! 안에 들어간다 — 그대로 펴 두면 10개라 `HotFn::current` 가 아예 컴파일되지 않는다.
@@ -108,7 +108,11 @@ macro_rules! hot_render_boundaries {
                     let _ = write!(
                         revision,
                         "{:016x}",
-                        crate::subsecond_dev::hot_fn_ptr($target)
+                        // `ptr_address()` 는 적용된 점프 테이블이 있으면 현재 패치 함수 주소를
+                        // 돌려준다. 일반 함수 포인터 캐스팅으로 바꾸면 base 주소가 고정돼 Studio가
+                        // 패치 뒤 재도색을 놓친다. 제네릭 벤더 trait 계약은 이 경계 구현 안에만
+                        // 두고 `subsecond_dev`의 공용 helper로 새지 않게 한다 (#4642).
+                        subsecond::HotFn::current($target).ptr_address().0
                     );
                 }
             )+


### PR DESCRIPTION
## 요약

- 개발 전용 렌더 교체 소켓·감시자·패치 계수를 `subsecond-runtime.ts`의 realm 단위 런타임으로 모으고, `main.ts`의 DEV 동적 import에서만 시작했습니다.
- `WasmBridge`와 `CanvasView`의 개발 전용 상태·메서드·이벤트 분기를 제거해 production bundle에 남던 죽은 표면을 없앴습니다.
- 배포 `dist` 아래의 모든 JavaScript chunk를 재귀 검사하도록 번들 계약을 보강했습니다.
- Rust 경계 모듈을 `render_patch_boundary`로 도메인화하고, 공용 `HotFunction` 제네릭 helper와 `BoundingBox` 즉시 분해 왕복을 제거했습니다.

## 검증

- `npm --prefix rhwp-studio test -- --runInBand` (923/923 통과)
- `npm --prefix rhwp-studio run build`
- `node --test scripts/frontend-studio-dist.test.mjs` (5/5 통과)
- `cargo test --profile release-test --target-dir target/pr-review --lib render_patch_boundary -- --nocapture` (3/3 통과)
- `cargo test --profile release-test --target-dir target/pr-review --features subsecond-dev --lib render_patch_boundary -- --nocapture` (4/4 통과)
- `cargo build --profile release-test --target-dir target/pr-review --target wasm32-unknown-unknown --features subsecond-dev --lib`

Closes #4636
Closes #4641
Closes #4642
