### PR TITLE
fix(search): 중첩 표 안의 텍스트를 grep이 찾게 한다 (#2792)

### DIFF
--- a/src/document_core/queries/grep.rs
+++ b/src/document_core/queries/grep.rs
@@ -54,7 +54,24 @@ pub struct GrepMatch {
     /// `--context N` 을 준 경우 매치가 속한 문단 **뒤** N개 문단의 텍스트.
     #[serde(rename = "contextAfter", skip_serializing_if = "Option::is_none")]
     pub context_after: Option<Vec<String>>,
+    /// [#2792] 표 안의 표에서 나온 매치면 그 중첩 깊이(바깥 표 = 0). 0 이면 생략되므로
+    /// 중첩이 없는 문서의 봉투는 종전과 바이트까지 같다.
+    ///
+    /// 0 이 아니면 **`cell` 은 매치의 정확한 위치가 아니라 그것을 담은 바깥 셀 문단**을
+    /// 가리킨다 — 중첩 경로를 그대로 싣는 정밀 주소는 별도 축(#2792 §경로 기반 선택)이다.
+    #[serde(rename = "nestedDepth", skip_serializing_if = "is_zero")]
+    pub nested_depth: usize,
 }
+
+/// 중첩이 없는 흔한 경우에 필드를 아예 빼기 위한 serde 술어.
+fn is_zero(value: &usize) -> bool {
+    *value == 0
+}
+
+/// 병적으로 깊은 중첩(손상/악의적 문서)에서 순회가 스택을 태우지 않게 하는 상한.
+/// `table_extract::MAX_NEST_DEPTH` / `explain` / `hidden_text` / `chart_extract` /
+/// `clipboard` 와 같은 값 — 깊이 0..=7 만 방문한다.
+const MAX_NEST_DEPTH: usize = 8;
 
 /// 표 셀 매치의 좌표.
 #[derive(Debug, Clone, Serialize)]
@@ -204,8 +221,9 @@ impl DocumentCore {
 
     /// 문서를 검색해 주소가 붙은 매치 목록을 돌려준다.
     ///
-    /// 본문·표 셀·글상자를 순회한다(`search_all` 과 같은 범위). `limit` 이 `Some` 이면
-    /// 그 개수에서 멈춘다 — 대형 문서에서 컨텍스트를 아끼기 위한 상한이다.
+    /// 본문·표 셀·글상자·중첩 표를 순회한다. 치환 엔진(`search_all` /
+    /// `replace_all_native`)은 바깥 셀까지만 본다 — 이 함수만 중첩 표를 내려간다.
+    /// `limit` 이 `Some` 이면 그 개수에서 멈춘다.
     ///
     /// 기존 계약과 완전히 동일한 얇은 래퍼다(`context: None`) — `grep_with_context` 로
     /// 위임한다.
@@ -256,6 +274,7 @@ impl DocumentCore {
                         equation,
                         context_before,
                         context_after,
+                        nested_depth: 0,
                     };
                 // 본문 문단 기준 컨텍스트 — 구역 문단 목록 안에서 앞뒤를 센다.
                 let (body_ctx_before, body_ctx_after) = match context {
@@ -305,69 +324,92 @@ impl DocumentCore {
                 for (ctrl_idx, ctrl) in para.controls.iter().enumerate() {
                     match ctrl {
                         Control::Table(table) => {
-                            for (cell_idx, cell) in table.cells.iter().enumerate() {
-                                for (cp_idx, cp) in cell.paragraphs.iter().enumerate() {
-                                    // 셀 안의 매치는 구역 문단이 아니라 그 셀의 문단
-                                    // 목록 안에서 앞뒤를 센다.
-                                    let (cell_ctx_before, cell_ctx_after) = match context {
-                                        Some(n) => {
-                                            let (b, a) =
-                                                context_window(&cell.paragraphs, cp_idx, n);
-                                            (Some(b), Some(a))
-                                        }
-                                        None => (None, None),
-                                    };
-                                    for offset in super::search_query::find_matches(
-                                        &cp.text,
-                                        query,
-                                        case_sensitive,
-                                    ) {
-                                        out.push(make_at(
-                                            cell_page(ctrl_idx, cell.row as usize),
+                            // [#2792] 셀 안의 표까지 내려간다. 종전에는 셀 문단 컨트롤
+                            // 순회가 Equation 만 봐서 중첩 표가 조용히 버려졌다.
+                            let mut queue = std::collections::VecDeque::new();
+                            queue.push_back((table, 0usize, None::<CellRef>));
+                            while let Some((current, depth, host)) = queue.pop_front() {
+                                if depth >= MAX_NEST_DEPTH {
+                                    continue;
+                                }
+                                for (cell_idx, cell) in current.cells.iter().enumerate() {
+                                    for (cp_idx, cp) in cell.paragraphs.iter().enumerate() {
+                                        let (cell_ctx_before, cell_ctx_after) = match context {
+                                            Some(n) => {
+                                                let (b, a) =
+                                                    context_window(&cell.paragraphs, cp_idx, n);
+                                                (Some(b), Some(a))
+                                            }
+                                            None => (None, None),
+                                        };
+                                        let addr = host.clone().unwrap_or(CellRef {
+                                            control: ctrl_idx,
+                                            cell: cell_idx,
+                                            paragraph: cp_idx,
+                                        });
+                                        let match_page = if depth == 0 {
+                                            cell_page(ctrl_idx, cell.row as usize)
+                                        } else {
+                                            None
+                                        };
+                                        for offset in super::search_query::find_matches(
                                             &cp.text,
-                                            offset,
-                                            Some(CellRef {
-                                                control: ctrl_idx,
-                                                cell: cell_idx,
-                                                paragraph: cp_idx,
-                                            }),
-                                            None,
-                                            None,
-                                            cell_ctx_before.clone(),
-                                            cell_ctx_after.clone(),
-                                        ));
-                                        if limit.is_some_and(|n| out.len() >= n) {
-                                            return out;
+                                            query,
+                                            case_sensitive,
+                                        ) {
+                                            let mut hit = make_at(
+                                                match_page,
+                                                &cp.text,
+                                                offset,
+                                                Some(addr.clone()),
+                                                None,
+                                                None,
+                                                cell_ctx_before.clone(),
+                                                cell_ctx_after.clone(),
+                                            );
+                                            hit.nested_depth = depth;
+                                            out.push(hit);
+                                            if limit.is_some_and(|n| out.len() >= n) {
+                                                return out;
+                                            }
                                         }
-                                    }
-                                    for (equation_idx, nested_control) in
-                                        cp.controls.iter().enumerate()
-                                    {
-                                        if let Control::Equation(equation) = nested_control {
-                                            for offset in super::search_query::find_matches(
-                                                &equation.script,
-                                                query,
-                                                case_sensitive,
-                                            ) {
-                                                out.push(make_at(
-                                                    cell_page(ctrl_idx, cell.row as usize),
-                                                    &equation.script,
-                                                    offset,
-                                                    Some(CellRef {
-                                                        control: ctrl_idx,
-                                                        cell: cell_idx,
-                                                        paragraph: cp_idx,
-                                                    }),
-                                                    None,
-                                                    Some(EquationRef {
-                                                        control: equation_idx,
-                                                    }),
-                                                    cell_ctx_before.clone(),
-                                                    cell_ctx_after.clone(),
-                                                ));
-                                                if limit.is_some_and(|n| out.len() >= n) {
-                                                    return out;
+                                        for (equation_idx, nested_control) in
+                                            cp.controls.iter().enumerate()
+                                        {
+                                            match nested_control {
+                                                Control::Equation(equation) => {
+                                                    for offset in super::search_query::find_matches(
+                                                        &equation.script,
+                                                        query,
+                                                        case_sensitive,
+                                                    ) {
+                                                        let mut hit = make_at(
+                                                            match_page,
+                                                            &equation.script,
+                                                            offset,
+                                                            Some(addr.clone()),
+                                                            None,
+                                                            Some(EquationRef {
+                                                                control: equation_idx,
+                                                            }),
+                                                            cell_ctx_before.clone(),
+                                                            cell_ctx_after.clone(),
+                                                        );
+                                                        hit.nested_depth = depth;
+                                                        out.push(hit);
+                                                        if limit.is_some_and(|n| out.len() >= n) {
+                                                            return out;
+                                                        }
+                                                    }
                                                 }
+                                                Control::Table(inner) => {
+                                                    queue.push_back((
+                                                        inner,
+                                                        depth + 1,
+                                                        Some(addr.clone()),
+                                                    ));
+                                                }
+                                                _ => {}
                                             }
                                         }
                                     }

--- a/tests/cases/issue_2792_search_nested_tables.rs
+++ b/tests/cases/issue_2792_search_nested_tables.rs
@@ -1,0 +1,219 @@
+//! [#2792] 표 안의 표(중첩 표) 텍스트가 검색에 잡히지 않던 결함.
+//!
+//! `grep` 은 본문 문단의 컨트롤에서 `Control::Table` 로 들어가 셀 문단까지 훑었지만,
+//! **셀 문단 안의 컨트롤**을 훑는 자리는 `Control::Equation` 만 봤다. 그래서 셀 안에
+//! 들어 있는 표(중첩 표)는 어느 갈래에도 걸리지 않고 조용히 버려졌고, 그 안의 텍스트는
+//! 순회 대상이 된 적이 없었다.
+//!
+//! 실패 모습이 나쁜 이유는 **오류가 아니기 때문**이다. `search` 는 exit 0 ·
+//! `matchCount: 0` 으로 성공 응답하므로 호출자는 "문서에 그 말이 없다"로 읽는다.
+//! 규제심사·검토보고 양식처럼 바깥 표 한 칸 안에 본문 표를 넣는 구조에서는 본문
+//! 상당 부분이 통째로 검색에서 빠진다.
+//!
+//! 이 파일이 못 박는 계약.
+//!
+//! 1. 중첩 표 안 텍스트가 **찾힌다** — 2단계 아래까지.
+//! 2. `nestedDepth` 가 실제 깊이를 알린다. 0(=중첩 아님)이면 **필드 자체가 없다** —
+//!    중첩 없는 문서의 봉투는 종전과 바이트까지 같다.
+//! 3. 중첩 매치의 `cell` 은 **그것을 담은 바깥 셀 문단**을 가리킨다(정확 위치가 아니다).
+//!    깊이 1·2 매치는 같은 바깥 `cell.paragraph` 를 쓴다.
+//! 4. 중첩 매치는 `page` 를 **싣지 않는다** — 바깥 행으로 계산한 쪽은 틀리기 때문이다.
+//! 5. 본문·바깥 셀 매치의 동작은 종전 그대로다(순서 포함).
+//! 6. `replace_all_native` 는 중첩 전용 토큰을 바꾸지 않는다 — 이 사이클은
+//!    `DocumentCore::grep` / CLI `search` / MCP search 만 가르친다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::document_core::DocumentCore;
+
+/// 3중 구조: 본문 → 바깥 표 셀 → 중첩 표 셀 → 더 깊은 표 셀.
+/// 단어를 층마다 다르게 두어야 "어느 층까지 닿았는가"가 구별된다.
+const NESTED_HML: &str = r#"<HWPML Version="2.91"><HEAD/><BODY><SECTION>
+  <P><TEXT><CHAR>본문전용단어</CHAR></TEXT></P>
+  <P><TEXT><TABLE RowCount="1" ColCount="1">
+    <SHAPEOBJECT><SIZE Width="8000" Height="4000"/></SHAPEOBJECT>
+    <ROW><CELL ColAddr="0" RowAddr="0" Width="8000" Height="4000"><PARALIST>
+      <P><TEXT><CHAR>바깥셀단어</CHAR></TEXT></P>
+      <P><TEXT><TABLE RowCount="1" ColCount="1">
+        <SHAPEOBJECT><SIZE Width="6000" Height="3000"/></SHAPEOBJECT>
+        <ROW><CELL ColAddr="0" RowAddr="0" Width="6000" Height="3000"><PARALIST>
+          <P><TEXT><CHAR>중첩셀단어</CHAR></TEXT></P>
+          <P><TEXT><TABLE RowCount="1" ColCount="1">
+            <SHAPEOBJECT><SIZE Width="4000" Height="2000"/></SHAPEOBJECT>
+            <ROW><CELL ColAddr="0" RowAddr="0" Width="4000" Height="2000"><PARALIST>
+              <P><TEXT><CHAR>더깊은셀단어</CHAR></TEXT></P>
+            </PARALIST></CELL></ROW>
+          </TABLE></TEXT></P>
+        </PARALIST></CELL></ROW>
+      </TABLE></TEXT></P>
+    </PARALIST></CELL></ROW>
+  </TABLE></TEXT></P>
+</SECTION></BODY><TAIL/></HWPML>"#;
+
+/// 중첩이 전혀 없는 대조군 — 봉투 무변경을 확인할 기준.
+const FLAT_HML: &str = r#"<HWPML Version="2.91"><HEAD/><BODY><SECTION>
+  <P><TEXT><CHAR>본문전용단어</CHAR></TEXT></P>
+  <P><TEXT><TABLE RowCount="1" ColCount="1">
+    <SHAPEOBJECT><SIZE Width="4000" Height="1200"/></SHAPEOBJECT>
+    <ROW><CELL ColAddr="0" RowAddr="0" Width="4000" Height="1200"><PARALIST>
+      <P><TEXT><CHAR>바깥셀단어</CHAR></TEXT></P>
+    </PARALIST></CELL></ROW>
+  </TABLE></TEXT></P>
+</SECTION></BODY><TAIL/></HWPML>"#;
+
+fn nested() -> DocumentCore {
+    DocumentCore::from_bytes(NESTED_HML.as_bytes()).expect("중첩 표 픽스처가 열려야 한다")
+}
+
+fn flat() -> DocumentCore {
+    DocumentCore::from_bytes(FLAT_HML.as_bytes()).expect("평면 표 픽스처가 열려야 한다")
+}
+
+#[test]
+fn nested_table_text_is_found() {
+    // 이 계약의 핵심. 종전에는 아래 두 단어가 어떤 질의로도 잡히지 않았다.
+    let doc = nested();
+    for word in ["본문전용단어", "바깥셀단어", "중첩셀단어", "더깊은셀단어"] {
+        let hits = doc.grep(word, true, None);
+        assert_eq!(
+            hits.len(),
+            1,
+            "{word} 를 찾지 못했습니다 (중첩 표 순회 누락)"
+        );
+        assert!(hits[0].text.contains(word), "{:?}", hits[0]);
+    }
+}
+
+#[test]
+fn nested_depth_reports_actual_depth() {
+    let doc = nested();
+    // 본문 매치는 표 밖이라 깊이 0 이고 셀 좌표도 없다.
+    let body = doc.grep("본문전용단어", true, None);
+    assert_eq!(body[0].nested_depth, 0, "{:?}", body[0]);
+    assert!(body[0].cell.is_none(), "{:?}", body[0]);
+
+    // 바깥 표의 셀 = 중첩이 아니다(깊이 0).
+    let outer = doc.grep("바깥셀단어", true, None);
+    assert_eq!(outer[0].nested_depth, 0, "{:?}", outer[0]);
+    assert!(outer[0].cell.is_some(), "{:?}", outer[0]);
+
+    // 한 단계·두 단계 아래.
+    assert_eq!(doc.grep("중첩셀단어", true, None)[0].nested_depth, 1);
+    assert_eq!(doc.grep("더깊은셀단어", true, None)[0].nested_depth, 2);
+}
+
+#[test]
+fn nested_match_addresses_the_containing_outer_cell() {
+    // 중첩 안의 (cell, paragraph) 를 바깥 좌표계인 척 실으면 소비자가 엉뚱한 칸을
+    // 고친다. 주소는 **담은 바깥 셀 문단**이어야 하고, 그 사실을 nestedDepth 가 알린다.
+    let doc = nested();
+    let deep = doc.grep("더깊은셀단어", true, None);
+    let mid = doc.grep("중첩셀단어", true, None);
+    let deep_cell = deep[0].cell.as_ref().expect("셀 좌표");
+    let mid_cell = mid[0].cell.as_ref().expect("셀 좌표");
+
+    // 두 중첩 매치는 같은 바깥 셀 문단이 담고 있다 — 바깥 표는 셀 하나뿐이고
+    // 중첩 표는 그 셀의 두 번째 문단에 들어 있다.
+    assert_eq!(deep_cell.control, mid_cell.control, "{deep:?} {mid:?}");
+    assert_eq!(deep_cell.cell, mid_cell.cell, "{deep:?} {mid:?}");
+    assert_eq!(
+        mid_cell.paragraph, 1,
+        "중첩 표를 담은 바깥 셀 문단을 가리켜야 합니다: {mid:?}"
+    );
+    assert_eq!(
+        deep_cell.paragraph, mid_cell.paragraph,
+        "깊이 2 매치도 같은 바깥 셀 문단이어야 합니다: {deep:?} {mid:?}"
+    );
+    assert_eq!(
+        deep_cell.paragraph, 1,
+        "깊이 2 매치의 cell.paragraph 는 바깥 호스트 1 이어야 합니다: {deep:?}"
+    );
+}
+
+#[test]
+fn nested_match_omits_page_rather_than_reporting_a_wrong_one() {
+    // 바깥 셀의 row 로 쪽을 계산하면 1×1 바깥 표가 여러 쪽에 걸칠 때 행 범위의 첫 쪽이
+    // 나온다 — 뒷쪽 텍스트가 앞쪽으로 보고된다. 없는 것보다 틀린 주소가 나쁘다.
+    let doc = nested();
+    for word in ["중첩셀단어", "더깊은셀단어"] {
+        let hits = doc.grep(word, true, None);
+        assert!(
+            hits[0].page.is_none(),
+            "중첩 매치에 쪽이 실렸습니다 (바깥 행 기준이라 틀릴 수 있음): {:?}",
+            hits[0]
+        );
+    }
+}
+
+#[test]
+fn flat_document_envelope_is_unchanged() {
+    // 추가 전용이어야 한다 — 중첩이 없으면 nestedDepth 는 직렬화에서 아예 빠진다.
+    let doc = flat();
+    for word in ["본문전용단어", "바깥셀단어"] {
+        let hits = doc.grep(word, true, None);
+        assert_eq!(hits.len(), 1, "{word}");
+        assert_eq!(hits[0].nested_depth, 0);
+        let json = serde_json::to_string(&hits[0]).expect("직렬화");
+        assert!(
+            !json.contains("nestedDepth"),
+            "중첩 없는 매치에 nestedDepth 가 실렸습니다: {json}"
+        );
+    }
+}
+
+#[test]
+fn nested_match_serializes_depth_and_no_page() {
+    let doc = nested();
+    let hits = doc.grep("더깊은셀단어", true, None);
+    let json = serde_json::to_string(&hits[0]).expect("직렬화");
+    assert!(json.contains("\"nestedDepth\":2"), "{json}");
+    assert!(
+        !json.contains("\"page\""),
+        "중첩 매치에 page 가 실렸습니다: {json}"
+    );
+    assert!(json.contains("\"cell\""), "{json}");
+}
+
+#[test]
+fn body_and_outer_cell_matches_keep_their_order() {
+    // 중첩분은 바깥 매치 **뒤에** 붙는다. 앞에 끼어들면 기존 소비자의 "첫 매치"가
+    // 조용히 다른 것을 가리키게 된다.
+    let doc = nested();
+    // 세 층 모두에 있는 공통 문자열로 한 번에 훑는다.
+    let hits = doc.grep("단어", true, None);
+    let depths: Vec<usize> = hits.iter().map(|h| h.nested_depth).collect();
+    assert!(
+        depths.windows(2).all(|w| w[0] <= w[1]),
+        "깊이가 오름차순이 아닙니다(중첩분이 앞에 끼어듦): {depths:?}"
+    );
+    assert_eq!(depths.first().copied(), Some(0), "{depths:?}");
+    assert_eq!(depths.last().copied(), Some(2), "{depths:?}");
+}
+
+#[test]
+fn limit_still_stops_early_with_nesting() {
+    // 상한은 중첩 순회에서도 그대로 걸려야 한다 — 안 걸리면 대형 문서에서 상한이
+    // 무력화된다.
+    let doc = nested();
+    let hits = doc.grep("단어", true, Some(2));
+    assert_eq!(hits.len(), 2, "{hits:?}");
+}
+
+#[test]
+fn replace_all_native_is_noop_on_nested_only_token() {
+    // grep 은 중첩 표까지 찾지만, 치환 엔진(`replace_all_native` / `search_all`)은
+    // 바깥 셀 문단만 본다. 이 사이클은 검색만 가르친다 — 치환은 아직 구멍이다.
+    let mut doc = nested();
+    assert_eq!(doc.grep("더깊은셀단어", true, None).len(), 1);
+    let result = doc
+        .replace_all_native("더깊은셀단어", "치환되면안됨", true)
+        .expect("replace_all_native 는 실패하지 않아야 한다");
+    let v: serde_json::Value =
+        serde_json::from_str(&result).unwrap_or_else(|e| panic!("{e}: {result}"));
+    assert_eq!(v["ok"], true, "{result}");
+    assert_eq!(
+        v["count"], 0,
+        "중첩 전용 토큰을 치환하면 안 됩니다: {result}"
+    );
+    assert_eq!(doc.grep("더깊은셀단어", true, None).len(), 1);
+    assert!(doc.grep("치환되면안됨", true, None).is_empty());
+}

--- a/tests/generated/regression_suite_013.rs
+++ b/tests/generated/regression_suite_013.rs
@@ -5,6 +5,9 @@
 #[path = "../boundary_integrity_contract.rs"]
 mod boundary_integrity_contract;
 
+#[path = "../cases/issue_2792_search_nested_tables.rs"]
+mod issue_2792_search_nested_tables;
+
 #[path = "../ir_diff_json_contract.rs"]
 mod ir_diff_json_contract;
 

--- a/tests/suites/manifest.json
+++ b/tests/suites/manifest.json
@@ -315,6 +315,7 @@
     ],
     "regression_suite_013": [
       "tests/boundary_integrity_contract.rs",
+      "tests/cases/issue_2792_search_nested_tables.rs",
       "tests/ir_diff_json_contract.rs",
       "tests/issue_1418_textbox_table_overlap.rs",
       "tests/issue_1686.rs",

--- a/tests/suites/unit-test-tiers.json
+++ b/tests/suites/unit-test-tiers.json
@@ -1296,7 +1296,7 @@
       "id": "src/document_core/queries/grep.rs::tests#1",
       "file": "src/document_core/queries/grep.rs",
       "sourcePath": "src/document_core/queries/grep.rs",
-      "line": 474,
+      "line": 516,
       "module": "tests",
       "testAttributes": 1,
       "tier": "white_box",


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

`search`/`grep` 이 바깥 표 셀 안의 **중첩 표** 본문을 조용히 버렸습니다. 셀 문단 컨트롤 순회가 `Equation` 만 보고 `Table` 은 어느 갈래에도 걸리지 않았습니다. 실패가 exit 0 · `matchCount: 0` 이라 호출자는 "문서에 그 말이 없다"로 읽습니다.

이 PR은 `DocumentCore::grep` / CLI `search` / MCP search 만 가르칩니다. 깊이 상한 8(`table_extract::MAX_NEST_DEPTH` / `explain` / `hidden_text` / `chart_extract` / `clipboard` 와 같은 값)으로 FIFO 순회하고, 깊이 0..=7 만 방문합니다. 중첩 매치는 `nestedDepth` 로 깊이를 알리고, `cell` 은 바깥 호스트 셀 문단을 가리키며, 잘못된 쪽 번호를 피하려고 `page` 는 생략합니다. 0 이면 필드를 생략해 평면 표 봉투는 종전과 바이트까지 같습니다.

치환(`replace_all_native` / `search_query`)·경로 코어는 건드리지 않습니다. 중첩 전용 토큰에 대한 `replace_all_native` 는 여전히 count 0 / no-op 입니다.

## 관련 이슈

Refs #2792

이 PR은 #2792 를 **닫지 않습니다**. path cores + replace + `search_query` 는 잔여입니다.

## 테스트

- [x] `cargo test` 통과 — `issue_2792_search_nested_tables` 9/9, lib `grep` 1/1 (`--profile release-test`)
- [x] `cargo clippy --all-targets -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 (검색 전용, 렌더 변경 없음)
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오(`rhwp-studio/e2e/…`) 또는 편집 커맨드 리뷰 체크리스트(`mydocs/manual/edit_command_review_checklist.md`) 통과 · 링크:
- [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부 — `rhwp replay --capsule` 영수증 캡슐 또는 관련 `--json` 봉투 원문 ([AGENTS.md 작업 증빙 절](../AGENTS.md#작업-증빙--에이전트-기본-경로-권장))
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시: [capability 카탈로그](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/agent_capability_registry.md)의 등록·검증 규칙을 반영

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 — 읽기 전용 조회가 표 중첩을 최대 8단까지 추가로 순회
- 재현·측정: 미측정. 공개 픽스처는 테스트 HML 3중 표. 악의적 깊은 중첩은 상한 8에서 멈춤

## 스크린샷

해당 없음 (검색 조회 전용, 시각 변경 없음)