### PR TITLE
fix(hwp5): HWPX→HWP 저장에서 글꼴 기본 이름을 실측표로 채운다 (#4898 조사 부산물)

### DIFF
--- a/src/parser/doc_info.rs
+++ b/src/parser/doc_info.rs
@@ -263,7 +263,7 @@ fn parse_bin_data(data: &[u8]) -> Result<BinData, DocInfoError> {
     Ok(bin)
 }
 
-fn parse_face_name(data: &[u8]) -> Result<Font, DocInfoError> {
+pub(crate) fn parse_face_name(data: &[u8]) -> Result<Font, DocInfoError> {
     let mut r = ByteReader::new(data);
     let attr = r.read_u8().unwrap_or(0);
 

--- a/src/serializer/doc_info.rs
+++ b/src/serializer/doc_info.rs
@@ -229,6 +229,187 @@ pub fn serialize_bin_data(bin_data: &BinData) -> Vec<u8> {
     w.into_bytes()
 }
 
+/// [#4898] 한글 글꼴 이름 → HWP5 FACE_NAME 의 **기본 글꼴 이름**(default_name) 실측 대응표.
+///
+/// 한글은 HWP5 로 저장할 때 이 자리에 영문(PostScript) 기본 이름을 함께 싣는다. HWPX 에는
+/// 대응 자리가 없어 HWPX→HWP 저장에서 이 값이 통째로 빠지고, 한글이 그 파일을 열 때 글꼴을
+/// 이름만으로 찾는다 — 글꼴이 없어 대체가 일어나면 글자 폭이 달라져 줄 수·쪽수가 흔들린다
+/// (한글 오라클 실측: 09254 FACE_NAME 33개가 오라클 37~65바이트 vs rhwp 19~23바이트,
+/// 차이가 정확히 이 필드였다).
+///
+/// **표는 실측이다.** 코퍼스의 한컴 저장 `.hwp` 원본 796건에서 `(글꼴 이름, default_name)`
+/// 36,351쌍을 모아, 이름별 최빈값이 60% 이상인 것만 담았다(2026-08-16 측정).
+/// 한 이름에 값이 갈리는 경우(같은 글꼴의 구·신 PostScript 이름)는 최빈값을 쓴다:
+/// `HY헤드라인M` HYHeadLine-Medium 1217 / HYHeadLine M 245 · `HY견고딕` HYGothic-Extra 351 /
+/// HYgtrE 126 · `HY견명조` HYMyeongJo-Extra 200 / HYmjrE 68.
+/// 라틴 글꼴은 한글도 이름을 그대로 싣는다(Arial→Arial).
+const FONT_DEFAULT_NAMES: &[(&str, &str)] = &[
+    ("#견고딕", "#Gyeongothic"),
+    ("#견명조", "#Gyeonmyeongjo"),
+    ("#그래픽", "#Graphic"),
+    ("#디나루", "#Dinaru"),
+    ("#세고딕", "#Segothic"),
+    ("#세나루", "#Senaru"),
+    ("#세명조", "#Semyeongjo"),
+    ("#신그래픽", "#Singraphic"),
+    ("#신디나루", "#Sindinaru"),
+    ("#신명조", "#Sinmyeongjo"),
+    ("#신문견고", "#Sinmungyeongo"),
+    ("#신문태고", "#Sinmuntaego"),
+    ("#신문태명", "#Sinmuntaemyeong"),
+    ("#신세고딕", "#Sinsegothic"),
+    ("#신중명조", "#Sin Jungmyeongjo"),
+    ("#신태명조", "#Sintaemyeongjo"),
+    ("#중고딕", "#Junggothic"),
+    ("#중명조", "#Jungmyeongjo"),
+    ("#태고딕", "#Taegothic"),
+    ("#태그래픽", "#Taegraphic"),
+    ("#태명조", "#Taemyeongjo"),
+    ("#태신명조", "#Taesinmyeongjo"),
+    ("-윤고딕340", "YDIYGO340"),
+    ("08서울남산체 B", "08SeoulNamsan B"),
+    ("08서울남산체 EB", "08SeoulNamsan EB"),
+    ("08서울남산체 M", "08SeoulNamsan M"),
+    ("08서울한강체 L", "08SeoulHangang L"),
+    ("08서울한강체 M", "08SeoulHangang M"),
+    ("AmeriGarmnd BT", "AmeriGarmnd BT"),
+    ("Arial", "Arial"),
+    ("Arial Black", "Arial Black"),
+    ("Arial Narrow", "Arial Narrow"),
+    ("Arial Unicode MS", "Arial Unicode MS"),
+    ("Calibri", "Calibri"),
+    ("Century", "Century"),
+    ("Courier New", "Courier New"),
+    ("Garamond", "Garamond"),
+    ("HCI Acacia", "HCI Acacia"),
+    ("HCI Bellflower", "HCI Bellflower"),
+    ("HCI Hollyhock", "HCI Hollyhock"),
+    ("HCI Morning Glory", "HCI Morning Glory"),
+    ("HCI Poppy", "HCI Poppy"),
+    ("HCI Tulip", "HCI Tulip"),
+    ("HY강B", "HYkanB"),
+    ("HY강M", "HYkanM"),
+    ("HY견고딕", "HYGothic-Extra"),
+    ("HY견명조", "HYMyeongJo-Extra"),
+    ("HY궁서", "HYgsrB"),
+    ("HY그래픽", "HYgprM"),
+    ("HY그래픽M", "HYGraphic-Medium"),
+    ("HY동녘M", "HYdnkM"),
+    ("HY백송B", "HYbsrB"),
+    ("HY수평선B", "HYsupB"),
+    ("HY수평선M", "HYsupM"),
+    ("HY신명조", "HYSinMyeongJo-Medium"),
+    ("HY엽서M", "HYPost-Medium"),
+    ("HY울릉도B", "HYwulB"),
+    ("HY울릉도M", "HYwulM"),
+    ("HY중고딕", "HYGothic-Medium"),
+    ("HY헤드라인M", "HYHeadLine-Medium"),
+    ("Hobo BT", "Hobo BT"),
+    ("KoPubWorld돋움체 Bold", "KoPubWorldDotum Bold"),
+    ("KoPub돋움체 Bold", "KoPubDotum Bold"),
+    ("KoPub돋움체 Light", "KoPubDotum Light"),
+    ("KoPub돋움체 Medium", "KoPubDotum Medium"),
+    ("KoPub바탕체 Bold", "KoPubBatang Bold"),
+    ("KoPub바탕체 Light", "KoPubBatang Light"),
+    ("KoPub바탕체 Medium", "KoPubBatang Medium"),
+    ("MS PMincho", "MS PMincho"),
+    ("Noto Sans CJK KR Bold", "Noto Sans CJK KR Bold"),
+    ("Noto Sans CJK KR DemiLight", "Noto Sans CJK KR DemiLight"),
+    ("Noto Sans CJK KR Medium", "Noto Sans CJK KR Medium"),
+    ("SimSun", "SimSun"),
+    ("Tahoma", "Tahoma"),
+    ("Times New Roman", "Times New Roman"),
+    ("Trebuchet MS", "Trebuchet MS"),
+    ("Verdana", "Verdana"),
+    ("가는안상수체", "가는안상수체"),
+    ("가는한", "Ganeunhan"),
+    ("경기천년바탕 Regular", "GyeonggiBatang Regular"),
+    ("고딕", "Gothic"),
+    ("굴림", "Gulim"),
+    ("굴림체", "GulimChe"),
+    ("궁서", "Gungsuh"),
+    ("궁서체", "GungsuhChe"),
+    ("나눔고딕", "NanumGothic"),
+    ("나눔고딕 ExtraBold", "NanumGothicExtraBold"),
+    ("나눔명조", "NanumMyeongjo"),
+    ("나눔명조 ExtraBold", "NanumMyeongjoExtraBold"),
+    ("돋움", "Dotum"),
+    ("돋움체", "DotumChe"),
+    ("맑은 고딕", "Malgun Gothic"),
+    ("맑은 고딕 Semilight", "Malgun Gothic Semilight"),
+    ("명조", "Myeongjo"),
+    ("문체부 궁체 정자체", "MGungJeong"),
+    ("문체부 돋음체", "MDotum"),
+    ("문체부 바탕체", "MBatang"),
+    ("문체부 쓰기 흘림체", "MSugiHeulim"),
+    ("문체부 제목 돋음체", "MJemokGothic"),
+    ("바탕", "Batang"),
+    ("바탕체", "BatangChe"),
+    ("산세리프", "Sans Serif"),
+    ("새굴림", "New Gulim"),
+    ("시스템", "System"),
+    ("신명 견고딕", "Sinmyeong Gyeongothic"),
+    ("신명 견명조", "Sinmyeong Gyeonmyeongjo"),
+    ("신명 궁서", "Sinmyeong Gungseo"),
+    ("신명 디나루", "Sinmyeong Dinaru"),
+    ("신명 세나루", "Sinmyeong Senaru"),
+    ("신명 세명조", "Sinmyeong Semyeongjo"),
+    ("신명 순명조", "Sinmyeong Sunmyeongjo"),
+    ("신명 신그래픽", "Sinmyeong Singraphic"),
+    ("신명 신명조", "Sinmyeong Sinmyeongjo"),
+    ("신명 신문명조", "Sinmyeong Sinmunmyeongjo"),
+    ("신명 신신명조", "Sinmyeong Sinsinmyeongjo"),
+    ("신명 중고딕", "Sinmyeong Junggothic"),
+    ("신명 중명조", "Sinmyeong Jungmyeongjo"),
+    ("신명 태고딕", "Sinmyeong Taegothic"),
+    ("신명 태그래픽", "Sinmyeong Taegraphic"),
+    ("신명 태명조", "Sinmyeong Taemyeongjo"),
+    ("신명조 간자", "Sinmyeongjo Chinese"),
+    ("신명조 약자", "Sinmyeongjo Jananese"),
+    ("양재 다운명조M", "YJ Daunmyeongjo M"),
+    ("양재 튼튼B", "YJ Teunteun B"),
+    ("옥수수", "Corn"),
+    ("중고딕 간자", "Junggothic Chinese"),
+    ("태 가는 헤드라인D", "Tae Headline D Narrow"),
+    ("태 가는 헤드라인T", "Tae Headline T Narrow"),
+    ("태 나무", "태 나무"),
+    ("태 헤드라인T", "Tae Headline T"),
+    ("필기", "Pilgi"),
+    ("한양견고딕", "HY Gyeongothic"),
+    ("한양견명조", "HY Gyeonmyeongjo"),
+    ("한양궁서", "HY Gungseo"),
+    ("한양그래픽", "HY Graphic"),
+    ("한양신명조", "HY Sinmyeongjo"),
+    ("한양신명조V", "HY Sinmyeongjo V"),
+    ("한양중고딕", "HY Junggothic"),
+    ("한양중고딕V", "HY Junggothic V"),
+    ("한양해서", "HYhaeseo"),
+    ("한컴 백제 M", "Haan Baekje M"),
+    ("한컴 윤고딕 250", "Haan YGodic 250"),
+    ("한컴 쿨재즈 B", "Haan Cooljazz B"),
+    ("한컴돋움", "Haansoft Dotum"),
+    ("한컴바탕", "Haansoft Batang"),
+    ("한컴산뜻돋움", "Han Santteut Dotum Regular"),
+    ("함초롬돋움", "HCR Dotum"),
+    ("함초롬돋움 확장", "HCR Dotum Ext"),
+    ("함초롬바탕", "HCR Batang"),
+    ("휴먼고딕", "휴먼고딕"),
+    ("휴먼둥근헤드라인", "Headline R"),
+    ("휴먼명조", "휴먼명조"),
+    ("휴먼모음T", "MoeumT R"),
+    ("휴먼아미체", "Ami R"),
+    ("휴먼엑스포", "Expo M"),
+    ("휴먼옛체", "Yet R"),
+];
+
+/// 글꼴 이름에 대응하는 기본 글꼴 이름(실측표). 없으면 `None`.
+fn measured_default_font_name(name: &str) -> Option<&'static str> {
+    FONT_DEFAULT_NAMES
+        .iter()
+        .find(|(korean, _)| *korean == name)
+        .map(|(_, default)| *default)
+}
+
 pub fn serialize_face_name(font: &Font) -> Vec<u8> {
     let mut w = ByteWriter::new();
 
@@ -244,6 +425,13 @@ pub fn serialize_face_name(font: &Font) -> Vec<u8> {
     });
 
     // attr 바이트 재구성
+    // [#4898] 기본 글꼴 이름: HWPX 에는 이 자리가 없어 HWPX 출처 문서는 늘 비어 있었다.
+    // 한글은 자기 글꼴 엔진의 대응을 여기 실어 두므로, 실측표로 같은 값을 채워 준다.
+    let default_name = font
+        .default_name
+        .as_deref()
+        .or_else(|| measured_default_font_name(&font.name));
+
     let mut attr = font.alt_type & 0x03;
     if alt_name.is_some() {
         attr |= 0x80;
@@ -251,7 +439,7 @@ pub fn serialize_face_name(font: &Font) -> Vec<u8> {
     if font.type_info.is_some() {
         attr |= 0x40;
     }
-    if font.default_name.is_some() {
+    if default_name.is_some() {
         attr |= 0x20;
     }
     w.write_u8(attr).unwrap();
@@ -265,7 +453,7 @@ pub fn serialize_face_name(font: &Font) -> Vec<u8> {
     if let Some(type_info) = font.type_info {
         w.write_bytes(&type_info).unwrap();
     }
-    if let Some(ref default_name) = font.default_name {
+    if let Some(default_name) = default_name {
         w.write_hwp_string(default_name).unwrap();
     }
 

--- a/src/serializer/doc_info/tests.rs
+++ b/src/serializer/doc_info/tests.rs
@@ -832,3 +832,48 @@ fn test_serialize_bullet_layout_and_roundtrip() {
     assert_eq!(parsed_info.bullets[0].char_shape_id, 2);
     assert_eq!(parsed_info.bullets[0].text_distance, 50);
 }
+
+/// [#4898] HWPX 출처 글꼴은 `default_name` 이 비어 있다 — 한글은 그 자리에 영문 기본
+/// 이름을 싣는다. 실측표로 같은 값을 채워 FACE_NAME 이 한컴 저장본과 같은 모양이 되게 한다.
+///
+/// 실측: 09254 의 FACE_NAME 33개가 한글 오라클 37~65바이트 vs rhwp 19~23바이트였고,
+/// 표 적용 후 크기가 일치했다(일치 레코드 399 → 410).
+/// 표 자체는 한컴 저장 `.hwp` 796건에서 모은 36,351쌍의 이름별 최빈값이다.
+#[test]
+fn issue4898_face_name_fills_measured_default_font_name() {
+    let mut font = Font {
+        name: "굴림체".to_string(),
+        ..Default::default()
+    };
+    font.default_name = None;
+
+    let bytes = serialize_face_name(&font);
+    // attr bit 0x20 = 기본 글꼴 이름 있음
+    assert_ne!(bytes[0] & 0x20, 0, "기본 글꼴 이름 플래그가 서야 한다");
+
+    let parsed = crate::parser::doc_info::parse_face_name(&bytes).expect("FACE_NAME 재파싱");
+    assert_eq!(
+        parsed.default_name.as_deref(),
+        Some("GulimChe"),
+        "한글이 싣는 영문 기본 이름과 같아야 한다"
+    );
+
+    // 원본이 이미 값을 갖고 있으면 그 값이 이긴다(표가 덮어쓰지 않는다).
+    let mut explicit = Font {
+        name: "굴림체".to_string(),
+        ..Default::default()
+    };
+    explicit.default_name = Some("Explicit".to_string());
+    let parsed = crate::parser::doc_info::parse_face_name(&serialize_face_name(&explicit))
+        .expect("FACE_NAME 재파싱");
+    assert_eq!(parsed.default_name.as_deref(), Some("Explicit"));
+
+    // 표에 없는 이름은 종전대로 비운다.
+    let unknown = Font {
+        name: "존재하지않는글꼴".to_string(),
+        ..Default::default()
+    };
+    let parsed = crate::parser::doc_info::parse_face_name(&serialize_face_name(&unknown))
+        .expect("FACE_NAME 재파싱");
+    assert_eq!(parsed.default_name, None);
+}


### PR DESCRIPTION
## 변경 요약

한글은 HWP5 로 저장할 때 `FACE_NAME` 에 영문(PostScript) **기본 글꼴 이름**을 함께 싣는다.
HWPX 에는 그 자리가 없어 HWPX 출처 문서는 이 값이 통째로 빠졌다 — 한글이 rhwp 산출을 열 때
글꼴을 이름만으로 찾게 되고, 글꼴이 없으면 대체 경로가 한컴 저장본과 달라진다.

`09254` 실측(한글 2022 로 같은 원본을 SaveAs 한 오라클과 대조):

```
FACE_NAME 33개   오라클 37~65바이트  vs  rhwp 19~23바이트
차이는 정확히 이 필드였다
  굴림체   → GulimChe            HY견고딕 → HYGothic-Extra
  HY견명조 → HYMyeongJo-Extra    HY신명조 → HYSinMyeongJo-Medium
```

## 표는 실측이다 — 추정 없음

코퍼스의 **한컴 저장 `.hwp` 원본 796건**에서 `(글꼴 이름, default_name)` **36,351쌍**을 모아,
이름별 최빈값이 60% 이상인 **156종**을 담았다(2026-08-16 측정). 한글이 이미 그 값을 파일에
싣고 있으므로 표를 지어낼 필요가 없다.

값이 갈리는 10종은 같은 글꼴의 구·신 PostScript 이름이라 최빈값을 쓰고 분포를 주석에 남겼다:

| 이름 | 분포 |
|---|---|
| HY헤드라인M | HYHeadLine-Medium 1,217 / HYHeadLine M 245 |
| HY견고딕 | HYGothic-Extra 351 / HYgtrE 126 |
| HY견명조 | HYMyeongJo-Extra 200 / HYmjrE 68 |

원본이 이미 값을 갖고 있으면 **그 값이 이긴다** — 표는 빈 자리만 채운다(회귀 시험으로 고정).

## 효과와 한계 (한계를 먼저)

- **쪽수 드리프트(#4898 의 x2h 축)는 이 PR 로 해소되지 않는다.** 표를 넣어도 `09254`·`09279`·
  `09420`·`09472` 는 그대로 1쪽 → 2쪽이다. "기본 글꼴 이름 누락이 쪽수 드리프트의 원인"이라는
  가설은 이 측정으로 **기각**됐고, 그 사실을 #4898 에 기록했다.
- 남는 효과는 **저장 충실도**다. FACE_NAME 레코드가 한컴 저장본과 같은 크기가 되고
  (`19/23` → `37/53`), `hwp5-inventory-diff` 일치 레코드가 **399 → 410**, 차이가 **68 → 57** 로
  줄어든다.

## 관련 이슈

refs #4898 (조사 부산물 — 쪽수 원인은 별건)

## 테스트

- [x] `cargo test` 통과 — 회귀 가드 신설(표 적용 · 원본 값 우선 · 표에 없는 이름은 빈 채 유지)
- [x] `cargo clippy --all-targets -- -D warnings` 통과
- [x] 회귀 게이트: `ir_field_sweep_baseline` · `hwp5_roundtrip_baseline` ·
      `convert_verify_corpus_ratchet` · `hwpx_to_hwp_adapter` 통과
      (DocInfo 바이트가 바뀌는 변경이라 래칫·왕복 baseline 을 특히 확인했다)
- [ ] SVG 내보내기 확인 — 해당 없음(조판 아님)
- [ ] WASM 렌더링 확인 — 해당 없음

## 검토 요청 사항

원본(HWPX)에 없던 값을 저장본에 **채워 넣는** 변경이라 판단이 갈릴 수 있다. 근거는
"한글 자신이 같은 상황에서 같은 값을 쓴다"는 실측이고, 표는 추정 없이 한컴 저장본에서만
뽑았다. 왕복 무손실 계약과 충돌하지 않는지(게이트는 통과) 리뷰에서 봐 주시면 좋겠다.

## 성능 영향 및 측정 결과

- 예상 영향: 없음 (글꼴 하나당 156항 선형 탐색, 문서당 수십 회)
- 재현·측정: 위 한글 오라클 실측 외 별도 성능 측정 없음
