### PR TITLE
HWP3 보안 트레일러 포스트양자 공개키 봉인(ML-KEM-768, FIPS 203)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
  "typenum",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
  "cpubits",
  "cpufeatures 0.3.0",
 ]
@@ -83,6 +93,18 @@ name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+]
 
 [[package]]
 name = "arrayref"
@@ -180,6 +202,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "blake3"
 version = "1.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,7 +301,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -310,13 +341,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher 0.4.4",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+ "zeroize",
+]
+
+[[package]]
 name = "cipher"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
  "crypto-common 0.2.2",
- "inout",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -505,6 +571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -606,7 +673,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -617,6 +684,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -994,6 +1062,15 @@ dependencies = [
 
 [[package]]
 name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "inout"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
@@ -1246,6 +1323,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,6 +1434,17 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -1537,12 +1642,14 @@ name = "rhwp"
 version = "0.8.4"
 dependencies = [
  "aes",
+ "argon2",
  "base64 0.23.1",
  "blake3",
  "byteorder",
  "cbc",
  "cfb",
- "cipher",
+ "chacha20poly1305",
+ "cipher 0.5.2",
  "codepage",
  "console_error_panic_hook",
  "crc32fast",
@@ -1581,6 +1688,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-test",
  "web-sys",
+ "zeroize",
  "zip",
 ]
 
@@ -2270,6 +2378,16 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "usvg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "hybrid-array",
+ "hybrid-array 0.4.14",
 ]
 
 [[package]]
@@ -248,7 +248,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
 dependencies = [
- "hybrid-array",
+ "hybrid-array 0.4.14",
 ]
 
 [[package]]
@@ -581,7 +581,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "hybrid-array",
+ "hybrid-array 0.4.14",
 ]
 
 [[package]]
@@ -1003,6 +1003,15 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hybrid-array"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
@@ -1076,7 +1085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "block-padding",
- "hybrid-array",
+ "hybrid-array 0.4.14",
 ]
 
 [[package]]
@@ -1145,6 +1154,25 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8645470337db67b01a7f966decf7d0bafedbae74147d33e641c67a91df239f"
+dependencies = [
+ "rand_core",
+ "zeroize",
 ]
 
 [[package]]
@@ -1263,6 +1291,18 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de49b3df74c35498c0232031bb7e85f9389f913e2796169c8ab47a53993a18f"
+dependencies = [
+ "hybrid-array 0.2.3",
+ "kem",
+ "rand_core",
+ "sha3",
 ]
 
 [[package]]
@@ -1662,11 +1702,13 @@ dependencies = [
  "hmac",
  "image",
  "js-sys",
+ "ml-kem",
  "paste",
  "pbkdf2",
  "pcx",
  "pdf-writer",
  "quick-xml",
+ "rand_core",
  "resvg 0.47.0",
  "roxmltree 0.21.1",
  "serde",
@@ -1877,6 +1919,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,11 @@ getrandom = { version = "0.4", features = ["wasm_js"] }
 sha1 = "0.11"
 sha2 = "0.11"
 blake3 = "1"
+# [보안 트레일러] HWP3 강암호 append 트레일러 — memory-hard KDF(Argon2id) +
+# misuse-resistant AEAD(XChaCha20-Poly1305). 순수 Rust(RustCrypto) 라 wasm 도 그대로 컴파일.
+argon2 = "0.5"
+chacha20poly1305 = { version = "0.10", features = ["alloc"] }
+zeroize = "1"
 zip = { version = "8.5", default-features = false, features = ["deflate"] }
 quick-xml = "0.41"
 roxmltree = "0.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,11 @@ blake3 = "1"
 argon2 = "0.5"
 chacha20poly1305 = { version = "0.10", features = ["alloc"] }
 zeroize = "1"
+# [보안 트레일러 · 포스트양자] ML-KEM-768(NIST FIPS 203) 격자 KEM — 공개키 봉인의
+# 양자안전 키교환. 대칭부(XChaCha20-Poly1305)는 이미 양자내성이고, Shor 에 깨지는
+# 비대칭 키교환만 격자 KEM 으로 교체한다. 순수 Rust(RustCrypto) 라 wasm 도 그대로 컴파일.
+ml-kem = "0.2"
+rand_core = "0.6"
 zip = { version = "8.5", default-features = false, features = ["deflate"] }
 quick-xml = "0.41"
 roxmltree = "0.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,15 @@ sha2 = "0.11"
 blake3 = "1"
 # [보안 트레일러] HWP3 강암호 append 트레일러 — memory-hard KDF(Argon2id) +
 # misuse-resistant AEAD(XChaCha20-Poly1305). 순수 Rust(RustCrypto) 라 wasm 도 그대로 컴파일.
-argon2 = "0.5"
-chacha20poly1305 = { version = "0.10", features = ["alloc"] }
+#
+# 기본 피처는 끈다 — argon2 의 `rand`/`password-hash` 와 chacha20poly1305 의
+# `getrandom` 은 rand_core 0.6 을 거쳐 **getrandom 0.2** 를 끌어오는데, 0.2 는
+# wasm32-unknown-unknown 에서 `js` 피처 없이는 compile_error! 로 죽는다(이
+# 저장소는 getrandom 0.4 + wasm_js 를 쓴다). 여기 코드는 소금·논스를
+# `getrandom::fill` 로 직접 만들고 저수준 Argon2 API 만 쓰므로 그 피처가
+# 필요 없다 — 끊어 두면 wasm 빌드가 구버전 getrandom 을 아예 만나지 않는다.
+argon2 = { version = "0.5", default-features = false, features = ["alloc"] }
+chacha20poly1305 = { version = "0.10", default-features = false, features = ["alloc"] }
 zeroize = "1"
 zip = { version = "8.5", default-features = false, features = ["deflate"] }
 quick-xml = "0.41"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod plan_schema;
 pub mod provenance;
 pub mod renderer;
 pub mod schema_registry;
+pub mod security_trailer;
 pub mod serializer;
 /// 핫패치 벤더(Dioxus subsecond) 어댑터. **rhwp 의 API 가 아니다** (#4580).
 ///

--- a/src/security_trailer.rs
+++ b/src/security_trailer.rs
@@ -1,0 +1,328 @@
+//! HWP3 보안 트레일러 — 유효한 HWP3 파일에 강암호 페이로드를 append 해, 순정 한컴에서는
+//! 정상 열람되고 rhwp 에서는 진짜 비밀을 복원하며, 어떤 상황에서도 에러 없이 정상화되는 구조.
+//!
+//! ## 3층 구조
+//!
+//! - **가시층(Visible)** — 민감정보를 뺀/가린 정상 HWP3 본문. 순정 한컴 + 모두가 읽는다.
+//! - **봉인 트레일러(Sealed)** — 진짜 비밀(AEAD 암호문). rhwp + 비밀번호만 연다.
+//! - **정상화(Normalize)** — 감지·검증·fallback. rhwp 런타임이 4상태로 수렴시킨다.
+//!
+//! ## 정보이론적 정직 조항
+//!
+//! 순정 한컴이 보여주는 **가시 내용의 기밀성은 여전히 56비트(DES) 상한**이다 — 그건 이
+//! 설계로 못 올린다. 이 설계는 "가시 내용을 더 세게 지진다"가 아니라, **진짜 비밀을 애초에
+//! 가시층에서 빼서 강암호 트레일러로 따로 보호한다**. 트레일러가 지키는 비밀에는 상한이 없다.
+//!
+//! ## 정당한 용도와 경고 (검사 우회 도구가 아니다)
+//!
+//! 이 모듈은 **권한자 복원이 가능한 리댁션**만 한다(REDACTED 전용) — 가시층은 실제 리댁션된
+//! 문서이지 위장 문서가 아니고, 문서 전체를 숨기는 decoy 모드는 넣지 않는다. 정당한 용도는
+//! 민감 필드(주민번호·계좌 등)를 문서에서 가리되 권한자(비밀번호 보유)가 원값을 복원하는 것이다.
+//!
+//! - **은닉 아님·탐지 가능**: 트레일러는 평문 매직마커(`RHWPSEC1`/`RHWPEND1`)로 시작·끝난다.
+//!   어떤 검사 도구든 이 마커를 스캔해 "봉인 트레일러 있음"을 즉시 식별할 수 있다. 이 설계는
+//!   내용을 **암호화**할 뿐, 트레일러의 **존재를 은폐(스테가노그래피)하지 않는다**.
+//! - **가시 기밀성 한계**: 순정 한컴이 보여주는 가시 내용의 기밀성은 여전히 56비트(DES) 상한.
+//! - **사용자 실수 위험**: 한컴이 재저장하면 트레일러가 소실될 수 있다 → 경고·읽기 전용 배포·
+//!   교육이 필요하다.
+//! - **법적/조직 준수**: 개인정보·금융정보 처리 규정, 보존정책, 로그·감사, 키 관리 정책을
+//!   조직 기준에 맞춰 문서화한 뒤 운용한다.
+//!
+//! ## 파일 레이아웃 (append; 순정 한컴은 EOF 까지만 읽는다)
+//!
+//! ```text
+//! [ 원본 HWP3 바이트 (완전히 유효한 문서) ]  <- 순정 한컴은 여기까지
+//! MAGIC_START [8]  "RHWPSEC1"
+//! version     [2]  u16 LE
+//! flags       [2]  u16 LE   (REDACTED=0x01; 그 외 미지원)
+//! kdf_algo    [1]  1=Argon2id
+//! aead_algo   [1]  1=XChaCha20-Poly1305
+//! salt        [16]
+//! nonce       [24]
+//! ct_len      [4]  u32 LE
+//! ciphertext  [ct_len]      (AEAD, AAD = 위 헤더 전체)
+//! trailer_len [4]  u32 LE   (MAGIC_START..MAGIC_END 총길이)
+//! MAGIC_END   [8]  "RHWPEND1"
+//! ```
+//!
+//! 탐지는 뒤에서부터: 끝 8바이트가 MAGIC_END 인지 → trailer_len 으로 시작 위치를 역산해
+//! MAGIC_START 확인. 둘 중 하나라도 안 맞으면 트레일러가 없는 것으로 본다(우연 일치 방어).
+
+use chacha20poly1305::aead::{Aead, Payload};
+use chacha20poly1305::{Key, KeyInit, XChaCha20Poly1305, XNonce};
+use zeroize::Zeroizing;
+
+pub const MAGIC_START: &[u8; 8] = b"RHWPSEC1";
+pub const MAGIC_END: &[u8; 8] = b"RHWPEND1";
+
+/// **유일 지원 모드** — 민감 스팬만 가리고 진짜 값은 권한자 복원용으로 트레일러에 둔다.
+/// 가시층은 decoy 가 아니라 **실제 리댁션된 문서**다: 표준 뷰어가 보는 것이 진짜 문서(의
+/// 가린 판)이지, 전혀 다른 위장 문서가 아니다. 이 도구는 "검사 우회"가 아니라 "권한자
+/// 복원 가능한 리댁션"만 수행한다. 문서 전체를 위장 문서 뒤에 숨기는 모드(구 0x02)는
+/// 의도적으로 넣지 않는다.
+pub const FLAG_REDACTED: u16 = 0x01;
+
+pub const VERSION: u16 = 1;
+pub const KDF_ARGON2ID: u8 = 1;
+pub const AEAD_XCHACHA20POLY1305: u8 = 1;
+
+// kdf_algo=1 의 고정 Argon2id 파라미터(seal/unseal 이 반드시 같아야 하므로 상수).
+// OWASP 권고 하한 근방 — memory-hard 성질을 지키면서 CI·wasm 에서도 감당된다.
+const ARGON2_MEM_KIB: u32 = 19_456; // 19 MiB
+const ARGON2_TIME: u32 = 2;
+const ARGON2_LANES: u32 = 1;
+
+const SALT_LEN: usize = 16;
+const NONCE_LEN: usize = 24;
+const TAG_LEN: usize = 16; // Poly1305
+const HEADER_LEN: usize = 8 + 2 + 2 + 1 + 1 + SALT_LEN + NONCE_LEN + 4; // MAGIC..ct_len = 58
+const MIN_TRAILER_LEN: usize = HEADER_LEN + TAG_LEN + 4 + 8; // 빈 비밀 + trailer_len + MAGIC_END
+
+#[derive(Debug)]
+pub enum SealError {
+    Kdf(String),
+    Aead,
+    Random(String),
+}
+
+impl std::fmt::Display for SealError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SealError::Kdf(e) => write!(f, "키 유도 실패: {e}"),
+            SealError::Aead => write!(f, "암호화 실패"),
+            SealError::Random(e) => write!(f, "엔트로피 획득 실패: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for SealError {}
+
+/// 파일을 열었을 때의 정상화 결과 — rhwp 는 절대 에러로 죽지 않고 넷 중 하나로 수렴한다.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Opened {
+    /// 트레일러 없음 → 평범한 HWP3. (한컴 재저장으로 트레일러가 사라진 Stripped 도 여기로 온다.)
+    Plain,
+    /// 트레일러 복호 성공 → 진짜 비밀 복원.
+    Sealed { plaintext: Vec<u8>, flags: u16 },
+    /// 트레일러는 있으나 복호 실패(비밀번호 오류·변조) → 가시층은 그대로 열고 경고.
+    Broken { reason: String },
+}
+
+fn derive_key(password: &[u8], salt: &[u8]) -> Result<Zeroizing<[u8; 32]>, SealError> {
+    use argon2::{Algorithm, Argon2, Params, Version};
+    let params = Params::new(ARGON2_MEM_KIB, ARGON2_TIME, ARGON2_LANES, Some(32))
+        .map_err(|e| SealError::Kdf(e.to_string()))?;
+    let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
+    let mut key = Zeroizing::new([0u8; 32]);
+    argon2
+        .hash_password_into(password, salt, key.as_mut())
+        .map_err(|e| SealError::Kdf(e.to_string()))?;
+    Ok(key)
+}
+
+/// 헤더(= AEAD 의 associated data). MAGIC..ct_len 전체를 묶어 어떤 헤더 필드(버전·플래그·
+/// 알고리즘·salt·nonce·길이)를 변조해도 복호가 거부되게 한다.
+fn build_header(
+    flags: u16,
+    salt: &[u8; SALT_LEN],
+    nonce: &[u8; NONCE_LEN],
+    ct_len: u32,
+) -> Vec<u8> {
+    let mut h = Vec::with_capacity(HEADER_LEN);
+    h.extend_from_slice(MAGIC_START);
+    h.extend_from_slice(&VERSION.to_le_bytes());
+    h.extend_from_slice(&flags.to_le_bytes());
+    h.push(KDF_ARGON2ID);
+    h.push(AEAD_XCHACHA20POLY1305);
+    h.extend_from_slice(salt);
+    h.extend_from_slice(nonce);
+    h.extend_from_slice(&ct_len.to_le_bytes());
+    h
+}
+
+/// 유효한 HWP3 바이트에 리댁션된 값을 강암호 트레일러로 append 한다(REDACTED 전용).
+/// `host_hwp3` 는 이미 민감 스팬이 가려진 **실제 리댁션 문서**여야 한다 — 이 함수는
+/// 그 가려진 원값(`secret`)만 권한자 복원용으로 봉인한다.
+pub fn seal(host_hwp3: &[u8], secret: &[u8], password: &[u8]) -> Result<Vec<u8>, SealError> {
+    let mut salt = [0u8; SALT_LEN];
+    let mut nonce = [0u8; NONCE_LEN];
+    getrandom::fill(&mut salt).map_err(|e| SealError::Random(e.to_string()))?;
+    getrandom::fill(&mut nonce).map_err(|e| SealError::Random(e.to_string()))?;
+
+    let key = derive_key(password, &salt)?;
+    let ct_len = (secret.len() + TAG_LEN) as u32;
+    let header = build_header(FLAG_REDACTED, &salt, &nonce, ct_len);
+
+    let cipher = XChaCha20Poly1305::new(Key::from_slice(key.as_ref()));
+    let ciphertext = cipher
+        .encrypt(
+            XNonce::from_slice(&nonce),
+            Payload {
+                msg: secret,
+                aad: &header,
+            },
+        )
+        .map_err(|_| SealError::Aead)?;
+    debug_assert_eq!(ciphertext.len(), ct_len as usize);
+
+    let trailer_len = (header.len() + ciphertext.len() + 4 + 8) as u32;
+    let mut out = Vec::with_capacity(host_hwp3.len() + trailer_len as usize);
+    out.extend_from_slice(host_hwp3);
+    out.extend_from_slice(&header);
+    out.extend_from_slice(&ciphertext);
+    out.extend_from_slice(&trailer_len.to_le_bytes());
+    out.extend_from_slice(MAGIC_END);
+    Ok(out)
+}
+
+/// 뒤에서부터 트레일러를 탐지 — 있으면 트레일러 시작 오프셋을 돌려준다. 끝이 MAGIC_END 이고
+/// trailer_len 이 가리키는 시작이 MAGIC_START 여야 한다(우연 일치·재저장 잔여 방어).
+pub fn detect_trailer(bytes: &[u8]) -> Option<usize> {
+    if bytes.len() < MIN_TRAILER_LEN {
+        return None;
+    }
+    let n = bytes.len();
+    if &bytes[n - 8..] != MAGIC_END {
+        return None;
+    }
+    let trailer_len = u32::from_le_bytes(bytes[n - 12..n - 8].try_into().ok()?) as usize;
+    if trailer_len < MIN_TRAILER_LEN || trailer_len > n {
+        return None;
+    }
+    let start = n - trailer_len;
+    if &bytes[start..start + 8] != MAGIC_START {
+        return None;
+    }
+    Some(start)
+}
+
+/// 가시층(트레일러를 뗀 원본 HWP3 바이트). 트레일러가 없으면 입력 그대로.
+pub fn visible_layer(bytes: &[u8]) -> &[u8] {
+    match detect_trailer(bytes) {
+        Some(start) => &bytes[..start],
+        None => bytes,
+    }
+}
+
+/// 파일을 정상화해 연다 — 절대 Err 를 내지 않고 Plain/Sealed/Broken 중 하나로 수렴한다.
+pub fn open(bytes: &[u8], password: &[u8]) -> Opened {
+    let start = match detect_trailer(bytes) {
+        Some(s) => s,
+        None => return Opened::Plain,
+    };
+    let t = &bytes[start..];
+    // 레이아웃: MAGIC_START[8] version[2] flags[2] kdf[1] aead[1] salt[16] nonce[24] ct_len[4] ct[..]
+    let version = u16::from_le_bytes([t[8], t[9]]);
+    if version != VERSION {
+        // 버전 협상: 모르는 버전은 향후 포맷 진화로 보고 트레일러를 무시(Plain).
+        return Opened::Plain;
+    }
+    let flags = u16::from_le_bytes([t[10], t[11]]);
+    let kdf = t[12];
+    let aead = t[13];
+    if kdf != KDF_ARGON2ID || aead != AEAD_XCHACHA20POLY1305 {
+        return Opened::Broken {
+            reason: format!("미지원 알고리즘 (kdf={kdf}, aead={aead})"),
+        };
+    }
+    let salt: [u8; SALT_LEN] = t[14..30].try_into().expect("salt 16");
+    let nonce: [u8; NONCE_LEN] = t[30..54].try_into().expect("nonce 24");
+    let ct_len = u32::from_le_bytes([t[54], t[55], t[56], t[57]]) as usize;
+    let ct_end = HEADER_LEN + ct_len;
+    if ct_len < TAG_LEN || ct_end + 4 + 8 > t.len() {
+        return Opened::Broken {
+            reason: "트레일러 길이 불일치".to_string(),
+        };
+    }
+    let ciphertext = &t[HEADER_LEN..ct_end];
+    let header = build_header(flags, &salt, &nonce, ct_len as u32);
+
+    let key = match derive_key(password, &salt) {
+        Ok(k) => k,
+        Err(e) => {
+            return Opened::Broken {
+                reason: e.to_string(),
+            }
+        }
+    };
+    let cipher = XChaCha20Poly1305::new(Key::from_slice(key.as_ref()));
+    match cipher.decrypt(
+        XNonce::from_slice(&nonce),
+        Payload {
+            msg: ciphertext,
+            aad: &header,
+        },
+    ) {
+        Ok(plaintext) => Opened::Sealed { plaintext, flags },
+        Err(_) => Opened::Broken {
+            reason: "복호 실패 (비밀번호 오류 또는 변조)".to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HOST: &[u8] = b"\x1b\x00\x00\x00HWP Document File V3.00\x00 ... valid hwp3 bytes ...";
+    const SECRET: &[u8] = "진짜 비밀 — 주민번호 900101-1234567".as_bytes();
+    const PW: &[u8] = b"correct horse battery staple";
+
+    #[test]
+    fn seal_then_open_roundtrips() {
+        let sealed = seal(HOST, SECRET, PW).unwrap();
+        // 가시층은 원본 그대로(순정 한컴이 읽는 것).
+        assert_eq!(visible_layer(&sealed), HOST);
+        // rhwp + 올바른 비밀번호 → 진짜 비밀 복원.
+        match open(&sealed, PW) {
+            Opened::Sealed { plaintext, flags } => {
+                assert_eq!(plaintext, SECRET);
+                assert_eq!(flags, FLAG_REDACTED);
+            }
+            other => panic!("Sealed 를 기대: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn wrong_password_is_broken_not_panic() {
+        let sealed = seal(HOST, SECRET, PW).unwrap();
+        assert!(matches!(open(&sealed, b"wrong"), Opened::Broken { .. }));
+    }
+
+    #[test]
+    fn tampered_ciphertext_is_broken() {
+        let mut sealed = seal(HOST, SECRET, PW).unwrap();
+        let n = sealed.len();
+        sealed[n - 20] ^= 0xFF; // 트레일러 내부(암호문/태그) 1비트 변조
+        assert!(matches!(open(&sealed, PW), Opened::Broken { .. }));
+    }
+
+    #[test]
+    fn no_trailer_is_plain() {
+        assert_eq!(open(HOST, PW), Opened::Plain);
+        assert_eq!(visible_layer(HOST), HOST);
+    }
+
+    #[test]
+    fn accidental_magic_end_in_body_is_plain() {
+        // 원본이 우연히 MAGIC_END 로 끝나도, trailer_len 역산이 MAGIC_START 와 안 맞아 Plain.
+        let mut tricky = HOST.to_vec();
+        tricky.extend_from_slice(MAGIC_END);
+        assert_eq!(open(&tricky, PW), Opened::Plain);
+        assert!(detect_trailer(&tricky).is_none());
+    }
+
+    #[test]
+    fn stripped_trailer_reopens_as_plain() {
+        // 한컴 재저장 = 가시층만 남고 트레일러 소실 → Plain 으로 정상화(에러 없음).
+        let sealed = seal(HOST, SECRET, PW).unwrap();
+        let stripped = visible_layer(&sealed).to_vec();
+        assert_eq!(open(&stripped, PW), Opened::Plain);
+    }
+
+    #[test]
+    fn empty_secret_roundtrips() {
+        let sealed = seal(HOST, b"", PW).unwrap();
+        assert!(matches!(open(&sealed, PW), Opened::Sealed { .. }));
+    }
+}

--- a/src/security_trailer.rs
+++ b/src/security_trailer.rs
@@ -730,14 +730,14 @@ mod tests {
         // 비밀번호 경로(open)로 공개키 트레일러를 열면 kdf=2 분기에서 Broken(패닉 없음).
         let (ek, _dk) = generate_keypair();
         let sealed = seal_to_pubkey(HOST, SECRET, &ek).unwrap();
-        assert!(matches!(open(&sealed, PW), Opened::Broken { .. }));
+        assert!(matches!(open(&sealed, &pw()), Opened::Broken { .. }));
     }
 
     #[test]
     fn pq_open_with_privkey_on_password_trailer_is_broken_not_panic() {
         // 공개키 경로(open_with_privkey)로 비밀번호(kdf=1) 트레일러를 열면 Broken(패닉 없음).
         let (_ek, dk) = generate_keypair();
-        let sealed = seal(HOST, SECRET, PW).unwrap();
+        let sealed = seal(HOST, SECRET, &pw()).unwrap();
         assert!(matches!(
             open_with_privkey(&sealed, &dk),
             Opened::Broken { .. }

--- a/src/security_trailer.rs
+++ b/src/security_trailer.rs
@@ -266,15 +266,26 @@ mod tests {
 
     const HOST: &[u8] = b"\x1b\x00\x00\x00HWP Document File V3.00\x00 ... valid hwp3 bytes ...";
     const SECRET: &[u8] = "진짜 비밀 — 주민번호 900101-1234567".as_bytes();
-    const PW: &[u8] = b"correct horse battery staple";
+
+    /// 테스트 비밀번호는 **실행마다 새로 뽑는다**.
+    ///
+    /// 상수로 두면 (a) CodeQL 이 하드코딩 암호값(critical)으로 잡고, (b) 어느
+    /// 경로가 특정 비밀번호에 우연히 기대게 되어도 드러나지 않는다. 난수면
+    /// 왕복·변조·오답 판정이 값에 무관하게 성립함을 매 실행이 재확인한다.
+    fn pw() -> Vec<u8> {
+        let mut buf = [0u8; 32];
+        getrandom::fill(&mut buf).expect("테스트 비밀번호 난수");
+        buf.to_vec()
+    }
 
     #[test]
     fn seal_then_open_roundtrips() {
-        let sealed = seal(HOST, SECRET, PW).unwrap();
+        let pw = pw();
+        let sealed = seal(HOST, SECRET, &pw).unwrap();
         // 가시층은 원본 그대로(순정 한컴이 읽는 것).
         assert_eq!(visible_layer(&sealed), HOST);
         // rhwp + 올바른 비밀번호 → 진짜 비밀 복원.
-        match open(&sealed, PW) {
+        match open(&sealed, &pw) {
             Opened::Sealed { plaintext, flags } => {
                 assert_eq!(plaintext, SECRET);
                 assert_eq!(flags, FLAG_REDACTED);
@@ -285,21 +296,26 @@ mod tests {
 
     #[test]
     fn wrong_password_is_broken_not_panic() {
-        let sealed = seal(HOST, SECRET, PW).unwrap();
-        assert!(matches!(open(&sealed, b"wrong"), Opened::Broken { .. }));
+        let (right, wrong) = (pw(), pw());
+        let sealed = seal(HOST, SECRET, &right).unwrap();
+        assert!(
+            matches!(open(&sealed, &wrong), Opened::Broken { .. }),
+            "다른 비밀번호는 Broken 이어야 한다"
+        );
     }
 
     #[test]
     fn tampered_ciphertext_is_broken() {
-        let mut sealed = seal(HOST, SECRET, PW).unwrap();
+        let pw = pw();
+        let mut sealed = seal(HOST, SECRET, &pw).unwrap();
         let n = sealed.len();
         sealed[n - 20] ^= 0xFF; // 트레일러 내부(암호문/태그) 1비트 변조
-        assert!(matches!(open(&sealed, PW), Opened::Broken { .. }));
+        assert!(matches!(open(&sealed, &pw), Opened::Broken { .. }));
     }
 
     #[test]
     fn no_trailer_is_plain() {
-        assert_eq!(open(HOST, PW), Opened::Plain);
+        assert_eq!(open(HOST, &pw()), Opened::Plain);
         assert_eq!(visible_layer(HOST), HOST);
     }
 
@@ -308,21 +324,23 @@ mod tests {
         // 원본이 우연히 MAGIC_END 로 끝나도, trailer_len 역산이 MAGIC_START 와 안 맞아 Plain.
         let mut tricky = HOST.to_vec();
         tricky.extend_from_slice(MAGIC_END);
-        assert_eq!(open(&tricky, PW), Opened::Plain);
+        assert_eq!(open(&tricky, &pw()), Opened::Plain);
         assert!(detect_trailer(&tricky).is_none());
     }
 
     #[test]
     fn stripped_trailer_reopens_as_plain() {
         // 한컴 재저장 = 가시층만 남고 트레일러 소실 → Plain 으로 정상화(에러 없음).
-        let sealed = seal(HOST, SECRET, PW).unwrap();
+        let pw = pw();
+        let sealed = seal(HOST, SECRET, &pw).unwrap();
         let stripped = visible_layer(&sealed).to_vec();
-        assert_eq!(open(&stripped, PW), Opened::Plain);
+        assert_eq!(open(&stripped, &pw), Opened::Plain);
     }
 
     #[test]
     fn empty_secret_roundtrips() {
-        let sealed = seal(HOST, b"", PW).unwrap();
-        assert!(matches!(open(&sealed, PW), Opened::Sealed { .. }));
+        let pw = pw();
+        let sealed = seal(HOST, b"", &pw).unwrap();
+        assert!(matches!(open(&sealed, &pw), Opened::Sealed { .. }));
     }
 }

--- a/src/security_trailer.rs
+++ b/src/security_trailer.rs
@@ -50,6 +50,8 @@
 
 use chacha20poly1305::aead::{Aead, Payload};
 use chacha20poly1305::{Key, KeyInit, XChaCha20Poly1305, XNonce};
+use ml_kem::kem::{Decapsulate, Encapsulate};
+use ml_kem::{Ciphertext, Encoded, EncodedSizeUser, KemCore, MlKem768};
 use zeroize::Zeroizing;
 
 pub const MAGIC_START: &[u8; 8] = b"RHWPSEC1";
@@ -64,7 +66,20 @@ pub const FLAG_REDACTED: u16 = 0x01;
 
 pub const VERSION: u16 = 1;
 pub const KDF_ARGON2ID: u8 = 1;
+/// **포스트양자 공개키 봉인** — kdf 슬롯을 재사용해 "키 유도 방식"을 ML-KEM-768(FIPS 203)
+/// 격자 KEM 으로 표시한다. 비밀번호 없이 수신자 공개키로 봉인하며, 파생된 32바이트 공유비밀을
+/// 그대로 AEAD 키로 쓴다. 대칭부(XChaCha20-Poly1305)는 이미 양자내성이고, Shor 에 깨지는
+/// 비대칭 키교환만 이 격자 KEM 으로 대체한다.
+pub const KDF_MLKEM768: u8 = 2;
 pub const AEAD_XCHACHA20POLY1305: u8 = 1;
+
+// ML-KEM-768 (FIPS 203, 보안 카테고리 3) 고정 크기. PQ 트레일러의 고정 프리픽스는
+// MAGIC_START[8] version[2] flags[2] kdf[1] aead[1] encap_len[4] = 18 바이트.
+const MLKEM768_EK_LEN: usize = 1184; // encapsulation key (공개키)
+const MLKEM768_DK_LEN: usize = 2400; // decapsulation key (개인키)
+const MLKEM768_CT_LEN: usize = 1088; // encapsulation (KEM 암호문)
+const MLKEM768_SS_LEN: usize = 32; // shared secret == XChaCha20 키 길이
+const PQ_HEADER_PREFIX: usize = 8 + 2 + 2 + 1 + 1 + 4; // = 18
 
 // kdf_algo=1 의 고정 Argon2id 파라미터(seal/unseal 이 반드시 같아야 하므로 상수).
 // OWASP 권고 하한 근방 — memory-hard 성질을 지키면서 CI·wasm 에서도 감당된다.
@@ -83,6 +98,13 @@ pub enum SealError {
     Kdf(String),
     Aead,
     Random(String),
+    /// 수신자 공개키 길이가 ML-KEM-768 EK(1184바이트)와 다르다.
+    BadPublicKey {
+        expected: usize,
+        got: usize,
+    },
+    /// ML-KEM 캡슐화 실패 — FIPS 203 상 실무 도달 불가지만, 절대 panic 하지 않도록 방어적으로 표면화.
+    Kem,
 }
 
 impl std::fmt::Display for SealError {
@@ -91,6 +113,13 @@ impl std::fmt::Display for SealError {
             SealError::Kdf(e) => write!(f, "키 유도 실패: {e}"),
             SealError::Aead => write!(f, "암호화 실패"),
             SealError::Random(e) => write!(f, "엔트로피 획득 실패: {e}"),
+            SealError::BadPublicKey { expected, got } => {
+                write!(
+                    f,
+                    "공개키 길이 오류: {expected}바이트 기대, {got}바이트 받음"
+                )
+            }
+            SealError::Kem => write!(f, "ML-KEM 캡슐화 실패"),
         }
     }
 }
@@ -221,9 +250,15 @@ pub fn open(bytes: &[u8], password: &[u8]) -> Opened {
     let kdf = t[12];
     let aead = t[13];
     if kdf != KDF_ARGON2ID || aead != AEAD_XCHACHA20POLY1305 {
-        return Opened::Broken {
-            reason: format!("미지원 알고리즘 (kdf={kdf}, aead={aead})"),
+        // kdf=2 는 공개키(ML-KEM) 봉인이다 — 비밀번호로는 못 연다. 안내 메시지만 개선하고
+        // 동작은 그대로(Broken) 유지한다(비밀번호 경로는 kdf=1 전용).
+        let reason = if kdf == KDF_MLKEM768 {
+            "공개키(ML-KEM) 봉인 트레일러다 — 비밀번호가 아니라 개인키로 열어야 한다(open_with_privkey)"
+                .to_string()
+        } else {
+            format!("미지원 알고리즘 (kdf={kdf}, aead={aead})")
         };
+        return Opened::Broken { reason };
     }
     let salt: [u8; SALT_LEN] = t[14..30].try_into().expect("salt 16");
     let nonce: [u8; NONCE_LEN] = t[30..54].try_into().expect("nonce 24");
@@ -256,6 +291,289 @@ pub fn open(bytes: &[u8], password: &[u8]) -> Opened {
         Ok(plaintext) => Opened::Sealed { plaintext, flags },
         Err(_) => Opened::Broken {
             reason: "복호 실패 (비밀번호 오류 또는 변조)".to_string(),
+        },
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 포스트양자 공개키 봉인 (kdf=2, ML-KEM-768 / NIST FIPS 203)
+//
+// 왜 필요한가: 기존 비밀번호 모드(Argon2id → XChaCha20-Poly1305)는 **이미 양자내성**이다 —
+// 대칭 암호는 Grover 로 유효 강도가 절반(256→128비트)으로 줄 뿐 여전히 안전하다. 양자
+// (Shor)에 깨지는 건 **비대칭 공개키 교환**이다. 그래서 이 모드는 비밀번호 공유 없이
+// 수신자의 공개키로 봉인하는 **양자안전 공개키 교환(ML-KEM 격자 KEM)** 을 추가한다.
+//
+// 흐름: 봉인자는 수신자 공개키(EK)로 `encapsulate` → (KEM 암호문 CT, 32바이트 공유비밀 SS).
+// SS 를 그대로 XChaCha20-Poly1305 키로 쓴다(ML-KEM 공유비밀은 균일 난수라 별도 KDF 불필요).
+// 수신자는 개인키(DK)로 `decapsulate(CT)` → 같은 SS 를 복원해 AEAD 를 푼다.
+//
+// PQ 트레일러 레이아웃(append; 비밀번호 트레일러와 매직마커·꼬리는 공유해 `detect_trailer`
+// 가 그대로 판별한다):
+//
+// ```text
+// MAGIC_START [8]  "RHWPSEC1"
+// version     [2]  u16 LE
+// flags       [2]  u16 LE   (REDACTED=0x01)
+// kdf_algo    [1]  2=ML-KEM-768
+// aead_algo   [1]  1=XChaCha20-Poly1305
+// encap_len   [4]  u32 LE   (= 1088)
+// encap       [encap_len]   KEM 암호문(CT)
+// nonce       [24]
+// ct_len      [4]  u32 LE
+// ciphertext  [ct_len]      (AEAD, AAD = MAGIC..ct_len 전체 헤더)
+// trailer_len [4]  u32 LE
+// MAGIC_END   [8]  "RHWPEND1"
+// ```
+//
+// 정당한 용도·경고는 비밀번호 모드와 동일하다 — REDACTED 전용, 평문 매직마커로 **탐지 가능**,
+// decoy 모드 없음. 이 모드가 바꾸는 건 "비밀을 여는 자격"뿐이다(비밀번호 → 개인키 보유).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `getrandom` 을 rand_core 0.6 `RngCore` + `CryptoRng` 로 감싼 어댑터 — ml-kem 0.2 의
+/// `generate`/`encapsulate` 가 요구하는 `CryptoRngCore`(= `CryptoRng + RngCore` 블랭킷)를
+/// 충족한다. 엔트로피는 OS(getrandom)에서 직접 뽑는다.
+struct GetRandomRng;
+
+impl rand_core::RngCore for GetRandomRng {
+    fn next_u32(&mut self) -> u32 {
+        let mut b = [0u8; 4];
+        getrandom::fill(&mut b).expect("getrandom: next_u32");
+        u32::from_le_bytes(b)
+    }
+    fn next_u64(&mut self) -> u64 {
+        let mut b = [0u8; 8];
+        getrandom::fill(&mut b).expect("getrandom: next_u64");
+        u64::from_le_bytes(b)
+    }
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        getrandom::fill(dest).expect("getrandom: fill_bytes");
+    }
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+        self.fill_bytes(dest);
+        Ok(())
+    }
+}
+
+impl rand_core::CryptoRng for GetRandomRng {}
+
+/// PQ 헤더(= AEAD associated data). MAGIC..ct_len 전체를 묶어 encap·nonce·길이·플래그 등
+/// 어느 헤더 필드를 변조해도 복호가 거부되게 한다(비밀번호 모드 `build_header` 와 같은 원리).
+fn build_pq_header(flags: u16, encap: &[u8], nonce: &[u8; NONCE_LEN], ct_len: u32) -> Vec<u8> {
+    let mut h = Vec::with_capacity(PQ_HEADER_PREFIX + encap.len() + NONCE_LEN + 4);
+    h.extend_from_slice(MAGIC_START);
+    h.extend_from_slice(&VERSION.to_le_bytes());
+    h.extend_from_slice(&flags.to_le_bytes());
+    h.push(KDF_MLKEM768);
+    h.push(AEAD_XCHACHA20POLY1305);
+    h.extend_from_slice(&(encap.len() as u32).to_le_bytes());
+    h.extend_from_slice(encap);
+    h.extend_from_slice(nonce);
+    h.extend_from_slice(&ct_len.to_le_bytes());
+    h
+}
+
+/// ML-KEM-768 키쌍을 새로 만든다 → `(공개키 EK 바이트[1184], 개인키 DK 바이트[2400])`.
+/// 공개키는 봉인자에게 배포하고, 개인키는 수신자만 보관해 `open_with_privkey` 로 연다.
+pub fn generate_keypair() -> (Vec<u8>, Vec<u8>) {
+    let mut rng = GetRandomRng;
+    // KemCore::generate → (decapsulation key, encapsulation key) = (dk, ek).
+    let (dk, ek) = MlKem768::generate(&mut rng);
+    let ek_bytes = ek.as_bytes().to_vec();
+    let dk_bytes = dk.as_bytes().to_vec();
+    debug_assert_eq!(ek_bytes.len(), MLKEM768_EK_LEN);
+    debug_assert_eq!(dk_bytes.len(), MLKEM768_DK_LEN);
+    (ek_bytes, dk_bytes)
+}
+
+/// 유효한 HWP3 바이트에 리댁션된 원값을 **수신자 공개키로** 봉인한 트레일러를 append 한다
+/// (비밀번호 불필요, REDACTED 전용). `host_hwp3` 는 이미 민감 스팬이 가려진 실제 리댁션
+/// 문서여야 한다 — 이 함수는 그 가려진 원값(`secret`)만 봉인한다.
+pub fn seal_to_pubkey(
+    host_hwp3: &[u8],
+    secret: &[u8],
+    recipient_public: &[u8],
+) -> Result<Vec<u8>, SealError> {
+    if recipient_public.len() != MLKEM768_EK_LEN {
+        return Err(SealError::BadPublicKey {
+            expected: MLKEM768_EK_LEN,
+            got: recipient_public.len(),
+        });
+    }
+    type Ek = <MlKem768 as KemCore>::EncapsulationKey;
+    // 길이는 위에서 검증했지만 from_bytes 는 정확 크기 Array 를 요구하므로 try_from 으로 안전 변환.
+    let ek_arr =
+        Encoded::<Ek>::try_from(recipient_public).map_err(|_| SealError::BadPublicKey {
+            expected: MLKEM768_EK_LEN,
+            got: recipient_public.len(),
+        })?;
+    let ek = Ek::from_bytes(&ek_arr);
+
+    let mut rng = GetRandomRng;
+    // encapsulate → (KEM 암호문 CT, 32바이트 공유비밀 SS). FIPS 203 상 무오류지만 방어적으로 map_err.
+    let (ct_kem, shared) = ek.encapsulate(&mut rng).map_err(|_| SealError::Kem)?;
+    let encap = ct_kem.as_slice();
+    debug_assert_eq!(encap.len(), MLKEM768_CT_LEN);
+    debug_assert_eq!(shared.as_slice().len(), MLKEM768_SS_LEN);
+
+    let mut nonce = [0u8; NONCE_LEN];
+    getrandom::fill(&mut nonce).map_err(|e| SealError::Random(e.to_string()))?;
+
+    let ct_len = (secret.len() + TAG_LEN) as u32;
+    let header = build_pq_header(FLAG_REDACTED, encap, &nonce, ct_len);
+
+    // AEAD 키 = 32바이트 공유비밀을 그대로 사용(ML-KEM SS 는 균일 난수). Zeroizing 로 소거 보장.
+    let mut key = Zeroizing::new([0u8; 32]);
+    key.copy_from_slice(shared.as_slice());
+    let cipher = XChaCha20Poly1305::new(Key::from_slice(key.as_ref()));
+    let ciphertext = cipher
+        .encrypt(
+            XNonce::from_slice(&nonce),
+            Payload {
+                msg: secret,
+                aad: &header,
+            },
+        )
+        .map_err(|_| SealError::Aead)?;
+    debug_assert_eq!(ciphertext.len(), ct_len as usize);
+
+    let trailer_len = (header.len() + ciphertext.len() + 4 + 8) as u32;
+    let mut out = Vec::with_capacity(host_hwp3.len() + trailer_len as usize);
+    out.extend_from_slice(host_hwp3);
+    out.extend_from_slice(&header);
+    out.extend_from_slice(&ciphertext);
+    out.extend_from_slice(&trailer_len.to_le_bytes());
+    out.extend_from_slice(MAGIC_END);
+    Ok(out)
+}
+
+/// 공개키로 봉인된 파일을 **개인키로** 정상화해 연다 — 절대 Err/panic 없이
+/// Plain/Sealed/Broken 중 하나로 수렴한다(모든 길이 읽기는 엄격 경계 검사).
+pub fn open_with_privkey(bytes: &[u8], secret_key: &[u8]) -> Opened {
+    let start = match detect_trailer(bytes) {
+        Some(s) => s,
+        None => return Opened::Plain,
+    };
+    let t = &bytes[start..];
+    // detect_trailer 가 t.len() >= MIN_TRAILER_LEN 를 보장하지만, 여기서도 프리픽스 경계를 명시 검사.
+    if t.len() < PQ_HEADER_PREFIX {
+        return Opened::Broken {
+            reason: "트레일러가 너무 짧다".to_string(),
+        };
+    }
+    let version = u16::from_le_bytes([t[8], t[9]]);
+    if version != VERSION {
+        // 모르는 버전은 향후 포맷 진화로 보고 무시(Plain) — 비밀번호 경로와 동일 정책.
+        return Opened::Plain;
+    }
+    let flags = u16::from_le_bytes([t[10], t[11]]);
+    let kdf = t[12];
+    let aead = t[13];
+    if kdf != KDF_MLKEM768 {
+        // 비밀번호(kdf=1) 트레일러를 개인키로 열려는 경우 등 → Broken(패닉 금지).
+        return Opened::Broken {
+            reason: "공개키 봉인이 아니다 (kdf != 2) — 비밀번호로 열어야 한다(open)".to_string(),
+        };
+    }
+    if aead != AEAD_XCHACHA20POLY1305 {
+        return Opened::Broken {
+            reason: format!("미지원 AEAD (aead={aead})"),
+        };
+    }
+
+    // ── 엄격 경계 파싱: 어떤 길이 필드가 조작돼도 인덱스 OOB/패닉 없이 Broken 으로 귀결 ──
+    let encap_len = u32::from_le_bytes([t[14], t[15], t[16], t[17]]) as usize;
+    let len_mismatch = || Opened::Broken {
+        reason: "트레일러 길이 불일치".to_string(),
+    };
+    // encap 이 정확히 ML-KEM-768 CT 크기인지 먼저 확인(decapsulate 가 고정 크기 Array 를 요구).
+    if encap_len != MLKEM768_CT_LEN {
+        return Opened::Broken {
+            reason: format!("encap 길이 불일치 ({encap_len})"),
+        };
+    }
+    let encap_end = match PQ_HEADER_PREFIX.checked_add(encap_len) {
+        Some(v) => v,
+        None => return len_mismatch(),
+    };
+    let nonce_end = match encap_end.checked_add(NONCE_LEN) {
+        Some(v) => v,
+        None => return len_mismatch(),
+    };
+    let ctlen_end = match nonce_end.checked_add(4) {
+        Some(v) => v,
+        None => return len_mismatch(),
+    };
+    if ctlen_end > t.len() {
+        return len_mismatch();
+    }
+    let encap = &t[PQ_HEADER_PREFIX..encap_end];
+    let nonce: [u8; NONCE_LEN] = t[encap_end..nonce_end].try_into().expect("nonce 24");
+    let ct_len = u32::from_le_bytes([
+        t[nonce_end],
+        t[nonce_end + 1],
+        t[nonce_end + 2],
+        t[nonce_end + 3],
+    ]) as usize;
+    let ct_start = ctlen_end;
+    let ct_end = match ct_start.checked_add(ct_len) {
+        Some(v) => v,
+        None => return len_mismatch(),
+    };
+    // 암호문 뒤에는 trailer_len[4] + MAGIC_END[8] = 12바이트가 있어야 한다.
+    let need_tail = match ct_end.checked_add(4 + 8) {
+        Some(v) => v,
+        None => return len_mismatch(),
+    };
+    if ct_len < TAG_LEN || need_tail > t.len() {
+        return len_mismatch();
+    }
+    let ciphertext = &t[ct_start..ct_end];
+    // AAD = MAGIC..ct_len 전체 헤더(암호문 직전까지). 원본 바이트를 그대로 써 봉인 시점과 바이트 동일.
+    let aad = &t[..ctlen_end];
+
+    // ── 개인키로 역캡슐화 → 공유비밀 복원 → AEAD 복호 ──
+    type Dk = <MlKem768 as KemCore>::DecapsulationKey;
+    let dk_arr = match Encoded::<Dk>::try_from(secret_key) {
+        Ok(a) => a,
+        Err(_) => {
+            return Opened::Broken {
+                reason: format!(
+                    "개인키 길이 오류: {}바이트 기대, {}바이트 받음",
+                    MLKEM768_DK_LEN,
+                    secret_key.len()
+                ),
+            }
+        }
+    };
+    let dk = Dk::from_bytes(&dk_arr);
+    let ct_kem = match Ciphertext::<MlKem768>::try_from(encap) {
+        Ok(c) => c,
+        Err(_) => return len_mismatch(),
+    };
+    // ML-KEM 역캡슐화는 무오류다 — 틀린 개인키·변조 CT 여도 (묵시적 거부로) *다른* 공유비밀을
+    // 돌려줄 뿐 Err 를 내지 않는다. 그래서 진짜 무결성 관문은 아래 AEAD 다: 공유비밀이 다르면
+    // AEAD 키가 달라져 복호가 실패하고 Broken 이 된다.
+    let shared = match dk.decapsulate(&ct_kem) {
+        Ok(s) => s,
+        Err(_) => {
+            return Opened::Broken {
+                reason: "역캡슐화 실패".to_string(),
+            }
+        }
+    };
+    let mut key = Zeroizing::new([0u8; 32]);
+    key.copy_from_slice(shared.as_slice());
+    let cipher = XChaCha20Poly1305::new(Key::from_slice(key.as_ref()));
+    match cipher.decrypt(
+        XNonce::from_slice(&nonce),
+        Payload {
+            msg: ciphertext,
+            aad,
+        },
+    ) {
+        Ok(plaintext) => Opened::Sealed { plaintext, flags },
+        Err(_) => Opened::Broken {
+            reason: "복호 실패 (개인키 불일치 또는 변조)".to_string(),
         },
     }
 }
@@ -324,5 +642,132 @@ mod tests {
     fn empty_secret_roundtrips() {
         let sealed = seal(HOST, b"", PW).unwrap();
         assert!(matches!(open(&sealed, PW), Opened::Sealed { .. }));
+    }
+
+    // ───────────────────────── 포스트양자 공개키 봉인 (kdf=2) ─────────────────────────
+
+    #[test]
+    fn pq_keypair_sizes_are_fips203() {
+        let (ek, dk) = generate_keypair();
+        assert_eq!(ek.len(), MLKEM768_EK_LEN, "EK=1184");
+        assert_eq!(dk.len(), MLKEM768_DK_LEN, "DK=2400");
+    }
+
+    #[test]
+    fn pq_generate_seal_open_roundtrips() {
+        let (ek, dk) = generate_keypair();
+        let sealed = seal_to_pubkey(HOST, SECRET, &ek).unwrap();
+        // 가시층은 원본 그대로(순정 한컴이 읽는 것) — 트레일러만 append.
+        assert_eq!(visible_layer(&sealed), HOST);
+        // 수신자 개인키 → 진짜 비밀 정확 복원.
+        match open_with_privkey(&sealed, &dk) {
+            Opened::Sealed { plaintext, flags } => {
+                assert_eq!(plaintext, SECRET);
+                assert_eq!(flags, FLAG_REDACTED);
+            }
+            other => panic!("Sealed 를 기대: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pq_wrong_private_key_is_broken_not_panic() {
+        let (ek, _dk) = generate_keypair();
+        let (_ek2, dk2) = generate_keypair(); // 서로 다른 키쌍의 개인키
+        let sealed = seal_to_pubkey(HOST, SECRET, &ek).unwrap();
+        // 틀린 개인키 → ML-KEM 묵시적 거부로 *다른* 공유비밀 → AEAD 복호 실패 → Broken(패닉 없음).
+        assert!(matches!(
+            open_with_privkey(&sealed, &dk2),
+            Opened::Broken { .. }
+        ));
+    }
+
+    #[test]
+    fn pq_tampered_ciphertext_is_broken() {
+        let (ek, dk) = generate_keypair();
+        let mut sealed = seal_to_pubkey(HOST, SECRET, &ek).unwrap();
+        let n = sealed.len();
+        // ciphertext 는 trailer_len[4]+MAGIC_END[8] 바로 앞에서 끝난다 → n-13 은 AEAD 태그 안.
+        sealed[n - 13] ^= 0xFF;
+        assert!(matches!(
+            open_with_privkey(&sealed, &dk),
+            Opened::Broken { .. }
+        ));
+    }
+
+    #[test]
+    fn pq_tampered_encap_header_is_broken() {
+        // encap 은 AAD(헤더)의 일부다 → 1비트만 변조해도 복호가 거부된다(AAD 바인딩 + KEM 불일치).
+        let (ek, dk) = generate_keypair();
+        let mut sealed = seal_to_pubkey(HOST, SECRET, &ek).unwrap();
+        let encap_off = HOST.len() + PQ_HEADER_PREFIX + 100; // encap 내부 임의 지점
+        sealed[encap_off] ^= 0xFF;
+        assert!(matches!(
+            open_with_privkey(&sealed, &dk),
+            Opened::Broken { .. }
+        ));
+    }
+
+    #[test]
+    fn pq_password_open_on_pq_trailer_is_broken_not_panic() {
+        // 비밀번호 경로(open)로 공개키 트레일러를 열면 kdf=2 분기에서 Broken(패닉 없음).
+        let (ek, _dk) = generate_keypair();
+        let sealed = seal_to_pubkey(HOST, SECRET, &ek).unwrap();
+        assert!(matches!(open(&sealed, PW), Opened::Broken { .. }));
+    }
+
+    #[test]
+    fn pq_open_with_privkey_on_password_trailer_is_broken_not_panic() {
+        // 공개키 경로(open_with_privkey)로 비밀번호(kdf=1) 트레일러를 열면 Broken(패닉 없음).
+        let (_ek, dk) = generate_keypair();
+        let sealed = seal(HOST, SECRET, PW).unwrap();
+        assert!(matches!(
+            open_with_privkey(&sealed, &dk),
+            Opened::Broken { .. }
+        ));
+    }
+
+    #[test]
+    fn pq_no_trailer_is_plain() {
+        let (_ek, dk) = generate_keypair();
+        assert_eq!(open_with_privkey(HOST, &dk), Opened::Plain);
+    }
+
+    #[test]
+    fn pq_stripped_trailer_reopens_as_plain() {
+        // 한컴 재저장 = 트레일러 소실 → 개인키 경로도 Plain 으로 정상화(에러 없음).
+        let (ek, dk) = generate_keypair();
+        let sealed = seal_to_pubkey(HOST, SECRET, &ek).unwrap();
+        let stripped = visible_layer(&sealed).to_vec();
+        assert_eq!(open_with_privkey(&stripped, &dk), Opened::Plain);
+    }
+
+    #[test]
+    fn pq_empty_secret_roundtrips() {
+        let (ek, dk) = generate_keypair();
+        let sealed = seal_to_pubkey(HOST, b"", &ek).unwrap();
+        match open_with_privkey(&sealed, &dk) {
+            Opened::Sealed { plaintext, .. } => assert_eq!(plaintext, b""),
+            other => panic!("Sealed 를 기대: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pq_bad_public_key_length_is_error() {
+        let short = vec![0u8; 100];
+        assert!(matches!(
+            seal_to_pubkey(HOST, SECRET, &short),
+            Err(SealError::BadPublicKey { .. })
+        ));
+    }
+
+    #[test]
+    fn pq_bad_private_key_length_is_broken_not_panic() {
+        let (ek, _dk) = generate_keypair();
+        let sealed = seal_to_pubkey(HOST, SECRET, &ek).unwrap();
+        let short = vec![0u8; 100];
+        assert!(matches!(
+            open_with_privkey(&sealed, &short),
+            Opened::Broken { .. }
+        ));
     }
 }


### PR DESCRIPTION
## 요약

기존 비밀번호 봉인 모드(#4826, `kdf=1`: Argon2id → XChaCha20-Poly1305) 위에 **포스트양자
공개키 봉인 모드(`kdf=2`: ML-KEM-768, NIST FIPS 203)** 를 추가한다. 비밀번호를 공유하지
않고 **수신자의 공개키**로 봉인하며, 여는 자격만 "비밀번호 보유"에서 "개인키 보유"로 바뀐다.

> ⚠️ **이 PR 은 #4826 위에 스택(stacked)** 되어 있다. base 는 `devel` 이지만 #4826 이 아직
> 머지 전이라 그 커밋(`762f38974`)이 이 PR 디프에 함께 보인다. #4826 이 머지되면 이 PR
> 디프는 순수 PQ 변경분만 남는다. 리뷰는 마지막 커밋 한 개
> (`feat: HWP3 보안 트레일러 포스트양자 공개키 봉인 …`)만 보면 된다.

## 왜 "공개키 교환"만 양자안전으로 바꾸나 (정직한 프레이밍)

**기존 비밀번호 모드는 이미 양자내성이다.** 대칭 암호(XChaCha20-Poly1305, 256비트 키)는
Grover 로 유효 강도가 절반(→128비트)으로 줄 뿐 여전히 안전하고, Argon2id 도 대칭
원시함수다. 양자 컴퓨터(Shor)에 실제로 깨지는 건 **비대칭 공개키 교환**이다.

그래서 이 PR 은 "가시 내용을 더 세게 지진다"가 아니라, **비밀번호 공유 없이 공개키로
봉인하는 경로**에서 그 유일한 양자취약점(비대칭 키교환)을 격자 KEM(ML-KEM)으로 대체한다.
공유비밀 32바이트를 그대로 AEAD 키로 쓰므로 대칭부는 종전과 완전히 동일하다.

## 무엇이 추가됐나

`src/security_trailer.rs`(leaf 파일 하나)와 의존성 2개(`ml-kem = "0.2"`, `rand_core = "0.6"`;
둘 다 순수 Rust·wasm 호환).

- `pub const KDF_MLKEM768: u8 = 2;` — ML-KEM-768 크기: EK=1184, DK=2400, CT(encap)=1088, SS=32.
- `generate_keypair() -> (공개키 EK, 개인키 DK)`
- `seal_to_pubkey(host, secret, recipient_public) -> Result<Vec<u8>, SealError>`
- `open_with_privkey(bytes, secret_key) -> Opened` — Plain/Sealed/Broken 로 수렴, 절대 패닉 없음.

### PQ 트레일러 레이아웃 (비밀번호 트레일러와 매직마커·꼬리 공유 → `detect_trailer` 그대로)

```
MAGIC_START[8] version[2] flags[2] kdf[1]=2 aead[1]=1
encap_len[4] encap[encap_len] nonce[24] ct_len[4] ciphertext[ct_len]
trailer_len[4] MAGIC_END[8]
```

AAD = `MAGIC..ct_len` 전체 헤더 → encap·nonce·길이·플래그 어느 것이든 변조하면 복호 거부.

## 암호학적 정확성 (핵심)

- **ML-KEM 역캡슐화는 무오류다.** 틀린 개인키·변조 CT 여도 (묵시적 거부/FO 변환) *다른*
  공유비밀을 돌려줄 뿐 `Err` 를 내지 않는다. 따라서 **진짜 무결성 관문은 AEAD**: 공유비밀이
  다르면 AEAD 키가 달라져 복호가 실패하고 `Broken` 이 된다. 이 성질을 테스트로 못박았다.
- **개인키 경로는 `checked_add` 기반 엄격 경계 파싱** — 어떤 길이 필드가 조작돼도 인덱스
  OOB/패닉 없이 `Broken` 으로 귀결한다.
- 공유비밀·유도 키는 `Zeroizing` 로 소거.

## 비밀번호 경로는 무변경

`kdf=1`(Argon2id) seal/open 크립토 로직은 한 줄도 바꾸지 않았다. 유일한 diff 는 `open()` 의
"미지원 알고리즘" 분기에서 `kdf=2` 트레일러가 들어왔을 때 **안내 메시지만** 개선한 것이다
(동작은 그대로 `Broken` — "개인키로 열어야 한다"고 알려줄 뿐).

## 정당한 범위 (#4826 과 동일)

REDACTED 전용, 평문 매직마커(`RHWPSEC1`/`RHWPEND1`)로 **탐지 가능**, 문서 전체를 숨기는
decoy 모드 없음. 이 모드가 바꾸는 건 "여는 자격"(비밀번호 → 개인키)뿐이다. 렌더러 표면을
건드리지 않는 라이브러리 변경이라 시각 회귀 대상이 아니다.

## 검증

- `cargo test --lib security_trailer::` — **19건 전부 통과**(기존 비밀번호 7 + 신규 PQ 12),
  `debug`·`release-test` 프로파일 양쪽.
  - 왕복(정확 복원)·키 크기(1184/2400)·틀린 개인키→`Broken`·CT 변조→`Broken`·AAD(encap)
    변조→`Broken`·비밀번호 경로로 PQ 열기→`Broken`·PQ 경로로 비밀번호 트레일러 열기→
    `Broken`·빈 비밀·잘못된 키 길이(패닉 없음) 등.
- `rustfmt --edition 2021 --check src/security_trailer.rs` 통과(leaf 파일만),
  `cargo clippy --lib --tests -- -D warnings` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
