### PR TITLE
feat(render_backend): 출력 백엔드 공통 trait 계층 신설

### DIFF
--- a/mydocs/tech/render_backend.md
+++ b/mydocs/tech/render_backend.md
@@ -1,0 +1,351 @@
+---
+kind: reference
+status: active
+canonical: mydocs/tech/render_backend.md
+last_verified: 2026-08-16
+---
+
+# 출력 백엔드 공통 계약 — `RenderBackend`
+
+`src/render_backend/` 가 정의하는 **출력 백엔드 공통 trait** 의 계약 문서다.
+기존 SVG·Skia·PDF·Canvas 출력 경로를 고치지 않고 그 위에 얹는 새 추상 계층이며,
+이 문서는 (1) 기존 경로 실측, (2) 새 계약과 불변식, (3) 기존 백엔드의 채택
+시나리오, (4) 비범위를 담는다.
+
+## 1. 왜 이 계층이 필요한가
+
+[프로젝트 로드맵](../../ROADMAP.md)은 업스트림 책임을 이렇게 적는다.
+
+> | 공통 문서 엔진 | HWP·HWPX·HWP3·HML 파싱, 내부 문서 구조, 조판, 편집, 저장과 **여러 출력 방식** |
+> — `ROADMAP.md:187`
+
+"여러 출력 방식"은 이미 여섯 갈래로 자랐지만, 그것들을 **하나로 묶는 계약이 없다**.
+그래서 두 가지가 막힌다.
+
+1. **새 백엔드를 붙일 형틀이 없다.** 무엇을 받아 무엇을 내야 하는지, 실패를 어떻게
+   말해야 하는지, 페이지 경계를 어떻게 다뤄야 하는지가 문서화된 계약이 아니라
+   기존 파일을 읽어 유추할 대상이다.
+2. **백엔드 간 정합을 검증할 공통 어휘가 없다.** "SVG 와 PDF 가 같은 페이지를 같게
+   그렸는가"를 물으려면 지금은 픽셀을 비교하는 수밖에 없고, 차이가 나도 *조판이 다른
+   op 를 준 것*인지 *같은 op 를 다르게 그린 것*인지 갈라낼 수 없다.
+
+`PaintOp` 는 이미 이 계층을 예비해 둔 자리다 — 정의부 주석이 스스로 그렇게 말한다.
+
+> `backend가 재생하는 leaf paint operation.`
+> — `src/paint/paint_op.rs:43`
+
+없던 것은 **그 op 를 받는 쪽의 계약**이다. 이 PR 이 그것을 신설한다.
+
+## 2. 1단계 조사 — 기존 출력 경로 실측
+
+### 2.1 진입점·입력·산출·오류
+
+| 백엔드 | 진입점 | 입력 | 산출 | 오류 |
+| --- | --- | --- | --- | --- |
+| SVG (렌더트리) | `src/renderer/svg.rs:233` `render_tree(&mut self, tree: &PageRenderTree)` | `&PageRenderTree` | 반환 없음 — 내부 `String` 버퍼에 누적, `svg.rs:216` `output() -> &str` 로 꺼냄 | **없음**(무오류 서명) |
+| SVG (레이어트리) | `src/renderer/svg_layer.rs:239` `LayerRenderer::render_page` | `&PageLayerTree` | 위와 같은 내부 버퍼 | `HwpError`(실제로는 항상 `Ok`) |
+| HTML | `src/renderer/html.rs:47` `render_tree(&mut self, tree: &PageRenderTree)` | `&PageRenderTree` | 내부 `String` 버퍼(`html.rs:42`) | **없음** |
+| Canvas(네이티브/테스트) | `src/renderer/canvas.rs:83`·`:88` | 둘 다 | `Vec<CanvasCommand>` | **없음** |
+| Web Canvas(wasm) | `src/renderer/web_canvas.rs:471`·`:476` | 둘 다 | **없음 — 부수효과**(`CanvasRenderingContext2d`) | 생성자만 `JsValue`(`web_canvas.rs:388`) |
+| Skia(`native-skia`) | `src/renderer/skia/renderer.rs:372` `render_raster_with_options(&self, &PageLayerTree, RasterRenderOptions)` | `&PageLayerTree` + 옵션 | `RasterRenderOutput { bytes, format, width, height, dpi, color_space }` | `HwpError::RenderError` |
+| PDF(호환 경로) | `src/renderer/pdf.rs:812` `svgs_to_pdf_with_options(&[String], &PdfExportOptions)` | **SVG 문자열 배열** | `Vec<u8>` | `String` |
+| PDF(직접 경로) | `src/renderer/pdf.rs:948` `layer_trees_to_pdf_with_options(&[PageLayerTree], &DirectPdfExportOptions)` | `&[PageLayerTree]` — **문서 단위** | `Vec<u8>` | `String` |
+
+읽어낸 것.
+
+- **산출 방식이 세 종류다.** 내부 버퍼에 쌓고 나중에 꺼내기(SVG·HTML), 소유값
+  반환(Skia·PDF), 부수효과만(Web Canvas). `-> Result<Vec<u8>>` 같은 고정 반환형은
+  SVG·HTML·WebCanvas 를 담지 못한다 → **연관 타입 `Output` 이 필수다.**
+- **오류 타입이 세 종류다.** 없음 / `HwpError` / `String`. → **연관 타입 `Error` 가 필요하다.**
+- **PDF 만 문서 단위다.** 나머지는 전부 페이지 한 장 단위다. → 계약은 페이지를 여러 장
+  받아 하나의 산출물로 닫을 수 있어야 한다(`(begin_page … end_page)* finish`).
+- **`&mut self` 와 `&self` 가 섞인다.** `LayerRenderer::render_page` 는 `&mut self`,
+  `LayerRasterRenderer::render_raster` 는 `&self` 다(Skia 는 렌더 중 실제로 불변).
+  → 더 넓은 쪽(`&mut self`)으로 잡는다. 불변 백엔드는 손해가 없다.
+
+### 2.2 좌표와 단위가 어디서 바뀌나
+
+| 사실 | 근거 |
+| --- | --- |
+| 레이어 IR 의 단위는 `px`, 좌표계는 `page-top-left-y-down` | `src/paint/schema.rs:22-23`, `PAGE_LAYER_TREE_UNIT`/`PAGE_LAYER_TREE_COORDINATE_SYSTEM` |
+| `BoundingBox` 네 필드 모두 px, 페이지 내 절대 위치 | `src/renderer/render_tree.rs:581-590` |
+| HWPUNIT → px 환산은 **렌더러 진입 전**에 끝난다 | `src/renderer/mod.rs:685-686` (`DEFAULT_DPI = 96.0`, `HWPUNIT_PER_INCH = 7200.0`), `mod.rs:1092` `hwpunit_to_px`, `render_tree.rs:619` `from_hwpunit_rect` |
+| 백엔드 파일 안에는 HWPUNIT 이 **한 번도 등장하지 않는다** | `svg.rs`·`pdf.rs`·`canvas.rs`·`html.rs`·`skia/renderer.rs` 전수 검색 0건 |
+| px → 형식 단위 환산은 백엔드 **안에서** 일어난다 | `src/renderer/pdf.rs:952` `const CSS_PX_TO_PDF_POINT: f64 = 72.0 / 96.0;`, 적용 `pdf.rs:966`·`:984-985` |
+| SVG 는 환산 없이 px 를 그대로 쓴다 | `src/renderer/svg.rs:2703` `width="{}" height="{}" viewBox="0 0 {} {}"` — SVG user unit == px |
+| 래스터 배율은 옵션으로 따로 받는다 | `RasterRenderOptions.scale`(`layer_renderer.rs:29`), 적용 `skia/renderer.rs:441-443` |
+
+**결론: 이 계층을 통과하는 좌표는 언제나 px 다.** 위로는 HWPUNIT 환산이 끝난 뒤이고,
+아래로는 형식 고유 단위 환산이 시작되기 전이다. 이 경계를 trait 문서 주석에 못박았다.
+
+### 2.3 이미 있는 trait 셋과 그 한계
+
+| trait | 위치 | 서명 | 왜 부족한가 |
+| --- | --- | --- | --- |
+| `Renderer` | `src/renderer/mod.rs:664` | `begin_page(w,h)`, `end_page()`, `draw_text/rect/line/ellipse/image/path(...)` | 원시 도형 단위라 `PaintOp` 어휘를 잃는다. `Result` 가 없어 **실패를 말할 수 없다**. 산출물 타입이 없다. |
+| `LayerRenderer` | `src/renderer/layer_renderer.rs:21` | `render_page(&mut self, tree: &PageLayerTree) -> LayerRenderResult<()>` | 페이지 한 장을 통째로 삼킨다. 산출물 타입도 능력 선언도 없고, 여러 페이지를 한 문서로 묶는 개념이 없다. 구현체는 셋뿐이며(`canvas.rs:331`, `svg_layer.rs:239`, `web_canvas.rs:2167`) **SVG 본체·Skia·PDF 는 구현하지 않는다.** |
+| `LayerRasterRenderer` | `src/renderer/layer_renderer.rs:73` | `render_raster(&self, tree, options) -> LayerRenderResult<RasterRenderOutput>` | 래스터 전용이라 벡터 백엔드를 담지 못한다. |
+
+즉 **세 trait 중 무엇도 SVG·Skia·PDF 를 함께 담지 못한다.** `RenderBackend` 는 그
+사이를 메운다.
+
+### 2.4 재생 순서의 정본
+
+`src/paint/replay_order.rs` 가 z 순서의 단일 출처다.
+
+- `PaintReplayPlane::ORDERED = [Background, BehindText, Flow, InFrontOfText]` — `:19-24`
+- `paint_op_replay_plane_with_layer(op, layer)` — `:40`
+
+Skia(`skia/renderer.rs:496`)와 Web Canvas(`web_canvas.rs:492`)는 이 plane 배열을 바깥
+루프로 돌린다. 반면 `CanvasRenderer` 는 plane 을 전혀 보지 않고 트리 순서로만 그리며
+(`canvas.rs:182`), SVG 는 `PageRenderTree` 쪽의 별도 z 계산(`svg.rs:249`)을 쓴다.
+새 구동기 `replay_page` 는 **정본(plane 배열)을 따른다**.
+
+### 2.5 조사에서 드러난 기존 결함 (이 PR 의 범위 밖, 기록만 남긴다)
+
+- `CanvasRenderer` 는 18개 `PaintOp` 중 10개를 조용히 버린다 — `canvas.rs:272-282` 의
+  빈 `{}` 팔. 능력 선언이 없으니 소비자는 이 사실을 알 방법이 없다.
+- `CanvasRenderer::render_layer_tree`(`canvas.rs:88-91`)와
+  `WebCanvasRenderer::render_layer_tree`(`web_canvas.rs:489`)는 `begin_page` 를 부르고
+  **`end_page` 를 부르지 않는다.** `Renderer` 의 페이지 짝이 레이어 경로에서 지켜지지
+  않는다는 뜻이다. 새 계약은 이 짝을 **강제**한다(§3.1).
+
+## 3. 계약과 불변식
+
+### 3.1 생명주기 (강제되는 불변식)
+
+```text
+( begin_page  draw*  end_page )*  finish
+```
+
+위반은 전부 오류이며, 조용히 넘어가지 않는다.
+
+| 위반 | 오류 |
+| --- | --- |
+| `begin_page` 없이 `draw` | `NoOpenPage { call: "draw" }` |
+| `begin_page` 없이 `end_page` | `NoOpenPage { call: "end_page" }` |
+| 열린 페이지가 있는데 `begin_page` | `PageAlreadyOpen` |
+| 열린 페이지를 두고 `finish` | `UnclosedPage { pages_completed }` |
+| 유한 양수가 아닌 페이지 치수 | `InvalidPageSize { width, height }` |
+
+**판정은 백엔드마다 재구현하지 않는다.** `render_backend::PageState` 가 상태기를
+한 곳에 담고 있고, 이 크레이트의 백엔드 셋은 전부 그것을 품는다. 그래야 "백엔드에
+따라 규칙이 다르다"가 생기지 않는다. 실패한 `begin_page` 는 페이지를 열지 않으므로
+호출자는 고친 치수로 다시 열 수 있다.
+
+### 3.2 좌표·단위 계약
+
+- 단위는 **px**. HWPUNIT 이 아니다.
+- 원점은 **페이지 왼쪽 위**, **y 는 아래로** 증가한다.
+- 좌표는 **페이지 절대 좌표**다. `PaintOp` 는 평탄화된 leaf op 이므로 조상 그룹·클립의
+  변환이 누적돼 있지 않다.
+- px → 형식 고유 단위(pt·device px·mm) 환산은 **백엔드 안에서** 한다. 그 계수는 이
+  trait 표면에 드러나지 않는다.
+
+이는 §2.2 에서 실측한 현재 동작과 정확히 같다. 새 규칙을 도입한 것이 아니라
+**이미 사실인 것을 계약으로 적은 것**이다.
+
+### 3.3 능력 선언 — 분기 대신 질의
+
+```rust
+pub struct BackendCapabilities {
+    pub name: &'static str,
+    pub vector_text: bool,
+    pub embedded_fonts: bool,
+    pub gradients: bool,
+    pub clipping: bool,
+    pub images: bool,
+    pub raster_only: bool,
+    pub multi_page: bool,
+    pub deterministic: bool,
+}
+```
+
+각 필드는 **최종 산출물이 그 성질을 보존하는가**를 뜻한다(중간 단계가 아니다).
+소비자는 `caps.supports(BackendFeature::VectorText)` 또는
+`caps.covers(&[..])` 로 **질의**한다. 백엔드 타입으로 `match` 하는 코드는 새 백엔드가
+붙을 때마다 전부 고쳐야 하지만, 질의는 고칠 것이 없다.
+
+불변식 하나: `raster_only && vector_text` 는 자기모순이다 —
+`BackendCapabilities::is_consistent()` 가 판정한다.
+
+### 3.4 오류
+
+`type Error` 는 백엔드가 고르지만, 생명주기 위반만은 모두 같아야 한다. 그래서
+`RenderBackendError` 를 제공하고 양방향 변환을 붙였다.
+
+- `From<HwpError> for RenderBackendError` — 기존 백엔드를 감쌀 때 오류를 잃지 않는다.
+- `From<RenderBackendError> for HwpError` — 새 계약을 기존 호출부에 되돌려 넣을 수 있다.
+
+### 3.5 스케치에서 바꾼 것과 그 이유
+
+원안 대비 세 가지를 바꿨다.
+
+1. **`finish_boxed(self: Box<Self>)` 를 추가했다.** `finish(self)` 는 산출물 소유권을
+   넘기려면 필요하지만 `Self: Sized` 를 요구해 vtable 에 오르지 못한다. 그러면
+   `Box<dyn RenderBackend<..>>` 에서 결과를 꺼낼 수 없다 — 백엔드를 런타임에 고르는
+   것이 이 계층의 존재 이유인데 그게 막힌다. `self: Box<Self>` 수신자는 object safe
+   이므로 이 한 메서드로 해결된다. 구현은 언제나 `(*self).finish()` 한 줄이다.
+2. **`BackendCapabilities` 에 `name`·`clipping`·`images`·`multi_page`·`deterministic`
+   를 더했다.** `name` 은 오류 메시지와 회귀 기준선 파일명에 쓸 안정 식별자이고,
+   `multi_page` 는 §2.1 에서 드러난 PDF(문서 단위) 대 나머지(페이지 단위)의 차이를
+   질의 가능하게 만든다. `deterministic` 은 백엔드 간 정합 시험의 전제 조건이다 —
+   기준선을 뜰 수 있는 백엔드를 가려낸다.
+3. **`PageSize` 를 `(f64, f64)` 대신 이름 있는 타입으로 두었다.** 기존
+   `Renderer::begin_page(width, height)` 는 두 `f64` 를 나란히 받아 뒤바꿔 넣어도
+   컴파일된다. 단위 계약을 문서로 못 박을 자리도 필요했다.
+
+## 4. 지금 들어 있는 백엔드
+
+| 백엔드 | `Output` | 무엇에 쓰나 |
+| --- | --- | --- |
+| `SvgBackend` (`svg_adapter.rs`) | `String` | **레퍼런스 어댑터.** 기존 `SvgLayerRenderer` 를 호출만 해서 진짜 SVG 문서를 낸다. 계약이 실제 백엔드를 감쌀 수 있음을 증명한다. |
+| `TraceBackend` (`backends.rs`) | `String` | op 시퀀스를 결정적 문자열로 기록. **백엔드 간 정합 시험의 기준선.** |
+| `NullBackend` (`backends.rs`) | `DrawStats` | 그린 op 를 종류별로 세는 계측기. 그리기 비용 없이 조판 산출량을 잰다. |
+
+### 4.1 `TraceBackend` 가 왜 그 자체로 값이 있나
+
+픽셀 비교는 두 백엔드가 다 완성돼야 하고, 달라도 **어디서** 갈렸는지 말해주지 않는다.
+`TraceBackend` 는 조판이 내보낸 op 시퀀스 자체를 고정하므로, 두 백엔드의 그림이 다를 때
+*같은 입력을 다르게 그린 것*인지 *애초에 다른 입력을 받은 것*인지를 가른다.
+
+출력 형식은 결정적이다.
+
+```text
+begin_page 400.00x300.00
+  pageBackground bbox=0.00,0.00,400.00,300.00
+  rectangle bbox=20.00,20.00,10.00,10.00
+end_page ops=2
+```
+
+좌표는 항상 `{:.2}` 로 찍어 `f64` 기본 출력의 자릿수 흔들림을 없앤다. op 이름표
+(`pageBackground`·`rectangle` …)는 **기존 LayerTree JSON export 의 `"type"` 값과 글자
+그대로 같다**(`src/paint/json.rs:507-1036`). 두 어휘가 갈라지지 않게 하려는 것이다.
+
+### 4.2 `SvgBackend` 어댑터의 얇음과 그 대가
+
+어댑터는 `src/renderer/**` 를 한 줄도 고치지 않고 공개 API 만 호출한다
+(`SvgLayerRenderer::new` → `LayerRenderer::render_page` → `output()`).
+대가는 하나다: 받은 op 들을 `LayerNode::leaf` 하나로 묶어 넘기므로 **원본 트리의
+그룹·클립 구조가 이 경로에서 평탄해진다.** 진짜 이관은 §5 다.
+
+### 4.3 구동기 `replay_page`
+
+기존 `PageLayerTree` 한 장을 임의의 백엔드로 재생하는 다리다. 새 백엔드는 트리 순회를
+다시 짤 필요 없이 trait 만 구현하면 된다. 순서는 §2.4 의 정본 plane 배열을 따르고,
+plane 안에서는 트리 전위 순회를 지키며, 조상의 `LayerNode::layer` 를 자손에게 상속한다.
+`B: ?Sized` 라 trait object 에도 그대로 쓰인다.
+
+## 5. 채택 시나리오 — 기존 백엔드가 어떻게 이 뒤로 옮겨가나
+
+이 PR 은 계약만 신설한다. 실제 이관은 아래 순서를 제안한다. 각 단계는 독립 PR 이며,
+앞 단계가 뒤 단계의 회귀 그물이 된다.
+
+### 5.1 SVG — `SvgRenderer` 안에서 직접 구현 (가장 먼저)
+
+`SvgRenderer` 는 이미 이 계약과 같은 모양의 내부 생명주기를 갖고 있다.
+
+- `begin_page(width, height)` — `svg.rs:2703` 에서 루트 `<svg>` 를 연다
+  (`RenderNodeType::Page` 진입점 `svg.rs:302-304`)
+- `end_page()` — `<defs>` 주입과 `</svg>` 닫기 (`svg.rs:851-853`)
+
+즉 SVG 는 `RenderBackend` 를 **직접** 구현할 수 있다. `type Output = String`,
+`type Error = RenderBackendError`, `draw` 는 지금의 `paint_op_to_render_node`
+(`svg_layer.rs:239` 아래) 대신 `PaintOp` 를 곧바로 SVG 요소로 내보낸다.
+그러면 §4.2 의 평탄화 손실이 사라지고, `SvgLayerRenderer` 의
+`PageLayerTree` → `PageRenderTree` 역변환(`svg_layer.rs:38-43`, 스스로
+"transition renderer" 라 적힌 곳)이 통째로 없어진다.
+
+이관 안전망: 이관 전후로 같은 문서에 `TraceBackend` 를 물려 op 시퀀스가 같은지 먼저
+확인하고(입력이 같음을 고정), 그다음 SVG 문자열을 비교한다.
+
+### 5.2 PDF — 문서 단위 산출을 `finish` 로 흡수
+
+직접 PDF 경로는 지금 `&[PageLayerTree]` 를 통째로 받는다(`pdf.rs:948`). 새 계약에서는
+페이지마다 `begin_page`/`end_page` 를 받고 `finish` 가 문서 전체를 낸다.
+
+```rust
+impl RenderBackend for PdfBackend {
+    type Output = Vec<u8>;   // 문서 하나
+    type Error = RenderBackendError;
+    // begin_page → 새 PDF 페이지 열기 (px → pt: CSS_PX_TO_PDF_POINT, pdf.rs:952)
+    // finish     → 문서 직렬화
+}
+```
+
+`capabilities().multi_page == true` 가 이 성질을 소비자에게 알린다. 호환 경로
+(`svgs_to_pdf_with_options`, `pdf.rs:812`)는 그대로 두어도 된다 — SVG 백엔드의
+`Output` 이 `String` 이므로 `SvgBackend → svgs_to_pdf` 조합이 계약 안에서 그대로 성립한다.
+
+### 5.3 Skia — `&self` 를 `&mut self` 로 좁히고 옵션을 생성자로
+
+Skia 는 `render_raster_with_options(&self, tree, options)` 로 트리 전체를 받는다
+(`skia/renderer.rs:372`). 이관은 옵션을 **생성자**로 옮기는 모양이다.
+
+```rust
+let mut backend = SkiaBackend::new(RasterRenderOptions { scale: 2.0, ..Default::default() });
+replay_page(&mut backend, &tree)?;
+let png: RasterRenderOutput = backend.finish()?;
+```
+
+`capabilities()` 는 `BackendCapabilities::raster("skia")` 에서 출발한다
+(`raster_only: true`, 따라서 `vector_text: false`). Skia 는 이미 plane 배열을
+바깥 루프로 돌리므로(`skia/renderer.rs:496`) `replay_page` 와 재생 순서가 같다 —
+이관 시 순서 회귀가 나지 않는다는 뜻이다. `native-skia` 피처 게이트는 그대로 유지하고,
+백엔드 구현 전체를 `#[cfg(feature = "native-skia")]` 로 감싼다.
+
+### 5.4 Canvas — 능력 선언으로 결손을 드러내기
+
+`CanvasRenderer` 가 10개 op 를 조용히 버리는 것(§2.5)은 이관 시 두 가지로 바뀐다.
+표현 못 하는 op 는 `UnsupportedOp { backend: "canvas", op }` 를 내거나,
+`capabilities()` 가 그 결손을 미리 선언한다. 어느 쪽이든 **소비자가 알 수 있게** 된다.
+`begin_page`/`end_page` 짝도 계약이 강제하므로 자동으로 고쳐진다.
+
+### 5.5 새 백엔드 (예: 인쇄용 PostScript, 접근성 트리)
+
+기존 코드를 읽을 필요 없이 `RenderBackend` 만 구현하고 `replay_page` 로 구동한다.
+`NullBackend` 로 생명주기부터 확인하고, `TraceBackend` 기준선으로 입력이 같음을
+고정한 뒤 산출물을 검증하는 것이 권장 순서다.
+
+## 6. 비범위
+
+이 PR 이 **하지 않는** 것.
+
+- **기존 백엔드 수정.** `src/renderer/**` 는 한 줄도 바뀌지 않는다. §5 는 제안이지
+  이 PR 의 내용이 아니다.
+- **기존 trait 폐기.** `Renderer`·`LayerRenderer`·`LayerRasterRenderer` 는 그대로다.
+  경쟁이 아니라 상위 계약이며, 이관이 끝나기 전에는 공존한다.
+- **클립·변환·레이어 합성의 계약화.** v1 은 leaf op 재생만 다룬다. 클립 영역은
+  `BackendCapabilities::clipping` 으로 **질의만** 가능하고, 클립을 백엔드에 전달하는
+  op(`push_clip`/`pop_clip` 같은 것)는 아직 없다. `PaintOp` 자체에 그 개념이 없기
+  때문이다.
+- **리소스 아레나 전달.** `ResourceArena`(폰트 blob·이미지)는 지금 `PageLayerTree` 에
+  달려 있고 trait 표면에 없다. 이미지·내장 폰트를 진짜로 그리는 백엔드는 이 통로가
+  필요하다 — 다음 개정에서 `begin_page` 인자나 별도 `set_resources` 로 추가할 자리다.
+- **비동기·스트리밍 출력.** 전부 동기다.
+- **CLI/MCP 표면 노출.** 이 계층은 아직 라이브러리 내부 계약이다.
+
+## 7. 검증
+
+| 게이트 | 결과 |
+| --- | --- |
+| `cargo build` | 통과 |
+| `cargo test --lib render_backend::` | 14 통과 / 0 실패 |
+| `cargo clippy --lib -- -D warnings` | 통과 |
+| `rustfmt --edition 2021 --check src/render_backend/mod.rs` | 통과(하위 모듈 포함) |
+
+단위 시험이 고정하는 것: trait object 다형 호출(`TraceBackend` 와 `SvgBackend` 를 같은
+`Box<dyn ..>` 벡터에 담아 구동), `begin_page` 없는 `draw` 의 오류, 페이지 경계 위반 3종,
+치수 유효성, `TraceBackend`/`SvgBackend` 결정성(같은 입력 → 같은 문자열), 능력 질의와
+자기모순 판정, `replay_page` 의 plane 재정렬, op 이름표와 LayerTree JSON 어휘의 일치,
+`PageState` 계수, `HwpError` 변환.
+
+### 작업 환경 함정
+
+- `cargo fmt --all -- --check` 는 이 환경에서 os error 206 으로 실패한다 →
+  `rustfmt --edition 2021 --check <파일>` 을 쓴다.
+- `renderer::composer::re_sample_gen::tests::test_gen_re_multisize` 는 이 변경과
+  무관하게 원래 실패한다. 회귀로 오인하지 않는다.
+- sparse-checkout 에서 `gym/` 을 빼면 `src/mcp_serve.rs:827` 의
+  `include_str!("../gym/README.md")` 때문에 **bin 타깃 빌드가 실패한다.**
+  `git sparse-checkout add gym` 으로 해소한다(라이브러리 빌드는 영향 없음).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod plan_schema;
 pub mod pq_sign;
 pub mod provenance;
 pub mod rag;
+pub mod render_backend;
 pub mod renderer;
 pub mod schema_registry;
 pub mod security_trailer;

--- a/src/render_backend/backends.rs
+++ b/src/render_backend/backends.rs
@@ -1,0 +1,188 @@
+//! 의존이 없는 계측용 백엔드 둘 — `NullBackend`, `TraceBackend`.
+//!
+//! 두 백엔드는 그림을 그리지 않는다. 대신 **계약이 지켜졌는지**를 볼 수 있게
+//! 만든다. `TraceBackend` 의 출력은 백엔드 간 정합 시험의 기준선이 된다 —
+//! "SVG 와 PDF 가 같은 페이지에서 같은 op 시퀀스를 받았는가"는 그림을 비교하지
+//! 않고도 이 문자열로 판정할 수 있다.
+
+use std::collections::BTreeMap;
+
+use crate::paint::PaintOp;
+
+use super::caps::BackendCapabilities;
+use super::traits::{PageSize, RenderBackend, RenderBackendError};
+use super::util::{paint_op_kind, PageState};
+
+/// `NullBackend` 가 세어 모은 계측값.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DrawStats {
+    /// 정상으로 닫힌 페이지 수.
+    pub pages: usize,
+    /// 그린 op 총수.
+    pub ops: usize,
+    /// op 종류별 개수. 키는 [`paint_op_kind`] 의 이름이며,
+    /// `BTreeMap` 이라 순회 순서가 결정적이다.
+    pub per_kind: BTreeMap<&'static str, usize>,
+}
+
+impl DrawStats {
+    /// 특정 종류의 op 를 몇 번 그렸는가.
+    pub fn count_of(&self, kind: &str) -> usize {
+        self.per_kind.get(kind).copied().unwrap_or(0)
+    }
+}
+
+/// 그린 op 를 세기만 하는 계측용 백엔드.
+///
+/// 쓰임새는 둘이다.
+/// 1. 조판 파이프라인이 **무엇을 얼마나** 내보내는지 그리기 비용 없이 재는 것.
+/// 2. 새 백엔드를 붙일 때 생명주기 계약이 지켜지는지 먼저 확인하는 것.
+#[derive(Debug, Clone, Default)]
+pub struct NullBackend {
+    state: PageState,
+    stats: DrawStats,
+}
+
+impl NullBackend {
+    /// 빈 계측기를 만든다.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// 지금까지 모은 계측값을 `finish` 없이 들여다본다.
+    pub fn stats(&self) -> &DrawStats {
+        &self.stats
+    }
+}
+
+impl RenderBackend for NullBackend {
+    type Output = DrawStats;
+    type Error = RenderBackendError;
+
+    fn capabilities(&self) -> BackendCapabilities {
+        BackendCapabilities {
+            multi_page: true,
+            deterministic: true,
+            ..BackendCapabilities::none("null")
+        }
+    }
+
+    fn begin_page(&mut self, size: PageSize) -> Result<(), Self::Error> {
+        self.state.begin(size)
+    }
+
+    fn draw(&mut self, op: &PaintOp) -> Result<(), Self::Error> {
+        self.state.record_draw()?;
+        self.stats.ops += 1;
+        *self.stats.per_kind.entry(paint_op_kind(op)).or_insert(0) += 1;
+        Ok(())
+    }
+
+    fn end_page(&mut self) -> Result<(), Self::Error> {
+        self.state.end()?;
+        self.stats.pages += 1;
+        Ok(())
+    }
+
+    fn finish(self) -> Result<Self::Output, Self::Error> {
+        self.state.assert_finished()?;
+        Ok(self.stats)
+    }
+
+    fn finish_boxed(self: Box<Self>) -> Result<Self::Output, Self::Error> {
+        (*self).finish()
+    }
+}
+
+/// op 시퀀스를 결정적 문자열로 기록하는 백엔드.
+///
+/// # 왜 이게 그림보다 쓸모 있나
+///
+/// 백엔드 정합을 픽셀로 비교하려면 두 백엔드가 다 완성돼 있어야 하고, 차이가
+/// 나도 **어느 단계에서** 갈렸는지 알 수 없다. `TraceBackend` 는 조판이 내보낸
+/// op 시퀀스 자체를 고정하므로, 두 백엔드가 다른 그림을 냈을 때
+/// "같은 입력을 받았는데 다르게 그린 것"인지 "애초에 다른 입력을 받은 것"인지를
+/// 갈라준다.
+///
+/// # 출력 형식
+///
+/// ```text
+/// begin_page 400.00x300.00
+///   textRun bbox=20.00,20.00,120.00,20.00
+///   rectangle bbox=0.00,0.00,10.00,10.00
+/// end_page ops=2
+/// ```
+///
+/// 좌표는 항상 `{:.2}` 로 찍는다. `f64` 기본 출력의 자릿수 흔들림을 없애
+/// 같은 입력이 언제나 같은 바이트열을 내게 하려는 것이다.
+#[derive(Debug, Clone, Default)]
+pub struct TraceBackend {
+    state: PageState,
+    lines: Vec<String>,
+}
+
+impl TraceBackend {
+    /// 빈 기록기를 만든다.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// 지금까지 기록된 줄들.
+    pub fn lines(&self) -> &[String] {
+        &self.lines
+    }
+
+    /// 지금까지 기록된 내용을 `finish` 없이 문자열로 본다.
+    pub fn trace(&self) -> String {
+        self.lines.join("\n")
+    }
+}
+
+impl RenderBackend for TraceBackend {
+    type Output = String;
+    type Error = RenderBackendError;
+
+    fn capabilities(&self) -> BackendCapabilities {
+        BackendCapabilities {
+            multi_page: true,
+            deterministic: true,
+            ..BackendCapabilities::none("trace")
+        }
+    }
+
+    fn begin_page(&mut self, size: PageSize) -> Result<(), Self::Error> {
+        self.state.begin(size)?;
+        self.lines
+            .push(format!("begin_page {:.2}x{:.2}", size.width, size.height));
+        Ok(())
+    }
+
+    fn draw(&mut self, op: &PaintOp) -> Result<(), Self::Error> {
+        self.state.record_draw()?;
+        let b = op.bounds();
+        self.lines.push(format!(
+            "  {} bbox={:.2},{:.2},{:.2},{:.2}",
+            paint_op_kind(op),
+            b.x,
+            b.y,
+            b.width,
+            b.height
+        ));
+        Ok(())
+    }
+
+    fn end_page(&mut self) -> Result<(), Self::Error> {
+        let (_, ops) = self.state.end()?;
+        self.lines.push(format!("end_page ops={ops}"));
+        Ok(())
+    }
+
+    fn finish(self) -> Result<Self::Output, Self::Error> {
+        self.state.assert_finished()?;
+        Ok(self.lines.join("\n"))
+    }
+
+    fn finish_boxed(self: Box<Self>) -> Result<Self::Output, Self::Error> {
+        (*self).finish()
+    }
+}

--- a/src/render_backend/caps.rs
+++ b/src/render_backend/caps.rs
@@ -1,0 +1,152 @@
+//! 백엔드 능력 선언 — 소비자가 백엔드 종류로 `match` 하는 대신 **질의**하게 만든다.
+//!
+//! 지금 코드베이스에서 "이 백엔드가 벡터 텍스트를 낼 수 있나"를 묻는 방법은
+//! 백엔드 타입을 아는 것뿐이다(예: `VariantSelectionBackend` 열거로 분기).
+//! 새 백엔드를 붙일 때마다 그 분기를 전부 찾아 고쳐야 한다는 뜻이다.
+//! `BackendCapabilities` 는 그 지식을 백엔드 자신에게 되돌려준다.
+
+/// 백엔드가 무엇을 할 수 있는지 스스로 밝힌다 — 소비자가 분기 대신 질의한다.
+///
+/// 모든 필드는 **그 백엔드의 최종 산출물이 그 성질을 보존하는가**를 뜻한다.
+/// 중간 단계에서 무엇을 하는지가 아니다. 예를 들어 PDF 는 내부적으로 SVG 를
+/// 거치더라도 최종 PDF 가 벡터 텍스트를 담으면 `vector_text: true` 다.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BackendCapabilities {
+    /// 백엔드 이름. 진단 메시지와 회귀 기준선 파일명에 쓰는 안정 식별자다.
+    pub name: &'static str,
+    /// 텍스트를 글리프/문자로 보존하는가(= 산출물에서 텍스트를 다시 선택·검색할 수 있는가).
+    pub vector_text: bool,
+    /// 폰트 바이트를 산출물 안에 실을 수 있는가.
+    pub embedded_fonts: bool,
+    /// 그라디언트 채우기를 표현할 수 있는가.
+    pub gradients: bool,
+    /// 클립 영역을 표현할 수 있는가.
+    pub clipping: bool,
+    /// 래스터 이미지를 실을 수 있는가.
+    pub images: bool,
+    /// 산출물이 픽셀뿐인가(벡터 정보를 잃는가).
+    ///
+    /// `raster_only == true` 이면 `vector_text` 는 반드시 `false` 다.
+    /// [`BackendCapabilities::is_consistent`] 가 이 불변식을 판정한다.
+    pub raster_only: bool,
+    /// 한 번의 `finish` 로 여러 페이지를 담을 수 있는가.
+    ///
+    /// `false` 면 소비자는 페이지마다 백엔드를 새로 만들어야 한다.
+    pub multi_page: bool,
+    /// 같은 op 시퀀스를 넣으면 같은 산출물이 나오는가(바이트 동일).
+    ///
+    /// 백엔드 간 정합 시험은 이 값이 `true` 인 백엔드에서만 기준선을 뜰 수 있다.
+    pub deterministic: bool,
+}
+
+impl BackendCapabilities {
+    /// 아무것도 못 하는 기준선. 계측용 백엔드가 여기서 출발한다.
+    pub const fn none(name: &'static str) -> Self {
+        Self {
+            name,
+            vector_text: false,
+            embedded_fonts: false,
+            gradients: false,
+            clipping: false,
+            images: false,
+            raster_only: false,
+            multi_page: false,
+            deterministic: false,
+        }
+    }
+
+    /// 벡터 출력 백엔드(SVG·PDF)가 흔히 갖는 조합.
+    pub const fn vector(name: &'static str) -> Self {
+        Self {
+            name,
+            vector_text: true,
+            embedded_fonts: false,
+            gradients: true,
+            clipping: true,
+            images: true,
+            raster_only: false,
+            multi_page: true,
+            deterministic: true,
+        }
+    }
+
+    /// 래스터 출력 백엔드(Skia·Canvas)가 흔히 갖는 조합.
+    ///
+    /// `raster_only` 가 켜지므로 `vector_text` 는 자동으로 꺼진다.
+    pub const fn raster(name: &'static str) -> Self {
+        Self {
+            name,
+            vector_text: false,
+            embedded_fonts: false,
+            gradients: true,
+            clipping: true,
+            images: true,
+            raster_only: true,
+            multi_page: false,
+            deterministic: false,
+        }
+    }
+
+    /// 한 가지 능력을 질의한다.
+    ///
+    /// 소비자 코드가 필드를 직접 읽는 대신 이 메서드를 쓰면, 나중에 능력이
+    /// 늘어나도 호출 형태가 바뀌지 않는다.
+    pub fn supports(&self, feature: BackendFeature) -> bool {
+        match feature {
+            BackendFeature::VectorText => self.vector_text,
+            BackendFeature::EmbeddedFonts => self.embedded_fonts,
+            BackendFeature::Gradients => self.gradients,
+            BackendFeature::Clipping => self.clipping,
+            BackendFeature::Images => self.images,
+            BackendFeature::MultiPage => self.multi_page,
+            BackendFeature::Deterministic => self.deterministic,
+        }
+    }
+
+    /// 선언이 자기모순이 아닌가 — 래스터 전용인데 벡터 텍스트를 주장하지는 않는가.
+    pub fn is_consistent(&self) -> bool {
+        !(self.raster_only && self.vector_text)
+    }
+
+    /// `self` 가 `required` 의 모든 능력을 포함하는가.
+    ///
+    /// 백엔드를 고를 때 "이 문서를 손실 없이 내보내려면 무엇이 필요한가"를
+    /// 능력 집합으로 적어두고 후보 백엔드에 물어보는 데 쓴다.
+    pub fn covers(&self, required: &[BackendFeature]) -> bool {
+        required.iter().all(|feature| self.supports(*feature))
+    }
+}
+
+/// 질의 가능한 능력 한 가지.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendFeature {
+    /// 텍스트를 텍스트로 보존.
+    VectorText,
+    /// 폰트 바이트 내장.
+    EmbeddedFonts,
+    /// 그라디언트.
+    Gradients,
+    /// 클립 영역.
+    Clipping,
+    /// 래스터 이미지.
+    Images,
+    /// 여러 페이지를 한 산출물에.
+    MultiPage,
+    /// 결정론 출력.
+    Deterministic,
+}
+
+impl BackendFeature {
+    /// 진단·기준선 파일에 쓰는 안정 문자열.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::VectorText => "vectorText",
+            Self::EmbeddedFonts => "embeddedFonts",
+            Self::Gradients => "gradients",
+            Self::Clipping => "clipping",
+            Self::Images => "images",
+            Self::MultiPage => "multiPage",
+            Self::Deterministic => "deterministic",
+        }
+    }
+}

--- a/src/render_backend/mod.rs
+++ b/src/render_backend/mod.rs
@@ -1,0 +1,395 @@
+//! 출력 백엔드 공통 계약 — `RenderBackend`.
+//!
+//! # 왜 이 모듈이 있나
+//!
+//! ROADMAP 은 업스트림 책임에 "공통 문서 엔진 … 조판, 편집, 저장과 **여러 출력
+//! 방식**"을 적어 두었다(`ROADMAP.md:187`). 그런데 실제 출력 경로들은 공통 계약
+//! 없이 각자 자란 상태다.
+//!
+//! | 백엔드 | 입력 | 산출 | 오류 |
+//! | --- | --- | --- | --- |
+//! | `SvgRenderer` (`src/renderer/svg.rs:233`) | `&PageRenderTree` | 내부 `String` 버퍼(`output()`) | 없음 |
+//! | `SvgLayerRenderer` (`src/renderer/svg_layer.rs:240`) | `&PageLayerTree` | 내부 `String` 버퍼 | `HwpError` |
+//! | `HtmlRenderer` (`src/renderer/html.rs:47`) | `&PageRenderTree` | 내부 `String` 버퍼 | 없음 |
+//! | `CanvasRenderer` (`src/renderer/canvas.rs:88`) | 둘 다 | `Vec<CanvasCommand>` | 없음 |
+//! | `SkiaLayerRenderer` (`src/renderer/skia/renderer.rs:372`) | `&PageLayerTree` | `RasterRenderOutput` | `HwpError` |
+//! | PDF (`src/renderer/pdf.rs:948`) | `&[PageLayerTree]` | `Vec<u8>` | `String` |
+//!
+//! 산출 방식이 셋(내부 버퍼 / 소유 반환 / 부수효과), 오류 타입이 셋(`없음` /
+//! `HwpError` / `String`)이다. 새 출력 형식을 붙일 때 따라야 할 형태도, 두
+//! 백엔드가 같은 페이지를 같게 그렸는지 물어볼 공통 어휘도 없다.
+//!
+//! 이 모듈은 그 공통 계약을 **기존 백엔드를 고치지 않고** 신설한다.
+//! 어댑터는 기존 코드를 호출만 하며, `src/renderer/**` 는 이 PR 에서 바뀌지 않는다.
+//!
+//! # 기존 trait 들과의 관계
+//!
+//! 이미 세 개의 trait 이 있지만 셋 다 이 계약을 대신하지 못한다.
+//!
+//! - `Renderer` (`src/renderer/mod.rs:664`) — `begin_page`/`draw_text`/`draw_rect`
+//!   … 원시 도형 단위다. `Result` 가 없어 실패를 말할 수 없고, 산출물 타입이
+//!   없으며, `PaintOp` 가 아니라 개별 인자를 받는다.
+//! - `LayerRenderer` (`src/renderer/layer_renderer.rs:21`) — 페이지 **한 장 통째로**
+//!   받는다(`render_page(&mut self, tree: &PageLayerTree)`). 산출물 타입도
+//!   능력 선언도 없고, 여러 페이지를 한 문서로 묶는 개념이 없다.
+//! - `LayerRasterRenderer` (`src/renderer/layer_renderer.rs:73`) — 래스터 전용이다.
+//!
+//! `RenderBackend` 는 그 사이를 메운다. `PaintOp` 단위(= 이미 backend 재생용으로
+//! 설계된 leaf op)로 받고, 연관 타입 `Output` 으로 산출물을 돌려주며,
+//! [`BackendCapabilities`] 로 자기 능력을 밝히고, 여러 페이지를 한 산출물로 묶는다.
+//!
+//! # 좌표·단위 계약 (요약)
+//!
+//! - 단위는 **px**, 원점은 **페이지 왼쪽 위**, **y 는 아래로** 증가한다.
+//!   이는 `PageLayerTree` 가 이미 선언한 값(`crate::paint::PAGE_LAYER_TREE_UNIT`,
+//!   `crate::paint::PAGE_LAYER_TREE_COORDINATE_SYSTEM`)과 같다.
+//! - HWPUNIT(1/7200 inch) → px 환산은 이 계층에 **들어오기 전에** 끝난다
+//!   (`crate::renderer::hwpunit_to_px`).
+//! - px → 형식 고유 단위 환산은 백엔드 **안에서** 한다. 예컨대 직접 PDF 경로는
+//!   `CSS_PX_TO_PDF_POINT = 72/96` 을 자기 안에서 곱한다(`src/renderer/pdf.rs:952`).
+//! - 좌표는 페이지 절대 좌표다. `PaintOp` 는 평탄화된 leaf op 이므로 조상 변환의
+//!   누적이 없다.
+//!
+//! # 쓰는 법
+//!
+//! ```no_run
+//! use rhwp::paint::PageLayerTree;
+//! use rhwp::render_backend::{replay_page, RenderBackend, TraceBackend};
+//!
+//! fn dump(tree: &PageLayerTree) -> String {
+//!     let mut backend = TraceBackend::new();
+//!     replay_page(&mut backend, tree).expect("생명주기 위반 없음");
+//!     backend.finish().expect("열린 페이지 없음")
+//! }
+//! ```
+//!
+//! 설계 배경과 기존 백엔드 채택 시나리오는 `mydocs/tech/render_backend.md`.
+
+pub mod backends;
+pub mod caps;
+pub mod svg_adapter;
+pub mod traits;
+pub mod util;
+
+pub use backends::{DrawStats, NullBackend, TraceBackend};
+pub use caps::{BackendCapabilities, BackendFeature};
+pub use svg_adapter::SvgBackend;
+pub use traits::{PageSize, RenderBackend, RenderBackendError};
+pub use util::{paint_op_kind, replay_page, PageState};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::paint::{CacheHint, GroupKind, LayerNode, PageLayerTree, PaintOp};
+    use crate::renderer::render_tree::{BoundingBox, LineNode, PageBackgroundNode, RectangleNode};
+    use crate::renderer::{LineStyle, ShapeStyle};
+
+    fn bbox(x: f64, y: f64, w: f64, h: f64) -> BoundingBox {
+        BoundingBox::new(x, y, w, h)
+    }
+
+    fn rect_op(x: f64, y: f64) -> PaintOp {
+        PaintOp::rectangle(
+            bbox(x, y, 10.0, 10.0),
+            RectangleNode::new(0.0, ShapeStyle::default(), None),
+        )
+    }
+
+    fn line_op() -> PaintOp {
+        PaintOp::line(
+            bbox(0.0, 0.0, 50.0, 0.0),
+            LineNode::new(0.0, 0.0, 50.0, 0.0, LineStyle::default()),
+        )
+    }
+
+    fn page_background_op(width: f64, height: f64) -> PaintOp {
+        PaintOp::page_background(
+            bbox(0.0, 0.0, width, height),
+            PageBackgroundNode {
+                background_color: None,
+                border_color: None,
+                border_width: 0.0,
+                gradient: None,
+                image: None,
+            },
+        )
+    }
+
+    /// 페이지 배경을 **일부러 마지막에** 넣은 트리.
+    /// `replay_page` 가 plane 순서로 재정렬하는지 보는 데 쓴다.
+    fn sample_tree() -> PageLayerTree {
+        let bounds = bbox(0.0, 0.0, 400.0, 300.0);
+        let leaf = LayerNode::leaf(
+            bounds,
+            None,
+            vec![
+                rect_op(20.0, 20.0),
+                line_op(),
+                page_background_op(400.0, 300.0),
+            ],
+        );
+        let root = LayerNode::group(
+            bounds,
+            None,
+            vec![leaf],
+            CacheHint::default(),
+            GroupKind::Body,
+        );
+        PageLayerTree::new(400.0, 300.0, root)
+    }
+
+    // 1. 정상 생명주기 — 계측 백엔드가 op 를 종류별로 센다.
+    #[test]
+    fn null_backend_counts_ops_by_kind() {
+        let mut backend = NullBackend::new();
+        backend.begin_page(PageSize::new(400.0, 300.0)).unwrap();
+        backend.draw(&rect_op(0.0, 0.0)).unwrap();
+        backend.draw(&rect_op(20.0, 20.0)).unwrap();
+        backend.draw(&line_op()).unwrap();
+        backend.end_page().unwrap();
+
+        let stats = backend.finish().unwrap();
+        assert_eq!(stats.pages, 1);
+        assert_eq!(stats.ops, 3);
+        assert_eq!(stats.count_of("rectangle"), 2);
+        assert_eq!(stats.count_of("line"), 1);
+        assert_eq!(stats.count_of("image"), 0);
+    }
+
+    // 2. begin_page 없이 draw 하면 오류다.
+    #[test]
+    fn draw_without_begin_page_is_error() {
+        let mut backend = NullBackend::new();
+        let err = backend.draw(&rect_op(0.0, 0.0)).unwrap_err();
+        assert_eq!(err, RenderBackendError::NoOpenPage { call: "draw" });
+
+        // TraceBackend·SvgBackend 도 같은 자리에서 같은 오류를 낸다.
+        let mut trace = TraceBackend::new();
+        assert_eq!(
+            trace.draw(&rect_op(0.0, 0.0)).unwrap_err(),
+            RenderBackendError::NoOpenPage { call: "draw" }
+        );
+        let mut svg = SvgBackend::new();
+        assert_eq!(
+            svg.draw(&rect_op(0.0, 0.0)).unwrap_err(),
+            RenderBackendError::NoOpenPage { call: "draw" }
+        );
+    }
+
+    // 3. 페이지 경계 위반 — 중복 열기, 안 연 채 닫기, 안 닫고 끝내기.
+    #[test]
+    fn page_boundary_violations_are_rejected() {
+        let mut backend = NullBackend::new();
+        assert_eq!(
+            backend.end_page().unwrap_err(),
+            RenderBackendError::NoOpenPage { call: "end_page" }
+        );
+
+        backend.begin_page(PageSize::new(100.0, 100.0)).unwrap();
+        assert_eq!(
+            backend.begin_page(PageSize::new(100.0, 100.0)).unwrap_err(),
+            RenderBackendError::PageAlreadyOpen
+        );
+
+        assert_eq!(
+            backend.finish().unwrap_err(),
+            RenderBackendError::UnclosedPage { pages_completed: 0 }
+        );
+    }
+
+    // 4. 페이지 치수 유효성.
+    #[test]
+    fn invalid_page_size_is_rejected() {
+        let mut backend = NullBackend::new();
+        assert_eq!(
+            backend.begin_page(PageSize::new(0.0, 300.0)).unwrap_err(),
+            RenderBackendError::InvalidPageSize {
+                width: 0.0,
+                height: 300.0
+            }
+        );
+        assert!(backend.begin_page(PageSize::new(-1.0, 300.0)).is_err());
+        assert!(backend.begin_page(PageSize::new(f64::NAN, 300.0)).is_err());
+        assert!(!PageSize::new(f64::INFINITY, 1.0).is_valid());
+        assert!(PageSize::new(1.0, 1.0).is_valid());
+        // 실패한 begin_page 는 페이지를 열지 않는다 — 이어서 정상 열기가 된다.
+        assert!(backend.begin_page(PageSize::new(10.0, 10.0)).is_ok());
+    }
+
+    // 5. TraceBackend 결정성 — 같은 입력이면 같은 문자열.
+    #[test]
+    fn trace_backend_is_deterministic() {
+        fn run() -> String {
+            let mut backend = TraceBackend::new();
+            replay_page(&mut backend, &sample_tree()).unwrap();
+            backend.finish().unwrap()
+        }
+
+        let first = run();
+        let second = run();
+        assert_eq!(first, second);
+        assert!(!first.is_empty());
+        // 자릿수 흔들림 없이 소수 2자리로 고정된다.
+        assert!(first.starts_with("begin_page 400.00x300.00"), "{first}");
+    }
+
+    // 6. 여러 페이지 경계가 추적 출력에 그대로 남는다.
+    #[test]
+    fn trace_backend_records_multiple_pages() {
+        let mut backend = TraceBackend::new();
+        backend.begin_page(PageSize::new(10.0, 10.0)).unwrap();
+        backend.draw(&rect_op(0.0, 0.0)).unwrap();
+        backend.end_page().unwrap();
+        backend.begin_page(PageSize::new(20.0, 20.0)).unwrap();
+        backend.end_page().unwrap();
+
+        let trace = backend.finish().unwrap();
+        let lines: Vec<&str> = trace.lines().collect();
+        assert_eq!(
+            lines,
+            vec![
+                "begin_page 10.00x10.00",
+                "  rectangle bbox=0.00,0.00,10.00,10.00",
+                "end_page ops=1",
+                "begin_page 20.00x20.00",
+                "end_page ops=0",
+            ]
+        );
+    }
+
+    // 7. 능력 질의 — 소비자가 백엔드 종류로 분기하지 않는다.
+    #[test]
+    fn capabilities_are_queryable_and_consistent() {
+        let svg = SvgBackend::new().capabilities();
+        assert_eq!(svg.name, "svg");
+        assert!(svg.supports(BackendFeature::VectorText));
+        assert!(svg.supports(BackendFeature::Gradients));
+        assert!(!svg.supports(BackendFeature::EmbeddedFonts));
+        assert!(svg.covers(&[BackendFeature::VectorText, BackendFeature::Images]));
+        assert!(!svg.covers(&[BackendFeature::EmbeddedFonts]));
+
+        let null = NullBackend::new().capabilities();
+        assert_eq!(null.name, "null");
+        assert!(!null.supports(BackendFeature::VectorText));
+        assert!(null.supports(BackendFeature::Deterministic));
+
+        // 자기모순 선언(래스터 전용인데 벡터 텍스트)은 불변식 위반이다.
+        for caps in [
+            svg,
+            null,
+            TraceBackend::new().capabilities(),
+            BackendCapabilities::raster("skia"),
+        ] {
+            assert!(caps.is_consistent(), "{}", caps.name);
+        }
+        let bogus = BackendCapabilities {
+            vector_text: true,
+            ..BackendCapabilities::raster("bogus")
+        };
+        assert!(!bogus.is_consistent());
+    }
+
+    // 8. trait 객체로 다형 호출 — 계측 백엔드와 실제 SVG 백엔드를 같은 통로로 몬다.
+    #[test]
+    fn backends_are_callable_through_trait_objects() {
+        let tree = sample_tree();
+        let mut backends: Vec<Box<dyn RenderBackend<Output = String, Error = RenderBackendError>>> =
+            vec![Box::new(TraceBackend::new()), Box::new(SvgBackend::new())];
+
+        let mut names = Vec::new();
+        let mut outputs = Vec::new();
+        for backend in backends.iter_mut() {
+            names.push(backend.capabilities().name);
+            replay_page(backend.as_mut(), &tree).unwrap();
+        }
+        for backend in backends {
+            outputs.push(backend.finish_boxed().unwrap());
+        }
+
+        assert_eq!(names, vec!["trace", "svg"]);
+        assert!(outputs[0].starts_with("begin_page"));
+        assert!(outputs[1].starts_with("<svg"));
+    }
+
+    // 9. 레퍼런스 어댑터가 진짜 SVG 문서를 낸다.
+    #[test]
+    fn svg_backend_emits_real_svg_document() {
+        let mut backend = SvgBackend::new();
+        replay_page(&mut backend, &sample_tree()).unwrap();
+        assert_eq!(backend.pages().len(), 1);
+
+        let svg = backend.finish().unwrap();
+        assert!(svg.starts_with("<svg"), "{svg}");
+        assert!(svg.contains("viewBox=\"0 0 400 300\""), "{svg}");
+        assert!(svg.trim_end().ends_with("</svg>"), "{svg}");
+    }
+
+    // 10. 어댑터도 결정적이다 — 같은 페이지를 두 번 그리면 같은 바이트열이다.
+    #[test]
+    fn svg_backend_is_deterministic() {
+        fn run() -> String {
+            let mut backend = SvgBackend::new();
+            replay_page(&mut backend, &sample_tree()).unwrap();
+            backend.finish().unwrap()
+        }
+        assert_eq!(run(), run());
+    }
+
+    // 11. replay_page 가 plane 순서(배경 → … → 글 앞)로 재정렬한다.
+    #[test]
+    fn replay_page_reorders_ops_into_replay_planes() {
+        let mut backend = TraceBackend::new();
+        replay_page(&mut backend, &sample_tree()).unwrap();
+        let trace = backend.finish().unwrap();
+        let lines: Vec<&str> = trace.lines().collect();
+
+        // 트리에는 rectangle, line, pageBackground 순으로 넣었지만
+        // 재생은 pageBackground(Background plane)부터 나가야 한다.
+        assert_eq!(lines[0], "begin_page 400.00x300.00");
+        assert!(lines[1].contains("pageBackground"), "{trace}");
+        assert!(lines[2].contains("rectangle"), "{trace}");
+        assert!(lines[3].contains("line"), "{trace}");
+        assert_eq!(lines[4], "end_page ops=3");
+    }
+
+    // 12. op 이름표가 기존 LayerTree JSON 의 "type" 값과 같은 어휘를 쓴다.
+    #[test]
+    fn paint_op_kind_uses_layer_json_type_names() {
+        assert_eq!(paint_op_kind(&rect_op(0.0, 0.0)), "rectangle");
+        assert_eq!(paint_op_kind(&line_op()), "line");
+        assert_eq!(
+            paint_op_kind(&page_background_op(10.0, 10.0)),
+            "pageBackground"
+        );
+    }
+
+    // 13. 생명주기 상태기 자체의 계수 — 백엔드 밖에서도 같은 판정을 재사용한다.
+    #[test]
+    fn page_state_tracks_counters() {
+        let mut state = PageState::new();
+        assert_eq!(state.current_page(), None);
+        assert!(state.assert_finished().is_ok());
+
+        state.begin(PageSize::new(5.0, 5.0)).unwrap();
+        assert_eq!(state.current_page(), Some(PageSize::new(5.0, 5.0)));
+        state.record_draw().unwrap();
+        state.record_draw().unwrap();
+        assert_eq!(state.ops_on_page(), 2);
+
+        let (size, ops) = state.end().unwrap();
+        assert_eq!(size, PageSize::new(5.0, 5.0));
+        assert_eq!(ops, 2);
+        assert_eq!(state.pages_completed(), 1);
+        assert_eq!(state.ops_total(), 2);
+        assert!(state.assert_finished().is_ok());
+    }
+
+    // 14. 오류가 기존 HwpError 로 손실 없이 건너간다.
+    #[test]
+    fn errors_convert_to_hwp_error() {
+        let err = RenderBackendError::NoOpenPage { call: "draw" };
+        let hwp: crate::error::HwpError = err.into();
+        assert!(matches!(hwp, crate::error::HwpError::RenderError(_)));
+        assert!(hwp.to_string().contains("begin_page"));
+    }
+}

--- a/src/render_backend/svg_adapter.rs
+++ b/src/render_backend/svg_adapter.rs
@@ -1,0 +1,116 @@
+//! 레퍼런스 어댑터 — 기존 SVG 렌더러를 `RenderBackend` 뒤에 세운다.
+//!
+//! 이 파일은 `src/renderer/**` 를 **한 줄도 고치지 않는다**. 기존 공개 API
+//! (`SvgLayerRenderer::new` / `LayerRenderer::render_page` / `SvgLayerRenderer::output`)
+//! 를 호출만 한다. 계약이 실제 백엔드를 감쌀 수 있는지 증명하는 것이 목적이다.
+//!
+//! # 얇음의 대가 (알려진 한계)
+//!
+//! 어댑터는 받은 op 들을 `LayerNode::leaf` 하나로 묶어 기존 렌더러에 넘긴다.
+//! 따라서 원본 트리의 그룹·클립 구조는 이 경로에서 평탄해진다. 진짜 이관은
+//! `SvgRenderer` 안에서 이 trait 을 직접 구현하는 것이며(그쪽엔 이미
+//! `begin_page`/`end_page` 내부 함수가 있다), 그 작업은 이 PR 의 범위가 아니다.
+//! 자세한 채택 시나리오는 `mydocs/tech/render_backend.md` 를 본다.
+
+use crate::paint::{LayerNode, PageLayerTree, PaintOp, RenderProfile};
+use crate::renderer::layer_renderer::LayerRenderer;
+use crate::renderer::render_tree::BoundingBox;
+use crate::renderer::svg_layer::SvgLayerRenderer;
+
+use super::caps::BackendCapabilities;
+use super::traits::{PageSize, RenderBackend, RenderBackendError};
+use super::util::PageState;
+
+/// 기존 SVG 렌더러를 `RenderBackend` 계약으로 감싼 어댑터.
+///
+/// 산출물은 페이지마다 독립된 `<svg>` 문서이며, `finish` 는 그것들을 줄바꿈으로
+/// 이어 붙인 하나의 문자열을 돌려준다. 페이지별로 따로 쓰려면 [`SvgBackend::pages`]
+/// 를 본다.
+#[derive(Debug)]
+pub struct SvgBackend {
+    state: PageState,
+    profile: RenderProfile,
+    pending: Vec<PaintOp>,
+    pages: Vec<String>,
+}
+
+impl SvgBackend {
+    /// 화면 프로파일(`RenderProfile::Screen`)로 어댑터를 만든다.
+    pub fn new() -> Self {
+        Self::with_profile(RenderProfile::Screen)
+    }
+
+    /// 렌더 프로파일을 지정해 어댑터를 만든다.
+    ///
+    /// 프로파일은 편집기 전용 시각 요소(문단 부호 등)를 낼지를 가른다 —
+    /// 기존 `PageLayerTree::with_profile` 이 쓰는 값과 같은 것이다.
+    pub fn with_profile(profile: RenderProfile) -> Self {
+        Self {
+            state: PageState::new(),
+            profile,
+            pending: Vec::new(),
+            pages: Vec::new(),
+        }
+    }
+
+    /// 지금까지 완성된 페이지별 SVG 문서들.
+    pub fn pages(&self) -> &[String] {
+        &self.pages
+    }
+}
+
+impl Default for SvgBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RenderBackend for SvgBackend {
+    type Output = String;
+    type Error = RenderBackendError;
+
+    fn capabilities(&self) -> BackendCapabilities {
+        BackendCapabilities {
+            // 어댑터 자신은 폰트 바이트를 싣지 않는다. SVG 에 폰트를 내장하는
+            // 일은 상위(`document_core`)가 `generate_embedded_font_style` 로
+            // 따로 한다.
+            embedded_fonts: false,
+            ..BackendCapabilities::vector("svg")
+        }
+    }
+
+    fn begin_page(&mut self, size: PageSize) -> Result<(), Self::Error> {
+        self.state.begin(size)?;
+        self.pending.clear();
+        Ok(())
+    }
+
+    fn draw(&mut self, op: &PaintOp) -> Result<(), Self::Error> {
+        self.state.record_draw()?;
+        self.pending.push(op.clone());
+        Ok(())
+    }
+
+    fn end_page(&mut self) -> Result<(), Self::Error> {
+        let (size, _) = self.state.end()?;
+        let bounds = BoundingBox::new(0.0, 0.0, size.width, size.height);
+        let root = LayerNode::leaf(bounds, None, std::mem::take(&mut self.pending));
+        let tree = PageLayerTree::with_profile(size.width, size.height, root, self.profile);
+
+        let mut renderer = SvgLayerRenderer::new();
+        renderer
+            .render_page(&tree)
+            .map_err(RenderBackendError::from)?;
+        self.pages.push(renderer.output().to_string());
+        Ok(())
+    }
+
+    fn finish(self) -> Result<Self::Output, Self::Error> {
+        self.state.assert_finished()?;
+        Ok(self.pages.join("\n"))
+    }
+
+    fn finish_boxed(self: Box<Self>) -> Result<Self::Output, Self::Error> {
+        (*self).finish()
+    }
+}

--- a/src/render_backend/traits.rs
+++ b/src/render_backend/traits.rs
@@ -1,0 +1,193 @@
+//! `RenderBackend` 계약 본체 — trait, 페이지 치수 타입, 공통 오류 타입.
+//!
+//! 이 파일이 정의하는 것은 **출력 백엔드가 지켜야 할 최소 계약**이다.
+//! 기존 SVG·Skia·PDF 백엔드는 각자 다른 입력(`PageRenderTree` / `PageLayerTree`)과
+//! 다른 출력(`String` / `Vec<u8>` / 부수효과)을 가지므로, 이 trait 은 그 차이를
+//! 연관 타입 `Output` 으로 흡수하고 **호출 순서(생명주기)와 좌표 계약만** 고정한다.
+
+use crate::error::HwpError;
+use crate::paint::{PageLayerTree, PaintOp};
+
+use super::caps::BackendCapabilities;
+
+/// 한 페이지의 출력 표면 치수.
+///
+/// # 단위 계약
+///
+/// - 단위는 **px** 이다. HWPUNIT(1/7200 inch)이 아니다.
+/// - 이는 `PageLayerTree` 가 선언한 단위(`crate::paint::PAGE_LAYER_TREE_UNIT == "px"`)와
+///   `BoundingBox` 필드 주석(`src/renderer/render_tree.rs`)이 이미 쓰는 단위와 같다.
+/// - 백엔드는 이 값을 자기 형식의 단위로 바꿀 책임이 있다(예: PDF 는 pt, Skia 는 device px).
+///   **변환은 백엔드 안에서 일어나고, 이 trait 을 통과하는 값은 언제나 px 이다.**
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PageSize {
+    /// 페이지 폭 (px).
+    pub width: f64,
+    /// 페이지 높이 (px).
+    pub height: f64,
+}
+
+impl PageSize {
+    /// px 단위 폭·높이로 페이지 치수를 만든다.
+    ///
+    /// 유효성(양수·유한)은 여기서 막지 않는다. `begin_page` 가
+    /// [`PageSize::is_valid`] 로 판정해 [`RenderBackendError::InvalidPageSize`] 를 낸다.
+    pub const fn new(width: f64, height: f64) -> Self {
+        Self { width, height }
+    }
+
+    /// 페이지 치수가 그릴 수 있는 값인가 — 유한하고 0 보다 큰가.
+    pub fn is_valid(&self) -> bool {
+        self.width.is_finite() && self.height.is_finite() && self.width > 0.0 && self.height > 0.0
+    }
+
+    /// 기존 `PageLayerTree` 에서 페이지 치수를 그대로 가져온다.
+    ///
+    /// `PageLayerTree::page_width` / `page_height` 는 이미 px 이므로 환산이 없다.
+    pub fn from_layer_tree(tree: &PageLayerTree) -> Self {
+        Self::new(tree.page_width, tree.page_height)
+    }
+}
+
+/// 백엔드 공통 오류.
+///
+/// 각 백엔드는 `RenderBackend::Error` 를 자유롭게 고를 수 있지만, **생명주기 위반**
+/// (페이지를 열지 않고 그리기 등)은 백엔드마다 다르게 판정되면 안 된다. 그래서
+/// 이 크레이트가 제공하는 백엔드는 모두 이 타입을 쓰고, 외부 백엔드도 자기 오류
+/// 타입에 `From<RenderBackendError>` 를 달아 같은 판정을 재사용하도록 권한다.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RenderBackendError {
+    /// `begin_page` 없이 `draw`/`end_page` 를 불렀다.
+    NoOpenPage {
+        /// 위반한 호출 이름(`"draw"` / `"end_page"`).
+        call: &'static str,
+    },
+    /// 이미 열린 페이지가 있는데 `begin_page` 를 또 불렀다.
+    PageAlreadyOpen,
+    /// 페이지를 닫지 않고 `finish` 를 불렀다.
+    UnclosedPage {
+        /// `finish` 시점까지 정상으로 닫힌 페이지 수.
+        pages_completed: usize,
+    },
+    /// 페이지 치수가 유한한 양수가 아니다.
+    InvalidPageSize {
+        /// 문제의 폭 (px).
+        width: f64,
+        /// 문제의 높이 (px).
+        height: f64,
+    },
+    /// 백엔드가 그 op 를 표현할 수 없다 — capabilities 로 미리 질의해 피할 수 있는 실패다.
+    UnsupportedOp {
+        /// 백엔드 이름(`BackendCapabilities::name`).
+        backend: &'static str,
+        /// op 종류 이름(`super::paint_op_kind`).
+        op: &'static str,
+    },
+    /// 감싼 기존 백엔드가 낸 오류를 문자열로 옮긴 것.
+    ///
+    /// 어댑터가 기존 `HwpError` 를 잃지 않고 전달하는 통로다.
+    Backend(String),
+}
+
+impl std::fmt::Display for RenderBackendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoOpenPage { call } => {
+                write!(f, "열린 페이지가 없습니다: {call} 앞에 begin_page 가 필요합니다")
+            }
+            Self::PageAlreadyOpen => {
+                write!(f, "이미 열린 페이지가 있습니다: end_page 없이 begin_page 를 다시 부를 수 없습니다")
+            }
+            Self::UnclosedPage { pages_completed } => write!(
+                f,
+                "닫지 않은 페이지가 있습니다: 완료된 페이지 {pages_completed}개 뒤에 end_page 가 필요합니다"
+            ),
+            Self::InvalidPageSize { width, height } => {
+                write!(f, "유효하지 않은 페이지 치수: {width}x{height} px")
+            }
+            Self::UnsupportedOp { backend, op } => {
+                write!(f, "백엔드 {backend}가 지원하지 않는 op 입니다: {op}")
+            }
+            Self::Backend(msg) => write!(f, "백엔드 오류: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for RenderBackendError {}
+
+impl From<HwpError> for RenderBackendError {
+    fn from(value: HwpError) -> Self {
+        Self::Backend(value.to_string())
+    }
+}
+
+impl From<RenderBackendError> for HwpError {
+    fn from(value: RenderBackendError) -> Self {
+        HwpError::RenderError(value.to_string())
+    }
+}
+
+/// 한 페이지 분량의 paint op 를 받아 자기 형식으로 그리는 출력 백엔드.
+///
+/// # 생명주기 (불변식)
+///
+/// 호출 순서는 다음 정규식과 같아야 한다.
+///
+/// ```text
+/// ( begin_page  draw*  end_page )*  finish
+/// ```
+///
+/// 이를 어기면 백엔드는 **오류를 내야 하고, 조용히 넘어가면 안 된다**.
+/// `super::PageState` 가 이 판정을 한 곳에 모아두므로 새 백엔드는 그걸 쓰면 된다.
+///
+/// # 좌표·단위 계약
+///
+/// - 모든 좌표와 치수는 **px** 다. `PaintOp::bounds()` 의 `BoundingBox` 도 px 다.
+/// - 원점은 **페이지 왼쪽 위**, **y 는 아래로 증가**한다.
+///   (`crate::paint::PAGE_LAYER_TREE_COORDINATE_SYSTEM == "page-top-left-y-down"`)
+/// - 좌표는 **페이지 절대 좌표**다. 그룹·클립 조상에 따른 누적 변환이 없다 —
+///   `PaintOp` 는 이미 평탄화된 leaf op 이기 때문이다.
+/// - 백엔드가 자기 형식 단위(pt, device px, mm)로 바꾸는 것은 백엔드 내부 일이며,
+///   그 변환 계수는 이 trait 표면에 드러나지 않는다.
+///
+/// # 왜 `finish(self)` 인가
+///
+/// 출력물(문자열·바이트열)의 소유권을 넘기기 위해서다. 대신 trait object 로는
+/// `finish` 를 부를 수 없으므로, `Box<dyn RenderBackend<..>>` 를 위해
+/// [`RenderBackend::finish_boxed`] 를 함께 둔다.
+pub trait RenderBackend {
+    /// 이 백엔드가 최종적으로 내놓는 산출물 타입(예: SVG `String`, PDF `Vec<u8>`).
+    type Output;
+    /// 이 백엔드가 내는 오류 타입. 생명주기 위반은 [`RenderBackendError`] 와 같은
+    /// 판정이어야 하므로 `From<RenderBackendError>` 를 다는 것을 권한다.
+    type Error;
+
+    /// 이 백엔드가 무엇을 할 수 있는지 스스로 밝힌다.
+    ///
+    /// 소비자는 백엔드 종류로 `match` 하지 말고 이 값을 **질의**해서 분기한다.
+    fn capabilities(&self) -> BackendCapabilities;
+
+    /// 새 페이지를 연다. 이미 열린 페이지가 있으면 오류다.
+    fn begin_page(&mut self, size: PageSize) -> Result<(), Self::Error>;
+
+    /// 열린 페이지에 leaf paint op 하나를 그린다.
+    ///
+    /// 페이지가 열려 있지 않으면 오류다. op 순서는 **그리기 순서**이며,
+    /// 뒤에 온 op 가 앞의 op 위에 그려진다.
+    fn draw(&mut self, op: &PaintOp) -> Result<(), Self::Error>;
+
+    /// 열린 페이지를 닫는다. 열린 페이지가 없으면 오류다.
+    fn end_page(&mut self) -> Result<(), Self::Error>;
+
+    /// 백엔드를 소비해 산출물을 낸다. 닫지 않은 페이지가 있으면 오류다.
+    fn finish(self) -> Result<Self::Output, Self::Error>
+    where
+        Self: Sized;
+
+    /// `Box<dyn RenderBackend<..>>` 에서도 산출물을 꺼낼 수 있게 하는 통로.
+    ///
+    /// 구현은 거의 언제나 `(*self).finish()` 한 줄이다. `finish(self)` 는
+    /// `Self: Sized` 를 요구해 vtable 에 올라가지 못하지만, `self: Box<Self>`
+    /// 수신자는 object safe 이므로 이 메서드는 trait object 에서 호출된다.
+    fn finish_boxed(self: Box<Self>) -> Result<Self::Output, Self::Error>;
+}

--- a/src/render_backend/util.rs
+++ b/src/render_backend/util.rs
@@ -1,0 +1,183 @@
+//! 백엔드 구현이 공유하는 부품 — 생명주기 상태기, op 이름표, 레이어 트리 구동기.
+//!
+//! 여기 있는 것들은 "모든 백엔드가 똑같이 해야 하는데 각자 구현하면 어긋나는"
+//! 일들이다. 한 곳에 두어야 백엔드 간 정합 시험이 의미를 갖는다.
+
+use crate::paint::{
+    paint_op_replay_plane_with_layer, LayerNode, LayerNodeKind, PageLayerTree, PaintOp,
+    PaintReplayPlane,
+};
+use crate::renderer::render_tree::RenderLayerInfo;
+
+use super::traits::{PageSize, RenderBackend, RenderBackendError};
+
+/// `PaintOp` 종류의 안정 이름.
+///
+/// 문자열은 `src/paint/json.rs` 의 LayerTree JSON export 가 쓰는 `"type"` 값과
+/// **글자 그대로 같다**. 그래야 백엔드 추적 로그와 기존 JSON 덤프를 같은
+/// 어휘로 맞대볼 수 있다.
+pub fn paint_op_kind(op: &PaintOp) -> &'static str {
+    match op {
+        PaintOp::PageBackground { .. } => "pageBackground",
+        PaintOp::TextRun { .. } => "textRun",
+        PaintOp::GlyphRun { .. } => "glyphRun",
+        PaintOp::GlyphOutline { .. } => "glyphOutline",
+        PaintOp::CharOverlap { .. } => "charOverlap",
+        PaintOp::TextControlMark { .. } => "textControlMark",
+        PaintOp::TabLeader { .. } => "tabLeader",
+        PaintOp::TextDecoration { .. } => "textDecoration",
+        PaintOp::FootnoteMarker { .. } => "footnoteMarker",
+        PaintOp::Line { .. } => "line",
+        PaintOp::Rectangle { .. } => "rectangle",
+        PaintOp::Ellipse { .. } => "ellipse",
+        PaintOp::Path { .. } => "path",
+        PaintOp::Image { .. } => "image",
+        PaintOp::Equation { .. } => "equation",
+        PaintOp::FormObject { .. } => "formObject",
+        PaintOp::Placeholder { .. } => "placeholder",
+        PaintOp::RawSvg { .. } => "rawSvg",
+    }
+}
+
+/// `RenderBackend` 생명주기 불변식을 한 곳에서 판정하는 상태기.
+///
+/// 백엔드마다 "페이지를 안 열고 그리면 어떻게 되나"가 달라지면 계약이 아니다.
+/// 이 크레이트의 백엔드는 전부 이 상태기를 품고, 외부 백엔드도 이걸 그대로
+/// 쓰면 같은 오류를 같은 자리에서 낸다.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct PageState {
+    open: Option<PageSize>,
+    pages_completed: usize,
+    ops_on_page: usize,
+    ops_total: usize,
+}
+
+impl PageState {
+    /// 아무 페이지도 열지 않은 초기 상태.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// `begin_page` 판정 — 치수 유효성과 중복 열기를 막는다.
+    pub fn begin(&mut self, size: PageSize) -> Result<(), RenderBackendError> {
+        if self.open.is_some() {
+            return Err(RenderBackendError::PageAlreadyOpen);
+        }
+        if !size.is_valid() {
+            return Err(RenderBackendError::InvalidPageSize {
+                width: size.width,
+                height: size.height,
+            });
+        }
+        self.open = Some(size);
+        self.ops_on_page = 0;
+        Ok(())
+    }
+
+    /// `draw` 판정 — 열린 페이지가 없으면 오류다. 성공하면 op 수를 센다.
+    pub fn record_draw(&mut self) -> Result<PageSize, RenderBackendError> {
+        match self.open {
+            Some(size) => {
+                self.ops_on_page += 1;
+                self.ops_total += 1;
+                Ok(size)
+            }
+            None => Err(RenderBackendError::NoOpenPage { call: "draw" }),
+        }
+    }
+
+    /// `end_page` 판정 — 닫은 페이지의 치수와 그 페이지에 그린 op 수를 돌려준다.
+    pub fn end(&mut self) -> Result<(PageSize, usize), RenderBackendError> {
+        match self.open.take() {
+            Some(size) => {
+                self.pages_completed += 1;
+                Ok((size, self.ops_on_page))
+            }
+            None => Err(RenderBackendError::NoOpenPage { call: "end_page" }),
+        }
+    }
+
+    /// `finish` 판정 — 열어둔 페이지가 남아 있으면 오류다.
+    pub fn assert_finished(&self) -> Result<(), RenderBackendError> {
+        if self.open.is_some() {
+            return Err(RenderBackendError::UnclosedPage {
+                pages_completed: self.pages_completed,
+            });
+        }
+        Ok(())
+    }
+
+    /// 지금 열려 있는 페이지 치수.
+    pub fn current_page(&self) -> Option<PageSize> {
+        self.open
+    }
+
+    /// 정상으로 닫힌 페이지 수.
+    pub fn pages_completed(&self) -> usize {
+        self.pages_completed
+    }
+
+    /// 지금 열린 페이지에 그린 op 수.
+    pub fn ops_on_page(&self) -> usize {
+        self.ops_on_page
+    }
+
+    /// 지금까지 그린 op 총수.
+    pub fn ops_total(&self) -> usize {
+        self.ops_total
+    }
+}
+
+/// 기존 `PageLayerTree` 한 장을 임의의 백엔드로 재생한다.
+///
+/// 이 함수가 `RenderBackend` 와 기존 IR 을 잇는 다리다. 새 백엔드는 트리 순회를
+/// 다시 짤 필요 없이 [`RenderBackend`] 만 구현하면 된다.
+///
+/// # 재생 순서
+///
+/// `src/paint/replay_order.rs` 의 [`PaintReplayPlane::ORDERED`]
+/// (배경 → 글 뒤 → 본문 흐름 → 글 앞)를 바깥 루프로 돌고, 각 plane 안에서는
+/// 트리 전위 순회 순서를 지킨다. 이는 Skia(`src/renderer/skia/renderer.rs:496`)와
+/// 웹 캔버스(`src/renderer/web_canvas.rs:492`)가 이미 쓰는 정본 순서와 같다.
+/// 조상 `LayerNode::layer` 는 자손에게 상속되며, plane 판정은
+/// `paint_op_replay_plane_with_layer` 에 위임한다.
+pub fn replay_page<B>(backend: &mut B, tree: &PageLayerTree) -> Result<(), B::Error>
+where
+    B: RenderBackend + ?Sized,
+{
+    backend.begin_page(PageSize::from_layer_tree(tree))?;
+    for plane in PaintReplayPlane::ORDERED {
+        replay_node(backend, &tree.root, None, plane)?;
+    }
+    backend.end_page()
+}
+
+fn replay_node<B>(
+    backend: &mut B,
+    node: &LayerNode,
+    inherited_layer: Option<RenderLayerInfo>,
+    plane: PaintReplayPlane,
+) -> Result<(), B::Error>
+where
+    B: RenderBackend + ?Sized,
+{
+    let active_layer = node.layer.or(inherited_layer);
+    match &node.kind {
+        LayerNodeKind::Group { children, .. } => {
+            for child in children {
+                replay_node(backend, child, active_layer, plane)?;
+            }
+        }
+        LayerNodeKind::ClipRect { child, .. } => {
+            replay_node(backend, child, active_layer, plane)?;
+        }
+        LayerNodeKind::Leaf { ops } => {
+            for op in ops {
+                if paint_op_replay_plane_with_layer(op, active_layer) == plane {
+                    backend.draw(op)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## 동기

`ROADMAP.md`는 업스트림 책임에 "공통 문서 엔진 … 조판, 편집, 저장과 **여러 출력 방식**"을 적습니다(`ROADMAP.md:187`). 그런데 그 "여러 출력 방식"은 공통 계약 없이 각자 자랐습니다. 산출 방식이 셋(내부 `String` 버퍼 / 소유값 반환 / 부수효과), 오류 타입이 셋(없음 / `HwpError` / `String`), 입력이 둘(`PageRenderTree` / `PageLayerTree`)이고, PDF만 문서 단위입니다.

| 백엔드 | 진입점 | 입력 | 산출 | 오류 |
|---|---|---|---|---|
| SVG (렌더트리) | `svg.rs:233` | `&PageRenderTree` | 내부 `String` 버퍼 | 없음 |
| SVG (레이어트리) | `svg_layer.rs:239` | `&PageLayerTree` | 내부 버퍼 | `HwpError`(항상 `Ok`) |
| HTML | `html.rs:47` | `&PageRenderTree` | 내부 버퍼 | 없음 |
| Canvas | `canvas.rs:83·88` | 둘 다 | `Vec<CanvasCommand>` | 없음 |
| Skia | `skia/renderer.rs:372` | `&PageLayerTree`+옵션 | `RasterRenderOutput` | `HwpError` |
| PDF | `pdf.rs:948` | `&[PageLayerTree]`(문서 단위) | `Vec<u8>` | `String` |

그래서 (1) 새 백엔드를 붙일 형틀이 없고, (2) 백엔드 간 정합을 물어볼 공통 어휘가 없습니다 — "SVG와 PDF가 같은 페이지를 같게 그렸는가"를 픽셀로만 비교할 수 있고, 달라도 *조판이 다른 op를 준 것*인지 *같은 op를 다르게 그린 것*인지 갈라낼 수 없습니다. `PaintOp` 정의부 주석이 이미 "backend가 재생하는 leaf paint operation"(`paint_op.rs:43`)이라 이 계층을 예비해 둔 자리였습니다. 없던 것은 **그 op를 받는 쪽의 계약**입니다.

**추가 발견**(범위 밖, 문서에 기록): `CanvasRenderer`가 18개 op 중 10개를 조용히 버림(`canvas.rs:272-282`), 레이어 경로에서 `begin_page`만 부르고 `end_page`를 안 부름(`canvas.rs:88-91`).

## 설계

`RenderBackend`는 `PaintOp` 단위로 받고, 연관 타입 `Output`/`Error`로 산출물과 오류의 차이를 흡수하며, `(begin_page draw* end_page)* finish` 생명주기를 **강제**합니다. 위반은 조용히 넘어가지 않고 오류가 됩니다. 판정은 `PageState` 하나에 모았습니다 — 백엔드에 따라 규칙이 갈라지면 계약이 아니기 때문입니다. `BackendCapabilities`는 소비자가 백엔드 타입으로 `match`하는 대신 **질의**하게 만듭니다.

좌표 계약은 새로 만든 것이 아니라 **이미 사실인 것을 못박은 것**입니다: 단위 px, 원점 페이지 왼쪽 위, y 아래로(`paint/schema.rs:22-23`).

```rust
pub trait RenderBackend {
    type Output;
    type Error;
    fn capabilities(&self) -> BackendCapabilities;
    fn begin_page(&mut self, size: PageSize) -> Result<(), Self::Error>;
    fn draw(&mut self, op: &PaintOp) -> Result<(), Self::Error>;
    fn end_page(&mut self) -> Result<(), Self::Error>;
    fn finish(self) -> Result<Self::Output, Self::Error> where Self: Sized;
    fn finish_boxed(self: Box<Self>) -> Result<Self::Output, Self::Error>;
}
```

스케치에서 바꾼 3가지(이유는 설계 문서 §3.5): `finish_boxed`(trait object에서 산출물을 꺼내기 위해 — `finish(self)`는 `Self: Sized`라 `Box<dyn RenderBackend>`에서 못 쓴다), capabilities 5개 필드 추가, `PageSize` 이름 있는 타입(기존 `begin_page(w, h)`는 두 `f64`를 뒤바꿔도 컴파일된다).

기존 `Renderer`·`LayerRenderer`·`LayerRasterRenderer`는 **그대로 둡니다** — 경쟁이 아니라 상위 계약이고, 셋 중 무엇도 SVG·Skia·PDF를 함께 담지 못합니다(설계 문서 §2.3).

## 사용법

```rust
use rhwp::render_backend::{replay_page, RenderBackend, SvgBackend, TraceBackend};

let mut backend = SvgBackend::new();
replay_page(&mut backend, &layer_tree)?;
let svg: String = backend.finish()?;
```

레퍼런스 어댑터는 **`SvgBackend`** — 기존 `SvgLayerRenderer` 공개 API만 호출해 진짜 `<svg>` 문서를 내며 기본 빌드에서 동작합니다(native-skia 불필요, `src/renderer/**` 무수정). **`TraceBackend`**(결정적 op 시퀀스 문자열)는 **백엔드 간 정합 시험의 기준선**이 됩니다. **`NullBackend`**는 그리기 비용 없이 조판 산출량을 잽니다.

**SVG가 앞으로 이렇게 씁니다**: `SvgLayerRenderer`는 이미 이 계약과 같은 모양의 내부 생명주기를 갖고 있어(`begin_page`가 루트 `<svg>`를 열고, `end_page`가 `<defs>`를 주입하고 닫음) `RenderBackend`를 직접 구현할 수 있습니다. **PDF**는 `&[PageLayerTree]` 통째 API가 `begin_page`/`end_page` 페이지 단위 + `finish` 문서 산출로 자연스럽게 접힙니다. **Skia**는 옵션을 생성자로 옮기는 모양이고 `native-skia` 피처 게이트를 유지합니다.

## 테스트

`cargo test --lib render_backend::` **14 통과 / 0 실패**. 고정하는 것: trait object 다형 호출, `begin_page` 없는 `draw` 오류(백엔드 3종이 같은 오류), 페이지 경계 위반 3종, 치수 유효성(0·음수·NaN·∞), `TraceBackend`/`SvgBackend` 결정성, capabilities 질의와 자기모순 판정, `replay_page`의 plane 재정렬, op 이름표와 JSON 어휘 일치.

```
$ cargo test --lib render_backend::
test result: ok. 14 passed; 0 failed

$ cargo clippy --lib -- -D warnings   # 통과
$ cargo build                          # 통과
```

## 범위

기존 백엔드 수정 없음, 기존 trait 폐기 없음, 클립/변환 op 계약화 없음, CLI/MCP 표면 노출 없음. `src/lib.rs`는 `pub mod render_backend;` 한 줄뿐(`rag`와 `renderer` 사이).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
