### PR TITLE
ci: Rust CodeQL을 build-mode none으로 전환

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -773,18 +773,25 @@ jobs:
       # [#3290] 호스티드 16GB VM 은 CodeQL 자동 감지 값이 적정하다. self-hosted 로
       # 되돌릴 경우 ram/threads 캡 필수 — #3289 사고(무캡 JVM 40~55GB×2 로 호스트
       # 포화·스톨) 및 task_m100_3289_report.md 거버넌스 절 참조.
-      - name: Initialize CodeQL
-        if: ${{ contains(format(',{0},', env.SELECTED_LANGUAGES), format(',{0},', matrix.language)) }}
+      - name: Initialize CodeQL (non-Rust)
+        if: ${{ matrix.language != 'rust' && contains(format(',{0},', env.SELECTED_LANGUAGES), format(',{0},', matrix.language)) }}
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+
+      - name: Initialize CodeQL (Rust)
+        if: ${{ matrix.language == 'rust' && contains(format(',{0},', env.SELECTED_LANGUAGES), format(',{0},', matrix.language)) }}
+        uses: github/codeql-action/init@v4
+        with:
+          languages: rust
+          build-mode: none
 
       - name: Install Rust toolchain
         if: ${{ matrix.language == 'rust' && contains(format(',{0},', env.SELECTED_LANGUAGES), format(',{0},', matrix.language)) }}
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 브랜치 (2026-08-01 시점)
 
-      # [#3790 Stage 5A] 기본 build mode의 내부 autobuild가 같은 source alert와
-      # fingerprint를 생성함을 canary로 확인했다. 중복 cache·수동 prebuild는 실행하지 않는다.
+      # [#5187] Rust는 명시적 none 모드로 분석한다. 동일 SHA 비교에서 현재 기본 경로와
+      # 추출 파일·SARIF 지표가 같았고, none 모드가 더 짧아 Rust 자동 빌드 의존을 제거한다.
       - name: Perform CodeQL Analysis
         if: ${{ contains(format(',{0},', env.SELECTED_LANGUAGES), format(',{0},', matrix.language)) }}
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## 변경 내용

- `.github/workflows/codeql.yml`의 CodeQL matrix 중 Rust 초기화만 별도 단계로 분리했습니다.
- Rust에 `build-mode: none`을 명시합니다.
- JavaScript/TypeScript와 Python의 CodeQL 초기화·분석 경로는 기존과 동일하게 유지합니다.

## 왜 이 변경을 하는가

Resolves #5187

CodeQL build mode를 운영에 변경하기 전에 동일한 candidate SHA에서 현재 기본 경로와 `none` 경로를 나란히 실행했습니다.

- 실험 PR: [#5188](https://github.com/edwardkim/rhwp/pull/5188)
- 비교 실행: [Actions run 32026738852](https://github.com/edwardkim/rhwp/actions/runs/32026738852)
- candidate SHA: `02cf90a6509a73291b68dc8dbc37060b497a4899`
- 비교 대상: 현재 기본 경로 vs Rust `build-mode: none`
- 현재 기본 경로: 15분 47초
- `none`: 14분 56초
- 차이: 51초 단축, 약 5.7%

두 분석 결과의 원시 SARIF `metricResults`를 비교한 결과 핵심 지표가 동일했습니다.

| 지표 | 양쪽 결과 |
| --- | ---: |
| 추출 파일 | 1,278 |
| 추출 오류 | 0 |
| 추출 경고 | 16 |
| 분석 요소 | 34,679,656 |
| 미추출 요소 | 0 |
| 미해결 매크로 호출 | 64 |
| SARIF alert | 33 |
| partial fingerprint | 66 |
| trap file | 0 |
| 결과 digest | `7e993cb37d7a05ac34762c77af575b261aad84f26fc191e0541e4de438a7a193` |

따라서 이 변경은 Rust 분석 결과를 줄이거나 다른 언어의 분석 동작을 바꾸는 변경이 아니라, 동일한 분석 결과를 내는 Rust 경로에서 불필요한 자동 빌드 의존을 제거해 실행 시간을 줄이는 변경입니다. 상세 표와 판정은 [#5187 결과 기록](https://github.com/edwardkim/rhwp/issues/5187#issuecomment-5315804901)에 남겼습니다.

참고로 Rust에 `build-mode: autobuild`를 명시한 별도 실험은 CodeQL이 Rust에서 해당 모드를 지원하지 않아 거부되었습니다. 따라서 이 PR에는 `autobuild`를 사용하지 않고, 성공한 현재 기본 경로와 `none` 비교 결과만 반영했습니다.

비교 판단은 부가적인 CodeQL CLI 진단 명령이 아니라 각 분석 job이 생성한 원시 SARIF와 그 안의 `metricResults`를 기준으로 했습니다.

## 검증

- `actionlint .github/workflows/codeql.yml`
- `git diff --check`
- `node --test scripts/tests/ci-impact-policy.test.cjs` — 31 passed

이 PR의 운영 CodeQL 결과는 새 PR head `d2001a13d30de61ff533fc11a86446981f0d55ff`에서 별도로 확인합니다.