### PR TITLE
feat(docdiff): 문서 의미 diff 엔진을 라이브러리로 신설

### DIFF
--- a/mydocs/tech/docdiff.md
+++ b/mydocs/tech/docdiff.md
@@ -1,0 +1,235 @@
+---
+kind: reference
+status: active
+canonical: mydocs/tech/docdiff.md
+last_verified: 2026-08-16
+---
+
+# 문서 의미 diff 엔진 — `src/docdiff/`
+
+두 `Document` IR 의 **구조적·의미적 차이**를 계산하는 재사용 라이브러리다. 회귀 검증,
+왕복 시험, 편집 전후 확인, 변환 손실 설명이 전부 같은 질문 하나를 던진다 — *"두 문서가
+어떻게 다른가."* 그 답을 **라이브러리로 부를 수 있게** 만든 것이 이 모듈이다.
+
+ROADMAP.md 는 업스트림 책임에 "공통 품질과 운영 | 호환성 원칙, 재현용 샘플, **회귀·시각
+검증**, 보안 수정, 문서와 공식 릴리스"를 적어 두었다(`ROADMAP.md` 192행). 회귀 검증이
+근거를 대려면 "어디가 달라졌나"를 **값으로** 돌려주는 층이 필요하다.
+
+관련 소스: `src/docdiff/mod.rs`(공개 표면·경계 문서), `model.rs`(결과 타입),
+`compare.rs`(비교 엔진), `summary.rs`(집계).
+
+## 1. 중복 조사 — 기존 장치와의 경계
+
+새 모듈을 짓기 전에 저장소에 이미 있는 비교 장치를 전수 확인했다. **결론: 재사용 가능한
+라이브러리 함수가 이미 하나 있고, 그것은 이 모듈과 층이 다르다.**
+
+### 1.1 실측
+
+| 장치 | 위치 | 소비 가능성 |
+| --- | --- | --- |
+| `roundtrip::diff_documents(a, b) -> IrDiff` | `src/serializer/hwpx/roundtrip.rs:731` | **공개 라이브러리 함수** — 이미 재사용 가능 |
+| `roundtrip_ir_diff(bytes)` | `src/serializer/hwpx/roundtrip.rs:492` | 공개. 위 함수의 왕복 구동부 |
+| `ir_diff(args) -> i32` (CLI `ir-diff`) | `src/main.rs:16670`, 디스패치 `src/main.rs:385` | **바이너리 안의 비공개 함수** — 라이브러리에서 못 부름 |
+| `ir_diff_paragraph_fields(...)` | `src/main.rs:15871` | 비공개. CLI 의 문단 비교 본체 |
+| `IrDiffEmitter` | `src/main.rs:15823` | 비공개. 출력 가드 + 카테고리 집계 |
+| `render-diff` (`diff_render_geometry`) | `src/diagnostics/render_geom_diff.rs:441`, 디스패치 `src/main.rs:392` | 공개. **렌더 기하** 축이라 IR 비교가 아니다 |
+| `hwpx-roundtrip` 배치 | `src/diagnostics/hwpx_roundtrip_batch.rs` | 공개. `roundtrip_ir_diff` 의 배치 구동부 |
+
+### 1.2 그래서 무엇이 이미 있고, 무엇이 없나
+
+**있다.** `roundtrip::diff_documents` 는 `(&Document, &Document) -> IrDiff` 시그니처의
+공개 함수다. 이름까지 같으므로 착각하기 쉽다. 그러나 그것이 **묻는 질문**은 다르다 —
+"저장했다 다시 읽었을 때 원본이 그대로 살아 있나"다. 비교 대상은 리소스 개수,
+문단별 `char_shapes` 시퀀스, `line_segs` 9 필드, 섹션 `PageDef`·`visibility`, 표·개체
+캡션, 필드 `parameters`, 그림 크기, `page_break`/`holdAnchorAndSO`/`flowWithText` 같은
+직렬화 보존 플래그다. 직렬화기 게이트로서는 정확히 옳다.
+
+**없다.** 그 함수는 **문단 텍스트를 아예 비교하지 않는다**(`roundtrip.rs` 전역에서
+`Paragraph::text` 비교 없음 — 모듈 머리주석의 "Stage 1~5에서 비교 대상 필드를 누적
+확장한다 (문단 텍스트 …)"가 아직 미도달인 상태다). 사람이 "문서가 어떻게 바뀌었나"를
+물을 때 가장 먼저 알고 싶은 것이 빠져 있다.
+
+그 자리를 CLI `ir-diff` 가 메우고 있다. 텍스트·`char_offsets`·`para_shape_id`·탭·
+`line_segs`·컨트롤·표(`diff_table`)·`ParaShape`·`TabDef` 를 비교한다. 문제는 **그것이 전부
+`src/main.rs` 안의 비공개 함수**라는 점이다. 라이브러리 소비자(다른 진단 모듈, MCP 도구,
+회귀 테스트, `rhwp-agent`)는 한 줄도 못 쓴다. 게다가 결과가 값이 아니라 **출력 문자열**
+이다 — `--json` 의 카테고리 집계마저 이미 만든 출력 줄의 앞부분을 되파싱해서
+(`IrDiffEmitter::diff`) `BTreeMap<String, u32>` 를 만든다.
+
+### 1.3 결정적 결함 — 자리끼리 맞대기
+
+두 기존 장치는 **똑같은 방식으로 문단을 짝짓는다**: `a.paragraphs[i]` 대
+`b.paragraphs[i]`, 남는 것은 개수 차이 한 줄
+(`roundtrip.rs:772-782`, `main.rs:16825-16848`).
+
+그래서 **문단 하나가 앞에 끼어들면 뒤따르는 문단 전부가 "달라졌다"로 보고된다.** 문단
+200 개짜리 문서 맨 앞에 머리말 한 줄을 넣으면 차이 201 건이 나온다. 저장기 회귀
+게이트로서는 무해하다(어차피 0 건이어야 하니까). 그러나 편집·변환 결과를 사람이나
+에이전트에게 **설명**하는 자리에서는 그 잡음이 곧 쓸모없음이다.
+
+### 1.4 경계 — 왜 둘 다 필요한가
+
+| | 무엇을 묻나 | 실패의 뜻 |
+| --- | --- | --- |
+| `roundtrip::diff_documents` (충실도) | 한 비트라도 잃지 않았나 | 저장기 결함 |
+| `rhwp ir-diff` (CLI, 필드 충실도) | 두 파일의 IR 필드가 다른가 | 변환 손실 후보 |
+| **`docdiff`** (의미) | 사람이 보기에 무엇이 바뀌었나 | 내용이 달라졌다 |
+
+충실도 게이트는 **관대하면 안 된다** — `line_segs` 한 칸이 어긋나면 한글이 본문을 통째로
+버리므로 실패여야 한다. 의미 diff 는 **엄격하면 안 된다** — 문단 하나 넣었는데 201 건을
+내면 아무도 안 읽는다. 두 요구는 한 함수에 담기지 않는다. 그래서 이 모듈은 셋째 장치가
+아니라 **한 단계 위의 층**이다.
+
+## 2. 공개 표면
+
+```rust
+pub fn diff_documents(a: &Document, b: &Document, opts: &DiffOptions) -> DocumentDiff;
+
+pub struct DiffOptions { pub ignore_whitespace: bool, pub max_findings: Option<usize> }
+pub struct DocumentDiff { pub identical: bool, pub findings: Vec<Finding>, pub truncated: bool }
+pub struct Finding { pub path: NodePath, pub kind: FindingKind, pub detail: String }
+pub enum FindingKind { SectionCountChanged, ParagraphAdded, ParagraphRemoved, TextChanged,
+                       ParagraphStyleChanged, TableShapeChanged, ControlCountChanged,
+                       ControlKindChanged, StyleCountChanged, StyleChanged }
+pub struct NodePath { /* Vec<PathStep> */ }
+pub enum PathStep { Section(usize), Paragraph(usize), Control(usize),
+                    TableCell { row: u16, col: u16 }, Style(usize) }
+pub struct DiffSummary { pub total: usize, pub truncated: bool,
+                         pub by_kind: Vec<(FindingKind, usize)> }
+
+impl DocumentDiff { pub fn summary(&self) -> DiffSummary; pub fn to_json(&self) -> Value; }
+```
+
+### 2.1 원 스케치에서 바꾼 것과 이유
+
+- **`NodePath` 를 `Vec<PathStep>` 으로.** 문자열 경로(`ir-diff` 와 `roundtrip` 의
+  `path: String`)는 소비자가 되파싱해야 한다. 타입이면 `path.section()` 으로 꺼낸다.
+  표시형(`sec[0]/para[3]/ctrl[1]/cell[r2,c0]/para[0]`)은 `Display` 로 제공한다.
+- **`FindingKind` 에 `ParagraphStyleChanged`·`ControlKindChanged`·`StyleCountChanged`
+  추가.** 스케치의 `StyleChanged` 하나로는 "문단이 가리키는 모양이 바뀜"과 "스타일 정의
+  자체가 바뀜"을 구별할 수 없었다. `ControlKindChanged` 는 표가 그림으로 바뀌는 것 같은
+  변환 사고를 개수 차이와 분리한다.
+- **`FindingKind::ALL` 과 `label()` 추가.** 집계 순서의 단일 출처이자 봉투의 안정 키다.
+- **`to_json()` 추가(직렬화 계층).** CLI·MCP 가 봉투에 그대로 끼우도록. 스키마 버전은
+  일부러 안 붙인다 — 봉투의 주인은 이 엔진이 아니라 명령이다.
+
+## 3. 결과 계약과 불변식
+
+1. **`identical == true` 이면 `findings` 는 비어 있고 `truncated` 도 `false` 다.**
+   구현은 `identical = findings.is_empty() && !truncated` 다. `max_findings: Some(0)` 에
+   차이가 있는 문서를 넣어도 `identical` 로 거짓말하지 않는다(테스트로 고정).
+2. **`truncated == true` 는 "정말로 더 있었다"를 뜻한다.** 상한에 걸려도 **순회는 끝까지
+   한다.** 조기 탈출하면 `truncated` 가 "더 있었을 수도"라는 약한 말이 된다.
+3. **결정적이다.** 순회는 문서 순서(구역 → 문단 → 컨트롤 → 셀, 끝으로 문서 정보)로
+   고정이고, LCS 되짚기는 갈림길에서 언제나 삭제를 먼저 고른다(`compare.rs` 의 `>=`).
+   `HashMap` 순회에 기대는 곳이 **한 군데도 없다** — 집계는 `FindingKind::ALL` 배열을
+   돈다. 같은 두 문서는 몇 번을 돌려도 같은 결과·같은 순서다(테스트로 고정).
+4. **`DiffSummary` 는 보고된 것의 회계다.** 상한에 버려진 차이는 세지 않고, 그 사실은
+   `summary.truncated` 가 말한다. `by_kind` 는 선언 순서이고 0 건 항목은 빠진다.
+5. **`detail` 은 계약이 아니다.** 사람이 읽는 한 줄이다. 기계 판정은 `kind` 와 `path` 로
+   한다. 미리보기는 40 **문자**(바이트 아님)에서 자르고 `…` 를 붙인다.
+6. **경로 첨자의 기준.** 짝지어진 문단과 삭제된 문단은 A 기준, 추가된 문단은 B 기준
+   첨자다(A 에 자리가 없으므로).
+
+## 4. 정렬 — 이 엔진의 본체
+
+```
+공통 앞(prefix) 깎기 → 공통 뒤(suffix) 깎기 → 남은 가운데만 LCS → 맞닿은 삭제·추가 짝짓기
+```
+
+마지막 단계가 핵심이다. LCS 만 쓰면 한 글자 고친 문단이 `Removed` + `Added` 두 건으로
+나온다. 사람이 보기엔 그건 **수정**이다. 그래서 앞뒤로 맞닿은 삭제 덩어리와 추가 덩어리를
+앞에서부터 짝지어 `Pair` 로 승격시키고, 남는 쪽만 순수 추가·삭제로 남긴다.
+
+결과:
+
+| 입력 | 기존 자리끼리 맞대기 | `docdiff` |
+| --- | --- | --- |
+| 문단 1 개 한 글자 수정 | `TextChanged` 1 | `TextChanged` 1 |
+| 문단 200 개 맨 앞에 1 줄 삽입 | 차이 201 건 | `ParagraphAdded` **1 건** |
+| 가운데 1 줄 삭제 | 뒤 전부 오염 | `ParagraphRemoved` 1 건 |
+
+**비용 상한.** LCS 표가 `LCS_CELL_BUDGET`(100만 칸, `u32` 로 4 MB)을 넘으면 자리끼리
+맞대는 방식으로 물러선다. 앞뒤를 먼저 깎으므로 실제 회귀 검증에서 LCS 를 돌리는
+"가운데"는 대개 몇 줄뿐이다. 물러선 경우에도 결과는 결정적이다.
+
+**재귀 깊이.** 표 셀 안 문단은 같은 규칙으로 재귀한다. `MAX_DEPTH`(32)는 실제 문서의
+중첩 깊이를 한참 넘는 스택 보호용이다.
+
+## 5. 채택 시나리오
+
+이 모듈은 **아무도 아직 쓰지 않는다**(신설 PR 이므로). 아래는 설계가 겨냥한 소비처다.
+
+### 5.1 회귀 시험
+
+`tests/` 의 왕복·변환 테스트가 실패할 때 "다르다" 대신 **근거**를 낸다.
+
+```rust
+let diff = docdiff::diff_documents(&before, &after, &DiffOptions::default().max_findings(20));
+assert!(diff.identical, "편집 전후 의미 차이:\n{}",
+        diff.findings.iter().map(|f| f.to_string()).collect::<Vec<_>>().join("\n"));
+```
+
+`Finding::to_string()` 이 `sec[0]/para[3] textChanged: A="..." B="..."` 로 나오므로 실패
+메시지가 곧 좌표다. 기존 충실도 게이트를 **대체하지 않고** 그 옆에 선다 — 충실도가
+실패했을 때 "그래서 사람이 보는 문서는 뭐가 달라졌나"를 같은 실패 메시지 안에서 답한다.
+
+### 5.2 왕복 검증 (`convert --verify`, `export-hwpx --verify`)
+
+현재 `--verify` 는 IR 차이가 있으면 exit 3 을 내고 상세는 `ir-diff` 로 미룬다
+(`main.rs:7816` 등의 "상세는 --json 또는 ir-diff"). 여기에 의미 요약 한 줄을 덧붙일 수
+있다 — "충실도 차이 47 건(직렬화 축), 의미 차이 0 건" 이면 사용자에게 **안심해도 된다**고
+말할 수 있고, 반대면 진짜 손실이다. 이 판정은 지금 아무도 못 한다.
+
+### 5.3 CLI
+
+- 신규 `doc-diff` 명령(후속 PR): `to_json()` 을 `provenance::marked()` 로 감싸면 봉투
+  완성. 차이 있으면 exit 3 — 기존 `ir-diff` 와 같은 게이트 규약.
+- 기존 `ir-diff` 를 이 엔진 위로 옮기는 것은 **별도 후속 PR** 이다. 이 PR 은 `main.rs` 를
+  건드리지 않는다.
+
+### 5.4 MCP
+
+`hwp_doc_diff` 도구의 결과 타입으로 그대로 쓴다. `FindingKind::label()` 이 안정 키이므로
+도구 스키마의 `enum` 을 코드에서 생성할 수 있다(`capabilities --mcp` 가 도구 정의의 단일
+출처라는 규약과 정합). 에이전트가 문자열을 파싱하지 않고 `kind` 로 분기한다.
+
+### 5.5 편집 파이프라인 (`edit --verify`, `run` 계획서)
+
+"의도한 것만 바뀌었나"를 **좌표로** 확인한다. 셀 하나를 고쳤으면 findings 는
+`sec[0]/para[2]/ctrl[0]/cell[r3,c1]/para[0] textChanged` 정확히 1 건이어야 한다. 지금은
+그 단언을 쓸 수단이 없다.
+
+## 6. 비범위
+
+- **파싱하지 않는다.** 입력은 `Document` IR 이다. 파일 열기는 호출자 몫이다.
+- **렌더 기하를 보지 않는다.** 화면 위 픽셀 변위는 `render-diff`
+  (`src/diagnostics/render_geom_diff.rs`)의 축이다. 두 축은 상호 보완이지 대체가 아니다.
+- **직렬화 충실도를 재지 않는다.** `line_segs`·`char_shapes`·원본 바이트 보존은 왕복
+  게이트가 본다.
+- **글상자·각주·머리말 안으로 아직 재귀하지 않는다.** 표 셀까지다. 컨트롤 개수·종류
+  차이는 잡히므로 손실이 조용히 통과하지는 않는다. 확장은 후속 작업.
+- **스타일 정의 전 필드를 비교하지 않는다.** 이름·종류·모양 참조까지다. 필드 단위
+  충실도는 왕복 게이트의 몫이다.
+- **`main.rs` 를 고치지 않는다.** `ir-diff` 추출은 후속 PR 이다.
+
+## 7. 검증
+
+| 게이트 | 결과 |
+| --- | --- |
+| `cargo build --lib` | 통과 |
+| `cargo test --lib docdiff::` | 22 통과 / 0 실패 |
+| `cargo test --doc docdiff` | 2 통과 / 0 실패 |
+| `cargo clippy --lib --tests -- -D warnings` | 통과 |
+| `rustfmt --edition 2021 --check src/docdiff/*.rs` | 통과 |
+
+단위 테스트가 고정하는 것: 같은 문서 → `identical`·차이 0, 빈 문서 대 빈 문서, 한 글자
+변경, 가운데 문단 추가·삭제(비오염), 구역 수 변화, 표 행렬 변화, 표 셀 좌표, 컨트롤
+개수·종류, 스타일 개수·정의, **결정성**(12 회 호출 동일), `max_findings` 상한과
+`truncated`, 상한 0 경계, 불변식 전수, 요약 집계 정확성·순서, 공백 무시, 문단모양 변화,
+경로 타입 접근, JSON 봉투 안정성, 카테고리 이름 고유성, 대형 문서 앞머리 삽입.
+
+## 관련 문서
+
+- [`parser_architecture.md`](parser_architecture.md) — 공통 `Document` IR 경계
+- [`envelope_provenance.md`](envelope_provenance.md) — 봉투 출처 표지 계약

--- a/src/docdiff/compare.rs
+++ b/src/docdiff/compare.rs
@@ -1,0 +1,568 @@
+//! 비교 엔진 — 두 `Document` IR 을 의미 수준에서 맞대 본다.
+//!
+//! ## 왜 자리끼리 맞대지 않는가
+//!
+//! 문단을 `a[i]` 대 `b[i]` 로 맞대면 **문단 하나가 앞에 끼어드는 순간** 뒤따르는 모든
+//! 문단이 "텍스트 바뀜"으로 보고된다. 한 줄 삽입이 수백 건의 거짓 차이가 되는 것이다.
+//! 그래서 이 엔진은 문단 목록을 먼저 **정렬(alignment)** 한다 — 공통 앞뒤를 깎아내고
+//! 남은 가운데만 최장 공통 부분수열(LCS)로 짝지은 뒤, 서로 맞닿은 삭제·추가 덩어리를
+//! 다시 짝지어 "바뀐 문단"으로 승격시킨다. 그 결과 한 글자 수정은 `TextChanged` 1 건,
+//! 한 문단 삽입은 `ParagraphAdded` 1 건이 된다.
+//!
+//! ## 결정성
+//!
+//! 순회는 문서 순서로 고정이고, LCS 되짚기는 갈림길에서 **언제나 삭제를 먼저** 고른다.
+//! 해시 자료구조를 돌지 않으므로 같은 두 문서는 언제나 같은 결과·같은 순서를 낸다.
+
+use std::borrow::Cow;
+
+use super::model::{DiffOptions, DocumentDiff, Finding, FindingKind, NodePath, PathStep};
+use crate::model::control::Control;
+use crate::model::document::Document;
+use crate::model::paragraph::Paragraph;
+use crate::model::style::Style;
+use crate::model::table::Table;
+
+/// LCS 표가 쓸 수 있는 최대 칸 수 — 넘으면 자리끼리 맞대는 방식으로 물러선다.
+///
+/// 칸당 `u32` 4 바이트라 최대 4 MB 다. 문단 1000 × 1000 쌍까지는 정렬이 돌고, 그보다
+/// 큰 덩어리는 정렬 없이 자리끼리 비교한다(결과는 여전히 결정적이다).
+const LCS_CELL_BUDGET: usize = 1_000_000;
+
+/// 표 중첩 재귀의 안전 상한 — 실제 문서의 중첩 깊이를 한참 넘는 스택 보호용이다.
+const MAX_DEPTH: usize = 32;
+
+/// `detail` 미리보기의 최대 글자 수(바이트가 아니라 문자다 — 한글이 잘리면 안 된다).
+const PREVIEW_CHARS: usize = 40;
+
+/// 두 문서의 구조적 차이를 계산한다.
+///
+/// 입력은 이미 파싱된 IR 이다 — 이 함수는 **파일을 열지 않는다.** 어떤 포맷에서
+/// 왔든(HWP5·HWPX·HWP3) 같은 `Document` 로 들어오면 같은 규칙으로 비교한다.
+///
+/// 결과의 불변식은 [`DocumentDiff`] 문서를 참고한다. 특히 `opts.max_findings` 에
+/// 걸리더라도 **순회는 끝까지** 하므로 `truncated` 는 "정말로 더 있었다"를 뜻한다.
+///
+/// ```
+/// use rhwp::docdiff::{diff_documents, DiffOptions};
+/// use rhwp::model::document::Document;
+///
+/// let a = Document::default();
+/// let b = Document::default();
+/// let diff = diff_documents(&a, &b, &DiffOptions::default());
+/// assert!(diff.identical);
+/// assert!(diff.findings.is_empty());
+/// ```
+pub fn diff_documents(a: &Document, b: &Document, opts: &DiffOptions) -> DocumentDiff {
+    let mut collector = Collector::new(opts.max_findings);
+    let root = NodePath::root();
+
+    if a.sections.len() != b.sections.len() {
+        collector.push(
+            &root,
+            FindingKind::SectionCountChanged,
+            format!("구역 수: A={} B={}", a.sections.len(), b.sections.len()),
+        );
+    }
+
+    // 짝이 맞는 구역만 안으로 들어간다. 남는 구역은 위의 개수 차이가 이미 말한다.
+    for (i, (sa, sb)) in a.sections.iter().zip(b.sections.iter()).enumerate() {
+        let path = root.child(PathStep::Section(i));
+        compare_paragraph_list(
+            &mut collector,
+            &path,
+            &sa.paragraphs,
+            &sb.paragraphs,
+            opts,
+            0,
+        );
+    }
+
+    compare_styles(
+        &mut collector,
+        &root,
+        &a.doc_info.styles,
+        &b.doc_info.styles,
+    );
+
+    let truncated = collector.truncated;
+    DocumentDiff {
+        identical: collector.findings.is_empty() && !truncated,
+        findings: collector.findings,
+        truncated,
+    }
+}
+
+/// 차이를 모으는 그릇 — 상한 관리와 `truncated` 표시를 한곳에 가둔다.
+struct Collector {
+    findings: Vec<Finding>,
+    max: Option<usize>,
+    truncated: bool,
+}
+
+impl Collector {
+    fn new(max: Option<usize>) -> Self {
+        Self {
+            findings: Vec::new(),
+            max,
+            truncated: false,
+        }
+    }
+
+    /// 차이 하나를 기록한다. 상한을 넘으면 **버렸다는 사실을 남기고** 조용히 지나간다.
+    fn push(&mut self, path: &NodePath, kind: FindingKind, detail: String) {
+        if let Some(max) = self.max {
+            if self.findings.len() >= max {
+                self.truncated = true;
+                return;
+            }
+        }
+        self.findings.push(Finding {
+            path: path.clone(),
+            kind,
+            detail,
+        });
+    }
+}
+
+/// 텍스트 비교용 정규화 — `ignore_whitespace` 가 꺼져 있으면 원문을 그대로 빌려준다.
+///
+/// 켜져 있으면 연속 공백을 한 칸으로 접고 양끝 공백을 없앤다. 정렬(문단 짝짓기)과
+/// 텍스트 비교가 **같은 정규화**를 쓰는 것이 중요하다 — 다르면 "짝은 지었는데 다르다"와
+/// "짝을 못 지었다"가 어긋난다.
+fn normalize(text: &str, ignore_whitespace: bool) -> Cow<'_, str> {
+    if !ignore_whitespace {
+        return Cow::Borrowed(text);
+    }
+    let mut out = String::with_capacity(text.len());
+    let mut pending_space = false;
+    for ch in text.chars() {
+        if ch.is_whitespace() {
+            pending_space = !out.is_empty();
+            continue;
+        }
+        if pending_space {
+            out.push(' ');
+            pending_space = false;
+        }
+        out.push(ch);
+    }
+    Cow::Owned(out)
+}
+
+/// 사람이 읽을 미리보기 — 문자 단위로 자르고 잘렸으면 말줄임표를 붙인다.
+fn preview(text: &str) -> String {
+    let mut out: String = text.chars().take(PREVIEW_CHARS).collect();
+    if text.chars().nth(PREVIEW_CHARS).is_some() {
+        out.push('…');
+    }
+    out
+}
+
+/// 문단 목록 정렬의 한 수 — 짝지음/추가/삭제.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AlignOp {
+    /// A 의 `i` 번과 B 의 `j` 번이 같은 문단이다(내용은 다를 수 있다).
+    Pair(usize, usize),
+    /// B 의 `j` 번만 있다.
+    Added(usize),
+    /// A 의 `i` 번만 있다.
+    Removed(usize),
+}
+
+/// 두 문단 목록을 비교한다 — 본문·표 셀 안 어디에서나 같은 규칙을 쓴다.
+fn compare_paragraph_list(
+    collector: &mut Collector,
+    base: &NodePath,
+    a: &[Paragraph],
+    b: &[Paragraph],
+    opts: &DiffOptions,
+    depth: usize,
+) {
+    let keys_a: Vec<Cow<'_, str>> = a
+        .iter()
+        .map(|p| normalize(&p.text, opts.ignore_whitespace))
+        .collect();
+    let keys_b: Vec<Cow<'_, str>> = b
+        .iter()
+        .map(|p| normalize(&p.text, opts.ignore_whitespace))
+        .collect();
+
+    for op in align(&keys_a, &keys_b) {
+        match op {
+            AlignOp::Pair(i, j) => {
+                let path = base.child(PathStep::Paragraph(i));
+                compare_paragraph(collector, &path, &a[i], &b[j], opts, depth);
+            }
+            AlignOp::Added(j) => {
+                // 추가된 문단은 A 에 자리가 없다 — 경로 첨자는 B 기준이다.
+                let path = base.child(PathStep::Paragraph(j));
+                collector.push(
+                    &path,
+                    FindingKind::ParagraphAdded,
+                    format!("B 에만 있는 문단: {:?}", preview(&b[j].text)),
+                );
+            }
+            AlignOp::Removed(i) => {
+                let path = base.child(PathStep::Paragraph(i));
+                collector.push(
+                    &path,
+                    FindingKind::ParagraphRemoved,
+                    format!("A 에만 있는 문단: {:?}", preview(&a[i].text)),
+                );
+            }
+        }
+    }
+}
+
+/// 짝지어진 문단 하나를 비교한다 — 텍스트·문단모양·컨트롤.
+fn compare_paragraph(
+    collector: &mut Collector,
+    path: &NodePath,
+    a: &Paragraph,
+    b: &Paragraph,
+    opts: &DiffOptions,
+    depth: usize,
+) {
+    if normalize(&a.text, opts.ignore_whitespace) != normalize(&b.text, opts.ignore_whitespace) {
+        collector.push(
+            path,
+            FindingKind::TextChanged,
+            format!("A={:?} B={:?}", preview(&a.text), preview(&b.text)),
+        );
+    }
+
+    if a.para_shape_id != b.para_shape_id || a.style_id != b.style_id {
+        collector.push(
+            path,
+            FindingKind::ParagraphStyleChanged,
+            format!(
+                "para_shape_id: A={} B={}, style_id: A={} B={}",
+                a.para_shape_id, b.para_shape_id, a.style_id, b.style_id
+            ),
+        );
+    }
+
+    if a.controls.len() != b.controls.len() {
+        collector.push(
+            path,
+            FindingKind::ControlCountChanged,
+            format!("컨트롤 수: A={} B={}", a.controls.len(), b.controls.len()),
+        );
+    }
+
+    for (k, (ca, cb)) in a.controls.iter().zip(b.controls.iter()).enumerate() {
+        let ctrl_path = path.child(PathStep::Control(k));
+        let (label_a, label_b) = (control_label(ca), control_label(cb));
+        if label_a != label_b {
+            collector.push(
+                &ctrl_path,
+                FindingKind::ControlKindChanged,
+                format!("컨트롤 종류: A={} B={}", label_a, label_b),
+            );
+            continue;
+        }
+        if let (Control::Table(ta), Control::Table(tb)) = (ca, cb) {
+            compare_table(collector, &ctrl_path, ta, tb, opts, depth);
+        }
+    }
+}
+
+/// 표 하나를 비교한다 — 행렬 모양, 셀 병합, 그리고 셀 안 문단.
+fn compare_table(
+    collector: &mut Collector,
+    path: &NodePath,
+    a: &Table,
+    b: &Table,
+    opts: &DiffOptions,
+    depth: usize,
+) {
+    if a.row_count != b.row_count || a.col_count != b.col_count {
+        collector.push(
+            path,
+            FindingKind::TableShapeChanged,
+            format!(
+                "행렬: A={}x{} B={}x{}",
+                a.row_count, a.col_count, b.row_count, b.col_count
+            ),
+        );
+    }
+    if a.cells.len() != b.cells.len() {
+        collector.push(
+            path,
+            FindingKind::TableShapeChanged,
+            format!("셀 수: A={} B={}", a.cells.len(), b.cells.len()),
+        );
+    }
+
+    // 깊이 상한을 넘으면 셀 안으로는 들어가지 않는다. 표 자체의 모양 차이는 위에서
+    // 이미 보고했으므로 여기서 멈춰도 "차이 없음"으로 오인되지 않는다.
+    if depth >= MAX_DEPTH {
+        return;
+    }
+
+    for (ca, cb) in a.cells.iter().zip(b.cells.iter()) {
+        let cell_path = path.child(PathStep::TableCell {
+            row: ca.row,
+            col: ca.col,
+        });
+        if ca.row != cb.row || ca.col != cb.col {
+            collector.push(
+                &cell_path,
+                FindingKind::TableShapeChanged,
+                format!(
+                    "셀 주소: A=(r{},c{}) B=(r{},c{})",
+                    ca.row, ca.col, cb.row, cb.col
+                ),
+            );
+        }
+        if ca.row_span != cb.row_span || ca.col_span != cb.col_span {
+            collector.push(
+                &cell_path,
+                FindingKind::TableShapeChanged,
+                format!(
+                    "셀 병합: A={}x{} B={}x{}",
+                    ca.row_span, ca.col_span, cb.row_span, cb.col_span
+                ),
+            );
+        }
+        compare_paragraph_list(
+            collector,
+            &cell_path,
+            &ca.paragraphs,
+            &cb.paragraphs,
+            opts,
+            depth + 1,
+        );
+    }
+}
+
+/// 문서 정보의 스타일 목록을 비교한다.
+///
+/// 스타일 본문(문단모양·글자모양의 모든 필드)까지 파고들지 않는다 — 여기서 보는 것은
+/// **문단이 가리키는 이름표가 달라졌는가**다. 필드 단위 충실도는 왕복 게이트의 몫이다.
+fn compare_styles(collector: &mut Collector, root: &NodePath, a: &[Style], b: &[Style]) {
+    if a.len() != b.len() {
+        collector.push(
+            root,
+            FindingKind::StyleCountChanged,
+            format!("스타일 수: A={} B={}", a.len(), b.len()),
+        );
+    }
+
+    for (i, (sa, sb)) in a.iter().zip(b.iter()).enumerate() {
+        let mut parts: Vec<String> = Vec::new();
+        if sa.local_name != sb.local_name {
+            parts.push(format!(
+                "이름: A={:?} B={:?}",
+                preview(&sa.local_name),
+                preview(&sb.local_name)
+            ));
+        }
+        if sa.english_name != sb.english_name {
+            parts.push(format!(
+                "영문이름: A={:?} B={:?}",
+                preview(&sa.english_name),
+                preview(&sb.english_name)
+            ));
+        }
+        if sa.style_type != sb.style_type {
+            parts.push(format!("종류: A={} B={}", sa.style_type, sb.style_type));
+        }
+        if sa.para_shape_id != sb.para_shape_id {
+            parts.push(format!(
+                "para_shape_id: A={} B={}",
+                sa.para_shape_id, sb.para_shape_id
+            ));
+        }
+        if sa.char_shape_id != sb.char_shape_id {
+            parts.push(format!(
+                "char_shape_id: A={} B={}",
+                sa.char_shape_id, sb.char_shape_id
+            ));
+        }
+        if !parts.is_empty() {
+            collector.push(
+                &root.child(PathStep::Style(i)),
+                FindingKind::StyleChanged,
+                parts.join("; "),
+            );
+        }
+    }
+}
+
+/// 컨트롤 종류 이름 — 종류가 바뀌었는지 판정하는 단일 출처.
+fn control_label(c: &Control) -> &'static str {
+    match c {
+        Control::SectionDef(_) => "sectionDef",
+        Control::ColumnDef(_) => "columnDef",
+        Control::Table(_) => "table",
+        Control::Shape(_) => "shape",
+        Control::Picture(_) => "picture",
+        Control::Header(_) => "header",
+        Control::Footer(_) => "footer",
+        Control::Footnote(_) => "footnote",
+        Control::Endnote(_) => "endnote",
+        Control::AutoNumber(_) => "autoNumber",
+        Control::NewNumber(_) => "newNumber",
+        Control::PageNumberPos(_) => "pageNumberPos",
+        Control::Bookmark(_) => "bookmark",
+        Control::IndexMark(_) => "indexMark",
+        Control::PageNumCtrl(_) => "pageNumCtrl",
+        Control::Hyperlink(_) => "hyperlink",
+        Control::Ruby(_) => "ruby",
+        Control::CharOverlap(_) => "charOverlap",
+        Control::PageHide(_) => "pageHide",
+        Control::HiddenComment(_) => "hiddenComment",
+        Control::Equation(_) => "equation",
+        Control::Field(_) => "field",
+        Control::Form(_) => "form",
+        Control::Unknown(_) => "unknown",
+    }
+}
+
+/// 두 키 목록을 정렬해 짝지음/추가/삭제의 수순을 낸다.
+///
+/// 공통 앞·뒤를 먼저 깎아내는 것이 요점이다 — 실제 회귀 검증에서 두 문서는 거의
+/// 같으므로, LCS 를 돌려야 하는 "가운데"는 대개 몇 줄뿐이다.
+fn align(a: &[Cow<'_, str>], b: &[Cow<'_, str>]) -> Vec<AlignOp> {
+    let mut ops = Vec::with_capacity(a.len().max(b.len()));
+
+    let max_prefix = a.len().min(b.len());
+    let mut prefix = 0;
+    while prefix < max_prefix && a[prefix] == b[prefix] {
+        prefix += 1;
+    }
+
+    let max_suffix = max_prefix - prefix;
+    let mut suffix = 0;
+    while suffix < max_suffix && a[a.len() - 1 - suffix] == b[b.len() - 1 - suffix] {
+        suffix += 1;
+    }
+
+    for i in 0..prefix {
+        ops.push(AlignOp::Pair(i, i));
+    }
+
+    let mid_a = &a[prefix..a.len() - suffix];
+    let mid_b = &b[prefix..b.len() - suffix];
+    ops.extend(align_middle(mid_a, mid_b, prefix, prefix));
+
+    for k in 0..suffix {
+        ops.push(AlignOp::Pair(a.len() - suffix + k, b.len() - suffix + k));
+    }
+
+    ops
+}
+
+/// 공통 앞뒤를 깎아낸 "가운데"만 정렬한다. `off_a`/`off_b` 는 원래 목록에서의 시작 첨자.
+fn align_middle(
+    a: &[Cow<'_, str>],
+    b: &[Cow<'_, str>],
+    off_a: usize,
+    off_b: usize,
+) -> Vec<AlignOp> {
+    if a.is_empty() && b.is_empty() {
+        return Vec::new();
+    }
+    if a.is_empty() {
+        return (0..b.len()).map(|j| AlignOp::Added(off_b + j)).collect();
+    }
+    if b.is_empty() {
+        return (0..a.len()).map(|i| AlignOp::Removed(off_a + i)).collect();
+    }
+
+    let raw = if (a.len() + 1).saturating_mul(b.len() + 1) > LCS_CELL_BUDGET {
+        positional_ops(a.len(), b.len(), off_a, off_b)
+    } else {
+        lcs_ops(a, b, off_a, off_b)
+    };
+    pair_adjacent(raw)
+}
+
+/// LCS 를 감당 못 할 만큼 큰 덩어리의 대비책 — 자리끼리 맞대고 남는 꼬리를 추가·삭제로.
+fn positional_ops(len_a: usize, len_b: usize, off_a: usize, off_b: usize) -> Vec<AlignOp> {
+    let pairs = len_a.min(len_b);
+    let mut ops: Vec<AlignOp> = (0..pairs)
+        .map(|k| AlignOp::Pair(off_a + k, off_b + k))
+        .collect();
+    ops.extend((pairs..len_a).map(|i| AlignOp::Removed(off_a + i)));
+    ops.extend((pairs..len_b).map(|j| AlignOp::Added(off_b + j)));
+    ops
+}
+
+/// 최장 공통 부분수열로 짝을 짓는다.
+///
+/// 되짚기는 갈림길에서 **삭제를 먼저** 고른다(`>=`). 이 한 줄이 결과 순서의 결정성을
+/// 보장한다 — 같은 길이의 답이 여럿일 때 언제나 같은 답을 고르기 때문이다.
+fn lcs_ops(a: &[Cow<'_, str>], b: &[Cow<'_, str>], off_a: usize, off_b: usize) -> Vec<AlignOp> {
+    let n = a.len();
+    let m = b.len();
+    let stride = m + 1;
+    let mut dp = vec![0u32; (n + 1) * stride];
+
+    for i in (0..n).rev() {
+        for j in (0..m).rev() {
+            dp[i * stride + j] = if a[i] == b[j] {
+                dp[(i + 1) * stride + j + 1] + 1
+            } else {
+                dp[(i + 1) * stride + j].max(dp[i * stride + j + 1])
+            };
+        }
+    }
+
+    let mut ops = Vec::with_capacity(n.max(m));
+    let (mut i, mut j) = (0usize, 0usize);
+    while i < n && j < m {
+        if a[i] == b[j] {
+            ops.push(AlignOp::Pair(off_a + i, off_b + j));
+            i += 1;
+            j += 1;
+        } else if dp[(i + 1) * stride + j] >= dp[i * stride + j + 1] {
+            ops.push(AlignOp::Removed(off_a + i));
+            i += 1;
+        } else {
+            ops.push(AlignOp::Added(off_b + j));
+            j += 1;
+        }
+    }
+    ops.extend((i..n).map(|i| AlignOp::Removed(off_a + i)));
+    ops.extend((j..m).map(|j| AlignOp::Added(off_b + j)));
+    ops
+}
+
+/// 맞닿은 삭제 덩어리와 추가 덩어리를 짝지어 "바뀐 문단"으로 승격시킨다.
+///
+/// LCS 만으로는 한 글자 고친 문단이 `Removed` + `Added` 두 건으로 나온다. 사람이
+/// 보기엔 그건 **수정**이다. 앞뒤로 맞닿은 두 덩어리를 앞에서부터 짝지어 `Pair` 로
+/// 바꾸고, 남는 쪽만 순수 추가·삭제로 남긴다.
+fn pair_adjacent(raw: Vec<AlignOp>) -> Vec<AlignOp> {
+    let mut out = Vec::with_capacity(raw.len());
+    let mut idx = 0;
+    while idx < raw.len() {
+        if !matches!(raw[idx], AlignOp::Removed(_)) {
+            out.push(raw[idx]);
+            idx += 1;
+            continue;
+        }
+
+        let mut removed = Vec::new();
+        while let Some(AlignOp::Removed(i)) = raw.get(idx) {
+            removed.push(*i);
+            idx += 1;
+        }
+        let mut added = Vec::new();
+        while let Some(AlignOp::Added(j)) = raw.get(idx) {
+            added.push(*j);
+            idx += 1;
+        }
+
+        let paired = removed.len().min(added.len());
+        for k in 0..paired {
+            out.push(AlignOp::Pair(removed[k], added[k]));
+        }
+        out.extend(removed.iter().skip(paired).map(|i| AlignOp::Removed(*i)));
+        out.extend(added.iter().skip(paired).map(|j| AlignOp::Added(*j)));
+    }
+    out
+}

--- a/src/docdiff/mod.rs
+++ b/src/docdiff/mod.rs
@@ -1,0 +1,587 @@
+//! `docdiff` — 두 문서 IR 의 **의미 차이**를 계산하는 재사용 엔진.
+//!
+//! 회귀 검증도, 왕복 시험도, 편집 전후 확인도 결국 같은 질문 하나를 던진다:
+//! *"두 문서가 어떻게 다른가."* 그 답을 **라이브러리로 부를 수 있게** 만든 것이 이
+//! 모듈이다. 입력은 이미 파싱된 [`Document`](crate::model::document::Document) 이고
+//! (이 모듈은 파일을 열지 않는다), 출력은 좌표가 붙은 [`Finding`] 목록이다.
+//!
+//! ```
+//! use rhwp::docdiff::{diff_documents, DiffOptions, FindingKind};
+//! use rhwp::model::document::{Document, Section};
+//! use rhwp::model::paragraph::Paragraph;
+//!
+//! let mut a = Document::default();
+//! a.sections.push(Section {
+//!     paragraphs: vec![Paragraph { text: "계약서".into(), ..Default::default() }],
+//!     ..Default::default()
+//! });
+//! let mut b = a.clone();
+//! b.sections[0].paragraphs[0].text = "계약서(안)".into();
+//!
+//! let diff = diff_documents(&a, &b, &DiffOptions::default());
+//! assert!(!diff.identical);
+//! assert_eq!(diff.findings[0].kind, FindingKind::TextChanged);
+//! assert_eq!(diff.findings[0].path.to_string(), "sec[0]/para[0]");
+//! ```
+//!
+//! # 기존 `ir-diff` 와의 경계
+//!
+//! 저장소에는 이미 문서를 맞대 보는 장치가 둘 있다. 이 모듈은 **셋째 장치가 아니라
+//! 한 단계 위의 층**이다.
+//!
+//! | | 무엇을 묻나 | 어디에 사는가 |
+//! |---|---|---|
+//! | [`crate::serializer::hwpx::roundtrip::diff_documents`] | *저장했다 다시 읽었을 때 원본이 그대로 살아 있나* — 글자모양 시퀀스, `line_segs` 9 필드, 용지·여백, 캡션, 그림 크기 | 라이브러리 (재사용 가능) |
+//! | `rhwp ir-diff` (CLI) | *두 파일의 IR 필드가 다른가* — 위의 것 + 본문 텍스트·`char_offsets`·탭·`ParaShape`·`TabDef` | `src/main.rs` 안의 비공개 함수 |
+//! | **`docdiff` (이 모듈)** | *사람이 보기에 문서가 어떻게 달라졌나* — 문단이 늘었나 줄었나, 어느 문단 글이 바뀌었나, 표 모양이 바뀌었나 | 라이브러리 |
+//!
+//! 셋의 차이는 **충실도(fidelity)와 의미(semantics)** 의 차이다. 앞의 둘은 "한 비트도
+//! 잃지 않았나"를 묻는 저장기 게이트라서, 문단 하나가 앞에 끼어들면 뒤따르는 문단
+//! 전부를 "달라졌다"로 보고한다(둘 다 `a[i]` 대 `b[i]` 로 자리끼리 맞댄다). 편집·변환
+//! 결과를 사람이나 에이전트에게 설명하는 자리에서는 그 잡음이 곧 쓸모없음이다.
+//!
+//! 그래서 이 모듈은 다르게 한다.
+//!
+//! - **정렬한다.** 문단 목록을 LCS 로 짝지어 삽입·삭제를 삽입·삭제로 본다. 한 문단
+//!   삽입은 `ParagraphAdded` 1 건이지 뒤 문단 전부의 `TextChanged` 가 아니다.
+//! - **좌표를 타입으로 준다.** `path: String` 이 아니라 [`NodePath`] 다. 소비자가
+//!   문자열을 파싱하지 않고 구역 번호를 꺼낼 수 있다.
+//! - **결과가 값이다.** 앞의 둘은 화면에 줄을 뿌리거나(`ir-diff`) 문자열 `detail` 을
+//!   쌓는다. `ir-diff --json` 의 카테고리 집계마저 **출력 문자열의 앞부분을 되파싱해**
+//!   만든다(`src/main.rs` 의 `IrDiffEmitter`). 여기서는 [`FindingKind`] 가 처음부터
+//!   타입이고 [`DiffSummary`] 가 그것을 센다.
+//! - **상한을 밝힌다.** 잘렸으면 [`DocumentDiff::truncated`] 로 말한다.
+//!
+//! 그러므로 둘 다 필요하다. 저장기 회귀는 여전히 충실도 게이트가 지켜야 하고
+//! (한 비트라도 잃으면 실패여야 한다), 사람·에이전트에게 내보이는 "무엇이 바뀌었나"는
+//! 이 엔진이 답한다.
+//!
+//! # 비범위
+//!
+//! - **파싱하지 않는다.** 입력은 `Document` IR 이다.
+//! - **렌더 좌표를 보지 않는다.** 화면 위 픽셀 변위는
+//!   [`crate::diagnostics::render_geom_diff`] 의 몫이다.
+//! - **직렬화 충실도를 재지 않는다.** `line_segs`·`char_shapes`·원본 바이트 보존은
+//!   왕복 게이트가 본다.
+//! - **글상자·각주·머리말 안으로는 아직 들어가지 않는다.** 표 셀까지만 재귀한다.
+//!   컨트롤 개수·종류 차이는 잡히므로 손실이 조용히 통과하지는 않는다.
+//! - **`main.rs` 를 고치지 않는다.** `ir-diff` 를 이 엔진 위로 옮기는 것은 후속 작업이다.
+
+mod compare;
+mod model;
+mod summary;
+
+pub use compare::diff_documents;
+pub use model::{DiffOptions, DiffSummary, DocumentDiff, Finding, FindingKind, NodePath, PathStep};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::control::Control;
+    use crate::model::document::{Document, Section};
+    use crate::model::paragraph::Paragraph;
+    use crate::model::style::Style;
+    use crate::model::table::{Cell, Table};
+
+    /// 텍스트만 채운 문단.
+    fn para(text: &str) -> Paragraph {
+        Paragraph {
+            text: text.to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// 구역별 문단 텍스트 목록으로 문서를 짓는다.
+    fn doc(sections: &[&[&str]]) -> Document {
+        Document {
+            sections: sections
+                .iter()
+                .map(|texts| Section {
+                    paragraphs: texts.iter().map(|t| para(t)).collect(),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    /// 행렬 크기와 셀별 텍스트로 표 컨트롤 하나를 품은 문단을 짓는다.
+    fn para_with_table(rows: u16, cols: u16, cell_texts: &[&str]) -> Paragraph {
+        let stride = cols.max(1);
+        let cells = cell_texts
+            .iter()
+            .enumerate()
+            .map(|(idx, text)| Cell {
+                row: (idx as u16) / stride,
+                col: (idx as u16) % stride,
+                row_span: 1,
+                col_span: 1,
+                paragraphs: vec![para(text)],
+                ..Default::default()
+            })
+            .collect();
+        Paragraph {
+            controls: vec![Control::Table(Box::new(Table {
+                row_count: rows,
+                col_count: cols,
+                cells,
+                ..Default::default()
+            }))],
+            ..Default::default()
+        }
+    }
+
+    fn kinds(diff: &DocumentDiff) -> Vec<FindingKind> {
+        diff.findings.iter().map(|f| f.kind).collect()
+    }
+
+    fn paths(diff: &DocumentDiff) -> Vec<String> {
+        diff.findings.iter().map(|f| f.path.to_string()).collect()
+    }
+
+    /// 같은 문서를 맞대면 `identical` 이고 차이가 하나도 없다.
+    #[test]
+    fn identical_documents_report_no_findings() {
+        let a = doc(&[&["첫 문단", "둘째 문단", "셋째 문단"]]);
+        let b = a.clone();
+        let diff = diff_documents(&a, &b, &DiffOptions::default());
+
+        assert!(diff.identical);
+        assert!(diff.findings.is_empty());
+        assert!(!diff.truncated);
+        assert_eq!(diff.summary().total, 0);
+    }
+
+    /// 빈 문서 대 빈 문서 — 구역이 아예 없어도, 빈 구역만 있어도 차이가 없다.
+    #[test]
+    fn empty_documents_are_identical() {
+        let diff = diff_documents(
+            &Document::default(),
+            &Document::default(),
+            &DiffOptions::default(),
+        );
+        assert!(diff.identical);
+        assert!(diff.findings.is_empty());
+        assert!(!diff.truncated);
+
+        let diff2 = diff_documents(&doc(&[&[]]), &doc(&[&[]]), &DiffOptions::default());
+        assert!(diff2.identical);
+    }
+
+    /// 문단 텍스트 한 글자 변경 — `TextChanged` 한 건이고 좌표가 그 문단을 짚는다.
+    #[test]
+    fn single_character_edit_is_one_text_change() {
+        let a = doc(&[&["계약서", "제1조 목적", "제2조 범위"]]);
+        let b = doc(&[&["계약서", "제1조 목적", "제2조 범위!"]]);
+        let diff = diff_documents(&a, &b, &DiffOptions::default());
+
+        assert!(!diff.identical);
+        assert_eq!(kinds(&diff), vec![FindingKind::TextChanged]);
+        assert_eq!(paths(&diff), vec!["sec[0]/para[2]"]);
+        assert!(diff.findings[0].detail.contains("제2조 범위"));
+    }
+
+    /// 가운데 문단 추가 — 정렬 덕분에 뒤따르는 문단이 오염되지 않는다.
+    #[test]
+    fn inserted_paragraph_does_not_cascade() {
+        let a = doc(&[&["가", "나", "다"]]);
+        let b = doc(&[&["가", "새 문단", "나", "다"]]);
+        let diff = diff_documents(&a, &b, &DiffOptions::default());
+
+        // 자리끼리 맞대는 방식이라면 3 건(나→새 문단, 다→나, 없음→다)이 났을 것이다.
+        assert_eq!(kinds(&diff), vec![FindingKind::ParagraphAdded]);
+        assert_eq!(paths(&diff), vec!["sec[0]/para[1]"]);
+        assert!(diff.findings[0].detail.contains("새 문단"));
+    }
+
+    /// 가운데 문단 삭제 — `ParagraphRemoved` 한 건.
+    #[test]
+    fn removed_paragraph_is_reported_once() {
+        let a = doc(&[&["가", "나", "다", "라"]]);
+        let b = doc(&[&["가", "다", "라"]]);
+        let diff = diff_documents(&a, &b, &DiffOptions::default());
+
+        assert_eq!(kinds(&diff), vec![FindingKind::ParagraphRemoved]);
+        assert_eq!(paths(&diff), vec!["sec[0]/para[1]"]);
+        assert!(diff.findings[0].detail.contains('나'));
+    }
+
+    /// 구역 수 변화 — 문서 뿌리 좌표에서 보고한다.
+    #[test]
+    fn section_count_change_is_reported_at_root() {
+        let a = doc(&[&["가"]]);
+        let b = doc(&[&["가"], &["나"]]);
+        let diff = diff_documents(&a, &b, &DiffOptions::default());
+
+        assert_eq!(kinds(&diff), vec![FindingKind::SectionCountChanged]);
+        assert_eq!(paths(&diff), vec!["doc"]);
+        assert!(diff.findings[0].detail.contains("A=1 B=2"));
+    }
+
+    /// 표 행렬 변화 — 행·열 수와 셀 수를 각각 짚는다.
+    #[test]
+    fn table_shape_change_is_detected() {
+        let mut a = doc(&[&[]]);
+        a.sections[0]
+            .paragraphs
+            .push(para_with_table(2, 2, &["A1", "A2", "B1", "B2"]));
+        let mut b = doc(&[&[]]);
+        b.sections[0]
+            .paragraphs
+            .push(para_with_table(3, 2, &["A1", "A2", "B1", "B2", "C1", "C2"]));
+
+        let diff = diff_documents(&a, &b, &DiffOptions::default());
+
+        assert_eq!(
+            kinds(&diff),
+            vec![
+                FindingKind::TableShapeChanged,
+                FindingKind::TableShapeChanged,
+            ]
+        );
+        assert_eq!(diff.findings[0].path.to_string(), "sec[0]/para[0]/ctrl[0]");
+        assert!(diff.findings[0].detail.contains("A=2x2 B=3x2"));
+        assert!(diff.findings[1].detail.contains("셀 수: A=4 B=6"));
+    }
+
+    /// 표 셀 안 텍스트 변경 — 좌표가 행·열까지 내려간다.
+    #[test]
+    fn table_cell_text_change_carries_cell_coordinates() {
+        let mut a = doc(&[&[]]);
+        a.sections[0]
+            .paragraphs
+            .push(para_with_table(2, 2, &["A1", "A2", "B1", "B2"]));
+        let mut b = doc(&[&[]]);
+        b.sections[0]
+            .paragraphs
+            .push(para_with_table(2, 2, &["A1", "A2", "B1", "바뀜"]));
+
+        let diff = diff_documents(&a, &b, &DiffOptions::default());
+
+        assert_eq!(kinds(&diff), vec![FindingKind::TextChanged]);
+        assert_eq!(
+            paths(&diff),
+            vec!["sec[0]/para[0]/ctrl[0]/cell[r1,c1]/para[0]"]
+        );
+        // 좌표에서 구역·문단을 문자열 파싱 없이 꺼낼 수 있어야 한다.
+        assert_eq!(diff.findings[0].path.section(), Some(0));
+        assert_eq!(diff.findings[0].path.paragraph(), Some(0));
+    }
+
+    /// 컨트롤 개수·종류 변화.
+    #[test]
+    fn control_count_and_kind_changes_are_detected() {
+        let mut a = doc(&[&[]]);
+        a.sections[0].paragraphs.push(Paragraph {
+            controls: vec![Control::Bookmark(Default::default())],
+            ..Default::default()
+        });
+        let mut b = doc(&[&[]]);
+        b.sections[0].paragraphs.push(Paragraph {
+            controls: vec![
+                Control::PageHide(Default::default()),
+                Control::Bookmark(Default::default()),
+            ],
+            ..Default::default()
+        });
+
+        let diff = diff_documents(&a, &b, &DiffOptions::default());
+
+        assert_eq!(
+            kinds(&diff),
+            vec![
+                FindingKind::ControlCountChanged,
+                FindingKind::ControlKindChanged,
+            ]
+        );
+        assert_eq!(paths(&diff)[1], "sec[0]/para[0]/ctrl[0]");
+        assert!(diff.findings[1].detail.contains("A=bookmark B=pageHide"));
+    }
+
+    /// 문서 정보의 스타일 개수·정의 변화.
+    #[test]
+    fn style_count_and_definition_changes_are_detected() {
+        let mut a = Document::default();
+        a.doc_info.styles.push(Style {
+            local_name: "바탕글".into(),
+            para_shape_id: 0,
+            ..Default::default()
+        });
+        let mut b = a.clone();
+        b.doc_info.styles[0].para_shape_id = 7;
+        b.doc_info.styles.push(Style {
+            local_name: "제목".into(),
+            ..Default::default()
+        });
+
+        let diff = diff_documents(&a, &b, &DiffOptions::default());
+
+        assert_eq!(
+            kinds(&diff),
+            vec![FindingKind::StyleCountChanged, FindingKind::StyleChanged]
+        );
+        assert_eq!(paths(&diff), vec!["doc", "style[0]"]);
+        assert!(diff.findings[1].detail.contains("para_shape_id: A=0 B=7"));
+        assert_eq!(diff.findings[1].path.section(), None);
+    }
+
+    /// 결정성 — 같은 두 문서는 몇 번을 돌려도 완전히 같은 결과·같은 순서다.
+    #[test]
+    fn same_input_always_yields_same_output() {
+        let mut a = doc(&[&["가", "나", "다", "라", "마"], &["별첨"]]);
+        let mut b = doc(&[&["가", "낫", "다", "새 줄", "라", "마"], &["별첨2"]]);
+        a.sections[0]
+            .paragraphs
+            .push(para_with_table(2, 2, &["A1", "A2", "B1", "B2"]));
+        b.sections[0]
+            .paragraphs
+            .push(para_with_table(2, 2, &["A1", "A2", "B1", "달라짐"]));
+        a.doc_info.styles.push(Style::default());
+        b.doc_info.styles.push(Style {
+            style_type: 1,
+            ..Default::default()
+        });
+
+        let opts = DiffOptions::default();
+        let first = diff_documents(&a, &b, &opts);
+        let second = diff_documents(&a, &b, &opts);
+
+        assert_eq!(first, second, "같은 두 문서는 같은 결과·같은 순서여야 한다");
+        assert_eq!(first.summary(), second.summary());
+        for _ in 0..10 {
+            assert_eq!(diff_documents(&a, &b, &opts), first);
+        }
+        assert!(!first.identical);
+    }
+
+    /// 상한을 넘기면 조용히 자르지 않고 `truncated` 로 밝힌다.
+    #[test]
+    fn exceeding_max_findings_sets_truncated() {
+        let a = doc(&[&["가", "나", "다", "라", "마"]]);
+        let b = doc(&[&["가1", "나1", "다1", "라1", "마1"]]);
+
+        let full = diff_documents(&a, &b, &DiffOptions::default());
+        assert_eq!(full.findings.len(), 5);
+        assert!(!full.truncated);
+
+        let capped = diff_documents(&a, &b, &DiffOptions::default().max_findings(2));
+        assert_eq!(capped.findings.len(), 2);
+        assert!(capped.truncated, "버린 차이가 있으면 반드시 밝힌다");
+        assert!(!capped.identical);
+        // 잘린 앞 2 건은 무제한 결과의 앞 2 건과 같아야 한다(결정성).
+        assert_eq!(capped.findings, full.findings[..2].to_vec());
+        assert!(capped.summary().truncated);
+    }
+
+    /// 상한 0 — 차이를 전부 버려도 `identical` 로 거짓말하지 않는다.
+    #[test]
+    fn zero_max_findings_never_claims_identical() {
+        let a = doc(&[&["가"]]);
+        let b = doc(&[&["나"]]);
+        let diff = diff_documents(&a, &b, &DiffOptions::default().max_findings(0));
+
+        assert!(diff.findings.is_empty());
+        assert!(diff.truncated);
+        assert!(
+            !diff.identical,
+            "차이를 전부 버렸다고 '같다'가 되면 게이트가 무너진다"
+        );
+
+        // 반대로 정말 같은 문서는 상한 0 이어도 identical 이다(버릴 것이 없으므로).
+        let same = diff_documents(&a, &a, &DiffOptions::default().max_findings(0));
+        assert!(same.identical);
+        assert!(!same.truncated);
+    }
+
+    /// 불변식 — `identical == true` 면 `findings` 는 비어 있고 자른 것도 없다.
+    #[test]
+    fn identical_implies_empty_findings_invariant() {
+        let cases: [(Document, Document); 5] = [
+            (doc(&[]), doc(&[])),
+            (doc(&[&[]]), doc(&[&[]])),
+            (doc(&[&["가"]]), doc(&[&["가"]])),
+            (doc(&[&["가"]]), doc(&[&["나"]])),
+            (doc(&[&["가"]]), doc(&[&["가"], &["나"]])),
+        ];
+        for (a, b) in &cases {
+            for opts in [
+                DiffOptions::default(),
+                DiffOptions::default().max_findings(1),
+                DiffOptions::default().max_findings(0),
+                DiffOptions::default().ignore_whitespace(true),
+            ] {
+                let diff = diff_documents(a, b, &opts);
+                if diff.identical {
+                    assert!(diff.findings.is_empty(), "불변식: identical → 차이 없음");
+                    assert!(!diff.truncated, "불변식: identical → 자른 것 없음");
+                }
+                assert_eq!(diff.summary().total, diff.findings.len());
+            }
+        }
+    }
+
+    /// 요약 집계 — 카테고리별 건수·총계·순서가 정확하다.
+    #[test]
+    fn summary_counts_each_category_exactly() {
+        let a = doc(&[&["머리말", "가", "나", "다", "지울 줄", "꼬리말"]]);
+        let b = doc(&[&["머리말", "가!", "나!", "다", "넣을 줄", "꼬리말"]]);
+        let diff = diff_documents(&a, &b, &DiffOptions::default());
+        let summary = diff.summary();
+
+        assert_eq!(summary.total, diff.findings.len());
+        assert_eq!(summary.count_of(FindingKind::TextChanged), 3);
+        assert_eq!(summary.count_of(FindingKind::ParagraphAdded), 0);
+        assert_eq!(summary.count_of(FindingKind::ParagraphRemoved), 0);
+        assert_eq!(summary.count_of(FindingKind::SectionCountChanged), 0);
+        assert!(!summary.truncated);
+
+        // 합이 총계와 맞고, 0 건 카테고리는 목록에 없다.
+        assert_eq!(
+            summary.by_kind.iter().map(|(_, n)| *n).sum::<usize>(),
+            summary.total
+        );
+        assert!(summary.by_kind.iter().all(|(_, n)| *n > 0));
+
+        // 순서는 FindingKind 선언 순서 — 해시 순회에 기대지 않는다.
+        let declared: Vec<_> = FindingKind::ALL
+            .iter()
+            .filter(|k| summary.count_of(**k) > 0)
+            .copied()
+            .collect();
+        assert_eq!(
+            summary.by_kind.iter().map(|(k, _)| *k).collect::<Vec<_>>(),
+            declared
+        );
+    }
+
+    /// 꼬리에 문단이 붙으면 추가로만 센다.
+    #[test]
+    fn summary_separates_added_from_removed() {
+        let a = doc(&[&["가", "나", "다"]]);
+        let b = doc(&[&["가", "나", "다", "라", "마"]]);
+        let summary = diff_documents(&a, &b, &DiffOptions::default()).summary();
+
+        assert_eq!(summary.count_of(FindingKind::ParagraphAdded), 2);
+        assert_eq!(summary.count_of(FindingKind::ParagraphRemoved), 0);
+        assert_eq!(summary.total, 2);
+    }
+
+    /// 공백 무시 옵션 — 들여쓰기 차이는 삼키되 글자 차이는 계속 잡는다.
+    #[test]
+    fn ignore_whitespace_swallows_indentation_only() {
+        let a = doc(&[&["  제1조   목적  ", "제2조"]]);
+        let b = doc(&[&["제1조 목적", "제2조"]]);
+
+        let strict = diff_documents(&a, &b, &DiffOptions::default());
+        assert_eq!(kinds(&strict), vec![FindingKind::TextChanged]);
+
+        let lenient = diff_documents(&a, &b, &DiffOptions::default().ignore_whitespace(true));
+        assert!(lenient.identical, "공백만 다르면 차이가 아니다");
+
+        let c = doc(&[&["제1조  범위", "제2조"]]);
+        let still = diff_documents(&a, &c, &DiffOptions::default().ignore_whitespace(true));
+        assert_eq!(kinds(&still), vec![FindingKind::TextChanged]);
+    }
+
+    /// 텍스트가 같아도 문단모양 참조가 바뀌면 잡는다.
+    #[test]
+    fn paragraph_shape_change_is_detected_without_text_change() {
+        let a = doc(&[&["같은 글"]]);
+        let mut b = a.clone();
+        b.sections[0].paragraphs[0].para_shape_id = 3;
+
+        let diff = diff_documents(&a, &b, &DiffOptions::default());
+
+        assert_eq!(kinds(&diff), vec![FindingKind::ParagraphStyleChanged]);
+        assert_eq!(paths(&diff), vec!["sec[0]/para[0]"]);
+        assert!(diff.findings[0].detail.contains("para_shape_id: A=0 B=3"));
+    }
+
+    /// 좌표는 타입이다 — 문자열을 파싱하지 않고 구역·문단을 꺼낸다.
+    #[test]
+    fn node_path_is_readable_without_string_parsing() {
+        let a = doc(&[&["가"], &["나", "다"]]);
+        let b = doc(&[&["가"], &["나", "라"]]);
+        let diff = diff_documents(&a, &b, &DiffOptions::default());
+
+        let path = &diff.findings[0].path;
+        assert_eq!(path.to_string(), "sec[1]/para[1]");
+        assert_eq!(path.section(), Some(1));
+        assert_eq!(path.paragraph(), Some(1));
+        assert!(!path.is_root());
+        assert_eq!(
+            path.steps(),
+            &[PathStep::Section(1), PathStep::Paragraph(1)]
+        );
+        assert!(NodePath::root().is_root());
+        assert_eq!(NodePath::root().to_string(), "doc");
+    }
+
+    /// 직렬화 계층 — 봉투 JSON 의 키·값이 계약대로이고 문자열까지 결정적이다.
+    #[test]
+    fn json_envelope_is_stable() {
+        let a = doc(&[&["가", "나"]]);
+        let b = doc(&[&["가", "낫", "다"]]);
+        let diff = diff_documents(&a, &b, &DiffOptions::default());
+
+        let json = diff.to_json();
+        assert_eq!(json["identical"], serde_json::json!(false));
+        assert_eq!(json["truncated"], serde_json::json!(false));
+        assert_eq!(json["findingCount"], serde_json::json!(2));
+        assert_eq!(
+            json["findings"][0]["kind"],
+            serde_json::json!("textChanged")
+        );
+        assert_eq!(
+            json["findings"][0]["path"],
+            serde_json::json!("sec[0]/para[1]")
+        );
+        assert_eq!(
+            json["summary"]["byKind"]["textChanged"],
+            serde_json::json!(1)
+        );
+        assert_eq!(
+            json["summary"]["byKind"]["paragraphAdded"],
+            serde_json::json!(1)
+        );
+
+        let once = serde_json::to_string(&diff.to_json()).unwrap();
+        let twice =
+            serde_json::to_string(&diff_documents(&a, &b, &DiffOptions::default()).to_json())
+                .unwrap();
+        assert_eq!(once, twice);
+    }
+
+    /// 카테고리 이름은 봉투의 안정 키다 — 겹치거나 비어 있으면 안 된다.
+    #[test]
+    fn finding_kind_labels_are_unique() {
+        let mut seen: Vec<&str> = FindingKind::ALL.iter().map(|k| k.label()).collect();
+        assert_eq!(seen.len(), FindingKind::ALL.len());
+        seen.sort_unstable();
+        seen.dedup();
+        assert_eq!(seen.len(), FindingKind::ALL.len(), "이름이 겹치면 안 된다");
+        assert!(FindingKind::ALL.iter().all(|k| !k.label().is_empty()));
+        assert_eq!(FindingKind::TextChanged.to_string(), "textChanged");
+    }
+
+    /// 큰 문서 맨 앞에 한 문단을 끼워도 차이는 한 건뿐이다.
+    #[test]
+    fn head_insertion_in_large_document_stays_one_finding() {
+        let body: Vec<String> = (0..200).map(|i| format!("본문 {}", i)).collect();
+        let refs: Vec<&str> = body.iter().map(|s| s.as_str()).collect();
+        let a = doc(&[&refs]);
+
+        let mut with_head = vec!["새 머리말"];
+        with_head.extend(refs.iter().copied());
+        let b = doc(&[&with_head]);
+
+        let diff = diff_documents(&a, &b, &DiffOptions::default());
+
+        assert_eq!(
+            kinds(&diff),
+            vec![FindingKind::ParagraphAdded],
+            "자리끼리 맞대는 방식이라면 201 건이 났을 것이다"
+        );
+        assert_eq!(paths(&diff), vec!["sec[0]/para[0]"]);
+    }
+}

--- a/src/docdiff/model.rs
+++ b/src/docdiff/model.rs
@@ -1,0 +1,319 @@
+//! `docdiff` 결과 타입 — 좌표(`NodePath`)·발견(`Finding`)·집계(`DiffSummary`).
+//!
+//! 이 파일에는 **판정 로직이 없다.** 비교는 [`super::compare`], 집계는
+//! [`super::summary`] 가 맡고 여기는 두 쪽이 공유하는 **계약**만 둔다. 결과 타입을
+//! 비교기와 분리해 두는 이유는 소비자(회귀 시험·CLI·MCP)가 비교 알고리즘이 아니라
+//! **결과 모양**에 의존하기 때문이다.
+
+use std::fmt;
+
+/// 문서 안의 한 지점을 가리키는 좌표 한 칸.
+///
+/// 첨자는 전부 0 부터 센다. 표 셀만 행·열 주소를 함께 싣는데, 병합 때문에
+/// `cells` 안의 순번보다 `(row, col)` 이 사람에게 훨씬 잘 읽히기 때문이다.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathStep {
+    /// 구역 — `sec[i]`
+    Section(usize),
+    /// 문단 — `para[i]`
+    Paragraph(usize),
+    /// 문단 안 컨트롤 — `ctrl[i]`
+    Control(usize),
+    /// 표 셀 — `cell[r{row},c{col}]`
+    TableCell {
+        /// 셀의 행 주소
+        row: u16,
+        /// 셀의 열 주소
+        col: u16,
+    },
+    /// 문서 정보(`doc_info`) 아래의 스타일 — `style[i]`
+    Style(usize),
+}
+
+impl fmt::Display for PathStep {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PathStep::Section(i) => write!(f, "sec[{}]", i),
+            PathStep::Paragraph(i) => write!(f, "para[{}]", i),
+            PathStep::Control(i) => write!(f, "ctrl[{}]", i),
+            PathStep::TableCell { row, col } => write!(f, "cell[r{},c{}]", row, col),
+            PathStep::Style(i) => write!(f, "style[{}]", i),
+        }
+    }
+}
+
+/// 차이가 난 지점의 좌표 — `sec[0]/para[3]/ctrl[1]/cell[r2,c0]/para[0]` 처럼 읽힌다.
+///
+/// 회귀 검증이 "달라졌다"가 아니라 "**어디가** 달라졌다"를 말할 수 있게 하는 값이다.
+/// 문자열이 아니라 타입으로 두는 이유는 소비자가 구역 번호 같은 것을 문자열 파싱
+/// 없이 꺼내 쓸 수 있어야 하기 때문이다([`NodePath::section`]).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NodePath {
+    steps: Vec<PathStep>,
+}
+
+impl NodePath {
+    /// 문서 전체를 가리키는 빈 경로.
+    pub fn root() -> Self {
+        Self::default()
+    }
+
+    /// 이 경로 아래 한 칸 내려간 새 경로를 만든다(원본은 그대로).
+    pub fn child(&self, step: PathStep) -> Self {
+        let mut steps = self.steps.clone();
+        steps.push(step);
+        Self { steps }
+    }
+
+    /// 경로를 이루는 좌표 칸들.
+    pub fn steps(&self) -> &[PathStep] {
+        &self.steps
+    }
+
+    /// 문서 전체를 가리키는 빈 경로인가.
+    pub fn is_root(&self) -> bool {
+        self.steps.is_empty()
+    }
+
+    /// 이 경로가 속한 구역 번호 — 구역 밖(문서 정보 등)이면 `None`.
+    pub fn section(&self) -> Option<usize> {
+        self.steps.iter().find_map(|s| match s {
+            PathStep::Section(i) => Some(*i),
+            _ => None,
+        })
+    }
+
+    /// 이 경로가 가리키는 **최말단** 문단 번호 — 문단을 안 가리키면 `None`.
+    ///
+    /// 표 셀 안 문단이면 셀 안에서의 번호가 나온다(바깥 문단 번호가 아니다).
+    pub fn paragraph(&self) -> Option<usize> {
+        self.steps.iter().rev().find_map(|s| match s {
+            PathStep::Paragraph(i) => Some(*i),
+            _ => None,
+        })
+    }
+}
+
+impl fmt::Display for NodePath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.steps.is_empty() {
+            return write!(f, "doc");
+        }
+        for (i, step) in self.steps.iter().enumerate() {
+            if i > 0 {
+                write!(f, "/")?;
+            }
+            write!(f, "{}", step)?;
+        }
+        Ok(())
+    }
+}
+
+/// 차이의 종류.
+///
+/// 종류는 **의미 단위**다 — 직렬화기 충실도 축(글자모양 시퀀스·lineseg 같은 것)은
+/// 여기 없다. 그쪽은 [`crate::serializer::hwpx::roundtrip::diff_documents`] 의 몫이다
+/// (경계는 모듈 문서 참고).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FindingKind {
+    /// 구역 수가 달라졌다.
+    SectionCountChanged,
+    /// B 에만 있는 문단(추가됨).
+    ParagraphAdded,
+    /// A 에만 있는 문단(삭제됨).
+    ParagraphRemoved,
+    /// 짝지어진 문단의 본문 텍스트가 달라졌다.
+    TextChanged,
+    /// 짝지어진 문단의 문단모양·스타일 참조가 달라졌다.
+    ParagraphStyleChanged,
+    /// 표의 행·열 수 또는 셀 병합 모양이 달라졌다.
+    TableShapeChanged,
+    /// 문단이 품은 컨트롤 개수가 달라졌다.
+    ControlCountChanged,
+    /// 같은 자리의 컨트롤 종류가 달라졌다(예: 표 → 그림).
+    ControlKindChanged,
+    /// 문서 정보의 스타일 개수가 달라졌다.
+    StyleCountChanged,
+    /// 같은 번호 스타일의 정의가 달라졌다.
+    StyleChanged,
+}
+
+impl FindingKind {
+    /// 선언 순서 그대로의 전체 목록 — 집계 순서의 단일 출처.
+    ///
+    /// 집계가 `HashMap` 을 돌지 않고 이 배열을 도는 덕분에 요약 순서가 항상 같다.
+    pub const ALL: [FindingKind; 10] = [
+        FindingKind::SectionCountChanged,
+        FindingKind::ParagraphAdded,
+        FindingKind::ParagraphRemoved,
+        FindingKind::TextChanged,
+        FindingKind::ParagraphStyleChanged,
+        FindingKind::TableShapeChanged,
+        FindingKind::ControlCountChanged,
+        FindingKind::ControlKindChanged,
+        FindingKind::StyleCountChanged,
+        FindingKind::StyleChanged,
+    ];
+
+    /// 기계 가독 이름 — 봉투·로그의 안정 키다. **바꾸면 계약이 깨진다.**
+    pub fn label(&self) -> &'static str {
+        match self {
+            FindingKind::SectionCountChanged => "sectionCountChanged",
+            FindingKind::ParagraphAdded => "paragraphAdded",
+            FindingKind::ParagraphRemoved => "paragraphRemoved",
+            FindingKind::TextChanged => "textChanged",
+            FindingKind::ParagraphStyleChanged => "paragraphStyleChanged",
+            FindingKind::TableShapeChanged => "tableShapeChanged",
+            FindingKind::ControlCountChanged => "controlCountChanged",
+            FindingKind::ControlKindChanged => "controlKindChanged",
+            FindingKind::StyleCountChanged => "styleCountChanged",
+            FindingKind::StyleChanged => "styleChanged",
+        }
+    }
+}
+
+impl fmt::Display for FindingKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// 차이 하나 — "어디가(`path`) 어떻게(`kind`) 얼마나(`detail`)".
+///
+/// `detail` 은 **사람이 읽는 한 줄**이다. 기계 판정은 `kind` 와 `path` 로 하고
+/// `detail` 을 파싱하지 마라 — 문구는 계약이 아니다.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Finding {
+    /// 차이가 난 지점.
+    pub path: NodePath,
+    /// 차이의 종류.
+    pub kind: FindingKind,
+    /// 사람이 읽는 상세 — 미리보기는 문자 단위로 잘려 있다.
+    pub detail: String,
+}
+
+impl Finding {
+    /// 봉투 한 칸으로 쓸 JSON 값.
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "path": self.path.to_string(),
+            "kind": self.kind.label(),
+            "detail": self.detail,
+        })
+    }
+}
+
+impl fmt::Display for Finding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} {}: {}", self.path, self.kind.label(), self.detail)
+    }
+}
+
+/// 비교 옵션.
+///
+/// `Default` 는 "아무것도 봐주지 않고, 아무것도 자르지 않는다" — 회귀 게이트가
+/// 기본값으로 안전하게 쓰도록 한 선택이다.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DiffOptions {
+    /// 텍스트 비교에서 공백 차이를 무시한다.
+    ///
+    /// 켜면 연속 공백을 한 칸으로 접고 양끝을 다듬은 뒤 비교한다. 문단을 짝짓는
+    /// 정렬에도 같은 정규화가 적용되므로, 들여쓰기만 바뀐 문서는 문단 추가·삭제가
+    /// 아니라 **차이 없음**으로 읽힌다.
+    pub ignore_whitespace: bool,
+    /// 보고할 차이 개수 상한 — `None` 이면 무제한.
+    ///
+    /// 상한에 걸려도 순회는 끝까지 한다. 그래야
+    /// [`DocumentDiff::truncated`] 가 "정말로 더 있었다"를 뜻한다.
+    pub max_findings: Option<usize>,
+}
+
+impl DiffOptions {
+    /// 공백 차이를 무시하도록 켠 사본.
+    pub fn ignore_whitespace(mut self, yes: bool) -> Self {
+        self.ignore_whitespace = yes;
+        self
+    }
+
+    /// 보고 상한을 건 사본.
+    pub fn max_findings(mut self, max: usize) -> Self {
+        self.max_findings = Some(max);
+        self
+    }
+}
+
+/// 두 문서를 비교한 결과.
+///
+/// # 불변식
+///
+/// 1. `identical == true` 이면 `findings` 는 비어 있고 `truncated` 도 `false` 다.
+/// 2. `truncated == true` 이면 상한 때문에 **버린 차이가 있다** — 결과는 부분 보고다.
+/// 3. `findings` 의 순서는 문서 순서(구역 → 문단 → 컨트롤 → 셀, 끝으로 문서 정보)로
+///    고정이다. 같은 두 문서는 언제나 같은 순서를 낸다.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DocumentDiff {
+    /// 차이가 하나도 없었는가 — 상한에 걸려 버린 것이 있으면 `false` 다.
+    pub identical: bool,
+    /// 발견한 차이(문서 순서).
+    pub findings: Vec<Finding>,
+    /// 상한 때문에 버린 차이가 있는가.
+    pub truncated: bool,
+}
+
+impl DocumentDiff {
+    /// 카테고리별 건수 집계.
+    pub fn summary(&self) -> DiffSummary {
+        super::summary::summarize(self)
+    }
+
+    /// 봉투 한 줄로 쓸 JSON 값 — `identical`/`truncated`/`findings`/`summary`.
+    ///
+    /// CLI·MCP 가 자기 봉투에 그대로 끼워 넣도록 **키만** 정하고 스키마 버전은
+    /// 붙이지 않는다. 봉투의 주인은 이 엔진이 아니라 명령이다.
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "identical": self.identical,
+            "truncated": self.truncated,
+            "findingCount": self.findings.len(),
+            "findings": self.findings.iter().map(Finding::to_json).collect::<Vec<_>>(),
+            "summary": self.summary().to_json(),
+        })
+    }
+}
+
+/// 카테고리별 건수 집계.
+///
+/// `by_kind` 는 [`FindingKind::ALL`] 선언 순서로 정렬돼 있고 **0 건은 빠진다**.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DiffSummary {
+    /// 보고된 차이 총 건수 — `findings.len()` 과 같다(버린 것은 안 센다).
+    pub total: usize,
+    /// 상한 때문에 버린 차이가 있는가.
+    pub truncated: bool,
+    /// (종류, 건수) — 종류 선언 순서, 0 건 제외.
+    pub by_kind: Vec<(FindingKind, usize)>,
+}
+
+impl DiffSummary {
+    /// 특정 종류의 건수 — 없으면 0.
+    pub fn count_of(&self, kind: FindingKind) -> usize {
+        self.by_kind
+            .iter()
+            .find(|(k, _)| *k == kind)
+            .map(|(_, n)| *n)
+            .unwrap_or(0)
+    }
+
+    /// 봉투 한 칸으로 쓸 JSON 값 — 종류 이름을 키로 한 객체.
+    pub fn to_json(&self) -> serde_json::Value {
+        let mut map = serde_json::Map::new();
+        for (kind, count) in &self.by_kind {
+            map.insert(kind.label().to_string(), serde_json::json!(count));
+        }
+        serde_json::json!({
+            "total": self.total,
+            "truncated": self.truncated,
+            "byKind": serde_json::Value::Object(map),
+        })
+    }
+}

--- a/src/docdiff/summary.rs
+++ b/src/docdiff/summary.rs
@@ -1,0 +1,26 @@
+//! 차이 목록 → 카테고리별 건수 집계.
+//!
+//! 집계는 [`FindingKind::ALL`] 을 순서대로 훑는다. `HashMap` 을 돌지 않는 것이
+//! 핵심이다 — 해시 순회 순서는 실행마다 달라질 수 있고, 그러면 "같은 두 문서면
+//! 같은 결과"라는 약속이 요약 계층에서 깨진다.
+
+use super::model::{DiffSummary, DocumentDiff, FindingKind};
+
+/// 차이 목록을 카테고리별로 센다.
+///
+/// 상한(`max_findings`)에 걸려 버린 차이는 세지 않는다 — 집계는 **보고된 것**의
+/// 회계이고, 더 있었다는 사실은 [`DiffSummary::truncated`] 가 말한다.
+pub fn summarize(diff: &DocumentDiff) -> DiffSummary {
+    let mut by_kind = Vec::new();
+    for kind in FindingKind::ALL {
+        let count = diff.findings.iter().filter(|f| f.kind == kind).count();
+        if count > 0 {
+            by_kind.push((kind, count));
+        }
+    }
+    DiffSummary {
+        total: diff.findings.len(),
+        truncated: diff.truncated,
+        by_kind,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod agent;
 pub mod agent_seal;
 pub mod capabilities_schema;
 pub mod diagnostics;
+pub mod docdiff;
 pub mod doclang;
 pub mod document_core;
 pub mod emf;


### PR DESCRIPTION
## 동기

회귀 검증·왕복 시험·편집 전후 확인·변환 손실 설명이 전부 같은 질문 하나를 던집니다 — "두 문서가 어떻게 다른가." `ROADMAP.md`가 업스트림 책임으로 못박은 "공통 품질과 운영 | … **회귀·시각 검증** …"(`ROADMAP.md:192`)이 바로 이 질문에 근거를 요구합니다. 그런데 그 답을 **라이브러리로 부를 공통 엔진이 없습니다.**

짓기 전에 기존 장치를 전수 조사했습니다. `roundtrip::diff_documents`(`src/serializer/hwpx/roundtrip.rs:731`)는 이미 공개 함수지만 묻는 질문이 다릅니다 — 리소스 개수·`char_shapes` 시퀀스·`line_segs`·`PageDef`·캡션 같은 **직렬화 충실도**만 보고 **문단 텍스트는 아예 비교하지 않습니다.** 그 자리를 CLI `ir-diff`(`main.rs:16670`)가 메우지만 본체(`ir_diff_paragraph_fields` `:15871`, `IrDiffEmitter` `:15823`)가 전부 `main.rs` 안의 비공개 함수라 라이브러리 소비자가 한 줄도 못 씁니다. `--json`의 카테고리 집계마저 **출력 문자열을 되파싱해서** 만듭니다.

결정적으로 **둘 다 문단을 `a[i]` 대 `b[i]`로 자리끼리 맞댑니다**(`roundtrip.rs:772-782`, `main.rs:16825-16848`). 문단 200개짜리 문서 맨 앞에 한 줄을 넣으면 차이 201건이 나옵니다. 충실도 게이트로서는 무해하지만(어차피 0건이어야 하니까), 사람이나 에이전트에게 변경을 **설명**하는 자리에서는 그 잡음이 곧 쓸모없음입니다.

## 설계

그래서 이 모듈은 셋째 장치가 아니라 **한 단계 위의 층**입니다.

- **정렬한다** — 공통 앞뒤를 깎고 남은 가운데만 LCS로 짝지은 뒤, 맞닿은 삭제·추가 덩어리를 다시 짝지어 "수정"으로 승격시킵니다. 앞머리 한 줄 삽입은 `ParagraphAdded` **1건**, 한 글자 수정은 `TextChanged` **1건**이 됩니다.
- **좌표를 타입으로 준다** — `path: String`이 아니라 `NodePath`라 `sec[0]/para[3]/ctrl[1]/cell[r2,c0]/para[0]`를 문자열 파싱 없이 읽습니다.
- **결과가 값이다** — `FindingKind`가 처음부터 타입이고 `DiffSummary`가 그것을 셉니다. 출력 되파싱 없음.
- **결정적이다** — 순회 순서 고정, LCS 되짚기는 갈림길에서 언제나 삭제 우선, `HashMap` 순회 없음.
- **상한을 밝힌다** — `max_findings`에 걸려도 순회는 끝까지 해서 `truncated`가 "정말로 더 있었다"를 뜻합니다. 상한 0이어도 `identical`로 거짓말하지 않습니다.

충실도 게이트는 관대하면 안 되고(`line_segs` 한 칸 어긋나면 한글이 본문을 버립니다), 의미 diff는 엄격하면 안 됩니다(201건을 내면 아무도 안 읽습니다). 두 요구는 한 함수에 담기지 않습니다. **둘 다 필요합니다.**

```rust
pub fn diff_documents(a: &Document, b: &Document, opts: &DiffOptions) -> DocumentDiff;
pub struct DocumentDiff { pub identical: bool, pub findings: Vec<Finding>, pub truncated: bool }
pub struct Finding { pub path: NodePath, pub kind: FindingKind, pub detail: String }
```

**불변식** — `identical = findings.is_empty() && !truncated`. `max_findings: Some(0)` + 실제 차이 → `identical=false, truncated=true, findings=[]`(거짓말 안 함).

## 사용법

```rust
use rhwp::docdiff::{diff_documents, DiffOptions};

let diff = diff_documents(&before, &after, &DiffOptions::default());
if !diff.identical {
    for f in &diff.findings { println!("{}", f); }  // sec[0]/para[3] textChanged: A="..." B="..."
    println!("{:?}", diff.summary().by_kind);
}
```

입력은 이미 파싱된 `Document` IR — **파일을 열지 않습니다.**

**채택 시나리오**:
1. **회귀 시험** — `assert!(diff.identical, "{}", findings.join("\n"))`. 실패 메시지가 곧 좌표.
2. **왕복 검증** — `convert --verify`가 지금 IR 차이 있으면 exit 3만 내는데, 여기에 "충실도 차이 47건(직렬화 축), 의미 차이 0건"을 붙일 수 있습니다. **지금 아무도 못 하는 판정**입니다.
3. **CLI** — 신규 `doc-diff` 명령(후속 PR)에서 `to_json()`을 `provenance::marked()`로 감싸면 봉투 완성.
4. **MCP** — `hwp_doc_diff` 결과 타입. `FindingKind::label()`이 안정 키라 도구 스키마 enum을 코드에서 생성 가능(`capabilities --mcp` 단일 출처 규약과 정합).
5. **편집 파이프라인** — `edit --verify`에서 "의도한 것만 바뀌었나"를 좌표로 단언.

## 테스트

`cargo test --lib docdiff::` **22 통과 / 0 실패**, `cargo test --doc docdiff` 2 통과.

고정한 것: 같은 문서 → identical / 빈 문서 대 빈 문서 / 한 글자 변경 / 가운데 문단 추가·삭제(**뒤 문단 비오염**) / 구역 수 변화 / 표 행렬 변화 / 표 셀 좌표 / 컨트롤 개수·종류 / 스타일 개수·정의 / **결정성**(12회 호출 완전 동일) / `max_findings` 상한과 `truncated` / **상한 0 경계**(전부 버려도 identical 아님) / 불변식 전수(5 문서쌍 × 4 옵션) / 요약 집계 정확성 / **대형 문서(200문단) 앞머리 삽입 → 1건**.

```
$ cargo test --lib docdiff::
test result: ok. 22 passed; 0 failed

$ cargo clippy --lib --tests -- -D warnings   # 통과
$ cargo build                                  # 통과
$ rustfmt --edition 2021 --check src/docdiff/*.rs   # 통과
```

## 범위

기존 파일은 `src/lib.rs`의 `pub mod docdiff;` 한 줄만 건드렸습니다(`diagnostics`와 `doclang` 사이). `ir-diff`를 이 엔진 위로 옮기는 추출은 후속 PR입니다. 렌더 기하(`render-diff`)·직렬화 충실도(왕복 게이트)는 비범위이며, 글상자·각주 재귀는 표 셀까지만 하고 후속으로 미뤘습니다(컨트롤 개수·종류 차이는 잡히므로 손실이 조용히 통과하지는 않습니다). 설계 문서: `mydocs/tech/docdiff.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
