### PR TITLE
ci: workflow PR 후행 review-only 검증을 trusted controller로 재사용한다 (#4740)

### DIFF
--- a/.github/workflows/ci-impact-policy.yml
+++ b/.github/workflows/ci-impact-policy.yml
@@ -215,6 +215,12 @@ jobs:
                     reason: 'pull-commit-list-incomplete',
                     candidateSha: '',
                   };
+                } else if (commitSummaries.at(-1)?.sha !== process.env.HEAD_SHA) {
+                  reviewSelection = {
+                    eligible: false,
+                    reason: 'pull-commit-head-mismatch',
+                    candidateSha: '',
+                  };
                 } else {
                   const commits = [];
                   for (const summary of commitSummaries) {

--- a/.github/workflows/ci-impact-policy.yml
+++ b/.github/workflows/ci-impact-policy.yml
@@ -131,6 +131,8 @@ jobs:
             core.setOutput('head_branch', pull.head.ref);
             core.setOutput('head_repository', pull.head.repo?.full_name || '');
             core.setOutput('author_permission', authorPermission);
+            core.setOutput('pull_commits', String(pull.commits));
+            core.setOutput('pull_created_at', pull.created_at);
 
       # SECURITY: never replace this ref with pull.head.sha, a merge ref, or github.sha.
       - name: Check out trusted base policy implementation
@@ -145,6 +147,7 @@ jobs:
           sparse-checkout: |
             scripts/ci-impact-classifier.cjs
             scripts/ci-impact-policy.cjs
+            scripts/verify_review_only_merge_resolution.py
           sparse-checkout-cone-mode: false
 
       # SECURITY: workflow runs, jobs, and steps are data only. No PR artifact or code is used.
@@ -161,13 +164,14 @@ jobs:
           HEAD_SHA: ${{ steps.resolve.outputs.head_sha }}
           HEAD_BRANCH: ${{ steps.resolve.outputs.head_branch }}
           HEAD_REPOSITORY: ${{ steps.resolve.outputs.head_repository }}
+          PULL_COMMITS: ${{ steps.resolve.outputs.pull_commits }}
         with:
           retries: 3
           script: |
             const fs = require('node:fs');
             const path = require('node:path');
             const { owner, repo } = context.repo;
-            const { selectLatestWorkflowRun } = require(path.join(
+            const { selectLatestWorkflowRun, selectReviewOnlyCandidate } = require(path.join(
               process.env.GITHUB_WORKSPACE,
               'trusted-base/scripts/ci-impact-policy.cjs',
             ));
@@ -192,13 +196,82 @@ jobs:
               status: file.status,
             }));
 
+            let reviewSelection = {
+              eligible: false,
+              reason: 'review-reuse-not-evaluated',
+              candidateSha: '',
+            };
+            if (process.env.HEAD_REPOSITORY === process.env.GITHUB_REPOSITORY) {
+              try {
+                const commitSummaries = await github.paginate(github.rest.pulls.listCommits, {
+                  owner,
+                  repo,
+                  pull_number: Number(process.env.PULL_NUMBER),
+                  per_page: 100,
+                });
+                if (commitSummaries.length !== Number(process.env.PULL_COMMITS)) {
+                  reviewSelection = {
+                    eligible: false,
+                    reason: 'pull-commit-list-incomplete',
+                    candidateSha: '',
+                  };
+                } else {
+                  const commits = [];
+                  for (const summary of commitSummaries) {
+                    let commit = null;
+                    const commitFiles = [];
+                    const pages = github.paginate.iterator(github.rest.repos.getCommit, {
+                      owner,
+                      repo,
+                      ref: summary.sha,
+                      per_page: 100,
+                    });
+                    for await (const response of pages) {
+                      if (!commit) commit = response.data;
+                      commitFiles.push(...(response.data.files || []));
+                    }
+                    if (!commit) throw new Error(`Commit metadata unavailable: ${summary.sha}`);
+                    commits.push({
+                      sha: commit.sha,
+                      parents: (commit.parents || []).map((parent) => ({ sha: parent.sha })),
+                      files: commitFiles.map((file) => ({
+                        filename: file.filename,
+                        previous_filename: file.previous_filename || '',
+                        status: file.status,
+                      })),
+                    });
+                  }
+                  reviewSelection = selectReviewOnlyCandidate(commits, process.env.BASE_SHA);
+                }
+              } catch (error) {
+                core.warning(`Review lineage collection failed; reuse is disabled. ${error.message}`);
+                reviewSelection = {
+                  eligible: false,
+                  reason: 'review-lineage-collection-error',
+                  candidateSha: '',
+                };
+              }
+            } else {
+              reviewSelection.reason = 'review-reuse-requires-same-repository';
+            }
+            core.setOutput('review_candidate_sha', reviewSelection.candidateSha || '');
+            core.setOutput(
+              'base_merge_sha',
+              reviewSelection.baseMergeBridge?.mergeSha || '',
+            );
+            core.setOutput(
+              'source_parent_sha',
+              reviewSelection.baseMergeBridge?.sourceParentSha || '',
+            );
+
             const evidence = {};
-            if (process.env.MODE === 'audit') {
-              const workflowPaths = {
-                CI: '.github/workflows/ci.yml',
-                CodeQL: '.github/workflows/codeql.yml',
-                'Render Diff': '.github/workflows/render-diff.yml',
-              };
+            const reviewEvidence = {};
+            const workflowPaths = {
+              CI: '.github/workflows/ci.yml',
+              CodeQL: '.github/workflows/codeql.yml',
+              'Render Diff': '.github/workflows/render-diff.yml',
+            };
+            if (process.env.MODE === 'audit' || reviewSelection.eligible) {
               let runs = [];
               try {
                 runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
@@ -214,18 +287,19 @@ jobs:
               } catch (error) {
                 core.warning(`Workflow run collection failed; audit will remain pending. ${error.message}`);
               }
-              for (const [name, expectedPath] of Object.entries(workflowPaths)) {
+              async function collectRun(name, expectedPath, headSha, allowPriorBase) {
                 const run = selectLatestWorkflowRun(runs, {
                   name,
                   path: expectedPath,
                   pullNumber: Number(process.env.PULL_NUMBER),
                   baseRef: process.env.BASE_REF,
                   baseSha: process.env.BASE_SHA,
-                  headSha: process.env.HEAD_SHA,
+                  headSha,
                   headBranch: process.env.HEAD_BRANCH,
                   headRepository: process.env.HEAD_REPOSITORY,
+                  allowPriorBase,
                 });
-                if (!run) continue;
+                if (!run) return null;
                 let jobs = [];
                 let jobsCollected = false;
                 try {
@@ -243,7 +317,7 @@ jobs:
                     + `audit will remain pending. ${error.message}`,
                   );
                 }
-                evidence[name] = {
+                const collected = {
                   run: {
                     name: run.name,
                     path: String(run.path || '').split('@')[0],
@@ -255,6 +329,8 @@ jobs:
                     headRepository: run.head_repository?.full_name || '',
                     pullNumbers: (run.pull_requests || []).map((pull) => pull.number),
                     baseShas: (run.pull_requests || []).map((pull) => pull.base?.sha || ''),
+                    runStartedAt: run.run_started_at || run.created_at || '',
+                    createdAt: run.created_at || '',
                   },
                   jobsCollected,
                   jobs: jobs.map((job) => ({
@@ -268,6 +344,55 @@ jobs:
                     })),
                   })),
                 };
+                if (name === 'CodeQL' && allowPriorBase) {
+                  try {
+                    const checks = await github.paginate(github.rest.checks.listForRef, {
+                      owner,
+                      repo,
+                      ref: headSha,
+                      filter: 'latest',
+                      per_page: 100,
+                    });
+                    const check = checks
+                      .filter((candidate) => (
+                        candidate.app?.slug === 'github-advanced-security'
+                        && candidate.name === 'CodeQL'
+                        && candidate.head_sha === headSha
+                      ))
+                      .sort((left, right) => (
+                        Date.parse(right.started_at || right.created_at || 0)
+                        - Date.parse(left.started_at || left.created_at || 0)
+                      ))[0];
+                    if (check) {
+                      collected.securityCheck = {
+                        appSlug: check.app?.slug || '',
+                        name: check.name,
+                        headSha: check.head_sha,
+                        status: check.status,
+                        conclusion: check.conclusion || '',
+                        startedAt: check.started_at || check.created_at || '',
+                      };
+                    }
+                  } catch (error) {
+                    core.warning(`Could not collect candidate CodeQL policy check. ${error.message}`);
+                  }
+                }
+                return collected;
+              }
+              for (const [name, expectedPath] of Object.entries(workflowPaths)) {
+                if (process.env.MODE === 'audit') {
+                  const current = await collectRun(name, expectedPath, process.env.HEAD_SHA, false);
+                  if (current) evidence[name] = current;
+                }
+                if (reviewSelection.eligible) {
+                  const prior = await collectRun(
+                    name,
+                    expectedPath,
+                    reviewSelection.candidateSha,
+                    true,
+                  );
+                  if (prior) reviewEvidence[name] = prior;
+                }
               }
             }
 
@@ -284,6 +409,49 @@ jobs:
               path.join(workspace, '.ci-impact-workflows.json'),
               JSON.stringify(evidence),
             );
+            fs.writeFileSync(
+              path.join(workspace, '.ci-impact-review-reuse.json'),
+              JSON.stringify({
+                lineageEligible: reviewSelection.eligible === true,
+                reason: reviewSelection.reason,
+                candidateSha: reviewSelection.candidateSha || '',
+                trailingCount: reviewSelection.trailingCount || 0,
+                baseMergeBridge: reviewSelection.baseMergeBridge || null,
+                workflows: reviewEvidence,
+              }),
+            );
+
+      # SECURITY: fetches same-repository commit objects as data; it never checks out or executes PR code.
+      - name: Verify trusted current-base merge bridge
+        id: verify-review-merge
+        if: >-
+          ${{
+            steps.resolve.outputs.active == 'true'
+            && steps.collect.outputs.base_merge_sha != ''
+          }}
+        continue-on-error: true
+        shell: bash
+        env:
+          BASE_MERGE_SHA: ${{ steps.collect.outputs.base_merge_sha }}
+          SOURCE_PARENT_SHA: ${{ steps.collect.outputs.source_parent_sha }}
+          CURRENT_BASE_SHA: ${{ steps.resolve.outputs.base_sha }}
+          HEAD_SHA: ${{ steps.resolve.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          printf 'verified=false\nreason=current-base-merge-verification-failed\n' >> "$GITHUB_OUTPUT"
+          git -C trusted-base fetch --no-tags --no-recurse-submodules origin \
+            "${HEAD_SHA}" "${BASE_MERGE_SHA}" "${SOURCE_PARENT_SHA}"
+          if expected_tree="$(git -C trusted-base merge-tree --write-tree \
+            "${SOURCE_PARENT_SHA}" "${CURRENT_BASE_SHA}" 2>/dev/null)"; then
+            expected_tree="${expected_tree%%$'\n'*}"
+            actual_tree="$(git -C trusted-base show -s --format=%T "${BASE_MERGE_SHA}")"
+            if [[ "${expected_tree}" == "${actual_tree}" ]]; then
+              printf 'verified=true\nreason=current-base-merge-tree-match\n' >> "$GITHUB_OUTPUT"
+            fi
+          elif reason="$(python3 trusted-base/scripts/verify_review_only_merge_resolution.py \
+            --repository trusted-base --base-sha "${CURRENT_BASE_SHA}" "${BASE_MERGE_SHA}")"; then
+            printf 'verified=true\nreason=%s\n' "${reason}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Classify with trusted base implementation
         id: classify
@@ -308,7 +476,9 @@ jobs:
           HEAD_REPOSITORY: ${{ steps.resolve.outputs.head_repository }}
           AUTHOR_PERMISSION: ${{ steps.resolve.outputs.author_permission }}
           PULL_NUMBER: ${{ steps.resolve.outputs.pull_number }}
+          PULL_CREATED_AT: ${{ steps.resolve.outputs.pull_created_at }}
           CLASSIFY_OUTCOME: ${{ steps.classify.outcome }}
+          REVIEW_MERGE_VERIFIED: ${{ steps.verify-review-merge.outputs.verified || 'false' }}
         with:
           script: |
             const fs = require('node:fs');
@@ -348,6 +518,23 @@ jobs:
                 core.warning(`Workflow evidence unavailable; audit will remain pending. ${error.message}`);
               }
             }
+            let reviewReuse = {
+              lineageEligible: false,
+              reason: 'review-reuse-input-unavailable',
+              candidateSha: '',
+              workflows: {},
+            };
+            try {
+              reviewReuse = JSON.parse(fs.readFileSync(
+                path.join(workspace, '.ci-impact-review-reuse.json'),
+                'utf8',
+              ));
+              reviewReuse.mergeTreeVerified = reviewReuse.baseMergeBridge
+                ? process.env.REVIEW_MERGE_VERIFIED === 'true'
+                : true;
+            } catch (error) {
+              core.warning(`Review reuse evidence unavailable; forcing full. ${error.message}`);
+            }
             const input = {
               repository: process.env.GITHUB_REPOSITORY,
               pullRequest: {
@@ -358,11 +545,16 @@ jobs:
                 headBranch: process.env.HEAD_BRANCH,
                 headRepository: process.env.HEAD_REPOSITORY,
                 authorPermission: process.env.AUTHOR_PERMISSION,
+                createdAt: process.env.PULL_CREATED_AT,
               },
               files: classifierInput.files,
               classification,
-              forceFullReason: classifierInput.forceFullReason,
+              forceFullReason: classifierInput.forceFullReason
+                || (process.env.CLASSIFY_OUTCOME === 'success'
+                  ? ''
+                  : 'trusted-classifier-unavailable'),
               controllerAvailable: true,
+              reviewReuse,
             };
             if (process.env.MODE === 'audit') {
               // Keep the triggering workflow's SHA independent from the live PR SHA.
@@ -395,6 +587,9 @@ jobs:
           RENDER_EXPECTED: ${{ steps.policy.outputs.render_diff_run_expected || 'true' }}
           AUDIT_CONCLUSION: ${{ steps.policy.outputs.audit_conclusion || 'n/a' }}
           REASON: ${{ steps.policy.outputs.audit_reason || steps.policy.outputs.reason || 'trusted-policy-unavailable' }}
+          REVIEW_FAST_PASS: ${{ steps.policy.outputs.trusted_review_fast_pass || 'false' }}
+          REVIEW_CANDIDATE: ${{ steps.policy.outputs.review_candidate_sha || '' }}
+          REVIEW_REASON: ${{ steps.policy.outputs.review_reuse_reason || 'review-reuse-unavailable' }}
         run: |
           {
             echo '### Trusted CI impact policy'
@@ -404,6 +599,9 @@ jobs:
             printf -- '- expected workflows (CI/CodeQL/Render Diff): %s/%s/%s\n' \
               "${CI_EXPECTED}" "${CODEQL_EXPECTED}" "${RENDER_EXPECTED}"
             printf -- '- aggregate conclusion: %s\n' "${AUDIT_CONCLUSION}"
+            printf -- '- trusted review fast-pass: %s\n' "${REVIEW_FAST_PASS}"
+            printf -- '- review candidate: %s\n' "${REVIEW_CANDIDATE}"
+            printf -- '- review reuse reason: %s\n' "${REVIEW_REASON}"
             printf -- '- reason: %s\n' "${REASON}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
@@ -422,6 +620,7 @@ jobs:
           AUDIT_CONCLUSION: ${{ steps.policy.outputs.audit_conclusion || 'failure' }}
           AUDIT_REASON: ${{ steps.policy.outputs.audit_reason || 'trusted-audit-unavailable' }}
           DESCRIPTION: ${{ steps.policy.outputs.status_description || 'trusted policy unavailable' }}
+          REVIEW_FAST_PASS: ${{ steps.policy.outputs.trusted_review_fast_pass || 'false' }}
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -450,7 +649,15 @@ jobs:
                 process.env.RENDER_EXPECTED,
               ].every((value) => value === 'false');
               if (process.env.DECISION === 'blocked') state = 'failure';
+              else if (process.env.REVIEW_FAST_PASS === 'true') state = 'success';
               else if (noWorkflowExpected) state = 'success';
+            } else if (
+              process.env.REVIEW_FAST_PASS === 'true'
+              && process.env.AUDIT_CONCLUSION === 'pending'
+            ) {
+              // Candidate truth is already complete. Keep the authorization visible while
+              // current-head no-op aggregates finish; a later failed audit still overwrites it.
+              state = 'success';
             } else if (new Set(['pending', 'success', 'failure']).has(
               process.env.AUDIT_CONCLUSION,
             )) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
       contents: read
       checks: read
       pull-requests: read
+      statuses: read
     outputs:
       fast_pass: ${{ steps.finalize.outputs.fast_pass || 'false' }}
       reason: ${{ steps.finalize.outputs.reason || 'preflight-unavailable' }}
@@ -242,6 +243,59 @@ jobs:
                 })[0];
             }
 
+            async function hasTrustedReviewReuse(pr) {
+              for (let attempt = 0; attempt < 7; attempt += 1) {
+                const statuses = await github.paginate(github.rest.repos.listCommitStatusesForRef, {
+                  owner,
+                  repo,
+                  ref: pr.head.sha,
+                  per_page: 100,
+                });
+                const latest = statuses
+                  .filter((status) => status.context === 'CI Impact Policy')
+                  .sort((left, right) => Number(right.id || 0) - Number(left.id || 0))[0];
+                if (latest) {
+                  const fields = new Map(String(latest.description || '').split(';').map((part) => {
+                    const separator = part.indexOf('=');
+                    return separator > 0
+                      ? [part.slice(0, separator), part.slice(separator + 1)]
+                      : ['', ''];
+                  }));
+                  const expectedFields = [
+                    'v', 'cv', 'mode', 'rfp', 'wf', 'rust', 'fe', 'render', 'skia', 'ql', 'b',
+                  ];
+                  const target = String(latest.target_url || '').match(/\/actions\/runs\/(\d+)$/);
+                  if (
+                    latest.state === 'success'
+                    && latest.creator?.login === 'github-actions[bot]'
+                    && fields.size === expectedFields.length
+                    && expectedFields.every((field) => fields.has(field))
+                    && fields.get('v') === '5'
+                    && fields.get('rfp') === '1'
+                    && fields.get('b') === pr.base.sha
+                    && target
+                  ) {
+                    const response = await github.rest.actions.getWorkflowRun({
+                      owner,
+                      repo,
+                      run_id: Number(target[1]),
+                    });
+                    const run = response.data;
+                    if (
+                      run.name === 'CI Impact Policy Controller'
+                      && String(run.path || '').split('@')[0] === '.github/workflows/ci-impact-policy.yml'
+                      && run.event === 'pull_request_target'
+                      && run.repository?.full_name === `${owner}/${repo}`
+                      && !(run.status === 'completed' && run.conclusion !== 'success')
+                    ) return true;
+                  }
+                  return false;
+                }
+                if (attempt < 6) await new Promise((resolve) => setTimeout(resolve, 5000));
+              }
+              return false;
+            }
+
             async function buildResult(candidateSha, pr) {
               const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
                 owner,
@@ -317,9 +371,12 @@ jobs:
                 isCiExecutionPath(file.filename)
                 || isCiExecutionPath(file.previous_filename || '')
               ));
-              if (hasCiExecutionSurfaceChange) {
+              if (hasCiExecutionSurfaceChange && !await hasTrustedReviewReuse(pr)) {
                 setResult(false, 'ci-execution-surface-change');
                 return;
+              }
+              if (hasCiExecutionSurfaceChange) {
+                core.info('trusted controller authorized enforcement-change review reuse');
               }
               if (prFiles.length > 0 && prFiles.every((file) => isAllowedReviewPath(file))) {
                 core.info(`all PR files are review-only; using base SHA ${pr.base.sha}`);

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,6 +56,7 @@ jobs:
       contents: read
       checks: read
       pull-requests: read
+      statuses: read
     outputs:
       fast_pass: ${{ steps.finalize.outputs.fast_pass || 'false' }}
       reason: ${{ steps.finalize.outputs.reason || 'preflight-unavailable' }}
@@ -164,6 +165,59 @@ jobs:
                   const aTime = Date.parse(a.completed_at || a.started_at || a.created_at || 0);
                   return bTime - aTime;
                 })[0];
+            }
+
+            async function hasTrustedReviewReuse(pr) {
+              for (let attempt = 0; attempt < 7; attempt += 1) {
+                const statuses = await github.paginate(github.rest.repos.listCommitStatusesForRef, {
+                  owner,
+                  repo,
+                  ref: pr.head.sha,
+                  per_page: 100,
+                });
+                const latest = statuses
+                  .filter((status) => status.context === 'CI Impact Policy')
+                  .sort((left, right) => Number(right.id || 0) - Number(left.id || 0))[0];
+                if (latest) {
+                  const fields = new Map(String(latest.description || '').split(';').map((part) => {
+                    const separator = part.indexOf('=');
+                    return separator > 0
+                      ? [part.slice(0, separator), part.slice(separator + 1)]
+                      : ['', ''];
+                  }));
+                  const expectedFields = [
+                    'v', 'cv', 'mode', 'rfp', 'wf', 'rust', 'fe', 'render', 'skia', 'ql', 'b',
+                  ];
+                  const target = String(latest.target_url || '').match(/\/actions\/runs\/(\d+)$/);
+                  if (
+                    latest.state === 'success'
+                    && latest.creator?.login === 'github-actions[bot]'
+                    && fields.size === expectedFields.length
+                    && expectedFields.every((field) => fields.has(field))
+                    && fields.get('v') === '5'
+                    && fields.get('rfp') === '1'
+                    && fields.get('b') === pr.base.sha
+                    && target
+                  ) {
+                    const response = await github.rest.actions.getWorkflowRun({
+                      owner,
+                      repo,
+                      run_id: Number(target[1]),
+                    });
+                    const run = response.data;
+                    if (
+                      run.name === 'CI Impact Policy Controller'
+                      && String(run.path || '').split('@')[0] === '.github/workflows/ci-impact-policy.yml'
+                      && run.event === 'pull_request_target'
+                      && run.repository?.full_name === `${owner}/${repo}`
+                      && !(run.status === 'completed' && run.conclusion !== 'success')
+                    ) return true;
+                  }
+                  return false;
+                }
+                if (attempt < 6) await new Promise((resolve) => setTimeout(resolve, 5000));
+              }
+              return false;
             }
 
             async function codeqlResult(candidateSha, pr) {
@@ -291,9 +345,12 @@ jobs:
                 isCiExecutionPath(file.filename)
                 || isCiExecutionPath(file.previous_filename || '')
               ));
-              if (hasCiExecutionSurfaceChange) {
+              if (hasCiExecutionSurfaceChange && !await hasTrustedReviewReuse(pr)) {
                 setResult(false, 'ci-execution-surface-change');
                 return;
+              }
+              if (hasCiExecutionSurfaceChange) {
+                core.info('trusted controller authorized enforcement-change review reuse');
               }
               if (prFiles.length > 0 && prFiles.every((file) => isAllowedReviewPath(file))) {
                 core.info(`all PR files are review-only; using base SHA ${pr.base.sha}`);

--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -70,6 +70,7 @@ jobs:
       actions: read
       contents: read
       pull-requests: read
+      statuses: read
     outputs:
       fast_pass: ${{ steps.finalize.outputs.fast_pass || 'false' }}
       reason: ${{ steps.finalize.outputs.reason || 'preflight-unavailable' }}
@@ -165,6 +166,59 @@ jobs:
                   const aTime = Date.parse(a.completed_at || a.started_at || a.created_at || 0);
                   return bTime - aTime;
                 })[0];
+            }
+
+            async function hasTrustedReviewReuse(pr) {
+              for (let attempt = 0; attempt < 7; attempt += 1) {
+                const statuses = await github.paginate(github.rest.repos.listCommitStatusesForRef, {
+                  owner,
+                  repo,
+                  ref: pr.head.sha,
+                  per_page: 100,
+                });
+                const latest = statuses
+                  .filter((status) => status.context === 'CI Impact Policy')
+                  .sort((left, right) => Number(right.id || 0) - Number(left.id || 0))[0];
+                if (latest) {
+                  const fields = new Map(String(latest.description || '').split(';').map((part) => {
+                    const separator = part.indexOf('=');
+                    return separator > 0
+                      ? [part.slice(0, separator), part.slice(separator + 1)]
+                      : ['', ''];
+                  }));
+                  const expectedFields = [
+                    'v', 'cv', 'mode', 'rfp', 'wf', 'rust', 'fe', 'render', 'skia', 'ql', 'b',
+                  ];
+                  const target = String(latest.target_url || '').match(/\/actions\/runs\/(\d+)$/);
+                  if (
+                    latest.state === 'success'
+                    && latest.creator?.login === 'github-actions[bot]'
+                    && fields.size === expectedFields.length
+                    && expectedFields.every((field) => fields.has(field))
+                    && fields.get('v') === '5'
+                    && fields.get('rfp') === '1'
+                    && fields.get('b') === pr.base.sha
+                    && target
+                  ) {
+                    const response = await github.rest.actions.getWorkflowRun({
+                      owner,
+                      repo,
+                      run_id: Number(target[1]),
+                    });
+                    const run = response.data;
+                    if (
+                      run.name === 'CI Impact Policy Controller'
+                      && String(run.path || '').split('@')[0] === '.github/workflows/ci-impact-policy.yml'
+                      && run.event === 'pull_request_target'
+                      && run.repository?.full_name === `${owner}/${repo}`
+                      && !(run.status === 'completed' && run.conclusion !== 'success')
+                    ) return true;
+                  }
+                  return false;
+                }
+                if (attempt < 6) await new Promise((resolve) => setTimeout(resolve, 5000));
+              }
+              return false;
             }
 
             async function renderDiffResult(candidateSha, pr, allowPriorPrBase = false) {
@@ -274,9 +328,12 @@ jobs:
                 isCiExecutionPath(file.filename)
                 || isCiExecutionPath(file.previous_filename || '')
               ));
-              if (hasCiExecutionSurfaceChange) {
+              if (hasCiExecutionSurfaceChange && !await hasTrustedReviewReuse(pr)) {
                 setResult(false, 'ci-execution-surface-change');
                 return;
+              }
+              if (hasCiExecutionSurfaceChange) {
+                core.info('trusted controller authorized enforcement-change review reuse');
               }
               if (prFiles.length > 0 && prFiles.every((file) => isAllowedReviewPath(file))) {
                 core.info(`all PR files are review-only; using base SHA ${pr.base.sha}`);

--- a/mydocs/manual/github_operations.md
+++ b/mydocs/manual/github_operations.md
@@ -267,6 +267,23 @@ CI 영향 분류와 trigger mirror는 다음 파일에 있다.
 관련 파일을 바꾼 경우 실제 존재하는 테스트만 선택해 실행하고, 변경 기록에 명령과 결과를 적는다. 경로
 필터 변경에는 적어도 classifier·policy의 Node test와 해당 CI·CodeQL workflow Python test를 포함한다.
 
+### 7.5 workflow PR의 후행 review 기록
+
+workflow·action·CI impact 정책을 바꾼 PR은 PR 전체 변경 목록에 실행 정책 파일이 남으므로, 후행
+`mydocs/**` commit만 보고 자체 preflight가 검증을 생략해서는 안 된다. 기본 브랜치의
+`CI Impact Policy Controller`가 exact Full candidate, 이후 review-only 계보, current-base merge bridge,
+현재 head·base 결합을 독립 검증해 `rfp=1` status를 발행한 same-repository PR만 제한적으로 fast-pass한다.
+
+consumer workflow는 status context 문자열만 신뢰하지 않는다. status의 policy version·current base SHA,
+creator, target Action run의 workflow name·path·`pull_request_target` event를 함께 확인한다. 증빙 누락,
+API pagination 경계, candidate의 fast-pass 실행, failed·pending run, GHAS CodeQL check 누락, fork, stale base는
+전부 Full 실행으로 fallback한다. 상세 허용 범위와 merge bridge 규칙은
+[review-only fast-pass](pr_review/review_only_fast_pass.md#a1-ci-실행-정책을-바꾼-pr의-trusted-재사용)를 따른다.
+
+이 controller는 default branch 등록형이므로 `devel` 병합은 배포 전 검증 단계다. 정상 release로 `main`에
+반영하기 전에는 live `pull_request_target` controller가 존재하지 않으며, 그 기간의 workflow PR은 계속 Full
+실행하는 것이 정상이다.
+
 ## 8. required check와 branch protection
 
 required context 이름은 외부 계약이다. job 이름 변경, workflow 분리, path skip, matrix 이름 변경은 YAML

--- a/mydocs/manual/pr_review/review_only_fast_pass.md
+++ b/mydocs/manual/pr_review/review_only_fast_pass.md
@@ -62,6 +62,32 @@ local Cargo 성공만으로 candidate의 GitHub Actions를 대체하지 않는�
 collaborator가 contributor code를 local에서 검증한 뒤 review·오늘할일만 같은 source head에 추가하는 경우도
 이 A 경로다. local 검증 결과와 candidate SHA, 재사용한 Build & Test URL을 review 문서에 기록한다.
 
+### A.1 CI 실행 정책을 바꾼 PR의 trusted 재사용
+
+PR 전체 변경에 `.github/workflows/**`, `.github/actions/**`, CI impact classifier·policy 또는
+review-only merge 검사기가 포함되면 PR head의 preflight만으로 A 경로를 허용하지 않는다. 해당 PR이 자신이
+바꾼 workflow로 검증을 생략할 수 있기 때문이다. 기본값은 `ci-execution-surface-change` Full 실행이다.
+
+예외는 기본 브랜치에 등록된 `CI Impact Policy Controller`가 current head에 `CI Impact Policy` status를
+발행한 same-repository PR뿐이다. controller는 PR head나 artifact를 실행하지 않고 live base의 정책 코드로
+다음을 독립 확인한다.
+
+1. exact code candidate의 CI·CodeQL과 변경 범위상 필요한 Render Diff가 같은 repository·branch·PR·SHA에서
+   **fast-pass가 아닌 Full 실행**으로 성공했다. CodeQL은 언어별 Analyze job과 같은 run 이후 GHAS CodeQL
+   check까지 성공 또는 neutral이어야 한다.
+2. candidate 뒤 current head까지는 허용된 single-parent review-only commit뿐이다. current-base bridge는
+   trusted controller가 commit object만 fetch해 자동 merge tree 일치 또는 `mydocs/` 한정 충돌 해소를 다시
+   검증한 경우에만 허용한다.
+3. status는 exact current head에 묶이고 policy version, `rfp=1`, current base SHA, trusted controller
+   `pull_request_target` run identity가 모두 일치한다.
+
+CI·CodeQL·Render Diff preflight는 이 status를 짧게 기다린 뒤에만 기존 candidate 탐색을 계속한다. status가
+누락·pending·failed·stale이거나 candidate 실행·GHAS check·commit/file 목록·merge tree 중 하나라도 불완전하면
+재사용하지 않고 Full 실행한다. 외부 fork의 실행 정책 변경은 이 예외 대상이 아니다.
+
+`pull_request_target`과 `workflow_run`은 기본 브랜치에 있는 workflow만 등록한다. 따라서 controller 변경을
+`devel`에 병합한 것만으로 이 예외가 활성화되지 않으며, 정상 release 절차로 `main`에 반영된 뒤부터 적용한다.
+
 ## B. PR 전체가 review-only
 
 PR 전체 파일이 허용 범위에만 있으면 preflight는 base SHA를 candidate로 기록하고
@@ -75,13 +101,14 @@ all-review-only-no-code-impact fast-pass를 즉시 선택한다. candidate의 �
 
 다음 중 하나면 fast-pass로 단정하지 않고 workflow의 full CI 결과를 기다린다.
 
-- code, test, CI workflow, Cargo.lock 변경
+- code, test, CI workflow, Cargo.lock 변경. 단, CI workflow 변경 뒤 review-only 기록만 추가된 경우에는
+  A.1의 trusted controller 증명이 전부 성립할 때만 예외로 한다.
 - 기존 sample, PDF, golden, baseline, fixture의 수정·삭제·rename
 - 허용 목록 밖의 신규 파일
 - A 경로의 candidate workflow 누락·실패·미완료·PR identity 불일치, current-base merge tree 불일치,
   `mydocs/` 밖 충돌 해소·해소 경로 조회 실패·복수 base merge 또는 허용되지 않은 merge 형태
 - preflight가 fast_pass=false를 반환
 
-fast-pass는 merge 조건을 없애지 않는다. 최신 head, mergeable 상태, required aggregate, 작업지시자 승인을
+fast-pass는 merge 조건을 없애지 않는다. 최신 head, mergeable 상태, required aggregate, 메인테이너 승인을
 확인한다. 완료된 원 PR의 기록만 담는 별도 B 경로 PR은 merge 뒤 issue/PR comment와 오늘할일을 반복하지 않고
 devel sync와 branch/worktree/target cleanup만 수행한다.

--- a/mydocs/manual/pr_review_workflow.md
+++ b/mydocs/manual/pr_review_workflow.md
@@ -146,6 +146,11 @@ base 반영을 강제하지 않는 정책이면, 같은 PR·같은 source reposi
 재사용해 trailing review-only commit을 fast-pass할 수 있다. contributor가 source·test를 새로 push한 경우에는
 그 새 code head의 CI를 먼저 통과시킨 뒤 review 기록을 한 번만 이어 붙인다.
 
+PR 자체가 workflow·action·CI impact 정책을 바꾼 경우에는 PR head의 이 판단을 그대로 신뢰하지 않는다.
+기본 브랜치 trusted controller가 exact Full candidate와 review-only tail을 증명한 same-repository PR만
+[review-only fast-pass의 A.1](pr_review/review_only_fast_pass.md#a1-ci-실행-정책을-바꾼-pr의-trusted-재사용)에
+따라 예외 처리한다. controller가 아직 `main`에 활성화되지 않았거나 status가 불완전하면 Full CI를 기다린다.
+
 단, GitHub의 `MERGEABLE` 표시는 텍스트 충돌이 없다는 참고값일 뿐 최신 `devel`과의 컴파일·테스트 호환을
 보장하지 않는다. source가 공용 struct·trait·API를 바꾼 뒤 최신 `devel`이 그 API의 초기화·호출부를
 추가했다면 current-base merge tree의 CI가 실패할 수 있다. 이 사실이 `git merge-tree` 또는 최신 PR head의

--- a/mydocs/orders/20260815.md
+++ b/mydocs/orders/20260815.md
@@ -12,8 +12,16 @@
   workflow 변경 PR의 heavy worker를 fast-pass한다.
 - classifier 31건, policy 31건, workflow Python 계약 70건, YAML parse, 변경 manual 링크와 diff 검사를
   통과했다. 상세는 [Stage 1 기록](../working/task_m100_4740_stage1_trusted_review_fast_pass.md)에 남긴다.
+- [PR #4824](https://github.com/edwardkim/rhwp/pull/4824)를 `devel` 대상으로 Open 생성했다. 초기
+  code candidate 자체검토에서 single-parent 여부만으로는 first-parent 연속성을 보장하지 못하는 경계를
+  발견했고, `09b923592`에서 exact 계보와 live PR head 일치를 fail-closed로 보정한 뒤 위 검증을 다시
+  통과했다. 이 exact code candidate의 CI·CodeQL·Render Diff는 20 success, 정책상 3 skip,
+  failure·cancelled·pending 0으로 완료됐다. 1,000줄을 넘는 workflow 보안 계약 변경이라 즉시 admin
+  merge하지 않고, [자체검토 기록](../pr/archives/pr_4824_review.md)과 오늘할일 trailing head를 별도
+  cycle로 검증한다.
 - controller는 `main` 등록 전에는 live가 아니므로 `devel` 병합만으로 활성화되지 않는다. PR 검증과 별도
-  merge 승인 뒤 정상 release에 포함해야 하며, 현재 #4819 run에는 소급 적용되지 않는다.
+  merge 승인 뒤 정상 release에 포함해야 하며, 현재 #4819 run에는 소급 적용되지 않는다. 최신 trailing
+  head의 Actions 통과와 mergeability 확인 전에는 통합하지 않는다.
 
 ## Issue #4812 - HWP/HWPX 선언 글꼴 웹폰트 공급 경로 전수 조사
 

--- a/mydocs/orders/20260815.md
+++ b/mydocs/orders/20260815.md
@@ -1,5 +1,20 @@
 # 오늘 할 일 - 2026년 8월 15일
 
+## Issue #4740 - workflow PR 후행 review-only fast-pass
+
+- #4819에서 Full CI·CodeQL이 성공한 code candidate 뒤에 review 문서만 추가했지만, PR 전체 변경의
+  workflow 파일 때문에 `ci-execution-surface-change` Full 실행이 반복되는 현상을 재현했다.
+- 최신 `upstream/devel@62a3ba677`에서 `task_m100_4740_trusted_review_fast_pass` 브랜치를 만들고
+  [수행계획](../plans/task_m100_4740.md)을 승인 기준으로 기록했다.
+- default branch의 `CI Impact Policy Controller`가 same-repository PR의 exact Full candidate,
+  single-parent review-only tail, GHAS CodeQL check와 current-base merge tree를 독립 검증하도록 policy v5를
+  구현했다. CI·CodeQL·Render Diff는 current head·base·controller run에 결합된 `rfp=1` status가 있을 때만
+  workflow 변경 PR의 heavy worker를 fast-pass한다.
+- classifier 31건, policy 31건, workflow Python 계약 70건, YAML parse, 변경 manual 링크와 diff 검사를
+  통과했다. 상세는 [Stage 1 기록](../working/task_m100_4740_stage1_trusted_review_fast_pass.md)에 남긴다.
+- controller는 `main` 등록 전에는 live가 아니므로 `devel` 병합만으로 활성화되지 않는다. PR 검증과 별도
+  merge 승인 뒤 정상 release에 포함해야 하며, 현재 #4819 run에는 소급 적용되지 않는다.
+
 ## Issue #4812 - HWP/HWPX 선언 글꼴 웹폰트 공급 경로 전수 조사
 
 - 최신 `upstream/devel@4cf8a5898` 위에 `task_m100_4812_font_webfont_survey` 브랜치를 만들고,

--- a/mydocs/plans/task_m100_4740.md
+++ b/mydocs/plans/task_m100_4740.md
@@ -1,0 +1,75 @@
+---
+kind: plan
+status: approved
+canonical: mydocs/plans/task_m100_4740.md
+last_verified: 2026-08-15
+---
+
+# Task M100 #4740 수행 계획서 — workflow PR 후행 review-only fast-pass
+
+- Issue: #4740
+- 관찰 PR: #4819
+- 기준선: `upstream/devel@62a3ba677`
+- 작업 브랜치: `task_m100_4740_trusted_review_fast_pass`
+- 운영 등급: O3 실행·보안 계약
+- 승인: 2026-08-15 메인테이너가 진단 범위와 특정 적용 조건을 확인한 뒤 구현 진행을 승인함
+
+## 문제
+
+workflow 또는 CI 정책을 바꾸는 PR은 정확한 code candidate에서 Full CI·CodeQL이 모두 성공한 뒤
+`mydocs/**` review 기록만 단순 후행 commit으로 추가해도, regular preflight가 PR 전체 변경에서
+CI 실행 표면을 발견하자마자 `ci-execution-surface-change`로 종료한다. #4819의 code candidate
+`bd01f5834`는 Full CI·CodeQL이 성공했지만 review-only head `b8b8a37b6`에서 전체 lane이 다시 실행됐다.
+
+이 fail-closed 기본값은 PR이 자신이 수정한 workflow로 검증을 생략하지 못하게 하는 보안 경계다.
+따라서 PR head의 주장만 믿어 조건을 완화하지 않고, 기본 브랜치의 trusted controller가 검증한
+evidence가 있을 때만 제한적으로 재사용한다.
+
+## 적용 범위
+
+다음 조건을 모두 만족하는 same-repository PR의 후행 review-only head만 fast-pass 대상으로 한다.
+
+1. 동일 PR source repository·branch의 정확한 candidate SHA에서 CI·CodeQL과 필요한 Render Diff가
+   Full 실행으로 성공했다.
+2. candidate 뒤 current head까지는 허용된 review-only single-parent commit뿐이다. current-base merge
+   bridge는 기존 자동 merge tree 일치 또는 `mydocs/` 한정 충돌 해소 규칙을 그대로 적용한다.
+3. candidate 뒤에는 workflow, action, classifier, policy, source, test, fixture, baseline 변경이 없다.
+4. trusted controller가 기본 브랜치 구현만 실행해 위 계보와 Actions identity를 검증한다.
+5. controller, evidence 또는 identity가 누락·실패·stale이면 Full 실행으로 닫는다.
+
+순수 `mydocs` PR과 일반 code PR의 기존 fast-pass, 외부 fork의 enforcement-surface 변경 차단,
+required aggregate 이름과 branch protection 계약은 바꾸지 않는다.
+
+## 구현 단계
+
+1. trusted controller가 PR commit 계보를 역순으로 읽어 녹색 Full candidate와 trailing review-only 범위를
+   판정하고, current head에 결합된 짧은 trusted evidence를 발행한다.
+2. CI·CodeQL·Render Diff preflight는 PR 전체에 enforcement 변경이 있을 때 기존 자체 판단을 완화하지
+   않는다. 대신 trusted evidence가 현재 head·candidate·workflow별 성공을 정확히 증명할 때만 worker를
+   fast-pass한다.
+3. `ci-impact-policy.cjs`의 감사 계약은 PR 전체 enforcement 변경 여부가 아니라 검증된 trailing evidence
+   존재 여부를 함께 확인하도록 확장한다. evidence가 없는 fast-pass는 계속 실패시킨다.
+4. workflow·policy mirror test와 #4819 계보 fixture를 추가한다.
+5. canonical 운영·review-only 매뉴얼에 적용 경계와 fallback을 반영한다.
+
+## 검증
+
+- Node: `node --test scripts/tests/ci-impact-classifier.test.cjs scripts/tests/ci-impact-policy.test.cjs`
+- Python: `python3 -m unittest scripts/tests/test_ci_impact_workflow.py scripts/tests/test_codeql_workflow.py scripts/tests/test_render_diff_workflow.py scripts/tests/test_review_only_fast_pass_workflows.py scripts/tests/test_ci_impact_policy_workflow.py`
+- workflow 계약: `python3 -m unittest scripts/tests/test_workflow_contract_wiring.py`
+- YAML/action: 저장소에 설치된 actionlint 경로가 있으면 변경 workflow 전체 실행
+- 문서·diff: `git diff --check`와 변경한 Markdown 링크 검사
+
+## 수용 기준
+
+- #4819형 계보에서 exact Full candidate와 candidate 이후 review-only 범위가 trusted evidence로 확인되면
+  최신 head의 CI·CodeQL·Render Diff heavy worker가 skip되고 required aggregate는 성공한다.
+- candidate 이후 enforcement/source/test 변경, failed·pending·missing candidate, repository·branch·SHA
+  mismatch, stale evidence, 외부 fork enforcement 변경은 Full 또는 failure로 fail-closed한다.
+- 기존 순수 review-only, 일반 trailing review-only, current-base bridge와 영향축 선택 테스트가 무회귀다.
+
+## 롤백
+
+trusted evidence가 최신 head에 결합되지 않거나 required check가 pending·누락되면 fast-pass 소비를 제거하고
+기존 `ci-execution-surface-change` Full fallback으로 되돌린다. workflow 파일과 정책 스크립트는 한 PR에서
+함께 revert해 controller와 consumer의 계약 버전 불일치를 남기지 않는다.

--- a/mydocs/pr/archives/pr_4824_review.md
+++ b/mydocs/pr/archives/pr_4824_review.md
@@ -1,0 +1,84 @@
+# PR #4824 자체검토 — workflow PR 후행 review-only fast-pass
+
+## 절차 라우팅
+
+```text
+base route: collaborator_self_merge.md
+modifiers: intake_and_review.md, local_validation.md,
+  review_only_fast_pass.md, rework_and_exceptions.md
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+  collaborator_self_merge.md, intake_and_review.md, local_validation.md,
+  review_only_fast_pass.md, rework_and_exceptions.md
+```
+
+## PR 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4824](https://github.com/edwardkim/rhwp/pull/4824) |
+| 관련 이슈 | [#4740](https://github.com/edwardkim/rhwp/issues/4740) |
+| 작성자 | `edwardkim` (maintainer self PR) |
+| base / head | `devel` / `task_m100_4740_trusted_review_fast_pass` |
+| code candidate | `09b923592e98c368dc06dd7d78294bdd9e2f3130` |
+| 규모 | 3 commits, 13 files, +1,045 / -27 |
+| code candidate 상태 | `MERGEABLE`, `CLEAN`, required checks 성공 |
+
+maintainer 자신의 PR이므로 외부 reviewer를 지정하지 않고 자체검토로 처리한다. 이 PR은 1,000줄을
+넘으므로 즉시 admin merge하지 않으며, 코드 후보 검토·CI와 review-only trailing head 검증을 서로 다른
+cycle로 수행한다.
+
+## 변경 범위와 설계 판단
+
+- default branch의 `CI Impact Policy Controller`가 same-repository PR의 Full 검증 후보와 현재 head 사이
+  first-parent 계보를 독립적으로 확인하고, current-base merge tree의 CI 영향까지 다시 분류한다.
+- CI·CodeQL·Render Diff consumer는 controller가 exact head·base·run에 결합해 발행한 `rfp=1` commit
+  status만 신뢰한다. status 부재·만료·불일치·외부 fork·정책 버전 불일치는 모두 Full 실행으로 닫힌다.
+- 기존 정책이 workflow 변경을 항상 execution surface로 분류하는 경계는 유지한다. fast-pass는 이미 Full
+  검증된 후보 뒤에 review-only 파일만 이어진 제한된 tail에서만 heavy worker를 재사용한다.
+- status producer, 세 consumer, policy v5, 회귀 테스트와 운영 문서는 하나의 버전 계약이다. 이를 별도 PR로
+  나누면 producer·consumer 또는 정책 버전이 맞지 않는 부분 배포 상태가 생기므로 한 PR로 유지했다.
+- workflow와 정책·문서만 변경하며 renderer, layout, HWP/HWPX fixture, golden에는 영향이 없다. 따라서
+  시각 검증과 WASM·브라우저 제품 검증은 적용하지 않았다.
+
+## 자체검토에서 발견해 보정한 사항
+
+초기 code candidate `68537dc73`의 review tail 판정은 각 commit이 single-parent인지만 확인하고, 그 parent가
+바로 다음 검사 대상 SHA인지 강제하지 않았다. 이 상태에서는 API 응답에 분리된 ordinary commit이 끼어도
+불연속 계보를 review-only tail로 오인할 여지가 있었다.
+
+`09b923592`에서 다음을 보정했다.
+
+- classifier가 head에서 candidate까지 `expectedSha`를 갱신하며 exact first-parent 연속성을 검증한다.
+- controller가 PR commits 응답의 마지막 SHA와 live `pull_request.head.sha`가 같은지 확인한다.
+- ordinary tail과 bridge tail 양쪽에 불연속 계보 회귀 계약을 추가하고, head 불일치가 fail-closed인지
+  workflow 계약으로 고정한다.
+
+이 보정 뒤 동일 범위 재검토에서 추가 차단 사항은 발견하지 않았다.
+
+## 완료된 로컬 검증
+
+- `node --test scripts/tests/ci-impact-classifier.test.cjs` — 31 passed
+- `node --test scripts/tests/ci-impact-policy.test.cjs` — 31 passed
+- 선택한 workflow Python 계약 — 70 passed
+- PyYAML로 변경된 workflow 4개 parse — 통과
+- manual 링크 검사와 `git diff --check upstream/devel...HEAD` — 통과
+- 로컬에 `actionlint`가 없어 실행하지 못했으며, GitHub Actions의 실제 workflow parse·실행으로 보완한다.
+
+## GitHub Actions와 활성화 경계
+
+- code candidate `09b923592`는 controller가 아직 default branch `main`에 등록되지 않은 상태라 의도대로
+  Full 경로를 실행한다.
+- exact code candidate에서 CI
+  [run 31883675640](https://github.com/edwardkim/rhwp/actions/runs/31883675640), CodeQL
+  [run 31883675457](https://github.com/edwardkim/rhwp/actions/runs/31883675457), Render Diff
+  [run 31883675475](https://github.com/edwardkim/rhwp/actions/runs/31883675475)가 성공했다. 전체 check
+  집계는 20 success, 정책상 3 skip, failure·cancelled·pending 0이다.
+- controller는 이 PR이 `devel`에 병합되는 것만으로 활성화되지 않는다. 이후 정상 release가 `main`에
+  반영된 뒤 생성되는 새 `pull_request_target` run부터 후행 review-only fast-pass가 작동한다.
+- review 문서 trailing head의 결과는 아래 최종 판정 전에 별도로 확인한다.
+
+## 최종 권고
+
+코드 후보의 보안 경계와 회귀 계약은 merge 가능한 범위로 판단한다. 다만 이 자체검토·오늘할일 문서를
+trailing commit으로 push한 뒤, 그 최신 head의 required checks가 모두 통과하고 PR이 `MERGEABLE`인지
+확인한 다음 메인테이너의 별도 merge 승인을 받아야 한다.

--- a/mydocs/working/task_m100_4740_stage1_trusted_review_fast_pass.md
+++ b/mydocs/working/task_m100_4740_stage1_trusted_review_fast_pass.md
@@ -1,0 +1,71 @@
+---
+kind: working
+status: completed
+canonical: mydocs/plans/task_m100_4740.md
+last_verified: 2026-08-15
+---
+
+# Task M100 #4740 Stage 1 — trusted review-only fast-pass
+
+## 기준선과 재현
+
+- 기준선: `upstream/devel@62a3ba677`
+- 계획 커밋: `43554af03`
+- 관찰 PR: #4819
+- Full code candidate: `bd01f583424054f6550afa0460a114c531ff662c`
+- review-only current head: `b8b8a37b615060485f552401e1eb23e2a136f714`
+
+candidate의 CI run `31880305532`와 CodeQL run `31880305422`는 성공했지만, current head에서는 PR 전체
+변경 목록의 workflow 파일 때문에 preflight가 `ci-execution-surface-change`로 종료하고 CI
+`31881202046`과 CodeQL `31881201970`을 Full로 다시 실행했다. PR head가 자신이 수정한 workflow로 검증을
+생략하지 못하게 만든 기존 fail-closed guard가 원인이며, 단순 path 예외로 완화할 수 없는 보안 경계다.
+
+## 구현
+
+기본 브랜치의 `CI Impact Policy Controller`가 다음 증빙을 live base의 코드로만 판정하도록 확장했다.
+
+- same-repository PR의 commit 수와 전 페이지 file 목록을 수집하고, newest-to-oldest로 single-parent
+  review-only tail과 직전 code candidate를 고른다.
+- current-base merge bridge는 commit object만 fetch하며 PR head를 checkout하거나 실행하지 않는다.
+  자동 merge tree 일치 또는 trusted base 검사기의 `mydocs/` 한정 remerge diff만 허용한다.
+- candidate의 exact repository·branch·PR·SHA에 결합된 CI·CodeQL·필요한 Render Diff run과 job/step을
+  감사한다. 세 workflow의 preflight가 fast-pass였던 candidate는 Full 증빙으로 인정하지 않는다.
+- CodeQL은 세 Analyze job 외에 같은 candidate와 run 시작 이후의 GHAS `CodeQL` check까지 확인한다.
+- 증빙이 완결되면 policy status v5에 `rfp=1`을 넣고 exact current head에 success로 발행한다. current-head
+  no-op aggregate가 끝나는 동안 audit event가 pending이어도 이 authorization은 유지하며, 실제 audit
+  failure는 failure status로 덮어쓴다.
+
+CI·CodeQL·Render Diff consumer는 PR 전체에 execution-surface 변경이 있을 때만 최대 30초 동안 status를
+기다린다. context·creator뿐 아니라 v5, `rfp=1`, current base SHA, target run의 controller name·path와
+`pull_request_target` event를 함께 확인한 뒤 기존 candidate 탐색을 계속한다. status가 이미 도착했으나
+재사용 불가이면 즉시 Full 경로로 전환한다.
+
+## Fail-closed 경계
+
+다음은 모두 `trusted_review_fast_pass=false` 또는 기존 Full 실행이다.
+
+- 외부 fork의 execution-surface 변경
+- PR commit 수 불일치, 빈/300-file 경계 commit, file/API/classifier 수집 오류
+- trailing source·test·workflow 변경, 일반 merge, 복수 base merge
+- candidate run 누락·pending·failure·identity 불일치 또는 candidate 자체 fast-pass
+- GHAS CodeQL check 누락·실패·candidate/run 시간 불일치
+- 검증되지 않은 current-base merge tree, stale base/status/controller run
+
+일반 code PR과 PR 전체가 review-only인 기존 경로는 policy status를 소비하지 않고 이전 계약을 유지한다.
+
+## 검증 결과
+
+- `node scripts/tests/ci-impact-classifier.test.cjs`: 31/31 PASS
+- `node scripts/tests/ci-impact-policy.test.cjs`: 31/31 PASS
+- CI·CodeQL·Render Diff·review-only·policy controller·workflow wiring Python 계약: 70/70 PASS
+- PyYAML 변경 workflow 4개 parse: PASS
+- 변경 manual 3개 Markdown 상대 링크: PASS
+- `git diff --check`: PASS
+- `actionlint`: 로컬 실행 파일이 없어 미실행. YAML 구조와 repository workflow mirror test로 보완했으며,
+  실제 Actions 결과는 PR에서 확인해야 한다.
+
+## 배포 경계
+
+`pull_request_target`과 `workflow_run`은 default branch에 있는 workflow만 등록한다. 이 변경을 `devel`에
+병합해도 controller는 아직 live가 아니며, 정상 release로 `main`에 반영된 뒤부터 후속 workflow PR이
+`rfp=1`을 사용할 수 있다. #4819의 이미 실행 중인 current head에는 소급 적용되지 않는다.

--- a/scripts/ci-impact-policy.cjs
+++ b/scripts/ci-impact-policy.cjs
@@ -319,6 +319,7 @@ function selectReviewOnlyCandidate(commits, currentBaseSha) {
   }
   let trailingCount = 0;
   let baseMergeBridge = null;
+  let expectedSha = '';
   for (let index = entries.length - 1; index >= 0; index -= 1) {
     const commit = entries[index] || {};
     const sha = String(commit.sha || '');
@@ -328,6 +329,13 @@ function selectReviewOnlyCandidate(commits, currentBaseSha) {
     const files = Array.isArray(commit.files) ? commit.files : [];
     if (!/^[0-9a-f]{40}$/.test(sha)) {
       return { eligible: false, reason: 'invalid-commit-sha', candidateSha: '' };
+    }
+    if (expectedSha && sha !== expectedSha) {
+      return {
+        eligible: false,
+        reason: `non-linear-review-tail:${sha}`,
+        candidateSha: '',
+      };
     }
     const isCurrentBaseMerge = parents.length === 2
       && parents.filter((parent) => parent === currentBaseSha).length === 1;
@@ -348,6 +356,7 @@ function selectReviewOnlyCandidate(commits, currentBaseSha) {
         };
       }
       baseMergeBridge = { mergeSha: sha, sourceParentSha };
+      expectedSha = sourceParentSha;
       continue;
     }
     if (files.length === 0 || files.length >= 300) {
@@ -358,6 +367,7 @@ function selectReviewOnlyCandidate(commits, currentBaseSha) {
         return { eligible: false, reason: `review-only-merge-not-reusable:${sha}`, candidateSha: '' };
       }
       trailingCount += 1;
+      expectedSha = parents[0];
       continue;
     }
     if (trailingCount === 0 && !baseMergeBridge) {

--- a/scripts/ci-impact-policy.cjs
+++ b/scripts/ci-impact-policy.cjs
@@ -2,7 +2,7 @@
 
 const fs = require('node:fs');
 
-const POLICY_VERSION = '4';
+const POLICY_VERSION = '5';
 const POLICY_CONTEXT = 'CI Impact Policy';
 const WORKFLOW_ORDER = ['CI', 'CodeQL', 'Render Diff'];
 const WORKFLOW_PATHS = {
@@ -289,6 +289,103 @@ function changesEnforcementSurface(files) {
   ));
 }
 
+function isReviewReferencePath(filename) {
+  const pdfPrefixes = ['pdf/', 'pdf-2020/', 'pdf-large/'];
+  return (
+    filename.startsWith('samples/')
+    && (
+      filename.endsWith('.hwp')
+      || filename.endsWith('.hwpx')
+      || filename.endsWith('.pdf')
+      || filename.endsWith('.png')
+    )
+  ) || (
+    pdfPrefixes.some((prefix) => filename.startsWith(prefix))
+    && filename.endsWith('.pdf')
+  );
+}
+
+function isAllowedReviewFile(file) {
+  const normalized = normalizeFile(file);
+  if (normalized.filename.startsWith('mydocs/')) return true;
+  return String(file?.status || '') === 'added'
+    && isReviewReferencePath(normalized.filename);
+}
+
+function selectReviewOnlyCandidate(commits, currentBaseSha) {
+  const entries = Array.isArray(commits) ? commits : [];
+  if (entries.length === 0) {
+    return { eligible: false, reason: 'no-pr-commits', candidateSha: '' };
+  }
+  let trailingCount = 0;
+  let baseMergeBridge = null;
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const commit = entries[index] || {};
+    const sha = String(commit.sha || '');
+    const parents = Array.isArray(commit.parents)
+      ? commit.parents.map((parent) => String(parent?.sha || parent || '')).filter(Boolean)
+      : [];
+    const files = Array.isArray(commit.files) ? commit.files : [];
+    if (!/^[0-9a-f]{40}$/.test(sha)) {
+      return { eligible: false, reason: 'invalid-commit-sha', candidateSha: '' };
+    }
+    const isCurrentBaseMerge = parents.length === 2
+      && parents.filter((parent) => parent === currentBaseSha).length === 1;
+    if (isCurrentBaseMerge) {
+      if (baseMergeBridge) {
+        return {
+          eligible: false,
+          reason: `multiple-current-base-update-merges:${sha}`,
+          candidateSha: '',
+        };
+      }
+      const sourceParentSha = parents.find((parent) => parent !== currentBaseSha) || '';
+      if (!sourceParentSha) {
+        return {
+          eligible: false,
+          reason: `current-base-source-parent-unavailable:${sha}`,
+          candidateSha: '',
+        };
+      }
+      baseMergeBridge = { mergeSha: sha, sourceParentSha };
+      continue;
+    }
+    if (files.length === 0 || files.length >= 300) {
+      return { eligible: false, reason: `unusable-file-list:${sha}`, candidateSha: '' };
+    }
+    if (files.every(isAllowedReviewFile)) {
+      if (parents.length !== 1) {
+        return { eligible: false, reason: `review-only-merge-not-reusable:${sha}`, candidateSha: '' };
+      }
+      trailingCount += 1;
+      continue;
+    }
+    if (trailingCount === 0 && !baseMergeBridge) {
+      return { eligible: false, reason: 'no-trailing-review-only-commits', candidateSha: '' };
+    }
+    if (baseMergeBridge && baseMergeBridge.sourceParentSha !== sha) {
+      return { eligible: false, reason: 'base-merge-source-parent-mismatch', candidateSha: '' };
+    }
+    return {
+      eligible: true,
+      reason: baseMergeBridge ? 'candidate-with-current-base-bridge' : 'candidate-with-review-tail',
+      candidateSha: sha,
+      trailingCount,
+      baseMergeBridge,
+    };
+  }
+  if (baseMergeBridge) {
+    return {
+      eligible: true,
+      reason: 'direct-current-base-bridge',
+      candidateSha: baseMergeBridge.sourceParentSha,
+      trailingCount,
+      baseMergeBridge,
+    };
+  }
+  return { eligible: false, reason: 'no-code-candidate', candidateSha: '' };
+}
+
 function matchesPathPattern(filename, pattern) {
   if (pattern === '*.md') return !filename.includes('/') && filename.endsWith('.md');
   if (pattern === 'rhwp-logo.*') return /^rhwp-logo\.[^/]+$/.test(filename);
@@ -333,7 +430,10 @@ function workflowRunMatchesPull(run, identity) {
   return pulls.some((pull) => (
     Number(pull?.number || 0) === Number(identity.pullNumber || 0)
     && String(pull?.base?.ref || '') === String(identity.baseRef || '')
-    && String(pull?.base?.sha || '') === String(identity.baseSha || '')
+    && (
+      identity.allowPriorBase === true
+      || String(pull?.base?.sha || '') === String(identity.baseSha || '')
+    )
     && String(pull?.head?.ref || '') === String(identity.headBranch || '')
     && String(pull?.head?.sha || '') === String(identity.headSha || '')
   ));
@@ -385,6 +485,7 @@ function statusDescription(policy) {
     `v=${POLICY_VERSION}`,
     `cv=${classification.classifier_version}`,
     `mode=${policy.decision}`,
+    `rfp=${policy.trusted_review_fast_pass === 'true' ? '1' : '0'}`,
     `wf=${workflowBits}`,
     `rust=${classification.rust_required === 'true' ? '1' : '0'}`,
     `fe=${classification.frontend_mode}`,
@@ -406,7 +507,7 @@ function parseStatusDescription(description) {
     fields.set(key, value);
   }
   const expected = [
-    'v', 'cv', 'mode', 'wf', 'rust', 'fe', 'render', 'skia', 'ql', 'b',
+    'v', 'cv', 'mode', 'rfp', 'wf', 'rust', 'fe', 'render', 'skia', 'ql', 'b',
   ];
   if (fields.size !== expected.length || expected.some((key) => !fields.has(key))) {
     throw new Error('policy status fields are incomplete');
@@ -417,6 +518,9 @@ function parseStatusDescription(description) {
   }
   if (!new Set(['blocked', 'full', 'selective']).has(fields.get('mode'))) {
     throw new Error('invalid policy mode');
+  }
+  if (!new Set(['0', '1']).has(fields.get('rfp'))) {
+    throw new Error('invalid trusted review fast-pass axis');
   }
   if (!/^[01]{3}$/.test(fields.get('wf'))) throw new Error('invalid workflow axes');
   if (!new Set(['0', '1']).has(fields.get('rust'))) throw new Error('invalid rust axis');
@@ -469,10 +573,18 @@ function determinePolicy(input = {}) {
     skip_eligible: decision === 'selective' ? 'true' : 'false',
     head_trust: headTrust,
     enforcement_surface_changed: enforcementChanged ? 'true' : 'false',
+    trusted_review_fast_pass: 'false',
+    review_candidate_sha: '',
     expected_workflows: expectedWorkflowMap(input.files, forceAllWorkflows),
     reason: classification.reason,
     classification,
   };
+  const reviewAudit = auditReviewReuse({ ...input, policy });
+  if (reviewAudit.eligible === true) {
+    policy.trusted_review_fast_pass = 'true';
+    policy.review_candidate_sha = reviewAudit.candidateSha;
+  }
+  policy.review_reuse_reason = reviewAudit.reason;
   policy.ci_run_expected = policy.expected_workflows.CI;
   policy.status_description = statusDescription(policy);
   return policy;
@@ -604,7 +716,10 @@ function auditCi(policy, jobs) {
 
   const laneJobs = [...CI_RUST_JOBS, CI_NATIVE_JOB, ...CI_FRONTEND_JOBS];
   if (preflight.fastPass) {
-    if (policy.enforcement_surface_changed === 'true') return 'fast-pass-with-enforcement-change:CI';
+    if (
+      policy.enforcement_surface_changed === 'true'
+      && policy.trusted_review_fast_pass !== 'true'
+    ) return 'fast-pass-with-enforcement-change:CI';
     for (const name of laneJobs) {
       const failure = requireSafeAliasedJobConclusion(byName, name, 'skipped');
       if (failure) return failure;
@@ -646,7 +761,10 @@ function auditCodeql(policy, jobs) {
   );
   if (preflight.error) return preflight.error;
   if (preflight.fastPass) {
-    if (policy.enforcement_surface_changed === 'true') return 'fast-pass-with-enforcement-change:CodeQL';
+    if (
+      policy.enforcement_surface_changed === 'true'
+      && policy.trusted_review_fast_pass !== 'true'
+    ) return 'fast-pass-with-enforcement-change:CodeQL';
     const templateName = 'Analyze (${{ matrix.language }})';
     const templateEntries = byName.get(templateName) || [];
     const expandedCount = Object.values(CODEQL_JOBS)
@@ -710,13 +828,100 @@ function auditRenderDiff(policy, jobs) {
     'Check out trusted CI impact classifier',
   );
   if (preflight.error) return preflight.error;
-  if (preflight.fastPass && policy.enforcement_surface_changed === 'true') {
+  if (
+    preflight.fastPass
+    && policy.enforcement_surface_changed === 'true'
+    && policy.trusted_review_fast_pass !== 'true'
+  ) {
     return 'fast-pass-with-enforcement-change:Render Diff';
   }
   const conclusion = preflight.fastPass || policy.classification.render_required !== 'true'
     ? 'skipped'
     : 'success';
   return requireSafeJobConclusion(byName, 'Canvas visual diff', conclusion);
+}
+
+function auditReviewReuse(input = {}) {
+  const policy = input.policy;
+  const reuse = input.reviewReuse || {};
+  const candidateSha = String(reuse.candidateSha || '');
+  if (!policy || policy.enforcement_surface_changed !== 'true') {
+    return { eligible: false, candidateSha: '', reason: 'review-reuse-not-required' };
+  }
+  if (String(input.forceFullReason || '')) {
+    return { eligible: false, candidateSha: '', reason: 'review-reuse-trusted-input-incomplete' };
+  }
+  if (policy.head_trust !== 'same-repository') {
+    return { eligible: false, candidateSha: '', reason: 'review-reuse-requires-same-repository' };
+  }
+  if (policy.decision === 'blocked') {
+    return { eligible: false, candidateSha: '', reason: 'review-reuse-policy-blocked' };
+  }
+  if (!reuse.lineageEligible || !/^[0-9a-f]{40}$/.test(candidateSha)) {
+    return {
+      eligible: false,
+      candidateSha: '',
+      reason: String(reuse.reason || 'review-reuse-lineage-unavailable'),
+    };
+  }
+  if (reuse.baseMergeBridge && reuse.mergeTreeVerified !== true) {
+    return { eligible: false, candidateSha: '', reason: 'review-reuse-merge-tree-unverified' };
+  }
+
+  for (const workflow of WORKFLOW_ORDER) {
+    if (policy.expected_workflows[workflow] !== 'true') continue;
+    const evidence = reuse.workflows?.[workflow];
+    if (!evidence?.run) {
+      return { eligible: false, candidateSha: '', reason: `review-reuse-missing-workflow:${workflow}` };
+    }
+    const run = evidence.run;
+    const runCreatedAt = Date.parse(run.createdAt || 0);
+    const pullCreatedAt = Date.parse(input.pullRequest?.createdAt || 0);
+    if (
+      String(run.name || '') !== workflow
+      || String(run.path || '') !== WORKFLOW_PATHS[workflow]
+      || String(run.event || '') !== 'pull_request'
+      || String(run.headSha || '') !== candidateSha
+      || String(run.headBranch || '') !== String(input.pullRequest?.headBranch || '')
+      || String(run.headRepository || '') !== String(input.pullRequest?.headRepository || '')
+      || !Array.isArray(run.pullNumbers)
+      || !run.pullNumbers.map(Number).includes(Number(input.pullRequest?.number || 0))
+      || !Number.isFinite(runCreatedAt)
+      || !Number.isFinite(pullCreatedAt)
+      || runCreatedAt < pullCreatedAt
+      || String(run.status || '') !== 'completed'
+      || String(run.conclusion || '') !== 'success'
+      || evidence.jobsCollected !== true
+    ) {
+      return { eligible: false, candidateSha: '', reason: `review-reuse-invalid-workflow:${workflow}` };
+    }
+    const failure = workflow === 'CI'
+      ? auditCi(policy, evidence.jobs)
+      : workflow === 'CodeQL'
+        ? auditCodeql(policy, evidence.jobs)
+        : auditRenderDiff(policy, evidence.jobs);
+    if (failure) {
+      return { eligible: false, candidateSha: '', reason: `review-reuse-${workflow}:${failure}` };
+    }
+    if (workflow === 'CodeQL') {
+      const check = evidence.securityCheck;
+      const runStartedAt = Date.parse(run.runStartedAt || 0);
+      const checkStartedAt = Date.parse(check?.startedAt || 0);
+      if (
+        check?.appSlug !== 'github-advanced-security'
+        || check?.name !== 'CodeQL'
+        || check?.headSha !== candidateSha
+        || check?.status !== 'completed'
+        || !new Set(['success', 'neutral']).has(check?.conclusion)
+        || !Number.isFinite(runStartedAt)
+        || !Number.isFinite(checkStartedAt)
+        || checkStartedAt < runStartedAt
+      ) {
+        return { eligible: false, candidateSha: '', reason: 'review-reuse-invalid-security-check:CodeQL' };
+      }
+    }
+  }
+  return { eligible: true, candidateSha, reason: 'trusted-review-only-full-candidate' };
 }
 
 function auditPolicyRuns(input = {}) {
@@ -810,6 +1015,9 @@ function flatOutputs(policy, audit) {
     skip_eligible: policy.skip_eligible,
     head_trust: policy.head_trust,
     enforcement_surface_changed: policy.enforcement_surface_changed,
+    trusted_review_fast_pass: policy.trusted_review_fast_pass,
+    review_candidate_sha: policy.review_candidate_sha,
+    review_reuse_reason: policy.review_reuse_reason,
     ci_run_expected: policy.expected_workflows.CI,
     codeql_run_expected: policy.expected_workflows.CodeQL,
     render_diff_run_expected: policy.expected_workflows['Render Diff'],
@@ -879,12 +1087,14 @@ module.exports = {
   WORKFLOW_ORDER,
   WORKFLOW_PATHS,
   auditPolicyRuns,
+  auditReviewReuse,
   changesEnforcementSurface,
   determinePolicy,
   expectedWorkflowMap,
   fullClassification,
   parseStatusDescription,
   runCli,
+  selectReviewOnlyCandidate,
   selectLatestWorkflowRun,
   statusDescription,
   workflowRunExpected,

--- a/scripts/tests/ci-impact-policy.test.cjs
+++ b/scripts/tests/ci-impact-policy.test.cjs
@@ -27,6 +27,7 @@ const {
   parseStatusDescription,
   runCli,
   selectLatestWorkflowRun,
+  selectReviewOnlyCandidate,
   workflowRunExpected,
 } = require('../ci-impact-policy.cjs');
 
@@ -57,6 +58,7 @@ function policyInput(overrides = {}) {
       headBranch: HEAD_BRANCH,
       headRepository: 'edwardkim/rhwp',
       authorPermission: 'write',
+      createdAt: '2026-08-15T00:00:00Z',
     },
     files,
     classification: classificationFor(files),
@@ -85,6 +87,7 @@ function workflowRun(name, status = 'completed', conclusion = 'success') {
     headRepository: 'edwardkim/rhwp',
     pullNumbers: [123],
     baseShas: [BASE_SHA],
+    createdAt: '2026-08-15T01:00:00Z',
   };
 }
 
@@ -205,6 +208,29 @@ function workflowEvidence(policy, options = {}) {
       jobsCollected: true,
       jobs: renderJobs(policy.classification, options.fastPass === true),
     };
+  }
+  return evidence;
+}
+
+function reviewReuseEvidence(policy, candidateSha, options = {}) {
+  const evidence = workflowEvidence(policy);
+  for (const [name, entry] of Object.entries(evidence)) {
+    entry.run.headSha = candidateSha;
+    entry.run.baseShas = ['d'.repeat(40)];
+    entry.run.runStartedAt = '2026-08-15T01:00:00Z';
+    if (name === 'CodeQL') {
+      entry.securityCheck = {
+        appSlug: 'github-advanced-security',
+        name: 'CodeQL',
+        headSha: candidateSha,
+        status: 'completed',
+        conclusion: options.securityConclusion || 'success',
+        startedAt: '2026-08-15T01:01:00Z',
+      };
+    }
+  }
+  if (options.fastPass === true && evidence.CI) {
+    evidence.CI.jobs = ciJobs(policy.classification, true);
   }
   return evidence;
 }
@@ -340,9 +366,10 @@ test('compact status description round-trips workflow and impact axes', () => {
   const policy = determinePolicy(policyInput());
   assert.ok(policy.status_description.length <= 140);
   assert.deepEqual(parseStatusDescription(policy.status_description), {
-    v: '4',
+    v: '5',
     cv: '3',
     mode: 'selective',
+    rfp: '0',
     wf: '111',
     rust: '0',
     fe: 'unit',
@@ -690,6 +717,143 @@ test('trailing review-only fast pass is accepted only on unchanged enforcement s
   assert.match(failure.reason, /fast-pass-with-enforcement-change/);
 });
 
+test('trusted full candidate permits enforcement-change review-only fast pass', () => {
+  const candidateSha = 'c'.repeat(40);
+  const files = [
+    { filename: '.github/workflows/ci.yml', status: 'modified' },
+    { filename: 'mydocs/pr/pr_4819_review.md', status: 'added' },
+  ];
+  const baselineInput = policyInput({ files, classification: classificationFor(files) });
+  const baselinePolicy = determinePolicy(baselineInput);
+  const reviewReuse = {
+    lineageEligible: true,
+    reason: 'candidate-with-review-tail',
+    candidateSha,
+    trailingCount: 1,
+    baseMergeBridge: null,
+    mergeTreeVerified: true,
+    workflows: reviewReuseEvidence(baselinePolicy, candidateSha),
+  };
+  const input = { ...baselineInput, reviewReuse };
+  const policy = determinePolicy(input);
+  assert.equal(policy.trusted_review_fast_pass, 'true');
+  assert.equal(policy.review_candidate_sha, candidateSha);
+  assert.equal(parseStatusDescription(policy.status_description).rfp, '1');
+
+  const audit = auditPolicyRuns({
+    ...input,
+    policy,
+    currentHeadSha: HEAD_SHA,
+    workflows: workflowEvidence(policy, { fastPass: true }),
+  });
+  assert.equal(audit.conclusion, 'success');
+
+  const fastCandidateInput = {
+    ...baselineInput,
+    reviewReuse: {
+      ...reviewReuse,
+      workflows: reviewReuseEvidence(baselinePolicy, candidateSha, { fastPass: true }),
+    },
+  };
+  assert.equal(determinePolicy(fastCandidateInput).trusted_review_fast_pass, 'false');
+});
+
+test('trusted review reuse fails closed on missing, pending, or mismatched candidate evidence', () => {
+  const candidateSha = 'c'.repeat(40);
+  const files = [{ filename: '.github/workflows/ci.yml', status: 'modified' }];
+  const baselineInput = policyInput({ files, classification: classificationFor(files) });
+  const baselinePolicy = determinePolicy(baselineInput);
+  const validEvidence = reviewReuseEvidence(baselinePolicy, candidateSha);
+  function reviewed(overrides = {}) {
+    return determinePolicy({
+      ...baselineInput,
+      reviewReuse: {
+        lineageEligible: true,
+        candidateSha,
+        mergeTreeVerified: true,
+        workflows: validEvidence,
+        ...overrides,
+      },
+    });
+  }
+
+  const missing = structuredClone(validEvidence);
+  delete missing.CodeQL;
+  assert.equal(reviewed({ workflows: missing }).trusted_review_fast_pass, 'false');
+
+  const pending = structuredClone(validEvidence);
+  pending.CI.run.status = 'in_progress';
+  pending.CI.run.conclusion = '';
+  assert.equal(reviewed({ workflows: pending }).trusted_review_fast_pass, 'false');
+
+  const mismatch = structuredClone(validEvidence);
+  mismatch.CodeQL.run.headRepository = 'external/rhwp';
+  assert.equal(reviewed({ workflows: mismatch }).trusted_review_fast_pass, 'false');
+
+  const missingSecurity = structuredClone(validEvidence);
+  delete missingSecurity.CodeQL.securityCheck;
+  assert.equal(reviewed({ workflows: missingSecurity }).trusted_review_fast_pass, 'false');
+
+  assert.equal(reviewed({ baseMergeBridge: { mergeSha: 'f'.repeat(40) }, mergeTreeVerified: false })
+    .trusted_review_fast_pass, 'false');
+  assert.equal(determinePolicy({
+    ...baselineInput,
+    forceFullReason: 'collection-error',
+    reviewReuse: {
+      lineageEligible: true,
+      candidateSha,
+      mergeTreeVerified: true,
+      workflows: validEvidence,
+    },
+  }).trusted_review_fast_pass, 'false');
+});
+
+test('review candidate lineage accepts only single-parent review tails and verified base bridges', () => {
+  const candidateSha = 'c'.repeat(40);
+  const reviewSha = 'd'.repeat(40);
+  const baseSha = 'e'.repeat(40);
+  const mergeSha = 'f'.repeat(40);
+  const candidate = {
+    sha: candidateSha,
+    parents: [{ sha: '1'.repeat(40) }],
+    files: [{ filename: '.github/workflows/ci.yml', status: 'modified' }],
+  };
+  const review = {
+    sha: reviewSha,
+    parents: [{ sha: candidateSha }],
+    files: [{ filename: 'mydocs/pr/pr_4819_review.md', status: 'added' }],
+  };
+  assert.deepEqual(selectReviewOnlyCandidate([candidate, review], baseSha), {
+    eligible: true,
+    reason: 'candidate-with-review-tail',
+    candidateSha,
+    trailingCount: 1,
+    baseMergeBridge: null,
+  });
+
+  const reviewMerge = {
+    ...review,
+    parents: [{ sha: candidateSha }, { sha: '2'.repeat(40) }],
+  };
+  assert.match(selectReviewOnlyCandidate([candidate, reviewMerge], baseSha).reason, /review-only-merge/);
+
+  const bridge = {
+    sha: mergeSha,
+    parents: [{ sha: candidateSha }, { sha: baseSha }],
+    files: [{ filename: 'mydocs/orders/20260815.md', status: 'modified' }],
+  };
+  const selected = selectReviewOnlyCandidate([candidate, bridge, {
+    ...review,
+    parents: [{ sha: mergeSha }],
+  }], baseSha);
+  assert.equal(selected.eligible, true);
+  assert.equal(selected.candidateSha, candidateSha);
+  assert.deepEqual(selected.baseMergeBridge, {
+    mergeSha,
+    sourceParentSha: candidateSha,
+  });
+});
+
 test('CodeQL fast pass accepts exactly one matrix skip representation', () => {
   const input = policyInput();
   const policy = determinePolicy(input);
@@ -767,5 +931,5 @@ test('CLI writes policy and aggregate audit outputs', (t) => {
   assert.equal(result.audit.conclusion, 'success');
   assert.match(outputs, /^codeql_run_expected=true$/m);
   assert.match(outputs, /^audit_conclusion=success$/m);
-  assert.equal(JSON.parse(fs.readFileSync(resultPath, 'utf8')).policy.policy_version, '4');
+  assert.equal(JSON.parse(fs.readFileSync(resultPath, 'utf8')).policy.policy_version, '5');
 });

--- a/scripts/tests/ci-impact-policy.test.cjs
+++ b/scripts/tests/ci-impact-policy.test.cjs
@@ -831,6 +831,15 @@ test('review candidate lineage accepts only single-parent review tails and verif
     baseMergeBridge: null,
   });
 
+  const disconnectedReview = {
+    ...review,
+    parents: [{ sha: '9'.repeat(40) }],
+  };
+  assert.match(
+    selectReviewOnlyCandidate([candidate, disconnectedReview], baseSha).reason,
+    /non-linear-review-tail/,
+  );
+
   const reviewMerge = {
     ...review,
     parents: [{ sha: candidateSha }, { sha: '2'.repeat(40) }],
@@ -852,6 +861,12 @@ test('review candidate lineage accepts only single-parent review tails and verif
     mergeSha,
     sourceParentSha: candidateSha,
   });
+
+  const disconnectedBridgeTail = selectReviewOnlyCandidate([candidate, bridge, {
+    ...review,
+    parents: [{ sha: '8'.repeat(40) }],
+  }], baseSha);
+  assert.match(disconnectedBridgeTail.reason, /non-linear-review-tail/);
 });
 
 test('CodeQL fast pass accepts exactly one matrix skip representation', () => {

--- a/scripts/tests/test_ci_impact_policy_workflow.py
+++ b/scripts/tests/test_ci_impact_policy_workflow.py
@@ -144,6 +144,7 @@ class CiImpactPolicyWorkflowTests(unittest.TestCase):
     def test_controller_collects_full_candidate_and_review_lineage(self) -> None:
         self.assertIn("selectReviewOnlyCandidate", self.workflow)
         self.assertIn("pull-commit-list-incomplete", self.workflow)
+        self.assertIn("pull-commit-head-mismatch", self.workflow)
         self.assertIn("allowPriorBase", self.workflow)
         self.assertIn("github-advanced-security", self.workflow)
         self.assertIn(".ci-impact-review-reuse.json", self.workflow)

--- a/scripts/tests/test_ci_impact_policy_workflow.py
+++ b/scripts/tests/test_ci_impact_policy_workflow.py
@@ -130,10 +130,34 @@ class CiImpactPolicyWorkflowTests(unittest.TestCase):
             else:
                 self.assertIn(marker, self.workflow)
 
-    def test_existing_workers_do_not_consume_policy_status(self) -> None:
+    def test_workers_consume_only_exact_trusted_review_reuse_status(self) -> None:
         for workflow in (self.ci_workflow, self.codeql_workflow, self.render_workflow):
-            self.assertNotIn("CI Impact Policy", workflow)
+            self.assertIn("status.context === 'CI Impact Policy'", workflow)
+            self.assertIn("fields.get('v') === '5'", workflow)
+            self.assertIn("fields.get('rfp') === '1'", workflow)
+            self.assertIn("fields.get('b') === pr.base.sha", workflow)
+            self.assertIn("run.name === 'CI Impact Policy Controller'", workflow)
+            self.assertIn("run.event === 'pull_request_target'", workflow)
+            self.assertIn("statuses: read", workflow)
             self.assertNotIn("skip_eligible", workflow)
+
+    def test_controller_collects_full_candidate_and_review_lineage(self) -> None:
+        self.assertIn("selectReviewOnlyCandidate", self.workflow)
+        self.assertIn("pull-commit-list-incomplete", self.workflow)
+        self.assertIn("allowPriorBase", self.workflow)
+        self.assertIn("github-advanced-security", self.workflow)
+        self.assertIn(".ci-impact-review-reuse.json", self.workflow)
+        self.assertIn("reviewReuse.mergeTreeVerified", self.workflow)
+        self.assertIn("REVIEW_FAST_PASS", self.workflow)
+        self.assertIn("else if (process.env.REVIEW_FAST_PASS === 'true') state = 'success'", self.workflow)
+        self.assertIn("process.env.AUDIT_CONCLUSION === 'pending'", self.workflow)
+
+    def test_merge_bridge_fetches_objects_without_checking_out_pr_head(self) -> None:
+        self.assertIn("name: Verify trusted current-base merge bridge", self.workflow)
+        self.assertIn("git -C trusted-base fetch", self.workflow)
+        self.assertIn("git -C trusted-base merge-tree --write-tree", self.workflow)
+        self.assertIn("verify_review_only_merge_resolution.py", self.workflow)
+        self.assertNotIn("ref: refs/pull/", self.workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 변경 요약

- workflow 또는 CI 정책을 바꾼 PR에서 Full 검증이 끝난 뒤 review 문서만 추가해도 CI·CodeQL·Render Diff가 다시 Full 실행되던 문제를 해결합니다.
- 기본 브랜치의 `CI Impact Policy Controller`가 exact Full candidate와 이후 review-only commit 계보를 독립 검증하고, current head에 결합된 policy v5 `rfp=1` status를 발행합니다.
- CI·CodeQL·Render Diff preflight는 실행 정책 변경이 있는 same-repository PR에서만 이 trusted status를 확인한 뒤 기존 fast-pass 후보 탐색을 계속합니다.

## 원인과 보안 경계

기존 preflight는 PR 전체 변경 목록에 workflow·action·CI impact policy 파일이 하나라도 있으면 즉시 `ci-execution-surface-change` Full 경로로 닫았습니다. 이 guard는 PR이 자신이 수정한 workflow로 검증을 생략하지 못하게 하는 필수 경계이므로 PR head의 자체 주장만으로 완화할 수 없습니다.

이번 변경은 live base의 controller만 다음 증빙을 확인하게 합니다.

- same repository·branch·PR·candidate SHA에서 fast-pass가 아닌 Full CI·CodeQL과 필요한 Render Diff가 성공했는지
- CodeQL 언어별 Analyze job과 같은 candidate/run 이후 GHAS `CodeQL` check가 성공 또는 neutral인지
- candidate 뒤가 허용된 single-parent review-only commit뿐인지
- current-base merge bridge가 자동 merge tree 일치 또는 `mydocs/` 한정 충돌 해소인지
- current head·base·policy version·controller run identity가 exact match인지

commit/file 목록 누락, pending·failed·stale evidence, candidate 자체 fast-pass, GHAS 누락, 외부 fork, 검증되지 않은 merge bridge는 모두 Full 실행으로 fallback합니다.

## 관련 이슈

Closes #4740

관찰 사례: #4819

## 테스트

- [x] `node scripts/tests/ci-impact-classifier.test.cjs` — 31/31
- [x] `node scripts/tests/ci-impact-policy.test.cjs` — 31/31
- [x] CI·CodeQL·Render Diff·review-only·policy controller·workflow wiring Python 계약 — 70/70
- [x] 변경 workflow 4개 PyYAML parse
- [x] 변경 manual 5개 Markdown 상대 링크 검사
- [x] `git diff --check upstream/devel...HEAD`
- [ ] `actionlint` — 로컬 실행 파일이 없어 미실행, GitHub Actions에서 실제 workflow 결과 확인 필요
- [ ] 작업 증빙 캡슐 — 권장 항목이며 이번 변경에서는 생성하지 않음

제품 Rust·WASM·Studio 동작은 변경하지 않아 Cargo·WASM·브라우저 렌더링 검증은 적용하지 않았습니다.

## 성능 영향 및 측정 결과

- 예상 영향: 개선. trusted evidence가 있는 workflow PR의 후행 review-only head에서 heavy worker 재실행을 제거합니다.
- 재현: #4819의 Full code candidate 뒤 review 문서만 추가한 head에서 기존 CI `31881202046`, CodeQL `31881201970`이 Full로 다시 실행됐습니다.
- consumer는 실행 정책 변경 PR에서 trusted status가 아직 없을 때만 최대 30초 대기하며, definitive status가 도착하면 즉시 재사용 또는 Full 경로를 선택합니다.

## 배포 주의

`pull_request_target`과 `workflow_run` controller는 default branch 등록형입니다. 이 PR을 `devel`에 병합한 것만으로 활성화되지 않으며, 정상 release로 `main`에 반영된 뒤부터 후속 workflow PR에 적용됩니다. #4819의 기존 run에는 소급 적용되지 않습니다.

## 스크린샷

해당 없음 — GitHub Actions 정책과 문서만 변경합니다.
