### PR TITLE
feat: planet6897 기여 3건 통합 반영

### DIFF
--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -120,6 +120,10 @@ HWP/HWPX → SVG.
 - `-o`, `-p` (공통)
 - `--show-para-marks` — 문단부호(↵/↓)
 - `--show-control-codes` — 조판부호(문단부호 + 개체 마커)
+- `--annotate-metric-font` — 배치 폭 계산에 쓴 내장 메트릭 face 를 각 `<text>`의
+  `data-metric-font` 와 루트 `<svg>`의 `data-rhwp-metric-fonts`(쉼표 목록)로 주석 (#4709).
+  임베드 호스트의 폰트 설치 확인·대체 폰트 자간 보정용. 레이아웃 불변, 기본 꺼짐.
+  WASM 은 `setAnnotateMetricFont(true)` 후 `renderPageSvg`.
 - `--debug-overlay` — 디버그 오버레이(문단/표 경계 + 인덱스 라벨)
 - `--respect-vpos-reset` — LINE_SEG vpos=0 리셋을 단/페이지 강제 경계로 처리
 - `--show-grid[=Nmm]` — 격자 오버레이(기본 1mm, 예 `--show-grid=3mm`)

--- a/mydocs/orders/20260815.md
+++ b/mydocs/orders/20260815.md
@@ -115,3 +115,19 @@
   시각 검증 범위는 [PR review](../pr/archives/pr_4775_review.md)에 보존한다.
 - 이 trailing review·오늘할일 head의 GitHub Actions가 성공하고 최신 mergeability와 작업지시자 승인을
   다시 확인하기 전에는 merge하거나 #3739을 종료하지 않는다.
+
+## PR #4801 - planet6897 기여 3건 체리픽 통합
+
+- [PR #4801](https://github.com/edwardkim/rhwp/pull/4801)은 `planet6897`의 #4796, #4797, #4798을
+  최신 `upstream/devel@44bcba400` 위에서 원래 순서대로 체리픽한 통합 PR이다. 원 SHA와 적용 SHA는
+  #4796 `397982cc0` → `d69b52996`, #4797 `a1b3a9bb` → `2ce9bfd57`, #4798 `bfe531ad` → `c7e2f1fe5`다.
+- code candidate `c7e2f1fe5`는 `MERGEABLE/CLEAN`이며 GitHub Lint(WASM check 포함), Build & Test
+  전체 shard, Native Skia, Canvas visual diff, CodeQL을 모두 통과했다. 로컬에서는 #4709 SVG 주석,
+  #4778 손상 위치 축, #3739 marker slot 회귀와 sweep PowerShell/Python 정적 검사를 통과했다.
+- 메인터너 보정은 필요하지 않았다. 원 PR별 판단과 보존 경계는
+  [#4796 검토](../pr/archives/pr_4796_review.md),
+  [#4797 검토](../pr/archives/pr_4797_review.md),
+  [#4798 검토](../pr/archives/pr_4798_review.md)에 남긴다.
+- 이 review·오늘할일 trailing head의 fast-pass와 최신 mergeability를 확인한 뒤, 작업지시자의
+  병합 지시에 따라 #4801을 squash merge한다. 병합 후에는 원 PR #4796~#4798을 통합 PR 링크와 함께
+  close하고 #4709·#4749·#4751·#4778·#4677 종료 상태, `devel` 동기화, 임시 검토 branch를 확인한다.

--- a/mydocs/pr/archives/pr_4796_review.md
+++ b/mydocs/pr/archives/pr_4796_review.md
@@ -1,0 +1,49 @@
+# PR #4796 검토 - SVG 배치 메트릭 글꼴 주석 옵트인
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| 원 PR | [#4796](https://github.com/edwardkim/rhwp/pull/4796) |
+| 통합 PR | [#4801](https://github.com/edwardkim/rhwp/pull/4801) |
+| 관련 이슈 | `Closes #4709` |
+| 작성자·검토 방식 | `planet6897` · collaborator 체리픽 통합 self-review |
+| 원 base / head | `devel` / `397982cc0fd93ab15295110a8b5a2d2088756ff7` |
+| 적용 commit | `d69b52996` |
+| 통합 code candidate | `c7e2f1fe5586eca576daeb58495da5718f7eebfc` |
+| 규모 | 9 files, +145/-0 (원 PR 기준) |
+| 라우팅 | collaborator external PR · intake/review · local validation · visual fixture evidence |
+
+원 기능 commit은 최신 `upstream/devel@44bcba400072128bdc4e4d6c05bf822e3ff60996` 위에 충돌 없이
+체리픽했다. 이 기록은 code candidate가 Full CI를 통과한 뒤 추가하는 review-only trailing 문서다.
+따라서 merge 직전에는 이 문서 head의 fast-pass와 최신 mergeability를 다시 확인한다.
+
+## 변경 범위와 판단
+
+- SVG text 요소에 실제 배치 계산에 사용한 글꼴을 `data-metric-font`으로, 문서 루트에는 사용 글꼴 목록을
+  `data-rhwp-metric-fonts`로 선택적으로 기록한다.
+- 기본값은 비활성화이며 Rust `DocumentCore`, WASM API, Studio, CLI `export-svg --annotate-metric-font`에서
+  명시적으로만 켠다. 기존 SVG 직렬화와 렌더 결과는 기본 경로에서 바뀌지 않는다.
+- 옛한글 표시 글꼴과 배치 글꼴이 다를 수 있는 경우도 확인했다. 주석은 표시 대체 글꼴이 아니라 실제
+  `style.font_family` 측정값을 보여 주므로 layout debugging 용도로 정확하다.
+
+메인터너 보정이 필요한 API 호환성·기본값 변경·출력 오염은 발견하지 못했다.
+
+## 완료된 검증
+
+- `cargo test --profile release-test --target-dir target\pr-review --test issue_4709_metric_font_annotation -- --nocapture`
+  를 통과했다(1 passed).
+- `git diff --check upstream/devel...HEAD`를 통과했다.
+- code candidate `c7e2f1fe5`의 GitHub Actions에서 Lint(WASM check 포함), Build & Test 전체 shard,
+  Native Skia, Canvas visual diff, CodeQL이 모두 성공했다.
+
+## 위험과 후속 범위
+
+- 이 주석은 layout 분석용 메타데이터다. 설치 글꼴 이름을 외부 SVG에 노출하는 것이 부담인 소비자는
+  옵션을 켜지 않아야 한다.
+- 실제 페이지 모양이나 글꼴 fallback 정책은 변경하지 않는다. 해당 범위는 별도 renderer 변경으로 다룬다.
+
+## 최종 권고
+
+수용을 권고한다. #4801의 review-only trailing head가 fast-pass 조건을 만족하고 최신
+`MERGEABLE/CLEAN` 상태를 재확인한 뒤, 작업지시자 승인에 따라 통합 PR로 병합한다.

--- a/mydocs/pr/archives/pr_4797_review.md
+++ b/mydocs/pr/archives/pr_4797_review.md
@@ -1,0 +1,50 @@
+# PR #4797 검토 - load/save sweep 감독 안정화
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| 원 PR | [#4797](https://github.com/edwardkim/rhwp/pull/4797) |
+| 통합 PR | [#4801](https://github.com/edwardkim/rhwp/pull/4801) |
+| 관련 이슈 | `Closes #4749, #4751` |
+| 작성자·검토 방식 | `planet6897` · collaborator 체리픽 통합 self-review |
+| 원 base / head | `devel` / `a1b3a9bb60e9fbce630822eec7db62e060ed735c` |
+| 적용 commit | `2ce9bfd57` |
+| 통합 code candidate | `c7e2f1fe5586eca576daeb58495da5718f7eebfc` |
+| 규모 | 3 files, +111/-14 (원 PR 기준) |
+| 라우팅 | collaborator external PR · intake/review · local validation |
+
+원 기능 commit은 최신 `upstream/devel@44bcba400072128bdc4e4d6c05bf822e3ff60996` 위에 충돌 없이
+체리픽했다. 이 기록은 code candidate Full CI 성공 뒤 추가하는 review-only trailing 문서이므로,
+merge 직전에는 이 문서 head의 fast-pass와 최신 mergeability를 다시 확인한다.
+
+## 변경 범위와 판단
+
+- sweep supervisor가 heartbeat 파일을 읽을 때 writer와 공유할 수 있게 열어, 일시적인 Windows
+  `Share violation`을 supervisor 사망으로 오인하지 않게 한다.
+- 실행 중 파일 크기에 비례한 stall 허용 시간을 사용하고, supervisor kill은 별도 TSV에 남긴다.
+- judge는 알려진 supervisor kill을 입력 파일 결함(`OPEN_FAIL`)이 아니라 `ORACLE_TIMEOUT` 계열로
+  분류해 defect 집계와 재검증 대상을 구분한다.
+
+파일 공유 예외와 실제 변환 결함의 분류 경계를 확인했으며, Windows 특이 실패를 숨기거나 정상 결과로
+바꾸는 보정은 발견하지 못했다. 메인터너 code 보정은 필요하지 않다.
+
+## 완료된 검증
+
+- `tools\loadsave_sweep\oracle_run.ps1`을 PowerShell AST로 파싱해 오류가 없음을 확인했다.
+- `python -m py_compile tools\loadsave_sweep\judge.py`를 통과했다.
+- `git diff --check upstream/devel...HEAD`를 통과했다.
+- code candidate `c7e2f1fe5`의 GitHub Actions에서 Lint, Build & Test 전체 shard, Native Skia,
+  Canvas visual diff, CodeQL이 모두 성공했다.
+
+## 위험과 후속 범위
+
+- 시간 한계는 실제 heartbeat 크기를 고려하는 보수적 감독 정책이다. 장시간 원격 oracle의 새 실패
+  서명은 별도 sweep 결과로 관찰해 threshold를 조정한다.
+- 이 변경은 Windows 공유 모드에서 발생하는 판독 경쟁을 좁힌다. 다른 외부 프로세스의 lock 정책을
+  일반화하지 않는다.
+
+## 최종 권고
+
+수용을 권고한다. #4801의 review-only trailing head가 fast-pass 조건을 만족하고 최신
+`MERGEABLE/CLEAN` 상태를 재확인한 뒤, 작업지시자 승인에 따라 통합 PR로 병합한다.

--- a/mydocs/pr/archives/pr_4798_review.md
+++ b/mydocs/pr/archives/pr_4798_review.md
@@ -1,0 +1,51 @@
+# PR #4798 검토 - 손상된 위치 축의 HWPX LineSeg 저장 억제
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| 원 PR | [#4798](https://github.com/edwardkim/rhwp/pull/4798) |
+| 통합 PR | [#4801](https://github.com/edwardkim/rhwp/pull/4801) |
+| 관련 이슈 | `Closes #4778, #4677` |
+| 작성자·검토 방식 | `planet6897` · collaborator 체리픽 통합 self-review |
+| 원 base / head | `devel` / `bfe531ad50dd7a48e065f6013a274c3d572cc70a` |
+| 적용 commit | `c7e2f1fe5` |
+| 통합 code candidate | `c7e2f1fe5586eca576daeb58495da5718f7eebfc` |
+| 규모 | 1 file, +80/-12 (원 PR 기준) |
+| 라우팅 | collaborator external PR · intake/review · local validation |
+
+원 기능 commit은 최신 `upstream/devel@44bcba400072128bdc4e4d6c05bf822e3ff60996` 위에 충돌 없이
+체리픽했다. 이 기록은 code candidate Full CI 성공 뒤 추가하는 review-only trailing 문서이므로,
+merge 직전에는 이 문서 head의 fast-pass와 최신 mergeability를 다시 확인한다.
+
+## 변경 범위와 판단
+
+- 문단 run의 위치 축이 연속적이지 않으면 저장된 `linesegarray`를 방출하지 않는다. 손상된 위치로
+  재사용되는 line segment가 한글 본문을 폐기하는 경로를 차단한다.
+- 위치 축이 온전한 문단의 기존 LineSeg 보존은 유지한다.
+- HWPX control slot의 `U+FFFC` marker는 별도 위치 슬롯을 차지하는 기존 #3739 계약을 유지해,
+  marker가 있는 정상 문단의 LineSeg를 잘못 억제하지 않는다.
+
+기존 #3739 경계 보존과 함께 검토했으며, suppression 범위가 정상 위치 축까지 넓어지는 결함은
+발견하지 못했다. 메인터너 보정은 필요하지 않다.
+
+## 완료된 검증
+
+- `cargo test --profile release-test --target-dir target\pr-review --lib issue4778_broken_position_axis_suppresses_stored_linesegs -- --nocapture`
+  를 통과했다(1 passed).
+- `cargo test --profile release-test --target-dir target\pr-review --test issue_3739_hwpx_same_char_shape_boundary -- --nocapture`
+  를 통과했다(4 passed).
+- `git diff --check upstream/devel...HEAD`를 통과했다.
+- code candidate `c7e2f1fe5`의 GitHub Actions에서 Lint, Build & Test 전체 shard, Native Skia,
+  Canvas visual diff, CodeQL이 모두 성공했다.
+
+## 위험과 후속 범위
+
+- 이 변경은 위치 축이 깨진 입력에서 저장 LineSeg를 보수적으로 버린다. 손상 입력의 layout 재구성
+  정밀화는 별도 serializer 진단 범위다.
+- 다른 HWPX control 종류의 위치 모델은 이 PR에서 확장하지 않는다.
+
+## 최종 권고
+
+수용을 권고한다. #4801의 review-only trailing head가 fast-pass 조건을 만족하고 최신
+`MERGEABLE/CLEAN` 상태를 재확인한 뒤, 작업지시자 승인에 따라 통합 PR로 병합한다.

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -170,6 +170,7 @@ impl DocumentCore {
             table_transpose_clipboard: None,
             paste_cascade_count: 0,
             show_paragraph_marks: false,
+            annotate_metric_font: false,
             show_control_codes: false,
             show_transparent_borders: false,
             clip_enabled: true,

--- a/src/document_core/mod.rs
+++ b/src/document_core/mod.rs
@@ -147,6 +147,8 @@ pub struct DocumentCore {
     pub(crate) paste_cascade_count: u32,
     /// 문단부호(¶) 표시 여부
     pub(crate) show_paragraph_marks: bool,
+    /// [#4709] SVG 출력에 배치 메트릭 face 주석(data-metric-font) 부착 여부 (옵트인)
+    pub(crate) annotate_metric_font: bool,
     /// 조판부호 표시 여부 (개체 마커 [표]/[그림] 등, 문단부호 포함)
     pub(crate) show_control_codes: bool,
     /// 투명선 표시 여부
@@ -340,6 +342,7 @@ impl DocumentCore {
             table_transpose_clipboard: None,
             paste_cascade_count: 0,
             show_paragraph_marks: false,
+            annotate_metric_font: false,
             show_control_codes: false,
             show_transparent_borders: false,
             clip_enabled: true,

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -1022,6 +1022,7 @@ impl DocumentCore {
         renderer.show_paragraph_marks = self.show_paragraph_marks;
         renderer.show_control_codes = self.show_control_codes;
         renderer.debug_overlay = self.debug_overlay;
+        renderer.annotate_metric_font = self.annotate_metric_font;
         renderer.render_tree(&tree);
         Ok(renderer.output().to_string())
     }
@@ -1040,6 +1041,7 @@ impl DocumentCore {
         // WASM에서도 문서 내장 face 사용량을 수집한다. 실제 CSS 생성은 아래의
         // embedded-only 경로가 담당하므로 시스템 font file I/O는 발생하지 않는다.
         renderer.inner_mut().font_embed_mode = crate::renderer::svg::FontEmbedMode::Style;
+        renderer.inner_mut().annotate_metric_font = self.annotate_metric_font;
         renderer.render_page(&layer_tree)?;
         let mut svg = renderer.output().to_string();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3751,6 +3751,7 @@ fn print_help() {
         "      --profile <프로필>      layer 출력 프로필: screen|print|high-quality|fast-preview"
     );
     println!("      --show-para-marks       문단부호(↵/↓) 표시");
+    println!("      --annotate-metric-font  배치에 쓴 내장 메트릭 face 를 data-metric-font 로 주석 (#4709)");
     println!("      --show-control-codes    조판부호 보이기 (문단부호 + 개체 마커 등)");
     println!("      --debug-overlay         디버그 오버레이 (문단/표 경계 + 인덱스 라벨)");
     println!("      --respect-vpos-reset    LINE_SEG vpos=0 리셋을 단/페이지 강제 경계로 처리");
@@ -4329,6 +4330,7 @@ fn export_svg(args: &[String]) -> i32 {
     let mut target_page: Option<u32> = None;
     let mut show_para_marks = false;
     let mut show_control_codes = false;
+    let mut annotate_metric_font = false;
     let mut debug_overlay = false;
     let mut grid_mm: Option<f64> = None;
     let mut grid_origin = GridOriginOption::Fixed((0.0_f64, 0.0_f64));
@@ -4386,6 +4388,10 @@ fn export_svg(args: &[String]) -> i32 {
             }
             "--show-control-codes" => {
                 show_control_codes = true;
+                i += 1;
+            }
+            "--annotate-metric-font" => {
+                annotate_metric_font = true;
                 i += 1;
             }
             "--debug-overlay" => {
@@ -4529,6 +4535,9 @@ fn export_svg(args: &[String]) -> i32 {
     }
     if show_control_codes {
         doc.set_show_control_codes(true);
+    }
+    if annotate_metric_font {
+        doc.set_annotate_metric_font(true);
     }
     if debug_overlay {
         doc.set_debug_overlay(true);

--- a/src/renderer/font_metrics_data.rs
+++ b/src/renderer/font_metrics_data.rs
@@ -228,6 +228,30 @@ pub fn find_metric(name: &str, bold: bool, italic: bool) -> Option<MetricMatch> 
     })
 }
 
+/// [#4709] 이 스타일의 글자폭 배치에 실제로 쓰인 내장 메트릭 face 이름.
+///
+/// `measure_char_width_embedded`(text_measurement.rs)의 해석 순서를 따른다:
+/// CSS 체인 첫 face → KoPub 전용 표 → 별칭 해석 → 메트릭 DB. DB 에 없는
+/// face(폭이 휴리스틱 추정으로 결정되는 경우)는 None — 주석도 붙이지 않는다.
+pub fn layout_metric_face_name(font_family: &str, bold: bool, italic: bool) -> Option<String> {
+    let primary = font_family
+        .split(',')
+        .next()
+        .unwrap_or(font_family)
+        .trim()
+        .trim_matches('\'');
+    // KoPub 은 kopub_char_width 전용 표가 find_metric 보다 앞선다 — face 자체가 정체.
+    let lower = primary.to_lowercase();
+    if primary.contains("KoPub돋움체")
+        || lower.contains("kopub dotum")
+        || primary.contains("KoPub바탕체")
+        || lower.contains("kopub batang")
+    {
+        return Some(primary.to_string());
+    }
+    find_metric(primary, bold, italic).map(|m| m.metric.name.to_string())
+}
+
 /// 기존 선형 스캔 구현 — 색인 등가성 검증 전용으로 보존 (수정 금지).
 #[cfg(test)]
 fn legacy_find_metric(name: &str, bold: bool, italic: bool) -> Option<MetricMatch> {

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -125,6 +125,14 @@ pub struct SvgRenderer {
     /// 일반 face 하나만 `@font-face`로 임베드하면 브라우저가 synthetic bold를
     /// 적용해 획 두께와 글리프 폭이 기준 PDF와 달라진다.
     font_bold_families: std::collections::HashSet<String>,
+    /// [#4709] 배치에 쓴 내장 메트릭 face를 출력에 주석으로 남길지 (옵트인).
+    ///
+    /// 켜면 각 `<text>`에 `data-metric-font`, 루트 `<svg>`에 페이지에서 쓰인
+    /// face 목록 `data-rhwp-metric-fonts`가 붙는다. 임베드 호스트가 폰트 설치
+    /// 확인·대체 폰트 보정에 쓴다. 기본 꺼짐 — 골든/스냅샷 출력 불변.
+    pub annotate_metric_font: bool,
+    /// [#4709] 현재 페이지에서 배치에 쓰인 메트릭 face 수집 (루트 주석용).
+    metric_faces: std::collections::BTreeSet<String>,
 }
 
 /// 디버그 오버레이용 문단 경계 정보
@@ -199,6 +207,8 @@ impl SvgRenderer {
             font_paths: Vec::new(),
             font_codepoints: std::collections::HashMap::new(),
             font_bold_families: std::collections::HashSet::new(),
+            annotate_metric_font: false,
+            metric_faces: std::collections::BTreeSet::new(),
         }
     }
 
@@ -2686,6 +2696,7 @@ impl Renderer for SvgRenderer {
         self.overlay_vpos_resets.clear();
         self.overlay_skip_depth = 0;
         self.overlay_page_section = -1;
+        self.metric_faces.clear();
         // xmlns:xlink 필수: SVG 가 <img> 로 로드될 때(예: blob URL 미리보기)
         // 엄격한 XML 파싱으로 인해 xmlns:xlink 미선언 시 <image xlink:href=...> 가 무시됨.
         self.output.push_str(&format!(
@@ -2708,6 +2719,21 @@ impl Renderer for SvgRenderer {
             }
             defs_block.push_str("</defs>\n");
             self.output.insert_str(self.defs_insert_pos, &defs_block);
+        }
+        // [#4709] 루트 <svg>에 이 페이지 배치에 쓰인 메트릭 face 목록 주석 (옵트인).
+        if self.annotate_metric_font && !self.metric_faces.is_empty() {
+            if let Some(pos) = self.output.find('>') {
+                let list = self
+                    .metric_faces
+                    .iter()
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(",");
+                self.output.insert_str(
+                    pos,
+                    &format!(" data-rhwp-metric-fonts=\"{}\"", escape_xml(&list)),
+                );
+            }
         }
         self.output.push_str("</svg>\n");
     }
@@ -2763,6 +2789,18 @@ impl Renderer for SvgRenderer {
         }
         if style.italic {
             base_attrs.push_str(" font-style=\"italic\"");
+        }
+        // [#4709] 옵트인: 이 run 의 배치 폭을 계산한 내장 메트릭 face 주석.
+        // 임베드 호스트가 함초롬 등 미설치 폰트의 자간 불일치를 보정할 근거.
+        if self.annotate_metric_font {
+            if let Some(face) = crate::renderer::font_metrics_data::layout_metric_face_name(
+                &style.font_family,
+                style.is_visually_bold(),
+                style.italic,
+            ) {
+                base_attrs.push_str(&format!(" data-metric-font=\"{}\"", escape_xml(&face)));
+                self.metric_faces.insert(face);
+            }
         }
         let attrs_for_cluster = |cluster_str: &str, fill: &str| {
             let cluster_font_family = if super::contains_old_hangul_jamo(cluster_str) {

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -643,9 +643,15 @@ pub(crate) fn render_paragraph_parts(
     vert_start: u32,
     ctx: &mut SerializeContext,
 ) -> (String, String, u32) {
-    let runs_xml = render_runs(para, ctx);
+    let (runs_xml, position_axis_intact) = render_runs(para, ctx);
 
-    if !para.line_segs.is_empty() {
+    // [#4778] 위치 축이 무너진 문단(파서가 담지 못한 8유닛 슬롯 — 예: 차례표지
+    // 0x0008 — 이 있거나 mismatch 폴백으로 컨트롤을 말미에 몰아쓴 문단)에는 저장
+    // lineseg 를 방출하지 않는다. 방출 텍스트와 textpos 사다리가 어긋난 lineseg 를
+    // 한글 2022 가 만나면 **그 문단부터 문서 끝까지 본문을 통째로 폐기**한다
+    // (성년후견 h2x: -112,075자 실측 — lineseg 억제만으로 전량 회복). 방출을
+    // 생략하면 한글이 열 때 재계산한다(#1380 과 같은 계약).
+    if !para.line_segs.is_empty() && position_axis_intact {
         // IR 기반 출력 — 원본 lineseg 값 보존 (#177)
         let linesegs = format!(
             "{}{}{}",
@@ -927,7 +933,13 @@ fn split_text_into(splitter: &mut RunSplitter, para: &Paragraph, tab_idx: &mut u
 
 /// Paragraph 본문을 완전한 `<hp:run>` 시퀀스로 직렬화한다 (#1378 다중 run 분할).
 ///
-fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
+/// 반환: (run 시퀀스 XML, **위치 축 보존 여부**).
+///
+/// [#4778] 두 번째 값이 `false` 면 방출된 텍스트 스트림이 원본 8유닛 슬롯 축과
+/// 어긋난 상태다(파서 미수용 슬롯 또는 mismatch 폴백). 호출부는 이때 저장
+/// lineseg 방출을 억제해야 한다 — textpos 사다리와 어긋난 lineseg 는 한글이
+/// 그 문단부터 본문을 통째 폐기하는 트리거다.
+fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> (String, bool) {
     // ID 참조 무결성 (구현계획서 1.5): 실제 char_shapes entry 만 reference.
     // 빈 IR 의 fallback 0 은 제외 — char_shapes 미등록 문서(`Document::default()`)의
     // 직렬화를 깨지 않도록.
@@ -946,12 +958,16 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
         && para.orphan_field_ends.is_empty()
     {
         // 방출할 것이 없는 문단 — 옮길 슬롯도 없으므로 위치 축은 그대로다.
-        return String::new();
+        return (String::new(), true);
     }
 
     let mut splitter = RunSplitter::new(para);
 
     let slot_count = inferred_control_slot_count(para);
+    // [#4778] U+FFFC 마커는 컨트롤이 없어도 위치 축의 정규 시민이다(HWP3 암호 변환본:
+    // 마커 리터럴이 그대로 방출돼 재파싱 고정점 유지 — #3739 --verify 계약). 억제는
+    // **마커로 설명되지 않는 8유닛 구멍**(차례표지 0x0008 등 파서 미수용 슬롯)에만 건다.
+    let marker_count = para.text.chars().filter(|c| *c == '\u{fffc}').count();
     // slots 와 각 slot 의 para.controls 인덱스(slot_ctrl_indices)를 병행 수집 —
     // [Task #1627] empty-text 문단의 bookmark in-order 방출에서 slot 사이 위치 계산에 사용.
     let (slots, slot_ctrl_indices): (Vec<&Control>, Vec<usize>) =
@@ -1052,9 +1068,14 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
     {
         let t = render_hp_t_content(&para.text, &para.tab_extended, &mut tab_idx);
         splitter.content.push_str(&t);
-        // 슬롯이 하나도 없는데 char_count 는 슬롯을 주장하면(파서가 못 읽은 컨트롤)
-        // 방출 축이 원본보다 짧다 — 이때도 lineseg 를 그대로 쓰면 안 된다.
-        return splitter.finish();
+        // 슬롯이 하나도 없는데 char_count 는 슬롯을 주장하면(파서가 못 읽은 컨트롤 —
+        // 예: 차례표지 0x0008) 방출 축이 원본보다 짧다 — 이때 lineseg 를 그대로 쓰면
+        // 한글이 그 문단부터 본문을 폐기한다(#4778). 축 붕괴를 호출부에 알린다.
+        // U+FFFC 마커가 슬롯 주장을 전부 설명하면 종전 계약 유지(#3739).
+        return (
+            splitter.finish(),
+            slot_count == 0 || marker_count >= slot_count,
+        );
     }
 
     // mismatch 경로: 슬롯 위치 추정 불가 — 텍스트(경계 분할 포함) 후 슬롯 일괄 방출
@@ -1074,8 +1095,11 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
         for ofe in &para.orphan_field_ends {
             emit_orphan_field_end(&mut splitter.content, ofe);
         }
-        // 컨트롤을 말미로 몰았으므로 원본 lineseg 좌표계는 더 이상 유효하지 않다.
-        return splitter.finish();
+        // 컨트롤을 말미로 몰았으므로 원본 lineseg 좌표계는 더 이상 유효하지 않다 —
+        // 호출부가 저장 lineseg 방출을 억제하게 한다(#4778). 단, 슬롯 부족분이
+        // U+FFFC 마커로 전부 설명되면 종전 계약(방출 유지, #3739 고정점)을 지킨다.
+        let shortfall = slot_count.saturating_sub(slots.len());
+        return (splitter.finish(), marker_count >= shortfall);
     }
 
     // 메인 경로 — UTF-16 위치 축 위에서 슬롯/필드/문자/경계를 함께 처리
@@ -1390,7 +1414,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
             field_end_emitted[i] = true;
         }
     }
-    splitter.finish()
+    (splitter.finish(), true)
 }
 
 fn inferred_control_slot_count(para: &Paragraph) -> usize {
@@ -4971,7 +4995,51 @@ mod tests {
     fn runs_of(para: &Paragraph) -> String {
         let doc = Document::default();
         let mut ctx = SerializeContext::collect_from_document(&doc);
-        render_runs(para, &mut ctx)
+        render_runs(para, &mut ctx).0
+    }
+
+    /// [#4778] 위치 축이 무너진 문단(파서 미수용 8유닛 슬롯 — 차례표지 0x0008 등)의
+    /// 저장 lineseg 는 방출하지 않는다. textpos 사다리와 어긋난 lineseg 를 한글 2022 가
+    /// 만나면 그 문단부터 문서 끝까지 본문을 폐기한다(성년후견 h2x -112,075자 실측,
+    /// lineseg 억제만으로 전량 회복).
+    #[test]
+    fn issue4778_broken_position_axis_suppresses_stored_linesegs() {
+        use crate::model::paragraph::LineSeg;
+        let doc = Document::default();
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+
+        // 성년후견 #156 동형: 텍스트 앞에 8유닛 슬롯 갭(차례표지 자리)이 있는데
+        // controls 는 비어 있다 — char_count/char_offsets 만 슬롯을 주장한다.
+        let mut broken = Paragraph::default();
+        broken.text = "다. 표제".to_string();
+        broken.char_offsets = (0..broken.text.chars().count() as u32)
+            .map(|i| 8 + i)
+            .collect();
+        broken.char_count = 8 + broken.text.chars().count() as u32 + 1;
+        broken.line_segs = vec![LineSeg {
+            line_height: 1100,
+            ..Default::default()
+        }];
+        let (_, linesegs, _) = render_paragraph_parts(&broken, 0, &mut ctx);
+        assert!(
+            linesegs.is_empty(),
+            "축 붕괴 문단은 저장 lineseg 를 방출하면 안 된다(한글 본문 폐기 트리거): {linesegs}"
+        );
+
+        // 대조군: 축이 온전한 문단은 종전대로 저장 lineseg 를 방출한다.
+        let mut intact = Paragraph::default();
+        intact.text = "본문".to_string();
+        intact.char_offsets = (0..intact.text.chars().count() as u32).collect();
+        intact.char_count = intact.text.chars().count() as u32 + 1;
+        intact.line_segs = vec![LineSeg {
+            line_height: 1100,
+            ..Default::default()
+        }];
+        let (_, linesegs, _) = render_paragraph_parts(&intact, 0, &mut ctx);
+        assert!(
+            linesegs.contains("<hp:lineseg"),
+            "온전한 문단의 저장 lineseg 보존이 깨졌다"
+        );
     }
 
     #[test]

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -642,6 +642,23 @@ impl HwpDocument {
         self.show_paragraph_marks
     }
 
+    /// [#4709] SVG 출력에 배치 메트릭 face 주석을 붙일지 설정한다 (기본 꺼짐).
+    ///
+    /// 켜면 `renderPageSvg` 계열 출력의 각 `<text>`에 `data-metric-font`,
+    /// 루트 `<svg>`에 `data-rhwp-metric-fonts`(쉼표 구분 목록)가 붙는다.
+    /// 임베드 호스트가 해당 폰트 설치 여부 확인·대체 폰트 자간 보정에 쓴다.
+    /// 배치(레이아웃)에는 영향이 없는 뷰 전용 주석이다.
+    #[wasm_bindgen(js_name = setAnnotateMetricFont)]
+    pub fn set_annotate_metric_font(&mut self, enabled: bool) {
+        self.annotate_metric_font = enabled;
+    }
+
+    /// [#4709] SVG 메트릭 face 주석 부착 여부를 반환한다.
+    #[wasm_bindgen(js_name = getAnnotateMetricFont)]
+    pub fn get_annotate_metric_font(&self) -> bool {
+        self.annotate_metric_font
+    }
+
     /// 조판부호 표시 여부를 반환한다.
     #[wasm_bindgen(js_name = getShowControlCodes)]
     pub fn get_show_control_codes(&self) -> bool {
@@ -8295,6 +8312,12 @@ impl HwpViewer {
     #[wasm_bindgen(js_name = renderPageSvg)]
     pub fn render_page_svg(&self, page_num: u32) -> Result<String, JsValue> {
         self.document.render_page_svg(page_num)
+    }
+
+    /// [#4709] SVG 출력에 배치 메트릭 face 주석을 붙일지 설정한다 (기본 꺼짐).
+    #[wasm_bindgen(js_name = setAnnotateMetricFont)]
+    pub fn set_annotate_metric_font(&mut self, enabled: bool) {
+        self.document.set_annotate_metric_font(enabled);
     }
 
     /// 명시적인 출력 profile로 특정 페이지 SVG 렌더링

--- a/tests/issue_4709_metric_font_annotation.rs
+++ b/tests/issue_4709_metric_font_annotation.rs
@@ -1,0 +1,41 @@
+//! [#4709] renderPageSvg 메트릭 face 주석 계약.
+//!
+//! 옵트인(`setAnnotateMetricFont(true)`) 시에만 각 `<text>` 에 `data-metric-font`,
+//! 루트 `<svg>` 에 `data-rhwp-metric-fonts`(쉼표 목록)가 붙는다. 기본값(꺼짐)의
+//! 출력은 종전과 바이트 단위로 같아야 한다 — 골든/스냅샷 불변 계약.
+
+fn load(path: &str) -> rhwp::wasm_api::HwpDocument {
+    let full = format!("{}/{}", env!("CARGO_MANIFEST_DIR"), path);
+    let bytes = std::fs::read(&full).expect("fixture 읽기");
+    rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("fixture 파싱")
+}
+
+#[test]
+fn annotation_is_optin_and_lists_metric_faces() {
+    let mut doc = load("samples/byeolpyo1.hwp");
+
+    let off = doc.render_page_svg_native(0).expect("기본 렌더");
+    assert!(
+        !off.contains("data-metric-font"),
+        "기본값(꺼짐)에서는 메트릭 주석이 없어야 한다 — 골든 출력 불변"
+    );
+
+    doc.set_annotate_metric_font(true);
+    let on = doc.render_page_svg_native(0).expect("주석 렌더");
+    assert!(
+        on.contains("data-metric-font=\""),
+        "옵트인 시 <text> 에 data-metric-font 가 붙어야 한다"
+    );
+    assert!(
+        on.contains("data-rhwp-metric-fonts=\""),
+        "옵트인 시 루트 <svg> 에 data-rhwp-metric-fonts 목록이 붙어야 한다"
+    );
+
+    // 주석 제거 시 기본 출력과 동일해야 한다 (주석은 뷰 전용, 레이아웃 불변).
+    doc.set_annotate_metric_font(false);
+    let off_again = doc.render_page_svg_native(0).expect("재렌더");
+    assert_eq!(
+        off, off_again,
+        "플래그를 끄면 종전 출력으로 되돌아와야 한다"
+    );
+}

--- a/tools/loadsave_sweep/README.md
+++ b/tools/loadsave_sweep/README.md
@@ -104,5 +104,11 @@ Phase A 산출물은 버전 무관이므로 재사용 — Phase B 만 `-HwpVersi
 <S>/s1/oracle_<ver>/verdicts/  verdicts.tsv + summary.md
 ```
 
-판정 어휘: `CONVERT_FAIL` > `OPEN_FAIL` > `MEASURE_FAIL` > `TEXT_MISMATCH` > `CTRL_DIFF` >
-`PAGE_DIFF` > `OK`. 원본이 안 열리는 문서는 `ORACLE_ORIG_FAIL` 로 모수에서 제외.
+판정 어휘: `CONVERT_FAIL` > `OPEN_FAIL` > `ORACLE_TIMEOUT` > `MEASURE_FAIL` > `TEXT_MISMATCH` >
+`CTRL_DIFF` > `PAGE_DIFF` > `OK`. 원본이 안 열리는 문서는 `ORACLE_ORIG_FAIL` 로 모수에서 제외.
+
+stall-kill 오판 방어(#4749/#4751): 감독은 heartbeat 를 `FileShare.ReadWrite` 로 읽어
+공유 위반 사망을 막고, stall 임계는 `StallSeconds + StallSecondsPerMB(기본 60) × 문서 MB`
+로 크기에 비례한다. 죽인 키는 `<OutDir>/stall_kills.tsv` 에 남고, judge 는 그 키의 ERR 를
+`OPEN_FAIL` 이 아닌 `ORACLE_TIMEOUT`(원본이면 `ORACLE_ORIG_TIMEOUT`) 으로 내
+"결함"과 "측정 실패 — 재확인 필요"를 가른다. 재확인 키·명령은 summary.md 에 나온다.

--- a/tools/loadsave_sweep/judge.py
+++ b/tools/loadsave_sweep/judge.py
@@ -4,6 +4,7 @@
 판정 어휘 (경로 하나에 여러 개 겹칠 수 있다 · 심각도 순):
     CONVERT_FAIL      rhwp 가 변환 자체를 못 함 (FAIL/TIMEOUT/SPAWN_FAIL)
     OPEN_FAIL         rhwp 산출물을 한글이 못 엶  ← 저장하기 치명 결함
+    ORACLE_TIMEOUT    감독의 stall-kill 이 만든 실패 ← 결함 아님, 재확인 필요 (#4751)
     MEASURE_FAIL      한글이 열었지만 측정 중 오류 (판정 불가)
     TEXT_MISMATCH     본문 텍스트 불일치            ← 텍스트 누락/변형
     CTRL_DIFF         컨트롤 집계 불일치 (표·그림 등) ← 개체 누락
@@ -11,6 +12,9 @@
     OK                위 어느 것도 아님
 
 원본이 한글에서 안 열리는 문서(ORACLE_ORIG_FAIL)는 판정 모수에서 제외해 따로 센다.
+원본이 stall-kill 에 걸린 문서(ORACLE_ORIG_TIMEOUT)도 모수에서 빠지되 결함이 아니라
+재확인 대상이다 — stall-kill 키는 oracle_run.ps1 이 남기는 stall_kills.tsv 로 식별한다
+(경로는 --stall-kills, 생략 시 result.tsv 옆에서 자동 탐색).
 rhwp 자기검증(exit 3/4)은 selfVerify 열에 참고로 싣는다 — 오라클 판정과 독립이다.
 
 원본 유령 성공 의심(원본 텍스트 0자 + 페이지 1)은 origSuspect 열에 SUSPECT 로 표시한다.
@@ -80,7 +84,20 @@ def main() -> int:
     ap.add_argument("--oracle", required=True, help="oracle result.tsv")
     ap.add_argument("--texts", required=True)
     ap.add_argument("--out", required=True)
+    ap.add_argument("--stall-kills", default=None,
+                    help="[#4751] oracle_run.ps1 의 stall_kills.tsv 경로 "
+                         "(생략 시 result.tsv 옆의 stall_kills.tsv 자동 탐색)")
     args = ap.parse_args()
+
+    # [#4751] 감독의 stall-kill 이 만든 실패는 실제 한글 크래시와 같은 HRESULT
+    # (0x800706BE)로 기록된다. 죽인 키 목록으로 가려내 "결함"이 아니라
+    # "측정 실패 — 재확인 필요"(ORACLE_TIMEOUT)로 판정한다.
+    stall_path = Path(args.stall_kills) if args.stall_kills else Path(args.oracle).parent / "stall_kills.tsv"
+    stall_killed: set[str] = set()
+    if stall_path.is_file():
+        for line in stall_path.read_text(encoding="utf-8-sig").splitlines():
+            if line.strip():
+                stall_killed.add(line.split("\t", 1)[0])
 
     docs = []
     for line in Path(args.master).read_text(encoding="utf-8").splitlines():
@@ -120,6 +137,7 @@ def main() -> int:
     rows = []
     counts: dict[str, Counter] = defaultdict(Counter)
     n_orig_fail = 0
+    n_orig_timeout = 0
     n_orig_missing = 0
     n_orig_suspect = 0
     n_orig_text_fail = 0
@@ -131,8 +149,15 @@ def main() -> int:
             n_orig_missing += 1
             continue  # Phase B 미도달 (부분 실행) — 모수에서 제외
         if orig["status"] != "OK":
-            n_orig_fail += 1
-            rows.append([docid, fmt, "-", "ORACLE_ORIG_FAIL", "", "", "", "", orig["err"][:200], doc["src"]])
+            if f"{docid}.orig" in stall_killed:
+                # [#4751] 원본이 stall-kill 에 걸리면 그 문서의 모든 경로가 모수에서
+                # 빠진다 — 결함이 아니라 측정 실패이므로 별도 판정으로 가른다.
+                n_orig_timeout += 1
+                rows.append([docid, fmt, "-", "ORACLE_ORIG_TIMEOUT", "", "", "", "",
+                             orig["err"][:200], doc["src"]])
+            else:
+                n_orig_fail += 1
+                rows.append([docid, fmt, "-", "ORACLE_ORIG_FAIL", "", "", "", "", orig["err"][:200], doc["src"]])
             continue
         orig_suspect = orig["textLen"] == 0 and orig["pages"] <= 1
         if orig_suspect:
@@ -165,7 +190,10 @@ def main() -> int:
                     verdicts.append("MEASURE_FAIL")
                     detail = "no oracle row (phase B incomplete?)"
                 elif var["status"] != "OK":
-                    verdicts.append("OPEN_FAIL")
+                    # [#4751] stall-kill 이 만든 ERR 는 저장하기 결함(OPEN_FAIL)이 아니라
+                    # 측정 실패 — 재확인 대상(ORACLE_TIMEOUT)이다.
+                    verdicts.append("ORACLE_TIMEOUT" if f"{docid}.{route}" in stall_killed
+                                    else "OPEN_FAIL")
                     detail = var["err"][:200]
                 else:
                     pages_str = f"{orig['pages']}->{var['pages']}"
@@ -203,7 +231,8 @@ def main() -> int:
     # 요약
     lines = ["# load/save 스윕 판정 요약", ""]
     total_judged = sum(sum(c.values()) for c in counts.values())
-    lines.append(f"- 문서: {len(docs)} (원본 오라클 실패 {n_orig_fail}, Phase B 미도달 {n_orig_missing}, "
+    lines.append(f"- 문서: {len(docs)} (원본 오라클 실패 {n_orig_fail}, 원본 stall-kill 재확인 대상 {n_orig_timeout}, "
+                 f"Phase B 미도달 {n_orig_missing}, "
                  f"원본 유령성공 의심 {n_orig_suspect}, 원본 텍스트추출 실패 {n_orig_text_fail})")
     if n_orig_suspect or n_orig_text_fail:
         lines.append(f"  - 원본 텍스트가 0자인 문서 {n_orig_suspect + n_orig_text_fail}건은 텍스트 축 판정을 보류했다 "
@@ -211,15 +240,32 @@ def main() -> int:
                      f"0자 원본과의 차이는 결함과 측정 실패를 구별할 수 없다. 쪽수·컨트롤 축은 그대로 판정한다.")
     lines.append(f"- 판정된 (문서×경로): {total_judged}")
     lines.append("")
-    lines.append("| route | OK | CONVERT_FAIL | OPEN_FAIL | TEXT_MISMATCH | CTRL_DIFF | PAGE_DIFF | MEASURE_FAIL |")
-    lines.append("|---|---|---|---|---|---|---|---|")
+    lines.append("| route | OK | CONVERT_FAIL | OPEN_FAIL | ORACLE_TIMEOUT | TEXT_MISMATCH | CTRL_DIFF | PAGE_DIFF | MEASURE_FAIL |")
+    lines.append("|---|---|---|---|---|---|---|---|---|")
     for route in ("h2h", "h2x", "x2h", "x2x"):
         c = counts[route]
         lines.append(f"| {route} | {c['OK']} | {c['CONVERT_FAIL']} | {c['OPEN_FAIL']} | "
+                     f"{c['ORACLE_TIMEOUT']} | "
                      f"{c['TEXT_MISMATCH']} | {c['CTRL_DIFF']} | {c['PAGE_DIFF']} | {c['MEASURE_FAIL']} |")
     lines.append("")
     lines.append("(표의 셀은 첫 번째(최고 심각도) 판정 기준. 겹친 판정 전체는 verdicts.tsv 의 verdict 열.)")
-    bad = [r for r in rows if r[3] not in ("OK", "ORACLE_ORIG_FAIL")]
+    # [#4751] stall-kill 유발 측정 실패는 결함 목록이 아니라 재확인 절로 안내한다.
+    timeouts = [r for r in rows if r[3].split(";")[0] in ("ORACLE_TIMEOUT", "ORACLE_ORIG_TIMEOUT")]
+    if timeouts:
+        keys = [(f"{r[0]}.orig" if r[3].startswith("ORACLE_ORIG") else f"{r[0]}.{r[2]}")
+                for r in timeouts]
+        lines.append("")
+        lines.append(f"## 재확인 필요 — stall-kill 유발 측정 실패 {len(timeouts)}건 (결함 아님)")
+        for k in keys:
+            lines.append(f"- `{k}`")
+        lines.append("")
+        lines.append("재확인: 위 키만 담은 task 파일을 만들어 감독을 넉넉한 임계로 재실행한 뒤 다시 판정한다.")
+        lines.append("```")
+        lines.append("oracle_run.ps1 -HwpVersion <ver> -TaskPath <재확인.task> -OutDir <재확인_out> -StallSeconds 1200")
+        lines.append("```")
+    bad = [r for r in rows
+           if r[3] not in ("OK", "ORACLE_ORIG_FAIL", "ORACLE_ORIG_TIMEOUT")
+           and r[3].split(";")[0] != "ORACLE_TIMEOUT"]
     if bad:
         lines.append("")
         lines.append(f"## 결함 상위 예시 ({min(len(bad), 20)}/{len(bad)})")

--- a/tools/loadsave_sweep/oracle_run.ps1
+++ b/tools/loadsave_sweep/oracle_run.ps1
@@ -14,6 +14,10 @@ param(
   [Parameter(Mandatory = $true)][string]$TaskPath,
   [Parameter(Mandatory = $true)][string]$OutDir,
   [int]$StallSeconds = 300,
+  # [#4751] Large documents legitimately take minutes to open. The stall allowance grows
+  # with file size: allowed = StallSeconds + StallSecondsPerMB * MB. A 11MB doc gets ~960s
+  # (same order as the 1200s recheck that passed 18/18), a 4KB doc keeps the base 300s.
+  [int]$StallSecondsPerMB = 60,
   [int]$RecycleEvery = 200,
   [int]$WarmupDocs = 5,
   # Hangul 2018 deadlocks in Open() when hidden -- only pass this on 2022+.
@@ -81,6 +85,21 @@ if (-not (Test-Path $OutDir)) { New-Item -ItemType Directory -Force -Path $OutDi
 $all = Get-Content -LiteralPath $TaskPath -Encoding UTF8 | Where-Object { $_.Trim().Length -gt 0 }
 Write-Output "[sup] tasks: $($all.Count) opens (single worker -- concurrent Hangul instances corrupt measurements)"
 
+# [#4751] key -> file MB, for the size-scaled stall allowance. Missing files map to 0
+# (base allowance). Built once up front; the loop below only does hashtable lookups.
+$sizeMB = @{}
+foreach ($taskLine in $all) {
+  $c = $taskLine -split "`t"
+  if ($c.Count -ge 2) {
+    $mb = 0.0
+    try { $mb = (Get-Item -LiteralPath $c[1] -ErrorAction Stop).Length / 1MB } catch { }
+    $sizeMB[$c[0]] = $mb
+  }
+}
+# [#4751] Every stall-kill is recorded here so judge.py can distinguish supervisor-made
+# failures (ORACLE_TIMEOUT: re-measure) from genuine Hangul crashes (OPEN_FAIL).
+$stallLog = Join-Path $OutDir 'stall_kills.tsv'
+
 $state = @{
   Out = Join-Path $OutDir 'result.tsv'
   HB = Join-Path $OutDir 'hb.txt'
@@ -100,6 +119,21 @@ function Start-Worker {
   if ($HideWindow) { $wargs += '-HideWindow' }
   $state.Proc = Start-Process -FilePath 'powershell.exe' -ArgumentList $wargs -PassThru -WindowStyle Hidden
   Write-Output "[sup] worker started (pid $($state.Proc.Id))"
+}
+
+# [#4749] The worker writes the heartbeat with WriteAllText while we read it; ReadAllText
+# opens with FileShare.Read, which conflicts with the writer's live handle and throws --
+# and $ErrorActionPreference='Stop' escalates that into supervisor death (measured: died
+# at minute 88 of a 217-minute pass). Open with FileShare.ReadWrite like Get-DoneCount,
+# and return $null on any failure so the caller just skips this 10s tick.
+function Read-SharedText($path) {
+  try {
+    $fs = New-Object System.IO.FileStream($path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+    try {
+      $sr = New-Object System.IO.StreamReader($fs, (New-Object System.Text.UTF8Encoding($false)))
+      try { return $sr.ReadToEnd() } finally { $sr.Dispose() }
+    } finally { $fs.Dispose() }
+  } catch { return $null }
 }
 
 function Get-DoneCount($path) {
@@ -135,14 +169,25 @@ while ($true) {
   if ($running) {
     $alive = $true
     if (Test-Path -LiteralPath $state.HB) {
-      $parts = ([System.IO.File]::ReadAllText($state.HB, [System.Text.Encoding]::UTF8)) -split '\|'
+      $hbText = Read-SharedText $state.HB
+      $parts = if ($null -ne $hbText) { $hbText -split '\|' } else { @() }
       if ($parts.Count -ge 3) {
-        $age = ($nowMs - [int64]$parts[1]) / 1000.0
-        if ($age -gt $StallSeconds) {
+        # A torn read (writer mid-flight) can leave a non-numeric timestamp; skip the tick.
+        $age = $null
+        try { $age = ($nowMs - [int64]$parts[1]) / 1000.0 } catch { }
+        # [#4751] Size-scaled allowance; heartbeat states without a task key (startup /
+        # warmup / ready) fall back to the base allowance.
+        $curKey = $parts[2]
+        $allowed = $StallSeconds
+        if ($sizeMB.ContainsKey($curKey)) { $allowed = $StallSeconds + [int]($StallSecondsPerMB * $sizeMB[$curKey]) }
+        if ($null -ne $age -and $age -gt $allowed) {
           $hp = [int]$parts[0]
-          Write-Output ("[sup] worker stalled {0:N0}s on '{1}' -> killing Hwp pid {2}" -f $age, $parts[2], $hp)
+          Write-Output ("[sup] worker stalled {0:N0}s (allowed {1}s) on '{2}' -> killing Hwp pid {3}" -f $age, $allowed, $curKey, $hp)
+          # [#4751] Record the kill so judge.py grades the resulting ERR as
+          # ORACLE_TIMEOUT (re-measure) instead of OPEN_FAIL (real defect).
+          try { Add-Content -LiteralPath $stallLog -Value ("{0}`t{1:N0}`t{2}" -f $curKey, $age, (Get-Date -Format o)) -Encoding UTF8 } catch { }
           if ($hp -gt 0) { try { Stop-Process -Id $hp -Force -ErrorAction SilentlyContinue } catch { } }
-          if ($age -gt ($StallSeconds * 2)) {
+          if ($age -gt ($allowed * 2)) {
             try { Stop-Process -Id $state.Proc.Id -Force -ErrorAction SilentlyContinue } catch { }
           }
         }


### PR DESCRIPTION
## 요약

planet6897 기여 PR 세 건을 최신 `devel` 위에서 원래 순서대로 체리픽해 통합합니다.

- #4796: SVG 출력의 선택적 배치 메트릭 글꼴 주석
- #4797: load/save sweep 감독 heartbeat 공유 위반 및 stall 오판 보정
- #4798: 위치 축이 손상된 HWPX 문단에서 잘못된 `lineseg` 저장 방지

원 PR: #4796 (`397982cc0fd93ab15295110a8b5a2d2088756ff7`), #4797 (`a1b3a9bb60e9fbce630822eec7db62e060ed735c`), #4798 (`bfe531ad50dd7a48e065f6013a274c3d572cc70a`)

## 검토 및 검증

- 각 원 PR head가 최신 `upstream/devel`과 충돌 없이 병합 가능한지 확인
- `cargo test --profile release-test --target-dir target\pr-review --test issue_4709_metric_font_annotation -- --nocapture`
- `cargo test --profile release-test --target-dir target\pr-review --lib issue4778_broken_position_axis_suppresses_stored_linesegs -- --nocapture`
- `cargo test --profile release-test --target-dir target\pr-review --test issue_3739_hwpx_same_char_shape_boundary -- --nocapture`
- PowerShell AST 파싱: `tools\loadsave_sweep\oracle_run.ps1`
- `python -m py_compile tools\loadsave_sweep\judge.py`
- `git diff --check upstream/devel...HEAD`

원 PR의 GitHub CI는 모두 통과했습니다. 통합 PR의 코드 CI 통과 뒤에는 PR review 및 오늘할일 문서를 후속 커밋으로 추가합니다.

Closes #4709, #4749, #4751, #4778, #4677.
