### PR TITLE
fix(hwpx): BinData 순번 축 폴백 — storage id 구멍 문서의 pic 드롭 해소 (#3893, #4049)

### DIFF
--- a/mydocs/orders/20260816.md
+++ b/mydocs/orders/20260816.md
@@ -12,6 +12,18 @@
 - 원 PR별 archive 검토 기록과 누적 보정 기록을 같은 통합 PR의 trailing docs-only commit에 추가했다. 이 문서
   head의 fast-pass와 `MERGEABLE`/`CLEAN` 확인 뒤 #4918을 merge하고 원 PR을 통합 반영 comment와 함께 close한다.
 
+## PR #4970 - HWP5 BinData 순번 충돌 보정 (2026년 8월 17일 후속 기록)
+
+- HWP5 `ImageAttr.bin_data_id`는 storage stream ID가 아니라 DocInfo `BIN_DATA` 레코드 순번이다. 기존 PR의
+  직접 storage ID 우선 폴백은 순번과 storage ID가 같은 숫자로 충돌하는 문서에서 다른 그림을 선택할 수 있어,
+  순번 사상을 우선하고 Link·sparse ID만 직접 조회로 남기는 메인터너 보정 `29b7d8963`을 추가했다.
+- 충돌 순서 `[3, 1, 2]`가 `image3`, `image1`, `image2`로 각각 해소되는 단위 회귀와 원 PR의 #3893 표본
+  2건을 통과했다. 고정 `target/pr-review`의 전체 nextest는 6,386 passed, 38 skipped, 7 slow, 329.093초였고
+  `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`도 통과했다.
+- [PR #4970](https://github.com/edwardkim/rhwp/pull/4970)의 code candidate `29b7d8963`은 GitHub Full CI,
+  Rust CodeQL, Lint, archive 3개와 regular 3개 및 slow shard를 모두 통과했다. 개별
+  [검토 기록](../pr/archives/pr_4970_review.md)을 같은 source branch의 trailing docs-only commit으로 추가한다.
+
 ## PR #4880 - PR 후 local worktree 정리 명시
 
 - collaborator self-merge의 merge 및 후속 처리 승인이 해당 PR만을 위해 만든 clean한 local branch와

--- a/mydocs/pr/archives/pr_4970_review.md
+++ b/mydocs/pr/archives/pr_4970_review.md
@@ -1,0 +1,41 @@
+---
+kind: pr-review
+status: code-ci-complete
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-17
+---
+
+# PR #4970 검토 - HWP5 BinData 순번 충돌 보정
+
+| 항목 | 기록 |
+| --- | --- |
+| 원 PR | [#4970](https://github.com/edwardkim/rhwp/pull/4970) · @planet6897 |
+| 원 source head | `1200c23921c795e202f17f24801a084eaecc61cf` |
+| 보정 code head | `29b7d896339924a7906e10de8e84ccf3a1493797` |
+| 기준선 | `upstream/devel@88b44de37b491a47494d2acac708b7b86a082951` |
+| 처리 경로 | `collaborator_external_pr` 9.3.1 contributor source 직접 보정 |
+| reviewer | @jangster77 |
+
+## 검토 및 메인터너 보정
+
+원 PR은 HWP5 본문의 `bin_data_id`가 1-based `BIN_DATA` 레코드 순번이고 `storage_id`와 별개라는
+핵심 진단을 올바르게 반영했다. 다만 `resolve_bin_id`가 direct storage ID를 먼저 조회하고, 그 키가 없을
+때만 순번 사상을 사용했다. storage ID 배열이 `[3, 1, 2]`처럼 재배열된 문서에서 순번 `1`은 첫 레코드의
+storage `3`을 가리켜야 하지만, 기존 구현은 존재하는 direct key `1`을 먼저 선택해 다른 그림을 참조한다.
+
+메인터너 보정 `29b7d8963`은 모든 실제 BIN_DATA 레코드에 순번→storage 사상을 만들고 이를 직접 조회보다
+우선한다. `storage_id=0` Link와 사상이 없는 sparse ID(차트·수동 구성)는 기존 직접 조회를 유지한다. 충돌
+순서 `[3, 1, 2]`가 `image3`, `image1`, `image2`로 해소되는 회귀 테스트를 추가해 두 축이 우연히 같은
+숫자를 쓰는 경우를 고정했다. contributor의 기존 커밋은 재작성하지 않고 같은 source head 위에만 추가했다.
+
+## 검증
+
+- `cargo test --profile release-test --target-dir target/pr-review --lib hwp5_bin_sequence_precedes_colliding_storage_id -- --nocapture`: 통과
+- `cargo test --profile release-test --target-dir target/pr-review --test issue_3893_bindata_sequence_ref -- --nocapture`: 2 passed
+- `cargo fmt --check`: 통과
+- `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast`: 6,386 passed, 38 skipped, 7 slow, 329.093초
+- `cargo clippy --all-targets -- -D warnings`: 통과
+- GitHub code candidate CI: [Full CI](https://github.com/edwardkim/rhwp/actions/runs/31959203731), [CodeQL](https://github.com/edwardkim/rhwp/actions/runs/31959203598) 통과. Lint, archive 3개, regular 3개, slow shard, Build & Test 및 Rust 분석이 성공했고, 변경 범위 밖 frontend/WASM/Native Skia gate는 정책상 skip됐다.
+- 최신 `upstream/devel` merge simulation과 `git diff --check upstream/devel...HEAD`: 통과
+
+코드 후보 `29b7d8963`은 `MERGEABLE`/`CLEAN`이며 **수용 가능**이다. 이 기록은 해당 후보의 녹색 CI 뒤에 추가하는 review-only trailing commit이다.

--- a/src/serializer/hwpx/context.rs
+++ b/src/serializer/hwpx/context.rs
@@ -102,9 +102,11 @@ pub struct SerializeContext {
     pub style_ids: IdPool<u16>,
     /// `bin_data_id` (IR) → manifest 엔트리 매핑
     pub bin_data_map: HashMap<u16, BinDataEntry>,
-    /// [#3893/#4049] BIN_DATA 레코드 순번(1-based) → storage_id 폴백 사상.
-    /// 직접 키(bin_data_map)에 없는 순번만 담는다 — `resolve_bin_id` 주석 참조.
-    bin_seq_fallback: HashMap<u16, u16>,
+    /// HWP5 BIN_DATA 레코드 순번(1-based) → storage_id 사상.
+    ///
+    /// `ImageAttr.bin_data_id`는 storage stream 이름이 아니라 DocInfo 레코드
+    /// 순번이다. storage_id와 같은 숫자가 있어도 순번 사상이 우선해야 한다.
+    bin_seq_to_storage: HashMap<u16, u16>,
     /// [#3546] OOXML 차트 파트 — Chart/chartN.xml 원형 방출 목록.
     /// 원본 content.hpf 는 Chart 파트를 나열하지 않으므로 manifest·3-way
     /// 단언 대상 밖이다.
@@ -146,7 +148,7 @@ impl Default for SerializeContext {
             numbering_ids: IdPool::default(),
             style_ids: IdPool::default(),
             bin_data_map: HashMap::new(),
-            bin_seq_fallback: HashMap::new(),
+            bin_seq_to_storage: HashMap::new(),
             chart_entries: Vec::new(),
             para_id_counter: 0,
             generated_hyperlink_id: u32::MAX,
@@ -290,16 +292,14 @@ impl SerializeContext {
             );
         }
 
-        // [#3893/#4049] 순번 축 폴백 사상 — 순번(1-based)과 storage_id 가 다르고,
-        // 그 순번이 직접 키로 존재하지 않는 항목만 담는다(직접 참조 불가림 계약).
+        // [#3893/#4049] HWP5 본문 개체의 BIN_DATA 순번 축. `storage_id`와
+        // 우연히 같은 숫자가 있어도 별개 의미이므로, 실제 데이터를 가진 모든
+        // 레코드의 사상을 등록한다. Link(storage_id=0)는 기존 직접 조회 경로를
+        // 유지한다.
         for (i, bd) in doc.doc_info.bin_data_list.iter().enumerate() {
             let seq = (i + 1) as u16;
-            if bd.storage_id != 0
-                && bd.storage_id != seq
-                && !ctx.bin_data_map.contains_key(&seq)
-                && ctx.bin_data_map.contains_key(&bd.storage_id)
-            {
-                ctx.bin_seq_fallback.insert(seq, bd.storage_id);
+            if bd.storage_id != 0 && ctx.bin_data_map.contains_key(&bd.storage_id) {
+                ctx.bin_seq_to_storage.insert(seq, bd.storage_id);
             }
         }
 
@@ -314,21 +314,18 @@ impl SerializeContext {
     }
 
     /// `bin_data_id` → manifest id 조회 (Stage 4의 `<hc:img binaryItemIDRef="...">` 용).
+    ///
+    /// HWP5 본문 개체의 `bin_data_id`는 BIN_DATA 레코드 순번이므로, 등록된
+    /// 순번 사상을 storage ID 직접 조회보다 먼저 적용한다. 사상이 없는 sparse
+    /// ID(차트)와 수동 구성 문서는 기존 직접 조회를 사용한다.
     pub fn resolve_bin_id(&self, bin_data_id: u16) -> Option<&str> {
-        self.bin_data_map
+        self.bin_seq_to_storage
             .get(&bin_data_id)
+            .and_then(|storage| self.bin_data_map.get(storage))
             .map(|e| e.manifest_id.as_str())
             .or_else(|| {
-                // [#3893/#4049] 순번 축 폴백 — HWP5 본문 참조는 BIN_DATA 레코드
-                // 순번(1-based)이고 storage_id(스트림 이름 축)와 별개다. 편집으로
-                // storage id 에 구멍 난 문서(실측: exam_social 1..4,7,8 / pic-crop-01
-                // 단일 3)에서 직접 조회가 빗나가면 순번→storage 사상으로 한 번 더
-                // 푼다. 직접 키가 있는 참조는 절대 가리지 않으므로(직접 조회 우선)
-                // Link 류 기존 동작은 불변이고, 모델 IR 도 손대지 않아 h2h 왕복
-                // 대칭성에 영향이 없다.
-                self.bin_seq_fallback
+                self.bin_data_map
                     .get(&bin_data_id)
-                    .and_then(|storage| self.bin_data_map.get(storage))
                     .map(|e| e.manifest_id.as_str())
             })
     }
@@ -1020,6 +1017,34 @@ mod tests {
         let e1 = &ctx.bin_data_map[&1];
         assert!(e1.is_embedded, "콘텐츠 보유 항목은 isEmbeded=1 유지");
         assert_eq!(e1.href, "BinData/image1.png");
+    }
+
+    #[test]
+    fn hwp5_bin_sequence_precedes_colliding_storage_id() {
+        // HWP5 Picture의 bin_data_id는 storage stream 번호가 아니라 BIN_DATA
+        // 레코드 순번이다. Worldcup 계열처럼 storage id가 재배열된 경우에도
+        // 순번 1은 첫 레코드(storage 3)를 가리켜야 한다.
+        use crate::model::bin_data::{BinData, BinDataContent, BinDataType};
+
+        let mut doc = Document::default();
+        for storage_id in [3u16, 1, 2] {
+            doc.doc_info.bin_data_list.push(BinData {
+                data_type: BinDataType::Embedding,
+                storage_id,
+                extension: Some("png".to_string()),
+                ..Default::default()
+            });
+            doc.bin_data_content.push(BinDataContent {
+                id: storage_id,
+                data: vec![storage_id as u8].into(),
+                extension: "png".to_string(),
+            });
+        }
+
+        let ctx = SerializeContext::collect_from_document(&doc);
+        assert_eq!(ctx.resolve_bin_id(1), Some("image3"));
+        assert_eq!(ctx.resolve_bin_id(2), Some("image1"));
+        assert_eq!(ctx.resolve_bin_id(3), Some("image2"));
     }
 
     #[test]

--- a/src/serializer/hwpx/context.rs
+++ b/src/serializer/hwpx/context.rs
@@ -102,6 +102,9 @@ pub struct SerializeContext {
     pub style_ids: IdPool<u16>,
     /// `bin_data_id` (IR) → manifest 엔트리 매핑
     pub bin_data_map: HashMap<u16, BinDataEntry>,
+    /// [#3893/#4049] BIN_DATA 레코드 순번(1-based) → storage_id 폴백 사상.
+    /// 직접 키(bin_data_map)에 없는 순번만 담는다 — `resolve_bin_id` 주석 참조.
+    bin_seq_fallback: HashMap<u16, u16>,
     /// [#3546] OOXML 차트 파트 — Chart/chartN.xml 원형 방출 목록.
     /// 원본 content.hpf 는 Chart 파트를 나열하지 않으므로 manifest·3-way
     /// 단언 대상 밖이다.
@@ -143,6 +146,7 @@ impl Default for SerializeContext {
             numbering_ids: IdPool::default(),
             style_ids: IdPool::default(),
             bin_data_map: HashMap::new(),
+            bin_seq_fallback: HashMap::new(),
             chart_entries: Vec::new(),
             para_id_counter: 0,
             generated_hyperlink_id: u32::MAX,
@@ -286,6 +290,19 @@ impl SerializeContext {
             );
         }
 
+        // [#3893/#4049] 순번 축 폴백 사상 — 순번(1-based)과 storage_id 가 다르고,
+        // 그 순번이 직접 키로 존재하지 않는 항목만 담는다(직접 참조 불가림 계약).
+        for (i, bd) in doc.doc_info.bin_data_list.iter().enumerate() {
+            let seq = (i + 1) as u16;
+            if bd.storage_id != 0
+                && bd.storage_id != seq
+                && !ctx.bin_data_map.contains_key(&seq)
+                && ctx.bin_data_map.contains_key(&bd.storage_id)
+            {
+                ctx.bin_seq_fallback.insert(seq, bd.storage_id);
+            }
+        }
+
         ctx
     }
 
@@ -301,6 +318,19 @@ impl SerializeContext {
         self.bin_data_map
             .get(&bin_data_id)
             .map(|e| e.manifest_id.as_str())
+            .or_else(|| {
+                // [#3893/#4049] 순번 축 폴백 — HWP5 본문 참조는 BIN_DATA 레코드
+                // 순번(1-based)이고 storage_id(스트림 이름 축)와 별개다. 편집으로
+                // storage id 에 구멍 난 문서(실측: exam_social 1..4,7,8 / pic-crop-01
+                // 단일 3)에서 직접 조회가 빗나가면 순번→storage 사상으로 한 번 더
+                // 푼다. 직접 키가 있는 참조는 절대 가리지 않으므로(직접 조회 우선)
+                // Link 류 기존 동작은 불변이고, 모델 IR 도 손대지 않아 h2h 왕복
+                // 대칭성에 영향이 없다.
+                self.bin_seq_fallback
+                    .get(&bin_data_id)
+                    .and_then(|storage| self.bin_data_map.get(storage))
+                    .map(|e| e.manifest_id.as_str())
+            })
     }
 
     /// 모든 참조가 해소되었는지 단언. 해소되지 않은 ID가 있으면 `SerializeError::XmlError` 반환.

--- a/tests/issue_3893_bindata_sequence_ref.rs
+++ b/tests/issue_3893_bindata_sequence_ref.rs
@@ -1,0 +1,112 @@
+//! [Issue #3893/#4049] HWP5 그림 BinData 참조는 BIN_DATA **레코드 순번**(1-based)
+//! 이고, 스트림 이름을 정하는 storage_id 와는 별개 축이다. 편집으로 storage id 에
+//! 구멍이 난 문서에서 두 축이 어긋나면 rhwp(storage_id 정본 키)가 참조를 못 풀어
+//! HWPX 저장 시 pic 컨트롤이 통째로 드롭됐다("binaryItemIDRef 미등록") — 파스
+//! 말미의 순번→storage_id 재사상으로 닫는다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+use rhwp::parse_document;
+
+fn read_sample(rel: &str) -> Vec<u8> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    std::fs::read(&path).unwrap_or_else(|e| panic!("read {rel}: {e}"))
+}
+
+fn count_pics(doc: &rhwp::model::document::Document) -> usize {
+    fn walk(paragraphs: &[rhwp::model::paragraph::Paragraph], n: &mut usize) {
+        for p in paragraphs {
+            for c in &p.controls {
+                match c {
+                    Control::Picture(_) => *n += 1,
+                    Control::Table(t) => {
+                        for cell in &t.cells {
+                            walk(&cell.paragraphs, n);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    let mut n = 0;
+    for sec in &doc.sections {
+        walk(&sec.paragraphs, &mut n);
+    }
+    n
+}
+
+/// 어긋난 문서의 HWPX 저장이 참조를 전부 해소해야 한다 — 종전에는
+/// "binaryItemIDRef 미등록" 으로 pic 이 드롭됐다. 모델 IR 은 손대지 않고
+/// (h2h 왕복 대칭성 보존) 저장 시점의 순번 축 폴백으로 푼다.
+#[test]
+fn gapped_storage_ids_resolve_at_export() {
+    for rel in ["samples/pic-crop-01.hwp", "samples/exam_social.hwp"] {
+        let bytes = read_sample(rel);
+        let doc = parse_document(&bytes).expect("parse");
+        // 샘플 전제: 순번↔storage 가 실제로 어긋나 있어야 한다.
+        let storage_ids: Vec<u16> = doc
+            .doc_info
+            .bin_data_list
+            .iter()
+            .map(|b| b.storage_id)
+            .collect();
+        assert!(
+            storage_ids
+                .iter()
+                .enumerate()
+                .any(|(i, &sid)| sid as usize != i + 1),
+            "{rel}: 샘플 전제 — storage id 구멍"
+        );
+
+        let core = DocumentCore::from_bytes(&bytes).expect("open");
+        let hwpx = core.export_hwpx_native().expect("export");
+        // 저장본의 모든 binaryItemIDRef 가 manifest 항목으로 해소돼야 한다.
+        let mut zip = zip::ZipArchive::new(std::io::Cursor::new(&hwpx)).expect("zip");
+        let mut hpf = String::new();
+        {
+            use std::io::Read;
+            zip.by_name("Contents/content.hpf")
+                .expect("hpf")
+                .read_to_string(&mut hpf)
+                .expect("read");
+        }
+        let names: Vec<String> = zip.file_names().map(str::to_string).collect();
+        for name in names.iter().filter(|n| n.starts_with("Contents/section")) {
+            use std::io::Read;
+            let mut xml = String::new();
+            zip.by_name(name).unwrap().read_to_string(&mut xml).unwrap();
+            for m in xml.split("binaryItemIDRef=\"").skip(1) {
+                let idref = m.split('"').next().unwrap_or("");
+                assert!(
+                    !idref.is_empty(),
+                    "{rel}: 빈 binaryItemIDRef — 참조 미해소 (#3893)"
+                );
+                assert!(
+                    hpf.contains(&format!("id=\"{idref}\"")),
+                    "{rel}: 본문 참조 {idref} 가 manifest 에 없어야 할 이유가 없다"
+                );
+            }
+        }
+    }
+}
+
+/// HWPX 왕복에서 pic 컨트롤이 드롭되지 않아야 한다 (#3893/#4049 의 실증상).
+#[test]
+fn pics_survive_hwpx_roundtrip() {
+    for rel in ["samples/pic-crop-01.hwp", "samples/exam_social.hwp"] {
+        let bytes = read_sample(rel);
+        let original = parse_document(&bytes).expect("parse");
+        let before = count_pics(&original);
+        assert!(before > 0, "{rel}: 샘플 전제 — pic 존재");
+
+        let core = DocumentCore::from_bytes(&bytes).expect("open");
+        let hwpx = core.export_hwpx_native().expect("export");
+        let roundtripped = parse_document(&hwpx).expect("reparse");
+        assert_eq!(
+            count_pics(&roundtripped),
+            before,
+            "{rel}: pic 컨트롤이 왕복에서 드롭되면 안 된다 (#3893/#4049)"
+        );
+    }
+}


### PR DESCRIPTION
## 변경 요약

HWP→HWPX 왕복에서 그림 컨트롤이 통째로 드롭되던(`Picture 직렬화 실패: binaryItemIDRef 미등록`) 계열(#3893, #4049)을 고칩니다.

### 근인 — BinData 참조의 두 축이 섞여 있었습니다

실측(두 재현체 프로브)으로 확정했습니다:

| 문서 | BIN_DATA 레코드(storage_id) | pic 참조 |
|---|---|---|
| pic-crop-01.hwp | [3] (1건) | 1, 1 |
| exam_social.hwp | [1,2,3,4,7,8] (6건) | …, 5, 6 |

HWP5 본문(SHAPE_PICTURE·OLE payload)의 BinData 참조는 **BIN_DATA 레코드 순번**(1-based)이고, `BinData/BIN{...}` 스트림 이름을 정하는 storage_id 와는 별개 축입니다. 대부분의 문서는 두 축이 일치하지만, 편집으로 storage id 에 구멍이 난 문서에서는 어긋납니다 — rhwp 는 `BinDataContent.id = storage_id` 를 정본 키로 쓰므로 참조 해소가 실패해 HWPX 저장 시 pic 이 드롭되고(IR controls 차이), 렌더에서도 해당 이미지가 소실됐습니다.

### 수정 — 모델 불변, 저장 시점 폴백

HWPX `SerializeContext` 에 순번(1-based)→storage_id 폴백 사상을 두고, `resolve_bin_id` 가 **직접 조회 실패 시에만** 그 사상으로 한 번 더 풉니다.

- 모델 IR 은 손대지 않습니다 — 파스 시점 전역 재사상안은 h2h 자기 왕복 대칭성(직렬화기가 역사상 없이 모델 값을 그대로 씀)을 깨서 `ir_field_sweep` 래칫과 Link 참조 테스트(issue_1142/1143)가 잡아냈고, 철회했습니다. 저장 시점 폴백은 그 세 게이트를 전부 통과합니다.
- 직접 키가 있는 참조는 절대 가리지 않으므로(직접 조회 우선) Link 류·정상 문서의 기존 동작은 불변입니다.
- OLE 참조(`write_ole` 의 bidref)도 같은 `resolve_bin_id` 를 쓰므로 함께 풀립니다.

## 관련 이슈

closes #3893
closes #4049

## 실측

```
rhwp export-hwpx samples/pic-crop-01.hwp rt.hwpx --verify --verify-pages
rhwp export-hwpx samples/exam_social.hwp rt.hwpx --verify --verify-pages
# 종전: Picture 직렬화 실패 경고 2건씩 + IR controls 차이 2건씩 (exit 3)
# 이 PR: 두 샘플 모두 양 검증 통과 (IR 차이 없음)
```

## 테스트

- [x] `cargo test` 통과 — 신규 2건(`issue_3893_bindata_sequence_ref`): 어긋난 문서의 저장본 전 참조가 manifest 로 해소(빈 ref 0) / 왕복에서 pic 컨트롤 수 보존. 전체 nextest 게이트 통과(ir_field_sweep 래칫·issue_1142/1143 포함)
- [x] `cargo clippy -- -D warnings` 통과
- [x] 관련 샘플 실측 — 위 2건
- [ ] 웹(WASM) 렌더링 확인 (해당 없음 — 그림 데이터 해소가 좋아지는 방향)
- [ ] rhwp-studio 변경 없음
- [ ] 작업 증빙 — 코드 수정(문서 편집 작업 아님)

## 성능 영향 및 측정 결과

- 예상 영향: 없음 (무구멍 문서는 storage_id 배열 항등 검사 1회로 종료)
- 재현·측정: 미측정

## 참고 — PR #4959 와의 표본 상호작용

이 수정은 `pic-crop-01.hwp` 의 IR 차이를 정상화하므로, #4959 가 `tests/issue_3915` 의 IR-실패 표본으로 그 문서를 쓰지 않도록 이미 조정돼 있습니다(hwp3-sample10 사용) — 두 PR 은 머지 순서와 무관하게 정합합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
