### PR TITLE
ci(preflight): R12 — agent_preflight 를 CI lint job 에 배선한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1045,6 +1045,16 @@ jobs:
           cargo build --workspace
           cargo clippy --workspace --all-targets -- -D warnings
 
+      # [로드맵 R12] 에이전트 표면 선검사 — 실패 경로 전수(전 명령 "없는 파일" 호출
+      # → exit≠0 + stdout 0바이트)·미선언 명령 감지(capabilities 에 flags 를 선언하지
+      # 않은 명령이 미지 플래그를 exit 0 으로 조용히 삼키는지)를 한 번에 돌린다.
+      # 바로 위 스텝의 `cargo build --workspace` 가 만든 debug 바이너리를 그대로 쓴다
+      # — 이 게이트만을 위해 release 를 다시 빌드하지 않는다. 큐 규율 검사(gh
+      # PR 목록 조회, 경고 전용)는 이 저장소의 병렬 세션 운영 규약용이라 CI 실행과는
+      # 무관하므로 --no-network 로 끈다(tools/agent_preflight.py 참고).
+      - name: Agent preflight (failure-path sweep + undeclared-command detection)
+        run: python3 tools/agent_preflight.py --repo . --bin target/debug/rhwp --no-network
+
       - name: Check WASM target
         run: cargo check --target wasm32-unknown-unknown --lib
 


### PR DESCRIPTION
## 동기

R12(실패 경로 전수 + 미선언 명령 감지)의 검사 로직은 `tools/agent_preflight.py`에 이미 있었고 devel에 머지돼 있었습니다(#3912). 잔여는 딱 하나, CI 배선이었습니다 — 2026-08-06 워크플로 전수 grep 실측 0건. 아무도 로컬에서 이 스크립트를 안 돌리면 새 명령이 `capabilities`에 `flags` 없이 등록되고도(#3884 G2의 `dump` 사고와 같은 모양) 아무 경고 없이 머지될 수 있는 상태였습니다.

## 설계

`--static-only`는 쓰지 않습니다 — 이 플래그는 R12가 정확히 필요로 하는 두 검사(실패 경로 stdout 스윕, 자기서술 밖 명령 검사)를 통째로 건너뜁니다(둘 다 빌드된 바이너리가 필요). 대신 `lint` job이 이미 `cargo build --workspace`로 만드는 debug 바이너리(`target/debug/rhwp`)를 그대로 `--bin`에 넘깁니다 — 이 게이트만을 위한 release 재빌드는 하지 않습니다. 큐 규율 검사(gh PR 목록 조회 등)는 병렬 세션 운영 규약용이지 CI 게이트가 아니므로 `--no-network`로 끕니다 — 이것이 R12가 열어둔 "정적 검사만 태울지, 경고 전용 큐 검사와 분리할지" 설계 질문의 답입니다: 정적-only로 후퇴하지 않고, 네트워크/경고 전용 축만 분리합니다.

```yaml
      - name: Agent preflight (failure-path sweep + undeclared-command detection)
        run: python3 tools/agent_preflight.py --repo . --bin target/debug/rhwp --no-network
```

`.github/workflows/ci.yml`의 `lint` job, "Check workspace members" 직후·"Check WASM target" 직전에 10줄 삽입. 다른 워크플로 파일은 무수정.

## 사용법

이 스텝은 매 PR·devel/main push마다 `lint` job 안에서 돕니다. 워크스페이스 빌드가 실패하면 이 스텝 자체가 도달하지 않고, 빌드가 성공하면 방금 만들어진 바이너리로 전 명령(현재 89개)에 대해 실패 경로 stdout 오염과 미선언 플래그 침묵 무시를 훑습니다. 앞으로 새 CLI/MCP 명령을 추가하는 모든 기여자는 이 게이트를 자동으로 거치게 됩니다.

## 테스트 — red→green 실증

`src/main.rs`에 `capabilities`엔 등재하되(`cmd()`, flags 미선언) 미지 플래그를 exit 0으로 삼키는 가짜 명령(#3884 G2와 동형)을 임시로 추가 → 재빌드 → 검사 실행:

```
$ python3 tools/agent_preflight.py --repo . --bin target/debug/rhwp --no-network
[자기서술 밖 명령]
  · 미지 플래그를 exit 0 으로 무시: ['preflight-fake-cmd']
PREFLIGHT_EXIT=1
```

원상복구 후 재빌드·재실행:

```
$ python3 tools/agent_preflight.py --repo . --bin target/debug/rhwp --no-network
전부 통과.
PREFLIGHT_EXIT=0
```

devel 정상 상태에서 거짓 양성 없음을 확인했습니다. `yaml.safe_load` 파싱 확인 + `scripts/tests/test_workflow_contract_wiring.py`(3 tests) 통과 확인.

## 트랙 진행률

R12는 트랙 B(가드·보안)의 마지막 미완료 항목입니다. README.md 집계표는 이 PR에서 손대지 않았습니다 — `tools/roadmap_progress.py --write`가 생성하는 파일입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
