### PR TITLE
feat(strategist): SWS/1.0 감사기를 engagement.py --validate 게이트에 자동 배선

### DIFF
--- a/.claude/agents/rhwp-strategist.md
+++ b/.claude/agents/rhwp-strategist.md
@@ -56,10 +56,14 @@ engagement.py --validate spec.json  ← 근거 대장 밖 주장은 exit 3 으�
    python3 tools/strategist/engagement.py --validate spec.json --evidence evidence.json
    ```
    exit 3 이면 위반 목록(`unlinked`/`unknown-evidence`/`placeholder`)을 고치고
-   재검증한다. 게이트를 통과하지 못한 spec 은 납품하지 않는다.
+   재검증한다. 게이트를 통과하지 못한 spec 은 납품하지 않는다. 같은 호출이
+   SWS/1.0 자동 감사(`sws_audit.json`)도 함께 남긴다 — 도달 레벨(SW-L1~L5)을
+   확인하고, L1(재독 검증) 미달이면 원인(인용 불일치·좌표 표류)을 먼저 고친다.
 5. **납품** — `scaffold` 가 광고된 빌드면 HWPX 산출물까지, 아니면 검증된
-   `spec.json` 과 근거 대장을 함께 납품하고 그 사실을 명시한다. 회신은 chief
-   와 같은 3부: 확인한 것(지도·대장 수치) / 산출물 / 다음.
+   `spec.json` 과 근거 대장을 함께 납품하고 그 사실을 명시한다. `sws_audit.json`
+   의 도달 레벨을 회신에 명시한다(SWS/1.0 §legitimacy — 낮은 레벨은 역량
+   판정이 아니라 정직한 현황이다). 회신은 chief 와 같은 3부: 확인한 것
+   (지도·대장 수치·SWS 도달 레벨) / 산출물 / 다음.
 
 ## 원칙
 

--- a/mydocs/manual/strategist_playbook.md
+++ b/mydocs/manual/strategist_playbook.md
@@ -59,7 +59,7 @@ engagement.json: {"objective": "…",             # 필수 — 고객 목표 문
 | A 코퍼스 지도 | 문서별 `info --json` (+광고되면 `explain --json`) | `corpus_map.json` |
 | B 근거 대장 | 질문 키워드별 `search --json` (+광고되면 `extract-data` 날짜·금액) | `evidence.json` |
 | C 산출물 골격 | scaffold_schema_v1 명세 — CLAIM 플레이스홀더 + 근거 연결표 | `spec.json` (+`deliverable.hwpx`) |
-| D 게이트 | `--validate <완성 spec>` — 주장-근거 연결의 기계 검증 | 판정 봉투 (exit 0/3) |
+| D 게이트 | `--validate <완성 spec>` — 주장-근거 연결의 기계 검증 + SWS/1.0 자동 감사 | 판정 봉투 (exit 0/3), `sws_deliverable.json`, `sws_audit.json` |
 
 C 의 HWPX 생성은 **`scaffold` 가 `capabilities` 에 광고된 경우에만** 실행한다
 (scaffold 는 #4888, devel 미포함 빌드에서는 `spec.json` 까지가 산출물이고 그
@@ -104,6 +104,30 @@ C 의 HWPX 생성은 **`scaffold` 가 `capabilities` 에 광고된 경우에만*
   - `placeholder` — 플레이스홀더가 실제 주장으로 작성되지 않음
 - 매치 0건인 질문에는 CLAIM 자체가 생성되지 않는다 — "근거 없음"이 그 절의
   정직한 내용이다. 0건은 오류가 아니다.
+
+## 5.1 SWS/1.0 자동 감사 — CAP-4903 과 SWS/1.0(#4904)의 접합
+
+`--validate` 는 근거 대장 연결(§5)만 보지 않는다. 같은 호출에서 spec·ledger·
+corpus_map 을 [SWS/1.0 공개 포맷](../tech/standards/strategy_work_standard.md)으로
+옮겨 [`sws_audit.py`](../../tools/strategist/sws_audit.py)를 자동 호출하고, 도달
+레벨(SW-L1~L5)을 `sws_audit.json` 에 남긴다(`--no-sws-audit` 로 생략).
+
+이전까지는 감사기가 독립 CLI로만 있어서 산출물마다 사람이 따로 불러야 했다 —
+호출을 잊으면 검증되지 않은 산출물이 그대로 나갔다. 지금은 게이트를 통과하는
+모든 산출물이 자동으로 채점된다.
+
+- **엔진이 보장하는 만큼만 정직하게 채점된다.** 좌표(L1)·전수성(L2)은 ledger·
+  corpus_map 값 그대로 옮겨 재독까지 검증한다. 하지만 `challenge`/`falsifier`/
+  `confidence`(L3·L4)는 spec.json 골격에 아직 담을 자리가 없다 — 에이전트가
+  §5 의 CLAIM 문장에 반증 시도와 확신도를 구조화해 싣기 전까지는 L3 이상이
+  미달로 남는 것이 맞다. 낮은 도달 레벨은 실패가 아니라 포맷의 현재 한계를
+  드러내는 정직한 신호다(SWS/1.0 §legitimacy).
+- **이 판정은 exit code 를 바꾸지 않는다.** §5 의 근거 대장 연결 게이트만
+  납품 가부를 결정한다. SWS 도달 레벨은 산출물에 함께 실어 고객에게 명시할
+  근거일 뿐, 별도 차단 조건이 아니다 — 낮은 레벨로도 §5 를 통과한 산출물은
+  기존과 같이 납품 가능하고, 그 사실을 `sws_audit.json` 이 숨기지 않는다.
+- 감사 실행 자체가 실패해도(바이너리 없음 등) §5 게이트 판정은 그대로
+  유지된다 — `swsAudit.error` 로 사유만 남는다.
 
 ## 6. 종료 코드
 

--- a/mydocs/tech/standards/strategy_work_standard.json
+++ b/mydocs/tech/standards/strategy_work_standard.json
@@ -68,6 +68,7 @@
     "mydocs/tech/standards/strategy_work_standard.md",
     "mydocs/tech/standards/agent_work_standard.md",
     "tools/strategist/sws_audit.py",
-    "tools/strategist/track_record.py"
+    "tools/strategist/track_record.py",
+    "tools/strategist/engagement.py"
   ]
 }

--- a/mydocs/tech/standards/strategy_work_standard.md
+++ b/mydocs/tech/standards/strategy_work_standard.md
@@ -49,6 +49,11 @@ SW-L1 산출물보다 더 좋은 전략이라는 뜻이 아니다 — 더 **되�
 
 자기 채점: `python tools/strategist/sws_audit.py <deliverable.json> --bin <rhwp> --level L1 --json`
 
+이 감사기는 독립 CLI 로도 쓰지만, [`tools/strategist/engagement.py`](../../../tools/strategist/engagement.py)
+`--validate` 가 산출물마다 **자동으로** 호출한다([Strategist playbook §5.1](../../manual/strategist_playbook.md#51-sws10-자동-감사--cap-4903-과-sws104904의-접합))
+— 사람이 감사를 잊고 산출물을 내보내는 경로를 막는다. 엔진이 실제로 채워 주는
+좌표(L1)·전수성(L2) 이상은 spec 골격에 아직 자리가 없어 정직하게 미달로 남는다.
+
 ## 왜 이 다섯 개인가
 
 각 레벨은 전략 산출물의 **알려진 실패 양식** 하나씩에 대응한다.

--- a/tools/strategist/engagement.py
+++ b/tools/strategist/engagement.py
@@ -34,6 +34,13 @@
                    scaffold 가 capabilities 에 광고된 경우에만 deliverable.hwpx 까지
     D 게이트       --validate <완성된 spec.json> — 모든 CLAIM 이 근거 대장에
                    실존하는 EV id 에 연결됐는지 검증. 판정은 예외가 아니라 데이터다.
+                   같은 호출에서 산출을 [SWS/1.0](../../mydocs/tech/standards/
+                   strategy_work_standard.md) 공개 포맷(sws_deliverable.json)으로
+                   옮겨 `sws_audit.py` 를 자동 호출하고, 도달 레벨을 sws_audit.json
+                   에 남긴다(`--no-sws-audit` 로 생략 가능). 이 판정은 exit code를
+                   바꾸지 않는다 — 엔진이 보장하는 범위(L1·L2)를 넘는 L3~L5 는
+                   에이전트의 전략 판단이 아직 spec 에 실리지 않았으면 정직하게
+                   미달로 남기기 때문이다.
 
 ## 사용
 
@@ -49,11 +56,14 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
+import os
 import re
 import shutil
 import subprocess
 import sys
+from datetime import date
 from pathlib import Path
 
 GENERATED_BY = "tools/strategist/engagement.py"
@@ -366,6 +376,106 @@ def validate_spec(spec: dict, ledger: dict) -> dict:
     }
 
 
+# --- SWS/1.0 게이트 (--validate 에 얹는 자동 감사) -----------------------------
+
+def _load_sws_audit():
+    """`sws_audit.py` 를 모듈로 로드한다 — subprocess 왕복 없이 같은 프로세스에서
+    감사기 함수(audit/Rereader)를 그대로 재사용한다. 두 파일은 같은 디렉터리에
+    있고 패키지가 아니므로 파일 경로로 직접 로드한다."""
+    path = Path(__file__).resolve().parent / "sws_audit.py"
+    spec = importlib.util.spec_from_file_location("sws_audit", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+def build_sws_deliverable(objective: str, ledger: dict, spec: dict,
+                          corpus_map: dict | None) -> dict:
+    """engagement.py 산출(ledger/spec/corpus_map)을 SWS/1.0 공개 포맷
+    (`mydocs/tech/standards/strategy_work_standard.json` 의 deliverableFormat)
+    으로 옮긴다. 엔진이 실제로 보장하는 것만 옮긴다 — 좌표·전수성(L1·L2)은
+    ledger·corpus_map 값 그대로다. challenge/falsifier/confidence(L3·L4)는
+    산출물 골격(spec.json)에 아직 실릴 자리가 없는 필드라 지어내지 않는다:
+    그 레벨은 미달로 정직하게 남는다(에이전트가 spec 에 반영해야 채워진다)."""
+    evidence = []
+    for e in ledger.get("entries", []):
+        locator = {k: e[k] for k in ("section", "paragraph", "page", "charOffset")
+                  if k in e}
+        evidence.append({
+            "id": e.get("id"), "file": e.get("file"), "locator": locator,
+            "quote": e.get("quote"), "command": e.get("command"),
+        })
+
+    if corpus_map is not None:
+        docs = corpus_map.get("documents", [])
+        declared = [d["file"] for d in docs]
+        read = [d["file"] for d in docs if d.get("status") == "ok"]
+        unreadable = [{"path": d["file"], "reason": f"info exit {d.get('infoExit')}"}
+                     for d in docs if d.get("status") != "ok"]
+    else:
+        # corpus_map.json 이 spec 옆에 없다(예: --out 을 달리 쓴 호출) — 근거가
+        # 실제로 인용한 파일만이라도 선언·읽음으로 남긴다. 미읽음 사유는 이
+        # 경로에서는 알 수 없으므로 지어내지 않고 비워 둔다.
+        files = sorted({e["file"] for e in evidence if e.get("file")})
+        declared = read = files
+        unreadable = []
+
+    known_ev = {e["id"] for e in evidence}
+    claims = []
+    for block in spec.get("blocks", []):
+        if block.get("type") not in ("heading", "paragraph"):
+            continue
+        text = block.get("text")
+        if not isinstance(text, str):
+            continue
+        claim_ids = sorted(set(CLAIM_RE.findall(text)), key=int)
+        if not claim_ids:
+            continue
+        ev_ids = [f"EV-{n}" for n in EV_RE.findall(text) if f"EV-{n}" in known_ev]
+        for n in claim_ids:
+            claims.append({"id": f"CLAIM-{n}", "text": text, "evidence": ev_ids})
+
+    return {
+        "engagement": objective,
+        "corpus": {"declared": declared, "read": read, "unreadable": unreadable},
+        "evidence": evidence,
+        "claims": claims,
+    }
+
+
+def run_sws_audit(objective: str, spec: dict, ledger: dict, spec_path: Path,
+                  bin_path: str | None) -> dict:
+    """SWS 감사를 실행하고 산출물(sws_deliverable.json)과 리포트(sws_audit.json)를
+    spec.json 옆에 남긴다. 실행 실패로 전체 --validate 를 막지 않는다 — 감사는
+    부가 판정이지 근거 대장 연결 게이트(validate_spec)를 대체하지 않는다."""
+    corpus_map_path = spec_path.parent / "corpus_map.json"
+    corpus_map = load_json(corpus_map_path) if corpus_map_path.is_file() else None
+    deliverable = build_sws_deliverable(objective, ledger, spec, corpus_map)
+    deliverable_path = spec_path.parent / "sws_deliverable.json"
+    dump_json(deliverable_path, deliverable)
+
+    # 재독 기준 폴더 — 근거의 file 은 corpus 루트 기준 상대경로다(engagement.py
+    # 의 build_ledger 가 corpus.relative_to(corpus) 로 채운다). --out 을
+    # 기본값(engagement.json 옆)으로 썼다면 corpus_map.json 의 corpus 값이 바로
+    # spec.json 기준 상대경로이므로 그대로 이어붙인다. 없으면 spec 폴더로
+    # 대체한다(문서를 못 찾으면 L1 이 정직하게 미달로 남는다).
+    base = spec_path.parent
+    if corpus_map and corpus_map.get("corpus"):
+        corpus_root = Path(corpus_map["corpus"])
+        base = corpus_root if corpus_root.is_absolute() else spec_path.parent / corpus_root
+
+    sws_audit = _load_sws_audit()
+    rr = sws_audit.Rereader(bin_path, base)
+    report = sws_audit.audit(deliverable, rr, base, date.today())
+    report["standard"] = "SWS/1.0"
+    report["deliverable"] = deliverable_path.as_posix()
+    report["rereadVerified"] = bool(bin_path)
+    report_path = spec_path.parent / "sws_audit.json"
+    dump_json(report_path, report)
+    return {"attained": report["attained"], "rereadVerified": report["rereadVerified"],
+            "deliverableFile": deliverable_path.name, "reportFile": report_path.name}
+
+
 # --- 실행 ---------------------------------------------------------------------
 
 def run_engagement(args) -> int:
@@ -402,7 +512,6 @@ def run_engagement(args) -> int:
         log(f"corpus 에 .hwp/.hwpx 문서가 없다: {corpus}")
         return 2
 
-    import os
     bin_path = args.bin or os.environ.get("RHWP_BIN") or shutil.which("rhwp")
     if not bin_path or not (Path(bin_path).is_file() or shutil.which(bin_path)):
         log("rhwp 바이너리를 찾을 수 없다 (--bin / RHWP_BIN / PATH)")
@@ -491,6 +600,17 @@ def run_validate(args) -> int:
         log(f"JSON 파싱 실패: {e}")
         return 2
     judgment = validate_spec(spec, ledger)
+
+    if not args.no_sws_audit:
+        bin_path = args.bin or os.environ.get("RHWP_BIN") or shutil.which("rhwp")
+        objective = spec.get("title") or ""
+        try:
+            judgment["swsAudit"] = run_sws_audit(objective, spec, ledger, spec_path,
+                                                 bin_path)
+        except Exception as e:  # noqa: BLE001 — 감사 실패로 게이트 결과 자체를 잃지 않는다
+            judgment["swsAudit"] = {"error": str(e)}
+            log(f"SWS 감사 실행 실패(게이트 판정에는 영향 없음): {e}")
+
     print(json.dumps(judgment, ensure_ascii=False, indent=1))
     return 0 if judgment["verdict"] == "pass" else 3
 
@@ -508,6 +628,8 @@ def main(argv=None) -> int:
                     help="완성된 spec.json 의 주장-근거 연결 검증 (exit 3 = 위반 존재)")
     ap.add_argument("--evidence", metavar="LEDGER", default=None,
                     help="--validate 에 쓸 근거 대장 (기본: spec 옆 evidence.json)")
+    ap.add_argument("--no-sws-audit", action="store_true",
+                    help="--validate 에서 SWS/1.0 자동 감사(sws_audit.json 산출)를 생략한다")
     ap.add_argument("--timeout", type=float, default=30.0)
     args = ap.parse_args(argv)
 


### PR DESCRIPTION
## 문제

SWS/1.0 표준과 재독 감사기 `tools/strategist/sws_audit.py`(#4904, 이미 devel 병합)는
지금까지 독립 CLI로만 존재했다. strategist 산출 경로(CAP-4903,
`tools/strategist/engagement.py`)의 `--validate` 게이트는 근거 대장 연결(주장이
실존 EV id를 인용하는지)만 검사하고, **그 인용이 실제로 원문에 있는지는 검사하지
않았다** — 지어낸 인용이나 표류한 좌표를 CLAIM에 적어도 §5 게이트는 통과했다.
사람이 `sws_audit.py`를 따로 호출하지 않으면 검증되지 않은 산출물이 그대로
납품될 수 있었다.

## 원인

두 도구가 같은 파이프라인의 이웃 단계인데도 서로를 호출하지 않았다.
`sws_audit.py`가 기대하는 산출물 스키마(`engagement`/`corpus`/`evidence`/`claims`,
표준 정본의 `deliverableFormat`)와 `engagement.py`가 실제로 쓰는 산출
(`spec.json`의 blocks + `evidence.json`의 ledger entries)의 형태가 달라, 자동
연결에는 변환 계층이 필요했다 — 이게 지금까지 비어 있었다.

## 수정

`tools/strategist/engagement.py`의 `run_validate()`에 자동 훅을 추가했다:

1. `build_sws_deliverable()` — spec.json(blocks 속 CLAIM-N/EV-N 텍스트)과
   evidence.json(ledger entries)을 SWS/1.0 공개 포맷으로 변환한다. 엔진이 실제로
   보장하는 것(좌표·전수성)만 옮기고, spec 골격에 아직 자리가 없는
   `challenge`/`falsifier`/`confidence`(SW-L3·L4)는 지어내지 않는다 — 그 레벨은
   정직하게 미달로 남는다.
2. `run_sws_audit()` — `sws_audit.py`를 같은 프로세스에 모듈로 로드해(subprocess
   왕복 없이) `audit()`을 호출하고, `sws_deliverable.json`·`sws_audit.json`을
   spec.json 옆에 남긴다. corpus 루트를 corpus_map.json에서 읽어 재독이 실제
   문서를 찾도록 경로를 맞췄다.
3. `--validate` 출력 JSON에 `swsAudit` 요약(도달 레벨)을 얹는다. **§5 게이트의
   exit code는 바꾸지 않는다** — SWS 판정은 부가 기록이지 새 차단 조건이 아니다
   (opt-out: `--no-sws-audit`).

문서 배선: `mydocs/manual/strategist_playbook.md`(§5.1 신설),
`.claude/agents/rhwp-strategist.md`(4·5단계에 SWS 감사 언급),
`mydocs/tech/standards/strategy_work_standard.md`(자동 배선 명시),
`.json`의 `surfaces`에 `engagement.py` 추가.

## 검증

- `python tools/strategist/sws_audit.py --self-check` → 문제 0건
- `python -m pytest scripts/tests/test_automation_tool_contracts.py` → 13건 통과
  (PR #4904 리뷰가 언급한 "Python 도구 계약 13건"과 동일 스위트, 회귀 없음)
- red→green 실증 — `cargo build --bin rhwp`(로컬 디버그 빌드)와 실 코퍼스
  (`samples/*.hwpx`)로 엔진 A→D 전 단계를 실행:
  - **green**: 실제 인용·좌표로 CLAIM을 채운 spec → `swsAudit.attained: "SW-L2"`,
    `rereadVerified: true` (L1·L2 통과, L3~L5는 정직하게 미달)
  - **red 1**(지어낸 인용): evidence의 quote를 원문에 없는 문장으로 바꾸면
    → SW-L1이 `"원문에서 인용을 찾지 못했다"`로 거부, `attained: null`
  - **red 2**(표류한 좌표): 실제 인용은 그대로 두고 `paragraph` 좌표만 바꾸면
    → SW-L1이 `"paragraph 좌표 불일치: 선언 999, 실제 매치 [42]"`로 거부
  - `--no-sws-audit`로 생략 시 `sws_audit.json`이 생성되지 않음을 확인, 바이너리
    부재 시(`rereadVerified: false`)에도 `--validate` 자체는 죽지 않음을 확인
- `scripts/tests/` 전체 실행 시 무관한 3개 파일(`test_cache_sweep_workflow.py`,
  `test_release_channel_policy_workflow.py`, `test_visual_sweep.py`)에서 기존
  실패가 있었으나 `engagement`/`strategist`를 참조하지 않아(grep 확인) 본 변경과
  무관 — 별도 환경 의존 이슈로 보인다.

diff는 5개 파일, +162/-6 (Python 로직 1파일 + 문서 4파일).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
