### PR TITLE
docs(pr): PR 템플릿 테스트 절에 스튜디오 검증 어휘(e2e·편집 게이트) 추가

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,7 @@ closes #
 - [ ] `cargo clippy -- -D warnings` 통과
 - [ ] 관련 샘플 파일로 SVG 내보내기 확인
 - [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)
+- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오(`rhwp-studio/e2e/…`) 또는 편집 커맨드 리뷰 체크리스트(`mydocs/manual/edit_command_review_checklist.md`) 통과 · 링크:
 - [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부 — `rhwp replay --capsule` 영수증 캡슐 또는 관련 `--json` 봉투 원문 ([AGENTS.md 작업 증빙 절](../AGENTS.md#작업-증빙--에이전트-기본-경로-권장))
 - [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시: [capability 카탈로그](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/agent_capability_registry.md)의 등록·검증 규칙을 반영
 


### PR DESCRIPTION
## 정정 공지

이 PR의 최초 버전은 "PR 템플릿이 0바이트라 채운다"는 **잘못된 전제**로 기존
템플릿을 통째로 교체했다. 실제로는 `git show`/`cat-file` 이 이 경로에서 빈 값을
반환하는 환경 문제에 속은 것이고, `devel` 에는 **이미 충실한 템플릿**(base 브랜치
경고·작업 증빙 `replay --capsule` 캡슐·capability 카탈로그·성능·스크린샷)이 있었다.
강제 갱신으로 **가산적 한 줄 추가**로 바로잡았다.

## 무엇을 / 왜

기존 템플릿은 이미 **CLI 검증 온램프**(작업 증빙 `replay --capsule` 영수증 캡슐)를
갖췄다. 그러나 독립 기여자 PR 을 역분석하니 **스튜디오·UI 기여자**(Tommy·johndoekim)의
검증 산출(**e2e·편집 커맨드 리뷰 체크리스트**)을 위한 칸이 없어, 그들의 검증이
템플릿에서 집계되지 않았다.

part of #4756 (자연 온램프 1/4)

## 변경 (딱 한 줄)

`## 테스트` 절에 스튜디오 검증 어휘를 추가한다:

```
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오(rhwp-studio/e2e/…) 또는
      편집 커맨드 리뷰 체크리스트(mydocs/manual/edit_command_review_checklist.md) 통과 · 링크:
```

나머지 템플릿은 **그대로** 보존한다. johndoekim 류의 e2e 작업·Tommy 류의 studio
변경이 이미 가진 산출물에 **이름만 붙여** 검증 절에서 자기 위치를 밝히게 된다.

## 검증

- `git diff --stat`: **1 file changed, 1 insertion(+)** (순수 가산, 파괴 없음)
- 마크다운 링크 검사 5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
