### PR TITLE
fix(studio): Subsecond 대화형 제어 활성화

### DIFF
--- a/mydocs/manual/dev_environment_guide.md
+++ b/mydocs/manual/dev_environment_guide.md
@@ -208,6 +208,10 @@ npm run subsecond:install
 처음 빌드하므로 수 분이 걸릴 수 있다. `target/dioxus-cli/`, `target/dx/`,
 `target/rhwp-subsecond-vite/`는 로컬 생성물이며 커밋하지 않는다.
 
+`subsecond:serve`는 Dioxus 대화형 제어를 켠다. 기동 배너의 `r`(전체 rebuild), `p`(자동 rebuild
+토글), `v`(상세 로그), `/`(전체 단축키)은 실행 중인 터미널에서 사용할 수 있다. 대화형 제어를
+끄면 배너는 단축키를 계속 보여도 키 입력은 동작하지 않으므로 `--interactive false`를 쓰지 않는다.
+
 이 경로에서는 일반 배포용 `wasm-pack build --target web --out-dir pkg`를 먼저 실행할 필요가 없다.
 `subsecond:serve`가 개발용 WASM을 `target/dx/`에 만들고, `dev:subsecond`가 필요한 JS/WASM 두 파일을
 `target/rhwp-subsecond-vite/`로 동기화한다.
@@ -243,6 +247,10 @@ npm run subsecond:serve     # dx serve --hot-patch (127.0.0.1:7711)
 cd rhwp-studio
 npm run dev:subsecond -- --host 0.0.0.0 --port 7700
 ```
+
+최초 기동 뒤에는 터미널 1에서 `/`를 눌러 단축키 메뉴가 나타나는지 먼저 확인한다. 이 확인은
+`subsecond:serve` 스크립트가 실제 대화형 모드로 실행됐는지 검증한다. 일반 Rust 저장은 자동 rebuild가
+기본으로 켜져 있어 바로 감지하며, 필요할 때만 `r`로 전체 rebuild를 요청한다.
 
 `0.0.0.0`은 Vite의 모든 NIC 수신 대기 주소다. 브라우저에는 이 서버의 실제 호스트 IP를 사용해
 `http://<host-ip>:7700/`으로 접속한다. `7711`은 Vite의 `/_dioxus`, `/wasm` 프록시 전용이므로 외부에

--- a/mydocs/manual/pr_review/collaborator_self_merge.md
+++ b/mydocs/manual/pr_review/collaborator_self_merge.md
@@ -60,5 +60,27 @@ git push upstream HEAD:task_m100_<issue>
 - draft·mergeable·head SHA·CI 상태는 작성 시점 참고값으로만 기록한다.
 - 작업지시자 승인을 받는다.
 
+### 8.4.1 명시 지시된 maintainer `--admin` merge 예외
+
+일반 collaborator는 `--admin`으로 branch protection을 우회하지 않는다. 단, maintainer 권한을 가진
+실행자가 collaborator self PR을 처리하면서 작업지시자로부터 **해당 PR의 `--admin` merge 명시 지시**를
+받은 경우에는 다음 조건을 모두 만족할 때만 사용할 수 있다.
+
+- code candidate와 review·오늘할일 trailing head 각각의 최신 GitHub Actions가 성공했고, 실패·대기 중인
+  check가 없다.
+- trailing head의 `mergeable`은 `MERGEABLE`, `mergeStateStatus`는 `CLEAN`이며, merge 직전에 다시
+  조회한 head SHA가 명령의 `--match-head-commit` 값과 같다.
+- trailing commit은 review, 오늘할일, stage·절차 문서만 추가한다. source, test, fixture, workflow,
+  baseline, sample 변경이 trailing commit에 섞이면 이 예외를 적용하지 않는다.
+- 이 옵션은 reviewer 부족, 실패한 검증, 오래된 code candidate, 충돌을 우회하는 용도로 사용하지 않는다.
+
+위 조건에서는 다음과 같이 squash merge할 수 있다. 권한이 없는 collaborator의 토큰에서는 명령이 실패할
+수 있으며, 그 경우 정상 merge 경로로 되돌아간다.
+
+~~~bash
+gh pr merge N --repo edwardkim/rhwp --squash --admin \
+  --match-head-commit <latest-trailing-head>
+~~~
+
 merge 뒤에는 이 PR 자체가 review 기록을 포함했는지와 issue 상태를 확인하기 위해
 [merge 후속 처리](post_merge.md)를 적용한다.

--- a/mydocs/orders/20260814.md
+++ b/mydocs/orders/20260814.md
@@ -166,3 +166,16 @@
   readiness gate가 성공했다. 상세 근거는 [PR review](../pr/archives/pr_4766_review.md)에 보존한다.
 - 이 trailing review-only head의 최신 CI와 mergeability를 다시 확인한 뒤 squash merge하고, #4765 자동 종료와
   remote branch 정리를 post-merge 절차로 처리한다.
+
+## PR #4769 - Subsecond 대화형 개발 제어 활성화
+
+- [PR #4769](https://github.com/edwardkim/rhwp/pull/4769)는 [#4768](https://github.com/edwardkim/rhwp/issues/4768)의
+  `subsecond:serve`가 Dioxus 대화형 제어를 실제로 켜도록 `--interactive true`를 전달한다. `7711`은 계속
+  `127.0.0.1` loopback이고, 외부 개발 접속은 Vite `7700`만 사용한다.
+- 대화형 Dioxus hot-patch 서버에서 `/` 메뉴가 표시되는 것을 확인했고, `npm run subsecond:serve -- --help`가
+  `--interactive true`와 loopback 주소를 전달함을 확인했다. 일반 `npx vite`와 `npm run dev`는 이 스크립트를
+  호출하지 않아 변경 범위 밖이다.
+- 최신 `upstream/devel@b37c0a79` 위 code candidate `712873a`의 Frontend package gates, CodeQL, Canvas
+  visual diff가 성공했다. 상세 근거는 [PR review](../pr/archives/pr_4769_review.md)에 보존한다.
+- 이 review-only trailing head의 최신 CI·mergeability를 확인한 뒤, 명시 지시와 maintainer 권한이 모두 있으면
+  self-merge 절차의 `--admin` 예외를 적용할 수 있다. merge 뒤 #4768 자동 종료와 branch 정리를 처리한다.

--- a/mydocs/pr/archives/pr_4769_review.md
+++ b/mydocs/pr/archives/pr_4769_review.md
@@ -1,0 +1,54 @@
+---
+kind: pr_review
+status: active
+pr: 4769
+issue: 4768
+last_verified: 2026-08-14
+---
+
+# PR #4769 검토: Subsecond 대화형 개발 제어 활성화
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4769](https://github.com/edwardkim/rhwp/pull/4769) |
+| 관련 이슈 | [#4768](https://github.com/edwardkim/rhwp/issues/4768) |
+| 작성자 | `jangster77` |
+| base / head | `devel` / `task_m100_4768` |
+| code candidate | `712873a50a6eae2b6d7e5a17c81dcb43c6c2984a` |
+| 작성 시점 merge 상태 | `MERGEABLE`, `CLEAN` |
+| 규모 | 3 files, +34 / -1 |
+
+base route: collaborator_self_merge
+modifiers: intake_and_review.md, local_validation.md
+loaded documents: pr_review_workflow.md, pr_review/README.md, collaborator_self_merge.md, intake_and_review.md, local_validation.md
+current head: `712873a50a6eae2b6d7e5a17c81dcb43c6c2984a`
+
+## 변경 범위와 판정
+
+- `subsecond:serve`만 Dioxus 대화형 제어를 켠다.
+- loopback `7711`, hot-patch feature와 Vite `7700` 프록시 계약은 유지한다.
+- 일반 `npx vite` 및 `npm run dev`는 수정한 npm script를 호출하지 않는다.
+- renderer 출력, fixture, baseline은 바꾸지 않는다. Render Diff는 Studio 설정 변경에 대해 canvas/PDF 비교를
+  실제로 실행해 성공했다.
+
+## 검증 결과
+
+- `--interactive true`의 동일 Dioxus hot-patch 명령에서 `/` 단축키 메뉴가 나타나는 것을 확인했다.
+- `npm run subsecond:serve -- --help`는 package script가 `--interactive true`와 `--addr 127.0.0.1`을
+  전달함을 확인했다.
+- 실제 `npm run subsecond:serve` 장기 서버는 사용자 터미널의 기존 Dioxus watcher와 target 충돌을 피하기 위해
+  중복 기동하지 않았다. 대화형 동작은 동일 `dx serve` 옵션의 사용자 확인 결과로 판정했다.
+- [CI run 31794523416](https://github.com/edwardkim/rhwp/actions/runs/31794523416): Frontend package gates와
+  Build & Test aggregate 성공
+- [CodeQL run 31794523255](https://github.com/edwardkim/rhwp/actions/runs/31794523255): JavaScript/TypeScript,
+  Python, Rust 분석 성공
+- [Render Diff run 31794523202](https://github.com/edwardkim/rhwp/actions/runs/31794523202): canvas/PDF visual
+  diff 성공
+
+## 결론
+
+차단 결함은 발견하지 못했다. 이 문서와 오늘할일, self-merge 예외 규칙을 포함한 trailing head의 CI와
+mergeability를 다시 확인한다. 작업지시자가 명시한 경우에만 maintainer `--admin` 예외를 적용하며, 실패 또는
+대기 중인 check를 우회하지 않는다. merge 후 #4768 종료 상태와 branch 정리를 post-merge 절차로 확인한다.

--- a/mydocs/working/task_m100_4768_stage1_subsecond_interactive_control.md
+++ b/mydocs/working/task_m100_4768_stage1_subsecond_interactive_control.md
@@ -1,0 +1,25 @@
+---
+kind: working
+status: active
+issue: 4768
+stage: 1
+last_verified: 2026-08-14
+---
+
+# #4768 Stage 1: Subsecond 대화형 개발 제어 활성화
+
+## 배경
+
+`subsecond:serve`는 Dioxus 기동 배너에 `/`, `r`, `p`, `v` 단축키를 표시하면서도 `--interactive false`를 전달해 실제 입력을 막고 있었다. 배너와 실제 동작의 불일치를 제거한다.
+
+## 변경
+
+- `subsecond:serve`의 Dioxus interactive 모드를 켠다.
+- `7711`의 `127.0.0.1` 바인딩, hot-patch feature, Vite의 `7700` 공개 경로는 유지한다.
+- 개발 가이드에 `/` 메뉴로 대화형 모드를 확인하고 자동 rebuild와 수동 rebuild를 구분하는 절차를 추가한다.
+
+## 테스트 근거
+
+- 동일 Dioxus 명령을 `--interactive true`로 실행해 `/` 단축키 메뉴가 나타나는 것을 확인했다.
+- `npm run subsecond:serve -- --help`로 package 스크립트가 `--interactive true`와 loopback 주소를 전달하는 것을 확인했다.
+- 일반 `npx vite`는 이 npm 스크립트를 호출하지 않으므로 변경 범위 밖이다.

--- a/mydocs/working/task_m100_4768_stage2_trailing_admin_merge_gate.md
+++ b/mydocs/working/task_m100_4768_stage2_trailing_admin_merge_gate.md
@@ -1,0 +1,26 @@
+---
+kind: working
+status: active
+issue: 4768
+stage: 2
+last_verified: 2026-08-14
+---
+
+# #4768 Stage 2: 최신 upstream 기록과 maintainer merge gate
+
+## 기준선
+
+code candidate `712873a`은 최신 `upstream/devel@b37c0a79` 위에서 CI를 통과했다. 오늘할일은 이 기준선의
+내용을 다시 읽어 다른 PR 기록을 보존한 뒤 #4769 항목을 추가한다.
+
+## trailing 기록
+
+- PR review와 오늘할일은 code candidate 뒤의 문서-only commit으로 추가한다.
+- 새 head의 CI와 mergeability를 다시 확인해, code candidate 결과와 trailing 문서 결과를 분리한다.
+
+## maintainer 예외 계약
+
+- `--admin`은 명시 지시, maintainer 권한, 두 head의 녹색 CI, `CLEAN` merge 상태가 함께 있을 때만 허용한다.
+- source·test·fixture·workflow·baseline이 trailing commit에 섞이거나 check가 실패·대기 중이면 이 예외를 쓰지
+  않는다.
+- 권한이 없는 collaborator의 `--admin` 실패는 정상 squash merge 경로로 처리한다.

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "subsecond:install": "DX_VERSION=$(node ../scripts/dioxus-cli-version.mjs) && cargo install dioxus-cli --version \"$DX_VERSION\" --locked --root ../target/dioxus-cli",
-    "subsecond:serve": "cd .. && target/dioxus-cli/bin/dx serve --web --package rhwp-subsecond --features subsecond-dev --hot-patch --port 7711 --addr 127.0.0.1 --open false --interactive false --inject-loading-scripts false",
+    "subsecond:serve": "cd .. && target/dioxus-cli/bin/dx serve --web --package rhwp-subsecond --features subsecond-dev --hot-patch --port 7711 --addr 127.0.0.1 --open false --interactive true --inject-loading-scripts false",
     "subsecond:sync": "mkdir -p ../target/rhwp-subsecond-vite && cp ../target/dx/rhwp-subsecond/debug/web/public/wasm/rhwp-subsecond.js ../target/dx/rhwp-subsecond/debug/web/public/wasm/rhwp-subsecond_bg.wasm ../target/rhwp-subsecond-vite/",
     "dev:subsecond": "npm run subsecond:sync && RHWP_SUBSECOND=1 vite",
     "build": "tsc && vite build",


### PR DESCRIPTION
## 요약

- `subsecond:serve`가 Dioxus 대화형 제어를 활성화하도록 변경합니다.
- `7711`은 기존처럼 `127.0.0.1` loopback으로 유지하고, 외부 접속은 Vite `7700`만 사용합니다.
- 개발 환경 가이드에 `/` 단축키 메뉴 확인과 자동·수동 rebuild 절차를 추가합니다.

## 검증

- 동일 Dioxus hot-patch 명령을 `--interactive true`로 실행해 `/` 단축키 메뉴가 표시되는 것을 확인했습니다.
- `npm run subsecond:serve -- --help`로 package 스크립트가 `--interactive true`와 `--addr 127.0.0.1`을 전달함을 확인했습니다.
- 일반 `npx vite` 및 `npm run dev`는 이 스크립트를 호출하지 않으므로 변경 범위 밖입니다.

Closes #4768
