### PR TITLE
fix(tools/sweep): 감독이 워커 heartbeat 를 공유 위반 없이 읽는다 (#4749)

### DIFF
--- a/tools/loadsave_sweep/oracle_run.ps1
+++ b/tools/loadsave_sweep/oracle_run.ps1
@@ -90,6 +90,20 @@ $state = @{
   Restarts = 0
 }
 
+# 워커가 같은 파일을 쓰는 중에도 읽는다. 실패는 예외가 아니라 $null -- 감독은 절대 죽지 않는다.
+function Read-SharedText([string]$path) {
+  try {
+    $fs = [System.IO.File]::Open(
+      $path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+    try {
+      $sr = New-Object System.IO.StreamReader($fs, [System.Text.Encoding]::UTF8)
+      try { return $sr.ReadToEnd() } finally { $sr.Dispose() }
+    } finally { $fs.Dispose() }
+  } catch {
+    return $null
+  }
+}
+
 function Start-Worker {
   $wargs = @(
     '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', (Join-Path $here 'oracle_worker.ps1'),
@@ -135,7 +149,11 @@ while ($true) {
   if ($running) {
     $alive = $true
     if (Test-Path -LiteralPath $state.HB) {
-      $parts = ([System.IO.File]::ReadAllText($state.HB, [System.Text.Encoding]::UTF8)) -split '\|'
+      # 워커가 쓰는 중이면 ReadAllText 는 공유 위반으로 던진다. ErrorActionPreference=Stop 아래에서
+      # 그 예외는 감독을 통째로 죽여 장시간 패스를 날린다 -- ReadWrite 공유로 열고, 그래도 실패하면
+      # 이번 tick 만 건너뛴다 (다음 10초 tick 에서 다시 읽으므로 stall 감지가 늦어지지 않는다).
+      $hbText = Read-SharedText $state.HB
+      $parts = if ($hbText) { $hbText -split '\|' } else { @() }
       if ($parts.Count -ge 3) {
         $age = ($nowMs - [int64]$parts[1]) / 1000.0
         if ($age -gt $StallSeconds) {


### PR DESCRIPTION
## 변경 요약

load/save 오라클 전수검사(#4678)의 Phase B 감독 `tools/loadsave_sweep/oracle_run.ps1` 이
워커의 heartbeat 파일을 읽다가 공유 위반 예외로 죽어, 두 시간이 넘는 전수 패스가 중간에
통째로 끊겼다. 실제로 이번 재스윕에서 88분 지점(8,780/29,896 opens)에 사망했다.

`ReadAllText` 는 `FileShare.Read` 로 여는데 워커(`oracle_worker.ps1:104`)는 같은 파일에
쓰기 핸들을 잡고 있다. 공유 모드가 양립하지 않아 `IOException` 이 나고, 스크립트 상단의
`$ErrorActionPreference = 'Stop'` 이 그것을 치명으로 승격시킨다.

바로 옆 `Get-DoneCount` 는 result.tsv 에 대해 같은 이유로 이미 `FileShare.ReadWrite` 를
쓰고 있고 주석까지 달려 있다 — heartbeat 경로만 이 규율이 빠져 있었다. `Read-SharedText`
헬퍼로 맞추고, 읽기에 실패하면 예외 대신 이번 tick 만 건너뛴다. 감시 루프는 10초 주기라
다음 tick 에서 다시 읽으므로 stall 감지는 늦어지지 않는다.

이 사망이 특히 나쁜 이유는 **조용하다**는 것이다. 감독이 죽어도 워커는 계속 살아 있어
겉보기 진행은 이어지고, 그 상태에서 감독만 다시 띄우면 워커가 둘이 돼 README 의
"동시 실행 금지 — 워커도 하나" 규약까지 깨진다.

## 관련 이슈

closes #4749

## 테스트

- [x] `cargo test` 통과 — **해당 없음**: Rust 소스 변경이 없는 `tools/` PowerShell 스크립트 단독 변경
- [x] `cargo clippy -- -D warnings` 통과 — **해당 없음** (위와 같음)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우) — 해당 없음
- [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부 — 해당 없음 (문서 편집 작업이 아님)
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시 — 해당 없음

실제로 수행한 검증:

- `[Parser]::ParseFile` 구문 검사 통과
- `git diff --check` 통과
- **동작 실측** — 같은 장비·같은 작업 목록(29,896 opens)에서:

  | | 수정 전 | 수정 후 |
  |---|---|---|
  | 생존 | 88분에 사망 (8,780 opens) | **완주** (29,896 opens) |
  | 겪은 stall-kill | 7회 | **23회** |
  | 감독 재시작 | — | 0 |

  수정 후 감독은 stall-kill 을 23회 겪고도 살아남아 전수 패스를 끝냈다. stall 감지
  기능이 죽지 않았음은 이 23회의 정상 동작이 보여준다.

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 — 10초 주기 감시 루프에서 파일 하나를 여는 방식만 바뀐다.
- 재현·측정: 위 표. 처리량 차이는 stall 빈도(문서 특성)에 좌우되며 이 변경과 무관하다.

## 스크린샷

해당 없음.
