### PR TITLE
fix(hwpx): 열거 밖 필드 종류를 CROSSREF 로 굳히지 않고 정체성을 지킨다 (#4896)

### DIFF
--- a/src/document_core/queries/field_query.rs
+++ b/src/document_core/queries/field_query.rs
@@ -1466,6 +1466,7 @@ fn collect_fields_from_paragraph(
                                 extra_properties: 0,
                                 ctrl_data_name: Some(fname.clone()),
                                 instance_id: None,
+                                raw_type: None,
                                 memo_index: 0,
                                 memo_paragraphs: Vec::new(),
                                 memo_text_direction: None,
@@ -2215,6 +2216,7 @@ fn insert_click_here_field_in_para(
         field_id,
         ctrl_id: tags::FIELD_CLICKHERE,
         instance_id: None,
+        raw_type: None,
         ctrl_data_name: if name.is_empty() {
             None
         } else {
@@ -2434,6 +2436,7 @@ mod tests {
             field_id: ctrl_id,
             ctrl_id,
             instance_id: None,
+            raw_type: None,
             ctrl_data_name: None,
             memo_index: 0,
             memo_paragraphs: Vec::new(),

--- a/src/model/control.rs
+++ b/src/model/control.rs
@@ -768,6 +768,13 @@ pub struct Field {
     pub field_id: u32,
     /// 원본 ctrl_id (직렬화용)
     pub ctrl_id: u32,
+    /// [#4896] HWPX `<hp:fieldBegin type="..">` 원문 — IR `FieldType` 이 모델링하지 않는
+    /// 종류일 때만 채운다(그 외는 `None`).
+    ///
+    /// 종류를 못 알아본다고 `CROSSREF` 로 굳히면 원본 필드 정체성이 사라진다(10k 스윕에서
+    /// 교정부호 필드 27경로가 상호참조로 바뀌었다). 원본이 준 값은 한글이 이미 받아들인
+    /// 값이므로 그대로 되돌려주는 편이 안전하고 무손실이다.
+    pub raw_type: Option<String>,
     /// HWPX `<hp:fieldBegin fieldid="..">` 원본 값 (동종 필드 간 공유되는 instance id).
     /// `id`(=field_id, 문서 내 고유)와 별개 값이며 실물 파일에서 서로 다를 수 있다(#1512).
     /// `None` 이면 fieldid 속성 자체가 없었거나 파서가 값을 못 읽은 경우 — 방출 생략.

--- a/src/parser/control.rs
+++ b/src/parser/control.rs
@@ -134,6 +134,9 @@ fn parse_field_control(ctrl_id: u32, ctrl_data: &[u8]) -> Control {
         field_id,
         ctrl_id,
         instance_id: None,
+        // [#4896] HWP5 는 ctrl_id 자체가 종류라 원문 문자열이 없다 — 직렬화기가
+        // `tags::OWPML_EXTRA_FIELD_TYPES` 로 ctrl_id 에서 이름을 되찾는다.
+        raw_type: None,
         ctrl_data_name: None,
         memo_index,
         memo_paragraphs: Vec::new(),

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -4960,7 +4960,15 @@ fn parse_field_begin_attrs(e: &quick_xml::events::BytesStart) -> Field {
     let mut fieldid_attr: Option<u32> = None;
     for attr in e.attributes().flatten() {
         match attr.key.as_ref() {
-            b"type" => f.field_type = parse_field_type(&attr_str(&attr)),
+            b"type" => {
+                let raw = attr_str(&attr);
+                f.field_type = parse_field_type(&raw);
+                // [#4896] IR 이 못 알아본 종류는 원문을 들고 간다 — 그래야 저장에서
+                // `CROSSREF` 로 굳지 않는다(교정부호 필드가 상호참조가 되던 결함).
+                if f.field_type == FieldType::Unknown {
+                    f.raw_type = Some(raw);
+                }
+            }
             b"name" => field_name = Some(attr_str(&attr)),
             // [Task #852 Stage 2.5] HWP5 직렬화에 필요한 필드 메타
             b"id" => {
@@ -5019,7 +5027,13 @@ fn parse_field_begin_attrs(e: &quick_xml::events::BytesStart) -> Field {
         FieldType::Memo => tags::FIELD_MEMO,
         FieldType::PrivateInfoSecurity => tags::FIELD_PRIVATE_INFO,
         FieldType::TableOfContents => tags::FIELD_TOC,
-        FieldType::Unknown => 0,
+        // [#4896] 종류를 못 알아봐도 실측표에 있는 값이면 HWP5 ctrl_id 를 준다 —
+        // 0 을 쓰면 HWPX→HWP 저장에서 한글이 무효 컨트롤로 보고 필드를 잃는다.
+        FieldType::Unknown => f
+            .raw_type
+            .as_deref()
+            .and_then(tags::owpml_extra_field_ctrl_id)
+            .unwrap_or(0),
     };
     // ClickHere 의 extra_properties 정답지 관찰값: 0x09
     if matches!(f.field_type, FieldType::ClickHere) {
@@ -9644,6 +9658,33 @@ mod tests {
             parse_field_type("TABLE_OF_CONTENTS"),
             FieldType::TableOfContents
         );
+    }
+
+    /// [#4896] IR 이 모르는 종류는 원문(`raw_type`)과 실측 ctrl_id 를 함께 챙긴다.
+    ///
+    /// 종전에는 `Unknown` 으로만 떨어져 ctrl_id 가 0 이 됐고, 직렬화기가 종류를 되찾을
+    /// 근거가 없어 `CROSSREF` 로 굳혔다 — 10k 스윕에서 교정부호 필드 27경로가 상호참조로
+    /// 바뀐 사슬의 입구다.
+    #[test]
+    fn unknown_field_type_keeps_raw_string_and_ctrl_id() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ctrl><hp:fieldBegin id="1" type="PROOFREADING_MARKS_DELETE" name="" editable="0" dirty="0"/></hp:ctrl>
+      <hp:t>지운 글</hp:t>
+      <hp:ctrl><hp:fieldEnd beginIDRef="1"/></hp:ctrl>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Field(f) = &section.paragraphs[0].controls[0] else {
+            panic!("expected Field control");
+        };
+        assert_eq!(f.field_type, FieldType::Unknown);
+        assert_eq!(f.raw_type.as_deref(), Some("PROOFREADING_MARKS_DELETE"));
+        assert_eq!(f.ctrl_id, tags::FIELD_PROOFREADING_DELETE);
     }
 
     #[test]

--- a/src/parser/tags.rs
+++ b/src/parser/tags.rs
@@ -244,6 +244,53 @@ pub const FIELD_PRIVATE_INFO: u32 = ctrl_id(b"%cpr");
 pub const FIELD_TOC: u32 = ctrl_id(b"%toc");
 /// 필드: 알 수 없음
 pub const FIELD_UNKNOWN: u32 = ctrl_id(b"%unk");
+/// 필드: 교정부호(삭제)
+pub const FIELD_PROOFREADING_DELETE: u32 = ctrl_id(b"%%*d");
+
+/// [#4896] IR `FieldType` 이 모델링하지 않는 필드 종류의 **정체성 보존표**.
+///
+/// OWPML `<hp:fieldBegin type>` 값 ↔ HWP5 필드 ctrl_id. 이 표가 없으면 두 포맷을 오갈 때
+/// 종류가 `Unknown` 으로 붕괴하고, 직렬화기가 본문 보존을 위해 `CROSSREF` 로 굳혀
+/// 원본 필드 정체성이 영구히 사라진다.
+///
+/// **실측으로만 채운다.** 10k 코퍼스 실측(hwpx 원본 1,853문서):
+/// 열거 밖 값은 `PROOFREADING_MARKS_DELETE` 하나뿐이었고(12회/7문서), 같은 문서에서
+/// 한글이 세는 컨트롤 `%%*d` 와 개수까지 일치했다.
+pub const OWPML_EXTRA_FIELD_TYPES: &[(&str, u32)] =
+    &[("PROOFREADING_MARKS_DELETE", FIELD_PROOFREADING_DELETE)];
+
+/// [#4896] HWP5 는 이 종류의 정체성을 **ctrl_id 가 아니라 command 문자열**로 들고 있다.
+///
+/// 실측(10k 코퍼스): 교정부호(삭제) 필드는 hwp 원본에서 ctrl_id 가 `%unk` 이고 command 가
+/// `$RevisionDelete;` 다. 같은 command 를 hwpx 원본도 그대로 싣고(type 은
+/// `PROOFREADING_MARKS_DELETE`), 두 포맷 모두에서 한글은 컨트롤을 `%%*d` 로 센다
+/// — 03430(6개)·01838(4개) 등에서 개수까지 일치한다.
+pub const OWPML_FIELD_TYPE_BY_COMMAND: &[(&str, &str)] =
+    &[("$RevisionDelete", "PROOFREADING_MARKS_DELETE")];
+
+/// 필드 command → OWPML `type` 문자열 (표에 없으면 `None`).
+pub fn owpml_field_type_by_command(command: &str) -> Option<&'static str> {
+    OWPML_FIELD_TYPE_BY_COMMAND
+        .iter()
+        .find(|(prefix, _)| command.starts_with(prefix))
+        .map(|(_, name)| *name)
+}
+
+/// OWPML `type` 문자열 → HWP5 필드 ctrl_id (표에 없으면 `None`).
+pub fn owpml_extra_field_ctrl_id(type_str: &str) -> Option<u32> {
+    OWPML_EXTRA_FIELD_TYPES
+        .iter()
+        .find(|(name, _)| *name == type_str)
+        .map(|(_, id)| *id)
+}
+
+/// HWP5 필드 ctrl_id → OWPML `type` 문자열 (표에 없으면 `None`).
+pub fn owpml_extra_field_type_str(ctrl_id: u32) -> Option<&'static str> {
+    OWPML_EXTRA_FIELD_TYPES
+        .iter()
+        .find(|(_, id)| *id == ctrl_id)
+        .map(|(name, _)| *name)
+}
 
 /// ctrl_id가 필드 컨트롤인지 확인 (첫 바이트가 '%')
 pub const fn is_field_ctrl_id(id: u32) -> bool {

--- a/src/serializer/hwpx/field.rs
+++ b/src/serializer/hwpx/field.rs
@@ -14,6 +14,7 @@ use std::io::Write;
 use quick_xml::Writer;
 
 use crate::model::control::{Bookmark, Field, FieldType, Hyperlink};
+use crate::parser::tags;
 
 use super::utils::{empty_tag, end_tag, filter_xml_1_0_chars, start_tag, start_tag_attrs, text};
 use super::SerializeError;
@@ -36,7 +37,7 @@ pub fn write_bookmark<W: Write>(w: &mut Writer<W>, bm: &Bookmark) -> Result<(), 
 /// 로 닫는다. 없으면 호출부가 `/>` 로 자기닫힘 처리.
 pub fn field_begin_open_tag(field: &Field) -> String {
     let id_str = field.field_id.to_string();
-    let ft = field_type_str(field.field_type);
+    let ft = field_type_attr(field);
     let name = xml_escape_attr(field.ctrl_data_name.as_deref().unwrap_or(""));
     // [#task-m100] 원본 `fieldid` 속성 보존 — id 와 별개 값일 수 있어(#1512) 생략하면
     // 왕복 시 영구 손실된다. 없으면(None) 속성 자체를 생략(#1391 자기닫힘 태그 호환).
@@ -76,7 +77,7 @@ fn xml_escape_attr(s: &str) -> String {
 /// HWPX 필드는 텍스트 흐름 안에서 `<hp:fieldBegin>` ~ 텍스트 ~ `<hp:fieldEnd>` 쌍으로 표현된다.
 pub fn write_field_begin<W: Write>(w: &mut Writer<W>, field: &Field) -> Result<(), SerializeError> {
     let id_str = field.field_id.to_string();
-    let ft = field_type_str(field.field_type);
+    let ft = field_type_attr(field);
     let fieldid_str = field.instance_id.map(|v| v.to_string());
     let editable_str = bool01(field.is_editable_in_form());
     let dirty_str = bool01(field.is_dirty());
@@ -216,6 +217,30 @@ fn bool01(b: bool) -> &'static str {
     }
 }
 
+/// `<hp:fieldBegin type="...">` 에 실을 값 — **원본 종류를 잃지 않는 자리**.
+///
+/// [#4896] IR `FieldType` 이 모델링하지 않는 종류(`Unknown`)를 무턱대고 `CROSSREF` 로
+/// 굳히면 본문은 살아도 **필드 정체성이 영구히 사라진다**(10k 스윕: 교정부호 필드 27경로가
+/// 상호참조로 바뀌었다). 원본이 준 값은 한글이 이미 받아들인 값이므로, 그 값을 알고 있으면
+/// 그대로 되돌려준다. 순서대로:
+///
+/// 1. HWPX 출처의 `type` 원문(`Field::raw_type`)
+/// 2. HWP5 출처의 command 실측 대응(`tags::OWPML_FIELD_TYPE_BY_COMMAND`, 예:
+///    `$RevisionDelete;` — hwp 는 종류를 ctrl_id 가 아니라 command 로 들고 있다)
+/// 3. ctrl_id 실측 대응(`tags::OWPML_EXTRA_FIELD_TYPES`, 예: `%%*d`)
+/// 4. 아무 근거도 없을 때만 본문 보존용 `CROSSREF` 대체
+fn field_type_attr(field: &Field) -> &str {
+    if field.field_type != FieldType::Unknown {
+        return field_type_str(field.field_type);
+    }
+    if let Some(raw) = field.raw_type.as_deref() {
+        return raw;
+    }
+    tags::owpml_field_type_by_command(&field.command)
+        .or_else(|| tags::owpml_extra_field_type_str(field.ctrl_id))
+        .unwrap_or_else(|| field_type_str(field.field_type))
+}
+
 /// `<hp:fieldBegin type="...">` 값. **반드시 OWPML `FieldType` 열거 안의 값이어야 한다**
 /// (`mydocs/manual/OWPML SCHEMA/ParaList XML schema.xml:2701-2719` — 15개).
 ///
@@ -272,6 +297,65 @@ mod tests {
         };
         let xml = to_string(|w| write_bookmark(w, &bm));
         assert!(xml.contains(r#"<hp:bookmark name="chapter1"/>"#), "{}", xml);
+    }
+
+    /// [#4896] HWPX 출처의 종류 원문은 그대로 되돌아간다 — 한글이 이미 받아들인 값이다.
+    /// 10k 코퍼스 실측: 한컴 원본이 쓰는 열거 밖 값은 `PROOFREADING_MARKS_DELETE` 하나였고
+    /// (12회/7문서), 종전 코드는 이를 `CROSSREF` 로 굳혀 교정부호를 상호참조로 바꿨다.
+    #[test]
+    fn unknown_field_keeps_original_type_string() {
+        let f = Field {
+            field_type: FieldType::Unknown,
+            raw_type: Some("PROOFREADING_MARKS_DELETE".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(field_type_attr(&f), "PROOFREADING_MARKS_DELETE");
+    }
+
+    /// [#4896] HWP5 출처는 원문 문자열이 없다 — ctrl_id 실측 대응표로 이름을 되찾는다.
+    /// (`%%*d` ↔ `PROOFREADING_MARKS_DELETE`: 같은 문서에서 한글 컨트롤 집계와 개수 일치)
+    #[test]
+    fn unknown_field_recovers_type_from_ctrl_id() {
+        let f = Field {
+            field_type: FieldType::Unknown,
+            ctrl_id: tags::FIELD_PROOFREADING_DELETE,
+            ..Default::default()
+        };
+        assert_eq!(field_type_attr(&f), "PROOFREADING_MARKS_DELETE");
+    }
+
+    /// [#4896] HWP5 원본은 종류를 ctrl_id 가 아니라 **command** 로 들고 있다 — 실측(03430)에서
+    /// 교정부호 필드의 ctrl_id 는 `%unk` 이고 command 만 `$RevisionDelete;` 였다.
+    #[test]
+    fn unknown_field_recovers_type_from_command() {
+        let f = Field {
+            field_type: FieldType::Unknown,
+            ctrl_id: tags::FIELD_UNKNOWN,
+            command: "$RevisionDelete;".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(field_type_attr(&f), "PROOFREADING_MARKS_DELETE");
+    }
+
+    /// 되찾을 근거가 하나도 없을 때만 본문 보존용 `CROSSREF` 로 대체한다(#4776 계약 유지).
+    #[test]
+    fn unknown_field_without_evidence_falls_back_to_crossref() {
+        let f = Field {
+            field_type: FieldType::Unknown,
+            ..Default::default()
+        };
+        assert_eq!(field_type_attr(&f), "CROSSREF");
+    }
+
+    /// 아는 종류는 종전대로 IR 값이 이긴다 — raw_type 이 끼어들지 않는다.
+    #[test]
+    fn known_field_type_ignores_raw_type() {
+        let f = Field {
+            field_type: FieldType::Hyperlink,
+            raw_type: Some("ZZZ_NOT_A_TYPE".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(field_type_attr(&f), "HYPERLINK");
     }
 
     #[test]
@@ -409,6 +493,11 @@ mod tests {
 
     #[test]
     fn unknown_field_type_never_emits_schema_outside_value() {
+        // [#4896] 이 불변식은 **되찾을 근거가 없을 때의 대체값**(`field_type_str`)에 걸린다.
+        // 원본이 준 값(`raw_type`)이나 ctrl_id 실측 대응은 열거 밖이어도 그대로 내보낸다 —
+        // 한컴 자신이 쓰는 값이라 한글이 받아들이고(코퍼스 실측 `PROOFREADING_MARKS_DELETE`
+        // 12회/7문서), 열거로 뭉개면 필드 정체성이 사라진다.
+        //
         // OWPML FieldType 열거(ParaList XML schema.xml:2701-2719)에 "UNKNOWN" 은 없다.
         // 열거 밖 값을 만나면 한글은 그 지점에서 섹션 파싱을 포기하고 이후 본문을 버린다
         // — 10k 스윕 h2x 절단군의 근인 하나다. 실측: 07868 은 105,388자 중 5,306자만
@@ -425,6 +514,11 @@ mod tests {
     }
 
     /// OWPML `FieldType` 열거 전체 (ParaList XML schema.xml:2701-2719).
+    ///
+    /// [#4896] **실물 파일은 이 목록보다 넓다** — 한컴이 만든 hwpx 가
+    /// `PROOFREADING_MARKS_DELETE`(목록에 없는 값)를 쓴다(10k 코퍼스 12회/7문서, 정상 개방).
+    /// 그러므로 이 목록은 "우리가 새로 지어낼 때 고를 값"의 화이트리스트일 뿐,
+    /// 원본에서 온 값을 거를 필터가 아니다.
     const OWPML_FIELD_TYPES: &[&str] = &[
         "CLICK_HERE",
         "HYPERLINK",

--- a/tests/issue_4896_field_type_identity.rs
+++ b/tests/issue_4896_field_type_identity.rs
@@ -1,0 +1,125 @@
+//! Issue #4896: 열거 밖 필드 종류가 `CROSSREF` 로 굳어 필드 정체성이 사라지는 결함.
+//!
+//! 한글 2022 오라클 10k 전수(s13)에서 원본의 교정부호 필드(`%%*d`)가 rhwp 저장본에서
+//! 상호참조(`%xrf`)로 바뀌었다 — 27경로. 사슬은 두 마디였다:
+//!
+//! 1. HWPX 파서가 모르는 `type` 값을 `FieldType::Unknown` 으로만 떨어뜨려 원문을 버린다.
+//! 2. HWPX 직렬화기가 `Unknown` 을 본문 보존용 `CROSSREF` 로 굳힌다(#4776).
+//!
+//! ②의 판단(열거 밖 값을 새로 지어내면 한글이 본문을 버린다)은 유효하다. 고칠 곳은 ①이다 —
+//! **원본이 준 값은 한글이 이미 받아들인 값**이므로 그대로 되돌려주면 본문도 정체성도 산다.
+//! 10k 코퍼스 실측: 한컴 hwpx 원본이 쓰는 열거 밖 값은 `PROOFREADING_MARKS_DELETE` 하나뿐이고
+//! (12회/7문서), 같은 문서에서 한글이 세는 컨트롤 `%%*d` 와 개수까지 일치한다.
+//!
+//! 표본은 저장소에 새 이진 파일을 넣지 않으려고 **시험 시점에 합성**한다(#3707 선례).
+
+use std::fs;
+use std::io::{Read, Write};
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+
+const SAMPLE: &str = "samples/누름틀-2024.hwpx";
+const EXOTIC: &str = "PROOFREADING_MARKS_DELETE";
+
+/// 표본의 `CLICK_HERE` 필드 하나를 열거 밖 종류로 바꾼 hwpx 를 만든다.
+fn synth_exotic_field_hwpx() -> Vec<u8> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", SAMPLE, e));
+    let mut zin = zip::ZipArchive::new(std::io::Cursor::new(bytes)).expect("zip 열기");
+    let mut out = Vec::new();
+    {
+        let mut zout = zip::ZipWriter::new(std::io::Cursor::new(&mut out));
+        let opts: zip::write::FileOptions<'_, ()> =
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+        let mut replaced = false;
+        for i in 0..zin.len() {
+            let mut f = zin.by_index(i).expect("zip 항목");
+            let name = f.name().to_string();
+            let mut data = Vec::new();
+            f.read_to_end(&mut data).expect("항목 읽기");
+            if !replaced && name.starts_with("Contents/section") && name.ends_with(".xml") {
+                let s = String::from_utf8_lossy(&data).into_owned();
+                if let Some(pos) = s.find(r#"type="CLICK_HERE""#) {
+                    let mut edited = s.clone();
+                    edited.replace_range(
+                        pos..pos + r#"type="CLICK_HERE""#.len(),
+                        &format!(r#"type="{EXOTIC}""#),
+                    );
+                    data = edited.into_bytes();
+                    replaced = true;
+                }
+            }
+            zout.start_file(name, opts).expect("항목 쓰기");
+            zout.write_all(&data).expect("바이트 쓰기");
+        }
+        assert!(replaced, "표본에 CLICK_HERE 필드가 있어야 합성이 성립한다");
+        zout.finish().expect("zip 마무리");
+    }
+    out
+}
+
+fn section_xml(bytes: &[u8]) -> String {
+    let mut zin = zip::ZipArchive::new(std::io::Cursor::new(bytes)).expect("zip 열기");
+    let mut out = String::new();
+    for i in 0..zin.len() {
+        let mut f = zin.by_index(i).expect("zip 항목");
+        let name = f.name().to_string();
+        if name.starts_with("Contents/section") && name.ends_with(".xml") {
+            let mut s = String::new();
+            f.read_to_string(&mut s).expect("section xml");
+            out.push_str(&s);
+        }
+    }
+    out
+}
+
+#[test]
+fn hwpx_roundtrip_keeps_out_of_enum_field_type() {
+    let synth = synth_exotic_field_hwpx();
+    let core = DocumentCore::from_bytes(&synth).expect("합성 hwpx 파싱");
+
+    let saved = core.export_hwpx_native().expect("hwpx 저장");
+    let xml = section_xml(&saved);
+
+    assert!(
+        xml.contains(&format!(r#"type="{EXOTIC}""#)),
+        "원본이 준 필드 종류가 그대로 되돌아가야 한다"
+    );
+    assert_eq!(
+        xml.matches(r#"type="CROSSREF""#).count(),
+        section_xml(&synth).matches(r#"type="CROSSREF""#).count(),
+        "모르는 종류를 상호참조로 굳히면 안 된다"
+    );
+}
+
+#[test]
+fn hwpx_to_hwp5_keeps_field_ctrl_id() {
+    let synth = synth_exotic_field_hwpx();
+    let mut core = DocumentCore::from_bytes(&synth).expect("합성 hwpx 파싱");
+
+    // HWP5 는 ctrl_id 자체가 종류다 — 0 으로 저장하면 한글이 무효 컨트롤로 보고 필드를 잃는다.
+    let saved = core.export_hwp_with_adapter().expect("hwp 저장");
+    let reloaded = DocumentCore::from_bytes(&saved).expect("hwp 재파싱");
+
+    let ctrl_ids = collect_field_ctrl_ids(&reloaded);
+    assert!(
+        ctrl_ids.contains(&u32::from_be_bytes(*b"%%*d")),
+        "교정부호 필드의 ctrl_id 가 보존되어야 한다: {ctrl_ids:?}"
+    );
+}
+
+fn collect_field_ctrl_ids(core: &DocumentCore) -> Vec<u32> {
+    use rhwp::model::control::Control;
+    let mut ids = Vec::new();
+    for section in &core.document().sections {
+        for para in &section.paragraphs {
+            for ctrl in &para.controls {
+                if let Control::Field(f) = ctrl {
+                    ids.push(f.ctrl_id);
+                }
+            }
+        }
+    }
+    ids
+}


### PR DESCRIPTION
## 변경 요약

원본의 **교정부호 필드가 저장 후 상호참조로 바뀌는** 결함을 고친다. 한글 2022 오라클 10k
전수(s13)에서 27경로가 걸렸다 — 한글이 세는 컨트롤이 `%%*d`(교정부호 삭제) → `%xrf`(상호참조)로
바뀐다. 사슬은 두 마디였다.

1. HWPX 파서가 모르는 `type` 값을 `FieldType::Unknown` 으로만 떨어뜨려 **원문을 버린다**.
2. HWPX 직렬화기가 `Unknown` 을 본문 보존용 `CROSSREF` 로 굳힌다(#4776).

②의 판단 — 모르는 값을 새로 지어내면 한글이 그 지점부터 본문을 버린다 — 은 유효하므로
그대로 둔다. 고칠 곳은 ①이다: **원본이 준 값은 한글이 이미 받아들인 값**이므로 되돌려주면
본문도 정체성도 산다.

## 근거 — 10k 코퍼스 실측

| 관측 | 값 |
|---|---|
| 한컴 hwpx 원본 1,853문서의 열거 밖 `type` | `PROOFREADING_MARKS_DELETE` 하나뿐 (12회 / 7문서) |
| 그 문서에서 한글이 세는 컨트롤 | `%%*d` — **개수까지 일치** |
| hwp 원본(03430)의 같은 필드 | ctrl_id `%unk`, command `$RevisionDelete;` |

즉 **HWPX 는 `type` 문자열이, HWP5 는 `command` 문자열이 정체성의 carrier** 다. 스키마 열거
(15개)는 실물보다 좁다 — `PROOFREADING_MARKS_DELETE` 는 목록에 없지만 한컴이 쓰고 한글이 연다.
그래서 열거는 "우리가 새로 지어낼 때 고를 값"의 화이트리스트로만 쓰고, 원본에서 온 값을 거르는
필터로는 쓰지 않는다.

## 수정

- `model/control.rs` — `Field::raw_type` 신설(HWPX `type` 원문, 모르는 종류일 때만).
- `parser/hwpx/section.rs` — `Unknown` 이어도 원문과 실측 ctrl_id 를 함께 챙긴다.
  종전엔 ctrl_id 가 `0` 이라 HWPX→HWP 저장에서 한글이 무효 컨트롤로 보고 필드를 잃었다.
- `parser/tags.rs` — 실측 대응표 2종(`type ↔ ctrl_id`, `command → type`). **실측으로만 채운다.**
- `serializer/hwpx/field.rs` — `type` 결정 순서:
  ① `raw_type` 원문 → ② command 대응 → ③ ctrl_id 대응 → ④ (근거 없을 때만) `CROSSREF`.

## 관련 이슈

closes #4896

## 테스트

- [x] `cargo test` 통과 — 신규 `tests/issue_4896_field_type_identity.rs`(2, 표본을 시험 시점에
      합성해 저장소에 새 이진 파일을 넣지 않는다), 단위 시험 6종
- [x] `cargo clippy --all-targets -- -D warnings` 통과
- [x] 회귀 게이트: `ir_field_sweep_baseline` · `hwpx_to_hwp_adapter` · `fields_json_contract` ·
      `hwpx_roundtrip_baseline` · `convert_verify_corpus_ratchet` ·
      `issue_1391_memo_field_roundtrip` · `issue_3545_clickhere_dirty_roundtrip` 통과
- [ ] SVG 내보내기 확인 — 해당 없음(조판 아님, 저장 표기만 바뀐다)
- [ ] WASM 렌더링 확인 — 해당 없음

### 한글 오라클 재측정 (영향 27문서 54경로)

| 항목 | 결과 |
|---|---|
| `%xrf` 치환 서명 | **27경로 → 17경로** |
| 완전 OK 로 전환 | **17경로** (x2x 7 · x2h 7 · h2x 3) |
| 신규 결함 | **0** |

경로별로는 x2x·x2h 가 전부 해소됐고(HWPX 출처의 `type` 원문 보존), h2x 는 command 대응이
닿는 `$RevisionDelete;` 문서 3건이 해소됐다.

### 남긴 것 (같은 이슈의 다른 정체성)

잔존 17경로는 종류가 다르다 — `%%*c`(`$RevisionSimpleChange`) · `%%me`(`MEMO/…` 명령) ·
`%unk`(`$RevisionSign`) · 이름이 비어 보이는 ctrl. **대응하는 OWPML `type` 이름을 실측으로
확인할 수 없어**(코퍼스의 한컴 hwpx 원본에 그 값이 하나도 없다) 추정으로 표를 채우지 않았다.
근거가 생기면 `tags::OWPML_FIELD_TYPE_BY_COMMAND` 에 한 줄씩 추가하면 닫힌다.

`MEMO/…` 계열은 별도 주의가 필요하다 — `type="MEMO"` 는 memo subList/memoShape 구조를 요구해서
내용 없이 종류만 바꾸면 한글이 파일을 아예 열지 못한다(기존 실측).

## 성능 영향 및 측정 결과

- 예상 영향: 없음 (필드 하나당 문자열 비교 몇 번)
- 재현·측정: 위 오라클 재측정 외 별도 성능 측정 없음
