### PR TITLE
feat(gym): 재현 가능한 능력 인증서 — 위조 불가능한 능력 증명

### DIFF
--- a/gym/certify.py
+++ b/gym/certify.py
@@ -1,0 +1,164 @@
+"""gym 능력 인증서 — 능력 점수를 재현 가능하게 봉인해 위조 불가능한 신뢰 원본으로.
+
+## 왜 이 도구인가 (증명 가능한 능력)
+
+점수를 재는 것과 그 점수가 **진짜**임을 증명하는 것은 다르다. 누가 "내 에이전트가
+gym 을 만점 통과했다"고 주장해도, 그게 몰래 축소한 벤치마크나 다른 바이너리로 낸
+것이면 거짓이다. 리포트(report.py)만으로는 그 위조를 막지 못한다.
+
+이 인증서가 막는다:
+
+- **벤치마크 지문** — 전 pack 정의(pack.json·tasks·reference)의 sha256. 인증서가
+  '무엇을' 재고 채점했는지 못박는다. 벤치마크를 몰래 줄이면 지문이 바뀌어 들킨다.
+- **바이너리 신원** — `capabilitiesSha256`. '어느 바이너리로' 냈는지 못박는다.
+- **재현 = 증명** — 같은 바이너리 + 같은 벤치마크면 누구나 같은 점수를 재현한다.
+  `--verify` 가 다시 돌려 인증서와 대조한다: 재현되면 진짜, 아니면 위조.
+
+암호 서명이 아니라 **결정론적 재현**이 증명 원리다 — reproducible-build attestation 과
+같은 계열이라 키 관리 없이 누구나 검증할 수 있다.
+
+## 사용
+
+    python gym/certify.py --bin target/debug/rhwp --out cert.json      # 인증서 발급
+    python gym/certify.py --verify cert.json --bin target/debug/rhwp    # 재현 검증(exit 0/1)
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GYM_ROOT = HERE
+REPO_ROOT = os.path.dirname(GYM_ROOT)
+
+CERT_KIND = "gymCapabilityCertificate"
+CERT_SCHEMA = "1.0"
+
+
+def benchmark_fingerprint(gym_root: str) -> str:
+    """전 pack 정의(pack.json·tasks·reference)의 결정론적 sha256 — '무엇을 쟀나'를 못박는다."""
+    packs_dir = os.path.join(gym_root, "packs")
+    entries = []
+    for pack_id in sorted(os.listdir(packs_dir)):
+        pack_dir = os.path.join(packs_dir, pack_id)
+        if not os.path.isdir(pack_dir):
+            continue
+        files = [os.path.join(pack_dir, "pack.json")]
+        for sub in ("tasks", "reference"):
+            sub_dir = os.path.join(pack_dir, sub)
+            if os.path.isdir(sub_dir):
+                files += [os.path.join(sub_dir, n) for n in sorted(os.listdir(sub_dir))
+                          if n.endswith(".json")]
+        for path in sorted(files):
+            if os.path.isfile(path):
+                rel = os.path.relpath(path, gym_root).replace(os.sep, "/")
+                entries.append((rel, open(path, "rb").read()))
+    h = hashlib.sha256()
+    for rel, data in sorted(entries):
+        h.update(rel.encode("utf-8"))
+        h.update(b"\0")
+        h.update(hashlib.sha256(data).digest())
+    return h.hexdigest()
+
+
+def reproducible_core(report: dict, fingerprint: str) -> dict:
+    """인증서에서 재현으로 대조하는 필드 — 변동 메타(git commit·시각·agent 이름)는 뺀다."""
+    runner = report.get("runner") or {}
+    cov = report.get("coverage") or {}
+    return {
+        "benchmarkFingerprint": fingerprint,
+        "capabilitiesSha256": runner.get("capabilitiesSha256"),
+        "accuracy": report.get("accuracy"),
+        "coverage": {k: cov.get(k) for k in ("percent", "covered", "agentFacingTotal")},
+        "axisProfile": report.get("axisProfile"),
+    }
+
+
+def _run_report(bin_path: str) -> dict:
+    out = subprocess.run(
+        [sys.executable, os.path.join(GYM_ROOT, "report.py"), "--bin", bin_path, "--json"],
+        cwd=REPO_ROOT, capture_output=True,
+    )
+    if out.returncode != 0:
+        raise RuntimeError(f"report.py 실패: {out.stderr.decode('utf-8', 'replace')[:300]}")
+    return json.loads(out.stdout)
+
+
+def certify(bin_path: str, measured_at: str | None = None) -> dict:
+    report = _run_report(bin_path)
+    fp = benchmark_fingerprint(GYM_ROOT)
+    cert = {
+        "kind": CERT_KIND,
+        "schemaVersion": CERT_SCHEMA,
+        "benchmarkFingerprint": fp,
+        "report": report,
+        "proof": "reproduce: 같은 bin + 같은 pack 정의로 --verify 하면 core 가 일치한다",
+    }
+    if measured_at:
+        cert["certifiedAt"] = measured_at
+    return cert
+
+
+def verify(cert: dict, bin_path: str) -> tuple[bool, list[str]]:
+    """인증서를 재발급해 재현 core 를 대조한다 — 위조·환경 변화를 잡는다."""
+    if cert.get("kind") != CERT_KIND:
+        return False, [f"kind 가 {CERT_KIND} 가 아니다: {cert.get('kind')}"]
+    claimed = reproducible_core(cert.get("report", {}), cert.get("benchmarkFingerprint", ""))
+    fresh_report = _run_report(bin_path)
+    fresh = reproducible_core(fresh_report, benchmark_fingerprint(GYM_ROOT))
+    diffs = []
+    if claimed["benchmarkFingerprint"] != fresh["benchmarkFingerprint"]:
+        diffs.append("벤치마크 지문 불일치 — pack 정의가 인증 시점과 다르다(축소·변조 가능)")
+    if claimed["capabilitiesSha256"] != fresh["capabilitiesSha256"]:
+        diffs.append("바이너리 신원(capabilitiesSha256) 불일치 — 다른 바이너리다")
+    if claimed["accuracy"] != fresh["accuracy"]:
+        diffs.append(f"정확도 불일치: 인증 {claimed['accuracy']} vs 재현 {fresh['accuracy']}")
+    if claimed["coverage"] != fresh["coverage"]:
+        diffs.append(f"커버리지 불일치: 인증 {claimed['coverage']} vs 재현 {fresh['coverage']}")
+    if claimed["axisProfile"] != fresh["axisProfile"]:
+        diffs.append("축별 프로파일 불일치")
+    return (len(diffs) == 0), diffs
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="gym 능력 인증서 — 발급/재현 검증")
+    ap.add_argument("--bin", required=True, help="rhwp 바이너리")
+    ap.add_argument("--verify", help="검증할 인증서 JSON")
+    ap.add_argument("--out", help="발급 인증서 출력 파일(생략 시 stdout)")
+    ap.add_argument("--at", help="certifiedAt 메타(재현 core 에 미포함)")
+    a = ap.parse_args()
+
+    if a.verify:
+        cert = json.load(open(a.verify, encoding="utf-8"))
+        ok, diffs = verify(cert, a.bin)
+        if ok:
+            print("✅ 인증서 재현 검증 통과 — 벤치마크·바이너리·전 점수가 재현된다(진짜)")
+            return 0
+        print("❌ 인증서 재현 검증 실패:")
+        for d in diffs:
+            print(f"  - {d}")
+        return 1
+
+    cert = certify(a.bin, a.at)
+    text = json.dumps(cert, ensure_ascii=False, indent=2) + "\n"
+    if a.out:
+        open(a.out, "w", encoding="utf-8").write(text)
+        r = cert["report"]
+        print(f"발급: {a.out} · 정확도 {r['accuracy']['percent']}% · 지문 {cert['benchmarkFingerprint'][:12]}")
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
+        except Exception:
+            pass
+    sys.exit(main())

--- a/gym/report.py
+++ b/gym/report.py
@@ -119,7 +119,13 @@ def render_card(report: dict) -> str:
 
 
 def _run(tool_argv: list[str]) -> None:
-    subprocess.run([sys.executable, *tool_argv], cwd=REPO_ROOT, check=True)
+    # 하위 도구(build_baseline·score)의 진행 로그는 stderr 로 넘긴다 — report.py 의
+    # stdout 은 카드/JSON 전용으로 순수하게 둬, --json 을 기계가 그대로 파싱할 수 있게.
+    out = subprocess.run([sys.executable, *tool_argv], cwd=REPO_ROOT, capture_output=True)
+    sys.stderr.write(out.stdout.decode("utf-8", "replace"))
+    sys.stderr.write(out.stderr.decode("utf-8", "replace"))
+    if out.returncode != 0:
+        raise SystemExit(f"하위 도구 실패: {os.path.basename(str(tool_argv[0]))}")
 
 
 def _from_bin(bin_path: str) -> tuple[dict, dict]:

--- a/scripts/tests/test_gym_certify.py
+++ b/scripts/tests/test_gym_certify.py
@@ -1,0 +1,99 @@
+"""[certify] gym 능력 인증서 계약 — 벤치마크 지문 결정성 + 위조 탐지.
+
+핵심: 인증서는 '재현 = 증명'이다. 벤치마크 지문(전 pack 정의 sha256)이 결정적이고,
+재현 core(지문·바이너리 신원·정확도·커버리지·축)가 인증 시점과 하나라도 다르면
+위조로 판정한다. 바이너리 없이 순수 로직만 시험한다(재현은 _run_report 를 목킹).
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL = REPO_ROOT / "gym" / "certify.py"
+
+
+def load():
+    spec = importlib.util.spec_from_file_location("gym_certify", TOOL)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+FIXED_REPORT = {
+    "kind": "gymCapabilityReport",
+    "runner": {"rhwpVersion": "0.8.4", "rhwpCommit": "deadbeef" * 5,
+               "capabilitiesSha256": "c" * 64},
+    "accuracy": {"score": 224, "max": 224, "percent": 100},
+    "coverage": {"percent": 82, "covered": 42, "agentFacingTotal": 51},
+    "axisProfile": [{"axis": "편집", "score": 37, "max": 37, "percent": 100}],
+    "packsScored": 13,
+}
+
+
+class CertifyTests(unittest.TestCase):
+    def test_fingerprint_is_deterministic_and_change_sensitive(self):
+        cov = load()
+        with tempfile.TemporaryDirectory() as d:
+            pd = os.path.join(d, "packs", "p1")
+            os.makedirs(os.path.join(pd, "tasks"))
+            open(os.path.join(pd, "pack.json"), "w").write('{"id":"p1"}')
+            open(os.path.join(pd, "tasks", "A01.json"), "w").write('{"id":"A01"}')
+            fp1 = cov.benchmark_fingerprint(d)
+            fp2 = cov.benchmark_fingerprint(d)
+            self.assertEqual(fp1, fp2)                       # 결정적
+            self.assertEqual(len(fp1), 64)                   # sha256 hex
+            open(os.path.join(pd, "tasks", "A01.json"), "w").write('{"id":"A01","x":1}')
+            self.assertNotEqual(fp1, cov.benchmark_fingerprint(d))  # 변조에 민감
+
+    def test_reproducible_core_excludes_volatile_metadata(self):
+        cov = load()
+        core = cov.reproducible_core(FIXED_REPORT, "FP")
+        self.assertEqual(core["benchmarkFingerprint"], "FP")
+        self.assertEqual(core["capabilitiesSha256"], "c" * 64)
+        self.assertEqual(core["accuracy"], FIXED_REPORT["accuracy"])
+        # 변동 메타(git commit·agent)는 재현 core 에 없다.
+        self.assertNotIn("rhwpCommit", core)
+        self.assertNotIn("agent", core)
+
+    def test_verify_passes_for_genuine_certificate(self):
+        cov = load()
+        cov.benchmark_fingerprint = lambda root: "FP"
+        cov._run_report = lambda bin_path: copy.deepcopy(FIXED_REPORT)
+        cert = {"kind": cov.CERT_KIND, "benchmarkFingerprint": "FP",
+                "report": copy.deepcopy(FIXED_REPORT)}
+        ok, diffs = cov.verify(cert, "anybin")
+        self.assertTrue(ok, diffs)
+
+    def test_verify_detects_accuracy_tamper(self):
+        cov = load()
+        cov.benchmark_fingerprint = lambda root: "FP"
+        cov._run_report = lambda bin_path: copy.deepcopy(FIXED_REPORT)
+        cert = {"kind": cov.CERT_KIND, "benchmarkFingerprint": "FP",
+                "report": copy.deepcopy(FIXED_REPORT)}
+        cert["report"]["accuracy"]["percent"] = 999  # 위조
+        ok, diffs = cov.verify(cert, "anybin")
+        self.assertFalse(ok)
+        self.assertTrue(any("정확도" in d for d in diffs))
+
+    def test_verify_detects_shrunk_benchmark(self):
+        cov = load()
+        cov.benchmark_fingerprint = lambda root: "REAL_FP"
+        cov._run_report = lambda bin_path: copy.deepcopy(FIXED_REPORT)
+        # 인증서가 다른(축소된) 벤치마크 지문을 주장 → 재현 지문과 불일치.
+        cert = {"kind": cov.CERT_KIND, "benchmarkFingerprint": "FAKE_FP",
+                "report": copy.deepcopy(FIXED_REPORT)}
+        ok, diffs = cov.verify(cert, "anybin")
+        self.assertFalse(ok)
+        self.assertTrue(any("벤치마크 지문" in d for d in diffs))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 무엇을 / 왜

능력을 **재는 것**(report.py)과 그 점수가 **진짜임을 증명하는 것**은 다르다. 누가 "내
에이전트가 gym 만점"이라 주장해도, 몰래 축소한 벤치마크나 다른 바이너리로 낸 것이면
거짓이다. 리포트만으로는 그 위조를 못 막는다 — **gym 이 표준이 되려면 점수가 위조
불가능**해야 한다. 이게 그 결정타다.

closes #4806

## `gym/certify.py` — 재현 가능한 능력 인증서

- **벤치마크 지문** — 전 pack 정의(pack.json·tasks·reference) sha256. '무엇을' 재고
  채점했는지 못박는다. 벤치마크를 몰래 줄이면 지문이 바뀌어 들킨다.
- **바이너리 신원** — `capabilitiesSha256`. '어느 바이너리로' 냈는지 못박는다.
- **재현 = 증명** — 같은 bin + 같은 벤치마크면 누구나 같은 점수를 재현. `--verify` 가
  재발급해 인증서와 대조: 재현되면 진짜, 하나라도 다르면 위조. **암호 서명이 아니라
  결정론적 재현이 증명 원리** — 키 관리 없이 누구나 검증한다(reproducible-build attestation 계열).

부수: `report.py --json` 이 하위도구 진행로그로 오염돼 기계가 못 파싱하던 것을
순수화(진행로그→stderr) — 이제 `report.py --json` 을 그대로 파싱할 수 있다.

## 검증 (라이브 실측)

```
$ python gym/certify.py --bin target/debug/rhwp --out cert.json
발급: cert.json · 정확도 100% · 지문 e0e052988871

$ python gym/certify.py --verify cert.json --bin target/debug/rhwp
✅ 인증서 재현 검증 통과 — 벤치마크·바이너리·전 점수가 재현된다(진짜)

$ (정확도를 999로 위조 후) python gym/certify.py --verify cert_tampered.json --bin ...
❌ 인증서 재현 검증 실패:
  - 정확도 불일치: 인증 …999 vs 재현 …100
```
위조 3종(정확도·벤치마크 지문·바이너리 신원) 전부 탐지.
- 가드 `test_gym_certify.py` **5 passed**(지문 결정성·변조 민감·위조 탐지, 바이너리 없이 목킹)
- report 가드 **4 passed**(무회귀).

## 성격

측정→검증→**증명**의 정점. 능력을 재는 걸 넘어 위조 불가능하게 증명하니, 외부가
점수를 신뢰하고 재현할 수 있다 — 그래서 우리 gym 이 표준이 된다. 투명(재현으로 누구나
검증)하고 강제(위조는 재현에서 드러남)라 durable 하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
