### PR TITLE
feat(gym): render-tree pack — 측정이 짚은 export-render-tree 채우기

### DIFF
--- a/gym/packs/render-tree/pack.json
+++ b/gym/packs/render-tree/pack.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "1.0",
+  "kind": "gymPack",
+  "id": "render-tree",
+  "title": "렌더 트리 구조 추출",
+  "axis": "조회 (렌더 트리 구조 추출)",
+  "description": "export-render-tree 로 페이지별 렌더 트리(bbox 계층)를 파일로 추출하는 능력을 실측한다. 렌더 트리 JSON 은 stdout 이 아니라 파일로만 나오므로(=--json 없음), 이 pack 은 export-render-tree 를 기준풀이 run 단계에서 실행해 그 산출 파일 존재로 명령을 강제하고, 총 쪽수 조회로 판정한다. 산출 파일은 export-render-tree 로만 만들 수 있어 다른 명령으로 우회할 수 없다.",
+  "requires": {
+    "commands": [
+      "export-render-tree",
+      "info"
+    ]
+  },
+  "runner": {
+    "rhwpVersion": "0.8.4",
+    "rhwpCommit": "4324eb0e4cf1a65f7efb305993a79ac44859a7ca",
+    "capabilitiesSha256": "4767e61c3af751bb2f97af9d0b3e5ffa5cbb5dc70a89cf3ae85987132fa5473d"
+  }
+}

--- a/gym/packs/render-tree/reference/RT01.json
+++ b/gym/packs/render-tree/reference/RT01.json
@@ -1,0 +1,27 @@
+{
+  "id": "RT01",
+  "steps": [
+    {
+      "run": [
+        "export-render-tree",
+        "{input}",
+        "-p",
+        "0",
+        "-o",
+        "{sub:_rt}"
+      ]
+    },
+    {
+      "answer": {
+        "pages": {
+          "cmd": [
+            "info",
+            "{input}",
+            "--json"
+          ],
+          "path": "pageCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/render-tree/tasks/RT01.json
+++ b/gym/packs/render-tree/tasks/RT01.json
@@ -1,0 +1,32 @@
+{
+  "id": "RT01",
+  "tier": 2,
+  "title": "1쪽 렌더 트리 추출과 쪽수 조회",
+  "input": "samples/2010-01-06.hwp",
+  "instructions": "입력 문서의 1쪽(0-기준 페이지 0) 렌더 트리를 export-render-tree 로 추출해 제출 폴더의 _rt/render_tree_001.json 로 제출하라. 또한 문서의 총 쪽수를 {\"pages\": <수>} 로 제출하라. 힌트: rhwp export-render-tree <문서> -p 0 -o _rt (→ _rt/render_tree_001.json 생성), rhwp info <문서> --json.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "_rt/render_tree_001.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "렌더 트리 산출 존재",
+      "op": "file_exists",
+      "file": "_rt/render_tree_001.json",
+      "minBytes": 10000
+    },
+    {
+      "name": "쪽수 일치",
+      "op": "answer_eq",
+      "answer": "pages",
+      "cmd": [
+        "info",
+        "{input}",
+        "--json"
+      ],
+      "path": "pageCount"
+    }
+  ]
+}


### PR DESCRIPTION
## 무엇을 / 왜

커버리지 측정기(#4785)가 미노출로 `export-render-tree`(렌더 트리 구조 추출)를 짚었다.
페이지별 렌더 트리(bbox 계층) 추출은 레이아웃을 이해하는 에이전트 능력인데 gym 과제가
없었다. **측정이 정한 방향**을 채운다.

closes #4794 · 측정 도구 #4785 데이터 기반

## 설계 판단 (전부 실측)

`export-render-tree` 는 트리 JSON 을 **stdout 이 아니라 파일**(`render_tree_NNN.json`)로만
낸다 — `--json` 옵션이 없어 `<f> --json` 은 exit 2. gym 러너는 stdout 을 파싱하므로 트리
내용을 dig 로 직접 검증할 수 없다. 그래서 **산출물+answer 하이브리드**:

- 기준풀이가 `export-render-tree {input} -p 0 -o _rt` 로 `render_tree_001.json` 생성 —
  이 파일은 그 명령으로만 만들 수 있어 **명령을 강제**하고 커버리지 gap 을 닫는다.
- 채점: `file_exists`(minBytes 10000, 실측 30039B) + 총 쪽수 `answer_eq`(`info` pageCount).

## 검증 (라이브 실측)

```
$ python gym/tools/build_baseline.py --agent baseline --pack render-tree --bin target/debug/rhwp
기준 풀이 왕복: 성공 1 · 실패 0
$ python gym/score.py --agent baseline --pack render-tree --bin target/debug/rhwp
render-tree  2/2  (1/1 과제)
```
- gym CI 가드 **17 passed**(무회귀) · `runner` = HEAD(`4324eb0e4c`) 신원 · 산출 byte-결정적

## 후속 (범위 밖, 정직히)

트리 **내용** 심층 검증(예: `bbox.h==1122.5`·노드 수)은 제출된 render-tree JSON 파일을
dig 하는 새 check 연산자(`file_json_eq` 류)가 필요하다 — gym-core 코드 변경이라 이 설계
범위 밖이지만, 그게 생기면 RT02+ 로 실제 레이아웃 구조를 강하게 검증할 수 있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
