### PR TITLE
feat(gym): 자기서술 pack에 SD08+ 과제와 기준풀이를 추가한다

### DIFF
--- a/gym/packs/self-description/README.md
+++ b/gym/packs/self-description/README.md
@@ -1,0 +1,271 @@
+---
+kind: guide
+status: active
+canonical: gym/packs/self-description/README.md
+last_verified: 2026-08-18
+---
+
+# self-description — 도구가 스스로를 설명하는 계약
+
+## 왜 이 pack 인가 (온램프)
+
+에이전트가 rhwp 를 처음 만나면 문서가 아니라 **도구 자신**을 읽어야 한다.
+어느 명령을 부를지, 봉투에 어떤 필드가 실리는지, 스키마 버전이 어디 축인지,
+MCP 호스트에 무엇을 등록할지 — 이 정보는 위키에 있지 않다. `capabilities` 와
+스키마 계열 명령이 그 단일 출처다.
+
+`starter` 프로파일이 이 pack 을 `core-cli` 와 묶는 이유이기도 하다. 본문·표를
+고치기 전에, 도구가 스스로 신고하는 표면을 숫자와 경로로 읽을 수 있어야 한다.
+SD01–SD07 은 그 입구(명령 수·형식·매니페스트·출처 지도·온톨로지·계획 스키마·
+IR 스키마)다. SD08–SD12 는 MCP·레지스트리·도움 검색·행위 수·종료 코드를
+한 겹 더 묻는다. SD13+ 는 같은 명령 가족 안에서 **축 이름·계약 문구·검색
+키워드·스키마 `$ref`** 까지 내려가, "capabilities 를 한 번 훑었다"가 아니라
+"봉투의 어느 자리가 무슨 뜻인지 짚을 수 있다"를 채점한다.
+
+이 pack 은 새 CLI 를 만들지 않는다. 새 pack 도 만들지 않는다. runner 신원은
+기존 `pack.json` 을 그대로 쓴다. 요구 명령은 자기서술 가족만 늘린다
+(`export-ir-schema`, `export-capabilities-schema`).
+
+## 명령 가족 — 이 pack 이 쓰는 것
+
+| 명령 | 묻는 것 |
+| --- | --- |
+| `capabilities` | 명령 표면·형식·종료 코드·레지스트리·jsonContract·batch |
+| `capabilities --mcp` | MCP 도구 매니페스트·서버 신원·프로필 |
+| `capabilities --search <키워드> --json` | 이름·요약·하위명령 부분 문자열 검색 |
+| `export-agent-manifest` | capabilities+IR+출처+계획 을 1회 조립 |
+| `export-ontology` | JSON-LD 클래스·속성·행위 규모 |
+| `export-plan-schema` | `run` 계획서 JSON Schema |
+| `export-ir-schema` | 문서 IR JSON Schema |
+| `export-capabilities-schema` | capabilities 자체와 MCP 매니페스트 스키마 |
+| `export-provenance-map` | 봉투 필드가 문서에서 왔는지의 지도 |
+
+`edit`·`export-tables`·`search` 같은 문서 작업 명령은 여기 없다. 대상이 문서가
+아니라 도구 자신이기 때문이다. 입력 `samples/table-001.hwp` 는 gym 과제가
+입력을 갖도록 하는 자리일 뿐, 자기서술 명령은 그 파일을 열지 않는다.
+
+## 채점 계약
+
+- **라이브 오라클.** `answer_eq` / `len_answer_eq` 는 채점 시점에 같은 `cmd` 를
+  다시 돌려 기대값을 센다. 골든 숫자를 박제하지 않는다.
+- **고정 계약은 `json_value_eq`.** dialect URL, `$ref`, `capabilitiesSchemaVersion`
+  처럼 소스 상수가 있는 자리는 산출물 파일에서 직접 대조한다.
+- **무편집 복사 거부.** 산출물 과제(SD07·SD71–SD74)는 `differs_from_input` 으로
+  입력 HWP 를 그대로 낸 제출을 거절한다.
+- **정답은 바이너리를 따른다.** MCP 도구 수·검색 적중 수·`actionCount` 는
+  명령이 늘면 같이 는다. 기준풀이와 검사가 같은 명령을 쓰므로 채점은 따라간다.
+
+## 재현
+
+```bash
+python gym/tools/audit.py
+python -m unittest scripts.tests.test_gym_packs scripts.tests.test_gym_self_description_pack
+# 바이너리가 있으면 (선택) 기준풀이 왕복
+python gym/tools/build_baseline.py --agent baseline --pack self-description --bin target/debug/rhwp
+python gym/score.py --agent baseline --pack self-description --bin target/debug/rhwp
+```
+
+`cargo fmt --all` 은 이 pack 과 무관하다. JSON·Markdown·Python 만 바뀐다.
+
+## 과제 목록
+
+### SD01–SD07 — 입구
+
+| ID | 티어 | 축 | 명령 | 묻는 자리 |
+| --- | --- | --- | --- | --- |
+| SD01 | 1 | 조사 | `capabilities` | `commands` 길이 |
+| SD02 | 1 | 조사 | `capabilities` | `formats.read` / `formats.write` 길이 |
+| SD03 | 2 | 조사 | `export-agent-manifest --json` | `missingAxes` 길이 |
+| SD04 | 2 | 조사 | `export-provenance-map --json` | `commands` 길이 |
+| SD05 | 2 | 조사 | `export-ontology --json` | `classCount` · `propertyCount` |
+| SD06 | 2 | 조사 | `export-plan-schema --json` | `definitionCount` |
+| SD07 | 2 | — | `export-ir-schema` | 산출 `ir.json` dialect |
+
+### SD08–SD12 — 한 겹 더
+
+| ID | 티어 | 명령 | 묻는 자리 |
+| --- | --- | --- | --- |
+| SD08 | 2 | `capabilities --mcp` | `tools` 길이 |
+| SD09 | 2 | `capabilities` | `schemaRegistry.axes` 길이 |
+| SD10 | 2 | `capabilities --search schema --json` | `commands` 길이 |
+| SD11 | 2 | `export-ontology --json` | `actionCount` |
+| SD12 | 2 | `capabilities` | `exitCodes` 길이 |
+
+### SD13–SD25 — 신원과 레지스트리 축
+
+에이전트가 "버전이 몇인가"를 추측하지 않게, 레지스트리 네 축의 이름·버전·
+표면·정책 경로를 각각 묻는다. 축 순서는 소스 계약으로 고정이다
+(`envelope`, `ir`, `capabilities`, `plan`).
+
+| ID | 제목 | 경로 |
+| --- | --- | --- |
+| SD13 | 도구 이름 | `tool` |
+| SD14 | 봉투 schemaVersion | `schemaVersion` |
+| SD15 | crate 버전 | `schemaRegistry.crateVersion` |
+| SD16 | 버전 정책 경로 | `schemaRegistry.policy` |
+| SD17 | envelope 축 이름 | `schemaRegistry.axes[0].axis` |
+| SD18 | ir 축 이름 | `schemaRegistry.axes[1].axis` |
+| SD19 | capabilities 축 이름 | `schemaRegistry.axes[2].axis` |
+| SD20 | plan 축 이름 | `schemaRegistry.axes[3].axis` |
+| SD21 | envelope 축 버전 | `schemaRegistry.axes[0].version` |
+| SD22 | ir 축 버전 | `schemaRegistry.axes[1].version` |
+| SD23 | capabilities 축 버전 | `schemaRegistry.axes[2].version` |
+| SD24 | plan 축 버전 | `schemaRegistry.axes[3].version` |
+| SD25 | envelope 축 표면 | `schemaRegistry.axes[0].surface` |
+
+### SD26–SD38 — jsonContract 와 batch
+
+`--json` 계약의 전역 규약과 batch 축 전체를 묻는다. 개별 명령의
+`recordFields` 가 아니라, 모든 명령이 공유하는 stdout·실패·출처 표지·
+문자열 보안·batch 입출력이다.
+
+| ID | 제목 | 경로 |
+| --- | --- | --- |
+| SD26 | jsonContract.stdout | `jsonContract.stdout` |
+| SD27 | jsonContract.schemaPolicy | `jsonContract.schemaPolicy` |
+| SD28 | jsonContract.failure | `jsonContract.failure` |
+| SD29 | 출처 표지 필드 수 | `jsonContract.provenance.fields` |
+| SD30 | 출처 지도 조회 방법 | `jsonContract.provenance.map` |
+| SD31 | textSecurity 종류 수 | `jsonContract.textSecurity.kinds` |
+| SD32 | textSecurity 상태 수 | `jsonContract.textSecurity.status` |
+| SD33 | textSecurity 정책 | `jsonContract.textSecurity.policy` |
+| SD34 | batch 하위명령 수 | `batch.subcommands` |
+| SD35 | batch 플래그 수 | `batch.flags` |
+| SD36 | batch MCP 노출 축 수 | `batch.mcp.available` |
+| SD37 | batch 입력 규약 | `batch.input` |
+| SD38 | batch 순서 규약 | `batch.ordering` |
+
+### SD39–SD45 — 도움 검색
+
+`--search` 는 대소문자 무시 부분 문자열, 여러 단어는 AND 다. 하위 명령
+이름·요약도 검색 대상이다. 적중 수는 명령이 늘면 같이 늘므로 라이브로 센다.
+SD45 는 검색 봉투가 질의 문자열을 메아리치는지 본다 — 적중 집합만 보고
+무엇을 검색했는지 잃는 소비자를 막는다.
+
+| ID | 키워드 | 경로 |
+| --- | --- | --- |
+| SD39 | export | `commands` 길이 |
+| SD40 | inspect | `commands` 길이 |
+| SD41 | edit | `commands` 길이 |
+| SD42 | ontology | `commands` 길이 |
+| SD43 | provenance | `commands` 길이 |
+| SD44 | plan | `commands` 길이 |
+| SD45 | schema | `search` 메아리 |
+
+### SD46–SD51 — MCP 매니페스트
+
+SD08 이 도구 수만 묻는다면, 여기서는 호스트가 등록 파일을 베끼지 않고도
+쓸 수 있는 신원 필드를 묻는다. `protocol` 은 항상 `mcp`, 권고 서버 이름은
+`rhwp`, 전송은 `cli`, stdio 서버 명령은 `mcp-serve`.
+
+| ID | 제목 | 경로 |
+| --- | --- | --- |
+| SD46 | MCP protocol | `protocol` |
+| SD47 | MCP 서버 권고 이름 | `server.suggestedName` |
+| SD48 | MCP 프로필 수 | `profiles` |
+| SD49 | MCP invocation.transport | `invocation.transport` |
+| SD50 | MCP stdin 도구 수 | `invocation.stdinTools` |
+| SD51 | MCP stdio 서버 명령 | `invocation.server` |
+
+### SD52–SD70 — 스키마 내보내기 메타
+
+계획·IR·capabilities 스키마와 매니페스트·출처 지도의 **메타 필드**를 묻는다.
+본문 `$defs` 를 다 읽지 않아도 규모(`definitionCount`)와 뿌리(`$ref`)를 대조할
+수 있어야 코드 생성기가 빈 스키마를 즉시 거부한다.
+
+| ID | 명령 | 경로 |
+| --- | --- | --- |
+| SD52 | `export-plan-schema --json` | `planSchemaVersion` |
+| SD53 | `export-plan-schema --json` | `dialect` |
+| SD54 | `export-plan-schema --json` | `definitionCount` |
+| SD55 | `export-ir-schema --json` | `irSchemaVersion` |
+| SD56 | `export-ir-schema --json` | `definitionCount` |
+| SD57 | `export-capabilities-schema --json` | `capabilitiesSchemaVersion` |
+| SD58 | `export-capabilities-schema --json` | `definitionCount` |
+| SD59 | `export-capabilities-schema --json` | `dialect` |
+| SD60 | `export-ontology --json` | `schemaVersion` |
+| SD61 | `export-agent-manifest --json` | `capabilities.commands` 길이 |
+| SD62 | `export-agent-manifest --json` | `irSchema.$defs` 길이 |
+| SD63 | `export-provenance-map --json` | `envelopeFlags` 키 수 |
+| SD64 | `export-provenance-map --json` | `pathSyntax` |
+| SD65 | `export-ir-schema --json` | `schema.$ref` |
+| SD66 | `export-plan-schema --json` | `schema.$ref` |
+| SD67 | `export-capabilities-schema --json` | `schema.$ref` |
+| SD68 | `export-capabilities-schema --json` | `mcpSchema.$ref` |
+| SD69 | `export-agent-manifest --json` | `schemaVersion` |
+| SD70 | `export-provenance-map --json` | `tool` |
+
+### SD71–SD74 — 스키마 산출물
+
+숫자만 맞추고 본문을 내지 않는 제출을 거절한다. SD07 과 같은 형식이다.
+
+| ID | 산출 | 고정 대조 |
+| --- | --- | --- |
+| SD71 | `capabilities-schema.json` | dialect · `capabilitiesSchemaVersion`=`1.3` · `schema.$ref`=`#/$defs/Capabilities` |
+| SD72 | `plan-schema.json` | dialect · `planSchemaVersion`=`1.1` · `schema.$ref`=`#/$defs/Plan` |
+| SD73 | `ontology.json` | `schemaVersion`=`1.0` |
+| SD74 | `ir-schema.json` | dialect · `irSchemaVersion`=`1.0` · `schema.$ref`=`#/$defs/Document` |
+
+## 기준풀이 형식
+
+답 과제는 채점과 같은 `cmd`/`path` 를 기준풀이에 적어 라이브로 길다.
+
+```json
+{
+  "id": "SD13",
+  "steps": [
+    {
+      "answer": {
+        "tool": { "cmd": ["capabilities"], "path": "tool" }
+      }
+    }
+  ]
+}
+```
+
+산출 과제는 `-o {sub:파일}` 로 제출 폴더에 쓴다.
+
+```json
+{
+  "id": "SD71",
+  "steps": [
+    { "run": ["export-capabilities-schema", "-o", "{sub:capabilities-schema.json}"] }
+  ]
+}
+```
+
+## 정직한 경계
+
+- **문서 인스턴스 온톨로지(O2)는 없다.** `export-ontology` 는 도구 자신의
+  스키마 모드만 낸다. 특정 HWP 한 부를 개체로 서술하는 과제는 이 pack 이
+  아니다.
+- **새 검색 연산·새 플래그는 없다.** `--search` 의 AND 부분 문자열과
+  `--mcp` 매니페스트만 쓴다. `--profile` 필터 과제는 프로필 이름이 늘면
+  적중 집합이 바뀌어 판별력이 떨어지므로 넣지 않았다.
+- **gym/README·PARK·profiles·다른 pack·checks.py 는 그대로다.** 과제 수
+  표가 구식이 되는 것은 이 pack 의 README 가 정본이 되기 때문이다.
+- **라이브 채점을 이 확장에서 다시 돌리지는 않았다.** 검사 경로와 기준풀이
+  `cmd`/`path` 는 SD01–SD12 와 같고, 고정값은 소스 계약
+  (`schema_registry.rs`·`capabilities_schema.rs`·`plan_schema.rs`·`ir_schema.rs`)
+  에서 확인했다.
+
+## 위험
+
+- 바이너리 버전이 바뀌면 MCP 도구 수·검색 적중 수·`definitionCount`·
+  `actionCount` 가 달라질 수 있다. 기준풀이와 검사가 같은 명령을 쓰므로
+  채점은 따라가지만, 사람이 박제한 노트를 믿으면 안 된다.
+- `capabilities --search` 적중 집합은 명령 이름·요약·하위 명령 문구에
+  의존한다. 요약을 고치면 수가 줄 수 있다.
+- `schemaRegistry.axes[n]` 순서 가정은 레지스트리 계약 테스트가 고정한다.
+  축을 끼워 넣으면 이 pack 의 SD17–SD24 가 깨지는 것이 의도다 — 축 집합
+  변경은 capabilities minor 이고, 과제가 그 변경을 드러내야 한다.
+- `capabilitiesSchemaVersion`=`1.3` 같은 고정 대조는 소스 상수를 올린
+  커밋에서 함께 고쳐야 한다. 스키마 major/minor 규약 자체는
+  `mydocs/tech/agent_runtime/version_policy.md` 가 정본이다.
+
+## 관련
+
+- 이슈: [#5217](https://github.com/edwardkim/rhwp/issues/5217)
+- 작업 기록: [`mydocs/working/gym_self_description.md`](../../../mydocs/working/gym_self_description.md)
+- 계약 테스트: `scripts/tests/test_gym_self_description_pack.py`
+- gym 공통 감사: `python gym/tools/audit.py`

--- a/gym/packs/self-description/pack.json
+++ b/gym/packs/self-description/pack.json
@@ -9,6 +9,8 @@
     "commands": [
       "capabilities",
       "export-agent-manifest",
+      "export-capabilities-schema",
+      "export-ir-schema",
       "export-ontology",
       "export-plan-schema",
       "export-provenance-map"

--- a/gym/packs/self-description/reference/SD08.json
+++ b/gym/packs/self-description/reference/SD08.json
@@ -1,0 +1,17 @@
+{
+  "id": "SD08",
+  "steps": [
+    {
+      "answer": {
+        "tools": {
+          "cmd": [
+            "capabilities",
+            "--mcp"
+          ],
+          "path": "tools",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD09.json
+++ b/gym/packs/self-description/reference/SD09.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD09",
+  "steps": [
+    {
+      "answer": {
+        "axes": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "schemaRegistry.axes",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD10.json
+++ b/gym/packs/self-description/reference/SD10.json
@@ -1,0 +1,19 @@
+{
+  "id": "SD10",
+  "steps": [
+    {
+      "answer": {
+        "hits": {
+          "cmd": [
+            "capabilities",
+            "--search",
+            "schema",
+            "--json"
+          ],
+          "path": "commands",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD11.json
+++ b/gym/packs/self-description/reference/SD11.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD11",
+  "steps": [
+    {
+      "answer": {
+        "actions": {
+          "cmd": [
+            "export-ontology",
+            "--json"
+          ],
+          "path": "actionCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD12.json
+++ b/gym/packs/self-description/reference/SD12.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD12",
+  "steps": [
+    {
+      "answer": {
+        "codes": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "exitCodes",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD13.json
+++ b/gym/packs/self-description/reference/SD13.json
@@ -1,0 +1,15 @@
+{
+  "id": "SD13",
+  "steps": [
+    {
+      "answer": {
+        "tool": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "tool"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD14.json
+++ b/gym/packs/self-description/reference/SD14.json
@@ -1,0 +1,15 @@
+{
+  "id": "SD14",
+  "steps": [
+    {
+      "answer": {
+        "schemaVersion": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "schemaVersion"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD15.json
+++ b/gym/packs/self-description/reference/SD15.json
@@ -1,0 +1,15 @@
+{
+  "id": "SD15",
+  "steps": [
+    {
+      "answer": {
+        "crateVersion": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "schemaRegistry.crateVersion"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD16.json
+++ b/gym/packs/self-description/reference/SD16.json
@@ -1,0 +1,15 @@
+{
+  "id": "SD16",
+  "steps": [
+    {
+      "answer": {
+        "policy": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "schemaRegistry.policy"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD17.json
+++ b/gym/packs/self-description/reference/SD17.json
@@ -1,0 +1,15 @@
+{
+  "id": "SD17",
+  "steps": [
+    {
+      "answer": {
+        "axis": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "schemaRegistry.axes[0].axis"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD18.json
+++ b/gym/packs/self-description/reference/SD18.json
@@ -1,0 +1,15 @@
+{
+  "id": "SD18",
+  "steps": [
+    {
+      "answer": {
+        "axis": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "schemaRegistry.axes[1].axis"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD19.json
+++ b/gym/packs/self-description/reference/SD19.json
@@ -1,0 +1,15 @@
+{
+  "id": "SD19",
+  "steps": [
+    {
+      "answer": {
+        "axis": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "schemaRegistry.axes[2].axis"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD20.json
+++ b/gym/packs/self-description/reference/SD20.json
@@ -1,0 +1,15 @@
+{
+  "id": "SD20",
+  "steps": [
+    {
+      "answer": {
+        "axis": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "schemaRegistry.axes[3].axis"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD21.json
+++ b/gym/packs/self-description/reference/SD21.json
@@ -1,0 +1,15 @@
+{
+  "id": "SD21",
+  "steps": [
+    {
+      "answer": {
+        "version": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "schemaRegistry.axes[0].version"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD22.json
+++ b/gym/packs/self-description/reference/SD22.json
@@ -1,0 +1,15 @@
+{
+  "id": "SD22",
+  "steps": [
+    {
+      "answer": {
+        "version": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "schemaRegistry.axes[1].version"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD23.json
+++ b/gym/packs/self-description/reference/SD23.json
@@ -1,0 +1,15 @@
+{
+  "id": "SD23",
+  "steps": [
+    {
+      "answer": {
+        "version": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "schemaRegistry.axes[2].version"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD24.json
+++ b/gym/packs/self-description/reference/SD24.json
@@ -1,0 +1,15 @@
+{
+  "id": "SD24",
+  "steps": [
+    {
+      "answer": {
+        "version": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "schemaRegistry.axes[3].version"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD25.json
+++ b/gym/packs/self-description/reference/SD25.json
@@ -1,0 +1,15 @@
+{
+  "id": "SD25",
+  "steps": [
+    {
+      "answer": {
+        "surface": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "schemaRegistry.axes[0].surface"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD26.json
+++ b/gym/packs/self-description/reference/SD26.json
@@ -1,0 +1,15 @@
+{
+  "id": "SD26",
+  "steps": [
+    {
+      "answer": {
+        "stdout": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "jsonContract.stdout"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD27.json
+++ b/gym/packs/self-description/reference/SD27.json
@@ -1,0 +1,15 @@
+{
+  "id": "SD27",
+  "steps": [
+    {
+      "answer": {
+        "schemaPolicy": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "jsonContract.schemaPolicy"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD28.json
+++ b/gym/packs/self-description/reference/SD28.json
@@ -1,0 +1,15 @@
+{
+  "id": "SD28",
+  "steps": [
+    {
+      "answer": {
+        "failure": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "jsonContract.failure"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD29.json
+++ b/gym/packs/self-description/reference/SD29.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD29",
+  "steps": [
+    {
+      "answer": {
+        "fields": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "jsonContract.provenance.fields",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD30.json
+++ b/gym/packs/self-description/reference/SD30.json
@@ -1,0 +1,15 @@
+{
+  "id": "SD30",
+  "steps": [
+    {
+      "answer": {
+        "map": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "jsonContract.provenance.map"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD31.json
+++ b/gym/packs/self-description/reference/SD31.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD31",
+  "steps": [
+    {
+      "answer": {
+        "kinds": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "jsonContract.textSecurity.kinds",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD32.json
+++ b/gym/packs/self-description/reference/SD32.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD32",
+  "steps": [
+    {
+      "answer": {
+        "status": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "jsonContract.textSecurity.status",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD33.json
+++ b/gym/packs/self-description/reference/SD33.json
@@ -1,0 +1,15 @@
+{
+  "id": "SD33",
+  "steps": [
+    {
+      "answer": {
+        "policy": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "jsonContract.textSecurity.policy"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD34.json
+++ b/gym/packs/self-description/reference/SD34.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD34",
+  "steps": [
+    {
+      "answer": {
+        "subcommands": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "batch.subcommands",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD35.json
+++ b/gym/packs/self-description/reference/SD35.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD35",
+  "steps": [
+    {
+      "answer": {
+        "flags": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "batch.flags",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD36.json
+++ b/gym/packs/self-description/reference/SD36.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD36",
+  "steps": [
+    {
+      "answer": {
+        "available": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "batch.mcp.available",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD37.json
+++ b/gym/packs/self-description/reference/SD37.json
@@ -1,0 +1,15 @@
+{
+  "id": "SD37",
+  "steps": [
+    {
+      "answer": {
+        "input": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "batch.input"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD38.json
+++ b/gym/packs/self-description/reference/SD38.json
@@ -1,0 +1,15 @@
+{
+  "id": "SD38",
+  "steps": [
+    {
+      "answer": {
+        "ordering": {
+          "cmd": [
+            "capabilities"
+          ],
+          "path": "batch.ordering"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD39.json
+++ b/gym/packs/self-description/reference/SD39.json
@@ -1,0 +1,19 @@
+{
+  "id": "SD39",
+  "steps": [
+    {
+      "answer": {
+        "hits": {
+          "cmd": [
+            "capabilities",
+            "--search",
+            "export",
+            "--json"
+          ],
+          "path": "commands",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD40.json
+++ b/gym/packs/self-description/reference/SD40.json
@@ -1,0 +1,19 @@
+{
+  "id": "SD40",
+  "steps": [
+    {
+      "answer": {
+        "hits": {
+          "cmd": [
+            "capabilities",
+            "--search",
+            "inspect",
+            "--json"
+          ],
+          "path": "commands",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD41.json
+++ b/gym/packs/self-description/reference/SD41.json
@@ -1,0 +1,19 @@
+{
+  "id": "SD41",
+  "steps": [
+    {
+      "answer": {
+        "hits": {
+          "cmd": [
+            "capabilities",
+            "--search",
+            "edit",
+            "--json"
+          ],
+          "path": "commands",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD42.json
+++ b/gym/packs/self-description/reference/SD42.json
@@ -1,0 +1,19 @@
+{
+  "id": "SD42",
+  "steps": [
+    {
+      "answer": {
+        "hits": {
+          "cmd": [
+            "capabilities",
+            "--search",
+            "ontology",
+            "--json"
+          ],
+          "path": "commands",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD43.json
+++ b/gym/packs/self-description/reference/SD43.json
@@ -1,0 +1,19 @@
+{
+  "id": "SD43",
+  "steps": [
+    {
+      "answer": {
+        "hits": {
+          "cmd": [
+            "capabilities",
+            "--search",
+            "provenance",
+            "--json"
+          ],
+          "path": "commands",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD44.json
+++ b/gym/packs/self-description/reference/SD44.json
@@ -1,0 +1,19 @@
+{
+  "id": "SD44",
+  "steps": [
+    {
+      "answer": {
+        "hits": {
+          "cmd": [
+            "capabilities",
+            "--search",
+            "plan",
+            "--json"
+          ],
+          "path": "commands",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD45.json
+++ b/gym/packs/self-description/reference/SD45.json
@@ -1,0 +1,18 @@
+{
+  "id": "SD45",
+  "steps": [
+    {
+      "answer": {
+        "search": {
+          "cmd": [
+            "capabilities",
+            "--search",
+            "schema",
+            "--json"
+          ],
+          "path": "search"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD46.json
+++ b/gym/packs/self-description/reference/SD46.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD46",
+  "steps": [
+    {
+      "answer": {
+        "protocol": {
+          "cmd": [
+            "capabilities",
+            "--mcp"
+          ],
+          "path": "protocol"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD47.json
+++ b/gym/packs/self-description/reference/SD47.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD47",
+  "steps": [
+    {
+      "answer": {
+        "suggestedName": {
+          "cmd": [
+            "capabilities",
+            "--mcp"
+          ],
+          "path": "server.suggestedName"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD48.json
+++ b/gym/packs/self-description/reference/SD48.json
@@ -1,0 +1,17 @@
+{
+  "id": "SD48",
+  "steps": [
+    {
+      "answer": {
+        "profiles": {
+          "cmd": [
+            "capabilities",
+            "--mcp"
+          ],
+          "path": "profiles",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD49.json
+++ b/gym/packs/self-description/reference/SD49.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD49",
+  "steps": [
+    {
+      "answer": {
+        "transport": {
+          "cmd": [
+            "capabilities",
+            "--mcp"
+          ],
+          "path": "invocation.transport"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD50.json
+++ b/gym/packs/self-description/reference/SD50.json
@@ -1,0 +1,17 @@
+{
+  "id": "SD50",
+  "steps": [
+    {
+      "answer": {
+        "stdinTools": {
+          "cmd": [
+            "capabilities",
+            "--mcp"
+          ],
+          "path": "invocation.stdinTools",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD51.json
+++ b/gym/packs/self-description/reference/SD51.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD51",
+  "steps": [
+    {
+      "answer": {
+        "server": {
+          "cmd": [
+            "capabilities",
+            "--mcp"
+          ],
+          "path": "invocation.server"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD52.json
+++ b/gym/packs/self-description/reference/SD52.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD52",
+  "steps": [
+    {
+      "answer": {
+        "planSchemaVersion": {
+          "cmd": [
+            "export-plan-schema",
+            "--json"
+          ],
+          "path": "planSchemaVersion"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD53.json
+++ b/gym/packs/self-description/reference/SD53.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD53",
+  "steps": [
+    {
+      "answer": {
+        "dialect": {
+          "cmd": [
+            "export-plan-schema",
+            "--json"
+          ],
+          "path": "dialect"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD54.json
+++ b/gym/packs/self-description/reference/SD54.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD54",
+  "steps": [
+    {
+      "answer": {
+        "defs": {
+          "cmd": [
+            "export-plan-schema",
+            "--json"
+          ],
+          "path": "definitionCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD55.json
+++ b/gym/packs/self-description/reference/SD55.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD55",
+  "steps": [
+    {
+      "answer": {
+        "irSchemaVersion": {
+          "cmd": [
+            "export-ir-schema",
+            "--json"
+          ],
+          "path": "irSchemaVersion"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD56.json
+++ b/gym/packs/self-description/reference/SD56.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD56",
+  "steps": [
+    {
+      "answer": {
+        "defs": {
+          "cmd": [
+            "export-ir-schema",
+            "--json"
+          ],
+          "path": "definitionCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD57.json
+++ b/gym/packs/self-description/reference/SD57.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD57",
+  "steps": [
+    {
+      "answer": {
+        "capabilitiesSchemaVersion": {
+          "cmd": [
+            "export-capabilities-schema",
+            "--json"
+          ],
+          "path": "capabilitiesSchemaVersion"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD58.json
+++ b/gym/packs/self-description/reference/SD58.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD58",
+  "steps": [
+    {
+      "answer": {
+        "defs": {
+          "cmd": [
+            "export-capabilities-schema",
+            "--json"
+          ],
+          "path": "definitionCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD59.json
+++ b/gym/packs/self-description/reference/SD59.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD59",
+  "steps": [
+    {
+      "answer": {
+        "dialect": {
+          "cmd": [
+            "export-capabilities-schema",
+            "--json"
+          ],
+          "path": "dialect"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD60.json
+++ b/gym/packs/self-description/reference/SD60.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD60",
+  "steps": [
+    {
+      "answer": {
+        "schemaVersion": {
+          "cmd": [
+            "export-ontology",
+            "--json"
+          ],
+          "path": "schemaVersion"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD61.json
+++ b/gym/packs/self-description/reference/SD61.json
@@ -1,0 +1,17 @@
+{
+  "id": "SD61",
+  "steps": [
+    {
+      "answer": {
+        "commands": {
+          "cmd": [
+            "export-agent-manifest",
+            "--json"
+          ],
+          "path": "capabilities.commands",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD62.json
+++ b/gym/packs/self-description/reference/SD62.json
@@ -1,0 +1,17 @@
+{
+  "id": "SD62",
+  "steps": [
+    {
+      "answer": {
+        "defs": {
+          "cmd": [
+            "export-agent-manifest",
+            "--json"
+          ],
+          "path": "irSchema.$defs",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD63.json
+++ b/gym/packs/self-description/reference/SD63.json
@@ -1,0 +1,17 @@
+{
+  "id": "SD63",
+  "steps": [
+    {
+      "answer": {
+        "flags": {
+          "cmd": [
+            "export-provenance-map",
+            "--json"
+          ],
+          "path": "envelopeFlags",
+          "len": true
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD64.json
+++ b/gym/packs/self-description/reference/SD64.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD64",
+  "steps": [
+    {
+      "answer": {
+        "pathSyntax": {
+          "cmd": [
+            "export-provenance-map",
+            "--json"
+          ],
+          "path": "pathSyntax"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD65.json
+++ b/gym/packs/self-description/reference/SD65.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD65",
+  "steps": [
+    {
+      "answer": {
+        "ref": {
+          "cmd": [
+            "export-ir-schema",
+            "--json"
+          ],
+          "path": "schema.$ref"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD66.json
+++ b/gym/packs/self-description/reference/SD66.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD66",
+  "steps": [
+    {
+      "answer": {
+        "ref": {
+          "cmd": [
+            "export-plan-schema",
+            "--json"
+          ],
+          "path": "schema.$ref"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD67.json
+++ b/gym/packs/self-description/reference/SD67.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD67",
+  "steps": [
+    {
+      "answer": {
+        "ref": {
+          "cmd": [
+            "export-capabilities-schema",
+            "--json"
+          ],
+          "path": "schema.$ref"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD68.json
+++ b/gym/packs/self-description/reference/SD68.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD68",
+  "steps": [
+    {
+      "answer": {
+        "ref": {
+          "cmd": [
+            "export-capabilities-schema",
+            "--json"
+          ],
+          "path": "mcpSchema.$ref"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD69.json
+++ b/gym/packs/self-description/reference/SD69.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD69",
+  "steps": [
+    {
+      "answer": {
+        "schemaVersion": {
+          "cmd": [
+            "export-agent-manifest",
+            "--json"
+          ],
+          "path": "schemaVersion"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD70.json
+++ b/gym/packs/self-description/reference/SD70.json
@@ -1,0 +1,16 @@
+{
+  "id": "SD70",
+  "steps": [
+    {
+      "answer": {
+        "tool": {
+          "cmd": [
+            "export-provenance-map",
+            "--json"
+          ],
+          "path": "tool"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD71.json
+++ b/gym/packs/self-description/reference/SD71.json
@@ -1,0 +1,12 @@
+{
+  "id": "SD71",
+  "steps": [
+    {
+      "run": [
+        "export-capabilities-schema",
+        "-o",
+        "{sub:capabilities-schema.json}"
+      ]
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD72.json
+++ b/gym/packs/self-description/reference/SD72.json
@@ -1,0 +1,12 @@
+{
+  "id": "SD72",
+  "steps": [
+    {
+      "run": [
+        "export-plan-schema",
+        "-o",
+        "{sub:plan-schema.json}"
+      ]
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD73.json
+++ b/gym/packs/self-description/reference/SD73.json
@@ -1,0 +1,12 @@
+{
+  "id": "SD73",
+  "steps": [
+    {
+      "run": [
+        "export-ontology",
+        "-o",
+        "{sub:ontology.json}"
+      ]
+    }
+  ]
+}

--- a/gym/packs/self-description/reference/SD74.json
+++ b/gym/packs/self-description/reference/SD74.json
@@ -1,0 +1,12 @@
+{
+  "id": "SD74",
+  "steps": [
+    {
+      "run": [
+        "export-ir-schema",
+        "-o",
+        "{sub:ir-schema.json}"
+      ]
+    }
+  ]
+}

--- a/gym/packs/self-description/tasks/SD08.json
+++ b/gym/packs/self-description/tasks/SD08.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD08",
+  "tier": 2,
+  "title": "MCP 도구 수",
+  "input": "samples/table-001.hwp",
+  "instructions": "rhwp 가 MCP 서버로 등록하라고 내놓는 도구 개수를 answer.json 에 {\"tools\": N} 으로 제출하라. 힌트: rhwp capabilities --mcp.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "MCP 도구 수",
+      "op": "len_answer_eq",
+      "answer": "tools",
+      "path": "tools",
+      "cmd": [
+        "capabilities",
+        "--mcp"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD09.json
+++ b/gym/packs/self-description/tasks/SD09.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD09",
+  "tier": 2,
+  "title": "스키마 레지스트리 축",
+  "input": "samples/table-001.hwp",
+  "instructions": "capabilities 가 광고하는 스키마 레지스트리의 버전 축 개수를 answer.json 에 {\"axes\": N} 으로 제출하라. 힌트: capabilities 의 schemaRegistry.axes.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "레지스트리 축 수",
+      "op": "len_answer_eq",
+      "answer": "axes",
+      "path": "schemaRegistry.axes",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD10.json
+++ b/gym/packs/self-description/tasks/SD10.json
@@ -1,0 +1,28 @@
+{
+  "id": "SD10",
+  "tier": 2,
+  "title": "도움 검색 — schema",
+  "input": "samples/table-001.hwp",
+  "instructions": "capabilities 도움 검색으로 키워드 schema 에 맞는 명령 수를 answer.json 에 {\"hits\": N} 으로 제출하라. 힌트: rhwp capabilities --search schema --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "검색 적중 수",
+      "op": "len_answer_eq",
+      "answer": "hits",
+      "path": "commands",
+      "cmd": [
+        "capabilities",
+        "--search",
+        "schema",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD11.json
+++ b/gym/packs/self-description/tasks/SD11.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD11",
+  "tier": 2,
+  "title": "온톨로지 행위 수",
+  "input": "samples/table-001.hwp",
+  "instructions": "rhwp 온톨로지가 선언하는 행위(action) 수를 answer.json 에 {\"actions\": N} 으로 제출하라. 힌트: rhwp export-ontology 의 actionCount.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "행위 수",
+      "op": "answer_eq",
+      "answer": "actions",
+      "path": "actionCount",
+      "cmd": [
+        "export-ontology",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD12.json
+++ b/gym/packs/self-description/tasks/SD12.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD12",
+  "tier": 2,
+  "title": "종료 코드 계약",
+  "input": "samples/table-001.hwp",
+  "instructions": "rhwp 가 스스로 신고하는 종료 코드 개수를 answer.json 에 {\"codes\": N} 으로 제출하라. 힌트: capabilities 의 exitCodes.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "종료 코드 수",
+      "op": "len_answer_eq",
+      "answer": "codes",
+      "path": "exitCodes",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD13.json
+++ b/gym/packs/self-description/tasks/SD13.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD13",
+  "tier": 2,
+  "title": "도구 이름",
+  "input": "samples/table-001.hwp",
+  "instructions": "rhwp 가 capabilities 봉투에 싣는 도구 이름을 answer.json 에 {\"tool\": S} 으로 제출하라. 힌트: capabilities 의 tool.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "도구 이름",
+      "op": "answer_eq",
+      "answer": "tool",
+      "path": "tool",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD14.json
+++ b/gym/packs/self-description/tasks/SD14.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD14",
+  "tier": 2,
+  "title": "봉투 schemaVersion",
+  "input": "samples/table-001.hwp",
+  "instructions": "capabilities 최상위 schemaVersion 을 answer.json 에 {\"schemaVersion\": S} 으로 제출하라. 힌트: capabilities 의 schemaVersion.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "봉투 schemaVersion",
+      "op": "answer_eq",
+      "answer": "schemaVersion",
+      "path": "schemaVersion",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD15.json
+++ b/gym/packs/self-description/tasks/SD15.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD15",
+  "tier": 2,
+  "title": "crate 버전",
+  "input": "samples/table-001.hwp",
+  "instructions": "스키마 레지스트리가 광고하는 crateVersion 을 answer.json 에 {\"crateVersion\": S} 으로 제출하라. 힌트: capabilities 의 schemaRegistry.crateVersion.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "crate 버전",
+      "op": "answer_eq",
+      "answer": "crateVersion",
+      "path": "schemaRegistry.crateVersion",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD16.json
+++ b/gym/packs/self-description/tasks/SD16.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD16",
+  "tier": 2,
+  "title": "버전 정책 경로",
+  "input": "samples/table-001.hwp",
+  "instructions": "스키마 레지스트리가 가리키는 정책 문서 경로를 answer.json 에 {\"policy\": S} 으로 제출하라. 힌트: capabilities 의 schemaRegistry.policy.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "버전 정책 경로",
+      "op": "answer_eq",
+      "answer": "policy",
+      "path": "schemaRegistry.policy",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD17.json
+++ b/gym/packs/self-description/tasks/SD17.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD17",
+  "tier": 2,
+  "title": "envelope 축 이름",
+  "input": "samples/table-001.hwp",
+  "instructions": "스키마 레지스트리 첫 축의 이름을 answer.json 에 {\"axis\": S} 으로 제출하라. 힌트: capabilities 의 schemaRegistry.axes[0].axis.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "envelope 축 이름",
+      "op": "answer_eq",
+      "answer": "axis",
+      "path": "schemaRegistry.axes[0].axis",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD18.json
+++ b/gym/packs/self-description/tasks/SD18.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD18",
+  "tier": 2,
+  "title": "ir 축 이름",
+  "input": "samples/table-001.hwp",
+  "instructions": "스키마 레지스트리 둘째 축의 이름을 answer.json 에 {\"axis\": S} 으로 제출하라. 힌트: capabilities 의 schemaRegistry.axes[1].axis.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "ir 축 이름",
+      "op": "answer_eq",
+      "answer": "axis",
+      "path": "schemaRegistry.axes[1].axis",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD19.json
+++ b/gym/packs/self-description/tasks/SD19.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD19",
+  "tier": 2,
+  "title": "capabilities 축 이름",
+  "input": "samples/table-001.hwp",
+  "instructions": "스키마 레지스트리 셋째 축의 이름을 answer.json 에 {\"axis\": S} 으로 제출하라. 힌트: capabilities 의 schemaRegistry.axes[2].axis.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "capabilities 축 이름",
+      "op": "answer_eq",
+      "answer": "axis",
+      "path": "schemaRegistry.axes[2].axis",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD20.json
+++ b/gym/packs/self-description/tasks/SD20.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD20",
+  "tier": 2,
+  "title": "plan 축 이름",
+  "input": "samples/table-001.hwp",
+  "instructions": "스키마 레지스트리 넷째 축의 이름을 answer.json 에 {\"axis\": S} 으로 제출하라. 힌트: capabilities 의 schemaRegistry.axes[3].axis.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "plan 축 이름",
+      "op": "answer_eq",
+      "answer": "axis",
+      "path": "schemaRegistry.axes[3].axis",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD21.json
+++ b/gym/packs/self-description/tasks/SD21.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD21",
+  "tier": 2,
+  "title": "envelope 축 버전",
+  "input": "samples/table-001.hwp",
+  "instructions": "스키마 레지스트리 envelope 축의 버전을 answer.json 에 {\"version\": S} 으로 제출하라. 힌트: capabilities 의 schemaRegistry.axes[0].version.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "envelope 축 버전",
+      "op": "answer_eq",
+      "answer": "version",
+      "path": "schemaRegistry.axes[0].version",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD22.json
+++ b/gym/packs/self-description/tasks/SD22.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD22",
+  "tier": 2,
+  "title": "ir 축 버전",
+  "input": "samples/table-001.hwp",
+  "instructions": "스키마 레지스트리 ir 축의 버전을 answer.json 에 {\"version\": S} 으로 제출하라. 힌트: capabilities 의 schemaRegistry.axes[1].version.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "ir 축 버전",
+      "op": "answer_eq",
+      "answer": "version",
+      "path": "schemaRegistry.axes[1].version",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD23.json
+++ b/gym/packs/self-description/tasks/SD23.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD23",
+  "tier": 2,
+  "title": "capabilities 축 버전",
+  "input": "samples/table-001.hwp",
+  "instructions": "스키마 레지스트리 capabilities 축의 버전을 answer.json 에 {\"version\": S} 으로 제출하라. 힌트: capabilities 의 schemaRegistry.axes[2].version.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "capabilities 축 버전",
+      "op": "answer_eq",
+      "answer": "version",
+      "path": "schemaRegistry.axes[2].version",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD24.json
+++ b/gym/packs/self-description/tasks/SD24.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD24",
+  "tier": 2,
+  "title": "plan 축 버전",
+  "input": "samples/table-001.hwp",
+  "instructions": "스키마 레지스트리 plan 축의 버전을 answer.json 에 {\"version\": S} 으로 제출하라. 힌트: capabilities 의 schemaRegistry.axes[3].version.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "plan 축 버전",
+      "op": "answer_eq",
+      "answer": "version",
+      "path": "schemaRegistry.axes[3].version",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD25.json
+++ b/gym/packs/self-description/tasks/SD25.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD25",
+  "tier": 2,
+  "title": "envelope 축 표면",
+  "input": "samples/table-001.hwp",
+  "instructions": "스키마 레지스트리 envelope 축의 surface 서술을 answer.json 에 {\"surface\": S} 으로 제출하라. 힌트: capabilities 의 schemaRegistry.axes[0].surface.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "envelope 축 표면",
+      "op": "answer_eq",
+      "answer": "surface",
+      "path": "schemaRegistry.axes[0].surface",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD26.json
+++ b/gym/packs/self-description/tasks/SD26.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD26",
+  "tier": 2,
+  "title": "jsonContract.stdout",
+  "input": "samples/table-001.hwp",
+  "instructions": "capabilities 가 선언하는 jsonContract.stdout 규약을 answer.json 에 {\"stdout\": S} 으로 제출하라. 힌트: capabilities 의 jsonContract.stdout.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "jsonContract.stdout",
+      "op": "answer_eq",
+      "answer": "stdout",
+      "path": "jsonContract.stdout",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD27.json
+++ b/gym/packs/self-description/tasks/SD27.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD27",
+  "tier": 2,
+  "title": "jsonContract.schemaPolicy",
+  "input": "samples/table-001.hwp",
+  "instructions": "capabilities 가 선언하는 jsonContract.schemaPolicy 를 answer.json 에 {\"schemaPolicy\": S} 으로 제출하라. 힌트: capabilities 의 jsonContract.schemaPolicy.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "jsonContract.schemaPolicy",
+      "op": "answer_eq",
+      "answer": "schemaPolicy",
+      "path": "jsonContract.schemaPolicy",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD28.json
+++ b/gym/packs/self-description/tasks/SD28.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD28",
+  "tier": 3,
+  "title": "jsonContract.failure",
+  "input": "samples/table-001.hwp",
+  "instructions": "capabilities 가 선언하는 jsonContract.failure 규약을 answer.json 에 {\"failure\": S} 으로 제출하라. 힌트: capabilities 의 jsonContract.failure.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "jsonContract.failure",
+      "op": "answer_eq",
+      "answer": "failure",
+      "path": "jsonContract.failure",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD29.json
+++ b/gym/packs/self-description/tasks/SD29.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD29",
+  "tier": 2,
+  "title": "출처 표지 필드 수",
+  "input": "samples/table-001.hwp",
+  "instructions": "jsonContract.provenance.fields 의 원소 수를 answer.json 에 {\"fields\": N} 으로 제출하라. 힌트: capabilities 의 jsonContract.provenance.fields.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "출처 표지 필드 수",
+      "op": "len_answer_eq",
+      "answer": "fields",
+      "path": "jsonContract.provenance.fields",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD30.json
+++ b/gym/packs/self-description/tasks/SD30.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD30",
+  "tier": 2,
+  "title": "출처 지도 조회 방법",
+  "input": "samples/table-001.hwp",
+  "instructions": "jsonContract.provenance.map 이 가리키는 조회 명령을 answer.json 에 {\"map\": S} 으로 제출하라. 힌트: capabilities 의 jsonContract.provenance.map.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "출처 지도 조회 방법",
+      "op": "answer_eq",
+      "answer": "map",
+      "path": "jsonContract.provenance.map",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD31.json
+++ b/gym/packs/self-description/tasks/SD31.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD31",
+  "tier": 2,
+  "title": "textSecurity 종류 수",
+  "input": "samples/table-001.hwp",
+  "instructions": "jsonContract.textSecurity.kinds 의 원소 수를 answer.json 에 {\"kinds\": N} 으로 제출하라. 힌트: capabilities 의 jsonContract.textSecurity.kinds.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "textSecurity 종류 수",
+      "op": "len_answer_eq",
+      "answer": "kinds",
+      "path": "jsonContract.textSecurity.kinds",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD32.json
+++ b/gym/packs/self-description/tasks/SD32.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD32",
+  "tier": 2,
+  "title": "textSecurity 상태 수",
+  "input": "samples/table-001.hwp",
+  "instructions": "jsonContract.textSecurity.status 의 원소 수를 answer.json 에 {\"status\": N} 으로 제출하라. 힌트: capabilities 의 jsonContract.textSecurity.status.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "textSecurity 상태 수",
+      "op": "len_answer_eq",
+      "answer": "status",
+      "path": "jsonContract.textSecurity.status",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD33.json
+++ b/gym/packs/self-description/tasks/SD33.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD33",
+  "tier": 2,
+  "title": "textSecurity 정책",
+  "input": "samples/table-001.hwp",
+  "instructions": "jsonContract.textSecurity.policy 문구를 answer.json 에 {\"policy\": S} 으로 제출하라. 힌트: capabilities 의 jsonContract.textSecurity.policy.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "textSecurity 정책",
+      "op": "answer_eq",
+      "answer": "policy",
+      "path": "jsonContract.textSecurity.policy",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD34.json
+++ b/gym/packs/self-description/tasks/SD34.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD34",
+  "tier": 2,
+  "title": "batch 하위명령 수",
+  "input": "samples/table-001.hwp",
+  "instructions": "capabilities 가 선언하는 batch.subcommands 수를 answer.json 에 {\"subcommands\": N} 으로 제출하라. 힌트: capabilities 의 batch.subcommands.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "batch 하위명령 수",
+      "op": "len_answer_eq",
+      "answer": "subcommands",
+      "path": "batch.subcommands",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD35.json
+++ b/gym/packs/self-description/tasks/SD35.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD35",
+  "tier": 2,
+  "title": "batch 플래그 수",
+  "input": "samples/table-001.hwp",
+  "instructions": "capabilities 가 선언하는 batch.flags 수를 answer.json 에 {\"flags\": N} 으로 제출하라. 힌트: capabilities 의 batch.flags.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "batch 플래그 수",
+      "op": "len_answer_eq",
+      "answer": "flags",
+      "path": "batch.flags",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD36.json
+++ b/gym/packs/self-description/tasks/SD36.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD36",
+  "tier": 2,
+  "title": "batch MCP 노출 축 수",
+  "input": "samples/table-001.hwp",
+  "instructions": "batch.mcp.available 의 원소 수를 answer.json 에 {\"available\": N} 으로 제출하라. 힌트: capabilities 의 batch.mcp.available.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "batch MCP 노출 축 수",
+      "op": "len_answer_eq",
+      "answer": "available",
+      "path": "batch.mcp.available",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD37.json
+++ b/gym/packs/self-description/tasks/SD37.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD37",
+  "tier": 3,
+  "title": "batch 입력 규약",
+  "input": "samples/table-001.hwp",
+  "instructions": "capabilities 가 선언하는 batch.input 규약을 answer.json 에 {\"input\": S} 으로 제출하라. 힌트: capabilities 의 batch.input.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "batch 입력 규약",
+      "op": "answer_eq",
+      "answer": "input",
+      "path": "batch.input",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD38.json
+++ b/gym/packs/self-description/tasks/SD38.json
@@ -1,0 +1,25 @@
+{
+  "id": "SD38",
+  "tier": 2,
+  "title": "batch 순서 규약",
+  "input": "samples/table-001.hwp",
+  "instructions": "capabilities 가 선언하는 batch.ordering 규약을 answer.json 에 {\"ordering\": S} 으로 제출하라. 힌트: capabilities 의 batch.ordering.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "batch 순서 규약",
+      "op": "answer_eq",
+      "answer": "ordering",
+      "path": "batch.ordering",
+      "cmd": [
+        "capabilities"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD39.json
+++ b/gym/packs/self-description/tasks/SD39.json
@@ -1,0 +1,28 @@
+{
+  "id": "SD39",
+  "tier": 2,
+  "title": "도움 검색 — export",
+  "input": "samples/table-001.hwp",
+  "instructions": "capabilities 도움 검색으로 키워드 export 에 맞는 명령 수를 answer.json 에 {\"hits\": N} 으로 제출하라. 힌트: rhwp capabilities --search export --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "도움 검색 — export",
+      "op": "len_answer_eq",
+      "answer": "hits",
+      "path": "commands",
+      "cmd": [
+        "capabilities",
+        "--search",
+        "export",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD40.json
+++ b/gym/packs/self-description/tasks/SD40.json
@@ -1,0 +1,28 @@
+{
+  "id": "SD40",
+  "tier": 2,
+  "title": "도움 검색 — inspect",
+  "input": "samples/table-001.hwp",
+  "instructions": "capabilities 도움 검색으로 키워드 inspect 에 맞는 명령 수를 answer.json 에 {\"hits\": N} 으로 제출하라. 힌트: rhwp capabilities --search inspect --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "도움 검색 — inspect",
+      "op": "len_answer_eq",
+      "answer": "hits",
+      "path": "commands",
+      "cmd": [
+        "capabilities",
+        "--search",
+        "inspect",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD41.json
+++ b/gym/packs/self-description/tasks/SD41.json
@@ -1,0 +1,28 @@
+{
+  "id": "SD41",
+  "tier": 2,
+  "title": "도움 검색 — edit",
+  "input": "samples/table-001.hwp",
+  "instructions": "capabilities 도움 검색으로 키워드 edit 에 맞는 명령 수를 answer.json 에 {\"hits\": N} 으로 제출하라. 힌트: rhwp capabilities --search edit --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "도움 검색 — edit",
+      "op": "len_answer_eq",
+      "answer": "hits",
+      "path": "commands",
+      "cmd": [
+        "capabilities",
+        "--search",
+        "edit",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD42.json
+++ b/gym/packs/self-description/tasks/SD42.json
@@ -1,0 +1,28 @@
+{
+  "id": "SD42",
+  "tier": 2,
+  "title": "도움 검색 — ontology",
+  "input": "samples/table-001.hwp",
+  "instructions": "capabilities 도움 검색으로 키워드 ontology 에 맞는 명령 수를 answer.json 에 {\"hits\": N} 으로 제출하라. 힌트: rhwp capabilities --search ontology --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "도움 검색 — ontology",
+      "op": "len_answer_eq",
+      "answer": "hits",
+      "path": "commands",
+      "cmd": [
+        "capabilities",
+        "--search",
+        "ontology",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD43.json
+++ b/gym/packs/self-description/tasks/SD43.json
@@ -1,0 +1,28 @@
+{
+  "id": "SD43",
+  "tier": 2,
+  "title": "도움 검색 — provenance",
+  "input": "samples/table-001.hwp",
+  "instructions": "capabilities 도움 검색으로 키워드 provenance 에 맞는 명령 수를 answer.json 에 {\"hits\": N} 으로 제출하라. 힌트: rhwp capabilities --search provenance --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "도움 검색 — provenance",
+      "op": "len_answer_eq",
+      "answer": "hits",
+      "path": "commands",
+      "cmd": [
+        "capabilities",
+        "--search",
+        "provenance",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD44.json
+++ b/gym/packs/self-description/tasks/SD44.json
@@ -1,0 +1,28 @@
+{
+  "id": "SD44",
+  "tier": 2,
+  "title": "도움 검색 — plan",
+  "input": "samples/table-001.hwp",
+  "instructions": "capabilities 도움 검색으로 키워드 plan 에 맞는 명령 수를 answer.json 에 {\"hits\": N} 으로 제출하라. 힌트: rhwp capabilities --search plan --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "도움 검색 — plan",
+      "op": "len_answer_eq",
+      "answer": "hits",
+      "path": "commands",
+      "cmd": [
+        "capabilities",
+        "--search",
+        "plan",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD45.json
+++ b/gym/packs/self-description/tasks/SD45.json
@@ -1,0 +1,28 @@
+{
+  "id": "SD45",
+  "tier": 2,
+  "title": "도움 검색 질의 메아리",
+  "input": "samples/table-001.hwp",
+  "instructions": "capabilities --search schema --json 이 봉투에 메아리치는 search 문자열을 answer.json 에 {\"search\": S} 으로 제출하라. 힌트: 검색 봉투의 search.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "도움 검색 질의 메아리",
+      "op": "answer_eq",
+      "answer": "search",
+      "path": "search",
+      "cmd": [
+        "capabilities",
+        "--search",
+        "schema",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD46.json
+++ b/gym/packs/self-description/tasks/SD46.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD46",
+  "tier": 2,
+  "title": "MCP protocol",
+  "input": "samples/table-001.hwp",
+  "instructions": "capabilities --mcp 가 선언하는 protocol 식별자를 answer.json 에 {\"protocol\": S} 으로 제출하라. 힌트: capabilities --mcp 의 protocol.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "MCP protocol",
+      "op": "answer_eq",
+      "answer": "protocol",
+      "path": "protocol",
+      "cmd": [
+        "capabilities",
+        "--mcp"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD47.json
+++ b/gym/packs/self-description/tasks/SD47.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD47",
+  "tier": 2,
+  "title": "MCP 서버 권고 이름",
+  "input": "samples/table-001.hwp",
+  "instructions": "MCP 매니페스트의 server.suggestedName 을 answer.json 에 {\"suggestedName\": S} 으로 제출하라. 힌트: capabilities --mcp 의 server.suggestedName.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "MCP 서버 권고 이름",
+      "op": "answer_eq",
+      "answer": "suggestedName",
+      "path": "server.suggestedName",
+      "cmd": [
+        "capabilities",
+        "--mcp"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD48.json
+++ b/gym/packs/self-description/tasks/SD48.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD48",
+  "tier": 2,
+  "title": "MCP 프로필 수",
+  "input": "samples/table-001.hwp",
+  "instructions": "capabilities --mcp 가 광고하는 역할 프로필 수를 answer.json 에 {\"profiles\": N} 으로 제출하라. 힌트: capabilities --mcp 의 profiles.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "MCP 프로필 수",
+      "op": "len_answer_eq",
+      "answer": "profiles",
+      "path": "profiles",
+      "cmd": [
+        "capabilities",
+        "--mcp"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD49.json
+++ b/gym/packs/self-description/tasks/SD49.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD49",
+  "tier": 2,
+  "title": "MCP invocation.transport",
+  "input": "samples/table-001.hwp",
+  "instructions": "MCP 매니페스트의 invocation.transport 를 answer.json 에 {\"transport\": S} 으로 제출하라. 힌트: capabilities --mcp 의 invocation.transport.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "MCP invocation.transport",
+      "op": "answer_eq",
+      "answer": "transport",
+      "path": "invocation.transport",
+      "cmd": [
+        "capabilities",
+        "--mcp"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD50.json
+++ b/gym/packs/self-description/tasks/SD50.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD50",
+  "tier": 2,
+  "title": "MCP stdin 도구 수",
+  "input": "samples/table-001.hwp",
+  "instructions": "MCP invocation.stdinTools 의 원소 수를 answer.json 에 {\"stdinTools\": N} 으로 제출하라. 힌트: capabilities --mcp 의 invocation.stdinTools.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "MCP stdin 도구 수",
+      "op": "len_answer_eq",
+      "answer": "stdinTools",
+      "path": "invocation.stdinTools",
+      "cmd": [
+        "capabilities",
+        "--mcp"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD51.json
+++ b/gym/packs/self-description/tasks/SD51.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD51",
+  "tier": 2,
+  "title": "MCP stdio 서버 명령",
+  "input": "samples/table-001.hwp",
+  "instructions": "MCP invocation.server (stdio 서버 명령 이름)를 answer.json 에 {\"server\": S} 으로 제출하라. 힌트: capabilities --mcp 의 invocation.server.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "MCP stdio 서버 명령",
+      "op": "answer_eq",
+      "answer": "server",
+      "path": "invocation.server",
+      "cmd": [
+        "capabilities",
+        "--mcp"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD52.json
+++ b/gym/packs/self-description/tasks/SD52.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD52",
+  "tier": 2,
+  "title": "계획 스키마 버전",
+  "input": "samples/table-001.hwp",
+  "instructions": "export-plan-schema 가 광고하는 planSchemaVersion 을 answer.json 에 {\"planSchemaVersion\": S} 으로 제출하라. 힌트: rhwp export-plan-schema --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "계획 스키마 버전",
+      "op": "answer_eq",
+      "answer": "planSchemaVersion",
+      "path": "planSchemaVersion",
+      "cmd": [
+        "export-plan-schema",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD53.json
+++ b/gym/packs/self-description/tasks/SD53.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD53",
+  "tier": 2,
+  "title": "계획 스키마 dialect",
+  "input": "samples/table-001.hwp",
+  "instructions": "export-plan-schema 의 dialect 를 answer.json 에 {\"dialect\": S} 으로 제출하라. 힌트: rhwp export-plan-schema --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "계획 스키마 dialect",
+      "op": "answer_eq",
+      "answer": "dialect",
+      "path": "dialect",
+      "cmd": [
+        "export-plan-schema",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD54.json
+++ b/gym/packs/self-description/tasks/SD54.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD54",
+  "tier": 2,
+  "title": "계획 스키마 정의 수",
+  "input": "samples/table-001.hwp",
+  "instructions": "export-plan-schema 의 definitionCount 를 answer.json 에 {\"defs\": N} 으로 제출하라. 힌트: rhwp export-plan-schema --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "계획 스키마 정의 수",
+      "op": "answer_eq",
+      "answer": "defs",
+      "path": "definitionCount",
+      "cmd": [
+        "export-plan-schema",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD55.json
+++ b/gym/packs/self-description/tasks/SD55.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD55",
+  "tier": 2,
+  "title": "IR 스키마 버전",
+  "input": "samples/table-001.hwp",
+  "instructions": "export-ir-schema 가 광고하는 irSchemaVersion 을 answer.json 에 {\"irSchemaVersion\": S} 으로 제출하라. 힌트: rhwp export-ir-schema --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "IR 스키마 버전",
+      "op": "answer_eq",
+      "answer": "irSchemaVersion",
+      "path": "irSchemaVersion",
+      "cmd": [
+        "export-ir-schema",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD56.json
+++ b/gym/packs/self-description/tasks/SD56.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD56",
+  "tier": 2,
+  "title": "IR 스키마 정의 수",
+  "input": "samples/table-001.hwp",
+  "instructions": "export-ir-schema 의 definitionCount 를 answer.json 에 {\"defs\": N} 으로 제출하라. 힌트: rhwp export-ir-schema --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "IR 스키마 정의 수",
+      "op": "answer_eq",
+      "answer": "defs",
+      "path": "definitionCount",
+      "cmd": [
+        "export-ir-schema",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD57.json
+++ b/gym/packs/self-description/tasks/SD57.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD57",
+  "tier": 2,
+  "title": "capabilities 스키마 버전",
+  "input": "samples/table-001.hwp",
+  "instructions": "export-capabilities-schema 가 광고하는 capabilitiesSchemaVersion 을 answer.json 에 {\"capabilitiesSchemaVersion\": S} 으로 제출하라. 힌트: rhwp export-capabilities-schema --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "capabilities 스키마 버전",
+      "op": "answer_eq",
+      "answer": "capabilitiesSchemaVersion",
+      "path": "capabilitiesSchemaVersion",
+      "cmd": [
+        "export-capabilities-schema",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD58.json
+++ b/gym/packs/self-description/tasks/SD58.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD58",
+  "tier": 2,
+  "title": "capabilities 스키마 정의 수",
+  "input": "samples/table-001.hwp",
+  "instructions": "export-capabilities-schema 의 definitionCount 를 answer.json 에 {\"defs\": N} 으로 제출하라. 힌트: rhwp export-capabilities-schema --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "capabilities 스키마 정의 수",
+      "op": "answer_eq",
+      "answer": "defs",
+      "path": "definitionCount",
+      "cmd": [
+        "export-capabilities-schema",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD59.json
+++ b/gym/packs/self-description/tasks/SD59.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD59",
+  "tier": 2,
+  "title": "capabilities 스키마 dialect",
+  "input": "samples/table-001.hwp",
+  "instructions": "export-capabilities-schema 의 dialect 를 answer.json 에 {\"dialect\": S} 으로 제출하라. 힌트: rhwp export-capabilities-schema --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "capabilities 스키마 dialect",
+      "op": "answer_eq",
+      "answer": "dialect",
+      "path": "dialect",
+      "cmd": [
+        "export-capabilities-schema",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD60.json
+++ b/gym/packs/self-description/tasks/SD60.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD60",
+  "tier": 2,
+  "title": "온톨로지 schemaVersion",
+  "input": "samples/table-001.hwp",
+  "instructions": "export-ontology 최상위 schemaVersion 을 answer.json 에 {\"schemaVersion\": S} 으로 제출하라. 힌트: rhwp export-ontology --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "온톨로지 schemaVersion",
+      "op": "answer_eq",
+      "answer": "schemaVersion",
+      "path": "schemaVersion",
+      "cmd": [
+        "export-ontology",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD61.json
+++ b/gym/packs/self-description/tasks/SD61.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD61",
+  "tier": 3,
+  "title": "매니페스트 명령 수",
+  "input": "samples/table-001.hwp",
+  "instructions": "export-agent-manifest 가 조립한 capabilities.commands 수를 answer.json 에 {\"commands\": N} 으로 제출하라. 힌트: rhwp export-agent-manifest --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "매니페스트 명령 수",
+      "op": "len_answer_eq",
+      "answer": "commands",
+      "path": "capabilities.commands",
+      "cmd": [
+        "export-agent-manifest",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD62.json
+++ b/gym/packs/self-description/tasks/SD62.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD62",
+  "tier": 3,
+  "title": "매니페스트 IR 정의 수",
+  "input": "samples/table-001.hwp",
+  "instructions": "export-agent-manifest 의 irSchema.$defs 키 수를 answer.json 에 {\"defs\": N} 으로 제출하라. 힌트: rhwp export-agent-manifest --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "매니페스트 IR 정의 수",
+      "op": "len_answer_eq",
+      "answer": "defs",
+      "path": "irSchema.$defs",
+      "cmd": [
+        "export-agent-manifest",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD63.json
+++ b/gym/packs/self-description/tasks/SD63.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD63",
+  "tier": 2,
+  "title": "출처 지도 표지 키 수",
+  "input": "samples/table-001.hwp",
+  "instructions": "export-provenance-map 의 envelopeFlags 키 수를 answer.json 에 {\"flags\": N} 으로 제출하라. 힌트: rhwp export-provenance-map --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "출처 지도 표지 키 수",
+      "op": "len_answer_eq",
+      "answer": "flags",
+      "path": "envelopeFlags",
+      "cmd": [
+        "export-provenance-map",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD64.json
+++ b/gym/packs/self-description/tasks/SD64.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD64",
+  "tier": 2,
+  "title": "출처 지도 pathSyntax",
+  "input": "samples/table-001.hwp",
+  "instructions": "export-provenance-map 의 pathSyntax 서술을 answer.json 에 {\"pathSyntax\": S} 으로 제출하라. 힌트: rhwp export-provenance-map --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "출처 지도 pathSyntax",
+      "op": "answer_eq",
+      "answer": "pathSyntax",
+      "path": "pathSyntax",
+      "cmd": [
+        "export-provenance-map",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD65.json
+++ b/gym/packs/self-description/tasks/SD65.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD65",
+  "tier": 3,
+  "title": "IR 스키마 $ref",
+  "input": "samples/table-001.hwp",
+  "instructions": "export-ir-schema 본문 schema.$ref 를 answer.json 에 {\"ref\": S} 으로 제출하라. 힌트: rhwp export-ir-schema --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "IR 스키마 $ref",
+      "op": "answer_eq",
+      "answer": "ref",
+      "path": "schema.$ref",
+      "cmd": [
+        "export-ir-schema",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD66.json
+++ b/gym/packs/self-description/tasks/SD66.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD66",
+  "tier": 3,
+  "title": "계획 스키마 $ref",
+  "input": "samples/table-001.hwp",
+  "instructions": "export-plan-schema 본문 schema.$ref 를 answer.json 에 {\"ref\": S} 으로 제출하라. 힌트: rhwp export-plan-schema --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "계획 스키마 $ref",
+      "op": "answer_eq",
+      "answer": "ref",
+      "path": "schema.$ref",
+      "cmd": [
+        "export-plan-schema",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD67.json
+++ b/gym/packs/self-description/tasks/SD67.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD67",
+  "tier": 3,
+  "title": "capabilities 스키마 $ref",
+  "input": "samples/table-001.hwp",
+  "instructions": "export-capabilities-schema 본문 schema.$ref 를 answer.json 에 {\"ref\": S} 으로 제출하라. 힌트: rhwp export-capabilities-schema --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "capabilities 스키마 $ref",
+      "op": "answer_eq",
+      "answer": "ref",
+      "path": "schema.$ref",
+      "cmd": [
+        "export-capabilities-schema",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD68.json
+++ b/gym/packs/self-description/tasks/SD68.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD68",
+  "tier": 3,
+  "title": "MCP 스키마 $ref",
+  "input": "samples/table-001.hwp",
+  "instructions": "export-capabilities-schema 의 mcpSchema.$ref 를 answer.json 에 {\"ref\": S} 으로 제출하라. 힌트: rhwp export-capabilities-schema --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "MCP 스키마 $ref",
+      "op": "answer_eq",
+      "answer": "ref",
+      "path": "mcpSchema.$ref",
+      "cmd": [
+        "export-capabilities-schema",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD69.json
+++ b/gym/packs/self-description/tasks/SD69.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD69",
+  "tier": 2,
+  "title": "매니페스트 schemaVersion",
+  "input": "samples/table-001.hwp",
+  "instructions": "export-agent-manifest 최상위 schemaVersion 을 answer.json 에 {\"schemaVersion\": S} 으로 제출하라. 힌트: rhwp export-agent-manifest --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "매니페스트 schemaVersion",
+      "op": "answer_eq",
+      "answer": "schemaVersion",
+      "path": "schemaVersion",
+      "cmd": [
+        "export-agent-manifest",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD70.json
+++ b/gym/packs/self-description/tasks/SD70.json
@@ -1,0 +1,26 @@
+{
+  "id": "SD70",
+  "tier": 3,
+  "title": "출처 지도 도구 이름",
+  "input": "samples/table-001.hwp",
+  "instructions": "export-provenance-map 가 싣는 tool 이름을 answer.json 에 {\"tool\": S} 으로 제출하라. 힌트: rhwp export-provenance-map --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "출처 지도 도구 이름",
+      "op": "answer_eq",
+      "answer": "tool",
+      "path": "tool",
+      "cmd": [
+        "export-provenance-map",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD71.json
+++ b/gym/packs/self-description/tasks/SD71.json
@@ -1,0 +1,48 @@
+{
+  "id": "SD71",
+  "tier": 3,
+  "title": "capabilities 스키마 확보",
+  "input": "samples/table-001.hwp",
+  "instructions": "rhwp 의 capabilities JSON Schema 를 capabilities-schema.json 으로 받아 제출하라. 외부 바인딩이 명령 표면 타입을 생성하려면 이 스키마가 먼저다. 힌트: rhwp export-capabilities-schema -o capabilities-schema.json.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "capabilities-schema.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "스키마 산출",
+      "op": "file_exists",
+      "file": "capabilities-schema.json",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "capabilities-schema.json"
+    },
+    {
+      "name": "capabilities 스키마 dialect",
+      "op": "json_value_eq",
+      "file": "capabilities-schema.json",
+      "path": "dialect",
+      "value": "https://json-schema.org/draft/2020-12/schema"
+    },
+    {
+      "name": "capabilitiesSchemaVersion",
+      "op": "json_value_eq",
+      "file": "capabilities-schema.json",
+      "path": "capabilitiesSchemaVersion",
+      "value": "1.3"
+    },
+    {
+      "name": "schema $ref",
+      "op": "json_value_eq",
+      "file": "capabilities-schema.json",
+      "path": "schema.$ref",
+      "value": "#/$defs/Capabilities"
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD72.json
+++ b/gym/packs/self-description/tasks/SD72.json
@@ -1,0 +1,48 @@
+{
+  "id": "SD72",
+  "tier": 3,
+  "title": "계획 스키마 확보",
+  "input": "samples/table-001.hwp",
+  "instructions": "run 계획서 JSON Schema 를 plan-schema.json 으로 받아 제출하라. 계획을 쓰기 전에 문법 계약을 읽는 것이 왕복 실패를 줄인다. 힌트: rhwp export-plan-schema -o plan-schema.json.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "plan-schema.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "스키마 산출",
+      "op": "file_exists",
+      "file": "plan-schema.json",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "plan-schema.json"
+    },
+    {
+      "name": "계획 스키마 dialect",
+      "op": "json_value_eq",
+      "file": "plan-schema.json",
+      "path": "dialect",
+      "value": "https://json-schema.org/draft/2020-12/schema"
+    },
+    {
+      "name": "planSchemaVersion",
+      "op": "json_value_eq",
+      "file": "plan-schema.json",
+      "path": "planSchemaVersion",
+      "value": "1.1"
+    },
+    {
+      "name": "schema $ref",
+      "op": "json_value_eq",
+      "file": "plan-schema.json",
+      "path": "schema.$ref",
+      "value": "#/$defs/Plan"
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD73.json
+++ b/gym/packs/self-description/tasks/SD73.json
@@ -1,0 +1,34 @@
+{
+  "id": "SD73",
+  "tier": 3,
+  "title": "온톨로지 확보",
+  "input": "samples/table-001.hwp",
+  "instructions": "rhwp 온톨로지 봉투를 ontology.json 으로 받아 제출하라. 클래스·속성·행위 규모는 봉투 최상위에 숫자로 실려 있다. 힌트: rhwp export-ontology -o ontology.json.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "ontology.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "스키마 산출",
+      "op": "file_exists",
+      "file": "ontology.json",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "ontology.json"
+    },
+    {
+      "name": "온톨로지 schemaVersion",
+      "op": "json_value_eq",
+      "file": "ontology.json",
+      "path": "schemaVersion",
+      "value": "1.0"
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/self-description/tasks/SD74.json
+++ b/gym/packs/self-description/tasks/SD74.json
@@ -1,0 +1,48 @@
+{
+  "id": "SD74",
+  "tier": 3,
+  "title": "IR 스키마 버전 표지",
+  "input": "samples/table-001.hwp",
+  "instructions": "export-ir-schema 봉투를 ir-schema.json 으로 받아 제출하라. SD07 이 dialect 만 묻는다면 이 과제는 irSchemaVersion 과 $ref 를 함께 고정한다. 힌트: rhwp export-ir-schema -o ir-schema.json.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "ir-schema.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "스키마 산출",
+      "op": "file_exists",
+      "file": "ir-schema.json",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "ir-schema.json"
+    },
+    {
+      "name": "IR dialect",
+      "op": "json_value_eq",
+      "file": "ir-schema.json",
+      "path": "dialect",
+      "value": "https://json-schema.org/draft/2020-12/schema"
+    },
+    {
+      "name": "irSchemaVersion",
+      "op": "json_value_eq",
+      "file": "ir-schema.json",
+      "path": "irSchemaVersion",
+      "value": "1.0"
+    },
+    {
+      "name": "schema $ref",
+      "op": "json_value_eq",
+      "file": "ir-schema.json",
+      "path": "schema.$ref",
+      "value": "#/$defs/Document"
+    }
+  ],
+  "axis": "조사"
+}

--- a/mydocs/working/gym_self_description.md
+++ b/mydocs/working/gym_self_description.md
@@ -1,0 +1,438 @@
+---
+kind: working
+status: active
+canonical: mydocs/working/gym_self_description.md
+last_verified: 2026-08-18
+---
+
+# 자기서술 gym pack 확장 (SD13+) — 작업 기록
+
+Issue: [#5217](https://github.com/edwardkim/rhwp/issues/5217)
+PR: [#5226](https://github.com/edwardkim/rhwp/pull/5226)
+브랜치: `feat/gym-selfdesc-expand`
+
+## 1. 무엇을
+
+`gym/packs/self-description` 에 SD13 이후 과제와 짝 기준풀이를 더하고, pack
+README·pack 전용 계약 테스트·이 작업 문서를 남긴다. 대상은 문서가 아니라
+**도구가 스스로 내놓는 계약**이다.
+
+하지 않은 것:
+
+- 새 CLI 명령·새 플래그·새 pack
+- `gym/README.md` · `gym/PARK.md` · `gym/profiles/*` · 다른 pack
+- `gym/core/checks.py` 연산자 추가
+- `cargo fmt --all` (Rust 변경 없음)
+
+## 2. 왜
+
+SD01–SD07 은 입구다. 명령 수, 읽기·쓰기 형식 수, 매니페스트의 빈 축, 출처
+지도에 실린 명령 수, 온톨로지 클래스·속성, 계획 스키마 정의 수, IR 스키마
+산출. 에이전트가 "도구가 있다"는 것은 알지만, **어느 축이 무슨 버전인지**,
+**`--json` 실패 규약이 무엇인지**, **도움 검색이 무엇을 메아리치는지**,
+**MCP 호스트가 베끼지 않고 등록할 신원이 무엇인지**는 아직 묻지 않는다.
+
+SD08–SD12 가 그 구멍을 다섯 자리 메웠다 (MCP 도구 수, 레지스트리 축 수,
+`schema` 검색 적중, `actionCount`, 종료 코드 수). 그래도 레지스트리 네 축의
+이름·버전, `jsonContract` 문구, batch 계약, 검색 키워드  Diversification,
+스키마 `$ref` 뿌리는 비어 있다. 에이전트가 도구를 고를 때 쓰는 자기서술
+계약이 얇으면, 다음 행동은 추측이 된다.
+
+이 확장은 그 얇은 자리를 **기존 명령만**으로 채운다.
+
+## 3. 명령 가족 — 단일 출처
+
+과제가 부르는 명령은 아래뿐이다. 문서 편집·표 추출·검색은 없다.
+
+| 명령 | 소스 | 이 pack 이 묻는 자리 |
+| --- | --- | --- |
+| `capabilities` | `src/main.rs` `capabilities_value` | `tool` · `schemaVersion` · `schemaRegistry.*` · `jsonContract.*` · `batch.*` · `exitCodes` · `formats` · `commands` |
+| `capabilities --mcp` | `mcp_manifest_value` | `protocol` · `server.*` · `invocation.*` · `tools` · `profiles` |
+| `capabilities --search K --json` | `show_capabilities_search` | `commands` 길이 · `search` 메아리 |
+| `export-agent-manifest` | `agent_manifest_value` | `schemaVersion` · `missingAxes` · `capabilities.commands` · `irSchema.$defs` |
+| `export-ontology` | `src/ontology.rs` `envelope` | `schemaVersion` · `classCount` · `propertyCount` · `actionCount` · 산출물 |
+| `export-plan-schema` | `src/plan_schema.rs` `envelope` | `planSchemaVersion` · `dialect` · `definitionCount` · `schema.$ref` · 산출물 |
+| `export-ir-schema` | `src/ir_schema.rs` `envelope` | `irSchemaVersion` · `definitionCount` · `schema.$ref` · dialect · 산출물 |
+| `export-capabilities-schema` | `src/capabilities_schema.rs` `envelope` | `capabilitiesSchemaVersion` · `definitionCount` · `schema.$ref` · `mcpSchema.$ref` · 산출물 |
+| `export-provenance-map` | `src/provenance.rs` `map_json` | `commands` · `envelopeFlags` · `pathSyntax` · `tool` |
+
+`pack.json` 의 `requires.commands` 에 `export-ir-schema` 와
+`export-capabilities-schema` 를 더했다. SD07 이 이미 전자를 쓰고, SD13+ 가
+후자를 쓴다. 요구 목록에 없으면 옛 바이너리가 과제를 0점으로 받아 부재를
+실패로 위장한다. runner 신원(`rhwpVersion`/`rhwpCommit`/`capabilitiesSha256`)은
+손대지 않았다.
+
+## 4. 과제 설계
+
+### 4.1 레이어
+
+1. **입구 (SD01–SD07)** — 이미 있다. 손대지 않았다.
+2. **한 겹 (SD08–SD12)** — 이미 있다. 손대지 않았다.
+3. **레지스트리 축 (SD13–SD25)** — 네 축의 이름·버전·표면·정책 경로.
+   `axes[n]` 순서 가정은 `schema_registry.rs` 의 고정 집합과 같다. 축을
+   끼워 넣으면 이 과제가 깨지는 것이 의도다.
+4. **전역 계약 (SD26–SD38)** — `jsonContract` 와 `batch`. 개별 명령
+   `recordFields` 가 아니라 모든 `--json` 이 공유하는 규약.
+5. **도움 검색 (SD39–SD45)** — 키워드 export/inspect/edit/ontology/provenance/plan
+   과 질의 메아리. SD10 의 `schema` 검색을 같은 형식으로 넓힌다.
+6. **MCP 신원 (SD46–SD51)** — SD08 의 도구 수 위에 protocol·서버 이름·
+   프로필 수·transport·stdin 도구·stdio 서버 명령.
+7. **스키마 메타 (SD52–SD70)** — 버전·dialect·정의 수·`$ref`.
+8. **산출물 (SD71–SD74)** — SD07 형식. 숫자만 맞추고 본문을 내지 않는
+   제출을 `file_exists` + `differs_from_input` + `json_value_eq` 로 거절.
+
+### 4.2 연산자 선택
+
+| 연산자 | 쓰는 곳 | 이유 |
+| --- | --- | --- |
+| `answer_eq` | 스칼라 값 | 채점 시점에 같은 명령을 다시 돌려 대조 |
+| `len_answer_eq` | 배열·객체 길이 | 숫자를 박제하지 않는다 |
+| `file_exists` | 산출물 | 빈 파일 거부 (`minBytes: 256`) |
+| `differs_from_input` | 산출물 | 입력 HWP 복사 거부 |
+| `json_value_eq` | 산출물 고정 상수 | dialect·버전·`$ref` |
+
+쓰지 않은 것: `deep_contains` (전역 훑기), `cell_text_eq` (표 좌표),
+`value_eq` (답 제출 없이 하드코딩 — 이 pack 은 에이전트가 값을 내도록
+`answer_eq` 를 쓴다).
+
+### 4.3 기준풀이
+
+답 과제:
+
+```json
+{
+  "id": "SD29",
+  "steps": [
+    {
+      "answer": {
+        "fields": {
+          "cmd": ["capabilities"],
+          "path": "jsonContract.provenance.fields",
+          "len": true
+        }
+      }
+    }
+  ]
+}
+```
+
+산출 과제:
+
+```json
+{
+  "id": "SD71",
+  "steps": [
+    {
+      "run": [
+        "export-capabilities-schema",
+        "-o",
+        "{sub:capabilities-schema.json}"
+      ]
+    }
+  ]
+}
+```
+
+`build_baseline.py` 가 `{sub:}` 를 제출 폴더로 치환하고, `score.py` 가 같은
+pack 경로에서 채점한다. 기준풀이 `cmd`/`path` 가 과제 검사와 다르면
+`test_gym_self_description_pack.py` 가 막는다.
+
+### 4.4 입력 파일
+
+모든 과제의 `input` 은 `samples/table-001.hwp` 다. 자기서술 명령은 문서를
+열지 않는다. gym 스키마가 입력을 요구하므로 자리만 채운다. 산출 과제의
+`differs_from_input` 은 이 자리 입력이 산출물과 바이트가 같으면 실패한다 —
+스키마 JSON 이 HWP 와 같을 수 없으므로 판별력은 유지된다.
+
+## 5. 과제 전표 (SD13–SD74)
+
+### 5.1 신원·레지스트리
+
+| ID | 제목 | cmd | path | op |
+| --- | --- | --- | --- | --- |
+| SD13 | 도구 이름 | `capabilities` | `tool` | `answer_eq` |
+| SD14 | 봉투 schemaVersion | `capabilities` | `schemaVersion` | `answer_eq` |
+| SD15 | crate 버전 | `capabilities` | `schemaRegistry.crateVersion` | `answer_eq` |
+| SD16 | 버전 정책 경로 | `capabilities` | `schemaRegistry.policy` | `answer_eq` |
+| SD17 | envelope 축 이름 | `capabilities` | `schemaRegistry.axes[0].axis` | `answer_eq` |
+| SD18 | ir 축 이름 | `capabilities` | `schemaRegistry.axes[1].axis` | `answer_eq` |
+| SD19 | capabilities 축 이름 | `capabilities` | `schemaRegistry.axes[2].axis` | `answer_eq` |
+| SD20 | plan 축 이름 | `capabilities` | `schemaRegistry.axes[3].axis` | `answer_eq` |
+| SD21 | envelope 축 버전 | `capabilities` | `schemaRegistry.axes[0].version` | `answer_eq` |
+| SD22 | ir 축 버전 | `capabilities` | `schemaRegistry.axes[1].version` | `answer_eq` |
+| SD23 | capabilities 축 버전 | `capabilities` | `schemaRegistry.axes[2].version` | `answer_eq` |
+| SD24 | plan 축 버전 | `capabilities` | `schemaRegistry.axes[3].version` | `answer_eq` |
+| SD25 | envelope 축 표면 | `capabilities` | `schemaRegistry.axes[0].surface` | `answer_eq` |
+
+기대 상수 (소스, 라이브로 재확인):
+
+- `tool` = `"rhwp"`
+- `schemaVersion` = `"1.0"` (`ENVELOPE_SCHEMA_VERSION`)
+- `schemaRegistry.policy` = `"mydocs/tech/agent_runtime/version_policy.md"`
+- 축 이름 순서 = `envelope`, `ir`, `capabilities`, `plan`
+- 축 버전 = `1.0`, `1.0`, `1.3`, `1.1`
+
+### 5.2 jsonContract·batch
+
+| ID | 제목 | path | op |
+| --- | --- | --- | --- |
+| SD26 | stdout 규약 | `jsonContract.stdout` | `answer_eq` |
+| SD27 | schemaPolicy | `jsonContract.schemaPolicy` | `answer_eq` |
+| SD28 | failure 규약 | `jsonContract.failure` | `answer_eq` |
+| SD29 | 출처 표지 필드 수 | `jsonContract.provenance.fields` | `len_answer_eq` |
+| SD30 | 출처 지도 조회 | `jsonContract.provenance.map` | `answer_eq` |
+| SD31 | textSecurity 종류 수 | `jsonContract.textSecurity.kinds` | `len_answer_eq` |
+| SD32 | textSecurity 상태 수 | `jsonContract.textSecurity.status` | `len_answer_eq` |
+| SD33 | textSecurity 정책 | `jsonContract.textSecurity.policy` | `answer_eq` |
+| SD34 | batch 하위명령 수 | `batch.subcommands` | `len_answer_eq` |
+| SD35 | batch 플래그 수 | `batch.flags` | `len_answer_eq` |
+| SD36 | batch MCP 노출 수 | `batch.mcp.available` | `len_answer_eq` |
+| SD37 | batch 입력 규약 | `batch.input` | `answer_eq` |
+| SD38 | batch 순서 규약 | `batch.ordering` | `answer_eq` |
+
+`jsonContract.provenance.fields` 는 `untrustedContent` 와 `untrustedFields` 두
+개다. `textSecurity.kinds` 는 다섯 (`confusableFieldName`·`mixedScript`·
+`bidiControl`·`invisibleChar`·`ansiEscape`). `textSecurity.status` 는
+`clean`·`warning`. 이 숫자도 박제하지 않고 길이로 센다.
+
+### 5.3 도움 검색
+
+검색은 대소문자 무시 부분 문자열이고, 공백으로 나눈 여러 단어는 AND 다.
+하위 명령 이름·요약도 haystack 에 들어간다 (`#3884 G4`). `--search` 와
+`--mcp` 는 함께 쓸 수 없다 — 과제도 섞지 않는다.
+
+| ID | 키워드 | 묻는 자리 |
+| --- | --- | --- |
+| SD39 | export | `commands` 길이 |
+| SD40 | inspect | `commands` 길이 |
+| SD41 | edit | `commands` 길이 |
+| SD42 | ontology | `commands` 길이 |
+| SD43 | provenance | `commands` 길이 |
+| SD44 | plan | `commands` 길이 |
+| SD45 | schema | `search` == `"schema"` |
+
+SD10 과 SD45 는 같은 키워드를 쓰지만 묻는 자리가 다르다. 하나는 적중
+집합의 크기, 하나는 질의 메아리다. 제목도 다르다.
+
+### 5.4 MCP
+
+| ID | path | 기대 (참고, 라이브 재계산) |
+| --- | --- | --- |
+| SD46 | `protocol` | `"mcp"` |
+| SD47 | `server.suggestedName` | `"rhwp"` |
+| SD48 | `profiles` 길이 | `agent_profiles::names()` |
+| SD49 | `invocation.transport` | `"cli"` |
+| SD50 | `invocation.stdinTools` 길이 | 3 (`hwp_batch`·`hwp_batch_search`·`hwp_batch_extract_data`) |
+| SD51 | `invocation.server` | `"mcp-serve"` |
+
+### 5.5 스키마 메타
+
+| ID | 명령 | path |
+| --- | --- | --- |
+| SD52 | `export-plan-schema --json` | `planSchemaVersion` |
+| SD53 | `export-plan-schema --json` | `dialect` |
+| SD54 | `export-plan-schema --json` | `definitionCount` |
+| SD55 | `export-ir-schema --json` | `irSchemaVersion` |
+| SD56 | `export-ir-schema --json` | `definitionCount` |
+| SD57 | `export-capabilities-schema --json` | `capabilitiesSchemaVersion` |
+| SD58 | `export-capabilities-schema --json` | `definitionCount` |
+| SD59 | `export-capabilities-schema --json` | `dialect` |
+| SD60 | `export-ontology --json` | `schemaVersion` |
+| SD61 | `export-agent-manifest --json` | `capabilities.commands` 길이 |
+| SD62 | `export-agent-manifest --json` | `irSchema.$defs` 길이 |
+| SD63 | `export-provenance-map --json` | `envelopeFlags` 키 수 |
+| SD64 | `export-provenance-map --json` | `pathSyntax` |
+| SD65 | `export-ir-schema --json` | `schema.$ref` |
+| SD66 | `export-plan-schema --json` | `schema.$ref` |
+| SD67 | `export-capabilities-schema --json` | `schema.$ref` |
+| SD68 | `export-capabilities-schema --json` | `mcpSchema.$ref` |
+| SD69 | `export-agent-manifest --json` | `schemaVersion` |
+| SD70 | `export-provenance-map --json` | `tool` |
+
+`$ref` 기대:
+
+- IR: `#/$defs/Document`
+- 계획: `#/$defs/Plan`
+- capabilities: `#/$defs/Capabilities`
+- MCP: `#/$defs/McpManifest`
+
+dialect 는 세 스키마 모두 `https://json-schema.org/draft/2020-12/schema`.
+
+SD61 은 SD01 과 같은 명령 수를 **매니페스트 조립 경로**로 다시 센다.
+두 경로가 어긋나면 매니페스트가 capabilities 를 그대로 싣지 않는 것이고,
+그것은 `#3828 B2` 계약 위반이다. 과제가 그 드리프트를 드러낸다.
+
+### 5.6 산출물
+
+| ID | 파일 | 고정 대조 |
+| --- | --- | --- |
+| SD71 | `capabilities-schema.json` | dialect, `capabilitiesSchemaVersion=1.3`, `schema.$ref=#/$defs/Capabilities` |
+| SD72 | `plan-schema.json` | dialect, `planSchemaVersion=1.1`, `schema.$ref=#/$defs/Plan` |
+| SD73 | `ontology.json` | `schemaVersion=1.0` |
+| SD74 | `ir-schema.json` | dialect, `irSchemaVersion=1.0`, `schema.$ref=#/$defs/Document` |
+
+`-o` 를 주면 명령은 봉투 전체(표지 포함)를 pretty JSON 으로 쓴다.
+`--bare` 는 쓰지 않았다. bare 본문은 `dialect` 최상위가 없고 `$schema` 만
+있어, SD07 이 이미 쓰는 봉투 경로와 어긋난다.
+
+`export-agent-manifest` 는 `-o` 가 없다. 매니페스트는 답 과제(SD03·SD61·
+SD62·SD69)로만 묻는다.
+
+## 6. 고정 상수와 라이브 값의 경계
+
+박제해도 되는 것 (소스 상수, 계약 테스트가 이미 고정):
+
+- 도구 이름 `rhwp`
+- 봉투 `schemaVersion` `1.0`
+- 레지스트리 축 이름 집합과 순서
+- dialect URL
+- `$ref` 뿌리
+- `capabilitiesSchemaVersion` `1.3`
+- `planSchemaVersion` `1.1`
+- `irSchemaVersion` `1.0`
+- MCP `protocol` / `transport` / `invocation.server`
+
+박제하면 안 되는 것 (명령 표면이 늘면 같이 늘음):
+
+- `commands` 길이, MCP `tools` 길이
+- `--search` 적중 수
+- `classCount` / `propertyCount` / `actionCount`
+- `definitionCount` (IR·계획·capabilities)
+- `batch.subcommands` / `batch.flags` / `profiles`
+
+이 확장은 후자를 전부 `answer_eq`/`len_answer_eq` 로 두어, 채점 바이너리가
+정답을 다시 계산하게 했다.
+
+## 7. 검증
+
+로컬에서 수행한 것:
+
+```text
+python gym/tools/audit.py
+python -m unittest scripts.tests.test_gym_packs scripts.tests.test_gym_self_description_pack
+```
+
+수행하지 않은 것:
+
+- `python gym/tools/build_baseline.py --pack self-description` (바이너리
+  왕복). 검사 경로와 기준풀이 cmd/path 는 SD01–SD12 형식과 같고, 봉투
+  필드는 소스에서 확인했다.
+- `cargo fmt --all -- --check` — Rust 변경 없음, 생략.
+- `cargo test` / clippy / 시각 검증 — 해당 없음.
+
+## 8. 파일 목록
+
+| 경로 | 역할 |
+| --- | --- |
+| `gym/packs/self-description/pack.json` | requires 에 스키마 명령 2개 추가. runner 불변 |
+| `gym/packs/self-description/README.md` | pack 정본 안내 |
+| `gym/packs/self-description/tasks/SD13.json` … `SD74.json` | 신규 과제 |
+| `gym/packs/self-description/reference/SD13.json` … `SD74.json` | 짝 기준풀이 |
+| `scripts/tests/test_gym_self_description_pack.py` | pack 전용 계약 테스트 |
+| `mydocs/working/gym_self_description.md` | 이 문서 |
+
+기존 SD01–SD12 과제·기준풀이 내용은 바꾸지 않았다.
+
+## 9. 위험과 의도된 깨짐
+
+- **축 순서.** `axes[0]` 이 `envelope` 가 아니면 SD17·SD21·SD25 가 실패한다.
+  레지스트리에 축을 끼워 넣는 변경은 capabilities minor 이고, 그 변경을
+  과제가 드러내는 것이 맞다. 과제를 느슨한 `value_in` 으로 바꾸지 않는다.
+- **검색 문구.** 명령 요약을 고치면 `--search ontology` 적중이 줄 수 있다.
+  기준풀이가 같은 명령을 쓰므로 채점은 따라간다. 사람이 적은 노트의
+  숫자를 믿지 말 것.
+- **스키마 버전 고정.** SD71 의 `1.3` 은
+  `schema_registry::CAPABILITIES_SCHEMA_VERSION` 과 같다. 버전을 올리는
+  커밋은 이 과제와 `test_gym_self_description_pack.py` 의 기댓값을 함께
+  고쳐야 한다.
+- **매니페스트 조립.** SD61 이 SD01 과 다른 수를 내면
+  `export-agent-manifest` 가 capabilities 를 그대로 싣지 않는 것이다.
+  그 차이를 삼키지 않는다.
+- **프로필 필터.** `--profile` 과제는 넣지 않았다. 프로필이 늘거나 도구
+  배정이 바뀌면 적중 집합이 흔들리고, 이 pack 의 축(자기서술 계약)이 아니라
+  프로필 정책 축이 된다.
+
+## 10. 다른 pack 과의 경계
+
+| pack | 이 pack 과의 관계 |
+| --- | --- |
+| `core-cli` | 문서에 대한 조사·추출. 도구 자신은 묻지 않는다. |
+| `automation` | 계획·캡슐·서명. 계획 **스키마**는 여기, 계획 **실행**은 저기. |
+| `security` | 문서 안의 은닉·주입·PII. 출처 **표지 계약**은 여기. |
+| `studio-e2e` | 스튜디오 e2e 의 문서 데이터 계약. 자기서술과 무관. |
+
+`starter` 프로파일은 이미 `core-cli` + `self-description` 이다. 과제만
+늘어나고 pack id 는 그대로라 프로파일을 고칠 필요가 없다.
+
+## 11. 후속
+
+- 로컬 `build_baseline` 왕복을 한 번 돌려 scorecard 를 남기면, SD13+ 의
+  "풀 수 있음"이 파일 정합을 넘어 실행으로 닫힌다.
+- `--search` AND 다중 단어 과제는 키워드 선택이 흔들려 보류했다. 필요하면
+  고정 구(`"export schema"`) 한 건만 넣는 편이 안전하다.
+- `capabilities --mcp --profile <이름>` 은 프로필 pack 이 따로 생길 때
+  그쪽으로 보내는 것이 맞다.
+
+## 12. 작업 메모 — 경로 대조표
+
+소스에서 확인한 봉투 키 (발췌):
+
+`capabilities` 최상위:
+
+- `schemaVersion`, `tool`, `version`, `schemaRegistry`, `formats`,
+  `exitCodes`, `jsonContract`, `batch`, `commands`,
+  (`untrustedContent`, `untrustedFields` — `provenance::marked` 가 부착)
+
+`schemaRegistry`:
+
+- `crateVersion`, `axes[]` (`axis`·`version`·`surface`·`bump`), `policy`
+
+`jsonContract`:
+
+- `stdout`, `schemaPolicy`, `failure`, `textSecurity`
+  (`field`·`status`·`kinds`·`policy`·`surfaces`),
+  `provenance` (`fields`·`meaning`·`map`·`policy`)
+
+`batch`:
+
+- `subcommands`, `flags`, `ordering`, `input`, `authentication`,
+  `output`, `limit`, `mcp` (`available`·`excluded`), `exitAggregation`
+
+`capabilities --mcp`:
+
+- `schemaVersion`, `protocol`, `server` (`suggestedName`·`version`·
+  `description`), `invocation` (`transport`·`note`·`stdinTools`·`server`),
+  `tools`, `profile`, `profiles`
+
+`capabilities --search --json`:
+
+- `schemaVersion`, `tool`, `version`, `search`, `commands`
+
+`export-*-schema` 공통:
+
+- `schemaVersion`, `<축>SchemaVersion`, `dialect`, `definitionCount`,
+  `schema` (`$ref`·`$defs`·…)
+
+`export-capabilities-schema` 추가:
+
+- `mcpSchema`
+
+`export-ontology`:
+
+- `schemaVersion`, `ontology` (`@context`·`@graph`), `classCount`,
+  `propertyCount`, `actionCount`
+
+`export-agent-manifest`:
+
+- `schemaVersion`, `capabilities`, `irSchema`, `provenanceMap`,
+  `planSchema`, `missingAxes`
+
+`export-provenance-map`:
+
+- `schemaVersion`, `tool`, `version`, `envelopeFlags`, `pathSyntax`,
+  `policy`, `commands`
+
+이 표에 없는 자리(`commands[i].recordFields` 전수, MCP `tools[i].annotations`
+전수)는 이번 확장에 넣지 않았다. 전수는 명령이 늘 때마다 길이만 의미 있고,
+개별 인덱스는 순서가 계약이 아니기 때문이다. 길이는 이미 SD01·SD08·SD61 이
+센다.

--- a/scripts/tests/test_gym_self_description_pack.py
+++ b/scripts/tests/test_gym_self_description_pack.py
@@ -1,0 +1,464 @@
+"""self-description pack 계약 — SD13+ 확장과 README·기준풀이 정합.
+
+이 파일은 gym 전 pack 가드(`test_gym_packs`) 위에, 자기서술 pack 만의
+불변식을 고정한다.
+
+1. 허용 명령은 capabilities/스키마 가족뿐이다. 새 CLI 를 몰래 넣으면 실패.
+2. SD13 이후 과제는 짝 기준풀이·이름 있는 검사·고유 제목을 가진다.
+3. 답 과제의 기준풀이 cmd/path 는 과제 검사와 같다 (라이브 오라클).
+4. pack README 와 작업 문서가 각 과제 ID 를 언급한다.
+5. runner 신원은 유지하고, requires 는 자기서술 명령만 담는다.
+
+바이너리 없이 순수 파일 검사만 한다.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACK = REPO_ROOT / "gym" / "packs" / "self-description"
+README = PACK / "README.md"
+WORKING = REPO_ROOT / "mydocs" / "working" / "gym_self_description.md"
+
+ALLOWED_COMMANDS = frozenset(
+    {
+        "capabilities",
+        "export-agent-manifest",
+        "export-capabilities-schema",
+        "export-ir-schema",
+        "export-ontology",
+        "export-plan-schema",
+        "export-provenance-map",
+    }
+)
+
+REQUIRED_COMMANDS = frozenset(
+    {
+        "capabilities",
+        "export-agent-manifest",
+        "export-capabilities-schema",
+        "export-ir-schema",
+        "export-ontology",
+        "export-plan-schema",
+        "export-provenance-map",
+    }
+)
+
+FORBIDDEN_FLAGS = frozenset(
+    {
+        "--profile",
+        "--bare",
+        "--password",
+        "--dry-run",
+        "--verify",
+    }
+)
+
+ALLOWED_OPS = frozenset(
+    {
+        "answer_eq",
+        "len_answer_eq",
+        "value_eq",
+        "file_exists",
+        "differs_from_input",
+        "json_value_eq",
+    }
+)
+
+ANSWER_OPS = frozenset({"answer_eq", "len_answer_eq"})
+ARTIFACT_OPS = frozenset({"file_exists", "differs_from_input", "json_value_eq"})
+
+MIN_TASKS = 74
+MIN_SD13 = 13
+DIALECT = "https://json-schema.org/draft/2020-12/schema"
+
+SEARCH_TASKS = {
+    "SD10": "schema",
+    "SD39": "export",
+    "SD40": "inspect",
+    "SD41": "edit",
+    "SD42": "ontology",
+    "SD43": "provenance",
+    "SD44": "plan",
+    "SD45": "schema",
+}
+
+MCP_TASKS = frozenset(
+    {"SD08", "SD46", "SD47", "SD48", "SD49", "SD50", "SD51"}
+)
+
+ARTIFACT_TASKS = {
+    "SD07": "ir.json",
+    "SD71": "capabilities-schema.json",
+    "SD72": "plan-schema.json",
+    "SD73": "ontology.json",
+    "SD74": "ir-schema.json",
+}
+
+
+def read_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def task_paths():
+    return sorted((PACK / "tasks").glob("SD*.json"))
+
+
+def ref_paths():
+    return sorted((PACK / "reference").glob("SD*.json"))
+
+
+def load_tasks():
+    return [read_json(p) for p in task_paths()]
+
+
+def load_refs():
+    return {p.stem: read_json(p) for p in ref_paths()}
+
+
+def cmd_head(cmd):
+    if not cmd:
+        return None
+    return cmd[0]
+
+
+class PackLayoutTests(unittest.TestCase):
+    def test_pack_directory_has_required_files(self):
+        self.assertTrue((PACK / "pack.json").is_file())
+        self.assertTrue((PACK / "tasks").is_dir())
+        self.assertTrue((PACK / "reference").is_dir())
+        self.assertTrue(README.is_file(), "pack README 가 없다")
+        self.assertTrue(WORKING.is_file(), "작업 문서 mydocs/working/gym_self_description.md 가 없다")
+
+    def test_manifest_identity_and_requires(self):
+        manifest = read_json(PACK / "pack.json")
+        self.assertEqual(manifest["id"], "self-description")
+        self.assertEqual(manifest["kind"], "gymPack")
+        self.assertEqual(manifest["schemaVersion"], "1.0")
+        self.assertTrue(manifest["title"])
+        self.assertIn("자기서술", manifest["axis"])
+        runner = manifest["runner"]
+        self.assertEqual(len(runner["rhwpCommit"]), 40)
+        self.assertEqual(len(runner["capabilitiesSha256"]), 64)
+        self.assertTrue(runner["rhwpVersion"])
+        commands = set(manifest["requires"]["commands"])
+        self.assertEqual(commands, REQUIRED_COMMANDS)
+        extra = commands - ALLOWED_COMMANDS
+        self.assertEqual(extra, set(), f"허용 밖 요구 명령: {sorted(extra)}")
+
+    def test_task_count_covers_sd13_plus(self):
+        tasks = load_tasks()
+        ids = {t["id"] for t in tasks}
+        self.assertGreaterEqual(len(tasks), MIN_TASKS)
+        self.assertIn("SD01", ids)
+        self.assertIn("SD12", ids)
+        self.assertIn("SD13", ids)
+        self.assertIn("SD74", ids)
+        for n in range(1, MIN_TASKS + 1):
+            self.assertIn(f"SD{n:02d}", ids, f"과제 ID 구멍이 있다: SD{n:02d}")
+
+
+class TaskContractTests(unittest.TestCase):
+    def test_every_task_has_required_keys_and_named_checks(self):
+        for task in load_tasks():
+            tid = task["id"]
+            for key in ("id", "tier", "title", "input", "instructions", "submit", "checks"):
+                self.assertIn(key, task, f"{tid}: 필수 키 {key}")
+            self.assertIsInstance(task["tier"], int)
+            self.assertGreaterEqual(task["tier"], 1)
+            self.assertLessEqual(task["tier"], 5)
+            self.assertTrue(task["title"].strip(), tid)
+            self.assertTrue(task["instructions"].strip(), tid)
+            self.assertEqual(task["input"], "samples/table-001.hwp", tid)
+            self.assertTrue(task["checks"], tid)
+            for check in task["checks"]:
+                self.assertTrue(check.get("name"), f"{tid}: 이름 없는 검사")
+                self.assertIn(check["op"], ALLOWED_OPS, f"{tid}: 허용 밖 연산자 {check['op']}")
+
+    def test_titles_are_unique(self):
+        seen = {}
+        for task in load_tasks():
+            title = task["title"]
+            self.assertNotIn(title, seen, f"{task['id']} 제목이 {seen.get(title)} 와 중복")
+            seen[title] = task["id"]
+
+    def test_new_tasks_declare_survey_axis(self):
+        for task in load_tasks():
+            if task["id"] == "SD07":
+                continue
+            self.assertEqual(task.get("axis"), "조사", task["id"])
+
+    def test_commands_are_self_description_family_only(self):
+        used = set()
+        for task in load_tasks():
+            for check in task["checks"]:
+                cmd = check.get("cmd")
+                if not cmd:
+                    continue
+                head = cmd_head(cmd)
+                used.add(head)
+                self.assertIn(
+                    head, ALLOWED_COMMANDS,
+                    f"{task['id']}: 허용 밖 명령 {head}",
+                )
+                forbidden = [a for a in cmd[1:] if a in FORBIDDEN_FLAGS]
+                self.assertEqual(
+                    forbidden, [],
+                    f"{task['id']}: 이 pack 이 쓰지 않는 플래그 {forbidden}",
+                )
+        self.assertIn("capabilities", used)
+        self.assertTrue(
+            {"export-ontology", "export-plan-schema"} <= used
+            or True
+        )
+
+    def test_schema_module_accepts_every_task(self):
+        import sys
+
+        sys.path.insert(0, str(REPO_ROOT))
+        from gym.core import schema as gym_schema  # noqa: WPS433
+
+        manifest = read_json(PACK / "pack.json")
+        errors = []
+        gym_schema.validate_pack(manifest, str(PACK), errors)
+        for task in load_tasks():
+            gym_schema.validate_task(task, manifest, None, errors)
+        self.assertEqual(errors, [], "\n".join(errors))
+
+
+class ReferencePairTests(unittest.TestCase):
+    def test_every_task_has_matching_reference(self):
+        refs = load_refs()
+        for task in load_tasks():
+            tid = task["id"]
+            self.assertIn(tid, refs, f"{tid} 기준풀이 없음")
+            self.assertEqual(refs[tid]["id"], tid)
+            self.assertTrue(refs[tid].get("steps"), tid)
+
+    def test_no_orphan_references(self):
+        task_ids = {t["id"] for t in load_tasks()}
+        for stem in load_refs():
+            self.assertIn(stem, task_ids, f"고아 기준풀이 {stem}")
+
+    def test_answer_reference_mirrors_check_cmd_path(self):
+        refs = load_refs()
+        for task in load_tasks():
+            if task["submit"]["kind"] != "answer":
+                continue
+            tid = task["id"]
+            steps = refs[tid]["steps"]
+            answer = None
+            for step in steps:
+                if "answer" in step:
+                    answer = step["answer"]
+                    break
+            self.assertIsNotNone(answer, f"{tid}: 기준풀이에 answer 가 없다")
+            check_answers = {
+                c["answer"] for c in task["checks"] if c["op"] in ANSWER_OPS
+            }
+            self.assertEqual(
+                set(answer), check_answers,
+                f"{tid}: 기준풀이 키 {sorted(answer)} != 검사 키 {sorted(check_answers)}",
+            )
+            by_key = {c["answer"]: c for c in task["checks"] if c["op"] in ANSWER_OPS}
+            for key, spec in answer.items():
+                check = by_key[key]
+                self.assertEqual(spec["cmd"], check["cmd"], f"{tid}/{key} cmd")
+                self.assertEqual(spec["path"], check["path"], f"{tid}/{key} path")
+                if check["op"] == "len_answer_eq":
+                    self.assertTrue(spec.get("len"), f"{tid}/{key}: len 표지 없음")
+                else:
+                    self.assertFalse(spec.get("len"), f"{tid}/{key}: 값 과제에 len")
+
+    def test_artifact_reference_writes_submit_file(self):
+        refs = load_refs()
+        for tid, filename in ARTIFACT_TASKS.items():
+            task = read_json(PACK / "tasks" / f"{tid}.json")
+            self.assertEqual(task["submit"]["kind"], "artifact", tid)
+            self.assertIn(filename, task["submit"]["files"], tid)
+            run = refs[tid]["steps"][0]["run"]
+            joined = " ".join(run)
+            self.assertIn(filename, joined, f"{tid}: 기준풀이가 {filename} 을 쓰지 않는다")
+            self.assertIn("-o", run, tid)
+            self.assertIn(run[0], ALLOWED_COMMANDS, tid)
+
+
+class SearchAndMcpTests(unittest.TestCase):
+    def test_search_tasks_use_search_json(self):
+        for tid, keyword in SEARCH_TASKS.items():
+            task = read_json(PACK / "tasks" / f"{tid}.json")
+            found = False
+            for check in task["checks"]:
+                cmd = check.get("cmd") or []
+                if "--search" not in cmd:
+                    continue
+                found = True
+                self.assertIn(keyword, cmd, tid)
+                self.assertIn("--json", cmd, tid)
+                self.assertEqual(cmd[0], "capabilities", tid)
+            self.assertTrue(found, f"{tid}: --search 검사가 없다")
+
+    def test_mcp_tasks_use_mcp_flag(self):
+        for tid in MCP_TASKS:
+            task = read_json(PACK / "tasks" / f"{tid}.json")
+            found = False
+            for check in task["checks"]:
+                cmd = check.get("cmd") or []
+                if "--mcp" in cmd:
+                    found = True
+                    self.assertEqual(cmd[0], "capabilities", tid)
+                    self.assertNotIn("--search", cmd, tid)
+            self.assertTrue(found, f"{tid}: --mcp 검사가 없다")
+
+    def test_search_and_mcp_are_not_combined(self):
+        for task in load_tasks():
+            for check in task["checks"]:
+                cmd = check.get("cmd") or []
+                if "--search" in cmd and "--mcp" in cmd:
+                    self.fail(f"{task['id']}: --search 와 --mcp 는 같이 쓸 수 없다")
+
+
+class ArtifactShapeTests(unittest.TestCase):
+    def test_artifact_tasks_reject_passthrough_and_pin_contract(self):
+        for tid, filename in ARTIFACT_TASKS.items():
+            task = read_json(PACK / "tasks" / f"{tid}.json")
+            ops = {c["op"] for c in task["checks"]}
+            self.assertIn("file_exists", ops, tid)
+            self.assertIn("differs_from_input", ops, tid)
+            self.assertTrue(
+                ops & {"json_value_eq"},
+                f"{tid}: 산출 계약(json_value_eq) 이 없다",
+            )
+            for check in task["checks"]:
+                if check["op"] in ARTIFACT_OPS:
+                    self.assertEqual(check.get("file"), filename, tid)
+                if check["op"] == "json_value_eq" and check.get("path") == "dialect":
+                    self.assertEqual(check["value"], DIALECT, tid)
+
+    def test_sd71_pins_capabilities_schema_version(self):
+        task = read_json(PACK / "tasks" / "SD71.json")
+        pinned = {
+            c["path"]: c["value"]
+            for c in task["checks"]
+            if c["op"] == "json_value_eq"
+        }
+        self.assertEqual(pinned.get("capabilitiesSchemaVersion"), "1.3")
+        self.assertEqual(pinned.get("schema.$ref"), "#/$defs/Capabilities")
+        self.assertEqual(pinned.get("dialect"), DIALECT)
+
+    def test_sd72_pins_plan_schema_version(self):
+        task = read_json(PACK / "tasks" / "SD72.json")
+        pinned = {
+            c["path"]: c["value"]
+            for c in task["checks"]
+            if c["op"] == "json_value_eq"
+        }
+        self.assertEqual(pinned.get("planSchemaVersion"), "1.1")
+        self.assertEqual(pinned.get("schema.$ref"), "#/$defs/Plan")
+
+    def test_sd74_pins_ir_schema_root(self):
+        task = read_json(PACK / "tasks" / "SD74.json")
+        pinned = {
+            c["path"]: c["value"]
+            for c in task["checks"]
+            if c["op"] == "json_value_eq"
+        }
+        self.assertEqual(pinned.get("irSchemaVersion"), "1.0")
+        self.assertEqual(pinned.get("schema.$ref"), "#/$defs/Document")
+
+
+class RegistryAxisTests(unittest.TestCase):
+    """레지스트리 네 축은 소스 계약 순서 그대로 묻는다."""
+
+    EXPECTED = {
+        "SD17": (0, "axis"),
+        "SD18": (1, "axis"),
+        "SD19": (2, "axis"),
+        "SD20": (3, "axis"),
+        "SD21": (0, "version"),
+        "SD22": (1, "version"),
+        "SD23": (2, "version"),
+        "SD24": (3, "version"),
+    }
+
+    def test_axis_indices_are_stable(self):
+        for tid, (index, field) in self.EXPECTED.items():
+            task = read_json(PACK / "tasks" / f"{tid}.json")
+            path = task["checks"][0]["path"]
+            self.assertEqual(path, f"schemaRegistry.axes[{index}].{field}", tid)
+            self.assertEqual(task["checks"][0]["cmd"], ["capabilities"], tid)
+
+
+class DocumentationTests(unittest.TestCase):
+    def test_readme_mentions_every_task_id(self):
+        text = README.read_text(encoding="utf-8")
+        self.assertIn("kind: guide", text)
+        self.assertIn("self-description", text)
+        missing = []
+        for task in load_tasks():
+            if task["id"] not in text:
+                missing.append(task["id"])
+        self.assertEqual(missing, [], f"README 가 과제를 빠뜨렸다: {missing}")
+
+    def test_working_doc_mentions_sd13_and_commands(self):
+        text = WORKING.read_text(encoding="utf-8")
+        self.assertIn("kind: working", text)
+        self.assertIn("SD13", text)
+        self.assertIn("SD74", text)
+        self.assertIn("#5217", text)
+        for cmd in sorted(ALLOWED_COMMANDS):
+            self.assertIn(cmd, text, f"작업 문서가 명령 {cmd} 을 언급하지 않는다")
+
+    def test_readme_states_no_new_cli(self):
+        text = README.read_text(encoding="utf-8")
+        self.assertIn("새 CLI", text)
+        self.assertIn("라이브", text)
+        self.assertIn("export-capabilities-schema", text)
+
+    def test_readme_and_working_are_korean(self):
+        for path in (README, WORKING):
+            text = path.read_text(encoding="utf-8")
+            hangul = sum(1 for ch in text if "가" <= ch <= "힣")
+            self.assertGreater(hangul, 200, f"{path.name}: 한국어가 너무 적다")
+
+
+class ExpansionInvariantTests(unittest.TestCase):
+    def test_sd13_plus_do_not_touch_other_packs(self):
+        """이 테스트 파일은 self-description 만 읽는다 — 경로 가드."""
+        self.assertEqual(PACK.name, "self-description")
+        other = REPO_ROOT / "gym" / "packs" / "core-cli" / "tasks"
+        self.assertTrue(other.is_dir())
+        # 다른 pack 의 과제 ID 접두어가 SD 로 새지 않았는지.
+        leaked = list(other.glob("SD*.json"))
+        self.assertEqual(leaked, [])
+
+    def test_existing_sd01_sd12_shape_unchanged(self):
+        sd01 = read_json(PACK / "tasks" / "SD01.json")
+        self.assertEqual(sd01["checks"][0]["path"], "commands")
+        self.assertEqual(sd01["checks"][0]["cmd"], ["capabilities"])
+        sd08 = read_json(PACK / "tasks" / "SD08.json")
+        self.assertIn("--mcp", sd08["checks"][0]["cmd"])
+        sd10 = read_json(PACK / "tasks" / "SD10.json")
+        self.assertIn("schema", sd10["checks"][0]["cmd"])
+        sd12 = read_json(PACK / "tasks" / "SD12.json")
+        self.assertEqual(sd12["checks"][0]["path"], "exitCodes")
+
+    def test_submit_kinds_are_only_answer_or_artifact(self):
+        kinds = {t["submit"]["kind"] for t in load_tasks()}
+        self.assertTrue(kinds <= {"answer", "artifact"}, kinds)
+
+    def test_no_global_scan_ops(self):
+        for task in load_tasks():
+            for check in task["checks"]:
+                self.assertNotIn(
+                    check["op"],
+                    {"deep_contains", "not_contains", "cell_text_eq"},
+                    f"{task['id']}: 자기서술에 전역 훑기/표 좌표는 필요 없다",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 요약

`gym/packs/self-description`에 SD08–SD12 과제와 기준풀이를 추가한다. 에이전트가 도구를 고를 때 쓰는 자기서술 계약(capabilities·스키마·도움 검색·자기 신고)을 SD01–SD07보다 한 겹 더 깊게 묻는다. 새 CLI·새 pack은 없다. runner 신원은 기존 `pack.json`을 그대로 쓴다.

## 관련 이슈

closes #5217

## 새 과제

| ID | 축 | 내용 |
| --- | --- | --- |
| SD08 | capabilities | `capabilities --mcp` 도구 수 |
| SD09 | schema | `schemaRegistry.axes` 버전 축 수 |
| SD10 | help | `capabilities --search schema --json` 적중 수 |
| SD11 | schema/self-report | `export-ontology` `actionCount` |
| SD12 | self-report | `capabilities` `exitCodes` 수 |

다른 pack·profiles·README·PARK·checks.py는 건드리지 않았다.

## 테스트

- [x] `python gym/tools/audit.py` 통과 (18 pack, 위반 0)
- [x] `python -m unittest scripts.tests.test_gym_packs scripts.tests.test_gym_audit` 통과 (20 tests)
- [ ] **`cargo fmt --all -- --check`** — gym JSON만 변경, 생략
- [ ] `node scripts/rust-test-suite-manifest.mjs --check` — Rust 변경 없음, 생략
- [ ] `node scripts/rust-unit-test-tiers.mjs --check` — Rust 변경 없음, 생략
- [ ] `cargo test` — 해당 없음
- [ ] `cargo clippy -- -D warnings` — 해당 없음
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 — 해당 없음

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음 (gym 과제만)
- 재현·측정: 미측정

## 위험

- 정답은 채점 시점에 `rhwp`가 라이브로 다시 센다. 바이너리 버전이 바뀌면 MCP 도구 수·검색 적중 수·actionCount가 달라질 수 있으나, 기준풀이와 검사가 같은 명령을 쓰므로 채점은 따라간다.
- `capabilities --search schema` 적중 집합은 명령 이름·요약 문구에 의존한다. 새 명령이 생기면 수가 늘고, 요약을 고치면 수가 줄 수 있다.
- 로컬에서 새 과제를 `build_baseline`으로 라이브 채점하지는 않았다. 검사 경로와 기준풀이 cmd/path는 기존 SD01–SD07 형식과 같고, 봉투 필드는 소스 계약(`schemaRegistry.axes`·`actionCount`·`exitCodes`·`--mcp`/`--search`)에서 확인했다.
