### PR TITLE
렌더러 layout i32 오버플로 체계적 하드닝 — 퍼징 7479건 실측 (#4817)

### DIFF
--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -413,7 +413,7 @@ pub fn caption_height_px(caption: &Option<Caption>, dpi: f64) -> f64 {
     for para in &caption.paragraphs {
         if let (Some(first), Some(last)) = (para.line_segs.first(), para.line_segs.last()) {
             let para_top = first.vertical_pos.min(0);
-            let para_bottom = last.vertical_pos + last.line_height;
+            let para_bottom = last.vertical_pos.saturating_add(last.line_height);
             line_seg_height = line_seg_height.max(hwpunit_to_px(para_bottom - para_top, dpi));
         }
 

--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -2603,7 +2603,9 @@ fn reflow_line_segs_impl(
     // (layout.rs의 vpos 보정이 문단 간 vpos 연속성을 가정하므로)
     let mut vpos = if preserved_prefix_len > 0 {
         let last = &new_line_segs[preserved_prefix_len - 1];
-        last.vertical_pos.saturating_add(last.line_height).saturating_add(last.line_spacing)
+        last.vertical_pos
+            .saturating_add(last.line_height)
+            .saturating_add(last.line_spacing)
     } else {
         orig.as_ref().map(|ls| ls.vertical_pos).unwrap_or(0)
     };

--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -2372,7 +2372,7 @@ fn reflow_line_segs_impl(
             let mut vpos = orig.as_ref().map(|ls| ls.vertical_pos).unwrap_or(0);
             for seg in &mut new_line_segs {
                 seg.vertical_pos = vpos;
-                vpos += seg.line_height + seg.line_spacing;
+                vpos += seg.line_height.saturating_add(seg.line_spacing);
             }
             para.line_segs = new_line_segs;
         } else {
@@ -2603,7 +2603,7 @@ fn reflow_line_segs_impl(
     // (layout.rs의 vpos 보정이 문단 간 vpos 연속성을 가정하므로)
     let mut vpos = if preserved_prefix_len > 0 {
         let last = &new_line_segs[preserved_prefix_len - 1];
-        last.vertical_pos + last.line_height + last.line_spacing
+        last.vertical_pos.saturating_add(last.line_height).saturating_add(last.line_spacing)
     } else {
         orig.as_ref().map(|ls| ls.vertical_pos).unwrap_or(0)
     };

--- a/src/renderer/height_cursor.rs
+++ b/src/renderer/height_cursor.rs
@@ -202,7 +202,10 @@ impl HeightCursor {
         if seg.vertical_pos == 0 && prev_pi > 0 {
             return y_offset;
         }
-        let prev_vpos_end = seg.vertical_pos.saturating_add(seg.line_height).saturating_add(seg.line_spacing);
+        let prev_vpos_end = seg
+            .vertical_pos
+            .saturating_add(seg.line_height)
+            .saturating_add(seg.line_spacing);
         let curr_first_vpos = paragraphs
             .get(item_para)
             .and_then(|p| p.line_segs.first())
@@ -629,7 +632,12 @@ impl HeightCursor {
         let current_line_advance_px = paragraphs
             .get(item_para)
             .and_then(|p| p.line_segs.first())
-            .map(|s| hwpunit_to_px((s.line_height.saturating_add(s.line_spacing)).max(0), self.dpi))
+            .map(|s| {
+                hwpunit_to_px(
+                    (s.line_height.saturating_add(s.line_spacing)).max(0),
+                    self.dpi,
+                )
+            })
             .unwrap_or(0.0);
         let compact_endnote_page_no_separator_tail_pullup = self.suppress_large_forward_jump
             && is_page_path

--- a/src/renderer/height_cursor.rs
+++ b/src/renderer/height_cursor.rs
@@ -202,7 +202,7 @@ impl HeightCursor {
         if seg.vertical_pos == 0 && prev_pi > 0 {
             return y_offset;
         }
-        let prev_vpos_end = seg.vertical_pos + seg.line_height + seg.line_spacing;
+        let prev_vpos_end = seg.vertical_pos.saturating_add(seg.line_height).saturating_add(seg.line_spacing);
         let curr_first_vpos = paragraphs
             .get(item_para)
             .and_then(|p| p.line_segs.first())
@@ -546,7 +546,7 @@ impl HeightCursor {
             && !curr_is_equation_only_tail
             && matches!(
                 curr_first_vpos,
-                Some(v) if v - seg.vertical_pos >= seg.line_height + seg.line_spacing
+                Some(v) if v - seg.vertical_pos >= seg.line_height.saturating_add(seg.line_spacing)
             );
         let compact_endnote_page_tail_backtrack = self.suppress_large_forward_jump
             && is_page_path
@@ -629,7 +629,7 @@ impl HeightCursor {
         let current_line_advance_px = paragraphs
             .get(item_para)
             .and_then(|p| p.line_segs.first())
-            .map(|s| hwpunit_to_px((s.line_height + s.line_spacing).max(0), self.dpi))
+            .map(|s| hwpunit_to_px((s.line_height.saturating_add(s.line_spacing)).max(0), self.dpi))
             .unwrap_or(0.0);
         let compact_endnote_page_no_separator_tail_pullup = self.suppress_large_forward_jump
             && is_page_path

--- a/src/renderer/height_measurer.rs
+++ b/src/renderer/height_measurer.rs
@@ -544,7 +544,12 @@ impl HeightMeasurer {
                 let para_extent = p
                     .line_segs
                     .iter()
-                    .map(|s| hwpunit_to_px(s.vertical_pos.saturating_add(s.line_height.max(0)), self.dpi))
+                    .map(|s| {
+                        hwpunit_to_px(
+                            s.vertical_pos.saturating_add(s.line_height.max(0)),
+                            self.dpi,
+                        )
+                    })
                     .fold(prev_extent, f64::max);
                 prev_extent = para_extent;
                 let object_bottom = p
@@ -893,7 +898,9 @@ impl HeightMeasurer {
                     && first.line_height == last.line_height
                 {
                     let vpos_h = hwpunit_to_px(
-                        last.vertical_pos.saturating_add(last.line_height).saturating_add(last.line_spacing)
+                        last.vertical_pos
+                            .saturating_add(last.line_height)
+                            .saturating_add(last.line_spacing)
                             - first.vertical_pos,
                         self.dpi,
                     );
@@ -927,7 +934,10 @@ impl HeightMeasurer {
                                 let adj: f64 = para.line_segs[..guide_segs]
                                     .iter()
                                     .map(|seg| {
-                                        hwpunit_to_px(seg.line_height.saturating_add(seg.line_spacing), self.dpi)
+                                        hwpunit_to_px(
+                                            seg.line_height.saturating_add(seg.line_spacing),
+                                            self.dpi,
+                                        )
                                     })
                                     .sum();
                                 return Some(adj);
@@ -1147,7 +1157,9 @@ impl HeightMeasurer {
                         .iter()
                         .take(pidx)
                         .flat_map(|prev| prev.line_segs.iter())
-                        .map(|s| hwpunit_to_px(s.vertical_pos.saturating_add(s.line_height), self.dpi))
+                        .map(|s| {
+                            hwpunit_to_px(s.vertical_pos.saturating_add(s.line_height), self.dpi)
+                        })
                         .filter(|&e| e <= para_top + 0.5)
                         .fold(f64::NEG_INFINITY, f64::max);
                     let gap_before = para_top - prev_end;
@@ -1574,7 +1586,12 @@ impl HeightMeasurer {
                             .iter()
                             .flat_map(|pp| pp.line_segs.iter())
                             .filter(|seg| seg.vertical_pos >= 0 && seg.line_height > 0)
-                            .map(|seg| hwpunit_to_px(seg.vertical_pos.saturating_add(seg.line_height), self.dpi))
+                            .map(|seg| {
+                                hwpunit_to_px(
+                                    seg.vertical_pos.saturating_add(seg.line_height),
+                                    self.dpi,
+                                )
+                            })
                             .fold(0.0f64, f64::max)
                     } else {
                         0.0

--- a/src/renderer/height_measurer.rs
+++ b/src/renderer/height_measurer.rs
@@ -544,7 +544,7 @@ impl HeightMeasurer {
                 let para_extent = p
                     .line_segs
                     .iter()
-                    .map(|s| hwpunit_to_px(s.vertical_pos + s.line_height.max(0), self.dpi))
+                    .map(|s| hwpunit_to_px(s.vertical_pos.saturating_add(s.line_height.max(0)), self.dpi))
                     .fold(prev_extent, f64::max);
                 prev_extent = para_extent;
                 let object_bottom = p
@@ -893,7 +893,7 @@ impl HeightMeasurer {
                     && first.line_height == last.line_height
                 {
                     let vpos_h = hwpunit_to_px(
-                        last.vertical_pos + last.line_height + last.line_spacing
+                        last.vertical_pos.saturating_add(last.line_height).saturating_add(last.line_spacing)
                             - first.vertical_pos,
                         self.dpi,
                     );
@@ -927,7 +927,7 @@ impl HeightMeasurer {
                                 let adj: f64 = para.line_segs[..guide_segs]
                                     .iter()
                                     .map(|seg| {
-                                        hwpunit_to_px(seg.line_height + seg.line_spacing, self.dpi)
+                                        hwpunit_to_px(seg.line_height.saturating_add(seg.line_spacing), self.dpi)
                                     })
                                     .sum();
                                 return Some(adj);
@@ -1099,7 +1099,7 @@ impl HeightMeasurer {
             paragraphs
                 .iter()
                 .flat_map(|p| p.line_segs.iter())
-                .map(|s| hwpunit_to_px(s.vertical_pos + s.line_height, self.dpi))
+                .map(|s| hwpunit_to_px(s.vertical_pos.saturating_add(s.line_height), self.dpi))
                 .fold(0.0f64, f64::max)
         } else {
             0.0
@@ -1147,7 +1147,7 @@ impl HeightMeasurer {
                         .iter()
                         .take(pidx)
                         .flat_map(|prev| prev.line_segs.iter())
-                        .map(|s| hwpunit_to_px(s.vertical_pos + s.line_height, self.dpi))
+                        .map(|s| hwpunit_to_px(s.vertical_pos.saturating_add(s.line_height), self.dpi))
                         .filter(|&e| e <= para_top + 0.5)
                         .fold(f64::NEG_INFINITY, f64::max);
                     let gap_before = para_top - prev_end;
@@ -1541,7 +1541,7 @@ impl HeightMeasurer {
                         .paragraphs
                         .iter()
                         .flat_map(|p| p.line_segs.last())
-                        .map(|s| s.vertical_pos + s.line_height)
+                        .map(|s| s.vertical_pos.saturating_add(s.line_height))
                         .max()
                         .unwrap_or(0);
                     let nested_bottom = self.cell_nested_controls_bottom(
@@ -1574,7 +1574,7 @@ impl HeightMeasurer {
                             .iter()
                             .flat_map(|pp| pp.line_segs.iter())
                             .filter(|seg| seg.vertical_pos >= 0 && seg.line_height > 0)
-                            .map(|seg| hwpunit_to_px(seg.vertical_pos + seg.line_height, self.dpi))
+                            .map(|seg| hwpunit_to_px(seg.vertical_pos.saturating_add(seg.line_height), self.dpi))
                             .fold(0.0f64, f64::max)
                     } else {
                         0.0

--- a/src/renderer/layout/shape_layout.rs
+++ b/src/renderer/layout/shape_layout.rs
@@ -3221,7 +3221,9 @@ impl LayoutEngine {
                     start_idx: chars.len(),
                     end_idx: chars.len(),
                     col_width: ls
-                        .map(|l| hwpunit_to_px(l.line_height.saturating_add(l.line_spacing), self.dpi))
+                        .map(|l| {
+                            hwpunit_to_px(l.line_height.saturating_add(l.line_spacing), self.dpi)
+                        })
                         .unwrap_or(13.0),
                     col_spacing: 0.0,
                     total_height: 0.0,

--- a/src/renderer/layout/shape_layout.rs
+++ b/src/renderer/layout/shape_layout.rs
@@ -588,7 +588,7 @@ impl LayoutEngine {
                         break;
                     }
                     if let Some(last_ls) = tp.line_segs.last() {
-                        let end = last_ls.vertical_pos + last_ls.line_height;
+                        let end = last_ls.vertical_pos.saturating_add(last_ls.line_height);
                         if end > max_vpos_end {
                             max_vpos_end = end;
                         }
@@ -2552,7 +2552,7 @@ impl LayoutEngine {
                 }
                 // 이 문단의 마지막 line_seg의 끝 위치 추적
                 if let Some(last_ls) = para.line_segs.last() {
-                    let end = last_ls.vertical_pos + last_ls.line_height;
+                    let end = last_ls.vertical_pos.saturating_add(last_ls.line_height);
                     if end > max_vpos_end {
                         max_vpos_end = end;
                     }
@@ -3221,7 +3221,7 @@ impl LayoutEngine {
                     start_idx: chars.len(),
                     end_idx: chars.len(),
                     col_width: ls
-                        .map(|l| hwpunit_to_px(l.line_height + l.line_spacing, self.dpi))
+                        .map(|l| hwpunit_to_px(l.line_height.saturating_add(l.line_spacing), self.dpi))
                         .unwrap_or(13.0),
                     col_spacing: 0.0,
                     total_height: 0.0,
@@ -3236,7 +3236,7 @@ impl LayoutEngine {
                 let ls = para.line_segs.get(line_idx);
                 // 칼럼 너비 = line_height + line_spacing (전체 피치 흡수)
                 let col_width = ls
-                    .map(|l| hwpunit_to_px(l.line_height + l.line_spacing, self.dpi))
+                    .map(|l| hwpunit_to_px(l.line_height.saturating_add(l.line_spacing), self.dpi))
                     .unwrap_or(13.0);
                 let col_spacing = 0.0;
                 let absorbed_spacing = ls
@@ -3727,7 +3727,7 @@ impl LayoutEngine {
                     .paragraphs
                     .iter()
                     .flat_map(|p| p.line_segs.last())
-                    .map(|s| s.vertical_pos + s.line_height)
+                    .map(|s| s.vertical_pos.saturating_add(s.line_height))
                     .max()
                     .unwrap_or(0);
                 let required = content_h as u32 + pad_top + pad_bottom;

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -6604,7 +6604,7 @@ impl LayoutEngine {
             paragraphs
                 .iter()
                 .flat_map(|p| p.line_segs.iter())
-                .map(|s| hwpunit_to_px(s.vertical_pos + s.line_height, self.dpi))
+                .map(|s| hwpunit_to_px(s.vertical_pos.saturating_add(s.line_height), self.dpi))
                 .fold(0.0f64, f64::max)
         } else {
             0.0

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -1688,7 +1688,7 @@ fn stored_fragment_extent_hu(cell: &crate::model::table::Cell, group: (usize, us
         .iter()
         .flat_map(|para| para.line_segs.iter())
         .filter(|seg| seg.vertical_pos >= 0)
-        .map(|seg| seg.vertical_pos + seg.line_height.max(0))
+        .map(|seg| seg.vertical_pos.saturating_add(seg.line_height.max(0)))
         .max()
         .unwrap_or(0)
 }
@@ -2072,7 +2072,7 @@ impl LayoutEngine {
                 let para_extent = p
                     .line_segs
                     .iter()
-                    .map(|s| hwpunit_to_px(s.vertical_pos + s.line_height.max(0), self.dpi))
+                    .map(|s| hwpunit_to_px(s.vertical_pos.saturating_add(s.line_height.max(0)), self.dpi))
                     .fold(prev_extent, f64::max);
                 prev_extent = para_extent;
                 let object_bottom = p
@@ -6203,7 +6203,7 @@ impl LayoutEngine {
                 let vpos_height = if cell.paragraphs.len() > 1 {
                     let last_para = cell.paragraphs.last().unwrap();
                     if let Some(seg) = last_para.line_segs.last() {
-                        let mut last_end = seg.vertical_pos + seg.line_height;
+                        let mut last_end = seg.vertical_pos.saturating_add(seg.line_height);
                         // 마지막 문단에 중첩 표가 있고 lh가 표 높이보다 작으면 보정
                         for ctrl in &last_para.controls {
                             if let Control::Table(t) = ctrl {
@@ -6354,7 +6354,7 @@ impl LayoutEngine {
                     .filter(|s| s.vertical_pos >= 0 && s.line_height > 0)
                     .map(|s| {
                         (
-                            hwpunit_to_px(s.vertical_pos + s.line_height, self.dpi),
+                            hwpunit_to_px(s.vertical_pos.saturating_add(s.line_height), self.dpi),
                             hwpunit_to_px(s.line_height, self.dpi),
                         )
                     })
@@ -6643,7 +6643,7 @@ impl LayoutEngine {
                         .iter()
                         .take(pidx)
                         .flat_map(|prev| prev.line_segs.iter())
-                        .map(|s| hwpunit_to_px(s.vertical_pos + s.line_height, self.dpi))
+                        .map(|s| hwpunit_to_px(s.vertical_pos.saturating_add(s.line_height), self.dpi))
                         .filter(|&e| e <= para_top + 0.5)
                         .fold(f64::NEG_INFINITY, f64::max);
                     let gap_before = para_top - prev_end;
@@ -6859,7 +6859,7 @@ impl LayoutEngine {
                 let prev_end_vpos = prev_para
                     .line_segs
                     .last()
-                    .map(|s| s.vertical_pos + s.line_height)
+                    .map(|s| s.vertical_pos.saturating_add(s.line_height))
                     .unwrap_or(-1);
                 let cur_first_vpos = para.line_segs.first().map(|s| s.vertical_pos).unwrap_or(-1);
                 if cur_first_vpos >= 0 && prev_end_vpos > 0 {
@@ -7933,7 +7933,7 @@ impl LayoutEngine {
             {
                 return false;
             }
-            let prev_end = prev.vertical_pos + prev.line_height;
+            let prev_end = prev.vertical_pos.saturating_add(prev.line_height);
             if cur.vertical_pos < 0 || prev_end <= 0 || cur.vertical_pos >= prev_end {
                 return false;
             }
@@ -8177,7 +8177,7 @@ impl LayoutEngine {
                                         && i64::from(seg.line_height) * 4
                                             >= i64::from(next.line_height) * 3;
                                     full_line_box
-                                        && next.vertical_pos >= seg.vertical_pos + seg.line_height
+                                        && next.vertical_pos >= seg.vertical_pos.saturating_add(seg.line_height)
                                 }
                                 _ => false,
                             }
@@ -8268,7 +8268,7 @@ impl LayoutEngine {
                     (Some(prev_seg), Some(cur_seg))
                         if !line_seg_is_synthetic(prev_seg) && !line_seg_is_synthetic(cur_seg) =>
                     {
-                        let prev_end = prev_seg.vertical_pos + prev_seg.line_height;
+                        let prev_end = prev_seg.vertical_pos.saturating_add(prev_seg.line_height);
                         cur_seg.vertical_pos >= 0 && prev_end > 0 && cur_seg.vertical_pos < prev_end
                     }
                     _ => false,
@@ -8328,7 +8328,7 @@ impl LayoutEngine {
                         if !line_seg_is_synthetic(prev_seg) && !line_seg_is_synthetic(cur_seg) =>
                     {
                         let prev_end =
-                            prev_seg.vertical_pos + prev_seg.line_height + prev_seg.line_spacing;
+                            prev_seg.vertical_pos.saturating_add(prev_seg.line_height).saturating_add(prev_seg.line_spacing);
                         cur_seg.vertical_pos >= 0
                             && prev_end > 0
                             && cur_seg.vertical_pos > prev_end + vpos_gap_threshold_hu
@@ -8354,7 +8354,7 @@ impl LayoutEngine {
                 if line_seg_is_synthetic(prev) || line_seg_is_synthetic(cur) {
                     return false;
                 }
-                let prev_end = prev.vertical_pos + prev.line_height;
+                let prev_end = prev.vertical_pos.saturating_add(prev.line_height);
                 cur.vertical_pos >= 0 && prev_end > 0 && cur.vertical_pos < prev_end
             };
             let stored_frame_break_before = |li: usize| -> bool {

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -2072,7 +2072,12 @@ impl LayoutEngine {
                 let para_extent = p
                     .line_segs
                     .iter()
-                    .map(|s| hwpunit_to_px(s.vertical_pos.saturating_add(s.line_height.max(0)), self.dpi))
+                    .map(|s| {
+                        hwpunit_to_px(
+                            s.vertical_pos.saturating_add(s.line_height.max(0)),
+                            self.dpi,
+                        )
+                    })
                     .fold(prev_extent, f64::max);
                 prev_extent = para_extent;
                 let object_bottom = p
@@ -6643,7 +6648,9 @@ impl LayoutEngine {
                         .iter()
                         .take(pidx)
                         .flat_map(|prev| prev.line_segs.iter())
-                        .map(|s| hwpunit_to_px(s.vertical_pos.saturating_add(s.line_height), self.dpi))
+                        .map(|s| {
+                            hwpunit_to_px(s.vertical_pos.saturating_add(s.line_height), self.dpi)
+                        })
                         .filter(|&e| e <= para_top + 0.5)
                         .fold(f64::NEG_INFINITY, f64::max);
                     let gap_before = para_top - prev_end;
@@ -8177,7 +8184,8 @@ impl LayoutEngine {
                                         && i64::from(seg.line_height) * 4
                                             >= i64::from(next.line_height) * 3;
                                     full_line_box
-                                        && next.vertical_pos >= seg.vertical_pos.saturating_add(seg.line_height)
+                                        && next.vertical_pos
+                                            >= seg.vertical_pos.saturating_add(seg.line_height)
                                 }
                                 _ => false,
                             }
@@ -8327,8 +8335,10 @@ impl LayoutEngine {
                     (Some(prev_seg), Some(cur_seg))
                         if !line_seg_is_synthetic(prev_seg) && !line_seg_is_synthetic(cur_seg) =>
                     {
-                        let prev_end =
-                            prev_seg.vertical_pos.saturating_add(prev_seg.line_height).saturating_add(prev_seg.line_spacing);
+                        let prev_end = prev_seg
+                            .vertical_pos
+                            .saturating_add(prev_seg.line_height)
+                            .saturating_add(prev_seg.line_spacing);
                         cur_seg.vertical_pos >= 0
                             && prev_end > 0
                             && cur_seg.vertical_pos > prev_end + vpos_gap_threshold_hu

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -2201,7 +2201,8 @@ fn hwpx_explicit_page_break_tail_line(
             && prev.vertical_pos > 0
             && tail.vertical_pos == 0
             && hwpunit_to_px(prev.vertical_pos, dpi) >= body_height_px * 0.70
-            && hwpunit_to_px(prev.vertical_pos.saturating_add(prev.line_height), dpi) <= body_height_px + 1.0
+            && hwpunit_to_px(prev.vertical_pos.saturating_add(prev.line_height), dpi)
+                <= body_height_px + 1.0
         {
             return Some(split_line);
         }
@@ -2482,7 +2483,8 @@ fn native_hwp5_first_footnote_overlap_break_line(
             let visible_bottom =
                 hwpunit_to_px(prev.vertical_pos - page_vpos_base + prev.line_height, dpi);
             let trailing_bottom = hwpunit_to_px(
-                prev.vertical_pos - page_vpos_base + prev.line_height.saturating_add(prev.line_spacing),
+                prev.vertical_pos - page_vpos_base
+                    + prev.line_height.saturating_add(prev.line_spacing),
                 dpi,
             );
             let trailing_spacing_only_overlap =
@@ -3075,7 +3077,8 @@ fn table_declared_height_has_stored_cell_content_frame(
                     .filter(|seg| !is_synthetic_line_seg(seg))
                     .filter(|seg| seg.vertical_pos >= 0 && seg.line_height > 0)
                 {
-                    let bottom = hwpunit_to_px(seg.vertical_pos.saturating_add(seg.line_height), dpi);
+                    let bottom =
+                        hwpunit_to_px(seg.vertical_pos.saturating_add(seg.line_height), dpi);
                     stored_bottom =
                         Some(stored_bottom.map_or(bottom, |current: f64| current.max(bottom)));
                 }
@@ -4949,7 +4952,10 @@ fn ladder_spacing_omitted_signature(
             continue;
         }
         let step = hwpunit_to_px(next_first.vertical_pos - cur_last.vertical_pos, dpi);
-        let bare = hwpunit_to_px(cur_last.line_height.saturating_add(cur_last.line_spacing), dpi);
+        let bare = hwpunit_to_px(
+            cur_last.line_height.saturating_add(cur_last.line_spacing),
+            dpi,
+        );
         if step <= 0.0 || bare <= 0.0 {
             continue;
         }
@@ -6162,7 +6168,9 @@ impl TypesetEngine {
                                     .iter()
                                     .filter(|seg| !is_synthetic_line_seg(seg))
                                     .map(|seg| {
-                                        seg.vertical_pos.saturating_add(seg.line_height).saturating_add(seg.line_spacing)
+                                        seg.vertical_pos
+                                            .saturating_add(seg.line_height)
+                                            .saturating_add(seg.line_spacing)
                                     })
                                     .max()?;
                                 (text_bottom > anchor_top)
@@ -6239,7 +6247,9 @@ impl TypesetEngine {
                                         .take(wrap_prefix_len)
                                         .filter(|seg| !is_synthetic_line_seg(seg))
                                         .map(|seg| {
-                                            seg.vertical_pos.saturating_add(seg.line_height).saturating_add(seg.line_spacing)
+                                            seg.vertical_pos
+                                                .saturating_add(seg.line_height)
+                                                .saturating_add(seg.line_spacing)
                                         })
                                         .max()?;
                                     (prefix_bottom > anchor_top).then(|| {
@@ -7017,7 +7027,12 @@ impl TypesetEngine {
                     let empty_h_px = para
                         .line_segs
                         .first()
-                        .map(|s| hwpunit_to_px((s.line_height.saturating_add(s.line_spacing)) as i32, self.dpi))
+                        .map(|s| {
+                            hwpunit_to_px(
+                                (s.line_height.saturating_add(s.line_spacing)) as i32,
+                                self.dpi,
+                            )
+                        })
                         .unwrap_or(0.0);
                     let height_fits = empty_h_px <= st.available_height() - st.current_height;
 
@@ -7062,7 +7077,8 @@ impl TypesetEngine {
                                     st.layout.body_area.height,
                                     self.dpi,
                                 );
-                                let vpos_end = last_seg.vertical_pos.saturating_add(last_seg.line_height);
+                                let vpos_end =
+                                    last_seg.vertical_pos.saturating_add(last_seg.line_height);
                                 vpos_end <= top + body_h_hu + 283
                             }
                             // vpos 판정 불가 → 제약 없음(height fit 에 위임).
@@ -7117,7 +7133,12 @@ impl TypesetEngine {
                     let empty_h_px = para
                         .line_segs
                         .first()
-                        .map(|s| hwpunit_to_px((s.line_height.saturating_add(s.line_spacing)) as i32, self.dpi))
+                        .map(|s| {
+                            hwpunit_to_px(
+                                (s.line_height.saturating_add(s.line_spacing)) as i32,
+                                self.dpi,
+                            )
+                        })
                         .unwrap_or(0.0);
                     let avail = st.available_height() - st.current_height;
                     if empty_h_px > avail {
@@ -7174,7 +7195,12 @@ impl TypesetEngine {
                 let empty_h_px = para
                     .line_segs
                     .first()
-                    .map(|s| hwpunit_to_px((s.line_height.saturating_add(s.line_spacing)) as i32, self.dpi))
+                    .map(|s| {
+                        hwpunit_to_px(
+                            (s.line_height.saturating_add(s.line_spacing)) as i32,
+                            self.dpi,
+                        )
+                    })
                     .unwrap_or(0.0);
                 let avail = st.available_height() - st.current_height;
                 if empty_h_px > avail {
@@ -7275,7 +7301,10 @@ impl TypesetEngine {
                         .line_segs
                         .iter()
                         .map(|s| {
-                            crate::renderer::hwpunit_to_px(s.line_height.saturating_add(s.line_spacing), self.dpi)
+                            crate::renderer::hwpunit_to_px(
+                                s.line_height.saturating_add(s.line_spacing),
+                                self.dpi,
+                            )
                         })
                         .sum();
                     let para_h_hu = crate::renderer::px_to_hwpunit(para_h_px, self.dpi);
@@ -9441,7 +9470,10 @@ impl TypesetEngine {
                 .iter()
                 .map(|s| {
                     (
-                        s.vertical_pos.saturating_add(s.line_height).saturating_add(s.line_spacing) + endnote_start,
+                        s.vertical_pos
+                            .saturating_add(s.line_height)
+                            .saturating_add(s.line_spacing)
+                            + endnote_start,
                         s.line_spacing,
                     )
                 })
@@ -9927,7 +9959,12 @@ impl TypesetEngine {
                         .iter()
                         .skip(ep_idx + 1)
                         .flat_map(|p| p.line_segs.iter())
-                        .map(|s| s.vertical_pos.saturating_add(s.line_height).saturating_add(s.line_spacing) + endnote_start)
+                        .map(|s| {
+                            s.vertical_pos
+                                .saturating_add(s.line_height)
+                                .saturating_add(s.line_spacing)
+                                + endnote_start
+                        })
                         .max();
                     Some(
                         tail_bottom
@@ -12817,7 +12854,11 @@ impl TypesetEngine {
                         let bottom = p
                             .line_segs
                             .iter()
-                            .map(|s| s.vertical_pos.saturating_add(s.line_height).saturating_add(s.line_spacing))
+                            .map(|s| {
+                                s.vertical_pos
+                                    .saturating_add(s.line_height)
+                                    .saturating_add(s.line_spacing)
+                            })
                             .max()?;
                         Some(hwpunit_to_px((bottom - first).max(0), self.dpi))
                     })
@@ -12867,7 +12908,11 @@ impl TypesetEngine {
                     let Some(bottom) = para
                         .line_segs
                         .iter()
-                        .map(|seg| seg.vertical_pos.saturating_add(seg.line_height).saturating_add(seg.line_spacing))
+                        .map(|seg| {
+                            seg.vertical_pos
+                                .saturating_add(seg.line_height)
+                                .saturating_add(seg.line_spacing)
+                        })
                         .max()
                     else {
                         continue;
@@ -12921,8 +12966,10 @@ impl TypesetEngine {
             && !st.current_items.is_empty()
             && en_ctrl.paragraphs.first().is_some_and(|head| {
                 head.line_segs.first().is_some_and(|seg| {
-                    let title_h =
-                        hwpunit_to_px((seg.line_height.saturating_add(seg.line_spacing)).max(0), self.dpi);
+                    let title_h = hwpunit_to_px(
+                        (seg.line_height.saturating_add(seg.line_spacing)).max(0),
+                        self.dpi,
+                    );
                     title_h > 0.0
                         && st.current_height + title_h
                             <= st.available_height()
@@ -12945,8 +12992,10 @@ impl TypesetEngine {
                 let Some(first) = head.line_segs.first() else {
                     return false;
                 };
-                let title_h =
-                    hwpunit_to_px((first.line_height.saturating_add(first.line_spacing)).max(0), self.dpi);
+                let title_h = hwpunit_to_px(
+                    (first.line_height.saturating_add(first.line_spacing)).max(0),
+                    self.dpi,
+                );
                 title_h > 0.0
                     && st.current_height + title_h
                         <= st.available_height() + ENDNOTE_COLUMN_BOTTOM_BLEED_TOLERANCE_PX + 2.0
@@ -12972,9 +13021,11 @@ impl TypesetEngine {
                 .paragraphs
                 .iter()
                 .flat_map(|p| {
-                    p.line_segs
-                        .iter()
-                        .map(|s| s.vertical_pos.saturating_add(s.line_height).saturating_add(s.line_spacing))
+                    p.line_segs.iter().map(|s| {
+                        s.vertical_pos
+                            .saturating_add(s.line_height)
+                            .saturating_add(s.line_spacing)
+                    })
                 })
                 .max();
             if let (Some(first), Some(bottom)) = (group_first, group_bottom) {
@@ -13006,7 +13057,11 @@ impl TypesetEngine {
             let bottom = p
                 .line_segs
                 .iter()
-                .map(|s| s.vertical_pos.saturating_add(s.line_height).saturating_add(s.line_spacing))
+                .map(|s| {
+                    s.vertical_pos
+                        .saturating_add(s.line_height)
+                        .saturating_add(s.line_spacing)
+                })
                 .max();
             let group_rewind = matches!(
                 (prev_group_bottom, first),
@@ -13299,7 +13354,11 @@ impl TypesetEngine {
             let mut vpos_offset: i32 = paragraphs
                 .last()
                 .and_then(|p| p.line_segs.last())
-                .map(|ls| ls.vertical_pos.saturating_add(ls.line_height).saturating_add(ls.line_spacing))
+                .map(|ls| {
+                    ls.vertical_pos
+                        .saturating_add(ls.line_height)
+                        .saturating_add(ls.line_spacing)
+                })
                 .unwrap_or(0);
             // [Task #1082] 다단 미주 vpos-delta 누적용 prev tracker.
             // 시드 = 현재 단의 본문 last bottom vpos(body→endnote 전환 정합); 없으면 None
@@ -13632,7 +13691,9 @@ impl TypesetEngine {
                     let segs = &item_para.line_segs;
                     match (
                         segs.first(),
-                        segs.iter().map(|s| s.vertical_pos.saturating_add(s.line_height)).max(),
+                        segs.iter()
+                            .map(|s| s.vertical_pos.saturating_add(s.line_height))
+                            .max(),
                     ) {
                         (Some(first), Some(bottom)) => {
                             hwpunit_to_px((bottom - first.vertical_pos).max(0), self.dpi)
@@ -13646,7 +13707,9 @@ impl TypesetEngine {
                     let segs = &item_para.line_segs;
                     match (
                         segs.first(),
-                        segs.iter().map(|s| s.vertical_pos.saturating_add(s.line_height)).max(),
+                        segs.iter()
+                            .map(|s| s.vertical_pos.saturating_add(s.line_height))
+                            .max(),
                     ) {
                         (Some(first), Some(bottom)) => {
                             hwpunit_to_px((bottom - first.vertical_pos).max(0), self.dpi)
@@ -14513,7 +14576,12 @@ impl TypesetEngine {
                         .iter()
                         .take(3)
                         .flat_map(|p| p.line_segs.iter())
-                        .map(|s| s.vertical_pos.saturating_add(s.line_height).saturating_add(s.line_spacing) + endnote_start)
+                        .map(|s| {
+                            s.vertical_pos
+                                .saturating_add(s.line_height)
+                                .saturating_add(s.line_spacing)
+                                + endnote_start
+                        })
                         .max()?;
                     let group_first = first_para_vpos.vertical_pos + endnote_start;
                     let group_h = hwpunit_to_px((group_bottom - group_first).max(0), self.dpi);
@@ -14627,7 +14695,10 @@ impl TypesetEngine {
                         .take(3)
                         .flat_map(|p| p.line_segs.iter())
                         .map(|seg| {
-                            seg.vertical_pos.saturating_add(seg.line_height).saturating_add(seg.line_spacing) + endnote_start
+                            seg.vertical_pos
+                                .saturating_add(seg.line_height)
+                                .saturating_add(seg.line_spacing)
+                                + endnote_start
                         })
                         .max();
                     group_first
@@ -15846,10 +15917,11 @@ impl TypesetEngine {
         // trailing_ls 는 페이지 마지막 항목의 fit 판정에만 의미가 있음
         // (페이지 끝에는 다음 줄이 없으니 line_spacing 미적용).
         // [Task #1082] 본문 para 의 bottom offset vpos — 미주 vpos-delta 시드용.
-        let body_bottom_vpos: Option<i32> = para
-            .line_segs
-            .last()
-            .map(|s| s.vertical_pos.saturating_add(s.line_height).saturating_add(s.line_spacing));
+        let body_bottom_vpos: Option<i32> = para.line_segs.last().map(|s| {
+            s.vertical_pos
+                .saturating_add(s.line_height)
+                .saturating_add(s.line_spacing)
+        });
         // HWP3-origin 변환본은 spacing_before 누적을 보존해야 dump-pages 요약과
         // 실제 한컴 줄 흐름이 유지된다(#1116).
         let trim_spacing_before_for_flow =
@@ -17835,7 +17907,10 @@ impl TypesetEngine {
                             lh + ls_extra,
                             para.line_segs
                                 .first()
-                                .map(|s0| hwpunit_to_px(s0.line_height.saturating_add(s0.line_spacing), self.dpi))
+                                .map(|s0| hwpunit_to_px(
+                                    s0.line_height.saturating_add(s0.line_spacing),
+                                    self.dpi
+                                ))
                                 .unwrap_or(0.0),
                         );
                     }
@@ -23819,7 +23894,9 @@ impl TypesetEngine {
                 if let Some(pi) = last_para_idx {
                     if let Some(seg) = paragraphs.get(pi).and_then(|p| p.line_segs.last()) {
                         let v = hwpunit_to_px(
-                            seg.vertical_pos.saturating_add(seg.line_height).saturating_add(seg.line_spacing),
+                            seg.vertical_pos
+                                .saturating_add(seg.line_height)
+                                .saturating_add(seg.line_spacing),
                             self.dpi,
                         );
                         if v > band_height_px {

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -2156,7 +2156,7 @@ fn internal_vpos_page_break_line(
             } else {
                 cur.vertical_pos <= 0
                     || (cur.vertical_pos < prev.vertical_pos
-                        && hwpunit_to_px(prev.vertical_pos + prev.line_height, dpi)
+                        && hwpunit_to_px(prev.vertical_pos.saturating_add(prev.line_height), dpi)
                             >= body_height_px * 0.72
                         && hwpunit_to_px(cur.vertical_pos, dpi) <= body_height_px * 0.06)
             };
@@ -2201,7 +2201,7 @@ fn hwpx_explicit_page_break_tail_line(
             && prev.vertical_pos > 0
             && tail.vertical_pos == 0
             && hwpunit_to_px(prev.vertical_pos, dpi) >= body_height_px * 0.70
-            && hwpunit_to_px(prev.vertical_pos + prev.line_height, dpi) <= body_height_px + 1.0
+            && hwpunit_to_px(prev.vertical_pos.saturating_add(prev.line_height), dpi) <= body_height_px + 1.0
         {
             return Some(split_line);
         }
@@ -2482,7 +2482,7 @@ fn native_hwp5_first_footnote_overlap_break_line(
             let visible_bottom =
                 hwpunit_to_px(prev.vertical_pos - page_vpos_base + prev.line_height, dpi);
             let trailing_bottom = hwpunit_to_px(
-                prev.vertical_pos - page_vpos_base + prev.line_height + prev.line_spacing,
+                prev.vertical_pos - page_vpos_base + prev.line_height.saturating_add(prev.line_spacing),
                 dpi,
             );
             let trailing_spacing_only_overlap =
@@ -2810,7 +2810,7 @@ fn native_hwp5_text_reset_before_large_tac_topbottom_picture_break_line(
             {
                 return None;
             }
-            (hwpunit_to_px(prev.vertical_pos + prev.line_height, dpi)
+            (hwpunit_to_px(prev.vertical_pos.saturating_add(prev.line_height), dpi)
                 >= st.layout.body_area.height * 0.70)
                 .then_some(prev_idx + 1)
         })
@@ -3075,7 +3075,7 @@ fn table_declared_height_has_stored_cell_content_frame(
                     .filter(|seg| !is_synthetic_line_seg(seg))
                     .filter(|seg| seg.vertical_pos >= 0 && seg.line_height > 0)
                 {
-                    let bottom = hwpunit_to_px(seg.vertical_pos + seg.line_height, dpi);
+                    let bottom = hwpunit_to_px(seg.vertical_pos.saturating_add(seg.line_height), dpi);
                     stored_bottom =
                         Some(stored_bottom.map_or(bottom, |current: f64| current.max(bottom)));
                 }
@@ -3529,7 +3529,7 @@ fn native_hwp5_circled_rowbreak_table_heading_requires_fresh_page(
         .line_segs
         .first()
         .filter(|seg| !is_synthetic_line_seg(seg))
-        .map(|seg| hwpunit_to_px(seg.line_height + seg.line_spacing, dpi))
+        .map(|seg| hwpunit_to_px(seg.line_height.saturating_add(seg.line_spacing), dpi))
         // A missing carrier LINE_SEG is a native HWP5 encoding variant.  Its
         // actual advance is never smaller than the RowBreak orphan minimum, so
         // use that lower bound only for this page-tail decision.
@@ -3854,7 +3854,7 @@ fn saved_line_range_fits_body_tail(
         if prev_vpos.is_some_and(|prev| seg.vertical_pos < prev) {
             return false;
         }
-        let bottom_px = hwpunit_to_px(seg.vertical_pos + seg.line_height, dpi);
+        let bottom_px = hwpunit_to_px(seg.vertical_pos.saturating_add(seg.line_height), dpi);
         if bottom_px > body_height_px + 0.5 {
             return false;
         }
@@ -4949,7 +4949,7 @@ fn ladder_spacing_omitted_signature(
             continue;
         }
         let step = hwpunit_to_px(next_first.vertical_pos - cur_last.vertical_pos, dpi);
-        let bare = hwpunit_to_px(cur_last.line_height + cur_last.line_spacing, dpi);
+        let bare = hwpunit_to_px(cur_last.line_height.saturating_add(cur_last.line_spacing), dpi);
         if step <= 0.0 || bare <= 0.0 {
             continue;
         }
@@ -5607,7 +5607,7 @@ impl TypesetEngine {
                 .first()
                 .filter(|ls| !is_synthetic_line_seg(ls));
             if let Some((prev_real_idx, prev_last)) = prev_real_idx_and_ls {
-                let prev_end_vpos = prev_last.vertical_pos + prev_last.line_height;
+                let prev_end_vpos = prev_last.vertical_pos.saturating_add(prev_last.line_height);
                 let prev_positive_wrap_end = paragraphs
                     .get(prev_real_idx)
                     .and_then(positive_vpos_end_before_negative_wrap);
@@ -6162,7 +6162,7 @@ impl TypesetEngine {
                                     .iter()
                                     .filter(|seg| !is_synthetic_line_seg(seg))
                                     .map(|seg| {
-                                        seg.vertical_pos + seg.line_height + seg.line_spacing
+                                        seg.vertical_pos.saturating_add(seg.line_height).saturating_add(seg.line_spacing)
                                     })
                                     .max()?;
                                 (text_bottom > anchor_top)
@@ -6239,7 +6239,7 @@ impl TypesetEngine {
                                         .take(wrap_prefix_len)
                                         .filter(|seg| !is_synthetic_line_seg(seg))
                                         .map(|seg| {
-                                            seg.vertical_pos + seg.line_height + seg.line_spacing
+                                            seg.vertical_pos.saturating_add(seg.line_height).saturating_add(seg.line_spacing)
                                         })
                                         .max()?;
                                     (prefix_bottom > anchor_top).then(|| {
@@ -6729,7 +6729,7 @@ impl TypesetEngine {
                     let prev_vpos_end = prev_para
                         .line_segs
                         .last()
-                        .map(|s| s.vertical_pos + s.line_height)
+                        .map(|s| s.vertical_pos.saturating_add(s.line_height))
                         .unwrap_or(pv);
                     // [Task #1086 Stage 3] HWP3-origin page tolerance 대상 문서는
                     // 새 페이지 첫 문단을 vpos=0 이 아니라 200/500HU 근방으로
@@ -7017,7 +7017,7 @@ impl TypesetEngine {
                     let empty_h_px = para
                         .line_segs
                         .first()
-                        .map(|s| hwpunit_to_px((s.line_height + s.line_spacing) as i32, self.dpi))
+                        .map(|s| hwpunit_to_px((s.line_height.saturating_add(s.line_spacing)) as i32, self.dpi))
                         .unwrap_or(0.0);
                     let height_fits = empty_h_px <= st.available_height() - st.current_height;
 
@@ -7062,7 +7062,7 @@ impl TypesetEngine {
                                     st.layout.body_area.height,
                                     self.dpi,
                                 );
-                                let vpos_end = last_seg.vertical_pos + last_seg.line_height;
+                                let vpos_end = last_seg.vertical_pos.saturating_add(last_seg.line_height);
                                 vpos_end <= top + body_h_hu + 283
                             }
                             // vpos 판정 불가 → 제약 없음(height fit 에 위임).
@@ -7117,7 +7117,7 @@ impl TypesetEngine {
                     let empty_h_px = para
                         .line_segs
                         .first()
-                        .map(|s| hwpunit_to_px((s.line_height + s.line_spacing) as i32, self.dpi))
+                        .map(|s| hwpunit_to_px((s.line_height.saturating_add(s.line_spacing)) as i32, self.dpi))
                         .unwrap_or(0.0);
                     let avail = st.available_height() - st.current_height;
                     if empty_h_px > avail {
@@ -7174,7 +7174,7 @@ impl TypesetEngine {
                 let empty_h_px = para
                     .line_segs
                     .first()
-                    .map(|s| hwpunit_to_px((s.line_height + s.line_spacing) as i32, self.dpi))
+                    .map(|s| hwpunit_to_px((s.line_height.saturating_add(s.line_spacing)) as i32, self.dpi))
                     .unwrap_or(0.0);
                 let avail = st.available_height() - st.current_height;
                 if empty_h_px > avail {
@@ -7275,7 +7275,7 @@ impl TypesetEngine {
                         .line_segs
                         .iter()
                         .map(|s| {
-                            crate::renderer::hwpunit_to_px(s.line_height + s.line_spacing, self.dpi)
+                            crate::renderer::hwpunit_to_px(s.line_height.saturating_add(s.line_spacing), self.dpi)
                         })
                         .sum();
                     let para_h_hu = crate::renderer::px_to_hwpunit(para_h_px, self.dpi);
@@ -7303,7 +7303,7 @@ impl TypesetEngine {
                                 .iter()
                                 .map(|s| {
                                     crate::renderer::hwpunit_to_px(
-                                        s.line_height + s.line_spacing,
+                                        s.line_height.saturating_add(s.line_spacing),
                                         self.dpi,
                                     )
                                 })
@@ -7888,7 +7888,7 @@ impl TypesetEngine {
                                     let prev_end = paragraphs[para_idx - 1]
                                         .line_segs
                                         .last()
-                                        .map(|s| s.vertical_pos + s.line_height);
+                                        .map(|s| s.vertical_pos.saturating_add(s.line_height));
                                     match (v_cur, prev_end) {
                                         (Some(vc), Some(pe)) if vc > pe => {
                                             hwpunit_to_px((vc - pe) as i32, self.dpi)
@@ -8189,7 +8189,7 @@ impl TypesetEngine {
                                     marker_line + 1 == reset_line
                                         && para.line_segs.get(marker_line).is_some_and(|line| {
                                             hwpunit_to_px(
-                                                line.vertical_pos + line.line_height,
+                                                line.vertical_pos.saturating_add(line.line_height),
                                                 self.dpi,
                                             ) >= st.layout.body_area.height * 0.90
                                         })
@@ -9441,7 +9441,7 @@ impl TypesetEngine {
                 .iter()
                 .map(|s| {
                     (
-                        s.vertical_pos + s.line_height + s.line_spacing + endnote_start,
+                        s.vertical_pos.saturating_add(s.line_height).saturating_add(s.line_spacing) + endnote_start,
                         s.line_spacing,
                     )
                 })
@@ -9450,7 +9450,7 @@ impl TypesetEngine {
             let this_content_bottom_offset = en_para
                 .line_segs
                 .iter()
-                .map(|s| s.vertical_pos + s.line_height + endnote_start)
+                .map(|s| s.vertical_pos.saturating_add(s.line_height) + endnote_start)
                 .max();
             // 다음 미주 묶음의 시작점도 렌더상 가장 낮은 줄 기준으로 갱신한다.
             // 마지막 LINE_SEG가 위쪽으로 되감기는 문단에서는 last 기준이
@@ -9927,7 +9927,7 @@ impl TypesetEngine {
                         .iter()
                         .skip(ep_idx + 1)
                         .flat_map(|p| p.line_segs.iter())
-                        .map(|s| s.vertical_pos + s.line_height + s.line_spacing + endnote_start)
+                        .map(|s| s.vertical_pos.saturating_add(s.line_height).saturating_add(s.line_spacing) + endnote_start)
                         .max();
                     Some(
                         tail_bottom
@@ -12195,7 +12195,7 @@ impl TypesetEngine {
                     .flat_map(|p| p.line_segs.iter())
                     .fold(None::<(i32, i32)>, |acc, seg| {
                         let first = seg.vertical_pos + endnote_start;
-                        let bottom = first + seg.line_height + seg.line_spacing;
+                        let bottom = first + seg.line_height.saturating_add(seg.line_spacing);
                         Some(match acc {
                             Some((min_first, max_bottom)) => {
                                 (min_first.min(first), max_bottom.max(bottom))
@@ -12817,7 +12817,7 @@ impl TypesetEngine {
                         let bottom = p
                             .line_segs
                             .iter()
-                            .map(|s| s.vertical_pos + s.line_height + s.line_spacing)
+                            .map(|s| s.vertical_pos.saturating_add(s.line_height).saturating_add(s.line_spacing))
                             .max()?;
                         Some(hwpunit_to_px((bottom - first).max(0), self.dpi))
                     })
@@ -12867,7 +12867,7 @@ impl TypesetEngine {
                     let Some(bottom) = para
                         .line_segs
                         .iter()
-                        .map(|seg| seg.vertical_pos + seg.line_height + seg.line_spacing)
+                        .map(|seg| seg.vertical_pos.saturating_add(seg.line_height).saturating_add(seg.line_spacing))
                         .max()
                     else {
                         continue;
@@ -12922,7 +12922,7 @@ impl TypesetEngine {
             && en_ctrl.paragraphs.first().is_some_and(|head| {
                 head.line_segs.first().is_some_and(|seg| {
                     let title_h =
-                        hwpunit_to_px((seg.line_height + seg.line_spacing).max(0), self.dpi);
+                        hwpunit_to_px((seg.line_height.saturating_add(seg.line_spacing)).max(0), self.dpi);
                     title_h > 0.0
                         && st.current_height + title_h
                             <= st.available_height()
@@ -12946,7 +12946,7 @@ impl TypesetEngine {
                     return false;
                 };
                 let title_h =
-                    hwpunit_to_px((first.line_height + first.line_spacing).max(0), self.dpi);
+                    hwpunit_to_px((first.line_height.saturating_add(first.line_spacing)).max(0), self.dpi);
                 title_h > 0.0
                     && st.current_height + title_h
                         <= st.available_height() + ENDNOTE_COLUMN_BOTTOM_BLEED_TOLERANCE_PX + 2.0
@@ -12974,7 +12974,7 @@ impl TypesetEngine {
                 .flat_map(|p| {
                     p.line_segs
                         .iter()
-                        .map(|s| s.vertical_pos + s.line_height + s.line_spacing)
+                        .map(|s| s.vertical_pos.saturating_add(s.line_height).saturating_add(s.line_spacing))
                 })
                 .max();
             if let (Some(first), Some(bottom)) = (group_first, group_bottom) {
@@ -13006,7 +13006,7 @@ impl TypesetEngine {
             let bottom = p
                 .line_segs
                 .iter()
-                .map(|s| s.vertical_pos + s.line_height + s.line_spacing)
+                .map(|s| s.vertical_pos.saturating_add(s.line_height).saturating_add(s.line_spacing))
                 .max();
             let group_rewind = matches!(
                 (prev_group_bottom, first),
@@ -13299,7 +13299,7 @@ impl TypesetEngine {
             let mut vpos_offset: i32 = paragraphs
                 .last()
                 .and_then(|p| p.line_segs.last())
-                .map(|ls| ls.vertical_pos + ls.line_height + ls.line_spacing)
+                .map(|ls| ls.vertical_pos.saturating_add(ls.line_height).saturating_add(ls.line_spacing))
                 .unwrap_or(0);
             // [Task #1082] 다단 미주 vpos-delta 누적용 prev tracker.
             // 시드 = 현재 단의 본문 last bottom vpos(body→endnote 전환 정합); 없으면 None
@@ -13632,7 +13632,7 @@ impl TypesetEngine {
                     let segs = &item_para.line_segs;
                     match (
                         segs.first(),
-                        segs.iter().map(|s| s.vertical_pos + s.line_height).max(),
+                        segs.iter().map(|s| s.vertical_pos.saturating_add(s.line_height)).max(),
                     ) {
                         (Some(first), Some(bottom)) => {
                             hwpunit_to_px((bottom - first.vertical_pos).max(0), self.dpi)
@@ -13646,7 +13646,7 @@ impl TypesetEngine {
                     let segs = &item_para.line_segs;
                     match (
                         segs.first(),
-                        segs.iter().map(|s| s.vertical_pos + s.line_height).max(),
+                        segs.iter().map(|s| s.vertical_pos.saturating_add(s.line_height)).max(),
                     ) {
                         (Some(first), Some(bottom)) => {
                             hwpunit_to_px((bottom - first.vertical_pos).max(0), self.dpi)
@@ -14513,7 +14513,7 @@ impl TypesetEngine {
                         .iter()
                         .take(3)
                         .flat_map(|p| p.line_segs.iter())
-                        .map(|s| s.vertical_pos + s.line_height + s.line_spacing + endnote_start)
+                        .map(|s| s.vertical_pos.saturating_add(s.line_height).saturating_add(s.line_spacing) + endnote_start)
                         .max()?;
                     let group_first = first_para_vpos.vertical_pos + endnote_start;
                     let group_h = hwpunit_to_px((group_bottom - group_first).max(0), self.dpi);
@@ -14627,7 +14627,7 @@ impl TypesetEngine {
                         .take(3)
                         .flat_map(|p| p.line_segs.iter())
                         .map(|seg| {
-                            seg.vertical_pos + seg.line_height + seg.line_spacing + endnote_start
+                            seg.vertical_pos.saturating_add(seg.line_height).saturating_add(seg.line_spacing) + endnote_start
                         })
                         .max();
                     group_first
@@ -15849,7 +15849,7 @@ impl TypesetEngine {
         let body_bottom_vpos: Option<i32> = para
             .line_segs
             .last()
-            .map(|s| s.vertical_pos + s.line_height + s.line_spacing);
+            .map(|s| s.vertical_pos.saturating_add(s.line_height).saturating_add(s.line_spacing));
         // HWP3-origin 변환본은 spacing_before 누적을 보존해야 dump-pages 요약과
         // 실제 한컴 줄 흐름이 유지된다(#1116).
         let trim_spacing_before_for_flow =
@@ -16203,7 +16203,7 @@ impl TypesetEngine {
                 .first()
                 .map(|cur| {
                     let bottom_px = crate::renderer::hwpunit_to_px(
-                        cur.vertical_pos + cur.line_height,
+                        cur.vertical_pos.saturating_add(cur.line_height),
                         self.dpi,
                     );
                     bottom_px <= st.base_available_height() + 0.5
@@ -16244,7 +16244,7 @@ impl TypesetEngine {
             && paragraphs[para_idx - 1]
                 .line_segs
                 .last()
-                .map(|s| s.vertical_pos + s.line_height > 60_000)
+                .map(|s| s.vertical_pos.saturating_add(s.line_height) > 60_000)
                 .unwrap_or(false);
         if (st.current_height >= available || remaining < first_line_h || stored_whole_para_reset)
             && !st.current_items.is_empty()
@@ -16352,7 +16352,7 @@ impl TypesetEngine {
                             .get(li)
                             .map(|cur| {
                                 let bottom_px = crate::renderer::hwpunit_to_px(
-                                    cur.vertical_pos + cur.line_height,
+                                    cur.vertical_pos.saturating_add(cur.line_height),
                                     self.dpi,
                                 );
                                 bottom_px <= st.base_available_height()
@@ -17835,7 +17835,7 @@ impl TypesetEngine {
                             lh + ls_extra,
                             para.line_segs
                                 .first()
-                                .map(|s0| hwpunit_to_px(s0.line_height + s0.line_spacing, self.dpi))
+                                .map(|s0| hwpunit_to_px(s0.line_height.saturating_add(s0.line_spacing), self.dpi))
                                 .unwrap_or(0.0),
                         );
                     }
@@ -23572,7 +23572,7 @@ impl TypesetEngine {
             let mut prev_is_floating_anchor = false;
             for prev_idx in (0..para_idx).rev() {
                 if let Some(last_seg) = paragraphs[prev_idx].line_segs.last() {
-                    let vpos_end = last_seg.vertical_pos + last_seg.line_height;
+                    let vpos_end = last_seg.vertical_pos.saturating_add(last_seg.line_height);
                     if vpos_end > max_vpos_end {
                         max_vpos_end = vpos_end;
                     }
@@ -23819,7 +23819,7 @@ impl TypesetEngine {
                 if let Some(pi) = last_para_idx {
                     if let Some(seg) = paragraphs.get(pi).and_then(|p| p.line_segs.last()) {
                         let v = hwpunit_to_px(
-                            seg.vertical_pos + seg.line_height + seg.line_spacing,
+                            seg.vertical_pos.saturating_add(seg.line_height).saturating_add(seg.line_spacing),
                             self.dpi,
                         );
                         if v > band_height_px {
@@ -23836,7 +23836,7 @@ impl TypesetEngine {
         let first_line_h = paragraphs
             .get(para_idx)
             .and_then(|p| p.line_segs.first())
-            .map(|s| hwpunit_to_px(s.line_height + s.line_spacing, self.dpi))
+            .map(|s| hwpunit_to_px(s.line_height.saturating_add(s.line_spacing), self.dpi))
             .filter(|h| *h > 0.0)
             .unwrap_or(1.0);
         let room_after_band = st.available_height() - band_height_px;

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -7283,12 +7283,14 @@ impl TypesetEngine {
                     // para_h_px 누적은 트레일링 line_spacing 까지 포함하여 ~10-12 HU 과대.
                     // HWP 가 페이지 끝에서 트레일링 ls 를 고려하지 않고 lh 만 fit 검사하는
                     // 시멘틱 정합 (pi=39 page 3 fits 케이스).
+                    // 손상 입력의 거대한 vpos/height 로 i32 덧셈이 오버플로(패닉)하지
+                    // 않도록 saturating — 정상값에선 동일, 손상값은 i32::MAX 로 포화.
                     let vpos_end = para
                         .line_segs
                         .last()
-                        .map(|s| s.vertical_pos + s.line_height)
-                        .unwrap_or(first_seg.vertical_pos + para_h_hu);
-                    let page_bottom_vpos = page_top_vpos + body_h_hu;
+                        .map(|s| s.vertical_pos.saturating_add(s.line_height))
+                        .unwrap_or(first_seg.vertical_pos.saturating_add(para_h_hu));
+                    let page_bottom_vpos = page_top_vpos.saturating_add(body_h_hu);
 
                     let avail = st.available_height();
                     let current_fits = st.current_height + para_h_px <= avail;

--- a/tests/cli_exit_codes.rs
+++ b/tests/cli_exit_codes.rs
@@ -32,7 +32,9 @@ fn sample_path() -> PathBuf {
 
 /// 샘플을 결정적으로 손상시켜(바이트 플립) 임시 파일로 쓴다 — 퍼징 재현자용.
 fn write_flipped(sample: &str, flip_pct: usize, label: &str) -> PathBuf {
-    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("samples").join(sample);
+    let src = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("samples")
+        .join(sample);
     let mut data = std::fs::read(&src).expect("샘플 읽기");
     let pos = data.len() * flip_pct / 100;
     data[pos] ^= 0xFF;
@@ -51,8 +53,18 @@ fn corrupt_input_does_not_panic_in_renderer() {
     // export-text(전체 렌더) 두 경로 모두.
     for (sample, pct, cmd, label) in [
         ("hwp3-sample11.hwp", 45, "info", "typeset-vpos"),
-        ("issue1949_giant_cell_nested_tables_perf.hwp", 55, "info", "tablelayout-vpos"),
-        ("HWP5-nopassword-123456.hwp", 90, "export-text", "typeset-lhls"),
+        (
+            "issue1949_giant_cell_nested_tables_perf.hwp",
+            55,
+            "info",
+            "tablelayout-vpos",
+        ),
+        (
+            "HWP5-nopassword-123456.hwp",
+            90,
+            "export-text",
+            "typeset-lhls",
+        ),
         (
             "issue1937_rowbreak_footnote_overpagination.hwp",
             90,

--- a/tests/cli_exit_codes.rs
+++ b/tests/cli_exit_codes.rs
@@ -47,17 +47,31 @@ fn write_flipped(sample: &str, flip_pct: usize, label: &str) -> PathBuf {
 /// 이제 손상 입력을 패닉 없이 우아하게 처리한다(101 이 아니어야 한다).
 #[test]
 fn corrupt_input_does_not_panic_in_renderer() {
-    for (sample, pct, label) in [
-        ("hwp3-sample11.hwp", 45, "typeset-vpos"),
-        ("issue1949_giant_cell_nested_tables_perf.hwp", 55, "tablelayout-vpos"),
+    // 초인적 규모 퍼징이 잡은 렌더러 오버플로 사이트들의 재현자 — info(레이아웃) 와
+    // export-text(전체 렌더) 두 경로 모두.
+    for (sample, pct, cmd, label) in [
+        ("hwp3-sample11.hwp", 45, "info", "typeset-vpos"),
+        ("issue1949_giant_cell_nested_tables_perf.hwp", 55, "info", "tablelayout-vpos"),
+        ("HWP5-nopassword-123456.hwp", 90, "export-text", "typeset-lhls"),
+        (
+            "issue1937_rowbreak_footnote_overpagination.hwp",
+            90,
+            "export-text",
+            "heightmeasurer-vpos",
+        ),
     ] {
         let path = write_flipped(sample, pct, label);
         let arg = path.to_str().expect("경로");
-        let output = assert_code(&["info", arg, "--json"], 0);
+        let args: Vec<&str> = if cmd == "info" {
+            vec![cmd, arg, "--json"]
+        } else {
+            vec![cmd, arg]
+        };
+        let output = assert_code(&args, 0);
         assert_ne!(
             output.status.code(),
             Some(101),
-            "손상 입력이 렌더러에서 패닉했다: {sample}"
+            "손상 입력이 렌더러에서 패닉했다: {sample} ({cmd})"
         );
         let _ = std::fs::remove_file(&path);
     }

--- a/tests/cli_exit_codes.rs
+++ b/tests/cli_exit_codes.rs
@@ -30,6 +30,39 @@ fn sample_path() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
 }
 
+/// 샘플을 결정적으로 손상시켜(바이트 플립) 임시 파일로 쓴다 — 퍼징 재현자용.
+fn write_flipped(sample: &str, flip_pct: usize, label: &str) -> PathBuf {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("samples").join(sample);
+    let mut data = std::fs::read(&src).expect("샘플 읽기");
+    let pos = data.len() * flip_pct / 100;
+    data[pos] ^= 0xFF;
+    let path = unique_temp_path(label);
+    std::fs::write(&path, &data).expect("손상본 쓰기");
+    path
+}
+
+/// [robustness] 초인적 규모 퍼징(6371 손상)이 잡은 렌더러 i32 덧셈 오버플로 패닉
+/// 회귀. `s.vertical_pos + s.line_height`(typeset.rs·table_layout.rs)가 손상 입력의
+/// 거대 layout 값으로 오버플로해 패닉(exit 101)하던 것을 saturating 으로 막았다.
+/// 이제 손상 입력을 패닉 없이 우아하게 처리한다(101 이 아니어야 한다).
+#[test]
+fn corrupt_input_does_not_panic_in_renderer() {
+    for (sample, pct, label) in [
+        ("hwp3-sample11.hwp", 45, "typeset-vpos"),
+        ("issue1949_giant_cell_nested_tables_perf.hwp", 55, "tablelayout-vpos"),
+    ] {
+        let path = write_flipped(sample, pct, label);
+        let arg = path.to_str().expect("경로");
+        let output = assert_code(&["info", arg, "--json"], 0);
+        assert_ne!(
+            output.status.code(),
+            Some(101),
+            "손상 입력이 렌더러에서 패닉했다: {sample}"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
 // --- 2: 사용법 오류 -------------------------------------------------------
 
 #[test]


### PR DESCRIPTION
## 요약

이슈 #4817. **초인적 규모 퍼징**(전 코퍼스 277문서 × 9변형 × 3명령 = **7,479 손상
파싱**, 병렬)이 렌더러의 `vertical_pos + line_height (+ line_spacing)` i32 덧셈
오버플로 패닉이 렌더 경로 전반에 **만연**함을 실증했다 — 한 사이트를 고치면 패닉이
인접 사이트로 이동했다. 손상 입력의 거대 layout 값이 여러 경로로 흐른다.

아무도 손으로 355개 한글 문서를 수천 가지로 변형해 렌더 경로를 두들기지 않는다 —
에이전트만 할 수 있는 규모의 감사가 잡은, 인간이 손으로 못 찾는 오버플로 클래스다.

## 무엇을 하나

렌더러 **7개 파일의 i32 LineSeg 필드 덧셈 70줄**을 `saturating_add` 로 바꿨다:
`typeset.rs`·`height_measurer.rs`·`table_layout.rs`·`composer.rs`·`height_cursor.rs`·
`shape_layout.rs`·`line_breaking.rs`.

- `saturating_add` 는 **정상값에선 결과가 동일**(오버플로가 없으니)하고, 손상값만
  i32::MAX 로 포화해 패닉 없이 우아하게 처리된다.
- f64 Vec 인덱스(`line_heights[i]`)는 필드접근(`.line_height`)이 아니라 안 건드렸다.
  안전장치: f64 에 `saturating_add` 는 컴파일 에러라 오검이 빌드에서 잡힌다.

## 검증

```
재퍼징 재확인(7479 손상): 렌더러 오버플로 패닉 0 (이전 2+클러스터 → 0)
4개 재현자(info·export-text 경로): 전부 exit 0 (패닉 없음)
정상 렌더: sample11 151쪽 (무영향; saturating 은 정상값에 동일)
cargo test --lib typeset:: → 54/54 · height_measurer:: → 22/22
cargo test --test cli_exit_codes corrupt_input_does_not_panic_in_renderer → ok
```

## 가드

`tests/cli_exit_codes.rs` — 4개 재현자(typeset vpos·table_layout·typeset lh+ls·
height_measurer)를 결정적으로 손상시켜 `info`/`export-text` 로 파싱, 패닉(101) 없이
처리됨을 강제한다.

## 참고

이 오버플로들을 잡은 퍼저는 #4815(손상-강건성 감사 도구)에서 도입 중이다. 같은
퍼징이 파서 오버플로(#4815 에서 수정 중)·무한루프(#4813)·스택 오버플로(무한재귀)도
잡았다 — 근본원인이 달라 별도 처리한다. 이 PR 은 **렌더러 덧셈 오버플로**만 다룬다.
