### PR TITLE
feat(gym): extraction pack — 측정이 짚은 빈 곳(chart-to-csv·export-text) 채우기

### DIFF
--- a/gym/packs/extraction/pack.json
+++ b/gym/packs/extraction/pack.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "1.0",
+  "kind": "gymPack",
+  "id": "extraction",
+  "title": "데이터 추출 (읽기)",
+  "axis": "조회 (문서에서 데이터를 뽑아내는 능력)",
+  "description": "에이전트가 문서에서 데이터를 뽑는 읽기 능력을 검증한다 — 차트 데이터 추출(chart-to-csv), 본문 텍스트 추출(export-text). 라이브 오라클로 봉투 값을 대조한다.",
+  "requires": {
+    "commands": [
+      "chart-to-csv",
+      "export-text"
+    ]
+  },
+  "runner": {
+    "rhwpVersion": "0.8.4",
+    "rhwpCommit": "4324eb0e4cf1a65f7efb305993a79ac44859a7ca",
+    "capabilitiesSha256": "4767e61c3af751bb2f97af9d0b3e5ffa5cbb5dc70a89cf3ae85987132fa5473d"
+  }
+}

--- a/gym/packs/extraction/reference/EX01.json
+++ b/gym/packs/extraction/reference/EX01.json
@@ -1,0 +1,19 @@
+{
+  "id": "EX01",
+  "steps": [
+    {
+      "answer": {
+        "rows": {
+          "cmd": [
+            "chart-to-csv",
+            "{input}",
+            "--chart",
+            "1",
+            "--json"
+          ],
+          "path": "charts[0].rowCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/extraction/reference/EX02.json
+++ b/gym/packs/extraction/reference/EX02.json
@@ -1,0 +1,17 @@
+{
+  "id": "EX02",
+  "steps": [
+    {
+      "answer": {
+        "pages": {
+          "cmd": [
+            "export-text",
+            "{input}",
+            "--json"
+          ],
+          "path": "pageCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/extraction/tasks/EX01.json
+++ b/gym/packs/extraction/tasks/EX01.json
@@ -1,0 +1,25 @@
+{
+  "id": "EX01",
+  "tier": 2,
+  "title": "차트 데이터 추출 — 행 수",
+  "input": "samples/chart/세로막대형/묶은세로막대형.hwp",
+  "instructions": "chart-to-csv 로 이 문서의 차트 1을 뽑아, 그 데이터의 행 수(카테고리 개수, rowCount)를 보고하라. 답 형식: {\"rows\": <수>}.",
+  "submit": {
+    "kind": "answer"
+  },
+  "checks": [
+    {
+      "name": "행 수 일치",
+      "op": "answer_eq",
+      "answer": "rows",
+      "cmd": [
+        "chart-to-csv",
+        "{input}",
+        "--chart",
+        "1",
+        "--json"
+      ],
+      "path": "charts[0].rowCount"
+    }
+  ]
+}

--- a/gym/packs/extraction/tasks/EX02.json
+++ b/gym/packs/extraction/tasks/EX02.json
@@ -1,0 +1,23 @@
+{
+  "id": "EX02",
+  "tier": 2,
+  "title": "본문 텍스트 추출 — 페이지 수",
+  "input": "samples/20250130-hongbo.hwp",
+  "instructions": "export-text 로 이 문서의 본문을 뽑아, 추출된 텍스트가 몇 페이지에 걸치는지(pageCount) 보고하라. 답 형식: {\"pages\": <수>}.",
+  "submit": {
+    "kind": "answer"
+  },
+  "checks": [
+    {
+      "name": "페이지 수 일치",
+      "op": "answer_eq",
+      "answer": "pages",
+      "cmd": [
+        "export-text",
+        "{input}",
+        "--json"
+      ],
+      "path": "pageCount"
+    }
+  ]
+}

--- a/gym/profiles/maintainer.json
+++ b/gym/profiles/maintainer.json
@@ -10,6 +10,7 @@
     "core-cli",
     "corpus-diagnostics",
     "expert-challenges",
+    "extraction",
     "layout-rendering",
     "objects-media",
     "security",


### PR DESCRIPTION
## 무엇을 / 왜

커버리지 측정기(#4785)가 에이전트-대면 82% 중 **미노출 빈 곳**으로 `chart-to-csv`·
`export-text` 를 짚었다. 둘 다 에이전트의 흔한 읽기 작업(차트 데이터·본문 추출)인데
gym 과제가 없었다. **측정이 정한 방향**을 데이터 기반으로 채운다.

closes #4786 · 측정 도구 #4785 의 출력이 이 pack 을 낳음

## 과제 (라이브 오라클)

- **EX01** `chart-to-csv` — 차트 1을 뽑아 행 수(rowCount)를 보고. answer_eq 로
  `charts[0].rowCount`(=4) 대조.
- **EX02** `export-text` — 본문을 뽑아 페이지 수(pageCount)를 보고. answer_eq 로
  `pageCount`(=4) 대조.

## 검증 (라이브 실측)

```
$ python gym/tools/build_baseline.py --agent baseline --pack extraction --bin target/debug/rhwp
기준 풀이 왕복: 성공 2 · 실패 0
$ python gym/score.py --agent baseline --pack extraction --bin target/debug/rhwp
extraction  4/4  (2/2 과제)
```
- gym CI 가드 `test_gym_score.py` **17 passed**(무회귀)
- 커버리지 재측정: `chart-to-csv`·`export-text` **노출 확인**(빈 곳 닫힘)
- `runner` = HEAD(`4324eb0e4c`) 바이너리 신원

## 성격

측정→실행 루프의 첫 결실 — #4785 가 잰 빈 곳을, 추측이 아니라 데이터로 채운다.
중복(#4781) 없이 커버리지가 82%에서 데이터 기반으로 오른다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
