### PR TITLE
ci: Nextest archive 디스크 정리 전 사용량 측정

### DIFF
--- a/.github/workflows/build-nextest-archives.yml
+++ b/.github/workflows/build-nextest-archives.yml
@@ -48,16 +48,20 @@ jobs:
           echo 'Disk space before cleanup:'
           df -h /
           df -B1 --output=source,size,used,avail,pcent,target /
-          for path in /usr/local/lib/android /usr/share/dotnet; do
-            if [[ -e "${path}" ]]; then
-              sudo du -sh "${path}"
-            else
-              echo "${path}: absent"
-            fi
-          done
-
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/share/dotnet
+          available_gb=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
+          if (( available_gb < 30 )); then
+            echo "Low disk space: ${available_gb}GB available; inspecting and removing unused toolchains."
+            for path in /usr/local/lib/android /usr/share/dotnet; do
+              if [[ -e "${path}" ]]; then
+                sudo du -sh "${path}"
+              else
+                echo "${path}: absent"
+              fi
+            done
+            sudo rm -rf /usr/local/lib/android /usr/share/dotnet
+          else
+            echo "Skip cleanup: ${available_gb}GB available"
+          fi
 
           echo 'Disk space after cleanup:'
           df -h /

--- a/.github/workflows/build-nextest-archives.yml
+++ b/.github/workflows/build-nextest-archives.yml
@@ -44,9 +44,24 @@ jobs:
       # 테스트 빌드 시 디스크 한도 초과를 줄인다.
       - name: Free disk space (remove unused pre-installed toolchains)
         run: |
+          set -euo pipefail
+          echo 'Disk space before cleanup:'
+          df -h /
+          df -B1 --output=source,size,used,avail,pcent,target /
+          for path in /usr/local/lib/android /usr/share/dotnet; do
+            if [[ -e "${path}" ]]; then
+              sudo du -sh "${path}"
+            else
+              echo "${path}: absent"
+            fi
+          done
+
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /usr/share/dotnet
-          df -h
+
+          echo 'Disk space after cleanup:'
+          df -h /
+          df -B1 --output=source,size,used,avail,pcent,target /
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)

--- a/.github/workflows/build-nextest-archives.yml
+++ b/.github/workflows/build-nextest-archives.yml
@@ -82,6 +82,13 @@ jobs:
           shared-key: test-archive
           save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/main') }}
 
+      - name: Inspect disk space after Rust build cache
+        run: |
+          set -euo pipefail
+          echo 'Disk space after Rust build cache:'
+          df -h /
+          df -B1 --output=source,size,used,avail,pcent,target /
+
       - name: Summarize test archive policy
         if: ${{ always() }}
         env:

--- a/mydocs/orders/20260817.md
+++ b/mydocs/orders/20260817.md
@@ -81,3 +81,17 @@
   배정 구조를 유지하면서 workspace compile/link 재사용과 조건부 디스크 정리를 검토한다.
 - review·오늘할일 trailing 문서 head의 fast-pass와 `CLEAN` 상태를 확인한 뒤 병합하고 작업 브랜치와
   전용 산출물을 정리한다.
+
+## PR #5182 디스크 여유 공간 조건부 정리
+
+- [PR #5182](https://github.com/edwardkim/rhwp/pull/5182)는 [#5181](https://github.com/edwardkim/rhwp/issues/5181)의
+  작업으로, Nextest archive 전 root 가용 공간을 측정하고 30GB 미만일 때만 Android/.NET 디렉터리를
+  정리하도록 보완했다. 충분한 공간에서는 정리를 건너뛰며, 정리 전·후와 Rust cache 복원 후 `df`를
+  기록한다.
+- code candidate `b6582f6fe`의 로컬 workflow 검증은 unittest 12 passed, actionlint, diff 검사를
+  통과했다. workflow-only 변경이므로 Cargo 전체 회귀 테스트는 생략했다.
+- CI run [32019381731](https://github.com/edwardkim/rhwp/actions/runs/32019381731)과 CodeQL run
+  [32019381393](https://github.com/edwardkim/rhwp/actions/runs/32019381393)은 archive, Native Skia,
+  regular/slow shard, Rust/Python/JavaScript 분석까지 모두 성공했다.
+- 검토 기록은 `mydocs/pr/archives/pr_5182_review.md`에 남겼다. 이 문서와 오늘할 일은 code candidate
+  검증 완료 뒤 같은 PR에 trailing commit으로 추가하며, 최신 head의 CI와 mergeability를 다시 확인한다.

--- a/mydocs/pr/archives/pr_5182_review.md
+++ b/mydocs/pr/archives/pr_5182_review.md
@@ -1,0 +1,90 @@
+---
+kind: pr-review
+status: active
+pr: 5182
+issue: 5181
+author: jangster77
+base: devel
+head: ci/5181-nextest-disk-preflight
+last_verified: 2026-08-17
+---
+
+# PR #5182 자체검토 - Nextest archive 디스크 정리 사전 측정
+
+## PR metadata
+
+| 항목 | 작성 시점 참고값 |
+| --- | --- |
+| PR | [#5182](https://github.com/edwardkim/rhwp/pull/5182) |
+| 관련 issue | [#5181](https://github.com/edwardkim/rhwp/issues/5181) |
+| 작성자 | `jangster77` (collaborator self-review) |
+| base / head | `devel` / `ci/5181-nextest-disk-preflight` |
+| 검증 code candidate SHA | `b6582f6fe8ff4e3a977cc5896d8076b8efc85a29` |
+| merge state | `MERGEABLE` |
+
+workflow 변경 PR의 자체검토이므로 reviewer를 별도로 지정하지 않았다. 문서 trailing commit 이후에는
+최신 head, Actions 결과와 mergeability를 다시 확인한다.
+
+## 변경 범위
+
+- Nextest archive 생성 전 root 파일시스템의 가용 공간을 `df`로 기록한다.
+- 가용 공간이 30GB 미만일 때만 Android와 .NET 사전 설치 디렉터리를 크기 측정 후 제거한다.
+- 가용 공간이 충분하면 정리를 건너뛰어 불필요한 16GB 삭제와 정리 시간을 피한다.
+- Rust build cache 복원 직후에도 root 파일시스템 사용량을 기록한다.
+- archive 생성·shard 분배 방식과 테스트 대상은 변경하지 않았다.
+
+## 로컬 검증
+
+다음 workflow 범위 검증을 완료했다.
+
+- `python3 -m unittest scripts/tests/test_nextest_archive_workflow.py` — 12 passed
+- `actionlint .github/workflows/build-nextest-archives.yml` — 통과
+- `git diff --check` — 통과
+- workflow-only 변경이므로 Cargo 전체 회귀 테스트는 실행하지 않았다.
+
+## 실측 근거
+
+기존 조건 없는 정리 동작을 확인하기 위해 [CI run #32018260377](https://github.com/edwardkim/rhwp/actions/runs/32018260377)을
+확인했다.
+
+- 정리 전 root: 84GB available (145GB 중 61GB 사용)
+- Android: 11GB, .NET: 5.2GB
+- 정리 후 root: 100GB available
+- Rust build cache 복원 후: 98GB available
+- archive build: 4분 47초, archive 기록 2.72초, 성공
+- 생성 archive: 61 files / 49 binaries, 273,369,819 bytes
+
+이 runner에서는 정리 전부터 84GB가 확보되어 있었으므로 16GB 삭제는 필요하지 않았다. 최신 구현은
+30GB 미만인 경우에만 정리하고, 정리 전·후와 cache 복원 후의 사용량을 남긴다.
+
+## GitHub Actions 검증
+
+code candidate `b6582f6fe`의 Full CI 및 CodeQL을 완료했다.
+
+| 검증 | 결과 |
+| --- | --- |
+| CI run | [32019381731](https://github.com/edwardkim/rhwp/actions/runs/32019381731) 성공 |
+| CodeQL run | [32019381393](https://github.com/edwardkim/rhwp/actions/runs/32019381393) 성공 |
+| Build test archive | 성공, 7분 28초 |
+| Native Skia tests | 성공, 7분 43초 |
+| regular shard 1~3 | 모두 성공 |
+| slow shard | 성공, 1분 46초 |
+| Analyze (Rust/Python/JavaScript) | 모두 성공 |
+| Lint, preflight, frontend package gates | 모두 성공 |
+| Frontend unit gates, WASM Build | 정책상 skipping |
+
+## 위험과 후속 조건
+
+- 30GB 임계값은 runner의 root 파일시스템 기준이며, 사전 설치 디렉터리가 없는 runner에서도 오류 없이
+  `absent`를 기록해야 한다.
+- 정리 대상은 현재 archive 빌드에 사용하지 않는 Android와 .NET 디렉터리로 한정했다.
+- 실제 runner의 정리 전·후·cache 복원 후 `df` 출력으로 임계값 판단과 공간 변화를 추적할 수 있다.
+- 문서 trailing commit은 workflow·source·test를 변경하지 않으며, code candidate의 Full CI 결과를
+  대체하지 않는다.
+
+## 현재 권고
+
+**병합 권고.** 디스크가 충분한 runner에서는 정리를 생략하고, 부족한 runner에서만 정리하는 조건부
+동작과 전후 측정이 구현됐다. code candidate의 로컬 검증과 Full CI·CodeQL이 모두 통과했다.
+문서 trailing head의 최신 preflight·aggregate가 성공하고 merge state가 `CLEAN`이면 작업지시자 승인
+후 병합할 수 있다.


### PR DESCRIPTION
## 변경 요약

- archive 정리 단계에서 삭제 전 루트 파일시스템 사용량을 기록합니다.
- `/usr/local/lib/android`와 `/usr/share/dotnet`의 삭제 전 실제 용량을 기록합니다.
- 삭제 후에도 human-readable/바이트 단위 디스크 사용량을 기록합니다.
- 측정 전에는 기존 삭제 동작을 제거하거나 조건부로 바꾸지 않습니다.

## 목적

현재 CI는 삭제 후 `df -h`만 기록하므로 정리 단계가 실제로 필요한지와 확보 공간을 판단할 수 없습니다. 다음 실행의 전후 수치를 근거로 정리 단계 유지·제거·조건부 실행을 결정할 수 있게 합니다.

## 검증

- `python3 -m unittest scripts/tests/test_nextest_archive_workflow.py` — 12건 통과
- `actionlint .github/workflows/build-nextest-archives.yml` — 통과
- `git diff --check` — 통과
- 제품 Cargo·WASM·브라우저 회귀 테스트 — workflow 로그 변경만 있어 생략

Fixes #5181
