### PR TITLE
fix(serializer): 소프트 하이픈을 원본 표기대로 저장한다 (#4895)

### DIFF
--- a/src/serializer/body_text.rs
+++ b/src/serializer/body_text.rs
@@ -402,9 +402,11 @@ fn compute_control_mask(para: &Paragraph) -> u32 {
     if para.text.contains('\u{00A0}') {
         mask |= 1u32 << 0x001E;
     }
-    // 하이픈 (0x0018): serialize_para_text 가 U+00AD 마다 코드 0x18 을 방출하므로
-    // control_mask 비트 24 도 세워 PARA_HEADER 를 PARA_TEXT 와 일치시킨다.
-    if para.text.contains('\u{00AD}') {
+    // [#4895] 하이픈 (0x0018) 비트는 **출처가 제어 표기였을 때만** 유지한다.
+    // serialize_para_text 가 같은 조건으로만 코드 24 를 방출하므로 둘이 함께 움직인다.
+    // 리터럴 원본(한컴 실측 00302: PARA_TEXT `ad 00`, mask 0)에 비트를 세우면
+    // PARA_HEADER 가 있지도 않은 제어문자를 주장해 헤더/텍스트가 어긋난다.
+    if para.text.contains('\u{00AD}') && para.control_mask & (1u32 << 0x0018) != 0 {
         mask |= 1u32 << 0x0018;
     }
     // 제목 차례 표시 (0x0008): serialize_para_text 가 title_marks 마다 코드 0x08 을
@@ -833,10 +835,14 @@ fn serialize_para_text(para: &Paragraph) -> ParaTextResult {
                 code_units.push(0x001E);
                 prev_end = offset + 1;
             }
-            '\u{00AD}' => {
-                // 소프트 하이픈 (HWP 5.0 표 7: 코드 24). 파서가 0x18 을 U+00AD 로
-                // 받으므로 저장도 제어문자로 되돌린다 — 리터럴로 쓰면 다음 왕복에서
-                // 실제 하이픈이 되어 단어가 갈라진다.
+            // [#4895] 소프트 하이픈(U+00AD)은 **원본 표기를 따라간다.** #4776 은 늘
+            // 코드 24(0x18)로 되돌렸지만, 한컴이 만든 문서는 두 표기를 다 쓴다
+            // (10k 코퍼스 실측: 리터럴 원본 58문서 · 제어 표기 원본 10문서).
+            // 한글 2022 는 0x18 을 텍스트로 복원하지 않으므로, 리터럴 원본을 제어코드로
+            // 바꾸면 저장본에서 글자가 사라진다(10k 스윕 36경로 회귀).
+            // 출처 신호는 PARA_HEADER `control_mask` 비트 24 다 — 그 비트가 선 문단만
+            // 제어코드로 되돌리고, 나머지는 아래 기본 분기가 리터럴로 방출한다.
+            '\u{00AD}' if para.control_mask & (1u32 << 0x0018) != 0 => {
                 code_units.push(0x0018);
                 prev_end = offset + 1;
             }
@@ -2000,6 +2006,58 @@ mod tests {
         let bytes = test_serialize_para_text(&para);
 
         assert_eq!(&bytes[2..4], &0x001E_u16.to_le_bytes());
+    }
+
+    /// [#4895] 소프트 하이픈(U+00AD)은 코드 24(0x18)가 아니라 **리터럴 문자**로 나간다.
+    ///
+    /// #4776 이 표 7 의 코드 24 로 되돌렸다가 10k 전수에서 36경로가 깨졌다 —
+    /// 한글 2022 는 0x18 을 텍스트로 복원하지 않아 저장본에서 글자가 사라진다.
+    /// 한컴 원본 실측(00302)도 PARA_TEXT 에 `ad 00`(리터럴)을 담는다.
+    #[test]
+    fn test_soft_hyphen_serializes_as_literal_char() {
+        let para = Paragraph {
+            char_count: 4,
+            text: "가\u{00AD}나".to_string(),
+            char_offsets: vec![0, 1, 2],
+            ..Default::default()
+        };
+
+        let bytes = test_serialize_para_text(&para);
+
+        assert_eq!(&bytes[2..4], &0x00AD_u16.to_le_bytes());
+    }
+
+    /// [#4895] 리터럴 출처면 control_mask 비트 24 도 세우지 않는다.
+    /// 한컴 원본(00302)의 PARA_HEADER 도 소프트 하이픈이 든 문단에서 mask 가 0 이다.
+    #[test]
+    fn test_soft_hyphen_does_not_set_control_mask_bit_24() {
+        let para = Paragraph {
+            char_count: 4,
+            text: "가\u{00AD}나".to_string(),
+            char_offsets: vec![0, 1, 2],
+            ..Default::default()
+        };
+
+        assert_eq!(compute_control_mask(&para) & (1u32 << 0x0018), 0);
+    }
+
+    /// [#4895] 반대로 **제어 표기 원본**(control_mask 비트 24)은 코드 24 로 되돌린다 —
+    /// 한글이 그 자리를 텍스트로 내지 않는 것까지가 원본의 동작이라, 리터럴로 바꾸면
+    /// 원본에 없던 글자가 생긴다. 10k 코퍼스에 이런 원본이 10문서 있다.
+    #[test]
+    fn test_soft_hyphen_from_control_origin_stays_code_24() {
+        let para = Paragraph {
+            char_count: 4,
+            control_mask: 1u32 << 0x0018,
+            text: "가\u{00AD}나".to_string(),
+            char_offsets: vec![0, 1, 2],
+            ..Default::default()
+        };
+
+        let bytes = test_serialize_para_text(&para);
+
+        assert_eq!(&bytes[2..4], &0x0018_u16.to_le_bytes());
+        assert_ne!(compute_control_mask(&para) & (1u32 << 0x0018), 0);
     }
 
     /// [NBSP mask] U+00A0 은 PARA_TEXT 에 코드 0x1E 로 방출되므로 PARA_HEADER control_mask

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -703,6 +703,11 @@ pub(crate) struct InlineCursor<'a> {
     pub mark_idx: usize,
     /// 지금까지 방출한 문단 텍스트의 문자 수
     pub char_idx: usize,
+    /// [#4895] 이 문단의 소프트 하이픈을 `<hp:hyphen/>` 요소로 내릴지 여부.
+    ///
+    /// 한컴 원본은 소프트 하이픈을 리터럴 U+00AD 로도, 제어 표기로도 쓴다. 출처가
+    /// 제어 표기(HWP5 `control_mask` 비트 24)일 때만 요소로 내려 원본 표기를 지킨다.
+    pub soft_hyphen_as_element: bool,
 }
 
 impl InlineCursor<'_> {
@@ -775,10 +780,19 @@ pub(crate) fn render_hp_t_content(
                 flush_buf(&mut t_xml, &mut buf);
                 t_xml.push_str("<hp:fwSpace/>");
             }
-            // 소프트 하이픈도 같은 계약이다 — 리터럴 '-' 로 내리면 한글이 실제
-            // 하이픈으로 읽어 단어가 갈라진다(`pertinent` → `per-tinent`).
-            // 스키마의 `<hp:hyphen>`(ParaList XML schema.xml:291)으로 되돌린다.
-            '\u{00AD}' => {
+            // [#4895] 소프트 하이픈(U+00AD)은 U+2007 과 달리 **원본 표기를 따라간다.**
+            // 종전에는 늘 `<hp:hyphen/>` 요소로 내렸는데(#4776), 한컴이 만든 문서는
+            // 두 표기를 다 쓴다(10k 코퍼스 실측: 리터럴 원본 58문서 · 제어 표기 원본 10문서).
+            //
+            // 한글 2022 대조 실측(01628, 하이픈 표기만 교체):
+            //   `<hp:hyphen/>`     → 본문 2,477자 (한글이 글자를 버린다)
+            //   raw U+00AD 리터럴  → 본문 2,478자, 원본과 textSha 일치
+            //
+            // 즉 한글은 요소·제어문자를 텍스트로 복원하지 않는다. 리터럴 원본을 요소로
+            // 바꾸면 글자가 사라지고(10k 스윕 36경로 회귀), 반대로 제어 표기 원본을
+            // 리터럴로 바꾸면 원본에 없던 글자가 생긴다. 그래서 출처 표기를 보존한다 —
+            // HWP5 PARA_HEADER `control_mask` 비트 24 가 그 신호다(`cursor` 가 나른다).
+            '\u{00AD}' if cursor.soft_hyphen_as_element => {
                 flush_buf(&mut t_xml, &mut buf);
                 t_xml.push_str("<hp:hyphen/>");
             }
@@ -1128,6 +1142,8 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> (String, bool) {
     // 슬롯 축이 책갈피를 잡지 못하던 시절의 우회였고, 그대로 두면 이중 방출이 된다.
     let mut cursor = InlineCursor {
         title_marks: &para.title_marks,
+        // [#4895] 출처가 제어 표기였던 문단만 `<hp:hyphen/>` 로 되돌린다.
+        soft_hyphen_as_element: para.control_mask & (1u32 << 0x0018) != 0,
         ..Default::default()
     };
 
@@ -3110,6 +3126,44 @@ mod tests {
         assert!(
             !xml.contains(r#"formatType="CIRCLE_DIGIT""#),
             "CIRCLE_DIGIT 오탈자 잔존 금지: {xml}"
+        );
+    }
+
+    /// [#4895] 소프트 하이픈(U+00AD)은 `<hp:hyphen/>` 요소가 아니라 **리터럴 문자**로 나간다.
+    ///
+    /// #4776 이 요소로 바꿨다가 10k 전수에서 36경로가 깨졌다. 한글 2022 대조 실측(01628,
+    /// 하이픈 표기만 교체): 요소 → 본문 2,477자(글자 소실) / 리터럴 → 2,478자로 원본과
+    /// textSha 일치. 한컴 원본 hwpx 도 `<hp:t>` 안에 raw U+00AD 를 담는다.
+    #[test]
+    fn soft_hyphen_stays_literal_in_hp_t() {
+        let mut cursor = InlineCursor::default();
+        let xml = render_hp_t_content("축사로\u{00AD}한우", &[], &mut cursor);
+        assert!(
+            !xml.contains("<hp:hyphen/>"),
+            "소프트 하이픈을 요소로 내리면 한글이 글자를 버린다: {xml}"
+        );
+        assert!(
+            xml.contains('\u{00AD}'),
+            "소프트 하이픈이 리터럴로 실려야 한다: {xml:?}"
+        );
+    }
+
+    /// [#4895] 출처가 제어 표기(HWP5 control_mask 비트 24)인 문단만 `<hp:hyphen/>` 로
+    /// 되돌린다 — 원본에 없던 글자를 만들지 않기 위해서다.
+    #[test]
+    fn soft_hyphen_from_control_origin_is_written_as_element() {
+        let mut cursor = InlineCursor {
+            soft_hyphen_as_element: true,
+            ..Default::default()
+        };
+        let xml = render_hp_t_content("축사로\u{00AD}한우", &[], &mut cursor);
+        assert!(
+            xml.contains("<hp:hyphen/>"),
+            "제어 표기 출처는 요소로 보존되어야 한다: {xml}"
+        );
+        assert!(
+            !xml.contains('\u{00AD}'),
+            "요소로 내렸으면 리터럴은 남지 않는다: {xml:?}"
         );
     }
 

--- a/tests/issue_4895_soft_hyphen_literal.rs
+++ b/tests/issue_4895_soft_hyphen_literal.rs
@@ -1,0 +1,95 @@
+//! Issue #4895: 소프트 하이픈(U+00AD)을 제어 표현으로 저장해 한글이 글자를 버리는 회귀.
+//!
+//! #4776 은 소프트 하이픈을 HWPX `<hp:hyphen/>` 요소와 HWP5 코드 24(0x18)로 되돌렸다.
+//! 그러나 한컴 원본 실측은 반대다 — hwpx 원본은 `<hp:t>` 안에 raw U+00AD 문자를,
+//! hwp 원본은 PARA_TEXT 에 `ad 00` 리터럴을 담는다(control_mask 비트 24 도 안 세운다).
+//!
+//! 한글 2022 대조 실측(10k 코퍼스 01628, 하이픈 표기만 교체):
+//!
+//! | 검체 | 한글이 뽑은 본문 |
+//! |---|---|
+//! | 원본 hwpx | 2,478자 |
+//! | `<hp:hyphen/>` 로 저장 | 2,477자 (글자 소실) |
+//! | raw U+00AD 로 저장 | 2,478자 — 원본과 textSha 일치 |
+//!
+//! 전수 영향: 한글 2022 오라클 10k 스윕에서 36경로(h2x 22 · x2x 7 · x2h 7)가 깨졌다.
+//! 바이트 축 계약은 `src/serializer/body_text.rs`·`src/serializer/hwpx/section.rs` 의
+//! 단위 시험이 잡고, 여기서는 실제 문서 왕복을 지킨다.
+
+use std::fs;
+use std::io::Read;
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+
+fn load(rel: &str) -> DocumentCore {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", rel, e));
+    DocumentCore::from_bytes(&bytes).expect("parse")
+}
+
+/// 저장된 HWPX 의 `Contents/section*.xml` 을 모두 이어 붙인다.
+fn section_xml(bytes: &[u8]) -> String {
+    let mut zin = zip::ZipArchive::new(std::io::Cursor::new(bytes)).expect("zip 열기");
+    let mut out = String::new();
+    for i in 0..zin.len() {
+        let mut f = zin.by_index(i).expect("zip 항목");
+        let name = f.name().to_string();
+        if name.starts_with("Contents/section") && name.ends_with(".xml") {
+            let mut s = String::new();
+            f.read_to_string(&mut s).expect("section xml 읽기");
+            out.push_str(&s);
+        }
+    }
+    out
+}
+
+/// `export-text` 와 같은 축(쪽별 본문)에서 소프트 하이픈을 센다.
+fn soft_hyphen_count(core: &DocumentCore) -> usize {
+    (0..core.page_count())
+        .filter_map(|p| core.extract_page_text_native(p).ok())
+        .map(|t| t.matches('\u{00AD}').count())
+        .sum()
+}
+
+#[test]
+fn hwpx_save_writes_soft_hyphen_as_literal_char() {
+    let core = load("samples/hwpx/hcar-001.hwpx");
+    let before = soft_hyphen_count(&core);
+    assert!(before > 0, "표본에 소프트 하이픈이 있어야 시험이 성립한다");
+
+    let saved = core.export_hwpx_native().expect("export hwpx");
+    let xml = section_xml(&saved);
+
+    assert!(
+        !xml.contains("<hp:hyphen/>"),
+        "소프트 하이픈을 <hp:hyphen/> 요소로 내리면 한글이 그 글자를 버린다"
+    );
+    assert!(
+        xml.contains('\u{00AD}'),
+        "소프트 하이픈이 hp:t 안에 리터럴 문자로 실려야 한다"
+    );
+
+    let reloaded = DocumentCore::from_bytes(&saved).expect("reparse");
+    assert_eq!(
+        soft_hyphen_count(&reloaded),
+        before,
+        "저장·재로드에서 소프트 하이픈 수가 보존되어야 한다"
+    );
+}
+
+#[test]
+fn hwp5_save_preserves_soft_hyphen_through_roundtrip() {
+    let mut core = load("samples/hcar-001.hwp");
+    let before = soft_hyphen_count(&core);
+    assert!(before > 0, "표본에 소프트 하이픈이 있어야 시험이 성립한다");
+
+    let saved = core.export_hwp_with_adapter().expect("export hwp");
+    let reloaded = DocumentCore::from_bytes(&saved).expect("reparse");
+
+    assert_eq!(
+        soft_hyphen_count(&reloaded),
+        before,
+        "HWP5 저장·재로드에서 소프트 하이픈이 '-'(U+002D)로 변질되거나 사라지면 안 된다"
+    );
+}


### PR DESCRIPTION
## 변경 요약

rhwp 저장본에서 **소프트 하이픈(U+00AD)이 사라지는 회귀**를 고친다. #4776 이 저장을 늘 제어
표기로 되돌리면서(HWPX `<hp:hyphen/>`, HWP5 코드 24), 한글이 그 표기를 텍스트로 복원하지 않아
글자가 없어졌다 — 한글 2022 오라클 10k 전수(s13)에서 **36경로**(h2x 22 · x2x 7 · x2h 7).

핵심은 "리터럴이냐 제어 표기냐"가 아니라 **출처 표기 보존**이다. 한컴이 만든 문서는 두 표기를
모두 쓴다(10k 코퍼스 실측: 리터럴 원본 58문서 · 제어 표기 원본 10문서). 한쪽으로 강제하면
반대편이 깨진다 — 리터럴 원본을 제어 표기로 바꾸면 글자가 사라지고, 제어 표기 원본을 리터럴로
바꾸면 원본에 없던 글자가 생긴다.

- `src/serializer/body_text.rs` — `control_mask` 비트 24 가 선 문단만 코드 24 로 되돌리고 나머지는
  리터럴로 방출한다. `compute_control_mask` 도 같은 조건으로만 비트를 세워 PARA_HEADER 와
  PARA_TEXT 가 함께 움직인다.
- `src/serializer/hwpx/section.rs` — `InlineCursor.soft_hyphen_as_element` 로 같은 신호를 날라
  제어 표기 출처만 `<hp:hyphen/>` 로 내린다.
- 파서 두 곳(`0x18 → U+00AD`, `<hp:hyphen/> → U+00AD`)은 **읽기 관용으로 유지**한다. 다른 도구가
  만든 파일에는 제어 표기가 있을 수 있다.

## 근거 — 한글 2022 실측

한컴 원본의 raw 표현:

```
00302 원본(.hwp)  PARA_TEXT payload : 20 00 ad 00 20 00 …   ← 리터럴, control_mask = 0
01628 원본(.hwpx) Contents/section0.xml : <hp:t>‘축사로<U+00AD>한우’ …</hp:t>
```

01628 대조 실측(하이픈 표기만 교체하고 한글 2022 로 개방, 정식 하네스 `oracle_run.ps1`):

| 검체 | 한글이 뽑은 본문 | textSha |
|---|---|---|
| 원본 hwpx | **2,478자** | `7de21364…` |
| `<hp:hyphen/>` 로 저장 | 2,477자 (글자 소실) | `19a3cc38…` |
| 무변경 재압축 (대조군) | 2,477자 | `19a3cc38…` |
| **raw U+00AD 로 저장** | **2,478자** | **`7de21364…` — 원본과 동일** |
| HWP5 코드 24(0x18)로 저장 | 2,477자 | `19a3cc38…` |

## 관련 이슈

closes #4895

## 테스트

- [x] `cargo test` 통과 — 신규 `tests/issue_4895_soft_hyphen_literal.rs`(2), 단위 시험 5종
      (양방향: 리터럴 출처 → 리터럴, 제어 표기 출처 → 제어 표기)
- [x] `cargo clippy --all-targets -- -D warnings` 통과
- [x] 회귀 게이트: `ir_field_sweep_baseline` · `convert_verify_corpus_ratchet` ·
      `hwpx_roundtrip_baseline` · `hwp5_roundtrip_baseline` 통과
      (초안이던 "항상 리터럴" 안은 `ir_field_sweep_baseline` 이 `control_mask` 발산 2건으로
      잡아냈다 — 그 신호가 출처 보존 설계로 이끌었다)
- [ ] SVG 내보내기 확인 — 해당 없음(조판 좌표 변경 아님, 저장 표기만 바뀐다)
- [ ] WASM 렌더링 확인 — 해당 없음

### 한글 오라클 재측정 (수정본, 코퍼스 68문서 136경로)

대상은 rhwp 가 U+00AD 를 보는 문서 전체 = 리터럴 원본 58 + 제어 표기 원본 10.

| 항목 | 결과 |
|---|---|
| 소프트 하이픈 판정 불일치 | **36경로 → 0** |
| 신규 결함 | **0** |
| 완전 OK 로 전환 | 31경로 |
| 제어 표기 원본 10문서 | 판정 불변 — 원본에 없던 글자가 생기지 않는다 |

남은 5경로는 첫 차이가 NBSP(`&#160;`) 삽입·쪽수·개체 축으로 바뀐 **별건**이다(소프트 하이픈
서명 잔존 0). 덤으로 `04132.h2x`(#4897 감사장 서식 본문 폐기)가 **-510자 → 0** 으로 회복됐다 —
요소 표기가 그 문서에서는 글자 하나가 아니라 본문 폐기까지 유발하고 있었다.

## 성능 영향 및 측정 결과

- 예상 영향: 없음 (문자 하나의 방출 분기 조건만 바뀐다)
- 재현·측정: 위 오라클 재측정 외 별도 성능 측정 없음
