### PR TITLE
feat(gym): JSON/CSV/NDJSON 지목 채점 연산자 추가

### DIFF
--- a/gym/core/checks.py
+++ b/gym/core/checks.py
@@ -181,6 +181,115 @@ def op_utf8_bom(ctx):
     return {"expected": expected, "actual": actual, "ok": actual == expected}
 
 
+def _load_json_at(ctx):
+    """제출 JSON을 읽고 `path` 좌표의 값을 돌려준다."""
+    with open(ctx.sub_path(ctx.check["file"]), encoding="utf-8") as fh:
+        return dig(json.load(fh), ctx.check.get("path", ""))
+
+
+def iter_ndjson_lines(path):
+    """비어 있지 않은 NDJSON 줄. 앞뒤 공백은 버리고 빈 줄은 센 대상이 아니다."""
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            stripped = line.strip()
+            if stripped:
+                yield stripped
+
+
+def op_json_len_eq(ctx):
+    """제출 JSON의 지목된 배열/객체 길이를 확인한다."""
+    expected = ctx.check["value"]
+    try:
+        got = _load_json_at(ctx)
+        if not isinstance(got, (list, dict)):
+            raise TypeError(f"배열/객체가 아님: {type(got).__name__}")
+        actual = len(got)
+    except (OSError, ValueError, KeyError, IndexError, TypeError) as exc:
+        return {"expected": expected, "actual": f"JSON 길이 확인 실패: {exc}", "ok": False}
+    return {"expected": expected, "actual": actual, "ok": norm(actual) == norm(expected)}
+
+
+def op_csv_row_count_eq(ctx):
+    """제출 CSV의 행 수(utf-8-sig)를 확인한다."""
+    expected = ctx.check["value"]
+    try:
+        with open(ctx.sub_path(ctx.check["file"]), encoding="utf-8-sig", newline="") as fh:
+            actual = sum(1 for _ in csv.reader(fh))
+    except (OSError, UnicodeError, csv.Error) as exc:
+        return {"expected": expected, "actual": f"CSV 행수 확인 실패: {exc}", "ok": False}
+    return {"expected": expected, "actual": actual, "ok": norm(actual) == norm(expected)}
+
+
+def op_ndjson_count_eq(ctx):
+    """제출 NDJSON의 비어 있지 않은 줄 수를 확인한다."""
+    expected = ctx.check["value"]
+    try:
+        actual = sum(1 for _ in iter_ndjson_lines(ctx.sub_path(ctx.check["file"])))
+    except (OSError, UnicodeError) as exc:
+        return {"expected": expected, "actual": f"NDJSON 줄수 확인 실패: {exc}", "ok": False}
+    return {"expected": expected, "actual": actual, "ok": norm(actual) == norm(expected)}
+
+
+def op_ndjson_field_eq(ctx):
+    """제출 NDJSON의 0부터 세는 비어 있지 않은 줄에서 지목 필드를 확인한다."""
+    expected = ctx.check["value"]
+    row_index = ctx.check["row"]
+    try:
+        if not isinstance(row_index, int) or isinstance(row_index, bool):
+            raise TypeError("row는 정수여야 함")
+        if row_index < 0:
+            raise IndexError("row는 음수일 수 없음")
+        actual = None
+        found = False
+        for index, line in enumerate(iter_ndjson_lines(ctx.sub_path(ctx.check["file"]))):
+            if index == row_index:
+                actual = dig(json.loads(line), ctx.check.get("path", ""))
+                found = True
+                break
+        if not found:
+            raise IndexError(f"행 {row_index} 없음")
+    except (OSError, UnicodeError, ValueError, KeyError, IndexError, TypeError) as exc:
+        return {"expected": expected, "actual": f"NDJSON 필드 확인 실패: {exc}", "ok": False}
+    return {"expected": expected, "actual": actual, "ok": norm(actual) == norm(expected)}
+
+
+def op_json_keys_contain(ctx):
+    """제출 JSON 객체가 `keys` 의 키를 모두 갖는지 확인한다."""
+    required = ctx.check["keys"]
+    try:
+        if not isinstance(required, list) or any(not isinstance(k, str) for k in required):
+            raise TypeError("keys는 문자열 목록이어야 함")
+        got = _load_json_at(ctx)
+        if not isinstance(got, dict):
+            raise TypeError(f"객체가 아님: {type(got).__name__}")
+        actual = sorted(got)
+        missing = [k for k in required if k not in got]
+    except (OSError, ValueError, KeyError, IndexError, TypeError) as exc:
+        return {"expected": required, "actual": f"JSON 키 확인 실패: {exc}", "ok": False}
+    return {"expected": list(required), "actual": actual, "ok": not missing}
+
+
+def op_text_line_eq(ctx):
+    """제출 텍스트의 0부터 세는 한 줄이 `value` 와 같은지 확인한다."""
+    expected = ctx.check["value"]
+    line_index = ctx.check["line"]
+    try:
+        if not isinstance(line_index, int) or isinstance(line_index, bool):
+            raise TypeError("line은 정수여야 함")
+        if line_index < 0:
+            raise IndexError("line은 음수일 수 없음")
+        with open(ctx.sub_path(ctx.check["file"]), encoding="utf-8") as fh:
+            for index, line in enumerate(fh):
+                if index == line_index:
+                    actual = line.rstrip("\r\n")
+                    break
+            else:
+                raise IndexError(f"줄 {line_index} 없음")
+    except (OSError, UnicodeError, IndexError, TypeError) as exc:
+        return {"expected": expected, "actual": f"텍스트 줄 확인 실패: {exc}", "ok": False}
+    return {"expected": expected, "actual": actual, "ok": actual == expected}
+
+
 # --- 봉투 연산자 — CLI 봉투의 지목된 자리를 본다 ---
 
 
@@ -259,6 +368,12 @@ REGISTRY = {
     "json_value_eq": (op_json_value_eq, False),
     "csv_cell_eq": (op_csv_cell_eq, False),
     "utf8_bom": (op_utf8_bom, False),
+    "json_len_eq": (op_json_len_eq, False),
+    "csv_row_count_eq": (op_csv_row_count_eq, False),
+    "ndjson_count_eq": (op_ndjson_count_eq, False),
+    "ndjson_field_eq": (op_ndjson_field_eq, False),
+    "json_keys_contain": (op_json_keys_contain, False),
+    "text_line_eq": (op_text_line_eq, False),
     # 봉투 연산자(CLI 호출)
     "answer_eq": (op_answer_eq, True),
     "len_answer_eq": (op_len_answer_eq, True),

--- a/gym/core/checks.py
+++ b/gym/core/checks.py
@@ -290,6 +290,190 @@ def op_text_line_eq(ctx):
     return {"expected": expected, "actual": actual, "ok": actual == expected}
 
 
+def _require_nonneg_int(name, value):
+    """좌표 정수를 받는다. bool 은 int 의 하위형이라 명시적으로 거절한다."""
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise TypeError(f"{name}은 정수여야 함")
+    if value < 0:
+        raise IndexError(f"{name}은 음수일 수 없음")
+    return value
+
+
+def json_type_name(value):
+    """JSON 값의 타입 이름. bool 은 number 가 아니다."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, (int, float)):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    return type(value).__name__
+
+
+def _require_str_list(name, value):
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise TypeError(f"{name}는 문자열 목록이어야 함")
+    return value
+
+
+def _csv_row_at(path, row_index):
+    _require_nonneg_int("row", row_index)
+    with open(path, encoding="utf-8-sig", newline="") as fh:
+        for index, row in enumerate(csv.reader(fh)):
+            if index == row_index:
+                return row
+    raise IndexError(f"행 {row_index} 없음")
+
+
+def _ndjson_record_at(path, row_index):
+    _require_nonneg_int("row", row_index)
+    for index, line in enumerate(iter_ndjson_lines(path)):
+        if index == row_index:
+            return json.loads(line)
+    raise IndexError(f"행 {row_index} 없음")
+
+
+def _text_line_at(path, line_index):
+    _require_nonneg_int("line", line_index)
+    with open(path, encoding="utf-8") as fh:
+        for index, line in enumerate(fh):
+            if index == line_index:
+                return line.rstrip("\r\n")
+    raise IndexError(f"줄 {line_index} 없음")
+
+
+def op_json_type_eq(ctx):
+    """제출 JSON의 지목된 값 타입(array/object/string/number/boolean/null)을 확인한다."""
+    expected = ctx.check["value"]
+    try:
+        if not isinstance(expected, str):
+            raise TypeError("value는 타입 이름 문자열이어야 함")
+        actual = json_type_name(_load_json_at(ctx))
+    except (OSError, ValueError, KeyError, IndexError, TypeError) as exc:
+        return {"expected": expected, "actual": f"JSON 타입 확인 실패: {exc}", "ok": False}
+    return {"expected": expected, "actual": actual, "ok": actual == expected}
+
+
+def op_json_len_ge(ctx):
+    """제출 JSON의 지목된 배열/객체 길이가 `value` 이상인지 확인한다."""
+    expected = ctx.check["value"]
+    try:
+        got = _load_json_at(ctx)
+        if not isinstance(got, (list, dict)):
+            raise TypeError(f"배열/객체가 아님: {type(got).__name__}")
+        actual = len(got)
+        ok = float(actual) >= float(expected)
+    except (OSError, ValueError, KeyError, IndexError, TypeError) as exc:
+        return {"expected": f">={expected}", "actual": f"JSON 길이 하한 확인 실패: {exc}",
+                "ok": False}
+    return {"expected": f">={expected}", "actual": actual, "ok": ok}
+
+
+def op_json_array_item_eq(ctx):
+    """제출 JSON 배열의 0부터 세는 `index` 항목이 `value` 와 같은지 확인한다."""
+    expected = ctx.check["value"]
+    try:
+        index = _require_nonneg_int("index", ctx.check["index"])
+        got = _load_json_at(ctx)
+        if not isinstance(got, list):
+            raise TypeError(f"배열이 아님: {type(got).__name__}")
+        actual = got[index]
+    except (OSError, ValueError, KeyError, IndexError, TypeError) as exc:
+        return {"expected": expected, "actual": f"JSON 배열 항목 확인 실패: {exc}", "ok": False}
+    return {"expected": expected, "actual": actual, "ok": norm(actual) == norm(expected)}
+
+
+def op_csv_col_count_eq(ctx):
+    """제출 CSV의 지목 행 열 수가 `value` 인지 확인한다."""
+    expected = ctx.check["value"]
+    try:
+        actual = len(_csv_row_at(ctx.sub_path(ctx.check["file"]), ctx.check["row"]))
+    except (OSError, UnicodeError, csv.Error, IndexError, TypeError) as exc:
+        return {"expected": expected, "actual": f"CSV 열수 확인 실패: {exc}", "ok": False}
+    return {"expected": expected, "actual": actual, "ok": norm(actual) == norm(expected)}
+
+
+def op_csv_header_eq(ctx):
+    """제출 CSV 첫 행(헤더)이 `values` 와 같은지 확인한다."""
+    expected = ctx.check["values"]
+    try:
+        _require_str_list("values", expected)
+        actual = _csv_row_at(ctx.sub_path(ctx.check["file"]), 0)
+    except (OSError, UnicodeError, csv.Error, IndexError, TypeError) as exc:
+        return {"expected": expected, "actual": f"CSV 헤더 확인 실패: {exc}", "ok": False}
+    return {"expected": list(expected), "actual": actual, "ok": actual == list(expected)}
+
+
+def op_csv_row_eq(ctx):
+    """제출 CSV의 지목 행 전체가 `values` 와 같은지 확인한다."""
+    expected = ctx.check["values"]
+    try:
+        _require_str_list("values", expected)
+        actual = _csv_row_at(ctx.sub_path(ctx.check["file"]), ctx.check["row"])
+    except (OSError, UnicodeError, csv.Error, IndexError, TypeError) as exc:
+        return {"expected": expected, "actual": f"CSV 행 확인 실패: {exc}", "ok": False}
+    return {"expected": list(expected), "actual": actual, "ok": actual == list(expected)}
+
+
+def op_ndjson_keys_contain(ctx):
+    """제출 NDJSON의 지목 행 객체가 `keys` 를 모두 갖는지 확인한다."""
+    required = ctx.check["keys"]
+    try:
+        _require_str_list("keys", required)
+        got = dig(_ndjson_record_at(ctx.sub_path(ctx.check["file"]), ctx.check["row"]),
+                  ctx.check.get("path", ""))
+        if not isinstance(got, dict):
+            raise TypeError(f"객체가 아님: {type(got).__name__}")
+        actual = sorted(got)
+        missing = [key for key in required if key not in got]
+    except (OSError, UnicodeError, ValueError, KeyError, IndexError, TypeError) as exc:
+        return {"expected": required, "actual": f"NDJSON 키 확인 실패: {exc}", "ok": False}
+    return {"expected": list(required), "actual": actual, "ok": not missing}
+
+
+def op_ndjson_len_eq(ctx):
+    """제출 NDJSON의 지목 행에서 배열/객체 길이가 `value` 인지 확인한다."""
+    expected = ctx.check["value"]
+    try:
+        got = dig(_ndjson_record_at(ctx.sub_path(ctx.check["file"]), ctx.check["row"]),
+                  ctx.check.get("path", ""))
+        if not isinstance(got, (list, dict)):
+            raise TypeError(f"배열/객체가 아님: {type(got).__name__}")
+        actual = len(got)
+    except (OSError, UnicodeError, ValueError, KeyError, IndexError, TypeError) as exc:
+        return {"expected": expected, "actual": f"NDJSON 길이 확인 실패: {exc}", "ok": False}
+    return {"expected": expected, "actual": actual, "ok": norm(actual) == norm(expected)}
+
+
+def op_text_line_count_eq(ctx):
+    """제출 텍스트의 줄 수가 `value` 인지 확인한다. 마지막 개행만 있는 빈 줄도 센다."""
+    expected = ctx.check["value"]
+    try:
+        with open(ctx.sub_path(ctx.check["file"]), encoding="utf-8") as fh:
+            actual = sum(1 for _ in fh)
+    except (OSError, UnicodeError) as exc:
+        return {"expected": expected, "actual": f"텍스트 줄수 확인 실패: {exc}", "ok": False}
+    return {"expected": expected, "actual": actual, "ok": norm(actual) == norm(expected)}
+
+
+def op_text_line_contains(ctx):
+    """제출 텍스트의 지목 줄이 `value` 부분 문자열을 갖는지 확인한다."""
+    expected = ctx.check["value"]
+    try:
+        if not isinstance(expected, str):
+            raise TypeError("value는 문자열이어야 함")
+        actual = _text_line_at(ctx.sub_path(ctx.check["file"]), ctx.check["line"])
+    except (OSError, UnicodeError, IndexError, TypeError) as exc:
+        return {"expected": expected, "actual": f"텍스트 줄 포함 확인 실패: {exc}", "ok": False}
+    return {"expected": expected, "actual": actual, "ok": expected in actual}
+
+
 # --- 봉투 연산자 — CLI 봉투의 지목된 자리를 본다 ---
 
 
@@ -374,6 +558,16 @@ REGISTRY = {
     "ndjson_field_eq": (op_ndjson_field_eq, False),
     "json_keys_contain": (op_json_keys_contain, False),
     "text_line_eq": (op_text_line_eq, False),
+    "json_type_eq": (op_json_type_eq, False),
+    "json_len_ge": (op_json_len_ge, False),
+    "json_array_item_eq": (op_json_array_item_eq, False),
+    "csv_col_count_eq": (op_csv_col_count_eq, False),
+    "csv_header_eq": (op_csv_header_eq, False),
+    "csv_row_eq": (op_csv_row_eq, False),
+    "ndjson_keys_contain": (op_ndjson_keys_contain, False),
+    "ndjson_len_eq": (op_ndjson_len_eq, False),
+    "text_line_count_eq": (op_text_line_count_eq, False),
+    "text_line_contains": (op_text_line_contains, False),
     # 봉투 연산자(CLI 호출)
     "answer_eq": (op_answer_eq, True),
     "len_answer_eq": (op_len_answer_eq, True),

--- a/gym/docs/checks.md
+++ b/gym/docs/checks.md
@@ -1,0 +1,361 @@
+---
+kind: guide
+status: active
+canonical: gym/docs/checks.md
+last_verified: 2026-08-18
+---
+
+# gym 채점 연산자 목록
+
+판정 어휘의 정본은 `gym/core/checks.py` 의 `REGISTRY` 다. 이 문서는 그 등록부를
+사람이 고를 수 있게 풀어 쓴 목록이다. 과제 JSON 은 연산자를 **고르기만** 하고
+정의하지 않는다 — 과제마다 판정 논리가 흩어지면 #4600 같은 오검출이 pack 수만큼
+늘어난다.
+
+CLI 를 부르지 않는 파일 연산자(`needs_cli=False`)는 제출 폴더의 산출물만 본다.
+바이너리 없이 단위시험이 돈다. 봉투 연산자(`needs_cli=True`)는 `cmd` 로 rhwp 를
+호출해 나온 JSON 봉투의 좌표를 본다.
+
+## 연산자를 고르는 규칙
+
+1. **대상을 지목하라.** `deep_contains` 는 "값이 어딘가 있으면 통과"라 엉뚱한 곳을
+   고친 제출을 걸러내지 못한다. 편집·산출 과제는 `value_eq`·`cell_text_eq`·
+   `json_len_eq`·`csv_row_eq` 처럼 좌표를 지목하는 연산자를 쓴다.
+2. **기대값을 박제하지 마라.** 정답은 채점 시점에 rhwp 로 재계산하거나
+   (`answer_eq` 계열), rhwp 자신에게 판정을 시킨다(`{sha256:}` + replay).
+   파일 연산자의 `value` 는 "이 자리의 관측"이지 골든 스냅샷이 아니다.
+3. **부재를 통과로 위장하지 마라.** 좌표가 없으면 `None` 이 아니라 실패 문자열을
+   남기고 `ok=False` 다. 빈 파일·깨진 UTF-8·음수 좌표·bool 좌표도 실패다.
+4. **전역 훑기는 편집 과제에서 금지.** `GLOBAL_SCAN_OPS = {deep_contains,
+   not_contains}`. 편집·보안 축에서 쓰려면 `allowGlobalScan` 으로 사유를 밝혀야
+   한다(#4600).
+
+`schema.validate_task` 는 미등록 연산자를 거절하고, `needs_cli` 가 거짓인데
+`cmd` 가 있으면 거절한다. 등록만 하고 스키마를 우회하는 길은 없다.
+
+## 파일 연산자 — CLI 를 부르지 않는다
+
+아래 연산자는 제출물 자체를 연다. `file` 은 제출 폴더 기준 상대 경로다.
+
+### 해시·존재
+
+| op | 필드 | 판정 |
+|---|---|---|
+| `same_hash` | `files` (2개) | 두 파일 SHA-256 이 같다 |
+| `differs_from_input` | `file` | 산출 SHA-256 ≠ 과제 `input` SHA-256 |
+| `file_exists` | `file`, `minBytes?` | 파일이 있고 크기가 하한 이상(기본 1) |
+| `files_differ` | `files` | 두 파일 해시가 서로 다르다 |
+| `utf8_bom` | `file`, `value?` | 선두 3바이트가 UTF-8 BOM 인지 |
+
+`differs_from_input` 은 무편집 복사본을 거부한다. `file_exists` 만 쓰면 빈
+껍데기나 쓰레기 바이트가 통과할 수 있으므로, 형식 연산자(`xml_root_eq`,
+`json_type_eq`, `csv_header_eq`)와 짝을 짓는다.
+
+### XML
+
+| op | 필드 | 판정 |
+|---|---|---|
+| `xml_root_eq` | `file`, `value` | root local-name 이 `value` |
+
+파싱 실패(깨진 마크업, 파일 없음)는 `ok=False` 이고 `actual` 에
+`XML 파싱 실패:` 접두가 붙는다.
+
+### JSON 지목 — #5205 와 후속
+
+에이전트가 남긴 `answer.json`·구조 덤프·추출 결과를 **전역 훑기 없이** 좌표로
+잰다. 경로 문법은 `dig()` 의 점·대괄호: `items[0].tags`, `meta.ok`, 빈 경로는
+문서 전체.
+
+| op | 필드 | 판정 |
+|---|---|---|
+| `json_value_eq` | `file`, `path?`, `value` | 좌표 값이 `value` (숫자 문자열은 `norm` 으로 같게) |
+| `json_len_eq` | `file`, `path?`, `value` | 배열/객체 길이가 `value` |
+| `json_len_ge` | `file`, `path?`, `value` | 배열/객체 길이가 `value` 이상 |
+| `json_type_eq` | `file`, `path?`, `value` | 타입이 `array`/`object`/`string`/`number`/`boolean`/`null` |
+| `json_array_item_eq` | `file`, `path?`, `index`, `value` | 배열의 0부터 세는 항목이 `value` |
+| `json_keys_contain` | `file`, `path?`, `keys` | 객체가 `keys` 문자열을 모두 가짐 |
+
+공통 예외 (`ok=False`, `actual` 에 `실패` 포함):
+
+- 파일 없음, 빈 파일, 깨진 JSON, 잘못된 UTF-8
+- `path` 가 없거나 인덱스 범위 밖 (`KeyError`/`IndexError`)
+- `json_len_eq`/`json_len_ge` 가 스칼라·null 을 만남 (`TypeError`)
+- `json_keys_contain` 이 배열/스칼라를 만남, 또는 `keys` 가 문자열 목록이 아님
+- `json_array_item_eq` 의 `index` 가 음수이거나 `bool` (`True` 는 `int` 의
+  하위형이라 명시 거절)
+- `json_type_eq` 의 `value` 가 문자열이 아님
+
+`norm` 은 `bool` 을 숫자로 바꾸지 않는다. `json_len_eq` 의 `value=True` 는
+길이 1 과 같지 않다. 숫자와 숫자 문자열(`"3"`, `"3.0"`)만 같다.
+
+#### 예: 추출 결과 길이
+
+```json
+{
+  "name": "항목 수",
+  "op": "json_len_eq",
+  "file": "answer.json",
+  "path": "items",
+  "value": 3
+}
+```
+
+`{"items":[1,2,3],"extra":[]}` 는 통과한다. `deep_contains` 로 `"items"` 문자열만
+찾으면 `extra` 만 채운 제출도 통과한다 — 그것이 지목 연산자를 쓰는 이유다.
+
+#### 예: 필수 키
+
+```json
+{
+  "name": "식별 키",
+  "op": "json_keys_contain",
+  "file": "answer.json",
+  "path": "row",
+  "keys": ["id", "name"]
+}
+```
+
+여분 키는 허용한다. 키 집합이 정확히 같아야 하면 `json_len_eq` 로 키 개수를
+한 번 더 잰다.
+
+#### 예: 타입 고정
+
+```json
+{
+  "name": "tags 는 배열",
+  "op": "json_type_eq",
+  "file": "out.json",
+  "path": "items[0].tags",
+  "value": "array"
+}
+```
+
+`true`/`false` 는 `boolean` 이지 `number` 가 아니다. `null` 은 `object` 가 아니다.
+
+### CSV 지목
+
+CSV 는 `utf-8-sig` 로 연다. 선두 BOM 은 헤더 첫 칸을 더럽히지 않는다.
+`csv.reader` 가 따옴표 안 개행을 한 논리 행으로 묶는다.
+
+| op | 필드 | 판정 |
+|---|---|---|
+| `csv_cell_eq` | `file`, `row`, `col`, `value` | 좌표 셀이 `value` (`norm`) |
+| `csv_row_count_eq` | `file`, `value` | 논리 행 수(헤더 포함)가 `value` |
+| `csv_col_count_eq` | `file`, `row`, `value` | 지목 행의 열 수가 `value` |
+| `csv_header_eq` | `file`, `values` | 0번 행이 문자열 목록과 정확히 같음 |
+| `csv_row_eq` | `file`, `row`, `values` | 지목 행 전체가 `values` 와 같음 |
+
+`csv_header_eq`/`csv_row_eq` 는 `norm` 을 쓰지 않는다. 헤더 `"01"` 과 `"1"` 은
+다른 칸이다. 셀 값 비교가 필요하면 `csv_cell_eq` 를 쓴다.
+
+예외:
+
+- 파일 없음, 깨진 UTF-8, `csv.Error`
+- `row`/`col` 이 음수·`bool`·범위 밖
+- 빈 파일에 `csv_header_eq` — 헤더 행 없음
+- `values` 가 문자열 목록이 아님
+
+#### 예: 표 추출 행 수
+
+```json
+{
+  "name": "헤더+데이터 3행",
+  "op": "csv_row_count_eq",
+  "file": "table.csv",
+  "value": 3
+}
+```
+
+```json
+{
+  "name": "헤더",
+  "op": "csv_header_eq",
+  "file": "table.csv",
+  "values": ["이름", "수량", "비고"]
+}
+```
+
+```json
+{
+  "name": "첫 데이터 행",
+  "op": "csv_row_eq",
+  "file": "table.csv",
+  "row": 1,
+  "values": ["갑", "1", "초안"]
+}
+```
+
+### NDJSON 지목
+
+한 줄이 한 레코드다. `iter_ndjson_lines` 는 앞뒤 공백을 버리고 **빈 줄은 세지
+않는다**. 줄 번호(`row`)는 비어 있지 않은 줄만 0부터 센다.
+
+| op | 필드 | 판정 |
+|---|---|---|
+| `ndjson_count_eq` | `file`, `value` | 비어 있지 않은 줄 수 |
+| `ndjson_field_eq` | `file`, `row`, `path?`, `value` | 그 줄 JSON 의 좌표가 `value` |
+| `ndjson_keys_contain` | `file`, `row`, `path?`, `keys` | 그 줄(또는 `path` 객체)이 키를 모두 가짐 |
+| `ndjson_len_eq` | `file`, `row`, `path?`, `value` | 그 줄의 배열/객체 길이 |
+
+예외:
+
+- 파일 없음, 깨진 UTF-8
+- 대상 줄이 JSON 이 아님 (`ndjson_field_eq`/`keys`/`len`)
+- `row` 음수·`bool`·범위 밖
+- 길이 연산자가 스칼라를 만남
+- `keys` 가 문자열 목록이 아님
+
+빈 줄만 있는 파일의 `ndjson_count_eq` 는 0 이다. `ndjson_field_eq` 의 `row=0` 은
+실패(`행 0 없음`)다.
+
+#### 예: 배치 스트림 한 건
+
+```json
+{
+  "name": "둘째 레코드 id",
+  "op": "ndjson_field_eq",
+  "file": "batch.ndjson",
+  "row": 1,
+  "path": "id",
+  "value": 2
+}
+```
+
+```text
+{"id":1,"name":"갑"}
+
+{"id":2,"name":"을"}
+{"id":3}
+```
+
+위 픽스처에서 비어 있지 않은 줄은 3개이고, `row=1` 은 `id=2` 다. 물리 줄 번호로
+세면 틀린다.
+
+### 텍스트 지목
+
+텍스트는 UTF-8 로 연다. 줄 끝 `\n`/`\r\n` 은 비교 전에 벗긴다. 마지막 줄에
+개행이 없어도 한 줄로 센다.
+
+| op | 필드 | 판정 |
+|---|---|---|
+| `text_line_eq` | `file`, `line`, `value` | 0부터 세는 한 줄이 `value` 와 같음 (부분 일치 아님) |
+| `text_line_contains` | `file`, `line`, `value` | 그 줄이 `value` 부분 문자열을 가짐 |
+| `text_line_count_eq` | `file`, `value` | 물리 줄 수. 빈 줄도 센다. 빈 파일은 0 |
+
+`text_line_contains` 는 **한 줄**을 지목한다. 파일 전체를 훑지 않으므로
+`GLOBAL_SCAN_OPS` 가 아니다. 빈 문자열 needle 은 모든 줄에 포함된다.
+
+예외:
+
+- 파일 없음, 깨진 UTF-8
+- `line` 음수·`bool`·범위 밖
+- 빈 파일에서 `line=0` — `줄 0 없음`
+- `text_line_contains` 의 `value` 가 문자열이 아님
+
+#### 예: 작업 영수증 한 줄
+
+```json
+{
+  "name": "둘째 줄",
+  "op": "text_line_eq",
+  "file": "receipt.txt",
+  "line": 1,
+  "value": "수량: 12"
+}
+```
+
+```json
+{
+  "name": "이름 포함",
+  "op": "text_line_contains",
+  "file": "receipt.txt",
+  "line": 0,
+  "value": "홍길동"
+}
+```
+
+## 봉투 연산자 — CLI 를 부른다
+
+`cmd` 가 필수다. 파일 연산자에 `cmd` 를 붙이면 스키마가 거절한다.
+
+| op | 필드 | 판정 |
+|---|---|---|
+| `answer_eq` | `cmd`, `path?`, `answer` | 봉투 좌표 == `answer.json` 의 키 |
+| `len_answer_eq` | `cmd`, `path?`, `answer` | 봉투 좌표 길이 == answer 키 |
+| `len_ge` | `cmd`, `path?`, `value` | 길이 ≥ value |
+| `value_eq` | `cmd`, `path?`, `value` | 봉투 좌표 == value (`norm`) |
+| `value_ge` | `cmd`, `path?`, `value` | 숫자 ≥ value |
+| `value_in` | `cmd`, `path?`, `values` | 값이 목록 중 하나 (`norm`) |
+| `deep_contains` | `cmd`, `path?`, `value` | 부분 문자열 전역 존재 (전역 훑기) |
+| `not_contains` | `cmd`, `path?`, `value` | 부분 문자열 전역 부재 (전역 훑기) |
+| `cell_text_eq` | `cmd`, `path?`, `table`, `row`, `col`, `value` | 표 좌표 텍스트 |
+
+편집 과제에서 `deep_contains`/`not_contains` 를 쓰려면 `allowGlobalScan` 이
+있어야 한다. 표는 `cells[0]` 순서 가정이 아니라 `(row, col)` 로 찾는다(#4600).
+
+## REGISTRY 계약
+
+`REGISTRY` 는 `(callable, needs_cli)` 맵이다. 기존 키를 지우거나 `needs_cli`
+플래그를 뒤집으면 스키마·채점·단위시험이 한꺼번에 깨진다.
+
+현재 파일 연산자(`needs_cli=False`):
+
+- `same_hash`, `differs_from_input`, `file_exists`, `files_differ`
+- `xml_root_eq`, `json_value_eq`, `csv_cell_eq`, `utf8_bom`
+- `json_len_eq`, `csv_row_count_eq`, `ndjson_count_eq`, `ndjson_field_eq`
+- `json_keys_contain`, `text_line_eq`
+- `json_type_eq`, `json_len_ge`, `json_array_item_eq`
+- `csv_col_count_eq`, `csv_header_eq`, `csv_row_eq`
+- `ndjson_keys_contain`, `ndjson_len_eq`
+- `text_line_count_eq`, `text_line_contains`
+
+현재 봉투 연산자(`needs_cli=True`):
+
+- `answer_eq`, `len_answer_eq`, `len_ge`
+- `value_eq`, `value_ge`, `value_in`
+- `deep_contains`, `not_contains`, `cell_text_eq`
+
+`GLOBAL_SCAN_OPS` 는 `{deep_contains, not_contains}` 만 가진다. 지목 연산자를
+여기에 넣지 않는다.
+
+## 예외 경로 요약
+
+모든 파일 연산자는 다음을 **통과로 위장하지 않는다**.
+
+| 상황 | 결과 |
+|---|---|
+| 제출 파일 없음 | `ok=False`, `actual` 에 실패/없음 |
+| 빈 JSON 파일 | 파싱 실패 |
+| 빈 CSV / 빈 NDJSON / 빈 텍스트 | 행·줄 수 0 은 통과 가능. 좌표 지목은 실패 |
+| 잘못된 UTF-8 | `UnicodeError` → 실패 |
+| 음수 `row`/`col`/`line`/`index` | `IndexError` → 실패 (`음수`) |
+| `bool` 좌표 (`True`/`False`) | `TypeError` → 실패 (`정수`) |
+| 경로 없음 | `KeyError`/`IndexError` → 실패 |
+| 배열이 필요한데 객체/스칼라 | `TypeError` → 실패 |
+| `keys`/`values` 가 문자열 목록이 아님 | `TypeError` → 실패 |
+
+단위시험은 `scripts/tests/test_gym_checks.py` 와
+`scripts/tests/test_gym_check_pinpoint.py` 가 위 행렬을 파일 픽스처만으로 재현한다.
+CLI 스텁을 심어 파일 연산자가 `run_cli` 를 부르지 않는지도 본다.
+
+## 새 연산자를 넣을 때
+
+1. `gym/core/checks.py` 에 `op_*` 를 추가한다. 예외는 삼켜서 `ok=False` 로 돌려
+   채점기가 죽지 않게 한다.
+2. `REGISTRY` 에 **추가만** 한다. 기존 키·플래그는 그대로 둔다.
+3. 좌표 연산자면 `GLOBAL_SCAN_OPS` 에 넣지 않는다. `needs_cli=False` 면 `cmd` 를
+   받지 않는다.
+4. `gym/docs/checks.md`(이 문서)와 `mydocs/working/gym_core_checks.md` 에 필드·
+   예외·예시를 적는다.
+5. `scripts/tests/test_gym_checks.py` 에 등록 계약과 대표 예외를,
+   `test_gym_check_pinpoint.py` 에 좌표 행렬을 넣는다.
+6. pack 과제는 연산자가 안정된 뒤에만 고른다. 연산자 PR 에서 pack 을 대량으로
+   바꾸지 않는다.
+7. `python -m unittest scripts/tests/test_gym_checks.py scripts/tests/test_gym_packs.py`
+   와 `python gym/tools/audit.py` 를 돌린다.
+
+## 관련
+
+- 구현: `gym/core/checks.py`, `gym/core/schema.py`, `gym/core/runner.py`
+- 작업 기록: `mydocs/working/gym_core_checks.md`
+- 이슈: #5205 (JSON/CSV/NDJSON 지목 채점), #4653 (판정 단일 출처), #4600 (좌표 지목)

--- a/mydocs/working/gym_core_checks.md
+++ b/mydocs/working/gym_core_checks.md
@@ -1,0 +1,400 @@
+---
+kind: working
+status: active
+canonical: gym/docs/checks.md
+last_verified: 2026-08-18
+---
+
+# gym 코어 지목 채점 연산자 — 작업 기록 (#5205)
+
+정본 목록은 [`gym/docs/checks.md`](../../gym/docs/checks.md) 다. 이 문서는
+왜 그 어휘가 생겼는지, 어떤 예외를 실패로 고정했는지, 단위시험이 무엇을
+재현하는지를 남긴다. pack 과제 JSON 은 여기서 바꾸지 않는다.
+
+## 한 줄 결론
+
+에이전트 산출(JSON / CSV / NDJSON / 텍스트)을 `deep_contains` 로 메우면
+"값이 어딘가 있으면 통과"가 되어 엉뚱한 칸을 채운 제출이 만점을 받는다.
+#5205 는 좌표를 지목하는 파일 연산자를 `REGISTRY` 에 추가한다. CLI 는
+부르지 않는다. 기존 키와 `GLOBAL_SCAN_OPS` 는 그대로다.
+
+## 배경
+
+gym 4부(#4653)가 판정 어휘를 `gym/core/checks.py` 한곳으로 모았다. pack 이
+늘어도 과제 파일은 연산자를 고르기만 한다. 그런데 파일 산출을 채점하는
+어휘가 `file_exists`·`json_value_eq`·`csv_cell_eq` 에 머물러 있으면, 길이와
+키 집합과 줄 단위 관측을 과제마다 손 검사로 때우게 된다. 손 검사는 전역
+훑기로  degenerates 한다.
+
+#5205 1차는 여섯 개를 등록했다.
+
+| op | 지목 |
+|---|---|
+| `json_len_eq` | JSON 배열/객체 길이 |
+| `csv_row_count_eq` | CSV 논리 행 수 (`utf-8-sig`) |
+| `ndjson_count_eq` | 비어 있지 않은 NDJSON 줄 수 |
+| `ndjson_field_eq` | NDJSON `row` + `path` |
+| `json_keys_contain` | 객체 키 포함 |
+| `text_line_eq` | 텍스트 `line` 완전 일치 |
+
+1차만으로는 타입·하한·헤더 전체·한 줄 포함을 표현하지 못한다. 과제가
+`json_value_eq` 로 타입을 우회하거나, `text_line_eq` 전체 문자열을 박제하게
+된다. 후속 지목 연산자는 같은 결(좌표, CLI 없음, 예외는 실패)로 구멍을
+메운다.
+
+| op | 지목 |
+|---|---|
+| `json_type_eq` | JSON 값 타입 이름 |
+| `json_len_ge` | 길이 하한 |
+| `json_array_item_eq` | 배열 `index` 항목 |
+| `csv_col_count_eq` | 지목 행 열 수 |
+| `csv_header_eq` | 0번 행 == `values` |
+| `csv_row_eq` | 지목 행 == `values` |
+| `ndjson_keys_contain` | NDJSON 행 키 포함 |
+| `ndjson_len_eq` | NDJSON 행 배열/객체 길이 |
+| `text_line_count_eq` | 텍스트 물리 줄 수 |
+| `text_line_contains` | 지목 줄 부분 문자열 |
+
+`text_line_contains` 는 파일 전체가 아니라 **한 줄**을 본다. 그래서
+`GLOBAL_SCAN_OPS` 에 넣지 않는다.
+
+## REGISTRY 를 깨지 않는 규칙
+
+`REGISTRY[op] = (fn, needs_cli)` 다. 스키마(`schema.validate_task`)와 러너
+(`eval_check`)와 단위시험이 이 맵을 공유한다.
+
+지켜야 할 것:
+
+1. **기존 키를 삭제하지 않는다.** `same_hash` 부터 `cell_text_eq` 까지
+   1차 이전 키는 그대로 남아 있어야 한다.
+2. **`needs_cli` 를 뒤집지 않는다.** 파일 연산자에 `True` 를 주면 모든
+   기존 과제가 `cmd` 를 요구하게 되고, 봉투 연산자에 `False` 를 주면 CLI
+   없이 빈 봉투를 본다.
+3. **`GLOBAL_SCAN_OPS` 는 `{deep_contains, not_contains}` 만.** 지목
+   연산자를 여기 넣으면 편집 과제가 스키마에서 막힌다.
+4. **추가만 한다.** 새 키는 파일 연산자면 `(op_*, False)` 로 붙인다.
+
+단위시험 `RegistryContractTests.test_registry_keeps_existing_keys` 가 1을
+고정하고, `test_global_scan_ops_unchanged` 가 3을 고정한다.
+
+## 경로 문법 (`dig`)
+
+`a.b[2].c` 형태. 빈 문자열은 문서 전체. 구현은 `gym/core/checks.py` 의
+`dig()`.
+
+관측한 실패 모드:
+
+| 입력 | 결과 |
+|---|---|
+| `""` | 루트 값 |
+| `items` | 객체 키 |
+| `items[0]` | 배열 0번 |
+| `items[0].tags` | 중첩 |
+| `items[0].tags[1]` | 중첩 배열 |
+| `gone` | `KeyError` → 연산자 실패 |
+| `items[9]` | `IndexError` → 실패 |
+| `meta[0]` | 객체에 정수 키 → `KeyError` → 실패 |
+| `note[0]` | 문자열 인덱싱은 Python 이 한 글자를 돌려주므로, 길이/키 연산자는
+  타입 검사에서 거절해야 한다. `json_len_eq` 는 스칼라를 거절한다. |
+
+`json_array_item_eq` 는 `path` 가 가리키는 **배열**에서 `index` 를 읽는다.
+`path="items[0].tags"`, `index=1` 이 `dig` 경로 `items[0].tags[1]` 과 같다.
+`index` 를 분리한 이유: 과제 JSON 에서 좌표를 숫자로 남기고, `bool` 거절을
+한곳에서 하기 위함이다.
+
+## `norm` 계약
+
+`norm` 은 숫자와 숫자 문자열을 같게 본다. `bool` 은 숫자로 바꾸지 않는다.
+
+| 왼쪽 | 오른쪽 | 같은가 |
+|---|---|---|
+| `3` | `"3"` | 예 |
+| `3` | `"3.0"` | 예 |
+| `3` | `3.0` | 예 |
+| `True` | `1` | 아니오 (`bool` 우선) |
+| `False` | `0` | 아니오 |
+| `"갑"` | `"갑"` | 예 |
+| `"01"` | `"1"` | 예 (`float`) |
+| `None` | `None` | 예 (`return v`) |
+
+CSV 헤더·행 전체 비교(`csv_header_eq`, `csv_row_eq`)는 `norm` 을 쓰지
+않는다. 헤더 `"01"` 과 `"1"` 을 같다고 보면 열 이름이 섞인다. 셀 하나
+비교(`csv_cell_eq`, `json_value_eq`, `json_array_item_eq`,
+`ndjson_field_eq`)만 `norm` 을 쓴다.
+
+## 예외 행렬
+
+모든 신규 파일 연산자는 예외를 삼켜 `{"ok": False, "actual": "...실패..."}`
+를 돌린다. 채점기가 스택을 흘리면 과제 하나가 런너를 죽인다.
+
+### 파일 계층
+
+| 상황 | json_* | csv_* | ndjson_* | text_* |
+|---|---|---|---|---|
+| 파일 없음 | 실패 | 실패 | 실패 | 실패 |
+| 빈 파일 | JSON 파싱 실패 | 행수 0 (count 만 통과 가능) | 줄수 0 (count 만 통과 가능) | 줄수 0. 좌표 지목은 `줄 0 없음` |
+| 잘못된 UTF-8 | 실패 | 실패 | 실패 | 실패 |
+| UTF-8 BOM | JSON 은 BOM 을 거부할 수 있음. CSV 는 `utf-8-sig` 로 제거 | BOM 이 행을 늘리지 않음 | JSON 줄 파싱에 BOM 이 끼면 실패 | 첫 줄에 U+FEFF 가 남으면 `text_line_eq` 불일치 |
+| CRLF | JSON 무관 | 논리 행은 LF 와 같음 | 빈 줄 규칙 동일 | `rstrip("\\r\\n")` 으로 벗김 |
+
+### 좌표 계층
+
+| 상황 | 적용 | 결과 |
+|---|---|---|
+| `row=-1` / `line=-1` / `index=-1` | 모든 좌표 연산자 | `음수` 실패 |
+| `row=True` / `line=False` / `index=True` | 동일 | `정수` 실패 (`bool` 은 `int` 하위형) |
+| 범위 밖 | 동일 | `없음` 또는 인덱스 실패 |
+| `path` 부재 | JSON/NDJSON | `실패` |
+| 스칼라에 `len` | `json_len_eq`, `json_len_ge`, `ndjson_len_eq` | `배열/객체가 아님` |
+| 배열에 `keys` | `json_keys_contain`, `ndjson_keys_contain` | `객체가 아님` |
+| `keys="id"` (문자열) | 키 연산자 | `문자열 목록` 실패 |
+| `values="name"` | `csv_header_eq`, `csv_row_eq` | 동일 |
+| `value=12` (숫자) | `text_line_contains`, `json_type_eq` | 타입 실패 |
+
+### JSON 깨짐
+
+다음 바디는 `json_len_eq`/`json_type_eq`/`json_keys_contain` 모두 실패다.
+
+- `""` (빈 파일)
+- `"   \\n"` (공백만)
+- `'{"a":'` (잘림)
+- `'{"a":1,}'` (trailing comma — 표준 json 모듈)
+- `"{'a': 1}"` (작은따옴표)
+- `"items=3"`
+- `"[1,2] junk"`
+- `"NaN"`, `"undefined"`
+
+NDJSON 은 줄 단위라 한 줄만 깨져도 그 `row` 의 `ndjson_field_eq` 만 실패한다.
+앞·뒤 줄은 살아 있다. `NDJSON_BAD` 픽스처(`{"id":1}\\n{not-json\\n{"id":3}`)에서
+`row=2` 의 `id=3` 은 통과한다. 빈 줄을 세지 않으므로 `row` 는 0,1,2 다.
+
+### CSV 따옴표 안 개행
+
+```
+name,note
+"갑","여러
+줄"
+을,단줄
+```
+
+물리 줄은 4 줄이지만 `csv.reader` 논리 행은 3 이다. `csv_row_count_eq`
+value=3, `csv_row_eq` row=1 values=`["갑", "여러\\n줄"]`. 물리 줄 수로 세는
+과제는 오검출한다.
+
+### 텍스트 줄 수
+
+| 바디 | `text_line_count_eq` |
+|---|---|
+| `""` | 0 |
+| `"한줄"` (개행 없음) | 1 |
+| `"한줄\\n"` | 1 |
+| `"한줄\\n\\n"` | 2 |
+| `"갑\\n\\n을\\n"` | 3 |
+| CRLF 3줄 | 3 |
+| 40줄 픽스처 | 40 |
+
+`text_line_eq` 는 마지막 개행 없는 줄도 읽는다. 빈 파일의 `line=0` 은
+실패다 — 빈 줄을 통과로 위장하지 않는다.
+
+## 픽스처 카탈로그 (단위시험)
+
+`scripts/tests/test_gym_check_pinpoint.py` 가 아래를 코드 상수로 둔다.
+별도 자산 파일은 만들지 않는다 — 파일 연산자 시험이 저장소 픽스처에
+의존하면 pack 과 섞인다.
+
+### `NESTED` JSON
+
+```json
+{
+  "meta": {"schema": "v1", "ok": true, "count": 3},
+  "items": [
+    {"id": 1, "name": "갑", "tags": ["초안", "표"], "qty": 2},
+    {"id": 2, "name": "을", "tags": ["확정"], "qty": 5},
+    {"id": 3, "name": "병", "tags": [], "qty": 0}
+  ],
+  "empty": [],
+  "blank": {},
+  "note": "한 줄 메모",
+  "flag": false,
+  "nil": null,
+  "pi": 3.14
+}
+```
+
+관측:
+
+- 루트 키 8개 → `json_len_eq` path="" value=8
+- `items` 길이 3, `items[0].tags` 길이 2, `items[2].tags` 길이 0
+- `meta.ok` 타입 `boolean`, `nil` 타입 `null`, `pi` 타입 `number`
+- `flag` 에 `json_type_eq` value=`number` 는 실패
+
+### CSV
+
+- `CSV_SIMPLE`: `name,qty,note` + 갑/을/병 3 데이터. 논리 행 4.
+- `CSV_QUOTED`: 따옴표 안 개행. 논리 행 3.
+- `CSV_HANGUL_HEADER`: `이름,수량,비고`.
+- `CSV_WIDE`: 8열.
+- 0..30 행 생성 행렬: 헤더만 있으면 1, 빈 파일은 0.
+
+### NDJSON
+
+- `NDJSON_SIMPLE`: 레코드 3, 사이에 빈 줄·공백 줄.
+- `NDJSON_TYPES`: null/bool/num/str/arr/obj 각 1줄.
+- `NDJSON_BAD`: 가운데 줄 비 JSON.
+- 0..25 레코드 생성 행렬(3의 배수마다 빈 줄 삽입). 빈 줄은 세지 않으므로
+  기대 줄 수는 레코드 수와 같다.
+
+### 텍스트
+
+- `TEXT_SIMPLE`: `첫째\\n둘째\\n셋째` (마지막 개행 없음).
+- `TEXT_CRLF`: CRLF 3줄.
+- `TEXT_BLANK`: 가운데 빈 줄.
+- `TEXT_HANGUL`: `이름: 홍길동` / `수량: 12` / `비고: 없음`.
+- `TEXT_LONG`: `줄00` … `줄39` 40줄. `text_line_eq` 가 각 줄을 맞고, 이웃
+  줄 값과는 불일치.
+
+## 단위시험 지도
+
+| 모듈 | 역할 |
+|---|---|
+| `scripts/tests/test_gym_checks.py` | 1차 6연산자 대표 경로 + REGISTRY/스키마 계약 + pack 스키마 불변 |
+| `scripts/tests/test_gym_check_pinpoint.py` | 1차+후속 좌표 행렬, 유니코드, 예외 카탈로그, CLI 미호출 |
+| `scripts/tests/test_gym_packs.py` | 기존 pack 구조. 연산자 추가만으로는 깨지지 않아야 한다 |
+| `gym/tools/audit.py` | pack 정합. 연산자 PR 은 pack 을 건드리지 않으므로 통과해야 한다 |
+
+`test_gym_checks.SchemaAcceptanceTests` 는 편집 축 pack 에서도 지목
+연산자가 `cmd` 없이 통과하고, `cmd` 를 붙이면 `CLI` 오류가 나는지 본다.
+
+`ExceptionPathCatalogTests.test_missing_file_fails_every_pinpoint_op` 는
+16개 지목 연산자 전부에 대해 빈 제출 폴더를 돌린다. 하나라도 `ok=True` 면
+부재를 통과로 위장한 것이다.
+
+`test_no_cli_on_extra_ops` 는 `runner.run_cli` 를 폭발 스텁으로 갈아끼운다.
+후속 10개 연산자가 스텁을 건드리지 않아야 한다.
+
+## 스키마와의 경계
+
+`validate_task` 는 연산자 필드의 세부를 검사하지 않는다. `op` 가
+`REGISTRY` 에 있고, `needs_cli` 와 `cmd` 의 유무가 맞으면 통과다.
+`row` 가 빠진 `ndjson_field_eq` 는 스키마가 아니라 실행 시
+`KeyError` → 실패로 떨어진다. 과제 작성 실수는 채점에서 드러난다.
+
+이 느슨함은 의도다. 필드 스키마를 과제 JSON 마다 강제하면 연산자 추가가
+스키마 마이그레이션이 된다. 단위시험이 실행 시 예외를 고정한다.
+
+편집 축(`axis` 가 `편집`/`보안`으로 시작)에서 `deep_contains` 는
+`allowGlobalScan` 없이 거절된다. 지목 연산자는 이 축에서도 그대로 통과한다.
+
+## pack 을 건드리지 않는 이유
+
+연산자 PR 에서 기존 과제를 새 연산자로 갈아끼우면 두 가지가  entangle 된다.
+
+1. 판정 어휘의 회귀와 과제 내용의 회귀를 한 커밋에서 구분할 수 없다.
+2. `audit.py` 의 기준 풀이 왕복·ID 고유성 검사가 과제 변경에 민감해진다.
+
+그래서 #5205 계열은 **어휘 + 단위시험 + 문서** 만 넣는다. pack 예시는
+아주 작지 않으면 넣지 않는다. 과제가 새 연산자를 고르는 일은 별 PR 이다.
+
+## CLI 를 부르지 않는 이유
+
+파일 연산자의 존재 이유는 "바이너리 없이 산출물 좌표를 잰다" 다. 추출
+결과를 rhwp 로 다시 뽑아 `value_eq` 하는 길이 이미 있다. JSON/CSV/NDJSON
+산출은 에이전트가 쓴 파일 그 자체이므로, 그 파일을 여는 쪽이 맞다.
+
+`needs_cli=False` 가 아니면 `schema` 가 `cmd` 를 요구하고, CI 의
+unittest 잡이 바이너리를 찾게 된다. 이 checkout 은 crates 없는 작업
+트리에서도 같은 시험을 돌려야 한다.
+
+## 구현 메모
+
+헬퍼는 후속 연산자만 쓴다. 1차 6개는 동작을 고정한 채 그대로 둔다.
+
+- `_require_nonneg_int(name, value)` — `bool` 거절, 음수 거절
+- `_require_str_list(name, value)` — `keys`/`values`
+- `json_type_name(value)` — `bool` 을 `number` 로 부르지 않음
+- `_csv_row_at(path, row)` — `utf-8-sig` + `csv.reader`
+- `_ndjson_record_at(path, row)` — 빈 줄 제외 후 `json.loads`
+- `_text_line_at(path, line)` — `rstrip("\\r\\n")`
+
+`json_len_ge` 의 비교는 `float(actual) >= float(expected)` 다. 숫자
+문자열 하한(`"3"`)을 받는다. `bool` 하한은 `float(True)==1.0` 이 되므로
+권장하지 않는다. 과제는 정수 리터럴을 쓴다.
+
+`csv_header_eq` 는 항상 0번 행을 본다. `row` 필드를 받지 않는다. 헤더가
+두 번째 줄인 변칙 CSV 는 `csv_row_eq` row=1 로 지목한다.
+
+`ndjson_count_eq` 는 JSON 유효성을 보지 않는다. 깨진 줄도 "비어 있지 않은
+줄"이면 센다. 형식까지 보려면 같은 파일에 `ndjson_field_eq` 를 한 줄
+이상 붙인다.
+
+`text_line_contains` 의 빈 needle 은 Python `"" in s` 와 같이 참이다.
+과제가 빈 문자열로 만점을 주지 않게 과제 쪽에서 `value` 를 비우지 않는다.
+
+## 연산자별 필드 치트시트
+
+| op | 필수 | 선택 | 비교 |
+|---|---|---|---|
+| `json_len_eq` | `file`, `value` | `path` | `norm` |
+| `json_len_ge` | `file`, `value` | `path` | `float` 하한 |
+| `json_type_eq` | `file`, `value` | `path` | 문자열 동등 |
+| `json_array_item_eq` | `file`, `index`, `value` | `path` | `norm` |
+| `json_keys_contain` | `file`, `keys` | `path` | 포함 (여분 허용) |
+| `csv_row_count_eq` | `file`, `value` | | `norm` |
+| `csv_col_count_eq` | `file`, `row`, `value` | | `norm` |
+| `csv_header_eq` | `file`, `values` | | 리스트 동등 |
+| `csv_row_eq` | `file`, `row`, `values` | | 리스트 동등 |
+| `ndjson_count_eq` | `file`, `value` | | `norm` |
+| `ndjson_field_eq` | `file`, `row`, `value` | `path` | `norm` |
+| `ndjson_keys_contain` | `file`, `row`, `keys` | `path` | 포함 |
+| `ndjson_len_eq` | `file`, `row`, `value` | `path` | `norm` |
+| `text_line_eq` | `file`, `line`, `value` | | 문자열 동등 |
+| `text_line_contains` | `file`, `line`, `value` | | `in` |
+| `text_line_count_eq` | `file`, `value` | | `norm` |
+
+모든 행에 `name` 을 붙이는 것은 pack 과제 계약이다. 단위시험 픽스처도
+같은 습관을 따른다.
+
+## 잘못된 사용
+
+- **파일 전체를 `deep_contains`.** 추출 JSON 어딘가에 `"3"` 이 있으면
+  통과한다. `json_len_eq` path=`items` value=3 을 쓴다.
+- **`text_line_eq` 로 파일 전체 덤프를 한 줄에 박제.** 개행이 있으면
+  첫 줄만 비교된다. 여러 줄이면 `text_line_eq` 를 줄마다 두거나
+  `text_line_count_eq` 와 짝을 짓는다.
+- **`csv_row_count_eq` 로 따옴표 안 개행을 물리 줄로 셈.** 논리 행을 쓴다.
+- **`ndjson_field_eq` 의 `row` 를 물리 줄 번호로 셈.** 빈 줄은 건너뛴다.
+- **`json_keys_contain` 로 키 부재를 검사.** 이 연산자는 포함만 본다.
+  없어야 하는 키는 별 연산자가 없다. 전역 `not_contains` 로 우회하지
+  말고, 필요한 키만 지목하거나 pack 을 기다린다.
+- **파일 연산자에 `cmd`.** 스키마가 거절한다.
+- **`json_type_eq` value=`int`.** 이름은 `number` 다. JSON 은 int/float
+  구분이 없다.
+
+## 로컬 게이트 (이 PR)
+
+```
+python -m unittest scripts/tests/test_gym_checks.py scripts/tests/test_gym_packs.py
+python -m unittest scripts/tests/test_gym_check_pinpoint.py
+python gym/tools/audit.py
+```
+
+`cargo fmt --all` 은 이 변경이 Python gym 코어·단위시험·문서뿐이라
+돌리지 않는다. crates 가 없는 작업 트리에서도 위 세 명령이면 충분하다.
+
+## 후속 (이 문서의 밖)
+
+- pack 과제가 새 연산자를 고르는 일 — 별 PR, 기준 풀이 왕복 필수
+- `json_keys_eq`(정확 집합), `ndjson_count_ge`, `csv_col_count_ge` 같은
+  대칭 어휘 — 필요가 과제에서 나온 뒤에 추가
+- 스키마가 `row`/`keys` 필수 키를 검증하게 하는 일 — 연산자 추가 비용을
+  올리는 트레이드오프. 지금은 실행 시 실패로 둔다
+
+## 변경 파일
+
+- `gym/core/checks.py` — 후속 10개 연산자 + 헬퍼. 기존 REGISTRY 키 유지
+- `gym/docs/checks.md` — 사람용 목록
+- `mydocs/working/gym_core_checks.md` — 이 기록
+- `scripts/tests/test_gym_checks.py` — 등록 계약 확장
+- `scripts/tests/test_gym_check_pinpoint.py` — 좌표·예외 행렬
+
+pack·profile·PARK.md·다른 gym/tools 는 바꾸지 않았다.

--- a/scripts/tests/test_gym_check_pinpoint.py
+++ b/scripts/tests/test_gym_check_pinpoint.py
@@ -1,0 +1,1284 @@
+"""[#5205] 지목 채점 연산자 — 좌표·예외·유니코드 행렬.
+
+기존 json_len_eq/csv_row_count_eq/ndjson_*/json_keys_contain/text_line_eq 와
+후속 지목 연산자(json_type_eq, json_len_ge, json_array_item_eq, csv_col_count_eq,
+csv_header_eq, csv_row_eq, ndjson_keys_contain, ndjson_len_eq, text_line_count_eq,
+text_line_contains)를 파일 픽스처만으로 판정한다. CLI 는 부르지 않는다.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_core():
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    from gym.core import checks, runner, schema  # noqa: WPS433
+
+    return checks, runner, schema
+
+
+def _write(root, name, content, *, encoding="utf-8", newline="\n"):
+    path = Path(root) / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(content, bytes):
+        path.write_bytes(content)
+        return path
+    with path.open("w", encoding=encoding, newline=newline) as fh:
+        fh.write(content)
+    return path
+
+
+class _OpCase(unittest.TestCase):
+    def eval_files(self, files, check, encoding="utf-8"):
+        _checks, runner, _schema = load_core()
+        with tempfile.TemporaryDirectory() as sub_dir:
+            for name, content in files.items():
+                _write(sub_dir, name, content, encoding=encoding)
+            return runner.eval_check(check, {}, sub_dir, {}, "unused-rhwp")
+
+    def eval_bytes(self, name, payload, check):
+        _checks, runner, _schema = load_core()
+        with tempfile.TemporaryDirectory() as sub_dir:
+            _write(sub_dir, name, payload)
+            return runner.eval_check(check, {}, sub_dir, {}, "unused-rhwp")
+
+
+def _json(obj):
+    return json.dumps(obj, ensure_ascii=False)
+
+
+NESTED = {
+    "meta": {"schema": "v1", "ok": True, "count": 3},
+    "items": [
+        {"id": 1, "name": "갑", "tags": ["초안", "표"], "qty": 2},
+        {"id": 2, "name": "을", "tags": ["확정"], "qty": 5},
+        {"id": 3, "name": "병", "tags": [], "qty": 0},
+    ],
+    "empty": [],
+    "blank": {},
+    "note": "한 줄 메모",
+    "flag": False,
+    "nil": None,
+    "pi": 3.14,
+}
+
+
+class JsonLenEqMatrixTests(_OpCase):
+    FILE = "out.json"
+
+    def _c(self, **kwargs):
+        check = {"name": "len", "op": "json_len_eq", "file": self.FILE, "value": 0}
+        check.update(kwargs)
+        return check
+
+    CASES = [
+        ('root_object_eight_keys', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, '', 8, True, None),
+        ('root_object_wrong', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, '', 5, False, None),
+        ('items_three', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'items', 3, True, None),
+        ('items_wrong', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'items', 2, False, None),
+        ('nested_tags_first', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'items[0].tags', 2, True, None),
+        ('nested_tags_second', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'items[1].tags', 1, True, None),
+        ('nested_tags_empty', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'items[2].tags', 0, True, None),
+        ('empty_array', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'empty', 0, True, None),
+        ('empty_object', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'blank', 0, True, None),
+        ('meta_object', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'meta', 3, True, None),
+        ('numeric_string', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'items', '3', True, None),
+        ('float_string', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'items', '3.0', True, None),
+        ('missing_key', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'gone', 0, False, '실패'),
+        ('scalar_string', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'note', 1, False, '실패'),
+        ('scalar_number', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'pi', 1, False, '실패'),
+        ('scalar_bool', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'flag', 1, False, '실패'),
+        ('scalar_null', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'nil', 0, False, '실패'),
+        ('index_oob', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'items[9]', 0, False, '실패'),
+        ('index_on_object', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'meta[0]', 0, False, '실패'),
+        ('deep_missing', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'items[0].missing', 0, False, '실패'),
+        ('array_len_0', {'xs': []}, 'xs', 0, True, None),
+        ('array_len_1', {'xs': [0]}, 'xs', 1, True, None),
+        ('array_len_2', {'xs': [0, 1]}, 'xs', 2, True, None),
+        ('array_len_3', {'xs': [0, 1, 2]}, 'xs', 3, True, None),
+        ('array_len_4', {'xs': [0, 1, 2, 3]}, 'xs', 4, True, None),
+        ('array_len_5', {'xs': [0, 1, 2, 3, 4]}, 'xs', 5, True, None),
+        ('array_len_6', {'xs': [0, 1, 2, 3, 4, 5]}, 'xs', 6, True, None),
+        ('array_len_7', {'xs': [0, 1, 2, 3, 4, 5, 6]}, 'xs', 7, True, None),
+        ('array_len_8', {'xs': [0, 1, 2, 3, 4, 5, 6, 7]}, 'xs', 8, True, None),
+        ('array_len_9', {'xs': [0, 1, 2, 3, 4, 5, 6, 7, 8]}, 'xs', 9, True, None),
+        ('array_len_10', {'xs': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}, 'xs', 10, True, None),
+        ('array_len_11', {'xs': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}, 'xs', 11, True, None),
+        ('array_len_12', {'xs': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]}, 'xs', 12, True, None),
+        ('array_len_13', {'xs': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]}, 'xs', 13, True, None),
+        ('array_len_14', {'xs': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]}, 'xs', 14, True, None),
+        ('array_len_15', {'xs': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]}, 'xs', 15, True, None),
+        ('array_len_16', {'xs': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]}, 'xs', 16, True, None),
+        ('array_len_17', {'xs': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]}, 'xs', 17, True, None),
+        ('array_len_18', {'xs': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]}, 'xs', 18, True, None),
+        ('array_len_19', {'xs': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]}, 'xs', 19, True, None),
+        ('array_len_20', {'xs': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]}, 'xs', 20, True, None),
+        ('object_len_0', {}, '', 0, True, None),
+        ('object_len_1', {'k0': 0}, '', 1, True, None),
+        ('object_len_2', {'k0': 0, 'k1': 1}, '', 2, True, None),
+        ('object_len_5', {'k0': 0, 'k1': 1, 'k2': 2, 'k3': 3, 'k4': 4}, '', 5, True, None),
+        ('object_len_8', {'k0': 0, 'k1': 1, 'k2': 2, 'k3': 3, 'k4': 4, 'k5': 5, 'k6': 6, 'k7': 7}, '', 8, True, None),
+        ('object_len_13', {'k0': 0, 'k1': 1, 'k2': 2, 'k3': 3, 'k4': 4, 'k5': 5, 'k6': 6, 'k7': 7, 'k8': 8, 'k9': 9, 'k10': 10, 'k11': 11, 'k12': 12}, '', 13, True, None),
+        ('object_len_21', {'k0': 0, 'k1': 1, 'k2': 2, 'k3': 3, 'k4': 4, 'k5': 5, 'k6': 6, 'k7': 7, 'k8': 8, 'k9': 9, 'k10': 10, 'k11': 11, 'k12': 12, 'k13': 13, 'k14': 14, 'k15': 15, 'k16': 16, 'k17': 17, 'k18': 18, 'k19': 19, 'k20': 20}, '', 21, True, None),
+        ('hangul_keys', {'이름': 1, '수량': 2, '비고': 3}, '', 3, True, None),
+        ('hangul_array', {'항목': ['가', '나', '다', '라']}, '항목', 4, True, None),
+        ('mixed_unicode', {'name': '이름', '태그': ['α', 'β']}, '태그', 2, True, None),
+        ('emoji_keys', {'✅': 1, '❌': 0}, '', 2, True, None),
+    ]
+
+    def test_matrix(self):
+        for name, obj, path, value, ok, needle in self.CASES:
+            with self.subTest(name):
+                detail = self.eval_files({self.FILE: _json(obj)}, self._c(path=path, value=value))
+                self.assertEqual(detail["ok"], ok, (name, detail))
+                if needle:
+                    self.assertIn(needle, str(detail["actual"]))
+
+    def test_bad_json_variants_fail(self):
+        for name, body in (
+            ("empty", ""),
+            ("spaces", "   \n"),
+            ("truncated", '{"a":'),
+            ("trailing_comma", '{"a":1,}'),
+            ("single_quotes", "{'a': 1}"),
+            ("not_json", "items=3"),
+            ("array_then_junk", "[1,2] junk"),
+            ("nan", "NaN"),
+            ("undefined", "undefined"),
+        ):
+            with self.subTest(name):
+                detail = self.eval_files({self.FILE: body}, self._c(path="", value=0))
+                self.assertFalse(detail["ok"], (name, detail))
+                self.assertIn("실패", str(detail["actual"]))
+
+    def test_missing_file_and_invalid_utf8(self):
+        detail = self.eval_files({}, self._c())
+        self.assertFalse(detail["ok"], detail)
+        detail = self.eval_bytes(self.FILE, b"\xff\xfe not utf8", self._c())
+        self.assertFalse(detail["ok"], detail)
+
+    def test_bool_false_does_not_match_nonzero_length(self):
+        detail = self.eval_files({self.FILE: _json([1, 2])}, self._c(path="", value=False))
+        self.assertFalse(detail["ok"], detail)
+
+
+class JsonTypeEqTests(_OpCase):
+    FILE = "out.json"
+
+    def _c(self, **kwargs):
+        check = {"name": "typ", "op": "json_type_eq", "file": self.FILE, "value": "object"}
+        check.update(kwargs)
+        return check
+
+    CASES = [
+        ('root_object', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, '', 'object', True),
+        ('items_array', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'items', 'array', True),
+        ('meta_object', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'meta', 'object', True),
+        ('note_string', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'note', 'string', True),
+        ('flag_bool', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'flag', 'boolean', True),
+        ('ok_bool', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'meta.ok', 'boolean', True),
+        ('count_number', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'meta.count', 'number', True),
+        ('pi_number', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'pi', 'number', True),
+        ('nil_null', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'nil', 'null', True),
+        ('first_name', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'items[0].name', 'string', True),
+        ('first_qty', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'items[0].qty', 'number', True),
+        ('tags_array', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'items[0].tags', 'array', True),
+        ('empty_array', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'empty', 'array', True),
+        ('empty_object', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'blank', 'object', True),
+        ('wrong_type', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'note', 'number', False),
+        ('bool_not_number', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'flag', 'number', False),
+        ('null_not_object', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'nil', 'object', False),
+        ('string_not_array', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'note', 'array', False),
+        ('missing', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'gone', 'object', False),
+        ('zero_number', {'n': 0}, 'n', 'number', True),
+        ('neg_number', {'n': -3}, 'n', 'number', True),
+        ('empty_string', {'s': ''}, 's', 'string', True),
+        ('true_bool', {'b': True}, 'b', 'boolean', True),
+        ('false_bool', {'b': False}, 'b', 'boolean', True),
+        ('nested_null', {'a': {'b': None}}, 'a.b', 'null', True),
+        ('list_of_null', {'xs': [None]}, 'xs[0]', 'null', True),
+    ]
+
+    def test_matrix(self):
+        for name, obj, path, value, ok in self.CASES:
+            with self.subTest(name):
+                detail = self.eval_files({self.FILE: _json(obj)}, self._c(path=path, value=value))
+                self.assertEqual(detail["ok"], ok, (name, detail))
+
+    def test_non_string_expected_fails(self):
+        detail = self.eval_files({self.FILE: _json({"a": 1})}, self._c(value=1))
+        self.assertFalse(detail["ok"], detail)
+
+    def test_bad_json_fails(self):
+        detail = self.eval_files({self.FILE: "{"}, self._c())
+        self.assertFalse(detail["ok"], detail)
+
+    def test_missing_file_fails(self):
+        detail = self.eval_files({}, self._c())
+        self.assertFalse(detail["ok"], detail)
+
+
+class JsonLenGeTests(_OpCase):
+    FILE = "out.json"
+
+    def _c(self, **kwargs):
+        check = {"name": "ge", "op": "json_len_ge", "file": self.FILE, "value": 1}
+        check.update(kwargs)
+        return check
+
+    CASES = [
+        ('arr_0_ge_0', {'xs': []}, 'xs', 0, True),
+        ('arr_0_ge_1', {'xs': []}, 'xs', 1, False),
+        ('arr_1_ge_1', {'xs': [0]}, 'xs', 1, True),
+        ('arr_1_ge_0', {'xs': [0]}, 'xs', 0, True),
+        ('arr_3_ge_3', {'xs': [0, 1, 2]}, 'xs', 3, True),
+        ('arr_3_ge_4', {'xs': [0, 1, 2]}, 'xs', 4, False),
+        ('arr_5_ge_5', {'xs': [0, 1, 2, 3, 4]}, 'xs', 5, True),
+        ('arr_5_ge_2', {'xs': [0, 1, 2, 3, 4]}, 'xs', 2, True),
+        ('arr_8_ge_8', {'xs': [0, 1, 2, 3, 4, 5, 6, 7]}, 'xs', 8, True),
+        ('arr_8_ge_9', {'xs': [0, 1, 2, 3, 4, 5, 6, 7]}, 'xs', 9, False),
+        ('arr_13_ge_10', {'xs': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]}, 'xs', 10, True),
+        ('arr_21_ge_21', {'xs': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]}, 'xs', 21, True),
+        ('arr_21_ge_22', {'xs': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]}, 'xs', 22, False),
+        ('obj_0_ge_0', {}, '', 0, True),
+        ('obj_2_ge_2', {'k0': 0, 'k1': 1}, '', 2, True),
+        ('obj_2_ge_3', {'k0': 0, 'k1': 1}, '', 3, False),
+        ('obj_4_ge_1', {'k0': 0, 'k1': 1, 'k2': 2, 'k3': 3}, '', 1, True),
+        ('items_ge_3', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'items', 3, True),
+        ('items_ge_4', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'items', 4, False),
+        ('tags_ge_2', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'items[0].tags', 2, True),
+        ('tags_ge_3', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'items[0].tags', 3, False),
+        ('empty_ge_0', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'empty', 0, True),
+        ('empty_ge_1', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'empty', 1, False),
+        ('scalar_fails', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'note', 1, False),
+        ('missing_fails', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'gone', 0, False),
+    ]
+
+    def test_matrix(self):
+        for name, obj, path, value, ok in self.CASES:
+            with self.subTest(name):
+                detail = self.eval_files({self.FILE: _json(obj)}, self._c(path=path, value=value))
+                self.assertEqual(detail["ok"], ok, (name, detail))
+
+    def test_numeric_string_bound(self):
+        detail = self.eval_files({self.FILE: _json({"xs": [1, 2]})}, self._c(path="xs", value="2"))
+        self.assertTrue(detail["ok"], detail)
+
+    def test_missing_file_fails(self):
+        detail = self.eval_files({}, self._c())
+        self.assertFalse(detail["ok"], detail)
+
+
+class JsonArrayItemEqTests(_OpCase):
+    FILE = "out.json"
+
+    def _c(self, **kwargs):
+        check = {"name": "item", "op": "json_array_item_eq", "file": self.FILE,
+                 "index": 0, "value": 1}
+        check.update(kwargs)
+        return check
+
+    CASES = [
+        ('first_int', {'xs': [10, 20, 30]}, 'xs', 0, 10, True),
+        ('second_int', {'xs': [10, 20, 30]}, 'xs', 1, 20, True),
+        ('third_int', {'xs': [10, 20, 30]}, 'xs', 2, 30, True),
+        ('wrong_value', {'xs': [10, 20, 30]}, 'xs', 1, 99, False),
+        ('numeric_string', {'xs': [10, 20]}, 'xs', 0, '10', True),
+        ('hangul', {'xs': ['갑', '을', '병']}, 'xs', 1, '을', True),
+        ('bool_true', {'xs': [True, False]}, 'xs', 0, True, True),
+        ('bool_false', {'xs': [True, False]}, 'xs', 1, False, True),
+        ('null_item', {'xs': [None]}, 'xs', 0, None, True),
+        ('nested_object_eq', {'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}]}, 'items', 1, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, True),
+        ('index_oob', {'xs': [1]}, 'xs', 3, 1, False),
+        ('not_array', {'xs': {'a': 1}}, 'xs', 0, 1, False),
+        ('root_array', [7, 8, 9], '', 2, 9, True),
+        ('empty_array_oob', {'xs': []}, 'xs', 0, None, False),
+        ('missing_path', {'xs': [1]}, 'gone', 0, 1, False),
+        ('hangul_idx_0', {'xs': ['가', '나', '다', '라', '마', '바', '사']}, 'xs', 0, '가', True),
+        ('hangul_idx_1', {'xs': ['가', '나', '다', '라', '마', '바', '사']}, 'xs', 1, '나', True),
+        ('hangul_idx_2', {'xs': ['가', '나', '다', '라', '마', '바', '사']}, 'xs', 2, '다', True),
+        ('hangul_idx_3', {'xs': ['가', '나', '다', '라', '마', '바', '사']}, 'xs', 3, '라', True),
+        ('hangul_idx_4', {'xs': ['가', '나', '다', '라', '마', '바', '사']}, 'xs', 4, '마', True),
+        ('hangul_idx_5', {'xs': ['가', '나', '다', '라', '마', '바', '사']}, 'xs', 5, '바', True),
+        ('hangul_idx_6', {'xs': ['가', '나', '다', '라', '마', '바', '사']}, 'xs', 6, '사', True),
+    ]
+
+    def test_matrix(self):
+        for name, obj, path, index, value, ok in self.CASES:
+            with self.subTest(name):
+                detail = self.eval_files(
+                    {self.FILE: _json(obj)},
+                    self._c(path=path, index=index, value=value),
+                )
+                self.assertEqual(detail["ok"], ok, (name, detail))
+
+    def test_bool_index_rejected(self):
+        detail = self.eval_files({self.FILE: _json([1, 2])}, self._c(path="", index=True, value=2))
+        self.assertFalse(detail["ok"], detail)
+        self.assertIn("정수", str(detail["actual"]))
+
+    def test_negative_index_rejected(self):
+        detail = self.eval_files({self.FILE: _json([1, 2])}, self._c(path="", index=-1, value=2))
+        self.assertFalse(detail["ok"], detail)
+        self.assertIn("음수", str(detail["actual"]))
+
+    def test_missing_file_fails(self):
+        detail = self.eval_files({}, self._c())
+        self.assertFalse(detail["ok"], detail)
+
+
+class JsonKeysContainExtraTests(_OpCase):
+    FILE = "out.json"
+
+    def _c(self, **kwargs):
+        check = {"name": "keys", "op": "json_keys_contain", "file": self.FILE, "keys": ["id"]}
+        check.update(kwargs)
+        return check
+
+    CASES = [
+        ('all_present', {'id': 1, 'name': '갑', 'qty': 2}, '', ['id', 'name'], True),
+        ('one_missing', {'id': 1, 'qty': 2}, '', ['id', 'name'], False),
+        ('empty_required_ok', {'id': 1}, '', [], True),
+        ('empty_object_missing', {}, '', ['id'], False),
+        ('nested_meta', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'meta', ['schema', 'ok'], True),
+        ('nested_item', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'items[0]', ['id', 'name', 'tags'], True),
+        ('nested_item_missing', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'items[0]', ['id', 'gone'], False),
+        ('hangul_keys', {'이름': '갑', '수량': 1}, '', ['이름'], True),
+        ('hangul_missing', {'이름': '갑'}, '', ['수량'], False),
+        ('unicode_mixed', {'id': 1, '이름': '을'}, '', ['id', '이름'], True),
+        ('path_array_fails', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'items', ['id'], False),
+        ('path_scalar_fails', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'note', ['id'], False),
+        ('missing_path', {'meta': {'schema': 'v1', 'ok': True, 'count': 3}, 'items': [{'id': 1, 'name': '갑', 'tags': ['초안', '표'], 'qty': 2}, {'id': 2, 'name': '을', 'tags': ['확정'], 'qty': 5}, {'id': 3, 'name': '병', 'tags': [], 'qty': 0}], 'empty': [], 'blank': {}, 'note': '한 줄 메모', 'flag': False, 'nil': None, 'pi': 3.14}, 'gone', ['id'], False),
+        ('has_f00', {'f00': 0, 'f01': 1, 'f02': 2, 'f03': 3, 'f04': 4, 'f05': 5, 'f06': 6, 'f07': 7, 'f08': 8, 'f09': 9, 'f10': 10, 'f11': 11, 'f12': 12, 'f13': 13, 'f14': 14, 'f15': 15}, '', ['f00'], True),
+        ('has_f01', {'f00': 0, 'f01': 1, 'f02': 2, 'f03': 3, 'f04': 4, 'f05': 5, 'f06': 6, 'f07': 7, 'f08': 8, 'f09': 9, 'f10': 10, 'f11': 11, 'f12': 12, 'f13': 13, 'f14': 14, 'f15': 15}, '', ['f01'], True),
+        ('has_f02', {'f00': 0, 'f01': 1, 'f02': 2, 'f03': 3, 'f04': 4, 'f05': 5, 'f06': 6, 'f07': 7, 'f08': 8, 'f09': 9, 'f10': 10, 'f11': 11, 'f12': 12, 'f13': 13, 'f14': 14, 'f15': 15}, '', ['f02'], True),
+        ('has_f03', {'f00': 0, 'f01': 1, 'f02': 2, 'f03': 3, 'f04': 4, 'f05': 5, 'f06': 6, 'f07': 7, 'f08': 8, 'f09': 9, 'f10': 10, 'f11': 11, 'f12': 12, 'f13': 13, 'f14': 14, 'f15': 15}, '', ['f03'], True),
+        ('has_f04', {'f00': 0, 'f01': 1, 'f02': 2, 'f03': 3, 'f04': 4, 'f05': 5, 'f06': 6, 'f07': 7, 'f08': 8, 'f09': 9, 'f10': 10, 'f11': 11, 'f12': 12, 'f13': 13, 'f14': 14, 'f15': 15}, '', ['f04'], True),
+        ('has_f05', {'f00': 0, 'f01': 1, 'f02': 2, 'f03': 3, 'f04': 4, 'f05': 5, 'f06': 6, 'f07': 7, 'f08': 8, 'f09': 9, 'f10': 10, 'f11': 11, 'f12': 12, 'f13': 13, 'f14': 14, 'f15': 15}, '', ['f05'], True),
+        ('has_f06', {'f00': 0, 'f01': 1, 'f02': 2, 'f03': 3, 'f04': 4, 'f05': 5, 'f06': 6, 'f07': 7, 'f08': 8, 'f09': 9, 'f10': 10, 'f11': 11, 'f12': 12, 'f13': 13, 'f14': 14, 'f15': 15}, '', ['f06'], True),
+        ('has_f07', {'f00': 0, 'f01': 1, 'f02': 2, 'f03': 3, 'f04': 4, 'f05': 5, 'f06': 6, 'f07': 7, 'f08': 8, 'f09': 9, 'f10': 10, 'f11': 11, 'f12': 12, 'f13': 13, 'f14': 14, 'f15': 15}, '', ['f07'], True),
+        ('has_f08', {'f00': 0, 'f01': 1, 'f02': 2, 'f03': 3, 'f04': 4, 'f05': 5, 'f06': 6, 'f07': 7, 'f08': 8, 'f09': 9, 'f10': 10, 'f11': 11, 'f12': 12, 'f13': 13, 'f14': 14, 'f15': 15}, '', ['f08'], True),
+        ('has_f09', {'f00': 0, 'f01': 1, 'f02': 2, 'f03': 3, 'f04': 4, 'f05': 5, 'f06': 6, 'f07': 7, 'f08': 8, 'f09': 9, 'f10': 10, 'f11': 11, 'f12': 12, 'f13': 13, 'f14': 14, 'f15': 15}, '', ['f09'], True),
+        ('has_f10', {'f00': 0, 'f01': 1, 'f02': 2, 'f03': 3, 'f04': 4, 'f05': 5, 'f06': 6, 'f07': 7, 'f08': 8, 'f09': 9, 'f10': 10, 'f11': 11, 'f12': 12, 'f13': 13, 'f14': 14, 'f15': 15}, '', ['f10'], True),
+        ('has_f11', {'f00': 0, 'f01': 1, 'f02': 2, 'f03': 3, 'f04': 4, 'f05': 5, 'f06': 6, 'f07': 7, 'f08': 8, 'f09': 9, 'f10': 10, 'f11': 11, 'f12': 12, 'f13': 13, 'f14': 14, 'f15': 15}, '', ['f11'], True),
+        ('has_f12', {'f00': 0, 'f01': 1, 'f02': 2, 'f03': 3, 'f04': 4, 'f05': 5, 'f06': 6, 'f07': 7, 'f08': 8, 'f09': 9, 'f10': 10, 'f11': 11, 'f12': 12, 'f13': 13, 'f14': 14, 'f15': 15}, '', ['f12'], True),
+        ('has_f13', {'f00': 0, 'f01': 1, 'f02': 2, 'f03': 3, 'f04': 4, 'f05': 5, 'f06': 6, 'f07': 7, 'f08': 8, 'f09': 9, 'f10': 10, 'f11': 11, 'f12': 12, 'f13': 13, 'f14': 14, 'f15': 15}, '', ['f13'], True),
+        ('has_f14', {'f00': 0, 'f01': 1, 'f02': 2, 'f03': 3, 'f04': 4, 'f05': 5, 'f06': 6, 'f07': 7, 'f08': 8, 'f09': 9, 'f10': 10, 'f11': 11, 'f12': 12, 'f13': 13, 'f14': 14, 'f15': 15}, '', ['f14'], True),
+        ('has_f15', {'f00': 0, 'f01': 1, 'f02': 2, 'f03': 3, 'f04': 4, 'f05': 5, 'f06': 6, 'f07': 7, 'f08': 8, 'f09': 9, 'f10': 10, 'f11': 11, 'f12': 12, 'f13': 13, 'f14': 14, 'f15': 15}, '', ['f15'], True),
+    ]
+
+    def test_matrix(self):
+        for name, obj, path, keys, ok in self.CASES:
+            with self.subTest(name):
+                detail = self.eval_files({self.FILE: _json(obj)}, self._c(path=path, keys=keys))
+                self.assertEqual(detail["ok"], ok, (name, detail))
+
+    def test_keys_must_be_string_list(self):
+        for keys in ("id", ["id", 1], {"id": True}, None, [None]):
+            with self.subTest(keys=keys):
+                detail = self.eval_files({self.FILE: _json({"id": 1})}, self._c(keys=keys))
+                self.assertFalse(detail["ok"], detail)
+
+
+CSV_SIMPLE = "name,qty,note\n갑,1,초안\n을,2,확정\n병,3,\n"
+CSV_QUOTED = 'name,note\n"갑","여러\n줄"\n을,단줄\n'
+CSV_BOM_BODY = "name,qty\n갑,1\n을,2\n"
+CSV_EMPTY_TRAIL = "a,b\n1,2\n\n"
+CSV_WIDE = "c0,c1,c2,c3,c4,c5,c6,c7\n" + ",".join(str(i) for i in range(8)) + "\n"
+CSV_HANGUL_HEADER = "이름,수량,비고\n사과,10,특\n배,4,보통\n"
+
+
+class CsvRowCountEqMatrixTests(_OpCase):
+    FILE = "out.csv"
+
+    def _c(self, value):
+        return {"name": "rows", "op": "csv_row_count_eq", "file": self.FILE, "value": value}
+
+    CASES = [
+        ('simple_four', 'name,qty,note\n갑,1,초안\n을,2,확정\n병,3,\n', 4, True),
+        ('simple_wrong', 'name,qty,note\n갑,1,초안\n을,2,확정\n병,3,\n', 3, False),
+        ('quoted_multiline_three', 'name,note\n"갑","여러\n줄"\n을,단줄\n', 3, True),
+        ('empty_zero', '', 0, True),
+        ('empty_nonzero', '', 1, False),
+        ('header_only', 'name,qty\\n', 1, True),
+        ('wide_two', 'c0,c1,c2,c3,c4,c5,c6,c7\n0,1,2,3,4,5,6,7\n', 2, True),
+        ('hangul_three', '이름,수량,비고\n사과,10,특\n배,4,보통\n', 3, True),
+        ('numeric_string', 'name,qty,note\n갑,1,초안\n을,2,확정\n병,3,\n', '4', True),
+        ('n_rows_0', '', 0, True),
+        ('n_rows_1', 'h\n', 1, True),
+        ('n_rows_2', 'h\n0\n', 2, True),
+        ('n_rows_3', 'h\n0\n1\n', 3, True),
+        ('n_rows_4', 'h\n0\n1\n2\n', 4, True),
+        ('n_rows_5', 'h\n0\n1\n2\n3\n', 5, True),
+        ('n_rows_6', 'h\n0\n1\n2\n3\n4\n', 6, True),
+        ('n_rows_7', 'h\n0\n1\n2\n3\n4\n5\n', 7, True),
+        ('n_rows_8', 'h\n0\n1\n2\n3\n4\n5\n6\n', 8, True),
+        ('n_rows_9', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n', 9, True),
+        ('n_rows_10', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n8\n', 10, True),
+        ('n_rows_11', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n', 11, True),
+        ('n_rows_12', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n', 12, True),
+        ('n_rows_13', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n', 13, True),
+        ('n_rows_14', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n', 14, True),
+        ('n_rows_15', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n', 15, True),
+        ('n_rows_16', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n', 16, True),
+        ('n_rows_17', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n', 17, True),
+        ('n_rows_18', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n', 18, True),
+        ('n_rows_19', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n', 19, True),
+        ('n_rows_20', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n', 20, True),
+        ('n_rows_21', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n', 21, True),
+        ('n_rows_22', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n', 22, True),
+        ('n_rows_23', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n', 23, True),
+        ('n_rows_24', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n', 24, True),
+        ('n_rows_25', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n', 25, True),
+        ('n_rows_26', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n', 26, True),
+        ('n_rows_27', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n', 27, True),
+        ('n_rows_28', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n', 28, True),
+        ('n_rows_29', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n', 29, True),
+        ('n_rows_30', 'h\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28\n', 30, True),
+    ]
+
+    def test_matrix(self):
+        for name, body, value, ok in self.CASES:
+            with self.subTest(name):
+                detail = self.eval_files({self.FILE: body}, self._c(value))
+                self.assertEqual(detail["ok"], ok, (name, detail))
+
+    def test_utf8_sig_does_not_add_row(self):
+        detail = self.eval_files({self.FILE: CSV_BOM_BODY}, self._c(3), encoding="utf-8-sig")
+        self.assertTrue(detail["ok"], detail)
+        self.assertEqual(detail["actual"], 3)
+
+    def test_crlf_same_as_lf(self):
+        body = "a,b\r\n1,2\r\n3,4\r\n"
+        detail = self.eval_files({self.FILE: body}, self._c(3))
+        self.assertTrue(detail["ok"], detail)
+
+    def test_missing_file_and_invalid_utf8(self):
+        self.assertFalse(self.eval_files({}, self._c(1))["ok"])
+        self.assertFalse(self.eval_bytes(self.FILE, b"\xff\xfe a,b\n", self._c(1))["ok"])
+
+
+class CsvColCountEqTests(_OpCase):
+    FILE = "out.csv"
+
+    def _c(self, **kwargs):
+        check = {"name": "cols", "op": "csv_col_count_eq", "file": self.FILE, "row": 0, "value": 3}
+        check.update(kwargs)
+        return check
+
+    CASES = [
+        ('header_three', 'name,qty,note\n갑,1,초안\n을,2,확정\n병,3,\n', 0, 3, True),
+        ('data_three', 'name,qty,note\n갑,1,초안\n을,2,확정\n병,3,\n', 1, 3, True),
+        ('wrong', 'name,qty,note\n갑,1,초안\n을,2,확정\n병,3,\n', 0, 2, False),
+        ('wide_eight', 'c0,c1,c2,c3,c4,c5,c6,c7\n0,1,2,3,4,5,6,7\n', 0, 8, True),
+        ('wide_data', 'c0,c1,c2,c3,c4,c5,c6,c7\n0,1,2,3,4,5,6,7\n', 1, 8, True),
+        ('quoted_two', 'name,note\n"갑","여러\n줄"\n을,단줄\n', 0, 2, True),
+        ('quoted_data', 'name,note\n"갑","여러\n줄"\n을,단줄\n', 1, 2, True),
+        ('row_oob', 'name,qty,note\n갑,1,초안\n을,2,확정\n병,3,\n', 9, 3, False),
+        ('neg_row', 'name,qty,note\n갑,1,초안\n을,2,확정\n병,3,\n', -1, 3, False),
+        ('hangul_three', '이름,수량,비고\n사과,10,특\n배,4,보통\n', 0, 3, True),
+        ('simple_row_0_cols', 'name,qty,note\n갑,1,초안\n을,2,확정\n병,3,\n', 0, 3, True),
+        ('simple_row_1_cols', 'name,qty,note\n갑,1,초안\n을,2,확정\n병,3,\n', 1, 3, True),
+        ('simple_row_2_cols', 'name,qty,note\n갑,1,초안\n을,2,확정\n병,3,\n', 2, 3, True),
+        ('simple_row_3_cols', 'name,qty,note\n갑,1,초안\n을,2,확정\n병,3,\n', 3, 3, True),
+    ]
+
+    def test_matrix(self):
+        for name, body, row, value, ok in self.CASES:
+            with self.subTest(name):
+                detail = self.eval_files({self.FILE: body}, self._c(row=row, value=value))
+                self.assertEqual(detail["ok"], ok, (name, detail))
+
+    def test_bool_row_rejected(self):
+        detail = self.eval_files({self.FILE: CSV_SIMPLE}, self._c(row=True, value=3))
+        self.assertFalse(detail["ok"], detail)
+
+    def test_empty_file_fails(self):
+        detail = self.eval_files({self.FILE: ""}, self._c(row=0, value=0))
+        self.assertFalse(detail["ok"], detail)
+
+    def test_missing_file_fails(self):
+        self.assertFalse(self.eval_files({}, self._c())["ok"])
+
+
+class CsvHeaderAndRowEqTests(_OpCase):
+    FILE = "out.csv"
+
+    def test_header_match(self):
+        detail = self.eval_files(
+            {self.FILE: CSV_SIMPLE},
+            {"name": "h", "op": "csv_header_eq", "file": self.FILE,
+             "values": ["name", "qty", "note"]},
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_header_mismatch(self):
+        detail = self.eval_files(
+            {self.FILE: CSV_SIMPLE},
+            {"name": "h", "op": "csv_header_eq", "file": self.FILE,
+             "values": ["name", "qty"]},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_header_hangul(self):
+        detail = self.eval_files(
+            {self.FILE: CSV_HANGUL_HEADER},
+            {"name": "h", "op": "csv_header_eq", "file": self.FILE,
+             "values": ["이름", "수량", "비고"]},
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_header_empty_file_fails(self):
+        detail = self.eval_files(
+            {self.FILE: ""},
+            {"name": "h", "op": "csv_header_eq", "file": self.FILE, "values": []},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_header_values_must_be_str_list(self):
+        detail = self.eval_files(
+            {self.FILE: CSV_SIMPLE},
+            {"name": "h", "op": "csv_header_eq", "file": self.FILE, "values": "name"},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_row_eq_match(self):
+        detail = self.eval_files(
+            {self.FILE: CSV_SIMPLE},
+            {"name": "r", "op": "csv_row_eq", "file": self.FILE, "row": 1,
+             "values": ["갑", "1", "초안"]},
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_row_eq_second_data(self):
+        detail = self.eval_files(
+            {self.FILE: CSV_SIMPLE},
+            {"name": "r", "op": "csv_row_eq", "file": self.FILE, "row": 2,
+             "values": ["을", "2", "확정"]},
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_row_eq_empty_note(self):
+        detail = self.eval_files(
+            {self.FILE: CSV_SIMPLE},
+            {"name": "r", "op": "csv_row_eq", "file": self.FILE, "row": 3,
+             "values": ["병", "3", ""]},
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_row_eq_mismatch(self):
+        detail = self.eval_files(
+            {self.FILE: CSV_SIMPLE},
+            {"name": "r", "op": "csv_row_eq", "file": self.FILE, "row": 1,
+             "values": ["갑", "9", "초안"]},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_row_eq_oob(self):
+        detail = self.eval_files(
+            {self.FILE: CSV_SIMPLE},
+            {"name": "r", "op": "csv_row_eq", "file": self.FILE, "row": 9,
+             "values": ["갑", "1", "초안"]},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_row_eq_negative(self):
+        detail = self.eval_files(
+            {self.FILE: CSV_SIMPLE},
+            {"name": "r", "op": "csv_row_eq", "file": self.FILE, "row": -1,
+             "values": ["name", "qty", "note"]},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_row_eq_bool_row(self):
+        detail = self.eval_files(
+            {self.FILE: CSV_SIMPLE},
+            {"name": "r", "op": "csv_row_eq", "file": self.FILE, "row": False,
+             "values": ["name", "qty", "note"]},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_quoted_multiline_row(self):
+        detail = self.eval_files(
+            {self.FILE: CSV_QUOTED},
+            {"name": "r", "op": "csv_row_eq", "file": self.FILE, "row": 1,
+             "values": ["갑", "여러\n줄"]},
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_header_missing_file(self):
+        detail = self.eval_files(
+            {},
+            {"name": "h", "op": "csv_header_eq", "file": self.FILE, "values": ["a"]},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+
+NDJSON_SIMPLE = (
+    '{"id":1,"name":"갑","tags":["초안","표"],"qty":2}\n'
+    '\n'
+    '{"id":2,"name":"을","tags":["확정"],"qty":5}\n'
+    '  \n'
+    '{"id":3,"name":"병","tags":[],"qty":0}\n'
+)
+NDJSON_TYPES = (
+    '{"kind":"null","v":null}\n'
+    '{"kind":"bool","v":true}\n'
+    '{"kind":"num","v":3.14}\n'
+    '{"kind":"str","v":"한글"}\n'
+    '{"kind":"arr","v":[1,2,3]}\n'
+    '{"kind":"obj","v":{"a":1,"b":2}}\n'
+)
+NDJSON_BAD = '{"id":1}\n{not-json\n{"id":3}\n'
+
+
+class NdjsonCountEqMatrixTests(_OpCase):
+    FILE = "out.ndjson"
+
+    def _c(self, value):
+        return {"name": "n", "op": "ndjson_count_eq", "file": self.FILE, "value": value}
+
+    CASES = [
+        ('simple_three', '{"id":1,"name":"갑","tags":["초안","표"],"qty":2}\n\n{"id":2,"name":"을","tags":["확정"],"qty":5}\n  \n{"id":3,"name":"병","tags":[],"qty":0}\n', 3, True),
+        ('simple_wrong', '{"id":1,"name":"갑","tags":["초안","표"],"qty":2}\n\n{"id":2,"name":"을","tags":["확정"],"qty":5}\n  \n{"id":3,"name":"병","tags":[],"qty":0}\n', 4, False),
+        ('types_six', '{"kind":"null","v":null}\n{"kind":"bool","v":true}\n{"kind":"num","v":3.14}\n{"kind":"str","v":"한글"}\n{"kind":"arr","v":[1,2,3]}\n{"kind":"obj","v":{"a":1,"b":2}}\n', 6, True),
+        ('empty_zero', '', 0, True),
+        ('only_blank', '\n\n  \n', 0, True),
+        ('numeric_string', '{"id":1,"name":"갑","tags":["초안","표"],"qty":2}\n\n{"id":2,"name":"을","tags":["확정"],"qty":5}\n  \n{"id":3,"name":"병","tags":[],"qty":0}\n', '3', True),
+        ('n_records_0', '', 0, True),
+        ('n_records_1', '{"i":0}\n\n', 1, True),
+        ('n_records_2', '{"i":0}\n\n{"i":1}\n', 2, True),
+        ('n_records_3', '{"i":0}\n\n{"i":1}\n{"i":2}\n', 3, True),
+        ('n_records_4', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n', 4, True),
+        ('n_records_5', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n{"i":4}\n', 5, True),
+        ('n_records_6', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n{"i":4}\n{"i":5}\n', 6, True),
+        ('n_records_7', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n{"i":4}\n{"i":5}\n{"i":6}\n\n', 7, True),
+        ('n_records_8', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n{"i":4}\n{"i":5}\n{"i":6}\n\n{"i":7}\n', 8, True),
+        ('n_records_9', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n{"i":4}\n{"i":5}\n{"i":6}\n\n{"i":7}\n{"i":8}\n', 9, True),
+        ('n_records_10', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n{"i":4}\n{"i":5}\n{"i":6}\n\n{"i":7}\n{"i":8}\n{"i":9}\n\n', 10, True),
+        ('n_records_11', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n{"i":4}\n{"i":5}\n{"i":6}\n\n{"i":7}\n{"i":8}\n{"i":9}\n\n{"i":10}\n', 11, True),
+        ('n_records_12', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n{"i":4}\n{"i":5}\n{"i":6}\n\n{"i":7}\n{"i":8}\n{"i":9}\n\n{"i":10}\n{"i":11}\n', 12, True),
+        ('n_records_13', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n{"i":4}\n{"i":5}\n{"i":6}\n\n{"i":7}\n{"i":8}\n{"i":9}\n\n{"i":10}\n{"i":11}\n{"i":12}\n\n', 13, True),
+        ('n_records_14', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n{"i":4}\n{"i":5}\n{"i":6}\n\n{"i":7}\n{"i":8}\n{"i":9}\n\n{"i":10}\n{"i":11}\n{"i":12}\n\n{"i":13}\n', 14, True),
+        ('n_records_15', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n{"i":4}\n{"i":5}\n{"i":6}\n\n{"i":7}\n{"i":8}\n{"i":9}\n\n{"i":10}\n{"i":11}\n{"i":12}\n\n{"i":13}\n{"i":14}\n', 15, True),
+        ('n_records_16', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n{"i":4}\n{"i":5}\n{"i":6}\n\n{"i":7}\n{"i":8}\n{"i":9}\n\n{"i":10}\n{"i":11}\n{"i":12}\n\n{"i":13}\n{"i":14}\n{"i":15}\n\n', 16, True),
+        ('n_records_17', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n{"i":4}\n{"i":5}\n{"i":6}\n\n{"i":7}\n{"i":8}\n{"i":9}\n\n{"i":10}\n{"i":11}\n{"i":12}\n\n{"i":13}\n{"i":14}\n{"i":15}\n\n{"i":16}\n', 17, True),
+        ('n_records_18', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n{"i":4}\n{"i":5}\n{"i":6}\n\n{"i":7}\n{"i":8}\n{"i":9}\n\n{"i":10}\n{"i":11}\n{"i":12}\n\n{"i":13}\n{"i":14}\n{"i":15}\n\n{"i":16}\n{"i":17}\n', 18, True),
+        ('n_records_19', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n{"i":4}\n{"i":5}\n{"i":6}\n\n{"i":7}\n{"i":8}\n{"i":9}\n\n{"i":10}\n{"i":11}\n{"i":12}\n\n{"i":13}\n{"i":14}\n{"i":15}\n\n{"i":16}\n{"i":17}\n{"i":18}\n\n', 19, True),
+        ('n_records_20', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n{"i":4}\n{"i":5}\n{"i":6}\n\n{"i":7}\n{"i":8}\n{"i":9}\n\n{"i":10}\n{"i":11}\n{"i":12}\n\n{"i":13}\n{"i":14}\n{"i":15}\n\n{"i":16}\n{"i":17}\n{"i":18}\n\n{"i":19}\n', 20, True),
+        ('n_records_21', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n{"i":4}\n{"i":5}\n{"i":6}\n\n{"i":7}\n{"i":8}\n{"i":9}\n\n{"i":10}\n{"i":11}\n{"i":12}\n\n{"i":13}\n{"i":14}\n{"i":15}\n\n{"i":16}\n{"i":17}\n{"i":18}\n\n{"i":19}\n{"i":20}\n', 21, True),
+        ('n_records_22', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n{"i":4}\n{"i":5}\n{"i":6}\n\n{"i":7}\n{"i":8}\n{"i":9}\n\n{"i":10}\n{"i":11}\n{"i":12}\n\n{"i":13}\n{"i":14}\n{"i":15}\n\n{"i":16}\n{"i":17}\n{"i":18}\n\n{"i":19}\n{"i":20}\n{"i":21}\n\n', 22, True),
+        ('n_records_23', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n{"i":4}\n{"i":5}\n{"i":6}\n\n{"i":7}\n{"i":8}\n{"i":9}\n\n{"i":10}\n{"i":11}\n{"i":12}\n\n{"i":13}\n{"i":14}\n{"i":15}\n\n{"i":16}\n{"i":17}\n{"i":18}\n\n{"i":19}\n{"i":20}\n{"i":21}\n\n{"i":22}\n', 23, True),
+        ('n_records_24', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n{"i":4}\n{"i":5}\n{"i":6}\n\n{"i":7}\n{"i":8}\n{"i":9}\n\n{"i":10}\n{"i":11}\n{"i":12}\n\n{"i":13}\n{"i":14}\n{"i":15}\n\n{"i":16}\n{"i":17}\n{"i":18}\n\n{"i":19}\n{"i":20}\n{"i":21}\n\n{"i":22}\n{"i":23}\n', 24, True),
+        ('n_records_25', '{"i":0}\n\n{"i":1}\n{"i":2}\n{"i":3}\n\n{"i":4}\n{"i":5}\n{"i":6}\n\n{"i":7}\n{"i":8}\n{"i":9}\n\n{"i":10}\n{"i":11}\n{"i":12}\n\n{"i":13}\n{"i":14}\n{"i":15}\n\n{"i":16}\n{"i":17}\n{"i":18}\n\n{"i":19}\n{"i":20}\n{"i":21}\n\n{"i":22}\n{"i":23}\n{"i":24}\n\n', 25, True),
+    ]
+
+    def test_matrix(self):
+        for name, body, value, ok in self.CASES:
+            with self.subTest(name):
+                detail = self.eval_files({self.FILE: body}, self._c(value))
+                self.assertEqual(detail["ok"], ok, (name, detail))
+
+    def test_missing_file_and_invalid_utf8(self):
+        self.assertFalse(self.eval_files({}, self._c(1))["ok"])
+        self.assertFalse(self.eval_bytes(self.FILE, b"\xff\xfe {}", self._c(1))["ok"])
+
+
+class NdjsonFieldEqMatrixTests(_OpCase):
+    FILE = "out.ndjson"
+
+    def _c(self, **kwargs):
+        check = {"name": "f", "op": "ndjson_field_eq", "file": self.FILE,
+                 "row": 0, "path": "id", "value": 1}
+        check.update(kwargs)
+        return check
+
+    CASES = [
+        ('id0', '{"id":1,"name":"갑","tags":["초안","표"],"qty":2}\n\n{"id":2,"name":"을","tags":["확정"],"qty":5}\n  \n{"id":3,"name":"병","tags":[],"qty":0}\n', 0, 'id', 1, True),
+        ('id1', '{"id":1,"name":"갑","tags":["초안","표"],"qty":2}\n\n{"id":2,"name":"을","tags":["확정"],"qty":5}\n  \n{"id":3,"name":"병","tags":[],"qty":0}\n', 1, 'id', 2, True),
+        ('id2', '{"id":1,"name":"갑","tags":["초안","표"],"qty":2}\n\n{"id":2,"name":"을","tags":["확정"],"qty":5}\n  \n{"id":3,"name":"병","tags":[],"qty":0}\n', 2, 'id', 3, True),
+        ('name1', '{"id":1,"name":"갑","tags":["초안","표"],"qty":2}\n\n{"id":2,"name":"을","tags":["확정"],"qty":5}\n  \n{"id":3,"name":"병","tags":[],"qty":0}\n', 1, 'name', '을', True),
+        ('qty0', '{"id":1,"name":"갑","tags":["초안","표"],"qty":2}\n\n{"id":2,"name":"을","tags":["확정"],"qty":5}\n  \n{"id":3,"name":"병","tags":[],"qty":0}\n', 0, 'qty', 2, True),
+        ('tag0', '{"id":1,"name":"갑","tags":["초안","표"],"qty":2}\n\n{"id":2,"name":"을","tags":["확정"],"qty":5}\n  \n{"id":3,"name":"병","tags":[],"qty":0}\n', 0, 'tags[0]', '초안', True),
+        ('tag1', '{"id":1,"name":"갑","tags":["초안","표"],"qty":2}\n\n{"id":2,"name":"을","tags":["확정"],"qty":5}\n  \n{"id":3,"name":"병","tags":[],"qty":0}\n', 0, 'tags[1]', '표', True),
+        ('wrong', '{"id":1,"name":"갑","tags":["초안","표"],"qty":2}\n\n{"id":2,"name":"을","tags":["확정"],"qty":5}\n  \n{"id":3,"name":"병","tags":[],"qty":0}\n', 0, 'id', 99, False),
+        ('missing_path', '{"id":1,"name":"갑","tags":["초안","표"],"qty":2}\n\n{"id":2,"name":"을","tags":["확정"],"qty":5}\n  \n{"id":3,"name":"병","tags":[],"qty":0}\n', 0, 'gone', 1, False),
+        ('row_oob', '{"id":1,"name":"갑","tags":["초안","표"],"qty":2}\n\n{"id":2,"name":"을","tags":["확정"],"qty":5}\n  \n{"id":3,"name":"병","tags":[],"qty":0}\n', 9, 'id', 1, False),
+        ('neg_row', '{"id":1,"name":"갑","tags":["초안","표"],"qty":2}\n\n{"id":2,"name":"을","tags":["확정"],"qty":5}\n  \n{"id":3,"name":"병","tags":[],"qty":0}\n', -1, 'id', 1, False),
+        ('type_null', '{"kind":"null","v":null}\n{"kind":"bool","v":true}\n{"kind":"num","v":3.14}\n{"kind":"str","v":"한글"}\n{"kind":"arr","v":[1,2,3]}\n{"kind":"obj","v":{"a":1,"b":2}}\n', 0, 'v', None, True),
+        ('type_bool', '{"kind":"null","v":null}\n{"kind":"bool","v":true}\n{"kind":"num","v":3.14}\n{"kind":"str","v":"한글"}\n{"kind":"arr","v":[1,2,3]}\n{"kind":"obj","v":{"a":1,"b":2}}\n', 1, 'v', True, True),
+        ('type_num', '{"kind":"null","v":null}\n{"kind":"bool","v":true}\n{"kind":"num","v":3.14}\n{"kind":"str","v":"한글"}\n{"kind":"arr","v":[1,2,3]}\n{"kind":"obj","v":{"a":1,"b":2}}\n', 2, 'v', 3.14, True),
+        ('type_str', '{"kind":"null","v":null}\n{"kind":"bool","v":true}\n{"kind":"num","v":3.14}\n{"kind":"str","v":"한글"}\n{"kind":"arr","v":[1,2,3]}\n{"kind":"obj","v":{"a":1,"b":2}}\n', 3, 'v', '한글', True),
+        ('type_arr0', '{"kind":"null","v":null}\n{"kind":"bool","v":true}\n{"kind":"num","v":3.14}\n{"kind":"str","v":"한글"}\n{"kind":"arr","v":[1,2,3]}\n{"kind":"obj","v":{"a":1,"b":2}}\n', 4, 'v[0]', 1, True),
+        ('type_obj_a', '{"kind":"null","v":null}\n{"kind":"bool","v":true}\n{"kind":"num","v":3.14}\n{"kind":"str","v":"한글"}\n{"kind":"arr","v":[1,2,3]}\n{"kind":"obj","v":{"a":1,"b":2}}\n', 5, 'v.a', 1, True),
+        ('bad_json_row', '{"id":1}\n{not-json\n{"id":3}\n', 1, 'id', 2, False),
+        ('after_bad', '{"id":1}\n{not-json\n{"id":3}\n', 2, 'id', 3, True),
+        ('row_0_id', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 0, 'id', 0, True),
+        ('row_0_name', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 0, 'name', '행0', True),
+        ('row_1_id', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 1, 'id', 1, True),
+        ('row_1_name', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 1, 'name', '행1', True),
+        ('row_2_id', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 2, 'id', 2, True),
+        ('row_2_name', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 2, 'name', '행2', True),
+        ('row_3_id', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 3, 'id', 3, True),
+        ('row_3_name', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 3, 'name', '행3', True),
+        ('row_4_id', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 4, 'id', 4, True),
+        ('row_4_name', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 4, 'name', '행4', True),
+        ('row_5_id', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 5, 'id', 5, True),
+        ('row_5_name', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 5, 'name', '행5', True),
+        ('row_6_id', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 6, 'id', 6, True),
+        ('row_6_name', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 6, 'name', '행6', True),
+        ('row_7_id', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 7, 'id', 7, True),
+        ('row_7_name', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 7, 'name', '행7', True),
+        ('row_8_id', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 8, 'id', 8, True),
+        ('row_8_name', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 8, 'name', '행8', True),
+        ('row_9_id', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 9, 'id', 9, True),
+        ('row_9_name', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 9, 'name', '행9', True),
+        ('row_10_id', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 10, 'id', 10, True),
+        ('row_10_name', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 10, 'name', '행10', True),
+        ('row_11_id', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 11, 'id', 11, True),
+        ('row_11_name', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 11, 'name', '행11', True),
+        ('row_12_id', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 12, 'id', 12, True),
+        ('row_12_name', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 12, 'name', '행12', True),
+        ('row_13_id', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 13, 'id', 13, True),
+        ('row_13_name', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 13, 'name', '행13', True),
+        ('row_14_id', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 14, 'id', 14, True),
+        ('row_14_name', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 14, 'name', '행14', True),
+        ('row_15_id', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 15, 'id', 15, True),
+        ('row_15_name', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 15, 'name', '행15', True),
+        ('row_16_id', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 16, 'id', 16, True),
+        ('row_16_name', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 16, 'name', '행16', True),
+        ('row_17_id', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 17, 'id', 17, True),
+        ('row_17_name', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 17, 'name', '행17', True),
+        ('row_18_id', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 18, 'id', 18, True),
+        ('row_18_name', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 18, 'name', '행18', True),
+        ('row_19_id', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 19, 'id', 19, True),
+        ('row_19_name', '{"id":0,"name":"행0"}\n{"id":1,"name":"행1"}\n{"id":2,"name":"행2"}\n{"id":3,"name":"행3"}\n{"id":4,"name":"행4"}\n{"id":5,"name":"행5"}\n{"id":6,"name":"행6"}\n{"id":7,"name":"행7"}\n{"id":8,"name":"행8"}\n{"id":9,"name":"행9"}\n{"id":10,"name":"행10"}\n{"id":11,"name":"행11"}\n{"id":12,"name":"행12"}\n{"id":13,"name":"행13"}\n{"id":14,"name":"행14"}\n{"id":15,"name":"행15"}\n{"id":16,"name":"행16"}\n{"id":17,"name":"행17"}\n{"id":18,"name":"행18"}\n{"id":19,"name":"행19"}\n', 19, 'name', '행19', True),
+    ]
+
+    def test_matrix(self):
+        for name, body, row, path, value, ok in self.CASES:
+            with self.subTest(name):
+                detail = self.eval_files(
+                    {self.FILE: body},
+                    self._c(row=row, path=path, value=value),
+                )
+                self.assertEqual(detail["ok"], ok, (name, detail))
+
+    def test_bool_row_rejected(self):
+        detail = self.eval_files({self.FILE: NDJSON_SIMPLE}, self._c(row=True, path="id", value=2))
+        self.assertFalse(detail["ok"], detail)
+
+    def test_empty_file_fails(self):
+        detail = self.eval_files({self.FILE: ""}, self._c())
+        self.assertFalse(detail["ok"], detail)
+        self.assertIn("없음", str(detail["actual"]))
+
+
+class NdjsonKeysAndLenTests(_OpCase):
+    FILE = "out.ndjson"
+
+    def test_keys_on_row(self):
+        detail = self.eval_files(
+            {self.FILE: NDJSON_SIMPLE},
+            {"name": "k", "op": "ndjson_keys_contain", "file": self.FILE, "row": 0,
+             "keys": ["id", "name", "tags"]},
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_keys_missing(self):
+        detail = self.eval_files(
+            {self.FILE: NDJSON_SIMPLE},
+            {"name": "k", "op": "ndjson_keys_contain", "file": self.FILE, "row": 0,
+             "keys": ["id", "missing"]},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_keys_nested_path(self):
+        detail = self.eval_files(
+            {self.FILE: NDJSON_TYPES},
+            {"name": "k", "op": "ndjson_keys_contain", "file": self.FILE, "row": 5,
+             "path": "v", "keys": ["a", "b"]},
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_keys_path_not_object(self):
+        detail = self.eval_files(
+            {self.FILE: NDJSON_SIMPLE},
+            {"name": "k", "op": "ndjson_keys_contain", "file": self.FILE, "row": 0,
+             "path": "tags", "keys": ["x"]},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_keys_row_oob(self):
+        detail = self.eval_files(
+            {self.FILE: NDJSON_SIMPLE},
+            {"name": "k", "op": "ndjson_keys_contain", "file": self.FILE, "row": 8,
+             "keys": ["id"]},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_keys_neg_row(self):
+        detail = self.eval_files(
+            {self.FILE: NDJSON_SIMPLE},
+            {"name": "k", "op": "ndjson_keys_contain", "file": self.FILE, "row": -1,
+             "keys": ["id"]},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_keys_bool_row(self):
+        detail = self.eval_files(
+            {self.FILE: NDJSON_SIMPLE},
+            {"name": "k", "op": "ndjson_keys_contain", "file": self.FILE, "row": True,
+             "keys": ["id"]},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_keys_not_list(self):
+        detail = self.eval_files(
+            {self.FILE: NDJSON_SIMPLE},
+            {"name": "k", "op": "ndjson_keys_contain", "file": self.FILE, "row": 0,
+             "keys": "id"},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_len_tags_row0(self):
+        detail = self.eval_files(
+            {self.FILE: NDJSON_SIMPLE},
+            {"name": "l", "op": "ndjson_len_eq", "file": self.FILE, "row": 0,
+             "path": "tags", "value": 2},
+        )
+        self.assertTrue(detail["ok"], detail)
+        self.assertEqual(detail["actual"], 2)
+
+    def test_len_tags_row1(self):
+        detail = self.eval_files(
+            {self.FILE: NDJSON_SIMPLE},
+            {"name": "l", "op": "ndjson_len_eq", "file": self.FILE, "row": 1,
+             "path": "tags", "value": 1},
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_len_tags_empty(self):
+        detail = self.eval_files(
+            {self.FILE: NDJSON_SIMPLE},
+            {"name": "l", "op": "ndjson_len_eq", "file": self.FILE, "row": 2,
+             "path": "tags", "value": 0},
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_len_root_object(self):
+        detail = self.eval_files(
+            {self.FILE: NDJSON_SIMPLE},
+            {"name": "l", "op": "ndjson_len_eq", "file": self.FILE, "row": 0,
+             "path": "", "value": 4},
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_len_scalar_fails(self):
+        detail = self.eval_files(
+            {self.FILE: NDJSON_SIMPLE},
+            {"name": "l", "op": "ndjson_len_eq", "file": self.FILE, "row": 0,
+             "path": "name", "value": 1},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_len_wrong(self):
+        detail = self.eval_files(
+            {self.FILE: NDJSON_SIMPLE},
+            {"name": "l", "op": "ndjson_len_eq", "file": self.FILE, "row": 0,
+             "path": "tags", "value": 9},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_len_missing_file(self):
+        detail = self.eval_files(
+            {},
+            {"name": "l", "op": "ndjson_len_eq", "file": self.FILE, "row": 0, "value": 1},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+
+TEXT_SIMPLE = "첫째\n둘째\n셋째"
+TEXT_CRLF = "첫째\r\n둘째\r\n셋째\r\n"
+TEXT_BLANK = "갑\n\n을\n"
+TEXT_HANGUL = "이름: 홍길동\n수량: 12\n비고: 없음\n"
+TEXT_LONG = "".join(f"줄{i:02d} 내용-{i}\n" for i in range(40))
+
+
+class TextLineEqMatrixTests(_OpCase):
+    FILE = "out.txt"
+
+    def _c(self, **kwargs):
+        check = {"name": "ln", "op": "text_line_eq", "file": self.FILE, "line": 0, "value": ""}
+        check.update(kwargs)
+        return check
+
+    CASES = [
+        ('first', '첫째\n둘째\n셋째', 0, '첫째', True),
+        ('second', '첫째\n둘째\n셋째', 1, '둘째', True),
+        ('third_no_nl', '첫째\n둘째\n셋째', 2, '셋째', True),
+        ('wrong', '첫째\n둘째\n셋째', 0, '둘째', False),
+        ('crlf_second', '첫째\r\n둘째\r\n셋째\r\n', 1, '둘째', True),
+        ('blank_middle', '갑\n\n을\n', 1, '', True),
+        ('blank_third', '갑\n\n을\n', 2, '을', True),
+        ('hangul_0', '이름: 홍길동\n수량: 12\n비고: 없음\n', 0, '이름: 홍길동', True),
+        ('hangul_1', '이름: 홍길동\n수량: 12\n비고: 없음\n', 1, '수량: 12', True),
+        ('oob', '첫째\n둘째\n셋째', 9, '첫째', False),
+        ('neg', '첫째\n둘째\n셋째', -1, '첫째', False),
+        ('long_00', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 0, '줄00 내용-0', True),
+        ('long_01', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 1, '줄01 내용-1', True),
+        ('long_01_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 1, '줄00 내용-0', False),
+        ('long_02', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 2, '줄02 내용-2', True),
+        ('long_02_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 2, '줄01 내용-1', False),
+        ('long_03', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 3, '줄03 내용-3', True),
+        ('long_03_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 3, '줄02 내용-2', False),
+        ('long_04', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 4, '줄04 내용-4', True),
+        ('long_04_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 4, '줄03 내용-3', False),
+        ('long_05', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 5, '줄05 내용-5', True),
+        ('long_05_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 5, '줄04 내용-4', False),
+        ('long_06', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 6, '줄06 내용-6', True),
+        ('long_06_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 6, '줄05 내용-5', False),
+        ('long_07', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 7, '줄07 내용-7', True),
+        ('long_07_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 7, '줄06 내용-6', False),
+        ('long_08', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 8, '줄08 내용-8', True),
+        ('long_08_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 8, '줄07 내용-7', False),
+        ('long_09', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 9, '줄09 내용-9', True),
+        ('long_09_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 9, '줄08 내용-8', False),
+        ('long_10', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 10, '줄10 내용-10', True),
+        ('long_10_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 10, '줄09 내용-9', False),
+        ('long_11', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 11, '줄11 내용-11', True),
+        ('long_11_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 11, '줄10 내용-10', False),
+        ('long_12', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 12, '줄12 내용-12', True),
+        ('long_12_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 12, '줄11 내용-11', False),
+        ('long_13', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 13, '줄13 내용-13', True),
+        ('long_13_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 13, '줄12 내용-12', False),
+        ('long_14', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 14, '줄14 내용-14', True),
+        ('long_14_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 14, '줄13 내용-13', False),
+        ('long_15', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 15, '줄15 내용-15', True),
+        ('long_15_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 15, '줄14 내용-14', False),
+        ('long_16', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 16, '줄16 내용-16', True),
+        ('long_16_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 16, '줄15 내용-15', False),
+        ('long_17', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 17, '줄17 내용-17', True),
+        ('long_17_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 17, '줄16 내용-16', False),
+        ('long_18', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 18, '줄18 내용-18', True),
+        ('long_18_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 18, '줄17 내용-17', False),
+        ('long_19', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 19, '줄19 내용-19', True),
+        ('long_19_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 19, '줄18 내용-18', False),
+        ('long_20', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 20, '줄20 내용-20', True),
+        ('long_20_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 20, '줄19 내용-19', False),
+        ('long_21', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 21, '줄21 내용-21', True),
+        ('long_21_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 21, '줄20 내용-20', False),
+        ('long_22', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 22, '줄22 내용-22', True),
+        ('long_22_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 22, '줄21 내용-21', False),
+        ('long_23', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 23, '줄23 내용-23', True),
+        ('long_23_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 23, '줄22 내용-22', False),
+        ('long_24', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 24, '줄24 내용-24', True),
+        ('long_24_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 24, '줄23 내용-23', False),
+        ('long_25', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 25, '줄25 내용-25', True),
+        ('long_25_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 25, '줄24 내용-24', False),
+        ('long_26', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 26, '줄26 내용-26', True),
+        ('long_26_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 26, '줄25 내용-25', False),
+        ('long_27', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 27, '줄27 내용-27', True),
+        ('long_27_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 27, '줄26 내용-26', False),
+        ('long_28', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 28, '줄28 내용-28', True),
+        ('long_28_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 28, '줄27 내용-27', False),
+        ('long_29', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 29, '줄29 내용-29', True),
+        ('long_29_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 29, '줄28 내용-28', False),
+        ('long_30', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 30, '줄30 내용-30', True),
+        ('long_30_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 30, '줄29 내용-29', False),
+        ('long_31', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 31, '줄31 내용-31', True),
+        ('long_31_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 31, '줄30 내용-30', False),
+        ('long_32', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 32, '줄32 내용-32', True),
+        ('long_32_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 32, '줄31 내용-31', False),
+        ('long_33', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 33, '줄33 내용-33', True),
+        ('long_33_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 33, '줄32 내용-32', False),
+        ('long_34', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 34, '줄34 내용-34', True),
+        ('long_34_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 34, '줄33 내용-33', False),
+        ('long_35', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 35, '줄35 내용-35', True),
+        ('long_35_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 35, '줄34 내용-34', False),
+        ('long_36', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 36, '줄36 내용-36', True),
+        ('long_36_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 36, '줄35 내용-35', False),
+        ('long_37', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 37, '줄37 내용-37', True),
+        ('long_37_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 37, '줄36 내용-36', False),
+        ('long_38', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 38, '줄38 내용-38', True),
+        ('long_38_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 38, '줄37 내용-37', False),
+        ('long_39', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 39, '줄39 내용-39', True),
+        ('long_39_wrong', '줄00 내용-0\n줄01 내용-1\n줄02 내용-2\n줄03 내용-3\n줄04 내용-4\n줄05 내용-5\n줄06 내용-6\n줄07 내용-7\n줄08 내용-8\n줄09 내용-9\n줄10 내용-10\n줄11 내용-11\n줄12 내용-12\n줄13 내용-13\n줄14 내용-14\n줄15 내용-15\n줄16 내용-16\n줄17 내용-17\n줄18 내용-18\n줄19 내용-19\n줄20 내용-20\n줄21 내용-21\n줄22 내용-22\n줄23 내용-23\n줄24 내용-24\n줄25 내용-25\n줄26 내용-26\n줄27 내용-27\n줄28 내용-28\n줄29 내용-29\n줄30 내용-30\n줄31 내용-31\n줄32 내용-32\n줄33 내용-33\n줄34 내용-34\n줄35 내용-35\n줄36 내용-36\n줄37 내용-37\n줄38 내용-38\n줄39 내용-39\n', 39, '줄38 내용-38', False),
+    ]
+
+    def test_matrix(self):
+        for name, body, line, value, ok in self.CASES:
+            with self.subTest(name):
+                detail = self.eval_files({self.FILE: body}, self._c(line=line, value=value))
+                self.assertEqual(detail["ok"], ok, (name, detail))
+
+    def test_bool_line_rejected(self):
+        detail = self.eval_files({self.FILE: TEXT_SIMPLE}, self._c(line=False, value="첫째"))
+        self.assertFalse(detail["ok"], detail)
+
+    def test_empty_file_fails(self):
+        detail = self.eval_files({self.FILE: ""}, self._c(line=0, value=""))
+        self.assertFalse(detail["ok"], detail)
+        self.assertIn("없음", str(detail["actual"]))
+
+    def test_missing_file_and_invalid_utf8(self):
+        self.assertFalse(self.eval_files({}, self._c())["ok"])
+        self.assertFalse(self.eval_bytes(self.FILE, b"\xff\xfe hi\n", self._c())["ok"])
+
+
+class TextLineCountAndContainsTests(_OpCase):
+    FILE = "out.txt"
+
+    def test_count_simple_three(self):
+        detail = self.eval_files(
+            {self.FILE: TEXT_SIMPLE},
+            {"name": "n", "op": "text_line_count_eq", "file": self.FILE, "value": 3},
+        )
+        self.assertTrue(detail["ok"], detail)
+        self.assertEqual(detail["actual"], 3)
+
+    def test_count_crlf_three(self):
+        detail = self.eval_files(
+            {self.FILE: TEXT_CRLF},
+            {"name": "n", "op": "text_line_count_eq", "file": self.FILE, "value": 3},
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_count_empty_zero(self):
+        detail = self.eval_files(
+            {self.FILE: ""},
+            {"name": "n", "op": "text_line_count_eq", "file": self.FILE, "value": 0},
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_count_blank_three(self):
+        detail = self.eval_files(
+            {self.FILE: TEXT_BLANK},
+            {"name": "n", "op": "text_line_count_eq", "file": self.FILE, "value": 3},
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_count_long_forty(self):
+        detail = self.eval_files(
+            {self.FILE: TEXT_LONG},
+            {"name": "n", "op": "text_line_count_eq", "file": self.FILE, "value": 40},
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_count_wrong(self):
+        detail = self.eval_files(
+            {self.FILE: TEXT_SIMPLE},
+            {"name": "n", "op": "text_line_count_eq", "file": self.FILE, "value": 2},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_count_numeric_string(self):
+        detail = self.eval_files(
+            {self.FILE: TEXT_SIMPLE},
+            {"name": "n", "op": "text_line_count_eq", "file": self.FILE, "value": "3"},
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_count_missing_file(self):
+        detail = self.eval_files(
+            {},
+            {"name": "n", "op": "text_line_count_eq", "file": self.FILE, "value": 1},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_contains_hit(self):
+        detail = self.eval_files(
+            {self.FILE: TEXT_HANGUL},
+            {"name": "c", "op": "text_line_contains", "file": self.FILE, "line": 0,
+             "value": "홍길동"},
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_contains_miss(self):
+        detail = self.eval_files(
+            {self.FILE: TEXT_HANGUL},
+            {"name": "c", "op": "text_line_contains", "file": self.FILE, "line": 0,
+             "value": "이순신"},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_contains_full_line(self):
+        detail = self.eval_files(
+            {self.FILE: TEXT_HANGUL},
+            {"name": "c", "op": "text_line_contains", "file": self.FILE, "line": 1,
+             "value": "수량: 12"},
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_contains_oob(self):
+        detail = self.eval_files(
+            {self.FILE: TEXT_HANGUL},
+            {"name": "c", "op": "text_line_contains", "file": self.FILE, "line": 9,
+             "value": "홍"},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_contains_neg(self):
+        detail = self.eval_files(
+            {self.FILE: TEXT_HANGUL},
+            {"name": "c", "op": "text_line_contains", "file": self.FILE, "line": -1,
+             "value": "홍"},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_contains_bool_line(self):
+        detail = self.eval_files(
+            {self.FILE: TEXT_HANGUL},
+            {"name": "c", "op": "text_line_contains", "file": self.FILE, "line": True,
+             "value": "수량"},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_contains_non_string_value(self):
+        detail = self.eval_files(
+            {self.FILE: TEXT_HANGUL},
+            {"name": "c", "op": "text_line_contains", "file": self.FILE, "line": 1,
+             "value": 12},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_contains_empty_needle_matches(self):
+        detail = self.eval_files(
+            {self.FILE: TEXT_HANGUL},
+            {"name": "c", "op": "text_line_contains", "file": self.FILE, "line": 0,
+             "value": ""},
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_contains_missing_file(self):
+        detail = self.eval_files(
+            {},
+            {"name": "c", "op": "text_line_contains", "file": self.FILE, "line": 0,
+             "value": "x"},
+        )
+        self.assertFalse(detail["ok"], detail)
+
+
+class ExceptionPathCatalogTests(_OpCase):
+    """모든 신규 지목 연산자의 공통 예외 — 파일 없음·깨진 바이트·좌표 거부."""
+
+    def test_missing_file_fails_every_pinpoint_op(self):
+        checks = [
+            {"name": "a", "op": "json_len_eq", "file": "m.json", "value": 0},
+            {"name": "b", "op": "json_type_eq", "file": "m.json", "value": "object"},
+            {"name": "c", "op": "json_len_ge", "file": "m.json", "value": 0},
+            {"name": "d", "op": "json_array_item_eq", "file": "m.json", "index": 0, "value": 1},
+            {"name": "e", "op": "json_keys_contain", "file": "m.json", "keys": ["id"]},
+            {"name": "f", "op": "csv_row_count_eq", "file": "m.csv", "value": 1},
+            {"name": "g", "op": "csv_col_count_eq", "file": "m.csv", "row": 0, "value": 1},
+            {"name": "h", "op": "csv_header_eq", "file": "m.csv", "values": ["a"]},
+            {"name": "i", "op": "csv_row_eq", "file": "m.csv", "row": 0, "values": ["a"]},
+            {"name": "j", "op": "ndjson_count_eq", "file": "m.ndjson", "value": 1},
+            {"name": "k", "op": "ndjson_field_eq", "file": "m.ndjson", "row": 0, "value": 1},
+            {"name": "l", "op": "ndjson_keys_contain", "file": "m.ndjson", "row": 0, "keys": ["id"]},
+            {"name": "m", "op": "ndjson_len_eq", "file": "m.ndjson", "row": 0, "value": 1},
+            {"name": "n", "op": "text_line_eq", "file": "m.txt", "line": 0, "value": "x"},
+            {"name": "o", "op": "text_line_count_eq", "file": "m.txt", "value": 1},
+            {"name": "p", "op": "text_line_contains", "file": "m.txt", "line": 0, "value": "x"},
+        ]
+        for check in checks:
+            with self.subTest(check["op"]):
+                detail = self.eval_files({}, check)
+                self.assertFalse(detail["ok"], detail)
+
+    def test_invalid_utf8_fails_textish_ops(self):
+        payload = b"\xff\xfe\x00 broken"
+        checks = [
+            ("out.json", {"name": "a", "op": "json_len_eq", "file": "out.json", "value": 0}),
+            ("out.csv", {"name": "b", "op": "csv_row_count_eq", "file": "out.csv", "value": 0}),
+            ("out.ndjson", {"name": "c", "op": "ndjson_count_eq", "file": "out.ndjson", "value": 0}),
+            ("out.txt", {"name": "d", "op": "text_line_count_eq", "file": "out.txt", "value": 0}),
+            ("out.txt", {"name": "e", "op": "text_line_eq", "file": "out.txt", "line": 0, "value": "x"}),
+        ]
+        for name, check in checks:
+            with self.subTest(check["op"]):
+                detail = self.eval_bytes(name, payload, check)
+                self.assertFalse(detail["ok"], detail)
+
+    def test_no_cli_on_extra_ops(self):
+        _checks, runner, _schema = load_core()
+        original = runner.run_cli
+
+        def boom(*_a, **_k):
+            raise AssertionError("file op 가 CLI 를 부르면 안 된다")
+
+        runner.run_cli = boom
+        try:
+            with tempfile.TemporaryDirectory() as sub_dir:
+                _write(sub_dir, "out.json", _json({"items": [1, 2, 3], "name": "갑"}))
+                _write(sub_dir, "out.csv", "name,qty\n갑,1\n")
+                _write(sub_dir, "out.ndjson", '{"id":1,"tags":[1,2]}\n')
+                _write(sub_dir, "out.txt", "하나\n둘\n")
+                samples = [
+                    {"name": "a", "op": "json_type_eq", "file": "out.json", "path": "items",
+                     "value": "array"},
+                    {"name": "b", "op": "json_len_ge", "file": "out.json", "path": "items",
+                     "value": 3},
+                    {"name": "c", "op": "json_array_item_eq", "file": "out.json", "path": "items",
+                     "index": 1, "value": 2},
+                    {"name": "d", "op": "csv_col_count_eq", "file": "out.csv", "row": 0, "value": 2},
+                    {"name": "e", "op": "csv_header_eq", "file": "out.csv",
+                     "values": ["name", "qty"]},
+                    {"name": "f", "op": "csv_row_eq", "file": "out.csv", "row": 1,
+                     "values": ["갑", "1"]},
+                    {"name": "g", "op": "ndjson_keys_contain", "file": "out.ndjson", "row": 0,
+                     "keys": ["id", "tags"]},
+                    {"name": "h", "op": "ndjson_len_eq", "file": "out.ndjson", "row": 0,
+                     "path": "tags", "value": 2},
+                    {"name": "i", "op": "text_line_count_eq", "file": "out.txt", "value": 2},
+                    {"name": "j", "op": "text_line_contains", "file": "out.txt", "line": 0,
+                     "value": "나"},
+                ]
+                for check in samples:
+                    with self.subTest(check["op"]):
+                        detail = runner.eval_check(check, {}, sub_dir, {}, "unused-rhwp")
+                        self.assertTrue(detail["ok"], detail)
+        finally:
+            runner.run_cli = original
+
+
+class SchemaPinpointOpsTests(unittest.TestCase):
+    def _task(self, check):
+        return {
+            "id": "X",
+            "tier": 2,
+            "title": "t",
+            "input": "samples/x.hwp",
+            "instructions": "i",
+            "submit": {"kind": "artifact"},
+            "checks": [check],
+        }
+
+    def test_cmd_rejected_on_every_extra_op(self):
+        _checks, _runner, schema = load_core()
+        pack = {"id": "p", "axis": "자동화"}
+        extras = [
+            {"name": "c", "op": "json_type_eq", "file": "out.json", "value": "object",
+             "cmd": ["info"]},
+            {"name": "c", "op": "csv_header_eq", "file": "out.csv", "values": ["a"],
+             "cmd": ["info"]},
+            {"name": "c", "op": "text_line_contains", "file": "out.txt", "line": 0,
+             "value": "x", "cmd": ["info"]},
+        ]
+        for check in extras:
+            errors = []
+            schema.validate_task(self._task(check), pack, None, errors)
+            self.assertTrue(any("CLI" in e for e in errors), (check["op"], errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_gym_checks.py
+++ b/scripts/tests/test_gym_checks.py
@@ -1,0 +1,507 @@
+"""[#5205] gym 지목 채점 연산자 — 파일 픽스처만으로 판정한다.
+
+에이전트 산출(JSON/CSV/NDJSON/텍스트)을 전역 훑기 없이 좌표로 잰다.
+새 연산자는 CLI 를 부르지 않으므로 바이너리 없이 돈다.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+NEW_OPS = (
+    "json_len_eq",
+    "csv_row_count_eq",
+    "ndjson_count_eq",
+    "ndjson_field_eq",
+    "json_keys_contain",
+    "text_line_eq",
+)
+
+EXISTING_FILE_OPS = (
+    "same_hash",
+    "differs_from_input",
+    "file_exists",
+    "files_differ",
+    "xml_root_eq",
+    "json_value_eq",
+    "csv_cell_eq",
+    "utf8_bom",
+)
+
+
+def load_core():
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    from gym.core import checks, runner, schema  # noqa: WPS433
+
+    return checks, runner, schema
+
+
+def _write(root, name, content, *, encoding="utf-8", newline="\n"):
+    path = Path(root) / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(content, bytes):
+        path.write_bytes(content)
+        return path
+    with path.open("w", encoding=encoding, newline=newline) as fh:
+        fh.write(content)
+    return path
+
+
+class _OpCase(unittest.TestCase):
+    """제출 폴더에 픽스처를 두고 eval_check 로 연산자를 호출한다."""
+
+    def eval_files(self, files, check, encoding="utf-8"):
+        _checks, runner, _schema = load_core()
+        with tempfile.TemporaryDirectory() as sub_dir:
+            for name, content in files.items():
+                _write(sub_dir, name, content, encoding=encoding)
+            return runner.eval_check(check, {}, sub_dir, {}, "unused-rhwp")
+
+
+class RegistryContractTests(unittest.TestCase):
+    def test_new_ops_are_registered_without_cli(self):
+        checks, _runner, _schema = load_core()
+        for op in NEW_OPS:
+            self.assertIn(op, checks.REGISTRY, op)
+            self.assertFalse(checks.needs_cli(op), op)
+
+    def test_existing_file_ops_still_skip_cli(self):
+        checks, _runner, _schema = load_core()
+        for op in EXISTING_FILE_OPS:
+            self.assertIn(op, checks.REGISTRY, op)
+            self.assertFalse(checks.needs_cli(op), op)
+
+    def test_global_scan_ops_unchanged(self):
+        checks, _runner, _schema = load_core()
+        self.assertEqual(checks.GLOBAL_SCAN_OPS, {"deep_contains", "not_contains"})
+        for op in NEW_OPS:
+            self.assertNotIn(op, checks.GLOBAL_SCAN_OPS)
+
+    def test_cli_ops_still_need_cli(self):
+        checks, _runner, _schema = load_core()
+        self.assertTrue(checks.needs_cli("value_eq"))
+        self.assertTrue(checks.needs_cli("cell_text_eq"))
+
+
+class SchemaAcceptanceTests(unittest.TestCase):
+    def _task(self, check):
+        return {
+            "id": "X",
+            "tier": 2,
+            "title": "t",
+            "input": "samples/x.hwp",
+            "instructions": "i",
+            "submit": {"kind": "artifact"},
+            "checks": [check],
+        }
+
+    def test_new_file_ops_do_not_require_cmd(self):
+        _checks, _runner, schema = load_core()
+        pack = {"id": "p", "axis": "편집 (좌표 지정)"}
+        for op in NEW_OPS:
+            check = {"name": "c", "op": op, "file": "out.json", "value": 1}
+            if op == "json_keys_contain":
+                check = {"name": "c", "op": op, "file": "out.json", "keys": ["a"]}
+            elif op == "ndjson_field_eq":
+                check = {"name": "c", "op": op, "file": "out.ndjson", "row": 0,
+                         "path": "id", "value": 1}
+            elif op == "text_line_eq":
+                check = {"name": "c", "op": op, "file": "out.txt", "line": 0, "value": "x"}
+            errors = []
+            schema.validate_task(self._task(check), pack, None, errors)
+            self.assertEqual(errors, [], f"{op}: {errors}")
+
+    def test_cmd_on_file_op_is_rejected(self):
+        _checks, _runner, schema = load_core()
+        pack = {"id": "p", "axis": "자동화"}
+        check = {"name": "c", "op": "json_len_eq", "file": "out.json",
+                 "path": "items", "value": 1, "cmd": ["info"]}
+        errors = []
+        schema.validate_task(self._task(check), pack, None, errors)
+        self.assertTrue(any("CLI" in e for e in errors), errors)
+
+
+class JsonLenEqTests(_OpCase):
+    FILE = "out.json"
+
+    def _check(self, **kwargs):
+        check = {"name": "len", "op": "json_len_eq", "file": self.FILE, "value": 3}
+        check.update(kwargs)
+        return check
+
+    def test_array_length_at_path(self):
+        detail = self.eval_files(
+            {self.FILE: json.dumps({"items": [1, 2, 3], "extra": []})},
+            self._check(path="items", value=3),
+        )
+        self.assertTrue(detail["ok"], detail)
+        self.assertEqual(detail["actual"], 3)
+
+    def test_object_length_at_root(self):
+        detail = self.eval_files(
+            {self.FILE: json.dumps({"a": 1, "b": 2})},
+            self._check(path="", value=2),
+        )
+        self.assertTrue(detail["ok"], detail)
+        self.assertEqual(detail["actual"], 2)
+
+    def test_numeric_string_value_matches(self):
+        detail = self.eval_files(
+            {self.FILE: json.dumps({"items": [1, 2]})},
+            self._check(path="items", value="2"),
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_wrong_length_fails(self):
+        detail = self.eval_files(
+            {self.FILE: json.dumps({"items": [1]})},
+            self._check(path="items", value=3),
+        )
+        self.assertFalse(detail["ok"], detail)
+        self.assertEqual(detail["actual"], 1)
+
+    def test_missing_path_fails(self):
+        detail = self.eval_files(
+            {self.FILE: json.dumps({"items": [1, 2, 3]})},
+            self._check(path="missing", value=0),
+        )
+        self.assertFalse(detail["ok"], detail)
+        self.assertIn("실패", str(detail["actual"]))
+
+    def test_bad_json_fails(self):
+        detail = self.eval_files({self.FILE: "{not json"}, self._check())
+        self.assertFalse(detail["ok"], detail)
+        self.assertIn("실패", str(detail["actual"]))
+
+    def test_empty_file_fails(self):
+        detail = self.eval_files({self.FILE: ""}, self._check())
+        self.assertFalse(detail["ok"], detail)
+
+    def test_scalar_at_path_fails(self):
+        detail = self.eval_files(
+            {self.FILE: json.dumps({"n": 7})},
+            self._check(path="n", value=1),
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_missing_file_fails(self):
+        detail = self.eval_files({}, self._check())
+        self.assertFalse(detail["ok"], detail)
+
+
+class CsvRowCountEqTests(_OpCase):
+    FILE = "out.csv"
+
+    def _check(self, value):
+        return {"name": "rows", "op": "csv_row_count_eq", "file": self.FILE, "value": value}
+
+    def test_counts_header_and_data_rows(self):
+        body = "name,qty\n갑,1\n을,2\n"
+        detail = self.eval_files({self.FILE: body}, self._check(3))
+        self.assertTrue(detail["ok"], detail)
+        self.assertEqual(detail["actual"], 3)
+
+    def test_utf8_sig_bom_does_not_add_a_row(self):
+        body = "name,qty\n갑,1\n"
+        detail = self.eval_files({self.FILE: body}, self._check(2), encoding="utf-8-sig")
+        self.assertTrue(detail["ok"], detail)
+        self.assertEqual(detail["actual"], 2)
+
+    def test_empty_file_is_zero_rows(self):
+        detail = self.eval_files({self.FILE: ""}, self._check(0))
+        self.assertTrue(detail["ok"], detail)
+        self.assertEqual(detail["actual"], 0)
+
+    def test_empty_file_rejects_nonzero(self):
+        detail = self.eval_files({self.FILE: ""}, self._check(1))
+        self.assertFalse(detail["ok"], detail)
+        self.assertEqual(detail["actual"], 0)
+
+    def test_wrong_count_fails(self):
+        detail = self.eval_files({self.FILE: "a,b\n1,2\n"}, self._check(9))
+        self.assertFalse(detail["ok"], detail)
+
+    def test_missing_file_fails(self):
+        detail = self.eval_files({}, self._check(1))
+        self.assertFalse(detail["ok"], detail)
+
+
+class NdjsonCountEqTests(_OpCase):
+    FILE = "out.ndjson"
+
+    def _check(self, value):
+        return {"name": "n", "op": "ndjson_count_eq", "file": self.FILE, "value": value}
+
+    def test_counts_nonempty_lines_only(self):
+        body = '{"id":1}\n\n{"id":2}\n  \n{"id":3}\n'
+        detail = self.eval_files({self.FILE: body}, self._check(3))
+        self.assertTrue(detail["ok"], detail)
+        self.assertEqual(detail["actual"], 3)
+
+    def test_empty_file_is_zero(self):
+        detail = self.eval_files({self.FILE: ""}, self._check(0))
+        self.assertTrue(detail["ok"], detail)
+        self.assertEqual(detail["actual"], 0)
+
+    def test_empty_file_rejects_nonzero(self):
+        detail = self.eval_files({self.FILE: "\n\n"}, self._check(1))
+        self.assertFalse(detail["ok"], detail)
+        self.assertEqual(detail["actual"], 0)
+
+    def test_wrong_count_fails(self):
+        detail = self.eval_files({self.FILE: '{"a":1}\n'}, self._check(2))
+        self.assertFalse(detail["ok"], detail)
+
+    def test_missing_file_fails(self):
+        detail = self.eval_files({}, self._check(1))
+        self.assertFalse(detail["ok"], detail)
+
+
+class NdjsonFieldEqTests(_OpCase):
+    FILE = "out.ndjson"
+
+    def _check(self, **kwargs):
+        check = {"name": "field", "op": "ndjson_field_eq", "file": self.FILE,
+                 "row": 1, "path": "id", "value": 2}
+        check.update(kwargs)
+        return check
+
+    def test_field_at_nonempty_row(self):
+        body = '{"id":1,"name":"갑"}\n\n{"id":2,"name":"을"}\n{"id":3}\n'
+        detail = self.eval_files({self.FILE: body}, self._check(row=1, path="id", value=2))
+        self.assertTrue(detail["ok"], detail)
+        self.assertEqual(detail["actual"], 2)
+
+    def test_nested_path(self):
+        body = '{"meta":{"ok":true}}\n'
+        detail = self.eval_files(
+            {self.FILE: body},
+            self._check(row=0, path="meta.ok", value=True),
+        )
+        self.assertTrue(detail["ok"], detail)
+        self.assertIs(detail["actual"], True)
+
+    def test_missing_path_fails(self):
+        body = '{"id":1}\n'
+        detail = self.eval_files(
+            {self.FILE: body},
+            self._check(row=0, path="missing", value=1),
+        )
+        self.assertFalse(detail["ok"], detail)
+        self.assertIn("실패", str(detail["actual"]))
+
+    def test_bad_json_on_target_row_fails(self):
+        body = '{"id":1}\n{not-json\n'
+        detail = self.eval_files(
+            {self.FILE: body},
+            self._check(row=1, path="id", value=1),
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_negative_row_fails(self):
+        detail = self.eval_files(
+            {self.FILE: '{"id":1}\n'},
+            self._check(row=-1, path="id", value=1),
+        )
+        self.assertFalse(detail["ok"], detail)
+        self.assertIn("음수", str(detail["actual"]))
+
+    def test_empty_file_fails(self):
+        detail = self.eval_files({self.FILE: ""}, self._check(row=0, path="id", value=1))
+        self.assertFalse(detail["ok"], detail)
+        self.assertIn("없음", str(detail["actual"]))
+
+    def test_row_past_end_fails(self):
+        detail = self.eval_files(
+            {self.FILE: '{"id":1}\n'},
+            self._check(row=3, path="id", value=1),
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_bool_row_is_rejected(self):
+        detail = self.eval_files(
+            {self.FILE: '{"id":1}\n'},
+            self._check(row=True, path="id", value=1),
+        )
+        self.assertFalse(detail["ok"], detail)
+
+
+class JsonKeysContainTests(_OpCase):
+    FILE = "out.json"
+
+    def _check(self, **kwargs):
+        check = {"name": "keys", "op": "json_keys_contain", "file": self.FILE,
+                 "keys": ["id", "name"]}
+        check.update(kwargs)
+        return check
+
+    def test_object_contains_all_keys(self):
+        detail = self.eval_files(
+            {self.FILE: json.dumps({"id": 1, "name": "갑", "extra": True})},
+            self._check(keys=["id", "name"]),
+        )
+        self.assertTrue(detail["ok"], detail)
+        self.assertEqual(detail["actual"], ["extra", "id", "name"])
+
+    def test_nested_object_path(self):
+        body = json.dumps({"row": {"id": 1, "qty": 2}})
+        detail = self.eval_files({self.FILE: body}, self._check(path="row", keys=["id", "qty"]))
+        self.assertTrue(detail["ok"], detail)
+
+    def test_missing_key_fails(self):
+        detail = self.eval_files(
+            {self.FILE: json.dumps({"id": 1})},
+            self._check(keys=["id", "name"]),
+        )
+        self.assertFalse(detail["ok"], detail)
+        self.assertEqual(detail["actual"], ["id"])
+
+    def test_missing_path_fails(self):
+        detail = self.eval_files(
+            {self.FILE: json.dumps({"row": {"id": 1}})},
+            self._check(path="gone", keys=["id"]),
+        )
+        self.assertFalse(detail["ok"], detail)
+        self.assertIn("실패", str(detail["actual"]))
+
+    def test_bad_json_fails(self):
+        detail = self.eval_files({self.FILE: "[}"}, self._check())
+        self.assertFalse(detail["ok"], detail)
+
+    def test_empty_file_fails(self):
+        detail = self.eval_files({self.FILE: ""}, self._check())
+        self.assertFalse(detail["ok"], detail)
+
+    def test_array_at_path_fails(self):
+        detail = self.eval_files(
+            {self.FILE: json.dumps({"row": [1, 2]})},
+            self._check(path="row", keys=["id"]),
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_non_list_keys_fails(self):
+        detail = self.eval_files(
+            {self.FILE: json.dumps({"id": 1})},
+            self._check(keys="id"),
+        )
+        self.assertFalse(detail["ok"], detail)
+
+
+class TextLineEqTests(_OpCase):
+    FILE = "out.txt"
+
+    def _check(self, **kwargs):
+        check = {"name": "line", "op": "text_line_eq", "file": self.FILE,
+                 "line": 0, "value": "첫째"}
+        check.update(kwargs)
+        return check
+
+    def test_zero_based_line_match(self):
+        body = "첫째\n둘째\n셋째"
+        detail = self.eval_files({self.FILE: body}, self._check(line=1, value="둘째"))
+        self.assertTrue(detail["ok"], detail)
+        self.assertEqual(detail["actual"], "둘째")
+
+    def test_last_line_without_trailing_newline(self):
+        detail = self.eval_files(
+            {self.FILE: "첫째\n둘째"},
+            self._check(line=1, value="둘째"),
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_wrong_line_fails(self):
+        detail = self.eval_files(
+            {self.FILE: "첫째\n둘째\n"},
+            self._check(line=0, value="둘째"),
+        )
+        self.assertFalse(detail["ok"], detail)
+        self.assertEqual(detail["actual"], "첫째")
+
+    def test_negative_line_fails(self):
+        detail = self.eval_files(
+            {self.FILE: "첫째\n"},
+            self._check(line=-1, value="첫째"),
+        )
+        self.assertFalse(detail["ok"], detail)
+        self.assertIn("음수", str(detail["actual"]))
+
+    def test_empty_file_fails(self):
+        detail = self.eval_files({self.FILE: ""}, self._check(line=0, value=""))
+        self.assertFalse(detail["ok"], detail)
+        self.assertIn("없음", str(detail["actual"]))
+
+    def test_line_past_end_fails(self):
+        detail = self.eval_files(
+            {self.FILE: "한줄\n"},
+            self._check(line=4, value="한줄"),
+        )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_missing_file_fails(self):
+        detail = self.eval_files({}, self._check())
+        self.assertFalse(detail["ok"], detail)
+
+    def test_crlf_line_strips_newline_only(self):
+        detail = self.eval_files(
+            {self.FILE: "갑\r\n을\r\n"},
+            self._check(line=1, value="을"),
+        )
+        self.assertTrue(detail["ok"], detail)
+
+    def test_bool_line_is_rejected(self):
+        detail = self.eval_files({self.FILE: "x\n"}, self._check(line=False, value="x"))
+        self.assertFalse(detail["ok"], detail)
+
+
+class NoCliInvocationTests(_OpCase):
+    def test_eval_check_does_not_call_run_cli(self):
+        _checks, runner, _schema = load_core()
+        original = runner.run_cli
+
+        def boom(*_args, **_kwargs):
+            raise AssertionError("file op 가 CLI 를 부르면 안 된다")
+
+        runner.run_cli = boom
+        try:
+            with tempfile.TemporaryDirectory() as sub_dir:
+                _write(sub_dir, "out.json", json.dumps({"items": [1, 2]}))
+                detail = runner.eval_check(
+                    {"name": "len", "op": "json_len_eq", "file": "out.json",
+                     "path": "items", "value": 2},
+                    {},
+                    sub_dir,
+                    {},
+                    "unused-rhwp",
+                )
+        finally:
+            runner.run_cli = original
+        self.assertTrue(detail["ok"], detail)
+
+
+class ExistingPacksStayValidTests(unittest.TestCase):
+    def test_registered_ops_do_not_break_pack_schema(self):
+        _checks, _runner, schema = load_core()
+        packs = REPO_ROOT / "gym" / "packs"
+        errors = []
+        for pack_dir in sorted(p for p in packs.iterdir() if (p / "pack.json").is_file()):
+            manifest = json.loads((pack_dir / "pack.json").read_text(encoding="utf-8"))
+            for path in sorted((pack_dir / "tasks").glob("*.json")):
+                schema.validate_task(
+                    json.loads(path.read_text(encoding="utf-8")),
+                    manifest,
+                    None,
+                    errors,
+                )
+        self.assertEqual(errors, [], "\n".join(errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_gym_checks.py
+++ b/scripts/tests/test_gym_checks.py
@@ -24,6 +24,21 @@ NEW_OPS = (
     "text_line_eq",
 )
 
+EXTRA_OPS = (
+    "json_type_eq",
+    "json_len_ge",
+    "json_array_item_eq",
+    "csv_col_count_eq",
+    "csv_header_eq",
+    "csv_row_eq",
+    "ndjson_keys_contain",
+    "ndjson_len_eq",
+    "text_line_count_eq",
+    "text_line_contains",
+)
+
+PINPOINT_FILE_OPS = NEW_OPS + EXTRA_OPS
+
 EXISTING_FILE_OPS = (
     "same_hash",
     "differs_from_input",
@@ -69,9 +84,18 @@ class _OpCase(unittest.TestCase):
 class RegistryContractTests(unittest.TestCase):
     def test_new_ops_are_registered_without_cli(self):
         checks, _runner, _schema = load_core()
-        for op in NEW_OPS:
+        for op in PINPOINT_FILE_OPS:
             self.assertIn(op, checks.REGISTRY, op)
             self.assertFalse(checks.needs_cli(op), op)
+
+    def test_registry_keeps_existing_keys(self):
+        checks, _runner, _schema = load_core()
+        required = EXISTING_FILE_OPS + NEW_OPS + (
+            "answer_eq", "len_answer_eq", "len_ge", "value_eq", "value_ge",
+            "value_in", "deep_contains", "not_contains", "cell_text_eq",
+        )
+        for op in required:
+            self.assertIn(op, checks.REGISTRY, op)
 
     def test_existing_file_ops_still_skip_cli(self):
         checks, _runner, _schema = load_core()
@@ -82,7 +106,7 @@ class RegistryContractTests(unittest.TestCase):
     def test_global_scan_ops_unchanged(self):
         checks, _runner, _schema = load_core()
         self.assertEqual(checks.GLOBAL_SCAN_OPS, {"deep_contains", "not_contains"})
-        for op in NEW_OPS:
+        for op in PINPOINT_FILE_OPS:
             self.assertNotIn(op, checks.GLOBAL_SCAN_OPS)
 
     def test_cli_ops_still_need_cli(self):
@@ -103,20 +127,42 @@ class SchemaAcceptanceTests(unittest.TestCase):
             "checks": [check],
         }
 
+    def _sample_check(self, op):
+        samples = {
+            "json_len_eq": {"name": "c", "op": op, "file": "out.json", "value": 1},
+            "csv_row_count_eq": {"name": "c", "op": op, "file": "out.csv", "value": 1},
+            "ndjson_count_eq": {"name": "c", "op": op, "file": "out.ndjson", "value": 1},
+            "ndjson_field_eq": {"name": "c", "op": op, "file": "out.ndjson", "row": 0,
+                                "path": "id", "value": 1},
+            "json_keys_contain": {"name": "c", "op": op, "file": "out.json", "keys": ["a"]},
+            "text_line_eq": {"name": "c", "op": op, "file": "out.txt", "line": 0, "value": "x"},
+            "json_type_eq": {"name": "c", "op": op, "file": "out.json", "path": "a",
+                             "value": "string"},
+            "json_len_ge": {"name": "c", "op": op, "file": "out.json", "path": "items",
+                            "value": 1},
+            "json_array_item_eq": {"name": "c", "op": op, "file": "out.json", "path": "items",
+                                   "index": 0, "value": 1},
+            "csv_col_count_eq": {"name": "c", "op": op, "file": "out.csv", "row": 0, "value": 2},
+            "csv_header_eq": {"name": "c", "op": op, "file": "out.csv",
+                              "values": ["name", "qty"]},
+            "csv_row_eq": {"name": "c", "op": op, "file": "out.csv", "row": 1,
+                           "values": ["갑", "1"]},
+            "ndjson_keys_contain": {"name": "c", "op": op, "file": "out.ndjson", "row": 0,
+                                    "keys": ["id"]},
+            "ndjson_len_eq": {"name": "c", "op": op, "file": "out.ndjson", "row": 0,
+                              "path": "tags", "value": 2},
+            "text_line_count_eq": {"name": "c", "op": op, "file": "out.txt", "value": 3},
+            "text_line_contains": {"name": "c", "op": op, "file": "out.txt", "line": 0,
+                                   "value": "갑"},
+        }
+        return samples[op]
+
     def test_new_file_ops_do_not_require_cmd(self):
         _checks, _runner, schema = load_core()
         pack = {"id": "p", "axis": "편집 (좌표 지정)"}
-        for op in NEW_OPS:
-            check = {"name": "c", "op": op, "file": "out.json", "value": 1}
-            if op == "json_keys_contain":
-                check = {"name": "c", "op": op, "file": "out.json", "keys": ["a"]}
-            elif op == "ndjson_field_eq":
-                check = {"name": "c", "op": op, "file": "out.ndjson", "row": 0,
-                         "path": "id", "value": 1}
-            elif op == "text_line_eq":
-                check = {"name": "c", "op": op, "file": "out.txt", "line": 0, "value": "x"}
+        for op in PINPOINT_FILE_OPS:
             errors = []
-            schema.validate_task(self._task(check), pack, None, errors)
+            schema.validate_task(self._task(self._sample_check(op)), pack, None, errors)
             self.assertEqual(errors, [], f"{op}: {errors}")
 
     def test_cmd_on_file_op_is_rejected(self):
@@ -484,6 +530,125 @@ class NoCliInvocationTests(_OpCase):
         finally:
             runner.run_cli = original
         self.assertTrue(detail["ok"], detail)
+
+
+class PinpointExceptionPathTests(_OpCase):
+    """1차 6연산자의 예외 — 부재·깨진 바이트·bool 좌표·스칼라 길이."""
+
+    def test_json_len_eq_rejects_directory_and_truncated(self):
+        detail = self.eval_files({"out.json": '{"xs":'}, {
+            "name": "len", "op": "json_len_eq", "file": "out.json", "path": "xs", "value": 0,
+        })
+        self.assertFalse(detail["ok"], detail)
+        self.assertIn("실패", str(detail["actual"]))
+
+    def test_json_len_eq_nested_index_out_of_range(self):
+        detail = self.eval_files({"out.json": json.dumps({"rows": [{"xs": [1]}]})}, {
+            "name": "len", "op": "json_len_eq", "file": "out.json",
+            "path": "rows[3].xs", "value": 0,
+        })
+        self.assertFalse(detail["ok"], detail)
+
+    def test_json_len_eq_bool_false_does_not_equal_two(self):
+        detail = self.eval_files({"out.json": json.dumps([1, 2])}, {
+            "name": "len", "op": "json_len_eq", "file": "out.json", "value": False,
+        })
+        self.assertFalse(detail["ok"], detail)
+
+    def test_csv_row_count_eq_quoted_newline_is_one_logical_row(self):
+        body = "name,note\n\"갑\",\"여러\n줄\"\n"
+        detail = self.eval_files({"out.csv": body}, {
+            "name": "rows", "op": "csv_row_count_eq", "file": "out.csv", "value": 2,
+        })
+        self.assertTrue(detail["ok"], detail)
+        self.assertEqual(detail["actual"], 2)
+
+    def test_csv_row_count_eq_crlf_three_rows(self):
+        detail = self.eval_files({"out.csv": "a,b\r\n1,2\r\n3,4\r\n"}, {
+            "name": "rows", "op": "csv_row_count_eq", "file": "out.csv", "value": 3,
+        })
+        self.assertTrue(detail["ok"], detail)
+
+    def test_csv_row_count_eq_invalid_utf8(self):
+        _checks, runner, _schema = load_core()
+        with tempfile.TemporaryDirectory() as sub_dir:
+            _write(sub_dir, "out.csv", b"\xff\xfe a,b\n")
+            detail = runner.eval_check(
+                {"name": "rows", "op": "csv_row_count_eq", "file": "out.csv", "value": 1},
+                {}, sub_dir, {}, "unused-rhwp",
+            )
+        self.assertFalse(detail["ok"], detail)
+
+    def test_ndjson_count_eq_ignores_whitespace_only_lines(self):
+        body = "{\"id\":1}\n\t\n  \n{\"id\":2}\n"
+        detail = self.eval_files({"out.ndjson": body}, {
+            "name": "n", "op": "ndjson_count_eq", "file": "out.ndjson", "value": 2,
+        })
+        self.assertTrue(detail["ok"], detail)
+        self.assertEqual(detail["actual"], 2)
+
+    def test_ndjson_field_eq_skips_blank_before_target_row(self):
+        body = "{\"id\":1}\n\n\n{\"id\":2,\"name\":\"을\"}\n"
+        detail = self.eval_files({"out.ndjson": body}, {
+            "name": "f", "op": "ndjson_field_eq", "file": "out.ndjson",
+            "row": 1, "path": "name", "value": "을",
+        })
+        self.assertTrue(detail["ok"], detail)
+
+    def test_ndjson_field_eq_string_row_rejected(self):
+        detail = self.eval_files({"out.ndjson": "{\"id\":1}\n"}, {
+            "name": "f", "op": "ndjson_field_eq", "file": "out.ndjson",
+            "row": "0", "path": "id", "value": 1,
+        })
+        self.assertFalse(detail["ok"], detail)
+
+    def test_json_keys_contain_empty_keys_on_empty_object(self):
+        detail = self.eval_files({"out.json": "{}"}, {
+            "name": "k", "op": "json_keys_contain", "file": "out.json", "keys": [],
+        })
+        self.assertTrue(detail["ok"], detail)
+
+    def test_json_keys_contain_rejects_number_in_keys(self):
+        detail = self.eval_files({"out.json": json.dumps({"id": 1})}, {
+            "name": "k", "op": "json_keys_contain", "file": "out.json", "keys": [1],
+        })
+        self.assertFalse(detail["ok"], detail)
+
+    def test_text_line_eq_keeps_internal_spaces(self):
+        detail = self.eval_files({"out.txt": "  갑  \n을\n"}, {
+            "name": "ln", "op": "text_line_eq", "file": "out.txt",
+            "line": 0, "value": "  갑  ",
+        })
+        self.assertTrue(detail["ok"], detail)
+
+    def test_text_line_eq_does_not_strip_internal_tab(self):
+        detail = self.eval_files({"out.txt": "갑\t을\n"}, {
+            "name": "ln", "op": "text_line_eq", "file": "out.txt",
+            "line": 0, "value": "갑을",
+        })
+        self.assertFalse(detail["ok"], detail)
+        self.assertEqual(detail["actual"], "갑\t을")
+
+    def test_text_line_eq_string_line_rejected(self):
+        detail = self.eval_files({"out.txt": "갑\n"}, {
+            "name": "ln", "op": "text_line_eq", "file": "out.txt",
+            "line": "0", "value": "갑",
+        })
+        self.assertFalse(detail["ok"], detail)
+
+    def test_all_six_ops_fail_on_missing_file(self):
+        checks = [
+            {"name": "a", "op": "json_len_eq", "file": "m.json", "value": 0},
+            {"name": "b", "op": "csv_row_count_eq", "file": "m.csv", "value": 1},
+            {"name": "c", "op": "ndjson_count_eq", "file": "m.ndjson", "value": 1},
+            {"name": "d", "op": "ndjson_field_eq", "file": "m.ndjson", "row": 0,
+             "path": "id", "value": 1},
+            {"name": "e", "op": "json_keys_contain", "file": "m.json", "keys": ["id"]},
+            {"name": "f", "op": "text_line_eq", "file": "m.txt", "line": 0, "value": "x"},
+        ]
+        for check in checks:
+            with self.subTest(check["op"]):
+                self.assertFalse(self.eval_files({}, check)["ok"], check)
 
 
 class ExistingPacksStayValidTests(unittest.TestCase):


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다.

## 변경 요약

gym 채점 어휘에 대상을 지목하는 파일 연산자 6개를 추가한다. 에이전트 산출(JSON / CSV / NDJSON / 텍스트)을 `deep_contains` 같은 전역 훑기로 메우지 않고 좌표로 판정한다. 새 CLI 는 만들지 않았고 `src/` 도 건드리지 않는다.

등재 연산자 (`needs_cli=False`, `GLOBAL_SCAN_OPS` 불변):

- `json_len_eq` — `path` 의 배열/객체 길이가 `value`
- `csv_row_count_eq` — UTF-8-SIG CSV 행 수가 `value`
- `ndjson_count_eq` — 비어 있지 않은 NDJSON 줄 수가 `value`
- `ndjson_field_eq` — 0부터 세는 비어 있지 않은 줄 `row` 의 `path` 가 `value`
- `json_keys_contain` — `path` 객체가 `keys` 를 모두 포함
- `text_line_eq` — 0부터 세는 텍스트 줄이 `value` (UTF-8)

기존 과제 JSON·pack·profile·README·PARK.md·다른 gym/tools 는 바꾸지 않았다.

## 관련 이슈

closes #5205

## 테스트

- [x] `python -m unittest scripts/tests/test_gym_checks.py scripts/tests/test_gym_packs.py` 통과 (68 tests)
- [x] `python gym/tools/audit.py` 통과 (18 pack, 위반 0)
- [ ] **`cargo fmt --all -- --check` 통과** — 이 checkout 은 crates/ 가 없는 sparse 작업 트리라 실행하지 않음. 이번 변경은 Python gym 코어·단위시험뿐이라 rustfmt 대상이 없다.
- [ ] `node scripts/rust-test-suite-manifest.mjs --check` — 위와 같은 이유로 생략
- [ ] `node scripts/rust-unit-test-tiers.mjs --check` — 위와 같은 이유로 생략
- [ ] `cargo test` — 해당 없음 (새 CLI/Rust 없음)
- [ ] `cargo clippy -- -D warnings` — 해당 없음
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 — 해당 없음
- [ ] 작업 증빙 캡슐 — 해당 없음 (순수 Python 연산자 등록)
- [ ] capability 카탈로그 — 해당 없음

로컬 게이트는 위 unittest + audit 이다. 새 rhwp CLI 명령은 없다.

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음
- 재현·측정: 미측정 (채점 연산자 추가, 런타임 경로 없음)

## 스크린샷

해당 없음