### PR TITLE
fix(hwpx): Scripts/* 패키지 파트를 왕복에서 원문 보존 (#3557)

### DIFF
--- a/src/parser/hwpx/mod.rs
+++ b/src/parser/hwpx/mod.rs
@@ -365,6 +365,21 @@ pub fn parse_hwpx(data: &[u8]) -> Result<Document, HwpxError> {
             hwpx_aux_entries.push((path.to_string(), bytes));
         }
     }
+    // [#3557] Scripts/* — IR 로 모델링되지 않는 패키지 스크립트를 원본 그대로
+    // 보존한다. 소실되면 문서 동작이 조용히 사라지는데 --verify(IR 대조)로는
+    // 잡히지 않는다. content.hpf 의 opf:item/spine 참조는 write_content_hpf 가
+    // 원본 블록에서 그대로 splice 하고, ZIP 방출은 serializer/hwpx/mod.rs 가
+    // 이 aux 엔트리를 통과시킨다.
+    let script_paths: Vec<String> = reader
+        .file_names()
+        .into_iter()
+        .filter(|n| n.starts_with("Scripts/"))
+        .collect();
+    for path in script_paths {
+        if let Ok(bytes) = reader.read_file_bytes(&path) {
+            hwpx_aux_entries.push((path, bytes));
+        }
+    }
 
     // 2. content.hpf → 섹션 파일 목록 + BinData 목록
     let content_xml = reader.read_file("Contents/content.hpf")?;

--- a/src/serializer/hwpx/content.rs
+++ b/src/serializer/hwpx/content.rs
@@ -27,6 +27,30 @@ pub struct BinDataEntry {
 /// IR 로 재생성하더라도 이 블록만은 원본을 보존해야 손실이 없다. self-closing
 /// (`<opf:metadata/>`) 형태도 처리한다. 형태를 인식하지 못하면 `None` 을 돌려
 /// 호출자가 하드코딩 기본값으로 폴백하도록 한다.
+/// [#3557] 원본 content.hpf 에서 `Scripts/` 항목의 `<opf:item .../>` 태그 원문과
+/// 그 id 목록을 추출한다 — 스크립트 파트는 IR 로 모델링되지 않으므로 매니페스트
+/// 참조도 원문 그대로 보존해야 패키지가 정합한다(zip 통과는 mod.rs).
+fn extract_script_items(original: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let mut rest = original;
+    while let Some(start) = rest.find("<opf:item ") {
+        let tail = &rest[start..];
+        let Some(end) = tail.find("/>") else { break };
+        let tag = &tail[..end + 2];
+        if tag.contains("href=\"Scripts/") {
+            let id = tag
+                .split("id=\"")
+                .nth(1)
+                .and_then(|t| t.split('"').next())
+                .unwrap_or("")
+                .to_string();
+            out.push((id, tag.to_string()));
+        }
+        rest = &tail[end + 2..];
+    }
+    out
+}
+
 fn extract_metadata_block(original: &str) -> Option<&str> {
     let open = original.find("<opf:metadata>")?;
     let close = original[open..].find("</opf:metadata>")? + open + "</opf:metadata>".len();
@@ -167,6 +191,15 @@ pub fn write_content_hpf(
         ],
     )?;
 
+    // [#3557] Scripts/* 항목 — 원본 태그 원문 splice(id·media-type 보존).
+    let script_items: Vec<(String, String)> =
+        original_str.map(extract_script_items).unwrap_or_default();
+    for (_, tag) in &script_items {
+        w.get_mut()
+            .write_all(tag.as_bytes())
+            .map_err(|e| SerializeError::XmlError(format!("script item splice: {e}")))?;
+    }
+
     for entry in bin_data {
         empty_tag(
             &mut w,
@@ -196,6 +229,16 @@ pub fn write_content_hpf(
             "opf:itemref",
             &[("idref", id.as_str()), ("linear", "yes")],
         )?;
+    }
+    // [#3557] Scripts spine 참조 — 한컴 원본은 스크립트 항목도 spine 에 나열한다.
+    for (id, _) in &script_items {
+        if !id.is_empty() {
+            empty_tag(
+                &mut w,
+                "opf:itemref",
+                &[("idref", id.as_str()), ("linear", "yes")],
+            )?;
+        }
     }
     end_tag(&mut w, "opf:spine")?;
 

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -121,6 +121,15 @@ pub fn serialize_hwpx_with_report(doc: &Document) -> Result<SerializedDocument, 
             .unwrap_or_else(|| SETTINGS_XML.as_bytes()),
     )?;
 
+    // 6-1. [#3557] Scripts/* — IR 밖 패키지 스크립트 원본 통과. 파서가 aux 로
+    //      보존한 것을 그대로 되쓴다(content.hpf 참조는 write_content_hpf 의
+    //      원본 splice 가 담당).
+    for (path, bytes) in &doc.hwpx_aux_entries {
+        if path.starts_with("Scripts/") {
+            z.write_deflated(path, bytes)?;
+        }
+    }
+
     // 7. META-INF/container.rdf — header + every section part.
     // Hancom uses this RDF graph alongside content.hpf; a stale one-section
     // RDF makes multi-section documents fail to open even when the ZIP and

--- a/tests/issue_3557_package_preservation.rs
+++ b/tests/issue_3557_package_preservation.rs
@@ -1,0 +1,101 @@
+//! [Issue #3557] HWPX 왕복에서 IR 로 모델링되지 않는 패키지 실체(OLE 바이너리·
+//! 임베드 폰트·스크립트)가 소실되지 않아야 한다 — `--verify`(IR 대조)로는 잡히지
+//! 않는 손실이라 패키지(ZIP) 수준 계약으로 고정한다.
+//!
+//! - OLE 바이너리·임베드 폰트는 `image{N}` 명명 불변식(#1891)으로 **개명**되지만
+//!   내용 바이트는 보존된다(개명은 의도 설계 — #4669 이슈 본문도 결함 아님으로
+//!   확인). 이 테스트는 바이트 보존을 계약으로 잰다.
+//! - Scripts/* 는 경로·바이트 원문 그대로, content.hpf 의 opf:item/spine 참조까지
+//!   보존된다(이 PR 의 수정 지점).
+
+use std::io::Read;
+
+use rhwp::document_core::DocumentCore;
+
+fn roundtrip(rel: &str) -> (Vec<u8>, Vec<u8>) {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let original = std::fs::read(&path).unwrap_or_else(|e| panic!("read {rel}: {e}"));
+    let doc = DocumentCore::from_bytes(&original).unwrap_or_else(|e| panic!("parse {rel}: {e:?}"));
+    let out = doc
+        .export_hwpx_native()
+        .unwrap_or_else(|e| panic!("export {rel}: {e:?}"));
+    (original, out)
+}
+
+fn zip_entries(bytes: &[u8]) -> Vec<(String, Vec<u8>)> {
+    let mut zip = zip::ZipArchive::new(std::io::Cursor::new(bytes)).expect("ZIP 열기");
+    let names: Vec<String> = zip.file_names().map(str::to_string).collect();
+    let mut out = Vec::new();
+    for name in names {
+        let mut data = Vec::new();
+        zip.by_name(&name)
+            .expect("엔트리")
+            .read_to_end(&mut data)
+            .expect("읽기");
+        out.push((name, data));
+    }
+    out
+}
+
+fn bin_data_payload_set(entries: &[(String, Vec<u8>)], ext: &str) -> Vec<Vec<u8>> {
+    let mut v: Vec<Vec<u8>> = entries
+        .iter()
+        .filter(|(n, _)| {
+            n.starts_with("BinData/") && n.to_ascii_lowercase().ends_with(&ext.to_ascii_lowercase())
+        })
+        .map(|(_, d)| d.clone())
+        .collect();
+    v.sort();
+    v
+}
+
+#[test]
+fn ole_binary_bytes_survive_roundtrip() {
+    let (original, out) = roundtrip("samples/한셀OLE.hwpx");
+    let a = bin_data_payload_set(&zip_entries(&original), ".ole");
+    let b = bin_data_payload_set(&zip_entries(&out), ".ole");
+    assert!(!a.is_empty(), "샘플 전제: OLE 바이너리가 있어야 한다");
+    assert_eq!(a, b, "OLE 바이너리 바이트가 왕복에서 보존돼야 한다 (#3557)");
+}
+
+#[test]
+fn embedded_font_bytes_survive_roundtrip() {
+    let (original, out) = roundtrip("samples/render-p35-font-native-bitmap.hwpx");
+    let a = bin_data_payload_set(&zip_entries(&original), ".ttf");
+    let b = bin_data_payload_set(&zip_entries(&out), ".ttf");
+    assert!(!a.is_empty(), "샘플 전제: 임베드 폰트가 있어야 한다");
+    assert_eq!(a, b, "임베드 폰트 바이트가 왕복에서 보존돼야 한다 (#3557)");
+}
+
+#[test]
+fn scripts_survive_roundtrip_with_manifest_refs() {
+    let (original, out) = roundtrip("samples/표-텍스트.hwpx");
+    let orig_entries = zip_entries(&original);
+    let out_entries = zip_entries(&out);
+    let orig_scripts: Vec<&(String, Vec<u8>)> = orig_entries
+        .iter()
+        .filter(|(n, _)| n.starts_with("Scripts/"))
+        .collect();
+    assert!(!orig_scripts.is_empty(), "샘플 전제: Scripts 파트");
+    for (name, data) in &orig_scripts {
+        let found = out_entries.iter().find(|(n, _)| n == name);
+        let Some((_, out_data)) = found else {
+            panic!("Scripts 엔트리 소실: {name} (#3557)");
+        };
+        assert_eq!(out_data, data, "Scripts 바이트 원문 보존: {name}");
+    }
+    let hpf = out_entries
+        .iter()
+        .find(|(n, _)| n == "Contents/content.hpf")
+        .map(|(_, d)| String::from_utf8_lossy(d).into_owned())
+        .expect("content.hpf");
+    assert!(
+        hpf.contains(r#"href="Scripts/headerScripts.js""#),
+        "content.hpf 매니페스트에 스크립트 항목이 보존돼야 한다: {hpf}"
+    );
+    let spine = hpf.split("<opf:spine>").nth(1).expect("spine");
+    assert!(
+        spine.contains(r#"idref="headersc""#),
+        "spine 에 스크립트 itemref 가 보존돼야 한다: {spine}"
+    );
+}


### PR DESCRIPTION
## 변경 요약

HWPX 왕복에서 IR 로 모델링되지 않는 패키지 실체가 소실되던 문제(#3557)의 잔여 축을 닫습니다.

### 현행 재실측 — 세 축 중 둘은 이미 해소돼 있었습니다

이슈(2026-07-24, v0.8.0 계열) 이후 devel 에서:

- **OLE 바이너리** — `samples/한셀OLE.hwpx` 왕복에서 `BinData/ole1.ole`(77,828 B)가 `BinData/image1.OLE` 로 **개명**되지만(#1891 `image{N}` 명명 불변식 — 의도 설계) 내용 77,828 B 전량과 manifest·본문 참조가 보존됩니다. dangling 참조 없음.
- **임베드 폰트** — `render-p35-font-native-bitmap.hwpx` 의 `.ttf` 도 같은 방식으로 개명-보존.
- **스크립트** — `표-텍스트.hwpx` 의 `Scripts/*.js` 는 **여전히 통째 소실** — 이 PR 의 수정 대상.

### 수정 — Scripts/* 원문 보존

- 파서(`parser/hwpx/mod.rs`): `Scripts/` 접두 ZIP 엔트리를 `hwpx_aux_entries` 로 원문 보존.
- 직렬화기(`serializer/hwpx/mod.rs`): 보존한 Scripts aux 엔트리를 ZIP 에 그대로 통과.
- `write_content_hpf`(`content.rs`): 원본 content.hpf 에서 `href="Scripts/…"` 인 `<opf:item>` 태그 원문(id·media-type 보존)과 spine `<opf:itemref>` 를 splice — 패키지 참조 정합까지 복원(기존 metadata splice 와 동형 기법).

## 관련 이슈

closes #3557

## 실측

```
rhwp export-hwpx samples/표-텍스트.hwpx rt.hwpx
# 종전: Scripts/headerScripts.js·sourceScripts.js 소실 (매니페스트 참조도 제거)
# 이 PR: ZIP 엔트리 소실 0, 두 스크립트 바이트 원문 동일, hpf item·spine 참조 보존, ir-diff 0건
```

## 테스트

- [x] `cargo test` 통과 — 신규 3건(`issue_3557_package_preservation`): OLE 바이너리 바이트 보존 / 임베드 폰트 바이트 보존(기존 해소분 회귀 봉인) / Scripts 경로·바이트·manifest·spine 보존(이 PR 수정분). 전체 nextest 게이트 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] 관련 샘플 실측 — 위 대조
- [ ] 웹(WASM) 렌더링 확인 (해당 없음)
- [ ] rhwp-studio 변경 없음
- [ ] 작업 증빙 — 코드 수정(문서 편집 작업 아님)

## 성능 영향 및 측정 결과

- 예상 영향: 없음 (Scripts 파트는 문서당 0~수 KB)
- 재현·측정: 미측정

🤖 Generated with [Claude Code](https://claude.com/claude-code)
