### PR TITLE
fix(hwpx): HWP5-origin 문서의 각주·미주 vpos 보정 스킵 — h2x 왕복 vertpos 차이 해소 (#4916, #4660, #3531)

### DIFF
--- a/src/parser/hwpx/mod.rs
+++ b/src/parser/hwpx/mod.rs
@@ -416,6 +416,15 @@ pub fn parse_hwpx(data: &[u8]) -> Result<Document, HwpxError> {
     }
 
     // 4. section*.xml → Section 변환
+    //
+    // [#4916 계열] rhwp 자기 산출 HWPX(HWP5-origin 마커)는 각주·미주 subList
+    // lineseg 의 vpos=0 보정(task 1692)을 건너뛴다 — HWP5 원본 저장값의 왕복
+    // 보존이 마커 계약(#1770)이다. 가드는 구역 파싱 동안만 유효(RAII).
+    let _hwp5_origin_guard = section::Hwp5OriginSourceGuard::set(
+        hwpx_aux_entries
+            .iter()
+            .any(|(path, _)| path == crate::model::document::HWP5_ORIGIN_HWPX_MARKER_PATH),
+    );
     let mut sections = Vec::new();
     for (section_idx, section_href) in package_info.section_files.iter().enumerate() {
         let section_xml = reader.read_file(section_href)?;

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -5258,7 +5258,38 @@ fn parse_ctrl_endnote(
     Ok(Control::Endnote(Box::new(note)))
 }
 
+thread_local! {
+    /// [#4916/#4660/#3531/#4882 계열] 지금 파싱 중인 HWPX 가 rhwp 자기 산출
+    /// (HWP5-origin 마커 보유)인가 — `parse_hwpx` 가 구역 파싱 동안 세운다.
+    static HWPX_HWP5_ORIGIN_SOURCE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// [#4916 계열] HWP5-origin 마커 문서 파싱 구간 표식 — RAII 로 해제된다.
+pub(crate) struct Hwp5OriginSourceGuard;
+
+impl Hwp5OriginSourceGuard {
+    pub(crate) fn set(active: bool) -> Self {
+        HWPX_HWP5_ORIGIN_SOURCE.with(|c| c.set(active));
+        Hwp5OriginSourceGuard
+    }
+}
+
+impl Drop for Hwp5OriginSourceGuard {
+    fn drop(&mut self) {
+        HWPX_HWP5_ORIGIN_SOURCE.with(|c| c.set(false));
+    }
+}
+
 fn normalize_hwpx_note_line_vpos(paragraph: &mut Paragraph) {
+    // [#4916/#4660/#3531/#4882 계열] rhwp 자기 산출 HWPX(HWP5-origin 마커)는
+    // 보정하지 않는다 — HWP5 원본의 각주·미주 subList 저장 lineseg 는 후속 줄
+    // vpos=0 이 **정당한 저장값**이라(마커 계약: lineSeg 시멘틱은 HWP5 원본을
+    // 따른다, #1770), 여기서 합성하면 h2x 왕복 IR 이 원본 파싱과 어긋나고
+    // (--verify vertpos 차이) 쪽수 자기정합도 깨진다. 실물 한컴 HWPX 의
+    // "미주 내부 후속 줄 vpos=0 아티팩트" 보정(task 1692, SO-SUEOP)은 종전 유지.
+    if HWPX_HWP5_ORIGIN_SOURCE.with(|c| c.get()) {
+        return;
+    }
     if paragraph.line_segs.len() <= 1 {
         return;
     }

--- a/tests/issue_3915_verify_axes_both_reported.rs
+++ b/tests/issue_3915_verify_axes_both_reported.rs
@@ -18,12 +18,13 @@ use std::process::{Command, Output};
 /// [#4677] `synam-001.hwp`의 이전 IR 차이는 책갈피 위치 보정으로 해소되었지만, 저장 HWPX의
 /// 쪽수 차이는 여전히 남아 있다.
 const PAGE_FAIL_SAMPLE: &str = "samples/synam-001.hwp";
-/// IR 축만 실패하고 쪽수는 안정적인 표본 — 1쪽, IR 차이 2건(pic 드롭, #3893).
+/// IR 축만 실패하고 쪽수는 안정적인 표본 — 1쪽 유지, IR 차이 2건(char_shapes, #3532).
 ///
 /// [#4916 계열] `issue1937` 의 이전 IR 차이(각주 subList lineseg vertpos)는
 /// HWP5-origin 노트 vpos 보정 스킵으로 해소되었다. 정상화된 문서를 표본으로
-/// 계속 쓰지 않는다(#3820 때 교체와 같은 관례).
-const IR_FAIL_SAMPLE: &str = "samples/pic-crop-01.hwp";
+/// 계속 쓰지 않는다(#3820 때 교체와 같은 관례). pic-crop-01 은 BinData 순번
+/// 재사상(#3893) 수정이 정상화하므로 표본으로 쓰지 않는다.
+const IR_FAIL_SAMPLE: &str = "samples/hwp3-sample10.hwp";
 /// 두 축 모두 통과하는 표본 — 무회귀 기준선.
 const CLEAN_SAMPLE: &str = "samples/table-001.hwp";
 

--- a/tests/issue_3915_verify_axes_both_reported.rs
+++ b/tests/issue_3915_verify_axes_both_reported.rs
@@ -18,11 +18,12 @@ use std::process::{Command, Output};
 /// [#4677] `synam-001.hwp`의 이전 IR 차이는 책갈피 위치 보정으로 해소되었지만, 저장 HWPX의
 /// 쪽수 차이는 여전히 남아 있다.
 const PAGE_FAIL_SAMPLE: &str = "samples/synam-001.hwp";
-/// IR 축만 실패하고 쪽수는 안정적인 표본 — 50쪽, IR 차이 2건.
+/// IR 축만 실패하고 쪽수는 안정적인 표본 — 1쪽, IR 차이 2건(pic 드롭, #3893).
 ///
-/// [#3820] `issue1937`의 이전 쪽수 49→50 차이는 RowBreak/각주 조판 보정으로 해소되었다.
-/// 정상화된 문서를 이중 실패 표본으로 계속 쓰지 않는다.
-const IR_FAIL_SAMPLE: &str = "samples/issue1937_rowbreak_footnote_overpagination.hwp";
+/// [#4916 계열] `issue1937` 의 이전 IR 차이(각주 subList lineseg vertpos)는
+/// HWP5-origin 노트 vpos 보정 스킵으로 해소되었다. 정상화된 문서를 표본으로
+/// 계속 쓰지 않는다(#3820 때 교체와 같은 관례).
+const IR_FAIL_SAMPLE: &str = "samples/pic-crop-01.hwp";
 /// 두 축 모두 통과하는 표본 — 무회귀 기준선.
 const CLEAN_SAMPLE: &str = "samples/table-001.hwp";
 

--- a/tests/issue_4916_note_vpos_roundtrip.rs
+++ b/tests/issue_4916_note_vpos_roundtrip.rs
@@ -1,0 +1,70 @@
+//! [Issue #4916/#4660/#3531 계열] HWP5→HWPX 왕복에서 각주·미주 subList lineseg
+//! 의 저장 vpos=0 이 재파싱 보정(task 1692 `normalize_hwpx_note_line_vpos`)으로
+//! 합성값으로 바뀌어 `--verify` 가 vertpos 차이를 내던 계약을 고정한다.
+//!
+//! 수정: rhwp 자기 산출 HWPX(HWP5-origin 마커, #1770)는 그 보정을 건너뛴다 —
+//! HWP5 원본 저장값의 왕복 보존이 마커 계약이다. 실물 한컴 HWPX 의 보정은
+//! 종전 유지(tests/issue_1692.rs 가 그 축을 잡는다).
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+use rhwp::model::paragraph::Paragraph;
+use rhwp::parse_document;
+
+const SAMPLE: &str = "samples/3-09월_교육_통합_2022.hwp";
+
+fn note_vpos_signature(paragraphs: &[Paragraph], out: &mut Vec<Vec<i32>>) {
+    for p in paragraphs {
+        for c in &p.controls {
+            match c {
+                Control::Footnote(n) => {
+                    for np in &n.paragraphs {
+                        out.push(np.line_segs.iter().map(|s| s.vertical_pos).collect());
+                    }
+                    note_vpos_signature(&n.paragraphs, out);
+                }
+                Control::Endnote(n) => {
+                    for np in &n.paragraphs {
+                        out.push(np.line_segs.iter().map(|s| s.vertical_pos).collect());
+                    }
+                    note_vpos_signature(&n.paragraphs, out);
+                }
+                Control::Table(t) => {
+                    for cell in &t.cells {
+                        note_vpos_signature(&cell.paragraphs, out);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+#[test]
+fn issue4916_note_sublist_vpos_survives_hwpx_roundtrip() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"));
+    let original = parse_document(&bytes).expect("parse hwp");
+
+    let mut orig_sig = Vec::new();
+    for sec in &original.sections {
+        note_vpos_signature(&sec.paragraphs, &mut orig_sig);
+    }
+    assert!(
+        orig_sig.iter().any(|v| v.len() > 1 && v[1..].contains(&0)),
+        "샘플 전제: 후속 줄 vpos=0 인 노트 subList lineseg 가 있어야 한다"
+    );
+
+    let core = DocumentCore::from_bytes(&bytes).expect("open");
+    let hwpx = core.export_hwpx_native().expect("export hwpx");
+    let roundtripped = parse_document(&hwpx).expect("reparse hwpx");
+
+    let mut rt_sig = Vec::new();
+    for sec in &roundtripped.sections {
+        note_vpos_signature(&sec.paragraphs, &mut rt_sig);
+    }
+    assert_eq!(
+        orig_sig, rt_sig,
+        "각주·미주 subList lineseg vpos 가 왕복에서 그대로여야 한다 (#4916 계열)"
+    );
+}


### PR DESCRIPTION
## 변경 요약

HWP5→HWPX 왕복에서 각주·미주 subList lineseg 의 저장 `vpos=0` 이 재파싱 시 합성값으로 바뀌어 `--verify` 가 vertpos 차이를 내던 계열(#4916, #4660, #3531 — 그리고 #4882 의 IR 축)을 고칩니다.

### 근인

task 1692(SO-SUEOP 미주 페이지 경계 보정)의 `normalize_hwpx_note_line_vpos` 는 **실물 한컴 HWPX** 의 "미주 내부 후속 줄 vpos=0 아티팩트" 를 파싱 시점에 이전 줄 advance 로 복원합니다. 그런데 이 보정이 **rhwp 자기 산출 HWPX**(HWP5-origin 마커 보유, #1770)에도 발동합니다 — HWP5 원본의 노트 subList 저장 lineseg 는 후속 줄 vpos=0 이 정당한 저장값이라, 보정하면 원본 파싱 IR 과 어긋나 `--verify` 가 깨집니다.

### 수정

HWP5-origin 마커가 있는 HWPX 파싱 동안 그 보정을 건너뜁니다 — 마커 계약("pagination/lineSeg 시멘틱은 HWP5 원본을 따른다")의 연장입니다. 구현은 `parse_hwpx` 가 구역 파싱 구간에 RAII 가드(thread-local, `SectionDepthGuard` 와 동형 패턴)를 세우는 방식입니다. 실물 한컴 HWPX(마커 없음)의 보정은 종전 그대로이고, 그 축의 기존 계약 테스트(`tests/issue_1692.rs` 12건)도 전부 통과합니다.

## 관련 이슈

closes #4916
closes #4660
closes #3531

#4882 는 이 수정으로 `--verify`(IR 차이 5건→0건)는 통과하지만 `--verify-pages`(215→223쪽)가 남아 닫지 않습니다 — 별도 레이아웃 축으로 이슈에 코멘트를 남깁니다.

## 실측

```
rhwp export-hwpx samples/3-09월_교육_통합_2022.hwp rt.hwpx --verify --verify-pages
# 종전: IR 차이 5건(en.p lineseg vertpos expected=0 actual=N)
# 이 PR: 검증 통과(--verify-pages): 23쪽 / 검증 통과(--verify): IR 차이 없음
```

같은 방식으로 `3-11월_실전_통합_2024-구분선위9미주사이8구분선아래7.hwp`(#4660, 21쪽)·`3-09월_교육_통합_2024-구분선아래20.hwp`(#3531, 23쪽) 모두 양 검증 통과.

## 테스트

- [x] `cargo test` 통과 — 신규 `issue4916_note_sublist_vpos_survives_hwpx_roundtrip`(후속 줄 vpos=0 실존 전제 + 왕복 서명 동일) + 기존 `issue_1692` 12건(실물 HWPX 보정 유지) 통과. 전체 nextest 게이트 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] 관련 샘플 실측 — 위 3건
- [ ] 웹(WASM) 렌더링 확인 (해당 없음 — 실물 HWPX 렌더 경로 무변경)
- [ ] rhwp-studio 변경 없음
- [ ] 작업 증빙 — 코드 수정(문서 편집 작업 아님)

## 성능 영향 및 측정 결과

- 예상 영향: 없음
- 재현·측정: 미측정

🤖 Generated with [Claude Code](https://claude.com/claude-code)
