### PR TITLE
feat(gym): robustness 결정적 손상 변형 확대 (#5218)

### DIFF
--- a/gym/docs/robustness.md
+++ b/gym/docs/robustness.md
@@ -1,0 +1,470 @@
+---
+kind: guide
+status: active
+canonical: gym/docs/robustness.md
+last_verified: 2026-08-18
+---
+
+# gym 손상-강건성 감사 규약
+
+이 문서는 `gym/tools/robustness.py` 의 **결정적 손상 카탈로그**와 **예외 경로
+계약**을 고정한다. 운영 한 줄 요약은
+[`gym/tools/README_robustness.md`](../tools/README_robustness.md) 를, 작업 기록은
+[`mydocs/working/gym_robustness.md`](../../mydocs/working/gym_robustness.md) 를 본다.
+시험 계약은 `scripts/tests/test_gym_robustness.py` 가 기계로 고정한다.
+
+`fuzz_corpus.py` 는 발견 엔진이다. 이 도구는 릴리스 **게이트**다. 무작위가 없고,
+같은 입력은 같은 라벨·바이트를 낸다. 원본과 바이트가 같은 무의미 변형은 버린다.
+
+## 1. 왜 이 기둥이 필요한가
+
+gym 의 앞 두 기둥은 과제의 채점을 지킨다.
+
+| 기둥 | 도구 | 질문 |
+|---|---|---|
+| 종점 무결성 | `discriminate.py` (#4808) | 일 안 한 제출이 만점을 받나? |
+| 경로 무결성 | `trajectory.py` (#4810) | 마지막 스텝을 빼도 통과하나? |
+| 도구 강건성 | `robustness.py` (#4814 / #5218) | 손상 입력에 rhwp 가 패닉·행 하나? |
+
+에이전트가 아무리 유능해도, 도구가 손상 문서에 죽으면 과제를 끝내지 못한다.
+2026 프론티어(AgentHijack 등)가 환경 손상을 재는 이유와 같다. 벤치마크가 자기
+도구의 적대적 강건성을 CI 로 인증하지 않으면, 능력 점수는 도구 수명의 상한선을
+숨긴다.
+
+이 감사기는 그 상한선을 **숫자로** 드러낸다.
+
+- 패닉(exit 101 · 시그널/음수 코드 · `panicked` · 스택 오버플로) → 실패.
+- 행(`TimeoutExpired` / timeout 표식) → 실패.
+- 깨끗한 비-0 실패 · 경고 후 부분복구 · 정상 파싱 → 우아함(정상).
+
+감사기 자신도 예외 경로에서 죽지 않는다. 읽을 수 없는 샘플, 빈/극소/거대 입력,
+바이트가 아닌 입력, 프로브 시간초과·OS 오류는 분류해 보고하고 중단하지 않는다.
+
+## 2. 사용
+
+```bash
+python gym/tools/robustness.py --bin target/debug/rhwp
+python gym/tools/robustness.py --bin target/debug/rhwp --limit 40
+python gym/tools/robustness.py --bin target/debug/rhwp --json
+```
+
+| 인자 | 기본 | 의미 |
+|---|---|---|
+| `--bin` | (필수) | rhwp 바이너리. `gym.core.runner.find_bin` 으로 해석한다. |
+| `--limit` | 16 | 정렬된 `.hwp` 를 결정적 stride 로 뽑는 표본 수. |
+| `--timeout` | 20 | 프로브 초. 비양수는 CLI 가 거절한다. |
+| `--json` | off | `gymRobustness` 봉투를 stdout 에 쓴다. |
+
+프로브 명령은 항상 `rhwp info <mutant> --json` 이다. 편집·렌더 명령은 이 게이트의
+범위가 아니다. 발견 엔진이 그 축을 담당한다.
+
+종료 코드:
+
+| exit | 의미 |
+|---|---|
+| 0 | 패닉 0 · 행 0. 읽기실패·프로브오류는 ok 를 뒤집지 않는다. |
+| 1 | 패닉 또는 행이 하나라도 있다. |
+| 2 | 바이너리를 찾지 못했다. |
+
+## 3. JSON 봉투
+
+`kind=gymRobustness`, `schemaVersion=1.0`. 키 집합은 시험이 `REPORT_KEYS` 로 고정한다.
+
+| 키 | 형 | 의미 |
+|---|---|---|
+| `kind` | str | 항상 `gymRobustness` |
+| `schemaVersion` | str | 항상 `1.0` |
+| `ok` | bool | `panics` 와 `hangs` 가 모두 비어 있을 때만 true |
+| `samplesTested` | int | 실제로 고른 표본 수 |
+| `totalSamples` | int | 디렉터리의 `.hwp` 총수 |
+| `mutantsChecked` | int | 프로브까지 도달한 변형 수 |
+| `gracefullyDegraded` | int | 비-0 이면서 패닉·행이 아닌 프로브 수 |
+| `panics` | list[str] | `이름:라벨 (code N): 머리` |
+| `hangs` | list[str] | `이름:라벨` |
+| `unreadables` | list[str] | 읽기/형태/변형 생성 실패 |
+| `probeErrors` | list[str] | 쓰기 실패·OS 오류·프로브 예외 |
+| `inputShapes` | object | `empty`/`tiny`/`normal`/`huge` 카운트 |
+
+`ok` 는 패닉·행만 본다. 읽기실패와 프로브오류는 **감사기 생존** 신호이지 rhwp
+강건성 실패가 아니다. 바이너리가 없어도 감사기가 죽으면 게이트가 거짓 음성을
+낸다.
+
+`validate_report()` 가 이 계약을 다시 검사한다. 키가 빠지거나 `ok` 가 패닉·행과
+어긋나면 위반 목록을 돌려준다.
+
+## 4. 입력 형태
+
+위치 기반 변형은 입력 길이에 따라 다르게 동작한다. 감사기는 표본을 네 형태로
+접어 `inputShapes` 에 남긴다.
+
+| 형태 | 조건 | 변형 동작 |
+|---|---|---|
+| `empty` | `n==0` | `empty-to-nul` 한 건만. 위치 기반 변형 없음. |
+| `tiny` | `1 <= n <= 64` | 위치 기반은 가능하나 일부는 원본과 같아 버려진다. OLE 꼬리는 잘린 매직을 심는다. |
+| `normal` | `65 <= n < 1MiB` | 전체 카탈로그. 크기 증가 변형 포함. |
+| `huge` | `n >= 1MiB` | 크기 증가 변형(`splice-*`, `pad-eof`, `widen-gap`, `even-length-pad`)을 생략한다. |
+
+형태 분류는 `classify_input_shape()` 가 맡는다. 비-바이트는 `TypeError` 다.
+감사기는 그 예외를 `unreadables` 로 접고 다음 표본으로 간다.
+
+## 5. 결정성 규칙
+
+1. 입력은 bytes-like 만 받는다. `str`/`int`/`None` 을 조용히 인코딩하지 않는다.
+2. 같은 바이트열은 같은 `(라벨, 바이트)` 순서를 낸다. 난수·시각· entroy 없음.
+3. `add()` 는 `mut == data` 이면 버린다. 무의미 변형이 프로브 예산을 먹지 않는다.
+4. 라벨은 가족 안에서 유일하다. 같은 바이트가 나와도 라벨이 다르면 둘 다 남긴다
+   (예: 1바이트 입력의 `flip@10%` 와 `flip@90%`).
+5. 조건부 가족(ZIP/HWP3)은 매직이 있을 때만 켠다. 없을 때는 inject 쪽이 켜진다.
+6. 거대 입력은 크기 증가 변형을 건너뛴다. 게이트는 헤더/절단만으로 충분하다.
+
+표본 선택은 파일명을 정렬한 뒤 stride 로 `limit` 개를 뽑는다. `.txt` 등 비-hwp 는
+제외한다. 디렉터리를 읽을 수 없으면 빈 목록을 돌려 감사기가 죽지 않게 한다.
+
+## 6. 분류기
+
+### 6.1 패닉
+
+`classify_panic(code, err)` = `is_panic(code, err)`.
+
+패닉으로 본다:
+
+- 출력(소문자)에 다음 표식이 있을 때: `panicked`, `stack overflow`, `core dumped`,
+  `fatal runtime error`, `sigsegv`, `sigabrt`, `sigill`, `sigbus`,
+  `access violation`, `segmentation fault`, `illegal instruction`, `abort trap`.
+- `code == 101` (Rust abort).
+- `code < 0` (POSIX 시그널 종료).
+- `code >= 0` 이고 상위 두 비트가 `0xC0000000` (Windows NTSTATUS 예외).
+
+패닉이 아니다:
+
+- `code is None` 이고 표식이 없을 때.
+- `code` 가 int 로 변환되지 않을 때.
+- `1`·`255` 같은 일반 CLI 오류 코드. 깨끗한 실패를 패닉으로 오판하지 않는다.
+
+시그널 종료(`-9`, `-24`, `-30`)는 **패닉 쪽**이다. 일부 환경은 시간초과를
+SIGKILL 로 돌려주지만, 이 게이트는 `TimeoutExpired` 만을 행의 권위로 둔다.
+시그널을 행으로 접으면 실제 크래시가 행으로 위장된다.
+
+### 6.2 행
+
+`classify_timeout(timed_out)` 이 true 일 때만 행이다.
+
+- `True`
+- `subprocess.TimeoutExpired`
+- `TimeoutError`
+- `OSError` 이면서 `errno` 가 `ETIMEDOUT` 또는 `ETIME`
+- 소문자 표식: `timeout`, `timed out`, `time-out`, `time expired`, `deadline exceeded`
+
+`False`/`None`/그 외 예외/`ValueError("timeout in name only")` 는 행이 아니다.
+
+### 6.3 프로브 접기
+
+`classify_probe_outcome(code, panicked, timed_out, head)`:
+
+| 결과 | 조건 | 보고 |
+|---|---|---|
+| `hang` | timeout 분류가 true | `hangs` |
+| `panic` | 패닉 분류 또는 `panicked` 플래그 | `panics` |
+| `error` | 머리가 `oserror `/`probe-error `/`unreadable ` 로 시작 | `probeErrors` |
+| `graceful` | `code not in (0, None)` | `gracefullyDegraded += 1` |
+| `ok` | `code == 0` | 카운트만 |
+| `error` | 그 외(`code is None` 이고 표식 없음) | `probeErrors` |
+
+우선순위는 행 > 패닉 > 오류머리 > 우아함 > 정상 이다. 행과 패닉이 동시에 오면
+행이 이긴다. 프로브가 timeout 을 이미 선언했기 때문이다.
+
+## 7. 예외 경로 — 감사기가 죽지 않는 계약
+
+감사기 자신이 예외로 죽으면 게이트는 "도구가 강건하다"는 거짓 음성을 못 내고,
+반대로 CI 가 붉어져 강건성 결함과 하네스 결함을 구분할 수 없다. 그래서 모든
+I/O·형식·프로브 경로는 분류 가능한 문자열로 접힌다.
+
+| 경로 | 함수 | 접는 곳 | 보고 키 |
+|---|---|---|---|
+| 비-바이트 입력 | `coerce_bytes` | `TypeError` | 호출 측. 감사는 `unreadables` |
+| 형태 분류 실패 | `classify_input_shape` | `TypeError` | `unreadables` |
+| 한도/초 변환 실패 | `normalize_limit` / `normalize_timeout` | 0 | 표본 없음 / 프로브 거절 |
+| 디렉터리 읽기 실패 | `select_samples` | `[] , 0` | 빈 보고 |
+| 표본 읽기 실패 | `read_sample` | `(None, 이유)` | `unreadables` |
+| 변형 생성 `TypeError` | `deterministic_mutants` | 감사 루프 | `unreadables` |
+| 변형 쓰기 실패 | `write_mutant` | 이유 문자열 | `probeErrors` |
+| timeout <= 0 | `probe` | `probe-error invalid-timeout` | `probeErrors` |
+| 빈 바이너리 경로 | `probe` | `probe-error missing-bin` | `probeErrors` |
+| `TimeoutExpired` | `probe` | `timed_out=True` | `hangs` |
+| `OSError` (없는 바이너리) | `probe` | `oserror …` | `probeErrors` |
+| 그 외 프로브 예외 | `probe` | `probe-error …` | `probeErrors` |
+| 임시 디렉터리 실패 | `audit` | 이유 문자열 | `probeErrors` |
+| `select_samples` 폭주 | `audit` | 이유 문자열 | `unreadables` |
+| 바이너리 탐색 실패 | `main` | stderr + exit 2 | (보고 없음) |
+
+`read_sample` / `write_mutant` / `probe` / `audit` / `main` 은 맨 바깥에서
+`Exception` 을 삼킨다. `# noqa: BLE001` 주석이 "감사기 생존이 우선"임을 남긴다.
+삼킨 예외는 메시지로 남기므로 침묵 삼킴이 아니다.
+
+시험은 이 표의 각 칸을 목킹으로 고정한다. 바이너리 없이 돌아간다.
+
+## 8. 변형 카탈로그
+
+카탈로그는 `MUTANT_CATALOG` 다. `mutant_catalog()` 가 사본을 돌려 시험·문서가
+같은 표를 본다. 무작위 필드가 없다.
+
+아래 표의 `when` 은 생성 조건이다. 조건이 맞아도 원본과 바이트가 같으면
+`add()` 가 버린다.
+
+### 8.1 empty
+
+| id | when | 하는 일 |
+|---|---|---|
+| `empty-to-nul` | `n==0` | NUL 한 바이트. 빈 입력의 유일한 변형. |
+
+### 8.2 truncate
+
+| id | when | 하는 일 |
+|---|---|---|
+| `truncate@P%` | `n>0` | 앞 `max(1, n*P/100)` 바이트만 남긴다. P ∈ {10,25,50,75,95,99} |
+| `chop-last` | `n>=2` | 마지막 1바이트를 자른다. 오프바이원 레코드 끝. |
+| `cut-first` | `n>=1` | 선두 1바이트를 버린다. 매직이 한 칸 밀린 파일. |
+| `odd-length-chop` | 짝수이고 `n>=2` | 짝수 길이를 홀수로 만들어 UTF-16 워드 정렬을 깨뜨린다. |
+| `shrink-gap` | `n>=8` | 1/4 지점의 4바이트를 삭제해 뒤 레코드를 당긴다. |
+
+잘린 OLE/ZIP 은 중앙 디렉터리·FAT 가 없는 복합문서를 재현한다. 첫 주행이 잡은
+HWP3 line-spacing 패닉도 짧은 본문에서 터졌다.
+
+### 8.3 flip
+
+| id | when | 하는 일 |
+|---|---|---|
+| `flip@P%` | `n>0` | 위치 `min(n-1, n*P/100)` 한 바이트를 XOR 0xFF. P ∈ {0,10,25,50,75,90,99} |
+
+가장자리(`0%`, `99%`)는 퍼센트 위치와 겹치지 않을 수 있다. 1바이트 입력에서는
+모든 플립이 같은 바이트를 건드리지만 라벨은 남는다.
+
+### 8.4 header
+
+| id | when | 하는 일 |
+|---|---|---|
+| `zero-header` | `n>0` | 선두 최대 512바이트를 0 으로 지운다. |
+| `header-smash` | `n>0` | 선두 최대 64바이트를 `DEADBEEF` 반복으로 덮는다. |
+| `rotate-header` | `n>=2` | 선두 8바이트를 한 칸 왼쪽 순환. |
+| `increment-header` | `n>0` | 선두 8바이트에 1 을 더한다(랩어라운드). |
+| `nibble-swap-head` | `n>0` | 선두 32바이트의 니블을 맞바꾼다. |
+
+`zero-header` 와 `header-smash` 를 나눈 이유: 매직이 없는 것과 매직이 다른
+손상인 것을 구분해야 파서의 형식 판별 분기를 따로 두드릴 수 있다.
+
+### 8.5 ole
+
+| id | when | 하는 일 |
+|---|---|---|
+| `ole-trunc-tail` | `n>64` | 꼬리 64바이트를 자른다. CFB 디렉터리/FAT 가 잘린 복합문서. |
+| `ole-trunc-tail` | `n<=64` | 꼬리 `k` 바이트를 잘린 OLE 매직으로 바꾼다. |
+| `ole-magic-poison` | `n>0` | 선두에 OLE 매직 XOR 0xFF 를 덮는다. |
+| `ole-sector-shift-poison` | `n>=32` | 오프셋 30 의 섹터 시프트를 `0xFFFF` 로. 거대 섹터 할당 유도. |
+| `ole-mini-fat-poison` | `n>=72` | 오프셋 60 의 MiniFAT 시작 섹터를 `0xFFFFFFFF` 로. |
+
+HWP5 는 CFB(OLE) 다. 섹터 시프트와 MiniFAT 는 할당 폭주·무한 루프의 고전 위치다.
+
+### 8.6 run
+
+| id | when | 하는 일 |
+|---|---|---|
+| `ff-run` | `n>0` | 1/3 지점에 최대 128바이트의 `0xFF` 런. |
+| `aa-run` | `n>0` | 선두 1/4 에 `0xAA` 런. |
+| `nul-mid` | `n>0` | 한가운데 최대 64바이트를 NUL. UTF-16 종료 위조. |
+| `00-run` | `n>0` | 2/3 지점에 NUL 런. 레코드 조기 종료. |
+| `55-run` | `n>0` | 선두 1/5 에 `0x55` 런. |
+
+런 패턴을 나눈 이유: `0xFF` 는 부호 없는 포화, `0x00` 은 종료, `0xAA`/`0x55` 는
+교차 비트다. 한 패턴만 보면 파서의 다른 정수 해석을 놓친다.
+
+### 8.7 unicode
+
+| id | when | 하는 일 |
+|---|---|---|
+| `utf16-nul-sprinkle` | `n>=2` | 20/40/60/80% 짝수 오프셋에 U+0000. |
+| `utf16-bom-inject` | `n>=2` | 선두에 UTF-16LE BOM(`FF FE`). |
+| `utf8-overlong` | `n>=2` | 1/5 지점에 overlong NUL(`C0 80`). |
+| `ascii-ctrl-sprinkle` | `n>0` | 15/35/55/75% 에 SOH(0x01). |
+| `path-sep-sprinkle` | `n>0` | 18/42/66/88% 에 `/` 와 `\\` 를 교차. |
+
+HWP 본문은 UTF-16LE 가 기본이다. NUL 뿌림은 문자열 절단을, BOM 은 인코딩 오인을,
+overlong 은 UTF-8 검증을, 경로 구분자는 스트림 이름 해석을 두드린다.
+
+### 8.8 zip
+
+| id | when | 하는 일 |
+|---|---|---|
+| `zip-local-header-flip` | `PK\\x03\\x04` 존재 | 그 4바이트만 XOR 0xFF. |
+| `zip-magic-inject` | 로컬 헤더 없음, `n>=4` | 선두에 로컬 헤더 매직을 심는다. |
+| `zip-cd-magic-flip` | `PK\\x01\\x02` 존재 | 중앙 디렉터리 매직만 플립. |
+| `zip-eocd-flip` | `PK\\x05\\x06` 존재 | EOCD 매직만 플립. |
+
+HWPX 는 ZIP 이다. 로컬 헤더·중앙 디렉터리·EOCD 를 따로 두드려야 아카이브
+탐색의 세 입구를 모두 본다. inject 는 비-ZIP(HWP5) 을 ZIP 으로 오인하게 한다.
+
+### 8.9 length
+
+| id | when | 하는 일 |
+|---|---|---|
+| `length-bomb@P%` | `n>=4` | 위치에 `0x7FFFFFFF` (u32 LE). P ∈ {10,40,70} |
+| `length-zero@30%` | `n>=4` | `0x00000000`. 빈 레코드 조기 종료. |
+| `length-one@60%` | `n>=4` | `0x00000001`. 오프바이원 슬라이스. |
+| `i32-min@20%` | `n>=4` | `0x80000000`. 음수 길이. |
+| `u16-max@12` | `n>=14` | 오프셋 12 의 u16 을 `0xFFFF`. |
+
+길이 필드는 할당 폭주와 정수 오버플로의 입구다. 양수 포화·0·1·음수 최소를
+모두 심어야 파서의 범위 검사가 한 갈래만 통과하는 일을 막는다.
+
+### 8.10 permute
+
+| id | when | 하는 일 |
+|---|---|---|
+| `reverse-prefix` | `n>=2` | 선두 16바이트를 뒤집는다. |
+| `swap-ends` | `n>=16` | 선두 8과 꼬리 8을 맞바꾼다. |
+| `slide-window-left` | `n>=8` | 선두 32바이트를 한 바이트 왼쪽. |
+| `slide-window-right` | `n>=8` | 선두 32바이트를 한 바이트 오른쪽. |
+| `repeat-mid-block` | `n>=32` | 한가운데 32바이트를 바로 앞에 복사. |
+
+매직 순서와 필드 정렬을 깨뜨린다. 바이트 값 오염(flip/run)과 다른 축이다.
+
+### 8.11 stripe
+
+| id | when | 하는 일 |
+|---|---|---|
+| `high-bit-stripe` | `n>0` | 16바이트마다 상위 비트. |
+| `low-bit-stripe` | `n>0` | 16바이트마다 최하위 비트 반전. |
+| `xor-stride7` | `n>0` | 7바이트마다 `0xA5` XOR. |
+| `interleave-zero-head` | `n>0` | 선두 32의 홀수 인덱스를 0. |
+| `duplicate-prefix` | `n>=16` | 선두 8을 바로 다음에 복제. |
+| `tail-over-head` | `n>=32` | 꼬리 16을 선두에 덮음. |
+| `invert-tail-64` | `n>0` | 꼬리 최대 64바이트 비트 반전. |
+| `complement-mid-32` | `n>0` | 한가운데 최대 32바이트 비트 반전. |
+| `bit-rotate-head` | `n>0` | 선두 16바이트를 1비트 왼쪽 회전. |
+| `decrement-tail` | `n>0` | 꼬리 8바이트에서 1 을 뺌. |
+
+스트라이프는 "드문드문" 오염이다. 한 필드만 건드리는 flip 과, 구간을 덮는 run
+사이에 있다. 체크섬·정렬·플래그 비트를 흔든다.
+
+### 8.12 splice
+
+크기 증가 변형. `n >= 1MiB` 이면 전부 생략한다.
+
+| id | when | 하는 일 |
+|---|---|---|
+| `splice-nul-mid` | 거대 아님 | 한가운데에 NUL 16바이트. |
+| `crlf-inject` | 거대 아님 | 한가운데에 CRLF. |
+| `pad-eof` | 거대 아님 | 끝에 SUB(0x1A). 구식 EOF. |
+| `widen-gap` | 거대 아님 | 1/4 지점에 NUL 4바이트. |
+| `even-length-pad` | 홀수이고 거대 아님 | NUL 하나를 붙여 짝수로. |
+
+끼워 넣기는 뒤 레코드의 오프셋을 민다. 절단이 "없는 바이트"를 재현한다면,
+splice 는 "있으면 안 되는 바이트"를 재현한다.
+
+### 8.13 hwp3
+
+| id | when | 하는 일 |
+|---|---|---|
+| `hwp3-sig-flip` | `HWP Document File` 존재 | 서명 첫 4바이트 XOR 0xFF. |
+| `hwp3-sig-inject` | 서명 없고 `n` 이 서명보다 김 | 선두에 HWP3 서명을 심음. |
+
+HWP3 파서는 HWP5/OLE 와 다른 입구다. 첫 강건성 주행이 잡은 DoS 2건이 이
+입구였다. 서명을 뒤집거나 심어 형식 판별 분기를 따로 두드린다.
+
+## 9. 정상 2KiB 입력에서 항상 나오는 라벨
+
+시험이 `ALWAYS_LABELS` 와 `EXPANDED_ALWAYS_LABELS` 로 고정한다. 2KiB
+(`bytes(range(256))*8`) 는 ZIP/HWP3 서명이 없고 짝수이며 거대하지 않다.
+
+기본(기존 게이트와 호환):
+
+- `truncate@25%` `truncate@50%` `truncate@75%` `truncate@95%`
+- `flip@10%` `flip@50%` `flip@90%`
+- `zero-header` `header-smash` `ole-trunc-tail` `ff-run` `utf16-nul-sprinkle`
+
+확대:
+
+- 절단/플립 가장자리, `chop-last`, `cut-first`, `odd-length-chop`, `shrink-gap`
+- 런 가족 전부, OLE poison, ZIP inject, 길이 폭탄 전부
+- permute/stripe 가족, unicode 주입, splice 가족
+- `hwp3-sig-inject`
+
+나오지 않아야 하는 것: `zip-local-header-flip`, `zip-cd-magic-flip`,
+`zip-eocd-flip`, `hwp3-sig-flip`, `empty-to-nul`, `even-length-pad`.
+
+## 10. 새 변형을 넣는 절차
+
+1. `MUTANT_CATALOG` 에 `id`/`family`/`when`/`why` 를 한 줄로 적는다. 무작위
+   파라미터가 있으면 넣지 않는다.
+2. `deterministic_mutants()` 에 같은 라벨로 `add()` 한다. 거대 입력에서 크기가
+   늘면 `huge` 가드를 건다.
+3. `mutant_family()` 에 라벨 → 가족 접기를 추가한다.
+4. 정상 2KiB 에서 항상 나오면 `EXPANDED_ALWAYS_LABELS` 에 넣는다. 조건부이면
+   시험에 "있을 때/없을 때" 쌍을 넣는다.
+5. `scripts/tests/test_gym_robustness.py` 에 바이트 계약(어느 오프셋이 어떤
+   상수인가)을 한 건 이상 적는다.
+6. 이 문서의 해당 가족 표를 같은 커밋에서 고친다.
+
+packs·checks·coverage·다른 도구는 건드리지 않는다. 이 기둥은 감사기 한 파일과
+그 시험·문서만 키운다.
+
+## 11. 발견 엔진과의 분업
+
+| | `robustness.py` | `fuzz_corpus.py` |
+|---|---|---|
+| 역할 | 릴리스 게이트 | 발견 엔진 |
+| 범위 | 결정적 부분집합 | 전 코퍼스 × 다명령 |
+| 난수 | 없음 | 없음(결정적)이되 조합이 넓다 |
+| 산출 | 패닉·행 0 인가 | file:line 클러스터 |
+| 실패 | 회귀 | 아직 안 고친 DoS 목록 |
+
+발견이 고유 버그를 내면 고치고, 이 게이트가 그 회귀를 막는다. 게이트를
+exhaustive 로 키우면 CI 예산이 발견 엔진과 겹친다. 그래서 거대 입력의 splice
+를 생략하고 표본을 stride 로 묶는다.
+
+## 12. 시험 지도
+
+`python -m unittest scripts.tests.test_gym_robustness scripts.tests.test_gym_audit`
+
+| 클래스 | 고정하는 것 |
+|---|---|
+| `RobustnessTests` | 기존 게이트: 결정성, 기본 라벨, 패닉/행, JSON 봉투 |
+| `ExpandedMutantContractTests` | 확대 가족·바이트 계약·조건부 ZIP/HWP3·거대 생략 |
+| `ExceptionPathTests` | coerce/normalize/probe/audit 의 모든 예외 접기 |
+| `ShapeAndSelectEdgeTests` | stride, 형태 카운트, 빈 디렉터리, 상수 계약 |
+
+바이너리 없이 돈다. `probe` 는 목킹한다. 실제 `subprocess.run` 을 쓰는 시험은
+없는 바이너리의 `OSError` 와 timeout/예외 목킹뿐이다.
+
+`test_gym_audit` 는 전 pack 정합을 지킨다. 이번 변경은 pack 을 건드리지 않으므로
+그대로 초록이어야 한다.
+
+## 13. 사람이 읽는 출력
+
+성공:
+
+```text
+gym 손상-강건성 감사: 샘플 16/N × 손상 M건 — 패닉 0 · 행 0
+(우아한 실패/부분복구 G · 읽기실패 U · 프로브오류 P)
+```
+
+실패:
+
+```text
+gym 손상-강건성 감사: 패닉 A · 행 B — rhwp 가 손상 입력에 죽는다:
+  - sample.hwp:ff-run (code 101): thread 'main' panicked ...
+  - sample.hwp:truncate@50%
+```
+
+JSON 모드는 같은 봉투를 들여쓴다. 기계는 `ok` 와 두 리스트만 보면 된다.
+
+## 14. 하지 않는 것
+
+- 난수 변형. 재현이 안 되면 게이트가 아니다.
+- 편집·렌더 명령 프로브. 발견 엔진의 몫.
+- pack/과제 변경. 채점 기둥과 섞지 않는다.
+- 읽기실패를 `ok=false` 로 뒤집기. 그건 환경 결함이다.
+- 시그널 종료를 행으로 접기. 크래시 위장이다.
+- 거대 입력에 바이트를 끼워 사본을 키우기. CI 예산을 먹는다.
+
+이 문서가 코드와 다르면 코드와 시험을 이긴다. 문서만 고치고 시험을 안 고치면
+계약이 아니다.

--- a/gym/tools/README_robustness.md
+++ b/gym/tools/README_robustness.md
@@ -1,0 +1,168 @@
+---
+kind: guide
+status: active
+canonical: gym/tools/README_robustness.md
+last_verified: 2026-08-18
+---
+
+# robustness.py — 운영 메모
+
+손상-강건성 감사기의 **한 페이지 운영 메모**다. 카탈로그·분류·예외 경로의 정본은
+[`gym/docs/robustness.md`](../docs/robustness.md) 다. 작업 기록은
+[`mydocs/working/gym_robustness.md`](../../mydocs/working/gym_robustness.md).
+
+## 30초
+
+```bash
+python gym/tools/robustness.py --bin target/debug/rhwp
+python gym/tools/robustness.py --bin target/debug/rhwp --limit 40 --json
+python -m unittest scripts.tests.test_gym_robustness scripts.tests.test_gym_audit
+```
+
+손상 문서를 **결정적으로** 만들어 `rhwp info --json` 으로 두드린다. 패닉·행이
+있으면 exit 1. 깨끗한 파싱 실패는 정상이다.
+
+## 언제 돌리나
+
+- rhwp 파서/정보 경로를 고친 뒤 회귀 확인.
+- 릴리스 게이트에서 "도구가 적대적 입력에 죽지 않는가"를 인증할 때.
+- 새 결정적 변형을 넣은 뒤, 시험만으로 부족한 실측이 필요할 때.
+
+돌리지 않는 때:
+
+- pack 채점·리더보드·트라젝토리. 다른 도구다.
+- 전 코퍼스 exhaustive 퍼징. `fuzz_corpus.py` 다.
+- 포맷 변경. 이번 도구는 Python 만 고친다.
+
+## 인자
+
+| 인자 | 기본 | 메모 |
+|---|---|---|
+| `--bin` | 필수 | `runner.find_bin` 이 상대/절대/이름 을 해석한다. |
+| `--limit` | 16 | `.hwp` 만. 정렬 후 stride. 음수/변환불능은 0건. |
+| `--timeout` | 20 | 초. CLI 는 양수만 받는다. 함수 `probe` 는 0 을 오류머리로 접는다. |
+| `--json` | off | 봉투를 stdout. 사람용 한 줄은 stderr 가 아니라 stdout. |
+
+표본 디렉터리는 저장소 `samples/` 고정이다. 다른 코퍼스를 넣으려면
+`audit(bin, samples_dir, limit, timeout)` 을 직접 부른다.
+
+## 종료 코드
+
+| 코드 | 언제 |
+|---|---|
+| 0 | 패닉 0 · 행 0 |
+| 1 | 패닉 또는 행 |
+| 2 | 바이너리를 찾지 못함 |
+
+읽기실패·프로브오류는 0 을 유지한다. 환경 결함을 도구 결함으로 위장하지 않는다.
+
+## 봉투에서 볼 키
+
+성공 판정: `ok`, `panics`, `hangs`.
+
+진단:
+
+- `mutantsChecked` — 프로브까지 간 변형 수. 0 이면 쓰기/프로브가 전부 접힌 것.
+- `gracefullyDegraded` — 우아한 실패. 클수록 파서가 손상에 깨끗이 거절한 것.
+- `unreadables` — 샘플을 못 읽었거나 변형 생성이 타입 오류.
+- `probeErrors` — 없는 바이너리, 디스크, invalid-timeout.
+- `inputShapes` — empty/tiny/normal/huge. 한 형태만 있으면 stride 가 편향된 것.
+
+`schemaVersion` 은 `1.0`. 키를 빼거나 더하면 `validate_report()` 가 위반을 낸다.
+
+## 기본 변형 (기존 게이트)
+
+정상 입력에서 항상:
+
+`truncate@25%` `truncate@50%` `truncate@75%` `truncate@95%`
+`flip@10%` `flip@50%` `flip@90%`
+`zero-header` `header-smash` `ole-trunc-tail` `ff-run` `utf16-nul-sprinkle`
+
+ZIP 로컬 헤더(`PK\x03\x04`)가 있을 때만 `zip-local-header-flip`.
+
+빈 입력은 `empty-to-nul` 한 건.
+
+## 확대 변형 (이번 가지)
+
+가족별로 한 줄:
+
+| 가족 | 라벨 예 | 한 줄 |
+|---|---|---|
+| truncate | `truncate@10%`, `chop-last`, `cut-first`, `odd-length-chop`, `shrink-gap` | 더 짧은 꼬리·선두 삭제·홀수 길이 |
+| flip | `flip@0%`, `flip@25%`, `flip@75%`, `flip@99%` | 가장자리와 사분면 |
+| header | `rotate-header`, `increment-header`, `nibble-swap-head` | 매직 순서·미세 오염 |
+| ole | `ole-magic-poison`, `ole-sector-shift-poison`, `ole-mini-fat-poison` | CFB 할당 입구 |
+| run | `aa-run`, `nul-mid`, `00-run`, `55-run` | 포화/종료/교차 비트 |
+| unicode | `utf16-bom-inject`, `utf8-overlong`, `ascii-ctrl-sprinkle`, `path-sep-sprinkle` | 인코딩·제어·경로 |
+| zip | `zip-magic-inject`, `zip-cd-magic-flip`, `zip-eocd-flip` | 세 아카이브 입구 |
+| length | `length-bomb@*`, `length-zero@30%`, `length-one@60%`, `i32-min@20%`, `u16-max@12` | 할당 폭주·음수 길이 |
+| permute | `reverse-prefix`, `swap-ends`, `slide-window-*`, `repeat-mid-block` | 필드 정렬 |
+| stripe | `high/low-bit-stripe`, `xor-stride7`, `invert-tail-64`, … | 드문드문 오염(하위 비트는 XOR) |
+| splice | `splice-nul-mid`, `crlf-inject`, `pad-eof`, `widen-gap`, `even-length-pad` | 끼워 넣기. 거대 입력 생략 |
+| hwp3 | `hwp3-sig-flip`, `hwp3-sig-inject` | HWP3 입구 |
+
+거대(`>= 1MiB`)에서는 splice 가족을 건너뛴다.
+
+## 예외 경로 — 운영자가 헷갈리는 것
+
+| 보이는 것 | 의미 | ok? |
+|---|---|---|
+| `unreadables: PermissionError` | 샘플을 못 읽음 | 유지(true) |
+| `probeErrors: oserror FileNotFoundError` | `--bin` 이 잘못됐거나 권한 | 유지 |
+| `probeErrors: probe-error invalid-timeout` | `audit(..., timeout=0)` 직접 호출 | 유지 |
+| `probeErrors: TypeError` (쓰기) | 변형이 바이트가 아님. 버그 | 유지, 도구 버그로 고친다 |
+| `panics: … panicked` | rhwp 가 죽음 | **false** |
+| `hangs: sample:label` | 프로브가 timeout | **false** |
+| exit 2 | `find_bin` 실패 | 보고 없음 |
+
+시그널 종료(`code < 0`)는 패닉이다. 행이 아니다.
+
+## 로컬에서 한 샘플만 보고 싶을 때
+
+모듈로 불러 변형만 본다. 바이너리 불필요.
+
+```python
+import importlib.util
+from pathlib import Path
+p = Path("gym/tools/robustness.py")
+spec = importlib.util.spec_from_file_location("r", p)
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+data = Path("samples/some.hwp").read_bytes()
+for label, mut in m.deterministic_mutants(data):
+    print(f"{label:24} {len(mut):8} {m.mutant_family(label)}")
+```
+
+감사 루프를 목킹하려면 `m.probe = lambda *a, **k: (1, False, False, "오류")` 후
+`m.audit("bin", "samples", 4, 5)`.
+
+## 시험
+
+```bash
+python -m unittest scripts.tests.test_gym_robustness
+python -m unittest scripts.tests.test_gym_audit
+```
+
+`RobustnessTests` 는 기존 게이트 호환. `ExpandedMutantContractTests` 는 확대
+바이트 계약. `ExceptionPathTests` 는 예외 접기. `ShapeAndSelectEdgeTests` 는
+stride 와 형태.
+
+`cargo fmt --all` 은 이 변경에 실행하지 않는다. Python 만 고친다.
+
+## 새 라벨을 넣을 때 최소 체크
+
+1. 라벨이 카탈로그 id 와 같거나 `id@파라미터` 형식인가.
+2. `mutant_family()` 가 `other` 로 떨어지지 않는가.
+3. 2KiB 픽스처에서 결정적이고 원본과 다른가.
+4. ZIP/HWP3 조건부가 반대 입력에서 꺼지는가.
+5. 거대 입력에서 크기가 늘지 않는가.
+6. `test_gym_robustness` 가 그 바이트를 한 줄이라도 고정하는가.
+
+자세한 표는 규약 문서 8절이다.
+
+## 관련
+
+- 이슈 #4814 (도구 강건성 기둥), #5218 (결정적 변형 확대)
+- PR 원본: 같은 가지 `feat/gym-robust-mutants`
+- 분업: `gym/tools/fuzz_corpus.py` 모듈 문자열
+- gym 개요의 해당 절: `gym/README.md` 「손상-강건성 감사」

--- a/gym/tools/robustness.py
+++ b/gym/tools/robustness.py
@@ -40,25 +40,70 @@ sys.path.insert(0, GYM_ROOT)
 
 from core import runner  # noqa: E402
 
+OLE_MAGIC = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
+ZIP_LOCAL = b"PK\x03\x04"
+HEADER_SMASH_PAT = b"\xde\xad\xbe\xef" * 16  # 64바이트 고정 패턴
+
 
 def deterministic_mutants(data: bytes):
-    """결정적 손상 변형들 — (라벨, 바이트). 무작위 없음(재현 가능)."""
+    """결정적 손상 변형들 — (라벨, 바이트). 무작위 없음(재현 가능).
+
+    같은 입력 → 같은 라벨·바이트. 원본과 동일한 무의미 변형은 넣지 않는다.
+    """
     n = len(data)
     if n == 0:
         # 빈 입력은 위치 기반 flip/절단을 할 수 없지만, 감사 자체가 예외를 내면 안 된다.
         return [("empty-to-nul", b"\0")]
     out = []
+
+    def add(label: str, mut: bytes) -> None:
+        if mut != data:
+            out.append((label, mut))
+
     for pct in (25, 50, 75, 95):                       # 절단
-        out.append((f"truncate@{pct}%", data[:max(1, n * pct // 100)]))
+        add(f"truncate@{pct}%", data[: max(1, n * pct // 100)])
     for pct in (10, 50, 90):                           # 바이트 플립
         pos = min(n - 1, n * pct // 100)
         b = bytearray(data)
         b[pos] ^= 0xFF
-        out.append((f"flip@{pct}%", bytes(b)))
+        add(f"flip@{pct}%", bytes(b))
     b = bytearray(data)                                # 헤더 매직 파손
     for i in range(min(n, 512)):
         b[i] = 0
-    out.append(("zero-header", bytes(b)))
+    add("zero-header", bytes(b))
+
+    smash_n = min(n, len(HEADER_SMASH_PAT))            # 헤더를 고정 패턴으로 덮어씀
+    b = bytearray(data)
+    b[:smash_n] = HEADER_SMASH_PAT[:smash_n]
+    add("header-smash", bytes(b))
+
+    # OLE CFB 섹터(512)보다 짧은 꼬리 절단 — 디렉터리/FAT 가 잘린 복합문서.
+    if n > 64:
+        add("ole-trunc-tail", data[:-64])
+    else:
+        k = min(4, n)  # 8바이트 매직의 앞 4바이트만 = 잘린 OLE 꼬리
+        add("ole-trunc-tail", data[:-k] + OLE_MAGIC[:k])
+
+    start = n // 3                                     # 본문 한가운데 0xFF 런
+    run = min(128, max(1, n - start))
+    b = bytearray(data)
+    b[start : start + run] = b"\xff" * run
+    add("ff-run", bytes(b))
+
+    if n >= 2:                                         # UTF-16LE NUL(U+0000) 뿌림
+        b = bytearray(data)
+        for pct in (20, 40, 60, 80):
+            pos = min(n - 2, n * pct // 100) & ~1
+            b[pos : pos + 2] = b"\x00\x00"
+        add("utf16-nul-sprinkle", bytes(b))
+
+    idx = data.find(ZIP_LOCAL)                         # HWPX 등 ZIP 로컬 헤더만
+    if idx >= 0:
+        b = bytearray(data)
+        for i in range(len(ZIP_LOCAL)):
+            b[idx + i] ^= 0xFF
+        add("zip-local-header-flip", bytes(b))
+
     return out
 
 
@@ -66,7 +111,7 @@ def select_samples(samples_dir: str, limit: int):
     """정렬된 .hwp 를 결정적 stride 로 limit 개 뽑는다(형식·크기 다양성 확보)."""
     everything = sorted(f for f in os.listdir(samples_dir) if f.endswith(".hwp"))
     if not everything or limit <= 0:
-        return everything[:max(0, limit)], len(everything)
+        return everything[: max(0, limit)], len(everything)
     if len(everything) <= limit:
         return everything, len(everything)
     stride = len(everything) / limit
@@ -94,15 +139,27 @@ def is_panic(code, err: str) -> bool:
     return code == 101 or code < 0 or windows_exception
 
 
+def classify_panic(code, err: str) -> bool:
+    """패닉 분류 — `is_panic` 과 동일 판정(감사·시험 공통 진입점)."""
+    return is_panic(code, err)
+
+
+def classify_timeout(timed_out) -> bool:
+    """행(timeout) 분류 — probe 의 timed_out 또는 TimeoutExpired."""
+    if isinstance(timed_out, BaseException):
+        return isinstance(timed_out, subprocess.TimeoutExpired)
+    return timed_out is True
+
+
 def probe(bin_path: str, path: str, timeout: int):
     """한 손상 파일을 파싱 시도 — (code, panicked, timed_out, head)."""
     try:
         p = subprocess.run([bin_path, "info", path, "--json"], cwd=REPO_ROOT,
                            capture_output=True, timeout=timeout)
         err = p.stderr.decode("utf-8", "replace") + p.stdout.decode("utf-8", "replace")
-        return p.returncode, is_panic(p.returncode, err), False, err[:160]
-    except subprocess.TimeoutExpired:
-        return None, False, True, f"timeout {timeout}s"
+        return p.returncode, classify_panic(p.returncode, err), False, err[:160]
+    except subprocess.TimeoutExpired as exc:
+        return None, False, classify_timeout(exc), f"timeout {timeout}s"
 
 
 def audit(bin_path: str, samples_dir: str, limit: int, timeout: int) -> dict:
@@ -121,9 +178,9 @@ def audit(bin_path: str, samples_dir: str, limit: int, timeout: int) -> dict:
                 code, panicked, timed_out, head = probe(bin_path, mut_path, timeout)
                 checked += 1
                 tag = f"{name}:{label}"
-                if timed_out:
+                if classify_timeout(timed_out):
                     hangs.append(tag)
-                elif panicked:
+                elif classify_panic(code, head) or panicked:
                     panics.append(f"{tag} (code {code}): {head}")
                 elif code not in (0, None):
                     degraded += 1

--- a/gym/tools/robustness.py
+++ b/gym/tools/robustness.py
@@ -17,6 +17,13 @@
 도구 자체의 손상 강건성. 이것이 다른 문서 벤치마크가 안 재는 축이다: 벤치마크가
 자기 도구가 적대적 입력에 죽지 않음을 CI 로 인증한다.
 
+감사기 자신은 예외 경로에서도 죽지 않는다. 읽을 수 없는 샘플, 빈/극소/거대 입력,
+바이트가 아닌 입력, 프로브 시간초과·OS 오류는 분류해 보고하고 중단하지 않는다.
+
+카탈로그·분류·봉투 계약은 `gym/docs/robustness.md` 와
+`gym/tools/README_robustness.md` 가 같은 표를 본다. 시험은
+`scripts/tests/test_gym_robustness.py` 가 고정한다.
+
 ## 사용
 
     python gym/tools/robustness.py --bin target/debug/rhwp            # 결정적 부분집합
@@ -27,6 +34,7 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import json
 import os
 import subprocess
@@ -42,40 +50,765 @@ from core import runner  # noqa: E402
 
 OLE_MAGIC = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
 ZIP_LOCAL = b"PK\x03\x04"
+ZIP_CD = b"PK\x01\x02"
+ZIP_EOCD = b"PK\x05\x06"
 HEADER_SMASH_PAT = b"\xde\xad\xbe\xef" * 16  # 64바이트 고정 패턴
+HWP3_SIG = b"HWP Document File"
+XOR_STRIDE_MASK = 0xA5
+LENGTH_BOMB_U32 = b"\xff\xff\xff\x7f"
+LENGTH_ZERO_U32 = b"\x00\x00\x00\x00"
+LENGTH_ONE_U32 = b"\x01\x00\x00\x00"
+I32_MIN_LE = b"\x00\x00\x00\x80"
+U16_MAX_LE = b"\xff\xff"
+UTF16_BOM_LE = b"\xff\xfe"
+UTF8_OVERLONG_NUL = b"\xc0\x80"
+CTRL_BYTE = 0x01
+STRIPE_STEP = 16
+XOR_STRIDE = 7
+
+# 입력 크기 분류 — 빈/극소/거대는 위치 기반 변형이 다르게 동작한다.
+TINY_MAX = 64
+HUGE_MIN = 1_048_576  # 1 MiB. 크기 증가 변형은 거대 입력에서 건너뛴다.
+PROBE_HEAD = 160
+SCHEMA_VERSION = "1.0"
+REPORT_KIND = "gymRobustness"
+
+# 감사 보고 고정 키. 시험이 이 집합을 계약으로 고정한다.
+REPORT_KEYS = (
+    "kind",
+    "schemaVersion",
+    "ok",
+    "samplesTested",
+    "totalSamples",
+    "mutantsChecked",
+    "gracefullyDegraded",
+    "panics",
+    "hangs",
+    "unreadables",
+    "probeErrors",
+    "inputShapes",
+)
+
+REPORT_LIST_KEYS = ("panics", "hangs", "unreadables", "probeErrors")
+REPORT_INT_KEYS = (
+    "samplesTested",
+    "totalSamples",
+    "mutantsChecked",
+    "gracefullyDegraded",
+)
+SHAPE_KEYS = ("empty", "tiny", "normal", "huge")
+
+# 정상(비어 있지 않은) 입력에서 항상 나오기를 기대하는 라벨.
+# 원본과 바이트가 같아지면 `add()` 가 버리므로 극소 입력에서는 일부만 남는다.
+ALWAYS_LABELS = (
+    "truncate@25%",
+    "truncate@50%",
+    "truncate@75%",
+    "truncate@95%",
+    "flip@10%",
+    "flip@50%",
+    "flip@90%",
+    "zero-header",
+    "header-smash",
+    "ole-trunc-tail",
+    "ff-run",
+    "utf16-nul-sprinkle",
+)
+
+# 2KiB 정상 입력에서 추가로 항상 나오는 확대 라벨. ZIP 조건부 라벨은 제외.
+EXPANDED_ALWAYS_LABELS = (
+    "truncate@10%",
+    "truncate@99%",
+    "flip@0%",
+    "flip@25%",
+    "flip@75%",
+    "flip@99%",
+    "chop-last",
+    "cut-first",
+    "aa-run",
+    "nul-mid",
+    "00-run",
+    "55-run",
+    "ole-magic-poison",
+    "ole-sector-shift-poison",
+    "zip-magic-inject",
+    "length-bomb@10%",
+    "length-bomb@40%",
+    "length-bomb@70%",
+    "length-zero@30%",
+    "length-one@60%",
+    "i32-min@20%",
+    "u16-max@12",
+    "reverse-prefix",
+    "swap-ends",
+    "high-bit-stripe",
+    "low-bit-stripe",
+    "xor-stride7",
+    "rotate-header",
+    "nibble-swap-head",
+    "increment-header",
+    "decrement-tail",
+    "interleave-zero-head",
+    "duplicate-prefix",
+    "tail-over-head",
+    "invert-tail-64",
+    "complement-mid-32",
+    "bit-rotate-head",
+    "utf16-bom-inject",
+    "ascii-ctrl-sprinkle",
+    "utf8-overlong",
+    "path-sep-sprinkle",
+    "slide-window-left",
+    "slide-window-right",
+    "repeat-mid-block",
+    "odd-length-chop",
+    "splice-nul-mid",
+    "crlf-inject",
+    "pad-eof",
+    "widen-gap",
+    "shrink-gap",
+)
+
+# 패닉 문자열 표식. 소문자 비교. 깨끗한 CLI 오류 문구와 겹치지 않게 고른다.
+PANIC_MARKERS = (
+    "panicked",
+    "stack overflow",
+    "core dumped",
+    "fatal runtime error",
+    "sigsegv",
+    "sigabrt",
+    "sigill",
+    "sigbus",
+    "access violation",
+    "segmentation fault",
+    "illegal instruction",
+    "abort trap",
+)
+
+# 행(timeout) 문자열 표식. 소문자 비교.
+TIMEOUT_MARKERS = (
+    "timeout",
+    "timed out",
+    "time-out",
+    "time expired",
+    "deadline exceeded",
+)
+
+# POSIX 음수 종료 코드(시그널)와 Windows NTSTATUS 상위 비트.
+RUST_ABORT = 101
+WINDOWS_EXCEPTION_MASK = 0xC0000000
+
+# 변형 가족 카탈로그 — 문서·시험이 같은 표를 본다. 무작위 필드 없음.
+MUTANT_CATALOG = (
+    {
+        "id": "empty-to-nul",
+        "family": "empty",
+        "when": "n==0",
+        "why": "빈 입력은 위치 기반 절단/플립을 할 수 없다. NUL 한 바이트로 고정한다.",
+    },
+    {
+        "id": "truncate",
+        "family": "truncate",
+        "when": "n>0",
+        "why": "잘린 복합문서·ZIP 중앙 디렉터리 부재를 재현한다.",
+        "params": (10, 25, 50, 75, 95, 99),
+    },
+    {
+        "id": "chop-last",
+        "family": "truncate",
+        "when": "n>=2",
+        "why": "마지막 1바이트만 잘라 오프바이원 레코드 끝을 재현한다.",
+    },
+    {
+        "id": "cut-first",
+        "family": "truncate",
+        "when": "n>=1",
+        "why": "선두 1바이트를 버려 매직이 한 칸 밀린 파일을 재현한다.",
+    },
+    {
+        "id": "flip",
+        "family": "flip",
+        "when": "n>0",
+        "why": "헤더·본문·꼬리 근처 한 바이트를 뒤집어 매직/길이 필드를 오염한다.",
+        "params": (10, 25, 50, 75, 90),
+    },
+    {
+        "id": "flip-edge",
+        "family": "flip",
+        "when": "n>0",
+        "why": "첫 바이트와 마지막 바이트 플립은 퍼센트 위치와 겹치지 않을 수 있다.",
+        "params": (0, 99),
+    },
+    {
+        "id": "zero-header",
+        "family": "header",
+        "when": "n>0",
+        "why": "선두 512바이트를 0 으로 지워 OLE/ZIP 매직을 없앤다.",
+    },
+    {
+        "id": "header-smash",
+        "family": "header",
+        "when": "n>0",
+        "why": "고정 DEADBEEF 패턴으로 헤더를 덮어 매직만 다른 손상과 구분한다.",
+    },
+    {
+        "id": "rotate-header",
+        "family": "header",
+        "when": "n>=2",
+        "why": "선두 8바이트를 한 칸 왼쪽으로 순환시켜 매직 순서를 깨뜨린다.",
+    },
+    {
+        "id": "increment-header",
+        "family": "header",
+        "when": "n>0",
+        "why": "선두 8바이트에 1 을 더해(랩어라운드) 매직을 미세 오염한다.",
+    },
+    {
+        "id": "nibble-swap-head",
+        "family": "header",
+        "when": "n>0",
+        "why": "선두 32바이트의 니블을 뒤집어 길이 필드의 상위/하위를 맞바꾼다.",
+    },
+    {
+        "id": "ole-trunc-tail",
+        "family": "ole",
+        "when": "n>0",
+        "why": "CFB 디렉터리/FAT 가 잘린 꼬리, 또는 잘린 OLE 매직을 심는다.",
+    },
+    {
+        "id": "ole-magic-poison",
+        "family": "ole",
+        "when": "n>0",
+        "why": "선두에 깨진 OLE 매직(원본 매직 XOR 0xFF)을 덮어쓴다.",
+    },
+    {
+        "id": "ole-sector-shift-poison",
+        "family": "ole",
+        "when": "n>=32",
+        "why": "CFB 섹터 시프트(오프셋 30)를 0xFFFF 로 바꿔 거대 섹터 할당을 유도한다.",
+    },
+    {
+        "id": "ole-mini-fat-poison",
+        "family": "ole",
+        "when": "n>=72",
+        "why": "CFB MiniFAT 시작 섹터(오프셋 60)를 0xFFFFFFFF 로 채운다.",
+    },
+    {
+        "id": "ff-run",
+        "family": "run",
+        "when": "n>0",
+        "why": "본문 1/3 지점에 0xFF 런을 넣어 길이·유니코드 필드를 포화시킨다.",
+    },
+    {
+        "id": "aa-run",
+        "family": "run",
+        "when": "n>0",
+        "why": "선두 1/4 에 0xAA 런을 넣어 0xFF 와 다른 비트 패턴을 본다.",
+    },
+    {
+        "id": "nul-mid",
+        "family": "run",
+        "when": "n>0",
+        "why": "한가운데 최대 64바이트를 NUL 로 지워 UTF-16 종료를 위조한다.",
+    },
+    {
+        "id": "00-run",
+        "family": "run",
+        "when": "n>0",
+        "why": "2/3 지점에 NUL 런을 넣어 레코드 조기 종료를 위조한다.",
+    },
+    {
+        "id": "55-run",
+        "family": "run",
+        "when": "n>0",
+        "why": "선두 1/5 에 0x55 런을 넣어 교차 비트 패턴을 본다.",
+    },
+    {
+        "id": "utf16-nul-sprinkle",
+        "family": "unicode",
+        "when": "n>=2",
+        "why": "짝수 오프셋에 U+0000 을 뿌려 UTF-16LE 본문 절단을 위조한다.",
+    },
+    {
+        "id": "utf16-bom-inject",
+        "family": "unicode",
+        "when": "n>=2",
+        "why": "선두에 UTF-16LE BOM 을 심어 인코딩 오인을 유도한다.",
+    },
+    {
+        "id": "utf8-overlong",
+        "family": "unicode",
+        "when": "n>=2",
+        "why": "1/5 지점에 overlong NUL(C0 80)을 심어 UTF-8 검증을 흔든다.",
+    },
+    {
+        "id": "ascii-ctrl-sprinkle",
+        "family": "unicode",
+        "when": "n>0",
+        "why": "고정 퍼센트 위치에 SOH(0x01)를 넣어 제어문자 경로를 본다.",
+    },
+    {
+        "id": "path-sep-sprinkle",
+        "family": "unicode",
+        "when": "n>0",
+        "why": "고정 위치에 경로 구분자(\\/)를 심어 경로 해석 오류를 유도한다.",
+    },
+    {
+        "id": "zip-local-header-flip",
+        "family": "zip",
+        "when": "ZIP 로컬 헤더가 있을 때",
+        "why": "HWPX 의 PK\\x03\\x04 만 뒤집어 아카이브 인식을 깨뜨린다.",
+    },
+    {
+        "id": "zip-magic-inject",
+        "family": "zip",
+        "when": "선두가 ZIP 로컬 헤더가 아닐 때",
+        "why": "비-ZIP 문서 선두에 PK 매직을 심어 형식 오인을 유도한다.",
+    },
+    {
+        "id": "zip-cd-magic-flip",
+        "family": "zip",
+        "when": "ZIP 중앙 디렉터리 매직이 있을 때",
+        "why": "PK\\x01\\x02 만 뒤집어 중앙 디렉터리 탐색을 깨뜨린다.",
+    },
+    {
+        "id": "zip-eocd-flip",
+        "family": "zip",
+        "when": "ZIP EOCD 매직이 있을 때",
+        "why": "PK\\x05\\x06 만 뒤집어 아카이브 끝 탐색을 깨뜨린다.",
+    },
+    {
+        "id": "length-bomb",
+        "family": "length",
+        "when": "n>=4",
+        "why": "추정 길이 필드에 0x7FFFFFFF 를 넣어 할당 폭주를 유도한다.",
+        "params": (10, 40, 70),
+    },
+    {
+        "id": "length-zero",
+        "family": "length",
+        "when": "n>=4",
+        "why": "추정 길이 필드에 0 을 넣어 빈 레코드 조기 종료를 유도한다.",
+        "params": (30,),
+    },
+    {
+        "id": "length-one",
+        "family": "length",
+        "when": "n>=4",
+        "why": "추정 길이 필드에 1 을 넣어 오프바이원 슬라이스를 유도한다.",
+        "params": (60,),
+    },
+    {
+        "id": "i32-min",
+        "family": "length",
+        "when": "n>=4",
+        "why": "부호 있는 최소값(0x80000000)을 넣어 음수 길이 경로를 본다.",
+        "params": (20,),
+    },
+    {
+        "id": "u16-max",
+        "family": "length",
+        "when": "n>=14",
+        "why": "오프셋 12 의 u16 을 0xFFFF 로 채워 카운트 필드를 포화시킨다.",
+    },
+    {
+        "id": "reverse-prefix",
+        "family": "permute",
+        "when": "n>=2",
+        "why": "선두 16바이트를 뒤집어 매직 순서를 깨뜨린다.",
+    },
+    {
+        "id": "swap-ends",
+        "family": "permute",
+        "when": "n>=16",
+        "why": "선두 8바이트와 꼬리 8바이트를 맞바꾼다.",
+    },
+    {
+        "id": "slide-window-left",
+        "family": "permute",
+        "when": "n>=8",
+        "why": "선두 32바이트를 한 바이트 왼쪽으로 밀어 필드 정렬을 흔든다.",
+    },
+    {
+        "id": "slide-window-right",
+        "family": "permute",
+        "when": "n>=8",
+        "why": "선두 32바이트를 한 바이트 오른쪽으로 밀어 필드 정렬을 흔든다.",
+    },
+    {
+        "id": "repeat-mid-block",
+        "family": "permute",
+        "when": "n>=32",
+        "why": "한가운데 32바이트를 바로 앞에 복사해 레코드 중복을 위조한다.",
+    },
+    {
+        "id": "high-bit-stripe",
+        "family": "stripe",
+        "when": "n>0",
+        "why": "16바이트마다 상위 비트를 켜 부호 있는 길이 해석을 흔든다.",
+    },
+    {
+        "id": "low-bit-stripe",
+        "family": "stripe",
+        "when": "n>0",
+        "why": "16바이트마다 최하위 비트를 뒤집어 홀짝 플래그를 깨뜨린다.",
+    },
+    {
+        "id": "xor-stride7",
+        "family": "stripe",
+        "when": "n>0",
+        "why": "7바이트마다 0xA5 를 XOR 해 주기적 체크섬·정렬을 흔든다.",
+    },
+    {
+        "id": "interleave-zero-head",
+        "family": "stripe",
+        "when": "n>0",
+        "why": "선두 32바이트의 홀수 인덱스를 0 으로 지워 교차 필드를 끊는다.",
+    },
+    {
+        "id": "duplicate-prefix",
+        "family": "stripe",
+        "when": "n>=16",
+        "why": "선두 8바이트를 바로 다음에 복제해 이중 매직을 만든다.",
+    },
+    {
+        "id": "tail-over-head",
+        "family": "stripe",
+        "when": "n>=32",
+        "why": "꼬리 16바이트를 선두에 덮어 매직을 본문 잔해로 바꾼다.",
+    },
+    {
+        "id": "invert-tail-64",
+        "family": "stripe",
+        "when": "n>0",
+        "why": "꼬리 최대 64바이트를 비트 반전한다.",
+    },
+    {
+        "id": "complement-mid-32",
+        "family": "stripe",
+        "when": "n>0",
+        "why": "한가운데 최대 32바이트를 비트 반전한다.",
+    },
+    {
+        "id": "bit-rotate-head",
+        "family": "stripe",
+        "when": "n>0",
+        "why": "선두 16바이트를 1비트 왼쪽으로 회전한다.",
+    },
+    {
+        "id": "decrement-tail",
+        "family": "stripe",
+        "when": "n>0",
+        "why": "꼬리 8바이트에서 1 을 빼 체크섬·길이를 미세 오염한다.",
+    },
+    {
+        "id": "odd-length-chop",
+        "family": "truncate",
+        "when": "n>=2 이고 짝수",
+        "why": "짝수 길이를 홀수로 만들어 UTF-16 워드 정렬을 깨뜨린다.",
+    },
+    {
+        "id": "even-length-pad",
+        "family": "splice",
+        "when": "n 이 홀수이고 거대 아님",
+        "why": "홀수 길이에 NUL 하나를 붙여 UTF-16 워드로 맞춘다.",
+    },
+    {
+        "id": "splice-nul-mid",
+        "family": "splice",
+        "when": "n>0 이고 거대 아님",
+        "why": "한가운데에 NUL 16바이트를 끼워 레코드 경계를 밀어낸다. 거대 입력은 크기가 늘지 않게 생략.",
+    },
+    {
+        "id": "crlf-inject",
+        "family": "splice",
+        "when": "n>0 이고 거대 아님",
+        "why": "한가운데에 CRLF 를 끼워 텍스트/바이너리 경계 오인을 유도한다.",
+    },
+    {
+        "id": "pad-eof",
+        "family": "splice",
+        "when": "n>0 이고 거대 아님",
+        "why": "파일 끝에 SUB(0x1A)를 붙여 구식 EOF 표식을 심는다.",
+    },
+    {
+        "id": "widen-gap",
+        "family": "splice",
+        "when": "n>0 이고 거대 아님",
+        "why": "1/4 지점에 NUL 4바이트를 끼워 오프셋을 밀어낸다.",
+    },
+    {
+        "id": "shrink-gap",
+        "family": "truncate",
+        "when": "n>=8",
+        "why": "1/4 지점의 4바이트를 삭제해 뒤 레코드를 앞으로 당긴다.",
+    },
+    {
+        "id": "hwp3-sig-flip",
+        "family": "hwp3",
+        "when": "HWP3 서명이 있을 때",
+        "why": "HWP Document File 서명의 첫 4바이트만 뒤집어 HWP3 인식을 깨뜨린다.",
+    },
+    {
+        "id": "hwp3-sig-inject",
+        "family": "hwp3",
+        "when": "HWP3 서명이 없고 n 이 서명보다 길 때",
+        "why": "비-HWP3 선두에 HWP3 서명을 심어 형식 오인을 유도한다.",
+    },
+)
 
 
-def deterministic_mutants(data: bytes):
+def coerce_bytes(data) -> bytes:
+    """바이트열만 받는다. bytearray/memoryview 는 복사하고, 그 외는 TypeError.
+
+    감사기가 str/int/None 을 조용히 인코딩하면 결정성이 깨진다. 호출자가
+    파일에서 읽은 바이트만 넘기도록 강제한다.
+    """
+    if isinstance(data, bytes):
+        return data
+    if isinstance(data, bytearray):
+        return bytes(data)
+    if isinstance(data, memoryview):
+        return data.tobytes()
+    raise TypeError(
+        "deterministic_mutants 는 bytes-like 만 받습니다"
+        f" (got {type(data).__name__})"
+    )
+
+
+def classify_input_shape(data) -> str:
+    """입력 형태 분류: empty / tiny / normal / huge. 비-바이트는 TypeError."""
+    payload = coerce_bytes(data)
+    n = len(payload)
+    if n == 0:
+        return "empty"
+    if n <= TINY_MAX:
+        return "tiny"
+    if n >= HUGE_MIN:
+        return "huge"
+    return "normal"
+
+
+def normalize_limit(limit) -> int:
+    """표본 수 한도. 변환 불능·음수는 0 (표본 없음)."""
+    try:
+        n = int(limit)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, n)
+
+
+def normalize_timeout(timeout) -> int:
+    """프로브 초. 변환 불능·비양수는 0 — 호출 측에서 거른다."""
+    try:
+        n = int(timeout)
+    except (TypeError, ValueError):
+        return 0
+    return n if n > 0 else 0
+
+
+def mutant_family(label: str) -> str:
+    """라벨을 가족 id 로 접는다. 카탈로그 확장 시 여기만 고치면 된다."""
+    if not isinstance(label, str) or not label:
+        return "other"
+    if label == "empty-to-nul":
+        return "empty"
+    if (
+        label.startswith("truncate@")
+        or label in ("chop-last", "cut-first", "odd-length-chop", "shrink-gap")
+    ):
+        return "truncate"
+    if label.startswith("flip@"):
+        return "flip"
+    if label in (
+        "zero-header",
+        "header-smash",
+        "rotate-header",
+        "increment-header",
+        "nibble-swap-head",
+    ):
+        return "header"
+    if label in ("ole-trunc-tail", "ole-magic-poison", "ole-sector-shift-poison", "ole-mini-fat-poison"):
+        return "ole"
+    if label in ("ff-run", "aa-run", "nul-mid", "00-run", "55-run"):
+        return "run"
+    if label in (
+        "utf16-nul-sprinkle",
+        "utf16-bom-inject",
+        "utf8-overlong",
+        "ascii-ctrl-sprinkle",
+        "path-sep-sprinkle",
+    ):
+        return "unicode"
+    if label in (
+        "zip-local-header-flip",
+        "zip-magic-inject",
+        "zip-cd-magic-flip",
+        "zip-eocd-flip",
+    ):
+        return "zip"
+    if (
+        label.startswith("length-bomb")
+        or label.startswith("length-zero")
+        or label.startswith("length-one")
+        or label.startswith("i32-min")
+        or label.startswith("u16-max")
+    ):
+        return "length"
+    if label in (
+        "reverse-prefix",
+        "swap-ends",
+        "slide-window-left",
+        "slide-window-right",
+        "repeat-mid-block",
+    ):
+        return "permute"
+    if label in (
+        "high-bit-stripe",
+        "low-bit-stripe",
+        "xor-stride7",
+        "interleave-zero-head",
+        "duplicate-prefix",
+        "tail-over-head",
+        "invert-tail-64",
+        "complement-mid-32",
+        "bit-rotate-head",
+        "decrement-tail",
+    ):
+        return "stripe"
+    if label in ("splice-nul-mid", "crlf-inject", "pad-eof", "widen-gap", "even-length-pad"):
+        return "splice"
+    if label in ("hwp3-sig-flip", "hwp3-sig-inject"):
+        return "hwp3"
+    return "other"
+
+
+def mutant_catalog() -> tuple:
+    """변형 가족 카탈로그 사본. 시험·문서가 같은 표를 참조한다."""
+    return tuple(dict(row) for row in MUTANT_CATALOG)
+
+
+def catalog_ids() -> tuple:
+    """카탈로그 id 튜플. 시험이 누락 가족을 잡는다."""
+    return tuple(row["id"] for row in MUTANT_CATALOG)
+
+
+def catalog_families() -> tuple:
+    """카탈로그 가족 id 의 등장 순서 유일 목록."""
+    seen, out = set(), []
+    for row in MUTANT_CATALOG:
+        fam = row["family"]
+        if fam not in seen:
+            seen.add(fam)
+            out.append(fam)
+    return tuple(out)
+
+
+def probe_head(text: str, limit: int = PROBE_HEAD) -> str:
+    """프로브 출력 머리. None/비문자는 빈 문자열."""
+    if text is None:
+        return ""
+    if not isinstance(text, str):
+        text = str(text)
+    if limit <= 0:
+        return ""
+    return text[:limit]
+
+
+def _posix_signal_timeout(code) -> bool:
+    """일부 환경은 시간초과를 SIGKILL(-9) / SIGXCPU 로 돌려준다. 행으로 보지 않는다.
+
+    감사는 subprocess.TimeoutExpired 를 행의 유일한 권위로 둔다. 시그널은 패닉 쪽
+    (음수 코드)으로 분류한다. 이 헬퍼는 문서화용이며 classify_timeout 은 쓰지 않는다.
+    """
+    return code in (-9, -24, -30)
+
+
+def _rotl8(value: int, bits: int = 1) -> int:
+    bits &= 7
+    value &= 0xFF
+    return ((value << bits) | (value >> (8 - bits))) & 0xFF
+
+
+def _swap_nibbles(value: int) -> int:
+    value &= 0xFF
+    return ((value & 0x0F) << 4) | ((value & 0xF0) >> 4)
+
+
+def _add_wrap(value: int, delta: int) -> int:
+    return (value + delta) & 0xFF
+
+
+def _find_magic(data: bytes, magic: bytes) -> int:
+    if not magic:
+        return -1
+    return data.find(magic)
+
+
+def _xor_slice(data: bytearray, start: int, width: int) -> None:
+    end = min(len(data), start + width)
+    for i in range(max(0, start), end):
+        data[i] ^= 0xFF
+
+
+def deterministic_mutants(data):
     """결정적 손상 변형들 — (라벨, 바이트). 무작위 없음(재현 가능).
 
     같은 입력 → 같은 라벨·바이트. 원본과 동일한 무의미 변형은 넣지 않는다.
+    비-바이트는 TypeError. 빈 입력은 empty-to-nul 한 건만.
     """
+    data = coerce_bytes(data)
     n = len(data)
     if n == 0:
         # 빈 입력은 위치 기반 flip/절단을 할 수 없지만, 감사 자체가 예외를 내면 안 된다.
         return [("empty-to-nul", b"\0")]
     out = []
+    huge = n >= HUGE_MIN
 
     def add(label: str, mut: bytes) -> None:
         if mut != data:
             out.append((label, mut))
 
-    for pct in (25, 50, 75, 95):                       # 절단
+    for pct in (10, 25, 50, 75, 95, 99):  # 절단
         add(f"truncate@{pct}%", data[: max(1, n * pct // 100)])
-    for pct in (10, 50, 90):                           # 바이트 플립
+    if n >= 2:
+        add("chop-last", data[:-1])
+    add("cut-first", data[1:])
+
+    for pct in (0, 10, 25, 50, 75, 90, 99):  # 바이트 플립
         pos = min(n - 1, n * pct // 100)
         b = bytearray(data)
         b[pos] ^= 0xFF
         add(f"flip@{pct}%", bytes(b))
-    b = bytearray(data)                                # 헤더 매직 파손
+
+    b = bytearray(data)  # 헤더 매직 파손
     for i in range(min(n, 512)):
         b[i] = 0
     add("zero-header", bytes(b))
 
-    smash_n = min(n, len(HEADER_SMASH_PAT))            # 헤더를 고정 패턴으로 덮어씀
+    smash_n = min(n, len(HEADER_SMASH_PAT))  # 헤더를 고정 패턴으로 덮어씀
     b = bytearray(data)
     b[:smash_n] = HEADER_SMASH_PAT[:smash_n]
     add("header-smash", bytes(b))
+
+    if n >= 2:  # 선두 순환
+        pref = min(8, n)
+        b = bytearray(data)
+        head = bytes(data[:pref])
+        b[:pref] = head[1:] + head[:1]
+        add("rotate-header", bytes(b))
+
+    inc_n = min(8, n)
+    b = bytearray(data)
+    for i in range(inc_n):
+        b[i] = _add_wrap(data[i], 1)
+    add("increment-header", bytes(b))
+
+    nib_n = min(32, n)
+    b = bytearray(data)
+    for i in range(nib_n):
+        b[i] = _swap_nibbles(data[i])
+    add("nibble-swap-head", bytes(b))
 
     # OLE CFB 섹터(512)보다 짧은 꼬리 절단 — 디렉터리/FAT 가 잘린 복합문서.
     if n > 64:
@@ -84,32 +817,252 @@ def deterministic_mutants(data: bytes):
         k = min(4, n)  # 8바이트 매직의 앞 4바이트만 = 잘린 OLE 꼬리
         add("ole-trunc-tail", data[:-k] + OLE_MAGIC[:k])
 
-    start = n // 3                                     # 본문 한가운데 0xFF 런
+    poison_n = min(n, len(OLE_MAGIC))
+    b = bytearray(data)
+    poisoned = bytes(x ^ 0xFF for x in OLE_MAGIC[:poison_n])
+    b[:poison_n] = poisoned
+    add("ole-magic-poison", bytes(b))
+
+    if n >= 32:
+        b = bytearray(data)
+        b[30:32] = U16_MAX_LE
+        add("ole-sector-shift-poison", bytes(b))
+    if n >= 72:
+        b = bytearray(data)
+        b[60:64] = b"\xff\xff\xff\xff"
+        add("ole-mini-fat-poison", bytes(b))
+
+    start = n // 3  # 본문 한가운데 0xFF 런
     run = min(128, max(1, n - start))
     b = bytearray(data)
     b[start : start + run] = b"\xff" * run
     add("ff-run", bytes(b))
 
-    if n >= 2:                                         # UTF-16LE NUL(U+0000) 뿌림
+    aa_n = min(n, max(1, n // 4))
+    b = bytearray(data)
+    b[:aa_n] = b"\xaa" * aa_n
+    add("aa-run", bytes(b))
+
+    mid = n // 2
+    nul_n = min(64, max(1, n - mid))
+    b = bytearray(data)
+    b[mid : mid + nul_n] = b"\x00" * nul_n
+    add("nul-mid", bytes(b))
+
+    two_third = (n * 2) // 3
+    zero_n = min(64, max(1, n - two_third))
+    b = bytearray(data)
+    b[two_third : two_third + zero_n] = b"\x00" * zero_n
+    add("00-run", bytes(b))
+
+    five_n = min(n, max(1, n // 5))
+    b = bytearray(data)
+    b[:five_n] = b"\x55" * five_n
+    add("55-run", bytes(b))
+
+    if n >= 2:  # UTF-16LE NUL(U+0000) 뿌림
         b = bytearray(data)
         for pct in (20, 40, 60, 80):
             pos = min(n - 2, n * pct // 100) & ~1
             b[pos : pos + 2] = b"\x00\x00"
         add("utf16-nul-sprinkle", bytes(b))
+        b = bytearray(data)
+        b[:2] = UTF16_BOM_LE
+        add("utf16-bom-inject", bytes(b))
+        over_at = min(n - 2, max(0, n // 5))
+        b = bytearray(data)
+        b[over_at : over_at + 2] = UTF8_OVERLONG_NUL
+        add("utf8-overlong", bytes(b))
 
-    idx = data.find(ZIP_LOCAL)                         # HWPX 등 ZIP 로컬 헤더만
+    b = bytearray(data)
+    for pct in (15, 35, 55, 75):
+        pos = min(n - 1, n * pct // 100)
+        b[pos] = CTRL_BYTE
+    add("ascii-ctrl-sprinkle", bytes(b))
+
+    b = bytearray(data)
+    seps = (0x2F, 0x5C)
+    for i, pct in enumerate((18, 42, 66, 88)):
+        pos = min(n - 1, n * pct // 100)
+        b[pos] = seps[i % 2]
+    add("path-sep-sprinkle", bytes(b))
+
+    idx = _find_magic(data, ZIP_LOCAL)  # HWPX 등 ZIP 로컬 헤더만
     if idx >= 0:
         b = bytearray(data)
-        for i in range(len(ZIP_LOCAL)):
-            b[idx + i] ^= 0xFF
+        _xor_slice(b, idx, len(ZIP_LOCAL))
         add("zip-local-header-flip", bytes(b))
+    elif n >= len(ZIP_LOCAL):
+        b = bytearray(data)
+        b[: len(ZIP_LOCAL)] = ZIP_LOCAL
+        add("zip-magic-inject", bytes(b))
+
+    cd_idx = _find_magic(data, ZIP_CD)
+    if cd_idx >= 0:
+        b = bytearray(data)
+        _xor_slice(b, cd_idx, len(ZIP_CD))
+        add("zip-cd-magic-flip", bytes(b))
+
+    eocd_idx = _find_magic(data, ZIP_EOCD)
+    if eocd_idx >= 0:
+        b = bytearray(data)
+        _xor_slice(b, eocd_idx, len(ZIP_EOCD))
+        add("zip-eocd-flip", bytes(b))
+
+    if n >= 4:
+        for pct in (10, 40, 70):
+            pos = min(n - 4, n * pct // 100)
+            b = bytearray(data)
+            b[pos : pos + 4] = LENGTH_BOMB_U32
+            add(f"length-bomb@{pct}%", bytes(b))
+        pos = min(n - 4, n * 30 // 100)
+        b = bytearray(data)
+        b[pos : pos + 4] = LENGTH_ZERO_U32
+        add("length-zero@30%", bytes(b))
+        pos = min(n - 4, n * 60 // 100)
+        b = bytearray(data)
+        b[pos : pos + 4] = LENGTH_ONE_U32
+        add("length-one@60%", bytes(b))
+        pos = min(n - 4, n * 20 // 100)
+        b = bytearray(data)
+        b[pos : pos + 4] = I32_MIN_LE
+        add("i32-min@20%", bytes(b))
+
+    if n >= 14:
+        b = bytearray(data)
+        b[12:14] = U16_MAX_LE
+        add("u16-max@12", bytes(b))
+
+    if n >= 2:
+        pref = min(16, n)
+        b = bytearray(data)
+        b[:pref] = bytes(reversed(data[:pref]))
+        add("reverse-prefix", bytes(b))
+
+    if n >= 16:
+        b = bytearray(data)
+        b[:8], b[-8:] = data[-8:], data[:8]
+        add("swap-ends", bytes(b))
+
+    if n >= 8:
+        win = min(32, n)
+        chunk = bytearray(data[:win])
+        left = chunk[1:] + chunk[:1]
+        b = bytearray(data)
+        b[:win] = left
+        add("slide-window-left", bytes(b))
+        right = chunk[-1:] + chunk[:-1]
+        b = bytearray(data)
+        b[:win] = right
+        add("slide-window-right", bytes(b))
+
+    if n >= 32:
+        mid = n // 2
+        block = data[mid : mid + 32]
+        dest = max(0, mid - 32)
+        b = bytearray(data)
+        b[dest : dest + 32] = block
+        add("repeat-mid-block", bytes(b))
+
+    b = bytearray(data)
+    for i in range(0, n, STRIPE_STEP):
+        b[i] = data[i] | 0x80
+    add("high-bit-stripe", bytes(b))
+
+    b = bytearray(data)
+    for i in range(0, n, STRIPE_STEP):
+        b[i] = data[i] ^ 0x01
+    add("low-bit-stripe", bytes(b))
+
+    b = bytearray(data)
+    for i in range(0, n, XOR_STRIDE):
+        b[i] = data[i] ^ XOR_STRIDE_MASK
+    add("xor-stride7", bytes(b))
+
+    head_n = min(32, n)
+    b = bytearray(data)
+    for i in range(1, head_n, 2):
+        b[i] = 0
+    add("interleave-zero-head", bytes(b))
+
+    if n >= 16:
+        b = bytearray(data)
+        b[8:16] = data[:8]
+        add("duplicate-prefix", bytes(b))
+
+    if n >= 32:
+        b = bytearray(data)
+        b[:16] = data[-16:]
+        add("tail-over-head", bytes(b))
+
+    tail_n = min(64, n)
+    b = bytearray(data)
+    for i in range(n - tail_n, n):
+        b[i] = data[i] ^ 0xFF
+    add("invert-tail-64", bytes(b))
+
+    mid = n // 2
+    mid_n = min(32, max(1, n - mid))
+    b = bytearray(data)
+    for i in range(mid, mid + mid_n):
+        b[i] = data[i] ^ 0xFF
+    add("complement-mid-32", bytes(b))
+
+    rot_n = min(16, n)
+    b = bytearray(data)
+    for i in range(rot_n):
+        b[i] = _rotl8(data[i], 1)
+    add("bit-rotate-head", bytes(b))
+
+    dec_n = min(8, n)
+    b = bytearray(data)
+    for i in range(n - dec_n, n):
+        b[i] = _add_wrap(data[i], -1)
+    add("decrement-tail", bytes(b))
+
+    if n >= 2 and (n % 2 == 0):
+        add("odd-length-chop", data[:-1])
+
+    hwp3_idx = _find_magic(data, HWP3_SIG)
+    if hwp3_idx >= 0:
+        b = bytearray(data)
+        _xor_slice(b, hwp3_idx, min(4, len(HWP3_SIG)))
+        add("hwp3-sig-flip", bytes(b))
+    elif n >= len(HWP3_SIG):
+        b = bytearray(data)
+        b[: len(HWP3_SIG)] = HWP3_SIG
+        add("hwp3-sig-inject", bytes(b))
+
+    # 거대 입력에 바이트를 끼우면 사본이 커진다. 게이트는 헤더/절단만으로 충분.
+    if not huge:
+        mid = n // 2
+        add("splice-nul-mid", data[:mid] + (b"\x00" * 16) + data[mid:])
+        add("crlf-inject", data[:mid] + b"\r\n" + data[mid:])
+        add("pad-eof", data + b"\x1a")
+        gap = n // 4
+        add("widen-gap", data[:gap] + (b"\x00" * 4) + data[gap:])
+        if n % 2 == 1:
+            add("even-length-pad", data + b"\x00")
+    if n >= 8:
+        gap = n // 4
+        end = min(n, gap + 4)
+        if end > gap:
+            add("shrink-gap", data[:gap] + data[end:])
 
     return out
 
 
 def select_samples(samples_dir: str, limit: int):
-    """정렬된 .hwp 를 결정적 stride 로 limit 개 뽑는다(형식·크기 다양성 확보)."""
-    everything = sorted(f for f in os.listdir(samples_dir) if f.endswith(".hwp"))
+    """정렬된 .hwp 를 결정적 stride 로 limit 개 뽑는다(형식·크기 다양성 확보).
+
+    디렉터리를 읽을 수 없으면 빈 목록을 돌려 감사기가 예외로 죽지 않게 한다.
+    """
+    limit = normalize_limit(limit)
+    try:
+        names = os.listdir(samples_dir)
+    except OSError:
+        return [], 0
+    everything = sorted(f for f in names if f.endswith(".hwp"))
     if not everything or limit <= 0:
         return everything[: max(0, limit)], len(everything)
     if len(everything) <= limit:
@@ -127,16 +1080,24 @@ def select_samples(samples_dir: str, limit: int):
 
 def is_panic(code, err: str) -> bool:
     """우아한 실패(비-0)와 패닉(크래시)을 가른다."""
+    if err is None:
+        err = ""
+    elif not isinstance(err, str):
+        err = str(err)
     low = err.lower()
-    if "panicked" in low or "stack overflow" in low or "core dumped" in low:
+    if any(marker in low for marker in PANIC_MARKERS):
         return True
     if code is None:
+        return False
+    try:
+        code = int(code)
+    except (TypeError, ValueError):
         return False
     # POSIX subprocess는 signal 종료를 음수로 돌려준다. Windows NTSTATUS 기반
     # 크래시는 큰 양수로 오므로 상위 두 비트로 구분한다. 임의의 CLI 오류 코드
     # (예: 255)를 패닉으로 오판하지 않는다.
-    windows_exception = code >= 0 and (code & 0xC0000000) == 0xC0000000
-    return code == 101 or code < 0 or windows_exception
+    windows_exception = code >= 0 and (code & WINDOWS_EXCEPTION_MASK) == WINDOWS_EXCEPTION_MASK
+    return code == RUST_ABORT or code < 0 or windows_exception
 
 
 def classify_panic(code, err: str) -> bool:
@@ -145,56 +1106,259 @@ def classify_panic(code, err: str) -> bool:
 
 
 def classify_timeout(timed_out) -> bool:
-    """행(timeout) 분류 — probe 의 timed_out 또는 TimeoutExpired."""
+    """행(timeout) 분류 — probe 의 timed_out, TimeoutExpired, 표식 문자열.
+
+    True 만 행이다. False/None/그 외 예외는 행이 아니다.
+    TimeoutExpired 와 TimeoutError 는 행. errno 시간초과 OSError 도 행.
+    """
     if isinstance(timed_out, BaseException):
-        return isinstance(timed_out, subprocess.TimeoutExpired)
+        if isinstance(timed_out, subprocess.TimeoutExpired):
+            return True
+        if isinstance(timed_out, TimeoutError):
+            return True
+        if isinstance(timed_out, OSError):
+            timed = {getattr(errno, name, None) for name in ("ETIMEDOUT", "ETIME")}
+            timed.discard(None)
+            return getattr(timed_out, "errno", None) in timed
+        return False
+    if isinstance(timed_out, str):
+        low = timed_out.lower()
+        return any(marker in low for marker in TIMEOUT_MARKERS)
     return timed_out is True
 
 
-def probe(bin_path: str, path: str, timeout: int):
-    """한 손상 파일을 파싱 시도 — (code, panicked, timed_out, head)."""
+def classify_probe_outcome(code, panicked, timed_out, head: str) -> str:
+    """한 프로브 결과를 hang / panic / graceful / ok / error 로 접는다."""
+    if classify_timeout(timed_out):
+        return "hang"
+    if classify_panic(code, head or "") or panicked:
+        return "panic"
+    if isinstance(head, str) and head.startswith(("oserror ", "probe-error ", "unreadable ")):
+        return "error"
+    if code not in (0, None):
+        return "graceful"
+    if code == 0:
+        return "ok"
+    return "error"
+
+
+def read_sample(path: str):
+    """샘플을 읽는다. 성공 시 (bytes, None), 실패 시 (None, 이유)."""
     try:
-        p = subprocess.run([bin_path, "info", path, "--json"], cwd=REPO_ROOT,
-                           capture_output=True, timeout=timeout)
+        with open(path, "rb") as fh:
+            return fh.read(), None
+    except OSError as exc:
+        return None, f"{type(exc).__name__}: {exc}"
+    except Exception as exc:  # noqa: BLE001 — 감사기 생존이 우선
+        return None, f"{type(exc).__name__}: {exc}"
+
+
+def write_mutant(path: str, mut: bytes):
+    """변형 바이트를 쓴다. 성공 시 None, 실패 시 이유 문자열."""
+    try:
+        payload = coerce_bytes(mut)
+    except TypeError as exc:
+        return f"TypeError: {exc}"
+    try:
+        with open(path, "wb") as fh:
+            fh.write(payload)
+        return None
+    except OSError as exc:
+        return f"{type(exc).__name__}: {exc}"
+    except Exception as exc:  # noqa: BLE001 — 감사기 생존이 우선
+        return f"{type(exc).__name__}: {exc}"
+
+
+def probe(bin_path: str, path: str, timeout: int):
+    """한 손상 파일을 파싱 시도 — (code, panicked, timed_out, head).
+
+    TimeoutExpired → 행. OSError(없는 바이너리·권한) → 패닉/행이 아닌 오류 머리.
+    그 외 예외도 감사기를 죽이지 않는다.
+    """
+    seconds = normalize_timeout(timeout)
+    if seconds <= 0:
+        return None, False, False, "probe-error invalid-timeout"
+    if not bin_path:
+        return None, False, False, "probe-error missing-bin"
+    try:
+        p = subprocess.run(
+            [bin_path, "info", path, "--json"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            timeout=seconds,
+        )
         err = p.stderr.decode("utf-8", "replace") + p.stdout.decode("utf-8", "replace")
-        return p.returncode, classify_panic(p.returncode, err), False, err[:160]
+        return p.returncode, classify_panic(p.returncode, err), False, probe_head(err)
     except subprocess.TimeoutExpired as exc:
-        return None, False, classify_timeout(exc), f"timeout {timeout}s"
+        return None, False, classify_timeout(exc), f"timeout {seconds}s"
+    except OSError as exc:
+        return None, False, False, probe_head(f"oserror {type(exc).__name__}: {exc}")
+    except Exception as exc:  # noqa: BLE001 — 감사기 생존이 우선
+        return None, False, False, probe_head(f"probe-error {type(exc).__name__}: {exc}")
+
+
+def empty_shape_counts() -> dict:
+    return {key: 0 for key in SHAPE_KEYS}
+
+
+def empty_report() -> dict:
+    """스키마를 만족하는 빈 보고. 예외 경로에서 감사기가 죽지 않게 쓴다."""
+    return {
+        "kind": REPORT_KIND,
+        "schemaVersion": SCHEMA_VERSION,
+        "ok": True,
+        "samplesTested": 0,
+        "totalSamples": 0,
+        "mutantsChecked": 0,
+        "gracefullyDegraded": 0,
+        "panics": [],
+        "hangs": [],
+        "unreadables": [],
+        "probeErrors": [],
+        "inputShapes": empty_shape_counts(),
+    }
+
+
+def validate_report(report) -> list:
+    """보고 스키마 위반 목록. 비어 있으면 계약 충족."""
+    issues = []
+    if not isinstance(report, dict):
+        return ["report-not-dict"]
+    missing = [key for key in REPORT_KEYS if key not in report]
+    extra = [key for key in report if key not in REPORT_KEYS]
+    if missing:
+        issues.append("missing:" + ",".join(missing))
+    if extra:
+        issues.append("extra:" + ",".join(sorted(extra)))
+    if report.get("kind") != REPORT_KIND:
+        issues.append("kind")
+    if report.get("schemaVersion") != SCHEMA_VERSION:
+        issues.append("schemaVersion")
+    if not isinstance(report.get("ok"), bool):
+        issues.append("ok-type")
+    for key in REPORT_INT_KEYS:
+        if not isinstance(report.get(key), int):
+            issues.append(f"{key}-type")
+        elif report.get(key) < 0:
+            issues.append(f"{key}-negative")
+    for key in REPORT_LIST_KEYS:
+        value = report.get(key)
+        if not isinstance(value, list):
+            issues.append(f"{key}-type")
+        elif any(not isinstance(item, str) for item in value):
+            issues.append(f"{key}-item-type")
+    shapes = report.get("inputShapes")
+    if not isinstance(shapes, dict):
+        issues.append("inputShapes-type")
+    else:
+        for key in SHAPE_KEYS:
+            if key not in shapes:
+                issues.append(f"inputShapes-missing-{key}")
+            elif not isinstance(shapes[key], int) or shapes[key] < 0:
+                issues.append(f"inputShapes-{key}")
+    if isinstance(report.get("ok"), bool):
+        expected_ok = not report.get("panics") and not report.get("hangs")
+        if report["ok"] != expected_ok:
+            issues.append("ok-mismatch")
+    return issues
+
+
+def format_human_report(report: dict) -> str:
+    """사람용 한 줄/여러 줄 요약. JSON 이 아닐 때 stdout 에 쓴다."""
+    if report.get("ok"):
+        return (
+            f"gym 손상-강건성 감사: 샘플 {report['samplesTested']}/{report['totalSamples']} × "
+            f"손상 {report['mutantsChecked']}건 — 패닉 0 · 행 0 "
+            f"(우아한 실패/부분복구 {report['gracefullyDegraded']}"
+            f" · 읽기실패 {len(report.get('unreadables', []))}"
+            f" · 프로브오류 {len(report.get('probeErrors', []))})"
+        )
+    lines = [
+        f"gym 손상-강건성 감사: 패닉 {len(report.get('panics', []))} · "
+        f"행 {len(report.get('hangs', []))} — rhwp 가 손상 입력에 죽는다:"
+    ]
+    for item in list(report.get("panics", [])) + list(report.get("hangs", [])):
+        lines.append(f"  - {item}")
+    return "\n".join(lines)
 
 
 def audit(bin_path: str, samples_dir: str, limit: int, timeout: int) -> dict:
-    picked, total = select_samples(samples_dir, limit)
+    report = empty_report()
+    try:
+        picked, total = select_samples(samples_dir, limit)
+    except Exception as exc:  # noqa: BLE001
+        report["unreadables"].append(f"select_samples: {type(exc).__name__}: {exc}")
+        report["ok"] = True
+        return report
+    report["samplesTested"] = len(picked)
+    report["totalSamples"] = total
     panics, hangs = [], []
+    unreadables, probe_errors = [], []
+    shapes = empty_shape_counts()
     checked = 0
     degraded = 0
-    with tempfile.TemporaryDirectory() as work:
+    try:
+        work_cm = tempfile.TemporaryDirectory()
+    except Exception as exc:  # noqa: BLE001
+        report["probeErrors"].append(f"tempdir: {type(exc).__name__}: {exc}")
+        return report
+    with work_cm as work:
         mut_path = os.path.join(work, "mutant.hwp")
         for name in picked:
-            with open(os.path.join(samples_dir, name), "rb") as fh:
-                data = fh.read()
-            for label, mut in deterministic_mutants(data):
-                with open(mut_path, "wb") as fh:
-                    fh.write(mut)
-                code, panicked, timed_out, head = probe(bin_path, mut_path, timeout)
+            data, read_err = read_sample(os.path.join(samples_dir, name))
+            if read_err is not None or data is None:
+                unreadables.append(f"{name}: {read_err or 'unreadable'}")
+                continue
+            try:
+                shape = classify_input_shape(data)
+            except TypeError as exc:
+                unreadables.append(f"{name}: TypeError: {exc}")
+                continue
+            shapes[shape] = shapes.get(shape, 0) + 1
+            try:
+                mutants = deterministic_mutants(data)
+            except TypeError as exc:
+                unreadables.append(f"{name}: TypeError: {exc}")
+                continue
+            except Exception as exc:  # noqa: BLE001
+                unreadables.append(f"{name}: {type(exc).__name__}: {exc}")
+                continue
+            for label, mut in mutants:
+                write_err = write_mutant(mut_path, mut)
+                if write_err is not None:
+                    probe_errors.append(f"{name}:{label}: {write_err}")
+                    continue
+                try:
+                    code, panicked, timed_out, head = probe(bin_path, mut_path, timeout)
+                except Exception as exc:  # noqa: BLE001
+                    probe_errors.append(f"{name}:{label}: probe-error {type(exc).__name__}: {exc}")
+                    continue
                 checked += 1
                 tag = f"{name}:{label}"
-                if classify_timeout(timed_out):
+                outcome = classify_probe_outcome(code, panicked, timed_out, head)
+                if outcome == "hang":
                     hangs.append(tag)
-                elif classify_panic(code, head) or panicked:
+                elif outcome == "panic":
                     panics.append(f"{tag} (code {code}): {head}")
-                elif code not in (0, None):
+                elif outcome == "error":
+                    probe_errors.append(f"{tag}: {head}")
+                elif outcome == "graceful":
                     degraded += 1
-    return {
-        "kind": "gymRobustness",
-        "schemaVersion": "1.0",
-        "ok": len(panics) == 0 and len(hangs) == 0,
-        "samplesTested": len(picked),
-        "totalSamples": total,
-        "mutantsChecked": checked,
-        "gracefullyDegraded": degraded,
-        "panics": panics,
-        "hangs": hangs,
-    }
+    report.update(
+        {
+            "ok": len(panics) == 0 and len(hangs) == 0,
+            "samplesTested": len(picked),
+            "totalSamples": total,
+            "mutantsChecked": checked,
+            "gracefullyDegraded": degraded,
+            "panics": panics,
+            "hangs": hangs,
+            "unreadables": unreadables,
+            "probeErrors": probe_errors,
+            "inputShapes": shapes,
+        }
+    )
+    return report
 
 
 def main() -> int:
@@ -206,21 +1370,25 @@ def main() -> int:
     a = ap.parse_args()
     if a.timeout <= 0:
         ap.error("--timeout은 양수여야 합니다")
-    bin_path = runner.find_bin(a.bin)
+    try:
+        bin_path = runner.find_bin(a.bin)
+    except Exception as exc:  # noqa: BLE001
+        print(f"gym 손상-강건성 감사: 바이너리를 찾지 못함: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 2
     samples_dir = os.path.join(REPO_ROOT, "samples")
-    report = audit(bin_path, samples_dir, a.limit, a.timeout)
+    try:
+        report = audit(bin_path, samples_dir, a.limit, a.timeout)
+    except Exception as exc:  # noqa: BLE001
+        report = empty_report()
+        report["probeErrors"].append(f"audit: {type(exc).__name__}: {exc}")
+    issues = validate_report(report)
+    if issues:
+        report.setdefault("probeErrors", []).append("schema: " + ";".join(issues))
     if a.json:
         sys.stdout.write(json.dumps(report, ensure_ascii=False, indent=2) + "\n")
-    elif report["ok"]:
-        print(f"gym 손상-강건성 감사: 샘플 {report['samplesTested']}/{report['totalSamples']} × "
-              f"손상 {report['mutantsChecked']}건 — 패닉 0 · 행 0 "
-              f"(우아한 실패/부분복구 {report['gracefullyDegraded']})")
     else:
-        print(f"gym 손상-강건성 감사: 패닉 {len(report['panics'])} · 행 {len(report['hangs'])} — "
-              "rhwp 가 손상 입력에 죽는다:")
-        for t in report["panics"] + report["hangs"]:
-            print(f"  - {t}")
-    return 0 if report["ok"] else 1
+        print(format_human_report(report))
+    return 0 if report.get("ok") else 1
 
 
 if __name__ == "__main__":

--- a/mydocs/working/gym_robustness.md
+++ b/mydocs/working/gym_robustness.md
@@ -1,0 +1,306 @@
+---
+kind: working
+status: active
+canonical: mydocs/working/gym_robustness.md
+last_verified: 2026-08-18
+---
+
+# gym 손상-강건성 감사 — 결정적 변형 확대 작업 기록
+
+Issue: #5218
+PR: https://github.com/edwardkim/rhwp/pull/5221
+Branch: `feat/gym-robust-mutants`
+Date: 2026-08-18
+
+## 1. 결론
+
+`gym/tools/robustness.py` 의 결정적 손상 변형을 확대하고, 감사기 자신의 예외
+경로를 분류·보고하도록 닫았다. 무작위는 쓰지 않는다. 같은 입력은 같은
+라벨·바이트를 내고, 원본과 동일한 무의미 변형은 버린다.
+
+이 가지는 새 PR 을 열지 않는다. 같은 브랜치에 이어서 밀어 #5221 을 키운다.
+
+검증:
+
+- `python -m unittest scripts.tests.test_gym_robustness scripts.tests.test_gym_audit`
+- `cargo fmt --all` 은 실행하지 않음 (Python/문서만, 사용자 지시)
+
+## 2. 배경
+
+원 PR(#5221)은 `header-smash` / `ole-trunc-tail` / `ff-run` / `utf16-nul-sprinkle`
+/ `zip-local-header-flip` 다섯 가족과 `classify_panic` / `classify_timeout` /
+JSON 봉투(`kind=gymRobustness`, `schemaVersion=1.0`)를 넣었다. 대비
+`upstream/devel` 삽입은 약 168줄이었다.
+
+그 상태의 빈틈:
+
+1. 정상 입력의 기본 변형이 12건 전후. ZIP 이 아니면 13번째가 없다. 헤더·본문·
+   길이·유니코드·아카이브 입구를 한 갈래만 두드린다.
+2. `probe` 가 `TimeoutExpired` 만 잡고, 없는 바이너리·권한·그 외 예외는 감사기를
+   죽일 수 있다.
+3. `select_samples` 가 없는 디렉터리에서 `os.listdir` 예외를 그대로 올린다.
+4. 빈/극소/거대 입력을 형태로 남기지 않아 표본 편향을 보고에서 못 본다.
+5. 카탈로그가 코드에만 있어 문서·시험이 같은 표를 공유하지 않는다.
+
+중단된 구조 초안 `tmp-gym-rescue/robustness.py` 는 예외 접기와 일부 확대 변형
+(가장자리 플립, `aa-run`, `nul-mid`, `zip-magic-inject`, `ole-magic-poison`,
+`length-bomb`, permute/stripe, `chop-last`, `splice-nul-mid`)을 가지고 있었다.
+초안의 예외 경로는 현행의 **진부분집합이 아니라 상위집합**이다 — `TypeError`
+강제, `OSError` 프로브 접기, `unreadables`/`probeErrors`/`inputShapes` 봉투.
+그래서 초안을 버리고 다시 쓰지 않고, 그 상위집합을 흡수한 뒤 가족을 더 늘렸다.
+
+## 3. 한 일
+
+### 3.1 감사기
+
+`gym/tools/robustness.py`
+
+- `coerce_bytes` — bytes/bytearray/memoryview 만. 그 외 `TypeError`.
+- `classify_input_shape` — empty/tiny/normal/huge.
+- `normalize_limit` / `normalize_timeout` — 변환 불능은 0.
+- `MUTANT_CATALOG` + `mutant_catalog` / `catalog_ids` / `catalog_families` /
+  `mutant_family`.
+- 확대 결정적 변형(아래 4절).
+- `read_sample` / `write_mutant` — 실패를 문자열로.
+- `probe` — invalid-timeout, missing-bin, `TimeoutExpired`, `OSError`, 그 외
+  예외를 머리 문자열로.
+- `classify_panic` 표식 확대. `classify_timeout` 이 `TimeoutError` ·
+  `ETIMEDOUT` · 표식 문자열을 받는다.
+- `classify_probe_outcome` — hang/panic/error/graceful/ok.
+- `empty_report` / `validate_report` / `format_human_report`.
+- `audit` 가 읽기실패·쓰기실패·프로브예외를 삼키고 보고에 남긴다.
+- 봉투에 `unreadables`, `probeErrors`, `inputShapes` 를 추가.
+
+### 3.2 시험
+
+`scripts/tests/test_gym_robustness.py`
+
+- 기존 `RobustnessTests` 유지. 봉투 키 집합을 새 `REPORT_KEYS` 에 맞춤.
+- `ExpandedMutantContractTests` — 가족 매핑, 헤더/OLE/길이/런/유니코드/
+  permute/stripe/splice 바이트 계약, ZIP/HWP3 조건부, 거대 입력 splice 생략.
+- `ExceptionPathTests` — coerce, normalize, 없는 디렉터리, 읽기/쓰기 실패,
+  probe timeout/OSError/RuntimeError, audit 의 unreadable/write/probe 접기,
+  스키마 검증.
+- `ShapeAndSelectEdgeTests` — stride 안정, 형태 카운트, 빈 샘플 1건 프로브,
+  상수 계약.
+
+### 3.3 문서
+
+- `gym/docs/robustness.md` — 규약. 카탈로그·분류·예외 표의 정본.
+- `gym/tools/README_robustness.md` — 운영 한 페이지.
+- 이 파일 — 작업 기록.
+
+packs·checks·coverage·다른 도구는 손대지 않았다.
+
+## 4. 변형 확대 목록
+
+기존(원 PR 유지):
+
+- `truncate@25,50,75,95%`
+- `flip@10,50,90%`
+- `zero-header`, `header-smash`, `ole-trunc-tail`, `ff-run`, `utf16-nul-sprinkle`
+- `zip-local-header-flip` (ZIP 로컬 헤더가 있을 때만)
+- `empty-to-nul`
+
+초안에서 흡수:
+
+- `flip@0%`, `flip@99%`
+- `aa-run`, `nul-mid`
+- `zip-magic-inject`
+- `ole-magic-poison`
+- `length-bomb@10,40,70%`
+- `reverse-prefix`, `swap-ends`
+- `high-bit-stripe`
+- `chop-last`
+- `splice-nul-mid` (거대 생략)
+
+이번에 추가:
+
+| 라벨 | 가족 | 의도 |
+|---|---|---|
+| `truncate@10%`, `truncate@99%` | truncate | 더 짧은/거의 전체 절단 |
+| `cut-first` | truncate | 매직이 한 칸 밀림 |
+| `odd-length-chop` | truncate | UTF-16 워드 정렬 파괴 |
+| `shrink-gap` | truncate | 중간 4바이트 삭제 |
+| `flip@25%`, `flip@75%` | flip | 사분면 플립 |
+| `rotate-header` | header | 매직 순환 |
+| `increment-header` | header | 매직 +1 |
+| `nibble-swap-head` | header | 니블 교환 |
+| `ole-sector-shift-poison` | ole | CFB 섹터 시프트 0xFFFF |
+| `ole-mini-fat-poison` | ole | MiniFAT 시작 0xFFFFFFFF |
+| `00-run`, `55-run` | run | 종료/교차 비트 런 |
+| `utf16-bom-inject` | unicode | LE BOM |
+| `utf8-overlong` | unicode | C0 80 |
+| `ascii-ctrl-sprinkle` | unicode | SOH |
+| `path-sep-sprinkle` | unicode | `/` `\\` |
+| `zip-cd-magic-flip` | zip | 중앙 디렉터리 |
+| `zip-eocd-flip` | zip | EOCD |
+| `length-zero@30%` | length | 길이 0 |
+| `length-one@60%` | length | 길이 1 |
+| `i32-min@20%` | length | 음수 최소 |
+| `u16-max@12` | length | 오프셋 12 u16 포화 |
+| `slide-window-left/right` | permute | 32바이트 창 이동 |
+| `repeat-mid-block` | permute | 중간 블록 복제 |
+| `low-bit-stripe` | stripe | LSB XOR 0x01 |
+| `xor-stride7` | stripe | 7바이트마다 0xA5 |
+| `interleave-zero-head` | stripe | 홀수 인덱스 0 |
+| `duplicate-prefix` | stripe | 이중 매직 |
+| `tail-over-head` | stripe | 꼬리로 헤더 덮음 |
+| `invert-tail-64` | stripe | 꼬리 비트 반전 |
+| `complement-mid-32` | stripe | 중간 비트 반전 |
+| `bit-rotate-head` | stripe | 1비트 회전 |
+| `decrement-tail` | stripe | 꼬리 -1 |
+| `crlf-inject` | splice | CRLF 끼움 |
+| `pad-eof` | splice | 0x1A EOF |
+| `widen-gap` | splice | 중간 NUL 4 |
+| `even-length-pad` | splice | 홀수→짝수 |
+| `hwp3-sig-flip` / `hwp3-sig-inject` | hwp3 | HWP3 입구 |
+
+거대 입력(`n >= 1MiB`)에서 크기가 는 변형은 만들지 않는다.
+
+## 5. 예외 경로 표 (시험과 같은 칸)
+
+| 입력 | 기대 | 시험 |
+|---|---|---|
+| `deterministic_mutants("ab")` | `TypeError` | `test_coerce_bytes_accepts_bytes_like_only` |
+| `classify_input_shape(None)` | `TypeError` | 위와 같음 |
+| `normalize_limit("nope")` | 0 | `test_normalize_limit_and_timeout` |
+| `normalize_timeout(0)` | 0 | 위와 같음 |
+| 없는 디렉터리 `select_samples` | `([], 0)` | `test_select_samples_oserror_and_bad_limit` |
+| 없는 파일 `read_sample` | `(None, 이유)` | `test_read_sample_missing_and_success` |
+| `write_mutant(..., "str")` | `TypeError: …` | `test_write_mutant_typeerror_and_oserror` |
+| `probe(..., timeout=0)` | `probe-error invalid-timeout` | `test_probe_invalid_timeout_and_missing_bin` |
+| `probe("", …)` | `probe-error missing-bin` | 위와 같음 |
+| 없는 바이너리 `probe` | `oserror …`, 패닉 아님 | `test_probe_oserror_is_not_panic` |
+| `TimeoutExpired` | hang | `test_probe_timeout_expired_is_hang` |
+| `RuntimeError` in `run` | `probe-error RuntimeError` | `test_probe_unexpected_exception_is_error` |
+| 읽기 거부 샘플 | `unreadables`, ok 유지 | `test_audit_records_unreadable_samples` |
+| 쓰기 실패 | `probeErrors`, checked=0 | `test_audit_records_write_errors` |
+| 프로브 예외 머리 | `probeErrors`, ok 유지 | `test_audit_records_probe_error_heads` |
+| `probe` 가 raise | 삼켜서 `probeErrors` | `test_audit_probe_raising_is_caught` |
+| 변형 생성 TypeError | `unreadables` | `test_audit_mutant_typeerror_is_unreadable` |
+| 빈 보고 | `validate_report` 빈 목록 | `test_empty_report_validates` |
+| 키 누락/`ok` 불일치 | 위반 목록 | `test_validate_report_detects_schema_breaks` |
+
+## 6. 호환
+
+기존 시험이 기대한 것:
+
+- `ALWAYS_LABELS` 12개가 2KiB 입력에 있다.
+- ZIP 이 아니면 `zip-local-header-flip` 이 없다. ZIP 이면 로컬 헤더 4바이트가
+  XOR 0xFF.
+- 빈 입력은 `[("empty-to-nul", b"\0")]`.
+- 극소 입력도 결정적이고 라벨이 유일하다.
+- `is_panic` / `classify_timeout` 의 기존 판정.
+- `select_samples` 의 stride 결정성.
+- 패닉·행 플래그, 우아한 실패의 `ok=true`.
+
+바뀐 것:
+
+- JSON 키 집합이 9개에서 12개로 늘었다. `unreadables`/`probeErrors`/
+  `inputShapes`. 기존 `test_json_report_shape` 의 `set(r) == set(REPORT_KEYS)`
+  를 새 키에 맞췄다.
+- 정상 2KiB 의 변형 수가 12+ 에서 40+ 로 늘었다. `assertGreaterEqual(..., 12)`
+  는 40 으로 올렸다. 하한만 올려 호환을 유지한다.
+- 사람용 성공 메시지에 읽기실패·프로브오류 카운트를 붙였다.
+
+`ok` 의미는 그대로다. 패닉·행만 뒤집는다.
+
+## 7. 의도적으로 안 한 일
+
+- `gym/README.md` 본문 수정. 이미 기둥을 설명하고, 카탈로그 정본은
+  `gym/docs/robustness.md` 로 분리했다.
+- pack/과제/checks/coverage 변경. 원 PR 범위와 같다.
+- `fuzz_corpus.py` 연동. 분업을 문서에만 적었다.
+- 실제 rhwp 바이너리로 전 코퍼스 주행. 이 작업의 게이트는 unittest 다.
+- `cargo fmt --all`. 사용자 지시. Rust 를 건드리지 않았다.
+- 새 PR. 같은 가지에 커밋·푸시만.
+
+## 8. 결정 기록
+
+### 8.1 초안을 흡수한 이유
+
+초안의 `classify_timeout` 은 `TimeoutExpired` 뿐 아니라 `TimeoutError` 와
+`ETIMEDOUT` 을 행으로 본다. 현행은 `TimeoutExpired` 만. 초안이 상위집합이다.
+`probe` 의 `OSError` 접기도 같다. 하위집합을 유지하면 없는 바이너리에서
+감사기가 죽는다. 그래서 초안을 버리고 현행을 키우는 쪽이 아니라, 초안의
+예외 접기를 그대로 옮긴 뒤 가족을 더했다.
+
+초안에 없던 것(섹터 시프트, MiniFAT, HWP3 서명, ZIP CD/EOCD, 길이 0/1/i32min,
+splice 확대, 스키마 검증)은 이 커밋에서 보탰다.
+
+### 8.2 읽기실패가 ok 를 안 뒤집는 이유
+
+샘플 디렉터리 권한·부분 손상은 환경이다. 그걸 `ok=false` 로 접으면 CI 가
+"rhwp 가 죽는다"고 거짓말한다. 리스트로 남기고 사람은 `unreadables` 길이를
+보면 된다.
+
+### 8.3 시그널을 행으로 안 보는 이유
+
+일부 러너는 timeout 을 SIGKILL(-9) 로 돌린다. 그걸 행으로 접으면 실제
+세그폴트도 행이 된다. 게이트의 행 권위는 `TimeoutExpired` 한 갈래다.
+시그널은 패닉 쪽(음수 코드)으로 남긴다. `_posix_signal_timeout` 은 이 결정을
+문서화하는 헬퍼일 뿐 `classify_timeout` 이 부르지 않는다.
+
+### 8.4 거대 입력에서 splice 를 생략하는 이유
+
+1MiB 사본에 16바이트를 끼우는 일은 게이트 판별력을 거의 안 올리고 메모리와
+시간을 먹는다. 헤더 오염과 절단이 같은 파서 입구를 더 값싸게 두드린다.
+
+### 8.5 라벨 유일, 바이트 중복 허용
+
+1바이트 입력에서 `flip@10%` 와 `flip@90%` 는 같은 바이트다. 라벨을 합치면
+가장자리 계약이 극소 입력에서 사라진다. 시험은 라벨 유일만 강제하고, 바이트
+중복은 허용한다. `add()` 가 버리는 것은 원본과 같은 경우뿐이다.
+
+## 9. 재현
+
+```text
+# 이 작업나무에서
+python -m unittest scripts.tests.test_gym_robustness scripts.tests.test_gym_audit
+
+# 변형 수만 보고 싶을 때
+python -c "import importlib.util; from pathlib import Path; p=Path('gym/tools/robustness.py'); s=importlib.util.spec_from_file_location('r', p); m=importlib.util.module_from_spec(s); s.loader.exec_module(m); print(len(m.deterministic_mutants(bytes(range(256))*8)))"
+```
+
+바이너리가 있으면:
+
+```text
+python gym/tools/robustness.py --bin target/debug/rhwp --json
+```
+
+이 작업은 바이너리 주행을 게이트에 넣지 않았다.
+
+## 10. 파일 목록
+
+| 경로 | 역할 |
+|---|---|
+| `gym/tools/robustness.py` | 감사기. 카탈로그·분류·예외 접기 |
+| `scripts/tests/test_gym_robustness.py` | 계약 시험 |
+| `gym/docs/robustness.md` | 규약 정본 |
+| `gym/tools/README_robustness.md` | 운영 메모 |
+| `mydocs/working/gym_robustness.md` | 이 기록 |
+
+## 11. 후속
+
+- 릴리스 게이트 워크플로가 이 도구를 이미 부른다면, 변형 수 증가로 시간이
+  늘었는지 한 번 재면 좋다. 표본 기본값 16 은 그대로다.
+- 발견 엔진(`fuzz_corpus.py`)이 새 가족을 재사용할지는 별 이슈. 지금은
+  게이트와 발견의 분업을 유지한다.
+- 실제 코퍼스에서 `hwp3-sig-flip` / `zip-eocd-flip` 이 몇 건이나 켜지는지는
+  바이너리 주행 때 `inputShapes` 와 라벨 히스토그램을 보면 된다. 감사 보고에
+  라벨 히스토그램은 아직 없다. 필요하면 `schemaVersion` 을 올리지 않고
+  선택 키로 넣는 편이 봉투 호환에 안전하다.
+
+## 12. 커밋 메시지 초안
+
+```text
+feat(#5218): gym 손상-강건성 감사에 결정적 변형과 예외 경로를 보강한다
+
+같은 입력은 같은 라벨·바이트를 내고, 원본과 동일한 무의미 변형은 버린다.
+OLE/ZIP/HWP3·길이·유니코드·스트라이프·스플라이스 가족을 늘리고,
+읽기/쓰기/프로브 예외는 보고로 접어 감사기가 죽지 않게 한다.
+카탈로그 규약과 운영 메모, 작업 기록을 같은 표로 고정한다.
+```
+
+이 초안을 실제 커밋에 쓴다. 새 PR 없음. `git add -A` 없음.

--- a/scripts/tests/test_gym_robustness.py
+++ b/scripts/tests/test_gym_robustness.py
@@ -8,12 +8,39 @@
 from __future__ import annotations
 
 import importlib.util
-import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
 
 TOOL = Path(__file__).resolve().parents[2] / "gym" / "tools" / "robustness.py"
+
+REPORT_KEYS = (
+    "kind",
+    "schemaVersion",
+    "ok",
+    "samplesTested",
+    "totalSamples",
+    "mutantsChecked",
+    "gracefullyDegraded",
+    "panics",
+    "hangs",
+)
+
+ALWAYS_LABELS = (
+    "truncate@25%",
+    "truncate@50%",
+    "truncate@75%",
+    "truncate@95%",
+    "flip@10%",
+    "flip@50%",
+    "flip@90%",
+    "zero-header",
+    "header-smash",
+    "ole-trunc-tail",
+    "ff-run",
+    "utf16-nul-sprinkle",
+)
 
 
 def load():
@@ -32,13 +59,51 @@ class RobustnessTests(unittest.TestCase):
         b = mod.deterministic_mutants(data)
         self.assertEqual([l for l, _ in a], [l for l, _ in b])   # 결정적(라벨 동일)
         self.assertEqual([m for _, m in a], [m for _, m in b])   # 결정적(바이트 동일)
-        self.assertGreaterEqual(len(a), 8)
+        self.assertGreaterEqual(len(a), 12)
         for label, mut in a:
             self.assertNotEqual(mut, data, f"{label} 이 원본과 같다(무의미 변형)")
+
+    def test_expanded_mutant_families_are_present(self):
+        mod = load()
+        data = bytes(range(256)) * 8
+        labels = [l for l, _ in mod.deterministic_mutants(data)]
+        for name in ALWAYS_LABELS:
+            self.assertIn(name, labels)
+        self.assertNotIn("zip-local-header-flip", labels)
+
+        zip_data = b"PK\x03\x04" + data
+        zip_labels = [l for l, _ in mod.deterministic_mutants(zip_data)]
+        self.assertIn("zip-local-header-flip", zip_labels)
+        flipped = dict(mod.deterministic_mutants(zip_data))["zip-local-header-flip"]
+        self.assertEqual(flipped[:4], bytes(x ^ 0xFF for x in b"PK\x03\x04"))
+        self.assertNotEqual(flipped, zip_data)
 
     def test_empty_input_has_a_deterministic_mutant(self):
         mod = load()
         self.assertEqual(mod.deterministic_mutants(b""), [("empty-to-nul", b"\0")])
+
+    def test_empty_and_tiny_inputs_still_work(self):
+        mod = load()
+        shapes = (
+            b"",
+            b"\x00",
+            b"\xff",
+            b"AB",
+            b"\x00" * 64,
+            b"\xff" * 128,
+            b"PK\x03\x04",
+            b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1" + b"\x00" * 80,
+        )
+        for data in shapes:
+            a = mod.deterministic_mutants(data)
+            b = mod.deterministic_mutants(data)
+            self.assertEqual(a, b, f"결정성 깨짐: {data[:16]!r}")
+            self.assertGreater(len(a), 0)
+            labels = []
+            for label, mut in a:
+                self.assertNotEqual(mut, data, f"{label} 이 원본과 같다")
+                labels.append(label)
+            self.assertEqual(labels, list(dict.fromkeys(labels)))
 
     def test_is_panic_distinguishes_crash_from_clean_failure(self):
         mod = load()
@@ -49,6 +114,22 @@ class RobustnessTests(unittest.TestCase):
         self.assertFalse(mod.is_panic(1, "오류: 유효하지 않은 파일")) # 깨끗한 실패
         self.assertFalse(mod.is_panic(255, "명시적 CLI 오류"))        # 일반 오류 코드는 패닉 아님
         self.assertFalse(mod.is_panic(0, "정상"))                    # 정상
+
+    def test_classify_panic_and_timeout_helpers(self):
+        mod = load()
+        self.assertTrue(mod.classify_panic(101, ""))
+        self.assertTrue(mod.classify_panic(0, "thread 'main' panicked"))
+        self.assertTrue(mod.classify_panic(-1073741819, ""))
+        self.assertTrue(mod.classify_panic(0xC0000005, ""))
+        self.assertFalse(mod.classify_panic(1, "오류: 유효하지 않은 파일"))
+        self.assertFalse(mod.classify_panic(255, "명시적 CLI 오류"))
+        self.assertFalse(mod.classify_panic(0, "정상"))
+        self.assertFalse(mod.classify_panic(None, ""))
+        self.assertTrue(mod.classify_timeout(True))
+        self.assertFalse(mod.classify_timeout(False))
+        self.assertFalse(mod.classify_timeout(None))
+        self.assertTrue(mod.classify_timeout(subprocess.TimeoutExpired("rhwp", 1)))
+        self.assertFalse(mod.classify_timeout(RuntimeError("other")))
 
     def test_select_samples_deterministic_and_bounded(self):
         mod = load()
@@ -88,6 +169,24 @@ class RobustnessTests(unittest.TestCase):
         self.assertEqual(r["panics"], [])
         self.assertEqual(r["hangs"], [])
         self.assertGreater(r["gracefullyDegraded"], 0)
+
+    def test_json_report_shape(self):
+        mod = load()
+        r = self._audit_with_probe(mod, (1, False, False, "오류"))
+        self.assertEqual(set(r), set(REPORT_KEYS))
+        self.assertEqual(r["kind"], "gymRobustness")
+        self.assertEqual(r["schemaVersion"], "1.0")
+        self.assertIsInstance(r["ok"], bool)
+        self.assertIsInstance(r["samplesTested"], int)
+        self.assertIsInstance(r["totalSamples"], int)
+        self.assertIsInstance(r["mutantsChecked"], int)
+        self.assertIsInstance(r["gracefullyDegraded"], int)
+        self.assertIsInstance(r["panics"], list)
+        self.assertIsInstance(r["hangs"], list)
+        self.assertEqual(r["samplesTested"], 1)
+        self.assertEqual(r["totalSamples"], 1)
+        self.assertGreaterEqual(r["mutantsChecked"], 12)
+        self.assertTrue(r["ok"])
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_gym_robustness.py
+++ b/scripts/tests/test_gym_robustness.py
@@ -3,15 +3,24 @@
 핵심: rhwp 는 손상 입력에 절대 패닉·행 하면 안 된다. 감사기는 코퍼스를 결정적으로
 손상시켜 파싱하고, 패닉(코드 101/음수/'panicked')·행(timeout) 이 있으면 실패로 잡는다.
 파싱은 목킹해 바이너리 없이 로직만 시험한다.
+
+확대 계약:
+- 같은 입력은 같은 라벨·바이트를 낸다(무작위 없음).
+- 원본과 바이트가 같은 무의미 변형은 버린다.
+- 빈/극소/거대/비-바이트/읽기실패/쓰기실패/프로브 예외에서도 감사기가 죽지 않는다.
+- JSON 봉투 키가 REPORT_KEYS 와 같고 ok 는 패닉·행 부재와 일치한다.
 """
 
 from __future__ import annotations
 
+import errno
 import importlib.util
+import os
 import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 TOOL = Path(__file__).resolve().parents[2] / "gym" / "tools" / "robustness.py"
 
@@ -25,6 +34,9 @@ REPORT_KEYS = (
     "gracefullyDegraded",
     "panics",
     "hangs",
+    "unreadables",
+    "probeErrors",
+    "inputShapes",
 )
 
 ALWAYS_LABELS = (
@@ -42,6 +54,77 @@ ALWAYS_LABELS = (
     "utf16-nul-sprinkle",
 )
 
+EXPANDED_ALWAYS_LABELS = (
+    "truncate@10%",
+    "truncate@99%",
+    "flip@0%",
+    "flip@25%",
+    "flip@75%",
+    "flip@99%",
+    "chop-last",
+    "cut-first",
+    "aa-run",
+    "nul-mid",
+    "00-run",
+    "55-run",
+    "ole-magic-poison",
+    "ole-sector-shift-poison",
+    "zip-magic-inject",
+    "length-bomb@10%",
+    "length-bomb@40%",
+    "length-bomb@70%",
+    "length-zero@30%",
+    "length-one@60%",
+    "i32-min@20%",
+    "u16-max@12",
+    "reverse-prefix",
+    "swap-ends",
+    "high-bit-stripe",
+    "low-bit-stripe",
+    "xor-stride7",
+    "rotate-header",
+    "nibble-swap-head",
+    "increment-header",
+    "decrement-tail",
+    "interleave-zero-head",
+    "duplicate-prefix",
+    "tail-over-head",
+    "invert-tail-64",
+    "complement-mid-32",
+    "bit-rotate-head",
+    "utf16-bom-inject",
+    "ascii-ctrl-sprinkle",
+    "utf8-overlong",
+    "path-sep-sprinkle",
+    "slide-window-left",
+    "slide-window-right",
+    "repeat-mid-block",
+    "odd-length-chop",
+    "splice-nul-mid",
+    "crlf-inject",
+    "pad-eof",
+    "widen-gap",
+    "shrink-gap",
+)
+
+FAMILY_IDS = (
+    "empty",
+    "truncate",
+    "flip",
+    "header",
+    "ole",
+    "run",
+    "unicode",
+    "zip",
+    "length",
+    "permute",
+    "stripe",
+    "splice",
+    "hwp3",
+)
+
+NORMAL_2K = bytes(range(256)) * 8  # 2KB, 짝수, ZIP/HWP3 서명 없음
+
 
 def load():
     spec = importlib.util.spec_from_file_location("gym_robustness", TOOL)
@@ -51,32 +134,53 @@ def load():
     return module
 
 
+def labels_of(pairs):
+    return [label for label, _ in pairs]
+
+
+def as_map(pairs):
+    return {label: payload for label, payload in pairs}
+
+
 class RobustnessTests(unittest.TestCase):
     def test_mutants_deterministic_and_nontrivial(self):
         mod = load()
-        data = bytes(range(256)) * 8  # 2KB
+        data = NORMAL_2K
         a = mod.deterministic_mutants(data)
         b = mod.deterministic_mutants(data)
-        self.assertEqual([l for l, _ in a], [l for l, _ in b])   # 결정적(라벨 동일)
-        self.assertEqual([m for _, m in a], [m for _, m in b])   # 결정적(바이트 동일)
-        self.assertGreaterEqual(len(a), 12)
+        self.assertEqual([l for l, _ in a], [l for l, _ in b])  # 결정적(라벨 동일)
+        self.assertEqual([m for _, m in a], [m for _, m in b])  # 결정적(바이트 동일)
+        self.assertGreaterEqual(len(a), 40)
         for label, mut in a:
             self.assertNotEqual(mut, data, f"{label} 이 원본과 같다(무의미 변형)")
 
     def test_expanded_mutant_families_are_present(self):
         mod = load()
-        data = bytes(range(256)) * 8
-        labels = [l for l, _ in mod.deterministic_mutants(data)]
+        data = NORMAL_2K
+        labels = labels_of(mod.deterministic_mutants(data))
         for name in ALWAYS_LABELS:
             self.assertIn(name, labels)
         self.assertNotIn("zip-local-header-flip", labels)
 
         zip_data = b"PK\x03\x04" + data
-        zip_labels = [l for l, _ in mod.deterministic_mutants(zip_data)]
+        zip_labels = labels_of(mod.deterministic_mutants(zip_data))
         self.assertIn("zip-local-header-flip", zip_labels)
-        flipped = dict(mod.deterministic_mutants(zip_data))["zip-local-header-flip"]
+        flipped = as_map(mod.deterministic_mutants(zip_data))["zip-local-header-flip"]
         self.assertEqual(flipped[:4], bytes(x ^ 0xFF for x in b"PK\x03\x04"))
         self.assertNotEqual(flipped, zip_data)
+
+    def test_expanded_always_labels_on_normal_payload(self):
+        mod = load()
+        labels = labels_of(mod.deterministic_mutants(NORMAL_2K))
+        for name in EXPANDED_ALWAYS_LABELS:
+            self.assertIn(name, labels, name)
+        self.assertNotIn("zip-local-header-flip", labels)
+        self.assertNotIn("zip-cd-magic-flip", labels)
+        self.assertNotIn("zip-eocd-flip", labels)
+        self.assertIn("zip-magic-inject", labels)
+        self.assertIn("hwp3-sig-inject", labels)
+        self.assertNotIn("hwp3-sig-flip", labels)
+        self.assertNotIn("empty-to-nul", labels)
 
     def test_empty_input_has_a_deterministic_mutant(self):
         mod = load()
@@ -105,15 +209,37 @@ class RobustnessTests(unittest.TestCase):
                 labels.append(label)
             self.assertEqual(labels, list(dict.fromkeys(labels)))
 
+    def test_coerce_bytes_accepts_bytes_like_only(self):
+        mod = load()
+        self.assertEqual(mod.coerce_bytes(b"ab"), b"ab")
+        self.assertEqual(mod.coerce_bytes(bytearray(b"ab")), b"ab")
+        self.assertEqual(mod.coerce_bytes(memoryview(b"ab")), b"ab")
+        for bad in ("ab", 12, None, ["x"], {"a": 1}):
+            with self.assertRaises(TypeError):
+                mod.coerce_bytes(bad)
+            with self.assertRaises(TypeError):
+                mod.deterministic_mutants(bad)
+            with self.assertRaises(TypeError):
+                mod.classify_input_shape(bad)
+
+    def test_classify_input_shape_buckets(self):
+        mod = load()
+        self.assertEqual(mod.classify_input_shape(b""), "empty")
+        self.assertEqual(mod.classify_input_shape(b"\x00"), "tiny")
+        self.assertEqual(mod.classify_input_shape(b"\x00" * 64), "tiny")
+        self.assertEqual(mod.classify_input_shape(b"\x00" * 65), "normal")
+        self.assertEqual(mod.classify_input_shape(NORMAL_2K), "normal")
+        self.assertEqual(mod.classify_input_shape(b"\x00" * mod.HUGE_MIN), "huge")
+
     def test_is_panic_distinguishes_crash_from_clean_failure(self):
         mod = load()
-        self.assertTrue(mod.is_panic(101, ""))                       # 어보트
-        self.assertTrue(mod.is_panic(0, "thread 'main' panicked"))   # 패닉 메시지
-        self.assertTrue(mod.is_panic(-1073741819, ""))               # AV(음수)
-        self.assertTrue(mod.is_panic(0xC0000005, ""))                # Windows AV(NTSTATUS)
-        self.assertFalse(mod.is_panic(1, "오류: 유효하지 않은 파일")) # 깨끗한 실패
-        self.assertFalse(mod.is_panic(255, "명시적 CLI 오류"))        # 일반 오류 코드는 패닉 아님
-        self.assertFalse(mod.is_panic(0, "정상"))                    # 정상
+        self.assertTrue(mod.is_panic(101, ""))  # 어보트
+        self.assertTrue(mod.is_panic(0, "thread 'main' panicked"))  # 패닉 메시지
+        self.assertTrue(mod.is_panic(-1073741819, ""))  # AV(음수)
+        self.assertTrue(mod.is_panic(0xC0000005, ""))  # Windows AV(NTSTATUS)
+        self.assertFalse(mod.is_panic(1, "오류: 유효하지 않은 파일"))  # 깨끗한 실패
+        self.assertFalse(mod.is_panic(255, "명시적 CLI 오류"))  # 일반 오류 코드는 패닉 아님
+        self.assertFalse(mod.is_panic(0, "정상"))  # 정상
 
     def test_classify_panic_and_timeout_helpers(self):
         mod = load()
@@ -139,14 +265,14 @@ class RobustnessTests(unittest.TestCase):
             Path(d, "not-a-sample.txt").write_bytes(b"x")
             picked1, total = mod.select_samples(d, 10)
             picked2, _ = mod.select_samples(d, 10)
-            self.assertEqual(total, 50)              # .txt 제외
+            self.assertEqual(total, 50)  # .txt 제외
             self.assertLessEqual(len(picked1), 10)
-            self.assertEqual(picked1, picked2)       # 결정적
+            self.assertEqual(picked1, picked2)  # 결정적
             self.assertTrue(all(f.endswith(".hwp") for f in picked1))
 
     def _audit_with_probe(self, mod, probe_result):
         with tempfile.TemporaryDirectory() as d:
-            Path(d, "s.hwp").write_bytes(bytes(range(256)) * 8)
+            Path(d, "s.hwp").write_bytes(NORMAL_2K)
             mod.probe = lambda bin_path, path, timeout: probe_result
             return mod.audit("bin", d, limit=1, timeout=5)
 
@@ -174,6 +300,7 @@ class RobustnessTests(unittest.TestCase):
         mod = load()
         r = self._audit_with_probe(mod, (1, False, False, "오류"))
         self.assertEqual(set(r), set(REPORT_KEYS))
+        self.assertEqual(set(r), set(mod.REPORT_KEYS))
         self.assertEqual(r["kind"], "gymRobustness")
         self.assertEqual(r["schemaVersion"], "1.0")
         self.assertIsInstance(r["ok"], bool)
@@ -183,10 +310,701 @@ class RobustnessTests(unittest.TestCase):
         self.assertIsInstance(r["gracefullyDegraded"], int)
         self.assertIsInstance(r["panics"], list)
         self.assertIsInstance(r["hangs"], list)
+        self.assertIsInstance(r["unreadables"], list)
+        self.assertIsInstance(r["probeErrors"], list)
+        self.assertIsInstance(r["inputShapes"], dict)
         self.assertEqual(r["samplesTested"], 1)
         self.assertEqual(r["totalSamples"], 1)
-        self.assertGreaterEqual(r["mutantsChecked"], 12)
+        self.assertGreaterEqual(r["mutantsChecked"], 40)
         self.assertTrue(r["ok"])
+        self.assertEqual(mod.validate_report(r), [])
+
+
+class ExpandedMutantContractTests(unittest.TestCase):
+    def test_catalog_covers_declared_families(self):
+        mod = load()
+        catalog = mod.mutant_catalog()
+        self.assertGreaterEqual(len(catalog), 40)
+        ids = [row["id"] for row in catalog]
+        self.assertEqual(ids, list(mod.catalog_ids()))
+        self.assertEqual(len(ids), len(set(ids)))
+        families = {row["family"] for row in catalog}
+        for fam in FAMILY_IDS:
+            self.assertIn(fam, families)
+        self.assertEqual(set(mod.catalog_families()), families)
+        for row in catalog:
+            self.assertIn("id", row)
+            self.assertIn("family", row)
+            self.assertIn("when", row)
+            self.assertIn("why", row)
+            self.assertTrue(row["why"])
+
+    def test_mutant_family_mapping(self):
+        mod = load()
+        cases = {
+            "empty-to-nul": "empty",
+            "truncate@25%": "truncate",
+            "chop-last": "truncate",
+            "cut-first": "truncate",
+            "odd-length-chop": "truncate",
+            "shrink-gap": "truncate",
+            "flip@0%": "flip",
+            "flip@90%": "flip",
+            "zero-header": "header",
+            "header-smash": "header",
+            "rotate-header": "header",
+            "increment-header": "header",
+            "nibble-swap-head": "header",
+            "ole-trunc-tail": "ole",
+            "ole-magic-poison": "ole",
+            "ole-sector-shift-poison": "ole",
+            "ole-mini-fat-poison": "ole",
+            "ff-run": "run",
+            "aa-run": "run",
+            "nul-mid": "run",
+            "00-run": "run",
+            "55-run": "run",
+            "utf16-nul-sprinkle": "unicode",
+            "utf16-bom-inject": "unicode",
+            "utf8-overlong": "unicode",
+            "ascii-ctrl-sprinkle": "unicode",
+            "path-sep-sprinkle": "unicode",
+            "zip-local-header-flip": "zip",
+            "zip-magic-inject": "zip",
+            "zip-cd-magic-flip": "zip",
+            "zip-eocd-flip": "zip",
+            "length-bomb@10%": "length",
+            "length-zero@30%": "length",
+            "length-one@60%": "length",
+            "i32-min@20%": "length",
+            "u16-max@12": "length",
+            "reverse-prefix": "permute",
+            "swap-ends": "permute",
+            "slide-window-left": "permute",
+            "slide-window-right": "permute",
+            "repeat-mid-block": "permute",
+            "high-bit-stripe": "stripe",
+            "low-bit-stripe": "stripe",
+            "xor-stride7": "stripe",
+            "interleave-zero-head": "stripe",
+            "duplicate-prefix": "stripe",
+            "tail-over-head": "stripe",
+            "invert-tail-64": "stripe",
+            "complement-mid-32": "stripe",
+            "bit-rotate-head": "stripe",
+            "decrement-tail": "stripe",
+            "splice-nul-mid": "splice",
+            "crlf-inject": "splice",
+            "pad-eof": "splice",
+            "widen-gap": "splice",
+            "even-length-pad": "splice",
+            "hwp3-sig-flip": "hwp3",
+            "hwp3-sig-inject": "hwp3",
+            "": "other",
+            "unknown-label": "other",
+        }
+        for label, family in cases.items():
+            self.assertEqual(mod.mutant_family(label), family, label)
+        self.assertEqual(mod.mutant_family(None), "other")
+
+    def test_header_smash_uses_fixed_pattern(self):
+        mod = load()
+        payload = as_map(mod.deterministic_mutants(NORMAL_2K))["header-smash"]
+        self.assertTrue(payload.startswith(mod.HEADER_SMASH_PAT))
+        self.assertEqual(payload[64:], NORMAL_2K[64:])
+
+    def test_zero_header_clears_first_512(self):
+        mod = load()
+        payload = as_map(mod.deterministic_mutants(NORMAL_2K))["zero-header"]
+        self.assertEqual(payload[:512], b"\x00" * 512)
+        self.assertEqual(payload[512:], NORMAL_2K[512:])
+
+    def test_ole_magic_poison_xors_signature(self):
+        mod = load()
+        payload = as_map(mod.deterministic_mutants(NORMAL_2K))["ole-magic-poison"]
+        expected = bytes(x ^ 0xFF for x in mod.OLE_MAGIC)
+        self.assertEqual(payload[:8], expected)
+        self.assertEqual(payload[8:], NORMAL_2K[8:])
+
+    def test_ole_sector_and_minifat_offsets(self):
+        mod = load()
+        mapped = as_map(mod.deterministic_mutants(NORMAL_2K))
+        self.assertEqual(mapped["ole-sector-shift-poison"][30:32], b"\xff\xff")
+        self.assertEqual(mapped["ole-mini-fat-poison"][60:64], b"\xff\xff\xff\xff")
+        tiny = as_map(mod.deterministic_mutants(b"\x00" * 20))
+        self.assertNotIn("ole-sector-shift-poison", tiny)
+        self.assertNotIn("ole-mini-fat-poison", tiny)
+
+    def test_length_bombs_are_little_endian_constants(self):
+        mod = load()
+        mapped = as_map(mod.deterministic_mutants(NORMAL_2K))
+        n = len(NORMAL_2K)
+        bomb10 = min(n - 4, n * 10 // 100)
+        self.assertEqual(mapped["length-bomb@10%"][bomb10 : bomb10 + 4], b"\xff\xff\xff\x7f")
+        zero30 = min(n - 4, n * 30 // 100)
+        self.assertEqual(mapped["length-zero@30%"][zero30 : zero30 + 4], b"\x00\x00\x00\x00")
+        one60 = min(n - 4, n * 60 // 100)
+        self.assertEqual(mapped["length-one@60%"][one60 : one60 + 4], b"\x01\x00\x00\x00")
+        i32 = min(n - 4, n * 20 // 100)
+        self.assertEqual(mapped["i32-min@20%"][i32 : i32 + 4], b"\x00\x00\x00\x80")
+        self.assertEqual(mapped["u16-max@12"][12:14], b"\xff\xff")
+
+    def test_run_families_overwrite_expected_windows(self):
+        mod = load()
+        mapped = as_map(mod.deterministic_mutants(NORMAL_2K))
+        n = len(NORMAL_2K)
+        start = n // 3
+        run = min(128, n - start)
+        self.assertEqual(mapped["ff-run"][start : start + run], b"\xff" * run)
+        aa_n = max(1, n // 4)
+        self.assertEqual(mapped["aa-run"][:aa_n], b"\xaa" * aa_n)
+        mid = n // 2
+        nul_n = min(64, n - mid)
+        self.assertEqual(mapped["nul-mid"][mid : mid + nul_n], b"\x00" * nul_n)
+        two_third = (n * 2) // 3
+        zero_n = min(64, n - two_third)
+        self.assertEqual(mapped["00-run"][two_third : two_third + zero_n], b"\x00" * zero_n)
+        five_n = max(1, n // 5)
+        self.assertEqual(mapped["55-run"][:five_n], b"\x55" * five_n)
+
+    def test_unicode_and_control_injections(self):
+        mod = load()
+        mapped = as_map(mod.deterministic_mutants(NORMAL_2K))
+        self.assertEqual(mapped["utf16-bom-inject"][:2], b"\xff\xfe")
+        over_at = len(NORMAL_2K) // 5
+        self.assertEqual(mapped["utf8-overlong"][over_at : over_at + 2], b"\xc0\x80")
+        n = len(NORMAL_2K)
+        ctrl = mapped["ascii-ctrl-sprinkle"]
+        for pct in (15, 35, 55, 75):
+            self.assertEqual(ctrl[n * pct // 100], 0x01)
+        seps = mapped["path-sep-sprinkle"]
+        self.assertEqual(seps[n * 18 // 100], 0x2F)
+        self.assertEqual(seps[n * 42 // 100], 0x5C)
+
+    def test_permute_and_stripe_contracts(self):
+        mod = load()
+        mapped = as_map(mod.deterministic_mutants(NORMAL_2K))
+        self.assertEqual(mapped["reverse-prefix"][:16], bytes(reversed(NORMAL_2K[:16])))
+        self.assertEqual(mapped["swap-ends"][:8], NORMAL_2K[-8:])
+        self.assertEqual(mapped["swap-ends"][-8:], NORMAL_2K[:8])
+        self.assertEqual(mapped["slide-window-left"][:32], NORMAL_2K[1:32] + NORMAL_2K[:1])
+        self.assertEqual(mapped["slide-window-right"][:32], NORMAL_2K[31:32] + NORMAL_2K[:31])
+        self.assertEqual(mapped["duplicate-prefix"][8:16], NORMAL_2K[:8])
+        self.assertEqual(mapped["tail-over-head"][:16], NORMAL_2K[-16:])
+        self.assertEqual(mapped["high-bit-stripe"][0] & 0x80, 0x80)
+        self.assertEqual(mapped["low-bit-stripe"][0], NORMAL_2K[0] ^ 0x01)
+        self.assertEqual(mapped["xor-stride7"][0], NORMAL_2K[0] ^ 0xA5)
+        self.assertEqual(mapped["interleave-zero-head"][1], 0)
+        self.assertEqual(mapped["increment-header"][0], (NORMAL_2K[0] + 1) & 0xFF)
+        self.assertEqual(mapped["decrement-tail"][-1], (NORMAL_2K[-1] - 1) & 0xFF)
+        self.assertEqual(mapped["bit-rotate-head"][0], ((NORMAL_2K[0] << 1) | (NORMAL_2K[0] >> 7)) & 0xFF)
+        self.assertEqual(mapped["nibble-swap-head"][0], ((NORMAL_2K[0] & 0x0F) << 4) | ((NORMAL_2K[0] & 0xF0) >> 4))
+        self.assertEqual(mapped["invert-tail-64"][-1], NORMAL_2K[-1] ^ 0xFF)
+        self.assertEqual(mapped["complement-mid-32"][len(NORMAL_2K) // 2], NORMAL_2K[len(NORMAL_2K) // 2] ^ 0xFF)
+        self.assertEqual(mapped["rotate-header"][:8], NORMAL_2K[1:8] + NORMAL_2K[:1])
+
+    def test_splice_grows_and_shrink_shortens(self):
+        mod = load()
+        mapped = as_map(mod.deterministic_mutants(NORMAL_2K))
+        n = len(NORMAL_2K)
+        self.assertEqual(len(mapped["splice-nul-mid"]), n + 16)
+        self.assertEqual(mapped["splice-nul-mid"][n // 2 : n // 2 + 16], b"\x00" * 16)
+        self.assertEqual(len(mapped["crlf-inject"]), n + 2)
+        self.assertEqual(mapped["crlf-inject"][n // 2 : n // 2 + 2], b"\r\n")
+        self.assertEqual(mapped["pad-eof"][-1:], b"\x1a")
+        self.assertEqual(len(mapped["widen-gap"]), n + 4)
+        self.assertEqual(len(mapped["shrink-gap"]), n - 4)
+        self.assertEqual(len(mapped["chop-last"]), n - 1)
+        self.assertEqual(len(mapped["cut-first"]), n - 1)
+        self.assertEqual(mapped["cut-first"], NORMAL_2K[1:])
+        self.assertEqual(len(mapped["odd-length-chop"]) % 2, 1)
+        self.assertNotIn("even-length-pad", mapped)
+
+    def test_odd_payload_gets_even_pad_not_odd_chop(self):
+        mod = load()
+        data = b"\x11" * 65
+        labels = labels_of(mod.deterministic_mutants(data))
+        self.assertIn("even-length-pad", labels)
+        self.assertNotIn("odd-length-chop", labels)
+        mapped = as_map(mod.deterministic_mutants(data))
+        self.assertEqual(mapped["even-length-pad"], data + b"\x00")
+
+    def test_zip_conditional_families(self):
+        mod = load()
+        local_only = b"xxxx" + b"PK\x03\x04" + b"yyyy" * 20
+        local_map = as_map(mod.deterministic_mutants(local_only))
+        self.assertIn("zip-local-header-flip", local_map)
+        self.assertNotIn("zip-magic-inject", local_map)
+        self.assertNotIn("zip-cd-magic-flip", local_map)
+        self.assertNotIn("zip-eocd-flip", local_map)
+        idx = local_only.find(b"PK\x03\x04")
+        self.assertEqual(
+            local_map["zip-local-header-flip"][idx : idx + 4],
+            bytes(x ^ 0xFF for x in b"PK\x03\x04"),
+        )
+
+        full = b"PK\x03\x04" + b"body" * 8 + b"PK\x01\x02" + b"cd" * 4 + b"PK\x05\x06" + b"end" * 4
+        full_map = as_map(mod.deterministic_mutants(full))
+        self.assertIn("zip-local-header-flip", full_map)
+        self.assertIn("zip-cd-magic-flip", full_map)
+        self.assertIn("zip-eocd-flip", full_map)
+        self.assertNotIn("zip-magic-inject", full_map)
+        cd = full.find(b"PK\x01\x02")
+        eocd = full.find(b"PK\x05\x06")
+        self.assertEqual(full_map["zip-cd-magic-flip"][cd : cd + 4], bytes(x ^ 0xFF for x in b"PK\x01\x02"))
+        self.assertEqual(full_map["zip-eocd-flip"][eocd : eocd + 4], bytes(x ^ 0xFF for x in b"PK\x05\x06"))
+
+    def test_hwp3_conditional_families(self):
+        mod = load()
+        inject = as_map(mod.deterministic_mutants(NORMAL_2K))
+        self.assertIn("hwp3-sig-inject", inject)
+        self.assertTrue(inject["hwp3-sig-inject"].startswith(mod.HWP3_SIG))
+        signed = mod.HWP3_SIG + b"\x00" * 80
+        flipped = as_map(mod.deterministic_mutants(signed))
+        self.assertIn("hwp3-sig-flip", flipped)
+        self.assertNotIn("hwp3-sig-inject", flipped)
+        expected = bytes(x ^ 0xFF for x in mod.HWP3_SIG[:4]) + mod.HWP3_SIG[4:]
+        self.assertEqual(flipped["hwp3-sig-flip"][: len(mod.HWP3_SIG)], expected)
+
+    def test_huge_input_skips_growing_splices(self):
+        mod = load()
+        # 실제 1MiB 를 여러 번 복사하면 시험이 느려지므로 최소 거대 크기만 쓴다.
+        huge = bytes([0x5A]) * mod.HUGE_MIN
+        labels = labels_of(mod.deterministic_mutants(huge))
+        for name in (
+            "splice-nul-mid",
+            "crlf-inject",
+            "pad-eof",
+            "widen-gap",
+            "even-length-pad",
+        ):
+            self.assertNotIn(name, labels, name)
+        for name in ("zero-header", "header-smash", "truncate@50%", "flip@50%", "shrink-gap"):
+            self.assertIn(name, labels, name)
+        self.assertEqual(mod.classify_input_shape(huge), "huge")
+
+    def test_tiny_ole_trunc_tail_plants_magic_prefix(self):
+        mod = load()
+        data = b"ABCD"
+        payload = as_map(mod.deterministic_mutants(data))["ole-trunc-tail"]
+        self.assertTrue(payload.endswith(mod.OLE_MAGIC[: min(4, len(data))]))
+
+    def test_utf16_sprinkle_uses_even_offsets(self):
+        mod = load()
+        payload = as_map(mod.deterministic_mutants(NORMAL_2K))["utf16-nul-sprinkle"]
+        n = len(NORMAL_2K)
+        for pct in (20, 40, 60, 80):
+            pos = min(n - 2, n * pct // 100) & ~1
+            self.assertEqual(payload[pos : pos + 2], b"\x00\x00")
+            self.assertEqual(pos % 2, 0)
+
+
+class ExceptionPathTests(unittest.TestCase):
+    def test_normalize_limit_and_timeout(self):
+        mod = load()
+        self.assertEqual(mod.normalize_limit(8), 8)
+        self.assertEqual(mod.normalize_limit("3"), 3)
+        self.assertEqual(mod.normalize_limit(-4), 0)
+        self.assertEqual(mod.normalize_limit(None), 0)
+        self.assertEqual(mod.normalize_limit("nope"), 0)
+        self.assertEqual(mod.normalize_limit(4.9), 4)
+        self.assertEqual(mod.normalize_timeout(8), 8)
+        self.assertEqual(mod.normalize_timeout("3"), 3)
+        self.assertEqual(mod.normalize_timeout(0), 0)
+        self.assertEqual(mod.normalize_timeout(-1), 0)
+        self.assertEqual(mod.normalize_timeout(None), 0)
+        self.assertEqual(mod.normalize_timeout("nope"), 0)
+
+    def test_select_samples_oserror_and_bad_limit(self):
+        mod = load()
+        missing = os.path.join(tempfile.gettempdir(), "gym-robust-missing-dir-does-not-exist")
+        picked, total = mod.select_samples(missing, 8)
+        self.assertEqual(picked, [])
+        self.assertEqual(total, 0)
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "a.hwp").write_bytes(b"x")
+            Path(d, "b.hwp").write_bytes(b"x")
+            empty, count = mod.select_samples(d, 0)
+            self.assertEqual(empty, [])
+            self.assertEqual(count, 2)
+            empty2, count2 = mod.select_samples(d, "bad")
+            self.assertEqual(empty2, [])
+            self.assertEqual(count2, 2)
+            all_picked, _ = mod.select_samples(d, 99)
+            self.assertEqual(all_picked, ["a.hwp", "b.hwp"])
+
+    def test_read_sample_missing_and_success(self):
+        mod = load()
+        data, err = mod.read_sample(os.path.join(tempfile.gettempdir(), "no-such-robust.hwp"))
+        self.assertIsNone(data)
+        self.assertIsInstance(err, str)
+        self.assertIn("Error", err)
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "ok.hwp")
+            Path(path).write_bytes(b"abc")
+            payload, err2 = mod.read_sample(path)
+            self.assertEqual(payload, b"abc")
+            self.assertIsNone(err2)
+
+    def test_write_mutant_typeerror_and_oserror(self):
+        mod = load()
+        self.assertTrue(mod.write_mutant("ignored", "not-bytes").startswith("TypeError"))
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "mut.hwp")
+            self.assertIsNone(mod.write_mutant(path, b"xyz"))
+            self.assertEqual(Path(path).read_bytes(), b"xyz")
+            self.assertIsNone(mod.write_mutant(path, bytearray(b"zz")))
+            missing_parent = os.path.join(d, "no-dir", "mut.hwp")
+            err = mod.write_mutant(missing_parent, b"x")
+            self.assertIsInstance(err, str)
+            self.assertTrue(err)
+
+    def test_probe_head_and_posix_signal_helper(self):
+        mod = load()
+        self.assertEqual(mod.probe_head(None), "")
+        self.assertEqual(mod.probe_head(1234), "1234")
+        self.assertEqual(mod.probe_head("abcdef", 3), "abc")
+        self.assertEqual(mod.probe_head("abcdef", 0), "")
+        self.assertTrue(mod._posix_signal_timeout(-9))
+        self.assertTrue(mod._posix_signal_timeout(-24))
+        self.assertFalse(mod._posix_signal_timeout(9))
+        self.assertFalse(mod._posix_signal_timeout(None))
+
+    def test_classify_timeout_strings_and_os_errnos(self):
+        mod = load()
+        self.assertTrue(mod.classify_timeout("Deadline Exceeded"))
+        self.assertTrue(mod.classify_timeout("process timed out"))
+        self.assertTrue(mod.classify_timeout("TIME-OUT"))
+        self.assertFalse(mod.classify_timeout("ok"))
+        self.assertTrue(mod.classify_timeout(TimeoutError("late")))
+        timed = OSError(getattr(errno, "ETIMEDOUT", 110), "late")
+        timed.errno = getattr(errno, "ETIMEDOUT", 110)
+        self.assertTrue(mod.classify_timeout(timed))
+        other = OSError(errno.ENOENT, "missing")
+        other.errno = errno.ENOENT
+        self.assertFalse(mod.classify_timeout(other))
+        self.assertFalse(mod.classify_timeout(ValueError("timeout in name only")))
+
+    def test_classify_panic_extra_markers_and_bad_code(self):
+        mod = load()
+        for marker in (
+            "stack overflow",
+            "core dumped",
+            "fatal runtime error",
+            "SIGSEGV",
+            "SIGABRT",
+            "access violation",
+            "Segmentation Fault",
+            "illegal instruction",
+            "Abort trap",
+        ):
+            self.assertTrue(mod.classify_panic(0, marker), marker)
+        self.assertFalse(mod.classify_panic("not-int", "clean"))
+        self.assertFalse(mod.classify_panic(1, None))
+        self.assertTrue(mod.classify_panic(101, None))
+        self.assertTrue(mod.classify_panic(101, 12345))
+        self.assertFalse(mod.classify_panic(2, b"bytes-err"))
+
+    def test_classify_probe_outcome_matrix(self):
+        mod = load()
+        self.assertEqual(mod.classify_probe_outcome(0, False, True, ""), "hang")
+        self.assertEqual(mod.classify_probe_outcome(101, False, False, ""), "panic")
+        self.assertEqual(mod.classify_probe_outcome(0, True, False, "ok"), "panic")
+        self.assertEqual(mod.classify_probe_outcome(0, False, False, "oserror FileNotFound"), "error")
+        self.assertEqual(mod.classify_probe_outcome(None, False, False, "probe-error boom"), "error")
+        self.assertEqual(mod.classify_probe_outcome(None, False, False, "unreadable x"), "error")
+        self.assertEqual(mod.classify_probe_outcome(2, False, False, "bad file"), "graceful")
+        self.assertEqual(mod.classify_probe_outcome(0, False, False, ""), "ok")
+        self.assertEqual(mod.classify_probe_outcome(None, False, False, "other"), "error")
+
+    def test_probe_invalid_timeout_and_missing_bin(self):
+        mod = load()
+        self.assertEqual(mod.probe("bin", "x.hwp", 0), (None, False, False, "probe-error invalid-timeout"))
+        self.assertEqual(mod.probe("bin", "x.hwp", -3), (None, False, False, "probe-error invalid-timeout"))
+        self.assertEqual(mod.probe("", "x.hwp", 5), (None, False, False, "probe-error missing-bin"))
+        self.assertEqual(mod.probe(None, "x.hwp", 5), (None, False, False, "probe-error missing-bin"))
+
+    def test_probe_oserror_is_not_panic(self):
+        mod = load()
+        code, panicked, timed_out, head = mod.probe(
+            os.path.join(tempfile.gettempdir(), "no-such-rhwp-bin-xyz"),
+            os.path.join(tempfile.gettempdir(), "no-such.hwp"),
+            2,
+        )
+        self.assertIsNone(code)
+        self.assertFalse(panicked)
+        self.assertFalse(timed_out)
+        self.assertTrue(head.startswith("oserror "))
+        self.assertEqual(mod.classify_probe_outcome(code, panicked, timed_out, head), "error")
+
+    def test_probe_timeout_expired_is_hang(self):
+        mod = load()
+
+        def boom(*_a, **_k):
+            raise subprocess.TimeoutExpired("rhwp", 1)
+
+        with mock.patch("subprocess.run", side_effect=boom):
+            code, panicked, timed_out, head = mod.probe("rhwp", "x.hwp", 1)
+        self.assertIsNone(code)
+        self.assertFalse(panicked)
+        self.assertTrue(timed_out)
+        self.assertTrue(head.startswith("timeout "))
+        self.assertEqual(mod.classify_probe_outcome(code, panicked, timed_out, head), "hang")
+
+    def test_probe_unexpected_exception_is_error(self):
+        mod = load()
+
+        def boom(*_a, **_k):
+            raise RuntimeError("broken pipe")
+
+        with mock.patch("subprocess.run", side_effect=boom):
+            code, panicked, timed_out, head = mod.probe("rhwp", "x.hwp", 1)
+        self.assertIsNone(code)
+        self.assertFalse(panicked)
+        self.assertFalse(timed_out)
+        self.assertTrue(head.startswith("probe-error RuntimeError"))
+        self.assertEqual(mod.classify_probe_outcome(code, panicked, timed_out, head), "error")
+
+    def test_probe_success_path_classifies_panic_from_output(self):
+        mod = load()
+
+        class Fake:
+            returncode = 0
+            stdout = b""
+            stderr = b"thread 'main' panicked at src/x.rs"
+
+        with mock.patch("subprocess.run", return_value=Fake()):
+            code, panicked, timed_out, head = mod.probe("rhwp", "x.hwp", 1)
+        self.assertEqual(code, 0)
+        self.assertTrue(panicked)
+        self.assertFalse(timed_out)
+        self.assertIn("panicked", head)
+
+    def test_audit_records_unreadable_samples(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "ok.hwp").write_bytes(NORMAL_2K)
+            Path(d, "bad.hwp").write_bytes(NORMAL_2K)
+            real_read = mod.read_sample
+
+            def wrapped(path):
+                if path.endswith("bad.hwp"):
+                    return None, "PermissionError: denied"
+                return real_read(path)
+
+            mod.read_sample = wrapped
+            mod.probe = lambda *_a, **_k: (1, False, False, "오류")
+            report = mod.audit("bin", d, limit=2, timeout=5)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["samplesTested"], 2)
+        self.assertEqual(len(report["unreadables"]), 1)
+        self.assertIn("bad.hwp", report["unreadables"][0])
+        self.assertGreater(report["mutantsChecked"], 0)
+        self.assertEqual(report["inputShapes"]["normal"], 1)
+
+    def test_audit_records_write_errors(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "s.hwp").write_bytes(NORMAL_2K)
+            mod.write_mutant = lambda *_a, **_k: "OSError: disk full"
+            report = mod.audit("bin", d, limit=1, timeout=5)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["mutantsChecked"], 0)
+        self.assertGreater(len(report["probeErrors"]), 0)
+        self.assertTrue(any("disk full" in item for item in report["probeErrors"]))
+
+    def test_audit_records_probe_error_heads(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "s.hwp").write_bytes(NORMAL_2K)
+            mod.probe = lambda *_a, **_k: (None, False, False, "oserror FileNotFoundError: gone")
+            report = mod.audit("bin", d, limit=1, timeout=5)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["panics"], [])
+        self.assertEqual(report["hangs"], [])
+        self.assertGreater(len(report["probeErrors"]), 0)
+        self.assertGreater(report["mutantsChecked"], 0)
+
+    def test_audit_probe_raising_is_caught(self):
+        mod = load()
+
+        def boom(*_a, **_k):
+            raise RuntimeError("probe exploded")
+
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "s.hwp").write_bytes(NORMAL_2K)
+            mod.probe = boom
+            report = mod.audit("bin", d, limit=1, timeout=5)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["mutantsChecked"], 0)
+        self.assertTrue(any("probe exploded" in item for item in report["probeErrors"]))
+
+    def test_audit_mutant_typeerror_is_unreadable(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "s.hwp").write_bytes(NORMAL_2K)
+            mod.deterministic_mutants = lambda *_a, **_k: (_ for _ in ()).throw(TypeError("bad"))
+            report = mod.audit("bin", d, limit=1, timeout=5)
+        self.assertTrue(report["ok"])
+        self.assertTrue(any("TypeError" in item for item in report["unreadables"]))
+        self.assertEqual(report["mutantsChecked"], 0)
+
+    def test_empty_report_validates(self):
+        mod = load()
+        report = mod.empty_report()
+        self.assertEqual(mod.validate_report(report), [])
+        self.assertTrue(report["ok"])
+        self.assertEqual(set(report), set(REPORT_KEYS))
+        self.assertEqual(report["inputShapes"], {"empty": 0, "tiny": 0, "normal": 0, "huge": 0})
+
+    def test_validate_report_detects_schema_breaks(self):
+        mod = load()
+        self.assertEqual(mod.validate_report("nope"), ["report-not-dict"])
+        report = mod.empty_report()
+        report.pop("hangs")
+        issues = mod.validate_report(report)
+        self.assertTrue(any(item.startswith("missing:") for item in issues))
+        report = mod.empty_report()
+        report["extraKey"] = 1
+        issues = mod.validate_report(report)
+        self.assertTrue(any(item.startswith("extra:") for item in issues))
+        report = mod.empty_report()
+        report["kind"] = "other"
+        report["schemaVersion"] = "9"
+        report["ok"] = "yes"
+        report["samplesTested"] = -1
+        report["panics"] = [1]
+        report["inputShapes"] = {"empty": 0}
+        issues = mod.validate_report(report)
+        self.assertIn("kind", issues)
+        self.assertIn("schemaVersion", issues)
+        self.assertIn("ok-type", issues)
+        self.assertIn("samplesTested-negative", issues)
+        self.assertIn("panics-item-type", issues)
+        self.assertTrue(any(item.startswith("inputShapes-missing-") for item in issues))
+        report = mod.empty_report()
+        report["ok"] = False
+        self.assertIn("ok-mismatch", mod.validate_report(report))
+
+    def test_format_human_report_ok_and_fail(self):
+        mod = load()
+        ok = mod.empty_report()
+        text = mod.format_human_report(ok)
+        self.assertIn("패닉 0", text)
+        self.assertIn("행 0", text)
+        fail = mod.empty_report()
+        fail["ok"] = False
+        fail["panics"] = ["s.hwp:ff-run (code 101): panicked"]
+        fail["hangs"] = ["s.hwp:truncate@50%"]
+        text = mod.format_human_report(fail)
+        self.assertIn("패닉 1", text)
+        self.assertIn("행 1", text)
+        self.assertIn("s.hwp:ff-run", text)
+        self.assertIn("s.hwp:truncate@50%", text)
+
+    def test_ok_success_is_not_graceful(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "s.hwp").write_bytes(NORMAL_2K)
+            mod.probe = lambda *_a, **_k: (0, False, False, "")
+            report = mod.audit("bin", d, limit=1, timeout=5)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["gracefullyDegraded"], 0)
+        self.assertGreater(report["mutantsChecked"], 0)
+        self.assertEqual(report["inputShapes"]["normal"], 1)
+
+    def test_mixed_panic_and_hang_keep_ok_false(self):
+        mod = load()
+        calls = {"n": 0}
+
+        def probe(*_a, **_k):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return 101, True, False, "panicked"
+            if calls["n"] == 2:
+                return None, False, True, "timeout"
+            return 1, False, False, "오류"
+
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "s.hwp").write_bytes(NORMAL_2K)
+            mod.probe = probe
+            report = mod.audit("bin", d, limit=1, timeout=5)
+        self.assertFalse(report["ok"])
+        self.assertEqual(len(report["panics"]), 1)
+        self.assertEqual(len(report["hangs"]), 1)
+        self.assertGreater(report["gracefullyDegraded"], 0)
+        self.assertEqual(mod.validate_report(report), [])
+
+
+class ShapeAndSelectEdgeTests(unittest.TestCase):
+    def test_stride_selection_is_stable_across_limits(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            for i in range(20):
+                Path(d, f"{i:02d}.hwp").write_bytes(b"x")
+            five, total = mod.select_samples(d, 5)
+            ten, _ = mod.select_samples(d, 10)
+            self.assertEqual(total, 20)
+            self.assertEqual(len(five), 5)
+            self.assertEqual(len(ten), 10)
+            self.assertEqual(five, [five[0], five[1], five[2], five[3], five[4]])
+            self.assertEqual(mod.select_samples(d, 5)[0], five)
+
+    def test_input_shape_counts_in_audit(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "empty.hwp").write_bytes(b"")
+            Path(d, "tiny.hwp").write_bytes(b"\x00" * 8)
+            Path(d, "normal.hwp").write_bytes(NORMAL_2K)
+            mod.probe = lambda *_a, **_k: (1, False, False, "오류")
+            report = mod.audit("bin", d, limit=3, timeout=5)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["inputShapes"]["empty"], 1)
+        self.assertEqual(report["inputShapes"]["tiny"], 1)
+        self.assertEqual(report["inputShapes"]["normal"], 1)
+        self.assertEqual(report["inputShapes"]["huge"], 0)
+        self.assertGreater(report["mutantsChecked"], 3)
+
+    def test_empty_sample_still_probes_single_mutant(self):
+        mod = load()
+        seen = []
+
+        def probe(_bin, path, _timeout):
+            seen.append(Path(path).read_bytes())
+            return 1, False, False, "오류"
+
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "empty.hwp").write_bytes(b"")
+            mod.probe = probe
+            report = mod.audit("bin", d, limit=1, timeout=5)
+        self.assertEqual(seen, [b"\x00"])
+        self.assertEqual(report["mutantsChecked"], 1)
+        self.assertEqual(report["inputShapes"]["empty"], 1)
+        self.assertEqual(report["gracefullyDegraded"], 1)
+
+    def test_no_hwp_files_yields_empty_clean_report(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "note.txt").write_text("x", encoding="utf-8")
+            report = mod.audit("bin", d, limit=8, timeout=5)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["samplesTested"], 0)
+        self.assertEqual(report["totalSamples"], 0)
+        self.assertEqual(report["mutantsChecked"], 0)
+        self.assertEqual(mod.validate_report(report), [])
+
+    def test_module_constants_match_test_contract(self):
+        mod = load()
+        self.assertEqual(mod.ALWAYS_LABELS, ALWAYS_LABELS)
+        self.assertEqual(mod.EXPANDED_ALWAYS_LABELS, EXPANDED_ALWAYS_LABELS)
+        self.assertEqual(mod.REPORT_KIND, "gymRobustness")
+        self.assertEqual(mod.SCHEMA_VERSION, "1.0")
+        self.assertEqual(mod.TINY_MAX, 64)
+        self.assertEqual(mod.HUGE_MIN, 1_048_576)
+        self.assertEqual(mod.OLE_MAGIC, b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1")
+        self.assertEqual(mod.ZIP_LOCAL, b"PK\x03\x04")
+        self.assertEqual(mod.ZIP_CD, b"PK\x01\x02")
+        self.assertEqual(mod.ZIP_EOCD, b"PK\x05\x06")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 변경 요약

`gym/tools/robustness.py` 의 결정적 손상 변형을 늘려 도구 강건성 감사의 판별력을 높인다. 무작위는 쓰지 않는다. 같은 입력은 같은 라벨·바이트를 내고, 원본과 바이트가 같은 무의미 변형은 버린다.

추가한 변형(기존 truncate/flip/zero-header 유지):

- `header-smash` — 선두 64바이트를 고정 패턴으로 덮어씀
- `ole-trunc-tail` — OLE-ish 꼬리 절단(64바이트) 또는 잘린 OLE 매직
- `ff-run` — 본문 중간의 결정적 0xFF 런
- `utf16-nul-sprinkle` — 짝수 오프셋에 UTF-16 NUL 삽입
- `zip-local-header-flip` — `PK\x03\x04` 가 있을 때만 로컬 헤더 플립

`classify_panic` / `classify_timeout` 을 감사 경로에 쓰고, JSON 봉투(`kind=gymRobustness`, `schemaVersion=1.0`) 시험을 고정한다. packs·checks·coverage·다른 도구는 손대지 않았다.

## 관련 이슈

closes #5218

## 테스트

- [x] `python -m unittest scripts.tests.test_gym_robustness scripts.tests.test_gym_audit` 통과 (16)
- [ ] **`cargo fmt --all -- --check` 통과** — 이번 변경은 Python만. 사용자 지시에 따라 실행하지 않음
- [ ] `node scripts/rust-test-suite-manifest.mjs --check` — 해당 없음
- [ ] `node scripts/rust-unit-test-tiers.mjs --check` — 해당 없음
- [ ] `cargo test` — 해당 없음
- [ ] `cargo clippy -- -D warnings` — 해당 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 감사 시 샘플당 변형이 8개에서 기본 12개(+ZIP이면 13개)로 늘어 프로브 횟수가 증가한다. 런타임 rhwp 파싱 경로는 불변.
- 재현·측정: 바이너리 없이 unittest만 실행. 미측정(게이트 로직 확대).
