### PR TITLE
fix(layout/table): 접어 둔 0높이 lineseg 보존 + 셀 lineWrap 왕복 보존 (#4898 부분)

### DIFF
--- a/src/diagnostics/ir_field_sweep.rs
+++ b/src/diagnostics/ir_field_sweep.rs
@@ -1000,6 +1000,7 @@ fn sweep_cell(base: &str, a: &Cell, b: &Cell, out: &mut DivergenceCollector) {
         paragraphs,
         list_header_width_ref,
         text_direction,
+        line_wrap,
         vertical_align,
         apply_inner_margin,
         is_header,
@@ -1023,6 +1024,7 @@ fn sweep_cell(base: &str, a: &Cell, b: &Cell, out: &mut DivergenceCollector) {
     f!(border_fill_id);
     f!(list_header_width_ref);
     f!(text_direction);
+    f!(line_wrap);
     f!(vertical_align);
     f!(apply_inner_margin);
     f!(is_header);

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -360,6 +360,9 @@ impl DocumentCore {
         use crate::model::control::Control;
 
         for section in &mut document.sections {
+            // [#4898] 이 구역의 저장 lineseg 가 배치 권위를 갖는지 먼저 판정한다 —
+            // 권위가 있으면 0높이 lineseg(한컴이 접어 둔 숨은 블록)를 재조판하지 않는다.
+            let section_sized = Self::section_has_sized_lineseg(section);
             let page_def = &section.section_def.page_def;
             let column_def = Self::find_initial_column_def(&section.paragraphs);
             let layout = PageLayoutInfo::from_page_def(page_def, &column_def, dpi);
@@ -382,7 +385,7 @@ impl DocumentCore {
                 // 본문 합성 lineseg 는 흐름 소비를 문단당 ~2.7px 팽창시켜 sijang
                 // 밀도 핀 -5쪽(302 vs 307, #2070v2)만 남기는 잉여 축으로 판정.
                 // 본문 NO_LS 텍스트 문단의 실폭 래핑은 composer recompose 가 담당한다.
-                if Self::needs_line_seg_reflow(para, include_empty) {
+                if Self::needs_line_seg_reflow_in_scope(para, include_empty, section_sized) {
                     let para_style = styles.para_styles.get(para.para_shape_id as usize);
                     let margin_left = para_style.map(|s| s.margin_left).unwrap_or(0.0);
                     let margin_right = para_style.map(|s| s.margin_right).unwrap_or(0.0);
@@ -716,11 +719,38 @@ impl DocumentCore {
         para: &crate::model::paragraph::Paragraph,
         include_empty: bool,
     ) -> bool {
+        Self::needs_line_seg_reflow_in_scope(para, include_empty, false)
+    }
+
+    /// [#4898] `section_has_sized_lineseg` 는 **이 구역의 lineseg 가 배치 권위를 갖는가**다.
+    ///
+    /// 높이 0 짜리 단일 lineseg 는 보통 "아직 계산 안 됨"이지만, 한컴은 숨긴 블록
+    /// (CLIPDATA 등)을 **일부러** 0높이로 접어서 저장한다. 구역에 0 아닌 lineseg 가 있으면
+    /// 그 구역의 저장 lineseg 는 믿을 수 있는 값이므로 0높이도 그대로 두어야 한다 — 새로
+    /// 조판하면 숨은 내용이 펼쳐져 뒤가 밀리고 쪽수가 는다(08852 실측: 한글 1쪽 → 2쪽,
+    /// 최대 vertpos 40,525 → 77,965).
+    fn needs_line_seg_reflow_in_scope(
+        para: &crate::model::paragraph::Paragraph,
+        include_empty: bool,
+        section_has_sized_lineseg: bool,
+    ) -> bool {
         if para.line_segs.len() == 1 && para.line_segs[0].is_missing_lineseg_placeholder() {
             return false;
         }
-        (include_empty && para.line_segs.is_empty())
-            || (para.line_segs.len() == 1 && para.line_segs[0].line_height == 0)
+        if include_empty && para.line_segs.is_empty() {
+            return true;
+        }
+        para.line_segs.len() == 1
+            && para.line_segs[0].line_height == 0
+            && !section_has_sized_lineseg
+    }
+
+    /// 구역(셀·글상자 등 중첩 포함)에 높이가 0 이 아닌 lineseg 가 하나라도 있는가.
+    fn section_has_sized_lineseg(section: &crate::model::document::Section) -> bool {
+        section
+            .paragraphs
+            .iter()
+            .any(|p| p.line_segs.iter().any(|s| s.line_height != 0))
     }
 
     /// HWP5 -> HWPX export가 넣은 LineSeg 부재 marker는 reflow gate에서만 사용한다.

--- a/src/model/table.rs
+++ b/src/model/table.rs
@@ -142,6 +142,14 @@ pub struct Cell {
     pub list_header_width_ref: u16,
     /// 텍스트 방향 (0: 가로, 1: 세로)
     pub text_direction: u8,
+    /// [#4898] 줄바꿈 방식 — LIST_HEADER `list_attr` bit 19~20, OWPML `lineWrap`.
+    ///
+    /// `0` = BREAK(어절 단위 줄바꿈, 기본) · `1` = SQUEEZE(자간을 조절해 한 줄 유지) ·
+    /// `2` = KEEP. 종전에는 이 두 비트를 읽지도 쓰지도 않아 HWPX→HWP 저장에서 항상 0 이
+    /// 됐다 — 셀 줄바꿈 방식이 바뀌면 줄 수·셀 높이·표 높이가 따라 바뀐다.
+    /// 매핑은 한글 2022 실측이다(SQUEEZE 만 쓰는 문서를 SaveAs → LIST_HEADER 19개가 전부
+    /// bit19=1, BREAK 위주 문서는 SQUEEZE 인 셀 하나만 1). KEEP=2 는 스키마 열거 순서다.
+    pub line_wrap: u8,
     /// 세로 정렬 (0: top, 1: center, 2: bottom)
     pub vertical_align: VerticalAlign,
     /// 안 여백 지정 여부 (list_attr bit 16)
@@ -420,6 +428,7 @@ impl Cell {
             padding: template.padding,
             list_header_width_ref: template.list_header_width_ref,
             text_direction: template.text_direction,
+            line_wrap: template.line_wrap,
             vertical_align: template.vertical_align,
             apply_inner_margin: template.apply_inner_margin,
             is_header: template.is_header,

--- a/src/parser/control.rs
+++ b/src/parser/control.rs
@@ -347,6 +347,9 @@ fn parse_cell(records: &[Record]) -> Cell {
     // bit 19~20: 줄바꿈 방식
     // bit 21~22: 세로 정렬 (0=top, 1=center, 2=bottom)
     cell.text_direction = ((list_attr >> 16) & 0x07) as u8;
+    // [#4898] 줄바꿈 방식(bit 19~20)도 싣는다 — 종전엔 읽지 않아 저장에서 0(BREAK)으로
+    // 굳었고, SQUEEZE 셀의 줄 수·높이가 달라져 한글 쪽수까지 흔들렸다.
+    cell.line_wrap = ((list_attr >> 19) & 0x03) as u8;
     let v_align = ((list_attr >> 21) & 0x03) as u8;
     cell.vertical_align = match v_align {
         1 => VerticalAlign::Center,

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -49,6 +49,12 @@ pub fn parse_hwpx_section(xml: &str) -> Result<Section, HwpxError> {
     let mut reader = Reader::from_str(xml);
     let mut buf = Vec::new();
 
+    // [#4898] 0높이 lineseg 정규화(#2070)의 판단 범위를 구역으로 넓힌다 — 문단 단위로
+    // 보면 한컴이 접어 둔 숨은 블록까지 지우게 된다. RAII 로 되돌려 중첩 파싱(표 셀 안의
+    // 구역 없음)이나 다음 구역에 값이 새지 않게 한다.
+    let sized = section_xml_has_sized_lineseg(xml);
+    let _lineseg_scope = SectionLinesegScope::enter(sized);
+
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref e)) => {
@@ -428,6 +434,40 @@ const MAX_HWPX_SECTION_DEPTH: u32 = 64;
 thread_local! {
     // 완전 경로 — 이 모듈의 `Cell` 은 이미 `crate::model::table::Cell`(표 셀)이다.
     static HWPX_SECTION_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+    /// [#4898] 이 구역의 lineseg 가 **배치 권위를 갖는가** — 0 아닌 높이가 하나라도 있으면 참.
+    ///
+    /// #2070 의 0높이 정규화를 문단이 아니라 **구역** 범위로 판단하기 위한 신호다.
+    /// `parse_paragraph` 는 표 셀·글상자·각주 등 여러 경로에서 재귀 호출되므로
+    /// 파라미터를 관통시키지 않고 형제 가드(`HWPX_SECTION_DEPTH`)와 같은 방식으로 나른다.
+    static HWPX_SECTION_HAS_SIZED_LINESEG: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// 구역 XML 에 **높이가 0 이 아닌 lineseg** 가 하나라도 있는지 훑는다.
+///
+/// [#4898] 한컴은 숨긴 블록(예: CLIPDATA)을 `vertsize="0"` lineseg 로 **접어서** 저장한다.
+/// 그 0높이를 "권위 없음"으로 보고 지우면 rhwp 가 그 문단을 새로 조판해 숨은 내용이
+/// 펼쳐지고, 뒤 내용이 밀려 쪽수가 늘어난다(08852 실측: 최대 vertpos 40,525 → 77,965,
+/// 1쪽 → 2쪽). 반대로 lineseg 를 **전부** 0 으로 채워 저장하는 생성계 문서도 실재하고,
+/// 그쪽은 #2070 대로 부재 취급해야 셀·문단 높이가 선언값으로 붕괴하지 않는다.
+///
+/// 두 경우를 가르는 신호가 "이 구역에 0 아닌 lineseg 가 있는가"다.
+fn section_xml_has_sized_lineseg(xml: &str) -> bool {
+    for tag in xml.split("<hp:lineseg").skip(1) {
+        let Some(end) = tag.find('>') else { continue };
+        let attrs = &tag[..end];
+        let sized = |name: &str| -> bool {
+            attrs
+                .split(name)
+                .nth(1)
+                .and_then(|rest| rest.strip_prefix("=\""))
+                .and_then(|rest| rest.split('"').next())
+                .is_some_and(|v| v.parse::<i64>().is_ok_and(|n| n != 0))
+        };
+        if sized("vertsize") || sized("textheight") {
+            return true;
+        }
+    }
+    false
 }
 
 /// `parse_paragraph` 진입 시 재귀 깊이를 +1 하고 이탈(Drop, 오류 전파·조기 반환
@@ -452,6 +492,23 @@ impl SectionDepthGuard {
 impl Drop for SectionDepthGuard {
     fn drop(&mut self) {
         HWPX_SECTION_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
+    }
+}
+
+/// [#4898] 구역 파싱 동안 "이 구역의 lineseg 가 배치 권위를 갖는가"를 세워 두고
+/// 이탈 시 이전 값으로 되돌리는 RAII 가드.
+struct SectionLinesegScope(bool);
+
+impl SectionLinesegScope {
+    fn enter(has_sized: bool) -> SectionLinesegScope {
+        let prev = HWPX_SECTION_HAS_SIZED_LINESEG.with(|f| f.replace(has_sized));
+        SectionLinesegScope(prev)
+    }
+}
+
+impl Drop for SectionLinesegScope {
+    fn drop(&mut self) {
+        HWPX_SECTION_HAS_SIZED_LINESEG.with(|f| f.set(self.0));
     }
 }
 
@@ -899,7 +956,14 @@ fn parse_paragraph(
     // 0 높이 lineseg 는 배치 권위가 없고(한글은 열 때 재계산) 실저장 취급 시
     // NO_LS 성장 경로가 죽어 셀/문단 높이가 선언값으로 붕괴한다 (#1380 대칭,
     // body_text.rs parse_para_line_seg 와 동일 규칙).
+    //
+    // [#4898] 단, 판단 범위는 문단이 아니라 **구역**이다. 한컴은 숨긴 블록을 0높이
+    // lineseg 로 접어서 저장하는데(08852: 9개가 vertpos 38605 에 겹쳐 있다), 그것까지
+    // 지우면 rhwp 가 그 문단을 새로 조판해 숨은 내용이 펼쳐지고 뒤가 밀려 쪽수가 는다
+    // (실측 1쪽 → 2쪽, 최대 vertpos 40,525 → 77,965). 구역에 0 아닌 lineseg 가 하나라도
+    // 있으면 그 구역의 lineseg 는 배치 권위가 있는 것이므로 0높이도 원본대로 보존한다.
     if !para.line_segs.is_empty()
+        && !HWPX_SECTION_HAS_SIZED_LINESEG.with(|f| f.get())
         && para
             .line_segs
             .iter()
@@ -2489,6 +2553,16 @@ fn parse_table_cell(
                                 b"textDirection" => {
                                     cell.text_direction =
                                         if attr_str(&attr) == "VERTICAL" { 1 } else { 0 };
+                                }
+                                // [#4898] 줄바꿈 방식. 종전엔 읽지 않아 HWP5 저장에서 항상
+                                // BREAK(0)이 됐고, SQUEEZE 셀은 한글이 줄을 다시 나눠
+                                // 셀·표 높이가 달라졌다(코퍼스 표본에 SQUEEZE 3,019회).
+                                b"lineWrap" => {
+                                    cell.line_wrap = match attr_str(&attr).as_str() {
+                                        "SQUEEZE" => 1,
+                                        "KEEP" => 2,
+                                        _ => 0,
+                                    };
                                 }
                                 _ => {}
                             }
@@ -9632,6 +9706,45 @@ mod tests {
         assert_eq!(
             eq.script, "a < b > c",
             "CDATA 로 감싸진 수식 스크립트가 소실되면 안 된다"
+        );
+    }
+
+    /// [#4898] 0높이 lineseg 정규화(#2070)는 **구역 단위**로 판단한다.
+    ///
+    /// 한컴은 숨긴 블록(CLIPDATA 등)을 `vertsize="0"` lineseg 로 접어서 저장한다. 그것을
+    /// 문단 단위로 "부재"로 보면 rhwp 가 그 문단을 새로 조판해 숨은 내용이 펼쳐지고 뒤가
+    /// 밀린다 — 08852 실측 최대 vertpos 40,525 → 77,965, 한글 1쪽 → 2쪽. 구역에 0 아닌
+    /// lineseg 가 있으면 그 구역의 lineseg 는 권위가 있으므로 0높이도 보존한다.
+    #[test]
+    fn issue4898_zero_height_linesegs_survive_when_section_has_sized_ones() {
+        let with_sized = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0"><hp:run charPrIDRef="0"><hp:t>본문</hp:t></hp:run>
+    <hp:linesegarray><hp:lineseg textpos="0" vertpos="0" vertsize="1200" textheight="1200" baseline="1020" spacing="600" horzpos="0" horzsize="42520" flags="393216"/></hp:linesegarray>
+  </hp:p>
+  <hp:p paraPrIDRef="0" styleIDRef="0"><hp:run charPrIDRef="0"><hp:t>숨긴 블록</hp:t></hp:run>
+    <hp:linesegarray><hp:lineseg textpos="0" vertpos="1200" vertsize="0" textheight="0" baseline="0" spacing="0" horzpos="0" horzsize="42520" flags="393216"/></hp:linesegarray>
+  </hp:p>
+</hs:sec>"#;
+        let section = parse_hwpx_section(with_sized).unwrap();
+        assert_eq!(
+            section.paragraphs[1].line_segs.len(),
+            1,
+            "0 아닌 lineseg 가 있는 구역에서는 0높이 lineseg 도 원본대로 보존해야 한다"
+        );
+
+        // 대조군(#2070): 구역 전체가 0높이면 종전대로 부재로 정규화한다 —
+        // 생성계 문서가 lineseg 를 0 으로 채워 저장하는 경우, 실저장 취급하면
+        // 셀·문단 높이가 선언값으로 붕괴한다.
+        let all_zero = with_sized.replace(
+            r#"vertsize="1200" textheight="1200""#,
+            r#"vertsize="0" textheight="0""#,
+        );
+        let section = parse_hwpx_section(&all_zero).unwrap();
+        assert!(
+            section.paragraphs.iter().all(|p| p.line_segs.is_empty()),
+            "구역 전체가 0높이면 종전대로 부재 취급한다"
         );
     }
 

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -674,7 +674,11 @@ fn serialize_cell(cell: &Cell, level: u16, records: &mut Vec<Record>) {
         VerticalAlign::Center => 1,
         VerticalAlign::Bottom => 2,
     };
-    let list_attr: u32 = ((cell.text_direction as u32) << 16) | (v_align_code << 21);
+    // [#4898] 줄바꿈 방식(bit 19~20)을 함께 되돌린다 — 빼먹으면 SQUEEZE 셀이 BREAK 로
+    // 굳어 한글이 줄을 다시 나눈다(줄 수 → 셀 높이 → 표 높이 → 쪽수).
+    let list_attr: u32 = ((cell.text_direction as u32) << 16)
+        | (((cell.line_wrap as u32) & 0x03) << 19)
+        | (v_align_code << 21);
     w.write_u32(list_attr).unwrap();
     let list_header_width_ref = if cell.list_header_width_ref == 0 {
         0x0400

--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -324,7 +324,9 @@ fn write_sub_list<W: Write>(
                     "HORIZONTAL"
                 },
             ),
-            ("lineWrap", "BREAK"),
+            // [#4898] 종전엔 상수 "BREAK" 였다 — 원본이 SQUEEZE 인 셀도 BREAK 로 굳어
+            // x2x 왕복에서 조용히 소실됐다(코퍼스 표본 3,019회). IR 값을 그대로 되돌린다.
+            ("lineWrap", cell_line_wrap_str(cell.line_wrap)),
             ("vertAlign", cell_vert_align_str(cell.vertical_align)),
             ("linkListIDRef", "0"),
             ("linkListNextIDRef", "0"),
@@ -562,6 +564,19 @@ fn cell_vert_align_str(v: VerticalAlign) -> &'static str {
     }
 }
 
+/// [#4898] 셀 줄바꿈 방식(LIST_HEADER bit 19~20) → OWPML `lineWrap`.
+///
+/// 한글 2022 실측으로 확정한 대응이다 — SQUEEZE 만 쓰는 문서를 한글이 HWP5 로 저장하면
+/// LIST_HEADER 가 전부 bit19=1, BREAK 위주 문서는 SQUEEZE 인 셀 하나만 1 이었다.
+/// `KEEP`(=2)은 스키마 열거 순서를 따른다(코퍼스 표본에는 나타나지 않았다).
+fn cell_line_wrap_str(line_wrap: u8) -> &'static str {
+    match line_wrap {
+        1 => "SQUEEZE",
+        2 => "KEEP",
+        _ => "BREAK",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -589,6 +604,59 @@ mod tests {
         }
         t.rebuild_grid();
         t
+    }
+
+    /// [#4898] 셀 줄바꿈 방식(`lineWrap`)이 HWPX 왕복에서 보존돼야 한다.
+    ///
+    /// 종전엔 파서가 이 속성을 읽지 않고 직렬화기가 상수 `"BREAK"` 를 방출해, 원본이
+    /// `SQUEEZE`(자간 조절로 한 줄 유지)인 셀이 조용히 `BREAK` 로 굳었다 — 한글은 그 셀의
+    /// 줄을 다시 나누므로 셀·표 높이가 달라진다. 코퍼스 표본(hwpx 648건)에 SQUEEZE 가
+    /// 3,019회 나온다. HWP5 축 대응(LIST_HEADER bit 19~20)은 한글 2022 SaveAs 실측이다.
+    #[test]
+    fn cell_line_wrap_survives_hwpx_roundtrip() {
+        use crate::model::control::Control;
+
+        let bytes0 = std::fs::read("samples/hwpx/basic-table-01.hwpx").expect("샘플 읽기");
+        let mut doc = crate::parser::hwpx::parse_hwpx(&bytes0).expect("샘플 파싱");
+        for section in &mut doc.sections {
+            for para in &mut section.paragraphs {
+                for control in &mut para.controls {
+                    if let Control::Table(table) = control {
+                        table.cells[0].line_wrap = 1; // SQUEEZE
+                    }
+                }
+            }
+        }
+
+        let bytes = crate::serializer::hwpx::serialize_hwpx(&doc).expect("직렬화");
+        let xml = String::from_utf8_lossy(&bytes).to_string();
+        let _ = xml; // zip 바이트라 XML 직접 검사 대신 재파싱으로 확인한다
+        let doc2 = crate::parser::hwpx::parse_hwpx(&bytes).expect("재파싱");
+        let wrapped = doc2
+            .sections
+            .iter()
+            .flat_map(|s| &s.paragraphs)
+            .flat_map(|p| &p.controls)
+            .filter_map(|c| match c {
+                Control::Table(t) => Some(t),
+                _ => None,
+            })
+            .any(|t| t.cells.first().is_some_and(|c| c.line_wrap == 1));
+        assert!(wrapped, "SQUEEZE 셀이 왕복에서 BREAK 로 굳으면 안 된다");
+    }
+
+    /// [#4898] 매핑은 한글 2022 실측이다 — SQUEEZE 만 쓰는 문서를 SaveAs 하면 LIST_HEADER
+    /// 19개가 전부 bit19=1, BREAK 위주 문서는 SQUEEZE 셀 하나만 1 이었다.
+    #[test]
+    fn cell_line_wrap_str_matches_owpml_enum() {
+        assert_eq!(cell_line_wrap_str(0), "BREAK");
+        assert_eq!(cell_line_wrap_str(1), "SQUEEZE");
+        assert_eq!(cell_line_wrap_str(2), "KEEP");
+        assert_eq!(
+            cell_line_wrap_str(9),
+            "BREAK",
+            "미지 값은 기본값으로 관용 처리"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 변경 요약

#4898("내용은 같은데 한글에서 쪽수가 1쪽 는다")의 **원인 두 갈래**를 고친다. 이 이슈는 단일
원인이 아니며, 이 PR 은 그중 확정된 것들만 담는다 — x2h 축의 주된 원인은 아직 규명 중이라
`closes` 로 걸지 않는다.

### 1. 한컴이 접어 둔 0높이 lineseg 를 다시 조판하지 않는다

한컴은 숨긴 블록(CLIPDATA 등)을 **0높이 lineseg** 로 접어서 저장한다. rhwp 는 그것을 "아직
계산 안 됨"으로 보고 새로 조판해, 숨은 내용이 펼쳐지며 뒤가 밀린다.

| 08852 | 원본 | 종전 산출 | 이 PR |
|---|---|---|---|
| 최대 vertpos | 40,525 | 77,965 | **40,525** |
| 한글 쪽수 (x2x) | 1 | 2 | **1** |
| 한글 쪽수 (x2h) | 1 | 2 | **1** |
| 한글 본문 | 2,634자 | 2,634자 | 2,634자 |

본문 높이 한계가 `84,188 − 5,668 − 4,252 = 74,268` 이라 77,965 는 넘친다 → 2쪽이었다.

정규화 판단 범위를 문단이 아니라 **구역**으로 옮겼다 — 구역에 0 아닌 lineseg 가 하나라도
있으면 그 구역의 저장 lineseg 는 배치 권위가 있으므로 0높이도 원본대로 둔다. **두 지점**을
함께 고쳐야 했다:

- `parser/hwpx/section.rs` — #2070 의 "전부 0높이면 부재로 정규화"에 구역 범위 조건 추가
- `document_core/commands/document.rs` — 로드 직후 `reflow_zero_height_paragraphs` 도 같은
  조건을 본다. 파서만 고쳤을 때는 이 패스가 값을 다시 덮어써 증상이 그대로였다.

#2070 이 지키려던 "lineseg 를 전부 0 으로 채워 저장하는 생성계 문서"는 그대로 부재 취급된다
(회귀 시험 2축으로 고정). 코퍼스 실측(hwpx 원본 3,396건): `0높이 없음` 3,370 · `lineseg 없음`
25 · `일부만 0높이` 1 · `전부 0높이` 0.

### 2. 셀 줄바꿈 방식(`lineWrap`)을 왕복에서 잃지 않는다

IR 에 담을 자리가 없어 HWPX 직렬화기는 상수 `"BREAK"` 를, HWP5 직렬화기는 LIST_HEADER
`list_attr` 줄바꿈 비트(19~20)를 늘 0 을 썼다. 한글은 그 셀의 줄을 다시 나누므로 줄 수 →
셀 높이 → 표 높이가 달라진다.

- 코퍼스 표본(hwpx 648건)에 `SQUEEZE` 가 **3,019회**. `09254` 원본 `SQUEEZE 1 / BREAK 53`
  → 종전 x2x 산출 `BREAK 54`(조용한 소실).
- 대응은 한글 2022 SaveAs 실측이다 — SQUEEZE 만 쓰는 문서(`00123`)를 한글이 HWP5 로 저장하면
  LIST_HEADER 19개가 전부 bit19=1, BREAK 위주 문서는 SQUEEZE 셀 하나만 1.
  → `BREAK=0 · SQUEEZE=1`(`KEEP=2` 는 스키마 열거 순서).
- 5점 이동: `Cell::line_wrap` 신설 · HWP5 파서/직렬화기 비트 19~20 · HWPX 파서 속성 적재 ·
  HWPX 직렬화기 IR 값 방출 · `ir_field_sweep` 철저 구조분해 등록.

수정 후 `09254.x2h` 의 줄바꿈 비트는 한글 오라클과 **완전 일치**(1×1 · 53×0, 종전 54×0)한다.

## 관련 이슈

refs #4898 (부분 수정 — 아래 "남은 것" 참조)

## 테스트

- [x] `cargo test` 통과 — 회귀 가드 4종 신설
      (0높이 보존/종전 정규화 2축, `lineWrap` 왕복, OWPML 열거 대응)
- [x] `cargo clippy --all-targets -- -D warnings` 통과
- [x] 회귀 게이트: `ir_field_sweep_baseline` · `hwpx_roundtrip_baseline` ·
      `hwpx_roundtrip_integration` · `hwpx_to_hwp_adapter` · `convert_verify_corpus_ratchet` 통과
- [ ] SVG 내보내기 확인 — 08852 는 한글 쪽수로 판정(위 표), 별도 SVG 비교는 미수행
- [ ] WASM 렌더링 확인 — 해당 없음

## 남은 것 — x2h 쪽수 드리프트(73경로)는 이 PR 이 닫지 못한다

`09254` 는 x2x 로 저장하면 1쪽(정상), x2h 만 2쪽이다. 이 PR 의 두 수정 뒤에도 그대로다.
지금까지 **배제된** 후보(모두 실측):

- 페이지 설정 — 원본·x2x·x2h 동일(`w=59528 h=84188 L/R=1984 T/B=4252 …`)
- lineseg — 원본을 파싱한 IR 과 x2h 산출을 파싱한 IR 이 문단별로 완전히 일치
- `lineWrap` — 이 PR 로 오라클과 일치시켰으나 쪽수는 그대로(가설 기각)
- 표 `table_attr` bit 26 · 개체 `common_attr` bit 28 — 드리프트 문서 98% / 정상 문서 98%로
  판별력 없음

다음 조사는 정상 문서를 한글 SaveAs 해 **드리프트 문서와 차분 비교**하는 방향으로 이어간다.

## 성능 영향 및 측정 결과

- 예상 영향: 없음 (구역당 lineseg 1회 스캔, 셀당 비트 연산)
- 재현·측정: 위 한글 오라클 실측 외 별도 성능 측정 없음
