### PR TITLE
gym 코퍼스 퍼징 발견 엔진 — DoS 근본원인 클러스터링 (#4828)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -935,6 +935,7 @@ jobs:
           python3 -m unittest scripts/tests/test_gym_trajectory.py
           python3 -m unittest scripts/tests/test_gym_leaderboard.py
           python3 -m unittest scripts/tests/test_gym_robustness.py
+          python3 -m unittest scripts/tests/test_gym_fuzz_corpus.py
           python3 -m unittest scripts/tests/test_gym_release_diff.py
           python3 -m unittest scripts/tests/test_gym_discriminate.py
 

--- a/gym/README.md
+++ b/gym/README.md
@@ -317,6 +317,25 @@ python gym/tools/robustness.py --bin target/debug/rhwp --limit 40
 적대적 입력에 죽지 않음을 인증한다. 첫 주행이 HWP3 파서의 실제 DoS 2건을 잡았다
 (line-spacing 곱셈 i32 오버플로 패닉 — 이 PR 에서 수정 · 무한루프 1건 — 후속 이슈).
 
+## 코퍼스 퍼징 발견 엔진 — DoS 를 근본원인별로 색출한다
+
+`robustness.py` 가 릴리스 **게이트**(바운드된 부분집합으로 "패닉·행 0" 강제)라면,
+`fuzz_corpus.py` 는 그 앞단의 **발견 엔진**이다. 전 코퍼스를 여러 명령·여러 손상으로
+**exhaustive** 하게 병렬로 두들겨, 아직 안 고쳐진 DoS 를 **소스 위치(file:line)별로
+클러스터링**해 "고쳐야 할 고유 버그 목록"을 낸다.
+
+```bash
+python gym/tools/fuzz_corpus.py --bin target/debug/rhwp                     # 전 코퍼스·기본 명령
+python gym/tools/fuzz_corpus.py --bin <bin> --commands info,export-text --json
+```
+
+- 패닉은 `panicked at file:line` 로 클러스터(스택 오버플로·어보트 코드도 별도 버킷).
+- 무한루프는 timeout → 명령·샘플별 버킷.
+
+아무도 손으로 수백 문서를 수천 가지로 퍼징하지 않는다 — 에이전트가 이걸 돌려 rhwp 를
+계속 경화한다(발견 → 수정 → `robustness.py` 게이트가 회귀를 막음). 이 캠페인의 실제
+DoS(렌더러·파서 오버플로·무한루프·스택 오버플로)를 전부 이 엔진이 잡았다.
+
 ## 설계 원칙 (채점기가 지키는 것)
 
 - 표준 라이브러리 전용, Windows/리눅스 경로 안전.

--- a/gym/tools/fuzz_corpus.py
+++ b/gym/tools/fuzz_corpus.py
@@ -1,0 +1,208 @@
+"""gym 코퍼스 퍼징 발견 엔진 — 전 코퍼스 × 다명령 × 다변형을 병렬로 두들겨 rhwp 의
+DoS(패닉·무한루프)를 **근본원인별로 클러스터링**한다.
+
+## 왜 이 도구인가 (강건성 감사와의 분업)
+
+`robustness.py`(#4814)는 릴리스 **게이트**다 — 바운드된 부분집합으로 "패닉·행 0"을
+강제해 회귀를 막는다. 이 도구는 그 앞단의 **발견 엔진**이다 — 전 코퍼스를 여러 명령·
+여러 손상으로 **exhaustive** 하게 두들겨 아직 안 고쳐진 DoS 를 찾아, 패닉을 **소스
+위치(file:line)별로 묶어** "고쳐야 할 고유 버그 목록"을 낸다. 아무도 손으로 수백
+문서를 수천 가지로 퍼징하지 않는다 — 에이전트가 이걸 돌려 rhwp 를 계속 경화한다.
+
+- 패닉: stderr 의 `panicked at file:line` → 그 위치로 클러스터. 스택 오버플로·시그널·
+  비-0 어보트도 별도 버킷.
+- 무한루프: timeout → 샘플별 버킷.
+
+## 사용
+
+    python gym/tools/fuzz_corpus.py --bin target/debug/rhwp                    # 기본 명령·전 코퍼스
+    python gym/tools/fuzz_corpus.py --bin <bin> --commands info,export-text    # 명령 지정
+    python gym/tools/fuzz_corpus.py --bin <bin> --limit 40 --workers 8 --json  # 부분집합·기계용
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GYM_ROOT = os.path.dirname(HERE)
+REPO_ROOT = os.path.dirname(GYM_ROOT)
+sys.path.insert(0, GYM_ROOT)
+
+from core import runner  # noqa: E402
+
+DEFAULT_COMMANDS = ["info", "export-text", "export-structure", "export-render-tree"]
+PANIC_RE = re.compile(r"panicked at ([^\n]+?:\d+)")
+
+
+def deterministic_mutants(data: bytes):
+    """결정적 손상 변형 — (라벨, 바이트). 무작위 없음(재현 가능)."""
+    n = len(data)
+    out = []
+    for pct in (5, 25, 50, 75, 95):
+        out.append((f"trunc{pct}", data[: max(1, n * pct // 100)]))
+    for pct in (10, 30, 50, 70, 90):
+        pos = min(n - 1, n * pct // 100)
+        b = bytearray(data)
+        b[pos] ^= 0xFF
+        out.append((f"flip{pct}", bytes(b)))
+    for pct in (10, 40, 70):  # 길이필드 추정 위치를 큰 값으로
+        pos = min(n - 4, n * pct // 100)
+        b = bytearray(data)
+        b[pos:pos + 4] = b"\xff\xff\xff\x7f"
+        out.append((f"biglen{pct}", bytes(b)))
+    return out
+
+
+def select_samples(samples_dir: str, limit: int):
+    everything = sorted(
+        f for f in os.listdir(samples_dir) if f.endswith((".hwp", ".hwpx", ".hml"))
+    )
+    if limit <= 0 or len(everything) <= limit:
+        return everything, len(everything)
+    stride = len(everything) / limit
+    picked, seen = [], set()
+    for i in range(limit):
+        f = everything[min(len(everything) - 1, int(i * stride))]
+        if f not in seen:
+            seen.add(f)
+            picked.append(f)
+    return picked, len(everything)
+
+
+def classify(code, err: str):
+    """(kind, bucket) — kind in {panic, hang, None}. bucket 은 클러스터 키."""
+    low = err.lower()
+    m = PANIC_RE.search(err)
+    if m:
+        return "panic", m.group(1)
+    if "stack overflow" in low:
+        return "panic", "stack-overflow"
+    if "panicked" in low or code == 101 or (code is not None and (code < 0 or code >= 132)):
+        return "panic", f"code{code}"
+    return None, None
+
+
+def probe(bin_path, cmd, mut_path, timeout):
+    args = [bin_path, cmd, mut_path]
+    if cmd == "convert":
+        args.append(mut_path + ".out.hwpx")
+    try:
+        p = subprocess.run(args, cwd=REPO_ROOT, capture_output=True, timeout=timeout)
+        err = p.stderr.decode("utf-8", "replace") + p.stdout.decode("utf-8", "replace")
+        return classify(p.returncode, err)
+    except subprocess.TimeoutExpired:
+        return "hang", cmd
+
+
+def fuzz(bin_path, samples_dir, commands, limit, workers, timeout, work_dir):
+    picked, total = select_samples(samples_dir, limit)
+    jobs = []
+    for i, name in enumerate(picked):
+        data = open(os.path.join(samples_dir, name), "rb").read()
+        for label, mut in deterministic_mutants(data):
+            jobs.append((i, name, label, mut))
+
+    panic_clusters, hang_clusters = {}, {}
+    checked = 0
+
+    def run_one(job):
+        idx, name, label, mut = job
+        p = os.path.join(work_dir, f"m{idx}_{label}.hwp")
+        open(p, "wb").write(mut)
+        try:
+            results = []
+            for cmd in commands:
+                kind, bucket = probe(bin_path, cmd, p, timeout)
+                if kind:
+                    results.append((kind, bucket, f"{name}:{label}:{cmd}"))
+            return results
+        finally:
+            try:
+                os.remove(p)
+            except OSError:
+                pass
+
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        for fut in as_completed([ex.submit(run_one, j) for j in jobs]):
+            checked += 1
+            for kind, bucket, tag in fut.result():
+                target = panic_clusters if kind == "panic" else hang_clusters
+                target.setdefault(bucket, []).append(tag)
+
+    panics = sorted(
+        ({"location": loc, "count": len(c), "example": c[0]} for loc, c in panic_clusters.items()),
+        key=lambda x: -x["count"],
+    )
+    hangs = sorted(
+        (
+            {
+                "command": cmd,
+                "count": len(c),
+                "samples": sorted({t.split(":")[0] for t in c}),
+                "example": c[0],
+            }
+            for cmd, c in hang_clusters.items()
+        ),
+        key=lambda x: -x["count"],
+    )
+    return {
+        "kind": "gymFuzzCorpus",
+        "schemaVersion": "1.0",
+        "ok": not panics and not hangs,
+        "samplesTested": len(picked),
+        "totalSamples": total,
+        "commands": commands,
+        "mutantsPerSample": len(deterministic_mutants(b"x" * 4096)),
+        "runsChecked": checked * len(commands),
+        "distinctPanicSites": len(panics),
+        "panicClusters": panics,
+        "hangClusters": hangs,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="gym 코퍼스 퍼징 발견 엔진 — DoS 를 근본원인별로 색출")
+    ap.add_argument("--bin", required=True)
+    ap.add_argument("--commands", default=",".join(DEFAULT_COMMANDS),
+                    help="쉼표구분 rhwp 명령 (기본: %(default)s)")
+    ap.add_argument("--limit", type=int, default=0, help="샘플 수(0=전수)")
+    ap.add_argument("--workers", type=int, default=8)
+    ap.add_argument("--timeout", type=int, default=10)
+    ap.add_argument("--json", action="store_true")
+    a = ap.parse_args()
+    bin_path = runner.find_bin(a.bin)
+    commands = [c.strip() for c in a.commands.split(",") if c.strip()]
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as work:
+        report = fuzz(bin_path, os.path.join(REPO_ROOT, "samples"), commands,
+                      a.limit, a.workers, a.timeout, work)
+    if a.json:
+        sys.stdout.write(json.dumps(report, ensure_ascii=False, indent=2) + "\n")
+    elif report["ok"]:
+        print(f"코퍼스 퍼징: 샘플 {report['samplesTested']}/{report['totalSamples']} × "
+              f"명령 {len(commands)} × {report['runsChecked']} 실행 — DoS 0")
+    else:
+        print(f"코퍼스 퍼징: 고유 패닉 {report['distinctPanicSites']}곳 · "
+              f"행 클러스터 {len(report['hangClusters'])}개 — 고쳐야 할 DoS:")
+        for p in report["panicClusters"]:
+            print(f"  PANIC {p['location']}  ({p['count']}건)  예: {p['example']}")
+        for h in report["hangClusters"]:
+            print(f"  HANG  {h['command']}  ({h['count']}건, {len(h['samples'])}샘플)  예: {h['example']}")
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
+        except Exception:
+            pass
+    sys.exit(main())

--- a/scripts/tests/test_gym_fuzz_corpus.py
+++ b/scripts/tests/test_gym_fuzz_corpus.py
@@ -1,0 +1,98 @@
+"""[fuzz_corpus] gym 코퍼스 퍼징 발견 엔진 계약 — 결정적 변형·분류·근본원인 클러스터링.
+
+퍼징(subprocess)은 목킹해 바이너리 없이 로직만 시험한다.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+TOOL = Path(__file__).resolve().parents[2] / "gym" / "tools" / "fuzz_corpus.py"
+
+
+def load():
+    spec = importlib.util.spec_from_file_location("gym_fuzz_corpus", TOOL)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FuzzCorpusTests(unittest.TestCase):
+    def test_mutants_deterministic_and_nontrivial(self):
+        mod = load()
+        data = bytes(range(256)) * 16
+        a = mod.deterministic_mutants(data)
+        b = mod.deterministic_mutants(data)
+        self.assertEqual(a, b)  # 결정적
+        self.assertGreaterEqual(len(a), 10)
+        for label, mut in a:
+            self.assertNotEqual(mut, data, f"{label} 이 원본과 같다")
+
+    def test_classify_distinguishes_panic_from_clean(self):
+        mod = load()
+        self.assertEqual(mod.classify(101, "thread 'main' panicked at src/x.rs:42:9")[0], "panic")
+        self.assertEqual(mod.classify(101, "panicked at src/x.rs:42:9")[1], "src/x.rs:42")
+        self.assertEqual(mod.classify(134, "stack overflow"), ("panic", "stack-overflow"))
+        self.assertEqual(mod.classify(101, "")[0], "panic")           # 어보트 코드
+        self.assertEqual(mod.classify(-1073741819, "")[0], "panic")   # AV(음수)
+        self.assertEqual(mod.classify(1, "오류: 유효하지 않은 파일"), (None, None))  # 깨끗한 실패
+        self.assertEqual(mod.classify(0, "정상"), (None, None))
+
+    def test_select_samples_deterministic_bounded(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            for i in range(40):
+                open(os.path.join(d, f"s{i:03d}.hwp"), "wb").write(b"x")
+            open(os.path.join(d, "note.txt"), "wb").write(b"x")
+            picked, total = mod.select_samples(d, 8)
+            self.assertEqual(total, 40)                 # .txt 제외
+            self.assertLessEqual(len(picked), 8)
+            self.assertEqual(picked, mod.select_samples(d, 8)[0])  # 결정적
+
+    def test_fuzz_clusters_panics_by_location(self):
+        mod = load()
+        # probe 를 목킹: cmd 별로 서로 다른 결과. 두 위치 패닉 + 한 행.
+        def fake_probe(bin_path, cmd, path, timeout):
+            if cmd == "a":
+                return ("panic", "src/x.rs:10")
+            if cmd == "b":
+                return ("panic", "src/x.rs:10")  # 같은 위치(다른 명령) → 한 클러스터
+            if cmd == "c":
+                return ("hang", "c")
+            return (None, None)
+        mod.probe = fake_probe
+        with tempfile.TemporaryDirectory() as d:
+            samples = os.path.join(d, "samples")
+            os.makedirs(samples)
+            open(os.path.join(samples, "one.hwp"), "wb").write(bytes(range(256)) * 16)
+            work = os.path.join(d, "w")
+            os.makedirs(work)
+            r = mod.fuzz("bin", samples, ["a", "b", "c"], limit=0, workers=2, timeout=5, work_dir=work)
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["distinctPanicSites"], 1)                 # x.rs:10 한 곳으로 묶임
+        self.assertEqual(r["panicClusters"][0]["location"], "src/x.rs:10")
+        self.assertEqual(len(r["hangClusters"]), 1)
+        self.assertEqual(r["hangClusters"][0]["command"], "c")
+
+    def test_fuzz_clean_when_no_dos(self):
+        mod = load()
+        mod.probe = lambda *a, **k: (None, None)
+        with tempfile.TemporaryDirectory() as d:
+            samples = os.path.join(d, "samples")
+            os.makedirs(samples)
+            open(os.path.join(samples, "one.hwp"), "wb").write(bytes(range(256)) * 16)
+            work = os.path.join(d, "w")
+            os.makedirs(work)
+            r = mod.fuzz("bin", samples, ["info"], limit=0, workers=2, timeout=5, work_dir=work)
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["panicClusters"], [])
+        self.assertEqual(r["hangClusters"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## gym 코퍼스 퍼징 발견 엔진 — DoS 를 근본원인별로 색출

`robustness.py`(#4814)는 릴리스 **게이트**(바운드·"패닉/행 0" 강제)다. 그 앞단의
**발견 엔진**이 없다 — 전 코퍼스를 여러 명령·여러 손상으로 exhaustive 하게 두들겨
아직 안 고쳐진 DoS 를 찾아 소스 위치별로 묶어주는 도구.

이 캠페인의 실제 DoS(렌더러/파서 오버플로·무한루프·스택 오버플로)는 전부 이런 병렬
퍼징으로 찾았다. 그 방법을 재사용 가능한 gym 도구로 정식화해, 어떤 에이전트든 돌려
새 DoS 를 발견→수정→(robustness 게이트가 회귀 차단)하게 한다.

## 제안

`gym/tools/fuzz_corpus.py`: 전 코퍼스 × 다명령(info·export-text·export-structure·
export-render-tree 기본, 지정 가능) × 결정적 변형(절단·플립·biglen)을 ThreadPoolExecutor
로 병렬 실행. 패닉을 `panicked at file:line` 로 클러스터(스택오버플로·어보트 별도),
무한루프를 timeout 으로 버킷. JSON/사람용 리포트. 바이너리-없는 가드 5건.

## Done when

- `fuzz_corpus.py --bin <rhwp>` 가 코퍼스를 병렬 퍼징해 고유 패닉 위치·행 클러스터를 낸다.
- 가드(`test_gym_fuzz_corpus.py`)가 변형 결정성·분류·클러스터링을 바이너리 없이 시험, CI 등록.
