### PR TITLE
fix(gym): WMF/EMF 메타파일 DIB 치수·좌표 산술 오버플로 + 무한 할당 DoS 하드닝 (#4846)

### DIFF
--- a/src/emf/converter/player.rs
+++ b/src/emf/converter/player.rs
@@ -59,8 +59,11 @@ impl Player {
         // Bounds → render_rect 매핑. Bounds가 비어 있으면 identity.
         let (rx, ry, rw, rh) = self.render_rect;
         let m = if let Some(h) = &self.header {
-            let w = (h.bounds.right - h.bounds.left) as f32;
-            let hh = (h.bounds.bottom - h.bounds.top) as f32;
+            // Bounds are attacker-controlled i32 coordinates; a naive
+            // `right - left` overflows (DoS panic under debug overflow checks)
+            // on crafted EMR_HEADER bounds. Saturate the extent computation.
+            let w = h.bounds.right.saturating_sub(h.bounds.left) as f32;
+            let hh = h.bounds.bottom.saturating_sub(h.bounds.top) as f32;
             if w > 0.0 && hh > 0.0 {
                 let sx = rw / w;
                 let sy = rh / hh;

--- a/src/wmf/converter/svg/mod.rs
+++ b/src/wmf/converter/svg/mod.rs
@@ -571,10 +571,13 @@ impl crate::wmf::converter::Player for SVGPlayer {
                 bottom,
             } = placeable.bounding_box;
 
+            // Placeable bounding-box coordinates are attacker-controlled i16
+            // values; `right - left` overflows on crafted bounds (DoS panic
+            // under debug overflow checks). Saturate the window extent.
             self.context_current = self
                 .context_current
                 .window_origin(left, top)
-                .window_ext(right - left, bottom - top);
+                .window_ext(right.saturating_sub(left), bottom.saturating_sub(top));
         }
 
         self.context_current = self

--- a/src/wmf/parser/mod.rs
+++ b/src/wmf/parser/mod.rs
@@ -59,14 +59,33 @@ pub fn read_variable<R: crate::wmf::Read>(
         return Ok((vec![0u8; 0], 0));
     }
 
-    let mut buffer = vec![0u8; len];
+    // `len` is derived from untrusted record/DIB size fields. Pre-allocating
+    // `vec![0u8; len]` for a crafted huge `len` aborts the process (OOM)
+    // before the too-short stream is ever detected. Grow the buffer only as
+    // bytes actually arrive, capping each reservation. Behaviour is identical
+    // for valid metafiles: exactly `len` bytes are returned, or an error if
+    // the stream is short.
+    const CHUNK: usize = 64 * 1024;
+    let mut buffer = Vec::new();
+    let mut filled = 0usize;
 
-    match buf.read(&mut buffer) {
-        Ok(bytes_read) if bytes_read == len => Ok((buffer, len)),
-        Ok(bytes_read) => Err(ReadError::new(format!(
-            "expected {len} bytes read, but {bytes_read} bytes read"
-        ))),
-        Err(err) => Err(ReadError::new(format!("{err:?}"))),
+    while filled < len {
+        let want = (len - filled).min(CHUNK);
+        buffer.resize(filled + want, 0u8);
+
+        match buf.read(&mut buffer[filled..]) {
+            Ok(0) => break,
+            Ok(bytes_read) => filled += bytes_read,
+            Err(err) => return Err(ReadError::new(format!("{err:?}"))),
+        }
+    }
+
+    if filled == len {
+        Ok((buffer, len))
+    } else {
+        Err(ReadError::new(format!(
+            "expected {len} bytes read, but {filled} bytes read"
+        )))
     }
 }
 

--- a/src/wmf/parser/objects/structure/bitmap16.rs
+++ b/src/wmf/parser/objects/structure/bitmap16.rs
@@ -123,7 +123,17 @@ impl Bitmap16 {
     }
 
     pub fn calc_length(&self) -> usize {
-        ((((self.width * self.bits_pixel as i16 + 15) >> 4) << 1) * self.height) as usize
+        // Width/Height/BitsPixel are attacker-controlled DIB dimensions. The
+        // MS-WMF formula `(((Width * BitsPixel + 15) >> 4) << 1) * Height`
+        // overflows when evaluated in `i16` (DoS panic under debug overflow
+        // checks; a negative `i16` result becomes a huge `usize` via
+        // sign-extension in release → OOM). Evaluate in `i64` with saturating
+        // arithmetic and clamp to a non-negative byte count.
+        let width = i64::from(self.width);
+        let bits_pixel = i64::from(self.bits_pixel as i16);
+        let height = i64::from(self.height);
+        let stride = ((width.saturating_mul(bits_pixel).saturating_add(15)) >> 4) << 1;
+        stride.saturating_mul(height).max(0) as usize
     }
 }
 
@@ -145,5 +155,41 @@ impl From<Bitmap16> for crate::wmf::parser::DeviceIndependentBitmap {
                 a_data: v.bits,
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wmf::parser::BitCount;
+
+    fn bitmap16(width: i16, height: i16, bits_pixel: BitCount) -> Bitmap16 {
+        Bitmap16 {
+            typ: 0,
+            width,
+            height,
+            width_bytes: 0,
+            planes: 1,
+            bits_pixel,
+            bits: vec![],
+        }
+    }
+
+    /// 손상된 DDB 치수(Width * BitsPixel)는 i16 산술을 넘겨 디버그 빌드에서
+    /// "multiply with overflow" 패닉을, 릴리스에서는 음수 i16 → 사인확장된 거대한
+    /// usize(할당 OOM)를 유발했다. 이제 i64 포화 산술로 계산되어 패닉 없이 올바른
+    /// 값을 돌려준다. 이 단언은 두 빌드 프로파일 모두에서 회귀를 잡는다.
+    #[test]
+    fn calc_length_does_not_overflow_on_huge_dimensions() {
+        // (((30000 * 24 + 15) >> 4) << 1) * 30000 = 2_700_000_000 — i16이면 오버플로.
+        let bm = bitmap16(30000, 30000, BitCount::BI_BITCOUNT_5);
+        assert_eq!(bm.calc_length(), 2_700_000_000);
+    }
+
+    /// 음수 치수는 0으로 클램프되어 사인확장 폭발을 막는다.
+    #[test]
+    fn calc_length_clamps_negative_dimensions_to_zero() {
+        let bm = bitmap16(-1, 1, BitCount::BI_BITCOUNT_5);
+        assert_eq!(bm.calc_length(), 0);
     }
 }

--- a/src/wmf/parser/objects/structure/bitmap_info_header/info.rs
+++ b/src/wmf/parser/objects/structure/bitmap_info_header/info.rs
@@ -164,3 +164,56 @@ impl BitmapInfoHeaderInfo {
         ))
     }
 }
+
+/// Computes the DIB pixel-buffer byte count from header dimensions using the
+/// MS-WMF formula `(((Width * Planes * BitCount + 31) & !31) / 8) * abs(Height)`.
+///
+/// Width/Height/BitCount are attacker-controlled; evaluating the formula in the
+/// header's narrow integer types (`u16` for a core header, `u32` for
+/// info/v4/v5) overflows on crafted dimensions and panics under debug overflow
+/// checks (DoS). Evaluate in `u64` with saturating arithmetic and clamp into
+/// `usize`; the caller (`read_variable`) bounds the actual allocation.
+pub(super) fn dib_image_size(width: u64, height: u64, planes: u64, bit_count: u64) -> usize {
+    let stride = (width
+        .saturating_mul(planes)
+        .saturating_mul(bit_count)
+        .saturating_add(31)
+        & !31)
+        / 8;
+
+    usize::try_from(stride.saturating_mul(height)).unwrap_or(usize::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::dib_image_size;
+    use crate::wmf::parser::{BitCount, BitmapInfoHeader, BitmapInfoHeaderCore};
+
+    /// 유효 치수에서는 기존 좁은-정수 공식과 동일한 바이트 수를 낸다(무회귀).
+    #[test]
+    fn dib_image_size_matches_formula_on_valid_dimensions() {
+        // (((640 * 1 * 24 + 31) & !31) / 8) * 480 = 921_600
+        assert_eq!(dib_image_size(640, 480, 1, 24), 921_600);
+    }
+
+    /// 거대한 치수(u32::MAX)에서도 u64 포화로 패닉하지 않고 유한한 값을 낸다.
+    #[test]
+    fn dib_image_size_saturates_on_huge_dimensions() {
+        let v = dib_image_size(u64::from(u32::MAX), u64::from(u32::MAX), 1, 32);
+        assert!(v > 0);
+    }
+
+    /// Core 헤더 `size()`는 손상된 치수에서 u16 산술 오버플로로 패닉했었다.
+    /// 이제 포화 산술로 유한 값을 돌려준다.
+    #[test]
+    fn core_header_size_does_not_overflow() {
+        let header = BitmapInfoHeader::Core(BitmapInfoHeaderCore {
+            header_size: 12,
+            width: u16::MAX,
+            height: u16::MAX,
+            planes: 1,
+            bit_count: BitCount::BI_BITCOUNT_5,
+        });
+        assert!(header.size() > 0);
+    }
+}

--- a/src/wmf/parser/objects/structure/bitmap_info_header/mod.rs
+++ b/src/wmf/parser/objects/structure/bitmap_info_header/mod.rs
@@ -72,14 +72,24 @@ impl BitmapInfoHeader {
     }
 
     pub fn size(&self) -> usize {
-        let size = match self {
+        // Width/Height/BitCount come straight from the metafile and are
+        // attacker-controlled. `dib_image_size` evaluates the byte-count
+        // formula in `u64` with saturating arithmetic so crafted dimensions
+        // cannot overflow the narrow header integer types (a DoS panic under
+        // debug overflow checks); the read is separately bounded downstream.
+        match self {
             Self::Core(BitmapInfoHeaderCore {
                 width,
                 height,
                 planes,
                 bit_count,
                 ..
-            }) => u32::from((((width * planes * (*bit_count as u16) + 31) & !31) / 8) * height),
+            }) => info::dib_image_size(
+                u64::from(*width),
+                u64::from(*height),
+                u64::from(*planes),
+                *bit_count as u64,
+            ),
             Self::Info(BitmapInfoHeaderInfo {
                 width,
                 height,
@@ -109,15 +119,15 @@ impl BitmapInfoHeader {
             }) => match compression {
                 crate::wmf::parser::Compression::BI_RGB
                 | crate::wmf::parser::Compression::BI_BITFIELDS
-                | crate::wmf::parser::Compression::BI_CMYK => {
-                    ((((*width as u32) * u32::from(*planes) * (*bit_count as u32) + 31) & !31) / 8)
-                        * height.unsigned_abs()
-                }
-                _ => *image_size,
+                | crate::wmf::parser::Compression::BI_CMYK => info::dib_image_size(
+                    u64::from(*width as u32),
+                    u64::from(height.unsigned_abs()),
+                    u64::from(*planes),
+                    *bit_count as u64,
+                ),
+                _ => *image_size as usize,
             },
-        };
-
-        size as usize
+        }
     }
 
     pub fn color_used(&self) -> u32 {

--- a/tests/wmf_emf_metafile_dos.rs
+++ b/tests/wmf_emf_metafile_dos.rs
@@ -1,0 +1,167 @@
+//! WMF/EMF 임베디드 메타파일 파서·컨버터의 DoS 하드닝 회귀 테스트.
+//!
+//! 손상된 메타파일 바이트(치수·좌표 필드 극단값)가 산술 오버플로 패닉이나
+//! 거대 할당(OOM)으로 번지지 않고 graceful 하게 처리되는지 확인한다. 디버그
+//! 빌드(overflow-checks on)에서 회귀 시 아래 테스트가 패닉으로 실패한다.
+
+use rhwp::wmf::converter::{SVGPlayer, WMFConverter};
+
+fn u32le(v: u32) -> [u8; 4] {
+    v.to_le_bytes()
+}
+fn u16le(v: u16) -> [u8; 2] {
+    v.to_le_bytes()
+}
+fn i32le(v: i32) -> [u8; 4] {
+    v.to_le_bytes()
+}
+fn i16le(v: i16) -> [u8; 2] {
+    v.to_le_bytes()
+}
+
+/// placeable(22B) + METAHEADER(18B) 프리픽스. 인자로 placeable 경계 사각형을 지정.
+fn wmf_header(left: i16, top: i16, right: i16, bottom: i16) -> Vec<u8> {
+    let mut b = Vec::new();
+    b.extend_from_slice(&u32le(0x9AC6_CDD7)); // placeable key
+    b.extend_from_slice(&u16le(0)); // hwmf
+    b.extend_from_slice(&i16le(left));
+    b.extend_from_slice(&i16le(top));
+    b.extend_from_slice(&i16le(right));
+    b.extend_from_slice(&i16le(bottom));
+    b.extend_from_slice(&u16le(0)); // inch
+    b.extend_from_slice(&u32le(0)); // reserved
+    b.extend_from_slice(&u16le(0)); // checksum
+    assert_eq!(b.len(), 22);
+    // METAHEADER
+    b.extend_from_slice(&u16le(1)); // type
+    b.extend_from_slice(&u16le(9)); // header size (words)
+    b.extend_from_slice(&u16le(0x0300)); // version
+    b.extend_from_slice(&u32le(0)); // size
+    b.extend_from_slice(&u16le(0)); // number of objects
+    b.extend_from_slice(&u32le(0)); // max record
+    b.extend_from_slice(&u16le(0)); // number of members
+    assert_eq!(b.len(), 40);
+    b
+}
+
+fn eof_record() -> Vec<u8> {
+    let mut b = Vec::new();
+    b.extend_from_slice(&u32le(3)); // record size (words)
+    b.extend_from_slice(&u16le(0x0000)); // META_EOF
+    b
+}
+
+/// META_STRETCHDIB 캐리어 (Info 40B DIB 헤더).
+fn stretchdib_info(width: i32, bit_count: u16) -> Vec<u8> {
+    let mut b = wmf_header(0, 0, 100, 100);
+    b.extend_from_slice(&u32le(0x40));
+    b.extend_from_slice(&u16le(0x0F43)); // META_STRETCHDIB
+    b.extend_from_slice(&u32le(0x00CC_0020)); // SRCCOPY
+    b.extend_from_slice(&u16le(0)); // DIB_RGB_COLORS
+    for _ in 0..8 {
+        b.extend_from_slice(&i16le(0));
+    }
+    b.extend_from_slice(&u32le(40)); // header_size
+    b.extend_from_slice(&i32le(width));
+    b.extend_from_slice(&i32le(1)); // height
+    b.extend_from_slice(&u16le(1)); // planes
+    b.extend_from_slice(&u16le(bit_count));
+    b.extend_from_slice(&u32le(0)); // BI_RGB
+    b.extend_from_slice(&u32le(0)); // image_size
+    b.extend_from_slice(&i32le(0));
+    b.extend_from_slice(&i32le(0));
+    b.extend_from_slice(&u32le(0)); // color_used
+    b.extend_from_slice(&u32le(0)); // color_important
+    b.extend_from_slice(&[0u8; 16]);
+    b
+}
+
+/// META_STRETCHDIB 캐리어 (Core 12B DIB 헤더).
+fn stretchdib_core(width: u16, bit_count: u16) -> Vec<u8> {
+    let mut b = wmf_header(0, 0, 100, 100);
+    b.extend_from_slice(&u32le(0x40));
+    b.extend_from_slice(&u16le(0x0F43));
+    b.extend_from_slice(&u32le(0x00CC_0020));
+    b.extend_from_slice(&u16le(0));
+    for _ in 0..8 {
+        b.extend_from_slice(&i16le(0));
+    }
+    b.extend_from_slice(&u32le(12)); // header_size = 0x0C
+    b.extend_from_slice(&u16le(width));
+    b.extend_from_slice(&u16le(1)); // height
+    b.extend_from_slice(&u16le(1)); // planes
+    b.extend_from_slice(&u16le(bit_count));
+    b.extend_from_slice(&[0u8; 16]);
+    b
+}
+
+fn convert_wmf(data: &[u8]) {
+    // 반환값은 무시 — 패닉/abort 없이 돌아오기만 하면 통과.
+    let _ = WMFConverter::new(data, SVGPlayer::new()).run();
+}
+
+/// placeable 경계 좌표(i16)의 `right - left`가 오버플로해도 패닉하지 않는다.
+#[test]
+fn wmf_placeable_bounds_overflow_is_graceful() {
+    let mut data = wmf_header(-32768, -32768, 32767, 32767);
+    data.extend_from_slice(&eof_record());
+    convert_wmf(&data);
+}
+
+/// Info DIB 치수(width*bitcount)가 u32를 넘겨도 패닉/OOM 없이 처리된다.
+#[test]
+fn wmf_stretchdib_info_huge_dimensions_are_graceful() {
+    convert_wmf(&stretchdib_info(0x1000_0000, 0x0020)); // BI_BITCOUNT_6 = 32bpp
+    convert_wmf(&stretchdib_info(i32::MAX, 0x0020));
+}
+
+/// Core DIB 치수(width*bitcount)가 u16을 넘겨도 패닉하지 않는다.
+#[test]
+fn wmf_stretchdib_core_huge_dimensions_are_graceful() {
+    convert_wmf(&stretchdib_core(0xFFFF, 0x0018)); // BI_BITCOUNT_5 = 24bpp
+}
+
+/// 유효한 소형 Info DIB는 여전히 패닉 없이 변환된다(무회귀 sanity).
+#[test]
+fn wmf_valid_small_dib_still_converts() {
+    convert_wmf(&stretchdib_info(4, 0x0020));
+    convert_wmf(&stretchdib_core(4, 0x0018));
+}
+
+/// EMF EMR_HEADER 경계(i32)의 `right - left`가 오버플로해도 패닉하지 않는다.
+#[test]
+fn emf_header_bounds_overflow_is_graceful() {
+    let mut b = Vec::new();
+    b.extend_from_slice(&u32le(1)); // EMR_HEADER
+    b.extend_from_slice(&u32le(88)); // size
+    b.extend_from_slice(&i32le(-1)); // bounds.left
+    b.extend_from_slice(&i32le(-1)); // bounds.top
+    b.extend_from_slice(&i32le(i32::MAX)); // bounds.right → right - left 오버플로
+    b.extend_from_slice(&i32le(i32::MAX)); // bounds.bottom
+    b.extend_from_slice(&i32le(0));
+    b.extend_from_slice(&i32le(0));
+    b.extend_from_slice(&i32le(10000));
+    b.extend_from_slice(&i32le(5000)); // frame
+    b.extend_from_slice(&u32le(0x464D_4520)); // " EMF"
+    b.extend_from_slice(&u32le(0x0001_0000)); // version
+    b.extend_from_slice(&u32le(108)); // bytes
+    b.extend_from_slice(&u32le(2)); // records
+    b.extend_from_slice(&u16le(1)); // handles
+    b.extend_from_slice(&u16le(0)); // reserved
+    b.extend_from_slice(&u32le(0));
+    b.extend_from_slice(&u32le(0));
+    b.extend_from_slice(&u32le(0));
+    b.extend_from_slice(&i32le(1920));
+    b.extend_from_slice(&i32le(1080));
+    b.extend_from_slice(&i32le(508));
+    b.extend_from_slice(&i32le(286));
+    b.extend_from_slice(&u32le(14)); // EMR_EOF
+    b.extend_from_slice(&u32le(20));
+    b.extend_from_slice(&u32le(0));
+    b.extend_from_slice(&u32le(0));
+    b.extend_from_slice(&u32le(20));
+
+    // 파싱 + SVG 변환 모두 패닉 없이 돌아와야 한다.
+    let _ = rhwp::emf::parse_emf(&b);
+    let _ = rhwp::emf::convert_to_svg(&b, (0.0, 0.0, 100.0, 100.0));
+}


### PR DESCRIPTION
## 무엇을

`#4846` — HWP/HWPX 에 임베디드된 WMF/EMF 벡터 이미지를 SVG로 변환하는 경로에서
손상된 메타파일 바이트가 산술 오버플로 패닉(디버그) / 무한 할당(릴리스 OOM)으로
프로세스를 중단시키는 DoS를 하드닝한다.

## 어떻게 찾았나

`src/wmf/`·`src/emf/` 레코드 파서/컨버터를 두 갈래로 퍼징했다.
(a) 유효 WMF placeable+METAHEADER / EMF EMR_HEADER 를 합성한 뒤 DIB 치수·비트수·
경계 좌표를 극단값으로 변이, (b) 유효 시드에 대한 바이트 변이 스윕(수천 회).
`WMFConverter::run` / `emf::convert_to_svg` 를 `catch_unwind` 로 감싸 패닉 위치를
클러스터링했다(디버그 빌드, overflow-checks on).

## 수정 지점 (모두 별개, 각각 실측 재현)

| # | 위치 | 원인 | 수정 |
|---|------|------|------|
| 1 | `wmf/.../bitmap16.rs:126` `calc_length` | DDB 비트 길이 i16 곱 오버플로 / 음수→usize 사인확장 | i64 포화 + 음수 0 클램프 |
| 2 | `wmf/.../bitmap_info_header/mod.rs:82` `size`(Core) | `W*Planes*BitCount` u16 오버플로 | 공용 `dib_image_size`(u64 포화) |
| 3 | 같은 파일 `:113` (Info/V4/V5) | 같은 식 u32 오버플로 | 상동 |
| 4 | `wmf/converter/svg/mod.rs:577` | placeable `right-left`/`bottom-top` i16 뺄셈 | `saturating_sub` |
| 5 | `emf/converter/player.rs:62-63` | EMR_HEADER `bounds` i32 뺄셈 | `saturating_sub` |

추가로 `read_variable`(`wmf/parser/mod.rs`)가 신뢰 불가 `len` 을 `vec![0u8; len]`
로 선할당하던 것을, 실제 도착 바이트만큼만 증분(64KiB 청크) 할당하도록 바꿨다.
위 크기 계산이 (수정 후) 거대값을 돌려주더라도 OOM abort 없이 스트림 부족
에러로 graceful 하게 떨어진다. 2·3은 META_STRETCHDIB 등 DIB 보유 레코드가
`DeviceIndependentBitmap::parse_with_color_usage → size()` 로 도달한다.

## 검증

- 재현 입력 5종 모두 패닉 → graceful(변환이 `Ok`/`Err` 로 정상 반환) 전환 확인.
- 변이 스윕(WMF 8k회 + EMF 20k회) 재실행 시 패닉 0건.
- 유효 소형 DIB 변환 결과 불변, `cargo test --lib` 무회귀(3707 pass · 0 fail).
- 회귀 테스트 추가: 단위(`bitmap16`, `bitmap_info_header::info`),
  통합(`tests/wmf_emf_metafile_dos.rs` — 손상 입력 5종 + 유효 sanity).
- `rustfmt --edition 2021` 를 변경 리프 파일에 적용, 서식 확인.

## 비고

`#4832`(`graphics_object.rs:22` 색인 OOB), `#4818`(renderer), `#4821`(parser vpos),
`#4830`(hwp5 재귀), `#4833/#4834`(model/page)와는 모두 별개 지점이다.
