### PR TITLE
gym: differential 순수 시험·보고 강화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -953,6 +953,7 @@ jobs:
           python3 -m unittest scripts/tests/test_gym_fuzz_corpus.py
           python3 -m unittest scripts/tests/test_gym_release_diff.py
           python3 -m unittest scripts/tests/test_gym_discriminate.py
+          python3 -m unittest scripts/tests/test_gym_differential.py
 
       # [#4855] 경쟁 벤치 하네스 순수 로직 가드 — 집계·능력 매트릭스·리포트 렌더·정직한
       # 저하(못 돌린 도구는 'n/a: 이유', 숫자 날조 금지)를 바이너리·외부도구 없이 검증한다.

--- a/gym/docs/differential.md
+++ b/gym/docs/differential.md
@@ -1,0 +1,501 @@
+---
+kind: guide
+status: active
+canonical: gym/docs/differential.md
+last_verified: 2026-08-18
+---
+
+# gym 교차형식 차등 규약
+
+이 문서는 `gym/tools/differential.py` 의 **오검출 관문**, **짝짓기**, **본문
+해시**, **관측 kind**, **예외 경로 계약**을 고정한다. 작업 기록은
+[`mydocs/working/gym_differential.md`](../../mydocs/working/gym_differential.md)
+를 본다. 시험 계약은 `scripts/tests/test_gym_differential.py` 가 기계로 고정한다.
+
+릴리스 차등(`release_diff.py`)은 같은 원리를 **시간축**(구/신 바이너리)으로
+돌린다. 이 문서가 다루는 것은 형식축 — 같은 문서의 HWP 판과 HWPX 판이다.
+두 도구의 분류 삼원을 섞지 말라. 이쪽의 심각도는 `contradiction` /
+`review` / `other-doc` 이고, 저쪽의 분류는 `stable` / `regression` /
+`surface-changed` 다.
+
+## 1. 왜 이 기둥이 필요한가
+
+운동장 채점기는 정답을 골든으로 박제하지 않고, 채점 시점에 rhwp 로 다시
+계산한다. 그러니 같은 문서의 두 형식에 같은 관측을 물리면 답이 같아야 한다.
+갈리면 둘 중 하나의 읽기 경로가 틀린 것이다. 기대값을 아무도 적어두지 않은
+자리까지 훑는 차등 테스트가 공짜로 생긴다.
+
+저장소에 쌍둥이 픽스처가 139쌍 있다. 관측 6종이면 즉시 834건의 판정이 된다.
+다만 이름이 같다고 같은 문서라는 보장은 없다. 개정판을 각각 저장한 쌍이
+있다. 관문이 없으면 도구가 거짓말을 한다.
+
+이 도구는 "무엇이 갈렸나" 를 가리키지 "어느 형식이 옳은가" 를 판정하지
+않는다. 한컴 정답지가 없다. 판정은 사람이 한다.
+
+## 2. 사용
+
+```bash
+python gym/tools/differential.py
+python gym/tools/differential.py --limit 20
+python gym/tools/differential.py --bin target/debug/rhwp -o gym/differential-report.json
+python gym/tools/differential.py --cli-timeout 30
+```
+
+| 인자 | 기본 | 의미 |
+|---|---|---|
+| `--limit` | `0` | 검사할 쌍 수. `0` 이하면 전부. 접두는 정렬된 입력의 앞부분이라 결정적이다. |
+| `--bin` | `runner.find_bin` | rhwp 바이너리. 상대경로는 러너가 절대화한다. |
+| `-o` / `--out` | `gym/differential-report.json` | JSON 보고 경로. UTF-8 · BOM 없음 · LF. |
+| `--cli-timeout` | `0` | 관측 CLI 초. `0` 이하는 무제한(기존 동작). |
+
+프로브 명령은 없다. 관측 명령은 아래 표의 여섯 줄이다. 본문 해시는
+`export-text --json`, IR 동일성은 `ir-diff --json` 이다.
+
+## 3. 오검출 관문 — 정직 조항
+
+`classify_pair(body_same, ir_identical, diverged)` 는 네 칸만 낸다.
+
+| 관측이 갈렸나 | 본문 해시가 같나 | IR 동일인가 | 라벨 | findings 에 넣나 |
+|---|---|---|---|---|
+| 아니오 | * | * | `None` | 아니오 |
+| 예 | 아니오 | * | `other-doc` | 아니오 |
+| 예 | 예 | 아니오 | `review` | 예 |
+| 예 | 예 | 예 | `contradiction` | 예 |
+
+규칙:
+
+1. **갈림이 없으면 침묵.** 본문·IR 을 보지도 않는다. 같은 관측은 결함이
+   아니다.
+2. **본문 해시가 다르면 다른 문서다.** 이름이 같아도 개정판이다. 결함으로
+   부르지 않는다. `sameNameDifferentDocument` 만 올린다.
+3. **본문이 같고 IR 이 다른데 관측이 갈리면 `review`.** rhwp 자신도 구조가
+   다르다고 말한 자리. 사람 판정 몫.
+4. **본문이 같고 IR 이 같은데 관측이 갈리면 `contradiction`.** 내부 모순.
+   우선순위가 높다.
+5. **본문 해시를 못 구하면 동일 문서로 치지 않는다.** `None == None` 은
+   거짓이다. 양쪽 export-text 가 같이 죽어도 `contradiction` 이 아니다.
+6. **IR 을 못 구하면 `identical=False` 다.** 못 본 것을 `contradiction`
+   으로 부르지 않는다. 본문이 같으면 `review`.
+
+`diverged` 인자는 목록·건수·bool 을 모두 받는다. 파이썬 진릿값으로만 본다.
+
+- 거짓으로 접히는 값(`None`, `0`, `""`, `[]`, `{}`, `False`) → 갈림 없음.
+- 그 외(`1`, `[행]`, `"x"`, `True`) → 갈림 있음.
+
+`classify_pair` 는 예외를 관측으로 접지 않는다. 호출자가 해시·IR 을 정직하게
+넣어야 한다.
+
+## 4. 짝짓기 — 결정적 대표 경로
+
+한 줄기에 `.hwp` / `.hwpx` 가 여러 개일 수 있다. `pick_twin_paths` 가
+대표 한 쌍을 고른다. walk 순서에 의존하지 않는다.
+
+1. 경로를 `/` 로 정규화한 뒤 **디렉터리** 를 본다.
+2. 같은 디렉터리에 양쪽이 있으면 그 짝을 쓴다. 그런 디렉터리가 여러 개면
+   디렉터리 경로가 사전순으로 앞선 것.
+3. 같은 디렉터리 짝이 없으면 **얕고 사전순** 인 경로(`path_rank` =
+   `(슬래시 수, 정규화 경로)`).
+4. 한쪽만 있으면 쌍이 아니다. 지어내지 않는다.
+5. 비문자·빈 경로는 순위에서 뺀다. 남는 유효 경로의 순위 규칙은 그대로다.
+
+확장자는 대소문자를 접는다(`.HWP` = `.hwp`). 줄기는 `os.path.splitext` 의
+앞부분이다. `find_twins_in` 은 줄기 사전순, 그다음 hwp 경로, 그다음 hwpx
+경로로 정렬한다.
+
+디렉터리가 없거나 `os.walk` 가 `OSError` 로 죽으면 빈 목록이다. 없는 쌍을
+지어내지 않는다.
+
+`--limit` 는 이 정렬된 목록의 접두다. 음수·변환 불능은 0 과 같다(전부).
+
+## 5. 본문 해시 — 없음은 동일이 아니다
+
+1차 관문은 공백을 무시한 본문의 SHA-256 이다.
+
+| 봉투 | 해시 | `same_body_hash` |
+|---|---|---|
+| `{"pages":[{"text":"가 나"},{"text":"다"}]}` | `hash("가나다")` | 같은 글자면 참 |
+| `{"pages":[{"text":"가나다"}]}` | 위와 같음 | 참 |
+| `{"pages":[]}` | 빈 문자열의 해시 | 빈 본문끼리 참 |
+| `{"pages":None}` / 키 없음 / 비-dict | `None` | 거짓 |
+| export-text 예외 | `None` | 거짓 |
+| 양쪽 다 `None` | — | **거짓** |
+
+규칙:
+
+- `pages_text` 가 `None` 을 내면 해시 함수를 부르지 않는다. 빈 문자열로
+  위장하지 않는다.
+- `normalize_body` 는 `str.split()` 이 지우는 공백(개행·탭·CR)만 접는다.
+  글자·문장부호는 접지 않는다.
+- `hash_text(None)` 은 `None` 이다. 빈 문자열의 해시로 바꾸지 않는다.
+- `same_body_hash(None, None)` 은 거짓이다. 양쪽이 같이 실패한 것을
+  "같은 문서" 로 부르면, 바이너리가 없을 때 전 쌍이 침묵한다.
+
+실측 근거: 표본 25쌍에서 어긋난 2건 중 1건은 본문 해시부터 달랐다. 다른
+개정판이었다. 결함이 아니었다.
+
+## 6. 관측 kind
+
+한 자리의 결과는 판정이 아니라 관측이다. HWP/HWPX 가 같은 kind·같은 값이면
+갈림이 아니다.
+
+| kind | 언제 | 표시 |
+|---|---|---|
+| `value` | JSON 봉투에 키가 있다 | raw 값 |
+| `nojson` | 종료는 됐는데 봉투가 없다 | `exitN` |
+| `badenv` | 봉투가 dict 가 아니다 | `badenv` |
+| `missing` | 봉투에 키가 없다 | `None` |
+| `timeout` | CLI 시간초과 | `timeout` |
+| `missing-bin` | 실행 파일이 없다 | `missing-bin` |
+| `permission` | 실행 권한이 없다 | `permission` |
+| `os-error` | 그 외 OS 오류 | `os-error` |
+| `type-error` | 주입 run 의 형식이 틀렸다 | `type-error` |
+| `value-error` | JSON/값 오류 | `value-error` |
+| `decode-error` | 유니코드 오류 | `decode-error` |
+| `cli-error` | `RuntimeError` | `cli-error` |
+| `unexpected` | 카탈로그 밖 | `unexpected` |
+
+`observation_from_result` 는 종료 코드를 문자열로 붙이지 않는다. `nojson`
+의 표시 `exit1` 과 값 `"exit1"` 은 다른 관측이다. 시험이 이 충돌을 고정한다.
+
+같은 오류가 양쪽 에 나면 갈림이 아니다. 한쪽만 나면 갈림이다. 그다음 관문이
+본문 해시와 IR 을 본다. 오류 관측이 관문의 순서를 바꾸지 않는다.
+
+## 7. 관측 동일성
+
+`observations_equal` / `_values_equal` 계약:
+
+| 왼쪽 | 오른쪽 | 같은가 | 왜 |
+|---|---|---|---|
+| `6` | `6.0` | 예 | JSON 숫자의 int/float 요동 |
+| `True` | `1` | 아니오 | bool 을 int 로 접지 않는다 |
+| `False` | `0` | 아니오 | 위와 같음 |
+| `{b:1,a:2}` | `{a:2.0,b:1}` | 예 | 키 순서 무관, 숫자 정규화 |
+| `{"kind":"nojson","code":1}` | `{"kind":"value","value":"exit1"}` | 아니오 | 종류가 다르면 표시가 같아도 다르다 |
+| `NaN` | `NaN` | 예 | 둘 다 비숫자. 차등으로 오신고하지 않는다 |
+| `+inf` | `-inf` | 아니오 | 부호가 다른 무한대 |
+| `[1,[2,3.0]]` | `[1.0,[2,3]]` | 예 | 중첩 숫자 정규화 |
+| `b"ab"` | `"ab"` | 아니오 | 바이트와 문자열은 다르다 |
+| `timeout` 관측 | `timeout` 같은 페이로드 | 예 | 같은 실패는 갈림이 아니다 |
+
+## 8. JSON 봉투
+
+`kind=gymDifferential`, `schemaVersion=1.0`. 키 집합은 시험이 `REPORT_KEYS` 로
+고정한다.
+
+| 키 | 형 | 의미 |
+|---|---|---|
+| `kind` | str | 항상 `gymDifferential` |
+| `schemaVersion` | str | 항상 `1.0` |
+| `ok` | bool | `contradictions == 0` 과만 참 |
+| `runner` | obj | `{bin}` |
+| `pairs` | int | 검사한 쌍 수 |
+| `observationsCompared` | int | 관측 대조 건수 |
+| `sameNameDifferentDocument` | int | 본문 해시가 달라 제외한 쌍 |
+| `findings` | list | `review` / `contradiction` 만. 줄기 순 |
+| `contradictions` | int | `severity==contradiction` 집계 |
+| `reviews` | int | `severity==review` 집계 |
+| `exit` | int | 0 / 1 / 3 |
+| `toolFailed` | bool | 도구 자리 오류가 있나 |
+
+부가 키:
+
+| 키 | 언제 |
+|---|---|
+| `toolErrors` | find-bin / walk / compare 실패. 심각도를 뒤집지 않는다 |
+| `pairErrors` | 한 쌍 루프의 예외. 그 쌍만 건너뜀 |
+| `writeError` | JSON 쓰기 실패. 종료 코드는 이미 계산한 상태를 따른다 |
+
+`validate_report` 가 정직 계약을 검사한다.
+
+- `ok` 는 `contradictions==0` 과만 같다.
+- `contradictions` / `reviews` 는 findings 의 severity 집계와 같다.
+- `contradiction` 행은 `irIdentical` 이 참이어야 한다.
+- `review` 행은 `irIdentical` 이 거짓이어야 한다.
+- `other-doc` 은 findings 에 없다.
+- `toolFailed` 가 참이면 `exit` 는 1. 그래도 심각도 집계는 뒤집지 않는다.
+- finding 의 `diverged` 는 비면 안 된다.
+
+## 9. 예외 경로 — 도구가 죽지 않는 자리
+
+감사기(이 차등 도구) 자신은 한 쌍의 CLI 예외로 멈추지 않는다. 없는
+바이너리, 권한, 시간초과, 깨진 stdout, walk 실패는 관측/오류 목록으로
+남기고 다음으로 간다.
+
+| 자리 | 잡는 것 | 접는 곳 |
+|---|---|---|
+| `run_cli` | timeout · missing-bin · permission · OSError · decode | 관측 |
+| `observe_with_run` | 주입 run 의 예외·형식 오류 | 관측 |
+| `body_hash` / `body_hash_with_run` | 위 | `None` 해시. 동일 문서 아님 |
+| `ir_identity_with_run` | 위 | `(False, None)`. contradiction 금지 |
+| `find_twins_in` | 디렉터리 부재 · walk OSError | 빈 목록 |
+| `find_bin` | OSError | 경로 유지 + toolErrors |
+| `write_report` | OSError | `writeError` |
+| 한 쌍 루프 | 그 외 예외 | `pairErrors`. 그 쌍만 건너뜀 |
+
+한 쌍을 못 봐도 다른 쌍은 계속 비교한다. 쌍 오류는 심각도 집계를 뒤집지
+않는다. 비교한 쌍만으로 모순/리뷰를 센다.
+
+`KeyboardInterrupt` · `SystemExit` · `MemoryError` · `GeneratorExit` 는
+삼키지 않는다. 사용자가 끊었는데 모순 0건이라고 쓰면 거짓말이다.
+
+## 10. 종료 코드
+
+| exit | 의미 |
+|---|---|
+| 0 | 모순 없음 (`ok`) 그리고 도구 실패 없음 |
+| 1 | 도구 실패 (`toolFailed`). 모순 집계는 봉투에 남긴다 |
+| 3 | IR 동일 모순 (`contradictions ≥ 1`) |
+
+도구 실패가 모순보다 앞선다. 바이너리를 못 찾았는데 exit 0 을 내면, 못 본
+것을 본 척하는 것이다. contradiction 이 있어도 도구 실패면 1 이다. 모순
+목록은 그대로 남긴다.
+
+`ok` 의 뜻은 바뀌지 않는다. `ok` 는 여전히 `contradictions==0` 이다.
+리뷰만 있는 보고는 `ok=true`, exit 0 이다. 리뷰는 사람 몫이지 자동 차단이
+아니다.
+
+쓰기 실패는 예외로 도구를 죽이지 않고 `writeError` 에 남긴다. 종료 코드는
+이미 계산한 상태를 따른다. 디스크가 가득 찼다고 모순을 없던 일로 바꾸지
+않는다.
+
+## 11. 보고 쓰기 형식
+
+`write_report` 는 UTF-8, BOM 없음, LF, 마지막 개행 하나, `ensure_ascii=False`,
+`indent=2` 다. 같은 입력이면 바이트가 같다. 시험이 BOM/`\r\n` 부재를 고정한다.
+
+## 12. 오검출 관문 요약
+
+도구가 거짓말하지 않도록 지키는 문:
+
+1. **이름이 같다고 같은 문서가 아니다.** 본문 해시가 1차 관문이다.
+2. **해시 부재는 동일 문서가 아니다.** `None==None` 을 참으로 부르지 않는다.
+3. **IR 을 못 보면 contradiction 이 아니다.**
+4. **같은 오류 양쪽은 갈림이 아니다.** 한쪽만 오류면 갈림이고, 그다음
+   관문이 본문·IR 을 본다.
+5. **한 쌍의 예외는 전수 스윕을 죽이지 않는다.** 그 쌍만 건너뛴다.
+6. **치명 예외는 삼키지 않는다.**
+7. **짝짓기는 walk 순서에 의존하지 않는다.** 같은 디렉터리, 그다음 얕고
+   사전순.
+
+## 13. 시험이 고정하는 것
+
+`python -m unittest scripts.tests.test_gym_differential`
+
+바이너리 없이 돈다. `run` · `subprocess.run` · `find_bin` 을 목으로
+갈아끼운다.
+
+고정하는 축:
+
+- 짝짓기 표(같은 디렉터리 우선, 역순 입력 동일).
+- 본문 해시 표(공백 접힘, 글자 불변, `None==None` 거짓).
+- 관문 진릿값 표.
+- 관측 동일성(숫자·bool·kind·NaN·중첩).
+- 예외 kind 카탈로그와 치명 예외 표지.
+- `compare_twins` 가 CLI 예외를 관측으로 접음.
+- IR 예외 → review. 해시 예외 → other-doc.
+- `validate_report` 정직 계약.
+- `main` 의 exit 0/1/3.
+
+## 14. 이 도구가 하지 않는 것
+
+- 한컴 문서가 맞는지 틀리는지 말하지 않는다.
+- 어느 형식이 "더 옳은지" 고르지 않는다.
+- 이름만 같은 다른 문서를 결함으로 부르지 않는다.
+- 본문 해시를 못 구했는데 내부 모순이라고 하지 않는다.
+- IR 을 못 구했는데 내부 모순이라고 하지 않는다.
+- 치명 예외를 삼켜 성공인 척하지 않는다.
+- 짝짓기 순위를 walk 순서나 파일 시각으로 바꾸지 않는다.
+- 공백 이외의 글자를 정규화하지 않는다.
+
+## 15. 관련 기둥
+
+| 기둥 | 도구 | 질문 |
+|---|---|---|
+| 교차형식 차등 | `differential.py` | 같은 문서의 두 형식이 같은 관측을 내나? |
+| 릴리스 차등 | `release_diff.py` | 두 바이너리가 같은 관측을 내나? |
+| 종점 무결성 | `discriminate.py` | 일 안 한 제출이 만점을 받나? |
+| 경로 무결성 | `trajectory.py` | 마지막 스텝을 빼도 통과하나? |
+| 도구 강건성 | `robustness.py` | 손상 입력에 rhwp 가 패닉·행 하나? |
+
+교차형식 차등은 오라클이다. 골든 파일이 없다. 오라클이 해시를 못 봤는데
+모순이라고 쓰면 사람 시간이 샌다. 그래서 `None` 해시는 `other-doc` 이다.
+
+## 16. 봉투 표본
+
+아래는 시험이 조립하는 최소 표본이다. 필드의 참/거짓이 집계와 어긋나면
+`validate_report` 가 거부한다.
+
+### 16.1 침묵 (갈림 없음)
+
+```json
+{
+  "kind": "gymDifferential",
+  "schemaVersion": "1.0",
+  "ok": true,
+  "runner": {"bin": "rhwp"},
+  "pairs": 4,
+  "observationsCompared": 24,
+  "sameNameDifferentDocument": 0,
+  "findings": [],
+  "contradictions": 0,
+  "reviews": 0,
+  "exit": 0,
+  "toolFailed": false
+}
+```
+
+관측이 같으면 본문 해시와 IR 을 보지 않는다. findings 는 비어 있다.
+
+### 16.2 이름만 같은 다른 문서
+
+관측은 갈렸지만 본문 해시가 다르다. findings 에 넣지 않는다.
+`sameNameDifferentDocument` 만 1 올린다. `ok` 는 참이다.
+
+### 16.3 review
+
+```json
+{
+  "ok": true,
+  "contradictions": 0,
+  "reviews": 1,
+  "findings": [
+    {
+      "stem": "doc",
+      "hwp": "doc.hwp",
+      "hwpx": "doc.hwpx",
+      "irIdentical": false,
+      "irDiffCount": 4,
+      "severity": "review",
+      "diverged": [
+        {
+          "observation": "pageCount",
+          "hwp": {"kind": "value", "value": 6},
+          "hwpx": {"kind": "value", "value": 7}
+        }
+      ]
+    }
+  ]
+}
+```
+
+본문은 같은데 IR 이 다르고 쪽수가 갈렸다. 사람 판정 몫. 자동 차단이 아니다.
+
+### 16.4 contradiction
+
+```json
+{
+  "ok": false,
+  "exit": 3,
+  "contradictions": 1,
+  "reviews": 0,
+  "findings": [
+    {
+      "stem": "doc",
+      "irIdentical": true,
+      "irDiffCount": 0,
+      "severity": "contradiction",
+      "diverged": [
+        {
+          "observation": "pageCount",
+          "hwp": {"kind": "value", "value": 6},
+          "hwpx": {"kind": "value", "value": 7}
+        }
+      ]
+    }
+  ]
+}
+```
+
+rhwp 가 "구조는 같다" 고 말한 뒤에도 쪽수가 다르다. 내부 모순이다.
+
+### 16.5 도구 실패
+
+```json
+{
+  "ok": true,
+  "exit": 1,
+  "toolFailed": true,
+  "contradictions": 0,
+  "findings": [],
+  "toolErrors": [
+    {
+      "where": "find-bin",
+      "kind": "os-error",
+      "error": "OSError",
+      "head": "..."
+    }
+  ]
+}
+```
+
+바이너리를 못 찾았을 때 `ok=true` · exit 0 이라고 쓰면, 못 본 것을 본
+척하는 것이다. `ok` 는 모순 0건이라는 뜻으로 남기고, exit 1 이 도구
+실패를 가린다. findings 를 지어내지 않는다.
+
+## 17. 한 쌍의 예외가 관문을 바꾸지 않는 예
+
+같은 줄기, 같은 관측 한 줄.
+
+| HWP 관측 | HWPX 관측 | 본문 해시 | IR | 결과 |
+|---|---|---|---|---|
+| value 6 | value 6 | (보지 않음) | (보지 않음) | 침묵 |
+| value 6 | value 7 | 다름 | (보지 않음) | other-doc |
+| value 6 | value 7 | 같음 | identical=false | review |
+| value 6 | value 7 | 같음 | identical=true | contradiction |
+| timeout | timeout (같은 페이로드) | (보지 않음) | (보지 않음) | 침묵 |
+| timeout | value 6 | 둘 다 None | (보지 않음) | other-doc |
+| timeout | value 6 | 같음 | 예외 | review |
+| timeout | value 6 | 같음 | identical=true | contradiction |
+| missing-bin | missing-bin | (보지 않음) | (보지 않음) | 침묵 |
+| value 6 | permission | 같음 | identical=true | contradiction |
+
+오류 관측은 값을 대신할 뿐, 오검출 관문의 순서를 바꾸지 않는다. 해시 부재를
+`identical=true` 로 건너뛰지 않는다.
+
+## 18. 짝짓기 표
+
+`pick_twin_paths(hwps, hwpxs)` 의 결정 표. 입력을 뒤집어도 같다.
+
+| hwps | hwpxs | 결과 | 왜 |
+|---|---|---|---|
+| `a.hwp` | `a.hwpx` | 그 쌍 | 유일 |
+| `b/a.hwp`, `a.hwp` | `a.hwpx` | `a.hwp` + `a.hwpx` | 같은 디렉터리(루트) |
+| `b/a.hwp` | `a.hwpx`, `b/a.hwpx` | `b/a.hwp` + `b/a.hwpx` | 같은 디렉터리 `b` |
+| `z/a.hwp`, `a/a.hwp` | 양쪽 hwpx | `a/a.*` | 같은 디렉터리 중 사전순 |
+| `deep/n/x.hwp`, `x.hwp` | `other/x.hwpx` | `x.hwp` + `other/x.hwpx` | 같은 폴더 짝 없음, 얕은 쪽 |
+| `aa/z.hwp`, `sub/z.hwp` | `sub/z.hwpx` | `sub/z.*` | 같은 폴더 짝이 sub 에만 |
+| `[]` | `a.hwpx` | `None` | 한쪽 없음. 지어내지 않음 |
+
+이 표를 바꾸면 139쌍의 대표가 흔들린다. 시험이 표와 역순 입력을 같이
+고정한다.
+
+## 19. 관측 여섯 줄
+
+기본 관측은 코드의 `OBSERVATIONS` 다. 시험이 이름 목록을 고정한다.
+
+| 이름 | 명령 | 봉투 키 |
+|---|---|---|
+| `pageCount` | `info {f} --json` | `pageCount` |
+| `tableCount` | `export-tables {f} --json` | `tableCount` |
+| `paragraphCount` | `explain {f} --json` | `paragraphCount` |
+| `fieldCount` | `fields {f} --json` | `fieldCount` |
+| `footnoteCount` | `explain {f} --json` | `footnoteCount` |
+| `endnoteCount` | `explain {f} --json` | `endnoteCount` |
+
+`{f}` 는 그 형식의 상대 경로로 바뀐다. 관측을 더 얹으면 판정이 139×N 으로
+는다. 관문을 건너뛰면 안 된다.
+
+## 20. 치명 예외
+
+다음 네 값은 관측으로 접지 않는다. 도구를 죽이는 것이 정직하다.
+
+- `KeyboardInterrupt`
+- `SystemExit`
+- `MemoryError`
+- `GeneratorExit`
+
+`run_cli_safe` · `observe_with_run` · `compare_twins` · `write_report_safe` ·
+`find_bin_safe` · `find_twins_safe` · `main` 이 모두 다시 올린다.
+
+사용자가 Ctrl+C 를 눌렀는데 "쌍둥이 0쌍 · 결함 후보 0건" 이라고 쓰면,
+못 끝낸 스윕을 끝낸 척하는 것이다.

--- a/gym/tools/differential.py
+++ b/gym/tools/differential.py
@@ -32,6 +32,20 @@ rhwp 로 재계산**한다. 이 성질에는 아직 쓰지 않은 쓸모가 하�
 보고 봉투: `kind=gymDifferential`, `schemaVersion=1.0`. 판정·집계·보고는 순수
 함수라 `scripts/tests/test_gym_differential.py` 가 바이너리 없이 고정한다.
 
+## 예외 경로 (도구가 한 쌍의 CLI 실패로 죽지 않도록)
+
+CLI 부재·권한·시간초과·디코드 실패는 관측 kind 로 접는다. 한 쌍의 예외가
+전수 스윕을 멈추게 하지 않는다. 다만 접는 자리에서도 **짝짓기·해시 정직
+조항은 그대로**다.
+
+- 본문 해시를 예외로 못 구하면 `None` 이다. `None == None` 을 동일 문서로
+  부르지 않는다.
+- `ir-diff` 가 예외로 죽으면 `identical=False` 다. IR 을 못 봤는데
+  `contradiction` 이라고 부르지 않는다.
+- 치명 예외(`KeyboardInterrupt` · `SystemExit` · `MemoryError` ·
+  `GeneratorExit`)는 삼키지 않는다. 사용자가 끊었는데 모순 0건이라고 쓰면
+  거짓말이다.
+
 사용:
   python gym/tools/differential.py [--limit N] [--bin <경로>] [-o 결과.json]
 """
@@ -72,20 +86,318 @@ OBSERVATIONS = [
     ("endnoteCount", ["explain", "{f}", "--json"], "endnoteCount"),
 ]
 
+#: 관측 kind 카탈로그. 시험과 문서가 같은 표를 본다.
+OBSERVATION_KINDS = (
+    "value",
+    "nojson",
+    "badenv",
+    "missing",
+    "timeout",
+    "missing-bin",
+    "permission",
+    "os-error",
+    "type-error",
+    "value-error",
+    "decode-error",
+    "cli-error",
+    "unexpected",
+)
 
-def run_cli(bin_path, args):
-    proc = subprocess.run([bin_path] + args, cwd=ROOT, capture_output=True)
+#: JSON 보고 고정 키. 분류가 성공한 봉투의 최소 집합.
+REPORT_KEYS = (
+    "kind",
+    "schemaVersion",
+    "ok",
+    "runner",
+    "pairs",
+    "observationsCompared",
+    "sameNameDifferentDocument",
+    "findings",
+    "contradictions",
+    "reviews",
+)
+
+#: 부가 키. 있어도 짝짓기·해시·심각도를 뒤집지 않는다.
+OPTIONAL_REPORT_KEYS = (
+    "toolFailed",
+    "toolErrors",
+    "pairErrors",
+    "writeError",
+    "exit",
+)
+
+#: 결함 후보의 심각도. other-doc 은 여기에 없다 — 그건 결함이 아니다.
+SEVERITIES = ("contradiction", "review")
+
+#: 관문이 내는 라벨. None 은 갈림 없음.
+GATE_LABELS = (None, "other-doc", "contradiction", "review")
+
+#: 종료 코드. 0=모순 없음, 1=도구 실패, 3=IR 동일 모순.
+EXIT_OK = 0
+EXIT_TOOL_FAILED = 1
+EXIT_CONTRADICTION = 3
+
+#: 관측 head / 오류 메시지 머리 길이.
+HEAD_LIMIT = 80
+ERROR_HEAD_LIMIT = 160
+
+#: CLI 기본 초. 0 이하는 시간제한 없음(기존 동작).
+CLI_TIMEOUT_DEFAULT = 0
+
+#: 예외 → 관측 kind. context 가 cli/hash/ir 이면 FileNotFound 는 missing-bin.
+EXCEPTION_KIND_BY_TYPE = {
+    FileNotFoundError: "missing-bin",
+    PermissionError: "permission",
+    TimeoutError: "timeout",
+    subprocess.TimeoutExpired: "timeout",
+    UnicodeError: "decode-error",
+    UnicodeDecodeError: "decode-error",
+    UnicodeEncodeError: "decode-error",
+    ValueError: "value-error",
+    TypeError: "type-error",
+    KeyError: "value-error",
+    IndexError: "value-error",
+    AttributeError: "type-error",
+    OSError: "os-error",
+}
+
+#: 삼키면 안 되는 예외 — 도구를 죽이는 것이 정직하다.
+FATAL_EXCEPTIONS = (KeyboardInterrupt, SystemExit, MemoryError, GeneratorExit)
+
+#: 관측/프로브에서 잡는 예외. BaseException 전부가 아니다.
+CATCHABLE_EXCEPTIONS = (
+    FileNotFoundError,
+    PermissionError,
+    TimeoutError,
+    subprocess.TimeoutExpired,
+    UnicodeError,
+    ValueError,
+    TypeError,
+    KeyError,
+    IndexError,
+    AttributeError,
+    OSError,
+    json.JSONDecodeError,
+    RuntimeError,
+)
+
+
+def is_fatal_exception(exc):
+    """도구를 접으면 안 되는 치명 예외인가. 순수."""
+    return isinstance(exc, FATAL_EXCEPTIONS)
+
+
+def exception_kind(exc, context="cli"):
+    """예외를 관측 kind 로 접는다. 순수.
+
+    context:
+      - cli: run_cli 실패. FileNotFound → missing-bin.
+      - hash: export-text 본문 해시. 같은 FileNotFound → missing-bin.
+      - ir: ir-diff 실패. 같은 FileNotFound → missing-bin.
+      - pair: 한 쌍 루프의 그 외 예외.
+      - write / walk / find-bin: 도구 자리. 분류를 바꾸지 않는다.
+    """
+    if exc is None:
+        return "unexpected"
+    if isinstance(exc, subprocess.TimeoutExpired) or isinstance(exc, TimeoutError):
+        return "timeout"
+    if isinstance(exc, FileNotFoundError):
+        return "missing-bin"
+    if isinstance(exc, PermissionError):
+        return "permission"
+    if isinstance(exc, UnicodeError):
+        return "decode-error"
+    if isinstance(exc, json.JSONDecodeError):
+        return "value-error"
+    if isinstance(exc, AttributeError):
+        return "type-error"
+    if isinstance(exc, TypeError):
+        return "type-error"
+    if isinstance(exc, (KeyError, IndexError)):
+        return "value-error"
+    if isinstance(exc, ValueError):
+        return "value-error"
+    if isinstance(exc, OSError):
+        return "os-error"
+    if isinstance(exc, RuntimeError):
+        return "cli-error"
+    return "unexpected"
+
+
+def exception_observation(exc, context="cli", head=""):
+    """예외를 관측 봉투로 접는다. 여기서 예외를 다시 올리지 않는다."""
+    kind = exception_kind(exc, context=context)
+    return {
+        "kind": kind,
+        "error": type(exc).__name__ if exc is not None else "NoneType",
+        "head": truncate_head(head or (str(exc) if exc is not None else ""), ERROR_HEAD_LIMIT),
+    }
+
+
+def exception_tool_error(exc, where, extra=None):
+    """도구 자리 오류 한 줄. 심각도·짝짓기를 바꾸지 않는다."""
+    row = {
+        "where": where,
+        "kind": exception_kind(exc, context=where),
+        "error": type(exc).__name__ if exc is not None else "NoneType",
+        "head": truncate_head(str(exc) if exc is not None else "", ERROR_HEAD_LIMIT),
+    }
+    if extra:
+        row.update(extra)
+    return row
+
+
+def truncate_head(text, limit=HEAD_LIMIT):
+    """출력 머리. None/비문자는 빈 문자열. 한도는 0 이하면 빈 값."""
+    if text is None:
+        return ""
+    if not isinstance(text, str):
+        try:
+            text = str(text)
+        except Exception:
+            return ""
     try:
-        return proc.returncode, json.loads(proc.stdout.decode("utf-8"))
+        n = int(limit)
+    except (TypeError, ValueError):
+        n = HEAD_LIMIT
+    if n <= 0:
+        return ""
+    return text[:n]
+
+
+def normalize_timeout(timeout):
+    """CLI 초. 변환 불능·비양수는 0 — 호출 측에서 시간제한을 끈다."""
+    try:
+        n = int(timeout)
+    except (TypeError, ValueError):
+        return 0
+    return n if n > 0 else 0
+
+
+def normalize_limit(limit):
+    """--limit. 변환 불능·음수는 0(전부). 순수."""
+    try:
+        n = int(limit)
+    except (TypeError, ValueError):
+        return 0
+    return n if n > 0 else 0
+
+
+def observation_kind_of(obs):
+    """관측 봉투의 kind. 형식이 아니면 None."""
+    if isinstance(obs, dict):
+        kind = obs.get("kind")
+        if isinstance(kind, str) and kind:
+            return kind
+    return None
+
+
+def is_known_observation_kind(kind):
+    return kind in OBSERVATION_KINDS
+
+
+def is_error_observation(obs):
+    """값 관측이 아닌 실패/부재 관측인가. 관문을 바꾸지 않는다 — 대조 대상일 뿐이다."""
+    kind = observation_kind_of(obs)
+    if kind is None:
+        return False
+    return kind != "value"
+
+
+def is_sha256_hex(value):
+    """64자 소문자/숫자 hex 인가. 순수. None/짧은 값은 거짓."""
+    if not isinstance(value, str) or len(value) != 64:
+        return False
+    try:
+        int(value, 16)
+    except ValueError:
+        return False
+    return value == value.lower()
+
+
+def decode_cli_stdout(raw):
+    """subprocess stdout 을 텍스트로. 바이트가 아니면 빈 문자열로 위장하지 않는다."""
+    if raw is None:
+        return ""
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, memoryview):
+        raw = raw.tobytes()
+    if isinstance(raw, bytearray):
+        raw = bytes(raw)
+    if not isinstance(raw, bytes):
+        raise TypeError(f"decode_cli_stdout 는 bytes/str 만 받습니다 (got {type(raw).__name__})")
+    return raw.decode("utf-8")
+
+
+def loads_cli_json(text):
+    """CLI stdout JSON. 비면 None. JSON 이 아니면 ValueError 를 올린다."""
+    if text is None:
+        return None
+    if not isinstance(text, str):
+        raise TypeError(f"loads_cli_json 는 str 만 받습니다 (got {type(text).__name__})")
+    stripped = text.strip()
+    if not stripped:
+        return None
+    return json.loads(stripped)
+
+
+def coerce_run_result(result):
+    """주입 run() 의 반환을 (code, env) 로. 형식이 아니면 TypeError.
+
+    compare_twins 가 목 run 을 받을 때의 계약. 예외를 여기서 삼키지 않는다.
+    """
+    if result is None:
+        raise TypeError("run() 이 None 을 반환했다")
+    if not isinstance(result, (tuple, list)) or len(result) < 2:
+        raise TypeError("run() 은 (code, env) 를 반환해야 한다")
+    return result[0], result[1]
+
+
+def run_cli(bin_path, args, timeout=None):
+    """rhwp 실행 → (exit, 봉투 json 또는 None).
+
+    timeout 이 양수면 subprocess 에 넘긴다. 예외는 여기서 삼키지 않는다 —
+    호출자가 run_cli_safe 로 접는다. JSON 이 아니면 env=None (기존 계약).
+    """
+    if not bin_path:
+        raise FileNotFoundError("바이너리 경로가 비어 있다")
+    kwargs = {"cwd": ROOT, "capture_output": True}
+    limit = normalize_timeout(timeout) if timeout is not None else 0
+    if limit:
+        kwargs["timeout"] = limit
+    proc = subprocess.run([bin_path] + list(args), **kwargs)
+    try:
+        text = decode_cli_stdout(proc.stdout)
+        return proc.returncode, loads_cli_json(text)
     except ValueError:
         return proc.returncode, None
+
+
+def run_cli_safe(bin_path, args, timeout=None):
+    """run_cli 를 예외 없이 접는다.
+
+    성공: (code, env) — env 는 dict 또는 None.
+    실패: (None, exception_observation). code 가 None 이면 실행 자체가 안 된 것.
+    """
+    try:
+        return run_cli(bin_path, args, timeout=timeout)
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return None, exception_observation(exc, context="cli")
+    except Exception as exc:
+        return None, exception_observation(exc, context="cli")
 
 
 def observation_from_result(code, env, key):
     """CLI 결과에서 대조 가능한 관측을 뽑는다. 순수.
 
     종료 코드를 문자열로 붙이면 실제 값과 충돌하므로 kind 로 가른다.
+    env 가 이미 예외 관측(kind+error)이면 그대로 돌려 한 겹 더 씌우지 않는다.
     """
+    if isinstance(env, dict) and env.get("kind") in OBSERVATION_KINDS and env.get("kind") != "value" and "error" in env:
+        return env
     if env is None:
         return {"kind": "nojson", "code": code}
     if not isinstance(env, dict):
@@ -106,10 +418,18 @@ def _values_equal(left, right):
     if isinstance(left, bool) or isinstance(right, bool):
         return isinstance(left, bool) and isinstance(right, bool) and left is right
     if isinstance(left, (int, float)) and isinstance(right, (int, float)):
+        # NaN 은 자기 자신과도 같지 않다. 차등으로 오신고하지 않도록 둘 다 NaN 이면 같다.
+        if isinstance(left, float) and isinstance(right, float):
+            if left != left and right != right:
+                return True
         return float(left) == float(right)
     if isinstance(left, str) and isinstance(right, str):
         return left == right
     if isinstance(left, list) and isinstance(right, list):
+        return len(left) == len(right) and all(
+            _values_equal(a, b) for a, b in zip(left, right)
+        )
+    if isinstance(left, tuple) and isinstance(right, tuple):
         return len(left) == len(right) and all(
             _values_equal(a, b) for a, b in zip(left, right)
         )
@@ -151,10 +471,22 @@ def pages_text(env):
 
 def normalize_body(text):
     """공백(개행·탭 포함)을 무시하는 본문."""
+    if text is None:
+        return None
+    if not isinstance(text, str):
+        try:
+            text = str(text)
+        except Exception:
+            return None
     return "".join(text.split())
 
 
 def hash_text(text):
+    """UTF-8 SHA-256 16진. text 가 None 이면 None — 빈 문자열로 위장하지 않는다."""
+    if text is None:
+        return None
+    if not isinstance(text, str):
+        raise TypeError(f"hash_text 는 str 만 받습니다 (got {type(text).__name__})")
     return hashlib.sha256(text.encode("utf-8", "replace")).hexdigest()
 
 
@@ -167,6 +499,7 @@ def body_hash_from_env(env):
 
 
 def same_body_hash(left, right):
+    """양쪽이 모두 재진 해시이고 같을 때만 참. None==None 은 거짓."""
     return left is not None and right is not None and left == right
 
 
@@ -178,7 +511,12 @@ def ir_identity(env):
 
 
 def classify_pair(body_same, ir_identical, diverged):
-    """관측이 갈린 쌍의 심각도. 갈림 없으면 None, 다른 문서면 other-doc."""
+    """관측이 갈린 쌍의 심각도. 갈림 없으면 None, 다른 문서면 other-doc.
+
+    이 함수는 예외를 관측으로 접지 않는다. 호출자가 본문 해시·IR 을 정직하게
+    넣어야 한다. 해시를 못 구했으면 body_same=False 로 넣을 것.
+    IR 을 못 구했으면 ir_identical=False 로 넣을 것.
+    """
     if not diverged:
         return None
     if not body_same:
@@ -209,10 +547,26 @@ def make_finding(stem, hwp, hwpx, ir_identical, ir_diff_count, diverged):
     }
 
 
+def finding_severity(ir_identical):
+    """IR 동일일 때만 contradiction. IR 을 못 봤으면 review 가 정직하다."""
+    return "contradiction" if ir_identical else "review"
+
+
 def path_rank(rel):
     """같은 줄기에서 대표 경로를 고르는 키 — 얕은 경로, 그다음 사전순."""
+    if not isinstance(rel, str):
+        rel = "" if rel is None else str(rel)
     norm = rel.replace("\\", "/")
     return (norm.count("/"), norm)
+
+
+def _string_paths(items):
+    """짝짓기에 쓸 경로만. 비문자·빈 값은 순위에서 뺀다. 순서는 호출자가 정한다."""
+    out = []
+    for item in items or ():
+        if isinstance(item, str) and item:
+            out.append(item)
+    return out
 
 
 def pick_twin_paths(hwps, hwpxs):
@@ -220,9 +574,11 @@ def pick_twin_paths(hwps, hwpxs):
 
     같은 디렉터리에 양쪽이 있으면 그 짝(디렉터리 경로가 앞선 것)을 쓰고,
     없으면 얕고 사전순인 경로를 고른다. walk 순서에 의존하지 않는다.
+
+    비문자 경로는 순위에서 뺀다. 남는 유효 경로의 순위 규칙은 그대로다.
     """
-    hwps = sorted(hwps, key=path_rank)
-    hwpxs = sorted(hwpxs, key=path_rank)
+    hwps = sorted(_string_paths(hwps), key=path_rank)
+    hwpxs = sorted(_string_paths(hwpxs), key=path_rank)
     if not hwps or not hwpxs:
         return None
     hwp_by_dir = {}
@@ -238,21 +594,53 @@ def pick_twin_paths(hwps, hwpxs):
     return hwps[0], hwpxs[0]
 
 
+def is_dir_safe(path):
+    """os.path.isdir 을 OSError 없이. 예외면 디렉터리가 아니다."""
+    try:
+        return os.path.isdir(path)
+    except OSError:
+        return False
+
+
 def find_twins_in(samples_dir, root=None):
-    """(stem, hwp, hwpx) 목록. 줄기 사전순. 상대경로는 `/` 로 정규화."""
-    if not os.path.isdir(samples_dir):
+    """(stem, hwp, hwpx) 목록. 줄기 사전순. 상대경로는 `/` 로 정규화.
+
+    디렉터리가 없거나 walk 가 OSError 로 죽으면 빈 목록 — 없는 쌍을
+    지어내지 않는다.
+    """
+    if not is_dir_safe(samples_dir):
         return []
     base = samples_dir if root is None else root
     seen = {}
-    for dirpath, dirnames, files in os.walk(samples_dir):
-        dirnames.sort()
-        for name in sorted(files):
-            stem, ext = os.path.splitext(name)
-            ext_l = ext.lower()
-            if ext_l not in TWIN_EXTS:
-                continue
-            rel = os.path.relpath(os.path.join(dirpath, name), base).replace("\\", "/")
-            seen.setdefault(stem, {}).setdefault(ext_l, []).append(rel)
+    try:
+        walker = os.walk(samples_dir)
+    except OSError:
+        return []
+    try:
+        for dirpath, dirnames, files in walker:
+            try:
+                dirnames.sort()
+            except Exception:
+                pass
+            try:
+                names = sorted(files)
+            except Exception:
+                names = list(files)
+            for name in names:
+                try:
+                    stem, ext = os.path.splitext(name)
+                except Exception:
+                    continue
+                ext_l = ext.lower() if isinstance(ext, str) else ""
+                if ext_l not in TWIN_EXTS:
+                    continue
+                try:
+                    rel = os.path.relpath(os.path.join(dirpath, name), base).replace("\\", "/")
+                except (OSError, ValueError, TypeError):
+                    continue
+                seen.setdefault(stem, {}).setdefault(ext_l, []).append(rel)
+    except OSError:
+        return []
     pairs = []
     for stem, by_ext in seen.items():
         picked = pick_twin_paths(by_ext.get(".hwp", []), by_ext.get(".hwpx", []))
@@ -266,61 +654,178 @@ def find_twins():
     return find_twins_in(os.path.join(ROOT, "samples"), root=ROOT)
 
 
+def find_twins_safe(samples_dir=None, root=None):
+    """짝 탐색을 예외 없이 접는다. 실패하면 ([], error)."""
+    try:
+        if samples_dir is None:
+            pairs = find_twins()
+        else:
+            pairs = find_twins_in(samples_dir, root=root)
+        return pairs, None
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return [], exception_tool_error(exc, "walk")
+    except Exception as exc:
+        return [], exception_tool_error(exc, "walk")
+
+
 def select_pairs(pairs, limit):
     """limit<=0 이면 전부. 앞부분은 정렬된 입력의 접두라 결정적이다."""
-    items = list(pairs)
-    if not limit:
+    try:
+        items = list(pairs)
+    except TypeError:
+        return []
+    n = normalize_limit(limit)
+    if not n:
         return items
-    return items[:limit]
+    return items[:n]
 
 
-def observe(bin_path, path, args, key):
-    code, env = run_cli(bin_path, [a.replace("{f}", path) for a in args])
+def observe(bin_path, path, args, key, timeout=None):
+    code, env = run_cli_safe(bin_path, [a.replace("{f}", path) for a in args], timeout=timeout)
     return observation_from_result(code, env, key)
 
 
-def body_hash(bin_path, path):
-    """공백을 무시한 본문의 해시 — 두 파일이 같은 문서인지 가르는 1차 관문."""
-    _code, env = run_cli(bin_path, ["export-text", path, "--json"])
-    return body_hash_from_env(env)
+def observe_with_run(run, path, args, key):
+    """주입 run 으로 한 관측. 예외는 관측으로 접는다. 치명 예외는 올린다."""
+    try:
+        rendered = [a.replace("{f}", path) for a in args]
+        code, env = coerce_run_result(run(rendered))
+        return observation_from_result(code, env, key)
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return exception_observation(exc, context="cli")
+    except Exception as exc:
+        return exception_observation(exc, context="cli")
 
 
-def compare_twins(pairs, run, observations=None):
+def body_hash(bin_path, path, timeout=None):
+    """공백을 무시한 본문의 해시 — 두 파일이 같은 문서인지 가르는 1차 관문.
+
+    CLI 예외는 None. 없음은 동일이 아니다.
+    """
+    try:
+        _code, env = run_cli(bin_path, ["export-text", path, "--json"], timeout=timeout)
+        return body_hash_from_env(env)
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS:
+        return None
+    except Exception:
+        return None
+
+
+def body_hash_with_run(run, path):
+    """주입 run 으로 본문 해시. 예외·형식 오류는 None — 동일 문서로 위장하지 않는다."""
+    try:
+        _code, env = coerce_run_result(run(["export-text", path, "--json"]))
+        return body_hash_from_env(env)
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS:
+        return None
+    except Exception:
+        return None
+
+
+def ir_identity_with_run(run, hwp, hwpx):
+    """주입 run 으로 IR 동일성. 예외면 (False, None) — contradiction 으로 위장하지 않는다."""
+    try:
+        _code, env = coerce_run_result(run(["ir-diff", hwp, hwpx, "--json"]))
+        return ir_identity(env)
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS:
+        return False, None
+    except Exception:
+        return False, None
+
+
+def compare_twins(pairs, run, observations=None, errors_out=None):
     """쌍 목록을 대조한다. 순수 — run(args)->(code, env) 만 주입하면 된다.
 
     반환: (관측대조건수, 이름만같은다른문서, findings)
+
+    한 쌍의 예외는 그 쌍만 건너뛴다. 본문 해시를 못 구하면 other-doc.
+    IR 을 못 구하면 review. contradiction 은 irIdentical=True 일 때만.
     """
+    detailed = compare_twins_detailed(pairs, run, observations=observations)
+    if errors_out is not None:
+        errors_out.extend(detailed["pairErrors"])
+    return detailed["compared"], detailed["other_doc"], detailed["findings"]
+
+
+def compare_twins_detailed(pairs, run, observations=None):
+    """compare_twins 의 상세 봉투. 3튜플 계약을 깨지 않으려고 갈라 둔다."""
     observations = OBSERVATIONS if observations is None else observations
     findings = []
     other_doc = 0
     compared = 0
-    for stem, hwp, hwpx in pairs:
-        observed = []
-        for label, args, key in observations:
-            left = observation_from_result(*run([a.replace("{f}", hwp) for a in args]), key)
-            right = observation_from_result(*run([a.replace("{f}", hwpx) for a in args]), key)
-            compared += 1
-            observed.append((label, left, right))
-        diverged = diverged_rows(observed)
-        if not diverged:
+    pair_errors = []
+    skipped_pairs = 0
+    try:
+        pair_list = list(pairs)
+    except TypeError:
+        return {
+            "compared": 0,
+            "other_doc": 0,
+            "findings": [],
+            "pairErrors": [exception_tool_error(TypeError("pairs"), "pair")],
+            "skippedPairs": 0,
+        }
+    for item in pair_list:
+        try:
+            stem, hwp, hwpx = item
+        except (TypeError, ValueError) as exc:
+            pair_errors.append(exception_tool_error(exc, "pair", extra={"stem": "?"}))
+            skipped_pairs += 1
             continue
-        ha = body_hash_from_env(run(["export-text", hwp, "--json"])[1])
-        hb = body_hash_from_env(run(["export-text", hwpx, "--json"])[1])
-        if not same_body_hash(ha, hb):
-            other_doc += 1
-            continue
-        _code, env = run(["ir-diff", hwp, hwpx, "--json"])
-        identical, diff_count = ir_identity(env)
-        findings.append(make_finding(stem, hwp, hwpx, identical, diff_count, diverged))
+        try:
+            observed = []
+            for label, args, key in observations:
+                left = observe_with_run(run, hwp, args, key)
+                right = observe_with_run(run, hwpx, args, key)
+                compared += 1
+                observed.append((label, left, right))
+            diverged = diverged_rows(observed)
+            if not diverged:
+                continue
+            ha = body_hash_with_run(run, hwp)
+            hb = body_hash_with_run(run, hwpx)
+            if not same_body_hash(ha, hb):
+                other_doc += 1
+                continue
+            identical, diff_count = ir_identity_with_run(run, hwp, hwpx)
+            findings.append(make_finding(stem, hwp, hwpx, identical, diff_count, diverged))
+        except FATAL_EXCEPTIONS:
+            raise
+        except CATCHABLE_EXCEPTIONS as exc:
+            pair_errors.append(exception_tool_error(exc, "pair", extra={"stem": stem}))
+            skipped_pairs += 1
+        except Exception as exc:
+            pair_errors.append(exception_tool_error(exc, "pair", extra={"stem": stem}))
+            skipped_pairs += 1
     findings.sort(key=lambda row: (row["stem"], row["hwp"], row["hwpx"]))
-    return compared, other_doc, findings
+    return {
+        "compared": compared,
+        "other_doc": other_doc,
+        "findings": findings,
+        "pairErrors": pair_errors,
+        "skippedPairs": skipped_pairs,
+    }
 
 
-def build_report(*, bin_name, pairs_count, compared, other_doc, findings):
+def build_report(*, bin_name, pairs_count, compared, other_doc, findings,
+                 tool_errors=None, pair_errors=None, write_error=None):
     ordered = sorted(findings, key=lambda row: (row.get("stem") or "", row.get("hwp") or ""))
     contradictions = sum(1 for row in ordered if row.get("severity") == "contradiction")
     reviews = sum(1 for row in ordered if row.get("severity") == "review")
-    return {
+    tool_errors = list(tool_errors or [])
+    pair_errors = list(pair_errors or [])
+    tool_failed = bool(tool_errors)
+    report = {
         "kind": REPORT_KIND,
         "schemaVersion": SCHEMA_VERSION,
         "ok": contradictions == 0,
@@ -331,13 +836,110 @@ def build_report(*, bin_name, pairs_count, compared, other_doc, findings):
         "findings": ordered,
         "contradictions": contradictions,
         "reviews": reviews,
+        "exit": EXIT_TOOL_FAILED if tool_failed else (EXIT_OK if contradictions == 0 else EXIT_CONTRADICTION),
+        "toolFailed": tool_failed,
     }
+    if tool_errors:
+        report["toolErrors"] = tool_errors
+    if pair_errors:
+        report["pairErrors"] = pair_errors
+    if write_error:
+        report["writeError"] = write_error
+    return report
+
+
+def status_exit(report):
+    """보고 봉투의 종료 코드. 도구 실패가 모순보다 앞선다.
+
+    도구가 죽었는데 모순 0건이라고 exit 0 을 내면, 못 본 것을 본 척하는
+    것이다. contradiction 이 있어도 도구 실패면 1 — 모순 집계는 봉투에
+    그대로 남긴다.
+    """
+    if not isinstance(report, dict):
+        return EXIT_TOOL_FAILED
+    if report.get("toolFailed"):
+        return EXIT_TOOL_FAILED
+    if report.get("ok"):
+        return EXIT_OK
+    return EXIT_CONTRADICTION
+
+
+def validate_report(report):
+    """보고 봉투의 정직 계약. 문제 문자열 목록(비면 통과).
+
+    - kind / schemaVersion 고정.
+    - ok 는 contradictions==0 과만 같다.
+    - contradictions / reviews 는 findings 의 severity 집계와 같다.
+    - contradiction 행은 irIdentical 이 참이어야 한다.
+    - review 행은 irIdentical 이 거짓이어야 한다.
+    - other-doc 은 findings 에 없다.
+    - toolFailed 가 참이면 exit 는 1. 그래도 심각도 집계는 뒤집지 않는다.
+    """
+    issues = []
+    if not isinstance(report, dict):
+        return ["report 가 dict 가 아니다"]
+    for key in REPORT_KEYS:
+        if key not in report:
+            issues.append(f"키 없음: {key}")
+    if report.get("kind") != REPORT_KIND:
+        issues.append(f"kind 가 {REPORT_KIND} 가 아니다")
+    if report.get("schemaVersion") != SCHEMA_VERSION:
+        issues.append(f"schemaVersion 이 {SCHEMA_VERSION} 이 아니다")
+    findings = report.get("findings")
+    if not isinstance(findings, list):
+        issues.append("findings 가 list 가 아니다")
+        findings = []
+    contradictions = sum(1 for row in findings if isinstance(row, dict) and row.get("severity") == "contradiction")
+    reviews = sum(1 for row in findings if isinstance(row, dict) and row.get("severity") == "review")
+    if report.get("contradictions") != contradictions:
+        issues.append("contradictions 가 findings 집계와 다르다")
+    if report.get("reviews") != reviews:
+        issues.append("reviews 가 findings 집계와 다르다")
+    if report.get("ok") != (contradictions == 0):
+        issues.append("ok 는 contradictions==0 과만 같아야 한다")
+    for row in findings:
+        if not isinstance(row, dict):
+            issues.append("finding 이 dict 가 아니다")
+            continue
+        sev = row.get("severity")
+        if sev == "other-doc":
+            issues.append("other-doc 을 finding 으로 부르면 안 된다")
+        if sev == "contradiction" and not row.get("irIdentical"):
+            issues.append(f"{row.get('stem')}: contradiction 인데 irIdentical 이 거짓이다")
+        if sev == "review" and row.get("irIdentical"):
+            issues.append(f"{row.get('stem')}: review 인데 irIdentical 이 참이다")
+        if sev not in SEVERITIES and sev is not None:
+            issues.append(f"{row.get('stem')}: 알 수 없는 severity {sev!r}")
+        diverged = row.get("diverged")
+        if not isinstance(diverged, list) or not diverged:
+            issues.append(f"{row.get('stem')}: finding 에 diverged 가 비어 있다")
+    if report.get("toolFailed"):
+        if report.get("exit") != EXIT_TOOL_FAILED:
+            issues.append("toolFailed 의 exit 는 1 이어야 한다")
+    else:
+        expected = EXIT_OK if contradictions == 0 else EXIT_CONTRADICTION
+        if report.get("exit") not in (None, expected):
+            issues.append("exit 가 ok/contradictions 계약과 다르다")
+    return issues
 
 
 def write_report(report, path):
     with io.open(path, "w", encoding="utf-8", newline="\n") as fh:
         fh.write(json.dumps(report, ensure_ascii=False, indent=2))
         fh.write("\n")
+
+
+def write_report_safe(report, path):
+    """쓰기 예외를 접는다. 성공이면 None, 실패면 오류 문자열."""
+    try:
+        write_report(report, path)
+        return None
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return f"write_report: {type(exc).__name__}: {truncate_head(str(exc), ERROR_HEAD_LIMIT)}"
+    except Exception as exc:
+        return f"write_report: {type(exc).__name__}: {truncate_head(str(exc), ERROR_HEAD_LIMIT)}"
 
 
 def format_finding_detail(finding):
@@ -349,45 +951,124 @@ def format_finding_detail(finding):
 
 def render_summary(report, out_path=None):
     lines = [
-        f"쌍둥이 {report['pairs']}쌍 · 관측 대조 {report['observationsCompared']}건",
-        f"이름만 같은 다른 문서(제외): {report['sameNameDifferentDocument']}쌍",
-        f"결함 후보: {len(report['findings'])}건 (그중 IR 동일 모순 {report['contradictions']}건)",
+        f"쌍둥이 {report.get('pairs', 0)}쌍 · 관측 대조 {report.get('observationsCompared', 0)}건",
+        f"이름만 같은 다른 문서(제외): {report.get('sameNameDifferentDocument', 0)}쌍",
+        f"결함 후보: {len(report.get('findings') or [])}건 (그중 IR 동일 모순 {report.get('contradictions', 0)}건)",
     ]
-    for finding in report["findings"]:
-        mark = "!!" if finding["severity"] == "contradiction" else "  "
+    if report.get("toolFailed"):
+        lines.append("도구 실패 → 분류를 위장하지 않음 (exit 1)")
+        for err in report.get("toolErrors") or []:
+            lines.append(
+                f"  도구[{err.get('where')}]: {err.get('kind')} · {err.get('error')}"
+            )
+    for finding in report.get("findings") or []:
+        mark = "!!" if finding.get("severity") == "contradiction" else "  "
         lines.append(
-            f" {mark} {finding['stem'][:46]:48} irIdentical={finding['irIdentical']} | "
+            f" {mark} {str(finding.get('stem') or '')[:46]:48} irIdentical={finding.get('irIdentical')} | "
             f"{format_finding_detail(finding)}"
         )
+    if report.get("pairErrors"):
+        for err in report["pairErrors"][:10]:
+            lines.append(f"  쌍 오류: {err.get('stem', '?')} · {err.get('kind')} · {err.get('error')}")
+    if report.get("writeError"):
+        lines.append(f"  쓰기 오류: {report['writeError']}")
     if out_path:
         lines.append(f"→ {out_path}")
     return lines
 
 
-def main():
+def find_bin_safe(path):
+    """runner.find_bin 을 예외 없이 접는다."""
+    try:
+        found = runner.find_bin(path)
+        return found, None
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        return path, exception_tool_error(exc, "find-bin")
+    except Exception as exc:
+        return path, exception_tool_error(exc, "find-bin")
+
+
+def parse_args(argv=None):
     ap = argparse.ArgumentParser()
     ap.add_argument("--limit", type=int, default=0, help="검사할 쌍 수 (0=전부)")
     ap.add_argument("--bin", default=None)
     ap.add_argument("-o", "--out", default=None)
-    a = ap.parse_args()
-
-    bin_path = runner.find_bin(a.bin)
-    pairs = select_pairs(find_twins(), a.limit)
-    compared, other_doc, findings = compare_twins(
-        pairs, lambda args: run_cli(bin_path, args)
+    ap.add_argument(
+        "--cli-timeout",
+        type=int,
+        default=CLI_TIMEOUT_DEFAULT,
+        help="관측 CLI 초(기본 0=무제한)",
     )
+    return ap.parse_args(argv)
+
+
+def default_out_path():
+    return os.path.join(runner.GYM, "differential-report.json")
+
+
+def attach_write_error(report, write_err):
+    """쓰기 오류를 보고에 붙인다. 심각도 집계는 바꾸지 않는다."""
+    if write_err:
+        report["writeError"] = write_err
+    return report
+
+
+def main(argv=None):
+    try:
+        a = parse_args(argv)
+    except FATAL_EXCEPTIONS:
+        raise
+    except SystemExit:
+        raise
+    except Exception:
+        return EXIT_TOOL_FAILED
+
+    tool_errors = []
+    bin_path, find_err = find_bin_safe(a.bin)
+    if find_err:
+        tool_errors.append(find_err)
+
+    pairs, walk_err = find_twins_safe()
+    if walk_err:
+        tool_errors.append(walk_err)
+    pairs = select_pairs(pairs, a.limit)
+
+    timeout = normalize_timeout(getattr(a, "cli_timeout", CLI_TIMEOUT_DEFAULT)) or None
+
+    def run(args):
+        return run_cli(bin_path, args, timeout=timeout)
+
+    pair_errors = []
+    try:
+        compared, other_doc, findings = compare_twins(
+            pairs, run, errors_out=pair_errors
+        )
+    except FATAL_EXCEPTIONS:
+        raise
+    except CATCHABLE_EXCEPTIONS as exc:
+        tool_errors.append(exception_tool_error(exc, "compare"))
+        compared, other_doc, findings = 0, 0, []
+    except Exception as exc:
+        tool_errors.append(exception_tool_error(exc, "compare"))
+        compared, other_doc, findings = 0, 0, []
+
     report = build_report(
-        bin_name=os.path.basename(bin_path),
+        bin_name=os.path.basename(bin_path) if bin_path else "",
         pairs_count=len(pairs),
         compared=compared,
         other_doc=other_doc,
         findings=findings,
+        tool_errors=tool_errors,
+        pair_errors=pair_errors,
     )
-    out = a.out or os.path.join(runner.GYM, "differential-report.json")
-    write_report(report, out)
+    out = a.out or default_out_path()
+    write_err = write_report_safe(report, out)
+    attach_write_error(report, write_err)
     for line in render_summary(report, out):
         print(line)
-    return 0 if report["ok"] else 3
+    return status_exit(report)
 
 
 if __name__ == "__main__":

--- a/gym/tools/differential.py
+++ b/gym/tools/differential.py
@@ -20,7 +20,7 @@ rhwp 로 재계산**한다. 이 성질에는 아직 쓰지 않은 쓸모가 하�
 통과시킨다.
 
 1. **본문 동일성** — 공백을 무시한 본문이 바이트로 같아야 한다. 다르면 그냥
-   다른 문서다(결함 아님).
+   다른 문서다(결함 아님). 본문 해시를 못 구하면 동일 문서로 치지 않는다.
 2. **IR 동일성** — `ir-diff` 가 `identical: true` 를 내야 한다. rhwp 자신이
    "두 문서의 구조는 같다" 고 말한 뒤에도 관측이 어긋난다면, 그것은 **내부
    모순**이고 결함 후보다.
@@ -29,9 +29,14 @@ rhwp 로 재계산**한다. 이 성질에는 아직 쓰지 않은 쓸모가 하�
 달랐다(다른 개정판 — 결함 아님), 나머지 1건은 IR 동일 판정에도 쪽수가 달랐다
 (진짜 후보).
 
+보고 봉투: `kind=gymDifferential`, `schemaVersion=1.0`. 판정·집계·보고는 순수
+함수라 `scripts/tests/test_gym_differential.py` 가 바이너리 없이 고정한다.
+
 사용:
   python gym/tools/differential.py [--limit N] [--bin <경로>] [-o 결과.json]
 """
+
+from __future__ import annotations
 
 import argparse
 import hashlib
@@ -53,6 +58,10 @@ from gym.core import runner  # noqa: E402
 
 ROOT = runner.ROOT
 
+REPORT_KIND = "gymDifferential"
+SCHEMA_VERSION = "1.0"
+TWIN_EXTS = (".hwp", ".hwpx")
+
 #: 두 형식에서 같아야 하는 관측. (이름, 인자 템플릿, 봉투 경로)
 OBSERVATIONS = [
     ("pageCount", ["info", "{f}", "--json"], "pageCount"),
@@ -72,33 +81,287 @@ def run_cli(bin_path, args):
         return proc.returncode, None
 
 
+def observation_from_result(code, env, key):
+    """CLI 결과에서 대조 가능한 관측을 뽑는다. 순수.
+
+    종료 코드를 문자열로 붙이면 실제 값과 충돌하므로 kind 로 가른다.
+    """
+    if env is None:
+        return {"kind": "nojson", "code": code}
+    if not isinstance(env, dict):
+        return {"kind": "badenv", "code": code}
+    if key not in env:
+        return {"kind": "missing", "key": key}
+    return {"kind": "value", "value": env[key]}
+
+
+def observations_equal(left, right):
+    """관측 동일성. 숫자 6 과 6.0 은 같고, bool 은 int 로 접히지 않는다."""
+    return _values_equal(left, right)
+
+
+def _values_equal(left, right):
+    if left is right:
+        return True
+    if isinstance(left, bool) or isinstance(right, bool):
+        return isinstance(left, bool) and isinstance(right, bool) and left is right
+    if isinstance(left, (int, float)) and isinstance(right, (int, float)):
+        return float(left) == float(right)
+    if isinstance(left, str) and isinstance(right, str):
+        return left == right
+    if isinstance(left, list) and isinstance(right, list):
+        return len(left) == len(right) and all(
+            _values_equal(a, b) for a, b in zip(left, right)
+        )
+    if isinstance(left, dict) and isinstance(right, dict):
+        if set(left) != set(right):
+            return False
+        return all(_values_equal(left[k], right[k]) for k in left)
+    return left == right
+
+
+def observation_display(obs):
+    """사람이 읽는 한 칸. 값 관측은 raw, 실패는 exitN."""
+    if isinstance(obs, dict):
+        kind = obs.get("kind")
+        if kind == "value":
+            return obs.get("value")
+        if kind == "nojson":
+            return f"exit{obs.get('code')}"
+        if kind == "missing":
+            return None
+        if kind:
+            return kind
+    return obs
+
+
+def pages_text(env):
+    """export-text 봉투에서 쪽 본문을 이어 붙인다. 봉투가 아니면 None."""
+    if not isinstance(env, dict):
+        return None
+    pages = env.get("pages")
+    if not isinstance(pages, list):
+        return None
+    parts = []
+    for page in pages:
+        if isinstance(page, dict):
+            parts.append(page.get("text") or "")
+    return "".join(parts)
+
+
+def normalize_body(text):
+    """공백(개행·탭 포함)을 무시하는 본문."""
+    return "".join(text.split())
+
+
+def hash_text(text):
+    return hashlib.sha256(text.encode("utf-8", "replace")).hexdigest()
+
+
+def body_hash_from_env(env):
+    """공백 무시 본문 해시. 봉투가 아니면 None — 없음은 동일이 아니다."""
+    text = pages_text(env)
+    if text is None:
+        return None
+    return hash_text(normalize_body(text))
+
+
+def same_body_hash(left, right):
+    return left is not None and right is not None and left == right
+
+
+def ir_identity(env):
+    """(identical, diffCount). 봉투가 없으면 identical=False."""
+    if not isinstance(env, dict):
+        return False, None
+    return bool(env.get("identical")), env.get("diffCount")
+
+
+def classify_pair(body_same, ir_identical, diverged):
+    """관측이 갈린 쌍의 심각도. 갈림 없으면 None, 다른 문서면 other-doc."""
+    if not diverged:
+        return None
+    if not body_same:
+        return "other-doc"
+    return "contradiction" if ir_identical else "review"
+
+
+def diverged_rows(observed):
+    """(label, hwp, hwpx) 목록에서 어긋난 행만, 관측 이름 순."""
+    rows = [
+        {"observation": label, "hwp": left, "hwpx": right}
+        for label, left, right in observed
+        if not observations_equal(left, right)
+    ]
+    rows.sort(key=lambda row: row["observation"])
+    return rows
+
+
+def make_finding(stem, hwp, hwpx, ir_identical, ir_diff_count, diverged):
+    return {
+        "stem": stem,
+        "hwp": hwp,
+        "hwpx": hwpx,
+        "irIdentical": ir_identical,
+        "irDiffCount": ir_diff_count,
+        "diverged": list(diverged),
+        "severity": "contradiction" if ir_identical else "review",
+    }
+
+
+def path_rank(rel):
+    """같은 줄기에서 대표 경로를 고르는 키 — 얕은 경로, 그다음 사전순."""
+    norm = rel.replace("\\", "/")
+    return (norm.count("/"), norm)
+
+
+def pick_twin_paths(hwps, hwpxs):
+    """한 줄기에 파일이 여러 개일 때 대표 HWP/HWPX 를 결정적으로 고른다.
+
+    같은 디렉터리에 양쪽이 있으면 그 짝(디렉터리 경로가 앞선 것)을 쓰고,
+    없으면 얕고 사전순인 경로를 고른다. walk 순서에 의존하지 않는다.
+    """
+    hwps = sorted(hwps, key=path_rank)
+    hwpxs = sorted(hwpxs, key=path_rank)
+    if not hwps or not hwpxs:
+        return None
+    hwp_by_dir = {}
+    for path in hwps:
+        hwp_by_dir.setdefault(os.path.dirname(path.replace("\\", "/")), path)
+    hwpx_by_dir = {}
+    for path in hwpxs:
+        hwpx_by_dir.setdefault(os.path.dirname(path.replace("\\", "/")), path)
+    local = sorted(set(hwp_by_dir) & set(hwpx_by_dir))
+    if local:
+        directory = local[0]
+        return hwp_by_dir[directory], hwpx_by_dir[directory]
+    return hwps[0], hwpxs[0]
+
+
+def find_twins_in(samples_dir, root=None):
+    """(stem, hwp, hwpx) 목록. 줄기 사전순. 상대경로는 `/` 로 정규화."""
+    if not os.path.isdir(samples_dir):
+        return []
+    base = samples_dir if root is None else root
+    seen = {}
+    for dirpath, dirnames, files in os.walk(samples_dir):
+        dirnames.sort()
+        for name in sorted(files):
+            stem, ext = os.path.splitext(name)
+            ext_l = ext.lower()
+            if ext_l not in TWIN_EXTS:
+                continue
+            rel = os.path.relpath(os.path.join(dirpath, name), base).replace("\\", "/")
+            seen.setdefault(stem, {}).setdefault(ext_l, []).append(rel)
+    pairs = []
+    for stem, by_ext in seen.items():
+        picked = pick_twin_paths(by_ext.get(".hwp", []), by_ext.get(".hwpx", []))
+        if picked:
+            pairs.append((stem, picked[0], picked[1]))
+    pairs.sort(key=lambda item: (item[0], item[1], item[2]))
+    return pairs
+
+
+def find_twins():
+    return find_twins_in(os.path.join(ROOT, "samples"), root=ROOT)
+
+
+def select_pairs(pairs, limit):
+    """limit<=0 이면 전부. 앞부분은 정렬된 입력의 접두라 결정적이다."""
+    items = list(pairs)
+    if not limit:
+        return items
+    return items[:limit]
+
+
 def observe(bin_path, path, args, key):
     code, env = run_cli(bin_path, [a.replace("{f}", path) for a in args])
-    if env is None:
-        return f"exit{code}"
-    return env.get(key)
+    return observation_from_result(code, env, key)
 
 
 def body_hash(bin_path, path):
     """공백을 무시한 본문의 해시 — 두 파일이 같은 문서인지 가르는 1차 관문."""
     _code, env = run_cli(bin_path, ["export-text", path, "--json"])
-    if env is None:
-        return None
-    text = "".join(p.get("text", "") for p in env.get("pages", []))
-    norm = "".join(text.split())
-    return hashlib.sha256(norm.encode("utf-8", "replace")).hexdigest()
+    return body_hash_from_env(env)
 
 
-def find_twins():
-    seen = {}
-    for root, _dirs, files in os.walk(os.path.join(ROOT, "samples")):
-        for name in files:
-            stem, ext = os.path.splitext(name)
-            if ext.lower() in (".hwp", ".hwpx"):
-                rel = os.path.relpath(os.path.join(root, name), ROOT).replace("\\", "/")
-                seen.setdefault(stem, {})[ext.lower()] = rel
-    return sorted((k, v[".hwp"], v[".hwpx"]) for k, v in seen.items()
-                  if ".hwp" in v and ".hwpx" in v)
+def compare_twins(pairs, run, observations=None):
+    """쌍 목록을 대조한다. 순수 — run(args)->(code, env) 만 주입하면 된다.
+
+    반환: (관측대조건수, 이름만같은다른문서, findings)
+    """
+    observations = OBSERVATIONS if observations is None else observations
+    findings = []
+    other_doc = 0
+    compared = 0
+    for stem, hwp, hwpx in pairs:
+        observed = []
+        for label, args, key in observations:
+            left = observation_from_result(*run([a.replace("{f}", hwp) for a in args]), key)
+            right = observation_from_result(*run([a.replace("{f}", hwpx) for a in args]), key)
+            compared += 1
+            observed.append((label, left, right))
+        diverged = diverged_rows(observed)
+        if not diverged:
+            continue
+        ha = body_hash_from_env(run(["export-text", hwp, "--json"])[1])
+        hb = body_hash_from_env(run(["export-text", hwpx, "--json"])[1])
+        if not same_body_hash(ha, hb):
+            other_doc += 1
+            continue
+        _code, env = run(["ir-diff", hwp, hwpx, "--json"])
+        identical, diff_count = ir_identity(env)
+        findings.append(make_finding(stem, hwp, hwpx, identical, diff_count, diverged))
+    findings.sort(key=lambda row: (row["stem"], row["hwp"], row["hwpx"]))
+    return compared, other_doc, findings
+
+
+def build_report(*, bin_name, pairs_count, compared, other_doc, findings):
+    ordered = sorted(findings, key=lambda row: (row.get("stem") or "", row.get("hwp") or ""))
+    contradictions = sum(1 for row in ordered if row.get("severity") == "contradiction")
+    reviews = sum(1 for row in ordered if row.get("severity") == "review")
+    return {
+        "kind": REPORT_KIND,
+        "schemaVersion": SCHEMA_VERSION,
+        "ok": contradictions == 0,
+        "runner": {"bin": bin_name},
+        "pairs": pairs_count,
+        "observationsCompared": compared,
+        "sameNameDifferentDocument": other_doc,
+        "findings": ordered,
+        "contradictions": contradictions,
+        "reviews": reviews,
+    }
+
+
+def write_report(report, path):
+    with io.open(path, "w", encoding="utf-8", newline="\n") as fh:
+        fh.write(json.dumps(report, ensure_ascii=False, indent=2))
+        fh.write("\n")
+
+
+def format_finding_detail(finding):
+    return ", ".join(
+        f"{row['observation']} {observation_display(row['hwp'])}≠{observation_display(row['hwpx'])}"
+        for row in finding.get("diverged", [])
+    )
+
+
+def render_summary(report, out_path=None):
+    lines = [
+        f"쌍둥이 {report['pairs']}쌍 · 관측 대조 {report['observationsCompared']}건",
+        f"이름만 같은 다른 문서(제외): {report['sameNameDifferentDocument']}쌍",
+        f"결함 후보: {len(report['findings'])}건 (그중 IR 동일 모순 {report['contradictions']}건)",
+    ]
+    for finding in report["findings"]:
+        mark = "!!" if finding["severity"] == "contradiction" else "  "
+        lines.append(
+            f" {mark} {finding['stem'][:46]:48} irIdentical={finding['irIdentical']} | "
+            f"{format_finding_detail(finding)}"
+        )
+    if out_path:
+        lines.append(f"→ {out_path}")
+    return lines
 
 
 def main():
@@ -109,59 +372,22 @@ def main():
     a = ap.parse_args()
 
     bin_path = runner.find_bin(a.bin)
-    pairs = find_twins()
-    if a.limit:
-        pairs = pairs[:a.limit]
-
-    findings, differing_but_other_doc, compared = [], 0, 0
-    for stem, hwp, hwpx in pairs:
-        diverged = []
-        for label, args, key in OBSERVATIONS:
-            va = observe(bin_path, hwp, args, key)
-            vb = observe(bin_path, hwpx, args, key)
-            compared += 1
-            if va != vb:
-                diverged.append({"observation": label, "hwp": va, "hwpx": vb})
-        if not diverged:
-            continue
-        # 관문 1 — 본문이 다르면 애초에 다른 문서다.
-        ha, hb = body_hash(bin_path, hwp), body_hash(bin_path, hwpx)
-        if ha != hb:
-            differing_but_other_doc += 1
-            continue
-        # 관문 2 — rhwp 자신이 IR 동일이라 말했는가.
-        _code, env = run_cli(bin_path, ["ir-diff", hwp, hwpx, "--json"])
-        identical = bool(env and env.get("identical"))
-        findings.append({
-            "stem": stem, "hwp": hwp, "hwpx": hwpx,
-            "irIdentical": identical,
-            "irDiffCount": (env or {}).get("diffCount"),
-            "diverged": diverged,
-            # IR 이 같다고 해놓고 관측이 어긋나면 내부 모순 — 우선순위가 높다.
-            "severity": "contradiction" if identical else "review",
-        })
-
-    report = {
-        "kind": "gymDifferentialReport", "schemaVersion": "1.0",
-        "runner": {"bin": os.path.basename(bin_path)},
-        "pairs": len(pairs), "observationsCompared": compared,
-        "sameNameDifferentDocument": differing_but_other_doc,
-        "findings": findings,
-        "contradictions": sum(1 for f in findings if f["severity"] == "contradiction"),
-    }
+    pairs = select_pairs(find_twins(), a.limit)
+    compared, other_doc, findings = compare_twins(
+        pairs, lambda args: run_cli(bin_path, args)
+    )
+    report = build_report(
+        bin_name=os.path.basename(bin_path),
+        pairs_count=len(pairs),
+        compared=compared,
+        other_doc=other_doc,
+        findings=findings,
+    )
     out = a.out or os.path.join(runner.GYM, "differential-report.json")
-    with io.open(out, "w", encoding="utf-8", newline="\n") as fh:
-        fh.write(json.dumps(report, ensure_ascii=False, indent=2))
-
-    print(f"쌍둥이 {report['pairs']}쌍 · 관측 대조 {compared}건")
-    print(f"이름만 같은 다른 문서(제외): {differing_but_other_doc}쌍")
-    print(f"결함 후보: {len(findings)}건 (그중 IR 동일 모순 {report['contradictions']}건)")
-    for f in findings:
-        mark = "!!" if f["severity"] == "contradiction" else "  "
-        detail = ", ".join(f"{d['observation']} {d['hwp']}≠{d['hwpx']}" for d in f["diverged"])
-        print(f" {mark} {f['stem'][:46]:48} irIdentical={f['irIdentical']} | {detail}")
-    print(f"→ {out}")
-    return 0 if report["contradictions"] == 0 else 3
+    write_report(report, out)
+    for line in render_summary(report, out):
+        print(line)
+    return 0 if report["ok"] else 3
 
 
 if __name__ == "__main__":

--- a/mydocs/working/gym_differential.md
+++ b/mydocs/working/gym_differential.md
@@ -1,0 +1,296 @@
+---
+kind: working
+status: active
+canonical: mydocs/working/gym_differential.md
+last_verified: 2026-08-18
+---
+
+# gym 교차형식 차등 — 예외 경로와 관문 정직성 보강
+
+Issue: #5224
+PR: https://github.com/edwardkim/rhwp/pull/5228
+Branch: `feat/gym-differential-hardening`
+Date: 2026-08-18
+
+## 1. 결론
+
+`gym/tools/differential.py` 의 짝짓기(`pick_twin_paths`)와 본문 해시
+(`same_body_hash` / `body_hash_from_env`)는 그대로 두고, CLI·walk·쓰기
+예외를 관측/오류 목록으로 접도록 닫았다. 해시를 못 구하면 동일 문서로
+치지 않는다. IR 을 못 구하면 `contradiction` 으로 위장하지 않는다.
+
+이 가지는 새 PR 을 열지 않는다. 같은 브랜치에 이어서 밀어 #5228 을 키운다.
+
+검증:
+
+- `python -m unittest scripts.tests.test_gym_differential`
+- `python gym/tools/audit.py`
+- `cargo fmt --all` 은 실행하지 않음 (Python/문서만, 사용자 지시)
+
+## 2. 배경
+
+원 PR(#5228)은 쌍둥이 짝짓기·본문 해시·관측 대조·오검출 관문·
+`gymDifferential` 보고 봉투를 순수 함수로 분리했다. 대비 `upstream/devel`
+삽입은 약 697줄이었다.
+
+그 상태의 빈틈:
+
+1. `run_cli` 가 `subprocess.run` 예외를 그대로 올린다. 없는 바이너리·권한·
+   시간초과가 차등 도구 전체를 죽인다.
+2. `compare_twins` 의 주입 `run` 이 예외를 내면 한 쌍이 아니라 전수 스윕이
+   멈춘다.
+3. `export-text` 가 예외로 죽으면 본문 해시를 못 구하는데, 그 상태를
+   어떻게 부를지 계약이 코드 주석에만 있다. `None==None` 을 참으로 접으면
+   바이너리 부재가 "전 쌍 침묵" 이 된다.
+4. `ir-diff` 가 예외로 죽으면 `identical` 을 못 본다. 그 상태를
+   `contradiction` 으로 부르면 거짓말이다.
+5. `os.walk` / `os.path.isdir` 의 `OSError` 가 짝 탐색을 죽인다.
+6. `write_report` 실패가 도구를 죽인다. 디스크가 가득 찼다고 모순 집계를
+   못 남긴다.
+7. 카탈로그가 코드에만 있어 문서·시험이 같은 표를 공유하지 않는다.
+
+관문 함수 자체를 네 값이 아닌 다섯 값으로 늘리면 기존 게이트 계약
+(`classify_pair` ↔ findings 포함 여부)이 깨진다. 그래서
+`classify_pair` 는 네 칸을 유지하고, 해시/IR 부재는 호출자가 `False` 로
+넣는다.
+
+## 3. 한 일
+
+### 3.1 도구
+
+`gym/tools/differential.py`
+
+- `exception_kind` / `exception_observation` / `exception_tool_error` —
+  예외를 관측/도구 오류 kind 로 접는다. CLI·hash·ir 의 `FileNotFound` 는
+  `missing-bin`.
+- `FATAL_EXCEPTIONS` — `KeyboardInterrupt` · `SystemExit` · `MemoryError` ·
+  `GeneratorExit` 는 삼키지 않는다.
+- `run_cli_safe` / `observe_with_run` — CLI 예외를 관측으로 접는다.
+- `body_hash` / `body_hash_with_run` — 예외면 `None`. `same_body_hash` 는
+  그대로 `None==None` 이 거짓.
+- `ir_identity_with_run` — 예외면 `(False, None)`. `make_finding` 은
+  `irIdentical=False` → `review`.
+- `compare_twins_detailed` — 한 쌍의 예외는 `pairErrors` 로 남기고 그
+  쌍만 건너뛴다. 3튜플 `compare_twins` 계약은 유지.
+- `find_twins_in` — `isdir`/`walk` OSError 는 빈 목록. 없는 쌍을 지어내지
+  않는다.
+- `pick_twin_paths` — 비문자 경로만 순위에서 뺀다. 같은 디렉터리 우선·
+  얕고 사전순 규칙은 그대로다.
+- `write_report_safe` / `find_bin_safe` / `find_twins_safe` — 한 쓰기가
+  전체를 죽이지 않는다.
+- `build_report` — `toolFailed` / `exit` 부가. `ok` 는 여전히
+  `contradictions==0`.
+- `validate_report` — ok/집계/irIdentical/other-doc 정직 계약.
+- `main` — 도구 실패면 exit 1. 모순이면 3. 아니면 0.
+
+### 3.2 시험
+
+`scripts/tests/test_gym_differential.py`
+
+- 기존 순수 시험(`TwinDiscovery` · `BodyHash` · `Observation` ·
+  `Classification` · `CompareTwins` · `Report`) 유지.
+- `ExceptionKindTests` — kind 카탈로그, 치명 예외 표지.
+- `TruncateAndTimeoutHelperTests` — head/timeout/limit/sha256.
+- `ObservationEqualityEdgeTests` — NaN, inf, 중첩, bool, 오류 페이로드.
+- `PairingHonestyTests` — 같은 디렉터리 우선, 역순 입력, walk OSError.
+- `HashHonestyTests` — `None==None` 거짓, 공백 접힘, 글자 불변.
+- `ClassifyHonestyTests` — 해시 부재를 contradiction 으로 부르지 않음.
+- `CompareTwinsExceptionTests` — 같은 오류 양쪽 = 갈림 아님.
+- `IrFailureIsNotContradictionTests` — ir-diff 예외 → review.
+- `MissingHashIsNotContradictionTests` — 해시 예외 → other-doc.
+- `ReportHonestyTests` — `validate_report` 가 ok/ir/other-doc 거짓말을 잡음.
+- `RunCliSafeTests` / `WriteReportSafeTests` / `FindBinAndMainTests`.
+- `GeneratedClassifyTableTests` / `GeneratedPairingTableTests` /
+  `GeneratedEqualityTableTests` / `GeneratedHashTableTests`.
+
+### 3.3 문서
+
+- `gym/docs/differential.md` — 관문 네 칸, 짝짓기, 해시, 관측 kind,
+  JSON 봉투, 예외 자리, 종료 코드, 표본.
+- `mydocs/working/gym_differential.md` — 이 기록.
+
+pack JSON 은 건드리지 않았다.
+
+## 4. 정직 조항 — 바꾸지 않은 것
+
+다음 계약은 원 PR 과 같다. 시험이 다시 고정한다.
+
+```
+classify_pair(갈림 없음, *)            → None
+classify_pair(갈림, body_same=False, *) → other-doc
+classify_pair(갈림, True, ir=True)      → contradiction
+classify_pair(갈림, True, ir=False)     → review
+```
+
+- `same_body_hash(None, None)` 는 거짓
+- `same_body_hash(hash, None)` 는 거짓
+- `body_hash_from_env` 의 공백 무시 SHA-256 은 그대로
+- `pick_twin_paths` 는 같은 디렉터리 우선, 없으면 얕고 사전순
+- 숫자 `6` 과 `6.0` 은 같고, `True` 는 `1` 로 접히지 않는다
+- `ok` 는 `contradictions==0` 과만 참
+- 리뷰만 있으면 `ok=true` (자동 차단 아님)
+- `other-doc` 은 findings 에 넣지 않는다
+- CLI 플래그 `--limit` `--bin` `-o` 는 그대로다 (`--cli-timeout` 만 추가)
+
+`other-doc` 을 `SEVERITIES` 에 넣지 않았다. 넣으면 이름만 같은 다른 문서가
+결함 후보로 집계된다.
+
+## 5. 예외 카탈로그
+
+| context | 예외 | kind |
+|---|---|---|
+| cli / hash / ir | FileNotFoundError | missing-bin |
+| * | PermissionError | permission |
+| * | TimeoutExpired / TimeoutError | timeout |
+| * | UnicodeError | decode-error |
+| * | JSONDecodeError | value-error |
+| * | TypeError | type-error |
+| * | ValueError / KeyError / IndexError | value-error |
+| * | OSError | os-error |
+| * | RuntimeError | cli-error |
+| * | 그 외 | unexpected |
+
+해시 자리의 예외는 관측으로 남기지 않고 `None` 해시로 접는다. 관측
+카탈로그에 `hash-missing` 을 만들지 않은 이유: 기존
+`same_body_hash` / `classify_pair` 가 `None` 만 보면 되기 때문이다. 새
+라벨을 넣으면 관문을 두 번 쓰게 된다.
+
+IR 자리의 예외도 새 라벨이 아니다. `ir_identity` 가 봉투 부재를 이미
+`(False, None)` 으로 접는다. 예외를 그 계약에 맞춘다.
+
+## 6. 보고 상태 표
+
+| 상황 | contradictions | reviews | other-doc 집계 | ok | exit |
+|---|---|---|---|---|---|
+| 갈림 없음 | 0 | 0 | 0 | 참 | 0 |
+| 해시 다름 | 0 | 0 | ≥1 | 참 | 0 |
+| 본문 같음, IR 다름, 갈림 | 0 | ≥1 | 0 | 참 | 0 |
+| 본문 같음, IR 같음, 갈림 | ≥1 | * | 0 | 거짓 | 3 |
+| find-bin/walk 실패 | 0 | 0 | 0 | 참 | 1 |
+| 모순 + 도구 실패 | ≥1 | * | * | 거짓 | 1 |
+
+마지막 두 행을 첫째 행으로 접으면 게이트가 속는다. `ok` 는 모순 유무만
+말하고, exit 1 이 도구 실패를 가린다.
+
+## 7. 검증 명령
+
+저장소 루트에서:
+
+```bash
+python -m unittest scripts.tests.test_gym_differential
+python gym/tools/audit.py
+git diff --shortstat upstream/devel
+```
+
+packs 를 고치지 않았으므로 audit 는 기존처럼 전 pack 통과여야 한다.
+`cargo fmt --all` 은 이번 변경에 해당 없다.
+
+## 8. 의도적으로 하지 않은 것
+
+- pack · reference · profile 편집 없음.
+- `release_diff.py` / `release_gate.py` 편집 없음. 형식축과 시간축을
+  섞지 않는다.
+- `classify_pair` 시그니처·네 칸 의미 변경 없음.
+- `pick_twin_paths` 순위 규칙 변경 없음.
+- `same_body_hash` 의 `None` 계약을 참으로 바꾸지 않음.
+- 무작위·시간·호스트 경로를 관측에 넣지 않음.
+- 새 PR 을 열지 않음. 같은 브랜치에 커밋한다.
+
+## 9. 남은 빈틈
+
+- 라이브 바이너리로 139쌍을 실제로 도는 전수 주행은 이 가지에서 돌리지
+  않았다. 단위 시험은 주입 `run` 으로 관문만 고정한다.
+- `run_cli` 기본 timeout 은 0(무제한)이다. `--cli-timeout` 을 주지 않으면
+  기존처럼 한 문서가 행하면 스윕도 행한다. 그건 호출자 몫이다.
+- `observation_from_result` 가 이미 예외 관측(kind+error)을 보면 그대로
+  통과시킨다. 실제 CLI 봉투가 `kind` 와 `error` 를 동시에 가지는 일은
+  info/explain/fields 계약에 없다.
+
+## 10. 파일 목록
+
+| 경로 | 역할 |
+|---|---|
+| `gym/tools/differential.py` | 교차형식 오라클. 예외 접기 + 관문 정직 |
+| `scripts/tests/test_gym_differential.py` | 바이너리 없는 계약 시험 |
+| `gym/docs/differential.md` | 규약 (정본 표) |
+| `mydocs/working/gym_differential.md` | 작업 기록 (여기) |
+
+## 11. 커밋 메시지 (초안)
+
+```
+test(gym): differential 예외 경로와 관문 정직 시험을 보강한다
+
+CLI/walk/쓰기 예외를 관측·도구 오류로 접고,
+본문 해시 부재와 IR 실패를 contradiction 으로 위장하지 않는다.
+```
+
+## 12. 관문 함수를 읽은 자리
+
+`classify_pair` 본체는 다음 여섯 줄이 전부다. 이 가지가 여기를 다섯 값으로
+늘리지 않았음을 기록으로 남긴다.
+
+```
+if not diverged:
+    return None
+if not body_same:
+    return "other-doc"
+return "contradiction" if ir_identical else "review"
+```
+
+해시를 모르는 입력은 `body_same=False` 로 넣는다. 넣는 순간 `None==None`
+을 참으로 접으면 전 쌍이 침묵한다. IR 을 모르는 입력은
+`ir_identical=False` 로 넣는다. 넣는 순간 못 본 내부 모순이 생긴다.
+둘 다 도구의 거짓말이다.
+
+`same_body_hash` 본체:
+
+```
+return left is not None and right is not None and left == right
+```
+
+이 한 줄을 `left == right` 로 줄이면 `None==None` 이 참이 된다. 시험이
+그 축약을 막는다.
+
+`pick_twin_paths` 본체는 같은 디렉터리 교집합이 있으면 그 중 사전순
+첫째, 없으면 `path_rank` 최소. 비문자 필터만 앞에 붙였다. 유효 경로의
+순위는 원 PR 과 같다.
+
+## 13. 시험 목록 (이 가지에서 늘어난 것)
+
+기존 반: TwinDiscovery / BodyHash / Observation / Classification /
+CompareTwins / Report.
+
+추가 반:
+
+| 클래스 | 고정하는 거짓말 |
+|---|---|
+| ExceptionKindTests | 치명 예외를 관측으로 부르지 않음 |
+| TruncateAndTimeoutHelperTests | 빈 문자열을 해시로 위장하지 않음 |
+| ObservationEqualityEdgeTests | True==1, 바이트==문자열 오신고 금지 |
+| PairingHonestyTests | walk 순서로 대표 경로를 바꾸지 않음 |
+| HashHonestyTests | None==None 을 동일 문서로 부르지 않음 |
+| ClassifyHonestyTests | 해시 부재를 contradiction 으로 부르지 않음 |
+| CompareTwinsExceptionTests | 같은 오류 양쪽 = 갈림 아님 |
+| IrFailureIsNotContradictionTests | ir-diff 예외를 내부 모순으로 부르지 않음 |
+| MissingHashIsNotContradictionTests | 해시 예외를 내부 모순으로 부르지 않음 |
+| ReportHonestyTests | other-doc 을 findings 에 넣지 않음 |
+| WriteReportSafeTests | 쓰기 실패가 ok 를 뒤집지 않음 |
+| RunCliSafeTests | CLI 예외가 도구를 죽이지 않음 |
+| FindBinAndMainTests | main exit 0/1/3 |
+| CatalogContractTests | SEVERITIES 에 other-doc 없음 |
+| Generated*TableTests | 표의 대칭·역순 입력 |
+| RenderSummaryHonestyTests | 도구 실패 요약이 침묵인 척하지 않음 |
+| FindingHonestyScanTests | severity 가 irIdentical 과 묶임 |
+
+## 14. 크기 게이트에 넣는 파일만
+
+packs 와 Rust 는 이 가지의 대상이 아니다. `git add -A` 를 쓰지 않는다.
+추가·수정 파일은 다음 네 개다.
+
+1. `gym/tools/differential.py`
+2. `scripts/tests/test_gym_differential.py`
+3. `gym/docs/differential.md`
+4. `mydocs/working/gym_differential.md`
+
+`.github/workflows/ci.yml` 은 원 PR 이 이미 한 줄 넣었다. 이 가지에서
+다시 건드리지 않는다.

--- a/scripts/tests/test_gym_differential.py
+++ b/scripts/tests/test_gym_differential.py
@@ -1,17 +1,23 @@
-"""[#5224] gym 교차형식 차등 오라클 계약 — 순수 판정·보고.
+"""[#5224/#5228] gym 교차형식 차등 오라클 계약 — 순수 판정·보고·예외.
 
 바이너리 없이 쌍둥이 짝짓기·본문 해시·관측 대조·오검출 관문·보고 봉투를 고정한다.
-CLI run 은 주입해 "관측이 갈렸을 때" 를 합성한다.
+CLI run 은 주입해 "관측이 갈렸을 때" 를 합성한다. 예외 경로는 관측/도구 오류로
+접히되, 짝짓기·해시 정직 조항은 그대로다.
 """
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
+import math
 import os
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TOOL = REPO_ROOT / "gym" / "tools" / "differential.py"
@@ -392,7 +398,1472 @@ class ReportTests(unittest.TestCase):
             loaded = json.loads(raw.decode("utf-8"))
         self.assertEqual(loaded["kind"], "gymDifferential")
         self.assertEqual(loaded["schemaVersion"], "1.0")
-        self.assertEqual(loaded, report)
+        self.assertEqual(loaded["ok"], report["ok"])
+        self.assertEqual(loaded["contradictions"], report["contradictions"])
+        self.assertEqual(loaded["findings"], report["findings"])
+
+
+class ExceptionKindTests(unittest.TestCase):
+    def test_timeout_kinds(self):
+        mod = load()
+        self.assertEqual(mod.exception_kind(TimeoutError("t")), "timeout")
+        self.assertEqual(
+            mod.exception_kind(subprocess.TimeoutExpired(cmd=["rhwp"], timeout=1)),
+            "timeout",
+        )
+
+    def test_file_not_found_is_missing_bin_in_cli_hash_ir(self):
+        mod = load()
+        err = FileNotFoundError("rhwp")
+        for context in ("cli", "hash", "ir", "observe", "pair"):
+            self.assertEqual(mod.exception_kind(err, context=context), "missing-bin", context)
+
+    def test_permission_and_oserror(self):
+        mod = load()
+        self.assertEqual(mod.exception_kind(PermissionError("no")), "permission")
+        self.assertEqual(mod.exception_kind(OSError("io")), "os-error")
+
+    def test_unicode_and_json(self):
+        mod = load()
+        self.assertEqual(
+            mod.exception_kind(UnicodeDecodeError("utf-8", b"\xff", 0, 1, "x")),
+            "decode-error",
+        )
+        self.assertEqual(mod.exception_kind(UnicodeError("u")), "decode-error")
+        self.assertEqual(mod.exception_kind(json.JSONDecodeError("e", "x", 0)), "value-error")
+
+    def test_type_value_runtime_unknown(self):
+        mod = load()
+        self.assertEqual(mod.exception_kind(TypeError("t")), "type-error")
+        self.assertEqual(mod.exception_kind(ValueError("v")), "value-error")
+        self.assertEqual(mod.exception_kind(RuntimeError("r")), "cli-error")
+        self.assertEqual(mod.exception_kind(Exception("e")), "unexpected")
+        self.assertEqual(mod.exception_kind(None), "unexpected")
+
+    def test_fatal_exceptions_are_flagged(self):
+        mod = load()
+        self.assertTrue(mod.is_fatal_exception(KeyboardInterrupt()))
+        self.assertTrue(mod.is_fatal_exception(SystemExit(2)))
+        self.assertTrue(mod.is_fatal_exception(MemoryError()))
+        self.assertTrue(mod.is_fatal_exception(GeneratorExit()))
+        self.assertFalse(mod.is_fatal_exception(OSError("x")))
+        self.assertFalse(mod.is_fatal_exception(ValueError("x")))
+        self.assertFalse(mod.is_fatal_exception(FileNotFoundError("x")))
+
+    def test_exception_observation_shape(self):
+        mod = load()
+        obs = mod.exception_observation(FileNotFoundError("rhwp"), context="cli")
+        self.assertEqual(obs["kind"], "missing-bin")
+        self.assertEqual(obs["error"], "FileNotFoundError")
+        self.assertIn("rhwp", obs["head"])
+
+    def test_exception_tool_error_shape(self):
+        mod = load()
+        row = mod.exception_tool_error(PermissionError("denied"), "write", extra={"path": "out.json"})
+        self.assertEqual(row["where"], "write")
+        self.assertEqual(row["kind"], "permission")
+        self.assertEqual(row["error"], "PermissionError")
+        self.assertEqual(row["path"], "out.json")
+
+    def test_exception_kind_catalog_covers_mapped_types(self):
+        mod = load()
+        for exc_type, kind in mod.EXCEPTION_KIND_BY_TYPE.items():
+            if exc_type is subprocess.TimeoutExpired:
+                exc = subprocess.TimeoutExpired(cmd=["rhwp"], timeout=1)
+            elif exc_type is UnicodeDecodeError:
+                exc = UnicodeDecodeError("utf-8", b"\xff", 0, 1, "x")
+            elif exc_type is UnicodeEncodeError:
+                exc = UnicodeEncodeError("ascii", "한", 0, 1, "x")
+            else:
+                try:
+                    exc = exc_type("x")
+                except Exception:
+                    continue
+            self.assertEqual(mod.exception_kind(exc), kind, exc_type.__name__)
+            self.assertIn(kind, mod.OBSERVATION_KINDS)
+
+
+class TruncateAndTimeoutHelperTests(unittest.TestCase):
+    def test_truncate_head_none_and_limit(self):
+        mod = load()
+        self.assertEqual(mod.truncate_head(None), "")
+        self.assertEqual(mod.truncate_head("abcdef", 3), "abc")
+        self.assertEqual(mod.truncate_head("abcdef", 0), "")
+        self.assertEqual(mod.truncate_head("abcdef", -1), "")
+        self.assertEqual(mod.truncate_head(1234, 2), "12")
+        self.assertEqual(mod.truncate_head("abcdef", "nope"), "abcdef"[:mod.HEAD_LIMIT])
+
+    def test_truncate_head_non_str_that_cannot_str(self):
+        mod = load()
+
+        class Boom:
+            def __str__(self):
+                raise RuntimeError("no")
+
+        self.assertEqual(mod.truncate_head(Boom()), "")
+
+    def test_normalize_timeout(self):
+        mod = load()
+        self.assertEqual(mod.normalize_timeout(30), 30)
+        self.assertEqual(mod.normalize_timeout("15"), 15)
+        self.assertEqual(mod.normalize_timeout(0), 0)
+        self.assertEqual(mod.normalize_timeout(-3), 0)
+        self.assertEqual(mod.normalize_timeout(None), 0)
+        self.assertEqual(mod.normalize_timeout("x"), 0)
+        self.assertEqual(mod.normalize_timeout(1.9), 1)
+
+    def test_normalize_limit(self):
+        mod = load()
+        self.assertEqual(mod.normalize_limit(0), 0)
+        self.assertEqual(mod.normalize_limit(3), 3)
+        self.assertEqual(mod.normalize_limit(-1), 0)
+        self.assertEqual(mod.normalize_limit(None), 0)
+        self.assertEqual(mod.normalize_limit("2"), 2)
+        self.assertEqual(mod.normalize_limit("nope"), 0)
+
+    def test_observation_kind_helpers(self):
+        mod = load()
+        self.assertEqual(mod.observation_kind_of(_value(1)), "value")
+        self.assertEqual(mod.observation_kind_of({"kind": "nojson", "code": 2}), "nojson")
+        self.assertIsNone(mod.observation_kind_of({}))
+        self.assertIsNone(mod.observation_kind_of("x"))
+        self.assertTrue(mod.is_known_observation_kind("value"))
+        self.assertTrue(mod.is_known_observation_kind("timeout"))
+        self.assertFalse(mod.is_known_observation_kind("other-doc"))
+        self.assertFalse(mod.is_error_observation(_value(1)))
+        self.assertTrue(mod.is_error_observation({"kind": "timeout", "error": "TimeoutError"}))
+
+    def test_is_sha256_hex(self):
+        mod = load()
+        good = "a" * 64
+        self.assertTrue(mod.is_sha256_hex(good))
+        self.assertFalse(mod.is_sha256_hex("A" * 64))
+        self.assertFalse(mod.is_sha256_hex("a" * 63))
+        self.assertFalse(mod.is_sha256_hex("g" * 64))
+        self.assertFalse(mod.is_sha256_hex(None))
+        self.assertFalse(mod.is_sha256_hex(1))
+
+    def test_hash_text_rejects_non_str(self):
+        mod = load()
+        self.assertIsNone(mod.hash_text(None))
+        with self.assertRaises(TypeError):
+            mod.hash_text(b"ab")
+        self.assertEqual(
+            mod.hash_text("가"),
+            hashlib.sha256("가".encode("utf-8", "replace")).hexdigest(),
+        )
+
+
+class ObservationEqualityEdgeTests(unittest.TestCase):
+    def test_nan_both_sides_are_equal(self):
+        mod = load()
+        self.assertTrue(mod.observations_equal(float("nan"), float("nan")))
+        self.assertTrue(mod.observations_equal(_value(float("nan")), _value(float("nan"))))
+
+    def test_inf_sign_matters(self):
+        mod = load()
+        self.assertTrue(mod.observations_equal(float("inf"), float("inf")))
+        self.assertFalse(mod.observations_equal(float("inf"), float("-inf")))
+        self.assertFalse(mod.observations_equal(_value(float("inf")), _value(float("-inf"))))
+
+    def test_nested_list_and_tuple(self):
+        mod = load()
+        self.assertTrue(mod.observations_equal([1, [2, 3.0]], [1.0, [2, 3]]))
+        self.assertTrue(mod.observations_equal((1, 2.0), (1.0, 2)))
+        self.assertFalse(mod.observations_equal([1, 2], [1, 2, 3]))
+        self.assertFalse(mod.observations_equal((1,), [1]))
+
+    def test_bytes_are_not_strings(self):
+        mod = load()
+        self.assertFalse(mod.observations_equal(b"ab", "ab"))
+        self.assertFalse(mod.observations_equal(_value(b"ab"), _value("ab")))
+
+    def test_error_payload_equality(self):
+        mod = load()
+        left = {"kind": "timeout", "error": "TimeoutError", "head": "x"}
+        right = {"kind": "timeout", "error": "TimeoutError", "head": "x"}
+        other = {"kind": "timeout", "error": "TimeoutError", "head": "y"}
+        self.assertTrue(mod.observations_equal(left, right))
+        self.assertFalse(mod.observations_equal(left, other))
+        self.assertFalse(mod.observations_equal(left, _value("timeout")))
+
+    def test_missing_and_nojson_and_badenv_are_distinct(self):
+        mod = load()
+        self.assertFalse(mod.observations_equal(
+            {"kind": "missing", "key": "pageCount"},
+            {"kind": "nojson", "code": None},
+        ))
+        self.assertFalse(mod.observations_equal(
+            {"kind": "badenv", "code": 0},
+            {"kind": "nojson", "code": 0},
+        ))
+
+    def test_true_false_zero_one_table(self):
+        mod = load()
+        table = [
+            (True, True, True),
+            (False, False, True),
+            (True, False, False),
+            (True, 1, False),
+            (False, 0, False),
+            (1, 1.0, True),
+            (0, 0.0, True),
+            ("0", 0, False),
+            (None, None, True),
+            (None, 0, False),
+        ]
+        for left, right, expected in table:
+            self.assertEqual(mod.observations_equal(left, right), expected, (left, right))
+            self.assertEqual(mod.observations_equal(right, left), expected, (right, left))
+
+
+class PairingHonestyTests(unittest.TestCase):
+    """같은 디렉터리 우선, 그다음 얕고 사전순. walk 순서에 의존하지 않는다."""
+
+    def test_same_directory_wins_even_if_other_is_shallower(self):
+        mod = load()
+        # 같은 폴더 짝이 deep 에만 있으면 그 짝. 루트의 hwp 만으로는 짝이 아니다.
+        self.assertEqual(
+            mod.pick_twin_paths(["z.hwp", "deep/z.hwp"], ["deep/z.hwpx"]),
+            ("deep/z.hwp", "deep/z.hwpx"),
+        )
+
+    def test_lexicographically_first_same_dir_wins(self):
+        mod = load()
+        self.assertEqual(
+            mod.pick_twin_paths(
+                ["b/z.hwp", "a/z.hwp"],
+                ["b/z.hwpx", "a/z.hwpx"],
+            ),
+            ("a/z.hwp", "a/z.hwpx"),
+        )
+        self.assertEqual(
+            mod.pick_twin_paths(
+                ["b/z.hwp", "a/z.hwp"],
+                ["a/z.hwpx", "b/z.hwpx"],
+            ),
+            ("a/z.hwp", "a/z.hwpx"),
+        )
+
+    def test_first_file_in_same_dir_is_kept(self):
+        mod = load()
+        # 같은 디렉터리에 hwp 가 여러 개면 먼저 본(정렬된) 경로.
+        self.assertEqual(
+            mod.pick_twin_paths(["dir/b.hwp", "dir/a.hwp"], ["dir/x.hwpx"]),
+            ("dir/a.hwp", "dir/x.hwpx"),
+        )
+
+    def test_empty_or_one_side_is_none(self):
+        mod = load()
+        self.assertIsNone(mod.pick_twin_paths([], ["a.hwpx"]))
+        self.assertIsNone(mod.pick_twin_paths(["a.hwp"], []))
+        self.assertIsNone(mod.pick_twin_paths([], []))
+        self.assertIsNone(mod.pick_twin_paths(None, ["a.hwpx"]))
+
+    def test_non_string_paths_do_not_change_ranking_of_rest(self):
+        mod = load()
+        self.assertEqual(
+            mod.pick_twin_paths([None, 1, "z.hwp", ""], ["z.hwpx", None]),
+            ("z.hwp", "z.hwpx"),
+        )
+
+    def test_backslash_normalized_before_dirname(self):
+        mod = load()
+        self.assertEqual(
+            mod.pick_twin_paths(["sub\\z.hwp"], ["sub/z.hwpx"]),
+            ("sub\\z.hwp", "sub/z.hwpx"),
+        )
+
+    def test_walk_order_does_not_change_pairs(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            _touch(d, "b/x.hwp")
+            _touch(d, "b/x.hwpx")
+            _touch(d, "a/x.hwp")
+            _touch(d, "a/x.hwpx")
+            first = mod.find_twins_in(d)
+            _touch(d, "c/x.hwp")
+            _touch(d, "c/x.hwpx")
+            second = mod.find_twins_in(d)
+        # 같은 줄기 x 의 대표는 디렉터리 사전순 a.
+        self.assertEqual(first, [("x", "a/x.hwp", "a/x.hwpx")])
+        self.assertEqual(second, [("x", "a/x.hwp", "a/x.hwpx")])
+
+    def test_unpaired_never_invented(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            _touch(d, "only.hwp")
+            _touch(d, "other.hwpx")
+            _touch(d, "nested/only.hwp")
+            self.assertEqual(mod.find_twins_in(d), [])
+
+    def test_file_instead_of_dir_is_empty(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            path = _touch(d, "notdir.hwp")
+            self.assertEqual(mod.find_twins_in(path), [])
+
+    def test_oserror_on_isdir_is_empty(self):
+        mod = load()
+        with mock.patch.object(mod.os.path, "isdir", side_effect=OSError("boom")):
+            self.assertEqual(mod.find_twins_in("/does/not/matter"), [])
+
+    def test_oserror_on_walk_is_empty(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            _touch(d, "a.hwp")
+            _touch(d, "a.hwpx")
+            with mock.patch.object(mod.os, "walk", side_effect=OSError("boom")):
+                self.assertEqual(mod.find_twins_in(d), [])
+
+    def test_find_twins_safe_folds_walk_error(self):
+        mod = load()
+        with mock.patch.object(mod, "find_twins", side_effect=OSError("boom")):
+            pairs, err = mod.find_twins_safe()
+        self.assertEqual(pairs, [])
+        self.assertEqual(err["where"], "walk")
+        self.assertEqual(err["kind"], "os-error")
+
+    def test_path_rank_depth_then_lex(self):
+        mod = load()
+        paths = ["z.hwp", "a/b.hwp", "a/a.hwp", "aa.hwp"]
+        self.assertEqual(
+            sorted(paths, key=mod.path_rank),
+            ["aa.hwp", "z.hwp", "a/a.hwp", "a/b.hwp"],
+        )
+
+
+class HashHonestyTests(unittest.TestCase):
+    """없음은 동일이 아니다. 공백만 접고, 글자는 접지 않는다."""
+
+    def test_none_equals_none_is_false(self):
+        mod = load()
+        self.assertFalse(mod.same_body_hash(None, None))
+
+    def test_empty_pages_is_hash_of_empty_not_none(self):
+        mod = load()
+        ha = mod.body_hash_from_env({"pages": []})
+        hb = mod.body_hash_from_env({"pages": [{"text": ""}]})
+        self.assertIsNotNone(ha)
+        self.assertEqual(ha, hb)
+        self.assertTrue(mod.same_body_hash(ha, hb))
+        self.assertTrue(mod.is_sha256_hex(ha))
+
+    def test_missing_pages_key_is_none(self):
+        mod = load()
+        self.assertIsNone(mod.body_hash_from_env({}))
+        self.assertIsNone(mod.body_hash_from_env({"pages": None}))
+        self.assertIsNone(mod.body_hash_from_env({"pages": "not-list"}))
+        self.assertIsNone(mod.body_hash_from_env("text"))
+
+    def test_whitespace_variants_collapse(self):
+        mod = load()
+        variants = [
+            {"pages": [{"text": "가나다"}]},
+            {"pages": [{"text": "가 나 다"}]},
+            {"pages": [{"text": "가\n나\t다"}]},
+            {"pages": [{"text": "가"}, {"text": "나다"}]},
+            {"pages": [{"text": " 가나다\n"}]},
+        ]
+        hashes = [mod.body_hash_from_env(env) for env in variants]
+        self.assertEqual(len(set(hashes)), 1)
+        self.assertTrue(all(mod.same_body_hash(hashes[0], h) for h in hashes))
+
+    def test_different_letters_do_not_collapse(self):
+        mod = load()
+        ha = mod.body_hash_from_env({"pages": [{"text": "가"}]})
+        hb = mod.body_hash_from_env({"pages": [{"text": "나"}]})
+        self.assertNotEqual(ha, hb)
+        self.assertFalse(mod.same_body_hash(ha, hb))
+
+    def test_non_dict_page_is_skipped_not_crash(self):
+        mod = load()
+        ha = mod.body_hash_from_env({"pages": ["not-dict", {"text": "가"}, None]})
+        hb = mod.body_hash_from_env({"pages": [{"text": "가"}]})
+        self.assertEqual(ha, hb)
+
+    def test_missing_text_key_counts_as_empty(self):
+        mod = load()
+        ha = mod.body_hash_from_env({"pages": [{} , {"text": "가"}]})
+        hb = mod.body_hash_from_env({"pages": [{"text": "가"}]})
+        self.assertEqual(ha, hb)
+
+    def test_hash_text_none_is_none(self):
+        mod = load()
+        self.assertIsNone(mod.hash_text(None))
+        self.assertIsNone(mod.normalize_body(None))
+
+    def test_body_hash_with_run_exception_is_none(self):
+        mod = load()
+
+        def boom(_args):
+            raise FileNotFoundError("rhwp")
+
+        self.assertIsNone(mod.body_hash_with_run(boom, "a.hwp"))
+        self.assertFalse(mod.same_body_hash(
+            mod.body_hash_with_run(boom, "a.hwp"),
+            mod.body_hash_with_run(boom, "a.hwpx"),
+        ))
+
+    def test_body_hash_with_run_bad_shape_is_none(self):
+        mod = load()
+        self.assertIsNone(mod.body_hash_with_run(lambda _a: None, "a.hwp"))
+        self.assertIsNone(mod.body_hash_with_run(lambda _a: "nope", "a.hwp"))
+        self.assertIsNone(mod.body_hash_with_run(lambda _a: (0,), "a.hwp"))
+
+    def test_body_hash_live_exception_is_none(self):
+        mod = load()
+        with mock.patch.object(mod, "run_cli", side_effect=PermissionError("x")):
+            self.assertIsNone(mod.body_hash("rhwp", "a.hwp"))
+
+    def test_pages_text_rejects_non_dict_env(self):
+        mod = load()
+        self.assertIsNone(mod.pages_text(None))
+        self.assertIsNone(mod.pages_text([]))
+        self.assertEqual(mod.pages_text({"pages": []}), "")
+
+
+class ClassifyHonestyTests(unittest.TestCase):
+    """관문이 네 칸만 낸다. 해시 부재를 contradiction 으로 부르지 않는다."""
+
+    def test_classify_pair_never_returns_unknown(self):
+        mod = load()
+        for body in (True, False, 1, 0, "", "x"):
+            for ir_id in (True, False, 1, 0, "", "x"):
+                for diverged in (None, 0, 1, [], [{}], False, True, "", "row"):
+                    got = mod.classify_pair(body, ir_id, diverged)
+                    self.assertIn(got, mod.GATE_LABELS)
+
+    def test_no_divergence_always_none(self):
+        mod = load()
+        for empty in (None, 0, 0.0, "", [], {}, False):
+            self.assertIsNone(mod.classify_pair(True, True, empty), empty)
+            self.assertIsNone(mod.classify_pair(False, True, empty), empty)
+            self.assertIsNone(mod.classify_pair(True, False, empty), empty)
+
+    def test_missing_body_never_contradiction(self):
+        mod = load()
+        row = [{"observation": "pageCount"}]
+        self.assertEqual(mod.classify_pair(False, True, row), "other-doc")
+        self.assertEqual(mod.classify_pair(False, False, row), "other-doc")
+        self.assertNotEqual(mod.classify_pair(False, True, row), "contradiction")
+
+    def test_ir_false_never_contradiction(self):
+        mod = load()
+        row = [{"observation": "pageCount"}]
+        self.assertEqual(mod.classify_pair(True, False, row), "review")
+        self.assertNotEqual(mod.classify_pair(True, False, row), "contradiction")
+
+    def test_finding_severity_matches_ir_flag(self):
+        mod = load()
+        self.assertEqual(mod.finding_severity(True), "contradiction")
+        self.assertEqual(mod.finding_severity(False), "review")
+        self.assertEqual(mod.finding_severity(0), "review")
+        self.assertEqual(mod.finding_severity(""), "review")
+
+
+class CompareTwinsExceptionTests(unittest.TestCase):
+    def test_same_cli_error_both_sides_is_not_divergence(self):
+        mod = load()
+
+        def run(_args):
+            raise FileNotFoundError("rhwp")
+
+        compared, other, findings = mod.compare_twins(
+            [("a", "a.hwp", "a.hwpx")],
+            run,
+            observations=[("pageCount", ["info", "{f}", "--json"], "pageCount")],
+        )
+        self.assertEqual(compared, 1)
+        self.assertEqual(other, 0)
+        self.assertEqual(findings, [])
+
+    def test_one_side_cli_error_is_divergence_then_hash_gate(self):
+        mod = load()
+
+        def run(args):
+            if args[0] == "info" and args[1].endswith(".hwpx"):
+                raise PermissionError("x")
+            if args[0] == "info":
+                return (0, {"pageCount": 6})
+            if args[0] == "export-text":
+                return (0, {"pages": [{"text": "같은본문"}]})
+            if args[0] == "ir-diff":
+                return (0, {"identical": True, "diffCount": 0})
+            raise AssertionError(args)
+
+        compared, other, findings = mod.compare_twins(
+            [("a", "a.hwp", "a.hwpx")],
+            run,
+            observations=[("pageCount", ["info", "{f}", "--json"], "pageCount")],
+        )
+        self.assertEqual(compared, 1)
+        self.assertEqual(other, 0)
+        self.assertEqual(findings[0]["severity"], "contradiction")
+        self.assertEqual(findings[0]["diverged"][0]["hwpx"]["kind"], "permission")
+
+    def test_timeout_one_side_is_observation_not_crash(self):
+        mod = load()
+
+        def run(args):
+            if args[0] == "info" and args[1].endswith(".hwp"):
+                raise subprocess.TimeoutExpired(cmd=args, timeout=1)
+            if args[0] == "info":
+                return (0, {"pageCount": 1})
+            if args[0] == "export-text":
+                return (1, None)
+            raise AssertionError(args)
+
+        compared, other, findings = mod.compare_twins(
+            [("a", "a.hwp", "a.hwpx")],
+            run,
+            observations=[("pageCount", ["info", "{f}", "--json"], "pageCount")],
+        )
+        self.assertEqual(compared, 1)
+        self.assertEqual(other, 1)
+        self.assertEqual(findings, [])
+
+    def test_pair_loop_keyboardinterrupt_is_not_swallowed(self):
+        mod = load()
+
+        def run(_args):
+            raise KeyboardInterrupt
+
+        with self.assertRaises(KeyboardInterrupt):
+            mod.compare_twins(
+                [("a", "a.hwp", "a.hwpx")],
+                run,
+                observations=[("pageCount", ["info", "{f}", "--json"], "pageCount")],
+            )
+
+    def test_malformed_pair_is_skipped(self):
+        mod = load()
+        detailed = mod.compare_twins_detailed(
+            [("nope",), ("a", "a.hwp", "a.hwpx")],
+            lambda args: (0, {"pageCount": 1}),
+            observations=[("pageCount", ["info", "{f}", "--json"], "pageCount")],
+        )
+        self.assertEqual(detailed["skippedPairs"], 1)
+        self.assertEqual(len(detailed["pairErrors"]), 1)
+        self.assertEqual(detailed["findings"], [])
+
+    def test_malformed_pairs_type_is_empty_detailed(self):
+        mod = load()
+        detailed = mod.compare_twins_detailed(None, lambda args: (0, {}))
+        self.assertEqual(detailed["compared"], 0)
+        self.assertEqual(detailed["findings"], [])
+        self.assertTrue(detailed["pairErrors"])
+
+
+class IrFailureIsNotContradictionTests(unittest.TestCase):
+    def test_ir_diff_exception_is_review(self):
+        mod = load()
+        body = (0, {"pages": [{"text": "같은본문"}]})
+
+        def run(args):
+            if args[0] == "info":
+                return (0, {"pageCount": 1 if args[1].endswith(".hwp") else 2})
+            if args[0] == "export-text":
+                return body
+            if args[0] == "ir-diff":
+                raise OSError("broken pipe")
+            raise AssertionError(args)
+
+        _c, other, findings = mod.compare_twins(
+            [("a", "a.hwp", "a.hwpx")],
+            run,
+            observations=[("pageCount", ["info", "{f}", "--json"], "pageCount")],
+        )
+        self.assertEqual(other, 0)
+        self.assertEqual(findings[0]["severity"], "review")
+        self.assertFalse(findings[0]["irIdentical"])
+        self.assertIsNone(findings[0]["irDiffCount"])
+
+    def test_ir_diff_none_envelope_is_review(self):
+        mod = load()
+        body = (0, {"pages": [{"text": "같은본문"}]})
+
+        def run(args):
+            if args[0] == "info":
+                return (0, {"pageCount": 1 if args[1].endswith(".hwp") else 2})
+            if args[0] == "export-text":
+                return body
+            if args[0] == "ir-diff":
+                return (2, None)
+            raise AssertionError(args)
+
+        _c, _o, findings = mod.compare_twins(
+            [("a", "a.hwp", "a.hwpx")],
+            run,
+            observations=[("pageCount", ["info", "{f}", "--json"], "pageCount")],
+        )
+        self.assertEqual(findings[0]["severity"], "review")
+        self.assertFalse(findings[0]["irIdentical"])
+
+    def test_ir_identity_with_run_folds_type_error(self):
+        mod = load()
+        identical, count = mod.ir_identity_with_run(lambda _a: "nope", "a.hwp", "a.hwpx")
+        self.assertFalse(identical)
+        self.assertIsNone(count)
+
+    def test_ir_identity_non_dict(self):
+        mod = load()
+        self.assertEqual(mod.ir_identity(None), (False, None))
+        self.assertEqual(mod.ir_identity([]), (False, None))
+        self.assertEqual(mod.ir_identity({"identical": 1, "diffCount": 0}), (True, 0))
+        self.assertEqual(mod.ir_identity({"identical": 0, "diffCount": 3}), (False, 3))
+
+
+class MissingHashIsNotContradictionTests(unittest.TestCase):
+    def test_hash_exception_both_sides_is_other_doc(self):
+        mod = load()
+
+        def run(args):
+            if args[0] == "info":
+                return (0, {"pageCount": 1 if args[1].endswith(".hwp") else 2})
+            if args[0] == "export-text":
+                raise TimeoutError("slow")
+            raise AssertionError(args)
+
+        _c, other, findings = mod.compare_twins(
+            [("a", "a.hwp", "a.hwpx")],
+            run,
+            observations=[("pageCount", ["info", "{f}", "--json"], "pageCount")],
+        )
+        self.assertEqual(other, 1)
+        self.assertEqual(findings, [])
+
+    def test_hash_exception_one_side_is_other_doc(self):
+        mod = load()
+
+        def run(args):
+            if args[0] == "info":
+                return (0, {"pageCount": 1 if args[1].endswith(".hwp") else 2})
+            if args[0] == "export-text" and args[1].endswith(".hwpx"):
+                raise FileNotFoundError("gone")
+            if args[0] == "export-text":
+                return (0, {"pages": [{"text": "가"}]})
+            raise AssertionError(args)
+
+        _c, other, findings = mod.compare_twins(
+            [("a", "a.hwp", "a.hwpx")],
+            run,
+            observations=[("pageCount", ["info", "{f}", "--json"], "pageCount")],
+        )
+        self.assertEqual(other, 1)
+        self.assertEqual(findings, [])
+
+    def test_same_missing_hash_is_still_other_doc(self):
+        """양쪽 해시가 둘 다 None 이어도 동일 문서가 아니다."""
+        mod = load()
+        self.assertFalse(mod.same_body_hash(None, None))
+        self.assertEqual(
+            mod.classify_pair(False, True, [{"observation": "pageCount"}]),
+            "other-doc",
+        )
+
+
+class ReportHonestyTests(unittest.TestCase):
+    def test_validate_report_accepts_clean_ok(self):
+        mod = load()
+        report = mod.build_report(
+            bin_name="rhwp", pairs_count=2, compared=12, other_doc=0, findings=[]
+        )
+        self.assertEqual(mod.validate_report(report), [])
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["exit"], mod.EXIT_OK)
+        self.assertFalse(report["toolFailed"])
+
+    def test_validate_report_catches_ok_lie(self):
+        mod = load()
+        report = mod.build_report(
+            bin_name="rhwp", pairs_count=1, compared=1, other_doc=0,
+            findings=[mod.make_finding(
+                "a", "a.hwp", "a.hwpx", True, 0,
+                [{"observation": "pageCount", "hwp": _value(1), "hwpx": _value(2)}],
+            )],
+        )
+        report["ok"] = True
+        issues = mod.validate_report(report)
+        self.assertTrue(any("ok" in item for item in issues))
+
+    def test_validate_report_rejects_other_doc_finding(self):
+        mod = load()
+        report = mod.build_report(
+            bin_name="rhwp", pairs_count=1, compared=1, other_doc=1, findings=[]
+        )
+        report["findings"] = [{"stem": "a", "severity": "other-doc", "irIdentical": False, "diverged": [{}]}]
+        report["reviews"] = 0
+        report["contradictions"] = 0
+        issues = mod.validate_report(report)
+        self.assertTrue(any("other-doc" in item for item in issues))
+
+    def test_validate_report_rejects_contradiction_without_ir(self):
+        mod = load()
+        finding = mod.make_finding(
+            "a", "a.hwp", "a.hwpx", False, 1,
+            [{"observation": "pageCount", "hwp": _value(1), "hwpx": _value(2)}],
+        )
+        finding["severity"] = "contradiction"
+        report = {
+            "kind": "gymDifferential",
+            "schemaVersion": "1.0",
+            "ok": False,
+            "runner": {"bin": "rhwp"},
+            "pairs": 1,
+            "observationsCompared": 1,
+            "sameNameDifferentDocument": 0,
+            "findings": [finding],
+            "contradictions": 1,
+            "reviews": 0,
+            "exit": 3,
+            "toolFailed": False,
+        }
+        issues = mod.validate_report(report)
+        self.assertTrue(any("irIdentical" in item for item in issues))
+
+    def test_tool_failed_does_not_invent_findings(self):
+        mod = load()
+        report = mod.build_report(
+            bin_name="rhwp", pairs_count=0, compared=0, other_doc=0, findings=[],
+            tool_errors=[{"where": "find-bin", "kind": "missing-bin", "error": "FileNotFoundError", "head": "x"}],
+        )
+        self.assertTrue(report["toolFailed"])
+        self.assertEqual(report["findings"], [])
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["exit"], mod.EXIT_TOOL_FAILED)
+        self.assertEqual(mod.validate_report(report), [])
+        self.assertEqual(mod.status_exit(report), 1)
+
+    def test_status_exit_prefers_tool_failed(self):
+        mod = load()
+        report = mod.build_report(
+            bin_name="rhwp", pairs_count=1, compared=1, other_doc=0,
+            findings=[mod.make_finding(
+                "a", "a.hwp", "a.hwpx", True, 0,
+                [{"observation": "pageCount", "hwp": _value(1), "hwpx": _value(2)}],
+            )],
+            tool_errors=[{"where": "write", "kind": "os-error", "error": "OSError", "head": "x"}],
+        )
+        self.assertFalse(report["ok"])
+        self.assertEqual(mod.status_exit(report), 1)
+
+    def test_validate_report_non_dict(self):
+        mod = load()
+        self.assertEqual(mod.validate_report(None), ["report 가 dict 가 아니다"])
+
+    def test_validate_report_missing_keys(self):
+        mod = load()
+        issues = mod.validate_report({"kind": "nope"})
+        self.assertTrue(any("키 없음" in item for item in issues))
+        self.assertTrue(any("kind" in item for item in issues))
+
+
+class WriteReportSafeTests(unittest.TestCase):
+    def test_write_error_is_string_not_exception(self):
+        mod = load()
+        report = mod.build_report(
+            bin_name="rhwp", pairs_count=0, compared=0, other_doc=0, findings=[]
+        )
+        err = mod.write_report_safe(report, os.path.join("no", "such", "dir", "out.json"))
+        self.assertIsInstance(err, str)
+        self.assertIn("write_report", err)
+
+    def test_write_success_is_none(self):
+        mod = load()
+        report = mod.build_report(
+            bin_name="rhwp", pairs_count=0, compared=0, other_doc=0, findings=[]
+        )
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.json")
+            self.assertIsNone(mod.write_report_safe(report, path))
+            self.assertTrue(os.path.isfile(path))
+
+    def test_write_does_not_swallow_keyboardinterrupt(self):
+        mod = load()
+        with mock.patch.object(mod, "write_report", side_effect=KeyboardInterrupt):
+            with self.assertRaises(KeyboardInterrupt):
+                mod.write_report_safe({}, "x.json")
+
+    def test_attach_write_error_does_not_change_ok(self):
+        mod = load()
+        report = mod.build_report(
+            bin_name="rhwp", pairs_count=0, compared=0, other_doc=0, findings=[]
+        )
+        mod.attach_write_error(report, "disk full")
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["writeError"], "disk full")
+        self.assertEqual(report["contradictions"], 0)
+
+
+class RunCliSafeTests(unittest.TestCase):
+    def test_missing_bin_is_observation(self):
+        mod = load()
+        with mock.patch.object(mod.subprocess, "run", side_effect=FileNotFoundError("rhwp")):
+            code, env = mod.run_cli_safe("missing", ["info", "a.hwp", "--json"])
+        self.assertIsNone(code)
+        self.assertEqual(env["kind"], "missing-bin")
+        self.assertEqual(env["error"], "FileNotFoundError")
+
+    def test_permission_is_observation(self):
+        mod = load()
+        with mock.patch.object(mod.subprocess, "run", side_effect=PermissionError("x")):
+            code, env = mod.run_cli_safe("rhwp", ["info"])
+        self.assertIsNone(code)
+        self.assertEqual(env["kind"], "permission")
+
+    def test_timeout_is_observation(self):
+        mod = load()
+        with mock.patch.object(
+            mod.subprocess, "run",
+            side_effect=subprocess.TimeoutExpired(cmd=["rhwp"], timeout=1),
+        ):
+            code, env = mod.run_cli_safe("rhwp", ["info"], timeout=1)
+        self.assertIsNone(code)
+        self.assertEqual(env["kind"], "timeout")
+
+    def test_oserror_is_observation(self):
+        mod = load()
+        with mock.patch.object(mod.subprocess, "run", side_effect=OSError(22, "bad")):
+            _code, env = mod.run_cli_safe("rhwp", ["info"])
+        self.assertEqual(env["kind"], "os-error")
+
+    def test_does_not_swallow_keyboardinterrupt(self):
+        mod = load()
+        with mock.patch.object(mod.subprocess, "run", side_effect=KeyboardInterrupt):
+            with self.assertRaises(KeyboardInterrupt):
+                mod.run_cli_safe("rhwp", ["info"])
+
+    def test_does_not_swallow_systemexit(self):
+        mod = load()
+        with mock.patch.object(mod.subprocess, "run", side_effect=SystemExit(2)):
+            with self.assertRaises(SystemExit):
+                mod.run_cli_safe("rhwp", ["info"])
+
+    def test_empty_bin_path_is_missing_bin(self):
+        mod = load()
+        code, env = mod.run_cli_safe("", ["info"])
+        self.assertIsNone(code)
+        self.assertEqual(env["kind"], "missing-bin")
+
+    def test_success_json(self):
+        mod = load()
+        proc = mock.Mock(stdout=b'{"pageCount": 6}', returncode=0)
+        with mock.patch.object(mod.subprocess, "run", return_value=proc):
+            code, env = mod.run_cli_safe("rhwp", ["info", "a.hwp", "--json"])
+        self.assertEqual(code, 0)
+        self.assertEqual(env, {"pageCount": 6})
+
+    def test_non_json_stdout_is_none_env(self):
+        mod = load()
+        proc = mock.Mock(stdout=b"not json", returncode=2)
+        with mock.patch.object(mod.subprocess, "run", return_value=proc):
+            code, env = mod.run_cli("rhwp", ["info"])
+        self.assertEqual(code, 2)
+        self.assertIsNone(env)
+
+    def test_timeout_kwarg_passed(self):
+        mod = load()
+        proc = mock.Mock(stdout=b"{}", returncode=0)
+        with mock.patch.object(mod.subprocess, "run", return_value=proc) as run:
+            mod.run_cli("rhwp", ["info"], timeout=5)
+        self.assertEqual(run.call_args.kwargs.get("timeout"), 5)
+
+    def test_timeout_zero_not_passed(self):
+        mod = load()
+        proc = mock.Mock(stdout=b"{}", returncode=0)
+        with mock.patch.object(mod.subprocess, "run", return_value=proc) as run:
+            mod.run_cli("rhwp", ["info"], timeout=0)
+        self.assertNotIn("timeout", run.call_args.kwargs)
+
+    def test_decode_cli_stdout_rejects_int(self):
+        mod = load()
+        with self.assertRaises(TypeError):
+            mod.decode_cli_stdout(1)
+        self.assertEqual(mod.decode_cli_stdout(None), "")
+        self.assertEqual(mod.decode_cli_stdout("abc"), "abc")
+        self.assertEqual(mod.decode_cli_stdout(b"abc"), "abc")
+
+    def test_loads_cli_json_empty_is_none(self):
+        mod = load()
+        self.assertIsNone(mod.loads_cli_json(None))
+        self.assertIsNone(mod.loads_cli_json("  "))
+        self.assertEqual(mod.loads_cli_json('{"a": 1}'), {"a": 1})
+        with self.assertRaises(TypeError):
+            mod.loads_cli_json(b"{}")
+
+    def test_observe_uses_safe_cli(self):
+        mod = load()
+        with mock.patch.object(mod.subprocess, "run", side_effect=FileNotFoundError("rhwp")):
+            obs = mod.observe("missing", "a.hwp", ["info", "{f}", "--json"], "pageCount")
+        self.assertEqual(obs["kind"], "missing-bin")
+
+    def test_observation_from_result_passes_through_error_obs(self):
+        mod = load()
+        env = {"kind": "timeout", "error": "TimeoutError", "head": "x"}
+        self.assertEqual(mod.observation_from_result(None, env, "pageCount"), env)
+
+
+class FindBinAndMainTests(unittest.TestCase):
+    def test_find_bin_safe_success(self):
+        mod = load()
+        with mock.patch.object(mod.runner, "find_bin", return_value="/opt/rhwp"):
+            found, err = mod.find_bin_safe("rhwp")
+        self.assertEqual(found, "/opt/rhwp")
+        self.assertIsNone(err)
+
+    def test_find_bin_safe_folds_oserror(self):
+        mod = load()
+        with mock.patch.object(mod.runner, "find_bin", side_effect=OSError("x")):
+            found, err = mod.find_bin_safe("rhwp")
+        self.assertEqual(found, "rhwp")
+        self.assertEqual(err["where"], "find-bin")
+        self.assertEqual(err["kind"], "os-error")
+
+    def test_find_bin_safe_does_not_swallow_keyboardinterrupt(self):
+        mod = load()
+        with mock.patch.object(mod.runner, "find_bin", side_effect=KeyboardInterrupt):
+            with self.assertRaises(KeyboardInterrupt):
+                mod.find_bin_safe("rhwp")
+
+    def test_parse_args_defaults(self):
+        mod = load()
+        a = mod.parse_args([])
+        self.assertEqual(a.limit, 0)
+        self.assertIsNone(a.bin)
+        self.assertIsNone(a.out)
+        self.assertEqual(a.cli_timeout, 0)
+
+    def test_main_exit_zero_when_no_pairs(self):
+        mod = load()
+        with mock.patch.object(mod, "find_bin_safe", return_value=("rhwp", None)), \
+                mock.patch.object(mod, "find_twins_safe", return_value=([], None)), \
+                mock.patch.object(mod, "write_report_safe", return_value=None), \
+                mock.patch.object(mod, "render_summary", return_value=["ok"]):
+            code = mod.main(["--limit", "0"])
+        self.assertEqual(code, 0)
+
+    def test_main_exit_one_when_find_bin_fails(self):
+        mod = load()
+        err = {"where": "find-bin", "kind": "os-error", "error": "OSError", "head": "x"}
+        with mock.patch.object(mod, "find_bin_safe", return_value=("rhwp", err)), \
+                mock.patch.object(mod, "find_twins_safe", return_value=([], None)), \
+                mock.patch.object(mod, "write_report_safe", return_value=None), \
+                mock.patch.object(mod, "render_summary", return_value=["fail"]):
+            code = mod.main([])
+        self.assertEqual(code, 1)
+
+    def test_main_exit_three_on_contradiction(self):
+        mod = load()
+        finding = {
+            "stem": "a", "hwp": "a.hwp", "hwpx": "a.hwpx",
+            "irIdentical": True, "irDiffCount": 0,
+            "diverged": [{"observation": "pageCount", "hwp": _value(1), "hwpx": _value(2)}],
+            "severity": "contradiction",
+        }
+        with mock.patch.object(mod, "find_bin_safe", return_value=("rhwp", None)), \
+                mock.patch.object(mod, "find_twins_safe", return_value=([("a", "a.hwp", "a.hwpx")], None)), \
+                mock.patch.object(mod, "compare_twins", return_value=(1, 0, [finding])), \
+                mock.patch.object(mod, "write_report_safe", return_value=None), \
+                mock.patch.object(mod, "render_summary", return_value=["bad"]):
+            code = mod.main([])
+        self.assertEqual(code, 3)
+
+    def test_main_write_error_does_not_change_ok_exit(self):
+        mod = load()
+        with mock.patch.object(mod, "find_bin_safe", return_value=("rhwp", None)), \
+                mock.patch.object(mod, "find_twins_safe", return_value=([], None)), \
+                mock.patch.object(mod, "write_report_safe", return_value="disk full"), \
+                mock.patch.object(mod, "render_summary", return_value=["ok"]):
+            code = mod.main([])
+        self.assertEqual(code, 0)
+
+
+class CatalogContractTests(unittest.TestCase):
+    def test_report_kind_and_schema(self):
+        mod = load()
+        self.assertEqual(mod.REPORT_KIND, "gymDifferential")
+        self.assertEqual(mod.SCHEMA_VERSION, "1.0")
+
+    def test_observation_catalog_contains_core_kinds(self):
+        mod = load()
+        for kind in ("value", "nojson", "badenv", "missing", "timeout", "missing-bin"):
+            self.assertIn(kind, mod.OBSERVATION_KINDS)
+
+    def test_severities_do_not_include_other_doc(self):
+        mod = load()
+        self.assertEqual(mod.SEVERITIES, ("contradiction", "review"))
+        self.assertNotIn("other-doc", mod.SEVERITIES)
+
+    def test_gate_labels_include_none_and_other_doc(self):
+        mod = load()
+        self.assertIn(None, mod.GATE_LABELS)
+        self.assertIn("other-doc", mod.GATE_LABELS)
+        self.assertIn("contradiction", mod.GATE_LABELS)
+        self.assertIn("review", mod.GATE_LABELS)
+
+    def test_exits(self):
+        mod = load()
+        self.assertEqual(mod.EXIT_OK, 0)
+        self.assertEqual(mod.EXIT_TOOL_FAILED, 1)
+        self.assertEqual(mod.EXIT_CONTRADICTION, 3)
+
+    def test_observations_six_labels(self):
+        mod = load()
+        labels = [row[0] for row in mod.OBSERVATIONS]
+        self.assertEqual(
+            labels,
+            ["pageCount", "tableCount", "paragraphCount", "fieldCount", "footnoteCount", "endnoteCount"],
+        )
+        for _name, args, key in mod.OBSERVATIONS:
+            self.assertIn("{f}", args)
+            self.assertTrue(key)
+
+    def test_twin_exts(self):
+        mod = load()
+        self.assertEqual(mod.TWIN_EXTS, (".hwp", ".hwpx"))
+
+    def test_fatal_tuple(self):
+        mod = load()
+        self.assertIn(KeyboardInterrupt, mod.FATAL_EXCEPTIONS)
+        self.assertIn(SystemExit, mod.FATAL_EXCEPTIONS)
+        self.assertIn(MemoryError, mod.FATAL_EXCEPTIONS)
+        self.assertIn(GeneratorExit, mod.FATAL_EXCEPTIONS)
+
+    def test_report_keys(self):
+        mod = load()
+        for key in (
+            "kind", "schemaVersion", "ok", "runner", "pairs",
+            "observationsCompared", "sameNameDifferentDocument",
+            "findings", "contradictions", "reviews",
+        ):
+            self.assertIn(key, mod.REPORT_KEYS)
+
+
+class GeneratedClassifyTableTests(unittest.TestCase):
+    def test_full_truth_table(self):
+        mod = load()
+        diverged_shapes = (
+            [{"observation": "pageCount"}],
+            [{"observation": "a"}, {"observation": "b"}],
+            "x",
+            1,
+            True,
+        )
+        empty_shapes = (None, 0, 0.0, "", [], {}, False)
+        for diverged in empty_shapes:
+            for body in (True, False):
+                for ir_id in (True, False):
+                    self.assertIsNone(
+                        mod.classify_pair(body, ir_id, diverged),
+                        (body, ir_id, diverged),
+                    )
+        for diverged in diverged_shapes:
+            self.assertEqual(mod.classify_pair(False, True, diverged), "other-doc")
+            self.assertEqual(mod.classify_pair(False, False, diverged), "other-doc")
+            self.assertEqual(mod.classify_pair(True, True, diverged), "contradiction")
+            self.assertEqual(mod.classify_pair(True, False, diverged), "review")
+
+
+class GeneratedPairingTableTests(unittest.TestCase):
+    CASES = [
+        (["a.hwp"], ["a.hwpx"], ("a.hwp", "a.hwpx")),
+        (["b/a.hwp", "a.hwp"], ["a.hwpx"], ("a.hwp", "a.hwpx")),
+        (["b/a.hwp"], ["a.hwpx", "b/a.hwpx"], ("b/a.hwp", "b/a.hwpx")),
+        (["z/a.hwp", "a/a.hwp"], ["z/a.hwpx", "a/a.hwpx"], ("a/a.hwp", "a/a.hwpx")),
+        (["deep/n/x.hwp", "x.hwp"], ["other/x.hwpx"], ("x.hwp", "other/x.hwpx")),
+        (["deep/n/x.hwp"], ["other/x.hwpx"], ("deep/n/x.hwp", "other/x.hwpx")),
+        (["aa/z.hwp", "sub/z.hwp"], ["sub/z.hwpx"], ("sub/z.hwp", "sub/z.hwpx")),
+        (["m/n/z.hwp", "m/z.hwp"], ["m/n/z.hwpx"], ("m/n/z.hwp", "m/n/z.hwpx")),
+        ([], ["a.hwpx"], None),
+        (["a.hwp"], [], None),
+        (["a.hwp", "b.hwp"], ["c.hwpx"], ("a.hwp", "c.hwpx")),
+        (["b.hwp", "a.hwp"], ["c.hwpx"], ("a.hwp", "c.hwpx")),
+        (["dir/b.hwp", "dir/a.hwp"], ["dir/z.hwpx"], ("dir/a.hwp", "dir/z.hwpx")),
+        (["0/a.hwp", "1/a.hwp"], ["0/a.hwpx"], ("0/a.hwp", "0/a.hwpx")),
+        (["samples/a.hwp"], ["fixtures/a.hwpx", "samples/a.hwpx"], ("samples/a.hwp", "samples/a.hwpx")),
+    ]
+
+    def test_table_and_reversed_inputs(self):
+        mod = load()
+        for hwps, hwpxs, expected in self.CASES:
+            self.assertEqual(mod.pick_twin_paths(hwps, hwpxs), expected, (hwps, hwpxs))
+            self.assertEqual(
+                mod.pick_twin_paths(list(reversed(hwps)), list(reversed(hwpxs))),
+                expected,
+                ("rev", hwps, hwpxs),
+            )
+
+
+class GeneratedEqualityTableTests(unittest.TestCase):
+    def test_symmetric_table(self):
+        mod = load()
+        nan = float("nan")
+        table = [
+            (_value(6), _value(6.0), True),
+            (_value(6), _value(7), False),
+            (_value(True), _value(1), False),
+            (_value(False), _value(0), False),
+            (_value(nan), _value(nan), True),
+            (_value(float("inf")), _value(float("-inf")), False),
+            ({"kind": "nojson", "code": 1}, _value("exit1"), False),
+            ({"kind": "missing", "key": "x"}, None, False),
+            ({"kind": "timeout", "error": "TimeoutError", "head": "a"},
+             {"kind": "timeout", "error": "TimeoutError", "head": "a"}, True),
+            ({"kind": "timeout", "error": "TimeoutError", "head": "a"},
+             {"kind": "permission", "error": "PermissionError", "head": "a"}, False),
+            ([1, {"a": 2.0}], [1.0, {"a": 2}], True),
+            ({"b": 1, "a": 2}, {"a": 2.0, "b": 1}, True),
+            ("가", "가", True),
+            ("가", "나", False),
+            (b"x", "x", False),
+        ]
+        for left, right, expected in table:
+            self.assertEqual(mod.observations_equal(left, right), expected, (left, right))
+            if not (isinstance(left, float) and math.isnan(left)):
+                self.assertEqual(mod.observations_equal(right, left), expected, (right, left))
+
+
+class GeneratedHashTableTests(unittest.TestCase):
+    VARIANTS_SAME = [
+        "한글본문",
+        "한 글 본 문",
+        "한글\n본문",
+        "한글\t본문",
+        "  한글본문  ",
+        "한글본문\r\n",
+        "한\r글본문",
+    ]
+    VARIANTS_DIFFERENT = [
+        "한글본문",
+        "한글본문.",
+        "한글본문2",
+        "한글본",
+        "본문한글",
+        "Hangul",
+    ]
+
+    def test_whitespace_family_shares_hash(self):
+        mod = load()
+        hashes = [
+            mod.body_hash_from_env({"pages": [{"text": text}]})
+            for text in self.VARIANTS_SAME
+        ]
+        self.assertEqual(len(set(hashes)), 1)
+        self.assertTrue(mod.is_sha256_hex(hashes[0]))
+
+    def test_letter_family_all_distinct(self):
+        mod = load()
+        hashes = [
+            mod.body_hash_from_env({"pages": [{"text": text}]})
+            for text in self.VARIANTS_DIFFERENT
+        ]
+        self.assertEqual(len(set(hashes)), len(hashes))
+        for i, left in enumerate(hashes):
+            for j, right in enumerate(hashes):
+                self.assertEqual(mod.same_body_hash(left, right), i == j, (i, j))
+
+    def test_split_pages_match_joined(self):
+        mod = load()
+        joined = mod.body_hash_from_env({"pages": [{"text": "가나다라마"}]})
+        split = mod.body_hash_from_env({
+            "pages": [{"text": "가 나"}, {"text": "다"}, {"text": "라마"}],
+        })
+        self.assertEqual(joined, split)
+
+
+class SelectPairsEdgeTests(unittest.TestCase):
+    def test_negative_and_bad_limit_mean_all(self):
+        mod = load()
+        pairs = [("a", "a.hwp", "a.hwpx"), ("b", "b.hwp", "b.hwpx")]
+        self.assertEqual(mod.select_pairs(pairs, -1), pairs)
+        self.assertEqual(mod.select_pairs(pairs, None), pairs)
+        self.assertEqual(mod.select_pairs(pairs, "nope"), pairs)
+        self.assertEqual(mod.select_pairs(pairs, 2), pairs)
+        self.assertEqual(mod.select_pairs(pairs, 99), pairs)
+
+    def test_non_iterable_pairs_is_empty(self):
+        mod = load()
+        self.assertEqual(mod.select_pairs(None, 1), [])
+        self.assertEqual(mod.select_pairs(1, 1), [])
+
+
+class RenderSummaryHonestyTests(unittest.TestCase):
+    def test_tool_failed_summary_does_not_say_clean(self):
+        mod = load()
+        report = mod.build_report(
+            bin_name="rhwp", pairs_count=0, compared=0, other_doc=0, findings=[],
+            tool_errors=[{"where": "find-bin", "kind": "missing-bin", "error": "FileNotFoundError", "head": "x"}],
+        )
+        text = "\n".join(mod.render_summary(report, "out.json"))
+        self.assertIn("도구 실패", text)
+        self.assertIn("exit 1", text)
+        self.assertIn("→ out.json", text)
+        self.assertNotIn("!!", text)
+
+    def test_review_is_not_double_bang(self):
+        mod = load()
+        finding = mod.make_finding(
+            "doc", "doc.hwp", "doc.hwpx", False, 2,
+            [{"observation": "tableCount", "hwp": _value(1), "hwpx": _value(2)}],
+        )
+        report = mod.build_report(
+            bin_name="rhwp", pairs_count=1, compared=1, other_doc=0, findings=[finding]
+        )
+        text = "\n".join(mod.render_summary(report))
+        self.assertNotIn("!!", text)
+        self.assertIn("tableCount 1≠2", text)
+
+    def test_pair_errors_and_write_error_appear(self):
+        mod = load()
+        report = mod.build_report(
+            bin_name="rhwp", pairs_count=1, compared=0, other_doc=0, findings=[],
+            pair_errors=[{"stem": "a", "kind": "os-error", "error": "OSError", "head": "x"}],
+            write_error="disk full",
+        )
+        text = "\n".join(mod.render_summary(report, "out.json"))
+        self.assertIn("쌍 오류", text)
+        self.assertIn("쓰기 오류", text)
+
+
+class ObserveWithRunTests(unittest.TestCase):
+    def test_value_path(self):
+        mod = load()
+        obs = mod.observe_with_run(
+            lambda args: (0, {"pageCount": 6}),
+            "a.hwp",
+            ["info", "{f}", "--json"],
+            "pageCount",
+        )
+        self.assertEqual(obs, _value(6))
+
+    def test_exception_path(self):
+        mod = load()
+        obs = mod.observe_with_run(
+            lambda args: (_ for _ in ()).throw(PermissionError("x")),
+            "a.hwp",
+            ["info", "{f}", "--json"],
+            "pageCount",
+        )
+        self.assertEqual(obs["kind"], "permission")
+
+    def test_placeholder_replaced(self):
+        mod = load()
+        seen = []
+
+        def run(args):
+            seen.append(args)
+            return (0, {"pageCount": 1})
+
+        mod.observe_with_run(run, "doc.hwp", ["info", "{f}", "--json"], "pageCount")
+        self.assertEqual(seen, [["info", "doc.hwp", "--json"]])
+
+    def test_systemexit_not_swallowed(self):
+        mod = load()
+        with self.assertRaises(SystemExit):
+            mod.observe_with_run(
+                lambda args: (_ for _ in ()).throw(SystemExit(2)),
+                "a.hwp",
+                ["info", "{f}"],
+                "pageCount",
+            )
+
+
+class FindingHonestyScanTests(unittest.TestCase):
+    def test_make_finding_severity_tied_to_ir(self):
+        mod = load()
+        row = [{"observation": "pageCount", "hwp": _value(1), "hwpx": _value(2)}]
+        contra = mod.make_finding("a", "a.hwp", "a.hwpx", True, 0, row)
+        review = mod.make_finding("a", "a.hwp", "a.hwpx", False, 4, row)
+        self.assertEqual(contra["severity"], "contradiction")
+        self.assertTrue(contra["irIdentical"])
+        self.assertEqual(review["severity"], "review")
+        self.assertFalse(review["irIdentical"])
+
+    def test_diverged_rows_sorted_and_skip_equal(self):
+        mod = load()
+        observed = [
+            ("tableCount", _value(1), _value(1)),
+            ("pageCount", _value(6), _value(7)),
+            ("fieldCount", _value(0), _value(1)),
+        ]
+        rows = mod.diverged_rows(observed)
+        self.assertEqual([r["observation"] for r in rows], ["fieldCount", "pageCount"])
+
+    def test_diverged_numeric_int_float_skipped(self):
+        mod = load()
+        self.assertEqual(mod.diverged_rows([("pageCount", _value(3), _value(3.0))]), [])
+
+    def test_build_report_sorts_findings(self):
+        mod = load()
+        row = [{"observation": "pageCount", "hwp": _value(1), "hwpx": _value(2)}]
+        report = mod.build_report(
+            bin_name="rhwp", pairs_count=2, compared=2, other_doc=0,
+            findings=[
+                mod.make_finding("m", "m.hwp", "m.hwpx", False, 1, row),
+                mod.make_finding("a", "a.hwp", "a.hwpx", True, 0, row),
+            ],
+        )
+        self.assertEqual([f["stem"] for f in report["findings"]], ["a", "m"])
+        self.assertEqual(mod.validate_report(report), [])
+
+
+class MultiObservationCompareTests(unittest.TestCase):
+    def test_two_observations_one_diverges(self):
+        mod = load()
+        body = (0, {"pages": [{"text": "같은본문"}]})
+
+        def run(args):
+            if args[0] == "info":
+                return (0, {"pageCount": 6})
+            if args[0] == "export-tables":
+                return (0, {"tableCount": 1 if args[1].endswith(".hwp") else 2})
+            if args[0] == "export-text":
+                return body
+            if args[0] == "ir-diff":
+                return (0, {"identical": False, "diffCount": 1})
+            raise AssertionError(args)
+
+        compared, other, findings = mod.compare_twins(
+            [("a", "a.hwp", "a.hwpx")],
+            run,
+            observations=[
+                ("pageCount", ["info", "{f}", "--json"], "pageCount"),
+                ("tableCount", ["export-tables", "{f}", "--json"], "tableCount"),
+            ],
+        )
+        self.assertEqual(compared, 2)
+        self.assertEqual(other, 0)
+        self.assertEqual(len(findings[0]["diverged"]), 1)
+        self.assertEqual(findings[0]["diverged"][0]["observation"], "tableCount")
+        self.assertEqual(findings[0]["severity"], "review")
+
+    def test_default_observations_count(self):
+        mod = load()
+
+        def run(args):
+            if args[0] == "info":
+                return (0, {"pageCount": 1})
+            if args[0] == "export-tables":
+                return (0, {"tableCount": 0})
+            if args[0] == "explain":
+                return (0, {"paragraphCount": 2, "footnoteCount": 0, "endnoteCount": 0})
+            if args[0] == "fields":
+                return (0, {"fieldCount": 0})
+            raise AssertionError(args)
+
+        compared, other, findings = mod.compare_twins(
+            [("a", "a.hwp", "a.hwpx")],
+            run,
+        )
+        self.assertEqual(compared, len(mod.OBSERVATIONS))
+        self.assertEqual(other, 0)
+        self.assertEqual(findings, [])
+
+
+class CoerceAndDecodeEdgeTests(unittest.TestCase):
+    def test_coerce_run_result(self):
+        mod = load()
+        self.assertEqual(mod.coerce_run_result((0, {"a": 1})), (0, {"a": 1}))
+        self.assertEqual(mod.coerce_run_result([1, None]), (1, None))
+        with self.assertRaises(TypeError):
+            mod.coerce_run_result(None)
+        with self.assertRaises(TypeError):
+            mod.coerce_run_result((0,))
+
+    def test_decode_memoryview_and_bytearray(self):
+        mod = load()
+        self.assertEqual(mod.decode_cli_stdout(bytearray(b"ab")), "ab")
+        self.assertEqual(mod.decode_cli_stdout(memoryview(b"cd")), "cd")
+
+    def test_run_cli_str_stdout(self):
+        mod = load()
+        proc = mock.Mock(stdout='{"pageCount": 2}', returncode=0)
+        with mock.patch.object(mod.subprocess, "run", return_value=proc):
+            code, env = mod.run_cli("rhwp", ["info"])
+        self.assertEqual((code, env), (0, {"pageCount": 2}))
+
+    def test_run_cli_empty_stdout(self):
+        mod = load()
+        proc = mock.Mock(stdout=b"", returncode=1)
+        with mock.patch.object(mod.subprocess, "run", return_value=proc):
+            code, env = mod.run_cli("rhwp", ["info"])
+        self.assertEqual(code, 1)
+        self.assertIsNone(env)
+
+
+class StatusExitTests(unittest.TestCase):
+    def test_non_dict_is_tool_failed(self):
+        mod = load()
+        self.assertEqual(mod.status_exit(None), 1)
+        self.assertEqual(mod.status_exit("x"), 1)
+
+    def test_ok_true_is_zero(self):
+        mod = load()
+        self.assertEqual(mod.status_exit({"ok": True}), 0)
+
+    def test_ok_false_is_three(self):
+        mod = load()
+        self.assertEqual(mod.status_exit({"ok": False}), 3)
+
+    def test_tool_failed_overrides_ok(self):
+        mod = load()
+        self.assertEqual(mod.status_exit({"ok": True, "toolFailed": True}), 1)
+        self.assertEqual(mod.status_exit({"ok": False, "toolFailed": True}), 1)
+
+
+class DisplayAndFormatTests(unittest.TestCase):
+    def test_display_error_kinds(self):
+        mod = load()
+        self.assertEqual(mod.observation_display({"kind": "timeout"}), "timeout")
+        self.assertEqual(mod.observation_display({"kind": "permission"}), "permission")
+        self.assertEqual(mod.observation_display({"kind": "badenv", "code": 0}), "badenv")
+        self.assertEqual(mod.observation_display("raw"), "raw")
+        self.assertEqual(mod.observation_display({"kind": ""}), {"kind": ""})
+
+    def test_format_finding_detail_empty(self):
+        mod = load()
+        self.assertEqual(mod.format_finding_detail({"diverged": []}), "")
+        detail = mod.format_finding_detail({
+            "diverged": [
+                {"observation": "pageCount", "hwp": _value(1), "hwpx": _value(2)},
+                {"observation": "tableCount", "hwp": {"kind": "timeout"}, "hwpx": _value(0)},
+            ]
+        })
+        self.assertIn("pageCount 1≠2", detail)
+        self.assertIn("tableCount timeout≠0", detail)
+
+
+class WalkAndDiscoveryMoreTests(unittest.TestCase):
+    def test_mixed_case_and_nested_and_junk(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            _touch(d, "Keep.HWP")
+            _touch(d, "Keep.hwpx")
+            _touch(d, "skip.doc")
+            _touch(d, "skip.hwp.bak")
+            _touch(d, "deep/nested/z.hwp")
+            _touch(d, "deep/nested/z.HWPX")
+            _touch(d, "deep/nested/only.hwpx")
+            pairs = mod.find_twins_in(d)
+        stems = [p[0] for p in pairs]
+        self.assertEqual(stems, ["Keep", "z"])
+        self.assertTrue(pairs[0][1].lower().endswith(".hwp"))
+        self.assertTrue(pairs[0][2].lower().endswith(".hwpx"))
+
+    def test_same_stem_different_dirs_prefers_local_pair(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            _touch(d, "root.hwp")
+            _touch(d, "nested/root.hwp")
+            _touch(d, "nested/root.hwpx")
+            pairs = mod.find_twins_in(d)
+        self.assertEqual(pairs, [("root", "nested/root.hwp", "nested/root.hwpx")])
+
+    def test_is_dir_safe_false_on_oserror(self):
+        mod = load()
+        with mock.patch.object(mod.os.path, "isdir", side_effect=OSError("x")):
+            self.assertFalse(mod.is_dir_safe("anywhere"))
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_gym_differential.py
+++ b/scripts/tests/test_gym_differential.py
@@ -1,0 +1,399 @@
+"""[#5224] gym 교차형식 차등 오라클 계약 — 순수 판정·보고.
+
+바이너리 없이 쌍둥이 짝짓기·본문 해시·관측 대조·오검출 관문·보고 봉투를 고정한다.
+CLI run 은 주입해 "관측이 갈렸을 때" 를 합성한다.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL = REPO_ROOT / "gym" / "tools" / "differential.py"
+
+
+def load():
+    spec = importlib.util.spec_from_file_location("gym_differential", TOOL)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _touch(root, rel):
+    path = os.path.join(root, *rel.split("/"))
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as fh:
+        fh.write(b"x")
+    return path
+
+
+def _value(v):
+    return {"kind": "value", "value": v}
+
+
+class TwinDiscoveryTests(unittest.TestCase):
+    def test_pairs_same_stem_and_ignores_unpaired(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            _touch(d, "a.hwp")
+            _touch(d, "a.hwpx")
+            _touch(d, "only.hwp")
+            _touch(d, "note.txt")
+            _touch(d, "nested/c.hwp")
+            _touch(d, "nested/c.hwpx")
+            pairs = mod.find_twins_in(d)
+        self.assertEqual(
+            pairs,
+            [
+                ("a", "a.hwp", "a.hwpx"),
+                ("c", "nested/c.hwp", "nested/c.hwpx"),
+            ],
+        )
+
+    def test_extension_case_insensitive(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            _touch(d, "Doc.HWP")
+            _touch(d, "Doc.Hwpx")
+            self.assertEqual(mod.find_twins_in(d), [("Doc", "Doc.HWP", "Doc.Hwpx")])
+
+    def test_missing_dir_is_empty(self):
+        mod = load()
+        self.assertEqual(mod.find_twins_in(os.path.join("no", "such", "samples")), [])
+
+    def test_root_prefix_matches_repo_layout(self):
+        mod = load()
+        with tempfile.TemporaryDirectory() as d:
+            _touch(d, "samples/x.hwp")
+            _touch(d, "samples/x.hwpx")
+            pairs = mod.find_twins_in(os.path.join(d, "samples"), root=d)
+        self.assertEqual(pairs, [("x", "samples/x.hwp", "samples/x.hwpx")])
+
+    def test_colliding_stems_prefer_same_directory_then_shallow(self):
+        mod = load()
+        # 루트와 sub 둘 다 짝이 있으면 디렉터리 경로가 앞선 루트를 고른다.
+        hwps = ["z.hwp", "sub/z.hwp", "aa/z.hwp"]
+        hwpxs = ["sub/z.hwpx", "z.hwpx"]
+        self.assertEqual(mod.pick_twin_paths(hwps, hwpxs), ("z.hwp", "z.hwpx"))
+        self.assertEqual(
+            mod.pick_twin_paths(list(reversed(hwps)), list(reversed(hwpxs))),
+            ("z.hwp", "z.hwpx"),
+        )
+        # 같은 폴더 짝이 sub 에만 있으면 그 짝.
+        self.assertEqual(
+            mod.pick_twin_paths(["aa/z.hwp", "sub/z.hwp"], ["sub/z.hwpx"]),
+            ("sub/z.hwp", "sub/z.hwpx"),
+        )
+        # 같은 폴더 짝이 없으면 얕은 경로.
+        self.assertEqual(
+            mod.pick_twin_paths(["deep/n/x.hwp", "x.hwp"], ["other/x.hwpx"]),
+            ("x.hwp", "other/x.hwpx"),
+        )
+
+    def test_select_pairs_limit_is_prefix(self):
+        mod = load()
+        pairs = [("b", "b.hwp", "b.hwpx"), ("a", "a.hwp", "a.hwpx")]
+        self.assertEqual(mod.select_pairs(pairs, 0), pairs)
+        self.assertEqual(mod.select_pairs(pairs, 1), [pairs[0]])
+
+
+class BodyHashTests(unittest.TestCase):
+    def test_whitespace_ignored_and_deterministic(self):
+        mod = load()
+        env_a = {"pages": [{"text": "가 나\n다"}, {"text": "라"}]}
+        env_b = {"pages": [{"text": "가나다라"}]}
+        ha = mod.body_hash_from_env(env_a)
+        hb = mod.body_hash_from_env(env_b)
+        self.assertEqual(ha, hb)
+        self.assertEqual(ha, mod.body_hash_from_env(env_a))
+        self.assertEqual(len(ha), 64)
+
+    def test_missing_envelope_is_not_identity(self):
+        mod = load()
+        self.assertIsNone(mod.body_hash_from_env(None))
+        self.assertIsNone(mod.body_hash_from_env({"no": "pages"}))
+        self.assertFalse(mod.same_body_hash(None, None))
+        self.assertFalse(mod.same_body_hash("a" * 64, None))
+        self.assertTrue(mod.same_body_hash("a" * 64, "a" * 64))
+
+
+class ObservationTests(unittest.TestCase):
+    def test_value_missing_and_nojson_are_distinct(self):
+        mod = load()
+        self.assertEqual(
+            mod.observation_from_result(0, {"pageCount": 6}, "pageCount"),
+            _value(6),
+        )
+        self.assertEqual(
+            mod.observation_from_result(0, {"pageCount": 6}, "tableCount"),
+            {"kind": "missing", "key": "tableCount"},
+        )
+        self.assertEqual(
+            mod.observation_from_result(2, None, "pageCount"),
+            {"kind": "nojson", "code": 2},
+        )
+        self.assertEqual(
+            mod.observation_from_result(0, ["not-a-dict"], "pageCount"),
+            {"kind": "badenv", "code": 0},
+        )
+
+    def test_numeric_int_and_float_match(self):
+        mod = load()
+        self.assertTrue(mod.observations_equal(_value(6), _value(6.0)))
+        self.assertTrue(mod.observations_equal(6, 6.0))
+        self.assertFalse(mod.observations_equal(_value(6), _value(7)))
+
+    def test_bool_is_not_int(self):
+        mod = load()
+        self.assertFalse(mod.observations_equal(True, 1))
+        self.assertTrue(mod.observations_equal(True, True))
+
+    def test_dict_key_order_does_not_matter(self):
+        mod = load()
+        self.assertTrue(
+            mod.observations_equal(
+                {"kind": "value", "value": {"b": 1, "a": 2}},
+                {"value": {"a": 2.0, "b": 1}, "kind": "value"},
+            )
+        )
+
+    def test_nojson_does_not_collide_with_string_value(self):
+        mod = load()
+        self.assertFalse(
+            mod.observations_equal(
+                {"kind": "nojson", "code": 1},
+                _value("exit1"),
+            )
+        )
+
+    def test_display_keeps_cli_shape(self):
+        mod = load()
+        self.assertEqual(mod.observation_display(_value(6)), 6)
+        self.assertEqual(mod.observation_display({"kind": "nojson", "code": 3}), "exit3")
+        self.assertIsNone(mod.observation_display({"kind": "missing", "key": "x"}))
+
+
+class ClassificationTests(unittest.TestCase):
+    def test_gate_matrix(self):
+        mod = load()
+        cases = [
+            (True, True, [], None),
+            (False, True, [{"observation": "pageCount"}], "other-doc"),
+            (True, True, [{"observation": "pageCount"}], "contradiction"),
+            (True, False, [{"observation": "pageCount"}], "review"),
+            (False, False, [{"observation": "pageCount"}], "other-doc"),
+        ]
+        for body_same, ir_identical, diverged, expected in cases:
+            self.assertEqual(
+                mod.classify_pair(body_same, ir_identical, diverged),
+                expected,
+                (body_same, ir_identical, bool(diverged)),
+            )
+
+
+class CompareTwinsTests(unittest.TestCase):
+    def _run_from(self, table):
+        def run(args):
+            key = tuple(args)
+            if key not in table:
+                raise AssertionError(f"예상하지 않은 CLI: {args}")
+            return table[key]
+
+        return run
+
+    def test_matching_pair_is_silent(self):
+        mod = load()
+        run = self._run_from(
+            {
+                ("info", "a.hwp", "--json"): (0, {"pageCount": 3}),
+                ("info", "a.hwpx", "--json"): (0, {"pageCount": 3.0}),
+            }
+        )
+        compared, other, findings = mod.compare_twins(
+            [("a", "a.hwp", "a.hwpx")],
+            run,
+            observations=[("pageCount", ["info", "{f}", "--json"], "pageCount")],
+        )
+        self.assertEqual(compared, 1)
+        self.assertEqual(other, 0)
+        self.assertEqual(findings, [])
+
+    def test_other_document_is_excluded(self):
+        mod = load()
+        run = self._run_from(
+            {
+                ("info", "a.hwp", "--json"): (0, {"pageCount": 1}),
+                ("info", "a.hwpx", "--json"): (0, {"pageCount": 2}),
+                ("export-text", "a.hwp", "--json"): (0, {"pages": [{"text": "가"}]}),
+                ("export-text", "a.hwpx", "--json"): (0, {"pages": [{"text": "나"}]}),
+            }
+        )
+        compared, other, findings = mod.compare_twins(
+            [("a", "a.hwp", "a.hwpx")],
+            run,
+            observations=[("pageCount", ["info", "{f}", "--json"], "pageCount")],
+        )
+        self.assertEqual(compared, 1)
+        self.assertEqual(other, 1)
+        self.assertEqual(findings, [])
+
+    def test_missing_body_hash_is_not_contradiction(self):
+        mod = load()
+        run = self._run_from(
+            {
+                ("info", "a.hwp", "--json"): (0, {"pageCount": 1}),
+                ("info", "a.hwpx", "--json"): (0, {"pageCount": 2}),
+                ("export-text", "a.hwp", "--json"): (1, None),
+                ("export-text", "a.hwpx", "--json"): (1, None),
+            }
+        )
+        _compared, other, findings = mod.compare_twins(
+            [("a", "a.hwp", "a.hwpx")],
+            run,
+            observations=[("pageCount", ["info", "{f}", "--json"], "pageCount")],
+        )
+        self.assertEqual(other, 1)
+        self.assertEqual(findings, [])
+
+    def test_ir_identical_divergence_is_contradiction(self):
+        mod = load()
+        body = (0, {"pages": [{"text": "같은본문"}]})
+        run = self._run_from(
+            {
+                ("info", "a.hwp", "--json"): (0, {"pageCount": 6}),
+                ("info", "a.hwpx", "--json"): (0, {"pageCount": 7}),
+                ("export-text", "a.hwp", "--json"): body,
+                ("export-text", "a.hwpx", "--json"): body,
+                ("ir-diff", "a.hwp", "a.hwpx", "--json"): (0, {"identical": True, "diffCount": 0}),
+            }
+        )
+        compared, other, findings = mod.compare_twins(
+            [("a", "a.hwp", "a.hwpx")],
+            run,
+            observations=[("pageCount", ["info", "{f}", "--json"], "pageCount")],
+        )
+        self.assertEqual((compared, other), (1, 0))
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["severity"], "contradiction")
+        self.assertTrue(findings[0]["irIdentical"])
+        self.assertEqual(findings[0]["irDiffCount"], 0)
+        self.assertEqual(findings[0]["diverged"][0]["observation"], "pageCount")
+        self.assertEqual(findings[0]["diverged"][0]["hwp"], _value(6))
+        self.assertEqual(findings[0]["diverged"][0]["hwpx"], _value(7))
+
+    def test_ir_different_divergence_is_review(self):
+        mod = load()
+        body = (0, {"pages": [{"text": "같은본문"}]})
+        run = self._run_from(
+            {
+                ("info", "a.hwp", "--json"): (0, {"pageCount": 6}),
+                ("info", "a.hwpx", "--json"): (0, {"pageCount": 7}),
+                ("export-text", "a.hwp", "--json"): body,
+                ("export-text", "a.hwpx", "--json"): body,
+                ("ir-diff", "a.hwp", "a.hwpx", "--json"): (0, {"identical": False, "diffCount": 4}),
+            }
+        )
+        _compared, _other, findings = mod.compare_twins(
+            [("a", "a.hwp", "a.hwpx")],
+            run,
+            observations=[("pageCount", ["info", "{f}", "--json"], "pageCount")],
+        )
+        self.assertEqual(findings[0]["severity"], "review")
+        self.assertEqual(findings[0]["irDiffCount"], 4)
+
+    def test_findings_sorted_by_stem(self):
+        mod = load()
+        body = (0, {"pages": [{"text": "x"}]})
+
+        def run(args):
+            if args[0] == "info":
+                return (0, {"pageCount": 1 if args[1].endswith(".hwp") else 2})
+            if args[0] == "export-text":
+                return body
+            if args[0] == "ir-diff":
+                return (0, {"identical": True, "diffCount": 0})
+            raise AssertionError(args)
+
+        _compared, _other, findings = mod.compare_twins(
+            [("z", "z.hwp", "z.hwpx"), ("a", "a.hwp", "a.hwpx")],
+            run,
+            observations=[("pageCount", ["info", "{f}", "--json"], "pageCount")],
+        )
+        self.assertEqual([row["stem"] for row in findings], ["a", "z"])
+
+
+class ReportTests(unittest.TestCase):
+    def test_kind_and_schema_and_counts(self):
+        mod = load()
+        findings = [
+            mod.make_finding(
+                "b", "b.hwp", "b.hwpx", False, 1,
+                [{"observation": "tableCount", "hwp": _value(1), "hwpx": _value(2)}],
+            ),
+            mod.make_finding(
+                "a", "a.hwp", "a.hwpx", True, 0,
+                [{"observation": "pageCount", "hwp": _value(6), "hwpx": _value(7)}],
+            ),
+        ]
+        report = mod.build_report(
+            bin_name="rhwp",
+            pairs_count=4,
+            compared=24,
+            other_doc=1,
+            findings=findings,
+        )
+        self.assertEqual(report["kind"], "gymDifferential")
+        self.assertEqual(report["schemaVersion"], "1.0")
+        self.assertEqual(report["kind"], mod.REPORT_KIND)
+        self.assertEqual(report["schemaVersion"], mod.SCHEMA_VERSION)
+        self.assertFalse(report["ok"])
+        self.assertEqual(report["pairs"], 4)
+        self.assertEqual(report["observationsCompared"], 24)
+        self.assertEqual(report["sameNameDifferentDocument"], 1)
+        self.assertEqual(report["contradictions"], 1)
+        self.assertEqual(report["reviews"], 1)
+        self.assertEqual([row["stem"] for row in report["findings"]], ["a", "b"])
+        self.assertEqual(report["runner"], {"bin": "rhwp"})
+
+    def test_ok_when_no_contradiction(self):
+        mod = load()
+        report = mod.build_report(
+            bin_name="rhwp", pairs_count=2, compared=12, other_doc=0, findings=[]
+        )
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["contradictions"], 0)
+        self.assertEqual(report["reviews"], 0)
+
+    def test_summary_and_report_file_are_deterministic(self):
+        mod = load()
+        finding = mod.make_finding(
+            "doc", "doc.hwp", "doc.hwpx", True, 0,
+            [{"observation": "pageCount", "hwp": _value(6), "hwpx": _value(7)}],
+        )
+        report = mod.build_report(
+            bin_name="rhwp", pairs_count=1, compared=6, other_doc=0, findings=[finding]
+        )
+        lines = mod.render_summary(report, "out.json")
+        self.assertIn("쌍둥이 1쌍", lines[0])
+        self.assertIn("!!", "\n".join(lines))
+        self.assertIn("pageCount 6≠7", "\n".join(lines))
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "differential-report.json")
+            mod.write_report(report, path)
+            raw = Path(path).read_bytes()
+            self.assertFalse(raw.startswith(b"\xef\xbb\xbf"))
+            self.assertNotIn(b"\r\n", raw)
+            loaded = json.loads(raw.decode("utf-8"))
+        self.assertEqual(loaded["kind"], "gymDifferential")
+        self.assertEqual(loaded["schemaVersion"], "1.0")
+        self.assertEqual(loaded, report)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 요약

`gym/tools/differential.py` 교차형식 차등 오라클의 판정·집계·보고를 순수 함수로 분리하고, rhwp 바이너리 없이 계약을 고정한다. 시험/보고가 얇아서 회귀를 조용히 놓치던 구멍을 막는다.

- 보고 봉투를 `kind=gymDifferential`, `schemaVersion=1.0` 으로 맞춘다. `ok`·`reviews` 집계를 남긴다.
- 관측은 `value`/`nojson`/`missing` 으로 가른다. 종료 코드 문자열이 실제 값과 충돌하지 않는다.
- 숫자 `6` 과 `6.0` 은 같고, `True` 는 `1` 로 접히지 않는다. 본문 해시가 없으면 동일 문서로 치지 않는다.
- 같은 줄기 파일이 여러 개일 때 walk 순서가 아니라 같은 폴더 짝·얕은 경로로 대표를 고른다.
- CLI 플래그는 그대로다. packs·checks·coverage·robustness·profiles·README 는 건드리지 않았다.

## 관련 이슈

closes #5224

## 테스트

- [x] `python -m unittest scripts.tests.test_gym_differential -v` — 24 passed
- [x] `python gym/tools/audit.py` — 18 pack 통과
- [ ] **`cargo fmt --all -- --check` 통과** (이번 변경은 Python/CI 만. 사용자 지시에 따라 생략)
- [ ] `node scripts/rust-test-suite-manifest.mjs --check` 통과 (해당 없음)
- [ ] `node scripts/rust-unit-test-tiers.mjs --check` 통과 (해당 없음)
- [ ] `cargo test` 통과 (해당 없음)
- [ ] `cargo clippy -- -D warnings` 통과 (해당 없음)
- [x] CI Lint 의 `Validate gym scorer contracts` 에 `test_gym_differential.py` 를 배선

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음
- 재현·측정: 미측정. 라이브 스윕은 기존과 같이 rhwp 가 필요하고, 단위 시험은 바이너리 없이 돈다.