### PR TITLE
손상 입력의 과다 line_seg O(n²) 무한정지 DoS 방어 (#4813)

### DIFF
--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -2376,7 +2376,7 @@ mod validate_linesegs_tests {
         assert_eq!(doc.sections[0].paragraphs[0].line_segs.len(), 3);
 
         // 경계: 줄바꿈만 있는 문단은 line_seg 수가 문자 수와 비슷해도 상한(+64) 안이라 보존.
-        let text: String = std::iter::repeat('\n').take(300).collect();
+        let text: String = "\n".repeat(300);
         let mut doc2 = doc_with_para(&text, 301);
         DocumentCore::drop_corrupt_oversized_linesegs(&mut doc2);
         assert_eq!(

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -81,6 +81,10 @@ impl DocumentCore {
         let mut document = parsed.document;
         let hml_metadata = parsed.hml_metadata;
 
+        // [#4813] 손상 입력 DoS 방어 — 파싱 직후, compose/pagination/layout 이 저장
+        // line_seg 를 소비하기 전에 물리적으로 불가능한 과다 line_seg 배열을 제거한다.
+        Self::drop_corrupt_oversized_linesegs(&mut document);
+
         // [#2279 실험 전용] 본문 저장 lineseg 전면 무시 → fresh 재계산.
         // 기계생성 결재문서의 부분-사다리 불신 실험 계측용 (기본 no-op).
         // 주의: 92셋 전수 실측(2026-07-18)에서 전면 fresh 는 88→76 광역 회귀 —
@@ -306,6 +310,32 @@ impl DocumentCore {
                 cell_path,
                 kind: WarningKind::LinesegTextRunReflow,
             });
+        }
+    }
+
+    /// [#4813] 손상 입력 DoS 방어 — 저장된 line_seg(줄 배열) 수가 문단의 문자 수를
+    /// 크게 초과하는 문단은 line_seg 를 비운다.
+    ///
+    /// line_seg 하나는 화면상 한 줄이고 한 줄은 문자를 최소 1개 담으므로, 정상
+    /// 문서에서는 언제나 `line_segs.len() ≤ 문자 수 + 1` 이다. 손상된 HWP/HWPX 는
+    /// 길이·개수 필드 훼손으로 이 배열을 수만 개까지 부풀릴 수 있고(퍼징 실측
+    /// `samples/hwp3-sample14.hwp` 10% 바이트 플립본: 한 문단의 line_seg 25,856 개 >
+    /// 문자 21,454 개), 그러면 `compose_lines`·layout 이 line_seg 마다 문단 전체
+    /// 텍스트를 다시 슬라이싱·배치해 O(line_seg 수 × 문단 길이) 로 폭주한다 —
+    /// `info`·`export-text` 가 유한 시간에 끝나지 않는 서비스 거부(DoS)다.
+    ///
+    /// 이런 배열은 신뢰할 수 없으므로 비운다. 이후 리플로우/합성 경로(`compose_lines`
+    /// 의 line_seg 부재 폴백 등)가 문단을 텍스트로부터 정상 재구성한다. 상한을
+    /// `문자 수 + 64` 로 넉넉히 잡아 정상 문서(줄바꿈만 있는 문단 포함)는 절대 걸리지
+    /// 않으므로 동작이 완전히 동일하다. 포맷 무관 가드다.
+    fn drop_corrupt_oversized_linesegs(document: &mut Document) {
+        for section in &mut document.sections {
+            for para in &mut section.paragraphs {
+                let seg_count = para.line_segs.len();
+                if seg_count > 64 && seg_count > para.text.chars().count() + 64 {
+                    para.line_segs.clear();
+                }
+            }
         }
     }
 
@@ -2310,6 +2340,55 @@ mod validate_linesegs_tests {
 
         let report = DocumentCore::validate_linesegs(&doc, true);
         assert!(report.is_empty());
+    }
+
+    fn doc_with_para(text: &str, seg_count: usize) -> Document {
+        let mut doc = Document::default();
+        let mut section = Section::default();
+        let mut para = Paragraph::default();
+        para.text = text.to_string();
+        para.line_segs = (0..seg_count).map(|_| LineSeg::default()).collect();
+        section.paragraphs.push(para);
+        doc.sections.push(section);
+        doc
+    }
+
+    /// [#4813] 문자 수를 크게 초과하는 손상 line_seg 배열(퍼징 실측 hwp3-sample14
+    /// 손상본: 문자 21,454 개인데 line_seg 25,856 개)은 비워져야 한다 —
+    /// compose/layout 이 line_seg 마다 문단 전체를 재슬라이싱하는 O(n²) 폭주(DoS)
+    /// 방지. 비우면 이후 폴백 경로가 문단을 정상 재구성한다.
+    #[test]
+    fn drop_corrupt_oversized_linesegs_clears_impossible_array() {
+        let mut doc = doc_with_para("가나다", 25_856); // 문자 3, line_seg 25,856
+        DocumentCore::drop_corrupt_oversized_linesegs(&mut doc);
+        assert!(
+            doc.sections[0].paragraphs[0].line_segs.is_empty(),
+            "문자 수를 크게 초과하는 손상 line_seg 배열은 비워져야 한다"
+        );
+    }
+
+    /// [#4813] 정상 문단은 절대 건드리지 않는다 — line_seg 수 ≤ 문자 수 + 64.
+    #[test]
+    fn drop_corrupt_oversized_linesegs_keeps_valid_paragraphs() {
+        // 일반 문단: 문자보다 line_seg 가 훨씬 적다.
+        let mut doc = doc_with_para("hello world", 3);
+        DocumentCore::drop_corrupt_oversized_linesegs(&mut doc);
+        assert_eq!(doc.sections[0].paragraphs[0].line_segs.len(), 3);
+
+        // 경계: 줄바꿈만 있는 문단은 line_seg 수가 문자 수와 비슷해도 상한(+64) 안이라 보존.
+        let text: String = std::iter::repeat('\n').take(300).collect();
+        let mut doc2 = doc_with_para(&text, 301);
+        DocumentCore::drop_corrupt_oversized_linesegs(&mut doc2);
+        assert_eq!(
+            doc2.sections[0].paragraphs[0].line_segs.len(),
+            301,
+            "line_seg 수가 문자 수를 넘지 않는 정상 문단은 보존되어야 한다"
+        );
+
+        // 작은 배열은 상한(64) 아래라 문자 수와 무관하게 보존한다.
+        let mut doc3 = doc_with_para("", 40);
+        DocumentCore::drop_corrupt_oversized_linesegs(&mut doc3);
+        assert_eq!(doc3.sections[0].paragraphs[0].line_segs.len(), 40);
     }
 
     /// 표 셀 내부 문단도 검증 — cell_path 가 기록됨


### PR DESCRIPTION
## 문제 (#4813)

퍼징(gym 손상-강건성 감사)이 rhwp 가 손상된 문서에서 유한 시간에 끝나지 않는(무한정지급) DoS 를 실측했다. 결정적 재현:

```python
data = open("samples/hwp3-sample14.hwp", "rb").read()
b = bytearray(data); b[len(b)*10//100] ^= 0xFF   # 10% 지점 바이트 플립
open("hang.hwp", "wb").write(bytes(b))
# rhwp info hang.hwp --json    → 60초 초과, 종료 안 함
# rhwp export-text hang.hwp    → 종료 안 함
```

## 원인 — 계측으로 확정 (파서 아님, 렌더 경로)

이슈의 원인 추정은 HWP3 파서 순회 루프였으나, 임시 반복 카운터와 단계 마커로 계측한 결과 실제 폭주 지점은 **파서가 아니라 렌더 경로**였다:

- `parse` 는 정상 종료한다. `info` 는 **compose(`compose_lines`)** 단계에서, `export-text` 는 **layout(`build_page_tree`)** 단계에서 멈춘다 (둘 다 `from_bytes` → paginate/build_page_tree 경로).
- 손상본의 한 문단이 **line_seg 25,856 개 > 문자 21,454 개**(`text_start`=[0, 9203, 0, 0, …] 비단조)를 갖는다. line_seg 하나는 화면상 한 줄이고 한 줄은 문자를 최소 1개 담으므로, 정상 문서는 언제나 `line_seg 수 ≤ 문자 수 + 1` 이다.
- `compose_lines`·layout 은 line_seg 마다 `para.text` 를 다시 슬라이싱·배치하므로, 이 배열이 부풀면 **O(line_seg 수 × 문단 길이) ≈ 5.5억 회** 로 폭주한다 — 사실상 종료하지 않는 DoS.

## 수정

`from_bytes` 파싱 직후(compose/pagination/layout 이 저장 line_seg 를 소비하기 전) 물리적으로 불가능한 과다 line_seg 배열을 비우는 **포맷 무관** 가드 `drop_corrupt_oversized_linesegs()` 를 추가한다. 비운 문단은 기존 리플로우/합성 폴백(`compose_lines` 의 line_seg 부재 경로 등)이 텍스트로부터 정상 재구성한다. 상한을 `문자 수 + 64` 로 넉넉히 잡아 정상 문서(줄바꿈만 있는 문단 포함)는 절대 걸리지 않으므로 동작이 완전히 동일하다.

이슈는 HWP3 파서로 지목했으나, 근본 원인은 특정 포맷이 아니라 렌더러가 소비하는 손상 line_seg 배열이므로 로드 직후 공통 지점에 가드를 둔다(HWP3 전용 분기 없음).

## 검증

- **재현 해소:** 손상본 `info` 무한정지 → **0.23s**, `export-text` → **1.78s** 종료(정상 오류/성공, 패닉 없음).
- **정상 회귀 없음:** 정상 문서 10종(HWP3 원본 `hwp3-sample14`·`hwp3-sample10`, HWP5, HWPX)의 `info`·`export-text` 출력이 수정 전/후 **바이트 동일**(SHA-256 비교).
- **회귀 테스트 2건 추가**: 손상 배열 제거 / 정상 문단 보존.
- `cargo test --lib` 전량 통과, `rustfmt --edition 2021 --check`·`cargo clippy --lib` 무경고.

### 비고

같은 퍼징 세트의 다른 표본(`issue2063_huge_cellbreak_table.hwp`, `hwp3-sample10-hwp5.hwp`)은 90초 계측 결과 **유한 시간에 종료**(디버그 빌드에서 느릴 뿐)했다 — 과다 line_seg 가 아닌 별개 원인이라 본 PR 범위 밖이다.

Closes #4813
