### PR TITLE
docs: PR 후 local worktree 정리 명시

### DIFF
--- a/mydocs/manual/pr_review/collaborator_self_merge.md
+++ b/mydocs/manual/pr_review/collaborator_self_merge.md
@@ -83,4 +83,11 @@ gh pr merge N --repo edwardkim/rhwp --squash --admin \
 ~~~
 
 merge 뒤에는 이 PR 자체가 review 기록을 포함했는지와 issue 상태를 확인하기 위해
-[merge 후속 처리](post_merge.md)를 적용한다.
+[merge 후속 처리](post_merge.md)를 적용한다. 이 과정이 끝나면 이번 PR만을 위해 만든 local worktree는
+clean 상태와 다른 작업의 소유 여부를 확인한 뒤 제거한다. 단순히 다음 작업에 재사용할 편의만으로 유지하지
+않으며, 제거할 수 없는 활성 작업 또는 사용자 보존 지시가 있으면 그 사유와 경로를 최종 상태에 남긴다.
+
+작업지시자가 이 경로의 PR 병합과 `merge 후 후속 처리`를 승인했다면, 그 승인은 이번 PR 전용의 clean한
+local branch와 local worktree를 제거하는 데에도 적용된다. 따라서 조건을 만족한 뒤에는 별도의 "정리" 지시를
+기다리지 않고 후속 처리에서 제거한다. 이 승인은 원격 head branch 삭제, 기본 작업공간, 공유 target,
+사용자·다른 도구의 branch/worktree 삭제에는 적용되지 않으며, 그 대상은 별도 승인과 소유 확인이 필요하다.

--- a/mydocs/manual/pr_review/post_merge.md
+++ b/mydocs/manual/pr_review/post_merge.md
@@ -24,6 +24,11 @@ last_verified: 2026-08-09
 시각 asset URL을 comment에 쓰면 asset이 devel에 실제 존재한 뒤에만 게시한다. 이미 완료된 원 PR의 기록만
 담는 별도 fast-pass PR은 5–6과 오늘할일 갱신을 반복하지 않고, devel sync와 cleanup만 수행한다.
 
+작업지시자가 PR 병합과 `merge 후 후속 처리`를 함께 승인한 경우, 7번은 선택 보고가 아니라 완료 전 실행
+게이트다. 해당 PR만을 위해 만든 clean한 local branch와 local worktree의 제거는 별도 승인 없이 이 단계에서
+수행한다. 원격 branch 삭제나 기본 작업공간·공유 산출물·사용자 또는 다른 도구 소유 대상의 삭제는 포함하지
+않는다.
+
 ## 7.5 renderer golden 선행조건
 
 renderer 영향 PR의 golden 재생성은 원 PR merge 전에
@@ -185,6 +190,16 @@ heavy worker skip, final aggregate, issue 상태를 PR comment에 남긴다. 반
 성공 merge뿐 아니라 reject/close, supersede, review 중단, 후속 기록 fast-pass 완료도 최종 종료 gate다.
 정리 또는 유지 사유를 확인하기 전에는 후속 처리 완료라고 보고하지 않는다.
 
+이번 PR 또는 검토만을 위해 만든 별도 local worktree는 merge와 필수 후속 처리가 끝난 뒤 **제거가 기본**이다.
+다음 작업의 편의를 위한 보존은 유지 사유가 아니다. 제거 전에는 clean 상태와 사용자·다른 도구의 소유 여부를
+확인하며, 활성 작업 또는 작업지시자의 명시 보존 지시 때문에 제거하지 못하면 정확한 경로와 사유를 최종 상태에
+기록한다. 기본 작업공간, 공유 `target/pr-review`, 사용자·다른 도구가 만든 worktree는 이 규칙의 삭제 대상이
+아니다.
+
+대상 worktree는 자기 자신을 제거할 수 없으므로, 정리 명령은 반드시 보존할 기본 작업공간 또는 다른 clean
+worktree에서 실행한다. merge가 성공한 것만 확인하고 대상 worktree에 그대로 남아 "후속 처리 완료"로
+보고해서는 안 된다.
+
 먼저 정확한 대상 이름과 worktree를 확인한다.
 
 ~~~bash
@@ -232,6 +247,9 @@ git branch -vv | rg ': gone\]' || true
 git ls-remote --heads upstream <headRefName>
 git status --short --branch
 ~~~
+
+최종 보고에는 이번 작업에서 사용한 각 local worktree를 `제거 완료` 또는 `유지`로 구분해 경로와 사유를
+기록한다. 이 확인 없이 PR 병합만으로 후속 처리가 완료된 것으로 보고하지 않는다.
 
 contributor fork의 head는 위 `upstream` 조회 대상이 아니다. PR metadata의 `headRepository`와
 `headRefName`을 기록하고, fork branch 삭제를 시도하지 않은 사실을 최종 상태에 남긴다.

--- a/mydocs/orders/20260816.md
+++ b/mydocs/orders/20260816.md
@@ -1,0 +1,14 @@
+# 오늘 할 일 - 2026년 8월 16일
+
+## PR #4880 - PR 후 local worktree 정리 명시
+
+- collaborator self-merge의 merge 및 후속 처리 승인이 해당 PR만을 위해 만든 clean한 local branch와
+  local worktree의 제거까지 포함하도록 절차를 보완했다.
+- merge 후 cleanup은 선택적 보고가 아닌 종료 게이트이며, 대상 worktree를 제거할 때는 기본 작업공간 또는
+  다른 보존 worktree에서 실행해야 한다. 대상 worktree 자신은 스스로를 제거할 수 없다.
+- 원격 head branch, 기본 작업공간, 공유 `target/pr-review`, 사용자 또는 다른 도구 소유 branch/worktree는
+  별도 승인과 소유 확인 없이는 정리하지 않는다.
+- [PR #4880](https://github.com/edwardkim/rhwp/pull/4880)을 `devel` 대상으로 Open 생성했다. collaborator
+  self PR이므로 reviewer는 지정하지 않았고, [자체검토 기록](../pr/archives/pr_4880_review.md)에 문서 전용
+  검증과 병합 조건을 남겼다. 최신 trailing head의 GitHub Actions, `MERGEABLE`/`CLEAN`, 작업지시자 승인 전에는
+  병합하지 않는다.

--- a/mydocs/pr/archives/pr_4880_review.md
+++ b/mydocs/pr/archives/pr_4880_review.md
@@ -1,0 +1,53 @@
+---
+kind: pr-review
+status: pending-ci
+pr: 4880
+author: jangster77
+base: devel
+head: codex/local-worktree-cleanup-policy
+last_verified: 2026-08-16
+---
+
+# PR #4880 자체검토 - PR 후 local worktree 정리 명시
+
+## PR metadata
+
+| 항목 | 작성 시점 참고값 |
+| --- | --- |
+| PR | [#4880](https://github.com/edwardkim/rhwp/pull/4880) |
+| 작성자 | `jangster77` (collaborator self-review) |
+| base / head | `devel` / `codex/local-worktree-cleanup-policy` |
+| code candidate | `7b427b40b` |
+| 변경 범위 | `mydocs/manual/pr_review/` 아래 절차 문서 2개 |
+
+collaborator 자체 PR이므로 reviewer를 지정하지 않았다. 현재 문서는 review·오늘할일 trailing commit을
+추가하는 중의 기록이며, merge 직전에 최신 head, GitHub Actions, mergeability를 다시 확인한다.
+
+## 변경 검토
+
+- self-merge의 merge·후속 처리 승인은 해당 PR 전용 local branch와 local worktree의 cleanup까지 포함한다고
+  명시했다.
+- cleanup은 선택적 상태 보고가 아니라 merge 후 종료 게이트이며, 대상 worktree 자신이 아닌 보존 worktree에서
+  실행해야 한다.
+- remote branch, 기본 작업공간, 공유 `target/pr-review`, 사용자 또는 다른 도구 소유 대상은 이 승인 범위에서
+  제외해 기존 소유권 보호를 유지한다.
+
+## 검증 결과
+
+| 검증 | 결과 |
+| --- | --- |
+| `git diff --cached --check` | 통과 |
+| 변경 경로 확인 | `collaborator_self_merge.md`, `post_merge.md`만 변경 |
+| 링크 경로 확인 | `post_merge.md` 상대 링크가 존재함을 확인 |
+| Cargo/npm/WASM | `mydocs` 전용 변경이므로 `local_validation.md` 4.3에 따라 미적용 |
+
+## 위험과 병합 조건
+
+- local cleanup은 이번 PR 전용이고 clean하며 다른 작업의 소유가 아님을 확인한 경우에만 자동으로 수행된다.
+- cleanup 승인 범위가 remote branch나 기본 작업공간까지 확장되지 않도록 절차 문구를 제한했다.
+- review·오늘할일 trailing head의 GitHub Actions 통과, `MERGEABLE`/`CLEAN` 확인, 작업지시자 승인이 필요하다.
+
+## 최종 권고
+
+**보류.** 문서 전용 local 검증은 통과했다. trailing 문서 commit의 CI와 최신 mergeability를 확인한 뒤
+작업지시자 승인에 따라 병합한다.


### PR DESCRIPTION
## 변경

- collaborator self-merge의 병합·후속 처리 승인에 해당 PR 전용 local branch/worktree 정리를 포함했습니다.
- merge 후속 처리에서 cleanup을 선택 보고가 아닌 종료 게이트로 정하고, 대상 worktree와 다른 보존 worktree에서 정리하도록 명시했습니다.
- 원격 branch, 기본 작업공간, 공유 target, 사용자 또는 다른 도구 소유 worktree는 별도 승인 없이는 정리 대상이 아님을 유지했습니다.

## 검증

- `git diff --cached --check`
- 변경 범위 확인: `mydocs/manual/pr_review/collaborator_self_merge.md`, `mydocs/manual/pr_review/post_merge.md`
- mydocs 전용 변경이므로 `local_validation.md` 4.3에 따라 Cargo 검증은 적용하지 않았습니다.
