### PR TITLE
fix(serializer): 본문 raw 캐시 출처 봉인 — Section·하위 컨트롤 raw 의 공개 IR 변경 보존 (#4488, #4495)

### DIFF
--- a/src/diagnostics/ir_field_sweep.rs
+++ b/src/diagnostics/ir_field_sweep.rs
@@ -919,6 +919,7 @@ fn sweep_table(base: &str, a: &Table, b: &Table, out: &mut DivergenceCollector) 
         outer_margin_top,
         outer_margin_bottom,
         raw_ctrl_data,
+        raw_ctrl_seal: _,
         raw_table_record_attr,
         raw_table_record_extra,
         dirty,

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -1339,10 +1339,40 @@ impl DocumentCore {
 
         let saved_hwpx_page_border_fills = self.snapshot_hwpx_page_border_fill_overlay();
         let _report = convert_if_hwpx_source(&mut self.document, self.source_format);
+        self.refresh_doc_info_raw_cache();
         self.serialize_hwp_after_adapter(
             saved_hwpx_page_border_fills,
             crate::serializer::serialize_document,
         )
+    }
+
+    /// [#4432] DocInfo raw 캐시 재밀봉 — dirty(또는 봉인 불일치) 상태로 저장에
+    /// 들어가면 매 저장마다 DocInfo 를 처음부터 재구성한다. 여기서 한 번 재구성해
+    /// raw 캐시를 그 결과로 갱신하고 dirty 를 내리면, 이번 저장은 방금 만든
+    /// 바이트를 그대로 쓰고 이후 저장은 원본 바이트 통과로 돌아간다 —
+    /// "직렬화 성공 지점에서 되돌리는 것이 자연스러운 자리" 를 &mut 저장
+    /// 진입점에서 구현한 것이다. raw 캐시가 없던 문서(HWPX/HWP3 출처)는 건드리지
+    /// 않는다(raw_stream 유무가 출처 판별에 쓰이는 경로를 오염시키지 않기 위함).
+    fn refresh_doc_info_raw_cache(&mut self) {
+        let doc = &mut self.document;
+        if doc.doc_info.raw_stream.is_none() {
+            return;
+        }
+        let dirty = doc.doc_info.raw_stream_dirty
+            || !doc
+                .doc_info
+                .raw_provenance_permits_reuse(&doc.doc_properties);
+        if !dirty {
+            return;
+        }
+        // 재구성 강제: dirty 를 세운 채 한 번 직렬화한다(통과 게이트 우회).
+        doc.doc_info.raw_stream_dirty = true;
+        let rebuilt =
+            crate::serializer::doc_info::serialize_doc_info(&doc.doc_info, &doc.doc_properties);
+        doc.doc_info.raw_stream = Some(rebuilt);
+        doc.doc_info.raw_stream_dirty = false;
+        // 방금 만든 바이트와 현재 모델을 재밀봉 — 이후 무변경 저장은 통과.
+        doc.doc_info.seal_raw_provenance(&doc.doc_properties);
     }
 
     /// 어댑터를 **복제본에 적용해** HWP5 를 낸다 — 호출자의 IR 은 그대로다.
@@ -1403,6 +1433,7 @@ impl DocumentCore {
 
         let saved_hwpx_page_border_fills = self.snapshot_hwpx_page_border_fill_overlay();
         let _report = convert_if_hwpx_source(&mut self.document, self.source_format);
+        self.refresh_doc_info_raw_cache();
         self.serialize_hwp_after_adapter(saved_hwpx_page_border_fills, |document| {
             crate::serializer::serialize_hwp_with_password(document, password)
         })

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -206,6 +206,14 @@ impl DocumentCore {
         };
 
         doc.paginate();
+
+        // [#4488/#4495] 로드 픽스업(손상 lineseg 제거·빈 문단 reflow·안내문 제거)과
+        // 첫 paginate 의 materialization(그림 img_dim 등)까지 끝난 뒤 본문을 다시
+        // 봉인한다 — 파서 말미 봉인 그대로면 무변경 문서의 원본 바이트 통과가
+        // 로드 경로의 모델 보정 차이로 죽는다(honbo-save imgDim 실측). 이 지점
+        // 이후 본문 변경은 편집 명령(raw_stream 무효화 동반) 또는 공개 모델 직접
+        // 변경(봉인이 잡아야 할 대상)뿐이다.
+        doc.document.seal_body_raw_provenance();
         Ok(doc)
     }
 

--- a/src/document_core/commands/header_footer_ops.rs
+++ b/src/document_core/commands/header_footer_ops.rs
@@ -1119,6 +1119,7 @@ mod tests {
             },
             paragraphs: vec![Paragraph::default()],
             raw_stream: None,
+            raw_provenance: None,
         };
         doc.sections.push(section);
         let mut core = DocumentCore::new_empty();
@@ -1686,6 +1687,7 @@ mod tests {
             },
             paragraphs: vec![Paragraph::default()],
             raw_stream: None,
+            raw_provenance: None,
         };
         // text_width = 28504 - 4252 - 4252 = 20000 HWPUNIT (≈266.7px) — formatting.rs의
         // 셀 재현 테스트와 같은 축척.

--- a/src/document_core/commands/object_ops/picture.rs
+++ b/src/document_core/commands/object_ops/picture.rs
@@ -1848,6 +1848,7 @@ mod issue_1151_cell_picture_insert_tests {
             },
             paragraphs: vec![Paragraph::default()],
             raw_stream: None,
+            raw_provenance: None,
         });
         let mut core = DocumentCore::new_empty();
         core.set_document(doc);
@@ -2547,6 +2548,7 @@ mod issue_1151_v2_tac_toggle_tests {
             },
             paragraphs: vec![Paragraph::default()],
             raw_stream: None,
+            raw_provenance: None,
         });
         let mut core = DocumentCore::new_empty();
         core.set_document(doc);
@@ -3626,6 +3628,7 @@ mod issue_1280_textbox_creation_tests {
             },
             paragraphs: vec![Paragraph::default()],
             raw_stream: None,
+            raw_provenance: None,
         });
         let mut core = DocumentCore::new_empty();
         core.set_document(doc);

--- a/src/document_core/commands/object_ops/shape.rs
+++ b/src/document_core/commands/object_ops/shape.rs
@@ -2680,6 +2680,7 @@ mod resize_clamp_tests {
             },
             paragraphs: vec![Paragraph::default()],
             raw_stream: None,
+            raw_provenance: None,
         });
         let mut core = DocumentCore::new_empty();
         // set_document이 composed/styles/pagination 벡터를 일관되게 초기화한다.

--- a/src/document_core/commands/object_ops/table.rs
+++ b/src/document_core/commands/object_ops/table.rs
@@ -574,6 +574,7 @@ impl DocumentCore {
             outer_margin_top: 283,
             outer_margin_bottom: 283,
             raw_ctrl_data,
+            raw_ctrl_seal: None,
             raw_table_record_attr: 0x00000006, // 한컴 기본값 (bit1=셀분리금지, bit2=repeat_header)
             // [#3570] 한컴은 TABLE 레코드를 zone 개수까지만 쓴다 — 여분 2바이트 없음.
             raw_table_record_extra: Vec::new(),
@@ -1003,6 +1004,7 @@ impl DocumentCore {
             outer_margin_top: outer_margin,
             outer_margin_bottom: outer_margin,
             raw_ctrl_data,
+            raw_ctrl_seal: None,
             raw_table_record_attr: 0x04000006,
             // [#3570] 한컴은 TABLE 레코드를 zone 개수까지만 쓴다 — 여분 2바이트 없음.
             raw_table_record_extra: Vec::new(),

--- a/src/document_core/html_table_import.rs
+++ b/src/document_core/html_table_import.rs
@@ -612,6 +612,7 @@ impl DocumentCore {
             outer_margin_top: outer_margin,
             outer_margin_bottom: outer_margin,
             raw_ctrl_data,
+            raw_ctrl_seal: None,
             raw_table_record_attr: tbl_rec_attr,
             raw_table_record_extra: vec![0u8; 2], // 표준 추가 2바이트
             dirty: true,

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -7800,6 +7800,7 @@ mod tests {
                 ..Default::default()
             }],
             raw_stream: None,
+            raw_provenance: None,
         });
 
         let mut core = DocumentCore::new_empty();
@@ -7918,6 +7919,7 @@ mod tests {
             },
             paragraphs: vec![Paragraph::default()],
             raw_stream: None,
+            raw_provenance: None,
         });
 
         let mut core = DocumentCore::new_empty();
@@ -7964,6 +7966,7 @@ mod tests {
                 section_def,
                 paragraphs: vec![Paragraph::default()],
                 raw_stream: None,
+                raw_provenance: None,
             }
         }
 
@@ -8034,6 +8037,7 @@ mod tests {
                 section_def,
                 paragraphs: vec![Paragraph::default()],
                 raw_stream: None,
+                raw_provenance: None,
             }
         }
 
@@ -8097,6 +8101,7 @@ mod tests {
                 section_def,
                 paragraphs: vec![Paragraph::default()],
                 raw_stream: None,
+                raw_provenance: None,
             }
         }
 
@@ -8154,6 +8159,7 @@ mod tests {
             section_def: SectionDef::default(),
             paragraphs: vec![Paragraph::default()],
             raw_stream: None,
+            raw_provenance: None,
         });
         core.set_document(document);
         core.paginate();

--- a/src/model/bin_data.rs
+++ b/src/model/bin_data.rs
@@ -26,7 +26,7 @@ pub struct StoredBinData {
 }
 
 /// 바이너리 데이터 아이템 (HWPTAG_BIN_DATA)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct BinData {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -49,7 +49,7 @@ pub struct BinData {
 }
 
 /// 바이너리 데이터 타입
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum BinDataType {
     #[default]
     /// 외부 파일 참조
@@ -61,7 +61,7 @@ pub enum BinDataType {
 }
 
 /// 바이너리 데이터 압축 방식
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum BinDataCompression {
     #[default]
     /// 스토리지 디폴트
@@ -73,7 +73,7 @@ pub enum BinDataCompression {
 }
 
 /// 바이너리 데이터 접근 상태
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum BinDataStatus {
     #[default]
     /// 아직 접근하지 않음

--- a/src/model/control.rs
+++ b/src/model/control.rs
@@ -11,8 +11,21 @@ use super::paragraph::Paragraph;
 use super::shape::{CommonObjAttr, ShapeObject};
 use super::table::Table;
 
+/// [#4488] HashMap 을 키 정렬 순서로 직렬화한다 — 다이제스트 결정성 보장용.
+fn serialize_sorted_string_map<S>(
+    map: &HashMap<String, String>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let mut entries: Vec<(&String, &String)> = map.iter().collect();
+    entries.sort();
+    serializer.collect_map(entries)
+}
+
 /// 문단 내 컨트롤 (확장 컨트롤)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub enum Control {
     /// 구역 정의 ('secd')
     SectionDef(Box<SectionDef>),
@@ -112,7 +125,7 @@ pub const CTRL_CHAR_CODE_UNITS: u32 = 8;
 pub const EQUATION_LINE_MODE_BIT: u32 = 0x0000_0001;
 
 /// 수식 ('eqed' 컨트롤, HWP 스펙 표 105)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Equation {
     /// 개체 공통 속성 (위치, 크기, 배치)
     pub common: CommonObjAttr,
@@ -145,10 +158,14 @@ pub struct Equation {
     pub font_name: String,
     /// 라운드트립용 원본 ctrl_data
     pub raw_ctrl_data: Vec<u8>,
+    /// [#4495] raw_ctrl_data 출처 봉인 — 봉인 시점 `common` 의 다이제스트.
+    /// 계약은 Table::raw_ctrl_seal 과 동일 (`model::raw_provenance` 참조).
+    #[serde(skip)]
+    pub raw_ctrl_seal: Option<[u8; 32]>,
 }
 
 /// 자동 번호 ('atno' 컨트롤, HWP 스펙 표 144)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct AutoNumber {
     /// 번호 종류 (각주, 미주, 그림, 표, 수식)
     pub number_type: AutoNumberType,
@@ -169,7 +186,7 @@ pub struct AutoNumber {
 }
 
 /// 자동 번호 종류
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum AutoNumberType {
     #[default]
     Page,
@@ -183,7 +200,7 @@ pub enum AutoNumberType {
 }
 
 /// 새 번호 지정 ('nwno' 컨트롤)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct NewNumber {
     /// 번호 종류
     pub number_type: AutoNumberType,
@@ -192,7 +209,7 @@ pub struct NewNumber {
 }
 
 /// 쪽 번호 위치 ('pgnp' 컨트롤, HWP 스펙 표 149)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct PageNumberPos {
     /// 번호 형식 (표 150 bit 0~7, 표 134 참조)
     pub format: u8,
@@ -209,7 +226,7 @@ pub struct PageNumberPos {
 }
 
 /// 책갈피 ('bokm' 컨트롤)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Bookmark {
     /// 책갈피 이름
     pub name: String,
@@ -225,7 +242,7 @@ pub struct Bookmark {
 /// | 0 | `BOTH` |
 /// | 1 | `EVEN` |
 /// | 2 | `ODD` |
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize)]
 pub enum PageStartsOn {
     /// 양쪽 (기본값)
     #[default]
@@ -275,7 +292,7 @@ impl PageStartsOn {
 }
 
 /// 쪽 번호 시작 쪽 컨트롤 ('pgct')
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize)]
 pub struct PageNumCtrl {
     /// 쪽 번호가 시작되는 쪽
     pub page_starts_on: PageStartsOn,
@@ -290,7 +307,7 @@ pub struct PageNumCtrl {
 ///
 /// HWPX 는 `<hp:ctrl><hp:indexmark><hp:firstKey/><hp:secondKey/></hp:indexmark></hp:ctrl>`
 /// 로 적는다(ParaList XML schema.xml:209).
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
 pub struct IndexMark {
     /// 첫째 키
     pub first_key: String,
@@ -299,7 +316,7 @@ pub struct IndexMark {
 }
 
 /// 하이퍼링크 ('%hlk' 필드)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Hyperlink {
     /// URL
     pub url: String,
@@ -308,7 +325,7 @@ pub struct Hyperlink {
 }
 
 /// 덧말 ('tdut' 컨트롤)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Ruby {
     /// 기준 텍스트 (`<hp:mainText>`) — 덧말이 달리는 본문 글자. (#1587)
     /// 파서가 para.text 에 넣지 않고 여기 보존한다(시각 충실도 핵심).
@@ -328,7 +345,7 @@ pub struct Ruby {
 }
 
 /// 글자 겹침 ('tcps' 컨트롤, HWP 스펙 표 152)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct CharOverlap {
     /// 겹칠 글자 목록 (최대 9글자)
     pub chars: Vec<char>,
@@ -343,7 +360,7 @@ pub struct CharOverlap {
 }
 
 /// 감추기 ('pghd' 컨트롤)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct PageHide {
     /// 머리말 감추기
     pub hide_header: bool,
@@ -360,7 +377,7 @@ pub struct PageHide {
 }
 
 /// 숨은 설명 ('tcmt' 컨트롤)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct HiddenComment {
     /// 문단 리스트
     pub paragraphs: Vec<Paragraph>,
@@ -370,7 +387,7 @@ pub struct HiddenComment {
 ///
 /// 편집 IR 은 빈 필드로 정규화된 상태가 authoritative 이고, 이 구조체는 **저장 시
 /// 원본 파일 형상을 되돌리기 위한 파생 상태**다 (값 API·렌더는 이 값을 보지 않는다).
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
 pub struct GuideResidue {
     /// 제거된 본문 텍스트 원문 (한컴이 안내문 뒤에 붙이는 trailing 공백까지 그대로).
     pub text: String,
@@ -385,7 +402,7 @@ pub struct GuideResidue {
 /// 스칼라와 재귀하는 listParam 1종, 도합 5종. 각 파라미터의 **의미는 해석하지 않고**
 /// 이름과 타입 그대로 보존한다(HWP5 왕복 시 `Prop`/`Direction`/`Path`/`Category` 등이
 /// `Command` 하나로 축소되던 손실의 근본 수정).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub enum Parameter {
     Boolean {
         name: Option<String>,
@@ -411,7 +428,7 @@ pub enum Parameter {
 
 /// `hp:ParameterList` 자체 — `<hp:parameters>`(필드 루트) 또는 `<hp:listParam>`(중첩) 둘 다
 /// 이 표현을 쓴다. `cnt` 속성은 `items.len()` 에서 유도하므로 별도 저장하지 않는다.
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
 pub struct ParameterList {
     pub name: Option<String>,
     pub items: Vec<Parameter>,
@@ -754,7 +771,7 @@ mod parameter_list_codec_tests {
 }
 
 /// 필드 컨트롤
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Field {
     /// 필드 타입
     pub field_type: FieldType,
@@ -953,7 +970,7 @@ impl Field {
 }
 
 /// 필드 타입
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum FieldType {
     #[default]
     Unknown,
@@ -990,7 +1007,7 @@ pub enum FormType {
 }
 
 /// 양식 개체 ('form' 컨트롤, ctrl_id=0x666f726d)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct FormObject {
     /// 양식 개체 타입
     pub form_type: FormType,
@@ -1013,11 +1030,15 @@ pub struct FormObject {
     /// 활성화 여부
     pub enabled: bool,
     /// 기타 속성 (원본 키-값 보존)
+    ///
+    /// [#4488] serde 직렬화는 정렬 순회를 강제한다 — HashMap 순회 순서가
+    /// 다이제스트(model::raw_provenance)에 실리면 봉인이 비결정적이 된다.
+    #[serde(serialize_with = "serialize_sorted_string_map")]
     pub properties: HashMap<String, String>,
 }
 
 /// 알 수 없는 컨트롤
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct UnknownControl {
     /// 컨트롤 ID
     pub ctrl_id: u32,

--- a/src/model/document.rs
+++ b/src/model/document.rs
@@ -245,10 +245,14 @@ pub struct Section {
     /// 원본 BodyText 레코드 스트림 바이트 (직렬화 시 원본 복원용)
     /// 편집 시 None으로 초기화하여 재직렬화 유도
     pub raw_stream: Option<Vec<u8>>,
+    /// [#4488] raw_stream 출처 봉인 — 파싱(+로드 픽스업) 완료 시점의 모델 상태와
+    /// 원본 바이트의 다이제스트 쌍. 저장 시 둘 다 일치할 때만 raw 를 재사용한다.
+    /// 계약 전문은 `model::raw_provenance` 모듈 주석.
+    pub raw_provenance: Option<crate::model::raw_provenance::SectionSeal>,
 }
 
 /// 구역 정의 (HWPTAG_CTRL_HEADER - 'secd')
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct SectionDef {
     /// 속성 비트 플래그
     pub flags: u32,

--- a/src/model/document.rs
+++ b/src/model/document.rs
@@ -47,7 +47,7 @@ pub const HWPX_ORIGIN_STREAM_PATH: &str = "/RhwpHwpxOrigin";
 pub const HWP3_ORIGIN_STREAM_PATH: &str = "/RhwpHwp3Origin";
 
 /// 파서가 모델링하지 않는 원시 레코드 (라운드트립 보존용)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct RawRecord {
     /// 태그 ID
     pub tag_id: u16,
@@ -154,7 +154,7 @@ pub struct HwpVersion {
 }
 
 /// 문서 속성 (HWPTAG_DOCUMENT_PROPERTIES)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct DocProperties {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -229,6 +229,10 @@ pub struct DocInfo {
     /// (1.2~1.5 등) 원본 값을 보존해 직렬화 때 그대로 재방출한다.
     /// 원본 HWPX가 없으면 None → serializer가 "1.2" 폴백.
     pub hwpml_version: Option<String>,
+    /// [#4493] raw_stream 출처 봉인 — 파싱(+로드 픽스업) 완료 시점의 모델 상태와
+    /// 원본 바이트의 다이제스트 쌍. 저장 시 둘 다 일치할 때만 raw 를 재사용한다.
+    /// 계약 전문은 `model::raw_provenance` 모듈 주석.
+    pub raw_provenance: Option<crate::model::raw_provenance::DocInfoSeal>,
 }
 
 /// 본문의 구역 (Section)

--- a/src/model/footnote.rs
+++ b/src/model/footnote.rs
@@ -12,7 +12,7 @@ use super::*;
 /// LIST_HEADER for Footnote (size=16): paraCount(SInt4) + property(UInt4) + 8 byte zero padding.
 ///
 /// 참조: `hwplib::ControlFootnote` + `CtrlHeaderFootnote`.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct Footnote {
     /// 각주 번호
     pub number: u16,
@@ -31,7 +31,7 @@ pub struct Footnote {
 }
 
 /// 미주 ('en  ' 컨트롤) — [Task #1050] Footnote 와 동일 구조
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct Endnote {
     /// 미주 번호
     pub number: u16,
@@ -50,7 +50,7 @@ pub struct Endnote {
 }
 
 /// 각주/미주 모양 (HWPTAG_FOOTNOTE_SHAPE)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct FootnoteShape {
     /// 속성 비트 플래그
     pub attr: u32,
@@ -237,7 +237,7 @@ impl FootnoteShape {
 }
 
 /// 번호 형식
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum NumberFormat {
     #[default]
     Digit, // 1, 2, 3
@@ -262,7 +262,7 @@ pub enum NumberFormat {
 }
 
 /// 번호 매기기 방식
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum FootnoteNumbering {
     #[default]
     /// 앞 구역에 이어서
@@ -274,7 +274,7 @@ pub enum FootnoteNumbering {
 }
 
 /// 배치 방법
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum FootnotePlacement {
     #[default]
     /// 각 단마다 따로 배열 / 문서의 마지막

--- a/src/model/header_footer.rs
+++ b/src/model/header_footer.rs
@@ -3,7 +3,7 @@
 use super::paragraph::Paragraph;
 
 /// 머리말 ('head' 컨트롤)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct Header {
     /// 적용 범위
     pub apply_to: HeaderFooterApply,
@@ -26,7 +26,7 @@ pub struct Header {
 }
 
 /// 꼬리말 ('foot' 컨트롤)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct Footer {
     /// 적용 범위
     pub apply_to: HeaderFooterApply,
@@ -49,7 +49,7 @@ pub struct Footer {
 }
 
 /// 머리말/꼬리말 적용 범위
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum HeaderFooterApply {
     #[default]
     /// 양쪽 (모든 페이지)
@@ -64,7 +64,7 @@ pub enum HeaderFooterApply {
 ///
 /// 구역 단위 페이지 템플릿. 양쪽/홀수/짝수 3종류 설정 가능.
 /// SectionDef의 자식 LIST_HEADER 레코드에서 파싱.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct MasterPage {
     /// 적용 범위 (양쪽/홀수/짝수)
     pub apply_to: HeaderFooterApply,

--- a/src/model/image.rs
+++ b/src/model/image.rs
@@ -5,7 +5,7 @@ use super::style::ShapeBorderLine;
 use super::*;
 
 /// 그림 개체 (HWPTAG_SHAPE_COMPONENT_PICTURE)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct Picture {
     /// 개체 공통 속성
     pub common: CommonObjAttr,
@@ -67,7 +67,7 @@ impl Picture {
 }
 
 /// 자르기 정보
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
 pub struct CropInfo {
     pub left: i32,
     pub top: i32,
@@ -76,7 +76,7 @@ pub struct CropInfo {
 }
 
 /// 이미지 속성
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct ImageAttr {
     /// 밝기
     pub brightness: i8,
@@ -96,13 +96,13 @@ pub struct ImageAttr {
 }
 
 /// HWPX 그림 효과 (`hp:effects`).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct PictureEffects {
     pub shadow: Option<PictureShadow>,
 }
 
 /// HWPX 그림 그림자 효과 (`hp:shadow`).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct PictureShadow {
     pub style: Option<String>,
     pub alpha: Option<String>,
@@ -117,14 +117,14 @@ pub struct PictureShadow {
 }
 
 /// HWPX 효과의 x/y 좌표성 값 (`hp:skew`, `hp:scale`).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct EffectPoint {
     pub x: Option<String>,
     pub y: Option<String>,
 }
 
 /// HWPX 효과 색상 (`hp:effectsColor`).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct EffectColor {
     pub color_type: Option<String>,
     pub scheme_idx: Option<String>,
@@ -134,7 +134,7 @@ pub struct EffectColor {
 }
 
 /// HWPX 효과 RGB 색상 (`hp:rgb`).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct EffectRgb {
     pub r: Option<String>,
     pub g: Option<String>,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -15,6 +15,7 @@ pub mod page;
 pub mod paragraph;
 pub mod path;
 pub mod provenance;
+pub mod raw_provenance;
 pub mod shape;
 pub mod style;
 pub mod table;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -33,7 +33,7 @@ pub type HwpUnit16 = i16;
 pub type ColorRef = u32;
 
 /// 2차원 좌표
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
 pub struct Point {
     pub x: i32,
     pub y: i32,
@@ -59,7 +59,7 @@ impl Rect {
 }
 
 /// 4방향 여백
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
 pub struct Padding {
     pub left: HwpUnit16,
     pub right: HwpUnit16,

--- a/src/model/page.rs
+++ b/src/model/page.rs
@@ -3,7 +3,7 @@
 use super::*;
 
 /// 용지 설정 (HWPTAG_PAGE_DEF)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct PageDef {
     /// 용지 가로 크기
     pub width: HwpUnit,
@@ -54,7 +54,7 @@ impl PageDef {
 }
 
 /// 제책 방법
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum BindingMethod {
     #[default]
     /// 한쪽 편집
@@ -66,7 +66,7 @@ pub enum BindingMethod {
 }
 
 /// 쪽 테두리/배경 (HWPTAG_PAGE_BORDER_FILL)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct PageBorderFill {
     /// 속성 비트 플래그
     pub attr: u32,
@@ -97,7 +97,7 @@ pub struct PageBorderFill {
 }
 
 /// 쪽 테두리 렌더 위치 기준
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize)]
 pub enum PageBorderBasis {
     /// 본문 영역 기준 (body_area edge 에서 spacing)
     #[default]
@@ -107,7 +107,7 @@ pub enum PageBorderBasis {
 }
 
 /// 쪽 테두리/배경 대화상자 위치 기준
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize)]
 pub enum PageBorderUiBasis {
     /// 한컴 UI의 종이 기준
     #[default]
@@ -117,7 +117,7 @@ pub enum PageBorderUiBasis {
 }
 
 /// 단 정의 ('cold' 컨트롤)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct ColumnDef {
     /// 단 종류
     pub column_type: ColumnType,
@@ -147,7 +147,7 @@ pub struct ColumnDef {
 }
 
 /// 단 종류
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum ColumnType {
     #[default]
     Normal,
@@ -158,7 +158,7 @@ pub enum ColumnType {
 }
 
 /// 단 방향
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum ColumnDirection {
     #[default]
     LeftToRight,

--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -4,7 +4,7 @@ use super::control::{Control, CTRL_CHAR_CODE_UNITS};
 use serde::{Deserialize, Serialize};
 
 /// 문단 (HWPTAG_PARA_HEADER + 하위 레코드)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct Paragraph {
     /// 문자 수 (제어 문자 포함)
     pub char_count: u32,
@@ -96,7 +96,7 @@ pub struct Paragraph {
 ///
 /// `Relaxed` 순서로 충분하다 — 값은 (문단, 폭)의 결정적 함수라 경합 시 최악이
 /// 중복 측정일 뿐 오답이 없다.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, serde::Serialize)]
 pub struct SingleLineOverflowMemo(std::sync::atomic::AtomicU64);
 
 impl SingleLineOverflowMemo {
@@ -237,7 +237,7 @@ pub enum ColumnBreakType {
 }
 
 /// 글자 모양 참조 (문단 내 위치별 글자 모양)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct CharShapeRef {
     /// 글자 모양이 바뀌는 시작 위치
     pub start_pos: u32,
@@ -249,7 +249,7 @@ pub struct CharShapeRef {
 ///
 /// **표준**: `mydocs/tech/document_ir_lineseg_standard.md` (Task #604)
 /// 모든 i32 필드는 HWPUNIT (1 inch = 7200 HWPUNIT).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct LineSeg {
     /// 본 줄이 차지하는 텍스트 시작 위치 (UTF-16 code unit, 문단 시작 기준)
     pub text_start: u32,
@@ -369,7 +369,7 @@ impl LineSeg {
 }
 
 /// 영역 태그 (HWPTAG_PARA_RANGE_TAG)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct RangeTag {
     /// 영역 시작
     pub start: u32,
@@ -392,7 +392,7 @@ pub struct RangeTag {
 /// 8 code unit 을 점유하므로 이 마커를 버리면 문단 축이 그만큼 짧아지고,
 /// 한글은 축이 어긋난 `<hp:lineseg textpos>` 를 만나면 본문을 통째로 버린다
 /// (10k 스윕 F-절단군 — 77 문서·2,237 개).
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
 pub struct TitleMark {
     /// `text` 문자열 내 삽입 위치 (이 인덱스의 문자 **앞**에 놓인다)
     pub char_idx: usize,
@@ -401,7 +401,7 @@ pub struct TitleMark {
 }
 
 /// 필드 텍스트 범위 (0x03 FIELD_BEGIN ~ 0x04 FIELD_END 사이 텍스트)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct FieldRange {
     /// text 문자열 내 시작 인덱스 (포함)
     pub start_char_idx: usize,
@@ -431,7 +431,7 @@ pub struct FieldRange {
 /// 다단락 필드의 종료 마커. begin 문단에서 `Control::Field` 로 보존되는 것과 달리,
 /// end 문단에는 컨트롤·FieldRange 가 없어 8유닛 슬롯을 표현할 산출물이 없다.
 /// 이를 기록해 직렬화기가 `<hp:fieldEnd>` 를 같은 위치에 복원한다 (Task #1556).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct OrphanFieldEnd {
     /// text 문자열 내 위치 (이 인덱스 직전에 8유닛 fieldEnd 슬롯이 놓인다).
     /// 텍스트 끝이면 `text.chars().count()`.

--- a/src/model/raw_provenance.rs
+++ b/src/model/raw_provenance.rs
@@ -1,0 +1,323 @@
+//! [#4493] DocInfo raw 캐시 출처 봉인(provenance seal).
+//!
+//! ## 문제
+//!
+//! 공개 저수준 API 는 `parse_document → model::Document 직접 변경 →
+//! serialize_document` 를 허용하는데, HWP 파싱은 `DocInfo.raw_stream` 과 레코드별
+//! `raw_data` 를 채우고 `raw_stream_dirty=false` 로 남긴다. 공개 모델 필드를 직접
+//! 바꾸면 dirty 표식이 서지 않으므로, 저장 시 원본 바이트 통과(스트림·레코드
+//! 양쪽)가 그대로 발동해 **메모리에서 보이던 변경이 저장·재로드 뒤 조용히
+//! 사라진다.**
+//!
+//! ## 처방 — 봉인과 검증
+//!
+//! 파싱과 모든 load fixup 이 끝난 시점(`parse_document_inner` 말미)에 봉인한다.
+//!
+//! - **스트림 봉인** — 원본 DocInfo 바이트와 모델 상태의 다이제스트 쌍. 저장 시
+//!   둘 다 일치할 때만 `raw_stream` 전체 통과를 허용한다. 공개 `raw_stream` 을
+//!   다른 바이트로 교체해도(raw digest 불일치) 봉인으로 승인되지 않는다.
+//! - **레코드 봉인** — DocInfo 의 레코드별 `raw_data` 지름길(BIN_DATA·FACE_NAME·
+//!   BORDER_FILL·CHAR_SHAPE·TAB_DEF·NUMBERING·BULLET·PARA_SHAPE·STYLE·
+//!   DOCUMENT_PROPERTIES)에 대응하는 레코드 단위 다이제스트. 스트림이 재생성될
+//!   때 **변경되지 않은 레코드만** 원본 바이트를 재사용하고, 변경된 레코드는
+//!   모델 writer 로 다시 쓴다 — 하위 raw 를 무조건 폐기해 미모델링 바이트를
+//!   잃는 방식은 쓰지 않는다(#4495 와 같은 원칙).
+//!
+//! 봉인은 모델 타입에 필드를 넣지 않고 이 모듈의 컨테이너(인덱스 정렬)로
+//! 중앙 보관한다 — 목록 삽입·삭제로 인덱스가 어긋나면 다이제스트가 어긋나
+//! 재생성으로 떨어지므로 안전한 방향으로 실패한다.
+//!
+//! ## 다이제스트 규약
+//!
+//! serde 직렬화(JSON 인코딩)를 blake3 로 해시한다 — `Debug`/`DefaultHasher`/
+//! 재귀 `Clone` 스냅샷에 의존하지 않는다. serde_json 은 구조체 필드를 선언
+//! 순서로, 숫자·float 를 결정적 표기(ryu/itoa)로 방출하므로 같은 프로세스에서
+//! 항상 같은 바이트를 낸다. DocInfo 트리에는 순회 순서가 비결정적인 맵 타입이
+//! 없다(생기면 이 모듈에서 정렬 직렬화로 감싸야 한다). 봉인 대상 필드는
+//! [`doc_info_model_digest`] 가 **전수 구조분해**로 나열한다 — 필드 추가 시
+//! 컴파일 오류로 목록 갱신을 강제한다.
+//!
+//! Section(`raw_stream`)·본문 컨트롤 raw 레코드의 같은 계약은 #4488·#4495 가
+//! 별도로 다룬다 — 스트림·소유자가 다르다.
+
+use serde::Serialize;
+
+use super::document::{DocInfo, DocProperties};
+
+/// 파싱 완료 시점의 DocInfo 봉인.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocInfoSeal {
+    /// 봉인 시점 모델 상태의 다이제스트 ([`doc_info_model_digest`]).
+    pub model_digest: [u8; 32],
+    /// 봉인 시점 `raw_stream` 바이트의 다이제스트.
+    pub raw_digest: [u8; 32],
+    /// 레코드별 봉인 — 인덱스는 봉인 시점 목록 순서.
+    pub record_seals: DocInfoRecordSeals,
+}
+
+/// 레코드별 `raw_data` 지름길에 대응하는 다이제스트 묶음.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DocInfoRecordSeals {
+    pub props: [u8; 32],
+    pub bin_data: Vec<[u8; 32]>,
+    /// 언어 축(바깥)×글꼴(안) — `DocInfo.font_faces` 와 같은 모양.
+    pub fonts: Vec<Vec<[u8; 32]>>,
+    pub border_fills: Vec<[u8; 32]>,
+    pub char_shapes: Vec<[u8; 32]>,
+    pub tab_defs: Vec<[u8; 32]>,
+    pub numberings: Vec<[u8; 32]>,
+    pub bullets: Vec<[u8; 32]>,
+    pub para_shapes: Vec<[u8; 32]>,
+    pub styles: Vec<[u8; 32]>,
+}
+
+/// 바이트 열의 다이제스트.
+pub fn bytes_digest(bytes: &[u8]) -> [u8; 32] {
+    *blake3::hash(bytes).as_bytes()
+}
+
+/// 레코드(직렬화 가능한 모델 값) 하나의 다이제스트.
+///
+/// 레코드의 `raw_data` 필드도 다이제스트에 포함된다 — 모델 필드가 변하지 않는 한
+/// `raw_data` 는 파싱 시점 그대로이므로 판정에 영향이 없고, `raw_data` 만 바꿔치기
+/// 하는 변경도 불일치로 떨어져 승인되지 않는다.
+pub fn record_digest<T: Serialize>(record: &T) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    serde_json::to_writer(&mut hasher, record)
+        .expect("레코드 다이제스트 직렬화는 실패할 수 없다 (순수 인메모리 인코딩)");
+    *hasher.finalize().as_bytes()
+}
+
+/// 봉인 컨테이너에서 `idx` 레코드의 raw 재사용 허용 여부.
+///
+/// - 봉인 자체가 없으면(`seals=None`, 파서를 거치지 않은 합성 IR) 종전 계약대로
+///   허용한다.
+/// - 봉인이 있으면 인덱스가 범위 안이고 다이제스트가 일치할 때만 허용한다 —
+///   목록 삽입·삭제로 인덱스가 밀리면 불일치로 떨어져 모델 writer 로 재생성된다.
+pub fn record_raw_permitted<T: Serialize>(
+    seals: Option<&[[u8; 32]]>,
+    idx: usize,
+    record: &T,
+) -> bool {
+    match seals {
+        None => true,
+        Some(seals) => seals
+            .get(idx)
+            .is_some_and(|sealed| *sealed == record_digest(record)),
+    }
+}
+
+/// DocInfo(+DocProperties) 모델 상태의 다이제스트.
+///
+/// 저장 산출물에 실리는 모델 필드 전부를 선언 순서로 직렬화해 해시한다.
+/// 구조분해에 `..` 를 쓰지 않는 것이 계약이다 — 새 필드가 생기면 여기가
+/// 컴파일 오류를 내서 "봉인 대상인가"의 판단을 강제한다. raw 캐시 자신
+/// (`raw_stream`)과 그 관리 표식(`raw_stream_dirty`, `raw_provenance`), 통과
+/// 경로가 스스로 처리하는 `distribute_doc_data_removed`(surgical remove)는 뺀다.
+pub fn doc_info_model_digest(doc_info: &DocInfo, doc_props: &DocProperties) -> [u8; 32] {
+    let DocInfo {
+        bin_data_list,
+        font_faces,
+        border_fills,
+        char_shapes,
+        tab_defs,
+        numberings,
+        bullets,
+        para_shapes,
+        styles,
+        extra_records,
+        raw_stream: _,
+        bullet_count,
+        memo_shape_count,
+        memo_properties_xml,
+        distribute_doc_data_removed: _,
+        raw_stream_dirty: _,
+        hwpx_head_tail,
+        hwpml_version,
+        raw_provenance: _,
+    } = doc_info;
+
+    #[derive(Serialize)]
+    struct Fingerprint<'a> {
+        bin_data_list: &'a [crate::model::bin_data::BinData],
+        font_faces: &'a [Vec<crate::model::style::Font>],
+        border_fills: &'a [crate::model::style::BorderFill],
+        char_shapes: &'a [crate::model::style::CharShape],
+        tab_defs: &'a [crate::model::style::TabDef],
+        numberings: &'a [crate::model::style::Numbering],
+        bullets: &'a [crate::model::style::Bullet],
+        para_shapes: &'a [crate::model::style::ParaShape],
+        styles: &'a [crate::model::style::Style],
+        extra_records: &'a [crate::model::document::RawRecord],
+        bullet_count: u32,
+        memo_shape_count: u32,
+        memo_properties_xml: &'a Option<String>,
+        hwpx_head_tail: &'a Option<String>,
+        hwpml_version: &'a Option<String>,
+        props: &'a DocProperties,
+    }
+
+    let fp = Fingerprint {
+        bin_data_list,
+        font_faces,
+        border_fills,
+        char_shapes,
+        tab_defs,
+        numberings,
+        bullets,
+        para_shapes,
+        styles,
+        extra_records,
+        bullet_count: *bullet_count,
+        memo_shape_count: *memo_shape_count,
+        memo_properties_xml,
+        hwpx_head_tail,
+        hwpml_version,
+        props: doc_props,
+    };
+
+    let mut hasher = blake3::Hasher::new();
+    serde_json::to_writer(&mut hasher, &fp)
+        .expect("모델 다이제스트 직렬화는 실패할 수 없다 (순수 인메모리 인코딩)");
+    *hasher.finalize().as_bytes()
+}
+
+/// 레코드 봉인 묶음 계산 — 봉인 시점의 목록 순서 그대로.
+fn compute_record_seals(doc_info: &DocInfo, doc_props: &DocProperties) -> DocInfoRecordSeals {
+    DocInfoRecordSeals {
+        props: record_digest(doc_props),
+        bin_data: doc_info.bin_data_list.iter().map(record_digest).collect(),
+        fonts: doc_info
+            .font_faces
+            .iter()
+            .map(|lang| lang.iter().map(record_digest).collect())
+            .collect(),
+        border_fills: doc_info.border_fills.iter().map(record_digest).collect(),
+        char_shapes: doc_info.char_shapes.iter().map(record_digest).collect(),
+        tab_defs: doc_info.tab_defs.iter().map(record_digest).collect(),
+        numberings: doc_info.numberings.iter().map(record_digest).collect(),
+        bullets: doc_info.bullets.iter().map(record_digest).collect(),
+        para_shapes: doc_info.para_shapes.iter().map(record_digest).collect(),
+        styles: doc_info.styles.iter().map(record_digest).collect(),
+    }
+}
+
+impl DocInfo {
+    /// 파싱(+로드 픽스업) 완료 시점에 호출 — raw 캐시가 있으면 현재 모델 상태와
+    /// 함께 봉인한다. raw 가 없으면(HWPX/HWP3/합성 IR) 봉인도 없다.
+    pub fn seal_raw_provenance(&mut self, doc_props: &DocProperties) {
+        self.raw_provenance = self.raw_stream.as_ref().map(|raw| DocInfoSeal {
+            model_digest: doc_info_model_digest(self, doc_props),
+            raw_digest: bytes_digest(raw),
+            record_seals: compute_record_seals(self, doc_props),
+        });
+    }
+
+    /// 저장 시점 스트림 통과 검증 — raw 바이트와 모델 상태가 둘 다 봉인과 같은가.
+    ///
+    /// 봉인이 없는 raw(`raw_provenance=None`, 파서를 거치지 않은 합성 IR 등)는
+    /// 종전 계약대로 통과를 허용한다 — 봉인은 공개 parse→mutate→serialize
+    /// 경로의 손실을 막기 위한 것이고, 파서가 만든 문서에는 항상 봉인이 있다.
+    pub fn raw_provenance_permits_reuse(&self, doc_props: &DocProperties) -> bool {
+        let Some(raw) = self.raw_stream.as_ref() else {
+            return false;
+        };
+        match &self.raw_provenance {
+            None => true,
+            Some(seal) => {
+                seal.raw_digest == bytes_digest(raw)
+                    && seal.model_digest == doc_info_model_digest(self, doc_props)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn digest_changes_when_model_changes() {
+        let mut di = DocInfo::default();
+        let props = DocProperties::default();
+        let before = doc_info_model_digest(&di, &props);
+        di.char_shapes
+            .push(crate::model::style::CharShape::default());
+        let after = doc_info_model_digest(&di, &props);
+        assert_ne!(before, after, "char_shapes 변경이 다이제스트에 실려야 한다");
+    }
+
+    #[test]
+    fn digest_ignores_raw_cache_fields() {
+        let mut di = DocInfo::default();
+        let props = DocProperties::default();
+        let before = doc_info_model_digest(&di, &props);
+        di.raw_stream = Some(vec![1, 2, 3]);
+        di.raw_stream_dirty = true;
+        di.distribute_doc_data_removed = true;
+        let after = doc_info_model_digest(&di, &props);
+        assert_eq!(before, after, "raw 캐시 표식은 모델 다이제스트 밖이다");
+    }
+
+    #[test]
+    fn sealed_raw_reuse_denied_after_model_mutation() {
+        let mut di = DocInfo::default();
+        let props = DocProperties::default();
+        di.raw_stream = Some(vec![9, 9, 9]);
+        di.seal_raw_provenance(&props);
+        assert!(di.raw_provenance_permits_reuse(&props), "무변경이면 재사용");
+
+        di.para_shapes
+            .push(crate::model::style::ParaShape::default());
+        assert!(
+            !di.raw_provenance_permits_reuse(&props),
+            "공개 모델 직접 변경 뒤에는 raw 재사용이 거부돼야 한다 (#4493)"
+        );
+    }
+
+    #[test]
+    fn sealed_raw_reuse_denied_after_raw_swap() {
+        let mut di = DocInfo::default();
+        let props = DocProperties::default();
+        di.raw_stream = Some(vec![9, 9, 9]);
+        di.seal_raw_provenance(&props);
+
+        di.raw_stream = Some(vec![8, 8, 8]);
+        assert!(
+            !di.raw_provenance_permits_reuse(&props),
+            "raw 바이트 교체는 기존 봉인으로 승인되지 않는다 (#4493)"
+        );
+    }
+
+    #[test]
+    fn unsealed_raw_keeps_legacy_passthrough() {
+        let mut di = DocInfo::default();
+        let props = DocProperties::default();
+        di.raw_stream = Some(vec![7]);
+        assert!(
+            di.raw_provenance_permits_reuse(&props),
+            "봉인 이전(합성 IR) 경로는 종전 계약 유지"
+        );
+    }
+
+    #[test]
+    fn record_raw_permission_follows_seal() {
+        let cs = crate::model::style::CharShape::default();
+        let sealed = [record_digest(&cs)];
+        assert!(record_raw_permitted(Some(&sealed), 0, &cs), "무변경 허용");
+        assert!(
+            !record_raw_permitted(Some(&sealed), 1, &cs),
+            "범위 밖(새 레코드)은 모델 writer"
+        );
+        let mut changed = cs;
+        changed.base_size = 2000;
+        assert!(
+            !record_raw_permitted(Some(&sealed), 0, &changed),
+            "변경 레코드는 raw 재사용 거부"
+        );
+        assert!(
+            record_raw_permitted(None, 0, &changed),
+            "봉인 없는 합성 IR 은 종전 계약"
+        );
+    }
+}

--- a/src/model/raw_provenance.rs
+++ b/src/model/raw_provenance.rs
@@ -232,6 +232,205 @@ impl DocInfo {
     }
 }
 
+// ===========================================================================
+// [#4488] Section raw_stream 봉인 + [#4495] 본문 컨트롤 하위 raw 봉인
+// ===========================================================================
+
+/// 파싱 완료 시점의 Section 봉인 — DocInfo 와 같은 계약, 다른 스트림·소유자.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SectionSeal {
+    /// 봉인 시점 모델 상태(section_def + paragraphs)의 다이제스트.
+    pub model_digest: [u8; 32],
+    /// 봉인 시점 `raw_stream` 바이트의 다이제스트.
+    pub raw_digest: [u8; 32],
+}
+
+/// Section 모델 상태의 다이제스트 — raw 캐시 필드는 전수 구조분해로 뺀다.
+pub fn section_model_digest(section: &crate::model::document::Section) -> [u8; 32] {
+    let crate::model::document::Section {
+        section_def,
+        paragraphs,
+        raw_stream: _,
+        raw_provenance: _,
+    } = section;
+
+    #[derive(Serialize)]
+    struct Fingerprint<'a> {
+        section_def: &'a crate::model::document::SectionDef,
+        paragraphs: &'a [crate::model::paragraph::Paragraph],
+    }
+
+    let mut hasher = blake3::Hasher::new();
+    serde_json::to_writer(
+        &mut hasher,
+        &Fingerprint {
+            section_def,
+            paragraphs,
+        },
+    )
+    .expect("모델 다이제스트 직렬화는 실패할 수 없다 (순수 인메모리 인코딩)");
+    *hasher.finalize().as_bytes()
+}
+
+impl crate::model::document::Section {
+    /// 파싱(+로드 픽스업) 완료 시점에 호출 — raw 캐시가 있으면 봉인한다.
+    pub fn seal_raw_provenance(&mut self) {
+        self.raw_provenance = self.raw_stream.as_ref().map(|raw| SectionSeal {
+            model_digest: section_model_digest(self),
+            raw_digest: bytes_digest(raw),
+        });
+    }
+
+    /// 저장 시점 검증 — DocInfo 쪽과 동일 계약(봉인 없는 raw 는 종전대로 허용).
+    pub fn raw_provenance_permits_reuse(&self) -> bool {
+        let Some(raw) = self.raw_stream.as_ref() else {
+            return false;
+        };
+        match &self.raw_provenance {
+            None => true,
+            Some(seal) => {
+                seal.raw_digest == bytes_digest(raw)
+                    && seal.model_digest == section_model_digest(self)
+            }
+        }
+    }
+}
+
+/// [#4495] OLE payload(raw_tag_data)가 대표하는 모델 필드의 다이제스트.
+///
+/// `serialize_ole_data` 의 모델 경로가 소비하는 필드가 판정 범위다 — 그 밖의
+/// 필드 변경은 이 레코드의 바이트에 영향을 주지 않으므로 raw 를 유지한다.
+pub fn ole_payload_digest(ole: &crate::model::shape::OleShape) -> [u8; 32] {
+    record_digest(&(ole.extent_x, ole.extent_y, ole.bin_data_id))
+}
+
+/// [#4495] 하위 raw 레코드를 가진 컨트롤 전부를 깊이 우선으로 봉인한다.
+///
+/// - Table/Equation CTRL_HEADER raw ↔ `common`(CommonObjAttr) — 저장기가 raw
+///   부재 시 합성하는 원천이 `common` 이므로 판정 범위도 `common` 이다.
+///   (`raw_ctrl_data` 자체는 판정 밖 — 셀 폭 조절처럼 raw 를 직접 갱신하는
+///   기존 명령(dual-write, table.rs `refresh_raw_ctrl_size` 참조)과 충돌하지
+///   않기 위함이다.)
+/// - OLE raw_tag_data ↔ payload 모델 필드([`ole_payload_digest`]).
+///
+/// 순회는 `for_each_ole_mut`(hwpx_to_hwp.rs)와 같은 소유자 집합을 밟는다 —
+/// 저장소에 정본 순회기가 아직 없어(#4422) 여기 사본을 둔다. 누락되면 그
+/// 컨트롤은 봉인 없이 남아 **종전 계약(raw 우선)** 으로 동작한다 — 새 검증이
+/// 빠지는 것이지 새 손실이 생기는 방향이 아니다.
+fn seal_raw_bearing_controls(paragraphs: &mut [crate::model::paragraph::Paragraph]) {
+    use crate::model::control::Control;
+    use crate::model::shape::ShapeObject;
+
+    fn walk_caption(caption: &mut crate::model::shape::Caption) {
+        seal_raw_bearing_controls(&mut caption.paragraphs);
+    }
+
+    fn walk_drawing(drawing: &mut crate::model::shape::DrawingObjAttr) {
+        if let Some(text_box) = &mut drawing.text_box {
+            seal_raw_bearing_controls(&mut text_box.paragraphs);
+        }
+        if let Some(caption) = &mut drawing.caption {
+            walk_caption(caption);
+        }
+    }
+
+    fn walk_shape(shape: &mut ShapeObject) {
+        match shape {
+            ShapeObject::Picture(pic) => {
+                if let Some(caption) = &mut pic.caption {
+                    walk_caption(caption);
+                }
+            }
+            ShapeObject::Group(group) => {
+                for child in &mut group.children {
+                    walk_shape(child);
+                }
+                if let Some(caption) = &mut group.caption {
+                    walk_caption(caption);
+                }
+            }
+            ShapeObject::Chart(chart) => {
+                walk_drawing(&mut chart.drawing);
+                if let Some(caption) = &mut chart.caption {
+                    walk_caption(caption);
+                }
+            }
+            ShapeObject::Ole(ole) => {
+                walk_drawing(&mut ole.drawing);
+                if let Some(caption) = &mut ole.caption {
+                    walk_caption(caption);
+                }
+                if !ole.raw_tag_data.is_empty() {
+                    ole.raw_tag_seal = Some(ole_payload_digest(ole));
+                }
+            }
+            _ => {
+                if let Some(drawing) = shape.drawing_mut() {
+                    walk_drawing(drawing);
+                }
+            }
+        }
+    }
+
+    for para in paragraphs {
+        for control in &mut para.controls {
+            match control {
+                Control::Table(table) => {
+                    for cell in &mut table.cells {
+                        seal_raw_bearing_controls(&mut cell.paragraphs);
+                    }
+                    if let Some(caption) = &mut table.caption {
+                        walk_caption(caption);
+                    }
+                    if !table.raw_ctrl_data.is_empty() {
+                        table.raw_ctrl_seal = Some(record_digest(&table.common));
+                    }
+                }
+                Control::Equation(eq) => {
+                    if !eq.raw_ctrl_data.is_empty() {
+                        eq.raw_ctrl_seal = Some(record_digest(&eq.common));
+                    }
+                }
+                Control::Picture(pic) => {
+                    if let Some(caption) = &mut pic.caption {
+                        walk_caption(caption);
+                    }
+                }
+                Control::Shape(shape) => walk_shape(shape),
+                Control::Header(header) => seal_raw_bearing_controls(&mut header.paragraphs),
+                Control::Footer(footer) => seal_raw_bearing_controls(&mut footer.paragraphs),
+                Control::Footnote(fnote) => seal_raw_bearing_controls(&mut fnote.paragraphs),
+                Control::Endnote(enote) => seal_raw_bearing_controls(&mut enote.paragraphs),
+                Control::HiddenComment(comment) => {
+                    seal_raw_bearing_controls(&mut comment.paragraphs)
+                }
+                Control::Field(field) => seal_raw_bearing_controls(&mut field.memo_paragraphs),
+                Control::SectionDef(section_def) => {
+                    for master_page in &mut section_def.master_pages {
+                        seal_raw_bearing_controls(&mut master_page.paragraphs);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+impl crate::model::document::Document {
+    /// [#4488/#4495] 본문 raw 캐시 전부를 봉인한다 — 파싱(+로드 픽스업) 완료
+    /// 시점에 호출. 컨트롤 봉인을 먼저 세우고(봉인 필드는 `#[serde(skip)]` 이라
+    /// Section 다이제스트에 실리지 않는다) Section 봉인을 계산한다.
+    pub fn seal_body_raw_provenance(&mut self) {
+        for section in &mut self.sections {
+            seal_raw_bearing_controls(&mut section.paragraphs);
+            for master_page in &mut section.section_def.master_pages {
+                seal_raw_bearing_controls(&mut master_page.paragraphs);
+            }
+            section.seal_raw_provenance();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/model/shape.rs
+++ b/src/model/shape.rs
@@ -27,7 +27,7 @@ pub(crate) mod common_obj_offsets {
 }
 
 /// 개체 공통 속성 (모든 개체에 공통)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct CommonObjAttr {
     /// 컨트롤 ID
     pub ctrl_id: u32,
@@ -112,7 +112,7 @@ pub struct CommonObjAttr {
 }
 
 /// HWPX 개체 `numberingType` (캡션 번호 범주)
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum ObjectNumberingType {
     #[default]
     None,
@@ -122,7 +122,7 @@ pub enum ObjectNumberingType {
 }
 
 /// HWPX 개체 `dropcapstyle` (드롭캡 표시 방식). OWPML Core 스키마 `DropCapStyleType`.
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum DropCapStyle {
     #[default]
     None,
@@ -132,7 +132,7 @@ pub enum DropCapStyle {
 }
 
 /// 세로 위치 기준
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum VertRelTo {
     #[default]
     Paper,
@@ -141,7 +141,7 @@ pub enum VertRelTo {
 }
 
 /// 세로 정렬 방식
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum VertAlign {
     #[default]
     Top,
@@ -152,7 +152,7 @@ pub enum VertAlign {
 }
 
 /// 가로 위치 기준
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum HorzRelTo {
     #[default]
     Paper,
@@ -162,7 +162,7 @@ pub enum HorzRelTo {
 }
 
 /// 가로 정렬 방식
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum HorzAlign {
     #[default]
     Left,
@@ -173,7 +173,7 @@ pub enum HorzAlign {
 }
 
 /// 크기 기준 (너비/높이)
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum SizeCriterion {
     /// 종이 기준 (퍼센트)
     Paper,
@@ -203,7 +203,7 @@ pub enum TextWrap {
 /// 텍스트가 흐르는 방향 (attr bit 24-25)
 ///
 /// HWPX `textFlow` 속성값과 대응한다.
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum TextFlow {
     #[default]
     BothSides,
@@ -213,7 +213,7 @@ pub enum TextFlow {
 }
 
 /// 개체 요소 속성 (그리기 개체 공통)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct ShapeComponentAttr {
     /// SHAPE_COMPONENT 내 ctrl_id (라운드트립 보존용, 0이면 기본값 사용)
     pub ctrl_id: u32,
@@ -303,7 +303,7 @@ impl Default for ShapeComponentAttr {
 }
 
 /// 그리기 개체 공통 속성
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct DrawingObjAttr {
     /// 개체 요소 속성
     pub shape_attr: ShapeComponentAttr,
@@ -330,7 +330,7 @@ pub struct DrawingObjAttr {
 }
 
 /// 글상자 (그리기 개체 내 텍스트)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct TextBox {
     /// LIST_HEADER list_attr (라운드트립 보존용)
     pub list_attr: u32,
@@ -358,7 +358,7 @@ pub struct TextBox {
 }
 
 /// 그리기 개체 종류
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub enum ShapeObject {
     /// 직선
     Line(LineShape),
@@ -510,7 +510,7 @@ impl ShapeObject {
 }
 
 /// 직선 개체 (HWPTAG_SHAPE_COMPONENT_LINE)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct LineShape {
     /// 공통 속성
     pub common: CommonObjAttr,
@@ -527,7 +527,7 @@ pub struct LineShape {
 }
 
 /// 연결선 타입 (9종)
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 #[repr(u32)]
 pub enum LinkLineType {
     #[default]
@@ -573,7 +573,7 @@ impl LinkLineType {
 }
 
 /// 연결선 제어점
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct ConnectorControlPoint {
     pub x: i32,
     pub y: i32,
@@ -581,7 +581,7 @@ pub struct ConnectorControlPoint {
 }
 
 /// 연결선 추가 데이터 (SC_LINE 확장)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct ConnectorData {
     /// 연결선 타입
     pub link_type: LinkLineType,
@@ -600,7 +600,7 @@ pub struct ConnectorData {
 }
 
 /// 사각형 개체 (HWPTAG_SHAPE_COMPONENT_RECTANGLE)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct RectangleShape {
     /// 공통 속성
     pub common: CommonObjAttr,
@@ -615,7 +615,7 @@ pub struct RectangleShape {
 }
 
 /// 타원 개체 (HWPTAG_SHAPE_COMPONENT_ELLIPSE)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct EllipseShape {
     /// 공통 속성
     pub common: CommonObjAttr,
@@ -640,7 +640,7 @@ pub struct EllipseShape {
 }
 
 /// 호 개체 (HWPTAG_SHAPE_COMPONENT_ARC)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct ArcShape {
     /// 공통 속성
     pub common: CommonObjAttr,
@@ -657,7 +657,7 @@ pub struct ArcShape {
 }
 
 /// 다각형 개체 (HWPTAG_SHAPE_COMPONENT_POLYGON)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct PolygonShape {
     /// 공통 속성
     pub common: CommonObjAttr,
@@ -670,7 +670,7 @@ pub struct PolygonShape {
 }
 
 /// 곡선 개체 (HWPTAG_SHAPE_COMPONENT_CURVE)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct CurveShape {
     /// 공통 속성
     pub common: CommonObjAttr,
@@ -683,7 +683,7 @@ pub struct CurveShape {
 }
 
 /// 묶음 개체 (HWPTAG_SHAPE_COMPONENT_CONTAINER)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct GroupShape {
     /// 공통 속성
     pub common: CommonObjAttr,
@@ -696,7 +696,7 @@ pub struct GroupShape {
 }
 
 /// 캡션 정보
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct Caption {
     /// 방향 (0: left, 1: right, 2: top, 3: bottom)
     pub direction: CaptionDirection,
@@ -715,7 +715,7 @@ pub struct Caption {
 }
 
 /// 캡션 방향
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum CaptionDirection {
     Left,
     Right,
@@ -725,7 +725,7 @@ pub enum CaptionDirection {
 }
 
 /// Left/Right 캡션의 세로 정렬
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum CaptionVertAlign {
     #[default]
     Top,
@@ -738,7 +738,7 @@ pub enum CaptionVertAlign {
 // ============================================================
 
 /// 차트 종류 (1차 범위: Bar/Column/Line/Pie/Area/Scatter)
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum ChartType {
     Bar,
     Column,
@@ -751,7 +751,7 @@ pub enum ChartType {
 }
 
 /// 범례 위치
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum LegendPosition {
     #[default]
     Right,
@@ -766,14 +766,14 @@ pub enum LegendPosition {
 }
 
 /// 범례
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Legend {
     pub position: LegendPosition,
     pub visible: bool,
 }
 
 /// 축
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Axis {
     pub label: Option<String>,
     pub labels: Vec<String>,
@@ -782,7 +782,7 @@ pub struct Axis {
 }
 
 /// 데이터 시리즈 (한 줄기 막대/선 등)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct DataSeries {
     /// 시리즈 이름 (범례 표시용)
     pub name: String,
@@ -795,7 +795,7 @@ pub struct DataSeries {
 }
 
 /// 차트 개체 (GSO + HWPTAG_CHART_DATA)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct ChartShape {
     /// 공통 속성
     pub common: CommonObjAttr,
@@ -824,7 +824,7 @@ pub struct ChartShape {
 // ============================================================
 
 /// OLE 프리뷰 이미지 포맷
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize)]
 pub enum OlePreviewFormat {
     Wmf,
     Emf,
@@ -833,14 +833,14 @@ pub enum OlePreviewFormat {
 }
 
 /// OLE 프리뷰 이미지
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct OlePreview {
     pub format: OlePreviewFormat,
     pub bytes: Vec<u8>,
 }
 
 /// OLE 표시 방식 (DrawingAspect)
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum OleDrawingAspect {
     #[default]
     Content,
@@ -850,7 +850,7 @@ pub enum OleDrawingAspect {
 }
 
 /// OLE 개체 (HWPTAG_SHAPE_COMPONENT_OLE)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct OleShape {
     /// 공통 속성
     pub common: CommonObjAttr,
@@ -870,6 +870,11 @@ pub struct OleShape {
     pub preview: Option<OlePreview>,
     /// OLE 레코드 원본 바이트 (라운드트립 보존)
     pub raw_tag_data: Vec<u8>,
+    /// [#4495] raw_tag_data 출처 봉인 — 봉인 시점 OLE payload 모델 필드
+    /// (extent_x/extent_y/bin_data_id)의 다이제스트. 저장 시 그 필드들이 봉인과
+    /// 같을 때만 raw 를 재사용한다. None 은 종전 계약(raw 우선) 유지.
+    #[serde(skip)]
+    pub raw_tag_seal: Option<[u8; 32]>,
     /// 캡션
     pub caption: Option<Caption>,
     /// [#3546] HWPX `<hp:chart chartIDRef="...">` 출신 표식 — chartIDRef 원문.

--- a/src/model/style.rs
+++ b/src/model/style.rs
@@ -48,7 +48,7 @@ pub fn border_width_mm_str(index: u8) -> &'static str {
 }
 
 /// 글꼴 정보 (HWPTAG_FACE_NAME)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Font {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -81,7 +81,7 @@ pub struct Font {
 /// 4개 속성을 모두 보존해 라운드트립 무손실을 보장한다. `font_type`/`is_embedded`/
 /// `bin_item_id_ref` 는 부모 `<hh:font>` 의 같은 이름 속성과 독립적이다
 /// (예: HFT 글꼴이 TTF 대체 글꼴을 가질 수 있음).
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
 pub struct SubstFont {
     /// 대체 글꼴 이름
     pub face: String,
@@ -99,7 +99,7 @@ pub struct SubstFont {
 ///
 /// `Default` 는 [수동 구현](#impl-Default-for-CharShape)이다 — 파생하면 `relative_sizes` 가
 /// 스펙 위반값 0 이 된다(#4141).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct CharShape {
     /// 원본 레코드 바이트 (라운드트립 보존용, 있으면 직렬화 시 우선 사용)
     pub raw_data: Option<Vec<u8>>,
@@ -293,7 +293,7 @@ pub enum UnderlineType {
 }
 
 /// 문단 머리 모양 종류 (attr1 bit 23~24)
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum HeadType {
     /// 없음
     #[default]
@@ -307,7 +307,7 @@ pub enum HeadType {
 }
 
 /// 문단 모양 (HWPTAG_PARA_SHAPE)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct ParaShape {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -382,7 +382,7 @@ impl PartialEq for ParaShape {
 impl Eq for ParaShape {}
 
 /// 문단 번호 정의 (HWPTAG_NUMBERING)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Numbering {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -403,7 +403,7 @@ pub struct Numbering {
 }
 
 /// 문단 머리 정보 (표 41)
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
 pub struct NumberingHead {
     /// 속성 (정렬, 너비 따름, 자동 내어쓰기 등)
     pub attr: u32,
@@ -418,7 +418,7 @@ pub struct NumberingHead {
 }
 
 /// 글머리표 정의 (HWPTAG_BULLET, 표 44, 24바이트)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Bullet {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -445,7 +445,7 @@ pub struct Bullet {
 }
 
 /// 텍스트 정렬 방식
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum Alignment {
     #[default]
     Justify,
@@ -457,7 +457,7 @@ pub enum Alignment {
 }
 
 /// 줄 간격 종류
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum LineSpacingType {
     #[default]
     Percent,
@@ -467,7 +467,7 @@ pub enum LineSpacingType {
 }
 
 /// 탭 정의 (HWPTAG_TAB_DEF)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct TabDef {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -482,7 +482,7 @@ pub struct TabDef {
 }
 
 /// 탭 항목
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct TabItem {
     /// 탭 위치
     pub position: HwpUnit,
@@ -511,7 +511,7 @@ impl PartialEq for TabDef {
 impl Eq for TabDef {}
 
 /// 스타일 (HWPTAG_STYLE)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Style {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -539,7 +539,7 @@ pub struct Style {
 }
 
 /// 테두리/배경 (HWPTAG_BORDER_FILL)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct BorderFill {
     /// 원본 레코드 바이트 (라운드트립 보존용)
     pub raw_data: Option<Vec<u8>>,
@@ -558,7 +558,7 @@ pub struct BorderFill {
 }
 
 /// 중심선 방향 (HWPX borderFill@centerLine)
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize)]
 pub enum CenterLine {
     /// 없음
     #[default]
@@ -623,7 +623,7 @@ impl CenterLine {
 }
 
 /// 테두리선 정보
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
 pub struct BorderLine {
     /// 선 종류
     pub line_type: BorderLineType,
@@ -635,7 +635,7 @@ pub struct BorderLine {
 
 /// 테두리선 종류 (HWP 스펙 표 27)
 /// 0=선없음, 1=실선, 2=파선, 3=점선, ...
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum BorderLineType {
     /// 선 없음 (0)
     None,
@@ -677,7 +677,7 @@ pub enum BorderLineType {
 }
 
 /// 대각선 정보
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
 pub struct DiagonalLine {
     /// 대각선 선 종류 코드. BorderLineType의 HWP/HWPX 코드와 같은 값을 사용한다.
     pub diagonal_type: u8,
@@ -688,7 +688,7 @@ pub struct DiagonalLine {
 }
 
 /// 채우기 정보
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Fill {
     /// 채우기 종류
     pub fill_type: FillType,
@@ -703,7 +703,7 @@ pub struct Fill {
 }
 
 /// 채우기 종류
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum FillType {
     #[default]
     None,
@@ -713,7 +713,7 @@ pub enum FillType {
 }
 
 /// 단색 채우기
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
 pub struct SolidFill {
     /// 배경색
     pub background_color: ColorRef,
@@ -724,7 +724,7 @@ pub struct SolidFill {
 }
 
 /// 그러데이션 채우기
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct GradientFill {
     /// 유형 (1: 줄무늬, 2: 원형, 3: 원뿔형, 4: 사각형)
     pub gradient_type: i16,
@@ -745,7 +745,7 @@ pub struct GradientFill {
 }
 
 /// 이미지 채우기
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct ImageFill {
     /// 채우기 유형
     pub fill_mode: ImageFillMode,

--- a/src/model/style.rs
+++ b/src/model/style.rs
@@ -783,7 +783,7 @@ pub enum ImageFillMode {
 }
 
 /// 테두리 선 정보 (그리기 개체용)
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
 pub struct ShapeBorderLine {
     /// 선 색상
     pub color: ColorRef,

--- a/src/model/table.rs
+++ b/src/model/table.rs
@@ -26,7 +26,7 @@ std::thread_local! {
 }
 
 /// 표 개체 (HWPTAG_TABLE)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct Table {
     /// 속성 비트 플래그
     pub attr: u32,
@@ -64,6 +64,12 @@ pub struct Table {
     pub outer_margin_bottom: i16,
     /// CTRL_HEADER ctrl_data의 4바이트(attr) 이후 추가 바이트 (라운드트립 보존용)
     pub raw_ctrl_data: Vec<u8>,
+    /// [#4495] raw_ctrl_data 출처 봉인 — 봉인 시점 `common`(CommonObjAttr) 의
+    /// 다이제스트. 저장 시 `common` 이 봉인과 같을 때만 raw 를 재사용한다.
+    /// None(합성 IR·봉인 이전)은 종전 계약(raw 우선) 유지. 다이제스트 밖 —
+    /// `model::raw_provenance` 참조.
+    #[serde(skip)]
+    pub raw_ctrl_seal: Option<[u8; 32]>,
     /// HWPTAG_TABLE 레코드의 원본 속성 값 (라운드트립 보존용, 0이면 재구성)
     pub raw_table_record_attr: u32,
     /// HWPTAG_TABLE 레코드의 border_fill_id 이후 추가 바이트 (라운드트립 보존용)
@@ -91,7 +97,7 @@ pub struct Table {
 
 /// 표 쪽 나눔 종류
 /// bit 0-1: 0=나누지 않음, 1=셀 단위로 나눔, 2=나눔(행 단위)
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum TablePageBreak {
     /// 나누지 않음 (0)
     #[default]
@@ -103,7 +109,7 @@ pub enum TablePageBreak {
 }
 
 /// 표 영역 속성
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct TableZone {
     /// 시작 열 주소
     pub start_col: u16,
@@ -118,7 +124,7 @@ pub struct TableZone {
 }
 
 /// 표 셀 (HWPTAG_LIST_HEADER + 셀 속성)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct Cell {
     /// 셀 열 주소 (0부터 시작)
     pub col: u16,
@@ -195,7 +201,7 @@ fn checked_table_span_end(start: u16, span: u16, axis: &str) -> Result<u16, Stri
 }
 
 /// 세로 정렬
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum VerticalAlign {
     #[default]
     Top,

--- a/src/parser/hml/adapter.rs
+++ b/src/parser/hml/adapter.rs
@@ -43,6 +43,7 @@ pub(crate) fn into_document(mut source: HmlSource) -> Result<Document, HmlError>
         document.sections.push(Section {
             section_def,
             paragraphs,
+            raw_provenance: None,
             raw_stream: None,
         });
     }

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -3993,6 +3993,7 @@ fn parse_hwp3_inner(
     let section = Section {
         section_def,
         paragraphs,
+        raw_provenance: None,
         raw_stream: None,
     };
     doc.sections.push(section);

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -6203,6 +6203,7 @@ fn parse_equation(
         font_name,
         version_info,
         raw_ctrl_data: Vec::new(),
+        raw_ctrl_seal: None,
     };
     Ok(Control::Equation(Box::new(equation)))
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1476,6 +1476,10 @@ fn parse_document_inner(
         .document
         .doc_info
         .seal_raw_provenance(&parsed.document.doc_properties);
+    // [#4488/#4495] 본문 Section raw_stream 과 하위 컨트롤 raw 레코드도 같은
+    // 지점에서 봉인한다. DocumentCore 로 열리는 경로는 from_bytes 의 로드 픽스업
+    // (손상 lineseg 제거 등) 뒤에 다시 봉인된다.
+    parsed.document.seal_body_raw_provenance();
     Ok(parsed)
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1467,6 +1467,22 @@ fn parse_document_inner(
     data: &[u8],
     password: Option<&[u8]>,
 ) -> Result<ParsedDocument, ParseError> {
+    let mut parsed = parse_document_inner_unsealed(data, password)?;
+    // [#4493] 파싱과 모든 load fixup 이 끝난 마지막 지점에서 DocInfo raw 출처를
+    // 봉인한다 — 이보다 앞(포맷별 파서 내부)에서 봉인하면 HWP3-변환본 spacing
+    // 반감 같은 로드 보정이 봉인을 깨서, 무변경 문서의 원본 바이트 통과가 죽는다.
+    // raw 캐시가 없는 포맷(HWPX/HWP3/HML)에서는 no-op.
+    parsed
+        .document
+        .doc_info
+        .seal_raw_provenance(&parsed.document.doc_properties);
+    Ok(parsed)
+}
+
+fn parse_document_inner_unsealed(
+    data: &[u8],
+    password: Option<&[u8]>,
+) -> Result<ParsedDocument, ParseError> {
     let open_policy = document_open_decompression_policy();
     match detect_format(data) {
         FileFormat::Hwp => {

--- a/src/serializer/body_text.rs
+++ b/src/serializer/body_text.rs
@@ -24,9 +24,16 @@ use crate::parser::tags;
 
 /// Section을 레코드 바이너리 스트림으로 직렬화
 pub fn serialize_section(section: &Section) -> Vec<u8> {
-    // 원본 스트림이 있으면 그대로 반환 (완벽한 라운드트립)
-    if let Some(ref raw) = section.raw_stream {
-        return raw.clone();
+    // 원본 스트림이 있으면 그대로 반환 (완벽한 라운드트립).
+    //
+    // [#4488] 다만 공개 모델 직접 변경은 raw_stream 을 무효화하지 않으므로,
+    // 파싱(+로드 픽스업) 시점에 봉인한 (모델, raw) 다이제스트 쌍과 현재 상태가
+    // 둘 다 일치할 때만 통과한다 — 불일치·raw 교체는 아래 모델 writer 로
+    // 재생성한다. 봉인 계약은 model::raw_provenance 참조.
+    if section.raw_provenance_permits_reuse() {
+        if let Some(ref raw) = section.raw_stream {
+            return raw.clone();
+        }
     }
 
     // [Task #852 Stage 2.4] Form 컨트롤의 z-order/TabOrder 카운터 reset.
@@ -1280,6 +1287,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1308,6 +1316,7 @@ mod tests {
             let section = Section {
                 paragraphs: vec![para],
                 raw_stream: None,
+                raw_provenance: None,
                 ..Default::default()
             };
             let parsed = parse_body_text_section(&serialize_section(&section)).unwrap();
@@ -1352,6 +1361,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
         let parsed = parse_body_text_section(&serialize_section(&section)).unwrap();
@@ -1392,6 +1402,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
         let parsed = parse_body_text_section(&serialize_section(&section)).unwrap();
@@ -1431,6 +1442,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
         let parsed = parse_body_text_section(&serialize_section(&section)).unwrap();
@@ -1469,6 +1481,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
         let parsed = parse_body_text_section(&serialize_section(&section)).unwrap();
@@ -1502,6 +1515,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1532,6 +1546,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1563,6 +1578,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1583,6 +1599,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1633,6 +1650,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para1, para2],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1672,6 +1690,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1713,6 +1732,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1762,6 +1782,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1804,6 +1825,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1839,6 +1861,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1885,6 +1908,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1924,6 +1948,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -2119,6 +2144,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -2170,6 +2196,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -2231,6 +2258,7 @@ mod tests {
             },
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
         };
 
         let bytes = serialize_section(&section);
@@ -2295,6 +2323,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -2353,6 +2382,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 

--- a/src/serializer/cfb_writer/tests.rs
+++ b/src/serializer/cfb_writer/tests.rs
@@ -63,6 +63,7 @@ fn test_serialize_hwp_cfb_streams() {
                 ..Default::default()
             }],
             raw_stream: None,
+            raw_provenance: None,
         }],
         preview: None,
         bin_data_content: Vec::new(),
@@ -210,6 +211,7 @@ fn test_full_roundtrip_uncompressed() {
                 ..Default::default()
             }],
             raw_stream: None,
+            raw_provenance: None,
         }],
         preview: None,
         bin_data_content: Vec::new(),
@@ -290,6 +292,7 @@ fn test_full_roundtrip_compressed() {
                 ..Default::default()
             }],
             raw_stream: None,
+            raw_provenance: None,
         }],
         preview: None,
         bin_data_content: Vec::new(),
@@ -1679,6 +1682,7 @@ fn test_ole_storage_size_prefix_restored() {
                 ..Default::default()
             }],
             raw_stream: None,
+            raw_provenance: None,
         }],
         preview: None,
         bin_data_content: vec![BinDataContent {
@@ -1766,6 +1770,7 @@ fn test_compressed_ole_storage_payload_is_deflated() {
                 ..Default::default()
             }],
             raw_stream: None,
+            raw_provenance: None,
         }],
         preview: None,
         bin_data_content: vec![BinDataContent {

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -575,8 +575,15 @@ fn serialize_table(table: &Table, level: u16, records: &mut Vec<Record>) {
     // IR 의 common 으로 합성한다 (attr=0 이면 pack_common_attr_bits 경유 —
     // flow_with_text bit 13 포함). HWP5 파스본(raw 보존)·어댑터 경로(Stage 2
     // 합성)는 raw_ctrl_data 가 채워져 있어 동작 불변.
+    // [#4495] raw 재사용은 봉인 검증을 거친다 — 공개 모델에서 `common` 을 직접
+    // 바꾸면(봉인 불일치) raw 대신 IR 합성으로 쓴다. 봉인 None(합성 IR·봉인
+    // 이전)은 종전 계약(raw 우선) 유지. raw 를 직접 갱신하는 기존 명령
+    // (refresh_raw_ctrl_size 의 dual-write)은 `common` 이 봉인과 같아 통과한다.
+    let raw_permitted = table
+        .raw_ctrl_seal
+        .is_none_or(|sealed| sealed == crate::model::raw_provenance::record_digest(&table.common));
     let composed_common;
-    let ctrl_data: &[u8] = if !table.raw_ctrl_data.is_empty() {
+    let ctrl_data: &[u8] = if !table.raw_ctrl_data.is_empty() && raw_permitted {
         &table.raw_ctrl_data
     } else {
         composed_common = serialize_common_obj_attr(&table.common);
@@ -1984,7 +1991,12 @@ fn serialize_group_child(
 }
 
 fn serialize_ole_data(ole: &OleShape) -> Vec<u8> {
-    if !ole.raw_tag_data.is_empty() {
+    // [#4495] payload 모델 필드(extent_x/extent_y/bin_data_id)를 직접 바꾸면
+    // (봉인 불일치) raw 대신 모델 값으로 쓴다. 봉인 None 은 종전 계약 유지.
+    let raw_permitted = ole
+        .raw_tag_seal
+        .is_none_or(|sealed| sealed == crate::model::raw_provenance::ole_payload_digest(ole));
+    if !ole.raw_tag_data.is_empty() && raw_permitted {
         return ole.raw_tag_data.clone();
     }
 
@@ -2775,7 +2787,12 @@ fn build_header_footer_list_header(
 /// raw_ctrl_data를 보존하여 라운드트립 무손실 직렬화.
 fn serialize_equation_control(eq: &Equation, level: u16, records: &mut Vec<Record>) {
     // CTRL_HEADER with CommonObjAttr (또는 원본 ctrl_data)
-    let ctrl_data = if eq.raw_ctrl_data.is_empty() {
+    // [#4495] 표 CTRL_HEADER 와 동일한 봉인 검증 — `common` 직접 변경 시 raw 대신
+    // IR 합성으로 쓴다.
+    let raw_permitted = eq
+        .raw_ctrl_seal
+        .is_none_or(|sealed| sealed == crate::model::raw_provenance::record_digest(&eq.common));
+    let ctrl_data = if eq.raw_ctrl_data.is_empty() || !raw_permitted {
         serialize_common_obj_attr(&eq.common)
     } else {
         eq.raw_ctrl_data.clone()

--- a/src/serializer/doc_info.rs
+++ b/src/serializer/doc_info.rs
@@ -13,6 +13,7 @@ use super::record_writer::write_record;
 
 use crate::model::bin_data::{BinData, BinDataType};
 use crate::model::document::{DocInfo, DocProperties};
+use crate::model::raw_provenance;
 use crate::model::style::{
     BorderFill, BorderLineType, Bullet, CenterLine, FillType, Font, ImageFillMode, Numbering,
     ParaShape, Style, TabDef,
@@ -21,8 +22,13 @@ use crate::parser::tags;
 
 /// DocInfo + DocProperties를 레코드 바이너리 스트림으로 직렬화
 pub fn serialize_doc_info(doc_info: &DocInfo, doc_props: &DocProperties) -> Vec<u8> {
-    // 원본 스트림이 있고 변경되지 않았으면 그대로 반환 (완벽한 라운드트립)
-    if !doc_info.raw_stream_dirty {
+    // 원본 스트림이 있고 변경되지 않았으면 그대로 반환 (완벽한 라운드트립).
+    //
+    // [#4493] "변경되지 않았음" 은 dirty 표식만으로 판정하지 않는다 — 공개 모델
+    // 필드 직접 변경은 표식을 세우지 않으므로, 파싱 시점에 봉인한 (모델, raw)
+    // 다이제스트 쌍과 현재 상태가 둘 다 일치할 때만 통과한다(불일치·raw 교체는
+    // 아래 모델 writer 로 재생성). 봉인 계약은 model::raw_provenance 참조.
+    if !doc_info.raw_stream_dirty && doc_info.raw_provenance_permits_reuse(doc_props) {
         if let Some(ref raw) = doc_info.raw_stream {
             let mut result = raw.clone();
             // 배포용 문서 해제 시 DISTRIBUTE_DOC_DATA 레코드 제거
@@ -35,11 +41,22 @@ pub fn serialize_doc_info(doc_info: &DocInfo, doc_props: &DocProperties) -> Vec<
 
     let mut stream = Vec::new();
 
+    // [#4493] 레코드별 raw_data 지름길도 봉인 검증을 거친다 — 스트림이 재생성될
+    // 때(공개 모델 직접 변경 등) 변경되지 않은 레코드만 원본 바이트를 재사용하고,
+    // 변경된 레코드는 모델 writer 로 다시 쓴다. 봉인이 없는 합성 IR(record_seals
+    // 부재)은 종전 계약(무조건 raw 우선)을 유지한다.
+    let seals = doc_info.raw_provenance.as_ref().map(|s| &s.record_seals);
+
     // 1. DOCUMENT_PROPERTIES
+    let props_data = match (doc_props.raw_data.as_ref(), seals) {
+        (Some(raw), None) => raw.clone(),
+        (Some(raw), Some(s)) if s.props == raw_provenance::record_digest(doc_props) => raw.clone(),
+        _ => serialize_document_properties_from_model(doc_props),
+    };
     stream.extend(write_record(
         tags::HWPTAG_DOCUMENT_PROPERTIES,
         0,
-        &serialize_document_properties(doc_props),
+        &props_data,
     ));
 
     // 2. ID_MAPPINGS
@@ -49,74 +66,90 @@ pub fn serialize_doc_info(doc_info: &DocInfo, doc_props: &DocProperties) -> Vec<
         &serialize_id_mappings(doc_info),
     ));
 
+    // 레코드 봉인 게이트 — raw_data 가 있고 봉인이 허용할 때만 raw 재사용.
+    fn sealed_raw<'a, T: serde::Serialize>(
+        record: &'a T,
+        raw: &'a Option<Vec<u8>>,
+        seals: Option<&[[u8; 32]]>,
+        idx: usize,
+    ) -> Option<&'a Vec<u8>> {
+        raw.as_ref()
+            .filter(|_| raw_provenance::record_raw_permitted(seals, idx, record))
+    }
+
     // 3~10: ID_MAPPINGS 하위 레코드 (모두 level 1)
-    for bin_data in &doc_info.bin_data_list {
-        let data = bin_data
-            .raw_data
-            .clone()
-            .unwrap_or_else(|| serialize_bin_data(bin_data));
+    for (i, bin_data) in doc_info.bin_data_list.iter().enumerate() {
+        let data = sealed_raw(
+            bin_data,
+            &bin_data.raw_data,
+            seals.map(|s| &s.bin_data[..]),
+            i,
+        )
+        .cloned()
+        .unwrap_or_else(|| serialize_bin_data(bin_data));
         stream.extend(write_record(tags::HWPTAG_BIN_DATA, 1, &data));
     }
 
-    for lang_fonts in &doc_info.font_faces {
-        for font in lang_fonts {
-            let data = font
-                .raw_data
-                .clone()
+    for (li, lang_fonts) in doc_info.font_faces.iter().enumerate() {
+        let lang_seals = seals.and_then(|s| s.fonts.get(li)).map(|v| &v[..]);
+        for (fi, font) in lang_fonts.iter().enumerate() {
+            let data = sealed_raw(font, &font.raw_data, lang_seals, fi)
+                .cloned()
                 .unwrap_or_else(|| serialize_face_name(font));
             stream.extend(write_record(tags::HWPTAG_FACE_NAME, 1, &data));
         }
     }
 
-    for bf in &doc_info.border_fills {
-        let data = bf
-            .raw_data
-            .clone()
+    for (i, bf) in doc_info.border_fills.iter().enumerate() {
+        let data = sealed_raw(bf, &bf.raw_data, seals.map(|s| &s.border_fills[..]), i)
+            .cloned()
             .unwrap_or_else(|| serialize_border_fill(bf));
         stream.extend(write_record(tags::HWPTAG_BORDER_FILL, 1, &data));
     }
 
-    for cs in &doc_info.char_shapes {
-        let data = cs
-            .raw_data
-            .clone()
+    for (i, cs) in doc_info.char_shapes.iter().enumerate() {
+        let data = sealed_raw(cs, &cs.raw_data, seals.map(|s| &s.char_shapes[..]), i)
+            .cloned()
             .unwrap_or_else(|| serialize_char_shape(cs));
         stream.extend(write_record(tags::HWPTAG_CHAR_SHAPE, 1, &data));
     }
 
-    for td in &doc_info.tab_defs {
-        let data = td.raw_data.clone().unwrap_or_else(|| serialize_tab_def(td));
+    for (i, td) in doc_info.tab_defs.iter().enumerate() {
+        let data = sealed_raw(td, &td.raw_data, seals.map(|s| &s.tab_defs[..]), i)
+            .cloned()
+            .unwrap_or_else(|| serialize_tab_def(td));
         stream.extend(write_record(tags::HWPTAG_TAB_DEF, 1, &data));
     }
 
-    for numbering in &doc_info.numberings {
-        let data = numbering
-            .raw_data
-            .clone()
-            .unwrap_or_else(|| serialize_numbering(numbering));
+    for (i, numbering) in doc_info.numberings.iter().enumerate() {
+        let data = sealed_raw(
+            numbering,
+            &numbering.raw_data,
+            seals.map(|s| &s.numberings[..]),
+            i,
+        )
+        .cloned()
+        .unwrap_or_else(|| serialize_numbering(numbering));
         stream.extend(write_record(tags::HWPTAG_NUMBERING, 1, &data));
     }
 
-    for bullet in &doc_info.bullets {
-        let data = bullet
-            .raw_data
-            .clone()
+    for (i, bullet) in doc_info.bullets.iter().enumerate() {
+        let data = sealed_raw(bullet, &bullet.raw_data, seals.map(|s| &s.bullets[..]), i)
+            .cloned()
             .unwrap_or_else(|| serialize_bullet(bullet));
         stream.extend(write_record(tags::HWPTAG_BULLET, 1, &data));
     }
 
-    for ps in &doc_info.para_shapes {
-        let data = ps
-            .raw_data
-            .clone()
+    for (i, ps) in doc_info.para_shapes.iter().enumerate() {
+        let data = sealed_raw(ps, &ps.raw_data, seals.map(|s| &s.para_shapes[..]), i)
+            .cloned()
             .unwrap_or_else(|| serialize_para_shape(ps));
         stream.extend(write_record(tags::HWPTAG_PARA_SHAPE, 1, &data));
     }
 
-    for style in &doc_info.styles {
-        let data = style
-            .raw_data
-            .clone()
+    for (i, style) in doc_info.styles.iter().enumerate() {
+        let data = sealed_raw(style, &style.raw_data, seals.map(|s| &s.styles[..]), i)
+            .cloned()
             .unwrap_or_else(|| serialize_style(style));
         stream.extend(write_record(tags::HWPTAG_STYLE, 1, &data));
     }
@@ -138,6 +171,12 @@ pub fn serialize_document_properties(props: &DocProperties) -> Vec<u8> {
     if let Some(ref raw) = props.raw_data {
         return raw.clone();
     }
+    serialize_document_properties_from_model(props)
+}
+
+/// [#4493] raw_data 를 무시하고 모델 값으로 DOCUMENT_PROPERTIES 를 쓴다 —
+/// 봉인 검증이 "모델이 바뀌었다" 고 판정한 경로 전용.
+fn serialize_document_properties_from_model(props: &DocProperties) -> Vec<u8> {
     let mut w = ByteWriter::new();
     w.write_u16(props.section_count).unwrap();
     w.write_u16(props.page_start_num).unwrap();

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -780,6 +780,7 @@ mod tests {
             font_name: "HYhwpEQ".to_string(),
             version_info: "Equation Version 60".to_string(),
             raw_ctrl_data: Vec::new(),
+            raw_ctrl_seal: None,
         })));
         section.paragraphs.push(para);
         doc.sections.push(section);

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -1807,6 +1807,7 @@ fn test_document_with_paragraphs() {
             },
         ],
         raw_stream: None,
+        raw_provenance: None,
     });
     doc.set_document(document);
 
@@ -2016,6 +2017,7 @@ fn create_doc_with_table() -> HwpDocument {
         },
         paragraphs: vec![parent_para],
         raw_stream: None,
+        raw_provenance: None,
     });
     doc.set_document(document);
     doc
@@ -2102,6 +2104,7 @@ fn create_doc_with_page_count_boundary_table() -> HwpDocument {
         },
         paragraphs: vec![parent_para],
         raw_stream: None,
+        raw_provenance: None,
     });
     doc.set_document(document);
     doc
@@ -4690,6 +4693,7 @@ fn create_doc_with_floating_picture(tac: bool, voff: u32, hoff: u32) -> HwpDocum
         },
         paragraphs: vec![pic_para, Paragraph::default()],
         raw_stream: None,
+        raw_provenance: None,
     });
     doc.set_document(document);
     doc

--- a/tests/issue_4488_4495_body_provenance.rs
+++ b/tests/issue_4488_4495_body_provenance.rs
@@ -1,0 +1,211 @@
+//! [Issue #4488/#4495] 공개 저수준 `parse_document → Document 직접 변경 →
+//! serialize_document` 경로에서 본문 변경이 Section `raw_stream`(#4488)과 하위
+//! 컨트롤 raw 레코드(#4495)에 가려져 조용히 사라지던 계약을 고정한다.
+//!
+//! - 무변경 문서는 Section 레코드 스트림 바이트를 정확히 재사용한다.
+//! - 공개 본문 텍스트·중첩 표 셀 텍스트 직접 변경은 저장·재로드 뒤 유지된다.
+//! - 표 CTRL_HEADER 의 모델 필드(`common`) 직접 변경도 유지된다 — raw_ctrl_data
+//!   가 남아 있어도 봉인 불일치로 IR 합성 경로를 탄다.
+//! - 공개 `raw_stream` 을 다른 바이트로 교체해도 봉인으로 승인되지 않는다.
+
+use rhwp::model::control::Control;
+use rhwp::{parse_document, serialize_document};
+
+const SAMPLE: &str = "samples/2026_oss_rst.hwp";
+const TABLE_SAMPLE: &str = "samples/basic/issue2007_nested_cell_pagination_42065.hwp";
+
+fn read_sample(rel: &str) -> Vec<u8> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    std::fs::read(&path).unwrap_or_else(|e| panic!("read {rel}: {e}"))
+}
+
+#[test]
+fn unchanged_parse_serialize_reuses_section_raw_bytes() {
+    let doc = parse_document(&read_sample(SAMPLE)).expect("parse");
+    let original: Vec<Vec<u8>> = doc
+        .sections
+        .iter()
+        .map(|s| {
+            assert!(
+                s.raw_provenance.is_some(),
+                "파서가 만든 문서에는 Section 봉인이 있어야 한다 (#4488)"
+            );
+            s.raw_stream.clone().expect("HWP5 Section raw 캐시")
+        })
+        .collect();
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    for (i, sec) in reparsed.sections.iter().enumerate() {
+        assert_eq!(
+            sec.raw_stream.as_ref(),
+            Some(&original[i]),
+            "무변경 구역 {i} 의 레코드 스트림은 바이트 그대로 통과해야 한다"
+        );
+    }
+}
+
+/// 본문 문단 텍스트를 같은 길이로 바꿔치기 — 길이 불변이라 char_count·char_shapes
+/// 경계에 영향을 주지 않는 가장 보수적인 공개 직접 변경.
+fn swap_first_char_of_longest_para(
+    doc: &mut rhwp::model::document::Document,
+) -> (usize, usize, String) {
+    let (si, pi) = {
+        let mut best = (0usize, 0usize, 0usize);
+        for (si, sec) in doc.sections.iter().enumerate() {
+            for (pi, para) in sec.paragraphs.iter().enumerate() {
+                let len = para.text.chars().count();
+                if len > best.2 {
+                    best = (si, pi, len);
+                }
+            }
+        }
+        assert!(best.2 >= 3, "샘플 전제: 본문 텍스트 문단이 있어야 한다");
+        (best.0, best.1)
+    };
+    let para = &mut doc.sections[si].paragraphs[pi];
+    let mut chars: Vec<char> = para.text.chars().collect();
+    let idx = chars
+        .iter()
+        .position(|c| *c != 'Ｘ' && !c.is_control())
+        .expect("교체할 글자");
+    chars[idx] = 'Ｘ'; // 전각 문자 — UTF-16 1유닛 유지
+    para.text = chars.into_iter().collect();
+    (si, pi, doc.sections[si].paragraphs[pi].text.clone())
+}
+
+#[test]
+fn public_body_text_mutation_survives_save_reload() {
+    let mut doc = parse_document(&read_sample(SAMPLE)).expect("parse");
+    let (si, pi, mutated) = swap_first_char_of_longest_para(&mut doc);
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    assert_eq!(
+        reparsed.sections[si].paragraphs[pi].text, mutated,
+        "공개 본문 텍스트 직접 변경이 저장·재로드 뒤 유지돼야 한다 (#4488)"
+    );
+}
+
+/// 첫 번째 표를 (구역, 문단, 컨트롤) 좌표로 찾는다.
+fn find_first_table(doc: &rhwp::model::document::Document) -> (usize, usize, usize) {
+    for (si, sec) in doc.sections.iter().enumerate() {
+        for (pi, para) in sec.paragraphs.iter().enumerate() {
+            for (ci, ctrl) in para.controls.iter().enumerate() {
+                if matches!(ctrl, Control::Table(_)) {
+                    return (si, pi, ci);
+                }
+            }
+        }
+    }
+    panic!("샘플 전제: 표가 있어야 한다");
+}
+
+#[test]
+fn nested_table_cell_text_mutation_survives_save_reload() {
+    let mut doc = parse_document(&read_sample(TABLE_SAMPLE)).expect("parse");
+    let (si, pi, ci) = find_first_table(&doc);
+    let Control::Table(table) = &mut doc.sections[si].paragraphs[pi].controls[ci] else {
+        unreachable!()
+    };
+    let (cell_idx, cp_idx) = {
+        let mut found = None;
+        'outer: for (celli, cell) in table.cells.iter().enumerate() {
+            for (cpi, cp) in cell.paragraphs.iter().enumerate() {
+                if cp.text.chars().count() >= 2 && cp.text.chars().any(|c| !c.is_control()) {
+                    found = Some((celli, cpi));
+                    break 'outer;
+                }
+            }
+        }
+        found.expect("샘플 전제: 텍스트 있는 셀 문단")
+    };
+    let cp = &mut table.cells[cell_idx].paragraphs[cp_idx];
+    let mut chars: Vec<char> = cp.text.chars().collect();
+    let idx = chars.iter().position(|c| !c.is_control()).unwrap();
+    chars[idx] = 'Ｘ';
+    cp.text = chars.into_iter().collect();
+    let mutated = cp.text.clone();
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    let Control::Table(table2) = &reparsed.sections[si].paragraphs[pi].controls[ci] else {
+        panic!("표가 유지돼야 한다")
+    };
+    assert_eq!(
+        table2.cells[cell_idx].paragraphs[cp_idx].text, mutated,
+        "중첩 표 셀 텍스트 직접 변경이 저장·재로드 뒤 유지돼야 한다 (#4488)"
+    );
+}
+
+#[test]
+fn table_common_mutation_survives_despite_raw_ctrl_data() {
+    let mut doc = parse_document(&read_sample(TABLE_SAMPLE)).expect("parse");
+    let (si, pi, ci) = find_first_table(&doc);
+    let new_margin_top = {
+        let Control::Table(table) = &mut doc.sections[si].paragraphs[pi].controls[ci] else {
+            unreachable!()
+        };
+        assert!(
+            !table.raw_ctrl_data.is_empty(),
+            "샘플 전제: HWP5 표는 raw_ctrl_data 를 갖는다"
+        );
+        assert!(
+            table.raw_ctrl_seal.is_some(),
+            "파서가 만든 표에는 CTRL_HEADER 봉인이 있어야 한다 (#4495)"
+        );
+        let v = table.common.margin.top + 37;
+        table.common.margin.top = v;
+        v
+    };
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    let Control::Table(table2) = &reparsed.sections[si].paragraphs[pi].controls[ci] else {
+        panic!("표가 유지돼야 한다")
+    };
+    assert_eq!(
+        table2.common.margin.top, new_margin_top,
+        "표 CTRL_HEADER 모델 필드 직접 변경이 raw_ctrl_data 에 가려지면 안 된다 (#4495)"
+    );
+}
+
+#[test]
+fn unchanged_table_keeps_raw_ctrl_bytes_when_body_elsewhere_changes() {
+    // 다른 곳(본문 문단)이 바뀌어 구역이 재생성돼도, 변경되지 않은 표의
+    // CTRL_HEADER 는 원본 raw 바이트를 유지해야 한다(하위 raw 전면 폐기 금지).
+    let mut doc = parse_document(&read_sample(TABLE_SAMPLE)).expect("parse");
+    let (si, pi, ci) = find_first_table(&doc);
+    let original_raw = {
+        let Control::Table(table) = &doc.sections[si].paragraphs[pi].controls[ci] else {
+            unreachable!()
+        };
+        table.raw_ctrl_data.clone()
+    };
+    swap_first_char_of_longest_para(&mut doc);
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    let Control::Table(table2) = &reparsed.sections[si].paragraphs[pi].controls[ci] else {
+        panic!("표가 유지돼야 한다")
+    };
+    assert_eq!(
+        table2.raw_ctrl_data, original_raw,
+        "무변경 표의 CTRL_HEADER raw 는 유지돼야 한다"
+    );
+}
+
+#[test]
+fn swapped_section_raw_stream_is_not_honored() {
+    let mut doc = parse_document(&read_sample(SAMPLE)).expect("parse");
+    let para_count = doc.sections[0].paragraphs.len();
+    doc.sections[0].raw_stream = Some(vec![0xDE; 64]);
+
+    let out = serialize_document(&doc).expect("교체 raw 는 무시되고 모델로 재생성돼야 한다");
+    let reparsed = parse_document(&out).expect("산출물은 정상 문서여야 한다");
+    assert_eq!(
+        reparsed.sections[0].paragraphs.len(),
+        para_count,
+        "산출물은 교체 바이트가 아니라 모델 상태를 담아야 한다 (#4488)"
+    );
+}

--- a/tests/issue_4493_docinfo_provenance.rs
+++ b/tests/issue_4493_docinfo_provenance.rs
@@ -1,0 +1,132 @@
+//! [Issue #4493] 공개 저수준 `parse_document → Document 직접 변경 →
+//! serialize_document` 경로에서 DocInfo 변경이 원본 raw 캐시(스트림·레코드)에
+//! 가려져 조용히 사라지던 계약을 고정한다.
+//!
+//! - 무변경 문서는 원본 DocInfo 레코드 스트림 바이트를 정확히 재사용한다.
+//! - 공개 모델 직접 변경(char_shape·doc_properties)은 저장·재로드 뒤 유지된다.
+//! - 공개 `raw_stream` 을 다른 바이트로 교체해도 기존 봉인으로 승인되지 않는다.
+//! - [#4432] &mut 저장 경로는 저장 성공 시 dirty 를 내리고 raw 캐시를 재밀봉한다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::{parse_document, serialize_document};
+
+const SAMPLE: &str = "samples/2026_oss_rst.hwp";
+
+fn sample_bytes() -> Vec<u8> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    std::fs::read(&path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"))
+}
+
+#[test]
+fn unchanged_parse_serialize_reuses_docinfo_raw_bytes() {
+    let doc = parse_document(&sample_bytes()).expect("parse");
+    let original_raw = doc
+        .doc_info
+        .raw_stream
+        .clone()
+        .expect("HWP5 파싱은 DocInfo raw 캐시를 채운다");
+    assert!(
+        doc.doc_info.raw_provenance.is_some(),
+        "파서가 만든 문서에는 봉인이 있어야 한다 (#4493)"
+    );
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    assert_eq!(
+        reparsed.doc_info.raw_stream.as_ref(),
+        Some(&original_raw),
+        "무변경 문서의 DocInfo 레코드 스트림은 바이트 그대로 통과해야 한다"
+    );
+}
+
+#[test]
+fn public_char_shape_mutation_survives_save_reload() {
+    let mut doc = parse_document(&sample_bytes()).expect("parse");
+    assert!(!doc.doc_info.char_shapes.is_empty());
+    let target = 0usize;
+    let new_size = doc.doc_info.char_shapes[target].base_size + 700;
+    // 공개 모델 직접 변경 — dirty 표식을 세우지 않는다(그게 이 이슈의 재현이다).
+    doc.doc_info.char_shapes[target].base_size = new_size;
+    assert!(!doc.doc_info.raw_stream_dirty);
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    assert_eq!(
+        reparsed.doc_info.char_shapes[target].base_size, new_size,
+        "공개 char_shape 직접 변경이 저장·재로드 뒤 유지돼야 한다 (#4493)"
+    );
+}
+
+#[test]
+fn public_doc_properties_mutation_survives_save_reload() {
+    let mut doc = parse_document(&sample_bytes()).expect("parse");
+    let new_start = doc.doc_properties.page_start_num + 4;
+    doc.doc_properties.page_start_num = new_start;
+    assert!(!doc.doc_info.raw_stream_dirty);
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    assert_eq!(
+        reparsed.doc_properties.page_start_num, new_start,
+        "공개 doc_properties 직접 변경이 저장·재로드 뒤 유지돼야 한다 (#4493)"
+    );
+}
+
+#[test]
+fn untouched_records_keep_raw_bytes_when_one_record_changes() {
+    // 레코드 봉인의 핵심: 하나가 바뀌어도 나머지 레코드는 원본 바이트를 유지한다
+    // (하위 raw 전면 폐기 금지 — 미모델링 바이트 보존).
+    let mut doc = parse_document(&sample_bytes()).expect("parse");
+    let untouched_raw = doc.doc_info.char_shapes[1].raw_data.clone();
+    assert!(
+        untouched_raw.is_some(),
+        "샘플 전제: 레코드 raw 가 있어야 한다"
+    );
+    doc.doc_info.char_shapes[0].base_size += 700;
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    assert_eq!(
+        reparsed.doc_info.char_shapes[1].raw_data, untouched_raw,
+        "변경되지 않은 레코드는 원본 바이트가 유지돼야 한다"
+    );
+}
+
+#[test]
+fn swapped_raw_stream_is_not_honored() {
+    let mut doc = parse_document(&sample_bytes()).expect("parse");
+    let char_shape_count = doc.doc_info.char_shapes.len();
+    // 봉인 이후 raw 바이트를 통째로 바꿔치기 — 승인되면 안 된다.
+    doc.doc_info.raw_stream = Some(vec![0xDE; 64]);
+
+    let out = serialize_document(&doc).expect("교체 raw 는 무시되고 모델로 재생성돼야 한다");
+    let reparsed = parse_document(&out).expect("산출물은 정상 문서여야 한다");
+    assert_eq!(
+        reparsed.doc_info.char_shapes.len(),
+        char_shape_count,
+        "산출물은 교체 바이트가 아니라 모델 상태를 담아야 한다 (#4493)"
+    );
+}
+
+#[test]
+fn issue_4432_save_lowers_dirty_and_reseals() {
+    let mut core = DocumentCore::from_bytes(&sample_bytes()).expect("open");
+    // dirty 를 세우는 통상 편집 경로 — 중앙 무효화 진입점(document_mut) 경유.
+    core.document_mut().doc_info.char_shapes[0].base_size += 700;
+    core.document_mut().doc_info.raw_stream_dirty = true;
+
+    let first = core.export_hwp_with_adapter().expect("save 1");
+    assert!(
+        !core.document().doc_info.raw_stream_dirty,
+        "저장 성공 지점에서 dirty 가 내려가야 한다 (#4432)"
+    );
+    let second = core.export_hwp_with_adapter().expect("save 2");
+    assert_eq!(first, second, "재밀봉 뒤 무변경 재저장은 같은 바이트");
+
+    // 재밀봉된 캐시가 실제 모델 상태와 정합해야 한다 — 재로드로 검증.
+    let reparsed = parse_document(&second).expect("reparse");
+    assert_eq!(
+        reparsed.doc_info.char_shapes[0].base_size,
+        core.document().doc_info.char_shapes[0].base_size
+    );
+}


### PR DESCRIPTION
## 변경 요약

공개 저수준 `parse_document → model::Document 직접 변경 → serialize_document` 경로에서 **본문** 변경이 Section `raw_stream`(#4488)과 하위 컨트롤 raw 레코드(#4495)에 가려져 조용히 사라지던 계약을 고칩니다. #4938(#4493 DocInfo 봉인)의 `model::raw_provenance` 인프라를 본문으로 확장한 것입니다.

> **의존**: 이 PR 은 #4938 위에 스택되어 있습니다 — #4938 이 먼저 머지되면 이 PR 의 diff 는 본문 축만 남습니다.

### [#4488] Section 봉인

- 파싱 말미(`parse_document_inner`)와 **DocumentCore 로드 경로의 마지막 지점**(`from_bytes_inner` 의 첫 `paginate()` 뒤 — 로드 픽스업(손상 lineseg 제거·빈 문단 reflow·안내문 제거)과 paginate 의 materialization(그림 img_dim 등)이 본문을 손보므로 그 뒤 재봉인이 필수. honbo-save 실측: paginate 전에 봉인하면 무변경 문서가 재생성 경로로 떨어져 `convert --verify` 래칫이 imgDim 차이로 깨진다) 두 지점에서 Section 의 (모델, raw) 다이제스트 쌍을 봉인합니다.
- `serialize_section` 은 raw 바이트와 모델 상태가 **둘 다** 봉인과 같을 때만 원본 바이트를 통과시키고, 공개 `raw_stream` 교체는 승인하지 않습니다. 봉인 없는 raw(합성 IR)는 종전 계약을 유지합니다.

### [#4495] 하위 컨트롤 raw 봉인

- Table·Equation CTRL_HEADER(`raw_ctrl_data`)와 OLE payload(`raw_tag_data`)에 컨트롤 단위 봉인(`raw_ctrl_seal`/`raw_tag_seal`, `#[serde(skip)]`)을 동승시켰습니다. 판정 범위는 각 raw 가 대표하는 모델 필드입니다 — Table/Equation 은 `common`(CommonObjAttr), OLE 는 `extent_x/extent_y/bin_data_id`. 셀 내용 편집처럼 그 레코드와 무관한 변경으로는 무효화되지 않아, **변경되지 않은 컨트롤의 미모델링 바이트가 보존됩니다**(전면 폐기 금지 조건).
- `raw_ctrl_data` 를 직접 갱신하는 기존 명령(dual-write, `refresh_raw_ctrl_size`)은 `common` 이 봉인과 같아 그대로 통과합니다 — 기존 계약 무충돌.
- 봉인 순회는 `for_each_ole_mut`(hwpx_to_hwp.rs)와 같은 소유자 집합을 밟습니다. 정본 순회기 부재(#4422)로 사본을 두었고 주석으로 연결했습니다 — 누락 소유자는 봉인 없이 남아 **종전 계약으로 동작**합니다(새 손실이 생기는 방향이 아님).
- FormObject.properties(HashMap)는 다이제스트 결정성을 위해 정렬 직렬화합니다.

### 부수

- 본문 모델 트리(~90종)에 `serde::Serialize` 파생 추가(다이제스트용, 동작 무변경).

### 알려진 인접 갭 (범위 밖)

`Table.common.treat_as_char` 같은 **비트-패킹 이중 표현 필드**는 봉인이 재생성을 강제해도 `serialize_common_obj_attr` 가 raw-first 로 `common.attr` 를 그대로 쓰므로 bool 단독 변경이 반영되지 않습니다 — 이는 provenance 가 아니라 attr↔bool 동기화 문제로, 별도 축입니다(이슈 코멘트로 남깁니다). 직접 직렬화되는 필드(`width`/`margin`/`z_order` 등)는 red→green 을 확인했습니다.

## 관련 이슈

closes #4488
closes #4495

## 테스트

- [x] `cargo test` 통과 — 신규 6건(`tests/issue_4488_4495_body_provenance.rs`): 무변경 구역 바이트 통과 유지 / 본문 텍스트·중첩 표 셀 텍스트 직접 변경 red→green / 표 `common` 직접 변경 red→green(raw_ctrl_data 존치 상태) / 무변경 표 CTRL_HEADER raw 보존 / Section raw 교체 불승인. 전체 nextest 게이트 통과
- [x] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 (해당 없음 — 렌더 경로 무변경)
- [ ] 웹(WASM) 렌더링 확인 (해당 없음)
- [ ] rhwp-studio 변경 없음
- [ ] 작업 증빙 — 코드 수정(문서 편집 작업 아님)

## 성능 영향 및 측정 결과

- 예상 영향: 문서 열기 시 본문 봉인 계산(serde 인코딩 + blake3)이 추가됩니다 — 문서 크기에 비례(전형 문서 수 ms~수십 ms). 무변경 저장 통과는 종전과 동일하게 유지됩니다.
- 재현·측정: 미측정 (전체 nextest 벽시계·`ir_field_sweep` 래칫 회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
