### PR TITLE
fix: HWP3 출처 추정이 파일 여백을 바꾸지 않게 한다 — 쪽수가 줄던 계열

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -720,16 +720,25 @@ fn apply_hwp3_origin_fixup(doc: &mut Document) {
     let ps_ratio = doc.doc_info.para_shapes.len() as f64 / total_paragraphs as f64;
     let cs_ratio = doc.doc_info.char_shapes.len() as f64 / total_paragraphs as f64;
     if ps_ratio < 0.05 && cs_ratio < 0.15 {
-        // [Task #554] 변환본 의심 시 margin_bottom 보정 (한글97 의 마지막 줄
-        // tolerance 모방). is_hwp3_variant 플래그 설정은 caller 가 별도 (HwpSummary
-        // HWP3-era + 더 관대한 ratio AND 조건) 로 처리 — hwpspec.hwp 같은 spec 문서
-        // false-positive 차단 위해 ratio 단독 변환본 확정 회피.
+        // [Task #554] 변환본 의심 시 한글97 의 마지막 줄 tolerance 를 흉내 낸다.
+        // is_hwp3_variant 플래그 설정은 caller 가 별도 (HwpSummary HWP3-era + 더 관대한
+        // ratio AND 조건) 로 처리 — hwpspec.hwp 같은 spec 문서 false-positive 차단 위해
+        // ratio 단독 변환본 확정 회피.
+        //
+        // 종전에는 `margin_bottom` 을 직접 1600 깎았다. 그건 **파일에 실리는 값**이라
+        // 저장본의 쪽 기하가 원본과 달라진다 — 위 #3707 블록이 같은 이유로 이미 금지한
+        // 조작이다. 이 휴리스틱은 확정이 아니라 추정이라 오탐 비용이 특히 크다:
+        // 02600 은 진짜 HWP5 인데 비율에 걸려 아래 여백이 4252 -> 2652 가 되고, 쪽당
+        // 내용이 늘어 한글이 36쪽 문서를 35쪽으로 연다(오라클 실측).
+        //
+        // 페이지네이터에게만 여유를 주는 `pagination_bottom_tolerance` 로 옮기면 의도한
+        // 조판 효과는 그대로 두면서 파일 값은 원본대로 남는다. 이 필드는 렌더러 내부
+        // 값이라 `--verify` IR 비교에서도 제외된다.
         for section in doc.sections.iter_mut() {
-            section.section_def.page_def.margin_bottom = section
-                .section_def
-                .page_def
-                .margin_bottom
-                .saturating_sub(1600);
+            let pd = &mut section.section_def.page_def;
+            if pd.pagination_bottom_tolerance == 0 {
+                pd.pagination_bottom_tolerance = 1600.min(pd.margin_bottom);
+            }
         }
     }
 }
@@ -2196,6 +2205,87 @@ mod tests {
         let _ = parse_document(&corrupt); // 결과값 무관 — 패닉만 안 하면 통과
     }
 
+    /// HWP3 변환본 추정 휴리스틱은 **파일에 실리는 여백을 건드리면 안 된다**.
+    ///
+    /// 종전에는 `margin_bottom` 을 직접 1600 깎았다. 이 판정은 확정이 아니라 추정이라
+    /// 오탐이 있는데, 오탐이 파일 값을 바꾸면 저장본의 쪽 기하가 원본과 달라진다
+    /// (02600 실측: 진짜 HWP5 인데 비율에 걸려 4252 -> 2652, 한글이 36쪽을 35쪽으로 연다).
+    ///
+    /// 같은 함수의 #3707 블록이 이미 같은 이유로 이 조작을 금지하고
+    /// `pagination_bottom_tolerance`(렌더러 내부 값, `--verify` IR 비교 제외)를 쓴다.
+    #[test]
+    fn hwp3_origin_heuristic_moves_tolerance_not_the_saved_margin() {
+        use crate::model::document::Section;
+        use crate::model::paragraph::Paragraph;
+        use crate::model::style::{CharShape, ParaShape};
+
+        let mut doc = Document::default();
+        let mut section = Section::default();
+        section.section_def.page_def.margin_bottom = 4252;
+        // 휴리스틱 발화 조건: 문단 > 50, ParaShape/문단 < 0.05, CharShape/문단 < 0.15
+        section.paragraphs = (0..60).map(|_| Paragraph::default()).collect();
+        doc.sections.push(section);
+        doc.doc_info.para_shapes = vec![ParaShape::default()];
+        doc.doc_info.char_shapes = vec![CharShape::default()];
+
+        apply_hwp3_origin_fixup(&mut doc);
+
+        let pd = &doc.sections[0].section_def.page_def;
+        assert_eq!(
+            pd.margin_bottom, 4252,
+            "파일에 실리는 여백은 그대로여야 한다 — 줄이면 한컴이 보는 쪽 기하가 원본과 달라진다"
+        );
+        assert_eq!(
+            pd.pagination_bottom_tolerance, 1600,
+            "조판 여유는 렌더러 내부 값으로만 준다"
+        );
+    }
+
+    /// 여백이 1600 보다 작으면 그만큼만 허용한다 — 음수 여유를 만들지 않는다.
+    #[test]
+    fn hwp3_origin_tolerance_is_clamped_to_the_available_margin() {
+        use crate::model::document::Section;
+        use crate::model::paragraph::Paragraph;
+        use crate::model::style::{CharShape, ParaShape};
+
+        let mut doc = Document::default();
+        let mut section = Section::default();
+        section.section_def.page_def.margin_bottom = 900;
+        section.paragraphs = (0..60).map(|_| Paragraph::default()).collect();
+        doc.sections.push(section);
+        doc.doc_info.para_shapes = vec![ParaShape::default()];
+        doc.doc_info.char_shapes = vec![CharShape::default()];
+
+        apply_hwp3_origin_fixup(&mut doc);
+
+        let pd = &doc.sections[0].section_def.page_def;
+        assert_eq!(pd.margin_bottom, 900);
+        assert_eq!(pd.pagination_bottom_tolerance, 900);
+    }
+
+    /// 휴리스틱이 발화하지 않는 문서는 아무것도 바뀌지 않는다.
+    #[test]
+    fn ordinary_hwp5_document_keeps_margin_and_tolerance() {
+        use crate::model::document::Section;
+        use crate::model::paragraph::Paragraph;
+        use crate::model::style::{CharShape, ParaShape};
+
+        let mut doc = Document::default();
+        let mut section = Section::default();
+        section.section_def.page_def.margin_bottom = 4252;
+        section.paragraphs = (0..60).map(|_| Paragraph::default()).collect();
+        doc.sections.push(section);
+        // 스타일이 문단 수만큼 있으면 변환본으로 보지 않는다.
+        doc.doc_info.para_shapes = (0..60).map(|_| ParaShape::default()).collect();
+        doc.doc_info.char_shapes = (0..60).map(|_| CharShape::default()).collect();
+
+        apply_hwp3_origin_fixup(&mut doc);
+
+        let pd = &doc.sections[0].section_def.page_def;
+        assert_eq!(pd.margin_bottom, 4252);
+        assert_eq!(pd.pagination_bottom_tolerance, 0);
+    }
+
     fn png_preview() -> Vec<u8> {
         let mut png = vec![0; 24];
         png[..8].copy_from_slice(b"\x89PNG\r\n\x1a\n");
@@ -2520,10 +2610,17 @@ mod tests {
         let mut doc = hwp3_ratio_suspect_doc();
         assert!(!doc.is_hwpx_variant);
         apply_hwp3_origin_fixup(&mut doc);
+        let pd = &doc.sections[0].section_def.page_def;
+        // 보정은 그대로 적용되지만 **파일 값이 아니라 렌더러 내부 값**에 실린다.
+        // 종전에는 `margin_bottom` 을 4252 - 1600 으로 깎았다 — 추정이 빗나가면 저장본의
+        // 쪽 기하가 원본과 달라진다(02600 실측: 36쪽 문서가 35쪽으로 열림).
         assert_eq!(
-            doc.sections[0].section_def.page_def.margin_bottom,
-            4252 - 1600,
-            "native HWP5 의심본은 종전대로 margin_bottom 보정"
+            pd.margin_bottom, 4252,
+            "파일에 실리는 여백은 건드리지 않는다"
+        );
+        assert_eq!(
+            pd.pagination_bottom_tolerance, 1600,
+            "native HWP5 의심본에는 종전대로 보정이 적용된다 — 자리만 옮겼다"
         );
     }
 
@@ -2532,8 +2629,12 @@ mod tests {
         let mut doc = hwp3_ratio_suspect_doc();
         doc.is_hwpx_variant = true;
         apply_hwp3_origin_fixup(&mut doc);
+        let pd = &doc.sections[0].section_def.page_def;
+        assert_eq!(pd.margin_bottom, 4252);
+        // 보정이 tolerance 로 옮겨간 뒤로는 여백만 봐서는 오발동을 잡을 수 없다 —
+        // 보정이 실리는 자리를 직접 본다.
         assert_eq!(
-            doc.sections[0].section_def.page_def.margin_bottom, 4252,
+            pd.pagination_bottom_tolerance, 0,
             "rhwp HWPX→HWP 변환본(마커)은 HWP3-origin 보정 오발동 금지 (#1880 v2, 2959953)"
         );
     }


### PR DESCRIPTION
## 무엇을 고쳤나

`apply_hwp3_origin_fixup` 의 Task #554 휴리스틱이 **파일에 실리는 여백**(`margin_bottom`)을
1600 HU 깎고 있었다. 이 값을 줄이면 쪽당 본문 가용이 늘어, 한글이 저장본을 원본보다
적은 쪽수로 연다.

이 판정은 확정이 아니라 **추정**이다 — 문단 수(>50)와 스타일 비율(ParaShape/문단 < 0.05,
CharShape/문단 < 0.15)로 "한컴이 HWP3 에서 변환한 파일인가" 를 맞힌다. 추정이라 오탐이
있고, 오탐이 파일 값을 바꾸면 그대로 저장본 결함이 된다.

## 근거는 코드 자신에 있었다

같은 함수의 `#3707` 블록이 이미 같은 조작을 금지하고 있다:

> 파일에 실리는 여백(`margin_bottom`)은 건드리지 않는다 — 줄이면 한컴이 보는 쪽 기하가
> 원본과 달라지고 `convert --verify` 의 IR 비교에도 잡힌다. 이 값은 그 비교에서 제외되는
> 렌더러 내부 값이라 왕복 정합을 깨지 않는다.

`#3707` 은 그래서 `pagination_bottom_tolerance`(페이지네이터에게만 여유를 주는 렌더러
내부 값)를 쓴다. 바로 아래 Task #554 경로만 규칙이 어긋나 있었다.

이 PR 은 휴리스틱의 **동작만** 그쪽으로 맞춘다. 판정 조건은 그대로다 — 의도한 조판 효과
(한글97 의 마지막 줄 tolerance 모방)는 유지되고, 오탐 비용만 "저장본 손상" 에서 "조판
추정 빗나감" 으로 낮아진다. `margin_bottom` 을 줄이면 쪽 테두리·쪽 번호 위치까지
움직이므로, 렌더링 관점에서도 tolerance 쪽이 더 정확하다.

## 오라클 실측

한글 2022 를 정답지로 10k 코퍼스의 쪽수 불일치 1,088 경로 중 **줄어든 계열 134경로**를
겨눴다. `export-hwpx` 가 재현하는 경로(h2x/x2x)만 골라 두 표본으로 쟀다.

    h2x −쪽 계열 28건  ->  28건 전부 원본 쪽수와 정확히 일치, 악화 0

    02600   36쪽 -> 35쪽 이던 것이 36쪽 (진단에 쓴 문서)
    03787    9쪽 ->  3쪽 이던 것이  9쪽 (−6)
    03376   19쪽 -> 18쪽 이던 것이 19쪽
    (그 외 −1 계열 다수)

x2x 1건(00997)은 −1 에서 +1 로 방향만 바뀌었다. 경로가 달라 이 휴리스틱과 무관한 별개
원인이고, `−쪽` 130경로 중 x2x 는 3건뿐이다.

## 측정에서 정정한 것

첫 표본을 경로 구분 없이 뽑아 잘못 읽을 뻔했다. `export-hwpx` 는 h2x/x2x 만 재현하는데
h2h 문서(03908)가 섞여 있었고, 그 시점에 COM 이 죽어 `-2` 가 찍혀 "악화" 로 집계됐다.
또 x2x 문서의 기준값을 h2x 행에서 찾아 엉뚱한 값과 비교했다. 경로를 맞추고 측정 실패를
판정에서 분리해 다시 쟀다 — 위 수치가 그 결과다.

## 검증

- 전체 테스트 통과
- 테스트 3건 추가: 휴리스틱 발화 시 여백 불변·여유만 부여 / 여백이 1600 보다 작으면
  그만큼만 허용(음수 여유 방지) / 발화하지 않는 문서는 무변화

## 관계

PR #4837(축 정합·쪽수 근인 8종)과 독립이다. 그쪽은 8유닛 슬롯 유실과 문서 설정값을
다루고, 이 PR 은 파서의 출처 추정이 파일 값을 바꾸던 문제를 다룬다. #4837 이 `+쪽`
계열을 걷어냈고 이 PR 이 `−쪽` 계열을 걷어낸다.
