### PR TITLE
fix: HWP3 HWPX 내보내기 IR 보존 (#3739)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,10 @@
   라우팅 결과에 해당하는 역할별 자식 절차를 따른다. 모 문서만 읽고 세부 경로를 추정해 진행하지 않는다.
 - 작업 단계가 바뀌면 현재 단계의 변경을 커밋한 뒤 다음 단계 문서를 시작한다.
 - GitHub comment, remote push, PR 생성은 사용자 승인을 받은 뒤 수행한다.
+- Windows PowerShell에서 한글을 포함한 여러 단락의 PR·review·comment 본문은 here-string을
+  `gh --body-file -`로 직접 pipe하지 않는다. UTF-8 **without BOM** 임시 Markdown 파일을
+  `--body-file`로 전달하고, 게시 뒤 API로 한글·선두 BOM·`??` 치환 여부를 확인한다. 정확한
+  명령과 정리 절차는 `mydocs/manual/pr_review_workflow.md`의 3.4.1을 따른다.
 
 ## 문서와 검증
 

--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -64,6 +64,8 @@ rhwp --password '문서비밀번호' export-text protected.hwp -o output/
 ```
 
 - `--password <값>`과 `--password-stdin`은 명령 앞뒤 어느 위치든 한 번만 지정할 수 있다.
+  `--password-stdin`은 Windows PowerShell/.NET pipe가 붙인 UTF-8 BOM도 인코딩 표식으로
+  처리하므로, 권장 stdin 전달 방식으로도 정상 비밀번호를 그대로 사용할 수 있다.
 - 비밀번호가 없으면 종료 코드 2, 틀리면 종료 코드 1이다. 지원하지 않는 HWP5
   EncryptVersion 또는 비압축 HWP3 암호 본문은 종료 코드 1로 거부한다.
 - 일반 열기·내보내기·변환 명령과 `dump-records`가 이 옵션을 사용한다.

--- a/mydocs/manual/codex/docs_and_git_workflow.md
+++ b/mydocs/manual/codex/docs_and_git_workflow.md
@@ -155,6 +155,9 @@ gh issue edit 1063 --add-assignee edwardkim -R edwardkim/rhwp
 - sandbox 네트워크 제한으로 `api.github.com` 연결 실패가 나면 동일 `gh` 명령을 escalation으로 재시도한다.
 - `gh`로 수행한 GitHub 변경은 오늘할일, 계획서, 보고서 중 관련 문서에 기록한다.
 - `gh` 사용도 하이퍼-워터폴 절차를 대체하지 않는다. 이슈 확인, 브랜치, 문서, 승인 게이트는 그대로 유지한다.
+- Windows PowerShell에서 한글 다단락 PR 본문을 게시·수정할 때는 pipe가 아닌 UTF-8 without BOM
+  `--body-file` 경로와 게시 후 API 검증을 사용한다. 중복 명령은 두지 않으며, 정본 절차는
+  [PR 리뷰·통합 워크플로의 Windows 본문 전송](../pr_review_workflow.md#341-windows-powershell-한글-본문)을 따른다.
 
 ## PR Workflow
 

--- a/mydocs/manual/pr_review_workflow.md
+++ b/mydocs/manual/pr_review_workflow.md
@@ -228,6 +228,39 @@ fast-pass 또는 Full CI aggregate 성공은 여전히 merge 직전 다시 확�
 - 게시 직후 해당 review/comment API의 `body`를 읽어 literal `\\n`이 남지 않았는지 확인하고, 임시 본문
   파일은 정확한 경로만 정리한다.
 
+#### 3.4.1 Windows PowerShell 한글 본문
+
+Windows PowerShell 5.1의 here-string을 `gh ... --body-file -`에 직접 pipe하면 현재 console code page나
+UTF-8 BOM이 `gh` 표준입력에 섞일 수 있다. 그러면 GitHub에는 한글이 `??`로 치환되거나 본문 첫 글자
+앞에 보이지 않는 BOM이 남는다. 한글을 포함한 다단락 PR 본문·review·comment에는 **UTF-8 without BOM
+파일 경로**만 사용한다.
+
+```powershell
+$body = @'
+## 변경 요약
+
+- 한글 본문 예시
+'@
+$bodyPath = Join-Path $env:TEMP "rhwp-pr-body-$PID.md"
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText($bodyPath, $body, $utf8NoBom)
+
+# 생성 또는 수정 중 하나를 사용한다.
+gh pr create --repo edwardkim/rhwp --base devel --head <branch> --body-file $bodyPath
+gh pr edit <N> --repo edwardkim/rhwp --body-file $bodyPath
+
+$posted = (gh pr view <N> --repo edwardkim/rhwp --json body | ConvertFrom-Json).body
+if ($posted.Length -eq 0 -or [int][char]$posted[0] -eq 0xFEFF -or $posted.Contains('??')) {
+    throw 'PR 본문 UTF-8 전송을 다시 확인하세요.'
+}
+Remove-Item -LiteralPath $bodyPath
+```
+
+`<N>`은 `gh pr create`가 성공한 뒤 실제 번호로 바꾼다. create 직후 본문을 검증할 때는 같은 방식으로
+`gh pr view`를 실행한다. `??`가 문서 내용으로 의도된 경우에는 그 검사 대신 예상한 한글 제목·문장을
+`Contains()`로 확인한다. 임시 파일은 정확한 `$bodyPath`만 정리하며, `.env`·token·server URL을 본문이나
+검증 출력에 넣지 않는다.
+
 ## 4. review 산출물의 공통 규칙
 
 PR review 문서는 merge 후에도 모순되지 않아야 한다. draft, mergeable, head SHA, CI 상태는

--- a/mydocs/orders/20260815.md
+++ b/mydocs/orders/20260815.md
@@ -1,5 +1,59 @@
 # 오늘 할 일 - 2026년 8월 15일
 
+## Issue #3931 - declared 선이월과 저장 fragment 소유권
+
+- 전용 worktree `/tmp/rhwp-3931`의 `task/3931-declared-rowbreak` 브랜치를 당시 원격 최신
+  `devel` `fbca0aa6c` 위로 1차 재기준화했다. 기본 작업공간의 #4704 WIP는 건드리지 않는다.
+- 1차 재기준화 release-test 바이너리에서 HWP 393쪽, HWPX 386쪽, 한컴 2020 KoPub 설치 PDF 383쪽을
+  재확인했다. sec=10 `pi=14`·`pi=23`은 모두 fragment scan 전에 `DIAG_ADVC`로 이월되고,
+  `pi=23` 문제 행 422.5px·대표 셀 콘텐츠 392.3px도 유지된다.
+- 보호 게이트 `issue_3738_rowbreak_table_footnote_fragment`는 33/33 통과했다.
+- 한컴 2020 PDF를 물리 p287~p288에서 직접 재대조해 과거 줄높이 과대 가설을 기각했다. 대상 셀은
+  24.5px pitch의 12줄+4줄로 두 쪽에 나뉘며, rhwp만 두 문단을 page index 291에 함께 둔다.
+- 작업지시자가 계획의 순차 진행을 승인했다. Stage 1은 동작 불변 진단과 RED 계약을 고정하고,
+  Stage 2에서 구조 증거가 완결된 HWP 표의 flow anchor만 저장 상단으로 재동기화한다. 전역 셀
+  줄높이는 변경하지 않는다.
+- 조사 중 발견한 Canvas2D KoPub 치환(#4741)과 160쪽 표 hit-test 선점(#4753)은 별도 이슈로
+  유지한다. #3931의 Rust 조판 수정에 섞지 않는다.
+- Stage 1·2를 완료했다. `pi=23`은 저장 pitch를 유지한 채 page index 290의 12줄과 index 291의
+  4줄로 분할되고 첫 조각은 본문 bbox 안에 남는다. HWP 전체는 392쪽이며 #3931 3건과 인접
+  focused 회귀 전건이 통과했다. 다음 실행 지점은 `pi=14` declared 선이월을 분리해 다루는
+  Stage 3이다.
+- Stage 3을 완료했다. `pi=14`는 0.1px declared 선이월 대신 기존 scanner가 155.8px 첫 조각을
+  만들며 답변을 page index 286/287로 나눈다. HWPX는 이미 scanner 경로임을 확인해 386쪽
+  래칫만 유지했다. red-check와 #3738 33건을 포함한 focused 회귀가 통과했으며, 다음 실행 지점은
+  Stage 4 광범위·플랫폼·시각 검증이다.
+- #4763 통합 전 Stage 4 자동 검증을 완료했다. 첫 전체 회귀의 중첩 partial table panic 19건은 local paragraph
+  slice에 root `para_index`를 강제한 것이 원인이었고, host 미확인 시 margin 회수를 하지 않는
+  fail-closed lookup으로 보완한 뒤 `release-test` 5,941/5,941를 통과했다. Native Skia 58+2+4건,
+  공식 Docker WASM과 Studio 922 통과·1 skip도 확인했다.
+- 이 시점의 비공개 10k 비교는 성공/오류 전이 0건, 쪽수 변화 8건 모두 HWP5 감소 방향이었다.
+  이 수치는 뒤의 #4763 재기준화 결과로 대체한다.
+- #4763(`#f8c784235`) 병합 뒤 Stage 1~3 여섯 커밋을 최신 `devel` 위로 rebase했다. #4763의
+  terminal response tail과 질문 7의 plain-text 저장 reset이 충돌한 원인을 ordinary cut 직후의
+  control-free 문단 경계로 좁혀 보완했다. control-only local reset은 제외해 질문 14 도형 조판과
+  HWP/HWPX 383쪽을 모두 보존한다.
+- 최신 검증은 `release-test` 6,023/6,023, Native Skia 58+2+4건, 공식 Docker WASM, Studio
+  922 통과·1 skip이다. 최신 10k A/B는 성공/오류 전이 0건이고, 쪽수 변화 5건은 모두 HWP5 감소
+  방향이며 변화 문서 전수 SVG export에서 양쪽 `overflowCellLines=0`이다. 원본·식별 목록·raw
+  결과는 외부에 노출하지 않는다.
+- 동일 물리 p284·p285·p287·p288 비교를
+  `output/3931/visual/current/issue3931-current/review/`에 생성했다. 7702 전용 Studio 서버도
+  최신 Docker JS/WASM과 해시가 일치한다. 공식 #3820 E2E도 이 서버에서 HWP/HWPX 383쪽과
+  page owner를 통과했고, 작업지시자가 시각 판정 통과를 선언했다. 다음 실행 지점은 검증용 생성물
+  제외와 로컬 통합 커밋이며, 원격 push·PR·이슈 close는 별도 승인 전에는 수행하지 않는다.
+- PR 직전 원격 `devel` `99f6c9312` 위로 다시 rebase했다. 사이 변경에는 renderer 파일이 없고
+  rebase 충돌도 없었다. 최신 기준 focused 8/8, `release-test` 6,027/6,027, Native Skia
+  58+2+4, clippy·fmt·diff, 공식 Docker WASM, Studio 922 통과·1 skip을 재확인했다.
+- 재시작한 Windows Chrome 150 CDP에서 WSL 절대 파일 입력 대신 Vite HTTP fixture 경로를 사용해
+  HWP/HWPX 각각 383쪽, source format과 지정 page owner를 통과했다. 로컬 검증 보고서는
+  `output/3931/validation/cdp_wasm_contract.html`에 두었다. 기존 비공개 10k A/B는 renderer 기준
+  `f8c784235` 비교 증거로 유지하고 원본·식별 정보는 외부에 노출하지 않는다.
+- 검증 완료 후보 `d81d11e54`를 원격 `task_m100_3931`에 push하고 Ready PR #4773을 생성했다.
+  reviewer는 `jangster77`로 지정했다. PR은 14 files, +1,412/-28의 대형 PR이므로 즉시 admin
+  merge하지 않고 `mydocs/pr/archives/pr_4773_review.md`와 대표 시각 asset을 trailing commit에
+  포함한 뒤 최신 CI와 reviewer 의견을 별도 cycle로 확인한다.
+
 ## PR #4776 - 저장 시 본문 손실 4종 보정
 
 - [PR #4776](https://github.com/edwardkim/rhwp/pull/4776)의 HWP3 문자, OWPML FieldType,

--- a/mydocs/orders/20260815.md
+++ b/mydocs/orders/20260815.md
@@ -34,3 +34,18 @@
 - 이 trailing review-only head의 fast-pass aggregate를 확인한 뒤, 작업지시자의 명시적 승인으로만 merge한다.
   `CI Impact Policy` required context는 strict up-to-date 보호 규칙과 GitHub Actions expected source를
   실제로 확인하기 전에는 활성화하지 않는다.
+
+## PR #4775 - HWP3 HWPX 내보내기 IR 보존
+
+- [PR #4775](https://github.com/edwardkim/rhwp/pull/4775)는 [#3739](https://github.com/edwardkim/rhwp/issues/3739)의
+  동일 글자모양 경계 소실을 보정하고, 암호 HWP3의 개체 슬롯·하이퍼텍스트·빈 그림 영역이 HWPX
+  표현으로 보존되도록 한다.
+- 최신 `upstream/devel@86b966ac5` 위 code candidate `d7585993`에서 release-test 빌드, 실제 암호 HWP3의
+  IR 무차이·24쪽 검증, #3739 통합 회귀 4건, BOM stdin 바이너리 회귀 1건, workspace build와 변경 파일
+  format·diff 검사를 통과했다. 전체 nextest·WASM은 로컬에서 실행하지 않았고, 전체 clippy는 이 Windows
+  호스트의 Cargo 내부 대기로 완료 결과를 내지 못했으나, code head GitHub Actions의 Lint·Build & Test·
+  Native Skia·Canvas visual diff·Rust CodeQL은 모두 성공했다.
+- collaborator self-review로 처리하며 외부 reviewer는 요청하지 않는다. 상세 판단·표현 정규화 경계·
+  시각 검증 범위는 [PR review](../pr/archives/pr_4775_review.md)에 보존한다.
+- 이 trailing review·오늘할일 head의 GitHub Actions가 성공하고 최신 mergeability와 작업지시자 승인을
+  다시 확인하기 전에는 merge하거나 #3739을 종료하지 않는다.

--- a/mydocs/plans/task_m100_3739.md
+++ b/mydocs/plans/task_m100_3739.md
@@ -25,18 +25,28 @@ HWPX 패키지와 페이지 검증은 성공하지만 종료 코드 3으로 끝�
 1. serializer가 동일 ID의 연속 `char_shapes` 경계를 각각 `<hp:run>`으로 출력한다.
 2. parser가 일반 run 경계를 같은 ID라는 이유만으로 제거하지 않는다.
 3. `secPr` 템플릿 handoff의 합성 중복은 제거해 기존 첫 문단 IR 정합을 유지한다.
-4. 단위 테스트와 `lseg-04-indent.hwp` CLI 회귀 테스트가 동일 ID 경계를 고정한다.
-5. Windows PowerShell에서 focused Cargo test, `cargo fmt --check`, `git diff --check`를 통과한다.
+4. HWP/HWP3 원본에 없는 HWPX field `Command` 단일 parameters 합성만 검증 차이에서
+   제외하고, 그 밖의 field 차이는 계속 검출한다.
+5. Windows PowerShell/.NET pipe의 UTF-8 BOM이 `--password-stdin` 비밀번호에 섞여도
+   HWP3·HWP5·암호 HWPX를 HWPX로 내보낼 수 있다.
+6. 단위 테스트와 `lseg-04-indent.hwp` CLI 회귀 테스트가 동일 ID 경계를 고정한다.
+7. Windows PowerShell에서 focused Cargo test, 변경 파일 `rustfmt --check`,
+   `git diff --check`를 통과한다.
 
 ## 4. 제외 범위
 
 - ParaShape 자동 간격·쪽 나누기와 [PR #4772](https://github.com/edwardkim/rhwp/pull/4772)의 header 경로
 - HWPX 외 형식 변환, UI 동작, 한컴 GUI 수동 판정
 - 원격 push·PR 생성·merge (별도 승인 필요)
+- `HWP3-password-123456.hwp`의 기존 hyperlink·문자 오프셋·그림 영역 IR 차이는
+  다음 스테이지에서 원인별로 분석한다.
 
 ## 5. 검증 순서
 
-1. serializer/parser 단위 회귀 테스트
-2. `samples/lseg-04-indent.hwp`에 대한 `export-hwpx --verify --verify-pages` 통합 회귀 테스트
-3. 포맷·diff 검사
-4. 필요 시 HWPX baseline focused test. 전체 PR CI 성격의 검증은 별도 승인 후 실행한다.
+1. serializer/parser와 HWP→HWPX 검증 정규화 단위 회귀 테스트
+2. `samples/lseg-04-indent.hwp`, `tac-img-02.hwp`에 대한
+   `export-hwpx --verify --verify-pages` 통합 회귀 테스트
+3. 실제 암호 HWP3·HWP5·HWPX 표본에 BOM 포함 `--password-stdin`과
+   `--verify-pages`를 적용한 HWPX 내보내기
+4. 포맷·diff 검사
+5. 필요 시 HWPX baseline focused test. 전체 PR CI 성격의 검증은 별도 승인 후 실행한다.

--- a/mydocs/plans/task_m100_3739.md
+++ b/mydocs/plans/task_m100_3739.md
@@ -29,8 +29,10 @@ HWPX 패키지와 페이지 검증은 성공하지만 종료 코드 3으로 끝�
    제외하고, 그 밖의 field 차이는 계속 검출한다.
 5. Windows PowerShell/.NET pipe의 UTF-8 BOM이 `--password-stdin` 비밀번호에 섞여도
    HWP3·HWP5·암호 HWPX를 HWPX로 내보낼 수 있다.
-6. 단위 테스트와 `lseg-04-indent.hwp` CLI 회귀 테스트가 동일 ID 경계를 고정한다.
-7. Windows PowerShell에서 focused Cargo test, 변경 파일 `rustfmt --check`,
+6. HWP3의 U+FFFC 개체 슬롯·하이퍼텍스트·빈 그림 `imgRect`를 HWPX의 대응 표현으로
+   보존하고, 암호 HWP3의 `--verify --verify-pages`가 exit 0을 반환한다.
+7. 단위 테스트와 `lseg-04-indent.hwp` CLI 회귀 테스트가 동일 ID 경계를 고정한다.
+8. Windows PowerShell에서 focused Cargo test, 변경 파일 `rustfmt --check`,
    `git diff --check`를 통과한다.
 
 ## 4. 제외 범위
@@ -38,15 +40,13 @@ HWPX 패키지와 페이지 검증은 성공하지만 종료 코드 3으로 끝�
 - ParaShape 자동 간격·쪽 나누기와 [PR #4772](https://github.com/edwardkim/rhwp/pull/4772)의 header 경로
 - HWPX 외 형식 변환, UI 동작, 한컴 GUI 수동 판정
 - 원격 push·PR 생성·merge (별도 승인 필요)
-- `HWP3-password-123456.hwp`의 기존 hyperlink·문자 오프셋·그림 영역 IR 차이는
-  다음 스테이지에서 원인별로 분석한다.
 
 ## 5. 검증 순서
 
 1. serializer/parser와 HWP→HWPX 검증 정규화 단위 회귀 테스트
 2. `samples/lseg-04-indent.hwp`, `tac-img-02.hwp`에 대한
    `export-hwpx --verify --verify-pages` 통합 회귀 테스트
-3. 실제 암호 HWP3·HWP5·HWPX 표본에 BOM 포함 `--password-stdin`과
-   `--verify-pages`를 적용한 HWPX 내보내기
+3. 실제 암호 HWP3 표본에 BOM 포함 `--password-stdin`과 `--verify --verify-pages`를,
+   HWP5·HWPX 표본에는 `--verify-pages`를 적용한 HWPX 내보내기
 4. 포맷·diff 검사
 5. 필요 시 HWPX baseline focused test. 전체 PR CI 성격의 검증은 별도 승인 후 실행한다.

--- a/mydocs/plans/task_m100_3739.md
+++ b/mydocs/plans/task_m100_3739.md
@@ -1,0 +1,42 @@
+# Task M100 #3739 수행계획서 — HWPX 동일 글자모양 경계 보존
+
+- 이슈: [#3739](https://github.com/edwardkim/rhwp/issues/3739) `HWPX 로 내보냈다 읽으면 IR 이 달라진다 — char_shapes (lseg-04-indent.hwp)`
+- 기준 커밋: `upstream/devel` `99f6c9312cdfd363a43246d44d90c3621e8f4ab3` (2026-08-14 확인)
+- 작업 브랜치: `codex/issue-3739-preserve-charshape-boundaries`
+
+## 1. 배경과 재현
+
+`samples/lseg-04-indent.hwp`를 `rhwp export-hwpx --verify --verify-pages`로 변환하면
+HWPX 패키지와 페이지 검증은 성공하지만 종료 코드 3으로 끝난다. 재파싱 뒤 문단 1~3의
+`char_shapes`에서 원본의 `[(0, 5), (209, 5)]` 중 두 번째 동일 ID 경계가 사라진다.
+
+## 2. 원인
+
+- `src/serializer/hwpx/section.rs`의 `RunSplitter::new`가 연속된 동일
+  `char_shape_id` 경계를 제거해 run을 하나로 평탄화한다.
+- `src/parser/hwpx/section.rs`도 연속된 동일 ID의 `<hp:run>` 시작을 제거한다.
+
+동일 ID라도 run 경계의 UTF-16 위치는 HWP `PARA_CHAR_SHAPE` IR에서 의미가 있으므로,
+일반 본문 경계는 보존해야 한다. 다만 섹션 첫 문단의 템플릿 `secPr` run과 뒤따르는
+첫 텍스트 run은 동일 ID를 두 번 만들 수 있으므로, 그 합성 경계만 기존처럼 정규화한다.
+
+## 3. 범위와 완료 조건
+
+1. serializer가 동일 ID의 연속 `char_shapes` 경계를 각각 `<hp:run>`으로 출력한다.
+2. parser가 일반 run 경계를 같은 ID라는 이유만으로 제거하지 않는다.
+3. `secPr` 템플릿 handoff의 합성 중복은 제거해 기존 첫 문단 IR 정합을 유지한다.
+4. 단위 테스트와 `lseg-04-indent.hwp` CLI 회귀 테스트가 동일 ID 경계를 고정한다.
+5. Windows PowerShell에서 focused Cargo test, `cargo fmt --check`, `git diff --check`를 통과한다.
+
+## 4. 제외 범위
+
+- ParaShape 자동 간격·쪽 나누기와 [PR #4772](https://github.com/edwardkim/rhwp/pull/4772)의 header 경로
+- HWPX 외 형식 변환, UI 동작, 한컴 GUI 수동 판정
+- 원격 push·PR 생성·merge (별도 승인 필요)
+
+## 5. 검증 순서
+
+1. serializer/parser 단위 회귀 테스트
+2. `samples/lseg-04-indent.hwp`에 대한 `export-hwpx --verify --verify-pages` 통합 회귀 테스트
+3. 포맷·diff 검사
+4. 필요 시 HWPX baseline focused test. 전체 PR CI 성격의 검증은 별도 승인 후 실행한다.

--- a/mydocs/pr/archives/pr_4775_review.md
+++ b/mydocs/pr/archives/pr_4775_review.md
@@ -1,0 +1,68 @@
+# PR #4775 검토 - HWP3 HWPX 내보내기 IR 보존
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4775](https://github.com/edwardkim/rhwp/pull/4775) |
+| 관련 이슈 | `Closes #3739` |
+| 작성자·검토 방식 | `jangster77` · 작성자 self-review (외부 reviewer 미지정) |
+| base / head | `devel` / `task_m100_3739` |
+| code candidate | `d7585993dd1b67e5bfc2e7db9165dae2a2cd79b6` (CI lint 보정 포함) |
+| 규모 | 코드 5 commits + 이 review·오늘할일 trailing commit |
+| 작성 시점 상태 | code head Full CI 성공, `MERGEABLE/CLEAN`; 이 trailing 문서 head CI 대기 |
+| 라우팅 | collaborator self-merge; intake·local validation·visual fixture evidence |
+
+`mergeable`, `mergeStateStatus`, head SHA 및 CI 결과는 작성 시점의 참고값이다. 이 review·오늘할일
+trailing commit을 push한 뒤에는 최신 head의 GitHub Actions, `MERGEABLE`, `CLEAN`을 merge 직전에
+다시 확인한다.
+
+## 변경 범위와 판단
+
+- 동일 `char_shape_id`라도 start position이 다른 HWPX run 경계를 serializer·parser에서 보존한다.
+- Windows PowerShell/.NET pipe의 선두 UTF-8 BOM을 암호 본문에서 제거해 암호 HWP3·HWP5·HWPX의
+  `--password-stdin` 내보내기를 보정한다.
+- 암호 HWP3가 개체 위치를 `U+FFFC` 한 글자로 보이되 실제 offset에서는 8 UTF-16 단위 슬롯으로
+  세는 계약을 HWPX control 슬롯으로 치환해, 이후 char shape가 밀리지 않게 한다.
+- HWP3 하이퍼텍스트는 HWPX `HYPERLINK` field와 Command parameter로 보존한다. URL이 비어 있으면
+  표시 문자열을 fallback으로 유지한다.
+- HWP3의 빈 그림 `imgRect`와 HWPX의 canonical 실측 사각형, HWP3 Hyperlink와 재파싱 HWPX Field의
+  차이는 원본·재파싱 control을 확인한 정확한 경우에만 HWP3→HWPX `--verify`에서 정규화한다.
+
+renderer, layout, WASM, Studio, 신규 sample·golden·기준 PDF는 변경하지 않았다. Windows PowerShell의
+한글 PR 본문 전송 절차와 review·오늘할일도 함께 정리했다. 기존 HWP/HWPX fixture를 쓰는
+parser·serializer 구조 보존 PR이므로 별도 visual sweep을 merge 근거로 사용하지 않았다. `--verify-pages`의
+24쪽 결과는 페이지 수 구조 검증이지 한컴 PDF와의 시각 일치 주장도 아니다.
+
+## 완료된 검증
+
+- 최신 `upstream/devel@86b966ac5` 위로 rebase한 뒤
+  `cargo build --profile release-test --target-dir target\pr-review --bin rhwp`를 통과했다.
+- 실제 암호 HWP3 표본을 `--password 123456 export-hwpx --verify --verify-pages`로 변환해
+  IR 무차이와 24쪽 재열기, exit 0을 확인했다.
+- `cargo test --profile release-test --target-dir target\pr-review --test issue_3739_hwpx_same_char_shape_boundary -- --nocapture`를
+  실행해 4 passed를 확인했다. BOM 포함 stdin의 암호 HWP3 IR·페이지 검증도 이 통합 테스트에 포함된다.
+- #3739 serializer/parser/정규화 focused 단위 테스트 4건과 HWP3 URL 누락 fallback field 단위 테스트를
+  code candidate에서 통과했다.
+- CI에서 실패한 `password_stdin_ignores_only_a_leading_utf8_bom` 바이너리 단위 테스트를 보정 뒤 다시
+  실행해 1 passed를 확인했고, `cargo build --workspace --target-dir target\pr-review`도 통과했다.
+- 변경한 `src/main.rs`의 `rustfmt --check`와 `git diff --check`를 통과했다. 전체 `cargo fmt --check`는
+  이 Windows 호스트에서 긴 파일 경로(`os error 206`)로 시작 단계에 실패했다.
+
+전체 `cargo nextest run --tests`, WASM은 로컬에서 실행하지 않았다. `cargo clippy --workspace --all-targets
+-- -D warnings`는 이 호스트에서 Cargo 내부 대기 상태로 완료 결과를 내지 못해 중단했다. 그러나 code head
+`d7585993`의 GitHub Actions는 Lint, Build & Test, Native Skia, Canvas visual diff, Rust CodeQL을 모두
+성공으로 판정했다. 이 trailing 문서 head는 별도로 CI 성공을 확인한다.
+
+## 위험과 후속 범위
+
+- 중첩 문단의 HWP3 Hyperlink는 원본 control 경로를 확인하는 정규화가 아직 없으므로 보수적으로 diff를
+  남긴다. 이번 표본의 본문 hyperlink만 추정 없이 정규화했다.
+- HWP3 추가정보가 없는 hyperlink의 표시 문자열은 실제 URL이 아닐 수 있다. 빈 값으로 버리지 않고
+  Command에 보존하지만, URL 추출 정밀화는 별도 범위다.
+- 다른 HWP5·HWPX field나 실제 picture geometry 차이는 정규화하지 않는다.
+
+## 최종 권고
+
+조건부 merge를 권고한다. 이 review·오늘할일 trailing head의 CI가 성공하고, merge 직전에 최신 head SHA,
+`MERGEABLE`, `CLEAN`을 다시 확인한 뒤 작업지시자 승인으로 self-merge한다.

--- a/mydocs/report/task_m100_3739_report.md
+++ b/mydocs/report/task_m100_3739_report.md
@@ -25,33 +25,53 @@ handoff만 예외적으로 정규화했다.
 - 실제 암호 표본 3종은 BOM 포함 stdin으로 HWPX 산출물 생성과 `--verify-pages`
   재열기(24·23·64쪽)를 모두 통과했다.
 
-`HWP3-password-123456.hwp`에 `--verify`까지 주면 hyperlink 2건의 미지원 변환과
-기존 문자 오프셋·그림 영역 차이를 포함한 15건이 남아 exit 3이다. 이는 내보내기 실패가
-아니며, 다음 스테이지에서 원인별 개선 대상으로 분리한다.
+## 2단계 — HWP3 IR 차이 분석 및 보정
+
+암호 HWP3 표본의 15건 차이를 원인별로 분리했다. HWP3 파서는 개체 자리에 `U+FFFC` 한
+글자를 남기지만 암호 표본의 `char_offsets`는 그 자리를 8 UTF-16 단위 슬롯으로 센다.
+직렬화기가 이 표식을 일반 텍스트로 다시 쓰면 실제 HWPX 개체와 겹쳐 이후 run 경계가
+밀렸다. `render_runs`가 확인된 표식만 해당 위치의 HWPX control로 치환하고, 슬롯 수
+추정도 표식의 1단위/실제 8단위 차이를 보정했다. 이 조치만으로 15건 중 13건을 없앴다.
+
+남은 하이퍼텍스트는 HWP3 `Control::Hyperlink`에 대응하는 HWPX control이 없으므로
+`fieldBegin type="HYPERLINK"`와 `Command` parameter로 승격했다. HWP3 추가정보에 URL이
+없으면 표시 문자열을 Command로 보존한다. HWPX 재파싱 시에는 `Field`가 되므로, HWP3의
+비슬롯 Hyperlink와 `[field]` 한 개의 정확한 표기 차이만 HWP3→HWPX 검증 정규화에서
+제외한다. HWP5에는 이 규칙을 적용하지 않는다.
+
+마지막 그림 차이는 HWP3의 `[0,0,0,0]` crop 센티널을 HWPX가 실제
+`(0,0,width,0)/(width,height,0,height)` 사각형으로 물질화한 경우뿐이었다. 크기나 다른
+기하가 함께 달라지면 여전히 검증 실패로 남긴다. 결과적으로
+`HWP3-password-123456.hwp`는 BOM 포함 stdin 비밀번호로도 `--verify --verify-pages`
+exit 0, 24쪽을 통과한다.
 
 ## 변경 파일
 
 - `src/serializer/hwpx/section.rs`
+- `src/serializer/hwpx/context.rs`
+- `src/serializer/hwpx/field.rs`
 - `src/parser/hwpx/section.rs`
 - `src/serializer/hwpx/roundtrip.rs`
 - `src/main.rs`
 - `tests/issue_3739_hwpx_same_char_shape_boundary.rs`
 - `mydocs/plans/task_m100_3739.md`
 - `mydocs/working/task_m100_3739_stage1.md`
+- `mydocs/working/task_m100_3739_stage2.md`
 - `mydocs/report/task_m100_3739_report.md`
 - `mydocs/manual/cli_commands.md`
 
 ## 검증
 
 - 실제 재현 샘플 CLI: `--verify --verify-pages` exit 0
-- #3739 serializer/parser/검증 정규화 단위 테스트: 3 passed
-- 실제 샘플 통합 회귀 테스트: 3 passed
+- #3739 serializer/parser/검증 정규화 단위 테스트: 4 passed
+- HWP3 URL 누락 fallback field 단위 테스트: 1 passed
+- 실제 샘플 통합 회귀 테스트: 4 passed
 - 기존 표 슬롯 동일-ID parser 테스트: 1 passed
 - 변경 Rust 파일 rustfmt 검사 및 diff whitespace 검사: 통과
 - 추가 HWP 4종(페이지 설정·탭·복합 표·각주/글상자): 모두 `--verify --verify-pages` exit 0
 - BOM 포함 stdin 암호 HWP3·HWP5·HWPX HWPX 변환: 모두 산출물 생성 및 페이지 재열기 통과
 
-이미지 포함 `tac-img-02.hwp`는 페이지 66쪽 검증은 통과했으나 field `parameters` 6건의
-기존 IR 차이로 exit 3이다. `char_shapes` 차이는 없으므로 #3739과는 무관하다.
+이미지 포함 `tac-img-02.hwp`는 Command 단일 parameter의 표현 차이를 HWP→HWPX 경로에만
+정규화한 뒤 66쪽 및 IR 검증을 통과한다.
 
 전체 baseline·clippy·PR CI는 사용자 승인 후 다음 검증 단계에서 실행한다.

--- a/mydocs/report/task_m100_3739_report.md
+++ b/mydocs/report/task_m100_3739_report.md
@@ -29,5 +29,9 @@ handoff만 예외적으로 정규화했다.
 - 실제 샘플 통합 회귀 테스트: 1 passed
 - 기존 표 슬롯 동일-ID parser 테스트: 1 passed
 - 변경 Rust 파일 rustfmt 검사 및 diff whitespace 검사: 통과
+- 추가 HWP 4종(페이지 설정·탭·복합 표·각주/글상자): 모두 `--verify --verify-pages` exit 0
+
+이미지 포함 `tac-img-02.hwp`는 페이지 66쪽 검증은 통과했으나 field `parameters` 6건의
+기존 IR 차이로 exit 3이다. `char_shapes` 차이는 없으므로 #3739과는 무관하다.
 
 전체 baseline·clippy·PR CI는 사용자 승인 후 다음 검증 단계에서 실행한다.

--- a/mydocs/report/task_m100_3739_report.md
+++ b/mydocs/report/task_m100_3739_report.md
@@ -1,0 +1,33 @@
+# Task M100 #3739 결과 보고서 — HWPX 동일 글자모양 경계 보존
+
+## 결과
+
+`samples/lseg-04-indent.hwp`를 HWPX로 내보낸 뒤 다시 읽을 때, 같은
+`char_shape_id`를 가진 두 번째 경계가 사라져 `--verify`가 exit 3으로 끝나던 문제를
+해소했다. 이제 `export-hwpx --verify --verify-pages`는 1쪽 검증과 IR 무차이를 모두
+통과하고 exit 0을 반환한다.
+
+## 원인과 조치
+
+serializer와 parser가 모두 연속 동일 ID를 값만으로 dedup했다. 그러나
+`(start_pos, char_shape_id)`에서 `start_pos`는 HWP `PARA_CHAR_SHAPE`의 보존 대상이다.
+따라서 일반 run 경계는 위치까지 유지하고, 템플릿이 만드는 첫 `secPr` run의 동일-ID
+handoff만 예외적으로 정규화했다.
+
+## 변경 파일
+
+- `src/serializer/hwpx/section.rs`
+- `src/parser/hwpx/section.rs`
+- `tests/issue_3739_hwpx_same_char_shape_boundary.rs`
+- `mydocs/plans/task_m100_3739.md`
+- `mydocs/working/task_m100_3739_stage1.md`
+
+## 검증
+
+- 실제 재현 샘플 CLI: `--verify --verify-pages` exit 0
+- #3739 serializer/parser 단위 테스트: 2 passed
+- 실제 샘플 통합 회귀 테스트: 1 passed
+- 기존 표 슬롯 동일-ID parser 테스트: 1 passed
+- 변경 Rust 파일 rustfmt 검사 및 diff whitespace 검사: 통과
+
+전체 baseline·clippy·PR CI는 사용자 승인 후 다음 검증 단계에서 실행한다.

--- a/mydocs/report/task_m100_3739_report.md
+++ b/mydocs/report/task_m100_3739_report.md
@@ -14,22 +14,42 @@ serializer와 parser가 모두 연속 동일 ID를 값만으로 dedup했다. 그
 따라서 일반 run 경계는 위치까지 유지하고, 템플릿이 만드는 첫 `secPr` run의 동일-ID
 handoff만 예외적으로 정규화했다.
 
+## 1단계 추가 보정
+
+- `tac-img-02.hwp`의 field `Command` 단일 parameters는 HWP/HWP3 원본에 해당 raw XML
+  저장 슬롯이 없어 HWPX 저장 과정에서 합성되는 표현이다. HWP/HWP3→HWPX `--verify`에서
+  그 정확한 diff만 제거해 실제 parameters·char_shapes 등 다른 차이는 계속 실패한다.
+- Windows PowerShell/.NET pipe가 `--password-stdin` 첫 바이트에 붙이는 UTF-8 BOM을
+  인코딩 표식으로 제거했다. 따라서 암호 HWP3·HWP5·HWPX도 stdin 비밀번호로 HWPX로
+  전환할 수 있다.
+- 실제 암호 표본 3종은 BOM 포함 stdin으로 HWPX 산출물 생성과 `--verify-pages`
+  재열기(24·23·64쪽)를 모두 통과했다.
+
+`HWP3-password-123456.hwp`에 `--verify`까지 주면 hyperlink 2건의 미지원 변환과
+기존 문자 오프셋·그림 영역 차이를 포함한 15건이 남아 exit 3이다. 이는 내보내기 실패가
+아니며, 다음 스테이지에서 원인별 개선 대상으로 분리한다.
+
 ## 변경 파일
 
 - `src/serializer/hwpx/section.rs`
 - `src/parser/hwpx/section.rs`
+- `src/serializer/hwpx/roundtrip.rs`
+- `src/main.rs`
 - `tests/issue_3739_hwpx_same_char_shape_boundary.rs`
 - `mydocs/plans/task_m100_3739.md`
 - `mydocs/working/task_m100_3739_stage1.md`
+- `mydocs/report/task_m100_3739_report.md`
+- `mydocs/manual/cli_commands.md`
 
 ## 검증
 
 - 실제 재현 샘플 CLI: `--verify --verify-pages` exit 0
-- #3739 serializer/parser 단위 테스트: 2 passed
-- 실제 샘플 통합 회귀 테스트: 1 passed
+- #3739 serializer/parser/검증 정규화 단위 테스트: 3 passed
+- 실제 샘플 통합 회귀 테스트: 3 passed
 - 기존 표 슬롯 동일-ID parser 테스트: 1 passed
 - 변경 Rust 파일 rustfmt 검사 및 diff whitespace 검사: 통과
 - 추가 HWP 4종(페이지 설정·탭·복합 표·각주/글상자): 모두 `--verify --verify-pages` exit 0
+- BOM 포함 stdin 암호 HWP3·HWP5·HWPX HWPX 변환: 모두 산출물 생성 및 페이지 재열기 통과
 
 이미지 포함 `tac-img-02.hwp`는 페이지 66쪽 검증은 통과했으나 field `parameters` 6건의
 기존 IR 차이로 exit 3이다. `char_shapes` 차이는 없으므로 #3739과는 무관하다.

--- a/mydocs/working/task_m100_3739_stage1.md
+++ b/mydocs/working/task_m100_3739_stage1.md
@@ -1,0 +1,42 @@
+# Task M100 #3739 — 구현·focused 검증 완료 보고서
+
+## 작업 잠금과 기준
+
+- 이슈 [#3739](https://github.com/edwardkim/rhwp/issues/3739)는 `jangster77`에게 할당했다.
+- 기준은 `upstream/devel` `99f6c9312cdfd363a43246d44d90c3621e8f4ab3`이며,
+  작업 브랜치는 `codex/issue-3739-preserve-charshape-boundaries`다.
+
+## 구현
+
+1. `src/serializer/hwpx/section.rs`
+   - `RunSplitter`가 연속된 동일 `char_shape_id`를 제거하지 않고, 각 `start_pos`마다
+     별도 `<hp:run>`을 방출하도록 변경했다.
+2. `src/parser/hwpx/section.rs`
+   - 일반 동일-ID run 경계를 보존하도록 전역 dedup을 제거했다.
+   - 섹션 첫 문단의 `secPr` 템플릿 run과 같은 ID의 첫 텍스트 run만 합성 중복으로
+     정규화해 기존 첫 문단 IR 계약을 유지했다.
+3. 회귀 테스트
+   - serializer 단위 테스트: 동일 ID 경계가 두 run으로 출력되는지 확인.
+   - parser 단위 테스트: 일반 경계 보존과 `secPr` handoff 예외를 확인.
+   - `tests/issue_3739_hwpx_same_char_shape_boundary.rs`: 실제
+     `samples/lseg-04-indent.hwp`에 `export-hwpx --verify --verify-pages`를 실행해
+     종료 코드 0을 고정.
+
+## focused 검증
+
+| 검증 | 결과 |
+|---|---|
+| `cargo build --profile release-test --target-dir target\pr-review --bin rhwp` | 통과 |
+| `rhwp export-hwpx samples\lseg-04-indent.hwp <temp>\lseg-04-indent.hwpx --verify --verify-pages` | 통과 — 1쪽, IR 차이 없음, exit 0 |
+| `issue_3739_hwpx_same_char_shape_boundary` 전용 테스트 실행 | 1 passed |
+| `issue_3739` library 단위 테스트 실행 | 2 passed |
+| 기존 `test_parse_control_keeps_interleaved_offsets` | 1 passed |
+| 변경 Rust 파일 `rustfmt --check` 및 `git diff --check` | 통과 |
+
+`cargo fmt --all`은 이 Windows 호스트에서 기존 경로 길이 제한(OS error 206)으로 실행되지
+않아, 변경한 Rust 파일에는 동일 rustfmt 버전으로 직접 `--check`를 수행했다.
+
+## 보류
+
+- HWPX baseline 전수, `cargo clippy`, 전체 PR CI 성격의 검증은 별도 승인 전에는 실행하지 않았다.
+- 원격 push·PR 생성·merge는 수행하지 않았다.

--- a/mydocs/working/task_m100_3739_stage1.md
+++ b/mydocs/working/task_m100_3739_stage1.md
@@ -36,6 +36,21 @@
 `cargo fmt --all`은 이 Windows 호스트에서 기존 경로 길이 제한(OS error 206)으로 실행되지
 않아, 변경한 Rust 파일에는 동일 rustfmt 버전으로 직접 `--check`를 수행했다.
 
+## 추가 HWP 샘플 확인
+
+같은 Windows `rhwp export-hwpx --verify --verify-pages` 명령으로 다음 샘플을 추가 확인했다.
+
+| 샘플 | 결과 |
+|---|---|
+| `hwp3-pagedef-1915.hwp` | exit 0 — IR 무차이 |
+| `issue1892_hwp3_tab_roundtrip.hwp` | exit 0 — IR 무차이 |
+| `hwpers_test4_complex_table.hwp` | exit 0 — IR 무차이 |
+| `footnote-tbox-01.hwp` | exit 0 — IR 무차이 |
+| `tac-img-02.hwp` | exit 3 — field `parameters` 6건 기존 차이, char_shapes 차이 없음; 페이지 66쪽 검증 통과 |
+
+마지막 항목은 #3739의 수정 경로와 다른 field 메타데이터 축이므로 본 수정의 회귀로 분류하지
+않았다.
+
 ## 보류
 
 - HWPX baseline 전수, `cargo clippy`, 전체 PR CI 성격의 검증은 별도 승인 전에는 실행하지 않았다.

--- a/mydocs/working/task_m100_3739_stage1.md
+++ b/mydocs/working/task_m100_3739_stage1.md
@@ -55,3 +55,31 @@
 
 - HWPX baseline 전수, `cargo clippy`, 전체 PR CI 성격의 검증은 별도 승인 전에는 실행하지 않았다.
 - 원격 push·PR 생성·merge는 수행하지 않았다.
+
+## 1단계 보정 — field parameters 및 Windows 암호 stdin
+
+1. `tac-img-02.hwp`의 field `parameters` 6건은 HWP 원본의 저장 슬롯 부재로 인해
+   HWPX serializer가 `Command` 단일 parameter를 합성하고, 재파서가 그 원문을 보존해
+   생기는 표현 차이였다. HWP/HWP3 입력의 **정확히 그 합성 표현만** 검증 diff에서
+   제외해 `--verify`가 실제 손실을 계속 보고하도록 했다.
+2. Windows PowerShell/.NET이 `--password-stdin` 첫 바이트에 붙이는 UTF-8 BOM을
+   비밀번호 본문으로 해석하던 문제를 고쳤다. stdin 전체의 선두 BOM만 제거하므로 실제
+   비밀번호와 두 번째 줄의 output password는 변경하지 않는다.
+3. `tests/issue_3739_hwpx_same_char_shape_boundary.rs`에 다음 실제 표본 회귀를 더했다.
+   - `tac-img-02.hwp`: `--verify --verify-pages` IR 무차이, 66쪽
+   - `HWP3-password-123456.hwp`: BOM 포함 `--password-stdin`으로 HWPX 생성·24쪽 재열기
+   - `HWP5-password-123456.hwpx`: 같은 경로로 생성·23쪽 재열기
+   - `hwp3-sample16-hwp5-2024-password-123456.hwp`: 같은 경로로 생성·64쪽 재열기
+
+암호 HWP3 표본은 위 변환 자체와 페이지 검증은 통과한다. 다만 `--verify`를 함께 주면
+기존 hyperlink 2건 드롭, 문자 오프셋·그림 영역을 포함한 15건 IR 차이로 exit 3이므로,
+이는 다음 스테이지에서 별도로 분석한다.
+
+### 1단계 focused 검증 추가
+
+| 검증 | 결과 |
+|---|---|
+| `issue_3739_hwpx_same_char_shape_boundary` | 3 passed |
+| `issue_3739` library 단위 테스트 | 3 passed |
+| BOM 포함 stdin으로 암호 HWP3·HWP5·HWPX `export-hwpx --verify-pages` | 모두 exit 0, 24·23·64쪽 |
+| 변경 Rust 파일 `rustfmt --check`, `git diff --check` | 통과 |

--- a/mydocs/working/task_m100_3739_stage2.md
+++ b/mydocs/working/task_m100_3739_stage2.md
@@ -1,0 +1,43 @@
+# Task M100 #3739 2단계 — HWP3 IR 차이 보정 완료
+
+## 목표
+
+1단계 커밋 `cd09580fb` 뒤에도 `HWP3-password-123456.hwp`는 HWPX 산출과 24쪽 재열기는
+성공했지만 `--verify`에서 15건의 IR 차이로 exit 3이었다. 이 단계는 각 차이를
+원인별로 분석하고, 실제 HWPX 표현을 보존한 뒤 검증 가능한 차이만 최소 범위로
+정규화한다.
+
+## 분석과 구현
+
+| 원인 | 관측 | 조치 |
+|---|---|---|
+| HWP3 개체 위치 | `U+FFFC`는 text에는 1단위지만 암호 표본의 offset에는 8단위 슬롯으로 기록됨 | 해당 표식을 `<hp:t>`로 쓰지 않고 control 슬롯으로 치환하고 슬롯 수 추정을 보정 |
+| HWP3 하이퍼텍스트 | 종전 HWPX serializer가 `Control::Hyperlink`를 버려 이후 `char_shapes`가 8단위 밀림 | `fieldBegin type="HYPERLINK"`와 `Command` parameter로 HWPX field를 방출 |
+| URL 누락 링크 | HWP3 추가정보에 URL이 없으면 `url`이 빈 문자열 | 표시 문자열을 Command fallback으로 보존 |
+| 그림 영역 | HWP3 `[0,0,0,0]`는 crop 정보 없음 센티널, HWPX는 실제 사각형을 요구 | 정확한 canonical 물질화 형태만 HWP3→HWPX 검증에서 제외 |
+
+개체 슬롯 보정 뒤 차이는 15건에서 그림 1건·하이퍼링크 위치 1건으로 줄었다. 하이퍼링크
+방출 뒤에는 HWPX 재파서의 `Field` 표기 2건이 새로 관찰됐으며, 둘은 HWP3의 비슬롯
+`Hyperlink`와 같은 정보를 표현한 것이다. HWP3 전용 정규화는 이 `[field]` 한 개와 빈
+`imgRect`의 canonical 물질화만 제외한다. 다른 컨트롤·`curSz`·`imgDim`·복합 기하 차이는
+계속 실패한다.
+
+## focused 검증 (Windows PowerShell)
+
+| 검증 | 결과 |
+|---|---|
+| `cargo build --profile release-test --target-dir target\pr-review --bin rhwp` | 통과 |
+| `HWP3-password-123456.hwp --password 123456 export-hwpx --verify --verify-pages` | exit 0, IR 무차이, 24쪽 |
+| `cargo test --profile release-test --target-dir target\pr-review --lib issue_3739 -- --nocapture` | 4 passed |
+| HWP3 URL 누락 fallback field 단위 테스트 | 1 passed |
+| `cargo test --profile release-test --target-dir target\pr-review --test issue_3739_hwpx_same_char_shape_boundary -- --nocapture` | 4 passed |
+| 변경 Rust 파일 `rustfmt --check`, `git diff --check` | 통과 |
+
+통합 테스트는 HWP3의 BOM 포함 `--password-stdin`에서도 `--verify --verify-pages`를
+통과하도록 고정한다. HWP5·HWPX 암호 표본은 기존처럼 BOM stdin과 페이지 재열기를
+계속 확인한다.
+
+## 범위 밖
+
+- 전체 baseline·clippy·PR CI 성격 검증, 원격 push·PR 생성·merge
+- 한컴 GUI 수동 판정

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,6 +160,13 @@ fn has_global_auth_option(args: &[String]) -> bool {
     })
 }
 
+/// Windows PowerShell/.NET이 UTF-8 표준입력의 첫 바이트에 붙일 수 있는 BOM은
+/// 비밀번호 본문이 아니라 인코딩 표식이다. 첫 줄 암호에 섞이면 정상 비밀번호도
+/// 오입력으로 판정되므로, stdin 전체의 맨 앞에서만 제거한다.
+fn strip_utf8_bom(input: &str) -> &str {
+    input.strip_prefix('\u{feff}').unwrap_or(input)
+}
+
 /// args 전체를 스캔해 입력·출력 인증 옵션을 떼어낸다.
 ///
 /// 뽑아낸 입력 암호와 출력 암호는 이 함수 안에서 thread-local 상태로 소비하고,
@@ -230,6 +237,7 @@ fn strip_global_auth_options(mut args: Vec<String>) -> Result<Vec<String>, i32> 
             eprintln!("오류: 표준 입력에서 비밀번호 읽기 실패 - {}", error);
             return Err(EXIT_RUNTIME);
         }
+        let stdin = strip_utf8_bom(&stdin);
         let mut lines = stdin.lines();
         if password_stdin {
             password = Some(lines.next().unwrap_or_default().to_string());
@@ -13372,6 +13380,7 @@ fn export_hwpx(args: &[String]) -> i32 {
             return EXIT_RUNTIME;
         }
     };
+    let source_format = rhwp::parser::detect_format(&data);
 
     let doc = match load_document(&data) {
         Ok(d) => d,
@@ -13474,6 +13483,15 @@ fn export_hwpx(args: &[String]) -> i32 {
                             doc.document(),
                             reloaded.document(),
                         );
+                        // HWP 계열은 HWPX `<hp:parameters>` 원문을 실을 슬롯이 없어
+                        // command 단일 parameters가 합성될 수 있다. 실제 내용 손실과
+                        // 구분해 이 표현 차이만 제외한다 (#3739).
+                        let diff = match source_format {
+                            rhwp::parser::FileFormat::Hwp | rhwp::parser::FileFormat::Hwp3 => {
+                                rhwp::serializer::hwpx::roundtrip::strip_hwp_to_hwpx_noise(diff)
+                            }
+                            _ => diff,
+                        };
                         if !diff.is_empty() {
                             print_ir_verify_failure(&diff, &output_path.display().to_string());
                             verify_report = serde_json::json!({
@@ -25500,6 +25518,16 @@ mod tests {
         // 비밀번호는 반환값이 아니라 CLI_PASSWORD(thread_local)로 전달된다.
         assert_eq!(cli_password().as_deref(), Some("secret"));
         set_cli_password(None);
+    }
+
+    #[test]
+    fn password_stdin_ignores_only_a_leading_utf8_bom() {
+        assert_eq!(strip_utf8_bom("\u{feff}123456\n"), "123456\n");
+        assert_eq!(strip_utf8_bom("123456\n"), "123456\n");
+        assert_eq!(
+            strip_utf8_bom("123456\n\u{feff}next"),
+            "123456\n\u{feff}next"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13483,12 +13483,19 @@ fn export_hwpx(args: &[String]) -> i32 {
                             doc.document(),
                             reloaded.document(),
                         );
-                        // HWP 계열은 HWPX `<hp:parameters>` 원문을 실을 슬롯이 없어
-                        // command 단일 parameters가 합성될 수 있다. 실제 내용 손실과
-                        // 구분해 이 표현 차이만 제외한다 (#3739).
+                        // HWP 계열은 HWPX와 표현 자리가 다른 필드 메타데이터가 있고,
+                        // HWP3에는 하이퍼텍스트·빈 그림 imgRect의 추가 정규화가 있다.
+                        // 실제 내용·배치 차이는 계속 검출한다 (#3739).
                         let diff = match source_format {
-                            rhwp::parser::FileFormat::Hwp | rhwp::parser::FileFormat::Hwp3 => {
+                            rhwp::parser::FileFormat::Hwp => {
                                 rhwp::serializer::hwpx::roundtrip::strip_hwp_to_hwpx_noise(diff)
+                            }
+                            rhwp::parser::FileFormat::Hwp3 => {
+                                rhwp::serializer::hwpx::roundtrip::strip_hwp3_to_hwpx_noise(
+                                    doc.document(),
+                                    reloaded.document(),
+                                    diff,
+                                )
                             }
                             _ => diff,
                         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -25410,8 +25410,8 @@ mod tests {
     use super::{
         allows_implicit_sibling_resources, cli_output_password, cli_password,
         collect_audit_capsules, replay_scratch_dir, set_cli_output_password, set_cli_password,
-        strip_global_auth_options, tab_ext_semantic_differs, with_replay_input_snapshot,
-        EXIT_USAGE,
+        strip_global_auth_options, strip_utf8_bom, tab_ext_semantic_differs,
+        with_replay_input_snapshot, EXIT_USAGE,
     };
     use rhwp::parser::FileFormat;
 

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -455,8 +455,13 @@ fn parse_paragraph(
     let mut text_parts: Vec<String> = Vec::new();
     let mut current_char_shape_id: u32 = 0;
     let mut char_shape_changes: Vec<(u32, u32)> = Vec::new(); // (utf16_pos, char_shape_id)
-                                                              // [Task #1556] fieldEnd 의 (beginIDRef, fieldid) 를 출현 순서대로 보관 — text_parts 의
-                                                              // `\u{0004}` 와 1:1 대응. 고아 fieldEnd 복원에 사용.
+                                                              // 템플릿 첫 run 의 secPr/colPr 뒤에는 같은 charPrIDRef 의 텍스트 run 이 한 번 더
+                                                              // 올 수 있다. 이 경우만 HWP PARA_CHAR_SHAPE 의 단일 시작 entry 로 정규화한다.
+                                                              // 일반 동일-ID run 경계는 위치 자체가 IR이 보존할 정보이므로 제거하면 안 된다 (#3739).
+    let mut preceding_run_had_sec_pr = false;
+    let mut preceding_run_char_shape_id: Option<u32> = None;
+    // [Task #1556] fieldEnd 의 (beginIDRef, fieldid) 를 출현 순서대로 보관 — text_parts 의
+    // `\u{0004}` 와 1:1 대응. 고아 fieldEnd 복원에 사용.
     let mut field_end_attrs: Vec<(u32, u32)> = Vec::new();
 
     loop {
@@ -474,7 +479,13 @@ fn parse_paragraph(
                         }
                         // 현재 UTF-16 위치에서 글자모양 변경 기록
                         let utf16_pos = calc_utf16_len_from_parts(&text_parts);
-                        char_shape_changes.push((utf16_pos, current_char_shape_id));
+                        let template_sec_pr_handoff = preceding_run_had_sec_pr
+                            && preceding_run_char_shape_id == Some(current_char_shape_id);
+                        if !template_sec_pr_handoff {
+                            char_shape_changes.push((utf16_pos, current_char_shape_id));
+                        }
+                        preceding_run_had_sec_pr = false;
+                        preceding_run_char_shape_id = Some(current_char_shape_id);
                     }
                     b"t" => {
                         // 텍스트 읽기 (탭 확장 데이터 포함)
@@ -523,6 +534,7 @@ fn parse_paragraph(
                         }
                     }
                     b"secPr" => {
+                        preceding_run_had_sec_pr = true;
                         // 문단 내 섹션 정의 파싱
                         let mut sd = SectionDef::default();
                         parse_section_def_start(ce, &mut sd);
@@ -760,21 +772,15 @@ fn parse_paragraph(
     para.has_para_text = !para.text.is_empty() || !para.controls.is_empty();
 
     // char_shapes는 원본 문단 순서(text_parts)를 기준으로 계산한 위치를 그대로 사용한다.
-    // [Task #1058 후속] 같은 char_shape_id 연속 dedup — HWPX 의 여러 run 이 같은
-    // charPrIDRef 일 때 HWP PARA_CHAR_SHAPE 는 첫 entry 1개만 유지하므로 정합.
-    let mut deduped_cs: Vec<CharShapeRef> = Vec::new();
-    for (pos, id) in char_shape_changes {
-        if let Some(last) = deduped_cs.last() {
-            if last.char_shape_id == id {
-                continue;
-            }
-        }
-        deduped_cs.push(CharShapeRef {
+    // 같은 char_shape_id라도 run 시작 위치가 다르면 HWP PARA_CHAR_SHAPE 의 의미 있는
+    // 경계다. secPr 템플릿 handoff만 run 시작 시점에 별도로 정규화한다 (#3739).
+    para.char_shapes = char_shape_changes
+        .into_iter()
+        .map(|(pos, id)| CharShapeRef {
             start_pos: pos,
             char_shape_id: id,
-        });
-    }
-    para.char_shapes = deduped_cs;
+        })
+        .collect();
 
     // [Task #1058 후속] column_type/raw_break_type — HWP 정합 (스펙 표 59):
     //   bit 0 (0x01) = 구역 나누기, bit 1 (0x02) = 다단 나누기,
@@ -7799,11 +7805,40 @@ mod tests {
         let para = &section.paragraphs[0];
         assert_eq!(para.text, "AB");
         assert_eq!(para.char_offsets, vec![0, 9]);
-        // [Task #1058] 같은 char_shape_id 연속 dedup — HWP PARA_CHAR_SHAPE 는 첫 entry 1개만 유지.
-        // 두 run 모두 charPrIDRef="0" 이므로 dedup 후 char_shapes.len() = 1.
-        assert_eq!(para.char_shapes[0].start_pos, 0);
-        assert_eq!(para.char_shapes.len(), 1);
+        // 같은 ID여도 표 슬롯 뒤의 별도 run 경계(start_pos=9)는 보존해야 한다 (#3739).
+        assert_eq!(
+            para.char_shapes
+                .iter()
+                .map(|cs| (cs.start_pos, cs.char_shape_id))
+                .collect::<Vec<_>>(),
+            vec![(0, 0), (9, 0)]
+        );
         assert_eq!(para.controls.len(), 1);
+    }
+
+    #[test]
+    fn issue_3739_secpr_template_handoff_same_id_is_normalized() {
+        // 첫 secPr run과 템플릿이 별도로 넣는 첫 텍스트 run은 같은 ID여도
+        // HWP PARA_CHAR_SHAPE에서 하나의 시작 entry여야 한다.
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="5"><hp:secPr textDirection="HORIZONTAL"></hp:secPr></hp:run>
+    <hp:run charPrIDRef="5"><hp:t>A</hp:t></hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let para = &section.paragraphs[0];
+        assert_eq!(para.text, "A");
+        assert_eq!(
+            para.char_shapes
+                .iter()
+                .map(|cs| (cs.start_pos, cs.char_shape_id))
+                .collect::<Vec<_>>(),
+            vec![(0, 5)]
+        );
     }
 
     #[test]

--- a/src/serializer/hwpx/context.rs
+++ b/src/serializer/hwpx/context.rs
@@ -108,6 +108,10 @@ pub struct SerializeContext {
     pub chart_entries: Vec<ChartPartEntry>,
     /// 문서 전역 문단 ID 카운터 — `<hp:p id="...">` 에 발급한다.
     para_id_counter: u32,
+    /// HWP3 전용 Hyperlink control을 HWPX `fieldBegin`으로 승격할 때 쓰는 ID.
+    /// HWP3 원본에는 HWPX field ID가 없으므로, 기존 Field ID와 충돌 가능성이 낮은
+    /// 상위 범위를 문서 내에서 단조 감소시켜 링크마다 다른 값을 발급한다.
+    generated_hyperlink_id: u32,
     /// subList(셀·글상자) 직렬화 중첩 깊이 (#1379 3단계).
     ///
     /// 본문 경로는 colPr 를 섹션 템플릿 첫 run 에서 처리하므로 인라인 미방출이
@@ -141,6 +145,7 @@ impl Default for SerializeContext {
             bin_data_map: HashMap::new(),
             chart_entries: Vec::new(),
             para_id_counter: 0,
+            generated_hyperlink_id: u32::MAX,
             sub_list_depth: 0,
             body_coldef_template_pending: false,
             content_loss: ContentLossReport::new(SerializedFormat::Hwpx),
@@ -149,6 +154,13 @@ impl Default for SerializeContext {
 }
 
 impl SerializeContext {
+    /// HWP3 `Control::Hyperlink`용 HWPX field ID를 하나 발급한다.
+    pub fn next_generated_hyperlink_id(&mut self) -> u32 {
+        let id = self.generated_hyperlink_id;
+        self.generated_hyperlink_id = self.generated_hyperlink_id.saturating_sub(1);
+        id
+    }
+
     /// Document IR 전체를 1-pass 스캔하여 ID 풀을 채운다.
     ///
     /// Stage 0에서는 최소 등록(header.xml 리소스만)만 수행한다. Stage 1~4에서

--- a/src/serializer/hwpx/field.rs
+++ b/src/serializer/hwpx/field.rs
@@ -136,7 +136,6 @@ pub fn write_field_end_full<W: Write>(
 // 하이퍼링크 (필드의 특수형) — <hp:fieldBegin type="HYPERLINK"> 변형
 // =====================================================================
 
-#[allow(dead_code)]
 pub fn write_hyperlink_begin<W: Write>(
     w: &mut Writer<W>,
     link: &Hyperlink,
@@ -160,7 +159,15 @@ pub fn write_hyperlink_begin<W: Write>(
     )?;
     start_tag(w, "hp:parameters")?;
     start_tag_attrs(w, "hp:stringParam", &[("name", "Command")])?;
-    text(w, &link.url)?;
+    // HWP3 Hyperlink control은 추가 정보 블록이 없거나 순서가 어긋난 경우 url을
+    // 비워 둔 채 표시 텍스트만 남긴다. 이때 URL처럼 보이는 표시 텍스트를 버리기보다
+    // HWPX Command의 최소값으로 승격한다.
+    let target = if link.url.is_empty() {
+        &link.text
+    } else {
+        &link.url
+    };
+    text(w, target)?;
     end_tag(w, "hp:stringParam")?;
     end_tag(w, "hp:parameters")?;
     end_tag(w, "hp:fieldBegin")
@@ -299,6 +306,23 @@ mod tests {
         );
         assert!(
             xml.contains(r#"<hp:stringParam name="Command">https://example.com</hp:stringParam>"#),
+            "{xml}"
+        );
+    }
+
+    #[test]
+    fn hyperlink_begin_uses_display_text_when_hwp3_url_is_absent() {
+        // HWP3 추가정보 블록이 없으면 URL 자리에 빈 문자열만 남을 수 있다. 표시 문자열을
+        // Command로 승격해야 HWPX 변환본이 빈 하이퍼링크가 되지 않는다.
+        let link = Hyperlink {
+            url: String::new(),
+            text: "https://example.com/help".to_string(),
+        };
+        let xml = to_string(|w| write_hyperlink_begin(w, &link, 8));
+        assert!(
+            xml.contains(
+                r#"<hp:stringParam name="Command">https://example.com/help</hp:stringParam>"#
+            ),
             "{xml}"
         );
     }

--- a/src/serializer/hwpx/roundtrip.rs
+++ b/src/serializer/hwpx/roundtrip.rs
@@ -528,6 +528,23 @@ pub fn strip_cross_format_noise(diff: IrDiff) -> IrDiff {
     }
 }
 
+/// HWP/HWP3를 HWPX로 저장할 때만 생기는 비교 불능 항목을 걷어낸다.
+///
+/// HWP 계열 필드에는 HWPX `<hp:parameters>` 원문을 실을 슬롯이 없다. 따라서
+/// `Field.command`만 있던 HWP 필드를 HWPX로 내보내면 스키마가 요구하는 최소
+/// `Command` 단일 parameters가 합성된다. 이는 command를 보존한 표현 변환이지 새 필드
+/// 메타데이터가 아니므로, `export-hwpx --verify`에서는 해당 한 방향 차이만 제외한다
+/// (#3739). 원문 parameters나 Command 외 항목의 차이는 계속 검출한다.
+pub fn strip_hwp_to_hwpx_noise(diff: IrDiff) -> IrDiff {
+    IrDiff {
+        differences: diff
+            .differences
+            .into_iter()
+            .filter(|d| !is_hwp_to_hwpx_incomparable(d))
+            .collect(),
+    }
+}
+
 /// HWPX를 HWP5로 저장한 뒤에만 적용하는 추가 비교 불능 항목을 걷어낸다.
 ///
 /// 한컴 2020은 HWPX 그림을 HWP5 `SC_PICTURE`로 저장할 때 extra의 original width/height
@@ -551,6 +568,20 @@ fn is_cross_format_incomparable(d: &IrDifference) -> bool {
         // 원본이 값을 안 가진 imgDim 만 — 다른 크기 필드가 섞여 있으면 남긴다.
         IrDifference::PictureSize { detail, .. } => {
             detail.starts_with("imgDim: expected=(0, 0)") && !detail.contains(';')
+        }
+        _ => false,
+    }
+}
+
+fn is_hwp_to_hwpx_incomparable(d: &IrDifference) -> bool {
+    match d {
+        // generated_field_parameters()가 raw_parameters_xml 없는 HWP 필드에만 만드는
+        // 정확한 최소 표현. cnt·이름·요소 종류·닫는 태그까지 모두 고정해 다른 parameters
+        // 손실이나 추가를 숨기지 않는다.
+        IrDifference::FieldContent { detail, .. } => {
+            const PREFIX: &str = r#"parameters: expected=None actual=Some("<hp:parameters cnt=\"1\" name=\"\"><hp:stringParam name=\"Command\">"#;
+            const SUFFIX: &str = r#"</hp:stringParam></hp:parameters>")"#;
+            detail.starts_with(PREFIX) && detail.ends_with(SUFFIX)
         }
         _ => false,
     }
@@ -2820,6 +2851,45 @@ mod tests {
         assert!(matches!(
             &filtered.differences[0],
             IrDifference::PictureSize { detail, .. } if detail.starts_with("curSz:")
+        ));
+    }
+
+    #[test]
+    fn issue_3739_hwp_to_hwpx_generated_command_parameters_are_incomparable() {
+        let diff = IrDiff {
+            differences: vec![
+                IrDifference::FieldContent {
+                    section: 0,
+                    paragraph: 0,
+                    path: "/ctrl[0]field".to_string(),
+                    detail: r#"parameters: expected=None actual=Some("<hp:parameters cnt=\"1\" name=\"\"><hp:stringParam name=\"Command\">https://example.test</hp:stringParam></hp:parameters>")"#.to_string(),
+                },
+                IrDifference::FieldContent {
+                    section: 0,
+                    paragraph: 1,
+                    path: "/ctrl[1]field".to_string(),
+                    detail: r#"parameters: expected=None actual=Some("<hp:parameters cnt=\"2\" name=\"\"><hp:stringParam name=\"Command\">keep</hp:stringParam><hp:stringParam name=\"Direction\">keep</hp:stringParam></hp:parameters>")"#.to_string(),
+                },
+                IrDifference::CharShapeCount {
+                    expected: 1,
+                    actual: 2,
+                },
+            ],
+        };
+
+        let filtered = strip_hwp_to_hwpx_noise(diff);
+        assert_eq!(
+            filtered.differences.len(),
+            2,
+            "합성 Command 단일 parameters 외 차이는 남겨야 한다"
+        );
+        assert!(matches!(
+            &filtered.differences[0],
+            IrDifference::FieldContent { detail, .. } if detail.contains("cnt=\\\"2\\\"")
+        ));
+        assert!(matches!(
+            &filtered.differences[1],
+            IrDifference::CharShapeCount { .. }
         ));
     }
 

--- a/src/serializer/hwpx/roundtrip.rs
+++ b/src/serializer/hwpx/roundtrip.rs
@@ -545,6 +545,25 @@ pub fn strip_hwp_to_hwpx_noise(diff: IrDiff) -> IrDiff {
     }
 }
 
+/// HWP3를 HWPX로 저장할 때만 생기는 추가 표현 차이를 걷어낸다.
+///
+/// HWP3의 하이퍼텍스트 개체와 그림 crop 사각형은 HWPX와 같은 IR 자리가 없다.
+/// 전자는 HWPX `HYPERLINK` field로, 후자는 HWPX가 요구하는 실제 이미지 사각형으로
+/// 물질화한다. 두 경우 모두 원래 내용이나 배치 크기를 바꾸지는 않지만, HWP3 전용
+/// `Control::Hyperlink`/영(0) 센티널과는 동일 비교할 수 없다. 이 함수는 그 두 방향의
+/// 정확한 형태만 제외하며 HWP5에는 적용하지 않는다.
+pub fn strip_hwp3_to_hwpx_noise(
+    expected_document: &Document,
+    actual_document: &Document,
+    diff: IrDiff,
+) -> IrDiff {
+    let mut diff = strip_hwp_to_hwpx_noise(diff);
+    diff.differences.retain(|difference| {
+        !is_hwp3_to_hwpx_incomparable(expected_document, actual_document, difference)
+    });
+    diff
+}
+
 /// HWPX를 HWP5로 저장한 뒤에만 적용하는 추가 비교 불능 항목을 걷어낸다.
 ///
 /// 한컴 2020은 HWPX 그림을 HWP5 `SC_PICTURE`로 저장할 때 extra의 original width/height
@@ -585,6 +604,116 @@ fn is_hwp_to_hwpx_incomparable(d: &IrDifference) -> bool {
         }
         _ => false,
     }
+}
+
+fn is_hwp3_to_hwpx_incomparable(
+    expected_document: &Document,
+    actual_document: &Document,
+    d: &IrDifference,
+) -> bool {
+    match d {
+        // HWP3 하이퍼텍스트는 별도 Control::Hyperlink 개체지만 HWPX에는 대응 컨트롤이
+        // 없어서 `fieldBegin type="HYPERLINK"`로 승격한다. 비교 축은 Hyperlink를
+        // 비슬롯으로 두므로, HWP3 원본의 빈 슬롯과 재파싱된 HWPX field 하나만 정확히
+        // 이 형태가 된다. 일반 HWP5 Field의 추가·소실에는 적용하지 않는다.
+        IrDifference::ParagraphControls {
+            section,
+            paragraph,
+            path,
+            expected,
+            actual,
+        } => {
+            expected == "[]"
+                && actual == "[field]"
+                && is_hwp3_top_level_hyperlink_field_materialization(
+                    expected_document,
+                    actual_document,
+                    *section,
+                    *paragraph,
+                    path,
+                )
+        }
+        // HWP3 SC_PICTURE의 영 imgRect는 crop 정보가 없다는 센티널이다. HWPX는
+        // `(0,0,width,0)/(width,height,0,height)` 실제 사각형을 반드시 기록한다.
+        // curSz·imgDim·다른 기하가 함께 달라지면 detail에 ';'가 붙으므로 남긴다.
+        IrDifference::PictureSize { detail, .. } => is_hwp3_zero_img_rect_materialization(detail),
+        _ => false,
+    }
+}
+
+fn is_hwp3_top_level_hyperlink_field_materialization(
+    expected_document: &Document,
+    actual_document: &Document,
+    section: usize,
+    paragraph: usize,
+    path: &str,
+) -> bool {
+    // 중첩 문단은 path를 해석해 원본 control까지 확인하는 경로가 아직 없으므로,
+    // 추정으로 정규화하지 않고 보수적으로 diff를 남긴다.
+    if !path.is_empty() {
+        return false;
+    }
+    let Some(expected) = expected_document
+        .sections
+        .get(section)
+        .and_then(|section| section.paragraphs.get(paragraph))
+    else {
+        return false;
+    };
+    let Some(actual) = actual_document
+        .sections
+        .get(section)
+        .and_then(|section| section.paragraphs.get(paragraph))
+    else {
+        return false;
+    };
+
+    expected
+        .controls
+        .iter()
+        .any(|control| matches!(control, crate::model::control::Control::Hyperlink(_)))
+        && actual.controls.iter().any(|control| {
+            matches!(
+                control,
+                crate::model::control::Control::Field(field)
+                    if field.field_type == crate::model::control::FieldType::Hyperlink
+            )
+        })
+}
+
+fn is_hwp3_zero_img_rect_materialization(detail: &str) -> bool {
+    const PREFIX: &str = "imgRect: expected=[0, 0, 0, 0]/[0, 0, 0, 0] actual=";
+    if !detail.starts_with(PREFIX) || detail.contains(';') {
+        return false;
+    }
+
+    let Some((x_part, y_part)) = detail[PREFIX.len()..].split_once('/') else {
+        return false;
+    };
+    let x: Vec<i32> = x_part
+        .strip_prefix('[')
+        .unwrap_or_default()
+        .strip_suffix(']')
+        .unwrap_or_default()
+        .split(", ")
+        .filter_map(|value| value.parse().ok())
+        .collect();
+    let y: Vec<i32> = y_part
+        .strip_prefix('[')
+        .unwrap_or_default()
+        .strip_suffix(']')
+        .unwrap_or_default()
+        .split(", ")
+        .filter_map(|value| value.parse().ok())
+        .collect();
+    matches!(
+        (x.as_slice(), y.as_slice()),
+        ([0, 0, width, 0], [same_width, height, 0, same_height])
+            if *width > 0
+                && *height > 0
+                && width == same_width
+                && height == same_height
+    )
 }
 
 fn is_hwpx_to_hwp_incomparable(d: &IrDifference) -> bool {
@@ -2890,6 +3019,82 @@ mod tests {
         assert!(matches!(
             &filtered.differences[1],
             IrDifference::CharShapeCount { .. }
+        ));
+    }
+
+    #[test]
+    fn issue_3739_hwp3_to_hwpx_materializes_hyperlink_and_empty_img_rect_only() {
+        use crate::model::control::{Control, Field, FieldType, Hyperlink};
+
+        let mut expected_document = Document::default();
+        let mut actual_document = Document::default();
+        let mut expected_section: crate::model::document::Section = Default::default();
+        let mut actual_section: crate::model::document::Section = Default::default();
+        for index in 0..4 {
+            let mut expected = Paragraph::default();
+            let mut actual = Paragraph::default();
+            if index == 0 {
+                expected.controls.push(Control::Hyperlink(Hyperlink {
+                    url: "https://example.test".to_string(),
+                    text: "example".to_string(),
+                }));
+                actual.controls.push(Control::Field(Field {
+                    field_type: FieldType::Hyperlink,
+                    command: "https://example.test".to_string(),
+                    ..Default::default()
+                }));
+            }
+            expected_section.paragraphs.push(expected);
+            actual_section.paragraphs.push(actual);
+        }
+        expected_document.sections.push(expected_section);
+        actual_document.sections.push(actual_section);
+
+        let diff = IrDiff {
+            differences: vec![
+                IrDifference::ParagraphControls {
+                    section: 0,
+                    paragraph: 0,
+                    path: String::new(),
+                    expected: "[]".to_string(),
+                    actual: "[field]".to_string(),
+                },
+                IrDifference::PictureSize {
+                    section: 0,
+                    paragraph: 1,
+                    path: "/ctrl[0]pic".to_string(),
+                    detail: "imgRect: expected=[0, 0, 0, 0]/[0, 0, 0, 0] actual=[0, 0, 2228, 0]/[2228, 2372, 0, 2372]".to_string(),
+                },
+                IrDifference::ParagraphControls {
+                    section: 0,
+                    paragraph: 2,
+                    path: String::new(),
+                    expected: "[pic]".to_string(),
+                    actual: "[field]".to_string(),
+                },
+                IrDifference::PictureSize {
+                    section: 0,
+                    paragraph: 3,
+                    path: "/ctrl[0]pic".to_string(),
+                    detail: "curSz: expected=1x1 actual=2x2; imgRect: expected=[0, 0, 0, 0]/[0, 0, 0, 0] actual=[0, 0, 2, 0]/[2, 2, 0, 2]".to_string(),
+                },
+            ],
+        };
+
+        let filtered = strip_hwp3_to_hwpx_noise(&expected_document, &actual_document, diff);
+        assert_eq!(
+            filtered.differences.len(),
+            2,
+            "실제 control/기하 차이는 남겨야 한다"
+        );
+        assert!(matches!(
+            &filtered.differences[0],
+            IrDifference::ParagraphControls { expected, actual, .. }
+                if expected == "[pic]" && actual == "[field]"
+        ));
+        assert!(matches!(
+            &filtered.differences[1],
+            IrDifference::PictureSize { detail, .. } if detail.starts_with("curSz:")
         ));
     }
 

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -36,7 +36,9 @@ use crate::model::shape::{
 };
 
 use super::context::SerializeContext;
-use super::field::{write_bookmark, write_field_begin, write_field_end, write_field_end_full};
+use super::field::{
+    write_bookmark, write_field_begin, write_field_end, write_field_end_full, write_hyperlink_begin,
+};
 use super::utils::xml_escape;
 use super::SerializeError;
 use super::{picture, table};
@@ -978,10 +980,10 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
                 } else {
                     // [#4677] 위치 축은 책갈피까지 포함한다(`occupies_hwpx_slot_axis`).
                     let slot = occupies_hwpx_slot_axis(c);
-                    // [#4388] Hyperlink/Unknown 은 슬롯이 아니라 여기서 조용히
-                    // 제외된다 — is_hwpx_inline_slot 에 등록하지 않기로 한 대가로,
-                    // 이 실제 배제 지점에서 직접 경고한다. HiddenComment 등 다른
-                    // non-slot 컨트롤은 이 헬퍼가 내부적으로 무시한다.
+                    // [#4388] Unknown 은 슬롯이 아니므로 이 실제 배제 지점에서 직접
+                    // 경고한다. HWP3 Hyperlink은 occupies_hwpx_slot_axis가 HWPX field로
+                    // 승격해 보존한다. HiddenComment 등 다른 non-slot 컨트롤은 이 헬퍼가
+                    // 내부적으로 무시한다.
                     if !slot {
                         warn_if_unrepresentable_in_hwpx(c);
                     }
@@ -1178,6 +1180,27 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
             }
         }
 
+        // HWP3 원본은 개체가 있는 위치를 U+FFFC 하나로 `text`에도 남기면서,
+        // char_offsets에서는 그 한 글자를 HWP5와 같은 8 UTF-16 단위 슬롯으로 센다.
+        // HWPX에서는 개체 태그 자체가 그 슬롯이므로 U+FFFC를 <hp:t>로 다시 쓰면
+        // 문자 1단위가 중복되고, 다음 문자까지는 슬롯이 감지되지 않아 제어가 문단
+        // 끝으로 밀린다. 현재 위치가 슬롯의 시작이고 소비할 control이 있을 때만
+        // 표시 문자를 그 control의 HWPX 표현으로 직접 바꾼다. 실제 리터럴 U+FFFC나
+        // 위치가 불명확한 합성 IR은 기존 텍스트 경로를 유지한다.
+        if c == '\u{fffc}' && slot_idx < slots.len() && char_pos == expected_utf16_pos {
+            flush_text_fragment(
+                &mut splitter.content,
+                &mut text_buf,
+                &para.tab_extended,
+                &mut tab_idx,
+            );
+            splitter.cut_before(expected_utf16_pos);
+            render_control_slot(&mut splitter.content, slots[slot_idx], ctx);
+            slot_idx += 1;
+            expected_utf16_pos = expected_utf16_pos.saturating_add(8);
+            continue;
+        }
+
         // 0-length 필드(start == end == idx): fieldBegin 방출 직후, 문자 push 전에 fieldEnd 방출.
         // post-char 검사(next_idx 기준)는 end-1 번째 문자 처리 후 방출하므로 0-length 필드에서
         // fieldEnd가 fieldBegin 앞에 나오거나 텍스트 뒤로 밀리는 문제가 생긴다.
@@ -1356,10 +1379,22 @@ fn inferred_control_slot_count(para: &Paragraph) -> usize {
         .count() as u32;
 
     let text_units: u32 = para.text.chars().map(char_utf16_width).sum();
+    // 암호 HWP3 parser는 개체 자리에 U+FFFC 하나를 남기되, 실제 offset은 HWP5와
+    // 같은 8단위로 전진시킨다. 이 표식은 HWPX에서 개체 슬롯으로 치환되므로, 1단위
+    // 텍스트로만 세면 `(char_count - text_units) / 8`가 0으로 내림되어 mismatch
+    // fallback(텍스트 뒤에 control 몰아쓰기)으로 빠진다. control이 없는 리터럴 U+FFFC는
+    // 제외하기 위해 가능한 control 수까지만 슬롯 증거로 반영한다.
+    let hwp3_object_marker_slots = para
+        .text
+        .chars()
+        .filter(|c| *c == '\u{fffc}')
+        .count()
+        .min(para.controls.len()) as u32;
     let from_char_count = para
         .char_count
         .saturating_sub(1)
-        .saturating_sub(text_units)
+        // U+FFFC 자체 1단위를 빼면 실제 8단위 control 슬롯만 남는다.
+        .saturating_sub(text_units.saturating_sub(hwp3_object_marker_slots))
         .saturating_add(autonum_count)
         / 8;
 
@@ -1372,7 +1407,12 @@ fn inferred_control_slot_count(para: &Paragraph) -> usize {
         }
         expected = pos.max(expected).saturating_add(char_utf16_width(c));
     }
-    let from_offsets = offsets_gap.saturating_add(autonum_count) / 8;
+    // marker 다음 offset gap은 8이 아니라 7(표식 텍스트 1단위를 이미 센 뒤)이므로,
+    // 나누기 전에 marker 수를 더해 실제 8단위 슬롯 수로 복원한다.
+    let from_offsets = offsets_gap
+        .saturating_add(autonum_count)
+        .saturating_add(hwp3_object_marker_slots)
+        / 8;
 
     // fieldEnd는 8 code unit 슬롯이지만 para.controls[]에 대응 컨트롤이 없다.
     // field_ranges.len()이 fieldEnd 수와 정확히 일치하므로 빼서 보정한다.
@@ -1413,7 +1453,10 @@ fn inferred_control_slot_count(para: &Paragraph) -> usize {
 /// 의 **비교 축**과 공유되기 때문이다 — 비교 축 변경은 #4388 처럼 무관한 회귀를 만든다.
 /// 여기서 필요한 것은 위치 축 하나뿐이다.
 fn occupies_hwpx_slot_axis(control: &Control) -> bool {
-    is_hwpx_inline_slot(control) || matches!(control, Control::Bookmark(_))
+    // Hyperlink은 HWP3의 8-unit object slot이고 HWPX에서는 fieldBegin으로 승격한다.
+    // `is_hwpx_inline_slot`에는 넣지 않는다. 해당 헬퍼는 포맷 비종속 diff에도 공유되어
+    // HWP5의 기존 Hyperlink 표현 범위까지 바꾸기 때문이다.
+    is_hwpx_inline_slot(control) || matches!(control, Control::Bookmark(_) | Control::Hyperlink(_))
 }
 
 pub(crate) fn is_hwpx_inline_slot(control: &Control) -> bool {
@@ -1462,6 +1505,17 @@ fn render_control_slot(out: &mut String, control: &Control, ctx: &mut SerializeC
             }
             Err(e) => eprintln!("[hwpx] Bookmark 직렬화 실패: {e}"),
         },
+        Control::Hyperlink(link) => {
+            let field_id = ctx.next_generated_hyperlink_id();
+            match writer_to_string(|w| write_hyperlink_begin(w, link, field_id)) {
+                Ok(xml) => {
+                    out.push_str("<hp:ctrl>");
+                    out.push_str(&xml);
+                    out.push_str("</hp:ctrl>");
+                }
+                Err(e) => eprintln!("[hwpx] Hyperlink 직렬화 실패: {e}"),
+            }
+        }
         Control::Equation(eq) => {
             out.push_str(&render_equation(eq));
         }
@@ -1554,14 +1608,14 @@ fn render_control_slot(out: &mut String, control: &Control, ctx: &mut SerializeC
                 out.push_str(&render_col_pr_ctrl(cd));
             }
         }
-        // [#4388] Hyperlink/Unknown 은 HWPX 로 옮길 대응 표현이 없어 여기서도
-        // 드롭된다("exact" 슬롯 분기 — 모든 컨트롤이 위치 슬롯인 문단). 경고는
-        // `warn_if_unrepresentable_in_hwpx` 하나로 통일한다(mismatch-분기 제외
-        // 지점, 위쪽 934행 부근과 동일 호출). 이 함수 아래 catch-all 이 처리한다.
+        // [#4388] Unknown은 HWPX 로 옮길 대응 표현이 없어 여기서도 드롭된다.
+        // Hyperlink은 위 arm에서 HWPX fieldBegin으로 승격한다. Unknown 경고는
+        // `warn_if_unrepresentable_in_hwpx` 하나로 통일한다(mismatch-분기 제외 지점,
+        // 위쪽 934행 부근과 동일 호출). 이 함수 아래 catch-all 이 처리한다.
         //
         // [#4388 census] catch-all `_`(warn 호출 포함)에 실제로 도달하는 나머지
         // `Control` 변형은 세 가지 — 새 변형을 추가할 때 이 목록을 갱신할 것:
-        //   - `Hyperlink`/`Unknown`: 위 참조. 조용히 버리지 않도록 경고.
+        //   - `Unknown`: 위 참조. 조용히 버리지 않도록 경고.
         //   - `SectionDef`: 의도적 무해 no-op. 위치 슬롯 축(hidden 슬롯 정합, 이 함수
         //     966행 근처 주석)만 소비하고 XML 은 별도 경로(`<hp:secPr>` 섹션 템플릿)가
         //     방출한다 — 여기서 다시 방출하면 중복이 된다. warn 헬퍼도 이 변형은

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -715,12 +715,12 @@ pub(crate) fn render_hp_t_content(
 /// 문단 콘텐츠를 `char_shapes` 경계 기준 다중 `<hp:run>` 으로 분할 출력하는 빌더 (#1378).
 ///
 /// 파서(`src/parser/hwpx/section.rs`)는 각 `<hp:run charPrIDRef>` 시작 위치에서
-/// `(utf16_pos, char_shape_id)` 를 기록하고 연속 동일 id 를 dedup 한다.
+/// `(utf16_pos, char_shape_id)` 를 기록한다. 동일 id라도 위치가 다른 경계는 보존한다.
 /// 이 빌더는 그 역방향: `segs[i].0` (i ≥ 1) 위치에서 run 을 닫고 새 run 을 연다.
 ///
 /// 경계 규칙 (구현계획서 1.2):
 /// 1. 경계와 슬롯/문자가 같은 위치면 경계 먼저 — 해당 콘텐츠는 새 run 소속 (`cut_before`)
-/// 2. 연속 동일 id 경계는 출력 시 skip (IR 은 이미 dedup 상태이나 방어적으로 유지)
+/// 2. 연속 동일 id 경계도 run으로 방출 — start_pos 보존 (#3739)
 /// 3. `char_shapes` 가 비어있으면 단일 run `charPrIDRef="0"`
 /// 4. `segs[0].start_pos > 0` 인 비정상 IR 도 첫 run 은 위치 0 부터 시작 (관용 처리)
 /// 5. 빈 세그먼트는 `<hp:t></hp:t>` 로 방출 — 재파싱 시 run 시작 entry 위치 보존
@@ -739,11 +739,6 @@ impl RunSplitter {
     fn new(para: &Paragraph) -> Self {
         let mut segs: Vec<(u32, u32)> = Vec::new();
         for cs in &para.char_shapes {
-            if let Some(&(_, last_id)) = segs.last() {
-                if last_id == cs.char_shape_id {
-                    continue; // 규칙 2
-                }
-            }
             segs.push((cs.start_pos, cs.char_shape_id));
         }
         if segs.is_empty() {
@@ -4919,16 +4914,16 @@ mod tests {
     }
 
     #[test]
-    fn task1378_consecutive_same_id_boundary_skipped() {
-        // 연속 동일 id 경계 skip — 파서 dedup 왕복 정합 (경계 케이스 3)
+    fn issue_3739_consecutive_same_id_boundary_preserved() {
+        // 같은 ID여도 start_pos는 HWP PARA_CHAR_SHAPE 의 보존 대상이다.
         let mut para = Paragraph::default();
         para.text = "abcdef".to_string();
         para.char_shapes = vec![cs(0, 5), cs(2, 5), cs(4, 6)];
         let xml = runs_of(&para);
         assert_eq!(
             xml,
-            r#"<hp:run charPrIDRef="5"><hp:t>abcd</hp:t></hp:run><hp:run charPrIDRef="6"><hp:t>ef</hp:t></hp:run>"#,
-            "동일 id 경계 (2,5) 는 skip 되고 (4,6) 만 분할해야 한다"
+            r#"<hp:run charPrIDRef="5"><hp:t>ab</hp:t></hp:run><hp:run charPrIDRef="5"><hp:t>cd</hp:t></hp:run><hp:run charPrIDRef="6"><hp:t>ef</hp:t></hp:run>"#,
+            "동일 id 경계 (2,5)도 별도 run으로 출력해야 한다"
         );
     }
 

--- a/tests/issue_3739_hwpx_same_char_shape_boundary.rs
+++ b/tests/issue_3739_hwpx_same_char_shape_boundary.rs
@@ -2,13 +2,15 @@
 
 #![cfg(not(target_arch = "wasm32"))]
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 
-const SAMPLE: &str = "samples/lseg-04-indent.hwp";
+static OUTPUT_DIR_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
-fn sample_path() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+fn sample_path(sample: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(sample)
 }
 
 fn rhwp_bin() -> String {
@@ -16,8 +18,9 @@ fn rhwp_bin() -> String {
 }
 
 fn unique_output_dir() -> PathBuf {
+    let sequence = OUTPUT_DIR_SEQUENCE.fetch_add(1, Ordering::Relaxed);
     std::env::temp_dir().join(format!(
-        "rhwp-issue3739-{}-{}",
+        "rhwp-issue3739-{}-{}-{sequence}",
         std::process::id(),
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -35,9 +38,8 @@ fn describe(args: &[String], output: &Output) -> String {
     )
 }
 
-#[test]
-fn export_hwpx_verify_preserves_same_char_shape_id_boundary() {
-    let source = sample_path();
+fn assert_export_hwpx_verify_success(sample: &str) {
+    let source = sample_path(sample);
     assert!(
         source.exists(),
         "회귀 입력 샘플이 없습니다: {}",
@@ -46,7 +48,7 @@ fn export_hwpx_verify_preserves_same_char_shape_id_boundary() {
 
     let output_dir = unique_output_dir();
     std::fs::create_dir(&output_dir).expect("임시 출력 디렉터리 생성");
-    let output = output_dir.join("lseg-04-indent.hwpx");
+    let output = output_dir.join("output.hwpx");
     let args = vec![
         "export-hwpx".to_string(),
         source.display().to_string(),
@@ -73,4 +75,75 @@ fn export_hwpx_verify_preserves_same_char_shape_id_boundary() {
     );
 
     std::fs::remove_dir_all(&output_dir).expect("임시 출력 디렉터리 정리");
+}
+
+fn assert_password_protected_export_hwpx_success(sample: &str) {
+    let source = sample_path(sample);
+    assert!(
+        source.exists(),
+        "회귀 입력 샘플이 없습니다: {}",
+        source.display()
+    );
+
+    let output_dir = unique_output_dir();
+    std::fs::create_dir(&output_dir).expect("임시 출력 디렉터리 생성");
+    let output = output_dir.join("output.hwpx");
+    let args = vec![
+        "export-hwpx".to_string(),
+        source.display().to_string(),
+        output.display().to_string(),
+        "--verify-pages".to_string(),
+        "--password-stdin".to_string(),
+    ];
+
+    // Windows PowerShell/.NET의 pipe는 UTF-8 BOM을 앞에 붙일 수 있다. raw stdin
+    // 경로도 그 실제 바이트열을 비밀번호로 오해하지 않아야 한다.
+    let mut child = Command::new(rhwp_bin())
+        .args(&args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("rhwp export-hwpx 실행");
+    let mut stdin = child.stdin.take().expect("stdin pipe");
+    stdin
+        .write_all(b"\xEF\xBB\xBF123456\n")
+        .expect("비밀번호 stdin 쓰기");
+    drop(stdin);
+    let result = child.wait_with_output().expect("rhwp 종료 대기");
+
+    assert_eq!(
+        result.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &result)
+    );
+    assert!(
+        output.is_file(),
+        "HWPX 산출물이 없습니다: {}",
+        output.display()
+    );
+
+    std::fs::remove_dir_all(&output_dir).expect("임시 출력 디렉터리 정리");
+}
+
+#[test]
+fn export_hwpx_verify_preserves_same_char_shape_id_boundary() {
+    assert_export_hwpx_verify_success("samples/lseg-04-indent.hwp");
+}
+
+#[test]
+fn issue_3739_export_hwpx_verify_accepts_generated_field_command_parameters() {
+    assert_export_hwpx_verify_success("samples/tac-img-02.hwp");
+}
+
+#[test]
+fn issue_3739_export_hwpx_accepts_password_stdin_for_hwp3_hwp5_and_hwpx() {
+    for sample in [
+        "samples/HWP3-password-123456.hwp",
+        "samples/HWP5-password-123456.hwpx",
+        "samples/hwp3-sample16-hwp5-2024-password-123456.hwp",
+    ] {
+        assert_password_protected_export_hwpx_success(sample);
+    }
 }

--- a/tests/issue_3739_hwpx_same_char_shape_boundary.rs
+++ b/tests/issue_3739_hwpx_same_char_shape_boundary.rs
@@ -1,0 +1,76 @@
+//! [#3739] HWP → HWPX export가 동일 글자모양 ID의 run 경계도 보존하는지 검증한다.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const SAMPLE: &str = "samples/lseg-04-indent.hwp";
+
+fn sample_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}
+
+fn unique_output_dir() -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "rhwp-issue3739-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos()
+    ))
+}
+
+fn describe(args: &[String], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn export_hwpx_verify_preserves_same_char_shape_id_boundary() {
+    let source = sample_path();
+    assert!(
+        source.exists(),
+        "회귀 입력 샘플이 없습니다: {}",
+        source.display()
+    );
+
+    let output_dir = unique_output_dir();
+    std::fs::create_dir(&output_dir).expect("임시 출력 디렉터리 생성");
+    let output = output_dir.join("lseg-04-indent.hwpx");
+    let args = vec![
+        "export-hwpx".to_string(),
+        source.display().to_string(),
+        output.display().to_string(),
+        "--verify".to_string(),
+        "--verify-pages".to_string(),
+    ];
+
+    let result = Command::new(rhwp_bin())
+        .args(&args)
+        .output()
+        .expect("rhwp export-hwpx 실행");
+
+    assert_eq!(
+        result.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &result)
+    );
+    assert!(
+        output.is_file(),
+        "HWPX 산출물이 없습니다: {}",
+        output.display()
+    );
+
+    std::fs::remove_dir_all(&output_dir).expect("임시 출력 디렉터리 정리");
+}

--- a/tests/issue_3739_hwpx_same_char_shape_boundary.rs
+++ b/tests/issue_3739_hwpx_same_char_shape_boundary.rs
@@ -77,7 +77,7 @@ fn assert_export_hwpx_verify_success(sample: &str) {
     std::fs::remove_dir_all(&output_dir).expect("임시 출력 디렉터리 정리");
 }
 
-fn assert_password_protected_export_hwpx_success(sample: &str) {
+fn assert_password_protected_export_hwpx_success(sample: &str, verify_ir: bool) {
     let source = sample_path(sample);
     assert!(
         source.exists(),
@@ -88,13 +88,16 @@ fn assert_password_protected_export_hwpx_success(sample: &str) {
     let output_dir = unique_output_dir();
     std::fs::create_dir(&output_dir).expect("임시 출력 디렉터리 생성");
     let output = output_dir.join("output.hwpx");
-    let args = vec![
+    let mut args = vec![
         "export-hwpx".to_string(),
         source.display().to_string(),
         output.display().to_string(),
         "--verify-pages".to_string(),
-        "--password-stdin".to_string(),
     ];
+    if verify_ir {
+        args.push("--verify".to_string());
+    }
+    args.push("--password-stdin".to_string());
 
     // Windows PowerShell/.NET의 pipe는 UTF-8 BOM을 앞에 붙일 수 있다. raw stdin
     // 경로도 그 실제 바이트열을 비밀번호로 오해하지 않아야 한다.
@@ -140,10 +143,16 @@ fn issue_3739_export_hwpx_verify_accepts_generated_field_command_parameters() {
 #[test]
 fn issue_3739_export_hwpx_accepts_password_stdin_for_hwp3_hwp5_and_hwpx() {
     for sample in [
-        "samples/HWP3-password-123456.hwp",
         "samples/HWP5-password-123456.hwpx",
         "samples/hwp3-sample16-hwp5-2024-password-123456.hwp",
     ] {
-        assert_password_protected_export_hwpx_success(sample);
+        assert_password_protected_export_hwpx_success(sample, false);
     }
+}
+
+#[test]
+fn issue_3739_hwp3_password_export_hwpx_preserves_ir_and_pages() {
+    // HWP3 object marker(U+FFFC)·하이퍼텍스트·빈 imgRect가 HWPX 표현으로 옮겨진 뒤에도
+    // 암호 stdin(BOM 포함) 경로에서 --verify와 --verify-pages가 모두 통과해야 한다.
+    assert_password_protected_export_hwpx_success("samples/HWP3-password-123456.hwp", true);
 }


### PR DESCRIPTION
## 변경 요약

- HWP3의 U+FFFC 개체 슬롯을 HWPX control 슬롯으로 치환해 run 경계와 char_shapes 위치를 보존합니다.
- HWP3 하이퍼텍스트를 HWPX HYPERLINK field로 보존하고 URL이 없을 때 표시 문자열을 Command로 유지합니다.
- HWP3 전용 그림 imgRect 센티널과 하이퍼링크의 표현 차이만 원본·재파싱 컨트롤을 확인한 뒤 정규화합니다.

## 관련 이슈

closes #3739

## 테스트

- [x] `cargo build --profile release-test --target-dir target/pr-review --bin rhwp`
- [x] `cargo test --profile release-test --target-dir target/pr-review --lib issue_3739 -- --nocapture` (4 passed)
- [x] `cargo test --profile release-test --target-dir target/pr-review --test issue_3739_hwpx_same_char_shape_boundary -- --nocapture` (4 passed)
- [x] 실제 암호 HWP3 `export-hwpx --verify --verify-pages` — IR 무차이, 24쪽
- [x] 변경 Rust 파일 `rustfmt --check`, `git diff --check`
- [ ] 전체 `cargo nextest run --tests` 및 clippy — 별도 전체 PR CI 승인 범위로 미실행, GitHub Actions에서 확인 예정
- [ ] 웹(WASM)·rhwp-studio UI 변경 없음

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음
- 재현·측정: 성능 경로 변경 없음

## 스크린샷

- parser·serializer 구조 보존 변경이며, HWP/HWPX fixture의 페이지 수와 IR 검증으로 확인했습니다. 렌더러·WASM 출력 변경 및 신규 기준 PDF는 없습니다.