### PR TITLE
fix(hwpx): 구역 시작 문단의 secd/cold 방출 순서를 IR 순서에 맞춘다 (#3367, #4433)

### DIFF
--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -580,6 +580,46 @@ pub fn write_section(
 
         // 템플릿의 텍스트 run 전체를 문단의 run 시퀀스(다중 run 분할 포함)로 1회 치환.
         out = out.replacen(TEMPLATE_TEXT_RUN, &first_runs, 1);
+
+        // [#3367/#4433] 컨트롤 방출 순서를 IR 순서에 맞춘다 — HWP5 원본이
+        // `[cold, secd]` 인 문단(field-01 실측: 전 구역 cold→secd)을 템플릿 고정
+        // 순서(secPr → ctrl/colPr)로 내보내면 재파싱 IR 이 `[secd, cold]` 로
+        // 뒤집혀 왕복 무손실 계약(ir-diff)이 깨진다. OWPML 스키마(run 의
+        // choice, ParaList XML schema)는 순서를 규정하지 않고, 한컴 원산 실물도
+        // colPr-before-secPr 20건 / colPr-after-secPr 315건으로 양쪽을 다 쓴다 —
+        // 문서 순서가 곧 보존 대상이다. 파서(parse_ctrl/secPr arm)는 이미 문서
+        // 순서를 보존하므로 방출만 IR 순서를 따르면 왕복이 닫힌다.
+        let cold_before_secd = {
+            let i_secd = p
+                .controls
+                .iter()
+                .position(|c| matches!(c, Control::SectionDef(_)));
+            let i_cold = p
+                .controls
+                .iter()
+                .position(|c| matches!(c, Control::ColumnDef(_)));
+            matches!((i_cold, i_secd), (Some(c), Some(s)) if c < s)
+        };
+        if cold_before_secd {
+            if let Some(Control::ColumnDef(cd)) = p
+                .controls
+                .iter()
+                .find(|c| matches!(c, Control::ColumnDef(_)))
+            {
+                // 위 #1407 치환이 이미 심어 둔 IR colPr 블록을 정확히 되찾아
+                // (render_col_pr_ctrl 은 결정적) secPr 앞으로 옮긴다.
+                let rendered = render_col_pr_ctrl(cd);
+                if let Some(colpr_at) = out.find(&rendered) {
+                    out.replace_range(colpr_at..colpr_at + rendered.len(), "");
+                    if let Some(secpr_at) = out.find("<hp:secPr ") {
+                        out.insert_str(secpr_at, &rendered);
+                    } else {
+                        // secPr 미발견(비정상 템플릿) — 원위치 복원으로 무손실 유지.
+                        out.insert_str(colpr_at, &rendered);
+                    }
+                }
+            }
+        }
     }
 
     // 추가 문단: `</hp:p></hs:sec>` 직전에 `<hp:p>` 요소를 삽입.

--- a/tests/issue_3367_secd_cold_order.rs
+++ b/tests/issue_3367_secd_cold_order.rs
@@ -1,0 +1,76 @@
+//! [Issue #3367/#4433] export-hwpx 가 구역 시작 문단의 secd/cold 컨트롤 순서를
+//! 뒤집던 계약을 고정한다.
+//!
+//! HWP5 원본(field-01)은 전 구역이 `[cold, secd]` 순서인데, HWPX writer 의
+//! 템플릿 고정 순서(secPr → ctrl/colPr)로 내보내면 재파싱 IR 이 `[secd, cold]`
+//! 로 뒤집혀 ir-diff(--verify)가 컨트롤 type 차이 6건을 냈다. OWPML 스키마는
+//! run 자식 순서를 규정하지 않고(choice), 한컴 원산 실물도 두 순서를 모두
+//! 쓰므로(20 vs 315건 실측) **문서 순서가 보존 대상**이다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+use rhwp::parse_document;
+
+const SAMPLE: &str = "samples/field-01.hwp";
+
+fn read_sample() -> Vec<u8> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    std::fs::read(&path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"))
+}
+
+/// 구역 첫 문단에서 (ColumnDef 위치, SectionDef 위치)를 얻는다.
+fn secd_cold_positions(para: &rhwp::model::paragraph::Paragraph) -> (Option<usize>, Option<usize>) {
+    let cold = para
+        .controls
+        .iter()
+        .position(|c| matches!(c, Control::ColumnDef(_)));
+    let secd = para
+        .controls
+        .iter()
+        .position(|c| matches!(c, Control::SectionDef(_)));
+    (cold, secd)
+}
+
+#[test]
+fn issue3367_export_hwpx_preserves_cold_before_secd_order() {
+    let bytes = read_sample();
+    let original = parse_document(&bytes).expect("parse");
+
+    // 샘플 전제: 원본은 cold 가 secd 앞이다 (#3367 실측 — 3개 구역 전부).
+    let mut checked = 0usize;
+    for sec in &original.sections {
+        let (cold, secd) = secd_cold_positions(&sec.paragraphs[0]);
+        if let (Some(c), Some(s)) = (cold, secd) {
+            assert!(c < s, "샘플 전제 위반: 원본이 cold→secd 순서가 아니다");
+            checked += 1;
+        }
+    }
+    assert!(
+        checked >= 2,
+        "샘플 전제 위반: cold+secd 구역이 2개 이상이어야 한다"
+    );
+
+    let core = DocumentCore::from_bytes(&bytes).expect("open");
+    let hwpx = core.export_hwpx_native().expect("export-hwpx");
+    let roundtripped = parse_document(&hwpx).expect("reparse hwpx");
+
+    assert_eq!(roundtripped.sections.len(), original.sections.len());
+    for (si, (a, b)) in original
+        .sections
+        .iter()
+        .zip(roundtripped.sections.iter())
+        .enumerate()
+    {
+        let (a_cold, a_secd) = secd_cold_positions(&a.paragraphs[0]);
+        let (b_cold, b_secd) = secd_cold_positions(&b.paragraphs[0]);
+        if let (Some(ac), Some(asd)) = (a_cold, a_secd) {
+            let (bc, bsd) = (b_cold.expect("cold 보존"), b_secd.expect("secd 보존"));
+            assert_eq!(
+                (ac < asd),
+                (bc < bsd),
+                "구역 {si}: secd/cold 상대 순서가 왕복에서 뒤집혔다 (#3367) — \
+                 원본 cold@{ac}/secd@{asd}, 왕복 cold@{bc}/secd@{bsd}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## 변경 요약

`export-hwpx` 가 구역 시작 문단의 secd/cold 컨트롤 순서를 뒤집던 문제(#3367)를 고칩니다. #4433 이 지목한 같은 축의 근인 규명을 포함합니다.

### 규명 — 뒤집는 쪽은 파서가 아니라 writer 의 템플릿 고정 순서

- **OWPML 스키마 확인**(#4433 의 선결 질문): `mydocs/manual/OWPML SCHEMA/ParaList XML schema.xml` 의 run 정의는 `xs:choice`(unbounded)로 `secPr` 와 `ctrl(colPr…)` 의 **출현 순서를 규정하지 않습니다**. 한컴 원산 실물도 두 순서를 모두 씁니다 — samples/ HWPX 전수 실측: colPr-before-secPr **20건** / colPr-after-secPr **315건**, secPr 안에 중첩된 colPr 은 **0건**. 따라서 원본 XML 의 문서 순서가 보존 대상입니다.
- **파서는 이미 문서 순서를 보존합니다** — `parse_ctrl` 의 colPr arm 과 `secPr` arm 모두 만난 자리에서 push 합니다(#4433 이 지목한 `parse_paragraph` 의 고정 push 는 secPr **안에** colPr 이 중첩된 변형 전용 방어 경로로, 실물 코퍼스 0건이라 실측 순서 뒤집기의 원인이 아닙니다). `parse_paragraph` 의 다른 컨트롤 arm 도 전부 만난 자리 push 로 확인했습니다.
- 실제 플립 지점은 **HWPX writer** 입니다: 섹션 템플릿이 `secPr → ctrl/colPr` 고정 순서라, HWP5 원본이 `[cold, secd]` 인 문단(field-01 실측: 전 구역)이 재파싱에서 `[secd, cold]` 로 뒤집혔습니다.

### 수정

첫 문단 IR 에서 ColumnDef 가 SectionDef 앞이면, #1407 치환이 심어 둔 IR colPr 블록(`render_col_pr_ctrl` — 결정적 문자열)을 secPr 앞으로 옮겨 방출합니다. IR 순서가 secd→cold 면 종전 그대로입니다. 파서가 문서 순서를 보존하므로 왕복이 닫힙니다.

## 관련 이슈

closes #3367
closes #4433

## 실측

```
$ rhwp export-hwpx samples/field-01.hwp out.hwpx && rhwp ir-diff out.hwpx samples/field-01.hwp
=== 비교 완료: 차이 0 건 ===        # 종전: ctrl type 차이 6건 (secd↔cold 스왑), exit 3
```

## 테스트

- [x] `cargo test` 통과 — 신규 `issue3367_export_hwpx_preserves_cold_before_secd_order`(field-01 전 구역의 상대 순서 왕복 보존, 샘플 전제 검증 포함). 전체 nextest 게이트 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] 관련 샘플 실측 — 위 ir-diff 0건
- [ ] 웹(WASM) 렌더링 확인 (해당 없음 — 레이아웃 무변경, 방출 순서만 변경)
- [ ] rhwp-studio 변경 없음
- [ ] 작업 증빙 — 코드 수정(문서 편집 작업 아님)

## 성능 영향 및 측정 결과

- 예상 영향: 없음 (첫 문단 1회 문자열 이동)
- 재현·측정: 미측정

🤖 Generated with [Claude Code](https://claude.com/claude-code)
