### PR TITLE
fix(paint): 컬러 글리프 캐시 키가 렌더 결과를 바꾸는 필드를 빠뜨린다

### DIFF
--- a/src/paint/paint_op.rs
+++ b/src/paint/paint_op.rs
@@ -437,33 +437,94 @@ fn color_layers_payload_resource_key(payload: &ColorLayersPayload) -> String {
         optional_text_range_key(payload.source_range_utf8),
         optional_glyph_range_key(payload.glyph_range),
     );
+    // `paint_graph` 와 `layers` 는 독립 필드다(COLRv1 그래프와 COLRv0 해석 레이어가
+    // 함께 실린다 — `has_colrv0_resolved_layer_contract` 참고). 둘 중 하나만 키에
+    // 넣으면 나머지 하나만 다른 두 페이로드가 같은 캐시 슬롯을 쓴다.
     if let Some(graph) = &payload.paint_graph {
         key.push_str(":graph:");
         key.push_str(&color_paint_graph_key(graph));
-    } else if !payload.layers.is_empty() {
+    }
+    if !payload.layers.is_empty() {
         key.push_str(":layers:");
         for (idx, layer) in payload.layers.iter().enumerate() {
             if idx > 0 {
                 key.push('|');
             }
-            key.push_str(&format!(
-                "{}:{}:{}:{}:{}:{}",
-                layer
-                    .layer_index
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "-".to_string()),
-                layer
-                    .glyph_id
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "-".to_string()),
-                optional_glyph_range_key(layer.glyph_range),
-                optional_text_range_key(layer.source_range_utf8),
-                font_color_glyph_ref_key(layer.source_font_ref.as_ref()),
-                layer
-                    .palette_index
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "-".to_string()),
-            ));
+            key.push_str(&color_layer_node_key(layer));
+        }
+    }
+    key
+}
+
+/// 레이어 하나의 키. **그려지는 결과를 바꾸는 필드는 전부 들어간다** — 기하
+/// (`commands`)·색(`fill`·`color`)·채움 규칙·불투명도·변환이 빠지면 색만 다른
+/// 컬러 글리프가 같은 슬롯을 공유한다.
+fn color_layer_node_key(layer: &ColorLayerNode) -> String {
+    format!(
+        "{}:{}:{}:{}:{}:{}:cmds:{}:fill:{}:rule:{}:color:{}:opacity:{}:xform:{}",
+        optional_u32_key(layer.layer_index),
+        optional_u32_key(layer.glyph_id),
+        optional_glyph_range_key(layer.glyph_range),
+        optional_text_range_key(layer.source_range_utf8),
+        font_color_glyph_ref_key(layer.source_font_ref.as_ref()),
+        layer
+            .palette_index
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_string()),
+        path_commands_key(layer.commands.as_deref()),
+        resolved_color_key(layer.fill.as_ref()),
+        layer
+            .fill_rule
+            .map(GlyphOutlineFillRule::as_str)
+            .unwrap_or("-"),
+        optional_u32_key(layer.color),
+        layer
+            .opacity
+            .map(|value| format!("{value:.6}"))
+            .unwrap_or_else(|| "-".to_string()),
+        optional_affine_key(layer.transform_to_run),
+    )
+}
+
+fn optional_u32_key<T: std::fmt::Display>(value: Option<T>) -> String {
+    value
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn resolved_color_key(color: Option<&ResolvedColor>) -> String {
+    match color {
+        Some(color) => format!(
+            "{}/{:.6},{:.6},{:.6},{:.6}",
+            color.color_space.as_deref().unwrap_or("-"),
+            color.rgba[0],
+            color.rgba[1],
+            color.rgba[2],
+            color.rgba[3],
+        ),
+        None => "-".to_string(),
+    }
+}
+
+fn path_commands_key(commands: Option<&[PathCommand]>) -> String {
+    let Some(commands) = commands else {
+        return "-".to_string();
+    };
+    let mut key = String::new();
+    for (idx, command) in commands.iter().enumerate() {
+        if idx > 0 {
+            key.push(';');
+        }
+        match command {
+            PathCommand::MoveTo(x, y) => key.push_str(&format!("M{x:.6},{y:.6}")),
+            PathCommand::LineTo(x, y) => key.push_str(&format!("L{x:.6},{y:.6}")),
+            PathCommand::CurveTo(a, b, c, d, e, f) => {
+                key.push_str(&format!("C{a:.6},{b:.6},{c:.6},{d:.6},{e:.6},{f:.6}"))
+            }
+            PathCommand::ArcTo(rx, ry, rot, large, sweep, x, y) => key.push_str(&format!(
+                "A{rx:.6},{ry:.6},{rot:.6},{large},{sweep},{x:.6},{y:.6}"
+            )),
+            PathCommand::ClosePath => key.push('Z'),
         }
     }
     key
@@ -1558,5 +1619,171 @@ impl PaintTextStyle {
             // [#4155] 종전엔 흰색만 "음영 없음"으로 봐서, 미지정 잔재 0 을 가진 텍스트
             // (HWP3 변환본 전건)가 늘 fill-only 경로에서 빠졌다. 판정 정본은 model::color.
             && crate::model::color::char_shade(self.shade_color).is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn layer() -> ColorLayerNode {
+        ColorLayerNode {
+            layer_index: Some(0),
+            glyph_id: Some(7),
+            glyph_range: None,
+            source_range_utf8: None,
+            source_font_ref: None,
+            commands: None,
+            fill: None,
+            fill_rule: None,
+            palette_index: None,
+            color: None,
+            opacity: None,
+            transform_to_run: None,
+        }
+    }
+
+    fn payload(layers: Vec<ColorLayerNode>) -> ColorLayersPayload {
+        ColorLayersPayload {
+            color_format: ColorGlyphFormat::ColrV0,
+            source_font_ref: None,
+            palette_ref: None,
+            layers,
+            paint_graph: None,
+            source_range_utf8: None,
+            glyph_range: None,
+        }
+    }
+
+    fn graph() -> ColorPaintGraphPayload {
+        ColorPaintGraphPayload {
+            root_node_id: 1,
+            nodes: vec![ColorPaintGraphNode {
+                node_id: 1,
+                kind: ColorPaintGraphNodeKind::SolidPath,
+                solid_path: None,
+                linear_gradient_path: None,
+                radial_gradient_path: None,
+                sweep_gradient_path: None,
+                transform: None,
+                source_range_utf8: None,
+                glyph_range: None,
+                source_font_ref: None,
+            }],
+        }
+    }
+
+    /// 채워지는 색이 다르면 캐시 슬롯도 달라야 한다. 종전 키는 `fill` 을 싣지
+    /// 않아 빨간 글리프와 파란 글리프가 같은 슬롯을 썼다.
+    #[test]
+    fn layer_fill_color_changes_the_resource_key() {
+        let mut red = layer();
+        red.fill = Some(ResolvedColor {
+            color_space: None,
+            rgba: [1.0, 0.0, 0.0, 1.0],
+        });
+        let mut blue = layer();
+        blue.fill = Some(ResolvedColor {
+            color_space: None,
+            rgba: [0.0, 0.0, 1.0, 1.0],
+        });
+
+        assert_ne!(
+            color_layers_payload_resource_key(&payload(vec![red])),
+            color_layers_payload_resource_key(&payload(vec![blue])),
+            "채움색이 다른데 같은 캐시 키가 나왔다"
+        );
+    }
+
+    /// 경로 기하가 다르면 그려지는 모양이 다르다.
+    #[test]
+    fn layer_path_commands_change_the_resource_key() {
+        let mut square = layer();
+        square.commands = Some(vec![
+            PathCommand::MoveTo(0.0, 0.0),
+            PathCommand::LineTo(10.0, 0.0),
+            PathCommand::ClosePath,
+        ]);
+        let mut wider = layer();
+        wider.commands = Some(vec![
+            PathCommand::MoveTo(0.0, 0.0),
+            PathCommand::LineTo(20.0, 0.0),
+            PathCommand::ClosePath,
+        ]);
+
+        assert_ne!(
+            color_layers_payload_resource_key(&payload(vec![square])),
+            color_layers_payload_resource_key(&payload(vec![wider])),
+        );
+    }
+
+    #[test]
+    fn layer_opacity_fill_rule_color_and_transform_change_the_resource_key() {
+        let base = color_layers_payload_resource_key(&payload(vec![layer()]));
+
+        let mut opaque = layer();
+        opaque.opacity = Some(0.5);
+        let mut ruled = layer();
+        ruled.fill_rule = Some(GlyphOutlineFillRule::EvenOdd);
+        let mut colored = layer();
+        colored.color = Some(0x00FF_0000);
+        let mut moved = layer();
+        moved.transform_to_run = Some(LayerAffineTransform {
+            a: 1.0,
+            b: 0.0,
+            c: 0.0,
+            d: 1.0,
+            e: 5.0,
+            f: 0.0,
+        });
+
+        for (name, changed) in [
+            ("opacity", opaque),
+            ("fill_rule", ruled),
+            ("color", colored),
+            ("transform_to_run", moved),
+        ] {
+            assert_ne!(
+                base,
+                color_layers_payload_resource_key(&payload(vec![changed])),
+                "{name} 이 달라도 키가 같다"
+            );
+        }
+    }
+
+    /// `paint_graph` 와 `layers` 는 공존한다. 그래프만 키에 실리면 레이어가
+    /// 다른 두 페이로드가 같은 슬롯을 쓴다.
+    #[test]
+    fn layers_are_keyed_even_when_a_paint_graph_is_present() {
+        let mut with_graph_a = payload(vec![layer()]);
+        with_graph_a.paint_graph = Some(graph());
+
+        let mut other = layer();
+        other.glyph_id = Some(99);
+        let mut with_graph_b = payload(vec![other]);
+        with_graph_b.paint_graph = Some(graph());
+
+        assert_ne!(
+            color_layers_payload_resource_key(&with_graph_a),
+            color_layers_payload_resource_key(&with_graph_b),
+            "그래프가 같고 레이어만 다른데 키가 같다"
+        );
+    }
+
+    /// 같은 입력은 같은 키여야 한다 — 캐시가 계속 빗나가면 안 된다.
+    #[test]
+    fn identical_payloads_share_one_key() {
+        let mut a = layer();
+        a.fill = Some(ResolvedColor {
+            color_space: Some("srgb".to_string()),
+            rgba: [0.25, 0.5, 0.75, 1.0],
+        });
+        a.commands = Some(vec![PathCommand::MoveTo(1.0, 2.0), PathCommand::ClosePath]);
+        let b = a.clone();
+
+        assert_eq!(
+            color_layers_payload_resource_key(&payload(vec![a])),
+            color_layers_payload_resource_key(&payload(vec![b])),
+        );
     }
 }


### PR DESCRIPTION
## 문제

`color_layers_payload_resource_key`(`src/paint/paint_op.rs`)가 만드는 컬러 글리프 캐시 키가 **그려지는 결과를 바꾸는 필드를 빠뜨립니다.** 그 결과 서로 다르게 그려져야 할 두 페이로드가 같은 캐시 슬롯을 공유하고, 캐시가 앞서 그린 것을 그대로 돌려줍니다.

이건 그 함수 자신이 선언한 계약 위반입니다 — `payload_resource_key` 주석은 이렇게 적혀 있습니다:

> color/bitmap/SVG payload families do not share a cache slot merely because a producer reused the same numeric resource id.

## 원인

두 곳입니다.

**(1) `paint_graph` 가 있으면 `layers` 가 키에서 통째로 빠진다** — `else if` 분기입니다.

```rust
if let Some(graph) = &payload.paint_graph { ... }
else if !payload.layers.is_empty() { ... }   // ← 그래프가 있으면 여기 안 옴
```

두 필드는 독립이며 함께 실립니다. 같은 파일의 `has_colrv0_resolved_layer_contract` 가 `paint_graph.is_none() && !layers.is_empty()` 로 둘을 함께 보는 것이 그 증거입니다(COLRv1 그래프와 COLRv0 해석 레이어의 공존). 그래프가 같고 레이어만 다른 두 페이로드는 **같은 키**를 받습니다.

**(2) `ColorLayerNode` 12개 필드 중 6개만 직렬화한다**

키에 들어가던 것: `layer_index`·`glyph_id`·`glyph_range`·`source_range_utf8`·`source_font_ref`·`palette_index` (전부 **식별 정보**)

빠져 있던 것: **`commands`(경로 기하) · `fill`(채움색) · `fill_rule` · `color` · `opacity` · `transform_to_run`** — 즉 **실제로 그려지는 내용을 결정하는 필드 전부**.

빨간 글리프와 파란 글리프가 나머지 메타데이터가 같으면 같은 키를 갖습니다.

## 수정

- 두 분기를 독립 `if` 로 바꿔 `layers` 가 항상 키에 실리게 했습니다.
- 레이어 키를 `color_layer_node_key` 로 분리하고 렌더에 영향을 주는 필드를 전부 실었습니다. 부동소수는 고정 자릿수(`{:.6}`)로 찍어 **같은 입력이 항상 같은 키**가 되게 했습니다(캐시가 계속 빗나가면 수정이 아니라 성능 회귀입니다).
- 경로 기하는 `M/L/C/A/Z` 컴팩트 표기로 직렬화했습니다.

행동 변경은 캐시 키 문자열뿐이며, 렌더 경로 자체는 건드리지 않았습니다.

## 검증

**이 파일 최초의 테스트 5개를 추가했습니다** (1,562줄, 종전 테스트 0개).

수정만 되돌리고 테스트는 남긴 채 돌려 **테스트가 실제로 결함을 잡는지 확인했습니다**:

```
test layer_path_commands_change_the_resource_key ... FAILED
test layers_are_keyed_even_when_a_paint_graph_is_present ... FAILED
test layer_opacity_fill_rule_color_and_transform_change_the_resource_key ... FAILED
test layer_fill_color_changes_the_resource_key ... FAILED
test identical_payloads_share_one_key ... ok          ← 캐시 적중은 유지돼야 하므로 통과가 맞음
test result: FAILED. 1 passed; 4 failed
```

수정 후:

```
$ cargo test --lib paint::paint_op
test result: ok. 5 passed; 0 failed

$ cargo test --lib paint::
test result: ok. 106 passed; 0 failed

$ cargo clippy --lib -- -D warnings     # 통과
$ rustfmt --edition 2021 --check src/paint/paint_op.rs   # 통과
```

`cargo test --lib renderer::` 는 1,134개 통과·1개 실패인데, 그 1건(`renderer::composer::re_sample_gen::tests::test_gen_re_multisize`)은 **이 변경 전에도 동일하게 실패**합니다 — 없는 경로를 여는 환경 의존 테스트(`Os { code: 3, NotFound }`)로 이 PR과 무관함을 stash 후 재실행으로 확인했습니다.

## 후속 (별도 PR 예정)

같은 결함 유형이 `color_paint_graph_key` 에도 있습니다 — `ColorPaintGraphNode` 10개 필드 중 4개만 직렬화해 `solid_path`·`linear_gradient_path`·`radial_gradient_path`·`sweep_gradient_path`·`transform` 이 빠집니다. 즉 **그라디언트 내용이 키에 없습니다.** 그라디언트 4종과 stop 직렬화가 필요해 이 PR을 키우므로 분리했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
