### PR TITLE
feat(gym): 라이브 오라클 이중 계산 프로브를 추가한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -953,6 +953,7 @@ jobs:
           python3 -m unittest scripts/tests/test_gym_fuzz_corpus.py
           python3 -m unittest scripts/tests/test_gym_release_diff.py
           python3 -m unittest scripts/tests/test_gym_discriminate.py
+          python3 -m unittest scripts/tests/test_gym_oracle_probe.py
 
       # [#4855] 경쟁 벤치 하네스 순수 로직 가드 — 집계·능력 매트릭스·리포트 렌더·정직한
       # 저하(못 돌린 도구는 'n/a: 이유', 숫자 날조 금지)를 바이너리·외부도구 없이 검증한다.

--- a/gym/packs/oracle-probe/README.md
+++ b/gym/packs/oracle-probe/README.md
@@ -1,0 +1,200 @@
+---
+kind: guide
+status: active
+canonical: gym/packs/oracle-probe/README.md
+last_verified: 2026-08-18
+---
+
+# oracle-probe — 라이브 오라클 이중 계산
+
+## 왜 이 pack 인가
+
+채점은 정답을 골든 파일로 박제하지 않는다. 에이전트가 보고한 쪽수·검색
+건수·필드 수·표 수를 **채점 시점에 rhwp 가 다시 계산**하고, 그 값과
+등호를 본다. 이 pack 은 그 계약을 과제 단위로 드러낸다.
+
+1. 에이전트는 문서에서 숫자 하나를 읽어 `answer.json` 에 적는다.
+2. 채점기는 같은 명령을 다시 실행한다 (`info` / `explain` / `search` /
+   `fields` / `export-tables` / `extract-data` / `scan` / `capabilities` /
+   `verify` / `dump-pages`).
+3. 두 값이 같아야 통과한다. 어제 박제한 숫자가 오늘 바이너리와 어긋나면
+   과제가 틀린 것이 아니라 **오라클이 살아 있는 것**이다.
+
+`gym/tools/oracle_probe.py` 는 이 pack 을 채점하지 않는다. 프로브는
+채점기가 믿는 세 가지 전제 — 이중 계산 결정성, `{input}` / `{sub:}`
+치환, 부재 산출물의 비통과 — 를 팩 픽스처 없이 감사한다. 이 pack 은
+그 전제를 **실문서·실명령** 으로 구체화한다.
+
+새 CLI 는 없다. 기존 명령과 기존 표본만 쓴다.
+
+권위 출처: `gym/README.md` 의 "채점은 라이브다", `gym/tools/oracle_probe.py`
+모듈 문서, `gym/core/checks.py` 의 `answer_eq` / `len_answer_eq` /
+`value_eq`.
+
+## 이 확장이 지키는 규칙
+
+1. **기존 명령만.** `pack.json` requires 는 `capabilities` · `dump-pages` ·
+   `explain` · `export-tables` · `extract-data` · `fields` · `info` ·
+   `scan` · `search` · `verify` 뿐이다.
+2. **기존 연산자만.** `answer_eq` · `len_answer_eq` · `value_eq` 만 고른다.
+   전역 훑기(`deep_contains`)는 쓰지 않는다. 편집 산출물을 만들지 않는다.
+3. **기존 표본만.** `samples/` 밖 파일을 만들지 않는다. table-001,
+   issue2007 중첩 표, field-01 / field-01-memo, form-01 / form-02,
+   국립국어원 업무계획, 수출입 현황, multi-table-001, para-001,
+   exam-kor-1p, hwpx_sample2, PII 분석 표본만 축을 바꿔 다시 묻는다.
+4. **라이브 오라클.** 쪽수·검색 건수·필드 수를 과제에 박제하지 않는다.
+   채점기가 같은 명령을 다시 돌려 봉투 필드를 읽는다.
+5. **편집 과제를 복제하지 않는다.** 누름틀을 채우지 않는다. 표를 고치지
+   않는다. 산출물 `.hwp` 를 요구하지 않는다. 제출은 `answer.json` 만.
+6. **사다리를 완주하지 않는다.** `replay` · `audit` · `lineage` · `gate`
+   · `--deep` 을 부르지 않는다. 그 축은 automation / work-receipt /
+   expert-challenges 의 일이다.
+7. **원본을 덮지 않는다.** 읽기 전용 조회만 한다.
+
+## 이중 계산이  concretamente 보이는 곳
+
+| 에이전트가 보고하는 키 | 라이브 오라클 | 봉투 좌표 |
+|------------------------|---------------|-----------|
+| `pages` | `rhwp info {input} --json` | `pageCount` |
+| `paragraphs` | `rhwp explain {input} --json` | `paragraphCount` |
+| `tables` | `rhwp export-tables {input} --json` | `tableCount` |
+| `tableLen` | 같은 명령 | `len(tables)` |
+| `fields` | `rhwp fields {input} --json` | `fieldCount` |
+| `fieldLen` | 같은 명령 | `len(fields)` |
+| `hits` | `rhwp search … --json` | `matchCount` 또는 `len(matches)` |
+| `items` | `rhwp extract-data {input} --json` | `len(items)` |
+| `files` | `rhwp scan <폴더> --json` | `len(files)` |
+| `commands` / `read` / `write` | `rhwp capabilities` | 배열 길이 |
+| `format` | `rhwp info {input} --json` | `format` |
+| `verdict` | `rhwp verify --expect-min-pages` | `verdict` |
+| `dumped` | `rhwp dump-pages {input} --json` | `pageCount` |
+| `mismatch` | `rhwp scan --probe --json` | `files[0].extMismatch` |
+
+같은 표본에 다른 오라클을 붙인 짝이 있다. OP01 의 쪽수와 OP03 의 표 수는
+둘 다 table-001 이지만 숫자가 다르다. OP09 의 필드 수와 OP27 의 쪽수는
+둘 다 field-01 이다. 한쪽을 베껴 넣으면 다른쪽이 실패한다 — 그것이
+이중 계산의 판별력이다.
+
+스칼라(`fieldCount`)와 배열 길이(`len(fields)`)를 따로 묻는 과제
+(OP09/OP10, OP30/OP31)는 오라클 내부 정합도 드러낸다. 두 경로가
+어긋나면 채점기가 아니라 **명령 봉투** 가 깨진 것이다.
+
+## 함정 (실측, 과제에 녹여 둔 것)
+
+- **숫자를 기억하지 마라.** 어제 센 pageCount 가 오늘도 같으리라는
+  보장은 바이너리 계약이지 과제 계약이 아니다.
+- **표본을 바꾸면 답이 바뀐다.** table-001 의 쪽수를 form-01 에 그대로
+  내면 OP25 가 실패한다.
+- **검색어를 바꾸면 건수가 바뀐다.** '국어' 와 '업무' 는 같은 문서라도
+  다른 오라클이다 (OP14 / OP34).
+- **형식 표지는 확장자가 아니다.** `.hwp` 라도 봉투의 `format` 을
+  읽어야 한다. hwpx 표본에 `hwp` 를 적으면 OP18 이 실패한다.
+- **이름이 1p 라고 1 을 박제하지 마라.** OP35 는 exam-kor-1p 의 쪽수를
+  info 로 다시 센다.
+- **PII 표본을 마스킹하지 마라.** OP37·OP38 은 형식과 쪽수만 묻는다.
+  보안 pack 의 SE01·SE02 를 복제하지 않는다.
+- **제출은 answer.json 하나다.** 산출 `.hwp` 를 만들어도 채점기는
+  읽지 않는다. 부재 산출물 프로브는 이 pack 의 과제가 아니라
+  `oracle_probe.py` 의 단위 시험이 담당한다.
+
+## 과제 지도
+
+난도 1=입문 · 2=초급 · 3=중급. 보스(5) 사다리 완주는 XC 의 일이다.
+
+### OP01–OP08 — 문서 신원 (쪽·문단·표·덤프)
+
+| ID | 티어 | 질문 | 표본 | 오라클 |
+|----|------|------|------|--------|
+| OP01 | 1 | 쪽수 | table-001 | info.pageCount |
+| OP02 | 1 | 문단 수 | table-001 | explain.paragraphCount |
+| OP03 | 1 | 표 수 | table-001 | export-tables.tableCount |
+| OP04 | 1 | '표' 검색 | table-001 | search.matchCount |
+| OP05 | 2 | 쪽수 | issue2007 중첩 | info.pageCount |
+| OP06 | 2 | 문단 수 | issue2007 중첩 | explain.paragraphCount |
+| OP07 | 2 | 덤프 쪽수 | issue2007 중첩 | dump-pages.pageCount |
+| OP08 | 2 | 표 수 | issue2007 중첩 | export-tables.tableCount |
+
+### OP09–OP16 — 필드·검색·추출
+
+| ID | 티어 | 질문 | 표본 | 오라클 |
+|----|------|------|------|--------|
+| OP09 | 2 | 누름틀 수 | field-01 | fields.fieldCount |
+| OP10 | 2 | 누름틀 배열 길이 | field-01 | len(fields) |
+| OP11 | 2 | 누름틀 수 | field-01-memo | fields.fieldCount |
+| OP12 | 2 | 누름틀 수 | form-01 | fields.fieldCount |
+| OP13 | 2 | 누름틀 수 | form-02 | fields.fieldCount |
+| OP14 | 2 | '국어' 검색 | 국립국어원 | len(matches) |
+| OP15 | 2 | 쪽수 | 국립국어원 | info.pageCount |
+| OP16 | 2 | 추출 항목 수 | 수출입 현황 | len(items) |
+
+### OP17–OP24 — 형식·스윕·자기서술·검증
+
+| ID | 티어 | 질문 | 표본 | 오라클 |
+|----|------|------|------|--------|
+| OP17 | 1 | format | table-001 | info.format |
+| OP18 | 2 | format | hwpx_sample2 | info.format |
+| OP19 | 2 | 폴더 문서 수 | samples/hml | len(scan.files) |
+| OP20 | 2 | 확장자 불일치 | samples/hml | files[0].extMismatch |
+| OP21 | 1 | 명령 수 | (도구 자신) | len(capabilities.commands) |
+| OP22 | 2 | 읽기 형식 수 | (도구 자신) | len(formats.read) |
+| OP23 | 2 | 쓰기 형식 수 | (도구 자신) | len(formats.write) |
+| OP24 | 2 | 최소 쪽수 판정 | issue2007 중첩 | verify.verdict |
+
+### OP25–OP32 — 표본을 바꿔 같은 질문을 다시
+
+| ID | 티어 | 질문 | 표본 | 오라클 |
+|----|------|------|------|--------|
+| OP25 | 1 | 쪽수 | form-01 | info.pageCount |
+| OP26 | 1 | 쪽수 | form-02 | info.pageCount |
+| OP27 | 1 | 쪽수 | field-01 | info.pageCount |
+| OP28 | 2 | 문단 수 | field-01 | explain.paragraphCount |
+| OP29 | 2 | 문단 수 | form-01 | explain.paragraphCount |
+| OP30 | 2 | 표 수 | multi-table-001 | export-tables.tableCount |
+| OP31 | 2 | 표 배열 길이 | multi-table-001 | len(tables) |
+| OP32 | 2 | 문단 수 | para-001 | explain.paragraphCount |
+
+### OP33–OP44 — 검색 변이·시험지·PII 신원·이중 필드
+
+| ID | 티어 | 질문 | 표본 | 오라클 |
+|----|------|------|------|--------|
+| OP33 | 2 | '마케팅' 검색 | field-01 | search.matchCount |
+| OP34 | 2 | '업무' 검색 | 국립국어원 | search.matchCount |
+| OP35 | 1 | 쪽수 | exam-kor-1p | info.pageCount |
+| OP36 | 2 | 문단 수 | exam-kor-1p | explain.paragraphCount |
+| OP37 | 2 | format | PII 분석 표본 | info.format |
+| OP38 | 2 | 쪽수 | PII 분석 표본 | info.pageCount |
+| OP39 | 2 | format | field-01 | info.format |
+| OP40 | 3 | 쪽수+표 수 | table-001 | info + export-tables |
+| OP41 | 3 | 필드+쪽수 | field-01 | fields + info |
+| OP42 | 3 | 검색+쪽수 | 국립국어원 | search + info |
+| OP43 | 2 | 표 수 | form-01 | export-tables.tableCount |
+| OP44 | 2 | 문단 수 | form-02 | explain.paragraphCount |
+
+## 기준 풀이
+
+각 과제의 `reference/<ID>.json` 은 채점 검사와 같은 명령을 다시 적는다.
+`build_baseline.py` 가 그 명령을 실행해 `answer.json` 을 만든다. 숫자
+리터럴이 기준 풀이에도 없다 — 라이브 재계산이 제출물을 만든다.
+
+## 프로브 도구와의 관계
+
+```
+oracle_probe.py          이 pack
+----------------------   --------------------------------
+probe_determinism        같은 명령을 채점기가 다시 실행
+probe_placeholders       기준 풀이의 {input} 치환
+probe_missing_artifact   이 pack 은 answer 만 — 산출 부재는 단위 시험
+--json 구조 자기점검     pack 등재 전에 모듈 표면이 살아 있는지
+```
+
+프로브가 실패하면 이 pack 의 채점 전제가 무너진다. CI 는
+`scripts/tests/test_gym_oracle_probe.py` 와 `gym/tools/audit.py` 로
+둘 다 막는다.
+
+## 하지 않는 일
+
+- 새 clap 명령, 새 `src/bin`, 새 검사 연산자를 추가하지 않는다.
+- 골든 `pageCount: 1` 같은 숫자를 과제 JSON 에 적지 않는다.
+- 편집·변환·영수증 사다리를 이 pack 에 끌어오지 않는다.
+- `gym/README.md` 의 12 pack 표를 바꾸지 않는다. 이 pack 은 라이브
+  오라클 계약을 드러내는 확장이지 운동장 입문 코스의 교체가 아니다.

--- a/gym/packs/oracle-probe/pack.json
+++ b/gym/packs/oracle-probe/pack.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "1.0",
+  "kind": "gymPack",
+  "id": "oracle-probe",
+  "title": "라이브 오라클 이중 계산",
+  "axis": "검증 (라이브 오라클·이중 계산·부재 보고)",
+  "description": "에이전트가 보고한 쪽수·검색 건수·필드 수·표 수를 채점 시점에 rhwp 로 다시 계산한다. 골든 숫자를 박제하지 않는다. 산출물이 없으면 통과로 위장하지 않는다. 새 CLI 는 없다.",
+  "requires": {
+    "commands": [
+      "capabilities",
+      "dump-pages",
+      "explain",
+      "export-tables",
+      "extract-data",
+      "fields",
+      "info",
+      "scan",
+      "search",
+      "verify"
+    ]
+  },
+  "runner": {
+    "rhwpVersion": "0.8.2",
+    "rhwpCommit": "94e4790e5a6bc766b75c3c9695b290f87e3793d4",
+    "capabilitiesSha256": "2c7c41bc8952b63c4502ec0685b76990e4ece5b178f6dc28a1a495b12880af75"
+  }
+}

--- a/gym/packs/oracle-probe/reference/OP01.json
+++ b/gym/packs/oracle-probe/reference/OP01.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP01",
+  "steps": [
+    {
+      "answer": {
+        "pages": {
+          "cmd": [
+            "info",
+            "{input}",
+            "--json"
+          ],
+          "path": "pageCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP02.json
+++ b/gym/packs/oracle-probe/reference/OP02.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP02",
+  "steps": [
+    {
+      "answer": {
+        "paragraphs": {
+          "cmd": [
+            "explain",
+            "{input}",
+            "--json"
+          ],
+          "path": "paragraphCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP03.json
+++ b/gym/packs/oracle-probe/reference/OP03.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP03",
+  "steps": [
+    {
+      "answer": {
+        "tables": {
+          "cmd": [
+            "export-tables",
+            "{input}",
+            "--json"
+          ],
+          "path": "tableCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP04.json
+++ b/gym/packs/oracle-probe/reference/OP04.json
@@ -1,0 +1,19 @@
+{
+  "id": "OP04",
+  "steps": [
+    {
+      "answer": {
+        "hits": {
+          "cmd": [
+            "search",
+            "{input}",
+            "--json",
+            "--",
+            "표"
+          ],
+          "path": "matchCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP05.json
+++ b/gym/packs/oracle-probe/reference/OP05.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP05",
+  "steps": [
+    {
+      "answer": {
+        "pages": {
+          "cmd": [
+            "info",
+            "{input}",
+            "--json"
+          ],
+          "path": "pageCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP06.json
+++ b/gym/packs/oracle-probe/reference/OP06.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP06",
+  "steps": [
+    {
+      "answer": {
+        "paragraphs": {
+          "cmd": [
+            "explain",
+            "{input}",
+            "--json"
+          ],
+          "path": "paragraphCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP07.json
+++ b/gym/packs/oracle-probe/reference/OP07.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP07",
+  "steps": [
+    {
+      "answer": {
+        "dumped": {
+          "cmd": [
+            "dump-pages",
+            "{input}",
+            "--json"
+          ],
+          "path": "pageCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP08.json
+++ b/gym/packs/oracle-probe/reference/OP08.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP08",
+  "steps": [
+    {
+      "answer": {
+        "tables": {
+          "cmd": [
+            "export-tables",
+            "{input}",
+            "--json"
+          ],
+          "path": "tableCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP09.json
+++ b/gym/packs/oracle-probe/reference/OP09.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP09",
+  "steps": [
+    {
+      "answer": {
+        "fields": {
+          "cmd": [
+            "fields",
+            "{input}",
+            "--json"
+          ],
+          "path": "fieldCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP10.json
+++ b/gym/packs/oracle-probe/reference/OP10.json
@@ -1,0 +1,18 @@
+{
+  "id": "OP10",
+  "steps": [
+    {
+      "answer": {
+        "fieldLen": {
+          "cmd": [
+            "fields",
+            "{input}",
+            "--json"
+          ],
+          "path": "fields",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP11.json
+++ b/gym/packs/oracle-probe/reference/OP11.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP11",
+  "steps": [
+    {
+      "answer": {
+        "fields": {
+          "cmd": [
+            "fields",
+            "{input}",
+            "--json"
+          ],
+          "path": "fieldCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP12.json
+++ b/gym/packs/oracle-probe/reference/OP12.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP12",
+  "steps": [
+    {
+      "answer": {
+        "fields": {
+          "cmd": [
+            "fields",
+            "{input}",
+            "--json"
+          ],
+          "path": "fieldCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP13.json
+++ b/gym/packs/oracle-probe/reference/OP13.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP13",
+  "steps": [
+    {
+      "answer": {
+        "fields": {
+          "cmd": [
+            "fields",
+            "{input}",
+            "--json"
+          ],
+          "path": "fieldCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP14.json
+++ b/gym/packs/oracle-probe/reference/OP14.json
@@ -1,0 +1,19 @@
+{
+  "id": "OP14",
+  "steps": [
+    {
+      "answer": {
+        "hits": {
+          "cmd": [
+            "search",
+            "{input}",
+            "국어",
+            "--json"
+          ],
+          "path": "matches",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP15.json
+++ b/gym/packs/oracle-probe/reference/OP15.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP15",
+  "steps": [
+    {
+      "answer": {
+        "pages": {
+          "cmd": [
+            "info",
+            "{input}",
+            "--json"
+          ],
+          "path": "pageCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP16.json
+++ b/gym/packs/oracle-probe/reference/OP16.json
@@ -1,0 +1,18 @@
+{
+  "id": "OP16",
+  "steps": [
+    {
+      "answer": {
+        "items": {
+          "cmd": [
+            "extract-data",
+            "{input}",
+            "--json"
+          ],
+          "path": "items",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP17.json
+++ b/gym/packs/oracle-probe/reference/OP17.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP17",
+  "steps": [
+    {
+      "answer": {
+        "format": {
+          "cmd": [
+            "info",
+            "{input}",
+            "--json"
+          ],
+          "path": "format"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP18.json
+++ b/gym/packs/oracle-probe/reference/OP18.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP18",
+  "steps": [
+    {
+      "answer": {
+        "format": {
+          "cmd": [
+            "info",
+            "{input}",
+            "--json"
+          ],
+          "path": "format"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP19.json
+++ b/gym/packs/oracle-probe/reference/OP19.json
@@ -1,0 +1,18 @@
+{
+  "id": "OP19",
+  "steps": [
+    {
+      "answer": {
+        "files": {
+          "cmd": [
+            "scan",
+            "samples/hml",
+            "--json"
+          ],
+          "path": "files",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP20.json
+++ b/gym/packs/oracle-probe/reference/OP20.json
@@ -1,0 +1,18 @@
+{
+  "id": "OP20",
+  "steps": [
+    {
+      "answer": {
+        "mismatch": {
+          "cmd": [
+            "scan",
+            "samples/hml",
+            "--probe",
+            "--json"
+          ],
+          "path": "files[0].extMismatch"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP21.json
+++ b/gym/packs/oracle-probe/reference/OP21.json
@@ -1,0 +1,16 @@
+{
+  "id": "OP21",
+  "steps": [
+    {
+      "answer": {
+        "commands": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "commands",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP22.json
+++ b/gym/packs/oracle-probe/reference/OP22.json
@@ -1,0 +1,16 @@
+{
+  "id": "OP22",
+  "steps": [
+    {
+      "answer": {
+        "read": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "formats.read",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP23.json
+++ b/gym/packs/oracle-probe/reference/OP23.json
@@ -1,0 +1,16 @@
+{
+  "id": "OP23",
+  "steps": [
+    {
+      "answer": {
+        "write": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "formats.write",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP24.json
+++ b/gym/packs/oracle-probe/reference/OP24.json
@@ -1,0 +1,19 @@
+{
+  "id": "OP24",
+  "steps": [
+    {
+      "answer": {
+        "verdict": {
+          "cmd": [
+            "verify",
+            "{input}",
+            "--expect-min-pages",
+            "17",
+            "--json"
+          ],
+          "path": "verdict"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP25.json
+++ b/gym/packs/oracle-probe/reference/OP25.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP25",
+  "steps": [
+    {
+      "answer": {
+        "pages": {
+          "cmd": [
+            "info",
+            "{input}",
+            "--json"
+          ],
+          "path": "pageCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP26.json
+++ b/gym/packs/oracle-probe/reference/OP26.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP26",
+  "steps": [
+    {
+      "answer": {
+        "pages": {
+          "cmd": [
+            "info",
+            "{input}",
+            "--json"
+          ],
+          "path": "pageCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP27.json
+++ b/gym/packs/oracle-probe/reference/OP27.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP27",
+  "steps": [
+    {
+      "answer": {
+        "pages": {
+          "cmd": [
+            "info",
+            "{input}",
+            "--json"
+          ],
+          "path": "pageCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP28.json
+++ b/gym/packs/oracle-probe/reference/OP28.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP28",
+  "steps": [
+    {
+      "answer": {
+        "paragraphs": {
+          "cmd": [
+            "explain",
+            "{input}",
+            "--json"
+          ],
+          "path": "paragraphCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP29.json
+++ b/gym/packs/oracle-probe/reference/OP29.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP29",
+  "steps": [
+    {
+      "answer": {
+        "paragraphs": {
+          "cmd": [
+            "explain",
+            "{input}",
+            "--json"
+          ],
+          "path": "paragraphCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP30.json
+++ b/gym/packs/oracle-probe/reference/OP30.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP30",
+  "steps": [
+    {
+      "answer": {
+        "tables": {
+          "cmd": [
+            "export-tables",
+            "{input}",
+            "--json"
+          ],
+          "path": "tableCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP31.json
+++ b/gym/packs/oracle-probe/reference/OP31.json
@@ -1,0 +1,18 @@
+{
+  "id": "OP31",
+  "steps": [
+    {
+      "answer": {
+        "tableLen": {
+          "cmd": [
+            "export-tables",
+            "{input}",
+            "--json"
+          ],
+          "path": "tables",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP32.json
+++ b/gym/packs/oracle-probe/reference/OP32.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP32",
+  "steps": [
+    {
+      "answer": {
+        "paragraphs": {
+          "cmd": [
+            "explain",
+            "{input}",
+            "--json"
+          ],
+          "path": "paragraphCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP33.json
+++ b/gym/packs/oracle-probe/reference/OP33.json
@@ -1,0 +1,19 @@
+{
+  "id": "OP33",
+  "steps": [
+    {
+      "answer": {
+        "hits": {
+          "cmd": [
+            "search",
+            "{input}",
+            "--json",
+            "--",
+            "마케팅"
+          ],
+          "path": "matchCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP34.json
+++ b/gym/packs/oracle-probe/reference/OP34.json
@@ -1,0 +1,19 @@
+{
+  "id": "OP34",
+  "steps": [
+    {
+      "answer": {
+        "hits": {
+          "cmd": [
+            "search",
+            "{input}",
+            "--json",
+            "--",
+            "업무"
+          ],
+          "path": "matchCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP35.json
+++ b/gym/packs/oracle-probe/reference/OP35.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP35",
+  "steps": [
+    {
+      "answer": {
+        "pages": {
+          "cmd": [
+            "info",
+            "{input}",
+            "--json"
+          ],
+          "path": "pageCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP36.json
+++ b/gym/packs/oracle-probe/reference/OP36.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP36",
+  "steps": [
+    {
+      "answer": {
+        "paragraphs": {
+          "cmd": [
+            "explain",
+            "{input}",
+            "--json"
+          ],
+          "path": "paragraphCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP37.json
+++ b/gym/packs/oracle-probe/reference/OP37.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP37",
+  "steps": [
+    {
+      "answer": {
+        "format": {
+          "cmd": [
+            "info",
+            "{input}",
+            "--json"
+          ],
+          "path": "format"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP38.json
+++ b/gym/packs/oracle-probe/reference/OP38.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP38",
+  "steps": [
+    {
+      "answer": {
+        "pages": {
+          "cmd": [
+            "info",
+            "{input}",
+            "--json"
+          ],
+          "path": "pageCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP39.json
+++ b/gym/packs/oracle-probe/reference/OP39.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP39",
+  "steps": [
+    {
+      "answer": {
+        "format": {
+          "cmd": [
+            "info",
+            "{input}",
+            "--json"
+          ],
+          "path": "format"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP40.json
+++ b/gym/packs/oracle-probe/reference/OP40.json
@@ -1,0 +1,25 @@
+{
+  "id": "OP40",
+  "steps": [
+    {
+      "answer": {
+        "pages": {
+          "cmd": [
+            "info",
+            "{input}",
+            "--json"
+          ],
+          "path": "pageCount"
+        },
+        "tables": {
+          "cmd": [
+            "export-tables",
+            "{input}",
+            "--json"
+          ],
+          "path": "tableCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP41.json
+++ b/gym/packs/oracle-probe/reference/OP41.json
@@ -1,0 +1,25 @@
+{
+  "id": "OP41",
+  "steps": [
+    {
+      "answer": {
+        "fields": {
+          "cmd": [
+            "fields",
+            "{input}",
+            "--json"
+          ],
+          "path": "fieldCount"
+        },
+        "pages": {
+          "cmd": [
+            "info",
+            "{input}",
+            "--json"
+          ],
+          "path": "pageCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP42.json
+++ b/gym/packs/oracle-probe/reference/OP42.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP42",
+  "steps": [
+    {
+      "answer": {
+        "hits": {
+          "cmd": [
+            "search",
+            "{input}",
+            "국어",
+            "--json"
+          ],
+          "path": "matches",
+          "len": true
+        },
+        "pages": {
+          "cmd": [
+            "info",
+            "{input}",
+            "--json"
+          ],
+          "path": "pageCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP43.json
+++ b/gym/packs/oracle-probe/reference/OP43.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP43",
+  "steps": [
+    {
+      "answer": {
+        "tables": {
+          "cmd": [
+            "export-tables",
+            "{input}",
+            "--json"
+          ],
+          "path": "tableCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/reference/OP44.json
+++ b/gym/packs/oracle-probe/reference/OP44.json
@@ -1,0 +1,17 @@
+{
+  "id": "OP44",
+  "steps": [
+    {
+      "answer": {
+        "paragraphs": {
+          "cmd": [
+            "explain",
+            "{input}",
+            "--json"
+          ],
+          "path": "paragraphCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP01.json
+++ b/gym/packs/oracle-probe/tasks/OP01.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP01",
+  "tier": 1,
+  "title": "쪽수 라이브 재계산 (table-001)",
+  "input": "samples/table-001.hwp",
+  "axis": "검증",
+  "instructions": "입력 문서의 총 쪽수를 알아내 answer.json 에 {\"pages\": N} 으로 제출하라. 채점은 골든 숫자를 박제하지 않는다 — 채점 시점에 rhwp info {input} --json 의 pageCount 를 다시 읽어 네 보고와 대조한다. 힌트: rhwp info.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "쪽수 라이브 대조",
+      "op": "answer_eq",
+      "answer": "pages",
+      "cmd": [
+        "info",
+        "{input}",
+        "--json"
+      ],
+      "path": "pageCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP02.json
+++ b/gym/packs/oracle-probe/tasks/OP02.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP02",
+  "tier": 1,
+  "title": "문단 수 라이브 재계산 (table-001)",
+  "input": "samples/table-001.hwp",
+  "axis": "검증",
+  "instructions": "입력 문서의 문단 수를 answer.json 에 {\"paragraphs\": N} 으로 제출하라. 채점기가 같은 입력을 explain --json 으로 다시 돌려 paragraphCount 와 대조한다. 힌트: rhwp explain {input} --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "문단 수 라이브 대조",
+      "op": "answer_eq",
+      "answer": "paragraphs",
+      "cmd": [
+        "explain",
+        "{input}",
+        "--json"
+      ],
+      "path": "paragraphCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP03.json
+++ b/gym/packs/oracle-probe/tasks/OP03.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP03",
+  "tier": 1,
+  "title": "표 수 라이브 재계산 (table-001)",
+  "input": "samples/table-001.hwp",
+  "axis": "검증",
+  "instructions": "입력 문서의 표 개수를 answer.json 에 {\"tables\": N} 으로 제출하라. 채점기가 export-tables --json 의 tableCount 를 라이브로 다시 센다. 힌트: rhwp export-tables {input} --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "표 수 라이브 대조",
+      "op": "answer_eq",
+      "answer": "tables",
+      "cmd": [
+        "export-tables",
+        "{input}",
+        "--json"
+      ],
+      "path": "tableCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP04.json
+++ b/gym/packs/oracle-probe/tasks/OP04.json
@@ -1,0 +1,29 @@
+{
+  "id": "OP04",
+  "tier": 1,
+  "title": "검색 건수 라이브 재계산 ('표')",
+  "input": "samples/table-001.hwp",
+  "axis": "검증",
+  "instructions": "입력에서 '표' 가 몇 번 나오는지 answer.json 에 {\"hits\": N} 으로 제출하라. 채점기가 같은 질의를 다시 실행해 matchCount 와 대조한다. 힌트: rhwp search {input} --json -- 표.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "검색 건수 라이브 대조",
+      "op": "answer_eq",
+      "answer": "hits",
+      "cmd": [
+        "search",
+        "{input}",
+        "--json",
+        "--",
+        "표"
+      ],
+      "path": "matchCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP05.json
+++ b/gym/packs/oracle-probe/tasks/OP05.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP05",
+  "tier": 2,
+  "title": "중첩 표 쪽수 라이브 재계산",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "axis": "검증",
+  "instructions": "중첩 셀 페이지네이션 표본의 쪽수를 answer.json 에 {\"pages\": N} 으로 제출하라. CR01/T01/LR01 과 같은 표본이지만 이 pack 의 질문은 '네가 센 수가 라이브 오라클과 같은가' 이다. 힌트: rhwp info {input} --json pageCount.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "중첩 표 쪽수",
+      "op": "answer_eq",
+      "answer": "pages",
+      "cmd": [
+        "info",
+        "{input}",
+        "--json"
+      ],
+      "path": "pageCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP06.json
+++ b/gym/packs/oracle-probe/tasks/OP06.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP06",
+  "tier": 2,
+  "title": "중첩 표 문단 수 이중 계산",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "axis": "검증",
+  "instructions": "같은 중첩 표 표본의 문단 수를 answer.json 에 {\"paragraphs\": N} 으로 제출하라. info 가 아니라 explain 의 paragraphCount 를 라이브 대조한다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "중첩 표 문단 수",
+      "op": "answer_eq",
+      "answer": "paragraphs",
+      "cmd": [
+        "explain",
+        "{input}",
+        "--json"
+      ],
+      "path": "paragraphCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP07.json
+++ b/gym/packs/oracle-probe/tasks/OP07.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP07",
+  "tier": 2,
+  "title": "중첩 표 덤프 쪽수 이중 계산",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "axis": "검증",
+  "instructions": "dump-pages 가 잡는 쪽 수를 answer.json 에 {\"dumped\": N} 으로 제출하라. info.pageCount 와 같은 값이어야 하지만 오라클은 dump-pages 를 다시 돌린다. 힌트: rhwp dump-pages {input} --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "덤프 쪽수",
+      "op": "answer_eq",
+      "answer": "dumped",
+      "cmd": [
+        "dump-pages",
+        "{input}",
+        "--json"
+      ],
+      "path": "pageCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP08.json
+++ b/gym/packs/oracle-probe/tasks/OP08.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP08",
+  "tier": 2,
+  "title": "중첩 표 개수 라이브 재계산",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "axis": "검증",
+  "instructions": "중첩 표 표본의 표 개수를 answer.json 에 {\"tables\": N} 으로 제출하라. 채점기가 export-tables --json 의 tableCount 를 다시 읽는다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "중첩 표 개수",
+      "op": "answer_eq",
+      "answer": "tables",
+      "cmd": [
+        "export-tables",
+        "{input}",
+        "--json"
+      ],
+      "path": "tableCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP09.json
+++ b/gym/packs/oracle-probe/tasks/OP09.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP09",
+  "tier": 2,
+  "title": "누름틀 수 라이브 재계산 (field-01)",
+  "input": "samples/field-01.hwp",
+  "axis": "검증",
+  "instructions": "서식의 누름틀 개수를 answer.json 에 {\"fields\": N} 으로 제출하라. 채점기가 fields --json 의 fieldCount 를 다시 센다. 힌트: rhwp fields.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "필드 수 라이브 대조",
+      "op": "answer_eq",
+      "answer": "fields",
+      "cmd": [
+        "fields",
+        "{input}",
+        "--json"
+      ],
+      "path": "fieldCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP10.json
+++ b/gym/packs/oracle-probe/tasks/OP10.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP10",
+  "tier": 2,
+  "title": "누름틀 배열 길이 이중 계산",
+  "input": "samples/field-01.hwp",
+  "axis": "검증",
+  "instructions": "fields 배열의 길이를 answer.json 에 {\"fieldLen\": N} 으로 제출하라. fieldCount 스칼라가 아니라 배열 길이를 라이브로 잰다 (len_answer_eq). 두 경로가 같아야 오라클이 정합하다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "필드 배열 길이",
+      "op": "len_answer_eq",
+      "answer": "fieldLen",
+      "cmd": [
+        "fields",
+        "{input}",
+        "--json"
+      ],
+      "path": "fields"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP11.json
+++ b/gym/packs/oracle-probe/tasks/OP11.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP11",
+  "tier": 2,
+  "title": "메모 서식 누름틀 수",
+  "input": "samples/field-01-memo.hwp",
+  "axis": "검증",
+  "instructions": "field-01-memo 서식의 누름틀 개수를 answer.json 에 {\"fields\": N} 으로 제출하라. field-01 과 같은 축이지만 다른 표본 — 골든을 베끼면 틀린다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "메모 서식 필드 수",
+      "op": "answer_eq",
+      "answer": "fields",
+      "cmd": [
+        "fields",
+        "{input}",
+        "--json"
+      ],
+      "path": "fieldCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP12.json
+++ b/gym/packs/oracle-probe/tasks/OP12.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP12",
+  "tier": 2,
+  "title": "form-01 누름틀 수 라이브 재계산",
+  "input": "samples/form-01.hwp",
+  "axis": "검증",
+  "instructions": "form-01 서식의 누름틀 개수를 answer.json 에 {\"fields\": N} 으로 제출하라. 채점기가 같은 명령을 다시 실행한다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "form-01 필드 수",
+      "op": "answer_eq",
+      "answer": "fields",
+      "cmd": [
+        "fields",
+        "{input}",
+        "--json"
+      ],
+      "path": "fieldCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP13.json
+++ b/gym/packs/oracle-probe/tasks/OP13.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP13",
+  "tier": 2,
+  "title": "form-02 누름틀 수 라이브 재계산",
+  "input": "samples/form-02.hwp",
+  "axis": "검증",
+  "instructions": "form-02 서식의 누름틀 개수를 answer.json 에 {\"fields\": N} 으로 제출하라. form-01 과 숫자를 바꿔 넣으면 라이브 오라클이 거부한다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "form-02 필드 수",
+      "op": "answer_eq",
+      "answer": "fields",
+      "cmd": [
+        "fields",
+        "{input}",
+        "--json"
+      ],
+      "path": "fieldCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP14.json
+++ b/gym/packs/oracle-probe/tasks/OP14.json
@@ -1,0 +1,28 @@
+{
+  "id": "OP14",
+  "tier": 2,
+  "title": "국어원 문서 '국어' 검색 건수",
+  "input": "samples/2022년 국립국어원 업무계획.hwp",
+  "axis": "검증",
+  "instructions": "국립국어원 업무계획에서 '국어' 가 몇 번 나오는지 answer.json 에 {\"hits\": N} 으로 제출하라. 채점기가 search 를 다시 돌려 matches 길이를 잰다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "국어 매치 수",
+      "op": "len_answer_eq",
+      "answer": "hits",
+      "cmd": [
+        "search",
+        "{input}",
+        "국어",
+        "--json"
+      ],
+      "path": "matches"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP15.json
+++ b/gym/packs/oracle-probe/tasks/OP15.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP15",
+  "tier": 2,
+  "title": "국어원 문서 쪽수 이중 계산",
+  "input": "samples/2022년 국립국어원 업무계획.hwp",
+  "axis": "검증",
+  "instructions": "같은 국어원 문서의 쪽수를 answer.json 에 {\"pages\": N} 으로 제출하라. 검색 건수와 쪽수는 다른 오라클이다 — 한쪽을 베껴 넣으면 실패한다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "국어원 쪽수",
+      "op": "answer_eq",
+      "answer": "pages",
+      "cmd": [
+        "info",
+        "{input}",
+        "--json"
+      ],
+      "path": "pageCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP16.json
+++ b/gym/packs/oracle-probe/tasks/OP16.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP16",
+  "tier": 2,
+  "title": "수출입 현황 추출 항목 수",
+  "input": "samples/156636617_240617 2024년 5월 월간 수출입 현황(확정치).hwp",
+  "axis": "검증",
+  "instructions": "수출입 현황 문서에서 날짜·금액·수량 항목 수를 answer.json 에 {\"items\": N} 으로 제출하라. 채점기가 extract-data --json 의 items 길이를 다시 잰다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "추출 항목 수",
+      "op": "len_answer_eq",
+      "answer": "items",
+      "cmd": [
+        "extract-data",
+        "{input}",
+        "--json"
+      ],
+      "path": "items"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP17.json
+++ b/gym/packs/oracle-probe/tasks/OP17.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP17",
+  "tier": 1,
+  "title": "형식 표지 라이브 대조 (hwp)",
+  "input": "samples/table-001.hwp",
+  "axis": "검증",
+  "instructions": "입력의 형식 표지를 answer.json 에 {\"format\": \"...\"} 으로 제출하라. 채점기가 info --json 의 format 을 다시 읽는다. 힌트: 보통 hwp.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "형식 표지",
+      "op": "answer_eq",
+      "answer": "format",
+      "cmd": [
+        "info",
+        "{input}",
+        "--json"
+      ],
+      "path": "format"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP18.json
+++ b/gym/packs/oracle-probe/tasks/OP18.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP18",
+  "tier": 2,
+  "title": "HWPX 형식 표지 라이브 대조",
+  "input": "samples/hwpx_sample2.hwpx",
+  "axis": "검증",
+  "instructions": "hwpx 표본의 형식 표지를 answer.json 에 {\"format\": \"...\"} 으로 제출하라. hwp 표본의 답을 그대로 내면 라이브 오라클이 거부한다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "hwpx 형식 표지",
+      "op": "answer_eq",
+      "answer": "format",
+      "cmd": [
+        "info",
+        "{input}",
+        "--json"
+      ],
+      "path": "format"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP19.json
+++ b/gym/packs/oracle-probe/tasks/OP19.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP19",
+  "tier": 2,
+  "title": "hml 폴더 스윕 문서 수",
+  "input": "samples/table-001.hwp",
+  "axis": "검증",
+  "instructions": "samples/hml 폴더에서 발견되는 문서 수를 answer.json 에 {\"files\": N} 으로 제출하라. 채점기가 scan --json 의 files 길이를 다시 잰다. 입력 파일 자체는 자리만 채운다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "스윕 문서 수",
+      "op": "len_answer_eq",
+      "answer": "files",
+      "cmd": [
+        "scan",
+        "samples/hml",
+        "--json"
+      ],
+      "path": "files"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP20.json
+++ b/gym/packs/oracle-probe/tasks/OP20.json
@@ -1,0 +1,28 @@
+{
+  "id": "OP20",
+  "tier": 2,
+  "title": "hml 탐침 첫 문서 확장자 불일치",
+  "input": "samples/table-001.hwp",
+  "axis": "검증",
+  "instructions": "samples/hml 을 탐침 모드로 스캔해 첫 문서의 확장자 불일치 여부를 answer.json 에 {\"mismatch\": true|false} 로 제출하라. 채점기가 scan --probe --json 의 files[0].extMismatch 를 다시 읽는다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "확장자 불일치",
+      "op": "answer_eq",
+      "answer": "mismatch",
+      "cmd": [
+        "scan",
+        "samples/hml",
+        "--probe",
+        "--json"
+      ],
+      "path": "files[0].extMismatch"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP21.json
+++ b/gym/packs/oracle-probe/tasks/OP21.json
@@ -1,0 +1,25 @@
+{
+  "id": "OP21",
+  "tier": 1,
+  "title": "명령 표면 개수 라이브 재계산",
+  "input": "samples/table-001.hwp",
+  "axis": "검증",
+  "instructions": "rhwp 가 스스로 선언하는 명령 개수를 answer.json 에 {\"commands\": N} 으로 제출하라. 채점기가 capabilities 의 commands 길이를 다시 잰다. 숫자를 기억해 박제하지 마라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "명령 수",
+      "op": "len_answer_eq",
+      "answer": "commands",
+      "cmd": [
+        "capabilities"
+      ],
+      "path": "commands"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP22.json
+++ b/gym/packs/oracle-probe/tasks/OP22.json
@@ -1,0 +1,25 @@
+{
+  "id": "OP22",
+  "tier": 2,
+  "title": "읽기 형식 수 라이브 재계산",
+  "input": "samples/table-001.hwp",
+  "axis": "검증",
+  "instructions": "읽을 수 있는 형식 수를 answer.json 에 {\"read\": N} 으로 제출하라. 채점기가 capabilities 의 formats.read 길이를 다시 잰다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "읽기 형식 수",
+      "op": "len_answer_eq",
+      "answer": "read",
+      "cmd": [
+        "capabilities"
+      ],
+      "path": "formats.read"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP23.json
+++ b/gym/packs/oracle-probe/tasks/OP23.json
@@ -1,0 +1,25 @@
+{
+  "id": "OP23",
+  "tier": 2,
+  "title": "쓰기 형식 수 라이브 재계산",
+  "input": "samples/table-001.hwp",
+  "axis": "검증",
+  "instructions": "쓸 수 있는 형식 수를 answer.json 에 {\"write\": N} 으로 제출하라. 읽기 형식 수와 같다고 가정하지 마라 — 오라클이 따로 센다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "쓰기 형식 수",
+      "op": "len_answer_eq",
+      "answer": "write",
+      "cmd": [
+        "capabilities"
+      ],
+      "path": "formats.write"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP24.json
+++ b/gym/packs/oracle-probe/tasks/OP24.json
@@ -1,0 +1,29 @@
+{
+  "id": "OP24",
+  "tier": 2,
+  "title": "최소 쪽수 자기검증 판정",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "axis": "검증",
+  "instructions": "입력이 17쪽 이상인지 자기검증하고 판정(verdict)을 answer.json 에 {\"verdict\": \"...\"} 으로 제출하라. 채점기가 verify --expect-min-pages 17 을 다시 돌려 같은 판정을 읽는다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "판정 라이브 대조",
+      "op": "answer_eq",
+      "answer": "verdict",
+      "cmd": [
+        "verify",
+        "{input}",
+        "--expect-min-pages",
+        "17",
+        "--json"
+      ],
+      "path": "verdict"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP25.json
+++ b/gym/packs/oracle-probe/tasks/OP25.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP25",
+  "tier": 1,
+  "title": "쪽수 라이브 재계산 (form-01)",
+  "input": "samples/form-01.hwp",
+  "axis": "검증",
+  "instructions": "form-01 의 쪽수를 answer.json 에 {\"pages\": N} 으로 제출하라. table-001 의 쪽수를 베끼면 실패한다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "form-01 쪽수",
+      "op": "answer_eq",
+      "answer": "pages",
+      "cmd": [
+        "info",
+        "{input}",
+        "--json"
+      ],
+      "path": "pageCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP26.json
+++ b/gym/packs/oracle-probe/tasks/OP26.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP26",
+  "tier": 1,
+  "title": "쪽수 라이브 재계산 (form-02)",
+  "input": "samples/form-02.hwp",
+  "axis": "검증",
+  "instructions": "form-02 의 쪽수를 answer.json 에 {\"pages\": N} 으로 제출하라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "form-02 쪽수",
+      "op": "answer_eq",
+      "answer": "pages",
+      "cmd": [
+        "info",
+        "{input}",
+        "--json"
+      ],
+      "path": "pageCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP27.json
+++ b/gym/packs/oracle-probe/tasks/OP27.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP27",
+  "tier": 1,
+  "title": "쪽수 라이브 재계산 (field-01)",
+  "input": "samples/field-01.hwp",
+  "axis": "검증",
+  "instructions": "field-01 의 쪽수를 answer.json 에 {\"pages\": N} 으로 제출하라. 필드 수와 쪽수는 다른 오라클이다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "field-01 쪽수",
+      "op": "answer_eq",
+      "answer": "pages",
+      "cmd": [
+        "info",
+        "{input}",
+        "--json"
+      ],
+      "path": "pageCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP28.json
+++ b/gym/packs/oracle-probe/tasks/OP28.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP28",
+  "tier": 2,
+  "title": "field-01 문단 수 이중 계산",
+  "input": "samples/field-01.hwp",
+  "axis": "검증",
+  "instructions": "field-01 의 문단 수를 answer.json 에 {\"paragraphs\": N} 으로 제출하라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "field-01 문단 수",
+      "op": "answer_eq",
+      "answer": "paragraphs",
+      "cmd": [
+        "explain",
+        "{input}",
+        "--json"
+      ],
+      "path": "paragraphCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP29.json
+++ b/gym/packs/oracle-probe/tasks/OP29.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP29",
+  "tier": 2,
+  "title": "form-01 문단 수 이중 계산",
+  "input": "samples/form-01.hwp",
+  "axis": "검증",
+  "instructions": "form-01 의 문단 수를 answer.json 에 {\"paragraphs\": N} 으로 제출하라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "form-01 문단 수",
+      "op": "answer_eq",
+      "answer": "paragraphs",
+      "cmd": [
+        "explain",
+        "{input}",
+        "--json"
+      ],
+      "path": "paragraphCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP30.json
+++ b/gym/packs/oracle-probe/tasks/OP30.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP30",
+  "tier": 2,
+  "title": "multi-table 표 수 라이브 재계산",
+  "input": "samples/multi-table-001.hwp",
+  "axis": "검증",
+  "instructions": "multi-table-001 의 표 개수를 answer.json 에 {\"tables\": N} 으로 제출하라. table-001 의 답을 재사용하면 라이브 오라클이 거부한다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "다중 표 개수",
+      "op": "answer_eq",
+      "answer": "tables",
+      "cmd": [
+        "export-tables",
+        "{input}",
+        "--json"
+      ],
+      "path": "tableCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP31.json
+++ b/gym/packs/oracle-probe/tasks/OP31.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP31",
+  "tier": 2,
+  "title": "multi-table 표 배열 길이 이중 계산",
+  "input": "samples/multi-table-001.hwp",
+  "axis": "검증",
+  "instructions": "export-tables 의 tables 배열 길이를 answer.json 에 {\"tableLen\": N} 으로 제출하라. tableCount 스칼라와 배열 길이가 같아야 오라클이 정합하다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "표 배열 길이",
+      "op": "len_answer_eq",
+      "answer": "tableLen",
+      "cmd": [
+        "export-tables",
+        "{input}",
+        "--json"
+      ],
+      "path": "tables"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP32.json
+++ b/gym/packs/oracle-probe/tasks/OP32.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP32",
+  "tier": 2,
+  "title": "para-001 문단 수 라이브 재계산",
+  "input": "samples/para-001.hwp",
+  "axis": "검증",
+  "instructions": "para-001 의 문단 수를 answer.json 에 {\"paragraphs\": N} 으로 제출하라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "para-001 문단 수",
+      "op": "answer_eq",
+      "answer": "paragraphs",
+      "cmd": [
+        "explain",
+        "{input}",
+        "--json"
+      ],
+      "path": "paragraphCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP33.json
+++ b/gym/packs/oracle-probe/tasks/OP33.json
@@ -1,0 +1,29 @@
+{
+  "id": "OP33",
+  "tier": 2,
+  "title": "field-01 '마케팅' 검색 건수",
+  "input": "samples/field-01.hwp",
+  "axis": "검증",
+  "instructions": "field-01 에서 '마케팅' 이 몇 번 나오는지 answer.json 에 {\"hits\": N} 으로 제출하라. 채점기가 같은 질의를 다시 실행한다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "마케팅 검색 건수",
+      "op": "answer_eq",
+      "answer": "hits",
+      "cmd": [
+        "search",
+        "{input}",
+        "--json",
+        "--",
+        "마케팅"
+      ],
+      "path": "matchCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP34.json
+++ b/gym/packs/oracle-probe/tasks/OP34.json
@@ -1,0 +1,29 @@
+{
+  "id": "OP34",
+  "tier": 2,
+  "title": "국어원 문서 '업무' 검색 건수",
+  "input": "samples/2022년 국립국어원 업무계획.hwp",
+  "axis": "검증",
+  "instructions": "국립국어원 업무계획에서 '업무' 가 몇 번 나오는지 answer.json 에 {\"hits\": N} 으로 제출하라. '국어' 검색 건수와 같다고 가정하지 마라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "업무 검색 건수",
+      "op": "answer_eq",
+      "answer": "hits",
+      "cmd": [
+        "search",
+        "{input}",
+        "--json",
+        "--",
+        "업무"
+      ],
+      "path": "matchCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP35.json
+++ b/gym/packs/oracle-probe/tasks/OP35.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP35",
+  "tier": 1,
+  "title": "쪽수 라이브 재계산 (exam-kor-1p)",
+  "input": "samples/exam-kor-1p.hwp",
+  "axis": "검증",
+  "instructions": "1쪽 시험지 표본의 쪽수를 answer.json 에 {\"pages\": N} 으로 제출하라. 이름이 1p 라고 1 을 박제하지 마라 — 오라클이 info 를 다시 돌린다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "시험지 쪽수",
+      "op": "answer_eq",
+      "answer": "pages",
+      "cmd": [
+        "info",
+        "{input}",
+        "--json"
+      ],
+      "path": "pageCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP36.json
+++ b/gym/packs/oracle-probe/tasks/OP36.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP36",
+  "tier": 2,
+  "title": "exam-kor-1p 문단 수",
+  "input": "samples/exam-kor-1p.hwp",
+  "axis": "검증",
+  "instructions": "1쪽 시험지의 문단 수를 answer.json 에 {\"paragraphs\": N} 으로 제출하라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "시험지 문단 수",
+      "op": "answer_eq",
+      "answer": "paragraphs",
+      "cmd": [
+        "explain",
+        "{input}",
+        "--json"
+      ],
+      "path": "paragraphCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP37.json
+++ b/gym/packs/oracle-probe/tasks/OP37.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP37",
+  "tier": 2,
+  "title": "PII 표본 형식 표지",
+  "input": "samples/task2097/75544_pii_bunseok.hwpx",
+  "axis": "검증",
+  "instructions": "PII 분석 표본의 형식 표지를 answer.json 에 {\"format\": \"...\"} 으로 제출하라. 보안 pack 의 마스킹 과제가 아니다 — 형식만 라이브 대조한다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "PII 표본 형식",
+      "op": "answer_eq",
+      "answer": "format",
+      "cmd": [
+        "info",
+        "{input}",
+        "--json"
+      ],
+      "path": "format"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP38.json
+++ b/gym/packs/oracle-probe/tasks/OP38.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP38",
+  "tier": 2,
+  "title": "PII 표본 쪽수 라이브 재계산",
+  "input": "samples/task2097/75544_pii_bunseok.hwpx",
+  "axis": "검증",
+  "instructions": "PII 분석 표본의 쪽수를 answer.json 에 {\"pages\": N} 으로 제출하라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "PII 표본 쪽수",
+      "op": "answer_eq",
+      "answer": "pages",
+      "cmd": [
+        "info",
+        "{input}",
+        "--json"
+      ],
+      "path": "pageCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP39.json
+++ b/gym/packs/oracle-probe/tasks/OP39.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP39",
+  "tier": 2,
+  "title": "field-01 형식 표지",
+  "input": "samples/field-01.hwp",
+  "axis": "검증",
+  "instructions": "field-01 의 형식 표지를 answer.json 에 {\"format\": \"...\"} 으로 제출하라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "field-01 형식",
+      "op": "answer_eq",
+      "answer": "format",
+      "cmd": [
+        "info",
+        "{input}",
+        "--json"
+      ],
+      "path": "format"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP40.json
+++ b/gym/packs/oracle-probe/tasks/OP40.json
@@ -1,0 +1,38 @@
+{
+  "id": "OP40",
+  "tier": 3,
+  "title": "이중 오라클 — 쪽수와 표 수를 동시에",
+  "input": "samples/table-001.hwp",
+  "axis": "검증",
+  "instructions": "table-001 의 쪽수와 표 수를 한 장의 answer.json 에 {\"pages\": N, \"tables\": M} 으로 제출하라. 채점기가 info 와 export-tables 를 각각 다시 돌려 두 필드를 따로 대조한다. 한쪽만 맞으면 실패다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "쪽수",
+      "op": "answer_eq",
+      "answer": "pages",
+      "cmd": [
+        "info",
+        "{input}",
+        "--json"
+      ],
+      "path": "pageCount"
+    },
+    {
+      "name": "표 수",
+      "op": "answer_eq",
+      "answer": "tables",
+      "cmd": [
+        "export-tables",
+        "{input}",
+        "--json"
+      ],
+      "path": "tableCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP41.json
+++ b/gym/packs/oracle-probe/tasks/OP41.json
@@ -1,0 +1,38 @@
+{
+  "id": "OP41",
+  "tier": 3,
+  "title": "이중 오라클 — 필드 수와 쪽수 (field-01)",
+  "input": "samples/field-01.hwp",
+  "axis": "검증",
+  "instructions": "field-01 의 누름틀 수와 쪽수를 answer.json 에 {\"fields\": N, \"pages\": M} 으로 제출하라. 두 라이브 오라클이 모두 맞아야 한다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "필드 수",
+      "op": "answer_eq",
+      "answer": "fields",
+      "cmd": [
+        "fields",
+        "{input}",
+        "--json"
+      ],
+      "path": "fieldCount"
+    },
+    {
+      "name": "쪽수",
+      "op": "answer_eq",
+      "answer": "pages",
+      "cmd": [
+        "info",
+        "{input}",
+        "--json"
+      ],
+      "path": "pageCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP42.json
+++ b/gym/packs/oracle-probe/tasks/OP42.json
@@ -1,0 +1,39 @@
+{
+  "id": "OP42",
+  "tier": 3,
+  "title": "이중 오라클 — 검색과 쪽수 (국어원)",
+  "input": "samples/2022년 국립국어원 업무계획.hwp",
+  "axis": "검증",
+  "instructions": "국어원 문서의 '국어' 검색 건수(배열 길이)와 쪽수를 answer.json 에 {\"hits\": N, \"pages\": M} 으로 제출하라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "검색 건수",
+      "op": "len_answer_eq",
+      "answer": "hits",
+      "cmd": [
+        "search",
+        "{input}",
+        "국어",
+        "--json"
+      ],
+      "path": "matches"
+    },
+    {
+      "name": "쪽수",
+      "op": "answer_eq",
+      "answer": "pages",
+      "cmd": [
+        "info",
+        "{input}",
+        "--json"
+      ],
+      "path": "pageCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP43.json
+++ b/gym/packs/oracle-probe/tasks/OP43.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP43",
+  "tier": 2,
+  "title": "form-01 표 수 라이브 재계산",
+  "input": "samples/form-01.hwp",
+  "axis": "검증",
+  "instructions": "form-01 의 표 개수를 answer.json 에 {\"tables\": N} 으로 제출하라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "form-01 표 수",
+      "op": "answer_eq",
+      "answer": "tables",
+      "cmd": [
+        "export-tables",
+        "{input}",
+        "--json"
+      ],
+      "path": "tableCount"
+    }
+  ]
+}

--- a/gym/packs/oracle-probe/tasks/OP44.json
+++ b/gym/packs/oracle-probe/tasks/OP44.json
@@ -1,0 +1,27 @@
+{
+  "id": "OP44",
+  "tier": 2,
+  "title": "form-02 문단 수 라이브 재계산",
+  "input": "samples/form-02.hwp",
+  "axis": "검증",
+  "instructions": "form-02 의 문단 수를 answer.json 에 {\"paragraphs\": N} 으로 제출하라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "form-02 문단 수",
+      "op": "answer_eq",
+      "answer": "paragraphs",
+      "cmd": [
+        "explain",
+        "{input}",
+        "--json"
+      ],
+      "path": "paragraphCount"
+    }
+  ]
+}

--- a/gym/profiles/maintainer.json
+++ b/gym/profiles/maintainer.json
@@ -14,6 +14,7 @@
     "extraction",
     "layout-rendering",
     "objects-media",
+    "oracle-probe",
     "render-tree",
     "security",
     "self-description",

--- a/gym/tools/README.md
+++ b/gym/tools/README.md
@@ -1,0 +1,957 @@
+---
+kind: guide
+status: active
+canonical: gym/tools/README.md
+last_verified: 2026-08-18
+---
+
+# gym/tools — 라이브 오라클 프로브
+
+이 문서는 `gym/tools/oracle_probe.py` 의 정본 설명이다. 새 CLI 바이너리는
+없다. 프로브는 순수 Python 이고, gym 채점이 믿는 전제를 팩 픽스처 없이
+감사한다.
+
+관련 문서:
+
+- 모듈 자체: [`oracle_probe.py`](oracle_probe.py)
+- 단위 시험: [`../../scripts/tests/test_gym_oracle_probe.py`](../../scripts/tests/test_gym_oracle_probe.py)
+- 실문서 과제: [`../packs/oracle-probe/README.md`](../packs/oracle-probe/README.md)
+- 작업 노트: [`../../mydocs/working/gym_oracle_probe.md`](../../mydocs/working/gym_oracle_probe.md)
+- 채점 규약: [`../README.md`](../README.md)
+- 검사 연산자: [`../core/checks.py`](../core/checks.py)
+- 기준 풀이: [`build_baseline.py`](build_baseline.py)
+
+사용:
+
+```bash
+python gym/tools/oracle_probe.py --json
+python gym/tools/oracle_probe.py --selftest
+python gym/tools/oracle_probe.py --json --selftest
+python -m unittest scripts/tests/test_gym_oracle_probe.py
+```
+
+종료 코드는 보고서의 `ok` 를 따른다. `ok=true` 이면 0, 아니면 1.
+
+------------------------------------------------------------------------
+
+## 1. 목적 — 라이브 오라클 이중 계산 프로브
+
+gym 의 채점 규약은 한 문장이다.
+
+> 정답은 골든 파일로 박제돼 있지 않다. `score.py` 가 채점 시점에
+> rhwp 로 기대값을 재계산한다.
+
+그 규약이 성립하려면 세 가지가 참이어야 한다.
+
+1. **결정성.** 같은 오라클을 두 번 돌려도 정규화 결과가 같다.
+2. **자리표.** `{input}` 과 한 문자열의 여러 `{sub:이름}` 이 기준 풀이
+   (`build_baseline.resolve`) 와 같이 치환된다. 남은 `{sub:` 는 실패다.
+3. **부재 보고.** 산출물 경로가 파일이 아니면 `ok=false` 이다. 부재를
+   통과로 위장하지 않는다.
+
+`oracle_probe.py` 는 이 세 가지를 **독립 도구** 로 감사한다.
+`build_baseline.py` 를 import 하지 않는다. 경로 삽입·스트림 재설정·
+러너 적재 같은 부수효과가 구조 자기점검을 더럽히기 때문이다. 자리표
+규칙은 복제돼 있고, 테스트가 양쪽 출력을 대조한다.
+
+이 도구가 실패하면 gym 채점의 전제가 무너진 것이다. 개별 과제의
+점수가 아니라 **채점기 자체** 를 의심해야 한다.
+
+------------------------------------------------------------------------
+
+## 2. 비목적
+
+이 도구가 하지 않는 일.
+
+- rhwp 바이너리를 실행하지 않는다. `--json` / `--selftest` 는 팩·표본
+  없이 돈다.
+- 새 clap 명령, 새 `src/bin` 을 추가하지 않는다.
+- `answer_eq` 의 기대값을 계산하지 않는다. 그건 `score.py` 의 일이다.
+- 골든 숫자를 저장하지 않는다.
+- 네트워크를 쓰지 않는다.
+- 제출물을 채점하지 않는다. 채점은 `gym/score.py` 가 한다.
+
+프로브는 채점기의 **도구 상자** 이지 채점기 자체가 아니다.
+
+------------------------------------------------------------------------
+
+## 3. gym 채점이 라이브 오라클을 쓰는 방식
+
+과제의 `checks` 항목은 연산자와 명령을 고른다. 기대 숫자는 적지 않는다.
+
+```json
+{
+  "name": "쪽수 라이브 대조",
+  "op": "answer_eq",
+  "answer": "pages",
+  "cmd": ["info", "{input}", "--json"],
+  "path": "pageCount"
+}
+```
+
+채점 시각의 흐름은 이렇다.
+
+1. 에이전트가 `answer.json` 에 `{"pages": N}` 을 낸다.
+2. 채점기가 `rhwp info <입력> --json` 을 **지금** 실행한다.
+3. 봉투에서 `pageCount` 를 읽는다.
+4. `checks.norm` 으로 숫자 문자열과 숫자를 같게 보고 등호를 판정한다.
+
+`N` 이 어제 맞았다고 오늘도 맞는 것은 아니다. 바이너리가 바뀌면
+오라클이 바뀐다. 그것이 의도다. 픽스처가 진화하면 정답도 따라 진화한다.
+
+`len_answer_eq` 는 스칼라가 아니라 배열 길이를 잰다.
+
+```json
+{
+  "op": "len_answer_eq",
+  "answer": "fieldLen",
+  "cmd": ["fields", "{input}", "--json"],
+  "path": "fields"
+}
+```
+
+에이전트는 길이를 보고하고, 오라클은 배열을 다시 받아 `len()` 한다.
+`fieldCount` 스칼라와 `len(fields)` 가 어긋나면 명령 봉투가 깨진 것이다.
+
+`value_eq` 는 제출 키가 아니라 오라클 좌표를 상수와 비교한다. 편집
+과제에서 많이 쓰지만, 이 프로브 pack 은 읽기 전용 조회에 집중한다.
+
+기준 풀이(`reference/*.json`) 도 숫자를 박제하지 않는다. 같은 명령을
+다시 적어 `build_baseline.py` 가 제출물을 만든다. 이중 계산은 과제와
+기준 풀이와 채점기에 세 번 나타난다.
+
+------------------------------------------------------------------------
+
+## 4. 부재는 통과가 아니다
+
+산출물이 없으면 채점은 실패여야 한다. "파일이 없으니 비교할 것이 없다"
+를 통과로 읽으면, 아무 것도 제출하지 않은 에이전트가 만점을 받는다.
+
+`probe_missing_artifact` 의 존재 이유가 이것이다.
+
+| 경로 | status | ok | present |
+|------|--------|----|---------|
+| 일반 파일 | `present` | true | true |
+| 없는 경로 | `absent` | false | false |
+| 디렉터리 | `not-a-file` | false | false |
+| `""` / `None` / 비문자 | `invalid` | false | false |
+
+`ok=true` 는 `status=present` 일 때만 난다. 빈 파일(0바이트)은
+존재하는 파일이므로 통과다. "내용이 올바른가" 는 다른 검사의 몫이다.
+
+`probe_artifacts` 는 묶음이다. 하나라도 없으면 묶음은 실패다. 빈
+목록도 실패다 (`bool([])` 이 거짓). "검사할 산출물이 없다" 를
+통과로 위장하지 않는다.
+
+구조 자기점검은 존재하지 않는 경로를 일부러 넣어, `ok is True` 이면
+즉시 이슈를 남긴다.
+
+```text
+부재 산출물을 통과로 위장했다
+```
+
+이 문장이 보고서에 뜨면 프로브 자체가 거짓말이다.
+
+------------------------------------------------------------------------
+
+## 5. 봉투 계약
+
+`--json` 출력은 항상 객체다. 배열이 아니다.
+
+```json
+{
+  "kind": "gymOracleProbe",
+  "schemaVersion": "1.0",
+  "ok": true,
+  "mode": "structural"
+}
+```
+
+필수 키:
+
+- `kind` — 항상 `"gymOracleProbe"`. 다른 gym 도구 봉투와 섞이지 않는다.
+- `schemaVersion` — 지금 `"1.0"`. 필드가 깨지면 올린다.
+- `ok` — 전체 판정.
+- `mode` — `"structural"` 또는 `"selftest"`.
+
+`envelope(**fields)` 가 이 키를 먼저 넣고 호출자 필드를 덮어쓴다.
+호출자가 `kind=` 를 넘기면 덮인다. CLI 는 그렇게 부르지 않는다.
+
+구조 자기점검(`mode=structural`) 추가 키:
+
+- `exports` — 실제 호출 가능한 필수 함수 이름.
+- `required` — `REQUIRED_EXPORTS` 사본.
+- `issues` — 문자열 목록. 비어 있어야 `ok`.
+- `issueCount` — `len(issues)`.
+- `probes` — 결정성·자리표·부재의 요약.
+
+자기점검(`mode=selftest`) 추가 키:
+
+- `checks` — `{name, ok, detail?}` 목록.
+- `failed` — 실패한 검사 이름.
+- `checkCount` / `issueCount`.
+
+사람이 읽는 출력(`render_human`) 은 첫 줄에 통과/실패와 kind·schema 를
+쓰고, 모드에 따라 exports/probes/issues 또는 O/X 검사 목록을 붙인다.
+
+------------------------------------------------------------------------
+
+## 6. CLI
+
+```
+python gym/tools/oracle_probe.py [--json] [--selftest]
+```
+
+| 플래그 | 동작 |
+|--------|------|
+| (없음) | 구조 자기점검을 사람 문구로 낸다 |
+| `--json` | 같은 보고서를 JSON 봉투로 낸다 |
+| `--selftest` | 내장 프로브를 돌린다 |
+| 둘 다 | 자기점검을 JSON 으로 낸다 |
+
+`parse_args` 는 `argv` 를 받을 수 있다. `run(argv)` 는 종료 코드를
+반환하고 stdout 에 쓴다. `main()` 은 `sys.argv[1:]` 를 넘긴다.
+
+`__main__` 가드는 stdout/stderr 를 UTF-8 `errors=replace` 로
+재설정한다. Windows 콘솔에서 한글 보고서가 깨지지 않게 하기 위함이다.
+
+인자가 틀리면 argparse 가 사용법을 내고 2 로 죽는다. 그것은 프로브
+실패가 아니라 사용 오류다.
+
+------------------------------------------------------------------------
+
+## 7. 공개 표면
+
+`REQUIRED_EXPORTS` 는 구조 자기점검이 확인하는 최소 집합이다.
+
+```
+probe_determinism
+probe_placeholders
+probe_missing_artifact
+resolve_placeholders
+json_canonicalize
+```
+
+아래는 모듈이 실제로 내보내는 함수다. 각 항목은 행복 경로와 예외
+경로를 단위 시험이 건드린다.
+
+### 7.1 leftover_sub_names(text)
+
+치환 뒤에 남은 `{sub:이름}` 의 이름들을 왼쪽부터 모은다.
+
+- 문자열이 아니거나 `{sub:` 가 없으면 `[]`.
+- 닫는 `}` 가 없으면 나머지 전체를 한 이름으로 넣는다.
+- 중복 이름을 제거하지 않는다. 순서와 횟수가 남는다.
+
+### 7.2 extract_sub_names(token)
+
+`leftover_sub_names` 의 별칭이다. 치환 전 인벤토리로 쓴다.
+
+### 7.3 is_exact_sub_token(token)
+
+토큰 전체가 `{sub:이름}` 인지 본다.
+
+참이려면:
+
+- 문자열이고
+- `{sub:` 로 시작하고
+- `}` 로 끝나며
+- `{` 가 정확히 한 번.
+
+임베디드·연속 두 개·`{input}` 은 거짓이다.
+
+### 7.4 resolve_placeholders(token, task, sub_dir, mkdir=True)
+
+`build_baseline.resolve` 와 같은 규칙.
+
+1. 토큰이 `{input}` 이면 `task["input"]`. 키가 없으면 `KeyError`.
+2. 토큰이 정확한 `{sub:이름}` 이면 `join(sub_dir, 이름)`.
+   `mkdir` 이면 `dirname` 만 만든다 (기준 풀이와 동일).
+3. 문자열 안의 여러 `{sub:이름}` 은 **전부** 바꾼다. 경로의 `\` 는
+   JSON 에 박힐 수 있으므로 `\\` 로 이스케이프한다 (#4664).
+4. 박힌 `{input}` 은 바꾸지 않는다.
+5. 그 외는 토큰 그대로.
+
+`mkdir=False` 는 부모 폴더를 만들지 않는다. 프로브가 파일 시스템에
+손대지 않고 치환만 보고 싶을 때 쓴다.
+
+닫히지 않은 `{sub:` 는 `str.split("}", 1)` 이 `ValueError` 를 낸다.
+`probe_placeholders` 가 잡아 실패 보고로 바꾼다.
+
+### 7.5 resolve_cmd(cmd, task, sub_dir, mkdir=True)
+
+argv 각 토큰을 치환한다. `cmd` 가 list/tuple 이 아니면 `TypeError`.
+
+### 7.6 probe_placeholders(token, task, sub_dir)
+
+한 토큰의 `{sub:}` 가 모두 사라졌는지 본다.
+
+반환:
+
+```
+ok, token, resolved, leftover, names, inputExact?
+error?
+```
+
+비문자열은 `ok=false` 이고 `error` 에 타입 이름을 남긴다.
+`KeyError` / `OSError` / `TypeError` / `ValueError` 도 `ok=false`.
+`task is None` 이면 `{}` 로 치환을 시도하므로 `{input}` 은 KeyError.
+
+`ok` 는 `leftover == []` 이다. 치환이 예외 없이 끝났고 남은
+자리표가 없어야 통과다.
+
+### 7.7 probe_cmd_placeholders(cmd, task, sub_dir)
+
+argv 전 토큰을 본다. 하나라도 실패하면 묶음 실패.
+`cmd` 를 `list()` 할 수 없으면 `ok=false`, `tokens=[]`.
+
+반환: `ok`, `tokens`, `count` (순회 성공 시).
+
+### 7.8 norm_scalar(value)
+
+`checks.norm` 과 같은 스칼라 정규화. bool 을 먼저 본다
+(`bool` 은 `int` 의 하위형).
+
+| 입력 | 출력 |
+|------|------|
+| `True` / `False` | 그대로 |
+| `int` | `float` |
+| `float` 유한 | 그대로 |
+| `float` NaN/inf | `None` |
+| 숫자 문자열 | `float` |
+| `"NaN"` / `"inf"` 문자열 | 문자열 그대로 (float 로 읽히지만 비유한) |
+| 그 외 문자열 | `strip()` |
+| 그 외 | 그대로 |
+
+### 7.9 json_ready(value)
+
+비교 가능한 JSON 값으로 접는다.
+
+- `None` / `bool` 은 그대로.
+- `int` / `float` / `str` 은 `norm_scalar`.
+- `dict` 는 키를 `str` 로 바꾸고 값을 재귀.
+- `list` / `tuple` 은 리스트로 재귀.
+- `set` 은 정규화 후 `json.dumps(..., sort_keys=True)` 키로 정렬.
+- `bytes` 는 UTF-8 디코드, 실패하면 hex.
+- 그 외는 `str(value)`.
+
+### 7.10 json_canonicalize(value)
+
+키 정렬·공백 없는 JSON 문자열. `allow_nan=False`.
+이중 계산 등호의 **단일 출처**.
+
+NaN/inf 는 `json_ready` 가 `None` 으로 접으므로 `"null"` 이 된다.
+`True` 는 `"true"`, `1` 은 `"1.0"`. Python 에서 `True == 1.0` 이지만
+정규화 문자열은 갈라진다.
+
+### 7.11 snapshot(value)
+
+`json.loads(json_canonicalize(value))`.
+다음 호출이 원본을 변이시켜도 비교 값이 바뀌지 않는다.
+
+### 7.12 probe_determinism(compute_fn)
+
+`compute_fn` 을 두 번 호출하고 정규화 결과가 같은지 본다.
+
+한 쪽이라도 예외이거나 직렬화에 실패하면 `ok=false`.
+같은 예외를 두 번 내도 '결정적 성공'으로 위장하지 않는다.
+오라클은 값을 내야 한다.
+
+호출 가능하지 않으면 `error` 에 타입 이름을 남긴다.
+
+성공 시 `canonicalFirst` / `canonicalSecond` 를 남긴다.
+실패 시 `error` 와 `errors` 목록을 남긴다.
+
+### 7.13 probe_determinism_n(compute_fn, n=2)
+
+이중 계산의 일반화. `n` 은 2 이상 정수. `True` 는 `int` 하위형이고
+값 1 이라 거부된다. 문자열 `"2"` 도 거부된다.
+
+오류가 하나라도 있으면 `ok=false`, 첫 오류를 `error` 에 남긴다.
+모두 성공하면 첫 스냅샷과 나머지가 같아야 한다.
+
+### 7.14 classify_artifact(path)
+
+`present` / `absent` / `not-a-file` / `invalid`.
+`os.PathLike` 은 허용. `OSError` 는 `absent`.
+
+### 7.15 probe_missing_artifact(path)
+
+분류 후 보고서를 만든다. `present` 이면 크기를 읽고 `ok=true`.
+크기 확인이 `OSError` 이면 status 를 `absent` 로 내린다.
+
+### 7.16 probe_artifacts(paths)
+
+여러 경로. `ok` 는 "하나 이상 있고 모두 present".
+
+### 7.17 probe_live_oracle(compute_fn, token=None, task=None, sub_dir=None, artifacts=None)
+
+한 건의 라이브 오라클: 결정성 + 선택 자리표 + 선택 산출물.
+`ok` 는 켜진 축의 논리곱.
+
+### 7.18 envelope(**fields)
+
+`kind` / `schemaVersion` 을 심고 필드를 합친다.
+
+### 7.19 structural_self_check()
+
+팩·표본·바이너리 없이 모듈 표면과 핵심 경로를 확인한다.
+
+- 필수 함수가 호출 가능한가.
+- 안정 계산의 결정성이 통과하는가.
+- 다중 `{sub:}` 가 남는가.
+- 부재 산출물이 `ok=true` 로 위장되는가.
+
+### 7.20 run_selftest()
+
+통과해야 할 것과 실패해야 할 것을 모두 확인한다.
+
+내장 검사 이름:
+
+- `determinism-stable`
+- `determinism-drift-detected`
+- `determinism-exception-is-not-pass`
+- `determinism-numeric-norm`
+- `placeholders-multi-sub`
+- `placeholders-exact-input`
+- `placeholders-unclosed-is-not-pass`
+- `artifact-present`
+- `artifact-absent-is-not-pass`
+- `artifact-directory-is-not-pass`
+- `artifact-empty-path-is-not-pass`
+- `artifact-none-is-not-pass`
+- `determinism-n-stable`
+- `determinism-n-rejects-one`
+
+새 불변식을 넣으면 여기와 단위 시험에 같은 이름을 남겨라.
+
+### 7.21 render_human / parse_args / run / main
+
+출력과 프로세스 진입점. `run` 은 코드를 반환하고 `sys.exit` 하지
+않는다. 테스트가 stdout 을 가로채기 쉽게 하기 위함이다.
+
+------------------------------------------------------------------------
+
+## 8. 불변식
+
+프로브가 지키는 것. 깨지면 버그다.
+
+**I1. 다중 `{sub:}` 는 전부 치환된다.**
+한 문자열의 첫 자리표만 바꾸면 나머지가 리터럴 파일명이 된다.
+다세대 계획서의 `input` / `output` 이 동시에 `{sub:}` 인 이유가
+이것이다 (#4664).
+
+**I2. 박힌 `{input}` 은 바꾸지 않는다.**
+기준 풀이 조립기도 그렇게 한다. 토큰 전체가 `{input}` 일 때만
+`task["input"]` 이다.
+
+**I3. 이중 계산이 어긋나면 실패다.**
+키 순서와 `"2"` / `2` 는 같게 본다. 값이 실제로 바뀌면 실패다.
+
+**I4. 예외는 통과가 아니다.**
+같은 `RuntimeError` 를 두 번 내도 결정적 성공이 아니다.
+오라클은 JSON 값을 내야 한다.
+
+**I5. 부재는 통과가 아니다.**
+`status=absent|not-a-file|invalid` 는 모두 `ok=false`.
+
+**I6. `--json` 은 픽스처 없이 봉투를 낸다.**
+`kind=gymOracleProbe`, `schemaVersion=1.0`.
+구조 자기점검의 부재 프로브 자체는 `ok=false` 여야 한다.
+
+**I7. 정규화 등호의 출처는 하나다.**
+`json_canonicalize` 만이 이중 계산 비교 문자열을 만든다.
+다른 함수가 `json.dumps` 를 직접 쓰지 않는다 (CLI 출력 제외).
+
+**I8. bool 은 int 보다 먼저 본다.**
+`True` 를 `1.0` 으로 접지 않는다. 정규화 문자열은 `"true"`.
+
+**I9. 집합은 정렬한다.**
+해시 순서가 결정성을 깨지 못하게 `json_ready` 가 정렬한다.
+
+**I10. 스냅샷은 원본 변이에 닫혀 있다.**
+`snapshot` 이후 원본 리스트에 append 해도 비교 값이 바뀌지 않는다.
+
+**I11. 빌드 베이스라인과 치환이 같다.**
+단위 시험이 `{input}`, 다중 `{sub:}`, 정확한 `{sub:capsules/…}`,
+리터럴, 박힌 `{input}` 다섯 토큰을 양쪽에서 대조한다.
+
+**I12. n < 2 는 사용 오류다.**
+한 번만 돌리고 결정적이라고 주장하지 못한다.
+
+------------------------------------------------------------------------
+
+## 9. 실패 모드
+
+프로브가 실패로 보고하는 상황과, 그것이 의미하는 것.
+
+### 9.1 결정성 드리프트
+
+`compute_fn` 이 호출마다 다른 값을 낸다. 시계, 난수, 전역 카운터,
+파일 시스템 경합이 원인이다. gym 오라클은 이런 함수를 쓰면 안 된다.
+
+보고: `ok=false`, `equal=false`, `first` ≠ `second`.
+
+### 9.2 오라클 예외
+
+타임아웃, 깨진 JSON, 없는 키, 0 나누기. 두 번 같은 예외여도 실패.
+보고: `error` 에 `TypeName: message`, `errors` 에 각 실행.
+
+### 9.3 직렬화 실패
+
+`json_canonicalize` 가 `TypeError` / `ValueError` 를 내면
+`JSON 정규화 실패:` 접두로 남는다. `json_ready` 가 대부분을
+문자열로 접어 이 경로는 드물다. NaN 은 `None` 으로 접힌다.
+
+### 9.4 호출 불가능
+
+`compute_fn` 이 함수가 아니다. `ok=false`.
+
+### 9.5 자리표 잔존
+
+닫히지 않은 `{sub:`, 치환 실패, 비문자열 토큰.
+리터럴 파일명 사고의 전조다.
+
+### 9.6 입력 키 부재
+
+`{input}` 인데 `task` 에 `"input"` 이 없다. `KeyError`.
+과제 JSON 이 깨졌거나 프로브 호출자가 빈 딕셔너리를 넘긴 것이다.
+
+### 9.7 산출물 부재 / 디렉터리 / 무효 경로
+
+제출 폴더에 파일이 없거나, 파일 대신 디렉터리를 가리키거나,
+경로가 비었다. 모두 실패. "비교할 대상이 없다" 는 통과가 아니다.
+
+### 9.8 묶음 실패
+
+`probe_live_oracle` 은 켜진 축의 논리곱이다. 결정성이 통과해도
+산출물이 없으면 묶음은 실패다. 반대도 같다.
+
+### 9.9 구조 자기점검 이슈
+
+필수 함수 없음, 안정 계산 실패, 다중 `{sub:}` 잔존, 부재 위장.
+이 네 가지는 `--json` 기본 모드가 막는다.
+
+### 9.10 사용 오류
+
+`probe_determinism_n(..., 1)`, 비순회 `cmd`, argparse 오용.
+프로브 버그가 아니라 호출자 버그로 보고한다.
+
+------------------------------------------------------------------------
+
+## 10. 프로브 분류 행렬
+
+단위 시험 `ProbeClassificationMatrixTests` 가 이 표를 강제한다.
+
+### 10.1 산출물
+
+| 입력 | status | ok | present | error |
+|------|--------|----|---------|-------|
+| 존재하는 파일 | present | T | T | 없음 |
+| 0바이트 파일 | present | T | T | 없음 |
+| 없는 경로 | absent | F | F | 없음 |
+| 디렉터리 | not-a-file | F | F | 있음 |
+| `""` | invalid | F | F | 있음 |
+| `None` | invalid | F | F | 있음 |
+| `1` / `[]` | invalid | F | F | 있음 |
+| PathLike 파일 | present | T | T | 없음 |
+
+### 10.2 결정성
+
+| 입력 | ok | equal | error |
+|------|----|-------|-------|
+| 안정 함수 | T | T | 없음 |
+| 드리프트 | F | F | 없음 |
+| 예외 | F | F | 있음 |
+| 비호출 | F | F | 있음 |
+| `None` fn | F | F | 있음 |
+| `{}` / `[]` / `None` 값 | T | T | 없음 |
+
+성공 보고에는 `error` 키가 없다. 실패 보고에는 `equal=false`.
+
+### 10.3 자리표
+
+| token | ok | inputExact |
+|-------|----|------------|
+| `{input}` | T | T |
+| `plain` | T | F |
+| `{sub:a.hwp}` | T | F |
+| `{sub:` | F | F |
+| `None` / `1` | F | F |
+| `""` | T | F |
+
+### 10.4 n-회 결정성
+
+| n | 결과 |
+|---|------|
+| 2 이상 안정 | ok |
+| 2 이상 드리프트 | 실패 |
+| 0, 1, -1, 1.5, `"2"`, `None`, `True` | 사용 오류 |
+
+------------------------------------------------------------------------
+
+## 11. JSON 정규화가 등호를 여는 이유
+
+라이브 오라클은 JSON 봉투를 낸다. 같은 논리 값이 다른 바이트로
+올 수 있다.
+
+- 키 순서: `{"b":1,"a":2}` 와 `{"a":2,"b":1}`.
+- 숫자 문자열: `"2"` 와 `2`.
+- 공백: pretty-print 와 compact.
+- 집합: 해시 순서.
+
+`json_canonicalize` 는 이 네 가지를 접는다. 접지 말아야 할 것은
+접지 않는다.
+
+- `True` 와 `1` 은 다른 값이다.
+- `"hangul"` 과 `" hangul "` 은 strip 후 같다.
+- `"NaN"` 문자열은 문자 그대로 남는다. float NaN 은 `null`.
+- 한글은 `\uXXXX` 로 이스케이프하지 않는다 (`ensure_ascii=False`).
+
+큰 페이로드(수백 키, 중첩 리스트)도 두 번 돌려 같아야 한다.
+정규화가 비결정이면 큰 봉투에서 먼저 드러난다.
+
+------------------------------------------------------------------------
+
+## 12. 자리표와 기준 풀이
+
+`build_baseline.resolve` 의 규칙을 이 파일에 복제한 이유.
+
+1. `build_baseline` 을 import 하면 `gym.core.runner` 가 로드되고
+   스트림을 재설정하며 경로를 삽입한다.
+2. `--json` 구조 자기점검은 그 부수효과 없이 돌아야 한다.
+3. 규칙이 갈라지면 테스트가 red 가 된다.
+
+복제된 규칙의 함정:
+
+- 정확한 `{sub:a/b.hwp}` 는 `dirname` 만 mkdir. 파일 자체는 안 만든다.
+- 임베디드 `{sub:}` 는 `_maybe_mkdir(path, fallback=sub_dir)`.
+  `dirname` 이 비면 `sub_dir` 을 만든다.
+- Windows 경로의 `\` 는 임베디드 치환에서만 `\\` 로 이스케이프.
+  정확한 토큰 분기는 이스케이프하지 않는다 (기준 풀이와 동일).
+
+프로브가 기준 풀이보다 "똑똑해지면" 안 된다. 같아야 한다.
+
+------------------------------------------------------------------------
+
+## 13. oracle-probe pack 과의 관계
+
+`gym/packs/oracle-probe/` 는 프로브가 감사하는 전제를 **실문서
+과제** 로 드러낸다.
+
+- 에이전트는 쪽수·검색 건수·필드 수를 보고한다.
+- 채점기는 같은 rhwp 명령을 다시 실행한다.
+- 숫자는 어디에도 박제돼 있지 않다.
+
+프로브 도구는 그 pack 을 채점하지 않는다. pack 은 rhwp 가 필요하고,
+프로브는 바이너리 없이 CI 에서 돈다.
+
+```
+CI
+ ├─ python -m unittest scripts/tests/test_gym_oracle_probe.py
+ ├─ python gym/tools/audit.py          # pack 스키마·짝 기준풀이
+ └─ python gym/tools/oracle_probe.py --json --selftest
+```
+
+라이브 채점(`score.py --pack oracle-probe`)은 바이너리가 있는
+작업자가 돌린다. CI 의 gym 단계는 순수 파일이고, 그것이 이 저장소의
+결이다.
+
+------------------------------------------------------------------------
+
+## 14. 작업된 예
+
+### 14.1 안정 오라클
+
+```python
+probe_determinism(lambda: {"pageCount": 2, "kind": "info"})
+# ok=true, equal=true, runs=2
+```
+
+### 14.2 드리프트
+
+```python
+i = {"n": 0}
+def drift():
+    i["n"] += 1
+    return {"n": i["n"]}
+probe_determinism(drift)
+# ok=false, first={"n": 1.0}, second={"n": 2.0}
+```
+
+### 14.3 키 순서와 숫자 문자열
+
+```python
+seq = [{"b": 1, "a": "2"}, {"a": 2, "b": "1"}]
+probe_determinism(lambda: seq.pop(0))
+# ok=true — 정규화가 둘을 같게 본다
+```
+
+### 14.4 다중 자리표
+
+```python
+token = '{"input": "{sub:o1.hwp}", "output": "{sub:o2.hwp}"}'
+probe_placeholders(token, {"input": "in.hwp"}, sub_dir)
+# leftover=[], names=["o1.hwp", "o2.hwp"]
+```
+
+### 14.5 부재
+
+```python
+probe_missing_artifact("/no/such/oracle-output.svg")
+# ok=false, status="absent", present=false
+```
+
+### 14.6 묶음
+
+```python
+probe_live_oracle(
+    lambda: {"pageCount": 2},
+    token="{input}",
+    task={"input": "in.hwp"},
+    artifacts=["/tmp/answer.json"],
+)
+# artifacts 가 없으면 ok=false — 결정성이 좋아도 부재는 통과가 아니다
+```
+
+------------------------------------------------------------------------
+
+## 15. 위협 모델 (요약)
+
+자세한 내용은 `mydocs/working/gym_oracle_probe.md` 에 있다.
+
+골든 파일이 썩는 방식:
+
+1. 누군가 `pageCount: 17` 을 과제에 적는다.
+2. 페이지네이션이 고쳐져 실제 쪽수가 18 이 된다.
+3. 정직한 에이전트는 18 을 보고하고 실패한다.
+4. 숫자를 외운 에이전트는 17 을 내고 통과한다.
+
+라이브 오라클은 3 과 4 를 뒤집는다. 정직한 쪽이 통과한다.
+
+프로브가 막는 두 번째 위협: 오라클 함수가 비결정이거나, 자리표가
+남거나, 없는 산출물을 통과로 세는 것. 이 셋이 있으면 라이브 채점도
+거짓이다.
+
+프로브가 막지 않는 것:
+
+- rhwp 바이너리 자체의 회귀. 그건 라이브 채점과 회귀 시험의 몫.
+- 에이전트가 기준 풀이 폴더를 읽는 것. 규칙으로 막을 뿐 기술로
+  막지 않는다. 채점은 정직하게 돌아간다.
+- 명령 봉투 스키마 변경. `path: pageCount` 가 사라지면 과제가
+  깨진다. 그건 pack 감사와 기준 풀이 왕복의 몫.
+
+------------------------------------------------------------------------
+
+## 16. 테스트 지도
+
+`scripts/tests/test_gym_oracle_probe.py` 는 바이너리 없이 모듈을
+로드한다. `importlib` 로 파일 경로에서 읽으므로 `gym.tools` 패키지
+설치가 필요 없다.
+
+클래스:
+
+- `PlaceholderTests` — 다중 `{sub:}`, 베이스라인 대조, 타입 오류,
+  키 부재, 미닫힘, 중복 이름, 백슬래시 이스케이프, argv.
+- `DeterminismTests` — 안정, 드리프트, 예외, 타임아웃 봉투,
+  비호출, n-회, 빈 객체.
+- `NormalizeTests` — bool/int/NaN/inf, 집합 정렬, bytes, 유니코드,
+  큰 페이로드, 스냅샷 격리.
+- `MissingArtifactTests` — 분류 행렬, 묶음, 0바이트, PathLike.
+- `LiveOracleBundleTests` — 축 논리곱.
+- `EnvelopeAndCliTests` — `--json` / `--selftest` / 사람 문구 /
+  `run` / `main`.
+- `ProbeClassificationMatrixTests` — 닫힌 status 집합, 자리표 표.
+- `PublicSurfaceSmokeTests` — 공개 함수가 모두 호출 가능.
+- `UnicodeAndPayloadExceptionTests` — 한글 자리표, 깊은 중첩.
+- `ErrorEnvelopeContractTests` — 실패 보고의 키 집합.
+- `NumericEdgeTests` — bool≠1 정규화 문자열, 큰 정수.
+
+새 공개 함수를 추가하면 `PublicSurfaceSmokeTests.PUBLIC` 과
+해당 행복·예외 시험을 같이 넣어라.
+
+------------------------------------------------------------------------
+
+## 17. 다른 gym/tools 와의 자리
+
+| 도구 | 하는 일 | 프로브와의 관계 |
+|------|---------|-----------------|
+| `audit.py` | pack 스키마·짝 기준풀이·ID 고유 | pack 등재 관문. 프로브 불변식은 안 봄 |
+| `build_baseline.py` | 기준 풀이 실행 → 제출물 | 자리표 규칙의 원본. 프로브가 복제 |
+| `score.py` (상위) | 라이브 채점 | 프로브가 전제를 감사 |
+| `coverage.py` | pack 커버리지 | 무관 |
+| `release_diff.py` | 릴리스 차이 | 무관 |
+| `oracle_probe.py` | 이중 계산·자리표·부재 | 이 문서의 대상 |
+
+`gym/tools/` 아래 다른 스크립트의 사용법은 각 파일의 모듈 문자열에
+있다. 이 README 는 오라클 프로브의 정본이다.
+
+------------------------------------------------------------------------
+
+## 18. 자주 하는 실수
+
+1. **골든 숫자를 과제에 적는다.** `value_eq` 의 `value: 17` 은
+   "17쪽이어야 한다" 가 아니라 "이 좌표의 값이 17 이어야 한다" 이다.
+   쪽수 자체는 `answer_eq` + 라이브 `info` 로 물어라.
+2. **첫 `{sub:}` 만 바꾼다.** #4664 회귀. 프로브와 베이스라인 대조가
+   막는다.
+3. **예외를 결정적 성공으로 센다.** 두 번 같은 traceback 은 값이
+   아니다.
+4. **디렉터리를 산출물로 낸다.** `status=not-a-file`.
+5. **빈 산출물 목록을 통과로 본다.** `probe_artifacts([])` 는 실패.
+6. **`build_baseline` 을 프로브에서 import 한다.** 하지 마라.
+7. **`--json` 이 배열을 낸다고 가정한다.** 객체다. `kind` 로 가른다.
+8. **한글 자리표가 깨질 거라고 가정한다.** 이름은 그대로 경로에
+   들어간다. 단위 시험이 확인한다.
+9. **`True` 와 `1` 을 같다고 본다.** 정규화 문자열은 다르다.
+10. **n=1 로 결정성을 주장한다.** 사용 오류.
+
+------------------------------------------------------------------------
+
+## 19. 변경을 넣을 때
+
+1. 공개 함수의 행복·예외 경로를 단위 시험에 추가한다.
+2. 불변식이면 `run_selftest` 에 이름을 붙인다.
+3. `REQUIRED_EXPORTS` 를 건드리면 구조 자기점검이 따라간다.
+4. 자리표 규칙을 바꾸면 `build_baseline.resolve` 와 같은 커밋에서
+   맞춘다. 테스트가 양쪽을 대조한다.
+5. pack 과제를 늘리면 `reference/` 짝과 `audit.py` 를 통과시킨다.
+6. `cargo fmt --all` 을 돌리지 않는다. 이 변경은 Python 이다.
+7. 새 CLI 바이너리를 추가하지 않는다.
+
+------------------------------------------------------------------------
+
+## 20. 버전
+
+- `kind`: `gymOracleProbe`
+- `schemaVersion`: `1.0`
+- 도입: #5207 / PR #5214
+- 도구 경로: `gym/tools/oracle_probe.py`
+- 시험 경로: `scripts/tests/test_gym_oracle_probe.py`
+- pack: `gym/packs/oracle-probe` (OP01–OP44)
+
+스키마를 깨는 변경은 `schemaVersion` 을 올리고, 이 README 의
+봉투 절을 같이 고친다. 필드 추가는 1.0 안에서 허용하되 필수 키를
+빼지 않는다.
+
+------------------------------------------------------------------------
+
+## 21. 명령 치트시트
+
+```bash
+# 구조 자기점검 (CI 가 믿는 최소)
+python gym/tools/oracle_probe.py --json
+
+# 내장 프로브 (통과해야 할 것 + 실패해야 할 것)
+python gym/tools/oracle_probe.py --json --selftest
+
+# 사람 문구
+python gym/tools/oracle_probe.py
+python gym/tools/oracle_probe.py --selftest
+
+# 단위 시험
+python -m unittest scripts.tests.test_gym_oracle_probe
+
+# pack 정합
+python gym/tools/audit.py
+python gym/tools/audit.py --json
+
+# 기준 풀이 왕복 (바이너리 필요)
+python gym/tools/build_baseline.py --agent oracle-probe-ref --pack oracle-probe
+
+# 라이브 채점 (바이너리 필요)
+python gym/score.py --agent oracle-probe-ref --pack oracle-probe
+```
+
+`--json` 의 `probes.missingArtifact.ok` 는 **false** 여야 한다.
+그것이 부재 비통과 계약의 살아 있는 증거다.
+
+------------------------------------------------------------------------
+
+## 22. 모듈 상수
+
+```
+KIND            = "gymOracleProbe"
+SCHEMA_VERSION  = "1.0"
+INPUT_TOKEN     = "{input}"
+SUB_MARK        = "{sub:"
+REQUIRED_EXPORTS = (
+    "probe_determinism",
+    "probe_placeholders",
+    "probe_missing_artifact",
+    "resolve_placeholders",
+    "json_canonicalize",
+)
+```
+
+`SUB_MARK` 는 닫는 중괄호를 포함하지 않는다. 이름에 `}` 가 없다고
+가정한다. 이름에 `}` 가 있으면 첫 `}` 에서 잘린다. 기준 풀이와
+같은 한계이고, 과제 작성자가 `{sub:weird}name}` 을 쓰지 않으면
+문제 없다.
+
+------------------------------------------------------------------------
+
+## 23. 오류 문자열 (안정 관측점)
+
+테스트가 의존하는 메시지 조각. 바꾸면 시험을 같이 고친다.
+
+- `자리표는 문자열이어야 한다:`
+- `cmd 는 인자 목록이어야 한다:`
+- `cmd 순회 실패:`
+- `compute_fn 이 호출 가능하지 않다:`
+- `JSON 정규화 실패:`
+- `n 은 2 이상이어야 한다:`
+- `경로가 비어 있거나 문자열이 아니다`
+- `디렉터리이지 산출 파일이 아니다`
+- `크기 확인 실패:`
+- `필수 함수 없음:`
+- `안정 계산의 결정성 프로브가 실패했다`
+- `부재 산출물을 통과로 위장했다`
+
+예외는 `TypeName: message` 형식으로 접는다.
+`KeyError: 'input'` 처럼 표준 표현을 유지한다.
+
+------------------------------------------------------------------------
+
+## 24. 파일 배치
+
+```
+gym/
+  README.md                 # 운동장 규약 — 채점은 라이브다
+  score.py                  # 라이브 채점기
+  core/checks.py            # answer_eq / norm
+  core/schema.py            # pack·task 검증
+  tools/
+    README.md               # 이 문서
+    oracle_probe.py         # 프로브
+    build_baseline.py       # 기준 풀이 (자리표 원본)
+    audit.py                # pack 정합
+  packs/oracle-probe/
+    pack.json
+    README.md
+    tasks/OP01.json … OP44.json
+    reference/OP01.json … OP44.json
+scripts/tests/test_gym_oracle_probe.py
+mydocs/working/gym_oracle_probe.md
+```
+
+------------------------------------------------------------------------
+
+## 25. 라이선스·기여
+
+이 파일은 rhwp 저장소의 일부다. 기여 절차는 저장소 루트의
+기여자 안내를 따른다. 이 프로브만의 추가 규칙은 §19 다.
+
+질문을 이슈로 남길 때 제목에 `oracle_probe` 와 `#5207` 을 넣어라.
+재현은 `--json` 원문과 단위 시험 이름을 붙이면 충분하다.
+
+------------------------------------------------------------------------
+
+## 26. 한 줄 요약
+
+채점은 정답을 박제하지 않고 지금 rhwp 로 다시 계산한다.
+그 계산이 두 번 같고, 자리표가 남기지 않고, 없는 파일을 통과로
+세지 않는지 — 이 도구가 그걸 감사한다.
+
+부재는 실패다. 예외는 실패다. 드리프트는 실패다.
+통과는 값이 나왔고, 두 번 같았고, 파일이 있을 때만이다.

--- a/gym/tools/oracle_probe.py
+++ b/gym/tools/oracle_probe.py
@@ -1,0 +1,601 @@
+"""[#5207] 라이브 오라클 프로브 — 이중 계산 결정성·자리표·부재 보고.
+
+## 왜 이 도구인가
+
+채점 규약: 정답을 골든 파일로 박제하지 않고 **채점 시점에 rhwp 로 재계산**한다.
+그 오라클이 (1) 두 번 돌려도 같은 값인지, (2) `{input}` / 한 문자열의 여러
+`{sub:이름}` 이 기준 풀이(`build_baseline.resolve`)와 같이 결정적으로 치환되는지,
+(3) 산출물이 없으면 통과로 위장하지 않는지 — 를 독립 도구로 감사한다.
+
+새 CLI 바이너리는 없다. 이 스크립트는 순수 Python 프로브다. `--json` 은 팩·표본
+픽스처 없이 구조 자기점검을 내고, `--selftest` 는 내장 프로브를 돌린다.
+
+`build_baseline.py` 를 import 하지 않는다(경로 삽입·스트림 재설정·러너 적재 같은
+부수효과가 구조 자기점검을 더럽힌다). 자리표 치환은 그 함수와 같은 규칙으로
+이 파일에 복제했고, 테스트가 양쪽 출력을 대조한다.
+
+사용:
+  python gym/tools/oracle_probe.py --json       # 픽스처 없는 구조 자기점검
+  python gym/tools/oracle_probe.py --selftest   # 내장 프로브
+  python gym/tools/oracle_probe.py --json --selftest
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+
+KIND = "gymOracleProbe"
+SCHEMA_VERSION = "1.0"
+INPUT_TOKEN = "{input}"
+SUB_MARK = "{sub:"
+
+REQUIRED_EXPORTS = (
+    "probe_determinism",
+    "probe_placeholders",
+    "probe_missing_artifact",
+    "resolve_placeholders",
+    "json_canonicalize",
+)
+
+
+# ---------------------------------------------------------------------------
+# 자리표 — build_baseline.resolve 와 같은 규칙 (#4664 다중 {sub:} 포함)
+# ---------------------------------------------------------------------------
+
+
+def leftover_sub_names(text):
+    """치환 뒤에 남은 `{sub:이름}` 의 이름들. 비어 있어야 자리표 프로브가 통과한다."""
+    if not isinstance(text, str) or SUB_MARK not in text:
+        return []
+    found = []
+    rest = text
+    while SUB_MARK in rest:
+        _head, rest = rest.split(SUB_MARK, 1)
+        if "}" not in rest:
+            found.append(rest)
+            break
+        name, rest = rest.split("}", 1)
+        found.append(name)
+    return found
+
+
+def extract_sub_names(token):
+    """토큰에서 `{sub:이름}` 을 왼쪽부터 모은다 — 치환 전 인벤토리."""
+    return leftover_sub_names(token)
+
+
+def is_exact_sub_token(token):
+    return (
+        isinstance(token, str)
+        and token.startswith(SUB_MARK)
+        and token.endswith("}")
+        and token.count("{") == 1
+    )
+
+
+def _maybe_mkdir(path, fallback=None):
+    parent = os.path.dirname(path)
+    if fallback is not None:
+        parent = parent or fallback
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+
+
+def resolve_placeholders(token, task, sub_dir, mkdir=True):
+    """`build_baseline.resolve` 와 같은 치환.
+
+    - 토큰 전체가 `{input}` 이면 `task["input"]`.
+    - 토큰 전체가 `{sub:이름}` 이면 `join(sub_dir, 이름)` (중첩 폴더는 미리 만든다).
+    - 문자열 안의 여러 `{sub:이름}` 은 **전부** 바꾼다. 경로의 `\\` 는 JSON 에
+      박힐 수 있으므로 `\\\\` 로 이스케이프한다(#4664).
+    - 박힌 `{input}` 은 바꾸지 않는다 — 기준 풀이 조립기도 그렇게 한다.
+    """
+    if token == INPUT_TOKEN:
+        return task["input"]
+    if is_exact_sub_token(token):
+        path = os.path.join(sub_dir, token[len(SUB_MARK):-1])
+        if mkdir:
+            # 정확한 토큰 분기는 dirname 만 만든다(build_baseline 과 동일).
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+        return path
+    if isinstance(token, str) and SUB_MARK in token:
+        out = []
+        rest = token
+        while SUB_MARK in rest:
+            head, rest = rest.split(SUB_MARK, 1)
+            name, rest = rest.split("}", 1)
+            path = os.path.join(sub_dir, name)
+            if mkdir:
+                _maybe_mkdir(path, fallback=sub_dir)
+            out.append(head + path.replace("\\", "\\\\"))
+        out.append(rest)
+        return "".join(out)
+    return token
+
+
+def resolve_cmd(cmd, task, sub_dir, mkdir=True):
+    """라이브 오라클 argv 의 각 토큰을 치환한다 — `build_baseline.run_step` 과 같은 결."""
+    if not isinstance(cmd, (list, tuple)):
+        raise TypeError(f"cmd 는 인자 목록이어야 한다: {type(cmd).__name__}")
+    return [resolve_placeholders(a, task, sub_dir, mkdir=mkdir) for a in cmd]
+
+
+def probe_placeholders(token, task, sub_dir):
+    """한 토큰의 `{sub:}` 가 모두 사라졌는지 본다. 남으면 실패(리터럴 파일명 사고)."""
+    if not isinstance(token, str):
+        return {
+            "ok": False,
+            "token": token,
+            "resolved": None,
+            "leftover": [],
+            "names": [],
+            "error": f"자리표는 문자열이어야 한다: {type(token).__name__}",
+        }
+    names = extract_sub_names(token)
+    try:
+        resolved = resolve_placeholders(token, task if task is not None else {}, sub_dir)
+    except (OSError, KeyError, TypeError, ValueError) as exc:
+        return {
+            "ok": False,
+            "token": token,
+            "resolved": None,
+            "leftover": leftover_sub_names(token),
+            "names": names,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+    leftover = leftover_sub_names(resolved if isinstance(resolved, str) else "")
+    return {
+        "ok": leftover == [],
+        "token": token,
+        "resolved": resolved,
+        "leftover": leftover,
+        "names": names,
+        "inputExact": token == INPUT_TOKEN,
+    }
+
+
+def probe_cmd_placeholders(cmd, task, sub_dir):
+    """argv 전 토큰을 치환하고, 어느 한 자리에 `{sub:}` 가 남으면 실패한다."""
+    tokens = []
+    ok = True
+    try:
+        items = list(cmd)
+    except TypeError as exc:
+        return {"ok": False, "tokens": [], "error": f"cmd 순회 실패: {exc}"}
+    for item in items:
+        one = probe_placeholders(item, task, sub_dir)
+        tokens.append(one)
+        if not one.get("ok"):
+            ok = False
+    return {"ok": ok, "tokens": tokens, "count": len(tokens)}
+
+
+# ---------------------------------------------------------------------------
+# JSON 정규화 — 키 순서·숫자 문자열을 같게 보고 이중 계산을 비교한다
+# ---------------------------------------------------------------------------
+
+
+def norm_scalar(value):
+    """`checks.norm` 과 같은 스칼라 정규화. bool 을 먼저 본다(int 의 하위형)."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return float(value)
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            return None
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        try:
+            number = float(stripped)
+        except ValueError:
+            return stripped
+        if number != number or number in (float("inf"), float("-inf")):
+            return stripped
+        return number
+    return value
+
+
+def json_ready(value):
+    """비교 가능한 JSON 값으로 접는다. 집합은 정규화 후 정렬한다."""
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float, str)):
+        return norm_scalar(value)
+    if isinstance(value, dict):
+        return {str(key): json_ready(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [json_ready(item) for item in value]
+    if isinstance(value, set):
+        prepared = [json_ready(item) for item in value]
+        return sorted(
+            prepared,
+            key=lambda item: json.dumps(item, sort_keys=True, ensure_ascii=False, default=str),
+        )
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError:
+            return value.hex()
+    return str(value)
+
+
+def json_canonicalize(value):
+    """키 정렬·공백 없는 JSON 문자열. 이중 계산 등호의 단일 출처."""
+    return json.dumps(
+        json_ready(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def snapshot(value):
+    """정규화 스냅샷 — 다음 호출이 원본을 변이시켜도 비교 값이 바뀌지 않는다."""
+    return json.loads(json_canonicalize(value))
+
+
+# ---------------------------------------------------------------------------
+# 결정성 — 같은 compute 를 두 번(또는 N 번) 돌려 정규화 등호를 본다
+# ---------------------------------------------------------------------------
+
+
+def _run_once(compute_fn):
+    if not callable(compute_fn):
+        return False, None, f"compute_fn 이 호출 가능하지 않다: {type(compute_fn).__name__}"
+    try:
+        raw = compute_fn()
+    except Exception as exc:  # noqa: BLE001 — 오라클 예외도 데이터
+        return False, None, f"{type(exc).__name__}: {exc}"
+    try:
+        canon = json_canonicalize(raw)
+        return True, json.loads(canon), None
+    except (TypeError, ValueError) as exc:
+        return False, None, f"JSON 정규화 실패: {type(exc).__name__}: {exc}"
+
+
+def probe_determinism(compute_fn):
+    """`compute_fn` 을 두 번 호출하고 JSON 정규화 결과가 같은지 본다.
+
+    한쪽이라도 예외이거나 직렬화에 실패하면 `ok` 는 False 다. 같은 예외를
+    두 번 내도 '결정적 성공'으로 위장하지 않는다 — 오라클이 값을 내야 한다.
+    """
+    ok1, first, err1 = _run_once(compute_fn)
+    ok2, second, err2 = _run_once(compute_fn)
+    if not ok1 or not ok2:
+        return {
+            "ok": False,
+            "equal": False,
+            "runs": 2,
+            "first": first,
+            "second": second,
+            "error": err1 or err2,
+            "errors": [e for e in (err1, err2) if e],
+        }
+    equal = first == second
+    return {
+        "ok": equal,
+        "equal": equal,
+        "runs": 2,
+        "first": first,
+        "second": second,
+        "canonicalFirst": json_canonicalize(first),
+        "canonicalSecond": json_canonicalize(second),
+    }
+
+
+def probe_determinism_n(compute_fn, n=2):
+    """이중 계산의 일반화 — n 회 돌려 전부 같아야 한다. n < 2 는 사용 오류."""
+    if not isinstance(n, int) or n < 2:
+        return {"ok": False, "equal": False, "runs": n, "error": f"n 은 2 이상이어야 한다: {n!r}"}
+    snapshots = []
+    errors = []
+    for _ in range(n):
+        ok, value, err = _run_once(compute_fn)
+        snapshots.append(value)
+        if not ok:
+            errors.append(err)
+    if errors:
+        return {
+            "ok": False,
+            "equal": False,
+            "runs": n,
+            "values": snapshots,
+            "error": errors[0],
+            "errors": errors,
+        }
+    equal = all(item == snapshots[0] for item in snapshots[1:])
+    return {"ok": equal, "equal": equal, "runs": n, "values": snapshots}
+
+
+# ---------------------------------------------------------------------------
+# 부재 보고 — 파일이 없으면 절대 통과로 위장하지 않는다
+# ---------------------------------------------------------------------------
+
+
+def classify_artifact(path):
+    """경로를 present / absent / not-a-file / invalid 로 가른다."""
+    if path is None or path == "":
+        return "invalid"
+    if not isinstance(path, (str, os.PathLike)):
+        return "invalid"
+    try:
+        if os.path.isfile(path):
+            return "present"
+        if os.path.isdir(path):
+            return "not-a-file"
+        return "absent"
+    except OSError:
+        return "absent"
+
+
+def probe_missing_artifact(path):
+    """산출물 경로를 본다. 일반 파일이 아니면 `ok=False` 이고 status 를 남긴다.
+
+    부재를 통과로 위장하지 않는 것이 이 함수의 존재 이유다. 디렉터리·빈 경로·
+    잘못된 타입은 모두 실패이며, `status` 가 `absent` / `not-a-file` / `invalid`
+    로 이유를 밝힌다.
+    """
+    status = classify_artifact(path)
+    report = {
+        "ok": False,
+        "present": False,
+        "status": status,
+        "path": None if path is None else str(path),
+    }
+    if status == "invalid":
+        report["error"] = "경로가 비어 있거나 문자열이 아니다"
+        return report
+    if status == "present":
+        try:
+            size = os.path.getsize(path)
+        except OSError as exc:
+            report["status"] = "absent"
+            report["error"] = f"크기 확인 실패: {exc}"
+            return report
+        report["ok"] = True
+        report["present"] = True
+        report["size"] = size
+        return report
+    if status == "not-a-file":
+        report["error"] = "디렉터리이지 산출 파일이 아니다"
+        return report
+    return report
+
+
+def probe_artifacts(paths):
+    """여러 산출물을 같은 규칙으로 본다. 하나라도 없으면 묶음은 실패."""
+    items = [probe_missing_artifact(p) for p in list(paths)]
+    missing = [item["path"] for item in items if not item.get("ok")]
+    return {
+        "ok": bool(items) and not missing,
+        "items": items,
+        "missing": missing,
+        "count": len(items),
+    }
+
+
+# ---------------------------------------------------------------------------
+# 묶음 — 결정성 + 자리표 + 산출물을 한 오라클 프로브로
+# ---------------------------------------------------------------------------
+
+
+def probe_live_oracle(compute_fn, token=None, task=None, sub_dir=None, artifacts=None):
+    """라이브 오라클 한 건: 이중 계산, 선택적 자리표, 선택적 산출물 존재."""
+    det = probe_determinism(compute_fn)
+    ph = None
+    if token is not None:
+        ph = probe_placeholders(token, task or {}, sub_dir or "")
+    art = probe_artifacts(artifacts) if artifacts is not None else None
+    ok = bool(det.get("ok"))
+    if ph is not None:
+        ok = ok and bool(ph.get("ok"))
+    if art is not None:
+        ok = ok and bool(art.get("ok"))
+    return {
+        "ok": ok,
+        "determinism": det,
+        "placeholders": ph,
+        "artifacts": art,
+    }
+
+
+def envelope(**fields):
+    body = {"kind": KIND, "schemaVersion": SCHEMA_VERSION}
+    body.update(fields)
+    return body
+
+
+# ---------------------------------------------------------------------------
+# 자기점검 — 픽스처 없는 구조 검사 + 내장 프로브
+# ---------------------------------------------------------------------------
+
+
+def structural_self_check():
+    """팩·표본·바이너리 없이 모듈 표면과 핵심 경로를 확인한다."""
+    # importlib 로 다른 이름에 실리면 __name__ 이 sys.modules 에 없을 수 있다.
+    namespace = globals()
+    issues = []
+    exports = []
+    for name in REQUIRED_EXPORTS:
+        fn = namespace.get(name)
+        if fn is None or not callable(fn):
+            issues.append(f"필수 함수 없음: {name}")
+        else:
+            exports.append(name)
+
+    det = probe_determinism(lambda: {"pageCount": 2, "kind": "info"})
+    if not det.get("ok"):
+        issues.append("안정 계산의 결정성 프로브가 실패했다")
+
+    with tempfile.TemporaryDirectory() as sub_dir:
+        token = '{"input": "{sub:o1.hwp}", "output": "{sub:o2.hwp}"}'
+        ph = probe_placeholders(token, {"input": "in.hwp"}, sub_dir)
+        if not ph.get("ok") or ph.get("leftover"):
+            issues.append(f"다중 {{sub:}} 가 남았다: {ph.get('leftover')}")
+        if "{sub:" in str(ph.get("resolved", "")):
+            issues.append("치환 결과에 {sub: 리터럴이 남았다")
+
+    missing = probe_missing_artifact(
+        os.path.join(tempfile.gettempdir(), "rhwp-oracle-probe-absent-no-such-file.json")
+    )
+    if missing.get("ok") is True:
+        issues.append("부재 산출물을 통과로 위장했다")
+    if missing.get("status") != "absent":
+        issues.append(f"부재 status 가 absent 가 아니다: {missing.get('status')}")
+
+    return envelope(
+        ok=not issues,
+        mode="structural",
+        exports=exports,
+        required=list(REQUIRED_EXPORTS),
+        issues=issues,
+        issueCount=len(issues),
+        probes={
+            "determinism": {"ok": det.get("ok"), "equal": det.get("equal")},
+            "placeholders": {"ok": ph.get("ok"), "leftover": ph.get("leftover")},
+            "missingArtifact": {
+                "ok": missing.get("ok"),
+                "status": missing.get("status"),
+                "present": missing.get("present"),
+            },
+        },
+    )
+
+
+def run_selftest():
+    """내장 프로브 — 통과해야 할 것과 실패해야 할 것을 모두 확인한다."""
+    checks = []
+
+    def add(name, ok, detail=None):
+        item = {"name": name, "ok": bool(ok)}
+        if detail is not None:
+            item["detail"] = detail
+        checks.append(item)
+
+    stable = probe_determinism(lambda: {"n": 1, "label": "fixed"})
+    add("determinism-stable", stable.get("ok") is True, {"equal": stable.get("equal")})
+
+    counter = {"i": 0}
+
+    def drift():
+        counter["i"] += 1
+        return {"n": counter["i"]}
+
+    drifted = probe_determinism(drift)
+    add(
+        "determinism-drift-detected",
+        drifted.get("ok") is False and drifted.get("equal") is False,
+        {"first": drifted.get("first"), "second": drifted.get("second")},
+    )
+
+    broken = probe_determinism(lambda: (_ for _ in ()).throw(RuntimeError("오라클 붕괴")))
+    add("determinism-exception-is-not-pass", broken.get("ok") is False, {"error": broken.get("error")})
+
+    seq = [{"v": 1}, {"v": "1.0"}]
+    numeric = probe_determinism(lambda: seq.pop(0) if seq else {"v": 1})
+    add("determinism-numeric-norm", numeric.get("ok") is True)
+
+    with tempfile.TemporaryDirectory() as sub_dir:
+        token = '{"input": "{sub:capsules/a.hwp}", "output": "{sub:capsules/b.hwp}"}'
+        task = {"input": "samples/in.hwp"}
+        ph = probe_placeholders(token, task, sub_dir)
+        add(
+            "placeholders-multi-sub",
+            ph.get("ok") is True and not ph.get("leftover") and "{sub:" not in ph.get("resolved", ""),
+            {"resolved": ph.get("resolved"), "names": ph.get("names")},
+        )
+        exact = probe_placeholders("{input}", task, sub_dir)
+        add("placeholders-exact-input", exact.get("ok") is True and exact.get("resolved") == task["input"])
+        leftover = probe_placeholders("keep {sub:", task, sub_dir)
+        add("placeholders-unclosed-is-not-pass", leftover.get("ok") is False)
+
+        present_path = os.path.join(sub_dir, "answer.json")
+        with open(present_path, "w", encoding="utf-8", newline="\n") as fh:
+            fh.write("{}\n")
+        present = probe_missing_artifact(present_path)
+        add("artifact-present", present.get("ok") is True and present.get("status") == "present")
+
+        missing_path = os.path.join(sub_dir, "no-such-output.svg")
+        missing = probe_missing_artifact(missing_path)
+        add(
+            "artifact-absent-is-not-pass",
+            missing.get("ok") is False and missing.get("status") == "absent" and missing.get("present") is False,
+            {"status": missing.get("status")},
+        )
+
+        as_dir = probe_missing_artifact(sub_dir)
+        add("artifact-directory-is-not-pass", as_dir.get("ok") is False and as_dir.get("status") == "not-a-file")
+
+    add("artifact-empty-path-is-not-pass", probe_missing_artifact("")["ok"] is False)
+    add("artifact-none-is-not-pass", probe_missing_artifact(None)["ok"] is False)
+
+    nrun = probe_determinism_n(lambda: {"k": True}, 3)
+    add("determinism-n-stable", nrun.get("ok") is True and nrun.get("runs") == 3)
+    add("determinism-n-rejects-one", probe_determinism_n(lambda: 1, 1).get("ok") is False)
+
+    failed = [c["name"] for c in checks if not c["ok"]]
+    return envelope(
+        ok=not failed,
+        mode="selftest",
+        checks=checks,
+        failed=failed,
+        issueCount=len(failed),
+        checkCount=len(checks),
+    )
+
+
+def render_human(report):
+    mode = report.get("mode", "?")
+    flag = "통과" if report.get("ok") else "실패"
+    lines = [f"라이브 오라클 프로브 [{mode}]: {flag}  (kind={report.get('kind')} schema={report.get('schemaVersion')})"]
+    if report.get("mode") == "structural":
+        lines.append("  exports: " + ", ".join(report.get("exports") or []))
+        probes = report.get("probes") or {}
+        for key, body in probes.items():
+            lines.append(f"  {key}: {body}")
+        for issue in report.get("issues") or []:
+            lines.append(f"  ! {issue}")
+    else:
+        for check in report.get("checks") or []:
+            mark = "O" if check.get("ok") else "X"
+            lines.append(f"  {mark} {check.get('name')}")
+        for name in report.get("failed") or []:
+            lines.append(f"  ! {name}")
+    return "\n".join(lines)
+
+
+def parse_args(argv=None):
+    ap = argparse.ArgumentParser(description="라이브 오라클 결정성·자리표·부재 프로브 (#5207)")
+    ap.add_argument("--json", action="store_true", help="JSON 봉투(kind=gymOracleProbe)를 낸다")
+    ap.add_argument("--selftest", action="store_true", help="내장 프로브를 실행한다")
+    return ap.parse_args(argv)
+
+
+def run(argv=None):
+    args = parse_args(argv)
+    report = run_selftest() if args.selftest else structural_self_check()
+    if args.json:
+        sys.stdout.write(json.dumps(report, ensure_ascii=False, indent=2) + "\n")
+    else:
+        sys.stdout.write(render_human(report) + "\n")
+    return 0 if report.get("ok") else 1
+
+
+def main():
+    return run(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass
+    sys.exit(main())

--- a/mydocs/working/gym_oracle_probe.md
+++ b/mydocs/working/gym_oracle_probe.md
@@ -1,0 +1,676 @@
+---
+kind: working-note
+status: active
+canonical: mydocs/working/gym_oracle_probe.md
+last_verified: 2026-08-18
+related:
+  - gym/tools/oracle_probe.py
+  - gym/tools/README.md
+  - gym/packs/oracle-probe/README.md
+  - scripts/tests/test_gym_oracle_probe.py
+  - "#5207"
+  - "PR #5214"
+---
+
+# 작업 노트 — 라이브 오라클 이중 계산 프로브
+
+이 노트는 구현 해설이 아니라 **왜 이렇게 만들었는가** 와 **무엇이
+남았는가** 를 남긴다. 도구의 정본 API 는 `gym/tools/README.md` 다.
+과제의 지도는 `gym/packs/oracle-probe/README.md` 다.
+
+작성 맥락: PR #5214 (`feat/gym-oracle-probe`) 를 프로브 모듈만으로
+두지 않고, 예외 시험·팩·작업 노트까지 확장한 기록.
+
+------------------------------------------------------------------------
+
+## 1. 왜 이중 계산인가
+
+채점의 유혹은 간단하다. 어제 센 숫자를 파일에 적어 두고, 오늘
+에이전트가 그 숫자를 맞히는지 본다. 빠르고, 바이너리가 필요 없고,
+CI 가 가볍다.
+
+그 유혹이 깨지는 순간은 항상 같다.
+
+- 페이지네이션을 고친다. 쪽수가 17 에서 18 이 된다.
+- 검색 토크나이저를 고친다. '국어' 매치가 12 에서 11 이 된다.
+- 필드 추출이 숨은 누름틀을 하나 더 본다.
+
+골든 파일을 믿으면 **정직한 에이전트가 실패** 하고 **숫자를 외운
+에이전트가 통과** 한다. 운동장이 측정하는 것은 "문서를 열어 값을
+읽는 능력" 이 아니라 "어제 커밋을 외우는 능력" 이 된다.
+
+이중 계산은 그 순서를 뒤집는다.
+
+1. 에이전트가 값을 보고한다.
+2. 채점기가 **같은 입력에 같은 명령을 지금** 실행한다.
+3. 두 값이 같으면 통과다.
+
+어제 18 이 정답이었는지 아무도 묻지 않는다. 오늘의 바이너리가
+내는 값이 정답이다. 픽스처가 진화하면 정답도 따라 진화한다.
+`gym/README.md` 가 "채점은 라이브다" 라고 쓴 문장의 구현이 이것이다.
+
+이중 계산이 성립하려면 오라클 함수 자체가 결정적이어야 한다.
+같은 명령을 두 번 돌려 다른 봉투가 나오면, 채점기는 동전 던지기다.
+`probe_determinism` 이 그 동전을 감사한다.
+
+자리표가 남으면 오라클이 엉뚱한 파일을 연다. `{sub:out.hwp}` 가
+리터럴 파일명으로 남으면 제출 폴더가 아니라 작업 디렉터리의
+`{sub:out.hwp}` 를 찾는다. 부재가 나고, 혹은 더 나쁘게 다른
+제출물의 파일을 읽는다. `probe_placeholders` 가 그 사고를 막는다.
+
+산출물이 없는데 통과하면, 아무 것도 하지 않은 에이전트가 만점이다.
+`probe_missing_artifact` 가 그 구멍을 닫는다.
+
+세 프로브는 채점기의 세 전제다. 과제가 늘어날수록 이 전제가
+흔들리면 피해가 pack 수만큼 곱해진다.
+
+------------------------------------------------------------------------
+
+## 2. 위협 모델 — 썩은 골든 파일
+
+### 2.1 공격자 / 실패 주체
+
+이 노트에서 "공격자" 는 악의적 해커가 아니다. 다음 셋이다.
+
+1. **바쁜 기여자.** 과제 하나를 빨리 넣고 싶어 숫자를 박제한다.
+2. **오래된 베이스라인.** 지난 달 스코어카드의 `pageCount` 를
+   오늘 과제에 복사한다.
+3. **비결정 오라클.** 시계, 난수, 해시 시드, 파일 순서에 의존하는
+   명령을 라이브 오라클로 등록한다.
+
+셋 모두 의도는 선하다. 결과는 운동장의 거짓 점수다.
+
+### 2.2 자산
+
+- 과제 JSON 의 `checks` — 무엇이 정답인가를 선언하는 곳.
+- 기준 풀이 `reference/` — 제출물을 재현하는 절차.
+- 스코어카드 — 외부에 보이는 점수.
+- `oracle_probe.py` — 전제를 감사하는 도구.
+
+### 2.3 위협 T1 — 박제된 기대값
+
+과제에 `"value": 17` 과 `"path": "pageCount"` 를 같이 적는다.
+페이지네이션이 바뀌면 정직한 제출이 실패한다.
+
+완화: 쪽수·건수·개수는 `answer_eq` / `len_answer_eq` 로만 묻는다.
+상수는 "이 좌표가 이 값이어야 한다" 가 문서 불변이 맞을 때만
+쓴다. 예: `format == "hwp"` 는 표본이 hwp 인 한 불변이다.
+
+oracle-probe pack 은 쪽수에 `value_eq` 를 쓰지 않는다.
+
+### 2.4 위협 T2 — 기준 풀이의 숫자 리터럴
+
+`reference/OP01.json` 에 `"pages": 1` 을 적으면 기준 풀이가
+라이브가 아니다. 바이너리가 바뀌어도 제출물은 1 을 낸다.
+
+완화: 기준 풀이는 명령을 다시 적는다. `build_baseline.py` 가
+그 명령을 실행해 `answer.json` 을 만든다. OP01–OP44 전부가 이
+형식이다.
+
+### 2.5 위협 T3 — 자리표 잔존
+
+`{sub:a.hwp}` 와 `{sub:b.hwp}` 가 한 JSON 문자열에 있을 때
+첫 것만 바꾸면 `b.hwp` 가 리터럴로 남는다. #4664 가 이 사고로
+열렸다.
+
+완화: `resolve_placeholders` 가 루프로 전부 바꾸고, 프로브가
+`leftover` 를 검사한다. 단위 시험이 `build_baseline.resolve` 와
+출력을 대조한다.
+
+### 2.6 위협 T4 — 부재 위장
+
+`os.path.exists` 가 거짓이면 "비교 생략, 통과" 로 읽는 채점기.
+제출하지 않은 에이전트가 만점.
+
+완화: 부재는 `ok=false`, `status=absent`. 구조 자기점검이
+존재하지 않는 경로를 넣어 `ok is True` 이면 이슈를 남긴다.
+
+### 2.7 위협 T5 — 예외를 결정적 성공으로 세기
+
+오라클이 두 번 같은 `RuntimeError` 를 낸다. "결정적이다" 라고
+통과시키면, 항상 죽는 명령이 만점 오라클이 된다.
+
+완화: 예외는 값이 아니다. `ok=false`. 자기점검에
+`determinism-exception-is-not-pass` 가 있다.
+
+### 2.8 위협 T6 — 비결정 정규화
+
+집합을 해시 순으로 직렬화하면 같은 값이 다른 문자열이 된다.
+키 순서가 삽입 순이면 마찬가지다.
+
+완화: `json_canonicalize` 가 `sort_keys=True` 이고, 집합은
+정규화 후 정렬한다. 스냅샷은 JSON 왕복이라 원본 변이에 닫혀 있다.
+
+### 2.9 위협 T7 — 프로브가 채점기를 import
+
+`build_baseline` 을 import 하면 러너가 로드되고 스트림이
+재설정된다. `--json` 구조 자기점검이 "환경이 깨끗한가" 가 아니라
+"러너가 살아 있는가" 를 측정하게 된다.
+
+완화: 규칙을 복제하고 테스트로 동기화한다. 프로브는 순수하다.
+
+### 2.10 위협 T8 — pack ID / 과제 ID 충돌
+
+리더보드가 과제 ID 로 행을 가른다. `OP01` 이 다른 pack 에도
+있으면 집계가 섞인다.
+
+완화: `audit.py` 와 `test_gym_packs.py` 가 전역 고유를 강제한다.
+이 확장의 ID 접두사는 `OP` 다. 2026-08-18 기준 충돌 없음.
+
+### 2.11 위협 T9 — 바이너리 없는 CI 에서 라이브 채점을 돌림
+
+rhwp 가 없는 러너에서 `score.py --pack oracle-probe` 를 돌리면
+전 과제가 `unavailable` 이거나 크래시한다. 부재를 0점으로
+위장하면 T4 와 같은 거짓말이다.
+
+완화: CI 의 gym 단계는 unittest + audit + oracle_probe 만 돈다.
+라이브 채점은 바이너리가 있는 작업자의 왕복이다.
+
+### 2.12 위협 T10 — 문서와 코드의 드리프트
+
+README 가 없는 함수를 설명하거나, 시험이 없는 불변식을 주장하면
+다음 기여자가 거짓 문서를 믿는다.
+
+완화: 공개 함수 목록을 시험이 들고 있다.
+`PublicSurfaceSmokeTests.PUBLIC`. 새 함수는 목록과 행복·예외
+시험을 같이 넣는다.
+
+### 2.13 수용하는 위험
+
+- 에이전트가 `reference/` 를 읽는다. 규칙으로 금할 뿐 기술로
+  막지 않는다. 채점은 여전히 라이브라 점수는 맞다. 측정되는
+  능력만 바뀐다.
+- rhwp 가 비결정이면 라이브 채점이 흔들린다. 프로브는 파이썬
+  함수만 본다. 바이너리 결정성은 별 시험의 몫이다.
+- `capabilities` 의 명령 수는 버전마다 바뀐다. OP21 은 그것이
+  의도다. 숫자를 외운 제출은 버전업 후 실패해야 한다.
+
+------------------------------------------------------------------------
+
+## 3. 프로브 행렬
+
+단위 시험과 자기점검이 공유하는 표. 코드가 바뀌면 이 절과
+`gym/tools/README.md` §10 을 같이 고친다.
+
+### 3.1 결정성
+
+```
+compute_fn                ok    equal   error
+------------------------  ----  ------  -----
+안정 dict                 T     T       없음
+드리프트 카운터           F     F       없음
+RuntimeError 반복         F     F       있음
+TimeoutError              F     F       있음
+비호출 / None             F     F       있음
+첫 성공 + 둘째 예외       F     F       있음
+{} / [] / None 값         T     T       없음
+키 순서만 다른 두 값      T     T       없음
+"2" 와 2                  T     T       없음
+True 와 1 (정규화 문자)   —     다름    —
+float NaN / inf           T     T       null 로 접힘
+n=1 / n=True / n="2"      F     F       사용 오류
+n=5 안정                  T     T       없음
+n=4 드리프트              F     F       없음
+```
+
+### 3.2 자리표
+
+```
+token                     ok    leftover   notes
+------------------------  ----  ---------  -----
+{input}                   T     []         inputExact
+plain-literal             T     []         그대로
+{sub:a.hwp}               T     []         mkdir dirname
+다중 {sub:} JSON          T     []         전부 치환
+keep {input} embedded     T     []         치환 안 함
+keep {sub:                F     있음       미닫힘
+None / 1 / dict           F     []         타입
+{input} + 빈 task         F     []         KeyError
+중복 {sub:a}{sub:a}       T     []         names 두 번
+한글 {sub:이름.hwp}       T     []         경로에 그대로
+```
+
+### 3.3 산출물
+
+```
+path                      status       ok    present
+------------------------  -----------  ----  -------
+존재하는 파일             present      T     T
+0바이트 파일              present      T     T
+PathLike 파일             present      T     T
+없는 경로                 absent       F     F
+디렉터리                  not-a-file   F     F
+""                        invalid      F     F
+None                      invalid      F     F
+int / list                invalid      F     F
+묶음 중 하나 부재         (묶음)       F     —
+묶음 빈 목록              (묶음)       F     —
+묶음 전부 present         (묶음)       T     —
+```
+
+### 3.4 묶음 (probe_live_oracle)
+
+```
+결정성   자리표        산출물        묶음 ok
+------   -----------   -----------   -------
+T        (생략)        (생략)        T
+T        실패          (생략)        F
+T        (생략)        부재          F
+F        성공          present       F
+T        성공          present       T
+```
+
+논리곱이다. 켜지 않은 축은 보지 않는다.
+
+### 3.5 봉투
+
+```
+mode          필수 키
+------------  ------------------------------------------
+structural    kind, schemaVersion, ok, mode, exports,
+              required, issues, issueCount, probes
+selftest      kind, schemaVersion, ok, mode, checks,
+              failed, checkCount, issueCount
+```
+
+`probes.missingArtifact.ok` 는 구조 모드에서 반드시 false.
+
+------------------------------------------------------------------------
+
+## 4. 설계에서 버린 대안
+
+### 4.1 골든 JSON 을 저장소에 커밋
+
+빠르다. 썩는다. §2.3. 버렸다.
+
+### 4.2 프로브가 rhwp 를 직접 실행
+
+진짜 이중 계산에 더 가깝다. CI 가 바이너리를 요구한다.
+이 저장소의 gym CI 단계는 순수 파일이라는 결을 깨는다. 버렸다.
+실문서 이중 계산은 pack 의 `answer_eq` 가 담당한다.
+
+### 4.3 build_baseline 을 import
+
+규칙의 단일 출처. 부수효과가 `--json` 을 더럽힌다. 복제 +
+대조 시험을 골랐다.
+
+### 4.4 새 clap 하위명령 `rhwp gym-oracle-probe`
+
+에이전트가 발견하기 쉽다. 이 PR 의 금지 사항이다
+("No new CLI binary"). Python 도구로 충분하다.
+
+### 4.5 검사 연산자 `oracle_eq` 를 checks.py 에 추가
+
+의미가 `answer_eq` 와 겹친다. pack 이 기존 연산자만 쓰라는
+규약과도 어긋난다. 기존 `answer_eq` / `len_answer_eq` 로
+이중 계산을 표현한다.
+
+### 4.6 gym/README 12 pack 표에 oracle-probe 를 넣기
+
+운동장 입문 코스를 13 으로 늘린다. 이 pack 은 채점 계약을
+드러내는 확장이지 가족 코스의 새 놀이기구가 아니다.
+work-receipt 확장이 표를 건드리지 않은 것과 같다.
+
+### 4.7 편집 과제를 이 pack 에 넣기
+
+누름틀을 채우면 이중 계산보다 편집 축을 측정한다.
+objects-media / text-editing / table-editing 의 일이다.
+이 pack 의 제출은 `answer.json` 만.
+
+------------------------------------------------------------------------
+
+## 5. pack 설계 메모
+
+### 5.1 왜 44 과제인가
+
+OP01–OP08 은 같은 질문(쪽·문단·표·검색)을 두 표본에 반복한다.
+표본을 바꾸면 답이 바뀐다는 것을 과제가 스스로 보여야
+"숫자를 외우면 된다" 가 성립하지 않는다.
+
+OP09–OP16 은 필드·검색·추출. 스칼라(`fieldCount`)와 배열 길이
+(`len(fields)`)를 짝지워 오라클 내부 정합을 드러낸다.
+
+OP17–OP24 는 형식 표지, 폴더 스윕, capabilities, verify.
+문서가 아니라 도구 자신이나 폴더를 오라클로 쓴다.
+
+OP25–OP39 는 표본을 더 갈아 끼운다. form-01/02, exam-kor-1p,
+PII 표본의 형식/쪽수. PII 표본을 넣되 마스킹하지 않는다 —
+보안 pack 을 복제하지 않기 위해서다.
+
+OP40–OP42 는 한 장의 `answer.json` 에 두 오라클을 동시에 묻는다.
+한쪽만 맞으면 실패. 이중 계산의 판별력을 과제 하나로 압축한다.
+
+OP43–OP44 는 form 표본의 표/문단. 쪽수와 다른 축.
+
+### 5.2 왜 이 명령들인가
+
+`pack.json` requires 는 기존 명령만:
+
+```
+capabilities dump-pages explain export-tables extract-data
+fields info scan search verify
+```
+
+전부 다른 pack 이 이미 쓰고, `answer_eq` 경로가 실측된 명령이다.
+새 플래그, 새 경로를 발명하지 않았다.
+
+### 5.3 runner 신원
+
+core-cli 와 같은 선언을 복사했다.
+
+```
+rhwpVersion: 0.8.2
+rhwpCommit:  94e4790e5a6bc766b75c3c9695b290f87e3793d4
+capabilitiesSha256: 2c7c41bc8952b63c4502ec0685b76990e4ece5b178f6dc28a1a495b12880af75
+```
+
+이 값은 "어느 바이너리로 기준을 세웠는가" 의 표지다.
+라이브 채점의 기대값을 고정하지 않는다. 신원이 비면
+`schema.validate_pack` 이 거부한다.
+
+### 5.4 기준 풀이 형식
+
+모든 reference 는:
+
+```json
+{
+  "id": "OP01",
+  "steps": [
+    { "answer": { "pages": { "cmd": ["info", "{input}", "--json"], "path": "pageCount" } } }
+  ]
+}
+```
+
+숫자 리터럴이 없다. `len: true` 는 `len_answer_eq` 과제에만 있다.
+
+------------------------------------------------------------------------
+
+## 6. 시험 설계 메모
+
+순수 시험이다. `importlib` 로 파일을 로드한다. rhwp 를 부르지
+않는다. `--json` / `--selftest` 는 같은 인터프리터로 서브프로세스를
+띄울 뿐 바이너리를 띄우지 않는다.
+
+예외 경로를 많이 넣은 이유: 행복 경로만 있으면 프로브가
+"항상 통과하는 도구" 가 된다. 실패해야 할 것이 실패하는지가
+이 도구의 존재 이유다.
+
+서브프로세스 시험은 세 개만 둔다 (구조 JSON, 자기점검 JSON,
+인자 없는 사람 문구). 나머지는 `run()` / `parse_args()` 를
+직접 부른다. Windows 에서 프로세스 기동이 느린 것을 피한다.
+
+`load(name=...)` 에 매번 다른 모듈 이름을 주는 이유:
+`sys.modules` 충돌과 테스트 격리. 같은 이름을 재쓰면 이전
+모듈 전역이 남을 수 있다.
+
+------------------------------------------------------------------------
+
+## 7. 남은 일
+
+이 확장이 닫지 않은 것. 후속 PR 의 재료다.
+
+### 7.1 바이너리 왕복은 이 작업 트리에서 돌리지 않았다
+
+`build_baseline.py --pack oracle-probe` 와
+`score.py --pack oracle-probe` 는 rhwp 가 필요하다.
+이 작업 트리는 sparse/격리라 바이너리 빌드를 강제하지 않았다.
+메인테이너가 바이너리 있는 트리에서 한 번 왕복하면
+"풀 수 있음이 실측된 과제" 계약이 닫힌다.
+
+왕복이 실패할 수 있는 지점:
+
+- `info.format` 필드 이름 변경.
+- `explain.paragraphCount` 부재.
+- `search --json -- 표` 의 `matchCount` 대 `matches`.
+- `verify --expect-min-pages` 의 종료 코드. 지금 과제는
+  `answer_eq` 만 있고 `expect_exits` 가 없다. verify 가
+  3 을 내면 기준 풀이가 죽을 수 있다. 그 경우
+  `allowExits` / 과제의 `expect_exits` 를 맞추면 된다.
+- `scan samples/hml` 의 상대 경로. 채점기는 저장소 루트에서
+  실행한다고 가정한다.
+
+### 7.2 verify 종료 코드
+
+OP24 는 `verdict` 를 라이브 대조한다. `verify` 가 기대를
+충족하지 못하면 exit 3 을 내는 것이 다른 pack (LR02) 의
+관측이다. OP24 에 `expect_exits: [0, 3]` 을 넣을지, 17쪽
+이상인 표본이라 0 만 허용할지는 왕복 때 정한다.
+issue2007 중첩 표는 LR02 가 17쪽 이상으로 쓰는 표본이라
+0 이 나올 가능성이 높다.
+
+### 7.3 capabilities 경로
+
+OP21–OP23 은 `capabilities` 에 `--json` 을 붙이지 않는다.
+SD01/SD02 와 같다. 기본 출력이 JSON 이라는 기존 계약에
+올라탄다. 기본 출력이 텍스트로 바뀌면 이 세 과제와
+self-description pack 이 같이 깨진다. 그때는 `--json` 을
+양쪽 pack 에 동시에 넣으면 된다.
+
+### 7.4 dump-pages 와 info 의 쪽수 불일치
+
+OP05 (info) 와 OP07 (dump-pages) 는 같은 표본의 쪽수를
+다른 명령으로 묻는다. 둘이 어긋나면 오라클 내부 정합
+이슈다. 과제는 둘을 따로 채점하므로 한쪽만 실패하는
+것으로 드러난다. 자동으로 둘을 비교하는 검사는 넣지
+않았다 — 그건 제품 회귀이지 gym 과제의 일이 아니다.
+
+### 7.5 프로브가 시계/시드를 주입하지 않는다
+
+비결정 오라클을 "같은 시드로 두 번" 돌리는 기능은 없다.
+gym 오라클은 시드가 필요 없는 조회여야 한다는 입장이다.
+시계가 들어가는 명령을 오라클로 등록하지 마라.
+
+### 7.6 schemaVersion 진화
+
+1.0 은 필수 키 네 개(kind, schemaVersion, ok, mode)다.
+프로브 결과 요약 필드를 늘려도 1.0 안에서 가능하다.
+필수 키를 바꾸면 1.1 과 CI 의 JSON 단언을 같이 올린다.
+
+### 7.7 다국어 오류 메시지
+
+오류 문자열은 한국어다. 테스트가 그 조각에 의존한다.
+영문 로케일 변환은 계획에 없다. 바꿀 일이 있으면 시험과
+README §23 을 한 커밋에서 고친다.
+
+### 7.8 PARK.md / INVITE.md / profile
+
+테마파크 지도에 oracle-probe 존을 그리지 않았다.
+`--profile` 에도 넣지 않았다. 원하면 후속. 넣지 않는 편이
+"채점 계약을 드러내는 확장" 이라는 자리와 맞다.
+
+### 7.9 프로브 결과를 scorecard 에 붙이기
+
+`score.py` 가 채점 앞에 `oracle_probe.structural_self_check()` 를
+돌려 `ok=false` 면 채점을 거절하는 훅은 매력적이다.
+이번 범위에 넣지 않았다. 채점 경로를 바꾸면 회귀 면적이
+커진다. 지금은 CI 가 프로브를 따로 돌리는 것으로 충분하다.
+
+### 7.10 Windows mkdir 의 정확한 토큰 분기
+
+`{sub:file.hwp}` (중첩 폴더 없음) 에서
+`os.makedirs(os.path.dirname(path), exist_ok=True)` 는
+`dirname` 이 `sub_dir` 이라 안전하다. `sub_dir` 이 `""` 이면
+`makedirs("")` 가 OSError 가 날 수 있다. 프로브는 그 예외를
+잡아 실패 보고로 바꾼다. 호출자는 빈 `sub_dir` 에 정확한
+토큰을 넣지 않는 것이 좋다. 단위 시험은 TemporaryDirectory 를
+쓴다.
+
+### 7.11 대형 페이로드 한계
+
+단위 시험은 400 키 + 80 중첩을 두 번 정규화한다. 메가바이트
+급 봉투는 시험하지 않았다. 오라클이 그런 봉투를 내면
+`json_canonicalize` 가 메모리를 쓴다. gym 조회 명령의
+`--json` 은 그 크기가 아니다.
+
+### 7.12 lone surrogate
+
+`json.dumps` 가 고립 서로게이트를 거부할 수 있다. 시험은
+예외를 허용한다. 문서 오라클이 고립 서로게이트를 내는 일은
+관측된 바 없다.
+
+------------------------------------------------------------------------
+
+## 8. 결정 로그
+
+| 날짜 | 결정 | 이유 |
+|------|------|------|
+| 2026-08 | 프로브는 순수 Python | CI 가 바이너리 없이 전제를 감사 |
+| 2026-08 | build_baseline 미import | 부수효과 차단, 대조 시험으로 동기화 |
+| 2026-08 | 예외는 비통과 | 항상 죽는 오라클을 만점 처리하지 않음 |
+| 2026-08 | 부재는 비통과 | 무제출 만점 방지 |
+| 2026-08 | 새 CLI 없음 | PR 범위, clap 표면 고정 |
+| 2026-08 | pack ID `oracle-probe`, 과제 `OP**` | 전역 충돌 없음 |
+| 2026-08 | 12 pack 표 미수정 | 입문 코스 교체가 아님 |
+| 2026-08 | 편집 과제 없음 | 축이 다름 |
+| 2026-08 | PII 표본은 형식/쪽수만 | 보안 pack 비복제 |
+| 2026-08 | 단위 시험을 예외 경로 중심으로 | 도구의 존재 이유가 실패 탐지 |
+
+------------------------------------------------------------------------
+
+## 9. 재현 체크리스트 (후속 작업자)
+
+바이너리가 있는 트리에서:
+
+```bash
+python gym/tools/oracle_probe.py --json --selftest
+python -m unittest scripts.tests.test_gym_oracle_probe
+python gym/tools/audit.py
+python gym/tools/build_baseline.py --agent op-ref --pack oracle-probe
+python gym/score.py --agent op-ref --pack oracle-probe
+```
+
+기대:
+
+- 프로브 `ok=true`, 부재 하위 프로브는 `ok=false`.
+- unittest 전부 통과.
+- audit 19 pack (또는 그 이상) 위반 0.
+- 기준 풀이가 OP01–OP44 의 `answer.json` 을 만든다.
+- 채점이 그 제출을 만점으로 읽는다.
+
+실패하면 이 노트의 §7 해당 항을 먼저 보라.
+
+------------------------------------------------------------------------
+
+## 10. 관련 이슈·PR
+
+- #5207 — 라이브 오라클 이중 계산 프로브 요청.
+- PR #5214 — `feat/gym-oracle-probe`.
+- #4664 — 다중 `{sub:}` 치환. 프로브가 그 규칙을 복제.
+- #4653 — pack 스키마, 기준 풀이 왕복, 검사 연산자 등록부.
+- #4600 — 편집 과제에 전역 훑기 금지. 이 pack 은 편집이 아님.
+
+------------------------------------------------------------------------
+
+## 11. 한 페이지 회고
+
+골든 파일은 편하다. 그리고 거짓말한다.
+
+gym 은 그 거짓말을 거절하고, 채점 순간에 rhwp 를 다시 돌린다.
+그 거절이 진짜이려면 오라클이 결정적이고, 자리표가 깨끗하고,
+없는 파일을 통과로 세지 않아야 한다.
+
+`oracle_probe.py` 는 그 세 문장을 바이너리 없이 검사한다.
+`oracle-probe` pack 은 그 세 문장을 실문서로 보여 준다.
+단위 시험은 실패해야 할 것이 실패하는지 본다.
+
+남은 일은 바이너리 왕복과, 원하면 score.py 앞단 훅이다.
+이번 작업은 전제를 문서화하고, 예외를 시험하고, 과제로
+구체화한 것으로 충분하다.
+
+부재는 실패다. 그것이 이 노트의 마지막 문장이어야 했지만, 후속
+작업자가 길을 잃지 않도록 부록을 붙인다.
+
+------------------------------------------------------------------------
+
+## 12. 부록 — 과제별 오라클 한 줄
+
+이 표는 pack README 의 지도를 작업 노트에 복제한 것이 아니다.
+**왕복 때 어디를 보면 되는가** 를 한 줄로 적는다.
+
+```
+OP01  info pageCount              table-001
+OP02  explain paragraphCount      table-001
+OP03  export-tables tableCount    table-001
+OP04  search matchCount 표        table-001
+OP05  info pageCount              issue2007 중첩
+OP06  explain paragraphCount      issue2007 중첩
+OP07  dump-pages pageCount        issue2007 중첩
+OP08  export-tables tableCount    issue2007 중첩
+OP09  fields fieldCount           field-01
+OP10  len(fields)                 field-01
+OP11  fields fieldCount           field-01-memo
+OP12  fields fieldCount           form-01
+OP13  fields fieldCount           form-02
+OP14  len(search.matches) 국어    국립국어원
+OP15  info pageCount              국립국어원
+OP16  len(extract-data.items)     수출입 현황
+OP17  info format                 table-001
+OP18  info format                 hwpx_sample2
+OP19  len(scan.files)             samples/hml
+OP20  files[0].extMismatch        samples/hml --probe
+OP21  len(capabilities.commands)  (도구)
+OP22  len(formats.read)           (도구)
+OP23  len(formats.write)          (도구)
+OP24  verify verdict min-pages 17 issue2007 중첩
+OP25  info pageCount              form-01
+OP26  info pageCount              form-02
+OP27  info pageCount              field-01
+OP28  explain paragraphCount      field-01
+OP29  explain paragraphCount      form-01
+OP30  export-tables tableCount    multi-table-001
+OP31  len(tables)                 multi-table-001
+OP32  explain paragraphCount      para-001
+OP33  search matchCount 마케팅    field-01
+OP34  search matchCount 업무      국립국어원
+OP35  info pageCount              exam-kor-1p
+OP36  explain paragraphCount      exam-kor-1p
+OP37  info format                 PII 분석 표본
+OP38  info pageCount              PII 분석 표본
+OP39  info format                 field-01
+OP40  info + export-tables        table-001
+OP41  fields + info               field-01
+OP42  search + info               국립국어원
+OP43  export-tables tableCount    form-01
+OP44  explain paragraphCount      form-02
+```
+
+왕복이 한 과제에서 죽으면 이 표의 명령과 좌표를 먼저 확인하라.
+좌표 이름이 바뀌었으면 과제·기준 풀이·이 표를 한 커밋에서 고친다.
+
+------------------------------------------------------------------------
+
+## 13. 부록 — 프로브 함수와 시험 클래스
+
+| 함수 | 행복 시험 | 예외 시험 |
+|------|-----------|-----------|
+| leftover_sub_names | extract/dup names | 비문자열 → [] |
+| extract_sub_names | 인벤토리 | (위와 동일) |
+| is_exact_sub_token | `{sub:a}` | 임베디드·None |
+| resolve_placeholders | 베이스라인 대조 | mkdir=False |
+| resolve_cmd | argv 치환 | 비목록 TypeError |
+| probe_placeholders | 다중 sub, {input} | 타입·KeyError·미닫힘 |
+| probe_cmd_placeholders | 전 토큰 | 비순회·혼합 실패 |
+| norm_scalar | int→float, strip | NaN/inf → None |
+| json_ready | set 정렬, bytes | 커스텀 str() |
+| json_canonicalize | 키 정렬, 한글 | NaN → null |
+| snapshot | 변이 격리 | — |
+| probe_determinism | 안정, 숫자 정규화 | 드리프트·예외·비호출 |
+| probe_determinism_n | n=5 안정 | n<2, 드리프트, 예외 |
+| classify_artifact | 행렬 | invalid 집합 닫힘 |
+| probe_missing_artifact | present, 0바이트 | absent/dir/empty/None |
+| probe_artifacts | 전부 present | 빈 목록, 하나 부재 |
+| probe_live_oracle | 세 축 통과 | 축 논리곱 실패 |
+| envelope | kind/version | kind 덮어쓰기 관측 |
+| structural_self_check | exports 전부 | (모듈이 건강하면 ok) |
+| run_selftest | failed=[] | 내장 실패 케이스 포함 |
+| render_human | 통과 문구 | 실패 O/X |
+| parse_args | 기본·플래그 | — |
+| run / main | 종료 0, 봉투 | — |
+
+이 표에 없는 공개 함수를 추가하면 시험이 `PUBLIC` 목록에서 실패한다.
+
+------------------------------------------------------------------------
+
+## 14. 마지막 문장
+
+부재는 실패다.

--- a/scripts/tests/test_gym_oracle_probe.py
+++ b/scripts/tests/test_gym_oracle_probe.py
@@ -1,0 +1,198 @@
+"""[#5207] 라이브 오라클 프로브 계약 — 다중 자리표·결정성 실패·부재 보고.
+
+핵심 불변식:
+1. 한 문자열의 여러 `{sub:이름}` 은 모두 치환된다(첫 하나만 바꾸면 안 된다).
+2. 두 번 계산이 어긋나면 결정성 프로브는 실패한다.
+3. 산출물이 없으면 status=absent 이고 통과로 위장하지 않는다.
+4. `--json` 은 팩 픽스처 없이 kind=gymOracleProbe / schemaVersion=1.0 을 낸다.
+
+바이너리·pack 없이 순수 함수와 임시 디렉터리만 시험한다.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL = REPO_ROOT / "gym" / "tools" / "oracle_probe.py"
+BASELINE = REPO_ROOT / "gym" / "tools" / "build_baseline.py"
+
+
+def load(name="gym_oracle_probe"):
+    spec = importlib.util.spec_from_file_location(name, TOOL)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_baseline():
+    spec = importlib.util.spec_from_file_location("gym_build_baseline_for_probe", BASELINE)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class PlaceholderTests(unittest.TestCase):
+    def test_multiple_sub_placeholders_all_resolve(self):
+        mod = load("gym_oracle_probe_multi_sub")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            token = '{"input": "{sub:o1.hwp}", "output": "{sub:o2.hwp}"}'
+            out = mod.probe_placeholders(token, {"input": "in.hwp"}, sub_dir)
+            self.assertTrue(out["ok"], out)
+            self.assertNotIn("{sub:", out["resolved"])
+            self.assertEqual(out["leftover"], [])
+            self.assertIn("o1.hwp", out["resolved"])
+            self.assertIn("o2.hwp", out["resolved"])
+            self.assertEqual(out["names"], ["o1.hwp", "o2.hwp"])
+
+    def test_resolve_matches_build_baseline(self):
+        probe = load("gym_oracle_probe_vs_baseline")
+        baseline = load_baseline()
+        task = {"input": "samples/in.hwp"}
+        with tempfile.TemporaryDirectory() as sub_dir:
+            tokens = (
+                "{input}",
+                '{"input": "{sub:o1.hwp}", "output": "{sub:o2.hwp}"}',
+                "{sub:capsules/child.hwp}",
+                "plain-literal",
+                "keep {input} embedded",
+            )
+            for token in tokens:
+                self.assertEqual(
+                    probe.resolve_placeholders(token, task, sub_dir),
+                    baseline.resolve(token, task, sub_dir),
+                    token,
+                )
+
+    def test_cmd_list_resolves_every_token(self):
+        mod = load("gym_oracle_probe_cmd")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            cmd = ["search", "{sub:edited.hwp}", "--json", "--", "규제"]
+            report = mod.probe_cmd_placeholders(cmd, {"input": "in.hwp"}, sub_dir)
+            self.assertTrue(report["ok"], report)
+            resolved = [t["resolved"] for t in report["tokens"]]
+            self.assertTrue(any(str(item).endswith("edited.hwp") for item in resolved))
+            self.assertTrue(all("{sub:" not in str(item) for item in resolved))
+
+
+class DeterminismTests(unittest.TestCase):
+    def test_stable_compute_passes(self):
+        mod = load("gym_oracle_probe_det_ok")
+        report = mod.probe_determinism(lambda: {"pageCount": 3, "kind": "info"})
+        self.assertTrue(report["ok"])
+        self.assertTrue(report["equal"])
+        self.assertEqual(report["runs"], 2)
+
+    def test_determinism_fail_on_drift(self):
+        mod = load("gym_oracle_probe_det_fail")
+        state = {"i": 0}
+
+        def drift():
+            state["i"] += 1
+            return {"n": state["i"]}
+
+        report = mod.probe_determinism(drift)
+        self.assertFalse(report["ok"])
+        self.assertFalse(report["equal"])
+        self.assertNotEqual(report["first"], report["second"])
+
+    def test_key_order_and_numeric_string_are_equal(self):
+        mod = load("gym_oracle_probe_norm")
+        seq = [{"b": 1, "a": "2"}, {"a": 2, "b": "1"}]
+        report = mod.probe_determinism(lambda: seq.pop(0))
+        self.assertTrue(report["ok"], report)
+
+    def test_exception_is_not_a_pass(self):
+        mod = load("gym_oracle_probe_exc")
+        report = mod.probe_determinism(lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+        self.assertFalse(report["ok"])
+        self.assertIn("RuntimeError", report.get("error", ""))
+
+
+class MissingArtifactTests(unittest.TestCase):
+    def test_missing_file_is_absent_not_pass(self):
+        mod = load("gym_oracle_probe_missing")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            path = os.path.join(sub_dir, "never-written.svg")
+            report = mod.probe_missing_artifact(path)
+            self.assertFalse(report["ok"])
+            self.assertFalse(report["present"])
+            self.assertEqual(report["status"], "absent")
+
+    def test_present_file_passes(self):
+        mod = load("gym_oracle_probe_present")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            path = os.path.join(sub_dir, "answer.json")
+            Path(path).write_text("{}\n", encoding="utf-8")
+            report = mod.probe_missing_artifact(path)
+            self.assertTrue(report["ok"])
+            self.assertTrue(report["present"])
+            self.assertEqual(report["status"], "present")
+
+    def test_directory_is_not_a_file_and_not_pass(self):
+        mod = load("gym_oracle_probe_dir")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            report = mod.probe_missing_artifact(sub_dir)
+            self.assertFalse(report["ok"])
+            self.assertEqual(report["status"], "not-a-file")
+
+
+class EnvelopeAndCliTests(unittest.TestCase):
+    def test_json_structural_self_check_has_schema(self):
+        proc = subprocess.run(
+            [sys.executable, str(TOOL), "--json"],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr.decode("utf-8", "replace"))
+        report = json.loads(proc.stdout.decode("utf-8"))
+        self.assertEqual(report["kind"], "gymOracleProbe")
+        self.assertEqual(report["schemaVersion"], "1.0")
+        self.assertEqual(report["mode"], "structural")
+        self.assertTrue(report["ok"], report)
+        self.assertFalse(report["probes"]["missingArtifact"]["ok"])
+        self.assertEqual(report["probes"]["missingArtifact"]["status"], "absent")
+
+    def test_selftest_covers_required_probes(self):
+        proc = subprocess.run(
+            [sys.executable, str(TOOL), "--json", "--selftest"],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr.decode("utf-8", "replace"))
+        report = json.loads(proc.stdout.decode("utf-8"))
+        names = {c["name"] for c in report["checks"]}
+        self.assertIn("placeholders-multi-sub", names)
+        self.assertIn("determinism-drift-detected", names)
+        self.assertIn("artifact-absent-is-not-pass", names)
+        self.assertTrue(report["ok"], report.get("failed"))
+
+    def test_run_helper_returns_envelope(self):
+        mod = load("gym_oracle_probe_run")
+        buf = io.StringIO()
+        old = sys.stdout
+        sys.stdout = buf
+        try:
+            code = mod.run(["--json"])
+        finally:
+            sys.stdout = old
+        self.assertEqual(code, 0)
+        report = json.loads(buf.getvalue())
+        self.assertEqual(report["kind"], "gymOracleProbe")
+        self.assertEqual(report["schemaVersion"], "1.0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_gym_oracle_probe.py
+++ b/scripts/tests/test_gym_oracle_probe.py
@@ -7,6 +7,9 @@
 4. `--json` 은 팩 픽스처 없이 kind=gymOracleProbe / schemaVersion=1.0 을 낸다.
 
 바이너리·pack 없이 순수 함수와 임시 디렉터리만 시험한다.
+예외 경로: 빈 입력, 깨진 JSON, 이중 계산 불일치, 오류 봉투, 키 부재,
+타입 불일치, NaN/inf, 유니코드, 큰 페이로드, 중복 프로브 id,
+결정적 정렬, 분류 행렬.
 """
 
 from __future__ import annotations
@@ -14,6 +17,7 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+import math
 import os
 import subprocess
 import sys
@@ -40,6 +44,11 @@ def load_baseline():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+# ---------------------------------------------------------------------------
+# 자리표 — 행복 / 예외
+# ---------------------------------------------------------------------------
 
 
 class PlaceholderTests(unittest.TestCase):
@@ -84,6 +93,163 @@ class PlaceholderTests(unittest.TestCase):
             self.assertTrue(any(str(item).endswith("edited.hwp") for item in resolved))
             self.assertTrue(all("{sub:" not in str(item) for item in resolved))
 
+    def test_exact_input_token_returns_task_input(self):
+        mod = load("gym_oracle_probe_exact_input")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            report = mod.probe_placeholders("{input}", {"input": "samples/a.hwp"}, sub_dir)
+            self.assertTrue(report["ok"])
+            self.assertTrue(report["inputExact"])
+            self.assertEqual(report["resolved"], "samples/a.hwp")
+            self.assertEqual(report["names"], [])
+
+    def test_embedded_input_is_not_replaced(self):
+        mod = load("gym_oracle_probe_embedded_input")
+        token = "keep {input} embedded"
+        resolved = mod.resolve_placeholders(token, {"input": "x.hwp"}, "unused")
+        self.assertEqual(resolved, token)
+
+    def test_exact_sub_token_builds_path_and_parent(self):
+        mod = load("gym_oracle_probe_exact_sub")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            token = "{sub:capsules/child.hwp}"
+            self.assertTrue(mod.is_exact_sub_token(token))
+            resolved = mod.resolve_placeholders(token, {"input": "in.hwp"}, sub_dir)
+            self.assertEqual(resolved, os.path.join(sub_dir, "capsules/child.hwp"))
+            self.assertTrue(os.path.isdir(os.path.dirname(resolved)))
+
+    def test_exact_sub_token_mkdir_false_skips_makedirs(self):
+        mod = load("gym_oracle_probe_sub_nomk")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            token = "{sub:ghost/never.hwp}"
+            resolved = mod.resolve_placeholders(
+                token, {"input": "in.hwp"}, sub_dir, mkdir=False
+            )
+            self.assertEqual(resolved, os.path.join(sub_dir, "ghost/never.hwp"))
+            self.assertFalse(os.path.isdir(os.path.join(sub_dir, "ghost")))
+
+    def test_non_string_token_is_not_pass(self):
+        mod = load("gym_oracle_probe_ph_nonstr")
+        report = mod.probe_placeholders(12, {"input": "in.hwp"}, ".")
+        self.assertFalse(report["ok"])
+        self.assertIsNone(report["resolved"])
+        self.assertEqual(report["leftover"], [])
+        self.assertIn("문자열", report["error"])
+
+    def test_none_token_is_not_pass(self):
+        mod = load("gym_oracle_probe_ph_none")
+        report = mod.probe_placeholders(None, {"input": "in.hwp"}, ".")
+        self.assertFalse(report["ok"])
+        self.assertIn("NoneType", report["error"])
+
+    def test_missing_input_key_is_not_pass(self):
+        mod = load("gym_oracle_probe_ph_keyerr")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            report = mod.probe_placeholders("{input}", {}, sub_dir)
+            self.assertFalse(report["ok"])
+            self.assertIn("KeyError", report["error"])
+
+    def test_none_task_on_exact_input_is_not_pass(self):
+        mod = load("gym_oracle_probe_ph_tasknone")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            report = mod.probe_placeholders("{input}", None, sub_dir)
+            self.assertFalse(report["ok"])
+            self.assertIn("KeyError", report["error"])
+
+    def test_unclosed_sub_is_not_pass(self):
+        mod = load("gym_oracle_probe_ph_unclosed")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            report = mod.probe_placeholders("keep {sub:", {"input": "in.hwp"}, sub_dir)
+            self.assertFalse(report["ok"])
+            self.assertTrue(report["leftover"] or report.get("error"))
+
+    def test_empty_string_token_is_pass_literal(self):
+        mod = load("gym_oracle_probe_ph_empty")
+        report = mod.probe_placeholders("", {"input": "in.hwp"}, ".")
+        self.assertTrue(report["ok"], report)
+        self.assertEqual(report["resolved"], "")
+        self.assertEqual(report["leftover"], [])
+        self.assertEqual(report["names"], [])
+
+    def test_leftover_sub_names_on_non_string_is_empty(self):
+        mod = load("gym_oracle_probe_leftover_nonstr")
+        self.assertEqual(mod.leftover_sub_names(None), [])
+        self.assertEqual(mod.leftover_sub_names(3), [])
+        self.assertEqual(mod.leftover_sub_names(b"{sub:x}"), [])
+
+    def test_extract_sub_names_inventory_before_resolve(self):
+        mod = load("gym_oracle_probe_extract_names")
+        names = mod.extract_sub_names("a {sub:one} b {sub:two/c} d")
+        self.assertEqual(names, ["one", "two/c"])
+
+    def test_duplicate_sub_names_are_kept_in_order(self):
+        mod = load("gym_oracle_probe_dup_names")
+        names = mod.extract_sub_names("{sub:a.hwp} then {sub:a.hwp}")
+        self.assertEqual(names, ["a.hwp", "a.hwp"])
+
+    def test_is_exact_sub_token_rejects_embedded_and_nested(self):
+        mod = load("gym_oracle_probe_exact_guard")
+        self.assertFalse(mod.is_exact_sub_token("{input}"))
+        self.assertFalse(mod.is_exact_sub_token("x{sub:a}"))
+        self.assertFalse(mod.is_exact_sub_token("{sub:a}x"))
+        self.assertFalse(mod.is_exact_sub_token("{sub:a}{sub:b}"))
+        self.assertFalse(mod.is_exact_sub_token(None))
+        self.assertFalse(mod.is_exact_sub_token(1))
+        self.assertTrue(mod.is_exact_sub_token("{sub:a}"))
+
+    def test_backslash_in_embedded_sub_is_escaped(self):
+        mod = load("gym_oracle_probe_bs_escape")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            token = '{"p": "{sub:o.hwp}"}'
+            resolved = mod.resolve_placeholders(token, {"input": "in.hwp"}, sub_dir)
+            if os.sep == "\\":
+                self.assertIn("\\\\", resolved)
+            self.assertNotIn("{sub:", resolved)
+
+    def test_resolve_cmd_type_error_on_non_list(self):
+        mod = load("gym_oracle_probe_cmd_type")
+        with self.assertRaises(TypeError):
+            mod.resolve_cmd("info {input}", {"input": "a.hwp"}, ".")
+        with self.assertRaises(TypeError):
+            mod.resolve_cmd(None, {"input": "a.hwp"}, ".")
+
+    def test_resolve_cmd_happy_path(self):
+        mod = load("gym_oracle_probe_cmd_ok")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            out = mod.resolve_cmd(
+                ["info", "{input}", "{sub:out.json}"],
+                {"input": "doc.hwp"},
+                sub_dir,
+            )
+            self.assertEqual(out[0], "info")
+            self.assertEqual(out[1], "doc.hwp")
+            self.assertTrue(str(out[2]).endswith("out.json"))
+
+    def test_probe_cmd_placeholders_non_iterable(self):
+        mod = load("gym_oracle_probe_cmd_bad")
+        report = mod.probe_cmd_placeholders(3, {"input": "a.hwp"}, ".")
+        self.assertFalse(report["ok"])
+        self.assertEqual(report["tokens"], [])
+        self.assertIn("순회", report["error"])
+
+    def test_probe_cmd_placeholders_mixed_failure(self):
+        mod = load("gym_oracle_probe_cmd_mix")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            report = mod.probe_cmd_placeholders(
+                ["ok", 12, "{sub:"],
+                {"input": "a.hwp"},
+                sub_dir,
+            )
+            self.assertFalse(report["ok"])
+            self.assertEqual(report["count"], 3)
+            self.assertTrue(report["tokens"][0]["ok"])
+            self.assertFalse(report["tokens"][1]["ok"])
+            self.assertFalse(report["tokens"][2]["ok"])
+
+
+# ---------------------------------------------------------------------------
+# 결정성 — 행복 / 드리프트 / 예외 / 정규화
+# ---------------------------------------------------------------------------
+
 
 class DeterminismTests(unittest.TestCase):
     def test_stable_compute_passes(self):
@@ -118,6 +284,253 @@ class DeterminismTests(unittest.TestCase):
         self.assertFalse(report["ok"])
         self.assertIn("RuntimeError", report.get("error", ""))
 
+    def test_same_exception_twice_is_still_not_pass(self):
+        mod = load("gym_oracle_probe_exc2")
+        report = mod.probe_determinism(lambda: 1 / 0)
+        self.assertFalse(report["ok"])
+        self.assertFalse(report["equal"])
+        self.assertEqual(len(report["errors"]), 2)
+        self.assertTrue(all("ZeroDivisionError" in e for e in report["errors"]))
+
+    def test_non_callable_is_not_pass(self):
+        mod = load("gym_oracle_probe_nocall")
+        report = mod.probe_determinism("not-a-fn")
+        self.assertFalse(report["ok"])
+        self.assertIn("호출 가능", report["error"])
+
+    def test_none_compute_fn_is_not_pass(self):
+        mod = load("gym_oracle_probe_fn_none")
+        report = mod.probe_determinism(None)
+        self.assertFalse(report["ok"])
+
+    def test_first_ok_second_raises(self):
+        mod = load("gym_oracle_probe_half")
+        box = {"n": 0}
+
+        def once():
+            box["n"] += 1
+            if box["n"] == 2:
+                raise TimeoutError("oracle timeout")
+            return {"ok": True}
+
+        report = mod.probe_determinism(once)
+        self.assertFalse(report["ok"])
+        self.assertIn("TimeoutError", report["error"])
+        self.assertIsNotNone(report["first"])
+        self.assertIsNone(report["second"])
+
+    def test_timeout_error_envelope_is_not_pass(self):
+        mod = load("gym_oracle_probe_timeout")
+        report = mod.probe_determinism(lambda: (_ for _ in ()).throw(TimeoutError("deadline")))
+        self.assertFalse(report["ok"])
+        self.assertIn("TimeoutError", report["error"])
+        self.assertIn("deadline", report["error"])
+
+    def test_value_error_envelope(self):
+        mod = load("gym_oracle_probe_valerr")
+        report = mod.probe_determinism(lambda: (_ for _ in ()).throw(ValueError("malformed")))
+        self.assertFalse(report["ok"])
+        self.assertIn("malformed", report["error"])
+
+    def test_json_normalize_failure_is_not_pass(self):
+        mod = load("gym_oracle_probe_nan_raw")
+
+        class Weird:
+            def __iter__(self):
+                raise TypeError("cannot walk")
+
+        # str(Weird()) is JSON-able via json_ready fallback, so force a raw nan
+        # that survives if json_ready is bypassed — use object that dumps fail.
+        # json_ready(custom) → str, so instead feed float('nan') after ready.
+        # probe uses json_canonicalize which maps nan → None, so this passes.
+        report = mod.probe_determinism(lambda: float("nan"))
+        self.assertTrue(report["ok"], report)
+        self.assertIsNone(report["first"])
+
+    def test_probe_determinism_n_stable(self):
+        mod = load("gym_oracle_probe_n_ok")
+        report = mod.probe_determinism_n(lambda: {"k": 1}, 5)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["runs"], 5)
+        self.assertEqual(len(report["values"]), 5)
+
+    def test_probe_determinism_n_rejects_one(self):
+        mod = load("gym_oracle_probe_n_one")
+        report = mod.probe_determinism_n(lambda: 1, 1)
+        self.assertFalse(report["ok"])
+        self.assertIn("2 이상", report["error"])
+
+    def test_probe_determinism_n_rejects_zero_and_negative(self):
+        mod = load("gym_oracle_probe_n_bad")
+        for n in (0, -1, 1.5, "2", None, True):
+            report = mod.probe_determinism_n(lambda: 1, n)
+            self.assertFalse(report["ok"], n)
+
+    def test_probe_determinism_n_drift(self):
+        mod = load("gym_oracle_probe_n_drift")
+        box = {"i": 0}
+
+        def drift():
+            box["i"] += 1
+            return box["i"]
+
+        report = mod.probe_determinism_n(drift, 4)
+        self.assertFalse(report["ok"])
+        self.assertFalse(report["equal"])
+        self.assertEqual(report["values"], [1.0, 2.0, 3.0, 4.0])
+
+    def test_probe_determinism_n_error_stops_ok(self):
+        mod = load("gym_oracle_probe_n_err")
+        box = {"i": 0}
+
+        def boom():
+            box["i"] += 1
+            if box["i"] == 3:
+                raise RuntimeError("third")
+            return {"i": box["i"]}
+
+        report = mod.probe_determinism_n(boom, 4)
+        self.assertFalse(report["ok"])
+        self.assertIn("RuntimeError", report["error"])
+        self.assertGreaterEqual(len(report["errors"]), 1)
+        self.assertTrue(any("third" in e for e in report["errors"]))
+
+    def test_empty_dict_is_deterministic(self):
+        mod = load("gym_oracle_probe_empty_dict")
+        report = mod.probe_determinism(lambda: {})
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["canonicalFirst"], "{}")
+
+    def test_empty_list_is_deterministic(self):
+        mod = load("gym_oracle_probe_empty_list")
+        report = mod.probe_determinism(lambda: [])
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["canonicalFirst"], "[]")
+
+
+# ---------------------------------------------------------------------------
+# 정규화 — 스칼라 / JSON / 스냅샷 / NaN / 유니코드 / 큰 페이로드
+# ---------------------------------------------------------------------------
+
+
+class NormalizeTests(unittest.TestCase):
+    def test_norm_scalar_bool_before_int(self):
+        mod = load("gym_oracle_probe_norm_bool")
+        self.assertIs(mod.norm_scalar(True), True)
+        self.assertIs(mod.norm_scalar(False), False)
+
+    def test_norm_scalar_int_becomes_float(self):
+        mod = load("gym_oracle_probe_norm_int")
+        self.assertEqual(mod.norm_scalar(3), 3.0)
+        self.assertIsInstance(mod.norm_scalar(3), float)
+
+    def test_norm_scalar_nan_inf_float_become_none(self):
+        mod = load("gym_oracle_probe_norm_nan")
+        self.assertIsNone(mod.norm_scalar(float("nan")))
+        self.assertIsNone(mod.norm_scalar(float("inf")))
+        self.assertIsNone(mod.norm_scalar(float("-inf")))
+
+    def test_norm_scalar_numeric_string(self):
+        mod = load("gym_oracle_probe_norm_numstr")
+        self.assertEqual(mod.norm_scalar("  2.0  "), 2.0)
+        self.assertEqual(mod.norm_scalar("3"), 3.0)
+
+    def test_norm_scalar_nan_string_stays_string(self):
+        mod = load("gym_oracle_probe_norm_nanstr")
+        self.assertEqual(mod.norm_scalar("NaN"), "NaN")
+        self.assertEqual(mod.norm_scalar("inf"), "inf")
+        self.assertEqual(mod.norm_scalar("-inf"), "-inf")
+
+    def test_norm_scalar_plain_string(self):
+        mod = load("gym_oracle_probe_norm_str")
+        self.assertEqual(mod.norm_scalar("  hangul  "), "hangul")
+
+    def test_norm_scalar_passthrough_other(self):
+        mod = load("gym_oracle_probe_norm_other")
+        self.assertEqual(mod.norm_scalar(None), None)
+        self.assertEqual(mod.norm_scalar([1]), [1])
+
+    def test_json_ready_set_is_sorted(self):
+        mod = load("gym_oracle_probe_set")
+        ready = mod.json_ready({"z", "a", "m"})
+        self.assertEqual(ready, ["a", "m", "z"])
+
+    def test_json_ready_bytes_utf8(self):
+        mod = load("gym_oracle_probe_bytes")
+        self.assertEqual(mod.json_ready("한글".encode("utf-8")), "한글")
+
+    def test_json_ready_bytes_invalid_becomes_hex(self):
+        mod = load("gym_oracle_probe_bytes_hex")
+        raw = b"\xff\xfe"
+        self.assertEqual(mod.json_ready(raw), raw.hex())
+
+    def test_json_ready_tuple_becomes_list(self):
+        mod = load("gym_oracle_probe_tuple")
+        self.assertEqual(mod.json_ready((1, "2")), [1.0, 2.0])
+
+    def test_json_ready_custom_object_str(self):
+        mod = load("gym_oracle_probe_custom")
+
+        class Box:
+            def __str__(self):
+                return "box-x"
+
+        self.assertEqual(mod.json_ready(Box()), "box-x")
+
+    def test_json_canonicalize_sorts_keys(self):
+        mod = load("gym_oracle_probe_canon_keys")
+        a = mod.json_canonicalize({"b": 1, "a": 2})
+        b = mod.json_canonicalize({"a": 2, "b": 1})
+        self.assertEqual(a, b)
+        self.assertEqual(a, '{"a":2.0,"b":1.0}')
+
+    def test_json_canonicalize_unicode_not_escaped(self):
+        mod = load("gym_oracle_probe_unicode")
+        text = mod.json_canonicalize({"msg": "한글✓"})
+        self.assertIn("한글", text)
+        self.assertNotIn("\\u", text)
+
+    def test_json_canonicalize_rejects_nothing_after_ready_nan(self):
+        mod = load("gym_oracle_probe_canon_nan")
+        # float nan folds to null; dumps with allow_nan=False still works
+        self.assertEqual(mod.json_canonicalize(float("nan")), "null")
+        self.assertEqual(mod.json_canonicalize(float("inf")), "null")
+
+    def test_snapshot_isolates_mutation(self):
+        mod = load("gym_oracle_probe_snap")
+        src = {"a": [1, 2]}
+        shot = mod.snapshot(src)
+        src["a"].append(3)
+        src["b"] = 9
+        self.assertEqual(shot, {"a": [1.0, 2.0]})
+
+    def test_large_payload_is_deterministic(self):
+        mod = load("gym_oracle_probe_large")
+        payload = {f"k{i:04d}": i for i in range(400)}
+        payload["nested"] = [{"i": i, "s": f"값{i}"} for i in range(80)]
+        report = mod.probe_determinism(lambda: payload)
+        self.assertTrue(report["ok"], report)
+        self.assertGreater(len(report["canonicalFirst"]), 1000)
+
+    def test_malformed_json_roundtrip_is_not_this_layers_job(self):
+        # 프로브는 파이썬 객체를 받지, JSON 텍스트를 파싱하지 않는다.
+        # 깨진 문자열은 그냥 문자열 스칼라다.
+        mod = load("gym_oracle_probe_malformed")
+        report = mod.probe_determinism(lambda: "{not json")
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["first"], "{not json")
+
+    def test_missing_keys_survive_canonicalize(self):
+        mod = load("gym_oracle_probe_misskey")
+        left = {"a": 1}
+        right = {"a": 1, "b": 2}
+        self.assertNotEqual(mod.json_canonicalize(left), mod.json_canonicalize(right))
+
+
+# ---------------------------------------------------------------------------
+# 산출물 부재 — 분류 행렬
+# ---------------------------------------------------------------------------
+
 
 class MissingArtifactTests(unittest.TestCase):
     def test_missing_file_is_absent_not_pass(self):
@@ -138,6 +551,7 @@ class MissingArtifactTests(unittest.TestCase):
             self.assertTrue(report["ok"])
             self.assertTrue(report["present"])
             self.assertEqual(report["status"], "present")
+            self.assertGreater(report["size"], 0)
 
     def test_directory_is_not_a_file_and_not_pass(self):
         mod = load("gym_oracle_probe_dir")
@@ -145,6 +559,177 @@ class MissingArtifactTests(unittest.TestCase):
             report = mod.probe_missing_artifact(sub_dir)
             self.assertFalse(report["ok"])
             self.assertEqual(report["status"], "not-a-file")
+
+    def test_empty_path_is_invalid(self):
+        mod = load("gym_oracle_probe_empty_path")
+        report = mod.probe_missing_artifact("")
+        self.assertFalse(report["ok"])
+        self.assertEqual(report["status"], "invalid")
+        self.assertIn("비어", report["error"])
+
+    def test_none_path_is_invalid(self):
+        mod = load("gym_oracle_probe_none_path")
+        report = mod.probe_missing_artifact(None)
+        self.assertFalse(report["ok"])
+        self.assertEqual(report["status"], "invalid")
+        self.assertIsNone(report["path"])
+
+    def test_int_path_is_invalid(self):
+        mod = load("gym_oracle_probe_int_path")
+        report = mod.probe_missing_artifact(1)
+        self.assertFalse(report["ok"])
+        self.assertEqual(report["status"], "invalid")
+
+    def test_pathlike_present(self):
+        mod = load("gym_oracle_probe_pathlike")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            path = Path(sub_dir) / "x.bin"
+            path.write_bytes(b"abc")
+            report = mod.probe_missing_artifact(path)
+            self.assertTrue(report["ok"])
+            self.assertEqual(report["size"], 3)
+
+    def test_classify_artifact_matrix(self):
+        mod = load("gym_oracle_probe_classify")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            present = os.path.join(sub_dir, "f.txt")
+            Path(present).write_text("x", encoding="utf-8")
+            matrix = {
+                None: "invalid",
+                "": "invalid",
+                3: "invalid",
+                present: "present",
+                sub_dir: "not-a-file",
+                os.path.join(sub_dir, "nope"): "absent",
+            }
+            for path, status in matrix.items():
+                self.assertEqual(mod.classify_artifact(path), status, path)
+
+    def test_probe_artifacts_empty_is_not_pass(self):
+        mod = load("gym_oracle_probe_arts_empty")
+        report = mod.probe_artifacts([])
+        self.assertFalse(report["ok"])
+        self.assertEqual(report["count"], 0)
+        self.assertEqual(report["missing"], [])
+
+    def test_probe_artifacts_one_missing_fails_bundle(self):
+        mod = load("gym_oracle_probe_arts_mix")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            good = os.path.join(sub_dir, "ok.json")
+            Path(good).write_text("{}", encoding="utf-8")
+            bad = os.path.join(sub_dir, "missing.json")
+            report = mod.probe_artifacts([good, bad])
+            self.assertFalse(report["ok"])
+            self.assertEqual(report["count"], 2)
+            self.assertEqual(report["missing"], [bad])
+
+    def test_probe_artifacts_all_present(self):
+        mod = load("gym_oracle_probe_arts_ok")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            paths = []
+            for name in ("a.json", "b.json"):
+                p = os.path.join(sub_dir, name)
+                Path(p).write_text("{}", encoding="utf-8")
+                paths.append(p)
+            report = mod.probe_artifacts(paths)
+            self.assertTrue(report["ok"])
+            self.assertEqual(report["missing"], [])
+
+    def test_zero_byte_file_is_present(self):
+        mod = load("gym_oracle_probe_zero")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            path = os.path.join(sub_dir, "empty.bin")
+            Path(path).write_bytes(b"")
+            report = mod.probe_missing_artifact(path)
+            self.assertTrue(report["ok"])
+            self.assertEqual(report["size"], 0)
+
+
+# ---------------------------------------------------------------------------
+# 묶음 프로브 / 봉투
+# ---------------------------------------------------------------------------
+
+
+class LiveOracleBundleTests(unittest.TestCase):
+    def test_live_oracle_determinism_only(self):
+        mod = load("gym_oracle_probe_live_det")
+        report = mod.probe_live_oracle(lambda: {"n": 1})
+        self.assertTrue(report["ok"])
+        self.assertTrue(report["determinism"]["ok"])
+        self.assertIsNone(report["placeholders"])
+        self.assertIsNone(report["artifacts"])
+
+    def test_live_oracle_placeholder_failure_fails_bundle(self):
+        mod = load("gym_oracle_probe_live_ph")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            report = mod.probe_live_oracle(
+                lambda: {"n": 1},
+                token=12,
+                task={"input": "a.hwp"},
+                sub_dir=sub_dir,
+            )
+            self.assertFalse(report["ok"])
+            self.assertFalse(report["placeholders"]["ok"])
+
+    def test_live_oracle_missing_artifact_fails_bundle(self):
+        mod = load("gym_oracle_probe_live_art")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            missing = os.path.join(sub_dir, "nope.svg")
+            report = mod.probe_live_oracle(
+                lambda: {"n": 1},
+                artifacts=[missing],
+            )
+            self.assertFalse(report["ok"])
+            self.assertFalse(report["artifacts"]["ok"])
+
+    def test_live_oracle_all_ok(self):
+        mod = load("gym_oracle_probe_live_all")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            path = os.path.join(sub_dir, "out.json")
+            Path(path).write_text("{}", encoding="utf-8")
+            report = mod.probe_live_oracle(
+                lambda: {"pageCount": 2},
+                token="{input}",
+                task={"input": "in.hwp"},
+                sub_dir=sub_dir,
+                artifacts=[path],
+            )
+            self.assertTrue(report["ok"], report)
+
+    def test_live_oracle_drift_fails_even_if_files_exist(self):
+        mod = load("gym_oracle_probe_live_drift")
+        box = {"i": 0}
+
+        def drift():
+            box["i"] += 1
+            return box["i"]
+
+        with tempfile.TemporaryDirectory() as sub_dir:
+            path = os.path.join(sub_dir, "out.json")
+            Path(path).write_text("{}", encoding="utf-8")
+            report = mod.probe_live_oracle(drift, artifacts=[path])
+            self.assertFalse(report["ok"])
+            self.assertFalse(report["determinism"]["ok"])
+
+    def test_envelope_always_has_kind_and_version(self):
+        mod = load("gym_oracle_probe_env")
+        body = mod.envelope(ok=True, extra=1)
+        self.assertEqual(body["kind"], "gymOracleProbe")
+        self.assertEqual(body["schemaVersion"], "1.0")
+        self.assertTrue(body["ok"])
+        self.assertEqual(body["extra"], 1)
+
+    def test_envelope_fields_do_not_clobber_kind_if_caller_is_careful(self):
+        mod = load("gym_oracle_probe_env2")
+        # 호출자가 kind 를 넘기면 update 가 덮는다 — 계약 문서화용 관측.
+        body = mod.envelope(kind="other")
+        self.assertEqual(body["kind"], "other")
+        self.assertEqual(body["schemaVersion"], "1.0")
+
+
+# ---------------------------------------------------------------------------
+# 자기점검 / CLI / 렌더
+# ---------------------------------------------------------------------------
 
 
 class EnvelopeAndCliTests(unittest.TestCase):
@@ -192,6 +777,380 @@ class EnvelopeAndCliTests(unittest.TestCase):
         report = json.loads(buf.getvalue())
         self.assertEqual(report["kind"], "gymOracleProbe")
         self.assertEqual(report["schemaVersion"], "1.0")
+
+    def test_run_selftest_json(self):
+        mod = load("gym_oracle_probe_run_st")
+        buf = io.StringIO()
+        old = sys.stdout
+        sys.stdout = buf
+        try:
+            code = mod.run(["--json", "--selftest"])
+        finally:
+            sys.stdout = old
+        self.assertEqual(code, 0)
+        report = json.loads(buf.getvalue())
+        self.assertEqual(report["mode"], "selftest")
+        self.assertGreaterEqual(report["checkCount"], 10)
+
+    def test_run_human_text_mentions_pass(self):
+        mod = load("gym_oracle_probe_human")
+        buf = io.StringIO()
+        old = sys.stdout
+        sys.stdout = buf
+        try:
+            code = mod.run([])
+        finally:
+            sys.stdout = old
+        self.assertEqual(code, 0)
+        text = buf.getvalue()
+        self.assertIn("라이브 오라클 프로브", text)
+        self.assertIn("통과", text)
+
+    def test_parse_args_defaults(self):
+        mod = load("gym_oracle_probe_args")
+        args = mod.parse_args([])
+        self.assertFalse(args.json)
+        self.assertFalse(args.selftest)
+        args = mod.parse_args(["--json", "--selftest"])
+        self.assertTrue(args.json)
+        self.assertTrue(args.selftest)
+
+    def test_render_human_selftest_marks(self):
+        mod = load("gym_oracle_probe_render")
+        text = mod.render_human(
+            {
+                "kind": "gymOracleProbe",
+                "schemaVersion": "1.0",
+                "ok": False,
+                "mode": "selftest",
+                "checks": [{"name": "a", "ok": True}, {"name": "b", "ok": False}],
+                "failed": ["b"],
+            }
+        )
+        self.assertIn("실패", text)
+        self.assertIn("O a", text)
+        self.assertIn("X b", text)
+        self.assertIn("! b", text)
+
+    def test_render_human_structural_lists_issues(self):
+        mod = load("gym_oracle_probe_render2")
+        text = mod.render_human(
+            {
+                "kind": "gymOracleProbe",
+                "schemaVersion": "1.0",
+                "ok": False,
+                "mode": "structural",
+                "exports": ["probe_determinism"],
+                "probes": {"determinism": {"ok": False}},
+                "issues": ["필수 함수 없음: x"],
+            }
+        )
+        self.assertIn("exports:", text)
+        self.assertIn("determinism", text)
+        self.assertIn("필수 함수 없음", text)
+
+    def test_structural_self_check_exports_required(self):
+        mod = load("gym_oracle_probe_struct")
+        report = mod.structural_self_check()
+        self.assertTrue(report["ok"], report)
+        for name in mod.REQUIRED_EXPORTS:
+            self.assertIn(name, report["exports"])
+
+    def test_run_selftest_function_direct(self):
+        mod = load("gym_oracle_probe_st_fn")
+        report = mod.run_selftest()
+        self.assertTrue(report["ok"], report.get("failed"))
+        self.assertEqual(report["kind"], "gymOracleProbe")
+        self.assertEqual(report["failed"], [])
+
+    def test_main_returns_zero_on_ok(self):
+        mod = load("gym_oracle_probe_main")
+        old_argv = sys.argv
+        buf = io.StringIO()
+        old = sys.stdout
+        sys.argv = ["oracle_probe.py", "--json"]
+        sys.stdout = buf
+        try:
+            code = mod.main()
+        finally:
+            sys.argv = old_argv
+            sys.stdout = old
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(buf.getvalue())["kind"], "gymOracleProbe")
+
+    def test_subprocess_no_args_exit_zero(self):
+        proc = subprocess.run(
+            [sys.executable, str(TOOL)],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr.decode("utf-8", "replace"))
+        self.assertIn("통과", proc.stdout.decode("utf-8"))
+
+    def test_stdout_json_is_object_not_array(self):
+        proc = subprocess.run(
+            [sys.executable, str(TOOL), "--json"],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            check=False,
+        )
+        payload = json.loads(proc.stdout.decode("utf-8"))
+        self.assertIsInstance(payload, dict)
+        self.assertNotIsInstance(payload, list)
+
+
+# ---------------------------------------------------------------------------
+# 프로브 분류 행렬 · 중복 id · 결정적 정렬
+# ---------------------------------------------------------------------------
+
+
+class ProbeClassificationMatrixTests(unittest.TestCase):
+    """프로브 결과의 (ok, status/error) 조합이 겹치지 않게 갈리는지."""
+
+    def test_artifact_status_set_is_closed(self):
+        mod = load("gym_oracle_probe_status_set")
+        allowed = {"present", "absent", "not-a-file", "invalid"}
+        with tempfile.TemporaryDirectory() as sub_dir:
+            present = os.path.join(sub_dir, "p")
+            Path(present).write_text("1", encoding="utf-8")
+            samples = [present, os.path.join(sub_dir, "no"), sub_dir, "", None, 0, []]
+            for path in samples:
+                status = mod.classify_artifact(path)
+                self.assertIn(status, allowed, path)
+
+    def test_determinism_ok_implies_equal_and_no_error(self):
+        mod = load("gym_oracle_probe_det_impl")
+        report = mod.probe_determinism(lambda: {"x": 1})
+        self.assertTrue(report["ok"])
+        self.assertTrue(report["equal"])
+        self.assertNotIn("error", report)
+
+    def test_determinism_fail_never_ok(self):
+        mod = load("gym_oracle_probe_det_impl2")
+        cases = [
+            lambda: (_ for _ in ()).throw(RuntimeError("x")),
+            None,
+            "nope",
+        ]
+        box = {"i": 0}
+
+        def drift():
+            box["i"] += 1
+            return box["i"]
+
+        cases.append(drift)
+        for fn in cases:
+            report = mod.probe_determinism(fn)
+            self.assertFalse(report["ok"])
+            self.assertFalse(report["equal"])
+
+    def test_placeholder_matrix(self):
+        mod = load("gym_oracle_probe_ph_matrix")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            task = {"input": "in.hwp"}
+            rows = [
+                ("{input}", True, True),
+                ("plain", True, False),
+                ("{sub:a.hwp}", True, False),
+                ("{sub:", False, False),
+                (None, False, False),
+                (1, False, False),
+            ]
+            for token, expect_ok, expect_exact in rows:
+                report = mod.probe_placeholders(token, task, sub_dir)
+                self.assertEqual(report["ok"], expect_ok, token)
+                if expect_ok:
+                    self.assertEqual(report.get("inputExact"), expect_exact, token)
+
+    def test_duplicate_probe_ids_in_cmd_are_independent(self):
+        """같은 {sub:이름} 이 두 자리에 있어도 각각 치환되고 leftover 가 없다."""
+        mod = load("gym_oracle_probe_dup_cmd")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            cmd = ["cp", "{sub:a.hwp}", "{sub:a.hwp}"]
+            report = mod.probe_cmd_placeholders(cmd, {"input": "in.hwp"}, sub_dir)
+            self.assertTrue(report["ok"], report)
+            self.assertEqual(report["count"], 3)
+            self.assertEqual(report["tokens"][1]["names"], ["a.hwp"])
+            self.assertEqual(report["tokens"][2]["names"], ["a.hwp"])
+
+    def test_deterministic_key_ordering_across_runs(self):
+        mod = load("gym_oracle_probe_order")
+        payload = {"m": 1, "z": 2, "a": 3}
+        texts = [mod.json_canonicalize(payload) for _ in range(8)]
+        self.assertEqual(len(set(texts)), 1)
+        self.assertTrue(texts[0].startswith('{"a":'))
+
+    def test_set_of_dicts_orders_deterministically(self):
+        mod = load("gym_oracle_probe_setdict")
+        # 집합은 해시 순이 아니라 json_ready 가 정렬한다.
+        left = mod.json_canonicalize({frozenset({"k": 1}.items()), frozenset({"k": 2}.items())})
+        right = mod.json_canonicalize({frozenset({"k": 2}.items()), frozenset({"k": 1}.items())})
+        # frozenset of items is not a dict; json_ready will str() them.
+        self.assertEqual(left, right)
+
+    def test_type_mismatch_in_placeholder_error_names_the_type(self):
+        mod = load("gym_oracle_probe_type_name")
+        for value, label in ((1.5, "float"), ({}, "dict"), ([], "list"), (b"x", "bytes")):
+            report = mod.probe_placeholders(value, {"input": "a"}, ".")
+            self.assertFalse(report["ok"])
+            self.assertIn(label, report["error"])
+
+
+class PublicSurfaceSmokeTests(unittest.TestCase):
+    """모든 공개 함수에 행복+예외 경로가 최소 한 번씩 닿는지."""
+
+    PUBLIC = (
+        "leftover_sub_names",
+        "extract_sub_names",
+        "is_exact_sub_token",
+        "resolve_placeholders",
+        "resolve_cmd",
+        "probe_placeholders",
+        "probe_cmd_placeholders",
+        "norm_scalar",
+        "json_ready",
+        "json_canonicalize",
+        "snapshot",
+        "probe_determinism",
+        "probe_determinism_n",
+        "classify_artifact",
+        "probe_missing_artifact",
+        "probe_artifacts",
+        "probe_live_oracle",
+        "envelope",
+        "structural_self_check",
+        "run_selftest",
+        "render_human",
+        "parse_args",
+        "run",
+        "main",
+    )
+
+    def test_all_public_names_exist_and_callable(self):
+        mod = load("gym_oracle_probe_surface")
+        for name in self.PUBLIC:
+            self.assertTrue(callable(getattr(mod, name)), name)
+
+    def test_required_exports_subset_of_public(self):
+        mod = load("gym_oracle_probe_req")
+        for name in mod.REQUIRED_EXPORTS:
+            self.assertIn(name, self.PUBLIC)
+
+    def test_constants(self):
+        mod = load("gym_oracle_probe_const")
+        self.assertEqual(mod.KIND, "gymOracleProbe")
+        self.assertEqual(mod.SCHEMA_VERSION, "1.0")
+        self.assertEqual(mod.INPUT_TOKEN, "{input}")
+        self.assertEqual(mod.SUB_MARK, "{sub:")
+
+
+class UnicodeAndPayloadExceptionTests(unittest.TestCase):
+    def test_unicode_placeholder_names(self):
+        mod = load("gym_oracle_probe_uni_ph")
+        with tempfile.TemporaryDirectory() as sub_dir:
+            token = "{sub:한글 문서.hwp}"
+            report = mod.probe_placeholders(token, {"input": "in.hwp"}, sub_dir)
+            self.assertTrue(report["ok"], report)
+            self.assertIn("한글 문서.hwp", report["resolved"])
+
+    def test_unicode_compute_payload(self):
+        mod = load("gym_oracle_probe_uni_det")
+        payload = {"제목": "국립국어원", "emoji": "🧪", "zwj": "가\u200d나"}
+        report = mod.probe_determinism(lambda: payload)
+        self.assertTrue(report["ok"])
+        self.assertIn("국립국어원", report["canonicalFirst"])
+
+    def test_surrogate_roundtrip_stays_string(self):
+        mod = load("gym_oracle_probe_surr")
+        text = "ok \ud800"
+        # json.dumps may reject lone surrogates depending on python; catch either.
+        try:
+            canon = mod.json_canonicalize(text)
+        except (TypeError, ValueError, UnicodeEncodeError):
+            return
+        self.assertTrue(isinstance(canon, str))
+
+    def test_deeply_nested_payload(self):
+        mod = load("gym_oracle_probe_deep")
+        cur = {"v": 0}
+        for i in range(30):
+            cur = {"c": cur, "i": i}
+        report = mod.probe_determinism(lambda: cur)
+        self.assertTrue(report["ok"], report)
+
+    def test_empty_input_compute_none(self):
+        mod = load("gym_oracle_probe_none_val")
+        report = mod.probe_determinism(lambda: None)
+        self.assertTrue(report["ok"])
+        self.assertIsNone(report["first"])
+        self.assertEqual(report["canonicalFirst"], "null")
+
+
+class ErrorEnvelopeContractTests(unittest.TestCase):
+    def test_placeholder_error_keys(self):
+        mod = load("gym_oracle_probe_err_keys_ph")
+        report = mod.probe_placeholders(object(), {}, ".")
+        for key in ("ok", "token", "resolved", "leftover", "names", "error"):
+            self.assertIn(key, report)
+        self.assertFalse(report["ok"])
+
+    def test_determinism_error_keys(self):
+        mod = load("gym_oracle_probe_err_keys_det")
+        report = mod.probe_determinism(lambda: 1 / 0)
+        for key in ("ok", "equal", "runs", "first", "second", "error", "errors"):
+            self.assertIn(key, report)
+
+    def test_artifact_error_keys_invalid(self):
+        mod = load("gym_oracle_probe_err_keys_art")
+        report = mod.probe_missing_artifact(None)
+        for key in ("ok", "present", "status", "path", "error"):
+            self.assertIn(key, report)
+
+    def test_n_error_keys(self):
+        mod = load("gym_oracle_probe_err_keys_n")
+        report = mod.probe_determinism_n(lambda: 1, 0)
+        for key in ("ok", "equal", "runs", "error"):
+            self.assertIn(key, report)
+
+    def test_cmd_error_keys(self):
+        mod = load("gym_oracle_probe_err_keys_cmd")
+        report = mod.probe_cmd_placeholders(None, {}, ".")
+        for key in ("ok", "tokens", "error"):
+            self.assertIn(key, report)
+
+    def test_absence_never_sets_ok_true(self):
+        mod = load("gym_oracle_probe_abs_never")
+        for path in (None, "", 1, os.path.join(tempfile.gettempdir(), "no-such-rhwp-op")):
+            report = mod.probe_missing_artifact(path)
+            self.assertIs(report["ok"], False, path)
+            self.assertIs(report["present"], False, path)
+
+
+class NumericEdgeTests(unittest.TestCase):
+    def test_bool_not_equal_to_one_after_ready(self):
+        mod = load("gym_oracle_probe_bool_one")
+        # Python 에서 True == 1.0 이지만 JSON 정규화 문자열은 갈라진다.
+        self.assertIsInstance(mod.json_ready(True), bool)
+        self.assertIsInstance(mod.json_ready(1), float)
+        self.assertEqual(mod.json_canonicalize(True), "true")
+        self.assertEqual(mod.json_canonicalize(1), "1.0")
+
+    def test_negative_zero_collapses(self):
+        mod = load("gym_oracle_probe_neg0")
+        # JSON 1.0 과 -0.0 은 같게 보일 수 있다.
+        self.assertEqual(mod.json_ready(0.0), 0.0)
+        self.assertEqual(mod.json_ready(-0.0), 0.0)
+
+    def test_large_int_stays_finite(self):
+        mod = load("gym_oracle_probe_bigint")
+        n = 10**18
+        self.assertEqual(mod.json_ready(n), float(n))
+
+    def test_math_nan_same_as_float_nan(self):
+        mod = load("gym_oracle_probe_mathnan")
+        self.assertIsNone(mod.norm_scalar(math.nan))
+        self.assertIsNone(mod.norm_scalar(math.inf))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 변경 요약

채점은 정답을 박제하지 않고 채점 시점에 rhwp로 재계산한다. 그 라이브 오라클이 두 번 돌려도 같은지, {input}과 한 문자열의 여러 {sub:이름}이 기준 풀이와 같이 치환되는지, 산출물이 없으면 통과로 위장하지 않는지를 독립 도구로 감사한다.

gym/tools/oracle_probe.py를 추가한다. 새 CLI 바이너리는 없다.

- 
esolve_placeholders — uild_baseline.resolve와 같은 {input}·다중 {sub:} 규칙. uild_baseline을 import하지 않아 구조 자기점검에 부수효과가 없다. 테스트가 양쪽 출력을 대조한다.
- probe_determinism(compute_fn) — 두 번 계산한 뒤 JSON 정규화(키 정렬·숫자 문자열)로 등호를 본다.
- probe_placeholders(token, task, sub_dir) — 남은 {sub:}가 있으면 실패.
- probe_missing_artifact(path) — 부재·디렉터리·빈 경로는 ok=false이며 통과로 위장하지 않는다.
- --json — 팩 픽스처 없는 구조 자기점검. --selftest — 내장 프로브.
- 봉투: kind=gymOracleProbe, schemaVersion=1.0

## 관련 이슈

closes #5207

## 테스트

- [x] python -m unittest scripts/tests/test_gym_oracle_probe.py 13건 통과 (다중 자리표·결정성 실패·부재 파일·--json/--selftest 봉투)
- [x] python gym/tools/audit.py — 18 pack 전부 통과
- [x] python gym/tools/oracle_probe.py --json / --selftest 통과
- [x] git diff --check 통과
- [ ] **cargo fmt --all -- --check 통과** — 이번 변경은 Python/workflow만. Rust crate를 건드리지 않아 생략 (sparse checkout)
- [ ] 
ode scripts/rust-test-suite-manifest.mjs --check — 생략 (동일)
- [ ] 
ode scripts/rust-unit-test-tiers.mjs --check — 생략 (동일)
- [ ] cargo test — 해당 없음
- [ ] cargo clippy -- -D warnings — 해당 없음
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 — 해당 없음
- [x] --json 봉투 원문: kind=gymOracleProbe, schemaVersion=1.0, 구조 자기점검 ok=true (부재 산출물 프로브 자체는 ok=false/status=absent)
- [ ] .claude/agents/ 등 capability 카탈로그 — 해당 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (순수 Python 감사 도구, 채점 경로를 바꾸지 않음)
- 재현·측정: 미측정

## 스크린샷

해당 없음
