### PR TITLE
fix(renderer): 도형 전용 문단 판정이 typeset 과 반대 답을 낸다 (#4626)

### DIFF
--- a/src/renderer/height_cursor.rs
+++ b/src/renderer/height_cursor.rs
@@ -42,8 +42,15 @@ fn para_has_equation_only(para: &Paragraph) -> bool {
             .any(|ctrl| matches!(ctrl, Control::Equation(_)))
 }
 
+/// [#4626] 빈 텍스트 판정은 `para_has_visible_text` 하나로 통일한다.
+///
+/// 종전의 `text.trim().is_empty()` 는 개체 대체 문자(`\u{FFFC}`)를 공백으로 보지
+/// 않아, **도형만 있는 문단의 표준형(`text == "\u{FFFC}"`)** 에서 `typeset.rs` 의
+/// 동명 술어와 반대 답을 냈다. 바로 위 형제 술어
+/// (`para_is_treat_as_char_equation_only`)는 이미 `para_has_visible_text` 를 쓴다 —
+/// 이 함수만 예외였다.
 fn para_is_treat_as_char_picture_only(para: &Paragraph) -> bool {
-    para.text.trim().is_empty()
+    !para_has_visible_text(para)
         && para.controls.iter().any(|ctrl| match ctrl {
             Control::Picture(pic) => pic.common.treat_as_char,
             Control::Shape(shape) => shape.common().treat_as_char,
@@ -1400,6 +1407,61 @@ mod tests {
     use super::*;
     use crate::model::paragraph::LineSeg;
     use crate::renderer::style_resolver::ResolvedParaStyle;
+
+    /// [#4626] 글자처럼 취급하는 도형 하나만 든 문단.
+    fn tac_shape_para(text: &str) -> Paragraph {
+        use crate::model::shape::{RectangleShape, ShapeObject};
+        let mut rect = RectangleShape::default();
+        rect.common.treat_as_char = true;
+        Paragraph {
+            text: text.to_string(),
+            controls: vec![Control::Shape(Box::new(ShapeObject::Rectangle(rect)))],
+            ..Default::default()
+        }
+    }
+
+    /// 도형만 있는 문단의 **표준형**은 `text == "\u{FFFC}"` 다. 종전 판정은
+    /// `trim()` 이 개체 대체 문자를 공백으로 보지 않아 여기서 `false` 를 냈고,
+    /// `typeset.rs` 의 동명 술어(`true`)와 정면으로 어긋났다.
+    #[test]
+    fn object_replacement_only_para_is_treat_as_char_picture_only() {
+        assert!(
+            para_is_treat_as_char_picture_only(&tac_shape_para("\u{FFFC}")),
+            "개체 대체 문자만 있는 문단을 도형 전용으로 보지 않았다"
+        );
+    }
+
+    /// 같은 파일의 형제 술어와 같은 답을 내야 한다 — 빈 텍스트 판정의 단일 정의.
+    #[test]
+    fn empty_and_control_only_paras_agree_with_visible_text_helper() {
+        for text in ["", "\u{FFFC}", "\u{FFFC}\u{FFFC}", "\u{000D}"] {
+            let para = tac_shape_para(text);
+            assert_eq!(
+                para_is_treat_as_char_picture_only(&para),
+                !para_has_visible_text(&para),
+                "text={text:?} 에서 빈 텍스트 판정이 갈렸다"
+            );
+        }
+    }
+
+    /// 실제 글자가 있으면 도형 전용이 아니다.
+    #[test]
+    fn para_with_real_text_is_not_treat_as_char_picture_only() {
+        assert!(!para_is_treat_as_char_picture_only(&tac_shape_para("가")));
+        assert!(!para_is_treat_as_char_picture_only(&tac_shape_para(
+            "\u{FFFC}가"
+        )));
+    }
+
+    /// 도형이 없으면 텍스트가 비어도 도형 전용이 아니다.
+    #[test]
+    fn para_without_treat_as_char_shape_is_not_picture_only() {
+        let para = Paragraph {
+            text: "\u{FFFC}".to_string(),
+            ..Default::default()
+        };
+        assert!(!para_is_treat_as_char_picture_only(&para));
+    }
 
     // DPI=96 → 75 HWPUNIT = 1px (1 inch = 7200 HU = 96px). 손계산 정합용.
     const DPI: f64 = 96.0;


### PR DESCRIPTION
## 문제

동명 함수 둘이 **같은 문단에 반대 답**을 냅니다 ([#4626](https://github.com/edwardkim/rhwp/issues/4626)).

```rust
// src/renderer/height_cursor.rs:45
fn para_is_treat_as_char_picture_only(para: &Paragraph) -> bool {
    para.text.trim().is_empty() && ...

// src/renderer/typeset.rs:1385
fn para_is_treat_as_char_picture_only(para: &Paragraph) -> bool {
    !para_has_visible_text(para) && ...
```

**도형만 있는 문단의 표준형**(`text == "\u{FFFC}"`)에서 height_cursor 는 `false`, typeset 은 `true` 를 냅니다.

## 원인

`para_has_visible_text` 는 개체 대체 문자(`\u{FFFC}`)를 보이는 텍스트에서 **제외**하지만, `trim()` 은 제외하지 않습니다. `\u{FFFC}` 는 공백이 아니므로 `"\u{FFFC}".trim().is_empty()` 는 `false` 입니다.

**어느 쪽이 예외인지는 같은 파일이 증언합니다.** `height_cursor.rs` 는 25행에 `para_has_visible_text` 를 typeset 과 **바이트 단위로 동일하게** 갖고 있고,

```rust
// height_cursor.rs:25 — typeset.rs:1207 과 동일
fn para_has_visible_text(para: &Paragraph) -> bool {
    para.text.chars().any(|c| c > '\u{001F}' && c != '\u{FFFC}')
}
```

바로 위 **형제 술어** `para_is_treat_as_char_equation_only`(29행)는 이미 그 헬퍼를 씁니다. 이 함수 하나만 `trim()` 이었습니다 — 의도적 선택이 아니라 누락으로 보이는 근거입니다.

## 수정

빈 텍스트 판정을 `para_has_visible_text` 하나로 통일했습니다(1줄 + 주석).

**영향 범위**: 호출부는 셋(373·508·512행)뿐이고 전부 `suppress_large_forward_jump` 게이트 안의 compact endnote 경로입니다.

**밝혀둘 점**: 이 변경은 `\u{FFFC}` 외에 **공백만 있는 문단**의 판정도 바꿉니다(`"  "` + 도형: 종전 `true` → 이후 `false`). `para_has_visible_text` 가 공백을 보이는 텍스트로 세기 때문이며, 이는 typeset 쪽 동작과 일치시키는 방향입니다. 이슈 본문은 `\u{FFFC}` 사례만 다루므로 명시합니다.

## 검증

**회귀 테스트 4개 추가**. 수정만 되돌리고 테스트는 남겨 결함을 실제로 잡는지 확인했습니다:

```
test object_replacement_only_para_is_treat_as_char_picture_only ... FAILED
test empty_and_control_only_paras_agree_with_visible_text_helper ... FAILED
test para_with_real_text_is_not_treat_as_char_picture_only ... ok
test para_without_treat_as_char_shape_is_not_picture_only ... ok
test result: FAILED. 53 passed; 2 failed
```

수정 후:

```
$ cargo test --lib renderer::height_cursor
test result: ok. 55 passed; 0 failed        # 기존 51 + 신규 4

$ cargo test --lib renderer::
test result: 1138 passed; 1 failed          # 아래 참조

$ cargo clippy --lib -- -D warnings         # 통과
$ rustfmt --edition 2021 --check src/renderer/height_cursor.rs   # 통과
```

`renderer::` 의 1건 실패(`renderer::composer::re_sample_gen::tests::test_gen_re_multisize`)는 **이 변경 전에도 동일하게 실패**하는 환경 의존 테스트입니다(없는 경로를 열어 `Os { code: 3, NotFound }`).

## 후속

이 술어가 `stacked_tac_picture_heights`(`typeset.rs`)를 게이트하므로, 이슈가 적었듯 **[#4333](https://github.com/edwardkim/rhwp/issues/4333) 의 남은 작업(누적 정의의 렌더 쪽 대응물)의 선행 조건**이 해소됩니다.

Refs #4626

🤖 Generated with [Claude Code](https://claude.com/claude-code)
