### PR TITLE
renderer: reflow LineSegs through physical frames

### DIFF
--- a/mydocs/orders/20260814.md
+++ b/mydocs/orders/20260814.md
@@ -90,3 +90,17 @@
   [결과](../report/task_m100_4290_4292_4624_security_report.md)에 보존했다.
 - 최신 trailing docs-only head의 GitHub Full CI·CodeQL·mergeability와 작업지시자 승인 뒤에만
   merge한다. merge 뒤 #4290·#4292·#4624 종료 상태와 remote branch를 공식 post-merge 절차로 확인한다.
+
+## PR #4755 - LayoutFrame 기반 LineSeg 재조판
+
+- [PR #4755](https://github.com/edwardkim/rhwp/pull/4755)의 code candidate `d534f738`에서 그림 회피
+  구간·표 셀·일반 문단을 물리 행 Frame으로 재조판하고 picture band 본문 편집을 원자적으로 게시했다.
+  focused LayoutFrame 9건, 실제 325쪽 picture band geometry 1건, frame reflow 10건, 표 소유 폭 2건을
+  Windows PowerShell의 `target/pr-review`에서 순차 실행해 통과했다.
+- 마지막 contributor commit `399e8065`는 구현계획서만 추가했으므로 코드 검증 범위에서 제외했다.
+  같은 PR identity의 code candidate CI·CodeQL·Render Diff 성공과 trailing review-only fast-pass
+  aggregate를 merge 판단에 사용한다. 상세 근거는 [PR #4755 검토](../pr/archives/pr_4755_review.md)와
+  [구현 검토](../pr/archives/pr_4755_review_impl.md)에 보존한다.
+- [#3211](https://github.com/edwardkim/rhwp/issues/3211)·[#4279](https://github.com/edwardkim/rhwp/issues/4279)는
+  merge 뒤에도 자동 종료하지 않는다. 최신 required aggregate·mergeability를 확인한 뒤 squash merge하고,
+  stale-run workflow API 404는 코드 검증과 분리해 기록한다.

--- a/mydocs/plans/task_m100_3211_layout_frame_correctness.md
+++ b/mydocs/plans/task_m100_3211_layout_frame_correctness.md
@@ -1,0 +1,172 @@
+# 구현계획서 — task_m100_3211 LayoutFrame 기반 LineSeg 재조판
+
+- **이슈**: [#3211](https://github.com/edwardkim/rhwp/issues/3211)
+- **선행 검증 PR**: [#4315](https://github.com/edwardkim/rhwp/pull/4315)
+- **구현 PR**: [#4755](https://github.com/edwardkim/rhwp/pull/4755)
+- **브랜치**: `renderer/lineseg-frame-reflow`
+- **기준**: `upstream/devel` `fbca0aa6c`
+- **작성일**: 2026-08-13
+- **최종 정합**: 2026-08-14
+
+## 1. 목표
+
+단일 가용 폭으로 문단 전체의 `LineSeg`를 먼저 확정하던 경로를 물리 행 단위의
+`LayoutFrame` 재조판으로 바꾼다. 그림 회피 영역이나 표 셀처럼 한 물리 행이 여러 가로 구간으로
+나뉘어도 각 구간의 텍스트 진행과 공통 세로 지표를 한 행의 계약으로 유지한다.
+
+저장 `LineSeg`는 새 행의 가로 geometry를 대신하지 않는다. 완전한 단일-segment 행만 보존할 수 있고,
+FIRST부터 LAST까지 나뉜 행은 하나의 물리 행으로 다시 계산한다.
+
+## 2. `LayoutFrame` 계약
+
+`LayoutFrame`은 RenderTree 산출물이 아니라 레이아웃이 소유하는 가변 flow geometry다.
+
+```rust
+pub(crate) struct LayoutFrame {
+    pub(crate) horizontal: Range<i32>,
+    pub(crate) top: i32,
+    pub(crate) exclusions: Vec<FrameExclusion>,
+    pub(crate) current_intervals: Vec<Range<i32>>,
+    pub(crate) next_geometry_event: Option<i32>,
+    pub(crate) minimum_width: i32,
+    rows: Vec<PhysicalRow>,
+}
+```
+
+### `LayoutFrame::carve()`
+
+```rust
+pub(crate) fn carve(&mut self, band_height: i32) -> &[Range<i32>];
+```
+
+호출자는 내용에서 계산한 후보 행 높이만 전달한다. 현재 가로 범위, 세로 위치, exclusion과 최소 폭은
+Frame이 이미 소유하므로 `Paragraph`나 물리 행 index를 인자로 다시 전달하지 않는다.
+
+`carve()`는 다음 상태만 계산한다.
+
+- 현재 미확정 행의 세로 band
+- 왼쪽에서 오른쪽으로 정렬된 가로 구간
+- 다음으로 이동할 수 있는 정확한 geometry event
+
+고정 조건:
+
+- band와 exclusion은 half-open 구간으로 교차한다.
+- `BothSides`는 양쪽 구간을, `LargestSide`는 선택된 한쪽 구간을 남긴다.
+- 사용할 수 있는 구간이 없으면 임의의 `+1` 없이 다음 geometry event에서 재시도한다.
+- 최소 폭 미만 구간은 두 개 이상일 때만 제거하여 마지막 구간 하나를 보존한다.
+- 더 높은 후보 행으로 다시 호출할 수 있도록 commit 이전 상태만 바꾼다.
+
+`carve()`는 텍스트를 채우거나 `LineSeg`를 생성하지 않고, 행을 commit하거나 Frame을 다음 행으로
+전진시키지 않는다.
+
+## 3. 물리 행 transaction
+
+`PhysicalRow`는 한 번 기록되는 `FrameRowMetrics`와 왼쪽에서 오른쪽으로 정렬된 `RowSegment`를
+소유한다. `LineSeg`의 FIRST/LAST 경계 비트는 완성된 행을 투영할 때 만든다.
+
+```rust
+pub(crate) fn commit_carved_row(
+    &mut self,
+    metrics: FrameRowMetrics,
+    segments: Vec<RowSegment>,
+) -> Option<usize>;
+```
+
+commit은 segment 수와 각 가로 구간이 마지막 `carve()` 결과와 정확히 같은지 확인한다. 수용된 행의
+모든 segment는 같은 `vertical_pos`, `line_height`, `text_height`, `baseline_distance`,
+`line_spacing`을 가지며, Frame의 세로 위치는 행 전체에 대해 정확히 한 번만 전진한다.
+
+문단 채움은 caller-owned Frame에서 다음 상태 전이로 수행한다.
+
+```rust
+let frame_checkpoint = frame.clone();
+let row_frame_checkpoint = frame.clone();
+let cursor_checkpoint = cursor.clone();
+
+loop {
+    frame.restore_checkpoint(row_frame_checkpoint.clone());
+    cursor = cursor_checkpoint.clone();
+
+    let intervals = frame.carve(candidate_height).to_vec();
+    let segments = fill_each_interval(intervals, &mut cursor)?;
+    let metrics = resolve_row_metrics(&segments);
+
+    if metrics.line_height != candidate_height {
+        candidate_height = metrics.line_height;
+        continue;
+    }
+
+    frame.commit_carved_row(metrics, segments)?;
+    break;
+}
+
+if transaction_failed {
+    frame.restore_checkpoint(frame_checkpoint);
+}
+```
+
+위 의사 코드는 `layout_paragraph_in_frame()`의 소유권과 rollback 순서를 고정한다. 작은 내부 계산을
+그 이름의 새 함수로 추출하라는 요구는 아니다.
+
+## 4. 연결 범위
+
+### `src/renderer/layout_frame.rs`
+
+- `LayoutFrame`, `PhysicalRow`, `RowSegment`, `FrameRowMetrics`를 레이아웃 계층에 둔다.
+- `carve()`와 `commit_carved_row()`를 분리한다.
+- 완성된 물리 행만 `project_line_segs()`에서 평탄한 `LineSeg`로 투영한다.
+
+### `src/renderer/composer/line_breaking.rs`
+
+- `FillCursor`가 가로 구간 사이의 token과 UTF-16 진행을 보존한다.
+- `fill_one_interval()`은 Frame이 제공한 한 구간만 채운다.
+- `layout_paragraph_in_frame()`은 행 높이가 달라지면 cursor와 Frame을 복원해 다시 carve한다.
+- 일반 scalar 문단도 지원 범위 안에서는 같은 Frame transaction을 사용한다.
+
+### 표와 그림 band
+
+- 표 셀은 표가 소유한 실제 내용 폭과 padding으로 Frame을 만든다.
+- 그림 회피 영역은 host부터 영향받는 마지막 문단까지 하나의 Frame에서 계산한다.
+- 문서 편집은 영향받는 그림 band 전체를 shadow 상태에서 계산하고, 성공한 완성 결과만 한 번에 게시한다.
+- 열 이동 뒤 geometry가 달라지면 새 열에서 다시 계산하며, 수렴하지 않으면 기존 공개 상태를 유지한다.
+
+RenderTree는 완성된 `LineSeg`만 소비하며 `carve()`나 미확정 행 상태를 소유하지 않는다.
+
+## 5. 검증 계획
+
+핵심 계약은 실제 구현과 같은 모듈의 focused test로 고정한다.
+
+```text
+taller_candidate_recarves_before_the_row_is_committed
+committed_row_projects_one_complete_lineseg_group_and_advances_once
+one_physical_row_projects_each_carved_interval_with_shared_metrics
+frame_reflow_projects_two_intervals_as_one_physical_row
+frame_reflow_retries_a_taller_row_without_consuming_the_cursor
+real_p325_picture_band_matches_the_stored_seven_paragraph_geometry
+picture_frame_body_edit_publishes_complete_band_before_recompose
+picture_frame_transaction_rejects_shadow_failure_without_publication
+```
+
+PR 후보는 다음 저장소 gate를 순차 통과시킨다.
+
+```text
+focused LayoutFrame, line-breaking, table-owner와 picture-band tests
+release-test 전체 회귀
+Native Skia 3종
+cargo fmt --all -- --check
+git diff --check
+cargo clippy --all-targets -- -D warnings
+cargo test --doc
+rhwp-studio TypeScript와 unit tests
+wasm-pack build --target web --out-dir pkg
+```
+
+## 6. 범위 밖
+
+- 저장 `LineSeg` cache의 재사용·무효화 정책
+- `reflow_linesegs_on_demand()`의 persistence 소유권 변경
+- 지원되지 않는 복수 그림 topology의 추정 처리
+- Shape, Tight, Through 전체 geometry 지원
+- 글꼴 shaping과 kerning에 따른 작은 줄 경계 차이
+
+마지막 항목은 구조적 Frame 정확성과 섞지 않고 #4439에서 별도로 추적한다.

--- a/mydocs/pr/archives/pr_4755_review.md
+++ b/mydocs/pr/archives/pr_4755_review.md
@@ -1,0 +1,84 @@
+# PR #4755 검토 기록 - LayoutFrame 기반 LineSeg 재조판
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4755](https://github.com/edwardkim/rhwp/pull/4755) |
+| 제목 | `fix(layout): publish picture-band body edits atomically` |
+| 작성자 | `humdrum00001010` (external contributor) |
+| base | `devel@fbca0aa6c22db9a30e6c417190ae4ddfe924773e` |
+| 검증한 code candidate | `d534f73851e8696e9bf7d2d80682c332e09d851a` |
+| 후속 문서 head | `399e8065ddd36f1a39cac971dcd505d160fb87e0` |
+| 규모 | code candidate 기준 24 files, +5,038/-321 |
+| 검토 방식 | collaborator가 `maintainerCanModify=true`인 외부 PR source에 review-only 기록을 trailing commit으로 추가한다. |
+
+## 라우팅과 source 고정
+
+```text
+base route: collaborator_external_pr.md
+modifiers: intake_and_review.md, local_validation.md, visual_fixture_evidence.md,
+           multi_pr_update_branch.md, review_only_fast_pass.md
+current code candidate: d534f73851e8696e9bf7d2d80682c332e09d851a
+source before reviewer record: 399e8065ddd36f1a39cac971dcd505d160fb87e0
+visibility branch: review/humdrum00001010-20260814
+```
+
+`399e8065`는 `mydocs/plans/task_m100_3211_layout_frame_correctness.md`만 추가한 문서 전용
+commit이다. 따라서 구현 검증은 그 직전 code candidate `d534f738`에 고정했고, 마지막 문서 추가는
+코드 재검증 범위에서 제외했다. `upstream/devel`이 source의 조상임을 확인했고,
+`git diff --check upstream/devel...HEAD`와 current-base `git merge-tree --write-tree`도 통과했다.
+
+## 관련 이슈와 변경 범위
+
+- [#3211](https://github.com/edwardkim/rhwp/issues/3211)의 그림 회피 영역, 표 셀, 일반 문단이 단일 폭
+  LineSeg만으로 재조판되던 제약을 `LayoutFrame`의 물리 행·가로 구간 모델로 바꾼다.
+- [#4279](https://github.com/edwardkim/rhwp/issues/4279)의 그림 band 본문 편집은 shadow 상태에서
+  계산한 뒤 완성 band만 공개하도록 원자적으로 게시한다.
+- [#4315](https://github.com/edwardkim/rhwp/pull/4315)의 선행 검증은 이 구현 PR로 대체한다.
+- 글꼴 shaping·kerning에 따른 작은 줄 경계 차이는 [#4439](https://github.com/edwardkim/rhwp/issues/4439)의
+  별도 범위로 남는다.
+
+`layout_frame.rs`에 물리 행과 구간 carve/commit 계약을 두고, resumable line filling, 표 소유 폭,
+그림 band 편집 게시을 연결했다. RenderTree는 완성된 LineSeg만 소비하며 미확정 Frame 상태를 소유하지
+않는다.
+
+## 완료한 로컬 검증
+
+모든 Cargo 명령은 Windows PowerShell에서 `target/pr-review`를 순차 재사용했고 incremental 관련 환경
+변수는 지정하지 않았다.
+
+| 검증 | 결과 |
+| --- | --- |
+| `cargo test --profile release-test --target-dir target/pr-review --lib layout_frame` | 9/9 통과 |
+| `cargo test --profile release-test --target-dir target/pr-review --lib real_p325_picture_band_matches_the_stored_seven_paragraph_geometry` | 1/1 통과 |
+| `cargo test --profile release-test --target-dir target/pr-review --lib frame_reflow` | 10/10 통과 |
+| `cargo test --profile release-test --target-dir target/pr-review --lib paragraph_frame_owner_width` | 2/2 통과 |
+| `git diff --check upstream/devel...d534f738` | 통과 |
+| 현재 base merge-tree | clean tree `c4ec08a707767465a072225d6aaac627dc5927c2` 생성 |
+
+## 렌더 검증과 GitHub CI
+
+이번 변경은 줄 재조판과 picture band 게시에 직접 영향을 주므로 renderer 검증을 적용했다. 실제
+`samples/3-09월_교육_통합_2022.hwp`의 325쪽 picture band에서 저장된 일곱 문단 geometry를 대조하는
+focused test가 통과했다. 새 golden 또는 PDF를 만들지 않았으므로 HWP 2020 변환은 수행하지 않았다.
+
+동일 PR identity와 source repository에서 실행한 code candidate `d534f738`의
+[CI](https://github.com/edwardkim/rhwp/actions/runs/31778690694),
+[CodeQL](https://github.com/edwardkim/rhwp/actions/runs/31778690524),
+[Render Diff](https://github.com/edwardkim/rhwp/actions/runs/31778690520)는 모두 성공했다.
+`399e8065`의 문서 전용 후속 head에서도 CI·CodeQL·Render Diff의 aggregate와 preflight는 성공했고
+heavy worker의 skipped는 review-only fast-pass의 정상 결과다.
+
+`Cancel stale PR runs`의 `pull_request_target` 실행은 PR 조회 API가 404를 반환해 실패했다. 이는
+이 PR의 코드나 review-only 경로와 무관한 workflow 정리 작업이며, 최신 Build & Test aggregate의
+성공 여부와 별도로 관찰한다. 최신 reviewer 기록 head에서도 required aggregate가 실패하거나 pending이면
+merge하지 않는다.
+
+## 권고
+
+로컬 검토에서 차단 결함은 발견하지 못했다. 이 review와 오늘할일만 추가한 trailing commit의
+review-only fast-pass aggregate가 성공하고, 최신 head가 mergeable이며, 작업지시자 승인을 반영한 뒤
+external contributor PR로 승인·squash merge한다. [#3211](https://github.com/edwardkim/rhwp/issues/3211)과
+[#4279](https://github.com/edwardkim/rhwp/issues/4279)는 PR 본문이 `Refs`로만 연결하므로 merge 뒤에도
+종료 상태를 자동으로 단정하지 않고 후속 범위를 확인한다.

--- a/mydocs/pr/archives/pr_4755_review_impl.md
+++ b/mydocs/pr/archives/pr_4755_review_impl.md
@@ -1,0 +1,32 @@
+# PR #4755 구현 검토 - LayoutFrame 기반 LineSeg 재조판
+
+## 구현 순서와 소유 경계
+
+1. `LayoutFrame::carve()`가 현재 물리 행의 exclusion을 가로 구간으로 만들고, 내용 계산은 구간별로
+   이어서 채운다.
+2. 후보 행 높이가 달라지면 cursor와 Frame checkpoint를 복원한 뒤 다시 carve한다. 확정 전에는
+   `commit_carved_row()`가 호출되지 않으므로 부분 LineSeg가 공개되지 않는다.
+3. 확정된 물리 행은 동일한 수직 metrics를 공유하는 LineSeg 묶음으로만 투영한다. 표 셀은 자기 content
+   폭으로 Frame을 만들고, 그림 band는 영향을 받는 문단 전체를 shadow 상태로 계산한다.
+4. picture frame 본문 편집은 전체 shadow 결과가 성공할 때 한 번에 게시한다. 실패하면 기존 공개 상태를
+   유지한다.
+
+## 검토 이력과 rollback 경계
+
+외부 contributor의 기능 commit 열 개(`eafd8b335`부터 `d534f738`까지)는 수정하지 않았다. 그 뒤의
+`399e8065`는 구현계획서만 추가한 문서 commit이며, 이 검토 기록과 오늘할일도 별도 review-only commit으로
+추가한다. source를 rebase·amend·force-push하지 않는다.
+
+rollback이 필요하면 병합된 PR의 squash commit을 되돌린다. trailing 문서 기록은 런타임 동작을 바꾸지
+않으므로 동작 복구의 별도 rollback 대상이 아니다.
+
+## 검증 및 merge 조건
+
+`layout_frame` 9건, 실제 325쪽 picture band geometry 1건, `frame_reflow` 10건,
+`paragraph_frame_owner_width` 2건의 focused test가 모두 통과했다. code candidate `d534f738`에서 같은
+PR identity의 CI·CodeQL·Render Diff도 성공했다.
+
+최신 reviewer 문서 head는 review-only fast-pass A 경로여야 한다. 최신 aggregate가 success이고
+mergeable 상태와 작업지시자 승인이 유지될 때만 squash merge한다. `Cancel stale PR runs`의 독립적인
+workflow API 404가 재현되면 required Build & Test aggregate와 분리해 기록하되, required check가
+실패·pending이면 merge하지 않는다.

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -415,24 +415,15 @@ impl DocumentCore {
                             table.page_break,
                             crate::model::table::TablePageBreak::RowBreak
                         );
-                        for cell in &mut table.cells {
-                            // [Task #671 후속 / Issue #671 자동보정 영역 정정]
-                            // 셀 폭 (cell.width) 에서 좌우 padding 차감하여 셀 inner 폭 계산.
-                            // col_width 사용 시 셀 너비 영역 밖으로 LINE_SEG 가 채워져
-                            // recompose_for_cell_width 가드 #1 (line_segs.is_empty()) 영역 거짓 →
-                            // PR #673 영역의 layout 단계 정정 미적용 → 자동보정 모드 영역 한 줄 겹침 회귀.
-                            let cell_w_px = crate::renderer::hwpunit_to_px(cell.width as i32, dpi);
-                            // [#2195] 실효 pad 규칙(aim=false = 표 기본, pad 사다리 2종)과
-                            // 정합 — 종전 셀 저장 pad 직접 차감은 measurer/recompose 와 폭이
-                            // 어긋나 셀 reflow 줄수가 이원화된다.
-                            let eff_pad = if cell.apply_inner_margin {
-                                cell.padding
-                            } else {
-                                cell.effective_padding(&table.padding)
-                            };
-                            let pad_left = crate::renderer::hwpunit_to_px(eff_pad.left as i32, dpi);
+                        let owner_widths = table.paragraph_frame_owner_widths();
+                        let table_padding = table.padding;
+                        for (cell, owner_width) in table.cells.iter_mut().zip(owner_widths) {
+                            let cell_w_px = crate::renderer::hwpunit_to_px(owner_width, dpi);
+                            let frame_padding = cell.paragraph_frame_padding(&table_padding);
+                            let pad_left =
+                                crate::renderer::hwpunit_to_px(frame_padding.left as i32, dpi);
                             let pad_right =
-                                crate::renderer::hwpunit_to_px(eff_pad.right as i32, dpi);
+                                crate::renderer::hwpunit_to_px(frame_padding.right as i32, dpi);
                             let cell_inner_width = (cell_w_px - pad_left - pad_right).max(1.0);
                             // [#2195/#2146] 사선(대각선) 셀의 빈 문단은 코너 라벨의
                             // 짝 — 한글은 흐름 배치하지 않으므로 합성 제외 (21761835
@@ -1057,15 +1048,15 @@ impl DocumentCore {
                 // 표 셀 내부 문단도 동일 처리
                 for ctrl in &mut para.controls {
                     if let Control::Table(ref mut table) = ctrl {
-                        for cell in &mut table.cells {
-                            // [Task #671 후속 / Issue #671 자동보정 영역 정정]
-                            // 셀 폭 (cell.width) 에서 좌우 padding 차감하여 셀 inner 폭 계산.
-                            // 동일 본질 정정: line 270 영역 참조.
-                            let cell_w_px = crate::renderer::hwpunit_to_px(cell.width as i32, dpi);
+                        let owner_widths = table.paragraph_frame_owner_widths();
+                        let table_padding = table.padding;
+                        for (cell, owner_width) in table.cells.iter_mut().zip(owner_widths) {
+                            let cell_w_px = crate::renderer::hwpunit_to_px(owner_width, dpi);
+                            let frame_padding = cell.paragraph_frame_padding(&table_padding);
                             let pad_left =
-                                crate::renderer::hwpunit_to_px(cell.padding.left as i32, dpi);
+                                crate::renderer::hwpunit_to_px(frame_padding.left as i32, dpi);
                             let pad_right =
-                                crate::renderer::hwpunit_to_px(cell.padding.right as i32, dpi);
+                                crate::renderer::hwpunit_to_px(frame_padding.right as i32, dpi);
                             let cell_inner_width = (cell_w_px - pad_left - pad_right).max(1.0);
                             for cell_para in &mut cell.paragraphs {
                                 if Self::needs_reflow_broadly(cell_para) {
@@ -2255,6 +2246,135 @@ mod validate_linesegs_tests {
         assert_eq!(cp.row, 0);
         assert_eq!(cp.col, 0);
         assert_eq!(cp.inner_para_idx, 0);
+    }
+
+    fn short_table_frame_document() -> Document {
+        use crate::model::table::{Cell, Table};
+        use crate::model::Padding;
+
+        const RAW_TRACK_WIDTH: u32 = 4_998;
+        let mut cells = Vec::new();
+        for row in 0..2 {
+            for col in 0..2 {
+                let paragraph = if (row, col) == (0, 1) {
+                    Paragraph {
+                        text: "reflow this cell".to_string(),
+                        char_offsets: "reflow this cell"
+                            .chars()
+                            .scan(0u32, |offset, character| {
+                                let current = *offset;
+                                *offset += character.len_utf16() as u32;
+                                Some(current)
+                            })
+                            .collect(),
+                        char_count: "reflow this cell".encode_utf16().count() as u32 + 1,
+                        ..Default::default()
+                    }
+                } else {
+                    Paragraph::default()
+                };
+                cells.push(Cell {
+                    row,
+                    col,
+                    row_span: 1,
+                    col_span: 1,
+                    width: RAW_TRACK_WIDTH,
+                    // The saved cell padding remains a paint fallback only when
+                    // the table's stored padding is all zero.
+                    padding: Padding {
+                        left: 141,
+                        right: 141,
+                        top: 141,
+                        bottom: 141,
+                    },
+                    paragraphs: vec![paragraph],
+                    ..Default::default()
+                });
+            }
+        }
+        let mut table = Table {
+            row_count: 2,
+            col_count: 2,
+            cells,
+            ..Default::default()
+        };
+        // Each raw row is 4 HWPUNIT short. The frame owner is the resolved
+        // table track, so the residual belongs to the last column.
+        table.common.width = 10_000;
+
+        Document {
+            sections: vec![Section {
+                section_def: crate::model::document::SectionDef {
+                    page_def: crate::model::page::PageDef::a4_default(),
+                    ..Default::default()
+                },
+                paragraphs: vec![Paragraph {
+                    controls: vec![Control::Table(Box::new(table))],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn short_table_frame_target_line(document: &Document) -> &LineSeg {
+        let Control::Table(table) = &document.sections[0].paragraphs[0].controls[0] else {
+            panic!("table control");
+        };
+        &table.cells[1].paragraphs[0].line_segs[0]
+    }
+
+    #[test]
+    fn eager_reflow_uses_table_frame_owner_width_and_padding() {
+        const RESOLVED_LAST_TRACK_WIDTH: i32 = 5_002;
+        let mut document = short_table_frame_document();
+        let styles = resolve_styles(&document.doc_info, DEFAULT_DPI);
+
+        DocumentCore::reflow_zero_height_paragraphs(
+            &mut document,
+            &styles,
+            DEFAULT_DPI,
+            true,
+            false,
+        );
+
+        let line = short_table_frame_target_line(&document);
+        assert_eq!(
+            line.segment_width,
+            crate::renderer::px_to_hwpunit(
+                crate::renderer::hwpunit_to_px(RESOLVED_LAST_TRACK_WIDTH, DEFAULT_DPI),
+                DEFAULT_DPI,
+            ),
+            "eager reflow must use the table-owned frame width and the table's zero padding"
+        );
+    }
+
+    #[test]
+    fn on_demand_reflow_uses_table_frame_owner_width_and_padding() {
+        const RESOLVED_LAST_TRACK_WIDTH: i32 = 5_002;
+        let document = short_table_frame_document();
+        let Control::Table(table) = &document.sections[0].paragraphs[0].controls[0] else {
+            panic!("table control");
+        };
+        assert_eq!(
+            table.paragraph_frame_owner_widths()[1],
+            RESOLVED_LAST_TRACK_WIDTH
+        );
+        let mut core = DocumentCore::new_empty();
+        core.set_document(document);
+        core.validation_report = DocumentCore::validate_linesegs(core.document(), false);
+
+        assert_eq!(core.reflow_linesegs_on_demand(), 1);
+        let line = short_table_frame_target_line(core.document());
+        assert_eq!(
+            line.segment_width,
+            crate::renderer::px_to_hwpunit(
+                crate::renderer::hwpunit_to_px(RESOLVED_LAST_TRACK_WIDTH, core.dpi),
+                core.dpi,
+            ),
+            "on-demand reflow must use the table-owned frame width and the table's zero padding"
+        );
     }
 
     /// 다중 경고 — 각각 기록됨

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -9,7 +9,7 @@ use crate::model::control::Control;
 use crate::model::document::Document;
 use crate::model::paragraph::{LineSeg, Paragraph};
 use crate::model::shape::{Caption, DrawingObjAttr, ShapeObject};
-use crate::renderer::composer::{compose_section, reflow_line_segs};
+use crate::renderer::composer::{compose_section, layout_picture_band, reflow_line_segs};
 use crate::renderer::layout::LayoutEngine;
 use crate::renderer::page_layout::PageLayoutInfo;
 use crate::renderer::style_resolver::{resolve_styles, ResolvedStyleSet};
@@ -1033,20 +1033,98 @@ impl DocumentCore {
                 .unwrap_or(layout.body_area.width);
 
             let mut min_reflowed_idx: Option<usize> = None;
-            for (pi, para) in section.paragraphs.iter_mut().enumerate() {
-                if Self::needs_reflow_broadly(para) {
+            let mut latest_non_tac_picture_host = None;
+            let mut pi = 0usize;
+            while pi < section.paragraphs.len() {
+                if section.paragraphs[pi].controls.iter().any(|control| {
+                    matches!(control, Control::Picture(picture) if !picture.common.treat_as_char)
+                }) {
+                    latest_non_tac_picture_host = Some(pi);
+                }
+                if Self::needs_reflow_broadly(&section.paragraphs[pi]) {
+                    // A damaged successor can still belong to a stored
+                    // Picture host. The forward walk records the latest
+                    // possible owner, resolves its own physical column, and
+                    // only claims this row when the completed projection
+                    // contains it.
+                    let mut tracked_picture_band_rejected = false;
+                    let picture_band = if let Some(host_index) = latest_non_tac_picture_host {
+                        let picture_column_def =
+                            Self::find_column_def_for_paragraph(&section.paragraphs, host_index);
+                        let picture_layout =
+                            PageLayoutInfo::from_page_def(page_def, &picture_column_def, dpi);
+                        let picture_col_width = picture_layout
+                            .column_areas
+                            .first()
+                            .map(|area| area.width)
+                            .unwrap_or(picture_layout.body_area.width);
+                        let picture_band = layout_picture_band(
+                            &section.paragraphs,
+                            host_index,
+                            px_to_hwpunit(picture_col_width, dpi),
+                            &styles,
+                            dpi,
+                        );
+                        // A tracked host keeps ownership until a complete
+                        // projection proves that its band already ended.
+                        match picture_band {
+                            Some(band) if band.paragraph_range.contains(&pi) => Some(band),
+                            Some(band) if band.paragraph_range.end <= pi => {
+                                latest_non_tac_picture_host = None;
+                                None
+                            }
+                            _ => {
+                                tracked_picture_band_rejected = true;
+                                None
+                            }
+                        }
+                    } else {
+                        None
+                    };
+                    if let Some(band) = picture_band {
+                        let paragraph_range = band.paragraph_range;
+                        let band_len = paragraph_range.len();
+                        debug_assert_eq!(band.line_segs.len(), band_len);
+                        for (paragraph, line_segs) in section.paragraphs[paragraph_range.clone()]
+                            .iter_mut()
+                            .zip(band.line_segs)
+                        {
+                            paragraph.invalidate_single_line_overflow_memo();
+                            paragraph.line_segs = line_segs;
+                        }
+                        reflowed += band_len;
+                        min_reflowed_idx =
+                            Some(min_reflowed_idx.map_or(paragraph_range.start, |start| {
+                                start.min(paragraph_range.start)
+                            }));
+                        pi = paragraph_range.end;
+                        continue;
+                    }
+                    if tracked_picture_band_rejected {
+                        break;
+                    }
+
+                    // A non-TAC Picture host owns a possible multi-paragraph
+                    // exclusion. If its complete band cannot be represented,
+                    // do not publish a scalar host row and leave the source
+                    // geometry intact for the caller's existing path.
+                    if section.paragraphs[pi].controls.iter().any(|control| {
+                        matches!(control, Control::Picture(picture) if !picture.common.treat_as_char)
+                    }) {
+                        break;
+                    }
+
+                    let para = &mut section.paragraphs[pi];
                     let para_style = styles.para_styles.get(para.para_shape_id as usize);
                     let margin_left = para_style.map(|s| s.margin_left).unwrap_or(0.0);
                     let margin_right = para_style.map(|s| s.margin_right).unwrap_or(0.0);
                     let available_width = (col_width - margin_left - margin_right).max(1.0);
                     reflow_line_segs(para, available_width, &styles, dpi);
                     reflowed += 1;
-                    if min_reflowed_idx.is_none() {
-                        min_reflowed_idx = Some(pi);
-                    }
+                    min_reflowed_idx.get_or_insert(pi);
                 }
                 // 표 셀 내부 문단도 동일 처리
-                for ctrl in &mut para.controls {
+                for ctrl in &mut section.paragraphs[pi].controls {
                     if let Control::Table(ref mut table) = ctrl {
                         let owner_widths = table.paragraph_frame_owner_widths();
                         let table_padding = table.padding;
@@ -1067,6 +1145,7 @@ impl DocumentCore {
                         }
                     }
                 }
+                pi += 1;
             }
 
             // [Task #927] reflow 후 vpos 일관성 재계산 — 본문 paragraphs 만.
@@ -2074,7 +2153,31 @@ impl DocumentCore {
 mod validate_linesegs_tests {
     use super::*;
     use crate::model::document::{Document, Section};
-    use crate::model::paragraph::{LineSeg, Paragraph};
+    use crate::model::paragraph::{ColumnBreakType, LineSeg, Paragraph};
+
+    fn p325_picture_band_core() -> DocumentCore {
+        DocumentCore::from_bytes(include_bytes!("../../../samples/3-09월_교육_통합_2022.hwp"))
+            .expect("p325 Picture-band corpus fixture")
+    }
+
+    fn line_seg_fields(lines: &[LineSeg]) -> Vec<(u32, i32, i32, i32, i32, i32, i32, i32, u32)> {
+        lines
+            .iter()
+            .map(|line| {
+                (
+                    line.text_start,
+                    line.vertical_pos,
+                    line.line_height,
+                    line.text_height,
+                    line.baseline_distance,
+                    line.line_spacing,
+                    line.column_start,
+                    line.segment_width,
+                    line.tag,
+                )
+            })
+            .collect()
+    }
 
     #[test]
     fn from_bytes_retains_hml_import_metadata_outside_document_ir() {
@@ -2441,6 +2544,270 @@ mod validate_linesegs_tests {
     fn needs_reflow_broadly_skips_empty_paragraph() {
         let para = Paragraph::default();
         assert!(!DocumentCore::needs_reflow_broadly(&para));
+    }
+
+    #[test]
+    fn on_demand_picture_band_publishes_the_complete_p325_transaction() {
+        let mut core = p325_picture_band_core();
+        let section = &mut core.document.sections[0];
+        let stored_band = section.paragraphs[325..332]
+            .iter()
+            .map(|paragraph| paragraph.line_segs.clone())
+            .collect::<Vec<_>>();
+        let stored_first_full_width = section.paragraphs[332].line_segs.clone();
+
+        for paragraph in &mut section.paragraphs[325..332] {
+            paragraph.single_line_overflow_memo.set(123, true);
+        }
+        section.paragraphs[332]
+            .single_line_overflow_memo
+            .set(123, true);
+        section.paragraphs[325].line_segs.clear();
+        core.validation_report = DocumentCore::validate_linesegs(&core.document, true);
+        assert!(
+            core.validation_report
+                .warnings
+                .iter()
+                .any(|warning| warning.paragraph_idx == 325),
+            "the missing host row must enter the explicit on-demand path"
+        );
+
+        assert_eq!(core.reflow_linesegs_on_demand(), 7);
+
+        let section = &core.document.sections[0];
+        let mut expected_vpos = stored_band[0][0].vertical_pos;
+        for (paragraph_index, stored) in (325..332).zip(&stored_band) {
+            let generated = &section.paragraphs[paragraph_index].line_segs;
+            assert_eq!(generated.len(), stored.len(), "p{paragraph_index}");
+            for (actual, expected) in generated.iter().zip(stored) {
+                assert_eq!(actual.text_start, expected.text_start, "p{paragraph_index}");
+                assert_eq!(actual.vertical_pos, expected_vpos, "p{paragraph_index}");
+                assert_eq!(
+                    actual.column_start, expected.column_start,
+                    "p{paragraph_index}"
+                );
+                assert_eq!(
+                    actual.segment_width, expected.segment_width,
+                    "p{paragraph_index}"
+                );
+                assert_eq!(
+                    actual.line_height, expected.line_height,
+                    "p{paragraph_index}"
+                );
+                assert_eq!(
+                    actual.text_height, expected.text_height,
+                    "p{paragraph_index}"
+                );
+                assert_eq!(
+                    actual.baseline_distance, expected.baseline_distance,
+                    "p{paragraph_index}"
+                );
+                assert!(
+                    actual.line_spacing.abs_diff(expected.line_spacing) <= 3,
+                    "p{paragraph_index}: generated={} stored={}",
+                    actual.line_spacing,
+                    expected.line_spacing,
+                );
+                assert!(actual.is_first_segment(), "p{paragraph_index}");
+                assert!(actual.is_last_segment(), "p{paragraph_index}");
+                expected_vpos += actual.line_height + actual.line_spacing;
+            }
+        }
+        assert!(
+            section.paragraphs[325..332]
+                .iter()
+                .all(|paragraph| paragraph.single_line_overflow_memo.is_unjudged()),
+            "each published row invalidates its derived overflow memo"
+        );
+        assert_eq!(
+            section.paragraphs[332].line_segs.len(),
+            stored_first_full_width.len(),
+            "p332 remains outside the transaction"
+        );
+        for (actual, expected) in section.paragraphs[332]
+            .line_segs
+            .iter()
+            .zip(&stored_first_full_width)
+        {
+            assert_eq!(actual.text_start, expected.text_start);
+            assert_eq!(actual.line_height, expected.line_height);
+            assert_eq!(actual.text_height, expected.text_height);
+            assert_eq!(actual.baseline_distance, expected.baseline_distance);
+            assert_eq!(actual.line_spacing, expected.line_spacing);
+            assert_eq!(actual.column_start, expected.column_start);
+            assert_eq!(actual.segment_width, expected.segment_width);
+            assert_eq!(actual.tag, expected.tag);
+        }
+        assert!(
+            section.paragraphs[332]
+                .line_segs
+                .iter()
+                .all(|line| line.column_start == 0 && line.segment_width > 3_406),
+            "p332 is the first full-width row after the side-wrap band"
+        );
+        assert!(
+            !section.paragraphs[332]
+                .single_line_overflow_memo
+                .is_unjudged(),
+            "p332 was not published as part of the Picture band"
+        );
+    }
+
+    #[test]
+    fn on_demand_picture_band_discovers_stored_p325_host_from_missing_successor() {
+        let mut core = p325_picture_band_core();
+        let section = &mut core.document.sections[0];
+        let stored_band = section.paragraphs[325..332]
+            .iter()
+            .map(|paragraph| paragraph.line_segs.clone())
+            .collect::<Vec<_>>();
+        let stored_p326_column_start = stored_band[1][0].column_start;
+        let stored_p326_segment_width = stored_band[1][0].segment_width;
+        let first_full_width = section.paragraphs[332].line_segs[0].segment_width;
+
+        for paragraph in &mut section.paragraphs[325..332] {
+            paragraph.single_line_overflow_memo.set(123, true);
+        }
+        section.paragraphs[326].line_segs.clear();
+        core.validation_report = DocumentCore::validate_linesegs(&core.document, true);
+        assert!(
+            core.validation_report
+                .warnings
+                .iter()
+                .any(|warning| warning.paragraph_idx == 326),
+            "the missing successor must enter the explicit on-demand path"
+        );
+
+        assert_eq!(core.reflow_linesegs_on_demand(), 7);
+
+        let section = &core.document.sections[0];
+        let mut expected_vpos = stored_band[0][0].vertical_pos;
+        for (paragraph_index, stored) in (325..332).zip(&stored_band) {
+            let generated = &section.paragraphs[paragraph_index].line_segs;
+            assert_eq!(generated.len(), stored.len(), "p{paragraph_index}");
+            for (actual, expected) in generated.iter().zip(stored) {
+                assert_eq!(actual.text_start, expected.text_start, "p{paragraph_index}");
+                assert_eq!(actual.vertical_pos, expected_vpos, "p{paragraph_index}");
+                assert_eq!(
+                    actual.column_start, expected.column_start,
+                    "p{paragraph_index}"
+                );
+                assert_eq!(
+                    actual.segment_width, expected.segment_width,
+                    "p{paragraph_index}"
+                );
+                assert_eq!(
+                    actual.line_height, expected.line_height,
+                    "p{paragraph_index}"
+                );
+                assert_eq!(
+                    actual.text_height, expected.text_height,
+                    "p{paragraph_index}"
+                );
+                assert_eq!(
+                    actual.baseline_distance, expected.baseline_distance,
+                    "p{paragraph_index}"
+                );
+                assert!(
+                    actual.line_spacing.abs_diff(expected.line_spacing) <= 3,
+                    "p{paragraph_index}: generated={} stored={}",
+                    actual.line_spacing,
+                    expected.line_spacing,
+                );
+                assert!(actual.is_first_segment(), "p{paragraph_index}");
+                assert!(actual.is_last_segment(), "p{paragraph_index}");
+                expected_vpos += actual.line_height + actual.line_spacing;
+            }
+        }
+        assert!(
+            section.paragraphs[325..332]
+                .iter()
+                .all(|paragraph| paragraph.single_line_overflow_memo.is_unjudged()),
+            "the stored host and every successor are atomically republished"
+        );
+        let p326 = &section.paragraphs[326].line_segs[0];
+        assert_eq!(p326.column_start, stored_p326_column_start);
+        assert_eq!(p326.segment_width, stored_p326_segment_width);
+        assert!(
+            p326.segment_width < first_full_width,
+            "p326 keeps the Picture band's narrow side-wrap width rather than scalar full width"
+        );
+    }
+
+    #[test]
+    fn on_demand_rejected_tracked_picture_band_leaves_successor_source_geometry_untouched() {
+        let mut core = p325_picture_band_core();
+        let section = &mut core.document.sections[0];
+        section.paragraphs[326].line_segs.clear();
+        section.paragraphs[329].column_type = ColumnBreakType::Page;
+        for paragraph in &mut section.paragraphs[325..333] {
+            paragraph.single_line_overflow_memo.set(123, true);
+        }
+        let source_rows = section.paragraphs[325..333]
+            .iter()
+            .map(|paragraph| line_seg_fields(&paragraph.line_segs))
+            .collect::<Vec<_>>();
+        core.validation_report = DocumentCore::validate_linesegs(&core.document, true);
+        assert!(
+            core.validation_report
+                .warnings
+                .iter()
+                .any(|warning| warning.paragraph_idx == 326),
+            "the missing successor must enter the explicit on-demand path"
+        );
+
+        assert_eq!(core.reflow_linesegs_on_demand(), 0);
+
+        let section = &core.document.sections[0];
+        for (paragraph_index, source) in (325..333).zip(&source_rows) {
+            assert_eq!(
+                line_seg_fields(&section.paragraphs[paragraph_index].line_segs),
+                *source,
+                "p{paragraph_index} stays source-owned after the tracked host rejects its transaction"
+            );
+        }
+        assert!(
+            section.paragraphs[326].line_segs.is_empty(),
+            "the rejected tracked host must not scalar-reflow the missing successor"
+        );
+        assert!(
+            section.paragraphs[325..333]
+                .iter()
+                .all(|paragraph| !paragraph.single_line_overflow_memo.is_unjudged()),
+            "the failed transaction must not publish or invalidate any source row"
+        );
+    }
+
+    #[test]
+    fn on_demand_rejected_picture_band_leaves_host_and_later_body_rows_untouched() {
+        let mut core = p325_picture_band_core();
+        let section = &mut core.document.sections[0];
+        let middle_before = line_seg_fields(&section.paragraphs[330].line_segs);
+        section.paragraphs[325].line_segs.clear();
+        section.paragraphs[329].column_type = ColumnBreakType::Page;
+        section.paragraphs[332].line_segs.clear();
+        let host_before = line_seg_fields(&section.paragraphs[325].line_segs);
+        let later_before = line_seg_fields(&section.paragraphs[332].line_segs);
+        core.validation_report = DocumentCore::validate_linesegs(&core.document, true);
+
+        assert_eq!(core.reflow_linesegs_on_demand(), 0);
+
+        let section = &core.document.sections[0];
+        assert_eq!(
+            line_seg_fields(&section.paragraphs[325].line_segs),
+            host_before,
+            "the rejected non-TAC Picture host cannot fall back to scalar geometry"
+        );
+        assert_eq!(
+            line_seg_fields(&section.paragraphs[330].line_segs),
+            middle_before,
+            "the incomplete transaction publishes no prefix rows"
+        );
+        assert_eq!(
+            line_seg_fields(&section.paragraphs[332].line_segs),
+            later_before,
+            "the conservative section stop leaves later body reflow for its existing owner"
+        );
     }
 
     // ---------- R3: LinesegTextRunReflow ----------

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -787,8 +787,8 @@ impl DocumentCore {
     ///
     /// `Table::split_cell*` 는 셀 폭·배치만 바꾸고 저장 line_segs 는 그대로 두므로,
     /// 렌더러(LayoutEngine::layout_paragraph)가 옛 폭 기준 줄을 그대로 그려 새(더
-    /// 좁은) 셀 클립 경계에서 glyph 가 잘린다. 대상 판별: 저장 seg 폭이 셀 폭을
-    /// 넘으면 stale 로 확정한다 — seg 폭은 항상 패딩만큼 셀 폭보다 작게 계산되므로
+    /// 좁은) 셀 클립 경계에서 glyph 가 잘린다. 대상 판별: 저장 seg 폭이 해석된 문단 frame 폭을
+    /// 넘으면 stale 로 확정한다 — seg 폭은 패딩을 빼며 frame 폭을 넘지 않으므로
     /// 초과는 옛 폭의 증거다 (`resize_table_cells_native` 의 reflow 계약을 분할에도
     /// 적용; 분할이 만든 새 셀은 원본 line_segs 를 클론하므로 같은 판별에 걸린다).
     ///
@@ -802,34 +802,37 @@ impl DocumentCore {
         parent_para_idx: usize,
         control_idx: usize,
     ) {
-        let stale_cells: Vec<(usize, usize)> = {
+        let (stale_cells, metrics) = {
             let para = &self.document.sections[section_idx].paragraphs[parent_para_idx];
             let Some(Control::Table(table)) = para.controls.get(control_idx) else {
                 return;
             };
-            table
+            let metrics = Self::table_cell_reflow_metrics(table);
+            let stale_cells: Vec<(usize, usize)> = table
                 .cells
                 .iter()
                 .enumerate()
-                .filter(|(_, cell)| {
+                .filter(|(cell_idx, cell)| {
+                    let Some(&(owner_width, _, _)) = metrics.get(*cell_idx) else {
+                        return false;
+                    };
                     cell.paragraphs
                         .iter()
                         .flat_map(|p| p.line_segs.iter())
-                        .any(|ls| (ls.segment_width as i64) > (cell.width as i64))
+                        .any(|ls| i64::from(ls.segment_width) > i64::from(owner_width))
                 })
                 .map(|(ci, cell)| (ci, cell.paragraphs.len()))
-                .collect()
+                .collect();
+            (stale_cells, metrics)
         };
-        for (cell_idx, para_count) in stale_cells {
-            for cell_para_idx in 0..para_count {
-                self.reflow_cell_paragraph_after_split(
-                    section_idx,
-                    parent_para_idx,
-                    control_idx,
-                    cell_idx,
-                    cell_para_idx,
-                );
-            }
+        self.reflow_table_cell_paragraphs_after_split(
+            section_idx,
+            parent_para_idx,
+            control_idx,
+            &stale_cells,
+            &metrics,
+        );
+        for &(cell_idx, _) in &stale_cells {
             self.rebuild_table_cell_vpos_ladder_native(
                 section_idx,
                 parent_para_idx,
@@ -944,17 +947,12 @@ impl DocumentCore {
         };
 
         self.document.sections[section_idx].raw_stream = None;
-        for (cell_idx, para_count) in changed_cells {
-            for cell_para_idx in 0..para_count {
-                self.reflow_cell_paragraph(
-                    section_idx,
-                    parent_para_idx,
-                    control_idx,
-                    cell_idx,
-                    cell_para_idx,
-                );
-            }
-        }
+        self.reflow_table_cell_paragraphs(
+            section_idx,
+            parent_para_idx,
+            control_idx,
+            &changed_cells,
+        );
         self.mark_section_dirty(section_idx);
         self.paginate_if_needed();
 
@@ -988,17 +986,12 @@ impl DocumentCore {
         };
 
         self.document.sections[section_idx].raw_stream = None;
-        for (cell_idx, para_count) in changed_cells {
-            for cell_para_idx in 0..para_count {
-                self.reflow_cell_paragraph(
-                    section_idx,
-                    parent_para_idx,
-                    control_idx,
-                    cell_idx,
-                    cell_para_idx,
-                );
-            }
-        }
+        self.reflow_table_cell_paragraphs(
+            section_idx,
+            parent_para_idx,
+            control_idx,
+            &changed_cells,
+        );
         self.mark_section_dirty(section_idx);
         self.paginate_if_needed();
 
@@ -2197,17 +2190,7 @@ impl DocumentCore {
                 Vec::new()
             }
         };
-        for (cell_idx, para_count) in reflow_cells {
-            for cell_para_idx in 0..para_count {
-                self.reflow_cell_paragraph(
-                    section_idx,
-                    parent_para_idx,
-                    control_idx,
-                    cell_idx,
-                    cell_para_idx,
-                );
-            }
-        }
+        self.reflow_table_cell_paragraphs(section_idx, parent_para_idx, control_idx, &reflow_cells);
 
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);
@@ -2249,17 +2232,7 @@ impl DocumentCore {
                 Vec::new()
             }
         };
-        for (cell_idx, para_count) in reflow {
-            for cell_para_idx in 0..para_count {
-                self.reflow_cell_paragraph(
-                    section_idx,
-                    parent_para_idx,
-                    control_idx,
-                    cell_idx,
-                    cell_para_idx,
-                );
-            }
-        }
+        self.reflow_table_cell_paragraphs(section_idx, parent_para_idx, control_idx, &reflow);
 
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);
@@ -3793,6 +3766,136 @@ mod tests {
         assert_eq!(common.width, 9000, "width at [12..16]");
         assert_eq!(common.height, 3000, "height at [16..20]");
         assert_eq!(common.horizontal_offset, 0, "h_offset at [8..12] untouched");
+    }
+}
+
+#[cfg(test)]
+mod table_frame_reflow_batch_tests {
+    use crate::document_core::DocumentCore;
+    use crate::model::control::Control;
+    use crate::model::document::{Document, Section};
+    use crate::model::paragraph::Paragraph;
+    use crate::model::table::{Cell, Table};
+
+    const ROWS: u16 = 2;
+    const COLUMNS: u16 = 2;
+    const PARAGRAPHS_PER_CELL: usize = 2;
+
+    fn core_with_two_by_two_table() -> DocumentCore {
+        let mut table = Table {
+            row_count: ROWS,
+            col_count: COLUMNS,
+            row_sizes: vec![COLUMNS as i16; ROWS as usize],
+            ..Default::default()
+        };
+        table.cells = (0..ROWS)
+            .flat_map(|row| {
+                (0..COLUMNS).map(move |col| Cell {
+                    row,
+                    col,
+                    row_span: 1,
+                    col_span: 1,
+                    width: 5_000,
+                    height: 1_000,
+                    paragraphs: vec![Paragraph::new_empty(); PARAGRAPHS_PER_CELL],
+                    ..Default::default()
+                })
+            })
+            .collect();
+        table.update_ctrl_dimensions();
+        table.rebuild_grid();
+
+        let mut host = Paragraph::new_empty();
+        host.controls.push(Control::Table(Box::new(table)));
+
+        let mut section = Section::default();
+        section.paragraphs.push(host);
+
+        let mut document = Document::default();
+        document.sections.push(section);
+
+        let mut core = DocumentCore::new_empty();
+        core.set_document(document);
+        core
+    }
+
+    fn core_with_residual_owner_width_table() -> DocumentCore {
+        let mut core = core_with_two_by_two_table();
+        let Control::Table(table) = &mut core.document.sections[0].paragraphs[0].controls[0] else {
+            unreachable!("fixture host must contain a table");
+        };
+        for cell in &mut table.cells {
+            cell.width = 4_998;
+            cell.paragraphs.truncate(1);
+            cell.paragraphs[0].line_segs[0].segment_width = 5_002;
+        }
+        table.update_ctrl_dimensions();
+        table.common.width = 10_000;
+        table.rebuild_grid();
+        core
+    }
+
+    #[test]
+    fn transpose_reflows_all_changed_cells_from_one_owner_width_plan() {
+        let mut core = core_with_two_by_two_table();
+        core.begin_batch_native().expect("begin batch");
+        Table::reset_paragraph_frame_owner_widths_calls_for_test();
+
+        core.transpose_table_cells_in_place_native(0, 0, 0)
+            .expect("transpose 2x2 table");
+
+        assert_eq!(
+            Table::paragraph_frame_owner_widths_calls_for_test(),
+            1,
+            "one owner-width plan must serve all {} changed-cell paragraphs",
+            usize::from(ROWS) * usize::from(COLUMNS) * PARAGRAPHS_PER_CELL,
+        );
+    }
+
+    #[test]
+    fn column_width_change_reflows_all_cells_from_one_owner_width_plan() {
+        let mut core = core_with_two_by_two_table();
+        core.begin_batch_native().expect("begin batch");
+        Table::reset_paragraph_frame_owner_widths_calls_for_test();
+
+        core.set_table_column_widths_native(0, 0, 0, vec![4_000, 6_000])
+            .expect("set 2x2 column widths");
+
+        assert_eq!(
+            Table::paragraph_frame_owner_widths_calls_for_test(),
+            1,
+            "one owner-width plan must serve all {} changed-cell paragraphs",
+            usize::from(ROWS) * usize::from(COLUMNS) * PARAGRAPHS_PER_CELL,
+        );
+    }
+
+    #[test]
+    fn split_keeps_valid_residual_owner_width_line_segs_after_vertical_merge() {
+        let mut core = core_with_residual_owner_width_table();
+        core.merge_table_cells_native(0, 0, 0, 0, 0, 1, 0)
+            .expect("vertically merge the left cells");
+        core.split_table_cell_native(0, 0, 0, 0, 0)
+            .expect("split the left cell back into two rows");
+
+        let Control::Table(table) = &core.document.sections[0].paragraphs[0].controls[0] else {
+            unreachable!("fixture host must still contain a table");
+        };
+        assert_eq!(
+            table.paragraph_frame_owner_widths(),
+            vec![4_998, 5_002, 4_998, 5_002],
+            "the residual belongs to the last column's paragraph frame"
+        );
+        let right_line_widths: Vec<_> = table
+            .cells
+            .iter()
+            .filter(|cell| cell.col == 1)
+            .map(|cell| cell.paragraphs[0].line_segs[0].segment_width)
+            .collect();
+        assert_eq!(
+            right_line_widths,
+            vec![5_002, 5_002],
+            "the untouched right cells already match their resolved owner width"
+        );
     }
 }
 

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -19,6 +19,8 @@ use crate::renderer::page_layout::PageLayoutInfo;
 use crate::renderer::pagination::PageItem;
 use crate::renderer::style_resolver::{resolve_styles, ResolvedStyleSet};
 
+pub(crate) type CellReflowMetrics = (i32, i16, i16);
+
 fn recalculate_cell_paragraph_vpos(
     paragraphs: &mut [Paragraph],
     start_para: usize,
@@ -2298,6 +2300,106 @@ impl DocumentCore {
         );
     }
 
+    /// Reflow every paragraph selected from one table after a width-changing operation.
+    ///
+    /// The table-wide frame calculation is intentionally outside the paragraph loop:
+    /// it derives each cell's resolved frame width from the same post-mutation table.
+    pub(crate) fn reflow_table_cell_paragraphs(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+        cells: &[(usize, usize)],
+    ) {
+        self.reflow_table_cell_paragraphs_impl(
+            section_idx,
+            parent_para_idx,
+            control_idx,
+            cells,
+            false,
+        );
+    }
+
+    /// Reflow stale cell paragraphs after a table split with the split-specific rule.
+    pub(crate) fn reflow_table_cell_paragraphs_after_split(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+        cells: &[(usize, usize)],
+        metrics: &[CellReflowMetrics],
+    ) {
+        self.reflow_table_cell_paragraphs_with_metrics(
+            section_idx,
+            parent_para_idx,
+            control_idx,
+            cells,
+            metrics,
+            true,
+        );
+    }
+
+    fn reflow_table_cell_paragraphs_impl(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+        cells: &[(usize, usize)],
+        split_stale_cell_reflow: bool,
+    ) {
+        if cells.is_empty() {
+            return;
+        }
+
+        let metrics = {
+            let Some(Control::Table(table)) = self.document.sections[section_idx].paragraphs
+                [parent_para_idx]
+                .controls
+                .get(control_idx)
+            else {
+                return;
+            };
+            Self::table_cell_reflow_metrics(table)
+        };
+
+        self.reflow_table_cell_paragraphs_with_metrics(
+            section_idx,
+            parent_para_idx,
+            control_idx,
+            cells,
+            &metrics,
+            split_stale_cell_reflow,
+        );
+    }
+
+    fn reflow_table_cell_paragraphs_with_metrics(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+        cells: &[(usize, usize)],
+        metrics: &[CellReflowMetrics],
+        split_stale_cell_reflow: bool,
+    ) {
+        for &(cell_idx, para_count) in cells {
+            let Some(cell_metrics) = metrics.get(cell_idx).copied() else {
+                continue;
+            };
+            for cell_para_idx in 0..para_count {
+                self.reflow_cell_paragraph_with_metrics(
+                    section_idx,
+                    parent_para_idx,
+                    control_idx,
+                    cell_idx,
+                    cell_para_idx,
+                    cell_metrics,
+                    None,
+                    split_stale_cell_reflow,
+                );
+            }
+        }
+    }
+
     fn reflow_cell_paragraph_with_edit(
         &mut self,
         section_idx: usize,
@@ -2308,11 +2410,8 @@ impl DocumentCore {
         edit_char_offset: Option<usize>,
         split_stale_cell_reflow: bool,
     ) {
-        use crate::renderer::hwpunit_to_px;
-
         // 셀/글상자 폭과 패딩 읽기 (불변 참조) — path 변형과 공유하는 helper 사용.
-        let (cell_width, pad_left, pad_right) = match self.document.sections[section_idx].paragraphs
-            [parent_para_idx]
+        let metrics = match self.document.sections[section_idx].paragraphs[parent_para_idx]
             .controls
             .get(control_idx)
             .and_then(|control| Self::cell_metrics_for_control(control, cell_idx))
@@ -2321,8 +2420,33 @@ impl DocumentCore {
             None => return,
         };
 
+        self.reflow_cell_paragraph_with_metrics(
+            section_idx,
+            parent_para_idx,
+            control_idx,
+            cell_idx,
+            cell_para_idx,
+            metrics,
+            edit_char_offset,
+            split_stale_cell_reflow,
+        );
+    }
+
+    fn reflow_cell_paragraph_with_metrics(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+        cell_idx: usize,
+        cell_para_idx: usize,
+        (cell_width, pad_left, pad_right): CellReflowMetrics,
+        edit_char_offset: Option<usize>,
+        split_stale_cell_reflow: bool,
+    ) {
+        use crate::renderer::hwpunit_to_px;
+
         let styles = resolve_styles(&self.document.doc_info, self.dpi);
-        let cell_width_px = hwpunit_to_px(cell_width as i32, self.dpi);
+        let cell_width_px = hwpunit_to_px(cell_width, self.dpi);
         let pad_left_px = hwpunit_to_px(pad_left as i32, self.dpi);
         let pad_right_px = hwpunit_to_px(pad_right as i32, self.dpi);
         let available_width = (cell_width_px - pad_left_px - pad_right_px).max(0.0);
@@ -2549,7 +2673,21 @@ impl DocumentCore {
     ///
     /// `reflow_cell_paragraph`(flat)와 `reflow_cell_paragraph_by_path`(중첩)가 공유한다.
     /// `None` = 표/글상자/그림 캡션이 아니거나 대상 셀/텍스트박스가 없음.
-    fn cell_metrics_for_control(control: &Control, cell_idx: usize) -> Option<(u32, i16, i16)> {
+    pub(crate) fn table_cell_reflow_metrics(
+        table: &crate::model::table::Table,
+    ) -> Vec<CellReflowMetrics> {
+        table
+            .cells
+            .iter()
+            .zip(table.paragraph_frame_owner_widths())
+            .map(|(cell, width)| {
+                let padding = cell.paragraph_frame_padding(&table.padding);
+                (width, padding.left, padding.right)
+            })
+            .collect()
+    }
+
+    fn cell_metrics_for_control(control: &Control, cell_idx: usize) -> Option<CellReflowMetrics> {
         match control {
             Control::Table(table) => {
                 if cell_idx == 65534 {
@@ -2560,28 +2698,21 @@ impl DocumentCore {
                         CaptionDirection::Left | CaptionDirection::Right => cap.width,
                         _ => cap.max_width,
                     };
-                    Some((w, 0, 0))
+                    Some((w as i32, 0, 0))
                 } else {
                     let cell = table.cells.get(cell_idx)?;
-                    let pad_l = if cell.apply_inner_margin {
-                        cell.padding.left
-                    } else {
-                        table.padding.left
-                    };
-                    let pad_r = if cell.apply_inner_margin {
-                        cell.padding.right
-                    } else {
-                        table.padding.right
-                    };
-                    Some((cell.width, pad_l, pad_r))
+                    let owner_widths = table.paragraph_frame_owner_widths();
+                    let width = *owner_widths.get(cell_idx)?;
+                    let padding = cell.paragraph_frame_padding(&table.padding);
+                    Some((width, padding.left, padding.right))
                 }
             }
             Control::Shape(shape) => {
                 let tb = super::super::helpers::get_textbox_from_shape(shape)?;
                 let common = shape.common();
-                Some((common.width as u32, tb.margin_left, tb.margin_right))
+                Some((common.width as i32, tb.margin_left, tb.margin_right))
             }
-            Control::Picture(pic) => Some((pic.common.width as u32, 0, 0)),
+            Control::Picture(pic) => Some((pic.common.width as i32, 0, 0)),
             _ => None,
         }
     }
@@ -2594,7 +2725,7 @@ impl DocumentCore {
         section_idx: usize,
         parent_para_idx: usize,
         path: &[(usize, usize, usize)],
-    ) -> Option<(u32, i16, i16)> {
+    ) -> Option<CellReflowMetrics> {
         let mut para = self
             .document
             .sections
@@ -2639,7 +2770,7 @@ impl DocumentCore {
         };
         let styles = resolve_styles(&self.document.doc_info, self.dpi);
         let dpi = self.dpi;
-        let cell_width_px = hwpunit_to_px(cell_width as i32, dpi);
+        let cell_width_px = hwpunit_to_px(cell_width, dpi);
         let pad_left_px = hwpunit_to_px(pad_left as i32, dpi);
         let pad_right_px = hwpunit_to_px(pad_right as i32, dpi);
         let available_width = (cell_width_px - pad_left_px - pad_right_px).max(0.0);
@@ -5979,6 +6110,190 @@ mod tests {
             panic!("표 컨트롤이어야 함");
         };
         &t.cells[0].paragraphs[0]
+    }
+
+    const RAW_TABLE_FRAME_WIDTH: u32 = 4_998;
+    const RESOLVED_TABLE_FRAME_WIDTH: i32 = 5_002;
+
+    fn paragraph_for_table_frame_mutation() -> Paragraph {
+        let text = "reflow this cell".to_string();
+        let char_offsets = text
+            .chars()
+            .scan(0u32, |offset, character| {
+                let current = *offset;
+                *offset += character.len_utf16() as u32;
+                Some(current)
+            })
+            .collect();
+        Paragraph {
+            char_count: text.encode_utf16().count() as u32 + 1,
+            char_offsets,
+            char_shapes: vec![CharShapeRef {
+                start_pos: 0,
+                char_shape_id: 0,
+            }],
+            has_para_text: true,
+            text,
+            ..Default::default()
+        }
+    }
+
+    fn table_with_short_row_frame_target() -> crate::model::table::Table {
+        use crate::model::table::{Cell, Table};
+        use crate::model::Padding;
+
+        let mut cells = Vec::new();
+        for row in 0..2 {
+            for col in 0..2 {
+                cells.push(Cell {
+                    row,
+                    col,
+                    row_span: 1,
+                    col_span: 1,
+                    width: RAW_TABLE_FRAME_WIDTH,
+                    padding: Padding {
+                        left: 141,
+                        right: 141,
+                        top: 141,
+                        bottom: 141,
+                    },
+                    paragraphs: vec![if (row, col) == (0, 1) {
+                        paragraph_for_table_frame_mutation()
+                    } else {
+                        Paragraph::default()
+                    }],
+                    ..Default::default()
+                });
+            }
+        }
+        let mut table = Table {
+            row_count: 2,
+            col_count: 2,
+            padding: Padding::default(),
+            cells,
+            ..Default::default()
+        };
+        table.common.width = 10_000;
+        table
+    }
+
+    fn core_with_table_frame_mutation_target() -> DocumentCore {
+        use crate::model::document::Section;
+
+        let document = Document {
+            sections: vec![Section {
+                paragraphs: vec![Paragraph {
+                    controls: vec![Control::Table(
+                        Box::new(table_with_short_row_frame_target()),
+                    )],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let mut core = DocumentCore::new_empty();
+        core.set_document(document);
+        core
+    }
+
+    fn core_with_nested_table_frame_mutation_target() -> (DocumentCore, Vec<(usize, usize, usize)>)
+    {
+        use crate::model::document::Section;
+        use crate::model::table::{Cell, Table};
+
+        let inner = table_with_short_row_frame_target();
+        let outer_table = Table {
+            row_count: 1,
+            col_count: 1,
+            cells: vec![Cell {
+                row: 0,
+                col: 0,
+                row_span: 1,
+                col_span: 1,
+                width: 10_000,
+                paragraphs: vec![Paragraph {
+                    controls: vec![Control::Table(Box::new(inner))],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let document = Document {
+            sections: vec![Section {
+                paragraphs: vec![Paragraph {
+                    controls: vec![Control::Table(Box::new(outer_table))],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let mut core = DocumentCore::new_empty();
+        core.set_document(document);
+        (core, vec![(0, 0, 0), (0, 1, 0)])
+    }
+
+    fn resolved_table_frame_segment_width(dpi: f64) -> i32 {
+        crate::renderer::px_to_hwpunit(
+            crate::renderer::hwpunit_to_px(RESOLVED_TABLE_FRAME_WIDTH, dpi),
+            dpi,
+        )
+    }
+
+    #[test]
+    fn flat_cell_text_mutation_uses_table_owned_frame_width() {
+        let mut core = core_with_table_frame_mutation_target();
+        let Control::Table(table) = &core.document.sections[0].paragraphs[0].controls[0] else {
+            panic!("expected table");
+        };
+        assert_eq!(
+            table.paragraph_frame_owner_widths()[1],
+            RESOLVED_TABLE_FRAME_WIDTH
+        );
+
+        core.delete_text_in_cell_native(0, 0, 0, 1, 0, 0, 1)
+            .expect("flat cell delete should reflow its paragraph");
+
+        let Control::Table(table) = &core.document.sections[0].paragraphs[0].controls[0] else {
+            panic!("expected table");
+        };
+        assert_eq!(
+            table.cells[1].paragraphs[0].line_segs[0].segment_width,
+            resolved_table_frame_segment_width(core.dpi),
+            "flat cell mutation must reflow through the table-owned frame"
+        );
+    }
+
+    #[test]
+    fn nested_cell_text_mutation_uses_table_owned_frame_width() {
+        let (mut core, path) = core_with_nested_table_frame_mutation_target();
+        let Control::Table(outer) = &core.document.sections[0].paragraphs[0].controls[0] else {
+            panic!("expected outer table");
+        };
+        let Control::Table(inner) = &outer.cells[0].paragraphs[0].controls[0] else {
+            panic!("expected inner table");
+        };
+        assert_eq!(
+            inner.paragraph_frame_owner_widths()[1],
+            RESOLVED_TABLE_FRAME_WIDTH
+        );
+
+        core.delete_text_in_cell_by_path(0, 0, &path, 0, 1)
+            .expect("nested cell delete should reflow its paragraph");
+
+        let Control::Table(outer) = &core.document.sections[0].paragraphs[0].controls[0] else {
+            panic!("expected outer table");
+        };
+        let Control::Table(inner) = &outer.cells[0].paragraphs[0].controls[0] else {
+            panic!("expected inner table");
+        };
+        assert_eq!(
+            inner.cells[1].paragraphs[0].line_segs[0].segment_width,
+            resolved_table_frame_segment_width(core.dpi),
+            "nested cell mutation must reflow through the table-owned frame"
+        );
     }
 
     /// [#2755] 항목 1 — `delete_range_in_cell_by_path` 가 깊이 1 셀에서 셀 폭 리플로우를

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -14,7 +14,9 @@ use crate::model::page::ColumnDef;
 use crate::model::paragraph::{LineSeg, ParaMeta, Paragraph};
 use crate::model::shape::{ShapeObject, TextWrap, VertRelTo};
 use crate::model::style::Alignment;
-use crate::renderer::composer::{compose_paragraph, reflow_line_segs, ComposedParagraph};
+use crate::renderer::composer::{
+    compose_paragraph, layout_picture_band, reflow_line_segs, ComposedParagraph,
+};
 use crate::renderer::page_layout::PageLayoutInfo;
 use crate::renderer::pagination::PageItem;
 use crate::renderer::style_resolver::{resolve_styles, ResolvedStyleSet};
@@ -494,7 +496,311 @@ fn target_table_first_global_page(
     None
 }
 
+/// Decide whether a Picture band needs another projection after pagination.
+///
+/// `None` means that the column which supplied the latest band projection
+/// still owns its host. `Some` supplies the newly observed column for one
+/// bounded re-projection. A changed column after that budget is exhausted
+/// cannot be published: its LineSegs were made for a different width.
+fn next_picture_band_column(
+    host_index: usize,
+    projected_column: u16,
+    observed_column: u16,
+    reprojections_remaining: usize,
+) -> Result<Option<u16>, HwpError> {
+    if observed_column == projected_column {
+        return Ok(None);
+    }
+    if reprojections_remaining > 0 {
+        return Ok(Some(observed_column));
+    }
+
+    Err(HwpError::RenderError(format!(
+        "그림 배치 영역({}..)의 단 배치가 수렴하지 않습니다",
+        host_index
+    )))
+}
+
 impl DocumentCore {
+    /// Return the completed Picture band which currently owns a body
+    /// paragraph, together with the host's physical column width.
+    fn picture_band_owning_body_paragraph(
+        &self,
+        section_idx: usize,
+        para_idx: usize,
+    ) -> Option<(usize, std::ops::Range<usize>, i32)> {
+        let section = self.document.sections.get(section_idx)?;
+        let host_index = (0..=para_idx).rev().find(|&index| {
+            section.paragraphs[index].controls.iter().any(|control| {
+                matches!(control, Control::Picture(picture) if !picture.common.treat_as_char)
+            })
+        })?;
+        let column_def = Self::find_column_def_for_paragraph(&section.paragraphs, host_index);
+        let layout =
+            PageLayoutInfo::from_page_def(&section.section_def.page_def, &column_def, self.dpi);
+        let column_index = self
+            .para_column_map
+            .get(section_idx)
+            .and_then(|columns| columns.get(host_index))
+            .copied()
+            .unwrap_or(0) as usize;
+        let column_width = layout
+            .column_areas
+            .get(column_index)
+            .or_else(|| layout.column_areas.first())
+            .map(|area| area.width)
+            .unwrap_or(layout.body_area.width);
+        let band = layout_picture_band(
+            &section.paragraphs,
+            host_index,
+            crate::renderer::px_to_hwpunit(column_width, self.dpi),
+            &self.styles,
+            self.dpi,
+        )?;
+        band.paragraph_range.contains(&para_idx).then_some((
+            host_index,
+            band.paragraph_range,
+            crate::renderer::px_to_hwpunit(column_width, self.dpi),
+        ))
+    }
+
+    /// Apply one body-paragraph mutation through its complete Picture band.
+    ///
+    /// A Picture-band edit can change page flow enough to move its host into
+    /// another physical column. Stage that bounded re-projection sequence on
+    /// a complete derived-state copy, then commit it only after every width
+    /// accepts the band.
+    fn apply_body_edit_through_picture_band<F>(
+        &mut self,
+        section_idx: usize,
+        para_idx: usize,
+        edit: F,
+    ) -> Result<bool, HwpError>
+    where
+        F: FnOnce(&mut Paragraph),
+    {
+        // Keep the ordinary scalar path cheap: only build the full staging
+        // core after the live state proves this paragraph belongs to a
+        // supported Picture band.
+        if self
+            .picture_band_owning_body_paragraph(section_idx, para_idx)
+            .is_none()
+        {
+            return Ok(false);
+        }
+
+        let mut staged = self.picture_band_edit_shadow();
+        let Some((host_index, mut previous_column)) =
+            staged.stage_body_edit_through_picture_band(section_idx, para_idx, edit)?
+        else {
+            return Ok(false);
+        };
+
+        let mut reprojections_remaining = 2;
+        loop {
+            let current_column = staged
+                .para_column_map
+                .get(section_idx)
+                .and_then(|columns| columns.get(host_index))
+                .copied()
+                .unwrap_or(0);
+            let Some(next_column) = next_picture_band_column(
+                host_index,
+                previous_column,
+                current_column,
+                reprojections_remaining,
+            )?
+            else {
+                break;
+            };
+
+            staged
+                .stage_body_edit_through_picture_band(section_idx, host_index, |_| {})?
+                .ok_or_else(|| {
+                    HwpError::RenderError(format!(
+                        "그림 배치 영역({}..)을 새 단 너비로 다시 배치할 수 없습니다",
+                        host_index
+                    ))
+                })?;
+            previous_column = next_column;
+            reprojections_remaining -= 1;
+        }
+
+        self.commit_picture_band_edit(section_idx, staged);
+        Ok(true)
+    }
+
+    /// Build only the state needed to stage a Picture-band body edit.
+    ///
+    /// The current paragraph-to-column map is the source width for the first
+    /// projection. The staging core always paginates privately so it can find
+    /// a destination column even when the live caller is batching. Every
+    /// section starts dirty, so that pass rebuilds instead of borrowing live
+    /// pagination or measurement state.
+    fn picture_band_edit_shadow(&self) -> DocumentCore {
+        let mut staged = DocumentCore::new_empty();
+        staged.document = self.document.clone();
+        staged.styles = self.styles.clone();
+        staged.composed = self.composed.clone();
+        staged.dpi = self.dpi;
+        staged.respect_vpos_reset = self.respect_vpos_reset;
+        staged.batch_mode = false;
+        staged.para_column_map = self.para_column_map.clone();
+        staged.dirty_sections = vec![true; staged.document.sections.len()];
+        staged
+    }
+
+    /// Commit a completed Picture-band staging core to this document core.
+    ///
+    /// A normal body edit finishes pagination in the staging core, so its
+    /// document section and every derived layout result cross this boundary
+    /// together. Batch mode retains the existing deferred-pagination contract:
+    /// only the edited section becomes dirty on the live core.
+    fn commit_picture_band_edit(&mut self, section_idx: usize, mut staged: DocumentCore) {
+        self.document.sections[section_idx] = staged.document.sections.remove(section_idx);
+
+        if self.batch_mode {
+            self.invalidate_page_tree_cache();
+            self.composed[section_idx] = staged.composed.remove(section_idx);
+            self.mark_section_dirty(section_idx);
+            if section_idx < self.dirty_paragraphs.len() {
+                self.dirty_paragraphs[section_idx] = None;
+            }
+            return;
+        }
+
+        self.pagination = std::mem::take(&mut staged.pagination);
+        self.composed = std::mem::take(&mut staged.composed);
+        self.render_normalization = std::mem::take(&mut staged.render_normalization);
+        self.measured_tables = std::mem::take(&mut staged.measured_tables);
+        self.dirty_sections = std::mem::take(&mut staged.dirty_sections);
+        self.measured_sections = std::mem::take(&mut staged.measured_sections);
+        self.dirty_paragraphs = std::mem::take(&mut staged.dirty_paragraphs);
+        self.para_column_map = std::mem::take(&mut staged.para_column_map);
+        self.para_offset = std::mem::take(&mut staged.para_offset);
+        self.pending_pagination_job = None;
+        self.deferred_pagination_descriptor = None;
+        self.invalidate_page_tree_cache();
+    }
+
+    /// Prepare a complete Picture-band projection in a staging core.
+    ///
+    /// The source paragraph list remains untouched while the edit, the fresh
+    /// band projection, released rows, and downstream vertical positions are
+    /// prepared on a shadow copy. Its section is recomposed and paginated only
+    /// in that staging core; the caller owns the live commit.
+    /// Returns the host and its pre-publication column when the target has a
+    /// supported Picture-band owner.
+    fn stage_body_edit_through_picture_band<F>(
+        &mut self,
+        section_idx: usize,
+        para_idx: usize,
+        edit: F,
+    ) -> Result<Option<(usize, u16)>, HwpError>
+    where
+        F: FnOnce(&mut Paragraph),
+    {
+        let Some((host_index, old_range, column_width_hwp)) =
+            self.picture_band_owning_body_paragraph(section_idx, para_idx)
+        else {
+            return Ok(None);
+        };
+        let pre_publication_column = self
+            .para_column_map
+            .get(section_idx)
+            .and_then(|columns| columns.get(host_index))
+            .copied()
+            .unwrap_or(0);
+
+        let section = &self.document.sections[section_idx];
+        let stored_host_end =
+            crate::renderer::composer::paragraph_flow_end(&section.paragraphs[host_index]);
+        let mut staged_paragraphs = section.paragraphs.clone();
+        edit(&mut staged_paragraphs[para_idx]);
+
+        let Some(new_band) = layout_picture_band(
+            &staged_paragraphs,
+            host_index,
+            column_width_hwp,
+            &self.styles,
+            self.dpi,
+        ) else {
+            return Err(HwpError::RenderError(format!(
+                "그림 배치 영역({}..)의 편집 결과를 완전한 줄 배치로 만들 수 없습니다",
+                host_index
+            )));
+        };
+        let new_range = new_band.paragraph_range.clone();
+        if new_range.start != host_index || !new_range.contains(&para_idx) {
+            return Err(HwpError::RenderError(format!(
+                "그림 배치 영역({}..)이 편집 문단 {}을 포함하지 않습니다",
+                host_index, para_idx
+            )));
+        }
+
+        for (paragraph, line_segs) in staged_paragraphs[new_range.clone()]
+            .iter_mut()
+            .zip(new_band.line_segs)
+        {
+            paragraph.invalidate_single_line_overflow_memo();
+            paragraph.line_segs = line_segs;
+        }
+
+        // When an edited paragraph clears the exclusion earlier than before,
+        // its old band successors become ordinary full-width paragraphs again.
+        // Reflow those successors on the shadow state before calculating the
+        // downstream vertical ladder.
+        for released_para_idx in new_range.end..old_range.end {
+            let column_def =
+                Self::find_column_def_for_paragraph(&staged_paragraphs, released_para_idx);
+            let layout =
+                PageLayoutInfo::from_page_def(&section.section_def.page_def, &column_def, self.dpi);
+            let column_index = self
+                .para_column_map
+                .get(section_idx)
+                .and_then(|columns| columns.get(released_para_idx))
+                .copied()
+                .unwrap_or(0) as usize;
+            let column_area = layout
+                .column_areas
+                .get(column_index)
+                .or_else(|| layout.column_areas.first())
+                .unwrap_or(&layout.body_area);
+            let paragraph = &mut staged_paragraphs[released_para_idx];
+            let para_style = self
+                .styles
+                .para_styles
+                .get(paragraph.para_shape_id as usize);
+            let margin_left = para_style.map(|style| style.margin_left).unwrap_or(0.0);
+            let margin_right = para_style.map(|style| style.margin_right).unwrap_or(0.0);
+            reflow_line_segs(
+                paragraph,
+                column_area.width - margin_left - margin_right,
+                &self.styles,
+                self.dpi,
+            );
+        }
+
+        let affected_end = old_range.end.max(new_range.end);
+        crate::renderer::composer::recalculate_section_vpos(
+            &mut staged_paragraphs,
+            host_index,
+            Some(host_index..affected_end),
+            stored_host_end,
+            &self.styles,
+            self.dpi,
+            self.document.layout_profile().hwp3_layout(),
+        );
+
+        // This staging core owns the section source and every changed LineSeg
+        // together. The caller can expose it only after convergence succeeds.
+        self.document.sections[section_idx].paragraphs = staged_paragraphs;
+        self.document.sections[section_idx].raw_stream = None;
+        self.recompose_section(section_idx);
+        self.paginate_if_needed();
+        Ok(Some((host_index, pre_publication_column)))
+    }
+
     /// [#2424] resumable step 시작 전에 descriptor가 여전히 같은 text-only table edit을
     /// 가리키는지 좌표로 다시 조회한다. 불일치하면 shadow state를 commit하지 않고 기존
     /// full pagination으로 fallback해야 한다.
@@ -1097,9 +1403,6 @@ impl DocumentCore {
             )));
         }
 
-        // 편집 시 raw 스트림 무효화 (재직렬화 유도)
-        self.document.sections[section_idx].raw_stream = None;
-
         // 텍스트 삽입
         let new_chars_count = text.chars().count();
         let active_field = self.active_field.clone();
@@ -1119,53 +1422,32 @@ impl DocumentCore {
             None,
             char_offset,
         );
-        {
-            let para = &mut self.document.sections[section_idx].paragraphs[para_idx];
+        let apply_insert = |para: &mut Paragraph| {
             para.insert_text_at(char_offset, text);
             keep_inactive_field_start_outside(para, &before_insertions, new_chars_count);
             keep_inactive_field_end_outside(para, &outside_insertions, new_chars_count);
             if has_clickhere_field_range(para) {
                 rebuild_char_offsets(para);
             }
-        }
+        };
+        let picture_band_applied =
+            self.apply_body_edit_through_picture_band(section_idx, para_idx, &apply_insert)?;
 
-        // line_segs 재계산 (리플로우) → vpos 재계산 → 재구성 → 재페이지네이션
-        // 다단 문서에서 편집 후 문단이 다른 단으로 재배치될 수 있으므로
-        // para_column_map 변경 감지 + 재reflow 수렴 루프 (최대 3회)
-        let old_col = self
-            .para_column_map
-            .get(section_idx)
-            .and_then(|m| m.get(para_idx))
-            .copied()
-            .unwrap_or(0);
-        // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
-        let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
-            &self.document.sections[section_idx].paragraphs[para_idx],
-        );
-        self.reflow_paragraph(section_idx, para_idx);
-        let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
-        crate::renderer::composer::recalculate_section_vpos(
-            &mut self.document.sections[section_idx].paragraphs,
-            para_idx,
-            None,
-            stored_end_for_reset,
-            &self.styles,
-            self.dpi,
-            doc_hwp3_layout,
-        );
-        self.recompose_paragraph(section_idx, para_idx);
-        self.paginate_if_needed();
+        if !picture_band_applied {
+            // 편집 시 raw 스트림 무효화 (재직렬화 유도)
+            self.document.sections[section_idx].raw_stream = None;
+            let para = &mut self.document.sections[section_idx].paragraphs[para_idx];
+            apply_insert(para);
 
-        for _ in 0..2 {
-            let new_col = self
+            // line_segs 재계산 (리플로우) → vpos 재계산 → 재구성 → 재페이지네이션
+            // 다단 문서에서 편집 후 문단이 다른 단으로 재배치될 수 있으므로
+            // para_column_map 변경 감지 + 재reflow 수렴 루프 (최대 3회)
+            let old_col = self
                 .para_column_map
                 .get(section_idx)
                 .and_then(|m| m.get(para_idx))
                 .copied()
                 .unwrap_or(0);
-            if new_col == old_col {
-                break;
-            }
             // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
             let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
                 &self.document.sections[section_idx].paragraphs[para_idx],
@@ -1183,6 +1465,35 @@ impl DocumentCore {
             );
             self.recompose_paragraph(section_idx, para_idx);
             self.paginate_if_needed();
+
+            for _ in 0..2 {
+                let new_col = self
+                    .para_column_map
+                    .get(section_idx)
+                    .and_then(|m| m.get(para_idx))
+                    .copied()
+                    .unwrap_or(0);
+                if new_col == old_col {
+                    break;
+                }
+                // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+                let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
+                    &self.document.sections[section_idx].paragraphs[para_idx],
+                );
+                self.reflow_paragraph(section_idx, para_idx);
+                let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
+                crate::renderer::composer::recalculate_section_vpos(
+                    &mut self.document.sections[section_idx].paragraphs,
+                    para_idx,
+                    None,
+                    stored_end_for_reset,
+                    &self.styles,
+                    self.dpi,
+                    doc_hwp3_layout,
+                );
+                self.recompose_paragraph(section_idx, para_idx);
+                self.paginate_if_needed();
+            }
         }
 
         let new_offset = char_offset + new_chars_count;
@@ -1242,48 +1553,26 @@ impl DocumentCore {
             )));
         }
 
-        // 편집 시 raw 스트림 무효화 (재직렬화 유도)
-        self.document.sections[section_idx].raw_stream = None;
-
         // 텍스트 삭제
-        self.document.sections[section_idx].paragraphs[para_idx].delete_text_at(char_offset, count);
+        let apply_delete = |para: &mut Paragraph| {
+            para.delete_text_at(char_offset, count);
+        };
+        let picture_band_applied =
+            self.apply_body_edit_through_picture_band(section_idx, para_idx, &apply_delete)?;
 
-        // line_segs 재계산 (리플로우) → 재구성 → 재페이지네이션
-        // 다단 수렴 루프 (최대 3회)
-        let old_col = self
-            .para_column_map
-            .get(section_idx)
-            .and_then(|m| m.get(para_idx))
-            .copied()
-            .unwrap_or(0);
-        // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
-        let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
-            &self.document.sections[section_idx].paragraphs[para_idx],
-        );
-        self.reflow_paragraph(section_idx, para_idx);
-        let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
-        crate::renderer::composer::recalculate_section_vpos(
-            &mut self.document.sections[section_idx].paragraphs,
-            para_idx,
-            None,
-            stored_end_for_reset,
-            &self.styles,
-            self.dpi,
-            doc_hwp3_layout,
-        );
-        self.recompose_paragraph(section_idx, para_idx);
-        self.paginate_if_needed();
+        if !picture_band_applied {
+            // 편집 시 raw 스트림 무효화 (재직렬화 유도)
+            self.document.sections[section_idx].raw_stream = None;
+            apply_delete(&mut self.document.sections[section_idx].paragraphs[para_idx]);
 
-        for _ in 0..2 {
-            let new_col = self
+            // line_segs 재계산 (리플로우) → 재구성 → 재페이지네이션
+            // 다단 수렴 루프 (최대 3회)
+            let old_col = self
                 .para_column_map
                 .get(section_idx)
                 .and_then(|m| m.get(para_idx))
                 .copied()
                 .unwrap_or(0);
-            if new_col == old_col {
-                break;
-            }
             // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
             let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
                 &self.document.sections[section_idx].paragraphs[para_idx],
@@ -1301,6 +1590,35 @@ impl DocumentCore {
             );
             self.recompose_paragraph(section_idx, para_idx);
             self.paginate_if_needed();
+
+            for _ in 0..2 {
+                let new_col = self
+                    .para_column_map
+                    .get(section_idx)
+                    .and_then(|m| m.get(para_idx))
+                    .copied()
+                    .unwrap_or(0);
+                if new_col == old_col {
+                    break;
+                }
+                // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+                let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
+                    &self.document.sections[section_idx].paragraphs[para_idx],
+                );
+                self.reflow_paragraph(section_idx, para_idx);
+                let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
+                crate::renderer::composer::recalculate_section_vpos(
+                    &mut self.document.sections[section_idx].paragraphs,
+                    para_idx,
+                    None,
+                    stored_end_for_reset,
+                    &self.styles,
+                    self.dpi,
+                    doc_hwp3_layout,
+                );
+                self.recompose_paragraph(section_idx, para_idx);
+                self.paginate_if_needed();
+            }
         }
 
         // 캐럿 위치 갱신 (DocProperties)
@@ -7220,6 +7538,639 @@ mod tests {
         assert!(
             para.single_line_overflow_memo.is_unjudged(),
             "삭제 직후 memo 는 미판정 상태여야 함 (다음 렌더에서 fresh 재판정)"
+        );
+    }
+
+    #[test]
+    fn picture_frame_body_edit_publishes_complete_band_before_recompose() {
+        use crate::model::control::Control;
+        use crate::model::page::ColumnDef;
+        use crate::renderer::page_layout::PageLayoutInfo;
+
+        const HOST: usize = 325;
+        const INTERIOR: usize = 326;
+        const DOWNSTREAM: usize = 332;
+        const DPI: f64 = 96.0;
+
+        let bytes = std::fs::read(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("samples/3-09월_교육_통합_2022.hwp"),
+        )
+        .expect("p325 corpus fixture");
+        let mut core = DocumentCore::from_bytes(&bytes).expect("parse p325 corpus fixture");
+
+        let styles = core.styles.clone();
+        let page_def = core.document.sections[0].section_def.page_def.clone();
+        let para_column_map = core.para_column_map.clone();
+        let hwp3_layout = core.document.layout_profile().hwp3_layout();
+        let original_paragraphs = core.document.sections[0].paragraphs.clone();
+        let column_def = original_paragraphs[..=HOST]
+            .iter()
+            .flat_map(|paragraph| &paragraph.controls)
+            .filter_map(|control| match control {
+                Control::ColumnDef(column) => Some(column.clone()),
+                _ => None,
+            })
+            .next_back()
+            .unwrap_or_else(ColumnDef::default);
+        let page_layout = PageLayoutInfo::from_page_def(&page_def, &column_def, DPI);
+        let host_column_index = para_column_map
+            .first()
+            .and_then(|columns| columns.get(HOST))
+            .copied()
+            .unwrap_or(0) as usize;
+        let column_width_hwp = crate::renderer::px_to_hwpunit(
+            page_layout
+                .column_areas
+                .get(host_column_index)
+                .or_else(|| page_layout.column_areas.first())
+                .unwrap_or(&page_layout.body_area)
+                .width,
+            DPI,
+        );
+        let initial_band = crate::renderer::composer::layout_picture_band(
+            &original_paragraphs,
+            HOST,
+            column_width_hwp,
+            &styles,
+            DPI,
+        )
+        .expect("p325 Picture frame");
+        assert_eq!(initial_band.paragraph_range, HOST..DOWNSTREAM);
+        assert!(initial_band.paragraph_range.contains(&INTERIOR));
+
+        let geometry = |paragraphs: &[Paragraph]| {
+            paragraphs
+                .iter()
+                .map(|paragraph| {
+                    paragraph
+                        .line_segs
+                        .iter()
+                        .map(|line| {
+                            (
+                                line.text_start,
+                                line.vertical_pos,
+                                line.line_height,
+                                line.text_height,
+                                line.baseline_distance,
+                                line.line_spacing,
+                                line.column_start,
+                                line.segment_width,
+                                line.tag,
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>()
+        };
+        let reflow_released_body_paragraph = |paragraphs: &mut [Paragraph], para_idx: usize| {
+            let column_def = DocumentCore::find_column_def_for_paragraph(paragraphs, para_idx);
+            let layout = PageLayoutInfo::from_page_def(&page_def, &column_def, DPI);
+            let column_index = para_column_map
+                .first()
+                .and_then(|columns| columns.get(para_idx))
+                .copied()
+                .unwrap_or(0) as usize;
+            let column_area = layout
+                .column_areas
+                .get(column_index)
+                .or_else(|| layout.column_areas.first())
+                .unwrap_or(&layout.body_area);
+            let paragraph = &mut paragraphs[para_idx];
+            let para_style = styles.para_styles.get(paragraph.para_shape_id as usize);
+            let margin_left = para_style.map(|style| style.margin_left).unwrap_or(0.0);
+            let margin_right = para_style.map(|style| style.margin_right).unwrap_or(0.0);
+            reflow_line_segs(
+                paragraph,
+                column_area.width - margin_left - margin_right,
+                &styles,
+                DPI,
+            );
+        };
+
+        let insertion = "가".repeat(4);
+        let original_text = original_paragraphs[INTERIOR].text.clone();
+        let mut expected_after_insert = original_paragraphs.clone();
+        expected_after_insert[INTERIOR].insert_text_at(0, &insertion);
+        let inserted_band = crate::renderer::composer::layout_picture_band(
+            &expected_after_insert,
+            HOST,
+            column_width_hwp,
+            &styles,
+            DPI,
+        )
+        .expect("edited p325 Picture frame");
+        let inserted_range = inserted_band.paragraph_range.clone();
+        assert_eq!(inserted_range, HOST..331);
+        assert_eq!(
+            inserted_band.line_segs[INTERIOR - HOST].len(),
+            2,
+            "the interior insertion must add one physical row"
+        );
+        for (paragraph, line_segs) in expected_after_insert[inserted_range.clone()]
+            .iter_mut()
+            .zip(inserted_band.line_segs)
+        {
+            paragraph.invalidate_single_line_overflow_memo();
+            paragraph.line_segs = line_segs;
+        }
+        for released_para_idx in inserted_range.end..initial_band.paragraph_range.end {
+            reflow_released_body_paragraph(&mut expected_after_insert, released_para_idx);
+        }
+        crate::renderer::composer::recalculate_section_vpos(
+            &mut expected_after_insert,
+            HOST,
+            Some(HOST..initial_band.paragraph_range.end.max(inserted_range.end)),
+            crate::renderer::composer::paragraph_flow_end(&original_paragraphs[HOST]),
+            &styles,
+            DPI,
+            hwp3_layout,
+        );
+
+        core.insert_text_native(0, INTERIOR, 0, &insertion)
+            .expect("Picture-owned paragraph insert succeeds");
+        assert_eq!(
+            core.document.sections[0].paragraphs[INTERIOR].text,
+            format!("{}{}", insertion, original_text),
+        );
+        assert!(
+            core.document.sections[0].raw_stream.is_none(),
+            "the successful transaction invalidates the source section together with its LineSegs"
+        );
+        assert_eq!(
+            geometry(&core.document.sections[0].paragraphs[HOST..=DOWNSTREAM]),
+            geometry(&expected_after_insert[HOST..=DOWNSTREAM]),
+            "the complete fresh band, released p331, and downstream p332 boundary must publish together"
+        );
+        assert_eq!(
+            core.document.sections[0].paragraphs[DOWNSTREAM].line_segs[0].segment_width,
+            original_paragraphs[DOWNSTREAM].line_segs[0].segment_width,
+            "p332 remains a full-width downstream paragraph while its vertical position is recomposed"
+        );
+
+        let before_delete = core.document.sections[0].paragraphs.clone();
+        let before_delete_band = crate::renderer::composer::layout_picture_band(
+            &before_delete,
+            HOST,
+            column_width_hwp,
+            &styles,
+            DPI,
+        )
+        .expect("inserted Picture frame before delete");
+        assert_eq!(before_delete_band.paragraph_range, HOST..331);
+        let mut expected_after_delete = before_delete.clone();
+        expected_after_delete[INTERIOR].delete_text_at(0, insertion.chars().count());
+        let deleted_band = crate::renderer::composer::layout_picture_band(
+            &expected_after_delete,
+            HOST,
+            column_width_hwp,
+            &styles,
+            DPI,
+        )
+        .expect("restored p325 Picture frame");
+        let deleted_range = deleted_band.paragraph_range.clone();
+        assert_eq!(deleted_range, HOST..DOWNSTREAM);
+        for (paragraph, line_segs) in expected_after_delete[deleted_range.clone()]
+            .iter_mut()
+            .zip(deleted_band.line_segs)
+        {
+            paragraph.invalidate_single_line_overflow_memo();
+            paragraph.line_segs = line_segs;
+        }
+        for released_para_idx in deleted_range.end..before_delete_band.paragraph_range.end {
+            reflow_released_body_paragraph(&mut expected_after_delete, released_para_idx);
+        }
+        crate::renderer::composer::recalculate_section_vpos(
+            &mut expected_after_delete,
+            HOST,
+            Some(
+                HOST..before_delete_band
+                    .paragraph_range
+                    .end
+                    .max(deleted_range.end),
+            ),
+            crate::renderer::composer::paragraph_flow_end(&before_delete[HOST]),
+            &styles,
+            DPI,
+            hwp3_layout,
+        );
+
+        core.delete_text_native(0, INTERIOR, 0, insertion.chars().count())
+            .expect("Picture-owned paragraph delete succeeds");
+        assert_eq!(
+            core.document.sections[0].paragraphs[INTERIOR].text, original_text,
+            "delete restores the edited paragraph text"
+        );
+        assert_eq!(
+            geometry(&core.document.sections[0].paragraphs[HOST..=DOWNSTREAM]),
+            geometry(&expected_after_delete[HOST..=DOWNSTREAM]),
+            "delete must also republish the fresh complete band and p332 boundary"
+        );
+    }
+
+    #[test]
+    fn picture_frame_transaction_rejects_shadow_failure_without_publication() {
+        const HOST: usize = 325;
+        const INTERIOR: usize = 326;
+        const DOWNSTREAM: usize = 332;
+
+        let bytes = std::fs::read(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("samples/3-09월_교육_통합_2022.hwp"),
+        )
+        .expect("p325 corpus fixture");
+        let mut core = DocumentCore::from_bytes(&bytes).expect("parse p325 corpus fixture");
+        let before_paragraphs = core.document.sections[0].paragraphs.clone();
+        let before_raw_stream = core.document.sections[0].raw_stream.clone();
+        let geometry = |paragraphs: &[Paragraph]| {
+            paragraphs
+                .iter()
+                .map(|paragraph| {
+                    paragraph
+                        .line_segs
+                        .iter()
+                        .map(|line| {
+                            (
+                                line.text_start,
+                                line.vertical_pos,
+                                line.line_height,
+                                line.text_height,
+                                line.baseline_distance,
+                                line.line_spacing,
+                                line.column_start,
+                                line.segment_width,
+                                line.tag,
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let result = core.apply_body_edit_through_picture_band(0, INTERIOR, |paragraph| {
+            paragraph.column_type = ColumnBreakType::Column;
+        });
+
+        assert!(
+            result.is_err(),
+            "the staged layout must reject a column break"
+        );
+        assert_eq!(
+            core.document.sections[0].paragraphs[INTERIOR].text, before_paragraphs[INTERIOR].text,
+            "a rejected shadow edit must not publish source text"
+        );
+        assert_eq!(
+            geometry(&core.document.sections[0].paragraphs[HOST..=DOWNSTREAM]),
+            geometry(&before_paragraphs[HOST..=DOWNSTREAM]),
+            "a rejected shadow edit must not publish partial LineSeg geometry"
+        );
+        assert_eq!(
+            core.document.sections[0].raw_stream, before_raw_stream,
+            "a rejected shadow edit must not invalidate source serialization state"
+        );
+    }
+
+    #[test]
+    fn picture_frame_column_convergence_accepts_stable_and_rejects_exhaustion() {
+        const HOST: usize = 325;
+
+        let projected = next_picture_band_column(HOST, 0, 1, 2)
+            .expect("a changed column has reprojection budget")
+            .expect("a changed column needs another projection");
+        assert_eq!(projected, 1);
+        assert_eq!(
+            next_picture_band_column(HOST, projected, 1, 1)
+                .expect("a stable projection must converge"),
+            None,
+            "the host keeps the column that supplied its final projection"
+        );
+
+        let mut projected = 0;
+        let mut reprojections_remaining = 2;
+        for observed in [1, 0] {
+            projected =
+                next_picture_band_column(HOST, projected, observed, reprojections_remaining)
+                    .expect("the bounded reprojection is still available")
+                    .expect("an alternating column needs another projection");
+            reprojections_remaining -= 1;
+        }
+        assert_eq!(projected, 0);
+        assert_eq!(reprojections_remaining, 0);
+        assert!(
+            matches!(
+                next_picture_band_column(HOST, projected, 1, reprojections_remaining),
+                Err(HwpError::RenderError(ref message))
+                    if message == "그림 배치 영역(325..)의 단 배치가 수렴하지 않습니다"
+            ),
+            "an exhausted alternating column sequence must be rejected before commit"
+        );
+    }
+
+    #[test]
+    fn picture_frame_reprojects_after_host_moves_to_unequal_column() {
+        use crate::model::control::Control;
+
+        const HOST: usize = 325;
+        const INTERIOR: usize = 326;
+        const DPI: f64 = 96.0;
+
+        let bytes = std::fs::read(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("samples/3-09월_교육_통합_2022.hwp"),
+        )
+        .expect("p325 corpus fixture");
+
+        let mut core = DocumentCore::from_bytes(&bytes).expect("parse p325 corpus fixture");
+        let column = core.document.sections[0].paragraphs[0]
+            .controls
+            .iter_mut()
+            .find_map(|control| match control {
+                Control::ColumnDef(column) => Some(column),
+                _ => None,
+            })
+            .expect("p0 column definition");
+        column.same_width = false;
+        column.proportional_widths = true;
+        column.widths = vec![10_000, 22_000];
+        column.gaps = vec![500];
+        core.document.sections[0].section_def.page_def.height = 12_000;
+        core.recompose_section(0);
+        core.paginate();
+
+        let before_col = core.para_column_map[0][HOST];
+        let (_, _, before_width_hwp) = core
+            .picture_band_owning_body_paragraph(0, HOST)
+            .expect("initial Picture band");
+        assert_eq!(
+            before_col, 0,
+            "fixture starts the host in the narrow column"
+        );
+
+        core.insert_text_native(0, HOST, 0, &"가".repeat(32))
+            .expect("host insert succeeds");
+
+        let after_col = core.para_column_map[0][HOST];
+        let (_, fresh_range, after_width_hwp) = core
+            .picture_band_owning_body_paragraph(0, HOST)
+            .expect("Picture band after pagination");
+        assert_eq!(after_col, 1, "the expanded host moves to the wide column");
+        assert_ne!(
+            before_width_hwp, after_width_hwp,
+            "the two physical columns must have different available widths"
+        );
+
+        let fresh_band = crate::renderer::composer::layout_picture_band(
+            &core.document.sections[0].paragraphs,
+            HOST,
+            after_width_hwp,
+            &core.styles,
+            DPI,
+        )
+        .expect("fresh band at the post-pagination column width");
+        assert_eq!(fresh_band.paragraph_range, fresh_range);
+        let horizontal_projection = |line: &LineSeg| {
+            (
+                line.text_start,
+                line.line_height,
+                line.text_height,
+                line.baseline_distance,
+                line.line_spacing,
+                line.column_start,
+                line.segment_width,
+                line.tag,
+            )
+        };
+        for (paragraph, fresh_lines) in core.document.sections[0].paragraphs[fresh_range.clone()]
+            .iter()
+            .zip(fresh_band.line_segs)
+        {
+            assert_eq!(
+                paragraph
+                    .line_segs
+                    .iter()
+                    .map(horizontal_projection)
+                    .collect::<Vec<_>>(),
+                fresh_lines
+                    .iter()
+                    .map(horizontal_projection)
+                    .collect::<Vec<_>>(),
+                "every current band member must match the post-pagination column projection"
+            );
+        }
+    }
+
+    #[test]
+    fn picture_frame_batch_edit_reprojects_before_final_pagination() {
+        use crate::model::control::Control;
+
+        const HOST: usize = 325;
+        const DPI: f64 = 96.0;
+
+        let bytes = std::fs::read(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("samples/3-09월_교육_통합_2022.hwp"),
+        )
+        .expect("p325 corpus fixture");
+
+        let mut core = DocumentCore::from_bytes(&bytes).expect("parse p325 corpus fixture");
+        let column = core.document.sections[0].paragraphs[0]
+            .controls
+            .iter_mut()
+            .find_map(|control| match control {
+                Control::ColumnDef(column) => Some(column),
+                _ => None,
+            })
+            .expect("p0 column definition");
+        column.same_width = false;
+        column.proportional_widths = true;
+        column.widths = vec![10_000, 22_000];
+        column.gaps = vec![500];
+        core.document.sections[0].section_def.page_def.height = 12_000;
+        core.recompose_section(0);
+        core.paginate();
+
+        let before_col = core.para_column_map[0][HOST];
+        let (_, _, before_width_hwp) = core
+            .picture_band_owning_body_paragraph(0, HOST)
+            .expect("initial Picture band");
+        assert_eq!(before_col, 0, "fixture starts in the narrow column");
+
+        core.begin_batch_native().expect("begin batch");
+        core.insert_text_native(0, HOST, 0, &"가".repeat(32))
+            .expect("host insert succeeds during batch");
+        let after_edit_col = core.para_column_map[0][HOST];
+        core.end_batch_native().expect("end batch");
+
+        let after_flush_col = core.para_column_map[0][HOST];
+        let (_, fresh_range, after_width_hwp) = core
+            .picture_band_owning_body_paragraph(0, HOST)
+            .expect("Picture band after final pagination");
+        assert_eq!(
+            after_edit_col, before_col,
+            "batch mode keeps the live column map deferred"
+        );
+        assert_eq!(
+            after_flush_col, 1,
+            "the expanded host moves to the wide column when the batch flushes"
+        );
+        assert_ne!(before_width_hwp, after_width_hwp);
+
+        let fresh_band = crate::renderer::composer::layout_picture_band(
+            &core.document.sections[0].paragraphs,
+            HOST,
+            after_width_hwp,
+            &core.styles,
+            DPI,
+        )
+        .expect("fresh band at the post-batch column width");
+        assert_eq!(fresh_band.paragraph_range, fresh_range);
+        let horizontal_projection = |line: &LineSeg| {
+            (
+                line.text_start,
+                line.line_height,
+                line.text_height,
+                line.baseline_distance,
+                line.line_spacing,
+                line.column_start,
+                line.segment_width,
+                line.tag,
+            )
+        };
+        let actual_projection = core.document.sections[0].paragraphs[fresh_range.clone()]
+            .iter()
+            .map(|paragraph| {
+                paragraph
+                    .line_segs
+                    .iter()
+                    .map(horizontal_projection)
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        let fresh_projection = fresh_band
+            .line_segs
+            .iter()
+            .map(|line_segs| {
+                line_segs
+                    .iter()
+                    .map(horizontal_projection)
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            actual_projection, fresh_projection,
+            "the deferred batch flush must already receive the destination-width Picture band"
+        );
+    }
+
+    #[test]
+    fn picture_frame_failed_narrow_column_convergence_publishes_nothing() {
+        use crate::model::control::Control;
+
+        const HOST: usize = 325;
+        const DOWNSTREAM: usize = 332;
+        let bytes = std::fs::read(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("samples/3-09월_교육_통합_2022.hwp"),
+        )
+        .expect("p325 corpus fixture");
+
+        let mut core = DocumentCore::from_bytes(&bytes).expect("parse p325 corpus fixture");
+        let host_style_id = core.document.sections[0].paragraphs[HOST].para_shape_id;
+        core.styles.para_styles[host_style_id as usize].margin_left =
+            crate::renderer::hwpunit_to_px(20_000, core.dpi);
+        let column = core.document.sections[0].paragraphs[0]
+            .controls
+            .iter_mut()
+            .find_map(|control| match control {
+                Control::ColumnDef(column) => Some(column),
+                _ => None,
+            })
+            .expect("p0 column definition");
+        column.same_width = false;
+        column.proportional_widths = true;
+        column.widths = vec![22_000, 10_000];
+        column.gaps = vec![500];
+        core.document.sections[0].section_def.page_def.height = 12_000;
+        core.recompose_section(0);
+        core.paginate();
+
+        let before_col = core.para_column_map[0][HOST];
+        let (_, before_range, before_width_hwp) = core
+            .picture_band_owning_body_paragraph(0, HOST)
+            .expect("supported Picture band in the wide source column");
+        assert_eq!(before_col, 0, "fixture starts in the wide column");
+        assert_eq!(before_range, HOST..326);
+        assert_eq!(before_width_hwp, 36_842);
+
+        let geometry = |paragraphs: &[Paragraph]| {
+            paragraphs
+                .iter()
+                .map(|paragraph| {
+                    paragraph
+                        .line_segs
+                        .iter()
+                        .map(|line| {
+                            (
+                                line.text_start,
+                                line.vertical_pos,
+                                line.line_height,
+                                line.text_height,
+                                line.baseline_distance,
+                                line.line_spacing,
+                                line.column_start,
+                                line.segment_width,
+                                line.tag,
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>()
+        };
+        let before_text = core.document.sections[0].paragraphs[HOST].text.clone();
+        let before_geometry = geometry(&core.document.sections[0].paragraphs[HOST..=DOWNSTREAM]);
+        let before_raw_stream = core.document.sections[0].raw_stream.clone();
+        let before_columns = core.para_column_map.clone();
+        let before_event_count = core.event_log.len();
+
+        let result = core.insert_text_native(0, HOST, 0, &"가".repeat(32));
+        let after_col = core.para_column_map[0][HOST];
+        let text_changed = core.document.sections[0].paragraphs[HOST].text != before_text;
+        let raw_changed = core.document.sections[0].raw_stream != before_raw_stream;
+        let event_count = core.event_log.len();
+
+        assert!(
+            matches!(
+                result,
+                Err(HwpError::RenderError(ref message))
+                    if message == "그림 배치 영역(325..)을 새 단 너비로 다시 배치할 수 없습니다"
+            ),
+            "the narrow destination column must reject its re-projection"
+        );
+        assert_eq!(
+            after_col, before_col,
+            "a rejected convergence must not publish its destination column"
+        );
+        assert!(
+            !text_changed,
+            "a rejected convergence must not publish text"
+        );
+        assert!(
+            !raw_changed,
+            "a rejected convergence must not invalidate raw data"
+        );
+        assert_eq!(
+            geometry(&core.document.sections[0].paragraphs[HOST..=DOWNSTREAM]),
+            before_geometry,
+            "a rejected convergence must not publish partial LineSeg geometry"
+        );
+        assert_eq!(
+            core.para_column_map, before_columns,
+            "a rejected convergence must not publish pagination state"
+        );
+        assert_eq!(
+            event_count, before_event_count,
+            "a rejected convergence must not publish an edit event"
         );
     }
 }

--- a/src/document_core/queries/cursor_rect.rs
+++ b/src/document_core/queries/cursor_rect.rs
@@ -3019,7 +3019,7 @@ impl DocumentCore {
         use crate::model::control::Control;
         use crate::renderer::layout::{layout_rect_to_bbox, PartialTableCellProbe, ProbeCutPlan};
         use crate::renderer::pagination::PageItem;
-        use crate::renderer::render_tree::{LayoutFrame, RenderNode, RenderNodeType};
+        use crate::renderer::render_tree::{PageLayoutContext, RenderNode, RenderNodeType};
         use FastCellRectOutcome::{Hit, NoHit, Unsupported};
 
         let Ok((page_content, paragraphs, _composed)) = self.find_page(page_num) else {
@@ -3251,7 +3251,7 @@ impl DocumentCore {
 
         // ── 대상 셀 하나만 방출하는 프로브 레이아웃 ──
         // [#4277] 캐럿 rect 프로브도 paint 트리가 아니라 흐름 상태만 만든다.
-        let mut scratch_frame = LayoutFrame::new(
+        let mut scratch_frame = PageLayoutContext::new(
             page_content.page_index,
             layout.page_width,
             layout.page_height,

--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -1,6 +1,6 @@
 //! 문단 (Paragraph, CharRun, LineSeg, RangeTag)
 
-use super::control::Control;
+use super::control::{Control, CTRL_CHAR_CODE_UNITS};
 use serde::{Deserialize, Serialize};
 
 /// 문단 (HWPTAG_PARA_HEADER + 하위 레코드)
@@ -1581,6 +1581,49 @@ impl Paragraph {
         let _ = already_filled; // 향후 디버그용 (현재 미사용)
 
         positions
+    }
+
+    /// Return each control's source `PARA_TEXT` UTF-16 start position.
+    ///
+    /// `char_offsets` point after every control gap preceding a visible
+    /// character. Consumers which anchor geometry in the raw stream therefore
+    /// need to reconstruct the individual starts inside that gap instead of
+    /// using the visible-text position alone.
+    pub(crate) fn control_utf16_positions(&self) -> Vec<u32> {
+        let text_positions = self.control_text_positions();
+        let text_chars = self.text.chars().collect::<Vec<_>>();
+        let text_end = self
+            .char_offsets
+            .last()
+            .zip(text_chars.last())
+            .map(|(offset, ch)| *offset + ch.len_utf16() as u32)
+            .unwrap_or_else(|| text_chars.iter().map(|ch| ch.len_utf16() as u32).sum());
+        let mut raw_positions = vec![text_end; text_positions.len()];
+
+        let mut group_start = 0;
+        while group_start < text_positions.len() {
+            let text_position = text_positions[group_start];
+            let mut group_end = group_start + 1;
+            while text_positions.get(group_end) == Some(&text_position) {
+                group_end += 1;
+            }
+
+            let count = (group_end - group_start) as u32;
+            let first_raw = self
+                .char_offsets
+                .get(text_position)
+                .copied()
+                .map(|offset| offset.saturating_sub(count * CTRL_CHAR_CODE_UNITS))
+                .unwrap_or(text_end);
+            for (ordinal, raw_position) in
+                raw_positions[group_start..group_end].iter_mut().enumerate()
+            {
+                *raw_position = first_raw + ordinal as u32 * CTRL_CHAR_CODE_UNITS;
+            }
+            group_start = group_end;
+        }
+
+        raw_positions
     }
 
     /// 편집/커서 이동용 control position 을 반환한다.

--- a/src/model/paragraph/tests.rs
+++ b/src/model/paragraph/tests.rs
@@ -1348,6 +1348,24 @@ fn test_control_text_positions_gap_between_chars() {
 }
 
 #[test]
+fn test_control_utf16_positions_reconstructs_a_shared_control_gap() {
+    // Two controls share the visible-text boundary before B. The raw stream
+    // has their distinct 8-unit control slots at 1 and 9 before B at 17.
+    let para = Paragraph {
+        text: "AB".to_string(),
+        char_offsets: vec![0, 17],
+        controls: vec![
+            Control::Table(Box::<Table>::default()),
+            Control::Table(Box::<Table>::default()),
+        ],
+        ..Default::default()
+    };
+
+    assert_eq!(para.control_text_positions(), vec![1, 1]);
+    assert_eq!(para.control_utf16_positions(), vec![1, 9]);
+}
+
+#[test]
 fn test_control_text_positions_gap_before() {
     // text = "A", char_offsets = [8] → 'A' 앞에 8 unit 갭 = inline ctrl 1개
     let para = Paragraph {

--- a/src/model/table.rs
+++ b/src/model/table.rs
@@ -266,6 +266,25 @@ impl Cell {
         }
     }
 
+    /// Padding that bounds a newly generated paragraph layout frame.
+    ///
+    /// An all-zero table padding is a real zero-width frame boundary for
+    /// stored HWP LineSeg geometry. `effective_padding()` deliberately keeps
+    /// a separate paint/measurement compatibility fallback to the cell's
+    /// saved padding, so frame construction must not reuse that exception.
+    pub(crate) fn paragraph_frame_padding(
+        &self,
+        table_padding: &crate::model::Padding,
+    ) -> crate::model::Padding {
+        if self.apply_inner_margin {
+            self.padding
+        } else if Self::table_padding_unspecified(table_padding) {
+            crate::model::Padding::default()
+        } else {
+            self.effective_padding(table_padding)
+        }
+    }
+
     pub fn cell_protect(&self) -> bool {
         self.list_header_width_ref & CELL_FLAG_PROTECT != 0
     }
@@ -402,6 +421,134 @@ impl Cell {
 }
 
 impl Table {
+    /// Widths owned by cell paragraph frames before padding and paragraph margins.
+    ///
+    /// Native tables may repeat a row with raw cell widths whose sum is a few
+    /// HWPUNIT short of the table's resolved column grid. Those raw values are
+    /// serialization auxiliaries, not independent row boundaries. Preserve
+    /// explicit/inferred local-resize rows; otherwise use genuine base-track
+    /// evidence and place any positive table-width residual on the last column.
+    ///
+    /// This is deliberately batch-shaped. Row-role inference examines the table
+    /// as a whole, so repeating it once per cell makes large native tables
+    /// quadratic and can prevent on-demand reflow from completing.
+    pub(crate) fn paragraph_frame_owner_widths(&self) -> Vec<i32> {
+        let to_i32 = |width: u64| width.min(i32::MAX as u64) as i32;
+        let mut owners = self
+            .cells
+            .iter()
+            .map(|cell| to_i32(u64::from(cell.width)))
+            .collect::<Vec<_>>();
+        let col_count = usize::from(self.col_count);
+        if owners.is_empty()
+            || col_count == 0
+            || self.common.treat_as_char
+            || self.common.width == 0
+        {
+            return owners;
+        }
+
+        let explicit_rows = self
+            .local_resize_rows
+            .iter()
+            .copied()
+            .collect::<std::collections::BTreeSet<_>>();
+        let (outlier_rows, inferred_rows) = self.inferred_width_row_roles();
+
+        // Runtime edit metadata is keyed by cell index, not by row/column.
+        // Preserve exact overrides without treating a missing override as zero.
+        for &(cell_index, width) in &self.local_resize_cell_widths {
+            if width > 0
+                && self
+                    .cells
+                    .get(cell_index)
+                    .is_some_and(|cell| explicit_rows.contains(&cell.row))
+            {
+                owners[cell_index] = to_i32(u64::from(width));
+            }
+        }
+
+        // Extract only real single-column evidence. `base_grid_column_widths`
+        // intentionally fills holes from the display grid; that fallback would
+        // make excluded local/outlier data look like a paragraph-frame base.
+        let mut base_tracks = vec![0u32; col_count];
+        for cell in &self.cells {
+            let col = usize::from(cell.col);
+            if cell.row >= self.row_count
+                || cell.col_span != 1
+                || cell.width == 0
+                || col >= col_count
+                || explicit_rows.contains(&cell.row)
+                || outlier_rows.contains(&cell.row)
+            {
+                continue;
+            }
+            base_tracks[col] = base_tracks[col].max(cell.width);
+        }
+        if base_tracks.contains(&0) {
+            return owners;
+        }
+        let base_total = base_tracks.iter().copied().map(u64::from).sum::<u64>();
+        let table_width = u64::from(self.common.width);
+        if table_width > base_total {
+            let residual = (table_width - base_total).min(u64::from(u32::MAX)) as u32;
+            if let Some(last) = base_tracks.last_mut() {
+                *last = last.saturating_add(residual);
+            }
+        }
+
+        let mut rows = vec![Vec::<usize>::new(); usize::from(self.row_count)];
+        for (cell_index, cell) in self.cells.iter().enumerate() {
+            if let Some(row) = rows.get_mut(usize::from(cell.row)) {
+                row.push(cell_index);
+            }
+        }
+        for (row_index, cell_indices) in rows.iter_mut().enumerate() {
+            let row = row_index as u16;
+            if explicit_rows.contains(&row) || inferred_rows.contains(&row) {
+                continue;
+            }
+            cell_indices.sort_by_key(|index| self.cells[*index].col);
+            let mut next_col = 0usize;
+            let mut row_total = 0u64;
+            let mut complete = !cell_indices.is_empty();
+            for &cell_index in cell_indices.iter() {
+                let cell = &self.cells[cell_index];
+                let start = usize::from(cell.col);
+                let Some(end) = start.checked_add(usize::from(cell.col_span)) else {
+                    complete = false;
+                    break;
+                };
+                if cell.row_span != 1
+                    || cell.col_span == 0
+                    || cell.width == 0
+                    || start != next_col
+                    || end > col_count
+                {
+                    complete = false;
+                    break;
+                }
+                row_total = row_total.saturating_add(u64::from(cell.width));
+                next_col = end;
+            }
+            if !complete || next_col != col_count || row_total == table_width {
+                continue;
+            }
+            for &cell_index in cell_indices.iter() {
+                let cell = &self.cells[cell_index];
+                let start = usize::from(cell.col);
+                let end = start + usize::from(cell.col_span);
+                let resolved = base_tracks[start..end]
+                    .iter()
+                    .copied()
+                    .map(u64::from)
+                    .sum::<u64>();
+                owners[cell_index] = to_i32(resolved);
+            }
+        }
+        owners
+    }
+
     /// [Task #1716] 반복 제목행으로 재사용할 **표 상단의 연속 제목행 블록** `0..H` 를 반환한다.
     ///
     /// 행 r 이 제목행 ⟺ header 셀(`is_header`, rowspan 덮개 포함)이 r 을 덮음. 상단(행 0)부터
@@ -450,16 +597,20 @@ impl Table {
         let mut grouped_rows =
             std::collections::BTreeMap::<Vec<(u16, u16)>, Vec<(u16, Vec<u32>)>>::new();
 
-        for row in 0..self.row_count {
+        let mut cells_by_row = vec![Vec::new(); usize::from(self.row_count)];
+        for cell in &self.cells {
+            if cell.row_span == 1 {
+                if let Some(row) = cells_by_row.get_mut(usize::from(cell.row)) {
+                    row.push(cell);
+                }
+            }
+        }
+
+        for (row_index, row_cells) in cells_by_row.iter_mut().enumerate() {
+            let row = row_index as u16;
             if explicit_rows.contains(&row) {
                 continue;
             }
-
-            let mut row_cells = self
-                .cells
-                .iter()
-                .filter(|cell| cell.row == row && cell.row_span == 1)
-                .collect::<Vec<_>>();
             row_cells.sort_by_key(|cell| cell.col);
 
             let mut next_col = 0u16;
@@ -467,7 +618,7 @@ impl Table {
             let mut widths = Vec::new();
             let mut valid = !row_cells.is_empty();
 
-            for cell in row_cells {
+            for cell in row_cells.iter().copied() {
                 let span = cell.col_span.max(1);
                 let end_col = cell.col.saturating_add(span);
                 if cell.col != next_col || end_col <= cell.col || end_col as usize > col_count {

--- a/src/model/table.rs
+++ b/src/model/table.rs
@@ -18,6 +18,13 @@ pub const CELL_FLAG_PROTECT: u16 = 0x0002;
 pub const CELL_FLAG_HEADER: u16 = 0x0004;
 pub const CELL_FLAG_EDITABLE_IN_FORM: u16 = 0x0008;
 
+#[cfg(test)]
+std::thread_local! {
+    static PARAGRAPH_FRAME_OWNER_WIDTHS_CALLS: std::cell::Cell<usize> = const {
+        std::cell::Cell::new(0)
+    };
+}
+
 /// 표 개체 (HWPTAG_TABLE)
 #[derive(Debug, Default, Clone)]
 pub struct Table {
@@ -421,6 +428,16 @@ impl Cell {
 }
 
 impl Table {
+    #[cfg(test)]
+    pub(crate) fn reset_paragraph_frame_owner_widths_calls_for_test() {
+        PARAGRAPH_FRAME_OWNER_WIDTHS_CALLS.with(|calls| calls.set(0));
+    }
+
+    #[cfg(test)]
+    pub(crate) fn paragraph_frame_owner_widths_calls_for_test() -> usize {
+        PARAGRAPH_FRAME_OWNER_WIDTHS_CALLS.with(|calls| calls.get())
+    }
+
     /// Widths owned by cell paragraph frames before padding and paragraph margins.
     ///
     /// Native tables may repeat a row with raw cell widths whose sum is a few
@@ -433,6 +450,9 @@ impl Table {
     /// as a whole, so repeating it once per cell makes large native tables
     /// quadratic and can prevent on-demand reflow from completing.
     pub(crate) fn paragraph_frame_owner_widths(&self) -> Vec<i32> {
+        #[cfg(test)]
+        PARAGRAPH_FRAME_OWNER_WIDTHS_CALLS.with(|calls| calls.set(calls.get() + 1));
+
         let to_i32 = |width: u64| width.min(i32::MAX as u64) as i32;
         let mut owners = self
             .cells

--- a/src/model/table/tests.rs
+++ b/src/model/table/tests.rs
@@ -73,6 +73,32 @@ fn test_cell_new_empty() {
 }
 
 #[test]
+fn paragraph_frame_padding_keeps_all_zero_table_boundary() {
+    let cell = Cell {
+        padding: Padding {
+            left: 141,
+            right: 141,
+            top: 141,
+            bottom: 141,
+        },
+        apply_inner_margin: false,
+        ..Default::default()
+    };
+    let table_padding = Padding::default();
+
+    let frame = cell.paragraph_frame_padding(&table_padding);
+    assert_eq!(
+        (frame.left, frame.right, frame.top, frame.bottom),
+        (0, 0, 0, 0)
+    );
+    let paint = cell.effective_padding(&table_padding);
+    assert_eq!(
+        (paint.left, paint.right, paint.top, paint.bottom),
+        (141, 141, 141, 141)
+    );
+}
+
+#[test]
 fn test_get_column_widths() {
     let table = make_table(2, 3);
     let widths = table.get_column_widths();
@@ -1267,6 +1293,68 @@ fn inferred_local_resize_rows_keeps_serialized_shift_row_matching_common_width()
     table.common.width = 43_190;
 
     assert_eq!(table.inferred_local_resize_rows(), vec![1]);
+}
+
+#[test]
+fn paragraph_frame_owner_width_resolves_a_short_repeated_row_on_the_table_grid() {
+    let cell = |row, col, width| Cell {
+        row,
+        col,
+        row_span: 1,
+        col_span: 1,
+        width,
+        ..Default::default()
+    };
+    let mut table = Table {
+        row_count: 3,
+        col_count: 2,
+        cells: vec![
+            cell(0, 0, 22_393),
+            cell(0, 1, 22_396),
+            cell(1, 0, 22_393),
+            cell(1, 1, 22_393),
+            cell(2, 0, 22_393),
+            cell(2, 1, 22_393),
+        ],
+        ..Default::default()
+    };
+    table.common.width = 44_789;
+
+    assert_eq!(table.paragraph_frame_owner_widths()[2..4], [22_393, 22_396]);
+
+    table.local_resize_rows.push(1);
+    table.local_resize_cell_widths.push((3, 22_400));
+    assert_eq!(table.paragraph_frame_owner_widths()[3], 22_400);
+}
+
+#[test]
+fn paragraph_frame_owner_widths_handles_the_large_document_table_shape_in_one_pass() {
+    const ROWS: u16 = 5_277;
+    const COLS: u16 = 10;
+    let mut cells = Vec::with_capacity(usize::from(ROWS) * usize::from(COLS));
+    for row in 0..ROWS {
+        for col in 0..COLS {
+            cells.push(Cell {
+                row,
+                col,
+                row_span: 1,
+                col_span: 1,
+                width: 1_000,
+                ..Default::default()
+            });
+        }
+    }
+    let mut table = Table {
+        row_count: ROWS,
+        col_count: COLS,
+        cells,
+        ..Default::default()
+    };
+    table.common.width = 10_000;
+
+    let owners = table.paragraph_frame_owner_widths();
+    assert_eq!(owners.len(), 52_770);
+    assert!(owners.iter().all(|width| *width == 1_000));
 }
 
 /// 삽입 지점의 열(행)에 비병합 셀이 하나도 없으면 insert_row / insert_column 의

--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -2905,9 +2905,9 @@ mod line_breaking;
 pub mod lineseg_compare;
 
 pub(crate) use line_breaking::{
-    is_line_end_forbidden, is_line_start_forbidden, paragraph_flow_end, recalculate_section_vpos,
-    reflow_line_segs, reflow_line_segs_after_cell_split, reflow_line_segs_after_cell_text_edit,
-    tokenize_paragraph, BreakToken,
+    is_line_end_forbidden, is_line_start_forbidden, layout_picture_band, paragraph_flow_end,
+    recalculate_section_vpos, reflow_line_segs, reflow_line_segs_after_cell_split,
+    reflow_line_segs_after_cell_text_edit, tokenize_paragraph, BreakToken,
 };
 
 #[cfg(test)]

--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -4,7 +4,7 @@
 //! CharShapeRef 경계에 따라 다중 TextRun으로 분할한다.
 //! 인라인 컨트롤(표/도형) 삽입 위치를 식별한다.
 
-use super::layout::{estimate_text_width, resolved_to_text_style};
+use super::layout::{control_line_seg_index, estimate_text_width, resolved_to_text_style};
 use super::style_resolver::{detect_lang_category, ResolvedStyleSet};
 use super::{hwpunit_to_px, px_to_hwpunit, TextStyle};
 use crate::model::control::Control;
@@ -354,6 +354,34 @@ pub(crate) fn first_text_line(composed: &ComposedParagraph) -> Option<usize> {
             .iter()
             .any(|r| r.text.chars().any(|c| c > '\u{001F}' && c != '\u{FFFC}'))
     })
+}
+
+/// Height of the physical LineSeg that owns a splittable TAC table.
+///
+/// A stored one-row table keeps the ordinary saved-ladder cap because its box
+/// may overlap the following saved row. A current reflow row, or a multi-row
+/// RowBreak table, uses the owning LineSeg as its vertical frame when that row
+/// covers the declared object.
+pub(crate) fn owned_rowbreak_tac_height(para: &Paragraph, control_index: usize) -> Option<i32> {
+    let Control::Table(table) = para.controls.get(control_index)? else {
+        return None;
+    };
+    if !table.common.treat_as_char
+        || !matches!(
+            table.page_break,
+            crate::model::table::TablePageBreak::RowBreak
+        )
+    {
+        return None;
+    }
+    let seg = para
+        .line_segs
+        .get(control_line_seg_index(para, control_index)?)?;
+    let is_current_row = seg.tag & LineSeg::TAG_IMPLEMENTATION_PROPERTY != 0;
+    if table.row_count <= 1 && !is_current_row {
+        return None;
+    }
+    (i64::from(seg.line_height) >= i64::from(table.common.height)).then_some(seg.line_height)
 }
 
 /// 캡션(문단 목록)의 총 높이를 px 로 계산한다.

--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -5,7 +5,7 @@
 
 use super::{find_active_char_shape, is_lang_neutral};
 use crate::model::control::{Control, CTRL_CHAR_CODE_UNITS};
-use crate::model::paragraph::{CharShapeRef, LineSeg, Paragraph};
+use crate::model::paragraph::{CharShapeRef, ColumnBreakType, LineSeg, Paragraph};
 use crate::model::style::LineSpacingType;
 use crate::renderer::layout::{
     estimate_text_width, estimate_text_width_unrounded, is_cjk_char, resolved_to_text_style,
@@ -14,6 +14,16 @@ use crate::renderer::layout::{
 use crate::renderer::layout_frame::{FrameRowMetrics, LayoutFrame, RowSegment};
 use crate::renderer::px_to_hwpunit;
 use crate::renderer::style_resolver::{detect_lang_category, ResolvedStyleSet};
+use std::ops::Range;
+
+/// A complete, source-independent projection of one supported Picture wrap
+/// band. The document layer owns the one-shot publication of every paragraph
+/// in this range.
+#[derive(Debug, Clone)]
+pub(crate) struct PictureBandLayout {
+    pub(crate) paragraph_range: Range<usize>,
+    pub(crate) line_segs: Vec<Vec<LineSeg>>,
+}
 
 /// 줄 나눔 토큰
 #[derive(Debug, Clone)]
@@ -49,6 +59,9 @@ struct FlowInlineControl {
     char_position: usize,
     width_hwp: i32,
     height_hwp: i32,
+    /// Equation supplies an object-owned baseline for the physical row. Other
+    /// inline objects keep the text metrics already selected by the caller.
+    baseline_distance_hwp: Option<i32>,
 }
 
 /// 줄 채움 결과
@@ -1650,13 +1663,39 @@ fn flow_inline_controls(para: &Paragraph) -> Vec<FlowInlineControl> {
                 return None;
             }
             let (width_hwp, height_hwp) = inline_control_size_hwp(control)?;
+            let baseline_distance_hwp = match control {
+                Control::Equation(equation) if equation.baseline > 0 => Some(
+                    height_hwp
+                        .saturating_mul(i32::from(equation.baseline))
+                        .saturating_div(100),
+                ),
+                _ => None,
+            };
             (char_position < text_len).then_some(FlowInlineControl {
                 char_position,
                 width_hwp,
                 height_hwp,
+                baseline_distance_hwp,
             })
         })
         .collect()
+}
+
+/// The picture-band frame intentionally admits only its floating host and the
+/// already-supported treat-as-character Equation flow. Other controls have
+/// their own layout owners and must leave this transaction untouched.
+fn supports_picture_band_frame_controls(para: &Paragraph) -> bool {
+    let mut non_tac_pictures = 0usize;
+    for control in &para.controls {
+        match control {
+            Control::Picture(picture) if !picture.common.treat_as_char => {
+                non_tac_pictures += 1;
+            }
+            Control::Equation(equation) if equation.common.treat_as_char => {}
+            _ => return false,
+        }
+    }
+    non_tac_pictures <= 1
 }
 
 /// 본문 뒤 남은 폭에 놓이지 않는 inline control은 별도 physical line을 가진다.
@@ -1763,6 +1802,14 @@ fn apply_inline_control_line_height(seg: &mut LineSeg, height_hwp: i32) {
     }
 }
 
+fn apply_inline_control_frame_height(metrics: &mut FrameRowMetrics, height_hwp: i32) {
+    if height_hwp > metrics.line_height {
+        metrics.line_height = height_hwp;
+        metrics.text_height = height_hwp;
+        metrics.baseline_distance = (height_hwp as f64 * 0.85).round() as i32;
+    }
+}
+
 fn frame_metrics_for_line(
     max_font_size: f64,
     fallback_font_size: f64,
@@ -1790,20 +1837,19 @@ fn frame_metrics_for_line(
     }
 }
 
-/// Lay out a scalar paragraph through a caller-owned physical frame.
+/// Lay out the small scalar/Picture-band paragraph subset through a
+/// caller-owned physical frame.
 ///
 /// Every interval returned by one carve belongs to the same physical row. The
 /// cursor continues from left to right and the frame does not advance until
-/// that complete row has been committed. This helper deliberately has no
-/// document or picture-band caller yet; it is the reflow boundary between the
-/// cursor and `LayoutFrame`.
+/// that complete row has been committed.
 pub(crate) fn layout_paragraph_in_frame(
     para: &Paragraph,
     frame: &mut LayoutFrame,
     styles: &ResolvedStyleSet,
     dpi: f64,
 ) -> Option<Vec<LineSeg>> {
-    if para.text.is_empty() || !para.controls.is_empty() {
+    if !supports_picture_band_frame_controls(para) {
         return None;
     }
 
@@ -1824,6 +1870,10 @@ pub(crate) fn layout_paragraph_in_frame(
         .map(|style| style.line_spacing_type)
         .unwrap_or(LineSpacingType::Percent);
     let line_spacing_value = para_style.map(|style| style.line_spacing).unwrap_or(160.0);
+    // Keep Equation width and height ownership with the current scalar
+    // `FlowInlineControl` path. A non-TAC Picture deliberately contributes no
+    // inline token: it is represented by the caller's exclusion instead.
+    let inline_controls = flow_inline_controls(para);
     let tokens = tokenize_paragraph_with_split_cell_space_metric(
         &text_chars,
         &para.char_offsets,
@@ -1832,12 +1882,46 @@ pub(crate) fn layout_paragraph_in_frame(
         english_break_unit,
         korean_break_unit,
         false,
-        &[],
+        &inline_controls,
     );
-    // Keep the existing scalar fallback for a terminal empty line after a
-    // forced break. The active character shape is deliberately not consulted
-    // here because the pre-frame reflow uses a fixed 12px fallback.
-    let fallback_font_size = 12.0;
+    let fallback_font_size = if para.text.is_empty() {
+        para.char_shapes
+            .first()
+            .and_then(|char_shape| styles.char_styles.get(char_shape.char_shape_id as usize))
+            .map(|style| style.font_size)
+            .unwrap_or(12.0)
+    } else {
+        12.0
+    };
+    // This matches the scalar path's terminal-control behavior: controls not
+    // admitted to `FlowInlineControl` because they sit after the last visible
+    // character enlarge the first line box without inventing a second width
+    // accounting path.
+    let terminal_inline_metrics = inline_controls
+        .is_empty()
+        .then(|| {
+            let height_hwp = inline_control_line_height_hwp(para)?;
+            let baseline_distance_hwp = para
+                .controls
+                .iter()
+                .filter_map(|control| match control {
+                    Control::Equation(equation)
+                        if equation.common.treat_as_char
+                            && equation.common.height as i32 == height_hwp
+                            && equation.baseline > 0 =>
+                    {
+                        Some(
+                            height_hwp
+                                .saturating_mul(i32::from(equation.baseline))
+                                .saturating_div(100),
+                        )
+                    }
+                    _ => None,
+                })
+                .max();
+            Some((height_hwp, baseline_distance_hwp))
+        })
+        .flatten();
     let source_tag = para
         .line_segs
         .first()
@@ -1883,6 +1967,9 @@ pub(crate) fn layout_paragraph_in_frame(
 
                 let mut segments = Vec::with_capacity(intervals.len());
                 let mut maximum_font_size = 0.0f64;
+                let mut inline_metrics = (frame.row_count() == first_row)
+                    .then_some(terminal_inline_metrics)
+                    .flatten();
                 let mut row_terminated = false;
                 for interval in intervals {
                     let available_width_px = crate::renderer::hwpunit_to_px(
@@ -1901,6 +1988,28 @@ pub(crate) fn layout_paragraph_in_frame(
                     )?;
                     let line = &filled.line;
                     maximum_font_size = maximum_font_size.max(line.max_font_size);
+                    for control in inline_controls.iter().filter(|control| {
+                        (line.start_idx..line.end_idx).contains(&control.char_position)
+                            || (line.end_idx == text_chars.len()
+                                && control.char_position == text_chars.len())
+                    }) {
+                        inline_metrics = match inline_metrics {
+                            Some((height_hwp, baseline_distance_hwp))
+                                if height_hwp > control.height_hwp =>
+                            {
+                                Some((height_hwp, baseline_distance_hwp))
+                            }
+                            Some((height_hwp, baseline_distance_hwp))
+                                if height_hwp == control.height_hwp =>
+                            {
+                                Some((
+                                    height_hwp,
+                                    baseline_distance_hwp.max(control.baseline_distance_hwp),
+                                ))
+                            }
+                            _ => Some((control.height_hwp, control.baseline_distance_hwp)),
+                        };
+                    }
                     let text_start = if frame.row_count() == first_row && segments.is_empty() {
                         0
                     } else {
@@ -1915,13 +2024,22 @@ pub(crate) fn layout_paragraph_in_frame(
                     }
                 }
 
-                let metrics = frame_metrics_for_line(
+                let mut metrics = frame_metrics_for_line(
                     maximum_font_size,
                     fallback_font_size,
                     line_spacing_type,
                     line_spacing_value,
                     dpi,
                 );
+                if let Some((height_hwp, baseline_distance_hwp)) = inline_metrics {
+                    let inline_owns_row_height = height_hwp > metrics.line_height;
+                    apply_inline_control_frame_height(&mut metrics, height_hwp);
+                    if inline_owns_row_height {
+                        if let Some(baseline_distance_hwp) = baseline_distance_hwp {
+                            metrics.baseline_distance = baseline_distance_hwp;
+                        }
+                    }
+                }
                 if metrics.line_height != candidate_height {
                     candidate_height = metrics.line_height;
                     continue;
@@ -1952,6 +2070,129 @@ pub(crate) fn layout_paragraph_in_frame(
         frame.restore_checkpoint(frame_checkpoint);
     }
     result
+}
+
+/// This mirrors `float_placement::horizontal_range`'s `HorzRelTo::Para`
+/// rule: the host's left paragraph margin shifts the object reference, but
+/// the right text margin does not shrink it.
+fn picture_band_paragraph_reference(
+    column_horizontal: &Range<i32>,
+    host_margin_left: i32,
+) -> Option<Range<i32>> {
+    let start = column_horizontal.start.saturating_add(host_margin_left);
+    (start < column_horizontal.end).then_some(start..column_horizontal.end)
+}
+
+/// Lay out one proven non-TAC Picture/Square band without reading stored
+/// `LineSeg` geometry. One `LayoutFrame` remains live from the Picture's
+/// source anchor through the first full-width paragraph boundary.
+///
+/// This is intentionally a fail-closed transaction. It accepts one host
+/// Picture, treats only TAC Equations as inline flow, and rejects any
+/// paragraph boundary that would require another layout owner.
+pub(crate) fn layout_picture_band(
+    paragraphs: &[Paragraph],
+    host_index: usize,
+    column_width_hwp: i32,
+    styles: &ResolvedStyleSet,
+    dpi: f64,
+) -> Option<PictureBandLayout> {
+    let host = paragraphs.get(host_index)?;
+    let column_horizontal = 0..column_width_hwp;
+    let margins_for = |paragraph: &Paragraph| {
+        let style = styles.para_styles.get(paragraph.para_shape_id as usize);
+        (
+            px_to_hwpunit(style.map(|value| value.margin_left).unwrap_or(0.0), dpi),
+            px_to_hwpunit(style.map(|value| value.margin_right).unwrap_or(0.0), dpi),
+        )
+    };
+    let horizontal_for = |paragraph: &Paragraph| {
+        let (margin_left, margin_right) = margins_for(paragraph);
+        let start = column_horizontal.start.saturating_add(margin_left);
+        let end = column_horizontal.end.saturating_sub(margin_right);
+        (start < end).then_some(start..end)
+    };
+    let host_horizontal = horizontal_for(host)?;
+    let (host_margin_left, _) = margins_for(host);
+    let host_paragraph_horizontal =
+        picture_band_paragraph_reference(&column_horizontal, host_margin_left)?;
+
+    let mut host_pictures = host
+        .controls
+        .iter()
+        .enumerate()
+        .filter_map(|(index, control)| match control {
+            Control::Picture(picture) if !picture.common.treat_as_char => {
+                Some((index, picture.as_ref()))
+            }
+            _ => None,
+        });
+    let (picture_control_index, picture) = host_pictures.next()?;
+    if host_pictures.next().is_some() {
+        return None;
+    }
+
+    // A paragraph-relative Picture starts at its control's raw UTF-16 stream
+    // position, not necessarily at the first visible character. Lay out a
+    // clean, full-width host first so the anchor row has no stored-LineSeg
+    // dependency.
+    let picture_raw_start = host
+        .control_utf16_positions()
+        .get(picture_control_index)
+        .copied()?;
+    let mut anchor_input = host.clone();
+    anchor_input.line_segs.clear();
+    let mut anchor_frame = LayoutFrame::new(host_horizontal.clone(), 0, Vec::new());
+    let anchor_rows = layout_paragraph_in_frame(&anchor_input, &mut anchor_frame, styles, dpi)?;
+    let anchor_top = anchor_rows
+        .iter()
+        .rfind(|row| row.text_start <= picture_raw_start)
+        .map(|row| row.vertical_pos)?;
+
+    let exclusion = crate::renderer::float_placement::resolve_picture_exclusion(
+        picture,
+        column_horizontal.clone(),
+        host_paragraph_horizontal,
+        anchor_top,
+    )?;
+    let exclusion_end = exclusion.vertical.end;
+    let mut frame = LayoutFrame::new(host_horizontal.clone(), 0, vec![exclusion]);
+    let mut line_segs = Vec::new();
+
+    for (paragraph_index, paragraph) in paragraphs.iter().enumerate().skip(host_index) {
+        if frame.top >= exclusion_end {
+            break;
+        }
+
+        let paragraph_style = styles.para_styles.get(paragraph.para_shape_id as usize);
+        if paragraph.column_type != ColumnBreakType::None
+            || paragraph_style.is_some_and(|style| {
+                style.spacing_before.abs() > f64::EPSILON
+                    || style.spacing_after.abs() > f64::EPSILON
+                    || style.page_break_before
+            })
+            || horizontal_for(paragraph)? != host_horizontal
+            || (paragraph_index != host_index
+                && paragraph.controls.iter().any(|control| {
+                    matches!(control, Control::Picture(picture) if !picture.common.treat_as_char)
+                }))
+        {
+            return None;
+        }
+
+        let mut input = paragraph.clone();
+        // Clones carry only source content. A failed band leaves every cached
+        // LineSeg exactly as it was; only the finished projection is published
+        // by the document owner.
+        input.line_segs.clear();
+        let paragraph_lines = layout_paragraph_in_frame(&input, &mut frame, styles, dpi)?;
+        line_segs.push(paragraph_lines);
+    }
+
+    (!line_segs.is_empty() && frame.top >= exclusion_end).then_some(PictureBandLayout {
+        paragraph_range: host_index..host_index + line_segs.len(),
+        line_segs,
+    })
 }
 
 /// 문단의 line_segs를 텍스트 내용과 컬럼 너비에 맞게 재계산한다.
@@ -2258,6 +2499,7 @@ fn reflow_line_segs_impl(
     // inline controls retain their established specialized paths below.
     let frame_eligible = !split_stale_cell_reflow
         && preserve_prefix_for_edit.is_none()
+        && !para.text.is_empty()
         && para.controls.is_empty()
         && preserved_prefix.is_empty();
     if frame_eligible {
@@ -2797,7 +3039,7 @@ mod fill_cursor_tests {
 #[cfg(test)]
 mod frame_reflow_tests {
     use super::*;
-    use crate::renderer::layout_frame::FrameExclusion;
+    use crate::renderer::layout_frame::{FrameExclusion, FrameExclusionPolicy};
     use crate::renderer::style_resolver::{ResolvedCharStyle, ResolvedParaStyle};
 
     fn styles(font_sizes: &[f64]) -> ResolvedStyleSet {
@@ -2973,6 +3215,7 @@ mod frame_reflow_tests {
             vec![FrameExclusion {
                 horizontal: 3_000..5_000,
                 vertical: 0..10_000,
+                policy: FrameExclusionPolicy::BothSides,
             }],
         );
 
@@ -3022,6 +3265,7 @@ mod frame_reflow_tests {
             vec![FrameExclusion {
                 horizontal: 4_000..5_000,
                 vertical: 1_000..5_000,
+                policy: FrameExclusionPolicy::BothSides,
             }],
         );
 
@@ -3077,6 +3321,233 @@ mod frame_reflow_tests {
             .iter()
             .all(|line| line.segment_width == 3_750 && line.column_start == 0));
         assert_eq!(para.line_segs[0].vertical_pos, 321);
+    }
+
+    #[test]
+    fn picture_band_uses_para_reference_not_text_frame_for_right_aligned_picture() {
+        use crate::model::image::Picture;
+        use crate::model::shape::{HorzAlign, HorzRelTo, TextFlow, TextWrap, VertAlign, VertRelTo};
+
+        const DPI: f64 = 96.0;
+        const COLUMN_WIDTH: i32 = 15_000;
+        const MARGIN_LEFT: i32 = 1_500;
+        const MARGIN_RIGHT: i32 = 3_000;
+        const PICTURE_WIDTH: u32 = 3_000;
+
+        let mut styles = styles(&[12.0]);
+        styles.para_styles[0].margin_left = crate::renderer::hwpunit_to_px(MARGIN_LEFT, DPI);
+        styles.para_styles[0].margin_right = crate::renderer::hwpunit_to_px(MARGIN_RIGHT, DPI);
+        let text_frame = MARGIN_LEFT..COLUMN_WIDTH - MARGIN_RIGHT;
+        let paragraph_reference = picture_band_paragraph_reference(&(0..COLUMN_WIDTH), MARGIN_LEFT)
+            .expect("host left margin leaves a usable Paragraph reference");
+        assert_eq!(paragraph_reference, MARGIN_LEFT..COLUMN_WIDTH);
+        assert_ne!(text_frame, paragraph_reference);
+
+        let picture = Picture {
+            common: crate::model::shape::CommonObjAttr {
+                width: PICTURE_WIDTH,
+                height: 600,
+                text_wrap: TextWrap::Square,
+                text_flow: TextFlow::BothSides,
+                vert_rel_to: VertRelTo::Para,
+                vert_align: VertAlign::Top,
+                horz_rel_to: HorzRelTo::Para,
+                horz_align: HorzAlign::Right,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let expected_exclusion = crate::renderer::float_placement::resolve_picture_exclusion(
+            &picture,
+            0..COLUMN_WIDTH,
+            paragraph_reference.clone(),
+            0,
+        )
+        .expect("supported Paragraph-relative Picture");
+        assert_eq!(expected_exclusion.horizontal, 12_000..15_000);
+
+        let mut host = paragraph(
+            "x",
+            vec![CharShapeRef {
+                start_pos: 0,
+                char_shape_id: 0,
+            }],
+        );
+        host.controls.push(Control::Picture(Box::new(picture)));
+
+        let band = layout_picture_band(&[host], 0, COLUMN_WIDTH, &styles, DPI)
+            .expect("the one-row Paragraph-relative Picture band");
+
+        assert_eq!(band.paragraph_range, 0..1);
+        assert_eq!(band.line_segs[0].len(), 1);
+        assert_eq!(band.line_segs[0][0].column_start, text_frame.start);
+        assert_eq!(
+            band.line_segs[0][0].segment_width,
+            text_frame.end - text_frame.start,
+            "the right-aligned Para exclusion begins at the text frame's end"
+        );
+    }
+
+    #[test]
+    fn real_p325_picture_band_matches_the_stored_seven_paragraph_geometry() {
+        use crate::model::page::ColumnDef;
+        use crate::renderer::page_layout::PageLayoutInfo;
+
+        const DPI: f64 = 96.0;
+        let bytes = std::fs::read(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("samples/3-09월_교육_통합_2022.hwp"),
+        )
+        .expect("p325 corpus fixture");
+        let document = crate::parse_document(&bytes).expect("parse p325 corpus fixture");
+        let section = &document.sections[0];
+        let column_def = section.paragraphs[..=325]
+            .iter()
+            .flat_map(|paragraph| &paragraph.controls)
+            .filter_map(|control| match control {
+                Control::ColumnDef(column) => Some(column.clone()),
+                _ => None,
+            })
+            .next_back()
+            .unwrap_or_else(ColumnDef::default);
+        let page_layout =
+            PageLayoutInfo::from_page_def(&section.section_def.page_def, &column_def, DPI);
+        let column_width = crate::renderer::px_to_hwpunit(page_layout.column_areas[0].width, DPI);
+        let styles = crate::renderer::style_resolver::resolve_styles(&document.doc_info, DPI);
+
+        let band = layout_picture_band(&section.paragraphs, 325, column_width, &styles, DPI)
+            .expect("one Picture + trailing TAC Equation p325 band");
+
+        assert_eq!(band.paragraph_range, 325..332);
+        assert_eq!(band.line_segs.len(), 7);
+        for (paragraph_index, generated) in band.paragraph_range.clone().zip(&band.line_segs) {
+            let stored = &section.paragraphs[paragraph_index].line_segs;
+            assert_eq!(generated.len(), 1, "p{paragraph_index}");
+            assert_eq!(
+                generated[0].text_start, stored[0].text_start,
+                "p{paragraph_index}"
+            );
+            assert_eq!(
+                generated[0].column_start, stored[0].column_start,
+                "p{paragraph_index}"
+            );
+            assert_eq!(
+                generated[0].segment_width, stored[0].segment_width,
+                "p{paragraph_index}"
+            );
+            assert!(
+                generated[0].line_height.abs_diff(stored[0].line_height) <= 1,
+                "p{paragraph_index}"
+            );
+            assert!(
+                generated[0].text_height.abs_diff(stored[0].text_height) <= 1,
+                "p{paragraph_index}"
+            );
+            assert!(
+                generated[0]
+                    .baseline_distance
+                    .abs_diff(stored[0].baseline_distance)
+                    <= 1,
+                "p{paragraph_index}: generated={} stored={}",
+                generated[0].baseline_distance,
+                stored[0].baseline_distance,
+            );
+            assert!(
+                generated[0].line_spacing.abs_diff(stored[0].line_spacing) <= 3,
+                "p{paragraph_index}"
+            );
+        }
+        assert!(
+            band.line_segs[0][0].line_height > 900,
+            "the host's trailing TAC Equation must enlarge the retried first row"
+        );
+        assert_eq!(
+            band.line_segs[0][0].baseline_distance,
+            section.paragraphs[325].line_segs[0].baseline_distance,
+            "p325 retains the TAC Equation's object-owned baseline"
+        );
+        assert_ne!(
+            band.line_segs.last().expect("band tail")[0].segment_width,
+            section.paragraphs[332].line_segs[0].segment_width,
+            "p332 is the first full-width paragraph after the exclusion"
+        );
+    }
+
+    #[test]
+    fn picture_band_rejects_a_truncated_p325_before_any_projection() {
+        use crate::model::page::ColumnDef;
+        use crate::renderer::page_layout::PageLayoutInfo;
+
+        const DPI: f64 = 96.0;
+        let bytes = std::fs::read(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("samples/3-09월_교육_통합_2022.hwp"),
+        )
+        .expect("p325 corpus fixture");
+        let document = crate::parse_document(&bytes).expect("parse p325 corpus fixture");
+        let section = &document.sections[0];
+        let column_def = section.paragraphs[..=325]
+            .iter()
+            .flat_map(|paragraph| &paragraph.controls)
+            .filter_map(|control| match control {
+                Control::ColumnDef(column) => Some(column.clone()),
+                _ => None,
+            })
+            .next_back()
+            .unwrap_or_else(ColumnDef::default);
+        let page_layout =
+            PageLayoutInfo::from_page_def(&section.section_def.page_def, &column_def, DPI);
+        let column_width = crate::renderer::px_to_hwpunit(page_layout.column_areas[0].width, DPI);
+        let styles = crate::renderer::style_resolver::resolve_styles(&document.doc_info, DPI);
+
+        assert!(
+            layout_picture_band(&section.paragraphs[325..329], 0, column_width, &styles, DPI)
+                .is_none(),
+            "a subset ending before the exclusion clears cannot be published"
+        );
+    }
+
+    #[test]
+    fn pic2_two_picture_host_is_explicitly_outside_the_one_picture_band_contract() {
+        use crate::model::page::ColumnDef;
+        use crate::renderer::page_layout::PageLayoutInfo;
+
+        const DPI: f64 = 96.0;
+        let bytes = std::fs::read(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("samples/pic2.hwp"),
+        )
+        .expect("pic2 fixture");
+        let document = crate::parse_document(&bytes).expect("parse pic2 fixture");
+        let section = &document.sections[0];
+        let column_def = section.paragraphs[..=0]
+            .iter()
+            .flat_map(|paragraph| &paragraph.controls)
+            .filter_map(|control| match control {
+                Control::ColumnDef(column) => Some(column.clone()),
+                _ => None,
+            })
+            .next_back()
+            .unwrap_or_else(ColumnDef::default);
+        let page_layout =
+            PageLayoutInfo::from_page_def(&section.section_def.page_def, &column_def, DPI);
+        let column_width = crate::renderer::px_to_hwpunit(page_layout.column_areas[0].width, DPI);
+        let styles = crate::renderer::style_resolver::resolve_styles(&document.doc_info, DPI);
+
+        assert_eq!(
+            section.paragraphs[0]
+                .controls
+                .iter()
+                .filter(|control| {
+                    matches!(control, Control::Picture(picture) if !picture.common.treat_as_char)
+                })
+                .count(),
+            2,
+            "fixture premise: pic2's first paragraph has two floating pictures"
+        );
+        assert!(
+            layout_picture_band(&section.paragraphs, 0, column_width, &styles, DPI).is_none(),
+            "two floating pictures are deliberately not a one-picture band"
+        );
     }
 }
 

--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -11,6 +11,7 @@ use crate::renderer::layout::{
     estimate_text_width, estimate_text_width_unrounded, is_cjk_char, resolved_to_text_style,
     stale_split_hanyang_shinmyeongjo_space_width,
 };
+use crate::renderer::layout_frame::{FrameRowMetrics, LayoutFrame, RowSegment};
 use crate::renderer::px_to_hwpunit;
 use crate::renderer::style_resolver::{detect_lang_category, ResolvedStyleSet};
 
@@ -57,6 +58,25 @@ struct LineBreakResult {
     end_idx: usize, // exclusive
     max_font_size: f64,
     has_line_break: bool, // 강제 줄 바꿈 여부
+}
+
+/// Why one carved interval stopped receiving text.
+///
+/// A false `has_line_break` alone is ambiguous: a segment can stop because it
+/// reached its interval, or because it finished the paragraph. Frame layout
+/// needs the distinction to decide whether the next horizontal interval is
+/// part of the same physical row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FillTermination {
+    IntervalFull,
+    ForcedBreak,
+    ParagraphEnd,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct FilledInterval {
+    line: LineBreakResult,
+    termination: FillTermination,
 }
 
 /// 줄 머리 금칙: 줄 시작에 올 수 없는 문자
@@ -806,7 +826,7 @@ fn fill_lines(
     let mut cursor = FillCursor::new(initial_start_idx, initial_is_first_line);
     let mut results = Vec::new();
 
-    while let Some(line) = fill_one_interval(
+    while let Some(interval) = fill_one_interval(
         tokens,
         text_chars,
         available_width_px,
@@ -816,7 +836,7 @@ fn fill_lines(
         condense_min_space,
         &mut cursor,
     ) {
-        results.push(line);
+        results.push(interval.line);
     }
 
     results
@@ -832,7 +852,7 @@ fn fill_one_interval(
     korean_break_unit: u8,
     condense_min_space: u8,
     cursor: &mut FillCursor,
-) -> Option<LineBreakResult> {
+) -> Option<FilledInterval> {
     if cursor.finished {
         return None;
     }
@@ -840,11 +860,14 @@ fn fill_one_interval(
     if tokens.is_empty() {
         cursor.finished = true;
         cursor.emitted_any = true;
-        return Some(LineBreakResult {
-            start_idx: cursor.initial_start_idx,
-            end_idx: cursor.initial_start_idx,
-            max_font_size: 0.0,
-            has_line_break: false,
+        return Some(FilledInterval {
+            line: LineBreakResult {
+                start_idx: cursor.initial_start_idx,
+                end_idx: cursor.initial_start_idx,
+                max_font_size: 0.0,
+                has_line_break: false,
+            },
+            termination: FillTermination::ParagraphEnd,
         });
     }
 
@@ -886,21 +909,27 @@ fn fill_one_interval(
 
             if cursor.line_start_idx <= last_end {
                 cursor.emitted_any = true;
-                return Some(LineBreakResult {
-                    start_idx: cursor.line_start_idx,
-                    end_idx: last_end,
-                    max_font_size: cursor.line_max_fs,
-                    has_line_break: false,
+                return Some(FilledInterval {
+                    line: LineBreakResult {
+                        start_idx: cursor.line_start_idx,
+                        end_idx: last_end,
+                        max_font_size: cursor.line_max_fs,
+                        has_line_break: false,
+                    },
+                    termination: FillTermination::ParagraphEnd,
                 });
             }
 
             if !cursor.emitted_any {
                 cursor.emitted_any = true;
-                return Some(LineBreakResult {
-                    start_idx: cursor.initial_start_idx,
-                    end_idx: text_chars.len(),
-                    max_font_size: 0.0,
-                    has_line_break: false,
+                return Some(FilledInterval {
+                    line: LineBreakResult {
+                        start_idx: cursor.initial_start_idx,
+                        end_idx: text_chars.len(),
+                        max_font_size: 0.0,
+                        has_line_break: false,
+                    },
+                    termination: FillTermination::ParagraphEnd,
                 });
             }
             return None;
@@ -923,7 +952,10 @@ fn fill_one_interval(
                 cursor.last_break_token_idx = None;
                 cursor.token_index += 1;
                 cursor.emitted_any = true;
-                return Some(result);
+                return Some(FilledInterval {
+                    line: result,
+                    termination: FillTermination::ForcedBreak,
+                });
             }
             BreakToken::Tab { idx, max_font_size } => {
                 // 탭 계산은 px로 수행 후 HWPUNIT 변환 (정밀도 유지)
@@ -966,7 +998,10 @@ fn fill_one_interval(
                     cursor.lw = to_hwp(next_tab2);
                     cursor.token_index += 1;
                     cursor.emitted_any = true;
-                    return Some(result);
+                    return Some(FilledInterval {
+                        line: result,
+                        termination: FillTermination::IntervalFull,
+                    });
                 }
 
                 cursor.last_break_token_idx = Some(ti);
@@ -1033,7 +1068,10 @@ fn fill_one_interval(
                             cursor.is_first_line = false;
                             cursor.fallback_char_idx = Some(ci + 1);
                             cursor.emitted_any = true;
-                            return Some(result);
+                            return Some(FilledInterval {
+                                line: result,
+                                termination: FillTermination::IntervalFull,
+                            });
                         }
                         cursor.lw += char_w;
                         ci += 1;
@@ -1111,7 +1149,10 @@ fn fill_one_interval(
                                 cursor.lw += w_hwp;
                                 cursor.token_index += 1;
                                 cursor.emitted_any = true;
-                                return Some(result);
+                                return Some(FilledInterval {
+                                    line: result,
+                                    termination: FillTermination::IntervalFull,
+                                });
                             }
 
                             // [#3822] 이전 break 뒤로 옮긴 현재 토큰이 새 줄에도
@@ -1128,14 +1169,20 @@ fn fill_one_interval(
                                 cursor.lw += w_hwp;
                                 cursor.token_index += 1;
                                 cursor.emitted_any = true;
-                                return Some(result);
+                                return Some(FilledInterval {
+                                    line: result,
+                                    termination: FillTermination::IntervalFull,
+                                });
                             }
 
                             cursor.line_space_savings = 0;
                             cursor.last_break_token_idx = None;
                             cursor.fallback_char_idx = Some(*start_idx);
                             cursor.emitted_any = true;
-                            return Some(result);
+                            return Some(FilledInterval {
+                                line: result,
+                                termination: FillTermination::IntervalFull,
+                            });
                         }
                     }
 
@@ -1716,6 +1763,197 @@ fn apply_inline_control_line_height(seg: &mut LineSeg, height_hwp: i32) {
     }
 }
 
+fn frame_metrics_for_line(
+    max_font_size: f64,
+    fallback_font_size: f64,
+    line_spacing_type: LineSpacingType,
+    line_spacing_value: f64,
+    dpi: f64,
+) -> FrameRowMetrics {
+    let font_size = if max_font_size > 0.0 {
+        max_font_size
+    } else {
+        fallback_font_size
+    };
+    let line_height = font_size_to_line_height(font_size, dpi).max(1);
+    FrameRowMetrics {
+        vertical_pos: 0,
+        line_height,
+        text_height: line_height,
+        baseline_distance: (line_height as f64 * 0.85) as i32,
+        line_spacing: compute_line_spacing_hwp(
+            line_spacing_type,
+            line_spacing_value,
+            line_height,
+            dpi,
+        ),
+    }
+}
+
+/// Lay out a scalar paragraph through a caller-owned physical frame.
+///
+/// Every interval returned by one carve belongs to the same physical row. The
+/// cursor continues from left to right and the frame does not advance until
+/// that complete row has been committed. This helper deliberately has no
+/// document or picture-band caller yet; it is the reflow boundary between the
+/// cursor and `LayoutFrame`.
+pub(crate) fn layout_paragraph_in_frame(
+    para: &Paragraph,
+    frame: &mut LayoutFrame,
+    styles: &ResolvedStyleSet,
+    dpi: f64,
+) -> Option<Vec<LineSeg>> {
+    if para.text.is_empty() || !para.controls.is_empty() {
+        return None;
+    }
+
+    let text_chars = para.text.chars().collect::<Vec<_>>();
+    let para_style = styles.para_styles.get(para.para_shape_id as usize);
+    let indent_px = para_style.map(|style| style.indent).unwrap_or(0.0);
+    let english_break_unit = para_style
+        .map(|style| style.english_break_unit)
+        .unwrap_or(0);
+    let korean_break_unit = para_style.map(|style| style.korean_break_unit).unwrap_or(0);
+    let condense_min_space = para_style
+        .map(|style| style.condense_min_space)
+        .unwrap_or(0);
+    let default_tab_width = para_style
+        .map(|style| style.default_tab_width)
+        .unwrap_or(0.0);
+    let line_spacing_type = para_style
+        .map(|style| style.line_spacing_type)
+        .unwrap_or(LineSpacingType::Percent);
+    let line_spacing_value = para_style.map(|style| style.line_spacing).unwrap_or(160.0);
+    let tokens = tokenize_paragraph_with_split_cell_space_metric(
+        &text_chars,
+        &para.char_offsets,
+        &para.char_shapes,
+        styles,
+        english_break_unit,
+        korean_break_unit,
+        false,
+        &[],
+    );
+    // Keep the existing scalar fallback for a terminal empty line after a
+    // forced break. The active character shape is deliberately not consulted
+    // here because the pre-frame reflow uses a fixed 12px fallback.
+    let fallback_font_size = 12.0;
+    let source_tag = para
+        .line_segs
+        .first()
+        .map(|segment| segment.tag)
+        .unwrap_or(LineSeg::TAG_IMPLEMENTATION_PROPERTY | LineSeg::TAG_SINGLE_SEGMENT_LINE);
+    let first_row = frame.row_count();
+    let frame_checkpoint = frame.clone();
+    let mut cursor = FillCursor::new(0, true);
+
+    let result = (|| {
+        while !cursor.finished {
+            let row_frame_checkpoint = frame.clone();
+            let cursor_checkpoint = cursor.clone();
+            let mut candidate_height = frame_metrics_for_line(
+                fallback_font_size,
+                fallback_font_size,
+                line_spacing_type,
+                line_spacing_value,
+                dpi,
+            )
+            .line_height;
+            const MAX_ROW_HEIGHT_TRIALS: usize = 8;
+            let mut attempted_trials = Vec::with_capacity(MAX_ROW_HEIGHT_TRIALS);
+
+            loop {
+                frame.restore_checkpoint(row_frame_checkpoint.clone());
+                cursor = cursor_checkpoint.clone();
+                let intervals = frame.carve(candidate_height).to_vec();
+                if intervals.is_empty()
+                    || intervals
+                        .iter()
+                        .any(|interval| interval.start >= interval.end)
+                {
+                    return None;
+                }
+                let trial = (frame.top, candidate_height, intervals.clone());
+                if attempted_trials.contains(&trial)
+                    || attempted_trials.len() == MAX_ROW_HEIGHT_TRIALS
+                {
+                    return None;
+                }
+                attempted_trials.push(trial);
+
+                let mut segments = Vec::with_capacity(intervals.len());
+                let mut maximum_font_size = 0.0f64;
+                let mut row_terminated = false;
+                for interval in intervals {
+                    let available_width_px = crate::renderer::hwpunit_to_px(
+                        interval.end.saturating_sub(interval.start),
+                        dpi,
+                    );
+                    let filled = fill_one_interval(
+                        &tokens,
+                        &text_chars,
+                        available_width_px,
+                        indent_px,
+                        default_tab_width,
+                        korean_break_unit,
+                        condense_min_space,
+                        &mut cursor,
+                    )?;
+                    let line = &filled.line;
+                    maximum_font_size = maximum_font_size.max(line.max_font_size);
+                    let text_start = if frame.row_count() == first_row && segments.is_empty() {
+                        0
+                    } else {
+                        char_index_to_utf16_offset(para, line.start_idx)
+                    };
+                    let text_end = char_index_to_utf16_offset(para, line.end_idx).max(text_start);
+                    segments.push(RowSegment::new(text_start..text_end, interval, source_tag));
+
+                    if filled.termination != FillTermination::IntervalFull {
+                        row_terminated = true;
+                        break;
+                    }
+                }
+
+                let metrics = frame_metrics_for_line(
+                    maximum_font_size,
+                    fallback_font_size,
+                    line_spacing_type,
+                    line_spacing_value,
+                    dpi,
+                );
+                if metrics.line_height != candidate_height {
+                    candidate_height = metrics.line_height;
+                    continue;
+                }
+
+                if row_terminated && segments.len() < frame.current_intervals.len() {
+                    let text_start = segments
+                        .last()
+                        .map(|segment| segment.text_range.end)
+                        .unwrap_or(0);
+                    for interval in frame.current_intervals[segments.len()..].iter().cloned() {
+                        segments.push(RowSegment::new(
+                            text_start..text_start,
+                            interval,
+                            source_tag | LineSeg::TAG_EMPTY_SEGMENT,
+                        ));
+                    }
+                }
+
+                frame.commit_carved_row(metrics, segments)?;
+                break;
+            }
+        }
+        Some(frame.project_line_segs_since(first_row))
+    })();
+
+    if result.is_none() {
+        frame.restore_checkpoint(frame_checkpoint);
+    }
+    result
+}
+
 /// 문단의 line_segs를 텍스트 내용과 컬럼 너비에 맞게 재계산한다.
 ///
 /// 텍스트 편집(삽입/삭제) 후 호출하여 줄 바꿈을 재배치한다.
@@ -2014,6 +2252,26 @@ fn reflow_line_segs_impl(
             }
         }
     }
+
+    // The frame owns physical-row recurrence only for an ordinary scalar
+    // reflow. Stored-prefix edits, split-cell recovery, empty paragraphs, and
+    // inline controls retain their established specialized paths below.
+    let frame_eligible = !split_stale_cell_reflow
+        && preserve_prefix_for_edit.is_none()
+        && para.controls.is_empty()
+        && preserved_prefix.is_empty();
+    if frame_eligible {
+        let mut frame = LayoutFrame::new(
+            0..seg_width_hwp,
+            orig.as_ref().map(|line| line.vertical_pos).unwrap_or(0),
+            Vec::new(),
+        );
+        if let Some(projected) = layout_paragraph_in_frame(para, &mut frame, styles, dpi) {
+            para.line_segs = projected;
+            return false;
+        }
+    }
+
     let line_breaks = fill_lines(
         &tokens[token_start..],
         &text_chars,
@@ -2395,7 +2653,7 @@ mod fill_cursor_tests {
             condense_min_space,
             &mut cursor,
         ) {
-            results.push(result);
+            results.push(result.line);
         }
         results
     }
@@ -2533,6 +2791,292 @@ mod fill_cursor_tests {
         ];
 
         assert_cursor_matches_frozen_scalar(&tokens, &text_chars, 24.0, 0.0, 48.0, 0, 0, 0, true);
+    }
+}
+
+#[cfg(test)]
+mod frame_reflow_tests {
+    use super::*;
+    use crate::renderer::layout_frame::FrameExclusion;
+    use crate::renderer::style_resolver::{ResolvedCharStyle, ResolvedParaStyle};
+
+    fn styles(font_sizes: &[f64]) -> ResolvedStyleSet {
+        ResolvedStyleSet {
+            char_styles: font_sizes
+                .iter()
+                .map(|font_size| ResolvedCharStyle {
+                    font_size: *font_size,
+                    ratio: 1.0,
+                    ..Default::default()
+                })
+                .collect(),
+            para_styles: vec![ResolvedParaStyle::default()],
+            ..Default::default()
+        }
+    }
+
+    fn paragraph(text: &str, char_shapes: Vec<CharShapeRef>) -> Paragraph {
+        Paragraph {
+            text: text.to_string(),
+            char_offsets: text
+                .chars()
+                .scan(0u32, |offset, character| {
+                    let current = *offset;
+                    *offset += character.len_utf16() as u32;
+                    Some(current)
+                })
+                .collect(),
+            char_count: text.encode_utf16().count() as u32 + 1,
+            char_shapes,
+            ..Default::default()
+        }
+    }
+
+    fn shared_metrics(lines: &[LineSeg]) -> Vec<(i32, i32, i32, i32, i32)> {
+        lines
+            .iter()
+            .map(|line| {
+                (
+                    line.vertical_pos,
+                    line.line_height,
+                    line.text_height,
+                    line.baseline_distance,
+                    line.line_spacing,
+                )
+            })
+            .collect()
+    }
+
+    fn line_fields(lines: &[LineSeg]) -> Vec<(u32, i32, i32, i32, i32, i32, i32, i32, u32)> {
+        lines
+            .iter()
+            .map(|line| {
+                (
+                    line.text_start,
+                    line.vertical_pos,
+                    line.line_height,
+                    line.text_height,
+                    line.baseline_distance,
+                    line.line_spacing,
+                    line.column_start,
+                    line.segment_width,
+                    line.tag,
+                )
+            })
+            .collect()
+    }
+
+    fn frozen_scalar_projection(
+        para: &Paragraph,
+        available_width_px: f64,
+        styles: &ResolvedStyleSet,
+        dpi: f64,
+    ) -> Vec<LineSeg> {
+        let text_chars = para.text.chars().collect::<Vec<_>>();
+        let style = styles.para_styles.get(para.para_shape_id as usize);
+        let indent_px = style.map(|value| value.indent).unwrap_or(0.0);
+        let english_break_unit = style.map(|value| value.english_break_unit).unwrap_or(0);
+        let korean_break_unit = style.map(|value| value.korean_break_unit).unwrap_or(0);
+        let condense_min_space = style.map(|value| value.condense_min_space).unwrap_or(0);
+        let default_tab_width = style.map(|value| value.default_tab_width).unwrap_or(0.0);
+        let line_spacing_type = style
+            .map(|value| value.line_spacing_type)
+            .unwrap_or(LineSpacingType::Percent);
+        let line_spacing_value = style.map(|value| value.line_spacing).unwrap_or(160.0);
+        let tokens = tokenize_paragraph_with_split_cell_space_metric(
+            &text_chars,
+            &para.char_offsets,
+            &para.char_shapes,
+            styles,
+            english_break_unit,
+            korean_break_unit,
+            false,
+            &[],
+        );
+        let line_breaks = fill_lines_before_cursor(
+            &tokens,
+            &text_chars,
+            available_width_px,
+            indent_px,
+            default_tab_width,
+            korean_break_unit,
+            condense_min_space,
+            0,
+            true,
+        );
+        let segment_width = px_to_hwpunit(available_width_px, dpi);
+        let source_tag = para
+            .line_segs
+            .first()
+            .map(|line| line.tag)
+            .unwrap_or(LineSeg::TAG_SINGLE_SEGMENT_LINE | LineSeg::TAG_IMPLEMENTATION_PROPERTY);
+        let mut vertical_pos = para
+            .line_segs
+            .first()
+            .map(|line| line.vertical_pos)
+            .unwrap_or(0);
+
+        line_breaks
+            .iter()
+            .enumerate()
+            .map(|(index, line)| {
+                let font_size = if line.max_font_size > 0.0 {
+                    line.max_font_size
+                } else {
+                    12.0
+                };
+                let line_height = font_size_to_line_height(font_size, dpi);
+                let line_spacing = compute_line_spacing_hwp(
+                    line_spacing_type,
+                    line_spacing_value,
+                    line_height,
+                    dpi,
+                );
+                let projected = LineSeg {
+                    text_start: if index == 0 {
+                        0
+                    } else {
+                        char_index_to_utf16_offset(para, line.start_idx)
+                    },
+                    vertical_pos,
+                    line_height,
+                    text_height: line_height,
+                    baseline_distance: (line_height as f64 * 0.85) as i32,
+                    line_spacing,
+                    column_start: 0,
+                    segment_width,
+                    tag: if source_tag == 0 {
+                        LineSeg::TAG_SINGLE_SEGMENT_LINE
+                    } else {
+                        source_tag
+                    },
+                };
+                vertical_pos += line_height + line_spacing;
+                projected
+            })
+            .collect()
+    }
+
+    #[test]
+    fn frame_reflow_projects_two_intervals_as_one_physical_row() {
+        let styles = styles(&[12.0]);
+        let para = paragraph(
+            "abcdef ghijkl",
+            vec![CharShapeRef {
+                start_pos: 0,
+                char_shape_id: 0,
+            }],
+        );
+        let mut frame = LayoutFrame::new(
+            0..9_000,
+            100,
+            vec![FrameExclusion {
+                horizontal: 3_000..5_000,
+                vertical: 0..10_000,
+            }],
+        );
+
+        let lines = layout_paragraph_in_frame(&para, &mut frame, &styles, 96.0)
+            .expect("two usable intervals accept scalar text");
+
+        assert_eq!(lines.len(), 2);
+        assert_eq!(
+            lines.iter().map(|line| line.text_start).collect::<Vec<_>>(),
+            vec![0, 7]
+        );
+        assert_eq!(
+            lines
+                .iter()
+                .map(|line| (line.column_start, line.segment_width))
+                .collect::<Vec<_>>(),
+            vec![(0, 3_000), (5_000, 4_000)]
+        );
+        assert_eq!(shared_metrics(&lines), vec![(100, 900, 900, 765, 540); 2]);
+        assert!(lines[0].is_first_segment());
+        assert!(!lines[0].is_last_segment());
+        assert!(!lines[1].is_first_segment());
+        assert!(lines[1].is_last_segment());
+        assert_eq!(frame.row_count(), 1);
+        assert_eq!(frame.top, 1_540);
+    }
+
+    #[test]
+    fn frame_reflow_retries_a_taller_row_without_consuming_the_cursor() {
+        let styles = styles(&[12.0, 20.0]);
+        let para = paragraph(
+            "abcdef ghijk",
+            vec![
+                CharShapeRef {
+                    start_pos: 0,
+                    char_shape_id: 0,
+                },
+                CharShapeRef {
+                    start_pos: 7,
+                    char_shape_id: 1,
+                },
+            ],
+        );
+        let mut frame = LayoutFrame::new(
+            0..9_000,
+            0,
+            vec![FrameExclusion {
+                horizontal: 4_000..5_000,
+                vertical: 1_000..5_000,
+            }],
+        );
+
+        let lines = layout_paragraph_in_frame(&para, &mut frame, &styles, 96.0)
+            .expect("the taller retry restores the first interval's cursor");
+
+        // The 12px trial has one full-width interval below the exclusion. The
+        // 20px row reaches it, so retrying from the same cursor must produce
+        // the two carved segments rather than an exhausted paragraph.
+        assert_eq!(lines.len(), 2);
+        assert_eq!(
+            lines.iter().map(|line| line.text_start).collect::<Vec<_>>(),
+            vec![0, 7]
+        );
+        assert_eq!(
+            lines
+                .iter()
+                .map(|line| (line.column_start, line.segment_width))
+                .collect::<Vec<_>>(),
+            vec![(0, 4_000), (5_000, 4_000)]
+        );
+        assert_eq!(
+            shared_metrics(&lines),
+            vec![(0, 1_500, 1_500, 1_275, 900); 2]
+        );
+        assert_eq!(frame.row_count(), 1);
+        assert_eq!(frame.top, 2_400);
+    }
+
+    #[test]
+    fn eligible_scalar_reflow_projects_the_frozen_scalar_oracle() {
+        let styles = styles(&[12.0]);
+        let mut para = paragraph(
+            "alpha beta gamma delta epsilon",
+            vec![CharShapeRef {
+                start_pos: 0,
+                char_shape_id: 0,
+            }],
+        );
+        para.line_segs = vec![LineSeg {
+            vertical_pos: 321,
+            tag: LineSeg::TAG_SINGLE_SEGMENT_LINE | LineSeg::TAG_IMPLEMENTATION_PROPERTY,
+            ..Default::default()
+        }];
+        let expected = frozen_scalar_projection(&para, 50.0, &styles, 96.0);
+        assert!(expected.len() > 1, "fixture must exercise row recurrence");
+
+        reflow_line_segs(&mut para, 50.0, &styles, 96.0);
+
+        assert_eq!(line_fields(&para.line_segs), line_fields(&expected));
+        assert!(para
+            .line_segs
+            .iter()
+            .all(|line| line.segment_width == 3_750 && line.column_start == 0));
+        assert_eq!(para.line_segs[0].vertical_pos, 321);
     }
 }
 

--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -51,7 +51,7 @@ struct FlowInlineControl {
 }
 
 /// 줄 채움 결과
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 struct LineBreakResult {
     start_idx: usize,
     end_idx: usize, // exclusive
@@ -745,9 +745,417 @@ fn text_token_fits_line_hwp(
     condensed_candidate <= effective_width_hwp + LINE_BREAK_TOLERANCE && condense_pull_allowed
 }
 
-/// 토큰을 줄에 배치하는 Greedy 알고리즘
-/// 한컴과 동일한 결과를 위해 HWPUNIT 정수로 폭을 누적한다.
+/// Greedy line-fill continuation.
+///
+/// A visible-text boundary does not always identify the next token: a long
+/// `Text` token can continue after an emitted row. Keep the complete state so
+/// callers can fill one interval at a time without rediscovering a boundary.
+#[derive(Debug, Clone)]
+struct FillCursor {
+    token_index: usize,
+    fallback_char_idx: Option<usize>,
+    initial_start_idx: usize,
+    line_start_idx: usize,
+    lw: i32,
+    line_space_savings: i32,
+    line_max_fs: f64,
+    is_first_line: bool,
+    last_break_token_idx: Option<usize>,
+    last_break_char_idx: usize,
+    width_at_last_break: i32,
+    space_savings_at_last_break: i32,
+    fs_at_last_break: f64,
+    finished: bool,
+    emitted_any: bool,
+}
+
+impl FillCursor {
+    fn new(initial_start_idx: usize, initial_is_first_line: bool) -> Self {
+        Self {
+            token_index: 0,
+            fallback_char_idx: None,
+            initial_start_idx,
+            line_start_idx: initial_start_idx,
+            lw: 0,
+            line_space_savings: 0,
+            line_max_fs: 0.0,
+            is_first_line: initial_is_first_line,
+            last_break_token_idx: None,
+            last_break_char_idx: 0,
+            width_at_last_break: 0,
+            space_savings_at_last_break: 0,
+            fs_at_last_break: 0.0,
+            finished: false,
+            emitted_any: false,
+        }
+    }
+}
+
+/// Fill all scalar intervals through the resumable greedy continuation.
 fn fill_lines(
+    tokens: &[BreakToken],
+    text_chars: &[char],
+    available_width_px: f64,
+    indent_px: f64,
+    default_tab_width: f64,
+    korean_break_unit: u8,
+    condense_min_space: u8,
+    initial_start_idx: usize,
+    initial_is_first_line: bool,
+) -> Vec<LineBreakResult> {
+    let mut cursor = FillCursor::new(initial_start_idx, initial_is_first_line);
+    let mut results = Vec::new();
+
+    while let Some(line) = fill_one_interval(
+        tokens,
+        text_chars,
+        available_width_px,
+        indent_px,
+        default_tab_width,
+        korean_break_unit,
+        condense_min_space,
+        &mut cursor,
+    ) {
+        results.push(line);
+    }
+
+    results
+}
+
+/// Fill at most one logical row and retain the greedy continuation state.
+fn fill_one_interval(
+    tokens: &[BreakToken],
+    text_chars: &[char],
+    available_width_px: f64,
+    indent_px: f64,
+    default_tab_width: f64,
+    korean_break_unit: u8,
+    condense_min_space: u8,
+    cursor: &mut FillCursor,
+) -> Option<LineBreakResult> {
+    if cursor.finished {
+        return None;
+    }
+
+    if tokens.is_empty() {
+        cursor.finished = true;
+        cursor.emitted_any = true;
+        return Some(LineBreakResult {
+            start_idx: cursor.initial_start_idx,
+            end_idx: cursor.initial_start_idx,
+            max_font_size: 0.0,
+            has_line_break: false,
+        });
+    }
+
+    let tab_w_px = if default_tab_width > 0.0 {
+        default_tab_width
+    } else {
+        48.0
+    };
+    let eff_w = |first: bool| -> i32 {
+        if indent_px > 0.0 {
+            if first {
+                to_hwp((available_width_px - indent_px).max(1.0))
+            } else {
+                to_hwp(available_width_px)
+            }
+        } else if indent_px < 0.0 {
+            if first {
+                to_hwp(available_width_px)
+            } else {
+                to_hwp((available_width_px + indent_px).max(1.0))
+            }
+        } else {
+            to_hwp(available_width_px)
+        }
+    };
+
+    loop {
+        if cursor.token_index >= tokens.len() {
+            cursor.finished = true;
+            let last_end = tokens
+                .last()
+                .map(|token| match token {
+                    BreakToken::Text { end_idx, .. } => *end_idx,
+                    BreakToken::Space { idx, .. }
+                    | BreakToken::Tab { idx, .. }
+                    | BreakToken::LineBreak { idx } => *idx + 1,
+                })
+                .unwrap_or(text_chars.len());
+
+            if cursor.line_start_idx <= last_end {
+                cursor.emitted_any = true;
+                return Some(LineBreakResult {
+                    start_idx: cursor.line_start_idx,
+                    end_idx: last_end,
+                    max_font_size: cursor.line_max_fs,
+                    has_line_break: false,
+                });
+            }
+
+            if !cursor.emitted_any {
+                cursor.emitted_any = true;
+                return Some(LineBreakResult {
+                    start_idx: cursor.initial_start_idx,
+                    end_idx: text_chars.len(),
+                    max_font_size: 0.0,
+                    has_line_break: false,
+                });
+            }
+            return None;
+        }
+
+        let ti = cursor.token_index;
+        match &tokens[ti] {
+            BreakToken::LineBreak { idx } => {
+                let result = LineBreakResult {
+                    start_idx: cursor.line_start_idx,
+                    end_idx: *idx + 1,
+                    max_font_size: cursor.line_max_fs,
+                    has_line_break: true,
+                };
+                cursor.line_start_idx = *idx + 1;
+                cursor.lw = 0;
+                cursor.line_space_savings = 0;
+                cursor.line_max_fs = 0.0;
+                cursor.is_first_line = false;
+                cursor.last_break_token_idx = None;
+                cursor.token_index += 1;
+                cursor.emitted_any = true;
+                return Some(result);
+            }
+            BreakToken::Tab { idx, max_font_size } => {
+                // 탭 계산은 px로 수행 후 HWPUNIT 변환 (정밀도 유지)
+                let lw_px = cursor.lw as f64 / 75.0;
+                let next_tab_px = ((lw_px / tab_w_px).floor() + 1.0) * tab_w_px;
+                let next_tab_hwp = to_hwp(next_tab_px);
+                if *max_font_size > cursor.line_max_fs {
+                    cursor.line_max_fs = *max_font_size;
+                }
+
+                if next_tab_hwp > eff_w(cursor.is_first_line) && cursor.line_start_idx < *idx {
+                    let result = if cursor.last_break_token_idx.is_some() {
+                        let result = LineBreakResult {
+                            start_idx: cursor.line_start_idx,
+                            end_idx: cursor.last_break_char_idx,
+                            max_font_size: cursor.fs_at_last_break,
+                            has_line_break: false,
+                        };
+                        cursor.line_start_idx = cursor.last_break_char_idx;
+                        cursor.lw -= cursor.width_at_last_break;
+                        cursor.line_space_savings -= cursor.space_savings_at_last_break;
+                        result
+                    } else {
+                        let result = LineBreakResult {
+                            start_idx: cursor.line_start_idx,
+                            end_idx: *idx,
+                            max_font_size: cursor.line_max_fs,
+                            has_line_break: false,
+                        };
+                        cursor.line_start_idx = *idx;
+                        cursor.lw = 0;
+                        cursor.line_space_savings = 0;
+                        cursor.line_max_fs = *max_font_size;
+                        result
+                    };
+                    cursor.is_first_line = false;
+                    cursor.last_break_token_idx = None;
+                    let lw_px2 = cursor.lw as f64 / 75.0;
+                    let next_tab2 = ((lw_px2 / tab_w_px).floor() + 1.0) * tab_w_px;
+                    cursor.lw = to_hwp(next_tab2);
+                    cursor.token_index += 1;
+                    cursor.emitted_any = true;
+                    return Some(result);
+                }
+
+                cursor.last_break_token_idx = Some(ti);
+                cursor.last_break_char_idx = *idx;
+                cursor.width_at_last_break = cursor.lw;
+                cursor.space_savings_at_last_break = cursor.line_space_savings;
+                cursor.fs_at_last_break = cursor.line_max_fs;
+                cursor.lw = next_tab_hwp;
+                cursor.token_index += 1;
+            }
+            BreakToken::Space {
+                idx,
+                width,
+                max_font_size,
+            } => {
+                if *max_font_size > cursor.line_max_fs {
+                    cursor.line_max_fs = *max_font_size;
+                }
+                cursor.last_break_token_idx = Some(ti);
+                cursor.last_break_char_idx = *idx;
+                cursor.width_at_last_break = cursor.lw;
+                cursor.space_savings_at_last_break = cursor.line_space_savings;
+                cursor.fs_at_last_break = cursor.line_max_fs;
+                let space_hwp = to_hwp(*width);
+                cursor.lw += space_hwp;
+                cursor.line_space_savings +=
+                    condense_space_savings_hwp(space_hwp, condense_min_space);
+                cursor.token_index += 1;
+            }
+            BreakToken::Text {
+                start_idx,
+                end_idx,
+                width,
+                max_font_size,
+                char_widths,
+            } => {
+                if let Some(next_char_idx) = cursor.fallback_char_idx {
+                    debug_assert!(*start_idx <= next_char_idx && next_char_idx <= *end_idx);
+                    let mut ci = next_char_idx;
+                    while ci < *end_idx {
+                        let rel_idx = ci - *start_idx;
+                        let char_w = char_widths
+                            .get(rel_idx)
+                            .map(|width| to_hwp(*width))
+                            .unwrap_or_else(|| {
+                                let ch = text_chars[ci];
+                                let char_w_px = if is_cjk_char(ch) {
+                                    cursor.line_max_fs.max(12.0)
+                                } else {
+                                    cursor.line_max_fs.max(12.0) * 0.5
+                                };
+                                to_hwp(char_w_px)
+                            });
+                        let current_width = eff_w(cursor.is_first_line);
+                        if cursor.lw + char_w > current_width && ci > cursor.line_start_idx {
+                            let result = LineBreakResult {
+                                start_idx: cursor.line_start_idx,
+                                end_idx: ci,
+                                max_font_size: cursor.line_max_fs,
+                                has_line_break: false,
+                            };
+                            cursor.line_start_idx = ci;
+                            cursor.lw = char_w;
+                            cursor.is_first_line = false;
+                            cursor.fallback_char_idx = Some(ci + 1);
+                            cursor.emitted_any = true;
+                            return Some(result);
+                        }
+                        cursor.lw += char_w;
+                        ci += 1;
+                    }
+                    cursor.fallback_char_idx = None;
+                    cursor.token_index += 1;
+                    continue;
+                }
+
+                if *max_font_size > cursor.line_max_fs {
+                    cursor.line_max_fs = *max_font_size;
+                }
+
+                let w_hwp = to_hwp(*width);
+
+                // 단일 문자 CJK/한글 토큰의 줄바꿈 가능 지점 처리
+                // 이 글자를 포함한 후 break point 갱신 (end_idx 사용)
+                // → 초과 시 이 글자까지 L0에 포함하고 다음 토큰부터 다음 줄
+                if *end_idx - *start_idx == 1 && *start_idx > cursor.line_start_idx {
+                    let c = text_chars[*start_idx];
+                    let allow_break = if is_hangul(c) {
+                        // [#2185] bit7=1 = 글자 단위 break 허용 (위 주석 참조)
+                        korean_break_unit == 1
+                    } else {
+                        is_cjk_ideograph(c)
+                    };
+                    let candidate_w = cursor.lw + w_hwp;
+                    // 이 글자가 줄에 들어가는 경우에만 break point 갱신
+                    if allow_break
+                        && condensed_line_width_hwp(candidate_w, cursor.line_space_savings)
+                            <= eff_w(cursor.is_first_line) + LINE_BREAK_TOLERANCE
+                    {
+                        cursor.last_break_token_idx = Some(ti);
+                        cursor.last_break_char_idx = *end_idx; // 이 글자 다음 (이 글자 포함)
+                        cursor.width_at_last_break = candidate_w; // 이 글자 폭 포함
+                        cursor.space_savings_at_last_break = cursor.line_space_savings;
+                        cursor.fs_at_last_break = cursor.line_max_fs;
+                    }
+                }
+                let effective_width = eff_w(cursor.is_first_line);
+                if !text_token_fits_line_hwp(
+                    cursor.lw,
+                    w_hwp,
+                    cursor.line_space_savings,
+                    effective_width,
+                    *max_font_size,
+                ) {
+                    if *start_idx > cursor.line_start_idx {
+                        if let Some(break_token_idx) = cursor.last_break_token_idx {
+                            let result = LineBreakResult {
+                                start_idx: cursor.line_start_idx,
+                                end_idx: cursor.last_break_char_idx,
+                                max_font_size: cursor.fs_at_last_break,
+                                has_line_break: false,
+                            };
+                            let mut next_start = cursor.last_break_char_idx;
+                            while next_start < text_chars.len() && text_chars[next_start] == ' ' {
+                                next_start += 1;
+                            }
+                            cursor.line_start_idx = next_start;
+                            cursor.lw = recalc_width_hwp(tokens, ti, next_start);
+                            cursor.line_space_savings = recalc_space_savings_hwp(
+                                tokens,
+                                ti,
+                                next_start,
+                                condense_min_space,
+                            );
+                            cursor.line_max_fs = *max_font_size;
+                            cursor.is_first_line = false;
+                            cursor.last_break_token_idx = None;
+
+                            // 현재 단일 CJK/한글 토큰 자체가 break point였던 기존 경로는
+                            // 이미 위 결과에 포함됐으므로 동작을 바꾸지 않는다.
+                            if break_token_idx == ti {
+                                cursor.lw += w_hwp;
+                                cursor.token_index += 1;
+                                cursor.emitted_any = true;
+                                return Some(result);
+                            }
+
+                            // [#3822] 이전 break 뒤로 옮긴 현재 토큰이 새 줄에도
+                            // 들어가는지 다시 확인한다. 종전에는 토큰 전체 폭을 무조건
+                            // 더하고 continue하여, 긴 영문·숫자 토큰의 글자 단위 fallback을
+                            // 건너뛰었다.
+                            if text_token_fits_line_hwp(
+                                cursor.lw,
+                                w_hwp,
+                                cursor.line_space_savings,
+                                eff_w(false),
+                                *max_font_size,
+                            ) {
+                                cursor.lw += w_hwp;
+                                cursor.token_index += 1;
+                                cursor.emitted_any = true;
+                                return Some(result);
+                            }
+
+                            cursor.line_space_savings = 0;
+                            cursor.last_break_token_idx = None;
+                            cursor.fallback_char_idx = Some(*start_idx);
+                            cursor.emitted_any = true;
+                            return Some(result);
+                        }
+                    }
+
+                    // 토큰에 저장된 개별 글자 폭을 HWPUNIT로 변환
+                    cursor.line_space_savings = 0;
+                    cursor.last_break_token_idx = None;
+                    cursor.fallback_char_idx = Some(*start_idx);
+                    continue;
+                }
+
+                cursor.lw += w_hwp;
+                cursor.token_index += 1;
+            }
+        }
+    }
+}
+
+/// Frozen scalar implementation used only to prove cursor equivalence.
+#[cfg(test)]
+fn fill_lines_before_cursor(
     tokens: &[BreakToken],
     text_chars: &[char],
     available_width_px: f64,
@@ -1085,6 +1493,7 @@ fn recalc_space_savings_hwp(
 
 /// 긴 단어 폴백: 글자 단위 분할 (HWPUNIT)
 /// char_widths_hwp: 토큰 내 각 글자의 HWPUNIT 폭 (None이면 휴리스틱)
+#[cfg(test)]
 fn char_level_break_hwp(
     text_chars: &[char],
     token_start: usize,
@@ -1956,6 +2365,174 @@ fn compute_line_spacing_hwp(
             let min_hwp = px_to_hwpunit(ls_value, dpi);
             (min_hwp - line_height_hwp).max(0)
         }
+    }
+}
+
+#[cfg(test)]
+mod fill_cursor_tests {
+    use super::*;
+
+    fn collect_one_interval_at_a_time(
+        tokens: &[BreakToken],
+        text_chars: &[char],
+        available_width_px: f64,
+        indent_px: f64,
+        default_tab_width: f64,
+        korean_break_unit: u8,
+        condense_min_space: u8,
+        initial_start_idx: usize,
+        initial_is_first_line: bool,
+    ) -> Vec<LineBreakResult> {
+        let mut cursor = FillCursor::new(initial_start_idx, initial_is_first_line);
+        let mut results = Vec::new();
+        while let Some(result) = fill_one_interval(
+            tokens,
+            text_chars,
+            available_width_px,
+            indent_px,
+            default_tab_width,
+            korean_break_unit,
+            condense_min_space,
+            &mut cursor,
+        ) {
+            results.push(result);
+        }
+        results
+    }
+
+    fn assert_cursor_matches_frozen_scalar(
+        tokens: &[BreakToken],
+        text_chars: &[char],
+        available_width_px: f64,
+        indent_px: f64,
+        default_tab_width: f64,
+        korean_break_unit: u8,
+        condense_min_space: u8,
+        initial_start_idx: usize,
+        initial_is_first_line: bool,
+    ) -> Vec<LineBreakResult> {
+        let frozen = fill_lines_before_cursor(
+            tokens,
+            text_chars,
+            available_width_px,
+            indent_px,
+            default_tab_width,
+            korean_break_unit,
+            condense_min_space,
+            initial_start_idx,
+            initial_is_first_line,
+        );
+        let scalar = fill_lines(
+            tokens,
+            text_chars,
+            available_width_px,
+            indent_px,
+            default_tab_width,
+            korean_break_unit,
+            condense_min_space,
+            initial_start_idx,
+            initial_is_first_line,
+        );
+        let resumed = collect_one_interval_at_a_time(
+            tokens,
+            text_chars,
+            available_width_px,
+            indent_px,
+            default_tab_width,
+            korean_break_unit,
+            condense_min_space,
+            initial_start_idx,
+            initial_is_first_line,
+        );
+
+        assert_eq!(scalar, frozen);
+        assert_eq!(resumed, frozen);
+        frozen
+    }
+
+    #[test]
+    fn cursor_resumes_a_long_text_token_at_each_interval() {
+        let text_chars = "abcdefghij".chars().collect::<Vec<_>>();
+        let tokens = vec![BreakToken::Text {
+            start_idx: 0,
+            end_idx: text_chars.len(),
+            width: 100.0,
+            max_font_size: 12.0,
+            char_widths: vec![10.0; text_chars.len()],
+        }];
+
+        let results = assert_cursor_matches_frozen_scalar(
+            &tokens,
+            &text_chars,
+            25.0,
+            0.0,
+            48.0,
+            0,
+            0,
+            0,
+            true,
+        );
+
+        assert_eq!(
+            results
+                .iter()
+                .map(|result| (result.start_idx, result.end_idx, result.has_line_break))
+                .collect::<Vec<_>>(),
+            vec![
+                (0, 2, false),
+                (2, 4, false),
+                (4, 6, false),
+                (6, 8, false),
+                (8, 10, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn cursor_preserves_scalar_space_tab_and_forced_break_results() {
+        let text_chars = "ab c\td\nxy".chars().collect::<Vec<_>>();
+        let tokens = vec![
+            BreakToken::Text {
+                start_idx: 0,
+                end_idx: 2,
+                width: 20.0,
+                max_font_size: 12.0,
+                char_widths: vec![10.0, 10.0],
+            },
+            BreakToken::Space {
+                idx: 2,
+                width: 5.0,
+                max_font_size: 12.0,
+            },
+            BreakToken::Text {
+                start_idx: 3,
+                end_idx: 4,
+                width: 10.0,
+                max_font_size: 12.0,
+                char_widths: vec![10.0],
+            },
+            BreakToken::Tab {
+                idx: 4,
+                max_font_size: 12.0,
+            },
+            BreakToken::Text {
+                start_idx: 5,
+                end_idx: 6,
+                width: 10.0,
+                max_font_size: 12.0,
+                char_widths: vec![10.0],
+            },
+            BreakToken::LineBreak { idx: 6 },
+            BreakToken::Text {
+                start_idx: 7,
+                end_idx: 9,
+                width: 20.0,
+                max_font_size: 12.0,
+                char_widths: vec![10.0, 10.0],
+            },
+        ];
+
+        assert_cursor_matches_frozen_scalar(&tokens, &text_chars, 24.0, 0.0, 48.0, 0, 0, 0, true);
     }
 }
 

--- a/src/renderer/composer/tests.rs
+++ b/src/renderer/composer/tests.rs
@@ -1664,3 +1664,44 @@ fn issue4149_memo_invalidated_by_mutation_paths() {
         "merge_from 후 미판정"
     );
 }
+
+#[test]
+fn owned_rowbreak_tac_height_selects_current_or_multirow_frames() {
+    use crate::model::control::Control;
+    use crate::model::table::{Table, TablePageBreak};
+
+    let para_with_rows = |row_count, line_height| Paragraph {
+        controls: vec![Control::Table(Box::new(Table {
+            row_count,
+            page_break: TablePageBreak::RowBreak,
+            common: crate::model::shape::CommonObjAttr {
+                treat_as_char: true,
+                height: 32_339,
+                ..Default::default()
+            },
+            ..Default::default()
+        }))],
+        line_segs: vec![LineSeg {
+            line_height,
+            segment_width: 49_324,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let multirow = para_with_rows(4, 32_339);
+    assert_eq!(owned_rowbreak_tac_height(&multirow, 0), Some(32_339));
+
+    let single_row = para_with_rows(1, 32_339);
+    assert_eq!(owned_rowbreak_tac_height(&single_row, 0), None);
+
+    let mut current_single_row = para_with_rows(1, 32_339);
+    current_single_row.line_segs[0].tag = LineSeg::TAG_IMPLEMENTATION_PROPERTY;
+    assert_eq!(
+        owned_rowbreak_tac_height(&current_single_row, 0),
+        Some(32_339)
+    );
+
+    let undersized = para_with_rows(4, 32_338);
+    assert_eq!(owned_rowbreak_tac_height(&undersized, 0), None);
+}

--- a/src/renderer/float_placement.rs
+++ b/src/renderer/float_placement.rs
@@ -1,17 +1,100 @@
 //! Flow reservation helpers for non-inline floating objects.
 
+use std::ops::Range;
+
 use crate::model::control::Control;
+use crate::model::image::Picture;
 use crate::model::paragraph::Paragraph;
-use crate::model::shape::{CommonObjAttr, HorzAlign, HorzRelTo, TextWrap, VertAlign, VertRelTo};
+use crate::model::shape::{
+    CommonObjAttr, HorzAlign, HorzRelTo, TextFlow, TextWrap, VertAlign, VertRelTo,
+};
 use crate::model::table::{Table, TablePageBreak};
 use crate::model::HwpUnit;
 
 use super::hwpunit_to_px;
+use super::layout::picture_flow_frame_size_hu;
+use super::layout_frame::{FrameExclusion, FrameExclusionPolicy};
 use super::page_layout::LayoutRect;
 
 /// Interpret an HWPUNIT value that may have been stored through a signed field.
 pub(crate) fn signed_hwpunit(value: HwpUnit) -> i32 {
     value as i32
+}
+
+/// Resolve the deliberately small Picture/Square side-wrap subset used by a
+/// caller-owned `LayoutFrame`.
+///
+/// The caller owns both the paragraph-relative anchor and the exclusion's
+/// lifetime. This function intentionally has no fallback policy: only an
+/// uncaptained, non-TAC Picture with `Square` and the two recovered side-wrap
+/// flows has a physical-row representation. Every other object shape remains
+/// with its existing owner.
+pub(crate) fn resolve_picture_exclusion(
+    picture: &Picture,
+    column_horizontal: Range<i32>,
+    paragraph_horizontal: Range<i32>,
+    paragraph_top: i32,
+) -> Option<FrameExclusion> {
+    let common = &picture.common;
+    if common.treat_as_char
+        || picture.caption.is_some()
+        || common.text_wrap != TextWrap::Square
+        || !matches!(common.horz_rel_to, HorzRelTo::Column | HorzRelTo::Para)
+        || common.vert_rel_to != VertRelTo::Para
+        || !matches!(common.vert_align, VertAlign::Top | VertAlign::Inside)
+    {
+        return None;
+    }
+    let policy = match common.text_flow {
+        TextFlow::BothSides => FrameExclusionPolicy::BothSides,
+        TextFlow::LargestOnly => FrameExclusionPolicy::LargestSide,
+        TextFlow::LeftOnly | TextFlow::RightOnly => return None,
+    };
+
+    let (width, height) = picture_flow_frame_size_hu(picture);
+    if column_horizontal.is_empty() || paragraph_horizontal.is_empty() || width <= 0 || height <= 0
+    {
+        return None;
+    }
+
+    let horizontal_offset = signed_hwpunit(common.horizontal_offset);
+    let reference = match common.horz_rel_to {
+        HorzRelTo::Column => column_horizontal,
+        HorzRelTo::Para => paragraph_horizontal,
+        HorzRelTo::Paper | HorzRelTo::Page => return None,
+    };
+    let reference_width = reference.end.saturating_sub(reference.start);
+    let visible_left = match common.horz_align {
+        HorzAlign::Left | HorzAlign::Inside => reference.start.saturating_add(horizontal_offset),
+        HorzAlign::Center => reference
+            .start
+            .saturating_add(
+                reference_width
+                    .saturating_sub(width)
+                    .max(0)
+                    .saturating_div(2),
+            )
+            .saturating_add(horizontal_offset),
+        HorzAlign::Right | HorzAlign::Outside => reference
+            .end
+            .saturating_sub(width)
+            .saturating_sub(horizontal_offset),
+    };
+    let visible_top = paragraph_top.saturating_add(signed_hwpunit(common.vertical_offset));
+    let horizontal = visible_left.saturating_sub(i32::from(common.margin.left))
+        ..visible_left
+            .saturating_add(width)
+            .saturating_add(i32::from(common.margin.right));
+    let vertical = visible_top.saturating_sub(i32::from(common.margin.top))
+        ..visible_top
+            .saturating_add(height)
+            .saturating_add(i32::from(common.margin.bottom));
+
+    (!horizontal.is_empty() && !vertical.is_empty()).then_some(FrameExclusion {
+        horizontal,
+        vertical,
+        policy,
+    })
 }
 
 /// A non-TAC `TopAndBottom` object positioned from its host paragraph.
@@ -465,6 +548,7 @@ mod tests {
     use crate::model::paragraph::LineSeg;
     use crate::model::shape::{HorzAlign, HorzRelTo, VertAlign};
     use crate::model::table::Cell;
+    use crate::renderer::layout_frame::FrameExclusionPolicy;
 
     fn base_common() -> CommonObjAttr {
         CommonObjAttr {
@@ -474,6 +558,83 @@ mod tests {
             horz_align: HorzAlign::Left,
             ..Default::default()
         }
+    }
+
+    fn supported_picture(flow: TextFlow) -> Picture {
+        Picture {
+            common: CommonObjAttr {
+                width: 300,
+                height: 200,
+                text_wrap: TextWrap::Square,
+                text_flow: flow,
+                vert_rel_to: VertRelTo::Para,
+                vert_align: VertAlign::Top,
+                horz_rel_to: HorzRelTo::Column,
+                horz_align: HorzAlign::Left,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn picture_exclusion_maps_only_recovered_side_wrap_flows() {
+        let both_sides = resolve_picture_exclusion(
+            &supported_picture(TextFlow::BothSides),
+            0..1_000,
+            0..1_000,
+            50,
+        )
+        .expect("BothSides is represented by the physical row frame");
+        assert_eq!(both_sides.policy, FrameExclusionPolicy::BothSides);
+
+        let largest_only = resolve_picture_exclusion(
+            &supported_picture(TextFlow::LargestOnly),
+            0..1_000,
+            0..1_000,
+            50,
+        )
+        .expect("LargestOnly has a recovered frame policy");
+        assert_eq!(largest_only.policy, FrameExclusionPolicy::LargestSide);
+
+        assert!(resolve_picture_exclusion(
+            &supported_picture(TextFlow::LeftOnly),
+            0..1_000,
+            0..1_000,
+            50,
+        )
+        .is_none());
+        assert!(resolve_picture_exclusion(
+            &supported_picture(TextFlow::RightOnly),
+            0..1_000,
+            0..1_000,
+            50,
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn picture_exclusion_uses_flow_frame_for_oversized_current_square_float() {
+        let mut picture = supported_picture(TextFlow::BothSides);
+        picture.shape_attr.current_width = 900;
+        picture.shape_attr.current_height = 800;
+
+        let exclusion = resolve_picture_exclusion(&picture, 0..1_000, 0..1_000, 50)
+            .expect("Square side-wrap float has a physical row frame");
+
+        assert_eq!(exclusion.horizontal, 0..300);
+        assert_eq!(exclusion.vertical, 50..250);
+    }
+
+    #[test]
+    fn picture_exclusion_rejects_non_square_or_inline_hosts() {
+        let mut picture = supported_picture(TextFlow::BothSides);
+        picture.common.treat_as_char = true;
+        assert!(resolve_picture_exclusion(&picture, 0..1_000, 0..1_000, 0).is_none());
+
+        picture.common.treat_as_char = false;
+        picture.common.text_wrap = TextWrap::TopAndBottom;
+        assert!(resolve_picture_exclusion(&picture, 0..1_000, 0..1_000, 0).is_none());
     }
 
     #[test]

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -9522,7 +9522,23 @@ impl LayoutEngine {
                 let mut stored_lh_covers_om = false;
                 if let Some(seg) = host_seg {
                     if seg.line_spacing > 0 {
-                        y_offset += hwpunit_to_px(seg.line_spacing, self.dpi);
+                        let current_owned_row_covers_object =
+                            self.profile.get().hwpx_stored_layout()
+                                && para.line_segs.len() == 1
+                                && seg.tag
+                                    & crate::model::paragraph::LineSeg::TAG_IMPLEMENTATION_PROPERTY
+                                    != 0
+                                && crate::renderer::composer::owned_rowbreak_tac_height(
+                                    para,
+                                    control_index,
+                                )
+                                .is_some();
+                        let trailing_spacing = hwpunit_to_px(seg.line_spacing, self.dpi);
+                        y_offset += if current_owned_row_covers_object {
+                            trailing_spacing / 2.0
+                        } else {
+                            trailing_spacing
+                        };
                     } else if seg.line_spacing < 0 {
                         // 음수 ls (Fixed 줄간격 TAC 표): y를 문단 advance로 리셋 (Task #9)
                         // 표 렌더 높이가 아닌, 일반 문단과 동일한 lh+ls advance 사용

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -378,7 +378,7 @@ fn receipt_seal_line_text(
 }
 
 fn push_tac_receipt_seal_line(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     col_node: &mut RenderNode,
     section_index: usize,
     para_index: usize,
@@ -503,7 +503,7 @@ fn tac_receipt_post_f081c_line(
 
 #[allow(clippy::too_many_arguments)]
 fn push_tac_post_f081c_line(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     col_node: &mut RenderNode,
     section_index: usize,
     para_index: usize,
@@ -1906,7 +1906,7 @@ fn force_para_end_on_last_run(col_node: &mut RenderNode) {
 
 /// 빈 TopAndBottom 표 host 문단의 조판부호를 표 시작 위치에 직접 그린다.
 fn push_empty_para_end_mark(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     col_node: &mut RenderNode,
     para: &Paragraph,
     styles: &ResolvedStyleSet,
@@ -3151,7 +3151,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_header_footer_paragraphs(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         area_node: &mut RenderNode,
         hf_paragraphs: &[Paragraph],
         _composed: &[ComposedParagraph],
@@ -4204,7 +4204,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_header_footer_picture(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         area_node: &mut RenderNode,
         pic: &crate::model::image::Picture,
         area: &LayoutRect,
@@ -4422,7 +4422,7 @@ impl LayoutEngine {
     /// 꼬리말 영역 노드를 생성하여 반환한다.
     fn build_footer(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         page_content: &PageContent,
         paragraphs: &[Paragraph],
         composed: &[ComposedParagraph],
@@ -4687,7 +4687,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn build_columns(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         body_node: &mut RenderNode,
         paper_images: &mut Vec<RenderNode>,
         page_content: &PageContent,
@@ -5016,7 +5016,7 @@ impl LayoutEngine {
     /// zone_layout 기준 + y 범위 인자로 단 구분선을 그린다.
     fn emit_zone_column_separators(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         body_node: &mut RenderNode,
         zone_layout: &PageLayoutInfo,
         y_start: f64,
@@ -5142,7 +5142,7 @@ impl LayoutEngine {
             extra_master_pages: Vec::new(),
         };
         // [#4277] 높이 측정 전용 — paint 트리가 아니라 흐름 상태만 만든다.
-        let mut frame = LayoutFrame::new(0, col_area.width, col_area.y + col_area.height);
+        let mut frame = PageLayoutContext::new(0, col_area.width, col_area.y + col_area.height);
         let mut paper_images: Vec<RenderNode> = Vec::new();
         let (_node, y_offset) = self.build_single_column(
             &mut frame,
@@ -5171,7 +5171,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn render_para_border_groups(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         composed: &[ComposedParagraph],
         col_node: &mut RenderNode,
         styles: &ResolvedStyleSet,
@@ -5476,7 +5476,7 @@ impl LayoutEngine {
 
     fn build_single_column(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         paper_images: &mut Vec<RenderNode>,
         col_content: &ColumnContent,
         page_content: &PageContent,
@@ -7221,7 +7221,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_column_item(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         col_node: &mut RenderNode,
         paper_images: &mut Vec<RenderNode>,
         para_start_y: &mut std::collections::HashMap<usize, f64>,
@@ -7832,7 +7832,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_endnote_separator_item(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         col_node: &mut RenderNode,
         col_area: &LayoutRect,
         mut y_offset: f64,
@@ -7883,7 +7883,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_table_control_block(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         col_node: &mut RenderNode,
         paper_images: &mut Vec<RenderNode>,
         para_start_y: &mut std::collections::HashMap<usize, f64>,
@@ -9040,7 +9040,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_table_item(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         col_node: &mut RenderNode,
         paper_images: &mut Vec<RenderNode>,
         para_start_y: &mut std::collections::HashMap<usize, f64>,
@@ -9679,7 +9679,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_partial_table_item(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         col_node: &mut RenderNode,
         para_start_y: &mut std::collections::HashMap<usize, f64>,
         para_index: usize,
@@ -10036,7 +10036,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_shape_item(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         col_node: &mut RenderNode,
         paper_images: &mut Vec<RenderNode>,
         para_start_y: &mut std::collections::HashMap<usize, f64>,
@@ -10938,7 +10938,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_wrap_around_paras(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         col_node: &mut RenderNode,
         paragraphs: &[Paragraph],
         composed: &[ComposedParagraph],
@@ -11248,7 +11248,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_column_shapes_pass(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         col_node: &mut RenderNode,
         paper_images: &mut Vec<RenderNode>,
         col_content: &ColumnContent,

--- a/src/renderer/layout/border_rendering.rs
+++ b/src/renderer/layout/border_rendering.rs
@@ -268,7 +268,7 @@ pub(crate) fn collect_cell_borders(
 /// 이중선/삼중선의 교차점 렌더링을 깔끔하게 처리한다.
 /// row_col_x: 행별 열 누적 위치 (셀별 독립 너비 지원)
 pub(crate) fn render_edge_borders(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     h_edges: &[Vec<Option<BorderLine>>],
     v_edges: &[Vec<Option<BorderLine>>],
     row_col_x: &[Vec<f64>],
@@ -430,7 +430,7 @@ fn inset_horizontal_border_group_at_top_clip(nodes: &mut [RenderNode], clip_y: f
 /// 투명 테두리를 빨간색 점선 Line 노드로 생성한다.
 /// 엣지 그리드에서 None 슬롯(투명 테두리)을 찾아 연속 구간을 병합한다.
 pub(crate) fn render_transparent_borders(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     h_edges: &[Vec<Option<BorderLine>>],
     v_edges: &[Vec<Option<BorderLine>>],
     row_col_x: &[Vec<f64>],
@@ -523,7 +523,7 @@ pub(crate) fn render_transparent_borders(
 /// 테두리선 Line 노드 생성 (이중선/삼중선 지원)
 /// None 타입이면 빈 벡터 반환
 pub(crate) fn create_border_line_nodes(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     border: &BorderLine,
     x1: f64,
     y1: f64,
@@ -634,7 +634,7 @@ pub(crate) fn create_border_line_nodes(
 /// 평행선 노드 생성 (이중선/삼중선용)
 /// lines: &[(offset, width)] — offset은 선 중심의 수직 이동량
 fn create_parallel_lines(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     color: u32,
     x1: f64,
     y1: f64,
@@ -682,7 +682,7 @@ fn create_parallel_lines(
 
 /// 임의 방향 평행선 노드 생성 (대각선 이중선/삼중선용)
 fn create_parallel_lines_perpendicular(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     color: u32,
     x1: f64,
     y1: f64,
@@ -736,7 +736,7 @@ fn create_parallel_lines_perpendicular(
 
 /// 단일선 노드 생성
 fn create_single_line(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     color: u32,
     width: f64,
     dash: StrokeDash,
@@ -770,7 +770,7 @@ fn create_single_line(
 }
 
 fn create_editor_only_line(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     color: u32,
     width: f64,
     dash: StrokeDash,
@@ -810,7 +810,7 @@ fn border_line_type_from_code(code: u8) -> BorderLineType {
 }
 
 fn create_diagonal_line_nodes(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     line_type: BorderLineType,
     color: u32,
     width_index: u8,
@@ -910,7 +910,7 @@ fn create_diagonal_line_nodes(
 }
 
 fn create_crooked_diagonal_line_nodes(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     line_type: BorderLineType,
     color: u32,
     width_index: u8,
@@ -1023,7 +1023,7 @@ fn border_line_type_to_dash(lt: BorderLineType) -> Option<StrokeDash> {
 ///   bit 10: BackSlash 대각선 꺾은선
 ///   bit 13: 중심선
 pub(crate) fn render_cell_diagonal(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     border_style: &ResolvedBorderStyle,
     cell_x: f64,
     cell_y: f64,
@@ -1217,7 +1217,7 @@ mod tests {
 
     #[test]
     fn render_hwpx_vertical_center_line_as_horizontal_bar() {
-        let mut tree = LayoutFrame::new(0, 200.0, 100.0);
+        let mut tree = PageLayoutContext::new(0, 200.0, 100.0);
         let nodes = render_cell_diagonal(
             &mut tree,
             &center_line_style(CenterLine::Vertical),
@@ -1238,7 +1238,7 @@ mod tests {
 
     #[test]
     fn render_hwpx_horizontal_center_line_as_vertical_bar() {
-        let mut tree = LayoutFrame::new(0, 200.0, 100.0);
+        let mut tree = PageLayoutContext::new(0, 200.0, 100.0);
         let nodes = render_cell_diagonal(
             &mut tree,
             &center_line_style(CenterLine::Horizontal),
@@ -1258,7 +1258,7 @@ mod tests {
 
     #[test]
     fn render_cross_center_line_creates_vertical_and_horizontal_lines() {
-        let mut tree = LayoutFrame::new(0, 200.0, 100.0);
+        let mut tree = PageLayoutContext::new(0, 200.0, 100.0);
         let nodes = render_cell_diagonal(
             &mut tree,
             &center_line_style(CenterLine::Cross),
@@ -1283,7 +1283,7 @@ mod tests {
 
     #[test]
     fn render_nonzero_diagonal_shape_codes_as_basic_x() {
-        let mut tree = LayoutFrame::new(0, 200.0, 100.0);
+        let mut tree = PageLayoutContext::new(0, 200.0, 100.0);
         let nodes = render_cell_diagonal(
             &mut tree,
             &diagonal_style((0b111 << 2) | (0b111 << 5)),
@@ -1308,7 +1308,7 @@ mod tests {
 
     #[test]
     fn render_slash_crooked_with_backslash_as_bent_backslash() {
-        let mut tree = LayoutFrame::new(0, 200.0, 100.0);
+        let mut tree = PageLayoutContext::new(0, 200.0, 100.0);
         let nodes = render_cell_diagonal(
             &mut tree,
             &diagonal_style((2 << 8) | (0b010 << 5)),
@@ -1338,7 +1338,7 @@ mod tests {
 
     #[test]
     fn render_thick_slim_diagonal_as_parallel_lines() {
-        let mut tree = LayoutFrame::new(0, 200.0, 100.0);
+        let mut tree = PageLayoutContext::new(0, 200.0, 100.0);
         let mut style = diagonal_style(0b010 << 2);
         style.diagonal.diagonal_type = 10;
         style.diagonal.width = 13;

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -1353,7 +1353,7 @@ fn collect_shape_marker_labels(show_ctrl: bool, para: Option<&Paragraph>) -> Vec
 impl LayoutEngine {
     pub(crate) fn layout_inline_table_paragraph(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         col_node: &mut RenderNode,
         para: &Paragraph,
         composed: Option<&ComposedParagraph>,
@@ -2084,7 +2084,7 @@ impl LayoutEngine {
     /// 문단 전체를 레이아웃하여 단 노드에 추가
     pub(crate) fn layout_paragraph(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         col_node: &mut RenderNode,
         para: &Paragraph,
         composed: Option<&ComposedParagraph>,
@@ -2121,7 +2121,7 @@ impl LayoutEngine {
     /// 문단 일부를 레이아웃하여 단 노드에 추가
     pub(crate) fn layout_partial_paragraph(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         col_node: &mut RenderNode,
         para: &Paragraph,
         composed: Option<&ComposedParagraph>,
@@ -2231,7 +2231,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn place_unmatched_line_tac_pictures(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         line_node: &mut RenderNode,
         comp_line: &ComposedLine,
         para: Option<&Paragraph>,
@@ -2312,7 +2312,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn place_empty_line_tac_forms(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         line_node: &mut RenderNode,
         comp_line: &ComposedLine,
         para: Option<&Paragraph>,
@@ -2373,7 +2373,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn place_empty_line_inline_equations(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         line_node: &mut RenderNode,
         comp_line: &ComposedLine,
         composed: &ComposedParagraph,
@@ -2650,7 +2650,7 @@ impl LayoutEngine {
 
     pub(crate) fn layout_composed_paragraph(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         col_node: &mut RenderNode,
         composed: &ComposedParagraph,
         styles: &ResolvedStyleSet,
@@ -4549,7 +4549,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn emit_line_runs(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         line_node: &mut RenderNode,
         col_node: &mut RenderNode,
         comp_line: &crate::renderer::composer::ComposedLine,
@@ -5714,7 +5714,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_click_here_and_bookmark_markers(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         line_node: &mut RenderNode,
         p: &Paragraph,
         comp_line: &crate::renderer::composer::ComposedLine,
@@ -6362,7 +6362,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_empty_runs_line(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         line_node: &mut RenderNode,
         comp_line: &crate::renderer::composer::ComposedLine,
         composed: &ComposedParagraph,
@@ -6535,7 +6535,7 @@ impl LayoutEngine {
     /// 원본 문단 데이터로 레이아웃 (ComposedParagraph 없는 경우 fallback)
     pub(crate) fn layout_raw_paragraph(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         col_node: &mut RenderNode,
         para: &Paragraph,
         col_area: &LayoutRect,
@@ -6849,7 +6849,7 @@ pub(crate) fn calc_sibling_topandbottom_reserved_hu(
 /// `layout_picture_full` 가 본문/머리말/꼬리말 path 의 진입점 helper 인 것과 짝.
 #[allow(clippy::too_many_arguments)]
 fn make_picture_image_node(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     pic: &crate::model::image::Picture,
     section_index: usize,
     para_index: usize,

--- a/src/renderer/layout/picture_footnote.rs
+++ b/src/renderer/layout/picture_footnote.rs
@@ -56,7 +56,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_picture(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         parent_node: &mut RenderNode,
         picture: &crate::model::image::Picture,
         container: &LayoutRect,
@@ -93,7 +93,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_picture_full(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         parent_node: &mut RenderNode,
         picture: &crate::model::image::Picture,
         container: &LayoutRect,
@@ -389,7 +389,7 @@ impl LayoutEngine {
     /// 본문 그림(Picture) 개체를 레이아웃하고 업데이트된 y_offset을 반환한다.
     pub(crate) fn layout_body_picture(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         parent_node: &mut RenderNode,
         picture: &crate::model::image::Picture,
         container: &LayoutRect,
@@ -672,7 +672,7 @@ impl LayoutEngine {
     /// 캡션을 레이아웃한다.
     pub(crate) fn layout_caption(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         parent_node: &mut RenderNode,
         caption: &Caption,
         styles: &ResolvedStyleSet,
@@ -748,7 +748,7 @@ impl LayoutEngine {
 
     fn layout_caption_topbottom_pictures(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         parent_node: &mut RenderNode,
         para: &Paragraph,
         caption_area: &LayoutRect,
@@ -893,7 +893,7 @@ impl LayoutEngine {
     /// 각주 영역 레이아웃 (구분선 + 각주 문단들)
     pub(crate) fn layout_footnote_area(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         fn_node: &mut RenderNode,
         footnotes: &[FootnoteRef],
         paragraphs: &[Paragraph],
@@ -1043,7 +1043,7 @@ impl LayoutEngine {
     /// base_cs_id: 번호 스타일 결정용 기본 char_shape_id (문단의 char_shapes[0])
     pub(crate) fn layout_footnote_paragraph_with_number(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         parent: &mut RenderNode,
         composed: &ComposedParagraph,
         styles: &ResolvedStyleSet,
@@ -1188,7 +1188,7 @@ impl LayoutEngine {
     /// 마지막 TextLine의 마지막 TextRun 우측에 윗첨자 번호를 추가한다.
     pub(crate) fn add_footnote_superscripts(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         parent: &mut RenderNode,
         para: &Paragraph,
         _styles: &ResolvedStyleSet,
@@ -1516,7 +1516,7 @@ impl LayoutEngine {
     /// border_attr의 bit 0~5가 선 종류, border_width가 두께 (0이면 기본 0.1mm)
     pub(crate) fn render_picture_border(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         parent: &mut RenderNode,
         picture: &crate::model::image::Picture,
         x: f64,

--- a/src/renderer/layout/shape_layout.rs
+++ b/src/renderer/layout/shape_layout.rs
@@ -119,7 +119,7 @@ fn should_suppress_group_child_construction_stroke(drawing: &DrawingObjAttr) -> 
 }
 
 fn push_placeholder_render_node(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     parent: &mut RenderNode,
     bbox: BoundingBox,
     fill_color: u32,
@@ -152,7 +152,7 @@ fn ole_cell_context(
 }
 
 fn push_ole_placeholder_render_node(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     parent: &mut RenderNode,
     bbox: BoundingBox,
     fill_color: u32,
@@ -181,7 +181,7 @@ fn push_ole_placeholder_render_node(
 }
 
 fn push_raw_svg_render_node(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     parent: &mut RenderNode,
     bbox: BoundingBox,
     svg: String,
@@ -196,7 +196,7 @@ fn push_raw_svg_render_node(
 }
 
 fn push_ole_raw_svg_render_node(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     parent: &mut RenderNode,
     bbox: BoundingBox,
     svg: String,
@@ -221,7 +221,7 @@ fn push_ole_raw_svg_render_node(
 }
 
 fn push_ole_empty_para_end_anchor(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     parent: &mut RenderNode,
     anchor_x: f64,
     anchor_y: f64,
@@ -457,7 +457,7 @@ fn reflow_matrix_textbox_para(
 impl LayoutEngine {
     fn push_hwpx_hmapsi_preview_clip_node(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         parent: &mut RenderNode,
         bbox: BoundingBox,
         cfb_data: &[u8],
@@ -626,7 +626,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_shape(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         parent: &mut RenderNode,
         paragraphs: &[Paragraph],
         para_index: usize,
@@ -947,7 +947,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_group_child_affine(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         parent: &mut RenderNode,
         child: &crate::model::shape::ShapeObject,
         group_origin_x: f64,
@@ -1148,7 +1148,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_shape_object(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         parent: &mut RenderNode,
         shape: &crate::model::shape::ShapeObject,
         base_x: f64,
@@ -1192,7 +1192,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_shape_object_with_group_origin(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         parent: &mut RenderNode,
         shape: &crate::model::shape::ShapeObject,
         base_x: f64,
@@ -2220,7 +2220,7 @@ impl LayoutEngine {
     /// 도형의 이미지 채우기를 자식 이미지 노드로 추가한다.
     pub(crate) fn add_image_fill_node(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         parent: &mut RenderNode,
         drawing: &crate::model::shape::DrawingObjAttr,
         base_x: f64,
@@ -2307,7 +2307,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_textbox_content(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         shape_node: &mut RenderNode,
         drawing: &crate::model::shape::DrawingObjAttr,
         base_x: f64,
@@ -3158,7 +3158,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_vertical_textbox_text_with_paras(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         shape_node: &mut RenderNode,
         paragraphs: &[Paragraph],
         text_box: &crate::model::shape::TextBox,

--- a/src/renderer/layout/table_cell_content.rs
+++ b/src/renderer/layout/table_cell_content.rs
@@ -29,7 +29,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_vertical_cell_text(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         cell_node: &mut RenderNode,
         composed_paras: &[ComposedParagraph],
         paragraphs: &[Paragraph],
@@ -319,7 +319,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_cell_shape(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         cell_node: &mut RenderNode,
         shape: &crate::model::shape::ShapeObject,
         inner_area: &LayoutRect,
@@ -416,7 +416,7 @@ impl LayoutEngine {
     /// enclosing_ctx: (section_index, body_para_index, 상위 경로, 표의 컨트롤 인덱스)
     pub(crate) fn layout_embedded_table(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         parent: &mut RenderNode,
         table: &crate::model::table::Table,
         styles: &ResolvedStyleSet,

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -414,7 +414,7 @@ const NESTED_FRAGMENT_FRAME_INSET_EPSILON_PX: f64 = 0.05;
 const NESTED_FRAGMENT_FRAME_TARGET_EPSILON_PX: f64 = 0.05;
 
 fn push_fragment_border_line(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     table_node: &mut RenderNode,
     x1: f64,
     y1: f64,
@@ -489,7 +489,7 @@ fn reconstructs_clipped_fragment_bottom(table_node: &RenderNode) -> bool {
 /// frame was emitted (issue2007 p11/p14).  Prefer moving that exact source
 /// line inward; add a line only when the source did not retain one.
 fn ensure_fragment_horizontal_frame_inside_clip(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     table_node: &mut RenderNode,
     table_left: f64,
     table_right: f64,
@@ -780,7 +780,7 @@ fn suppress_future_nested_table_border_residue(node: &mut RenderNode, clip_botto
 /// this helper intentionally accepts the ancestor clip rather than requiring
 /// the table itself to own it (42065 p10-p14).
 fn reconstruct_nested_table_fragment_frame(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     table_node: &mut RenderNode,
     clip_top: f64,
     clip_bottom: f64,
@@ -918,7 +918,7 @@ fn reconstruct_nested_table_fragment_frame(
 /// repair first, while this pass reaches the real bordered table below an
 /// unbordered RowBreak wrapper.
 fn reconstruct_nested_table_descendant_fragment_frames(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     node: &mut RenderNode,
     clip_top: f64,
     clip_bottom: f64,
@@ -950,7 +950,7 @@ fn reconstruct_nested_table_descendant_fragment_frames(
 /// with current-page content, and the small source-spacer translation is
 /// limited to the direct siblings following a suppressed residual tail.
 fn repair_clipped_nested_table_fragment_frame(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     node: &mut RenderNode,
     suppress_bottom_text_residue: bool,
     repair_unclipped_hwpx_top_residue: bool,
@@ -1182,7 +1182,7 @@ fn repair_clipped_nested_table_fragment_frame(
 /// only delegates to the direct-child-table helper above, so it cannot widen a
 /// continuation's vertical viewport or reveal a future-page text tail.
 pub(super) fn extend_completed_nested_table_border_clips(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     node: &mut RenderNode,
     suppress_bottom_text_residue: bool,
     repair_unclipped_hwpx_top_residue: bool,
@@ -1311,7 +1311,7 @@ fn has_independent_col_row_y(col_row_y: &[Vec<f64>], row_y: &[f64]) -> bool {
 }
 
 fn render_cell_box_borders(
-    tree: &mut LayoutFrame,
+    tree: &mut PageLayoutContext,
     bs: &ResolvedBorderStyle,
     x: f64,
     y: f64,
@@ -2098,7 +2098,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_table(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         col_node: &mut RenderNode,
         table: &crate::model::table::Table,
         section_index: usize,
@@ -3917,7 +3917,7 @@ impl LayoutEngine {
     /// 셀 배경 렌더링 (fill_color + pattern + gradient)
     pub(crate) fn render_cell_background(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         cell_node: &mut RenderNode,
         border_style: Option<&crate::renderer::style_resolver::ResolvedBorderStyle>,
         cell_x: f64,
@@ -4241,7 +4241,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_horizontal_cell_paragraphs(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         table_node: &mut RenderNode,
         cell_node: &mut RenderNode,
         cell: &crate::model::table::Cell,
@@ -5856,7 +5856,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_table_cells(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         table_node: &mut RenderNode,
         table: &crate::model::table::Table,
         section_index: usize,

--- a/src/renderer/layout/table_partial.rs
+++ b/src/renderer/layout/table_partial.rs
@@ -700,7 +700,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_partial_table_cells(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         table_node: &mut RenderNode,
         table: &crate::model::table::Table,
         para_index: usize,
@@ -2598,7 +2598,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_partial_table(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         col_node: &mut RenderNode,
         paragraphs: &[Paragraph],
         para_index: usize,
@@ -2695,7 +2695,7 @@ impl LayoutEngine {
     #[allow(clippy::too_many_arguments)]
     fn layout_partial_table_resolved(
         &self,
-        tree: &mut LayoutFrame,
+        tree: &mut PageLayoutContext,
         col_node: &mut RenderNode,
         outer_table: &crate::model::table::Table,
         host: PartialTableHostContext<'_>,

--- a/src/renderer/layout_frame.rs
+++ b/src/renderer/layout_frame.rs
@@ -77,10 +77,19 @@ impl PhysicalRow {
     }
 }
 
+/// The side-wrap choices represented by this physical-row frame. This is
+/// layout geometry, rather than a mirror of model `TextFlow`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FrameExclusionPolicy {
+    BothSides,
+    LargestSide,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct FrameExclusion {
     pub(crate) horizontal: Range<i32>,
     pub(crate) vertical: Range<i32>,
+    pub(crate) policy: FrameExclusionPolicy,
 }
 
 /// Mutable geometry of one layout flow.
@@ -150,8 +159,25 @@ impl LayoutFrame {
                     if interval.end <= left || right <= interval.start {
                         carved.push(interval.clone());
                     } else if interval.start < left && right < interval.end {
-                        carved.push(interval.start..left);
-                        carved.push(right..interval.end);
+                        let left_interval = interval.start..left;
+                        let right_interval = right..interval.end;
+                        if exclusion.policy == FrameExclusionPolicy::LargestSide {
+                            let left_width = left_interval.end - left_interval.start;
+                            let right_width = right_interval.end - right_interval.start;
+                            // HWP's `LargestOnly` choice normally keeps the
+                            // widest side, ties left, and has one recovered
+                            // narrow-lane exception: a 1,440-HWP left lane
+                            // chooses the right side even when it is shorter.
+                            if left_width == MINIMUM_USABLE_INTERVAL_HWP || left_width < right_width
+                            {
+                                carved.push(right_interval);
+                            } else {
+                                carved.push(left_interval);
+                            }
+                        } else {
+                            carved.push(left_interval);
+                            carved.push(right_interval);
+                        }
                     } else if interval.start < left {
                         carved.push(interval.start..left);
                     } else if right < interval.end {
@@ -358,6 +384,7 @@ mod tests {
             vec![FrameExclusion {
                 horizontal: 0..60,
                 vertical: 1_000..3_000,
+                policy: FrameExclusionPolicy::BothSides,
             }],
         );
 
@@ -480,6 +507,7 @@ mod tests {
             vec![FrameExclusion {
                 horizontal: 35..65,
                 vertical: 0..1_000,
+                policy: FrameExclusionPolicy::BothSides,
             }],
         );
         assert_eq!(frame.carve(400), &[0..35, 65..100]);
@@ -513,5 +541,130 @@ mod tests {
         assert_eq!(projected[0].segment_width, 35);
         assert_eq!(projected[1].column_start, 65);
         assert_eq!(projected[1].segment_width, 35);
+    }
+
+    #[test]
+    fn both_sides_four_physical_rows_project_eight_segments() {
+        // `pic2` has two floating Pictures and is intentionally rejected by
+        // the one-Picture transaction. This independent frame proof keeps the
+        // core's ordinary two-interval physical-row behavior explicit.
+        let mut frame = frame(
+            0..100,
+            0,
+            vec![FrameExclusion {
+                horizontal: 35..65,
+                vertical: 0..1_000,
+                policy: FrameExclusionPolicy::BothSides,
+            }],
+        );
+
+        for row in 0..4 {
+            assert_eq!(frame.carve(100), &[0..35, 65..100]);
+            assert_eq!(
+                frame.commit_carved_row(
+                    metrics(100, 0),
+                    vec![
+                        RowSegment::new(
+                            (row * 2) as u32..(row * 2 + 1) as u32,
+                            0..35,
+                            LineSeg::TAG_FIRST_SEGMENT,
+                        ),
+                        RowSegment::new(
+                            (row * 2 + 1) as u32..(row * 2 + 2) as u32,
+                            65..100,
+                            LineSeg::TAG_LAST_SEGMENT,
+                        ),
+                    ],
+                ),
+                Some(row)
+            );
+        }
+
+        let projected = frame.project_line_segs();
+        assert_eq!(projected.len(), 8);
+        for (row, pair) in projected.chunks_exact(2).enumerate() {
+            assert_eq!(pair[0].vertical_pos, (row * 100) as i32);
+            assert_eq!(pair[1].vertical_pos, pair[0].vertical_pos);
+            assert_eq!(
+                (pair[0].column_start, pair[0].segment_width),
+                (0, 35),
+                "row {row} left interval"
+            );
+            assert_eq!(
+                (pair[1].column_start, pair[1].segment_width),
+                (65, 35),
+                "row {row} right interval"
+            );
+            assert!(pair[0].is_first_segment());
+            assert!(!pair[0].is_last_segment());
+            assert!(!pair[1].is_first_segment());
+            assert!(pair[1].is_last_segment());
+        }
+    }
+
+    #[test]
+    fn largest_side_carve_chooses_the_wider_right_lane() {
+        let mut frame = frame(
+            0..100,
+            0,
+            vec![FrameExclusion {
+                horizontal: 20..60,
+                vertical: 0..1_000,
+                policy: FrameExclusionPolicy::LargestSide,
+            }],
+        );
+
+        let expected = 60..100;
+        assert_eq!(frame.carve(100), std::slice::from_ref(&expected));
+    }
+
+    #[test]
+    fn largest_side_carve_breaks_a_tie_to_the_left_lane() {
+        let mut frame = frame(
+            0..100,
+            0,
+            vec![FrameExclusion {
+                horizontal: 30..70,
+                vertical: 0..1_000,
+                policy: FrameExclusionPolicy::LargestSide,
+            }],
+        );
+
+        let expected = 0..30;
+        assert_eq!(frame.carve(100), std::slice::from_ref(&expected));
+    }
+
+    #[test]
+    fn largest_side_carve_moves_a_1440_hwp_left_lane_to_the_right() {
+        let mut frame = frame(
+            0..10_000,
+            0,
+            vec![FrameExclusion {
+                horizontal: 1_440..9_000,
+                vertical: 0..1_000,
+                policy: FrameExclusionPolicy::LargestSide,
+            }],
+        );
+
+        let expected = 9_000..10_000;
+        assert_eq!(frame.carve(100), std::slice::from_ref(&expected));
+    }
+
+    #[test]
+    fn live_frame_retries_when_the_1440_exception_selects_an_unusable_right_lane() {
+        let mut frame = LayoutFrame::new(
+            0..10_000,
+            0,
+            vec![FrameExclusion {
+                horizontal: 1_440..9_000,
+                vertical: 0..1_000,
+                policy: FrameExclusionPolicy::LargestSide,
+            }],
+        );
+
+        let expected = 0..10_000;
+        assert_eq!(frame.carve(100), std::slice::from_ref(&expected));
+        assert_eq!(frame.top, 1_000);
+        assert_eq!(frame.next_geometry_event, None);
     }
 }

--- a/src/renderer/layout_frame.rs
+++ b/src/renderer/layout_frame.rs
@@ -2,6 +2,80 @@
 
 use std::ops::Range;
 
+use crate::model::paragraph::LineSeg;
+
+const SEGMENT_BOUNDARY_TAGS: u32 = LineSeg::TAG_FIRST_SEGMENT | LineSeg::TAG_LAST_SEGMENT;
+
+/// The vertical values shared by every horizontal segment in one physical row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FrameRowMetrics {
+    pub(crate) vertical_pos: i32,
+    pub(crate) line_height: i32,
+    pub(crate) text_height: i32,
+    pub(crate) baseline_distance: i32,
+    pub(crate) line_spacing: i32,
+}
+
+impl FrameRowMetrics {
+    fn from_line_seg(seg: &LineSeg) -> Self {
+        Self {
+            vertical_pos: seg.vertical_pos,
+            line_height: seg.line_height,
+            text_height: seg.text_height,
+            baseline_distance: seg.baseline_distance,
+            line_spacing: seg.line_spacing,
+        }
+    }
+}
+
+/// One horizontal part of a physical row before it is flattened into a
+/// `LineSeg`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RowSegment {
+    pub(crate) text_range: Range<u32>,
+    pub(crate) horizontal: Range<i32>,
+    /// The source tag retains provenance and line properties. Projection owns
+    /// the FIRST/LAST boundary bits because they describe this row's group.
+    pub(crate) source_tag: u32,
+}
+
+impl RowSegment {
+    pub(crate) fn new(text_range: Range<u32>, horizontal: Range<i32>, source_tag: u32) -> Self {
+        Self {
+            text_range,
+            horizontal,
+            source_tag: source_tag & !SEGMENT_BOUNDARY_TAGS,
+        }
+    }
+
+    fn from_single_line_seg(seg: &LineSeg) -> Option<Self> {
+        (seg.is_first_segment() && seg.is_last_segment() && seg.segment_width > 0).then(|| {
+            Self::new(
+                seg.text_start..seg.text_start,
+                seg.column_start..seg.column_start.saturating_add(seg.segment_width),
+                seg.tag,
+            )
+        })
+    }
+}
+
+/// A completed physical row. Its vertical values are recorded once, while its
+/// horizontal segments retain their left-to-right order until projection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PhysicalRow {
+    metrics: FrameRowMetrics,
+    segments: Vec<RowSegment>,
+}
+
+impl PhysicalRow {
+    fn from_single_line_seg(seg: &LineSeg) -> Option<Self> {
+        Some(Self {
+            metrics: FrameRowMetrics::from_line_seg(seg),
+            segments: vec![RowSegment::from_single_line_seg(seg)?],
+        })
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct FrameExclusion {
     pub(crate) horizontal: Range<i32>,
@@ -20,6 +94,7 @@ pub(crate) struct LayoutFrame {
     pub(crate) current_intervals: Vec<Range<i32>>,
     pub(crate) next_geometry_event: Option<i32>,
     pub(crate) minimum_width: i32,
+    rows: Vec<PhysicalRow>,
 }
 
 impl LayoutFrame {
@@ -119,25 +194,141 @@ impl LayoutFrame {
             return &self.current_intervals;
         }
     }
+
+    /// Retain stored rows only when each stored `LineSeg` is a complete,
+    /// single-segment physical row. A split FIRST/LAST group has to be
+    /// reflowed as one row instead of being flattened into this scalar entry.
+    pub(crate) fn retain_preserved_single_segment_rows(&mut self, line_segs: &[LineSeg]) -> bool {
+        let Some(rows) = line_segs
+            .iter()
+            .map(PhysicalRow::from_single_line_seg)
+            .collect::<Option<Vec<_>>>()
+        else {
+            return false;
+        };
+
+        if let Some(last) = rows.last() {
+            self.top = last
+                .metrics
+                .vertical_pos
+                .saturating_add(last.metrics.line_height)
+                .saturating_add(last.metrics.line_spacing);
+            self.current_intervals.clear();
+            self.next_geometry_event = None;
+        }
+        self.rows.extend(rows);
+        true
+    }
+
+    /// Commit the row carved at the current frame position.
+    ///
+    /// The caller supplies exactly one text result for every interval returned
+    /// by `carve`. The frame gives all of them one vertical position, retains
+    /// them as one physical row, then advances exactly once.
+    pub(crate) fn commit_carved_row(
+        &mut self,
+        mut metrics: FrameRowMetrics,
+        segments: Vec<RowSegment>,
+    ) -> Option<usize> {
+        if self.current_intervals.is_empty()
+            || segments.len() != self.current_intervals.len()
+            || segments
+                .iter()
+                .zip(&self.current_intervals)
+                .any(|(segment, interval)| segment.horizontal != *interval)
+        {
+            return None;
+        }
+
+        metrics.vertical_pos = self.top;
+        let row_index = self.rows.len();
+        self.rows.push(PhysicalRow { metrics, segments });
+        self.top = self
+            .top
+            .saturating_add(metrics.line_height)
+            .saturating_add(metrics.line_spacing);
+        // A carved interval belongs only to the row just committed. Requiring
+        // a new carve prevents a caller from advancing this frame twice with
+        // stale geometry.
+        self.current_intervals.clear();
+        Some(row_index)
+    }
+
+    pub(crate) fn row_count(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Flatten retained physical rows at the document boundary.
+    pub(crate) fn project_line_segs(&self) -> Vec<LineSeg> {
+        let mut projected = Vec::new();
+
+        for row in &self.rows {
+            let last_segment = row.segments.len().saturating_sub(1);
+            for (segment_index, segment) in row.segments.iter().enumerate() {
+                let mut tag = segment.source_tag & !SEGMENT_BOUNDARY_TAGS;
+                if segment_index == 0 {
+                    tag |= LineSeg::TAG_FIRST_SEGMENT;
+                }
+                if segment_index == last_segment {
+                    tag |= LineSeg::TAG_LAST_SEGMENT;
+                }
+                projected.push(LineSeg {
+                    text_start: segment.text_range.start,
+                    vertical_pos: row.metrics.vertical_pos,
+                    line_height: row.metrics.line_height,
+                    text_height: row.metrics.text_height,
+                    baseline_distance: row.metrics.baseline_distance,
+                    line_spacing: row.metrics.line_spacing,
+                    column_start: segment.horizontal.start,
+                    segment_width: segment
+                        .horizontal
+                        .end
+                        .saturating_sub(segment.horizontal.start),
+                    tag,
+                });
+            }
+        }
+
+        projected
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn taller_candidate_recarves_before_the_row_is_committed() {
-        let mut frame = LayoutFrame {
-            horizontal: 0..100,
-            top: 0,
-            exclusions: vec![FrameExclusion {
-                horizontal: 0..60,
-                vertical: 1_000..3_000,
-            }],
+    fn metrics(line_height: i32, line_spacing: i32) -> FrameRowMetrics {
+        FrameRowMetrics {
+            vertical_pos: -1,
+            line_height,
+            text_height: line_height - 10,
+            baseline_distance: line_height - 20,
+            line_spacing,
+        }
+    }
+
+    fn frame(horizontal: Range<i32>, top: i32, exclusions: Vec<FrameExclusion>) -> LayoutFrame {
+        LayoutFrame {
+            horizontal,
+            top,
+            exclusions,
             current_intervals: Vec::new(),
             next_geometry_event: None,
             minimum_width: 1,
-        };
+            rows: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn taller_candidate_recarves_before_the_row_is_committed() {
+        let mut frame = frame(
+            0..100,
+            0,
+            vec![FrameExclusion {
+                horizontal: 0..60,
+                vertical: 1_000..3_000,
+            }],
+        );
 
         let carved = frame.carve(900);
         assert_eq!(carved.len(), 1);
@@ -154,5 +345,142 @@ mod tests {
         assert_eq!(carved.len(), 1);
         assert_eq!(carved[0], 0..100);
         assert_eq!(frame.top, 3_000);
+    }
+
+    #[test]
+    fn committed_row_projects_one_complete_lineseg_group_and_advances_once() {
+        let mut frame = frame(10..110, 500, Vec::new());
+        let carved = frame.carve(900);
+        assert_eq!(carved.len(), 1);
+        assert_eq!(carved[0], 10..110);
+
+        assert_eq!(
+            frame.commit_carved_row(
+                metrics(900, 100),
+                vec![RowSegment::new(
+                    7..31,
+                    10..110,
+                    LineSeg::TAG_IMPLEMENTATION_PROPERTY | LineSeg::TAG_FIRST_SEGMENT,
+                )],
+            ),
+            Some(0)
+        );
+        assert_eq!(frame.top, 1_500);
+        assert_eq!(frame.row_count(), 1);
+        assert_eq!(frame.commit_carved_row(metrics(900, 100), Vec::new()), None);
+        assert_eq!(frame.top, 1_500);
+
+        let projected = frame.project_line_segs();
+        assert_eq!(projected.len(), 1);
+        assert_eq!(projected[0].text_start, 7);
+        assert_eq!(projected[0].vertical_pos, 500);
+        assert_eq!(projected[0].column_start, 10);
+        assert_eq!(projected[0].segment_width, 100);
+        assert!(projected[0].is_first_segment());
+        assert!(projected[0].is_last_segment());
+        assert_ne!(projected[0].tag & LineSeg::TAG_IMPLEMENTATION_PROPERTY, 0);
+    }
+
+    #[test]
+    fn retains_only_complete_single_segment_rows() {
+        let stored = [
+            LineSeg {
+                text_start: 0,
+                vertical_pos: 100,
+                line_height: 300,
+                text_height: 280,
+                baseline_distance: 250,
+                line_spacing: 20,
+                column_start: 40,
+                segment_width: 60,
+                tag: LineSeg::TAG_SINGLE_SEGMENT_LINE,
+            },
+            LineSeg {
+                text_start: 12,
+                vertical_pos: 420,
+                line_height: 300,
+                text_height: 280,
+                baseline_distance: 250,
+                line_spacing: 20,
+                column_start: 40,
+                segment_width: 60,
+                tag: LineSeg::TAG_SINGLE_SEGMENT_LINE | LineSeg::TAG_IMPLEMENTATION_PROPERTY,
+            },
+        ];
+        let mut frame = frame(0..100, 0, Vec::new());
+
+        assert!(frame.retain_preserved_single_segment_rows(&stored));
+        assert_eq!(frame.row_count(), 2);
+        assert_eq!(frame.top, 740);
+        let projected = frame.project_line_segs();
+        assert_eq!(projected.len(), 2);
+        assert_eq!(projected[1].text_start, 12);
+        assert_eq!(projected[1].vertical_pos, 420);
+        assert!(projected
+            .iter()
+            .all(|segment| { segment.is_first_segment() && segment.is_last_segment() }));
+
+        let split_row = [
+            LineSeg {
+                tag: LineSeg::TAG_FIRST_SEGMENT,
+                ..Default::default()
+            },
+            LineSeg {
+                tag: LineSeg::TAG_LAST_SEGMENT,
+                ..Default::default()
+            },
+        ];
+        assert!(!frame.retain_preserved_single_segment_rows(&split_row));
+        assert_eq!(frame.row_count(), 2);
+
+        let empty_geometry = [LineSeg {
+            tag: LineSeg::TAG_SINGLE_SEGMENT_LINE,
+            ..Default::default()
+        }];
+        assert!(!frame.retain_preserved_single_segment_rows(&empty_geometry));
+        assert_eq!(frame.row_count(), 2);
+    }
+
+    #[test]
+    fn one_physical_row_projects_each_carved_interval_with_shared_metrics() {
+        let mut frame = frame(
+            0..100,
+            200,
+            vec![FrameExclusion {
+                horizontal: 35..65,
+                vertical: 0..1_000,
+            }],
+        );
+        assert_eq!(frame.carve(400), &[0..35, 65..100]);
+
+        assert_eq!(
+            frame.commit_carved_row(
+                metrics(400, 50),
+                vec![
+                    RowSegment::new(0..4, 0..35, LineSeg::TAG_FIRST_SEGMENT),
+                    RowSegment::new(
+                        4..9,
+                        65..100,
+                        LineSeg::TAG_LAST_SEGMENT | LineSeg::TAG_IMPLEMENTATION_PROPERTY,
+                    ),
+                ],
+            ),
+            Some(0)
+        );
+        assert_eq!(frame.top, 650);
+
+        let projected = frame.project_line_segs();
+        assert_eq!(projected.len(), 2);
+        assert_eq!(projected[0].vertical_pos, 200);
+        assert_eq!(projected[1].vertical_pos, 200);
+        assert_eq!(projected[0].line_height, projected[1].line_height);
+        assert!(projected[0].is_first_segment());
+        assert!(!projected[0].is_last_segment());
+        assert!(!projected[1].is_first_segment());
+        assert!(projected[1].is_last_segment());
+        assert_eq!(projected[0].column_start, 0);
+        assert_eq!(projected[0].segment_width, 35);
+        assert_eq!(projected[1].column_start, 65);
+        assert_eq!(projected[1].segment_width, 35);
     }
 }

--- a/src/renderer/layout_frame.rs
+++ b/src/renderer/layout_frame.rs
@@ -1,0 +1,158 @@
+//! Physical-row geometry for paragraph layout.
+
+use std::ops::Range;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FrameExclusion {
+    pub(crate) horizontal: Range<i32>,
+    pub(crate) vertical: Range<i32>,
+}
+
+/// Mutable geometry of one layout flow.
+///
+/// A carve is tentative. It may move the candidate row to an exact geometry
+/// event, but it does not commit text or advance past a completed row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LayoutFrame {
+    pub(crate) horizontal: Range<i32>,
+    pub(crate) top: i32,
+    pub(crate) exclusions: Vec<FrameExclusion>,
+    pub(crate) current_intervals: Vec<Range<i32>>,
+    pub(crate) next_geometry_event: Option<i32>,
+    pub(crate) minimum_width: i32,
+}
+
+impl LayoutFrame {
+    /// Carve the current physical row into ordered horizontal intervals.
+    pub(crate) fn carve(&mut self, band_height: i32) -> &[Range<i32>] {
+        let old_max = self.next_geometry_event.map(|_| {
+            self.current_intervals
+                .iter()
+                .map(|interval| interval.end - interval.start)
+                .max()
+                .unwrap_or(0)
+        });
+        let mut candidate_top = self.top;
+
+        loop {
+            let bottom = candidate_top.saturating_add(band_height.max(0));
+            let base = self.horizontal.clone();
+            let mut intervals = vec![base.clone()];
+            let mut next_geometry_event = None;
+            let minimum_width = self.minimum_width.max(0);
+            let mut adequate = base.end - base.start >= minimum_width;
+
+            for exclusion in &self.exclusions {
+                if exclusion.vertical.start >= bottom || candidate_top >= exclusion.vertical.end {
+                    continue;
+                }
+
+                let before = intervals.clone();
+                let left = exclusion.horizontal.start;
+                let right = exclusion.horizontal.end;
+                let mut carved = Vec::with_capacity(intervals.len() + 1);
+
+                for interval in &intervals {
+                    if interval.end <= left || right <= interval.start {
+                        carved.push(interval.clone());
+                    } else if interval.start < left && right < interval.end {
+                        carved.push(interval.start..left);
+                        carved.push(right..interval.end);
+                    } else if interval.start < left {
+                        carved.push(interval.start..left);
+                    } else if right < interval.end {
+                        carved.push(right..interval.end);
+                    } else {
+                        carved.push(interval.start..interval.start);
+                    }
+                }
+
+                let changed = before != carved;
+                intervals = carved;
+                if changed {
+                    next_geometry_event = Some(
+                        next_geometry_event.map_or(exclusion.vertical.end, |event: i32| {
+                            event.min(exclusion.vertical.end)
+                        }),
+                    );
+                }
+
+                adequate = intervals
+                    .iter()
+                    .any(|interval| interval.end - interval.start >= minimum_width);
+                if !adequate {
+                    break;
+                }
+            }
+
+            let mut index = 0;
+            while intervals.len() > 1 && index < intervals.len() {
+                if intervals[index].end - intervals[index].start < minimum_width {
+                    intervals.remove(index);
+                } else {
+                    index += 1;
+                }
+            }
+
+            let retry = if !adequate {
+                next_geometry_event.filter(|event| *event > candidate_top)
+            } else {
+                let new_max = intervals
+                    .iter()
+                    .map(|interval| interval.end - interval.start)
+                    .max()
+                    .unwrap_or(0);
+                old_max
+                    .filter(|previous| *previous > new_max)
+                    .and(next_geometry_event)
+                    .filter(|event| *event > candidate_top)
+            };
+
+            if let Some(event) = retry {
+                candidate_top = event;
+                continue;
+            }
+
+            self.top = candidate_top;
+            self.current_intervals = intervals;
+            self.next_geometry_event = next_geometry_event;
+            return &self.current_intervals;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn taller_candidate_recarves_before_the_row_is_committed() {
+        let mut frame = LayoutFrame {
+            horizontal: 0..100,
+            top: 0,
+            exclusions: vec![FrameExclusion {
+                horizontal: 0..60,
+                vertical: 1_000..3_000,
+            }],
+            current_intervals: Vec::new(),
+            next_geometry_event: None,
+            minimum_width: 1,
+        };
+
+        let carved = frame.carve(900);
+        assert_eq!(carved.len(), 1);
+        assert_eq!(carved[0], 0..100);
+        assert_eq!(frame.top, 0);
+
+        let carved = frame.carve(2_000);
+        assert_eq!(carved.len(), 1);
+        assert_eq!(carved[0], 60..100);
+        assert_eq!(frame.next_geometry_event, Some(3_000));
+
+        frame.top = 3_000;
+        let carved = frame.carve(2_000);
+        assert_eq!(carved.len(), 1);
+        assert_eq!(carved[0], 0..100);
+        assert_eq!(frame.top, 3_000);
+    }
+}

--- a/src/renderer/layout_frame.rs
+++ b/src/renderer/layout_frame.rs
@@ -5,6 +5,7 @@ use std::ops::Range;
 use crate::model::paragraph::LineSeg;
 
 const SEGMENT_BOUNDARY_TAGS: u32 = LineSeg::TAG_FIRST_SEGMENT | LineSeg::TAG_LAST_SEGMENT;
+const MINIMUM_USABLE_INTERVAL_HWP: i32 = 1_440;
 
 /// The vertical values shared by every horizontal segment in one physical row.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -98,6 +99,24 @@ pub(crate) struct LayoutFrame {
 }
 
 impl LayoutFrame {
+    /// Start a paragraph-local physical frame at a known horizontal extent.
+    pub(crate) fn new(horizontal: Range<i32>, top: i32, exclusions: Vec<FrameExclusion>) -> Self {
+        Self {
+            horizontal,
+            top,
+            exclusions,
+            current_intervals: Vec::new(),
+            next_geometry_event: None,
+            minimum_width: MINIMUM_USABLE_INTERVAL_HWP,
+            rows: Vec::new(),
+        }
+    }
+
+    /// Discard an uncommitted row trial and restore its exact frame state.
+    pub(crate) fn restore_checkpoint(&mut self, checkpoint: Self) {
+        *self = checkpoint;
+    }
+
     /// Carve the current physical row into ordered horizontal intervals.
     pub(crate) fn carve(&mut self, band_height: i32) -> &[Range<i32>] {
         let old_max = self.next_geometry_event.map(|_| {
@@ -290,6 +309,18 @@ impl LayoutFrame {
         }
 
         projected
+    }
+
+    /// Flatten only rows appended after a paragraph-local checkpoint.
+    pub(crate) fn project_line_segs_since(&self, first_row: usize) -> Vec<LineSeg> {
+        let first_segment = self.rows[..first_row.min(self.rows.len())]
+            .iter()
+            .map(|row| row.segments.len())
+            .sum();
+        self.project_line_segs()
+            .into_iter()
+            .skip(first_segment)
+            .collect()
     }
 }
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod image_header;
 pub mod image_resolver;
 pub mod layer_renderer;
 pub mod layout;
+pub(crate) mod layout_frame;
 pub mod page_layout;
 pub mod page_number;
 pub mod pagination;

--- a/src/renderer/render_tree.rs
+++ b/src/renderer/render_tree.rs
@@ -1479,7 +1479,7 @@ pub(crate) fn doc_path_for_node(node: &RenderNode) -> Option<DocPath> {
 /// 런타임에 확인하던 자리(`shape_layout.rs` 의 hmapsi 미리보기 게이트)는, 프레임이 페이지
 /// 기하 없이는 생성될 수 없다는 이 구성 불변식으로 대체됐다.
 #[derive(Debug, Clone)]
-pub struct LayoutFrame {
+pub struct PageLayoutContext {
     /// 다음 노드 ID 카운터
     next_id: NodeId,
     /// 인라인 Shape 좌표 맵: (section, para, control, cell_path) → (x, y)
@@ -1490,7 +1490,7 @@ pub struct LayoutFrame {
     page_bbox: BoundingBox,
 }
 
-impl LayoutFrame {
+impl PageLayoutContext {
     /// 새 흐름 상태. id 는 root(0) 다음부터 발급한다.
     pub fn new(page_index: u32, width: f64, height: f64) -> Self {
         Self {
@@ -1580,6 +1580,9 @@ impl LayoutFrame {
     }
 }
 
+#[deprecated(note = "use PageLayoutContext")]
+pub type LayoutFrame = PageLayoutContext;
+
 /// 한 페이지의 렌더 트리
 #[derive(Debug, Clone, Serialize)]
 pub struct PageRenderTree {
@@ -1587,7 +1590,7 @@ pub struct PageRenderTree {
     pub root: RenderNode,
     /// 레이아웃 흐름 상태 (id 카운터 + 인라인 Shape 레지스트리). 직렬화 대상 아님.
     #[serde(skip)]
-    pub(crate) frame: LayoutFrame,
+    pub(crate) frame: PageLayoutContext,
 }
 
 /// `clip_overlapping_same_bin_images` 전용 대략적 replay plane 분류.
@@ -1632,12 +1635,12 @@ impl PageRenderTree {
         );
         Self {
             root,
-            frame: LayoutFrame::new(page_index, width, height),
+            frame: PageLayoutContext::new(page_index, width, height),
         }
     }
 
     /// 레이아웃 흐름 상태 가변 참조 — 재귀 진입 시 `&mut tree.frame` 으로 넘긴다.
-    pub(crate) fn frame_mut(&mut self) -> &mut LayoutFrame {
+    pub(crate) fn frame_mut(&mut self) -> &mut PageLayoutContext {
         &mut self.frame
     }
 
@@ -1660,7 +1663,7 @@ impl PageRenderTree {
             .set_inline_shape_position(sec, para, ctrl, cell_ctx, x, y);
     }
 
-    /// 인라인 Shape 좌표 조회 (셀 컨텍스트 포함). `LayoutFrame` 위임.
+    /// 인라인 Shape 좌표 조회 (셀 컨텍스트 포함). `PageLayoutContext` 위임.
     pub fn get_inline_shape_position(
         &self,
         sec: usize,
@@ -1853,7 +1856,7 @@ impl PageRenderTree {
 }
 
 impl Deref for PageRenderTree {
-    type Target = LayoutFrame;
+    type Target = PageLayoutContext;
 
     fn deref(&self) -> &Self::Target {
         &self.frame

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -17024,6 +17024,22 @@ impl TypesetEngine {
                     }
                 }
             }
+            let has_owned_rowbreak_tac_frame = st.profile.hwpx_stored_layout()
+                && tac_count == 1
+                && fmt.line_heights.len() == 1
+                && para
+                    .controls
+                    .iter()
+                    .enumerate()
+                    .any(|(control_index, control)| {
+                        matches!(control, Control::Table(table)
+                        if self.is_effective_tac_table(para, table, &fmt))
+                            && crate::renderer::composer::owned_rowbreak_tac_height(
+                                para,
+                                control_index,
+                            )
+                            .is_some()
+                    });
             // [#3738] 위 합은 표만 센다. 그런데 같은 문단의 **선행 자리차지 개체가
             // 있는** TAC 그림/글상자는 Task #402 경로가 자기 line_seg 만큼 이미
             // current_height 에 더했다(위 13980 블록). cap 이 그 줄을 빼놓으면
@@ -17090,7 +17106,12 @@ impl TypesetEngine {
                         _ => None,
                     })
                     .sum();
-                (effective_sb + outer_top + tac_seg_total).min(fmt.total_height)
+                let owned_row_total = effective_sb + outer_top + tac_seg_total;
+                if has_owned_rowbreak_tac_frame {
+                    owned_row_total
+                } else {
+                    owned_row_total.min(fmt.total_height)
+                }
             } else {
                 fmt.total_height
             };
@@ -17466,6 +17487,12 @@ impl TypesetEngine {
             tac_table_line_idx.unwrap_or(0)
         };
 
+        let owned_single_tac_row_height =
+            (st.profile.hwpx_stored_layout() && tac_count == 1 && fmt.line_heights.len() == 1)
+                .then(|| crate::renderer::composer::owned_rowbreak_tac_height(para, ctrl_idx))
+                .flatten()
+                .map(|height| hwpunit_to_px(height, self.dpi));
+
         // [Task #1152] 호스트 문단의 intra-paragraph vpos-reset 가드 —
         // (a) 빈-host ctrl 1:1 매핑(원형), (b) [#2322] 텍스트-host 포함 일반형:
         // 표의 매핑 lineseg(tac_seg_idx>0)가 저장 vpos==0 이면 "이 표를 새 쪽
@@ -17506,6 +17533,8 @@ impl TypesetEngine {
                     }
                 })
                 .unwrap_or(ft.total_height)
+        } else if let Some(owned_row_height) = owned_single_tac_row_height {
+            owned_row_height
         } else if tac_table_line_idx == Some(0) && fmt.line_heights.len() > 1 {
             // PR #1088 follow-up: hwp-multi-001 pi=46 처럼 TAC 표가 문단의
             // 첫 줄이고 뒤따르는 제목 줄이 같은 문단의 line1(vpos reset)로

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -14224,7 +14224,7 @@ impl TypesetEngine {
     ) -> f64 {
         use crate::renderer::layout::{layout_rect_to_bbox, LayoutEngine};
         use crate::renderer::page_layout::LayoutRect;
-        use crate::renderer::render_tree::{LayoutFrame, RenderNode, RenderNodeType};
+        use crate::renderer::render_tree::{PageLayoutContext, RenderNode, RenderNodeType};
 
         // 렌더 `layout_column_item` 의 FullParagraph 텍스트 경로 정합: 실제 텍스트가 있는 para 는
         // **leading 컨트롤-전용 줄**(수식 객체마커 ￼ 등)을 건너뛰고 첫 텍스트 줄부터 그린다.
@@ -14259,10 +14259,10 @@ impl TypesetEngine {
         };
         // [#4277] 페이지네이션 측정은 paint 트리를 만들지 않는다 — 레이아웃 재귀가 실제로
         // 쓰는 건 흐름 상태(id 카운터 + 인라인 Shape 레지스트리 + 페이지 기하)뿐이므로
-        // `LayoutFrame` 만 만든다. `col_node` 는 방출된 노드를 받는 sink 로만 쓰이고
+        // `PageLayoutContext` 만 만든다. `col_node` 는 방출된 노드를 받는 sink 로만 쓰이고
         // 높이만 읽은 뒤 버려진다.
         let scratch = LayoutEngine::new(self.dpi);
-        let mut frame = LayoutFrame::new(0, en_col_w, height);
+        let mut frame = PageLayoutContext::new(0, en_col_w, height);
         let col_id = frame.next_id();
         let mut col_node = RenderNode::new(
             col_id,


### PR DESCRIPTION
## 변경 요약

`reflow_line_segs()`가 문단을 하나의 고정 폭으로 먼저 확정하면서, 표 셀의 실제 내용 폭과 그림 회피 영역처럼 한 물리 행에 여러 가로 구간이 생기는 경우 저장된 LineSeg 기하와 비캐시 재계산 결과가 달라졌습니다.

`LayoutFrame::carve()`가 현재 물리 행의 가용 구간을 결정하고, 그 구간들에 텍스트를 이어 배치한 뒤 같은 행의 LineSeg에 공통 세로 지표를 기록하고 프레임을 한 번만 전진하도록 변경합니다. 본문, 표 소유 폭·여백, 그림 배치 영역과 편집 시 재계산이 같은 프레임 계약을 사용하며, render tree는 완성된 LineSeg만 소비합니다. 그림 배치 영역 안의 본문 편집은 shadow 상태에서 전체 영역을 다시 계산하고, 단 이동 수렴 뒤 한 번만 게시합니다.

구현 의미와 검증 경계는 `mydocs/plans/task_m100_3211_layout_frame_correctness.md`에 기록했습니다.

## 관련 이슈

- Closes #3211
- Refs #4279
- Supersedes #4315
- 글꼴 shaping과 kerning에 따른 줄 경계 차이는 #4439에서 별도로 추적합니다.

## 테스트

- [x] `cargo build --release`
- [x] `cargo test --release --lib` — 3,647 passed, 13 ignored
- [x] `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast` — 5,977/5,978 passed; 유일한 wall-clock timing flake인 `scan_cost_stays_linear_as_input_grows`는 같은 release-test binary의 LLDB focused 실행에서 1/1 passed (clean 8.52x, dirty 7.74x; 40x 상한)
- [x] Native Skia — lib 58/58, missing-picture 2/2, direct PDF 4/4
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --doc` — 4 passed, 2 ignored
- [x] `(cd rhwp-studio && npx tsc --noEmit)`
- [x] `npm --prefix rhwp-studio test` — 922 passed, 1 skipped
- [x] `wasm-pack build --target web --out-dir pkg`

## 성능 영향 및 측정 결과

- 예상 영향: 정확성 우선. 그림 배치 영역의 본문 편집은 영향받는 전체 영역을 shadow 상태에서 재계산합니다.
- 재현·측정: 절대 성능은 미측정했습니다. 캐시 계층 변경은 이 PR에 포함하지 않습니다.

## 스크린샷

별도 스크린샷은 없습니다. 전체 release-test의 SVG snapshot과 관련 페이지네이션 회귀를 통과했습니다.
