### PR TITLE
feat(run): 계획 실행 저널에 입출력 SHA-256 지문 체인을 싣는다 (#4378 R23)

### DIFF
--- a/mydocs/manual/agent_knowledge_map.md
+++ b/mydocs/manual/agent_knowledge_map.md
@@ -447,6 +447,8 @@ IR·provenance·plan 네 축을 한 번에 조립하고, 빠진 축은 `missingA
 | `invalid` | array | **정적 선검증 위반.** 비어 있지 않으면 한 step 도 실행하지 않는다 | `run` |
 | `assertions` | object | 적용된 단언 `{verify,notFoundEmpty}` — 미지정 기본값도 명시해 저널에 남는다 | `run` (실측; `recordFields` 에는 없다) |
 | `preview` | array | `--dry-run` 전용. 선검증이 이미 계산한 대상 목록 | `run --dry-run` (실측) |
+| `inputSha256` | string | [#4378 R23] 실행에 쓴 `input` 문서 바이트의 SHA-256(R22 와 같은 해시 함수). 앞 실행 저널의 `outputSha256` 과 값이 같으면 두 실행이 연속이다 — 다르면 그 사이 다른 도구가 문서를 건드렸다는 뜻(저널만으로 탐지, 실행을 막지는 않는다) | `run` |
+| `outputSha256` | string | [#4378 R23] 실제로 저장한 산출 바이트의 SHA-256. 다음 계획의 `preconditions.inputSha256` 또는 다음 저널의 `inputSha256` 과 이어 붙이면 편집 사슬이 재구성된다 — `replay` 의 동명 필드는 임시 재실행 영수증이라 문맥이 다르다(같은 해시 함수, 다른 대상) | `run` |
 
 #### 작업 영수증 (`replay`)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1766,7 +1766,7 @@ fn mcp_tool_definitions() -> Vec<serde_json::Value> {
             }),
             "run",
             serde_json::json!(["run", "--plan-json", "{plan}", "--json"]),
-            &["schemaVersion", "planVersion", "input", "output", "outputFormat", "steps", "steps[].confusable", "steps[].skipped", "verify", "invalid", "changedPages", "dryRun", "preview"],
+            &["schemaVersion", "planVersion", "input", "output", "outputFormat", "steps", "steps[].confusable", "steps[].skipped", "verify", "invalid", "changedPages", "dryRun", "preview", "inputSha256", "outputSha256"],
         ),
         tool_with_optional_args(
             "hwp_replay",
@@ -2472,6 +2472,8 @@ fn capabilities_command_entries() -> Vec<serde_json::Value> {
                 "steps",
                 "verify",
                 "invalid",
+                "inputSha256",
+                "outputSha256",
             ],
         ),
         // [#4391] 작업 영수증 — run 계획의 제3자 재현·증명. 사용자 파일은 건드리지
@@ -22205,6 +22207,10 @@ fn run_plan_engine(plan: &serde_json::Value) -> (serde_json::Value, i32) {
         Ok(d) => d,
         Err(e) => return fail(format!("입력을 읽을 수 없습니다 - {}: {}", input, e)),
     };
+    // [#4378 R23] 입력 지문 — CAS 대조(있으면)와 성공 저널의 `inputSha256` 이 같은
+    // 값을 공유한다. R22 가 세운 해시 함수(`sha256_hex_of`)를 그대로 재사용한다 —
+    // 저널이 계획서와 다른 해시를 쓰면 사슬(R23)이 끊긴다.
+    let input_sha256 = sha256_hex_of(&bytes);
     // [#4378 R22] CAS — 계획이 세워진 시점의 문서가 아니면 실행 0·저장 0 으로
     // 거절한다(#3905 M1: 두 exit 0 이 편집 하나를 지우는 경합의 차단기).
     let precondition_failure = |expected: &str, actual: String| {
@@ -22229,9 +22235,8 @@ fn run_plan_engine(plan: &serde_json::Value) -> (serde_json::Value, i32) {
         )
     };
     if let Some(expected) = expected_input_sha.as_deref() {
-        let actual = sha256_hex_of(&bytes);
-        if actual != expected {
-            return precondition_failure(expected, actual);
+        if input_sha256 != expected {
+            return precondition_failure(expected, input_sha256.clone());
         }
         cas_test_mark_checked_and_wait();
     }
@@ -22661,6 +22666,11 @@ fn run_plan_engine(plan: &serde_json::Value) -> (serde_json::Value, i32) {
         Ok(b) => b,
         Err(e) => return fail(format!("{} 직렬화 실패 - {}", out_format.label(), e)),
     };
+    // [#4378 R23] 산출 지문 — 다음 계획의 `preconditions.inputSha256`(또는 다음
+    // 저널의 `inputSha256`)과 대조하면 저널만으로 편집 사슬을 재구성할 수 있다.
+    // 이 값은 실제로 디스크에 쓰는 바이트(`out_bytes`)의 해시다 — 재파싱 후
+    // 해시를 다시 재는 것이 아니라 "무엇을 썼는가"를 직접 지문 찍는다.
+    let output_sha256 = sha256_hex_of(&out_bytes);
     let mut verify_report = serde_json::Value::Null;
     if assert_verify {
         let cross = out_format == EditOutputFormat::Hwp
@@ -22706,6 +22716,10 @@ fn run_plan_engine(plan: &serde_json::Value) -> (serde_json::Value, i32) {
                 "input": input, "output": output, "outputFormat": out_format.label(),
                 "steps": journal_steps, "verify": verify_report,
                 "changedPages": changed_pages,
+                // [#4378 R23] 지문 체인 — 앞 실행의 outputSha256 = 뒤 실행의
+                // inputSha256 이면 저널만으로 편집 사슬을 재구성할 수 있다.
+                "inputSha256": input_sha256,
+                "outputSha256": output_sha256,
                 "assertions": { "notFoundEmpty": assert_not_found_empty, "verify": assert_verify },
             }),
             "run",

--- a/tests/run_plan_journal_hash_chain_contract.rs
+++ b/tests/run_plan_journal_hash_chain_contract.rs
@@ -1,0 +1,201 @@
+//! [#4378 R23] `run` 저널 지문 체인 — 연속 실행의 `outputSha256` = `inputSha256`.
+//!
+//! R22 는 계획서 `preconditions.inputSha256` 로 낡은 기준의 실행을 **거절**한다
+//! (CAS, 사전 차단). R23 은 그와 다른 축이다 — 도구는 매 성공 실행마다 저널에
+//! `inputSha256`/`outputSha256` 지문만 낸다. 그 지문을 이어 붙여 "누가 어떤
+//! 상태에서 무엇을 바꿨나"를 재구성하는 것은 호출자(무상태 CLI 철학) 몫이므로,
+//! 이 계약이 고정하는 것은 재구성이 **가능함**이다:
+//!
+//! 1. 연속 실행: 저널 1의 `outputSha256` = 저널 2의 `inputSha256`.
+//! 2. 불연속(다른 도구가 중간에 문서를 건드림): 두 값이 달라 저널 비교만으로
+//!    드러난다 — 단, `preconditions` 없이 호출했으므로 실행 자체는 막히지
+//!    않는다(R23 은 탐지이지 R22 의 차단이 아니다).
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::process::{Command, Output};
+
+use sha2::{Digest, Sha256};
+
+const SAMPLE: &str = "samples/basic/issue2007_nested_cell_pagination_42065.hwp";
+
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(rhwp_bin())
+        .args(args)
+        .output()
+        .expect("rhwp 실행")
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "journal_hash_chain_{name}_{}_{nonce}.hwp",
+        std::process::id()
+    ))
+}
+
+/// 대상 문서 1쪽 본문에서 실제로 존재하는 2글자 조각 — replace_text 선검증
+/// (매치 존재)을 통과시키기 위한 실측 기반 find 값.
+fn existing_snippet(path: &std::path::Path) -> String {
+    let o = run(&["export-text", path.to_str().unwrap(), "-p", "0", "--json"]);
+    assert_eq!(
+        o.status.code(),
+        Some(0),
+        "{}",
+        String::from_utf8_lossy(&o.stdout)
+    );
+    let env: serde_json::Value = serde_json::from_slice(&o.stdout).expect("봉투");
+    let text = env["pages"][0]["text"].as_str().expect("쪽 텍스트");
+    let chars: Vec<char> = text.chars().filter(|c| !c.is_whitespace()).collect();
+    assert!(chars.len() >= 2, "샘플 1쪽에 본문이 있어야 한다");
+    chars[..2].iter().collect()
+}
+
+fn run_plan_in_place(path: &std::path::Path, find: &str, replace: &str) -> serde_json::Value {
+    let plan = serde_json::json!({
+        "planVersion": "1.0",
+        "input": path.to_string_lossy(),
+        "output": path.to_string_lossy(),
+        "steps": [{ "action": "replace_text", "find": find, "replace": replace }],
+    })
+    .to_string();
+    let o = run(&["run", "--plan-json", &plan, "--json"]);
+    assert_eq!(
+        o.status.code(),
+        Some(0),
+        "run 실행 실패: {}",
+        String::from_utf8_lossy(&o.stdout)
+    );
+    serde_json::from_slice(&o.stdout).expect("run 저널 봉투")
+}
+
+fn is_sha256_hex(v: &serde_json::Value) -> bool {
+    v.as_str()
+        .is_some_and(|s| s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit()))
+}
+
+/// 저널이 `inputSha256`/`outputSha256` 을 64자리 16진으로 싣는다 — 필드 존재 자체의
+/// 최소 계약. 필드가 없던 시절에는 이 단언이 곧 red 였다.
+#[test]
+fn journal_carries_input_and_output_sha256() {
+    let doc = tmp("fields_present");
+    std::fs::copy(SAMPLE, &doc).expect("샘플 복사");
+    let find = existing_snippet(&doc);
+    let journal = run_plan_in_place(&doc, &find, &find);
+    assert!(
+        is_sha256_hex(&journal["inputSha256"]),
+        "inputSha256 이 64자리 16진이 아니다: {journal}"
+    );
+    assert!(
+        is_sha256_hex(&journal["outputSha256"]),
+        "outputSha256 이 64자리 16진이 아니다: {journal}"
+    );
+    let _ = std::fs::remove_file(&doc);
+}
+
+/// 저널의 `inputSha256` 이 실제로 실행에 쓰인 입력 바이트의 해시와 같다 — R22 와
+/// 같은 해시 함수(파일 바이트 sha256)를 재사용했음을 실증한다.
+#[test]
+fn journal_input_sha256_matches_actual_input_bytes() {
+    let doc = tmp("input_matches");
+    std::fs::copy(SAMPLE, &doc).expect("샘플 복사");
+    let original_bytes = std::fs::read(&doc).expect("원본 읽기");
+    let expected = sha256_hex(&original_bytes);
+    let find = existing_snippet(&doc);
+    let journal = run_plan_in_place(&doc, &find, &find);
+    assert_eq!(journal["inputSha256"], expected, "{journal}");
+    let _ = std::fs::remove_file(&doc);
+}
+
+/// 저널의 `outputSha256` 이 실제로 디스크에 쓰인 산출 바이트의 해시와 같다.
+#[test]
+fn journal_output_sha256_matches_actual_written_bytes() {
+    let doc = tmp("output_matches");
+    std::fs::copy(SAMPLE, &doc).expect("샘플 복사");
+    let find = existing_snippet(&doc);
+    let journal = run_plan_in_place(&doc, &find, &find);
+    let written = std::fs::read(&doc).expect("산출 읽기");
+    let expected = sha256_hex(&written);
+    assert_eq!(journal["outputSha256"], expected, "{journal}");
+    let _ = std::fs::remove_file(&doc);
+}
+
+/// DoD ① — 연속 실행: 앞 저널의 outputSha256 = 뒤 저널의 inputSha256.
+#[test]
+fn consecutive_runs_chain_output_to_input() {
+    let doc = tmp("chain_continuous");
+    std::fs::copy(SAMPLE, &doc).expect("샘플 복사");
+
+    let find1 = existing_snippet(&doc);
+    let journal1 = run_plan_in_place(&doc, &find1, &find1);
+
+    let find2 = existing_snippet(&doc);
+    let journal2 = run_plan_in_place(&doc, &find2, &find2);
+
+    // Null == Null 로 통과하는 무의미한 일치를 막는다 — 두 값이 실제 지문이어야
+    // "연속"이라는 단언에 뜻이 있다.
+    assert!(is_sha256_hex(&journal1["outputSha256"]), "{journal1}");
+    assert!(is_sha256_hex(&journal2["inputSha256"]), "{journal2}");
+    assert_eq!(
+        journal1["outputSha256"], journal2["inputSha256"],
+        "연속 실행이면 앞 outputSha256 = 뒤 inputSha256 이어야 한다\n저널1: {journal1}\n저널2: {journal2}"
+    );
+    let _ = std::fs::remove_file(&doc);
+}
+
+/// DoD ② — 불연속: 다른 도구(`edit replace-text`, `run` 이 아닌 별도 진입점)가
+/// 중간에 문서를 건드리면 저널 비교만으로 그 사실이 드러난다. `preconditions`
+/// 를 주지 않았으므로 실행 자체는 막히지 않는다(R23 = 탐지, R22 = 차단).
+#[test]
+fn interleaved_edit_by_another_tool_breaks_the_chain_detectably() {
+    let doc = tmp("chain_broken");
+    std::fs::copy(SAMPLE, &doc).expect("샘플 복사");
+
+    let find1 = existing_snippet(&doc);
+    let journal1 = run_plan_in_place(&doc, &find1, &find1);
+
+    // "다른 도구" — run 계획서가 아니라 단발 edit 진입점으로 같은 문서를 고친다.
+    let find_for_other_tool = existing_snippet(&doc);
+    let o = run(&[
+        "edit",
+        "replace-text",
+        doc.to_str().unwrap(),
+        "--find",
+        &find_for_other_tool,
+        "--replace",
+        "다른도구",
+        "-o",
+        doc.to_str().unwrap(),
+        "--json",
+    ]);
+    assert_eq!(
+        o.status.code(),
+        Some(0),
+        "끼어든 편집 실패: {}",
+        String::from_utf8_lossy(&o.stdout)
+    );
+
+    // preconditions 없이 계획 2를 실행 — R22 의 차단이 아니라 R23 의 탐지를 본다.
+    let find2 = existing_snippet(&doc);
+    let journal2 = run_plan_in_place(&doc, &find2, &find2);
+
+    assert_ne!(
+        journal1["outputSha256"], journal2["inputSha256"],
+        "끼어든 편집이 있었는데도 저널이 연속으로 보이면 사슬이 탐지력을 잃은 것이다\n저널1: {journal1}\n저널2: {journal2}"
+    );
+    let _ = std::fs::remove_file(&doc);
+}


### PR DESCRIPTION
## 동기

#3905 M1이 드러낸 경합을 R22(#4922, `preconditions.inputSha256` CAS)가 **미래 실행**에 대해서만 막았습니다 — 계획을 세우기 전에 알고 있어야 씁니다. 그런데 **과거 실행들이 정말 사슬로 이어졌는지**(A의 산출을 B가 그대로 이어받았는지, 아니면 그 사이 다른 도구가 손댔는지)는 저널만 봐서는 알 수 없었습니다. `run` 저널은 `input`/`output` **경로**만 싣고 **바이트 지문**은 안 실었습니다. 트랙 C 문서가 R23 착수 게이트로 적어 둔 "R22가 먼저 정리돼야 같은 해시 축을 쓸 수 있다"가 #4922로 열렸습니다.

## 설계

새 해시 계산이 아니라 **R22가 이미 만든 `sha256_hex_of`를 그대로 재사용**합니다 — CAS 대조에 쓴 지문과 저널에 남기는 지문이 다른 함수면 사슬이 애초에 안 맞습니다. `run_plan_engine`에서:

- **`inputSha256`** — 읽어들인 `bytes`(CAS 대조 여부와 무관하게 매번)의 지문.
- **`outputSha256`** — 실제로 디스크에 쓴 `out_bytes`의 지문(재파싱 후 다시 재는 게 아니라 "쓴 것"을 직접 찍음).

소비자는 저널 N개를 훑어 `journal[i].outputSha256 == journal[i+1].inputSha256`이면 연속 실행, 다르면 그 사이 외부 개입이 있었다는 뜻입니다. **차단이 아니라 표지입니다** — R22가 "미래를 막는" 축이라면 R23은 "과거를 재구성하는" 축입니다.

`replay` 영수증에도 동명 필드가 있지만 문맥이 다릅니다(임시 재실행 증명 vs 저널 사슬) — 같은 해시 함수, 다른 대상이라 `agent_knowledge_map.md`에 그 구분을 명시했습니다.

## 사용법

```json
// 실행 1 저널
{ "output": "a.hwpx", "inputSha256": "aaa...", "outputSha256": "bbb..." }
// 실행 2 저널 (a.hwpx를 그대로 입력으로 받음)
{ "input": "a.hwpx", "inputSha256": "bbb...", ... }   // bbb == bbb → 연속
```

외부 도구가 실행 1과 2 사이에 `a.hwpx`를 건드리면 실행 2의 `inputSha256`이 `bbb`와 달라져 저널만으로 개입이 드러납니다.

## 테스트

`tests/run_plan_journal_hash_chain_contract.rs` **5 tests, 0 failed**:

```
test journal_carries_input_and_output_sha256 ... ok
test journal_output_sha256_matches_actual_written_bytes ... ok
test journal_input_sha256_matches_actual_input_bytes ... ok
test consecutive_runs_chain_output_to_input ... ok
test interleaved_edit_by_another_tool_breaks_the_chain_detectably ... ok
```

고정한 것: 두 필드가 저널에 실제로 실림 / `outputSha256`이 디스크에 쓴 바이트와 정확히 일치(재계산이 아니라 동일 소스) / `inputSha256`이 실제 입력 바이트와 일치 / 연속 두 실행에서 A의 outputSha256 = B의 inputSha256 / **다른 도구가 중간에 개입하면 체인이 감지 가능하게 끊김**(핵심 시나리오).

`cargo clippy --lib --bin rhwp -- -D warnings` 통과, `rustfmt --edition 2021 --check` 통과.

## 범위

`src/main.rs`(run_plan_engine 지문 계산·저널 필드, capabilities/mcp_tool_definitions recordFields 등재), `mydocs/manual/agent_knowledge_map.md`(§2-2 필드 사전 2행), 신규 테스트 1개 파일. `planSchemaVersion` 무변경(저널 출력 추가일 뿐 계획서 입력 문법 불변).

## 로드맵 정합성

R23(트랙 C) DoD를 닫습니다. R22 위 스택 — 같은 해시 함수 재사용으로 CAS 지문과 저널 지문이 하나의 축으로 이어집니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
