### PR TITLE
fix(renderer): 같은 자리 겹침 Square 그림 무리를 저장 줄 흔적대로 앵커 쪽에 남긴다 (#4770)

### DIFF
--- a/mydocs/orders/20260815.md
+++ b/mydocs/orders/20260815.md
@@ -1,0 +1,18 @@
+# 오늘 할 일 - 2026년 8월 15일
+
+## PR #4774 - 저장 LineSeg 기반 Square 그림 스택 앵커 유지
+
+- [PR #4774](https://github.com/edwardkim/rhwp/pull/4774)는 [#4770](https://github.com/edwardkim/rhwp/issues/4770)의
+  비-TAC `Square` 그림 스택이 한글의 저장 LineSeg 판단과 달리 쪽당 한 장으로 분산되는 문제를
+  앵커 쪽 유지 조건으로 보정한다.
+- contributor 원 변경 뒤 `rendering`과 `typeset`의 스택 판정이 비대칭인 것을 확인했다. collaborator
+  보정은 빈 문단, `Square`, 겹침 불허, 공통 세로 대역이라는 공통 구조 계약과 페이지 절대 본문 하단
+  비교로 통일해 #1995 낱장 분할 억제의 과적용을 막았다. `TopAndBottom` 스택은 억제하지 않는 회귀도
+  추가했다.
+- rustfmt, native-skia clippy, 새 unit test, release-test 전체 integration test를 통과했고,
+  code candidate `85cafced1`의 GitHub CI Build & Test, Native Skia, Rust CodeQL, Canvas visual diff도
+  모두 성공했다. 상세 근거는 [PR review](../pr/archives/pr_4774_review.md)와
+  [구현 검토](../pr/archives/pr_4774_review_impl.md)에 보존한다.
+- 이 trailing review-only head의 fast-pass aggregate와 최신 mergeability를 재확인한 뒤,
+  작업지시자가 승인한 일반 squash merge를 수행한다. merge 뒤 #4770의 close 상태, contributor 감사
+  댓글, `planet6897` fork branch 보존 및 로컬 검토 branch 정리를 공식 post-merge 절차로 처리한다.

--- a/mydocs/pr/archives/pr_4774_review.md
+++ b/mydocs/pr/archives/pr_4774_review.md
@@ -1,0 +1,61 @@
+# PR #4774 검토 - 저장 LineSeg 기반 Square 그림 스택 앵커 유지
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4774](https://github.com/edwardkim/rhwp/pull/4774) |
+| 관련 이슈 | [#4770](https://github.com/edwardkim/rhwp/issues/4770) |
+| 작성자 | `planet6897` (`Jaeuk Ryu`) |
+| 검토 방식 | 작업지시자 승인에 따른 collaborator 셀프 리뷰 및 maintainer 보정 |
+| base / head | `devel` / `pr/devel-4770` |
+| code candidate | `85cafced1cdd44f54f601aa9821f671b80159a67` |
+| 규모 | 3 commits, 3 files, +221 / -21 |
+| 작성 시점 상태 | `MERGEABLE`, `CLEAN` |
+
+`mergeable`, `mergeStateStatus`, head SHA와 CI 결과는 작성 시점의 참고값이다. 최종 merge 직전에
+trailing head의 GitHub Actions 상태와 mergeability를 다시 확인한다.
+
+## 변경 범위와 판단
+
+- 원 contributor 변경은 빈 본문 문단에서 완전히 겹친 비-TAC `Square` 그림 무리가 저장된 LineSeg의
+  가로 시작점과 세로 위치를 만족하면 앵커 쪽에 남도록 한다. 이로써 #4770의 HPV 코호트 표본에서
+  그림을 쪽당 한 장씩 분산하는 과대 페이지화를 막는다.
+- collaborator 보정은 `rendering`과 `typeset`의 판정 조건을 하나의 구조 계약으로 통일했다. 빈 문단,
+  비-TAC 그림, `Square`, `allow_overlap = false`, 공통 세로 앵커 대역을 모두 만족해야만 억제한다.
+- `LineSeg::vertical_pos`는 페이지 절대 좌표이므로 그림 하단을 본문 높이가 아니라 절대 본문 하단과
+  비교하도록 고쳤다.
+- `TopAndBottom` 감싸기처럼 #1995의 낱장 분할 억제를 적용하면 안 되는 스택은 음성 회귀로 고정했다.
+  셀 내부 그림 스택의 #2004 경로는 이 본문 전용 보정에서 제외된다.
+- renderer와 typeset 경로가 바뀌므로 시각 검증 대상이다. 원 PR은 HPV 코호트 HWP, #1995 및 #2004
+  표본의 페이지 수와 SVG 겹침 근거를 제시했다. 검토에서는 이 수치를 독립적으로 재산출하지 않았고,
+  최신 GitHub Canvas visual diff 성공 및 새 구조 단정으로 무회귀를 확인했다.
+
+## 완료된 검증
+
+- `cargo fmt --check`를 통과했다.
+- `CARGO_TARGET_DIR=target/pr-review cargo clippy --features native-skia -- -D warnings`를 통과했다.
+- `CARGO_TARGET_DIR=target/pr-review cargo test --profile release-test --lib test_4770_anchor_pile_contract_requires_square_stack_and_page_bottom`를
+  실행해 1건 통과, 실패 0건을 확인했다.
+- `CARGO_TARGET_DIR=target/pr-review cargo test --profile release-test --tests`를 종료 코드 `0`으로
+  완료했다. 라이브러리 단위 3,682건 통과, 실패 0건을 포함해 전체 integration test binary가 통과했다.
+- code candidate의 GitHub Actions를 확인했다.
+  - [CI](https://github.com/edwardkim/rhwp/actions/runs/31812950867): Lint, Native Skia, test archive,
+    default-feature 3 shards, slow shard, Build & Test aggregate 성공
+  - [CodeQL](https://github.com/edwardkim/rhwp/actions/runs/31812950600): Rust 분석 성공
+  - [Render Diff](https://github.com/edwardkim/rhwp/actions/runs/31812950668): Canvas visual diff 성공
+- frontend 및 독립 WASM Build job은 변경 영향 분류에 따라 `skipping`이며 실패가 아니다.
+
+## 위험과 후속 범위
+
+- 이 보정은 저장 LineSeg가 있는 본문 그림 스택의 구조 조건만 해석한다. LineSeg가 없거나 그림이
+  `Square`가 아닌 문서는 기존 흐름을 유지한다.
+- 원 PR이 제시한 HWP/Hancom PDF 페이지 수 근거는 contributor 측 실측이다. 이번 검토는 동일 표본의
+  별도 MCP PDF 재생성을 수행하지 않았으며, 이는 원본 근거를 대체하지 않는다.
+- 추가 결함은 발견하지 못했다.
+
+## 최종 권고
+
+merge를 권고한다. 이 review·오늘할일만 담은 trailing head의 preflight와 Build & Test aggregate가
+성공하고, merge 직전에 최신 head SHA, `MERGEABLE`, `CLEAN`을 다시 확인한 뒤 작업지시자가 승인한
+일반 squash merge를 수행한다.

--- a/mydocs/pr/archives/pr_4774_review_impl.md
+++ b/mydocs/pr/archives/pr_4774_review_impl.md
@@ -1,0 +1,35 @@
+# PR #4774 구현 검토 - 앵커 그림 스택 maintainer 보정
+
+## 목적
+
+contributor 원 변경이 #4770의 저장 LineSeg 기반 그림 스택을 앵커 쪽에 유지하는 동안, 기존 #1995
+낱장 분할 억제를 비대칭 조건으로 넓게 비활성화하지 않도록 보정한다. contributor 원 commit은 재작성하지
+않고, 해당 source head 위에 collaborator commit을 추가한다.
+
+## 커밋 계보
+
+| 순서 | SHA | 구분 | 내용 |
+| --- | --- | --- | --- |
+| 1 | `c92fe4fbe88d6a8b5a0f78b8db5ec77b5eeeff63` | contributor | 저장 LineSeg가 그림 스택의 앵커 쪽 유지 조건을 보이면 #1995/#2004 재분류를 억제 |
+| 2 | `74cd60a9067dd9e0ecee041d50a8f69439a2469f` | collaborator 보정 | 두 렌더 경로의 구조 술어와 절대 본문 하단 좌표 비교를 통일, `TopAndBottom` 음성 회귀 추가 |
+| 3 | `85cafced1cdd44f54f601aa9821f671b80159a67` | collaborator 보정 | 공통 `Option` helper의 clippy 계약과 포맷 정리 |
+
+## 보정 내용
+
+1. `floating_image_stack_extents`가 그림 스택의 최소 폭과 최대 높이를 반환하고, 재분류와 typeset이
+   같은 구조 조건을 사용한다.
+2. `body_pile_stays_on_anchor_page`가 첫 LineSeg의 가로 시작점과 그림 하단을 판정한다. 본문 하단은
+   `PageAreas::body_area.bottom`의 페이지 절대 좌표를 사용한다.
+3. `TextWrap::TopAndBottom`을 `Square`로 오인하지 않는 회귀를 `typeset` 단위 테스트로 추가한다.
+4. 보정 코드와 stage 기록은 contributor head 위의 별도 commit으로 분리했고, contributor commit에는
+   rebase, amend, reset 또는 force push를 사용하지 않았다.
+
+## 검증과 통합 단계
+
+- 보정 head `85cafced1`에서 rustfmt, native-skia clippy, 새 unit test 및 release-test 전체 integration
+  test를 완료했다.
+- 같은 head의 GitHub CI, Rust CodeQL, Canvas visual diff가 모두 성공했다.
+- 다음 trailing commit은 review와 오늘할일만 포함한다. 허용 범위의 single-parent 문서 commit이므로
+  code candidate `85cafced1`의 녹색 Full CI를 review-only fast-pass 후보로 사용한다.
+- trailing head의 aggregate와 mergeability를 재확인한 뒤 일반 squash merge를 수행한다. merge SHA,
+  #4770 상태, contributor 감사 댓글, fork branch 보존 여부는 merge 후속 처리 단계에서 확인한다.

--- a/mydocs/working/task_m100_4770_stage2_maintainer_anchor_pile_contract.md
+++ b/mydocs/working/task_m100_4770_stage2_maintainer_anchor_pile_contract.md
@@ -1,0 +1,34 @@
+---
+kind: working
+status: active
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-14
+---
+
+# #4770 Stage 2 - 메인터너 앵커 그림 스택 계약 보정
+
+## 배경
+
+PR #4774의 첫 보정은 HPV 코호트의 본문 Square 그림 24장이 한글처럼 하나의 앵커 쪽에
+겹쳐 남도록, 저장 첫 줄의 wrap-zone과 `vertical_pos`를 사용했다. 검토에서 두 경로의
+판정 범위가 달라 일반 전면 그림의 #1995 낱장 배치까지 억제할 수 있고, 페이지 절대 좌표인
+`vertical_pos`를 본문 높이와 직접 비교한다는 결함을 확인했다.
+
+## 보정
+
+- `rendering.rs`에 비-TAC Square, 겹침불허, 빈 문단, 동일 세로 band, 전면급 그림 다수를
+  하나의 공통 저장 스택 계약으로 추출했다.
+- `typeset.rs`의 #1995 억제는 자체적인 폭·높이 추정을 제거하고 공통 계약만 사용한다.
+  `TopAndBottom`, 본문 텍스트, 서로 다른 anchor 또는 겹침 허용 그림은 기존 낱장 배치를 유지한다.
+- `LineSeg.vertical_pos`는 페이지 상단 기준 절대 좌표이므로 두 경로 모두 `PageAreas.body_area.bottom`
+  또는 layout의 본문 하단 절대 좌표와 비교한다.
+
+## 회귀 계약
+
+- 본문 하단에 정확히 닿는 Square 스택은 앵커 쪽에 남는다.
+- 같은 wrap-zone과 `vertical_pos`라도 `TopAndBottom` 그림은 #1995 낱장 배치를 억제하지 않는다.
+- HPV, #1995, #2004 셀 스택의 기존 실문서 검증은 후속 maintainer 검증 단계에서 다시 확인한다.
+
+## 검증 상태
+
+이 stage에서는 코드와 회귀 단정을 추가했다. 로컬 테스트와 원격 CI는 아직 실행하지 않았다.

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -365,9 +365,7 @@ fn floating_image_stack_extents(para: &Paragraph, min_height_hu: i32) -> Option<
     let mut min_pic_w = i32::MAX;
     let mut max_pic_h = i32::MIN;
     for ctrl in &para.controls {
-        let Some(common) = floating_stack_picture_common(ctrl) else {
-            return None;
-        };
+        let common = floating_stack_picture_common(ctrl)?;
         if common.treat_as_char
             || !matches!(common.text_wrap, TextWrap::Square)
             || common.allow_overlap
@@ -4896,11 +4894,11 @@ impl DocumentCore {
             let matches: Vec<usize> = section
                 .paragraphs
                 .iter()
-                    .enumerate()
-                    .filter(|(_, p)| {
-                        para_is_floating_image_stack(p, min_height_hu)
+                .enumerate()
+                .filter(|(_, p)| {
+                    para_is_floating_image_stack(p, min_height_hu)
                         && !body_pile_stays_on_anchor_page(p, min_height_hu, body_bottom_hu)
-                    })
+                })
                 .map(|(i, _)| i)
                 .collect();
             // [#2004] 표 셀 내부 부동 이미지 스택 검출(본문 스택과 별개 경로).

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -384,6 +384,37 @@ fn para_is_floating_image_stack(para: &Paragraph, min_height_hu: i32) -> bool {
     count >= 2 && (max_voff as i64 - min_voff as i64) <= min_pic_h as i64
 }
 
+/// [#4770] 본문 그림 스택이 "앵커 쪽에 겹친 채 남는" 저장 형상인지.
+///
+/// 두 조건이 함께 성립해야 한다:
+/// 1. 저장 첫 줄이 그림 폭 이상 오른쪽에서 시작(cs ≥ min 그림 폭) — 저작 한글이
+///    빈 줄을 Square 배제로 그림 **옆에** 끼운 흔적.
+/// 2. 첫 그림이 앵커 위치의 잔여 본문 높이에 물리적으로 들어감(저장 vpos + max 그림
+///    높이 ≤ 본문 높이) — 들어가지 않으면 한글은 겹침불허 캐스케이드로 낱장 분산한다.
+///
+/// HPV 코호트 s2/pi1007(그림 24장 150×212mm, cs=42520·vpos=5040, 한글 1쪽)은 둘 다
+/// 성립 → 스택 유지. #2004 본문 96장(cs=0·vpos=53602, 한글 96쪽)과 셀 스택 픽스처
+/// (cs-옆끼임이나 그림 h≈65k 가 잔여에 안 들어감, 한글 8쪽)는 성립하지 않아 기존
+/// 낱장 분산이 보존된다. **셀 내부 스택에는 적용하지 않는다** — 컨테이너가 쪽이
+/// 아니라 셀이라 잔여 판정의 기준이 다르다.
+fn body_pile_stays_on_anchor_page(para: &Paragraph, body_h_hu: i32) -> bool {
+    let mut min_pic_w = i32::MAX;
+    let mut max_pic_h = i32::MIN;
+    for ctrl in &para.controls {
+        let Some(common) = floating_stack_picture_common(ctrl) else {
+            return false;
+        };
+        min_pic_w = min_pic_w.min(common.width as i32);
+        max_pic_h = max_pic_h.max(common.height as i32);
+    }
+    if min_pic_w == i32::MAX {
+        return false;
+    }
+    para.line_segs.first().is_some_and(|seg| {
+        seg.column_start >= min_pic_w && seg.vertical_pos.saturating_add(max_pic_h) <= body_h_hu
+    })
+}
+
 /// 문단의 그림/그림-도형을 인라인(tac=true)으로 재분류(정규화본에만 적용, 원본 무손상).
 fn reclassify_floating_pictures_inline(para: &mut Paragraph) {
     for ctrl in para.controls.iter_mut() {
@@ -4855,7 +4886,10 @@ impl DocumentCore {
                 .paragraphs
                 .iter()
                 .enumerate()
-                .filter(|(_, p)| para_is_floating_image_stack(p, min_height_hu))
+                .filter(|(_, p)| {
+                    para_is_floating_image_stack(p, min_height_hu)
+                        && !body_pile_stays_on_anchor_page(p, body_h_hu)
+                })
                 .map(|(i, _)| i)
                 .collect();
             // [#2004] 표 셀 내부 부동 이미지 스택 검출(본문 스택과 별개 경로).

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -8,7 +8,7 @@ use crate::document_core::{
 use crate::error::HwpError;
 use crate::model::control::Control;
 use crate::model::document::{Document, Section};
-use crate::model::page::ColumnDef;
+use crate::model::page::{ColumnDef, PageAreas};
 use crate::model::paragraph::{ColumnBreakType, Paragraph};
 use crate::model::style::Alignment;
 use crate::paint::{
@@ -345,43 +345,57 @@ fn floating_stack_picture_common(ctrl: &Control) -> Option<&crate::model::shape:
     }
 }
 
-/// 한 문단이 "동일 위치·겹침불허·전면급 부동 그림 다수" 스택인지.
-/// 한글은 이런 그림을 쪽당 1장씩 배치하지만 rhwp 는 앵커 쪽에 겹쳐 그린다(#2004 부동 변종).
-/// 게이트를 좁혀(모든 컨트롤이 tac=false·Square·overlap=false·전면급 그림 + 동일 세로오프셋 +
-/// 개수≥2 + 가시 텍스트 없음) 일반 부동개체 문단 오검출을 차단한다.
-fn para_is_floating_image_stack(para: &Paragraph, min_height_hu: i32) -> bool {
+/// 동일 위치·겹침불허·전면급 부동 그림 스택의 폭·높이 범위.
+///
+/// 모든 control이 비-TAC Square 그림/그림-도형이고, 가시 텍스트가 없으며, 세로 offset이
+/// 그림 높이 하나 안에서 겹칠 때만 반환한다. 본문 정규화와 #1995 낱장 배치 억제가 같은
+/// 저장 형상을 판정하도록 이 조건을 한 곳에 둔다.
+fn floating_image_stack_extents(para: &Paragraph, min_height_hu: i32) -> Option<(i32, i32)> {
     use crate::model::shape::TextWrap;
     if para.text.chars().any(|c| c > '\u{001F}' && c != '\u{FFFC}') {
-        return false;
+        return None;
     }
     if para.controls.is_empty() {
-        return false;
+        return None;
     }
     let mut count = 0usize;
     let mut min_voff = i32::MAX;
     let mut max_voff = i32::MIN;
     let mut min_pic_h = i32::MAX;
+    let mut min_pic_w = i32::MAX;
+    let mut max_pic_h = i32::MIN;
     for ctrl in &para.controls {
         let Some(common) = floating_stack_picture_common(ctrl) else {
-            return false;
+            return None;
         };
         if common.treat_as_char
             || !matches!(common.text_wrap, TextWrap::Square)
             || common.allow_overlap
             || (common.height as i32) < min_height_hu
         {
-            return false;
+            return None;
         }
         let voff = common.vertical_offset as i32;
         min_voff = min_voff.min(voff);
         max_voff = max_voff.max(voff);
         min_pic_h = min_pic_h.min(common.height as i32);
+        min_pic_w = min_pic_w.min(common.width as i32);
+        max_pic_h = max_pic_h.max(common.height as i32);
         count += 1;
     }
     // [#2004] 세로오프셋이 동일하거나(#1995: 전부 0) 이미지 높이보다 작은 band 안에서
     // varying(156714340: 0/-3360/-2940 …)이어 서로 크게 겹치면 "겹침 스택"으로 판정한다.
     // 오프셋 spread ≥ 이미지 높이면 이미 세로로 벌어진 정상 배치이므로 제외.
-    count >= 2 && (max_voff as i64 - min_voff as i64) <= min_pic_h as i64
+    (count >= 2 && (max_voff as i64 - min_voff as i64) <= min_pic_h as i64)
+        .then_some((min_pic_w, max_pic_h))
+}
+
+/// 한 문단이 "동일 위치·겹침불허·전면급 부동 그림 다수" 스택인지.
+/// 한글은 이런 그림을 쪽당 1장씩 배치하지만 rhwp 는 앵커 쪽에 겹쳐 그린다(#2004 부동 변종).
+/// 게이트를 좁혀(모든 컨트롤이 tac=false·Square·overlap=false·전면급 그림 + 동일 세로오프셋 +
+/// 개수≥2 + 가시 텍스트 없음) 일반 부동개체 문단 오검출을 차단한다.
+fn para_is_floating_image_stack(para: &Paragraph, min_height_hu: i32) -> bool {
+    floating_image_stack_extents(para, min_height_hu).is_some()
 }
 
 /// [#4770] 본문 그림 스택이 "앵커 쪽에 겹친 채 남는" 저장 형상인지.
@@ -389,29 +403,28 @@ fn para_is_floating_image_stack(para: &Paragraph, min_height_hu: i32) -> bool {
 /// 두 조건이 함께 성립해야 한다:
 /// 1. 저장 첫 줄이 그림 폭 이상 오른쪽에서 시작(cs ≥ min 그림 폭) — 저작 한글이
 ///    빈 줄을 Square 배제로 그림 **옆에** 끼운 흔적.
-/// 2. 첫 그림이 앵커 위치의 잔여 본문 높이에 물리적으로 들어감(저장 vpos + max 그림
-///    높이 ≤ 본문 높이) — 들어가지 않으면 한글은 겹침불허 캐스케이드로 낱장 분산한다.
+/// 2. 첫 그림이 앵커 위치의 본문 하단에 물리적으로 들어감(저장 vpos + max 그림
+///    높이 ≤ 본문 하단 절대 좌표) — 들어가지 않으면 한글은 겹침불허 캐스케이드로 낱장 분산한다.
 ///
 /// HPV 코호트 s2/pi1007(그림 24장 150×212mm, cs=42520·vpos=5040, 한글 1쪽)은 둘 다
 /// 성립 → 스택 유지. #2004 본문 96장(cs=0·vpos=53602, 한글 96쪽)과 셀 스택 픽스처
 /// (cs-옆끼임이나 그림 h≈65k 가 잔여에 안 들어감, 한글 8쪽)는 성립하지 않아 기존
 /// 낱장 분산이 보존된다. **셀 내부 스택에는 적용하지 않는다** — 컨테이너가 쪽이
 /// 아니라 셀이라 잔여 판정의 기준이 다르다.
-fn body_pile_stays_on_anchor_page(para: &Paragraph, body_h_hu: i32) -> bool {
-    let mut min_pic_w = i32::MAX;
-    let mut max_pic_h = i32::MIN;
-    for ctrl in &para.controls {
-        let Some(common) = floating_stack_picture_common(ctrl) else {
-            return false;
-        };
-        min_pic_w = min_pic_w.min(common.width as i32);
-        max_pic_h = max_pic_h.max(common.height as i32);
-    }
-    if min_pic_w == i32::MAX {
+///
+/// `vertical_pos`는 페이지 상단 기준 절대 좌표이므로 `body_bottom_hu`와 비교해야 한다.
+/// 이 계약은 본문 정규화와 typeset의 #1995 낱장 배치 억제가 함께 사용한다.
+pub(crate) fn body_pile_stays_on_anchor_page(
+    para: &Paragraph,
+    min_height_hu: i32,
+    body_bottom_hu: i32,
+) -> bool {
+    let Some((min_pic_w, max_pic_h)) = floating_image_stack_extents(para, min_height_hu) else {
         return false;
-    }
+    };
     para.line_segs.first().is_some_and(|seg| {
-        seg.column_start >= min_pic_w && seg.vertical_pos.saturating_add(max_pic_h) <= body_h_hu
+        seg.column_start >= min_pic_w
+            && seg.vertical_pos.saturating_add(max_pic_h) <= body_bottom_hu
     })
 }
 
@@ -4876,20 +4889,18 @@ impl DocumentCore {
             }
             let section = &self.document.sections[idx];
             let pd = &section.section_def.page_def;
-            let body_h_hu = pd.height as i32
-                - pd.margin_top as i32
-                - pd.margin_bottom as i32
-                - pd.margin_header as i32
-                - pd.margin_footer as i32;
+            let body_area = PageAreas::from_page_def(pd).body_area;
+            let body_h_hu = body_area.height();
+            let body_bottom_hu = body_area.bottom;
             let min_height_hu = (body_h_hu / 2).max(1);
             let matches: Vec<usize> = section
                 .paragraphs
                 .iter()
-                .enumerate()
-                .filter(|(_, p)| {
-                    para_is_floating_image_stack(p, min_height_hu)
-                        && !body_pile_stays_on_anchor_page(p, body_h_hu)
-                })
+                    .enumerate()
+                    .filter(|(_, p)| {
+                        para_is_floating_image_stack(p, min_height_hu)
+                        && !body_pile_stays_on_anchor_page(p, min_height_hu, body_bottom_hu)
+                    })
                 .map(|(i, _)| i)
                 .collect();
             // [#2004] 표 셀 내부 부동 이미지 스택 검출(본문 스택과 별개 경로).

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -9,6 +9,7 @@
 //! MS Word/OOXML의 cantSplit/tblHeader를 참고.
 
 use crate::model::control::Control;
+use crate::document_core::queries::rendering::body_pile_stays_on_anchor_page;
 use crate::model::footnote::{Footnote, FootnoteShape};
 use crate::model::header_footer::HeaderFooterApply;
 use crate::model::page::{ColumnDef, ColumnType, PageDef};
@@ -7671,30 +7672,22 @@ impl TypesetEngine {
                 .iter()
                 .filter(|c| matches!(c, Control::Picture(pic) if !pic.common.treat_as_char))
                 .count();
-            // [#4770] 저장 첫 줄이 그림 폭 이상 오른쪽에서 시작하고(cs ≥ 그림 폭 —
-            // 저작 한글이 빈 줄을 Square 배제로 그림 옆에 끼운 흔적) 첫 그림이 앵커
-            // 잔여 본문에 물리적으로 들어가면(저장 vpos + max 그림 높이 ≤ 본문 높이)
-            // pile 은 앵커 쪽에 겹친 채 남는다(HPV 코호트 s2/pi1007: cs=42520·
-            // vpos=5040, 한글 1쪽 ↔ 낱장 배치 시 24쪽). 펼쳐진 스택(#1995 96장,
-            // vpos=53602 로 안 들어감, 한글 96쪽)은 걸리지 않는다.
-            let stored_line_beside_pile = {
-                let mut min_w = i32::MAX;
-                let mut max_h = i32::MIN;
-                for c in &para.controls {
-                    if let Control::Picture(pic) = c {
-                        if !pic.common.treat_as_char {
-                            min_w = min_w.min(pic.common.width as i32);
-                            max_h = max_h.max(pic.common.height as i32);
-                        }
-                    }
-                }
-                min_w != i32::MAX
-                    && para.line_segs.first().is_some_and(|seg| {
-                        seg.column_start >= min_w
-                            && hwpunit_to_px(seg.vertical_pos.saturating_add(max_h), self.dpi)
-                                <= fullpage_img_body_h + 0.5
-                    })
-            };
+            // [#4770] #2004 본문 정규화와 같은 엄격한 저장 스택 계약을 쓴다. 즉 빈
+            // 문단의 비-TAC Square·겹침불허 그림/그림-도형이 같은 세로 band에 있고,
+            // 저장 첫 줄이 그림 폭 이상 오른쪽에서 시작하며, 그림 하단이 본문 하단 절대
+            // 좌표 안에 있을 때만 #1995 낱장 배치를 억제한다. 일반 TopAndBottom·서로
+            // 다른 anchor·본문 텍스트 문단은 기존 분산을 유지한다.
+            let fullpage_img_min_height_hu =
+                (crate::renderer::px_to_hwpunit(st.layout.body_area.height, self.dpi) / 2).max(1);
+            let fullpage_img_body_bottom_hu = crate::renderer::px_to_hwpunit(
+                st.layout.body_area.y + st.layout.body_area.height,
+                self.dpi,
+            );
+            let stored_line_beside_pile = body_pile_stays_on_anchor_page(
+                para,
+                fullpage_img_min_height_hu,
+                fullpage_img_body_bottom_hu,
+            );
             let is_multi_fullpage_img_para = !stored_line_beside_pile
                 && has_majority_fullpage_images(fullpage_img_ctrls.len(), noninline_pic_count);
 
@@ -26734,6 +26727,50 @@ mod tests {
             "[#4770] 저장 줄이 그림 옆에 끼인(cs ≥ 그림 폭) 스택은 앵커 쪽 1 페이지에 \
              남아야 함. 실제 {} 페이지 — 낱장 분산이 오발동",
             typeset_result.pages.len(),
+        );
+    }
+
+    #[test]
+    fn test_4770_anchor_pile_contract_requires_square_stack_and_page_bottom() {
+        use crate::document_core::queries::rendering::body_pile_stays_on_anchor_page;
+        use crate::model::page::PageAreas;
+        use crate::model::shape::TextWrap;
+
+        let page_def = a4_page_def();
+        let body_area = PageAreas::from_page_def(&page_def).body_area;
+        let make_para = |text_wrap| {
+            let make_pic = || {
+                let mut pic = crate::model::image::Picture::default();
+                pic.common.treat_as_char = false;
+                pic.common.text_wrap = text_wrap;
+                pic.common.allow_overlap = false;
+                pic.common.width = 51974;
+                pic.common.height = 60000;
+                crate::model::control::Control::Picture(Box::new(pic))
+            };
+            Paragraph {
+                line_segs: vec![LineSeg {
+                    vertical_pos: body_area.bottom - 60000,
+                    column_start: 51974,
+                    segment_width: 3480,
+                    ..Default::default()
+                }],
+                controls: vec![make_pic(), make_pic(), make_pic()],
+                ..Default::default()
+            }
+        };
+
+        assert!(
+            body_pile_stays_on_anchor_page(&make_para(TextWrap::Square), 30000, body_area.bottom),
+            "페이지 상단 기준 vpos가 본문 하단에 정확히 닿는 Square 스택은 앵커 쪽에 남아야 함"
+        );
+        assert!(
+            !body_pile_stays_on_anchor_page(
+                &make_para(TextWrap::TopAndBottom),
+                30000,
+                body_area.bottom,
+            ),
+            "TopAndBottom 전면 그림은 cs/vpos가 같아도 #1995 낱장 배치를 억제하면 안 됨"
         );
     }
 

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -7671,8 +7671,32 @@ impl TypesetEngine {
                 .iter()
                 .filter(|c| matches!(c, Control::Picture(pic) if !pic.common.treat_as_char))
                 .count();
-            let is_multi_fullpage_img_para =
-                has_majority_fullpage_images(fullpage_img_ctrls.len(), noninline_pic_count);
+            // [#4770] 저장 첫 줄이 그림 폭 이상 오른쪽에서 시작하고(cs ≥ 그림 폭 —
+            // 저작 한글이 빈 줄을 Square 배제로 그림 옆에 끼운 흔적) 첫 그림이 앵커
+            // 잔여 본문에 물리적으로 들어가면(저장 vpos + max 그림 높이 ≤ 본문 높이)
+            // pile 은 앵커 쪽에 겹친 채 남는다(HPV 코호트 s2/pi1007: cs=42520·
+            // vpos=5040, 한글 1쪽 ↔ 낱장 배치 시 24쪽). 펼쳐진 스택(#1995 96장,
+            // vpos=53602 로 안 들어감, 한글 96쪽)은 걸리지 않는다.
+            let stored_line_beside_pile = {
+                let mut min_w = i32::MAX;
+                let mut max_h = i32::MIN;
+                for c in &para.controls {
+                    if let Control::Picture(pic) = c {
+                        if !pic.common.treat_as_char {
+                            min_w = min_w.min(pic.common.width as i32);
+                            max_h = max_h.max(pic.common.height as i32);
+                        }
+                    }
+                }
+                min_w != i32::MAX
+                    && para.line_segs.first().is_some_and(|seg| {
+                        seg.column_start >= min_w
+                            && hwpunit_to_px(seg.vertical_pos.saturating_add(max_h), self.dpi)
+                                <= fullpage_img_body_h + 0.5
+                    })
+            };
+            let is_multi_fullpage_img_para = !stored_line_beside_pile
+                && has_majority_fullpage_images(fullpage_img_ctrls.len(), noninline_pic_count);
 
             // [#2097] 이 문단의 TopAndBottom 자리차지 float pushdown 가로 컬럼
             // (h_left, h_right, 스택_높이) px — 가로 겹침으로 스택/나란히 판별.
@@ -26647,6 +26671,68 @@ mod tests {
             typeset_result.pages.len() >= 3,
             "[#1995] 전면 non-TAC 이미지 3장은 각각 한 페이지에 단독 배치되어야 함(>= 3 페이지). \
              실제 {} 페이지 — 미수정 시 한 앵커에 스택",
+            typeset_result.pages.len(),
+        );
+    }
+
+    /// #4770: 같은 앵커에 겹친 Square 전면 그림 무리라도, 저장 첫 줄이 그림 폭 이상
+    /// 오른쪽에서 시작하면(cs ≥ 그림 폭 — 한글이 빈 줄을 그림 옆에 끼운 저장 흔적)
+    /// 한글은 스택을 앵커 쪽에 남긴다. 낱장 분산(#1995)을 걸면 안 된다.
+    ///
+    /// HPV 코호트 s2/pi=1007 실측: 그림 24장(150×212mm) cs=42520=그림 폭·sw=3480,
+    /// 한글 1쪽 ↔ 분산 시 24쪽(+24) — 이슈 #4770.
+    #[test]
+    fn test_typeset_4770_stored_line_beside_pile_keeps_stack_on_anchor_page() {
+        use crate::model::shape::TextWrap;
+        let engine = TypesetEngine::with_default_dpi();
+        let paginator = Paginator::with_default_dpi();
+        let styles = ResolvedStyleSet::default();
+        let page_def = a4_page_def();
+        let col_def = ColumnDef::default();
+        let composed: Vec<ComposedParagraph> = Vec::new();
+
+        // #1995 테스트와 같은 전면 그림 3장 — 유일한 차이는 저장 첫 줄의
+        // column_start 가 그림 폭 이상(= 줄이 그림 옆에 끼임)이라는 것.
+        let make_pic = || {
+            let mut pic = crate::model::image::Picture::default();
+            pic.common.treat_as_char = false;
+            pic.common.text_wrap = TextWrap::Square;
+            pic.common.width = 51974;
+            pic.common.height = 60000;
+            crate::model::control::Control::Picture(Box::new(pic))
+        };
+        let host_para = Paragraph {
+            line_segs: vec![LineSeg {
+                line_height: 1000,
+                line_spacing: 600,
+                column_start: 51974,
+                segment_width: 3480,
+                ..Default::default()
+            }],
+            controls: vec![make_pic(), make_pic(), make_pic()],
+            ..Default::default()
+        };
+        let paras = vec![host_para];
+
+        let (_paginator_result, measured) =
+            paginator.paginate(&paras, &composed, &styles, &page_def, &col_def, 0);
+        let typeset_result = engine.typeset_section(
+            &paras,
+            &composed,
+            &styles,
+            &page_def,
+            &col_def,
+            0,
+            &measured.tables,
+            false,
+            &std::collections::HashSet::new(),
+        );
+
+        assert_eq!(
+            typeset_result.pages.len(),
+            1,
+            "[#4770] 저장 줄이 그림 옆에 끼인(cs ≥ 그림 폭) 스택은 앵커 쪽 1 페이지에 \
+             남아야 함. 실제 {} 페이지 — 낱장 분산이 오발동",
             typeset_result.pages.len(),
         );
     }

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -8,8 +8,8 @@
 //! Chromium LayoutNG의 Break Token 패턴, LibreOffice Writer의 Master/Follow Chain,
 //! MS Word/OOXML의 cantSplit/tblHeader를 참고.
 
-use crate::model::control::Control;
 use crate::document_core::queries::rendering::body_pile_stays_on_anchor_page;
+use crate::model::control::Control;
 use crate::model::footnote::{Footnote, FootnoteShape};
 use crate::model::header_footer::HeaderFooterApply;
 use crate::model::page::{ColumnDef, ColumnType, PageDef};


### PR DESCRIPTION
## 무엇을

#4770: 같은 문단에 완전 겹침으로 앵커된 Square(어울림)·겹침불허 전면 그림 무리를 rhwp가 무조건 쪽당 1장으로 분산해, 한글이 한 쪽에 겹쳐 두는 문서가 크게 과대 페이지가 되는 문제를 고칩니다. 대표: HPV 코호트 연구.hwp s2/pi=1007(그림 24장 150×212mm) — rhwp 260쪽 vs 한글 235쪽(+24가 이 문단 하나).

## 어떻게 — 저장 lineseg에 새겨진 저작 한글의 판단을 따른다

세 실측 표본이 판별자를 줍니다(이슈 #4770 코멘트에 전체 근거):

| 표본 | 한글 실배치 | 저장 첫 lineseg |
|---|---|---|
| HPV pi=1007 (24장) | **1쪽 겹침 유지** | cs=42520(=그림 폭만큼 밀림)·sw=3480, vpos=5040 → 그림이 잔여 본문에 들어감 |
| #1995 본문 96장 | 쪽당 1장 (96쪽) | cs=0, vpos=53602 → 잔여에 안 들어감 |
| #2004 셀 스택 픽스처 | 쪽당 1장 (8쪽) | cs-옆끼임이지만 컨테이너가 셀 |

가드 2곳(둘 다 같은 술어 — **cs ≥ min 그림 폭** AND **저장 vpos + max 그림 높이 ≤ 본문 높이**, 본문 문단 한정):

- `rendering.rs` `compute_render_normalized`: #2004 tac 재분류를 본문 스택에서 이 형상일 때 건너뜀 (셀 스택 경로는 불변)
- `typeset.rs` #1995 다수 전면 이미지 낱장 배치: 같은 형상일 때 발동 억제

저장 lineseg가 없는 소스(HWPX)는 판단 근거가 없어 기존 동작 그대로입니다.

## 검증

- **nextest 5931/5931 통과** (좀비 테스트 프로세스 정리 후; `issue_2308_stable_compat_projection_reuses_arc_identity` 포함), clippy(native-skia) 0, rustfmt 클린
- **10k 쪽수 게이트**(r37 코퍼스, COM-free `rhwp info` 대조): **개선 1 · 회귀 0 · 불변 9,999** — 유일 변화가 HPV 260→236(한글 235)
- **COM 드리프트 사다리**(한글 2022, 전 문단 2,684개): 수정 후 pi746 이후 전이 0, 문서 끝까지 +1 평탄
- 회귀 표본: #1995 청년주거 96장 268쪽=한글 유지, #2004 셀 픽스처 8쪽=한글 유지, 156714340 8쪽 유지, #4654 체육대회 pile 18쪽 유지
- 시각: 수정 후 p212 SVG에 24장이 전부 동일 좌표(86.7, 180.5)에 겹쳐 페인트 — 기존의 쪽 밖 세로 적재(23장 소실, 최대 초과 19,110px) 해소
- 회귀 고정 테스트 추가: `test_typeset_4770_stored_line_beside_pile_keeps_stack_on_anchor_page`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
