### PR TITLE
fix(studio): Vite native config loader 호환성 개선

### DIFF
--- a/mydocs/orders/20260814.md
+++ b/mydocs/orders/20260814.md
@@ -135,3 +135,16 @@
   [#4764](https://github.com/edwardkim/rhwp/issues/4764)에서 추적한다.
 - 이 trailing review-only head의 preflight와 Build & Test aggregate가 성공하고 최신 mergeability와
   작업지시자 승인을 확인한 뒤에만 squash merge와 후속 처리를 진행한다.
+
+## PR #4766 - Vite native config loader 호환성 개선
+
+- [PR #4766](https://github.com/edwardkim/rhwp/pull/4766)은 [#4765](https://github.com/edwardkim/rhwp/issues/4765)의
+  `rhwp-studio` Vite 설정에서 CommonJS `__dirname` 의존을 ESM `import.meta.dirname` 기준 경로로 교체한다.
+  alias, WASM, sample, npm 경로는 설정 파일 상대 위치를 유지하며 renderer 동작은 바꾸지 않는다.
+- Studio TypeScript 검사와 923개 패키지 테스트(922 passed, 0 failed, 1 skipped), native config-loader Vite
+  기동을 완료했다. `__dirname` config-loader 경고는 사라졌고 WASI experimental warning은 별도 Node/Vite
+  의존 도구 체인 경고로 남는다.
+- code candidate `724664ed3`의 Frontend package gates, CodeQL, Render Diff canvas/PDF 비교와 CanvasKit
+  readiness gate가 성공했다. 상세 근거는 [PR review](../pr/archives/pr_4766_review.md)에 보존한다.
+- 이 trailing review-only head의 최신 CI와 mergeability를 다시 확인한 뒤 squash merge하고, #4765 자동 종료와
+  remote branch 정리를 post-merge 절차로 처리한다.

--- a/mydocs/pr/archives/pr_4766_review.md
+++ b/mydocs/pr/archives/pr_4766_review.md
@@ -1,0 +1,53 @@
+---
+kind: pr_review
+status: active
+pr: 4766
+issue: 4765
+last_verified: 2026-08-14
+---
+
+# PR #4766 검토: Vite native config loader 호환성 개선
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4766](https://github.com/edwardkim/rhwp/pull/4766) |
+| 관련 이슈 | [#4765](https://github.com/edwardkim/rhwp/issues/4765) |
+| 작성자 | `jangster77` |
+| base / head | `devel` / `task_m100_4765` |
+| code candidate | `724664ed3e7201dbf9736ae52b1a00093fbb9a0d` |
+| 작성 시점 merge 상태 | `MERGEABLE`, `CLEAN` |
+| 규모 | 2 files, +36 / -11 |
+
+base route: collaborator_self_merge
+modifiers: intake_and_review.md, local_validation.md
+loaded documents: pr_review_workflow.md, pr_review/README.md, collaborator_self_merge.md, intake_and_review.md, local_validation.md
+current head: `724664ed3e7201dbf9736ae52b1a00093fbb9a0d`
+
+## 변경 범위와 판정
+
+- `rhwp-studio/vite.config.ts`에서 설정 파일 기준 디렉터리를 `import.meta.dirname`으로 한 번 계산한다.
+- `package.json`, WASM, sample, npm 경로는 모두 같은 설정 파일 상대 위치를 계속 사용한다.
+- Canvas 렌더러, 문서 레이아웃, 런타임 WASM 계약은 바꾸지 않으므로 별도 시각 fixture 증적은 필요하지 않다.
+- Render Diff CI는 변경 분류 후 canvas/PDF 비교와 CanvasKit readiness gate를 실제로 실행해 성공했다.
+
+## 검증 결과
+
+로컬 Node.js 24 환경에서 다음을 완료했다.
+
+- `(cd rhwp-studio && npx tsc --noEmit)` 통과
+- `npm --prefix rhwp-studio test` 통과: 922 passed, 0 failed, 1 skipped
+- `cd rhwp-studio && npx vite --configLoader native --host 127.0.0.1 --port 7701 --clearScreen false` 정상 기동
+  - Vite native config-loader의 `__dirname` 경고는 재현되지 않았다.
+  - Node/Vite 의존 도구 체인의 WASI experimental warning은 남았으며, 이번 설정 경고와 별개다.
+
+로컬에는 Node.js 22가 설치되어 있지 않아, CI의 Node.js 22 환경은 GitHub Actions 결과로 확인했다.
+
+- [CI run 31789409561](https://github.com/edwardkim/rhwp/actions/runs/31789409561): Frontend package gates와 Build & Test aggregate 성공
+- [CodeQL run 31789409187](https://github.com/edwardkim/rhwp/actions/runs/31789409187): JavaScript/TypeScript, Python, Rust 분석 성공
+- [Render Diff run 31789409185](https://github.com/edwardkim/rhwp/actions/runs/31789409185): canvas/PDF visual diff와 CanvasKit readiness gate 성공
+
+## 결론
+
+발견한 차단 결함은 없다. 이 문서와 오늘할일을 포함한 trailing head의 GitHub Actions가 성공하고 merge 직전에 최신 head·mergeability를 재확인한 뒤 squash merge한다. `Closes #4765`의 자동 종료 상태와 branch 정리는 merge 후속 절차에서 확인한다.

--- a/mydocs/working/task_m100_4765_stage1_vite_native_config_loader.md
+++ b/mydocs/working/task_m100_4765_stage1_vite_native_config_loader.md
@@ -1,0 +1,24 @@
+---
+kind: working
+status: active
+issue: 4765
+stage: 1
+last_verified: 2026-08-14
+---
+
+# #4765 Stage 1: Vite native config loader 경로 호환성
+
+## 배경
+
+`rhwp-studio`의 Vite 설정은 ESM 구성 파일에서 CommonJS 전역인 `__dirname`을 사용했다. Vite 8은 향후 기본값이 될 native config loader에서 이 패턴을 지원하지 않는다고 경고한다.
+
+## 변경
+
+- 설정 모듈의 디렉터리를 `import.meta.dirname`으로 한 번 계산했다.
+- `package.json`, `pkg`, `target/rhwp-subsecond-vite`, `samples`, `npm`의 경로는 모두 기존과 같은 설정 파일 상대 위치를 기준으로 해석한다.
+- 애플리케이션 런타임, WASM 산출물 위치, Vite 플러그인 설정은 바꾸지 않는다.
+
+## 검증 계약
+
+- PR CI와 동일한 Node.js 22에서 TypeScript 검사와 Studio 패키지 테스트를 실행한다.
+- Node.js 22에서 Vite native config-loader 경고 없이 설정을 읽는지 개발 서버 기동으로 확인한다.

--- a/rhwp-studio/vite.config.ts
+++ b/rhwp-studio/vite.config.ts
@@ -3,9 +3,10 @@ import { resolve, extname, join } from 'path';
 import { readFileSync, readFile } from 'fs';
 import { VitePWA } from 'vite-plugin-pwa';
 
-const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8'));
+const configDir = import.meta.dirname;
+const pkg = JSON.parse(readFileSync(resolve(configDir, 'package.json'), 'utf-8'));
 const subsecondWasmDir = resolve(
-  __dirname,
+  configDir,
   '..',
   'target',
   'rhwp-subsecond-vite',
@@ -32,14 +33,14 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@': resolve(__dirname, 'src'),
+      '@': resolve(configDir, 'src'),
       '@wasm/rhwp.js': useSubsecondWasm
         ? resolve(subsecondWasmDir, 'rhwp-subsecond.js')
-        : resolve(__dirname, '..', 'pkg', 'rhwp.js'),
-      '@wasm': resolve(__dirname, '..', 'pkg'),
+        : resolve(configDir, '..', 'pkg', 'rhwp.js'),
+      '@wasm': resolve(configDir, '..', 'pkg'),
       // 플러그인 패키지 — 동적 import 로만 들어오므로 별도 청크가 된다.
       // 올리지 않으면 코드도 로드되지 않는다(플러그인 없는 studio 의 초기 비용 0).
-      '@rhwp/hwpctrl/studio-plugin': resolve(__dirname, '..', 'npm', 'hwpctrl-ocx', 'src', 'studio-plugin.mjs'),
+      '@rhwp/hwpctrl/studio-plugin': resolve(configDir, '..', 'npm', 'hwpctrl-ocx', 'src', 'studio-plugin.mjs'),
     },
   },
   server: {
@@ -57,11 +58,11 @@ export default defineConfig({
     fs: {
       // [Task #741 후속] 외부 file path 그림 영역 영역 samples/ dir 영역 영역 fetch 가능 영역.
       allow: [
-        __dirname,
-        resolve(__dirname, '..', 'pkg'),
+        configDir,
+        resolve(configDir, '..', 'pkg'),
         subsecondWasmDir,
-        resolve(__dirname, '..', 'samples'),
-        resolve(__dirname, '..', 'npm', 'editor'),
+        resolve(configDir, '..', 'samples'),
+        resolve(configDir, '..', 'npm', 'editor'),
       ],
     },
     watch: {
@@ -82,7 +83,7 @@ export default defineConfig({
     {
       name: 'serve-samples-dir',
       configureServer(server) {
-        const samplesDir = resolve(__dirname, '..', 'samples');
+        const samplesDir = resolve(configDir, '..', 'samples');
         server.middlewares.use('/samples', (req, res, next) => {
           if (!req.url) return next();
           // URL decode + sanitize (path traversal 차단)


### PR DESCRIPTION
## 요약

- `rhwp-studio` Vite 설정의 `__dirname` 의존을 ESM `import.meta.dirname` 기반 설정 디렉터리로 교체했습니다.
- 별칭, 개발 서버 허용 경로, 샘플 정적 제공 경로가 기존과 같은 설정 파일 상대 경로를 유지합니다.
- Vite 8 native config loader의 미래 호환성 경고를 제거합니다.

## 검증

- `cd rhwp-studio && npx tsc --noEmit`
- `npm --prefix rhwp-studio test`
  - 922 passed, 0 failed, 1 skipped
- `cd rhwp-studio && npx vite --configLoader native --host 127.0.0.1 --port 7701 --clearScreen false`
  - Vite 8.2.1 정상 기동, `__dirname` native config-loader 경고 없음

로컬에는 Node.js 24만 설치되어 있어, 실제 PR CI 환경인 Node.js 22 검증은 GitHub Actions에서 확인합니다. Vite 의존 도구 체인에서 발생하는 WASI experimental warning은 이 변경 후에도 남으며, config-loader 경고와 별개입니다.

Closes #4765
