### PR TITLE
fix(paint): COLR 그래프 노드 키가 칠하는 내용을 빠뜨린다

### DIFF
--- a/src/paint/paint_op.rs
+++ b/src/paint/paint_op.rs
@@ -437,33 +437,94 @@ fn color_layers_payload_resource_key(payload: &ColorLayersPayload) -> String {
         optional_text_range_key(payload.source_range_utf8),
         optional_glyph_range_key(payload.glyph_range),
     );
+    // `paint_graph` 와 `layers` 는 독립 필드다(COLRv1 그래프와 COLRv0 해석 레이어가
+    // 함께 실린다 — `has_colrv0_resolved_layer_contract` 참고). 둘 중 하나만 키에
+    // 넣으면 나머지 하나만 다른 두 페이로드가 같은 캐시 슬롯을 쓴다.
     if let Some(graph) = &payload.paint_graph {
         key.push_str(":graph:");
         key.push_str(&color_paint_graph_key(graph));
-    } else if !payload.layers.is_empty() {
+    }
+    if !payload.layers.is_empty() {
         key.push_str(":layers:");
         for (idx, layer) in payload.layers.iter().enumerate() {
             if idx > 0 {
                 key.push('|');
             }
-            key.push_str(&format!(
-                "{}:{}:{}:{}:{}:{}",
-                layer
-                    .layer_index
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "-".to_string()),
-                layer
-                    .glyph_id
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "-".to_string()),
-                optional_glyph_range_key(layer.glyph_range),
-                optional_text_range_key(layer.source_range_utf8),
-                font_color_glyph_ref_key(layer.source_font_ref.as_ref()),
-                layer
-                    .palette_index
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "-".to_string()),
-            ));
+            key.push_str(&color_layer_node_key(layer));
+        }
+    }
+    key
+}
+
+/// 레이어 하나의 키. **그려지는 결과를 바꾸는 필드는 전부 들어간다** — 기하
+/// (`commands`)·색(`fill`·`color`)·채움 규칙·불투명도·변환이 빠지면 색만 다른
+/// 컬러 글리프가 같은 슬롯을 공유한다.
+fn color_layer_node_key(layer: &ColorLayerNode) -> String {
+    format!(
+        "{}:{}:{}:{}:{}:{}:cmds:{}:fill:{}:rule:{}:color:{}:opacity:{}:xform:{}",
+        optional_u32_key(layer.layer_index),
+        optional_u32_key(layer.glyph_id),
+        optional_glyph_range_key(layer.glyph_range),
+        optional_text_range_key(layer.source_range_utf8),
+        font_color_glyph_ref_key(layer.source_font_ref.as_ref()),
+        layer
+            .palette_index
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_string()),
+        path_commands_key(layer.commands.as_deref()),
+        resolved_color_key(layer.fill.as_ref()),
+        layer
+            .fill_rule
+            .map(GlyphOutlineFillRule::as_str)
+            .unwrap_or("-"),
+        optional_u32_key(layer.color),
+        layer
+            .opacity
+            .map(|value| format!("{value:.6}"))
+            .unwrap_or_else(|| "-".to_string()),
+        optional_affine_key(layer.transform_to_run),
+    )
+}
+
+fn optional_u32_key<T: std::fmt::Display>(value: Option<T>) -> String {
+    value
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn resolved_color_key(color: Option<&ResolvedColor>) -> String {
+    match color {
+        Some(color) => format!(
+            "{}/{:.6},{:.6},{:.6},{:.6}",
+            color.color_space.as_deref().unwrap_or("-"),
+            color.rgba[0],
+            color.rgba[1],
+            color.rgba[2],
+            color.rgba[3],
+        ),
+        None => "-".to_string(),
+    }
+}
+
+fn path_commands_key(commands: Option<&[PathCommand]>) -> String {
+    let Some(commands) = commands else {
+        return "-".to_string();
+    };
+    let mut key = String::new();
+    for (idx, command) in commands.iter().enumerate() {
+        if idx > 0 {
+            key.push(';');
+        }
+        match command {
+            PathCommand::MoveTo(x, y) => key.push_str(&format!("M{x:.6},{y:.6}")),
+            PathCommand::LineTo(x, y) => key.push_str(&format!("L{x:.6},{y:.6}")),
+            PathCommand::CurveTo(a, b, c, d, e, f) => {
+                key.push_str(&format!("C{a:.6},{b:.6},{c:.6},{d:.6},{e:.6},{f:.6}"))
+            }
+            PathCommand::ArcTo(rx, ry, rot, large, sweep, x, y) => key.push_str(&format!(
+                "A{rx:.6},{ry:.6},{rot:.6},{large},{sweep},{x:.6},{y:.6}"
+            )),
+            PathCommand::ClosePath => key.push('Z'),
         }
     }
     key
@@ -1558,5 +1619,171 @@ impl PaintTextStyle {
             // [#4155] 종전엔 흰색만 "음영 없음"으로 봐서, 미지정 잔재 0 을 가진 텍스트
             // (HWP3 변환본 전건)가 늘 fill-only 경로에서 빠졌다. 판정 정본은 model::color.
             && crate::model::color::char_shade(self.shade_color).is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn layer() -> ColorLayerNode {
+        ColorLayerNode {
+            layer_index: Some(0),
+            glyph_id: Some(7),
+            glyph_range: None,
+            source_range_utf8: None,
+            source_font_ref: None,
+            commands: None,
+            fill: None,
+            fill_rule: None,
+            palette_index: None,
+            color: None,
+            opacity: None,
+            transform_to_run: None,
+        }
+    }
+
+    fn payload(layers: Vec<ColorLayerNode>) -> ColorLayersPayload {
+        ColorLayersPayload {
+            color_format: ColorGlyphFormat::ColrV0,
+            source_font_ref: None,
+            palette_ref: None,
+            layers,
+            paint_graph: None,
+            source_range_utf8: None,
+            glyph_range: None,
+        }
+    }
+
+    fn graph() -> ColorPaintGraphPayload {
+        ColorPaintGraphPayload {
+            root_node_id: 1,
+            nodes: vec![ColorPaintGraphNode {
+                node_id: 1,
+                kind: ColorPaintGraphNodeKind::SolidPath,
+                solid_path: None,
+                linear_gradient_path: None,
+                radial_gradient_path: None,
+                sweep_gradient_path: None,
+                transform: None,
+                source_range_utf8: None,
+                glyph_range: None,
+                source_font_ref: None,
+            }],
+        }
+    }
+
+    /// 채워지는 색이 다르면 캐시 슬롯도 달라야 한다. 종전 키는 `fill` 을 싣지
+    /// 않아 빨간 글리프와 파란 글리프가 같은 슬롯을 썼다.
+    #[test]
+    fn layer_fill_color_changes_the_resource_key() {
+        let mut red = layer();
+        red.fill = Some(ResolvedColor {
+            color_space: None,
+            rgba: [1.0, 0.0, 0.0, 1.0],
+        });
+        let mut blue = layer();
+        blue.fill = Some(ResolvedColor {
+            color_space: None,
+            rgba: [0.0, 0.0, 1.0, 1.0],
+        });
+
+        assert_ne!(
+            color_layers_payload_resource_key(&payload(vec![red])),
+            color_layers_payload_resource_key(&payload(vec![blue])),
+            "채움색이 다른데 같은 캐시 키가 나왔다"
+        );
+    }
+
+    /// 경로 기하가 다르면 그려지는 모양이 다르다.
+    #[test]
+    fn layer_path_commands_change_the_resource_key() {
+        let mut square = layer();
+        square.commands = Some(vec![
+            PathCommand::MoveTo(0.0, 0.0),
+            PathCommand::LineTo(10.0, 0.0),
+            PathCommand::ClosePath,
+        ]);
+        let mut wider = layer();
+        wider.commands = Some(vec![
+            PathCommand::MoveTo(0.0, 0.0),
+            PathCommand::LineTo(20.0, 0.0),
+            PathCommand::ClosePath,
+        ]);
+
+        assert_ne!(
+            color_layers_payload_resource_key(&payload(vec![square])),
+            color_layers_payload_resource_key(&payload(vec![wider])),
+        );
+    }
+
+    #[test]
+    fn layer_opacity_fill_rule_color_and_transform_change_the_resource_key() {
+        let base = color_layers_payload_resource_key(&payload(vec![layer()]));
+
+        let mut opaque = layer();
+        opaque.opacity = Some(0.5);
+        let mut ruled = layer();
+        ruled.fill_rule = Some(GlyphOutlineFillRule::EvenOdd);
+        let mut colored = layer();
+        colored.color = Some(0x00FF_0000);
+        let mut moved = layer();
+        moved.transform_to_run = Some(LayerAffineTransform {
+            a: 1.0,
+            b: 0.0,
+            c: 0.0,
+            d: 1.0,
+            e: 5.0,
+            f: 0.0,
+        });
+
+        for (name, changed) in [
+            ("opacity", opaque),
+            ("fill_rule", ruled),
+            ("color", colored),
+            ("transform_to_run", moved),
+        ] {
+            assert_ne!(
+                base,
+                color_layers_payload_resource_key(&payload(vec![changed])),
+                "{name} 이 달라도 키가 같다"
+            );
+        }
+    }
+
+    /// `paint_graph` 와 `layers` 는 공존한다. 그래프만 키에 실리면 레이어가
+    /// 다른 두 페이로드가 같은 슬롯을 쓴다.
+    #[test]
+    fn layers_are_keyed_even_when_a_paint_graph_is_present() {
+        let mut with_graph_a = payload(vec![layer()]);
+        with_graph_a.paint_graph = Some(graph());
+
+        let mut other = layer();
+        other.glyph_id = Some(99);
+        let mut with_graph_b = payload(vec![other]);
+        with_graph_b.paint_graph = Some(graph());
+
+        assert_ne!(
+            color_layers_payload_resource_key(&with_graph_a),
+            color_layers_payload_resource_key(&with_graph_b),
+            "그래프가 같고 레이어만 다른데 키가 같다"
+        );
+    }
+
+    /// 같은 입력은 같은 키여야 한다 — 캐시가 계속 빗나가면 안 된다.
+    #[test]
+    fn identical_payloads_share_one_key() {
+        let mut a = layer();
+        a.fill = Some(ResolvedColor {
+            color_space: Some("srgb".to_string()),
+            rgba: [0.25, 0.5, 0.75, 1.0],
+        });
+        a.commands = Some(vec![PathCommand::MoveTo(1.0, 2.0), PathCommand::ClosePath]);
+        let b = a.clone();
+
+        assert_eq!(
+            color_layers_payload_resource_key(&payload(vec![a])),
+            color_layers_payload_resource_key(&payload(vec![b])),
+        );
     }
 }

--- a/src/paint/paint_op.rs
+++ b/src/paint/paint_op.rs
@@ -537,11 +537,93 @@ fn color_paint_graph_key(graph: &ColorPaintGraphPayload) -> String {
             key.push('|');
         }
         key.push_str(&format!(
-            "{}:{}:{}:{}",
+            "{}:{}:{}:{}:range:{}:paint:{}",
             node.node_id,
             node.kind.as_str(),
             optional_glyph_range_key(node.glyph_range),
             font_color_glyph_ref_key(node.source_font_ref.as_ref()),
+            optional_text_range_key(node.source_range_utf8),
+            color_paint_graph_node_paint_key(node),
+        ));
+    }
+    key
+}
+
+/// 그래프 노드가 **실제로 무엇을 칠하는가**. `kind` 는 종류만 말하고 내용은
+/// 말하지 않는다 — 두 SolidPath 노드가 서로 다른 색이어도 `kind` 는 같다.
+/// 페인트 내용이 키에 없으면 그 둘이 같은 캐시 슬롯을 쓴다.
+fn color_paint_graph_node_paint_key(node: &ColorPaintGraphNode) -> String {
+    if let Some(solid) = &node.solid_path {
+        return format!(
+            "solid:{}:{}:{}:{}:{}",
+            path_commands_key(Some(&solid.commands)),
+            resolved_color_key(Some(&solid.fill)),
+            solid.fill_rule.as_str(),
+            optional_u32_key(solid.source_glyph_id),
+            optional_u32_key(solid.palette_index),
+        );
+    }
+    if let Some(linear) = &node.linear_gradient_path {
+        return format!(
+            "linear:{}:{:.6},{:.6},{:.6},{:.6}:{}:{}:{}:{}",
+            path_commands_key(Some(&linear.commands)),
+            linear.gradient.x0,
+            linear.gradient.y0,
+            linear.gradient.x1,
+            linear.gradient.y1,
+            gradient_stops_key(&linear.gradient.stops),
+            linear.fill_rule.as_str(),
+            optional_u32_key(linear.source_glyph_id),
+            optional_u32_key(linear.palette_index),
+        );
+    }
+    if let Some(radial) = &node.radial_gradient_path {
+        return format!(
+            "radial:{}:{:.6},{:.6},{:.6}:{}:{}:{}:{}",
+            path_commands_key(Some(&radial.commands)),
+            radial.gradient.cx,
+            radial.gradient.cy,
+            radial.gradient.radius,
+            gradient_stops_key(&radial.gradient.stops),
+            radial.fill_rule.as_str(),
+            optional_u32_key(radial.source_glyph_id),
+            optional_u32_key(radial.palette_index),
+        );
+    }
+    if let Some(sweep) = &node.sweep_gradient_path {
+        return format!(
+            "sweep:{}:{:.6},{:.6},{:.6},{:.6}:{}:{}:{}:{}",
+            path_commands_key(Some(&sweep.commands)),
+            sweep.gradient.cx,
+            sweep.gradient.cy,
+            sweep.gradient.start_angle_degrees,
+            sweep.gradient.end_angle_degrees,
+            gradient_stops_key(&sweep.gradient.stops),
+            sweep.fill_rule.as_str(),
+            optional_u32_key(sweep.source_glyph_id),
+            optional_u32_key(sweep.palette_index),
+        );
+    }
+    if let Some(transform) = &node.transform {
+        return format!(
+            "transform:{}:{}",
+            transform.child_node_id,
+            affine_key(transform.transform),
+        );
+    }
+    "-".to_string()
+}
+
+fn gradient_stops_key(stops: &[ColorGradientStop]) -> String {
+    let mut key = String::from("stops:");
+    for (idx, stop) in stops.iter().enumerate() {
+        if idx > 0 {
+            key.push(';');
+        }
+        key.push_str(&format!(
+            "{:.6}@{}",
+            stop.offset,
+            resolved_color_key(Some(&stop.color))
         ));
     }
     key
@@ -1655,22 +1737,145 @@ mod tests {
         }
     }
 
+    fn graph_node() -> ColorPaintGraphNode {
+        ColorPaintGraphNode {
+            node_id: 1,
+            kind: ColorPaintGraphNodeKind::SolidPath,
+            solid_path: None,
+            linear_gradient_path: None,
+            radial_gradient_path: None,
+            sweep_gradient_path: None,
+            transform: None,
+            source_range_utf8: None,
+            glyph_range: None,
+            source_font_ref: None,
+        }
+    }
+
     fn graph() -> ColorPaintGraphPayload {
         ColorPaintGraphPayload {
             root_node_id: 1,
-            nodes: vec![ColorPaintGraphNode {
-                node_id: 1,
-                kind: ColorPaintGraphNodeKind::SolidPath,
-                solid_path: None,
-                linear_gradient_path: None,
-                radial_gradient_path: None,
-                sweep_gradient_path: None,
-                transform: None,
-                source_range_utf8: None,
-                glyph_range: None,
-                source_font_ref: None,
-            }],
+            nodes: vec![graph_node()],
         }
+    }
+
+    fn graph_of(node: ColorPaintGraphNode) -> ColorPaintGraphPayload {
+        ColorPaintGraphPayload {
+            root_node_id: 1,
+            nodes: vec![node],
+        }
+    }
+
+    fn color(rgba: [f32; 4]) -> ResolvedColor {
+        ResolvedColor {
+            color_space: None,
+            rgba,
+        }
+    }
+
+    fn square() -> Vec<PathCommand> {
+        vec![
+            PathCommand::MoveTo(0.0, 0.0),
+            PathCommand::LineTo(10.0, 10.0),
+            PathCommand::ClosePath,
+        ]
+    }
+
+    fn solid_node(fill: [f32; 4]) -> ColorPaintGraphNode {
+        let mut node = graph_node();
+        node.solid_path = Some(ColorPaintSolidPathNode {
+            commands: square(),
+            fill: color(fill),
+            fill_rule: GlyphOutlineFillRule::NonZero,
+            source_glyph_id: None,
+            palette_index: None,
+        });
+        node
+    }
+
+    fn linear_node(x1: f64, stop_color: [f32; 4]) -> ColorPaintGraphNode {
+        let mut node = graph_node();
+        node.kind = ColorPaintGraphNodeKind::LinearGradientPath;
+        node.linear_gradient_path = Some(ColorPaintLinearGradientPathNode {
+            commands: square(),
+            gradient: ColorLinearGradient {
+                x0: 0.0,
+                y0: 0.0,
+                x1,
+                y1: 0.0,
+                stops: vec![ColorGradientStop {
+                    offset: 0.0,
+                    color: color(stop_color),
+                }],
+            },
+            fill_rule: GlyphOutlineFillRule::NonZero,
+            source_glyph_id: None,
+            palette_index: None,
+        });
+        node
+    }
+
+    fn graph_key(node: ColorPaintGraphNode) -> String {
+        let mut payload = payload(vec![]);
+        payload.paint_graph = Some(graph_of(node));
+        color_layers_payload_resource_key(&payload)
+    }
+
+    /// `kind` 는 종류만 말한다. 두 SolidPath 노드가 서로 다른 색이어도 종전 키는
+    /// 같았고, 캐시가 앞서 그린 색을 돌려줬다.
+    #[test]
+    fn graph_solid_path_fill_changes_the_resource_key() {
+        assert_ne!(
+            graph_key(solid_node([1.0, 0.0, 0.0, 1.0])),
+            graph_key(solid_node([0.0, 0.0, 1.0, 1.0])),
+            "SolidPath 채움색이 다른데 같은 캐시 키가 나왔다"
+        );
+    }
+
+    #[test]
+    fn graph_solid_path_geometry_changes_the_resource_key() {
+        let base = solid_node([1.0, 0.0, 0.0, 1.0]);
+        let mut wider = solid_node([1.0, 0.0, 0.0, 1.0]);
+        wider.solid_path.as_mut().unwrap().commands = vec![
+            PathCommand::MoveTo(0.0, 0.0),
+            PathCommand::LineTo(99.0, 0.0),
+        ];
+
+        assert_ne!(graph_key(base), graph_key(wider));
+    }
+
+    /// 그라디언트 기하와 stop 색이 각각 키를 바꿔야 한다.
+    #[test]
+    fn graph_linear_gradient_geometry_and_stops_change_the_resource_key() {
+        let base = graph_key(linear_node(10.0, [1.0, 0.0, 0.0, 1.0]));
+
+        assert_ne!(
+            base,
+            graph_key(linear_node(20.0, [1.0, 0.0, 0.0, 1.0])),
+            "그라디언트 끝점이 달라도 키가 같다"
+        );
+        assert_ne!(
+            base,
+            graph_key(linear_node(10.0, [0.0, 1.0, 0.0, 1.0])),
+            "그라디언트 stop 색이 달라도 키가 같다"
+        );
+    }
+
+    /// 같은 `kind` 라도 페인트 내용이 없는 노드와 있는 노드는 달라야 한다.
+    #[test]
+    fn graph_node_without_paint_differs_from_one_with_paint() {
+        assert_ne!(
+            graph_key(graph_node()),
+            graph_key(solid_node([1.0, 0.0, 0.0, 1.0])),
+        );
+    }
+
+    #[test]
+    fn identical_graphs_share_one_key() {
+        assert_eq!(
+            graph_key(solid_node([0.25, 0.5, 0.75, 1.0])),
+            graph_key(solid_node([0.25, 0.5, 0.75, 1.0])),
+        );
     }
 
     /// 채워지는 색이 다르면 캐시 슬롯도 달라야 한다. 종전 키는 `fill` 을 싣지


### PR DESCRIPTION
## 문제

[#4910](https://github.com/edwardkim/rhwp/pull/4910) 과 **같은 결함 유형이 그래프 경로에도** 있습니다. COLRv1 페인트 그래프의 캐시 키가 **노드가 실제로 무엇을 칠하는가**를 담지 않아, 서로 다르게 그려져야 할 두 그래프가 같은 캐시 슬롯을 공유합니다.

## 원인

`color_paint_graph_key` 가 `ColorPaintGraphNode` **10개 필드 중 4개만** 직렬화합니다.

키에 들어가던 것: `node_id` · `kind` · `glyph_range` · `source_font_ref` — 전부 **식별 정보**입니다.

빠져 있던 것: **`solid_path` · `linear_gradient_path` · `radial_gradient_path` · `sweep_gradient_path` · `transform` · `source_range_utf8`** — 즉 **페인트 내용 전부**.

`kind` 는 종류만 말하고 내용은 말하지 않습니다. 두 `SolidPath` 노드는 채움색이 빨강이든 파랑이든 `kind` 가 같아서 **동일한 키**를 받습니다. 그라디언트도 마찬가지로 끝점·중심·각도·stop 색이 전부 키 밖에 있었습니다.

## 수정

- `color_paint_graph_node_paint_key` 를 추가해 노드가 실제로 품은 페인트를 키에 싣습니다 — solid(경로·채움색·채움규칙), linear/radial/sweep(경로·기하·stop·채움규칙), transform(자식 id·아핀).
- 그라디언트 stop 은 `gradient_stops_key` 로 `offset@색` 을 순서대로 잇습니다.
- 부동소수는 고정 자릿수(`{:.6}`)로 찍어 **같은 입력이 항상 같은 키**가 되게 했습니다(캐시가 계속 빗나가면 수정이 아니라 성능 회귀입니다).
- `source_range_utf8` 도 함께 실었습니다.

행동 변경은 캐시 키 문자열뿐이며 렌더 경로는 건드리지 않았습니다.

## 검증

**테스트 5개 추가** (이 파일 합계 10개). #4910 과 같은 방식으로 **수정만 되돌리고 테스트는 남겨** 결함을 실제로 잡는지 확인했습니다:

```
test graph_solid_path_fill_changes_the_resource_key ... FAILED
test graph_solid_path_geometry_changes_the_resource_key ... FAILED
test graph_linear_gradient_geometry_and_stops_change_the_resource_key ... FAILED
test graph_node_without_paint_differs_from_one_with_paint ... FAILED
test identical_graphs_share_one_key ... ok        ← 캐시 적중은 유지돼야 하므로 통과가 맞음
test result: FAILED. 6 passed; 4 failed
```

수정 후:

```
$ cargo test --lib paint::
test result: ok. 111 passed; 0 failed

$ cargo clippy --lib -- -D warnings     # 통과
$ rustfmt --edition 2021 --check src/paint/paint_op.rs   # 통과
```

## 스택 의존성

**#4910 위에 스택됩니다** — 같은 함수 계열이고 `path_commands_key`·`resolved_color_key`·`optional_u32_key` 헬퍼를 재사용하므로, 따로 두면 머지 시 충돌합니다. #4910 머지 후 이 PR 고유 diff 는 마지막 커밋 1개(+218/-13)입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
