### PR TITLE
파서 normalize_variant_paragraph_vpos i32 오버플로 패닉 수정 — 퍼징 실측 DoS (#4820)

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -625,7 +625,12 @@ fn normalize_variant_paragraph_vpos(doc: &mut crate::model::document::Document) 
                 ls.vertical_pos = ls.vertical_pos.saturating_sub(cumulative_sb);
             }
             let last = para.line_segs.last().unwrap();
-            prev_vpos_end = last.vertical_pos + last.line_height + last.line_spacing;
+            // 주변(saturating_sub/add)과 달리 여기만 raw 덧셈이라 손상 입력의 거대
+            // vpos/height 로 i32 오버플로 패닉하던 것을 saturating 으로 맞춘다.
+            prev_vpos_end = last
+                .vertical_pos
+                .saturating_add(last.line_height)
+                .saturating_add(last.line_spacing);
         }
     }
 }
@@ -2173,6 +2178,20 @@ fn load_bin_data_content(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// [robustness] 초인적 퍼징(7479 손상)이 잡은 `normalize_variant_paragraph_vpos`
+    /// 의 i32 덧셈 오버플로 패닉 회귀(mod.rs:628). 손상 입력의 거대 vpos/height 로
+    /// `vertical_pos + line_height + line_spacing` 이 오버플로해 패닉하던 것을
+    /// saturating 으로 막았다 — 이제 파싱이 패닉 없이 Ok/Err 로 끝난다.
+    #[test]
+    fn corrupt_variant_vpos_does_not_overflow_panic() {
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/samples/hwp3-sample11-hwp5.hwp");
+        let data = std::fs::read(path).expect("샘플 읽기");
+        let mut corrupt = data.clone();
+        let pos = corrupt.len() * 90 / 100; // 감사기가 패닉을 재현한 결정적 손상
+        corrupt[pos] ^= 0xFF;
+        let _ = parse_document(&corrupt); // 결과값 무관 — 패닉만 안 하면 통과
+    }
 
     fn png_preview() -> Vec<u8> {
         let mut png = vec![0; 24];

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2185,7 +2185,10 @@ mod tests {
     /// saturating 으로 막았다 — 이제 파싱이 패닉 없이 Ok/Err 로 끝난다.
     #[test]
     fn corrupt_variant_vpos_does_not_overflow_panic() {
-        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/samples/hwp3-sample11-hwp5.hwp");
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/samples/hwp3-sample11-hwp5.hwp"
+        );
         let data = std::fs::read(path).expect("샘플 읽기");
         let mut corrupt = data.clone();
         let pos = corrupt.len() * 90 / 100; // 감사기가 패닉을 재현한 결정적 손상


### PR DESCRIPTION
## 요약

이슈 #4820. 초인적 규모 퍼징(전 코퍼스 × 다변형 × 다명령 = **7,479 손상 파싱**)이
잡은 파서 i32 덧셈 오버플로 패닉을 수정한다.

`src/parser/mod.rs:628` 의 `normalize_variant_paragraph_vpos` 에서
`prev_vpos_end = last.vertical_pos + last.line_height + last.line_spacing` 가 손상
입력의 거대 vpos/height 로 i32 를 넘겨 **패닉**(exit 101)했다. 바로 위 620·625 는
이미 `saturating_sub`/`saturating_add` 인데 이 한 줄만 raw 덧셈이라 하드닝 누락이었다.

## 수정

```rust
prev_vpos_end = last.vertical_pos
    .saturating_add(last.line_height)
    .saturating_add(last.line_spacing);
```

정상값에선 결과가 동일(오버플로 없음), 손상값만 i32::MAX 로 포화해 패닉을 막는다.

## 검증

```
cargo test --lib corrupt_variant_vpos_does_not_overflow_panic → ok
  (parse_document 파스-레벨 무패닉 — 렌더러 경로와 무오염. 재현자 hwp3-sample11-hwp5.hwp 90% 플립)
```

## 참고

이 오버플로를 잡은 퍼저는 #4815 에서 도입 중이다. 같은 퍼징이 렌더러 오버플로
(#4818)·hwp3 파서 오버플로(#4815)·무한루프(#4813)·스택 오버플로(무한재귀)도 잡았다.
이 PR 은 `parser/mod.rs` 의 덧셈 오버플로 1건만 다룬다.
