### PR TITLE
refactor(renderer): TAC 표 유효 높이 계산을 typeset·pagination 공통 함수로 뽑는다 (#4627)

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1099,6 +1099,18 @@ pub fn px_to_hwpunit(px: f64, dpi: f64) -> i32 {
     (px * HWPUNIT_PER_INCH / dpi) as i32
 }
 
+/// TAC(글자처럼 취급) 표 한 칸의 유효 높이 — 저장된 line_seg 높이와 실측 표 높이 중
+/// 큰 쪽을 쓴다.
+///
+/// [#4627] 같은 식(`seg_lh.max(mt_h)`)이 `typeset.rs`(레이아웃 확정)와
+/// `pagination/engine.rs`(`RHWP_USE_PAGINATOR=1` 대안 경로)에 각각 따로 있었다 —
+/// 표 높이가 페이지 경계를 정하므로 두 사본이 갈리면 쪽수가 움직인다. 두 소비자
+/// 모두 이 함수를 불러 사본을 없앤다(행동 변경 없음, 순수 NFC).
+#[inline]
+pub fn tac_table_effective_height(seg_lh: f64, mt_h: f64) -> f64 {
+    seg_lh.max(mt_h)
+}
+
 /// [Task #1745] 텍스트 혼합 anchor 문단의 Square wrap 표 우측 wrap 띠 (cs, sw) HU 도출.
 ///
 /// Square wrap(어울림) 표가 텍스트 문단(예: 별표 제목)에 anchor 되면 anchor 문단의

--- a/src/renderer/pagination/engine.rs
+++ b/src/renderer/pagination/engine.rs
@@ -919,7 +919,8 @@ impl Paginator {
                                         crate::renderer::hwpunit_to_px(seg.line_height, self.dpi);
                                     let mt_h =
                                         measured.get_table_height(para_idx, ci).unwrap_or(0.0);
-                                    let effective_h = seg_lh.max(mt_h);
+                                    let effective_h =
+                                        crate::renderer::tac_table_effective_height(seg_lh, mt_h);
                                     let ls = if seg.line_spacing > 0 {
                                         crate::renderer::hwpunit_to_px(seg.line_spacing, self.dpi)
                                     } else {

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -17836,7 +17836,8 @@ impl TypesetEngine {
                                 .find(|mt| mt.para_index == para_idx && mt.control_index == ci)
                                 .map(|mt| mt.total_height)
                                 .unwrap_or(0.0);
-                            let effective_h = seg_lh.max(mt_h);
+                            let effective_h =
+                                crate::renderer::tac_table_effective_height(seg_lh, mt_h);
                             let ls_half = hwpunit_to_px(seg.line_spacing, self.dpi) / 2.0;
                             tac_seg_total += effective_h + ls_half;
                         }


### PR DESCRIPTION
## 동기

같은 식 `effective_h = seg_lh.max(mt_h)`가 `typeset.rs`(레이아웃 확정 경로)와 `pagination/engine.rs`(`RHWP_USE_PAGINATOR=1` 대안 경로)에 각각 따로 있었다(#4627). 표 높이가 페이지 경계를 정하므로 두 사본이 갈리면 쪽수가 움직인다 — 이 계열에서 "지금은 일치한다"가 안전을 뜻하지 않는다는 게 `tac_picture_or_shape_height_px`(#4625)·`para_is_treat_as_char_picture_only`(#4626)에서 이미 두 번 확인됐다.

## 원인

두 렌더 경로가 같은 판단을 각자 구현해 재발 지점이 됐다. 이슈 본문이 직접 지적한 선행 질문 — `RHWP_USE_PAGINATOR` 대안 경로 자체가 아직 필요한가(#4605) — 은 이 PR의 범위 밖이다: 그 경로의 존폐와 무관하게, **어느 쪽이 남든 식은 하나여야 한다**는 사실만 고친다.

## 수정

`src/renderer/mod.rs`에 `tac_table_effective_height(seg_lh, mt_h)`를 신설해 두 소비자가 공통으로 부른다. 순수 NFC — 함수 본문이 원래 식과 정확히 같다(`seg_lh.max(mt_h)`).

## 검증

`cargo test --lib renderer::` 통과(회귀 없음), `cargo clippy --lib -- -D warnings` 경고 0, `rustfmt --edition 2021 --check` 통과.

## 범위

`src/renderer/mod.rs`(+9), `src/renderer/typeset.rs`(+2/-1), `src/renderer/pagination/engine.rs`(+2/-1). 3 files, +16/-2. `RHWP_USE_PAGINATOR` 경로 존폐는 별개 이슈(#4605)로 남겨둔다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)