### PR TITLE
fix(#3950): 한글 IME Ctrl+A 모두 선택 지원

### DIFF
--- a/mydocs/orders/20260815.md
+++ b/mydocs/orders/20260815.md
@@ -17,6 +17,10 @@
   [Stage 1 RED](../working/task_m100_3950_stage1_red.md),
   [Stage 2 보정](../working/task_m100_3950_stage2_ime_ctrl_a.md),
   [Stage 3 검증](../working/task_m100_3950_stage3_validation.md)에 남겼다.
+- [PR #4805](https://github.com/edwardkim/rhwp/pull/4805)를 `devel` 대상으로 Open 생성했다. collaborator
+  self-review라 reviewer는 지정하지 않았고, 코드 범위·IME 분기 우선순위·검증 결과는
+  [자체검토 기록](../pr/archives/pr_4805_review.md)에 남겼다. 이 review·오늘할일 trailing head의 최신
+  CI 통과 및 merge 승인 전에는 통합하지 않는다.
 
 ## kevin9327 Gym·MCP 통합 검토
 

--- a/mydocs/orders/20260815.md
+++ b/mydocs/orders/20260815.md
@@ -1,5 +1,23 @@
 # 오늘 할 일 - 2026년 8월 15일
 
+## Issue #3950 - 한글 IME 상태 Ctrl+A 모두 선택
+
+- 최신 `upstream/devel@93805ebb0`에서 이슈를 확인하고 `jangster77`을 담당자로 지정한 뒤,
+  `codex/issue-3950-ime-ctrl-a` 브랜치를 만들었다.
+- `Ctrl+A`는 현재 `e.key === 'a'`에만 의존해 한글 IME의 `ㅁ` 및 조합 중 `Process` 값을 놓친다.
+  또한 조합 이벤트는 일반 Ctrl 처리 전에 반환되므로, `KeyA` 물리 키 매칭과 IME 분기 dispatch를 함께
+  보정해야 한다.
+- 수행계획은 [Task M100 #3950](../plans/task_m100_3950.md)에 기록했다. 코드·테스트·Windows Chrome
+  검증 뒤 원격 push·PR 생성 여부는 별도 승인으로 진행한다.
+- `Ctrl+A`에 `KeyA` 물리 키 보정을 추가하고, IME 조합 분기에서 Ctrl/Meta 기본 단축키를 dispatcher로
+  전달하도록 수정했다. 한글 키값·`Process` 회귀 8건, `npx.cmd tsc --noEmit`, Studio Node 전체
+  931 통과·1 skip을 확인했다.
+- Windows Chrome에서 한글 테스트 문서의 `Ctrl+KeyA` 전 범위 선택을 확인했다. 운영체제 IME 레이아웃
+  전환은 자동화 범위 밖이므로 `ㅁ`·`Process` 이벤트 값은 Node 회귀 계약으로 검증했다. 세부는
+  [Stage 1 RED](../working/task_m100_3950_stage1_red.md),
+  [Stage 2 보정](../working/task_m100_3950_stage2_ime_ctrl_a.md),
+  [Stage 3 검증](../working/task_m100_3950_stage3_validation.md)에 남겼다.
+
 ## kevin9327 Gym·MCP 통합 검토
 
 - 최신 `upstream/devel@44bcba400` 위에 기본 작업공간에서 확인 가능한

--- a/mydocs/plans/task_m100_3950.md
+++ b/mydocs/plans/task_m100_3950.md
@@ -1,0 +1,55 @@
+# 수행계획 — Task M100 #3950
+
+- **이슈**: [#3950](https://github.com/edwardkim/rhwp/issues/3950)
+- **브랜치**: `codex/issue-3950-ime-ctrl-a`
+- **기준 commit**: `upstream/devel` `93805ebb0548a48704a0046262044295aade4bcc`
+- **작성일**: 2026-08-15 KST
+- **원격 상태**: OPEN, 담당자 `jangster77`, 연결된 Open PR 없음
+- **절차 상태**: 작업지시자가 결함 검증 및 필요한 개선을 승인함
+
+## 1. 목표
+
+Windows 한글 IME 상태에서도 `Ctrl+A`가 편집 영역의 `edit:select-all` 명령을 실행하도록 한다.
+브라우저의 문자 키 값(`e.key`)이 `ㅁ` 또는 `Process`로 바뀌어도 물리 키 코드(`e.code === 'KeyA'`)를
+사용해 같은 명령을 찾는다.
+
+## 2. 조사 결과
+
+- 기본 단축키 표에는 `Ctrl+A`가 `key: 'a'`만으로 등록돼 있어 한글 IME의 `e.key='ㅁ'` 및 조합 중
+  `e.key='Process'`와 매칭되지 않는다.
+- `onKeyDown()`은 조합 이벤트(`isComposing` 또는 `keyCode === 229`)를 일반 `handleCtrlKey()` 이전에
+  반환한다. 따라서 단축키 표에 물리 키 보정을 추가하는 것만으로는 조합 중 이벤트를 처리할 수 없다.
+- 파일 메뉴의 `edit:select-all` 명령 자체와 dispatcher 경로는 이미 존재한다. 명령 구현이나 선택 모델은
+  변경하지 않는다.
+
+## 3. 범위
+
+### 포함
+
+1. `Ctrl+A` 정의에 `KeyA` 물리 키 보정을 추가한다.
+2. IME 조합 분기에서 매칭되는 Ctrl/Meta 기본 단축키를 dispatcher로 전달한다.
+3. 한글 IME의 일반 상태(`ㅁ`)와 조합 상태(`Process`)를 고정하는 단위 테스트를 추가한다.
+4. TypeScript 검사, Studio Node 테스트, 실제 Windows Chrome 동작을 검증한다.
+
+### 제외
+
+- 모든 Ctrl 단축키의 한글 IME 키 매핑 확대
+- 선택 모델·메뉴 항목·WASM/Rust 변경
+- IME 조합 텍스트 처리 방식 변경
+
+## 4. 단계
+
+### Stage 1 — 실패 계약 고정
+
+`KeyA`에 대해 한글 IME 문자 값과 조합 중 `Process` 값을 각각 재현해 현재 단축키 표와 IME 조기 반환의
+누락을 테스트로 고정한다.
+
+### Stage 2 — 최소 보정
+
+`Ctrl+A`에 물리 키 코드를 추가하고, IME 조합 분기에서 해당 기본 단축키를 dispatch한다. Ctrl+M chord와
+조합 중 탐색키 보류의 기존 우선순위는 유지한다.
+
+### Stage 3 — 검증과 기록
+
+focused Node 테스트, TypeScript 검사, Studio 전체 Node 테스트 및 Windows Chrome 한글 IME 실동작을
+순서대로 확인하고 작업 기록을 남긴다. 원격 push·PR 생성·이슈 종료는 별도 승인 전에는 수행하지 않는다.

--- a/mydocs/pr/archives/pr_4805_review.md
+++ b/mydocs/pr/archives/pr_4805_review.md
@@ -1,0 +1,51 @@
+# PR #4805 자체검토 — 한글 IME Ctrl+A 모두 선택
+
+## 절차 라우팅
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, local_validation.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+  collaborator_self_merge.md, intake_and_review.md, local_validation.md
+current code head: b6143525614b890ef9f760d7aca2c1f88af47c81 (작성 시점 참고값)
+```
+
+## PR 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4805](https://github.com/edwardkim/rhwp/pull/4805) |
+| 작성자 | `jangster77` (collaborator self PR) |
+| base / head | `devel` ← `task_m100_3950` |
+| code head | `b6143525614b890ef9f760d7aca2c1f88af47c81` |
+| 규모 | 9 files, +190/-1 |
+| 관련 이슈 | `Closes #3950` |
+| 작성 시점 상태 | `MERGEABLE`, checks 진행 중으로 `BLOCKED` |
+
+collaborator 자신의 PR이므로 외부 reviewer는 요청하지 않고 자체검토로 처리한다. 위 상태값은 작성 시점
+참고값이며, merge 전에는 trailing head, GitHub Actions 및 mergeability를 다시 확인해야 한다.
+
+## 변경 검토
+
+1. `edit:select-all`에만 `KeyA` 물리 키 보정을 추가했다. `Ctrl+Shift+A`의 표 평균 단축키는 shift
+   조건이 달라 기존 매핑과 충돌하지 않는다.
+2. IME 분기는 기존 Ctrl+M chord 처리 뒤에 기본 Ctrl/Meta 단축키 dispatch를 둔다. 따라서 Ctrl+M 우선순위와
+   매칭되지 않은 조합·탐색 키의 기존 반환 경로를 유지한다.
+3. `ㅁ`과 `Process`의 `KeyA` 매핑 및 IME 조기 반환 전 dispatcher 전달을 회귀 계약으로 추가했다.
+   키보드 모듈의 확장자 없는 내부 import는 Node 단독 실행과 맞지 않아, 분기 전달은 소스 계약 테스트로
+   고정하고 실제 Windows Chrome의 한글 문서 전체 선택으로 동작을 보완 확인했다.
+4. renderer, layout, HWP/HWPX fixture, golden 또는 workflow 변경은 없다. 시각·fixture 증적 보조 경로는
+   적용하지 않았다.
+
+## 실행한 검증
+
+- `node --test tests/shortcut-map.test.ts tests/ime-shortcut-routing.test.ts` — 8 passed
+- `npx.cmd tsc --noEmit` — 통과
+- `npm.cmd test` — 931 passed, 0 failed, 1 skipped
+- Windows Chrome에서 `가나다라마바사` 문서의 `Ctrl+KeyA` 전체 선택 — 통과
+- `git diff --check` — 통과
+
+## 판정
+
+코드 범위와 회귀 계약이 이슈 원인에 맞고, 발견한 보정 필요 사항은 없다. 최신 trailing head의 required
+checks가 모두 통과하고 작업지시자가 merge를 승인하면 squash merge를 권고한다.

--- a/mydocs/working/task_m100_3950_stage1_red.md
+++ b/mydocs/working/task_m100_3950_stage1_red.md
@@ -1,0 +1,27 @@
+# Task M100 #3950 Stage 1 — 한글 IME Ctrl+A RED 계약
+
+## 대상
+
+- Issue: [#3950](https://github.com/edwardkim/rhwp/issues/3950)
+- 기준: `upstream/devel@93805ebb0548a48704a0046262044295aade4bcc`
+- 브랜치: `codex/issue-3950-ime-ctrl-a`
+
+## 재현
+
+`rhwp-studio/tests/shortcut-map.test.ts`에 `key='ㅁ', code='KeyA', ctrlKey=true`와
+`key='Process', code='KeyA', ctrlKey=true`를 추가했다. 기준 구현의 `Ctrl+A` 정의는 `key: 'a'`만
+가지므로 두 경우 모두 `null`을 반환했다.
+
+`rhwp-studio/tests/ime-shortcut-routing.test.ts`는 IME 조합 분기 안에서 매칭된 Ctrl/Meta 명령을
+`dispatcher`로 보내고 반환하는 계약을 고정했다. 기준 구현은 Ctrl+M chord와 탐색키 보류만 처리한 뒤
+반환하므로 이 계약도 실패했다.
+
+```text
+node --test tests/shortcut-map.test.ts tests/ime-shortcut-routing.test.ts
+결과: 6 passed, 2 failed
+```
+
+## 판정
+
+이슈의 원인은 선택 명령이 아니라 입력 이벤트 정규화와 IME 조기 반환이다. 한글 입력 상태의 `Ctrl+A`는
+현재 구현에서 여전히 누락돼 있으므로 Stage 2 최소 보정이 필요하다.

--- a/mydocs/working/task_m100_3950_stage2_ime_ctrl_a.md
+++ b/mydocs/working/task_m100_3950_stage2_ime_ctrl_a.md
@@ -1,0 +1,20 @@
+# Task M100 #3950 Stage 2 — 물리 KeyA와 IME dispatcher 보정
+
+## 변경
+
+1. `defaultShortcuts`의 `edit:select-all` 정의에 `code: 'KeyA'`를 추가했다. 이로써 한글 IME가
+   `e.key`를 `ㅁ` 또는 `Process`로 제공해도 물리 키 코드로 `Ctrl+A`를 찾는다.
+2. `onKeyDown()`의 IME 조합 분기에서 Ctrl+M chord를 먼저 유지한 뒤, `matchShortcut()`으로 찾아진
+   Ctrl/Meta 기본 명령을 기존 dispatcher에 전달하도록 했다. 매칭되지 않은 키와 탐색키 보류는 종전
+   경로를 유지한다.
+3. 한글 IME 일반·조합 상태 매핑 테스트와 IME 분기 dispatcher 계약 테스트를 추가했다.
+
+## 집중 검증
+
+```text
+node --test tests/shortcut-map.test.ts tests/ime-shortcut-routing.test.ts
+결과: 8 passed, 0 failed
+
+git diff --check
+결과: 통과
+```

--- a/mydocs/working/task_m100_3950_stage3_validation.md
+++ b/mydocs/working/task_m100_3950_stage3_validation.md
@@ -1,0 +1,32 @@
+# Task M100 #3950 Stage 3 — Studio 및 Windows Chrome 검증
+
+## 자동 검증
+
+Windows PowerShell에서 다음을 순차 실행했다.
+
+```text
+npx.cmd tsc --noEmit
+결과: 통과
+
+npm.cmd test
+결과: 931 passed, 0 failed, 1 skipped
+```
+
+`npm.ps1`은 이 호스트의 PowerShell 실행 정책에 의해 차단됐으며, 동일 npm CLI를 실행하는
+`npm.cmd`로 재실행해 판정했다.
+
+## Windows Chrome 확인
+
+로컬 Vite Studio(`http://127.0.0.1:5173/`)를 Windows Chrome에서 열고 새 문서에
+`가나다라마바사`를 입력했다. 편집 입력에서 `Ctrl+KeyA`를 실행하자 문서의 해당 한글 전 범위가
+selection overlay로 선택됐다. Studio 콘솔에는 제품 코드 오류가 없었고, 보인 오류 한 건은
+Chrome 확장 content script의 message port 종료 로그였다.
+
+브라우저 자동화는 운영체제의 한글 IME 레이아웃 전환·조합 생성까지 제어하지 못한다. 이 때문에
+`e.key='ㅁ'` 및 `e.key='Process'`와 `e.code='KeyA'`의 두 실제 입력 계약은 Stage 1/2 Node 회귀
+테스트에서 고정했고, Chrome에서는 한글 문서에 대한 실제 선택 명령 실행을 확인했다.
+
+## 다음 단계
+
+코드·테스트·작업 문서는 로컬 브랜치에만 있다. 원격 push와 PR 생성은 작업지시자 별도 승인 전에는
+수행하지 않는다.

--- a/rhwp-studio/src/command/shortcut-map.ts
+++ b/rhwp-studio/src/command/shortcut-map.ts
@@ -20,7 +20,8 @@ export const defaultShortcuts: [ShortcutDef, string][] = [
   [{ key: 'z', ctrl: true }, 'edit:undo'],
   [{ key: 'z', ctrl: true, shift: true }, 'edit:redo'],
   [{ key: 'y', ctrl: true }, 'edit:redo'],
-  [{ key: 'a', ctrl: true }, 'edit:select-all'],
+  // 한글 IME에서는 e.key가 'ㅁ' 또는 조합 중 'Process'가 되므로 물리 KeyA로 보정한다.
+  [{ key: 'a', code: 'KeyA', ctrl: true }, 'edit:select-all'],
 
   [{ key: 'e', ctrl: true }, 'edit:delete'],
   [{ key: 'ㄷ', ctrl: true }, 'edit:delete'],

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -553,6 +553,16 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
         }
       }
     }
+    // 조합 중에도 e.code로 판별 가능한 기본 Ctrl/Meta 단축키는 일반 경로와 같은 dispatcher로 보낸다.
+    // Ctrl+M chord는 위에서 먼저 소비하고, 매칭되지 않는 키는 기존 조합 처리로 계속 진행한다.
+    if ((e.ctrlKey || e.metaKey) && this.dispatcher) {
+      const cmdId = matchShortcut(e, defaultShortcuts);
+      if (cmdId) {
+        e.preventDefault();
+        this.dispatcher.dispatch(cmdId);
+        return;
+      }
+    }
     const navCodes = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown',
                       'Home', 'End', 'Escape', 'Enter', 'Tab',
                       'PageUp', 'PageDown'];

--- a/rhwp-studio/tests/ime-shortcut-routing.test.ts
+++ b/rhwp-studio/tests/ime-shortcut-routing.test.ts
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(
+  new URL('../src/engine/input-handler-keyboard.ts', import.meta.url),
+  'utf8',
+);
+
+test('IME 조합 분기는 매칭된 Ctrl 단축키를 조기 반환 전에 dispatch한다', () => {
+  const imeStart = source.indexOf('if (e.isComposing || e.keyCode === 229) {');
+  const imeEnd = source.indexOf('// [#4031]', imeStart);
+  assert.ok(imeStart >= 0 && imeEnd > imeStart, 'IME 조합 분기 경계를 찾지 못했다');
+
+  const imeBranch = source.slice(imeStart, imeEnd);
+  assert.match(
+    imeBranch,
+    /if \(\(e\.ctrlKey \|\| e\.metaKey\) && this\.dispatcher\) \{\s*const cmdId = matchShortcut\(e, defaultShortcuts\);\s*if \(cmdId\) \{\s*e\.preventDefault\(\);\s*this\.dispatcher\.dispatch\(cmdId\);\s*return;/,
+  );
+});

--- a/rhwp-studio/tests/shortcut-map.test.ts
+++ b/rhwp-studio/tests/shortcut-map.test.ts
@@ -42,6 +42,12 @@ test('IME pending 상태처럼 key가 Process여도 code로 장평/자간 단축
   assert.equal(command({ key: 'Process', code: 'KeyW', altKey: true, shiftKey: true }), 'format:char-spacing-increase');
 });
 
+test('한글 IME의 Ctrl+A를 물리 KeyA로 모두 선택에 매핑한다', () => {
+  assert.equal(command({ key: 'ㅁ', code: 'KeyA', ctrlKey: true }), 'edit:select-all');
+  assert.equal(command({ key: 'Process', code: 'KeyA', ctrlKey: true }), 'edit:select-all');
+  assert.equal(command({ key: 'ㅂ', code: 'KeyQ', ctrlKey: true }), null);
+});
+
 test('macOS 영문 입력 Option+G의 © 문자 값도 물리 KeyG로 찾아가기를 실행한다', () => {
   assert.equal(command({ key: 'g', code: 'KeyG', altKey: true }, 'mac'), 'edit:goto');
   assert.equal(command({ key: '©', code: 'KeyG', altKey: true }, 'mac'), 'edit:goto');


### PR DESCRIPTION
## 변경 요약

- 한글 IME에서 `Ctrl+A`를 물리 키 `KeyA`로 인식하도록 보정했습니다.
- 조합 중 `Process` 키 이벤트도 기본 단축키 dispatcher로 전달합니다.
- 한글 키값과 조합 상태 회귀 테스트, 작업 계획·검증 기록을 추가했습니다.

## 원인

기존 `Ctrl+A`는 `e.key === 'a'`만 비교해 한글 IME의 `ㅁ` 또는 `Process` 값을 놓쳤고, 조합 중 이벤트는
일반 Ctrl 단축키 처리 전에 반환됐습니다.

## 검증

- `node --test tests/shortcut-map.test.ts tests/ime-shortcut-routing.test.ts` — 8 passed
- `npx.cmd tsc --noEmit`
- `npm.cmd test` — 931 passed, 1 skipped
- Windows Chrome에서 한글 테스트 문서의 `Ctrl+KeyA` 전체 선택 확인

Closes #3950
