### PR TITLE
feat(gym): pack 건강 감사 도구 — 지시·검사 이름·힌트 (#5215)

### DIFF
--- a/gym/docs/pack_health.md
+++ b/gym/docs/pack_health.md
@@ -1,0 +1,365 @@
+---
+kind: guide
+status: active
+canonical: gym/docs/pack_health.md
+last_verified: 2026-08-18
+---
+
+# gym pack 건강 감사
+
+정본 구현은 `gym/tools/pack_health.py` 다. 이 문서는 그 도구가 **무엇을 보고**,
+**무엇을 보지 않으며**, **어떤 코드로 보고하는가**를 사람이 고를 수 있게
+풀어 쓴 목록이다. 작업 기록·오탐 결정·시험 지도는
+[`mydocs/working/gym_pack_health.md`](../../mydocs/working/gym_pack_health.md)
+에 남긴다.
+
+`audit.py` 가 스키마·기준풀이 짝·전역 과제 ID 를 보면, 이 도구는 그 **다음 층**
+이다. 지시문이 비거나 한 줄이고, 같은 과제에서 `check.name` 이 겹치고, 힌트가
+답을 그대로 적고, `submit.kind` 가 모르는 값이어도 `audit.py` 는 통과한다.
+운동장 품질이 조용히 내려간다. pack 건강은 그 구멍을 같은 JSON 봉투로 닫는다.
+
+바이너리·네트워크를 부르지 않는다. `packs/` 아래 JSON 만 읽는다. 기존 pack
+과제를 고쳐 실패를 만들 필요는 없다 — 규칙은 픽스처로 고정하고, 현재
+`gym/packs` 가 이미 지키는 계약만 승격한다.
+
+## 한 줄 결론
+
+```bash
+python gym/tools/pack_health.py            # 리포트, 이슈가 있어도 0
+python gym/tools/pack_health.py --json     # 같은 리포트 JSON, 기본 0
+python gym/tools/pack_health.py --strict   # 이슈가 있으면 1
+python gym/tools/pack_health.py --pack id  # 한 pack 만
+python gym/tools/pack_health.py --codes    # 이슈 코드 목록
+```
+
+기본은 **관측**이다. `--strict` 만 품질 관문이다. `packs/` 자체를 못 읽으면
+`--strict` 없이도 종료 1 이다.
+
+## audit.py 와 나눈 일
+
+| 층 | 도구 | 보는 것 | 보지 않는 것 |
+|---|---|---|---|
+| 정합 | `audit.py` | kind/schema, 과제↔기준 짝, 고아 reference, 전역 ID 충돌, 등록 연산자 | 지시 길이, 힌트 유출, 이름 중복, 경로 위생 |
+| 건강 | `pack_health.py` | 지시·힌트·이름·제출 형식·경로 위생·연산자 필수 필드·매니페스트 신원 | 바이너리 존재, 채점 실행, 기준풀이 왕복 성공 |
+
+두 도구는 같은 파일을 읽어도 **판정 어휘가 다르다**. audit 이슈는 문자열
+한 줄이고, pack 건강 이슈는 `{code, severity, task, where, message}` 다.
+코드 표는 `--codes` 와 이 문서가 공유한다.
+
+같은 계약을 두 번 쓰는 곳이 있다. pack.json 신원, 고아 reference, 미등록
+연산자는 audit 도 본다. 건강 도구가 다시 보는 이유는 CI 에서 audit 을 돌리기
+전에 **같은 봉투** 로 관측할 수 있게 하려는 것이다. 실패 메시지를 복사하지
+않고 코드를 붙인다.
+
+## 봉투
+
+```json
+{
+  "kind": "gymPackHealth",
+  "schemaVersion": "1.0",
+  "ok": true,
+  "packCount": 18,
+  "taskCount": 112,
+  "issueCount": 0,
+  "errorCount": 0,
+  "warningCount": 0,
+  "codes": {},
+  "packs": [
+    {
+      "id": "core-cli",
+      "taskCount": 14,
+      "issueCount": 0,
+      "issues": []
+    }
+  ]
+}
+```
+
+`ok` 는 `scanError` 가 없고 `issueCount == 0` 일 때만 참이다. 경고도 이슈로
+센다. 경고만 빼고 보려면 `--exclude empty_hint` 처럼 코드를 지정한다.
+
+이슈 한 줄:
+
+| 키 | 뜻 |
+|---|---|
+| `code` | 아래 표의 기계 이름 |
+| `severity` | `error` 또는 `warning` |
+| `task` | 과제 id. pack 단위 이슈면 `null` |
+| `where` | `tasks/A01.json#checks[0]` 같은 위치 |
+| `message` | 사람이 읽는 한 줄 (한국어) |
+
+## 종료 코드
+
+| 상황 | 종료 |
+|---|---|
+| 리포트 성공 (이슈 있어도 기본) | 0 |
+| `--strict` 이고 이슈 있음 | 1 |
+| `packs/` 없음 (`scanError`) | 1 |
+| `--min-instructions` / `--min-title` < 1 | 2 |
+| `--codes` 목록만 | 0 |
+
+자기시험(`unittest`)은 픽스처에 일부러 이슈를 심고 기본 종료 0 을 확인한다.
+게이트는 `--strict` 다. 두 경로를 섞지 마라.
+
+## 검사 층
+
+### 1. 지시문
+
+- 키 없음 / 빈 문자열 / 문자열이 아님
+- 앞뒤 공백을 뺀 글자가 기본 20 미만 (`--min-instructions`)
+- 힌트 마커 앞에 본문이 없음 (`힌트:` 로만 시작)
+- 마커는 있는데 꼬리가 빔 (warning)
+- 문장 끝 힌트 꼬리가 두 번 이상 (warning)
+- `TODO` / `FIXME` / `XXX` / `TBD` / `lorem ipsum` / `여기를 채우`
+- NUL 같은 제어 문자 (개행·탭은 허용)
+
+본문 안 괄호 힌트 `(힌트: export-text)` 는 꼬리로 치지 않는다. T06 처럼
+"스스로 찾아(힌트: 명령) … 힌트: 실제 CLI" 는 한 번의 꼬리다.
+
+### 2. 과제 신원
+
+- `id` 공란, 앞뒤·내부 공백, 파일명(`A01.json`) 과 불일치
+- `title` 공란, 앞뒤 공백, `--min-title`(기본 2) 미만
+- 같은 pack 안에서 `id` 중복
+- `tier` 없음, 정수 아님, `bool` 위장, 1~5 밖
+- `input` 없음, 빈 값, 배열, 앞뒤 공백, 절대 경로, 백슬래시, `..` 탈출
+
+`title` 안의 중간 공백(`쪽수 세기`)은 허용한다. `id` 의 중간 공백은 허용하지
+않는다. 리더보드가 ID 로 과제를 가르기 때문이다.
+
+### 3. 검사(check)
+
+- `checks` 없음·빈 배열·배열 아님·항목이 객체 아님
+- `name` 없음·빈 값·앞뒤 공백·같은 과제 안 중복
+- `op` 없음·빈 값·`REGISTRY` 에 없는 이름
+- `answer_eq` / `len_answer_eq` 에 `answer` 없음
+- `value_eq` 계열·`cell_text_eq`·`csv_cell_eq`·`xml_root_eq` 에 `value` 없음
+- 파일 연산자에 `file` 없음, 해시 비교에 `files` 2개 미만
+- `file`/`files` 가 절대 경로이거나 백슬래시
+- CLI 연산자에 `cmd` 없음·빈 배열·문자열 항목 아님
+- 파일 연산자에 `cmd` 가 있음 (스키마와 같은 계약)
+- `cell_text_eq` 에 `table`/`row`/`col` 이 0 이상 정수가 아님 (`True` 거절)
+- `csv_cell_eq` 에 `row`/`col` 없음
+- 편집·보안 축에서 `deep_contains`/`not_contains` 를 `allowGlobalScan` 없이 사용
+
+같은 `name` 이 **다른 과제** 에 있는 것은 허용한다. "쪽수 일치" 는 pack 안
+관용 이름이다.
+
+등록부 목록은 `gym/core/checks.py` 의 `REGISTRY` 를 우선하고, 그 모듈을 못
+읽으면 도구 안의 내장 목록으로 후퇴한다. 후퇴 목록은 현재 트리와 같다.
+
+### 4. 제출
+
+- `submit` 없음, 객체 아님, `kind` 없음
+- `kind` 가 `answer` / `artifact` / `pair` 가 아님
+- `artifact` 인데 `files` 가 빔 (warning)
+- `pair` 인데 `files` 가 2개 미만 (warning)
+- `files` 가 배열이 아님, 항목이 빈 문자열·비문자열, 앞뒤 공백
+- 절대 경로, 백슬래시, 같은 이름 중복
+
+`answer` 에 `files` 가 없는 것은 허용한다. 채점기가 `answer.json` 을 기본으로
+열기 때문이다. `files` 를 썼으면 위생은 본다.
+
+### 5. 힌트 유출
+
+`split_hint` 가 본문과 꼬리를 가른다. 꼬리가 있을 때만 본다.
+
+- `답은 4`, `정답은 …`, `answer is …` 같은 직접 스포일러
+- 구체 스칼라만 가진 작은 JSON (`{"pages": 4}`)
+- 검사 `value`/`expected` 가 본문에 없는데 꼬리에 단독으로 등장
+
+오탐으로 치지 않는 것:
+
+- 자리표 `{ "<필드이름>": "홍길동" }`, `{"pages": "<수>"}`
+- 본문이 이미 시킨 값을 CLI 예시에 반복 (`첫 칸을 '계획실행'으로` + 힌트 명령)
+- 명령 접미의 형식 토큰 (`export-hwpx`, `conv.hwpx` 안의 `hwpx`)
+- `0` / `1` / `-1` 과 `ok`/`true`/`json`/`hwp` 같은 흔한 짧은 토큰
+
+### 6. 기준풀이
+
+짝 파일이 **있을 때만** 본다. 없는 것은 audit 몫이다.
+
+- `steps` 키 없음 / `null` / 배열 아님 / 빈 배열 / 빈 객체만
+- `reference.id` 가 과제 `id` 와 다름
+- `steps` 항목이 객체가 아님
+- `run` 이 있는데 비었음
+- `answer` 가 있는데 비었음
+- `answer.*.cmd` 가 있는데 비었음
+- 짝 과제가 없는 `reference/*.json` (고아)
+
+### 7. pack.json 매니페스트
+
+- 객체가 아님, `kind != gymPack`, `schemaVersion != 1.0`
+- `id` 가 폴더 이름과 다름
+- `title` / `axis` 공란 또는 앞뒤 공백
+- `requires.commands` 없음·빔·비문자열
+- `runner` 없음, `rhwpVersion` / `rhwpCommit` / `capabilitiesSha256` 공란
+- `tasks/` 에 JSON 이 없음 (warning)
+
+## 이슈 코드
+
+기계 이름은 `--codes` 가 찍는 표와 같다. 새 코드를 넣으면 카탈로그 튜플과
+단위시험 `test_catalog_covers_all_code_constants` 가 같이 늘어나야 한다.
+
+### 지시
+
+| code | severity | 뜻 |
+|---|---|---|
+| `empty_instructions` | error | 키가 없거나 비었다 |
+| `short_instructions` | error | 최소 글자 미만 |
+| `instructions_type` | error | 문자열 아님 |
+| `instructions_hint_only` | error | 마커 앞에 본문 없음 |
+| `empty_hint` | warning | 마커만 있고 꼬리 없음 |
+| `duplicate_hint_marker` | warning | 문장 끝 꼬리가 둘 이상 |
+| `instructions_todo` | error | TODO/FIXME 자리표 |
+| `instructions_control_char` | error | 제어 문자 |
+
+### 검사
+
+| code | severity | 뜻 |
+|---|---|---|
+| `missing_check_name` | error | name 없음 |
+| `empty_check_name` | error | name 빔 |
+| `duplicate_check_name` | error | 같은 과제에서 이름 중복 |
+| `check_name_whitespace` | error | name 앞뒤 공백 |
+| `missing_check_op` | error | op 없음 |
+| `empty_check_op` | error | op 빔 |
+| `unknown_check_op` | error | 미등록 연산자 |
+| `check_missing_answer` | error | answer_eq 계열에 answer 없음 |
+| `check_missing_value` | error | 값 비교에 value 없음 |
+| `check_missing_file` | error | 파일 연산자에 file 없음 |
+| `check_missing_files` | error | 해시 비교에 files 없음 |
+| `check_files_short` | error | files 가 2개 미만 |
+| `check_file_empty` | error | file 항목 빔 |
+| `check_file_absolute` | error | 절대 경로 |
+| `check_file_backslash` | error | 백슬래시 경로 |
+| `check_missing_cmd` | error | CLI 연산자에 cmd 없음 |
+| `check_cmd_type` | error | cmd 가 배열 아님 |
+| `check_cmd_empty` | error | cmd 빔 |
+| `check_cmd_item_type` | error | cmd 항목이 문자열 아님 |
+| `check_unexpected_cmd` | error | 파일 연산자에 cmd |
+| `cell_missing_coord` | error | cell_text_eq 좌표 없음 |
+| `csv_missing_coord` | error | csv_cell_eq 좌표 없음 |
+| `global_scan_undeclared` | error | 편집 축 전역 훑기 |
+| `checks_type` | error | checks 가 배열 아님 |
+| `empty_checks` | error | checks 빔 |
+| `check_type` | error | 항목이 객체 아님 |
+
+### 신원·입력
+
+| code | severity | 뜻 |
+|---|---|---|
+| `task_id_whitespace` | error | id 공백 |
+| `task_title_whitespace` | error | title 앞뒤 공백 |
+| `empty_task_id` | error | id 빔 |
+| `empty_title` | error | title 빔 |
+| `title_too_short` | error | title 최소 글자 미만 |
+| `id_filename_mismatch` | error | 파일명 ≠ id |
+| `duplicate_task_id` | error | pack 안 id 중복 |
+| `missing_tier` | error | tier 없음 |
+| `tier_type` | error | tier 가 정수 아님 |
+| `tier_range` | error | tier 가 1~5 밖 |
+| `missing_input` | error | input 없음 |
+| `empty_input` | error | input 빔 |
+| `input_type` | error | input 이 문자열 아님 |
+| `input_whitespace` | error | input 앞뒤 공백 |
+| `input_absolute` | error | 절대 경로 |
+| `input_backslash` | error | 백슬래시 |
+| `input_parent_traversal` | error | `..` 탈출 |
+
+### 제출·힌트·기준풀이·매니페스트
+
+| code | severity | 뜻 |
+|---|---|---|
+| `unknown_submit_kind` | error | kind 미지 |
+| `missing_submit` | error | submit 없음 |
+| `missing_submit_kind` | error | kind 없음 |
+| `submit_type` | error | submit 이 객체 아님 |
+| `artifact_without_files` | warning | artifact 에 files 없음 |
+| `pair_without_files` | warning | pair 에 files 2개 미만 |
+| `submit_files_type` | error | files 가 배열 아님 |
+| `submit_file_empty` | error | 항목 빔 |
+| `submit_file_type` | error | 항목이 문자열 아님 |
+| `submit_file_whitespace` | error | 항목 앞뒤 공백 |
+| `submit_file_absolute` | error | 절대 경로 |
+| `submit_file_backslash` | error | 백슬래시 |
+| `submit_file_duplicate` | error | 같은 이름 중복 |
+| `hint_answer_dump` | error | 정답 JSON |
+| `hint_spoiler` | error | "답은 N" |
+| `hint_embeds_check_value` | error | 기대값 복붙 |
+| `empty_reference_steps` | error | steps 빔 |
+| `reference_steps_type` | error | steps 타입 |
+| `reference_id_mismatch` | error | reference.id ≠ 과제 id |
+| `reference_step_type` | error | step 이 객체 아님 |
+| `reference_run_empty` | error | run 빔 |
+| `reference_answer_empty` | error | answer 빔 |
+| `reference_cmd_empty` | error | answer.cmd 빔 |
+| `orphan_reference` | error | 짝 과제 없음 |
+| `parse_error` | error | JSON 파싱 실패 |
+| `missing_pack_json` | error | pack.json 없음 |
+| `missing_tasks_dir` | error | tasks/ 없음 |
+| `empty_pack` | warning | 과제 0건 |
+| `pack_type` | error | pack.json 이 객체 아님 |
+| `pack_kind` | error | kind ≠ gymPack |
+| `pack_schema_version` | error | schemaVersion ≠ 1.0 |
+| `pack_id_mismatch` | error | id ≠ 폴더 |
+| `pack_empty_title` | error | title 빔 |
+| `pack_empty_axis` | error | axis 빔 |
+| `pack_title_whitespace` | error | title 앞뒤 공백 |
+| `pack_axis_whitespace` | error | axis 앞뒤 공백 |
+| `pack_missing_requires` | error | requires.commands 없음 |
+| `pack_empty_commands` | error | commands 빔 |
+| `pack_command_type` | error | commands 항목 타입 |
+| `pack_missing_runner` | error | runner 없음 |
+| `pack_missing_runner_field` | error | runner 필드 빔 |
+
+## CLI 플래그
+
+| 플래그 | 뜻 |
+|---|---|
+| `--json` | 봉투를 JSON 으로 |
+| `--strict` | 이슈가 있으면 종료 1 |
+| `--pack ID` | 한 pack. 여러 번 지정 가능 |
+| `--root DIR` | `packs/` 를 담은 디렉터리 |
+| `--min-instructions N` | 지시 최소 글자 (기본 20) |
+| `--min-title N` | title 최소 글자 (기본 2) |
+| `--codes` | 코드 표만 출력 |
+| `--exclude CODE` | 집계에서 뺄 코드. 여러 번 가능 |
+
+`--pack` 에 없는 id 를 주면 그 id 로 `missing_pack_json` 한 줄을 만든다.
+없는 pack 을 조용히 건너뛰지 않는다.
+
+## 오탐 정책
+
+규칙을 넓힐 때는 **현재 `gym/packs` 18개 · 112 과제가 통과하는지** 먼저 본다.
+실패하는 규칙이 진짜 품질 구멍이면 pack 을 고친다. 본문 관용 표현이면 규칙을
+좁힌다. 기존 과제를 실패로 뒤집으려고 문구를 다시 쓰지 않는다.
+
+이미 좁힌 예:
+
+- `(힌트: export-text)` 는 꼬리 마커가 아니다. T06 본문 안내를 중복으로
+  세지 않기 위해서다.
+- `export-hwpx` 안의 `hwpx` 는 기대값 복붙이 아니다.
+- 자리표 키 `<필드이름>` 을 가진 JSON 은 정답 봉투가 아니다.
+- `tier=True` 는 정수 1 로 보지 않는다. `bool` 은 `int` 하위형이다.
+
+## 새 규칙을 넣는 법
+
+1. `CODE_*` 상수를 추가하고 `ISSUE_CATALOG` 한 줄을 같은 이름으로 넣는다.
+2. 스캔 함수는 픽스처만 보고, 실제 pack 경로를 하드코딩하지 않는다.
+3. `scripts/tests/test_gym_pack_health.py` 에 통과·실패 픽스처를 한 쌍 넣는다.
+4. `RealRepoHealthGateTests.test_current_tree_stays_clean` 이 여전히 이슈 0
+   인지 확인한다. 실패하면 오탐인지 실제 구멍인지 먼저 가른다.
+5. 이 표와 `--codes` 출력이 같은지 눈으로 본다.
+
+`python -m unittest scripts/tests/test_gym_pack_health.py` 와
+`python gym/tools/audit.py` 를 같이 돌린다. 이 도구는 Python 만 추가하므로
+`cargo fmt --all` 은 필요 없다.
+
+## 관련 문서
+
+- [`gym/README.md`](../README.md) — 제출 형식 `answer` / `artifact` / `pair`
+- [`gym/core/checks.py`](../core/checks.py) — 채점 연산자 `REGISTRY`
+- [`gym/core/schema.py`](../core/schema.py) — pack/task 스키마
+- [`gym/tools/audit.py`](../tools/audit.py) — 정합 감사
+- [`mydocs/working/gym_pack_health.md`](../../mydocs/working/gym_pack_health.md) — 작업 기록

--- a/gym/tools/pack_health.py
+++ b/gym/tools/pack_health.py
@@ -10,13 +10,21 @@
 이 도구는 그 다음 층이다. 바이너리·네트워크 없이 pack JSON 만 읽어:
 
 - 빈/짧은 `instructions` (기본 20글자 미만)
-- 과제 안 `check.name` 누락·중복
-- 과제 `id`/`title` 의 앞뒤·내부 공백
+- 과제 안 `check.name` 누락·중복·앞뒤 공백
+- 과제 `id`/`title` 의 앞뒤·내부 공백, 짧은 title
 - 기준풀이 파일은 있는데 `steps` 가 비었다
-- 모르는 `submit.kind`
+- 모르는 `submit.kind`, 제출 파일 경로 위생
 - 힌트가 답을 직접 노출하는지 (정답 JSON 덤프, `답은 N`, 검사 기대값 복붙)
+- 힌트만 있고 본문이 비었거나, 마커만 있고 힌트가 빔, TODO 자리표
+- pack.json 신원(kind·schema·id=폴더·title·axis·requires·runner)
+- 과제 `tier`/`input` 범위·경로 위생
+- 미지/`op` 누락, CLI 연산자 `cmd` 누락, 파일 연산자 `file`/`files` 누락
+- 전역 훑기 연산자를 편집 축에서 사유 없이 씀
+- 짝 reference 의 id 불일치, 빈 `run`/`answer`, 고아 reference, 빈 pack
 
 을 pack 별로 보고한다. 기존 pack 을 고치지 않는다 — 도구만 추가한다.
+실제 트리 과제를 실패로 뒤집지 않도록, 새 규칙은 픽스처로 고정하고
+현재 gym/packs 가 이미 지키는 계약만 승격한다.
 
 ## 종료 코드 (CI 자기시험과 게이트를 가른다)
 
@@ -28,6 +36,8 @@
     python gym/tools/pack_health.py --strict   # 이슈가 있으면 1
     python gym/tools/pack_health.py --pack id  # 한 pack 만
     python gym/tools/pack_health.py --root DIR # gym/ 루트 (packs/ 를 담은 곳)
+    python gym/tools/pack_health.py --codes    # 이슈 코드 목록만
+    python gym/tools/pack_health.py --exclude C  # 코드 C 를 집계에서 뺌
 
 `--strict` 는 품질 관문이다. 기본은 관측이다.
 """
@@ -51,6 +61,65 @@ SCHEMA_VERSION = "1.0"
 KNOWN_SUBMIT_KINDS = frozenset({"answer", "artifact", "pair"})
 MIN_INSTRUCTION_CHARS = 20
 MIN_HINT_VALUE_CHARS = 4
+MIN_TITLE_CHARS = 2
+PACK_KIND = "gymPack"
+PACK_SCHEMA_VERSION = "1.0"
+RUNNER_KEYS = ("rhwpVersion", "rhwpCommit", "capabilitiesSha256")
+EDITING_AXES = ("편집", "보안")
+
+# core.checks 를 못 읽으면 쓰는 내장 목록. 현재 트리 REGISTRY 와 같다.
+FALLBACK_FILE_OPS = frozenset(
+    {
+        "same_hash",
+        "differs_from_input",
+        "file_exists",
+        "files_differ",
+        "xml_root_eq",
+        "json_value_eq",
+        "csv_cell_eq",
+        "utf8_bom",
+    }
+)
+FALLBACK_CLI_OPS = frozenset(
+    {
+        "answer_eq",
+        "len_answer_eq",
+        "len_ge",
+        "value_eq",
+        "value_ge",
+        "value_in",
+        "deep_contains",
+        "not_contains",
+        "cell_text_eq",
+    }
+)
+FALLBACK_GLOBAL_OPS = frozenset({"deep_contains", "not_contains"})
+OPS_NEED_ANSWER = frozenset({"answer_eq", "len_answer_eq"})
+OPS_NEED_VALUE = frozenset(
+    {
+        "value_eq",
+        "value_ge",
+        "value_in",
+        "cell_text_eq",
+        "xml_root_eq",
+        "json_value_eq",
+        "csv_cell_eq",
+        "len_ge",
+    }
+)
+OPS_NEED_FILE = frozenset(
+    {
+        "differs_from_input",
+        "file_exists",
+        "xml_root_eq",
+        "json_value_eq",
+        "csv_cell_eq",
+        "utf8_bom",
+    }
+)
+OPS_NEED_FILES = frozenset({"same_hash", "files_differ"})
+OPS_NEED_CELL_COORD = frozenset({"cell_text_eq"})
+OPS_NEED_CSV_COORD = frozenset({"csv_cell_eq"})
 
 CODE_EMPTY_INSTRUCTIONS = "empty_instructions"
 CODE_SHORT_INSTRUCTIONS = "short_instructions"
@@ -81,6 +150,69 @@ CODE_CHECK_TYPE = "check_type"
 CODE_PARSE_ERROR = "parse_error"
 CODE_MISSING_PACK = "missing_pack_json"
 CODE_MISSING_TASKS = "missing_tasks_dir"
+CODE_PACK_TYPE = "pack_type"
+CODE_PACK_KIND = "pack_kind"
+CODE_PACK_SCHEMA_VERSION = "pack_schema_version"
+CODE_PACK_ID_MISMATCH = "pack_id_mismatch"
+CODE_PACK_EMPTY_TITLE = "pack_empty_title"
+CODE_PACK_EMPTY_AXIS = "pack_empty_axis"
+CODE_PACK_TITLE_WHITESPACE = "pack_title_whitespace"
+CODE_PACK_AXIS_WHITESPACE = "pack_axis_whitespace"
+CODE_PACK_MISSING_REQUIRES = "pack_missing_requires"
+CODE_PACK_EMPTY_COMMANDS = "pack_empty_commands"
+CODE_PACK_COMMAND_TYPE = "pack_command_type"
+CODE_PACK_MISSING_RUNNER = "pack_missing_runner"
+CODE_PACK_MISSING_RUNNER_FIELD = "pack_missing_runner_field"
+CODE_EMPTY_PACK = "empty_pack"
+CODE_ORPHAN_REFERENCE = "orphan_reference"
+CODE_MISSING_TIER = "missing_tier"
+CODE_TIER_TYPE = "tier_type"
+CODE_TIER_RANGE = "tier_range"
+CODE_MISSING_INPUT = "missing_input"
+CODE_EMPTY_INPUT = "empty_input"
+CODE_INPUT_TYPE = "input_type"
+CODE_INPUT_WHITESPACE = "input_whitespace"
+CODE_INPUT_ABSOLUTE = "input_absolute"
+CODE_INPUT_BACKSLASH = "input_backslash"
+CODE_INPUT_PARENT = "input_parent_traversal"
+CODE_TITLE_TOO_SHORT = "title_too_short"
+CODE_CHECK_NAME_WHITESPACE = "check_name_whitespace"
+CODE_MISSING_CHECK_OP = "missing_check_op"
+CODE_EMPTY_CHECK_OP = "empty_check_op"
+CODE_UNKNOWN_CHECK_OP = "unknown_check_op"
+CODE_CHECK_MISSING_ANSWER = "check_missing_answer"
+CODE_CHECK_MISSING_VALUE = "check_missing_value"
+CODE_CHECK_MISSING_FILE = "check_missing_file"
+CODE_CHECK_MISSING_FILES = "check_missing_files"
+CODE_CHECK_FILES_SHORT = "check_files_short"
+CODE_CHECK_FILE_EMPTY = "check_file_empty"
+CODE_CHECK_FILE_ABSOLUTE = "check_file_absolute"
+CODE_CHECK_FILE_BACKSLASH = "check_file_backslash"
+CODE_CHECK_MISSING_CMD = "check_missing_cmd"
+CODE_CHECK_CMD_TYPE = "check_cmd_type"
+CODE_CHECK_CMD_EMPTY = "check_cmd_empty"
+CODE_CHECK_CMD_ITEM_TYPE = "check_cmd_item_type"
+CODE_CHECK_UNEXPECTED_CMD = "check_unexpected_cmd"
+CODE_CELL_MISSING_COORD = "cell_missing_coord"
+CODE_CSV_MISSING_COORD = "csv_missing_coord"
+CODE_GLOBAL_SCAN_UNDECLARED = "global_scan_undeclared"
+CODE_SUBMIT_FILES_TYPE = "submit_files_type"
+CODE_SUBMIT_FILE_EMPTY = "submit_file_empty"
+CODE_SUBMIT_FILE_TYPE = "submit_file_type"
+CODE_SUBMIT_FILE_WHITESPACE = "submit_file_whitespace"
+CODE_SUBMIT_FILE_ABSOLUTE = "submit_file_absolute"
+CODE_SUBMIT_FILE_BACKSLASH = "submit_file_backslash"
+CODE_SUBMIT_FILE_DUPLICATE = "submit_file_duplicate"
+CODE_INSTRUCTIONS_HINT_ONLY = "instructions_hint_only"
+CODE_EMPTY_HINT = "empty_hint"
+CODE_DUPLICATE_HINT_MARKER = "duplicate_hint_marker"
+CODE_INSTRUCTIONS_TODO = "instructions_todo"
+CODE_INSTRUCTIONS_CONTROL_CHAR = "instructions_control_char"
+CODE_REFERENCE_ID_MISMATCH = "reference_id_mismatch"
+CODE_REFERENCE_STEP_TYPE = "reference_step_type"
+CODE_REFERENCE_RUN_EMPTY = "reference_run_empty"
+CODE_REFERENCE_ANSWER_EMPTY = "reference_answer_empty"
+CODE_REFERENCE_CMD_EMPTY = "reference_cmd_empty"
 
 SEVERITY_ERROR = "error"
 SEVERITY_WARNING = "warning"
@@ -117,6 +249,110 @@ COMMON_HINT_TOKENS = frozenset(
         "id",
     }
 )
+
+TODO_RE = re.compile(
+    r"\b(?:TODO|FIXME|XXX|TBD)\b|여기를 채우|지시문을 작성|lorem ipsum",
+    re.IGNORECASE,
+)
+CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f]")
+
+# (code, default_severity, layer, 한 줄 설명) — --codes 와 문서가 같은 표를 본다.
+ISSUE_CATALOG: tuple[tuple[str, str, str, str], ...] = (
+    (CODE_EMPTY_INSTRUCTIONS, SEVERITY_ERROR, "지시", "instructions 키가 없거나 비었다"),
+    (CODE_SHORT_INSTRUCTIONS, SEVERITY_ERROR, "지시", "instructions 가 최소 글자 미만이다"),
+    (CODE_INSTRUCTIONS_TYPE, SEVERITY_ERROR, "지시", "instructions 가 문자열이 아니다"),
+    (CODE_INSTRUCTIONS_HINT_ONLY, SEVERITY_ERROR, "지시", "힌트 마커 앞에 본문이 없다"),
+    (CODE_EMPTY_HINT, SEVERITY_WARNING, "지시", "힌트 마커는 있는데 내용이 비었다"),
+    (CODE_DUPLICATE_HINT_MARKER, SEVERITY_WARNING, "지시", "힌트 마커가 두 번 이상이다"),
+    (CODE_INSTRUCTIONS_TODO, SEVERITY_ERROR, "지시", "TODO/FIXME 자리표가 남아 있다"),
+    (CODE_INSTRUCTIONS_CONTROL_CHAR, SEVERITY_ERROR, "지시", "지시문에 제어 문자가 있다"),
+    (CODE_MISSING_CHECK_NAME, SEVERITY_ERROR, "검사", "check.name 이 없다"),
+    (CODE_EMPTY_CHECK_NAME, SEVERITY_ERROR, "검사", "check.name 이 비었다"),
+    (CODE_DUPLICATE_CHECK_NAME, SEVERITY_ERROR, "검사", "같은 과제에서 check.name 이 겹친다"),
+    (CODE_CHECK_NAME_WHITESPACE, SEVERITY_ERROR, "검사", "check.name 앞뒤에 공백이 있다"),
+    (CODE_MISSING_CHECK_OP, SEVERITY_ERROR, "검사", "check.op 가 없다"),
+    (CODE_EMPTY_CHECK_OP, SEVERITY_ERROR, "검사", "check.op 가 비었다"),
+    (CODE_UNKNOWN_CHECK_OP, SEVERITY_ERROR, "검사", "등록되지 않은 연산자다"),
+    (CODE_CHECK_MISSING_ANSWER, SEVERITY_ERROR, "검사", "answer_eq 계열에 answer 가 없다"),
+    (CODE_CHECK_MISSING_VALUE, SEVERITY_ERROR, "검사", "값 비교 연산자에 value 가 없다"),
+    (CODE_CHECK_MISSING_FILE, SEVERITY_ERROR, "검사", "파일 연산자에 file 이 없다"),
+    (CODE_CHECK_MISSING_FILES, SEVERITY_ERROR, "검사", "해시 비교 연산자에 files 가 없다"),
+    (CODE_CHECK_FILES_SHORT, SEVERITY_ERROR, "검사", "files 가 2개 미만이다"),
+    (CODE_CHECK_FILE_EMPTY, SEVERITY_ERROR, "검사", "file/files 항목이 비었다"),
+    (CODE_CHECK_FILE_ABSOLUTE, SEVERITY_ERROR, "검사", "file 경로가 절대 경로다"),
+    (CODE_CHECK_FILE_BACKSLASH, SEVERITY_ERROR, "검사", "file 경로에 백슬래시가 있다"),
+    (CODE_CHECK_MISSING_CMD, SEVERITY_ERROR, "검사", "CLI 연산자에 cmd 가 없다"),
+    (CODE_CHECK_CMD_TYPE, SEVERITY_ERROR, "검사", "cmd 가 배열이 아니다"),
+    (CODE_CHECK_CMD_EMPTY, SEVERITY_ERROR, "검사", "cmd 가 비었다"),
+    (CODE_CHECK_CMD_ITEM_TYPE, SEVERITY_ERROR, "검사", "cmd 항목이 문자열이 아니다"),
+    (CODE_CHECK_UNEXPECTED_CMD, SEVERITY_ERROR, "검사", "파일 연산자에 cmd 가 있다"),
+    (CODE_CELL_MISSING_COORD, SEVERITY_ERROR, "검사", "cell_text_eq 에 table/row/col 이 없다"),
+    (CODE_CSV_MISSING_COORD, SEVERITY_ERROR, "검사", "csv_cell_eq 에 row/col 이 없다"),
+    (CODE_GLOBAL_SCAN_UNDECLARED, SEVERITY_ERROR, "검사", "편집 축에서 전역 훑기를 사유 없이 썼다"),
+    (CODE_CHECKS_TYPE, SEVERITY_ERROR, "검사", "checks 가 배열이 아니다"),
+    (CODE_EMPTY_CHECKS, SEVERITY_ERROR, "검사", "checks 가 없거나 비었다"),
+    (CODE_CHECK_TYPE, SEVERITY_ERROR, "검사", "checks 항목이 객체가 아니다"),
+    (CODE_TASK_ID_WHITESPACE, SEVERITY_ERROR, "신원", "과제 id 에 공백이 있다"),
+    (CODE_TASK_TITLE_WHITESPACE, SEVERITY_ERROR, "신원", "과제 title 앞뒤에 공백이 있다"),
+    (CODE_EMPTY_TASK_ID, SEVERITY_ERROR, "신원", "과제 id 가 비었다"),
+    (CODE_EMPTY_TITLE, SEVERITY_ERROR, "신원", "과제 title 이 비었다"),
+    (CODE_TITLE_TOO_SHORT, SEVERITY_ERROR, "신원", "과제 title 이 최소 글자 미만이다"),
+    (CODE_ID_FILENAME_MISMATCH, SEVERITY_ERROR, "신원", "파일명과 과제 id 가 다르다"),
+    (CODE_DUPLICATE_TASK_ID, SEVERITY_ERROR, "신원", "같은 pack 에서 과제 id 가 겹친다"),
+    (CODE_MISSING_TIER, SEVERITY_ERROR, "신원", "tier 키가 없다"),
+    (CODE_TIER_TYPE, SEVERITY_ERROR, "신원", "tier 가 정수가 아니다"),
+    (CODE_TIER_RANGE, SEVERITY_ERROR, "신원", "tier 가 1~5 밖이다"),
+    (CODE_MISSING_INPUT, SEVERITY_ERROR, "입력", "input 키가 없다"),
+    (CODE_EMPTY_INPUT, SEVERITY_ERROR, "입력", "input 이 비었다"),
+    (CODE_INPUT_TYPE, SEVERITY_ERROR, "입력", "input 이 문자열이 아니다"),
+    (CODE_INPUT_WHITESPACE, SEVERITY_ERROR, "입력", "input 앞뒤에 공백이 있다"),
+    (CODE_INPUT_ABSOLUTE, SEVERITY_ERROR, "입력", "input 이 절대 경로다"),
+    (CODE_INPUT_BACKSLASH, SEVERITY_ERROR, "입력", "input 에 백슬래시가 있다"),
+    (CODE_INPUT_PARENT, SEVERITY_ERROR, "입력", "input 이 상위 디렉터리를 가리킨다"),
+    (CODE_EMPTY_REFERENCE_STEPS, SEVERITY_ERROR, "기준풀이", "reference 는 있는데 steps 가 비었다"),
+    (CODE_REFERENCE_STEPS_TYPE, SEVERITY_ERROR, "기준풀이", "reference.steps 가 배열이 아니다"),
+    (CODE_REFERENCE_ID_MISMATCH, SEVERITY_ERROR, "기준풀이", "reference.id 가 과제 id 와 다르다"),
+    (CODE_REFERENCE_STEP_TYPE, SEVERITY_ERROR, "기준풀이", "steps 항목이 객체가 아니다"),
+    (CODE_REFERENCE_RUN_EMPTY, SEVERITY_ERROR, "기준풀이", "steps.run 이 비었다"),
+    (CODE_REFERENCE_ANSWER_EMPTY, SEVERITY_ERROR, "기준풀이", "steps.answer 가 비었다"),
+    (CODE_REFERENCE_CMD_EMPTY, SEVERITY_ERROR, "기준풀이", "answer 항목의 cmd 가 비었다"),
+    (CODE_ORPHAN_REFERENCE, SEVERITY_ERROR, "기준풀이", "짝 과제가 없는 reference 다"),
+    (CODE_UNKNOWN_SUBMIT_KIND, SEVERITY_ERROR, "제출", "submit.kind 를 모른다"),
+    (CODE_MISSING_SUBMIT, SEVERITY_ERROR, "제출", "submit 이 없다"),
+    (CODE_MISSING_SUBMIT_KIND, SEVERITY_ERROR, "제출", "submit.kind 가 없다"),
+    (CODE_SUBMIT_TYPE, SEVERITY_ERROR, "제출", "submit 이 객체가 아니다"),
+    (CODE_ARTIFACT_WITHOUT_FILES, SEVERITY_WARNING, "제출", "artifact 인데 files 가 비었다"),
+    (CODE_PAIR_WITHOUT_FILES, SEVERITY_WARNING, "제출", "pair 인데 files 가 2개 미만이다"),
+    (CODE_SUBMIT_FILES_TYPE, SEVERITY_ERROR, "제출", "submit.files 가 배열이 아니다"),
+    (CODE_SUBMIT_FILE_EMPTY, SEVERITY_ERROR, "제출", "submit.files 항목이 비었다"),
+    (CODE_SUBMIT_FILE_TYPE, SEVERITY_ERROR, "제출", "submit.files 항목이 문자열이 아니다"),
+    (CODE_SUBMIT_FILE_WHITESPACE, SEVERITY_ERROR, "제출", "submit.files 항목 앞뒤에 공백이 있다"),
+    (CODE_SUBMIT_FILE_ABSOLUTE, SEVERITY_ERROR, "제출", "submit.files 가 절대 경로다"),
+    (CODE_SUBMIT_FILE_BACKSLASH, SEVERITY_ERROR, "제출", "submit.files 에 백슬래시가 있다"),
+    (CODE_SUBMIT_FILE_DUPLICATE, SEVERITY_ERROR, "제출", "submit.files 가 중복이다"),
+    (CODE_HINT_ANSWER_DUMP, SEVERITY_ERROR, "힌트", "힌트에 정답 JSON 이 있다"),
+    (CODE_HINT_SPOILER, SEVERITY_ERROR, "힌트", "힌트가 정답을 직접 적었다"),
+    (CODE_HINT_EMBEDS_VALUE, SEVERITY_ERROR, "힌트", "힌트가 검사 기대값을 복붙했다"),
+    (CODE_PARSE_ERROR, SEVERITY_ERROR, "구조", "JSON 파싱에 실패했다"),
+    (CODE_MISSING_PACK, SEVERITY_ERROR, "구조", "pack.json 이 없다"),
+    (CODE_MISSING_TASKS, SEVERITY_ERROR, "구조", "tasks/ 가 없다"),
+    (CODE_PACK_TYPE, SEVERITY_ERROR, "매니페스트", "pack.json 이 객체가 아니다"),
+    (CODE_PACK_KIND, SEVERITY_ERROR, "매니페스트", "kind 가 gymPack 이 아니다"),
+    (CODE_PACK_SCHEMA_VERSION, SEVERITY_ERROR, "매니페스트", "schemaVersion 이 1.0 이 아니다"),
+    (CODE_PACK_ID_MISMATCH, SEVERITY_ERROR, "매니페스트", "pack.id 가 폴더 이름과 다르다"),
+    (CODE_PACK_EMPTY_TITLE, SEVERITY_ERROR, "매니페스트", "pack.title 이 비었다"),
+    (CODE_PACK_EMPTY_AXIS, SEVERITY_ERROR, "매니페스트", "pack.axis 가 비었다"),
+    (CODE_PACK_TITLE_WHITESPACE, SEVERITY_ERROR, "매니페스트", "pack.title 앞뒤에 공백이 있다"),
+    (CODE_PACK_AXIS_WHITESPACE, SEVERITY_ERROR, "매니페스트", "pack.axis 앞뒤에 공백이 있다"),
+    (CODE_PACK_MISSING_REQUIRES, SEVERITY_ERROR, "매니페스트", "requires.commands 가 없다"),
+    (CODE_PACK_EMPTY_COMMANDS, SEVERITY_ERROR, "매니페스트", "requires.commands 가 비었다"),
+    (CODE_PACK_COMMAND_TYPE, SEVERITY_ERROR, "매니페스트", "requires.commands 항목이 문자열이 아니다"),
+    (CODE_PACK_MISSING_RUNNER, SEVERITY_ERROR, "매니페스트", "runner 가 없다"),
+    (CODE_PACK_MISSING_RUNNER_FIELD, SEVERITY_ERROR, "매니페스트", "runner 신원 필드가 비었다"),
+    (CODE_EMPTY_PACK, SEVERITY_WARNING, "구조", "tasks/ 에 과제가 없다"),
+)
+
+_OPS_CACHE: tuple[frozenset[str], frozenset[str], frozenset[str], frozenset[str]] | None = None
 
 
 def issue(
@@ -165,19 +401,57 @@ def instruction_length(text: str) -> int:
     return len(text.strip())
 
 
+def _marker_is_parenthetical(text: str, idx: int) -> bool:
+    """`(힌트: export-text)` 처럼 본문 안 괄호 힌트는 꼬리 마커가 아니다."""
+    before = text[:idx]
+    if before.rstrip().endswith("("):
+        return True
+    return before.count("(") > before.count(")")
+
+
+def _marker_is_section(text: str, idx: int) -> bool:
+    """문장 끝·줄바꿈·맨 앞의 힌트 꼬리만 센다."""
+    if _marker_is_parenthetical(text, idx):
+        return False
+    if idx == 0:
+        return True
+    if text[idx - 1] in "\n\r":
+        return True
+    prefix = text[:idx].rstrip()
+    return prefix.endswith((".", "。", "!", "?", "다", "라", "요"))
+
+
+def iter_hint_markers(text: str) -> list[tuple[int, str, bool]]:
+    """(index, marker, is_section) 출현 목록."""
+    found: list[tuple[int, str, bool]] = []
+    if not text:
+        return found
+    for marker in HINT_MARKERS:
+        start = 0
+        while True:
+            idx = text.find(marker, start)
+            if idx < 0:
+                break
+            found.append((idx, marker, _marker_is_section(text, idx)))
+            start = idx + len(marker)
+    found.sort(key=lambda row: row[0])
+    return found
+
+
 def split_hint(instructions: str) -> tuple[str, str | None]:
-    """본문과 힌트 꼬리를 가른다. 마커가 없으면 힌트는 None."""
+    """본문과 힌트 꼬리를 가른다. 마커가 없으면 힌트는 None.
+
+    괄호 안 `(힌트: export-text)` 는 본문 안내로 보고, 문장 끝의 꼬리 마커를
+    우선한다. 꼬리가 없으면 첫 마커로 후퇴한다.
+    """
     if not isinstance(instructions, str):
         return "", None
-    found_at = -1
-    found_marker = ""
-    for marker in HINT_MARKERS:
-        idx = instructions.find(marker)
-        if idx >= 0 and (found_at < 0 or idx < found_at):
-            found_at = idx
-            found_marker = marker
-    if found_at < 0:
+    found = iter_hint_markers(instructions)
+    if not found:
         return instructions, None
+    section = [row for row in found if row[2]]
+    chosen = section[0] if section else found[0]
+    found_at, found_marker, _is_section = chosen
     body = instructions[:found_at]
     hint = instructions[found_at + len(found_marker) :]
     return body, hint
@@ -304,6 +578,103 @@ def check_expected_literals(check: dict) -> list[str]:
     return out
 
 
+def known_ops_bundle() -> tuple[frozenset[str], frozenset[str], frozenset[str], frozenset[str]]:
+    """(all_ops, cli_ops, file_ops, global_ops). core.checks 를 우선한다."""
+    global _OPS_CACHE
+    if _OPS_CACHE is not None:
+        return _OPS_CACHE
+    all_ops = FALLBACK_FILE_OPS | FALLBACK_CLI_OPS
+    cli_ops = FALLBACK_CLI_OPS
+    file_ops = FALLBACK_FILE_OPS
+    global_ops = FALLBACK_GLOBAL_OPS
+    try:
+        if GYM_ROOT not in sys.path:
+            sys.path.insert(0, GYM_ROOT)
+        from core import checks as check_registry  # type: ignore
+
+        registry = getattr(check_registry, "REGISTRY", None)
+        if isinstance(registry, dict) and registry:
+            all_ops = frozenset(registry)
+            cli_ops = frozenset(
+                op for op, spec in registry.items() if isinstance(spec, tuple) and spec[1]
+            )
+            file_ops = all_ops - cli_ops
+        scanned = getattr(check_registry, "GLOBAL_SCAN_OPS", None)
+        if isinstance(scanned, (set, frozenset, list, tuple)) and scanned:
+            global_ops = frozenset(scanned)
+    except Exception:
+        pass
+    _OPS_CACHE = (all_ops, cli_ops, file_ops, global_ops)
+    return _OPS_CACHE
+
+
+def reset_ops_cache() -> None:
+    """단위시험이 등록부를 갈아끼운 뒤 호출한다."""
+    global _OPS_CACHE
+    _OPS_CACHE = None
+
+
+def catalog_codes() -> list[str]:
+    return [row[0] for row in ISSUE_CATALOG]
+
+
+def catalog_entry(code: str) -> tuple[str, str, str] | None:
+    for item_code, severity, layer, summary in ISSUE_CATALOG:
+        if item_code == code:
+            return severity, layer, summary
+    return None
+
+
+def render_codes() -> str:
+    """이슈 코드 목록 — `--codes` 가 그대로 찍는다."""
+    lines = ["code\tseverity\tlayer\tsummary"]
+    for code, severity, layer, summary in ISSUE_CATALOG:
+        lines.append(f"{code}\t{severity}\t{layer}\t{summary}")
+    return "\n".join(lines)
+
+
+def is_absolute_path(path: str) -> bool:
+    if not path:
+        return False
+    if path.startswith("/") or path.startswith("\\"):
+        return True
+    if len(path) >= 2 and path[0].isalpha() and path[1] == ":":
+        return True
+    return False
+
+
+def has_backslash(path: str) -> bool:
+    return "\\" in path
+
+
+def has_parent_traversal(path: str) -> bool:
+    parts = re.split(r"[\\/]+", path)
+    return ".." in parts
+
+
+def is_nonneg_int(value) -> bool:
+    """좌표는 0 이상 정수. bool 은 int 하위형이라 거절한다."""
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def pack_axis_is_editing(axis: str | None) -> bool:
+    if not isinstance(axis, str) or not axis:
+        return False
+    return any(axis.startswith(prefix) for prefix in EDITING_AXES)
+
+
+def effective_axis(task: dict, pack_axis: str | None) -> str:
+    raw = task.get("axis")
+    if isinstance(raw, str) and raw.strip():
+        return raw
+    return pack_axis or ""
+
+
+def count_hint_markers(text: str) -> int:
+    """문장 끝 힌트 꼬리만 센다. 괄호 안 안내는 중복으로 치지 않는다."""
+    return sum(1 for _idx, _marker, is_section in iter_hint_markers(text) if is_section)
+
+
 def iter_pack_dirs(packs_root: str, pack_ids: list[str] | None = None) -> list[tuple[str, str]]:
     """(pack_id, pack_dir). packs_root 는 gym/ (packs/ 를 담은 곳)."""
     packs_dir = os.path.join(packs_root, "packs")
@@ -370,11 +741,74 @@ def scan_instructions(task: dict, where: str, tid: str | None, min_chars: int) -
                 extra={"length": length, "min": min_chars},
             )
         )
+    issues.extend(scan_instruction_quality(text, where, tid))
     return issues
 
 
-def scan_identity(task: dict, filename: str, where: str) -> list[dict]:
-    """id/title 공백·공란·파일명 불일치."""
+def scan_instruction_quality(text: str, where: str, tid: str | None) -> list[dict]:
+    """길이·타입 다음 층 — 자리표·힌트 골격·제어 문자."""
+    issues: list[dict] = []
+    if CONTROL_CHAR_RE.search(text):
+        issues.append(
+            issue(
+                CODE_INSTRUCTIONS_CONTROL_CHAR,
+                "instructions 에 제어 문자가 있다",
+                task=tid,
+                where=where,
+            )
+        )
+    if TODO_RE.search(text):
+        issues.append(
+            issue(
+                CODE_INSTRUCTIONS_TODO,
+                "instructions 에 TODO/FIXME 자리표가 남아 있다",
+                task=tid,
+                where=where,
+            )
+        )
+    marker_count = count_hint_markers(text)
+    if marker_count > 1:
+        issues.append(
+            issue(
+                CODE_DUPLICATE_HINT_MARKER,
+                f"힌트 마커가 {marker_count}번 나온다",
+                task=tid,
+                where=where,
+                severity=SEVERITY_WARNING,
+                extra={"count": marker_count},
+            )
+        )
+    body, hint = split_hint(text)
+    if hint is not None:
+        if not body.strip():
+            issues.append(
+                issue(
+                    CODE_INSTRUCTIONS_HINT_ONLY,
+                    "힌트 마커 앞에 과제 본문이 없다",
+                    task=tid,
+                    where=where,
+                )
+            )
+        if not hint.strip():
+            issues.append(
+                issue(
+                    CODE_EMPTY_HINT,
+                    "힌트 마커는 있는데 내용이 비었다",
+                    task=tid,
+                    where=where,
+                    severity=SEVERITY_WARNING,
+                )
+            )
+    return issues
+
+
+def scan_identity(
+    task: dict,
+    filename: str,
+    where: str,
+    min_title: int = MIN_TITLE_CHARS,
+) -> list[dict]:
+    """id/title 공백·공란·파일명 불일치·짧은 title."""
     issues: list[dict] = []
     tid = task.get("id")
     title = task.get("title")
@@ -418,10 +852,112 @@ def scan_identity(task: dict, filename: str, where: str) -> list[dict]:
                 where=where,
             )
         )
+    elif len(title.strip()) < min_title:
+        issues.append(
+            issue(
+                CODE_TITLE_TOO_SHORT,
+                f"과제 title 이 {len(title.strip())}글자(< {min_title})다",
+                task=shown,
+                where=where,
+                extra={"length": len(title.strip()), "min": min_title},
+            )
+        )
     return issues
 
 
-def scan_checks(task: dict, where: str, tid: str | None) -> list[dict]:
+def scan_tier(task: dict, where: str, tid: str | None) -> list[dict]:
+    issues: list[dict] = []
+    if "tier" not in task:
+        issues.append(issue(CODE_MISSING_TIER, "tier 키가 없다", task=tid, where=where))
+        return issues
+    tier = task.get("tier")
+    if isinstance(tier, bool) or not isinstance(tier, int):
+        issues.append(
+            issue(
+                CODE_TIER_TYPE,
+                f"tier 가 정수가 아니다 ({type(tier).__name__})",
+                task=tid,
+                where=where,
+            )
+        )
+        return issues
+    if tier < 1 or tier > 5:
+        issues.append(
+            issue(
+                CODE_TIER_RANGE,
+                f"tier 가 {tier} 이다 (허용 1~5)",
+                task=tid,
+                where=where,
+                extra={"tier": tier},
+            )
+        )
+    return issues
+
+
+def scan_input(task: dict, where: str, tid: str | None) -> list[dict]:
+    issues: list[dict] = []
+    if "input" not in task:
+        issues.append(issue(CODE_MISSING_INPUT, "input 키가 없다", task=tid, where=where))
+        return issues
+    raw = task.get("input")
+    if not isinstance(raw, str):
+        issues.append(
+            issue(
+                CODE_INPUT_TYPE,
+                f"input 이 문자열이 아니다 ({type(raw).__name__})",
+                task=tid,
+                where=where,
+            )
+        )
+        return issues
+    if not raw.strip():
+        issues.append(issue(CODE_EMPTY_INPUT, "input 이 비었다", task=tid, where=where))
+        return issues
+    if has_edge_whitespace(raw):
+        issues.append(
+            issue(
+                CODE_INPUT_WHITESPACE,
+                f"input 앞뒤에 공백이 있다: {raw!r}",
+                task=tid,
+                where=where,
+            )
+        )
+    if is_absolute_path(raw):
+        issues.append(
+            issue(
+                CODE_INPUT_ABSOLUTE,
+                f"input 이 절대 경로다: {raw}",
+                task=tid,
+                where=where,
+            )
+        )
+    if has_backslash(raw):
+        issues.append(
+            issue(
+                CODE_INPUT_BACKSLASH,
+                "input 경로에 백슬래시가 있다 — POSIX 상대 경로를 써라",
+                task=tid,
+                where=where,
+            )
+        )
+    if has_parent_traversal(raw):
+        issues.append(
+            issue(
+                CODE_INPUT_PARENT,
+                "input 이 상위 디렉터리(..) 를 가리킨다",
+                task=tid,
+                where=where,
+            )
+        )
+    return issues
+
+
+def scan_checks(
+    task: dict,
+    where: str,
+    tid: str | None,
+    pack_axis: str | None = None,
+) -> list[dict]:
     issues: list[dict] = []
     checks = task.get("checks")
     if checks is None:
@@ -492,7 +1028,17 @@ def scan_checks(task: dict, where: str, tid: str | None) -> list[dict]:
                 )
             )
             continue
-        names.append(raw_name)
+        if has_edge_whitespace(raw_name):
+            issues.append(
+                issue(
+                    CODE_CHECK_NAME_WHITESPACE,
+                    f"checks[{index}].name 앞뒤에 공백이 있다: {raw_name!r}",
+                    task=tid,
+                    where=prefix,
+                    extra={"index": index},
+                )
+            )
+        names.append(raw_name.strip())
 
     counts = Counter(names)
     for name, count in counts.items():
@@ -506,6 +1052,295 @@ def scan_checks(task: dict, where: str, tid: str | None) -> list[dict]:
                     extra={"name": name, "count": count},
                 )
             )
+
+    axis = effective_axis(task, pack_axis)
+    for index, check in enumerate(checks):
+        if isinstance(check, dict):
+            issues.extend(
+                scan_check_contract(
+                    check,
+                    f"{where}#checks[{index}]",
+                    tid,
+                    index,
+                    axis,
+                )
+            )
+    return issues
+
+
+def scan_path_field(
+    raw,
+    *,
+    code_empty: str,
+    code_absolute: str,
+    code_backslash: str,
+    label: str,
+    tid: str | None,
+    where: str,
+    extra: dict | None = None,
+) -> list[dict]:
+    """상대 POSIX 경로 위생. 문자열이 아니면 호출하지 않는다."""
+    issues: list[dict] = []
+    if not raw.strip():
+        issues.append(
+            issue(code_empty, f"{label} 이 비었다", task=tid, where=where, extra=extra)
+        )
+        return issues
+    if is_absolute_path(raw):
+        issues.append(
+            issue(
+                code_absolute,
+                f"{label} 이 절대 경로다: {raw}",
+                task=tid,
+                where=where,
+                extra=extra,
+            )
+        )
+    if has_backslash(raw):
+        issues.append(
+            issue(
+                code_backslash,
+                f"{label} 에 백슬래시가 있다",
+                task=tid,
+                where=where,
+                extra=extra,
+            )
+        )
+    return issues
+
+
+def scan_check_contract(
+    check: dict,
+    where: str,
+    tid: str | None,
+    index: int,
+    axis: str,
+) -> list[dict]:
+    """op·필수 필드·cmd 계약. 이름은 scan_checks 가 이미 봤다."""
+    issues: list[dict] = []
+    extra = {"index": index}
+    all_ops, cli_ops, file_ops, global_ops = known_ops_bundle()
+
+    if "op" not in check or check.get("op") is None:
+        issues.append(
+            issue(CODE_MISSING_CHECK_OP, f"checks[{index}] 에 op 가 없다", task=tid, where=where, extra=extra)
+        )
+        return issues
+    op = check.get("op")
+    if not isinstance(op, str):
+        issues.append(
+            issue(
+                CODE_MISSING_CHECK_OP,
+                f"checks[{index}].op 이 문자열이 아니다 ({type(op).__name__})",
+                task=tid,
+                where=where,
+                extra=extra,
+            )
+        )
+        return issues
+    if not op.strip():
+        issues.append(
+            issue(CODE_EMPTY_CHECK_OP, f"checks[{index}].op 이 비었다", task=tid, where=where, extra=extra)
+        )
+        return issues
+    if op not in all_ops:
+        issues.append(
+            issue(
+                CODE_UNKNOWN_CHECK_OP,
+                f"checks[{index}].op {op!r} 는 등록되지 않았다",
+                task=tid,
+                where=where,
+                extra={"index": index, "op": op},
+            )
+        )
+        return issues
+
+    if op in global_ops and pack_axis_is_editing(axis) and not check.get("allowGlobalScan"):
+        issues.append(
+            issue(
+                CODE_GLOBAL_SCAN_UNDECLARED,
+                f"편집/보안 축에서 {op} 를 쓰려면 allowGlobalScan 사유가 필요하다",
+                task=tid,
+                where=where,
+                extra={"index": index, "op": op, "axis": axis},
+            )
+        )
+
+    if op in OPS_NEED_ANSWER and "answer" not in check:
+        issues.append(
+            issue(
+                CODE_CHECK_MISSING_ANSWER,
+                f"{op} 에 answer 키가 없다",
+                task=tid,
+                where=where,
+                extra={"index": index, "op": op},
+            )
+        )
+    if op in OPS_NEED_VALUE and "value" not in check:
+        issues.append(
+            issue(
+                CODE_CHECK_MISSING_VALUE,
+                f"{op} 에 value 키가 없다",
+                task=tid,
+                where=where,
+                extra={"index": index, "op": op},
+            )
+        )
+
+    if op in OPS_NEED_FILE:
+        raw_file = check.get("file")
+        if not isinstance(raw_file, str):
+            issues.append(
+                issue(
+                    CODE_CHECK_MISSING_FILE,
+                    f"{op} 에 file 이 없다",
+                    task=tid,
+                    where=where,
+                    extra={"index": index, "op": op},
+                )
+            )
+        else:
+            issues.extend(
+                scan_path_field(
+                    raw_file,
+                    code_empty=CODE_CHECK_FILE_EMPTY,
+                    code_absolute=CODE_CHECK_FILE_ABSOLUTE,
+                    code_backslash=CODE_CHECK_FILE_BACKSLASH,
+                    label="check.file",
+                    tid=tid,
+                    where=where,
+                    extra={"index": index, "op": op},
+                )
+            )
+
+    if op in OPS_NEED_FILES:
+        files = check.get("files")
+        if not isinstance(files, list):
+            issues.append(
+                issue(
+                    CODE_CHECK_MISSING_FILES,
+                    f"{op} 에 files 가 없다",
+                    task=tid,
+                    where=where,
+                    extra={"index": index, "op": op},
+                )
+            )
+        elif len(files) < 2:
+            issues.append(
+                issue(
+                    CODE_CHECK_FILES_SHORT,
+                    f"{op} 의 files 가 {len(files)}개다 (2개 필요)",
+                    task=tid,
+                    where=where,
+                    extra={"index": index, "op": op, "count": len(files)},
+                )
+            )
+        else:
+            for f_index, item in enumerate(files):
+                if not isinstance(item, str):
+                    issues.append(
+                        issue(
+                            CODE_CHECK_FILE_EMPTY,
+                            f"{op}.files[{f_index}] 가 문자열이 아니다",
+                            task=tid,
+                            where=where,
+                            extra={"index": index, "op": op},
+                        )
+                    )
+                    continue
+                issues.extend(
+                    scan_path_field(
+                        item,
+                        code_empty=CODE_CHECK_FILE_EMPTY,
+                        code_absolute=CODE_CHECK_FILE_ABSOLUTE,
+                        code_backslash=CODE_CHECK_FILE_BACKSLASH,
+                        label=f"check.files[{f_index}]",
+                        tid=tid,
+                        where=where,
+                        extra={"index": index, "op": op},
+                    )
+                )
+
+    if op in OPS_NEED_CELL_COORD:
+        missing = [key for key in ("table", "row", "col") if not is_nonneg_int(check.get(key))]
+        if missing:
+            issues.append(
+                issue(
+                    CODE_CELL_MISSING_COORD,
+                    f"cell_text_eq 에 좌표 {', '.join(missing)} 가 없거나 정수가 아니다",
+                    task=tid,
+                    where=where,
+                    extra={"index": index, "missing": missing},
+                )
+            )
+    if op in OPS_NEED_CSV_COORD:
+        missing = [key for key in ("row", "col") if not is_nonneg_int(check.get(key))]
+        if missing:
+            issues.append(
+                issue(
+                    CODE_CSV_MISSING_COORD,
+                    f"csv_cell_eq 에 좌표 {', '.join(missing)} 가 없거나 정수가 아니다",
+                    task=tid,
+                    where=where,
+                    extra={"index": index, "missing": missing},
+                )
+            )
+
+    cmd = check.get("cmd")
+    if op in cli_ops:
+        if "cmd" not in check or cmd is None:
+            issues.append(
+                issue(
+                    CODE_CHECK_MISSING_CMD,
+                    f"CLI 연산자 {op} 에 cmd 가 없다",
+                    task=tid,
+                    where=where,
+                    extra={"index": index, "op": op},
+                )
+            )
+        elif not isinstance(cmd, list):
+            issues.append(
+                issue(
+                    CODE_CHECK_CMD_TYPE,
+                    f"{op}.cmd 가 배열이 아니다 ({type(cmd).__name__})",
+                    task=tid,
+                    where=where,
+                    extra={"index": index, "op": op},
+                )
+            )
+        elif not cmd:
+            issues.append(
+                issue(
+                    CODE_CHECK_CMD_EMPTY,
+                    f"{op}.cmd 가 비었다",
+                    task=tid,
+                    where=where,
+                    extra={"index": index, "op": op},
+                )
+            )
+        else:
+            for c_index, item in enumerate(cmd):
+                if not isinstance(item, str) or not item.strip():
+                    issues.append(
+                        issue(
+                            CODE_CHECK_CMD_ITEM_TYPE,
+                            f"{op}.cmd[{c_index}] 가 빈 값이거나 문자열이 아니다",
+                            task=tid,
+                            where=where,
+                            extra={"index": index, "op": op, "cmdIndex": c_index},
+                        )
+                    )
+                    break
+    elif op in file_ops and cmd:
+        issues.append(
+            issue(
+                CODE_CHECK_UNEXPECTED_CMD,
+                f"파일 연산자 {op} 는 CLI 를 부르지 않는데 cmd 가 있다",
+                task=tid,
+                where=where,
+                extra={"index": index, "op": op},
+            )
+        )
     return issues
 
 
@@ -584,6 +1419,91 @@ def scan_submit(task: dict, where: str, tid: str | None) -> list[dict]:
                     severity=SEVERITY_WARNING,
                 )
             )
+    if "files" in submit:
+        issues.extend(scan_submit_files(files, where, tid))
+    return issues
+
+
+def scan_submit_files(files, where: str, tid: str | None) -> list[dict]:
+    issues: list[dict] = []
+    if not isinstance(files, list):
+        issues.append(
+            issue(
+                CODE_SUBMIT_FILES_TYPE,
+                f"submit.files 가 배열이 아니다 ({type(files).__name__})",
+                task=tid,
+                where=where,
+            )
+        )
+        return issues
+    seen: dict[str, int] = {}
+    for index, item in enumerate(files):
+        prefix = f"{where}#submit.files[{index}]"
+        if not isinstance(item, str):
+            issues.append(
+                issue(
+                    CODE_SUBMIT_FILE_TYPE,
+                    f"submit.files[{index}] 가 문자열이 아니다",
+                    task=tid,
+                    where=prefix,
+                    extra={"index": index},
+                )
+            )
+            continue
+        if not item.strip():
+            issues.append(
+                issue(
+                    CODE_SUBMIT_FILE_EMPTY,
+                    f"submit.files[{index}] 가 비었다",
+                    task=tid,
+                    where=prefix,
+                    extra={"index": index},
+                )
+            )
+            continue
+        if has_edge_whitespace(item):
+            issues.append(
+                issue(
+                    CODE_SUBMIT_FILE_WHITESPACE,
+                    f"submit.files[{index}] 앞뒤에 공백이 있다: {item!r}",
+                    task=tid,
+                    where=prefix,
+                    extra={"index": index},
+                )
+            )
+        if is_absolute_path(item):
+            issues.append(
+                issue(
+                    CODE_SUBMIT_FILE_ABSOLUTE,
+                    f"submit.files[{index}] 가 절대 경로다: {item}",
+                    task=tid,
+                    where=prefix,
+                    extra={"index": index},
+                )
+            )
+        if has_backslash(item):
+            issues.append(
+                issue(
+                    CODE_SUBMIT_FILE_BACKSLASH,
+                    f"submit.files[{index}] 에 백슬래시가 있다",
+                    task=tid,
+                    where=prefix,
+                    extra={"index": index},
+                )
+            )
+        key = item.strip()
+        if key in seen:
+            issues.append(
+                issue(
+                    CODE_SUBMIT_FILE_DUPLICATE,
+                    f"submit.files 에 {key!r} 가 중복이다",
+                    task=tid,
+                    where=where,
+                    extra={"file": key},
+                )
+            )
+        else:
+            seen[key] = index
     return issues
 
 
@@ -592,7 +1512,7 @@ def _steps_are_vacuous(steps: list) -> bool:
         return True
     for step in steps:
         if not isinstance(step, dict):
-            continue
+            return False
         if not step:
             continue
         if any(value not in (None, "", [], {}) for value in step.values()):
@@ -661,7 +1581,86 @@ def scan_reference(ref_path: str, filename: str, tid: str | None) -> list[dict]:
                 where=where,
             )
         ]
-    return []
+    issues: list[dict] = []
+    ref_id = doc.get("id")
+    if isinstance(tid, str) and tid.strip() and ref_id is not None and ref_id != tid:
+        issues.append(
+            issue(
+                CODE_REFERENCE_ID_MISMATCH,
+                f"reference.id({ref_id!r}) 가 과제 id({tid!r}) 와 다르다",
+                task=tid,
+                where=where,
+                extra={"referenceId": ref_id},
+            )
+        )
+    issues.extend(scan_reference_steps(steps, where, tid))
+    return issues
+
+
+def scan_reference_steps(steps: list, where: str, tid: str | None) -> list[dict]:
+    issues: list[dict] = []
+    for index, step in enumerate(steps):
+        prefix = f"{where}#steps[{index}]"
+        if not isinstance(step, dict):
+            issues.append(
+                issue(
+                    CODE_REFERENCE_STEP_TYPE,
+                    f"steps[{index}] 가 객체가 아니다",
+                    task=tid,
+                    where=prefix,
+                    extra={"index": index},
+                )
+            )
+            continue
+        if "run" in step:
+            run = step.get("run")
+            empty_run = run in (None, "", [], {})
+            if isinstance(run, list) and not any(
+                isinstance(item, str) and item.strip() for item in run
+            ):
+                empty_run = True
+            if isinstance(run, str) and not run.strip():
+                empty_run = True
+            if empty_run:
+                issues.append(
+                    issue(
+                        CODE_REFERENCE_RUN_EMPTY,
+                        f"steps[{index}].run 이 비었다",
+                        task=tid,
+                        where=prefix,
+                        extra={"index": index},
+                    )
+                )
+        if "answer" in step:
+            answer = step.get("answer")
+            if not isinstance(answer, dict) or not answer:
+                issues.append(
+                    issue(
+                        CODE_REFERENCE_ANSWER_EMPTY,
+                        f"steps[{index}].answer 가 비었다",
+                        task=tid,
+                        where=prefix,
+                        extra={"index": index},
+                    )
+                )
+                continue
+            for key, spec in answer.items():
+                if not isinstance(spec, dict):
+                    continue
+                if "cmd" not in spec:
+                    continue
+                cmd = spec.get("cmd")
+                if not isinstance(cmd, list) or not cmd:
+                    issues.append(
+                        issue(
+                            CODE_REFERENCE_CMD_EMPTY,
+                            f"steps[{index}].answer.{key}.cmd 가 비었다",
+                            task=tid,
+                            where=prefix,
+                            extra={"index": index, "key": key},
+                        )
+                    )
+    return issues
 
 
 def scan_hint(task: dict, where: str, tid: str | None) -> list[dict]:
@@ -728,13 +1727,17 @@ def scan_task(
     filename: str,
     ref_path: str | None,
     min_chars: int,
+    pack_axis: str | None = None,
+    min_title: int = MIN_TITLE_CHARS,
 ) -> list[dict]:
     where = f"tasks/{filename}"
     tid = task.get("id") if isinstance(task.get("id"), str) else None
     issues: list[dict] = []
-    issues.extend(scan_identity(task, filename, where))
+    issues.extend(scan_identity(task, filename, where, min_title=min_title))
+    issues.extend(scan_tier(task, where, tid))
+    issues.extend(scan_input(task, where, tid))
     issues.extend(scan_instructions(task, where, tid, min_chars))
-    issues.extend(scan_checks(task, where, tid))
+    issues.extend(scan_checks(task, where, tid, pack_axis=pack_axis))
     issues.extend(scan_submit(task, where, tid))
     issues.extend(scan_hint(task, where, tid))
     if ref_path:
@@ -742,10 +1745,121 @@ def scan_task(
     return issues
 
 
+def scan_manifest(manifest: dict, pack_id: str, pack_dir: str) -> list[dict]:
+    """pack.json 신원 — audit/schema 와 같은 최소 계약, 이 봉투 코드로."""
+    issues: list[dict] = []
+    where = "pack.json"
+    kind = manifest.get("kind")
+    if kind != PACK_KIND:
+        issues.append(
+            issue(
+                CODE_PACK_KIND,
+                f"kind 가 {PACK_KIND} 가 아니다: {kind!r}",
+                where=where,
+                extra={"kind": kind},
+            )
+        )
+    version = manifest.get("schemaVersion")
+    if version != PACK_SCHEMA_VERSION:
+        issues.append(
+            issue(
+                CODE_PACK_SCHEMA_VERSION,
+                f"schemaVersion 이 {PACK_SCHEMA_VERSION} 이 아니다: {version!r}",
+                where=where,
+                extra={"schemaVersion": version},
+            )
+        )
+    declared = manifest.get("id")
+    folder = os.path.basename(os.path.normpath(pack_dir))
+    if declared != pack_id or declared != folder:
+        issues.append(
+            issue(
+                CODE_PACK_ID_MISMATCH,
+                f"pack.id({declared!r}) 가 폴더({folder}) 와 다르다",
+                where=where,
+                extra={"id": declared, "folder": folder},
+            )
+        )
+    title = manifest.get("title")
+    if not isinstance(title, str) or not title.strip():
+        issues.append(issue(CODE_PACK_EMPTY_TITLE, "pack.title 이 비었다", where=where))
+    elif has_edge_whitespace(title):
+        issues.append(
+            issue(
+                CODE_PACK_TITLE_WHITESPACE,
+                f"pack.title 앞뒤에 공백이 있다: {title!r}",
+                where=where,
+            )
+        )
+    axis = manifest.get("axis")
+    if not isinstance(axis, str) or not axis.strip():
+        issues.append(issue(CODE_PACK_EMPTY_AXIS, "pack.axis 가 비었다", where=where))
+    elif has_edge_whitespace(axis):
+        issues.append(
+            issue(
+                CODE_PACK_AXIS_WHITESPACE,
+                f"pack.axis 앞뒤에 공백이 있다: {axis!r}",
+                where=where,
+            )
+        )
+    requires = manifest.get("requires")
+    commands = requires.get("commands") if isinstance(requires, dict) else None
+    if not isinstance(requires, dict) or "commands" not in requires:
+        issues.append(
+            issue(CODE_PACK_MISSING_REQUIRES, "requires.commands 가 없다", where=where)
+        )
+    elif not isinstance(commands, list) or not commands:
+        issues.append(
+            issue(CODE_PACK_EMPTY_COMMANDS, "requires.commands 가 비었다", where=where)
+        )
+    elif any(not isinstance(item, str) or not item.strip() for item in commands):
+        issues.append(
+            issue(
+                CODE_PACK_COMMAND_TYPE,
+                "requires.commands 항목이 빈 값이거나 문자열이 아니다",
+                where=where,
+            )
+        )
+    runner = manifest.get("runner")
+    if not isinstance(runner, dict) or not runner:
+        issues.append(issue(CODE_PACK_MISSING_RUNNER, "runner 가 없다", where=where))
+    else:
+        missing = [key for key in RUNNER_KEYS if not runner.get(key)]
+        if missing:
+            issues.append(
+                issue(
+                    CODE_PACK_MISSING_RUNNER_FIELD,
+                    f"runner 필드가 비었다: {', '.join(missing)}",
+                    where=where,
+                    extra={"missing": missing},
+                )
+            )
+    return issues
+
+
+def scan_orphan_references(tasks_dir: str, ref_dir: str) -> list[dict]:
+    """짝 과제가 없는 reference/*.json — audit 과 같은 계약, 코드만 이 봉투."""
+    if not os.path.isdir(ref_dir):
+        return []
+    task_names = set(list_json_names(tasks_dir)) if os.path.isdir(tasks_dir) else set()
+    issues: list[dict] = []
+    for name in list_json_names(ref_dir):
+        if name not in task_names:
+            issues.append(
+                issue(
+                    CODE_ORPHAN_REFERENCE,
+                    f"고아 기준풀이 reference/{name} — 짝 과제(tasks/{name})가 없다",
+                    where=f"reference/{name}",
+                )
+            )
+    return issues
+
+
 def scan_pack(
     pack_id: str,
     pack_dir: str,
     min_chars: int = MIN_INSTRUCTION_CHARS,
+    min_title: int = MIN_TITLE_CHARS,
 ) -> dict:
     """pack 하나. 반환: {id, taskCount, issueCount, issues}."""
     issues: list[dict] = []
@@ -756,12 +1870,23 @@ def scan_pack(
         )
         return _pack_report(pack_id, 0, issues)
 
-    _manifest, err = _load_json(manifest_path)
+    manifest, err = _load_json(manifest_path)
     if err:
         issues.append(
             issue(CODE_PARSE_ERROR, f"pack.json {err}", where="pack.json")
         )
         return _pack_report(pack_id, 0, issues)
+    if not isinstance(manifest, dict):
+        issues.append(
+            issue(
+                CODE_PACK_TYPE,
+                f"pack.json 이 객체가 아니다 ({type(manifest).__name__})",
+                where="pack.json",
+            )
+        )
+        return _pack_report(pack_id, 0, issues)
+    issues.extend(scan_manifest(manifest, pack_id, pack_dir))
+    pack_axis = manifest.get("axis") if isinstance(manifest.get("axis"), str) else None
 
     tasks_dir = os.path.join(pack_dir, "tasks")
     ref_dir = os.path.join(pack_dir, "reference")
@@ -772,6 +1897,15 @@ def scan_pack(
         return _pack_report(pack_id, 0, issues)
 
     task_files = list_json_names(tasks_dir)
+    if not task_files:
+        issues.append(
+            issue(
+                CODE_EMPTY_PACK,
+                "tasks/ 에 과제가 없다",
+                where="tasks",
+                severity=SEVERITY_WARNING,
+            )
+        )
     id_owners: dict[str, list[str]] = {}
     task_count = 0
     for name in task_files:
@@ -802,8 +1936,18 @@ def scan_pack(
         ref_path = os.path.join(ref_dir, name)
         if not os.path.isfile(ref_path):
             ref_path = None
-        issues.extend(scan_task(task, name, ref_path, min_chars))
+        issues.extend(
+            scan_task(
+                task,
+                name,
+                ref_path,
+                min_chars,
+                pack_axis=pack_axis,
+                min_title=min_title,
+            )
+        )
 
+    issues.extend(scan_orphan_references(tasks_dir, ref_dir))
     for tid, owners in sorted(id_owners.items()):
         if len(owners) > 1:
             issues.append(
@@ -835,10 +1979,20 @@ def _pack_report(pack_id: str, task_count: int, issues: list[dict]) -> dict:
     }
 
 
+def _filter_pack_issues(pack: dict, exclude: set[str]) -> dict:
+    kept = [item for item in pack.get("issues") or [] if item.get("code") not in exclude]
+    clone = dict(pack)
+    clone["issues"] = kept
+    clone["issueCount"] = len(kept)
+    return clone
+
+
 def audit(
     packs_root: str,
     pack_ids: list[str] | None = None,
     min_chars: int = MIN_INSTRUCTION_CHARS,
+    min_title: int = MIN_TITLE_CHARS,
+    exclude_codes: list[str] | None = None,
 ) -> dict:
     """전 pack(또는 지정 pack) 건강 감사. 순수 파일 검사.
 
@@ -869,7 +2023,18 @@ def audit(
                         )
                     )
         for pack_id, pack_dir in found:
-            pack_rows.append(scan_pack(pack_id, pack_dir, min_chars=min_chars))
+            pack_rows.append(
+                scan_pack(
+                    pack_id,
+                    pack_dir,
+                    min_chars=min_chars,
+                    min_title=min_title,
+                )
+            )
+
+    exclude = set(exclude_codes or [])
+    if exclude:
+        pack_rows = [_filter_pack_issues(pack, exclude) for pack in pack_rows]
 
     pack_rows.sort(key=lambda row: row["id"])
     all_issues = [item for pack in pack_rows for item in pack["issues"]]
@@ -894,6 +2059,8 @@ def audit(
     }
     if scan_error:
         report["scanError"] = scan_error
+    if exclude:
+        report["excludedCodes"] = sorted(exclude)
     return report
 
 
@@ -906,12 +2073,22 @@ def render_report(report: dict) -> str:
         return head
     if report.get("ok"):
         return f"gym pack 건강: {pack_n} pack · {task_n} 과제 — 이슈 0"
-    lines = [f"gym pack 건강: {pack_n} pack · {task_n} 과제 · 이슈 {issue_n}건"]
+    err_n = report.get("errorCount", 0)
+    warn_n = report.get("warningCount", 0)
+    lines = [
+        f"gym pack 건강: {pack_n} pack · {task_n} 과제 · 이슈 {issue_n}건 "
+        f"(error {err_n} · warning {warn_n})"
+    ]
     for pack in report.get("packs") or []:
         for item in pack.get("issues") or []:
             task = item.get("task")
             loc = f"{pack['id']}/{task}" if task else pack["id"]
-            lines.append(f"  [{loc}] {item.get('code')}: {item.get('message')}")
+            sev = item.get("severity") or SEVERITY_ERROR
+            lines.append(f"  [{loc}] {item.get('code')}: {item.get('message')} ({sev})")
+    codes = report.get("codes") or {}
+    if codes:
+        joined = ", ".join(f"{code}={count}" for code, count in codes.items())
+        lines.append(f"  코드 집계: {joined}")
     return "\n".join(lines)
 
 
@@ -953,16 +2130,49 @@ def build_parser() -> argparse.ArgumentParser:
         dest="min_instructions",
         help=f"instructions 최소 글자(기본 {MIN_INSTRUCTION_CHARS})",
     )
+    ap.add_argument(
+        "--min-title",
+        type=int,
+        default=MIN_TITLE_CHARS,
+        dest="min_title",
+        help=f"과제 title 최소 글자(기본 {MIN_TITLE_CHARS})",
+    )
+    ap.add_argument(
+        "--codes",
+        action="store_true",
+        dest="list_codes",
+        help="이슈 코드 목록만 출력하고 종료한다",
+    )
+    ap.add_argument(
+        "--exclude",
+        action="append",
+        default=None,
+        dest="exclude_codes",
+        help="집계에서 뺄 이슈 코드 (여러 번 지정 가능)",
+    )
     return ap
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    if args.list_codes:
+        sys.stdout.write(render_codes() + "\n")
+        return 0
     min_chars = args.min_instructions
     if min_chars < 1:
         sys.stderr.write("--min-instructions 는 1 이상이어야 한다\n")
         return 2
-    report = audit(args.root, pack_ids=args.packs, min_chars=min_chars)
+    min_title = args.min_title
+    if min_title < 1:
+        sys.stderr.write("--min-title 은 1 이상이어야 한다\n")
+        return 2
+    report = audit(
+        args.root,
+        pack_ids=args.packs,
+        min_chars=min_chars,
+        min_title=min_title,
+        exclude_codes=args.exclude_codes,
+    )
     if args.json:
         sys.stdout.write(json.dumps(report, ensure_ascii=False, indent=2) + "\n")
     else:

--- a/gym/tools/pack_health.py
+++ b/gym/tools/pack_health.py
@@ -1,0 +1,979 @@
+"""gym pack 건강 감사 — 지시문·검사 이름·힌트·제출 형식의 품질 게이트.
+
+## 왜 이 도구인가 (audit 가 못 보는 층)
+
+`audit.py` 는 스키마·기준풀이 짝·과제 ID 전역 고유만 본다. 지시문이 비거나 한
+줄짜리이고, 같은 과제 안에서 `check.name` 이 비거나 겹치고, 힌트가 답을 그대로
+적어 두고, `submit.kind` 가 모르는 값이어도 그 감사는 통과한다. 운동장 품질이
+조용히 내려간다.
+
+이 도구는 그 다음 층이다. 바이너리·네트워크 없이 pack JSON 만 읽어:
+
+- 빈/짧은 `instructions` (기본 20글자 미만)
+- 과제 안 `check.name` 누락·중복
+- 과제 `id`/`title` 의 앞뒤·내부 공백
+- 기준풀이 파일은 있는데 `steps` 가 비었다
+- 모르는 `submit.kind`
+- 힌트가 답을 직접 노출하는지 (정답 JSON 덤프, `답은 N`, 검사 기대값 복붙)
+
+을 pack 별로 보고한다. 기존 pack 을 고치지 않는다 — 도구만 추가한다.
+
+## 종료 코드 (CI 자기시험과 게이트를 가른다)
+
+현재 트리가 깨끗하지 않을 수 있고, 도구 자체를 CI 에서 돌릴 때는 리포트만
+필요할 수 있다. 그래서:
+
+    python gym/tools/pack_health.py            # 리포트, 이슈가 있어도 0
+    python gym/tools/pack_health.py --json     # 같은 리포트 JSON, 기본 0
+    python gym/tools/pack_health.py --strict   # 이슈가 있으면 1
+    python gym/tools/pack_health.py --pack id  # 한 pack 만
+    python gym/tools/pack_health.py --root DIR # gym/ 루트 (packs/ 를 담은 곳)
+
+`--strict` 는 품질 관문이다. 기본은 관측이다.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GYM_ROOT = os.path.dirname(HERE)
+
+KIND = "gymPackHealth"
+SCHEMA_VERSION = "1.0"
+
+# gym/README.md 「제출 형식」이 선언한 세 값. 새 kind 는 채점기가 모르면 제출이 증발한다.
+KNOWN_SUBMIT_KINDS = frozenset({"answer", "artifact", "pair"})
+MIN_INSTRUCTION_CHARS = 20
+MIN_HINT_VALUE_CHARS = 4
+
+CODE_EMPTY_INSTRUCTIONS = "empty_instructions"
+CODE_SHORT_INSTRUCTIONS = "short_instructions"
+CODE_INSTRUCTIONS_TYPE = "instructions_type"
+CODE_MISSING_CHECK_NAME = "missing_check_name"
+CODE_EMPTY_CHECK_NAME = "empty_check_name"
+CODE_DUPLICATE_CHECK_NAME = "duplicate_check_name"
+CODE_TASK_ID_WHITESPACE = "task_id_whitespace"
+CODE_TASK_TITLE_WHITESPACE = "task_title_whitespace"
+CODE_EMPTY_TASK_ID = "empty_task_id"
+CODE_EMPTY_TITLE = "empty_title"
+CODE_ID_FILENAME_MISMATCH = "id_filename_mismatch"
+CODE_DUPLICATE_TASK_ID = "duplicate_task_id"
+CODE_EMPTY_REFERENCE_STEPS = "empty_reference_steps"
+CODE_REFERENCE_STEPS_TYPE = "reference_steps_type"
+CODE_UNKNOWN_SUBMIT_KIND = "unknown_submit_kind"
+CODE_MISSING_SUBMIT = "missing_submit"
+CODE_MISSING_SUBMIT_KIND = "missing_submit_kind"
+CODE_SUBMIT_TYPE = "submit_type"
+CODE_ARTIFACT_WITHOUT_FILES = "artifact_without_files"
+CODE_PAIR_WITHOUT_FILES = "pair_without_files"
+CODE_HINT_ANSWER_DUMP = "hint_answer_dump"
+CODE_HINT_SPOILER = "hint_spoiler"
+CODE_HINT_EMBEDS_VALUE = "hint_embeds_check_value"
+CODE_CHECKS_TYPE = "checks_type"
+CODE_EMPTY_CHECKS = "empty_checks"
+CODE_CHECK_TYPE = "check_type"
+CODE_PARSE_ERROR = "parse_error"
+CODE_MISSING_PACK = "missing_pack_json"
+CODE_MISSING_TASKS = "missing_tasks_dir"
+
+SEVERITY_ERROR = "error"
+SEVERITY_WARNING = "warning"
+
+HINT_MARKERS = ("힌트:", "힌트 :", "Hint:", "hint:")
+SPOILER_RE = re.compile(
+    r"(?:정답(?:은|이)?|답은|answer\s*(?:is|:))\s+.+\S",
+    re.IGNORECASE,
+)
+BARE_ANSWER_RE = re.compile(r"^\s*(?:정답|답)?\s*[=:]?\s*-?\d+(?:\.\d+)?\s*$")
+PLACEHOLDER_RE = re.compile(r"[<{\[][^>}\]]+[>}\]]")
+
+# 너무 흔한 짧은 토큰은 힌트 복붙으로 치지 않는다(명령 이름·불린·한 글자).
+COMMON_HINT_TOKENS = frozenset(
+    {
+        "ok",
+        "true",
+        "false",
+        "allow",
+        "deny",
+        "info",
+        "json",
+        "hwp",
+        "hwpx",
+        "hwp3",
+        "hml",
+        "pdf",
+        "html",
+        "out",
+        "ws",
+        "in",
+        "to",
+        "on",
+        "id",
+    }
+)
+
+
+def issue(
+    code: str,
+    message: str,
+    *,
+    task: str | None = None,
+    where: str = "",
+    severity: str = SEVERITY_ERROR,
+    extra: dict | None = None,
+) -> dict:
+    """한 이슈 — 리포트·시험이 같은 키를 본다."""
+    row = {
+        "code": code,
+        "severity": severity,
+        "task": task,
+        "where": where,
+        "message": message,
+    }
+    if extra:
+        row.update(extra)
+    return row
+
+
+def _load_json(path: str):
+    """(doc, error). 성공이면 error 는 None."""
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh), None
+    except FileNotFoundError as exc:
+        return None, f"파일 없음: {exc}"
+    except (ValueError, OSError) as exc:
+        return None, f"파싱 실패: {exc}"
+
+
+def has_edge_whitespace(text: str) -> bool:
+    return text != text.strip()
+
+
+def has_any_whitespace(text: str) -> bool:
+    return any(ch.isspace() for ch in text)
+
+
+def instruction_length(text: str) -> int:
+    """앞뒤 공백을 뺀 글자 수. 한글도 코드포인트 1글자."""
+    return len(text.strip())
+
+
+def split_hint(instructions: str) -> tuple[str, str | None]:
+    """본문과 힌트 꼬리를 가른다. 마커가 없으면 힌트는 None."""
+    if not isinstance(instructions, str):
+        return "", None
+    found_at = -1
+    found_marker = ""
+    for marker in HINT_MARKERS:
+        idx = instructions.find(marker)
+        if idx >= 0 and (found_at < 0 or idx < found_at):
+            found_at = idx
+            found_marker = marker
+    if found_at < 0:
+        return instructions, None
+    body = instructions[:found_at]
+    hint = instructions[found_at + len(found_marker) :]
+    return body, hint
+
+
+def extract_json_fragments(text: str) -> list[object]:
+    """본문에서 `{…}` / `[…]` JSON 조각을 최대한 건진다. 깨진 중괄호는 건너뛴다."""
+    if not text:
+        return []
+    found: list[object] = []
+    n = len(text)
+    i = 0
+    while i < n:
+        if text[i] not in "{[":
+            i += 1
+            continue
+        opener = text[i]
+        closer = "}" if opener == "{" else "]"
+        depth = 0
+        in_str = False
+        escape = False
+        j = i
+        while j < n:
+            ch = text[j]
+            if in_str:
+                if escape:
+                    escape = False
+                elif ch == "\\":
+                    escape = True
+                elif ch == '"':
+                    in_str = False
+            else:
+                if ch == '"':
+                    in_str = True
+                elif ch == opener:
+                    depth += 1
+                elif ch == closer:
+                    depth -= 1
+                    if depth == 0:
+                        blob = text[i : j + 1]
+                        try:
+                            found.append(json.loads(blob))
+                        except ValueError:
+                            pass
+                        i = j + 1
+                        break
+            j += 1
+        else:
+            i += 1
+    return found
+
+
+def is_placeholder_value(value) -> bool:
+    """`<수>`, `{input}` 처럼 자리를 비워 둔 값은 정답 노출이 아니다."""
+    if not isinstance(value, str):
+        return False
+    stripped = value.strip()
+    if not stripped:
+        return False
+    if PLACEHOLDER_RE.fullmatch(stripped):
+        return True
+    if stripped.startswith("<") and stripped.endswith(">"):
+        return True
+    return False
+
+
+def fragment_looks_like_answer(obj) -> bool:
+    """구체 스칼라만 가진 작은 객체/배열이면 정답 덤프로 본다.
+
+    키가 `<필드이름>` 처럼 자리표이면 CLI 문법 예시이지 정답 봉투가 아니다.
+    """
+    if isinstance(obj, dict):
+        if not obj or len(obj) > 8:
+            return False
+        if any(is_placeholder_value(str(key)) or PLACEHOLDER_RE.search(str(key)) for key in obj):
+            return False
+        scalars = 0
+        for value in obj.values():
+            if isinstance(value, (dict, list)):
+                return False
+            if is_placeholder_value(value):
+                continue
+            if isinstance(value, str) and not value.strip():
+                continue
+            if isinstance(value, str) and PLACEHOLDER_RE.search(value):
+                continue
+            scalars += 1
+        return scalars >= 1
+    if isinstance(obj, list):
+        if not obj or len(obj) > 12:
+            return False
+        if all(is_placeholder_value(v) or v in ("...", "…") for v in obj):
+            return False
+        return all(isinstance(v, (str, int, float, bool)) or v is None for v in obj)
+    return False
+
+
+def token_appears_bare(text: str, token: str) -> bool:
+    """토큰이 파일명·명령 일부(`export-hwpx`, `conv.hwpx`)가 아니라 단독으로 있나."""
+    if not text or not token:
+        return False
+    if token.isascii() and any(ch.isalnum() for ch in token):
+        pattern = r"(?<![A-Za-z0-9_.-])" + re.escape(token) + r"(?![A-Za-z0-9_.-])"
+        return re.search(pattern, text) is not None
+    return token in text
+
+
+def check_expected_literals(check: dict) -> list[str]:
+    """채점이 기대하는 구체 값 — 힌트에 그대로 있으면 답을 준 것이다."""
+    out: list[str] = []
+    for key in ("value", "expected"):
+        raw = check.get(key)
+        if isinstance(raw, bool):
+            continue
+        if isinstance(raw, (int, float)):
+            # 0/1 은 쪽수·건수 힌트에 흔해 spoiler 로 치지 않는다.
+            if isinstance(raw, int) and raw in (0, 1, -1):
+                continue
+            out.append(str(raw))
+        elif isinstance(raw, str):
+            token = raw.strip()
+            if len(token) >= MIN_HINT_VALUE_CHARS and token.lower() not in COMMON_HINT_TOKENS:
+                out.append(token)
+    return out
+
+
+def iter_pack_dirs(packs_root: str, pack_ids: list[str] | None = None) -> list[tuple[str, str]]:
+    """(pack_id, pack_dir). packs_root 는 gym/ (packs/ 를 담은 곳)."""
+    packs_dir = os.path.join(packs_root, "packs")
+    if not os.path.isdir(packs_dir):
+        return []
+    names = sorted(os.listdir(packs_dir))
+    wanted = set(pack_ids) if pack_ids else None
+    rows = []
+    for name in names:
+        if wanted is not None and name not in wanted:
+            continue
+        path = os.path.join(packs_dir, name)
+        if os.path.isdir(path):
+            rows.append((name, path))
+    return rows
+
+
+def list_json_names(directory: str) -> list[str]:
+    if not os.path.isdir(directory):
+        return []
+    return sorted(name for name in os.listdir(directory) if name.endswith(".json"))
+
+
+def scan_instructions(task: dict, where: str, tid: str | None, min_chars: int) -> list[dict]:
+    issues: list[dict] = []
+    if "instructions" not in task:
+        issues.append(
+            issue(
+                CODE_EMPTY_INSTRUCTIONS,
+                "instructions 키가 없다",
+                task=tid,
+                where=where,
+            )
+        )
+        return issues
+    text = task.get("instructions")
+    if not isinstance(text, str):
+        issues.append(
+            issue(
+                CODE_INSTRUCTIONS_TYPE,
+                f"instructions 가 문자열이 아니다 ({type(text).__name__})",
+                task=tid,
+                where=where,
+            )
+        )
+        return issues
+    length = instruction_length(text)
+    if length == 0:
+        issues.append(
+            issue(
+                CODE_EMPTY_INSTRUCTIONS,
+                "instructions 가 비었다",
+                task=tid,
+                where=where,
+            )
+        )
+    elif length < min_chars:
+        issues.append(
+            issue(
+                CODE_SHORT_INSTRUCTIONS,
+                f"instructions 가 {length}글자(< {min_chars})다",
+                task=tid,
+                where=where,
+                extra={"length": length, "min": min_chars},
+            )
+        )
+    return issues
+
+
+def scan_identity(task: dict, filename: str, where: str) -> list[dict]:
+    """id/title 공백·공란·파일명 불일치."""
+    issues: list[dict] = []
+    tid = task.get("id")
+    title = task.get("title")
+    shown = tid if isinstance(tid, str) and tid.strip() else None
+
+    if not isinstance(tid, str) or not tid.strip():
+        issues.append(
+            issue(CODE_EMPTY_TASK_ID, "과제 id 가 비었다", task=shown, where=where)
+        )
+    elif has_edge_whitespace(tid) or has_any_whitespace(tid):
+        issues.append(
+            issue(
+                CODE_TASK_ID_WHITESPACE,
+                f"과제 id 에 공백이 있다: {tid!r}",
+                task=tid.strip() or shown,
+                where=where,
+            )
+        )
+    elif filename.endswith(".json"):
+        stem = filename[: -len(".json")]
+        if stem != tid:
+            issues.append(
+                issue(
+                    CODE_ID_FILENAME_MISMATCH,
+                    f"파일명({stem}) 과 과제 id({tid}) 가 다르다",
+                    task=tid,
+                    where=where,
+                )
+            )
+
+    if not isinstance(title, str) or not title.strip():
+        issues.append(
+            issue(CODE_EMPTY_TITLE, "과제 title 이 비었다", task=shown, where=where)
+        )
+    elif has_edge_whitespace(title):
+        issues.append(
+            issue(
+                CODE_TASK_TITLE_WHITESPACE,
+                f"과제 title 앞뒤에 공백이 있다: {title!r}",
+                task=shown,
+                where=where,
+            )
+        )
+    return issues
+
+
+def scan_checks(task: dict, where: str, tid: str | None) -> list[dict]:
+    issues: list[dict] = []
+    checks = task.get("checks")
+    if checks is None:
+        issues.append(
+            issue(CODE_EMPTY_CHECKS, "checks 가 없다", task=tid, where=where)
+        )
+        return issues
+    if not isinstance(checks, list):
+        issues.append(
+            issue(
+                CODE_CHECKS_TYPE,
+                f"checks 가 배열이 아니다 ({type(checks).__name__})",
+                task=tid,
+                where=where,
+            )
+        )
+        return issues
+    if not checks:
+        issues.append(
+            issue(CODE_EMPTY_CHECKS, "checks 가 비었다", task=tid, where=where)
+        )
+        return issues
+
+    names: list[str] = []
+    for index, check in enumerate(checks):
+        prefix = f"{where}#checks[{index}]"
+        if not isinstance(check, dict):
+            issues.append(
+                issue(
+                    CODE_CHECK_TYPE,
+                    f"checks[{index}] 가 객체가 아니다",
+                    task=tid,
+                    where=prefix,
+                )
+            )
+            continue
+        if "name" not in check or check.get("name") is None:
+            issues.append(
+                issue(
+                    CODE_MISSING_CHECK_NAME,
+                    f"checks[{index}] 에 name 이 없다",
+                    task=tid,
+                    where=prefix,
+                    extra={"index": index},
+                )
+            )
+            continue
+        raw_name = check.get("name")
+        if not isinstance(raw_name, str):
+            issues.append(
+                issue(
+                    CODE_MISSING_CHECK_NAME,
+                    f"checks[{index}].name 이 문자열이 아니다 ({type(raw_name).__name__})",
+                    task=tid,
+                    where=prefix,
+                    extra={"index": index},
+                )
+            )
+            continue
+        if not raw_name.strip():
+            issues.append(
+                issue(
+                    CODE_EMPTY_CHECK_NAME,
+                    f"checks[{index}].name 이 비었다",
+                    task=tid,
+                    where=prefix,
+                    extra={"index": index},
+                )
+            )
+            continue
+        names.append(raw_name)
+
+    counts = Counter(names)
+    for name, count in counts.items():
+        if count > 1:
+            issues.append(
+                issue(
+                    CODE_DUPLICATE_CHECK_NAME,
+                    f"check.name {name!r} 이 이 과제에서 {count}번 나온다",
+                    task=tid,
+                    where=where,
+                    extra={"name": name, "count": count},
+                )
+            )
+    return issues
+
+
+def scan_submit(task: dict, where: str, tid: str | None) -> list[dict]:
+    issues: list[dict] = []
+    if "submit" not in task:
+        issues.append(
+            issue(CODE_MISSING_SUBMIT, "submit 이 없다", task=tid, where=where)
+        )
+        return issues
+    submit = task.get("submit")
+    if not isinstance(submit, dict):
+        issues.append(
+            issue(
+                CODE_SUBMIT_TYPE,
+                f"submit 이 객체가 아니다 ({type(submit).__name__})",
+                task=tid,
+                where=where,
+            )
+        )
+        return issues
+    if "kind" not in submit or submit.get("kind") is None:
+        issues.append(
+            issue(
+                CODE_MISSING_SUBMIT_KIND,
+                "submit.kind 가 없다",
+                task=tid,
+                where=where,
+            )
+        )
+        return issues
+    kind = submit.get("kind")
+    if not isinstance(kind, str) or not kind.strip():
+        issues.append(
+            issue(
+                CODE_UNKNOWN_SUBMIT_KIND,
+                f"submit.kind 가 비었다: {kind!r}",
+                task=tid,
+                where=where,
+                extra={"kind": kind},
+            )
+        )
+        return issues
+    if kind not in KNOWN_SUBMIT_KINDS:
+        issues.append(
+            issue(
+                CODE_UNKNOWN_SUBMIT_KIND,
+                f"submit.kind {kind!r} 는 모른다 (허용: {', '.join(sorted(KNOWN_SUBMIT_KINDS))})",
+                task=tid,
+                where=where,
+                extra={"kind": kind},
+            )
+        )
+        return issues
+
+    files = submit.get("files")
+    if kind == "artifact":
+        if not isinstance(files, list) or not files:
+            issues.append(
+                issue(
+                    CODE_ARTIFACT_WITHOUT_FILES,
+                    "submit.kind=artifact 인데 files 가 비었다",
+                    task=tid,
+                    where=where,
+                    severity=SEVERITY_WARNING,
+                )
+            )
+    elif kind == "pair":
+        if not isinstance(files, list) or len(files) < 2:
+            issues.append(
+                issue(
+                    CODE_PAIR_WITHOUT_FILES,
+                    "submit.kind=pair 인데 files 가 2개 미만이다",
+                    task=tid,
+                    where=where,
+                    severity=SEVERITY_WARNING,
+                )
+            )
+    return issues
+
+
+def _steps_are_vacuous(steps: list) -> bool:
+    if not steps:
+        return True
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        if not step:
+            continue
+        if any(value not in (None, "", [], {}) for value in step.values()):
+            return False
+    return True
+
+
+def scan_reference(ref_path: str, filename: str, tid: str | None) -> list[dict]:
+    """짝 기준풀이가 있을 때만 호출. 없으면 이 도구의 소관이 아니다(audit 몫)."""
+    where = f"reference/{filename}"
+    if not os.path.isfile(ref_path):
+        return []
+    doc, err = _load_json(ref_path)
+    if err:
+        return [
+            issue(
+                CODE_PARSE_ERROR,
+                f"reference/{filename} {err}",
+                task=tid,
+                where=where,
+            )
+        ]
+    if not isinstance(doc, dict):
+        return [
+            issue(
+                CODE_REFERENCE_STEPS_TYPE,
+                f"reference/{filename} 이 객체가 아니다",
+                task=tid,
+                where=where,
+            )
+        ]
+    if "steps" not in doc:
+        return [
+            issue(
+                CODE_EMPTY_REFERENCE_STEPS,
+                "reference 는 있는데 steps 키가 없다",
+                task=tid,
+                where=where,
+            )
+        ]
+    steps = doc.get("steps")
+    if steps is None:
+        return [
+            issue(
+                CODE_EMPTY_REFERENCE_STEPS,
+                "reference 는 있는데 steps 가 null 이다",
+                task=tid,
+                where=where,
+            )
+        ]
+    if not isinstance(steps, list):
+        return [
+            issue(
+                CODE_REFERENCE_STEPS_TYPE,
+                f"reference.steps 가 배열이 아니다 ({type(steps).__name__})",
+                task=tid,
+                where=where,
+            )
+        ]
+    if _steps_are_vacuous(steps):
+        return [
+            issue(
+                CODE_EMPTY_REFERENCE_STEPS,
+                "reference 는 있는데 steps 가 비었다",
+                task=tid,
+                where=where,
+            )
+        ]
+    return []
+
+
+def scan_hint(task: dict, where: str, tid: str | None) -> list[dict]:
+    """힌트가 답을 직접 적어 두면 과제가 측정하지 않는다."""
+    text = task.get("instructions")
+    if not isinstance(text, str) or not text.strip():
+        return []
+    body, hint = split_hint(text)
+    if hint is None:
+        return []
+    issues: list[dict] = []
+    stripped = hint.strip()
+    if not stripped:
+        return issues
+
+    if BARE_ANSWER_RE.match(stripped) or SPOILER_RE.search(stripped):
+        issues.append(
+            issue(
+                CODE_HINT_SPOILER,
+                "힌트가 정답을 직접 적고 있다",
+                task=tid,
+                where=where,
+                extra={"hint": stripped[:80]},
+            )
+        )
+
+    for fragment in extract_json_fragments(hint):
+        if fragment_looks_like_answer(fragment):
+            issues.append(
+                issue(
+                    CODE_HINT_ANSWER_DUMP,
+                    f"힌트에 정답 JSON 이 들어 있다: {json.dumps(fragment, ensure_ascii=False)[:80]}",
+                    task=tid,
+                    where=where,
+                )
+            )
+            break
+
+    literals: list[str] = []
+    for check in task.get("checks") or []:
+        if isinstance(check, dict):
+            literals.extend(check_expected_literals(check))
+    seen = set()
+    for token in literals:
+        if token in seen:
+            continue
+        seen.add(token)
+        # 본문이 이미 시킨 값(채울 문구)을 힌트 CLI 예시에 반복하는 것은 유출이 아니다.
+        if token_appears_bare(hint, token) and token not in body:
+            issues.append(
+                issue(
+                    CODE_HINT_EMBEDS_VALUE,
+                    f"힌트가 검사 기대값 {token!r} 을 그대로 담고 있다",
+                    task=tid,
+                    where=where,
+                    extra={"value": token},
+                )
+            )
+    return issues
+
+
+def scan_task(
+    task: dict,
+    filename: str,
+    ref_path: str | None,
+    min_chars: int,
+) -> list[dict]:
+    where = f"tasks/{filename}"
+    tid = task.get("id") if isinstance(task.get("id"), str) else None
+    issues: list[dict] = []
+    issues.extend(scan_identity(task, filename, where))
+    issues.extend(scan_instructions(task, where, tid, min_chars))
+    issues.extend(scan_checks(task, where, tid))
+    issues.extend(scan_submit(task, where, tid))
+    issues.extend(scan_hint(task, where, tid))
+    if ref_path:
+        issues.extend(scan_reference(ref_path, filename, tid))
+    return issues
+
+
+def scan_pack(
+    pack_id: str,
+    pack_dir: str,
+    min_chars: int = MIN_INSTRUCTION_CHARS,
+) -> dict:
+    """pack 하나. 반환: {id, taskCount, issueCount, issues}."""
+    issues: list[dict] = []
+    manifest_path = os.path.join(pack_dir, "pack.json")
+    if not os.path.isfile(manifest_path):
+        issues.append(
+            issue(CODE_MISSING_PACK, "pack.json 이 없다", where="pack.json")
+        )
+        return _pack_report(pack_id, 0, issues)
+
+    _manifest, err = _load_json(manifest_path)
+    if err:
+        issues.append(
+            issue(CODE_PARSE_ERROR, f"pack.json {err}", where="pack.json")
+        )
+        return _pack_report(pack_id, 0, issues)
+
+    tasks_dir = os.path.join(pack_dir, "tasks")
+    ref_dir = os.path.join(pack_dir, "reference")
+    if not os.path.isdir(tasks_dir):
+        issues.append(
+            issue(CODE_MISSING_TASKS, "tasks/ 가 없다", where="tasks")
+        )
+        return _pack_report(pack_id, 0, issues)
+
+    task_files = list_json_names(tasks_dir)
+    id_owners: dict[str, list[str]] = {}
+    task_count = 0
+    for name in task_files:
+        path = os.path.join(tasks_dir, name)
+        task, err = _load_json(path)
+        if err:
+            issues.append(
+                issue(
+                    CODE_PARSE_ERROR,
+                    f"tasks/{name} {err}",
+                    where=f"tasks/{name}",
+                )
+            )
+            continue
+        if not isinstance(task, dict):
+            issues.append(
+                issue(
+                    CODE_PARSE_ERROR,
+                    f"tasks/{name} 이 객체가 아니다",
+                    where=f"tasks/{name}",
+                )
+            )
+            continue
+        task_count += 1
+        tid = task.get("id")
+        if isinstance(tid, str) and tid.strip():
+            id_owners.setdefault(tid.strip(), []).append(name)
+        ref_path = os.path.join(ref_dir, name)
+        if not os.path.isfile(ref_path):
+            ref_path = None
+        issues.extend(scan_task(task, name, ref_path, min_chars))
+
+    for tid, owners in sorted(id_owners.items()):
+        if len(owners) > 1:
+            issues.append(
+                issue(
+                    CODE_DUPLICATE_TASK_ID,
+                    f"과제 id {tid!r} 가 이 pack 에서 {', '.join(owners)} 에 중복이다",
+                    task=tid,
+                    where="tasks",
+                    extra={"files": list(owners)},
+                )
+            )
+    return _pack_report(pack_id, task_count, issues)
+
+
+def _pack_report(pack_id: str, task_count: int, issues: list[dict]) -> dict:
+    issues_sorted = sorted(
+        issues,
+        key=lambda row: (
+            row.get("where") or "",
+            row.get("code") or "",
+            row.get("message") or "",
+        ),
+    )
+    return {
+        "id": pack_id,
+        "taskCount": task_count,
+        "issueCount": len(issues_sorted),
+        "issues": issues_sorted,
+    }
+
+
+def audit(
+    packs_root: str,
+    pack_ids: list[str] | None = None,
+    min_chars: int = MIN_INSTRUCTION_CHARS,
+) -> dict:
+    """전 pack(또는 지정 pack) 건강 감사. 순수 파일 검사.
+
+    packs_root: `packs/` 를 담은 디렉토리(보통 gym/).
+    """
+    packs_dir = os.path.join(packs_root, "packs")
+    pack_rows: list[dict] = []
+    scan_error = None
+    if not os.path.isdir(packs_dir):
+        scan_error = f"packs/ 가 없다: {packs_dir}"
+    else:
+        found = iter_pack_dirs(packs_root, pack_ids)
+        if pack_ids:
+            have = {row[0] for row in found}
+            for missing in pack_ids:
+                if missing not in have:
+                    pack_rows.append(
+                        _pack_report(
+                            missing,
+                            0,
+                            [
+                                issue(
+                                    CODE_MISSING_PACK,
+                                    f"지정한 pack 이 없다: {missing}",
+                                    where="packs",
+                                )
+                            ],
+                        )
+                    )
+        for pack_id, pack_dir in found:
+            pack_rows.append(scan_pack(pack_id, pack_dir, min_chars=min_chars))
+
+    pack_rows.sort(key=lambda row: row["id"])
+    all_issues = [item for pack in pack_rows for item in pack["issues"]]
+    error_count = sum(1 for item in all_issues if item.get("severity") == SEVERITY_ERROR)
+    warning_count = sum(1 for item in all_issues if item.get("severity") != SEVERITY_ERROR)
+    codes: dict[str, int] = {}
+    for item in all_issues:
+        codes[item["code"]] = codes.get(item["code"], 0) + 1
+    task_count = sum(pack["taskCount"] for pack in pack_rows)
+    issue_count = len(all_issues)
+    report = {
+        "kind": KIND,
+        "schemaVersion": SCHEMA_VERSION,
+        "ok": scan_error is None and issue_count == 0,
+        "packCount": len(pack_rows),
+        "taskCount": task_count,
+        "issueCount": issue_count,
+        "errorCount": error_count,
+        "warningCount": warning_count,
+        "codes": dict(sorted(codes.items())),
+        "packs": pack_rows,
+    }
+    if scan_error:
+        report["scanError"] = scan_error
+    return report
+
+
+def render_report(report: dict) -> str:
+    pack_n = report.get("packCount", 0)
+    task_n = report.get("taskCount", 0)
+    issue_n = report.get("issueCount", 0)
+    if report.get("scanError"):
+        head = f"gym pack 건강: 스캔 실패 — {report['scanError']}"
+        return head
+    if report.get("ok"):
+        return f"gym pack 건강: {pack_n} pack · {task_n} 과제 — 이슈 0"
+    lines = [f"gym pack 건강: {pack_n} pack · {task_n} 과제 · 이슈 {issue_n}건"]
+    for pack in report.get("packs") or []:
+        for item in pack.get("issues") or []:
+            task = item.get("task")
+            loc = f"{pack['id']}/{task}" if task else pack["id"]
+            lines.append(f"  [{loc}] {item.get('code')}: {item.get('message')}")
+    return "\n".join(lines)
+
+
+def exit_status(report: dict, strict: bool) -> int:
+    """기본 0. --strict 이거나 packs/ 자체를 못 읽으면 이슈 시 1."""
+    if report.get("scanError"):
+        return 1
+    if strict and not report.get("ok"):
+        return 1
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(
+        description="gym pack 건강 감사 (지시·검사 이름·힌트·제출 형식)"
+    )
+    ap.add_argument("--json", action="store_true", help="JSON 봉투로 출력")
+    ap.add_argument(
+        "--strict",
+        action="store_true",
+        help="이슈가 있으면 종료 코드 1 (기본은 리포트만 내고 0)",
+    )
+    ap.add_argument(
+        "--pack",
+        action="append",
+        default=None,
+        dest="packs",
+        help="검사할 pack id (여러 번 지정 가능)",
+    )
+    ap.add_argument(
+        "--root",
+        default=GYM_ROOT,
+        help="gym/ 루트 (packs/ 를 담은 디렉토리). 기본은 이 파일 기준 gym/",
+    )
+    ap.add_argument(
+        "--min-instructions",
+        type=int,
+        default=MIN_INSTRUCTION_CHARS,
+        dest="min_instructions",
+        help=f"instructions 최소 글자(기본 {MIN_INSTRUCTION_CHARS})",
+    )
+    return ap
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    min_chars = args.min_instructions
+    if min_chars < 1:
+        sys.stderr.write("--min-instructions 는 1 이상이어야 한다\n")
+        return 2
+    report = audit(args.root, pack_ids=args.packs, min_chars=min_chars)
+    if args.json:
+        sys.stdout.write(json.dumps(report, ensure_ascii=False, indent=2) + "\n")
+    else:
+        sys.stdout.write(render_report(report) + "\n")
+    return exit_status(report, args.strict)
+
+
+if __name__ == "__main__":
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
+        except Exception:
+            pass
+    sys.exit(main())

--- a/mydocs/working/gym_pack_health.md
+++ b/mydocs/working/gym_pack_health.md
@@ -1,0 +1,188 @@
+---
+kind: working
+status: active
+canonical: gym/docs/pack_health.md
+last_verified: 2026-08-18
+---
+
+# gym pack 건강 감사 — 작업 기록 (#5215)
+
+정본 목록은 [`gym/docs/pack_health.md`](../../gym/docs/pack_health.md) 다. 이
+문서는 왜 그 층이 생겼는지, 1차와 2차가 무엇을 갈랐는지, 어떤 오탐을 거절했는지,
+단위시험이 무엇을 재현하는지를 남긴다. pack 과제 JSON 은 여기서 바꾸지 않는다.
+
+## 한 줄 결론
+
+`audit.py` 는 스키마·기준풀이 짝·전역 ID 만 본다. 지시문이 비거나 힌트가 답을
+적어도 통과한다. #5215 는 `gym/tools/pack_health.py` 를 추가해 그 다음 층을
+같은 저장소 안에서 관측한다. 기본 종료는 0 이고 `--strict` 만 게이트다.
+기존 pack 은 고치지 않는다. 새 규칙은 픽스처로 고정한다.
+
+## 배경
+
+gym 4부(#4653)가 pack 을 `packs/<id>/{pack.json,tasks,reference}` 로 쪼갰다.
+`audit.py` 는 "등재될 자격"(짝이 있나, id 가 겹치나, 연산자가 등록됐나)을
+강제한다. 그런데 등재 자격과 풀이 품질은 다르다.
+
+- 지시문이 `"세어라"` 네 글자여도 스키마는 통과한다.
+- `checks` 두 줄의 `name` 이 같아도 채점기는 인덱스로 돈다. 리포트는 사람을
+  속인다.
+- 힌트에 `{"pages": 4}` 를 박아도 audit 은 파일을 읽지 않는다.
+- `submit.kind: "folder"` 는 채점기가 제출을 증발시키지만 등재는 된다.
+
+운동장이 자랄수록 이 구멍은 pack 수만큼 늘어난다. pack 건강은 그 구멍을
+바이너리 없이 막는다.
+
+## 1차와 2차
+
+1차는 지시·이름·힌트·제출 kind 만 봤다. 현재 트리 18 pack · 112 과제가 이슈 0
+인 것을 확인한 뒤, 같은 봉투에 2차 계약을 올렸다. 2차가 보는 것:
+
+| 층 | 이유 | 현재 트리가 이미 지키는가 |
+|---|---|---|
+| pack.json 신원 | audit 과 같은 최소 선언을 코드로 | 예 |
+| tier 1~5, bool 거절 | 스키마와 같음. `True` 를 1 로 보지 않음 | 예 |
+| input 경로 위생 | 절대 경로·백슬래시·`..` 는 재현 불가 | 예 (전부 상대 POSIX) |
+| 연산자 필수 필드 | `answer_eq` 에 `answer` 없음은 채점 불능 | 예 |
+| CLI `cmd` / 파일 `file` | 스키마 `needs_cli` 와 같음 | 예 |
+| 편집 축 전역 훑기 | #4600 재발 | 예 (현재 트리에 전역 훑기 없음) |
+| 제출 파일 경로 | 채점기가 상대 경로로 연다 | 예 |
+| 힌트 골격 | 본문 없는 꼬리, TODO 자리표 | 예 |
+| reference.id / 빈 run | audit 문자열을 코드로 | 예 |
+| 고아 reference | audit 과 같음 | 예 |
+
+"이미 지키는 계약만 승격한다" 가 2차의 원칙이다. 규칙을 넓혀 현재 트리가
+실패하면, 먼저 오탐인지 실제 구멍인지 가른다. 오탐이면 규칙을 좁히고 pack
+문구를 다시 쓰지 않는다.
+
+## 오탐으로 거절한 것
+
+### T06 괄호 힌트
+
+`core-cli/T06` 본문은 이렇게 적혀 있다.
+
+```text
+… 문구 하나를 스스로 찾아(힌트: export-text) 그 문구를 '검증완료' 로 …
+힌트: rhwp edit replace-text.
+```
+
+문장 안 `(힌트: export-text)` 는 "어느 명령으로 찾을지" 안내이지 꼬리 힌트가
+아니다. 첫 구현은 `str.find("힌트:")` 로 마커를 세어 이 과제를
+`duplicate_hint_marker` 경고로 만들었다. 경고도 `issueCount` 에 들어가
+`ok=false` 가 된다.
+
+처리는 pack 을 고치는 것이 아니라 `split_hint` / `count_hint_markers` 가
+괄호 안 마커를 꼬리로 치지 않게 한 것이다. 문장 끝(`.` / 줄바꿈 / 맨 앞)만
+꼬리다. 픽스처
+`test_parenthetical_hint_is_not_duplicate_tail` 가 T06 문형을 재현한다.
+
+### 자리표 JSON 과 CLI 접미
+
+fill-fields 예시는 `{"<필드이름>": "홍길동"}` 이다. 키가 자리표면 정답 봉투가
+아니다. `export-hwpx` / `conv.hwpx` 안의 `hwpx` 는 형식 토큰이지
+`value_eq: "hwpx"` 의 복붙이 아니다. 1차에서 이미 거절한 오탐이고 2차도
+유지한다.
+
+### 0/1 과 흔한 토큰
+
+쪽수·건수 힌트에 `1` 이 흔하다. `value` 가 0/1/-1 이면 복붙으로 치지 않는다.
+`json`, `hwp`, `true` 같은 짧은 토큰도 같다.
+
+### bool 좌표
+
+`cell_text_eq` 의 `table=True` 는 Python 에서 `int` 하위형이라 `>= 0` 검사를
+통과한다. 좌표로 쓰면 1번 표가 아니라 "참" 이 된다. `is_nonneg_int` 가
+`bool` 을 거절한다.
+
+## 일부러 보지 않는 것
+
+- **기준풀이 부재.** audit 가 이미 짝을 강제한다. 건강 도구가 없으면 침묵한다.
+  자기시험에서 기준 없이 도구만 돌릴 수 있게 하려는 것이다.
+- **전역 과제 ID 충돌.** audit 의 `taskIdCollisions` 몫이다. 건강 도구는 pack
+  안 중복만 본다.
+- **바이너리 명령 존재.** `cmd[0]` 이 그 바이너리에 있는지는 러너 몫이다.
+- **채점 성공.** 건강은 파일이 채점 **가능한 모양** 인지만 본다. 왕복은
+  `build_baseline.py` + `score.py` 다.
+- **지시문이 과제를 풀 수 있을 만큼 구체적인가.** 너무 주관적이다. 길이·자리표·
+  스포일러만 본다.
+- **pack 과제를 자동으로 고침.** 도구는 리포트만 낸다.
+
+## 종료 코드를 가른 이유
+
+현재 트리가 항상 깨끗하다고 가정할 수 없다. 다른 브랜치의 pack 이 섞이거나,
+작성 중인 픽스처를 같은 트리에서 돌릴 수 있다. 그래서:
+
+- 기본: 관측. 이슈가 있어도 0. CI 자기시험이 도구 **자체** 를 깨지 않는다.
+- `--strict`: 품질 관문. 머지 전 게이트나 로컬 훅이 쓴다.
+- `scanError`: packs/ 자체가 없으면 관측도 실패다. 기본도 1.
+
+`unittest` 는 픽스처에 이슈를 심고 `exit_status(..., strict=False) == 0` 과
+`strict=True == 1` 을 같이 고정한다.
+
+## 시험 지도
+
+파일은 `scripts/tests/test_gym_pack_health.py` 다. 실제 `gym/packs` 를 고쳐
+실패를 만들지 않는다. 임시 디렉터리에 pack 하나를 심고 코드를 확인한다.
+
+| 클래스 | 고정하는 계약 |
+|---|---|
+| `EnvelopeTests` | kind/schema, 기본 종료 0 |
+| `InstructionTests` | 빈/짧은/타입, `--min-instructions` |
+| `CheckNameTests` | 이름 없음·빈 값·중복, 과제 사이 동명 허용 |
+| `IdentityTests` | id/title 공백, 파일명 불일치 |
+| `ReferenceStepTests` | 부재는 침묵, 빈 steps, 빈 객체 |
+| `SubmitKindTests` | 미지 kind, 세 허용 값, artifact 경고 |
+| `HintHealthTests` | 스포일러·JSON 덤프·자리표·본문 반복 |
+| `StructureTests` | pack.json 없음, 파싱 실패, pack 필터 |
+| `RenderAndCliTests` | 사람 리포트, `--json`, `--strict` |
+| `RealRepoTests` | 현재 트리 스캔이 예외 없이 봉투를 냄 |
+| `UtilityTests` | 길이·공백·자리표·bare token |
+| `ManifestHealthTests` | kind/schema/id/title/axis/requires/runner |
+| `InputAndTierTests` | tier 범위, input 경로 위생, min-title |
+| `CheckContractTests` | op·cmd·file·좌표·전역 훑기 |
+| `SubmitPathTests` | files 타입·공백·절대 경로·중복 |
+| `InstructionQualityTests` | 힌트만, 빈 꼬리, 중복 꼬리, TODO, 제어 문자, 괄호 힌트 |
+| `ReferenceDetailTests` | id 불일치, 빈 run/answer/cmd, 고아, 빈 pack |
+| `CatalogAndCliExtraTests` | `--codes`, `--exclude`, 카탈로그 완전성 |
+| `RealRepoHealthGateTests` | 현재 트리 이슈 0 |
+
+`test_current_tree_stays_clean` 이 2차의 안전장치다. 새 규칙이 실제 pack 을
+실패로 뒤집으면 이 시험이 먼저 붉어진다. 그때 pack 을 고치기 전에 오탐부터
+의심한다.
+
+## 구현 메모
+
+- 도구는 `gym/core` 를 **선택적으로** 읽는다. `REGISTRY` 를 가져오면 미지
+  `op` 판정이 코어와 같다. 가져오지 못하면 내장 `FALLBACK_*` 로 후퇴한다.
+  단위시험 `test_known_ops_include_registry` 가 현재 트리에서 등록부가
+  보이는지 확인한다.
+- `ISSUE_CATALOG` 는 `--codes` 와 문서 표의 단일 출처다.
+  `test_catalog_covers_all_code_constants` 가 `CODE_*` 와 카탈로그를 묶는다.
+- `scan_pack` 은 manifest → tasks → orphan reference 순이다. pack.json 이
+  없으면 과제를 읽지 않는다.
+- 경고도 `issues[]` 에 들어간다. `ok` 는 경고가 있어도 거짓이다. 경고만
+  무시하려면 `--exclude`.
+
+## 현재 트리 실측
+
+이 기록을 남기는 시점의 로컬 스캔:
+
+```text
+python gym/tools/pack_health.py
+# gym pack 건강: 18 pack · 112 과제 — 이슈 0
+
+python gym/tools/audit.py
+# gym 정합 감사: 18 pack 전부 통과 — 위반 0
+```
+
+숫자(18/112)는 브랜치가 자라는 대로 변한다. 시험은 `>= 10 pack`, `>= 40 과제`,
+이슈 0 만 고정한다.
+
+## 관련 이슈·문서
+
+- #5215 — pack 건강 감사 도구
+- #4653 — gym 4부 pack 구조
+- #4600 — 편집 과제 전역 훑기 금지
+- [`gym/docs/pack_health.md`](../../gym/docs/pack_health.md) — 코드 표 정본
+- [`gym/tools/audit.py`](../../gym/tools/audit.py) — 정합 층
+- [`gym/core/schema.py`](../../gym/core/schema.py) — 스키마

--- a/scripts/tests/test_gym_pack_health.py
+++ b/scripts/tests/test_gym_pack_health.py
@@ -2,7 +2,8 @@
 
 audit.py 는 스키마·기준풀이 짝만 본다. 이 가드는 빈/짧은 instructions, 중복·누락
 check.name, 과제 id/title 공백, 빈 reference.steps, 미지 submit.kind, 힌트 정답
-노출을 픽스처로 고정한다. 실제 저장소 pack 은 고치지 않는다.
+노출, pack.json 신원, tier/input 위생, 연산자 필수 필드, 제출 경로, 고아
+reference 를 픽스처로 고정한다. 실제 저장소 pack 은 고치지 않는다.
 """
 
 from __future__ import annotations
@@ -23,6 +24,26 @@ CLEAN_INSTRUCTIONS = (
     "입력 문서의 총 쪽수를 알아내 answer.json 에 제출하라. "
     "힌트: rhwp info <문서> --json."
 )
+
+DEFAULT_CHECKS = [
+    {
+        "name": "쪽수 일치",
+        "op": "answer_eq",
+        "answer": "pages",
+        "cmd": ["info", "{input}", "--json"],
+        "path": "pageCount",
+    }
+]
+
+
+def _cli_check(name="쪽수 일치", op="answer_eq", **extra):
+    row = {
+        "name": name,
+        "op": op,
+        "cmd": extra.pop("cmd", ["info", "{input}", "--json"]),
+    }
+    row.update(extra)
+    return row
 
 
 def load():
@@ -48,9 +69,7 @@ def _task(
         "input": "samples/x.hwp",
         "instructions": instructions,
         "submit": submit if submit is not None else {"kind": "answer"},
-        "checks": checks
-        if checks is not None
-        else [{"name": "쪽수 일치", "op": "answer_eq", "answer": "pages"}],
+        "checks": checks if checks is not None else [dict(DEFAULT_CHECKS[0])],
     }
     doc.update(extra)
     return doc
@@ -72,27 +91,33 @@ def _write_json(path, doc):
         fh.write("\n")
 
 
+def _default_manifest(pid):
+    return {
+        "schemaVersion": "1.0",
+        "kind": "gymPack",
+        "id": pid,
+        "title": "t",
+        "axis": "조회 (x)",
+        "requires": {"commands": ["info"]},
+        "runner": {
+            "rhwpVersion": "0.8.4",
+            "rhwpCommit": "a" * 40,
+            "capabilitiesSha256": "b" * 64,
+        },
+    }
+
+
 def _write_pack(root, pid, tasks, refs=None, manifest=True):
     pack_dir = os.path.join(root, "packs", pid)
     os.makedirs(os.path.join(pack_dir, "tasks"), exist_ok=True)
     os.makedirs(os.path.join(pack_dir, "reference"), exist_ok=True)
     if manifest:
-        _write_json(
-            os.path.join(pack_dir, "pack.json"),
-            {
-                "schemaVersion": "1.0",
-                "kind": "gymPack",
-                "id": pid,
-                "title": "t",
-                "axis": "조회 (x)",
-                "requires": {"commands": ["info"]},
-                "runner": {
-                    "rhwpVersion": "0.8.4",
-                    "rhwpCommit": "a" * 40,
-                    "capabilitiesSha256": "b" * 64,
-                },
-            },
-        )
+        doc = dict(_default_manifest(pid))
+        if isinstance(manifest, dict):
+            doc.update(manifest)
+            if "id" not in manifest:
+                doc["id"] = pid
+        _write_json(os.path.join(pack_dir, "pack.json"), doc)
     for task in tasks:
         tid = task.get("id") or "X"
         name = extra_name(task)
@@ -238,8 +263,8 @@ class CheckNameTests(unittest.TestCase):
                 tmp,
                 "p1",
                 [
-                    _task("A01", checks=[{"name": "쪽수 일치", "op": "answer_eq"}]),
-                    _task("A02", checks=[{"name": "쪽수 일치", "op": "answer_eq"}]),
+                    _task("A01", checks=[_cli_check("쪽수 일치", answer="pages")]),
+                    _task("A02", checks=[_cli_check("쪽수 일치", answer="pages")]),
                 ],
             )
             report = mod.audit(tmp)
@@ -411,7 +436,7 @@ class HintHealthTests(unittest.TestCase):
             "첫 필드에 '홍길동' 을 채우라. "
             '힌트: rhwp edit fill-fields --data \'{"<필드이름>": "홍길동"}\'.'
         )
-        checks = [{"name": "값", "op": "value_eq", "value": "홍길동"}]
+        checks = [_cli_check("값", op="value_eq", value="홍길동")]
         with tempfile.TemporaryDirectory() as tmp:
             _write_pack(tmp, "p1", [_task(instructions=text, checks=checks)])
             report = mod.audit(tmp)
@@ -422,7 +447,7 @@ class HintHealthTests(unittest.TestCase):
     def test_format_token_inside_command_is_ok(self):
         mod = load()
         text = "입력을 HWPX 로 변환하라. 힌트: rhwp export-hwpx <입력> conv.hwpx --verify."
-        checks = [{"name": "형식", "op": "value_eq", "value": "hwpx"}]
+        checks = [_cli_check("형식", op="value_eq", value="hwpx")]
         with tempfile.TemporaryDirectory() as tmp:
             _write_pack(tmp, "p1", [_task(instructions=text, checks=checks)])
             report = mod.audit(tmp)
@@ -450,7 +475,17 @@ class HintHealthTests(unittest.TestCase):
         """과제가 '이 값으로 바꿔라'고 본문에 쓰는 것은 힌트 유출이 아니다."""
         mod = load()
         text = "첫 칸을 '계획실행' 으로 바꿔라. 힌트: rhwp run --plan-json."
-        checks = [{"name": "칸", "op": "cell_text_eq", "value": "계획실행"}]
+        checks = [
+            _cli_check(
+                "칸",
+                op="cell_text_eq",
+                value="계획실행",
+                table=0,
+                row=0,
+                col=0,
+                cmd=["export-tables", "{file:out.hwp}", "--json"],
+            )
+        ]
         with tempfile.TemporaryDirectory() as tmp:
             _write_pack(tmp, "p1", [_task(instructions=text, checks=checks)])
             report = mod.audit(tmp)
@@ -636,6 +671,811 @@ class UtilityTests(unittest.TestCase):
         self.assertFalse(mod.token_appears_bare("rhwp export-hwpx conv.hwpx", "hwpx"))
         self.assertTrue(mod.token_appears_bare("형식은 hwpx 다", "hwpx"))
         self.assertTrue(mod.token_appears_bare("셀에 계획실행을 넣으면", "계획실행"))
+
+
+def _issues(report, pack_id=None):
+    packs = report.get("packs") or []
+    if pack_id is not None:
+        packs = [p for p in packs if p["id"] == pack_id]
+    return [item for p in packs for item in p.get("issues") or []]
+
+
+class ManifestHealthTests(unittest.TestCase):
+    def test_pack_kind_must_be_gym_pack(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task()], manifest={"kind": "gymProfile"})
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_PACK_KIND, codes_of(report, "p1"))
+
+    def test_pack_schema_version(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task()], manifest={"schemaVersion": "2.0"})
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_PACK_SCHEMA_VERSION, codes_of(report, "p1"))
+
+    def test_pack_id_must_match_folder(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task()], manifest={"id": "other"})
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_PACK_ID_MISMATCH, codes_of(report, "p1"))
+
+    def test_pack_empty_title_and_axis(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task()], manifest={"title": "  ", "axis": ""})
+            report = mod.audit(tmp)
+        found = codes_of(report, "p1")
+        self.assertIn(mod.CODE_PACK_EMPTY_TITLE, found)
+        self.assertIn(mod.CODE_PACK_EMPTY_AXIS, found)
+
+    def test_pack_title_axis_whitespace(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task()], manifest={"title": " 조회 ", "axis": " 편집 "})
+            report = mod.audit(tmp)
+        found = codes_of(report, "p1")
+        self.assertIn(mod.CODE_PACK_TITLE_WHITESPACE, found)
+        self.assertIn(mod.CODE_PACK_AXIS_WHITESPACE, found)
+
+    def test_pack_missing_requires_commands(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task()], manifest={"requires": {}})
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_PACK_MISSING_REQUIRES, codes_of(report, "p1"))
+
+    def test_pack_empty_commands(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task()], manifest={"requires": {"commands": []}})
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_PACK_EMPTY_COMMANDS, codes_of(report, "p1"))
+
+    def test_pack_command_type(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task()], manifest={"requires": {"commands": [1, ""]}})
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_PACK_COMMAND_TYPE, codes_of(report, "p1"))
+
+    def test_pack_missing_runner(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task()], manifest={"runner": {}})
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_PACK_MISSING_RUNNER, codes_of(report, "p1"))
+
+    def test_pack_missing_runner_field(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(
+                tmp,
+                "p1",
+                [_task()],
+                manifest={"runner": {"rhwpVersion": "0.8.4", "rhwpCommit": "a" * 40}},
+            )
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_PACK_MISSING_RUNNER_FIELD, codes_of(report, "p1"))
+        self.assertTrue(any("capabilitiesSha256" in m for m in messages_of(report, "p1")))
+
+    def test_pack_json_array_is_type_error(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_dir = _write_pack(tmp, "p1", [_task()])
+            _write_json(os.path.join(pack_dir, "pack.json"), ["not", "object"])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_PACK_TYPE, codes_of(report, "p1"))
+
+
+class InputAndTierTests(unittest.TestCase):
+    def test_missing_tier(self):
+        mod = load()
+        task = _task()
+        del task["tier"]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [task])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_MISSING_TIER, codes_of(report, "p1"))
+
+    def test_tier_bool_is_not_int(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(tier=True)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_TIER_TYPE, codes_of(report, "p1"))
+
+    def test_tier_string(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(tier="2")])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_TIER_TYPE, codes_of(report, "p1"))
+
+    def test_tier_out_of_range(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(tier=6)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_TIER_RANGE, codes_of(report, "p1"))
+
+    def test_tier_zero(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(tier=0)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_TIER_RANGE, codes_of(report, "p1"))
+
+    def test_valid_tiers_1_to_5(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            for n in range(1, 6):
+                _write_pack(tmp, f"p{n}", [_task(tid=f"A0{n}", tier=n)])
+            report = mod.audit(tmp)
+        self.assertTrue(report["ok"], report["packs"])
+
+    def test_missing_input(self):
+        mod = load()
+        task = _task()
+        del task["input"]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [task])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_MISSING_INPUT, codes_of(report, "p1"))
+
+    def test_empty_input(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(input="  ")])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_EMPTY_INPUT, codes_of(report, "p1"))
+
+    def test_input_not_string(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(input=["a.hwp", "b.hwp"])])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_INPUT_TYPE, codes_of(report, "p1"))
+
+    def test_input_edge_whitespace(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(input=" samples/x.hwp ")])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_INPUT_WHITESPACE, codes_of(report, "p1"))
+
+    def test_input_absolute_posix(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(input="/tmp/x.hwp")])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_INPUT_ABSOLUTE, codes_of(report, "p1"))
+
+    def test_input_absolute_windows(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(input="C:\\docs\\x.hwp")])
+            report = mod.audit(tmp)
+        found = codes_of(report, "p1")
+        self.assertIn(mod.CODE_INPUT_ABSOLUTE, found)
+        self.assertIn(mod.CODE_INPUT_BACKSLASH, found)
+
+    def test_input_parent_traversal(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(input="../secret/x.hwp")])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_INPUT_PARENT, codes_of(report, "p1"))
+
+    def test_title_too_short_respects_min(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(title="가")])
+            ok = mod.audit(tmp, min_title=1)
+            tight = mod.audit(tmp, min_title=3)
+        self.assertTrue(ok["ok"])
+        self.assertIn(mod.CODE_TITLE_TOO_SHORT, codes_of(tight, "p1"))
+
+
+class CheckContractTests(unittest.TestCase):
+    def test_check_name_edge_whitespace(self):
+        mod = load()
+        checks = [_cli_check(" 쪽수 일치 ", answer="pages")]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_CHECK_NAME_WHITESPACE, codes_of(report, "p1"))
+
+    def test_missing_check_op(self):
+        mod = load()
+        checks = [{"name": "쪽수 일치", "answer": "pages"}]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_MISSING_CHECK_OP, codes_of(report, "p1"))
+
+    def test_empty_check_op(self):
+        mod = load()
+        checks = [{"name": "쪽수 일치", "op": "  "}]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_EMPTY_CHECK_OP, codes_of(report, "p1"))
+
+    def test_unknown_check_op(self):
+        mod = load()
+        checks = [_cli_check("쪽수", op="looks_ok", answer="pages")]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_UNKNOWN_CHECK_OP, codes_of(report, "p1"))
+        self.assertTrue(any("looks_ok" in m for m in messages_of(report, "p1")))
+
+    def test_answer_eq_requires_answer(self):
+        mod = load()
+        checks = [_cli_check("쪽수", op="answer_eq")]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_CHECK_MISSING_ANSWER, codes_of(report, "p1"))
+
+    def test_value_eq_requires_value(self):
+        mod = load()
+        checks = [_cli_check("값", op="value_eq")]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_CHECK_MISSING_VALUE, codes_of(report, "p1"))
+
+    def test_file_op_requires_file(self):
+        mod = load()
+        checks = [{"name": "존재", "op": "file_exists"}]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_CHECK_MISSING_FILE, codes_of(report, "p1"))
+
+    def test_file_op_rejects_absolute_and_backslash(self):
+        mod = load()
+        checks = [{"name": "존재", "op": "file_exists", "file": "C:\\tmp\\out.hwp"}]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        found = codes_of(report, "p1")
+        self.assertIn(mod.CODE_CHECK_FILE_ABSOLUTE, found)
+        self.assertIn(mod.CODE_CHECK_FILE_BACKSLASH, found)
+
+    def test_same_hash_requires_two_files(self):
+        mod = load()
+        checks = [{"name": "동일", "op": "same_hash", "files": ["a.hwp"]}]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_CHECK_FILES_SHORT, codes_of(report, "p1"))
+
+    def test_same_hash_missing_files(self):
+        mod = load()
+        checks = [{"name": "동일", "op": "same_hash"}]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_CHECK_MISSING_FILES, codes_of(report, "p1"))
+
+    def test_cli_op_requires_cmd(self):
+        mod = load()
+        checks = [{"name": "쪽수", "op": "answer_eq", "answer": "pages"}]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_CHECK_MISSING_CMD, codes_of(report, "p1"))
+
+    def test_cli_cmd_must_be_list(self):
+        mod = load()
+        checks = [_cli_check("쪽수", answer="pages", cmd="info")]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_CHECK_CMD_TYPE, codes_of(report, "p1"))
+
+    def test_cli_cmd_empty_list(self):
+        mod = load()
+        checks = [_cli_check("쪽수", answer="pages", cmd=[])]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_CHECK_CMD_EMPTY, codes_of(report, "p1"))
+
+    def test_cli_cmd_item_must_be_string(self):
+        mod = load()
+        checks = [_cli_check("쪽수", answer="pages", cmd=["info", 3])]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_CHECK_CMD_ITEM_TYPE, codes_of(report, "p1"))
+
+    def test_file_op_rejects_cmd(self):
+        mod = load()
+        checks = [
+            {
+                "name": "존재",
+                "op": "file_exists",
+                "file": "out.hwp",
+                "cmd": ["info", "{file:out.hwp}"],
+            }
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_CHECK_UNEXPECTED_CMD, codes_of(report, "p1"))
+
+    def test_cell_text_requires_coords(self):
+        mod = load()
+        checks = [_cli_check("칸", op="cell_text_eq", value="계획실행")]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_CELL_MISSING_COORD, codes_of(report, "p1"))
+
+    def test_cell_text_bool_coord_rejected(self):
+        mod = load()
+        checks = [
+            _cli_check(
+                "칸",
+                op="cell_text_eq",
+                value="계획실행",
+                table=True,
+                row=0,
+                col=0,
+            )
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_CELL_MISSING_COORD, codes_of(report, "p1"))
+
+    def test_csv_cell_requires_coords(self):
+        mod = load()
+        checks = [{"name": "셀", "op": "csv_cell_eq", "file": "out.csv", "value": "a"}]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_CSV_MISSING_COORD, codes_of(report, "p1"))
+
+    def test_global_scan_on_editing_axis_needs_allow(self):
+        mod = load()
+        checks = [_cli_check("훑기", op="deep_contains", value="비밀")]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(
+                tmp,
+                "p1",
+                [_task(checks=checks, axis="편집 (표 좌표 지정)")],
+                manifest={"axis": "편집 (표 좌표 지정)"},
+            )
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_GLOBAL_SCAN_UNDECLARED, codes_of(report, "p1"))
+
+    def test_global_scan_allowed_with_reason(self):
+        mod = load()
+        checks = [
+            _cli_check(
+                "훑기",
+                op="deep_contains",
+                value="비밀",
+                allowGlobalScan="은닉 문구가 좌표를 갖지 않는다",
+            )
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(
+                tmp,
+                "p1",
+                [_task(checks=checks, axis="편집 (표 좌표 지정)")],
+                manifest={"axis": "편집 (표 좌표 지정)"},
+            )
+            report = mod.audit(tmp)
+        self.assertNotIn(mod.CODE_GLOBAL_SCAN_UNDECLARED, codes_of(report, "p1"))
+        self.assertTrue(report["ok"], report["packs"])
+
+    def test_global_scan_on_inquiry_axis_is_ok(self):
+        mod = load()
+        checks = [_cli_check("훑기", op="not_contains", value="TODO")]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        self.assertNotIn(mod.CODE_GLOBAL_SCAN_UNDECLARED, codes_of(report, "p1"))
+        self.assertTrue(report["ok"], report["packs"])
+
+    def test_well_formed_file_and_pair_ops_pass(self):
+        mod = load()
+        checks = [
+            {"name": "존재", "op": "file_exists", "file": "out.hwp"},
+            {"name": "원본과 다름", "op": "differs_from_input", "file": "out.hwp"},
+            {"name": "동일", "op": "same_hash", "files": ["o1.hwp", "o2.hwp"]},
+            {
+                "name": "칸",
+                "op": "csv_cell_eq",
+                "file": "t.csv",
+                "row": 1,
+                "col": 0,
+                "value": "앞칸",
+            },
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(
+                tmp,
+                "p1",
+                [_task(submit={"kind": "artifact", "files": ["out.hwp", "t.csv"]}, checks=checks)],
+            )
+            report = mod.audit(tmp)
+        self.assertTrue(report["ok"], report["packs"])
+
+
+class SubmitPathTests(unittest.TestCase):
+    def test_submit_files_must_be_list(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(submit={"kind": "answer", "files": "answer.json"})])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_SUBMIT_FILES_TYPE, codes_of(report, "p1"))
+
+    def test_submit_file_empty(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(submit={"kind": "artifact", "files": ["", "out.hwp"]})])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_SUBMIT_FILE_EMPTY, codes_of(report, "p1"))
+
+    def test_submit_file_not_string(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(submit={"kind": "artifact", "files": [1]})])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_SUBMIT_FILE_TYPE, codes_of(report, "p1"))
+
+    def test_submit_file_whitespace(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(submit={"kind": "artifact", "files": [" out.hwp "]})])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_SUBMIT_FILE_WHITESPACE, codes_of(report, "p1"))
+
+    def test_submit_file_absolute_and_backslash(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(
+                tmp,
+                "p1",
+                [_task(submit={"kind": "artifact", "files": ["D:\\out\\edited.hwp"]})],
+            )
+            report = mod.audit(tmp)
+        found = codes_of(report, "p1")
+        self.assertIn(mod.CODE_SUBMIT_FILE_ABSOLUTE, found)
+        self.assertIn(mod.CODE_SUBMIT_FILE_BACKSLASH, found)
+
+    def test_submit_file_duplicate(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(
+                tmp,
+                "p1",
+                [_task(submit={"kind": "artifact", "files": ["out.hwp", "out.hwp"]})],
+            )
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_SUBMIT_FILE_DUPLICATE, codes_of(report, "p1"))
+
+    def test_pair_without_files_still_warning(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(submit={"kind": "pair", "files": ["only.hwp"]})])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_PAIR_WITHOUT_FILES, codes_of(report, "p1"))
+        self.assertGreater(report["warningCount"], 0)
+
+
+class InstructionQualityTests(unittest.TestCase):
+    def test_hint_only_instructions(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions="힌트: rhwp info <문서> --json.")])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_INSTRUCTIONS_HINT_ONLY, codes_of(report, "p1"))
+
+    def test_empty_hint_after_marker(self):
+        mod = load()
+        text = "입력 문서의 총 쪽수를 알아내 answer.json 에 제출하라. 힌트:"
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions=text)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_EMPTY_HINT, codes_of(report, "p1"))
+        self.assertGreater(report["warningCount"], 0)
+
+    def test_duplicate_hint_marker(self):
+        mod = load()
+        text = (
+            "입력 문서의 총 쪽수를 알아내 제출하라. "
+            "힌트: rhwp info. 힌트: 다시 적지 마라."
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions=text)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_DUPLICATE_HINT_MARKER, codes_of(report, "p1"))
+
+    def test_parenthetical_hint_is_not_duplicate_tail(self):
+        """T06 처럼 본문 `(힌트: export-text)` 는 꼬리 마커가 아니다."""
+        mod = load()
+        text = (
+            "입력 문서에서 문구를 스스로 찾아(힌트: export-text) "
+            "그 문구를 바꾼 산출물을 제출하라. 힌트: rhwp edit replace-text."
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions=text)])
+            report = mod.audit(tmp)
+        self.assertNotIn(mod.CODE_DUPLICATE_HINT_MARKER, codes_of(report, "p1"))
+        self.assertTrue(report["ok"], report["packs"])
+        body, hint = mod.split_hint(text)
+        self.assertIn("export-text", body)
+        self.assertIsNotNone(hint)
+        self.assertIn("replace-text", hint)
+
+    def test_todo_placeholder(self):
+        mod = load()
+        text = "TODO: 여기에 쪽수 세기 지시문을 작성한다. 충분히 길게."
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions=text)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_INSTRUCTIONS_TODO, codes_of(report, "p1"))
+
+    def test_fixme_placeholder(self):
+        mod = load()
+        text = "FIXME 자리표를 지우고 실제 과제를 적어라. 스무 글자는 넘긴다."
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions=text)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_INSTRUCTIONS_TODO, codes_of(report, "p1"))
+
+    def test_control_character(self):
+        mod = load()
+        text = "입력 문서의 총 쪽수를 알아내 제출하라.\x00숨은문자"
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions=text)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_INSTRUCTIONS_CONTROL_CHAR, codes_of(report, "p1"))
+
+    def test_newline_and_tab_are_not_control_issues(self):
+        mod = load()
+        text = "입력 문서의 총 쪽수를 알아내 제출하라.\n힌트:\trhwp info <문서> --json."
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions=text)])
+            report = mod.audit(tmp)
+        self.assertNotIn(mod.CODE_INSTRUCTIONS_CONTROL_CHAR, codes_of(report, "p1"))
+        self.assertTrue(report["ok"], report["packs"])
+
+
+class ReferenceDetailTests(unittest.TestCase):
+    def test_reference_id_mismatch(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task()], refs={"A01.json": _ref("B99")})
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_REFERENCE_ID_MISMATCH, codes_of(report, "p1"))
+
+    def test_reference_step_not_object(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(
+                tmp,
+                "p1",
+                [_task()],
+                refs={"A01.json": {"id": "A01", "steps": ["run info"]}},
+            )
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_REFERENCE_STEP_TYPE, codes_of(report, "p1"))
+
+    def test_reference_run_empty(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(
+                tmp,
+                "p1",
+                [_task()],
+                refs={
+                    "A01.json": {
+                        "id": "A01",
+                        "steps": [{"run": []}, {"run": ["info", "{input}", "--json"]}],
+                    }
+                },
+            )
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_REFERENCE_RUN_EMPTY, codes_of(report, "p1"))
+
+    def test_reference_answer_empty(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(
+                tmp,
+                "p1",
+                [_task()],
+                refs={
+                    "A01.json": {
+                        "id": "A01",
+                        "steps": [{"write_json": {"file": "out.json"}, "answer": {}}],
+                    }
+                },
+            )
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_REFERENCE_ANSWER_EMPTY, codes_of(report, "p1"))
+
+    def test_reference_cmd_empty(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(
+                tmp,
+                "p1",
+                [_task()],
+                refs={
+                    "A01.json": {
+                        "id": "A01",
+                        "steps": [{"answer": {"pages": {"cmd": [], "path": "pageCount"}}}],
+                    }
+                },
+            )
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_REFERENCE_CMD_EMPTY, codes_of(report, "p1"))
+
+    def test_orphan_reference(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_dir = _write_pack(tmp, "p1", [_task()])
+            _write_json(os.path.join(pack_dir, "reference", "Z99.json"), _ref("Z99"))
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_ORPHAN_REFERENCE, codes_of(report, "p1"))
+
+    def test_empty_pack_is_warning(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_dir = _write_pack(tmp, "p1", [_task()])
+            os.remove(os.path.join(pack_dir, "tasks", "A01.json"))
+            os.remove(os.path.join(pack_dir, "reference", "A01.json"))
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_EMPTY_PACK, codes_of(report, "p1"))
+        self.assertGreater(report["warningCount"], 0)
+
+
+class CatalogAndCliExtraTests(unittest.TestCase):
+    def test_catalog_covers_all_code_constants(self):
+        mod = load()
+        codes = set(mod.catalog_codes())
+        exported = [
+            value
+            for name, value in vars(mod).items()
+            if name.startswith("CODE_") and isinstance(value, str)
+        ]
+        missing = [item for item in exported if item not in codes]
+        self.assertEqual(missing, [], missing)
+        self.assertGreaterEqual(len(codes), 70)
+
+    def test_catalog_rows_have_severity_and_layer(self):
+        mod = load()
+        for code, severity, layer, summary in mod.ISSUE_CATALOG:
+            self.assertIn(severity, (mod.SEVERITY_ERROR, mod.SEVERITY_WARNING), code)
+            self.assertTrue(layer, code)
+            self.assertTrue(summary, code)
+
+    def test_cli_codes_lists_catalog(self):
+        mod = load()
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            code = mod.main(["--codes"])
+        text = buf.getvalue()
+        self.assertEqual(code, 0)
+        self.assertIn("empty_instructions", text)
+        self.assertIn("unknown_check_op", text)
+        self.assertIn("pack_id_mismatch", text)
+        self.assertIn("severity", text)
+
+    def test_exclude_code_drops_issue(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions="짧다")])
+            full = mod.audit(tmp)
+            trimmed = mod.audit(tmp, exclude_codes=[mod.CODE_SHORT_INSTRUCTIONS])
+        self.assertIn(mod.CODE_SHORT_INSTRUCTIONS, codes_of(full, "p1"))
+        self.assertNotIn(mod.CODE_SHORT_INSTRUCTIONS, codes_of(trimmed, "p1"))
+        self.assertIn("excludedCodes", trimmed)
+
+    def test_cli_exclude_and_json(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions="짧다")])
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                code = mod.main(
+                    ["--root", tmp, "--json", "--exclude", "short_instructions"]
+                )
+            payload = json.loads(buf.getvalue())
+        self.assertEqual(code, 0)
+        self.assertNotIn("short_instructions", payload.get("codes") or {})
+
+    def test_cli_bad_min_title(self):
+        mod = load()
+        err = io.StringIO()
+        with redirect_stderr(err):
+            code = mod.main(["--min-title", "0"])
+        self.assertEqual(code, 2)
+        self.assertIn("min-title", err.getvalue())
+
+    def test_render_includes_severity_and_code_summary(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions="짧다")])
+            text = mod.render_report(mod.audit(tmp))
+        self.assertIn("error", text)
+        self.assertIn("코드 집계", text)
+        self.assertIn("short_instructions", text)
+
+    def test_path_helpers(self):
+        mod = load()
+        self.assertTrue(mod.is_absolute_path("/tmp/a.hwp"))
+        self.assertTrue(mod.is_absolute_path("D:\\a.hwp"))
+        self.assertFalse(mod.is_absolute_path("samples/a.hwp"))
+        self.assertTrue(mod.has_backslash("samples\\a.hwp"))
+        self.assertTrue(mod.has_parent_traversal("foo/../bar.hwp"))
+        self.assertFalse(mod.has_parent_traversal("foo/bar.hwp"))
+        self.assertTrue(mod.is_nonneg_int(0))
+        self.assertFalse(mod.is_nonneg_int(True))
+        self.assertFalse(mod.is_nonneg_int(-1))
+
+    def test_editing_axis_prefixes(self):
+        mod = load()
+        self.assertTrue(mod.pack_axis_is_editing("편집 (표 좌표 지정)"))
+        self.assertTrue(mod.pack_axis_is_editing("보안 (은닉)"))
+        self.assertFalse(mod.pack_axis_is_editing("조회 (x)"))
+        self.assertEqual(mod.effective_axis({"axis": "조사"}, "편집"), "조사")
+        self.assertEqual(mod.effective_axis({}, "편집 (표)"), "편집 (표)")
+
+    def test_known_ops_include_registry(self):
+        mod = load()
+        mod.reset_ops_cache()
+        all_ops, cli_ops, file_ops, global_ops = mod.known_ops_bundle()
+        self.assertIn("answer_eq", cli_ops)
+        self.assertIn("file_exists", file_ops)
+        self.assertIn("deep_contains", global_ops)
+        self.assertTrue(all_ops >= (cli_ops | file_ops))
+
+    def test_scan_error_render(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            text = mod.render_report(mod.audit(tmp))
+        self.assertIn("스캔 실패", text)
+
+
+class RealRepoHealthGateTests(unittest.TestCase):
+    def test_current_tree_stays_clean(self):
+        """새 규칙은 현재 gym/packs 를 실패로 뒤집지 않는다."""
+        mod = load()
+        report = mod.audit(str(REPO_ROOT / "gym"))
+        self.assertEqual(report["kind"], "gymPackHealth")
+        self.assertGreaterEqual(report["packCount"], 10)
+        self.assertEqual(
+            report["issueCount"],
+            0,
+            report.get("codes"),
+        )
+        self.assertTrue(report["ok"], report.get("codes"))
+
+    def test_issue_rows_have_stable_keys(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions="짧다")])
+            rows = _issues(mod.audit(tmp), "p1")
+        self.assertGreater(len(rows), 0)
+        for row in rows:
+            self.assertIn("code", row)
+            self.assertIn("severity", row)
+            self.assertIn("message", row)
+            self.assertIn("where", row)
+            self.assertIn("task", row)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_gym_pack_health.py
+++ b/scripts/tests/test_gym_pack_health.py
@@ -1,0 +1,642 @@
+"""[pack_health] gym pack 건강 감사 계약 — 지시·검사 이름·힌트·제출 형식.
+
+audit.py 는 스키마·기준풀이 짝만 본다. 이 가드는 빈/짧은 instructions, 중복·누락
+check.name, 과제 id/title 공백, 빈 reference.steps, 미지 submit.kind, 힌트 정답
+노출을 픽스처로 고정한다. 실제 저장소 pack 은 고치지 않는다.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL = REPO_ROOT / "gym" / "tools" / "pack_health.py"
+
+CLEAN_INSTRUCTIONS = (
+    "입력 문서의 총 쪽수를 알아내 answer.json 에 제출하라. "
+    "힌트: rhwp info <문서> --json."
+)
+
+
+def load():
+    spec = importlib.util.spec_from_file_location("gym_pack_health", TOOL)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _task(
+    tid="A01",
+    title="쪽수 세기",
+    instructions=CLEAN_INSTRUCTIONS,
+    submit=None,
+    checks=None,
+    **extra,
+):
+    doc = {
+        "id": tid,
+        "tier": 1,
+        "title": title,
+        "input": "samples/x.hwp",
+        "instructions": instructions,
+        "submit": submit if submit is not None else {"kind": "answer"},
+        "checks": checks
+        if checks is not None
+        else [{"name": "쪽수 일치", "op": "answer_eq", "answer": "pages"}],
+    }
+    doc.update(extra)
+    return doc
+
+
+def _ref(tid="A01", steps=None):
+    return {
+        "id": tid,
+        "steps": steps
+        if steps is not None
+        else [{"answer": {"pages": {"cmd": ["info", "{input}", "--json"], "path": "pageCount"}}}],
+    }
+
+
+def _write_json(path, doc):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8", newline="\n") as fh:
+        json.dump(doc, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
+
+
+def _write_pack(root, pid, tasks, refs=None, manifest=True):
+    pack_dir = os.path.join(root, "packs", pid)
+    os.makedirs(os.path.join(pack_dir, "tasks"), exist_ok=True)
+    os.makedirs(os.path.join(pack_dir, "reference"), exist_ok=True)
+    if manifest:
+        _write_json(
+            os.path.join(pack_dir, "pack.json"),
+            {
+                "schemaVersion": "1.0",
+                "kind": "gymPack",
+                "id": pid,
+                "title": "t",
+                "axis": "조회 (x)",
+                "requires": {"commands": ["info"]},
+                "runner": {
+                    "rhwpVersion": "0.8.4",
+                    "rhwpCommit": "a" * 40,
+                    "capabilitiesSha256": "b" * 64,
+                },
+            },
+        )
+    for task in tasks:
+        tid = task.get("id") or "X"
+        name = extra_name(task)
+        _write_json(os.path.join(pack_dir, "tasks", name), task)
+        if refs is not False:
+            ref_doc = None
+            if isinstance(refs, dict):
+                ref_doc = refs.get(name) or refs.get(tid)
+            if ref_doc is None and refs is not False:
+                ref_doc = _ref(tid if isinstance(tid, str) else "X")
+            if ref_doc is not None:
+                _write_json(os.path.join(pack_dir, "reference", name), ref_doc)
+    return pack_dir
+
+
+def extra_name(task):
+    """파일명. 기본은 id.json. `_filename` 으로 덮어쓸 수 있다."""
+    override = task.pop("_filename", None) if isinstance(task, dict) else None
+    if override:
+        return override
+    tid = task.get("id") if isinstance(task, dict) else None
+    if isinstance(tid, str) and tid.strip() and not any(ch.isspace() for ch in tid):
+        return f"{tid}.json"
+    return "TASK.json"
+
+
+def codes_of(report, pack_id=None):
+    packs = report.get("packs") or []
+    if pack_id is not None:
+        packs = [p for p in packs if p["id"] == pack_id]
+    return [item["code"] for p in packs for item in p.get("issues") or []]
+
+
+def messages_of(report, pack_id=None):
+    packs = report.get("packs") or []
+    if pack_id is not None:
+        packs = [p for p in packs if p["id"] == pack_id]
+    return [item["message"] for p in packs for item in p.get("issues") or []]
+
+
+class EnvelopeTests(unittest.TestCase):
+    def test_clean_fixture_is_ok(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task()])
+            report = mod.audit(tmp)
+        self.assertEqual(report["kind"], "gymPackHealth")
+        self.assertEqual(report["schemaVersion"], "1.0")
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["issueCount"], 0)
+        self.assertEqual(report["packCount"], 1)
+        self.assertEqual(report["taskCount"], 1)
+        self.assertEqual(report["errorCount"], 0)
+        self.assertEqual(report["codes"], {})
+
+    def test_default_exit_zero_even_with_issues(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions="짧다")])
+            report = mod.audit(tmp)
+            self.assertFalse(report["ok"])
+            self.assertGreater(report["issueCount"], 0)
+            self.assertEqual(mod.exit_status(report, strict=False), 0)
+            self.assertEqual(mod.exit_status(report, strict=True), 1)
+
+
+class InstructionTests(unittest.TestCase):
+    def test_empty_instructions(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions="   ")])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_EMPTY_INSTRUCTIONS, codes_of(report, "p1"))
+
+    def test_missing_instructions_key(self):
+        mod = load()
+        task = _task()
+        del task["instructions"]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [task])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_EMPTY_INSTRUCTIONS, codes_of(report, "p1"))
+
+    def test_short_instructions_under_20(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions="열아홉글자짜리지시문임.")])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_SHORT_INSTRUCTIONS, codes_of(report, "p1"))
+        self.assertTrue(any("< 20" in m for m in messages_of(report, "p1")))
+
+    def test_min_chars_override(self):
+        mod = load()
+        text = "스무글자가넘는지시문입니다!"
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions=text)])
+            ok = mod.audit(tmp, min_chars=5)
+            tight = mod.audit(tmp, min_chars=80)
+        self.assertTrue(ok["ok"])
+        self.assertIn(mod.CODE_SHORT_INSTRUCTIONS, codes_of(tight, "p1"))
+
+    def test_non_string_instructions(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions=["리스트"])])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_INSTRUCTIONS_TYPE, codes_of(report, "p1"))
+
+
+class CheckNameTests(unittest.TestCase):
+    def test_missing_check_name(self):
+        mod = load()
+        checks = [{"op": "answer_eq", "answer": "pages"}]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_MISSING_CHECK_NAME, codes_of(report, "p1"))
+
+    def test_empty_check_name(self):
+        mod = load()
+        checks = [{"name": "  ", "op": "answer_eq"}]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_EMPTY_CHECK_NAME, codes_of(report, "p1"))
+
+    def test_duplicate_check_name_inside_task(self):
+        mod = load()
+        checks = [
+            {"name": "쪽수 일치", "op": "answer_eq"},
+            {"name": "쪽수 일치", "op": "value_eq"},
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(checks=checks)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_DUPLICATE_CHECK_NAME, codes_of(report, "p1"))
+        self.assertTrue(any("2번" in m for m in messages_of(report, "p1")))
+
+    def test_same_name_in_different_tasks_is_ok(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(
+                tmp,
+                "p1",
+                [
+                    _task("A01", checks=[{"name": "쪽수 일치", "op": "answer_eq"}]),
+                    _task("A02", checks=[{"name": "쪽수 일치", "op": "answer_eq"}]),
+                ],
+            )
+            report = mod.audit(tmp)
+        self.assertNotIn(mod.CODE_DUPLICATE_CHECK_NAME, codes_of(report, "p1"))
+        self.assertTrue(report["ok"])
+
+
+class IdentityTests(unittest.TestCase):
+    def test_task_id_leading_whitespace(self):
+        mod = load()
+        task = _task(tid=" A01")
+        task["_filename"] = "A01.json"
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [task])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_TASK_ID_WHITESPACE, codes_of(report, "p1"))
+
+    def test_task_id_internal_whitespace(self):
+        mod = load()
+        task = _task(tid="A 01")
+        task["_filename"] = "A01.json"
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [task])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_TASK_ID_WHITESPACE, codes_of(report, "p1"))
+
+    def test_title_edge_whitespace(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(title=" 쪽수 세기 ")])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_TASK_TITLE_WHITESPACE, codes_of(report, "p1"))
+
+    def test_title_internal_space_is_ok(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(title="쪽수 세기")])
+            report = mod.audit(tmp)
+        self.assertNotIn(mod.CODE_TASK_TITLE_WHITESPACE, codes_of(report, "p1"))
+        self.assertTrue(report["ok"])
+
+    def test_id_filename_mismatch(self):
+        mod = load()
+        task = _task(tid="A01")
+        task["_filename"] = "B01.json"
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [task], refs={"B01.json": _ref("A01")})
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_ID_FILENAME_MISMATCH, codes_of(report, "p1"))
+
+
+class ReferenceStepTests(unittest.TestCase):
+    def test_missing_reference_is_not_this_tools_job(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task()], refs=False)
+            report = mod.audit(tmp)
+        self.assertNotIn(mod.CODE_EMPTY_REFERENCE_STEPS, codes_of(report, "p1"))
+        self.assertTrue(report["ok"])
+
+    def test_empty_steps_list(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task()], refs={"A01.json": _ref("A01", steps=[])})
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_EMPTY_REFERENCE_STEPS, codes_of(report, "p1"))
+
+    def test_missing_steps_key(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task()], refs={"A01.json": {"id": "A01"}})
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_EMPTY_REFERENCE_STEPS, codes_of(report, "p1"))
+
+    def test_null_steps(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task()], refs={"A01.json": {"id": "A01", "steps": None}})
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_EMPTY_REFERENCE_STEPS, codes_of(report, "p1"))
+
+    def test_vacuous_step_objects(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(
+                tmp,
+                "p1",
+                [_task()],
+                refs={"A01.json": _ref("A01", steps=[{}, {"run": None}])},
+            )
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_EMPTY_REFERENCE_STEPS, codes_of(report, "p1"))
+
+    def test_steps_wrong_type(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task()], refs={"A01.json": {"id": "A01", "steps": "run"}})
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_REFERENCE_STEPS_TYPE, codes_of(report, "p1"))
+
+
+class SubmitKindTests(unittest.TestCase):
+    def test_unknown_submit_kind(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(submit={"kind": "folder"})])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_UNKNOWN_SUBMIT_KIND, codes_of(report, "p1"))
+        self.assertTrue(any("folder" in m for m in messages_of(report, "p1")))
+
+    def test_known_kinds_pass(self):
+        mod = load()
+        cases = (
+            ("answer", {"kind": "answer"}),
+            ("artifact", {"kind": "artifact", "files": ["out.hwp"]}),
+            ("pair", {"kind": "pair", "files": ["o1.hwp", "o2.hwp", "plan.json"]}),
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            for tid, submit in cases:
+                _write_pack(tmp, tid, [_task(tid=tid, submit=submit)])
+            report = mod.audit(tmp)
+        self.assertTrue(report["ok"], report["packs"])
+
+    def test_missing_submit_kind(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(submit={"files": ["a"]})])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_MISSING_SUBMIT_KIND, codes_of(report, "p1"))
+
+    def test_artifact_without_files_is_warning(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(submit={"kind": "artifact"})])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_ARTIFACT_WITHOUT_FILES, codes_of(report, "p1"))
+        self.assertGreater(report["warningCount"], 0)
+
+
+class HintHealthTests(unittest.TestCase):
+    def test_command_hint_is_ok(self):
+        mod = load()
+        body, hint = mod.split_hint(CLEAN_INSTRUCTIONS)
+        self.assertIsNotNone(hint)
+        self.assertIn("쪽수", body)
+        self.assertIn("rhwp info", hint)
+
+    def test_hint_answer_json_dump(self):
+        mod = load()
+        text = CLEAN_INSTRUCTIONS.split("힌트:")[0] + '힌트: {"pages": 4}'
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions=text)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_HINT_ANSWER_DUMP, codes_of(report, "p1"))
+
+    def test_hint_placeholder_json_is_ok(self):
+        mod = load()
+        text = '입력 문서의 총 쪽수를 알아내 제출하라. 힌트: {"pages": "<수>"}'
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions=text)])
+            report = mod.audit(tmp)
+        self.assertNotIn(mod.CODE_HINT_ANSWER_DUMP, codes_of(report, "p1"))
+        self.assertTrue(report["ok"])
+
+    def test_hint_cli_syntax_with_placeholder_key_is_ok(self):
+        """fill-fields 의 `{"<필드이름>": "홍길동"}` 는 문법 예시이지 정답 봉투가 아니다."""
+        mod = load()
+        text = (
+            "첫 필드에 '홍길동' 을 채우라. "
+            '힌트: rhwp edit fill-fields --data \'{"<필드이름>": "홍길동"}\'.'
+        )
+        checks = [{"name": "값", "op": "value_eq", "value": "홍길동"}]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions=text, checks=checks)])
+            report = mod.audit(tmp)
+        self.assertNotIn(mod.CODE_HINT_ANSWER_DUMP, codes_of(report, "p1"))
+        self.assertNotIn(mod.CODE_HINT_EMBEDS_VALUE, codes_of(report, "p1"))
+        self.assertTrue(report["ok"], report["packs"])
+
+    def test_format_token_inside_command_is_ok(self):
+        mod = load()
+        text = "입력을 HWPX 로 변환하라. 힌트: rhwp export-hwpx <입력> conv.hwpx --verify."
+        checks = [{"name": "형식", "op": "value_eq", "value": "hwpx"}]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions=text, checks=checks)])
+            report = mod.audit(tmp)
+        self.assertNotIn(mod.CODE_HINT_EMBEDS_VALUE, codes_of(report, "p1"))
+        self.assertTrue(report["ok"], report["packs"])
+
+    def test_hint_spoiler_phrase(self):
+        mod = load()
+        text = "쪽수를 세어 제출하라. 힌트: 답은 4 이다"
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions=text)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_HINT_SPOILER, codes_of(report, "p1"))
+
+    def test_hint_embeds_check_value(self):
+        mod = load()
+        text = "첫 칸을 고치라. 힌트: 셀에 계획실행을 넣으면 된다"
+        checks = [{"name": "칸", "op": "cell_text_eq", "value": "계획실행"}]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions=text, checks=checks)])
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_HINT_EMBEDS_VALUE, codes_of(report, "p1"))
+
+    def test_expected_value_in_body_not_hint_is_ok(self):
+        """과제가 '이 값으로 바꿔라'고 본문에 쓰는 것은 힌트 유출이 아니다."""
+        mod = load()
+        text = "첫 칸을 '계획실행' 으로 바꿔라. 힌트: rhwp run --plan-json."
+        checks = [{"name": "칸", "op": "cell_text_eq", "value": "계획실행"}]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions=text, checks=checks)])
+            report = mod.audit(tmp)
+        self.assertNotIn(mod.CODE_HINT_EMBEDS_VALUE, codes_of(report, "p1"))
+        self.assertTrue(report["ok"])
+
+    def test_extract_json_fragments_skips_broken_braces(self):
+        mod = load()
+        bits = mod.extract_json_fragments('앞 {깨짐 그리고 {"ok": 1} 뒤')
+        self.assertEqual(bits, [{"ok": 1}])
+
+
+class StructureTests(unittest.TestCase):
+    def test_missing_pack_json(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task()], manifest=False)
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_MISSING_PACK, codes_of(report, "p1"))
+
+    def test_parse_error_on_task(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task()])
+            bad = os.path.join(tmp, "packs", "p1", "tasks", "Z99.json")
+            with open(bad, "w", encoding="utf-8", newline="\n") as fh:
+                fh.write("{not json\n")
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_PARSE_ERROR, codes_of(report, "p1"))
+
+    def test_missing_packs_dir_is_scan_error(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            report = mod.audit(tmp)
+        self.assertFalse(report["ok"])
+        self.assertIn("scanError", report)
+        self.assertEqual(mod.exit_status(report, strict=False), 1)
+
+    def test_duplicate_task_id_in_pack(self):
+        mod = load()
+        a = _task(tid="A01")
+        b = _task(tid="A01")
+        a["_filename"] = "A01.json"
+        b["_filename"] = "A01b.json"
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(
+                tmp,
+                "p1",
+                [a, b],
+                refs={"A01.json": _ref("A01"), "A01b.json": _ref("A01")},
+            )
+            report = mod.audit(tmp)
+        self.assertIn(mod.CODE_DUPLICATE_TASK_ID, codes_of(report, "p1"))
+
+    def test_issues_are_grouped_per_pack(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "alpha", [_task("A01", instructions="짧다")])
+            _write_pack(tmp, "beta", [_task("B01")])
+            report = mod.audit(tmp)
+        by_id = {p["id"]: p for p in report["packs"]}
+        self.assertGreater(by_id["alpha"]["issueCount"], 0)
+        self.assertEqual(by_id["beta"]["issueCount"], 0)
+        self.assertEqual(report["packCount"], 2)
+
+    def test_pack_filter(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "alpha", [_task("A01", instructions="짧다")])
+            _write_pack(tmp, "beta", [_task("B01", instructions="짧다")])
+            report = mod.audit(tmp, pack_ids=["beta"])
+        self.assertEqual(report["packCount"], 1)
+        self.assertEqual(report["packs"][0]["id"], "beta")
+
+    def test_unknown_pack_id_is_reported(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task()])
+            report = mod.audit(tmp, pack_ids=["nope"])
+        self.assertIn(mod.CODE_MISSING_PACK, codes_of(report, "nope"))
+
+
+class RenderAndCliTests(unittest.TestCase):
+    def test_human_render_lists_pack_and_code(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions="짧다")])
+            text = mod.render_report(mod.audit(tmp))
+        self.assertIn("이슈", text)
+        self.assertIn("short_instructions", text)
+        self.assertIn("p1/A01", text)
+
+    def test_clean_render(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task()])
+            text = mod.render_report(mod.audit(tmp))
+        self.assertIn("이슈 0", text)
+
+    def test_cli_json_default_exit_zero(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions="짧다")])
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                code = mod.main(["--root", tmp, "--json"])
+            payload = json.loads(buf.getvalue())
+        self.assertEqual(code, 0)
+        self.assertEqual(payload["kind"], "gymPackHealth")
+        self.assertFalse(payload["ok"])
+
+    def test_cli_strict_exits_one(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task(instructions="짧다")])
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                code = mod.main(["--root", tmp, "--strict"])
+        self.assertEqual(code, 1)
+        self.assertIn("short_instructions", buf.getvalue())
+
+    def test_cli_strict_clean_is_zero(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_pack(tmp, "p1", [_task()])
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                code = mod.main(["--root", tmp, "--strict", "--json"])
+        self.assertEqual(code, 0)
+        self.assertTrue(json.loads(buf.getvalue())["ok"])
+
+    def test_cli_bad_min_instructions(self):
+        mod = load()
+        err = io.StringIO()
+        with redirect_stderr(err):
+            code = mod.main(["--min-instructions", "0"])
+        self.assertEqual(code, 2)
+        self.assertIn("min-instructions", err.getvalue())
+
+
+class RealRepoTests(unittest.TestCase):
+    def test_real_gym_scan_does_not_crash(self):
+        """현재 트리 스캔은 예외 없이 봉투를 낸다. 이슈가 있어도 기본 종료는 0."""
+        mod = load()
+        report = mod.audit(str(REPO_ROOT / "gym"))
+        self.assertEqual(report["kind"], "gymPackHealth")
+        self.assertEqual(report["schemaVersion"], "1.0")
+        self.assertGreaterEqual(report["packCount"], 10)
+        self.assertGreaterEqual(report["taskCount"], 40)
+        self.assertIn("packs", report)
+        self.assertEqual(mod.exit_status(report, strict=False), 0)
+        # --json 자기시험: 현재 트리가 깨끗하지 않아도 도구는 관측만 한다.
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            code = mod.main(["--root", str(REPO_ROOT / "gym"), "--json"])
+        self.assertEqual(code, 0)
+        again = json.loads(buf.getvalue())
+        self.assertEqual(again["kind"], "gymPackHealth")
+        self.assertEqual(again["packCount"], report["packCount"])
+
+
+class UtilityTests(unittest.TestCase):
+    def test_instruction_length_strips(self):
+        mod = load()
+        self.assertEqual(mod.instruction_length("  열글자입니다  "), 6)
+
+    def test_has_whitespace_helpers(self):
+        mod = load()
+        self.assertTrue(mod.has_edge_whitespace(" A01"))
+        self.assertTrue(mod.has_any_whitespace("A 01"))
+        self.assertFalse(mod.has_any_whitespace("A01"))
+        self.assertFalse(mod.has_edge_whitespace("쪽수 세기"))
+
+    def test_fragment_placeholder_is_not_answer(self):
+        mod = load()
+        self.assertFalse(mod.fragment_looks_like_answer({"pages": "<수>"}))
+        self.assertFalse(mod.fragment_looks_like_answer({"<필드이름>": "홍길동"}))
+        self.assertTrue(mod.fragment_looks_like_answer({"pages": 4}))
+        self.assertTrue(mod.is_placeholder_value("{input}"))
+
+    def test_token_appears_bare_ignores_command_suffix(self):
+        mod = load()
+        self.assertFalse(mod.token_appears_bare("rhwp export-hwpx conv.hwpx", "hwpx"))
+        self.assertTrue(mod.token_appears_bare("형식은 hwpx 다", "hwpx"))
+        self.assertTrue(mod.token_appears_bare("셀에 계획실행을 넣으면", "계획실행"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 요약

`audit.py` 는 스키마·기준풀이 짝만 본다. 지시문이 비거나 검사 이름이 겹치거나 힌트가 답을 직접 적어도 통과한다. 운동장 품질이 조용히 내려간다.

이 PR 은 `gym/tools/pack_health.py` 를 추가한다. `gym/packs` 를 바이너리 없이 읽어 과제 지시·검사 이름·힌트·제출 형식의 건강을 pack 별로 보고한다. 새 rhwp CLI 는 만들지 않았고, 기존 pack·README·profiles·checks·coverage·robustness 는 건드리지 않았다.

## 관련 이슈

closes #5215

## 동작

- 봉투: `kind=gymPackHealth`, `schemaVersion=1.0`
- 검사: 빈/짧은 instructions(< 20글자), 누락·중복 `check.name`, 과제 id/title 공백, reference 는 있는데 steps 가 빔, 미지 `submit.kind`
- 힌트 건강: 정답 JSON 덤프, `답은 N`, 본문에 없는 검사 기대값 복붙. CLI 문법 예시(`{"<필드이름>": "홍길동"}`, `export-hwpx`)는 오탐으로 치지 않는다
- CLI: `--json` · `--strict` · `--pack` · `--root` · `--min-instructions`
- 종료 코드: 기본은 리포트만 내고 0. `--strict` 만 이슈 시 1. packs/ 자체를 못 읽으면 1

## 테스트

- [x] `python -m unittest scripts/tests/test_gym_pack_health.py` — 53건 통과 (빈/짧은 지시, 중복·누락 이름, id/title 공백, 빈 steps, 미지 submit.kind, 힌트 유출, 기본 종료 0 / --strict 1 픽스처)
- [x] `python gym/tools/audit.py` — 18 pack 전부 통과, 위반 0
- [x] `python gym/tools/pack_health.py` — 현재 트리 18 pack · 112 과제, 이슈 0
- Python gym 도구만 추가한다. sparse checkout 이라 `cargo fmt --all` 은 실행하지 않았다.

## 성능 영향

영향 없음. 새 Python 파일 검사이며 기본 채점 경로에 연결하지 않는다.
