### PR TITLE
fix(sweep): 실패 키를 자동 재측정해 가짜 결함을 걷어낸다 (#4899)

### DIFF
--- a/tools/loadsave_sweep/README.md
+++ b/tools/loadsave_sweep/README.md
@@ -101,6 +101,8 @@ Phase A 산출물은 버전 무관이므로 재사용 — Phase B 만 `-HwpVersi
 <S>/s1/oracle_tasks.tsv        Phase B 작업 목록 (key \t path)
 <S>/s1/oracle_<ver>/result.tsv key, status, pages, textLen, textSha, ctrls, fileBytes, err
 <S>/s1/oracle_<ver>/texts/     한글이 추출한 본문 텍스트 (판정·삼각측량용)
+<S>/s1/oracle_<ver>/stall_kills.tsv  key, 정지 초, 시각, 직전 kill 이후 경과 초 (#4751/#4899)
+<S>/s1/oracle_<ver>/retried.tsv      key, 재측정 전 status, 재측정 후 status (#4899)
 <S>/s1/oracle_<ver>/verdicts/  verdicts.tsv + summary.md
 ```
 
@@ -112,3 +114,20 @@ stall-kill 오판 방어(#4749/#4751): 감독은 heartbeat 를 `FileShare.ReadWr
 로 크기에 비례한다. 죽인 키는 `<OutDir>/stall_kills.tsv` 에 남고, judge 는 그 키의 ERR 를
 `OPEN_FAIL` 이 아닌 `ORACLE_TIMEOUT`(원본이면 `ORACLE_ORIG_TIMEOUT`) 으로 내
 "결함"과 "측정 실패 — 재확인 필요"를 가른다. 재확인 키·명령은 summary.md 에 나온다.
+
+### 실패 키 자동 재측정 (#4899)
+
+한글 COM 은 강제 종료·자원 압박 뒤 한동안 불안정해서 **멀쩡한 문서도 실패**한다. s13 전수
+(29,896 opens)에서 실패로 남은 6건이 재측정에서 6/6 정상이었고, 그중 하나는 최상위 판정인
+`OPEN_FAIL`("저장 치명 결함")로 기록돼 있었다. 그래서 패스는 스스로 한 번 더 잰다:
+
+- 본 패스가 끝나면 `OK` 가 아닌 키를 모아, **남은 Hwp.exe 를 모두 내리고 20초 쉰 뒤**
+  깨끗한 워커로 재측정한다(임계는 `max(StallSeconds×4, 1200)`).
+- 두 번째도 실패하면 그대로 결함으로 남긴다. 성공하면 `result.tsv` 의 그 행을 교체한다.
+- 무엇이 어떻게 바뀌었는지는 `<OutDir>/retried.tsv` 에 `key<TAB>before<TAB>after` 로 남는다.
+- 재측정을 끄려면 `-NoRetryFailures`.
+
+kill 연쇄 방어도 함께 있다 — 강제 종료 직후 첫 `Open()` 이 수 분 블록되는 회복 구간
+(`RecoverySeconds`, 기본 600초)에는 임계에 `RecoveryBonusSeconds`(기본 300초)를 더하고,
+같은 키를 두 번 죽였으면 세 번째는 죽이지 않고 4배까지 기다린다. `stall_kills.tsv` 에는
+직전 kill 이후 경과(초)가 4번째 열로 함께 남아 사후에 사슬을 식별할 수 있다.

--- a/tools/loadsave_sweep/oracle_run.ps1
+++ b/tools/loadsave_sweep/oracle_run.ps1
@@ -18,8 +18,19 @@ param(
   # with file size: allowed = StallSeconds + StallSecondsPerMB * MB. A 11MB doc gets ~960s
   # (same order as the 1200s recheck that passed 18/18), a 4KB doc keeps the base 300s.
   [int]$StallSecondsPerMB = 60,
+  # [#4899] 강제 종료 직후 첫 Open 은 수 분 블록된다(문서화된 현상). 그 회복 시간이 다음
+  # 문서의 stall 카운트다운에 그대로 잡히면 kill 이 연쇄해, 6~14KB 짜리 짧은 서식까지
+  # 줄줄이 죽는다(s13 실측: 00464·05148 은 orig/h2h/h2x 가 연달아 각 2회씩, 문서당 30분 손실).
+  # kill 이후 이 시간 동안은 임계를 넉넉히 잡는다.
+  [int]$RecoverySeconds = 600,
+  # 회복 구간에서 더해 줄 여유(기본: 기준 임계만큼 = 두 배).
+  [int]$RecoveryBonusSeconds = 300,
   [int]$RecycleEvery = 200,
   [int]$WarmupDocs = 5,
+  # [#4899] 실패로 끝난 키는 패스 말미에 깨끗한 워커로 1회 다시 잰다. 두 번 다 실패해야
+  # 결함으로 기록한다 — s13 에서는 실패 6건이 재측정에서 **6/6 정상**이었고, 그중 하나는
+  # 최상위 판정인 OPEN_FAIL 로 남아 있었다.
+  [switch]$NoRetryFailures,
   # Hangul 2018 deadlocks in Open() when hidden -- only pass this on 2022+.
   [switch]$HideWindow
 )
@@ -104,15 +115,20 @@ $state = @{
   Out = Join-Path $OutDir 'result.tsv'
   HB = Join-Path $OutDir 'hb.txt'
   Texts = Join-Path $OutDir 'texts'
+  Tasks = $TaskPath
   Total = $all.Count
   Proc = $null
   Restarts = 0
 }
 
+# [#4899] kill 연쇄 방어용 상태.
+$lastKillAt = $null
+$killCount = @{}
+
 function Start-Worker {
   $wargs = @(
     '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', (Join-Path $here 'oracle_worker.ps1'),
-    '-TaskPath', $TaskPath, '-OutPath', $state.Out, '-HeartbeatPath', $state.HB,
+    '-TaskPath', $state.Tasks, '-OutPath', $state.Out, '-HeartbeatPath', $state.HB,
     '-ExpectMajor', $expectMajor, '-TextDir', $state.Texts,
     '-RecycleEvery', $RecycleEvery, '-WarmupDocs', $WarmupDocs
   )
@@ -180,12 +196,24 @@ while ($true) {
         $curKey = $parts[2]
         $allowed = $StallSeconds
         if ($sizeMB.ContainsKey($curKey)) { $allowed = $StallSeconds + [int]($StallSecondsPerMB * $sizeMB[$curKey]) }
+        # [#4899] 직전 kill 의 회복 구간이면 임계를 늘린다 — 강제 종료 직후 첫 Open 이
+        # 수 분 블록되는 것을 "이 문서가 느리다"로 오해하면 kill 이 연쇄한다.
+        $sinceKill = if ($null -ne $lastKillAt) { ((Get-Date) - $lastKillAt).TotalSeconds } else { [double]::PositiveInfinity }
+        if ($sinceKill -lt $RecoverySeconds) { $allowed += $RecoveryBonusSeconds }
+        # 같은 키를 두 번 죽였으면 세 번째는 죽이지 않고 크게 기다린다(진짜 대형 문서 보호).
+        $priorKills = if ($killCount.ContainsKey($curKey)) { [int]$killCount[$curKey] } else { 0 }
+        if ($priorKills -ge 2) { $allowed = $allowed * 4 }
         if ($null -ne $age -and $age -gt $allowed) {
           $hp = [int]$parts[0]
           Write-Output ("[sup] worker stalled {0:N0}s (allowed {1}s) on '{2}' -> killing Hwp pid {3}" -f $age, $allowed, $curKey, $hp)
           # [#4751] Record the kill so judge.py grades the resulting ERR as
           # ORACLE_TIMEOUT (re-measure) instead of OPEN_FAIL (real defect).
-          try { Add-Content -LiteralPath $stallLog -Value ("{0}`t{1:N0}`t{2}" -f $curKey, $age, (Get-Date -Format o)) -Encoding UTF8 } catch { }
+          # [#4899] 직전 kill 이후 경과(초)를 함께 남긴다 — 사후에 kill 연쇄를 식별하려면
+          # "언제 죽였나"만으로는 부족하고 "직전 kill 로부터 얼마 만인가"가 필요하다.
+          $gap = if ([double]::IsPositiveInfinity($sinceKill)) { '-' } else { '{0:N0}' -f $sinceKill }
+          try { Add-Content -LiteralPath $stallLog -Value ("{0}`t{1:N0}`t{2}`t{3}" -f $curKey, $age, (Get-Date -Format o), $gap) -Encoding UTF8 } catch { }
+          $lastKillAt = Get-Date
+          $killCount[$curKey] = $priorKills + 1
           if ($hp -gt 0) { try { Stop-Process -Id $hp -Force -ErrorAction SilentlyContinue } catch { } }
           if ($age -gt ($allowed * 2)) {
             try { Stop-Process -Id $state.Proc.Id -Force -ErrorAction SilentlyContinue } catch { }
@@ -217,4 +245,135 @@ while ($true) {
 
 $d = Get-DoneCount $state.Out
 Write-Output ("[sup] PASS {0} COMPLETE: {1}/{2} records, {3:N1} min" -f $HwpVersion, $d, $state.Total, ((Get-Date) - $t0).TotalMinutes)
+
+# ============================================================
+# [#4899] 실패 키 자동 재측정 — 한 번의 실패로 결함을 단정하지 않는다.
+#
+# 한글 COM 은 강제 종료·자원 압박 뒤 한동안 불안정해서, 멀쩡한 문서도 `0x800706BE` 로
+# 실패한다. s13 전수(29,896 opens)에서 실패로 남은 6건이 재측정에서 **6/6 정상**이었고,
+# 그중 `03908.h2h` 는 최상위 판정인 OPEN_FAIL("저장 치명 결함")로 기록돼 있었다.
+# 사람이 손으로 다시 재야만 걷히던 가짜 판정을, 패스가 스스로 걷어낸다.
+# 재측정 대상은 보통 수 건이라 비용은 사실상 0이다(6/29,896).
+# ============================================================
+# [#4899] judge.py 는 result.tsv 를 `encoding="utf-8"`(BOM 미허용)로 읽는다. PowerShell 의
+# `Set-Content -Encoding UTF8` 은 BOM 을 붙여, 병합본 첫 줄의 key 가 BOM 을 달고 나와
+# 그 문서의 판정이 통째로 어긋난다. 워커가 쓰던 형식(BOM 없는 UTF-8)을 그대로 유지한다.
+$Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+function Write-Utf8NoBom($path, $lines) {
+  [System.IO.File]::WriteAllLines($path, [string[]]@($lines), $Utf8NoBom)
+}
+function Append-Utf8NoBom($path, $line) {
+  [System.IO.File]::AppendAllText($path, ($line + "`r`n"), $Utf8NoBom)
+}
+
+function Get-FailedKeys($resultPath) {
+  $failed = New-Object System.Collections.Generic.List[string]
+  if (-not (Test-Path -LiteralPath $resultPath)) { return $failed }
+  $text = Read-SharedText $resultPath
+  if ($null -eq $text) { return $failed }
+  foreach ($line in $text -split "`r?`n") {
+    if ([string]::IsNullOrWhiteSpace($line)) { continue }
+    $c = $line -split "`t"
+    # result.tsv: key, status, pages, textLen, textSha, ctrls, fileBytes, err
+    if ($c.Count -ge 2 -and $c[1] -ne 'OK') { $failed.Add($c[0]) }
+  }
+  return $failed
+}
+
+$retryLog = Join-Path $OutDir 'retried.tsv'
+$failedKeys = if ($NoRetryFailures) { @() } else { Get-FailedKeys $state.Out }
+
+if ($failedKeys.Count -gt 0) {
+  Write-Output ("[sup] {0} failed key(s) -- re-measuring once with a clean worker (#4899)" -f $failedKeys.Count)
+
+  # 재측정은 오염되지 않은 상태에서 시작한다: 남은 Hwp.exe 를 모두 내리고 잠시 쉰다.
+  $stale = @(Get-Process -Name 'Hwp' -ErrorAction SilentlyContinue)
+  if ($stale.Count -gt 0) {
+    Write-Output "[sup] terminating $($stale.Count) leftover Hwp.exe process(es) before retry"
+    foreach ($p in $stale) { try { Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue } catch { } }
+  }
+  Start-Sleep -Seconds 20
+
+  $failedSet = @{}
+  foreach ($k in $failedKeys) { $failedSet[$k] = $true }
+  $retryTasks = Join-Path $OutDir 'retry_tasks.tsv'
+  $retryLines = foreach ($taskLine in $all) {
+    $c = $taskLine -split "`t"
+    if ($c.Count -ge 2 -and $failedSet.ContainsKey($c[0])) { $taskLine }
+  }
+  Write-Utf8NoBom $retryTasks $retryLines
+
+  $retryOut = Join-Path $OutDir 'result_retry.tsv'
+  if (Test-Path -LiteralPath $retryOut) { Remove-Item -LiteralPath $retryOut -Force }
+
+  $state.Tasks = $retryTasks
+  $state.Out = $retryOut
+  $state.Total = @($retryLines).Count
+  $state.Restarts = 0
+  # 재측정에서는 임계를 넉넉히 준다 — 대형 문서가 기준 임계에 걸려 또 죽으면 의미가 없다.
+  $StallSeconds = [Math]::Max($StallSeconds * 4, 1200)
+  $t1 = Get-Date
+  Start-Worker
+  while ($true) {
+    Start-Sleep -Seconds 10
+    $rd = Get-DoneCount $state.Out
+    $running = $false
+    if ($null -ne $state.Proc) {
+      try { $running = -not (Get-Process -Id $state.Proc.Id -ErrorAction Stop).HasExited } catch { $running = $false }
+    }
+    if (-not $running) {
+      if ($rd -lt $state.Total -and $state.Restarts -lt 5) {
+        $state.Restarts++
+        Write-Output "[sup] retry worker exited early ($rd/$($state.Total)) -> restart #$($state.Restarts)"
+        Start-Worker
+        continue
+      }
+      break
+    }
+    if (((Get-Date) - $t1).TotalMinutes -gt 60) {
+      Write-Output "[sup] retry pass over 60 min -- stopping"
+      try { Stop-Process -Id $state.Proc.Id -Force -ErrorAction SilentlyContinue } catch { }
+      break
+    }
+  }
+
+  # 재측정 결과를 본 결과에 반영한다. 두 번 다 실패한 키는 그대로 둔다(진짜 결함).
+  $retryRows = @{}
+  $rtext = Read-SharedText $retryOut
+  if ($null -ne $rtext) {
+    foreach ($line in $rtext -split "`r?`n") {
+      if ([string]::IsNullOrWhiteSpace($line)) { continue }
+      $c = $line -split "`t"
+      if ($c.Count -ge 2) { $retryRows[$c[0]] = $line }
+    }
+  }
+  $mainPath = Join-Path $OutDir 'result.tsv'
+  $mainText = Read-SharedText $mainPath
+  $merged = New-Object System.Collections.Generic.List[string]
+  $recovered = 0
+  $stillFailed = 0
+  foreach ($line in ($mainText -split "`r?`n")) {
+    if ([string]::IsNullOrWhiteSpace($line)) { continue }
+    $c = $line -split "`t"
+    $key = $c[0]
+    if ($retryRows.ContainsKey($key)) {
+      $rc = $retryRows[$key] -split "`t"
+      if ($rc.Count -ge 2 -and $rc[1] -eq 'OK') {
+        $merged.Add($retryRows[$key])
+        Append-Utf8NoBom $retryLog ("{0}`t{1}`t{2}" -f $key, $c[1], 'OK')
+        $recovered++
+        continue
+      }
+      Append-Utf8NoBom $retryLog ("{0}`t{1}`t{2}" -f $key, $c[1], $rc[1])
+      $stillFailed++
+    }
+    $merged.Add($line)
+  }
+  Write-Utf8NoBom $mainPath $merged
+  # 재측정 목록에 넣었는데 결과 행이 없는 키(작업 목록에 없거나 워커가 못 끝낸 경우)는
+  # 회복도 잔존 실패도 아니다 — 따로 세어야 "왜 숫자가 안 맞나"를 나중에 되짚을 수 있다.
+  $notMeasured = $failedKeys.Count - $recovered - $stillFailed
+  Write-Output ("[sup] retry {0}: recovered {1} / still failed {2} / not re-measured {3} -> {4}" -f $failedKeys.Count, $recovered, $stillFailed, $notMeasured, $retryLog)
+}
+
 Write-Output "[sup] reminder: run tools/hangul_version_oracle/restore_com_default.ps1 when all passes are done."


### PR DESCRIPTION
## 변경 요약

한글 COM 은 강제 종료·자원 압박 뒤 한동안 불안정해서 **멀쩡한 문서도 실패**한다. s13 전수
(29,896 opens)에서 실패로 남은 6건이 재측정에서 **6/6 정상**이었고, 그중 `03908.h2h` 는 최상위
판정인 `OPEN_FAIL`("저장 치명 결함")로 기록돼 있었다. 지금까지는 사람이 손으로 다시 재야만
이 가짜 판정이 걷혔고, 안 하면 전수 결과에 그대로 남았다.

### 1. 실패 키 자동 재측정

본 패스가 끝나면 `OK` 가 아닌 키를 모아, **남은 Hwp.exe 를 모두 내리고 20초 쉰 뒤** 깨끗한
워커로 한 번 더 잰다(임계 `max(StallSeconds×4, 1200)`).

- 성공하면 `result.tsv` 의 그 행을 교체한다.
- **두 번 다 실패하면 그대로 결함으로 남긴다** — 조용히 지우지 않는다.
- 무엇이 어떻게 바뀌었는지 `retried.tsv` 에 `key / before / after` 로 남는다.
- 대상은 보통 수 건이라 비용이 사실상 0이다(s13 기준 **6 / 29,896**). `-NoRetryFailures` 로 끈다.

### 2. kill 연쇄 방어

강제 종료 직후 첫 `Open()` 이 수 분 블록되는 것을 "이 문서가 느리다"로 오해해 kill 이 연쇄했다.
s13 실측: `00464`·`05148` 은 orig/h2h/h2x 가 연달아 각 2회씩 죽어 문서당 30분이 날아갔고,
정작 그 문서들은 6~14KB 짜리 짧은 서식이라 재측정에서 몇 초 만에 열렸다.

- 회복 구간(`RecoverySeconds`, 기본 600초)에는 임계에 `RecoveryBonusSeconds`(기본 300초)를 더한다.
- 같은 키를 두 번 죽였으면 세 번째는 죽이지 않고 4배까지 기다린다(진짜 대형 문서 보호).

### 3. `stall_kills.tsv` 에 직전 kill 이후 경과(초)

사후에 사슬을 식별하려면 "언제 죽였나"만으로는 부족하고 "직전 kill 로부터 얼마 만인가"가 필요하다.

## 관련 이슈

closes #4899

## 테스트 — 한글 2022 실측

정식 하네스를 그대로 돌려 세 갈래를 확인했다.

| 시나리오 | 결과 |
|---|---|
| 실패 행(`ERR`)이 남은 패스 | 재측정 → **`OK` 로 교체**, `retried.tsv` 에 `seeded_fail / ERR / OK` |
| 나머지 정상 키 | 손대지 않음(3행 그대로) |
| 재측정으로도 못 고치는 키 | `ERR` 유지 — 결함으로 남는다 |

**BOM 함정도 함께 막았다**: judge.py 는 `result.tsv` 를 `encoding="utf-8"` 로 읽는데 PowerShell 의
`Set-Content -Encoding UTF8` 은 BOM 을 붙인다. 병합본 첫 줄의 key 가 BOM 을 달면 그 문서 판정이
통째로 어긋나므로, 워커가 쓰던 형식(BOM 없는 UTF-8)을 유지하는 헬퍼로 쓴다. 실제로 1차 구현에서
BOM 이 붙는 것을 확인하고 고쳤다.

- [x] `retried.tsv`·병합 `result.tsv` 모두 BOM 없음 확인
- [x] PowerShell 파서 구문 검사 통과
- [ ] 마지막 회귀 확인 1회는 **한글 COM 이 이 장비에서 `CO_E_SERVER_EXEC_FAILURE` 로 넘어가**
      돌리지 못했다(하루치 반복 실행이 세션 COM 을 망가뜨리는 알려진 현상, DCOM 10010).
      위 표의 측정은 그 이전에 정상 상태에서 받은 것이다.

## 성능 영향 및 측정 결과

- 예상 영향: 본 패스 없음. 말미에 실패 키 수만큼(보통 한 자리) 추가 개방.
- 재현·측정: 위 실측 외 별도 성능 측정 없음.
