### PR TITLE
fix(tools): loadsave sweep 감독의 heartbeat 공유 위반 사망과 stall-kill 오판을 막는다 (#4749 #4751)

### DIFF
--- a/tools/loadsave_sweep/README.md
+++ b/tools/loadsave_sweep/README.md
@@ -104,5 +104,11 @@ Phase A 산출물은 버전 무관이므로 재사용 — Phase B 만 `-HwpVersi
 <S>/s1/oracle_<ver>/verdicts/  verdicts.tsv + summary.md
 ```
 
-판정 어휘: `CONVERT_FAIL` > `OPEN_FAIL` > `MEASURE_FAIL` > `TEXT_MISMATCH` > `CTRL_DIFF` >
-`PAGE_DIFF` > `OK`. 원본이 안 열리는 문서는 `ORACLE_ORIG_FAIL` 로 모수에서 제외.
+판정 어휘: `CONVERT_FAIL` > `OPEN_FAIL` > `ORACLE_TIMEOUT` > `MEASURE_FAIL` > `TEXT_MISMATCH` >
+`CTRL_DIFF` > `PAGE_DIFF` > `OK`. 원본이 안 열리는 문서는 `ORACLE_ORIG_FAIL` 로 모수에서 제외.
+
+stall-kill 오판 방어(#4749/#4751): 감독은 heartbeat 를 `FileShare.ReadWrite` 로 읽어
+공유 위반 사망을 막고, stall 임계는 `StallSeconds + StallSecondsPerMB(기본 60) × 문서 MB`
+로 크기에 비례한다. 죽인 키는 `<OutDir>/stall_kills.tsv` 에 남고, judge 는 그 키의 ERR 를
+`OPEN_FAIL` 이 아닌 `ORACLE_TIMEOUT`(원본이면 `ORACLE_ORIG_TIMEOUT`) 으로 내
+"결함"과 "측정 실패 — 재확인 필요"를 가른다. 재확인 키·명령은 summary.md 에 나온다.

--- a/tools/loadsave_sweep/judge.py
+++ b/tools/loadsave_sweep/judge.py
@@ -4,6 +4,7 @@
 판정 어휘 (경로 하나에 여러 개 겹칠 수 있다 · 심각도 순):
     CONVERT_FAIL      rhwp 가 변환 자체를 못 함 (FAIL/TIMEOUT/SPAWN_FAIL)
     OPEN_FAIL         rhwp 산출물을 한글이 못 엶  ← 저장하기 치명 결함
+    ORACLE_TIMEOUT    감독의 stall-kill 이 만든 실패 ← 결함 아님, 재확인 필요 (#4751)
     MEASURE_FAIL      한글이 열었지만 측정 중 오류 (판정 불가)
     TEXT_MISMATCH     본문 텍스트 불일치            ← 텍스트 누락/변형
     CTRL_DIFF         컨트롤 집계 불일치 (표·그림 등) ← 개체 누락
@@ -11,6 +12,9 @@
     OK                위 어느 것도 아님
 
 원본이 한글에서 안 열리는 문서(ORACLE_ORIG_FAIL)는 판정 모수에서 제외해 따로 센다.
+원본이 stall-kill 에 걸린 문서(ORACLE_ORIG_TIMEOUT)도 모수에서 빠지되 결함이 아니라
+재확인 대상이다 — stall-kill 키는 oracle_run.ps1 이 남기는 stall_kills.tsv 로 식별한다
+(경로는 --stall-kills, 생략 시 result.tsv 옆에서 자동 탐색).
 rhwp 자기검증(exit 3/4)은 selfVerify 열에 참고로 싣는다 — 오라클 판정과 독립이다.
 
 원본 유령 성공 의심(원본 텍스트 0자 + 페이지 1)은 origSuspect 열에 SUSPECT 로 표시한다.
@@ -80,7 +84,20 @@ def main() -> int:
     ap.add_argument("--oracle", required=True, help="oracle result.tsv")
     ap.add_argument("--texts", required=True)
     ap.add_argument("--out", required=True)
+    ap.add_argument("--stall-kills", default=None,
+                    help="[#4751] oracle_run.ps1 의 stall_kills.tsv 경로 "
+                         "(생략 시 result.tsv 옆의 stall_kills.tsv 자동 탐색)")
     args = ap.parse_args()
+
+    # [#4751] 감독의 stall-kill 이 만든 실패는 실제 한글 크래시와 같은 HRESULT
+    # (0x800706BE)로 기록된다. 죽인 키 목록으로 가려내 "결함"이 아니라
+    # "측정 실패 — 재확인 필요"(ORACLE_TIMEOUT)로 판정한다.
+    stall_path = Path(args.stall_kills) if args.stall_kills else Path(args.oracle).parent / "stall_kills.tsv"
+    stall_killed: set[str] = set()
+    if stall_path.is_file():
+        for line in stall_path.read_text(encoding="utf-8-sig").splitlines():
+            if line.strip():
+                stall_killed.add(line.split("\t", 1)[0])
 
     docs = []
     for line in Path(args.master).read_text(encoding="utf-8").splitlines():
@@ -120,6 +137,7 @@ def main() -> int:
     rows = []
     counts: dict[str, Counter] = defaultdict(Counter)
     n_orig_fail = 0
+    n_orig_timeout = 0
     n_orig_missing = 0
     n_orig_suspect = 0
     n_orig_text_fail = 0
@@ -131,8 +149,15 @@ def main() -> int:
             n_orig_missing += 1
             continue  # Phase B 미도달 (부분 실행) — 모수에서 제외
         if orig["status"] != "OK":
-            n_orig_fail += 1
-            rows.append([docid, fmt, "-", "ORACLE_ORIG_FAIL", "", "", "", "", orig["err"][:200], doc["src"]])
+            if f"{docid}.orig" in stall_killed:
+                # [#4751] 원본이 stall-kill 에 걸리면 그 문서의 모든 경로가 모수에서
+                # 빠진다 — 결함이 아니라 측정 실패이므로 별도 판정으로 가른다.
+                n_orig_timeout += 1
+                rows.append([docid, fmt, "-", "ORACLE_ORIG_TIMEOUT", "", "", "", "",
+                             orig["err"][:200], doc["src"]])
+            else:
+                n_orig_fail += 1
+                rows.append([docid, fmt, "-", "ORACLE_ORIG_FAIL", "", "", "", "", orig["err"][:200], doc["src"]])
             continue
         orig_suspect = orig["textLen"] == 0 and orig["pages"] <= 1
         if orig_suspect:
@@ -165,7 +190,10 @@ def main() -> int:
                     verdicts.append("MEASURE_FAIL")
                     detail = "no oracle row (phase B incomplete?)"
                 elif var["status"] != "OK":
-                    verdicts.append("OPEN_FAIL")
+                    # [#4751] stall-kill 이 만든 ERR 는 저장하기 결함(OPEN_FAIL)이 아니라
+                    # 측정 실패 — 재확인 대상(ORACLE_TIMEOUT)이다.
+                    verdicts.append("ORACLE_TIMEOUT" if f"{docid}.{route}" in stall_killed
+                                    else "OPEN_FAIL")
                     detail = var["err"][:200]
                 else:
                     pages_str = f"{orig['pages']}->{var['pages']}"
@@ -203,7 +231,8 @@ def main() -> int:
     # 요약
     lines = ["# load/save 스윕 판정 요약", ""]
     total_judged = sum(sum(c.values()) for c in counts.values())
-    lines.append(f"- 문서: {len(docs)} (원본 오라클 실패 {n_orig_fail}, Phase B 미도달 {n_orig_missing}, "
+    lines.append(f"- 문서: {len(docs)} (원본 오라클 실패 {n_orig_fail}, 원본 stall-kill 재확인 대상 {n_orig_timeout}, "
+                 f"Phase B 미도달 {n_orig_missing}, "
                  f"원본 유령성공 의심 {n_orig_suspect}, 원본 텍스트추출 실패 {n_orig_text_fail})")
     if n_orig_suspect or n_orig_text_fail:
         lines.append(f"  - 원본 텍스트가 0자인 문서 {n_orig_suspect + n_orig_text_fail}건은 텍스트 축 판정을 보류했다 "
@@ -211,15 +240,32 @@ def main() -> int:
                      f"0자 원본과의 차이는 결함과 측정 실패를 구별할 수 없다. 쪽수·컨트롤 축은 그대로 판정한다.")
     lines.append(f"- 판정된 (문서×경로): {total_judged}")
     lines.append("")
-    lines.append("| route | OK | CONVERT_FAIL | OPEN_FAIL | TEXT_MISMATCH | CTRL_DIFF | PAGE_DIFF | MEASURE_FAIL |")
-    lines.append("|---|---|---|---|---|---|---|---|")
+    lines.append("| route | OK | CONVERT_FAIL | OPEN_FAIL | ORACLE_TIMEOUT | TEXT_MISMATCH | CTRL_DIFF | PAGE_DIFF | MEASURE_FAIL |")
+    lines.append("|---|---|---|---|---|---|---|---|---|")
     for route in ("h2h", "h2x", "x2h", "x2x"):
         c = counts[route]
         lines.append(f"| {route} | {c['OK']} | {c['CONVERT_FAIL']} | {c['OPEN_FAIL']} | "
+                     f"{c['ORACLE_TIMEOUT']} | "
                      f"{c['TEXT_MISMATCH']} | {c['CTRL_DIFF']} | {c['PAGE_DIFF']} | {c['MEASURE_FAIL']} |")
     lines.append("")
     lines.append("(표의 셀은 첫 번째(최고 심각도) 판정 기준. 겹친 판정 전체는 verdicts.tsv 의 verdict 열.)")
-    bad = [r for r in rows if r[3] not in ("OK", "ORACLE_ORIG_FAIL")]
+    # [#4751] stall-kill 유발 측정 실패는 결함 목록이 아니라 재확인 절로 안내한다.
+    timeouts = [r for r in rows if r[3].split(";")[0] in ("ORACLE_TIMEOUT", "ORACLE_ORIG_TIMEOUT")]
+    if timeouts:
+        keys = [(f"{r[0]}.orig" if r[3].startswith("ORACLE_ORIG") else f"{r[0]}.{r[2]}")
+                for r in timeouts]
+        lines.append("")
+        lines.append(f"## 재확인 필요 — stall-kill 유발 측정 실패 {len(timeouts)}건 (결함 아님)")
+        for k in keys:
+            lines.append(f"- `{k}`")
+        lines.append("")
+        lines.append("재확인: 위 키만 담은 task 파일을 만들어 감독을 넉넉한 임계로 재실행한 뒤 다시 판정한다.")
+        lines.append("```")
+        lines.append("oracle_run.ps1 -HwpVersion <ver> -TaskPath <재확인.task> -OutDir <재확인_out> -StallSeconds 1200")
+        lines.append("```")
+    bad = [r for r in rows
+           if r[3] not in ("OK", "ORACLE_ORIG_FAIL", "ORACLE_ORIG_TIMEOUT")
+           and r[3].split(";")[0] != "ORACLE_TIMEOUT"]
     if bad:
         lines.append("")
         lines.append(f"## 결함 상위 예시 ({min(len(bad), 20)}/{len(bad)})")

--- a/tools/loadsave_sweep/oracle_run.ps1
+++ b/tools/loadsave_sweep/oracle_run.ps1
@@ -14,6 +14,10 @@ param(
   [Parameter(Mandatory = $true)][string]$TaskPath,
   [Parameter(Mandatory = $true)][string]$OutDir,
   [int]$StallSeconds = 300,
+  # [#4751] Large documents legitimately take minutes to open. The stall allowance grows
+  # with file size: allowed = StallSeconds + StallSecondsPerMB * MB. A 11MB doc gets ~960s
+  # (same order as the 1200s recheck that passed 18/18), a 4KB doc keeps the base 300s.
+  [int]$StallSecondsPerMB = 60,
   [int]$RecycleEvery = 200,
   [int]$WarmupDocs = 5,
   # Hangul 2018 deadlocks in Open() when hidden -- only pass this on 2022+.
@@ -81,6 +85,21 @@ if (-not (Test-Path $OutDir)) { New-Item -ItemType Directory -Force -Path $OutDi
 $all = Get-Content -LiteralPath $TaskPath -Encoding UTF8 | Where-Object { $_.Trim().Length -gt 0 }
 Write-Output "[sup] tasks: $($all.Count) opens (single worker -- concurrent Hangul instances corrupt measurements)"
 
+# [#4751] key -> file MB, for the size-scaled stall allowance. Missing files map to 0
+# (base allowance). Built once up front; the loop below only does hashtable lookups.
+$sizeMB = @{}
+foreach ($taskLine in $all) {
+  $c = $taskLine -split "`t"
+  if ($c.Count -ge 2) {
+    $mb = 0.0
+    try { $mb = (Get-Item -LiteralPath $c[1] -ErrorAction Stop).Length / 1MB } catch { }
+    $sizeMB[$c[0]] = $mb
+  }
+}
+# [#4751] Every stall-kill is recorded here so judge.py can distinguish supervisor-made
+# failures (ORACLE_TIMEOUT: re-measure) from genuine Hangul crashes (OPEN_FAIL).
+$stallLog = Join-Path $OutDir 'stall_kills.tsv'
+
 $state = @{
   Out = Join-Path $OutDir 'result.tsv'
   HB = Join-Path $OutDir 'hb.txt'
@@ -100,6 +119,21 @@ function Start-Worker {
   if ($HideWindow) { $wargs += '-HideWindow' }
   $state.Proc = Start-Process -FilePath 'powershell.exe' -ArgumentList $wargs -PassThru -WindowStyle Hidden
   Write-Output "[sup] worker started (pid $($state.Proc.Id))"
+}
+
+# [#4749] The worker writes the heartbeat with WriteAllText while we read it; ReadAllText
+# opens with FileShare.Read, which conflicts with the writer's live handle and throws --
+# and $ErrorActionPreference='Stop' escalates that into supervisor death (measured: died
+# at minute 88 of a 217-minute pass). Open with FileShare.ReadWrite like Get-DoneCount,
+# and return $null on any failure so the caller just skips this 10s tick.
+function Read-SharedText($path) {
+  try {
+    $fs = New-Object System.IO.FileStream($path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+    try {
+      $sr = New-Object System.IO.StreamReader($fs, (New-Object System.Text.UTF8Encoding($false)))
+      try { return $sr.ReadToEnd() } finally { $sr.Dispose() }
+    } finally { $fs.Dispose() }
+  } catch { return $null }
 }
 
 function Get-DoneCount($path) {
@@ -135,14 +169,25 @@ while ($true) {
   if ($running) {
     $alive = $true
     if (Test-Path -LiteralPath $state.HB) {
-      $parts = ([System.IO.File]::ReadAllText($state.HB, [System.Text.Encoding]::UTF8)) -split '\|'
+      $hbText = Read-SharedText $state.HB
+      $parts = if ($null -ne $hbText) { $hbText -split '\|' } else { @() }
       if ($parts.Count -ge 3) {
-        $age = ($nowMs - [int64]$parts[1]) / 1000.0
-        if ($age -gt $StallSeconds) {
+        # A torn read (writer mid-flight) can leave a non-numeric timestamp; skip the tick.
+        $age = $null
+        try { $age = ($nowMs - [int64]$parts[1]) / 1000.0 } catch { }
+        # [#4751] Size-scaled allowance; heartbeat states without a task key (startup /
+        # warmup / ready) fall back to the base allowance.
+        $curKey = $parts[2]
+        $allowed = $StallSeconds
+        if ($sizeMB.ContainsKey($curKey)) { $allowed = $StallSeconds + [int]($StallSecondsPerMB * $sizeMB[$curKey]) }
+        if ($null -ne $age -and $age -gt $allowed) {
           $hp = [int]$parts[0]
-          Write-Output ("[sup] worker stalled {0:N0}s on '{1}' -> killing Hwp pid {2}" -f $age, $parts[2], $hp)
+          Write-Output ("[sup] worker stalled {0:N0}s (allowed {1}s) on '{2}' -> killing Hwp pid {3}" -f $age, $allowed, $curKey, $hp)
+          # [#4751] Record the kill so judge.py grades the resulting ERR as
+          # ORACLE_TIMEOUT (re-measure) instead of OPEN_FAIL (real defect).
+          try { Add-Content -LiteralPath $stallLog -Value ("{0}`t{1:N0}`t{2}" -f $curKey, $age, (Get-Date -Format o)) -Encoding UTF8 } catch { }
           if ($hp -gt 0) { try { Stop-Process -Id $hp -Force -ErrorAction SilentlyContinue } catch { } }
-          if ($age -gt ($StallSeconds * 2)) {
+          if ($age -gt ($allowed * 2)) {
             try { Stop-Process -Id $state.Proc.Id -Force -ErrorAction SilentlyContinue } catch { }
           }
         }


### PR DESCRIPTION
## 무엇을

load/save 오라클 전수검사(#4678) 감독 루프의 인프라 결함 2건을 고칩니다. 두 이슈 모두 원인·설계·실측이 이슈 본문에 확정돼 있고, 이 PR은 그 설계를 저장소에 반영합니다.

### #4749 — heartbeat 공유 위반으로 감독 사망

- `oracle_run.ps1`이 워커가 `WriteAllText`로 잡고 있는 heartbeat를 `ReadAllText`(FileShare.Read)로 읽다가 `IOException` → `$ErrorActionPreference='Stop'`이 치명 승격 → **88분 지점 감독 사망**(실측). 감독이 죽어도 워커는 살아 있어 stall 감시 공백을 뒤늦게 발견하게 되고, 감독만 재기동하면 워커 2개로 동시 실행 금지 규약까지 깨집니다.
- 수정: `Read-SharedText` 헬퍼 — 바로 옆 `Get-DoneCount`가 이미 쓰는 `FileShare.ReadWrite`로 열고, 실패하면 예외 대신 `$null`(해당 10초 tick만 스킵). torn read로 타임스탬프가 깨진 tick도 스킵합니다.
- 이슈의 실측: 수정 전 88분 사망(8,780 opens) / 수정 후 **217분+ 완주**(29,896 opens).

### #4751 — stall-kill이 만든 실패가 OPEN_FAIL로 오판

- 강제 종료된 인스턴스의 `Open()`은 실제 한글 크래시와 **같은 `0x800706BE`** 를 던져, 정상 대형 문서(예: 204쪽·144,577자)가 최중증 판정 `OPEN_FAIL`로 찍혔습니다(1차 판정 5건 전부 가짜, `-StallSeconds 1200` 재확인 18/18 OK). 원본이 걸리면 분모까지 움직입니다(5문서 모수 이탈 실측).
- 수정 (이슈 제안 그대로 2층):
  1. **크기 비례 임계** — `-StallSecondsPerMB`(기본 60): `허용 = StallSeconds + PerMB × MB`. 11MB 문서 ~960초(재확인 통과치 1200초와 같은 자릿수), 4KB 문서는 기본 300초 유지.
  2. **판정 분리** — 감독이 죽인 키를 `<OutDir>/stall_kills.tsv`에 기록, `judge.py`가 그 키의 ERR를 `ORACLE_TIMEOUT`(원본이면 `ORACLE_ORIG_TIMEOUT`)으로 판정. 결함 목록이 아닌 **"재확인 필요"** 절로 분리하고 재확인 키·명령을 summary에 출력합니다.

## 검증

- judge 합성 스모크: 같은 `0x800706BE` ERR 3건 중 stall_kills 목록의 키만 `ORACLE_TIMEOUT`/`ORACLE_ORIG_TIMEOUT`, 목록 밖은 `OPEN_FAIL` 유지, summary에 재확인 절 출력 — PASS
- `oracle_run.ps1` 파스 검사 통과, `.ps1` 추가분은 ASCII 전용
- DoD 대조: stall-kill 실패가 OPEN_FAIL로 집계되지 않음 ✓ / 재확인 키·명령 노출 ✓ / 대형 문서 임계 확보(크기 비례) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
