### PR TITLE
feat: rhwp explore — 문서별 affordance 라우터

### DIFF
--- a/.claude/skills/rhwp-explore/SKILL.md
+++ b/.claude/skills/rhwp-explore/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: rhwp-explore
+description: rhwp CLI 로 처음 보는 HWP/HWPX 문서에 "무엇을 할 수 있는지"를 즉시 파악합니다. rhwp explore 가 문서를 한 번 분석해 적용 가능한 행동(표→CSV·누름틀 채우기·구조 추출·차트→CSV·보안 스윕·요약)만 골라 순위 매긴 메뉴로 주고, 각 항목의 다음 명령·스킬·근거·확신도까지 함께 라우팅합니다. 트리거 — 사용자가 "이 문서로 뭘 할 수 있어?", "어떤 rhwp 도구를 써야 해?", "이 hwp 어떻게 다뤄?", "문서 탐색/뭘 하고 놀지", "rhwp explore" 등을 물을 때. explain(문서가 무엇인지)·capabilities(도구 일반)와 구별되는 세 번째 축입니다. 전체 레퍼런스는 mydocs/manual/cli_commands.md.
+---
+
+# rhwp-explore — 문서별 어포던스 라우터 Skill
+
+## 목적
+
+처음 보는 문서 앞에서 "70개 명령 중 무엇이 **이 문서**에 맞는가"를 매번 뒤지지 않게
+한다. `rhwp explore` 가 문서를 한 번 분석해 적용 가능한 행동만 골라 순위 매긴 메뉴로
+돌려주므로, 에이전트는 그 첫 항목의 `command` 를 그대로 실행하면 된다.
+
+- `explain` = 문서가 **무엇인지**(형식·쪽수·표·누름틀 서술)
+- `capabilities` = 도구가 **일반적으로** 무엇을 하는지
+- `explore` = **이 문서로** 무엇을 할 수 있는지 (셋 중 유일하게 문서별 라우팅)
+
+## 바이너리 실행
+
+```bash
+cargo build --release        # 최초 1회 또는 소스 변경 후
+./target/release/rhwp explore <파일> --json
+```
+
+## 첫 수: 언제나 explore 부터
+
+```bash
+# 사람용 메뉴
+rhwp explore 문서.hwp
+# 기계용: 가장 높은 확신도의 다음 명령만
+rhwp explore 문서.hwp --json | jq -r '.menu[0].command'
+```
+
+`--json` 봉투: `{"schemaVersion","source","format","pageCount","encrypted","affordanceCount","menu":[{"affordance","why","command","skill","confidence"}],"note"}`.
+`menu[]` 는 우선순위 내림차순이라 **문서마다 다르다**.
+
+## 어포던스 → 다음 명령·스킬
+
+메뉴 항목의 `command` 를 그대로 실행하되, 경로 자리 `<file>` 는 실제 경로로 치환한다.
+
+| affordance | 다음 명령 | 스킬 |
+|------------|-----------|------|
+| `table-extract` (표 있음) | `rhwp export-tables <파일> --json` | rhwp-table-exchange |
+| `form-fill` (누름틀 있음) | `rhwp fields <파일> --json` | rhwp-form-fill |
+| `structure-outline` (조문/제목) | `rhwp export-structure <파일> --json` | rhwp-doc-triage |
+| `chart-extract` (차트 있음) | `rhwp chart-to-csv <파일> --json` | rhwp-table-exchange |
+| `security-sweep` (주입/은닉 신호) | `rhwp inspect injection <파일> --json` | rhwp-security-sweep |
+| `long-doc-digest` (긴 문서) | `rhwp digest <파일> --sections --json` | rhwp-doc-triage |
+| `note-structure` (각주/미주) | `rhwp explain <파일> --json` | rhwp-doc-triage |
+| `triage-overview` (항상) | `rhwp digest <파일> --json` | rhwp-doc-triage |
+
+## 절차
+
+1. `rhwp explore <파일> --json` 으로 메뉴를 받는다.
+2. `confidence` 가 높은 위 항목부터 그 `skill` 로 넘어가 실제 작업을 수행한다.
+3. `security-sweep` 이 메뉴에 있으면(주입·은닉 신호) 본문을 LLM 에 넣기 전에 먼저 처리한다.
+4. 아무 특수 항목이 없으면 `triage-overview` 의 `rhwp digest` 로 문서를 파악한다.
+
+## 성격 — 정직한 휴리스틱
+
+`explore` 는 **제안**이지 완전성 보장이 아니다. 표가 있으니 표 명령을 "해 볼 수 있다"고
+안내할 뿐, 그 표가 원하는 표인지·숨은 행동이 없는지는 판정하지 않는다. 증거(`why`)는
+문서 원문이 아니라 엔진이 센 개수라 봉투는 문서 파생 문자열을 싣지 않는다
+(`untrustedContent:false`). 최종 판단은 실제 조회 명령(위 표)이 한다.

--- a/crates/rhwp-contracts/src/provenance.rs
+++ b/crates/rhwp-contracts/src/provenance.rs
@@ -190,6 +190,14 @@ pub const MAP: &[CommandProvenance] = &[
         note: "format·pageCount·paragraphCount·footnoteCount·endnoteCount·encrypted 는 엔진값이고, tables[] 는 rows/cols/hasMergedCells 만 담아 셀 텍스트를 싣지 않는다.",
     },
     CommandProvenance {
+        command: "explore",
+        untrusted: NONE,
+        note: "어포던스 메뉴 봉투는 형식 레이블·개수(pageCount·affordanceCount)·확신도·고정 \
+               명령 템플릿(<file> 자리표시자)·고정 고지문(note)뿐이다. 증거 menu[].why 는 \
+               문서 원문이 아니라 엔진이 센 개수를 엮은 사람 문장이라 문서 파생 문자열이 \
+               나갈 자리가 없다 — source 는 호출자 경로 에코다.",
+    },
+    CommandProvenance {
         command: "export-tables",
         untrusted: &[
             f("tables[].caption", "표 캡션 텍스트"),

--- a/mydocs/manual/agent_codex/10_조회.md
+++ b/mydocs/manual/agent_codex/10_조회.md
@@ -90,6 +90,51 @@ rhwp explain samples/field-01.hwp --json
 }
 ```
 
+### `explore` — 이 문서로 할 수 있는 rhwp 행동을 순위 매긴 메뉴로 라우팅(표·누름틀·구조·차트·보안·요약)
+
+- 종류: `query` · exit 규약: 0 성공 / 1 IO / 2 사용법 / 3 판정 실패(데이터)
+- 사용법: `explore <파일.hwp|파일.hwpx|파일.hml> [--json]`
+- 플래그: `--json`
+- 봉투 필드: `schemaVersion` · `source` · `format` · `pageCount` · `encrypted` · `affordanceCount` · `menu` · `note` — 정의는 [지식지도 §2-2](../agent_knowledge_map.md)
+- **출처 표지**: 문서 파생 필드 없음 (엔진·에코 값뿐)
+
+실측 표본 — 이 문서로 무엇을 할지 — 문서별 행동 메뉴 라우팅 (exit 0):
+
+```bash
+rhwp explore samples/basic/issue2007_nested_cell_pagination_42065.hwp --json
+```
+
+```json
+{
+  "affordanceCount": 4,
+  "encrypted": false,
+  "format": "HWP5",
+  "menu": [
+    {
+      "affordance": "form-fill",
+      "command": "rhwp fields <file> --json",
+      "confidence": "high",
+      "skill": "rhwp-form-fill",
+      "why": "누름틀(입력 필드) 36개 — 값 채우기·명단 메일머지 대상"
+    },
+    {
+      "affordance": "table-extract",
+      "command": "rhwp export-tables <file> --json",
+      "confidence": "high",
+      "skill": "rhwp-table-exchange",
+      "why": "표 5개 — 격자를 CSV 로 뽑아 고치고 되돌리기"
+    },
+    "… (4개 중 2개 표시)"
+  ],
+  "note": "정직한 휴리스틱 안내다 — 이 문서에 적용 가능한 rhwp 행동을 개수 근거와 함께 제안할 뿐, 완전성을 보장하지 않는다. 각 항목은 '해 볼 수 있는' 다음 명령이며 증거(why)는 엔진이 센 값이다. explain(문서가 무엇인지)·capabilities(도구 일반)와 달리 expl… (191자 중 160자)",
+  "pageCount": 17,
+  "schemaVersion": "1.0",
+  "source": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "untrustedContent": false,
+  "untrustedFields": []
+}
+```
+
 ### `digest` — 문서 요약 봉투(메타·개요·발췌·nextStep)를 한 번 호출로 출력
 
 - 종류: `query` · exit 규약: 0 성공 / 1 IO / 2 사용법 / 3 판정 실패(데이터)

--- a/mydocs/manual/agent_knowledge_map.md
+++ b/mydocs/manual/agent_knowledge_map.md
@@ -296,10 +296,11 @@ IR·provenance·plan 네 축을 한 번에 조립하고, 빠진 축은 `missingA
 를 싣고 `--dry-run` 에서는 싣지 않는다. `edit set-cell` 은 `oldText` 때문에
 `untrustedContent:true`, `edit fill-fields`·`replace-text` 는 `false` 다(실측).
 
-### 2-2. 전수 사전 — 281개 필드
+### 2-2. 전수 사전 — 284개 필드
 
 `capabilities` 의 `recordFields` 고유 **278개**와 그 밖의 실측-only 필드
-`assertions`·`docId`·`preview` **3개**를 합친 281개다. `등장 명령` 은 자기서술
+`assertions`·`docId`·`preview` **3개**, `explore` 전용 `affordanceCount`·`menu`·`note`
+**3개**를 합친 284개다. `등장 명령` 은 자기서술
 기준이며, 실제 봉투에는 조건부로 더 실리는 필드가 있다(§2-5).
 
 #### 신원·스키마
@@ -334,6 +335,14 @@ IR·provenance·plan 네 축을 한 번에 조립하고, 빠진 축은 `missingA
 | `footnoteCount` | number | 각주 수 | `explain` |
 | `endnoteCount` | number | 미주 수 | `explain` |
 | `wasDistribution` | bool | 입력이 배포용(읽기전용)이었나 | `convert` |
+
+#### 탐색 메뉴 (`explore`)
+
+| 필드 | 타입 | 의미 · `null` 의 뜻 | 등장 명령 |
+|---|---|---|---|
+| `affordanceCount` | number | `menu` 배열 길이 — 이 문서에 적용 가능하다고 판단한 행동 수 | `explore` |
+| `menu` | array | 순위 매긴 행동 메뉴 `{affordance,why,command,skill,confidence}`. `affordance`·`command`·`skill` 은 고정 어휘, `why` 만 기존 조회가 센 개수를 엮은 문장(문서 파생 아님) | `explore` |
+| `note` | string | 정직성 고지 — 메뉴는 제안이지 완전성 보장이 아니라는 고정 문구 | `explore` |
 
 #### 요약·개요 (`digest`)
 

--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -685,6 +685,37 @@ rhwp explain 편람.hwp
 rhwp explain 편람.hwp --json | jq '{format, pageCount, tables, fields}'
 ```
 
+### `explore <파일.hwp|파일.hwpx|파일.hml> [--json]`
+이 문서로 **무엇을 할 수 있는지**를 라우팅하는 어포던스 메뉴다. `explain` 이 문서가
+*무엇인지*를, `capabilities` 가 *도구 일반*을 서술한다면, `explore` 는 *이 문서*에
+적용 가능한 rhwp 행동만 골라 순위 매긴 메뉴로 준다 — 처음 보는 문서 앞에서 "70개
+명령 중 무엇이 이 문서에 맞는지"를 매번 뒤지지 않게 하는 놀이터 입구다.
+- 새 판정 로직이 아니라 기존 조회(`export-tables`·`fields`·`export-structure`·
+  `chart-to-csv`·`explain`(각주/미주)·`inspect injection`·`inspect hidden-text`)가
+  이미 센 개수에서 유도한 **결정론적** 메뉴다. LLM 판정은 없다.
+- 기본 출력은 사람용 메뉴. `--json` 이면 봉투 —
+  `{"schemaVersion":"1.0","source","format","pageCount","encrypted","affordanceCount","menu":[{"affordance","why","command","skill","confidence"}],"note"}`
+- `menu[]` 는 우선순위 내림차순이다. 있는 어포던스만 담기므로 **문서마다 메뉴가
+  다르다** — 표가 많은 문서는 `table-extract` 가, 서식은 `form-fill` 이, 주입 신호가
+  있으면 `security-sweep` 가 위로 온다. 아무 특수 신호가 없어도 `triage-overview`
+  한 갈래는 늘 담겨 메뉴가 비지 않는다.
+- 각 항목: `affordance`(안정 식별자), `why`(엔진이 센 개수 근거), `command`(다음에
+  실행할 명령 템플릿 — 경로 자리는 `<file>` 자리표시자), `skill`(다루는 스킬 이름),
+  `confidence`(high/medium/low).
+- **정직한 휴리스틱**이다 — 적용 가능한 행동을 제안할 뿐 완전성을 보장하지 않는다.
+  `note` 필드가 이 성격을 봉투 안에서도 밝힌다.
+- 증거(`why`)는 문서 원문이 아니라 개수·형식 레이블이라 봉투는 문서 파생 문자열을
+  싣지 않는다(`untrustedContent:false`). `capabilities --mcp` 의 `hwp_explore` 도구로도
+  노출된다(읽기 전용·무상태).
+- 암호 문서는 다른 명령과 같은 규약(`--password`/`--password-stdin`).
+
+```bash
+# 이 문서로 무엇을 할 수 있는지 사람용 메뉴로
+rhwp explore 편람.hwp
+# 기계용: 가장 높은 확신도의 다음 명령만 뽑기
+rhwp explore 편람.hwp --json | jq -r '.menu[0] | "\(.command)  # \(.why)"'
+```
+
 ### `search <파일> [--json] [--ignore-case] [--limit N] [--] <검색어>` (#3283)
 문서를 검색해 매치마다 **구역·문단·페이지·문자 오프셋**을 함께 돌려준다.
 평문을 뽑아 외부에서 찾으면 주소가 소멸해 근거 제시가 불가능한데, rhwp 는 조판 엔진이

--- a/src/agent_profiles.rs
+++ b/src/agent_profiles.rs
@@ -87,6 +87,7 @@ pub const PROFILES: &[AgentProfile] = &[
         tools: &[
             "hwp_info",
             "hwp_explain",
+            "hwp_explore",
             "hwp_digest",
             "hwp_export_text",
             "hwp_export_structure",
@@ -96,6 +97,7 @@ pub const PROFILES: &[AgentProfile] = &[
         ],
         session_tools: None,
         recipe: &[
+            "처음 보는 문서면 hwp_explore 로 '이 문서로 무엇을 할 수 있는지' 행동 메뉴를 먼저 받는다",
             "hwp_explain 으로 메타·구조·표·누름틀을 한 봉투로, 또는 hwp_digest 로 메타·개요·발췌를 한 번에 파악",
             "hwp_export_structure 로 목차 확보 후 필요한 절만 hwp_export_text",
             "근거 위치는 hwp_search 로 쪽 번호까지",

--- a/src/document_core/queries/explore.rs
+++ b/src/document_core/queries/explore.rs
@@ -1,0 +1,422 @@
+//! [#gym] `explore` 명령의 어포던스 라우터 — "이 문서로 무엇을 할 수 있는가".
+//!
+//! `explain` 이 문서가 **무엇인지**(형식·쪽수·표·누름틀)를 서술한다면, `explore` 는
+//! 이 문서에 대해 **무엇을 할 수 있는지**를 라우팅한다. 처음 보는 문서 앞에서
+//! 에이전트가 "70개 명령 중 무엇이 이 문서에 적용되는가"를 매번 뒤지지 않도록,
+//! 문서를 한 번 분석해 **적용 가능한 행동만** 골라 순위 매긴 메뉴로 돌려준다.
+//!
+//! ## 새 판정 로직이 아니다
+//!
+//! 어포던스는 **기존 조회가 이미 센 값**에서 유도한다 — `table_extract::extract_tables`,
+//! `field_query::collect_all_fields`, `structure::build_structure`,
+//! `chart_extract::collect_charts`, `explain::count_notes`, `injection_scan`,
+//! `hidden_text`. 이 모듈은 탐지기를 다시 구현하지 않고, 그 개수를 [`DocFacts`] 로
+//! 받아 **순위 매긴 메뉴**([`build_menu`])로 옮길 뿐이다. `explain` 이 네 조회의
+//! 값을 사람 문장으로 옮기는 것과 같은 결정론적 템플릿 조립이다.
+//!
+//! ## 정직한 휴리스틱
+//!
+//! 메뉴는 **제안**이지 완전성 보장이 아니다. "표가 있으니 표 명령을 써 볼 수 있다"고
+//! 안내할 뿐, 그 표가 원하는 표인지·다른 숨은 행동이 없는지는 판정하지 않는다.
+//! 증거(`why`)는 문서 원문이 아니라 **엔진이 센 개수·형식 레이블**이라 출처상
+//! 문서 파생 문자열을 싣지 않는다(봉투 표지 `untrustedContent:false`). 명령
+//! 템플릿의 경로 자리는 실제 경로가 아니라 `<file>` 자리표시자를 쓴다 — 소비자가
+//! 자기 경로로 치환한다.
+
+/// "긴 문서" 판정 임계 — 이 쪽수 이상이면 통독 대신 요약·절 청킹을 권한다.
+///
+/// 10쪽은 한 화면에 담기지 않아 컨텍스트를 아껴 읽어야 하는 실무 하한이다.
+pub const LONG_DOC_PAGES: u32 = 10;
+
+/// 봉투에 함께 싣는 정직성 고지 — 메뉴가 제안이지 보장이 아님을 명시한다.
+pub const HONESTY_NOTE: &str = "정직한 휴리스틱 안내다 — 이 문서에 적용 가능한 rhwp 행동을 \
+개수 근거와 함께 제안할 뿐, 완전성을 보장하지 않는다. 각 항목은 '해 볼 수 있는' 다음 명령이며 \
+증거(why)는 엔진이 센 값이다. explain(문서가 무엇인지)·capabilities(도구 일반)와 달리 \
+explore 는 이 문서로 무엇을 할 수 있는지를 라우팅한다.";
+
+/// 기존 조회가 이미 계산한 문서 사실의 묶음 — 이 모듈은 이 개수만 읽는다.
+///
+/// 문서를 다시 파싱하지 않는다. 호출부(main 의 `explore_document`)가 기존 공개
+/// 질의를 각각 한 번씩 호출해 채운다.
+#[derive(Debug, Clone, Default)]
+pub struct DocFacts {
+    /// 형식 레이블(HWP5/HWPX/HWP3/HML …) — 엔진 판정값.
+    pub format_label: String,
+    /// 조판 페이지 수.
+    pub page_count: u32,
+    /// 본문 문단 수.
+    pub para_count: usize,
+    /// `extract_tables` 가 센 표 개수.
+    pub table_count: usize,
+    /// 그중 병합 셀(rowSpan/colSpan>1)을 가진 표 개수.
+    pub merged_table_count: usize,
+    /// `collect_all_fields` 가 센 누름틀(입력 필드) 개수.
+    pub field_count: usize,
+    /// `collect_charts` 가 센 차트 개수.
+    pub chart_count: usize,
+    /// `build_structure` 최상위 노드(제목·조문) 개수.
+    pub structure_node_count: usize,
+    /// `count_notes` 각주 개수.
+    pub footnote_count: usize,
+    /// `count_notes` 미주 개수.
+    pub endnote_count: usize,
+    /// `scan_injection` 프롬프트 주입 신호 개수.
+    pub injection_signal_count: usize,
+    /// `detect_hidden_text` 은닉 텍스트 판정 개수.
+    pub hidden_text_count: usize,
+    /// 문서가 암호로 보호돼 있는가(`header.encrypted`).
+    pub encrypted: bool,
+}
+
+/// 메뉴 항목 하나 — "이 문서로 해 볼 수 있는 행동" 하나.
+///
+/// 필드는 그대로 봉투의 `menu[]` 원소가 된다. `command`·`skill`·`affordance` 는
+/// 고정 어휘(정적 문자열)이고, `why` 만 개수를 엮은 사람 문장이다.
+#[derive(Debug, Clone)]
+pub struct Affordance {
+    /// 안정 식별자 — 소비자가 문자열 매칭으로 분기할 수 있는 고정 어휘.
+    pub affordance: &'static str,
+    /// 근거 — 이 문서에서 이 어포던스를 켠 개수/형식. 엔진값이라 문서 파생이 아니다.
+    pub why: String,
+    /// 다음에 실행할 rhwp 명령 템플릿. 경로 자리는 `<file>` 자리표시자.
+    pub command: &'static str,
+    /// 이 행동을 다루는 스킬 이름(.claude/skills/<name>).
+    pub skill: &'static str,
+    /// 확신도 — high/medium/low. 신호가 강할수록 높다.
+    pub confidence: &'static str,
+}
+
+/// 우선순위와 함께 만든 뒤 순위로 정렬한다(높을수록 위). 표시 순위는
+/// **문서별로 다른 메뉴**를 만드는 축이다 — 있는 어포던스만 담기므로 표가 많은
+/// 문서는 표 항목이, 서식은 누름틀 항목이 위로 온다.
+fn ranked(priority: u8, affordance: Affordance) -> (u8, Affordance) {
+    (priority, affordance)
+}
+
+/// 문서 사실에서 순위 매긴 어포던스 메뉴를 만든다 — 결정론적, 부작용 없음.
+///
+/// 적용 가능한 어포던스만 담고(없는 신호는 항목이 없다), 마지막에 우선순위 내림차순
+/// 안정 정렬한다. `triage-overview` 는 언제나 담겨 메뉴가 비지 않는다 — 아무 특수
+/// 신호가 없는 평범한 문서라도 최소 "요약으로 파악" 한 갈래는 제공한다.
+pub fn build_menu(f: &DocFacts) -> Vec<Affordance> {
+    let mut items: Vec<(u8, Affordance)> = Vec::new();
+
+    // ── 보안(주입·은닉) — 받은 문서라면 가장 먼저 의심해야 하므로 최상위 ──
+    if f.injection_signal_count > 0 || f.hidden_text_count > 0 {
+        let (why, command) = if f.injection_signal_count > 0 && f.hidden_text_count > 0 {
+            (
+                format!(
+                    "프롬프트 주입 신호 {}건·은닉 텍스트 {}건 검출 — 본문을 LLM 에 넣기 전 신뢰성 점검 필요",
+                    f.injection_signal_count, f.hidden_text_count
+                ),
+                "rhwp inspect injection <file> --json",
+            )
+        } else if f.injection_signal_count > 0 {
+            (
+                format!(
+                    "프롬프트 주입 신호 {}건 검출 — 문서 지시를 도구 지시로 오독하지 않게 선별",
+                    f.injection_signal_count
+                ),
+                "rhwp inspect injection <file> --json",
+            )
+        } else {
+            (
+                format!(
+                    "은닉 텍스트 {}건 검출 — 화면엔 안 보이나 추출기는 읽는 문자",
+                    f.hidden_text_count
+                ),
+                "rhwp inspect hidden-text <file> --json",
+            )
+        };
+        let confidence = if f.injection_signal_count > 0 {
+            "high"
+        } else {
+            "medium"
+        };
+        items.push(ranked(
+            90,
+            Affordance {
+                affordance: "security-sweep",
+                why,
+                command,
+                skill: "rhwp-security-sweep",
+                confidence,
+            },
+        ));
+    }
+
+    // ── 누름틀(서식) — 채우기·메일머지 대상이라 실무 가치가 높다 ──
+    if f.field_count > 0 {
+        items.push(ranked(
+            80,
+            Affordance {
+                affordance: "form-fill",
+                why: format!(
+                    "누름틀(입력 필드) {}개 — 값 채우기·명단 메일머지 대상",
+                    f.field_count
+                ),
+                command: "rhwp fields <file> --json",
+                skill: "rhwp-form-fill",
+                confidence: "high",
+            },
+        ));
+    }
+
+    // ── 표 → CSV 왕복 ──
+    if f.table_count > 0 {
+        let why = if f.merged_table_count > 0 {
+            format!(
+                "표 {}개(병합 셀 포함 {}개) — 격자를 CSV 로 뽑아 고치고 되돌리기",
+                f.table_count, f.merged_table_count
+            )
+        } else {
+            format!("표 {}개 — 격자를 CSV 로 뽑아 고치고 되돌리기", f.table_count)
+        };
+        items.push(ranked(
+            75,
+            Affordance {
+                affordance: "table-extract",
+                why,
+                command: "rhwp export-tables <file> --json",
+                skill: "rhwp-table-exchange",
+                confidence: "high",
+            },
+        ));
+    }
+
+    // ── 제목·조문 구조 → 조문 단위 인용·청킹 ──
+    if f.structure_node_count > 0 {
+        items.push(ranked(
+            70,
+            Affordance {
+                affordance: "structure-outline",
+                why: format!(
+                    "제목·조문 구조 {}개 노드 — 조문 단위 인용·RAG 청킹",
+                    f.structure_node_count
+                ),
+                command: "rhwp export-structure <file> --json",
+                skill: "rhwp-doc-triage",
+                confidence: if f.structure_node_count >= 3 {
+                    "high"
+                } else {
+                    "medium"
+                },
+            },
+        ));
+    }
+
+    // ── 차트 → CSV ──
+    if f.chart_count > 0 {
+        items.push(ranked(
+            60,
+            Affordance {
+                affordance: "chart-extract",
+                why: format!(
+                    "차트 {}개 — 계열·카테고리 수치를 CSV 로 추출",
+                    f.chart_count
+                ),
+                command: "rhwp chart-to-csv <file> --json",
+                skill: "rhwp-table-exchange",
+                confidence: "high",
+            },
+        ));
+    }
+
+    // ── 각주·미주 참조 구조 ──
+    if f.footnote_count + f.endnote_count > 0 {
+        items.push(ranked(
+            45,
+            Affordance {
+                affordance: "note-structure",
+                why: format!(
+                    "각주 {}개·미주 {}개 — 참조 구조를 포함한 문서",
+                    f.footnote_count, f.endnote_count
+                ),
+                command: "rhwp explain <file> --json",
+                skill: "rhwp-doc-triage",
+                confidence: "high",
+            },
+        ));
+    }
+
+    // ── 긴 문서 → 통독 대신 요약·절 청킹 ──
+    if f.page_count >= LONG_DOC_PAGES {
+        items.push(ranked(
+            40,
+            Affordance {
+                affordance: "long-doc-digest",
+                why: format!(
+                    "{}쪽 장문 — 통째로 읽기 전 요약·절 단위 청킹 권장",
+                    f.page_count
+                ),
+                command: "rhwp digest <file> --sections --json",
+                skill: "rhwp-doc-triage",
+                confidence: if f.page_count >= 2 * LONG_DOC_PAGES {
+                    "high"
+                } else {
+                    "medium"
+                },
+            },
+        ));
+    }
+
+    // ── 항상: 처음 보는 문서의 기본 갈래(요약으로 파악) ──
+    let overview_why = if f.encrypted {
+        format!(
+            "{} 형식·{}쪽·문단 {}개(암호 보호 — 후속 명령에 --password 필요) — 문서 전체를 한 봉투로 파악",
+            f.format_label, f.page_count, f.para_count
+        )
+    } else {
+        format!(
+            "{} 형식·{}쪽·문단 {}개 — 문서 전체를 한 봉투로 파악",
+            f.format_label, f.page_count, f.para_count
+        )
+    };
+    items.push(ranked(
+        20,
+        Affordance {
+            affordance: "triage-overview",
+            why: overview_why,
+            command: "rhwp digest <file> --json",
+            skill: "rhwp-doc-triage",
+            confidence: "high",
+        },
+    ));
+
+    // 우선순위 내림차순 안정 정렬 — 같은 우선순위는 삽입 순서를 유지한다.
+    items.sort_by(|a, b| b.0.cmp(&a.0));
+    items.into_iter().map(|(_, a)| a).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn facts() -> DocFacts {
+        DocFacts {
+            format_label: "HWP5".to_string(),
+            page_count: 3,
+            para_count: 40,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn plain_document_still_offers_overview() {
+        // 아무 특수 신호가 없어도 메뉴는 비지 않는다 — 최소 한 갈래(요약)를 준다.
+        let menu = build_menu(&facts());
+        assert_eq!(menu.len(), 1, "{menu:?}");
+        assert_eq!(menu[0].affordance, "triage-overview");
+        assert_eq!(menu[0].command, "rhwp digest <file> --json");
+    }
+
+    #[test]
+    fn tables_surface_the_table_affordance() {
+        let mut f = facts();
+        f.table_count = 3;
+        f.merged_table_count = 1;
+        let menu = build_menu(&f);
+        let table = menu
+            .iter()
+            .find(|a| a.affordance == "table-extract")
+            .expect("표 어포던스");
+        assert!(table.why.contains('3'), "{}", table.why);
+        assert!(table.why.contains("병합"), "{}", table.why);
+        assert_eq!(table.skill, "rhwp-table-exchange");
+    }
+
+    #[test]
+    fn form_fields_surface_the_form_affordance() {
+        let mut f = facts();
+        f.field_count = 8;
+        let menu = build_menu(&f);
+        let form = menu
+            .iter()
+            .find(|a| a.affordance == "form-fill")
+            .expect("서식 어포던스");
+        assert_eq!(form.command, "rhwp fields <file> --json");
+        assert_eq!(form.skill, "rhwp-form-fill");
+    }
+
+    #[test]
+    fn injection_signal_ranks_security_first() {
+        // 주입 신호가 있으면 보안 점검이 메뉴 최상위여야 한다.
+        let mut f = facts();
+        f.table_count = 2;
+        f.field_count = 2;
+        f.injection_signal_count = 1;
+        let menu = build_menu(&f);
+        assert_eq!(menu[0].affordance, "security-sweep", "{menu:?}");
+        assert_eq!(menu[0].confidence, "high");
+        assert!(menu[0].command.contains("inspect injection"));
+    }
+
+    #[test]
+    fn hidden_text_only_is_medium_confidence_hidden_command() {
+        let mut f = facts();
+        f.hidden_text_count = 2;
+        let menu = build_menu(&f);
+        let sec = &menu[0];
+        assert_eq!(sec.affordance, "security-sweep");
+        assert_eq!(sec.confidence, "medium");
+        assert!(sec.command.contains("hidden-text"), "{}", sec.command);
+    }
+
+    #[test]
+    fn long_document_offers_sectioned_digest() {
+        let mut f = facts();
+        f.page_count = 40;
+        let menu = build_menu(&f);
+        let long = menu
+            .iter()
+            .find(|a| a.affordance == "long-doc-digest")
+            .expect("장문 어포던스");
+        assert_eq!(long.confidence, "high");
+        assert!(long.command.contains("--sections"));
+        // 짧은 문서에는 없어야 한다 — 문서별 판별.
+        assert!(build_menu(&facts())
+            .iter()
+            .all(|a| a.affordance != "long-doc-digest"));
+    }
+
+    #[test]
+    fn different_documents_yield_different_menus() {
+        // explore 의 존재 이유: 문서마다 다른 메뉴.
+        let mut form = facts();
+        form.field_count = 5;
+        let mut report = facts();
+        report.table_count = 4;
+        report.chart_count = 2;
+        report.structure_node_count = 6;
+
+        let form_ids: Vec<&str> = build_menu(&form).iter().map(|a| a.affordance).collect();
+        let report_ids: Vec<&str> = build_menu(&report).iter().map(|a| a.affordance).collect();
+        assert!(form_ids.contains(&"form-fill"));
+        assert!(!form_ids.contains(&"chart-extract"));
+        assert!(report_ids.contains(&"chart-extract"));
+        assert!(!report_ids.contains(&"form-fill"));
+        assert_ne!(form_ids, report_ids);
+    }
+
+    #[test]
+    fn menu_is_sorted_by_priority_descending() {
+        let mut f = facts();
+        f.field_count = 1;
+        f.table_count = 1;
+        f.chart_count = 1;
+        f.injection_signal_count = 1;
+        let menu = build_menu(&f);
+        // security(90) > form(80) > table(75) > chart(60) > overview(20)
+        let ids: Vec<&str> = menu.iter().map(|a| a.affordance).collect();
+        assert_eq!(
+            ids,
+            vec![
+                "security-sweep",
+                "form-fill",
+                "table-extract",
+                "chart-extract",
+                "triage-overview"
+            ]
+        );
+    }
+}

--- a/src/document_core/queries/explore.rs
+++ b/src/document_core/queries/explore.rs
@@ -170,7 +170,10 @@ pub fn build_menu(f: &DocFacts) -> Vec<Affordance> {
                 f.table_count, f.merged_table_count
             )
         } else {
-            format!("표 {}개 — 격자를 CSV 로 뽑아 고치고 되돌리기", f.table_count)
+            format!(
+                "표 {}개 — 격자를 CSV 로 뽑아 고치고 되돌리기",
+                f.table_count
+            )
         };
         items.push(ranked(
             75,

--- a/src/document_core/queries/mod.rs
+++ b/src/document_core/queries/mod.rs
@@ -4,6 +4,8 @@ mod cursor_rect;
 pub(crate) mod doc_tree_nav;
 /// [#3828] `explain` 명령 전용 집계(각주/미주 개수) — 다른 조회가 채우지 못하는 구멍.
 pub mod explain;
+/// [#gym] `explore` 명령의 어포던스 라우터 — 기존 조회 개수에서 문서별 행동 메뉴를 유도.
+pub mod explore;
 // [#3281] `fields` CLI 가 필드 위치(NestedEntry)를 읽어야 하므로 공개한다.
 // 읽기 전용 질의 모듈이며 `structure`·`rendering` 과 같은 가시성이다.
 pub mod field_query;

--- a/src/main.rs
+++ b/src/main.rs
@@ -397,6 +397,7 @@ fn main() {
         Some("thumbnail") => exit_with(extract_thumbnail(&args[2..])),
         Some("fields") => exit_with(show_fields(&args[2..])),
         Some("explain") => exit_with(explain_document(&args[2..])),
+        Some("explore") => exit_with(explore_document(&args[2..])),
         Some("edit") => exit_with(run_edit(&args[2..])),
         Some("run") => exit_with(cmd_run_plan(&args[2..])),
         Some("replay") => exit_with(cmd_replay(&args[2..])),
@@ -613,6 +614,7 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
                 | "hwp_extract_data"
                 | "hwp_fields"
                 | "hwp_explain"
+                | "hwp_explore"
                 | "hwp_inspect_hidden_text"
                 | "hwp_inspect_injection"
                 | "hwp_inspect_unicode"
@@ -1152,6 +1154,25 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
                 "endnoteCount",
                 "encrypted",
                 "summary",
+            ],
+        ),
+        // [#gym] 어포던스 라우터 — hwp_explain(문서가 무엇인지)의 자매 도구로, 이 문서로
+        // 무엇을 할 수 있는지 순위 매긴 행동 메뉴를 준다. 새 판정 없이 기존 조회 개수에서 유도.
+        tool(
+            "hwp_explore",
+            "이 문서로 무엇을 할 수 있는지 — 적용 가능한 rhwp 행동을 순위 매긴 메뉴(표→CSV·누름틀 채우기·구조 추출·차트→CSV·보안 스윕·요약)로 라우팅한다. 처음 보는 문서 앞에서 '어떤 명령이 이 문서에 맞는지'를 매번 뒤지지 않도록, 각 항목이 근거(why)·다음 명령(command)·스킬(skill)·확신도를 함께 준다. 기존 조회 개수에서 유도한 정직한 휴리스틱이라 제안일 뿐 완전성을 보장하지 않는다.",
+            path_schema(serde_json::json!({})),
+            "explore",
+            serde_json::json!(["explore", "{path}", "--json"]),
+            &[
+                "schemaVersion",
+                "source",
+                "format",
+                "pageCount",
+                "encrypted",
+                "affordanceCount",
+                "menu",
+                "note",
             ],
         ),
         // [#3787 S3] 신뢰할 수 없는 문서를 LLM 에 먹이기 전에 부르는 도구.
@@ -3173,6 +3194,25 @@ fn capabilities_command_entries() -> Vec<serde_json::Value> {
                 "summary",
             ],
         ),
+        // [#gym] 어포던스 라우터 — explain(문서가 무엇인지)·capabilities(도구 일반)와
+        // 구별되는 세 번째 축: 이 문서로 무엇을 할 수 있는지. 기존 조회 개수에서 유도.
+        cmd_json(
+            "explore",
+            "query",
+            "이 문서로 할 수 있는 rhwp 행동을 순위 매긴 메뉴로 라우팅(표·누름틀·구조·차트·보안·요약)",
+            false,
+            &["--json"],
+            &[
+                "schemaVersion",
+                "source",
+                "format",
+                "pageCount",
+                "encrypted",
+                "affordanceCount",
+                "menu",
+                "note",
+            ],
+        ),
         // [#3787 S2/S3/S4] 문서를 읽기만 하는 보안 검사 명령군. 세 하위 명령의 플래그와
         // 봉투 필드는 합집합으로 광고해 capabilities 자체가 어느 축도 숨기지 않게 한다.
         cmd_json(
@@ -4221,6 +4261,14 @@ fn print_help() {
     println!("      fields 를 조합한 템플릿 조립일 뿐 LLM 판정은 없다 (#3828)");
     println!();
     println!("      --json                  요약 봉투를 JSON으로 stdout에 출력");
+    println!();
+    println!("  explore <파일.hwp|파일.hwpx|파일.hml> [--json]");
+    println!("      이 문서로 무엇을 할 수 있는지 — 적용 가능한 rhwp 행동을 순위 매긴 메뉴로");
+    println!("      라우팅한다(표·누름틀·구조·차트·보안·요약). 각 항목은 근거·다음 명령·");
+    println!("      스킬·확신도를 준다. explain(문서가 무엇인지)과 구별되는 어포던스 축이며,");
+    println!("      기존 조회 개수에서 유도한 정직한 휴리스틱이라 완전성을 보장하지 않는다");
+    println!();
+    println!("      --json                  어포던스 메뉴 봉투를 JSON으로 stdout에 출력");
     println!();
     println!("  capabilities [--mcp]");
     println!("      도구 자기서술 JSON 출력 (명령·플래그·JSON 계약·종료 코드) — 에이전트용");
@@ -25677,6 +25725,156 @@ fn explain_document(args: &[String]) -> i32 {
         encrypted,
     );
     println!("{summary}");
+    EXIT_OK
+}
+
+/// `rhwp explore <파일> [--json]` — 이 문서로 **무엇을 할 수 있는지** 어포던스 메뉴를 라우팅한다.
+///
+/// [#gym] 새 판정 로직이 아니라 기존 조회(`table_extract`·`field_query`·`structure`·
+/// `chart_extract`·`explain::count_notes`·`injection_scan`·`hidden_text`)가 이미 센
+/// 개수에서 유도한 결정론적 메뉴다 — 순위·근거·명령 매핑 로직은
+/// `document_core::queries::explore` 에 있다. `explain`(문서가 무엇인지)·
+/// `capabilities`(도구 일반)와 달리 explore 는 **이 문서로 무엇을 할 수 있는지**를
+/// 라우팅한다. 정직한 휴리스틱이라 제안일 뿐 완전성을 보장하지 않는다. 암호 문서는
+/// `load_document` 가 다른 명령과 같은 규약으로 처리한다.
+fn explore_document(args: &[String]) -> i32 {
+    use rhwp::document_core::queries::chart_extract::collect_charts;
+    use rhwp::document_core::queries::explore::{build_menu, DocFacts, HONESTY_NOTE};
+    use rhwp::document_core::queries::hidden_text::HiddenTextOptions;
+    use rhwp::document_core::queries::injection_scan as scan;
+    use rhwp::document_core::queries::structure::{build_structure, StructureMode};
+    use rhwp::document_core::queries::table_extract::extract_tables;
+
+    let mut json_mode = false;
+    let mut file_path: Option<&str> = None;
+    for arg in args {
+        match arg.as_str() {
+            "--json" => json_mode = true,
+            other if other.starts_with('-') => {
+                eprintln!("알 수 없는 옵션: {other}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if file_path.replace(other).is_some() {
+                    eprintln!("오류: 입력 파일은 하나만 지정할 수 있습니다: {other}");
+                    return EXIT_USAGE;
+                }
+            }
+        }
+    }
+    let Some(file_path) = file_path else {
+        eprintln!("사용법: rhwp explore <파일.hwp|파일.hwpx|파일.hml> [--json]");
+        return EXIT_USAGE;
+    };
+
+    let data = match fs::read(file_path) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: 파일을 읽을 수 없습니다 - {file_path}: {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+
+    let detected_format = rhwp::parser::detect_format(&data);
+    let doc = match load_document(&data) {
+        Ok(d) => d,
+        Err(e) => return e.report(),
+    };
+    let document = doc.document();
+
+    let format_label = match detected_format {
+        rhwp::parser::FileFormat::Hwp => "HWP5",
+        rhwp::parser::FileFormat::Hwpx => "HWPX",
+        rhwp::parser::FileFormat::Hwp3 => "HWP3",
+        rhwp::parser::FileFormat::Hml => "HML",
+        rhwp::parser::FileFormat::DrmProtected => "DRM",
+        rhwp::parser::FileFormat::Empty => "빈 파일",
+        rhwp::parser::FileFormat::Unknown => "알 수 없음",
+    };
+
+    // 기존 공개 조회를 각각 한 번씩만 호출해 개수를 모은다 — 탐지기 재구현·재파싱 없음.
+    let tables = extract_tables(document);
+    let merged_table_count = tables
+        .iter()
+        .filter(|g| g.cells.iter().any(|c| c.row_span > 1 || c.col_span > 1))
+        .count();
+    let structure = build_structure(document, StructureMode::Auto);
+    let notes = rhwp::document_core::queries::explain::count_notes(document);
+    let injection_options = scan::InjectionScanOptions {
+        min_confidence: scan::Confidence::Low,
+        include_fields: true,
+        tool_names: mcp_tool_name_registry(),
+    };
+    let injection_signal_count = doc.scan_injection(&injection_options).len();
+    let hidden = doc.detect_hidden_text(&HiddenTextOptions::default());
+
+    let facts = DocFacts {
+        format_label: format_label.to_string(),
+        page_count: doc.page_count(),
+        para_count: document.sections.iter().map(|s| s.paragraphs.len()).sum(),
+        table_count: tables.len(),
+        merged_table_count,
+        field_count: doc.collect_all_fields().len(),
+        chart_count: collect_charts(document).len(),
+        structure_node_count: structure.node_count,
+        footnote_count: notes.footnote_count,
+        endnote_count: notes.endnote_count,
+        injection_signal_count,
+        hidden_text_count: hidden.hidden_text.len(),
+        encrypted: document.header.encrypted,
+    };
+
+    let menu = build_menu(&facts);
+
+    if json_mode {
+        let menu_json: Vec<serde_json::Value> = menu
+            .iter()
+            .map(|a| {
+                serde_json::json!({
+                    "affordance": a.affordance,
+                    "why": a.why,
+                    "command": a.command,
+                    "skill": a.skill,
+                    "confidence": a.confidence,
+                })
+            })
+            .collect();
+        let envelope = provenance::marked(
+            serde_json::json!({
+                "schemaVersion": ENVELOPE_SCHEMA_VERSION,
+                "source": file_path,
+                "format": format_label,
+                "pageCount": facts.page_count,
+                "encrypted": facts.encrypted,
+                "affordanceCount": menu.len(),
+                "menu": menu_json,
+                "note": HONESTY_NOTE,
+            }),
+            "explore",
+        );
+        println!("{envelope}");
+        return EXIT_OK;
+    }
+
+    // 기본 출력은 사람용 메뉴 — 기계 소비는 --json 이 담당한다.
+    println!(
+        "이 문서로 해 볼 수 있는 행동 ({format_label} 형식·{}쪽·어포던스 {}개):",
+        facts.page_count,
+        menu.len()
+    );
+    for (i, a) in menu.iter().enumerate() {
+        println!(
+            "  {}. [{}] {} — 스킬 {}",
+            i + 1,
+            a.confidence,
+            a.affordance,
+            a.skill
+        );
+        println!("      이유: {}", a.why);
+        println!("      명령: {}", a.command);
+    }
+    println!();
+    println!("{HONESTY_NOTE}");
     EXIT_OK
 }
 

--- a/tests/provenance_contract.rs
+++ b/tests/provenance_contract.rs
@@ -808,6 +808,17 @@ fn recipes() -> Vec<Recipe> {
             exit: 0,
             ndjson: false,
         },
+        // [#gym] explore — 어포던스 메뉴 봉투. 증거(menu[].why)는 엔진이 센 개수라 문서
+        // 파생 문자열이 없다(untrustedContent:false). 본문·표·개요가 있는 main 을 써
+        // 오라클을 비지 않게 하고, 표지 존재·지도 정합만 확인한다.
+        Recipe {
+            command: "explore",
+            doc: Some(main.clone()),
+            args: vec![s("explore"), p(&main), s("--json")],
+            stdin: None,
+            exit: 0,
+            ndjson: false,
+        },
         Recipe {
             command: "edit",
             doc: Some(table.clone()),

--- a/tools/gen_agent_codex.py
+++ b/tools/gen_agent_codex.py
@@ -74,6 +74,7 @@ PLAN_A = {
 LIVE = {
     "info": ([ "info", DOC, "--json"], "문서 신상 — 형식·쪽수·구역·글꼴"),
     "explain": (["explain", FORM, "--json"], "메타·구조·표·누름틀 한 봉투 요약"),
+    "explore": (["explore", DOC, "--json"], "이 문서로 무엇을 할지 — 문서별 행동 메뉴 라우팅"),
     "digest": (["digest", GOV, "--json"], "요약·RAG 청킹 — 개요와 발췌"),
     "search": (["search", GOV, "국어", "--json"], "주소(쪽) 붙은 전수 검색"),
     "export-text": (["export-text", DOC, "-p", "0", "--json"], "쪽 단위 평문"),
@@ -126,7 +127,7 @@ COMMON_REASON = "입력 합성 비용 또는 산출 부피 때문에 표본 실�
 # 가족 분류 — (장 파일 이름, 제목, 소속 명령 판별자)
 FAMILIES = [
     ("10_조회", "조회 — 문서를 읽고 파악한다",
-     ["info", "explain", "digest", "search", "export-text", "export-structure", "fields", "dump-pages", "extract-pages"]),
+     ["info", "explain", "explore", "digest", "search", "export-text", "export-structure", "fields", "dump-pages", "extract-pages"]),
     ("20_표와_데이터", "표·데이터 — 구조화 수확과 왕복",
      ["export-tables", "table-to-csv", "csv-to-table", "extract-data", "scan",
       # [#4100] 차트 숫자 데이터도 같은 CSV 왕복 규약을 쓴다 — 표와 한 가족이다.


### PR DESCRIPTION
⚠️ 세션 한도로 6종 계약테스트 실행 직전 중단. 코드는 완성 상태로 커밋·push했으나 로컬 검증 미완 — CI를 관문으로. 리셋 후 마무리 예정. Draft.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>