### PR TITLE
에이전트 제로프릭션 온보딩 — 한 명령으로 설치·검증·MCP배선·첫 레시피까지 (#4852)

### DIFF
--- a/.claude/skills/rhwp-onboarding/SKILL.md
+++ b/.claude/skills/rhwp-onboarding/SKILL.md
@@ -37,6 +37,30 @@ python tools/agent_onboarding/rhwp_doctor.py --json     # 기계 판독(stdout=J
    `--force` 없이 덮어쓰지 않는다.
 4. **첫 5분 레시피 지도** — 실존하는 스킬·레시피만 인용해 5대 고가치 과제를 명령과 함께 제시.
 
+## 닥터가 실제로 돌리는 명령 (손으로 확인할 때)
+
+닥터가 `FAIL` 을 내면 같은 명령을 직접 쳐서 원인을 본다 — 닥터는 아래를 감싼 것뿐이다.
+
+```bash
+rhwp --version
+rhwp info samples/basic/english.hwp --json
+rhwp export-text samples/basic/english.hwp --json --max-chars 2000
+```
+
+`.mcp.json` 이 띄우는 상주 서버도 같은 바이너리다 — 배선 전에 한 번 손으로 띄워 본다.
+
+```bash
+rhwp mcp-serve
+```
+
+붙였으면 첫 과제로 넘어간다. 어느 스킬로 갈지는 아래 지도를 따르되, 한 문서를 빠르게
+파악하는 최단 경로는 이 두 명령이다.
+
+```bash
+rhwp explain samples/basic/english.hwp --json
+rhwp digest samples/basic/english.hwp --json
+```
+
 ## 종료 코드로 판정
 
 | 코드 | 뜻 | 다음 |

--- a/.claude/skills/rhwp-onboarding/SKILL.md
+++ b/.claude/skills/rhwp-onboarding/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: rhwp-onboarding
+description: rhwp 를 처음 만나는 에이전트를 한 명령으로 온보딩합니다. tools/agent_onboarding/rhwp_doctor.py 하나로 바이너리 위치·버전 확인 → 번들 샘플 자가검증(info/export-text) → 붙여넣기용 .mcp.json 방출 → 첫 5분 레시피 지도(트리아지·표 추출·서식 채우기·보안 스윕·작업 영수증)까지 끝내고, 종료 코드로 정상/빌드필요를 신호합니다. 트리거 — 사용자가 "rhwp 처음/설치/시작/온보딩", "rhwp 어떻게 붙여/시작해", "rhwp 돌아가는지 확인", "rhwp 셋업/부트스트랩", "rhwp 뭐부터", ".mcp.json 만들어줘" 등을 요청할 때. 5분 경로 정본은 mydocs/manual/agent_onboarding.md.
+---
+
+# rhwp-onboarding — 제로프릭션 온보딩 Skill
+
+## 목적
+
+rhwp 를 **처음 보는** 에이전트(또는 그 사람)를 "설치 → 검증 → MCP 배선 → 첫 레시피"까지
+한 번에 데려간다. 이 스킬은 얇다 — 실제 일은 닥터 스크립트와 5분 경로 문서가 한다.
+
+- 닥터: [`tools/agent_onboarding/rhwp_doctor.py`](../../../tools/agent_onboarding/rhwp_doctor.py) (순수 Python 3, 의존성 0)
+- 5분 경로 정본: [`mydocs/manual/agent_onboarding.md`](../../../mydocs/manual/agent_onboarding.md)
+
+이미 MCP 로 붙어 있고 **세션/무상태 도구 선택**이 논점이면 이 스킬이 아니라
+`rhwp-mcp-session` 을 쓴다. 이 스킬은 그 앞단(0→1 부트스트랩) 전용이다.
+
+## 한 명령
+
+저장소 루트에서:
+
+```bash
+python tools/agent_onboarding/rhwp_doctor.py            # 사람용 리포트
+python tools/agent_onboarding/rhwp_doctor.py --json     # 기계 판독(stdout=JSON 하나)
+```
+
+닥터가 하는 일:
+
+1. **바이너리 위치·버전** — `PATH` → `target/release/rhwp` 순으로 찾고 `--version` 확인.
+   없으면 `cargo build --release --bin rhwp` 를 찍고 **종료 코드 3** 으로 신호(긴 빌드를
+   대신 돌리지 않는다).
+2. **자가검증** — `samples/` 의 작은 문서로 `info` / `export-text --json` 을 돌려 구조 출력을
+   확인한다. 통과를 위조하지 않는다 — 못 돌린 검사는 `SKIP`/`FAIL` 로 정직하게 보고.
+3. **`.mcp.json` 방출** — `{ "mcpServers": { "rhwp": { "command": "rhwp", "args": ["mcp-serve"] } } }`.
+   `PATH` 에 없으면 절대 경로를 채워준다. `--write <경로>` 로 파일로 쓰되 기존 파일은
+   `--force` 없이 덮어쓰지 않는다.
+4. **첫 5분 레시피 지도** — 실존하는 스킬·레시피만 인용해 5대 고가치 과제를 명령과 함께 제시.
+
+## 종료 코드로 판정
+
+| 코드 | 뜻 | 다음 |
+|---:|---|---|
+| 0 | 정상 | `.mcp.json` 붙이고 첫 레시피로 |
+| 1 | 임계 실패 | `FAIL` 상세 진단 |
+| 2 | 사용법 오류 | 인자 교정 |
+| 3 | 바이너리 미발견 | `cargo build --release --bin rhwp` |
+
+## 다음
+
+- MCP 통합 전체 절차: [`mydocs/manual/mcp_integration_guide.md`](../../../mydocs/manual/mcp_integration_guide.md)
+- CLI 전체 명령: [`mydocs/manual/cli_commands.md`](../../../mydocs/manual/cli_commands.md)
+- 과제별 스킬: `rhwp-doc-triage` · `rhwp-table-exchange` · `rhwp-form-fill` ·
+  `rhwp-security-sweep` · `rhwp-work-receipt`

--- a/mydocs/manual/agent_onboarding.md
+++ b/mydocs/manual/agent_onboarding.md
@@ -1,0 +1,138 @@
+---
+kind: guide
+status: active
+canonical: mydocs/manual/agent_onboarding.md
+last_verified: 2026-08-15
+---
+
+# 에이전트 제로프릭션 온보딩 — 한 명령으로 설치·검증·MCP배선·첫 레시피
+
+**목표 한 줄**: rhwp 를 처음 보는 AI 에이전트(또는 그 사람)가 **명령 하나**로
+"바이너리 있음 → 자가검증 통과 → MCP 배선 완료 → 첫 레시피를 안다" 상태까지 도달한다.
+
+그 한 명령이 [`tools/agent_onboarding/rhwp_doctor.py`](../../tools/agent_onboarding/rhwp_doctor.py)
+(순수 Python 3 표준 라이브러리, 외부 의존성 0)다. 이 문서는 그 5분 경로를 설명한다.
+전체 통합 절차는 [MCP 통합 가이드](mcp_integration_guide.md), 전체 명령 표면은
+[CLI 명령어 매뉴얼](cli_commands.md)이 정본이며 여기서 중복하지 않는다.
+
+## 전제 (정직하게)
+
+- **빌드된 rhwp 바이너리 1개.** rhwp 는 Rust 크레이트라 배포 바이너리를 쓰거나 직접 빌드한다.
+  아직 없으면 저장소 루트에서 한 번:
+  ```bash
+  cargo build --release --bin rhwp     # 산출물: target/release/rhwp (Windows: rhwp.exe)
+  ```
+  닥터는 이 빌드를 **대신 돌려주지 않는다** — 없으면 위 명령을 찍고 종료 코드 3으로 신호한다
+  (긴 빌드로 매달리지 않기 위해서다).
+- **Python 3.** 닥터는 표준 라이브러리만 쓴다. 설치할 패키지가 없다.
+
+## 5분 경로
+
+### 1. 빌드 (최초 1회, 이미 있으면 건너뜀)
+
+```bash
+cargo build --release --bin rhwp
+```
+
+### 2. 닥터 실행 — 넷을 한 번에
+
+```bash
+python tools/agent_onboarding/rhwp_doctor.py
+```
+
+이 한 줄이 다음을 순서대로 한다:
+
+1. **바이너리 위치·버전** — `PATH` → `target/release/rhwp` 순으로 찾고 `rhwp --version` 을 확인한다.
+2. **번들 샘플 자가검증** — `samples/` 의 작은 문서로 `info` 와 `export-text --json` 을 돌려
+   구조 출력이 실제로 나오는지 확인한다. **통과를 위조하지 않는다** — 못 돌린 검사는
+   이유와 함께 `SKIP`/`FAIL` 로 정직하게 보고한다.
+3. **붙여넣기용 `.mcp.json`** 을 방출한다(다음 단계).
+4. **첫 5분 레시피 지도**를 출력한다(4단계 아래 표).
+
+### 3. `.mcp.json` 붙여넣기
+
+닥터가 찍어준 스니펫을 **호스트(Claude Code 등) 프로젝트 루트**의 `.mcp.json` 에 두거나,
+이미 파일이 있으면 `mcpServers` 키만 병합한다:
+
+```jsonc
+{ "mcpServers": { "rhwp": { "command": "rhwp", "args": ["mcp-serve"] } } }
+```
+
+- `rhwp` 가 `PATH` 에 없으면 닥터는 `command` 에 **바이너리 절대 경로**를 넣어준다
+  (예: `target/release/rhwp.exe`). 이는 [MCP 통합 가이드](mcp_integration_guide.md)의
+  계약과 같다 — 전송은 stdio 뿐이라 포트·인증 설정이 없다.
+- 파일로 바로 쓰려면 `--write <경로>` 를 준다. **기존 파일은 덮어쓰지 않는다** —
+  덮어쓰려면 `--force` 를 명시해야 한다.
+  ```bash
+  python tools/agent_onboarding/rhwp_doctor.py --write .mcp.json          # 없을 때만 기록
+  python tools/agent_onboarding/rhwp_doctor.py --write .mcp.json --force  # 덮어쓰기 허용
+  ```
+- 저장소 루트 [`.mcp.json`](../../.mcp.json) 은 Claude Code 용으로 이미 rhwp 를 붙여 둔다.
+  다른 호스트(Cursor·Cline·Continue·Zed 등) 설정은 [MCP 부착 키트](mcp_attach_kit.md) 참조.
+
+### 4. 첫 레시피 — 가장 값어치 높은 5과제
+
+닥터가 이 표를 출력하며, **실존하는 스킬·레시피만** 인용한다(런타임에 파일 존재를 확인해
+`[OK]`/`[missing]` 로 표시). 스킬은 트리거 문구로 자동 발동하고, 레시피는 실측 절차서다.
+
+| 과제 | 명령(1차) | 스킬 | 레시피 |
+|---|---|---|---|
+| 문서 트리아지 (처음 보는 문서 파악) | `rhwp digest "<파일>" --json` | [`rhwp-doc-triage`](../../.claude/skills/rhwp-doc-triage/SKILL.md) | — |
+| 표 추출 (병합 보존 / CSV 왕복) | `rhwp export-tables "<파일>" --json` | [`rhwp-table-exchange`](../../.claude/skills/rhwp-table-exchange/SKILL.md) | [레시피 02](recipes/02_table_csv_roundtrip.md) |
+| 서식 채우기 (누름틀 → 제출본) | `rhwp fields "<파일>" --json` → `rhwp edit fill-fields …` | [`rhwp-form-fill`](../../.claude/skills/rhwp-form-fill/SKILL.md) | [레시피 01](recipes/01_fill_form_and_submit.md) · [05](recipes/05_mail_merge_batch_fill.md) |
+| 보안 스윕 (주입·은닉·유니코드) | `rhwp inspect injection "<파일>" --json` | [`rhwp-security-sweep`](../../.claude/skills/rhwp-security-sweep/SKILL.md) | [레시피 10](recipes/10_security_sweep_before_share.md) · [04](recipes/04_safety_check_untrusted_doc.md) |
+| 작업 영수증 (3-해시 증명) | `rhwp replay --plan-json '{…}' --json` | [`rhwp-work-receipt`](../../.claude/skills/rhwp-work-receipt/SKILL.md) | — |
+
+과제를 무엇으로 풀지 막힐 때의 판단 트리·봉투 실측은
+[에이전트 실무 대체 예제집](agent_task_playbook.md)과
+[CLI JSON 파이프라인 가이드](cli_json_pipeline_guide.md)가 잇는다.
+
+### 5. 판정 읽기
+
+닥터는 마지막에 판정과 종료 코드를 찍는다. 에이전트는 `--json` 으로 기계 판독한다:
+
+```bash
+python tools/agent_onboarding/rhwp_doctor.py --json | jq '{ok, exitCode, checks: [.checks[] | {id, status}]}'
+```
+
+| 종료 코드 | 뜻 | 다음 행동 |
+|---:|---|---|
+| 0 | 모든 임계 검사 통과 | `.mcp.json` 붙이고 첫 레시피로 진행 |
+| 1 | 임계 검사 실패(바이너리는 있으나 버전/자가검증이 깨짐) | 출력의 `FAIL` 상세를 보고 진단 |
+| 2 | 사용법 오류(`--write` 덮어쓰기 거부 등) | 인자를 고쳐 재실행 |
+| 3 | 바이너리 미발견(아직 빌드 안 됨) | 위 `cargo build --release --bin rhwp` 실행 |
+
+`--json` 모드에서는 **stdout 에 리포트 JSON 하나만** 나가고(에이전트가 그대로 파싱),
+사람용 텍스트는 stderr 로 간다. 리포트 스키마: `{schemaVersion, tool, ok, exitCode,
+binary{found,path,source,onPath,version}, sample, checks[], mcpJson, recipes[], buildCommand}`.
+
+## 닥터가 하는 검사 (요약)
+
+| 검사 id | 하는 일 | 통과 조건 |
+|---|---|---|
+| `version` | `rhwp --version` | 종료 0 + 비어 있지 않은 버전 문자열 |
+| `selftest-info` | `rhwp info <샘플> --json` | JSON 파싱 + `format`·`pageCount` 필드 존재 |
+| `selftest-export-text` | `rhwp export-text <샘플> --json --max-chars 2000` | JSON 파싱 + `pages` 배열 비어 있지 않음 |
+
+- 자가검증 샘플은 `samples/basic/english.hwp` 같은 **평범한 문서**를 우선 고른다. 없으면
+  `--sample <경로>` 로 지정한다.
+- 모든 하위 프로세스는 타임아웃으로 감싸므로 어떤 검사도 매달리지 않는다.
+- 바이너리를 직접 지목하려면 `--rhwp <경로>`, 저장소 루트를 옮기려면 `--repo-root <경로>`.
+
+## 문제 해결
+
+- **`exit=3`, "rhwp 미발견"** — 아직 빌드 안 됐다. `cargo build --release --bin rhwp`.
+  네이티브 빌드는 항상 로컬 cargo 를 쓴다(Docker 는 WASM 전용) —
+  [개발 환경 가이드](dev_environment_guide.md).
+- **"샘플 문서를 찾지 못함"** — `samples/` 가 없는 축소 체크아웃이다. `--sample <파일>` 로
+  아무 `.hwp`/`.hwpx` 를 준다.
+- **Windows 콘솔 한글 깨짐** — 닥터는 stdout/stderr 를 UTF-8 로 맞춰 cp949 콘솔에서도
+  한글·JSON 이 깨지지 않게 한다. 그래도 콘솔 폰트 문제로 보이면 `--json` 을 파일로 리다이렉트해
+  읽는다.
+
+## 다음 단계
+
+- MCP 세션 도구(재파싱 없는 반복 조회 `hwp_open`→`hwp_doc_text`→`hwp_close`)와 무상태 도구
+  선택 기준: [MCP 통합 가이드](mcp_integration_guide.md), 스킬 [`rhwp-mcp-session`](../../.claude/skills/rhwp-mcp-session/SKILL.md).
+- rhwp 참조 문서 전체 지도: [에이전트 지식 지도](agent_knowledge_map.md).
+- 사람(기여자) 관점의 저장소 진입점: [rhwp 온보딩 가이드](onboarding_guide.md).

--- a/tools/agent_onboarding/rhwp_doctor.py
+++ b/tools/agent_onboarding/rhwp_doctor.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""rhwp_doctor.py — 에이전트 제로프릭션 온보딩 닥터 + 부트스트랩.
+
+한 명령으로 "rhwp 를 처음 보는 에이전트"가 다음 넷을 한 번에 끝낸다:
+
+  1. 바이너리 위치·버전 확인 (PATH → target/release → 없으면 빌드 명령 안내)
+  2. 번들 샘플로 읽기 전용 자가검증 (info / export-text 구조 출력 확인)
+  3. 붙여넣기용 .mcp.json 스니펫 방출 (rhwp mcp-serve)
+  4. "첫 5분" 레시피 지도 (실존 스킬·레시피만 인용)
+
+설계 규약(저장소 철학과 일치):
+  - 판정은 데이터다: 통과를 절대 위조하지 않는다. 못 돌린 검사는 SKIPPED/FAIL 로
+    이유와 함께 정직하게 보고한다.
+  - 매달리지 않는다: 바이너리가 없으면 긴 빌드를 강제하지 않고 빌드 명령만 찍고
+    종료 코드로 신호한다. 모든 하위 프로세스는 타임아웃으로 감싼다.
+  - 순수 Python 3 표준 라이브러리만 사용한다(외부 의존성 0). 반복 실행에 안전하다.
+
+종료 코드(에이전트 계약):
+  0  모든 임계 검사 통과 — 바로 붙여도 됨
+  1  임계 검사 실패 — 바이너리는 있으나 버전/자가검증이 깨짐
+  2  사용법 오류 — 잘못된 인자, --write 덮어쓰기 거부(--force 없이)
+  3  바이너리 미발견 — 아직 빌드 안 됨(조치: 아래 빌드 명령 실행)
+
+--json 을 주면 stdout 에는 기계 판독용 리포트 JSON 하나만 나가고, 사람용 텍스트는
+전부 stderr 로 간다(에이전트가 stdout 을 그대로 파싱한다).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+SCHEMA_VERSION = "1.0"
+BUILD_COMMAND = "cargo build --release --bin rhwp"
+# 하위 프로세스 상한(초) — 어떤 검사도 매달리지 않게 한다.
+VERSION_TIMEOUT = 20
+SELFTEST_TIMEOUT = 45
+
+# 자가검증에 쓸 "정상 문서" 후보(첫 존재 파일 선택). 병리적 픽스처가 아니라
+# 평범한 문서만 고른다 — 자가검증이 실패하면 그건 진짜 신호여야 한다.
+SAMPLE_CANDIDATES = [
+    "samples/basic/english.hwp",
+    "samples/basic/KTX.hwp",
+    "samples/basic/BookReview.hwp",
+    "samples/2022년 국립국어원 업무계획.hwp",
+    "samples/2022년 국립국어원 업무계획.hwpx",
+]
+
+# 첫 5분 레시피 지도 — 브리프가 지정한 5대 고가치 과제.
+# 각 항목의 skill/recipe 경로는 런타임에 실존을 검증해 인용한다(없으면 정직하게 표시).
+RECIPES = [
+    {
+        "task": "문서 트리아지 — 처음 보는 문서를 컨텍스트 아끼며 파악",
+        "command": 'rhwp digest "<파일>" --json',
+        "skill": "rhwp-doc-triage",
+        "recipe": None,
+    },
+    {
+        "task": "표 추출 — 병합 보존 격자 / CSV 왕복",
+        "command": 'rhwp export-tables "<파일>" --json',
+        "skill": "rhwp-table-exchange",
+        "recipe": "mydocs/manual/recipes/02_table_csv_roundtrip.md",
+    },
+    {
+        "task": "서식 채우기 — 누름틀 조사 후 값 채워 제출본 생성",
+        "command": 'rhwp fields "<파일>" --json  →  rhwp edit fill-fields "<파일>" --data @row.json -o out.hwp --json',
+        "skill": "rhwp-form-fill",
+        "recipe": "mydocs/manual/recipes/01_fill_form_and_submit.md",
+    },
+    {
+        "task": "보안 스윕 — 배포 전/수신 후 주입·은닉·유니코드 점검",
+        "command": 'rhwp inspect injection "<파일>" --json',
+        "skill": "rhwp-security-sweep",
+        "recipe": "mydocs/manual/recipes/10_security_sweep_before_share.md",
+    },
+    {
+        "task": "작업 영수증 — 산출물을 3-해시로 증명·재현 검증",
+        "command": "rhwp replay --plan-json '{\"planVersion\":\"1.0\",...}' --json",
+        "skill": "rhwp-work-receipt",
+        "recipe": None,
+    },
+]
+
+PASS, FAIL, SKIP = "PASS", "FAIL", "SKIP"
+
+
+# --------------------------------------------------------------------------- #
+# 순수 로직(바이너리 불요) — 가드 테스트가 여기를 겨눈다.
+# --------------------------------------------------------------------------- #
+def default_repo_root() -> Path:
+    """이 스크립트 위치(tools/agent_onboarding/x.py)에서 저장소 루트를 유도한다."""
+    return Path(__file__).resolve().parents[2]
+
+
+def build_mcp_snippet(command: str, args=None):
+    """붙여넣기용 .mcp.json 딕셔너리를 만든다.
+
+    command 은 PATH 에 rhwp 가 있으면 "rhwp", 아니면 바이너리 절대 경로다
+    (mcp_integration_guide.md: "PATH 에 없으면 command 에 절대 경로를 쓴다").
+    """
+    if args is None:
+        args = ["mcp-serve"]
+    return {"mcpServers": {"rhwp": {"command": command, "args": list(args)}}}
+
+
+def aggregate(checks, binary_found: bool):
+    """검사 목록 → (ok, exit_code). 순수 함수(가드 테스트 대상).
+
+    ok 는 임계 검사가 하나도 실패/스킵되지 않았을 때만 True.
+    exit_code: 0 정상 / 3 바이너리 미발견 / 1 임계 실패.
+    """
+    critical = [c for c in checks if c.get("critical")]
+    all_pass = all(c["status"] == PASS for c in critical)
+    if not binary_found:
+        return False, 3
+    if all_pass:
+        return True, 0
+    return False, 1
+
+
+def resolve_recipe_map(repo_root: Path):
+    """RECIPES 를 실존 검증과 함께 해석한다. 없는 스킬/레시피는 정직하게 표시."""
+    out = []
+    for r in RECIPES:
+        skill_rel = f".claude/skills/{r['skill']}"
+        skill_exists = (repo_root / skill_rel / "SKILL.md").is_file()
+        recipe_rel = r["recipe"]
+        recipe_exists = bool(recipe_rel) and (repo_root / recipe_rel).is_file()
+        out.append(
+            {
+                "task": r["task"],
+                "command": r["command"],
+                "skill": r["skill"],
+                "skillPath": skill_rel,
+                "skillExists": skill_exists,
+                "recipe": recipe_rel,
+                "recipeExists": recipe_exists,
+            }
+        )
+    return out
+
+
+def pick_sample(repo_root: Path, override: str | None):
+    """자가검증용 샘플 경로를 고른다(override 우선, 아니면 후보 중 첫 존재)."""
+    if override:
+        p = Path(override)
+        return p if p.is_file() else None
+    for rel in SAMPLE_CANDIDATES:
+        p = repo_root / rel
+        if p.is_file():
+            return p
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# 바이너리 조달·실행
+# --------------------------------------------------------------------------- #
+def find_binary(repo_root: Path, override: str | None):
+    """rhwp 바이너리를 찾는다. 반환: (path|None, source, on_path)."""
+    if override:
+        p = Path(override)
+        if p.is_file():
+            return p, "--rhwp", False
+        return None, "--rhwp(미발견)", False
+    on_path = shutil.which("rhwp")
+    if on_path:
+        return Path(on_path), "PATH", True
+    exe = "rhwp.exe" if os.name == "nt" else "rhwp"
+    cand = repo_root / "target" / "release" / exe
+    if cand.is_file():
+        return cand, "target/release", False
+    return None, "(미발견)", False
+
+
+def _run(binary: Path, args, timeout: int):
+    """rhwp 를 실행하고 (exit, stdout_str, stderr_str) 반환. 타임아웃/오류는 예외로 던진다.
+
+    Windows cp949 로케일에서도 UTF-8 JSON 이 깨지지 않도록 bytes 로 받아 직접 디코드한다.
+    """
+    proc = subprocess.run(
+        [str(binary), *args],
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+    )
+    out = proc.stdout.decode("utf-8", errors="replace")
+    err = proc.stderr.decode("utf-8", errors="replace")
+    return proc.returncode, out, err
+
+
+def check_version(binary: Path):
+    cmd = "rhwp --version"
+    try:
+        code, out, err = _run(binary, ["--version"], VERSION_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        return _mk("version", "바이너리 버전", FAIL, cmd, f"{VERSION_TIMEOUT}s 내 무응답(타임아웃)", True)
+    except OSError as e:
+        return _mk("version", "바이너리 버전", FAIL, cmd, f"실행 불가: {e}", True)
+    text = (out or err).strip()
+    if code == 0 and text:
+        return _mk("version", "바이너리 버전", PASS, cmd, text.splitlines()[0], True, version=text.splitlines()[0])
+    return _mk("version", "바이너리 버전", FAIL, cmd, f"exit={code}, 출력='{text[:80]}'", True)
+
+
+def check_info(binary: Path, sample: Path):
+    cmd = f'rhwp info "{sample}" --json'
+    try:
+        code, out, err = _run(binary, ["info", str(sample), "--json"], SELFTEST_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        return _mk("selftest-info", "자가검증: info", FAIL, cmd, f"{SELFTEST_TIMEOUT}s 내 무응답(타임아웃)", True)
+    except OSError as e:
+        return _mk("selftest-info", "자가검증: info", FAIL, cmd, f"실행 불가: {e}", True)
+    if code != 0:
+        return _mk("selftest-info", "자가검증: info", FAIL, cmd, f"exit={code}: {(err or out).strip()[:120]}", True)
+    try:
+        obj = json.loads(out)
+    except json.JSONDecodeError as e:
+        return _mk("selftest-info", "자가검증: info", FAIL, cmd, f"JSON 파싱 실패: {e}", True)
+    if not isinstance(obj, dict) or "format" not in obj or "pageCount" not in obj:
+        return _mk("selftest-info", "자가검증: info", FAIL, cmd, "구조 출력에 format/pageCount 없음", True)
+    detail = f"format={obj.get('format')}, pageCount={obj.get('pageCount')}, version={obj.get('version')}"
+    return _mk("selftest-info", "자가검증: info", PASS, cmd, detail, True)
+
+
+def check_export_text(binary: Path, sample: Path):
+    cmd = f'rhwp export-text "{sample}" --json --max-chars 2000'
+    try:
+        code, out, err = _run(
+            binary, ["export-text", str(sample), "--json", "--max-chars", "2000"], SELFTEST_TIMEOUT
+        )
+    except subprocess.TimeoutExpired:
+        return _mk("selftest-export-text", "자가검증: export-text", FAIL, cmd, f"{SELFTEST_TIMEOUT}s 내 무응답(타임아웃)", True)
+    except OSError as e:
+        return _mk("selftest-export-text", "자가검증: export-text", FAIL, cmd, f"실행 불가: {e}", True)
+    if code != 0:
+        return _mk("selftest-export-text", "자가검증: export-text", FAIL, cmd, f"exit={code}: {(err or out).strip()[:120]}", True)
+    try:
+        obj = json.loads(out)
+    except json.JSONDecodeError as e:
+        return _mk("selftest-export-text", "자가검증: export-text", FAIL, cmd, f"JSON 파싱 실패: {e}", True)
+    pages = obj.get("pages") if isinstance(obj, dict) else None
+    if not isinstance(pages, list) or len(pages) < 1:
+        return _mk("selftest-export-text", "자가검증: export-text", FAIL, cmd, "pages 배열이 비었거나 없음", True)
+    chars = sum(len(p.get("text", "")) for p in pages if isinstance(p, dict))
+    detail = f"pageCount={obj.get('pageCount')}, pages={len(pages)}, 본문문자={chars}"
+    return _mk("selftest-export-text", "자가검증: export-text", PASS, cmd, detail, True)
+
+
+def _mk(cid, title, status, command, detail, critical, version=None):
+    d = {"id": cid, "title": title, "status": status, "command": command, "detail": detail, "critical": critical}
+    if version is not None:
+        d["version"] = version
+    return d
+
+
+# --------------------------------------------------------------------------- #
+# 출력
+# --------------------------------------------------------------------------- #
+def render_human(report, out):
+    p = lambda *a: print(*a, file=out)
+    b = report["binary"]
+    p("rhwp doctor — 에이전트 제로프릭션 온보딩 점검")
+    p(f"repo: {report['repoRoot']}")
+    p("")
+    p("[1] 바이너리 위치·버전")
+    if b["found"]:
+        p(f"  [PASS] rhwp 발견: {b['path']}  (source: {b['source']})")
+    else:
+        p(f"  [FAIL] rhwp 미발견 — 아직 빌드 안 됨. 저장소 루트에서 실행:")
+        p(f"           {report['buildCommand']}")
+    for c in report["checks"]:
+        p(f"  [{c['status']}] {c['title']}: {c['command']}")
+        if c["detail"]:
+            p(f"           → {c['detail']}")
+    p("")
+    p(f"[2] 붙여넣기용 .mcp.json  (호스트 프로젝트 루트에 두거나 mcpServers 키를 병합)")
+    for line in json.dumps(report["mcpJson"], ensure_ascii=False, indent=2).splitlines():
+        p(f"  {line}")
+    if report.get("mcpJsonWritten"):
+        p(f"  → 기록함: {report['mcpJsonWritten']}")
+    p("")
+    p("[3] 첫 5분 레시피 지도 (실존 스킬·레시피만 인용)")
+    for r in report["recipes"]:
+        sflag = "OK" if r["skillExists"] else "missing"
+        p(f"  · {r['task']}")
+        p(f"      명령: {r['command']}")
+        p(f"      스킬: {r['skill']} [{sflag}]  ({r['skillPath']})")
+        if r["recipe"]:
+            rflag = "OK" if r["recipeExists"] else "missing"
+            p(f"      레시피: {r['recipe']} [{rflag}]")
+    p("")
+    verdict = "정상 — 바로 붙여도 됩니다" if report["ok"] else "미완 — 위 FAIL/빌드 안내를 먼저 처리하세요"
+    p(f"판정: {verdict}  (exit={report['exitCode']})")
+
+
+def _force_utf8_streams():
+    """stdout/stderr 를 UTF-8 로 맞춘다. Windows 콘솔(cp949)에서도 한글·em-dash·
+    UTF-8 JSON 이 깨지지 않게 한다. 에이전트는 어차피 stdout 을 UTF-8 로 파싱한다."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            try:
+                reconfigure(encoding="utf-8", errors="replace")
+            except (ValueError, OSError):
+                pass
+
+
+def main(argv=None) -> int:
+    _force_utf8_streams()
+    ap = argparse.ArgumentParser(
+        prog="rhwp_doctor.py",
+        description="rhwp 에이전트 온보딩 닥터 — 바이너리 검증 + 자가검증 + .mcp.json + 레시피 지도",
+    )
+    ap.add_argument("--json", action="store_true", help="기계 판독용 리포트 JSON 을 stdout 으로")
+    ap.add_argument("--write", metavar="PATH", help=".mcp.json 스니펫을 이 경로에 기록(기존 파일은 --force 필요)")
+    ap.add_argument("--force", action="store_true", help="--write 시 기존 파일 덮어쓰기 허용")
+    ap.add_argument("--rhwp", metavar="PATH", help="rhwp 바이너리 경로를 직접 지정")
+    ap.add_argument("--sample", metavar="PATH", help="자가검증에 쓸 샘플 문서 경로")
+    ap.add_argument("--repo-root", metavar="PATH", help="저장소 루트(기본: 스크립트 위치에서 유도)")
+    args = ap.parse_args(argv)
+
+    # --json 모드: 사람용 텍스트는 stderr, stdout 은 순수 JSON 만.
+    human_out = sys.stderr if args.json else sys.stdout
+
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else default_repo_root()
+    binary, source, on_path = find_binary(repo_root, args.rhwp)
+
+    checks = []
+    if binary is not None:
+        checks.append(check_version(binary))
+        sample = pick_sample(repo_root, args.sample)
+        if sample is None:
+            note = "샘플 문서를 찾지 못함(samples/ 없음). --sample 로 지정하세요."
+            checks.append(_mk("selftest-info", "자가검증: info", SKIP, "rhwp info <샘플> --json", note, True))
+            checks.append(_mk("selftest-export-text", "자가검증: export-text", SKIP, "rhwp export-text <샘플> --json", note, True))
+        else:
+            checks.append(check_info(binary, sample))
+            checks.append(check_export_text(binary, sample))
+    else:
+        sample = None
+
+    # .mcp.json 스니펫(바이너리 유무와 무관하게 방출 — 문서 산출물).
+    if binary is not None and not on_path:
+        snippet = build_mcp_snippet(str(binary))
+    else:
+        snippet = build_mcp_snippet("rhwp")
+
+    ok, exit_code = aggregate(checks, binary is not None)
+
+    report = {
+        "schemaVersion": SCHEMA_VERSION,
+        "tool": "rhwp_doctor",
+        "ok": ok,
+        "exitCode": exit_code,
+        "repoRoot": str(repo_root),
+        "binary": {
+            "found": binary is not None,
+            "path": str(binary) if binary else None,
+            "source": source,
+            "onPath": on_path,
+            "version": next((c.get("version") for c in checks if c.get("id") == "version" and c.get("version")), None),
+        },
+        "sample": str(sample) if sample else None,
+        "checks": checks,
+        "mcpJson": snippet,
+        "mcpJsonWritten": None,
+        "recipes": resolve_recipe_map(repo_root),
+        "buildCommand": BUILD_COMMAND,
+    }
+
+    # --write 처리(덮어쓰기 보호).
+    if args.write:
+        target = Path(args.write)
+        if target.exists() and not args.force:
+            print(f"경고: {target} 가 이미 있어 기록하지 않았습니다. 덮어쓰려면 --force 를 주세요.", file=sys.stderr)
+            _emit(report, args.json, human_out)
+            return 2
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(json.dumps(snippet, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+            report["mcpJsonWritten"] = str(target)
+        except OSError as e:
+            print(f"경고: {target} 기록 실패: {e}", file=sys.stderr)
+            _emit(report, args.json, human_out)
+            return 2
+
+    _emit(report, args.json, human_out)
+    return exit_code
+
+
+def _emit(report, as_json, human_out):
+    if as_json:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        render_human(report, human_out)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/agent_onboarding/test_rhwp_doctor.py
+++ b/tools/agent_onboarding/test_rhwp_doctor.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""rhwp_doctor.py 의 순수 로직 가드 테스트 — 바이너리 불요.
+
+.mcp.json 방출기와 리포트 집계(종료 코드), 레시피 지도 실존 검증, 샘플 선택을
+스텁 경로로 검증한다. rhwp 바이너리 없이도 돌므로 CI 의 바이너리 불요 게이트에 맞는다.
+
+실행:
+    python -m unittest tools/agent_onboarding/test_rhwp_doctor.py
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# CWD 와 무관하게 대상 모듈을 import 한다(CI 는 저장소 루트에서 파일 경로로 호출).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import rhwp_doctor as doc  # noqa: E402
+
+
+class TestMcpSnippet(unittest.TestCase):
+    def test_path_case_uses_bare_command(self):
+        snip = doc.build_mcp_snippet("rhwp")
+        self.assertEqual(snip["mcpServers"]["rhwp"]["command"], "rhwp")
+        self.assertEqual(snip["mcpServers"]["rhwp"]["args"], ["mcp-serve"])
+
+    def test_absolute_path_case(self):
+        abspath = r"C:\repo\target\release\rhwp.exe"
+        snip = doc.build_mcp_snippet(abspath)
+        self.assertEqual(snip["mcpServers"]["rhwp"]["command"], abspath)
+        self.assertEqual(snip["mcpServers"]["rhwp"]["args"], ["mcp-serve"])
+
+    def test_snippet_is_json_roundtrippable(self):
+        import json
+
+        snip = doc.build_mcp_snippet("rhwp")
+        again = json.loads(json.dumps(snip, ensure_ascii=False))
+        self.assertEqual(again["mcpServers"]["rhwp"]["args"], ["mcp-serve"])
+
+    def test_args_are_copied_not_aliased(self):
+        shared = ["mcp-serve"]
+        snip = doc.build_mcp_snippet("rhwp", shared)
+        shared.append("--boom")
+        self.assertEqual(snip["mcpServers"]["rhwp"]["args"], ["mcp-serve"])
+
+
+class TestAggregate(unittest.TestCase):
+    def _chk(self, status, critical=True):
+        return {"id": "x", "status": status, "critical": critical}
+
+    def test_all_pass_is_zero(self):
+        ok, code = doc.aggregate([self._chk(doc.PASS), self._chk(doc.PASS)], binary_found=True)
+        self.assertTrue(ok)
+        self.assertEqual(code, 0)
+
+    def test_critical_fail_is_one(self):
+        ok, code = doc.aggregate([self._chk(doc.PASS), self._chk(doc.FAIL)], binary_found=True)
+        self.assertFalse(ok)
+        self.assertEqual(code, 1)
+
+    def test_critical_skip_is_not_ok(self):
+        ok, code = doc.aggregate([self._chk(doc.SKIP)], binary_found=True)
+        self.assertFalse(ok)
+        self.assertEqual(code, 1)
+
+    def test_binary_missing_is_three(self):
+        # 바이너리가 없으면 검사 목록이 비어 있어도 종료 코드 3(빌드 필요).
+        ok, code = doc.aggregate([], binary_found=False)
+        self.assertFalse(ok)
+        self.assertEqual(code, 3)
+
+    def test_noncritical_fail_does_not_sink_health(self):
+        ok, code = doc.aggregate([self._chk(doc.PASS), self._chk(doc.FAIL, critical=False)], binary_found=True)
+        self.assertTrue(ok)
+        self.assertEqual(code, 0)
+
+
+class TestRecipeMap(unittest.TestCase):
+    def test_missing_repo_marks_everything_absent(self):
+        with tempfile.TemporaryDirectory() as d:
+            rows = doc.resolve_recipe_map(Path(d))
+            self.assertEqual(len(rows), len(doc.RECIPES))
+            for r in rows:
+                self.assertFalse(r["skillExists"])
+                self.assertFalse(r["recipeExists"])
+
+    def test_detects_existing_skill_and_recipe(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            # 첫 레시피의 스킬 SKILL.md 를 만들어 실존 검출을 확인.
+            skill = doc.RECIPES[0]["skill"]
+            (root / ".claude" / "skills" / skill).mkdir(parents=True)
+            (root / ".claude" / "skills" / skill / "SKILL.md").write_text("x", encoding="utf-8")
+            # recipe 가 있는 항목 하나를 골라 파일 생성.
+            with_recipe = next(r for r in doc.RECIPES if r["recipe"])
+            rp = root / with_recipe["recipe"]
+            rp.parent.mkdir(parents=True, exist_ok=True)
+            rp.write_text("x", encoding="utf-8")
+
+            rows = doc.resolve_recipe_map(root)
+            by_skill = {r["skill"]: r for r in rows}
+            self.assertTrue(by_skill[skill]["skillExists"])
+            self.assertTrue(next(r for r in rows if r["recipe"] == with_recipe["recipe"])["recipeExists"])
+
+    def test_recipe_none_is_never_marked_existing(self):
+        # recipe 가 None 인 항목은 recipeExists 가 항상 False 여야 한다(빈 인용 방지).
+        rows = doc.resolve_recipe_map(doc.default_repo_root())
+        for r in rows:
+            if r["recipe"] is None:
+                self.assertFalse(r["recipeExists"])
+
+
+class TestPickSample(unittest.TestCase):
+    def test_none_when_absent(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertIsNone(doc.pick_sample(Path(d), None))
+
+    def test_override_wins_when_present(self):
+        with tempfile.TemporaryDirectory() as d:
+            f = Path(d) / "my.hwp"
+            f.write_text("x", encoding="utf-8")
+            self.assertEqual(doc.pick_sample(Path(d), str(f)), f)
+
+    def test_override_absent_returns_none(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertIsNone(doc.pick_sample(Path(d), str(Path(d) / "nope.hwp")))
+
+    def test_finds_candidate_in_tree(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            rel = doc.SAMPLE_CANDIDATES[0]
+            p = root / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("x", encoding="utf-8")
+            self.assertEqual(doc.pick_sample(root, None), p)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 무엇을 / 왜

에이전트는 **사소하게 채택 가능한** 도구를 기본값으로 고른다. 이 PR 은 rhwp 의 자발적 채택
레버로, "처음 보는 에이전트 → 설치·검증·MCP배선·첫 레시피까지"의 거리를 **한 명령**으로 줄인다.

`python tools/agent_onboarding/rhwp_doctor.py` (순수 Python 3 표준 라이브러리, 의존성 0) 하나가:

1. **바이너리 위치·버전** — `PATH` → `target/release/rhwp` 순으로 찾고 `rhwp --version` 확인. 없으면
   `cargo build --release --bin rhwp` 를 찍고 **exit 3** 으로 신호(긴 빌드를 대신 돌리지 않음).
2. **번들 샘플 자가검증** — `samples/basic/english.hwp` 로 `info` / `export-text --json` 을 돌려 구조
   출력을 확인. **통과를 위조하지 않는다** — 못 돌린 검사는 `SKIP`/`FAIL` 로 이유와 함께 보고.
3. **붙여넣기용 `.mcp.json` 방출** — `rhwp mcp-serve`. `PATH` 에 없으면 절대 경로를 채워준다.
   `--write <경로>`(기존 파일은 `--force` 없이 덮어쓰지 않음).
4. **첫 5분 레시피 지도** — 실존 스킬·레시피만 런타임 확인해 인용(트리아지·표 추출·서식 채우기·
   보안 스윕·작업 영수증).

`--json` 으로 기계 판독(stdout=리포트 JSON 하나), 종료 코드로 정상(0)/임계실패(1)/사용법(2)/
빌드필요(3)를 신호한다.

## 실제 닥터 출력 (이 저장소에서 실측)

바이너리를 빌드한 상태에서 `python tools/agent_onboarding/rhwp_doctor.py`:

```
rhwp doctor — 에이전트 제로프릭션 온보딩 점검
repo: .../rhwp-wt-onboard

[1] 바이너리 위치·버전
  [PASS] rhwp 발견: .../target/release/rhwp.exe  (source: target/release)
  [PASS] 바이너리 버전: rhwp --version
           → rhwp v0.8.4
  [PASS] 자가검증: info: rhwp info ".../samples/basic/english.hwp" --json
           → format=hwp5, pageCount=1, version=5.0.3.0
  [PASS] 자가검증: export-text: rhwp export-text ".../samples/basic/english.hwp" --json --max-chars 2000
           → pageCount=1, pages=1, 본문문자=1281

[2] 붙여넣기용 .mcp.json  (호스트 프로젝트 루트에 두거나 mcpServers 키를 병합)
  { "mcpServers": { "rhwp": { "command": "<절대경로>/rhwp.exe", "args": ["mcp-serve"] } } }

[3] 첫 5분 레시피 지도 (실존 스킬·레시피만 인용)
  · 문서 트리아지 …   스킬: rhwp-doc-triage [OK]
  · 표 추출 …         스킬: rhwp-table-exchange [OK]   레시피: recipes/02_… [OK]
  · 서식 채우기 …     스킬: rhwp-form-fill [OK]        레시피: recipes/01_… [OK]
  · 보안 스윕 …       스킬: rhwp-security-sweep [OK]   레시피: recipes/10_… [OK]
  · 작업 영수증 …     스킬: rhwp-work-receipt [OK]

판정: 정상 — 바로 붙여도 됩니다  (exit=0)
```

우아한 저하(바이너리 미빌드): 크래시·행 없이 `[FAIL] rhwp 미발견 … cargo build --release --bin rhwp`
를 찍고 `.mcp.json` 은 `command:"rhwp"` (PATH 형)로 방출, **exit 3**. `--json` 은 stdout 에 순수 JSON
하나만 낸다(실측 파싱 OK, exit 0).

## 5분 경로

1. `cargo build --release --bin rhwp` (최초 1회)
2. `python tools/agent_onboarding/rhwp_doctor.py`
3. 방출된 `.mcp.json` 을 호스트 루트에 붙임(또는 `--write`)
4. 첫 레시피 표(과제 → 명령 → 스킬 → 레시피)에서 하나 실행

정본: `mydocs/manual/agent_onboarding.md`.

## 변경 파일 (새 파일만)

- `tools/agent_onboarding/rhwp_doctor.py` — 닥터 + 부트스트랩
- `tools/agent_onboarding/test_rhwp_doctor.py` — 바이너리 불요 가드 테스트(16건)
- `mydocs/manual/agent_onboarding.md` — 5분 경로 문서(한글)
- `.claude/skills/rhwp-onboarding/SKILL.md` — 얇은 온보딩 스킬(닥터·문서로 라우팅)

`src/**` · MCP 서버 모듈 · `gym/tools/**` · `main.rs`/CLI 디스패치 · 기존 명령 파일 · `ci.yml` 은
**건드리지 않았다**(병렬 세션 소유 표면).

## 검증 (이 머신에서 실측)

- 닥터 end-to-end: 바이너리 빌드 후 전 검사 PASS · exit 0(위 출력).
- 우아한 저하: 빈 repo-root 로 exit 3, 크래시·행 없음. `--write` 덮어쓰기 보호 exit 2, `--force` 로 0.
- 가드 테스트: `python -m unittest tools/agent_onboarding/test_rhwp_doctor.py` → **16 passed**
  (바이너리 불요: `.mcp.json` 방출·집계 종료코드·레시피 실존·샘플 선택).
- 문서 링크: `python scripts/check_markdown_links.py` 두 신규 md 통과(이상 없음).
- Python + Markdown 만 변경 — rustfmt 불요.

## 후속 (이 PR 범위 밖)

- **CI 배선**: 가드 테스트를 `lint` 잡의 python unittest 목록에 한 줄로 추가하면 매 PR 에서 돈다.
  현재 그 영역을 병렬 세션들이 활발히 편집 중이라 앵커 충돌을 피해 이 PR 에서는 뺐다 — 별도
  1줄 배선 PR 로 남긴다.
- **Rust 하위명령**: `rhwp onboard`(닥터를 CLI 표면으로 승격)가 더 나을 수 있으나 `main.rs`/
  디스패치 소유 충돌을 피해 이번엔 Python + docs 로 유지한다.

Closes #4852
