### PR TITLE
feat(renderer): SVG 출력에 배치 메트릭 face 주석 옵트인 — data-metric-font (#4709)

### DIFF
--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -120,6 +120,10 @@ HWP/HWPX → SVG.
 - `-o`, `-p` (공통)
 - `--show-para-marks` — 문단부호(↵/↓)
 - `--show-control-codes` — 조판부호(문단부호 + 개체 마커)
+- `--annotate-metric-font` — 배치 폭 계산에 쓴 내장 메트릭 face 를 각 `<text>`의
+  `data-metric-font` 와 루트 `<svg>`의 `data-rhwp-metric-fonts`(쉼표 목록)로 주석 (#4709).
+  임베드 호스트의 폰트 설치 확인·대체 폰트 자간 보정용. 레이아웃 불변, 기본 꺼짐.
+  WASM 은 `setAnnotateMetricFont(true)` 후 `renderPageSvg`.
 - `--debug-overlay` — 디버그 오버레이(문단/표 경계 + 인덱스 라벨)
 - `--respect-vpos-reset` — LINE_SEG vpos=0 리셋을 단/페이지 강제 경계로 처리
 - `--show-grid[=Nmm]` — 격자 오버레이(기본 1mm, 예 `--show-grid=3mm`)

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -170,6 +170,7 @@ impl DocumentCore {
             table_transpose_clipboard: None,
             paste_cascade_count: 0,
             show_paragraph_marks: false,
+            annotate_metric_font: false,
             show_control_codes: false,
             show_transparent_borders: false,
             clip_enabled: true,

--- a/src/document_core/mod.rs
+++ b/src/document_core/mod.rs
@@ -147,6 +147,8 @@ pub struct DocumentCore {
     pub(crate) paste_cascade_count: u32,
     /// 문단부호(¶) 표시 여부
     pub(crate) show_paragraph_marks: bool,
+    /// [#4709] SVG 출력에 배치 메트릭 face 주석(data-metric-font) 부착 여부 (옵트인)
+    pub(crate) annotate_metric_font: bool,
     /// 조판부호 표시 여부 (개체 마커 [표]/[그림] 등, 문단부호 포함)
     pub(crate) show_control_codes: bool,
     /// 투명선 표시 여부
@@ -340,6 +342,7 @@ impl DocumentCore {
             table_transpose_clipboard: None,
             paste_cascade_count: 0,
             show_paragraph_marks: false,
+            annotate_metric_font: false,
             show_control_codes: false,
             show_transparent_borders: false,
             clip_enabled: true,

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -1022,6 +1022,7 @@ impl DocumentCore {
         renderer.show_paragraph_marks = self.show_paragraph_marks;
         renderer.show_control_codes = self.show_control_codes;
         renderer.debug_overlay = self.debug_overlay;
+        renderer.annotate_metric_font = self.annotate_metric_font;
         renderer.render_tree(&tree);
         Ok(renderer.output().to_string())
     }
@@ -1040,6 +1041,7 @@ impl DocumentCore {
         // WASM에서도 문서 내장 face 사용량을 수집한다. 실제 CSS 생성은 아래의
         // embedded-only 경로가 담당하므로 시스템 font file I/O는 발생하지 않는다.
         renderer.inner_mut().font_embed_mode = crate::renderer::svg::FontEmbedMode::Style;
+        renderer.inner_mut().annotate_metric_font = self.annotate_metric_font;
         renderer.render_page(&layer_tree)?;
         let mut svg = renderer.output().to_string();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3751,6 +3751,7 @@ fn print_help() {
         "      --profile <프로필>      layer 출력 프로필: screen|print|high-quality|fast-preview"
     );
     println!("      --show-para-marks       문단부호(↵/↓) 표시");
+    println!("      --annotate-metric-font  배치에 쓴 내장 메트릭 face 를 data-metric-font 로 주석 (#4709)");
     println!("      --show-control-codes    조판부호 보이기 (문단부호 + 개체 마커 등)");
     println!("      --debug-overlay         디버그 오버레이 (문단/표 경계 + 인덱스 라벨)");
     println!("      --respect-vpos-reset    LINE_SEG vpos=0 리셋을 단/페이지 강제 경계로 처리");
@@ -4329,6 +4330,7 @@ fn export_svg(args: &[String]) -> i32 {
     let mut target_page: Option<u32> = None;
     let mut show_para_marks = false;
     let mut show_control_codes = false;
+    let mut annotate_metric_font = false;
     let mut debug_overlay = false;
     let mut grid_mm: Option<f64> = None;
     let mut grid_origin = GridOriginOption::Fixed((0.0_f64, 0.0_f64));
@@ -4386,6 +4388,10 @@ fn export_svg(args: &[String]) -> i32 {
             }
             "--show-control-codes" => {
                 show_control_codes = true;
+                i += 1;
+            }
+            "--annotate-metric-font" => {
+                annotate_metric_font = true;
                 i += 1;
             }
             "--debug-overlay" => {
@@ -4529,6 +4535,9 @@ fn export_svg(args: &[String]) -> i32 {
     }
     if show_control_codes {
         doc.set_show_control_codes(true);
+    }
+    if annotate_metric_font {
+        doc.set_annotate_metric_font(true);
     }
     if debug_overlay {
         doc.set_debug_overlay(true);

--- a/src/renderer/font_metrics_data.rs
+++ b/src/renderer/font_metrics_data.rs
@@ -228,6 +228,30 @@ pub fn find_metric(name: &str, bold: bool, italic: bool) -> Option<MetricMatch> 
     })
 }
 
+/// [#4709] 이 스타일의 글자폭 배치에 실제로 쓰인 내장 메트릭 face 이름.
+///
+/// `measure_char_width_embedded`(text_measurement.rs)의 해석 순서를 따른다:
+/// CSS 체인 첫 face → KoPub 전용 표 → 별칭 해석 → 메트릭 DB. DB 에 없는
+/// face(폭이 휴리스틱 추정으로 결정되는 경우)는 None — 주석도 붙이지 않는다.
+pub fn layout_metric_face_name(font_family: &str, bold: bool, italic: bool) -> Option<String> {
+    let primary = font_family
+        .split(',')
+        .next()
+        .unwrap_or(font_family)
+        .trim()
+        .trim_matches('\'');
+    // KoPub 은 kopub_char_width 전용 표가 find_metric 보다 앞선다 — face 자체가 정체.
+    let lower = primary.to_lowercase();
+    if primary.contains("KoPub돋움체")
+        || lower.contains("kopub dotum")
+        || primary.contains("KoPub바탕체")
+        || lower.contains("kopub batang")
+    {
+        return Some(primary.to_string());
+    }
+    find_metric(primary, bold, italic).map(|m| m.metric.name.to_string())
+}
+
 /// 기존 선형 스캔 구현 — 색인 등가성 검증 전용으로 보존 (수정 금지).
 #[cfg(test)]
 fn legacy_find_metric(name: &str, bold: bool, italic: bool) -> Option<MetricMatch> {

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -125,6 +125,14 @@ pub struct SvgRenderer {
     /// 일반 face 하나만 `@font-face`로 임베드하면 브라우저가 synthetic bold를
     /// 적용해 획 두께와 글리프 폭이 기준 PDF와 달라진다.
     font_bold_families: std::collections::HashSet<String>,
+    /// [#4709] 배치에 쓴 내장 메트릭 face를 출력에 주석으로 남길지 (옵트인).
+    ///
+    /// 켜면 각 `<text>`에 `data-metric-font`, 루트 `<svg>`에 페이지에서 쓰인
+    /// face 목록 `data-rhwp-metric-fonts`가 붙는다. 임베드 호스트가 폰트 설치
+    /// 확인·대체 폰트 보정에 쓴다. 기본 꺼짐 — 골든/스냅샷 출력 불변.
+    pub annotate_metric_font: bool,
+    /// [#4709] 현재 페이지에서 배치에 쓰인 메트릭 face 수집 (루트 주석용).
+    metric_faces: std::collections::BTreeSet<String>,
 }
 
 /// 디버그 오버레이용 문단 경계 정보
@@ -199,6 +207,8 @@ impl SvgRenderer {
             font_paths: Vec::new(),
             font_codepoints: std::collections::HashMap::new(),
             font_bold_families: std::collections::HashSet::new(),
+            annotate_metric_font: false,
+            metric_faces: std::collections::BTreeSet::new(),
         }
     }
 
@@ -2686,6 +2696,7 @@ impl Renderer for SvgRenderer {
         self.overlay_vpos_resets.clear();
         self.overlay_skip_depth = 0;
         self.overlay_page_section = -1;
+        self.metric_faces.clear();
         // xmlns:xlink 필수: SVG 가 <img> 로 로드될 때(예: blob URL 미리보기)
         // 엄격한 XML 파싱으로 인해 xmlns:xlink 미선언 시 <image xlink:href=...> 가 무시됨.
         self.output.push_str(&format!(
@@ -2708,6 +2719,21 @@ impl Renderer for SvgRenderer {
             }
             defs_block.push_str("</defs>\n");
             self.output.insert_str(self.defs_insert_pos, &defs_block);
+        }
+        // [#4709] 루트 <svg>에 이 페이지 배치에 쓰인 메트릭 face 목록 주석 (옵트인).
+        if self.annotate_metric_font && !self.metric_faces.is_empty() {
+            if let Some(pos) = self.output.find('>') {
+                let list = self
+                    .metric_faces
+                    .iter()
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(",");
+                self.output.insert_str(
+                    pos,
+                    &format!(" data-rhwp-metric-fonts=\"{}\"", escape_xml(&list)),
+                );
+            }
         }
         self.output.push_str("</svg>\n");
     }
@@ -2763,6 +2789,18 @@ impl Renderer for SvgRenderer {
         }
         if style.italic {
             base_attrs.push_str(" font-style=\"italic\"");
+        }
+        // [#4709] 옵트인: 이 run 의 배치 폭을 계산한 내장 메트릭 face 주석.
+        // 임베드 호스트가 함초롬 등 미설치 폰트의 자간 불일치를 보정할 근거.
+        if self.annotate_metric_font {
+            if let Some(face) = crate::renderer::font_metrics_data::layout_metric_face_name(
+                &style.font_family,
+                style.is_visually_bold(),
+                style.italic,
+            ) {
+                base_attrs.push_str(&format!(" data-metric-font=\"{}\"", escape_xml(&face)));
+                self.metric_faces.insert(face);
+            }
         }
         let attrs_for_cluster = |cluster_str: &str, fill: &str| {
             let cluster_font_family = if super::contains_old_hangul_jamo(cluster_str) {

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -642,6 +642,23 @@ impl HwpDocument {
         self.show_paragraph_marks
     }
 
+    /// [#4709] SVG 출력에 배치 메트릭 face 주석을 붙일지 설정한다 (기본 꺼짐).
+    ///
+    /// 켜면 `renderPageSvg` 계열 출력의 각 `<text>`에 `data-metric-font`,
+    /// 루트 `<svg>`에 `data-rhwp-metric-fonts`(쉼표 구분 목록)가 붙는다.
+    /// 임베드 호스트가 해당 폰트 설치 여부 확인·대체 폰트 자간 보정에 쓴다.
+    /// 배치(레이아웃)에는 영향이 없는 뷰 전용 주석이다.
+    #[wasm_bindgen(js_name = setAnnotateMetricFont)]
+    pub fn set_annotate_metric_font(&mut self, enabled: bool) {
+        self.annotate_metric_font = enabled;
+    }
+
+    /// [#4709] SVG 메트릭 face 주석 부착 여부를 반환한다.
+    #[wasm_bindgen(js_name = getAnnotateMetricFont)]
+    pub fn get_annotate_metric_font(&self) -> bool {
+        self.annotate_metric_font
+    }
+
     /// 조판부호 표시 여부를 반환한다.
     #[wasm_bindgen(js_name = getShowControlCodes)]
     pub fn get_show_control_codes(&self) -> bool {
@@ -8295,6 +8312,12 @@ impl HwpViewer {
     #[wasm_bindgen(js_name = renderPageSvg)]
     pub fn render_page_svg(&self, page_num: u32) -> Result<String, JsValue> {
         self.document.render_page_svg(page_num)
+    }
+
+    /// [#4709] SVG 출력에 배치 메트릭 face 주석을 붙일지 설정한다 (기본 꺼짐).
+    #[wasm_bindgen(js_name = setAnnotateMetricFont)]
+    pub fn set_annotate_metric_font(&mut self, enabled: bool) {
+        self.document.set_annotate_metric_font(enabled);
     }
 
     /// 명시적인 출력 profile로 특정 페이지 SVG 렌더링

--- a/tests/issue_4709_metric_font_annotation.rs
+++ b/tests/issue_4709_metric_font_annotation.rs
@@ -1,0 +1,41 @@
+//! [#4709] renderPageSvg 메트릭 face 주석 계약.
+//!
+//! 옵트인(`setAnnotateMetricFont(true)`) 시에만 각 `<text>` 에 `data-metric-font`,
+//! 루트 `<svg>` 에 `data-rhwp-metric-fonts`(쉼표 목록)가 붙는다. 기본값(꺼짐)의
+//! 출력은 종전과 바이트 단위로 같아야 한다 — 골든/스냅샷 불변 계약.
+
+fn load(path: &str) -> rhwp::wasm_api::HwpDocument {
+    let full = format!("{}/{}", env!("CARGO_MANIFEST_DIR"), path);
+    let bytes = std::fs::read(&full).expect("fixture 읽기");
+    rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("fixture 파싱")
+}
+
+#[test]
+fn annotation_is_optin_and_lists_metric_faces() {
+    let mut doc = load("samples/byeolpyo1.hwp");
+
+    let off = doc.render_page_svg_native(0).expect("기본 렌더");
+    assert!(
+        !off.contains("data-metric-font"),
+        "기본값(꺼짐)에서는 메트릭 주석이 없어야 한다 — 골든 출력 불변"
+    );
+
+    doc.set_annotate_metric_font(true);
+    let on = doc.render_page_svg_native(0).expect("주석 렌더");
+    assert!(
+        on.contains("data-metric-font=\""),
+        "옵트인 시 <text> 에 data-metric-font 가 붙어야 한다"
+    );
+    assert!(
+        on.contains("data-rhwp-metric-fonts=\""),
+        "옵트인 시 루트 <svg> 에 data-rhwp-metric-fonts 목록이 붙어야 한다"
+    );
+
+    // 주석 제거 시 기본 출력과 동일해야 한다 (주석은 뷰 전용, 레이아웃 불변).
+    doc.set_annotate_metric_font(false);
+    let off_again = doc.render_page_svg_native(0).expect("재렌더");
+    assert_eq!(
+        off, off_again,
+        "플래그를 끄면 종전 출력으로 되돌아와야 한다"
+    );
+}


### PR DESCRIPTION
## 무엇을

#4709 제안 ①: `renderPageSvg` 계열 SVG 출력에 **배치에 쓴 내장 메트릭 face**를 옵트인 주석으로 노출합니다. 임베드 호스트가 (a) 해당 폰트 설치 여부를 확인해 안내하거나 (b) 대체 폰트에 맞춰 `textLength`/`letter-spacing` 보정을 넣을 근거가 됩니다.

## 사용법

```js
doc.setAnnotateMetricFont(true);   // WASM HwpDocument / HwpEditor, 기본 false
const svg = doc.renderPageSvg(0);
```
```
rhwp export-svg 문서.hwp --annotate-metric-font    # CLI (검증용)
```

출력(이슈 제안 형식 그대로):

```xml
<svg ... data-rhwp-metric-fonts="Dotum,HanyangSinMyeongJo,HumanMyeongJo,Palatino Linotype">
  <text ... data-metric-font="HanyangSinMyeongJo">…</text>
```

- `data-metric-font` — 그 run의 글자폭 배치를 계산한 내장 메트릭 face(별칭 해석 후의 메트릭 DB 이름). 해석 순서는 `measure_char_width_embedded`와 동일(체인 첫 face → KoPub 전용 표 → 별칭 → 메트릭 DB). DB 밖 face(폭이 휴리스틱 추정)는 주석을 생략해 "내장 메트릭으로 배치됨"이라는 의미를 지킵니다.
- `data-rhwp-metric-fonts` — 페이지에서 쓰인 face의 쉼표 구분 목록(루트 1곳만 읽는 호스트용).

## 왜 옵트인인가

기본 꺼짐이며 **기본 출력은 바이트 단위로 불변**입니다 — 골든/스냅샷·기존 소비자 무영향. 주석은 뷰 전용이라 레이아웃(페이지네이션)에도 영향이 없습니다. 계약 테스트(`tests/issue_4709_metric_font_annotation.rs`)가 꺼짐=주석 0·재꺼짐=원출력 복원·켜짐=두 주석 존재를 고정합니다.

## 검증

- nextest **6019/6019 통과**, clippy(native-skia) 0, rustfmt 클린
- 실문서 프로브(acrc 29269): 꺼짐=주석 0/출력 불변, 켜짐=`data-metric-font` 396개 + 루트 목록 정상
- legacy(`renderPageSvg`)·layer(`renderPageSvgWithProfile`) 두 경로 모두 배선
- `mydocs/manual/cli_commands.md`에 CLI 플래그 등재

제안 ②(호스트 계측 콜백 부활)는 페이지네이션 분기라 이 PR 범위 밖입니다. ③(대체 스택 권고)은 이 주석으로 호스트가 face별 대응을 직접 걸 수 있게 되면서 필요성이 줄지만, 별도 문서 건으로 남깁니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
