### PR TITLE
fix(hwpx): hp:pic offset 을 pos 유래로 재작성하지 않는다 (#4668)

### DIFF
--- a/src/serializer/hwpx/picture.rs
+++ b/src/serializer/hwpx/picture.rs
@@ -99,7 +99,7 @@ pub fn write_picture<W: Write>(
     // --- 자식 순서 (한컴 관찰 샘플 기준) ---
     // offset, orgSz, curSz, flip, rotationInfo, renderingInfo, imgRect, imgClip,
     // inMargin, imgDim, img, effects, sz, pos, outMargin
-    write_offset(w, &pic.common)?;
+    write_offset(w, &pic.shape_attr)?;
     write_org_sz(w, &pic.shape_attr)?;
     write_cur_sz(w, pic)?;
     write_flip(w, &pic.shape_attr)?;
@@ -129,9 +129,17 @@ pub fn write_picture<W: Write>(
 
 // ---------- 자식 요소 ----------
 
-fn write_offset<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), SerializeError> {
-    let x = c.horizontal_offset.to_string();
-    let y = c.vertical_offset.to_string();
+// [#4668] hp:offset 은 파서가 보존한 shape_attr.offset_x/y 원문을 되쓴다 —
+// 종전에는 pic 전용 writer 만 pos 유래(c.horizontal_offset/vertical_offset)로
+// 재유도해, 음수(u32 wraparound) offset 으로 쪽 밖에 둔 그림이 무편집 저장 후
+// 쪽 안에 노출됐다(transMatrix 병진과도 모순). 도형·OLE·컨테이너 공용
+// writer(shape.rs write_offset, #3544)와 동형.
+fn write_offset<W: Write>(
+    w: &mut Writer<W>,
+    sa: &ShapeComponentAttr,
+) -> Result<(), SerializeError> {
+    let x = (sa.offset_x as u32).to_string();
+    let y = (sa.offset_y as u32).to_string();
     empty_tag(w, "hp:offset", &[("x", &x), ("y", &y)])
 }
 

--- a/src/serializer/hwpx/roundtrip.rs
+++ b/src/serializer/hwpx/roundtrip.rs
@@ -449,7 +449,10 @@ fn diff_picture_size(
     {
         parts.push(format!(
             "offset: expected=({}, {}) actual=({}, {})",
-            a.shape_attr.offset_x, a.shape_attr.offset_y, b.shape_attr.offset_x, b.shape_attr.offset_y
+            a.shape_attr.offset_x,
+            a.shape_attr.offset_y,
+            b.shape_attr.offset_x,
+            b.shape_attr.offset_y
         ));
     }
     if parts.is_empty() {

--- a/src/serializer/hwpx/roundtrip.rs
+++ b/src/serializer/hwpx/roundtrip.rs
@@ -442,6 +442,16 @@ fn diff_picture_size(
             a.img_dim, b.img_dim
         ));
     }
+    // [#4668] hp:offset — 종전 pic writer 가 pos 유래로 재작성해도 이 게이트가
+    // offset 을 비교하지 않아 잡히지 않았다(음수 wraparound offset 그림 노출).
+    if a.shape_attr.offset_x != b.shape_attr.offset_x
+        || a.shape_attr.offset_y != b.shape_attr.offset_y
+    {
+        parts.push(format!(
+            "offset: expected=({}, {}) actual=({}, {})",
+            a.shape_attr.offset_x, a.shape_attr.offset_y, b.shape_attr.offset_x, b.shape_attr.offset_y
+        ));
+    }
     if parts.is_empty() {
         None
     } else {
@@ -2945,6 +2955,31 @@ mod tests {
                 assert_eq!(path, "/ctrl[0]pic");
                 assert!(
                     detail.contains("curSz") && detail.contains("imgDim"),
+                    "{detail}"
+                );
+            }
+            other => panic!("PictureSize 여야 함: {other:?}"),
+        }
+    }
+
+    /// [#4668] offset 재작성이 게이트에 잡혀야 한다 — 종전 PictureSize 비교가
+    /// curSz/imgRect/imgDim 만 보고 offset 을 비교하지 않아, pic writer 의 pos
+    /// 유래 offset 재작성이 왕복 검증을 통과했다.
+    #[test]
+    fn issue4668_picture_offset_diff_in_gate() {
+        let mut pa = crate::model::image::Picture::default();
+        pa.shape_attr.offset_x = 5250;
+        pa.shape_attr.offset_y = -4332;
+        let pb = crate::model::image::Picture::default(); // offset (0, 0)
+        let a = doc_with_control(crate::model::control::Control::Picture(Box::new(pa)));
+        let b = doc_with_control(crate::model::control::Control::Picture(Box::new(pb)));
+        let diff = diff_documents(&a, &b);
+        assert_eq!(diff.differences.len(), 1, "{:?}", diff.differences);
+        match &diff.differences[0] {
+            IrDifference::PictureSize { path, detail, .. } => {
+                assert_eq!(path, "/ctrl[0]pic");
+                assert!(
+                    detail.contains("offset: expected=(5250, -4332) actual=(0, 0)"),
                     "{detail}"
                 );
             }

--- a/tests/issue_4668_pic_offset_preserved.rs
+++ b/tests/issue_4668_pic_offset_preserved.rs
@@ -1,0 +1,67 @@
+//! [Issue #4668] HWPX 저장 시 `hp:pic` 의 `<hp:offset>` 이 원본 값 대신 `<hp:pos>`
+//! 의 vertOffset/horzOffset 에서 재유도되어, 저장만 해도 그림 offset 이 바뀌던
+//! 문제의 회귀 계약. 음수(u32 wraparound) offset 으로 쪽 밖에 둔 그림이 무편집
+//! 저장 후 쪽 안(문단 앵커 위치)에 노출되는 표시 변화를 한글 실측으로 확인한
+//! 결함이다 — pic 전용 writer(`picture.rs write_offset`)만 pos 유래로 방출했고,
+//! 도형·OLE·컨테이너 공용 writer(`shape.rs`, #3544)는 이미 원문을 보존한다.
+
+use std::io::Read;
+
+use rhwp::document_core::DocumentCore;
+
+/// 원본 pic 에 `<hp:offset x="5250" y="4294962964"/>`(y = −4332 wraparound)가
+/// 실존하고, 그 pic 의 `<hp:pos>` 는 vertOffset=0/horzOffset=0 인 실물 샘플.
+const SAMPLE: &str = "samples/ta-pic-cell-center-pos-bottom.hwpx";
+
+fn sample_path() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn section_xml_of(bytes: &[u8]) -> String {
+    let mut zip = zip::ZipArchive::new(std::io::Cursor::new(bytes)).expect("ZIP 열기 실패");
+    let names: Vec<String> = zip.file_names().map(str::to_string).collect();
+    let mut xml = String::new();
+    for name in names {
+        if name.starts_with("Contents/section") && name.ends_with(".xml") {
+            zip.by_name(&name)
+                .expect("section 엔트리")
+                .read_to_string(&mut xml)
+                .expect("section XML 은 UTF-8 이어야 한다");
+        }
+    }
+    xml
+}
+
+#[test]
+fn issue_4668_pic_offset_is_not_rewritten_from_pos() {
+    let bytes = std::fs::read(sample_path()).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"));
+
+    // 전제: 원본에 wraparound offset 과 pos(vertOffset=10436) 가 함께 있어야
+    // "pos 유래 재작성" 회귀를 이 샘플로 판별할 수 있다.
+    let original = section_xml_of(&bytes);
+    assert!(
+        original.contains(r#"<hp:offset x="5250" y="4294962964"/>"#),
+        "샘플 전제 위반: 원본 wraparound hp:offset 이 없다"
+    );
+    assert!(
+        original.contains(r#"vertOffset="10436""#),
+        "샘플 전제 위반: 재작성 판별용 pos vertOffset 이 없다"
+    );
+
+    let doc = DocumentCore::from_bytes(&bytes).unwrap_or_else(|e| panic!("parse {SAMPLE}: {e:?}"));
+    let exported = doc
+        .export_hwpx_native()
+        .unwrap_or_else(|e| panic!("export {SAMPLE}: {e:?}"));
+    let saved = section_xml_of(&exported);
+
+    // 계약: 원본 offset 원문이 그대로 살아 있어야 한다.
+    assert!(
+        saved.contains(r#"<hp:offset x="5250" y="4294962964"/>"#),
+        "hp:pic offset 이 원문 보존되지 않았다 — pos 유래 재작성(#4668) 재발 의심"
+    );
+    // 회귀 신호: 종전 결함의 산출 형태(pos vertOffset 을 offset y 로 복사).
+    assert!(
+        !saved.contains(r#"<hp:offset x="0" y="10436"/>"#),
+        "hp:pic offset 이 pos vertOffset 으로 재작성됐다(#4668 재발)"
+    );
+}


### PR DESCRIPTION
## 변경 요약

HWPX 저장 시 `hp:pic` 의 `<hp:offset>` 이 원본 값 대신 `<hp:pos>` 의 vertOffset/horzOffset 에서 재유도되던 문제를 고칩니다 (#4668 분석 그대로).

- **writer** — pic 전용 `picture.rs write_offset` 을 도형·OLE·컨테이너 공용 writer(`shape.rs write_offset`, #3544)와 동형으로 `shape_attr.offset_x/y` 원문 방출(u32 wraparound 부호화 유지)로 교체했습니다. 종전에는 pic 만 pos 유래(`common.horizontal_offset/vertical_offset`)로 방출해, 음수(wraparound) offset 으로 쪽 밖에 둔 그림이 **무편집 저장만으로** 쪽 안(문단 앵커 위치)에 노출됐고, 무변경으로 남는 `hc:transMatrix` 병진과도 모순이 생겼습니다.
- **게이트** — 왕복 검증의 `PictureSize` 비교(`roundtrip.rs diff_picture_size`)가 curSz/imgRect/imgDim 만 보고 offset 을 비교하지 않아 이 재작성이 잡히지 않던 사각을 막았습니다(offset 비교 추가).

## 관련 이슈

closes #4668

## 실측 (동봉 샘플 `samples/ta-pic-cell-center-pos-bottom.hwpx`)

- 원본: `<hp:offset x="5250" y="4294962964"/>` (y = −4332 wraparound), 그 pic 의 pos 는 vertOffset=0
- 종전 저장본: `<hp:offset x="0" y="10436"/>` — 다른 pic 의 pos 값으로 재작성
- 이 PR: 원문 그대로 보존

## 테스트

- [x] `cargo test` 통과 — 신규 2건(`issue_4668_pic_offset_is_not_rewritten_from_pos` 통합 테스트, `issue4668_picture_offset_diff_in_gate` 게이트 단위 테스트) 포함 전체 nextest 게이트 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] 관련 샘플 파일 실측 — 위 대조
- [ ] 웹(WASM) 렌더링 확인 (해당 없음 — 렌더 경로 무변경, 저장 방출만 변경)
- [ ] rhwp-studio 변경 없음
- [ ] 작업 증빙 — 코드 수정(문서 편집 작업 아님)

## 성능 영향 및 측정 결과

- 예상 영향: 없음
- 재현·측정: 미측정


🤖 Generated with [Claude Code](https://claude.com/claude-code)
