### PR TITLE
feat(gym): 에이전트 세션 트레이스 기록·채점 도구 (#5206)

### DIFF
--- a/gym/docs/agent_session.md
+++ b/gym/docs/agent_session.md
@@ -1,0 +1,306 @@
+# gym 에이전트 세션 트레이스
+
+이 문서는 `gym/tools/agent_session.py` 의 한국어 정본이다. 종점 채점만 있으면
+에이전트가 우회·역순·여분 명령으로도 만점을 받는다. 이 도구는 **선언된 세션**
+(명령 열 + 기대 종료)과 **기록된 트레이스**(JSONL)를 기계 대조한다.
+
+- 채점 축: 명령 계열(`argv[0]`) · 종료 코드 · 순서
+- 쓰지 않는 것: LLM-judge, 골든 경로 문자열 비교, 새 rhwp CLI
+- 재생(`score-replay`)은 rhwp 없이 픽스처 JSONL 만으로 돈다
+- 기록(`record`)은 `--bin` 이 실재할 때만 실행한다. 없으면 거절한다
+
+관련 이슈 #5206 · PR #5211.
+
+## 왜 이 도구인가
+
+gym 채점은 산출(종점)을 본다. `trajectory.py` 는 기준 풀이에서 마지막 외부
+스텝을 잘라 그 스텝이 load-bearing 인지 감사한다. 둘 다 "에이전트가 실제로
+어떤 명령 열을 어떤 순서로 밟았는가"는 파일로 남기지 않는다.
+
+이 도구는 그 구멍을 메운다.
+
+| 도구 | 보는 것 | 보지 않는 것 |
+|------|---------|--------------|
+| gym 채점 (`score.py`) | 종점 산출 | 명령 열 |
+| `trajectory.py` | 마지막 스텝이 필요한가 | 에이전트가 밟은 경로 |
+| `agent_session.py` | 선언 경로 vs 관측 경로 | 산출 내용·LLM 판정 |
+
+종점이 맞아도 경로가 틀리면 실패다. 경로가 맞아도 종료 코드가 틀리면 실패다.
+여분 스텝·누락 스텝·역순은 각각 다른 사유로 남는다.
+
+## 하지 않는 것
+
+- **새 rhwp CLI 를 만들지 않는다.** `info`, `export-text` 같은 기존 명령을
+  세션 `run` 에 적을 뿐이다. `rhwp agent-session` 같은 하위명령은 없다.
+- **재생에 바이너리를 요구하지 않는다.** `score-replay` 는 `--bin` 인자가
+  없고 PATH 에서 rhwp 를 찾지도 않는다.
+- **없는 바이너리를 가장해 트레이스를 위조하지 않는다.** `record --bin` 이
+  없거나 경로가 파일이 아니면 `RecordRefused`(종료 2) 로 거절한다.
+- **pack·README·profiles·checks·coverage 를 건드리지 않는다.** 이 도구는
+  기본 채점 경로에 연결하지 않는다.
+- **자리표를 몰래 해석해 디스크를 요구하지 않는다.** 재생 채점의 합격 축은
+  계열·종료·순서다. `expectPath` 디스크 존재는 `check_paths=True`(기록 직후
+  재검증)일 때만 합격에 넣는다.
+
+## 세션 정의
+
+```json
+{
+  "id": "inspect-then-export",
+  "input": "samples/x.hwp",
+  "subDir": "work",
+  "steps": [
+    {"run": ["info", "{input}", "--json"], "expectExit": 0},
+    {
+      "run": ["export-text", "{input}", "-o", "{sub:out.txt}"],
+      "expectExit": 0,
+      "expectPath": "{sub:out.txt}"
+    }
+  ]
+}
+```
+
+### 필드
+
+| 필드 | 필수 | 의미 |
+|------|------|------|
+| `id` | 예 | 비어 있지 않은 문자열. 리포트 `sessionId` |
+| `input` | 아니오 | `{input}` 자리표 기본값. 문자열 |
+| `subDir` | 아니오 | `{sub:이름}` 자리표 기본값. 작업 폴더 |
+| `steps` | 예 | 비어 있지 않은 객체 배열 |
+| `steps[].run` | 예 | 비어 있지 않은 문자열 배열. `run[0]` 이 명령 계열 |
+| `steps[].expectExit` | 아니오 | 정수. 기본 0. 불리언 금지 |
+| `steps[].expectPath` | 아니오 | 기대 산출 경로. 자리표 가능 |
+
+`run` 은 rhwp 의 새 표면이 아니다. 이미 있는 하위명령 이름만 적는다.
+이 도구는 명령 존재 여부를 바이너리에 묻지 않는다 — 선언과 관측의
+`argv[0]` 이 같은지만 본다.
+
+### 자리표
+
+| 자리표 | 해석 | 컨텍스트가 없을 때 |
+|--------|------|-------------------|
+| `{input}` | 세션/CLI 입력 경로 | 그대로 남김 |
+| `{sub:이름}` | `subDir/이름` | 그대로 남김 |
+| `{그 외}` | 알 수 없음 | 검증에서 위반, 해석은 그대로 남김 |
+
+중괄호가 짝이 아니면 검증 위반이다. `{sub:}` 처럼 이름이 비거나 공백·중괄호가
+들어가면 위반이다. 토큰 안에 자리표를 끼울 수 있다
+(`pre-{sub:a.txt}-post`).
+
+엄격 모드(`resolve_token(..., strict=True)`)는 미해석 자리표를
+`PlaceholderError` 로 올린다. 재생 채점의 기본은 비엄격이다. 작업 폴더가
+없어도 픽스처 재생이 실패하지 않게 하기 위함이다.
+
+## 트레이스 JSONL
+
+한 줄 = 한 스텝.
+
+```json
+{"ts":"2026-08-18T00:00:00Z","argv":["info","samples/x.hwp","--json"],"exit":0,"stdoutSha256":"<hex64>","ok":true}
+```
+
+| 필드 | 필수 | 의미 |
+|------|------|------|
+| `ts` | 예 | 비어 있지 않은 문자열 (UTC `YYYY-MM-DDTHH:MM:SSZ` 권장) |
+| `argv` | 예 | 비어 있지 않은 문자열 배열. `argv[0]` 이 관측 계열 |
+| `exit` | 예 | 정수. 불리언 금지 |
+| `ok` | 예 | 불리언. 기록 당시 `exit==expectExit` 그리고 경로 검사 |
+| `stdoutSha256` | 아니오 | 64자리 hex. 있으면 형식 검사 |
+
+빈 줄은 건너뛴다. 본문이 UTF-8 BOM 으로 시작하면 한 번 벗긴다. 한 줄이
+배열·스칼라이면 `TraceParseError` 다. `ok` 가 없거나 `stdoutSha256` 이
+hex64 가 아니면 `TraceSchemaError` 다.
+
+기록기가 stdout 을 받았을 때만 해시를 넣는다. 재생 채점은 해시 값을
+비교하지 않는다 — 해시는 추적용이다.
+
+## 채점 리포트
+
+```json
+{
+  "kind": "gymAgentSession",
+  "schemaVersion": "1.0",
+  "ok": false,
+  "sessionId": "inspect-then-export",
+  "declared": 2,
+  "observed": 2,
+  "matched": 1,
+  "orderOk": false,
+  "steps": [],
+  "extraSteps": [],
+  "missingSteps": [],
+  "mismatches": [{"reason": "wrongOrder", "declared": ["info","export-text"], "observed": ["export-text","info"]}]
+}
+```
+
+`kind` 와 `schemaVersion` 은 고정이다. 다른 도구의 리포트와 섞이지 않게 한다.
+
+### mismatch 사유
+
+| reason | 언제 |
+|--------|------|
+| `wrongCommand` | 같은 자리에서 계열이 다르다 (`info` vs `search`) |
+| `wrongOrder` | 계열 다중집합은 같은데 순서가 다르다 |
+| `wrongExit` | 계열·순서는 맞는데 종료 코드가 다르다 |
+| `extraStep` | 관측이 선언보다 길다 (접두가 같거나 LCS 삽입) |
+| `missingStep` | 관측이 선언보다 짧다 |
+| `wrongPath` | `check_paths=True` 이고 `expectPath` 가 디스크에 없다 |
+| `badSession` | 세션 파일이 없거나 JSON/스키마가 깨졌다 |
+| `badTrace` | 트레이스가 없거나 JSONL/스키마가 깨졌다 |
+
+인접 `del+ins` 는 `sub`(교체)로 접어 여분+누락으로 오인하지 않는다.
+같은 다중집합의 순열은 `wrongOrder` 이지 `wrongCommand` 가 아니다.
+
+재생 채점에서 `expectPath` 가 없어도 통과할 수 있다. 기록 직후 재검증
+(`check_paths=True`)에서만 경로 부재가 `wrongPath` 가 된다.
+
+## CLI
+
+이 도구의 CLI 는 **Python 모듈 표면**이다. rhwp 바이너리의 하위명령이 아니다.
+
+```
+python gym/tools/agent_session.py validate --session S.json
+python gym/tools/agent_session.py score-replay --session S.json --replay T.jsonl
+python gym/tools/agent_session.py record --session S.json --bin target/debug/rhwp --out T.jsonl
+```
+
+공통: `--json` 이면 리포트를 JSON 으로 낸다. 없으면 한국어 한 줄+목록.
+
+### validate
+
+세션 정의만 본다. 바이너리 불요. 파일이 없거나 JSON 이 아니면 이슈 목록과
+종료 1. 스키마 위반(빈 `id`, 빈 `steps`, 자리표 오류)도 종료 1.
+성공이면 `kind=gymAgentSessionValidate`, `ok=true`.
+
+### score-replay
+
+기록된 JSONL 을 바이너리 없이 채점한다.
+
+- `--session` 세션 JSON
+- `--replay` 트레이스 JSONL
+- `--input` 세션 `input` 덮어쓰기 (자리표 해석용, 디스크 필수 아님)
+- `--sub-dir` 작업 폴더 (재생 합격에는 쓰지 않음)
+
+`--bin` 인자가 없다. 구현이 PATH 에서 rhwp 를 찾지도 않는다. 단위 시험은
+픽스처 두 파일만으로 통과·실패 사유를 고정한다.
+
+로드 실패는 채점 리포트로 접힌다.
+
+- 세션 쪽 예외 → `reason=badSession`
+- 트레이스 쪽 예외 → `reason=badTrace`
+- 세션을 읽은 뒤 트레이스가 깨지면 `sessionId` 는 유지한다
+
+종료 0 = 경로 합격, 종료 1 = 불합격 또는 입력 오류.
+
+### record
+
+세션을 실행해 JSONL 을 쓴다. **`--bin` 이 필수**다.
+
+- `--bin` 이 없거나 공백 → `RecordRefused`, 종료 2, 파일 없음
+- `--bin` 경로가 파일이 아님 → `RecordRefused`, 종료 2, 파일 없음
+- 세션/실행/쓰기 실패 → `SessionError` 계열, 종료 1
+- 성공 후 자기 채점 리포트를 낸다 (`kind=gymAgentSessionRecord`)
+
+주입 실행기(`record_session(..., execute=...)`)를 쓰는 단위 시험도
+`--bin` 자리(존재하는 더미 파일)를 요구한다. 실행기를 바꿔도 위조 금지
+계약은 남는다.
+
+## 예외 계층
+
+모든 계약 위반은 `SessionError`(ValueError 하위)다. CLI 와 시험은
+`code` 로 유형을 가른다.
+
+| 유형 | code | 종료 | 의미 |
+|------|------|------|------|
+| `SessionError` | `sessionError` | 1 | 분류되지 않은 계약 위반 |
+| `RecordRefused` | `recordRefused` | 2 | `--bin` 없이 기록 위조 시도 |
+| `SessionFileError` | `sessionFile` | 1 | 세션 JSON 을 열 수 없음 |
+| `SessionParseError` | `sessionParse` | 1 | 세션이 UTF-8 JSON 이 아님 |
+| `SessionSchemaError` | `sessionSchema` | 1 | id/steps/자리표 스키마 위반 |
+| `TraceFileError` | `traceFile` | 1 | 트레이스 JSONL 을 열 수 없음 |
+| `TraceParseError` | `traceParse` | 1 | 줄 파싱 실패 또는 이벤트 없음 |
+| `TraceSchemaError` | `traceSchema` | 1 | ts/argv/exit/ok 필드 위반 |
+| `ExecuteError` | `executeError` | 1 | 실행기 예외 또는 exit 미반환 |
+| `WriteError` | `writeError` | 1 | JSONL 쓰기 실패 |
+| `PlaceholderError` | `placeholderError` | 1 | 엄격 자리표 해석 실패 |
+
+`to_dict()` 는 `type`, `code`, `message`, `exitCode` 와 선택 필드
+`path` / `line` / `detail` 을 낸다. `classify_exception()` 은 세션 쪽을
+`badSession`, 트레이스 쪽을 `badTrace` 로 접는다.
+
+### 입출력 가드
+
+- 빈 경로: 읽기면 `SessionFileError` / `TraceFileError`, 쓰기면 `WriteError`
+- 없는 파일: 같은 유형, 메시지에 `찾을 수 없다`
+- 디렉터리: Windows 는 `PermissionError` 가 나기도 하므로 `isdir` 을 우선한다
+- UTF-8 이 아님: `SessionParseError` / `TraceParseError`
+- JSON 깨짐: 세션은 `SessionParseError`, 줄 단위는 `TraceParseError`(줄 번호)
+- 직렬화 불가 이벤트: `WriteError`
+- 실행기 `RuntimeError`: `ExecuteError` 로 감싼다. 이미 `SessionError` 이면
+  다시 감싸지 않는다
+- 실행기 결과가 `exit` 없거나 정수가 아님: `ExecuteError`
+- 작업 폴더/`{sub:}` 부모 생성 실패: `WriteError`
+
+`validate_session` / `validate_trace` 는 이슈 목록을 돌려 예외를 던지지
+않는다. 파일 로더(`load_session_file` / `load_trace_file`)가 이슈를
+`SessionSchemaError` / `TraceSchemaError` 로 올린다. 채점 함수
+`score_session` 은 예외 대신 `badSession` / `badTrace` 리포트를 낸다.
+
+## 재생 없이 시험하는 방법
+
+바이너리가 없는 환경(sparse checkout, CI 의 Python 전용 job)에서도
+다음이 돌아가야 한다.
+
+```
+python -m unittest scripts.tests.test_gym_agent_session
+python -m unittest scripts.tests.test_gym_agent_session_errors
+python gym/tools/audit.py
+```
+
+통과 픽스처는 `info` → `export-text` 두 줄 JSONL 이다. 실패 픽스처는
+잘못된 명령(`search`), 역순, 여분(`digest`), 누락, 종료 코드 2 다.
+기록 경로는 존재하는 더미 파일 + 주입 실행기로만 시험한다. 없는
+바이너리를 실행하지 않는다.
+
+`audit.py` 는 pack 정합 감사다. 이 도구는 pack 을 추가하지 않으므로
+기존 pack 전부가 계속 통과해야 한다.
+
+## 작업 예
+
+통과:
+
+```
+gym 에이전트 세션: inspect-then-export — 통과 (2/2 스텝, 순서·계열·종료 일치)
+  [0] 일치 — 기대 info exit=0, 관측 info exit=0
+  [1] 일치 — 기대 export-text exit=0, 관측 export-text exit=0
+```
+
+역순:
+
+```
+gym 에이전트 세션: inspect-then-export — 실패 (일치 0/2, 관측 2)
+  [0] 불일치 — 기대 info exit=0, 관측 export-text exit=0
+  [1] 불일치 — 기대 export-text exit=0, 관측 info exit=0
+  순서 불일치: 선언 ['info', 'export-text'] / 관측 ['export-text', 'info']
+```
+
+기록 거절:
+
+```
+record 모드는 --bin 이 필요합니다. 바이너리 없이 트레이스를 위조하지 않습니다.
+```
+
+종료 코드는 2 이고 `--out` 경로는 생기지 않는다.
+
+## 구현 위치
+
+| 경로 | 역할 |
+|------|------|
+| `gym/tools/agent_session.py` | 도구 본체 (검증·채점·기록·CLI·예외) |
+| `scripts/tests/test_gym_agent_session.py` | 경로 채점 계약 (통과·역순·여분·누락) |
+| `scripts/tests/test_gym_agent_session_errors.py` | 예외·입출력·CLI 실패 |
+| `gym/docs/agent_session.md` | 이 문서 |
+| `mydocs/working/gym_agent_session.md` | 작업 노트 |
+
+`cargo fmt --all` 은 이 변경에 필요 없다. Python 도구와 문서만 추가한다.

--- a/gym/tools/agent_session.py
+++ b/gym/tools/agent_session.py
@@ -81,11 +81,186 @@ OK_EXIT = 0
 
 
 class SessionError(ValueError):
-    """세션·트레이스·기록 입력이 계약을 깨뜨렸을 때."""
+    """세션·트레이스·기록 입력이 계약을 깨뜨렸을 때.
+
+    하위 유형은 `code` 로 기계 분류한다. CLI 는 유형에 따라
+    검증 리포트 / 채점 리포트 / stderr 거절 문구를 고른다.
+    """
+
+    code = "sessionError"
+    exit_code = FAIL_EXIT
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str | None = None,
+        path: str | None = None,
+        detail=None,
+        line: int | None = None,
+    ):
+        super().__init__(message)
+        if code is not None:
+            self.code = code
+        self.path = path
+        self.detail = detail
+        self.line = line
+
+    def to_dict(self) -> dict:
+        payload = {
+            "type": type(self).__name__,
+            "code": self.code,
+            "message": str(self),
+            "exitCode": int(self.exit_code),
+        }
+        if self.path is not None:
+            payload["path"] = self.path
+        if self.detail is not None:
+            payload["detail"] = self.detail
+        if self.line is not None:
+            payload["line"] = self.line
+        return payload
 
 
 class RecordRefused(SessionError):
     """record 가 바이너리 없이 위조하려 할 때 — 실행하지 않고 거절."""
+
+    code = "recordRefused"
+    exit_code = USAGE_EXIT
+
+
+class SessionFileError(SessionError):
+    """세션 JSON 파일을 열 수 없다 (없음·디렉터리·권한)."""
+
+    code = "sessionFile"
+
+
+class SessionParseError(SessionError):
+    """세션 파일이 UTF-8 JSON 이 아니다."""
+
+    code = "sessionParse"
+
+
+class SessionSchemaError(SessionError):
+    """세션 JSON 은 열렸으나 스키마(id/steps/자리표)가 깨졌다."""
+
+    code = "sessionSchema"
+
+
+class TraceFileError(SessionError):
+    """트레이스 JSONL 파일을 열 수 없다."""
+
+    code = "traceFile"
+
+
+class TraceParseError(SessionError):
+    """트레이스 줄이 JSON 이 아니거나 이벤트가 없다."""
+
+    code = "traceParse"
+
+
+class TraceSchemaError(SessionError):
+    """트레이스 이벤트 필드(ts/argv/exit/ok/stdoutSha256)가 깨졌다."""
+
+    code = "traceSchema"
+
+
+class ExecuteError(SessionError):
+    """기록 실행기가 예외를 내거나 exit 을 반환하지 않았다."""
+
+    code = "executeError"
+
+
+class WriteError(SessionError):
+    """트레이스 JSONL 쓰기가 실패했다."""
+
+    code = "writeError"
+
+
+class PlaceholderError(SessionError):
+    """자리표 해석이 계약을 깨뜨렸다 (엄격 모드)."""
+
+    code = "placeholderError"
+
+
+ERROR_CODE_CATALOG = (
+    ("sessionError", SessionError, "분류되지 않은 세션 계약 위반"),
+    ("recordRefused", RecordRefused, "record 가 --bin 없이 위조하려 함"),
+    ("sessionFile", SessionFileError, "세션 JSON 파일을 열 수 없음"),
+    ("sessionParse", SessionParseError, "세션 파일이 UTF-8 JSON 이 아님"),
+    ("sessionSchema", SessionSchemaError, "세션 스키마(id/steps/자리표) 위반"),
+    ("traceFile", TraceFileError, "트레이스 JSONL 을 열 수 없음"),
+    ("traceParse", TraceParseError, "트레이스 줄 파싱 실패 또는 이벤트 없음"),
+    ("traceSchema", TraceSchemaError, "트레이스 이벤트 필드 위반"),
+    ("executeError", ExecuteError, "실행기 예외 또는 exit 미반환"),
+    ("writeError", WriteError, "트레이스 JSONL 쓰기 실패"),
+    ("placeholderError", PlaceholderError, "자리표 엄격 해석 실패"),
+)
+
+
+def error_code_names() -> list[str]:
+    return [row[0] for row in ERROR_CODE_CATALOG]
+
+
+def error_class_for_code(code: str):
+    for name, cls, _hint in ERROR_CODE_CATALOG:
+        if name == code:
+            return cls
+    return SessionError
+
+
+def classify_exception(exc: BaseException) -> str:
+    """예외 → 채점 mismatch reason. record 거절은 채점 사유가 아니다."""
+    if isinstance(exc, (SessionSchemaError, SessionParseError, SessionFileError)):
+        return REASON_BAD_SESSION
+    if isinstance(exc, RecordRefused):
+        return REASON_BAD_SESSION
+    if isinstance(exc, (TraceSchemaError, TraceParseError, TraceFileError)):
+        return REASON_BAD_TRACE
+    if isinstance(exc, SessionError):
+        return REASON_BAD_TRACE
+    return REASON_BAD_TRACE
+
+
+def wrap_io_error(exc: OSError, path: str, *, reading: bool = True) -> SessionError:
+    """OSError → 읽기면 SessionFileError, 쓰기면 WriteError.
+
+    Windows 는 디렉터리를 open 하면 IsADirectoryError 대신 PermissionError 가
+    나는 경우가 있어, 경로가 디렉터리면 그걸 우선한다.
+    """
+    cls: type[SessionError] = SessionFileError if reading else WriteError
+    action = "읽기" if reading else "쓰기"
+    if isinstance(exc, FileNotFoundError):
+        return cls(f"파일을 찾을 수 없다: {path}", path=path)
+    if isinstance(exc, IsADirectoryError) or os.path.isdir(path):
+        return cls(f"경로가 디렉터리다: {path}", path=path)
+    if isinstance(exc, PermissionError):
+        return cls(f"파일 {action} 권한이 없다: {path}", path=path)
+    return cls(f"파일 {action} 실패: {path}: {exc}", path=path)
+
+
+def fail_score_report(
+    reason: str,
+    detail: str,
+    session_id: str | None = None,
+    declared: int = 0,
+    observed: int = 0,
+) -> dict:
+    """로드/파싱 실패를 채점 리포트로 접는다. 바이너리는 부르지 않는다."""
+    return {
+        "kind": REPORT_KIND,
+        "schemaVersion": SCHEMA_VERSION,
+        "ok": False,
+        "sessionId": session_id,
+        "declared": declared,
+        "observed": observed,
+        "matched": 0,
+        "orderOk": False,
+        "steps": [],
+        "extraSteps": [],
+        "missingSteps": [],
+        "mismatches": [{"reason": reason, "detail": detail}],
+    }
 
 
 class SessionContext:
@@ -174,8 +349,17 @@ def placeholder_issues(token: str, path: str) -> list[str]:
     return issues
 
 
-def resolve_token(token: str, context: SessionContext | None, create_parents: bool = False) -> str:
-    """한 인자에서 `{input}` / `{sub:이름}` 을 치환. 모르는 토큰은 그대로 둔다."""
+def resolve_token(
+    token: str,
+    context: SessionContext | None,
+    create_parents: bool = False,
+    strict: bool = False,
+) -> str:
+    """한 인자에서 `{input}` / `{sub:이름}` 을 치환. 모르는 토큰은 그대로 둔다.
+
+    strict=True 이면 미해석 자리표·알 수 없는 자리표를 PlaceholderError 로 올린다.
+    기본(False)은 재생 채점이 작업 폴더 없이 돌아가게 자리표를 남긴다.
+    """
     if not isinstance(token, str) or "{" not in token:
         return token
     ctx = context or SessionContext()
@@ -186,28 +370,54 @@ def resolve_token(token: str, context: SessionContext | None, create_parents: bo
         kind, name = classify_placeholder(body)
         if kind == "input":
             if ctx.input_path is None:
+                if strict:
+                    raise PlaceholderError("strict: {input} 을 해석할 input 이 없다")
                 out.append(token[start:end])
             else:
                 out.append(ctx.input_path)
         elif kind == "sub":
             if ctx.sub_dir is None or not name:
+                if strict:
+                    raise PlaceholderError(f"strict: {{sub:{name or ''}}} 을 해석할 subDir 이 없다")
                 out.append(token[start:end])
             else:
                 path = os.path.join(ctx.sub_dir, name.replace("/", os.sep))
                 if create_parents:
                     parent = os.path.dirname(path)
                     if parent:
-                        os.makedirs(parent, exist_ok=True)
+                        try:
+                            os.makedirs(parent, exist_ok=True)
+                        except OSError as exc:
+                            raise WriteError(
+                                f"자리표 부모 디렉터리 생성 실패: {parent}: {exc}",
+                                path=parent,
+                            ) from exc
                 out.append(path)
         else:
+            if strict:
+                raise PlaceholderError(f"strict: 알 수 없는 자리표 {{{body}}}")
             out.append(token[start:end])
         cursor = end
     out.append(token[cursor:])
     return "".join(out)
 
 
-def resolve_argv(argv, context: SessionContext | None, create_parents: bool = False) -> list[str]:
-    return [resolve_token(a, context, create_parents=create_parents) for a in list(argv)]
+def resolve_argv(
+    argv,
+    context: SessionContext | None,
+    create_parents: bool = False,
+    strict: bool = False,
+) -> list[str]:
+    if argv is None:
+        raise SessionSchemaError("run 인자가 없다")
+    try:
+        items = list(argv)
+    except TypeError as exc:
+        raise SessionSchemaError(f"run 인자가 순회 가능하지 않다: {exc}") from exc
+    return [
+        resolve_token(a, context, create_parents=create_parents, strict=strict)
+        for a in items
+    ]
 
 
 def expected_ok(exit_code: int, expect_exit: int, path_ok: bool | None) -> bool:
@@ -306,10 +516,15 @@ def validate_trace_event(event, index: int) -> list[str]:
 
 
 def parse_trace_jsonl(text: str) -> list[dict]:
-    """JSONL 본문 → 이벤트 목록. 빈 줄은 건너뛴다. 잘못된 줄은 SessionError."""
+    """JSONL 본문 → 이벤트 목록. 빈 줄은 건너뛴다. 잘못된 줄은 TraceParseError."""
     events = []
     if text is None:
-        raise SessionError("트레이스가 비어 있다")
+        raise TraceParseError("트레이스가 비어 있다")
+    if not isinstance(text, str):
+        raise TraceParseError(f"트레이스는 문자열이어야 한다: {type(text).__name__}")
+    # UTF-8 BOM 이 첫 줄에 붙으면 JSON 파서가 거절한다. 한 번만 벗긴다.
+    if text.startswith("\ufeff"):
+        text = text.lstrip("\ufeff")
     for line_no, raw in enumerate(text.splitlines(), start=1):
         line = raw.strip()
         if not line:
@@ -317,10 +532,18 @@ def parse_trace_jsonl(text: str) -> list[dict]:
         try:
             event = json.loads(line)
         except ValueError as exc:
-            raise SessionError(f"trace 줄 {line_no}: JSON 이 아니다: {exc}") from exc
+            raise TraceParseError(
+                f"trace 줄 {line_no}: JSON 이 아니다: {exc}",
+                line=line_no,
+            ) from exc
+        if not isinstance(event, dict):
+            raise TraceParseError(
+                f"trace 줄 {line_no}: 객체여야 한다 (배열/스칼라 금지)",
+                line=line_no,
+            )
         events.append(event)
     if not events:
-        raise SessionError("트레이스에 이벤트가 없다")
+        raise TraceParseError("트레이스에 이벤트가 없다")
     return events
 
 
@@ -334,41 +557,71 @@ def validate_trace(events) -> list[str]:
 
 
 def load_json_file(path: str):
+    """세션 JSON 로드. 없음/디렉터리/권한/UTF-8/JSON 을 유형별로 접는다."""
+    if path is None or not str(path).strip():
+        raise SessionFileError("세션 경로가 비어 있다", path=path)
     try:
         with open(path, encoding="utf-8") as fh:
             return json.load(fh)
     except FileNotFoundError as exc:
-        raise SessionError(f"파일을 찾을 수 없다: {path}") from exc
+        raise wrap_io_error(exc, path, reading=True) from exc
+    except IsADirectoryError as exc:
+        raise wrap_io_error(exc, path, reading=True) from exc
+    except PermissionError as exc:
+        raise wrap_io_error(exc, path, reading=True) from exc
+    except UnicodeDecodeError as exc:
+        raise SessionParseError(f"UTF-8 이 아니다: {path}: {exc}", path=path) from exc
     except ValueError as exc:
-        raise SessionError(f"JSON 파싱 실패: {path}: {exc}") from exc
+        raise SessionParseError(f"JSON 파싱 실패: {path}: {exc}", path=path) from exc
+    except OSError as exc:
+        raise wrap_io_error(exc, path, reading=True) from exc
 
 
 def load_text_file(path: str) -> str:
+    """트레이스 JSONL 본문 로드. 없음/디렉터리/권한/UTF-8 을 유형별로 접는다."""
+    if path is None or not str(path).strip():
+        raise TraceFileError("트레이스 경로가 비어 있다", path=path)
     try:
         with open(path, encoding="utf-8") as fh:
             return fh.read()
     except FileNotFoundError as exc:
-        raise SessionError(f"파일을 찾을 수 없다: {path}") from exc
+        raise TraceFileError(f"파일을 찾을 수 없다: {path}", path=path) from exc
+    except UnicodeDecodeError as exc:
+        raise TraceParseError(f"UTF-8 이 아니다: {path}: {exc}", path=path) from exc
     except OSError as exc:
-        raise SessionError(f"파일 읽기 실패: {path}: {exc}") from exc
+        wrapped = wrap_io_error(exc, path, reading=True)
+        raise TraceFileError(str(wrapped), path=path) from exc
 
 
 def write_jsonl(path: str, events: list[dict]) -> None:
+    if path is None or not str(path).strip():
+        raise WriteError("트레이스 출력 경로가 비어 있다", path=path)
+    if not isinstance(events, list):
+        raise WriteError(f"이벤트 목록이 배열이 아니다: {type(events).__name__}", path=path)
     parent = os.path.dirname(path)
-    if parent:
-        os.makedirs(parent, exist_ok=True)
-    lines = [json.dumps(ev, ensure_ascii=False, separators=(",", ":")) for ev in events]
-    with open(path, "w", encoding="utf-8", newline="\n") as fh:
-        fh.write("\n".join(lines))
-        if lines:
-            fh.write("\n")
+    try:
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        lines = [json.dumps(ev, ensure_ascii=False, separators=(",", ":")) for ev in events]
+        with open(path, "w", encoding="utf-8", newline="\n") as fh:
+            fh.write("\n".join(lines))
+            if lines:
+                fh.write("\n")
+    except TypeError as exc:
+        raise WriteError(f"트레이스 직렬화 실패: {path}: {exc}", path=path) from exc
+    except OSError as exc:
+        raise wrap_io_error(exc, path, reading=False) from exc
 
 
 def load_session_file(path: str) -> dict:
     doc = load_json_file(path)
     issues = validate_session(doc)
     if issues:
-        raise SessionError("세션 정의가 유효하지 않다: " + "; ".join(issues))
+        raise SessionSchemaError(
+            "세션 정의가 유효하지 않다: " + "; ".join(issues),
+            path=path,
+            detail=list(issues),
+        )
     return doc
 
 
@@ -376,7 +629,11 @@ def load_trace_file(path: str) -> list[dict]:
     events = parse_trace_jsonl(load_text_file(path))
     issues = validate_trace(events)
     if issues:
-        raise SessionError("트레이스가 유효하지 않다: " + "; ".join(issues))
+        raise TraceSchemaError(
+            "트레이스가 유효하지 않다: " + "; ".join(issues),
+            path=path,
+            detail=list(issues),
+        )
     return events
 
 
@@ -689,11 +946,23 @@ def require_record_bin(bin_path: str | None) -> str:
 
 
 def default_execute(bin_path: str, argv: list[str], cwd: str | None = None) -> dict:
-    proc = subprocess.run(
-        [bin_path] + list(argv),
-        cwd=cwd or REPO_ROOT,
-        capture_output=True,
-    )
+    """실바이너리 한 번 실행. FileNotFound/권한/OS 오류는 ExecuteError."""
+    if not bin_path:
+        raise ExecuteError("실행 바이너리 경로가 비어 있다")
+    try:
+        proc = subprocess.run(
+            [bin_path] + list(argv),
+            cwd=cwd or REPO_ROOT,
+            capture_output=True,
+        )
+    except FileNotFoundError as exc:
+        raise ExecuteError(f"실행 파일을 찾을 수 없다: {bin_path}") from exc
+    except PermissionError as exc:
+        raise ExecuteError(f"실행 권한이 없다: {bin_path}") from exc
+    except OSError as exc:
+        raise ExecuteError(f"실행 실패: {bin_path}: {exc}") from exc
+    except subprocess.SubprocessError as exc:
+        raise ExecuteError(f"서브프로세스 오류: {bin_path}: {exc}") from exc
     return {"exit": proc.returncode, "stdout": proc.stdout}
 
 
@@ -708,7 +977,10 @@ def record_session(
     """세션을 실행해 JSONL 이벤트를 만든다. execute 가 없으면 실바이너리 필요."""
     issues = validate_session(session)
     if issues:
-        raise SessionError("세션 정의가 유효하지 않다: " + "; ".join(issues))
+        raise SessionSchemaError(
+            "세션 정의가 유효하지 않다: " + "; ".join(issues),
+            detail=list(issues),
+        )
     ctx = context or SessionContext.from_session(session)
     if execute is None:
         resolved_bin = require_record_bin(bin_path)
@@ -720,24 +992,46 @@ def record_session(
         )
 
     if ctx.sub_dir:
-        os.makedirs(ctx.sub_dir, exist_ok=True)
+        try:
+            os.makedirs(ctx.sub_dir, exist_ok=True)
+        except OSError as exc:
+            raise WriteError(
+                f"작업 폴더를 만들 수 없다: {ctx.sub_dir}: {exc}",
+                path=ctx.sub_dir,
+            ) from exc
 
     events = []
-    for step in session["steps"]:
+    for step_index, step in enumerate(session["steps"]):
         argv = resolve_argv(step["run"], ctx, create_parents=True)
-        result = execute(bin_path, argv)
+        try:
+            result = execute(bin_path, argv)
+        except SessionError:
+            raise
+        except Exception as exc:
+            raise ExecuteError(
+                f"실행기 예외 (steps[{step_index}] {argv[:3]}): {exc}"
+            ) from exc
         if not isinstance(result, dict) or "exit" not in result:
-            raise SessionError(f"실행기가 exit 을 반환하지 않았다: {argv[:3]}")
+            raise ExecuteError(f"실행기가 exit 을 반환하지 않았다: {argv[:3]}")
+        try:
+            exit_code = int(result["exit"])
+        except (TypeError, ValueError) as exc:
+            raise ExecuteError(
+                f"실행기 exit 이 정수가 아니다: {result.get('exit')!r}"
+            ) from exc
         path_ok = None
         expect_path = step.get("expectPath")
         if isinstance(expect_path, str) and expect_path:
             resolved = resolve_token(expect_path, ctx, create_parents=False)
             path_ok = os.path.exists(resolved)
-        ts = clock() if clock else utc_now()
+        try:
+            ts = clock() if clock else utc_now()
+        except Exception as exc:
+            raise SessionError(f"시계 콜백 예외: {exc}") from exc
         events.append(
             build_trace_event(
                 argv,
-                int(result["exit"]),
+                exit_code,
                 stdout=result.get("stdout"),
                 expect_exit=normalize_expect_exit(step),
                 path_ok=path_ok,
@@ -814,6 +1108,36 @@ def render_score(report: dict) -> str:
     return "\n".join(lines)
 
 
+REASON_LABELS_KO = {
+    REASON_WRONG_COMMAND: "명령 계열 불일치",
+    REASON_WRONG_ORDER: "순서 불일치",
+    REASON_WRONG_EXIT: "종료 코드 불일치",
+    REASON_EXTRA_STEP: "여분 스텝",
+    REASON_MISSING_STEP: "누락 스텝",
+    REASON_WRONG_PATH: "기대 경로 없음",
+    REASON_BAD_TRACE: "트레이스 계약 위반",
+    REASON_BAD_SESSION: "세션 정의 계약 위반",
+}
+
+
+def reason_label_ko(reason: str) -> str:
+    return REASON_LABELS_KO.get(reason, reason)
+
+
+def render_error(exc: BaseException) -> str:
+    """예외를 한 줄 한국어 진단으로 접는다. CLI stderr / 문서 예시용."""
+    if isinstance(exc, RecordRefused):
+        return f"기록 거절: {exc}"
+    if isinstance(exc, SessionError):
+        bits = [f"{exc.code}: {exc}"]
+        if exc.path:
+            bits.append(f"경로={exc.path}")
+        if exc.line is not None:
+            bits.append(f"줄={exc.line}")
+        return " ".join(bits)
+    return f"미분류 예외: {type(exc).__name__}: {exc}"
+
+
 def validate_report(issues: list[str], session_id: str | None = None) -> dict:
     return {
         "kind": VALIDATE_KIND,
@@ -845,24 +1169,20 @@ def cmd_validate(args) -> int:
 
 
 def cmd_score_replay(args) -> int:
+    """픽스처 JSONL 만으로 채점한다. rhwp 바이너리를 부르지 않는다."""
+    session = None
     try:
         session = load_session_file(args.session)
         events = load_trace_file(args.replay)
     except SessionError as exc:
-        report = {
-            "kind": REPORT_KIND,
-            "schemaVersion": SCHEMA_VERSION,
-            "ok": False,
-            "sessionId": None,
-            "declared": 0,
-            "observed": 0,
-            "matched": 0,
-            "orderOk": False,
-            "steps": [],
-            "extraSteps": [],
-            "missingSteps": [],
-            "mismatches": [{"reason": REASON_BAD_TRACE, "detail": str(exc)}],
-        }
+        sid = None
+        if isinstance(session, dict):
+            sid = session.get("id")
+        report = fail_score_report(
+            classify_exception(exc),
+            str(exc),
+            session_id=sid,
+        )
         emit(report, args.json, render_score(report))
         return FAIL_EXIT
     ctx = SessionContext.from_session(session, input_path=args.input, sub_dir=args.sub_dir)
@@ -882,7 +1202,7 @@ def cmd_record(args) -> int:
         return USAGE_EXIT
     except SessionError as exc:
         sys.stderr.write(str(exc) + "\n")
-        return FAIL_EXIT
+        return getattr(exc, "exit_code", FAIL_EXIT)
     report = score_session(session, events, ctx)
     payload = {
         "kind": RECORD_KIND,

--- a/gym/tools/agent_session.py
+++ b/gym/tools/agent_session.py
@@ -1,0 +1,946 @@
+"""gym 에이전트 세션 트레이스 — 선언된 명령 열을 기록하고 경로를 채점한다.
+
+## 왜 이 도구인가 (종점만 보면 경로가 사라진다)
+
+gym 채점은 산출(종점)을 본다. `trajectory.py` 는 기준 풀이에서 마지막 외부 스텝을
+잘라 그 스텝이 load-bearing 인지 감사한다. 둘 다 "에이전트가 실제로 어떤 명령
+열을 어떤 순서로 밟았는가"는 파일로 남기지 않는다. 종점만 맞으면 우회·역순·여분
+명령도 만점이 된다.
+
+이 도구는 **선언된 세션**(명령 열 + 기대 종료)과 **기록된 트레이스**(JSONL)를
+기계 대조한다. 채점 축은 명령 계열(`argv[0]`)·종료 코드·순서다. LLM-judge 도
+골든 경로 문자열 비교도 쓰지 않는다.
+
+재생(`score-replay`)은 rhwp 를 부르지 않는다 — 픽스처 JSONL 만으로 단위 시험이
+가능하다. 기록(`record`)은 `--bin` 이 있을 때만 실행한다. 없으면 거절한다.
+없는 바이너리를 가장해 트레이스를 위조하지 않는다.
+
+## 세션 정의
+
+    {
+      "id": "inspect-then-export",
+      "input": "samples/x.hwp",
+      "subDir": "work",
+      "steps": [
+        {"run": ["info", "{input}", "--json"], "expectExit": 0},
+        {"run": ["export-text", "{input}", "-o", "{sub:out.txt}"],
+         "expectExit": 0, "expectPath": "{sub:out.txt}"}
+      ]
+    }
+
+`{input}` 은 세션(또는 CLI) 입력 경로, `{sub:이름}` 은 작업 폴더 안 경로다.
+
+## 트레이스 JSONL (한 줄 = 한 스텝)
+
+    {"ts": "2026-08-18T00:00:00Z", "argv": ["info", "samples/x.hwp", "--json"],
+     "exit": 0, "stdoutSha256": "<hex>", "ok": true}
+
+## 사용
+
+    python gym/tools/agent_session.py validate --session S.json
+    python gym/tools/agent_session.py score-replay --session S.json --replay T.jsonl
+    python gym/tools/agent_session.py record --session S.json --bin target/debug/rhwp --out T.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GYM_ROOT = os.path.dirname(HERE)
+REPO_ROOT = os.path.dirname(GYM_ROOT)
+
+SCHEMA_VERSION = "1.0"
+REPORT_KIND = "gymAgentSession"
+VALIDATE_KIND = "gymAgentSessionValidate"
+RECORD_KIND = "gymAgentSessionRecord"
+
+PLACEHOLDER_RE = re.compile(r"\{([^{}]+)\}")
+HEX64_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+SUB_NAME_RE = re.compile(r"^[^\s{}]+$")
+
+REASON_WRONG_COMMAND = "wrongCommand"
+REASON_WRONG_ORDER = "wrongOrder"
+REASON_WRONG_EXIT = "wrongExit"
+REASON_EXTRA_STEP = "extraStep"
+REASON_MISSING_STEP = "missingStep"
+REASON_WRONG_PATH = "wrongPath"
+REASON_BAD_TRACE = "badTrace"
+REASON_BAD_SESSION = "badSession"
+
+USAGE_EXIT = 2
+FAIL_EXIT = 1
+OK_EXIT = 0
+
+
+class SessionError(ValueError):
+    """세션·트레이스·기록 입력이 계약을 깨뜨렸을 때."""
+
+
+class RecordRefused(SessionError):
+    """record 가 바이너리 없이 위조하려 할 때 — 실행하지 않고 거절."""
+
+
+class SessionContext:
+    """자리표 해석에 쓰는 입력 문서·작업 폴더. 없으면 해당 자리표는 미해석."""
+
+    def __init__(self, input_path: str | None = None, sub_dir: str | None = None):
+        self.input_path = input_path
+        self.sub_dir = sub_dir
+
+    @classmethod
+    def from_session(
+        cls,
+        session: dict,
+        input_path: str | None = None,
+        sub_dir: str | None = None,
+    ) -> SessionContext:
+        return cls(
+            input_path if input_path is not None else session.get("input"),
+            sub_dir if sub_dir is not None else session.get("subDir"),
+        )
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_text(data: str | bytes | None) -> str | None:
+    if data is None:
+        return None
+    if isinstance(data, str):
+        data = data.encode("utf-8")
+    return sha256_bytes(data)
+
+
+def command_family(argv) -> str:
+    """명령 계열 = argv[0]. 빈 argv 는 빈 문자열."""
+    if not argv:
+        return ""
+    first = argv[0]
+    if not isinstance(first, str):
+        return ""
+    return first
+
+
+def find_placeholders(token: str) -> list[tuple[int, int, str]]:
+    """토큰 안 `{…}` 자리표의 (시작, 끝, 본문) 목록. 중첩 없음."""
+    if not isinstance(token, str):
+        return []
+    found = []
+    for match in PLACEHOLDER_RE.finditer(token):
+        found.append((match.start(), match.end(), match.group(1)))
+    return found
+
+
+def classify_placeholder(body: str) -> tuple[str, str | None]:
+    """자리표 본문 → (종류, 이름). 종류: input / sub / unknown."""
+    if body == "input":
+        return "input", None
+    if body.startswith("sub:"):
+        return "sub", body[4:]
+    return "unknown", body
+
+
+def placeholder_issues(token: str, path: str) -> list[str]:
+    issues = []
+    if not isinstance(token, str):
+        issues.append(f"{path}: 인자는 문자열이어야 한다")
+        return issues
+    if token.count("{") != token.count("}"):
+        issues.append(f"{path}: 자리표 중괄호가 짝이 아니다: {token!r}")
+    for _start, _end, body in find_placeholders(token):
+        kind, name = classify_placeholder(body)
+        if kind == "sub":
+            if not name:
+                issues.append(f"{path}: {{sub:}} 이름이 비었다")
+            elif not SUB_NAME_RE.match(name):
+                issues.append(f"{path}: {{sub:{name}}} 이름이 유효하지 않다")
+        elif kind == "unknown":
+            issues.append(f"{path}: 알 수 없는 자리표 {{{body}}}")
+    if "{" in token and not find_placeholders(token) and "}" not in token:
+        issues.append(f"{path}: 닫히지 않은 자리표: {token!r}")
+    return issues
+
+
+def resolve_token(token: str, context: SessionContext | None, create_parents: bool = False) -> str:
+    """한 인자에서 `{input}` / `{sub:이름}` 을 치환. 모르는 토큰은 그대로 둔다."""
+    if not isinstance(token, str) or "{" not in token:
+        return token
+    ctx = context or SessionContext()
+    out = []
+    cursor = 0
+    for start, end, body in find_placeholders(token):
+        out.append(token[cursor:start])
+        kind, name = classify_placeholder(body)
+        if kind == "input":
+            if ctx.input_path is None:
+                out.append(token[start:end])
+            else:
+                out.append(ctx.input_path)
+        elif kind == "sub":
+            if ctx.sub_dir is None or not name:
+                out.append(token[start:end])
+            else:
+                path = os.path.join(ctx.sub_dir, name.replace("/", os.sep))
+                if create_parents:
+                    parent = os.path.dirname(path)
+                    if parent:
+                        os.makedirs(parent, exist_ok=True)
+                out.append(path)
+        else:
+            out.append(token[start:end])
+        cursor = end
+    out.append(token[cursor:])
+    return "".join(out)
+
+
+def resolve_argv(argv, context: SessionContext | None, create_parents: bool = False) -> list[str]:
+    return [resolve_token(a, context, create_parents=create_parents) for a in list(argv)]
+
+
+def expected_ok(exit_code: int, expect_exit: int, path_ok: bool | None) -> bool:
+    if exit_code != expect_exit:
+        return False
+    if path_ok is False:
+        return False
+    return True
+
+
+def normalize_expect_exit(step: dict) -> int:
+    raw = step.get("expectExit", 0)
+    if raw is None:
+        return 0
+    return int(raw)
+
+
+def declared_family(step: dict) -> str:
+    return command_family(step.get("run") or [])
+
+
+def validate_session(doc) -> list[str]:
+    """세션 정의 구조 검사. 빈 목록이면 유효. 바이너리 불요."""
+    issues: list[str] = []
+    if not isinstance(doc, dict):
+        return ["세션 정의는 객체여야 한다"]
+    sid = doc.get("id")
+    if not isinstance(sid, str) or not sid.strip():
+        issues.append("id 가 비어 있다")
+    if "input" in doc and doc["input"] is not None and not isinstance(doc["input"], str):
+        issues.append("input 은 문자열이어야 한다")
+    if "subDir" in doc and doc["subDir"] is not None and not isinstance(doc["subDir"], str):
+        issues.append("subDir 은 문자열이어야 한다")
+    steps = doc.get("steps")
+    if not isinstance(steps, list):
+        issues.append("steps 가 배열이 아니다")
+        return issues
+    if not steps:
+        issues.append("steps 가 비어 있다")
+        return issues
+    for index, step in enumerate(steps):
+        prefix = f"steps[{index}]"
+        if not isinstance(step, dict):
+            issues.append(f"{prefix}: 객체여야 한다")
+            continue
+        run = step.get("run")
+        if not isinstance(run, list) or not run:
+            issues.append(f"{prefix}.run: 비어 있지 않은 인자 배열이어야 한다")
+        else:
+            for arg_i, arg in enumerate(run):
+                if not isinstance(arg, str) or arg == "":
+                    issues.append(f"{prefix}.run[{arg_i}]: 비어 있지 않은 문자열이어야 한다")
+                else:
+                    issues.extend(placeholder_issues(arg, f"{prefix}.run[{arg_i}]"))
+            if isinstance(run[0], str) and not run[0].strip():
+                issues.append(f"{prefix}.run[0]: 명령 계열이 비어 있다")
+        if "expectExit" in step and step["expectExit"] is not None:
+            if not isinstance(step["expectExit"], int) or isinstance(step["expectExit"], bool):
+                issues.append(f"{prefix}.expectExit: 정수여야 한다")
+        if "expectPath" in step and step["expectPath"] is not None:
+            if not isinstance(step["expectPath"], str) or not step["expectPath"]:
+                issues.append(f"{prefix}.expectPath: 비어 있지 않은 문자열이어야 한다")
+            else:
+                issues.extend(placeholder_issues(step["expectPath"], f"{prefix}.expectPath"))
+    return issues
+
+
+def validate_trace_event(event, index: int) -> list[str]:
+    prefix = f"trace[{index}]"
+    if not isinstance(event, dict):
+        return [f"{prefix}: 객체여야 한다"]
+    issues = []
+    ts = event.get("ts")
+    if not isinstance(ts, str) or not ts.strip():
+        issues.append(f"{prefix}.ts: 비어 있지 않은 문자열이어야 한다")
+    argv = event.get("argv")
+    if not isinstance(argv, list) or not argv:
+        issues.append(f"{prefix}.argv: 비어 있지 않은 배열이어야 한다")
+    else:
+        for arg_i, arg in enumerate(argv):
+            if not isinstance(arg, str):
+                issues.append(f"{prefix}.argv[{arg_i}]: 문자열이어야 한다")
+    if "exit" not in event:
+        issues.append(f"{prefix}.exit: 필수")
+    elif not isinstance(event["exit"], int) or isinstance(event["exit"], bool):
+        issues.append(f"{prefix}.exit: 정수여야 한다")
+    if "ok" not in event:
+        issues.append(f"{prefix}.ok: 필수")
+    elif not isinstance(event["ok"], bool):
+        issues.append(f"{prefix}.ok: 불리언이어야 한다")
+    digest = event.get("stdoutSha256")
+    if digest is not None:
+        if not isinstance(digest, str) or not HEX64_RE.match(digest):
+            issues.append(f"{prefix}.stdoutSha256: 64자리 hex 여야 한다")
+    return issues
+
+
+def parse_trace_jsonl(text: str) -> list[dict]:
+    """JSONL 본문 → 이벤트 목록. 빈 줄은 건너뛴다. 잘못된 줄은 SessionError."""
+    events = []
+    if text is None:
+        raise SessionError("트레이스가 비어 있다")
+    for line_no, raw in enumerate(text.splitlines(), start=1):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except ValueError as exc:
+            raise SessionError(f"trace 줄 {line_no}: JSON 이 아니다: {exc}") from exc
+        events.append(event)
+    if not events:
+        raise SessionError("트레이스에 이벤트가 없다")
+    return events
+
+
+def validate_trace(events) -> list[str]:
+    if not isinstance(events, list):
+        return ["트레이스는 이벤트 배열이어야 한다"]
+    issues = []
+    for index, event in enumerate(events):
+        issues.extend(validate_trace_event(event, index))
+    return issues
+
+
+def load_json_file(path: str):
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+    except FileNotFoundError as exc:
+        raise SessionError(f"파일을 찾을 수 없다: {path}") from exc
+    except ValueError as exc:
+        raise SessionError(f"JSON 파싱 실패: {path}: {exc}") from exc
+
+
+def load_text_file(path: str) -> str:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return fh.read()
+    except FileNotFoundError as exc:
+        raise SessionError(f"파일을 찾을 수 없다: {path}") from exc
+    except OSError as exc:
+        raise SessionError(f"파일 읽기 실패: {path}: {exc}") from exc
+
+
+def write_jsonl(path: str, events: list[dict]) -> None:
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    lines = [json.dumps(ev, ensure_ascii=False, separators=(",", ":")) for ev in events]
+    with open(path, "w", encoding="utf-8", newline="\n") as fh:
+        fh.write("\n".join(lines))
+        if lines:
+            fh.write("\n")
+
+
+def load_session_file(path: str) -> dict:
+    doc = load_json_file(path)
+    issues = validate_session(doc)
+    if issues:
+        raise SessionError("세션 정의가 유효하지 않다: " + "; ".join(issues))
+    return doc
+
+
+def load_trace_file(path: str) -> list[dict]:
+    events = parse_trace_jsonl(load_text_file(path))
+    issues = validate_trace(events)
+    if issues:
+        raise SessionError("트레이스가 유효하지 않다: " + "; ".join(issues))
+    return events
+
+
+def lcs_table(left: list[str], right: list[str]) -> list[list[int]]:
+    n, m = len(left), len(right)
+    table = [[0] * (m + 1) for _ in range(n + 1)]
+    for i, a in enumerate(left):
+        row = table[i]
+        nxt = table[i + 1]
+        for j, b in enumerate(right):
+            if a == b:
+                nxt[j + 1] = row[j] + 1
+            else:
+                nxt[j + 1] = row[j + 1] if row[j + 1] >= nxt[j] else nxt[j]
+    return table
+
+
+def lcs_ops(left: list[str], right: list[str]) -> list[tuple[str, int | None, int | None]]:
+    """LCS 역추적 — match / del / ins. 인덱스는 원 수열 기준."""
+    table = lcs_table(left, right)
+    i, j = len(left), len(right)
+    raw: list[tuple[str, int | None, int | None]] = []
+    while i > 0 or j > 0:
+        if i > 0 and j > 0 and left[i - 1] == right[j - 1]:
+            raw.append(("match", i - 1, j - 1))
+            i -= 1
+            j -= 1
+        elif j > 0 and (i == 0 or table[i][j - 1] >= table[i - 1][j]):
+            raw.append(("ins", None, j - 1))
+            j -= 1
+        else:
+            raw.append(("del", i - 1, None))
+            i -= 1
+    raw.reverse()
+    return raw
+
+
+def collapse_ops(ops: list[tuple[str, int | None, int | None]]) -> list[tuple[str, int | None, int | None]]:
+    """인접 del+ins 를 sub(명령 교체)로 접어 여분+누락으로 오인하지 않게 한다."""
+    out: list[tuple[str, int | None, int | None]] = []
+    index = 0
+    while index < len(ops):
+        kind, dec_i, obs_i = ops[index]
+        if (
+            kind == "del"
+            and index + 1 < len(ops)
+            and ops[index + 1][0] == "ins"
+        ):
+            out.append(("sub", dec_i, ops[index + 1][2]))
+            index += 2
+            continue
+        if (
+            kind == "ins"
+            and index + 1 < len(ops)
+            and ops[index + 1][0] == "del"
+        ):
+            out.append(("sub", ops[index + 1][1], obs_i))
+            index += 2
+            continue
+        out.append((kind, dec_i, obs_i))
+        index += 1
+    return out
+
+
+def same_multiset(left: list[str], right: list[str]) -> bool:
+    if len(left) != len(right):
+        return False
+    counts: dict[str, int] = {}
+    for item in left:
+        counts[item] = counts.get(item, 0) + 1
+    for item in right:
+        counts[item] = counts.get(item, 0) - 1
+        if counts[item] < 0:
+            return False
+    return all(v == 0 for v in counts.values())
+
+
+def classify_sequence(declared: list[str], observed: list[str]) -> list[str]:
+    """선언 계열 vs 관측 계열 → 순서/여분/누락/교체 사유. 같으면 빈 목록."""
+    if declared == observed:
+        return []
+    if not declared and observed:
+        return [REASON_EXTRA_STEP]
+    if declared and not observed:
+        return [REASON_MISSING_STEP]
+    if len(observed) > len(declared) and observed[: len(declared)] == declared:
+        return [REASON_EXTRA_STEP]
+    if len(observed) < len(declared) and declared[: len(observed)] == observed:
+        return [REASON_MISSING_STEP]
+    if same_multiset(declared, observed) and declared != observed:
+        return [REASON_WRONG_ORDER]
+    reasons = []
+    for kind, _dec_i, _obs_i in collapse_ops(lcs_ops(declared, observed)):
+        if kind == "ins" and REASON_EXTRA_STEP not in reasons:
+            reasons.append(REASON_EXTRA_STEP)
+        elif kind == "del" and REASON_MISSING_STEP not in reasons:
+            reasons.append(REASON_MISSING_STEP)
+        elif kind == "sub" and REASON_WRONG_COMMAND not in reasons:
+            reasons.append(REASON_WRONG_COMMAND)
+    if not reasons:
+        reasons.append(REASON_WRONG_COMMAND)
+    return reasons
+
+
+def _path_exists(path: str | None) -> bool | None:
+    if not path or "{" in path:
+        return None
+    return os.path.exists(path)
+
+
+def compare_step(
+    index: int,
+    step: dict,
+    event: dict | None,
+    context: SessionContext | None,
+    check_paths: bool = False,
+) -> dict:
+    """한 스텝의 계열·종료·순서 대조. event 가 없으면 누락.
+
+    재생 채점의 합격 축은 계열·종료·순서다. expectPath 디스크 존재는
+    `check_paths=True`(기록 직후 재검증)일 때만 합격에 넣는다. 픽스처
+    JSONL 재생이 작업 폴더 부재로 실패하지 않게 한다.
+    """
+    family = declared_family(step)
+    expect_exit = normalize_expect_exit(step)
+    expect_path = step.get("expectPath")
+    resolved_path = None
+    if isinstance(expect_path, str):
+        resolved_path = resolve_token(expect_path, context)
+    row = {
+        "index": index,
+        "declaredFamily": family,
+        "observedFamily": None,
+        "familyOk": False,
+        "declaredExit": expect_exit,
+        "observedExit": None,
+        "exitOk": False,
+        "orderOk": False,
+        "pathOk": None,
+        "ok": False,
+    }
+    if event is None:
+        return row
+    observed_family = command_family(event.get("argv") or [])
+    observed_exit = event.get("exit")
+    family_ok = observed_family == family
+    exit_ok = observed_exit == expect_exit
+    path_ok = None
+    if check_paths and resolved_path is not None:
+        path_ok = _path_exists(resolved_path)
+    row["observedFamily"] = observed_family
+    row["observedExit"] = observed_exit
+    row["familyOk"] = family_ok
+    row["exitOk"] = bool(exit_ok)
+    row["orderOk"] = family_ok
+    row["pathOk"] = path_ok
+    path_blocks = check_paths and path_ok is False
+    row["ok"] = bool(family_ok and exit_ok and not path_blocks)
+    return row
+
+
+def score_session(
+    session: dict,
+    events: list[dict],
+    context: SessionContext | None = None,
+    check_paths: bool = False,
+) -> dict:
+    """선언 세션 vs 트레이스. 기본은 계열·종료·순서만(디스크 불요)."""
+    session_issues = validate_session(session)
+    if session_issues:
+        return {
+            "kind": REPORT_KIND,
+            "schemaVersion": SCHEMA_VERSION,
+            "ok": False,
+            "sessionId": session.get("id") if isinstance(session, dict) else None,
+            "declared": 0,
+            "observed": 0,
+            "matched": 0,
+            "orderOk": False,
+            "steps": [],
+            "extraSteps": [],
+            "missingSteps": [],
+            "mismatches": [{"reason": REASON_BAD_SESSION, "detail": issue} for issue in session_issues],
+        }
+    trace_issues = validate_trace(events)
+    if trace_issues:
+        return {
+            "kind": REPORT_KIND,
+            "schemaVersion": SCHEMA_VERSION,
+            "ok": False,
+            "sessionId": session["id"],
+            "declared": len(session["steps"]),
+            "observed": len(events) if isinstance(events, list) else 0,
+            "matched": 0,
+            "orderOk": False,
+            "steps": [],
+            "extraSteps": [],
+            "missingSteps": [],
+            "mismatches": [{"reason": REASON_BAD_TRACE, "detail": issue} for issue in trace_issues],
+        }
+
+    steps = session["steps"]
+    ctx = context or SessionContext.from_session(session)
+    declared_fams = [declared_family(step) for step in steps]
+    observed_fams = [command_family(ev.get("argv") or []) for ev in events]
+    seq_reasons = classify_sequence(declared_fams, observed_fams)
+
+    compared = []
+    paired = min(len(steps), len(events))
+    for index in range(paired):
+        compared.append(compare_step(index, steps[index], events[index], ctx, check_paths))
+    missing_rows = []
+    for index in range(paired, len(steps)):
+        row = compare_step(index, steps[index], None, ctx, check_paths)
+        compared.append(row)
+        missing_rows.append({
+            "index": index,
+            "family": declared_fams[index],
+            "expectExit": normalize_expect_exit(steps[index]),
+        })
+    extra_rows = []
+    for offset, event in enumerate(events[len(steps):]):
+        extra_rows.append({
+            "index": len(steps) + offset,
+            "family": command_family(event.get("argv") or []),
+            "exit": event.get("exit"),
+            "argv": list(event.get("argv") or []),
+        })
+
+    mismatches: list[dict] = []
+    for reason in seq_reasons:
+        payload = {"reason": reason, "declared": list(declared_fams), "observed": list(observed_fams)}
+        if reason == REASON_EXTRA_STEP:
+            payload["extra"] = extra_rows
+        if reason == REASON_MISSING_STEP:
+            payload["missing"] = missing_rows
+        mismatches.append(payload)
+
+    # 순서·계열은 맞는데 종료 코드나 expectPath 만 틀린 경우.
+    if REASON_WRONG_ORDER not in seq_reasons:
+        for row in compared:
+            if row["observedFamily"] is None:
+                continue
+            if row["familyOk"] and not row["exitOk"]:
+                mismatches.append({
+                    "reason": REASON_WRONG_EXIT,
+                    "index": row["index"],
+                    "declaredExit": row["declaredExit"],
+                    "observedExit": row["observedExit"],
+                })
+            if check_paths and row["familyOk"] and row["pathOk"] is False:
+                mismatches.append({
+                    "reason": REASON_WRONG_PATH,
+                    "index": row["index"],
+                    "expectPath": steps[row["index"]].get("expectPath"),
+                })
+
+    order_ok = declared_fams == observed_fams
+    matched = sum(1 for row in compared if row["ok"])
+    ok = order_ok and not extra_rows and not missing_rows and not mismatches
+    return {
+        "kind": REPORT_KIND,
+        "schemaVersion": SCHEMA_VERSION,
+        "ok": ok,
+        "sessionId": session["id"],
+        "declared": len(steps),
+        "observed": len(events),
+        "matched": matched,
+        "orderOk": order_ok,
+        "steps": compared,
+        "extraSteps": extra_rows,
+        "missingSteps": missing_rows,
+        "mismatches": mismatches,
+    }
+
+
+def build_trace_event(
+    argv,
+    exit_code: int,
+    stdout: str | bytes | None = None,
+    expect_exit: int = 0,
+    path_ok: bool | None = None,
+    ts: str | None = None,
+) -> dict:
+    event = {
+        "ts": ts or utc_now(),
+        "argv": [str(a) for a in list(argv)],
+        "exit": int(exit_code),
+        "ok": expected_ok(int(exit_code), int(expect_exit), path_ok),
+    }
+    digest = sha256_text(stdout)
+    if digest is not None:
+        event["stdoutSha256"] = digest
+    return event
+
+
+def require_record_bin(bin_path: str | None) -> str:
+    """record 는 --bin 이 실재해야 한다. 없으면 거절(위조 금지)."""
+    if bin_path is None or not str(bin_path).strip():
+        raise RecordRefused(
+            "record 모드는 --bin 이 필요합니다. 바이너리 없이 트레이스를 위조하지 않습니다."
+        )
+    path = str(bin_path).strip()
+    if not os.path.isfile(path):
+        raise RecordRefused(
+            f"record 모드: 바이너리를 찾을 수 없습니다: {path} "
+            "(없는 실행파일을 가장해 기록하지 않습니다)"
+        )
+    return path
+
+
+def default_execute(bin_path: str, argv: list[str], cwd: str | None = None) -> dict:
+    proc = subprocess.run(
+        [bin_path] + list(argv),
+        cwd=cwd or REPO_ROOT,
+        capture_output=True,
+    )
+    return {"exit": proc.returncode, "stdout": proc.stdout}
+
+
+def record_session(
+    session: dict,
+    bin_path: str | None,
+    out_path: str | None = None,
+    context: SessionContext | None = None,
+    execute=None,
+    clock=None,
+) -> list[dict]:
+    """세션을 실행해 JSONL 이벤트를 만든다. execute 가 없으면 실바이너리 필요."""
+    issues = validate_session(session)
+    if issues:
+        raise SessionError("세션 정의가 유효하지 않다: " + "; ".join(issues))
+    ctx = context or SessionContext.from_session(session)
+    if execute is None:
+        resolved_bin = require_record_bin(bin_path)
+        execute = lambda _bin, argv: default_execute(resolved_bin, argv)
+    elif bin_path is None or not str(bin_path).strip():
+        # 주입 실행기여도 호출부가 --bin 없이 record 를 열면 거절한다.
+        raise RecordRefused(
+            "record 모드는 --bin 이 필요합니다. 바이너리 없이 트레이스를 위조하지 않습니다."
+        )
+
+    if ctx.sub_dir:
+        os.makedirs(ctx.sub_dir, exist_ok=True)
+
+    events = []
+    for step in session["steps"]:
+        argv = resolve_argv(step["run"], ctx, create_parents=True)
+        result = execute(bin_path, argv)
+        if not isinstance(result, dict) or "exit" not in result:
+            raise SessionError(f"실행기가 exit 을 반환하지 않았다: {argv[:3]}")
+        path_ok = None
+        expect_path = step.get("expectPath")
+        if isinstance(expect_path, str) and expect_path:
+            resolved = resolve_token(expect_path, ctx, create_parents=False)
+            path_ok = os.path.exists(resolved)
+        ts = clock() if clock else utc_now()
+        events.append(
+            build_trace_event(
+                argv,
+                int(result["exit"]),
+                stdout=result.get("stdout"),
+                expect_exit=normalize_expect_exit(step),
+                path_ok=path_ok,
+                ts=ts,
+            )
+        )
+    if out_path:
+        write_jsonl(out_path, events)
+    return events
+
+
+def render_validate(issues: list[str], session_id: str | None = None) -> str:
+    if not issues:
+        label = session_id or "세션"
+        return f"gym 에이전트 세션 검증: {label} — 유효"
+    lines = [f"gym 에이전트 세션 검증: 위반 {len(issues)}건"]
+    for issue in issues:
+        lines.append(f"  - {issue}")
+    return "\n".join(lines)
+
+
+def render_score(report: dict) -> str:
+    sid = report.get("sessionId") or "?"
+    if report.get("ok"):
+        head = (
+            f"gym 에이전트 세션: {sid} — 통과 "
+            f"({report.get('matched')}/{report.get('declared')} 스텝, 순서·계열·종료 일치)"
+        )
+    else:
+        head = (
+            f"gym 에이전트 세션: {sid} — 실패 "
+            f"(일치 {report.get('matched')}/{report.get('declared')}, "
+            f"관측 {report.get('observed')})"
+        )
+    lines = [head]
+    for row in report.get("steps") or []:
+        idx = row.get("index")
+        if row.get("observedFamily") is None:
+            lines.append(f"  [{idx}] 누락 — 기대 {row.get('declaredFamily')} exit={row.get('declaredExit')}")
+            continue
+        mark = "일치" if row.get("ok") else "불일치"
+        detail = (
+            f"기대 {row.get('declaredFamily')} exit={row.get('declaredExit')}, "
+            f"관측 {row.get('observedFamily')} exit={row.get('observedExit')}"
+        )
+        lines.append(f"  [{idx}] {mark} — {detail}")
+    for extra in report.get("extraSteps") or []:
+        lines.append(
+            f"  [+{extra.get('index')}] 여분 — {extra.get('family')} exit={extra.get('exit')}"
+        )
+    for mismatch in report.get("mismatches") or []:
+        reason = mismatch.get("reason")
+        if reason == REASON_WRONG_ORDER:
+            lines.append(
+                f"  순서 불일치: 선언 {mismatch.get('declared')} / 관측 {mismatch.get('observed')}"
+            )
+        elif reason == REASON_WRONG_COMMAND:
+            lines.append(
+                f"  명령 계열 불일치: 선언 {mismatch.get('declared')} / 관측 {mismatch.get('observed')}"
+            )
+        elif reason == REASON_WRONG_EXIT:
+            lines.append(
+                f"  [{mismatch.get('index')}] 종료 코드 불일치: "
+                f"기대 {mismatch.get('declaredExit')} / 관측 {mismatch.get('observedExit')}"
+            )
+        elif reason == REASON_EXTRA_STEP:
+            lines.append(f"  여분 스텝 {len(mismatch.get('extra') or [])}건")
+        elif reason == REASON_MISSING_STEP:
+            lines.append(f"  누락 스텝 {len(mismatch.get('missing') or [])}건")
+        elif reason == REASON_WRONG_PATH:
+            lines.append(f"  [{mismatch.get('index')}] 기대 경로 없음: {mismatch.get('expectPath')}")
+        elif reason in (REASON_BAD_SESSION, REASON_BAD_TRACE):
+            lines.append(f"  {mismatch.get('detail')}")
+    return "\n".join(lines)
+
+
+def validate_report(issues: list[str], session_id: str | None = None) -> dict:
+    return {
+        "kind": VALIDATE_KIND,
+        "schemaVersion": SCHEMA_VERSION,
+        "ok": len(issues) == 0,
+        "sessionId": session_id,
+        "issueCount": len(issues),
+        "issues": list(issues),
+    }
+
+
+def emit(payload, as_json: bool, text: str) -> None:
+    if as_json:
+        sys.stdout.write(json.dumps(payload, ensure_ascii=False, indent=2) + "\n")
+    else:
+        sys.stdout.write(text + "\n")
+
+
+def cmd_validate(args) -> int:
+    try:
+        doc = load_json_file(args.session)
+    except SessionError as exc:
+        emit(validate_report([str(exc)]), args.json, render_validate([str(exc)]))
+        return FAIL_EXIT
+    issues = validate_session(doc)
+    sid = doc.get("id") if isinstance(doc, dict) else None
+    emit(validate_report(issues, sid), args.json, render_validate(issues, sid))
+    return OK_EXIT if not issues else FAIL_EXIT
+
+
+def cmd_score_replay(args) -> int:
+    try:
+        session = load_session_file(args.session)
+        events = load_trace_file(args.replay)
+    except SessionError as exc:
+        report = {
+            "kind": REPORT_KIND,
+            "schemaVersion": SCHEMA_VERSION,
+            "ok": False,
+            "sessionId": None,
+            "declared": 0,
+            "observed": 0,
+            "matched": 0,
+            "orderOk": False,
+            "steps": [],
+            "extraSteps": [],
+            "missingSteps": [],
+            "mismatches": [{"reason": REASON_BAD_TRACE, "detail": str(exc)}],
+        }
+        emit(report, args.json, render_score(report))
+        return FAIL_EXIT
+    ctx = SessionContext.from_session(session, input_path=args.input, sub_dir=args.sub_dir)
+    report = score_session(session, events, ctx)
+    emit(report, args.json, render_score(report))
+    return OK_EXIT if report["ok"] else FAIL_EXIT
+
+
+def cmd_record(args) -> int:
+    try:
+        require_record_bin(args.bin)
+        session = load_session_file(args.session)
+        ctx = SessionContext.from_session(session, input_path=args.input, sub_dir=args.sub_dir)
+        events = record_session(session, args.bin, out_path=args.out, context=ctx)
+    except RecordRefused as exc:
+        sys.stderr.write(str(exc) + "\n")
+        return USAGE_EXIT
+    except SessionError as exc:
+        sys.stderr.write(str(exc) + "\n")
+        return FAIL_EXIT
+    report = score_session(session, events, ctx)
+    payload = {
+        "kind": RECORD_KIND,
+        "schemaVersion": SCHEMA_VERSION,
+        "ok": report["ok"],
+        "sessionId": session["id"],
+        "out": args.out,
+        "eventCount": len(events),
+        "score": report,
+    }
+    emit(payload, args.json, render_score(report))
+    return OK_EXIT if report["ok"] else FAIL_EXIT
+
+
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(
+        description="gym 에이전트 세션 트레이스 — 선언된 명령 열을 기록·재생 채점"
+    )
+    sub = ap.add_subparsers(dest="cmd")
+
+    p_val = sub.add_parser("validate", help="세션 정의 JSON 검증 (바이너리 불요)")
+    p_val.add_argument("--session", required=True, help="세션 정의 JSON")
+    p_val.add_argument("--json", action="store_true")
+    p_val.set_defaults(func=cmd_validate)
+
+    p_rep = sub.add_parser("score-replay", help="기록된 JSONL 을 바이너리 없이 채점")
+    p_rep.add_argument("--session", required=True, help="세션 정의 JSON")
+    p_rep.add_argument("--replay", required=True, help="트레이스 JSONL")
+    p_rep.add_argument("--input", default=None, help="세션 input 덮어쓰기")
+    p_rep.add_argument("--sub-dir", default=None, dest="sub_dir", help="작업 폴더")
+    p_rep.add_argument("--json", action="store_true")
+    p_rep.set_defaults(func=cmd_score_replay)
+
+    p_rec = sub.add_parser("record", help="세션을 실행해 JSONL 기록 (--bin 필수)")
+    p_rec.add_argument("--session", required=True, help="세션 정의 JSON")
+    p_rec.add_argument("--bin", default=None, help="rhwp 실행 파일. 없으면 거절")
+    p_rec.add_argument("--out", required=True, help="트레이스 JSONL 출력 경로")
+    p_rec.add_argument("--input", default=None, help="세션 input 덮어쓰기")
+    p_rec.add_argument("--sub-dir", default=None, dest="sub_dir", help="작업 폴더")
+    p_rec.add_argument("--json", action="store_true")
+    p_rec.set_defaults(func=cmd_record)
+
+    return ap
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not getattr(args, "cmd", None):
+        parser.print_help()
+        return USAGE_EXIT
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
+        except Exception:
+            pass
+    sys.exit(main())

--- a/mydocs/working/gym_agent_session.md
+++ b/mydocs/working/gym_agent_session.md
@@ -1,0 +1,195 @@
+---
+kind: working
+status: active
+canonical: mydocs/working/gym_agent_session.md
+last_verified: 2026-08-18
+issue: 5206
+pr: 5211
+---
+
+# gym 에이전트 세션 도구 작업 노트 (PR #5211)
+
+## 한 줄
+
+`feat/gym-agent-session` 초안(세션 정의 + JSONL 재생 채점, 약 1350줄)에
+예외 계층·입출력 가드·실패 CLI 접기와 한국어 문서·경계 시험을 얹는다.
+새 PR 을 열지 않고 같은 브랜치에 얹는다.
+
+## 배경
+
+이슈 #5206 · PR #5211 초안은 경로 채점의 핵심만 닫았다.
+
+- 선언 세션 vs JSONL 트레이스를 계열·종료·순서로 대조
+- `validate` / `score-replay` / `record` Python CLI
+- 재생은 바이너리 없이 픽스처만, `record` 는 `--bin` 없으면 거절
+- 단위 시험 30건, pack 미변경
+
+초안에서 비어 있던 것:
+
+- 파일 없음·디렉터리·UTF-8·JSON 깨짐을 한 `SessionError` 로만 접음
+- 세션 실패와 트레이스 실패가 `score-replay` 에서 같은 `badTrace` 로 보임
+- 실행기 예외·exit 미반환·쓰기 실패의 유형이 없음
+- 한국어 사용 문서(`gym/docs`)와 작업 노트가 없음
+- Windows 에서 디렉터리 open 이 `PermissionError` 로 나오는 경우 미분류
+
+이 노트는 그 구멍을 메운 이유를 남긴다. 동작 계약의 정본은
+`gym/docs/agent_session.md` 다.
+
+## 범위
+
+포함한 것:
+
+- `gym/tools/agent_session.py` — 예외 계층, `wrap_io_error`,
+  `classify_exception`, `fail_score_report`, 로더/기록기 가드,
+  엄격 자리표, CLI 실패 분류
+- `scripts/tests/test_gym_agent_session.py` — 렌더·재생 무바이너리
+  계약·경로 검사·LCS 추가
+- `scripts/tests/test_gym_agent_session_errors.py` — 예외 카탈로그와
+  입출력·CLI 실패 전수
+- `gym/docs/agent_session.md` — 한국어 사용 문서
+- `mydocs/working/gym_agent_session.md` — 이 노트
+
+넣지 않은 것:
+
+- 새 rhwp CLI (`rhwp agent-session` 따위)
+- pack·과제·기준 풀이·profiles·checks·coverage
+- `gym/README.md` · `gym/PARK.md` 집계 문구
+- `trajectory.py` 연동 (마지막 스텝 감사와 경로 채점은 별 도구)
+- LLM-judge, 골든 경로 문자열 비교, stdout 본문 대조
+- `cargo fmt --all` (Python·문서만)
+- 기본 채점 경로(`score.py` / `certify.py`) 연결
+
+## 설계 원칙
+
+1. **재생은 바이너리 없이.** `score-replay` 서브파서에 `--bin` 이 없고
+   구현이 PATH 를 보지 않는다. 단위 시험이 이 계약을 잠근다.
+2. **기록은 위조하지 않는다.** `--bin` 없거나 파일이 아니면
+   `RecordRefused`(종료 2). 주입 실행기도 `--bin` 자리를 요구한다.
+3. **예외는 유형으로 가른다.** 없/권한/UTF-8/JSON/스키마/실행/쓰기를
+   한 메시지로 뭉개지 않는다. CLI 는 유형을 `badSession` /
+   `badTrace` / stderr 거절로 접는다.
+4. **채점 함수는 예외 대신 리포트.** `score_session` 은 잘못된
+   세션·트레이스를 `ok=false` 리포트로 낸다. 로더만 예외를 던진다.
+5. **자리표 기본은 관대하다.** 재생이 작업 폴더 부재로 실패하지
+   않는다. 엄격 모드는 별도 플래그.
+6. **새 CLI 표면 금지.** `run[0]` 은 이미 있는 명령 이름일 뿐이고
+   존재 여부를 바이너리에 묻지 않는다.
+
+## 예외 계층을 나눈 이유
+
+초안은 `SessionError` 와 `RecordRefused` 두 개만 있었다. 파일 없음과
+JSON 깨짐과 스키마 위반이 같은 유형이면 `score-replay --json` 소비자가
+재시도(파일 없음)와 수정(스키마)을 가릴 수 없다.
+
+| 층 | 유형 | 소비자가 하는 일 |
+|----|------|------------------|
+| 파일 | `*FileError` | 경로를 고친다 |
+| 파싱 | `*ParseError` | JSON/UTF-8 을 고친다 |
+| 스키마 | `*SchemaError` | 필드·자리표를 고친다 |
+| 실행 | `ExecuteError` | 바이너리·실행기를 본다 |
+| 쓰기 | `WriteError` | 출력 경로·디스크를 본다 |
+| 거절 | `RecordRefused` | `--bin` 을 준다. 위조하지 않는다 |
+
+Windows 특이: 디렉터리를 `open` 하면 `IsADirectoryError` 대신
+`PermissionError` 가 난다. `wrap_io_error` 는 `os.path.isdir` 을
+우선해 "권한이 없다"로 오인하지 않는다.
+
+UTF-8 BOM 은 JSONL 첫 줄을 깨뜨린다. `parse_trace_jsonl` 은 본문
+선두 BOM 을 한 번 벗긴다. 줄 중간 BOM 은 그대로 두어 파싱 실패가 된다.
+
+실행기가 이미 `SessionError` 를 던지면 다시 `ExecuteError` 로 감싸지
+않는다. `RecordRefused` 가 실행기에서 나와도 거절로 남아야 한다.
+
+## CLI 종료 코드
+
+| 상황 | 종료 |
+|------|------|
+| 하위명령 없음 / argparse 사용법 | 2 |
+| `RecordRefused` | 2 |
+| 검증·채점 불합격, 파일/파싱/스키마/실행/쓰기 실패 | 1 |
+| 합격 | 0 |
+
+`validate` 의 파일 오류는 JSON 리포트(`issues`)로 나간다. `record` 의
+거절·실패는 stderr 한 줄이다. `score-replay` 의 로드 실패는 채점
+리포트(`mismatches[0].reason`)로 접힌다 — 세션 쪽은 `badSession`,
+트레이스 쪽은 `badTrace`. 초안은 둘 다 `badTrace` 였다.
+
+## 시험 지도
+
+`scripts/tests/test_gym_agent_session.py` — 경로 채점 계약.
+
+- 자리표 해석, 세션 검증, JSONL 파싱
+- 통과 / 잘못된 명령 / 역순 / 여분 / 누락 / 종료 코드
+- `record` 거절과 주입 실행기
+- CLI validate / score-replay / record
+- 렌더, 재생 무바이너리 계약, `check_paths`, LCS
+
+`scripts/tests/test_gym_agent_session_errors.py` — 예외·입출력.
+
+- 카탈로그 11코드, `to_dict`, 하위 유형
+- `classify_exception` / `fail_score_report` / `wrap_io_error`
+- 세션·트레이스 로더: 빈 경로, 없음, 디렉터리, UTF-8, JSON, 스키마
+- JSONL: BOM, 배열 줄, 스칼라 줄, 빈 본문, 줄 번호
+- 쓰기: 빈 경로, 디렉터리, 직렬화 불가, 빈 목록
+- 엄격 자리표
+- 실행기 예외 / exit 없음 / 비정수 exit / 시계 콜백
+- CLI validate·score-replay·record 실패 종료 코드
+- PATH 에서 rhwp 를 지워도 `score-replay` 가 통과
+
+두 파일을 합쳐도 바이너리를 실행하지 않는다. 더미 파일은 `--bin`
+자리만 채운다.
+
+## 검증
+
+```
+python -m unittest scripts.tests.test_gym_agent_session
+python -m unittest scripts.tests.test_gym_agent_session_errors
+python gym/tools/audit.py
+```
+
+`cargo fmt --all` 은 돌리지 않는다. Rust 를 건드리지 않았고 sparse
+checkout 에서 전체 fmt 는 범위 밖이다.
+
+`audit.py` 는 pack 스키마·과제↔기준 짝·ID 고유를 본다. 이 작업은
+pack 을 추가하지 않으므로 기존 18 pack 이 계속 통과해야 한다.
+
+## 초안과의 호환
+
+- `SessionError` / `RecordRefused` 이름은 유지. 새 유형은 하위 클래스
+- `parse_trace_jsonl("")` 는 여전히 `SessionError` 로 잡을 수 있다
+  (`TraceParseError` 하위)
+- `require_record_bin` 메시지에 `--bin` / `찾을 수 없` / `위조` 유지
+- 리포트 `kind=gymAgentSession`, `schemaVersion=1.0` 유지
+- CLI 인자 이름은 그대로. `score-replay` 에 `--bin` 을 추가하지 않음
+- 합격 축은 계열·종료·순서. stdout 본문 대조를 넣지 않음
+
+깨뜨린 것:
+
+- `score-replay` 가 세션 파일을 못 읽으면 이제 `badSession` 이다
+  (초안은 `badTrace`). 초안 시험은 이 경로를 잠그지 않았다.
+- `load_json_file` 의 JSON 실패는 `SessionParseError` 다. 메시지
+  `JSON 파싱 실패:` 접두는 유지.
+
+## 의도적으로 넣지 않은 확장
+
+- 명령 화이트리스트 (`info`/`export-text` 만 허용). 이 도구는 계열
+  문자열을 비교할 뿐 명령 사전을 갖지 않는다. 사전을 넣으면 새 CLI
+  표면처럼 보인다.
+- stdout 해시 대조. 해시는 추적용이고 재생 합격 축이 아니다.
+- 세션 디렉터리 일괄 채점. 한 세션·한 트레이스가 단위다.
+- pack 과제화. 기본 채점 경로에 연결하면 종점 채점과 섞인다.
+
+## 커밋 단위
+
+1. 예외 계층·입출력 가드 (도구 본체)
+2. 경계 시험 (기존 + 예외 전용)
+3. 한국어 문서 (`gym/docs` + 이 노트)
+
+커밋 메시지는 한국어다. `git add -A` 는 쓰지 않는다. 같은 브랜치
+`feat/gym-agent-session` 에만 push 하고 새 PR 을 열지 않는다.
+
+## 크기 게이트
+
+`git diff --shortstat upstream/devel...HEAD` 의 insertions 가
+3000 이상이어야 한다. 초안 1350 + 예외/시험/문서. 숫자는 목적이
+아니라 예외 분류와 실패 시험을 빠짐없이 잠근 결과다.

--- a/scripts/tests/test_gym_agent_session.py
+++ b/scripts/tests/test_gym_agent_session.py
@@ -399,6 +399,124 @@ class RenderTests(unittest.TestCase):
         self.assertIn("실패", text)
         self.assertIn("순서", text)
 
+    def test_human_render_pass_and_extra_and_exit(self):
+        mod = load()
+        ok = mod.render_score(mod.score_session(session_doc(), events_of(PASS_TRACE)))
+        self.assertIn("통과", ok)
+        extra = mod.render_score(mod.score_session(session_doc(), events_of(EXTRA_STEP_TRACE)))
+        self.assertIn("여분", extra)
+        missing = mod.render_score(mod.score_session(session_doc(), events_of(MISSING_STEP_TRACE)))
+        self.assertIn("누락", missing)
+        wrong = mod.render_score(mod.score_session(session_doc(), events_of(WRONG_COMMAND_TRACE)))
+        self.assertIn("계열", wrong)
+        exit_txt = mod.render_score(mod.score_session(session_doc(), events_of(WRONG_EXIT_TRACE)))
+        self.assertIn("종료", exit_txt)
+
+    def test_reason_labels_cover_all_reason_constants(self):
+        mod = load()
+        for reason in (
+            mod.REASON_WRONG_COMMAND,
+            mod.REASON_WRONG_ORDER,
+            mod.REASON_WRONG_EXIT,
+            mod.REASON_EXTRA_STEP,
+            mod.REASON_MISSING_STEP,
+            mod.REASON_WRONG_PATH,
+            mod.REASON_BAD_TRACE,
+            mod.REASON_BAD_SESSION,
+        ):
+            label = mod.reason_label_ko(reason)
+            self.assertTrue(label)
+            self.assertNotEqual(label, "")
+
+
+class ReplayWithoutBinaryContractTests(unittest.TestCase):
+    def test_score_replay_never_requires_bin(self):
+        """재생 채점은 --bin 없이 픽스처만으로 끝나야 한다."""
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            session = os.path.join(tmp, "s.json")
+            replay = os.path.join(tmp, "t.jsonl")
+            with open(session, "w", encoding="utf-8", newline="\n") as fh:
+                json.dump(session_doc(), fh, ensure_ascii=False)
+            with open(replay, "w", encoding="utf-8", newline="\n") as fh:
+                fh.write(PASS_TRACE)
+            parser = mod.build_parser()
+            args = parser.parse_args([
+                "score-replay", "--session", session, "--replay", replay, "--json",
+            ])
+            self.assertFalse(hasattr(args, "bin") and getattr(args, "bin", None))
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                code = mod.cmd_score_replay(args)
+            self.assertEqual(code, 0)
+            self.assertTrue(json.loads(buf.getvalue())["ok"])
+
+    def test_parser_score_replay_has_no_bin_flag(self):
+        # record 도움말에만 --bin 이 있다. score-replay 서브파서는 bin 을 받지 않는다.
+        replay_help = None
+        parser = load().build_parser()
+        for action in parser._actions:
+            choices = getattr(action, "choices", None)
+            if not isinstance(choices, dict):
+                continue
+            if "score-replay" in choices:
+                replay_help = choices["score-replay"].format_help()
+        self.assertIsNotNone(replay_help)
+        self.assertNotIn("--bin", replay_help)
+
+
+class CheckPathsScoringTests(unittest.TestCase):
+    def test_replay_ignores_missing_expect_path(self):
+        mod = load()
+        report = mod.score_session(session_doc(), events_of(PASS_TRACE), check_paths=False)
+        self.assertTrue(report["ok"])
+        self.assertIsNone(report["steps"][1]["pathOk"])
+
+    def test_check_paths_false_path_is_wrong_path(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = mod.SessionContext("samples/x.hwp", tmp)
+            report = mod.score_session(
+                session_doc(), events_of(PASS_TRACE), context=ctx, check_paths=True,
+            )
+            self.assertFalse(report["ok"])
+            self.assertIn("wrongPath", reasons_of(report))
+
+
+class ClassifyMoreSequenceTests(unittest.TestCase):
+    def test_empty_and_prefix_and_mixed(self):
+        mod = load()
+        self.assertEqual(mod.classify_sequence([], []), [])
+        self.assertEqual(mod.classify_sequence([], ["a"]), ["extraStep"])
+        self.assertEqual(mod.classify_sequence(["a"], []), ["missingStep"])
+        self.assertEqual(mod.classify_sequence(["a", "b", "c"], ["a", "c"]), ["missingStep"])
+        reasons = mod.classify_sequence(["a", "b"], ["x", "y", "z"])
+        self.assertTrue(reasons)
+        self.assertTrue(any(r in reasons for r in ("wrongCommand", "extraStep", "missingStep")))
+
+    def test_same_multiset_helper(self):
+        mod = load()
+        self.assertTrue(mod.same_multiset(["a", "b"], ["b", "a"]))
+        self.assertFalse(mod.same_multiset(["a", "a"], ["a"]))
+        self.assertFalse(mod.same_multiset(["a"], ["b"]))
+
+
+class ShaAndFamilyTests(unittest.TestCase):
+    def test_sha256_none_and_bytes(self):
+        mod = load()
+        self.assertIsNone(mod.sha256_text(None))
+        self.assertEqual(mod.sha256_text("ab"), mod.sha256_bytes(b"ab"))
+        self.assertEqual(mod.command_family([]), "")
+        self.assertEqual(mod.command_family([1]), "")
+        self.assertEqual(mod.command_family(["export-text", "x"]), "export-text")
+
+    def test_expected_ok_path_false_blocks(self):
+        mod = load()
+        self.assertTrue(mod.expected_ok(0, 0, None))
+        self.assertTrue(mod.expected_ok(0, 0, True))
+        self.assertFalse(mod.expected_ok(0, 0, False))
+        self.assertFalse(mod.expected_ok(1, 0, True))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_gym_agent_session.py
+++ b/scripts/tests/test_gym_agent_session.py
@@ -1,0 +1,404 @@
+"""[agent_session] gym 에이전트 세션 트레이스 계약 — 경로(명령 열) 채점.
+
+핵심: 선언된 세션과 JSONL 트레이스를 명령 계열(argv[0])·종료 코드·순서로
+대조한다. 종점 산출이 아니라 밟은 경로를 잰다. trajectory.py 의 마지막 스텝
+절단과 겹치지 않는다. 픽스처만으로 재생 채점하며 바이너리는 쓰지 않는다.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+TOOL = Path(__file__).resolve().parents[2] / "gym" / "tools" / "agent_session.py"
+
+# 픽스처 트레이스 — 선언 세션 inspect-then-export (info → export-text)
+PASS_TRACE = """\
+{"ts":"2026-08-18T00:00:00Z","argv":["info","samples/x.hwp","--json"],"exit":0,"stdoutSha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","ok":true}
+{"ts":"2026-08-18T00:00:01Z","argv":["export-text","samples/x.hwp","-o","work/out.txt"],"exit":0,"ok":true}
+"""
+
+WRONG_COMMAND_TRACE = """\
+{"ts":"2026-08-18T00:00:00Z","argv":["search","samples/x.hwp","--json"],"exit":0,"ok":true}
+{"ts":"2026-08-18T00:00:01Z","argv":["export-text","samples/x.hwp","-o","work/out.txt"],"exit":0,"ok":true}
+"""
+
+WRONG_ORDER_TRACE = """\
+{"ts":"2026-08-18T00:00:00Z","argv":["export-text","samples/x.hwp","-o","work/out.txt"],"exit":0,"ok":true}
+{"ts":"2026-08-18T00:00:01Z","argv":["info","samples/x.hwp","--json"],"exit":0,"ok":true}
+"""
+
+EXTRA_STEP_TRACE = """\
+{"ts":"2026-08-18T00:00:00Z","argv":["info","samples/x.hwp","--json"],"exit":0,"ok":true}
+{"ts":"2026-08-18T00:00:01Z","argv":["export-text","samples/x.hwp","-o","work/out.txt"],"exit":0,"ok":true}
+{"ts":"2026-08-18T00:00:02Z","argv":["digest","samples/x.hwp","--json"],"exit":0,"ok":true}
+"""
+
+MISSING_STEP_TRACE = """\
+{"ts":"2026-08-18T00:00:00Z","argv":["info","samples/x.hwp","--json"],"exit":0,"ok":true}
+"""
+
+WRONG_EXIT_TRACE = """\
+{"ts":"2026-08-18T00:00:00Z","argv":["info","samples/x.hwp","--json"],"exit":2,"ok":false}
+{"ts":"2026-08-18T00:00:01Z","argv":["export-text","samples/x.hwp","-o","work/out.txt"],"exit":0,"ok":true}
+"""
+
+
+def load():
+    spec = importlib.util.spec_from_file_location("gym_agent_session", TOOL)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def session_doc():
+    return {
+        "id": "inspect-then-export",
+        "input": "samples/x.hwp",
+        "subDir": "work",
+        "steps": [
+            {"run": ["info", "{input}", "--json"], "expectExit": 0},
+            {
+                "run": ["export-text", "{input}", "-o", "{sub:out.txt}"],
+                "expectExit": 0,
+                "expectPath": "{sub:out.txt}",
+            },
+        ],
+    }
+
+
+def events_of(text):
+    return load().parse_trace_jsonl(text)
+
+
+def reasons_of(report):
+    return [m["reason"] for m in report.get("mismatches", [])]
+
+
+class ResolveTests(unittest.TestCase):
+    def test_input_and_sub_placeholders(self):
+        mod = load()
+        ctx = mod.SessionContext("samples/x.hwp", os.path.join("work", "sub"))
+        self.assertEqual(mod.resolve_token("{input}", ctx), "samples/x.hwp")
+        resolved = mod.resolve_token("{sub:out.txt}", ctx)
+        self.assertEqual(resolved, os.path.join("work", "sub", "out.txt"))
+
+    def test_embedded_sub_and_unknown_passthrough(self):
+        mod = load()
+        ctx = mod.SessionContext("in.hwp", "w")
+        self.assertEqual(
+            mod.resolve_token("pre-{sub:a.txt}-post", ctx),
+            "pre-" + os.path.join("w", "a.txt") + "-post",
+        )
+        self.assertEqual(mod.resolve_token("{nope}", ctx), "{nope}")
+        self.assertEqual(mod.resolve_token("literal", ctx), "literal")
+
+    def test_resolve_argv_keeps_family(self):
+        mod = load()
+        ctx = mod.SessionContext.from_session(session_doc())
+        argv = mod.resolve_argv(session_doc()["steps"][0]["run"], ctx)
+        self.assertEqual(argv[0], "info")
+        self.assertEqual(argv[1], "samples/x.hwp")
+        self.assertEqual(mod.command_family(argv), "info")
+
+    def test_missing_context_leaves_placeholder(self):
+        mod = load()
+        self.assertEqual(mod.resolve_token("{input}", None), "{input}")
+        self.assertEqual(mod.resolve_token("{sub:a}", mod.SessionContext()), "{sub:a}")
+
+
+class ValidateSessionTests(unittest.TestCase):
+    def test_good_session_has_no_issues(self):
+        self.assertEqual(load().validate_session(session_doc()), [])
+
+    def test_missing_id_and_empty_steps(self):
+        mod = load()
+        self.assertTrue(any("id" in i for i in mod.validate_session({"steps": [{"run": ["info"]}]})))
+        self.assertTrue(any("steps" in i for i in mod.validate_session({"id": "x", "steps": []})))
+        self.assertTrue(any("객체" in i for i in mod.validate_session([])))
+
+    def test_bad_run_and_expect_fields(self):
+        mod = load()
+        bad = {
+            "id": "x",
+            "steps": [
+                {"run": []},
+                {"run": ["info"], "expectExit": "zero", "expectPath": ""},
+                {"run": [""]},
+                {"run": ["info", "{mystery}"]},
+            ],
+        }
+        issues = " ".join(mod.validate_session(bad))
+        self.assertIn("run", issues)
+        self.assertIn("expectExit", issues)
+        self.assertIn("expectPath", issues)
+        self.assertIn("자리표", issues)
+
+    def test_unbalanced_placeholder_is_flagged(self):
+        issues = load().validate_session({
+            "id": "x",
+            "steps": [{"run": ["info", "{input"]}],
+        })
+        self.assertTrue(any("중괄호" in i or "자리표" in i for i in issues))
+
+
+class ParseTraceTests(unittest.TestCase):
+    def test_parses_fixture_and_skips_blank_lines(self):
+        ev = events_of(PASS_TRACE + "\n\n")
+        self.assertEqual(len(ev), 2)
+        self.assertEqual(ev[0]["argv"][0], "info")
+        self.assertEqual(ev[1]["exit"], 0)
+
+    def test_rejects_empty_and_bad_json(self):
+        mod = load()
+        with self.assertRaises(mod.SessionError):
+            mod.parse_trace_jsonl("")
+        with self.assertRaises(mod.SessionError):
+            mod.parse_trace_jsonl("not-json\n")
+
+    def test_event_schema_requires_ts_argv_exit_ok(self):
+        mod = load()
+        issues = mod.validate_trace_event({"argv": ["info"], "exit": 0, "ok": True}, 0)
+        self.assertTrue(any(".ts" in i for i in issues))
+        issues = mod.validate_trace_event({
+            "ts": "t", "argv": ["info"], "exit": 0, "ok": True,
+            "stdoutSha256": "zzzz",
+        }, 3)
+        self.assertTrue(any("stdoutSha256" in i for i in issues))
+
+
+class ScorePassTests(unittest.TestCase):
+    def test_matching_trace_passes(self):
+        mod = load()
+        report = mod.score_session(session_doc(), events_of(PASS_TRACE))
+        self.assertEqual(report["kind"], "gymAgentSession")
+        self.assertEqual(report["schemaVersion"], "1.0")
+        self.assertTrue(report["ok"])
+        self.assertTrue(report["orderOk"])
+        self.assertEqual(report["declared"], 2)
+        self.assertEqual(report["observed"], 2)
+        self.assertEqual(report["matched"], 2)
+        self.assertEqual(report["extraSteps"], [])
+        self.assertEqual(report["missingSteps"], [])
+        self.assertEqual(report["mismatches"], [])
+        self.assertEqual(report["steps"][0]["declaredFamily"], "info")
+        self.assertEqual(report["steps"][1]["declaredFamily"], "export-text")
+
+    def test_build_event_hashes_stdout_and_sets_ok(self):
+        mod = load()
+        ev = mod.build_trace_event(["info"], 0, stdout="hello", expect_exit=0, ts="t")
+        self.assertEqual(ev["ts"], "t")
+        self.assertTrue(ev["ok"])
+        self.assertEqual(ev["stdoutSha256"], mod.sha256_text("hello"))
+        ev_bad = mod.build_trace_event(["info"], 1, expect_exit=0, ts="t")
+        self.assertFalse(ev_bad["ok"])
+        self.assertNotIn("stdoutSha256", ev_bad)
+
+
+class ScoreWrongCommandTests(unittest.TestCase):
+    def test_wrong_family_is_wrong_command(self):
+        report = load().score_session(session_doc(), events_of(WRONG_COMMAND_TRACE))
+        self.assertFalse(report["ok"])
+        self.assertIn("wrongCommand", reasons_of(report))
+        self.assertFalse(report["steps"][0]["familyOk"])
+        self.assertEqual(report["steps"][0]["observedFamily"], "search")
+        self.assertEqual(report["steps"][0]["declaredFamily"], "info")
+
+
+class ScoreWrongOrderTests(unittest.TestCase):
+    def test_swapped_steps_are_wrong_order(self):
+        report = load().score_session(session_doc(), events_of(WRONG_ORDER_TRACE))
+        self.assertFalse(report["ok"])
+        self.assertFalse(report["orderOk"])
+        self.assertIn("wrongOrder", reasons_of(report))
+        self.assertNotIn("wrongCommand", reasons_of(report))
+        self.assertEqual(report["steps"][0]["observedFamily"], "export-text")
+        self.assertEqual(report["steps"][1]["observedFamily"], "info")
+
+
+class ScoreExtraStepTests(unittest.TestCase):
+    def test_trailing_extra_step(self):
+        report = load().score_session(session_doc(), events_of(EXTRA_STEP_TRACE))
+        self.assertFalse(report["ok"])
+        self.assertIn("extraStep", reasons_of(report))
+        self.assertEqual(len(report["extraSteps"]), 1)
+        self.assertEqual(report["extraSteps"][0]["family"], "digest")
+        self.assertEqual(report["declared"], 2)
+        self.assertEqual(report["observed"], 3)
+        # 선언 두 스텝은 그대로 일치한다.
+        self.assertTrue(report["steps"][0]["familyOk"])
+        self.assertTrue(report["steps"][1]["familyOk"])
+
+
+class ScoreMissingAndExitTests(unittest.TestCase):
+    def test_missing_step(self):
+        report = load().score_session(session_doc(), events_of(MISSING_STEP_TRACE))
+        self.assertFalse(report["ok"])
+        self.assertIn("missingStep", reasons_of(report))
+        self.assertEqual(len(report["missingSteps"]), 1)
+        self.assertEqual(report["missingSteps"][0]["family"], "export-text")
+
+    def test_wrong_exit_same_family(self):
+        report = load().score_session(session_doc(), events_of(WRONG_EXIT_TRACE))
+        self.assertFalse(report["ok"])
+        self.assertIn("wrongExit", reasons_of(report))
+        self.assertTrue(report["steps"][0]["familyOk"])
+        self.assertFalse(report["steps"][0]["exitOk"])
+        self.assertEqual(report["steps"][0]["observedExit"], 2)
+
+    def test_invalid_session_scores_as_bad_session(self):
+        report = load().score_session({"id": ""}, [])
+        self.assertFalse(report["ok"])
+        self.assertIn("badSession", reasons_of(report))
+
+
+class ClassifySequenceTests(unittest.TestCase):
+    def test_prefix_extra_and_middle_insert(self):
+        mod = load()
+        self.assertEqual(mod.classify_sequence(["a", "b"], ["a", "b", "c"]), ["extraStep"])
+        self.assertEqual(mod.classify_sequence(["a", "b"], ["a"]), ["missingStep"])
+        self.assertEqual(mod.classify_sequence(["a", "b"], ["b", "a"]), ["wrongOrder"])
+        self.assertEqual(mod.classify_sequence(["a", "b"], ["a", "x"]), ["wrongCommand"])
+
+    def test_lcs_collapses_adjacent_replace(self):
+        mod = load()
+        ops = mod.collapse_ops(mod.lcs_ops(["info", "export-text"], ["search", "export-text"]))
+        kinds = [op[0] for op in ops]
+        self.assertIn("sub", kinds)
+        self.assertIn("match", kinds)
+
+
+class RecordRefuseTests(unittest.TestCase):
+    def test_missing_bin_is_refused(self):
+        mod = load()
+        with self.assertRaises(mod.RecordRefused) as ctx:
+            mod.require_record_bin(None)
+        self.assertIn("--bin", str(ctx.exception))
+        with self.assertRaises(mod.RecordRefused):
+            mod.require_record_bin("   ")
+        with self.assertRaises(mod.RecordRefused) as ctx:
+            mod.require_record_bin(os.path.join("no", "such", "rhwp-binary"))
+        self.assertIn("찾을 수 없", str(ctx.exception))
+
+    def test_record_without_bin_does_not_write(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, "t.jsonl")
+            with self.assertRaises(mod.RecordRefused):
+                mod.record_session(session_doc(), None, out_path=out)
+            self.assertFalse(os.path.exists(out))
+
+    def test_injected_execute_still_requires_bin_flag(self):
+        mod = load()
+        fake = lambda _bin, argv: {"exit": 0, "stdout": b""}
+        with self.assertRaises(mod.RecordRefused):
+            mod.record_session(session_doc(), None, execute=fake)
+
+    def test_injected_execute_records_jsonl(self):
+        mod = load()
+        calls = []
+
+        def fake(bin_path, argv):
+            calls.append((bin_path, list(argv)))
+            return {"exit": 0, "stdout": b"{}"}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            # 존재하는 더미 파일은 --bin 자리만 채운다. 실행은 fake 가 맡는다.
+            dummy = os.path.join(tmp, "dummy-rhwp")
+            with open(dummy, "w", encoding="utf-8", newline="\n") as fh:
+                fh.write("not-a-real-binary\n")
+            out = os.path.join(tmp, "trace.jsonl")
+            sub = os.path.join(tmp, "work")
+            ctx = mod.SessionContext("samples/x.hwp", sub)
+            events = mod.record_session(
+                session_doc(), dummy, out_path=out, context=ctx, execute=fake,
+                clock=lambda: "2026-08-18T00:00:00Z",
+            )
+            self.assertEqual(len(events), 2)
+            self.assertEqual(events[0]["argv"][0], "info")
+            self.assertEqual(events[0]["argv"][1], "samples/x.hwp")
+            self.assertEqual(events[1]["argv"][0], "export-text")
+            self.assertTrue(os.path.isfile(out))
+            replayed = mod.parse_trace_jsonl(Path(out).read_text(encoding="utf-8"))
+            self.assertEqual(len(replayed), 2)
+            self.assertEqual(calls[0][0], dummy)
+        self.assertEqual(len(calls), 2)
+
+
+class CliTests(unittest.TestCase):
+    def _write(self, tmp, name, text):
+        path = os.path.join(tmp, name)
+        with open(path, "w", encoding="utf-8", newline="\n") as fh:
+            fh.write(text)
+        return path
+
+    def test_validate_cli_json(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, "s.json", json.dumps(session_doc(), ensure_ascii=False))
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                code = mod.main(["validate", "--session", path, "--json"])
+            self.assertEqual(code, 0)
+            payload = json.loads(buf.getvalue())
+            self.assertEqual(payload["kind"], "gymAgentSessionValidate")
+            self.assertTrue(payload["ok"])
+
+    def test_score_replay_cli_pass_and_wrong_order(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            session = self._write(tmp, "s.json", json.dumps(session_doc(), ensure_ascii=False))
+            good = self._write(tmp, "ok.jsonl", PASS_TRACE)
+            bad = self._write(tmp, "order.jsonl", WRONG_ORDER_TRACE)
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                code = mod.main(["score-replay", "--session", session, "--replay", good, "--json"])
+            self.assertEqual(code, 0)
+            self.assertTrue(json.loads(buf.getvalue())["ok"])
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                code = mod.main(["score-replay", "--session", session, "--replay", bad, "--json"])
+            self.assertEqual(code, 1)
+            report = json.loads(buf.getvalue())
+            self.assertFalse(report["ok"])
+            self.assertIn("wrongOrder", reasons_of(report))
+
+    def test_record_cli_refuses_without_bin(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            session = self._write(tmp, "s.json", json.dumps(session_doc(), ensure_ascii=False))
+            out = os.path.join(tmp, "t.jsonl")
+            err = io.StringIO()
+            with redirect_stderr(err):
+                code = mod.main(["record", "--session", session, "--out", out])
+            self.assertEqual(code, 2)
+            self.assertIn("--bin", err.getvalue())
+            self.assertFalse(os.path.exists(out))
+
+    def test_no_subcommand_is_usage(self):
+        mod = load()
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            code = mod.main([])
+        self.assertEqual(code, 2)
+        self.assertIn("usage", buf.getvalue().lower())
+
+
+class RenderTests(unittest.TestCase):
+    def test_human_render_mentions_order(self):
+        mod = load()
+        text = mod.render_score(mod.score_session(session_doc(), events_of(WRONG_ORDER_TRACE)))
+        self.assertIn("실패", text)
+        self.assertIn("순서", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_gym_agent_session_errors.py
+++ b/scripts/tests/test_gym_agent_session_errors.py
@@ -1,0 +1,927 @@
+"""[agent_session] 예외 계층·입출력 가드·CLI 실패 접기.
+
+재생(score-replay)은 바이너리 없이 픽스처만으로 실패 유형을 분류해야 한다.
+record 는 --bin 없거나 실행 파일이 없으면 RecordRefused 로 거절하고
+트레이스를 쓰지 않는다. 새 rhwp CLI 는 만들지 않는다.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+TOOL = Path(__file__).resolve().parents[2] / "gym" / "tools" / "agent_session.py"
+
+PASS_TRACE = (
+    '{"ts":"2026-08-18T00:00:00Z","argv":["info","samples/x.hwp","--json"],'
+    '"exit":0,"ok":true}\n'
+    '{"ts":"2026-08-18T00:00:01Z","argv":["export-text","samples/x.hwp","-o",'
+    '"work/out.txt"],"exit":0,"ok":true}\n'
+)
+
+
+def load():
+    spec = importlib.util.spec_from_file_location("gym_agent_session_errors", TOOL)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def session_doc():
+    return {
+        "id": "inspect-then-export",
+        "input": "samples/x.hwp",
+        "subDir": "work",
+        "steps": [
+            {"run": ["info", "{input}", "--json"], "expectExit": 0},
+            {
+                "run": ["export-text", "{input}", "-o", "{sub:out.txt}"],
+                "expectExit": 0,
+                "expectPath": "{sub:out.txt}",
+            },
+        ],
+    }
+
+
+def write_text(path, text):
+    with open(path, "w", encoding="utf-8", newline="\n") as fh:
+        fh.write(text)
+    return path
+
+
+class ExceptionHierarchyTests(unittest.TestCase):
+    def test_all_codes_are_unique_and_mapped(self):
+        mod = load()
+        names = mod.error_code_names()
+        self.assertEqual(len(names), len(set(names)))
+        self.assertGreaterEqual(len(names), 11)
+        for code in names:
+            cls = mod.error_class_for_code(code)
+            self.assertTrue(issubclass(cls, mod.SessionError))
+            inst = cls("x")
+            self.assertEqual(inst.code, code)
+            payload = inst.to_dict()
+            self.assertEqual(payload["code"], code)
+            self.assertEqual(payload["type"], cls.__name__)
+            self.assertIn("message", payload)
+            self.assertIn("exitCode", payload)
+
+    def test_unknown_code_falls_back_to_session_error(self):
+        mod = load()
+        self.assertIs(mod.error_class_for_code("no-such-code"), mod.SessionError)
+
+    def test_record_refused_is_usage_exit(self):
+        mod = load()
+        exc = mod.RecordRefused("거절")
+        self.assertEqual(exc.exit_code, 2)
+        self.assertEqual(exc.code, "recordRefused")
+        self.assertIsInstance(exc, mod.SessionError)
+        self.assertIsInstance(exc, ValueError)
+
+    def test_to_dict_includes_optional_fields(self):
+        mod = load()
+        exc = mod.TraceParseError("bad", path="t.jsonl", line=3, detail=["x"])
+        payload = exc.to_dict()
+        self.assertEqual(payload["path"], "t.jsonl")
+        self.assertEqual(payload["line"], 3)
+        self.assertEqual(payload["detail"], ["x"])
+
+    def test_subclass_identity(self):
+        mod = load()
+        pairs = [
+            (mod.SessionFileError, "sessionFile"),
+            (mod.SessionParseError, "sessionParse"),
+            (mod.SessionSchemaError, "sessionSchema"),
+            (mod.TraceFileError, "traceFile"),
+            (mod.TraceParseError, "traceParse"),
+            (mod.TraceSchemaError, "traceSchema"),
+            (mod.ExecuteError, "executeError"),
+            (mod.WriteError, "writeError"),
+            (mod.PlaceholderError, "placeholderError"),
+        ]
+        for cls, code in pairs:
+            self.assertTrue(issubclass(cls, mod.SessionError), cls)
+            self.assertEqual(cls.code, code)
+
+
+class ClassifyExceptionTests(unittest.TestCase):
+    def test_session_side_maps_to_bad_session(self):
+        mod = load()
+        self.assertEqual(mod.classify_exception(mod.SessionFileError("x")), "badSession")
+        self.assertEqual(mod.classify_exception(mod.SessionParseError("x")), "badSession")
+        self.assertEqual(mod.classify_exception(mod.SessionSchemaError("x")), "badSession")
+        self.assertEqual(mod.classify_exception(mod.RecordRefused("x")), "badSession")
+
+    def test_trace_side_maps_to_bad_trace(self):
+        mod = load()
+        self.assertEqual(mod.classify_exception(mod.TraceFileError("x")), "badTrace")
+        self.assertEqual(mod.classify_exception(mod.TraceParseError("x")), "badTrace")
+        self.assertEqual(mod.classify_exception(mod.TraceSchemaError("x")), "badTrace")
+        self.assertEqual(mod.classify_exception(mod.SessionError("x")), "badTrace")
+        self.assertEqual(mod.classify_exception(RuntimeError("x")), "badTrace")
+
+    def test_fail_score_report_shape(self):
+        mod = load()
+        report = mod.fail_score_report("badSession", "세션 없음", session_id="s")
+        self.assertEqual(report["kind"], "gymAgentSession")
+        self.assertEqual(report["schemaVersion"], "1.0")
+        self.assertFalse(report["ok"])
+        self.assertEqual(report["sessionId"], "s")
+        self.assertEqual(report["mismatches"][0]["reason"], "badSession")
+        self.assertEqual(report["steps"], [])
+
+
+class WrapIoErrorTests(unittest.TestCase):
+    def test_file_not_found_and_permission(self):
+        mod = load()
+        missing = mod.wrap_io_error(FileNotFoundError("no"), "gone.json", reading=True)
+        self.assertIsInstance(missing, mod.SessionFileError)
+        self.assertIn("찾을 수 없다", str(missing))
+        perm = mod.wrap_io_error(PermissionError("no"), "locked.json", reading=True)
+        self.assertIsInstance(perm, mod.SessionFileError)
+        self.assertIn("권한", str(perm))
+
+    def test_directory_is_classified(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            wrapped = mod.wrap_io_error(PermissionError("win"), tmp, reading=True)
+            self.assertIn("디렉터리", str(wrapped))
+            self.assertEqual(wrapped.path, tmp)
+
+    def test_write_side_uses_write_error(self):
+        mod = load()
+        wrapped = mod.wrap_io_error(OSError("disk"), "out.jsonl", reading=False)
+        self.assertIsInstance(wrapped, mod.WriteError)
+        self.assertIn("쓰기", str(wrapped))
+
+    def test_is_a_directory_error_when_available(self):
+        mod = load()
+        wrapped = mod.wrap_io_error(IsADirectoryError("dir"), "d", reading=True)
+        self.assertIn("디렉터리", str(wrapped))
+
+
+class LoadJsonFileErrorTests(unittest.TestCase):
+    def test_empty_path(self):
+        mod = load()
+        with self.assertRaises(mod.SessionFileError):
+            mod.load_json_file("")
+        with self.assertRaises(mod.SessionFileError):
+            mod.load_json_file(None)
+
+    def test_missing_file(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "no.json")
+            with self.assertRaises(mod.SessionFileError) as ctx:
+                mod.load_json_file(path)
+            self.assertIn("찾을 수 없다", str(ctx.exception))
+            self.assertEqual(ctx.exception.path, path)
+
+    def test_directory_path(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(mod.SessionFileError) as ctx:
+                mod.load_json_file(tmp)
+            self.assertIn("디렉터리", str(ctx.exception))
+
+    def test_invalid_json(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write_text(os.path.join(tmp, "bad.json"), "{not json")
+            with self.assertRaises(mod.SessionParseError) as ctx:
+                mod.load_json_file(path)
+            self.assertIn("JSON", str(ctx.exception))
+            self.assertEqual(ctx.exception.path, path)
+
+    def test_non_utf8(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "latin.json")
+            with open(path, "wb") as fh:
+                fh.write(b"\xff\xfe{")
+            with self.assertRaises(mod.SessionParseError) as ctx:
+                mod.load_json_file(path)
+            self.assertIn("UTF-8", str(ctx.exception))
+
+    def test_valid_object(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write_text(os.path.join(tmp, "ok.json"), '{"id":"x"}')
+            self.assertEqual(mod.load_json_file(path)["id"], "x")
+
+
+class LoadTextAndTraceFileErrorTests(unittest.TestCase):
+    def test_empty_trace_path(self):
+        mod = load()
+        with self.assertRaises(mod.TraceFileError):
+            mod.load_text_file("")
+        with self.assertRaises(mod.TraceFileError):
+            mod.load_text_file("   ")
+
+    def test_missing_trace_file(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "no.jsonl")
+            with self.assertRaises(mod.TraceFileError):
+                mod.load_trace_file(path)
+
+    def test_directory_as_trace(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(mod.TraceFileError):
+                mod.load_text_file(tmp)
+
+    def test_empty_trace_body(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write_text(os.path.join(tmp, "empty.jsonl"), "\n\n")
+            with self.assertRaises(mod.TraceParseError) as ctx:
+                mod.load_trace_file(path)
+            self.assertIn("이벤트", str(ctx.exception))
+
+    def test_bad_jsonl_line(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write_text(os.path.join(tmp, "bad.jsonl"), "not-json\n")
+            with self.assertRaises(mod.TraceParseError) as ctx:
+                mod.load_trace_file(path)
+            self.assertEqual(ctx.exception.line, 1)
+
+    def test_jsonl_array_line_is_rejected(self):
+        mod = load()
+        with self.assertRaises(mod.TraceParseError):
+            mod.parse_trace_jsonl("[1,2]\n")
+
+    def test_jsonl_scalar_line_is_rejected(self):
+        mod = load()
+        with self.assertRaises(mod.TraceParseError):
+            mod.parse_trace_jsonl("12\n")
+
+    def test_bom_is_stripped(self):
+        mod = load()
+        text = "\ufeff" + PASS_TRACE
+        events = mod.parse_trace_jsonl(text)
+        self.assertEqual(len(events), 2)
+        self.assertEqual(events[0]["argv"][0], "info")
+
+    def test_none_and_non_string_trace(self):
+        mod = load()
+        with self.assertRaises(mod.TraceParseError):
+            mod.parse_trace_jsonl(None)
+        with self.assertRaises(mod.TraceParseError):
+            mod.parse_trace_jsonl(123)
+
+    def test_schema_invalid_event_raises_trace_schema(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write_text(
+                os.path.join(tmp, "schema.jsonl"),
+                '{"ts":"t","argv":["info"],"exit":0}\n',
+            )
+            with self.assertRaises(mod.TraceSchemaError) as ctx:
+                mod.load_trace_file(path)
+            self.assertTrue(ctx.exception.detail)
+            self.assertTrue(any("ok" in i for i in ctx.exception.detail))
+
+    def test_non_utf8_trace(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "bin.jsonl")
+            with open(path, "wb") as fh:
+                fh.write(b"\xff\xfe{")
+            with self.assertRaises(mod.TraceParseError):
+                mod.load_trace_file(path)
+
+
+class LoadSessionFileErrorTests(unittest.TestCase):
+    def test_schema_error_carries_issues(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write_text(os.path.join(tmp, "s.json"), '{"id":"","steps":[]}')
+            with self.assertRaises(mod.SessionSchemaError) as ctx:
+                mod.load_session_file(path)
+            self.assertTrue(ctx.exception.detail)
+            self.assertTrue(any("id" in i or "steps" in i for i in ctx.exception.detail))
+
+    def test_good_session_returns_doc(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write_text(
+                os.path.join(tmp, "s.json"),
+                json.dumps(session_doc(), ensure_ascii=False),
+            )
+            doc = mod.load_session_file(path)
+            self.assertEqual(doc["id"], "inspect-then-export")
+
+
+class WriteJsonlErrorTests(unittest.TestCase):
+    def test_empty_out_path(self):
+        mod = load()
+        with self.assertRaises(mod.WriteError):
+            mod.write_jsonl("", [{"ts": "t", "argv": ["info"], "exit": 0, "ok": True}])
+
+    def test_events_must_be_list(self):
+        mod = load()
+        with self.assertRaises(mod.WriteError):
+            mod.write_jsonl("x.jsonl", {"not": "list"})
+
+    def test_directory_as_out_path(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(mod.WriteError):
+                mod.write_jsonl(tmp, [{"ts": "t", "argv": ["info"], "exit": 0, "ok": True}])
+
+    def test_unserializable_event(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "t.jsonl")
+            with self.assertRaises(mod.WriteError):
+                mod.write_jsonl(path, [{"ts": "t", "argv": [object()]}])
+
+    def test_writes_trailing_newline(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "nested", "t.jsonl")
+            ev = {"ts": "t", "argv": ["info"], "exit": 0, "ok": True}
+            mod.write_jsonl(path, [ev])
+            text = Path(path).read_text(encoding="utf-8")
+            self.assertTrue(text.endswith("\n"))
+            self.assertEqual(len(text.strip().splitlines()), 1)
+
+    def test_empty_events_writes_empty_file(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "empty.jsonl")
+            mod.write_jsonl(path, [])
+            self.assertEqual(Path(path).read_text(encoding="utf-8"), "")
+
+
+class PlaceholderStrictTests(unittest.TestCase):
+    def test_strict_missing_input(self):
+        mod = load()
+        with self.assertRaises(mod.PlaceholderError):
+            mod.resolve_token("{input}", None, strict=True)
+
+    def test_strict_missing_sub(self):
+        mod = load()
+        with self.assertRaises(mod.PlaceholderError):
+            mod.resolve_token("{sub:a.txt}", mod.SessionContext(), strict=True)
+
+    def test_strict_unknown(self):
+        mod = load()
+        with self.assertRaises(mod.PlaceholderError):
+            mod.resolve_token("{nope}", mod.SessionContext("in.hwp", "w"), strict=True)
+
+    def test_non_strict_passthrough(self):
+        mod = load()
+        self.assertEqual(mod.resolve_token("{input}", None), "{input}")
+        self.assertEqual(mod.resolve_token("{nope}", None), "{nope}")
+
+    def test_resolve_argv_none_is_schema_error(self):
+        mod = load()
+        with self.assertRaises(mod.SessionSchemaError):
+            mod.resolve_argv(None, None)
+
+    def test_strict_argv_resolves(self):
+        mod = load()
+        ctx = mod.SessionContext("in.hwp", "w")
+        argv = mod.resolve_argv(["info", "{input}"], ctx, strict=True)
+        self.assertEqual(argv, ["info", "in.hwp"])
+
+
+class RecordExecuteErrorTests(unittest.TestCase):
+    def test_executor_exception_is_execute_error(self):
+        mod = load()
+
+        def boom(_bin, _argv):
+            raise RuntimeError("boom")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dummy = write_text(os.path.join(tmp, "dummy"), "x")
+            with self.assertRaises(mod.ExecuteError) as ctx:
+                mod.record_session(session_doc(), dummy, execute=boom)
+            self.assertIn("실행기 예외", str(ctx.exception))
+
+    def test_executor_without_exit(self):
+        mod = load()
+
+        def bad(_bin, _argv):
+            return {"stdout": b""}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dummy = write_text(os.path.join(tmp, "dummy"), "x")
+            with self.assertRaises(mod.ExecuteError) as ctx:
+                mod.record_session(session_doc(), dummy, execute=bad)
+            self.assertIn("exit", str(ctx.exception))
+
+    def test_executor_non_int_exit(self):
+        mod = load()
+
+        def bad(_bin, _argv):
+            return {"exit": "zero"}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dummy = write_text(os.path.join(tmp, "dummy"), "x")
+            with self.assertRaises(mod.ExecuteError):
+                mod.record_session(session_doc(), dummy, execute=bad)
+
+    def test_clock_exception_is_session_error(self):
+        mod = load()
+
+        def fake(_bin, _argv):
+            return {"exit": 0, "stdout": b""}
+
+        def bad_clock():
+            raise RuntimeError("clock")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dummy = write_text(os.path.join(tmp, "dummy"), "x")
+            with self.assertRaises(mod.SessionError) as ctx:
+                mod.record_session(
+                    session_doc(), dummy, execute=fake, clock=bad_clock,
+                )
+            self.assertIn("시계", str(ctx.exception))
+
+    def test_invalid_session_is_schema_error(self):
+        mod = load()
+        with self.assertRaises(mod.SessionSchemaError):
+            mod.record_session({"id": ""}, "dummy")
+
+    def test_session_error_from_executor_is_not_wrapped(self):
+        mod = load()
+
+        def refuse(_bin, _argv):
+            raise mod.RecordRefused("안 함")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dummy = write_text(os.path.join(tmp, "dummy"), "x")
+            with self.assertRaises(mod.RecordRefused):
+                mod.record_session(session_doc(), dummy, execute=refuse)
+
+
+class DefaultExecuteErrorTests(unittest.TestCase):
+    def test_empty_bin(self):
+        mod = load()
+        with self.assertRaises(mod.ExecuteError):
+            mod.default_execute("", ["info"])
+
+    def test_missing_bin_file(self):
+        mod = load()
+        with self.assertRaises(mod.ExecuteError):
+            mod.default_execute(os.path.join("no", "such", "rhwp-bin"), ["info"])
+
+
+class RequireRecordBinMessageTests(unittest.TestCase):
+    def test_messages_stay_korean_and_refuse_forgery(self):
+        mod = load()
+        with self.assertRaises(mod.RecordRefused) as ctx:
+            mod.require_record_bin(None)
+        self.assertIn("위조", str(ctx.exception))
+        with self.assertRaises(mod.RecordRefused) as ctx:
+            mod.require_record_bin(os.path.join("no", "rhwp"))
+        self.assertIn("가장해", str(ctx.exception))
+
+    def test_existing_file_is_accepted(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write_text(os.path.join(tmp, "dummy"), "x")
+            self.assertEqual(mod.require_record_bin(path), path)
+
+
+class CliValidateErrorTests(unittest.TestCase):
+    def test_missing_session_json_exit_1(self):
+        mod = load()
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            code = mod.main(["validate", "--session", "no-such-session.json", "--json"])
+        self.assertEqual(code, 1)
+        payload = json.loads(buf.getvalue())
+        self.assertFalse(payload["ok"])
+        self.assertGreaterEqual(payload["issueCount"], 1)
+        self.assertIn("찾을 수 없다", payload["issues"][0])
+
+    def test_bad_json_session(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write_text(os.path.join(tmp, "s.json"), "{")
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                code = mod.main(["validate", "--session", path, "--json"])
+            self.assertEqual(code, 1)
+            payload = json.loads(buf.getvalue())
+            self.assertFalse(payload["ok"])
+            self.assertTrue(any("JSON" in i for i in payload["issues"]))
+
+    def test_schema_invalid_session(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write_text(os.path.join(tmp, "s.json"), '{"id":"x","steps":[]}')
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                code = mod.main(["validate", "--session", path, "--json"])
+            self.assertEqual(code, 1)
+            payload = json.loads(buf.getvalue())
+            self.assertEqual(payload["kind"], "gymAgentSessionValidate")
+            self.assertTrue(any("steps" in i for i in payload["issues"]))
+
+    def test_directory_as_session(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                code = mod.main(["validate", "--session", tmp, "--json"])
+            self.assertEqual(code, 1)
+            payload = json.loads(buf.getvalue())
+            self.assertTrue(any("디렉터리" in i for i in payload["issues"]))
+
+
+class CliScoreReplayErrorTests(unittest.TestCase):
+    def _write(self, tmp, name, text):
+        return write_text(os.path.join(tmp, name), text)
+
+    def test_missing_session_is_bad_session(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            replay = self._write(tmp, "t.jsonl", PASS_TRACE)
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                code = mod.main([
+                    "score-replay",
+                    "--session", os.path.join(tmp, "no.json"),
+                    "--replay", replay,
+                    "--json",
+                ])
+            self.assertEqual(code, 1)
+            report = json.loads(buf.getvalue())
+            self.assertFalse(report["ok"])
+            self.assertEqual(report["mismatches"][0]["reason"], "badSession")
+
+    def test_missing_replay_is_bad_trace(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            session = self._write(tmp, "s.json", json.dumps(session_doc(), ensure_ascii=False))
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                code = mod.main([
+                    "score-replay",
+                    "--session", session,
+                    "--replay", os.path.join(tmp, "no.jsonl"),
+                    "--json",
+                ])
+            self.assertEqual(code, 1)
+            report = json.loads(buf.getvalue())
+            self.assertFalse(report["ok"])
+            self.assertEqual(report["sessionId"], "inspect-then-export")
+            self.assertEqual(report["mismatches"][0]["reason"], "badTrace")
+
+    def test_bad_jsonl_is_bad_trace(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            session = self._write(tmp, "s.json", json.dumps(session_doc(), ensure_ascii=False))
+            replay = self._write(tmp, "t.jsonl", "{{{")
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                code = mod.main([
+                    "score-replay", "--session", session, "--replay", replay, "--json",
+                ])
+            self.assertEqual(code, 1)
+            report = json.loads(buf.getvalue())
+            self.assertEqual(report["mismatches"][0]["reason"], "badTrace")
+
+    def test_schema_invalid_session_is_bad_session(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            session = self._write(tmp, "s.json", '{"id":"","steps":[{"run":["info"]}]}')
+            replay = self._write(tmp, "t.jsonl", PASS_TRACE)
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                code = mod.main([
+                    "score-replay", "--session", session, "--replay", replay, "--json",
+                ])
+            self.assertEqual(code, 1)
+            report = json.loads(buf.getvalue())
+            self.assertEqual(report["mismatches"][0]["reason"], "badSession")
+
+    def test_replay_does_not_look_for_rhwp_binary(self):
+        """score-replay 는 rhwp 를 PATH 에서 찾지 않는다."""
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            session = self._write(tmp, "s.json", json.dumps(session_doc(), ensure_ascii=False))
+            replay = self._write(tmp, "t.jsonl", PASS_TRACE)
+            env_path = os.environ.get("PATH")
+            try:
+                os.environ["PATH"] = tmp
+                buf = io.StringIO()
+                with redirect_stdout(buf):
+                    code = mod.main([
+                        "score-replay", "--session", session, "--replay", replay, "--json",
+                    ])
+            finally:
+                if env_path is None:
+                    os.environ.pop("PATH", None)
+                else:
+                    os.environ["PATH"] = env_path
+            self.assertEqual(code, 0)
+            self.assertTrue(json.loads(buf.getvalue())["ok"])
+
+
+class CliRecordErrorTests(unittest.TestCase):
+    def test_missing_bin_is_usage_2(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            session = write_text(
+                os.path.join(tmp, "s.json"),
+                json.dumps(session_doc(), ensure_ascii=False),
+            )
+            out = os.path.join(tmp, "t.jsonl")
+            err = io.StringIO()
+            with redirect_stderr(err):
+                code = mod.main(["record", "--session", session, "--out", out])
+            self.assertEqual(code, 2)
+            self.assertFalse(os.path.exists(out))
+
+    def test_missing_bin_file_is_usage_2(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            session = write_text(
+                os.path.join(tmp, "s.json"),
+                json.dumps(session_doc(), ensure_ascii=False),
+            )
+            out = os.path.join(tmp, "t.jsonl")
+            err = io.StringIO()
+            with redirect_stderr(err):
+                code = mod.main([
+                    "record",
+                    "--session", session,
+                    "--bin", os.path.join(tmp, "no-rhwp"),
+                    "--out", out,
+                ])
+            self.assertEqual(code, 2)
+            self.assertIn("찾을 수 없", err.getvalue())
+            self.assertFalse(os.path.exists(out))
+
+    def test_bad_session_is_fail_1(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            session = write_text(os.path.join(tmp, "s.json"), '{"id":""}')
+            dummy = write_text(os.path.join(tmp, "dummy"), "x")
+            out = os.path.join(tmp, "t.jsonl")
+            err = io.StringIO()
+            with redirect_stderr(err):
+                code = mod.main([
+                    "record", "--session", session, "--bin", dummy, "--out", out,
+                ])
+            self.assertEqual(code, 1)
+            self.assertFalse(os.path.exists(out))
+
+
+class RenderErrorTests(unittest.TestCase):
+    def test_render_error_prefixes(self):
+        mod = load()
+        self.assertTrue(mod.render_error(mod.RecordRefused("x")).startswith("기록 거절"))
+        text = mod.render_error(mod.TraceParseError("bad", path="t", line=2))
+        self.assertIn("traceParse", text)
+        self.assertIn("줄=2", text)
+        self.assertIn("미분류", mod.render_error(RuntimeError("z")))
+
+    def test_validate_render_ok_and_fail(self):
+        mod = load()
+        self.assertIn("유효", mod.render_validate([], "sid"))
+        fail = mod.render_validate(["id 가 비어 있다"])
+        self.assertIn("위반", fail)
+        self.assertIn("id", fail)
+
+
+class ValidateSessionMoreEdgeTests(unittest.TestCase):
+    def test_non_string_input_and_subdir(self):
+        mod = load()
+        issues = " ".join(mod.validate_session({
+            "id": "x",
+            "input": 1,
+            "subDir": 2,
+            "steps": [{"run": ["info"]}],
+        }))
+        self.assertIn("input", issues)
+        self.assertIn("subDir", issues)
+
+    def test_bool_expect_exit_rejected(self):
+        mod = load()
+        issues = " ".join(mod.validate_session({
+            "id": "x",
+            "steps": [{"run": ["info"], "expectExit": True}],
+        }))
+        self.assertIn("expectExit", issues)
+
+    def test_non_dict_step(self):
+        mod = load()
+        issues = " ".join(mod.validate_session({"id": "x", "steps": [None, "info"]}))
+        self.assertIn("객체", issues)
+
+    def test_empty_sub_name(self):
+        mod = load()
+        issues = " ".join(mod.validate_session({
+            "id": "x",
+            "steps": [{"run": ["info", "{sub:}"]}],
+        }))
+        self.assertIn("이름", issues)
+
+    def test_whitespace_id(self):
+        mod = load()
+        issues = " ".join(mod.validate_session({
+            "id": "   ",
+            "steps": [{"run": ["info"]}],
+        }))
+        self.assertIn("id", issues)
+
+    def test_expect_path_unknown_placeholder(self):
+        mod = load()
+        issues = " ".join(mod.validate_session({
+            "id": "x",
+            "steps": [{"run": ["info"], "expectPath": "{mystery}"}],
+        }))
+        self.assertIn("자리표", issues)
+
+
+class ValidateTraceEventMoreTests(unittest.TestCase):
+    def test_non_dict_event(self):
+        mod = load()
+        self.assertTrue(any("객체" in i for i in mod.validate_trace_event([], 0)))
+
+    def test_empty_argv_and_non_int_exit(self):
+        mod = load()
+        issues = " ".join(mod.validate_trace_event({
+            "ts": "t", "argv": [], "exit": True, "ok": "yes",
+        }, 1))
+        self.assertIn("argv", issues)
+        self.assertIn("exit", issues)
+        self.assertIn("ok", issues)
+
+    def test_argv_non_string(self):
+        mod = load()
+        issues = " ".join(mod.validate_trace_event({
+            "ts": "t", "argv": [1], "exit": 0, "ok": True,
+        }, 0))
+        self.assertIn("문자열", issues)
+
+    def test_valid_hex_digest_accepted(self):
+        mod = load()
+        digest = "a" * 64
+        issues = mod.validate_trace_event({
+            "ts": "t", "argv": ["info"], "exit": 0, "ok": True, "stdoutSha256": digest,
+        }, 0)
+        self.assertEqual(issues, [])
+
+    def test_trace_not_list(self):
+        mod = load()
+        self.assertTrue(any("배열" in i for i in mod.validate_trace({})))
+
+
+class ScoreInvalidTraceTests(unittest.TestCase):
+    def test_invalid_trace_is_bad_trace(self):
+        mod = load()
+        report = mod.score_session(session_doc(), [{"argv": ["info"]}])
+        self.assertFalse(report["ok"])
+        self.assertEqual(report["mismatches"][0]["reason"], "badTrace")
+
+    def test_non_list_events(self):
+        mod = load()
+        report = mod.score_session(session_doc(), "nope")
+        self.assertFalse(report["ok"])
+        self.assertEqual(report["mismatches"][0]["reason"], "badTrace")
+
+    def test_non_dict_session(self):
+        mod = load()
+        report = mod.score_session([], [])
+        self.assertFalse(report["ok"])
+        self.assertEqual(report["mismatches"][0]["reason"], "badSession")
+
+
+class LcsAndCollapseMoreTests(unittest.TestCase):
+    def test_insert_then_delete_collapses_to_sub(self):
+        mod = load()
+        ops = mod.collapse_ops([("ins", None, 0), ("del", 0, None)])
+        self.assertEqual(ops[0][0], "sub")
+
+    def test_identical_lcs_is_all_match(self):
+        mod = load()
+        ops = mod.lcs_ops(["a", "b"], ["a", "b"])
+        self.assertEqual([op[0] for op in ops], ["match", "match"])
+
+    def test_empty_right_is_all_del(self):
+        mod = load()
+        ops = mod.lcs_ops(["a"], [])
+        self.assertEqual([op[0] for op in ops], ["del"])
+
+    def test_empty_left_is_all_ins(self):
+        mod = load()
+        ops = mod.lcs_ops([], ["a"])
+        self.assertEqual([op[0] for op in ops], ["ins"])
+
+
+class BuildTraceEventMoreTests(unittest.TestCase):
+    def test_bytes_stdout_hashed(self):
+        mod = load()
+        ev = mod.build_trace_event(["info"], 0, stdout=b"hi", ts="t")
+        self.assertEqual(ev["stdoutSha256"], mod.sha256_bytes(b"hi"))
+
+    def test_path_ok_false_marks_not_ok(self):
+        mod = load()
+        ev = mod.build_trace_event(["info"], 0, expect_exit=0, path_ok=False, ts="t")
+        self.assertFalse(ev["ok"])
+
+
+class NormalizeAndFamilyTests(unittest.TestCase):
+    def test_normalize_expect_exit_none_is_zero(self):
+        mod = load()
+        self.assertEqual(mod.normalize_expect_exit({}), 0)
+        self.assertEqual(mod.normalize_expect_exit({"expectExit": None}), 0)
+        self.assertEqual(mod.normalize_expect_exit({"expectExit": 3}), 3)
+
+    def test_declared_family_empty_run(self):
+        mod = load()
+        self.assertEqual(mod.declared_family({}), "")
+        self.assertEqual(mod.declared_family({"run": []}), "")
+
+
+class CompareStepMissingEventTests(unittest.TestCase):
+    def test_missing_event_is_not_ok(self):
+        mod = load()
+        row = mod.compare_step(0, {"run": ["info"], "expectExit": 0}, None, None)
+        self.assertFalse(row["ok"])
+        self.assertFalse(row["familyOk"])
+        self.assertIsNone(row["observedFamily"])
+
+    def test_unresolved_expect_path_skips_disk(self):
+        mod = load()
+        step = {"run": ["export-text"], "expectExit": 0, "expectPath": "{sub:out.txt}"}
+        event = {"argv": ["export-text"], "exit": 0, "ok": True}
+        row = mod.compare_step(0, step, event, None, check_paths=True)
+        self.assertTrue(row["ok"])
+        self.assertIsNone(row["pathOk"])
+
+
+class SessionContextTests(unittest.TestCase):
+    def test_from_session_cli_override(self):
+        mod = load()
+        ctx = mod.SessionContext.from_session(
+            session_doc(), input_path="other.hwp", sub_dir="tmp",
+        )
+        self.assertEqual(ctx.input_path, "other.hwp")
+        self.assertEqual(ctx.sub_dir, "tmp")
+
+    def test_from_session_defaults(self):
+        mod = load()
+        ctx = mod.SessionContext.from_session(session_doc())
+        self.assertEqual(ctx.input_path, "samples/x.hwp")
+        self.assertEqual(ctx.sub_dir, "work")
+
+
+class EmitAndMainTests(unittest.TestCase):
+    def test_emit_text_and_json(self):
+        mod = load()
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            mod.emit({"ok": True}, True, "ignored")
+        self.assertEqual(json.loads(buf.getvalue())["ok"], True)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            mod.emit({"ok": True}, False, "안녕")
+        self.assertIn("안녕", buf.getvalue())
+
+    def test_unknown_command_is_usage(self):
+        mod = load()
+        err = io.StringIO()
+        with self.assertRaises(SystemExit) as ctx:
+            with redirect_stderr(err):
+                mod.main(["nope"])
+        self.assertNotEqual(ctx.exception.code, 0)
+
+
+class ErrorCatalogContractTests(unittest.TestCase):
+    def test_catalog_tuples_have_hint(self):
+        mod = load()
+        for code, cls, hint in mod.ERROR_CODE_CATALOG:
+            self.assertTrue(code)
+            self.assertTrue(issubclass(cls, mod.SessionError))
+            self.assertTrue(hint)
+            self.assertIsInstance(hint, str)
+
+    def test_render_error_uses_code(self):
+        mod = load()
+        for code, cls, _hint in mod.ERROR_CODE_CATALOG:
+            if cls is mod.RecordRefused:
+                continue
+            text = mod.render_error(cls("메시지"))
+            self.assertIn(code, text)
+            self.assertIn("메시지", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 요약

종점 채점만 있으면 에이전트가 우회·역순·여분 명령으로도 만점을 받는다. `trajectory.py` 는 기준 풀이 마지막 스텝이 load-bearing 인지만 감사하고, 에이전트가 실제로 밟은 명령 열을 파일로 남겨 채점하지 않는다.

이 PR 은 `gym/tools/agent_session.py` 를 추가한다. 선언된 세션(명령 열 + 기대 종료)을 JSONL 트레이스로 기록하고, 재생 시 rhwp 없이 명령 계열(`argv[0]`)·종료 코드·순서를 기계 채점한다. 새 rhwp CLI 표면은 만들지 않았고, 기존 pack·README·profiles·checks·coverage 는 건드리지 않았다.

## 관련 이슈

closes #5206

## 동작

- 세션 정의: `id`, `steps[].run` (`{input}` / `{sub:이름}` 자리표), 선택 `expectExit` / `expectPath`
- 트레이스 JSONL: `ts`, `argv`, `exit`, `stdoutSha256?`, `ok`
- 채점 리포트: `kind=gymAgentSession`, `schemaVersion=1.0`
- CLI: `validate` / `score-replay` / `record`
- `record` 는 `--bin` 이 없거나 실행 파일이 없으면 거절한다. 없는 바이너리를 가장해 트레이스를 위조하지 않는다.

## 테스트

- [x] `python -m unittest scripts.tests.test_gym_agent_session` — 30건 통과 (pass / 잘못된 명령 / 잘못된 순서 / 여분 스텝 픽스처 포함)
- [x] `python gym/tools/audit.py` — 18 pack 전부 통과, 위반 0
- Python gym 도구만 추가한다. sparse checkout 이라 `cargo fmt --all` 은 실행하지 않았다.

## 성능 영향

영향 없음. 새 Python 도구이며 기본 채점 경로에 연결하지 않는다.
