### PR TITLE
fix: planet6897 HWPX·HWP5 보존 PR 5건 통합

### DIFF
--- a/mydocs/orders/20260816.md
+++ b/mydocs/orders/20260816.md
@@ -1,5 +1,18 @@
 # 오늘 할 일 - 2026년 8월 16일
 
+## planet6897 PR #4943, #4945, #4946, #4948, #4952 통합 후보
+
+- 최신 `upstream/devel@76e407b127c2` 위 가시성 branch `review/planet6897-20260816-r6`에서 열린 원 PR 5건을
+  번호 순으로 누적했다. #4943의 DocInfo 선행 commit은 이미 #4941에 포함되어 빈 적용으로 생략했고, 나머지
+  본문 provenance, boolean lexical, HWP5 글꼴 기본 이름, `secd`/`cold` 순서, 고아 `fieldEnd` 보존 commit은
+  충돌 없이 적용했다.
+- 원 PR별 최신 source head, GitHub 필수 CI와 local 전용 회귀를 확인했다. 누적 후보의 전체 nextest는
+  6,514 passed, 38 skipped, 7 slow, 378.554초로 끝났고 `cargo fmt --check`,
+  `cargo clippy --all-targets -- -D warnings`, diff 검사도 통과했다.
+- 원 PR별 archive review 5건과 누적 적용 기록을 같은 통합 PR에 포함한다. 통합 PR merge 전에는 각 원 PR의
+  최신 head·mergeable·필수 Actions를 재확인하고, 승인 뒤 통합 PR만 병합한 후 원 PR을 통합 반영 comment와 함께
+  close한다.
+
 ## kevin9327 PR #4925~#4937 통합 후보
 
 - Open non-draft #4925, #4926, #4927, #4929, #4930, #4934, #4935, #4937의 최신 source head를

--- a/mydocs/orders/20260816.md
+++ b/mydocs/orders/20260816.md
@@ -12,6 +12,10 @@
 - 원 PR별 archive review 5건과 누적 적용 기록을 같은 통합 PR에 포함한다. 통합 PR merge 전에는 각 원 PR의
   최신 head·mergeable·필수 Actions를 재확인하고, 승인 뒤 통합 PR만 병합한 후 원 PR을 통합 반영 comment와 함께
   close한다.
+- [PR #4953](https://github.com/edwardkim/rhwp/pull/4953)의 최초 code candidate
+  `f8d7366c9544`는 Full Build & Test, CodeQL, Canvas visual diff, Native Skia, 세 archive와
+  slow/regular shard를 모두 통과했고 `MERGEABLE`/`CLEAN`이었다. 이 trailing docs-only 기록을 push한 뒤에는
+  새 head의 fast-pass와 mergeability를 다시 확인한다.
 
 ## kevin9327 PR #4925~#4937 통합 후보
 

--- a/mydocs/pr/archives/pr_4943_review.md
+++ b/mydocs/pr/archives/pr_4943_review.md
@@ -1,0 +1,43 @@
+---
+kind: pr-review
+status: local-review-complete
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-16
+---
+
+# PR #4943 검토 - 본문 raw 캐시 출처 봉인
+
+## 접수
+
+| 항목 | 기록 |
+| --- | --- |
+| PR | [#4943](https://github.com/edwardkim/rhwp/pull/4943) |
+| 작성자 / source | @planet6897 / `fix/4488-section-provenance` |
+| 원 source head | `c2b5042c30fd8a99ec76d3c80325abe55e739b08` |
+| 기준 devel | `76e407b127c261427854172990bde6b2e1793edf` |
+| 가시성 검토 branch | `review/planet6897-20260816-r6` |
+| local 적용 commit | `ce5a99ba28c2223e1303c6eae7f21e61aae53ba8` |
+| 원 PR 상태 참고값 | `CONFLICTING` / `DIRTY`; 원 source의 오래된 base 상태이며 최신 누적 후보의 적용에는 충돌이 없었음 |
+
+원 source의 선행 DocInfo provenance commit은 이미 `upstream/devel`에 반영되어 cherry-pick 시 빈 적용이 됐다.
+남은 본문 Section·하위 컨트롤 raw 출처 봉인 commit만 누적 후보에 적용했다. 공개 IR 변경 뒤에도
+오래된 raw bytes가 serializer를 우회하지 않도록 Section, Table, Equation, OLE 경계를 각각 봉인한다.
+
+## 검증
+
+| 범위 | 명령 또는 근거 | 결과 |
+| --- | --- | --- |
+| 본문 provenance | `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --test issue_4488_4495_body_provenance --test-threads 12 --no-fail-fast` | 6 passed |
+| 누적 전체 Rust | `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast` | 6,514 passed, 38 skipped, 7 slow, 378.554초 |
+| 품질 | `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `git diff --check upstream/devel...HEAD` | 통과 |
+| 원 source CI | 최신 head의 Build & Test, Native Skia, Canvas visual diff, CodeQL | 모두 성공 |
+
+변경은 저장 전 raw 재사용의 허용 여부를 결정하는 모델·serializer 경계이며 renderer/paint 동작을 변경하지
+않는다. 따라서 별도 PDF pixel sweep은 적용하지 않았고, provenance 전용 회귀와 누적 전체 baseline으로
+출력 경계를 확인했다.
+
+## 판단
+
+원 PR의 GitHub 충돌 표시는 오래된 기준선에 대한 상태다. 최신 `devel` 위 누적 후보에서는 clean 적용과
+전용·전체 검증이 모두 통과했으며, 추가 메인터너 보정은 필요하지 않았다.
+**통합 수용 권고.**

--- a/mydocs/pr/archives/pr_4943_review_impl.md
+++ b/mydocs/pr/archives/pr_4943_review_impl.md
@@ -1,0 +1,51 @@
+---
+kind: pr-review-implementation
+status: local-review-complete
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-16
+---
+
+# PR #4943~#4952 planet6897 누적 검토 적용 기록
+
+이 기록은 다수 PR의 누적 적용 순서만 설명한다. 개별 변경의 검토·위험·수용 판단은
+[#4943](pr_4943_review.md), [#4945](pr_4945_review.md), [#4946](pr_4946_review.md),
+[#4948](pr_4948_review.md), [#4952](pr_4952_review.md) 기록이 정본이다.
+
+## 기준과 적용
+
+| 항목 | 기록 |
+| --- | --- |
+| 기준 devel | `76e407b127c261427854172990bde6b2e1793edf` |
+| 가시성 검토 branch | `review/planet6897-20260816-r6` |
+| 누적 후보 head | `575610644fb8ddfe185daafda7ab394d2e60c9cc` |
+| 적용 방식 | 최신 원 PR head를 fetch한 뒤 오래된 번호 순서로 cherry-pick. 원 contributor branch는 rewrite하거나 직접 push하지 않음 |
+
+| 순서 | 원 PR / source commit | local commit | 처리 |
+| --- | --- | --- | --- |
+| 1 | #4943 `7cef482a0741100ea86b009dd7f81bcaf87cd744` | 적용 생략 | DocInfo raw provenance는 이미 `upstream/devel`의 #4941에 포함되어 빈 cherry-pick이 됨 |
+| 2 | #4943 `c2b5042c30fd8a99ec76d3c80325abe55e739b08` | `ce5a99ba28c2223e1303c6eae7f21e61aae53ba8` | 본문 Section·하위 컨트롤 raw provenance 적용 |
+| 3 | #4945 `6a985214ff89f5552a736e1243895fec7bea4f35` | `04bc2a90d957d28ad3c51117960d84cb20bbb772` | booleanParam lexical 표기 보존 적용 |
+| 4 | #4946 `62fe2dc775f1b2aaa2d6bb6ac16121246af51c2b` | `328e6e886aeb97d3d61164113a427d9c325bd9ac` | HWP5 글꼴 기본 이름 실측표 적용 |
+| 5 | #4948 `43acd85f1705ded12f859e217e77b508a282be92` | `83d2996df4c4d8baaf0fd5dcb44f9b11ddf66d76` | 구역 시작 `secd`/`cold` 순서 보존 적용 |
+| 6 | #4952 `ca77e38cf48eb2bf6750177cac9fac4b24ea9a13` | `575610644fb8ddfe185daafda7ab394d2e60c9cc` | 고아 `fieldEnd` 문단의 HWP5 왕복 보존 적용 |
+
+원 #4943은 GitHub에서 당시 `CONFLICTING`/`DIRTY`였지만, 이는 오래된 source base 때문이다. 위 기준선에서
+본문 provenance commit은 자동 병합됐으며 수동 conflict 해소나 메인터너 코드 보정은 없었다.
+
+## 완료 검증
+
+1. 원 PR 5개의 source head를 fetch해 기록한 SHA와 일치함을 재확인했다.
+2. 각 전용 회귀 `issue_4488_4495_body_provenance` 6건, `issue4437_boolean_lexical_round_trips_verbatim`,
+   `issue4898_face_name_fills_measured_default_font_name`, `issue_3367_secd_cold_order`,
+   `issue_4398_orphan_fieldend`가 모두 통과했다.
+3. `samples/hwpx_sample2.hwpx`를 HWP5로 실제 변환해 `--verify --json`의 `identical:true`,
+   `diffCount:0`을 확인했다.
+4. 누적 후보에서 `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --tests
+   --test-threads 12 --no-fail-fast`를 실행해 6,514 passed, 38 skipped, 7 slow, 378.554초로 종료했다.
+5. `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `git diff --check`를 통과했다.
+
+## 다음 단계
+
+1. 이 누적 후보와 개별 archive review 기록을 하나의 `devel` 대상 통합 PR로 올린다.
+2. merge 전에는 원 PR별 최신 source head, mergeable 상태, 필수 GitHub Actions를 다시 확인한다.
+3. 작업지시자 merge 승인 뒤 통합 PR만 병합하고, 원 PR에는 통합 반영 사유를 남겨 close한다.

--- a/mydocs/pr/archives/pr_4945_review.md
+++ b/mydocs/pr/archives/pr_4945_review.md
@@ -1,0 +1,41 @@
+---
+kind: pr-review
+status: local-review-complete
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-16
+---
+
+# PR #4945 검토 - booleanParam lexical 표기 보존
+
+## 접수
+
+| 항목 | 기록 |
+| --- | --- |
+| PR | [#4945](https://github.com/edwardkim/rhwp/pull/4945) |
+| 작성자 / source | @planet6897 / `fix/4437-boolean-lexical` |
+| 원 source head | `6a985214ff89f5552a736e1243895fec7bea4f35` |
+| 기준 devel | `76e407b127c261427854172990bde6b2e1793edf` |
+| 가시성 검토 branch | `review/planet6897-20260816-r6` |
+| local 적용 commit | `04bc2a90d957d28ad3c51117960d84cb20bbb772` |
+| 원 PR 상태 참고값 | `MERGEABLE` / `CLEAN` |
+
+HWPX `booleanParam`의 의미값만 보존하면 `false`/`true`와 `0`/`1`의 원본 lexical 표기가 정규화되어
+바이트 왕복이 달라진다. 이 변경은 유효한 xs:boolean 표기만 보관해 재방출하고, 프로그램이 새로 만드는
+값은 기존 `0`/`1` 정규화를 유지한다.
+
+## 검증
+
+| 범위 | 명령 또는 근거 | 결과 |
+| --- | --- | --- |
+| 모델 단위 | `cargo test --profile release-test --target-dir target/pr-review --lib issue4437_boolean_lexical_round_trips_verbatim -- --nocapture` | 1 passed |
+| 누적 전체 Rust | `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast` | 6,514 passed, 38 skipped, 7 slow, 378.554초 |
+| 품질 | `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `git diff --check upstream/devel...HEAD` | 통과 |
+| 원 source CI | 최신 head의 Build & Test와 필수 분석 job | 성공; CodeQL aggregate는 `NEUTRAL` |
+
+모델·HWPX parser/serializer의 lexical 보존 변경이며 레이아웃이나 paint 경로를 바꾸지 않는다. 별도 시각
+대조 대신 유효 표기 재렌더와 프로그램 생성값 정규화의 단위 계약 및 전체 회귀를 적용했다.
+
+## 판단
+
+입력 lexical과 의미값의 경계를 명확히 지키며 기존 생성값의 canonical 동작도 유지한다. 최신 누적 후보에서
+추가 메인터너 보정이나 충돌 해소가 필요하지 않았다. **통합 수용 권고.**

--- a/mydocs/pr/archives/pr_4946_review.md
+++ b/mydocs/pr/archives/pr_4946_review.md
@@ -1,0 +1,42 @@
+---
+kind: pr-review
+status: local-review-complete
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-16
+---
+
+# PR #4946 검토 - HWP5 글꼴 기본 이름 실측표
+
+## 접수
+
+| 항목 | 기록 |
+| --- | --- |
+| PR | [#4946](https://github.com/edwardkim/rhwp/pull/4946) |
+| 작성자 / source | @planet6897 / `fix/4898-font-default-name` |
+| 원 source head | `62fe2dc775f1b2aaa2d6bb6ac16121246af51c2b` |
+| 기준 devel | `76e407b127c261427854172990bde6b2e1793edf` |
+| 가시성 검토 branch | `review/planet6897-20260816-r6` |
+| local 적용 commit | `328e6e886aeb97d3d61164113a427d9c325bd9ac` |
+| 원 PR 상태 참고값 | `MERGEABLE` / `CLEAN` |
+
+HWPX 출처 글꼴은 HWP5 `FACE_NAME`의 영문 기본 이름이 비어 있을 수 있다. serializer는 명시된
+`default_name`을 우선하고, 없는 경우에만 실측표의 이름을 채우며 미확인 이름을 추정하지 않는다.
+
+## 검증
+
+| 범위 | 명령 또는 근거 | 결과 |
+| --- | --- | --- |
+| 글꼴 단위 | `cargo test --profile release-test --target-dir target/pr-review --lib issue4898_face_name_fills_measured_default_font_name -- --nocapture` | 1 passed |
+| 실제 HWPX→HWP5 | `target/pr-review/release-test/rhwp convert samples/hwpx_sample2.hwpx /tmp/rhwp-pr4946-hwpx_sample2.hwp --verify --json` | HWP5 300,032 bytes, `identical:true`, `diffCount:0` |
+| 누적 전체 Rust | `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast` | 6,514 passed, 38 skipped, 7 slow, 378.554초 |
+| 품질 | `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `git diff --check upstream/devel...HEAD` | 통과 |
+| 원 source CI | 최신 head의 Build & Test와 필수 분석 job | 성공; CodeQL aggregate는 `NEUTRAL` |
+
+실제 변환 과정에서 알려진 HWP5 Hyperlink 확장 파라미터 손실 경고(#4396)가 stderr에 있었지만,
+이 PR의 글꼴 기본 이름 경계와 무관하며 `--verify` IR 판정은 성공했다.
+
+## 판단
+
+명시값 우선·미확인값 미추정 원칙과 실제 HWPX→HWP5 자기검증이 함께 확인됐다. 현재 후보에서 글꼴 표가
+새로운 페이지 수 충실도 해결책이라고 과장하지 않으며, 별도 fidelity 문제는 분리된 상태다.
+**통합 수용 권고.**

--- a/mydocs/pr/archives/pr_4948_review.md
+++ b/mydocs/pr/archives/pr_4948_review.md
@@ -1,0 +1,41 @@
+---
+kind: pr-review
+status: local-review-complete
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-16
+---
+
+# PR #4948 검토 - 구역 시작 secd/cold 순서 보존
+
+## 접수
+
+| 항목 | 기록 |
+| --- | --- |
+| PR | [#4948](https://github.com/edwardkim/rhwp/pull/4948) |
+| 작성자 / source | @planet6897 / `fix/3367-secd-cold-order` |
+| 원 source head | `43acd85f1705ded12f859e217e77b508a282be92` |
+| 기준 devel | `76e407b127c261427854172990bde6b2e1793edf` |
+| 가시성 검토 branch | `review/planet6897-20260816-r6` |
+| local 적용 commit | `83d2996df4c4d8baaf0fd5dcb44f9b11ddf66d76` |
+| 원 PR 상태 참고값 | `MERGEABLE` / `CLEAN` |
+
+HWPX writer가 구역 시작 문단의 템플릿 순서를 고정해, IR에서 `cold`가 `secd`보다 앞선 문서도
+`secd` 먼저 방출하던 문제를 고친다. 첫 문단의 제어 순서가 `cold → secd`인 경우만 `colPr` 블록을
+앞으로 이동해 원 IR 순서를 보존한다.
+
+## 검증
+
+| 범위 | 명령 또는 근거 | 결과 |
+| --- | --- | --- |
+| 구역 순서 회귀 | `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --test issue_3367_secd_cold_order --test-threads 12 --no-fail-fast` | 1 passed |
+| 누적 전체 Rust | `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast` | 6,514 passed, 38 skipped, 7 slow, 378.554초 |
+| 품질 | `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `git diff --check upstream/devel...HEAD` | 통과 |
+| 원 source CI | 최신 head의 Build & Test와 필수 분석 job | 성공; CodeQL aggregate는 `NEUTRAL` |
+
+이 변경은 HWPX XML 구조의 순서 보존 경계다. 회귀는 HWP→HWPX→재파싱으로 다구역 `cold`/`secd`의
+상대 위치를 확인한다. renderer/layout/paint 경로는 변경하지 않아 별도 pixel sweep은 적용하지 않았다.
+
+## 판단
+
+고정 템플릿을 일반화하지 않고 실제 IR이 역순인 경우에만 보정하며, 기존 순서는 그대로 둔다.
+최신 누적 후보에서 추가 메인터너 보정이나 충돌 해소가 필요하지 않았다. **통합 수용 권고.**

--- a/mydocs/pr/archives/pr_4952_review.md
+++ b/mydocs/pr/archives/pr_4952_review.md
@@ -1,0 +1,42 @@
+---
+kind: pr-review
+status: local-review-complete
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-16
+---
+
+# PR #4952 검토 - 고아 fieldEnd 문단 보존
+
+## 접수
+
+| 항목 | 기록 |
+| --- | --- |
+| PR | [#4952](https://github.com/edwardkim/rhwp/pull/4952) |
+| 작성자 / source | @planet6897 / `fix/4398-orphan-fieldend` |
+| 원 source head | `ca77e38cf48eb2bf6750177cac9fac4b24ea9a13` |
+| 기준 devel | `76e407b127c261427854172990bde6b2e1793edf` |
+| 가시성 검토 branch | `review/planet6897-20260816-r6` |
+| local 적용 commit | `575610644fb8ddfe185daafda7ab394d2e60c9cc` |
+| 원 PR 상태 참고값 | `MERGEABLE` / `CLEAN` |
+
+다문단 필드의 종료 마커가 다음 문단에 단독으로 남는 경우, serializer가 이를 빈 문단으로 접어
+`PARA_TEXT`와 control mask를 생략하면 `char_count`가 9에서 1로 붕괴한다. 방출 가능한
+`orphan_field_ends.begin_ctrl_id != 0` 조건을 `has_content`와 `compute_control_mask`에 같은 기준으로
+반영해 record header와 본문 bytes를 일치시킨다.
+
+## 검증
+
+| 범위 | 명령 또는 근거 | 결과 |
+| --- | --- | --- |
+| HWPX→HWP5→HWPX | `cargo test --profile release-test --target-dir target/pr-review --test issue_4398_orphan_fieldend -- --nocapture` | 1 passed; `char_count=9`, 고아 fieldEnd 보존 |
+| 누적 전체 Rust | `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast` | 6,514 passed, 38 skipped, 7 slow, 378.554초 |
+| 품질 | `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `git diff --check upstream/devel...HEAD` | 통과 |
+| 원 source CI | 최신 head의 Build & Test와 필수 분석 job | 성공; CodeQL aggregate는 `NEUTRAL` |
+
+전용 회귀 실행 중 기존 HWP5 CTRL_DATA의 알려진 `ClickHere` 파라미터 손실 경고(#4396)가 표준 오류에
+나왔지만, 테스트의 HWP5 재파싱·최종 HWPX 고아 fieldEnd/`char_count` 단언은 모두 성공했다.
+
+## 판단
+
+실제 방출 조건과 문단 존재·mask 판정을 동일하게 만들어 손상된 header/body 조합을 막는다. 최신 devel에
+적용할 때 자동 병합됐고 추가 메인터너 보정은 필요하지 않았다. **통합 수용 권고.**

--- a/src/diagnostics/ir_field_sweep.rs
+++ b/src/diagnostics/ir_field_sweep.rs
@@ -919,6 +919,7 @@ fn sweep_table(base: &str, a: &Table, b: &Table, out: &mut DivergenceCollector) 
         outer_margin_top,
         outer_margin_bottom,
         raw_ctrl_data,
+        raw_ctrl_seal: _,
         raw_table_record_attr,
         raw_table_record_extra,
         dirty,

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -206,6 +206,14 @@ impl DocumentCore {
         };
 
         doc.paginate();
+
+        // [#4488/#4495] 로드 픽스업(손상 lineseg 제거·빈 문단 reflow·안내문 제거)과
+        // 첫 paginate 의 materialization(그림 img_dim 등)까지 끝난 뒤 본문을 다시
+        // 봉인한다 — 파서 말미 봉인 그대로면 무변경 문서의 원본 바이트 통과가
+        // 로드 경로의 모델 보정 차이로 죽는다(honbo-save imgDim 실측). 이 지점
+        // 이후 본문 변경은 편집 명령(raw_stream 무효화 동반) 또는 공개 모델 직접
+        // 변경(봉인이 잡아야 할 대상)뿐이다.
+        doc.document.seal_body_raw_provenance();
         Ok(doc)
     }
 

--- a/src/document_core/commands/header_footer_ops.rs
+++ b/src/document_core/commands/header_footer_ops.rs
@@ -1119,6 +1119,7 @@ mod tests {
             },
             paragraphs: vec![Paragraph::default()],
             raw_stream: None,
+            raw_provenance: None,
         };
         doc.sections.push(section);
         let mut core = DocumentCore::new_empty();
@@ -1686,6 +1687,7 @@ mod tests {
             },
             paragraphs: vec![Paragraph::default()],
             raw_stream: None,
+            raw_provenance: None,
         };
         // text_width = 28504 - 4252 - 4252 = 20000 HWPUNIT (≈266.7px) — formatting.rs의
         // 셀 재현 테스트와 같은 축척.

--- a/src/document_core/commands/object_ops/picture.rs
+++ b/src/document_core/commands/object_ops/picture.rs
@@ -1848,6 +1848,7 @@ mod issue_1151_cell_picture_insert_tests {
             },
             paragraphs: vec![Paragraph::default()],
             raw_stream: None,
+            raw_provenance: None,
         });
         let mut core = DocumentCore::new_empty();
         core.set_document(doc);
@@ -2547,6 +2548,7 @@ mod issue_1151_v2_tac_toggle_tests {
             },
             paragraphs: vec![Paragraph::default()],
             raw_stream: None,
+            raw_provenance: None,
         });
         let mut core = DocumentCore::new_empty();
         core.set_document(doc);
@@ -3626,6 +3628,7 @@ mod issue_1280_textbox_creation_tests {
             },
             paragraphs: vec![Paragraph::default()],
             raw_stream: None,
+            raw_provenance: None,
         });
         let mut core = DocumentCore::new_empty();
         core.set_document(doc);

--- a/src/document_core/commands/object_ops/shape.rs
+++ b/src/document_core/commands/object_ops/shape.rs
@@ -2680,6 +2680,7 @@ mod resize_clamp_tests {
             },
             paragraphs: vec![Paragraph::default()],
             raw_stream: None,
+            raw_provenance: None,
         });
         let mut core = DocumentCore::new_empty();
         // set_document이 composed/styles/pagination 벡터를 일관되게 초기화한다.

--- a/src/document_core/commands/object_ops/table.rs
+++ b/src/document_core/commands/object_ops/table.rs
@@ -574,6 +574,7 @@ impl DocumentCore {
             outer_margin_top: 283,
             outer_margin_bottom: 283,
             raw_ctrl_data,
+            raw_ctrl_seal: None,
             raw_table_record_attr: 0x00000006, // 한컴 기본값 (bit1=셀분리금지, bit2=repeat_header)
             // [#3570] 한컴은 TABLE 레코드를 zone 개수까지만 쓴다 — 여분 2바이트 없음.
             raw_table_record_extra: Vec::new(),
@@ -1003,6 +1004,7 @@ impl DocumentCore {
             outer_margin_top: outer_margin,
             outer_margin_bottom: outer_margin,
             raw_ctrl_data,
+            raw_ctrl_seal: None,
             raw_table_record_attr: 0x04000006,
             // [#3570] 한컴은 TABLE 레코드를 zone 개수까지만 쓴다 — 여분 2바이트 없음.
             raw_table_record_extra: Vec::new(),

--- a/src/document_core/html_table_import.rs
+++ b/src/document_core/html_table_import.rs
@@ -612,6 +612,7 @@ impl DocumentCore {
             outer_margin_top: outer_margin,
             outer_margin_bottom: outer_margin,
             raw_ctrl_data,
+            raw_ctrl_seal: None,
             raw_table_record_attr: tbl_rec_attr,
             raw_table_record_extra: vec![0u8; 2], // 표준 추가 2바이트
             dirty: true,

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -7803,6 +7803,7 @@ mod tests {
                 ..Default::default()
             }],
             raw_stream: None,
+            raw_provenance: None,
         });
 
         let mut core = DocumentCore::new_empty();
@@ -7921,6 +7922,7 @@ mod tests {
             },
             paragraphs: vec![Paragraph::default()],
             raw_stream: None,
+            raw_provenance: None,
         });
 
         let mut core = DocumentCore::new_empty();
@@ -7967,6 +7969,7 @@ mod tests {
                 section_def,
                 paragraphs: vec![Paragraph::default()],
                 raw_stream: None,
+                raw_provenance: None,
             }
         }
 
@@ -8037,6 +8040,7 @@ mod tests {
                 section_def,
                 paragraphs: vec![Paragraph::default()],
                 raw_stream: None,
+                raw_provenance: None,
             }
         }
 
@@ -8100,6 +8104,7 @@ mod tests {
                 section_def,
                 paragraphs: vec![Paragraph::default()],
                 raw_stream: None,
+                raw_provenance: None,
             }
         }
 
@@ -8157,6 +8162,7 @@ mod tests {
             section_def: SectionDef::default(),
             paragraphs: vec![Paragraph::default()],
             raw_stream: None,
+            raw_provenance: None,
         });
         core.set_document(document);
         core.paginate();

--- a/src/model/control.rs
+++ b/src/model/control.rs
@@ -407,6 +407,13 @@ pub enum Parameter {
     Boolean {
         name: Option<String>,
         value: bool,
+        /// [#4437] 원본 lexical 표기 보존. `xs:boolean` 은 `0`/`1`/`false`/`true`
+        /// 네 표기가 모두 유효하고 실물 코퍼스에 섞여 있다(`Fiexde=1`,
+        /// `RefHyperLink=false`). 종전 렌더는 항상 `0`/`1` 로 정규화해 원본이
+        /// `false` 로 적은 것이 왕복에서 바이트가 달라졌다. 파서가 유효 lexical
+        /// 을 그대로 담고, 렌더는 이 값을 우선 되쓴다. 프로그램 생성 값은 None
+        /// → 종전대로 `0`/`1`.
+        lexical: Option<String>,
     },
     Integer {
         name: Option<String>,
@@ -467,8 +474,15 @@ impl ParameterList {
 impl Parameter {
     fn render_xml_into(&self, out: &mut String) {
         match self {
-            Parameter::Boolean { name, value } => {
-                render_scalar_param(out, "booleanParam", name, if *value { "1" } else { "0" });
+            Parameter::Boolean {
+                name,
+                value,
+                lexical,
+            } => {
+                // [#4437] 원본 표기 우선 — 파서가 검증한 유효 lexical 만 담기므로
+                // 그대로 되써도 스키마 안전하다.
+                let text = lexical.as_deref().unwrap_or(if *value { "1" } else { "0" });
+                render_scalar_param(out, "booleanParam", name, text);
             }
             Parameter::Integer { name, value } => {
                 render_scalar_param(out, "integerParam", name, &value.to_string());
@@ -506,6 +520,15 @@ fn render_scalar_param(out: &mut String, tag: &str, name: &Option<String>, text:
     out.push_str("</hp:");
     out.push_str(tag);
     out.push('>');
+}
+
+/// [#4437] `xs:boolean` 의 유효 lexical 이면 그 표기를 돌려준다 — 아니면 None.
+///
+/// 렌더가 이 값을 검증 없이 되쓰므로 유효 표기만 담는 것이 계약이다. 규정 밖
+/// 텍스트(빈 문자열 등)는 None 으로 떨어져 종전 정규화(`0`/`1`)를 탄다.
+pub(crate) fn boolean_lexical_of(text: &str) -> Option<String> {
+    let t = text.trim();
+    matches!(t, "0" | "1" | "true" | "false").then(|| t.to_string())
 }
 
 /// `ParameterList::render_xml` 전용 최소 XML 텍스트/속성값 이스케이프.
@@ -593,6 +616,7 @@ fn parse_one_param(s: &str, pos: &mut usize) -> Option<Parameter> {
             "booleanParam" => Parameter::Boolean {
                 name: Some(name),
                 value: matches!(text.trim(), "1" | "true"),
+                lexical: boolean_lexical_of(&text),
             },
             "integerParam" => Parameter::Integer {
                 name: Some(name),
@@ -719,13 +743,16 @@ mod parameter_list_codec_tests {
                     value: "이곳을 마우스로 누르고 내용을 입력하세요.".to_string(),
                     preserve_space: false,
                 },
+                // [#4437] 실물 코퍼스 표기 그대로 — `1` 과 `false` 가 섞여 있다.
                 Parameter::Boolean {
                     name: Some("Fiexde".to_string()),
                     value: true,
+                    lexical: Some("1".to_string()),
                 },
                 Parameter::Boolean {
                     name: Some("RefHyperLink".to_string()),
                     value: false,
+                    lexical: Some("false".to_string()),
                 },
                 Parameter::Float {
                     name: Some("Ratio".to_string()),
@@ -750,6 +777,37 @@ mod parameter_list_codec_tests {
         assert!(xml.ends_with("</hp:parameters>"));
         let parsed = ParameterList::parse_xml(&xml).expect("parse_xml 실패");
         assert_eq!(parsed, original);
+    }
+
+    /// [#4437] 원본 lexical(`false`/`true`) 이 정규화(`0`/`1`)되지 않고 바이트
+    /// 그대로 왕복해야 한다.
+    #[test]
+    fn issue4437_boolean_lexical_round_trips_verbatim() {
+        let xml = sample_tree().render_xml("parameters");
+        assert!(
+            xml.contains(r#"<hp:booleanParam name="RefHyperLink">false</hp:booleanParam>"#),
+            "원본 `false` 표기가 `0` 으로 정규화되면 안 된다: {xml}"
+        );
+        assert!(
+            xml.contains(r#"<hp:booleanParam name="Fiexde">1</hp:booleanParam>"#),
+            "원본 `1` 표기는 그대로: {xml}"
+        );
+        // parse → render 재왕복도 바이트 동일.
+        let reparsed = ParameterList::parse_xml(&xml).expect("parse_xml");
+        assert_eq!(reparsed.render_xml("parameters"), xml);
+
+        // lexical 이 없는(프로그램 생성) Boolean 은 종전대로 0/1 정규화.
+        let synth = ParameterList {
+            name: Some(String::new()),
+            items: vec![Parameter::Boolean {
+                name: Some("New".to_string()),
+                value: false,
+                lexical: None,
+            }],
+        };
+        assert!(synth
+            .render_xml("parameters")
+            .contains(r#"<hp:booleanParam name="New">0</hp:booleanParam>"#));
     }
 
     #[test]

--- a/src/model/control.rs
+++ b/src/model/control.rs
@@ -11,8 +11,21 @@ use super::paragraph::Paragraph;
 use super::shape::{CommonObjAttr, ShapeObject};
 use super::table::Table;
 
+/// [#4488] HashMap 을 키 정렬 순서로 직렬화한다 — 다이제스트 결정성 보장용.
+fn serialize_sorted_string_map<S>(
+    map: &HashMap<String, String>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let mut entries: Vec<(&String, &String)> = map.iter().collect();
+    entries.sort();
+    serializer.collect_map(entries)
+}
+
 /// 문단 내 컨트롤 (확장 컨트롤)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub enum Control {
     /// 구역 정의 ('secd')
     SectionDef(Box<SectionDef>),
@@ -112,7 +125,7 @@ pub const CTRL_CHAR_CODE_UNITS: u32 = 8;
 pub const EQUATION_LINE_MODE_BIT: u32 = 0x0000_0001;
 
 /// 수식 ('eqed' 컨트롤, HWP 스펙 표 105)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Equation {
     /// 개체 공통 속성 (위치, 크기, 배치)
     pub common: CommonObjAttr,
@@ -145,10 +158,14 @@ pub struct Equation {
     pub font_name: String,
     /// 라운드트립용 원본 ctrl_data
     pub raw_ctrl_data: Vec<u8>,
+    /// [#4495] raw_ctrl_data 출처 봉인 — 봉인 시점 `common` 의 다이제스트.
+    /// 계약은 Table::raw_ctrl_seal 과 동일 (`model::raw_provenance` 참조).
+    #[serde(skip)]
+    pub raw_ctrl_seal: Option<[u8; 32]>,
 }
 
 /// 자동 번호 ('atno' 컨트롤, HWP 스펙 표 144)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct AutoNumber {
     /// 번호 종류 (각주, 미주, 그림, 표, 수식)
     pub number_type: AutoNumberType,
@@ -169,7 +186,7 @@ pub struct AutoNumber {
 }
 
 /// 자동 번호 종류
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum AutoNumberType {
     #[default]
     Page,
@@ -183,7 +200,7 @@ pub enum AutoNumberType {
 }
 
 /// 새 번호 지정 ('nwno' 컨트롤)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct NewNumber {
     /// 번호 종류
     pub number_type: AutoNumberType,
@@ -192,7 +209,7 @@ pub struct NewNumber {
 }
 
 /// 쪽 번호 위치 ('pgnp' 컨트롤, HWP 스펙 표 149)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct PageNumberPos {
     /// 번호 형식 (표 150 bit 0~7, 표 134 참조)
     pub format: u8,
@@ -209,7 +226,7 @@ pub struct PageNumberPos {
 }
 
 /// 책갈피 ('bokm' 컨트롤)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Bookmark {
     /// 책갈피 이름
     pub name: String,
@@ -225,7 +242,7 @@ pub struct Bookmark {
 /// | 0 | `BOTH` |
 /// | 1 | `EVEN` |
 /// | 2 | `ODD` |
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize)]
 pub enum PageStartsOn {
     /// 양쪽 (기본값)
     #[default]
@@ -275,7 +292,7 @@ impl PageStartsOn {
 }
 
 /// 쪽 번호 시작 쪽 컨트롤 ('pgct')
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize)]
 pub struct PageNumCtrl {
     /// 쪽 번호가 시작되는 쪽
     pub page_starts_on: PageStartsOn,
@@ -290,7 +307,7 @@ pub struct PageNumCtrl {
 ///
 /// HWPX 는 `<hp:ctrl><hp:indexmark><hp:firstKey/><hp:secondKey/></hp:indexmark></hp:ctrl>`
 /// 로 적는다(ParaList XML schema.xml:209).
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
 pub struct IndexMark {
     /// 첫째 키
     pub first_key: String,
@@ -299,7 +316,7 @@ pub struct IndexMark {
 }
 
 /// 하이퍼링크 ('%hlk' 필드)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Hyperlink {
     /// URL
     pub url: String,
@@ -308,7 +325,7 @@ pub struct Hyperlink {
 }
 
 /// 덧말 ('tdut' 컨트롤)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Ruby {
     /// 기준 텍스트 (`<hp:mainText>`) — 덧말이 달리는 본문 글자. (#1587)
     /// 파서가 para.text 에 넣지 않고 여기 보존한다(시각 충실도 핵심).
@@ -328,7 +345,7 @@ pub struct Ruby {
 }
 
 /// 글자 겹침 ('tcps' 컨트롤, HWP 스펙 표 152)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct CharOverlap {
     /// 겹칠 글자 목록 (최대 9글자)
     pub chars: Vec<char>,
@@ -343,7 +360,7 @@ pub struct CharOverlap {
 }
 
 /// 감추기 ('pghd' 컨트롤)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct PageHide {
     /// 머리말 감추기
     pub hide_header: bool,
@@ -360,7 +377,7 @@ pub struct PageHide {
 }
 
 /// 숨은 설명 ('tcmt' 컨트롤)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct HiddenComment {
     /// 문단 리스트
     pub paragraphs: Vec<Paragraph>,
@@ -370,7 +387,7 @@ pub struct HiddenComment {
 ///
 /// 편집 IR 은 빈 필드로 정규화된 상태가 authoritative 이고, 이 구조체는 **저장 시
 /// 원본 파일 형상을 되돌리기 위한 파생 상태**다 (값 API·렌더는 이 값을 보지 않는다).
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
 pub struct GuideResidue {
     /// 제거된 본문 텍스트 원문 (한컴이 안내문 뒤에 붙이는 trailing 공백까지 그대로).
     pub text: String,
@@ -385,7 +402,7 @@ pub struct GuideResidue {
 /// 스칼라와 재귀하는 listParam 1종, 도합 5종. 각 파라미터의 **의미는 해석하지 않고**
 /// 이름과 타입 그대로 보존한다(HWP5 왕복 시 `Prop`/`Direction`/`Path`/`Category` 등이
 /// `Command` 하나로 축소되던 손실의 근본 수정).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub enum Parameter {
     Boolean {
         name: Option<String>,
@@ -411,7 +428,7 @@ pub enum Parameter {
 
 /// `hp:ParameterList` 자체 — `<hp:parameters>`(필드 루트) 또는 `<hp:listParam>`(중첩) 둘 다
 /// 이 표현을 쓴다. `cnt` 속성은 `items.len()` 에서 유도하므로 별도 저장하지 않는다.
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
 pub struct ParameterList {
     pub name: Option<String>,
     pub items: Vec<Parameter>,
@@ -754,7 +771,7 @@ mod parameter_list_codec_tests {
 }
 
 /// 필드 컨트롤
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Field {
     /// 필드 타입
     pub field_type: FieldType,
@@ -960,7 +977,7 @@ impl Field {
 }
 
 /// 필드 타입
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum FieldType {
     #[default]
     Unknown,
@@ -997,7 +1014,7 @@ pub enum FormType {
 }
 
 /// 양식 개체 ('form' 컨트롤, ctrl_id=0x666f726d)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct FormObject {
     /// 양식 개체 타입
     pub form_type: FormType,
@@ -1020,11 +1037,15 @@ pub struct FormObject {
     /// 활성화 여부
     pub enabled: bool,
     /// 기타 속성 (원본 키-값 보존)
+    ///
+    /// [#4488] serde 직렬화는 정렬 순회를 강제한다 — HashMap 순회 순서가
+    /// 다이제스트(model::raw_provenance)에 실리면 봉인이 비결정적이 된다.
+    #[serde(serialize_with = "serialize_sorted_string_map")]
     pub properties: HashMap<String, String>,
 }
 
 /// 알 수 없는 컨트롤
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct UnknownControl {
     /// 컨트롤 ID
     pub ctrl_id: u32,

--- a/src/model/document.rs
+++ b/src/model/document.rs
@@ -245,10 +245,14 @@ pub struct Section {
     /// 원본 BodyText 레코드 스트림 바이트 (직렬화 시 원본 복원용)
     /// 편집 시 None으로 초기화하여 재직렬화 유도
     pub raw_stream: Option<Vec<u8>>,
+    /// [#4488] raw_stream 출처 봉인 — 파싱(+로드 픽스업) 완료 시점의 모델 상태와
+    /// 원본 바이트의 다이제스트 쌍. 저장 시 둘 다 일치할 때만 raw 를 재사용한다.
+    /// 계약 전문은 `model::raw_provenance` 모듈 주석.
+    pub raw_provenance: Option<crate::model::raw_provenance::SectionSeal>,
 }
 
 /// 구역 정의 (HWPTAG_CTRL_HEADER - 'secd')
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct SectionDef {
     /// 속성 비트 플래그
     pub flags: u32,

--- a/src/model/footnote.rs
+++ b/src/model/footnote.rs
@@ -12,7 +12,7 @@ use super::*;
 /// LIST_HEADER for Footnote (size=16): paraCount(SInt4) + property(UInt4) + 8 byte zero padding.
 ///
 /// 참조: `hwplib::ControlFootnote` + `CtrlHeaderFootnote`.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct Footnote {
     /// 각주 번호
     pub number: u16,
@@ -31,7 +31,7 @@ pub struct Footnote {
 }
 
 /// 미주 ('en  ' 컨트롤) — [Task #1050] Footnote 와 동일 구조
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct Endnote {
     /// 미주 번호
     pub number: u16,
@@ -50,7 +50,7 @@ pub struct Endnote {
 }
 
 /// 각주/미주 모양 (HWPTAG_FOOTNOTE_SHAPE)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct FootnoteShape {
     /// 속성 비트 플래그
     pub attr: u32,
@@ -237,7 +237,7 @@ impl FootnoteShape {
 }
 
 /// 번호 형식
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum NumberFormat {
     #[default]
     Digit, // 1, 2, 3
@@ -262,7 +262,7 @@ pub enum NumberFormat {
 }
 
 /// 번호 매기기 방식
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum FootnoteNumbering {
     #[default]
     /// 앞 구역에 이어서
@@ -274,7 +274,7 @@ pub enum FootnoteNumbering {
 }
 
 /// 배치 방법
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum FootnotePlacement {
     #[default]
     /// 각 단마다 따로 배열 / 문서의 마지막

--- a/src/model/header_footer.rs
+++ b/src/model/header_footer.rs
@@ -3,7 +3,7 @@
 use super::paragraph::Paragraph;
 
 /// 머리말 ('head' 컨트롤)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct Header {
     /// 적용 범위
     pub apply_to: HeaderFooterApply,
@@ -26,7 +26,7 @@ pub struct Header {
 }
 
 /// 꼬리말 ('foot' 컨트롤)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct Footer {
     /// 적용 범위
     pub apply_to: HeaderFooterApply,
@@ -49,7 +49,7 @@ pub struct Footer {
 }
 
 /// 머리말/꼬리말 적용 범위
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum HeaderFooterApply {
     #[default]
     /// 양쪽 (모든 페이지)
@@ -64,7 +64,7 @@ pub enum HeaderFooterApply {
 ///
 /// 구역 단위 페이지 템플릿. 양쪽/홀수/짝수 3종류 설정 가능.
 /// SectionDef의 자식 LIST_HEADER 레코드에서 파싱.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct MasterPage {
     /// 적용 범위 (양쪽/홀수/짝수)
     pub apply_to: HeaderFooterApply,

--- a/src/model/image.rs
+++ b/src/model/image.rs
@@ -5,7 +5,7 @@ use super::style::ShapeBorderLine;
 use super::*;
 
 /// 그림 개체 (HWPTAG_SHAPE_COMPONENT_PICTURE)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct Picture {
     /// 개체 공통 속성
     pub common: CommonObjAttr,
@@ -67,7 +67,7 @@ impl Picture {
 }
 
 /// 자르기 정보
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
 pub struct CropInfo {
     pub left: i32,
     pub top: i32,
@@ -76,7 +76,7 @@ pub struct CropInfo {
 }
 
 /// 이미지 속성
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct ImageAttr {
     /// 밝기
     pub brightness: i8,
@@ -96,13 +96,13 @@ pub struct ImageAttr {
 }
 
 /// HWPX 그림 효과 (`hp:effects`).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct PictureEffects {
     pub shadow: Option<PictureShadow>,
 }
 
 /// HWPX 그림 그림자 효과 (`hp:shadow`).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct PictureShadow {
     pub style: Option<String>,
     pub alpha: Option<String>,
@@ -117,14 +117,14 @@ pub struct PictureShadow {
 }
 
 /// HWPX 효과의 x/y 좌표성 값 (`hp:skew`, `hp:scale`).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct EffectPoint {
     pub x: Option<String>,
     pub y: Option<String>,
 }
 
 /// HWPX 효과 색상 (`hp:effectsColor`).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct EffectColor {
     pub color_type: Option<String>,
     pub scheme_idx: Option<String>,
@@ -134,7 +134,7 @@ pub struct EffectColor {
 }
 
 /// HWPX 효과 RGB 색상 (`hp:rgb`).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct EffectRgb {
     pub r: Option<String>,
     pub g: Option<String>,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -33,7 +33,7 @@ pub type HwpUnit16 = i16;
 pub type ColorRef = u32;
 
 /// 2차원 좌표
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
 pub struct Point {
     pub x: i32,
     pub y: i32,
@@ -59,7 +59,7 @@ impl Rect {
 }
 
 /// 4방향 여백
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
 pub struct Padding {
     pub left: HwpUnit16,
     pub right: HwpUnit16,

--- a/src/model/page.rs
+++ b/src/model/page.rs
@@ -3,7 +3,7 @@
 use super::*;
 
 /// 용지 설정 (HWPTAG_PAGE_DEF)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct PageDef {
     /// 용지 가로 크기
     pub width: HwpUnit,
@@ -54,7 +54,7 @@ impl PageDef {
 }
 
 /// 제책 방법
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum BindingMethod {
     #[default]
     /// 한쪽 편집
@@ -66,7 +66,7 @@ pub enum BindingMethod {
 }
 
 /// 쪽 테두리/배경 (HWPTAG_PAGE_BORDER_FILL)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct PageBorderFill {
     /// 속성 비트 플래그
     pub attr: u32,
@@ -97,7 +97,7 @@ pub struct PageBorderFill {
 }
 
 /// 쪽 테두리 렌더 위치 기준
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize)]
 pub enum PageBorderBasis {
     /// 본문 영역 기준 (body_area edge 에서 spacing)
     #[default]
@@ -107,7 +107,7 @@ pub enum PageBorderBasis {
 }
 
 /// 쪽 테두리/배경 대화상자 위치 기준
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize)]
 pub enum PageBorderUiBasis {
     /// 한컴 UI의 종이 기준
     #[default]
@@ -117,7 +117,7 @@ pub enum PageBorderUiBasis {
 }
 
 /// 단 정의 ('cold' 컨트롤)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct ColumnDef {
     /// 단 종류
     pub column_type: ColumnType,
@@ -147,7 +147,7 @@ pub struct ColumnDef {
 }
 
 /// 단 종류
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum ColumnType {
     #[default]
     Normal,
@@ -158,7 +158,7 @@ pub enum ColumnType {
 }
 
 /// 단 방향
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum ColumnDirection {
     #[default]
     LeftToRight,

--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -4,7 +4,7 @@ use super::control::{Control, CTRL_CHAR_CODE_UNITS};
 use serde::{Deserialize, Serialize};
 
 /// 문단 (HWPTAG_PARA_HEADER + 하위 레코드)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct Paragraph {
     /// 문자 수 (제어 문자 포함)
     pub char_count: u32,
@@ -96,7 +96,7 @@ pub struct Paragraph {
 ///
 /// `Relaxed` 순서로 충분하다 — 값은 (문단, 폭)의 결정적 함수라 경합 시 최악이
 /// 중복 측정일 뿐 오답이 없다.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, serde::Serialize)]
 pub struct SingleLineOverflowMemo(std::sync::atomic::AtomicU64);
 
 impl SingleLineOverflowMemo {
@@ -237,7 +237,7 @@ pub enum ColumnBreakType {
 }
 
 /// 글자 모양 참조 (문단 내 위치별 글자 모양)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct CharShapeRef {
     /// 글자 모양이 바뀌는 시작 위치
     pub start_pos: u32,
@@ -249,7 +249,7 @@ pub struct CharShapeRef {
 ///
 /// **표준**: `mydocs/tech/document_ir_lineseg_standard.md` (Task #604)
 /// 모든 i32 필드는 HWPUNIT (1 inch = 7200 HWPUNIT).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct LineSeg {
     /// 본 줄이 차지하는 텍스트 시작 위치 (UTF-16 code unit, 문단 시작 기준)
     pub text_start: u32,
@@ -369,7 +369,7 @@ impl LineSeg {
 }
 
 /// 영역 태그 (HWPTAG_PARA_RANGE_TAG)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct RangeTag {
     /// 영역 시작
     pub start: u32,
@@ -392,7 +392,7 @@ pub struct RangeTag {
 /// 8 code unit 을 점유하므로 이 마커를 버리면 문단 축이 그만큼 짧아지고,
 /// 한글은 축이 어긋난 `<hp:lineseg textpos>` 를 만나면 본문을 통째로 버린다
 /// (10k 스윕 F-절단군 — 77 문서·2,237 개).
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
 pub struct TitleMark {
     /// `text` 문자열 내 삽입 위치 (이 인덱스의 문자 **앞**에 놓인다)
     pub char_idx: usize,
@@ -401,7 +401,7 @@ pub struct TitleMark {
 }
 
 /// 필드 텍스트 범위 (0x03 FIELD_BEGIN ~ 0x04 FIELD_END 사이 텍스트)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct FieldRange {
     /// text 문자열 내 시작 인덱스 (포함)
     pub start_char_idx: usize,
@@ -431,7 +431,7 @@ pub struct FieldRange {
 /// 다단락 필드의 종료 마커. begin 문단에서 `Control::Field` 로 보존되는 것과 달리,
 /// end 문단에는 컨트롤·FieldRange 가 없어 8유닛 슬롯을 표현할 산출물이 없다.
 /// 이를 기록해 직렬화기가 `<hp:fieldEnd>` 를 같은 위치에 복원한다 (Task #1556).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct OrphanFieldEnd {
     /// text 문자열 내 위치 (이 인덱스 직전에 8유닛 fieldEnd 슬롯이 놓인다).
     /// 텍스트 끝이면 `text.chars().count()`.

--- a/src/model/raw_provenance.rs
+++ b/src/model/raw_provenance.rs
@@ -232,6 +232,205 @@ impl DocInfo {
     }
 }
 
+// ===========================================================================
+// [#4488] Section raw_stream 봉인 + [#4495] 본문 컨트롤 하위 raw 봉인
+// ===========================================================================
+
+/// 파싱 완료 시점의 Section 봉인 — DocInfo 와 같은 계약, 다른 스트림·소유자.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SectionSeal {
+    /// 봉인 시점 모델 상태(section_def + paragraphs)의 다이제스트.
+    pub model_digest: [u8; 32],
+    /// 봉인 시점 `raw_stream` 바이트의 다이제스트.
+    pub raw_digest: [u8; 32],
+}
+
+/// Section 모델 상태의 다이제스트 — raw 캐시 필드는 전수 구조분해로 뺀다.
+pub fn section_model_digest(section: &crate::model::document::Section) -> [u8; 32] {
+    let crate::model::document::Section {
+        section_def,
+        paragraphs,
+        raw_stream: _,
+        raw_provenance: _,
+    } = section;
+
+    #[derive(Serialize)]
+    struct Fingerprint<'a> {
+        section_def: &'a crate::model::document::SectionDef,
+        paragraphs: &'a [crate::model::paragraph::Paragraph],
+    }
+
+    let mut hasher = blake3::Hasher::new();
+    serde_json::to_writer(
+        &mut hasher,
+        &Fingerprint {
+            section_def,
+            paragraphs,
+        },
+    )
+    .expect("모델 다이제스트 직렬화는 실패할 수 없다 (순수 인메모리 인코딩)");
+    *hasher.finalize().as_bytes()
+}
+
+impl crate::model::document::Section {
+    /// 파싱(+로드 픽스업) 완료 시점에 호출 — raw 캐시가 있으면 봉인한다.
+    pub fn seal_raw_provenance(&mut self) {
+        self.raw_provenance = self.raw_stream.as_ref().map(|raw| SectionSeal {
+            model_digest: section_model_digest(self),
+            raw_digest: bytes_digest(raw),
+        });
+    }
+
+    /// 저장 시점 검증 — DocInfo 쪽과 동일 계약(봉인 없는 raw 는 종전대로 허용).
+    pub fn raw_provenance_permits_reuse(&self) -> bool {
+        let Some(raw) = self.raw_stream.as_ref() else {
+            return false;
+        };
+        match &self.raw_provenance {
+            None => true,
+            Some(seal) => {
+                seal.raw_digest == bytes_digest(raw)
+                    && seal.model_digest == section_model_digest(self)
+            }
+        }
+    }
+}
+
+/// [#4495] OLE payload(raw_tag_data)가 대표하는 모델 필드의 다이제스트.
+///
+/// `serialize_ole_data` 의 모델 경로가 소비하는 필드가 판정 범위다 — 그 밖의
+/// 필드 변경은 이 레코드의 바이트에 영향을 주지 않으므로 raw 를 유지한다.
+pub fn ole_payload_digest(ole: &crate::model::shape::OleShape) -> [u8; 32] {
+    record_digest(&(ole.extent_x, ole.extent_y, ole.bin_data_id))
+}
+
+/// [#4495] 하위 raw 레코드를 가진 컨트롤 전부를 깊이 우선으로 봉인한다.
+///
+/// - Table/Equation CTRL_HEADER raw ↔ `common`(CommonObjAttr) — 저장기가 raw
+///   부재 시 합성하는 원천이 `common` 이므로 판정 범위도 `common` 이다.
+///   (`raw_ctrl_data` 자체는 판정 밖 — 셀 폭 조절처럼 raw 를 직접 갱신하는
+///   기존 명령(dual-write, table.rs `refresh_raw_ctrl_size` 참조)과 충돌하지
+///   않기 위함이다.)
+/// - OLE raw_tag_data ↔ payload 모델 필드([`ole_payload_digest`]).
+///
+/// 순회는 `for_each_ole_mut`(hwpx_to_hwp.rs)와 같은 소유자 집합을 밟는다 —
+/// 저장소에 정본 순회기가 아직 없어(#4422) 여기 사본을 둔다. 누락되면 그
+/// 컨트롤은 봉인 없이 남아 **종전 계약(raw 우선)** 으로 동작한다 — 새 검증이
+/// 빠지는 것이지 새 손실이 생기는 방향이 아니다.
+fn seal_raw_bearing_controls(paragraphs: &mut [crate::model::paragraph::Paragraph]) {
+    use crate::model::control::Control;
+    use crate::model::shape::ShapeObject;
+
+    fn walk_caption(caption: &mut crate::model::shape::Caption) {
+        seal_raw_bearing_controls(&mut caption.paragraphs);
+    }
+
+    fn walk_drawing(drawing: &mut crate::model::shape::DrawingObjAttr) {
+        if let Some(text_box) = &mut drawing.text_box {
+            seal_raw_bearing_controls(&mut text_box.paragraphs);
+        }
+        if let Some(caption) = &mut drawing.caption {
+            walk_caption(caption);
+        }
+    }
+
+    fn walk_shape(shape: &mut ShapeObject) {
+        match shape {
+            ShapeObject::Picture(pic) => {
+                if let Some(caption) = &mut pic.caption {
+                    walk_caption(caption);
+                }
+            }
+            ShapeObject::Group(group) => {
+                for child in &mut group.children {
+                    walk_shape(child);
+                }
+                if let Some(caption) = &mut group.caption {
+                    walk_caption(caption);
+                }
+            }
+            ShapeObject::Chart(chart) => {
+                walk_drawing(&mut chart.drawing);
+                if let Some(caption) = &mut chart.caption {
+                    walk_caption(caption);
+                }
+            }
+            ShapeObject::Ole(ole) => {
+                walk_drawing(&mut ole.drawing);
+                if let Some(caption) = &mut ole.caption {
+                    walk_caption(caption);
+                }
+                if !ole.raw_tag_data.is_empty() {
+                    ole.raw_tag_seal = Some(ole_payload_digest(ole));
+                }
+            }
+            _ => {
+                if let Some(drawing) = shape.drawing_mut() {
+                    walk_drawing(drawing);
+                }
+            }
+        }
+    }
+
+    for para in paragraphs {
+        for control in &mut para.controls {
+            match control {
+                Control::Table(table) => {
+                    for cell in &mut table.cells {
+                        seal_raw_bearing_controls(&mut cell.paragraphs);
+                    }
+                    if let Some(caption) = &mut table.caption {
+                        walk_caption(caption);
+                    }
+                    if !table.raw_ctrl_data.is_empty() {
+                        table.raw_ctrl_seal = Some(record_digest(&table.common));
+                    }
+                }
+                Control::Equation(eq) => {
+                    if !eq.raw_ctrl_data.is_empty() {
+                        eq.raw_ctrl_seal = Some(record_digest(&eq.common));
+                    }
+                }
+                Control::Picture(pic) => {
+                    if let Some(caption) = &mut pic.caption {
+                        walk_caption(caption);
+                    }
+                }
+                Control::Shape(shape) => walk_shape(shape),
+                Control::Header(header) => seal_raw_bearing_controls(&mut header.paragraphs),
+                Control::Footer(footer) => seal_raw_bearing_controls(&mut footer.paragraphs),
+                Control::Footnote(fnote) => seal_raw_bearing_controls(&mut fnote.paragraphs),
+                Control::Endnote(enote) => seal_raw_bearing_controls(&mut enote.paragraphs),
+                Control::HiddenComment(comment) => {
+                    seal_raw_bearing_controls(&mut comment.paragraphs)
+                }
+                Control::Field(field) => seal_raw_bearing_controls(&mut field.memo_paragraphs),
+                Control::SectionDef(section_def) => {
+                    for master_page in &mut section_def.master_pages {
+                        seal_raw_bearing_controls(&mut master_page.paragraphs);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+impl crate::model::document::Document {
+    /// [#4488/#4495] 본문 raw 캐시 전부를 봉인한다 — 파싱(+로드 픽스업) 완료
+    /// 시점에 호출. 컨트롤 봉인을 먼저 세우고(봉인 필드는 `#[serde(skip)]` 이라
+    /// Section 다이제스트에 실리지 않는다) Section 봉인을 계산한다.
+    pub fn seal_body_raw_provenance(&mut self) {
+        for section in &mut self.sections {
+            seal_raw_bearing_controls(&mut section.paragraphs);
+            for master_page in &mut section.section_def.master_pages {
+                seal_raw_bearing_controls(&mut master_page.paragraphs);
+            }
+            section.seal_raw_provenance();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/model/shape.rs
+++ b/src/model/shape.rs
@@ -27,7 +27,7 @@ pub(crate) mod common_obj_offsets {
 }
 
 /// 개체 공통 속성 (모든 개체에 공통)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct CommonObjAttr {
     /// 컨트롤 ID
     pub ctrl_id: u32,
@@ -112,7 +112,7 @@ pub struct CommonObjAttr {
 }
 
 /// HWPX 개체 `numberingType` (캡션 번호 범주)
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum ObjectNumberingType {
     #[default]
     None,
@@ -122,7 +122,7 @@ pub enum ObjectNumberingType {
 }
 
 /// HWPX 개체 `dropcapstyle` (드롭캡 표시 방식). OWPML Core 스키마 `DropCapStyleType`.
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum DropCapStyle {
     #[default]
     None,
@@ -132,7 +132,7 @@ pub enum DropCapStyle {
 }
 
 /// 세로 위치 기준
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum VertRelTo {
     #[default]
     Paper,
@@ -141,7 +141,7 @@ pub enum VertRelTo {
 }
 
 /// 세로 정렬 방식
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum VertAlign {
     #[default]
     Top,
@@ -152,7 +152,7 @@ pub enum VertAlign {
 }
 
 /// 가로 위치 기준
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum HorzRelTo {
     #[default]
     Paper,
@@ -162,7 +162,7 @@ pub enum HorzRelTo {
 }
 
 /// 가로 정렬 방식
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum HorzAlign {
     #[default]
     Left,
@@ -173,7 +173,7 @@ pub enum HorzAlign {
 }
 
 /// 크기 기준 (너비/높이)
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum SizeCriterion {
     /// 종이 기준 (퍼센트)
     Paper,
@@ -203,7 +203,7 @@ pub enum TextWrap {
 /// 텍스트가 흐르는 방향 (attr bit 24-25)
 ///
 /// HWPX `textFlow` 속성값과 대응한다.
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum TextFlow {
     #[default]
     BothSides,
@@ -213,7 +213,7 @@ pub enum TextFlow {
 }
 
 /// 개체 요소 속성 (그리기 개체 공통)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct ShapeComponentAttr {
     /// SHAPE_COMPONENT 내 ctrl_id (라운드트립 보존용, 0이면 기본값 사용)
     pub ctrl_id: u32,
@@ -303,7 +303,7 @@ impl Default for ShapeComponentAttr {
 }
 
 /// 그리기 개체 공통 속성
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct DrawingObjAttr {
     /// 개체 요소 속성
     pub shape_attr: ShapeComponentAttr,
@@ -330,7 +330,7 @@ pub struct DrawingObjAttr {
 }
 
 /// 글상자 (그리기 개체 내 텍스트)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct TextBox {
     /// LIST_HEADER list_attr (라운드트립 보존용)
     pub list_attr: u32,
@@ -358,7 +358,7 @@ pub struct TextBox {
 }
 
 /// 그리기 개체 종류
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub enum ShapeObject {
     /// 직선
     Line(LineShape),
@@ -510,7 +510,7 @@ impl ShapeObject {
 }
 
 /// 직선 개체 (HWPTAG_SHAPE_COMPONENT_LINE)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct LineShape {
     /// 공통 속성
     pub common: CommonObjAttr,
@@ -527,7 +527,7 @@ pub struct LineShape {
 }
 
 /// 연결선 타입 (9종)
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 #[repr(u32)]
 pub enum LinkLineType {
     #[default]
@@ -573,7 +573,7 @@ impl LinkLineType {
 }
 
 /// 연결선 제어점
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct ConnectorControlPoint {
     pub x: i32,
     pub y: i32,
@@ -581,7 +581,7 @@ pub struct ConnectorControlPoint {
 }
 
 /// 연결선 추가 데이터 (SC_LINE 확장)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct ConnectorData {
     /// 연결선 타입
     pub link_type: LinkLineType,
@@ -600,7 +600,7 @@ pub struct ConnectorData {
 }
 
 /// 사각형 개체 (HWPTAG_SHAPE_COMPONENT_RECTANGLE)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct RectangleShape {
     /// 공통 속성
     pub common: CommonObjAttr,
@@ -615,7 +615,7 @@ pub struct RectangleShape {
 }
 
 /// 타원 개체 (HWPTAG_SHAPE_COMPONENT_ELLIPSE)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct EllipseShape {
     /// 공통 속성
     pub common: CommonObjAttr,
@@ -640,7 +640,7 @@ pub struct EllipseShape {
 }
 
 /// 호 개체 (HWPTAG_SHAPE_COMPONENT_ARC)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct ArcShape {
     /// 공통 속성
     pub common: CommonObjAttr,
@@ -657,7 +657,7 @@ pub struct ArcShape {
 }
 
 /// 다각형 개체 (HWPTAG_SHAPE_COMPONENT_POLYGON)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct PolygonShape {
     /// 공통 속성
     pub common: CommonObjAttr,
@@ -670,7 +670,7 @@ pub struct PolygonShape {
 }
 
 /// 곡선 개체 (HWPTAG_SHAPE_COMPONENT_CURVE)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct CurveShape {
     /// 공통 속성
     pub common: CommonObjAttr,
@@ -683,7 +683,7 @@ pub struct CurveShape {
 }
 
 /// 묶음 개체 (HWPTAG_SHAPE_COMPONENT_CONTAINER)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct GroupShape {
     /// 공통 속성
     pub common: CommonObjAttr,
@@ -696,7 +696,7 @@ pub struct GroupShape {
 }
 
 /// 캡션 정보
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct Caption {
     /// 방향 (0: left, 1: right, 2: top, 3: bottom)
     pub direction: CaptionDirection,
@@ -715,7 +715,7 @@ pub struct Caption {
 }
 
 /// 캡션 방향
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum CaptionDirection {
     Left,
     Right,
@@ -725,7 +725,7 @@ pub enum CaptionDirection {
 }
 
 /// Left/Right 캡션의 세로 정렬
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum CaptionVertAlign {
     #[default]
     Top,
@@ -738,7 +738,7 @@ pub enum CaptionVertAlign {
 // ============================================================
 
 /// 차트 종류 (1차 범위: Bar/Column/Line/Pie/Area/Scatter)
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum ChartType {
     Bar,
     Column,
@@ -751,7 +751,7 @@ pub enum ChartType {
 }
 
 /// 범례 위치
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum LegendPosition {
     #[default]
     Right,
@@ -766,14 +766,14 @@ pub enum LegendPosition {
 }
 
 /// 범례
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Legend {
     pub position: LegendPosition,
     pub visible: bool,
 }
 
 /// 축
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Axis {
     pub label: Option<String>,
     pub labels: Vec<String>,
@@ -782,7 +782,7 @@ pub struct Axis {
 }
 
 /// 데이터 시리즈 (한 줄기 막대/선 등)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct DataSeries {
     /// 시리즈 이름 (범례 표시용)
     pub name: String,
@@ -795,7 +795,7 @@ pub struct DataSeries {
 }
 
 /// 차트 개체 (GSO + HWPTAG_CHART_DATA)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct ChartShape {
     /// 공통 속성
     pub common: CommonObjAttr,
@@ -824,7 +824,7 @@ pub struct ChartShape {
 // ============================================================
 
 /// OLE 프리뷰 이미지 포맷
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize)]
 pub enum OlePreviewFormat {
     Wmf,
     Emf,
@@ -833,14 +833,14 @@ pub enum OlePreviewFormat {
 }
 
 /// OLE 프리뷰 이미지
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct OlePreview {
     pub format: OlePreviewFormat,
     pub bytes: Vec<u8>,
 }
 
 /// OLE 표시 방식 (DrawingAspect)
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum OleDrawingAspect {
     #[default]
     Content,
@@ -850,7 +850,7 @@ pub enum OleDrawingAspect {
 }
 
 /// OLE 개체 (HWPTAG_SHAPE_COMPONENT_OLE)
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct OleShape {
     /// 공통 속성
     pub common: CommonObjAttr,
@@ -870,6 +870,11 @@ pub struct OleShape {
     pub preview: Option<OlePreview>,
     /// OLE 레코드 원본 바이트 (라운드트립 보존)
     pub raw_tag_data: Vec<u8>,
+    /// [#4495] raw_tag_data 출처 봉인 — 봉인 시점 OLE payload 모델 필드
+    /// (extent_x/extent_y/bin_data_id)의 다이제스트. 저장 시 그 필드들이 봉인과
+    /// 같을 때만 raw 를 재사용한다. None 은 종전 계약(raw 우선) 유지.
+    #[serde(skip)]
+    pub raw_tag_seal: Option<[u8; 32]>,
     /// 캡션
     pub caption: Option<Caption>,
     /// [#3546] HWPX `<hp:chart chartIDRef="...">` 출신 표식 — chartIDRef 원문.

--- a/src/model/style.rs
+++ b/src/model/style.rs
@@ -783,7 +783,7 @@ pub enum ImageFillMode {
 }
 
 /// 테두리 선 정보 (그리기 개체용)
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize)]
 pub struct ShapeBorderLine {
     /// 선 색상
     pub color: ColorRef,

--- a/src/model/table.rs
+++ b/src/model/table.rs
@@ -26,7 +26,7 @@ std::thread_local! {
 }
 
 /// 표 개체 (HWPTAG_TABLE)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct Table {
     /// 속성 비트 플래그
     pub attr: u32,
@@ -64,6 +64,12 @@ pub struct Table {
     pub outer_margin_bottom: i16,
     /// CTRL_HEADER ctrl_data의 4바이트(attr) 이후 추가 바이트 (라운드트립 보존용)
     pub raw_ctrl_data: Vec<u8>,
+    /// [#4495] raw_ctrl_data 출처 봉인 — 봉인 시점 `common`(CommonObjAttr) 의
+    /// 다이제스트. 저장 시 `common` 이 봉인과 같을 때만 raw 를 재사용한다.
+    /// None(합성 IR·봉인 이전)은 종전 계약(raw 우선) 유지. 다이제스트 밖 —
+    /// `model::raw_provenance` 참조.
+    #[serde(skip)]
+    pub raw_ctrl_seal: Option<[u8; 32]>,
     /// HWPTAG_TABLE 레코드의 원본 속성 값 (라운드트립 보존용, 0이면 재구성)
     pub raw_table_record_attr: u32,
     /// HWPTAG_TABLE 레코드의 border_fill_id 이후 추가 바이트 (라운드트립 보존용)
@@ -91,7 +97,7 @@ pub struct Table {
 
 /// 표 쪽 나눔 종류
 /// bit 0-1: 0=나누지 않음, 1=셀 단위로 나눔, 2=나눔(행 단위)
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum TablePageBreak {
     /// 나누지 않음 (0)
     #[default]
@@ -103,7 +109,7 @@ pub enum TablePageBreak {
 }
 
 /// 표 영역 속성
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct TableZone {
     /// 시작 열 주소
     pub start_col: u16,
@@ -118,7 +124,7 @@ pub struct TableZone {
 }
 
 /// 표 셀 (HWPTAG_LIST_HEADER + 셀 속성)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct Cell {
     /// 셀 열 주소 (0부터 시작)
     pub col: u16,
@@ -203,7 +209,7 @@ fn checked_table_span_end(start: u16, span: u16, axis: &str) -> Result<u16, Stri
 }
 
 /// 세로 정렬
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, serde::Serialize)]
 pub enum VerticalAlign {
     #[default]
     Top,

--- a/src/parser/doc_info.rs
+++ b/src/parser/doc_info.rs
@@ -263,7 +263,7 @@ fn parse_bin_data(data: &[u8]) -> Result<BinData, DocInfoError> {
     Ok(bin)
 }
 
-fn parse_face_name(data: &[u8]) -> Result<Font, DocInfoError> {
+pub(crate) fn parse_face_name(data: &[u8]) -> Result<Font, DocInfoError> {
     let mut r = ByteReader::new(data);
     let attr = r.read_u8().unwrap_or(0);
 

--- a/src/parser/hml/adapter.rs
+++ b/src/parser/hml/adapter.rs
@@ -43,6 +43,7 @@ pub(crate) fn into_document(mut source: HmlSource) -> Result<Document, HmlError>
         document.sections.push(Section {
             section_def,
             paragraphs,
+            raw_provenance: None,
             raw_stream: None,
         });
     }

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -3993,6 +3993,7 @@ fn parse_hwp3_inner(
     let section = Section {
         section_def,
         paragraphs,
+        raw_provenance: None,
         raw_stream: None,
     };
     doc.sections.push(section);

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -5557,6 +5557,9 @@ impl ParamFrame {
             ParamFrame::Boolean { name, text } => Parameter::Boolean {
                 name,
                 value: matches!(text.trim(), "1" | "true"),
+                // [#4437] 원본 lexical 표기(`false`/`true`/`0`/`1`) 보존 — 렌더가
+                // 정규화로 되쓰면 왕복 바이트가 달라진다.
+                lexical: crate::model::control::boolean_lexical_of(&text),
             },
             ParamFrame::Integer { name, text } => Parameter::Integer {
                 name,

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -6291,6 +6291,7 @@ fn parse_equation(
         font_name,
         version_info,
         raw_ctrl_data: Vec::new(),
+        raw_ctrl_seal: None,
     };
     Ok(Control::Equation(Box::new(equation)))
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1485,6 +1485,10 @@ fn parse_document_inner(
         .document
         .doc_info
         .seal_raw_provenance(&parsed.document.doc_properties);
+    // [#4488/#4495] 본문 Section raw_stream 과 하위 컨트롤 raw 레코드도 같은
+    // 지점에서 봉인한다. DocumentCore 로 열리는 경로는 from_bytes 의 로드 픽스업
+    // (손상 lineseg 제거 등) 뒤에 다시 봉인된다.
+    parsed.document.seal_body_raw_provenance();
     Ok(parsed)
 }
 

--- a/src/serializer/body_text.rs
+++ b/src/serializer/body_text.rs
@@ -259,8 +259,16 @@ fn serialize_paragraph_with_msb(
     // 함께 되살리고, 그로 인해 벌어진 위치들을 `residue_shifts` 로 돌려준다 — 아래
     // PARA_CHAR_SHAPE 가 그 시프트를 반영해야 텍스트 버퍼와 서식 경계가 어긋나지 않는다.
     // 표시만 있는 문단도 PARA_TEXT 가 있어야 8유닛이 파일에 남는다.
-    let has_content =
-        !para.text.is_empty() || !para.controls.is_empty() || !para.title_marks.is_empty();
+    // [#4398] 다단락 필드의 고아 종료 마커(짝 fieldBegin 이 앞 문단)도 8유닛
+    // 실체다 — 이것만 있는 문단을 "빈 문단" 으로 접으면 PARA_TEXT 없이 헤더만
+    // char_count 를 주장하는 자기모순 레코드가 되거나(종전), #4677 가드로
+    // char_count=1 로 무너져 FIELD_END 슬롯이 영구 소실된다. `serialize_para_text`
+    // 는 begin_ctrl_id 를 아는 마커만 방출하므로 판정도 같은 조건을 쓴다.
+    let has_emittable_orphan_end = para.orphan_field_ends.iter().any(|o| o.begin_ctrl_id != 0);
+    let has_content = !para.text.is_empty()
+        || !para.controls.is_empty()
+        || !para.title_marks.is_empty()
+        || has_emittable_orphan_end;
     let (text_data, residue_shifts): (Option<Vec<u8>>, Vec<GuideResidueShift>) =
         if has_content || (para.has_para_text && para.char_count > 1) {
             let result = serialize_para_text(para);
@@ -394,6 +402,12 @@ fn compute_control_mask(para: &Paragraph) -> u32 {
     }
     // FIELD_END (0x0004): field_ranges가 있으면 비트 4 설정
     if !para.field_ranges.is_empty() {
+        mask |= 1u32 << 0x0004;
+    }
+    // [#4398] 다단락 필드의 고아 종료 마커 — serialize_para_text 가 방출하는
+    // 조건(begin_ctrl_id 기지)과 동일하게 비트 4 를 세운다. PARA_TEXT 와 mask 는
+    // 항상 함께 움직여야 한다.
+    if para.orphan_field_ends.iter().any(|o| o.begin_ctrl_id != 0) {
         mask |= 1u32 << 0x0004;
     }
     // TAB (0x0009): text에 탭이 있으면 비트 9 설정

--- a/src/serializer/body_text.rs
+++ b/src/serializer/body_text.rs
@@ -24,9 +24,16 @@ use crate::parser::tags;
 
 /// Section을 레코드 바이너리 스트림으로 직렬화
 pub fn serialize_section(section: &Section) -> Vec<u8> {
-    // 원본 스트림이 있으면 그대로 반환 (완벽한 라운드트립)
-    if let Some(ref raw) = section.raw_stream {
-        return raw.clone();
+    // 원본 스트림이 있으면 그대로 반환 (완벽한 라운드트립).
+    //
+    // [#4488] 다만 공개 모델 직접 변경은 raw_stream 을 무효화하지 않으므로,
+    // 파싱(+로드 픽스업) 시점에 봉인한 (모델, raw) 다이제스트 쌍과 현재 상태가
+    // 둘 다 일치할 때만 통과한다 — 불일치·raw 교체는 아래 모델 writer 로
+    // 재생성한다. 봉인 계약은 model::raw_provenance 참조.
+    if section.raw_provenance_permits_reuse() {
+        if let Some(ref raw) = section.raw_stream {
+            return raw.clone();
+        }
     }
 
     // [Task #852 Stage 2.4] Form 컨트롤의 z-order/TabOrder 카운터 reset.
@@ -1286,6 +1293,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1314,6 +1322,7 @@ mod tests {
             let section = Section {
                 paragraphs: vec![para],
                 raw_stream: None,
+                raw_provenance: None,
                 ..Default::default()
             };
             let parsed = parse_body_text_section(&serialize_section(&section)).unwrap();
@@ -1358,6 +1367,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
         let parsed = parse_body_text_section(&serialize_section(&section)).unwrap();
@@ -1398,6 +1408,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
         let parsed = parse_body_text_section(&serialize_section(&section)).unwrap();
@@ -1437,6 +1448,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
         let parsed = parse_body_text_section(&serialize_section(&section)).unwrap();
@@ -1475,6 +1487,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
         let parsed = parse_body_text_section(&serialize_section(&section)).unwrap();
@@ -1508,6 +1521,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1538,6 +1552,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1569,6 +1584,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1589,6 +1605,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1639,6 +1656,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para1, para2],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1678,6 +1696,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1719,6 +1738,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1768,6 +1788,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1810,6 +1831,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1845,6 +1867,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1891,6 +1914,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -1930,6 +1954,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -2177,6 +2202,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -2228,6 +2254,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -2289,6 +2316,7 @@ mod tests {
             },
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
         };
 
         let bytes = serialize_section(&section);
@@ -2353,6 +2381,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 
@@ -2411,6 +2440,7 @@ mod tests {
         let section = Section {
             paragraphs: vec![para],
             raw_stream: None,
+            raw_provenance: None,
             ..Default::default()
         };
 

--- a/src/serializer/cfb_writer/tests.rs
+++ b/src/serializer/cfb_writer/tests.rs
@@ -63,6 +63,7 @@ fn test_serialize_hwp_cfb_streams() {
                 ..Default::default()
             }],
             raw_stream: None,
+            raw_provenance: None,
         }],
         preview: None,
         bin_data_content: Vec::new(),
@@ -210,6 +211,7 @@ fn test_full_roundtrip_uncompressed() {
                 ..Default::default()
             }],
             raw_stream: None,
+            raw_provenance: None,
         }],
         preview: None,
         bin_data_content: Vec::new(),
@@ -290,6 +292,7 @@ fn test_full_roundtrip_compressed() {
                 ..Default::default()
             }],
             raw_stream: None,
+            raw_provenance: None,
         }],
         preview: None,
         bin_data_content: Vec::new(),
@@ -1679,6 +1682,7 @@ fn test_ole_storage_size_prefix_restored() {
                 ..Default::default()
             }],
             raw_stream: None,
+            raw_provenance: None,
         }],
         preview: None,
         bin_data_content: vec![BinDataContent {
@@ -1766,6 +1770,7 @@ fn test_compressed_ole_storage_payload_is_deflated() {
                 ..Default::default()
             }],
             raw_stream: None,
+            raw_provenance: None,
         }],
         preview: None,
         bin_data_content: vec![BinDataContent {

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -575,8 +575,15 @@ fn serialize_table(table: &Table, level: u16, records: &mut Vec<Record>) {
     // IR 의 common 으로 합성한다 (attr=0 이면 pack_common_attr_bits 경유 —
     // flow_with_text bit 13 포함). HWP5 파스본(raw 보존)·어댑터 경로(Stage 2
     // 합성)는 raw_ctrl_data 가 채워져 있어 동작 불변.
+    // [#4495] raw 재사용은 봉인 검증을 거친다 — 공개 모델에서 `common` 을 직접
+    // 바꾸면(봉인 불일치) raw 대신 IR 합성으로 쓴다. 봉인 None(합성 IR·봉인
+    // 이전)은 종전 계약(raw 우선) 유지. raw 를 직접 갱신하는 기존 명령
+    // (refresh_raw_ctrl_size 의 dual-write)은 `common` 이 봉인과 같아 통과한다.
+    let raw_permitted = table
+        .raw_ctrl_seal
+        .is_none_or(|sealed| sealed == crate::model::raw_provenance::record_digest(&table.common));
     let composed_common;
-    let ctrl_data: &[u8] = if !table.raw_ctrl_data.is_empty() {
+    let ctrl_data: &[u8] = if !table.raw_ctrl_data.is_empty() && raw_permitted {
         &table.raw_ctrl_data
     } else {
         composed_common = serialize_common_obj_attr(&table.common);
@@ -1988,7 +1995,12 @@ fn serialize_group_child(
 }
 
 fn serialize_ole_data(ole: &OleShape) -> Vec<u8> {
-    if !ole.raw_tag_data.is_empty() {
+    // [#4495] payload 모델 필드(extent_x/extent_y/bin_data_id)를 직접 바꾸면
+    // (봉인 불일치) raw 대신 모델 값으로 쓴다. 봉인 None 은 종전 계약 유지.
+    let raw_permitted = ole
+        .raw_tag_seal
+        .is_none_or(|sealed| sealed == crate::model::raw_provenance::ole_payload_digest(ole));
+    if !ole.raw_tag_data.is_empty() && raw_permitted {
         return ole.raw_tag_data.clone();
     }
 
@@ -2779,7 +2791,12 @@ fn build_header_footer_list_header(
 /// raw_ctrl_data를 보존하여 라운드트립 무손실 직렬화.
 fn serialize_equation_control(eq: &Equation, level: u16, records: &mut Vec<Record>) {
     // CTRL_HEADER with CommonObjAttr (또는 원본 ctrl_data)
-    let ctrl_data = if eq.raw_ctrl_data.is_empty() {
+    // [#4495] 표 CTRL_HEADER 와 동일한 봉인 검증 — `common` 직접 변경 시 raw 대신
+    // IR 합성으로 쓴다.
+    let raw_permitted = eq
+        .raw_ctrl_seal
+        .is_none_or(|sealed| sealed == crate::model::raw_provenance::record_digest(&eq.common));
+    let ctrl_data = if eq.raw_ctrl_data.is_empty() || !raw_permitted {
         serialize_common_obj_attr(&eq.common)
     } else {
         eq.raw_ctrl_data.clone()

--- a/src/serializer/doc_info.rs
+++ b/src/serializer/doc_info.rs
@@ -268,6 +268,187 @@ pub fn serialize_bin_data(bin_data: &BinData) -> Vec<u8> {
     w.into_bytes()
 }
 
+/// [#4898] 한글 글꼴 이름 → HWP5 FACE_NAME 의 **기본 글꼴 이름**(default_name) 실측 대응표.
+///
+/// 한글은 HWP5 로 저장할 때 이 자리에 영문(PostScript) 기본 이름을 함께 싣는다. HWPX 에는
+/// 대응 자리가 없어 HWPX→HWP 저장에서 이 값이 통째로 빠지고, 한글이 그 파일을 열 때 글꼴을
+/// 이름만으로 찾는다 — 글꼴이 없어 대체가 일어나면 글자 폭이 달라져 줄 수·쪽수가 흔들린다
+/// (한글 오라클 실측: 09254 FACE_NAME 33개가 오라클 37~65바이트 vs rhwp 19~23바이트,
+/// 차이가 정확히 이 필드였다).
+///
+/// **표는 실측이다.** 코퍼스의 한컴 저장 `.hwp` 원본 796건에서 `(글꼴 이름, default_name)`
+/// 36,351쌍을 모아, 이름별 최빈값이 60% 이상인 것만 담았다(2026-08-16 측정).
+/// 한 이름에 값이 갈리는 경우(같은 글꼴의 구·신 PostScript 이름)는 최빈값을 쓴다:
+/// `HY헤드라인M` HYHeadLine-Medium 1217 / HYHeadLine M 245 · `HY견고딕` HYGothic-Extra 351 /
+/// HYgtrE 126 · `HY견명조` HYMyeongJo-Extra 200 / HYmjrE 68.
+/// 라틴 글꼴은 한글도 이름을 그대로 싣는다(Arial→Arial).
+const FONT_DEFAULT_NAMES: &[(&str, &str)] = &[
+    ("#견고딕", "#Gyeongothic"),
+    ("#견명조", "#Gyeonmyeongjo"),
+    ("#그래픽", "#Graphic"),
+    ("#디나루", "#Dinaru"),
+    ("#세고딕", "#Segothic"),
+    ("#세나루", "#Senaru"),
+    ("#세명조", "#Semyeongjo"),
+    ("#신그래픽", "#Singraphic"),
+    ("#신디나루", "#Sindinaru"),
+    ("#신명조", "#Sinmyeongjo"),
+    ("#신문견고", "#Sinmungyeongo"),
+    ("#신문태고", "#Sinmuntaego"),
+    ("#신문태명", "#Sinmuntaemyeong"),
+    ("#신세고딕", "#Sinsegothic"),
+    ("#신중명조", "#Sin Jungmyeongjo"),
+    ("#신태명조", "#Sintaemyeongjo"),
+    ("#중고딕", "#Junggothic"),
+    ("#중명조", "#Jungmyeongjo"),
+    ("#태고딕", "#Taegothic"),
+    ("#태그래픽", "#Taegraphic"),
+    ("#태명조", "#Taemyeongjo"),
+    ("#태신명조", "#Taesinmyeongjo"),
+    ("-윤고딕340", "YDIYGO340"),
+    ("08서울남산체 B", "08SeoulNamsan B"),
+    ("08서울남산체 EB", "08SeoulNamsan EB"),
+    ("08서울남산체 M", "08SeoulNamsan M"),
+    ("08서울한강체 L", "08SeoulHangang L"),
+    ("08서울한강체 M", "08SeoulHangang M"),
+    ("AmeriGarmnd BT", "AmeriGarmnd BT"),
+    ("Arial", "Arial"),
+    ("Arial Black", "Arial Black"),
+    ("Arial Narrow", "Arial Narrow"),
+    ("Arial Unicode MS", "Arial Unicode MS"),
+    ("Calibri", "Calibri"),
+    ("Century", "Century"),
+    ("Courier New", "Courier New"),
+    ("Garamond", "Garamond"),
+    ("HCI Acacia", "HCI Acacia"),
+    ("HCI Bellflower", "HCI Bellflower"),
+    ("HCI Hollyhock", "HCI Hollyhock"),
+    ("HCI Morning Glory", "HCI Morning Glory"),
+    ("HCI Poppy", "HCI Poppy"),
+    ("HCI Tulip", "HCI Tulip"),
+    ("HY강B", "HYkanB"),
+    ("HY강M", "HYkanM"),
+    ("HY견고딕", "HYGothic-Extra"),
+    ("HY견명조", "HYMyeongJo-Extra"),
+    ("HY궁서", "HYgsrB"),
+    ("HY그래픽", "HYgprM"),
+    ("HY그래픽M", "HYGraphic-Medium"),
+    ("HY동녘M", "HYdnkM"),
+    ("HY백송B", "HYbsrB"),
+    ("HY수평선B", "HYsupB"),
+    ("HY수평선M", "HYsupM"),
+    ("HY신명조", "HYSinMyeongJo-Medium"),
+    ("HY엽서M", "HYPost-Medium"),
+    ("HY울릉도B", "HYwulB"),
+    ("HY울릉도M", "HYwulM"),
+    ("HY중고딕", "HYGothic-Medium"),
+    ("HY헤드라인M", "HYHeadLine-Medium"),
+    ("Hobo BT", "Hobo BT"),
+    ("KoPubWorld돋움체 Bold", "KoPubWorldDotum Bold"),
+    ("KoPub돋움체 Bold", "KoPubDotum Bold"),
+    ("KoPub돋움체 Light", "KoPubDotum Light"),
+    ("KoPub돋움체 Medium", "KoPubDotum Medium"),
+    ("KoPub바탕체 Bold", "KoPubBatang Bold"),
+    ("KoPub바탕체 Light", "KoPubBatang Light"),
+    ("KoPub바탕체 Medium", "KoPubBatang Medium"),
+    ("MS PMincho", "MS PMincho"),
+    ("Noto Sans CJK KR Bold", "Noto Sans CJK KR Bold"),
+    ("Noto Sans CJK KR DemiLight", "Noto Sans CJK KR DemiLight"),
+    ("Noto Sans CJK KR Medium", "Noto Sans CJK KR Medium"),
+    ("SimSun", "SimSun"),
+    ("Tahoma", "Tahoma"),
+    ("Times New Roman", "Times New Roman"),
+    ("Trebuchet MS", "Trebuchet MS"),
+    ("Verdana", "Verdana"),
+    ("가는안상수체", "가는안상수체"),
+    ("가는한", "Ganeunhan"),
+    ("경기천년바탕 Regular", "GyeonggiBatang Regular"),
+    ("고딕", "Gothic"),
+    ("굴림", "Gulim"),
+    ("굴림체", "GulimChe"),
+    ("궁서", "Gungsuh"),
+    ("궁서체", "GungsuhChe"),
+    ("나눔고딕", "NanumGothic"),
+    ("나눔고딕 ExtraBold", "NanumGothicExtraBold"),
+    ("나눔명조", "NanumMyeongjo"),
+    ("나눔명조 ExtraBold", "NanumMyeongjoExtraBold"),
+    ("돋움", "Dotum"),
+    ("돋움체", "DotumChe"),
+    ("맑은 고딕", "Malgun Gothic"),
+    ("맑은 고딕 Semilight", "Malgun Gothic Semilight"),
+    ("명조", "Myeongjo"),
+    ("문체부 궁체 정자체", "MGungJeong"),
+    ("문체부 돋음체", "MDotum"),
+    ("문체부 바탕체", "MBatang"),
+    ("문체부 쓰기 흘림체", "MSugiHeulim"),
+    ("문체부 제목 돋음체", "MJemokGothic"),
+    ("바탕", "Batang"),
+    ("바탕체", "BatangChe"),
+    ("산세리프", "Sans Serif"),
+    ("새굴림", "New Gulim"),
+    ("시스템", "System"),
+    ("신명 견고딕", "Sinmyeong Gyeongothic"),
+    ("신명 견명조", "Sinmyeong Gyeonmyeongjo"),
+    ("신명 궁서", "Sinmyeong Gungseo"),
+    ("신명 디나루", "Sinmyeong Dinaru"),
+    ("신명 세나루", "Sinmyeong Senaru"),
+    ("신명 세명조", "Sinmyeong Semyeongjo"),
+    ("신명 순명조", "Sinmyeong Sunmyeongjo"),
+    ("신명 신그래픽", "Sinmyeong Singraphic"),
+    ("신명 신명조", "Sinmyeong Sinmyeongjo"),
+    ("신명 신문명조", "Sinmyeong Sinmunmyeongjo"),
+    ("신명 신신명조", "Sinmyeong Sinsinmyeongjo"),
+    ("신명 중고딕", "Sinmyeong Junggothic"),
+    ("신명 중명조", "Sinmyeong Jungmyeongjo"),
+    ("신명 태고딕", "Sinmyeong Taegothic"),
+    ("신명 태그래픽", "Sinmyeong Taegraphic"),
+    ("신명 태명조", "Sinmyeong Taemyeongjo"),
+    ("신명조 간자", "Sinmyeongjo Chinese"),
+    ("신명조 약자", "Sinmyeongjo Jananese"),
+    ("양재 다운명조M", "YJ Daunmyeongjo M"),
+    ("양재 튼튼B", "YJ Teunteun B"),
+    ("옥수수", "Corn"),
+    ("중고딕 간자", "Junggothic Chinese"),
+    ("태 가는 헤드라인D", "Tae Headline D Narrow"),
+    ("태 가는 헤드라인T", "Tae Headline T Narrow"),
+    ("태 나무", "태 나무"),
+    ("태 헤드라인T", "Tae Headline T"),
+    ("필기", "Pilgi"),
+    ("한양견고딕", "HY Gyeongothic"),
+    ("한양견명조", "HY Gyeonmyeongjo"),
+    ("한양궁서", "HY Gungseo"),
+    ("한양그래픽", "HY Graphic"),
+    ("한양신명조", "HY Sinmyeongjo"),
+    ("한양신명조V", "HY Sinmyeongjo V"),
+    ("한양중고딕", "HY Junggothic"),
+    ("한양중고딕V", "HY Junggothic V"),
+    ("한양해서", "HYhaeseo"),
+    ("한컴 백제 M", "Haan Baekje M"),
+    ("한컴 윤고딕 250", "Haan YGodic 250"),
+    ("한컴 쿨재즈 B", "Haan Cooljazz B"),
+    ("한컴돋움", "Haansoft Dotum"),
+    ("한컴바탕", "Haansoft Batang"),
+    ("한컴산뜻돋움", "Han Santteut Dotum Regular"),
+    ("함초롬돋움", "HCR Dotum"),
+    ("함초롬돋움 확장", "HCR Dotum Ext"),
+    ("함초롬바탕", "HCR Batang"),
+    ("휴먼고딕", "휴먼고딕"),
+    ("휴먼둥근헤드라인", "Headline R"),
+    ("휴먼명조", "휴먼명조"),
+    ("휴먼모음T", "MoeumT R"),
+    ("휴먼아미체", "Ami R"),
+    ("휴먼엑스포", "Expo M"),
+    ("휴먼옛체", "Yet R"),
+];
+
+/// 글꼴 이름에 대응하는 기본 글꼴 이름(실측표). 없으면 `None`.
+fn measured_default_font_name(name: &str) -> Option<&'static str> {
+    FONT_DEFAULT_NAMES
+        .iter()
+        .find(|(korean, _)| *korean == name)
+        .map(|(_, default)| *default)
+}
+
 pub fn serialize_face_name(font: &Font) -> Vec<u8> {
     let mut w = ByteWriter::new();
 
@@ -283,6 +464,13 @@ pub fn serialize_face_name(font: &Font) -> Vec<u8> {
     });
 
     // attr 바이트 재구성
+    // [#4898] 기본 글꼴 이름: HWPX 에는 이 자리가 없어 HWPX 출처 문서는 늘 비어 있었다.
+    // 한글은 자기 글꼴 엔진의 대응을 여기 실어 두므로, 실측표로 같은 값을 채워 준다.
+    let default_name = font
+        .default_name
+        .as_deref()
+        .or_else(|| measured_default_font_name(&font.name));
+
     let mut attr = font.alt_type & 0x03;
     if alt_name.is_some() {
         attr |= 0x80;
@@ -290,7 +478,7 @@ pub fn serialize_face_name(font: &Font) -> Vec<u8> {
     if font.type_info.is_some() {
         attr |= 0x40;
     }
-    if font.default_name.is_some() {
+    if default_name.is_some() {
         attr |= 0x20;
     }
     w.write_u8(attr).unwrap();
@@ -304,7 +492,7 @@ pub fn serialize_face_name(font: &Font) -> Vec<u8> {
     if let Some(type_info) = font.type_info {
         w.write_bytes(&type_info).unwrap();
     }
-    if let Some(ref default_name) = font.default_name {
+    if let Some(default_name) = default_name {
         w.write_hwp_string(default_name).unwrap();
     }
 

--- a/src/serializer/doc_info/tests.rs
+++ b/src/serializer/doc_info/tests.rs
@@ -832,3 +832,48 @@ fn test_serialize_bullet_layout_and_roundtrip() {
     assert_eq!(parsed_info.bullets[0].char_shape_id, 2);
     assert_eq!(parsed_info.bullets[0].text_distance, 50);
 }
+
+/// [#4898] HWPX 출처 글꼴은 `default_name` 이 비어 있다 — 한글은 그 자리에 영문 기본
+/// 이름을 싣는다. 실측표로 같은 값을 채워 FACE_NAME 이 한컴 저장본과 같은 모양이 되게 한다.
+///
+/// 실측: 09254 의 FACE_NAME 33개가 한글 오라클 37~65바이트 vs rhwp 19~23바이트였고,
+/// 표 적용 후 크기가 일치했다(일치 레코드 399 → 410).
+/// 표 자체는 한컴 저장 `.hwp` 796건에서 모은 36,351쌍의 이름별 최빈값이다.
+#[test]
+fn issue4898_face_name_fills_measured_default_font_name() {
+    let mut font = Font {
+        name: "굴림체".to_string(),
+        ..Default::default()
+    };
+    font.default_name = None;
+
+    let bytes = serialize_face_name(&font);
+    // attr bit 0x20 = 기본 글꼴 이름 있음
+    assert_ne!(bytes[0] & 0x20, 0, "기본 글꼴 이름 플래그가 서야 한다");
+
+    let parsed = crate::parser::doc_info::parse_face_name(&bytes).expect("FACE_NAME 재파싱");
+    assert_eq!(
+        parsed.default_name.as_deref(),
+        Some("GulimChe"),
+        "한글이 싣는 영문 기본 이름과 같아야 한다"
+    );
+
+    // 원본이 이미 값을 갖고 있으면 그 값이 이긴다(표가 덮어쓰지 않는다).
+    let mut explicit = Font {
+        name: "굴림체".to_string(),
+        ..Default::default()
+    };
+    explicit.default_name = Some("Explicit".to_string());
+    let parsed = crate::parser::doc_info::parse_face_name(&serialize_face_name(&explicit))
+        .expect("FACE_NAME 재파싱");
+    assert_eq!(parsed.default_name.as_deref(), Some("Explicit"));
+
+    // 표에 없는 이름은 종전대로 비운다.
+    let unknown = Font {
+        name: "존재하지않는글꼴".to_string(),
+        ..Default::default()
+    };
+    let parsed = crate::parser::doc_info::parse_face_name(&serialize_face_name(&unknown))
+        .expect("FACE_NAME 재파싱");
+    assert_eq!(parsed.default_name, None);
+}

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -780,6 +780,7 @@ mod tests {
             font_name: "HYhwpEQ".to_string(),
             version_info: "Equation Version 60".to_string(),
             raw_ctrl_data: Vec::new(),
+            raw_ctrl_seal: None,
         })));
         section.paragraphs.push(para);
         doc.sections.push(section);

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -580,6 +580,46 @@ pub fn write_section(
 
         // 템플릿의 텍스트 run 전체를 문단의 run 시퀀스(다중 run 분할 포함)로 1회 치환.
         out = out.replacen(TEMPLATE_TEXT_RUN, &first_runs, 1);
+
+        // [#3367/#4433] 컨트롤 방출 순서를 IR 순서에 맞춘다 — HWP5 원본이
+        // `[cold, secd]` 인 문단(field-01 실측: 전 구역 cold→secd)을 템플릿 고정
+        // 순서(secPr → ctrl/colPr)로 내보내면 재파싱 IR 이 `[secd, cold]` 로
+        // 뒤집혀 왕복 무손실 계약(ir-diff)이 깨진다. OWPML 스키마(run 의
+        // choice, ParaList XML schema)는 순서를 규정하지 않고, 한컴 원산 실물도
+        // colPr-before-secPr 20건 / colPr-after-secPr 315건으로 양쪽을 다 쓴다 —
+        // 문서 순서가 곧 보존 대상이다. 파서(parse_ctrl/secPr arm)는 이미 문서
+        // 순서를 보존하므로 방출만 IR 순서를 따르면 왕복이 닫힌다.
+        let cold_before_secd = {
+            let i_secd = p
+                .controls
+                .iter()
+                .position(|c| matches!(c, Control::SectionDef(_)));
+            let i_cold = p
+                .controls
+                .iter()
+                .position(|c| matches!(c, Control::ColumnDef(_)));
+            matches!((i_cold, i_secd), (Some(c), Some(s)) if c < s)
+        };
+        if cold_before_secd {
+            if let Some(Control::ColumnDef(cd)) = p
+                .controls
+                .iter()
+                .find(|c| matches!(c, Control::ColumnDef(_)))
+            {
+                // 위 #1407 치환이 이미 심어 둔 IR colPr 블록을 정확히 되찾아
+                // (render_col_pr_ctrl 은 결정적) secPr 앞으로 옮긴다.
+                let rendered = render_col_pr_ctrl(cd);
+                if let Some(colpr_at) = out.find(&rendered) {
+                    out.replace_range(colpr_at..colpr_at + rendered.len(), "");
+                    if let Some(secpr_at) = out.find("<hp:secPr ") {
+                        out.insert_str(secpr_at, &rendered);
+                    } else {
+                        // secPr 미발견(비정상 템플릿) — 원위치 복원으로 무손실 유지.
+                        out.insert_str(colpr_at, &rendered);
+                    }
+                }
+            }
+        }
     }
 
     // 추가 문단: `</hp:p></hs:sec>` 직전에 `<hp:p>` 요소를 삽입.

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -1807,6 +1807,7 @@ fn test_document_with_paragraphs() {
             },
         ],
         raw_stream: None,
+        raw_provenance: None,
     });
     doc.set_document(document);
 
@@ -2016,6 +2017,7 @@ fn create_doc_with_table() -> HwpDocument {
         },
         paragraphs: vec![parent_para],
         raw_stream: None,
+        raw_provenance: None,
     });
     doc.set_document(document);
     doc
@@ -2102,6 +2104,7 @@ fn create_doc_with_page_count_boundary_table() -> HwpDocument {
         },
         paragraphs: vec![parent_para],
         raw_stream: None,
+        raw_provenance: None,
     });
     doc.set_document(document);
     doc
@@ -4690,6 +4693,7 @@ fn create_doc_with_floating_picture(tac: bool, voff: u32, hoff: u32) -> HwpDocum
         },
         paragraphs: vec![pic_para, Paragraph::default()],
         raw_stream: None,
+        raw_provenance: None,
     });
     doc.set_document(document);
     doc

--- a/tests/issue_3367_secd_cold_order.rs
+++ b/tests/issue_3367_secd_cold_order.rs
@@ -1,0 +1,76 @@
+//! [Issue #3367/#4433] export-hwpx 가 구역 시작 문단의 secd/cold 컨트롤 순서를
+//! 뒤집던 계약을 고정한다.
+//!
+//! HWP5 원본(field-01)은 전 구역이 `[cold, secd]` 순서인데, HWPX writer 의
+//! 템플릿 고정 순서(secPr → ctrl/colPr)로 내보내면 재파싱 IR 이 `[secd, cold]`
+//! 로 뒤집혀 ir-diff(--verify)가 컨트롤 type 차이 6건을 냈다. OWPML 스키마는
+//! run 자식 순서를 규정하지 않고(choice), 한컴 원산 실물도 두 순서를 모두
+//! 쓰므로(20 vs 315건 실측) **문서 순서가 보존 대상**이다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+use rhwp::parse_document;
+
+const SAMPLE: &str = "samples/field-01.hwp";
+
+fn read_sample() -> Vec<u8> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    std::fs::read(&path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"))
+}
+
+/// 구역 첫 문단에서 (ColumnDef 위치, SectionDef 위치)를 얻는다.
+fn secd_cold_positions(para: &rhwp::model::paragraph::Paragraph) -> (Option<usize>, Option<usize>) {
+    let cold = para
+        .controls
+        .iter()
+        .position(|c| matches!(c, Control::ColumnDef(_)));
+    let secd = para
+        .controls
+        .iter()
+        .position(|c| matches!(c, Control::SectionDef(_)));
+    (cold, secd)
+}
+
+#[test]
+fn issue3367_export_hwpx_preserves_cold_before_secd_order() {
+    let bytes = read_sample();
+    let original = parse_document(&bytes).expect("parse");
+
+    // 샘플 전제: 원본은 cold 가 secd 앞이다 (#3367 실측 — 3개 구역 전부).
+    let mut checked = 0usize;
+    for sec in &original.sections {
+        let (cold, secd) = secd_cold_positions(&sec.paragraphs[0]);
+        if let (Some(c), Some(s)) = (cold, secd) {
+            assert!(c < s, "샘플 전제 위반: 원본이 cold→secd 순서가 아니다");
+            checked += 1;
+        }
+    }
+    assert!(
+        checked >= 2,
+        "샘플 전제 위반: cold+secd 구역이 2개 이상이어야 한다"
+    );
+
+    let core = DocumentCore::from_bytes(&bytes).expect("open");
+    let hwpx = core.export_hwpx_native().expect("export-hwpx");
+    let roundtripped = parse_document(&hwpx).expect("reparse hwpx");
+
+    assert_eq!(roundtripped.sections.len(), original.sections.len());
+    for (si, (a, b)) in original
+        .sections
+        .iter()
+        .zip(roundtripped.sections.iter())
+        .enumerate()
+    {
+        let (a_cold, a_secd) = secd_cold_positions(&a.paragraphs[0]);
+        let (b_cold, b_secd) = secd_cold_positions(&b.paragraphs[0]);
+        if let (Some(ac), Some(asd)) = (a_cold, a_secd) {
+            let (bc, bsd) = (b_cold.expect("cold 보존"), b_secd.expect("secd 보존"));
+            assert_eq!(
+                (ac < asd),
+                (bc < bsd),
+                "구역 {si}: secd/cold 상대 순서가 왕복에서 뒤집혔다 (#3367) — \
+                 원본 cold@{ac}/secd@{asd}, 왕복 cold@{bc}/secd@{bsd}"
+            );
+        }
+    }
+}

--- a/tests/issue_4398_orphan_fieldend.rs
+++ b/tests/issue_4398_orphan_fieldend.rs
@@ -1,0 +1,66 @@
+//! [Issue #4398] 다단락 필드의 고아 fieldEnd(짝 fieldBegin 이 앞 문단)가 HWP5
+//! 를 거치는 왕복에서 소실돼 char_count 9→1 로 무너지던 계약을 고정한다.
+//!
+//! 근인: `serialize_section` 의 `has_content` 판정과 `compute_control_mask` 가
+//! `orphan_field_ends` 를 몰라, 고아 종료 마커만 있는 문단이 "빈 문단" 으로
+//! 접혔다 — PARA_TEXT 없이 헤더만 char_count 를 주장하는 자기모순 레코드
+//! (한글 2022 는 그런 문단을 만나면 본문 전체를 버린다) 또는 #4677 가드의
+//! char_count=1 붕괴. 방출 자체(`serialize_para_text` 의 mid-text·trailing 고아
+//! 방출)는 이미 있었으므로 게이트만 맞추면 왕복이 닫힌다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::parse_document;
+
+const SAMPLE: &str = "samples/task2279/36378481_gyeoljae.hwpx";
+
+fn read_sample() -> Vec<u8> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    std::fs::read(&path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"))
+}
+
+/// 고아 fieldEnd 만 가진(텍스트·컨트롤 없는) 문단의 인덱스와 char_count.
+fn orphan_only_para(doc: &rhwp::model::document::Document) -> (usize, u32) {
+    for (pi, p) in doc.sections[0].paragraphs.iter().enumerate() {
+        if !p.orphan_field_ends.is_empty() && p.text.is_empty() && p.controls.is_empty() {
+            return (pi, p.char_count);
+        }
+    }
+    panic!("샘플 전제: 고아 fieldEnd 전용 문단이 있어야 한다");
+}
+
+#[test]
+fn issue4398_orphan_fieldend_survives_hwp5_roundtrip() {
+    let original = parse_document(&read_sample()).expect("parse hwpx");
+    let (pi, cc) = orphan_only_para(&original);
+    assert_eq!(cc, 9, "샘플 전제: 고아 8유닛 + 종결 1 = 9");
+    assert_ne!(
+        original.sections[0].paragraphs[pi].orphan_field_ends[0].begin_ctrl_id, 0,
+        "샘플 전제: 짝 fieldBegin 의 ctrl_id 가 연결돼 있어야 한다"
+    );
+
+    // HWPX → HWP5
+    let mut core = DocumentCore::from_bytes(&read_sample()).expect("open hwpx");
+    let hwp = core.export_hwp_with_adapter().expect("convert to hwp");
+    let mid = parse_document(&hwp).expect("parse hwp");
+    let mid_para = &mid.sections[0].paragraphs[pi];
+    assert_eq!(
+        mid_para.char_count, 9,
+        "HWP5 저장본에서 고아 fieldEnd 8유닛이 실체(PARA_TEXT)로 남아야 한다 (#4398)"
+    );
+    assert_eq!(
+        mid_para.orphan_field_ends.len(),
+        1,
+        "HWP5 재파싱이 고아 종료 마커를 복원해야 한다"
+    );
+
+    // HWP5 → HWPX (왕복 완주)
+    let core2 = DocumentCore::from_bytes(&hwp).expect("open hwp");
+    let hwpx2 = core2.export_hwpx_native().expect("export hwpx");
+    let fin = parse_document(&hwpx2).expect("parse final hwpx");
+    let fin_para = &fin.sections[0].paragraphs[pi];
+    assert_eq!(
+        fin_para.char_count, 9,
+        "왕복 후에도 char_count 가 무너지면 안 된다 (종전: 9→1)"
+    );
+    assert_eq!(fin_para.orphan_field_ends.len(), 1, "hp:fieldEnd 재방출");
+}

--- a/tests/issue_4488_4495_body_provenance.rs
+++ b/tests/issue_4488_4495_body_provenance.rs
@@ -1,0 +1,211 @@
+//! [Issue #4488/#4495] 공개 저수준 `parse_document → Document 직접 변경 →
+//! serialize_document` 경로에서 본문 변경이 Section `raw_stream`(#4488)과 하위
+//! 컨트롤 raw 레코드(#4495)에 가려져 조용히 사라지던 계약을 고정한다.
+//!
+//! - 무변경 문서는 Section 레코드 스트림 바이트를 정확히 재사용한다.
+//! - 공개 본문 텍스트·중첩 표 셀 텍스트 직접 변경은 저장·재로드 뒤 유지된다.
+//! - 표 CTRL_HEADER 의 모델 필드(`common`) 직접 변경도 유지된다 — raw_ctrl_data
+//!   가 남아 있어도 봉인 불일치로 IR 합성 경로를 탄다.
+//! - 공개 `raw_stream` 을 다른 바이트로 교체해도 봉인으로 승인되지 않는다.
+
+use rhwp::model::control::Control;
+use rhwp::{parse_document, serialize_document};
+
+const SAMPLE: &str = "samples/2026_oss_rst.hwp";
+const TABLE_SAMPLE: &str = "samples/basic/issue2007_nested_cell_pagination_42065.hwp";
+
+fn read_sample(rel: &str) -> Vec<u8> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    std::fs::read(&path).unwrap_or_else(|e| panic!("read {rel}: {e}"))
+}
+
+#[test]
+fn unchanged_parse_serialize_reuses_section_raw_bytes() {
+    let doc = parse_document(&read_sample(SAMPLE)).expect("parse");
+    let original: Vec<Vec<u8>> = doc
+        .sections
+        .iter()
+        .map(|s| {
+            assert!(
+                s.raw_provenance.is_some(),
+                "파서가 만든 문서에는 Section 봉인이 있어야 한다 (#4488)"
+            );
+            s.raw_stream.clone().expect("HWP5 Section raw 캐시")
+        })
+        .collect();
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    for (i, sec) in reparsed.sections.iter().enumerate() {
+        assert_eq!(
+            sec.raw_stream.as_ref(),
+            Some(&original[i]),
+            "무변경 구역 {i} 의 레코드 스트림은 바이트 그대로 통과해야 한다"
+        );
+    }
+}
+
+/// 본문 문단 텍스트를 같은 길이로 바꿔치기 — 길이 불변이라 char_count·char_shapes
+/// 경계에 영향을 주지 않는 가장 보수적인 공개 직접 변경.
+fn swap_first_char_of_longest_para(
+    doc: &mut rhwp::model::document::Document,
+) -> (usize, usize, String) {
+    let (si, pi) = {
+        let mut best = (0usize, 0usize, 0usize);
+        for (si, sec) in doc.sections.iter().enumerate() {
+            for (pi, para) in sec.paragraphs.iter().enumerate() {
+                let len = para.text.chars().count();
+                if len > best.2 {
+                    best = (si, pi, len);
+                }
+            }
+        }
+        assert!(best.2 >= 3, "샘플 전제: 본문 텍스트 문단이 있어야 한다");
+        (best.0, best.1)
+    };
+    let para = &mut doc.sections[si].paragraphs[pi];
+    let mut chars: Vec<char> = para.text.chars().collect();
+    let idx = chars
+        .iter()
+        .position(|c| *c != 'Ｘ' && !c.is_control())
+        .expect("교체할 글자");
+    chars[idx] = 'Ｘ'; // 전각 문자 — UTF-16 1유닛 유지
+    para.text = chars.into_iter().collect();
+    (si, pi, doc.sections[si].paragraphs[pi].text.clone())
+}
+
+#[test]
+fn public_body_text_mutation_survives_save_reload() {
+    let mut doc = parse_document(&read_sample(SAMPLE)).expect("parse");
+    let (si, pi, mutated) = swap_first_char_of_longest_para(&mut doc);
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    assert_eq!(
+        reparsed.sections[si].paragraphs[pi].text, mutated,
+        "공개 본문 텍스트 직접 변경이 저장·재로드 뒤 유지돼야 한다 (#4488)"
+    );
+}
+
+/// 첫 번째 표를 (구역, 문단, 컨트롤) 좌표로 찾는다.
+fn find_first_table(doc: &rhwp::model::document::Document) -> (usize, usize, usize) {
+    for (si, sec) in doc.sections.iter().enumerate() {
+        for (pi, para) in sec.paragraphs.iter().enumerate() {
+            for (ci, ctrl) in para.controls.iter().enumerate() {
+                if matches!(ctrl, Control::Table(_)) {
+                    return (si, pi, ci);
+                }
+            }
+        }
+    }
+    panic!("샘플 전제: 표가 있어야 한다");
+}
+
+#[test]
+fn nested_table_cell_text_mutation_survives_save_reload() {
+    let mut doc = parse_document(&read_sample(TABLE_SAMPLE)).expect("parse");
+    let (si, pi, ci) = find_first_table(&doc);
+    let Control::Table(table) = &mut doc.sections[si].paragraphs[pi].controls[ci] else {
+        unreachable!()
+    };
+    let (cell_idx, cp_idx) = {
+        let mut found = None;
+        'outer: for (celli, cell) in table.cells.iter().enumerate() {
+            for (cpi, cp) in cell.paragraphs.iter().enumerate() {
+                if cp.text.chars().count() >= 2 && cp.text.chars().any(|c| !c.is_control()) {
+                    found = Some((celli, cpi));
+                    break 'outer;
+                }
+            }
+        }
+        found.expect("샘플 전제: 텍스트 있는 셀 문단")
+    };
+    let cp = &mut table.cells[cell_idx].paragraphs[cp_idx];
+    let mut chars: Vec<char> = cp.text.chars().collect();
+    let idx = chars.iter().position(|c| !c.is_control()).unwrap();
+    chars[idx] = 'Ｘ';
+    cp.text = chars.into_iter().collect();
+    let mutated = cp.text.clone();
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    let Control::Table(table2) = &reparsed.sections[si].paragraphs[pi].controls[ci] else {
+        panic!("표가 유지돼야 한다")
+    };
+    assert_eq!(
+        table2.cells[cell_idx].paragraphs[cp_idx].text, mutated,
+        "중첩 표 셀 텍스트 직접 변경이 저장·재로드 뒤 유지돼야 한다 (#4488)"
+    );
+}
+
+#[test]
+fn table_common_mutation_survives_despite_raw_ctrl_data() {
+    let mut doc = parse_document(&read_sample(TABLE_SAMPLE)).expect("parse");
+    let (si, pi, ci) = find_first_table(&doc);
+    let new_margin_top = {
+        let Control::Table(table) = &mut doc.sections[si].paragraphs[pi].controls[ci] else {
+            unreachable!()
+        };
+        assert!(
+            !table.raw_ctrl_data.is_empty(),
+            "샘플 전제: HWP5 표는 raw_ctrl_data 를 갖는다"
+        );
+        assert!(
+            table.raw_ctrl_seal.is_some(),
+            "파서가 만든 표에는 CTRL_HEADER 봉인이 있어야 한다 (#4495)"
+        );
+        let v = table.common.margin.top + 37;
+        table.common.margin.top = v;
+        v
+    };
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    let Control::Table(table2) = &reparsed.sections[si].paragraphs[pi].controls[ci] else {
+        panic!("표가 유지돼야 한다")
+    };
+    assert_eq!(
+        table2.common.margin.top, new_margin_top,
+        "표 CTRL_HEADER 모델 필드 직접 변경이 raw_ctrl_data 에 가려지면 안 된다 (#4495)"
+    );
+}
+
+#[test]
+fn unchanged_table_keeps_raw_ctrl_bytes_when_body_elsewhere_changes() {
+    // 다른 곳(본문 문단)이 바뀌어 구역이 재생성돼도, 변경되지 않은 표의
+    // CTRL_HEADER 는 원본 raw 바이트를 유지해야 한다(하위 raw 전면 폐기 금지).
+    let mut doc = parse_document(&read_sample(TABLE_SAMPLE)).expect("parse");
+    let (si, pi, ci) = find_first_table(&doc);
+    let original_raw = {
+        let Control::Table(table) = &doc.sections[si].paragraphs[pi].controls[ci] else {
+            unreachable!()
+        };
+        table.raw_ctrl_data.clone()
+    };
+    swap_first_char_of_longest_para(&mut doc);
+
+    let out = serialize_document(&doc).expect("serialize");
+    let reparsed = parse_document(&out).expect("reparse");
+    let Control::Table(table2) = &reparsed.sections[si].paragraphs[pi].controls[ci] else {
+        panic!("표가 유지돼야 한다")
+    };
+    assert_eq!(
+        table2.raw_ctrl_data, original_raw,
+        "무변경 표의 CTRL_HEADER raw 는 유지돼야 한다"
+    );
+}
+
+#[test]
+fn swapped_section_raw_stream_is_not_honored() {
+    let mut doc = parse_document(&read_sample(SAMPLE)).expect("parse");
+    let para_count = doc.sections[0].paragraphs.len();
+    doc.sections[0].raw_stream = Some(vec![0xDE; 64]);
+
+    let out = serialize_document(&doc).expect("교체 raw 는 무시되고 모델로 재생성돼야 한다");
+    let reparsed = parse_document(&out).expect("산출물은 정상 문서여야 한다");
+    assert_eq!(
+        reparsed.sections[0].paragraphs.len(),
+        para_count,
+        "산출물은 교체 바이트가 아니라 모델 상태를 담아야 한다 (#4488)"
+    );
+}


### PR DESCRIPTION
## 통합 범위

- #4943: 본문 raw 캐시 출처 봉인
- #4945: HWPX `booleanParam` lexical 표기 보존
- #4946: HWPX→HWP5 글꼴 기본 이름 실측표
- #4948: 구역 시작 `secd`/`cold` 순서 보존
- #4952: 고아 `fieldEnd` 문단의 HWP5 왕복 보존

## 적용

최신 `upstream/devel@76e407b127c2` 위 가시성 branch에서 번호 순으로 누적했다. #4943의 DocInfo provenance 선행 commit은 이미 #4941로 기준선에 포함되어 빈 cherry-pick으로 생략했고, 나머지 source commit은 충돌 없이 적용했다. 원 contributor branch는 rewrite하거나 직접 push하지 않았다.

## 로컬 검증

- PR별 focused 회귀: raw provenance 6건, boolean lexical, 글꼴 기본 이름, `secd`/`cold` 순서, 고아 `fieldEnd` HWPX→HWP5→HWPX
- 실제 `samples/hwpx_sample2.hwpx` HWP5 변환: `--verify --json`에서 `identical:true`, `diffCount:0`
- 전체 nextest: 6,514 passed, 38 skipped, 7 slow, 378.554초
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `git diff --check` 통과

## 검토 기록

원 PR별 archive 검토 기록과 누적 적용 기록을 이 PR에 포함했다. 별도 통합 PR 번호 review 문서는 만들지 않았다.

- `mydocs/pr/archives/pr_4943_review.md`
- `mydocs/pr/archives/pr_4943_review_impl.md`
- `mydocs/pr/archives/pr_4945_review.md`
- `mydocs/pr/archives/pr_4946_review.md`
- `mydocs/pr/archives/pr_4948_review.md`
- `mydocs/pr/archives/pr_4952_review.md`

## 병합 조건

각 원 PR의 최신 head·필수 GitHub Actions·mergeability를 병합 직전에 다시 확인한다. 작업지시자 승인 뒤 통합 PR만 병합하고, 원 PR에는 통합 반영 사유를 남겨 close한다.