### PR TITLE
fix: CanvasKit KoPub SFNT 원본 사용

### DIFF
--- a/mydocs/orders/20260816.md
+++ b/mydocs/orders/20260816.md
@@ -21,4 +21,6 @@
   빌드도 통과했다. 페이지네이션, Rust, fixture는 변경하지 않았다.
 - [PR #4881](https://github.com/edwardkim/rhwp/pull/4881)을 `devel` 대상으로 Open 생성했다. collaborator self
   PR이므로 reviewer는 지정하지 않았으며, [자체검토 기록](../pr/archives/pr_4881_review.md)에 브라우저 확인 범위와
-  최신 CI·mergeability 재확인 조건을 남겼다.
+  최신 CI·mergeability 재확인 조건을 남겼다. 기록 당시 head `2102eead0`의 CI preflight, frontend package,
+  CodeQL JavaScript/TypeScript, Canvas visual diff, Build & Test는 모두 통과했고 `MERGEABLE`/`CLEAN`이었다.
+  이 CI 결과를 반영하는 문서 전용 trailing commit의 최신 CI도 merge 전 다시 확인한다.

--- a/mydocs/orders/20260816.md
+++ b/mydocs/orders/20260816.md
@@ -12,3 +12,13 @@
   self PR이므로 reviewer는 지정하지 않았고, [자체검토 기록](../pr/archives/pr_4880_review.md)에 문서 전용
   검증과 병합 조건을 남겼다. 최신 trailing head의 GitHub Actions, `MERGEABLE`/`CLEAN`, 작업지시자 승인 전에는
   병합하지 않는다.
+
+## PR #4881 - CanvasKit KoPub SFNT 원본 사용
+
+- CSS 웹폰트의 WOFF/WOFF2 경로는 유지하고, CanvasKit 직접 렌더링에만 KoPub TTF/OTF SFNT 원본을 사용하도록
+  분리했다. 압축 웹폰트 바이트를 CanvasKit에 직접 전달해 발생할 수 있는 글리프·메트릭 차이를 줄이는 보정이다.
+- `npm test`는 936개 통과, 0개 실패, 1개 skip으로 완료했고, CanvasKit 커버리지·프로덕션 빌드·WASM 패키지
+  빌드도 통과했다. 페이지네이션, Rust, fixture는 변경하지 않았다.
+- [PR #4881](https://github.com/edwardkim/rhwp/pull/4881)을 `devel` 대상으로 Open 생성했다. collaborator self
+  PR이므로 reviewer는 지정하지 않았으며, [자체검토 기록](../pr/archives/pr_4881_review.md)에 브라우저 확인 범위와
+  최신 CI·mergeability 재확인 조건을 남겼다.

--- a/mydocs/pr/archives/pr_4881_review.md
+++ b/mydocs/pr/archives/pr_4881_review.md
@@ -57,6 +57,22 @@ loaded documents: `pr_review_workflow.md`, `pr_review/README.md`, `collaborator_
 이번 PR의 SFNT 선택은 단위 계약으로 검증했으며, #4764의 실제 문서 PDF 대조와 페이지 수 결론은 별도 근거로
 계속 확인한다.
 
+## GitHub CI 결과
+
+기록 당시 code candidate `2102eead0`에서 GitHub Actions를 완료까지 관찰했다.
+
+| CI | 결과 |
+| --- | --- |
+| CI preflight | 성공 |
+| Frontend package gates | 성공 |
+| Build & Test | 성공 |
+| CodeQL JavaScript/TypeScript 분석 | 성공 |
+| Canvas visual diff | 성공 (6분 24초) |
+| Rust lint, Native Skia, WASM Build, Rust test shards | 프론트 변경 범위에 따른 정상 skip |
+
+완료 시점 참고값은 `MERGEABLE`/`CLEAN`이었다. 이 문서 commit은 review·오늘할일만 변경하므로 새 trailing
+head의 CI와 mergeability를 merge 직전에 다시 확인한다.
+
 ## 위험과 병합 조건
 
 - CDN의 SFNT 원본 URL이 제공되는 동안에만 CanvasKit 직접 렌더링이 해당 원본을 사용한다. 기존 offline
@@ -68,5 +84,5 @@ loaded documents: `pr_review_workflow.md`, `pr_review/README.md`, `collaborator_
 
 ## 최종 권고
 
-**보류.** 로컬 프론트 검증은 통과했다. trailing 문서 commit의 최신 CI와 mergeability를 확인한 뒤
-작업지시자 승인에 따라 병합한다.
+**보류.** 로컬 프론트 검증과 code candidate GitHub CI는 통과했다. trailing 문서 commit의 최신 CI와
+mergeability를 확인한 뒤 작업지시자 승인에 따라 병합한다.

--- a/mydocs/pr/archives/pr_4881_review.md
+++ b/mydocs/pr/archives/pr_4881_review.md
@@ -1,0 +1,72 @@
+---
+kind: pr-review
+status: pending-ci
+pr: 4881
+author: jangster77
+base: devel
+head: codex/4764-kopub-canvaskit-sfnt
+last_verified: 2026-08-16
+---
+
+# PR #4881 자체검토 - CanvasKit KoPub SFNT 원본 사용
+
+## PR metadata
+
+| 항목 | 작성 시점 참고값 |
+| --- | --- |
+| PR | [#4881](https://github.com/edwardkim/rhwp/pull/4881) |
+| 작성자 | `jangster77` (collaborator self-review) |
+| base / head | `devel` / `codex/4764-kopub-canvaskit-sfnt` |
+| code candidate | `13462cbaa` |
+| 변경 범위 | CanvasKit 글꼴 계획, 해당 계약 테스트, stage 문서 |
+| 관련 이슈 | [#4764](https://github.com/edwardkim/rhwp/issues/4764) |
+
+collaborator 자체 PR이므로 reviewer를 지정하지 않았다. 이 문서는 review·오늘할일 trailing commit을 추가하는
+중의 기록이며, merge 직전에 최신 head, GitHub Actions, mergeability를 다시 확인한다.
+
+base route: `collaborator_self_merge.md`
+
+modifiers: `intake_and_review.md`, `local_validation.md`, `visual_fixture_evidence.md`
+
+loaded documents: `pr_review_workflow.md`, `pr_review/README.md`, `collaborator_self_merge.md`,
+`intake_and_review.md`, `local_validation.md`, `visual_fixture_evidence.md`
+
+## 변경 검토
+
+- CSS `FontFace`는 기존 KoPub WOFF/WOFF2 URL과 전송 형식을 그대로 유지한다.
+- `resolveCanvasKitFontPlan`만 `canvasKitFile`을 선택해 KoPub은 TTF, KoPubWorld는 OTF SFNT 원본을 CanvasKit에
+  전달한다.
+- 같은 SFNT 원본을 공유하는 별칭을 URL 단위로 묶어 기존 중복 방지 계약을 보존한다.
+- SFNT 원본 URL을 지정하는 KoPub·KoPubWorld 테스트를 추가했다.
+- 페이지네이션, Rust, HWP/HWPX fixture, 기준 PDF는 변경하지 않았다. 따라서 이 PR은 #4764 전체를 닫지 않는다.
+
+## 검증 결과
+
+| 검증 | 결과 |
+| --- | --- |
+| `wasm-pack build --target web --out-dir pkg` | 통과 |
+| `cd rhwp-studio && npm test` | 936 passed, 0 failed, 1 skipped |
+| `cd rhwp-studio && node --test tests/page-margin-guides.test.ts` | 3 passed |
+| `cd rhwp-studio && node --test tests/canvaskit-font-plan.test.ts` | 4 passed |
+| `cd rhwp-studio && npm run e2e:canvaskit-font-coverage` | 통과 |
+| `cd rhwp-studio && npm run build` | 통과 |
+| `git diff --check` | 통과 |
+| `http://127.0.0.1:7700` browser shell | 기동 및 console error 0건 확인 |
+
+브라우저 자동화의 숨김 file input 선택 이벤트 제한으로 기준 HWP를 자동 업로드해 캔버스 픽셀을 대조하지는 못했다.
+이번 PR의 SFNT 선택은 단위 계약으로 검증했으며, #4764의 실제 문서 PDF 대조와 페이지 수 결론은 별도 근거로
+계속 확인한다.
+
+## 위험과 병합 조건
+
+- CDN의 SFNT 원본 URL이 제공되는 동안에만 CanvasKit 직접 렌더링이 해당 원본을 사용한다. 기존 offline
+  fail-closed 판정은 CSS URL과 CanvasKit URL을 모두 확인하도록 유지했다.
+- CanvasKit에 전달하는 TTF/OTF는 CSS WOFF/WOFF2보다 크므로, 문서에서 해당 글꼴을 요청한 경우에만 기존 계획
+  단계에서 fetch된다.
+- review·오늘할일 trailing head의 GitHub Actions 통과, 최신 `MERGEABLE`/`CLEAN` 확인, 작업지시자 승인이
+  필요하다.
+
+## 최종 권고
+
+**보류.** 로컬 프론트 검증은 통과했다. trailing 문서 commit의 최신 CI와 mergeability를 확인한 뒤
+작업지시자 승인에 따라 병합한다.

--- a/mydocs/working/task_m100_4764_stage1_kopub_canvaskit_sfnt.md
+++ b/mydocs/working/task_m100_4764_stage1_kopub_canvaskit_sfnt.md
@@ -1,0 +1,36 @@
+---
+kind: work-stage
+status: active
+issue: 4764
+stage: 1
+last_verified: 2026-08-16
+---
+
+# Stage 1 - KoPub CanvasKit SFNT 원본 연결
+
+## 관찰
+
+- [#4764](https://github.com/edwardkim/rhwp/issues/4764)는 #3820에서 고정한 383/82/17 페이지 수를 바꾸지
+  않고 HWP 2020 PDF와의 잔여 raster fidelity를 개선한다.
+- 2025 행정업무운영 편람 화면 비교에서 문서 선언 `KoPub돋움체 Light`가 CDN으로 로드됐어도 PDF와 글리프
+  형태·폭이 다르게 보였다.
+- CSS `FontFace`는 브라우저 Canvas2D에는 적용되지만 CanvasKit은 별도 font byte source를 fetch해 native
+  `Typeface`/`FontMgr`로 준비한다. 기존 CanvasKit plan은 CSS와 같은 KoPub WOFF/KoPubWorld WOFF2를
+  사용했다.
+
+## 원인과 보정
+
+- jsDelivr `font-kopub@1.0.2`는 같은 KoPub face의 WOFF와 TTF를 함께 제공한다. `font-kopubworld@1.0.3`는
+  WOFF2와 OTF를 함께 제공한다.
+- CSS는 네트워크 비용이 작은 기존 WOFF/WOFF2를 계속 사용한다. CanvasKit plan에는 `canvasKitFile`을 추가해
+  FreeType/Skia가 직접 해석할 TTF/OTF SFNT 원본을 선택한다.
+- 문서 글꼴명과 동의어는 같은 CanvasKit source URL로 묶되, source 비교도 CSS URL이 아닌 CanvasKit URL로
+  수행한다.
+
+## 회귀 계약
+
+- `canvaskit-font-plan.test.ts`는 KoPub돋움·KoPub바탕·KoPubWorld돋움·KoPubWorld바탕의 CanvasKit URL이
+  각각 TTF/OTF임을 고정한다.
+- 기존 CSS loader 계약은 WOFF/WOFF2 URL을 계속 요청해 웹 표면의 다운로드 형식을 바꾸지 않는다.
+- 이 stage는 페이지 수·Rust layout·fixture를 변경하지 않는다. 후속 browser/PDF 비교는 같은 383/82/17
+  페이지 수와 #4764의 HWP 2020 PDF 대응표를 유지한다.

--- a/rhwp-studio/src/core/font-loader.ts
+++ b/rhwp-studio/src/core/font-loader.ts
@@ -11,6 +11,8 @@ interface FontEntry {
   file: string;
   /** woff2(기본), woff, truetype 또는 opentype — CDN 원본 글꼴 파일용 */
   format?: 'woff2' | 'woff' | 'truetype' | 'opentype';
+  /** CanvasKit이 직접 해석할 SFNT 원본. CSS 웹폰트와 다른 경우에만 지정한다. */
+  canvasKitFile?: string;
   /** CSS unicode-range — 지정 시 해당 코드포인트만 매칭, 다운로드도 해당 영역 사용 시에만 발생 */
   unicodeRange?: string;
 }
@@ -136,35 +138,35 @@ const FONT_LIST: FontEntry[] = [
   { name: 'Government_16040911', file: CDN_GOVERNMENT_SYMBOL_REGULAR, format: 'truetype' },
   { name: '정부상징 부처명_16040911', file: CDN_GOVERNMENT_SYMBOL_REGULAR, format: 'truetype' },
   // === KoPub (KOPUS 공개 패키지, 문서 요청 시에만 CDN 로드) ===
-  { name: 'KoPub돋움체 Light', file: `${CDN_KOPUB}/KoPubDotum-Light.woff`, format: 'woff' },
-  { name: 'KoPub돋움체 Medium', file: `${CDN_KOPUB}/KoPubDotum-Medium.woff`, format: 'woff' },
-  { name: 'KoPub돋움체 Bold', file: `${CDN_KOPUB}/KoPubDotum-Bold.woff`, format: 'woff' },
-  { name: 'KoPub바탕체 Light', file: `${CDN_KOPUB}/KoPubBatang-Light.woff`, format: 'woff' },
-  { name: 'KoPub바탕체 Medium', file: `${CDN_KOPUB}/KoPubBatang-Medium.woff`, format: 'woff' },
-  { name: 'KoPub바탕체 Bold', file: `${CDN_KOPUB}/KoPubBatang-Bold.woff`, format: 'woff' },
-  { name: 'KoPubDotum Light', file: `${CDN_KOPUB}/KoPubDotum-Light.woff`, format: 'woff' },
-  { name: 'KoPubDotum Medium', file: `${CDN_KOPUB}/KoPubDotum-Medium.woff`, format: 'woff' },
-  { name: 'KoPubDotum Bold', file: `${CDN_KOPUB}/KoPubDotum-Bold.woff`, format: 'woff' },
-  { name: 'KoPubBatang Light', file: `${CDN_KOPUB}/KoPubBatang-Light.woff`, format: 'woff' },
-  { name: 'KoPubBatang Medium', file: `${CDN_KOPUB}/KoPubBatang-Medium.woff`, format: 'woff' },
-  { name: 'KoPubBatang Bold', file: `${CDN_KOPUB}/KoPubBatang-Bold.woff`, format: 'woff' },
-  { name: 'KoPubDotumLight', file: `${CDN_KOPUB}/KoPubDotum-Light.woff`, format: 'woff' },
-  { name: 'KoPubDotumMedium', file: `${CDN_KOPUB}/KoPubDotum-Medium.woff`, format: 'woff' },
-  { name: 'KoPubDotumBold', file: `${CDN_KOPUB}/KoPubDotum-Bold.woff`, format: 'woff' },
-  { name: 'KoPubBatangLight', file: `${CDN_KOPUB}/KoPubBatang-Light.woff`, format: 'woff' },
-  { name: 'KoPubBatangMedium', file: `${CDN_KOPUB}/KoPubBatang-Medium.woff`, format: 'woff' },
-  { name: 'KoPubBatangBold', file: `${CDN_KOPUB}/KoPubBatang-Bold.woff`, format: 'woff' },
+  { name: 'KoPub돋움체 Light', file: `${CDN_KOPUB}/KoPubDotum-Light.woff`, format: 'woff', canvasKitFile: `${CDN_KOPUB}/KoPubDotum-Light.ttf` },
+  { name: 'KoPub돋움체 Medium', file: `${CDN_KOPUB}/KoPubDotum-Medium.woff`, format: 'woff', canvasKitFile: `${CDN_KOPUB}/KoPubDotum-Medium.ttf` },
+  { name: 'KoPub돋움체 Bold', file: `${CDN_KOPUB}/KoPubDotum-Bold.woff`, format: 'woff', canvasKitFile: `${CDN_KOPUB}/KoPubDotum-Bold.ttf` },
+  { name: 'KoPub바탕체 Light', file: `${CDN_KOPUB}/KoPubBatang-Light.woff`, format: 'woff', canvasKitFile: `${CDN_KOPUB}/KoPubBatang-Light.ttf` },
+  { name: 'KoPub바탕체 Medium', file: `${CDN_KOPUB}/KoPubBatang-Medium.woff`, format: 'woff', canvasKitFile: `${CDN_KOPUB}/KoPubBatang-Medium.ttf` },
+  { name: 'KoPub바탕체 Bold', file: `${CDN_KOPUB}/KoPubBatang-Bold.woff`, format: 'woff', canvasKitFile: `${CDN_KOPUB}/KoPubBatang-Bold.ttf` },
+  { name: 'KoPubDotum Light', file: `${CDN_KOPUB}/KoPubDotum-Light.woff`, format: 'woff', canvasKitFile: `${CDN_KOPUB}/KoPubDotum-Light.ttf` },
+  { name: 'KoPubDotum Medium', file: `${CDN_KOPUB}/KoPubDotum-Medium.woff`, format: 'woff', canvasKitFile: `${CDN_KOPUB}/KoPubDotum-Medium.ttf` },
+  { name: 'KoPubDotum Bold', file: `${CDN_KOPUB}/KoPubDotum-Bold.woff`, format: 'woff', canvasKitFile: `${CDN_KOPUB}/KoPubDotum-Bold.ttf` },
+  { name: 'KoPubBatang Light', file: `${CDN_KOPUB}/KoPubBatang-Light.woff`, format: 'woff', canvasKitFile: `${CDN_KOPUB}/KoPubBatang-Light.ttf` },
+  { name: 'KoPubBatang Medium', file: `${CDN_KOPUB}/KoPubBatang-Medium.woff`, format: 'woff', canvasKitFile: `${CDN_KOPUB}/KoPubBatang-Medium.ttf` },
+  { name: 'KoPubBatang Bold', file: `${CDN_KOPUB}/KoPubBatang-Bold.woff`, format: 'woff', canvasKitFile: `${CDN_KOPUB}/KoPubBatang-Bold.ttf` },
+  { name: 'KoPubDotumLight', file: `${CDN_KOPUB}/KoPubDotum-Light.woff`, format: 'woff', canvasKitFile: `${CDN_KOPUB}/KoPubDotum-Light.ttf` },
+  { name: 'KoPubDotumMedium', file: `${CDN_KOPUB}/KoPubDotum-Medium.woff`, format: 'woff', canvasKitFile: `${CDN_KOPUB}/KoPubDotum-Medium.ttf` },
+  { name: 'KoPubDotumBold', file: `${CDN_KOPUB}/KoPubDotum-Bold.woff`, format: 'woff', canvasKitFile: `${CDN_KOPUB}/KoPubDotum-Bold.ttf` },
+  { name: 'KoPubBatangLight', file: `${CDN_KOPUB}/KoPubBatang-Light.woff`, format: 'woff', canvasKitFile: `${CDN_KOPUB}/KoPubBatang-Light.ttf` },
+  { name: 'KoPubBatangMedium', file: `${CDN_KOPUB}/KoPubBatang-Medium.woff`, format: 'woff', canvasKitFile: `${CDN_KOPUB}/KoPubBatang-Medium.ttf` },
+  { name: 'KoPubBatangBold', file: `${CDN_KOPUB}/KoPubBatang-Bold.woff`, format: 'woff', canvasKitFile: `${CDN_KOPUB}/KoPubBatang-Bold.ttf` },
   // === KoPubWorld (KOPUS 공개 글꼴, 문서 요청 시에만 CDN 로드) ===
-  { name: 'KoPubWorld돋움체 Light', file: `${CDN_KOPUB_WORLD}/KoPubWorld-Dotum-Light.woff2` },
-  { name: 'KoPubWorld돋움체 Medium', file: `${CDN_KOPUB_WORLD}/KoPubWorld-Dotum-Medium.woff2` },
-  { name: 'KoPubWorld돋움체 Bold', file: `${CDN_KOPUB_WORLD}/KoPubWorld-Dotum-Bold.woff2` },
-  { name: 'KoPubWorld바탕체 Light', file: `${CDN_KOPUB_WORLD}/KoPubWorld-Batang-Light.woff2` },
-  { name: 'KoPubWorld바탕체 Medium', file: `${CDN_KOPUB_WORLD}/KoPubWorld-Batang-Medium.woff2` },
-  { name: 'KoPubWorld바탕체 Bold', file: `${CDN_KOPUB_WORLD}/KoPubWorld-Batang-Bold.woff2` },
-  { name: 'KoPubWorld Dotum', file: `${CDN_KOPUB_WORLD}/KoPubWorld-Dotum-Medium.woff2` },
-  { name: 'KoPubWorld Batang', file: `${CDN_KOPUB_WORLD}/KoPubWorld-Batang-Medium.woff2` },
-  { name: 'KoPubWorldDotum', file: `${CDN_KOPUB_WORLD}/KoPubWorld-Dotum-Medium.woff2` },
-  { name: 'KoPubWorldBatang', file: `${CDN_KOPUB_WORLD}/KoPubWorld-Batang-Medium.woff2` },
+  { name: 'KoPubWorld돋움체 Light', file: `${CDN_KOPUB_WORLD}/KoPubWorld-Dotum-Light.woff2`, canvasKitFile: `${CDN_KOPUB_WORLD}/KoPubWorld-Dotum-Light.otf` },
+  { name: 'KoPubWorld돋움체 Medium', file: `${CDN_KOPUB_WORLD}/KoPubWorld-Dotum-Medium.woff2`, canvasKitFile: `${CDN_KOPUB_WORLD}/KoPubWorld-Dotum-Medium.otf` },
+  { name: 'KoPubWorld돋움체 Bold', file: `${CDN_KOPUB_WORLD}/KoPubWorld-Dotum-Bold.woff2`, canvasKitFile: `${CDN_KOPUB_WORLD}/KoPubWorld-Dotum-Bold.otf` },
+  { name: 'KoPubWorld바탕체 Light', file: `${CDN_KOPUB_WORLD}/KoPubWorld-Batang-Light.woff2`, canvasKitFile: `${CDN_KOPUB_WORLD}/KoPubWorld-Batang-Light.otf` },
+  { name: 'KoPubWorld바탕체 Medium', file: `${CDN_KOPUB_WORLD}/KoPubWorld-Batang-Medium.woff2`, canvasKitFile: `${CDN_KOPUB_WORLD}/KoPubWorld-Batang-Medium.otf` },
+  { name: 'KoPubWorld바탕체 Bold', file: `${CDN_KOPUB_WORLD}/KoPubWorld-Batang-Bold.woff2`, canvasKitFile: `${CDN_KOPUB_WORLD}/KoPubWorld-Batang-Bold.otf` },
+  { name: 'KoPubWorld Dotum', file: `${CDN_KOPUB_WORLD}/KoPubWorld-Dotum-Medium.woff2`, canvasKitFile: `${CDN_KOPUB_WORLD}/KoPubWorld-Dotum-Medium.otf` },
+  { name: 'KoPubWorld Batang', file: `${CDN_KOPUB_WORLD}/KoPubWorld-Batang-Medium.woff2`, canvasKitFile: `${CDN_KOPUB_WORLD}/KoPubWorld-Batang-Medium.otf` },
+  { name: 'KoPubWorldDotum', file: `${CDN_KOPUB_WORLD}/KoPubWorld-Dotum-Medium.woff2`, canvasKitFile: `${CDN_KOPUB_WORLD}/KoPubWorld-Dotum-Medium.otf` },
+  { name: 'KoPubWorldBatang', file: `${CDN_KOPUB_WORLD}/KoPubWorld-Batang-Medium.woff2`, canvasKitFile: `${CDN_KOPUB_WORLD}/KoPubWorld-Batang-Medium.otf` },
   // === Noonnu에서 웹사이트 사용 가능으로 확인된 문서 사용 글꼴 ===
   { name: '경기천년바탕 Bold', file: `${CDN_GYEONGGI_MILLENNIUM}/Batang_Regular.woff`, format: 'woff' },
   { name: '경기천년바탕 Regular', file: `${CDN_GYEONGGI_MILLENNIUM}/Batang_Regular.woff`, format: 'woff' },
@@ -313,10 +315,12 @@ export function resolveCanvasKitFontPlan(
       unavailableFonts.set(normalized, requested.trim());
       continue;
     }
-    const localFile = entry.file.startsWith('fonts/')
-      ? entry.file.slice('fonts/'.length)
+    const canvasKitFile = entry.canvasKitFile ?? entry.file;
+    const localFile = canvasKitFile.startsWith('fonts/')
+      ? canvasKitFile.slice('fonts/'.length)
       : null;
-    const unavailable = (options.disableExternalWebFonts === true && isExternalFontFile(entry.file))
+    const unavailable = (options.disableExternalWebFonts === true
+      && (isExternalFontFile(entry.file) || isExternalFontFile(canvasKitFile)))
       || (localFile !== null
         && options.availableLocalFiles !== undefined
         && !options.availableLocalFiles.has(localFile));
@@ -328,11 +332,12 @@ export function resolveCanvasKitFontPlan(
   }
 
   for (const { entry, requested } of requiredEntries) {
-    const url = canvasKitFontUrl(entry.file, options.localFontBaseUrl);
+    const canvasKitFile = entry.canvasKitFile ?? entry.file;
+    const url = canvasKitFontUrl(canvasKitFile, options.localFontBaseUrl);
     const aliases = sourcesByUrl.get(url) ?? new Set<string>();
     aliases.add(requested);
     for (const candidate of FONT_LIST) {
-      if (candidate.file === entry.file) aliases.add(candidate.name);
+      if ((candidate.canvasKitFile ?? candidate.file) === canvasKitFile) aliases.add(candidate.name);
     }
     sourcesByUrl.set(url, aliases);
   }

--- a/rhwp-studio/tests/canvaskit-font-plan.test.ts
+++ b/rhwp-studio/tests/canvaskit-font-plan.test.ts
@@ -29,6 +29,22 @@ test('CanvasKit font plan follows the existing Hanyang Jung Gothic substitution'
   assert.ok(plan.sources[0].aliases.includes('HY중고딕'));
 });
 
+test('CanvasKit font plan uses KoPub SFNT originals while CSS keeps web formats', () => {
+  const plan = resolveCanvasKitFontPlan([
+    'KoPub돋움체 Light',
+    'KoPub바탕체 Bold',
+    'KoPubWorld돋움체 Medium',
+    'KoPubWorld바탕체 Light',
+  ]);
+
+  assert.deepEqual(plan.unavailableFonts, []);
+  const sourceFor = (family: string) => plan.sources.find(source => source.aliases.includes(family));
+  assert.match(sourceFor('KoPub돋움체 Light')?.url ?? '', /font-kopub@1\.0\.2\/fonts\/KoPubDotum-Light\.ttf$/);
+  assert.match(sourceFor('KoPub바탕체 Bold')?.url ?? '', /font-kopub@1\.0\.2\/fonts\/KoPubBatang-Bold\.ttf$/);
+  assert.match(sourceFor('KoPubWorld돋움체 Medium')?.url ?? '', /font-kopubworld@1\.0\.3\/fonts\/KoPubWorld-Dotum-Medium\.otf$/);
+  assert.match(sourceFor('KoPubWorld바탕체 Light')?.url ?? '', /font-kopubworld@1\.0\.3\/fonts\/KoPubWorld-Batang-Light\.otf$/);
+});
+
 test('CanvasKit font plan fails closed for unavailable surface fonts', () => {
   const offline = resolveCanvasKitFontPlan(
     ['함초롬바탕', 'Times New Roman'],


### PR DESCRIPTION
## 변경 요약

- CSS 웹폰트는 기존 WOFF/WOFF2 전송 경로를 유지합니다.
- CanvasKit의 직접 렌더링만 KoPub TTF/OTF SFNT 원본을 사용하도록 분리했습니다.
- KoPub·KoPubWorld 별칭이 동일 SFNT 원본으로 묶이는 계약 테스트를 추가했습니다.
- 페이지네이션, Rust, HWP/HWPX fixture는 변경하지 않았습니다.

관련: #4764

## 검증

- `wasm-pack build --target web --out-dir pkg`
- `cd rhwp-studio && npm test` (`936 passed`, `0 failed`, `1 skipped`)
- `cd rhwp-studio && node --test tests/page-margin-guides.test.ts` (`3 passed`)
- `cd rhwp-studio && npm run e2e:canvaskit-font-coverage`
- `cd rhwp-studio && npm run build`
- `http://127.0.0.1:7700` 브라우저 셸 기동 및 콘솔 오류 없음 확인

## 범위

이 PR은 CanvasKit에 압축 웹폰트를 직접 넘겨 생기는 글리프·메트릭 차이를 줄이는 경로 보정입니다. #4764의 페이지 수·PDF 시각 대조 전체 결론은 후속 CI와 실제 문서 검증에서 계속 확인합니다.
