### PR TITLE
feat(dar): DATP 참조 드라이버에 COMMIT 전 정책 게이트 — DAR 층 3 격차 봉합

### DIFF
--- a/mydocs/tech/standards/document_agent_runtime.md
+++ b/mydocs/tech/standards/document_agent_runtime.md
@@ -32,7 +32,7 @@ rhwp 를 "에이전트 도구가 딸린 문서 엔진"에서 **검증 가능하�
 |---|---|---|---|
 | 1 | 문서 에이전트 프로토콜 (DAP) | **빠짐** | 봉투마다 `schemaVersion` 은 있으나 요청·트랜잭션 신원과 안정 오류 코드를 묶는 프로토콜 이름이 없다 → [DAP/1.0](document_agent_protocol.md) |
 | 2 | 문서 트랜잭션 프로토콜 (DATP) | **실질 있음·이름 없음** | `run`(선언적 계획·정적 선검증·원자 실행·저널) + `replay`(입력·계획·산출 3해시 영수증, `--expect-output-sha256` 제3자 재현, 불일치 exit 3) → [DATP/1.0](document_transaction_protocol.md) 이 이를 형식화 |
-| 3 | 샌드박스·정책 엔진 | **빠짐** | 능력 축소(MCP 프로필)는 있으나 작업 단위 정책 서술·집행·해시가 없다 |
+| 3 | 샌드박스·정책 엔진 | **부분** | 능력 축소(MCP 프로필) + DATP 참조 드라이버의 COMMIT 전 집행(`tools/dar/transaction.py commit --policy`: `admissionPolicy` 서술 → 위반은 4000 으로 커밋 차단, 통과분은 `policySha256` 을 영수증에 기록). `rhwp run`(러스트 본체) 에는 아직 미결속 |
 | 4 | 능력 등록부 | **있음** | `capabilities`·`export-agent-manifest`·[capability 카탈로그](../../manual/agent_capability_registry.md) |
 | 5 | 문서 에이전트 벤치마크 | **부분** | `gym/` 과제 팩·`tools/agent_bench` 존재. 표준 점수 계약 미정 |
 | 6 | 문서 컴파일러 / IR | **있음** | 전 포맷 파서가 공통 `Document` IR 반환([parser_architecture](../parser_architecture.md)), `export-ir-schema` 로 자기서술 |

--- a/tools/dar/conformance.py
+++ b/tools/dar/conformance.py
@@ -198,8 +198,22 @@ def check_datp(bin_path: str) -> list[dict]:
         driver_ok,
         "tools/dar/transaction.py 참조 드라이버가 전이표·validated 게이트·사후 검증으로 강제"
         if driver_ok else "미구현 — 참조 드라이버 없음")
-    add("정책 해시(policySha256)가 영수증에 실린다", False,
-        "미구현 — 정책 엔진(DAR 층 3) 대상")
+    # 정책 엔진(DAR 층 3) — COMMIT 전 집행 + 정책 해시가 영수증에 실리는가.
+    # 상태기계 검사와 같은 근거 등급: 참조 드라이버 소스에서 표지를 확인한다
+    # (rhwp gate/audit --policy 는 이미 끝난 캡슐을 심사하는 별개 표면이고,
+    # 여기서 보는 것은 COMMIT 자체를 가르는 policy_gate.rs 와 같은 설계다).
+    policy_wired = driver_ok
+    if policy_wired:
+        policy_wired = ("--policy" in src
+                        and "def parse_policy" in src
+                        and "def evaluate_policy" in src
+                        and 'tx.state["policySha256"] = policy_sha' in src
+                        and "4000" in src)
+    add("정책 해시(policySha256)가 영수증에 실린다 — 위반 시 COMMIT 자체가 거부된다",
+        policy_wired,
+        "tools/dar/transaction.py: commit --policy → 위반은 4000으로 커밋 차단(디스크 무변경), "
+        "통과는 policySha256을 영수증에 기록"
+        if policy_wired else "미구현 — 정책 엔진(DAR 층 3) 대상")
     _ = datp
     return checks
 

--- a/tools/dar/transaction.py
+++ b/tools/dar/transaction.py
@@ -25,6 +25,7 @@ MODIFY 는 원본 무훼손, 한 트랜잭션은 한 입력 해시. **선언만�
     python3 $T validate --tx <id>
     python3 $T diff     --tx <id>
     python3 $T commit   --tx <id> -o 산출.hwpx      # VALIDATE 성공 없으면 거절
+    python3 $T commit   --tx <id> -o 산출.hwpx --policy policy.json  # 정책 위반이면 거절(4000)
     python3 $T rollback --tx <id>
     python3 $T replay   --tx <id>                    # 영수증 재실행 상태를 기록
     python3 $T verify   --tx <id>                    # 영수증·입출력 해시 검증 상태를 기록
@@ -32,6 +33,19 @@ MODIFY 는 원본 무훼손, 한 트랜잭션은 한 입력 해시. **선언만�
 
 종료 코드는 DAP/1.0 오류 코드의 상위 1자리다: 0 성공 / 1 런타임 / 2 사용법 /
 3 판정 / 4 정책. **판정(3)은 실패가 아니라 결과다.**
+
+## 정책 (DAR 층 3 — COMMIT 전 집행)
+
+`--policy <policy.json>` 은 [`src/policy_gate.rs`](../../src/policy_gate.rs) 와 같은
+JSON 모양(`kind: admissionPolicy`, `eq|in|gte|lte` 4연산자, 미지 키는 로드 시점
+오류)을 쓰지만 **다른 판정 사전**이다 — `policy_gate.rs` 는 이미 끝난 작업 캡슐의
+계보·서명·앵커를 재계산해 반입을 가른다(`rhwp gate`/`rhwp audit --policy`); 이
+드라이버는 아직 COMMIT 되지 않은 트랜잭션 자신의 제안을 가른다. 그래서 판정 키
+사전이 다르다(POLICY_JUDGMENT_KEYS): `op`(제안 연산) · `format`(문서 포맷) ·
+`validated`(VALIDATE 통과 여부). 정책이 거부하면 COMMIT 은 4000 으로 떨어지고
+디스크는 무변경이다 — 산출 복사도 영수증 기록도 일어나지 않는다. 정책 해시
+(`policySha256`)는 통과한 COMMIT 의 영수증에 실려, 나중에 "그때 어느 정책판으로
+심사했는가"를 소급 없이 증언한다.
 """
 
 from __future__ import annotations
@@ -79,6 +93,70 @@ def sha256_file(p: Path) -> str:
 def sha256_obj(obj) -> str:
     return hashlib.sha256(
         json.dumps(obj, ensure_ascii=False, sort_keys=True).encode("utf-8")).hexdigest()
+
+
+# --- COMMIT 전 정책 (DAR 층 3) ------------------------------------------------
+#
+# src/policy_gate.rs 와 같은 정책 언어(연산자 4개, 미지 키는 로드 시점 거부,
+# default_deny)를 쓰되 다른 판정 사전을 쓴다 — 위 모듈 docstring 참고. 새 정책
+# 엔진을 짓는 게 아니라 그 설계를 COMMIT 문맥에 맞는 사전으로 재사용한다.
+
+POLICY_JUDGMENT_KEYS = ("op", "format", "validated")
+POLICY_OPS = ("eq", "in", "gte", "lte")
+
+
+def parse_policy(text: str) -> dict:
+    """정책 JSON을 파싱하고 키·연산자를 사전 대조한다 — 위반은 ValueError."""
+    v = json.loads(text)
+    if v.get("kind") != "admissionPolicy":
+        raise ValueError("정책 kind 가 admissionPolicy 가 아닙니다")
+    default_verdict = v.get("defaultVerdict", "deny")
+    if default_verdict not in ("deny", "allow"):
+        raise ValueError(f"미지 defaultVerdict: {default_verdict} (deny|allow)")
+    rules = []
+    for idx, rule in enumerate(v.get("rules") or []):
+        rid = rule.get("id") or f"R{idx}"
+        req = rule.get("require")
+        if not isinstance(req, dict):
+            raise ValueError(f"{rid}: require 객체가 필요합니다")
+        require = []
+        for key, cond in req.items():
+            if key not in POLICY_JUDGMENT_KEYS:
+                raise ValueError(
+                    f"{rid}: 미지 판정 키 `{key}` — 사전: {list(POLICY_JUDGMENT_KEYS)} "
+                    "(오타는 항상-참 구멍이 되므로 로드 시점에 거부한다)")
+            if not isinstance(cond, dict):
+                raise ValueError(f"{rid}.{key}: {{연산자: 값}} 객체가 필요합니다")
+            for op, expected in cond.items():
+                if op not in POLICY_OPS:
+                    raise ValueError(f"{rid}.{key}: 미지 연산자 `{op}` — 허용: {list(POLICY_OPS)}")
+                require.append((key, op, expected))
+        rules.append({"id": rid, "require": require})
+    return {"name": v.get("name") or "(이름 없음)", "defaultDeny": default_verdict != "allow",
+            "rules": rules}
+
+
+def evaluate_policy(policy: dict, judgments: dict) -> tuple[bool, list]:
+    """평가 — (verdict allow?, violations). 게이트는 모르는 것을 통과시키지 않는다."""
+    violations = []
+    for rule in policy["rules"]:
+        for key, op, expected in rule["require"]:
+            actual = judgments.get(key)
+            if op == "eq":
+                ok = actual == expected
+            elif op == "in":
+                ok = isinstance(expected, list) and actual in expected
+            elif op == "gte":
+                ok = isinstance(actual, (int, float)) and not isinstance(actual, bool) and actual >= expected
+            elif op == "lte":
+                ok = isinstance(actual, (int, float)) and not isinstance(actual, bool) and actual <= expected
+            else:  # pragma: no cover — parse_policy 가 이미 막는다
+                ok = False
+            if not ok:
+                violations.append({"rule": rule["id"], "key": key, "op": op,
+                                   "expected": expected, "actual": actual})
+    allow = (not policy["defaultDeny"]) if not policy["rules"] else not violations
+    return allow, violations
 
 
 def envelope(request_id, operation, status, code, record=None, tx=None,
@@ -392,6 +470,39 @@ def op_commit(a, tx: Tx) -> int:
         return emit(envelope(rid, "transaction.commit", "error", 2000,
                              tx=tx.state["transactionId"],
                              record={"reason": f"산출 경로가 이미 있다: {final} (--overwrite 필요)"}))
+
+    # 정책 (DAR 층 3) — COMMIT 직전, 아직 아무것도 쓰지 않은 시점에 가른다.
+    policy_sha = None
+    policy_path = getattr(a, "policy", None)
+    if policy_path:
+        try:
+            policy_text = Path(policy_path).read_text(encoding="utf-8")
+        except OSError as e:
+            return emit(envelope(rid, "transaction.commit", "error", 2000,
+                                 tx=tx.state["transactionId"],
+                                 record={"reason": f"정책을 읽을 수 없다 - {policy_path}: {e}"}))
+        policy_sha = hashlib.sha256(policy_text.encode("utf-8")).hexdigest()
+        try:
+            policy = parse_policy(policy_text)
+        except (ValueError, json.JSONDecodeError) as e:
+            return emit(envelope(rid, "transaction.commit", "error", 2000,
+                                 tx=tx.state["transactionId"],
+                                 record={"reason": f"정책 사용법 오류: {e}"}))
+        judgments = {
+            "op": tx.state["proposal"]["op"],
+            "format": tx.state["format"],
+            "validated": tx.state["validated"],
+        }
+        allow, violations = evaluate_policy(policy, judgments)
+        if not allow:
+            # 정책 위반은 오류가 아니라 판정(4000)이다 — 원본·작업본 무훼손, COMMIT 미실행.
+            return emit(envelope(rid, "transaction.commit", "verdict", 4000,
+                                 tx=tx.state["transactionId"],
+                                 record={"reason": "정책이 이 COMMIT을 거부했다",
+                                         "policy": policy["name"], "policySha256": policy_sha,
+                                         "violations": violations, "commitBlocked": True}))
+    tx.state["policySha256"] = policy_sha
+
     final.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(out, final)
 
@@ -564,6 +675,7 @@ def main(argv=None) -> int:
         x = sub.add_parser(name); x.add_argument("--tx", required=True)
     c = sub.add_parser("commit"); c.add_argument("--tx", required=True)
     c.add_argument("-o", "--output", required=True); c.add_argument("--overwrite", action="store_true")
+    c.add_argument("--policy", help="admissionPolicy JSON — 위반 시 COMMIT 거부(4000), 통과 시 해시를 영수증에 기록")
     rp = sub.add_parser("replay")
     replay_input = rp.add_mutually_exclusive_group(required=True)
     replay_input.add_argument("--receipt")


### PR DESCRIPTION
## 요약

DAR 척추 문서(`mydocs/tech/standards/document_agent_runtime.md`)가 층 3(샌드박스·정책
엔진)을 "빠짐"으로 실측 보고했고, `tools/dar/conformance.py`의 다음 검사는 조건 없이
`False`로 하드코딩돼 있었다:

```python
add("정책 해시(policySha256)가 영수증에 실린다", False,
    "미구현 — 정책 엔진(DAR 층 3) 대상")
```

먼저 `src/policy_gate.rs`·`rhwp gate`·`rhwp audit --policy` 를 전수 확인했다 — 이미
존재하지만 전부 **이미 끝난 작업 캡슐을 사후 심사**하는 반입 게이트다(계보·서명·앵커
재계산). DATP 상태기계의 `COMMIT` 연산 자체를 가르는 장치는 어디에도 없었다 — 참조
드라이버 `tools/dar/transaction.py`의 영수증 스키마는 `policySha256` 필드를 이미 갖고
있었지만 아무도 채우지 않는 죽은 필드였다(`tx.state.get("policySha256")` → 항상 `None`).

## 원인

DAP/DATP 결속(1단계)이 끝난 뒤에야 정책 엔진(2단계)을 얹는다는 로드맵 순서상, `COMMIT`
경로에 정책 게이트가 아직 배선되지 않은 것이 정상적인 격차였다. `policy_gate.rs`의
설계(4연산자·미지 키 로드 시점 거부·default-deny)는 이미 있었지만 그 설계를 재사용해
COMMIT 문맥에 물릴 자리가 없었다.

## 수정

`tools/dar/transaction.py`의 `commit` 서브커맨드에 `--policy <policy.json>`을 추가했다.

- `policy_gate.rs`와 같은 정책 언어(`kind: admissionPolicy`, `eq|in|gte|lte`, 미지 키
  로드 시점 거부, default-deny)를 그대로 재사용하되, 판정 사전은 COMMIT 문맥에 맞게
  좁혔다: `op`(제안 연산)·`format`(문서 포맷)·`validated`(VALIDATE 통과 여부).
  `policy_gate.rs`의 계보·서명·앵커 사전과 목적이 다르다 — 그쪽은 이미 끝난 작업을,
  이쪽은 아직 커밋되지 않은 제안을 가른다.
- 정책 위반은 모듈 docstring이 이미 예고해 뒀던 "4 정책" 종료코드(`4000`)로 떨어지고,
  **파일 복사도 영수증 기록도 일어나지 않는다** — 위반은 실패가 아니라 판정이다(기존
  3xxx 판정 관례와 동일).
- 통과분은 `policySha256`(정책 파일 SHA-256)을 영수증에 기록해 "그때 어느 정책판으로
  심사했는가"를 소급 변경 없이 증언한다(DATP/1.0 문서가 이미 요구해 온 필드).
- `conformance.py`의 해당 검사를 하드코딩 `False`에서, 상태기계 검사와 같은 근거
  등급(참조 드라이버 소스 표지 확인)으로 바꿨다.
- DAR 척추 문서의 층 3 행을 "빠짐"→"부분"으로 갱신하고, 이 게이트가 `rhwp run`(러스트
  본체)에는 아직 결속되지 않았다는 것도 명시했다 — 없는 것을 있다고 적지 않는다.

## 검증

`python3 tools/dar/conformance.py --bin <rhwp>` 실측(수정 전 → 후):

```
DATP/1.0 —  9/10 →  10/10 충족
합계      — 14/18(78%) → 15/18(83%)
```

`--self-check`(정본 정합)도 문제 0건으로 유지된다.

실제 rhwp 바이너리로 KTX.hwp 표본을 갖고 BEGIN→SELECT→PROPOSE→MODIFY→VALIDATE→COMMIT
전체 사이클을 수동 실행해:

1. **거부 사례** — `format: hwpx`만 허용하는 정책으로 `.hwp` 문서를 커밋 → `exit 4`,
   `code: 4000`, 산출 파일 미생성(디스크 무변경) 확인.
2. **통과 사례** — `op: replace-text` + `validated: true`를 요구하는 정책으로 동일
   트랜잭션을 커밋 → `exit 0`, 산출 파일 생성, 영수증의 `policySha256`이 정책 파일의
   `sha256sum`과 정확히 일치함을 확인(`382272d0...`).
3. 정책 파일이 없을 때(`--policy` 미지정)는 기존 동작과 동일 — `policySha256: null`.

Python 문법 검사(`py_compile`) 통과, `ruff check`로 새 코드에 신규 lint 이슈 없음 확인
(파일에 있는 기존 E702 세미콜론 스타일 경고는 이번 변경과 무관한 기존 코드).

Rust 코드는 변경하지 않았다 — `cargo test`/`clippy`/`rustfmt` 대상 파일 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
