### PR TITLE
test(batch): --threads 축 결정론·실패격리 회귀 테스트 (측정 우선 — batch 는 이미 병렬, ~8.6배)

### DIFF
--- a/tests/batch_parallel_determinism_contract.rs
+++ b/tests/batch_parallel_determinism_contract.rs
@@ -1,0 +1,188 @@
+//! 배치 병렬 처리량 축 — `--threads` 축에 대한 **결정론·실패 격리** 계약 회귀 테스트.
+//!
+//! `batch` 는 이미 병렬이다: 경계 있는 워커 풀 + 입력 순서 재정렬 버퍼(cap = `threads*8`) +
+//! 역압 + 파일별 `catch_unwind` 실패 격리 (`batch_stream_records`). 이 파일은 그 병렬성이
+//! 스레드 수와 무관하게 지켜야 할 관측 가능한 계약을 회귀로 고정한다.
+//!
+//! - 결정론: 같은 입력이면 `--threads` 값과 무관하게 stdout 이 바이트 단위로 동일하다 — 워커가 순서 밖으로 끝나도 방출은 입력 순서(저장소 철학 = 결정론).
+//! - 실패 격리: 읽을 수 없는 파일은 그 입력 위치의 실패 레코드가 되고 배치를 중단시키지 않는다 — 병렬 실행에서도 입력 N = 성공 + 실패, 부분 실패 exit 1.
+//! - 퇴화 입력: 빈 목록·단건·전건 실패에서 병렬 경로가 패닉·교착 없이 계약대로 끝난다.
+//!
+//! 기존 `batch_axes_contract.rs` 는 기본 스레드 수·입력 3건으로 순서를 보긴 하지만,
+//! `--threads` 를 고정해 서로 다른 스레드 수의 출력이 **동일한지**는 검증하지 않았고
+//! 재정렬 버퍼 용량을 넘겨 역압 경로를 태우지도 않았다. 이 파일이 그 공백을 메운다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+/// info 축은 가장 싸고 모든 HWP/HWPX 에서 견고해 병렬 계약 픽스처에 적합하다.
+/// 여섯 개의 **서로 다른** 정상 문서 — 레코드가 줄마다 달라 재정렬이 관측 가능하다.
+const GOOD: [&str; 6] = [
+    "samples/hwp3-sample.hwp",
+    "samples/table-001.hwp",
+    "samples/field-01.hwp",
+    "samples/test-image.hwpx",
+    "samples/추진일정.hwpx",
+    "samples/table-complex.hwp",
+];
+
+/// 저장소 안에 존재하지 않는 경로 — 읽기 실패로 실패 레코드가 되어야 한다.
+const MISSING: &str = "samples/__batch_parallel_no_such_file__.hwp";
+
+/// 실패를 끼워 넣는 입력 위치(0-based). 재정렬 버퍼 안팎에 골고루 둔다.
+const BAD_POSITIONS: [usize; 3] = [7, 18, 27];
+/// 총 입력 줄 수. `--threads 3` 의 cap(=24)을 넘겨 역압 경로를 태운다.
+const LINES: usize = 30;
+
+fn manifest(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+/// 두 계약 테스트가 공유하는 입력. 정상 문서를 돌려 쓰되 지정 위치에 실패를 끼운다.
+fn build_input() -> String {
+    let mut lines = Vec::with_capacity(LINES);
+    let mut g = 0usize;
+    for i in 0..LINES {
+        if BAD_POSITIONS.contains(&i) {
+            lines.push(manifest(MISSING).to_string_lossy().into_owned());
+        } else {
+            lines.push(
+                manifest(GOOD[g % GOOD.len()])
+                    .to_string_lossy()
+                    .into_owned(),
+            );
+            g += 1;
+        }
+    }
+    let mut body = lines.join("\n");
+    body.push('\n');
+    body
+}
+
+/// stdin 을 자식이 읽기 전에 종료하는 경로의 BrokenPipe 는 정상이므로 무시한다
+/// (`batch_axes_contract.rs` 와 같은 규약).
+fn write_stdin_ignoring_early_exit(child: &mut std::process::Child, body: &str) {
+    use std::io::ErrorKind;
+    if let Err(err) = child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(body.as_bytes())
+    {
+        assert_eq!(
+            err.kind(),
+            ErrorKind::BrokenPipe,
+            "stdin 쓰기 실패: {err:?}"
+        );
+    }
+}
+
+fn run(threads: &str, body: &str) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(["batch", "info", "--json", "--threads", threads])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("rhwp 실행 실패");
+    write_stdin_ignoring_early_exit(&mut child, body);
+    child.wait_with_output().expect("rhwp 종료 대기 실패")
+}
+
+fn records(out: &Output) -> Vec<serde_json::Value> {
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap_or_else(|e| panic!("NDJSON 아님 ({e}): {l}")))
+        .collect()
+}
+
+/// 계약 1: `--threads` 값이 달라도 stdout 이 바이트 단위로 동일하다(결정론).
+/// 직렬(=1)을 기준으로 역압 경로(3)와 완전 병렬(8)을 비교한다.
+#[test]
+fn batch_output_is_byte_identical_across_thread_counts() {
+    let body = build_input();
+    let serial = run("1", &body);
+    assert_eq!(
+        serial.status.code(),
+        Some(1),
+        "부분 실패이므로 exit 1 이어야 한다\nstderr:\n{}",
+        String::from_utf8_lossy(&serial.stderr)
+    );
+    // 1 은 정의상 입력 순서. 3 은 cap(24)<30 이라 역압, 8 은 완전 병렬.
+    for threads in ["3", "8"] {
+        let parallel = run(threads, &body);
+        assert_eq!(
+            parallel.stdout, serial.stdout,
+            "--threads {threads} 의 stdout 이 --threads 1 과 바이트 단위로 다르다 (결정론 위반)"
+        );
+        assert_eq!(
+            parallel.status.code(),
+            serial.status.code(),
+            "--threads {threads} 의 종료 코드가 --threads 1 과 다르다"
+        );
+    }
+}
+
+/// 계약 2: 병렬 실행에서도 실패는 **그 입력 위치에만** 나타나고 배치를 중단시키지 않는다.
+/// 레코드가 입력 순서로 나오므로 위치별 성공/실패가 그대로 관측된다.
+#[test]
+fn batch_failure_isolation_holds_under_parallel() {
+    let body = build_input();
+    let out = run("4", &body);
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "부분 실패 → exit 1\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let recs = records(&out);
+    // 입력 N = 성공 + 실패: 누락 없이 전건이 레코드가 된다.
+    assert_eq!(recs.len(), LINES, "레코드 수가 입력 줄 수와 다르다");
+    for (i, rec) in recs.iter().enumerate() {
+        let is_err = rec.get("error").is_some();
+        assert_eq!(
+            is_err,
+            BAD_POSITIONS.contains(&i),
+            "위치 {i} 의 실패 여부가 계약과 다르다: {rec}"
+        );
+        if is_err {
+            assert_eq!(rec["exitClass"], "runtime", "{rec}");
+        }
+    }
+    let failed = recs.iter().filter(|r| r.get("error").is_some()).count();
+    assert_eq!(failed, BAD_POSITIONS.len(), "실패 수가 주입 수와 다르다");
+}
+
+/// 계약 3: 병렬 경로가 빈 목록·단건·전건 실패에서 패닉·교착 없이 계약대로 끝난다.
+#[test]
+fn batch_parallel_handles_degenerate_inputs() {
+    // 빈 목록 → 레코드 0, exit 0.
+    let empty = run("8", "");
+    assert_eq!(empty.status.code(), Some(0), "빈 목록은 exit 0");
+    assert!(records(&empty).is_empty(), "빈 목록은 레코드 0");
+
+    // 단건 성공 → 레코드 1, 실패 없음, exit 0.
+    let one = run("8", &format!("{}\n", manifest(GOOD[0]).to_string_lossy()));
+    assert_eq!(one.status.code(), Some(0), "단건 성공은 exit 0");
+    let recs = records(&one);
+    assert_eq!(recs.len(), 1, "단건은 레코드 1");
+    assert!(
+        recs[0].get("error").is_none(),
+        "정상 문서인데 실패: {}",
+        recs[0]
+    );
+
+    // 전건 실패 → 레코드 3 전부 실패, exit 1 (격리가 스트림을 끝까지 유지).
+    let all_bad = format!("{m}\n{m}\n{m}\n", m = manifest(MISSING).to_string_lossy());
+    let bad = run("8", &all_bad);
+    assert_eq!(bad.status.code(), Some(1), "전건 실패는 exit 1");
+    let recs = records(&bad);
+    assert_eq!(recs.len(), 3, "전건 실패도 전건이 레코드");
+    assert!(
+        recs.iter().all(|r| r.get("error").is_some()),
+        "전건이 실패 레코드여야 한다"
+    );
+}


### PR DESCRIPTION
## 무엇을 / 왜

배치 병렬 **처리량 축**을 측정 우선으로 점검한 결과(#4872), `rhwp batch` 는 **이미 병렬**이었다:
`batch_stream_records` 가 경계 있는 워커 풀 + 입력 순서 재정렬 버퍼(cap = `threads*8`) + 역압 +
파일별 `catch_unwind` 실패 격리 + broken-pipe abort 로 구성돼 있고, `--threads N`(기본
`available_parallelism`) 도 이미 있다. 실측 처리량 이득도 크다(export-text 200건: 직렬 91.0s →
8스레드 10.6s, **약 8.6배**). 즉 "직렬 루프 병렬화" 라는 큰 변경은 **불필요**하다.

문제는 그 병렬성이 지켜야 할 **두 계약이 `--threads` 축에서 회귀 테스트로 고정돼 있지 않다**는
점이다. 기존 `batch_axes_contract.rs` 는 기본 스레드 수·입력 3건으로 순서만 볼 뿐, 서로 다른
스레드 수의 출력이 동일한지·재정렬 버퍼가 가득 차는 역압 구간을 검증하지 않는다. 이 PR 은
그 공백을 메우는 회귀 테스트만 추가한다(오케스트레이션 코드는 건드리지 않는다).

## 변경

`tests/batch_parallel_determinism_contract.rs` 신규 — `--threads` 축의 계약을 고정한다:

1. **결정론**: 같은 입력을 `--threads 1` / `3` / `8` 로 돌린 stdout 이 **바이트 단위로 동일**해야
   한다. 입력 30건·실패 3건을 섞고, `--threads 3` 의 cap(=24)<30 이라 **역압 경로까지** 태운다.
   워커가 순서 밖으로 끝나도 방출은 입력 순서여야 한다는 저장소 철학(결정론)을 못 박는다.
2. **실패 격리(병렬)**: 읽을 수 없는 파일이 **그 입력 위치의 실패 레코드**가 되고 배치를
   중단시키지 않는다 — 입력 N = 성공 + 실패, 부분 실패 exit 1. `--threads 4` 병렬 실행에서 검증.
3. **퇴화 입력**: 빈 목록·단건·전건 실패에서 병렬 경로가 패닉·교착 없이 계약대로 끝난다.

`info` 축을 픽스처로 쓴다(가장 싸고 모든 HWP/HWPX 에서 견고). 검증은 바이트 동치와 위치
대조라 **머신 부하와 무관하게 정확**하다.

## 측정 (정직 벤치)

- 환경: Windows 11, 논리 코어 32, rustc 1.93.1, `--release`. 코퍼스: `samples/` 대표 실문서를
  200개로 복제(약 542MB, 임시·커밋 안 함). 각 스레드 수 3회 최솟값, warm cache.
- **유의: 이 처리량 수치는 같은 머신에서 형제 세션이 동시에 돌아 CPU 약 50%가 점유된 상태에서
  측정됐다.** 고스레드 포화·역전은 경합이 섞인 값이므로 절대 배수를 과신하지 말 것. 반면
  결정론(동일 md5)은 부하와 무관하게 정확하다.

export-text 200건: 1스레드 91009ms(1.00x) → 2:38569(2.36x) → 4:20801(4.38x) → 8:10632(**8.56x**)
→ 16:10489(8.68x) → 32:13540(6.72x). 6종 전부 stdout md5 동일(`ccf1be03…`) = **결정론 확인**.

해석: 8스레드까지 거의 선형(8.6배)으로 병렬화는 코퍼스 축 이득을 **이미 제공**한다. 8~16에서
포화, 32에서 역전(파싱은 메모리 대역폭 바운드 성향 + 기본값이 초과구독일 수 있음, 경합 환경
가중). 값이 작은 info 가 export-text 보다 더 잘 확장되지 **않는** 점은 병목이 방출부 직렬화보다
파싱/대역폭 쪽임을 시사한다.

## 왜 코드(오케스트레이션)는 바꾸지 않았나 (정직 게이트)

- 병렬화·결정론·역압·격리는 **이미 올바르게** 구현돼 있다(위 실측). 재작성은 불필요한 churn.
- 기본 스레드 상한 조정·방출부 직렬화 오프로드는 후보지만, **경합 없는 유휴 머신에서 깨끗한
  델타를 측정하기 전에는** 실이득을 주장할 수 없다. 측정 못 한 이득은 주장하지 않는다. 이
  후보들은 #4872 에 향후 과제로 분리해 두었다.

## 검증

- `rustfmt --edition 2021`(저장소 rustfmt.toml: max_width 100 / Unix newline) — 신규 파일 fmt 안정.
- `cargo clippy --tests -- -D warnings` — 통과.
- `cargo test --test batch_parallel_determinism_contract --test batch_axes_contract` — 통과.
