### PR TITLE
feat(tools): 회귀 폐회로 — 현장 사건을 영구 게이트로 승격 (promote·gate)

### DIFF
--- a/tools/crash_minimizer.py
+++ b/tools/crash_minimizer.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""HWPX 크래시 최소화기 — 실패 재현 문서를 최소 픽스처로 자동 축소한다.
+
+## 왜 있는가 (fuzz_corpus 와의 분업)
+
+`gym/tools/fuzz_corpus.py`(#4884 계열)는 **발견** 엔진이다 — 전 코퍼스를 두들겨
+"어느 문서가 어느 위치에서 패닉하는가"를 클러스터링한다. 그런데 발견된 재현체는
+대개 수백 KB~수 MB 실문서라서, 그대로는 이슈에 못 싣고(개인정보·저작권·용량)
+회귀 테스트 픽스처로도 못 쓴다. 지금까지는 사람이 `tools/make_issue*_fixture.py`
+같은 **일회용 스크립트를 이슈마다 새로 짜서** 손으로 줄여 왔다 (#3738·#3751·
+#3765·#3798 각각 별도 파일이 그 증거다).
+
+이 도구는 그 수작업을 일반화한다: 실패 시그니처(패닉 위치·abort·timeout)를
+**보존하는 한도 안에서** 문서를 델타 디버깅(ddmin)으로 깎아, "같은 자리에서
+같은 방식으로 죽는 가장 작은 문서"를 만든다. 발견(fuzz_corpus) → **축소(이 도구)**
+→ 이슈/픽스처가 한 파이프라인이 된다.
+
+## 범위와 한계
+
+- **HWPX 전용.** HWPX 는 ZIP + XML 이라 표준 라이브러리(zipfile·ElementTree)로
+  안전하게 재작성할 수 있다. HWP5 는 CFB 컨테이너라 표준 라이브러리만으로는
+  재작성이 위험해 범위 밖이다 (필요해지면 rhwp 자신의 convert 를 오라클로 삼는
+  별도 설계가 맞다).
+- 기본 시그니처는 **패닉·abort·timeout 만** 버그로 친다. 깨끗한 오류 종료(exit 1
+  + 진단 메시지)는 정상 동작이므로 기본값에선 재현 실패로 처리한다
+  (`--accept-exit N` 으로 명시적으로 켤 수 있다).
+- 축소는 같은 시그니처를 유지할 때만 채택한다 — 다른 버그로 미끄러진 축소본은
+  버린다. "panicked at src/a.rs:10" 이 "src/b.rs:99" 로 바뀌면 그건 다른 이슈다.
+
+## 축소 전략 (순서대로, 각각 고정점까지)
+
+1. **ZIP 멤버 가지치기** — 미리보기(Preview/*)·바이너리(BinData/*)·스크립트 등
+   없어도 재현되는 멤버를 통째로 제거한다.
+2. **문단 ddmin** — 각 `Contents/section*.xml` 의 최상위 문단(`<hp:p>`)을
+   델타 디버깅으로 깎는다. 청크 제거 → 실패 유지 확인 → 채택의 반복.
+3. **런 ddmin** — 남은 문단 안의 `<hp:run>` 들을 같은 방식으로 깎는다.
+
+## 사용
+
+    # 기본: info --json 으로 재현 확인하며 축소
+    python3 tools/crash_minimizer.py crash.hwpx --bin target/debug/rhwp \
+        --cmd "info {doc} --json" -o minimal.hwpx
+
+    # 이슈 초안까지 (시그니처·전후 크기·재현 명령 포함)
+    python3 tools/crash_minimizer.py crash.hwpx --bin target/debug/rhwp \
+        --cmd "export-text {doc}" -o minimal.hwpx --emit-issue issue_draft.md
+
+    # 오라클을 임의 명령으로 (rhwp 아닌 스크립트도 가능 — 자가 테스트가 이 경로를 쓴다)
+    python3 tools/crash_minimizer.py crash.hwpx --oracle "python3 my_check.py {doc}"
+
+종료 코드: 0 = 축소 성공(산출물 실존), 1 = 실행 실패, 2 = 입력 오류 또는
+원본이 애초에 재현되지 않음(축소할 실패가 없음). exit 0 이면 산출물이 원본과
+같은 시그니처로 실패함을 마지막에 한 번 더 재검증한 상태다 — agent-toolkit 의
+"성공처럼 보이는 미완성 산출물을 남기지 않는다" 계약과 같다.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import io
+import json
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+
+# Rust 2021 패닉 형식: "thread 'main' panicked at src/parser/x.rs:123:45:"
+PANIC_RE = re.compile(r"panicked at\s+([^\r\n:]+\.rs:\d+)")
+
+# 이 멤버들이 없으면 HWPX 가 문서로 열리지 않는다 — 가지치기 대상에서 제외.
+ESSENTIAL_MEMBERS = ("mimetype", "version.xml", "META-INF/", "Contents/content.hpf")
+
+DEFAULT_TIMEOUT = 30.0
+
+
+def log(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+class Oracle:
+    """문서 하나를 명령에 먹여 실패 시그니처를 판정한다."""
+
+    def __init__(self, cmd_template: list[str], timeout: float, accept_exits: set[int]):
+        self.cmd_template = cmd_template
+        self.timeout = timeout
+        self.accept_exits = accept_exits
+        self.runs = 0
+
+    def signature(self, doc_path: Path) -> tuple | None:
+        """실패면 정규화된 시그니처 튜플, 실패가 아니면 None."""
+        cmd = [a.replace("{doc}", str(doc_path)) for a in self.cmd_template]
+        self.runs += 1
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=self.timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return ("timeout",)
+
+        panic = PANIC_RE.search(proc.stderr or "")
+        if panic:
+            # 열 번호·경로 구분자 차이를 무시하고 file.rs:line 만 본다.
+            return ("panic", panic.group(1).replace("\\", "/"))
+        rc = proc.returncode
+        if rc is None:
+            return ("abort", "unknown")
+        # Windows 액세스 위반(0xC0000005 등)·시그널 종료는 큰 값/음수로 온다.
+        if rc < 0 or rc >= 0xC0000000:
+            return ("abort", rc)
+        if rc != 0 and rc in self.accept_exits:
+            return ("exit", rc)
+        return None
+
+
+class HwpxDoc:
+    """ZIP 멤버 딕셔너리로 든 HWPX 한 부. 순서·압축 방식을 보존해 재작성한다."""
+
+    def __init__(self, names: list[str], data: dict[str, bytes], compress: dict[str, int]):
+        self.names = names
+        self.data = data
+        self.compress = compress
+
+    @classmethod
+    def load(cls, path: Path) -> "HwpxDoc":
+        with zipfile.ZipFile(path) as z:
+            infos = z.infolist()
+            return cls(
+                [i.filename for i in infos],
+                {i.filename: z.read(i.filename) for i in infos},
+                {i.filename: i.compress_type for i in infos},
+            )
+
+    def without_members(self, drop: set[str]) -> "HwpxDoc":
+        names = [n for n in self.names if n not in drop]
+        return HwpxDoc(
+            names,
+            {n: self.data[n] for n in names},
+            {n: self.compress[n] for n in names},
+        )
+
+    def with_member(self, name: str, payload: bytes) -> "HwpxDoc":
+        doc = HwpxDoc(list(self.names), dict(self.data), dict(self.compress))
+        doc.data[name] = payload
+        return doc
+
+    def write(self, path: Path) -> None:
+        with zipfile.ZipFile(path, "w") as z:
+            for n in self.names:
+                info = zipfile.ZipInfo(n)
+                info.compress_type = self.compress[n]
+                z.writestr(info, self.data[n])
+
+    def total_bytes(self) -> int:
+        return sum(len(v) for v in self.data.values())
+
+
+class Minimizer:
+    def __init__(self, oracle: Oracle, target_sig: tuple, workdir: Path):
+        self.oracle = oracle
+        self.target_sig = target_sig
+        self.workdir = workdir
+        self._probe_counter = 0
+
+    def still_fails(self, doc: HwpxDoc) -> bool:
+        self._probe_counter += 1
+        probe = self.workdir / f"probe_{self._probe_counter}.hwpx"
+        doc.write(probe)
+        sig = self.oracle.signature(probe)
+        probe.unlink(missing_ok=True)
+        return sig == self.target_sig
+
+    # --- 전략 1: ZIP 멤버 가지치기 -------------------------------------
+
+    def prune_members(self, doc: HwpxDoc) -> HwpxDoc:
+        candidates = [
+            n
+            for n in doc.names
+            if not any(n == e or n.startswith(e) for e in ESSENTIAL_MEMBERS)
+            and not re.match(r"Contents/section\d+\.xml$", n)
+            and n != "Contents/header.xml"
+        ]
+        for name in candidates:
+            trial = doc.without_members({name})
+            if self.still_fails(trial):
+                log(f"  멤버 제거: {name}")
+                doc = trial
+        return doc
+
+    # --- 전략 2·3: XML 자식 ddmin ---------------------------------------
+
+    def ddmin_children(self, doc: HwpxDoc, member: str, child_localname: str) -> HwpxDoc:
+        """member XML 의 (임의 깊이) 부모 아래 child_localname 자식들을 ddmin 으로 깎는다."""
+        try:
+            root, ns_map = parse_with_ns(doc.data[member])
+        except ET.ParseError:
+            return doc
+
+        parents = [
+            p for p in root.iter() if any(localname(c.tag) == child_localname for c in p)
+        ]
+        for parent in parents:
+            children = [c for c in parent if localname(c.tag) == child_localname]
+            if len(children) <= 1:
+                continue
+            keep = self._ddmin(
+                children,
+                lambda kept, _p=parent, _all=children: self._probe_with_children(
+                    doc, member, root, ns_map, _p, _all, kept
+                ),
+            )
+            if len(keep) < len(children):
+                log(f"  {member}: <{child_localname}> {len(children)} → {len(keep)}")
+                _replace_children(parent, children, keep)
+                doc = doc.with_member(member, serialize_with_ns(root, ns_map))
+        return doc
+
+    def _probe_with_children(self, doc, member, root, ns_map, parent, all_children, kept):
+        removed = [c for c in all_children if c not in kept]
+        _replace_children(parent, all_children, kept)
+        trial = doc.with_member(member, serialize_with_ns(root, ns_map))
+        ok = self.still_fails(trial)
+        _replace_children(parent, kept, all_children)  # 원상복구
+        _ = removed
+        return ok
+
+    @staticmethod
+    def _ddmin(items: list, test_keep) -> list:
+        """고전 ddmin: kept 부분집합이 실패를 유지하면 채택, 청크를 절반씩 좁힌다."""
+        cur = list(items)
+        n = 2
+        while len(cur) >= 2:
+            chunk = max(1, len(cur) // n)
+            reduced = False
+            for start in range(0, len(cur), chunk):
+                candidate = cur[:start] + cur[start + chunk :]
+                if candidate and test_keep(candidate):
+                    cur = candidate
+                    n = max(n - 1, 2)
+                    reduced = True
+                    break
+            if not reduced:
+                if n >= len(cur):
+                    break
+                n = min(len(cur), n * 2)
+        return cur
+
+
+def localname(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def parse_with_ns(payload: bytes):
+    ns_map = {}
+    for event, item in ET.iterparse(io.BytesIO(payload), events=("start-ns",)):
+        prefix, uri = item
+        ns_map[prefix] = uri
+    root = ET.fromstring(payload)
+    return root, ns_map
+
+
+def serialize_with_ns(root, ns_map) -> bytes:
+    for prefix, uri in ns_map.items():
+        ET.register_namespace(prefix, uri)
+    return ET.tostring(root, encoding="UTF-8", xml_declaration=True)
+
+
+def _replace_children(parent, current: list, new: list) -> None:
+    """parent 에서 current 집합을 걷어내고, 그 첫 위치에 new 를 순서대로 되꽂는다."""
+    all_children = list(parent)
+    insert_at = all_children.index(current[0])
+    for c in current:
+        parent.remove(c)
+    for offset, c in enumerate(new):
+        parent.insert(insert_at + offset, c)
+
+
+def emit_issue_draft(path: Path, args, sig: tuple, before: int, after: int, minimal: Path):
+    repro_cmd = " ".join(args.oracle_template).replace("{doc}", minimal.name)
+    kind = sig[0]
+    where = sig[1] if len(sig) > 1 else ""
+    payload = minimal.read_bytes()
+    attach = (
+        f"```\nbase64 -d <<'EOF' > {minimal.name}\n"
+        + base64.b64encode(payload).decode("ascii")
+        + "\nEOF\n```"
+        if len(payload) <= 48 * 1024
+        else f"(픽스처 {len(payload)}바이트 — 파일 첨부: `{minimal.name}`)"
+    )
+    path.write_text(
+        f"""# [자동 최소화] {kind} {where}
+
+## 증상
+
+`{repro_cmd}` 실행 시 {kind}{f' — `{where}`' if where else ''}.
+
+## 재현
+
+원본 {before:,}바이트 → 최소화 {after:,}바이트 (tools/crash_minimizer.py, 오라클 {args.timeout:.0f}s).
+같은 시그니처를 유지하는 한도에서 ZIP 멤버·문단·런을 델타 디버깅으로 제거한 결과다.
+
+{attach}
+
+## 판정 기준
+
+- 시그니처: `{sig}`
+- 최소화 산출물이 위 명령에서 같은 시그니처로 실패함을 저장 직전 재검증했다.
+""",
+        encoding="utf-8",
+    )
+
+
+def main(argv=None) -> int:
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+        sys.stderr.reconfigure(encoding="utf-8")
+
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("input", help="크래시가 재현되는 .hwpx")
+    ap.add_argument("--bin", help="rhwp 바이너리 경로 (--cmd 와 함께)")
+    ap.add_argument("--cmd", help='rhwp 하위 명령 템플릿, 예: "info {doc} --json"')
+    ap.add_argument("--oracle", help='임의 오라클 전체 명령 템플릿, 예: "python3 chk.py {doc}"')
+    ap.add_argument("-o", "--output", default=None, help="최소화 산출물 경로 (기본: <입력>.min.hwpx)")
+    ap.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
+    ap.add_argument("--accept-exit", type=int, action="append", default=[],
+                    help="이 종료 코드도 실패 시그니처로 인정 (기본: 패닉/abort/timeout 만)")
+    ap.add_argument("--emit-issue", help="이슈 초안 markdown 경로")
+    ap.add_argument("--max-passes", type=int, default=4, help="전략 반복 고정점 상한")
+    args = ap.parse_args(argv)
+
+    input_path = Path(args.input)
+    if not input_path.is_file():
+        log(f"입력이 없다: {input_path}")
+        return 2
+    if not zipfile.is_zipfile(input_path):
+        log("입력이 ZIP(HWPX)이 아니다 — 이 도구는 HWPX 전용이다 (docstring 참조).")
+        return 2
+
+    if args.oracle:
+        template = shlex.split(args.oracle)
+    elif args.bin and args.cmd:
+        template = [args.bin] + shlex.split(args.cmd)
+    else:
+        log("--oracle 또는 (--bin 과 --cmd) 가 필요하다.")
+        return 2
+    args.oracle_template = template
+
+    import shutil
+    exe = template[0].strip('"')
+    if not (Path(exe).is_file() or shutil.which(exe)):
+        log(f"오라클 실행 파일을 찾을 수 없다: {exe}"
+            " (Git Bash 의 /c/... 경로는 Windows 에서 안 통한다 — C:\\... 로)")
+        return 2
+
+    oracle = Oracle(template, args.timeout, set(args.accept_exit))
+    target_sig = oracle.signature(input_path)
+    if target_sig is None:
+        log("원본이 실패하지 않는다 — 최소화할 것이 없다. (깨끗한 오류 종료를 실패로 치려면 --accept-exit)")
+        return 2
+    log(f"목표 시그니처: {target_sig}")
+
+    output = Path(args.output) if args.output else input_path.with_suffix(".min.hwpx")
+    before_bytes = input_path.stat().st_size
+
+    started = time.monotonic()
+    with tempfile.TemporaryDirectory(prefix="crashmin_") as td:
+        mini = Minimizer(oracle, target_sig, Path(td))
+        doc = HwpxDoc.load(input_path)
+
+        for pass_no in range(1, args.max_passes + 1):
+            log(f"[pass {pass_no}]")
+            size_before_pass = doc.total_bytes()
+            doc = mini.prune_members(doc)
+            for member in [n for n in doc.names if re.match(r"Contents/section\d+\.xml$", n)]:
+                doc = mini.ddmin_children(doc, member, "p")
+                doc = mini.ddmin_children(doc, member, "run")
+            if doc.total_bytes() >= size_before_pass:
+                break
+
+        doc.write(output)
+
+    final_sig = oracle.signature(output)
+    if final_sig != target_sig:
+        output.unlink(missing_ok=True)
+        log(f"재검증 실패(시그니처 {final_sig}) — 산출물을 남기지 않는다.")
+        return 1
+
+    after_bytes = output.stat().st_size
+    elapsed = time.monotonic() - started
+    print(json.dumps({
+        "input": str(input_path),
+        "output": str(output),
+        "signature": list(target_sig),
+        "bytesBefore": before_bytes,
+        "bytesAfter": after_bytes,
+        "oracleRuns": oracle.runs,
+        "seconds": round(elapsed, 1),
+    }, ensure_ascii=False))
+
+    if args.emit_issue:
+        emit_issue_draft(Path(args.emit_issue), args, target_sig, before_bytes, after_bytes, output)
+        log(f"이슈 초안: {args.emit_issue}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/regression_loop/gate.py
+++ b/tools/regression_loop/gate.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""회귀 게이트 — 한때 고쳐진 결함이 다시 살아났는지 판정한다.
+
+## 왜 있는가
+
+[`promote.py`](promote.py) 가 쌓은 대장(`tests/regression_corpus/ledger.json`)은
+"한때 깨졌던 것"의 목록이다. 이 게이트는 그중 **고쳐진 것으로 확인된**(`guarded`)
+항목을 전부 다시 돌려, 하나라도 원래 시그니처로 되살아났으면 실패한다.
+
+이것이 고리의 마지막 마디다. 발견(fuzz_corpus)·트리아지(fde)·축소(crash_minimizer)·
+승격(promote)까지 왔어도, 재발을 잡는 상시 게이트가 없으면 같은 결함이 조용히
+돌아온다.
+
+## 판정 규칙 (정직하게)
+
+- `guarded` 항목이 **원래 시그니처로** 다시 실패 → 회귀. exit 3.
+- `guarded` 항목이 **다른 시그니처로** 실패 → 회귀로 세되 별도 표기한다.
+  같은 자리는 아니지만 고쳐진 것이 다시 깨진 건 사실이다.
+- `open` 항목(아직 안 고쳐진 사건)은 재현돼도 **게이트를 실패시키지 않는다.**
+  알려진 미수정 결함으로 CI 를 막는 것은 게이트를 무의미하게 만든다 — 대신
+  보고에는 항상 싣는다.
+- 픽스처가 없는 항목(최소화 불가)은 자동 판정 대상이 아니다. `skipped` 로
+  세고 보고에 남긴다 — **조용히 빠뜨리지 않는다.**
+
+## 사용
+
+    python3 tools/regression_loop/gate.py --bin target/release/rhwp
+    python3 tools/regression_loop/gate.py --bin <rhwp> --json
+
+종료 코드: 0 = 회귀 없음 / 1 = 실행 실패 / 2 = 입력 오류 / 3 = 회귀 발견(판정).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LEDGER = REPO_ROOT / "tests" / "regression_corpus" / "ledger.json"
+PANIC_RE = re.compile(r"panicked at\s+([^\r\n:]+\.rs:\d+)")
+
+
+def log(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+def signature_of(bin_path: str, doc: Path, cmd_args: list[str], timeout: float):
+    cmd = [bin_path] + [a.replace("{doc}", str(doc)) for a in cmd_args]
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8",
+                           errors="replace", timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return ["timeout"]
+    m = PANIC_RE.search(p.stderr or "")
+    if m:
+        return ["panic", m.group(1).replace("\\", "/")]
+    if p.returncode < 0 or p.returncode >= 0xC0000000:
+        return ["abort", p.returncode]
+    return None
+
+
+def main(argv=None) -> int:
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+        sys.stderr.reconfigure(encoding="utf-8")
+
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--bin", help="rhwp 바이너리 (기본: RHWP_BIN → PATH)")
+    ap.add_argument("--timeout", type=float, default=30.0)
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+
+    if not LEDGER.is_file():
+        log(f"대장이 없다 — 승격된 사건이 아직 없다: {LEDGER.relative_to(REPO_ROOT)}")
+        return 0
+    import os
+    bin_path = args.bin or os.environ.get("RHWP_BIN") or shutil.which("rhwp")
+    if not bin_path or not (Path(bin_path).is_file() or shutil.which(bin_path)):
+        log("rhwp 바이너리를 찾을 수 없다 (--bin / RHWP_BIN / PATH).")
+        return 2
+
+    led = json.loads(LEDGER.read_text(encoding="utf-8"))
+    regressions, still_open, skipped, held = [], [], [], []
+
+    for e in led.get("entries", []):
+        if not e.get("fixture"):
+            skipped.append({**e, "why": "픽스처 없음 — 수동 절차 항목"})
+            continue
+        fixture = REPO_ROOT / e["fixture"]
+        if not fixture.is_file():
+            skipped.append({**e, "why": f"픽스처 파일 없음: {e['fixture']}"})
+            continue
+        sig = signature_of(bin_path, fixture, e["command"].split(), args.timeout)
+        if e["status"] == "guarded":
+            if sig is None:
+                held.append(e["id"])
+            else:
+                regressions.append({
+                    "id": e["id"], "expected": e["signature"], "observed": sig,
+                    "sameSignature": sig == e["signature"], "command": e["command"],
+                })
+        elif sig is not None:
+            still_open.append(e["id"])
+
+    report = {
+        "ledger": str(LEDGER.relative_to(REPO_ROOT)).replace("\\", "/"),
+        "guardedHeld": held,
+        "regressions": regressions,
+        "stillOpen": still_open,
+        "skipped": [{"id": s["id"], "why": s["why"]} for s in skipped],
+    }
+
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=1))
+    else:
+        print(f"회귀 게이트 — 영구 게이트 {len(held)}건 유지, 회귀 {len(regressions)}건")
+        for r in regressions:
+            same = "같은 자리" if r["sameSignature"] else f"다른 자리(원래 {r['expected']})"
+            print(f"  ✗ {r['id']} 회귀 — {r['observed']} [{same}]  `{r['command']}`")
+        if still_open:
+            print(f"  ○ 미수정 재현(게이트 미실패): {', '.join(still_open)}")
+        for s in skipped:
+            print(f"  – 건너뜀 {s['id']}: {s['why']}")
+
+    return 3 if regressions else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/regression_loop/promote.py
+++ b/tools/regression_loop/promote.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""현장 사건을 영구 회귀 게이트로 승격한다 — 한 번 고친 것이 두 번 깨지지 않게.
+
+## 왜 있는가 (닫히지 않은 고리)
+
+이 저장소는 결함을 **찾는** 장치가 여럿이다: `gym/tools/fuzz_corpus.py`(퍼즈 발견),
+`tools/fde/triage.py`(고객 증상 트리아지), `tools/crash_minimizer.py`(최소 재현체).
+고치는 경로도 있다. 그런데 **고친 뒤 그 사건이 영구 시험으로 남는 경로가 없다.**
+
+지금의 회귀 스위트(`tests/security_corpus_regression.rs`·
+`tests/convert_verify_corpus_ratchet.rs` 등)는 전부 사람이 도메인별로 손으로 쓴
+것이다. 고객이 들고 온 사건 하나하나에 Rust 시험을 손으로 쓰는 사람은 없다.
+그래서 사건은 처리되고 **잊힌다** — 같은 결함이 다시 들어와도 아무 게이트도
+울리지 않는다.
+
+이 도구는 그 고리를 닫는다: 사건 → (재현 확인) → 최소화 → 대장 등재 →
+[수정] → (수정 확인) → **영구 게이트**. 대장은 "한때 깨졌던 것"의 목록이고
+줄어들지 않는다.
+
+## 정직 규칙 (유령 게이트를 만들지 않는다)
+
+1. **재현되지 않는 사건은 승격하지 않는다.** 등재 전에 실제로 실패를
+   재현시켜 본다. 재현 안 되면 exit 3 으로 거절한다 — 아무것도 지키지 않는
+   게이트가 지키는 척하는 것이 최악이다.
+2. **`open` 과 `guarded` 를 구별한다.** 등재 직후는 `open`(아직 안 고쳐짐)이고,
+   게이트를 실패시키지 않는다. `--confirm-fixed` 로 **더는 재현되지 않음을
+   확인해야만** `guarded` 가 되고, 그때부터 재발이 곧 회귀다.
+3. 고객 문서는 대장에 싣지 않는다 — 최소화 산출물만 픽스처로 커밋하고,
+   최소화가 불가능하면(HWP5 등) 시그니처와 절차만 남긴다.
+
+## 사용
+
+    # fde 티켓에서 승격 (권장 경로)
+    python3 tools/regression_loop/promote.py --ticket ticket.json --bin <rhwp>
+
+    # 직접 지정
+    python3 tools/regression_loop/promote.py --doc bad.hwpx \
+        --cmd "info {doc} --json" --bin <rhwp>
+
+    # 수정이 머지된 뒤 — 더는 재현되지 않음을 확인하고 영구 게이트로 승격
+    python3 tools/regression_loop/promote.py --confirm-fixed RG-3 --bin <rhwp>
+
+    python3 tools/regression_loop/promote.py --list
+
+종료 코드: 0 = 승격됨 / 1 = 실행 실패 / 2 = 입력 오류 /
+3 = 판정(재현 안 됨 → 등재 거절, 또는 --confirm-fixed 인데 아직 재현됨).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LEDGER = REPO_ROOT / "tests" / "regression_corpus" / "ledger.json"
+FIXTURES = REPO_ROOT / "tests" / "regression_corpus" / "fixtures"
+MINIMIZER = REPO_ROOT / "tools" / "crash_minimizer.py"
+
+PANIC_RE = re.compile(r"panicked at\s+([^\r\n:]+\.rs:\d+)")
+
+
+def log(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+def load_ledger() -> dict:
+    if LEDGER.is_file():
+        return json.loads(LEDGER.read_text(encoding="utf-8"))
+    return {"schemaVersion": "1", "note": "한때 깨졌던 것들 — 줄어들지 않는다.", "entries": []}
+
+
+def save_ledger(led: dict) -> None:
+    LEDGER.parent.mkdir(parents=True, exist_ok=True)
+    LEDGER.write_text(json.dumps(led, ensure_ascii=False, indent=1) + "\n", encoding="utf-8")
+
+
+def signature_of(bin_path: str, doc: Path, cmd_args: list[str], timeout: float):
+    """실행해 실패 시그니처를 낸다. 실패가 아니면 None — triage.py 와 같은 판정 규칙."""
+    cmd = [bin_path] + [a.replace("{doc}", str(doc)) for a in cmd_args]
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8",
+                           errors="replace", timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return ["timeout"]
+    m = PANIC_RE.search(p.stderr or "")
+    if m:
+        return ["panic", m.group(1).replace("\\", "/")]
+    if p.returncode < 0 or p.returncode >= 0xC0000000:
+        return ["abort", p.returncode]
+    return None
+
+
+def minimize(doc: Path, bin_path: str, cmd_args: list[str], out: Path) -> Path | None:
+    """HWPX 면 최소화한다. 실패하거나 대상이 아니면 None — 원본을 대신 싣지 않는다."""
+    if doc.suffix.lower() != ".hwpx" or not MINIMIZER.is_file():
+        return None
+    out.parent.mkdir(parents=True, exist_ok=True)
+    p = subprocess.run(
+        [sys.executable, str(MINIMIZER), str(doc), "--bin", bin_path,
+         "--cmd", " ".join(cmd_args), "-o", str(out)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    return out if p.returncode == 0 and out.is_file() else None
+
+
+def cmd_promote(args) -> int:
+    bin_path = args.bin or shutil.which("rhwp")
+    if not bin_path or not (Path(bin_path).is_file() or shutil.which(bin_path)):
+        log("rhwp 바이너리를 찾을 수 없다 (--bin).")
+        return 2
+
+    if args.ticket:
+        t = json.loads(Path(args.ticket).read_text(encoding="utf-8"))
+        doc = Path(args.ticket).parent / Path(t["doc"]).name
+        if not doc.is_file():
+            doc = Path(t["doc"])
+        failed = [s for s in t.get("steps", []) if "failureSignature" in s]
+        if not failed:
+            log("티켓에 실패 단계가 없다 — 승격할 사건이 아니다.")
+            return 3
+        cmd_args = failed[0]["command"].split()
+        source = f"fde-ticket:{Path(args.ticket).name}"
+    elif args.doc and args.cmd:
+        doc, cmd_args, source = Path(args.doc), args.cmd.split(), args.source or "manual"
+    else:
+        log("--ticket 또는 (--doc 과 --cmd) 가 필요하다.")
+        return 2
+
+    if not doc.is_file():
+        log(f"문서가 없다: {doc}")
+        return 2
+
+    # 정직 규칙 1 — 재현되지 않으면 등재하지 않는다.
+    sig = signature_of(bin_path, doc, cmd_args, args.timeout)
+    if sig is None:
+        log("이 사건은 지금 재현되지 않는다 — 등재를 거절한다(유령 게이트 금지).")
+        return 3
+    log(f"재현 확인: {sig}")
+
+    led = load_ledger()
+    for e in led["entries"]:
+        if e["signature"] == sig and e["command"] == " ".join(cmd_args):
+            log(f"이미 대장에 있다: {e['id']} ({e['status']})")
+            return 0
+
+    rg_id = f"RG-{len(led['entries']) + 1}"
+    fixture = minimize(doc, bin_path, cmd_args, FIXTURES / f"{rg_id}.hwpx")
+    if fixture:
+        # 최소화본이 같은 시그니처로 실패하는지 재확인 — 축소가 사건을 바꿨으면 못 쓴다.
+        if signature_of(bin_path, fixture, cmd_args, args.timeout) != sig:
+            log("최소화본이 다른 시그니처로 실패한다 — 픽스처를 버리고 절차만 남긴다.")
+            fixture.unlink(missing_ok=True)
+            fixture = None
+
+    entry = {
+        "id": rg_id,
+        "status": "open",
+        "signature": sig,
+        "command": " ".join(cmd_args),
+        "fixture": str(fixture.relative_to(REPO_ROOT)).replace("\\", "/") if fixture else None,
+        "source": source,
+        "note": None if fixture else "최소화 불가(HWPX 아님 또는 축소 실패) — 시그니처·절차만",
+    }
+    led["entries"].append(entry)
+    save_ledger(led)
+    log(f"승격: {rg_id} status=open"
+        + (f", 픽스처 {entry['fixture']}" if fixture else " (픽스처 없음)"))
+    log("수정이 머지되면 --confirm-fixed 로 guarded 로 올려라 — 그때부터 재발이 회귀다.")
+    print(json.dumps(entry, ensure_ascii=False))
+    return 0
+
+
+def cmd_confirm_fixed(args) -> int:
+    bin_path = args.bin or shutil.which("rhwp")
+    if not bin_path:
+        log("rhwp 바이너리를 찾을 수 없다 (--bin).")
+        return 2
+    led = load_ledger()
+    entry = next((e for e in led["entries"] if e["id"] == args.confirm_fixed), None)
+    if entry is None:
+        log(f"대장에 없는 id: {args.confirm_fixed}")
+        return 2
+    if not entry.get("fixture"):
+        log("픽스처가 없는 항목은 자동 확인할 수 없다 — 절차대로 수동 확인 후 대장을 직접 고쳐라.")
+        return 2
+
+    fixture = REPO_ROOT / entry["fixture"]
+    sig = signature_of(bin_path, fixture, entry["command"].split(), args.timeout)
+    if sig is not None:
+        log(f"아직 재현된다({sig}) — guarded 로 올리지 않는다.")
+        return 3
+    entry["status"] = "guarded"
+    save_ledger(led)
+    log(f"{entry['id']} → guarded. 이제 재발하면 게이트가 실패한다.")
+    return 0
+
+
+def cmd_list(_args) -> int:
+    led = load_ledger()
+    if not led["entries"]:
+        print("대장이 비어 있다.")
+        return 0
+    for e in led["entries"]:
+        mark = "🛡" if e["status"] == "guarded" else "○"
+        print(f"{mark} {e['id']:<7} {e['status']:<8} {str(e['signature']):<44} {e['source']}")
+    guarded = sum(1 for e in led["entries"] if e["status"] == "guarded")
+    print(f"\n총 {len(led['entries'])}건 · 영구 게이트 {guarded}건 · 미수정 {len(led['entries']) - guarded}건")
+    return 0
+
+
+def main(argv=None) -> int:
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+        sys.stderr.reconfigure(encoding="utf-8")
+
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--ticket", help="tools/fde/triage.py 가 낸 티켓 JSON")
+    ap.add_argument("--doc", help="재현 문서 (직접 지정)")
+    ap.add_argument("--cmd", help='재현 명령 템플릿, 예: "info {doc} --json"')
+    ap.add_argument("--source", help="사건 출처 표기 (기본: manual)")
+    ap.add_argument("--bin", help="rhwp 바이너리")
+    ap.add_argument("--timeout", type=float, default=30.0)
+    ap.add_argument("--confirm-fixed", metavar="RG-N", help="수정 확인 후 guarded 로 승격")
+    ap.add_argument("--list", action="store_true", help="대장 조회")
+    args = ap.parse_args(argv)
+
+    if args.list:
+        return cmd_list(args)
+    if args.confirm_fixed:
+        return cmd_confirm_fixed(args)
+    return cmd_promote(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 변경 요약

**현장 사건을 영구 회귀 게이트로 승격하는 폐회로**를 추가합니다. `tools/regression_loop/promote.py`(승격)와 `gate.py`(재발 판정) 2종.

**닫히지 않았던 고리**: 이 저장소는 결함을 **찾는** 장치가 여럿입니다 — `gym/tools/fuzz_corpus.py`(퍼즈 발견), `tools/fde/triage.py`(고객 증상 트리아지, #4894), `tools/crash_minimizer.py`(최소 재현체, #4891). 고치는 경로도 있습니다. 그런데 **고친 뒤 그 사건이 영구 시험으로 남는 경로가 없었습니다.**

기존 회귀 스위트(`tests/security_corpus_regression.rs`·`tests/convert_verify_corpus_ratchet.rs` 등)는 전부 사람이 도메인별로 손으로 쓴 것입니다. 고객이 들고 온 사건 하나하나에 Rust 시험을 손으로 쓰는 사람은 없고, 그래서 사건은 처리되고 잊힙니다 — 같은 결함이 다시 들어와도 아무 게이트도 울리지 않습니다.

```
사건(fde 티켓/퍼즈/수동) → 재현 확인 → 최소화 → 대장 등재(open)
                                                      ↓ [수정 머지]
                                          수정 확인 → guarded(영구 게이트)
                                                      ↓
                                    gate.py 전수 재실행 → 재발이면 exit 3
```

## 정직 규칙 (유령 게이트를 만들지 않는다)

- **재현되지 않는 사건은 등재를 거절**합니다(exit 3). 아무것도 지키지 않는 게이트가 지키는 척하는 것이 최악입니다.
- **`open`(미수정)과 `guarded`(수정 확인됨)를 구별**합니다. 알려진 미수정 결함으로 CI 를 막으면 게이트가 무의미해지므로 `open` 재현은 게이트를 실패시키지 않되 **보고에는 항상 싣습니다**. `guarded` 재발만 회귀로 판정합니다.
- **최소화본이 다른 시그니처로 실패하면 픽스처를 버립니다** — 축소가 사건을 바꿨다는 뜻입니다.
- 픽스처 없는 항목(최소화 불가)은 `skipped` 로 세고 보고에 남깁니다 — 조용히 빠뜨리지 않습니다.
- 고객 문서는 대장에 싣지 않습니다 — 최소화 산출물만 픽스처로, 불가능하면 시그니처와 절차만.

## 관련 이슈

없음 (도구 추가)

## 테스트

결정적 가짜 오라클(문서에 마커가 있으면 Rust 패닉 형식으로 죽고, `FIXED=1` 이면 고쳐진 척)로 **전 경로 8/8 실측**:

- [x] 재현 안 되는 사건 → **승격 거절**(exit 3)
- [x] 진짜 사건 승격 → `open`, 최소화 **4,503→868B (19%)**, 시그니처 정확히 기록
- [x] 같은 사건 중복 등재 방지
- [x] 아직 안 고쳐졌는데 `--confirm-fixed` → **거절**(exit 3)
- [x] `open` 항목 재현 → 게이트 통과 + 보고에 `stillOpen` 표기
- [x] 수정 확인 후 `guarded` 승격
- [x] 고쳐진 상태 → 게이트 통과(`guardedHeld`)
- [x] **회귀 발생 → 게이트가 exit 3 으로 탐지** (같은 자리/다른 자리 구분 포함)
- [ ] `cargo test` / `cargo clippy` — 해당 없음 (Rust 소스 미변경, 독립 Python 도구)

## 성능 영향 및 측정 결과

- 예상 영향: 없음 (독립 실행 도구 추가, 기존 코드 미변경)

## 스택 의존성

`tools/crash_minimizer.py`(#4891) 위에 스택됩니다 — 최소화가 이 고리의 축소 마디이고, 픽스처 없이는 게이트가 자동 판정할 수 없습니다. #4891 머지 후 이 PR 고유 diff 는 커밋 1개(파일 2개)입니다. `tools/fde/triage.py`(#4894)의 티켓을 `--ticket` 으로 직접 먹을 수 있으나, 없어도 `--doc`/`--cmd` 로 동작합니다(선택 의존).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
