### PR TITLE
fix(serializer): DocInfo raw 캐시 출처 봉인 — 공개 IR 직접 변경 보존 (#4493, #4432)

### DIFF
--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -1339,10 +1339,40 @@ impl DocumentCore {
 
         let saved_hwpx_page_border_fills = self.snapshot_hwpx_page_border_fill_overlay();
         let _report = convert_if_hwpx_source(&mut self.document, self.source_format);
+        self.refresh_doc_info_raw_cache();
         self.serialize_hwp_after_adapter(
             saved_hwpx_page_border_fills,
             crate::serializer::serialize_document,
         )
+    }
+
+    /// [#4432] DocInfo raw 캐시 재밀봉 — dirty(또는 봉인 불일치) 상태로 저장에
+    /// 들어가면 매 저장마다 DocInfo 를 처음부터 재구성한다. 여기서 한 번 재구성해
+    /// raw 캐시를 그 결과로 갱신하고 dirty 를 내리면, 이번 저장은 방금 만든
+    /// 바이트를 그대로 쓰고 이후 저장은 원본 바이트 통과로 돌아간다 —
+    /// "직렬화 성공 지점에서 되돌리는 것이 자연스러운 자리" 를 &mut 저장
+    /// 진입점에서 구현한 것이다. raw 캐시가 없던 문서(HWPX/HWP3 출처)는 건드리지
+    /// 않는다(raw_stream 유무가 출처 판별에 쓰이는 경로를 오염시키지 않기 위함).
+    fn refresh_doc_info_raw_cache(&mut self) {
+        let doc = &mut self.document;
+        if doc.doc_info.raw_stream.is_none() {
+            return;
+        }
+        let dirty = doc.doc_info.raw_stream_dirty
+            || !doc
+                .doc_info
+                .raw_provenance_permits_reuse(&doc.doc_properties);
+        if !dirty {
+            return;
+        }
+        // 재구성 강제: dirty 를 세운 채 한 번 직렬화한다(통과 게이트 우회).
+        doc.doc_info.raw_stream_dirty = true;
+        let rebuilt =
+            crate::serializer::doc_info::serialize_doc_info(&doc.doc_info, &doc.doc_properties);
+        doc.doc_info.raw_stream = Some(rebuilt);
+        doc.doc_info.raw_stream_dirty = false;
+        // 방금 만든 바이트와 현재 모델을 재밀봉 — 이후 무변경 저장은 통과.
+        doc.doc_info.seal_raw_provenance(&doc.doc_properties);
     }
 
     /// 어댑터를 **복제본에 적용해** HWP5 를 낸다 — 호출자의 IR 은 그대로다.
@@ -1403,6 +1433,7 @@ impl DocumentCore {
 
         let saved_hwpx_page_border_fills = self.snapshot_hwpx_page_border_fill_overlay();
         let _report = convert_if_hwpx_source(&mut self.document, self.source_format);
+        self.refresh_doc_info_raw_cache();
         self.serialize_hwp_after_adapter(saved_hwpx_page_border_fills, |document| {
             crate::serializer::serialize_hwp_with_password(document, password)
         })

--- a/src/model/bin_data.rs
+++ b/src/model/bin_data.rs
@@ -26,7 +26,7 @@ pub struct StoredBinData {
 }
 
 /// 바이너리 데이터 아이템 (HWPTAG_BIN_DATA)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct BinData {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -49,7 +49,7 @@ pub struct BinData {
 }
 
 /// 바이너리 데이터 타입
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum BinDataType {
     #[default]
     /// 외부 파일 참조
@@ -61,7 +61,7 @@ pub enum BinDataType {
 }
 
 /// 바이너리 데이터 압축 방식
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum BinDataCompression {
     #[default]
     /// 스토리지 디폴트
@@ -73,7 +73,7 @@ pub enum BinDataCompression {
 }
 
 /// 바이너리 데이터 접근 상태
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum BinDataStatus {
     #[default]
     /// 아직 접근하지 않음

--- a/src/model/document.rs
+++ b/src/model/document.rs
@@ -47,7 +47,7 @@ pub const HWPX_ORIGIN_STREAM_PATH: &str = "/RhwpHwpxOrigin";
 pub const HWP3_ORIGIN_STREAM_PATH: &str = "/RhwpHwp3Origin";
 
 /// 파서가 모델링하지 않는 원시 레코드 (라운드트립 보존용)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct RawRecord {
     /// 태그 ID
     pub tag_id: u16,
@@ -154,7 +154,7 @@ pub struct HwpVersion {
 }
 
 /// 문서 속성 (HWPTAG_DOCUMENT_PROPERTIES)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct DocProperties {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -229,6 +229,10 @@ pub struct DocInfo {
     /// (1.2~1.5 등) 원본 값을 보존해 직렬화 때 그대로 재방출한다.
     /// 원본 HWPX가 없으면 None → serializer가 "1.2" 폴백.
     pub hwpml_version: Option<String>,
+    /// [#4493] raw_stream 출처 봉인 — 파싱(+로드 픽스업) 완료 시점의 모델 상태와
+    /// 원본 바이트의 다이제스트 쌍. 저장 시 둘 다 일치할 때만 raw 를 재사용한다.
+    /// 계약 전문은 `model::raw_provenance` 모듈 주석.
+    pub raw_provenance: Option<crate::model::raw_provenance::DocInfoSeal>,
 }
 
 /// 본문의 구역 (Section)

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -15,6 +15,7 @@ pub mod page;
 pub mod paragraph;
 pub mod path;
 pub mod provenance;
+pub mod raw_provenance;
 pub mod shape;
 pub mod style;
 pub mod table;

--- a/src/model/raw_provenance.rs
+++ b/src/model/raw_provenance.rs
@@ -1,0 +1,323 @@
+//! [#4493] DocInfo raw 캐시 출처 봉인(provenance seal).
+//!
+//! ## 문제
+//!
+//! 공개 저수준 API 는 `parse_document → model::Document 직접 변경 →
+//! serialize_document` 를 허용하는데, HWP 파싱은 `DocInfo.raw_stream` 과 레코드별
+//! `raw_data` 를 채우고 `raw_stream_dirty=false` 로 남긴다. 공개 모델 필드를 직접
+//! 바꾸면 dirty 표식이 서지 않으므로, 저장 시 원본 바이트 통과(스트림·레코드
+//! 양쪽)가 그대로 발동해 **메모리에서 보이던 변경이 저장·재로드 뒤 조용히
+//! 사라진다.**
+//!
+//! ## 처방 — 봉인과 검증
+//!
+//! 파싱과 모든 load fixup 이 끝난 시점(`parse_document_inner` 말미)에 봉인한다.
+//!
+//! - **스트림 봉인** — 원본 DocInfo 바이트와 모델 상태의 다이제스트 쌍. 저장 시
+//!   둘 다 일치할 때만 `raw_stream` 전체 통과를 허용한다. 공개 `raw_stream` 을
+//!   다른 바이트로 교체해도(raw digest 불일치) 봉인으로 승인되지 않는다.
+//! - **레코드 봉인** — DocInfo 의 레코드별 `raw_data` 지름길(BIN_DATA·FACE_NAME·
+//!   BORDER_FILL·CHAR_SHAPE·TAB_DEF·NUMBERING·BULLET·PARA_SHAPE·STYLE·
+//!   DOCUMENT_PROPERTIES)에 대응하는 레코드 단위 다이제스트. 스트림이 재생성될
+//!   때 **변경되지 않은 레코드만** 원본 바이트를 재사용하고, 변경된 레코드는
+//!   모델 writer 로 다시 쓴다 — 하위 raw 를 무조건 폐기해 미모델링 바이트를
+//!   잃는 방식은 쓰지 않는다(#4495 와 같은 원칙).
+//!
+//! 봉인은 모델 타입에 필드를 넣지 않고 이 모듈의 컨테이너(인덱스 정렬)로
+//! 중앙 보관한다 — 목록 삽입·삭제로 인덱스가 어긋나면 다이제스트가 어긋나
+//! 재생성으로 떨어지므로 안전한 방향으로 실패한다.
+//!
+//! ## 다이제스트 규약
+//!
+//! serde 직렬화(JSON 인코딩)를 blake3 로 해시한다 — `Debug`/`DefaultHasher`/
+//! 재귀 `Clone` 스냅샷에 의존하지 않는다. serde_json 은 구조체 필드를 선언
+//! 순서로, 숫자·float 를 결정적 표기(ryu/itoa)로 방출하므로 같은 프로세스에서
+//! 항상 같은 바이트를 낸다. DocInfo 트리에는 순회 순서가 비결정적인 맵 타입이
+//! 없다(생기면 이 모듈에서 정렬 직렬화로 감싸야 한다). 봉인 대상 필드는
+//! [`doc_info_model_digest`] 가 **전수 구조분해**로 나열한다 — 필드 추가 시
+//! 컴파일 오류로 목록 갱신을 강제한다.
+//!
+//! Section(`raw_stream`)·본문 컨트롤 raw 레코드의 같은 계약은 #4488·#4495 가
+//! 별도로 다룬다 — 스트림·소유자가 다르다.
+
+use serde::Serialize;
+
+use super::document::{DocInfo, DocProperties};
+
+/// 파싱 완료 시점의 DocInfo 봉인.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocInfoSeal {
+    /// 봉인 시점 모델 상태의 다이제스트 ([`doc_info_model_digest`]).
+    pub model_digest: [u8; 32],
+    /// 봉인 시점 `raw_stream` 바이트의 다이제스트.
+    pub raw_digest: [u8; 32],
+    /// 레코드별 봉인 — 인덱스는 봉인 시점 목록 순서.
+    pub record_seals: DocInfoRecordSeals,
+}
+
+/// 레코드별 `raw_data` 지름길에 대응하는 다이제스트 묶음.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DocInfoRecordSeals {
+    pub props: [u8; 32],
+    pub bin_data: Vec<[u8; 32]>,
+    /// 언어 축(바깥)×글꼴(안) — `DocInfo.font_faces` 와 같은 모양.
+    pub fonts: Vec<Vec<[u8; 32]>>,
+    pub border_fills: Vec<[u8; 32]>,
+    pub char_shapes: Vec<[u8; 32]>,
+    pub tab_defs: Vec<[u8; 32]>,
+    pub numberings: Vec<[u8; 32]>,
+    pub bullets: Vec<[u8; 32]>,
+    pub para_shapes: Vec<[u8; 32]>,
+    pub styles: Vec<[u8; 32]>,
+}
+
+/// 바이트 열의 다이제스트.
+pub fn bytes_digest(bytes: &[u8]) -> [u8; 32] {
+    *blake3::hash(bytes).as_bytes()
+}
+
+/// 레코드(직렬화 가능한 모델 값) 하나의 다이제스트.
+///
+/// 레코드의 `raw_data` 필드도 다이제스트에 포함된다 — 모델 필드가 변하지 않는 한
+/// `raw_data` 는 파싱 시점 그대로이므로 판정에 영향이 없고, `raw_data` 만 바꿔치기
+/// 하는 변경도 불일치로 떨어져 승인되지 않는다.
+pub fn record_digest<T: Serialize>(record: &T) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    serde_json::to_writer(&mut hasher, record)
+        .expect("레코드 다이제스트 직렬화는 실패할 수 없다 (순수 인메모리 인코딩)");
+    *hasher.finalize().as_bytes()
+}
+
+/// 봉인 컨테이너에서 `idx` 레코드의 raw 재사용 허용 여부.
+///
+/// - 봉인 자체가 없으면(`seals=None`, 파서를 거치지 않은 합성 IR) 종전 계약대로
+///   허용한다.
+/// - 봉인이 있으면 인덱스가 범위 안이고 다이제스트가 일치할 때만 허용한다 —
+///   목록 삽입·삭제로 인덱스가 밀리면 불일치로 떨어져 모델 writer 로 재생성된다.
+pub fn record_raw_permitted<T: Serialize>(
+    seals: Option<&[[u8; 32]]>,
+    idx: usize,
+    record: &T,
+) -> bool {
+    match seals {
+        None => true,
+        Some(seals) => seals
+            .get(idx)
+            .is_some_and(|sealed| *sealed == record_digest(record)),
+    }
+}
+
+/// DocInfo(+DocProperties) 모델 상태의 다이제스트.
+///
+/// 저장 산출물에 실리는 모델 필드 전부를 선언 순서로 직렬화해 해시한다.
+/// 구조분해에 `..` 를 쓰지 않는 것이 계약이다 — 새 필드가 생기면 여기가
+/// 컴파일 오류를 내서 "봉인 대상인가"의 판단을 강제한다. raw 캐시 자신
+/// (`raw_stream`)과 그 관리 표식(`raw_stream_dirty`, `raw_provenance`), 통과
+/// 경로가 스스로 처리하는 `distribute_doc_data_removed`(surgical remove)는 뺀다.
+pub fn doc_info_model_digest(doc_info: &DocInfo, doc_props: &DocProperties) -> [u8; 32] {
+    let DocInfo {
+        bin_data_list,
+        font_faces,
+        border_fills,
+        char_shapes,
+        tab_defs,
+        numberings,
+        bullets,
+        para_shapes,
+        styles,
+        extra_records,
+        raw_stream: _,
+        bullet_count,
+        memo_shape_count,
+        memo_properties_xml,
+        distribute_doc_data_removed: _,
+        raw_stream_dirty: _,
+        hwpx_head_tail,
+        hwpml_version,
+        raw_provenance: _,
+    } = doc_info;
+
+    #[derive(Serialize)]
+    struct Fingerprint<'a> {
+        bin_data_list: &'a [crate::model::bin_data::BinData],
+        font_faces: &'a [Vec<crate::model::style::Font>],
+        border_fills: &'a [crate::model::style::BorderFill],
+        char_shapes: &'a [crate::model::style::CharShape],
+        tab_defs: &'a [crate::model::style::TabDef],
+        numberings: &'a [crate::model::style::Numbering],
+        bullets: &'a [crate::model::style::Bullet],
+        para_shapes: &'a [crate::model::style::ParaShape],
+        styles: &'a [crate::model::style::Style],
+        extra_records: &'a [crate::model::document::RawRecord],
+        bullet_count: u32,
+        memo_shape_count: u32,
+        memo_properties_xml: &'a Option<String>,
+        hwpx_head_tail: &'a Option<String>,
+        hwpml_version: &'a Option<String>,
+        props: &'a DocProperties,
+    }
+
+    let fp = Fingerprint {
+        bin_data_list,
+        font_faces,
+        border_fills,
+        char_shapes,
+        tab_defs,
+        numberings,
+        bullets,
+        para_shapes,
+        styles,
+        extra_records,
+        bullet_count: *bullet_count,
+        memo_shape_count: *memo_shape_count,
+        memo_properties_xml,
+        hwpx_head_tail,
+        hwpml_version,
+        props: doc_props,
+    };
+
+    let mut hasher = blake3::Hasher::new();
+    serde_json::to_writer(&mut hasher, &fp)
+        .expect("모델 다이제스트 직렬화는 실패할 수 없다 (순수 인메모리 인코딩)");
+    *hasher.finalize().as_bytes()
+}
+
+/// 레코드 봉인 묶음 계산 — 봉인 시점의 목록 순서 그대로.
+fn compute_record_seals(doc_info: &DocInfo, doc_props: &DocProperties) -> DocInfoRecordSeals {
+    DocInfoRecordSeals {
+        props: record_digest(doc_props),
+        bin_data: doc_info.bin_data_list.iter().map(record_digest).collect(),
+        fonts: doc_info
+            .font_faces
+            .iter()
+            .map(|lang| lang.iter().map(record_digest).collect())
+            .collect(),
+        border_fills: doc_info.border_fills.iter().map(record_digest).collect(),
+        char_shapes: doc_info.char_shapes.iter().map(record_digest).collect(),
+        tab_defs: doc_info.tab_defs.iter().map(record_digest).collect(),
+        numberings: doc_info.numberings.iter().map(record_digest).collect(),
+        bullets: doc_info.bullets.iter().map(record_digest).collect(),
+        para_shapes: doc_info.para_shapes.iter().map(record_digest).collect(),
+        styles: doc_info.styles.iter().map(record_digest).collect(),
+    }
+}
+
+impl DocInfo {
+    /// 파싱(+로드 픽스업) 완료 시점에 호출 — raw 캐시가 있으면 현재 모델 상태와
+    /// 함께 봉인한다. raw 가 없으면(HWPX/HWP3/합성 IR) 봉인도 없다.
+    pub fn seal_raw_provenance(&mut self, doc_props: &DocProperties) {
+        self.raw_provenance = self.raw_stream.as_ref().map(|raw| DocInfoSeal {
+            model_digest: doc_info_model_digest(self, doc_props),
+            raw_digest: bytes_digest(raw),
+            record_seals: compute_record_seals(self, doc_props),
+        });
+    }
+
+    /// 저장 시점 스트림 통과 검증 — raw 바이트와 모델 상태가 둘 다 봉인과 같은가.
+    ///
+    /// 봉인이 없는 raw(`raw_provenance=None`, 파서를 거치지 않은 합성 IR 등)는
+    /// 종전 계약대로 통과를 허용한다 — 봉인은 공개 parse→mutate→serialize
+    /// 경로의 손실을 막기 위한 것이고, 파서가 만든 문서에는 항상 봉인이 있다.
+    pub fn raw_provenance_permits_reuse(&self, doc_props: &DocProperties) -> bool {
+        let Some(raw) = self.raw_stream.as_ref() else {
+            return false;
+        };
+        match &self.raw_provenance {
+            None => true,
+            Some(seal) => {
+                seal.raw_digest == bytes_digest(raw)
+                    && seal.model_digest == doc_info_model_digest(self, doc_props)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn digest_changes_when_model_changes() {
+        let mut di = DocInfo::default();
+        let props = DocProperties::default();
+        let before = doc_info_model_digest(&di, &props);
+        di.char_shapes
+            .push(crate::model::style::CharShape::default());
+        let after = doc_info_model_digest(&di, &props);
+        assert_ne!(before, after, "char_shapes 변경이 다이제스트에 실려야 한다");
+    }
+
+    #[test]
+    fn digest_ignores_raw_cache_fields() {
+        let mut di = DocInfo::default();
+        let props = DocProperties::default();
+        let before = doc_info_model_digest(&di, &props);
+        di.raw_stream = Some(vec![1, 2, 3]);
+        di.raw_stream_dirty = true;
+        di.distribute_doc_data_removed = true;
+        let after = doc_info_model_digest(&di, &props);
+        assert_eq!(before, after, "raw 캐시 표식은 모델 다이제스트 밖이다");
+    }
+
+    #[test]
+    fn sealed_raw_reuse_denied_after_model_mutation() {
+        let mut di = DocInfo::default();
+        let props = DocProperties::default();
+        di.raw_stream = Some(vec![9, 9, 9]);
+        di.seal_raw_provenance(&props);
+        assert!(di.raw_provenance_permits_reuse(&props), "무변경이면 재사용");
+
+        di.para_shapes
+            .push(crate::model::style::ParaShape::default());
+        assert!(
+            !di.raw_provenance_permits_reuse(&props),
+            "공개 모델 직접 변경 뒤에는 raw 재사용이 거부돼야 한다 (#4493)"
+        );
+    }
+
+    #[test]
+    fn sealed_raw_reuse_denied_after_raw_swap() {
+        let mut di = DocInfo::default();
+        let props = DocProperties::default();
+        di.raw_stream = Some(vec![9, 9, 9]);
+        di.seal_raw_provenance(&props);
+
+        di.raw_stream = Some(vec![8, 8, 8]);
+        assert!(
+            !di.raw_provenance_permits_reuse(&props),
+            "raw 바이트 교체는 기존 봉인으로 승인되지 않는다 (#4493)"
+        );
+    }
+
+    #[test]
+    fn unsealed_raw_keeps_legacy_passthrough() {
+        let mut di = DocInfo::default();
+        let props = DocProperties::default();
+        di.raw_stream = Some(vec![7]);
+        assert!(
+            di.raw_provenance_permits_reuse(&props),
+            "봉인 이전(합성 IR) 경로는 종전 계약 유지"
+        );
+    }
+
+    #[test]
+    fn record_raw_permission_follows_seal() {
+        let cs = crate::model::style::CharShape::default();
+        let sealed = [record_digest(&cs)];
+        assert!(record_raw_permitted(Some(&sealed), 0, &cs), "무변경 허용");
+        assert!(
+            !record_raw_permitted(Some(&sealed), 1, &cs),
+            "범위 밖(새 레코드)은 모델 writer"
+        );
+        let mut changed = cs;
+        changed.base_size = 2000;
+        assert!(
+            !record_raw_permitted(Some(&sealed), 0, &changed),
+            "변경 레코드는 raw 재사용 거부"
+        );
+        assert!(
+            record_raw_permitted(None, 0, &changed),
+            "봉인 없는 합성 IR 은 종전 계약"
+        );
+    }
+}

--- a/src/model/style.rs
+++ b/src/model/style.rs
@@ -48,7 +48,7 @@ pub fn border_width_mm_str(index: u8) -> &'static str {
 }
 
 /// 글꼴 정보 (HWPTAG_FACE_NAME)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Font {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -81,7 +81,7 @@ pub struct Font {
 /// 4개 속성을 모두 보존해 라운드트립 무손실을 보장한다. `font_type`/`is_embedded`/
 /// `bin_item_id_ref` 는 부모 `<hh:font>` 의 같은 이름 속성과 독립적이다
 /// (예: HFT 글꼴이 TTF 대체 글꼴을 가질 수 있음).
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
 pub struct SubstFont {
     /// 대체 글꼴 이름
     pub face: String,
@@ -99,7 +99,7 @@ pub struct SubstFont {
 ///
 /// `Default` 는 [수동 구현](#impl-Default-for-CharShape)이다 — 파생하면 `relative_sizes` 가
 /// 스펙 위반값 0 이 된다(#4141).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct CharShape {
     /// 원본 레코드 바이트 (라운드트립 보존용, 있으면 직렬화 시 우선 사용)
     pub raw_data: Option<Vec<u8>>,
@@ -293,7 +293,7 @@ pub enum UnderlineType {
 }
 
 /// 문단 머리 모양 종류 (attr1 bit 23~24)
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum HeadType {
     /// 없음
     #[default]
@@ -307,7 +307,7 @@ pub enum HeadType {
 }
 
 /// 문단 모양 (HWPTAG_PARA_SHAPE)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct ParaShape {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -382,7 +382,7 @@ impl PartialEq for ParaShape {
 impl Eq for ParaShape {}
 
 /// 문단 번호 정의 (HWPTAG_NUMBERING)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Numbering {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -403,7 +403,7 @@ pub struct Numbering {
 }
 
 /// 문단 머리 정보 (표 41)
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
 pub struct NumberingHead {
     /// 속성 (정렬, 너비 따름, 자동 내어쓰기 등)
     pub attr: u32,
@@ -418,7 +418,7 @@ pub struct NumberingHead {
 }
 
 /// 글머리표 정의 (HWPTAG_BULLET, 표 44, 24바이트)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Bullet {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -445,7 +445,7 @@ pub struct Bullet {
 }
 
 /// 텍스트 정렬 방식
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum Alignment {
     #[default]
     Justify,
@@ -457,7 +457,7 @@ pub enum Alignment {
 }
 
 /// 줄 간격 종류
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum LineSpacingType {
     #[default]
     Percent,
@@ -467,7 +467,7 @@ pub enum LineSpacingType {
 }
 
 /// 탭 정의 (HWPTAG_TAB_DEF)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct TabDef {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -482,7 +482,7 @@ pub struct TabDef {
 }
 
 /// 탭 항목
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct TabItem {
     /// 탭 위치
     pub position: HwpUnit,
@@ -511,7 +511,7 @@ impl PartialEq for TabDef {
 impl Eq for TabDef {}
 
 /// 스타일 (HWPTAG_STYLE)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Style {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -539,7 +539,7 @@ pub struct Style {
 }
 
 /// 테두리/배경 (HWPTAG_BORDER_FILL)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct BorderFill {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -558,7 +558,7 @@ pub struct BorderFill {
 }
 
 /// 중심선 방향 (HWPX borderFill@centerLine)
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize)]
 pub enum CenterLine {
     /// 없음
     #[default]
@@ -623,7 +623,7 @@ impl CenterLine {
 }
 
 /// 테두리선 정보
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
 pub struct BorderLine {
     /// 선 종류
     pub line_type: BorderLineType,
@@ -635,7 +635,7 @@ pub struct BorderLine {
 
 /// 테두리선 종류 (HWP 스펙 표 27)
 /// 0=선없음, 1=실선, 2=파선, 3=점선, ...
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum BorderLineType {
     /// 선 없음 (0)
     None,
@@ -677,7 +677,7 @@ pub enum BorderLineType {
 }
 
 /// 대각선 정보
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
 pub struct DiagonalLine {
     /// 대각선 선 종류 코드. BorderLineType의 HWP/HWPX 코드와 같은 값을 사용한다.
     pub diagonal_type: u8,
@@ -688,7 +688,7 @@ pub struct DiagonalLine {
 }
 
 /// 채우기 정보
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Fill {
     /// 채우기 종류
     pub fill_type: FillType,
@@ -703,7 +703,7 @@ pub struct Fill {
 }
 
 /// 채우기 종류
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum FillType {
     #[default]
     None,
@@ -713,7 +713,7 @@ pub enum FillType {
 }
 
 /// 단색 채우기
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
 pub struct SolidFill {
     /// 배경색
     pub background_color: ColorRef,
@@ -724,7 +724,7 @@ pub struct SolidFill {
 }
 
 /// 그러데이션 채우기
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct GradientFill {
     /// 유형 (1: 줄무늬, 2: 원형, 3: 원뿔형, 4: 사각형)
     pub gradient_type: i16,
@@ -745,7 +745,7 @@ pub struct GradientFill {
 }
 
 /// 이미지 채우기
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct ImageFill {
     /// 채우기 유형
     pub fill_mode: ImageFillMode,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1467,6 +1467,22 @@ fn parse_document_inner(
     data: &[u8],
     password: Option<&[u8]>,
 ) -> Result<ParsedDocument, ParseError> {
+    let mut parsed = parse_document_inner_unsealed(data, password)?;
+    // [#4493] 파싱과 모든 load fixup 이 끝난 마지막 지점에서 DocInfo raw 출처를
+    // 봉인한다 — 이보다 앞(포맷별 파서 내부)에서 봉인하면 HWP3-변환본 spacing
+    // 반감 같은 로드 보정이 봉인을 깨서, 무변경 문서의 원본 바이트 통과가 죽는다.
+    // raw 캐시가 없는 포맷(HWPX/HWP3/HML)에서는 no-op.
+    parsed
+        .document
+        .doc_info
+        .seal_raw_provenance(&parsed.document.doc_properties);
+    Ok(parsed)
+}
+
+fn parse_document_inner_unsealed(
+    data: &[u8],
+    password: Option<&[u8]>,
+) -> Result<ParsedDocument, ParseError> {
     let open_policy = document_open_decompression_policy();
     match detect_format(data) {
         FileFormat::Hwp => {

--- a/src/serializer/doc_info.rs
+++ b/src/serializer/doc_info.rs
@@ -13,6 +13,7 @@ use super::record_writer::write_record;
 
 use crate::model::bin_data::{BinData, BinDataType};
 use crate::model::document::{DocInfo, DocProperties};
+use crate::model::raw_provenance;
 use crate::model::style::{
     BorderFill, BorderLineType, Bullet, CenterLine, FillType, Font, ImageFillMode, Numbering,
     ParaShape, Style, TabDef,
@@ -21,8 +22,13 @@ use crate::parser::tags;
 
 /// DocInfo + DocProperties를 레코드 바이너리 스트림으로 직렬화
 pub fn serialize_doc_info(doc_info: &DocInfo, doc_props: &DocProperties) -> Vec<u8> {
-    // 원본 스트림이 있고 변경되지 않았으면 그대로 반환 (완벽한 라운드트립)
-    if !doc_info.raw_stream_dirty {
+    // 원본 스트림이 있고 변경되지 않았으면 그대로 반환 (완벽한 라운드트립).
+    //
+    // [#4493] "변경되지 않았음" 은 dirty 표식만으로 판정하지 않는다 — 공개 모델
+    // 필드 직접 변경은 표식을 세우지 않으므로, 파싱 시점에 봉인한 (모델, raw)
+    // 다이제스트 쌍과 현재 상태가 둘 다 일치할 때만 통과한다(불일치·raw 교체는
+    // 아래 모델 writer 로 재생성). 봉인 계약은 model::raw_provenance 참조.
+    if !doc_info.raw_stream_dirty && doc_info.raw_provenance_permits_reuse(doc_props) {
         if let Some(ref raw) = doc_info.raw_stream {
             let mut result = raw.clone();
             // 배포용 문서 해제 시 DISTRIBUTE_DOC_DATA 레코드 제거
@@ -35,11 +41,22 @@ pub fn serialize_doc_info(doc_info: &DocInfo, doc_props: &DocProperties) -> Vec<
 
     let mut stream = Vec::new();
 
+    // [#4493] 레코드별 raw_data 지름길도 봉인 검증을 거친다 — 스트림이 재생성될
+    // 때(공개 모델 직접 변경 등) 변경되지 않은 레코드만 원본 바이트를 재사용하고,
+    // 변경된 레코드는 모델 writer 로 다시 쓴다. 봉인이 없는 합성 IR(record_seals
+    // 부재)은 종전 계약(무조건 raw 우선)을 유지한다.
+    let seals = doc_info.raw_provenance.as_ref().map(|s| &s.record_seals);
+
     // 1. DOCUMENT_PROPERTIES
+    let props_data = match (doc_props.raw_data.as_ref(), seals) {
+        (Some(raw), None) => raw.clone(),
+        (Some(raw), Some(s)) if s.props == raw_provenance::record_digest(doc_props) => raw.clone(),
+        _ => serialize_document_properties_from_model(doc_props),
+    };
     stream.extend(write_record(
         tags::HWPTAG_DOCUMENT_PROPERTIES,
         0,
-        &serialize_document_properties(doc_props),
+        &props_data,
     ));
 
     // 2. ID_MAPPINGS
@@ -49,74 +66,90 @@ pub fn serialize_doc_info(doc_info: &DocInfo, doc_props: &DocProperties) -> Vec<
         &serialize_id_mappings(doc_info),
     ));
 
+    // 레코드 봉인 게이트 — raw_data 가 있고 봉인이 허용할 때만 raw 재사용.
+    fn sealed_raw<'a, T: serde::Serialize>(
+        record: &'a T,
+        raw: &'a Option<Vec<u8>>,
+        seals: Option<&[[u8; 32]]>,
+        idx: usize,
+    ) -> Option<&'a Vec<u8>> {
+        raw.as_ref()
+            .filter(|_| raw_provenance::record_raw_permitted(seals, idx, record))
+    }
+
     // 3~10: ID_MAPPINGS 하위 레코드 (모두 level 1)
-    for bin_data in &doc_info.bin_data_list {
-        let data = bin_data
-            .raw_data
-            .clone()
-            .unwrap_or_else(|| serialize_bin_data(bin_data));
+    for (i, bin_data) in doc_info.bin_data_list.iter().enumerate() {
+        let data = sealed_raw(
+            bin_data,
+            &bin_data.raw_data,
+            seals.map(|s| &s.bin_data[..]),
+            i,
+        )
+        .cloned()
+        .unwrap_or_else(|| serialize_bin_data(bin_data));
         stream.extend(write_record(tags::HWPTAG_BIN_DATA, 1, &data));
     }
 
-    for lang_fonts in &doc_info.font_faces {
-        for font in lang_fonts {
-            let data = font
-                .raw_data
-                .clone()
+    for (li, lang_fonts) in doc_info.font_faces.iter().enumerate() {
+        let lang_seals = seals.and_then(|s| s.fonts.get(li)).map(|v| &v[..]);
+        for (fi, font) in lang_fonts.iter().enumerate() {
+            let data = sealed_raw(font, &font.raw_data, lang_seals, fi)
+                .cloned()
                 .unwrap_or_else(|| serialize_face_name(font));
             stream.extend(write_record(tags::HWPTAG_FACE_NAME, 1, &data));
         }
     }
 
-    for bf in &doc_info.border_fills {
-        let data = bf
-            .raw_data
-            .clone()
+    for (i, bf) in doc_info.border_fills.iter().enumerate() {
+        let data = sealed_raw(bf, &bf.raw_data, seals.map(|s| &s.border_fills[..]), i)
+            .cloned()
             .unwrap_or_else(|| serialize_border_fill(bf));
         stream.extend(write_record(tags::HWPTAG_BORDER_FILL, 1, &data));
     }
 
-    for cs in &doc_info.char_shapes {
-        let data = cs
-            .raw_data
-            .clone()
+    for (i, cs) in doc_info.char_shapes.iter().enumerate() {
+        let data = sealed_raw(cs, &cs.raw_data, seals.map(|s| &s.char_shapes[..]), i)
+            .cloned()
             .unwrap_or_else(|| serialize_char_shape(cs));
         stream.extend(write_record(tags::HWPTAG_CHAR_SHAPE, 1, &data));
     }
 
-    for td in &doc_info.tab_defs {
-        let data = td.raw_data.clone().unwrap_or_else(|| serialize_tab_def(td));
+    for (i, td) in doc_info.tab_defs.iter().enumerate() {
+        let data = sealed_raw(td, &td.raw_data, seals.map(|s| &s.tab_defs[..]), i)
+            .cloned()
+            .unwrap_or_else(|| serialize_tab_def(td));
         stream.extend(write_record(tags::HWPTAG_TAB_DEF, 1, &data));
     }
 
-    for numbering in &doc_info.numberings {
-        let data = numbering
-            .raw_data
-            .clone()
-            .unwrap_or_else(|| serialize_numbering(numbering));
+    for (i, numbering) in doc_info.numberings.iter().enumerate() {
+        let data = sealed_raw(
+            numbering,
+            &numbering.raw_data,
+            seals.map(|s| &s.numberings[..]),
+            i,
+        )
+        .cloned()
+        .unwrap_or_else(|| serialize_numbering(numbering));
         stream.extend(write_record(tags::HWPTAG_NUMBERING, 1, &data));
     }
 
-    for bullet in &doc_info.bullets {
-        let data = bullet
-            .raw_data
-            .clone()
+    for (i, bullet) in doc_info.bullets.iter().enumerate() {
+        let data = sealed_raw(bullet, &bullet.raw_data, seals.map(|s| &s.bullets[..]), i)
+            .cloned()
             .unwrap_or_else(|| serialize_bullet(bullet));
         stream.extend(write_record(tags::HWPTAG_BULLET, 1, &data));
     }
 
-    for ps in &doc_info.para_shapes {
-        let data = ps
-            .raw_data
-            .clone()
+    for (i, ps) in doc_info.para_shapes.iter().enumerate() {
+        let data = sealed_raw(ps, &ps.raw_data, seals.map(|s| &s.para_shapes[..]), i)
+            .cloned()
             .unwrap_or_else(|| serialize_para_shape(ps));
         stream.extend(write_record(tags::HWPTAG_PARA_SHAPE, 1, &data));
     }
 
-    for style in &doc_info.styles {
-        let data = style
-            .raw_data
-            .clone()
+    for (i, style) in doc_info.styles.iter().enumerate() {
+        let data = sealed_raw(style, &style.raw_data, seals.map(|s| &s.styles[..]), i)
+            .cloned()
             .unwrap_or_else(|| serialize_style(style));
         stream.extend(write_record(tags::HWPTAG_STYLE, 1, &data));
     }
@@ -138,6 +171,12 @@ pub fn serialize_document_properties(props: &DocProperties) -> Vec<u8> {
     if let Some(ref raw) = props.raw_data {
         return raw.clone();
     }
+    serialize_document_properties_from_model(props)
+}
+
+/// [#4493] raw_data 를 무시하고 모델 값으로 DOCUMENT_PROPERTIES 를 쓴다 —
+/// 봉인 검증이 "모델이 바뀌었다" 고 판정한 경로 전용.
+fn serialize_document_properties_from_model(props: &DocProperties) -> Vec<u8> {
     let mut w = ByteWriter::new();
     w.write_u16(props.section_count).unwrap();
     w.write_u16(props.page_start_num).unwrap();

--- a/tests/issue_4493_docinfo_provenance.rs
+++ b/tests/issue_4493_docinfo_provenance.rs
@@ -1,0 +1,132 @@
+//! [Issue #4493] 공개 저수준 `parse_document → Document 직접 변경 →
+//! serialize_document` 경로에서 DocInfo 변경이 원본 raw 캐시(스트림·레코드)에
+//! 가려져 조용히 사라지던 계약을 고정한다.
+//!
+//! - 무변경 문서는 원본 DocInfo 레코드 스트림 바이트를 정확히 재사용한다.
+//! - 공개 모델 직접 변경(char_shape·doc_properties)은 저장·재로드 뒤 유지된다.
+//! - 공개 `raw_stream` 을 다른 바이트로 교체해도 기존 봉인으로 승인되지 않는다.
+//! - [#4432] &mut 저장 경로는 저장 성공 시 dirty 를 내리고 raw 캐시를 재밀봉한다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::{parse_document, serialize_document};
+
+const SAMPLE: &str = "samples/2026_oss_rst.hwp";
+
+fn sample_bytes() -> Vec<u8> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    std::fs::read(&path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"))
+}
+
+#[test]
+fn unchanged_parse_serialize_reuses_docinfo_raw_bytes() {
+    let doc = parse_document(&sample_bytes()).expect("parse");
+    let original_raw = doc
+        .doc_info
+        .raw_stream
+        .clone()
+        .expect("HWP5 파싱은 DocInfo raw 캐시를 채운다");
+    assert!(
+        doc.doc_info.raw_provenance.is_some(),
+        "파서가 만든 문서에는 봉인이 있어야 한다 (#4493)"
+    );
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    assert_eq!(
+        reparsed.doc_info.raw_stream.as_ref(),
+        Some(&original_raw),
+        "무변경 문서의 DocInfo 레코드 스트림은 바이트 그대로 통과해야 한다"
+    );
+}
+
+#[test]
+fn public_char_shape_mutation_survives_save_reload() {
+    let mut doc = parse_document(&sample_bytes()).expect("parse");
+    assert!(!doc.doc_info.char_shapes.is_empty());
+    let target = 0usize;
+    let new_size = doc.doc_info.char_shapes[target].base_size + 700;
+    // 공개 모델 직접 변경 — dirty 표식을 세우지 않는다(그게 이 이슈의 재현이다).
+    doc.doc_info.char_shapes[target].base_size = new_size;
+    assert!(!doc.doc_info.raw_stream_dirty);
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    assert_eq!(
+        reparsed.doc_info.char_shapes[target].base_size, new_size,
+        "공개 char_shape 직접 변경이 저장·재로드 뒤 유지돼야 한다 (#4493)"
+    );
+}
+
+#[test]
+fn public_doc_properties_mutation_survives_save_reload() {
+    let mut doc = parse_document(&sample_bytes()).expect("parse");
+    let new_start = doc.doc_properties.page_start_num + 4;
+    doc.doc_properties.page_start_num = new_start;
+    assert!(!doc.doc_info.raw_stream_dirty);
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    assert_eq!(
+        reparsed.doc_properties.page_start_num, new_start,
+        "공개 doc_properties 직접 변경이 저장·재로드 뒤 유지돼야 한다 (#4493)"
+    );
+}
+
+#[test]
+fn untouched_records_keep_raw_bytes_when_one_record_changes() {
+    // 레코드 봉인의 핵심: 하나가 바뀌어도 나머지 레코드는 원본 바이트를 유지한다
+    // (하위 raw 전면 폐기 금지 — 미모델링 바이트 보존).
+    let mut doc = parse_document(&sample_bytes()).expect("parse");
+    let untouched_raw = doc.doc_info.char_shapes[1].raw_data.clone();
+    assert!(
+        untouched_raw.is_some(),
+        "샘플 전제: 레코드 raw 가 있어야 한다"
+    );
+    doc.doc_info.char_shapes[0].base_size += 700;
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    assert_eq!(
+        reparsed.doc_info.char_shapes[1].raw_data, untouched_raw,
+        "변경되지 않은 레코드는 원본 바이트가 유지돼야 한다"
+    );
+}
+
+#[test]
+fn swapped_raw_stream_is_not_honored() {
+    let mut doc = parse_document(&sample_bytes()).expect("parse");
+    let char_shape_count = doc.doc_info.char_shapes.len();
+    // 봉인 이후 raw 바이트를 통째로 바꿔치기 — 승인되면 안 된다.
+    doc.doc_info.raw_stream = Some(vec![0xDE; 64]);
+
+    let out = serialize_document(&doc).expect("교체 raw 는 무시되고 모델로 재생성돼야 한다");
+    let reparsed = parse_document(&out).expect("산출물은 정상 문서여야 한다");
+    assert_eq!(
+        reparsed.doc_info.char_shapes.len(),
+        char_shape_count,
+        "산출물은 교체 바이트가 아니라 모델 상태를 담아야 한다 (#4493)"
+    );
+}
+
+#[test]
+fn issue_4432_save_lowers_dirty_and_reseals() {
+    let mut core = DocumentCore::from_bytes(&sample_bytes()).expect("open");
+    // dirty 를 세우는 통상 편집 경로 — 중앙 무효화 진입점(document_mut) 경유.
+    core.document_mut().doc_info.char_shapes[0].base_size += 700;
+    core.document_mut().doc_info.raw_stream_dirty = true;
+
+    let first = core.export_hwp_with_adapter().expect("save 1");
+    assert!(
+        !core.document().doc_info.raw_stream_dirty,
+        "저장 성공 지점에서 dirty 가 내려가야 한다 (#4432)"
+    );
+    let second = core.export_hwp_with_adapter().expect("save 2");
+    assert_eq!(first, second, "재밀봉 뒤 무변경 재저장은 같은 바이트");
+
+    // 재밀봉된 캐시가 실제 모델 상태와 정합해야 한다 — 재로드로 검증.
+    let reparsed = parse_document(&second).expect("reparse");
+    assert_eq!(
+        reparsed.doc_info.char_shapes[0].base_size,
+        core.document().doc_info.char_shapes[0].base_size
+    );
+}


### PR DESCRIPTION
## 변경 요약

공개 저수준 `parse_document → model::Document 직접 변경 → serialize_document` 경로에서 DocInfo 변경이 원본 raw 캐시에 가려져 조용히 사라지던 문제(#4493)와, `raw_stream_dirty` 를 아무도 내리지 않아 원본 바이트 통과 최적화가 영구 무력화되던 문제(#4432)를 함께 고칩니다.

### 봉인(provenance seal) — `model::raw_provenance` 신설

- **스트림 봉인** — 파싱과 모든 load fixup 이 끝난 지점(`parse_document_inner` 말미)에 원본 DocInfo 바이트와 모델 상태의 다이제스트 쌍을 봉인합니다. 저장 시(`serialize_doc_info`) **둘 다** 봉인과 같을 때만 `raw_stream` 통과를 허용하고, 공개 `raw_stream` 을 다른 바이트로 교체해도 봉인으로 승인되지 않습니다.
- **레코드 봉인** — DocInfo 의 레코드별 `raw_data` 지름길(BIN_DATA·FACE_NAME·BORDER_FILL·CHAR_SHAPE·TAB_DEF·NUMBERING·BULLET·PARA_SHAPE·STYLE·DOCUMENT_PROPERTIES 10곳)도 레코드 단위 다이제스트로 검증합니다 — 스트림이 재생성될 때 **변경되지 않은 레코드만** 원본 바이트를 재사용하고, 변경된 레코드는 모델 writer 로 다시 씁니다. 하위 raw 전면 폐기(미모델링 바이트 손실)는 하지 않습니다.
- 봉인 지점이 fixup **뒤**인 것이 핵심입니다 — HWP3-변환본 spacing 반감 같은 로드 보정 앞에서 봉인하면 무변경 문서의 통과가 죽어 저장 정합이 회귀합니다.
- 다이제스트는 serde 직렬화(선언 순서·결정적 숫자 표기)를 blake3 로 해시합니다 — `Debug`/`DefaultHasher`/재귀 `Clone` 스냅샷에 의존하지 않고, 파서는 직렬화기를 호출하지 않습니다. 봉인 대상 필드는 **전수 구조분해**로 나열해 `DocInfo` 필드 추가 시 컴파일 오류로 목록 갱신을 강제합니다. 봉인은 모델 타입에 필드를 넣지 않고 중앙 컨테이너(인덱스 정렬)로 보관합니다 — 목록 삽입·삭제로 인덱스가 어긋나면 재생성으로 떨어져 안전한 방향으로 실패합니다.
- 봉인이 없는 raw(파서를 거치지 않은 합성 IR)는 종전 계약(통과 허용)을 유지합니다.

### [#4432] 저장 성공 지점에서 dirty 를 내린다

&mut 저장 진입점(`export_hwp_with_adapter`, 비밀번호 변형)에서 dirty(또는 봉인 불일치)면 DocInfo 를 **한 번** 재구성해 raw 캐시를 그 결과로 갱신하고 dirty 를 내린 뒤 재밀봉합니다 — 이번 저장은 방금 만든 바이트를 그대로 쓰고, 이후 무변경 저장은 원본 바이트 통과로 돌아갑니다. raw 캐시가 없던 문서(HWPX/HWP3 출처)는 건드리지 않습니다.

### 부수 — 모델 타입 serde Serialize 파생

다이제스트 계산을 위해 DocInfo 트리 타입(~27종)에 `serde::Serialize` 파생을 추가했습니다(동작 무변경, 기존에 일부 모델 타입이 이미 파생하던 것과 동일 패턴).

## 관련 이슈

closes #4493
closes #4432

## 테스트

- [x] `cargo test` 통과 — 신규 12건: 봉인 단위 테스트 6건(`model::raw_provenance::tests`) + 통합 6건(`tests/issue_4493_docinfo_provenance.rs`: 무변경 바이트 통과 유지 / char_shape·doc_properties 공개 직접 변경 red→green / 무변경 레코드 raw 보존 / raw 교체 불승인 / #4432 dirty 하강·재밀봉·재저장 바이트 동일). 전체 nextest 게이트 통과
- [x] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 (해당 없음 — 렌더 경로 무변경)
- [ ] 웹(WASM) 렌더링 확인 (해당 없음)
- [ ] rhwp-studio 변경 없음
- [ ] 작업 증빙 — 코드 수정(문서 편집 작업 아님)

## 성능 영향 및 측정 결과

- 예상 영향: 문서 열기 1회당 DocInfo 봉인 계산(blake3 + serde 인코딩)이 추가됩니다. DocInfo 레코드는 문서당 수십~수천 건·레코드당 수백 바이트 수준이라 ms 급이며, 저장 시 무변경 통과는 종전과 동일하게 유지됩니다. 편집 후 반복 저장은 #4432 재밀봉으로 오히려 재구성 횟수가 줄어듭니다.
- 재현·측정: 미측정 (전체 nextest 벽시계 회귀 없음)

## 범위 밖 (후속)

- #4488 (Section `raw_stream`)·#4495 (본문 컨트롤 하위 raw) — 같은 원리, 다른 스트림·소유자. 본 PR 의 봉인 인프라를 재사용하는 별도 PR 로 잇습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
