### PR TITLE
feat(hwp5): 덧말('tdut') CTRL_HEADER 양방향 구현 — HWP5 왕복 소실 해소 (#4397)

### DIFF
--- a/src/parser/control.rs
+++ b/src/parser/control.rs
@@ -47,6 +47,8 @@ pub fn parse_control(ctrl_id: u32, ctrl_data: &[u8], child_records: &[Record]) -
         tags::CTRL_BOOKMARK => parse_bookmark(ctrl_data),
         tags::CTRL_INDEX_MARK => parse_index_mark(ctrl_data),
         tags::CTRL_PAGE_NUM_CTRL => parse_page_num_ctrl(ctrl_data),
+        // [#4397] 'tdut'(덧말) — 상수 이름과 달리 CTRL_CHAR_OVERLAP 이 'tdut' 다.
+        tags::CTRL_CHAR_OVERLAP => parse_ruby(ctrl_data),
         tags::CTRL_TCPS => parse_char_overlap(ctrl_data),
         tags::CTRL_EQUATION => parse_equation_control(ctrl_data, child_records),
         tags::CTRL_FORM => parse_form_control(ctrl_data, child_records),
@@ -772,6 +774,25 @@ fn parse_index_mark(ctrl_data: &[u8]) -> Control {
 ///   UINT8(1): 펼침
 ///   UINT8(1): charshape 아이디 수(cnt)
 ///   UINT[cnt](4×cnt): charshape_id 배열
+/// [#4397] 덧말('tdut') CTRL_HEADER payload 파싱 — HWP5 스펙 표 151.
+///
+/// `mainText`(HWP string) + `subText`(HWP string) + 덧말 위치/Fsizeratio/Option/
+/// Style number/정렬 (UINT32 ×5). 종전에는 arm 이 없어 `Control::Unknown` 으로
+/// 떨어졌고, HWPX→HWP5 저장도 최소 CTRL_HEADER(짝 맞춤, #4677)만 내 내용이
+/// 통째로 소실됐다 — 저장측(serialize_control)과 함께 양방향을 잇는다.
+fn parse_ruby(ctrl_data: &[u8]) -> Control {
+    let mut ruby = crate::model::control::Ruby::default();
+    let mut r = ByteReader::new(ctrl_data);
+    ruby.main_text = r.read_hwp_string().unwrap_or_default();
+    ruby.ruby_text = r.read_hwp_string().unwrap_or_default();
+    ruby.pos_type = r.read_u32().unwrap_or(0) as u8;
+    ruby.sz_ratio = r.read_u32().unwrap_or(0) as u8;
+    ruby.option = r.read_u32().unwrap_or(0);
+    ruby.style_id_ref = r.read_u32().unwrap_or(0) as u16;
+    ruby.align = r.read_u32().unwrap_or(0) as u8;
+    Control::Ruby(ruby)
+}
+
 fn parse_char_overlap(ctrl_data: &[u8]) -> Control {
     let mut co = CharOverlap::default();
     if ctrl_data.len() < 2 {

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -200,15 +200,29 @@ pub fn serialize_control(
         }
         // [Task #852 Stage 2.4] 양식 개체 직렬화 — CTRL_HEADER + HWPTAG_FORM_OBJECT
         Control::Form(form) => serialize_form_control(form, level, records),
+        // [#4397] 덧말('tdut') — CTRL_HEADER 에 스펙 표 151 payload 를 온전히 싣는다.
+        // #4677 은 짝(제어문자↔헤더)만 맞춰 한글의 본문 폐기를 막았고, 여기서
+        // 내용(mainText/subText/위치/크기비율/옵션/스타일/정렬)까지 옮겨 왕복
+        // 소실을 없앤다. 파서측 parse_ruby(parser/control.rs)와 레이아웃 동일.
+        Control::Ruby(ruby) => {
+            let mut w = ByteWriter::new();
+            w.write_hwp_string(&ruby.main_text).unwrap();
+            w.write_hwp_string(&ruby.ruby_text).unwrap();
+            w.write_u32(u32::from(ruby.pos_type)).unwrap();
+            w.write_u32(u32::from(ruby.sz_ratio)).unwrap();
+            w.write_u32(ruby.option).unwrap();
+            w.write_u32(u32::from(ruby.style_id_ref)).unwrap();
+            w.write_u32(u32::from(ruby.align)).unwrap();
+            records.push(make_ctrl_record(
+                tags::CTRL_CHAR_OVERLAP,
+                level,
+                &w.into_bytes(),
+            ));
+        }
         // 미구현 컨트롤은 최소한의 CTRL_HEADER만 생성
-        Control::Hyperlink(_) | Control::Ruby(_) | Control::Unknown(_) => {
+        Control::Hyperlink(_) | Control::Unknown(_) => {
             let ctrl_id = match ctrl {
                 Control::Unknown(u) => u.ctrl_id,
-                // [#4677] 덧말은 PARA_TEXT 에 `17 00 'tdut'` 제어문자가 나가므로 짝이 되는
-                // CTRL_HEADER 도 반드시 있어야 한다. 내용(mainText/subText/속성)까지 옮기는
-                // 것은 #4397 소관이고, 여기서는 **짝을 맞추는 것**이 목적이다 — 짝이 없으면
-                // 한글 2022 가 그 문서의 본문을 통째로 버린다.
-                Control::Ruby(_) => tags::CTRL_CHAR_OVERLAP,
                 _ => 0,
             };
             if ctrl_id != 0 {

--- a/tests/issue_4397_ruby_hwp5_roundtrip.rs
+++ b/tests/issue_4397_ruby_hwp5_roundtrip.rs
@@ -1,0 +1,73 @@
+//! [Issue #4397] HWPX Ruby(덧말) 컨트롤이 HWPX→HWP→HWPX 왕복에서 통째로
+//! 사라지던 계약을 고정한다.
+//!
+//! 종전: HWP5 저장은 최소 CTRL_HEADER(짝 맞춤, #4677)만 내고 파서에는 'tdut'
+//! arm 이 없어 `Control::Unknown` 으로 떨어졌다 — 본문/덧말 텍스트와 스타일이
+//! 경고 없이 소실. 이 PR 은 스펙 표 151 payload(mainText·subText·위치·크기비율·
+//! 옵션·스타일·정렬)를 양방향으로 잇는다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+use rhwp::parse_document;
+
+const SAMPLE: &str = "samples/hwpx/opengov/36389301_결재문서본문_직장훈련계획_덧말.hwpx";
+
+fn read_sample() -> Vec<u8> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    std::fs::read(&path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"))
+}
+
+fn first_ruby(doc: &rhwp::model::document::Document) -> Option<&rhwp::model::control::Ruby> {
+    doc.sections
+        .iter()
+        .flat_map(|s| &s.paragraphs)
+        .find_map(|p| {
+            p.controls.iter().find_map(|c| match c {
+                Control::Ruby(r) => Some(r),
+                _ => None,
+            })
+        })
+}
+
+#[test]
+fn issue4397_ruby_survives_hwp5_roundtrip() {
+    let original = parse_document(&read_sample()).expect("parse hwpx");
+    let ruby0 = first_ruby(&original)
+        .expect("샘플 전제: 덧말 컨트롤")
+        .clone();
+    assert!(!ruby0.main_text.is_empty(), "샘플 전제: 본문 텍스트");
+    assert!(!ruby0.ruby_text.is_empty(), "샘플 전제: 덧말 텍스트");
+
+    // HWPX → HWP5
+    let mut core = DocumentCore::from_bytes(&read_sample()).expect("open hwpx");
+    let hwp = core.export_hwp_with_adapter().expect("convert to hwp");
+    let mid = parse_document(&hwp).expect("parse hwp");
+    let ruby1 = first_ruby(&mid).expect("HWP5 재파싱이 덧말을 복원해야 한다 (#4397)");
+    assert_eq!(ruby1.main_text, ruby0.main_text, "mainText 보존");
+    assert_eq!(ruby1.ruby_text, ruby0.ruby_text, "subText 보존");
+    assert_eq!(
+        (
+            ruby1.pos_type,
+            ruby1.align,
+            ruby1.sz_ratio,
+            ruby1.option,
+            ruby1.style_id_ref
+        ),
+        (
+            ruby0.pos_type,
+            ruby0.align,
+            ruby0.sz_ratio,
+            ruby0.option,
+            ruby0.style_id_ref
+        ),
+        "속성 보존"
+    );
+
+    // HWP5 → HWPX (왕복 완주)
+    let core2 = DocumentCore::from_bytes(&hwp).expect("open hwp");
+    let hwpx2 = core2.export_hwpx_native().expect("export hwpx");
+    let fin = parse_document(&hwpx2).expect("parse final hwpx");
+    let ruby2 = first_ruby(&fin).expect("왕복 후에도 덧말이 있어야 한다 (#4397)");
+    assert_eq!(ruby2.main_text, ruby0.main_text);
+    assert_eq!(ruby2.ruby_text, ruby0.ruby_text);
+}


### PR DESCRIPTION
## 변경 요약

HWPX Ruby(덧말) 컨트롤이 HWPX→HWP→HWPX 왕복에서 경고 없이 통째로 사라지던 문제(#4397)를 고칩니다 — 이슈의 "이상적" 방향(HWP5 실제 슬롯 구현)입니다.

- **저장(serializer/control.rs)** — `Control::Ruby` 를 "미구현 최소 헤더" arm 에서 분리해, HWP5 스펙 **표 151**('tdut' 덧말: mainText·subText HWP string + 덧말 위치/Fsizeratio/Option/Style number/정렬 UINT32 ×5) payload 를 CTRL_HEADER 에 온전히 싣습니다. #4677 이 맞춘 짝(PARA_TEXT `0x0017+'tdut'` ↔ CTRL_HEADER)은 그대로이고 내용이 채워집니다.
- **파싱(parser/control.rs)** — 'tdut' dispatcher arm(`parse_ruby`)을 추가했습니다. 종전에는 arm 이 없어 `Control::Unknown` 으로 떨어졌습니다(참고: 상수 `CTRL_CHAR_OVERLAP` 이 이름과 달리 'tdut' 입니다 — 기존 주석 계약 그대로 따랐습니다).

양쪽이 같은 표 151 레이아웃을 쓰므로 자기 왕복이 닫히고, HWPX 재-export(`render_dutmal`)까지 이어집니다.

## 관련 이슈

closes #4397

## 실측 (이슈 재현체 `samples/hwpx/opengov/36389301_결재문서본문_직장훈련계획_덧말.hwpx`)

```
rhwp convert <원본> mid.hwp && rhwp export-hwpx mid.hwp final.hwpx && rhwp ir-diff <원본> final.hwpx
```

- 종전: `section[0] paragraph[6] controls: expected=[ruby] actual=[]`
- 이 PR: **차이 0건**

## 검증 한계 (정직 고지)

payload 레이아웃은 HWP5 스펙 표 151 을 그대로 따랐고 자기 왕복은 무손실이지만, **변환 산출물을 한글 2022 로 여는 오라클 검증은 이 세션에서 수행하지 못했습니다**(COM 미사용 세션). 스펙 문서와 짝 규약(#4677)이 근거이며, 필요하면 loadsave 오라클 스윕(#4678 하네스)에서 후속 확인 가능합니다.

## 테스트

- [x] `cargo test` 통과 — 신규 `issue4397_ruby_survives_hwp5_roundtrip`(HWPX→HWP5→HWPX 전 구간에서 mainText/subText/5속성 보존). 전체 nextest 게이트 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] 관련 샘플 실측 — ir-diff 0건
- [ ] 웹(WASM) 렌더링 확인 (해당 없음)
- [ ] rhwp-studio 변경 없음
- [ ] 작업 증빙 — 코드 수정(문서 편집 작업 아님)

## 성능 영향 및 측정 결과

- 예상 영향: 없음
- 재현·측정: 미측정

🤖 Generated with [Claude Code](https://claude.com/claude-code)
