### PR TITLE
feat(service): 문서 열기·조회의 공통 축 src/service 신설

### DIFF
--- a/mydocs/tech/service_layer.md
+++ b/mydocs/tech/service_layer.md
@@ -1,0 +1,334 @@
+---
+kind: reference
+status: active
+canonical: mydocs/tech/service_layer.md
+last_verified: 2026-08-16
+---
+
+# 서비스 연계 표면 — `src/service`
+
+CLI·MCP·WASM 이 **함께 서는** 문서 열기·조회 축의 계약 문서다. 구현 정본은
+`src/service/`(`mod.rs`·`error.rs`·`open.rs`·`query.rs`)이고, 이 문서는 그 계약과
+채택 경로를 서술한다.
+
+## 1. 왜 필요한가
+
+`ROADMAP.md` 의 "rhwp가 공식적으로 맡는 범위" 표는 **서비스 연계 표면**을 업스트림
+책임으로 명시한다.
+
+> 서비스 연계 표면 | 자동화와 백엔드 서비스가 사용할 CLI의 기계 판독 출력, MCP 서버와
+> 공개 API 계약
+
+그런데 그 계약을 담을 공통 모듈이 없었다. 그래서 계약의 첫 네 걸음(**열기 · 메타 조회 ·
+검색 · 텍스트 내보내기**)이 표면마다 다시 쓰여 있다. 아래는 devel(441254611) 기준 실측이다.
+
+| 하는 일 | CLI `src/main.rs` | MCP `src/mcp_serve.rs` | WASM `src/wasm_api.rs` / 코어 |
+|---|---|---|---|
+| 바이트 읽고 실패 보고 | `fs::read` + `"파일을 읽을 수 없습니다"` 블록 **45곳** (첫 곳 `main.rs:4714`) | `session_open` `mcp_serve.rs:1421` | 호출자(JS) 몫 |
+| 비밀번호 유무 분기 | `load_document` `main.rs:115`, `load_document_core` `main.rs:124` | `session_open` `mcp_serve.rs:1429` | `HwpDocument::from_bytes*` `wasm_api.rs:433`·`437` |
+| 실패를 갈래로 나누기 | `classify_hwp_error` `main.rs:104` — **한국어 문장 부분일치** | 없음. 전부 `"{path} 파싱 실패"` `mcp_serve.rs:1435` | 없음. `HwpError` 를 `JsValue` 로 통째 전달 |
+| 형식 재판별 | `rhwp::parser::detect_format` **24곳** (예 `main.rs:4722`·`4963`·`5472`) | `mcp_serve.rs:1438` | `DocumentCore::from_bytes_inner` `document.rs:75` 가 계산하고 **폐기** |
+| 메타 산출 | `info_json_value` `main.rs:10314` | 같은 함수 재사용 `mcp_serve.rs:1680` | `DocumentCore::get_document_info` `document_core/mod.rs:258` — **필드·글꼴 규칙이 다름** |
+| 검색 엔진 | `grep` `main.rs:9936`, `grep_with_context` `main.rs:13323` | `grep` `mcp_serve.rs:1791` | `search_all_text_native` `wasm_api.rs:5115` — **엔진 자체가 다름** |
+| 쪽 텍스트 추출 루프 | `main.rs:6618`·`10569`·`10651`·`10700` | `mcp_serve.rs:215`·`1598` | `extract_page_text_native` 직접 호출 |
+
+### 1.1 중복의 대가 — 같은 질문, 다른 답
+
+숫자보다 중요한 것은 마지막 세 줄이다.
+
+- **"이 문서가 쓰는 글꼴은?"** `info --json`(`main.rs:10346`)은 선언된 글꼴군을 문서
+  순서대로, 중복까지 보존해 준다. WASM 이 쓰는 `get_document_info`
+  (`document_core/mod.rs:261`)는 `BTreeSet` 으로 정렬·중복 제거하고 대체 글꼴까지
+  해소해서 준다. 같은 문서에 두 답이 있다.
+- **"이 단어가 어디 있는가?"** CLI·MCP 는 좌표(구역·문단·**쪽**·문자 오프셋)가 붙은
+  `GrepMatch` 를 준다. WASM 은 좌표 어휘가 다른 `search_all_text_native` 의 산출을 준다.
+- **"왜 못 열었는가?"** CLI 만 갈래를 나눈다. 그 갈래조차 한국어 문장 부분일치다.
+
+  ```rust
+  // src/main.rs:104 classify_hwp_error
+  if msg.contains("비밀번호가 일치하지 않") { LoadError::WrongPassword }
+  else if msg.contains("비밀번호가 필요한 암호 문서") { LoadError::NeedPassword }
+  ```
+
+  이 판정이 exit code 를 정한다. 문장 한 글자가 바뀌면 종료 코드가 조용히 바뀌고,
+  그 판정은 CLI 안에만 있어 MCP·WASM 은 갈래를 아예 잃는다.
+
+**어느 표면에 물었느냐로 답이 달라지는 값은 계약이 아니다.** `src/service` 는 그
+답을 한 번만 정의하기 위한 축이다.
+
+### 1.2 이 PR 의 경계
+
+이 PR 은 **축을 세우기만 한다**. `main.rs`·`mcp_serve.rs`·`wasm_api.rs` 는 한 줄도
+고치지 않았다. 세 소비자의 이관은 4장의 시나리오대로 후속 PR 에서 표면별로 진행한다.
+`src/lib.rs` 변경은 `pub mod service;` **한 줄**이다.
+
+## 2. 공개 API
+
+```rust
+// 진입점 — 설정을 든 값 타입. 복제해서 설정만 다른 서비스를 만든다.
+pub struct DocumentService { /* max_bytes, title_scan */ }
+impl DocumentService {
+    pub fn new() -> Self;
+    pub fn with_max_bytes(self, max_bytes: Option<usize>) -> Self;
+    pub fn with_title_scan(self, title_scan: bool) -> Self;
+    pub fn max_bytes(&self) -> Option<usize>;
+
+    pub fn open_bytes(&self, bytes: &[u8], opts: &OpenOptions)
+        -> Result<OpenedDocument, ServiceError>;
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn open_path(&self, path: &Path, opts: &OpenOptions)
+        -> Result<OpenedDocument, ServiceError>;
+}
+
+pub const DEFAULT_MAX_BYTES: usize = 256 * 1024 * 1024;
+
+pub struct OpenOptions { pub password: Option<String>, pub max_bytes: Option<usize> }
+
+pub struct OpenedDocument { /* DocumentCore + FileFormat + size_bytes + DocumentSource */ }
+impl OpenedDocument {
+    pub fn format(&self) -> FileFormat;
+    pub fn size_bytes(&self) -> usize;
+    pub fn source(&self) -> &DocumentSource;
+    pub fn core(&self) -> &DocumentCore;
+    pub fn document(&self) -> &Document;
+    pub fn page_count(&self) -> u32;
+    pub fn into_core(self) -> DocumentCore;          // 편집으로 넘어가는 탈출구
+
+    pub fn info(&self) -> DocumentInfo;
+    pub fn search(&self, query: &str, opts: &SearchOptions) -> SearchOutcome;
+    pub fn export_text(&self, opts: &TextExportOptions) -> TextExport;
+}
+
+pub fn format_token(format: FileFormat) -> &'static str;  // "hwp5"|"hwpx"|"hwp3"|"hml"|…
+```
+
+산출 타입은 전부 `Serialize`(camelCase)라 봉투에 그대로 실린다.
+
+| 타입 | 담는 것 |
+|---|---|
+| `DocumentInfo` | `format`·`sizeBytes`·`version`·`sections`·`pageCount`·`paraCount`·`encrypted`·`fonts`·`title` |
+| `SearchOutcome` | `query`·`caseSensitive`·`matchCount`·`totalMatchCount`·`truncated`·`omittedCount`·`offset`·`nextOffset`·`matches[]`(좌표 포함) |
+| `TextExport` | `pageCount`·`truncated`·`omittedCount`·`charOffset`·`nextOffset`·`outOfRange[]`·`pages[]` |
+| `PageText` | `page`·`text`·`truncated`·`omittedCount`·`extractError` |
+
+`schemaVersion` 과 `source` 는 **일부러 뺐다**. 스키마 버전은 봉투를 만드는 표면의
+몫이고, `source` 자리에는 표면마다 다른 이름(경로·`docId`·업로드 파일명)이 와야 한다.
+
+### 2.1 스케치에서 바꾼 것과 그 이유
+
+| 스케치 | 채택형 | 이유 |
+|---|---|---|
+| `ServiceError::Encrypted` 하나 | `PasswordRequired` / `PasswordMismatch` 둘 | 현행 CLI 가 이미 두 갈래를 서로 다른 exit code(USAGE/RUNTIME)로 매핑한다. 하나로 뭉치면 소비자가 다시 문자열을 갈라 읽어야 한다. |
+| `NotFound` (payload 없음) | `NotFound { path }` + `Io { path, kind }` 신설 | "파일이 없다"(경로를 고치면 됨)와 "읽을 수 없다"(권한·환경)는 조치가 다르다. |
+| `UnsupportedFormat` (payload 없음) | `UnsupportedFormat { detected }` | DRM 컨테이너·빈 파일·미상 바이트는 사용자가 할 수 있는 조치가 다르다. 감지 결과를 버리지 않는다. |
+| — | `DocumentService::with_title_scan` | `title` 추정은 앞 3쪽 **텍스트 렌더**를 요구한다. 수천 건 대장화에서 비용이 지배적이라 끌 수 있어야 한다. |
+| — | `DEFAULT_MAX_BYTES` 기본 켬 | 현행 세 표면에 크기 상한이 **하나도 없다**. 자동화·백엔드가 쓰는 표면에서 그건 구멍이다. |
+
+## 3. 오류 타입 계약
+
+```rust
+pub enum ServiceError {
+    NotFound { path: PathBuf },
+    Io { path: PathBuf, kind: std::io::ErrorKind },
+    UnsupportedFormat { detected: FileFormat },
+    PasswordRequired,
+    PasswordMismatch,
+    TooLarge { size_bytes: usize, limit_bytes: usize },
+    Parse(String),
+}
+```
+
+| 변형 | `code()` | `is_usage_error()` | `needs_password()` | 권장 exit code |
+|---|---|---|---|---|
+| `NotFound` | `NOT_FOUND` | true | false | 2 (USAGE) |
+| `Io` | `IO` | false | false | 1 (RUNTIME) |
+| `UnsupportedFormat` | `UNSUPPORTED_FORMAT` | true | false | 2 (USAGE) |
+| `PasswordRequired` | `PASSWORD_REQUIRED` | true | true | 2 (USAGE) |
+| `PasswordMismatch` | `PASSWORD_MISMATCH` | false | true | 1 (RUNTIME) |
+| `TooLarge` | `TOO_LARGE` | true | false | 2 (USAGE) |
+| `Parse` | `PARSE` | false | false | 1 (RUNTIME) |
+
+`code()` 문자열이 **계약**이다. 토큰 추가는 허용, 변경·삭제는 소비자를 깨뜨린다.
+`Display` 는 사람에게 보일 한국어 문장이며 **판정의 근거가 아니다**.
+
+### 3.1 판정은 오류가 아니다
+
+`Ok` 안에 담기고 `Err` 로 올라오지 **않는** 것들이다.
+
+| 상황 | 표현 |
+|---|---|
+| 매치 0건 | `SearchOutcome { total_match_count: 0, .. }` · `is_empty() == true` |
+| 빈 검색어 | 위와 같음(0건). 빈 검색어 거절은 인자 검증이고, 그건 표면의 몫이다. |
+| 범위 밖 쪽 요청 | `TextExport::out_of_range: Vec<u32>` |
+| 쪽 텍스트 추출 실패 | `PageText::extract_error: Option<String>` — 그 쪽도 목록에서 **빼지 않는다** |
+| 절단 | `truncated`·`omitted_count`·`next_offset` |
+
+쪽 항목을 빼지 않는 규칙은 이 저장소가 이미 지키는 것이다(#3787 S7·#4854). 빼면
+`pageCount` 가 줄어 문서가 실제보다 짧아 보이고, "빈 쪽"과 "못 읽은 쪽"이 같은
+모습이 된다.
+
+### 3.2 타입 복원 경계 — 알려진 이음매
+
+`DocumentCore::from_bytes` 는 타입 있는 `ParseError` 를
+`HwpError::InvalidFile(String)` 으로 **평탄화해서** 돌려준다
+(`document_core/commands/document.rs:80`). 이 PR 은 기존 파일을 고치지 않으므로 그
+평탄화를 되돌릴 수 없고, 타입 복원은 `ServiceError::from_open_failure` 한 곳에서만
+일어난다.
+
+다만 `main.rs` 처럼 한국어 문장을 **상수로 박지 않는다**. 대조할 바늘을 그 자리에서
+타입으로부터 만든다.
+
+```rust
+if inner.contains(&CryptoError::WrongPassword.to_string())        { PasswordMismatch }
+if inner.contains(&ParseError::EncryptedDocument.to_string())     { PasswordRequired }
+```
+
+업스트림이 문구를 고치면 바늘도 같이 따라가므로, 문구 변경이 exit code 를 조용히
+뒤집는 사고가 나지 않는다. HWP5·HWPX·HWP3 의 비밀번호 불일치는 세 형식 모두 같은
+문장을 감싸 내보내므로(`암호 오류: …` / `HWPX 오류: …` / `HWP 3.0 오류: …`) 부분
+일치 하나로 셋을 덮는다.
+
+또 하나 바로잡은 갈래: **비밀번호를 주었는데도** "암호 문서" 오류가 오면 그건
+"비밀번호를 주세요"가 아니라 "그 비밀번호가 틀렸다"이다. 현행 CLI 는 이 경우에도
+`--password <pw> 로 전달` 을 출력해 이미 준 것을 다시 요구한다.
+
+**후속**: `DocumentCore::from_bytes` 계열이 타입 있는 오류를 돌려주게 되면 이 이음매는
+사라진다. 그 변경은 기존 소비자 전부를 건드리므로 이 PR 의 범위가 아니다.
+
+## 4. 채택 시나리오
+
+### 4.1 CLI (`src/main.rs`)
+
+현행 명령 하나의 앞머리는 이렇게 생겼다(45곳 반복).
+
+```rust
+let data = match fs::read(file_path) {
+    Ok(d) => d,
+    Err(e) => { eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e); return EXIT_RUNTIME; }
+};
+let source_format = rhwp::parser::detect_format(&data);   // 코어가 이미 계산했다가 버린 값
+let doc = match load_document(&data) { Ok(d) => d, Err(e) => return e.report() };
+```
+
+이관 후.
+
+```rust
+let opened = match SERVICE.open_path(Path::new(file_path), &open_opts) {
+    Ok(opened) => opened,
+    Err(error) => {
+        eprintln!("오류: {error}");
+        return if error.is_usage_error() { EXIT_USAGE } else { EXIT_RUNTIME };
+    }
+};
+let source_format = opened.format();     // 재판별 없음
+```
+
+- `classify_hwp_error`·`LoadError`·`CLI_PASSWORD` thread-local 전역이 사라진다.
+  비밀번호는 `OpenOptions` 로 흘러 시그니처에 보인다 — `batch` 가 워커 스레드로
+  갈라질 때 인증이 조용히 사라지던 함정(`is_batch_invocation` 이 네 옵션을 통째로
+  거부하는 이유)이 구조적으로 없어진다.
+- `info_json_value` 는 `opened.info()` 를 감싸 `schemaVersion`·`source`·`warnings` 만
+  얹는 얇은 함수가 된다.
+- `export-text --json` 은 `opened.export_text(...)` 산출에 껍데기만 붙인다.
+- **무회귀 조건**: 봉투 필드 이름·순서는 이미 맞춰 두었다. 이관 PR 은 기존 계약
+  테스트를 그대로 통과해야 하며, 통과가 곧 등가 증명이다.
+
+### 4.2 MCP (`src/mcp_serve.rs`)
+
+`session_open` 은 서비스 호출 + 핸들 등록으로 줄어든다.
+
+```rust
+let opened = match SERVICE.open_path(Path::new(path), &opts) {
+    Ok(opened) => opened,
+    Err(error) => return tool_error_typed(&error),   // code + nextCall 을 타입에서
+};
+let detected_format = opened.format();               // 재판별 없음
+let size_bytes = opened.size_bytes();
+sessions.insert(SessionDoc { core: opened.into_core(), detected_format, size_bytes, .. });
+```
+
+가장 큰 이득은 **오류 갈래를 얻는 것**이다. 지금 MCP 는 모든 열기 실패를
+`"{path} 파싱 실패: {e}"` 하나로 뭉친다. `ServiceError::code()` 를 봉투의 `code` 로,
+`needs_password()` 를 `nextCall`(같은 도구 + `password`) 제안 조건으로 쓰면
+에이전트가 실패에서 다음 수를 읽을 수 있다. 세션 조회 도구(`hwp_doc_search`·
+`hwp_doc_text`)의 창(offset/limit) 계산은 `SearchOptions`/`TextExportOptions` 로
+대체된다 — 지금은 CLI 쪽 헬퍼를 `crate::` 로 빌려 쓰는데, 그 경로는 **바이너리
+크레이트 안에서만** 성립해서 WASM 은 애초에 낄 수 없었다.
+
+### 4.3 WASM (`src/wasm_api.rs`)
+
+WASM 은 `#[wasm_bindgen]` 표면이라 값을 JSON 문자열로 넘긴다. 서비스 산출이 전부
+`Serialize` 이므로 그 벽을 그대로 통과한다.
+
+```rust
+#[wasm_bindgen(js_name = openDocument)]
+pub fn open_document(bytes: &[u8], password: Option<String>) -> Result<String, JsValue> {
+    let opts = OpenOptions { password, max_bytes: None };
+    match SERVICE.open_bytes(bytes, &opts) {
+        Ok(opened) => Ok(serde_json::to_string(&opened.info()).unwrap()),
+        // 브라우저가 error.code 로 분기한다 — 문장을 파싱하지 않는다.
+        Err(error) => Err(JsValue::from_str(&format!(r#"{{"code":"{}"}}"#, error.code()))),
+    }
+}
+```
+
+- `open_path` 는 `#[cfg(not(target_arch = "wasm32"))]` 이라 WASM 빌드에 들어가지
+  않는다. WASM 은 `open_bytes` 만 쓴다.
+- `getDocumentInfo` 는 `DocumentInfo` 로 수렴한다 — 1.1 의 "글꼴 두 답"이 여기서
+  닫힌다. **호환 주의**: 현행 `get_document_info` 의 `fontsUsed`(정렬·중복 제거·대체
+  해소)와 `fontSubstitutions` 는 렌더러가 쓰는 값이므로, 이관 PR 은 `DocumentInfo`
+  에 `fonts` 를 두고 렌더 전용 필드는 별도 질의로 남기거나 필드를 추가해야 한다.
+  같은 이름으로 다른 값을 주는 것만 금지한다.
+- `searchAllText` 는 좌표가 붙는 `search` 로 수렴한다. 브라우저 뷰어가 "몇 쪽"에
+  답할 수 있게 되는 부수 효과가 있다.
+
+### 4.4 이관 순서 제안
+
+1. MCP `session_open` — 표면이 가장 작고, 오류 갈래 이득이 가장 크다.
+2. CLI `info`·`export-text`·`search` 3개 명령 — 봉투 계약 테스트가 등가를 지킨다.
+3. CLI 나머지 명령의 `fs::read` + `load_document` 블록 일괄 치환.
+4. WASM `getDocumentInfo`·`searchAllText` — 브라우저 호환 표면이라 마지막.
+
+## 5. 비범위
+
+이 축이 **다루지 않는** 것.
+
+- **편집·저장.** 읽기 전용이다. 편집이 필요하면 `into_core()` 로 코어를 가져가
+  기존 경로로 계속한다.
+- **렌더링**(SVG/PNG/PDF), **조판 옵션**(DPI·조판부호·디버그 오버레이).
+- **MCP 세션 수명**(`docId` 발급·만료·저널) — 세션은 MCP 의 정책이다.
+- **봉투 껍데기** — `schemaVersion`·`source`·`untrustedContent` 출처 표지는 표면이
+  붙인다(`mydocs/tech/envelope_provenance.md`).
+- **인자 파싱·exit code 결정.** 서비스는 판정을 주고, 정책은 표면이 정한다.
+- **LLM·네트워크·전역 상태.** 결정적이고 부수효과가 없다.
+
+## 6. 검증
+
+`src/service/mod.rs` 의 `#[cfg(test)] mod tests` 16건. 샘플 경로는
+`env!("CARGO_MANIFEST_DIR")` 기준이라 작업 디렉터리에 의존하지 않는다.
+
+| 테스트 | 덮는 계약 |
+|---|---|
+| `open_path_reads_and_parses_hwpx_sample` | 열기 성공·형식·원본 크기·출처 보존 |
+| `format_is_auto_detected_from_bytes_alone` | 확장자 없이 바이트만으로 HWP/HWPX 판별 |
+| `missing_path_is_not_found_not_parse_failure` | `NotFound` + `code()` + `is_usage_error()` |
+| `unrecognized_bytes_are_unsupported_format` | `UnsupportedFormat{Unknown}` · `{Empty}` 구분 |
+| `size_limit_rejects_before_parsing` | `TooLarge`, 호출 단위 상한이 기본값을 덮어씀 |
+| `info_reports_format_size_and_counts` | 메타 필드 + camelCase 직렬화 어휘 |
+| `title_scan_can_be_disabled` | 기능 플래그, 나머지 메타의 결정성 |
+| `export_text_keeps_one_entry_per_page` | 쪽 주소 보존 |
+| `export_text_truncation_reports_omission_and_next_offset` | 절단 어휘 |
+| `export_text_out_of_range_page_is_data_not_error` | 범위 밖 쪽 = 데이터 |
+| `search_returns_matches_with_coordinates` | 검색 매치 + 좌표 |
+| `search_without_match_is_ok_not_error` | 0건·빈 검색어 = `Ok` |
+| `search_window_walks_all_matches_without_moving_the_total` | offset/limit 창, 총량 불변 |
+| `error_codes_and_severity_are_stable` | `code()`·`is_usage_error()`·`needs_password()` 표 |
+| `open_failure_classification_derives_needles_from_types` | 3.2 의 바늘이 타입에서 나옴 |
+| `service_is_deterministic_and_read_only` | 같은 입력 → 같은 산출, 원본 무훼손 |
+
+## 관련 문서
+
+- `ROADMAP.md` — "rhwp가 공식적으로 맡는 범위" 표
+- [`mydocs/tech/envelope_provenance.md`](envelope_provenance.md) — 봉투 출처 표지 계약
+- [`mydocs/manual/cli_commands.md`](../manual/cli_commands.md) — CLI 명령 레퍼런스
+- [`mydocs/manual/mcp_integration_guide.md`](../manual/mcp_integration_guide.md) — MCP 통합 절차

--- a/mydocs/working/task_m100_4919_stage1_ci_format_correction.md
+++ b/mydocs/working/task_m100_4919_stage1_ci_format_correction.md
@@ -1,0 +1,30 @@
+---
+kind: working-note
+status: completed
+issue: 4919
+pr: 4919
+stage: 1
+last_verified: 2026-08-16
+---
+
+# PR #4919 CI formatter 보정
+
+## 원인
+
+GitHub Actions의 `Lint (fmt, clippy, WASM check)`가 `src/lib.rs`의 공개 모듈 선언 순서를
+`rustfmt` 정렬 규칙과 다르게 두어 실패했다. 이 실패로 Rust archive와 test shard가 모두
+skip되었고, 집계 `Build & Test`도 실패했다.
+
+## 보정
+
+`service` 공개 모듈 선언을 `serializer` 뒤로 옮겨 `cargo fmt --all -- --check`의 요구와
+일치시켰다. API, 구현, 테스트 동작은 바꾸지 않는다.
+
+## 검증
+
+- `cargo fmt --all -- --check`
+- PR #4919의 최신 contributor head와 maintainer 보정 시작 SHA 일치 확인
+
+## 후속
+
+보정 commit을 contributor의 `feat/service-layer` 브랜치에 push한 뒤 새 Full CI를 확인한다.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod rag;
 pub mod renderer;
 pub mod schema_registry;
 pub mod security_trailer;
+pub mod service;
 pub mod serializer;
 /// 핫패치 벤더(Dioxus subsecond) 어댑터. **rhwp 의 API 가 아니다** (#4580).
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@ pub mod rag;
 pub mod renderer;
 pub mod schema_registry;
 pub mod security_trailer;
-pub mod service;
 pub mod serializer;
+pub mod service;
 /// 핫패치 벤더(Dioxus subsecond) 어댑터. **rhwp 의 API 가 아니다** (#4580).
 ///
 /// `pub` 인 이유는 `tools/rhwp-subsecond` 가 `link_wasm_exports()` 를 불러 wasm export 를 살려

--- a/src/service/error.rs
+++ b/src/service/error.rs
@@ -1,0 +1,197 @@
+//! 서비스 계층 오류 타입 — **자연어가 아니라 타입이 판정한다**.
+//!
+//! 이 모듈이 존재하는 이유는 하나다. 지금 CLI 는 문서 열기 실패를 이렇게 가른다
+//! (`src/main.rs` `classify_hwp_error`).
+//!
+//! ```text
+//! if msg.contains("비밀번호가 일치하지 않") { WrongPassword }
+//! else if msg.contains("비밀번호가 필요한 암호 문서") { NeedPassword }
+//! ```
+//!
+//! 한국어 문장 한 글자만 바뀌어도 **exit code 가 조용히 바뀐다**. 그리고 그 판정은
+//! CLI 안에만 있어서 MCP 는 아예 갈래를 잃고 모든 실패를 `"{path} 파싱 실패"` 하나로
+//! 뭉갠다. 소비자가 실패를 기계로 다루려면 실패에 **이름**이 있어야 한다.
+//!
+//! [`ServiceError`] 는 그 이름이다. 소비자는 [`ServiceError::code`] 로 안정 토큰을,
+//! [`ServiceError::is_usage_error`] 로 "요청을 고치면 되는 실패인가"를 얻는다.
+//! `Display` 는 사람에게 보일 한국어 문장이지만 **판정의 근거가 아니다**.
+
+use std::path::PathBuf;
+
+use crate::parser::crypto::CryptoError;
+use crate::parser::{FileFormat, ParseError};
+use crate::HwpError;
+
+/// 서비스 계층이 돌려주는 실패의 전부.
+///
+/// "매치 0건", "빈 문서", "표가 없음" 같은 **판정은 여기 없다** — 그것들은 실패가
+/// 아니라 `Ok` 안의 값이다([`crate::service::SearchOutcome`] 참고).
+///
+/// `PartialEq` 를 구현하므로 테스트와 소비자가 값 비교로 갈래를 확인할 수 있다.
+/// (`Eq` 는 [`FileFormat`] 이 `Eq` 를 구현하지 않아 파생하지 않는다.)
+#[derive(Debug, Clone, PartialEq)]
+pub enum ServiceError {
+    /// 입력 경로가 존재하지 않는다.
+    NotFound {
+        /// 열려고 한 경로.
+        path: PathBuf,
+    },
+    /// 경로는 있으나 읽지 못했다(권한 없음·디렉터리·I/O 오류 등).
+    ///
+    /// `NotFound` 와 갈라 두는 이유: "파일이 없다"는 호출자가 경로를 고치면 되는
+    /// 사용법 오류지만, "읽을 수 없다"는 환경 문제라 재시도·권한 조정의 대상이다.
+    Io {
+        /// 열려고 한 경로.
+        path: PathBuf,
+        /// 표준 I/O 오류 갈래. `std::io::Error` 는 `Clone`·`PartialEq` 가 아니라
+        /// 갈래만 보존한다.
+        kind: std::io::ErrorKind,
+    },
+    /// 매직 바이트로 판별한 형식이 rhwp 가 여는 4형식(HWP5·HWPX·HWP3·HML)이 아니다.
+    ///
+    /// 파서를 부르기 **전에** 판정하므로, 손상된 대용량 입력이 파서를 통과할 기회를
+    /// 얻지 못한다. `detected` 에는 [`FileFormat::Unknown`]·[`FileFormat::Empty`]·
+    /// [`FileFormat::DrmProtected`] 중 하나가 담긴다 — DRM 컨테이너를 "알 수 없음"과
+    /// 같은 말로 보고하면 사용자가 할 수 있는 조치(DRM 해제 후 저장)를 알 수 없다.
+    UnsupportedFormat {
+        /// 매직 바이트로 감지한 형식.
+        detected: FileFormat,
+    },
+    /// 암호 문서인데 비밀번호를 받지 못했다.
+    PasswordRequired,
+    /// 비밀번호가 일치하지 않거나 암호화 데이터가 손상됐다.
+    PasswordMismatch,
+    /// 입력이 크기 상한을 넘었다. **파싱 전에** 판정한다.
+    TooLarge {
+        /// 실제 입력 크기.
+        size_bytes: usize,
+        /// 적용된 상한([`crate::service::OpenOptions::max_bytes`] 또는 서비스 기본값).
+        limit_bytes: usize,
+    },
+    /// 그 밖의 파싱 실패. 원문 메시지는 **사람에게 보여주기 위한 것**이며,
+    /// 소비자가 이 문자열을 다시 갈라 읽으면 안 된다.
+    Parse(String),
+}
+
+impl ServiceError {
+    /// 기계 판독용 안정 토큰. JSON 봉투의 `code` 필드와 exit code 매핑의 단일 축이다.
+    ///
+    /// 이 문자열은 **계약**이다. 값 추가는 허용하되 기존 토큰의 변경·삭제는 소비자를
+    /// 깨뜨린다.
+    pub fn code(&self) -> &'static str {
+        match self {
+            ServiceError::NotFound { .. } => "NOT_FOUND",
+            ServiceError::Io { .. } => "IO",
+            ServiceError::UnsupportedFormat { .. } => "UNSUPPORTED_FORMAT",
+            ServiceError::PasswordRequired => "PASSWORD_REQUIRED",
+            ServiceError::PasswordMismatch => "PASSWORD_MISMATCH",
+            ServiceError::TooLarge { .. } => "TOO_LARGE",
+            ServiceError::Parse(_) => "PARSE",
+        }
+    }
+
+    /// 호출자가 **요청을 고치면 해소되는** 실패인가.
+    ///
+    /// CLI 는 이 값이 참이면 `EXIT_USAGE`(2), 거짓이면 `EXIT_RUNTIME`(1) 로 매핑하면
+    /// 된다. 현행 `main.rs` 의 `LoadError` 매핑(NeedPassword→USAGE,
+    /// WrongPassword→RUNTIME)과 일치한다 — 이 축이 없으면 소비자는 다시 문자열을
+    /// 들여다볼 수밖에 없다.
+    pub fn is_usage_error(&self) -> bool {
+        matches!(
+            self,
+            ServiceError::NotFound { .. }
+                | ServiceError::UnsupportedFormat { .. }
+                | ServiceError::PasswordRequired
+                | ServiceError::TooLarge { .. }
+        )
+    }
+
+    /// 비밀번호를 주면 다시 시도할 가치가 있는 실패인가.
+    ///
+    /// MCP 같은 대화형 소비자가 `nextCall` 로 "password 를 붙여 재시도"를 제안할
+    /// 조건이다.
+    pub fn needs_password(&self) -> bool {
+        matches!(
+            self,
+            ServiceError::PasswordRequired | ServiceError::PasswordMismatch
+        )
+    }
+
+    /// `DocumentCore` 가 돌려준 [`HwpError`] 를 서비스 오류로 옮긴다.
+    ///
+    /// # 왜 문자열을 들여다보는가 — 그리고 왜 그래도 안전한가
+    ///
+    /// `DocumentCore::from_bytes` 는 타입 있는 [`ParseError`] 를
+    /// `HwpError::InvalidFile(String)` 으로 **평탄화해서** 돌려준다. 이 PR 은 기존
+    /// 파일을 고치지 않으므로 그 평탄화를 되돌릴 수 없고, 타입 복원은 이 경계에서
+    /// 한 번만 일어난다.
+    ///
+    /// 다만 `main.rs` 처럼 한국어 문장을 **상수로 박아 넣지는 않는다**. 대조할
+    /// 바늘을 타입에서 그 자리에서 만든다 — `ParseError::EncryptedDocument.to_string()`,
+    /// `CryptoError::WrongPassword.to_string()`. 업스트림이 문구를 고치면 바늘도
+    /// 같이 따라가므로, 문구 변경이 exit code 를 조용히 뒤집는 사고가 나지 않는다.
+    /// HWPX·HWP3 의 비밀번호 불일치도 같은 문장을 감싸 내보내므로(`HWPX 오류: …`)
+    /// 부분 일치로 세 형식을 한 번에 덮는다.
+    ///
+    /// `password_supplied` 는 갈래를 하나 더 바로잡는다. 비밀번호를 **주었는데도**
+    /// "암호 문서" 오류가 오면 그건 "비밀번호를 주세요"가 아니라 "그 비밀번호가
+    /// 틀렸다"이다. 현행 CLI 는 이 경우에도 `--password 를 전달하세요` 를 출력해,
+    /// 이미 준 것을 다시 요구한다.
+    pub(crate) fn from_open_failure(error: &HwpError, password_supplied: bool) -> ServiceError {
+        let HwpError::InvalidFile(inner) = error else {
+            return ServiceError::Parse(error.to_string());
+        };
+        if inner.contains(&CryptoError::WrongPassword.to_string()) {
+            return ServiceError::PasswordMismatch;
+        }
+        if inner.contains(&ParseError::EncryptedDocument.to_string()) {
+            return if password_supplied {
+                ServiceError::PasswordMismatch
+            } else {
+                ServiceError::PasswordRequired
+            };
+        }
+        ServiceError::Parse(inner.clone())
+    }
+}
+
+impl std::fmt::Display for ServiceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ServiceError::NotFound { path } => {
+                write!(f, "파일을 찾을 수 없습니다: {}", path.display())
+            }
+            ServiceError::Io { path, kind } => {
+                write!(f, "파일을 읽을 수 없습니다: {} ({kind:?})", path.display())
+            }
+            ServiceError::UnsupportedFormat { detected } => match detected {
+                FileFormat::Empty => write!(f, "빈 파일(0 바이트)입니다."),
+                FileFormat::DrmProtected => write!(
+                    f,
+                    "DRM/보안 컨테이너로 보호된 문서입니다. 보호를 해제한 뒤 저장해 열어주세요."
+                ),
+                other => write!(
+                    f,
+                    "지원하지 않는 형식입니다: {other:?}. rhwp 는 HWP 5.0·HWPX·일부 HWP 3.0·HWPML 을 엽니다."
+                ),
+            },
+            ServiceError::PasswordRequired => {
+                write!(f, "비밀번호가 필요한 암호 문서입니다.")
+            }
+            ServiceError::PasswordMismatch => write!(
+                f,
+                "비밀번호가 일치하지 않거나 암호화 데이터가 손상되었습니다."
+            ),
+            ServiceError::TooLarge {
+                size_bytes,
+                limit_bytes,
+            } => write!(
+                f,
+                "입력이 크기 상한을 넘었습니다: {size_bytes}바이트 (상한 {limit_bytes}바이트)"
+            ),
+            ServiceError::Parse(message) => write!(f, "문서 파싱 실패 - {message}"),
+        }
+    }
+}
+
+impl std::error::Error for ServiceError {}

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,0 +1,563 @@
+//! 서비스 연계 표면 — CLI·MCP·WASM 이 **함께 서는** 문서 열기·조회 축.
+//!
+//! # 왜 이 모듈이 있는가
+//!
+//! `ROADMAP.md` 의 "rhwp가 공식적으로 맡는 범위" 표는 **서비스 연계 표면**을
+//! 업스트림 책임으로 못 박는다 — "자동화와 백엔드 서비스가 사용할 CLI의 기계 판독
+//! 출력, MCP 서버와 공개 API 계약". 그런데 그 계약을 담을 공통 모듈이 없어서,
+//! 계약의 첫 네 걸음(**열기 · 메타 조회 · 검색 · 텍스트 내보내기**)이 표면마다
+//! 다시 쓰여 있다.
+//!
+//! | 하는 일 | CLI (`src/main.rs`) | MCP (`src/mcp_serve.rs`) | WASM (`src/wasm_api.rs`) |
+//! |---|---|---|---|
+//! | 바이트 읽고 오류 보고 | `fs::read` + 오류 블록 **45곳** | `session_open` 1곳 | 호출자(JS) 몫 |
+//! | 비밀번호 유무 분기 | `load_document` / `load_document_core` (2곳) | `session_open` | `from_bytes` / `from_bytes_with_password` |
+//! | 실패를 갈래로 나누기 | `classify_hwp_error` — **한국어 문장 부분일치** | 없음(전부 "파싱 실패") | 없음(`JsValue` 로 통째 전달) |
+//! | 형식 재판별 | `detect_format` **24곳** | `detect_format` 1곳 | 코어가 계산 후 폐기 |
+//! | 메타 JSON | `info_json_value` | `info_json_value` 재사용 | `DocumentCore::get_document_info` — **필드도 글꼴 규칙도 다름** |
+//! | 검색 | `grep`/`grep_with_context` | `grep` | `search_all_text_native` — **엔진 자체가 다름** |
+//!
+//! 마지막 두 줄이 이 축이 필요한 이유를 가장 잘 보여준다. "이 문서가 쓰는 글꼴은
+//! 무엇인가"에 CLI 는 선언 순서 그대로(중복 포함)를, WASM 은 정렬·중복 제거·대체
+//! 글꼴 해소본을 준다. "이 단어가 어디 있는가"에 CLI·MCP 는 좌표를 주고 WASM 은
+//! 다른 엔진의 다른 모양을 준다. **어느 표면에 물었느냐로 답이 달라지는 값은
+//! 계약이 아니다.**
+//!
+//! # 설계 규약
+//!
+//! - **결정적·읽기 전용.** LLM·네트워크·전역 상태 없음. 비밀번호도 전역이 아니라
+//!   [`OpenOptions`] 인자로 흐른다(현행 CLI 의 `thread_local` 전역과 대비).
+//! - **오류는 타입.** [`ServiceError`] 가 갈래를 이름으로 준다. 소비자가 한국어
+//!   문장을 부분일치로 판정하는 일이 없어야 한다.
+//! - **판정은 오류가 아니다.** 매치 0건, 범위 밖 쪽 요청, 추출 실패한 쪽은 전부
+//!   `Ok` 안의 데이터다. 그걸로 무엇을 할지는 표면의 정책이다.
+//! - **파싱을 새로 쓰지 않는다.** [`crate::parser`] 와 [`crate::document_core`] 를
+//!   그대로 쓴다. 이 축은 그 위에 얹는 **계약**이지 두 번째 파서가 아니다.
+//!
+//! # 범위 밖
+//!
+//! 편집·저장·렌더링·MCP 세션 수명·JSON 봉투 껍데기(`schemaVersion`·`source`)는 이
+//! 축이 다루지 않는다. 편집이 필요하면 [`OpenedDocument::into_core`] 로 코어를
+//! 가져가 기존 경로로 계속한다.
+//!
+//! # 쓰는 법
+//!
+//! ```no_run
+//! use std::path::Path;
+//! use rhwp::service::{DocumentService, OpenOptions, SearchOptions, ServiceError};
+//!
+//! let service = DocumentService::new();
+//! let opened = match service.open_path(Path::new("문서.hwpx"), &OpenOptions::new()) {
+//!     Ok(opened) => opened,
+//!     // 갈래를 **타입으로** 받는다. 문자열을 다시 읽지 않는다.
+//!     Err(error) => {
+//!         eprintln!("[{}] {error}", error.code());
+//!         std::process::exit(if error.is_usage_error() { 2 } else { 1 });
+//!     }
+//! };
+//!
+//! let info = opened.info();
+//! println!("{} · {}쪽", info.format, info.page_count);
+//!
+//! // 매치 0건은 오류가 아니라 답이다.
+//! let found = opened.search("계약", &SearchOptions::new().with_limit(20));
+//! println!("{}건 중 {}건", found.total_match_count, found.match_count);
+//! # let _: fn(ServiceError) = |_| ();
+//! ```
+
+pub mod error;
+pub mod open;
+pub mod query;
+
+pub use error::ServiceError;
+pub use open::{
+    format_token, DocumentInfo, DocumentService, DocumentSource, OpenOptions, OpenedDocument,
+    DEFAULT_MAX_BYTES,
+};
+pub use query::{PageText, SearchOptions, SearchOutcome, TextExport, TextExportOptions};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::FileFormat;
+    use std::path::{Path, PathBuf};
+
+    /// 저장소 루트 기준 샘플 경로. 작업 디렉터리에 의존하지 않는다.
+    fn sample(relative: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+    }
+
+    fn hwpx_sample() -> PathBuf {
+        sample("samples/hwpx/143E433F503322BD33.hwpx")
+    }
+
+    fn hwp_sample() -> PathBuf {
+        sample("samples/143E433F503322BD33.hwp")
+    }
+
+    /// 상한 없는 서비스 — 샘플 크기와 무관하게 열리도록.
+    fn service() -> DocumentService {
+        DocumentService::new().with_max_bytes(None)
+    }
+
+    #[test]
+    fn open_path_reads_and_parses_hwpx_sample() {
+        let path = hwpx_sample();
+        let expected_size = std::fs::metadata(&path).expect("샘플 메타").len() as usize;
+        let opened = service()
+            .open_path(&path, &OpenOptions::new())
+            .expect("HWPX 샘플은 열려야 한다");
+        assert_eq!(opened.format(), FileFormat::Hwpx);
+        // 원본 크기를 **버리지 않는다** — 소비자가 파일을 다시 stat 하지 않아도 된다.
+        assert_eq!(opened.size_bytes(), expected_size);
+        assert_eq!(
+            opened.source(),
+            &DocumentSource::Path(path),
+            "경로에서 열었으면 출처가 경로여야 한다"
+        );
+        assert!(opened.page_count() >= 1);
+    }
+
+    #[test]
+    fn format_is_auto_detected_from_bytes_alone() {
+        // 같은 문서의 두 형식이 확장자 없이 **바이트만으로** 갈려야 한다.
+        let hwpx = std::fs::read(hwpx_sample()).expect("HWPX 샘플 읽기");
+        let hwp = std::fs::read(hwp_sample()).expect("HWP 샘플 읽기");
+
+        let opened_hwpx = service()
+            .open_bytes(&hwpx, &OpenOptions::new())
+            .expect("HWPX 바이트");
+        let opened_hwp = service()
+            .open_bytes(&hwp, &OpenOptions::new())
+            .expect("HWP 바이트");
+
+        assert_eq!(opened_hwpx.format(), FileFormat::Hwpx);
+        assert_eq!(opened_hwp.format(), FileFormat::Hwp);
+        assert_eq!(opened_hwpx.info().format, "hwpx");
+        assert_eq!(opened_hwp.info().format, "hwp5");
+        assert_eq!(opened_hwpx.source(), &DocumentSource::Bytes);
+    }
+
+    #[test]
+    fn missing_path_is_not_found_not_parse_failure() {
+        let missing = sample("samples/이런파일은없다_87f3.hwpx");
+        let error = service()
+            .open_path(&missing, &OpenOptions::new())
+            .expect_err("없는 파일은 실패해야 한다");
+        assert_eq!(
+            error,
+            ServiceError::NotFound {
+                path: missing.clone()
+            }
+        );
+        assert_eq!(error.code(), "NOT_FOUND");
+        // "경로를 고치면 되는" 실패다 — 소비자는 이걸로 EXIT_USAGE 를 고른다.
+        assert!(error.is_usage_error());
+        assert!(!error.needs_password());
+    }
+
+    #[test]
+    fn unrecognized_bytes_are_unsupported_format() {
+        let service = service();
+        let junk = service
+            .open_bytes(b"this is not a hwp document at all", &OpenOptions::new())
+            .expect_err("미상 바이트는 실패해야 한다");
+        assert_eq!(
+            junk,
+            ServiceError::UnsupportedFormat {
+                detected: FileFormat::Unknown
+            }
+        );
+        assert_eq!(junk.code(), "UNSUPPORTED_FORMAT");
+
+        // 빈 입력은 "알 수 없음"과 **다른 사실**이다 — 감지 결과를 그대로 싣는다.
+        let empty = service
+            .open_bytes(&[], &OpenOptions::new())
+            .expect_err("빈 입력은 실패해야 한다");
+        assert_eq!(
+            empty,
+            ServiceError::UnsupportedFormat {
+                detected: FileFormat::Empty
+            }
+        );
+    }
+
+    #[test]
+    fn size_limit_rejects_before_parsing() {
+        let bytes = std::fs::read(hwpx_sample()).expect("HWPX 샘플 읽기");
+        let limit = 1024;
+        assert!(
+            bytes.len() > limit,
+            "샘플이 상한보다 커야 의미 있는 검증이다"
+        );
+
+        let error = DocumentService::new()
+            .open_bytes(&bytes, &OpenOptions::new().with_max_bytes(limit))
+            .expect_err("상한 초과는 실패해야 한다");
+        assert_eq!(
+            error,
+            ServiceError::TooLarge {
+                size_bytes: bytes.len(),
+                limit_bytes: limit,
+            }
+        );
+        assert_eq!(error.code(), "TOO_LARGE");
+
+        // 호출 단위 상한이 서비스 기본값을 덮어쓴다.
+        let tight = DocumentService::new().with_max_bytes(Some(limit));
+        assert!(tight.open_bytes(&bytes, &OpenOptions::new()).is_err());
+        assert!(tight
+            .open_bytes(&bytes, &OpenOptions::new().with_max_bytes(bytes.len()))
+            .is_ok());
+    }
+
+    #[test]
+    fn info_reports_format_size_and_counts() {
+        let path = hwpx_sample();
+        let expected_size = std::fs::metadata(&path).expect("샘플 메타").len() as usize;
+        let opened = service()
+            .open_path(&path, &OpenOptions::new())
+            .expect("HWPX 샘플");
+        let info = opened.info();
+
+        assert_eq!(info.format, "hwpx");
+        assert_eq!(info.size_bytes, expected_size);
+        assert!(info.sections >= 1, "구역이 최소 하나는 있어야 한다");
+        assert_eq!(info.page_count, opened.page_count());
+        assert!(info.para_count >= 1, "문단이 최소 하나는 있어야 한다");
+        assert!(!info.encrypted, "평문 샘플이다");
+        assert!(info.version.is_some(), "HWPX 는 버전 문자열을 갖는다");
+
+        // 직렬화 어휘가 봉투 계약(camelCase)과 같아야 한다.
+        let json = serde_json::to_value(&info).expect("직렬화");
+        for key in ["format", "sizeBytes", "pageCount", "paraCount", "fonts"] {
+            assert!(json.get(key).is_some(), "{key} 필드가 있어야 한다");
+        }
+    }
+
+    #[test]
+    fn title_scan_can_be_disabled() {
+        let path = hwpx_sample();
+        let scanned = service()
+            .open_path(&path, &OpenOptions::new())
+            .expect("HWPX 샘플")
+            .info();
+        let unscanned = service()
+            .with_title_scan(false)
+            .open_path(&path, &OpenOptions::new())
+            .expect("HWPX 샘플")
+            .info();
+
+        assert!(
+            unscanned.title.is_none(),
+            "제목 추정을 끄면 언제나 None 이다"
+        );
+        // 나머지 메타는 옵션과 무관하게 같아야 한다(결정성).
+        assert_eq!(scanned.page_count, unscanned.page_count);
+        assert_eq!(scanned.fonts, unscanned.fonts);
+    }
+
+    #[test]
+    fn export_text_keeps_one_entry_per_page() {
+        let opened = service()
+            .open_path(&hwpx_sample(), &OpenOptions::new())
+            .expect("HWPX 샘플");
+        let export = opened.export_text(&TextExportOptions::new());
+
+        assert_eq!(
+            export.page_count as u32,
+            opened.page_count(),
+            "쪽 항목을 빼면 pageCount 가 문서를 실제보다 짧게 말한다"
+        );
+        assert_eq!(export.pages.len(), export.page_count);
+        for (index, page) in export.pages.iter().enumerate() {
+            assert_eq!(page.page, index as u32, "쪽 번호는 0부터 연속이다");
+        }
+        assert!(!export.truncated);
+        assert_eq!(export.omitted_count, 0);
+        assert_eq!(export.next_offset, None, "무제한이면 더 읽을 것이 없다");
+        assert!(export.out_of_range.is_empty());
+        assert!(!export.has_failures());
+        assert!(
+            !export.concatenated().trim().is_empty(),
+            "샘플에는 본문 텍스트가 있다"
+        );
+    }
+
+    #[test]
+    fn export_text_truncation_reports_omission_and_next_offset() {
+        let opened = service()
+            .open_path(&hwpx_sample(), &OpenOptions::new())
+            .expect("HWPX 샘플");
+        let full = opened.export_text(&TextExportOptions::new());
+        let full_chars: usize = full.pages.iter().map(|p| p.text.chars().count()).sum();
+        assert!(full_chars > 40, "절단을 검증하려면 본문이 충분해야 한다");
+
+        let cut = opened.export_text(&TextExportOptions::new().with_max_chars(20));
+        let cut_chars: usize = cut.pages.iter().map(|p| p.text.chars().count()).sum();
+
+        assert_eq!(cut_chars, 20);
+        assert!(cut.truncated);
+        assert_eq!(cut.omitted_count, full_chars - 20);
+        assert_eq!(cut.next_offset, Some(20), "이어읽기 지점을 명시한다");
+        assert_eq!(
+            cut.page_count, full.page_count,
+            "예산이 떨어져도 쪽 주소는 남는다"
+        );
+    }
+
+    #[test]
+    fn export_text_out_of_range_page_is_data_not_error() {
+        let opened = service()
+            .open_path(&hwpx_sample(), &OpenOptions::new())
+            .expect("HWPX 샘플");
+        let beyond = opened.page_count() + 100;
+        let export = opened.export_text(&TextExportOptions::new().with_pages(vec![0, beyond]));
+
+        assert_eq!(export.pages.len(), 1, "유효한 쪽만 실린다");
+        assert_eq!(export.pages[0].page, 0);
+        assert_eq!(
+            export.out_of_range,
+            vec![beyond],
+            "건너뛴 쪽을 조용히 숨기지 않는다"
+        );
+    }
+
+    #[test]
+    fn search_returns_matches_with_coordinates() {
+        let opened = service()
+            .open_path(&hwpx_sample(), &OpenOptions::new())
+            .expect("HWPX 샘플");
+        // 문서 내용을 하드코딩하지 않는다 — 문서에서 실제 문자열을 뽑아 그걸 찾는다.
+        //
+        // 조판된 쪽 텍스트는 줄바꿈이 낱말 사이에 끼어들 수 있어 그대로 검색어로
+        // 쓰면 안 된다. 그래서 두 단계로 간다: 한 글자로 문단을 찾고, 그 **문단
+        // 텍스트**에서 이어진 두 글자를 뽑는다(문단 안이면 반드시 연속이다).
+        let text = opened.export_text(&TextExportOptions::new()).concatenated();
+        let seed = text
+            .chars()
+            .find(|c| {
+                !c.is_whitespace()
+                    && !opened
+                        .search(&c.to_string(), &SearchOptions::new())
+                        .is_empty()
+            })
+            .expect("본문 글자가 문단에서도 찾혀야 한다");
+        let seeded = opened.search(&seed.to_string(), &SearchOptions::new());
+        let anchor = &seeded.matches[0];
+        let needle: String = anchor
+            .text
+            .chars()
+            .skip(anchor.char_offset)
+            .take(2)
+            .collect();
+
+        let found = opened.search(&needle, &SearchOptions::new());
+        assert!(!found.is_empty(), "문단에서 뽑은 문자열은 찾혀야 한다");
+        assert_eq!(found.query, needle);
+        assert_eq!(found.match_count, found.matches.len());
+        assert_eq!(found.match_count, found.total_match_count);
+        assert!(!found.truncated);
+        assert_eq!(found.omitted_count, 0);
+
+        let first = &found.matches[0];
+        assert_eq!(first.length, needle.chars().count());
+        assert!(
+            first.text.contains(&needle),
+            "매치가 속한 문단 텍스트가 함께 온다"
+        );
+        // 좌표가 붙는다는 것이 이 축의 요점이다 — 조판된 문단은 쪽 번호를 갖는다.
+        assert!(
+            found.matches.iter().any(|m| m.page.is_some()),
+            "매치에 쪽 좌표가 붙어야 한다"
+        );
+    }
+
+    #[test]
+    fn search_without_match_is_ok_not_error() {
+        let opened = service()
+            .open_path(&hwpx_sample(), &OpenOptions::new())
+            .expect("HWPX 샘플");
+
+        let none = opened.search("존재하지않는문자열_9f2c1b7e", &SearchOptions::new());
+        assert!(none.is_empty());
+        assert_eq!(none.total_match_count, 0);
+        assert_eq!(none.match_count, 0);
+        assert!(none.matches.is_empty());
+        assert!(!none.truncated, "0건은 절단이 아니다");
+        assert_eq!(none.next_offset, None);
+
+        // 빈 검색어도 판정(0건)이지 실패가 아니다.
+        let empty = opened.search("", &SearchOptions::new());
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn search_window_walks_all_matches_without_moving_the_total() {
+        let opened = service()
+            .open_path(&hwpx_sample(), &OpenOptions::new())
+            .expect("HWPX 샘플");
+        let text = opened.export_text(&TextExportOptions::new()).concatenated();
+        // 여러 번 나오는 글자를 고른다 — 창 이동을 검증하려면 매치가 2건 이상이어야 한다.
+        let needle = text
+            .chars()
+            .find(|c| {
+                !c.is_whitespace()
+                    && opened
+                        .search(&c.to_string(), &SearchOptions::new())
+                        .total_match_count
+                        >= 3
+            })
+            .map(|c| c.to_string())
+            .expect("3건 이상 나오는 글자가 있어야 한다");
+
+        let all = opened.search(&needle, &SearchOptions::new());
+        let total = all.total_match_count;
+
+        let first = opened.search(&needle, &SearchOptions::new().with_limit(2));
+        assert_eq!(first.match_count, 2);
+        assert_eq!(
+            first.total_match_count, total,
+            "총량은 창과 무관하게 고정이다"
+        );
+        assert!(first.truncated);
+        assert_eq!(first.omitted_count, total - 2);
+        assert_eq!(first.next_offset, Some(2));
+
+        let second = opened.search(&needle, &SearchOptions::new().with_limit(2).with_offset(2));
+        assert_eq!(second.total_match_count, total);
+        assert_eq!(second.offset, 2);
+        // 창이 겹치지 않는다.
+        assert_ne!(
+            first.matches[0].char_offset.to_string() + &first.matches[0].paragraph.to_string(),
+            second.matches[0].char_offset.to_string() + &second.matches[0].paragraph.to_string(),
+        );
+
+        // 마지막 창을 지나면 더 없음이다.
+        let past_end = opened.search(&needle, &SearchOptions::new().with_offset(total));
+        assert_eq!(past_end.match_count, 0);
+        assert_eq!(past_end.total_match_count, total);
+        assert_eq!(past_end.next_offset, None);
+    }
+
+    #[test]
+    fn error_codes_and_severity_are_stable() {
+        // 소비자가 exit code·JSON code 로 매핑하는 축이다. 토큰이 바뀌면 계약이 깨진다.
+        let cases: [(ServiceError, &str, bool, bool); 7] = [
+            (
+                ServiceError::NotFound {
+                    path: PathBuf::from("x"),
+                },
+                "NOT_FOUND",
+                true,
+                false,
+            ),
+            (
+                ServiceError::Io {
+                    path: PathBuf::from("x"),
+                    kind: std::io::ErrorKind::PermissionDenied,
+                },
+                "IO",
+                false,
+                false,
+            ),
+            (
+                ServiceError::UnsupportedFormat {
+                    detected: FileFormat::DrmProtected,
+                },
+                "UNSUPPORTED_FORMAT",
+                true,
+                false,
+            ),
+            (
+                ServiceError::PasswordRequired,
+                "PASSWORD_REQUIRED",
+                true,
+                true,
+            ),
+            (
+                ServiceError::PasswordMismatch,
+                "PASSWORD_MISMATCH",
+                false,
+                true,
+            ),
+            (
+                ServiceError::TooLarge {
+                    size_bytes: 2,
+                    limit_bytes: 1,
+                },
+                "TOO_LARGE",
+                true,
+                false,
+            ),
+            (ServiceError::Parse("깨짐".into()), "PARSE", false, false),
+        ];
+        for (error, code, usage, needs_password) in cases {
+            assert_eq!(error.code(), code);
+            assert_eq!(error.is_usage_error(), usage, "{code}");
+            assert_eq!(error.needs_password(), needs_password, "{code}");
+            assert!(
+                !error.to_string().is_empty(),
+                "{code} 는 사람용 문장도 준다"
+            );
+        }
+    }
+
+    #[test]
+    fn open_failure_classification_derives_needles_from_types() {
+        use crate::parser::crypto::CryptoError;
+        use crate::parser::ParseError;
+        use crate::HwpError;
+
+        // 바늘을 한국어 상수로 박지 않고 **타입에서** 만든다는 사실 자체를 잠근다.
+        let encrypted = HwpError::from(ParseError::EncryptedDocument);
+        assert_eq!(
+            ServiceError::from_open_failure(&encrypted, false),
+            ServiceError::PasswordRequired
+        );
+        // 비밀번호를 주었는데도 암호 오류면 "주세요"가 아니라 "틀렸다"이다.
+        assert_eq!(
+            ServiceError::from_open_failure(&encrypted, true),
+            ServiceError::PasswordMismatch
+        );
+
+        let wrong = HwpError::from(ParseError::CryptoError(CryptoError::WrongPassword));
+        assert_eq!(
+            ServiceError::from_open_failure(&wrong, true),
+            ServiceError::PasswordMismatch
+        );
+
+        // 그 밖의 파싱 실패는 이름 없는 갈래로 뭉치되, 원문은 사람용으로 보존한다.
+        let other = HwpError::InvalidFile("레코드 손상".into());
+        assert_eq!(
+            ServiceError::from_open_failure(&other, false),
+            ServiceError::Parse("레코드 손상".into())
+        );
+    }
+
+    #[test]
+    fn service_is_deterministic_and_read_only() {
+        // 같은 입력을 두 번 열면 두 번 다 같은 답이 나와야 한다.
+        let bytes = std::fs::read(hwpx_sample()).expect("HWPX 샘플 읽기");
+        let service = service();
+        let first = service
+            .open_bytes(&bytes, &OpenOptions::new())
+            .expect("첫 열기");
+        let second = service
+            .open_bytes(&bytes, &OpenOptions::new())
+            .expect("둘째 열기");
+
+        assert_eq!(first.info(), second.info());
+        assert_eq!(
+            first.export_text(&TextExportOptions::new()),
+            second.export_text(&TextExportOptions::new())
+        );
+        // 검색 결과는 직렬화 값으로 비교한다 — 그쪽이 소비자가 실제로 받는 계약이다.
+        assert_eq!(
+            serde_json::to_value(first.search("가", &SearchOptions::new())).expect("직렬화"),
+            serde_json::to_value(second.search("가", &SearchOptions::new())).expect("직렬화")
+        );
+        // 원본 바이트는 그대로다 — 이 축은 읽기만 한다.
+        assert_eq!(bytes, std::fs::read(hwpx_sample()).expect("재읽기"));
+    }
+}

--- a/src/service/open.rs
+++ b/src/service/open.rs
@@ -1,0 +1,405 @@
+//! 문서 열기 — 형식 자동판별·크기 상한·비밀번호를 **한 곳에서** 처리한다.
+//!
+//! 지금은 이 일이 표면마다 다시 쓰여 있다. `src/main.rs` 는 `fs::read` → 오류 출력
+//! 블록을 45번, `detect_format` 을 24번 되풀이하고, `src/mcp_serve.rs` 는 같은
+//! 순서를 `session_open` 에서 한 번 더 쓰며, `src/wasm_api.rs` 는 비밀번호 유무
+//! 분기를 세 번째로 쓴다. 셋의 결과가 다른 곳이 이미 있다 — 예를 들어 CLI 만
+//! 비밀번호 오류를 갈래로 나누고, MCP 는 전부 "파싱 실패" 하나로 뭉갠다.
+//!
+//! [`DocumentService::open_bytes`] 는 그 순서를 한 번만 정의한다.
+//!
+//! 1. 크기 상한 — **파서를 부르기 전에** 끊는다.
+//! 2. 형식 자동판별 — 열 수 없는 형식은 파서를 부르기 전에 [`ServiceError::UnsupportedFormat`].
+//! 3. 비밀번호 유무 분기 → [`DocumentCore`] 로드.
+//! 4. 실패는 [`ServiceError`] 로 이름을 붙여 올린다.
+//!
+//! 감지한 형식과 원본 크기는 **버리지 않고** [`OpenedDocument`] 가 들고 있는다.
+//! 현행 소비자가 이미 파싱한 바이트를 `detect_format` 으로 한 번 더 훑는 이유가
+//! 바로 이 두 값을 잃어버려서다(`DocumentCore::from_bytes_inner` 는 내부에서
+//! `detect_format` 을 부르고도 결과를 폐기한다).
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::path::Path;
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+use crate::document_core::DocumentCore;
+use crate::model::document::Document;
+use crate::parser::FileFormat;
+use crate::service::error::ServiceError;
+
+/// 서비스가 열지 않는 입력을 파싱 전에 끊기 위한 기본 크기 상한(256 MiB).
+///
+/// 현행 표면에는 상한이 **아예 없다** — 신뢰할 수 없는 업로드를 그대로 파서에
+/// 넣는다. 자동화·백엔드가 쓰는 표면에서 이건 상한이 아니라 구멍이라, 새 축은
+/// 기본값을 켠 채로 시작한다. 무제한이 필요하면 명시적으로 끈다
+/// ([`DocumentService::with_max_bytes`]).
+pub const DEFAULT_MAX_BYTES: usize = 256 * 1024 * 1024;
+
+/// 제목 추정이 훑는 앞쪽 페이지 수. `info --json` 의 `title` 규칙과 같은 "앞 3쪽".
+const TITLE_SCAN_PAGES: u32 = 3;
+
+/// 문서 열기·조회의 진입점. **읽기 전용·결정적**이다.
+///
+/// 같은 바이트와 같은 옵션은 언제나 같은 결과를 낸다. LLM·네트워크·전역 상태를
+/// 쓰지 않으며, 전역 비밀번호를 `thread_local` 로 숨겨 나르지도 않는다
+/// (현행 CLI 의 `CLI_PASSWORD` 가 그렇게 한다 — 그 값은 시그니처에 보이지 않아
+/// 호출자가 무엇이 적용되는지 알 수 없다).
+///
+/// 값 타입이므로 복제해서 설정만 다른 서비스를 만들 수 있다.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocumentService {
+    max_bytes: Option<usize>,
+    title_scan: bool,
+}
+
+impl Default for DocumentService {
+    fn default() -> Self {
+        DocumentService {
+            max_bytes: Some(DEFAULT_MAX_BYTES),
+            title_scan: true,
+        }
+    }
+}
+
+impl DocumentService {
+    /// 기본 설정(상한 [`DEFAULT_MAX_BYTES`], 제목 추정 켬)으로 만든다.
+    pub fn new() -> Self {
+        DocumentService::default()
+    }
+
+    /// 입력 크기 상한을 바꾼다. `None` 이면 무제한.
+    ///
+    /// [`OpenOptions::max_bytes`] 가 지정되면 호출 단위로 이 값을 덮어쓴다.
+    pub fn with_max_bytes(mut self, max_bytes: Option<usize>) -> Self {
+        self.max_bytes = max_bytes;
+        self
+    }
+
+    /// [`DocumentInfo::title`] 추정 여부를 바꾼다.
+    ///
+    /// 제목 추정은 앞 3쪽의 **텍스트 렌더**를 요구한다. 수백~수천 건을 훑는
+    /// 대장화에서는 이 비용이 지배적이므로 끌 수 있어야 한다. 끄면 `title` 은
+    /// 언제나 `None` 이다.
+    pub fn with_title_scan(mut self, title_scan: bool) -> Self {
+        self.title_scan = title_scan;
+        self
+    }
+
+    /// 현재 적용 중인 기본 크기 상한.
+    pub fn max_bytes(&self) -> Option<usize> {
+        self.max_bytes
+    }
+
+    /// 바이트 버퍼에서 문서를 연다. 모든 표면이 결국 지나가는 유일한 문이다.
+    ///
+    /// WASM 을 포함한 모든 타깃에서 쓸 수 있다 — 파일 시스템을 건드리지 않는다.
+    pub fn open_bytes(
+        &self,
+        bytes: &[u8],
+        opts: &OpenOptions,
+    ) -> Result<OpenedDocument, ServiceError> {
+        self.open_inner(bytes, opts, DocumentSource::Bytes)
+    }
+
+    /// 경로에서 문서를 연다. 읽기 실패는 파싱 실패와 **다른 이름**으로 올라온다.
+    ///
+    /// 네이티브 타깃 전용이다. WASM 에는 열 파일 시스템이 없으므로
+    /// [`DocumentService::open_bytes`] 를 쓴다.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn open_path(
+        &self,
+        path: &Path,
+        opts: &OpenOptions,
+    ) -> Result<OpenedDocument, ServiceError> {
+        let bytes = match std::fs::read(path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Err(ServiceError::NotFound {
+                    path: path.to_path_buf(),
+                })
+            }
+            Err(error) => {
+                return Err(ServiceError::Io {
+                    path: path.to_path_buf(),
+                    kind: error.kind(),
+                })
+            }
+        };
+        self.open_inner(&bytes, opts, DocumentSource::Path(path.to_path_buf()))
+    }
+
+    fn open_inner(
+        &self,
+        bytes: &[u8],
+        opts: &OpenOptions,
+        source: DocumentSource,
+    ) -> Result<OpenedDocument, ServiceError> {
+        // 1) 상한 — 파서를 부르기 전에 끊는다. 손상 입력이 파서를 통과할 기회를
+        //    얻지 못하는 것이 상한의 요점이다.
+        if let Some(limit) = opts.max_bytes.or(self.max_bytes) {
+            if bytes.len() > limit {
+                return Err(ServiceError::TooLarge {
+                    size_bytes: bytes.len(),
+                    limit_bytes: limit,
+                });
+            }
+        }
+        // 2) 형식 자동판별 — 열 수 없는 형식은 여기서 끝난다. 열 수 있는 형식이면
+        //    이 값을 **보관**한다(소비자가 다시 훑지 않게).
+        let format = crate::parser::detect_format(bytes);
+        if !is_openable(format) {
+            return Err(ServiceError::UnsupportedFormat { detected: format });
+        }
+        // 3) 비밀번호 유무 분기 — 세 표면이 각자 쓰던 그 분기, 여기 한 번만.
+        let loaded = match opts.password.as_deref() {
+            Some(password) => DocumentCore::from_bytes_with_password(bytes, password.as_bytes()),
+            None => DocumentCore::from_bytes(bytes),
+        };
+        // 4) 실패에 이름을 붙인다.
+        let core = loaded
+            .map_err(|error| ServiceError::from_open_failure(&error, opts.password.is_some()))?;
+        Ok(OpenedDocument {
+            core,
+            format,
+            size_bytes: bytes.len(),
+            source,
+            title_scan: self.title_scan,
+        })
+    }
+}
+
+/// 열기 한 번에 적용할 옵션.
+///
+/// 비밀번호는 **인자로 전달한다**. 현행 CLI 처럼 전역(`thread_local`)에 숨기면
+/// 호출 지점만 봐서는 어떤 인증이 적용되는지 알 수 없고, `batch` 처럼 워커
+/// 스레드로 갈라지는 경로에서 조용히 사라진다.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OpenOptions {
+    /// 암호 문서 비밀번호. `None` 이면 평문 경로로 연다.
+    ///
+    /// 값은 [`OpenedDocument`] 에 보존되지 않는다 — 열기가 끝나면 잊는다.
+    pub password: Option<String>,
+    /// 이 호출에만 적용할 크기 상한. `None` 이면 서비스 기본값을 쓴다.
+    ///
+    /// 무제한으로 열려면 서비스 쪽을 [`DocumentService::with_max_bytes`]`(None)`
+    /// 으로 만든다 — 호출 단위 `None` 은 "지정 안 함"이지 "무제한"이 아니다.
+    pub max_bytes: Option<usize>,
+}
+
+impl OpenOptions {
+    /// 비밀번호 없이, 서비스 기본 상한으로 여는 옵션.
+    pub fn new() -> Self {
+        OpenOptions::default()
+    }
+
+    /// 비밀번호를 붙인다.
+    pub fn with_password(mut self, password: impl Into<String>) -> Self {
+        self.password = Some(password.into());
+        self
+    }
+
+    /// 이 호출에만 적용할 크기 상한을 붙인다.
+    pub fn with_max_bytes(mut self, max_bytes: usize) -> Self {
+        self.max_bytes = Some(max_bytes);
+        self
+    }
+}
+
+/// 문서가 어디서 왔는지. 봉투의 `source` 자리에 그대로 쓸 수 있다.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DocumentSource {
+    /// 경로에서 읽었다.
+    Path(PathBuf),
+    /// 바이트 버퍼에서 열었다(WASM 업로드·MCP 인메모리 등). 이름은 소비자가 붙인다 —
+    /// MCP 는 `docId`, WASM 은 브라우저가 아는 파일명이 그 자리에 온다.
+    Bytes,
+}
+
+/// 열린 문서 하나. 파싱된 IR 과 **열 때 알아낸 사실**(형식·원본 크기·출처)을 함께 든다.
+///
+/// 읽기 전용이다. 편집이 필요하면 [`OpenedDocument::into_core`] 로 소유권을 가져가
+/// `DocumentCore` 를 직접 쓴다 — 편집·저장은 이 축의 범위가 아니다.
+pub struct OpenedDocument {
+    pub(crate) core: DocumentCore,
+    format: FileFormat,
+    size_bytes: usize,
+    source: DocumentSource,
+    title_scan: bool,
+}
+
+impl std::fmt::Debug for OpenedDocument {
+    /// `DocumentCore` 는 문서 IR 전체라 `Debug` 출력이 사실상 문서 덤프다.
+    /// 로그에 문서 내용이 통째로 흘러나가지 않도록 메타만 찍는다.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpenedDocument")
+            .field("format", &self.format)
+            .field("size_bytes", &self.size_bytes)
+            .field("source", &self.source)
+            .field("page_count", &self.core.page_count())
+            .finish()
+    }
+}
+
+impl OpenedDocument {
+    /// 매직 바이트로 감지한 원본 형식.
+    ///
+    /// 소비자가 `detect_format` 을 다시 부를 이유가 없다 — 그 재호출이 지금
+    /// `main.rs` 에 24곳, `mcp_serve.rs` 에 1곳 있다.
+    pub fn format(&self) -> FileFormat {
+        self.format
+    }
+
+    /// 원본 바이트 크기.
+    pub fn size_bytes(&self) -> usize {
+        self.size_bytes
+    }
+
+    /// 문서 출처.
+    pub fn source(&self) -> &DocumentSource {
+        &self.source
+    }
+
+    /// 조판까지 끝난 문서 코어(읽기 전용).
+    pub fn core(&self) -> &DocumentCore {
+        &self.core
+    }
+
+    /// 문서 IR(읽기 전용).
+    pub fn document(&self) -> &Document {
+        &self.core.document
+    }
+
+    /// 총 페이지 수.
+    pub fn page_count(&self) -> u32 {
+        self.core.page_count()
+    }
+
+    /// 코어의 소유권을 가져간다 — 편집·저장으로 넘어가는 탈출구.
+    ///
+    /// 이 축은 읽기 전용이므로 변이 API 를 제공하지 않는다. 편집이 필요한
+    /// 소비자(MCP 세션 도구 등)는 여기서 코어를 받아 기존 경로로 계속한다.
+    pub fn into_core(self) -> DocumentCore {
+        self.core
+    }
+
+    /// 문서 메타 — 쪽수·형식·암호화 등.
+    ///
+    /// **왜 이 함수가 필요한가**: 같은 질문에 지금 두 개의 답이 있다.
+    /// `main.rs::info_json_value` 는 글꼴을 선언 순서대로 중복까지 보존해서 주고,
+    /// `DocumentCore::get_document_info`(WASM 이 쓰는 쪽)는 `BTreeSet` 으로
+    /// 정렬·중복 제거하고 대체 글꼴까지 해소해서 준다. 어느 표면에 물었느냐로
+    /// 답이 달라지는 필드는 계약이 아니다.
+    ///
+    /// 이 축은 **`info --json` 의 어휘로 통일한다** — 그쪽이 이미 문서화된 봉투
+    /// 계약(`schemaVersion` 이 걸린)이고, 문서 인벤토리라는 목적상 "선언된 순서와
+    /// 중복"이 정보이기 때문이다.
+    pub fn info(&self) -> DocumentInfo {
+        let document = self.document();
+        let version = if self.format == FileFormat::Hml {
+            // HML 에는 HWP 바이너리 버전이 없다. 0.0.0.0 을 지어내지 않는다.
+            None
+        } else {
+            Some(format!(
+                "{}.{}.{}.{}",
+                document.header.version.major,
+                document.header.version.minor,
+                document.header.version.build,
+                document.header.version.revision,
+            ))
+        };
+        // 선언된 모든 글꼴군(한글·영어·한자·일어·기타·기호·사용자)을 문서 순서대로
+        // 평탄화한다. 중복은 남긴다 — 어느 군에서 왔는지가 소비자에게 정보다.
+        let fonts: Vec<String> = document
+            .doc_info
+            .font_faces
+            .iter()
+            .flatten()
+            .map(|face| face.name.clone())
+            .collect();
+        let para_count: usize = document.sections.iter().map(|s| s.paragraphs.len()).sum();
+        DocumentInfo {
+            format: format_token(self.format),
+            size_bytes: self.size_bytes,
+            version,
+            sections: document.sections.len(),
+            page_count: self.core.page_count(),
+            para_count,
+            encrypted: document.header.encrypted,
+            fonts,
+            title: if self.title_scan {
+                self.guess_title()
+            } else {
+                None
+            },
+        }
+    }
+
+    /// 앞쪽 몇 쪽의 첫 의미 줄을 제목으로 추정한다. best-effort 이며 계약이 아니다.
+    fn guess_title(&self) -> Option<String> {
+        for page in 0..self.core.page_count().min(TITLE_SCAN_PAGES) {
+            let Ok(text) = self.core.extract_page_text_native(page) else {
+                // 표지가 깨진 문서 하나 때문에 메타 조회 전체가 실패하면 안 된다.
+                continue;
+            };
+            if let Some(line) = text.lines().map(str::trim).find(|l| !l.is_empty()) {
+                return Some(line.to_string());
+            }
+        }
+        None
+    }
+}
+
+/// 문서 메타 한 벌. 봉투에 그대로 실을 수 있도록 camelCase 로 직렬화한다.
+///
+/// `schemaVersion`·`source` 는 **일부러 빼 두었다** — 스키마 버전은 봉투를 만드는
+/// 표면의 몫이고, `source` 는 표면마다 다른 이름(경로·`docId`·업로드 파일명)이
+/// 들어가야 하기 때문이다.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DocumentInfo {
+    /// 형식 토큰 — `hwp5`·`hwpx`·`hwp3`·`hml`.
+    pub format: &'static str,
+    /// 원본 바이트 크기.
+    pub size_bytes: usize,
+    /// HWP 버전 문자열(`major.minor.build.revision`). HML 은 `None`.
+    pub version: Option<String>,
+    /// 구역 수.
+    pub sections: usize,
+    /// 총 페이지 수.
+    pub page_count: u32,
+    /// 총 문단 수(본문 기준).
+    pub para_count: usize,
+    /// 파일 헤더가 밝힌 암호화 여부.
+    pub encrypted: bool,
+    /// 선언된 글꼴 이름(문서 순서, 중복 보존).
+    pub fonts: Vec<String>,
+    /// 추정 제목. 없거나 추정을 끄면 `None`.
+    pub title: Option<String>,
+}
+
+/// 형식 → 봉투 토큰. `info --json` 의 `format` 어휘와 같은 문자열이다.
+pub fn format_token(format: FileFormat) -> &'static str {
+    match format {
+        FileFormat::Hwp => "hwp5",
+        FileFormat::Hwpx => "hwpx",
+        FileFormat::Hwp3 => "hwp3",
+        FileFormat::Hml => "hml",
+        FileFormat::DrmProtected => "drm-protected",
+        FileFormat::Empty => "empty",
+        FileFormat::Unknown => "unknown",
+    }
+}
+
+/// rhwp 가 문서로 여는 형식인가.
+///
+/// DRM 컨테이너·빈 파일·미상 바이트를 파서에 넘기지 않는 게 요점이다. 파서도
+/// 결국 거절하지만, 거절의 **이름**이 형식 판정에서 나와야 소비자가 "지원하지
+/// 않는 형식"과 "손상된 문서"를 가를 수 있다.
+fn is_openable(format: FileFormat) -> bool {
+    matches!(
+        format,
+        FileFormat::Hwp | FileFormat::Hwpx | FileFormat::Hwp3 | FileFormat::Hml
+    )
+}

--- a/src/service/query.rs
+++ b/src/service/query.rs
@@ -1,0 +1,355 @@
+//! 읽기 전용 질의 — 검색과 텍스트 내보내기.
+//!
+//! 두 질의 모두 **`Result` 를 돌려주지 않는다**. "매치가 없다", "요청한 쪽이
+//! 범위 밖이다", "그 쪽의 텍스트를 못 뽑았다"는 전부 판정이지 실패가 아니고,
+//! 판정을 오류로 올리면 소비자는 `Err` 안에서 다시 문자열을 갈라 읽어야 한다.
+//! 그래서 여기서는 **판정을 데이터로** 싣는다 — 그 데이터로 exit code 를 정할지
+//! 경고만 낼지는 표면의 정책이다.
+//!
+//! 절단 어휘(`truncated`·`omittedCount`·`nextOffset`)는 이 저장소가 이미 CLI 와
+//! MCP 양쪽에서 쓰는 것을 그대로 따른다. 새 어휘를 만들면 세 번째 방언이 된다.
+
+use serde::Serialize;
+
+use crate::document_core::queries::grep::GrepMatch;
+use crate::service::open::OpenedDocument;
+
+/// 검색 옵션.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchOptions {
+    /// 대소문자 구분. 기본 `true`(현행 `search`·`hwp_doc_search` 기본값).
+    pub case_sensitive: bool,
+    /// 돌려줄 매치 수 상한. `None` 이면 창을 자르지 않는다.
+    ///
+    /// 총량(`total_match_count`)은 **언제나 전수**로 센다 — 상한은 표시만 줄인다.
+    pub limit: Option<usize>,
+    /// 몇 번째 매치부터 돌려줄지(0 기준).
+    pub offset: usize,
+    /// 매치가 속한 문단의 앞뒤 몇 문단을 함께 담을지. `None` 이면 담지 않는다.
+    pub context_paragraphs: Option<usize>,
+}
+
+impl Default for SearchOptions {
+    fn default() -> Self {
+        SearchOptions {
+            case_sensitive: true,
+            limit: None,
+            offset: 0,
+            context_paragraphs: None,
+        }
+    }
+}
+
+impl SearchOptions {
+    /// 기본 옵션(대소문자 구분, 무제한, 처음부터).
+    pub fn new() -> Self {
+        SearchOptions::default()
+    }
+
+    /// 대소문자 구분 여부를 정한다.
+    pub fn case_sensitive(mut self, case_sensitive: bool) -> Self {
+        self.case_sensitive = case_sensitive;
+        self
+    }
+
+    /// 표시 상한을 정한다.
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// 시작 오프셋을 정한다.
+    pub fn with_offset(mut self, offset: usize) -> Self {
+        self.offset = offset;
+        self
+    }
+
+    /// 앞뒤 문맥 문단 수를 정한다.
+    pub fn with_context_paragraphs(mut self, context: usize) -> Self {
+        self.context_paragraphs = Some(context);
+        self
+    }
+}
+
+/// 검색 결과. **매치 0건도 정상 결과다.**
+///
+/// 필드 이름은 현행 `search --json` 봉투와 같다(`schemaVersion`·`source`·`query`
+/// 위쪽 껍데기는 표면이 붙인다). 파생값(`match_count`·`truncated`·`omitted_count`)을
+/// 저장 필드로 둔 이유는 생성자에서 한 번에 계산해 두면 소비자가 산술로 유도하다
+/// 어긋날 일이 없기 때문이다 — 이 저장소가 `omittedCount` 를 굳이 명시하는 것과
+/// 같은 이유다.
+///
+/// `PartialEq` 는 파생하지 않는다 — `GrepMatch`(`document_core::queries::grep`)가
+/// `PartialEq` 가 아니고, 그 타입은 이 PR 의 수정 범위 밖이다. 두 결과가 같은지
+/// 봐야 하면 직렬화 값을 비교하라(그쪽이 실제 계약이기도 하다).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchOutcome {
+    /// 검색어(에코).
+    pub query: String,
+    /// 적용된 대소문자 구분.
+    pub case_sensitive: bool,
+    /// 이 응답에 실린 매치 수.
+    pub match_count: usize,
+    /// 문서 전체의 매치 수(오프셋·상한과 무관한 전수).
+    pub total_match_count: usize,
+    /// 이 응답이 전체가 아닌가.
+    pub truncated: bool,
+    /// 이 응답에서 빠진 매치 수.
+    pub omitted_count: usize,
+    /// 적용된 시작 오프셋.
+    pub offset: usize,
+    /// 다음 창의 시작 오프셋. 더 없으면 생략된다.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_offset: Option<usize>,
+    /// 좌표가 붙은 매치들(구역·문단·쪽·문자 오프셋, 표 셀·글상자·수식 좌표 포함).
+    pub matches: Vec<GrepMatch>,
+}
+
+impl SearchOutcome {
+    /// 매치가 하나도 없는가. **오류가 아니라 질문에 대한 답이다.**
+    pub fn is_empty(&self) -> bool {
+        self.total_match_count == 0
+    }
+}
+
+/// 텍스트 내보내기 옵션.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TextExportOptions {
+    /// 뽑을 쪽 번호(0 기준). `None` 이면 전체.
+    pub pages: Option<Vec<u32>>,
+    /// 돌려줄 문자 수 상한. `None` 이면 무제한.
+    pub max_chars: Option<usize>,
+    /// 이어붙인 텍스트에서 건너뛸 문자 수(0 기준). 이어읽기용.
+    pub char_offset: usize,
+}
+
+impl TextExportOptions {
+    /// 전체 쪽·무제한.
+    pub fn new() -> Self {
+        TextExportOptions::default()
+    }
+
+    /// 뽑을 쪽을 지정한다.
+    pub fn with_pages(mut self, pages: Vec<u32>) -> Self {
+        self.pages = Some(pages);
+        self
+    }
+
+    /// 문자 수 상한을 지정한다.
+    pub fn with_max_chars(mut self, max_chars: usize) -> Self {
+        self.max_chars = Some(max_chars);
+        self
+    }
+
+    /// 시작 문자 오프셋을 지정한다.
+    pub fn with_char_offset(mut self, char_offset: usize) -> Self {
+        self.char_offset = char_offset;
+        self
+    }
+}
+
+/// 쪽 하나의 텍스트.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PageText {
+    /// 0 기준 쪽 번호.
+    pub page: u32,
+    /// 쪽 텍스트. 잘렸거나 추출에 실패했으면 그만큼 짧거나 비어 있다.
+    pub text: String,
+    /// 이 쪽이 잘렸는가. 안 잘렸으면 직렬화에서 빠진다.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub truncated: bool,
+    /// 이 쪽에서 생략된 문자 수. 0이면 직렬화에서 빠진다.
+    #[serde(skip_serializing_if = "is_zero")]
+    pub omitted_count: usize,
+    /// 이 쪽의 텍스트 추출이 실패했으면 그 사유.
+    ///
+    /// 실패한 쪽도 **목록에서 빼지 않는다**. 빼면 `pageCount` 가 줄어 문서가 실제보다
+    /// 짧아 보이고, "빈 쪽"과 "못 읽은 쪽"이 같은 모습이 된다.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extract_error: Option<String>,
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn is_zero(value: &usize) -> bool {
+    *value == 0
+}
+
+/// 텍스트 내보내기 결과.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TextExport {
+    /// 실린 쪽 수(= `pages.len()`).
+    pub page_count: usize,
+    /// 어디선가 잘렸는가.
+    pub truncated: bool,
+    /// 전체에서 생략된 문자 수.
+    pub omitted_count: usize,
+    /// 적용된 시작 문자 오프셋.
+    pub char_offset: usize,
+    /// 다음 이어읽기 시작 오프셋. 더 없으면 생략된다.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_offset: Option<usize>,
+    /// 요청했으나 문서 범위 밖이라 건너뛴 쪽 번호.
+    ///
+    /// 빈 결과를 조용히 돌려주면 오타(`--page 999`)가 성공처럼 보인다. 그렇다고
+    /// 오류로 올리면 "일부만 유효한 요청"을 표현할 수 없다. 그래서 **데이터로**
+    /// 싣는다 — 이걸 보고 끊을지 경고만 할지는 표면의 정책이다.
+    pub out_of_range: Vec<u32>,
+    /// 쪽별 텍스트.
+    pub pages: Vec<PageText>,
+}
+
+impl TextExport {
+    /// 쪽 텍스트를 줄바꿈으로 이어 붙인 하나의 문자열.
+    ///
+    /// 파일로 떨구거나 해시를 뜨는 소비자용 편의 함수다.
+    pub fn concatenated(&self) -> String {
+        let mut out = String::new();
+        for page in &self.pages {
+            if !out.is_empty() {
+                out.push('\n');
+            }
+            out.push_str(&page.text);
+        }
+        out
+    }
+
+    /// 추출에 실패한 쪽이 하나라도 있는가.
+    pub fn has_failures(&self) -> bool {
+        self.pages.iter().any(|p| p.extract_error.is_some())
+    }
+}
+
+impl OpenedDocument {
+    /// 문서를 검색한다. 매치마다 **좌표**(구역·문단·쪽·문자 오프셋)가 붙는다.
+    ///
+    /// 총량은 언제나 전수로 세고 창(offset·limit)만 옮긴다 — `total_match_count`
+    /// 의 뜻이 페이지네이션에 따라 흔들리면 "몇 건 중 몇 건"이라는 계약이 무너진다.
+    ///
+    /// 빈 검색어는 매치 0건이다(오류가 아니다). 빈 검색어를 거절할지는 인자 검증의
+    /// 문제이고, 그건 표면의 몫이다.
+    ///
+    /// 엔진은 [`crate::document_core::DocumentCore::grep_with_context`] 다 — CLI 와
+    /// MCP 가 이미 쓰는 그 엔진이며, WASM 만 다른 엔진(`search_all_text_native`)을
+    /// 쓰고 있었다. 이 축은 좌표가 붙는 쪽으로 통일한다.
+    pub fn search(&self, query: &str, opts: &SearchOptions) -> SearchOutcome {
+        let all =
+            self.core
+                .grep_with_context(query, opts.case_sensitive, None, opts.context_paragraphs);
+        let total = all.len();
+        let skipped = all.into_iter().skip(opts.offset);
+        let matches: Vec<GrepMatch> = match opts.limit {
+            Some(limit) => skipped.take(limit).collect(),
+            None => skipped.collect(),
+        };
+        let consumed = opts.offset.saturating_add(matches.len());
+        SearchOutcome {
+            query: query.to_string(),
+            case_sensitive: opts.case_sensitive,
+            match_count: matches.len(),
+            total_match_count: total,
+            truncated: matches.len() < total,
+            omitted_count: total.saturating_sub(matches.len()),
+            offset: opts.offset,
+            next_offset: if consumed < total {
+                Some(consumed)
+            } else {
+                None
+            },
+            matches,
+        }
+    }
+
+    /// 쪽 주소가 붙은 텍스트를 뽑는다.
+    ///
+    /// 순서는 **쪽 선택 → 추출 → 오프셋 창 → 문자 상한**이다. 상한은 추출 시간이
+    /// 아니라 **소비자 컨텍스트**를 지키는 장치이므로 전수 추출 뒤 표시만 자른다
+    /// (그래야 총량과 생략량을 정직하게 보고할 수 있다).
+    ///
+    /// 잘린 쪽도, 오프셋에 다 먹힌 쪽도, 추출에 실패한 쪽도 목록에서 빠지지 않는다.
+    pub fn export_text(&self, opts: &TextExportOptions) -> TextExport {
+        let page_count = self.page_count();
+        let (selected, out_of_range): (Vec<u32>, Vec<u32>) = match &opts.pages {
+            Some(requested) => requested.iter().copied().partition(|p| *p < page_count),
+            None => ((0..page_count).collect(), Vec::new()),
+        };
+
+        // 1) 추출 — 실패한 쪽은 빈 텍스트 + 사유로 남긴다.
+        let mut extracted: Vec<(u32, String, Option<String>)> = Vec::with_capacity(selected.len());
+        for page in selected {
+            match self.core.extract_page_text_native(page) {
+                Ok(text) => extracted.push((page, text, None)),
+                Err(error) => extracted.push((page, String::new(), Some(error.to_string()))),
+            }
+        }
+        let total_chars: usize = extracted.iter().map(|(_, t, _)| t.chars().count()).sum();
+
+        // 2) 오프셋 창 — 이어붙인 좌표에서 char_offset 만큼 건너뛴다.
+        let mut skip = opts.char_offset;
+        let windowed: Vec<(u32, String, Option<String>)> = extracted
+            .into_iter()
+            .map(|(page, text, failure)| {
+                if skip == 0 {
+                    return (page, text, failure);
+                }
+                let len = text.chars().count();
+                if skip >= len {
+                    skip -= len;
+                    (page, String::new(), failure)
+                } else {
+                    let tail = text.chars().skip(skip).collect();
+                    skip = 0;
+                    (page, tail, failure)
+                }
+            })
+            .collect();
+
+        // 3) 문자 상한 — 예산이 떨어져도 쪽 항목은 남긴다.
+        let mut budget = opts.max_chars;
+        let mut omitted_total = 0usize;
+        let mut shown_chars = 0usize;
+        let mut pages = Vec::with_capacity(windowed.len());
+        for (page, text, extract_error) in windowed {
+            let total = text.chars().count();
+            let keep = match budget {
+                Some(remaining) => remaining.min(total),
+                None => total,
+            };
+            if let Some(remaining) = budget.as_mut() {
+                *remaining -= keep;
+            }
+            let omitted = total - keep;
+            omitted_total += omitted;
+            shown_chars += keep;
+            let kept: String = if omitted == 0 {
+                text
+            } else {
+                text.chars().take(keep).collect()
+            };
+            pages.push(PageText {
+                page,
+                text: kept,
+                truncated: omitted > 0,
+                omitted_count: omitted,
+                extract_error,
+            });
+        }
+
+        let consumed = opts.char_offset.saturating_add(shown_chars);
+        TextExport {
+            page_count: pages.len(),
+            truncated: omitted_total > 0,
+            omitted_count: omitted_total,
+            char_offset: opts.char_offset,
+            next_offset: if consumed < total_chars {
+                Some(consumed)
+            } else {
+                None
+            },
+            out_of_range,
+            pages,
+        }
+    }
+}


### PR DESCRIPTION
## 동기

`ROADMAP.md`의 "rhwp가 공식적으로 맡는 범위" 표는 **서비스 연계 표면**을 업스트림 책임으로 명시합니다 — "자동화와 백엔드 서비스가 사용할 CLI의 기계 판독 출력, MCP 서버와 공개 API 계약". 그런데 그 계약을 담을 공통 모듈이 없어서, 계약의 첫 네 걸음(열기·메타 조회·검색·텍스트 내보내기)이 표면마다 다시 쓰여 있습니다.

devel(`441254611`) 실측: `src/main.rs`가 `fs::read`+오류 블록을 **45곳**, `detect_format`을 **24곳** 되풀이하고, `src/mcp_serve.rs:1417`이 같은 순서를 한 번 더 쓰며, `src/wasm_api.rs:433·437`이 세 번째 사본입니다.

숫자보다 심각한 건 **세 표면이 다른 답을 준다**는 점입니다.
- "이 문서가 쓰는 글꼴은?" — `info --json`(`main.rs:10346`)은 선언 순서·중복 보존본을, WASM의 `get_document_info`(`document_core/mod.rs:261`)는 BTreeSet 정렬·중복 제거본을 줍니다. **같은 질문, 다른 값.**
- "이 단어가 어디 있는가?" — CLI·MCP는 좌표(구역·문단·쪽·오프셋)를 주는데, WASM(`wasm_api.rs:5115`)은 **다른 엔진의 다른 모양**을 줍니다.
- "왜 못 열었는가?" — CLI만 갈래를 나누는데 그 갈래조차 `classify_hwp_error`(`main.rs:104`)의 **한국어 문장 부분일치**이고, 그 판정이 exit code를 정합니다. 문장 한 글자가 바뀌면 종료 코드가 조용히 바뀝니다.

어느 표면에 물었느냐로 답이 달라지는 값은 계약이 아닙니다.

## 설계

`src/service`는 그 답을 한 번만 정의합니다. `DocumentService::open_bytes/open_path`가 **크기 상한 → 형식 자동판별 → 비밀번호 분기 → 타입 있는 실패**의 순서를 한 곳에서 정의하고, 감지 형식과 원본 크기를 버리지 않고 `OpenedDocument`가 들고 있어 소비자가 재판별할 이유를 없앱니다.

네 가지 규약:
1. **결정적·읽기 전용** — LLM·네트워크·전역 상태 없음. 비밀번호도 전역 `thread_local`이 아니라 `OpenOptions` 인자로 흐릅니다.
2. **오류는 타입** — `ServiceError`가 `code()`(안정 토큰)·`is_usage_error()`·`needs_password()`를 주므로 소비자가 exit code / JSON `code`를 문자열 판정 없이 고릅니다.
3. **판정은 오류가 아니다** — 매치 0건, 범위 밖 쪽 요청은 전부 `Ok` 안의 데이터입니다.
4. **파싱을 새로 쓰지 않음** — `crate::parser`·`crate::document_core` 재사용, 두 번째 파서 아님.

**이 PR은 축을 세우기만 하고 `main.rs`·`mcp_serve.rs`·`wasm_api.rs`는 한 줄도 고치지 않았습니다.** `src/lib.rs` 변경은 `pub mod service;` 한 줄뿐(`security_trailer`와 `serializer` 사이, 알파벳순). 이관은 후속 PR에서 표면별로 진행합니다.

## 사용법 — 세 소비자의 채택 시나리오

```rust
use rhwp::service::{DocumentService, OpenOptions};

let opened = DocumentService::new().open_path(&path, &OpenOptions::default())?;
let info = opened.info();
let hits = opened.search("찾을말", &SearchOptions::default());  // Result 아님 — 0건은 답
```

- **CLI** — `fs::read`+`detect_format`+`load_document` 3단 블록이 `open_path` 한 번으로 줄고, 실패는 `error.is_usage_error()`로 exit code를 고릅니다. `classify_hwp_error`·`CLI_PASSWORD` thread-local이 사라지고, 비밀번호가 시그니처에 보이므로 `batch`가 워커 스레드로 갈라질 때 인증이 조용히 사라지던 함정이 구조적으로 없어집니다.
- **MCP** — `session_open`이 서비스 호출+핸들 등록으로 줄고, `ServiceError::code()`를 봉투의 `code`로, `needs_password()`를 `nextCall` 제안 조건으로 쓰면 에이전트가 실패에서 다음 수를 읽습니다.
- **WASM** — 산출 타입이 전부 `Serialize`(camelCase)라 `#[wasm_bindgen]` 벽을 그대로 통과합니다. 글꼴 두 답 문제가 여기서 닫힙니다.

권장 이관 순서: MCP `session_open`(표면 최소·이득 최대) → CLI `info`/`export-text`/`search` → CLI 나머지 45개 블록 → WASM.

## 테스트

`src/service/mod.rs`의 `#[cfg(test)] mod tests` **16건**. 열기 성공(`samples/hwpx/143E433F503322BD33.hwpx`), 확장자 없이 바이트만으로 HWP/HWPX 자동판별, 없는 파일이 `NotFound`, 미상 바이트가 `UnsupportedFormat`, 크기 상한 초과, 메타 필드 camelCase 직렬화, 좌표 붙는 검색, 매치 0건이 `Ok`, `code()`/`is_usage_error()`/`needs_password()` 표, 결정성과 원본 무훼손을 덮습니다.

```
$ cargo test --lib service::
test result: ok. 16 passed; 0 failed

$ cargo clippy --lib -- -D warnings   # 통과
$ cargo build                          # 통과
$ rustfmt --edition 2021 --check src/service/*.rs   # 통과
```

## 범위

`src/lib.rs`의 `pub mod service;` 한 줄 외 기존 파일 무수정. `mydocs/tech/service_layer.md` 설계 문서에 이음매(`DocumentCore::from_bytes`가 타입 있는 `ParseError`를 문자열로 평탄화하는 지점의 복원 전략)를 명시했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
