### PR TITLE
fix(serializer/hwp5): 고아 fieldEnd 문단을 빈 문단으로 접지 않는다 (#4398)

### DIFF
--- a/src/serializer/body_text.rs
+++ b/src/serializer/body_text.rs
@@ -252,8 +252,16 @@ fn serialize_paragraph_with_msb(
     // 함께 되살리고, 그로 인해 벌어진 위치들을 `residue_shifts` 로 돌려준다 — 아래
     // PARA_CHAR_SHAPE 가 그 시프트를 반영해야 텍스트 버퍼와 서식 경계가 어긋나지 않는다.
     // 표시만 있는 문단도 PARA_TEXT 가 있어야 8유닛이 파일에 남는다.
-    let has_content =
-        !para.text.is_empty() || !para.controls.is_empty() || !para.title_marks.is_empty();
+    // [#4398] 다단락 필드의 고아 종료 마커(짝 fieldBegin 이 앞 문단)도 8유닛
+    // 실체다 — 이것만 있는 문단을 "빈 문단" 으로 접으면 PARA_TEXT 없이 헤더만
+    // char_count 를 주장하는 자기모순 레코드가 되거나(종전), #4677 가드로
+    // char_count=1 로 무너져 FIELD_END 슬롯이 영구 소실된다. `serialize_para_text`
+    // 는 begin_ctrl_id 를 아는 마커만 방출하므로 판정도 같은 조건을 쓴다.
+    let has_emittable_orphan_end = para.orphan_field_ends.iter().any(|o| o.begin_ctrl_id != 0);
+    let has_content = !para.text.is_empty()
+        || !para.controls.is_empty()
+        || !para.title_marks.is_empty()
+        || has_emittable_orphan_end;
     let (text_data, residue_shifts): (Option<Vec<u8>>, Vec<GuideResidueShift>) =
         if has_content || (para.has_para_text && para.char_count > 1) {
             let result = serialize_para_text(para);
@@ -387,6 +395,12 @@ fn compute_control_mask(para: &Paragraph) -> u32 {
     }
     // FIELD_END (0x0004): field_ranges가 있으면 비트 4 설정
     if !para.field_ranges.is_empty() {
+        mask |= 1u32 << 0x0004;
+    }
+    // [#4398] 다단락 필드의 고아 종료 마커 — serialize_para_text 가 방출하는
+    // 조건(begin_ctrl_id 기지)과 동일하게 비트 4 를 세운다. PARA_TEXT 와 mask 는
+    // 항상 함께 움직여야 한다.
+    if para.orphan_field_ends.iter().any(|o| o.begin_ctrl_id != 0) {
         mask |= 1u32 << 0x0004;
     }
     // TAB (0x0009): text에 탭이 있으면 비트 9 설정

--- a/tests/issue_4398_orphan_fieldend.rs
+++ b/tests/issue_4398_orphan_fieldend.rs
@@ -1,0 +1,66 @@
+//! [Issue #4398] 다단락 필드의 고아 fieldEnd(짝 fieldBegin 이 앞 문단)가 HWP5
+//! 를 거치는 왕복에서 소실돼 char_count 9→1 로 무너지던 계약을 고정한다.
+//!
+//! 근인: `serialize_section` 의 `has_content` 판정과 `compute_control_mask` 가
+//! `orphan_field_ends` 를 몰라, 고아 종료 마커만 있는 문단이 "빈 문단" 으로
+//! 접혔다 — PARA_TEXT 없이 헤더만 char_count 를 주장하는 자기모순 레코드
+//! (한글 2022 는 그런 문단을 만나면 본문 전체를 버린다) 또는 #4677 가드의
+//! char_count=1 붕괴. 방출 자체(`serialize_para_text` 의 mid-text·trailing 고아
+//! 방출)는 이미 있었으므로 게이트만 맞추면 왕복이 닫힌다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::parse_document;
+
+const SAMPLE: &str = "samples/task2279/36378481_gyeoljae.hwpx";
+
+fn read_sample() -> Vec<u8> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    std::fs::read(&path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"))
+}
+
+/// 고아 fieldEnd 만 가진(텍스트·컨트롤 없는) 문단의 인덱스와 char_count.
+fn orphan_only_para(doc: &rhwp::model::document::Document) -> (usize, u32) {
+    for (pi, p) in doc.sections[0].paragraphs.iter().enumerate() {
+        if !p.orphan_field_ends.is_empty() && p.text.is_empty() && p.controls.is_empty() {
+            return (pi, p.char_count);
+        }
+    }
+    panic!("샘플 전제: 고아 fieldEnd 전용 문단이 있어야 한다");
+}
+
+#[test]
+fn issue4398_orphan_fieldend_survives_hwp5_roundtrip() {
+    let original = parse_document(&read_sample()).expect("parse hwpx");
+    let (pi, cc) = orphan_only_para(&original);
+    assert_eq!(cc, 9, "샘플 전제: 고아 8유닛 + 종결 1 = 9");
+    assert_ne!(
+        original.sections[0].paragraphs[pi].orphan_field_ends[0].begin_ctrl_id, 0,
+        "샘플 전제: 짝 fieldBegin 의 ctrl_id 가 연결돼 있어야 한다"
+    );
+
+    // HWPX → HWP5
+    let mut core = DocumentCore::from_bytes(&read_sample()).expect("open hwpx");
+    let hwp = core.export_hwp_with_adapter().expect("convert to hwp");
+    let mid = parse_document(&hwp).expect("parse hwp");
+    let mid_para = &mid.sections[0].paragraphs[pi];
+    assert_eq!(
+        mid_para.char_count, 9,
+        "HWP5 저장본에서 고아 fieldEnd 8유닛이 실체(PARA_TEXT)로 남아야 한다 (#4398)"
+    );
+    assert_eq!(
+        mid_para.orphan_field_ends.len(),
+        1,
+        "HWP5 재파싱이 고아 종료 마커를 복원해야 한다"
+    );
+
+    // HWP5 → HWPX (왕복 완주)
+    let core2 = DocumentCore::from_bytes(&hwp).expect("open hwp");
+    let hwpx2 = core2.export_hwpx_native().expect("export hwpx");
+    let fin = parse_document(&hwpx2).expect("parse final hwpx");
+    let fin_para = &fin.sections[0].paragraphs[pi];
+    assert_eq!(
+        fin_para.char_count, 9,
+        "왕복 후에도 char_count 가 무너지면 안 된다 (종전: 9→1)"
+    );
+    assert_eq!(fin_para.orphan_field_ends.len(), 1, "hp:fieldEnd 재방출");
+}


### PR DESCRIPTION
## 변경 요약

다단락 필드의 고아 `fieldEnd`(짝 fieldBegin 이 앞 문단)가 HWP5 를 거치는 왕복에서 소실돼 `char_count` 9→1 로 무너지던 문제(#4398, 407문서 관측)를 고칩니다.

이슈 등록 이후 `serialize_para_text` 에는 고아 종료 마커 방출(mid-text·trailing, `begin_ctrl_id` 기지 조건)이 들어와 있었지만, **그 앞의 두 게이트가 `orphan_field_ends` 를 몰랐습니다**:

- `has_content` 판정 — 고아 마커만 있는 문단(텍스트·컨트롤 없음)을 "빈 문단" 으로 접어 `PARA_TEXT` 자체를 안 썼습니다. 그 결과가 이슈의 자기모순 레코드(헤더만 cc=9 주장) 또는 #4677 가드의 cc=1 붕괴입니다. `begin_ctrl_id` 를 아는(방출 가능한) 고아가 있으면 내용 있는 문단으로 판정합니다.
- `compute_control_mask` — 같은 조건으로 FIELD_END(0x0004) 비트를 세워 PARA_TEXT 와 mask 를 일치시킵니다.

방출 조건(`begin_ctrl_id != 0`)과 판정 조건을 동일하게 맞춘 것이 계약입니다 — 필드 종류를 모르는 고아는 종전대로 내지 않습니다(종류를 지어내면 한글이 짝을 못 맞춤).

## 관련 이슈

closes #4398

## 실측 (이슈 재현체 `samples/task2279/36378481_gyeoljae.hwpx`)

```
rhwp convert <원본> mid.hwp && rhwp export-hwpx mid.hwp final.hwpx && rhwp ir-diff <원본> final.hwpx
```

| | 종전 | 이 PR |
|---|---|---|
| 문단 0.9 `cc` | **9 → 1 붕괴** | 9 유지 |
| 문단 0.9 `cs[1].pos` | 8 → 0 | 8 유지 |
| ir-diff 총계 | 12건 | **10건** (잔여는 별개의 저장 lineseg vpos 축 — 수정 전에도 동일하게 존재) |

mid.hwp 의 문단 0.9 는 이제 `PARA_TEXT`(FIELD_END 8유닛 + 종결 1 = 9유닛)를 실체로 갖고, HWP5 재파싱이 `orphan_field_ends` 로 복원하며, 재-export 가 `hp:fieldEnd` 를 되씁니다 — 왕복이 닫힙니다.

## 테스트

- [x] `cargo test` 통과 — 신규 `issue4398_orphan_fieldend_survives_hwp5_roundtrip`(HWPX→HWP5→HWPX 전 구간에서 cc=9·고아 마커 보존). 전체 nextest 게이트 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] 관련 샘플 실측 — 위 표
- [ ] 웹(WASM) 렌더링 확인 (해당 없음)
- [ ] rhwp-studio 변경 없음
- [ ] 작업 증빙 — 코드 수정(문서 편집 작업 아님)

## 성능 영향 및 측정 결과

- 예상 영향: 없음 (문단당 O(고아 수) 판정 2회)
- 재현·측정: 미측정

🤖 Generated with [Claude Code](https://claude.com/claude-code)
