### PR TITLE
fix(model): booleanParam 원본 lexical 표기 보존 (#4437)

### DIFF
--- a/src/model/control.rs
+++ b/src/model/control.rs
@@ -390,6 +390,13 @@ pub enum Parameter {
     Boolean {
         name: Option<String>,
         value: bool,
+        /// [#4437] 원본 lexical 표기 보존. `xs:boolean` 은 `0`/`1`/`false`/`true`
+        /// 네 표기가 모두 유효하고 실물 코퍼스에 섞여 있다(`Fiexde=1`,
+        /// `RefHyperLink=false`). 종전 렌더는 항상 `0`/`1` 로 정규화해 원본이
+        /// `false` 로 적은 것이 왕복에서 바이트가 달라졌다. 파서가 유효 lexical
+        /// 을 그대로 담고, 렌더는 이 값을 우선 되쓴다. 프로그램 생성 값은 None
+        /// → 종전대로 `0`/`1`.
+        lexical: Option<String>,
     },
     Integer {
         name: Option<String>,
@@ -450,8 +457,15 @@ impl ParameterList {
 impl Parameter {
     fn render_xml_into(&self, out: &mut String) {
         match self {
-            Parameter::Boolean { name, value } => {
-                render_scalar_param(out, "booleanParam", name, if *value { "1" } else { "0" });
+            Parameter::Boolean {
+                name,
+                value,
+                lexical,
+            } => {
+                // [#4437] 원본 표기 우선 — 파서가 검증한 유효 lexical 만 담기므로
+                // 그대로 되써도 스키마 안전하다.
+                let text = lexical.as_deref().unwrap_or(if *value { "1" } else { "0" });
+                render_scalar_param(out, "booleanParam", name, text);
             }
             Parameter::Integer { name, value } => {
                 render_scalar_param(out, "integerParam", name, &value.to_string());
@@ -489,6 +503,15 @@ fn render_scalar_param(out: &mut String, tag: &str, name: &Option<String>, text:
     out.push_str("</hp:");
     out.push_str(tag);
     out.push('>');
+}
+
+/// [#4437] `xs:boolean` 의 유효 lexical 이면 그 표기를 돌려준다 — 아니면 None.
+///
+/// 렌더가 이 값을 검증 없이 되쓰므로 유효 표기만 담는 것이 계약이다. 규정 밖
+/// 텍스트(빈 문자열 등)는 None 으로 떨어져 종전 정규화(`0`/`1`)를 탄다.
+pub(crate) fn boolean_lexical_of(text: &str) -> Option<String> {
+    let t = text.trim();
+    matches!(t, "0" | "1" | "true" | "false").then(|| t.to_string())
 }
 
 /// `ParameterList::render_xml` 전용 최소 XML 텍스트/속성값 이스케이프.
@@ -576,6 +599,7 @@ fn parse_one_param(s: &str, pos: &mut usize) -> Option<Parameter> {
             "booleanParam" => Parameter::Boolean {
                 name: Some(name),
                 value: matches!(text.trim(), "1" | "true"),
+                lexical: boolean_lexical_of(&text),
             },
             "integerParam" => Parameter::Integer {
                 name: Some(name),
@@ -702,13 +726,16 @@ mod parameter_list_codec_tests {
                     value: "이곳을 마우스로 누르고 내용을 입력하세요.".to_string(),
                     preserve_space: false,
                 },
+                // [#4437] 실물 코퍼스 표기 그대로 — `1` 과 `false` 가 섞여 있다.
                 Parameter::Boolean {
                     name: Some("Fiexde".to_string()),
                     value: true,
+                    lexical: Some("1".to_string()),
                 },
                 Parameter::Boolean {
                     name: Some("RefHyperLink".to_string()),
                     value: false,
+                    lexical: Some("false".to_string()),
                 },
                 Parameter::Float {
                     name: Some("Ratio".to_string()),
@@ -733,6 +760,37 @@ mod parameter_list_codec_tests {
         assert!(xml.ends_with("</hp:parameters>"));
         let parsed = ParameterList::parse_xml(&xml).expect("parse_xml 실패");
         assert_eq!(parsed, original);
+    }
+
+    /// [#4437] 원본 lexical(`false`/`true`) 이 정규화(`0`/`1`)되지 않고 바이트
+    /// 그대로 왕복해야 한다.
+    #[test]
+    fn issue4437_boolean_lexical_round_trips_verbatim() {
+        let xml = sample_tree().render_xml("parameters");
+        assert!(
+            xml.contains(r#"<hp:booleanParam name="RefHyperLink">false</hp:booleanParam>"#),
+            "원본 `false` 표기가 `0` 으로 정규화되면 안 된다: {xml}"
+        );
+        assert!(
+            xml.contains(r#"<hp:booleanParam name="Fiexde">1</hp:booleanParam>"#),
+            "원본 `1` 표기는 그대로: {xml}"
+        );
+        // parse → render 재왕복도 바이트 동일.
+        let reparsed = ParameterList::parse_xml(&xml).expect("parse_xml");
+        assert_eq!(reparsed.render_xml("parameters"), xml);
+
+        // lexical 이 없는(프로그램 생성) Boolean 은 종전대로 0/1 정규화.
+        let synth = ParameterList {
+            name: Some(String::new()),
+            items: vec![Parameter::Boolean {
+                name: Some("New".to_string()),
+                value: false,
+                lexical: None,
+            }],
+        };
+        assert!(synth
+            .render_xml("parameters")
+            .contains(r#"<hp:booleanParam name="New">0</hp:booleanParam>"#));
     }
 
     #[test]

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -5469,6 +5469,9 @@ impl ParamFrame {
             ParamFrame::Boolean { name, text } => Parameter::Boolean {
                 name,
                 value: matches!(text.trim(), "1" | "true"),
+                // [#4437] 원본 lexical 표기(`false`/`true`/`0`/`1`) 보존 — 렌더가
+                // 정규화로 되쓰면 왕복 바이트가 달라진다.
+                lexical: crate::model::control::boolean_lexical_of(&text),
             },
             ParamFrame::Integer { name, text } => Parameter::Integer {
                 name,


### PR DESCRIPTION
## 변경 요약

`booleanParam` 렌더(`model/control.rs render_xml_into`)가 값을 언제나 `"0"`/`"1"` 로 정규화해, 원본이 `false`/`true` 로 적은 문서의 왕복 바이트가 달라지던 잠복 결함(#4437)을 고칩니다.

- `Parameter::Boolean` 에 `lexical: Option<String>` 필드를 추가해 **원본 lexical 표기를 보존**합니다. 파서 두 곳(HWPX 실물 파서 `ParamFrame::finish`, 캐노니컬 코덱 `parse_one_param`)이 유효 `xs:boolean` lexical(`0`/`1`/`true`/`false`)일 때만 원문을 담고, 렌더는 이 값을 우선 되씁니다.
- 프로그램 생성 값(`lexical: None`)은 종전대로 `0`/`1` 로 방출합니다 — 렌더가 lexical 을 검증 없이 되쓰므로 "유효 표기만 담는다"가 파서 측 계약입니다(규정 밖 텍스트는 None 폴백).
- `floatParam` 은 이슈 분석대로 코퍼스 관측 0건(숫자 포맷 정합 미검증 상태)이라 손대지 않았습니다 — 실물이 나오면 같은 기법을 적용할 수 있습니다.

이슈가 지적한 대로 이 경로는 현재 `raw_parameters_xml` 이 있으면 도달하지 않는 **폴백 전용(잠복)** 입니다 — API 로 필드를 신설하거나 HWP5 슬롯이 생기는 순간 처음 실사용되므로, 표기 보존을 미리 정합시켜 둡니다.

## 관련 이슈

closes #4437

## 테스트

- [x] `cargo test` 통과 — 신규 `issue4437_boolean_lexical_round_trips_verbatim`: 실물 코퍼스 표기(`Fiexde=1`·`RefHyperLink=false` 혼재)가 render→parse→render 에서 바이트 동일 왕복, lexical 없는 합성 값은 종전 `0`/`1` 정규화 유지. 기존 코덱 왕복 테스트(`render_then_parse_round_trips_the_tree`)도 lexical 포함 형태로 통과. 전체 nextest 게이트 통과
- [x] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 (해당 없음 — 렌더 경로 무변경)
- [ ] 웹(WASM) 렌더링 확인 (해당 없음)
- [ ] rhwp-studio 변경 없음
- [ ] 작업 증빙 — 코드 수정(문서 편집 작업 아님)

## 성능 영향 및 측정 결과

- 예상 영향: 없음 (Option<String> 필드 1개, 폴백 경로 전용)
- 재현·측정: 미측정

🤖 Generated with [Claude Code](https://claude.com/claude-code)
