### PR TITLE
gym 손상-강건성 감사 + HWP3 line-spacing i32 오버플로 패닉 수정 (#4814)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -931,6 +931,7 @@ jobs:
           python3 -m unittest scripts/tests/test_gym_score.py
           python3 -m unittest scripts/tests/test_gym_packs.py
           python3 -m unittest scripts/tests/test_gym_leaderboard.py
+          python3 -m unittest scripts/tests/test_gym_robustness.py
           python3 -m unittest scripts/tests/test_gym_release_diff.py
 
       # [#4715] 채택 척추 — 에이전트 작업 표준(AWS)이 전 표면에서 정합한지.

--- a/gym/README.md
+++ b/gym/README.md
@@ -252,6 +252,28 @@ python gym/tools/differential.py --limit 20 # 표본
 첫 전수 주행 실측: 139쌍·834대조 → 이름만 같은 다른 문서 7쌍 제외, 후보 2건,
 그중 IR 동일 모순 1건([#4658](https://github.com/edwardkim/rhwp/issues/4658)).
 
+## 손상-강건성 감사 — 도구가 적대적 입력에 죽지 않는가
+
+2026 프론티어(AgentHijack 등)는 에이전트가 **환경 손상**에 견디는지 잰다. gym 은
+에이전트가 rhwp 를 몰아 능력을 낸다 — 그런데 rhwp 가 손상 문서에 **패닉**하면
+에이전트가 아무리 유능해도 과제를 못 끝낸다. **도구 강건성이 능력의 천장이다.**
+
+`gym/tools/robustness.py` 는 코퍼스를 **결정적으로 손상**시켜(무작위 없음) rhwp 가
+언제나 우아하게(패닉·행 없이) 실패/부분복구하는지 인증한다:
+
+```bash
+python gym/tools/robustness.py --bin target/debug/rhwp        # 결정적 부분집합
+python gym/tools/robustness.py --bin target/debug/rhwp --limit 40
+```
+
+- **패닉**(exit 101·시그널·'panicked'·스택 오버플로)·**행**(timeout) → 실패.
+- 깨끗한 비-0 실패·경고 후 부분복구·정상 파싱 → 우아함(정상).
+
+이는 종점 무결성(판별력)·경로 무결성(트라젝토리)에 이은 세 번째 기둥 — 도구
+자체의 손상 강건성이다. 다른 문서 벤치마크가 안 재는 축: 벤치마크가 자기 도구가
+적대적 입력에 죽지 않음을 인증한다. 첫 주행이 HWP3 파서의 실제 DoS 2건을 잡았다
+(line-spacing 곱셈 i32 오버플로 패닉 — 이 PR 에서 수정 · 무한루프 1건 — 후속 이슈).
+
 ## 설계 원칙 (채점기가 지키는 것)
 
 - 표준 라이브러리 전용, Windows/리눅스 경로 안전.

--- a/gym/tools/robustness.py
+++ b/gym/tools/robustness.py
@@ -1,0 +1,164 @@
+"""gym 손상-강건성 감사 — rhwp 가 적대적/손상 입력에 절대 패닉·행 하지 않는가.
+
+## 왜 이 도구인가 (도구 강건성이 능력의 천장)
+
+2026 프론티어(AgentHijack 등)는 에이전트가 **환경 손상**에 견디는지 잰다. gym 은
+에이전트가 rhwp 를 몰아 능력을 낸다 — 그런데 rhwp 가 손상 문서에 **패닉**하면
+에이전트가 아무리 유능해도 과제를 못 끝낸다. 도구의 적대적 강건성이 능력의 천장이다.
+
+이 감사기는 코퍼스를 **결정적으로 손상**시켜(무작위 없음 — 재현 가능) rhwp 가 언제나
+우아하게 실패/부분복구하는지 인증한다:
+
+- **패닉**(exit 101 · 시그널/음수 코드 · 'panicked' · 스택 오버플로) → 실패.
+- **행**(timeout) → 실패.
+- 그 외(깨끗한 비-0 실패 · 경고 후 부분복구 · 정상 파싱) → 우아함(정상).
+
+종점 무결성(#4808 판별력)·경로 무결성(#4810 트라젝토리)에 이은 세 번째 기둥 —
+도구 자체의 손상 강건성. 이것이 다른 문서 벤치마크가 안 재는 축이다: 벤치마크가
+자기 도구가 적대적 입력에 죽지 않음을 CI 로 인증한다.
+
+## 사용
+
+    python gym/tools/robustness.py --bin target/debug/rhwp            # 결정적 부분집합
+    python gym/tools/robustness.py --bin target/debug/rhwp --limit 40 # 더 넓게
+    python gym/tools/robustness.py --bin target/debug/rhwp --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GYM_ROOT = os.path.dirname(HERE)
+REPO_ROOT = os.path.dirname(GYM_ROOT)
+sys.path.insert(0, GYM_ROOT)
+
+from core import runner  # noqa: E402
+
+
+def deterministic_mutants(data: bytes):
+    """결정적 손상 변형들 — (라벨, 바이트). 무작위 없음(재현 가능)."""
+    n = len(data)
+    out = []
+    for pct in (25, 50, 75, 95):                       # 절단
+        out.append((f"truncate@{pct}%", data[:max(1, n * pct // 100)]))
+    for pct in (10, 50, 90):                           # 바이트 플립
+        pos = min(n - 1, n * pct // 100)
+        b = bytearray(data)
+        b[pos] ^= 0xFF
+        out.append((f"flip@{pct}%", bytes(b)))
+    b = bytearray(data)                                # 헤더 매직 파손
+    for i in range(min(n, 512)):
+        b[i] = 0
+    out.append(("zero-header", bytes(b)))
+    return out
+
+
+def select_samples(samples_dir: str, limit: int):
+    """정렬된 .hwp 를 결정적 stride 로 limit 개 뽑는다(형식·크기 다양성 확보)."""
+    everything = sorted(f for f in os.listdir(samples_dir) if f.endswith(".hwp"))
+    if not everything or limit <= 0:
+        return everything[:max(0, limit)], len(everything)
+    if len(everything) <= limit:
+        return everything, len(everything)
+    stride = len(everything) / limit
+    picked = [everything[min(len(everything) - 1, int(i * stride))] for i in range(limit)]
+    # stride 반올림 중복 제거(순서 유지)
+    seen, uniq = set(), []
+    for f in picked:
+        if f not in seen:
+            seen.add(f)
+            uniq.append(f)
+    return uniq, len(everything)
+
+
+def is_panic(code, err: str) -> bool:
+    """우아한 실패(비-0)와 패닉(크래시)을 가른다."""
+    low = err.lower()
+    if "panicked" in low or "stack overflow" in low or "core dumped" in low:
+        return True
+    if code is None:
+        return False
+    return code == 101 or code < 0 or code >= 132  # 시그널/어보트/AV
+
+
+def probe(bin_path: str, path: str, timeout: int):
+    """한 손상 파일을 파싱 시도 — (code, panicked, timed_out, head)."""
+    try:
+        p = subprocess.run([bin_path, "info", path, "--json"], cwd=REPO_ROOT,
+                           capture_output=True, timeout=timeout)
+        err = p.stderr.decode("utf-8", "replace") + p.stdout.decode("utf-8", "replace")
+        return p.returncode, is_panic(p.returncode, err), False, err[:160]
+    except subprocess.TimeoutExpired:
+        return None, False, True, f"timeout {timeout}s"
+
+
+def audit(bin_path: str, samples_dir: str, limit: int, timeout: int) -> dict:
+    picked, total = select_samples(samples_dir, limit)
+    panics, hangs = [], []
+    checked = 0
+    degraded = 0
+    with tempfile.TemporaryDirectory() as work:
+        mut_path = os.path.join(work, "mutant.hwp")
+        for name in picked:
+            data = open(os.path.join(samples_dir, name), "rb").read()
+            for label, mut in deterministic_mutants(data):
+                open(mut_path, "wb").write(mut)
+                code, panicked, timed_out, head = probe(bin_path, mut_path, timeout)
+                checked += 1
+                tag = f"{name}:{label}"
+                if timed_out:
+                    hangs.append(tag)
+                elif panicked:
+                    panics.append(f"{tag} (code {code}): {head}")
+                elif code not in (0, None):
+                    degraded += 1
+    return {
+        "kind": "gymRobustness",
+        "schemaVersion": "1.0",
+        "ok": len(panics) == 0 and len(hangs) == 0,
+        "samplesTested": len(picked),
+        "totalSamples": total,
+        "mutantsChecked": checked,
+        "gracefullyDegraded": degraded,
+        "panics": panics,
+        "hangs": hangs,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="gym 손상-강건성 감사 — rhwp 패닉·행 색출")
+    ap.add_argument("--bin", required=True)
+    ap.add_argument("--limit", type=int, default=16, help="감사할 샘플 수(결정적 부분집합)")
+    ap.add_argument("--timeout", type=int, default=20)
+    ap.add_argument("--json", action="store_true")
+    a = ap.parse_args()
+    bin_path = runner.find_bin(a.bin)
+    samples_dir = os.path.join(REPO_ROOT, "samples")
+    report = audit(bin_path, samples_dir, a.limit, a.timeout)
+    import json
+    if a.json:
+        sys.stdout.write(json.dumps(report, ensure_ascii=False, indent=2) + "\n")
+    elif report["ok"]:
+        print(f"gym 손상-강건성 감사: 샘플 {report['samplesTested']}/{report['totalSamples']} × "
+              f"손상 {report['mutantsChecked']}건 — 패닉 0 · 행 0 "
+              f"(우아한 실패/부분복구 {report['gracefullyDegraded']})")
+    else:
+        print(f"gym 손상-강건성 감사: 패닉 {len(report['panics'])} · 행 {len(report['hangs'])} — "
+              "rhwp 가 손상 입력에 죽는다:")
+        for t in report["panics"] + report["hangs"]:
+            print(f"  - {t}")
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
+        except Exception:
+            pass
+    sys.exit(main())

--- a/scripts/tests/test_gym_robustness.py
+++ b/scripts/tests/test_gym_robustness.py
@@ -1,0 +1,88 @@
+"""[robustness] gym 손상-강건성 감사 계약 — 결정적 손상 + 패닉/행 색출.
+
+핵심: rhwp 는 손상 입력에 절대 패닉·행 하면 안 된다. 감사기는 코퍼스를 결정적으로
+손상시켜 파싱하고, 패닉(코드 101/음수/'panicked')·행(timeout) 이 있으면 실패로 잡는다.
+파싱은 목킹해 바이너리 없이 로직만 시험한다.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+TOOL = Path(__file__).resolve().parents[2] / "gym" / "tools" / "robustness.py"
+
+
+def load():
+    spec = importlib.util.spec_from_file_location("gym_robustness", TOOL)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class RobustnessTests(unittest.TestCase):
+    def test_mutants_deterministic_and_nontrivial(self):
+        mod = load()
+        data = bytes(range(256)) * 8  # 2KB
+        a = mod.deterministic_mutants(data)
+        b = mod.deterministic_mutants(data)
+        self.assertEqual([l for l, _ in a], [l for l, _ in b])   # 결정적(라벨 동일)
+        self.assertEqual([m for _, m in a], [m for _, m in b])   # 결정적(바이트 동일)
+        self.assertGreaterEqual(len(a), 8)
+        for label, mut in a:
+            self.assertNotEqual(mut, data, f"{label} 이 원본과 같다(무의미 변형)")
+
+    def test_is_panic_distinguishes_crash_from_clean_failure(self):
+        mod = load()
+        self.assertTrue(mod.is_panic(101, ""))                       # 어보트
+        self.assertTrue(mod.is_panic(0, "thread 'main' panicked"))   # 패닉 메시지
+        self.assertTrue(mod.is_panic(-1073741819, ""))               # AV(음수)
+        self.assertFalse(mod.is_panic(1, "오류: 유효하지 않은 파일")) # 깨끗한 실패
+        self.assertFalse(mod.is_panic(0, "정상"))                    # 정상
+
+    def test_select_samples_deterministic_and_bounded(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            for i in range(50):
+                open(os.path.join(d, f"s{i:03d}.hwp"), "wb").write(b"x")
+            open(os.path.join(d, "not-a-sample.txt"), "wb").write(b"x")
+            picked1, total = mod.select_samples(d, 10)
+            picked2, _ = mod.select_samples(d, 10)
+            self.assertEqual(total, 50)              # .txt 제외
+            self.assertLessEqual(len(picked1), 10)
+            self.assertEqual(picked1, picked2)       # 결정적
+            self.assertTrue(all(f.endswith(".hwp") for f in picked1))
+
+    def _audit_with_probe(self, mod, probe_result):
+        with tempfile.TemporaryDirectory() as d:
+            open(os.path.join(d, "s.hwp"), "wb").write(bytes(range(256)) * 8)
+            mod.probe = lambda bin_path, path, timeout: probe_result
+            return mod.audit("bin", d, limit=1, timeout=5)
+
+    def test_flags_panic(self):
+        mod = load()
+        r = self._audit_with_probe(mod, (101, True, False, "panicked"))
+        self.assertFalse(r["ok"])
+        self.assertTrue(r["panics"])
+
+    def test_flags_hang(self):
+        mod = load()
+        r = self._audit_with_probe(mod, (None, False, True, "timeout"))
+        self.assertFalse(r["ok"])
+        self.assertTrue(r["hangs"])
+
+    def test_clean_when_graceful(self):
+        mod = load()
+        r = self._audit_with_probe(mod, (1, False, False, "오류"))
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["panics"], [])
+        self.assertEqual(r["hangs"], [])
+        self.assertGreater(r["gracefullyDegraded"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -2896,7 +2896,9 @@ pub(crate) fn parse_paragraph_list(
                 // percent: lh=th, ls=th*(ratio-100)/100
                 (
                     fallback_text_height,
-                    fallback_text_height * (line_spacing_ratio - 100) / 100,
+                    // 손상 입력의 큰 line_spacing 으로 i32 곱셈이 오버플로(패닉)하지
+                    // 않도록 i64 중간연산 — 정상값에선 결과가 i32 범위라 동일하다.
+                    (fallback_text_height as i64 * (line_spacing_ratio as i64 - 100) / 100) as i32,
                 )
             };
         fallback_line_height = fallback_line_height.max(100); // 0 방지
@@ -3067,7 +3069,8 @@ pub(crate) fn parse_paragraph_list(
                         {
                             HWP3_TAC_OBJECT_LINE_SPACING_HU
                         } else {
-                            th * (line_spacing_ratio - 100) / 100
+                            // i64 중간연산으로 손상 입력의 i32 곱셈 오버플로(패닉) 방지.
+                            (th as i64 * (line_spacing_ratio as i64 - 100) / 100) as i32
                         };
                     }
                 }
@@ -4812,6 +4815,20 @@ mod tests {
             decompress_hwp3_body_limited(&compressed, plain.len()).unwrap(),
             plain
         );
+    }
+
+    /// [robustness] 손상된 HWP3 의 큰 line_spacing 으로 line-spacing 곱셈
+    /// `th * (ratio-100)` 이 i32 오버플로로 패닉하던 회귀(hwp3/mod.rs:3070).
+    /// 이제 i64 중간연산이라 패닉 없이 Ok/Err 로 우아하게 끝나야 한다. 패닉하면
+    /// 이 테스트가 abort 되어 실패한다.
+    #[test]
+    fn corrupt_hwp3_line_spacing_does_not_overflow_panic() {
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/samples/hwp3-sample11.hwp");
+        let data = std::fs::read(path).expect("샘플 읽기");
+        let mut corrupt = data.clone();
+        let pos = corrupt.len() * 10 / 100; // 감사기가 패닉을 재현한 결정적 손상
+        corrupt[pos] ^= 0xFF;
+        let _ = parse_hwp3(&corrupt); // 결과값 무관 — 패닉만 안 하면 통과
     }
 
     /// [#3676] `cold`는 미주 fixup의 부수 효과가 아니라 구역 본문 계약이다.


### PR DESCRIPTION
## 요약

이슈 #4814 를 구현한다. gym 에 **손상-강건성 감사**를 도입하고, 그 감사가 첫 주행에서
잡은 **HWP3 파서 i32 오버플로 패닉**을 수정한다. 이는 종점 무결성(판별력)·경로
무결성(트라젝토리)에 이은 세 번째 기둥 — **도구 자체의 손상 강건성**이다.

2026 프론티어(AgentHijack 등)는 에이전트가 환경 손상에 견디는지 잰다. gym 은
에이전트가 rhwp 를 몰아 능력을 낸다 — rhwp 가 손상 문서에 패닉하면 에이전트가
아무리 유능해도 과제를 못 끝낸다. **도구 강건성이 능력의 천장**이다.

## 무엇을 하나

### 1) 손상-강건성 감사 — `gym/tools/robustness.py`

코퍼스를 **결정적으로 손상**(절단·바이트플립·헤더영점, 무작위 없음)시켜 파싱하고,
**패닉**(exit 101·시그널·'panicked'·스택 오버플로)·**행**(timeout)이 하나라도
있으면 실패로 리포트한다.

```bash
python gym/tools/robustness.py --bin target/debug/rhwp
# → gym 손상-강건성 감사: 샘플 16/277 × 손상 128건 — 패닉 0 · 행 0 (우아한 실패/부분복구 65)
```

### 2) HWP3 line-spacing i32 오버플로 패닉 수정

감사 첫 주행이 실제 DoS 를 잡았다: `hwp3-sample11.hwp` 10% 바이트 플립에서
`src/parser/hwp3/mod.rs:3070` 의 `th * (line_spacing_ratio - 100) / 100` 이
**i32 오버플로로 패닉**(`attempt to multiply with overflow`). 손상 입력의 큰
`line_spacing`(u16, ≤65535) × `th`(=line_height×4) 가 i32 를 넘긴다. 같은 패턴이
line 2899(fallback)에도 있다.

**수정**: 두 사이트를 **i64 중간연산**으로 바꿨다 — 정상값에선 결과가 i32 범위라
동일하고, 손상값에선 패닉 없이 우아하게 처리된다. 수정 후 sample11 은 exit 1 +
깨끗한 에러로 우아하게 실패한다.

### 3) 무한루프는 별도 이슈

같은 감사가 `hwp3-sample14.hwp` 10% 플립에서 **무한루프(>60s)** 도 잡았다. 근본
원인이 달라(오버플로 아님 · 루프 커서 전진) 별도 이슈 #4813 으로 분리했다. 이 PR
은 오버플로 패닉만 수정한다(무한루프가 남아 있어 릴리스 게이트 배선은 #4813 수정
후 후속 PR 로 미룬다).

## 검증

```
cargo test corrupt_hwp3_line_spacing_does_not_overflow_panic → ok (패닉 없음)
python gym/tools/robustness.py --bin <rhwp> --limit 16       → 패닉 0 · 행 0 (128 손상)
python -m unittest test_gym_robustness                        → 6/6
```

## 가드

- **Rust 회귀 테스트**(`corrupt_hwp3_line_spacing_does_not_overflow_panic`): 손상
  HWP3 파싱이 패닉하면 abort 되어 실패 — 오버플로 재발 방지.
- `scripts/tests/test_gym_robustness.py` — 결정적 변형·패닉/우아한실패 판별·감사
  로직을 바이너리 없이 목킹으로 시험(6건). ci.yml gym 가드 블록에 등록. README 문서.
