### PR TITLE
fix(tools/sweep): stall-kill 을 실제 한글 크래시와 갈라낸다 (#4751)

### DIFF
--- a/tools/loadsave_sweep/README.md
+++ b/tools/loadsave_sweep/README.md
@@ -87,6 +87,10 @@ Phase A 산출물은 버전 무관이므로 재사용 — Phase B 만 `-HwpVersi
   `restore_com_default.ps1`.
 - 워커는 heartbeat 를 쓰고 supervisor 가 정지(stall)를 감지해 Hwp.exe 를 죽인다.
   강제종료 직후 첫 Open 은 수 분 블록될 수 있어 warmup 으로 흡수한다.
+- **stall 허용치는 문서 크기에 비례한다** — `StallSeconds + StallSecondsPerMB × MB`
+  (기본 300초 + 60초/MB). 평평한 임계는 한글이 그저 느리게 여는 대형 문서를 죽인다.
+  실측: 204쪽·10.9MB 산출물이 300초 임계에서는 두 번 죽어 `OPEN_FAIL` 로 오판됐고,
+  여유를 준 재측정에서는 정상 개방됐다.
 - **유령 성공 주의**: 대화상자 자동거부로 "빈 문서 열기 성공"이 나올 수 있다.
   judge 가 원본 텍스트 0자+1쪽을 `origSuspect` 로 표시한다 — 전수에서 이 비율이 높으면
   보안 모듈 등록 상태부터 의심할 것.
@@ -100,9 +104,16 @@ Phase A 산출물은 버전 무관이므로 재사용 — Phase B 만 `-HwpVersi
 <S>/s1/phase_a.ndjson          Phase A 저널 (exit 0/3/4/FAIL/TIMEOUT + rhwp 자기검증)
 <S>/s1/oracle_tasks.tsv        Phase B 작업 목록 (key \t path)
 <S>/s1/oracle_<ver>/result.tsv key, status, pages, textLen, textSha, ctrls, fileBytes, err
+<S>/s1/oracle_<ver>/stall_kills.tsv  감독이 강제 종료한 key (age, allowance, bytes, utcMs)
 <S>/s1/oracle_<ver>/texts/     한글이 추출한 본문 텍스트 (판정·삼각측량용)
 <S>/s1/oracle_<ver>/verdicts/  verdicts.tsv + summary.md
 ```
 
-판정 어휘: `CONVERT_FAIL` > `OPEN_FAIL` > `MEASURE_FAIL` > `TEXT_MISMATCH` > `CTRL_DIFF` >
-`PAGE_DIFF` > `OK`. 원본이 안 열리는 문서는 `ORACLE_ORIG_FAIL` 로 모수에서 제외.
+판정 어휘: `CONVERT_FAIL` > `OPEN_FAIL` > `MEASURE_FAIL` > `ORACLE_TIMEOUT` > `TEXT_MISMATCH` >
+`CTRL_DIFF` > `PAGE_DIFF` > `OK`. 원본이 안 열리는 문서는 `ORACLE_ORIG_FAIL`
+(stall-kill 이면 `ORACLE_ORIG_TIMEOUT`) 로 모수에서 제외.
+
+`ORACLE_TIMEOUT` 은 결함이 아니라 **측정 실패**다. 감독이 Hwp.exe 를 강제 종료하면 워커의
+`Open` 은 실제 한글 크래시와 같은 `HRESULT 0x800706BE` 로 실패하므로, 감독이 남긴
+`stall_kills.tsv` 없이는 둘을 구별할 수 없다. judge 는 이 목록의 키를 `OPEN_FAIL` 에서
+갈라내고 요약 끝에 재확인 명령과 대상 키를 출력한다 — **재확인 전에는 수치에 넣지 말 것.**

--- a/tools/loadsave_sweep/judge.py
+++ b/tools/loadsave_sweep/judge.py
@@ -5,6 +5,7 @@
     CONVERT_FAIL      rhwp 가 변환 자체를 못 함 (FAIL/TIMEOUT/SPAWN_FAIL)
     OPEN_FAIL         rhwp 산출물을 한글이 못 엶  ← 저장하기 치명 결함
     MEASURE_FAIL      한글이 열었지만 측정 중 오류 (판정 불가)
+    ORACLE_TIMEOUT    감독이 stall-kill 한 탓의 실패 (판정 불가 · 재확인 필요)
     TEXT_MISMATCH     본문 텍스트 불일치            ← 텍스트 누락/변형
     CTRL_DIFF         컨트롤 집계 불일치 (표·그림 등) ← 개체 누락
     PAGE_DIFF         페이지 수 불일치               ← 레이아웃 신호 (참고)
@@ -12,6 +13,11 @@
 
 원본이 한글에서 안 열리는 문서(ORACLE_ORIG_FAIL)는 판정 모수에서 제외해 따로 센다.
 rhwp 자기검증(exit 3/4)은 selfVerify 열에 참고로 싣는다 — 오라클 판정과 독립이다.
+
+stall-kill 로 죽은 측정은 결함이 아니다. 감독이 Hwp.exe 를 강제 종료하면 워커의 Open 은 실제
+한글 크래시와 **같은** HRESULT(0x800706BE)로 실패한다. 그대로 두면 정상 문서가 OPEN_FAIL 로
+오판되므로(#4751), 감독이 남긴 stall_kills.tsv 의 키는 ORACLE_TIMEOUT 으로 갈라내고 요약에
+재확인 명령을 함께 낸다.
 
 원본 유령 성공 의심(원본 텍스트 0자 + 페이지 1)은 origSuspect 열로 표시한다. 보안 모듈
 미등록 등으로 대화상자가 자동 거부되면 "빈 문서를 연 성공"이 나온다(메모리: 빈 PDF 사례).
@@ -76,7 +82,15 @@ def main() -> int:
     ap.add_argument("--oracle", required=True, help="oracle result.tsv")
     ap.add_argument("--texts", required=True)
     ap.add_argument("--out", required=True)
+    ap.add_argument("--stall-kills", help="감독의 stall_kills.tsv (기본: oracle result.tsv 옆)")
     args = ap.parse_args()
+
+    kills_path = Path(args.stall_kills) if args.stall_kills else Path(args.oracle).with_name("stall_kills.tsv")
+    stall_killed: set[str] = set()
+    if kills_path.is_file():
+        for line in kills_path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                stall_killed.add(line.split("\t", 1)[0])
 
     docs = []
     for line in Path(args.master).read_text(encoding="utf-8").splitlines():
@@ -118,6 +132,8 @@ def main() -> int:
     n_orig_fail = 0
     n_orig_missing = 0
     n_orig_suspect = 0
+    n_orig_timeout = 0
+    timeout_keys: list[str] = []
 
     for doc in docs:
         docid, fmt = doc["docid"], doc["format"]
@@ -126,8 +142,17 @@ def main() -> int:
             n_orig_missing += 1
             continue  # Phase B 미도달 (부분 실행) — 모수에서 제외
         if orig["status"] != "OK":
-            n_orig_fail += 1
-            rows.append([docid, fmt, "-", "ORACLE_ORIG_FAIL", "", "", "", "", orig["err"][:200], doc["src"]])
+            # 원본이 stall-kill 로 죽으면 그 문서의 모든 경로가 모수에서 빠진다 — 결함이 아니라
+            # 재확인 대상임이 판정에 드러나야 한다.
+            if f"{docid}.orig" in stall_killed:
+                n_orig_timeout += 1
+                timeout_keys.append(f"{docid}.orig")
+                rows.append([docid, fmt, "-", "ORACLE_ORIG_TIMEOUT", "", "", "", "",
+                             orig["err"][:200], doc["src"]])
+            else:
+                n_orig_fail += 1
+                rows.append([docid, fmt, "-", "ORACLE_ORIG_FAIL", "", "", "", "",
+                             orig["err"][:200], doc["src"]])
             continue
         orig_suspect = orig["textLen"] == 0 and orig["pages"] <= 1
         if orig_suspect:
@@ -153,7 +178,12 @@ def main() -> int:
                     verdicts.append("MEASURE_FAIL")
                     detail = "no oracle row (phase B incomplete?)"
                 elif var["status"] != "OK":
-                    verdicts.append("OPEN_FAIL")
+                    # 감독이 죽인 측정은 결함 판정이 아니다 — 같은 HRESULT 라도 원인이 다르다.
+                    if f"{docid}.{route}" in stall_killed:
+                        verdicts.append("ORACLE_TIMEOUT")
+                        timeout_keys.append(f"{docid}.{route}")
+                    else:
+                        verdicts.append("OPEN_FAIL")
                     detail = var["err"][:200]
                 else:
                     pages_str = f"{orig['pages']}->{var['pages']}"
@@ -190,19 +220,38 @@ def main() -> int:
     # 요약
     lines = ["# load/save 스윕 판정 요약", ""]
     total_judged = sum(sum(c.values()) for c in counts.values())
-    lines.append(f"- 문서: {len(docs)} (원본 오라클 실패 {n_orig_fail}, Phase B 미도달 {n_orig_missing}, "
-                 f"원본 유령성공 의심 {n_orig_suspect})")
+    lines.append(f"- 문서: {len(docs)} (원본 오라클 실패 {n_orig_fail}, 원본 stall 타임아웃 {n_orig_timeout}, "
+                 f"Phase B 미도달 {n_orig_missing}, 원본 유령성공 의심 {n_orig_suspect})")
     lines.append(f"- 판정된 (문서×경로): {total_judged}")
     lines.append("")
-    lines.append("| route | OK | CONVERT_FAIL | OPEN_FAIL | TEXT_MISMATCH | CTRL_DIFF | PAGE_DIFF | MEASURE_FAIL |")
-    lines.append("|---|---|---|---|---|---|---|---|")
+    lines.append("| route | OK | CONVERT_FAIL | OPEN_FAIL | TEXT_MISMATCH | CTRL_DIFF | PAGE_DIFF "
+                 "| MEASURE_FAIL | ORACLE_TIMEOUT |")
+    lines.append("|---|---|---|---|---|---|---|---|---|")
     for route in ("h2h", "h2x", "x2h", "x2x"):
         c = counts[route]
         lines.append(f"| {route} | {c['OK']} | {c['CONVERT_FAIL']} | {c['OPEN_FAIL']} | "
-                     f"{c['TEXT_MISMATCH']} | {c['CTRL_DIFF']} | {c['PAGE_DIFF']} | {c['MEASURE_FAIL']} |")
+                     f"{c['TEXT_MISMATCH']} | {c['CTRL_DIFF']} | {c['PAGE_DIFF']} | {c['MEASURE_FAIL']} | "
+                     f"{c['ORACLE_TIMEOUT']} |")
     lines.append("")
     lines.append("(표의 셀은 첫 번째(최고 심각도) 판정 기준. 겹친 판정 전체는 verdicts.tsv 의 verdict 열.)")
-    bad = [r for r in rows if r[3] not in ("OK", "ORACLE_ORIG_FAIL")]
+    if timeout_keys:
+        # 이 키들은 결함 판정이 아니다. 여유를 준 재확인을 거치기 전에는 수치에 넣지 말 것.
+        lines.append("")
+        lines.append(f"## 재확인 필요 — stall-kill 로 측정 실패 ({len(timeout_keys)})")
+        lines.append("")
+        lines.append("감독이 Hwp.exe 를 강제 종료해 생긴 실패다. 실제 한글 크래시와 HRESULT 가 같아")
+        lines.append("구별되지 않으므로 결함으로 세지 않는다. 여유를 늘려 이 키만 다시 측정할 것:")
+        lines.append("")
+        lines.append("```powershell")
+        lines.append("# oracle_tasks.tsv 에서 아래 키만 추려 recheck_tasks.tsv 를 만든 뒤")
+        lines.append("oracle_run.ps1 -TaskPath recheck_tasks.tsv -OutDir <OutDir>_recheck `")
+        lines.append("  -StallSeconds 1200 -HwpVersion <ver> -HideWindow")
+        lines.append("```")
+        lines.append("")
+        lines.append("대상: " + ", ".join(f"`{k}`" for k in sorted(timeout_keys)[:60])
+                     + (" ..." if len(timeout_keys) > 60 else ""))
+    bad = [r for r in rows
+           if r[3] not in ("OK", "ORACLE_ORIG_FAIL", "ORACLE_ORIG_TIMEOUT", "ORACLE_TIMEOUT")]
     if bad:
         lines.append("")
         lines.append(f"## 결함 상위 예시 ({min(len(bad), 20)}/{len(bad)})")

--- a/tools/loadsave_sweep/oracle_run.ps1
+++ b/tools/loadsave_sweep/oracle_run.ps1
@@ -13,7 +13,12 @@ param(
   [Parameter(Mandatory = $true)][string]$HwpVersion,
   [Parameter(Mandatory = $true)][string]$TaskPath,
   [Parameter(Mandatory = $true)][string]$OutDir,
+  # Stall allowance for a 0-byte document. The real allowance scales with file size (below) --
+  # a flat threshold kills big documents that Hangul is merely slow to open, and the resulting
+  # failure is indistinguishable from a real crash (#4751).
   [int]$StallSeconds = 300,
+  # Extra allowance per MB of the document being measured. 11MB -> 300 + 660 = 960s.
+  [int]$StallSecondsPerMB = 60,
   [int]$RecycleEvery = 200,
   [int]$WarmupDocs = 5,
   # Hangul 2018 deadlocks in Open() when hidden -- only pass this on 2022+.
@@ -81,13 +86,42 @@ if (-not (Test-Path $OutDir)) { New-Item -ItemType Directory -Force -Path $OutDi
 $all = Get-Content -LiteralPath $TaskPath -Encoding UTF8 | Where-Object { $_.Trim().Length -gt 0 }
 Write-Output "[sup] tasks: $($all.Count) opens (single worker -- concurrent Hangul instances corrupt measurements)"
 
+$taskPathByKey = @{}
+foreach ($ln in $all) {
+  $i = $ln.IndexOf("`t")
+  if ($i -gt 0) { $taskPathByKey[$ln.Substring(0, $i)] = $ln.Substring($i + 1) }
+}
+
 $state = @{
   Out = Join-Path $OutDir 'result.tsv'
   HB = Join-Path $OutDir 'hb.txt'
+  Kills = Join-Path $OutDir 'stall_kills.tsv'
   Texts = Join-Path $OutDir 'texts'
   Total = $all.Count
   Proc = $null
   Restarts = 0
+  Sizes = @{}
+}
+
+# 크기에 비례한 stall 허용치. 평평한 임계는 한글이 그저 느리게 여는 대형 문서를 죽이고,
+# 그 실패는 진짜 크래시와 같은 HRESULT 로 남아 구별되지 않는다 (#4751).
+function Get-StallAllowance([string]$key) {
+  if (-not $state.Sizes.ContainsKey($key)) {
+    $bytes = 0
+    $p = $taskPathByKey[$key]
+    if ($p) { try { $bytes = (Get-Item -LiteralPath $p -ErrorAction Stop).Length } catch { $bytes = 0 } }
+    $state.Sizes[$key] = $bytes
+  }
+  $mb = $state.Sizes[$key] / 1MB
+  return $StallSeconds + [int]($StallSecondsPerMB * $mb)
+}
+
+# 죽인 키를 남긴다. judge 가 이 목록으로 stall-kill 실패를 실제 크래시와 갈라낸다 (#4751).
+function Write-StallKill([string]$key, [double]$age, [int]$allow) {
+  $ms = [int64]([datetime]::UtcNow - [datetime]'1970-01-01').TotalMilliseconds
+  $size = if ($state.Sizes.ContainsKey($key)) { $state.Sizes[$key] } else { 0 }
+  $line = "{0}`t{1:N0}`t{2}`t{3}`t{4}" -f $key, $age, $allow, $size, $ms
+  try { [System.IO.File]::AppendAllText($state.Kills, $line + "`n", (New-Object System.Text.UTF8Encoding($false))) } catch { }
 }
 
 # 워커가 같은 파일을 쓰는 중에도 읽는다. 실패는 예외가 아니라 $null -- 감독은 절대 죽지 않는다.
@@ -156,11 +190,14 @@ while ($true) {
       $parts = if ($hbText) { $hbText -split '\|' } else { @() }
       if ($parts.Count -ge 3) {
         $age = ($nowMs - [int64]$parts[1]) / 1000.0
-        if ($age -gt $StallSeconds) {
+        $key = $parts[2]
+        $allow = Get-StallAllowance $key
+        if ($age -gt $allow) {
           $hp = [int]$parts[0]
-          Write-Output ("[sup] worker stalled {0:N0}s on '{1}' -> killing Hwp pid {2}" -f $age, $parts[2], $hp)
+          Write-Output ("[sup] worker stalled {0:N0}s (allow {1}s) on '{2}' -> killing Hwp pid {3}" -f $age, $allow, $key, $hp)
+          Write-StallKill $key $age $allow
           if ($hp -gt 0) { try { Stop-Process -Id $hp -Force -ErrorAction SilentlyContinue } catch { } }
-          if ($age -gt ($StallSeconds * 2)) {
+          if ($age -gt ($allow * 2)) {
             try { Stop-Process -Id $state.Proc.Id -Force -ErrorAction SilentlyContinue } catch { }
           }
         }

--- a/tools/loadsave_sweep/oracle_run.ps1
+++ b/tools/loadsave_sweep/oracle_run.ps1
@@ -90,6 +90,20 @@ $state = @{
   Restarts = 0
 }
 
+# 워커가 같은 파일을 쓰는 중에도 읽는다. 실패는 예외가 아니라 $null -- 감독은 절대 죽지 않는다.
+function Read-SharedText([string]$path) {
+  try {
+    $fs = [System.IO.File]::Open(
+      $path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+    try {
+      $sr = New-Object System.IO.StreamReader($fs, [System.Text.Encoding]::UTF8)
+      try { return $sr.ReadToEnd() } finally { $sr.Dispose() }
+    } finally { $fs.Dispose() }
+  } catch {
+    return $null
+  }
+}
+
 function Start-Worker {
   $wargs = @(
     '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', (Join-Path $here 'oracle_worker.ps1'),
@@ -135,7 +149,11 @@ while ($true) {
   if ($running) {
     $alive = $true
     if (Test-Path -LiteralPath $state.HB) {
-      $parts = ([System.IO.File]::ReadAllText($state.HB, [System.Text.Encoding]::UTF8)) -split '\|'
+      # 워커가 쓰는 중이면 ReadAllText 는 공유 위반으로 던진다. ErrorActionPreference=Stop 아래에서
+      # 그 예외는 감독을 통째로 죽여 장시간 패스를 날린다 -- ReadWrite 공유로 열고, 그래도 실패하면
+      # 이번 tick 만 건너뛴다 (다음 10초 tick 에서 다시 읽으므로 stall 감지가 늦어지지 않는다).
+      $hbText = Read-SharedText $state.HB
+      $parts = if ($hbText) { $hbText -split '\|' } else { @() }
       if ($parts.Count -ge 3) {
         $age = ($nowMs - [int64]$parts[1]) / 1000.0
         if ($age -gt $StallSeconds) {


### PR DESCRIPTION
> **선행 PR 있음** — 이 브랜치는 #4750(`fix/4749-sweep-heartbeat-share`) 위에 쌓았다.
> 같은 감독 루프의 인접한 줄을 건드리기 때문이다. #4750 을 먼저 merge 하면 이 PR 은
> 마지막 커밋 하나(`0b0d718`)만 남는다.

## 변경 요약

감독이 Hwp.exe 를 강제 종료(stall-kill)하면 워커의 `Open` 은 **진짜 한글 크래시와 같은**
`HRESULT 0x800706BE` 로 실패한다. `judge.py` 는 그것을 `OPEN_FAIL` — 이 하네스에서 가장
무거운 "저장하기 치명 결함" — 으로 판정해 왔다. 측정 인프라의 부작용이 없는 회귀를
만들어내는 구조다.

두 층을 고친다.

**1. stall 허용치를 문서 크기에 비례시킨다.** 평평한 300초는 4KB 문서와 11MB 문서에 똑같이
걸려, 한글이 그저 느리게 여는 대형 문서를 죽였다. `StallSeconds + StallSecondsPerMB × MB`
(기본 300초 + 60초/MB)로 바꿔 작은 문서의 대기는 그대로 두고 큰 문서에만 시간을 준다.

**2. 그래도 죽인 키는 `stall_kills.tsv` 에 남긴다.** judge 는 이 목록의 실패를 `OPEN_FAIL`
이 아니라 `ORACLE_TIMEOUT`(원본이면 `ORACLE_ORIG_TIMEOUT`)으로 내고, 요약 끝에 재확인
명령과 대상 키를 출력한다. 임계를 아무리 늘려도 넘기는 문서는 남으므로, **구별 가능하게
남기는 쪽이 근본 방어**다.

원본(`.orig`)이 stall 로 죽으면 그 문서의 **모든 경로가 판정 모수에서 통째로 빠진다** —
결함 수만이 아니라 분모까지 움직이므로 이 경우도 별도 판정으로 드러낸다.

## 관련 이슈

closes #4751

## 테스트

- [x] `cargo test` 통과 — **해당 없음**: Rust 소스 변경이 없는 `tools/` 스크립트 단독 변경
- [x] `cargo clippy -- -D warnings` 통과 — **해당 없음** (위와 같음)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우) — 해당 없음
- [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부 — 해당 없음 (문서 편집 작업이 아님)
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시 — 해당 없음

실제로 수행한 검증 — **10k 전수 실측 데이터로 재판정**했다.

같은 스윕(문서 10,000 · 29,896 opens)의 `result.tsv` 에, 감독 로그에서 재구성한
`stall_kills.tsv`(30행 / 고유 16키)를 주고 새 judge 를 돌린 결과:

| | 수정 전 판정 | 수정 후 판정 |
|---|---|---|
| `01646` `01670` `02131` `07105` `07119`.h2h | OPEN_FAIL 5 | **ORACLE_TIMEOUT 5** |
| `03383` `06395` `06397` `06887` `07044`.orig | ORACLE_ORIG_FAIL 5 | **ORACLE_ORIG_TIMEOUT 5** |
| `03908.h2x` `07615.h2x` | OPEN_FAIL 2 | **OPEN_FAIL 2** (그대로) |

이 분류가 옳다는 것은 **독립 근거 두 가지**로 확인했다.

1. 가짜 5건의 산출물 sha256 이 직전 스윕(s4)과 **완전히 동일**한데, s4 에서는 정상 개방됐다 —
   코드 변화로 설명되지 않는다.
2. 그 키들을 `-StallSeconds 1200` 으로 다시 열자 **18/18 전부 OK**.
   `07119.h2h` 는 204쪽·144,577자·10.9MB 였다.

진짜 크래시 2건은 오분류되지 않고 `OPEN_FAIL` 로 남았다(#4680 의 HWP3→HWPX 잔존군).

호환성: `stall_kills.tsv` 가 없으면 판정은 기존과 **완전히 동일**하다 — 없는 경로를 주고
재실행해 `OPEN_FAIL 7 / ORACLE_ORIG_FAIL 5` 로 수정 전과 일치함을 확인했다.

그 밖에:

- `[Parser]::ParseFile` 구문 검사, `py_compile`, `git diff --check` 통과
- judge 종료 코드 0

## 성능 영향 및 측정 결과

- 예상 영향: **개선**. stall-kill 1회는 강제 종료 + warmup 재개로 5분 이상을 먹는다. 이번
  전수에서 23회가 발생해 처리량이 276 → 111 opens/min 로 떨어졌다. 대형 문서가 불필요하게
  죽지 않으면 그만큼 줄어든다.
- 재현·측정: 위 표. 크기 기반 허용치의 실제 감소폭은 코퍼스의 대형 문서 비율에 좌우되므로
  다음 전수 패스에서 측정한다.

## 스크린샷

해당 없음.
