### PR TITLE
fix(parser/hwpx): HwpUnitChar 값 2× 스케일 정수 오버플로 패닉 하드닝 — 손상 .hwpx DoS (#4839)

### DIFF
--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -1285,7 +1285,9 @@ fn parse_para_shape_switch(
                                         // HWP3 암호 원본의 별도 spacing 계약은 HWP3 parser
                                         // 안에서만 처리한다. HWPX 전체에 반감 적용하면
                                         // 일반 HWPX 문단 흐름과 기준 HWP3 변환본이 함께 밀린다.
-                                        let val2x = val * 2;
+                                        // 손상 문서의 극단 value 는 i32 곱셈 오버플로 패닉을
+                                        // 유발하므로 saturating 으로 막는다(정상값은 무영향).
+                                        let val2x = val.saturating_mul(2);
                                         match tag_name {
                                             b"left" => {
                                                 ps.margin_left = val2x;
@@ -1354,7 +1356,8 @@ fn parse_para_shape_switch(
                                     let effective_type = ls_type.unwrap_or(ps.line_spacing_type);
                                     ps.line_spacing = match effective_type {
                                         LineSpacingType::Percent => v,
-                                        _ => v * 2,
+                                        // 손상 value 의 i32 곱셈 오버플로 패닉 차단.
+                                        _ => v.saturating_mul(2),
                                     };
                                     case_line_spacing = Some(v);
                                 }
@@ -1903,8 +1906,9 @@ fn parse_tab_def(
                         let mut item = parse_tab_item(ce);
                         if in_hwpunitchar_case {
                             // HwpUnitChar 값은 실제 HWPUNIT(1× 스케일)이므로
-                            // HWP 바이너리와 동일한 2× 스케일로 변환
-                            item.position *= 2;
+                            // HWP 바이너리와 동일한 2× 스케일로 변환.
+                            // 손상 pos 의 u32 곱셈 오버플로 패닉 차단(정상값은 무영향).
+                            item.position = item.position.saturating_mul(2);
                             td.tabs.push(item);
                             found_case = true;
                         } else if in_default {
@@ -2688,6 +2692,54 @@ mod tests {
         assert_eq!(ps.indent, -4520);
         assert_eq!(ps.spacing_before, 568);
         assert_eq!(ps.spacing_after, 1136);
+    }
+
+    /// 손상 HWPX 의 HwpUnitChar `<hp:case>` 값이 2× IR 스케일 변환에서 정수
+    /// 곱셈 오버플로 패닉(DoS)을 일으키지 않고 saturating 으로 안전 처리되는지
+    /// 검증한다. 종전에는 `value`/`pos` 극단값이 `parse_hwpx_header` 를 패닉시켜
+    /// info/export-text/export-structure/convert 전부가 손상 문서 한 건에
+    /// 죽었다(header.rs:1288/1357/1907, `attempt to multiply with overflow`).
+    #[test]
+    fn hwpunitchar_oversized_value_saturates_without_panic() {
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head"
+  xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core"
+  xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph">
+  <hh:refList>
+    <hh:paraProperties itemCnt="1">
+      <hh:paraPr id="1">
+        <hp:switch>
+          <hp:case hp:required-namespace="http://www.hancom.co.kr/hwpml/2016/HwpUnitChar">
+            <hh:margin>
+              <hc:left value="2000000000" unit="HWPUNIT"/>
+              <hc:right value="2000000000" unit="HWPUNIT"/>
+            </hh:margin>
+            <hh:lineSpacing type="FIXED" value="2000000000"/>
+          </hp:case>
+        </hp:switch>
+      </hh:paraPr>
+    </hh:paraProperties>
+    <hh:tabProperties itemCnt="1">
+      <hh:tabPr id="0" autoTabLeft="0" autoTabRight="0">
+        <hp:switch>
+          <hp:case hp:required-namespace="http://www.hancom.co.kr/hwpml/2016/HwpUnitChar">
+            <hh:tabItem pos="2147483648" type="LEFT" leader="NONE" unit="HWPUNIT"/>
+          </hp:case>
+        </hp:switch>
+      </hh:tabPr>
+    </hh:tabProperties>
+  </hh:refList>
+</hh:head>"##;
+
+        // 핵심: 패닉하지 않고 Ok 를 돌려준다.
+        let (doc_info, _) = parse_hwpx_header(xml).expect("손상 HwpUnitChar 값은 패닉 없이 파싱");
+        let ps = &doc_info.para_shapes[1];
+        // 2_000_000_000 × 2 는 i32 를 넘으므로 i32::MAX 로 포화된다.
+        assert_eq!(ps.margin_left, i32::MAX);
+        assert_eq!(ps.margin_right, i32::MAX);
+        assert_eq!(ps.line_spacing, i32::MAX);
+        // 2_147_483_648(u32) × 2 는 u32 를 넘으므로 u32::MAX 로 포화된다.
+        assert_eq!(doc_info.tab_defs[0].tabs[0].position, u32::MAX);
     }
 
     #[test]


### PR DESCRIPTION
## 배경

close #4839

손상되거나 조작된 `.hwpx` 의 `Contents/header.xml` 에서 HwpUnitChar `<hp:case>` 안 극단 정수값이 "HwpUnitChar 1× → HWP5 2× IR 스케일" 변환(`* 2`)에서 **정수 곱셈 오버플로 패닉**을 일으킨다. `parse_hwpx_header` 가 그대로 죽으면서 `info` / `export-text` / `export-structure` / `convert` 전부가 **손상 문서 한 건에 프로세스째 종료**된다 (DoS, exit 101). 퍼징(원본 바이트 손상 + XML 파트 손상, 샘플 4종)으로 발견했다.

## 변경

`src/parser/hwpx/header.rs` 세 곳의 `* 2` 를 `saturating_mul(2)` 로 교체한다. 셋 다 같은 스케일 변환이며 오버플로 가드가 없었다.

| 위치 | 대상 | 타입 |
|------|------|------|
| `1288` | 문단 여백 left/right/intent/prev/next | `i32` |
| `1357` | 문단 lineSpacing | `i32` |
| `1907` | 탭 position | `u32` |

정상 문서 값은 수천 HWPUNIT 수준이라 결과가 바뀌지 않고, 극단값만 `i32::MAX` / `u32::MAX` 로 포화되어 그레이스풀하게 처리된다. (같은 함수의 `exact_value_from_default` 는 이미 `i64::from(...)` 승격이라 안전하다 — 손대지 않음.)

## 재현 (수정 전)

정상 `.hwpx` 의 `<hh:paraPr>` 에 HwpUnitChar `<hp:case>` + `<hc:left value="2000000000"/>` 주입 후:

```
$ rhwp info corrupt.hwpx
thread 'main' panicked at src\parser\hwpx\header.rs:1288:53:
attempt to multiply with overflow
```
exit 101. 호출 사슬: `parse_para_shape_switch` → `parse_para_shape` → `parse_hwpx_header` → `parse_hwpx`.

## 검증

- 재현 파일 → `info` / `export-text` / `export-structure` / `convert` 모두 **exit 0, 패닉 없음**.
- 정상 샘플 3종(`SO-SUEOP` / `hwp3-sample-hwpx` / `HWP5-nopassword-123456`)의 `info` / `export-text` / `export-structure` 출력 **바이트 동일**(회귀 없음).
- 회귀 테스트 `hwpunitchar_oversized_value_saturates_without_panic` 추가 (여백·줄간격·탭 세 경로 모두 포화 확인).
- `cargo test --lib` **3703 passed / 0 failed**.
- `rustfmt --edition 2021 --check src/parser/hwpx/header.rs` 통과.

## 범위

HWPX 파서 전용(`src/parser/hwpx/header.rs`)에 한정한다. renderer `vertical_pos+line_height`, `parser/mod.rs` 오버플로(#4821), HWP5 body 재귀(#4830) 등 다른 DoS 는 별도 PR 이 다루므로 건드리지 않았다.
