### PR TITLE
fix: Local Font Access 부분 열거 시 문서 폰트 face를 보완한다

### DIFF
--- a/mydocs/manual/README.md
+++ b/mydocs/manual/README.md
@@ -33,6 +33,7 @@ last_verified: 2026-08-15
 | AI 에이전트 호스트에 rhwp 를 MCP 도구로 연결 | [MCP 통합 가이드](mcp_integration_guide.md) | [CLI 명령어 매뉴얼](cli_commands.md), [CLI JSON 파이프라인 가이드](cli_json_pipeline_guide.md) |
 | 브라우저 확장 개발·배포 | [브라우저 확장 개발 가이드](browser_extension_dev_guide.md) | [Chrome/Edge 확장 빌드·배포](chrome_edge_extension_build_deploy.md) |
 | Studio E2E·CDP 검증 | [E2E 조판 자동 검증](e2e_verification_guide.md) | [CDP E2E 가이드](e2e-cdp.md) |
+| 로컬 폰트 감지·이름·backend·정답지 불일치 대응 | [폰트 감지·대체 사고 대응 절차](font_incident_response.md) | [폰트 fallback 전략](../tech/font_fallback_strategy.md), [시각 검증 거버넌스](verification/visual_verification_governance.md) |
 | HWP/HWPX 저장 회귀 기준 | [HWP5 roundtrip baseline](hwp5_roundtrip_baseline.md), [HWPX roundtrip baseline](hwpx_roundtrip_baseline.md) | [문서 진단 도구](document_diagnostics_tool_manual.md), [HWPX2HWP probe 온보딩](hwpx2hwp_probe_onboarding.md) |
 | `@rhwp/core` 편집 API | [소비자용 편집 API](consumer_edit_api_guide.md) | [WASM options object 규약](wasm_api_options_convention.md) |
 | 웹한글컨트롤 호환 층 개발·Oracle 대조 | [웹한글컨트롤 호환 개발 가이드](webhwpctrl_compat_development.md) | [`@rhwp/hwpctrl` 패키지 안내](../../npm/hwpctrl-ocx/README.md), [호환 하니스](../../tools/hwpctrl_compat/README.md) |

--- a/mydocs/manual/font_incident_response.md
+++ b/mydocs/manual/font_incident_response.md
@@ -1,0 +1,205 @@
+---
+kind: canonical
+status: active
+canonical: mydocs/manual/font_incident_response.md
+last_verified: 2026-08-15
+---
+
+# 폰트 감지·대체 사고 대응 절차
+
+## 목적
+
+문서에 기록된 글꼴과 실제 화면·SVG·PNG·PDF 글립 또는 조판이 다를 때, 이름 하나를 예외 처리하기
+전에 원인을 같은 형식으로 분류하고 후속 이슈까지 인계하는 절차다. 대상은 다음 축을 포함한다.
+
+- 브라우저 Local Font Access와 Canvas2D 설치 face 감지
+- family/full name/PostScript/localized alias/style·weight 해소
+- Canvas2D CSS face와 CanvasKit SFNT/Typeface 조달
+- native/WASM 레이아웃 메트릭과 한컴/PDF missing-font 대체 결과
+
+기술 계약은 [폰트 fallback 전략](../tech/font_fallback_strategy.md), 시각 판정은
+[시각 검증 거버넌스](verification/visual_verification_governance.md)를 함께 따른다.
+
+## 1. 작업 시작 게이트
+
+1. 증상과 글꼴명으로 기존 이슈·PR·`mydocs/tech/investigations/`·`mydocs/troubleshootings/`를 찾는다.
+2. 이슈가 있으면 댓글과 담당자를 확인하고 메인테이너를 담당자로 지정한다. 없으면 재현과 완료 기준을
+   포함한 이슈를 먼저 만든다.
+3. 연결된 open PR이 없는지 확인한다.
+4. 깨끗한 기존 checkout에서 최신 `upstream/devel`을 fetch하고 이슈 전용 브랜치를 만든다.
+5. 수행계획에 관련 이슈 disposition과 아래 7축 진단 매트릭스를 포함하고 메인테이너 승인을 받는다.
+
+원격 push, PR 생성, GitHub 코멘트와 이슈 종료는 일반
+[문서와 Git 워크플로우](codex/docs_and_git_workflow.md)의 승인 경계를 유지한다.
+
+## 2. 필수 진단 매트릭스
+
+| 축 | 필수 기록 |
+| --- | --- |
+| 환경 | OS, browser/version, Local Font Access 권한, renderer backend, snapshot version·generation |
+| 원문 | document family, 언어 slot, style/weight, HWPX `substFont`, embedded font 여부 |
+| 열거 | family/full/PostScript/style, localized alias, `FontData.blob()` 가능 여부 |
+| probe | raw FontFace/local 또는 raw Canvas 결과, test vector, exact/fallback 폭, 모호성 |
+| 선택 | 아래 상태 분류, 실제 CSS chain 또는 Typeface key, 선택 provenance |
+| backend | Canvas2D effective font·폭, CanvasKit SFNT/typeface 여부, native/portable fallback |
+| oracle | 한컴·PDF producer/version, 설치 글꼴과 hash, 쪽수·대표 glyph·첫 발산 지점 |
+
+진단 결과는 이슈별 조사 문서에 보존한다. 반복 가능한 절차는 이 문서에, 장기 기술 계약은
+`font_fallback_strategy.md`에 승격한다.
+
+### 2.1 선택 상태 분류
+
+| 상태 | 의미 |
+| --- | --- |
+| `exact-enumerated` | 열거된 face의 exact/localized alias와 style까지 일치 |
+| `exact-probed` | 열거에는 없지만 문서의 정확한 이름을 raw Canvas/FontFace가 사용 가능 |
+| `alias-only` | family/full/PostScript 중 일부 이름으로만 연결되며 동일 face 근거가 있음 |
+| `style-collapsed` | family는 있으나 요청 style/weight가 다른 face로 뭉개짐 |
+| `fallback-only` | exact face가 없고 문서 대체 또는 portable fallback만 사용 |
+| `ambiguous` | probe 폭이 fallback과 구분되지 않거나 동일 face 근거가 부족 |
+
+`exact-probed`는 Canvas2D 사용 가능 상태일 뿐 CanvasKit 사용 가능 상태가 아니다.
+
+## 3. 감지 실패 유형별 확인 순서
+
+### 3.1 Local Font Access
+
+API 함수의 존재, 성공 응답, 큰 결과 count를 전체 설치 글꼴 목록의 완전성으로 간주하지 않는다.
+
+1. 문서 후보를 열거 record의 family/full/PostScript/style/localized alias와 대조한다.
+2. 해소되지 않은 후보만 raw Canvas presence probe로 확인한다.
+3. raw probe는 제품이 패치한 `CanvasRenderingContext2D.font` setter를 통과하지 않아야 한다.
+4. 양성·음성·모호 후보를 감지 세대에 저장하고 같은 세대에서 반복 측정하지 않는다.
+5. 새 문서에 아직 확인하지 않은 후보가 있거나 사용자가 명시적으로 재감지할 때만 새 세대를 만든다.
+
+### 3.2 이름과 style
+
+- family가 있다는 이유로 Light/Medium/Bold 또는 variable font axis를 임의 선택하지 않는다.
+- SFNT name table의 Unicode family, typographic family, subfamily, full name, PostScript name을 함께
+  기록한다.
+- 지역화 이름과 영문 이름은 같은 바이너리의 name table 또는 공인 배포 근거가 있을 때만 alias로
+  연결한다.
+- successor font는 일반 문자열 alias가 아니라 대상 legacy 이름에만 적용하는 curated mapping으로
+  둔다. 메트릭이 다르면 하나의 layout profile로 합치지 않는다.
+
+### 3.3 backend
+
+- Canvas2D는 브라우저가 CSS 이름으로 face를 찾으면 원본 파일 bytes 없이 그릴 수 있다.
+- CanvasKit은 실제 SFNT bytes와 style별 Typeface가 필요하다. `FontData.blob()` 실패 또는
+  `exact-probed`를 local Typeface 성공으로 보고하지 않는다.
+- native/WASM 레이아웃 메트릭, Canvas2D paint, CanvasKit glyph는 각각 따로 판정한다.
+- 한 backend의 성공으로 다른 backend나 페이지네이션을 완료 처리하지 않는다.
+
+## 4. RED fixture 최소 분할
+
+폰트 감지 코드를 변경할 때 최소한 다음 상태를 자동 테스트한다.
+
+1. Local Font Access 미지원
+2. API 지원 + exact face 열거
+3. API 지원 + family/alias만 열거하고 요청 style face 누락
+4. API 지원 + 문서 후보 전체 누락, raw Canvas exact face 사용 가능
+5. 메타데이터 열거 성공 + `FontData.blob()` 실패
+6. raw candidate와 fallback 폭을 구분할 수 없는 모호 결과
+7. 오래된 snapshot에 새 문서 후보가 없는 상태
+
+브라우저 버전 변화로 자연 재현이 사라질 수 있으므로 3·4번은 mock 또는 CDP 하니스로 강제한다.
+글자별 render/measure hot path에서 probe가 호출되지 않는지 호출 횟수도 고정한다.
+
+## 5. 검증 자산 경계
+
+- 공개 재배포가 허용된 폰트만 저장소 fixture·asset 후보로 검토한다.
+- 상용·사내·재배포 불명 폰트는 저장소 밖 `ttfs/` 경로에서 사용하고 파일 hash, name table 요약,
+  라이선스 출처만 기록한다.
+- 폰트 바이너리, private HWP/HWPX, 비공개 corpus와 식별 가능한 파일 목록은 PR에 첨부하지 않는다.
+- PDF oracle에는 입력 hash, 한컴 버전, PDF producer, 설치 글꼴 목록과 hash를 함께 기록한다.
+- missing-font PDF와 exact-font PDF를 같은 정답지로 섞지 않는다.
+
+## 6. 검증 게이트
+
+### Studio 감지·Canvas2D만 변경
+
+```bash
+cd rhwp-studio
+node tests/local-fonts.test.ts
+node tests/document-font-status.test.ts
+node tests/font-substitution.test.ts
+npx tsc --noEmit
+npm test
+npm run build
+```
+
+실제 설치 face 검증은 [CDP 가이드](e2e-cdp.md)에 따라 호스트 Chrome에서 실행한다.
+
+```bash
+cd rhwp-studio
+CHROME_CDP=http://localhost:19222 npm run e2e:issue-4741
+```
+
+보고에는 raw/patched effective font, 대표 문자열 폭과 delta, browser/version, snapshot provenance,
+probe/cache 횟수를 남긴다. E2E가 localStorage를 임시 변경하면 기존 값을 백업하고 종료 전에 복원한다.
+
+### CanvasKit·renderer·layout까지 변경
+
+[로컬 사전 검증](pr_review/local_validation.md)의 변경 범위별 게이트를 추가한다. Rust/WASM 변경이
+있으면 focused test, release-test, Native Skia, wasm-pack build와 필요한 시각 증적을 수행한다.
+쪽수·geometry가 변하면 HWP/HWPX와 provenance가 고정된 PDF를 함께 대조하고 최종 시각 판정은
+메인테이너가 한다.
+
+## 7. 관련 이슈 인계 게이트
+
+계획서의 모든 관련 이슈를 다음 중 하나로 분류한다.
+
+| disposition | 조건 |
+| --- | --- |
+| `포함` | 이번 구현과 수용 기준에서 완료 |
+| `제외-후속 담당` | 범위 밖이지만 이슈·담당자·다음 행동이 정해짐 |
+| `차단` | 외부 조건 또는 선행 작업과 해제 조건이 명시됨 |
+| `대체됨` | 다른 이슈/PR이 같은 수용 기준을 충족했다는 증거가 있음 |
+
+다음 두 시점에 GitHub 상태를 다시 조회한다.
+
+1. **PR 생성 전**: 관련 이슈의 담당자, 연결 open PR, 남은 수용 기준, PR 본문의 `Refs`/`Closes`
+   대상을 확인한다.
+2. **merge 후**: 자동 종료 결과와 실제 산출물을 대조한다. 잔여가 있으면 이슈를 open으로 유지하고
+   담당자·다음 작업을 명시한다.
+
+“후속에서 처리”라는 문장만 남기고 담당자 없는 open 이슈로 방치하지 않는다. 반대로 계획이나 일부
+테스트만 존재하는 상태를 완료로 간주하지 않는다.
+
+## 8. 이슈 조사 기록 템플릿
+
+```markdown
+## 환경
+- OS / browser / backend / permission:
+- snapshot version / generation:
+
+## 원문 face
+- family / full / PostScript / style:
+- embedded / substFont:
+
+## 감지
+- enumeration:
+- raw probe:
+- state: exact-enumerated | exact-probed | alias-only | style-collapsed | fallback-only | ambiguous
+
+## backend 결과
+- Canvas2D effective font / width:
+- CanvasKit SFNT / Typeface:
+- native/WASM metric:
+
+## oracle
+- input/PDF/font hashes and producer:
+- page/glyph/first divergence:
+
+## 관련 이슈 disposition
+- #NNNN: 포함 | 제외-후속 담당 | 차단 | 대체됨 — owner / next action
+```
+
+## 관련 문서
+
+- [Issue #4741 조사](../tech/investigations/issue-4741/README.md)
+- [폰트 fallback 전략](../tech/font_fallback_strategy.md)
+- [시각 검증 거버넌스](verification/visual_verification_governance.md)
+- [PDF/SVG visual sweep](verification/visual_sweep_guide.md)
+- [CDP E2E](e2e-cdp.md)
+- [로컬 사전 검증](pr_review/local_validation.md)

--- a/mydocs/orders/20260815.md
+++ b/mydocs/orders/20260815.md
@@ -88,6 +88,26 @@
   preflight가 실행 중이므로 최신 trailing head의 Actions 통과와 메인테이너의 별도
   merge 승인 전까지 통합하지 않는다.
 
+## Issue #4741 - Local Font Access 부분 열거 보완
+
+- #4739의 의도적 비범위였던 Local Font Access 부분 열거 누락을 후속 처리했다. API 존재를 전체 설치
+  목록의 완전성으로 간주하지 않고, 열거 record로 해소되지 않은 현재 문서 후보만 raw Canvas descriptor로
+  제한적으로 확인한다.
+- snapshot v3은 열거 face와 probe-only face의 provenance, 확인·probe·미해소 후보를 분리한다.
+  probe-only face는 Canvas2D exact chain에만 사용하고 SFNT bytes 없는 CanvasKit Typeface 성공으로
+  가장하지 않는다. 같은 감지 세대에서는 결과를 캐시해 hot path 재측정을 금지한다.
+- focused TypeScript 37/37, `npx tsc --noEmit`, Studio 전체 930 통과·1 skip, production build와
+  E2E manifest 102/102를 통과했다. Chrome 151 CDP의 부분 열거 강제 E2E에서 Local Font Access 1회,
+  raw/patched KoPub 폭 delta 0px와 probe-only CanvasKit bytes `null`을 확인했다.
+- 실제 `samples/2025 행정업무운영 편람(최종).hwp`는 Canvas2D 383쪽을 유지했고 물리 11쪽의
+  `KoPub바탕체 Light` exact face를 확인했다. 메인테이너의 시각 판정도 통과했다.
+- [PR #4802](https://github.com/edwardkim/rhwp/pull/4802)를 Open 생성했고 code candidate
+  `4084c024d`의 CI, CodeQL, Render Diff와 required `Build & Test`가 성공했다. 최신
+  `upstream/devel@bcb65ed68`과의 merge simulation도 충돌 없이 통과했다.
+- collaborator 자체 PR이라 외부 reviewer는 지정하지 않았다. 코드·backend 경계·관련 이슈 인계 판정은
+  [자체검토 기록](../pr/archives/pr_4802_review.md)에 남겼다. review·오늘할일 trailing head의 최신
+  Actions 통과와 메인테이너의 별도 merge 승인 전에는 통합하지 않는다.
+
 ## Issue #3931 - declared 선이월과 저장 fragment 소유권
 
 - 전용 worktree `/tmp/rhwp-3931`의 `task/3931-declared-rowbreak` 브랜치를 당시 원격 최신

--- a/mydocs/plans/task_m100_4741.md
+++ b/mydocs/plans/task_m100_4741.md
@@ -1,0 +1,234 @@
+# 수행계획 — Task M100 #4741
+
+- **이슈**: [#4741](https://github.com/edwardkim/rhwp/issues/4741)
+- **선행 이슈**: [#1328](https://github.com/edwardkim/rhwp/issues/1328),
+  [#2217](https://github.com/edwardkim/rhwp/issues/2217),
+  [#4739](https://github.com/edwardkim/rhwp/issues/4739)
+- **브랜치**: `task/4741-local-font-access-gap-probe`
+- **작업공간**: `/home/edward/mygithub/rhwp`의 현재 checkout
+- **기준 commit**: `upstream/devel` `93805ebb0548a48704a0046262044295aade4bcc`
+- **작성일**: 2026-08-15 KST
+- **원격 상태**: #4741 OPEN, 담당자 `edwardkim`, 연결된 Open PR 없음
+- **절차 상태**: 원인 조사와 수행계획 작성 완료, 메인테이너 구현 승인 대기
+
+## 1. 목표
+
+Local Font Access API가 존재하지만 설치 face 일부를 반환하지 않는 환경에서도, 현재 문서가 실제로
+사용하는 정확한 로컬 face를 Canvas2D가 보존하도록 한다. KoPub 이름 하나를 예외 목록에 더하는 방식이
+아니라 다음 계약을 만든다.
+
+1. API 지원 여부와 열거 결과의 완전성을 서로 다른 상태로 취급한다.
+2. 열거 결과에서 해소되지 않은 **현재 문서 후보만** 원시 Canvas 경로로 제한적으로 확인한다.
+3. 정확한 face와 style을 보존하되, probe만 통과한 face를 SFNT 바이트까지 확보한 것으로 오인하지 않는다.
+4. 감지는 문서 로드·명시적 갱신 경계에서 캐시하고 글자 측정·그리기 hot path에서는 실행하지 않는다.
+5. 같은 종류의 다른 폰트 문제가 발생하면 공통 진단 매트릭스와 후속 이슈 절차로 빠르게 분류한다.
+
+#3931의 표 분할 문턱과 Rust 레이아웃 메트릭은 이 작업에서 변경하지 않는다. KoPub 및 정부상징 폰트
+파일은 `/home/edward/mygithub/ttfs` 아래 외부 검증 자산으로 유지하고 저장소·PR에 포함하지 않는다.
+
+## 2. 기존 처리에서 누락된 이유
+
+### 2.1 최초 설계가 API 지원 여부를 완전성으로 간주했다
+
+#1328은 브라우저를 다음 두 경우로 나눴다.
+
+- Chrome/Edge: 사용자 승인 뒤 `queryLocalFonts()`로 전체 로컬 글꼴 목록을 얻는다.
+- Firefox 등 API 미지원 환경: 현재 문서 후보만 Canvas presence probe로 확인한다.
+
+이 설계가 `detectLocalFonts()`의 `if (Local Font Access) ... else if (candidate probe)` 구조로 구현됐다.
+그 결과 `queryLocalFonts()`가 함수로 존재하는 순간 후보 probe는 실행되지 않는다. 현재 상태 모델도
+`source === 'local-font-access'`이면 `complete: true`로 보고하므로, API가 일부 face를 누락했는지를
+표현할 수 없다.
+
+### 2.2 테스트가 존재·부재 두 분할만 고정했다
+
+기존 테스트는 Local Font Access 정상 열거와 API 미지원 후보 probe를 각각 검증한다. 다음 세 번째
+상태가 없다.
+
+> API는 정상 응답하지만, 응답에 없는 문서 후보를 원시 Canvas는 실제 설치 face로 사용할 수 있음
+
+따라서 Chrome 150에서 `queryLocalFonts()`는 KoPub을 0개 반환하고 raw Canvas는
+`KoPub바탕체 Light`를 사용하는 환경 차이가 회귀 테스트에 들어오지 않았다.
+
+### 2.3 후속 수정의 검증 환경이 결함을 가렸다
+
+#4739는 KoPub serif 분류, 정확한 style face 선택, 첫 paint 이전 snapshot 준비와 단일 repaint를
+고쳤지만 #4741의 불완전 열거 보완은 명시적으로 제외했다. 최종 Chrome 151 환경에서는 KoPub 6개
+face가 모두 열거되어 수정된 정상 경로가 통과했다. 즉 Chrome 150의 음성 조건이 Chrome 151의
+양성 조건으로 바뀌면서 잔여 결함을 자연 재현만으로 확인할 수 없었다.
+
+### 2.4 probe가 제품의 전역 Canvas patch와 분리되지 않았다
+
+`local-fonts.ts`의 probe는 `context.font = ...`를 사용한다. 그러나 `wasm-bridge.ts`는
+`CanvasRenderingContext2D.prototype.font` setter를 전역 패치해 미확인 원본 이름을 fallback
+chain으로 바꾼다. 부분 열거 보완에 기존 probe를 그대로 재사용하면 확인하려는 face가 먼저 치환되어
+fallback을 측정하는 순환이 생길 수 있다.
+
+### 2.5 관련 이슈의 인계 상태를 완료 게이트로 확인하지 않았다
+
+#4739 계획에는 #4741을 후속 범위로 남겼지만, 병합 뒤 관련 이슈마다 담당자·남은 수용 기준·다음
+행동을 재확인하는 공통 절차가 없었다. #4739가 완료된 뒤에도 #4741은 담당자와 연결 PR 없이 OPEN으로
+남았다. 이 문제는 코드 결함과 별개인 운영 누락이며, 재사용 절차에서 함께 막는다.
+
+상세 근거는 [#4741 조사 기록](../tech/investigations/issue-4741/README.md)에 보존한다.
+
+## 3. 범위와 비범위
+
+### 포함
+
+1. Local Font Access 결과와 문서 후보를 병합하는 hybrid 감지 계약
+2. 열거에서 해소되지 않은 정확한 문서 face만 대상으로 하는 원시 Canvas probe
+3. family/full name/PostScript/style 별칭을 고려한 해소 여부 판정
+4. 열거·probe provenance와 완전성 범위를 표현하는 snapshot/state 모델
+5. Canvas2D exact face 우선 chain과 대표 문자열 폭 회귀 테스트
+6. 문서 후보 fingerprint와 감지 세대를 사용하는 bounded cache 및 한 번의 view 갱신
+7. 재사용 가능한 폰트 사고 대응 절차와 진단 매트릭스
+8. #4739에서 이어진 KoPub 및 정부상징 legacy/successor chain의 focused 회귀
+
+### 제외
+
+- KoPub·정부상징·ROKG 및 상용 폰트 바이너리의 저장소 추가·변환·재배포
+- 모든 시스템 글꼴을 background에서 다시 열거하거나 사용자 동의 전에 probe하는 동작
+- probe-positive face에서 얻지 못한 SFNT 바이트를 추정해 CanvasKit에 등록하는 동작
+- #3931의 표 분할 문턱, Rust `font_metrics_data`, 전역 페이지네이션 상수 변경
+- 한글 PDF의 missing-font 대체 글립을 브라우저 로컬 폰트 선택 규칙으로 혼합
+- 모호한 폭 결과를 설치 확정으로 승격하는 휴리스틱
+
+## 4. 구현 원칙
+
+### 4.1 hybrid snapshot
+
+1. 사용자가 승인한 감지에서 `queryLocalFonts()`를 한 번 실행한다.
+2. 응답을 기존 다국어 alias/full/PostScript/style 레코드로 정규화한다.
+3. `candidateFamilies` 중 해당 레코드와 번들 웹폰트로 해소되지 않은 이름만 추린다.
+4. 남은 후보만 원시 Canvas setter로 probe한다.
+5. 양성 후보를 presence-only 레코드로 병합하고 열거 레코드와 provenance를 구분한다.
+
+단일 `source` 값으로 완전성을 과장하지 않는다. snapshot은 최소한 `enumerated`, `probed`,
+`unresolved`, `checkedCandidates`를 구분할 수 있어야 한다. 저장 형식 버전 변경 시 이전 v1/v2
+snapshot을 보수적으로 승격하되, 과거 Local Font Access snapshot을 문서 후보 기준 완전 상태로
+간주하지 않는다.
+
+### 4.2 원시 Canvas probe 격리
+
+제품의 전역 font substitution patch가 설치되기 전 캡처한 원래 descriptor 또는 전용 raw setter
+helper를 사용한다. probe는 `fontFamilyChainForDisplay()`를 통과하지 않아야 한다. 이 계약을 다음
+테스트로 고정한다.
+
+- 전역 patch가 설치된 뒤에도 정확한 후보와 fallback 폭을 raw setter로 측정한다.
+- 후보가 fallback 세 종류와 우연히 같은 폭이면 설치로 확정하지 않고 `ambiguous`로 남긴다.
+- 한글·Latin·숫자 혼합 문자열을 사용하고 모든 비교는 유한값인지 확인한다.
+- probe 횟수는 정규화된 미해소 후보 수와 고정 test vector 수의 곱으로 제한한다.
+
+### 4.3 face 정확도와 backend 경계
+
+- 열거 레코드는 family/full/PostScript/style을 보존하고 Canvas2D CSS chain의 첫 face를 정확히
+  선택한다.
+- probe-only 레코드는 문서가 선언한 정확한 이름만 확인한 것으로 취급한다. 발견하지 못한 alias,
+  style, weight를 추정하지 않는다.
+- CanvasKit은 `FontData.blob()`으로 실제 SFNT 바이트를 얻은 열거 레코드만 local Typeface로
+  등록한다. presence-only 레코드는 Canvas2D에서만 사용하고 CanvasKit은 기존 portable fallback을
+  유지한다.
+- 현재 Rust layout은 local snapshot과 독립이므로 감지 세대가 바뀌어도 HWP/HWPX를 다시 파싱하거나
+  재페이지네이션하지 않는다. Canvas2D view가 브라우저 글꼴로 별도 측정 cache를 보유하는지 먼저
+  확인하고, 실제로 있는 cache만 무효화한 뒤 한 번 repaint한다. #4741의 “레이아웃과 페이지 재계산”
+  기준은 이 구조적 사실에 맞춰 검증 결과에 명시한다.
+
+## 5. 수행 단계
+
+### Stage 1 — RED 계약과 상태 모델
+
+1. Local Font Access가 다른 글꼴은 반환하지만 설치된 문서 후보 하나를 누락하는 mock을 만든다.
+2. 기존 코드에서 후보 probe가 실행되지 않고 정확 face가 snapshot/chain에서 사라지는 RED를 고정한다.
+3. 전역 Canvas patch를 통과한 probe가 fallback을 재측정하는 RED를 고정한다.
+4. snapshot v1/v2 migration과 부분 완전성 표현을 테스트로 설계한다.
+5. KoPub 외에 localized alias, style face 누락, variable/중복 family의 대표 합성 fixture를 추가한다.
+
+### Stage 2 — hybrid 감지와 raw probe
+
+1. 미해소 후보 계산과 bounded raw probe helper를 구현한다.
+2. Local Font Access 레코드와 presence-only 결과를 provenance 손실 없이 병합한다.
+3. 문서 후보 fingerprint, snapshot generation, 명시적 rescan을 cache key와 invalidation 경계로 둔다.
+4. 음성·모호 결과도 같은 세대에서 재측정하지 않되, 새 감지 요청에서는 다시 확인한다.
+5. 권한 거절·API 예외·Canvas 미지원은 기존 portable fallback으로 fail closed한다.
+
+### Stage 3 — Canvas2D 적용과 backend 회귀
+
+1. probe-positive `KoPub바탕체 Light`가 exact first face로 남는 chain을 고정한다.
+2. patched Canvas2D 대표 문자열 폭이 raw exact face 폭과 허용 오차 내에서 일치하게 한다.
+3. 같은 감지 세대에서 toolbar와 visible Canvas2D view를 한 번만 갱신한다.
+4. KoPub Light/Medium/Bold, 정부상징 legacy → ROKG successor → 문서 대체 face 순서를 회귀한다.
+5. CanvasKit의 SFNT byte 보유/미보유 경계를 테스트해 presence-only 결과가 Typeface 등록을 가장하지
+   않게 한다.
+
+### Stage 4 — 반복 가능한 폰트 사고 대응 절차
+
+신규 canonical 가이드 `mydocs/manual/font_incident_response.md`를 만들고
+`mydocs/manual/README.md` 및 `mydocs/tech/font_fallback_strategy.md`에서 연결한다. 가이드에는 다음
+진단 매트릭스를 필수 기록으로 둔다.
+
+| 축 | 필수 기록 |
+| --- | --- |
+| 환경 | OS, browser/version, 권한, backend, snapshot version/generation |
+| 원문 | document family, language slot, style/weight, HWPX `substFont`, embedded 여부 |
+| 열거 | family/full/PostScript/style, localized alias, blob 가능 여부 |
+| probe | raw FontFace/local 또는 raw Canvas 결과, test vector, exact/fallback 폭, 모호성 |
+| 선택 | exact-enumerated / exact-probed / alias-only / style-collapsed / fallback-only / ambiguous |
+| backend | Canvas2D effective chain/폭, CanvasKit SFNT/typeface 여부, portable fallback |
+| oracle | 한컴/PDF producer, 설치 폰트와 hash, 쪽수·대표 glyph·첫 발산 지점 |
+
+후속 이슈 절차는 다음 순서로 고정한다.
+
+1. 기존 이슈·PR·조사 문서와 현재 `devel`의 코드를 교차 확인한다.
+2. 관련 이슈를 `포함 / 제외-후속 담당 / 차단 / 대체됨` 중 하나로 계획서에 분류한다.
+3. RED에는 API 없음뿐 아니라 부분 열거, alias만 열거, style 하나 누락, blob 실패를 포함한다.
+4. 공개 재현 폰트는 regression matrix에 추가하고, 비공개·재배포 불가 바이너리는 외부 경로와 hash만
+   기록한다.
+5. Canvas2D와 CanvasKit의 조달 능력을 분리해 판정하고 한 backend의 성공으로 다른 backend를
+   완료 처리하지 않는다.
+6. PR 생성 전과 merge 후에 관련 이슈를 다시 조회해 담당자, 잔여 수용 기준, 다음 행동을 확인한다.
+7. 후속이 남으면 현재 이슈 완료 코멘트에 범위와 연결 이슈를 명시하고, 담당자 없는 OPEN 상태로
+   방치하지 않는다.
+
+### Stage 5 — 검증과 판정
+
+- focused TypeScript: `local-fonts`, `font-substitution`, `wasm-bridge`, 초기화·상태·repaint 계약
+- `npx tsc --noEmit`
+- 호스트 `npm test`와 `npm run build`
+- Chrome CDP: 자연 열거 결과에 의존하지 않고 `queryLocalFonts()` 일부 누락을 강제한 재현 하니스
+- raw/patched Canvas2D의 exact face, effective chain, 대표 문자열 폭과 probe 호출 횟수 대조
+- 실제 KoPub 설치 환경에서 HWP/HWPX 대표 쪽과 첫 페이지 경계 확인
+- CanvasKit은 열거 face의 SFNT 등록 회귀와 probe-only portable fallback을 각각 확인
+- `git diff --check`, 변경 Markdown의 상대 링크와 manual metadata 확인
+
+변경이 `rhwp-studio`에 한정되면 프로젝트 검증표에 따라 TypeScript, npm test, 실제 browser 동작을
+필수 게이트로 한다. Rust/WASM 소스를 변경하지 않으면 release-test 전체·Native Skia·wasm-pack build는
+필수 범위로 확대하지 않는다. 폰트 선택은 studio 기능 E2E로 검증하되, 페이지 geometry가 실제로
+바뀌면 메인테이너의 HWP/PDF 시각 판정을 추가한다.
+
+## 6. 완료 기준
+
+- Local Font Access의 존재가 snapshot 완전성을 의미하지 않는다.
+- KoPub face가 열거에서 빠져도 문서 후보 raw probe로 exact Canvas2D face가 보존된다.
+- probe가 전역 font substitution patch를 우회하며 hot path에서 반복되지 않는다.
+- Light/Medium/Bold와 localized alias가 임의로 한 family 기본 face에 합쳐지지 않는다.
+- patched Canvas2D 폭이 raw exact face 폭과 정한 허용 오차 내에서 일치한다.
+- CanvasKit은 SFNT bytes 없는 probe-only face를 local Typeface로 오인하지 않는다.
+- 관련 이슈 인계와 폰트 진단 매트릭스가 canonical manual에 반영되고 문서 지도에서 발견 가능하다.
+- #4741의 모든 수용 기준과 관련 이슈 disposition을 PR 준비·merge 후 두 차례 재확인한다.
+
+## 7. 관련 이슈 disposition
+
+| 이슈 | 이번 작업의 판정 |
+| --- | --- |
+| #1328 | 최초 상태 모델의 설계 근거. 부분 열거 계약을 보완하되 종료 상태는 유지 |
+| #2217 | 다국어 alias/SFNT byte 경계 회귀 대상으로 포함. 별도 재개 없음 |
+| #4739 | serif/style/first-paint/repaint 선행 구현. 회귀 대상으로 포함 |
+| #3931 | 페이지 분할 축은 제외. #4741 face 수정 뒤 관찰값만 다시 기록 |
+| #4741 | 본 작업에서 구현·검증·절차화 |
+
+## 8. 승인 요청 지점
+
+이 계획을 메인테이너가 승인한 뒤 Stage 1 RED부터 소스 구현을 시작한다. 계획 승인 전에는 소스,
+테스트, canonical manual을 변경하지 않는다. remote push, PR 생성, GitHub 코멘트·이슈 종료는 각각
+프로젝트 절차에 따른 별도 승인을 받는다.

--- a/mydocs/plans/task_m100_4741.md
+++ b/mydocs/plans/task_m100_4741.md
@@ -9,7 +9,7 @@
 - **기준 commit**: `upstream/devel` `93805ebb0548a48704a0046262044295aade4bcc`
 - **작성일**: 2026-08-15 KST
 - **원격 상태**: #4741 OPEN, 담당자 `edwardkim`, 연결된 Open PR 없음
-- **절차 상태**: 원인 조사와 수행계획 작성 완료, 메인테이너 구현 승인 대기
+- **절차 상태**: 메인테이너 계획 승인, Stage 1~5 구현·자동·Chrome 검증 완료, 원격 처리 승인 대기
 
 ## 1. 목표
 
@@ -229,6 +229,6 @@ helper를 사용한다. probe는 `fontFamilyChainForDisplay()`를 통과하지 �
 
 ## 8. 승인 요청 지점
 
-이 계획을 메인테이너가 승인한 뒤 Stage 1 RED부터 소스 구현을 시작한다. 계획 승인 전에는 소스,
-테스트, canonical manual을 변경하지 않는다. remote push, PR 생성, GitHub 코멘트·이슈 종료는 각각
-프로젝트 절차에 따른 별도 승인을 받는다.
+메인테이너가 계획을 승인한 뒤 Stage 1~5를 수행했고 결과를
+[Stage 5 검증 기록](../working/task_m100_4741_stage5_validation.md)에 남겼다. remote push, PR 생성,
+GitHub 코멘트·이슈 종료는 각각 프로젝트 절차에 따른 별도 승인을 받는다.

--- a/mydocs/pr/archives/pr_4802_review.md
+++ b/mydocs/pr/archives/pr_4802_review.md
@@ -1,0 +1,132 @@
+---
+kind: review
+status: self-review-complete
+pr: 4802
+issue: 4741
+author: edwardkim
+base: devel
+---
+
+# PR #4802 자체검토 — Local Font Access 부분 열거 보완
+
+## 절차 라우팅
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, local_validation.md,
+  visual_fixture_evidence.md, rework_and_exceptions.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+  collaborator_self_merge.md, intake_and_review.md, local_validation.md,
+  visual_fixture_evidence.md, rework_and_exceptions.md
+current code candidate: 4084c024d0f888e02ffd0334d8548031dc939c3a
+```
+
+## PR 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4802](https://github.com/edwardkim/rhwp/pull/4802) |
+| 작성자 | `edwardkim` (collaborator self PR) |
+| base / head | `devel` ← `task/4741-local-font-access-gap-probe` |
+| code candidate | `4084c024d0f888e02ffd0334d8548031dc939c3a` |
+| 작성 시점 최신 devel | `bcb65ed6814d7c7867c05f4bcf9e8d6af9ede0d2` |
+| merge base | `93805ebb0548a48704a0046262044295aade4bcc` |
+| 규모 | 17 files, +1,225/-67, 6 commits |
+| 관련 이슈 | `Closes #4741`; #1328, #2217, #4739 회귀; #3931 별도 조판 축 |
+| 작성 시점 상태 | code candidate `MERGEABLE` / `CLEAN`, Actions 통과 참고값 |
+| 검토 | collaborator 자체검토; 외부 reviewer 미지정 |
+
+1,000줄을 넘는 대형 PR이므로 즉시 admin merge하지 않고 코드 검토, 최신 base simulation,
+focused·시각 검증과 trailing 기록 CI를 별도 cycle로 판정한다. 증분의 절반 이상은 계획·조사·canonical
+manual·검증 기록이며, 제품 변경은 Studio의 local-font 감지와 Canvas2D 접합면에 한정된다.
+
+## 변경 검토
+
+### 부분 열거와 상태 모델
+
+기존 구현은 `queryLocalFonts()`가 존재하면 그 결과를 완전한 목록으로 간주해 문서 후보 probe를
+건너뛰었다. 이 PR은 열거 record와 현재 문서 후보를 대조하고, family/full/PostScript/style alias로
+해소되지 않은 후보만 raw Canvas probe에 보낸다. snapshot v3은 열거 face와 probe-only face의
+`detectionSource`, `checkedFamilies`, `probedFamilies`, `unresolvedFamilies`를 보존한다. v1/v2 저장값은
+과거 Local Font Access 결과를 문서 후보 기준 완료 상태로 과장하지 않고 보수적으로 승격한다.
+
+`complete`를 항상 false로 두되 이미 판정한 후보는 `checkedFamilies`로 구분하므로, 새 문서 후보는 다시
+확인할 수 있고 같은 후보는 반복 prompt·probe하지 않는다. probe 폭이 fallback과 구분되지 않는 경우는
+설치 face로 승격하지 않고 unresolved에 남는다. 같은 감지 세대의 결과는 저장 snapshot과
+`detectedAt` 기반 repaint generation으로 재사용되며 글자 측정·그리기 hot path에는 probe 호출이 없다.
+
+### raw Canvas와 backend 경계
+
+`canvas-font-raw.ts`는 전역 substitution patch 설치 직전 native `font` descriptor를 한 번 보존한다.
+presence probe는 이를 직접 호출해 확인 대상이 먼저 fallback chain으로 치환되는 순환을 피한다. descriptor가
+없는 비표준 Canvas/mock만 기존 property setter로 fail-soft한다.
+
+probe-only record는 문서가 선언한 정확한 face 이름만 갖고 PostScript name이나 SFNT bytes를 추정하지
+않는다. 따라서 Canvas2D chain은 exact face를 첫 항목으로 사용할 수 있지만 CanvasKit의
+`loadLocalFontBytesFor()`는 이 record를 local Typeface로 등록하지 않는다. Local Font Access에서 실제
+열거된 face만 기존 SFNT blob 경로를 사용한다.
+
+개발 모드의 `window.__localFonts` 진단 표면은 제품 singleton과 실제 전역 patch를 E2E에서 관찰하기
+위한 것이며 production build에는 노출되지 않는다. 옵션·권한 모달 문구도 전체 열거와 문서별 누락 후보
+확인을 구분하고, 결과를 로컬 저장소 밖으로 전송하지 않는 경계를 유지한다.
+
+### 범위와 관련 이슈
+
+- #1328은 API 지원/미지원 2분할의 선행 설계로 유지하며 부분 열거를 세 번째 상태로 보완한다.
+- #2217의 localized alias와 SFNT byte 조달 경계를 회귀로 유지한다.
+- #4739의 KoPub serif/style, 첫 paint 이전 snapshot과 단일 repaint를 회귀로 유지한다.
+- #3931의 Rust 페이지 분할 문턱과 전역 metric은 변경하지 않는다.
+- KoPub·정부상징·ROKG 폰트 바이너리는 저장소와 PR에 포함하지 않았다.
+
+작성 시점 재조회에서 #1328, #2217, #3931, #4739는 CLOSED이고 #4741은 `edwardkim` 담당 OPEN이다.
+PR의 `Closes #4741`에 따른 실제 종료와 잔여 조건은 merge 후 다시 확인한다.
+
+## 최신 base simulation
+
+PR 생성 기준 `devel` 뒤에 #3950 IME commit `bcb65ed6814d7c7867c05f4bcf9e8d6af9ede0d2`가
+추가됐다. 두 변경의 파일 교집합은 없고 다음 simulation이 충돌 없이 tree를 만들었다.
+
+```text
+git merge-tree --write-tree upstream/devel 4084c024d0f888e02ffd0334d8548031dc939c3a
+fdb0732a5af3f772682a3ce9f73ffdae12dcb0a6
+```
+
+`git diff --check upstream/devel...HEAD`도 통과했다. review·오늘할일 trailing commit에는 #4802 기록만
+추가하며, 최신 devel의 #4805 오늘할일을 source branch에 복사하지 않는다. trailing head를 만들고 다시
+simulation해 실제 merge tree가 양쪽 기록을 모두 보존하는지 확인한다.
+
+## 완료한 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| 자체검토 focused | local-font, 문서 상태, substitution, modal copy, 초기화 순서 5개 suite 통과 |
+| `npx tsc --noEmit` | 통과 |
+| Stage 5 focused | 세부 TypeScript 계약 37/37 통과 |
+| Stage 5 `npm test` | 931건 중 930 통과, 1 skip, 실패 0 |
+| Stage 5 production build | `npm run build` 통과 |
+| E2E manifest | tracked 102개 / manifest 102행 일치 |
+| Chrome 151 CDP | 부분 열거 강제, LFA 1회, raw/patched KoPub 폭 delta 0px 통과 |
+| 실제 HWP | `samples/2025 행정업무운영 편람(최종).hwp` 383쪽과 물리 11쪽 exact KoPub face 확인 |
+| code candidate Actions | CI, CodeQL, Render Diff 성공; required `Build & Test` 통과 |
+| Markdown / diff | 상대 링크·metadata 검사와 `git diff --check` 통과 |
+
+Rust/renderer/WASM 소스, fixture, golden, baseline을 바꾸지 않았으므로 Cargo·Native Skia·wasm-pack 전체
+재빌드는 범위에서 제외했다. 동일 code candidate에서 로컬 Studio 전체 검증과 GitHub의 frontend package
+gate가 성공했으므로 자체검토에서는 이를 재사용하고 focused 계약과 TypeScript 검사를 반복했다.
+
+시각 판단은 pixel visual sweep이 아니라 실제 Windows Chrome의 Canvas2D face·폭·383쪽 경계와
+메인테이너의 화면 판정으로 수행했다. 따라서 임시 compare/overlay/review PNG나 별도 PR asset은 없다.
+Render Diff의 Canvas visual diff도 같은 code candidate에서 성공했다.
+
+## 위험과 판정
+
+- Canvas 폭 probe는 여러 text/fallback에서도 exact face와 fallback이 구분되지 않으면 false negative가
+  될 수 있다. 이 경우 설치를 오탐하지 않고 unresolved로 남겨 portable fallback을 유지한다.
+- probe-only face는 CanvasKit SFNT 조달 능력을 뜻하지 않는다. backend별 상태를 합치지 않은 현재 경계를
+  유지해야 한다.
+- snapshot의 checked 후보는 사용자 승인 감지 시점의 결과다. 명시적 rescan은 새 generation을 만들고,
+  같은 generation은 hot path에서 재측정하지 않는다.
+
+코드·테스트·문서 검토에서 merge를 막는 finding은 발견하지 못했다. review·오늘할일 trailing head의 최신
+required checks가 모두 통과하고 `MERGEABLE` / `CLEAN` 및 exact head SHA를 다시 확인한 뒤, 메인테이너가
+merge를 별도로 승인하면 squash merge를 권고한다.

--- a/mydocs/tech/font_fallback_strategy.md
+++ b/mydocs/tech/font_fallback_strategy.md
@@ -2,7 +2,7 @@
 kind: canonical
 status: active
 canonical: mydocs/tech/font_fallback_strategy.md
-last_verified: 2026-07-16
+last_verified: 2026-08-15
 ---
 
 # CJK 폰트 폴백 전략 보고서
@@ -12,6 +12,9 @@ last_verified: 2026-07-16
 > 2026-07-17 현행화: canonical 웹폰트 source는 `assets/fonts/`이며, Git 추적 WOFF2는 36개
 > (22,651,296 bytes)다. Studio의 runtime `fonts/...` URL과 이 문서의 fallback 정책은 변경하지 않았다.
 > 아래 2026-04-07 로드맵·권장안의 `web/fonts` 표현은 당시 구현 경로를 설명하는 기록으로 보존한다.
+>
+> 2026-08-15 현행화: Local Font Access API의 성공 응답은 설치 face 전체 열거를 보장하지 않는다.
+> 문서 후보 coverage와 Canvas2D/CanvasKit 조달 능력을 분리하는 hybrid 감지 계약을 6.2에 반영했다.
 
 ## 목차
 
@@ -386,17 +389,27 @@ async function getSystemFonts(): Promise<Set<string>> {
 **장점**: 시스템 설치 폰트 전체 목록 확보
 **단점**: Chrome 전용, 사용자 권한 요청 필요
 
-### 6.2 권장 감지 전략
+### 6.2 현행 hybrid 감지 전략
 
 ```
-문서 로드 시:
-  1. HWP 문서에서 사용된 폰트 목록 추출
-  2. 각 폰트에 대해 document.fonts.check() 또는 measureText 비교로 감지
-  3. 사용 가능 → 그대로 사용
-  4. 사용 불가 → 대체 매핑 테이블에서 오픈소스 폰트 결정
-  5. 오픈소스 폰트 woff2 로드 → FontFace API로 등록
-  6. Canvas ctx.font에 최종 폰트명 설정
+사용자 승인 뒤 감지 세대마다:
+  1. HWP/HWPX 문서의 exact face 후보 추출
+  2. Local Font Access 지원 시 목록을 한 번 열거하고 family/full/PostScript/style/지역화 이름 정규화
+  3. 열거 record와 번들 exact face로 해소되지 않은 문서 후보만 raw Canvas presence probe
+  4. 열거 face, probe-positive face, 확인했지만 미해소인 후보를 provenance와 함께 snapshot에 저장
+  5. 같은 감지 세대에서는 결과 재사용 — glyph/measure hot path에서 probe 금지
+  6. Canvas2D는 exact-enumerated 또는 exact-probed face를 CSS chain 앞에 배치
+  7. CanvasKit은 FontData.blob()으로 SFNT bytes를 얻은 exact-enumerated face만 Typeface로 등록
+  8. 나머지는 문서 대체 face → 공개 웹폰트 → portable generic 순서로 fallback
 ```
+
+`queryLocalFonts()` 함수의 존재, 성공, 결과 count는 문서 후보에 대한 완전성 증거가 아니다. 제품이
+`CanvasRenderingContext2D.font` setter를 패치하는 경우 presence probe는 패치 전 원시 descriptor 또는
+격리 realm을 사용해야 한다. `exact-probed`는 CSS Canvas2D 사용 가능 상태이며 SFNT bytes를 확보한
+상태가 아니므로 CanvasKit local Typeface 성공으로 승격하지 않는다.
+
+진단 매트릭스, RED fixture 분할, 검증 자산과 관련 이슈 인계 절차는
+[폰트 감지·대체 사고 대응 절차](../manual/font_incident_response.md)를 따른다.
 
 ### 6.3 font-loader.ts 개선안
 

--- a/mydocs/tech/investigations/README.md
+++ b/mydocs/tech/investigations/README.md
@@ -54,3 +54,4 @@ last_verified: 2026-08-15
 - [Issue #2392 picture props apply 계약 조사](issue-2392/README.md)
 - [Issue #3486 HWP3 렌더링 정합 조사](issue-3486/README.md)
 - [Issue #4739 정부상징 폰트 후계·대체 조사](issue-4739/README.md)
+- [Issue #4741 Local Font Access 부분 열거 누락 조사](issue-4741/README.md)

--- a/mydocs/tech/investigations/issue-4741/README.md
+++ b/mydocs/tech/investigations/issue-4741/README.md
@@ -1,0 +1,142 @@
+---
+kind: investigation
+status: active
+canonical: mydocs/tech/font_fallback_strategy.md
+last_verified: 2026-08-15
+---
+
+# Issue #4741 — Local Font Access 부분 열거 누락 조사
+
+## 결론
+
+#4741은 KoPub 이름 목록이 빠진 문제가 아니라 로컬 글꼴 감지 상태 모델의 세 번째 경우가 누락된
+문제다.
+
+| 상태 | 기존 모델 | 필요한 모델 |
+| --- | --- | --- |
+| API 지원, 후보 열거됨 | Local Font Access complete | exact-enumerated |
+| API 미지원 | 문서 후보 Canvas probe | exact-probed 또는 unresolved |
+| **API 지원, 후보 일부 누락** | **complete로 오판, probe 생략** | **미해소 후보만 raw probe** |
+
+Chrome 150 재현에서는 `queryLocalFonts()`가 748개를 반환했지만 KoPub은 0개였고, raw FontFace와
+Canvas2D는 설치된 `KoPub바탕체 Light`를 사용했다. 따라서 함수 존재와 성공 응답만으로 문서 후보에
+대한 완전성을 주장할 수 없다.
+
+## 확인한 코드 경로
+
+### `local-fonts.ts`
+
+- `DetectLocalFontsOptions.candidateFamilies`는 “Local Font Access API가 없는 브라우저” 전용으로
+  문서화되어 있다.
+- `detectLocalFonts()`는 `isLocalFontAccessSupported()`가 참이면 열거 snapshot만 만들고,
+  후보 probe는 `else if`에서만 실행한다.
+- `getLocalFontState()`는 snapshot source가 `local-font-access`이면 `complete: true`로 반환한다.
+- Canvas probe는 `context.font = ...`로 후보와 fallback 폭을 비교한다.
+
+이 분기는 `3f9595c0c`(`Task #1328: Stage 1 local font state model`)에서 도입됐다. 이후 #2217의
+다국어 이름·style 레코드 보강은 열거된 `FontData`의 품질을 개선했지만, 열거되지 않은 설치 face를
+발견하는 분기 자체는 바꾸지 않았다.
+
+### `wasm-bridge.ts`
+
+`installCanvasFontSubstitution()`은 `CanvasRenderingContext2D.prototype.font` descriptor를 바꿔
+모든 setter 입력에 `fontFamilyChainForDisplay()`를 적용한다. 원래 descriptor는 함수 closure 안에만
+남는다. 이 patch 설치 후 일반 `context.font = ...`로 presence probe를 수행하면 미확인 후보가 먼저
+fallback으로 치환될 수 있다.
+
+따라서 부분 열거 보완은 기존 probe 호출 조건만 넓혀서는 안 된다. 원래 descriptor의 setter를
+명시적으로 쓰거나 제품 patch와 격리한 raw Canvas 계약이 필요하다.
+
+## 문서·테스트에서 확인한 누락 경로
+
+### #1328의 설계 전제
+
+계획과 작업 기록은 Chrome/Edge에서 Local Font Access 전체 목록, Firefox에서 문서 후보 probe라는
+플랫폼 이분법을 반복한다. “API가 존재하지만 일부 설치 face가 빠짐”은 상태·위험·수용 기준에 없다.
+
+### 단위 테스트의 partition gap
+
+현재 `local-fonts.test.ts`에는 `queryLocalFonts = undefined`일 때 문서 후보만 probe snapshot으로
+저장하는 테스트가 있다. API가 빈 배열이나 다른 face만 반환하면서 raw Canvas에서는 후보를 사용할 수
+있는 테스트는 없다.
+
+### #4739의 의도적 비범위와 환경 이동
+
+#4739 계획은 불완전 `queryLocalFonts()` 보완을 제외하고 구현 뒤 남는 재현을 #4741에서 처리한다고
+명시했다. #4739 최종 검증의 Chrome 151은 KoPub 6개 face를 모두 snapshot에 제공했다. Chrome 150의
+부분 열거 음성 조건이 없어졌으므로, 정상 환경 E2E만으로는 #4741 잔여를 검출할 수 없었다.
+
+### 운영 인계 누락
+
+#4739가 merge된 뒤 #4741은 OPEN이었지만 담당자와 연결 PR이 없었다. 선행 계획의 비범위 표시는
+기술적 분리에는 성공했으나, merge 후 관련 이슈를 재조회해 owner와 next action을 고정하는 절차가
+없어 후속 처리가 자동으로 이어지지 않았다.
+
+## 다른 폰트에 재발할 수 있는 유형
+
+| 유형 | 예 | 잘못된 완료 신호 | 필요한 판정 |
+| --- | --- | --- | --- |
+| 부분 열거 | KoPub이 LFA 결과에 없지만 raw Canvas 사용 가능 | API 성공, count가 큼 | 문서 후보 exact raw probe |
+| 지역화 이름 | `08서울한강체 M` 대 `08SeoulHangang M` | family 하나가 열거됨 | name table alias/full/PostScript 대조 |
+| style face 누락 | Light만 빠지고 Regular/Bold만 열거 | family 존재 | style/weight별 face 해소 |
+| family 선점 | custom loader가 Regular 하나로 Bold까지 처리 | glyph가 보임 | backend별 style matching |
+| variable font 축 소실 | family는 같으나 weight/width 축 붕괴 | 동일 family 문자열 | axes와 실제 face key 분리 |
+| blob 실패 | 메타데이터는 있으나 `FontData.blob()` 불가 | Canvas2D 성공 | CanvasKit SFNT 조달을 별도 판정 |
+| probe 모호성 | 후보 폭이 fallback 폭과 우연히 동일 | width delta 0 | 여러 vector/fallback, ambiguous 유지 |
+| 전역 patch 순환 | probe 입력이 먼저 fallback으로 치환 | probe가 실행됨 | raw setter/격리 realm 증명 |
+| stale snapshot | 다른 browser/version 결과 재사용 | 저장 snapshot 존재 | version/generation/candidate scope 확인 |
+| fallback 분류 오판 | `바탕체`를 monospace로 분류 | chain이 유효 CSS | 분류와 exact face를 별도 검증 |
+
+## backend 경계
+
+Canvas2D와 CanvasKit은 로컬 폰트를 조달하는 능력이 다르다.
+
+- Canvas2D는 브라우저가 CSS 이름으로 face를 해석하면 실제 TTF/OTF 바이트 없이 그릴 수 있다.
+- CanvasKit은 local Typeface 등록에 SFNT 바이트가 필요하다. raw Canvas probe 양성만으로 바이트를
+  만들거나 `FontData.blob()` 성공을 추정할 수 없다.
+- 따라서 `exact-probed`는 Canvas2D 사용 가능 상태이며 CanvasKit 사용 가능 상태가 아니다.
+
+한 backend의 성공을 다른 backend 완료 근거로 사용하면 #2206/#2217에서 이미 분리했던
+“레이아웃 메트릭, 이름 해소, 실제 glyph typeface” 축이 다시 섞인다.
+
+## 재현과 검증에 필요한 상태 매트릭스
+
+향후 폰트 이슈는 최소한 다음 네 열거 fixture를 갖는다.
+
+1. API 미지원
+2. API 지원 + exact face 열거
+3. API 지원 + family/alias만 열거하고 style face 누락
+4. API 지원 + 후보 전체 누락, raw Canvas exact face 사용 가능
+
+각 fixture에서 다음 결과를 함께 기록한다.
+
+- snapshot source와 candidate coverage
+- exact/alias/style 해소 결과와 provenance
+- raw Canvas와 patched Canvas의 effective font/폭
+- probe 호출 횟수와 cache generation
+- CanvasKit SFNT bytes/Typeface 등록 여부
+- fallback chain과 unresolved/ambiguous 이유
+
+브라우저 버전 변화로 자연 재현이 사라질 수 있으므로 3·4번은 CDP 실행 환경에서도 test harness로
+강제할 수 있어야 한다. 실제 환경 관찰만으로 회귀 게이트를 대신하지 않는다.
+
+## 장기 절차로 승격할 항목
+
+이 조사에서 확정한 다음 절차는 #4741 구현 단계에서
+`mydocs/manual/font_incident_response.md`로 승격한다.
+
+1. 환경·원문·열거·probe·선택·backend·oracle의 7축 진단 매트릭스
+2. 부분 열거·localized alias·style 누락·blob 실패를 포함한 RED fixture
+3. 공개 폰트와 비공개/재배포 불가 폰트의 자산 경계
+4. 관련 이슈 disposition과 PR 전·merge 후 owner/next-action 재확인
+
+감지 및 fallback의 장기 기술 계약은
+[`font_fallback_strategy.md`](../../font_fallback_strategy.md)에 반영하고, 이 문서는 #4741 당시의
+원인과 증거를 보존한다.
+
+## 관련 문서
+
+- [#4741 수행계획](../../../plans/task_m100_4741.md)
+- [#4739 조사](../issue-4739/README.md)
+- [폰트 fallback 전략](../../font_fallback_strategy.md)
+- [Studio CDP 가이드](../../../manual/e2e-cdp.md)

--- a/mydocs/working/task_m100_4741_stage5_validation.md
+++ b/mydocs/working/task_m100_4741_stage5_validation.md
@@ -1,0 +1,110 @@
+# Task M100 #4741 Stage 5 — 부분 열거·Canvas2D·절차 검증
+
+## 범위
+
+Local Font Access API가 설치 face 일부를 누락하는 상태를 강제하고, 문서 후보 raw probe와 snapshot
+provenance, exact Canvas2D face, cache, CanvasKit 조달 경계와 편람 페이지 경계를 검증했다. 변경은
+`rhwp-studio` TypeScript와 E2E 및 문서에 한정되며 Rust/renderer/WASM 소스는 바꾸지 않았다.
+
+## 자동 검증
+
+- focused TypeScript 37/37 통과
+  - `local-fonts.test.ts` 15/15
+  - `document-font-status.test.ts` 5/5
+  - `font-substitution.test.ts` 9/9
+  - `local-fonts-modal-copy.test.ts` 2/2
+  - `document-initialization-order.test.ts` 6/6
+- `npx tsc --noEmit`: 통과
+- 호스트 `npm test`: 931건 중 930 통과, 1 skip, 실패 0
+- `npm run build`: 통과
+- `python3 scripts/check_e2e_manifest.py`: tracked 102개와 manifest 102행 일치
+- `git diff --check`: 통과
+- 변경 Markdown 상대 링크 검사: 이상 없음
+- 문서 메타데이터 검사: 560개 이상 없음
+
+Rust/WASM 소스 변경이 없으므로 release-test 전체, Native Skia, wasm-pack 재빌드는 이번 변경 범위의
+필수 게이트로 확대하지 않았다. production Studio build는 기존 `pkg/` WASM을 포함해 성공했다.
+
+## 호스트 Chrome CDP
+
+- Windows 11 Chrome `151.0.7922.138`, CDP 1.3
+- Vite `http://localhost:7700`
+- 실행:
+
+```bash
+cd rhwp-studio
+CHROME_CDP=http://localhost:19222 npm run e2e:issue-4741
+```
+
+테스트 탭의 `queryLocalFonts()`만 다음 부분 결과로 강제했다.
+
+- 열거됨: `Issue4741 Enumerated Control Regular`
+- 열거 누락·실제 설치: `KoPub바탕체 Light`
+- 열거 누락·미설치 대조군: `Issue4741 Missing Control`
+
+결과:
+
+| 항목 | 결과 |
+| --- | --- |
+| Local Font Access 호출 | 최초 1회, 같은 감지 세대 재호출 0회 |
+| KoPub record provenance | `font-presence-probe` |
+| snapshot | v3, checked 2, probed 1, unresolved 1 |
+| raw effective font | `72px "KoPub바탕체 Light"` |
+| patched effective font | exact KoPub face → proportional serif fallback |
+| 대표 문자열 raw 폭 | `2003.3277587890625px` |
+| 대표 문자열 patched 폭 | `2003.3277587890625px` |
+| 폭 delta | `0px` |
+| probe-only CanvasKit bytes | `null`, 추가 Local Font Access 호출 없음 |
+
+전역 Canvas font substitution patch가 설치된 상태에서도 probe는 보존한 raw descriptor를 사용했다.
+단위 테스트 mock에서 patched setter 호출은 0이고 raw setter 호출은 후보 수와 고정 vector의 상한 안에
+머물렀다.
+
+## 편람 HWP 실제 경계
+
+정확한 샘플 경로는 저장소의
+`samples/2025 행정업무운영 편람(최종).hwp`이며, Vite의 percent-encoded `/samples/...` URL로
+10,687,488 bytes를 가져왔다. Windows Chrome에 WSL 절대경로를 넘기지 않았다.
+
+- backend: Canvas2D
+- 페이지 수: 383
+- 물리 11쪽으로 이동한 뒤 `KoPub바탕체 Light` 지정 2,104회를 수집
+- 대표 요청은 style별 exact face를 포함한 Rust chain
+- 제품 patch 뒤 effective font는
+  `16px "KoPub바탕체 Light", Batang, AppleMyungjo, "Noto Serif KR", serif`
+- `GulimChe`와 `monospace` 없음
+
+Rust 페이지네이션은 local snapshot과 독립이므로 문서를 다시 파싱하거나 재페이지네이션하지 않았다.
+편람 383쪽 경계가 유지됐고 Canvas2D paint face만 exact local face로 해소됐다.
+
+## E2E 격리와 복구
+
+초기 하니스는 Vite 동적 import가 app과 다른 module instance를 만들 수 있어 제품 singleton의 font
+chain을 관찰하지 못했다. 개발 모드 `window.__localFonts` 진단 표면을 app singleton에 연결해 실제
+전역 patch 경로를 검증하도록 정정했다.
+
+하니스 작성 중 7700 origin의 저장 snapshot을 초기화한 사실을 발견한 즉시 실제 Chrome Local Font
+Access와 문서 후보로 snapshot을 재생성했다. 최종 하니스는 원래 `rhwp-local-fonts` 값을 백업하고
+종료 전에 복원한다. 최종 실행 뒤 읽기 전용 확인 결과는 다음과 같다.
+
+- snapshot v3
+- `detectedAt`: `2026-08-15T07:51:13.300Z`
+- 375 face family record
+- `KoPub바탕체 Light` exact record 존재
+
+테스트 탭은 종료됐으며 메인테이너의 다른 Chrome 탭을 닫거나 변경하지 않았다.
+
+## 문서화
+
+- [폰트 감지·대체 사고 대응 절차](../manual/font_incident_response.md)
+- [폰트 fallback 전략](../tech/font_fallback_strategy.md) 6.2 hybrid 감지 계약
+- [#4741 원인 조사](../tech/investigations/issue-4741/README.md)
+
+다른 폰트 이슈에서는 환경·원문·열거·probe·선택·backend·oracle 7축 매트릭스와
+`포함 / 제외-후속 담당 / 차단 / 대체됨` disposition을 사용한다. PR 생성 전과 merge 후 관련 이슈의
+담당자·잔여 수용 기준·다음 행동을 다시 조회한다.
+
+## 판정
+
+#4741의 구현·자동 검증·Chrome 기능 검증과 페이지 경계 확인은 통과했다. remote push, PR 생성,
+GitHub 코멘트와 이슈 종료는 아직 수행하지 않았다.

--- a/rhwp-studio/e2e/MANIFEST.md
+++ b/rhwp-studio/e2e/MANIFEST.md
@@ -72,6 +72,7 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `issue-4272-nested-table-object-copy.test.mjs` | 상시 | active | #4272 물리 5쪽 3중 중첩 표 객체 선택의 owner path·control index 분리와 Ctrl+C 검증 | basic/issue2007_nested_cell_pagination_42065.hwp | npm e2e:issue-4272-table-copy | `output/4272/nested-table-object-copy.{json,png}` |
 | `issue-4272-nested-cell-text-selection.test.mjs` | 상시 | active | #4272 중첩 표 안쪽 셀의 전체 cellPath 선택 rect, 실제 마우스 드래그와 Ctrl+C/V | basic/issue2007_nested_cell_pagination_42065.hwp | npm e2e:issue-4272 | 물리 5쪽 `23,504`, `output/4272/nested-cell-*.{json,png}` |
 | `issue-536-boxed-pua-canvas2d.test.mjs` | 상시 | active | #536 실제 HWP의 사각 안 숫자 PUA를 기본 Canvas2D가 결정적으로 합성 | basic/issue2007_nested_cell_pagination_42065.hwp | npm e2e:issue-536 | #4122 17쪽 pagination stack 계약 포함 |
+| `local-font-partial-enumeration-issue4741.test.mjs` | 상시 | active | #4741 Local Font Access 부분 열거를 강제해 raw probe·exact Canvas2D face·폭·cache 계약 검증 | — | npm e2e:issue-4741 | KoPub바탕체 Light 설치 호스트 Chrome 전용 |
 | `issue-595.test.mjs` | 진단 | hold | Issue #595 진단 e2e | exam_math.hwp | 수동 | legacy-name · #595 진단 (assertion 0) |
 | `line-spacing.test.mjs` | 상시 | active | 줄간격 변경에 따른 페이지 넘김 검증 | — | 수동 |  |
 | `navigation-shortcuts.test.mjs` | 상시 | active | 플랫폼별 navigation shortcut | — | 수동 |  |

--- a/rhwp-studio/e2e/MANIFEST.md
+++ b/rhwp-studio/e2e/MANIFEST.md
@@ -72,7 +72,7 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `issue-4272-nested-table-object-copy.test.mjs` | 상시 | active | #4272 물리 5쪽 3중 중첩 표 객체 선택의 owner path·control index 분리와 Ctrl+C 검증 | basic/issue2007_nested_cell_pagination_42065.hwp | npm e2e:issue-4272-table-copy | `output/4272/nested-table-object-copy.{json,png}` |
 | `issue-4272-nested-cell-text-selection.test.mjs` | 상시 | active | #4272 중첩 표 안쪽 셀의 전체 cellPath 선택 rect, 실제 마우스 드래그와 Ctrl+C/V | basic/issue2007_nested_cell_pagination_42065.hwp | npm e2e:issue-4272 | 물리 5쪽 `23,504`, `output/4272/nested-cell-*.{json,png}` |
 | `issue-536-boxed-pua-canvas2d.test.mjs` | 상시 | active | #536 실제 HWP의 사각 안 숫자 PUA를 기본 Canvas2D가 결정적으로 합성 | basic/issue2007_nested_cell_pagination_42065.hwp | npm e2e:issue-536 | #4122 17쪽 pagination stack 계약 포함 |
-| `local-font-partial-enumeration-issue4741.test.mjs` | 상시 | active | #4741 Local Font Access 부분 열거를 강제해 raw probe·exact Canvas2D face·폭·cache 계약 검증 | — | npm e2e:issue-4741 | KoPub바탕체 Light 설치 호스트 Chrome 전용 |
+| `local-font-partial-enumeration-issue4741.test.mjs` | 상시 | active | #4741 Local Font Access 부분 열거를 강제해 raw probe·exact Canvas2D face·폭·cache·편람 383쪽 계약 검증 | 2025 행정업무운영 편람(최종).hwp | npm e2e:issue-4741 | KoPub바탕체 Light 설치 호스트 Chrome 전용 |
 | `issue-595.test.mjs` | 진단 | hold | Issue #595 진단 e2e | exam_math.hwp | 수동 | legacy-name · #595 진단 (assertion 0) |
 | `line-spacing.test.mjs` | 상시 | active | 줄간격 변경에 따른 페이지 넘김 검증 | — | 수동 |  |
 | `navigation-shortcuts.test.mjs` | 상시 | active | 플랫폼별 navigation shortcut | — | 수동 |  |

--- a/rhwp-studio/e2e/local-font-partial-enumeration-issue4741.test.mjs
+++ b/rhwp-studio/e2e/local-font-partial-enumeration-issue4741.test.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+/**
+ * Issue #4741 — Local Font Access가 설치 face를 누락해도 문서 후보 raw probe가 exact
+ * Canvas2D face와 폭을 보존한다.
+ *
+ * KoPub바탕체 Light가 설치된 호스트 Chrome에서 실행한다. queryLocalFonts는 이 테스트 탭에서만
+ * 의도적으로 부분 결과를 반환하도록 덮어쓰며 다른 탭과 실제 저장 글꼴 목록은 변경하지 않는다.
+ */
+
+import { assert, loadApp, runTest, setTestCase } from './helpers.mjs';
+
+const FACE = 'KoPub바탕체 Light';
+const TEST_TEXT = '행정업무운영 편람 KoPub바탕체 Light 0123456789 가나다라마';
+const WIDTH_TOLERANCE_PX = 0.01;
+
+runTest('Issue #4741 Local Font Access 부분 열거와 exact Canvas2D face', async ({ page }) => {
+  await page.evaluateOnNewDocument(() => {
+    Object.defineProperty(globalThis, 'queryLocalFonts', {
+      configurable: true,
+      value: async () => {
+        globalThis.__issue4741QueryCount = (globalThis.__issue4741QueryCount ?? 0) + 1;
+        return [{
+          family: 'Issue4741 Enumerated Control',
+          fullName: 'Issue4741 Enumerated Control Regular',
+          postscriptName: 'Issue4741EnumeratedControl-Regular',
+          style: 'Regular',
+        }];
+      },
+    });
+  });
+  await loadApp(page);
+
+  setTestCase('#4741 부분 열거 후보 probe와 patched/raw Canvas 폭');
+  const result = await page.evaluate(async ({ face, text }) => {
+    const localFonts = globalThis.__localFonts;
+    if (!localFonts) throw new Error('개발용 local-font 진단 표면을 찾을 수 없습니다');
+    const originalStoredSnapshot = localStorage.getItem('rhwp-local-fonts');
+    await localFonts.clearStoredLocalFonts();
+
+    const isolatedFrame = document.createElement('iframe');
+    isolatedFrame.hidden = true;
+    document.body.appendChild(isolatedFrame);
+    const rawContext = isolatedFrame.contentDocument?.createElement('canvas').getContext('2d');
+    if (!rawContext) throw new Error('격리된 raw Canvas2D context를 만들 수 없습니다');
+    rawContext.font = `72px "${face}"`;
+    const rawWidth = rawContext.measureText(text).width;
+    const rawEffectiveFont = rawContext.font;
+
+    const detected = await localFonts.detectLocalFonts({
+      force: true,
+      includeRegistered: true,
+      candidateFamilies: [face, 'Issue4741 Missing Control'],
+    });
+    const state = localFonts.getLocalFontState();
+    const record = localFonts.resolveLocalFont(face);
+
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d');
+    if (!context) throw new Error('patched Canvas2D context를 만들 수 없습니다');
+    context.font = `72px "${face}"`;
+    const patchedWidth = context.measureText(text).width;
+    const patchedEffectiveFont = context.font;
+
+    const queryCountAfterFirstDetection = globalThis.__issue4741QueryCount ?? 0;
+    await localFonts.detectLocalFonts({ candidateFamilies: [face] });
+    const queryCountAfterCachedDetection = globalThis.__issue4741QueryCount ?? 0;
+
+    const result = {
+      rawWidth,
+      patchedWidth,
+      widthDelta: Math.abs(rawWidth - patchedWidth),
+      rawEffectiveFont,
+      patchedEffectiveFont,
+      detected,
+      state,
+      record,
+      queryCountAfterFirstDetection,
+      queryCountAfterCachedDetection,
+    };
+    if (originalStoredSnapshot === null) {
+      localStorage.removeItem('rhwp-local-fonts');
+    } else {
+      localStorage.setItem('rhwp-local-fonts', originalStoredSnapshot);
+    }
+    return result;
+  }, { face: FACE, text: TEST_TEXT });
+
+  assert(result.queryCountAfterFirstDetection === 1, 'Local Font Access는 최초 감지에서 한 번만 호출');
+  assert(result.queryCountAfterCachedDetection === 1, '같은 감지 세대의 후보는 cache에서 재사용');
+  assert(result.detected.includes(FACE), '열거에서 빠진 KoPub exact face를 raw probe로 확인');
+  assert(result.record?.detectionSource === 'font-presence-probe', 'probe-only provenance 보존');
+  assert(result.state.probedFamilies.includes(FACE), 'snapshot에 probe-positive 후보 기록');
+  assert(result.state.unresolvedFamilies.includes('Issue4741 Missing Control'), '음성 후보도 확인 완료로 기록');
+  assert(result.patchedEffectiveFont.includes(FACE), 'patched Canvas가 exact KoPub face를 보존');
+  assert(!/GulimChe|monospace/u.test(result.patchedEffectiveFont), 'KoPub바탕체를 고정폭 fallback으로 분류하지 않음');
+  assert(
+    result.widthDelta <= WIDTH_TOLERANCE_PX,
+    `patched/raw Canvas 폭 일치: delta=${result.widthDelta}px`,
+  );
+
+  console.log(JSON.stringify(result, null, 2));
+}, { skipLoadApp: true });

--- a/rhwp-studio/e2e/local-font-partial-enumeration-issue4741.test.mjs
+++ b/rhwp-studio/e2e/local-font-partial-enumeration-issue4741.test.mjs
@@ -8,7 +8,7 @@
  * 의도적으로 부분 결과를 반환하도록 덮어쓰며 다른 탭과 실제 저장 글꼴 목록은 변경하지 않는다.
  */
 
-import { assert, loadApp, runTest, setTestCase } from './helpers.mjs';
+import { assert, loadApp, loadHwpFile, runTest, setTestCase } from './helpers.mjs';
 
 const FACE = 'KoPub바탕체 Light';
 const TEST_TEXT = '행정업무운영 편람 KoPub바탕체 Light 0123456789 가나다라마';
@@ -100,4 +100,58 @@ runTest('Issue #4741 Local Font Access 부분 열거와 exact Canvas2D face', as
   );
 
   console.log(JSON.stringify(result, null, 2));
+
+  setTestCase('#4741 편람 HWP 물리 11쪽 exact face와 페이지 경계');
+  await page.evaluate(() => {
+    const prototype = CanvasRenderingContext2D.prototype;
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, 'font');
+    if (!descriptor?.get || !descriptor.set) throw new Error('patched Canvas font descriptor가 없습니다');
+    globalThis.__issue4741CanvasFonts = [];
+    Object.defineProperty(prototype, 'font', {
+      configurable: true,
+      enumerable: descriptor.enumerable,
+      get() {
+        return descriptor.get.call(this);
+      },
+      set(value) {
+        descriptor.set.call(this, value);
+        if (/KoPub/u.test(String(value))) {
+          globalThis.__issue4741CanvasFonts.push({
+            requested: String(value),
+            effective: descriptor.get.call(this),
+          });
+        }
+      },
+    });
+  });
+  const sample = await loadHwpFile(page, '2025 행정업무운영 편람(최종).hwp');
+  await page.evaluate(() => {
+    const view = globalThis.__canvasView;
+    const container = document.querySelector('#scroll-container');
+    const pageOffset = view?.virtualScroll?.getPageOffset?.(10);
+    if (!container || !Number.isFinite(pageOffset)) throw new Error('물리 11쪽 offset을 찾을 수 없습니다');
+    globalThis.__issue4741CanvasFonts = [];
+    container.scrollTop = pageOffset;
+    container.dispatchEvent(new Event('scroll'));
+  });
+  await page.evaluate(() => new Promise(resolve => setTimeout(resolve, 1500)));
+  const sampleResult = await page.evaluate(() => ({
+    pageCount: globalThis.__wasm?.pageCount,
+    backend: globalThis.__canvasView?.getRenderBackend?.(),
+    fonts: globalThis.__issue4741CanvasFonts ?? [],
+  }));
+  const exactLightFonts = sampleResult.fonts.filter(item => /KoPub바탕체 Light/u.test(item.requested));
+  assert(sample.pageCount === 383 && sampleResult.pageCount === 383, '편람 HWP 페이지 경계는 383쪽 유지');
+  assert(sampleResult.backend === 'canvas2d', '편람 검증 backend는 Canvas2D');
+  assert(exactLightFonts.length > 0, '물리 11쪽 렌더가 KoPub바탕체 Light를 요청');
+  assert(
+    exactLightFonts.every(item => item.effective.includes(FACE) && !/GulimChe|monospace/u.test(item.effective)),
+    '물리 11쪽 KoPub바탕체 Light가 exact proportional serif chain으로 렌더',
+  );
+  console.log(JSON.stringify({
+    pageCount: sampleResult.pageCount,
+    backend: sampleResult.backend,
+    exactLightAssignments: exactLightFonts.length,
+    representativeFont: exactLightFonts[0] ?? null,
+  }, null, 2));
 }, { skipLoadApp: true });

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -34,6 +34,7 @@
     "e2e:issue-2214": "node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless",
     "e2e:issue-3815": "node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless --continuous-only",
     "e2e:issue-3820": "node e2e/issue-3820-hwp-hwpx-page-count.test.mjs --mode=headless",
+    "e2e:issue-4741": "node e2e/local-font-partial-enumeration-issue4741.test.mjs",
     "e2e:issue-3137-perf": "node e2e/probe-input-perf-issue3137.mjs --mode=headless",
     "e2e:issue-4031-cell-enter": "node e2e/cell-enter-pagination-issue4031.test.mjs --mode=headless",
     "e2e:issue-2809": "node e2e/issue-2809-split-alignment.test.mjs --mode=headless",

--- a/rhwp-studio/src/core/canvas-font-raw.ts
+++ b/rhwp-studio/src/core/canvas-font-raw.ts
@@ -1,0 +1,44 @@
+/**
+ * Canvas2D font substitution과 설치 글꼴 presence probe가 공유하는 원시 font descriptor.
+ *
+ * wasm-bridge가 전역 setter를 패치하기 직전에 native descriptor를 등록한다. 로컬 글꼴 probe는
+ * 이 descriptor를 직접 호출해 제품의 fallback 치환을 다시 통과하지 않는다.
+ */
+
+type CanvasFontContext = Pick<CanvasRenderingContext2D, 'font'>;
+
+type CanvasFontDescriptor = Pick<PropertyDescriptor, 'get' | 'set'>;
+
+let rawCanvasFontDescriptor: CanvasFontDescriptor | null = null;
+
+function findCanvasFontDescriptor(context: CanvasFontContext): CanvasFontDescriptor | null {
+  let prototype = Object.getPrototypeOf(context) as object | null;
+  while (prototype) {
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, 'font');
+    if (descriptor?.get && descriptor.set) return descriptor;
+    prototype = Object.getPrototypeOf(prototype) as object | null;
+  }
+  return null;
+}
+
+/** 전역 substitution patch를 설치하기 전의 Canvas2D font descriptor를 한 번만 보존한다. */
+export function rememberRawCanvasFontDescriptor(descriptor: PropertyDescriptor): void {
+  if (rawCanvasFontDescriptor || !descriptor.get || !descriptor.set) return;
+  rawCanvasFontDescriptor = { get: descriptor.get, set: descriptor.set };
+}
+
+/** 제품의 전역 font substitution setter를 우회해 정확한 CSS font 문자열을 설정한다. */
+export function setRawCanvasFont(context: CanvasFontContext, value: string): void {
+  const descriptor = rawCanvasFontDescriptor ?? findCanvasFontDescriptor(context);
+  if (descriptor?.set) {
+    descriptor.set.call(context, value);
+    return;
+  }
+  // 단순 mock 또는 descriptor가 없는 비표준 Canvas 구현의 호환 경로다.
+  context.font = value;
+}
+
+/** 테스트 전용: 모듈에 보존된 native descriptor를 초기화한다. */
+export function resetRawCanvasFontDescriptorForTests(): void {
+  rawCanvasFontDescriptor = null;
+}

--- a/rhwp-studio/src/core/local-fonts.ts
+++ b/rhwp-studio/src/core/local-fonts.ts
@@ -6,6 +6,7 @@
  * 사용자 승인 흐름에서만 호출하도록 API를 분리한다.
  */
 import { REGISTERED_FONTS } from './font-loader.ts';
+import { setRawCanvasFont } from './canvas-font-raw.ts';
 
 /** queryLocalFonts 반환 타입 (DOM 표준 미포함) */
 interface FontData {
@@ -31,18 +32,24 @@ export interface LocalFontRecord {
   style: string;
   displayName: string;
   aliases: string[];
+  /** face를 실제 Local Font Access 열거로 얻었는지, 이름 presence probe로만 확인했는지 구분한다. */
+  detectionSource?: LocalFontDetectionSource;
 }
 
 export interface LocalFontSnapshot {
-  /** v1은 family 문자열만 저장한 이전 형식이며 로드 시 v2 레코드로 승격한다. */
-  version: 1 | 2;
+  /** v1은 family 전용, v2는 face 레코드, v3는 문서 후보 coverage/provenance를 보존한다. */
+  version: 1 | 2 | 3;
   detectedAt: string;
   families: string[];
-  /** v2에서만 저장되는 설치 글꼴 face 메타데이터. */
+  /** v2 이상에서 저장되는 설치 글꼴 face 메타데이터. */
   fontRecords?: LocalFontRecord[];
   source: LocalFontDetectionSource;
-  /** font-presence-probe는 전체 목록이 아니라 문서 후보만 확인한다. */
+  /** 이 감지 세대에서 존재 여부 판정을 마친 문서 후보. */
   checkedFamilies?: string[];
+  /** Local Font Access 결과에 없어 raw Canvas presence probe로 확인된 후보. */
+  probedFamilies?: string[];
+  /** 확인을 마쳤지만 열거·probe 어느 쪽에서도 찾지 못한 후보. */
+  unresolvedFamilies?: string[];
 }
 
 export type LocalFontStorageKind =
@@ -61,6 +68,8 @@ export interface LocalFontState {
   storage: LocalFontStorageKind;
   count: number;
   checkedFamilies: string[];
+  probedFamilies: string[];
+  unresolvedFamilies: string[];
   detectedAt: string | null;
   lastError: string | null;
 }
@@ -70,7 +79,7 @@ export interface DetectLocalFontsOptions {
   force?: boolean;
   /** true면 REGISTERED_FONTS에 포함된 family도 반환한다. */
   includeRegistered?: boolean;
-  /** Local Font Access API가 없는 브라우저에서 현재 문서 글꼴만 확인할 때 사용한다. */
+  /** 현재 문서 face 중 열거 결과에 없는 후보를 제한적으로 확인할 때 사용한다. */
   candidateFamilies?: readonly string[];
 }
 
@@ -252,6 +261,22 @@ function buildLocalFontLookup(records: readonly LocalFontRecord[]): LocalFontLoo
   return lookup;
 }
 
+function resolveLocalFontFromLookup(fontName: string, lookup: LocalFontLookup): LocalFontRecord | null {
+  const target = normalizeFontAlias(fontName);
+  if (!target) return null;
+  const matches = lookup.aliases.get(target) ?? [];
+  if (matches.length === 0) return null;
+
+  const uniqueMatch = (records: readonly LocalFontRecord[] | undefined): LocalFontRecord | null =>
+    records?.length === 1 ? records[0] : null;
+  return uniqueMatch(lookup.postscriptNames.get(target))
+    ?? uniqueMatch(lookup.fullNames.get(target))
+    ?? uniqueMatch(lookup.familyStyles.get(target))
+    // family만으로 여러 style face가 매칭되면 임의 face를 고르지 않는다.
+    ?? uniqueMatch(lookup.families.get(target))
+    ?? (matches.length === 1 ? matches[0] : null);
+}
+
 function emptySfntFontNames(): SfntFontNames {
   return { families: [], fullNames: [], postscriptNames: [], styles: [] };
 }
@@ -391,7 +416,11 @@ function isUsableFontDisplayName(value: string): boolean {
   return !/[\u00ab\u00bb\u00c2\u00c3\u00d0\u00db]/.test(value);
 }
 
-function makeLocalFontRecord(fontData: Pick<FontData, 'family' | 'fullName' | 'postscriptName' | 'style'>, sfntNames: SfntFontNames = emptySfntFontNames()): LocalFontRecord | null {
+function makeLocalFontRecord(
+  fontData: Pick<FontData, 'family' | 'fullName' | 'postscriptName' | 'style'>,
+  sfntNames: SfntFontNames = emptySfntFontNames(),
+  detectionSource: LocalFontDetectionSource = 'local-font-access',
+): LocalFontRecord | null {
   const families = normalizeFontNames([fontData.family, ...sfntNames.families]);
   const fullNames = normalizeFontNames([fontData.fullName, ...sfntNames.fullNames]);
   const postscriptNames = normalizeFontNames([fontData.postscriptName, ...sfntNames.postscriptNames]);
@@ -412,10 +441,14 @@ function makeLocalFontRecord(fontData: Pick<FontData, 'family' | 'fullName' | 'p
     style: styles[0] ?? '',
     displayName: preferredLocalFontDisplayName(fullNames, families) || family,
     aliases,
+    detectionSource,
   };
 }
 
-function normalizeLocalFontRecords(value: unknown): LocalFontRecord[] {
+function normalizeLocalFontRecords(
+  value: unknown,
+  defaultSource: LocalFontDetectionSource = 'local-font-access',
+): LocalFontRecord[] {
   if (!Array.isArray(value)) return [];
   const records = new Map<string, LocalFontRecord>();
   for (const candidate of value) {
@@ -431,7 +464,9 @@ function normalizeLocalFontRecords(value: unknown): LocalFontRecord[] {
       fullNames: [],
       postscriptNames: [],
       styles: [],
-    });
+    }, data.detectionSource === 'font-presence-probe' || data.detectionSource === 'local-font-access'
+      ? data.detectionSource
+      : defaultSource);
     if (!record) continue;
     const aliases = normalizeFontNames([...record.aliases, ...(Array.isArray(data.aliases) ? data.aliases : [])]);
     const displayCandidates = [
@@ -451,13 +486,21 @@ function normalizeLocalFontRecords(value: unknown): LocalFontRecord[] {
   return Array.from(records.values()).sort((a, b) => a.displayName.localeCompare(b.displayName, 'ko'));
 }
 
-function recordsFromFamilies(families: readonly string[]): LocalFontRecord[] {
-  return normalizeLocalFontRecords(families.map(family => ({ family, fullName: family, postscriptName: '', style: '' })));
+function recordsFromFamilies(
+  families: readonly string[],
+  detectionSource: LocalFontDetectionSource = 'font-presence-probe',
+): LocalFontRecord[] {
+  return normalizeLocalFontRecords(
+    families.map(family => ({ family, fullName: family, postscriptName: '', style: '', detectionSource })),
+    detectionSource,
+  );
 }
 
 function snapshotRecords(snapshot: LocalFontSnapshot | null): LocalFontRecord[] {
   if (!snapshot) return [];
-  return snapshot.fontRecords?.length ? snapshot.fontRecords : recordsFromFamilies(snapshot.families);
+  return snapshot.fontRecords?.length
+    ? normalizeLocalFontRecords(snapshot.fontRecords, snapshot.source)
+    : recordsFromFamilies(snapshot.families, snapshot.source);
 }
 
 function cacheLocalFontSnapshot(snapshot: LocalFontSnapshot | null): void {
@@ -474,7 +517,7 @@ async function collectLocalFontRecords(fontDataList: readonly FontData[]): Promi
       const index = nextIndex;
       nextIndex += 1;
       const fontData = fontDataList[index];
-      records[index] = makeLocalFontRecord(fontData, await readSfntFontNames(fontData));
+      records[index] = makeLocalFontRecord(fontData, await readSfntFontNames(fontData), 'local-font-access');
     }
   };
   await Promise.all(Array.from(
@@ -489,34 +532,49 @@ function normalizeSnapshot(value: unknown): LocalFontSnapshot | null {
   const data = value as Partial<LocalFontSnapshot>;
   if (data.source !== 'local-font-access' && data.source !== 'font-presence-probe') return null;
   if (typeof data.detectedAt !== 'string' || !data.detectedAt) return null;
-  if (data.version !== 1 && data.version !== 2) return null;
-  const records = data.version === 2
-    ? normalizeLocalFontRecords(data.fontRecords)
+  if (data.version !== 1 && data.version !== 2 && data.version !== 3) return null;
+  const records = data.version >= 2
+    ? normalizeLocalFontRecords(data.fontRecords, data.source)
     : [];
   return makeSnapshot(
-    records.length > 0 ? records : recordsFromFamilies(normalizeFamilies(data.families)),
+    records.length > 0 ? records : recordsFromFamilies(normalizeFamilies(data.families), data.source),
     data.source,
-    data.checkedFamilies,
-    data.detectedAt,
+    {
+      checkedFamilies: data.version === 3 || data.source === 'font-presence-probe'
+        ? data.checkedFamilies
+        : undefined,
+      probedFamilies: data.version === 3 ? data.probedFamilies : undefined,
+      unresolvedFamilies: data.version === 3 ? data.unresolvedFamilies : undefined,
+      detectedAt: data.detectedAt,
+    },
   );
+}
+
+interface MakeSnapshotOptions {
+  checkedFamilies?: readonly string[];
+  probedFamilies?: readonly string[];
+  unresolvedFamilies?: readonly string[];
+  detectedAt?: string;
 }
 
 function makeSnapshot(
   records: readonly LocalFontRecord[],
   source: LocalFontDetectionSource,
-  checkedFamilies?: readonly string[],
-  detectedAt = new Date().toISOString(),
+  options: MakeSnapshotOptions = {},
 ): LocalFontSnapshot {
-  const fontRecords = normalizeLocalFontRecords(records);
+  const fontRecords = normalizeLocalFontRecords(records, source);
+  const checkedFamilies = normalizeFamilies(options.checkedFamilies);
+  const probedFamilies = normalizeFamilies(options.probedFamilies);
+  const unresolvedFamilies = normalizeFamilies(options.unresolvedFamilies);
   return {
-    version: 2,
-    detectedAt,
+    version: 3,
+    detectedAt: options.detectedAt ?? new Date().toISOString(),
     families: normalizeFamilies(fontRecords.map(record => record.family)),
     fontRecords,
     source,
-    checkedFamilies: source === 'font-presence-probe'
-      ? normalizeFamilies(checkedFamilies)
-      : undefined,
+    checkedFamilies: checkedFamilies.length > 0 ? checkedFamilies : undefined,
+    probedFamilies: probedFamilies.length > 0 ? probedFamilies : undefined,
+    unresolvedFamilies: unresolvedFamilies.length > 0 ? unresolvedFamilies : undefined,
   };
 }
 
@@ -541,7 +599,7 @@ function measureWithFamily(
   family: string,
   text: string,
 ): number {
-  context.font = `${PROBE_FONT_SIZE}px ${family}`;
+  setRawCanvasFont(context, `${PROBE_FONT_SIZE}px ${family}`);
   return context.measureText(text).width;
 }
 
@@ -569,6 +627,17 @@ function probeCandidateFamilies(candidateFamilies: readonly string[]): string[] 
     .filter(family => !GENERIC_FONTS.has(family))
     .filter(family => !REGISTERED_FONTS.has(family))
     .filter(family => isFamilyLikelyAvailable(context, family));
+}
+
+function unresolvedCandidateFamilies(
+  records: readonly LocalFontRecord[],
+  candidateFamilies: readonly string[],
+): string[] {
+  const lookup = buildLocalFontLookup(records);
+  return normalizeFamilies(candidateFamilies)
+    .filter(family => !GENERIC_FONTS.has(family))
+    .filter(family => !REGISTERED_FONTS.has(family))
+    .filter(family => resolveLocalFontFromLookup(family, lookup) === null);
 }
 
 const GENERIC_FONTS = new Set(['serif', 'sans-serif', 'monospace']);
@@ -814,15 +883,36 @@ export async function detectLocalFonts(options: DetectLocalFontsOptions = {}): P
     }
   }
 
+  const checkedFamilies = normalizeFamilies([
+    ...(cachedSnapshot?.checkedFamilies ?? []),
+    ...(options.candidateFamilies ?? []),
+  ]);
   let snapshot: LocalFontSnapshot | null = null;
   if (isLocalFontAccessSupported()) {
     const queryLocalFonts = (globalThis as LocalFontGlobal).queryLocalFonts!;
     const fontDataList = await queryLocalFonts();
-    snapshot = makeSnapshot(await collectLocalFontRecords(fontDataList), 'local-font-access');
-  } else if (isFontPresenceProbeSupported() && options.candidateFamilies?.length) {
-    const checkedFamilies = normalizeFamilies(options.candidateFamilies);
+    const enumeratedRecords = await collectLocalFontRecords(fontDataList);
+    const probeCandidates = unresolvedCandidateFamilies(enumeratedRecords, checkedFamilies);
+    const probedFamilies = isFontPresenceProbeSupported()
+      ? probeCandidateFamilies(probeCandidates)
+      : [];
+    const records = [
+      ...enumeratedRecords,
+      ...recordsFromFamilies(probedFamilies, 'font-presence-probe'),
+    ];
+    snapshot = makeSnapshot(records, 'local-font-access', {
+      checkedFamilies,
+      probedFamilies,
+      unresolvedFamilies: unresolvedCandidateFamilies(records, checkedFamilies),
+    });
+  } else if (isFontPresenceProbeSupported() && checkedFamilies.length > 0) {
     const families = probeCandidateFamilies(checkedFamilies);
-    snapshot = makeSnapshot(recordsFromFamilies(families), 'font-presence-probe', checkedFamilies);
+    const records = recordsFromFamilies(families, 'font-presence-probe');
+    snapshot = makeSnapshot(records, 'font-presence-probe', {
+      checkedFamilies,
+      probedFamilies: families,
+      unresolvedFamilies: unresolvedCandidateFamilies(records, checkedFamilies),
+    });
   }
 
   if (!snapshot) return [];
@@ -853,19 +943,7 @@ export function getDetectedLocalFonts(): string[] {
 
 /** HWP/CSS 글꼴명에서 동일한 설치 글꼴 face를 찾는다. */
 export function resolveLocalFont(fontName: string): LocalFontRecord | null {
-  const target = normalizeFontAlias(fontName);
-  if (!target) return null;
-  const matches = cachedFontLookup.aliases.get(target) ?? [];
-  if (matches.length === 0) return null;
-
-  const uniqueMatch = (records: readonly LocalFontRecord[] | undefined): LocalFontRecord | null =>
-    records?.length === 1 ? records[0] : null;
-  return uniqueMatch(cachedFontLookup.postscriptNames.get(target))
-    ?? uniqueMatch(cachedFontLookup.fullNames.get(target))
-    ?? uniqueMatch(cachedFontLookup.familyStyles.get(target))
-    // family만으로 여러 style face가 매칭되면 임의 face를 고르지 않는다.
-    ?? uniqueMatch(cachedFontLookup.families.get(target))
-    ?? (matches.length === 1 ? matches[0] : null);
+  return resolveLocalFontFromLookup(fontName, cachedFontLookup);
 }
 
 /** CSS family와 달리 style별 native Typeface cache를 구분하는 안정 키다. */
@@ -970,10 +1048,10 @@ export async function loadLocalFontBytes(fontName: string): Promise<ArrayBuffer 
 /** 현재 로컬 글꼴 감지/저장 상태를 반환한다. */
 export function getLocalFontState(): LocalFontState {
   const method = getLocalFontDetectionMethod();
-  const complete = cachedSnapshot?.source === 'local-font-access';
-  const checkedFamilies = cachedSnapshot?.source === 'font-presence-probe'
-    ? (cachedSnapshot.checkedFamilies ?? [])
-    : (complete ? (cachedSnapshot?.families ?? []) : []);
+  // Local Font Access가 성공해도 설치 face 일부가 빠질 수 있으므로 전체 시스템 기준 complete를
+  // 주장하지 않는다. 문서별 완료 여부는 checkedFamilies로 판정한다.
+  const complete = false;
+  const checkedFamilies = cachedSnapshot?.checkedFamilies ?? [];
   return {
     supported: method !== null,
     method,
@@ -984,6 +1062,8 @@ export function getLocalFontState(): LocalFontState {
     storage: getStorageKind(),
     count: cachedSnapshot?.families.length ?? 0,
     checkedFamilies,
+    probedFamilies: cachedSnapshot?.probedFamilies ?? [],
+    unresolvedFamilies: cachedSnapshot?.unresolvedFamilies ?? [],
     detectedAt: cachedSnapshot?.detectedAt ?? null,
     lastError: lastStorageError,
   };

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -201,6 +201,7 @@ export interface DeferredPaginationResult {
 }
 
 import { fontFamilyChainForDisplay } from './font-substitution';
+import { rememberRawCanvasFontDescriptor } from './canvas-font-raw';
 import type { FileSystemFileHandleLike } from '@/command/file-system-access';
 
 /**
@@ -232,6 +233,7 @@ function installCanvasFontSubstitution(): void {
   const proto = CanvasRenderingContext2D.prototype;
   const descriptor = Object.getOwnPropertyDescriptor(proto, 'font');
   if (!descriptor?.get || !descriptor.set || descriptor.configurable === false) return;
+  rememberRawCanvasFontDescriptor(descriptor);
 
   Object.defineProperty(proto, 'font', {
     configurable: true,

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -1161,7 +1161,9 @@ async function promptLocalFontsIfNeeded(docInfo: DocumentInfo, displayName: stri
     const nextReport = analyzeDocumentFonts(docInfo.fontsUsed);
     eventBus.emit('local-fonts-changed', { fonts, report: nextReport });
     const state = getLocalFontState();
-    const resultLabel = state.source === 'font-presence-probe' ? '확인됨' : '감지됨';
+    const resultLabel = state.source === 'font-presence-probe'
+      ? '확인됨'
+      : (state.probedFamilies.length > 0 ? '열거·확인됨' : '열거됨');
     msg.textContent = `${displayName} (로컬 글꼴 ${fonts.length}개 ${resultLabel})`;
     showToast({
       message: `로컬 글꼴 ${fonts.length}개를 ${resultLabel.replace('됨', '')}하고 저장했습니다.\n다음 문서 로드부터 감지 결과를 재사용합니다.`,

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -52,7 +52,13 @@ import { DocumentDirtyState } from '@/core/document-dirty-state';
 import { initThemeSync, setThemeMode, getThemeMode, getEffectiveTheme } from '@/core/theme';
 import { analyzeDocumentFonts } from '@/core/document-font-status';
 import { setDocumentFontSubstitutions } from '@/core/font-substitution';
-import { detectLocalFonts, getLocalFontState, loadStoredLocalFonts } from '@/core/local-fonts';
+import {
+  clearStoredLocalFonts,
+  detectLocalFonts,
+  getLocalFontState,
+  loadStoredLocalFonts,
+  resolveLocalFont,
+} from '@/core/local-fonts';
 import { userSettings } from '@/core/user-settings';
 import { AutosaveManager, type AutosaveScheduleSettings, type AutosaveStatus } from '@/recovery/autosave-manager';
 import { clearAutosaveDrafts, deleteAutosaveDraft, listAutosaveDrafts, type AutosaveDraft } from '@/recovery/autosave-store';
@@ -117,6 +123,12 @@ if (import.meta.env.DEV) {
   (window as any).__documentState = documentState;
   (window as any).__autosaveManager = autosaveManager;
   (window as any).__theme = { getThemeMode, getEffectiveTheme, setThemeMode };
+  (window as any).__localFonts = {
+    clearStoredLocalFonts,
+    detectLocalFonts,
+    getLocalFontState,
+    resolveLocalFont,
+  };
   initRhwpDev(wasm);
 }
 let canvasView: CanvasView | null = null;

--- a/rhwp-studio/src/ui/local-fonts-modal.ts
+++ b/rhwp-studio/src/ui/local-fonts-modal.ts
@@ -73,7 +73,7 @@ export class LocalFontsModal {
     desc.style.margin = '0 0 12px 0';
     desc.textContent = this.report.detectionMethod === 'font-presence-probe'
       ? '현재 문서에 rhwp 기본 지원 글꼴이 아닌 글꼴이 있습니다. 원본에 가깝게 표시하기 위해, 이 문서에 필요한 글꼴이 이 기기에 설치되어 있는지 확인합니다.'
-      : '현재 문서에 rhwp 기본 지원 글꼴이 아닌 글꼴이 있습니다. 원본에 가깝게 표시하려면 로컬 글꼴 감지를 허용해 주세요.';
+      : '현재 문서에 rhwp 기본 지원 글꼴이 아닌 글꼴이 있습니다. 로컬 글꼴 목록을 확인하고, 목록에서 빠진 현재 문서 후보만 추가 확인하려면 감지를 허용해 주세요.';
     body.appendChild(desc);
 
     const privacy = document.createElement('p');
@@ -82,7 +82,7 @@ export class LocalFontsModal {
     privacy.style.color = 'var(--color-text-secondary)';
     privacy.textContent = this.report.detectionMethod === 'font-presence-probe'
       ? '이 브라우저에서는 설치된 모든 글꼴 목록을 가져오지 않고, 현재 문서에 필요한 글꼴만 확인합니다. 확인 결과는 이 브라우저/확장 로컬 저장소에만 보관되며 서버로 전송하지 않습니다. 감지를 건너뛰면 대체 글꼴로 계속 표시합니다.'
-      : '감지 결과는 이 브라우저/확장 로컬 저장소에만 보관되며 서버로 전송하지 않습니다. 감지를 건너뛰면 대체 글꼴로 계속 표시합니다.';
+      : 'Chrome/Edge의 로컬 글꼴 목록은 일부 설치 face를 누락할 수 있어 현재 문서의 미해소 후보만 추가 확인합니다. 결과는 이 브라우저/확장 로컬 저장소에만 보관되며 서버로 전송하지 않습니다. 감지를 건너뛰면 대체 글꼴로 계속 표시합니다.';
     body.appendChild(privacy);
 
     if (this.options.disableExternalWebFonts) {

--- a/rhwp-studio/src/ui/options-dialog.ts
+++ b/rhwp-studio/src/ui/options-dialog.ts
@@ -158,7 +158,7 @@ export class OptionsDialog extends ModalDialog {
 
     const localDesc = document.createElement('p');
     localDesc.className = 'opt-desc';
-    localDesc.textContent = 'PC에 설치된 글꼴을 감지하여 글꼴 목록에 추가합니다. (Chrome/Edge 전체 감지 지원, Firefox는 문서 로드 시 필요한 글꼴만 확인)';
+    localDesc.textContent = 'PC에 설치된 글꼴을 감지하여 글꼴 목록에 추가합니다. (Chrome/Edge는 목록 열거 후 문서에서 누락된 후보를 추가 확인, Firefox는 문서에 필요한 후보만 확인)';
     localSection.appendChild(localDesc);
 
     const localRow = document.createElement('div');
@@ -200,7 +200,7 @@ export class OptionsDialog extends ModalDialog {
       localStatus.textContent = '감지 중...';
       try {
         const fonts = await detectLocalFonts({ force: true });
-        updateLocalStatus(`${fonts.length}개 로컬 글꼴을 감지하고 저장했습니다.`);
+        updateLocalStatus(`${fonts.length}개 로컬 글꼴 열거 결과를 저장했습니다. 문서별 누락 후보는 문서를 열 때 추가 확인합니다.`);
         this.eventBus?.emit('local-fonts-changed', { fonts, source: 'options-dialog' });
       } catch (error) {
         updateLocalStatus(describeLocalFontDetectionError(error));
@@ -397,7 +397,10 @@ function formatLocalFontStatus(state: LocalFontState): string {
   if (state.source === 'font-presence-probe') {
     return `문서별 확인 결과 저장됨: 사용 가능 ${state.count}개 / 확인한 글꼴 ${state.checkedFamilies.length}개${dateSuffix}`;
   }
-  return `전체 로컬 글꼴 감지 결과 저장됨: ${state.count}개${dateSuffix}`;
+  if (state.checkedFamilies.length > 0) {
+    return `로컬 글꼴 결과 저장됨: 사용 가능 ${state.count}개 / 문서 후보 ${state.checkedFamilies.length}개 / 열거 누락 확인 ${state.probedFamilies.length}개${dateSuffix}`;
+  }
+  return `로컬 글꼴 열거 결과 저장됨: ${state.count}개 · 문서별 누락 후보는 문서를 열 때 추가 확인${dateSuffix}`;
 }
 
 function formatDetectedAt(value: string | null): string {

--- a/rhwp-studio/tests/local-fonts.test.ts
+++ b/rhwp-studio/tests/local-fonts.test.ts
@@ -18,6 +18,10 @@ import {
 } from '../src/core/local-fonts.ts';
 import { analyzeDocumentFonts } from '../src/core/document-font-status.ts';
 import { fontFamilyChainForDisplay } from '../src/core/font-substitution.ts';
+import {
+  rememberRawCanvasFontDescriptor,
+  resetRawCanvasFontDescriptorForTests,
+} from '../src/core/canvas-font-raw.ts';
 
 const STORAGE_KEY = 'rhwp-local-fonts';
 
@@ -134,6 +138,59 @@ function createProbeDocument(installedFamilies: readonly string[]): unknown {
   };
 }
 
+function createPatchedProbeDocument(installedFamilies: readonly string[]): {
+  document: unknown;
+  patchedSetCount: () => number;
+  rawSetCount: () => number;
+} {
+  const installed = new Set(installedFamilies);
+  let patchedSetCalls = 0;
+  let rawSetCalls = 0;
+  const context = {
+    rawFont: '',
+    measureText(text: string) {
+      const fallback = this.rawFont.split(',').pop()?.trim() ?? 'sans-serif';
+      const target = firstQuotedFontFamily(this.rawFont);
+      const fallbackWidth = fallback.includes('monospace') ? 12 : fallback.includes('serif') ? 10 : 11;
+      const width = target && installed.has(target) ? fallbackWidth + 3 : fallbackWidth;
+      return { width: text.length * width };
+    },
+  };
+  const rawDescriptor: PropertyDescriptor = {
+    configurable: true,
+    get(this: typeof context) {
+      return this.rawFont;
+    },
+    set(this: typeof context, value: string) {
+      rawSetCalls++;
+      this.rawFont = value;
+    },
+  };
+  rememberRawCanvasFontDescriptor(rawDescriptor);
+  Object.defineProperty(context, 'font', {
+    configurable: true,
+    get: rawDescriptor.get,
+    set(this: typeof context, value: string) {
+      patchedSetCalls++;
+      rawDescriptor.set!.call(this, value.replace(/"KoPub바탕체 Light"/u, 'monospace'));
+    },
+  });
+  return {
+    document: {
+      createElement(tagName: string) {
+        if (tagName !== 'canvas') return {};
+        return {
+          getContext(contextId: string) {
+            return contextId === '2d' ? context : null;
+          },
+        };
+      },
+    },
+    patchedSetCount: () => patchedSetCalls,
+    rawSetCount: () => rawSetCalls,
+  };
+}
+
 function utf16Be(value: string): Uint8Array {
   const bytes = new Uint8Array(value.length * 2);
   for (let index = 0; index < value.length; index += 1) {
@@ -213,16 +270,19 @@ test('저장된 localStorage snapshot 로드는 queryLocalFonts를 호출하지 
     assert.equal(queryCount, 0);
     assert.deepEqual(getLocalFonts(), sortedKo(['로컬A', '로컬B']));
     assert.deepEqual(getDetectedLocalFonts(), sortedKo(['로컬A', '로컬B', '함초롬바탕']));
+    assert.equal(analyzeDocumentFonts(['새 문서 글꼴']).shouldPromptLocalAccess, true);
     assert.deepEqual(getLocalFontState(), {
       supported: true,
       method: 'local-font-access',
       loaded: true,
       stored: true,
       source: 'local-font-access',
-      complete: true,
+      complete: false,
       storage: 'local-storage',
       count: 3,
-      checkedFamilies: sortedKo(['로컬A', '로컬B', '함초롬바탕']),
+      checkedFamilies: [],
+      probedFamilies: [],
+      unresolvedFamilies: [],
       detectedAt: '2026-06-21T00:00:00.000Z',
       lastError: null,
     });
@@ -500,7 +560,7 @@ test('SFNT 지역화 이름을 보존해 HWP 한글 full name을 영문 family�
       ['08서울한강체 M', 'available', 'local'],
     ]);
     assert.equal(firstQuotedFontFamily(cssChain), record?.fullName);
-    assert.equal(stored.version, 2);
+    assert.equal(stored.version, 3);
     assert.equal('blob' in (stored.fontRecords?.[0] ?? {}), false);
   } finally {
     await clearStoredLocalFonts();
@@ -954,7 +1014,8 @@ test('Local Font Access가 문서 face를 누락하면 미해소 후보만 probe
       style: 'Regular',
     }];
   };
-  g.document = createProbeDocument(['KoPub바탕체 Light']);
+  const patchedProbe = createPatchedProbeDocument(['KoPub바탕체 Light']);
+  g.document = patchedProbe.document;
 
   try {
     const fonts = await detectLocalFonts({
@@ -966,15 +1027,33 @@ test('Local Font Access가 문서 face를 누락하면 미해소 후보만 probe
     const chain = fontFamilyChainForDisplay('KoPub바탕체 Light');
 
     assert.equal(queryCount, 1);
+    assert.equal(patchedProbe.patchedSetCount(), 0);
+    assert.ok(patchedProbe.rawSetCount() > 0);
+    assert.ok(patchedProbe.rawSetCount() <= 48);
     assert.ok(fonts.includes('KoPub바탕체 Light'));
     assert.equal(resolveLocalFont('KoPub바탕체 Light')?.fullName, 'KoPub바탕체 Light');
+    assert.equal(resolveLocalFont('KoPub바탕체 Light')?.detectionSource, 'font-presence-probe');
+    assert.equal(resolveLocalFont('열거된 글꼴 Regular')?.detectionSource, 'local-font-access');
     assert.match(chain, /^"KoPub바탕체 Light"/u);
     assert.deepEqual(
       state.checkedFamilies,
       sortedKo(['열거된 글꼴 Regular', 'KoPub바탕체 Light', '없는글꼴']),
     );
+    assert.equal(storedSnapshot?.version, 3);
+    assert.deepEqual(storedSnapshot?.probedFamilies, ['KoPub바탕체 Light']);
+    assert.deepEqual(storedSnapshot?.unresolvedFamilies, ['없는글꼴']);
+    assert.deepEqual(state.probedFamilies, ['KoPub바탕체 Light']);
+    assert.deepEqual(state.unresolvedFamilies, ['없는글꼴']);
     assert.equal(state.complete, false);
+
+    const rawSetCount = patchedProbe.rawSetCount();
+    assert.deepEqual(await detectLocalFonts({ candidateFamilies: ['KoPub바탕체 Light'] }), fonts);
+    assert.equal(queryCount, 1);
+    assert.equal(patchedProbe.rawSetCount(), rawSetCount);
+    assert.equal(await loadLocalFontBytes('KoPub바탕체 Light'), null);
+    assert.equal(queryCount, 1);
   } finally {
+    resetRawCanvasFontDescriptorForTests();
     await clearStoredLocalFonts();
     resetLocalFontsForTests();
     restoreGlobals(originals);

--- a/rhwp-studio/tests/local-fonts.test.ts
+++ b/rhwp-studio/tests/local-fonts.test.ts
@@ -909,3 +909,74 @@ test('Local Font Access API가 없으면 문서 후보 글꼴만 probe snapshot�
     restoreGlobals(originals);
   }
 });
+
+test('Local Font Access가 문서 face를 누락하면 미해소 후보만 probe해 exact face를 보존한다', async () => {
+  const g = globalThis as TestGlobals;
+  const originals = {
+    browser: g.browser,
+    chrome: g.chrome,
+    document: g.document,
+    localStorage: g.localStorage,
+    queryLocalFonts: g.queryLocalFonts,
+  };
+  let storedSnapshot: LocalFontSnapshot | null = null;
+  let queryCount = 0;
+
+  resetLocalFontsForTests();
+  g.browser = undefined;
+  g.chrome = undefined;
+  g.localStorage = {
+    get length() {
+      return storedSnapshot ? 1 : 0;
+    },
+    clear() {
+      storedSnapshot = null;
+    },
+    getItem() {
+      return null;
+    },
+    key() {
+      return storedSnapshot ? STORAGE_KEY : null;
+    },
+    removeItem() {
+      storedSnapshot = null;
+    },
+    setItem(_key: string, value: string) {
+      storedSnapshot = JSON.parse(value) as LocalFontSnapshot;
+    },
+  } as Storage;
+  g.queryLocalFonts = async () => {
+    queryCount++;
+    return [{
+      family: '열거된 글꼴',
+      fullName: '열거된 글꼴 Regular',
+      postscriptName: 'Enumerated-Regular',
+      style: 'Regular',
+    }];
+  };
+  g.document = createProbeDocument(['KoPub바탕체 Light']);
+
+  try {
+    const fonts = await detectLocalFonts({
+      force: true,
+      includeRegistered: true,
+      candidateFamilies: ['열거된 글꼴 Regular', 'KoPub바탕체 Light', '없는글꼴'],
+    });
+    const state = getLocalFontState();
+    const chain = fontFamilyChainForDisplay('KoPub바탕체 Light');
+
+    assert.equal(queryCount, 1);
+    assert.ok(fonts.includes('KoPub바탕체 Light'));
+    assert.equal(resolveLocalFont('KoPub바탕체 Light')?.fullName, 'KoPub바탕체 Light');
+    assert.match(chain, /^"KoPub바탕체 Light"/u);
+    assert.deepEqual(
+      state.checkedFamilies,
+      sortedKo(['열거된 글꼴 Regular', 'KoPub바탕체 Light', '없는글꼴']),
+    );
+    assert.equal(state.complete, false);
+  } finally {
+    await clearStoredLocalFonts();
+    resetLocalFontsForTests();
+    restoreGlobals(originals);
+  }
+});


### PR DESCRIPTION
## 변경 요약

- `queryLocalFonts()`가 설치 face 일부를 누락해도 현재 문서의 미해소 후보만 원시 Canvas로 제한적으로 확인합니다.
- 열거된 SFNT face와 probe-only Canvas2D face의 provenance를 분리하고 snapshot v3, 후보 fingerprint, 감지 generation으로 결과를 캐시합니다.
- 전역 Canvas 폰트 치환 patch를 우회하는 raw descriptor를 사용해 정확한 face를 probe하고, probe-only face가 CanvasKit Typeface로 등록된 것처럼 취급하지 않습니다.
- 같은 유형의 폰트 문제를 빠르게 분류하도록 7축 진단 매트릭스와 관련 이슈 인계 절차를 canonical manual에 추가했습니다.

## 원인과 영향

기존 구현은 Local Font Access API의 존재와 열거 결과의 완전성을 같은 상태로 취급했습니다. 따라서 API가 정상 응답하면서 `KoPub바탕체 Light` 같은 설치 face만 누락하면 문서 후보 probe가 실행되지 않았고, Canvas2D 치환 경로가 원본 이름을 제거한 뒤 고정폭 fallback을 선택했습니다.

이 변경은 누락된 문서 후보만 bounded raw probe로 보완해 exact Canvas2D face와 대표 문자열 폭을 보존합니다. 감지는 문서 로드와 명시적 갱신 경계에서만 수행하며, 글자 측정·그리기 hot path에서는 반복하지 않습니다. Rust 레이아웃과 #3931의 표 분할 문턱은 변경하지 않습니다.

## 관련 이슈

Closes #4741

관련 회귀 범위: #1328, #2217, #4739  
별도 조판 축: #3931

## 테스트

- [x] focused TypeScript 37/37 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm test`: 931건 중 930 통과, 1 skip, 실패 0
- [x] `npm run build` 통과
- [x] E2E manifest 검사: tracked 102개와 manifest 102행 일치
- [x] Chrome 151 CDP 부분 열거 E2E 통과
  - Local Font Access 최초 1회, 같은 감지 generation 재호출 0회
  - snapshot v3: checked 2, probed 1, unresolved 1
  - raw/patched `KoPub바탕체 Light` 대표 문자열 폭 delta `0px`
  - probe-only CanvasKit bytes `null`
- [x] 실제 `samples/2025 행정업무운영 편람(최종).hwp` Canvas2D 확인
  - 383쪽 유지
  - 물리 11쪽의 `KoPub바탕체 Light` exact face 확인
- [x] `git diff --check`, 변경 Markdown 상대 링크, 문서 metadata 검사 통과
- [x] `cargo test` / `cargo clippy`: Rust 소스 비변경으로 범위 제외
- [x] wasm-pack 재빌드: Rust/WASM 소스 비변경으로 범위 제외; 기존 `pkg/`를 포함한 production Studio build 통과
- [ ] 작업 증빙 캡슐: 이번 작업에서는 별도 `rhwp replay` 캡슐을 생성하지 않았으며 계획·조사·Stage 5 검증 기록을 포함했습니다.

## 성능 영향 및 측정 결과

- 예상 영향: 감지 시점에만 미해소 문서 후보 수와 고정 test vector 수에 비례하는 bounded probe가 추가됩니다. hot path 영향은 없습니다.
- 재현·측정: Chrome E2E에서 최초 감지 후 같은 generation의 Local Font Access 재호출이 없고, raw probe 호출이 후보 수와 고정 vector 상한 안에 있음을 확인했습니다.

## 스크린샷

별도 스크린샷은 없습니다. 메인테이너가 Chrome에서 실제 HWP의 383쪽 경계와 물리 11쪽 exact face를 시각 판정했습니다.
