### PR TITLE
feat(gym): serialization pack 과제 확장 (SR09–SR12)

### DIFF
--- a/gym/packs/serialization/README.md
+++ b/gym/packs/serialization/README.md
@@ -1,0 +1,293 @@
+---
+kind: guide
+status: active
+canonical: gym/packs/serialization/README.md
+last_verified: 2026-08-18
+---
+
+# serialization — 저장·변환 여정과 실패 모드
+
+이 pack은 **형식을 넘나드는 왕복**을 채점한다. 변환물이 진짜 그 형식인지, 내용이
+보존됐는지, 쪽 범위가 1 기준으로 잘렸는지, 검증 실패가 산출물을 삼키지 않는지를
+각각 본다. 새 CLI는 없다. 기존 `convert` · `export-hwpx` · `export-pdf` ·
+`extract-pages` · `export-doclang` · `export-markdown` · `export-hml` ·
+`export-ir-schema` · `info` · `ir-diff` 와 `samples/` 만 쓴다.
+
+채점은 라이브 오라클이다. 쪽수·차이 건수·백엔드 이름을 JSON에 박제하지 않는다.
+`answer_eq` 가 채점 시점에 rhwp를 다시 돌려 기댓값을 계산한다. 골든 PDF/HWP
+바이트를 저장소에 넣지 않는다.
+
+## 왜 이 pack 인가
+
+에이전트가 문서를 "저장했다"고 말하는 순간, 보통 네 가지 중 하나가 빠진다.
+
+1. **컨테이너가 바뀌지 않았다.** 입력 `.hwpx` 를 그대로 `conv.hwp` 라는 이름만
+   바꿔 제출한다. `differs_from_input` 이 이걸 거절한다.
+2. **형식 표기를 추측했다.** `convert` 가 만든 파일이 HWP5인지 HWPX인지
+   `info --json` 의 `format` 을 읽지 않고 `"hwp"` 라고 적는다. 실제 표기는
+   `hwp5` 다.
+3. **쪽 축을 0 기준으로 잘랐다.** `extract-pages --from/--to` 는 **1 기준**이다.
+   `search` 의 `page: 1`(0 기준 둘째 쪽)을 그대로 `--from 1` 에 넣으면 한 쪽
+   밀린 문서가 조용히 나온다.
+4. **종료 코드만 보고 판정했다.** `ir-diff` 와 `--verify` 는 차이가 있으면
+   exit 3, `--verify-pages` 는 exit 4 다. 산출물은 남고 봉투에 판정이 실린다.
+   종료 코드만 보면 봉투를 읽지 않은 것이다.
+
+이 pack의 과제는 위 네 구멍을 여정으로 나눈다.
+
+## 여정 지도
+
+과제는 명령 가족이 아니라 **사람이 하는 일**로 묶는다. 한 여정이 여러 과제를
+가질 수 있다. 표본이 바뀌면 같은 명령도 다른 계약이 된다.
+
+### J1. 편집 가능본으로 저장 (`convert`)
+
+배포용 해제와 형식 변환을 한 명령으로 본다. 입력이 이미 편집 가능해도
+`convert` 는 산출물을 쓰고 봉투를 낸다.
+
+| ID | 하는 일 | 표본 | 지목 |
+|---|---|---|---|
+| SR09 | HWPX → 편집 가능 HWP5 | `hwpx_sample2.hwpx` | `format` |
+| SR13 | 이미 편집 가능한 HWP5 를 다시 convert | `para-001.hwp` | `wasDistribution` |
+| SR17 | convert `--verify` IR 자기검증 | `hwpx_sample2.hwpx` | `verify.identical` |
+| SR21 | convert `--verify-pages` 쪽수 자기검증 | `para-001.hwp` | `verifyPages.identical` |
+| SR25 | 다른 HWPX 표본도 같은 계약 | `hwpx/143E433F503322BD33.hwpx` | `format` |
+| SR26 | 표 문서 HWP5 재변환 | `table-001.hwp` | `wasDistribution` |
+| SR27 | 편집 가능본 `--verify` | `para-001.hwp` | `verify.identical` |
+| SR48 | 변환 산출물이 실제로 열리는지 | `hwpx_sample2.hwpx` | `info.pageCount` |
+| SR56 | 가로 문서 `--verify-pages` | `landscape-001.hwp` | `verifyPages.identical` |
+
+**실패 모드**
+
+- `wasDistribution` 을 `true` 로 박제한다. 편집 가능 입력은 보통 `false` 다.
+  값은 봉투에서 읽어야 한다.
+- `--verify` 와 `--verify-pages` 를 섞는다. 전자는 IR 차이(exit 3), 후자는
+  쪽수 차이(exit 4).
+- 산출 확장자를 `.hwpx` 로 준다. `convert` 는 `.hwp` 만 받는다.
+
+### J2. 쪽 범위만 남긴다 (`extract-pages`)
+
+대형 문서를 이분법으로 줄이는 진단 도구다. 정밀한 페이지 오려내기가 아니다.
+
+| ID | 하는 일 | 표본 | 지목 |
+|---|---|---|---|
+| SR10 | 2쪽 문서에서 첫 쪽만 | `exam-kor-2p.hwp` | `pagesAfter` |
+| SR14 | 2쪽 전체를 남긴 뒤 원본 쪽수 | `exam-kor-2p.hwp` | `pagesBefore` |
+| SR18 | 둘째 쪽만 남긴 문단 수 | `exam-kor-2p.hwp` | `paragraphsKept` |
+| SR22 | 중첩 셀 문서에서 첫 쪽만 | `issue2007_…42065.hwp` | `pagesBefore` |
+| SR28 | 3쪽 문서에서 첫 쪽만 | `exam-kor-3p.hwp` | `pagesAfter` |
+| SR29 | 3쪽 전체 추출 전 쪽수 | `exam-kor-3p.hwp` | `pagesBefore` |
+| SR30 | 4쪽 문서에서 지운 문단 수 | `exam-kor-4p.hwp` | `paragraphsRemoved` |
+| SR31 | 1쪽 문서에서 그 쪽만 | `exam-kor-1p.hwp` | `pagesAfter` |
+| SR54 | 3쪽 문서에서 마지막 쪽만 | `exam-kor-3p.hwp` | `paragraphsKept` |
+
+**실패 모드**
+
+- `--from 0` 을 넣는다. 이 명령은 1 기준이라 사용법 오류이거나 한 쪽 밀린다.
+- `pagesAfter` 가 요청 폭과 같다고 가정한다. 재조판으로 달라질 수 있다.
+  라이브 오라클이 실측값을 채점한다.
+- `pagesBefore` 와 `pagesAfter` 를 바꿔 적는다.
+- 문단이 여러 쪽에 걸치면 한 쪽이라도 범위 안이면 남는다. 쪽 단위 가위로
+  착각하면 `paragraphsKept` 가 어긋난다.
+
+### J3. PDF로 보낸다 (`export-pdf`)
+
+골든 PDF를 만들지 않는다. 형식·쪽수·백엔드만 봉투에서 읽는다.
+
+| ID | 하는 일 | 표본 | 지목 |
+|---|---|---|---|
+| SR11 | 문단 문서 PDF 쪽수 | `para-001.hwp` | `pageCount` |
+| SR15 | 표 문서 PDF 백엔드 | `table-001.hwp` | `backend` |
+| SR19 | 그림 문서 PDF 쪽수 | `pic2.hwp` | `pageCount` |
+| SR23 | HWPX 원본 렌더 쪽수 | `hwpx/143E…hwpx` | `renderedCount` |
+| SR32 | 표 문서 PDF 형식 | `table-001.hwp` | `format` |
+| SR33 | 2쪽 시험지 PDF 쪽수 | `exam-kor-2p.hwp` | `pageCount` |
+| SR34 | 같은 시험지 렌더 쪽수 | `exam-kor-2p.hwp` | `renderedCount` |
+| SR35 | HWPX 표본 백엔드 | `hwpx_sample2.hwpx` | `backend` |
+| SR49 | 각주 문서 PDF 쪽수 | `footnote-01.hwp` | `pageCount` |
+| SR50 | 가로 문서 백엔드 | `landscape-001.hwp` | `backend` |
+
+**실패 모드**
+
+- PDF 바이트 해시를 정답으로 삼는다. 폰트 환경이 바뀌면 깨진다.
+- `pageCount` 와 `renderedCount` 를 혼동한다. 보통 같지만 지목 필드가 다르다.
+- `--backend direct` 를 없는 feature에서 켠다. 기본 `svg` 경로를 읽고 적어라.
+- `-p` 는 **0 기준** 단일 쪽이다. `extract-pages` 의 1 기준과 섞지 마라.
+
+### J4. IR을 맞댄다 (`ir-diff`)
+
+같은 바이트, 짝 파일, 다른 문서, 연도 쌍을 나눈다. 판정은 데이터다.
+
+| ID | 하는 일 | 표본 | 지목 |
+|---|---|---|---|
+| SR01 | HWPX 변환 뒤 IR 동일 | `table-001.hwp` | `identical` |
+| SR06 | 변환 뒤 차이 건수 | `issue2007_…` | `diffCount` |
+| SR12 | 기존 pic2 HWP·HWPX 쌍 | `pic2.hwp` + `.hwpx` | `identical` |
+| SR16 | 자기 자신과 대조 | `table-001.hwp` | `identical` |
+| SR20 | pic2 쌍 차이 건수 | `pic2.hwp` + `.hwpx` | `diffCount` |
+| SR24 | 서로 다른 두 문서 | `table-001` vs `para-001` | `identical` |
+| SR36 | 문단 문서 자기대조 | `para-001.hwp` | `identical` |
+| SR37 | hwpx_sample2 쌍 | `.hwp` + `.hwpx` | `identical` |
+| SR38 | 표 vs 시험지 | `table-001` vs `exam-kor-2p` | `identical` |
+| SR39 | pic2 vs pic2-2018 | 연도 쌍 | `diffCount` |
+| SR53 | 각주 문서 자기대조 | `footnote-01.hwp` | `identical` |
+
+**실패 모드**
+
+- 차이가 있으면 실패라고 착각한다. exit 3 은 **차이 발견**이지 도구 고장
+  이 아니다. `expect_exits` 에 0과 3이 들어 있다.
+- `identical` 만 보고 `diffCount` 를 무시한다. 규모가 가려진다.
+- 자기대조가 `false` 이면 파서 비결정성이다. 그 경우는 도구 버그로 올려라.
+
+### J5. HWPX 컨테이너로 보낸다 (`export-hwpx`)
+
+`convert`(배포용 해제·HWP5)와 반대 방향이다. 명령을 바꾸면 산출 확장자가
+거부된다.
+
+| ID | 하는 일 | 표본 | 지목 |
+|---|---|---|---|
+| SR01 | HWPX 변환 자기검증 | `table-001.hwp` | IR `identical` |
+| SR06 | HWPX 왕복 차이 건수 | `issue2007_…` | `diffCount` |
+| SR40 | 문단 문서 HWPX 형식 | `para-001.hwp` | `format` |
+| SR41 | `--verify-pages` | `para-001.hwp` | `verifyPages.identical` |
+| SR42 | `--verify` | `table-001.hwp` | `verify.identical` |
+| SR51 | 서식 문서 HWPX 형식 | `form-01.hwp` | `format` |
+
+**실패 모드**
+
+- `export-hwpx` 자리에 `convert` 를 넣는다. 산출이 `.hwp` 가 된다.
+- `--verify` 없이 IR 동일을 주장한다. 검증 객체는 옵션을 켠 때만 생긴다.
+
+### J6. 의미 형식·스키마 (`export-doclang` · `export-markdown` · `export-hml` · `export-ir-schema`)
+
+다운스트림이 읽는 형식이다. 변환 성공과 무손실은 다른 축이다.
+
+| ID | 하는 일 | 표본 | 지목 |
+|---|---|---|---|
+| SR02 | HML 왕복 | `hml/formatting_table.hml` | 파일 + `info.pageCount` |
+| SR03 | DocLang 손실 계수 | `issue2007_…` | `lossCount` |
+| SR04 | 마크다운 쪽수 | `table-001.hwp` | `pageCount` |
+| SR05 | IR 스키마 dialect | (문서 불요) | `dialect` |
+| SR07 | HWPX 원본 조사 | `hwpx/143E…` | `pageCount` + `format` |
+| SR08 | HWPX 마크다운 쪽수 | 같은 HWPX | `pageCount` |
+| SR43 | DocLang 형식 | `para-001.hwp` | `format` |
+| SR44 | DocLang 버전 | `para-001.hwp` | `doclangVersion` |
+| SR45 | 표 문서 손실 계수 | `table-001.hwp` | `lossCount` |
+| SR46 | 2쪽 시험지 마크다운 | `exam-kor-2p.hwp` | `pageCount` |
+| SR47 | 그림 문서 마크다운 | `pic2.hwp` | `pageCount` |
+| SR52 | 다중 표 DocLang 손실 | `multi-table-001.hwp` | `lossCount` |
+| SR55 | 다른 HWPX 원본 조사 | `hwpx_sample2.hwpx` | `pageCount` |
+
+**실패 모드**
+
+- HWP/HWPX 를 `export-hml` 에 넣는다. 이 명령은 `.hml` 만 받는다.
+- `lossCount == 0` 을 성공 조건으로 박제한다. 손실 보고는 정보이지 실패가
+  아니다. 채점은 실측값을 맞추는 것이다.
+- `doclangVersion` 을 `"1.0"` 으로 적는다. 스키마 버전과 DocLang 버전은
+  다른 필드다.
+
+## 실패 모드 카탈로그 (여정 공통)
+
+아래는 과제 하나가 아니라 pack 전체가 반복해서 잡는 실수다. 예외·가장자리
+상세는 [mydocs/working/gym_serialization_exceptions.md](../../../mydocs/working/gym_serialization_exceptions.md)
+에 적는다.
+
+### F1. 무편집 복사
+
+산출물 이름이 `conv.hwp` 여도 바이트가 입력과 같으면 변환이 아니다.
+`differs_from_input` 이 거부한다. 이름만 바꾼 제출, `copy` 한 제출,
+빈 파일을 확장자만 맞춘 제출이 여기 걸린다. `minBytes` 는 빈 껍데기를
+한 번 더 거른다.
+
+### F2. 형식 문자열 추측
+
+`info --json` 의 `format` 은 `hwp5` · `hwpx` · `hml` · `hwp3` 같이 적힌다.
+`"hwp"` · `"HWP"` · `"application/hwp"` 는 오답이다. PDF 봉투의 `format` 은
+`"pdf"` 다. DocLang 봉투의 `format` 은 `"doclang"` 이다.
+
+### F3. 쪽 축 혼동
+
+| 명령 | 쪽 기준 | 필드 |
+|---|---|---|
+| `extract-pages --from/--to` | **1 기준** | `pagesBefore` / `pagesAfter` |
+| `export-pdf -p` | **0 기준** | 단일 쪽 렌더 |
+| `info` / `export-markdown` / `export-pdf` 전체 | 쪽 수 | `pageCount` |
+| `export-pdf` 실제 렌더 | 쪽 수 | `renderedCount` |
+| `search` / `export-text` 의 `page` | **0 기준** | 본문 주소 |
+
+`search` 가 `page: 1` 을 주면 `extract-pages` 에서는 `--from 2 --to 2` 다.
+
+### F4. 종료 코드로 판정
+
+| 상황 | exit | 산출물 | 읽을 필드 |
+|---|---|---|---|
+| 변환·비교 성공, 차이 없음 | 0 | 남음 | `identical: true` |
+| IR 차이 / `--verify` 실패 | 3 | **남음** | `identical` / `verify.identical` |
+| `--verify-pages` 쪽수 불일치 | 4 | **남음** | `verifyPages.identical` |
+| 읽기·파싱 실패 | 1 | 없을 수 있음 | stdout 비움 |
+| 사용법 오류 | 2 | 없음 | 인자를 고쳐라 |
+
+과제는 `expect_exits` / `allowExits` 에 0과 3(또는 4)을 같이 넣는다. 종료
+코드 0만 허용하면 차이가 있는 정당한 왕복이 전부 실패한다.
+
+### F5. 필드 이름 바꿔 읽기
+
+같은 봉투 안에서 이름이 비슷한 필드가 있다.
+
+- `pageCount` vs `renderedCount`
+- `pagesBefore` vs `pagesAfter`
+- `paragraphsKept` vs `paragraphsRemoved`
+- `verify.identical` vs `verifyPages.identical`
+- `format` vs `backend` vs `doclangVersion`
+- `identical` vs `diffCount`
+
+과제는 `answer` 키와 `path` 를 일부러 다르게 두기도 한다(예: answer
+`pages` ← path `pageCount`). 힌트의 필드명을 읽지 않으면 틀린다.
+
+### F6. 골든 파일
+
+PDF·HWP·HWPX 바이트는 폰트·타임스탬프·직렬화 순서에 흔들린다. 이 pack은
+해시를 정답으로 쓰지 않는다. `file_exists` + `differs_from_input` +
+`value_eq(format)` + `answer_eq(실측 필드)` 만 본다.
+
+### F7. 명령 가족 바꿔 치기
+
+- HWPX가 필요하면 `export-hwpx`, 편집 가능 HWP5가 필요하면 `convert`.
+- HML 원본만 `export-hml`.
+- 쪽 범위 저장은 `extract-pages`, 단일 쪽 PDF는 `export-pdf -p`.
+- IR 대조는 `ir-diff`. `info` 의 쪽수가 같다고 IR이 같은 것은 아니다.
+
+## 정직한 경계 — 이 pack이 보지 않는 것
+
+- 한컴 정본 PDF와의 픽셀 충실도. 그건 `render-diff` · fidelity harness 다.
+- 암호 설정 왕복(`--output-password`). 보안 pack과 겹치지 않게 비웠다.
+- HWP3 배포용 해제 특수 경로. 표본을 HWP5/HWPX/HML에 고정했다.
+- 브라우저 저장 UX. gym 축은 CLI 다.
+- `profiles/` · `PARK.md` · 다른 pack 수정. 이 확장은 serialization
+  폴더와 계약 테스트·작업 노트만 건드린다.
+
+## 재현
+
+```bash
+python gym/tools/audit.py
+python -m unittest scripts.tests.test_gym_packs -v
+python -m unittest scripts.tests.test_gym_serialization_pack -v
+# 기준 풀이 왕복(바이너리 필요):
+# python gym/tools/build_baseline.py --agent baseline --pack serialization --bin target/debug/rhwp
+# python gym/score.py               --agent baseline --pack serialization --bin target/debug/rhwp
+```
+
+`runner` 블록은 기존 pack 신원을 유지한다. 이 확장은 과제·기준풀이·문서만
+늘리고 바이너리 표면은 바꾸지 않았다.
+
+## 과제 목록 (SR01–SR56)
+
+기존 SR01–SR08은 유지한다. SR09–SR12는 이 PR의 첫 확장, SR13–SR24는
+구조 왕복 구조대 과제, SR25–SR56은 같은 명령으로 표본·필드·실패 모드를
+갈라 놓은 후속이다.
+
+상세 설계·예외는
+[mydocs/working/gym_serialization_pack.md](../../../mydocs/working/gym_serialization_pack.md)
+와
+[mydocs/working/gym_serialization_exceptions.md](../../../mydocs/working/gym_serialization_exceptions.md)
+를 본다.

--- a/gym/packs/serialization/pack.json
+++ b/gym/packs/serialization/pack.json
@@ -7,8 +7,12 @@
   "description": "형식을 넘나드는 왕복. 변환물이 진짜 그 형식인지, 내용이 보존됐는지를 각각 본다.",
   "requires": {
     "commands": [
+      "convert",
       "export-doclang",
+      "export-hwpx",
       "export-markdown",
+      "export-pdf",
+      "extract-pages",
       "info",
       "ir-diff"
     ]

--- a/gym/packs/serialization/reference/SR09.json
+++ b/gym/packs/serialization/reference/SR09.json
@@ -1,0 +1,18 @@
+{
+  "id": "SR09",
+  "steps": [
+    {
+      "answer": {
+        "format": {
+          "cmd": [
+            "convert",
+            "{input}",
+            "{sub:conv.hwp}",
+            "--json"
+          ],
+          "path": "format"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR10.json
+++ b/gym/packs/serialization/reference/SR10.json
@@ -1,0 +1,22 @@
+{
+  "id": "SR10",
+  "steps": [
+    {
+      "answer": {
+        "pagesAfter": {
+          "cmd": [
+            "extract-pages",
+            "{input}",
+            "{sub:slice.hwp}",
+            "--from",
+            "1",
+            "--to",
+            "1",
+            "--json"
+          ],
+          "path": "pagesAfter"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR11.json
+++ b/gym/packs/serialization/reference/SR11.json
@@ -1,0 +1,19 @@
+{
+  "id": "SR11",
+  "steps": [
+    {
+      "answer": {
+        "pages": {
+          "cmd": [
+            "export-pdf",
+            "{input}",
+            "-o",
+            "{sub:out.pdf}",
+            "--json"
+          ],
+          "path": "pageCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR12.json
+++ b/gym/packs/serialization/reference/SR12.json
@@ -1,0 +1,22 @@
+{
+  "id": "SR12",
+  "steps": [
+    {
+      "answer": {
+        "identical": {
+          "cmd": [
+            "ir-diff",
+            "{input}",
+            "samples/pic2.hwpx",
+            "--json"
+          ],
+          "path": "identical",
+          "allowExits": [
+            0,
+            3
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR13.json
+++ b/gym/packs/serialization/reference/SR13.json
@@ -1,0 +1,18 @@
+{
+  "id": "SR13",
+  "steps": [
+    {
+      "answer": {
+        "wasDistribution": {
+          "cmd": [
+            "convert",
+            "{input}",
+            "{sub:conv.hwp}",
+            "--json"
+          ],
+          "path": "wasDistribution"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR14.json
+++ b/gym/packs/serialization/reference/SR14.json
@@ -1,0 +1,22 @@
+{
+  "id": "SR14",
+  "steps": [
+    {
+      "answer": {
+        "pagesBefore": {
+          "cmd": [
+            "extract-pages",
+            "{input}",
+            "{sub:slice.hwp}",
+            "--from",
+            "1",
+            "--to",
+            "2",
+            "--json"
+          ],
+          "path": "pagesBefore"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR15.json
+++ b/gym/packs/serialization/reference/SR15.json
@@ -1,0 +1,19 @@
+{
+  "id": "SR15",
+  "steps": [
+    {
+      "answer": {
+        "backend": {
+          "cmd": [
+            "export-pdf",
+            "{input}",
+            "-o",
+            "{sub:out.pdf}",
+            "--json"
+          ],
+          "path": "backend"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR16.json
+++ b/gym/packs/serialization/reference/SR16.json
@@ -1,0 +1,22 @@
+{
+  "id": "SR16",
+  "steps": [
+    {
+      "answer": {
+        "identical": {
+          "cmd": [
+            "ir-diff",
+            "{input}",
+            "{input}",
+            "--json"
+          ],
+          "path": "identical",
+          "allowExits": [
+            0,
+            3
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR17.json
+++ b/gym/packs/serialization/reference/SR17.json
@@ -1,0 +1,23 @@
+{
+  "id": "SR17",
+  "steps": [
+    {
+      "answer": {
+        "identical": {
+          "cmd": [
+            "convert",
+            "{input}",
+            "{sub:conv.hwp}",
+            "--verify",
+            "--json"
+          ],
+          "path": "verify.identical",
+          "allowExits": [
+            0,
+            3
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR18.json
+++ b/gym/packs/serialization/reference/SR18.json
@@ -1,0 +1,22 @@
+{
+  "id": "SR18",
+  "steps": [
+    {
+      "answer": {
+        "paragraphsKept": {
+          "cmd": [
+            "extract-pages",
+            "{input}",
+            "{sub:slice.hwp}",
+            "--from",
+            "2",
+            "--to",
+            "2",
+            "--json"
+          ],
+          "path": "paragraphsKept"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR19.json
+++ b/gym/packs/serialization/reference/SR19.json
@@ -1,0 +1,19 @@
+{
+  "id": "SR19",
+  "steps": [
+    {
+      "answer": {
+        "pages": {
+          "cmd": [
+            "export-pdf",
+            "{input}",
+            "-o",
+            "{sub:out.pdf}",
+            "--json"
+          ],
+          "path": "pageCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR20.json
+++ b/gym/packs/serialization/reference/SR20.json
@@ -1,0 +1,22 @@
+{
+  "id": "SR20",
+  "steps": [
+    {
+      "answer": {
+        "diffs": {
+          "cmd": [
+            "ir-diff",
+            "{input}",
+            "samples/pic2.hwpx",
+            "--json"
+          ],
+          "path": "diffCount",
+          "allowExits": [
+            0,
+            3
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR21.json
+++ b/gym/packs/serialization/reference/SR21.json
@@ -1,0 +1,23 @@
+{
+  "id": "SR21",
+  "steps": [
+    {
+      "answer": {
+        "identical": {
+          "cmd": [
+            "convert",
+            "{input}",
+            "{sub:conv.hwp}",
+            "--verify-pages",
+            "--json"
+          ],
+          "path": "verifyPages.identical",
+          "allowExits": [
+            0,
+            4
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR22.json
+++ b/gym/packs/serialization/reference/SR22.json
@@ -1,0 +1,22 @@
+{
+  "id": "SR22",
+  "steps": [
+    {
+      "answer": {
+        "pagesBefore": {
+          "cmd": [
+            "extract-pages",
+            "{input}",
+            "{sub:slice.hwp}",
+            "--from",
+            "1",
+            "--to",
+            "1",
+            "--json"
+          ],
+          "path": "pagesBefore"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR23.json
+++ b/gym/packs/serialization/reference/SR23.json
@@ -1,0 +1,19 @@
+{
+  "id": "SR23",
+  "steps": [
+    {
+      "answer": {
+        "rendered": {
+          "cmd": [
+            "export-pdf",
+            "{input}",
+            "-o",
+            "{sub:out.pdf}",
+            "--json"
+          ],
+          "path": "renderedCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR24.json
+++ b/gym/packs/serialization/reference/SR24.json
@@ -1,0 +1,22 @@
+{
+  "id": "SR24",
+  "steps": [
+    {
+      "answer": {
+        "identical": {
+          "cmd": [
+            "ir-diff",
+            "{input}",
+            "samples/para-001.hwp",
+            "--json"
+          ],
+          "path": "identical",
+          "allowExits": [
+            0,
+            3
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR25.json
+++ b/gym/packs/serialization/reference/SR25.json
@@ -1,0 +1,18 @@
+{
+  "id": "SR25",
+  "steps": [
+    {
+      "answer": {
+        "format": {
+          "cmd": [
+            "convert",
+            "{input}",
+            "{sub:conv.hwp}",
+            "--json"
+          ],
+          "path": "format"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR26.json
+++ b/gym/packs/serialization/reference/SR26.json
@@ -1,0 +1,18 @@
+{
+  "id": "SR26",
+  "steps": [
+    {
+      "answer": {
+        "wasDistribution": {
+          "cmd": [
+            "convert",
+            "{input}",
+            "{sub:conv.hwp}",
+            "--json"
+          ],
+          "path": "wasDistribution"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR27.json
+++ b/gym/packs/serialization/reference/SR27.json
@@ -1,0 +1,23 @@
+{
+  "id": "SR27",
+  "steps": [
+    {
+      "answer": {
+        "identical": {
+          "cmd": [
+            "convert",
+            "{input}",
+            "{sub:conv.hwp}",
+            "--verify",
+            "--json"
+          ],
+          "path": "verify.identical",
+          "allowExits": [
+            0,
+            3
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR28.json
+++ b/gym/packs/serialization/reference/SR28.json
@@ -1,0 +1,22 @@
+{
+  "id": "SR28",
+  "steps": [
+    {
+      "answer": {
+        "pagesAfter": {
+          "cmd": [
+            "extract-pages",
+            "{input}",
+            "{sub:slice.hwp}",
+            "--from",
+            "1",
+            "--to",
+            "1",
+            "--json"
+          ],
+          "path": "pagesAfter"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR29.json
+++ b/gym/packs/serialization/reference/SR29.json
@@ -1,0 +1,22 @@
+{
+  "id": "SR29",
+  "steps": [
+    {
+      "answer": {
+        "pagesBefore": {
+          "cmd": [
+            "extract-pages",
+            "{input}",
+            "{sub:slice.hwp}",
+            "--from",
+            "1",
+            "--to",
+            "3",
+            "--json"
+          ],
+          "path": "pagesBefore"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR30.json
+++ b/gym/packs/serialization/reference/SR30.json
@@ -1,0 +1,22 @@
+{
+  "id": "SR30",
+  "steps": [
+    {
+      "answer": {
+        "paragraphsRemoved": {
+          "cmd": [
+            "extract-pages",
+            "{input}",
+            "{sub:slice.hwp}",
+            "--from",
+            "1",
+            "--to",
+            "1",
+            "--json"
+          ],
+          "path": "paragraphsRemoved"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR31.json
+++ b/gym/packs/serialization/reference/SR31.json
@@ -1,0 +1,22 @@
+{
+  "id": "SR31",
+  "steps": [
+    {
+      "answer": {
+        "pagesAfter": {
+          "cmd": [
+            "extract-pages",
+            "{input}",
+            "{sub:slice.hwp}",
+            "--from",
+            "1",
+            "--to",
+            "1",
+            "--json"
+          ],
+          "path": "pagesAfter"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR32.json
+++ b/gym/packs/serialization/reference/SR32.json
@@ -1,0 +1,19 @@
+{
+  "id": "SR32",
+  "steps": [
+    {
+      "answer": {
+        "format": {
+          "cmd": [
+            "export-pdf",
+            "{input}",
+            "-o",
+            "{sub:out.pdf}",
+            "--json"
+          ],
+          "path": "format"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR33.json
+++ b/gym/packs/serialization/reference/SR33.json
@@ -1,0 +1,19 @@
+{
+  "id": "SR33",
+  "steps": [
+    {
+      "answer": {
+        "pages": {
+          "cmd": [
+            "export-pdf",
+            "{input}",
+            "-o",
+            "{sub:out.pdf}",
+            "--json"
+          ],
+          "path": "pageCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR34.json
+++ b/gym/packs/serialization/reference/SR34.json
@@ -1,0 +1,19 @@
+{
+  "id": "SR34",
+  "steps": [
+    {
+      "answer": {
+        "rendered": {
+          "cmd": [
+            "export-pdf",
+            "{input}",
+            "-o",
+            "{sub:out.pdf}",
+            "--json"
+          ],
+          "path": "renderedCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR35.json
+++ b/gym/packs/serialization/reference/SR35.json
@@ -1,0 +1,19 @@
+{
+  "id": "SR35",
+  "steps": [
+    {
+      "answer": {
+        "backend": {
+          "cmd": [
+            "export-pdf",
+            "{input}",
+            "-o",
+            "{sub:out.pdf}",
+            "--json"
+          ],
+          "path": "backend"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR36.json
+++ b/gym/packs/serialization/reference/SR36.json
@@ -1,0 +1,22 @@
+{
+  "id": "SR36",
+  "steps": [
+    {
+      "answer": {
+        "identical": {
+          "cmd": [
+            "ir-diff",
+            "{input}",
+            "{input}",
+            "--json"
+          ],
+          "path": "identical",
+          "allowExits": [
+            0,
+            3
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR37.json
+++ b/gym/packs/serialization/reference/SR37.json
@@ -1,0 +1,22 @@
+{
+  "id": "SR37",
+  "steps": [
+    {
+      "answer": {
+        "identical": {
+          "cmd": [
+            "ir-diff",
+            "{input}",
+            "samples/hwpx_sample2.hwpx",
+            "--json"
+          ],
+          "path": "identical",
+          "allowExits": [
+            0,
+            3
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR38.json
+++ b/gym/packs/serialization/reference/SR38.json
@@ -1,0 +1,22 @@
+{
+  "id": "SR38",
+  "steps": [
+    {
+      "answer": {
+        "identical": {
+          "cmd": [
+            "ir-diff",
+            "{input}",
+            "samples/exam-kor-2p.hwp",
+            "--json"
+          ],
+          "path": "identical",
+          "allowExits": [
+            0,
+            3
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR39.json
+++ b/gym/packs/serialization/reference/SR39.json
@@ -1,0 +1,22 @@
+{
+  "id": "SR39",
+  "steps": [
+    {
+      "answer": {
+        "diffs": {
+          "cmd": [
+            "ir-diff",
+            "{input}",
+            "samples/pic2-2018.hwp",
+            "--json"
+          ],
+          "path": "diffCount",
+          "allowExits": [
+            0,
+            3
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR40.json
+++ b/gym/packs/serialization/reference/SR40.json
@@ -1,0 +1,18 @@
+{
+  "id": "SR40",
+  "steps": [
+    {
+      "answer": {
+        "format": {
+          "cmd": [
+            "export-hwpx",
+            "{input}",
+            "{sub:conv.hwpx}",
+            "--json"
+          ],
+          "path": "format"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR41.json
+++ b/gym/packs/serialization/reference/SR41.json
@@ -1,0 +1,23 @@
+{
+  "id": "SR41",
+  "steps": [
+    {
+      "answer": {
+        "identical": {
+          "cmd": [
+            "export-hwpx",
+            "{input}",
+            "{sub:conv.hwpx}",
+            "--verify-pages",
+            "--json"
+          ],
+          "path": "verifyPages.identical",
+          "allowExits": [
+            0,
+            4
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR42.json
+++ b/gym/packs/serialization/reference/SR42.json
@@ -1,0 +1,23 @@
+{
+  "id": "SR42",
+  "steps": [
+    {
+      "answer": {
+        "identical": {
+          "cmd": [
+            "export-hwpx",
+            "{input}",
+            "{sub:conv.hwpx}",
+            "--verify",
+            "--json"
+          ],
+          "path": "verify.identical",
+          "allowExits": [
+            0,
+            3
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR43.json
+++ b/gym/packs/serialization/reference/SR43.json
@@ -1,0 +1,19 @@
+{
+  "id": "SR43",
+  "steps": [
+    {
+      "answer": {
+        "format": {
+          "cmd": [
+            "export-doclang",
+            "{input}",
+            "-o",
+            "{sub:out.doclang}",
+            "--json"
+          ],
+          "path": "format"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR44.json
+++ b/gym/packs/serialization/reference/SR44.json
@@ -1,0 +1,19 @@
+{
+  "id": "SR44",
+  "steps": [
+    {
+      "answer": {
+        "version": {
+          "cmd": [
+            "export-doclang",
+            "{input}",
+            "-o",
+            "{sub:out.doclang}",
+            "--json"
+          ],
+          "path": "doclangVersion"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR45.json
+++ b/gym/packs/serialization/reference/SR45.json
@@ -1,0 +1,19 @@
+{
+  "id": "SR45",
+  "steps": [
+    {
+      "answer": {
+        "loss": {
+          "cmd": [
+            "export-doclang",
+            "{input}",
+            "-o",
+            "{sub:out.doclang}",
+            "--json"
+          ],
+          "path": "lossCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR46.json
+++ b/gym/packs/serialization/reference/SR46.json
@@ -1,0 +1,19 @@
+{
+  "id": "SR46",
+  "steps": [
+    {
+      "answer": {
+        "pages": {
+          "cmd": [
+            "export-markdown",
+            "{input}",
+            "-o",
+            "{sub:md}",
+            "--json"
+          ],
+          "path": "pageCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR47.json
+++ b/gym/packs/serialization/reference/SR47.json
@@ -1,0 +1,19 @@
+{
+  "id": "SR47",
+  "steps": [
+    {
+      "answer": {
+        "pages": {
+          "cmd": [
+            "export-markdown",
+            "{input}",
+            "-o",
+            "{sub:md}",
+            "--json"
+          ],
+          "path": "pageCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR48.json
+++ b/gym/packs/serialization/reference/SR48.json
@@ -1,0 +1,25 @@
+{
+  "id": "SR48",
+  "steps": [
+    {
+      "run": [
+        "convert",
+        "{input}",
+        "{sub:conv.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "answer": {
+        "pages": {
+          "cmd": [
+            "info",
+            "{sub:conv.hwp}",
+            "--json"
+          ],
+          "path": "pageCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR49.json
+++ b/gym/packs/serialization/reference/SR49.json
@@ -1,0 +1,19 @@
+{
+  "id": "SR49",
+  "steps": [
+    {
+      "answer": {
+        "pages": {
+          "cmd": [
+            "export-pdf",
+            "{input}",
+            "-o",
+            "{sub:out.pdf}",
+            "--json"
+          ],
+          "path": "pageCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR50.json
+++ b/gym/packs/serialization/reference/SR50.json
@@ -1,0 +1,19 @@
+{
+  "id": "SR50",
+  "steps": [
+    {
+      "answer": {
+        "backend": {
+          "cmd": [
+            "export-pdf",
+            "{input}",
+            "-o",
+            "{sub:out.pdf}",
+            "--json"
+          ],
+          "path": "backend"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR51.json
+++ b/gym/packs/serialization/reference/SR51.json
@@ -1,0 +1,18 @@
+{
+  "id": "SR51",
+  "steps": [
+    {
+      "answer": {
+        "format": {
+          "cmd": [
+            "export-hwpx",
+            "{input}",
+            "{sub:conv.hwpx}",
+            "--json"
+          ],
+          "path": "format"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR52.json
+++ b/gym/packs/serialization/reference/SR52.json
@@ -1,0 +1,19 @@
+{
+  "id": "SR52",
+  "steps": [
+    {
+      "answer": {
+        "loss": {
+          "cmd": [
+            "export-doclang",
+            "{input}",
+            "-o",
+            "{sub:out.doclang}",
+            "--json"
+          ],
+          "path": "lossCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR53.json
+++ b/gym/packs/serialization/reference/SR53.json
@@ -1,0 +1,22 @@
+{
+  "id": "SR53",
+  "steps": [
+    {
+      "answer": {
+        "identical": {
+          "cmd": [
+            "ir-diff",
+            "{input}",
+            "{input}",
+            "--json"
+          ],
+          "path": "identical",
+          "allowExits": [
+            0,
+            3
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR54.json
+++ b/gym/packs/serialization/reference/SR54.json
@@ -1,0 +1,22 @@
+{
+  "id": "SR54",
+  "steps": [
+    {
+      "answer": {
+        "paragraphsKept": {
+          "cmd": [
+            "extract-pages",
+            "{input}",
+            "{sub:slice.hwp}",
+            "--from",
+            "3",
+            "--to",
+            "3",
+            "--json"
+          ],
+          "path": "paragraphsKept"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR55.json
+++ b/gym/packs/serialization/reference/SR55.json
@@ -1,0 +1,17 @@
+{
+  "id": "SR55",
+  "steps": [
+    {
+      "answer": {
+        "pages": {
+          "cmd": [
+            "info",
+            "{input}",
+            "--json"
+          ],
+          "path": "pageCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/reference/SR56.json
+++ b/gym/packs/serialization/reference/SR56.json
@@ -1,0 +1,23 @@
+{
+  "id": "SR56",
+  "steps": [
+    {
+      "answer": {
+        "identical": {
+          "cmd": [
+            "convert",
+            "{input}",
+            "{sub:conv.hwp}",
+            "--verify-pages",
+            "--json"
+          ],
+          "path": "verifyPages.identical",
+          "allowExits": [
+            0,
+            4
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR09.json
+++ b/gym/packs/serialization/tasks/SR09.json
@@ -1,0 +1,50 @@
+{
+  "id": "SR09",
+  "tier": 2,
+  "title": "HWPX를 편집 가능 HWP5로",
+  "input": "samples/hwpx_sample2.hwpx",
+  "instructions": "입력(HWPX)을 편집 가능 HWP5 로 변환해 conv.hwp 를 제출하고, 변환 봉투의 형식 표기를 answer.json 에 {\"format\": \"...\"} 로 적어라. 힌트: rhwp convert --json.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "conv.hwp",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "HWP5 산출",
+      "op": "file_exists",
+      "file": "conv.hwp",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "conv.hwp"
+    },
+    {
+      "name": "info 형식",
+      "op": "value_eq",
+      "value": "hwp5",
+      "path": "format",
+      "cmd": [
+        "info",
+        "{file:conv.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "변환 봉투 형식",
+      "op": "answer_eq",
+      "answer": "format",
+      "path": "format",
+      "cmd": [
+        "convert",
+        "{input}",
+        "{file:conv.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR10.json
+++ b/gym/packs/serialization/tasks/SR10.json
@@ -1,0 +1,43 @@
+{
+  "id": "SR10",
+  "tier": 2,
+  "title": "쪽 범위 저장 후 쪽수",
+  "input": "samples/exam-kor-2p.hwp",
+  "instructions": "입력의 첫 쪽만 남겨 slice.hwp 로 저장하고, 추출 후 쪽수를 answer.json 에 {\"pagesAfter\": N} 으로 제출하라. 힌트: rhwp extract-pages --from 1 --to 1 --json 의 pagesAfter. 재조판으로 요청 범위와 결과 쪽수가 다를 수 있다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "slice.hwp",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "추출물 실재",
+      "op": "file_exists",
+      "file": "slice.hwp",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "slice.hwp"
+    },
+    {
+      "name": "추출 후 쪽수",
+      "op": "answer_eq",
+      "answer": "pagesAfter",
+      "path": "pagesAfter",
+      "cmd": [
+        "extract-pages",
+        "{input}",
+        "{file:slice.hwp}",
+        "--from",
+        "1",
+        "--to",
+        "1",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR11.json
+++ b/gym/packs/serialization/tasks/SR11.json
@@ -1,0 +1,53 @@
+{
+  "id": "SR11",
+  "tier": 2,
+  "title": "PDF 내보내기 쪽수",
+  "input": "samples/para-001.hwp",
+  "instructions": "입력을 PDF 로 내보내 out.pdf 를 제출하고, 렌더된 쪽 수를 answer.json 에 {\"pages\": N} 으로 적어라. 힌트: rhwp export-pdf --json 의 pageCount.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "out.pdf",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "PDF 산출",
+      "op": "file_exists",
+      "file": "out.pdf",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "out.pdf"
+    },
+    {
+      "name": "PDF 형식",
+      "op": "value_eq",
+      "value": "pdf",
+      "path": "format",
+      "cmd": [
+        "export-pdf",
+        "{input}",
+        "-o",
+        "{file:out.pdf}",
+        "--json"
+      ]
+    },
+    {
+      "name": "렌더 쪽 수",
+      "op": "answer_eq",
+      "answer": "pages",
+      "path": "pageCount",
+      "cmd": [
+        "export-pdf",
+        "{input}",
+        "-o",
+        "{file:out.pdf}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR12.json
+++ b/gym/packs/serialization/tasks/SR12.json
@@ -1,0 +1,32 @@
+{
+  "id": "SR12",
+  "tier": 3,
+  "title": "기존 HWP·HWPX 쌍 IR 대조",
+  "input": "samples/pic2.hwp",
+  "instructions": "입력과 짝 HWPX(samples/pic2.hwpx) 의 IR 동일 여부를 answer.json 에 {\"identical\": true|false} 로 적어라. 힌트: rhwp ir-diff.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "IR 동일 판정",
+      "op": "answer_eq",
+      "answer": "identical",
+      "path": "identical",
+      "cmd": [
+        "ir-diff",
+        "{input}",
+        "samples/pic2.hwpx",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "변환"
+}

--- a/gym/packs/serialization/tasks/SR13.json
+++ b/gym/packs/serialization/tasks/SR13.json
@@ -1,0 +1,50 @@
+{
+  "id": "SR13",
+  "tier": 2,
+  "title": "이미 편집 가능한 HWP5를 다시 convert",
+  "input": "samples/para-001.hwp",
+  "instructions": "입력은 이미 편집 가능한 HWP5 다. 그래도 convert 로 conv.hwp 를 만들고, 변환 봉투의 배포용 여부(wasDistribution)를 answer.json 에 {\"wasDistribution\": true|false} 로 적어라. convert 는 입력이 이미 편집 가능해도 산출물을 쓰고 봉투를 낸다 — 배포용 해제만이 전부가 아니다. 힌트: rhwp convert --json 의 wasDistribution.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "conv.hwp",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "HWP5 산출",
+      "op": "file_exists",
+      "file": "conv.hwp",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "conv.hwp"
+    },
+    {
+      "name": "info 형식",
+      "op": "value_eq",
+      "value": "hwp5",
+      "path": "format",
+      "cmd": [
+        "info",
+        "{file:conv.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "배포용 여부",
+      "op": "answer_eq",
+      "answer": "wasDistribution",
+      "path": "wasDistribution",
+      "cmd": [
+        "convert",
+        "{input}",
+        "{file:conv.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR14.json
+++ b/gym/packs/serialization/tasks/SR14.json
@@ -1,0 +1,43 @@
+{
+  "id": "SR14",
+  "tier": 2,
+  "title": "쪽 범위 전체 추출 후 원본 쪽수",
+  "input": "samples/exam-kor-2p.hwp",
+  "instructions": "입력의 1~2쪽을 그대로 남겨 slice.hwp 로 저장하고, 추출 전 원본 쪽수를 answer.json 에 {\"pagesBefore\": N} 으로 제출하라. --from/--to 는 1 기준이다. 힌트: rhwp extract-pages --from 1 --to 2 --json 의 pagesBefore.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "slice.hwp",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "추출물 실재",
+      "op": "file_exists",
+      "file": "slice.hwp",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "slice.hwp"
+    },
+    {
+      "name": "추출 전 쪽수",
+      "op": "answer_eq",
+      "answer": "pagesBefore",
+      "path": "pagesBefore",
+      "cmd": [
+        "extract-pages",
+        "{input}",
+        "{file:slice.hwp}",
+        "--from",
+        "1",
+        "--to",
+        "2",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR15.json
+++ b/gym/packs/serialization/tasks/SR15.json
@@ -1,0 +1,53 @@
+{
+  "id": "SR15",
+  "tier": 2,
+  "title": "PDF 내보내기 백엔드",
+  "input": "samples/table-001.hwp",
+  "instructions": "입력을 PDF 로 내보내 out.pdf 를 제출하고, 사용한 백엔드를 answer.json 에 {\"backend\": \"...\"} 로 적어라. 힌트: rhwp export-pdf --json 의 backend. 기본은 svg 경로이며, 박제하지 말고 봉투를 읽어라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "out.pdf",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "PDF 산출",
+      "op": "file_exists",
+      "file": "out.pdf",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "out.pdf"
+    },
+    {
+      "name": "PDF 형식",
+      "op": "value_eq",
+      "value": "pdf",
+      "path": "format",
+      "cmd": [
+        "export-pdf",
+        "{input}",
+        "-o",
+        "{file:out.pdf}",
+        "--json"
+      ]
+    },
+    {
+      "name": "PDF 백엔드",
+      "op": "answer_eq",
+      "answer": "backend",
+      "path": "backend",
+      "cmd": [
+        "export-pdf",
+        "{input}",
+        "-o",
+        "{file:out.pdf}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR16.json
+++ b/gym/packs/serialization/tasks/SR16.json
@@ -1,0 +1,32 @@
+{
+  "id": "SR16",
+  "tier": 2,
+  "title": "같은 파일 IR 자기대조",
+  "input": "samples/table-001.hwp",
+  "instructions": "입력을 자기 자신과 ir-diff 해 IR 동일 여부를 answer.json 에 {\"identical\": true|false} 로 적어라. 같은 바이트를 두 번 읽으면 동일해야 한다. 힌트: rhwp ir-diff <입력> <입력> --json. 차이가 있으면 exit 3 이지만 봉투는 남는다(판정은 데이터).",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "IR 동일 판정",
+      "op": "answer_eq",
+      "answer": "identical",
+      "path": "identical",
+      "cmd": [
+        "ir-diff",
+        "{input}",
+        "{input}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "변환"
+}

--- a/gym/packs/serialization/tasks/SR17.json
+++ b/gym/packs/serialization/tasks/SR17.json
@@ -1,0 +1,55 @@
+{
+  "id": "SR17",
+  "tier": 3,
+  "title": "HWPX convert --verify IR 자기검증",
+  "input": "samples/hwpx_sample2.hwpx",
+  "instructions": "입력을 편집 가능 HWP5 로 변환할 때 --verify 를 켜고, 검증 객체의 identical 을 answer.json 에 {\"identical\": true|false} 로 적어라. 차이가 있어도 산출물은 남고 봉투의 verify 가 판정한다(exit 3). 힌트: rhwp convert --verify --json 의 verify.identical.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "conv.hwp",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "HWP5 산출",
+      "op": "file_exists",
+      "file": "conv.hwp",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "conv.hwp"
+    },
+    {
+      "name": "info 형식",
+      "op": "value_eq",
+      "value": "hwp5",
+      "path": "format",
+      "cmd": [
+        "info",
+        "{file:conv.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "verify IR 동일",
+      "op": "answer_eq",
+      "answer": "identical",
+      "path": "verify.identical",
+      "cmd": [
+        "convert",
+        "{input}",
+        "{file:conv.hwp}",
+        "--verify",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR18.json
+++ b/gym/packs/serialization/tasks/SR18.json
@@ -1,0 +1,43 @@
+{
+  "id": "SR18",
+  "tier": 2,
+  "title": "둘째 쪽만 남긴 뒤 잔여 문단 수",
+  "input": "samples/exam-kor-2p.hwp",
+  "instructions": "입력의 둘째 쪽만 남겨 slice.hwp 로 저장하고, 남긴 문단 수를 answer.json 에 {\"paragraphsKept\": N} 으로 제출하라. extract-pages 는 쪽 단위로 자르되 문단 단위로 지운다. 힌트: rhwp extract-pages --from 2 --to 2 --json 의 paragraphsKept.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "slice.hwp",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "추출물 실재",
+      "op": "file_exists",
+      "file": "slice.hwp",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "slice.hwp"
+    },
+    {
+      "name": "남긴 문단 수",
+      "op": "answer_eq",
+      "answer": "paragraphsKept",
+      "path": "paragraphsKept",
+      "cmd": [
+        "extract-pages",
+        "{input}",
+        "{file:slice.hwp}",
+        "--from",
+        "2",
+        "--to",
+        "2",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR19.json
+++ b/gym/packs/serialization/tasks/SR19.json
@@ -1,0 +1,53 @@
+{
+  "id": "SR19",
+  "tier": 2,
+  "title": "그림 문서 PDF 쪽수",
+  "input": "samples/pic2.hwp",
+  "instructions": "그림이 있는 입력을 PDF 로 내보내 out.pdf 를 제출하고, 렌더된 쪽 수를 answer.json 에 {\"pages\": N} 으로 적어라. 힌트: rhwp export-pdf --json 의 pageCount. 골든 PDF 바이트를 박제하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "out.pdf",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "PDF 산출",
+      "op": "file_exists",
+      "file": "out.pdf",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "out.pdf"
+    },
+    {
+      "name": "PDF 형식",
+      "op": "value_eq",
+      "value": "pdf",
+      "path": "format",
+      "cmd": [
+        "export-pdf",
+        "{input}",
+        "-o",
+        "{file:out.pdf}",
+        "--json"
+      ]
+    },
+    {
+      "name": "렌더 쪽 수",
+      "op": "answer_eq",
+      "answer": "pages",
+      "path": "pageCount",
+      "cmd": [
+        "export-pdf",
+        "{input}",
+        "-o",
+        "{file:out.pdf}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR20.json
+++ b/gym/packs/serialization/tasks/SR20.json
@@ -1,0 +1,32 @@
+{
+  "id": "SR20",
+  "tier": 3,
+  "title": "기존 HWP·HWPX 쌍 IR 차이 건수",
+  "input": "samples/pic2.hwp",
+  "instructions": "입력과 짝 HWPX(samples/pic2.hwpx) 의 IR 차이 건수를 answer.json 에 {\"diffs\": N} 으로 적어라. identical 만 보면 차이 규모가 가려진다. 힌트: rhwp ir-diff --json 의 diffCount. 차이가 있으면 exit 3 이지만 봉투는 남는다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "IR 차이 건수",
+      "op": "answer_eq",
+      "answer": "diffs",
+      "path": "diffCount",
+      "cmd": [
+        "ir-diff",
+        "{input}",
+        "samples/pic2.hwpx",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "변환"
+}

--- a/gym/packs/serialization/tasks/SR21.json
+++ b/gym/packs/serialization/tasks/SR21.json
@@ -1,0 +1,55 @@
+{
+  "id": "SR21",
+  "tier": 3,
+  "title": "convert --verify-pages 쪽수 자기검증",
+  "input": "samples/para-001.hwp",
+  "instructions": "입력을 convert 할 때 --verify-pages 를 켜고, 쪽수 검증 객체의 identical 을 answer.json 에 {\"identical\": true|false} 로 적어라. 쪽수가 어긋나면 산출물은 남고 exit 4 다. 힌트: rhwp convert --verify-pages --json 의 verifyPages.identical.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "conv.hwp",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "HWP5 산출",
+      "op": "file_exists",
+      "file": "conv.hwp",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "conv.hwp"
+    },
+    {
+      "name": "info 형식",
+      "op": "value_eq",
+      "value": "hwp5",
+      "path": "format",
+      "cmd": [
+        "info",
+        "{file:conv.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "verifyPages 동일",
+      "op": "answer_eq",
+      "answer": "identical",
+      "path": "verifyPages.identical",
+      "cmd": [
+        "convert",
+        "{input}",
+        "{file:conv.hwp}",
+        "--verify-pages",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        4
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR22.json
+++ b/gym/packs/serialization/tasks/SR22.json
@@ -1,0 +1,43 @@
+{
+  "id": "SR22",
+  "tier": 3,
+  "title": "다중 쪽 문서에서 첫 쪽만 남긴 원본 쪽수",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "중첩 셀 페이지네이션 샘플의 첫 쪽만 남겨 slice.hwp 로 저장하고, 추출 전 원본 쪽수를 answer.json 에 {\"pagesBefore\": N} 으로 제출하라. 재조판으로 pagesAfter 는 1이 아닐 수 있다. 힌트: rhwp extract-pages --from 1 --to 1 --json 의 pagesBefore.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "slice.hwp",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "추출물 실재",
+      "op": "file_exists",
+      "file": "slice.hwp",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "slice.hwp"
+    },
+    {
+      "name": "추출 전 쪽수",
+      "op": "answer_eq",
+      "answer": "pagesBefore",
+      "path": "pagesBefore",
+      "cmd": [
+        "extract-pages",
+        "{input}",
+        "{file:slice.hwp}",
+        "--from",
+        "1",
+        "--to",
+        "1",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR23.json
+++ b/gym/packs/serialization/tasks/SR23.json
@@ -1,0 +1,53 @@
+{
+  "id": "SR23",
+  "tier": 2,
+  "title": "HWPX 원본 PDF 렌더 쪽수",
+  "input": "samples/hwpx/143E433F503322BD33.hwpx",
+  "instructions": "HWPX 원본을 PDF 로 내보내 out.pdf 를 제출하고, 실제 렌더한 쪽 수를 answer.json 에 {\"rendered\": N} 으로 적어라. pageCount 와 renderedCount 는 보통 같지만, 봉투 필드를 혼동하면 오답이다. 힌트: rhwp export-pdf --json 의 renderedCount.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "out.pdf",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "PDF 산출",
+      "op": "file_exists",
+      "file": "out.pdf",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "out.pdf"
+    },
+    {
+      "name": "PDF 형식",
+      "op": "value_eq",
+      "value": "pdf",
+      "path": "format",
+      "cmd": [
+        "export-pdf",
+        "{input}",
+        "-o",
+        "{file:out.pdf}",
+        "--json"
+      ]
+    },
+    {
+      "name": "렌더한 쪽 수",
+      "op": "answer_eq",
+      "answer": "rendered",
+      "path": "renderedCount",
+      "cmd": [
+        "export-pdf",
+        "{input}",
+        "-o",
+        "{file:out.pdf}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR24.json
+++ b/gym/packs/serialization/tasks/SR24.json
@@ -1,0 +1,32 @@
+{
+  "id": "SR24",
+  "tier": 3,
+  "title": "서로 다른 두 문서 IR 불일치",
+  "input": "samples/table-001.hwp",
+  "instructions": "입력과 다른 문서(samples/para-001.hwp) 를 ir-diff 해 IR 동일 여부를 answer.json 에 {\"identical\": true|false} 로 적어라. 다른 문서면 보통 차이가 나고 exit 3 이다. 봉투의 identical 을 읽고, 종료 코드만으로 추측하지 마라. 힌트: rhwp ir-diff --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "IR 동일 판정",
+      "op": "answer_eq",
+      "answer": "identical",
+      "path": "identical",
+      "cmd": [
+        "ir-diff",
+        "{input}",
+        "samples/para-001.hwp",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "변환"
+}

--- a/gym/packs/serialization/tasks/SR25.json
+++ b/gym/packs/serialization/tasks/SR25.json
@@ -1,0 +1,50 @@
+{
+  "id": "SR25",
+  "tier": 2,
+  "title": "다른 HWPX 표본을 편집 가능 HWP5로",
+  "input": "samples/hwpx/143E433F503322BD33.hwpx",
+  "instructions": "HWPX 원본을 편집 가능 HWP5 로 변환해 conv.hwp 를 제출하고, 변환 봉투의 형식 표기를 answer.json 에 {\"format\": \"...\"} 로 적어라. 힌트: rhwp convert --json 의 format. SR09 와 같은 명령이지만 표본이 다르다 — 한 파일이 통과해도 다른 컨테이너에서 형식이 바뀌면 실패다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "conv.hwp",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "HWP5 산출",
+      "op": "file_exists",
+      "file": "conv.hwp",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "conv.hwp"
+    },
+    {
+      "name": "info 형식",
+      "op": "value_eq",
+      "value": "hwp5",
+      "path": "format",
+      "cmd": [
+        "info",
+        "{file:conv.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "변환 봉투 형식",
+      "op": "answer_eq",
+      "answer": "format",
+      "path": "format",
+      "cmd": [
+        "convert",
+        "{input}",
+        "{file:conv.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR26.json
+++ b/gym/packs/serialization/tasks/SR26.json
@@ -1,0 +1,50 @@
+{
+  "id": "SR26",
+  "tier": 2,
+  "title": "표 문서 HWP5를 다시 convert",
+  "input": "samples/table-001.hwp",
+  "instructions": "표가 있는 편집 가능 HWP5 를 convert 로 conv.hwp 로 만들고, 변환 봉투의 배포용 여부(wasDistribution)를 answer.json 에 {\"wasDistribution\": true|false} 로 적어라. convert 는 이미 편집 가능한 입력에도 산출물을 쓴다. 힌트: rhwp convert --json 의 wasDistribution.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "conv.hwp",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "HWP5 산출",
+      "op": "file_exists",
+      "file": "conv.hwp",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "conv.hwp"
+    },
+    {
+      "name": "info 형식",
+      "op": "value_eq",
+      "value": "hwp5",
+      "path": "format",
+      "cmd": [
+        "info",
+        "{file:conv.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "배포용 여부",
+      "op": "answer_eq",
+      "answer": "wasDistribution",
+      "path": "wasDistribution",
+      "cmd": [
+        "convert",
+        "{input}",
+        "{file:conv.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR27.json
+++ b/gym/packs/serialization/tasks/SR27.json
@@ -1,0 +1,55 @@
+{
+  "id": "SR27",
+  "tier": 3,
+  "title": "이미 편집 가능한 HWP5 convert --verify",
+  "input": "samples/para-001.hwp",
+  "instructions": "편집 가능 HWP5 를 convert --verify 로 conv.hwp 를 만들고, 검증 객체의 identical 을 answer.json 에 {\"identical\": true|false} 로 적어라. 차이가 있어도 산출물은 남고 exit 3 이다. 힌트: rhwp convert --verify --json 의 verify.identical.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "conv.hwp",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "HWP5 산출",
+      "op": "file_exists",
+      "file": "conv.hwp",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "conv.hwp"
+    },
+    {
+      "name": "info 형식",
+      "op": "value_eq",
+      "value": "hwp5",
+      "path": "format",
+      "cmd": [
+        "info",
+        "{file:conv.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "verify IR 동일",
+      "op": "answer_eq",
+      "answer": "identical",
+      "path": "verify.identical",
+      "cmd": [
+        "convert",
+        "{input}",
+        "{file:conv.hwp}",
+        "--verify",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR28.json
+++ b/gym/packs/serialization/tasks/SR28.json
@@ -1,0 +1,43 @@
+{
+  "id": "SR28",
+  "tier": 2,
+  "title": "3쪽 문서에서 첫 쪽만 남긴 뒤 쪽수",
+  "input": "samples/exam-kor-3p.hwp",
+  "instructions": "3쪽 표본의 첫 쪽만 남겨 slice.hwp 로 저장하고, 추출 후 쪽수를 answer.json 에 {\"pagesAfter\": N} 으로 제출하라. --from/--to 는 1 기준이다. 재조판으로 요청 범위와 결과 쪽수가 다를 수 있다. 힌트: rhwp extract-pages --from 1 --to 1 --json 의 pagesAfter.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "slice.hwp",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "추출물 실재",
+      "op": "file_exists",
+      "file": "slice.hwp",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "slice.hwp"
+    },
+    {
+      "name": "추출 후 쪽수",
+      "op": "answer_eq",
+      "answer": "pagesAfter",
+      "path": "pagesAfter",
+      "cmd": [
+        "extract-pages",
+        "{input}",
+        "{file:slice.hwp}",
+        "--from",
+        "1",
+        "--to",
+        "1",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR29.json
+++ b/gym/packs/serialization/tasks/SR29.json
@@ -1,0 +1,43 @@
+{
+  "id": "SR29",
+  "tier": 2,
+  "title": "3쪽 문서 전체 추출 전 원본 쪽수",
+  "input": "samples/exam-kor-3p.hwp",
+  "instructions": "3쪽 표본의 1~3쪽을 그대로 남겨 slice.hwp 로 저장하고, 추출 전 원본 쪽수를 answer.json 에 {\"pagesBefore\": N} 으로 제출하라. 힌트: rhwp extract-pages --from 1 --to 3 --json 의 pagesBefore.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "slice.hwp",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "추출물 실재",
+      "op": "file_exists",
+      "file": "slice.hwp",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "slice.hwp"
+    },
+    {
+      "name": "추출 전 쪽수",
+      "op": "answer_eq",
+      "answer": "pagesBefore",
+      "path": "pagesBefore",
+      "cmd": [
+        "extract-pages",
+        "{input}",
+        "{file:slice.hwp}",
+        "--from",
+        "1",
+        "--to",
+        "3",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR30.json
+++ b/gym/packs/serialization/tasks/SR30.json
@@ -1,0 +1,43 @@
+{
+  "id": "SR30",
+  "tier": 3,
+  "title": "4쪽 문서에서 첫 쪽만 남긴 뒤 지운 문단 수",
+  "input": "samples/exam-kor-4p.hwp",
+  "instructions": "4쪽 표본의 첫 쪽만 남겨 slice.hwp 로 저장하고, 지운 문단 수를 answer.json 에 {\"paragraphsRemoved\": N} 으로 제출하라. extract-pages 는 쪽 단위로 자르되 문단 단위로 지운다. 힌트: rhwp extract-pages --from 1 --to 1 --json 의 paragraphsRemoved.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "slice.hwp",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "추출물 실재",
+      "op": "file_exists",
+      "file": "slice.hwp",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "slice.hwp"
+    },
+    {
+      "name": "지운 문단 수",
+      "op": "answer_eq",
+      "answer": "paragraphsRemoved",
+      "path": "paragraphsRemoved",
+      "cmd": [
+        "extract-pages",
+        "{input}",
+        "{file:slice.hwp}",
+        "--from",
+        "1",
+        "--to",
+        "1",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR31.json
+++ b/gym/packs/serialization/tasks/SR31.json
@@ -1,0 +1,43 @@
+{
+  "id": "SR31",
+  "tier": 2,
+  "title": "1쪽 문서에서 그 쪽만 남긴 뒤 쪽수",
+  "input": "samples/exam-kor-1p.hwp",
+  "instructions": "1쪽 표본의 첫 쪽만 남겨 slice.hwp 로 저장하고, 추출 후 쪽수를 answer.json 에 {\"pagesAfter\": N} 으로 제출하라. 입력이 이미 1쪽이어도 extract-pages 는 산출물을 새로 쓴다. 힌트: rhwp extract-pages --from 1 --to 1 --json 의 pagesAfter.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "slice.hwp",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "추출물 실재",
+      "op": "file_exists",
+      "file": "slice.hwp",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "slice.hwp"
+    },
+    {
+      "name": "추출 후 쪽수",
+      "op": "answer_eq",
+      "answer": "pagesAfter",
+      "path": "pagesAfter",
+      "cmd": [
+        "extract-pages",
+        "{input}",
+        "{file:slice.hwp}",
+        "--from",
+        "1",
+        "--to",
+        "1",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR32.json
+++ b/gym/packs/serialization/tasks/SR32.json
@@ -1,0 +1,53 @@
+{
+  "id": "SR32",
+  "tier": 2,
+  "title": "표 문서 PDF 형식 표기",
+  "input": "samples/table-001.hwp",
+  "instructions": "표 문서를 PDF 로 내보내 out.pdf 를 제출하고, 변환 봉투의 형식 표기를 answer.json 에 {\"format\": \"...\"} 로 적어라. 힌트: rhwp export-pdf --json 의 format. 골든 PDF 바이트를 박제하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "out.pdf",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "PDF 산출",
+      "op": "file_exists",
+      "file": "out.pdf",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "out.pdf"
+    },
+    {
+      "name": "PDF 형식",
+      "op": "value_eq",
+      "value": "pdf",
+      "path": "format",
+      "cmd": [
+        "export-pdf",
+        "{input}",
+        "-o",
+        "{file:out.pdf}",
+        "--json"
+      ]
+    },
+    {
+      "name": "변환 봉투 형식",
+      "op": "answer_eq",
+      "answer": "format",
+      "path": "format",
+      "cmd": [
+        "export-pdf",
+        "{input}",
+        "-o",
+        "{file:out.pdf}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR33.json
+++ b/gym/packs/serialization/tasks/SR33.json
@@ -1,0 +1,53 @@
+{
+  "id": "SR33",
+  "tier": 2,
+  "title": "2쪽 시험지 PDF 쪽수",
+  "input": "samples/exam-kor-2p.hwp",
+  "instructions": "2쪽 시험지를 PDF 로 내보내 out.pdf 를 제출하고, 렌더된 쪽 수를 answer.json 에 {\"pages\": N} 으로 적어라. 힌트: rhwp export-pdf --json 의 pageCount.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "out.pdf",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "PDF 산출",
+      "op": "file_exists",
+      "file": "out.pdf",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "out.pdf"
+    },
+    {
+      "name": "PDF 형식",
+      "op": "value_eq",
+      "value": "pdf",
+      "path": "format",
+      "cmd": [
+        "export-pdf",
+        "{input}",
+        "-o",
+        "{file:out.pdf}",
+        "--json"
+      ]
+    },
+    {
+      "name": "렌더 쪽 수",
+      "op": "answer_eq",
+      "answer": "pages",
+      "path": "pageCount",
+      "cmd": [
+        "export-pdf",
+        "{input}",
+        "-o",
+        "{file:out.pdf}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR34.json
+++ b/gym/packs/serialization/tasks/SR34.json
@@ -1,0 +1,53 @@
+{
+  "id": "SR34",
+  "tier": 2,
+  "title": "2쪽 시험지 PDF 실제 렌더 쪽수",
+  "input": "samples/exam-kor-2p.hwp",
+  "instructions": "2쪽 시험지를 PDF 로 내보내 out.pdf 를 제출하고, 실제 렌더한 쪽 수를 answer.json 에 {\"rendered\": N} 으로 적어라. pageCount 와 renderedCount 는 보통 같지만 봉투 필드를 혼동하면 오답이다. 힌트: rhwp export-pdf --json 의 renderedCount.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "out.pdf",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "PDF 산출",
+      "op": "file_exists",
+      "file": "out.pdf",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "out.pdf"
+    },
+    {
+      "name": "PDF 형식",
+      "op": "value_eq",
+      "value": "pdf",
+      "path": "format",
+      "cmd": [
+        "export-pdf",
+        "{input}",
+        "-o",
+        "{file:out.pdf}",
+        "--json"
+      ]
+    },
+    {
+      "name": "렌더한 쪽 수",
+      "op": "answer_eq",
+      "answer": "rendered",
+      "path": "renderedCount",
+      "cmd": [
+        "export-pdf",
+        "{input}",
+        "-o",
+        "{file:out.pdf}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR35.json
+++ b/gym/packs/serialization/tasks/SR35.json
@@ -1,0 +1,53 @@
+{
+  "id": "SR35",
+  "tier": 2,
+  "title": "HWPX 표본 PDF 백엔드",
+  "input": "samples/hwpx_sample2.hwpx",
+  "instructions": "HWPX 표본을 PDF 로 내보내 out.pdf 를 제출하고, 사용한 백엔드를 answer.json 에 {\"backend\": \"...\"} 로 적어라. 기본은 svg 경로이며, 박제하지 말고 봉투를 읽어라. 힌트: rhwp export-pdf --json 의 backend.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "out.pdf",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "PDF 산출",
+      "op": "file_exists",
+      "file": "out.pdf",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "out.pdf"
+    },
+    {
+      "name": "PDF 형식",
+      "op": "value_eq",
+      "value": "pdf",
+      "path": "format",
+      "cmd": [
+        "export-pdf",
+        "{input}",
+        "-o",
+        "{file:out.pdf}",
+        "--json"
+      ]
+    },
+    {
+      "name": "PDF 백엔드",
+      "op": "answer_eq",
+      "answer": "backend",
+      "path": "backend",
+      "cmd": [
+        "export-pdf",
+        "{input}",
+        "-o",
+        "{file:out.pdf}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR36.json
+++ b/gym/packs/serialization/tasks/SR36.json
@@ -1,0 +1,32 @@
+{
+  "id": "SR36",
+  "tier": 2,
+  "title": "문단 문서 IR 자기대조",
+  "input": "samples/para-001.hwp",
+  "instructions": "입력을 자기 자신과 ir-diff 해 IR 동일 여부를 answer.json 에 {\"identical\": true|false} 로 적어라. 같은 바이트를 두 번 읽으면 동일해야 한다. 힌트: rhwp ir-diff <입력> <입력> --json. 차이가 있으면 exit 3 이지만 봉투는 남는다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "IR 동일 판정",
+      "op": "answer_eq",
+      "answer": "identical",
+      "path": "identical",
+      "cmd": [
+        "ir-diff",
+        "{input}",
+        "{input}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "변환"
+}

--- a/gym/packs/serialization/tasks/SR37.json
+++ b/gym/packs/serialization/tasks/SR37.json
@@ -1,0 +1,32 @@
+{
+  "id": "SR37",
+  "tier": 3,
+  "title": "같은 줄기 HWP·HWPX 쌍 IR 대조",
+  "input": "samples/hwpx_sample2.hwp",
+  "instructions": "입력과 짝 HWPX(samples/hwpx_sample2.hwpx) 의 IR 동일 여부를 answer.json 에 {\"identical\": true|false} 로 적어라. 힌트: rhwp ir-diff. 종료 코드만으로 추측하지 말고 봉투의 identical 을 읽어라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "IR 동일 판정",
+      "op": "answer_eq",
+      "answer": "identical",
+      "path": "identical",
+      "cmd": [
+        "ir-diff",
+        "{input}",
+        "samples/hwpx_sample2.hwpx",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "변환"
+}

--- a/gym/packs/serialization/tasks/SR38.json
+++ b/gym/packs/serialization/tasks/SR38.json
@@ -1,0 +1,32 @@
+{
+  "id": "SR38",
+  "tier": 3,
+  "title": "표 문서와 시험지 IR 불일치",
+  "input": "samples/table-001.hwp",
+  "instructions": "입력과 다른 문서(samples/exam-kor-2p.hwp) 를 ir-diff 해 IR 동일 여부를 answer.json 에 {\"identical\": true|false} 로 적어라. 다른 문서면 보통 차이가 나고 exit 3 이다. 힌트: rhwp ir-diff --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "IR 동일 판정",
+      "op": "answer_eq",
+      "answer": "identical",
+      "path": "identical",
+      "cmd": [
+        "ir-diff",
+        "{input}",
+        "samples/exam-kor-2p.hwp",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "변환"
+}

--- a/gym/packs/serialization/tasks/SR39.json
+++ b/gym/packs/serialization/tasks/SR39.json
@@ -1,0 +1,32 @@
+{
+  "id": "SR39",
+  "tier": 3,
+  "title": "그림 문서 연도 쌍 IR 차이 건수",
+  "input": "samples/pic2.hwp",
+  "instructions": "입력과 다른 연도 저장본(samples/pic2-2018.hwp) 의 IR 차이 건수를 answer.json 에 {\"diffs\": N} 으로 적어라. identical 만 보면 차이 규모가 가려진다. 힌트: rhwp ir-diff --json 의 diffCount.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "IR 차이 건수",
+      "op": "answer_eq",
+      "answer": "diffs",
+      "path": "diffCount",
+      "cmd": [
+        "ir-diff",
+        "{input}",
+        "samples/pic2-2018.hwp",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "변환"
+}

--- a/gym/packs/serialization/tasks/SR40.json
+++ b/gym/packs/serialization/tasks/SR40.json
@@ -1,0 +1,50 @@
+{
+  "id": "SR40",
+  "tier": 2,
+  "title": "문단 문서를 HWPX로 변환",
+  "input": "samples/para-001.hwp",
+  "instructions": "입력을 HWPX 로 변환해 conv.hwpx 를 제출하고, 변환 봉투의 형식 표기를 answer.json 에 {\"format\": \"...\"} 로 적어라. 힌트: rhwp export-hwpx --json 의 format. convert 와 달리 이 명령은 HWPX 컨테이너를 만든다.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "conv.hwpx",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "HWPX 산출",
+      "op": "file_exists",
+      "file": "conv.hwpx",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "conv.hwpx"
+    },
+    {
+      "name": "info 형식",
+      "op": "value_eq",
+      "value": "hwpx",
+      "path": "format",
+      "cmd": [
+        "info",
+        "{file:conv.hwpx}",
+        "--json"
+      ]
+    },
+    {
+      "name": "변환 봉투 형식",
+      "op": "answer_eq",
+      "answer": "format",
+      "path": "format",
+      "cmd": [
+        "export-hwpx",
+        "{input}",
+        "{file:conv.hwpx}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR41.json
+++ b/gym/packs/serialization/tasks/SR41.json
@@ -1,0 +1,55 @@
+{
+  "id": "SR41",
+  "tier": 3,
+  "title": "문단 문서 export-hwpx --verify-pages",
+  "input": "samples/para-001.hwp",
+  "instructions": "입력을 HWPX 로 변환할 때 --verify-pages 를 켜고, 쪽수 검증 객체의 identical 을 answer.json 에 {\"identical\": true|false} 로 적어라. 쪽수가 어긋나면 산출물은 남고 exit 4 다. 힌트: rhwp export-hwpx --verify-pages --json 의 verifyPages.identical.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "conv.hwpx",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "HWPX 산출",
+      "op": "file_exists",
+      "file": "conv.hwpx",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "conv.hwpx"
+    },
+    {
+      "name": "info 형식",
+      "op": "value_eq",
+      "value": "hwpx",
+      "path": "format",
+      "cmd": [
+        "info",
+        "{file:conv.hwpx}",
+        "--json"
+      ]
+    },
+    {
+      "name": "verifyPages 동일",
+      "op": "answer_eq",
+      "answer": "identical",
+      "path": "verifyPages.identical",
+      "cmd": [
+        "export-hwpx",
+        "{input}",
+        "{file:conv.hwpx}",
+        "--verify-pages",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        4
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR42.json
+++ b/gym/packs/serialization/tasks/SR42.json
@@ -1,0 +1,55 @@
+{
+  "id": "SR42",
+  "tier": 3,
+  "title": "표 문서 export-hwpx --verify IR 자기검증",
+  "input": "samples/table-001.hwp",
+  "instructions": "표 문서를 HWPX 로 변환할 때 --verify 를 켜고, 검증 객체의 identical 을 answer.json 에 {\"identical\": true|false} 로 적어라. 차이가 있어도 산출물은 남고 exit 3 이다. 힌트: rhwp export-hwpx --verify --json 의 verify.identical.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "conv.hwpx",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "HWPX 산출",
+      "op": "file_exists",
+      "file": "conv.hwpx",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "conv.hwpx"
+    },
+    {
+      "name": "info 형식",
+      "op": "value_eq",
+      "value": "hwpx",
+      "path": "format",
+      "cmd": [
+        "info",
+        "{file:conv.hwpx}",
+        "--json"
+      ]
+    },
+    {
+      "name": "verify IR 동일",
+      "op": "answer_eq",
+      "answer": "identical",
+      "path": "verify.identical",
+      "cmd": [
+        "export-hwpx",
+        "{input}",
+        "{file:conv.hwpx}",
+        "--verify",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR43.json
+++ b/gym/packs/serialization/tasks/SR43.json
@@ -1,0 +1,29 @@
+{
+  "id": "SR43",
+  "tier": 2,
+  "title": "문단 문서 DocLang 형식 표기",
+  "input": "samples/para-001.hwp",
+  "instructions": "입력을 DocLang 으로 내보내고, 변환 봉투의 형식 표기를 answer.json 에 {\"format\": \"...\"} 로 적어라. 힌트: rhwp export-doclang --json 의 format.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "DocLang 형식",
+      "op": "answer_eq",
+      "answer": "format",
+      "path": "format",
+      "cmd": [
+        "export-doclang",
+        "{input}",
+        "-o",
+        "{file:out.doclang}",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "변환"
+}

--- a/gym/packs/serialization/tasks/SR44.json
+++ b/gym/packs/serialization/tasks/SR44.json
@@ -1,0 +1,29 @@
+{
+  "id": "SR44",
+  "tier": 2,
+  "title": "문단 문서 DocLang 버전",
+  "input": "samples/para-001.hwp",
+  "instructions": "입력을 DocLang 으로 내보내고, 봉투의 DocLang 버전을 answer.json 에 {\"version\": \"...\"} 로 적어라. 힌트: rhwp export-doclang --json 의 doclangVersion. 버전 문자열을 기억해 박제하지 말고 봉투를 읽어라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "DocLang 버전",
+      "op": "answer_eq",
+      "answer": "version",
+      "path": "doclangVersion",
+      "cmd": [
+        "export-doclang",
+        "{input}",
+        "-o",
+        "{file:out.doclang}",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "변환"
+}

--- a/gym/packs/serialization/tasks/SR45.json
+++ b/gym/packs/serialization/tasks/SR45.json
@@ -1,0 +1,29 @@
+{
+  "id": "SR45",
+  "tier": 3,
+  "title": "표 문서 DocLang 손실 계수",
+  "input": "samples/table-001.hwp",
+  "instructions": "표 문서를 DocLang 으로 내보내고 손실 건수를 answer.json 에 {\"loss\": N} 으로 제출하라. 힌트: rhwp export-doclang --json 의 lossCount. 손실이 0이 아닐 수 있다 — 변환 성공과 무손실은 다른 축이다.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "손실 건수",
+      "op": "answer_eq",
+      "answer": "loss",
+      "path": "lossCount",
+      "cmd": [
+        "export-doclang",
+        "{input}",
+        "-o",
+        "{file:out.doclang}",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "변환"
+}

--- a/gym/packs/serialization/tasks/SR46.json
+++ b/gym/packs/serialization/tasks/SR46.json
@@ -1,0 +1,29 @@
+{
+  "id": "SR46",
+  "tier": 2,
+  "title": "2쪽 시험지 마크다운 쪽수",
+  "input": "samples/exam-kor-2p.hwp",
+  "instructions": "2쪽 시험지를 마크다운으로 내보내고 렌더된 쪽 수를 answer.json 에 {\"pages\": N} 으로 제출하라. 힌트: rhwp export-markdown --json 의 pageCount.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "렌더 쪽 수",
+      "op": "answer_eq",
+      "answer": "pages",
+      "path": "pageCount",
+      "cmd": [
+        "export-markdown",
+        "{input}",
+        "-o",
+        "{file:md}",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "변환"
+}

--- a/gym/packs/serialization/tasks/SR47.json
+++ b/gym/packs/serialization/tasks/SR47.json
@@ -1,0 +1,29 @@
+{
+  "id": "SR47",
+  "tier": 2,
+  "title": "그림 문서 마크다운 쪽수",
+  "input": "samples/pic2.hwp",
+  "instructions": "그림이 있는 입력을 마크다운으로 내보내고 렌더된 쪽 수를 answer.json 에 {\"pages\": N} 으로 제출하라. 힌트: rhwp export-markdown --json 의 pageCount.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "렌더 쪽 수",
+      "op": "answer_eq",
+      "answer": "pages",
+      "path": "pageCount",
+      "cmd": [
+        "export-markdown",
+        "{input}",
+        "-o",
+        "{file:md}",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "변환"
+}

--- a/gym/packs/serialization/tasks/SR48.json
+++ b/gym/packs/serialization/tasks/SR48.json
@@ -1,0 +1,60 @@
+{
+  "id": "SR48",
+  "tier": 2,
+  "title": "HWPX convert 산출물이 열리는지",
+  "input": "samples/hwpx_sample2.hwpx",
+  "instructions": "입력을 편집 가능 HWP5 로 변환해 conv.hwp 를 제출하고, 산출물이 열리는지 쪽수를 answer.json 에 {\"pages\": N} 으로 적어라. 쪽수는 환경·재조판에 따라 달라질 수 있으니 1 이상이면 충분하다. 힌트: rhwp convert 후 rhwp info --json 의 pageCount.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "conv.hwp",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "HWP5 산출",
+      "op": "file_exists",
+      "file": "conv.hwp",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "conv.hwp"
+    },
+    {
+      "name": "info 형식",
+      "op": "value_eq",
+      "value": "hwp5",
+      "path": "format",
+      "cmd": [
+        "info",
+        "{file:conv.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "열리는 쪽수",
+      "op": "value_ge",
+      "value": 1,
+      "path": "pageCount",
+      "cmd": [
+        "info",
+        "{file:conv.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "산출 쪽수",
+      "op": "answer_eq",
+      "answer": "pages",
+      "path": "pageCount",
+      "cmd": [
+        "info",
+        "{file:conv.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR49.json
+++ b/gym/packs/serialization/tasks/SR49.json
@@ -1,0 +1,53 @@
+{
+  "id": "SR49",
+  "tier": 2,
+  "title": "각주 문서 PDF 쪽수",
+  "input": "samples/footnote-01.hwp",
+  "instructions": "각주가 있는 입력을 PDF 로 내보내 out.pdf 를 제출하고, 렌더된 쪽 수를 answer.json 에 {\"pages\": N} 으로 적어라. 힌트: rhwp export-pdf --json 의 pageCount.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "out.pdf",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "PDF 산출",
+      "op": "file_exists",
+      "file": "out.pdf",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "out.pdf"
+    },
+    {
+      "name": "PDF 형식",
+      "op": "value_eq",
+      "value": "pdf",
+      "path": "format",
+      "cmd": [
+        "export-pdf",
+        "{input}",
+        "-o",
+        "{file:out.pdf}",
+        "--json"
+      ]
+    },
+    {
+      "name": "렌더 쪽 수",
+      "op": "answer_eq",
+      "answer": "pages",
+      "path": "pageCount",
+      "cmd": [
+        "export-pdf",
+        "{input}",
+        "-o",
+        "{file:out.pdf}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR50.json
+++ b/gym/packs/serialization/tasks/SR50.json
@@ -1,0 +1,53 @@
+{
+  "id": "SR50",
+  "tier": 2,
+  "title": "가로 문서 PDF 백엔드",
+  "input": "samples/landscape-001.hwp",
+  "instructions": "가로 용지 문서를 PDF 로 내보내 out.pdf 를 제출하고, 사용한 백엔드를 answer.json 에 {\"backend\": \"...\"} 로 적어라. 힌트: rhwp export-pdf --json 의 backend.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "out.pdf",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "PDF 산출",
+      "op": "file_exists",
+      "file": "out.pdf",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "out.pdf"
+    },
+    {
+      "name": "PDF 형식",
+      "op": "value_eq",
+      "value": "pdf",
+      "path": "format",
+      "cmd": [
+        "export-pdf",
+        "{input}",
+        "-o",
+        "{file:out.pdf}",
+        "--json"
+      ]
+    },
+    {
+      "name": "PDF 백엔드",
+      "op": "answer_eq",
+      "answer": "backend",
+      "path": "backend",
+      "cmd": [
+        "export-pdf",
+        "{input}",
+        "-o",
+        "{file:out.pdf}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR51.json
+++ b/gym/packs/serialization/tasks/SR51.json
@@ -1,0 +1,50 @@
+{
+  "id": "SR51",
+  "tier": 2,
+  "title": "서식 문서를 HWPX로",
+  "input": "samples/form-01.hwp",
+  "instructions": "서식 문서를 HWPX 로 변환해 conv.hwpx 를 제출하고, 변환 봉투의 형식 표기를 answer.json 에 {\"format\": \"...\"} 로 적어라. 힌트: rhwp export-hwpx --json 의 format.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "conv.hwpx",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "HWPX 산출",
+      "op": "file_exists",
+      "file": "conv.hwpx",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "conv.hwpx"
+    },
+    {
+      "name": "info 형식",
+      "op": "value_eq",
+      "value": "hwpx",
+      "path": "format",
+      "cmd": [
+        "info",
+        "{file:conv.hwpx}",
+        "--json"
+      ]
+    },
+    {
+      "name": "변환 봉투 형식",
+      "op": "answer_eq",
+      "answer": "format",
+      "path": "format",
+      "cmd": [
+        "export-hwpx",
+        "{input}",
+        "{file:conv.hwpx}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR52.json
+++ b/gym/packs/serialization/tasks/SR52.json
@@ -1,0 +1,29 @@
+{
+  "id": "SR52",
+  "tier": 3,
+  "title": "다중 표 문서 DocLang 손실 계수",
+  "input": "samples/multi-table-001.hwp",
+  "instructions": "표가 여러 개인 입력을 DocLang 으로 내보내고 손실 건수를 answer.json 에 {\"loss\": N} 으로 제출하라. 힌트: rhwp export-doclang --json 의 lossCount.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "손실 건수",
+      "op": "answer_eq",
+      "answer": "loss",
+      "path": "lossCount",
+      "cmd": [
+        "export-doclang",
+        "{input}",
+        "-o",
+        "{file:out.doclang}",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "변환"
+}

--- a/gym/packs/serialization/tasks/SR53.json
+++ b/gym/packs/serialization/tasks/SR53.json
@@ -1,0 +1,32 @@
+{
+  "id": "SR53",
+  "tier": 3,
+  "title": "각주 문서 IR 자기대조",
+  "input": "samples/footnote-01.hwp",
+  "instructions": "각주 문서를 자기 자신과 ir-diff 해 IR 동일 여부를 answer.json 에 {\"identical\": true|false} 로 적어라. 힌트: rhwp ir-diff <입력> <입력> --json.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "IR 동일 판정",
+      "op": "answer_eq",
+      "answer": "identical",
+      "path": "identical",
+      "cmd": [
+        "ir-diff",
+        "{input}",
+        "{input}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ],
+  "axis": "변환"
+}

--- a/gym/packs/serialization/tasks/SR54.json
+++ b/gym/packs/serialization/tasks/SR54.json
@@ -1,0 +1,43 @@
+{
+  "id": "SR54",
+  "tier": 3,
+  "title": "3쪽 문서에서 마지막 쪽만 남긴 문단 수",
+  "input": "samples/exam-kor-3p.hwp",
+  "instructions": "3쪽 표본의 셋째 쪽만 남겨 slice.hwp 로 저장하고, 남긴 문단 수를 answer.json 에 {\"paragraphsKept\": N} 으로 제출하라. 힌트: rhwp extract-pages --from 3 --to 3 --json 의 paragraphsKept.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "slice.hwp",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "추출물 실재",
+      "op": "file_exists",
+      "file": "slice.hwp",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "slice.hwp"
+    },
+    {
+      "name": "남긴 문단 수",
+      "op": "answer_eq",
+      "answer": "paragraphsKept",
+      "path": "paragraphsKept",
+      "cmd": [
+        "extract-pages",
+        "{input}",
+        "{file:slice.hwp}",
+        "--from",
+        "3",
+        "--to",
+        "3",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/serialization/tasks/SR55.json
+++ b/gym/packs/serialization/tasks/SR55.json
@@ -1,0 +1,38 @@
+{
+  "id": "SR55",
+  "tier": 2,
+  "title": "HWPX 원본 info 형식과 쪽수",
+  "input": "samples/hwpx_sample2.hwpx",
+  "instructions": "HWPX 원본의 쪽수를 answer.json 에 {\"pages\": N} 으로 제출하라. rhwp 는 HWP 와 HWPX 를 같은 IR 로 읽는다. 힌트: rhwp info --json 의 pageCount.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "쪽수",
+      "op": "answer_eq",
+      "answer": "pages",
+      "path": "pageCount",
+      "cmd": [
+        "info",
+        "{input}",
+        "--json"
+      ]
+    },
+    {
+      "name": "형식 표기",
+      "op": "value_eq",
+      "value": "hwpx",
+      "path": "format",
+      "cmd": [
+        "info",
+        "{input}",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/serialization/tasks/SR56.json
+++ b/gym/packs/serialization/tasks/SR56.json
@@ -1,0 +1,55 @@
+{
+  "id": "SR56",
+  "tier": 3,
+  "title": "가로 문서 convert --verify-pages",
+  "input": "samples/landscape-001.hwp",
+  "instructions": "가로 용지 문서를 convert --verify-pages 로 conv.hwp 를 만들고, 쪽수 검증 객체의 identical 을 answer.json 에 {\"identical\": true|false} 로 적어라. 힌트: rhwp convert --verify-pages --json 의 verifyPages.identical.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "conv.hwp",
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "HWP5 산출",
+      "op": "file_exists",
+      "file": "conv.hwp",
+      "minBytes": 256
+    },
+    {
+      "name": "원본과 다름 (무편집 복사 거부 — 판별력)",
+      "op": "differs_from_input",
+      "file": "conv.hwp"
+    },
+    {
+      "name": "info 형식",
+      "op": "value_eq",
+      "value": "hwp5",
+      "path": "format",
+      "cmd": [
+        "info",
+        "{file:conv.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "verifyPages 동일",
+      "op": "answer_eq",
+      "answer": "identical",
+      "path": "verifyPages.identical",
+      "cmd": [
+        "convert",
+        "{input}",
+        "{file:conv.hwp}",
+        "--verify-pages",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        4
+      ]
+    }
+  ]
+}

--- a/mydocs/working/gym_serialization_exceptions.md
+++ b/mydocs/working/gym_serialization_exceptions.md
@@ -1,0 +1,245 @@
+---
+kind: investigation
+status: active
+canonical: gym/packs/serialization/README.md
+last_verified: 2026-08-18
+---
+
+# serialization pack 예외·가장자리 노트
+
+이 문서는 저장·변환 과제가 **일부러 박제하지 않는 값**과, 현장에서 반복되는
+가장자리 실패를 기록한다. 여정 지도는
+[gym/packs/serialization/README.md](../../gym/packs/serialization/README.md),
+작업 계보는 [gym_serialization_pack.md](gym_serialization_pack.md).
+
+값은 환경·재조판·폰트·직렬화 순서에 흔들린다. 그래서 과제 JSON에 숫자를
+넣지 않고, 채점 시점에 rhwp가 같은 명령을 다시 돌린다. 아래는 "흔들린다"가
+정확히 무엇을 뜻하는지의 목록이다.
+
+## E1. extract-pages 재조판
+
+`extract-pages` 는 쪽 단위로 자르되 **문단 단위로** 지운다.
+
+- 여러 쪽에 걸친 문단은 한 쪽이라도 `--from/--to` 안이면 남는다.
+- 남긴 문단을 다시 조판하면 쪽 수가 요청 폭과 달라질 수 있다.
+- 구역·DocInfo·BinData 는 그대로 남는다. 그림이 많은 문서는 첫 쪽만
+  남겨도 파일 크기가 크게 줄지 않을 수 있다.
+
+그래서 SR10/SR28/SR31 은 `pagesAfter` 를 라이브로 읽고, SR14/SR22/SR29 는
+`pagesBefore`(원본 쪽수, 비교적 안정)를 읽는다. `pagesAfter == (to-from+1)`
+을 단언하지 않는다.
+
+중첩 셀 표본(`issue2007_nested_cell_pagination_42065.hwp`, SR22)은 이
+가장자리를 드러내려고 골랐다. 셀이 쪽을 넘기면 문단 단위 삭제가 쪽 가위와
+어긋난다.
+
+## E2. 쪽 축이 명령마다 다르다
+
+같은 단어 "page" 가 세 가지 기준을 가리킨다.
+
+1. `extract-pages --from/--to` — **1 기준**. 첫 쪽이 1.
+2. `export-pdf -p`, `export-text` 의 `pages[].page`, `search` 의
+   `matches[].page` — **0 기준**. 첫 쪽이 0.
+3. `pageCount` / `renderedCount` / `pagesBefore` / `pagesAfter` — 개수.
+   기준이 아니라 합이다.
+
+에이전트가 `search` 결과 `page: 1` 을 `--from 1` 에 넣으면 둘째 쪽이
+아니라 첫째 쪽이 남는다. 오류 메시지 없이 한 쪽 밀린 문서가 나온다.
+SR18 은 둘째 쪽(`--from 2 --to 2`)을 일부러 넣어 이 함정을 밟게 한다.
+
+`export-pdf -p` 는 이 pack 의 과제에 넣지 않았다. 0 기준과 1 기준을 한
+과제 안에 섞으면 채점 힌트가 힌트 역할을 못 한다. 단일 쪽 PDF가 필요하면
+별도 과제에서 `-p 0` 을 명시해야 한다.
+
+## E3. PDF 바이트는 정답이 아니다
+
+`export-pdf` 산출물은 다음이 바뀌면 바이트가 달라진다.
+
+- 시스템 폰트 목록, `RHWP_FONT_PATH`, `--font-path`
+- `--backend svg|direct` (direct 는 `native-skia` feature)
+- `--text-as-paths`
+- fallback family (Windows 바탕/맑은 고딕, Linux Noto, macOS Apple)
+- 수식 폰트
+
+SR11/SR15/SR19/SR23/SR32–SR35/SR49/SR50 은 바이트를 비교하지 않는다.
+`file_exists` + `differs_from_input` + `format`/`backend`/`pageCount`/
+`renderedCount` 만 본다.
+
+`pageCount` 와 `renderedCount` 는 전체 문서 내보내기에서 보통 같다.
+SR23/SR34 가 `renderedCount` 를 따로 묻는 이유는 필드 혼동을 가르기
+위해서다. 두 값이 갈라지는 경우는 부분 렌더(`-p`)나 렌더 실패인데, 이
+pack 은 전체 문서를 보낸다.
+
+## E4. convert 는 "배포용 해제만" 이 아니다
+
+입력이 이미 편집 가능한 HWP5 여도 `convert` 는
+
+- 산출 경로에 파일을 쓰고
+- `wasDistribution` 을 봉투에 실어
+- `--verify` / `--verify-pages` 를 옵션으로 받는다.
+
+SR13/SR26 은 이 계약을 묻는다. `wasDistribution: true` 를 박제하면
+편집 가능 표본에서 틀린다. 배포용 표본을 이 pack 에 넣지 않은 이유는
+암호·배포 플래그 조합이 보안 pack 과 겹치기 때문이다.
+
+`convert` 출력 확장자는 `.hwp` 만 허용한다. `.hwpx` 를 주면 입력을
+읽기 전에 exit 2 다. HWPX 가 필요하면 `export-hwpx` 다 (SR01/SR06/
+SR40–SR42/SR51).
+
+## E5. 검증 실패는 산출물을 삼키지 않는다
+
+`--verify` 가 IR 차이를 보면 exit 3, `--verify-pages` 가 쪽수 차이를
+보면 exit 4. **파일은 남아 있다.**
+
+이 규약을 어기면 파이프라인이 "실패 = 산출 없음" 으로 잘못 갈라진다.
+과제는 `file_exists` 를 먼저 두고, 그다음 `answer_eq` 로 검증 객체를
+읽는다. `expect_exits` 에 0과 3(또는 4)을 같이 넣는다.
+
+`verify` / `verifyPages` 객체는 해당 옵션을 준 경우에만 생긴다.
+옵션 없이 `verify.identical` 을 읽으면 경로가 `null` 이라 실패한다.
+SR17/SR21/SR27/SR41/SR42/SR56 의 기준풀이는 옵션을 켠 명령을 그대로
+다시 돌린다.
+
+## E6. ir-diff 의 세 갈래
+
+1. **자기대조** (SR16/SR36/SR53): 같은 경로를 두 번 읽는다. `identical`
+   은 true 여야 한다. false 면 파서 비결정성이므로 pack 이 아니라
+   코어 이슈다.
+2. **짝 파일** (SR12/SR20/SR37): 저장소에 있는 HWP·HWPX 쌍. 동일할 수도
+   있고 차이가 날 수도 있다. 값을 박제하지 않는다.
+3. **다른 문서** (SR24/SR38) 또는 **연도 쌍** (SR39): 보통 차이가 나고
+   exit 3 이다. `identical` 과 `diffCount` 를 나눈다.
+
+stdout 은 차이가 있어도 JSON 한 줄이다. 읽기 실패만 stdout 을 비운다.
+에이전트가 exit 3 을 "명령이 죽었다" 로 읽으면 봉투를 버린다.
+
+`categories` 필드는 이 pack 이 묻지 않는다. 카테고리 이름이 바뀌면
+과제가 전부 흔들린다. 규모는 `diffCount` 면 충분하다.
+
+## E7. DocLang 손실은 실패가 아니다
+
+`export-doclang` 은 표현할 수 없는 정보를 `lossCount` 로 보고하고
+변환 자체는 성공한다. SR03/SR45/SR52 는 그 숫자를 맞추는 과제이지
+0 을 요구하는 과제가 아니다.
+
+`format` 은 `"doclang"`, `doclangVersion` 은 `"0.6"` 근처다. 후자를
+과제에 박제하지 않고 SR44 가 봉투에서 읽게 했다. 스키마 버전
+(`schemaVersion: "1.0"`)과 섞으면 틀린다.
+
+입력은 HWP5/HWPX 만 받는다. HML·HWP3·DRM·빈 파일은 사용법 오류다.
+이 pack 의 DocLang 과제는 그 거부 경로를 시험하지 않는다.
+
+## E8. export-hml 은 원본 형식이 이미 HML 일 때만
+
+SR02 는 `samples/hml/formatting_table.hml` 만 받는다. HWP 를 넣으면
+거부된다. "아무 문서나 HML 로" 가 아니라 "HML 원본을 다시 HML 로" 다.
+계약을 읽고 대상을 고르는 것 자체가 과제다.
+
+산출물은 `info` 로 열려야 하고 (`pageCount >= 1`) 원본과 바이트가
+달라야 한다. HML 직렬화는 속성 순서·공백이 달라질 수 있어 해시 비교는
+쓰지 않는다.
+
+## E9. IR 스키마는 문서를 받지 않는다
+
+SR05 의 `export-ir-schema` 는 입력이 필요 없다. 과제 `input` 필드는
+스키마상 필수라 `samples/table-001.hwp` 를 적었지만 명령은 그 파일을
+열지 않는다. `differs_from_input` 은 스키마 JSON 이 HWP 가 아님을
+확인할 뿐이다.
+
+`dialect` 는 JSON Schema 2020-12 URI 다. 이 문자열을 과제에 박제한
+이유는 스키마 방언이 바뀌는 것이 곧 계약 파기이기 때문이다. 쪽수처럼
+환경에 흔들리는 값이 아니다.
+
+## E10. 최소 바이트와 빈 껍데기
+
+`file_exists` 의 기본 `minBytes` 는 1 이다. 변환 산출은 256, 스키마는
+128 로 올렸다. `%PDF-` 나 `PK` 시그니처만 있는 수 바이트 가짜 파일은
+여기서 걸린다. 진짜 시그니처 검사는 `info` / `export-pdf --json` 의
+`format` 이 맡는다.
+
+`xml_root_eq` 는 SVG 과제용이라 이 pack 에 쓰지 않았다. PDF 는 XML이
+아니다.
+
+## E11. 자리표
+
+기준풀이는 `{sub:conv.hwp}` 처럼 제출 폴더 자리표를 쓴다. 과제의
+`cmd` 는 `{file:conv.hwp}` 다. 둘을 섞으면 채점기가 파일을 못 찾는다.
+구조대 초안과 기존 SR09–SR12 가 이 구분을 이미 지키고 있어 후속
+과제도 그대로 따랐다.
+
+다세대 계획서에서 `{sub:}` 가 여러 번 나오면 **전부** 치환해야 한다.
+첫 하나만 바꾸면 다음 세대가 입력을 잃는다. 이 pack 의 기준풀이는
+한 세대(변환 한 번 + 답 한 번)라 그 함정이 작지만, SR48 은 convert
+run 다음에 info answer 가 이어지므로 같은 `conv.hwp` 자리표를 두
+단계에서 쓴다.
+
+## E12. unavailable 과 0점
+
+`pack.json` 의 `requires.commands` 에 없는 바이너리로 이 pack 을
+돌리면 점수는 0 이 아니라 `unavailable` 이다. 부재를 실패로 위장하지
+않는 것이 gym 계약이다.
+
+이 확장이 `convert` · `export-pdf` · `extract-pages` · `export-hwpx` 를
+requires 에 넣은 이유다. 오래된 바이너리는 이 pack 을 건너뛰고, 새
+바이너리만 채점한다.
+
+## E13. 과제 ID 와 프로파일
+
+`SR*` 는 전역 고유해야 한다. 다른 pack 이 SR 접두사를 쓰면
+`audit.py` 가 충돌로 막는다. 프로파일(`profiles/*.json`)은 pack id
+목록이지 과제 id 목록이 아니다. 과제를 늘려도 프로파일 JSON 은
+바꾸지 않는다.
+
+`gym/README.md` 의 "serialization 8과제 · 만점 19" 는 이 확장 이후
+숫자가 틀린다. 집계 문서는 별도 커밋으로 고친다. 이 PR 범위는
+pack 내부와 계약 테스트다.
+
+## E14. 윈도우 경로와 한글 표본
+
+표본 경로에 공백·한글이 있는 파일(`2025 행정업무운영 편람` 등)은
+고르지 않았다. 채점기 자리표 치환은 견디지만, 문서와 셸 예제가
+깨지기 쉽다. ASCII 경로의 작은 표본만 썼다.
+
+Windows 에서 `os.path.join` 이 백슬래시를 만든다. 과제 JSON 의
+`samples/...` 는 슬래시로 적는다. 채점기가 저장소 루트 상대 경로로
+연다.
+
+## E15. 이 pack 이 의도적으로 안 밟는 가장자리
+
+- 입력==출력 경로 거부 (원본 보호). gym 제출은 항상 다른 폴더다.
+- `--output-password` 왕복. 보안·암호 pack 범위.
+- DRM·배포용 전용 표본. 위에서 말한 겹침.
+- `export-pdf --backend direct` 강제. feature 없는 CI 가 깨진다.
+- 한컴 정본 PDF 픽셀 비교. fidelity harness 범위.
+- 빈 파일·잘린 OLE 손상. robustness 도구 범위.
+
+이 목록을 과제로 만들고 싶으면 새 CLI 없이 기존 명령의 거부 경로를
+`expect_exits: [2]` 로 받는 과제를 따로 설계해야 한다. 이번 확장은
+성공 경로의 필드 지목에 집중했다.
+
+## 빠른 대조표
+
+| 흔들리는 것 | 박제? | 대신 하는 일 |
+|---|---|---|
+| PDF/HWP 바이트 | 금지 | `file_exists` + `differs_from_input` |
+| `pagesAfter` | 금지 | `answer_eq` 실측 |
+| `pageCount` / `renderedCount` | 금지 | `answer_eq` 실측 |
+| `backend` | 금지 | `answer_eq` 실측 |
+| `wasDistribution` | 금지 | `answer_eq` 실측 |
+| `lossCount` / `diffCount` | 금지 | `answer_eq` 실측 |
+| `doclangVersion` | 금지 | `answer_eq` 실측 |
+| `format` (`hwp5`/`hwpx`/`pdf`/`doclang`) | 허용 (`value_eq`) | 계약 문자열 |
+| IR 스키마 `dialect` | 허용 (`json_value_eq`) | 계약 URI |
+| `--from/--to` 가 1 기준 | 문서에 고정 | instructions + 테스트 |
+
+## 관련 테스트
+
+`scripts/tests/test_gym_serialization_pack.py` 가 아래를 고정한다.
+
+- SR01–SR56 이 빠짐없이 있고 기준풀이와 id 가 같다
+- 산출 과제는 `differs_from_input` 을 가진다
+- `extract-pages` 과제는 1 기준 인자를 쓴다
+- `ir-diff` / `--verify` 는 exit 0·3, `--verify-pages` 는 0·4
+- 과제 JSON 에 골든 해시·고정 쪽수가 없다
+- 모든 `input` 경로가 저장소에 실재한다
+- README 가 여정과 실패 모드를 한국어로 적는다

--- a/mydocs/working/gym_serialization_pack.md
+++ b/mydocs/working/gym_serialization_pack.md
@@ -1,0 +1,209 @@
+---
+kind: investigation
+status: active
+canonical: gym/packs/serialization/README.md
+last_verified: 2026-08-18
+---
+
+# serialization pack 확장 작업 노트
+
+이 문서는 PR #5232 (`feat/gym-serialization-expand`) 를 키운 작업 기록이다.
+규범 문서는 [gym/packs/serialization/README.md](../../gym/packs/serialization/README.md)
+다. 예외·가장자리는
+[gym_serialization_exceptions.md](gym_serialization_exceptions.md) 에 모은다.
+
+## 무엇을 했는가
+
+serialization pack은 형식 왕복 축인데 과제가 얇았다. 기존 PR은 SR09–SR12
+네 건만 더했다(약 259 insertions). 구조대 초안 SR13–SR24 가
+`tmp-gym-rescue/serialization/` 에 남아 있었고, 그 과제·기준풀이를
+`gym/packs/serialization/` 으로 옮긴 뒤 같은 계약으로 SR25–SR56 을 더했다.
+
+건드리지 않은 것:
+
+- 새 CLI, 새 pack, T07 복제
+- `profiles/` · `gym/README.md` · `gym/PARK.md` · `gym/core/checks.py`
+- 다른 pack 의 과제 ID
+- `cargo fmt --all` (JSON·문서·테스트만 바꿨다)
+- `pack.json` 의 `runner` 신원. 요구 명령만 `convert` · `export-hwpx` ·
+  `export-pdf` · `extract-pages` 를 명시했다.
+
+## 왜 이 두께인가
+
+왕복 축은 "한 명령 × 한 표본" 으로 닫히지 않는다. 같은 `convert` 라도
+
+- 입력이 HWPX 인가, 이미 편집 가능한 HWP5 인가
+- 읽는 필드가 `format` 인가 `wasDistribution` 인가
+- `--verify` 인가 `--verify-pages` 인가
+- 산출물이 실제로 `info` 로 열리는가
+
+가 다른 계약이다. `extract-pages` 는 쪽 수(1/2/3/4쪽 표본)와 필드
+(`pagesBefore` / `pagesAfter` / `paragraphsKept` / `paragraphsRemoved`) 가
+갈라지고, `export-pdf` 는 `format` / `backend` / `pageCount` /
+`renderedCount` 가 갈라진다. 과제를 합치면 에이전트가 힌트 한 줄을
+외워 모든 왕복을 통과한다.
+
+## 과제 계보
+
+### 기존 (devel)
+
+| ID | 명령 | 요지 |
+|---|---|---|
+| SR01 | `export-hwpx` + `ir-diff` | HWPX 변환 자기검증 |
+| SR02 | `export-hml` | HML 원본만 왕복 |
+| SR03 | `export-doclang` | 손실 계수 |
+| SR04 | `export-markdown` | 쪽수 |
+| SR05 | `export-ir-schema` | dialect |
+| SR06 | `export-hwpx` + `ir-diff` | 차이 건수 |
+| SR07 | `info` | HWPX 원본 조사 |
+| SR08 | `export-markdown` | HWPX 마크다운 |
+
+### 첫 확장 (SR09–SR12)
+
+| ID | 명령 | 요지 |
+|---|---|---|
+| SR09 | `convert` | HWPX → HWP5 `format` |
+| SR10 | `extract-pages` | 첫 쪽 `pagesAfter` |
+| SR11 | `export-pdf` | `pageCount` |
+| SR12 | `ir-diff` | 기존 pic2 쌍 `identical` |
+
+### 구조대 (SR13–SR24)
+
+구조대 초안은 이미 라이브 오라클 형식이었다. 고친 것 없이 복사했다.
+
+| ID | 명령 | 요지 |
+|---|---|---|
+| SR13 | `convert` | 편집 가능본 `wasDistribution` |
+| SR14 | `extract-pages` | 1–2쪽 `pagesBefore` |
+| SR15 | `export-pdf` | `backend` |
+| SR16 | `ir-diff` | 자기대조 |
+| SR17 | `convert --verify` | `verify.identical` |
+| SR18 | `extract-pages` | 둘째 쪽 `paragraphsKept` |
+| SR19 | `export-pdf` | 그림 문서 `pageCount` |
+| SR20 | `ir-diff` | pic2 쌍 `diffCount` |
+| SR21 | `convert --verify-pages` | `verifyPages.identical` |
+| SR22 | `extract-pages` | 중첩 셀 `pagesBefore` |
+| SR23 | `export-pdf` | HWPX `renderedCount` |
+| SR24 | `ir-diff` | 다른 두 문서 `identical` |
+
+### 후속 (SR25–SR56)
+
+같은 연산자·같은 힌트 문체를 유지하고 표본과 필드만 갈랐다. 새 연산자를
+만들지 않았다.
+
+- convert: SR25, SR26, SR27, SR48, SR56
+- extract-pages: SR28, SR29, SR30, SR31, SR54
+- export-pdf: SR32, SR33, SR34, SR35, SR49, SR50
+- ir-diff: SR36, SR37, SR38, SR39, SR53
+- export-hwpx: SR40, SR41, SR42, SR51
+- doclang/markdown/info: SR43, SR44, SR45, SR46, SR47, SR52, SR55
+
+## 설계 규칙 (이 확장이 지킨 것)
+
+1. **라이브 오라클.** 쪽수·차이 건수·백엔드·버전 문자열을 과제 JSON에
+   숫자/문자열로 박제하지 않는다. `answer_eq` 가 재계산한다.
+2. **지목 연산자.** `deep_contains` 를 쓰지 않는다. `value_eq` ·
+   `answer_eq` · `file_exists` · `differs_from_input` · `value_ge` 만
+   쓴다.
+3. **판별력.** 산출물이 있는 과제는 `differs_from_input` 과 `minBytes` 를
+   같이 둔다. 이름만 바꾼 복사를 거절한다.
+4. **exit 계약.** `ir-diff` / `--verify` 는 `expect_exits: [0, 3]`,
+   `--verify-pages` 는 `[0, 4]`. 기준풀이의 `allowExits` 와 맞춘다.
+5. **1 기준 명시.** `extract-pages` 과제는 instructions 에 `--from/--to`
+   가 1 기준이라고 적는다.
+6. **기존 표본만.** 새 fixture를 만들지 않는다. `samples/` 에 이미 있는
+   작은 파일만 고른다.
+7. **ID 전역 고유.** `SR*` 접두사는 이 pack 만 쓴다. 다른 pack 과
+   충돌하지 않는지 `audit.py` 가 확인한다.
+8. **기준풀이 짝.** 과제 파일 이름과 reference 파일 이름이 같다. id
+   필드도 같다.
+
+## 표본 선택 이유
+
+| 표본 | 이유 |
+|---|---|
+| `para-001.hwp` | 작은 문단 문서. convert/pdf/hwpx 기본축 |
+| `table-001.hwp` | 표가 있어 DocLang 손실·IR 차이가 의미 있다 |
+| `exam-kor-1p/2p/3p/4p.hwp` | 쪽 수가 이름에 드러나 extract-pages 축을 가른다 |
+| `pic2.hwp` + `pic2.hwpx` | 저장소에 이미 있는 짝 파일 |
+| `pic2-2018.hwp` | 같은 그림의 다른 연도 저장본. 차이 규모용 |
+| `hwpx_sample2.hwpx` + `.hwp` | 다른 짝 파일. pic2 한 쌍만 보면 과적합 |
+| `hwpx/143E433F503322BD33.hwpx` | 기존 SR07/SR08 이 쓰던 HWPX 원본 |
+| `basic/issue2007_…42065.hwp` | 중첩 셀·페이지네이션. 재조판 위험이 드러난다 |
+| `hml/formatting_table.hml` | `export-hml` 계약 (HML 전용) |
+| `footnote-01.hwp` | 각주가 렌더 쪽에 영향을 줄 수 있다 |
+| `form-01.hwp` | 서식 컨트롤이 있는 HWPX 변환 |
+| `landscape-001.hwp` | 가로 용지. 쪽수 검증이 세로 문서와 다르다 |
+| `multi-table-001.hwp` | 표가 여러 개라 DocLang 손실 축이 살아 있다 |
+
+고의로 빼 둔 표본:
+
+- `2025 행정업무운영 편람` 같은 대형 문서. gym 채점이 무거워진다.
+- 암호 걸린 `HWP5-password-*.hwp`. 보안 pack 과 겹친다.
+- HWP3 원본. convert 경로가 다르고 이 확장의 범위가 아니다.
+
+## pack.json requires
+
+devel 의 requires 는 `export-doclang` · `export-markdown` · `info` ·
+`ir-diff` 뿐이었다. SR01/SR02/SR05 가 이미 `export-hwpx` · `export-hml` ·
+`export-ir-schema` 를 쓰는데도 빠져 있었다. 이번 확장은 **새로 두드리는
+명령** 을 명시했다.
+
+```text
+convert
+export-doclang
+export-hwpx
+export-markdown
+export-pdf
+extract-pages
+info
+ir-diff
+```
+
+`export-hml` · `export-ir-schema` 는 기존 과제 전용이라 목록을 부풀리지
+않았다. 요구 명령이 없는 바이너리는 pack 전체가 `unavailable` 이지 0점이
+아니다. 명령을 더 넣으면 오래된 바이너리가 더 자주 unavailable 이 되므로
+신규 과제에 실제로 필요한 것만 넣었다.
+
+`runner` 는 기존 해시·커밋을 유지한다. 이 확장은 바이너리를 다시 측정하지
+않았다.
+
+## 검증
+
+로컬에서 바이너리 없이 돌리는 것:
+
+```text
+python gym/tools/audit.py
+python -m unittest scripts.tests.test_gym_packs -v
+python -m unittest scripts.tests.test_gym_serialization_pack -v
+```
+
+`audit.py` 는 전 pack 스키마·기준풀이 짝·ID 충돌을 본다.
+`test_gym_packs.py` 는 같은 계약을 CI 가 항상 돌린다.
+`test_gym_serialization_pack.py` 는 이 pack 만의 여정·필드·exit·표본
+실재·골든 파일 금지를 본다.
+
+바이너리 왕복(`build_baseline.py` / `score.py`)은 이 작업 환경에서
+돌리지 못했다. 기준풀이 형식은 기존 SR01–SR12 와 같다. 라이브 오라클이라
+값 박제가 없으므로 바이너리만 있으면 재계산된다.
+
+## 위험과 잔여
+
+- `extract-pages` 의 `pagesAfter` 는 재조판으로 요청 범위와 다를 수 있다.
+  값을 박제하지 않았으므로 채점은 흔들리지 않는다. 다만 에이전트가
+  "1쪽만 남겼으니 1" 이라고 추측하면 틀린다.
+- `export-pdf` 바이트는 폰트에 흔들린다. 채점은 `format` · `pageCount` ·
+  `renderedCount` · `backend` 만 본다.
+- `convert` / `export-hwpx` 의 `--verify` 는 차이가 있는 표본에서 exit 3
+  이다. 과제가 0만 허용하면 기준풀이도 실패한다. 0과 3을 같이 넣었다.
+- `ir-diff` 자기대조(SR16/SR36/SR53)가 false 이면 파서 비결정성이다.
+  그런 실패는 pack 이 아니라 코어 버그로 올려야 한다.
+- gym/README 의 과제 수(serialization 8, 만점 19)는 이 PR 이 고치지
+  않는다. 집계 문서는 별도 커밋이 맞다.
+
+## 관련
+
+- 이슈 #5223 (serialization pack 과제 확장)
+- PR #5232
+- 구조대 초안: 작업 트리 밖 `tmp-gym-rescue/serialization/`
+- 예외 노트: [gym_serialization_exceptions.md](gym_serialization_exceptions.md)

--- a/scripts/tests/test_gym_serialization_pack.py
+++ b/scripts/tests/test_gym_serialization_pack.py
@@ -1,0 +1,388 @@
+"""serialization pack 계약 — 여정·필드 지목·exit·표본 실재.
+
+[#5223 / PR #5232] 저장·변환 pack 이 기존 CLI 와 samples 만으로 왕복을
+가르는지, 골든 바이트를 박제하지 않는지, extract-pages 가 1 기준인지,
+ir-diff/--verify 가 차이(exit 3/4)를 실패로 위장하지 않는지를 CI 가
+항상 확인한다. 바이너리 없이 순수 파일 검사다.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GYM = REPO_ROOT / "gym"
+PACK = GYM / "packs" / "serialization"
+TASKS = PACK / "tasks"
+REFS = PACK / "reference"
+README = PACK / "README.md"
+WORKING = REPO_ROOT / "mydocs" / "working" / "gym_serialization_pack.md"
+EXCEPTIONS = REPO_ROOT / "mydocs" / "working" / "gym_serialization_exceptions.md"
+
+EXPECTED_IDS = [f"SR{i:02d}" for i in range(1, 57)]
+
+NEW_REQUIRES = {
+    "convert",
+    "export-doclang",
+    "export-hwpx",
+    "export-markdown",
+    "export-pdf",
+    "extract-pages",
+    "info",
+    "ir-diff",
+}
+
+LIVE_ANSWER_PATHS = {
+    "pageCount",
+    "renderedCount",
+    "pagesAfter",
+    "pagesBefore",
+    "paragraphsKept",
+    "paragraphsRemoved",
+    "backend",
+    "wasDistribution",
+    "lossCount",
+    "diffCount",
+    "doclangVersion",
+    "identical",
+    "verify.identical",
+    "verifyPages.identical",
+}
+
+CONVERT_FAMILY = {"SR09", "SR13", "SR17", "SR21", "SR25", "SR26", "SR27", "SR56"}
+EXTRACT_FAMILY = {"SR10", "SR14", "SR18", "SR22", "SR28", "SR29", "SR30", "SR31", "SR54"}
+PDF_FAMILY = {
+    "SR11", "SR15", "SR19", "SR23", "SR32", "SR33", "SR34", "SR35", "SR49", "SR50",
+}
+IR_FAMILY = {
+    "SR01", "SR06", "SR12", "SR16", "SR20", "SR24", "SR36", "SR37", "SR38", "SR39", "SR53",
+}
+HWPX_FAMILY = {"SR01", "SR06", "SR40", "SR41", "SR42", "SR51"}
+DOCLANG_FAMILY = {"SR03", "SR43", "SR44", "SR45", "SR52"}
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_core():
+    sys.path.insert(0, str(REPO_ROOT))
+    from gym.core import schema  # noqa: WPS433
+
+    return schema
+
+
+def all_tasks():
+    return [load_json(p) for p in sorted(TASKS.glob("SR*.json"))]
+
+
+def all_refs():
+    return [load_json(p) for p in sorted(REFS.glob("SR*.json"))]
+
+
+def walk_cmds(obj):
+    """task checks / reference steps 안의 cmd·run 리스트를 모은다."""
+    found = []
+    if isinstance(obj, dict):
+        if isinstance(obj.get("cmd"), list):
+            found.append(obj["cmd"])
+        if isinstance(obj.get("run"), list):
+            found.append(obj["run"])
+        for value in obj.values():
+            found.extend(walk_cmds(value))
+    elif isinstance(obj, list):
+        for item in obj:
+            found.extend(walk_cmds(item))
+    return found
+
+
+class PackManifestContractTests(unittest.TestCase):
+    def test_pack_json_keeps_identity_and_declares_new_commands(self):
+        manifest = load_json(PACK / "pack.json")
+        self.assertEqual(manifest["id"], "serialization")
+        self.assertEqual(manifest["kind"], "gymPack")
+        self.assertEqual(manifest["schemaVersion"], "1.0")
+        self.assertIn("변환", manifest["axis"])
+        self.assertEqual(set(manifest["requires"]["commands"]), NEW_REQUIRES)
+        runner = manifest["runner"]
+        self.assertEqual(len(runner["rhwpCommit"]), 40)
+        self.assertEqual(len(runner["capabilitiesSha256"]), 64)
+        self.assertTrue(runner["rhwpVersion"])
+
+    def test_schema_accepts_the_live_pack(self):
+        schema = load_core()
+        errors = []
+        schema.validate_pack(load_json(PACK / "pack.json"), str(PACK), errors)
+        self.assertEqual(errors, [], errors)
+
+
+class TaskInventoryTests(unittest.TestCase):
+    def test_expected_ids_are_complete_and_paired(self):
+        task_ids = [p.stem for p in sorted(TASKS.glob("SR*.json"))]
+        ref_ids = [p.stem for p in sorted(REFS.glob("SR*.json"))]
+        self.assertEqual(task_ids, EXPECTED_IDS)
+        self.assertEqual(ref_ids, EXPECTED_IDS)
+        for tid in EXPECTED_IDS:
+            task = load_json(TASKS / f"{tid}.json")
+            ref = load_json(REFS / f"{tid}.json")
+            self.assertEqual(task["id"], tid)
+            self.assertEqual(ref["id"], tid)
+
+    def test_every_task_passes_schema(self):
+        schema = load_core()
+        manifest = load_json(PACK / "pack.json")
+        errors = []
+        for task in all_tasks():
+            schema.validate_task(task, manifest, None, errors)
+        self.assertEqual(errors, [], errors)
+
+    def test_every_check_is_named(self):
+        missing = []
+        for task in all_tasks():
+            for check in task["checks"]:
+                if not check.get("name"):
+                    missing.append(task["id"])
+        self.assertEqual(missing, [])
+
+    def test_tiers_stay_in_range(self):
+        for task in all_tasks():
+            self.assertIsInstance(task["tier"], int, task["id"])
+            self.assertGreaterEqual(task["tier"], 1, task["id"])
+            self.assertLessEqual(task["tier"], 5, task["id"])
+
+
+class SampleAndOracleTests(unittest.TestCase):
+    def test_every_input_exists_in_the_repo(self):
+        missing = []
+        for task in all_tasks():
+            rel = task["input"]
+            if not (REPO_ROOT / rel).is_file():
+                missing.append(f"{task['id']}:{rel}")
+        self.assertEqual(missing, [], f"표본 없음: {missing}")
+
+    def test_secondary_sample_paths_in_cmds_exist(self):
+        missing = []
+        for task in all_tasks():
+            for cmd in walk_cmds(task):
+                for tok in cmd:
+                    if isinstance(tok, str) and tok.startswith("samples/"):
+                        if not (REPO_ROOT / tok).is_file():
+                            missing.append(f"{task['id']}:{tok}")
+        self.assertEqual(missing, [], f"보조 표본 없음: {missing}")
+
+    def test_artifact_tasks_reject_unedited_copies(self):
+        missing = []
+        for task in all_tasks():
+            # SR01/SR06 는 devel 부터 value_eq(format) 로 형식만 본다.
+            if task["id"] in {"SR01", "SR06"}:
+                continue
+            files = task.get("submit", {}).get("files") or []
+            produced = [f for f in files if f != "answer.json"]
+            if not produced:
+                continue
+            ops = {c["op"] for c in task["checks"]}
+            if "file_exists" not in ops:
+                missing.append(f"{task['id']} file_exists 없음")
+            if "differs_from_input" not in ops:
+                missing.append(f"{task['id']} differs_from_input 없음")
+        self.assertEqual(missing, [], missing)
+
+    def test_no_golden_hashes_or_frozen_page_counts(self):
+        """라이브 오라클 — 흔들리는 값을 JSON 에 숫자로 박제하지 않는다."""
+        frozen = []
+        for task in all_tasks():
+            raw = json.dumps(task, ensure_ascii=False)
+            if re.search(r'"sha256"|[0-9a-f]{64}', raw, re.I):
+                if task["id"] != "SR05":
+                    frozen.append(f"{task['id']} 해시 박제 의심")
+            for check in task["checks"]:
+                if check["op"] == "answer_eq" and check.get("path") in LIVE_ANSWER_PATHS:
+                    if "value" in check:
+                        frozen.append(f"{task['id']} {check['path']} 값 박제")
+                if check["op"] == "value_eq" and check.get("path") in {
+                    "pageCount", "renderedCount", "pagesAfter", "pagesBefore",
+                    "paragraphsKept", "paragraphsRemoved", "lossCount", "diffCount",
+                }:
+                    frozen.append(f"{task['id']} {check['path']} 를 value_eq 로 박제")
+        self.assertEqual(frozen, [], frozen)
+
+    def test_live_answer_eq_does_not_embed_expected_literals(self):
+        for task in all_tasks():
+            for check in task["checks"]:
+                if check.get("op") != "answer_eq":
+                    continue
+                self.assertIn("cmd", check, task["id"])
+                self.assertIn("path", check, task["id"])
+                self.assertNotIn("value", check, task["id"])
+
+
+class JourneyFamilyTests(unittest.TestCase):
+    def test_convert_family_writes_hwp_and_reads_envelope(self):
+        for tid in sorted(CONVERT_FAMILY):
+            task = load_json(TASKS / f"{tid}.json")
+            cmds = walk_cmds(task)
+            self.assertTrue(any(c and c[0] == "convert" for c in cmds), tid)
+            produced = (task.get("submit", {}).get("files") or [])
+            self.assertIn("conv.hwp", produced, tid)
+
+    def test_extract_family_is_one_based(self):
+        for tid in sorted(EXTRACT_FAMILY):
+            task = load_json(TASKS / f"{tid}.json")
+            found = False
+            for cmd in walk_cmds(task):
+                if not cmd or cmd[0] != "extract-pages":
+                    continue
+                found = True
+                self.assertIn("--from", cmd, tid)
+                self.assertIn("--to", cmd, tid)
+                frm = int(cmd[cmd.index("--from") + 1])
+                to = int(cmd[cmd.index("--to") + 1])
+                self.assertGreaterEqual(frm, 1, f"{tid} --from 는 1 기준")
+                self.assertGreaterEqual(to, frm, tid)
+            self.assertTrue(found, tid)
+            hint = task["instructions"] + " " + " ".join(
+                tok for cmd in walk_cmds(task) for tok in cmd)
+            self.assertIn("--from", hint, tid)
+
+    def test_pdf_family_checks_format_or_live_field(self):
+        for tid in sorted(PDF_FAMILY):
+            task = load_json(TASKS / f"{tid}.json")
+            cmds = walk_cmds(task)
+            self.assertTrue(any(c and c[0] == "export-pdf" for c in cmds), tid)
+            paths = {c.get("path") for c in task["checks"]}
+            self.assertTrue(
+                paths & {"format", "backend", "pageCount", "renderedCount"},
+                tid,
+            )
+
+    def test_ir_family_allows_diff_exit(self):
+        for tid in sorted(IR_FAMILY):
+            task = load_json(TASKS / f"{tid}.json")
+            ir_checks = [
+                c for c in task["checks"]
+                if c.get("cmd") and c["cmd"][0] == "ir-diff"
+            ]
+            self.assertTrue(ir_checks, tid)
+            for check in ir_checks:
+                self.assertEqual(check.get("expect_exits"), [0, 3], tid)
+
+    def test_verify_and_verify_pages_exits(self):
+        verify = []
+        pages = []
+        for task in all_tasks():
+            for cmd in walk_cmds(task):
+                if "--verify-pages" in cmd:
+                    pages.append(task["id"])
+                elif "--verify" in cmd:
+                    verify.append(task["id"])
+            for check in task["checks"]:
+                cmd = check.get("cmd") or []
+                if "--verify-pages" in cmd:
+                    self.assertEqual(check.get("expect_exits"), [0, 4], task["id"])
+                    self.assertEqual(check.get("path"), "verifyPages.identical")
+                elif "--verify" in cmd:
+                    self.assertEqual(check.get("expect_exits"), [0, 3], task["id"])
+                    self.assertEqual(check.get("path"), "verify.identical")
+        self.assertGreaterEqual(len(set(verify)), 2)
+        self.assertGreaterEqual(len(set(pages)), 2)
+
+    def test_hwpx_family_does_not_use_convert_for_hwpx_output(self):
+        for tid in sorted(HWPX_FAMILY):
+            task = load_json(TASKS / f"{tid}.json")
+            ref = load_json(REFS / f"{tid}.json")
+            files = task.get("submit", {}).get("files") or []
+            self.assertIn("conv.hwpx", files, tid)
+            heads = {cmd[0] for cmd in walk_cmds(task) + walk_cmds(ref) if cmd}
+            self.assertIn("export-hwpx", heads, tid)
+            self.assertNotIn("convert", heads, tid)
+
+    def test_doclang_family_reads_envelope_not_xml_bytes(self):
+        for tid in sorted(DOCLANG_FAMILY):
+            task = load_json(TASKS / f"{tid}.json")
+            cmds = walk_cmds(task)
+            self.assertTrue(any(c and c[0] == "export-doclang" for c in cmds), tid)
+            paths = {c.get("path") for c in task["checks"] if c.get("op") == "answer_eq"}
+            self.assertTrue(paths & {"lossCount", "format", "doclangVersion"}, tid)
+
+
+class ReferencePairTests(unittest.TestCase):
+    def test_reference_steps_exist(self):
+        for ref in all_refs():
+            self.assertTrue(ref.get("steps"), ref["id"])
+
+    def test_reference_reuses_the_task_command(self):
+        """기준풀이가 과제가 지목한 명령을 다시 돌린다 — 다른 오라클을 몰래 쓰지 않는다."""
+        mismatches = []
+        for tid in EXPECTED_IDS:
+            task = load_json(TASKS / f"{tid}.json")
+            ref = load_json(REFS / f"{tid}.json")
+            task_heads = {cmd[0] for cmd in walk_cmds(task) if cmd}
+            ref_heads = {cmd[0] for cmd in walk_cmds(ref) if cmd}
+            if tid in {"SR02", "SR05"}:
+                continue
+            if tid == "SR48":
+                self.assertIn("convert", ref_heads)
+                self.assertIn("info", ref_heads)
+                continue
+            if not (task_heads & ref_heads):
+                mismatches.append(f"{tid}: task={sorted(task_heads)} ref={sorted(ref_heads)}")
+        self.assertEqual(mismatches, [], mismatches)
+
+    def test_reference_uses_sub_placeholders_not_file(self):
+        leaked = []
+        for ref in all_refs():
+            raw = json.dumps(ref, ensure_ascii=False)
+            if "{file:" in raw:
+                leaked.append(ref["id"])
+        self.assertEqual(leaked, [], leaked)
+
+
+class DocumentationTests(unittest.TestCase):
+    def test_readme_is_korean_journeys_and_failure_modes(self):
+        text = README.read_text(encoding="utf-8")
+        self.assertIn("여정", text)
+        self.assertIn("실패 모드", text)
+        for marker in ("J1", "J2", "J3", "J4", "J5", "J6", "F1", "F3", "F4"):
+            self.assertIn(marker, text, marker)
+        self.assertIn("1 기준", text)
+        self.assertIn("라이브 오라클", text)
+        self.assertNotRegex(text, r"^[A-Za-z0-9 ,.\-']+$")
+
+    def test_working_notes_and_exceptions_exist(self):
+        working = WORKING.read_text(encoding="utf-8")
+        notes = EXCEPTIONS.read_text(encoding="utf-8")
+        self.assertIn("SR13", working)
+        self.assertIn("SR24", working)
+        self.assertIn("라이브 오라클", working)
+        self.assertIn("E1", notes)
+        self.assertIn("E3", notes)
+        self.assertIn("재조판", notes)
+        self.assertIn("wasDistribution", notes)
+
+    def test_readme_lists_rescued_and_followup_ids(self):
+        text = README.read_text(encoding="utf-8")
+        for tid in ("SR09", "SR13", "SR24", "SR25", "SR56"):
+            self.assertIn(tid, text, tid)
+
+
+class NoNewCliTests(unittest.TestCase):
+    def test_commands_are_existing_surface_only(self):
+        allowed = NEW_REQUIRES | {"export-hml", "export-ir-schema"}
+        unknown = []
+        for task in all_tasks():
+            for cmd in walk_cmds(task):
+                if cmd and cmd[0] not in allowed:
+                    unknown.append(f"{task['id']}:{cmd[0]}")
+        self.assertEqual(unknown, [], unknown)
+
+    def test_no_new_pack_directory(self):
+        self.assertTrue((PACK / "pack.json").is_file())
+        self.assertFalse((GYM / "packs" / "serialization-expand").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 요약

serialization pack이 형식 왕복 축인데 과제가 얇아서, 기존 CLI와 `samples/`만으로 SR 과제 4개를 추가한다. 새 pack·새 CLI·T07 복제는 없다. profiles/README/PARK/checks.py/다른 pack은 건드리지 않았다. runner는 기존 `serialization/pack.json`을 그대로 둔다.

Closes #5223

## 추가 과제

| ID | 제목 | 명령 | 표본 | 지목 연산자 |
|---|---|---|---|---|
| SR09 | HWPX를 편집 가능 HWP5로 | `convert` | `samples/hwpx_sample2.hwpx` | `file_exists` · `differs_from_input` · `value_eq(format)` · `answer_eq(format)` |
| SR10 | 쪽 범위 저장 후 쪽수 | `extract-pages` | `samples/exam-kor-2p.hwp` | `file_exists` · `differs_from_input` · `answer_eq(pagesAfter)` |
| SR11 | PDF 내보내기 쪽수 | `export-pdf` | `samples/para-001.hwp` | `file_exists` · `differs_from_input` · `value_eq(format)` · `answer_eq(pageCount)` |
| SR12 | 기존 HWP·HWPX 쌍 IR 대조 | `ir-diff` | `samples/pic2.hwp` + `samples/pic2.hwpx` | `answer_eq(identical)` |

기존 SR01–SR08은 유지한다. 과제 ID는 전역 고유하다.

## 검증

- `python gym/tools/audit.py` — 18 pack 전부 통과, 위반 0
- `python -m unittest scripts.tests.test_gym_packs -v` — 15 tests OK
- `cargo fmt --all` 는 이 변경(JSON만)에서 돌리지 않았다

## 위험

- `extract-pages`의 `pagesAfter`는 재조판으로 요청 범위와 다를 수 있다. 라이브 오라클(`answer_eq`)이라 값 박제는 없다.
- `export-pdf`는 폰트 환경에 따라 바이트가 달라질 수 있으나, 채점은 `format`·`pageCount`만 본다.
- `convert`/`export-pdf`/`extract-pages`를 로컬 rhwp 바이너리로 실행해 보지는 못했다. 기준 풀이는 기존 pack과 같은 라이브 재계산 형식이다.
- `ir-diff`는 차이가 있으면 exit 3이므로 `expect_exits`/`allowExits`에 0과 3을 넣었다.