### PR TITLE
fix: planet6897 HWPX 보존 PR 일괄 통합

### DIFF
--- a/mydocs/orders/20260816.md
+++ b/mydocs/orders/20260816.md
@@ -80,3 +80,21 @@
   PR #4883 code head의 GitHub CI·CodeQL·Render Diff·Native Skia·세 regular shard와 slow shard도 모두 통과했다.
 - 원 PR별 archive 검토 기록을 같은 PR의 trailing docs-only commit으로 추가한다. 이 문서 head의 fast-pass
   통과 뒤 통합 PR을 merge하고 각 원 PR을 #4883 링크와 처리 사유를 남겨 close한다.
+
+## PR #4941 - planet6897 열린 PR 5건 누적 통합
+
+- #4928, #4932, #4933, #4938, #4940의 최신 원 head를 통합했다. 원 contributor branch는 rewrite하거나
+  직접 push하지 않았으며, 원본 PR은 중복 병합하지 않는다.
+- 명시적 `hp:ole id="0"` 보존과 중첩 표 셀의 section lineseg 권위 적용은 메인터너 보정
+  `1afe41afb`에 포함했다. 이에 따라 원 #4932와 #4940 head가 아닌 통합 PR #4941만 병합 후보이다.
+- 전용 target `target/pr-review-planet6897`에서 `cargo fmt --all -- --check`, 전체
+  `cargo test --profile release-test --tests`, `cargo clippy --all-targets --all-features -- -D warnings`,
+  `cargo build --release`를 모두 종료 코드 `0`으로 완료했다.
+- [PR #4941](https://github.com/edwardkim/rhwp/pull/4941)의 code-and-review head `b11c20231`는 GitHub
+  Actions를 통과했다. Lint, Native Skia, 세 archive, regular 3개 shard, slow shard 및 최종 Build & Test가
+  성공했고, 영향 범위 정책상 WASM·frontend·Canvas·CodeQL 분석은 skip, 각 preflight는 통과했다.
+- 원 PR별 [#4928](../pr/archives/pr_4928_review.md), [#4932](../pr/archives/pr_4932_review.md),
+  [#4933](../pr/archives/pr_4933_review.md), [#4938](../pr/archives/pr_4938_review.md),
+  [#4940](../pr/archives/pr_4940_review.md) 검토 기록에 통합 결론과 CI 근거를 남겼다. 이 기록과
+  오늘할일을 포함하는 docs-only trailing head의 CI 및 `MERGEABLE`/`CLEAN`을 재확인한 후 #4941을 merge하고,
+  원 PR 5개에는 통합 반영 사유를 남겨 close한다.

--- a/mydocs/pr/archives/pr_4928_review.md
+++ b/mydocs/pr/archives/pr_4928_review.md
@@ -44,3 +44,13 @@
 위 전체 local validation은 통합 코드 후보에서 전용 target 디렉터리
 `/Users/tsjang/rhwp/target/pr-review-planet6897`로 수행했다. 원본 #4928은 독립적으로
 병합하지 않으며, 해당 변경을 포함한 #4941의 최신 head CI가 통과하면 #4941만 병합한다.
+
+## 원격 CI 완료 기록
+
+통합 PR [#4941](https://github.com/edwardkim/rhwp/pull/4941)의 code-and-review head
+`b11c20231`에 대해 GitHub Actions가 성공으로 완료됐다. `Lint`, `Native Skia tests`, 세 test
+archive, regular test 3개 shard, slow test shard 및 최종 `Build & Test`가 모두 통과했다. 영향 범위
+정책에 따라 WASM·frontend·Canvas visual diff·CodeQL 분석 job은 skip됐고, 각 preflight는 통과했다.
+
+이후 문서 전용 trailing commit으로 head가 전진하므로, 병합 전에는 그 최신 head의 CI와
+`MERGEABLE`/`CLEAN`을 다시 확인한다.

--- a/mydocs/pr/archives/pr_4928_review.md
+++ b/mydocs/pr/archives/pr_4928_review.md
@@ -1,0 +1,46 @@
+# PR #4928 검토 - HWPX 고아 fieldEnd 순서 보존
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4928](https://github.com/edwardkim/rhwp/pull/4928) |
+| 작성자 | `planet6897` |
+| 검토자 | `jangster77` |
+| 검토 방식 | 외부 기여 PR 누적 체리픽 검토 |
+| base / 원본 head | `devel` / `0558d8dfb36292e1f6649eefe56bbc0f8455f53b` |
+| 검토 브랜치 반영 | `review/planet6897-20260816`의 `18256a12c` |
+| 검토일 | 2026-08-16 |
+| 작성 시점 병합 상태 | `CLEAN` |
+
+## 검토 범위와 판단
+
+- 동일 control slot에서 fieldBegin과 고아 fieldEnd가 함께 나타날 때, fieldBegin 및 짝 fieldEnd를
+  먼저 방출하고 그 뒤 고아 fieldEnd를 방출하도록 HWPX 직렬화 순서를 제한한다.
+- field가 아닌 slot은 기존 고아 fieldEnd 선행 순서를 유지한다. 따라서 순서 보정 범위가 교차 문단
+  field에만 한정된다.
+- 추가 결함은 발견하지 못했다.
+
+## 검증
+
+- `cargo fmt --all -- --check` 통과
+- `CARGO_TARGET_DIR=target/pr-review-planet6897 cargo test --lib issue4902` 통과
+- 누적 검토 브랜치에서 `git diff --check` 통과
+
+## 최종 권고
+
+원본 PR head의 CI와 병합 가능 상태를 merge 직전에 다시 확인한 뒤 병합을 권고한다.
+
+
+## 통합 병합 판단 및 local validation
+
+- 통합 PR: [#4941](https://github.com/edwardkim/rhwp/pull/4941)
+- 통합 코드 후보: `1afe41afb`를 포함한 `integrate/planet6897-open-prs-20260816`
+- `cargo fmt --all -- --check`: 성공
+- `cargo test --profile release-test --tests`: 성공 (exit 0)
+- `cargo clippy --all-targets --all-features -- -D warnings`: 성공 (exit 0)
+- `cargo build --release`: 성공 (exit 0)
+
+위 전체 local validation은 통합 코드 후보에서 전용 target 디렉터리
+`/Users/tsjang/rhwp/target/pr-review-planet6897`로 수행했다. 원본 #4928은 독립적으로
+병합하지 않으며, 해당 변경을 포함한 #4941의 최신 head CI가 통과하면 #4941만 병합한다.

--- a/mydocs/pr/archives/pr_4932_review.md
+++ b/mydocs/pr/archives/pr_4932_review.md
@@ -48,3 +48,13 @@
 명시적 `hp:ole id="0"`을 보존하는 메인터너 보정은 `1afe41afb`에 포함되어 #4941로
 반영됐다. 원본 #4932 head에는 이 보정이 없으므로 개별 병합하지 않고, 전체 local validation을
 통과한 #4941의 최신 head CI가 통과하면 #4941만 병합한다.
+
+## 원격 CI 완료 기록
+
+통합 PR [#4941](https://github.com/edwardkim/rhwp/pull/4941)의 code-and-review head
+`b11c20231`에 대해 GitHub Actions가 성공으로 완료됐다. `Lint`, `Native Skia tests`, 세 test
+archive, regular test 3개 shard, slow test shard 및 최종 `Build & Test`가 모두 통과했다. 영향 범위
+정책에 따라 WASM·frontend·Canvas visual diff·CodeQL 분석 job은 skip됐고, 각 preflight는 통과했다.
+
+이후 문서 전용 trailing commit으로 head가 전진하므로, 병합 전에는 그 최신 head의 CI와
+`MERGEABLE`/`CLEAN`을 다시 확인한다.

--- a/mydocs/pr/archives/pr_4932_review.md
+++ b/mydocs/pr/archives/pr_4932_review.md
@@ -1,0 +1,50 @@
+# PR #4932 검토 - HWPX OLE shape component 원문 보존
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4932](https://github.com/edwardkim/rhwp/pull/4932) |
+| 작성자 | `planet6897` |
+| 검토자 | `jangster77` |
+| 검토 방식 | 외부 기여 PR 누적 체리픽 검토 및 메인터너 보정 |
+| base / 원본 head | `devel` / `bdeae910f490454b59ae4e390be15bfcb14c6075` |
+| 검토 브랜치 반영 | `709ceec7c`, `c2762524d` |
+| 메인터너 보정 | `1afe41afb` |
+| 검토일 | 2026-08-16 |
+| 작성 시점 병합 상태 | `CLEAN` |
+
+## 검토 범위와 판단
+
+- OLE의 `id`와 `instid`, offset·원본/현재 크기·flip·renderingInfo·lineShape를 분리 보존하는
+  방향은 적절하다.
+- OWPML 스키마상 `hp:ole`가 상속하는 공통 도형의 `id`는 `xs:nonNegativeInteger`이므로
+  명시적 `id="0"`도 유효하다. 원본 구현은 이를 속성 부재와 합쳐 직렬화 시 `instid`로 바꿀 수 있었다.
+- 메인터너 보정 `1afe41afb`은 `Option<u32>`으로 속성 부재와 `0`을 구분하고, 별도 회귀 테스트를
+  추가했다.
+
+## 검증
+
+- `cargo fmt --all -- --check` 통과
+- `CARGO_TARGET_DIR=target/pr-review-planet6897 cargo test --lib issue4669` 통과, 5건
+- `CARGO_TARGET_DIR=target/pr-review-planet6897 cargo test --test issue_4668_pic_offset_preserved` 통과
+- 누적 검토 브랜치에서 `git diff --check` 통과
+
+## 최종 권고
+
+원본 PR head에는 `id="0"` 보정이 아직 없으므로, 메인터너 보정을 해당 PR 또는 통합 PR에 반영한 뒤
+병합을 권고한다.
+
+
+## 통합 병합 판단 및 local validation
+
+- 통합 PR: [#4941](https://github.com/edwardkim/rhwp/pull/4941)
+- 통합 코드 후보: `1afe41afb`를 포함한 `integrate/planet6897-open-prs-20260816`
+- `cargo fmt --all -- --check`: 성공
+- `cargo test --profile release-test --tests`: 성공 (exit 0)
+- `cargo clippy --all-targets --all-features -- -D warnings`: 성공 (exit 0)
+- `cargo build --release`: 성공 (exit 0)
+
+명시적 `hp:ole id="0"`을 보존하는 메인터너 보정은 `1afe41afb`에 포함되어 #4941로
+반영됐다. 원본 #4932 head에는 이 보정이 없으므로 개별 병합하지 않고, 전체 local validation을
+통과한 #4941의 최신 head CI가 통과하면 #4941만 병합한다.

--- a/mydocs/pr/archives/pr_4933_review.md
+++ b/mydocs/pr/archives/pr_4933_review.md
@@ -1,0 +1,44 @@
+# PR #4933 검토 - HWPX 그림 shape component offset 보존
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4933](https://github.com/edwardkim/rhwp/pull/4933) |
+| 작성자 | `planet6897` |
+| 검토자 | `jangster77` |
+| 검토 방식 | 외부 기여 PR 누적 체리픽 검토 |
+| base / 원본 head | `devel` / `004799dc8d32fb9e464c9257a854507f2566dac4` |
+| 검토 브랜치 반영 | `6d3b70af2`, `f430db8e6` |
+| 검토일 | 2026-08-16 |
+| 작성 시점 병합 상태 | `CLEAN` |
+
+## 검토 범위와 판단
+
+- HWPX picture 직렬화가 common position 대신 shape component의 저장 offset을 사용하게 해,
+  음수 좌표를 포함한 원문 offset이 위치 보정으로 덮이지 않도록 한다.
+- 실물 HWPX 샘플을 이용한 통합 테스트가 저장 전후 offset 값을 확인한다.
+- 추가 결함은 발견하지 못했다.
+
+## 검증
+
+- `cargo fmt --all -- --check` 통과
+- `CARGO_TARGET_DIR=target/pr-review-planet6897 cargo test --test issue_4668_pic_offset_preserved` 통과
+- 누적 검토 브랜치에서 `git diff --check` 통과
+
+## 최종 권고
+
+원본 PR head의 CI와 병합 가능 상태를 merge 직전에 다시 확인한 뒤 병합을 권고한다.
+
+
+## 통합 병합 판단 및 local validation
+
+- 통합 PR: [#4941](https://github.com/edwardkim/rhwp/pull/4941)
+- 통합 코드 후보: `1afe41afb`를 포함한 `integrate/planet6897-open-prs-20260816`
+- `cargo fmt --all -- --check`: 성공
+- `cargo test --profile release-test --tests`: 성공 (exit 0)
+- `cargo clippy --all-targets --all-features -- -D warnings`: 성공 (exit 0)
+- `cargo build --release`: 성공 (exit 0)
+
+원본 #4933은 독립적으로 병합하지 않으며, 해당 변경을 포함해 전체 local validation을 통과한
+#4941의 최신 head CI가 통과하면 #4941만 병합한다.

--- a/mydocs/pr/archives/pr_4933_review.md
+++ b/mydocs/pr/archives/pr_4933_review.md
@@ -42,3 +42,13 @@
 
 원본 #4933은 독립적으로 병합하지 않으며, 해당 변경을 포함해 전체 local validation을 통과한
 #4941의 최신 head CI가 통과하면 #4941만 병합한다.
+
+## 원격 CI 완료 기록
+
+통합 PR [#4941](https://github.com/edwardkim/rhwp/pull/4941)의 code-and-review head
+`b11c20231`에 대해 GitHub Actions가 성공으로 완료됐다. `Lint`, `Native Skia tests`, 세 test
+archive, regular test 3개 shard, slow test shard 및 최종 `Build & Test`가 모두 통과했다. 영향 범위
+정책에 따라 WASM·frontend·Canvas visual diff·CodeQL 분석 job은 skip됐고, 각 preflight는 통과했다.
+
+이후 문서 전용 trailing commit으로 head가 전진하므로, 병합 전에는 그 최신 head의 CI와
+`MERGEABLE`/`CLEAN`을 다시 확인한다.

--- a/mydocs/pr/archives/pr_4938_review.md
+++ b/mydocs/pr/archives/pr_4938_review.md
@@ -42,3 +42,13 @@
 
 원본 #4938은 독립적으로 병합하지 않으며, 해당 변경을 포함해 전체 local validation을 통과한
 #4941의 최신 head CI가 통과하면 #4941만 병합한다.
+
+## 원격 CI 완료 기록
+
+통합 PR [#4941](https://github.com/edwardkim/rhwp/pull/4941)의 code-and-review head
+`b11c20231`에 대해 GitHub Actions가 성공으로 완료됐다. `Lint`, `Native Skia tests`, 세 test
+archive, regular test 3개 shard, slow test shard 및 최종 `Build & Test`가 모두 통과했다. 영향 범위
+정책에 따라 WASM·frontend·Canvas visual diff·CodeQL 분석 job은 skip됐고, 각 preflight는 통과했다.
+
+이후 문서 전용 trailing commit으로 head가 전진하므로, 병합 전에는 그 최신 head의 CI와
+`MERGEABLE`/`CLEAN`을 다시 확인한다.

--- a/mydocs/pr/archives/pr_4938_review.md
+++ b/mydocs/pr/archives/pr_4938_review.md
@@ -1,0 +1,44 @@
+# PR #4938 검토 - DocInfo raw provenance와 편집 저장 계약
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4938](https://github.com/edwardkim/rhwp/pull/4938) |
+| 작성자 | `planet6897` |
+| 검토자 | `jangster77` |
+| 검토 방식 | 외부 기여 PR 누적 체리픽 검토 |
+| base / 원본 head | `devel` / `7cef482a0741100ea86b009dd7f81bcaf87cd744` |
+| 검토 브랜치 반영 | `84135dd6e` |
+| 검토일 | 2026-08-16 |
+| 작성 시점 병합 상태 | `CLEAN` |
+
+## 검토 범위와 판단
+
+- DocInfo 전체와 record별 digest를 분리해, 원문 raw 재사용은 모델이 원문과 일치할 때만 허용한다.
+- 문서 속성 또는 char shape를 public API로 변경하면 stale raw를 재사용하지 않고 해당 범위를 재직렬화한다.
+- raw stream을 바꿔 끼우는 경우도 digest 검증으로 차단한다.
+- 추가 결함은 발견하지 못했다.
+
+## 검증
+
+- `cargo fmt --all -- --check` 통과
+- `CARGO_TARGET_DIR=target/pr-review-planet6897 cargo test --test issue_4493_docinfo_provenance` 통과, 6건
+- 누적 검토 브랜치에서 `git diff --check` 통과
+
+## 최종 권고
+
+원본 PR head의 CI와 병합 가능 상태를 merge 직전에 다시 확인한 뒤 병합을 권고한다.
+
+
+## 통합 병합 판단 및 local validation
+
+- 통합 PR: [#4941](https://github.com/edwardkim/rhwp/pull/4941)
+- 통합 코드 후보: `1afe41afb`를 포함한 `integrate/planet6897-open-prs-20260816`
+- `cargo fmt --all -- --check`: 성공
+- `cargo test --profile release-test --tests`: 성공 (exit 0)
+- `cargo clippy --all-targets --all-features -- -D warnings`: 성공 (exit 0)
+- `cargo build --release`: 성공 (exit 0)
+
+원본 #4938은 독립적으로 병합하지 않으며, 해당 변경을 포함해 전체 local validation을 통과한
+#4941의 최신 head CI가 통과하면 #4941만 병합한다.

--- a/mydocs/pr/archives/pr_4940_review.md
+++ b/mydocs/pr/archives/pr_4940_review.md
@@ -1,0 +1,50 @@
+# PR #4940 검토 - HWPX lineseg 범위와 표 셀 lineWrap 보존
+
+## 메타데이터
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#4940](https://github.com/edwardkim/rhwp/pull/4940) |
+| 작성자 | `planet6897` |
+| 검토자 | `jangster77` |
+| 검토 방식 | 외부 기여 PR 누적 체리픽 검토 및 메인터너 보정 |
+| base / 원본 head | `devel` / `00e4dc7a859a4143753864d05b5b9aa14642fc84` |
+| 검토 브랜치 반영 | `994ea507e`, `06536d461` |
+| 메인터너 보정 | `1afe41afb` |
+| 검토일 | 2026-08-16 |
+| 작성 시점 병합 상태 | `CLEAN` |
+
+## 검토 범위와 판단
+
+- HWP5 `LIST_HEADER` bit 19~20과 HWPX `lineWrap`의 BREAK/SQUEEZE/KEEP 매핑을 IR에 보존해,
+  셀 줄 수와 표 높이가 저장 과정에서 바뀌지 않도록 한 점은 적절하다.
+- 원본 구현의 section lineseg 권위 판정은 최상위 문단만 확인하고 셀 문단은 이전의 문단 단위
+  reflow를 유지했다. 따라서 저장 lineseg가 있는 표 내부의 0 높이 블록을 다시 조판해 페이지 수를
+  바꿀 수 있었다.
+- 메인터너 보정 `1afe41afb`은 중첩 표 셀까지 양수 lineseg를 재귀 판정하고, 셀 재조판에도 같은
+  section 권위를 적용한다.
+
+## 검증
+
+- `cargo fmt --all -- --check` 통과
+- `CARGO_TARGET_DIR=target/pr-review-planet6897 cargo test --lib issue4898` 통과, 2건
+- `CARGO_TARGET_DIR=target/pr-review-planet6897 cargo test --lib cell_line_wrap` 통과, 2건
+- 누적 검토 브랜치에서 `git diff --check` 통과
+
+## 최종 권고
+
+원본 PR head에는 중첩 표 lineseg 보정이 아직 없으므로, 메인터너 보정을 해당 PR 또는 통합 PR에 반영한 뒤
+병합을 권고한다.
+
+## 통합 병합 판단 및 local validation
+
+- 통합 PR: [#4941](https://github.com/edwardkim/rhwp/pull/4941)
+- 통합 코드 후보: `1afe41afb`를 포함한 `integrate/planet6897-open-prs-20260816`
+- `cargo fmt --all -- --check`: 성공
+- `cargo test --profile release-test --tests`: 성공 (exit 0)
+- `cargo clippy --all-targets --all-features -- -D warnings`: 성공 (exit 0)
+- `cargo build --release`: 성공 (exit 0)
+
+중첩 표 셀까지 section lineseg 권위를 적용하는 메인터너 보정은 `1afe41afb`에 포함되어
+#4941로 반영됐다. 원본 #4940 head에는 이 보정이 없으므로 개별 병합하지 않고, 전체 local
+validation을 통과한 #4941의 최신 head CI가 통과하면 #4941만 병합한다.

--- a/mydocs/pr/archives/pr_4940_review.md
+++ b/mydocs/pr/archives/pr_4940_review.md
@@ -48,3 +48,13 @@
 중첩 표 셀까지 section lineseg 권위를 적용하는 메인터너 보정은 `1afe41afb`에 포함되어
 #4941로 반영됐다. 원본 #4940 head에는 이 보정이 없으므로 개별 병합하지 않고, 전체 local
 validation을 통과한 #4941의 최신 head CI가 통과하면 #4941만 병합한다.
+
+## 원격 CI 완료 기록
+
+통합 PR [#4941](https://github.com/edwardkim/rhwp/pull/4941)의 code-and-review head
+`b11c20231`에 대해 GitHub Actions가 성공으로 완료됐다. `Lint`, `Native Skia tests`, 세 test
+archive, regular test 3개 shard, slow test shard 및 최종 `Build & Test`가 모두 통과했다. 영향 범위
+정책에 따라 WASM·frontend·Canvas visual diff·CodeQL 분석 job은 skip됐고, 각 preflight는 통과했다.
+
+이후 문서 전용 trailing commit으로 head가 전진하므로, 병합 전에는 그 최신 head의 CI와
+`MERGEABLE`/`CLEAN`을 다시 확인한다.

--- a/mydocs/working/task_m100_planet6897_stage1_maintainer_nested_preservation.md
+++ b/mydocs/working/task_m100_planet6897_stage1_maintainer_nested_preservation.md
@@ -1,0 +1,29 @@
+# planet6897 PR 일괄 검토 Stage 1 - 메인터너 보정: 중첩 lineseg와 OLE 0 ID 보존
+
+## 목적
+
+`planet6897`의 비드래프트 PR #4928, #4932, #4933, #4938, #4940을 최신
+`upstream/devel` 위 검토 브랜치에 누적한 뒤 발견한 두 라운드트립 경계를 보정한다.
+
+## 보정 내용
+
+1. #4940의 구역 저장 lineseg 권위 판정은 본문뿐 아니라 표 셀과 중첩 표 셀의 문단까지
+   재귀한다. 셀 재조판도 같은 `section_sized` 판정을 사용해, 0 높이로 저장된 숨은 셀
+   블록을 다시 펼치지 않는다.
+2. #4932의 HWPX `hp:ole@id`는 OWPML 스키마에서 `xs:nonNegativeInteger`이므로 `0`도
+   유효하다. `Option<u32>`으로 속성 부재와 명시적 `0`을 구분해, 저장 시 원래 `id=0`을
+   유지한다.
+
+## 회귀 근거
+
+- `parser::hwpx::section::tests::issue4669_explicit_zero_id_is_not_rewritten_to_instid`
+  - `id="0"`과 별도 `instid`를 함께 파싱해 두 값이 분리 보존되는지 확인한다.
+- `document_core::commands::document::tests::issue4898_section_authority_includes_nested_table_cells`
+  - 중첩 표 셀의 양수 lineseg가 section 권위에 포함되고, 같은 구역의 0 높이 lineseg는
+    재조판 대상에서 제외되는지 확인한다.
+
+## 범위
+
+- 변경: `src/document_core/commands/document.rs`, `src/parser/hwpx/section.rs`
+- 문서: 이 stage 기록 한 건
+- 외부 PR 원격 push와 GitHub 리뷰 제출은 보정 검증 뒤 별도 승인으로 진행한다.

--- a/src/diagnostics/ir_field_sweep.rs
+++ b/src/diagnostics/ir_field_sweep.rs
@@ -1000,6 +1000,7 @@ fn sweep_cell(base: &str, a: &Cell, b: &Cell, out: &mut DivergenceCollector) {
         paragraphs,
         list_header_width_ref,
         text_direction,
+        line_wrap,
         vertical_align,
         apply_inner_margin,
         is_header,
@@ -1023,6 +1024,7 @@ fn sweep_cell(base: &str, a: &Cell, b: &Cell, out: &mut DivergenceCollector) {
     f!(border_fill_id);
     f!(list_header_width_ref);
     f!(text_direction);
+    f!(line_wrap);
     f!(vertical_align);
     f!(apply_inner_margin);
     f!(is_header);

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -360,6 +360,9 @@ impl DocumentCore {
         use crate::model::control::Control;
 
         for section in &mut document.sections {
+            // [#4898] 이 구역의 저장 lineseg 가 배치 권위를 갖는지 먼저 판정한다 —
+            // 권위가 있으면 0높이 lineseg(한컴이 접어 둔 숨은 블록)를 재조판하지 않는다.
+            let section_sized = Self::section_has_sized_lineseg(section);
             let page_def = &section.section_def.page_def;
             let column_def = Self::find_initial_column_def(&section.paragraphs);
             let layout = PageLayoutInfo::from_page_def(page_def, &column_def, dpi);
@@ -382,7 +385,7 @@ impl DocumentCore {
                 // 본문 합성 lineseg 는 흐름 소비를 문단당 ~2.7px 팽창시켜 sijang
                 // 밀도 핀 -5쪽(302 vs 307, #2070v2)만 남기는 잉여 축으로 판정.
                 // 본문 NO_LS 텍스트 문단의 실폭 래핑은 composer recompose 가 담당한다.
-                if Self::needs_line_seg_reflow(para, include_empty) {
+                if Self::needs_line_seg_reflow_in_scope(para, include_empty, section_sized) {
                     let para_style = styles.para_styles.get(para.para_shape_id as usize);
                     let margin_left = para_style.map(|s| s.margin_left).unwrap_or(0.0);
                     let margin_right = para_style.map(|s| s.margin_right).unwrap_or(0.0);
@@ -716,11 +719,38 @@ impl DocumentCore {
         para: &crate::model::paragraph::Paragraph,
         include_empty: bool,
     ) -> bool {
+        Self::needs_line_seg_reflow_in_scope(para, include_empty, false)
+    }
+
+    /// [#4898] `section_has_sized_lineseg` 는 **이 구역의 lineseg 가 배치 권위를 갖는가**다.
+    ///
+    /// 높이 0 짜리 단일 lineseg 는 보통 "아직 계산 안 됨"이지만, 한컴은 숨긴 블록
+    /// (CLIPDATA 등)을 **일부러** 0높이로 접어서 저장한다. 구역에 0 아닌 lineseg 가 있으면
+    /// 그 구역의 저장 lineseg 는 믿을 수 있는 값이므로 0높이도 그대로 두어야 한다 — 새로
+    /// 조판하면 숨은 내용이 펼쳐져 뒤가 밀리고 쪽수가 는다(08852 실측: 한글 1쪽 → 2쪽,
+    /// 최대 vertpos 40,525 → 77,965).
+    fn needs_line_seg_reflow_in_scope(
+        para: &crate::model::paragraph::Paragraph,
+        include_empty: bool,
+        section_has_sized_lineseg: bool,
+    ) -> bool {
         if para.line_segs.len() == 1 && para.line_segs[0].is_missing_lineseg_placeholder() {
             return false;
         }
-        (include_empty && para.line_segs.is_empty())
-            || (para.line_segs.len() == 1 && para.line_segs[0].line_height == 0)
+        if include_empty && para.line_segs.is_empty() {
+            return true;
+        }
+        para.line_segs.len() == 1
+            && para.line_segs[0].line_height == 0
+            && !section_has_sized_lineseg
+    }
+
+    /// 구역(셀·글상자 등 중첩 포함)에 높이가 0 이 아닌 lineseg 가 하나라도 있는가.
+    fn section_has_sized_lineseg(section: &crate::model::document::Section) -> bool {
+        section
+            .paragraphs
+            .iter()
+            .any(|p| p.line_segs.iter().any(|s| s.line_height != 0))
     }
 
     /// HWP5 -> HWPX export가 넣은 LineSeg 부재 marker는 reflow gate에서만 사용한다.

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -1339,10 +1339,40 @@ impl DocumentCore {
 
         let saved_hwpx_page_border_fills = self.snapshot_hwpx_page_border_fill_overlay();
         let _report = convert_if_hwpx_source(&mut self.document, self.source_format);
+        self.refresh_doc_info_raw_cache();
         self.serialize_hwp_after_adapter(
             saved_hwpx_page_border_fills,
             crate::serializer::serialize_document,
         )
+    }
+
+    /// [#4432] DocInfo raw 캐시 재밀봉 — dirty(또는 봉인 불일치) 상태로 저장에
+    /// 들어가면 매 저장마다 DocInfo 를 처음부터 재구성한다. 여기서 한 번 재구성해
+    /// raw 캐시를 그 결과로 갱신하고 dirty 를 내리면, 이번 저장은 방금 만든
+    /// 바이트를 그대로 쓰고 이후 저장은 원본 바이트 통과로 돌아간다 —
+    /// "직렬화 성공 지점에서 되돌리는 것이 자연스러운 자리" 를 &mut 저장
+    /// 진입점에서 구현한 것이다. raw 캐시가 없던 문서(HWPX/HWP3 출처)는 건드리지
+    /// 않는다(raw_stream 유무가 출처 판별에 쓰이는 경로를 오염시키지 않기 위함).
+    fn refresh_doc_info_raw_cache(&mut self) {
+        let doc = &mut self.document;
+        if doc.doc_info.raw_stream.is_none() {
+            return;
+        }
+        let dirty = doc.doc_info.raw_stream_dirty
+            || !doc
+                .doc_info
+                .raw_provenance_permits_reuse(&doc.doc_properties);
+        if !dirty {
+            return;
+        }
+        // 재구성 강제: dirty 를 세운 채 한 번 직렬화한다(통과 게이트 우회).
+        doc.doc_info.raw_stream_dirty = true;
+        let rebuilt =
+            crate::serializer::doc_info::serialize_doc_info(&doc.doc_info, &doc.doc_properties);
+        doc.doc_info.raw_stream = Some(rebuilt);
+        doc.doc_info.raw_stream_dirty = false;
+        // 방금 만든 바이트와 현재 모델을 재밀봉 — 이후 무변경 저장은 통과.
+        doc.doc_info.seal_raw_provenance(&doc.doc_properties);
     }
 
     /// 어댑터를 **복제본에 적용해** HWP5 를 낸다 — 호출자의 IR 은 그대로다.
@@ -1403,6 +1433,7 @@ impl DocumentCore {
 
         let saved_hwpx_page_border_fills = self.snapshot_hwpx_page_border_fill_overlay();
         let _report = convert_if_hwpx_source(&mut self.document, self.source_format);
+        self.refresh_doc_info_raw_cache();
         self.serialize_hwp_after_adapter(saved_hwpx_page_border_fills, |document| {
             crate::serializer::serialize_hwp_with_password(document, password)
         })

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -491,7 +491,14 @@ impl DocumentCore {
                                         && cell_para.text.is_empty()
                                         && cell_para.controls.is_empty()
                                         && !cell_diagonal);
-                                if Self::needs_line_seg_reflow(cell_para, inc) {
+                                // [#4898] 본문과 셀은 같은 구역의 저장 lineseg 좌표계를
+                                // 공유한다. 셀만 구역 권위를 무시하면 한컴이 0 높이로 접어
+                                // 둔 셀 내부 블록을 다시 조판해 표 높이와 뒤쪽 페이지가 변한다.
+                                if Self::needs_line_seg_reflow_in_scope(
+                                    cell_para,
+                                    inc,
+                                    section_sized,
+                                ) {
                                     reflow_line_segs(cell_para, cell_inner_width, styles, dpi);
                                 }
                             }
@@ -745,12 +752,28 @@ impl DocumentCore {
             && !section_has_sized_lineseg
     }
 
-    /// 구역(셀·글상자 등 중첩 포함)에 높이가 0 이 아닌 lineseg 가 하나라도 있는가.
+    /// 구역 본문·중첩 표 셀에 높이가 0 이 아닌 lineseg 가 하나라도 있는가.
     fn section_has_sized_lineseg(section: &crate::model::document::Section) -> bool {
         section
             .paragraphs
             .iter()
-            .any(|p| p.line_segs.iter().any(|s| s.line_height != 0))
+            .any(Self::paragraph_or_nested_table_has_sized_lineseg)
+    }
+
+    /// 표 셀은 section의 저장 좌표계를 공유하므로, 중첩 표까지 재귀해 lineseg 권위를
+    /// 판정한다. 글상자 문단은 이 자동 reflow 경로의 대상이 아니므로 포함하지 않는다.
+    fn paragraph_or_nested_table_has_sized_lineseg(
+        para: &crate::model::paragraph::Paragraph,
+    ) -> bool {
+        para.line_segs.iter().any(|s| s.line_height != 0)
+            || para.controls.iter().any(|control| match control {
+                Control::Table(table) => table.cells.iter().any(|cell| {
+                    cell.paragraphs
+                        .iter()
+                        .any(Self::paragraph_or_nested_table_has_sized_lineseg)
+                }),
+                _ => false,
+            })
     }
 
     /// HWP5 -> HWPX export가 넣은 LineSeg 부재 marker는 reflow gate에서만 사용한다.
@@ -3016,6 +3039,40 @@ mod validate_linesegs_tests {
         seg.line_height = 1000;
         para.line_segs.push(seg);
         assert!(!DocumentCore::needs_reflow_broadly(&para));
+    }
+
+    #[test]
+    fn issue4898_section_authority_includes_nested_table_cells() {
+        let zero_height_para = Paragraph {
+            line_segs: vec![LineSeg {
+                line_height: 0,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let mut cell = crate::model::table::Cell::default();
+        cell.paragraphs.push(Paragraph {
+            line_segs: vec![LineSeg {
+                line_height: 100,
+                ..Default::default()
+            }],
+            ..Default::default()
+        });
+        let mut table = crate::model::table::Table::default();
+        table.cells.push(cell);
+        let section = Section {
+            paragraphs: vec![Paragraph {
+                controls: vec![Control::Table(Box::new(table))],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        assert!(DocumentCore::section_has_sized_lineseg(&section));
+        assert!(
+            !DocumentCore::needs_line_seg_reflow_in_scope(&zero_height_para, false, true),
+            "셀의 저장 lineseg가 있는 구역에서는 0 높이 lineseg를 재조판하면 안 된다"
+        );
     }
 }
 

--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -402,10 +402,11 @@ fn for_each_ole_mut(doc: &mut Document, f: &mut dyn FnMut(&mut OleShape)) {
 /// 읽는 중첩 `OOXMLChartContents` 가 들어 있다(#4055 실측: 그 사본만 고쳐도 렌더에
 /// 반영된다).
 ///
-/// 두 브랜치는 `sz`/`pos`/`outMargin`/`zOrder`/`textWrap` 이 전부 같고, 모델에 남는
-/// 차이는 `bin_data_id`·`instance_id`·`rotate_image`·`drawing_aspect`·`caption` 뿐이다
-/// (`parse_common_shape_children` 이 `orgSz`/`curSz`/`flip`/`lineShape` 를 IR 에 싣지
-/// 않는다). 그중 HWP5 로 나가는 것은 앞의 둘이고 둘 다 fallback 쪽이 정답이다.
+/// 두 브랜치는 `sz`/`pos`/`outMargin`/`zOrder`/`textWrap` 이 전부 같고(실물은
+/// `orgSz`/`curSz`/`flip`/`lineShape` 도 동일하게 중복 기록한다 — #4669 이후 양쪽
+/// 모두 IR 에 실린다), 모델에 남는 차이는 `bin_data_id`·`instance_id`·
+/// `rotate_image`·`drawing_aspect`·`caption` 뿐이다. 그중 HWP5 로 나가는 것은
+/// 앞의 둘이고 둘 다 fallback 쪽이 정답이다.
 ///
 /// ## fallback 이 없으면
 ///

--- a/src/model/bin_data.rs
+++ b/src/model/bin_data.rs
@@ -26,7 +26,7 @@ pub struct StoredBinData {
 }
 
 /// 바이너리 데이터 아이템 (HWPTAG_BIN_DATA)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct BinData {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -49,7 +49,7 @@ pub struct BinData {
 }
 
 /// 바이너리 데이터 타입
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum BinDataType {
     #[default]
     /// 외부 파일 참조
@@ -61,7 +61,7 @@ pub enum BinDataType {
 }
 
 /// 바이너리 데이터 압축 방식
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum BinDataCompression {
     #[default]
     /// 스토리지 디폴트
@@ -73,7 +73,7 @@ pub enum BinDataCompression {
 }
 
 /// 바이너리 데이터 접근 상태
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum BinDataStatus {
     #[default]
     /// 아직 접근하지 않음

--- a/src/model/document.rs
+++ b/src/model/document.rs
@@ -47,7 +47,7 @@ pub const HWPX_ORIGIN_STREAM_PATH: &str = "/RhwpHwpxOrigin";
 pub const HWP3_ORIGIN_STREAM_PATH: &str = "/RhwpHwp3Origin";
 
 /// 파서가 모델링하지 않는 원시 레코드 (라운드트립 보존용)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct RawRecord {
     /// 태그 ID
     pub tag_id: u16,
@@ -154,7 +154,7 @@ pub struct HwpVersion {
 }
 
 /// 문서 속성 (HWPTAG_DOCUMENT_PROPERTIES)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct DocProperties {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -229,6 +229,10 @@ pub struct DocInfo {
     /// (1.2~1.5 등) 원본 값을 보존해 직렬화 때 그대로 재방출한다.
     /// 원본 HWPX가 없으면 None → serializer가 "1.2" 폴백.
     pub hwpml_version: Option<String>,
+    /// [#4493] raw_stream 출처 봉인 — 파싱(+로드 픽스업) 완료 시점의 모델 상태와
+    /// 원본 바이트의 다이제스트 쌍. 저장 시 둘 다 일치할 때만 raw 를 재사용한다.
+    /// 계약 전문은 `model::raw_provenance` 모듈 주석.
+    pub raw_provenance: Option<crate::model::raw_provenance::DocInfoSeal>,
 }
 
 /// 본문의 구역 (Section)

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -15,6 +15,7 @@ pub mod page;
 pub mod paragraph;
 pub mod path;
 pub mod provenance;
+pub mod raw_provenance;
 pub mod shape;
 pub mod style;
 pub mod table;

--- a/src/model/raw_provenance.rs
+++ b/src/model/raw_provenance.rs
@@ -1,0 +1,323 @@
+//! [#4493] DocInfo raw 캐시 출처 봉인(provenance seal).
+//!
+//! ## 문제
+//!
+//! 공개 저수준 API 는 `parse_document → model::Document 직접 변경 →
+//! serialize_document` 를 허용하는데, HWP 파싱은 `DocInfo.raw_stream` 과 레코드별
+//! `raw_data` 를 채우고 `raw_stream_dirty=false` 로 남긴다. 공개 모델 필드를 직접
+//! 바꾸면 dirty 표식이 서지 않으므로, 저장 시 원본 바이트 통과(스트림·레코드
+//! 양쪽)가 그대로 발동해 **메모리에서 보이던 변경이 저장·재로드 뒤 조용히
+//! 사라진다.**
+//!
+//! ## 처방 — 봉인과 검증
+//!
+//! 파싱과 모든 load fixup 이 끝난 시점(`parse_document_inner` 말미)에 봉인한다.
+//!
+//! - **스트림 봉인** — 원본 DocInfo 바이트와 모델 상태의 다이제스트 쌍. 저장 시
+//!   둘 다 일치할 때만 `raw_stream` 전체 통과를 허용한다. 공개 `raw_stream` 을
+//!   다른 바이트로 교체해도(raw digest 불일치) 봉인으로 승인되지 않는다.
+//! - **레코드 봉인** — DocInfo 의 레코드별 `raw_data` 지름길(BIN_DATA·FACE_NAME·
+//!   BORDER_FILL·CHAR_SHAPE·TAB_DEF·NUMBERING·BULLET·PARA_SHAPE·STYLE·
+//!   DOCUMENT_PROPERTIES)에 대응하는 레코드 단위 다이제스트. 스트림이 재생성될
+//!   때 **변경되지 않은 레코드만** 원본 바이트를 재사용하고, 변경된 레코드는
+//!   모델 writer 로 다시 쓴다 — 하위 raw 를 무조건 폐기해 미모델링 바이트를
+//!   잃는 방식은 쓰지 않는다(#4495 와 같은 원칙).
+//!
+//! 봉인은 모델 타입에 필드를 넣지 않고 이 모듈의 컨테이너(인덱스 정렬)로
+//! 중앙 보관한다 — 목록 삽입·삭제로 인덱스가 어긋나면 다이제스트가 어긋나
+//! 재생성으로 떨어지므로 안전한 방향으로 실패한다.
+//!
+//! ## 다이제스트 규약
+//!
+//! serde 직렬화(JSON 인코딩)를 blake3 로 해시한다 — `Debug`/`DefaultHasher`/
+//! 재귀 `Clone` 스냅샷에 의존하지 않는다. serde_json 은 구조체 필드를 선언
+//! 순서로, 숫자·float 를 결정적 표기(ryu/itoa)로 방출하므로 같은 프로세스에서
+//! 항상 같은 바이트를 낸다. DocInfo 트리에는 순회 순서가 비결정적인 맵 타입이
+//! 없다(생기면 이 모듈에서 정렬 직렬화로 감싸야 한다). 봉인 대상 필드는
+//! [`doc_info_model_digest`] 가 **전수 구조분해**로 나열한다 — 필드 추가 시
+//! 컴파일 오류로 목록 갱신을 강제한다.
+//!
+//! Section(`raw_stream`)·본문 컨트롤 raw 레코드의 같은 계약은 #4488·#4495 가
+//! 별도로 다룬다 — 스트림·소유자가 다르다.
+
+use serde::Serialize;
+
+use super::document::{DocInfo, DocProperties};
+
+/// 파싱 완료 시점의 DocInfo 봉인.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocInfoSeal {
+    /// 봉인 시점 모델 상태의 다이제스트 ([`doc_info_model_digest`]).
+    pub model_digest: [u8; 32],
+    /// 봉인 시점 `raw_stream` 바이트의 다이제스트.
+    pub raw_digest: [u8; 32],
+    /// 레코드별 봉인 — 인덱스는 봉인 시점 목록 순서.
+    pub record_seals: DocInfoRecordSeals,
+}
+
+/// 레코드별 `raw_data` 지름길에 대응하는 다이제스트 묶음.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DocInfoRecordSeals {
+    pub props: [u8; 32],
+    pub bin_data: Vec<[u8; 32]>,
+    /// 언어 축(바깥)×글꼴(안) — `DocInfo.font_faces` 와 같은 모양.
+    pub fonts: Vec<Vec<[u8; 32]>>,
+    pub border_fills: Vec<[u8; 32]>,
+    pub char_shapes: Vec<[u8; 32]>,
+    pub tab_defs: Vec<[u8; 32]>,
+    pub numberings: Vec<[u8; 32]>,
+    pub bullets: Vec<[u8; 32]>,
+    pub para_shapes: Vec<[u8; 32]>,
+    pub styles: Vec<[u8; 32]>,
+}
+
+/// 바이트 열의 다이제스트.
+pub fn bytes_digest(bytes: &[u8]) -> [u8; 32] {
+    *blake3::hash(bytes).as_bytes()
+}
+
+/// 레코드(직렬화 가능한 모델 값) 하나의 다이제스트.
+///
+/// 레코드의 `raw_data` 필드도 다이제스트에 포함된다 — 모델 필드가 변하지 않는 한
+/// `raw_data` 는 파싱 시점 그대로이므로 판정에 영향이 없고, `raw_data` 만 바꿔치기
+/// 하는 변경도 불일치로 떨어져 승인되지 않는다.
+pub fn record_digest<T: Serialize>(record: &T) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    serde_json::to_writer(&mut hasher, record)
+        .expect("레코드 다이제스트 직렬화는 실패할 수 없다 (순수 인메모리 인코딩)");
+    *hasher.finalize().as_bytes()
+}
+
+/// 봉인 컨테이너에서 `idx` 레코드의 raw 재사용 허용 여부.
+///
+/// - 봉인 자체가 없으면(`seals=None`, 파서를 거치지 않은 합성 IR) 종전 계약대로
+///   허용한다.
+/// - 봉인이 있으면 인덱스가 범위 안이고 다이제스트가 일치할 때만 허용한다 —
+///   목록 삽입·삭제로 인덱스가 밀리면 불일치로 떨어져 모델 writer 로 재생성된다.
+pub fn record_raw_permitted<T: Serialize>(
+    seals: Option<&[[u8; 32]]>,
+    idx: usize,
+    record: &T,
+) -> bool {
+    match seals {
+        None => true,
+        Some(seals) => seals
+            .get(idx)
+            .is_some_and(|sealed| *sealed == record_digest(record)),
+    }
+}
+
+/// DocInfo(+DocProperties) 모델 상태의 다이제스트.
+///
+/// 저장 산출물에 실리는 모델 필드 전부를 선언 순서로 직렬화해 해시한다.
+/// 구조분해에 `..` 를 쓰지 않는 것이 계약이다 — 새 필드가 생기면 여기가
+/// 컴파일 오류를 내서 "봉인 대상인가"의 판단을 강제한다. raw 캐시 자신
+/// (`raw_stream`)과 그 관리 표식(`raw_stream_dirty`, `raw_provenance`), 통과
+/// 경로가 스스로 처리하는 `distribute_doc_data_removed`(surgical remove)는 뺀다.
+pub fn doc_info_model_digest(doc_info: &DocInfo, doc_props: &DocProperties) -> [u8; 32] {
+    let DocInfo {
+        bin_data_list,
+        font_faces,
+        border_fills,
+        char_shapes,
+        tab_defs,
+        numberings,
+        bullets,
+        para_shapes,
+        styles,
+        extra_records,
+        raw_stream: _,
+        bullet_count,
+        memo_shape_count,
+        memo_properties_xml,
+        distribute_doc_data_removed: _,
+        raw_stream_dirty: _,
+        hwpx_head_tail,
+        hwpml_version,
+        raw_provenance: _,
+    } = doc_info;
+
+    #[derive(Serialize)]
+    struct Fingerprint<'a> {
+        bin_data_list: &'a [crate::model::bin_data::BinData],
+        font_faces: &'a [Vec<crate::model::style::Font>],
+        border_fills: &'a [crate::model::style::BorderFill],
+        char_shapes: &'a [crate::model::style::CharShape],
+        tab_defs: &'a [crate::model::style::TabDef],
+        numberings: &'a [crate::model::style::Numbering],
+        bullets: &'a [crate::model::style::Bullet],
+        para_shapes: &'a [crate::model::style::ParaShape],
+        styles: &'a [crate::model::style::Style],
+        extra_records: &'a [crate::model::document::RawRecord],
+        bullet_count: u32,
+        memo_shape_count: u32,
+        memo_properties_xml: &'a Option<String>,
+        hwpx_head_tail: &'a Option<String>,
+        hwpml_version: &'a Option<String>,
+        props: &'a DocProperties,
+    }
+
+    let fp = Fingerprint {
+        bin_data_list,
+        font_faces,
+        border_fills,
+        char_shapes,
+        tab_defs,
+        numberings,
+        bullets,
+        para_shapes,
+        styles,
+        extra_records,
+        bullet_count: *bullet_count,
+        memo_shape_count: *memo_shape_count,
+        memo_properties_xml,
+        hwpx_head_tail,
+        hwpml_version,
+        props: doc_props,
+    };
+
+    let mut hasher = blake3::Hasher::new();
+    serde_json::to_writer(&mut hasher, &fp)
+        .expect("모델 다이제스트 직렬화는 실패할 수 없다 (순수 인메모리 인코딩)");
+    *hasher.finalize().as_bytes()
+}
+
+/// 레코드 봉인 묶음 계산 — 봉인 시점의 목록 순서 그대로.
+fn compute_record_seals(doc_info: &DocInfo, doc_props: &DocProperties) -> DocInfoRecordSeals {
+    DocInfoRecordSeals {
+        props: record_digest(doc_props),
+        bin_data: doc_info.bin_data_list.iter().map(record_digest).collect(),
+        fonts: doc_info
+            .font_faces
+            .iter()
+            .map(|lang| lang.iter().map(record_digest).collect())
+            .collect(),
+        border_fills: doc_info.border_fills.iter().map(record_digest).collect(),
+        char_shapes: doc_info.char_shapes.iter().map(record_digest).collect(),
+        tab_defs: doc_info.tab_defs.iter().map(record_digest).collect(),
+        numberings: doc_info.numberings.iter().map(record_digest).collect(),
+        bullets: doc_info.bullets.iter().map(record_digest).collect(),
+        para_shapes: doc_info.para_shapes.iter().map(record_digest).collect(),
+        styles: doc_info.styles.iter().map(record_digest).collect(),
+    }
+}
+
+impl DocInfo {
+    /// 파싱(+로드 픽스업) 완료 시점에 호출 — raw 캐시가 있으면 현재 모델 상태와
+    /// 함께 봉인한다. raw 가 없으면(HWPX/HWP3/합성 IR) 봉인도 없다.
+    pub fn seal_raw_provenance(&mut self, doc_props: &DocProperties) {
+        self.raw_provenance = self.raw_stream.as_ref().map(|raw| DocInfoSeal {
+            model_digest: doc_info_model_digest(self, doc_props),
+            raw_digest: bytes_digest(raw),
+            record_seals: compute_record_seals(self, doc_props),
+        });
+    }
+
+    /// 저장 시점 스트림 통과 검증 — raw 바이트와 모델 상태가 둘 다 봉인과 같은가.
+    ///
+    /// 봉인이 없는 raw(`raw_provenance=None`, 파서를 거치지 않은 합성 IR 등)는
+    /// 종전 계약대로 통과를 허용한다 — 봉인은 공개 parse→mutate→serialize
+    /// 경로의 손실을 막기 위한 것이고, 파서가 만든 문서에는 항상 봉인이 있다.
+    pub fn raw_provenance_permits_reuse(&self, doc_props: &DocProperties) -> bool {
+        let Some(raw) = self.raw_stream.as_ref() else {
+            return false;
+        };
+        match &self.raw_provenance {
+            None => true,
+            Some(seal) => {
+                seal.raw_digest == bytes_digest(raw)
+                    && seal.model_digest == doc_info_model_digest(self, doc_props)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn digest_changes_when_model_changes() {
+        let mut di = DocInfo::default();
+        let props = DocProperties::default();
+        let before = doc_info_model_digest(&di, &props);
+        di.char_shapes
+            .push(crate::model::style::CharShape::default());
+        let after = doc_info_model_digest(&di, &props);
+        assert_ne!(before, after, "char_shapes 변경이 다이제스트에 실려야 한다");
+    }
+
+    #[test]
+    fn digest_ignores_raw_cache_fields() {
+        let mut di = DocInfo::default();
+        let props = DocProperties::default();
+        let before = doc_info_model_digest(&di, &props);
+        di.raw_stream = Some(vec![1, 2, 3]);
+        di.raw_stream_dirty = true;
+        di.distribute_doc_data_removed = true;
+        let after = doc_info_model_digest(&di, &props);
+        assert_eq!(before, after, "raw 캐시 표식은 모델 다이제스트 밖이다");
+    }
+
+    #[test]
+    fn sealed_raw_reuse_denied_after_model_mutation() {
+        let mut di = DocInfo::default();
+        let props = DocProperties::default();
+        di.raw_stream = Some(vec![9, 9, 9]);
+        di.seal_raw_provenance(&props);
+        assert!(di.raw_provenance_permits_reuse(&props), "무변경이면 재사용");
+
+        di.para_shapes
+            .push(crate::model::style::ParaShape::default());
+        assert!(
+            !di.raw_provenance_permits_reuse(&props),
+            "공개 모델 직접 변경 뒤에는 raw 재사용이 거부돼야 한다 (#4493)"
+        );
+    }
+
+    #[test]
+    fn sealed_raw_reuse_denied_after_raw_swap() {
+        let mut di = DocInfo::default();
+        let props = DocProperties::default();
+        di.raw_stream = Some(vec![9, 9, 9]);
+        di.seal_raw_provenance(&props);
+
+        di.raw_stream = Some(vec![8, 8, 8]);
+        assert!(
+            !di.raw_provenance_permits_reuse(&props),
+            "raw 바이트 교체는 기존 봉인으로 승인되지 않는다 (#4493)"
+        );
+    }
+
+    #[test]
+    fn unsealed_raw_keeps_legacy_passthrough() {
+        let mut di = DocInfo::default();
+        let props = DocProperties::default();
+        di.raw_stream = Some(vec![7]);
+        assert!(
+            di.raw_provenance_permits_reuse(&props),
+            "봉인 이전(합성 IR) 경로는 종전 계약 유지"
+        );
+    }
+
+    #[test]
+    fn record_raw_permission_follows_seal() {
+        let cs = crate::model::style::CharShape::default();
+        let sealed = [record_digest(&cs)];
+        assert!(record_raw_permitted(Some(&sealed), 0, &cs), "무변경 허용");
+        assert!(
+            !record_raw_permitted(Some(&sealed), 1, &cs),
+            "범위 밖(새 레코드)은 모델 writer"
+        );
+        let mut changed = cs;
+        changed.base_size = 2000;
+        assert!(
+            !record_raw_permitted(Some(&sealed), 0, &changed),
+            "변경 레코드는 raw 재사용 거부"
+        );
+        assert!(
+            record_raw_permitted(None, 0, &changed),
+            "봉인 없는 합성 IR 은 종전 계약"
+        );
+    }
+}

--- a/src/model/shape.rs
+++ b/src/model/shape.rs
@@ -882,6 +882,10 @@ pub struct OleShape {
     /// None 으로 접힌다(둘 다 미관측 변형 — 이 경우 switch 래핑은
     /// 재방출되지 않는다).
     pub chart_switch_fallback: Option<Box<OleShape>>,
+    /// [#4669] HWPX `<hp:ole id="...">` 원문 — `instid` 와 별개 값이다(한컴
+    /// 원산 파일 실측: id=2141242094 / instid=1067500271). 종전에는 `instid` 만
+    /// 파싱해 재방출 `id` 가 instance_id(또는 "0")로 되쓰였다. HWP5 출신은 None.
+    pub hwpx_ole_id: Option<u32>,
 }
 
 #[cfg(test)]

--- a/src/model/style.rs
+++ b/src/model/style.rs
@@ -48,7 +48,7 @@ pub fn border_width_mm_str(index: u8) -> &'static str {
 }
 
 /// 글꼴 정보 (HWPTAG_FACE_NAME)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Font {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -81,7 +81,7 @@ pub struct Font {
 /// 4개 속성을 모두 보존해 라운드트립 무손실을 보장한다. `font_type`/`is_embedded`/
 /// `bin_item_id_ref` 는 부모 `<hh:font>` 의 같은 이름 속성과 독립적이다
 /// (예: HFT 글꼴이 TTF 대체 글꼴을 가질 수 있음).
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
 pub struct SubstFont {
     /// 대체 글꼴 이름
     pub face: String,
@@ -99,7 +99,7 @@ pub struct SubstFont {
 ///
 /// `Default` 는 [수동 구현](#impl-Default-for-CharShape)이다 — 파생하면 `relative_sizes` 가
 /// 스펙 위반값 0 이 된다(#4141).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct CharShape {
     /// 원본 레코드 바이트 (라운드트립 보존용, 있으면 직렬화 시 우선 사용)
     pub raw_data: Option<Vec<u8>>,
@@ -293,7 +293,7 @@ pub enum UnderlineType {
 }
 
 /// 문단 머리 모양 종류 (attr1 bit 23~24)
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum HeadType {
     /// 없음
     #[default]
@@ -307,7 +307,7 @@ pub enum HeadType {
 }
 
 /// 문단 모양 (HWPTAG_PARA_SHAPE)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct ParaShape {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -382,7 +382,7 @@ impl PartialEq for ParaShape {
 impl Eq for ParaShape {}
 
 /// 문단 번호 정의 (HWPTAG_NUMBERING)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Numbering {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -403,7 +403,7 @@ pub struct Numbering {
 }
 
 /// 문단 머리 정보 (표 41)
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
 pub struct NumberingHead {
     /// 속성 (정렬, 너비 따름, 자동 내어쓰기 등)
     pub attr: u32,
@@ -418,7 +418,7 @@ pub struct NumberingHead {
 }
 
 /// 글머리표 정의 (HWPTAG_BULLET, 표 44, 24바이트)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Bullet {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -445,7 +445,7 @@ pub struct Bullet {
 }
 
 /// 텍스트 정렬 방식
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum Alignment {
     #[default]
     Justify,
@@ -457,7 +457,7 @@ pub enum Alignment {
 }
 
 /// 줄 간격 종류
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum LineSpacingType {
     #[default]
     Percent,
@@ -467,7 +467,7 @@ pub enum LineSpacingType {
 }
 
 /// 탭 정의 (HWPTAG_TAB_DEF)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct TabDef {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -482,7 +482,7 @@ pub struct TabDef {
 }
 
 /// 탭 항목
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct TabItem {
     /// 탭 위치
     pub position: HwpUnit,
@@ -511,7 +511,7 @@ impl PartialEq for TabDef {
 impl Eq for TabDef {}
 
 /// 스타일 (HWPTAG_STYLE)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Style {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -539,7 +539,7 @@ pub struct Style {
 }
 
 /// 테두리/배경 (HWPTAG_BORDER_FILL)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct BorderFill {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -558,7 +558,7 @@ pub struct BorderFill {
 }
 
 /// 중심선 방향 (HWPX borderFill@centerLine)
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize)]
 pub enum CenterLine {
     /// 없음
     #[default]
@@ -623,7 +623,7 @@ impl CenterLine {
 }
 
 /// 테두리선 정보
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
 pub struct BorderLine {
     /// 선 종류
     pub line_type: BorderLineType,
@@ -635,7 +635,7 @@ pub struct BorderLine {
 
 /// 테두리선 종류 (HWP 스펙 표 27)
 /// 0=선없음, 1=실선, 2=파선, 3=점선, ...
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum BorderLineType {
     /// 선 없음 (0)
     None,
@@ -677,7 +677,7 @@ pub enum BorderLineType {
 }
 
 /// 대각선 정보
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
 pub struct DiagonalLine {
     /// 대각선 선 종류 코드. BorderLineType의 HWP/HWPX 코드와 같은 값을 사용한다.
     pub diagonal_type: u8,
@@ -688,7 +688,7 @@ pub struct DiagonalLine {
 }
 
 /// 채우기 정보
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Fill {
     /// 채우기 종류
     pub fill_type: FillType,
@@ -703,7 +703,7 @@ pub struct Fill {
 }
 
 /// 채우기 종류
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum FillType {
     #[default]
     None,
@@ -713,7 +713,7 @@ pub enum FillType {
 }
 
 /// 단색 채우기
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
 pub struct SolidFill {
     /// 배경색
     pub background_color: ColorRef,
@@ -724,7 +724,7 @@ pub struct SolidFill {
 }
 
 /// 그러데이션 채우기
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct GradientFill {
     /// 유형 (1: 줄무늬, 2: 원형, 3: 원뿔형, 4: 사각형)
     pub gradient_type: i16,
@@ -745,7 +745,7 @@ pub struct GradientFill {
 }
 
 /// 이미지 채우기
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct ImageFill {
     /// 채우기 유형
     pub fill_mode: ImageFillMode,

--- a/src/model/table.rs
+++ b/src/model/table.rs
@@ -142,6 +142,14 @@ pub struct Cell {
     pub list_header_width_ref: u16,
     /// 텍스트 방향 (0: 가로, 1: 세로)
     pub text_direction: u8,
+    /// [#4898] 줄바꿈 방식 — LIST_HEADER `list_attr` bit 19~20, OWPML `lineWrap`.
+    ///
+    /// `0` = BREAK(어절 단위 줄바꿈, 기본) · `1` = SQUEEZE(자간을 조절해 한 줄 유지) ·
+    /// `2` = KEEP. 종전에는 이 두 비트를 읽지도 쓰지도 않아 HWPX→HWP 저장에서 항상 0 이
+    /// 됐다 — 셀 줄바꿈 방식이 바뀌면 줄 수·셀 높이·표 높이가 따라 바뀐다.
+    /// 매핑은 한글 2022 실측이다(SQUEEZE 만 쓰는 문서를 SaveAs → LIST_HEADER 19개가 전부
+    /// bit19=1, BREAK 위주 문서는 SQUEEZE 인 셀 하나만 1). KEEP=2 는 스키마 열거 순서다.
+    pub line_wrap: u8,
     /// 세로 정렬 (0: top, 1: center, 2: bottom)
     pub vertical_align: VerticalAlign,
     /// 안 여백 지정 여부 (list_attr bit 16)
@@ -420,6 +428,7 @@ impl Cell {
             padding: template.padding,
             list_header_width_ref: template.list_header_width_ref,
             text_direction: template.text_direction,
+            line_wrap: template.line_wrap,
             vertical_align: template.vertical_align,
             apply_inner_margin: template.apply_inner_margin,
             is_header: template.is_header,

--- a/src/parser/control.rs
+++ b/src/parser/control.rs
@@ -350,6 +350,9 @@ fn parse_cell(records: &[Record]) -> Cell {
     // bit 19~20: 줄바꿈 방식
     // bit 21~22: 세로 정렬 (0=top, 1=center, 2=bottom)
     cell.text_direction = ((list_attr >> 16) & 0x07) as u8;
+    // [#4898] 줄바꿈 방식(bit 19~20)도 싣는다 — 종전엔 읽지 않아 저장에서 0(BREAK)으로
+    // 굳었고, SQUEEZE 셀의 줄 수·높이가 달라져 한글 쪽수까지 흔들렸다.
+    cell.line_wrap = ((list_attr >> 19) & 0x03) as u8;
     let v_align = ((list_attr >> 21) & 0x03) as u8;
     cell.vertical_align = match v_align {
         1 => VerticalAlign::Center,

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -6828,7 +6828,9 @@ fn parse_hp_ole_element(
     let mut draw_aspect = OleDrawingAspect::default();
     // [#4669] `id` 는 `instid` 와 별개 값이다(한컴 원산 실측). 종전에는 id arm 이
     // 없어(차트는 #3546 에서 받음) 재방출 id 가 "0" 또는 instid 로 되쓰였다.
-    let mut id_attr: u32 = 0;
+    // `id`는 선택 속성이고 0도 유효하다. 따라서 값 0을 "속성 없음"과 합치면
+    // 원문 id=0을 instance_id로 다시 써서 라운드트립을 깨뜨린다.
+    let mut id_attr: Option<u32> = None;
     let mut saw_instid = false;
 
     for attr in e.attributes().flatten() {
@@ -6881,7 +6883,7 @@ fn parse_hp_ole_element(
                 let digits: String = s.chars().filter(|c| c.is_ascii_digit()).collect();
                 bin_id = digits.parse().unwrap_or(0);
             }
-            b"id" => id_attr = parse_u32(&attr),
+            b"id" => id_attr = Some(parse_u32(&attr)),
             b"instid" => {
                 saw_instid = true;
                 common.instance_id = parse_u32(&attr);
@@ -6896,7 +6898,7 @@ fn parse_hp_ole_element(
     // 명시적 instid="0"(차트 fallback OLE 의 한컴 정답값, #4099 오라클)은 보존해야
     // 하므로 "0 이면 폴백" 이 아니라 "속성이 없으면 폴백" 이다.
     if !saw_instid {
-        common.instance_id = id_attr;
+        common.instance_id = id_attr.unwrap_or_default();
     }
 
     let mut extent: Option<(i32, i32)> = None;
@@ -6925,9 +6927,7 @@ fn parse_hp_ole_element(
         ole.drawing.border_line = ls;
     }
     // [#4669] id 원문 보존 — instid 와 분리해 재방출 시 원본 id 를 되쓴다.
-    if id_attr != 0 {
-        ole.hwpx_ole_id = Some(id_attr);
-    }
+    ole.hwpx_ole_id = id_attr;
     ole.bin_data_id = bin_id;
     ole.drawing_aspect = draw_aspect;
     // <hc:extent> 가 있으면 원본 개체 크기를 보존한다(없으면 종전 기본값 7200).
@@ -9381,6 +9381,36 @@ mod tests {
     /// [#4669] 명시적 `instid="0"` 은 id 로 덮지 않는다 — 차트 fallback OLE 의
     /// 한컴 정답값이 instance_id=0 이다(#4099 오라클). id 폴백은 instid **부재**
     /// 시에만 작동해야 한다.
+    #[test]
+    fn issue4669_explicit_zero_id_is_not_rewritten_to_instid() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="0" zOrder="7" textWrap="SQUARE" instid="1067500271" binaryItemIDRef="ole1">
+        <hp:sz width="7200" height="7200" protect="0"/>
+        <hp:pos treatAsChar="1" vertRelTo="PARA" horzRelTo="PARA"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Ole(ole) = shape.as_ref() else {
+            panic!("expected OLE shape");
+        };
+        assert_eq!(ole.hwpx_ole_id, Some(0), "명시적 id=0 원문 보존");
+        assert_eq!(
+            ole.common.instance_id, 1067500271,
+            "instid 와 id는 별개로 보존"
+        );
+    }
+
     #[test]
     fn issue4669_explicit_zero_instid_is_not_overridden_by_id() {
         let xml = r#"<?xml version="1.0" encoding="UTF-8"?>

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -6755,6 +6755,7 @@ fn parse_hp_ole_element(
     // [#4669] `id` 는 `instid` 와 별개 값이다(한컴 원산 실측). 종전에는 id arm 이
     // 없어(차트는 #3546 에서 받음) 재방출 id 가 "0" 또는 instid 로 되쓰였다.
     let mut id_attr: u32 = 0;
+    let mut saw_instid = false;
 
     for attr in e.attributes().flatten() {
         match attr.key.as_ref() {
@@ -6807,15 +6808,20 @@ fn parse_hp_ole_element(
                 bin_id = digits.parse().unwrap_or(0);
             }
             b"id" => id_attr = parse_u32(&attr),
-            b"instid" => common.instance_id = parse_u32(&attr),
+            b"instid" => {
+                saw_instid = true;
+                common.instance_id = parse_u32(&attr);
+            }
             // [#2931] 개체 잠금(lock) — 종전 미파싱으로 직렬화 시 항상 "0"으로
             // 되돌아가 OLE 개체의 잠금 상태가 유실됐다.
             b"lock" => common.locked = attr_str(&attr) == "1",
             _ => {}
         }
     }
-    // 차트(#3546)와 동형 — instid 부재 시 id 가 instance_id 를 겸한다.
-    if common.instance_id == 0 {
+    // 차트(#3546)와 동형 — instid **부재** 시에만 id 가 instance_id 를 겸한다.
+    // 명시적 instid="0"(차트 fallback OLE 의 한컴 정답값, #4099 오라클)은 보존해야
+    // 하므로 "0 이면 폴백" 이 아니라 "속성이 없으면 폴백" 이다.
+    if !saw_instid {
         common.instance_id = id_attr;
     }
 
@@ -9296,6 +9302,36 @@ mod tests {
             1,
             "lineShape style=SOLID"
         );
+    }
+
+    /// [#4669] 명시적 `instid="0"` 은 id 로 덮지 않는다 — 차트 fallback OLE 의
+    /// 한컴 정답값이 instance_id=0 이다(#4099 오라클). id 폴백은 instid **부재**
+    /// 시에만 작동해야 한다.
+    #[test]
+    fn issue4669_explicit_zero_instid_is_not_overridden_by_id() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="1117817146" zOrder="7" textWrap="SQUARE" instid="0" binaryItemIDRef="ole1">
+        <hp:sz width="7200" height="7200" protect="0"/>
+        <hp:pos treatAsChar="1" vertRelTo="PARA" horzRelTo="PARA"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Ole(ole) = shape.as_ref() else {
+            panic!("expected OLE shape");
+        };
+        assert_eq!(ole.common.instance_id, 0, "명시적 instid=0 보존 (#4099)");
+        assert_eq!(ole.hwpx_ole_id, Some(1117817146), "id 원문은 별도 보존");
     }
 
     #[test]

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -49,6 +49,12 @@ pub fn parse_hwpx_section(xml: &str) -> Result<Section, HwpxError> {
     let mut reader = Reader::from_str(xml);
     let mut buf = Vec::new();
 
+    // [#4898] 0높이 lineseg 정규화(#2070)의 판단 범위를 구역으로 넓힌다 — 문단 단위로
+    // 보면 한컴이 접어 둔 숨은 블록까지 지우게 된다. RAII 로 되돌려 중첩 파싱(표 셀 안의
+    // 구역 없음)이나 다음 구역에 값이 새지 않게 한다.
+    let sized = section_xml_has_sized_lineseg(xml);
+    let _lineseg_scope = SectionLinesegScope::enter(sized);
+
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref e)) => {
@@ -428,6 +434,40 @@ const MAX_HWPX_SECTION_DEPTH: u32 = 64;
 thread_local! {
     // 완전 경로 — 이 모듈의 `Cell` 은 이미 `crate::model::table::Cell`(표 셀)이다.
     static HWPX_SECTION_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+    /// [#4898] 이 구역의 lineseg 가 **배치 권위를 갖는가** — 0 아닌 높이가 하나라도 있으면 참.
+    ///
+    /// #2070 의 0높이 정규화를 문단이 아니라 **구역** 범위로 판단하기 위한 신호다.
+    /// `parse_paragraph` 는 표 셀·글상자·각주 등 여러 경로에서 재귀 호출되므로
+    /// 파라미터를 관통시키지 않고 형제 가드(`HWPX_SECTION_DEPTH`)와 같은 방식으로 나른다.
+    static HWPX_SECTION_HAS_SIZED_LINESEG: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// 구역 XML 에 **높이가 0 이 아닌 lineseg** 가 하나라도 있는지 훑는다.
+///
+/// [#4898] 한컴은 숨긴 블록(예: CLIPDATA)을 `vertsize="0"` lineseg 로 **접어서** 저장한다.
+/// 그 0높이를 "권위 없음"으로 보고 지우면 rhwp 가 그 문단을 새로 조판해 숨은 내용이
+/// 펼쳐지고, 뒤 내용이 밀려 쪽수가 늘어난다(08852 실측: 최대 vertpos 40,525 → 77,965,
+/// 1쪽 → 2쪽). 반대로 lineseg 를 **전부** 0 으로 채워 저장하는 생성계 문서도 실재하고,
+/// 그쪽은 #2070 대로 부재 취급해야 셀·문단 높이가 선언값으로 붕괴하지 않는다.
+///
+/// 두 경우를 가르는 신호가 "이 구역에 0 아닌 lineseg 가 있는가"다.
+fn section_xml_has_sized_lineseg(xml: &str) -> bool {
+    for tag in xml.split("<hp:lineseg").skip(1) {
+        let Some(end) = tag.find('>') else { continue };
+        let attrs = &tag[..end];
+        let sized = |name: &str| -> bool {
+            attrs
+                .split(name)
+                .nth(1)
+                .and_then(|rest| rest.strip_prefix("=\""))
+                .and_then(|rest| rest.split('"').next())
+                .is_some_and(|v| v.parse::<i64>().is_ok_and(|n| n != 0))
+        };
+        if sized("vertsize") || sized("textheight") {
+            return true;
+        }
+    }
+    false
 }
 
 /// `parse_paragraph` 진입 시 재귀 깊이를 +1 하고 이탈(Drop, 오류 전파·조기 반환
@@ -452,6 +492,23 @@ impl SectionDepthGuard {
 impl Drop for SectionDepthGuard {
     fn drop(&mut self) {
         HWPX_SECTION_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
+    }
+}
+
+/// [#4898] 구역 파싱 동안 "이 구역의 lineseg 가 배치 권위를 갖는가"를 세워 두고
+/// 이탈 시 이전 값으로 되돌리는 RAII 가드.
+struct SectionLinesegScope(bool);
+
+impl SectionLinesegScope {
+    fn enter(has_sized: bool) -> SectionLinesegScope {
+        let prev = HWPX_SECTION_HAS_SIZED_LINESEG.with(|f| f.replace(has_sized));
+        SectionLinesegScope(prev)
+    }
+}
+
+impl Drop for SectionLinesegScope {
+    fn drop(&mut self) {
+        HWPX_SECTION_HAS_SIZED_LINESEG.with(|f| f.set(self.0));
     }
 }
 
@@ -899,7 +956,14 @@ fn parse_paragraph(
     // 0 높이 lineseg 는 배치 권위가 없고(한글은 열 때 재계산) 실저장 취급 시
     // NO_LS 성장 경로가 죽어 셀/문단 높이가 선언값으로 붕괴한다 (#1380 대칭,
     // body_text.rs parse_para_line_seg 와 동일 규칙).
+    //
+    // [#4898] 단, 판단 범위는 문단이 아니라 **구역**이다. 한컴은 숨긴 블록을 0높이
+    // lineseg 로 접어서 저장하는데(08852: 9개가 vertpos 38605 에 겹쳐 있다), 그것까지
+    // 지우면 rhwp 가 그 문단을 새로 조판해 숨은 내용이 펼쳐지고 뒤가 밀려 쪽수가 는다
+    // (실측 1쪽 → 2쪽, 최대 vertpos 40,525 → 77,965). 구역에 0 아닌 lineseg 가 하나라도
+    // 있으면 그 구역의 lineseg 는 배치 권위가 있는 것이므로 0높이도 원본대로 보존한다.
     if !para.line_segs.is_empty()
+        && !HWPX_SECTION_HAS_SIZED_LINESEG.with(|f| f.get())
         && para
             .line_segs
             .iter()
@@ -2489,6 +2553,16 @@ fn parse_table_cell(
                                 b"textDirection" => {
                                     cell.text_direction =
                                         if attr_str(&attr) == "VERTICAL" { 1 } else { 0 };
+                                }
+                                // [#4898] 줄바꿈 방식. 종전엔 읽지 않아 HWP5 저장에서 항상
+                                // BREAK(0)이 됐고, SQUEEZE 셀은 한글이 줄을 다시 나눠
+                                // 셀·표 높이가 달라졌다(코퍼스 표본에 SQUEEZE 3,019회).
+                                b"lineWrap" => {
+                                    cell.line_wrap = match attr_str(&attr).as_str() {
+                                        "SQUEEZE" => 1,
+                                        "KEEP" => 2,
+                                        _ => 0,
+                                    };
                                 }
                                 _ => {}
                             }
@@ -9810,6 +9884,45 @@ mod tests {
         assert_eq!(
             eq.script, "a < b > c",
             "CDATA 로 감싸진 수식 스크립트가 소실되면 안 된다"
+        );
+    }
+
+    /// [#4898] 0높이 lineseg 정규화(#2070)는 **구역 단위**로 판단한다.
+    ///
+    /// 한컴은 숨긴 블록(CLIPDATA 등)을 `vertsize="0"` lineseg 로 접어서 저장한다. 그것을
+    /// 문단 단위로 "부재"로 보면 rhwp 가 그 문단을 새로 조판해 숨은 내용이 펼쳐지고 뒤가
+    /// 밀린다 — 08852 실측 최대 vertpos 40,525 → 77,965, 한글 1쪽 → 2쪽. 구역에 0 아닌
+    /// lineseg 가 있으면 그 구역의 lineseg 는 권위가 있으므로 0높이도 보존한다.
+    #[test]
+    fn issue4898_zero_height_linesegs_survive_when_section_has_sized_ones() {
+        let with_sized = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0"><hp:run charPrIDRef="0"><hp:t>본문</hp:t></hp:run>
+    <hp:linesegarray><hp:lineseg textpos="0" vertpos="0" vertsize="1200" textheight="1200" baseline="1020" spacing="600" horzpos="0" horzsize="42520" flags="393216"/></hp:linesegarray>
+  </hp:p>
+  <hp:p paraPrIDRef="0" styleIDRef="0"><hp:run charPrIDRef="0"><hp:t>숨긴 블록</hp:t></hp:run>
+    <hp:linesegarray><hp:lineseg textpos="0" vertpos="1200" vertsize="0" textheight="0" baseline="0" spacing="0" horzpos="0" horzsize="42520" flags="393216"/></hp:linesegarray>
+  </hp:p>
+</hs:sec>"#;
+        let section = parse_hwpx_section(with_sized).unwrap();
+        assert_eq!(
+            section.paragraphs[1].line_segs.len(),
+            1,
+            "0 아닌 lineseg 가 있는 구역에서는 0높이 lineseg 도 원본대로 보존해야 한다"
+        );
+
+        // 대조군(#2070): 구역 전체가 0높이면 종전대로 부재로 정규화한다 —
+        // 생성계 문서가 lineseg 를 0 으로 채워 저장하는 경우, 실저장 취급하면
+        // 셀·문단 높이가 선언값으로 붕괴한다.
+        let all_zero = with_sized.replace(
+            r#"vertsize="1200" textheight="1200""#,
+            r#"vertsize="0" textheight="0""#,
+        );
+        let section = parse_hwpx_section(&all_zero).unwrap();
+        assert!(
+            section.paragraphs.iter().all(|p| p.line_segs.is_empty()),
+            "구역 전체가 0높이면 종전대로 부재 취급한다"
         );
     }
 

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -6694,6 +6694,7 @@ fn parse_hp_chart_element(
     let mut extent: Option<(i32, i32)> = None;
     let mut shape_attr = ShapeComponentAttr::default();
     let mut caption: Option<crate::model::shape::Caption> = None;
+    let mut line_shape: Option<crate::model::style::ShapeBorderLine> = None;
     parse_common_shape_children(
         reader,
         &mut common,
@@ -6701,6 +6702,7 @@ fn parse_hp_chart_element(
         &mut extent,
         &mut shape_attr,
         &mut caption,
+        &mut line_shape,
     )?;
     if numbering_type_picture {
         common.hwp5_gen_shape_attr_bit28 = true;
@@ -6714,6 +6716,10 @@ fn parse_hp_chart_element(
     let mut ole = OleShape::default();
     ole.common = common;
     ole.drawing.shape_attr = shape_attr;
+    // [#4669] `<hp:lineShape>` 원본 보존 — 없으면 기본값 유지(종전과 동일).
+    if let Some(ls) = line_shape {
+        ole.drawing.border_line = ls;
+    }
     ole.bin_data_id = 60000u32 + chart_num as u32;
     ole.chart_id_ref = chart_id_ref;
     // <hc:extent> 가 있으면 원본 개체 크기를 보존한다(없으면 종전 기본값 7200).
@@ -6746,6 +6752,9 @@ fn parse_hp_ole_element(
     let mut bin_id: u32 = 0;
     let mut numbering_type_picture = false;
     let mut draw_aspect = OleDrawingAspect::default();
+    // [#4669] `id` 는 `instid` 와 별개 값이다(한컴 원산 실측). 종전에는 id arm 이
+    // 없어(차트는 #3546 에서 받음) 재방출 id 가 "0" 또는 instid 로 되쓰였다.
+    let mut id_attr: u32 = 0;
 
     for attr in e.attributes().flatten() {
         match attr.key.as_ref() {
@@ -6797,6 +6806,7 @@ fn parse_hp_ole_element(
                 let digits: String = s.chars().filter(|c| c.is_ascii_digit()).collect();
                 bin_id = digits.parse().unwrap_or(0);
             }
+            b"id" => id_attr = parse_u32(&attr),
             b"instid" => common.instance_id = parse_u32(&attr),
             // [#2931] 개체 잠금(lock) — 종전 미파싱으로 직렬화 시 항상 "0"으로
             // 되돌아가 OLE 개체의 잠금 상태가 유실됐다.
@@ -6804,10 +6814,15 @@ fn parse_hp_ole_element(
             _ => {}
         }
     }
+    // 차트(#3546)와 동형 — instid 부재 시 id 가 instance_id 를 겸한다.
+    if common.instance_id == 0 {
+        common.instance_id = id_attr;
+    }
 
     let mut extent: Option<(i32, i32)> = None;
     let mut shape_attr = ShapeComponentAttr::default();
     let mut caption: Option<crate::model::shape::Caption> = None;
+    let mut line_shape: Option<crate::model::style::ShapeBorderLine> = None;
     parse_common_shape_children(
         reader,
         &mut common,
@@ -6815,6 +6830,7 @@ fn parse_hp_ole_element(
         &mut extent,
         &mut shape_attr,
         &mut caption,
+        &mut line_shape,
     )?;
     if numbering_type_picture {
         common.hwp5_gen_shape_attr_bit28 = true;
@@ -6824,6 +6840,14 @@ fn parse_hp_ole_element(
     let mut ole = OleShape::default();
     ole.common = common;
     ole.drawing.shape_attr = shape_attr;
+    // [#4669] `<hp:lineShape>` 원본 보존 — 없으면 기본값 유지(종전과 동일).
+    if let Some(ls) = line_shape {
+        ole.drawing.border_line = ls;
+    }
+    // [#4669] id 원문 보존 — instid 와 분리해 재방출 시 원본 id 를 되쓴다.
+    if id_attr != 0 {
+        ole.hwpx_ole_id = Some(id_attr);
+    }
     ole.bin_data_id = bin_id;
     ole.drawing_aspect = draw_aspect;
     // <hc:extent> 가 있으면 원본 개체 크기를 보존한다(없으면 종전 기본값 7200).
@@ -6851,6 +6875,11 @@ fn apply_hwpx_ole_shape_component_contract(ole: &mut crate::model::shape::OleSha
     } else {
         7200
     };
+    // [#4669] 파싱된 `<hp:curSz width="0">`(한컴 원산 관례)를 orgSz 로 materialize
+    // 할 때 was_zero 센티널(#2017)을 세운다 — pic·일반 도형과 동형. writer
+    // (write_cur_sz)가 센티널을 보고 원본 0 을 복원한다. orgSz 미파싱(HWP5 출신
+    // 등 original=0)이면 no-op 이라 아래 extent 폴백과 충돌하지 않는다.
+    materialize_shape_current_size_from_original(&mut ole.common, &mut ole.drawing.shape_attr);
     let shape_attr = &mut ole.drawing.shape_attr;
     shape_attr.ctrl_id = tags::SHAPE_OLE_ID;
     shape_attr.is_two_ctrl_id = true;
@@ -6888,8 +6917,13 @@ fn parse_common_shape_children(
     // 캡션을 읽지만 차트·OLE 만 빠져 있었다. HWP5 파서(parser/control/shape.rs:213,
     // 222)와 동형으로 drawing.caption 에 채운 뒤 호출자가 `.caption` 으로 정규화한다.
     caption_out: &mut Option<crate::model::shape::Caption>,
+    // [#4669] `<hp:lineShape>` 수집용. 종전 미파싱으로 OLE 테두리 선이 저장 시
+    // 기본값으로 되쓰였다(offset/orgSz/curSz/flip/renderingInfo 와 함께 이 공용
+    // 파서만 shape-component 자식 arm 이 없던 간극).
+    line_shape_out: &mut Option<crate::model::style::ShapeBorderLine>,
 ) -> Result<(), HwpxError> {
     let mut buf = Vec::new();
+    let mut has_pos = false;
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref ce)) | Ok(Event::Empty(ref ce)) => {
@@ -6910,6 +6944,20 @@ fn parse_common_shape_children(
                     }
                     b"rotationInfo" => {
                         parse_shape_rotation_info(ce, shape_attr_out);
+                    }
+                    // [#4669] offset/orgSz/curSz — 공용 개체 파서(parse_object_layout_child)
+                    // 와 동형으로 위임한다. 종전 미파싱으로 원본 curSz=0(한컴 원산
+                    // 관례)·offset 이 IR 에 실리지 않아 저장 시 재유도값으로 되쓰였다.
+                    b"offset" | b"orgSz" | b"curSz" => {
+                        parse_object_layout_child(local, ce, common, shape_attr_out, &mut has_pos);
+                    }
+                    // [#4669] flip/renderingInfo/lineShape — 도형·그림 파서와 동형.
+                    b"flip" => parse_shape_flip(ce, shape_attr_out),
+                    b"renderingInfo" => {
+                        parse_rendering_info(reader, shape_attr_out)?;
+                    }
+                    b"lineShape" => {
+                        *line_shape_out = Some(parse_line_shape_attr(ce));
                     }
                     b"sz" => {
                         for attr in ce.attributes().flatten() {
@@ -6935,6 +6983,7 @@ fn parse_common_shape_children(
                         }
                     }
                     b"pos" => {
+                        has_pos = true;
                         for attr in ce.attributes().flatten() {
                             match attr.key.as_ref() {
                                 b"vertRelTo" => {
@@ -9168,6 +9217,85 @@ mod tests {
                 "높이 {raw} 는 Absolute 로 접혀야 한다"
             );
         }
+    }
+
+    /// [#4669] `hp:ole` 의 shape-component 자식(offset/orgSz/curSz/flip/
+    /// renderingInfo/lineShape)과 `id` 속성이 IR 에 실려야 한다. 종전엔 공용
+    /// 자식 파서(`parse_common_shape_children`)에 arm 이 없고 `id` 는 instid 만
+    /// 파싱해, 저장 시 전부 재유도값·"0" 으로 되쓰였다. 값은 실물
+    /// samples/한셀OLE.hwpx 의 hp:ole 을 축약했고(id≠instid 실측), curSz=0 은
+    /// 한컴 원산 관례로 was_zero 센티널(#2017, pic 과 동형)까지 고정한다.
+    #[test]
+    fn issue4669_parse_ole_preserves_shape_component_children_and_id() {
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="2141242094" zOrder="1" numberingType="PICTURE" textWrap="SQUARE"
+              textFlow="BOTH_SIDES" lock="0" instid="1067500271" objectType="EMBEDDED"
+              binaryItemIDRef="ole1" drawAspect="CONTENT">
+        <hp:offset x="12" y="34"/>
+        <hp:orgSz width="42001" height="13501"/>
+        <hp:curSz width="0" height="0"/>
+        <hp:flip horizontal="1" vertical="0"/>
+        <hp:rotationInfo angle="0" centerX="14999" centerY="2025" rotateimage="1"/>
+        <hp:renderingInfo>
+          <hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+          <hc:scaMatrix e1="0.714245" e2="0" e3="0" e4="0" e5="0.300052" e6="0"/>
+          <hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/>
+        </hp:renderingInfo>
+        <hc:extent x="29999" y="4051"/>
+        <hp:lineShape color="#000000" width="5" style="SOLID" endCap="ROUND"/>
+        <hp:sz width="29999" widthRelTo="ABSOLUTE" height="4051" heightRelTo="ABSOLUTE" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="COLUMN" vertOffset="0" horzOffset="0"/>
+        <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"##;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Ole(ole) = shape.as_ref() else {
+            panic!("expected OLE shape");
+        };
+        assert_eq!(ole.hwpx_ole_id, Some(2141242094), "id 원문 보존");
+        assert_eq!(
+            ole.common.instance_id, 1067500271,
+            "instid 는 id 와 분리 보존"
+        );
+        let sa = &ole.drawing.shape_attr;
+        assert_eq!((sa.offset_x, sa.offset_y), (12, 34), "hp:offset");
+        assert_eq!(
+            (sa.original_width, sa.original_height),
+            (42001, 13501),
+            "hp:orgSz"
+        );
+        // curSz=0 → orgSz 로 materialize 하되 원본 0 복원용 센티널이 서야 한다.
+        assert_eq!((sa.current_width, sa.current_height), (42001, 13501));
+        assert!(
+            sa.current_width_was_zero && sa.current_height_was_zero,
+            "curSz=0 센티널(#2017)"
+        );
+        assert!(sa.horz_flip && !sa.vert_flip, "hp:flip");
+        assert!(sa.rotate_image, "rotationInfo rotateimage=1");
+        // 행렬 값은 f32 양자화(hwp5_matrix_value)를 거친다 — 1e-5 면 충분.
+        assert!(
+            (sa.render_sx - 0.714245).abs() < 1e-5,
+            "renderingInfo scaMatrix 보존: {}",
+            sa.render_sx
+        );
+        assert_eq!(ole.drawing.border_line.width, 5, "lineShape width");
+        assert_eq!(
+            ole.drawing.border_line.attr & 0xFF,
+            1,
+            "lineShape style=SOLID"
+        );
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1476,6 +1476,22 @@ fn parse_document_inner(
     data: &[u8],
     password: Option<&[u8]>,
 ) -> Result<ParsedDocument, ParseError> {
+    let mut parsed = parse_document_inner_unsealed(data, password)?;
+    // [#4493] 파싱과 모든 load fixup 이 끝난 마지막 지점에서 DocInfo raw 출처를
+    // 봉인한다 — 이보다 앞(포맷별 파서 내부)에서 봉인하면 HWP3-변환본 spacing
+    // 반감 같은 로드 보정이 봉인을 깨서, 무변경 문서의 원본 바이트 통과가 죽는다.
+    // raw 캐시가 없는 포맷(HWPX/HWP3/HML)에서는 no-op.
+    parsed
+        .document
+        .doc_info
+        .seal_raw_provenance(&parsed.document.doc_properties);
+    Ok(parsed)
+}
+
+fn parse_document_inner_unsealed(
+    data: &[u8],
+    password: Option<&[u8]>,
+) -> Result<ParsedDocument, ParseError> {
     let open_policy = document_open_decompression_policy();
     match detect_format(data) {
         FileFormat::Hwp => {

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -674,7 +674,11 @@ fn serialize_cell(cell: &Cell, level: u16, records: &mut Vec<Record>) {
         VerticalAlign::Center => 1,
         VerticalAlign::Bottom => 2,
     };
-    let list_attr: u32 = ((cell.text_direction as u32) << 16) | (v_align_code << 21);
+    // [#4898] 줄바꿈 방식(bit 19~20)을 함께 되돌린다 — 빼먹으면 SQUEEZE 셀이 BREAK 로
+    // 굳어 한글이 줄을 다시 나눈다(줄 수 → 셀 높이 → 표 높이 → 쪽수).
+    let list_attr: u32 = ((cell.text_direction as u32) << 16)
+        | (((cell.line_wrap as u32) & 0x03) << 19)
+        | (v_align_code << 21);
     w.write_u32(list_attr).unwrap();
     let list_header_width_ref = if cell.list_header_width_ref == 0 {
         0x0400

--- a/src/serializer/doc_info.rs
+++ b/src/serializer/doc_info.rs
@@ -13,6 +13,7 @@ use super::record_writer::write_record;
 
 use crate::model::bin_data::{BinData, BinDataType};
 use crate::model::document::{DocInfo, DocProperties};
+use crate::model::raw_provenance;
 use crate::model::style::{
     BorderFill, BorderLineType, Bullet, CenterLine, FillType, Font, ImageFillMode, Numbering,
     ParaShape, Style, TabDef,
@@ -21,8 +22,13 @@ use crate::parser::tags;
 
 /// DocInfo + DocProperties를 레코드 바이너리 스트림으로 직렬화
 pub fn serialize_doc_info(doc_info: &DocInfo, doc_props: &DocProperties) -> Vec<u8> {
-    // 원본 스트림이 있고 변경되지 않았으면 그대로 반환 (완벽한 라운드트립)
-    if !doc_info.raw_stream_dirty {
+    // 원본 스트림이 있고 변경되지 않았으면 그대로 반환 (완벽한 라운드트립).
+    //
+    // [#4493] "변경되지 않았음" 은 dirty 표식만으로 판정하지 않는다 — 공개 모델
+    // 필드 직접 변경은 표식을 세우지 않으므로, 파싱 시점에 봉인한 (모델, raw)
+    // 다이제스트 쌍과 현재 상태가 둘 다 일치할 때만 통과한다(불일치·raw 교체는
+    // 아래 모델 writer 로 재생성). 봉인 계약은 model::raw_provenance 참조.
+    if !doc_info.raw_stream_dirty && doc_info.raw_provenance_permits_reuse(doc_props) {
         if let Some(ref raw) = doc_info.raw_stream {
             let mut result = raw.clone();
             // 배포용 문서 해제 시 DISTRIBUTE_DOC_DATA 레코드 제거
@@ -35,11 +41,22 @@ pub fn serialize_doc_info(doc_info: &DocInfo, doc_props: &DocProperties) -> Vec<
 
     let mut stream = Vec::new();
 
+    // [#4493] 레코드별 raw_data 지름길도 봉인 검증을 거친다 — 스트림이 재생성될
+    // 때(공개 모델 직접 변경 등) 변경되지 않은 레코드만 원본 바이트를 재사용하고,
+    // 변경된 레코드는 모델 writer 로 다시 쓴다. 봉인이 없는 합성 IR(record_seals
+    // 부재)은 종전 계약(무조건 raw 우선)을 유지한다.
+    let seals = doc_info.raw_provenance.as_ref().map(|s| &s.record_seals);
+
     // 1. DOCUMENT_PROPERTIES
+    let props_data = match (doc_props.raw_data.as_ref(), seals) {
+        (Some(raw), None) => raw.clone(),
+        (Some(raw), Some(s)) if s.props == raw_provenance::record_digest(doc_props) => raw.clone(),
+        _ => serialize_document_properties_from_model(doc_props),
+    };
     stream.extend(write_record(
         tags::HWPTAG_DOCUMENT_PROPERTIES,
         0,
-        &serialize_document_properties(doc_props),
+        &props_data,
     ));
 
     // 2. ID_MAPPINGS
@@ -49,74 +66,90 @@ pub fn serialize_doc_info(doc_info: &DocInfo, doc_props: &DocProperties) -> Vec<
         &serialize_id_mappings(doc_info),
     ));
 
+    // 레코드 봉인 게이트 — raw_data 가 있고 봉인이 허용할 때만 raw 재사용.
+    fn sealed_raw<'a, T: serde::Serialize>(
+        record: &'a T,
+        raw: &'a Option<Vec<u8>>,
+        seals: Option<&[[u8; 32]]>,
+        idx: usize,
+    ) -> Option<&'a Vec<u8>> {
+        raw.as_ref()
+            .filter(|_| raw_provenance::record_raw_permitted(seals, idx, record))
+    }
+
     // 3~10: ID_MAPPINGS 하위 레코드 (모두 level 1)
-    for bin_data in &doc_info.bin_data_list {
-        let data = bin_data
-            .raw_data
-            .clone()
-            .unwrap_or_else(|| serialize_bin_data(bin_data));
+    for (i, bin_data) in doc_info.bin_data_list.iter().enumerate() {
+        let data = sealed_raw(
+            bin_data,
+            &bin_data.raw_data,
+            seals.map(|s| &s.bin_data[..]),
+            i,
+        )
+        .cloned()
+        .unwrap_or_else(|| serialize_bin_data(bin_data));
         stream.extend(write_record(tags::HWPTAG_BIN_DATA, 1, &data));
     }
 
-    for lang_fonts in &doc_info.font_faces {
-        for font in lang_fonts {
-            let data = font
-                .raw_data
-                .clone()
+    for (li, lang_fonts) in doc_info.font_faces.iter().enumerate() {
+        let lang_seals = seals.and_then(|s| s.fonts.get(li)).map(|v| &v[..]);
+        for (fi, font) in lang_fonts.iter().enumerate() {
+            let data = sealed_raw(font, &font.raw_data, lang_seals, fi)
+                .cloned()
                 .unwrap_or_else(|| serialize_face_name(font));
             stream.extend(write_record(tags::HWPTAG_FACE_NAME, 1, &data));
         }
     }
 
-    for bf in &doc_info.border_fills {
-        let data = bf
-            .raw_data
-            .clone()
+    for (i, bf) in doc_info.border_fills.iter().enumerate() {
+        let data = sealed_raw(bf, &bf.raw_data, seals.map(|s| &s.border_fills[..]), i)
+            .cloned()
             .unwrap_or_else(|| serialize_border_fill(bf));
         stream.extend(write_record(tags::HWPTAG_BORDER_FILL, 1, &data));
     }
 
-    for cs in &doc_info.char_shapes {
-        let data = cs
-            .raw_data
-            .clone()
+    for (i, cs) in doc_info.char_shapes.iter().enumerate() {
+        let data = sealed_raw(cs, &cs.raw_data, seals.map(|s| &s.char_shapes[..]), i)
+            .cloned()
             .unwrap_or_else(|| serialize_char_shape(cs));
         stream.extend(write_record(tags::HWPTAG_CHAR_SHAPE, 1, &data));
     }
 
-    for td in &doc_info.tab_defs {
-        let data = td.raw_data.clone().unwrap_or_else(|| serialize_tab_def(td));
+    for (i, td) in doc_info.tab_defs.iter().enumerate() {
+        let data = sealed_raw(td, &td.raw_data, seals.map(|s| &s.tab_defs[..]), i)
+            .cloned()
+            .unwrap_or_else(|| serialize_tab_def(td));
         stream.extend(write_record(tags::HWPTAG_TAB_DEF, 1, &data));
     }
 
-    for numbering in &doc_info.numberings {
-        let data = numbering
-            .raw_data
-            .clone()
-            .unwrap_or_else(|| serialize_numbering(numbering));
+    for (i, numbering) in doc_info.numberings.iter().enumerate() {
+        let data = sealed_raw(
+            numbering,
+            &numbering.raw_data,
+            seals.map(|s| &s.numberings[..]),
+            i,
+        )
+        .cloned()
+        .unwrap_or_else(|| serialize_numbering(numbering));
         stream.extend(write_record(tags::HWPTAG_NUMBERING, 1, &data));
     }
 
-    for bullet in &doc_info.bullets {
-        let data = bullet
-            .raw_data
-            .clone()
+    for (i, bullet) in doc_info.bullets.iter().enumerate() {
+        let data = sealed_raw(bullet, &bullet.raw_data, seals.map(|s| &s.bullets[..]), i)
+            .cloned()
             .unwrap_or_else(|| serialize_bullet(bullet));
         stream.extend(write_record(tags::HWPTAG_BULLET, 1, &data));
     }
 
-    for ps in &doc_info.para_shapes {
-        let data = ps
-            .raw_data
-            .clone()
+    for (i, ps) in doc_info.para_shapes.iter().enumerate() {
+        let data = sealed_raw(ps, &ps.raw_data, seals.map(|s| &s.para_shapes[..]), i)
+            .cloned()
             .unwrap_or_else(|| serialize_para_shape(ps));
         stream.extend(write_record(tags::HWPTAG_PARA_SHAPE, 1, &data));
     }
 
-    for style in &doc_info.styles {
-        let data = style
-            .raw_data
-            .clone()
+    for (i, style) in doc_info.styles.iter().enumerate() {
+        let data = sealed_raw(style, &style.raw_data, seals.map(|s| &s.styles[..]), i)
+            .cloned()
             .unwrap_or_else(|| serialize_style(style));
         stream.extend(write_record(tags::HWPTAG_STYLE, 1, &data));
     }
@@ -138,6 +171,12 @@ pub fn serialize_document_properties(props: &DocProperties) -> Vec<u8> {
     if let Some(ref raw) = props.raw_data {
         return raw.clone();
     }
+    serialize_document_properties_from_model(props)
+}
+
+/// [#4493] raw_data 를 무시하고 모델 값으로 DOCUMENT_PROPERTIES 를 쓴다 —
+/// 봉인 검증이 "모델이 바뀌었다" 고 판정한 경로 전용.
+fn serialize_document_properties_from_model(props: &DocProperties) -> Vec<u8> {
     let mut w = ByteWriter::new();
     w.write_u16(props.section_count).unwrap();
     w.write_u16(props.page_start_num).unwrap();

--- a/src/serializer/hwpx/picture.rs
+++ b/src/serializer/hwpx/picture.rs
@@ -99,7 +99,7 @@ pub fn write_picture<W: Write>(
     // --- 자식 순서 (한컴 관찰 샘플 기준) ---
     // offset, orgSz, curSz, flip, rotationInfo, renderingInfo, imgRect, imgClip,
     // inMargin, imgDim, img, effects, sz, pos, outMargin
-    write_offset(w, &pic.common)?;
+    write_offset(w, &pic.shape_attr)?;
     write_org_sz(w, &pic.shape_attr)?;
     write_cur_sz(w, pic)?;
     write_flip(w, &pic.shape_attr)?;
@@ -129,9 +129,17 @@ pub fn write_picture<W: Write>(
 
 // ---------- 자식 요소 ----------
 
-fn write_offset<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), SerializeError> {
-    let x = c.horizontal_offset.to_string();
-    let y = c.vertical_offset.to_string();
+// [#4668] hp:offset 은 파서가 보존한 shape_attr.offset_x/y 원문을 되쓴다 —
+// 종전에는 pic 전용 writer 만 pos 유래(c.horizontal_offset/vertical_offset)로
+// 재유도해, 음수(u32 wraparound) offset 으로 쪽 밖에 둔 그림이 무편집 저장 후
+// 쪽 안에 노출됐다(transMatrix 병진과도 모순). 도형·OLE·컨테이너 공용
+// writer(shape.rs write_offset, #3544)와 동형.
+fn write_offset<W: Write>(
+    w: &mut Writer<W>,
+    sa: &ShapeComponentAttr,
+) -> Result<(), SerializeError> {
+    let x = (sa.offset_x as u32).to_string();
+    let y = (sa.offset_y as u32).to_string();
     empty_tag(w, "hp:offset", &[("x", &x), ("y", &y)])
 }
 

--- a/src/serializer/hwpx/roundtrip.rs
+++ b/src/serializer/hwpx/roundtrip.rs
@@ -449,7 +449,10 @@ fn diff_picture_size(
     {
         parts.push(format!(
             "offset: expected=({}, {}) actual=({}, {})",
-            a.shape_attr.offset_x, a.shape_attr.offset_y, b.shape_attr.offset_x, b.shape_attr.offset_y
+            a.shape_attr.offset_x,
+            a.shape_attr.offset_y,
+            b.shape_attr.offset_x,
+            b.shape_attr.offset_y
         ));
     }
     if parts.is_empty() {

--- a/src/serializer/hwpx/roundtrip.rs
+++ b/src/serializer/hwpx/roundtrip.rs
@@ -442,6 +442,16 @@ fn diff_picture_size(
             a.img_dim, b.img_dim
         ));
     }
+    // [#4668] hp:offset — 종전 pic writer 가 pos 유래로 재작성해도 이 게이트가
+    // offset 을 비교하지 않아 잡히지 않았다(음수 wraparound offset 그림 노출).
+    if a.shape_attr.offset_x != b.shape_attr.offset_x
+        || a.shape_attr.offset_y != b.shape_attr.offset_y
+    {
+        parts.push(format!(
+            "offset: expected=({}, {}) actual=({}, {})",
+            a.shape_attr.offset_x, a.shape_attr.offset_y, b.shape_attr.offset_x, b.shape_attr.offset_y
+        ));
+    }
     if parts.is_empty() {
         None
     } else {
@@ -2945,6 +2955,31 @@ mod tests {
                 assert_eq!(path, "/ctrl[0]pic");
                 assert!(
                     detail.contains("curSz") && detail.contains("imgDim"),
+                    "{detail}"
+                );
+            }
+            other => panic!("PictureSize 여야 함: {other:?}"),
+        }
+    }
+
+    /// [#4668] offset 재작성이 게이트에 잡혀야 한다 — 종전 PictureSize 비교가
+    /// curSz/imgRect/imgDim 만 보고 offset 을 비교하지 않아, pic writer 의 pos
+    /// 유래 offset 재작성이 왕복 검증을 통과했다.
+    #[test]
+    fn issue4668_picture_offset_diff_in_gate() {
+        let mut pa = crate::model::image::Picture::default();
+        pa.shape_attr.offset_x = 5250;
+        pa.shape_attr.offset_y = -4332;
+        let pb = crate::model::image::Picture::default(); // offset (0, 0)
+        let a = doc_with_control(crate::model::control::Control::Picture(Box::new(pa)));
+        let b = doc_with_control(crate::model::control::Control::Picture(Box::new(pb)));
+        let diff = diff_documents(&a, &b);
+        assert_eq!(diff.differences.len(), 1, "{:?}", diff.differences);
+        match &diff.differences[0] {
+            IrDifference::PictureSize { path, detail, .. } => {
+                assert_eq!(path, "/ctrl[0]pic");
+                assert!(
+                    detail.contains("offset: expected=(5250, -4332) actual=(0, 0)"),
                     "{detail}"
                 );
             }

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -1253,11 +1253,23 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> (String, bool) {
             // 방출돼, 말미 슬롯(표 등)이 고아 fieldEnd 의 8유닛 갭을 먼저 가로채
             // char_offsets 가 +8 밀렸다(36380743 문단 0.10: 표가 fieldEnd 자리로 당겨짐).
             // 갭 소유자인 고아 fieldEnd 를 먼저 방출하고 while 을 재평가한다.
+            //
+            // [#4902] 단, 그 갭을 다투는 슬롯이 **이 문단의 fieldBegin** 이면 양보하지
+            // 않는다. 한 자리에서 begin 과 (앞 문단 필드를 닫는) 고아 end 가 겹치면
+            // 원본 순서는 언제나 `begin → end → end` 다 — HWP5 PARA_TEXT 실측
+            // (08368 문단: `<0x0003 %clk><0x0004><0x0004>해 도 별 목 차`).
+            // 고아를 앞세우면 `<hp:fieldEnd>` 가 짝 `<hp:fieldBegin>` 보다 먼저 나가고,
+            // 한글은 그 지점에서 구역 파싱을 포기해 **이후 본문을 통째로 버린다**
+            // (실측: 19쪽 35,205자 → 2쪽 7,838자, 개체 45→1. 고아를 짝 뒤로 옮기거나
+            // 지우면 100% 복원되고, beginIDRef 값만 고치는 것으로는 복원되지 않는다).
+            // #1948 이 막으려던 것은 **표 등 다른 슬롯**이 갭을 가로채는 경우다.
+            let field_begin_owns_gap = matches!(slots[slot_idx], Control::Field(_));
             if let Some(oi) = para
                 .orphan_field_ends
                 .iter()
                 .enumerate()
                 .position(|(i, ofe)| ofe.char_idx == idx && !orphan_emitted[i])
+                .filter(|_| !field_begin_owns_gap)
             {
                 flush_text_fragment(
                     &mut splitter.content,
@@ -5299,6 +5311,86 @@ mod tests {
         let doc = Document::default();
         let mut ctx = SerializeContext::collect_from_document(&doc);
         render_runs(para, &mut ctx).0
+    }
+
+    /// [#4902] 한 자리에서 이 문단의 `fieldBegin` 과 (앞 문단 필드를 닫는) 고아 `fieldEnd`
+    /// 가 겹치면 **begin 이 먼저** 나가야 한다.
+    ///
+    /// 한컴 원본 PARA_TEXT 는 언제나 `begin(0x03) → end(0x04) → end(0x04)`(LIFO) 순이다
+    /// (08368 실측). 고아를 앞세우면 한글은 짝 없는 `fieldEnd` 를 만나 그 지점에서 구역
+    /// 파싱을 포기하고 이후 본문·개체를 통째로 버린다 — 실측 19쪽 35,205자 → 2쪽 7,838자,
+    /// 개체 45→1. `beginIDRef` 값을 유효한 id 로 고쳐도 복원되지 않고, 순서를 바로잡으면
+    /// 100% 복원된다.
+    #[test]
+    fn issue4902_field_begin_precedes_orphan_field_end_at_same_slot() {
+        use crate::model::control::{Field, FieldType};
+        use crate::model::paragraph::OrphanFieldEnd;
+
+        let doc = Document::default();
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let _ = &mut ctx;
+
+        // 08368 문단 32 동형: 8유닛 슬롯 3개(begin·짝 end·고아 end) 뒤에 텍스트.
+        let mut para = Paragraph::default();
+        para.text = "해도".to_string();
+        para.char_offsets = vec![24, 25];
+        para.char_count = 24 + 2 + 1;
+        para.controls = vec![Control::Field(Field {
+            field_type: FieldType::ClickHere,
+            field_id: 1_867_945_538,
+            ctrl_id: crate::parser::tags::FIELD_CLICKHERE,
+            ..Default::default()
+        })];
+        para.field_ranges = vec![FieldRange {
+            start_char_idx: 0,
+            end_char_idx: 0,
+            control_idx: 0,
+            end_field_id: 1_867_945_538,
+            inner_slot_count: 0,
+        }];
+        para.orphan_field_ends = vec![OrphanFieldEnd {
+            char_idx: 0,
+            begin_id_ref: 0,
+            field_id: 0,
+            begin_ctrl_id: 0,
+        }];
+
+        let runs = runs_of(&para);
+        let begin = runs.find("<hp:fieldBegin").expect("fieldBegin 방출");
+        let orphan = runs
+            .find(r#"<hp:fieldEnd beginIDRef="0""#)
+            .expect("고아 fieldEnd 방출");
+        assert!(
+            begin < orphan,
+            "고아 fieldEnd 가 짝 fieldBegin 보다 앞서면 한글이 본문을 버린다:\n{runs}"
+        );
+    }
+
+    /// [#1948] 반면 갭을 다투는 슬롯이 **표 등 다른 컨트롤**이면 종전대로 고아 fieldEnd 가
+    /// 먼저다 — 그러지 않으면 말미 슬롯이 고아의 8유닛 갭을 가로채 `char_offsets` 가 밀린다.
+    #[test]
+    fn issue1948_orphan_field_end_still_precedes_non_field_slot() {
+        use crate::model::paragraph::OrphanFieldEnd;
+
+        let mut para = Paragraph::default();
+        para.text = "가".to_string();
+        para.char_offsets = vec![16];
+        para.char_count = 16 + 1 + 1;
+        para.controls = vec![Control::Table(Box::default())];
+        para.orphan_field_ends = vec![OrphanFieldEnd {
+            char_idx: 0,
+            begin_id_ref: 2_031_845_287,
+            field_id: 0,
+            begin_ctrl_id: crate::parser::tags::FIELD_CLICKHERE,
+        }];
+
+        let runs = runs_of(&para);
+        let orphan = runs.find("<hp:fieldEnd").expect("고아 fieldEnd 방출");
+        let table = runs.find("<hp:tbl").expect("표 방출");
+        assert!(
+            orphan < table,
+            "표 슬롯이 고아 fieldEnd 의 갭을 가로채면 char_offsets 가 밀린다:\n{runs}"
+        );
     }
 
     /// [#4778] 위치 축이 무너진 문단(파서 미수용 8유닛 슬롯 — 차례표지 0x0008 등)의

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -347,7 +347,10 @@ pub(crate) fn write_ole<W: Write>(
     ctx: &mut SerializeContext,
 ) -> Result<(), SerializeError> {
     let c = &ole.common;
-    let id_str = c.instance_id.to_string();
+    // [#4669] 원본 `id` 는 `instid` 와 별개 값이다 — 파서가 보존한 원문을 되쓰고,
+    // HWP5 출신(None)은 종전대로 instance_id 를 겸용한다.
+    let id_str = ole.hwpx_ole_id.unwrap_or(c.instance_id).to_string();
+    let instid_str = c.instance_id.to_string();
     let z_order = c.z_order.to_string();
     let tw = text_wrap_str(c.text_wrap);
     let tf = text_flow_str(c.text_flow);
@@ -385,7 +388,7 @@ pub(crate) fn write_ole<W: Write>(
             ("dropcapstyle", "None"),
             ("href", ""),
             ("groupLevel", "0"),
-            ("instid", &id_str),
+            ("instid", &instid_str),
             ("objectType", "UNKNOWN"),
             ("binaryItemIDRef", &bidref),
             ("hasMoniker", "0"),
@@ -1974,6 +1977,64 @@ mod tests {
         assert_eq!(hatch_style_str(5), "CROSS");
         assert_eq!(hatch_style_str(6), "CROSS_DIAGONAL");
         assert_eq!(hatch_style_str(99), "HORIZONTAL");
+    }
+
+    /// [#4669] 재방출 `id` 는 파서가 보존한 원문(hwpx_ole_id)을 되쓰고 `instid`
+    /// 는 instance_id 를 쓴다 — 원산 파일은 두 값이 다르다(실측 2141242094 /
+    /// 1067500271). 종전엔 둘 다 instance_id 로 방출돼 id 원문이 유실됐다.
+    /// curSz=0 센티널(#2017)의 OLE 경로 복원도 함께 고정한다.
+    #[test]
+    fn issue4669_write_ole_preserves_original_id_and_cur_sz_zero() {
+        use crate::model::document::Document;
+
+        let doc = Document::default();
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+
+        let mut ole = OleShape::default();
+        ole.hwpx_ole_id = Some(2141242094);
+        ole.common.instance_id = 1067500271;
+        ole.drawing.shape_attr.original_width = 42001;
+        ole.drawing.shape_attr.original_height = 13501;
+        ole.drawing.shape_attr.current_width = 42001;
+        ole.drawing.shape_attr.current_height = 13501;
+        ole.drawing.shape_attr.current_width_was_zero = true;
+        ole.drawing.shape_attr.current_height_was_zero = true;
+
+        let mut w: Writer<Vec<u8>> = Writer::new(Vec::new());
+        write_ole(&mut w, &ole, &mut ctx).expect("write_ole");
+        let xml = String::from_utf8(w.into_inner()).unwrap();
+
+        assert!(xml.contains(r#"id="2141242094""#), "id 원문 보존: {xml}");
+        assert!(
+            xml.contains(r#"instid="1067500271""#),
+            "instid 는 instance_id: {xml}"
+        );
+        assert!(
+            xml.contains(r#"<hp:curSz width="0" height="0"/>"#),
+            "curSz=0 원문 복원(#2017 센티널): {xml}"
+        );
+        assert!(
+            xml.contains(r#"<hp:orgSz width="42001" height="13501"/>"#),
+            "orgSz 보존: {xml}"
+        );
+    }
+
+    /// [#4669] HWP5 출신(hwpx_ole_id=None)은 종전대로 id=instid=instance_id.
+    #[test]
+    fn issue4669_write_ole_without_original_id_falls_back_to_instance_id() {
+        use crate::model::document::Document;
+
+        let doc = Document::default();
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+
+        let mut ole = OleShape::default();
+        ole.common.instance_id = 77;
+
+        let mut w: Writer<Vec<u8>> = Writer::new(Vec::new());
+        write_ole(&mut w, &ole, &mut ctx).expect("write_ole");
+        let xml = String::from_utf8(w.into_inner()).unwrap();
+        assert!(xml.contains(r#"id="77""#), "{xml}");
+        assert!(xml.contains(r#"instid="77""#), "{xml}");
     }
 
     /// [버그] OLE 의 `bin_data_id` 는 HWP5 바이너리상 u32 필드다. 종전 코드는

--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -324,7 +324,9 @@ fn write_sub_list<W: Write>(
                     "HORIZONTAL"
                 },
             ),
-            ("lineWrap", "BREAK"),
+            // [#4898] 종전엔 상수 "BREAK" 였다 — 원본이 SQUEEZE 인 셀도 BREAK 로 굳어
+            // x2x 왕복에서 조용히 소실됐다(코퍼스 표본 3,019회). IR 값을 그대로 되돌린다.
+            ("lineWrap", cell_line_wrap_str(cell.line_wrap)),
             ("vertAlign", cell_vert_align_str(cell.vertical_align)),
             ("linkListIDRef", "0"),
             ("linkListNextIDRef", "0"),
@@ -562,6 +564,19 @@ fn cell_vert_align_str(v: VerticalAlign) -> &'static str {
     }
 }
 
+/// [#4898] 셀 줄바꿈 방식(LIST_HEADER bit 19~20) → OWPML `lineWrap`.
+///
+/// 한글 2022 실측으로 확정한 대응이다 — SQUEEZE 만 쓰는 문서를 한글이 HWP5 로 저장하면
+/// LIST_HEADER 가 전부 bit19=1, BREAK 위주 문서는 SQUEEZE 인 셀 하나만 1 이었다.
+/// `KEEP`(=2)은 스키마 열거 순서를 따른다(코퍼스 표본에는 나타나지 않았다).
+fn cell_line_wrap_str(line_wrap: u8) -> &'static str {
+    match line_wrap {
+        1 => "SQUEEZE",
+        2 => "KEEP",
+        _ => "BREAK",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -589,6 +604,59 @@ mod tests {
         }
         t.rebuild_grid();
         t
+    }
+
+    /// [#4898] 셀 줄바꿈 방식(`lineWrap`)이 HWPX 왕복에서 보존돼야 한다.
+    ///
+    /// 종전엔 파서가 이 속성을 읽지 않고 직렬화기가 상수 `"BREAK"` 를 방출해, 원본이
+    /// `SQUEEZE`(자간 조절로 한 줄 유지)인 셀이 조용히 `BREAK` 로 굳었다 — 한글은 그 셀의
+    /// 줄을 다시 나누므로 셀·표 높이가 달라진다. 코퍼스 표본(hwpx 648건)에 SQUEEZE 가
+    /// 3,019회 나온다. HWP5 축 대응(LIST_HEADER bit 19~20)은 한글 2022 SaveAs 실측이다.
+    #[test]
+    fn cell_line_wrap_survives_hwpx_roundtrip() {
+        use crate::model::control::Control;
+
+        let bytes0 = std::fs::read("samples/hwpx/basic-table-01.hwpx").expect("샘플 읽기");
+        let mut doc = crate::parser::hwpx::parse_hwpx(&bytes0).expect("샘플 파싱");
+        for section in &mut doc.sections {
+            for para in &mut section.paragraphs {
+                for control in &mut para.controls {
+                    if let Control::Table(table) = control {
+                        table.cells[0].line_wrap = 1; // SQUEEZE
+                    }
+                }
+            }
+        }
+
+        let bytes = crate::serializer::hwpx::serialize_hwpx(&doc).expect("직렬화");
+        let xml = String::from_utf8_lossy(&bytes).to_string();
+        let _ = xml; // zip 바이트라 XML 직접 검사 대신 재파싱으로 확인한다
+        let doc2 = crate::parser::hwpx::parse_hwpx(&bytes).expect("재파싱");
+        let wrapped = doc2
+            .sections
+            .iter()
+            .flat_map(|s| &s.paragraphs)
+            .flat_map(|p| &p.controls)
+            .filter_map(|c| match c {
+                Control::Table(t) => Some(t),
+                _ => None,
+            })
+            .any(|t| t.cells.first().is_some_and(|c| c.line_wrap == 1));
+        assert!(wrapped, "SQUEEZE 셀이 왕복에서 BREAK 로 굳으면 안 된다");
+    }
+
+    /// [#4898] 매핑은 한글 2022 실측이다 — SQUEEZE 만 쓰는 문서를 SaveAs 하면 LIST_HEADER
+    /// 19개가 전부 bit19=1, BREAK 위주 문서는 SQUEEZE 셀 하나만 1 이었다.
+    #[test]
+    fn cell_line_wrap_str_matches_owpml_enum() {
+        assert_eq!(cell_line_wrap_str(0), "BREAK");
+        assert_eq!(cell_line_wrap_str(1), "SQUEEZE");
+        assert_eq!(cell_line_wrap_str(2), "KEEP");
+        assert_eq!(
+            cell_line_wrap_str(9),
+            "BREAK",
+            "미지 값은 기본값으로 관용 처리"
+        );
     }
 
     #[test]

--- a/tests/issue_4493_docinfo_provenance.rs
+++ b/tests/issue_4493_docinfo_provenance.rs
@@ -1,0 +1,132 @@
+//! [Issue #4493] 공개 저수준 `parse_document → Document 직접 변경 →
+//! serialize_document` 경로에서 DocInfo 변경이 원본 raw 캐시(스트림·레코드)에
+//! 가려져 조용히 사라지던 계약을 고정한다.
+//!
+//! - 무변경 문서는 원본 DocInfo 레코드 스트림 바이트를 정확히 재사용한다.
+//! - 공개 모델 직접 변경(char_shape·doc_properties)은 저장·재로드 뒤 유지된다.
+//! - 공개 `raw_stream` 을 다른 바이트로 교체해도 기존 봉인으로 승인되지 않는다.
+//! - [#4432] &mut 저장 경로는 저장 성공 시 dirty 를 내리고 raw 캐시를 재밀봉한다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::{parse_document, serialize_document};
+
+const SAMPLE: &str = "samples/2026_oss_rst.hwp";
+
+fn sample_bytes() -> Vec<u8> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    std::fs::read(&path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"))
+}
+
+#[test]
+fn unchanged_parse_serialize_reuses_docinfo_raw_bytes() {
+    let doc = parse_document(&sample_bytes()).expect("parse");
+    let original_raw = doc
+        .doc_info
+        .raw_stream
+        .clone()
+        .expect("HWP5 파싱은 DocInfo raw 캐시를 채운다");
+    assert!(
+        doc.doc_info.raw_provenance.is_some(),
+        "파서가 만든 문서에는 봉인이 있어야 한다 (#4493)"
+    );
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    assert_eq!(
+        reparsed.doc_info.raw_stream.as_ref(),
+        Some(&original_raw),
+        "무변경 문서의 DocInfo 레코드 스트림은 바이트 그대로 통과해야 한다"
+    );
+}
+
+#[test]
+fn public_char_shape_mutation_survives_save_reload() {
+    let mut doc = parse_document(&sample_bytes()).expect("parse");
+    assert!(!doc.doc_info.char_shapes.is_empty());
+    let target = 0usize;
+    let new_size = doc.doc_info.char_shapes[target].base_size + 700;
+    // 공개 모델 직접 변경 — dirty 표식을 세우지 않는다(그게 이 이슈의 재현이다).
+    doc.doc_info.char_shapes[target].base_size = new_size;
+    assert!(!doc.doc_info.raw_stream_dirty);
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    assert_eq!(
+        reparsed.doc_info.char_shapes[target].base_size, new_size,
+        "공개 char_shape 직접 변경이 저장·재로드 뒤 유지돼야 한다 (#4493)"
+    );
+}
+
+#[test]
+fn public_doc_properties_mutation_survives_save_reload() {
+    let mut doc = parse_document(&sample_bytes()).expect("parse");
+    let new_start = doc.doc_properties.page_start_num + 4;
+    doc.doc_properties.page_start_num = new_start;
+    assert!(!doc.doc_info.raw_stream_dirty);
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    assert_eq!(
+        reparsed.doc_properties.page_start_num, new_start,
+        "공개 doc_properties 직접 변경이 저장·재로드 뒤 유지돼야 한다 (#4493)"
+    );
+}
+
+#[test]
+fn untouched_records_keep_raw_bytes_when_one_record_changes() {
+    // 레코드 봉인의 핵심: 하나가 바뀌어도 나머지 레코드는 원본 바이트를 유지한다
+    // (하위 raw 전면 폐기 금지 — 미모델링 바이트 보존).
+    let mut doc = parse_document(&sample_bytes()).expect("parse");
+    let untouched_raw = doc.doc_info.char_shapes[1].raw_data.clone();
+    assert!(
+        untouched_raw.is_some(),
+        "샘플 전제: 레코드 raw 가 있어야 한다"
+    );
+    doc.doc_info.char_shapes[0].base_size += 700;
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    assert_eq!(
+        reparsed.doc_info.char_shapes[1].raw_data, untouched_raw,
+        "변경되지 않은 레코드는 원본 바이트가 유지돼야 한다"
+    );
+}
+
+#[test]
+fn swapped_raw_stream_is_not_honored() {
+    let mut doc = parse_document(&sample_bytes()).expect("parse");
+    let char_shape_count = doc.doc_info.char_shapes.len();
+    // 봉인 이후 raw 바이트를 통째로 바꿔치기 — 승인되면 안 된다.
+    doc.doc_info.raw_stream = Some(vec![0xDE; 64]);
+
+    let out = serialize_document(&doc).expect("교체 raw 는 무시되고 모델로 재생성돼야 한다");
+    let reparsed = parse_document(&out).expect("산출물은 정상 문서여야 한다");
+    assert_eq!(
+        reparsed.doc_info.char_shapes.len(),
+        char_shape_count,
+        "산출물은 교체 바이트가 아니라 모델 상태를 담아야 한다 (#4493)"
+    );
+}
+
+#[test]
+fn issue_4432_save_lowers_dirty_and_reseals() {
+    let mut core = DocumentCore::from_bytes(&sample_bytes()).expect("open");
+    // dirty 를 세우는 통상 편집 경로 — 중앙 무효화 진입점(document_mut) 경유.
+    core.document_mut().doc_info.char_shapes[0].base_size += 700;
+    core.document_mut().doc_info.raw_stream_dirty = true;
+
+    let first = core.export_hwp_with_adapter().expect("save 1");
+    assert!(
+        !core.document().doc_info.raw_stream_dirty,
+        "저장 성공 지점에서 dirty 가 내려가야 한다 (#4432)"
+    );
+    let second = core.export_hwp_with_adapter().expect("save 2");
+    assert_eq!(first, second, "재밀봉 뒤 무변경 재저장은 같은 바이트");
+
+    // 재밀봉된 캐시가 실제 모델 상태와 정합해야 한다 — 재로드로 검증.
+    let reparsed = parse_document(&second).expect("reparse");
+    assert_eq!(
+        reparsed.doc_info.char_shapes[0].base_size,
+        core.document().doc_info.char_shapes[0].base_size
+    );
+}

--- a/tests/issue_4668_pic_offset_preserved.rs
+++ b/tests/issue_4668_pic_offset_preserved.rs
@@ -1,0 +1,67 @@
+//! [Issue #4668] HWPX 저장 시 `hp:pic` 의 `<hp:offset>` 이 원본 값 대신 `<hp:pos>`
+//! 의 vertOffset/horzOffset 에서 재유도되어, 저장만 해도 그림 offset 이 바뀌던
+//! 문제의 회귀 계약. 음수(u32 wraparound) offset 으로 쪽 밖에 둔 그림이 무편집
+//! 저장 후 쪽 안(문단 앵커 위치)에 노출되는 표시 변화를 한글 실측으로 확인한
+//! 결함이다 — pic 전용 writer(`picture.rs write_offset`)만 pos 유래로 방출했고,
+//! 도형·OLE·컨테이너 공용 writer(`shape.rs`, #3544)는 이미 원문을 보존한다.
+
+use std::io::Read;
+
+use rhwp::document_core::DocumentCore;
+
+/// 원본 pic 에 `<hp:offset x="5250" y="4294962964"/>`(y = −4332 wraparound)가
+/// 실존하고, 그 pic 의 `<hp:pos>` 는 vertOffset=0/horzOffset=0 인 실물 샘플.
+const SAMPLE: &str = "samples/ta-pic-cell-center-pos-bottom.hwpx";
+
+fn sample_path() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn section_xml_of(bytes: &[u8]) -> String {
+    let mut zip = zip::ZipArchive::new(std::io::Cursor::new(bytes)).expect("ZIP 열기 실패");
+    let names: Vec<String> = zip.file_names().map(str::to_string).collect();
+    let mut xml = String::new();
+    for name in names {
+        if name.starts_with("Contents/section") && name.ends_with(".xml") {
+            zip.by_name(&name)
+                .expect("section 엔트리")
+                .read_to_string(&mut xml)
+                .expect("section XML 은 UTF-8 이어야 한다");
+        }
+    }
+    xml
+}
+
+#[test]
+fn issue_4668_pic_offset_is_not_rewritten_from_pos() {
+    let bytes = std::fs::read(sample_path()).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"));
+
+    // 전제: 원본에 wraparound offset 과 pos(vertOffset=10436) 가 함께 있어야
+    // "pos 유래 재작성" 회귀를 이 샘플로 판별할 수 있다.
+    let original = section_xml_of(&bytes);
+    assert!(
+        original.contains(r#"<hp:offset x="5250" y="4294962964"/>"#),
+        "샘플 전제 위반: 원본 wraparound hp:offset 이 없다"
+    );
+    assert!(
+        original.contains(r#"vertOffset="10436""#),
+        "샘플 전제 위반: 재작성 판별용 pos vertOffset 이 없다"
+    );
+
+    let doc = DocumentCore::from_bytes(&bytes).unwrap_or_else(|e| panic!("parse {SAMPLE}: {e:?}"));
+    let exported = doc
+        .export_hwpx_native()
+        .unwrap_or_else(|e| panic!("export {SAMPLE}: {e:?}"));
+    let saved = section_xml_of(&exported);
+
+    // 계약: 원본 offset 원문이 그대로 살아 있어야 한다.
+    assert!(
+        saved.contains(r#"<hp:offset x="5250" y="4294962964"/>"#),
+        "hp:pic offset 이 원문 보존되지 않았다 — pos 유래 재작성(#4668) 재발 의심"
+    );
+    // 회귀 신호: 종전 결함의 산출 형태(pos vertOffset 을 offset y 로 복사).
+    assert!(
+        !saved.contains(r#"<hp:offset x="0" y="10436"/>"#),
+        "hp:pic offset 이 pos vertOffset 으로 재작성됐다(#4668 재발)"
+    );
+}


### PR DESCRIPTION
## 요약

- @planet6897의 비드래프트 PR #4928, #4932, #4933, #4938, #4940을 최신 `upstream/devel` 위에 누적 적용했습니다.
- 메인터너 보정으로 중첩 표 셀의 저장 lineseg 권위와 HWPX OLE의 명시적 `id="0"` 보존을 추가했습니다.

## 포함 원본 PR

- #4928: 고아 `fieldEnd` 방출 순서
- #4932: OLE shape component 원문 보존
- #4933: picture shape component offset 보존
- #4938: DocInfo raw provenance와 편집 저장 계약
- #4940: lineseg 범위 및 셀 `lineWrap` 보존

## 로컬 검증

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=target/pr-review-planet6897 cargo test --profile release-test --tests`
- `CARGO_TARGET_DIR=target/pr-review-planet6897 cargo clippy --all-targets --all-features -- -D warnings`
- `CARGO_TARGET_DIR=target/pr-review-planet6897 cargo build --release`
- 원 PR 관련 집중 회귀 16건
- `git diff --check upstream/devel...HEAD`

## 후속

초기 CI가 완료되면 원본 PR별 review 문서 5개를 trailing commit으로 반영하고, 그 최신 head의 CI를 다시 확인합니다.