### PR TITLE
feat(gym): 전 pack 정합 감사 — 해결가능·고유·정합을 기계 강제

### DIFF
--- a/gym/tools/audit.py
+++ b/gym/tools/audit.py
@@ -1,0 +1,154 @@
+"""gym 정합 감사 — 모든 pack 이 "그 방식"(해결 가능·고유·정합)을 지키는지 전수 검사.
+
+## 왜 이 도구인가 (강제된 표준)
+
+gym 이 자라고 기여자가 늘수록, 새 pack 이 조용히 규약을 어길 수 있다: 과제에 기준
+풀이가 없거나(=해결 가능성 미선언), 과제 ID 가 다른 pack 과 충돌하거나, 스키마를
+벗어나거나. 개별 검증(`schema.validate_pack`/`validate_task`)은 pack 하나·과제 하나만
+본다 — **전 저장소에 걸친 정합**(과제↔기준 짝·과제 ID 전역 고유·고아 기준풀이)은
+아무도 안 본다. 그 틈으로 정합이 무너진다.
+
+이 감사기가 그 전수 정합을 강제한다. gym 에 기여하는 모든 에이전트의 pack 은 이걸
+통과해야 한다 — 벗어날 수 없되 감옥이 아니라 **품질 관문**이다(규칙은 열려 있고,
+검사하는 것은 해결 가능성·고유성·정합 같은 품질이다). 바이너리 없이 순수 파일 검사라
+CI 에서 상시 돈다.
+
+## 검사하는 것 (그 방식)
+
+- **스키마 정합** — `schema.validate_pack` + `validate_task`(바이너리 불요, 명령 존재
+  검사만 러너에 위임).
+- **해결 가능성 선언** — 모든 과제에 짝 기준풀이(`tasks/X.json` ↔ `reference/X.json`,
+  id 일치). 기준풀이 없는 과제는 "풀 수 있다" 는 근거가 없다.
+- **고아 기준풀이 없음** — 기준풀이는 반드시 과제를 가진다.
+- **과제 ID 전역 고유** — pack 간 ID 충돌 금지(리더보드·집계가 ID 로 과제를 가른다).
+
+## 사용
+
+    python gym/tools/audit.py           # 전 pack 감사, 문제 있으면 exit 1
+    python gym/tools/audit.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GYM_ROOT = os.path.dirname(HERE)
+sys.path.insert(0, GYM_ROOT)
+
+from core import schema  # noqa: E402  (gym/core)
+
+
+def _load(path):
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def audit(packs_root: str) -> dict:
+    """전 pack 정합 감사 — 순수 파일 검사(바이너리·네트워크 없음).
+
+    packs_root: `gym/packs` 를 담은 디렉토리(보통 gym/).
+    반환: {ok, packs:[{id, issues}], taskIdCollisions, issueCount}.
+    """
+    packs_dir = os.path.join(packs_root, "packs")
+    pack_reports = []
+    task_id_owners: dict[str, list[str]] = {}
+
+    for pack_id in sorted(os.listdir(packs_dir)):
+        pack_dir = os.path.join(packs_dir, pack_id)
+        if not os.path.isdir(pack_dir):
+            continue
+        issues: list[str] = []
+        manifest_path = os.path.join(pack_dir, "pack.json")
+        if not os.path.isfile(manifest_path):
+            pack_reports.append({"id": pack_id, "issues": ["pack.json 이 없다"]})
+            continue
+        try:
+            manifest = _load(manifest_path)
+        except (ValueError, OSError) as e:
+            pack_reports.append({"id": pack_id, "issues": [f"pack.json 파싱 실패: {e}"]})
+            continue
+
+        schema.validate_pack(manifest, pack_dir, issues)
+
+        tasks_dir = os.path.join(pack_dir, "tasks")
+        ref_dir = os.path.join(pack_dir, "reference")
+        task_ids: set[str] = set()
+        task_files = sorted(f for f in os.listdir(tasks_dir)) if os.path.isdir(tasks_dir) else []
+        ref_files = set(f for f in os.listdir(ref_dir)) if os.path.isdir(ref_dir) else set()
+
+        for name in task_files:
+            if not name.endswith(".json"):
+                continue
+            try:
+                task = _load(os.path.join(tasks_dir, name))
+            except (ValueError, OSError) as e:
+                issues.append(f"tasks/{name} 파싱 실패: {e}")
+                continue
+            # 명령 존재 검사만 러너에 위임(known_commands=None) — 구조는 그대로 검증.
+            schema.validate_task(task, manifest, None, issues)
+            tid = task.get("id")
+            if tid:
+                task_ids.add(tid)
+                task_id_owners.setdefault(tid, []).append(pack_id)
+            # 해결 가능성: 짝 기준풀이가 있고 id 가 맞는가.
+            if name not in ref_files:
+                issues.append(f"과제 {name} 에 짝 기준풀이(reference/{name})가 없다 — 해결 가능성 미선언")
+            else:
+                try:
+                    ref = _load(os.path.join(ref_dir, name))
+                    if ref.get("id") != tid:
+                        issues.append(f"reference/{name} 의 id({ref.get('id')}) 가 과제 id({tid}) 와 다르다")
+                except (ValueError, OSError) as e:
+                    issues.append(f"reference/{name} 파싱 실패: {e}")
+
+        # 고아 기준풀이: 과제 없는 reference.
+        task_names = {f for f in task_files if f.endswith(".json")}
+        for name in sorted(ref_files):
+            if name.endswith(".json") and name not in task_names:
+                issues.append(f"고아 기준풀이 reference/{name} — 짝 과제(tasks/{name})가 없다")
+
+        pack_reports.append({"id": pack_id, "issues": issues})
+
+    collisions = {tid: owners for tid, owners in task_id_owners.items() if len(owners) > 1}
+    issue_count = sum(len(p["issues"]) for p in pack_reports) + len(collisions)
+    return {
+        "kind": "gymAudit",
+        "schemaVersion": "1.0",
+        "ok": issue_count == 0,
+        "packCount": len(pack_reports),
+        "packs": [p for p in pack_reports if p["issues"]],
+        "taskIdCollisions": collisions,
+        "issueCount": issue_count,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="gym 전 pack 정합 감사 (해결가능·고유·정합)")
+    ap.add_argument("--json", action="store_true")
+    a = ap.parse_args()
+    report = audit(GYM_ROOT)
+    if a.json:
+        sys.stdout.write(json.dumps(report, ensure_ascii=False, indent=2) + "\n")
+    elif report["ok"]:
+        print(f"gym 정합 감사: {report['packCount']} pack 전부 통과 — 위반 0")
+    else:
+        print(f"gym 정합 감사: 위반 {report['issueCount']}건")
+        for p in report["packs"]:
+            for issue in p["issues"]:
+                print(f"  [{p['id']}] {issue}")
+        for tid, owners in report["taskIdCollisions"].items():
+            print(f"  [전역] 과제 ID '{tid}' 충돌: {', '.join(owners)}")
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
+        except Exception:
+            pass
+    sys.exit(main())

--- a/scripts/tests/test_gym_audit.py
+++ b/scripts/tests/test_gym_audit.py
@@ -1,0 +1,91 @@
+"""[audit] gym 정합 감사 계약 — 전-저장소 정합 불변식.
+
+CI 강제: 실제 저장소의 전 pack 이 "그 방식"(해결 가능·고유·정합)을 지킨다. 비정합
+pack(짝 기준풀이 없음·과제 ID 전역 충돌)이 들어오면 이 테스트가 red 로 막는다.
+바이너리 없이 순수 파일 검사만 시험한다.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL = REPO_ROOT / "gym" / "tools" / "audit.py"
+
+
+def load():
+    spec = importlib.util.spec_from_file_location("gym_audit", TOOL)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_pack(root, pid, task_id, with_ref=True):
+    pd = os.path.join(root, "packs", pid)
+    os.makedirs(os.path.join(pd, "tasks"))
+    os.makedirs(os.path.join(pd, "reference"))
+    json.dump(
+        {"schemaVersion": "1.0", "kind": "gymPack", "id": pid, "title": "t", "axis": "조회 (x)",
+         "requires": {"commands": ["info"]},
+         "runner": {"rhwpVersion": "0.8.4", "rhwpCommit": "a" * 40, "capabilitiesSha256": "b" * 64}},
+        open(os.path.join(pd, "pack.json"), "w", encoding="utf-8"), ensure_ascii=False)
+    json.dump(
+        {"id": task_id, "tier": 2, "title": "t", "input": "samples/x.hwp", "instructions": "i",
+         "submit": {"kind": "answer"},
+         "checks": [{"op": "answer_eq", "answer": "p", "cmd": ["info", "{input}", "--json"],
+                     "path": "pageCount"}]},
+        open(os.path.join(pd, "tasks", f"{task_id}.json"), "w", encoding="utf-8"), ensure_ascii=False)
+    if with_ref:
+        json.dump(
+            {"id": task_id, "steps": [{"answer": {"p": {"cmd": ["info", "{input}", "--json"],
+                                                        "path": "pageCount"}}}]},
+            open(os.path.join(pd, "reference", f"{task_id}.json"), "w", encoding="utf-8"),
+            ensure_ascii=False)
+
+
+class AuditTests(unittest.TestCase):
+    def test_real_repo_all_packs_conform(self):
+        report = load().audit(str(REPO_ROOT / "gym"))
+        self.assertTrue(
+            report["ok"],
+            f"gym 정합 위반: {report['packs']} · 충돌 {report['taskIdCollisions']}")
+        self.assertGreaterEqual(report["packCount"], 10)
+
+    def test_missing_reference_is_flagged(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01", with_ref=False)
+            r = load().audit(d)
+            self.assertFalse(r["ok"])
+            self.assertTrue(any("기준풀이" in i for p in r["packs"] for i in p["issues"]))
+
+    def test_orphan_reference_is_flagged(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "X01", with_ref=True)
+            os.remove(os.path.join(d, "packs", "p1", "tasks", "X01.json"))
+            r = load().audit(d)
+            self.assertFalse(r["ok"])
+            self.assertTrue(any("고아" in i for p in r["packs"] for i in p["issues"]))
+
+    def test_task_id_collision_across_packs_is_flagged(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "DUP", with_ref=True)
+            _write_pack(d, "p2", "DUP", with_ref=True)
+            r = load().audit(d)
+            self.assertFalse(r["ok"])
+            self.assertIn("DUP", r["taskIdCollisions"])
+
+    def test_clean_fixture_passes(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write_pack(d, "p1", "A01", with_ref=True)
+            _write_pack(d, "p2", "B01", with_ref=True)
+            self.assertTrue(load().audit(d)["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 무엇을 / 왜

gym 이 자라고 기여자가 늘수록(kevin9327·planet6897·…) 새 pack 이 조용히 규약을 어길
수 있다: 짝 기준풀이 없음(=해결 가능성 미선언)·과제 ID 전역 충돌·스키마 이탈. 개별
검증(`schema.validate_pack`/`validate_task`)은 pack·과제 하나만 본다 — **전 저장소에
걸친 정합**(과제↔기준 짝·과제 ID 전역 고유·고아 기준풀이)은 아무도 안 본다.

`gym/tools/audit.py` 가 그 전수 정합을 강제한다. 모든 gym 기여가 통과해야 하는 **품질
관문**이다 — 벗어날 수 없되 감옥이 아니라, 규칙은 열려 있고 검사하는 것은 해결
가능성·고유성·정합 같은 품질이다. **표준이 자기 정합을 스스로 지키게** 한다.

closes #4803

## 검사하는 것 (그 방식)

- **스키마 정합** — `validate_pack` + `validate_task` 위임(바이너리 불요, 명령 존재
  검사만 러너에).
- **해결 가능성 선언** — 모든 과제에 짝 기준풀이(`tasks/X.json` ↔ `reference/X.json`, id 일치).
- **고아 기준풀이 없음** · **과제 ID 전역 고유**(pack 간 충돌 금지).

## 검증 (라이브 실측)

```
$ python gym/tools/audit.py
gym 정합 감사: 17 pack 전부 통과 — 위반 0
```
- 감사 가드 `test_gym_audit.py` **5 passed** — 실제 17 pack 정합 + 위반 3종(짝 없음·
  고아 기준풀이·ID 전역 충돌) 포착 + 클린 픽스처 통과.
- 기존 gym 가드(score·coverage) **21 passed**(무회귀).
- 바이너리 없이 순수 파일 검사 → CI 상시 가능(ci.yml 미변경, 앵커 충돌 회피 — 가드는
  단독 실행 가능, 배선은 프레임 통합 시 일괄).

## 성격 (합법성)

이건 은닉·강요가 아니라 **투명한 품질 강제**다 — 규칙이 열려 있고(감사기 docstring 이
계약을 서술), 검사하는 것이 품질(해결 가능성·정합)이라 기여자에게 이롭다. 표준이 이렇게
자기를 지키기에, 늘어나는 기여자 사이에서도 "그 방식"이 무너지지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
