### PR TITLE
feat(gym): work-receipt 작업 영수증 여정 pack (#5231)

### DIFF
--- a/gym/packs/work-receipt/README.md
+++ b/gym/packs/work-receipt/README.md
@@ -1,0 +1,182 @@
+---
+kind: guide
+status: active
+canonical: gym/packs/work-receipt/README.md
+last_verified: 2026-08-18
+---
+
+# work-receipt — 일일 작업 영수증 여정
+
+## 왜 이 pack 인가
+
+에이전트가 한 일을 **말이 아니라 재실행으로** 증명한다. 매일 밟는 길은 짧다.
+
+1. 영수증 한 장 (`replay`) — 입력·계획·산출 SHA-256 3종
+2. 뿌리 계보 (`lineage`) — 부모 없는 첫 캡슐, `parentOk==null`
+3. 부모 링크 (`lineage` 둘째 자리) — 어제 산출이 오늘 입력, `lineageOk`
+4. 폴더 회계 (`audit`) — 오늘 폴더의 **정확 건수**, 비율이 아님
+
+automation·expert-challenges 가 다루는 사다리 완주(AU02 재현율 1.0+total≥1,
+AU12 depth 2, AU07 gate --deep, XC01–XC05)는 복제하지 않는다. T07 서식
+채움도 이 pack 의 일이 아니다. 새 CLI 는 없다.
+
+권위 출처: 스킬 `rhwp-work-receipt`, `mydocs/manual/cli_commands.md` 의
+replay·audit·lineage, 에이전트 작업 표준 AW-L1.
+
+## 이 확장이 지키는 규칙
+
+1. **기존 명령만.** `pack.json` requires 는 `audit` · `lineage` · `replay`
+   뿐이다. `gate` · `conformance` · `settle` · `recall-scope` · `keygen` ·
+   `fill-fields` · `fields` 를 부르지 않는다.
+2. **기존 연산자만.** `gym/core/checks.py` REGISTRY 에 있는 것만 고른다.
+   `answer_eq` · `value_eq` · `value_in` · `file_exists` · `json_value_eq` ·
+   `files_differ` 가 전부다. 전역 훑기(`deep_contains`)는 쓰지 않는다.
+3. **기존 표본만.** `samples/` 밖 파일을 만들지 않는다. field-01, field-01-memo,
+   form-01, form-02, table-001, 중첩 표 규제 표본만 축을 바꿔 다시 묻는다.
+4. **라이브 오라클.** 해시·버전 숫자를 과제에 박제하지 않는다. 채점기가 같은
+   명령을 다시 돌려 봉투 필드를 읽는다.
+5. **T07 을 복제하지 않는다.** 누름틀을 채우지 않는다. 첫 필드 홍길동을 묻지
+   않는다.
+6. **사다리를 완주하지 않는다.** `--deep` 재현, 적합성 L5/L3, 정산 4관문,
+   오염 리콜, 3세대 depth 를 넣지 않는다.
+7. **원본을 덮지 않는다.** 산출은 제출 폴더의 `-o` / `--capsule` 뿐이다.
+
+## 명령 표면 (pack.json requires)
+
+| 명령 | 하는 일 | 이 pack 에서 읽는 봉투 |
+|------|---------|------------------------|
+| `replay` | 단건 영수증 발급·제3자 검증 | `mode` · `steps` · `input` · `inputSha256` · `planSha256` · `outputSha256` · `toolVersion` · `schemaVersion` · `reproduced` · `expectedOutputSha256` |
+| `lineage` | 머리부터 뿌리까지 계보 | `valid` · `depth` · `brokenAt` · `links[].parentOk` · `links[].lineageOk` · `links[].reproduced` |
+| `audit` | 폴더 직속 캡슐 전수 재현 | `total` · `reproduced` · `failed` · `schemaVersion` |
+
+`--deep` 은 이 pack 이 쓰지 않는다. 얕은 계보에서 `reproduced` 는 null 이다
+(WR27). 거짓 주장 해시는 `reproduced==false` 이고 exit 3 이다 (WR14).
+
+플래그 에코 필드(`mode`, `input`, `expectedOutputSha256`)는 값이 명령에서 온
+것이라 박제가 아니라 계약 확인이다.
+
+## 함정 (실측, 과제에 녹여 둔 것)
+
+- **영수증 발급 중 `output` 경로의 실파일은 생기지 않는다.** 임시 재실행이다.
+  실산출이 필요하면 `rhwp run` 을 따로 실행하라 (WR03·WR32 기준풀이).
+- **`--expect-output-sha256` 이 없으면 `reproduced` 와 `expectedOutputSha256`
+  은 null** 이다. false 가 아니다 (WR09·WR10).
+- **캡슐은 발급 후 불변이다.** 에디터로 열어 저장하면 부모 해시 대조가 깨진다.
+- **`--parent` 상대 경로는 캡슐 파일 기준**이다. 같은 폴더에 두는 것이 가장
+  단순하다 (WR33).
+- **audit 대상은 폴더 직속 `*.capsule.json`** (비재귀). 0개면 exit 2.
+- **비율만 맞추는 제출을 거부한다.** AU02 는 `reproducedRate==1.0` 과
+  `total≥1` 이다. 이 pack 은 `total==N` 과 `reproduced==N` 을 정확히 묻는다.
+- **형제는 체인이 아니다.** 부모 없이 나란히 둔 두·세 장(WR40–WR42·WR53·WR56)
+  은 depth 를 묻지 않는다.
+- **T07 금지.** 누름틀 값을 넣지 마라. 영수증은 치환 계획의 해시만 본다.
+
+## 과제 지도
+
+난도 1=입문 · 2=초급 · 3=중급 · 4=고급. 보스(5) 사다리 완주는 XC 의 일이다.
+
+### WR01–WR04 — 개장 코어 (초안)
+
+| ID | 티어 | 질문 | 표본 |
+|----|------|------|------|
+| WR01 | 2 | 일일 영수증 3해시 라이브 | field-01.hwp |
+| WR02 | 2 | 첫 영수증은 뿌리 (depth 1 · parentOk null) | field-01.hwp |
+| WR03 | 3 | 어제 산출 = 오늘 입력 (lineageOk · parentOk) | field-01.hwp |
+| WR04 | 2 | 오늘 폴더 회계 정확 1건 | field-01.hwp |
+
+### WR05–WR56 — 일일 여정을 가른다
+
+WR01–WR04 가 네 축의 입구다. 확장은 **같은 명령 가족**으로 모드·검증 기각·
+다른 표본·캡슐 내부 자리·형제 회계를 가른다.
+
+| ID | 티어 | 질문 | 표본 |
+|----|------|------|------|
+| WR05 | 1 | 발급 모드 attest 상수 | `samples/field-01.hwp` |
+| WR06 | 2 | 도구 버전 라이브 대조 | `samples/field-01.hwp` |
+| WR07 | 1 | 영수증 스키마 버전 라이브 | `samples/field-01.hwp` |
+| WR08 | 1 | 영수증 입력 경로 에코 | `samples/field-01.hwp` |
+| WR09 | 2 | 발급 영수증 reproduced 는 null | `samples/field-01.hwp` |
+| WR10 | 2 | 발급 영수증 expectedOutputSha256 는 null | `samples/field-01.hwp` |
+| WR11 | 2 | 출근장 치환 3해시 | `samples/field-01.hwp` |
+| WR12 | 2 | 규제 표본 3해시 | `samples/basic/issue2007_nested_cell_pagination_42065.hwp` |
+| WR13 | 3 | 두 걸음 계획 step 수 | `samples/field-01.hwp` |
+| WR14 | 3 | 거짓 산출 주장 기각 | `samples/field-01.hwp` |
+| WR15 | 2 | 검증 모드 verify 상수 | `samples/field-01.hwp` |
+| WR16 | 2 | 거짓 주장 해시 에코 | `samples/field-01.hwp` |
+| WR17 | 2 | 마감장 치환 3해시 | `samples/field-01.hwp` |
+| WR18 | 2 | 메모 표본 3해시 | `samples/field-01-memo.hwp` |
+| WR19 | 2 | 서식1 뿌리는 parentOk null | `samples/form-01.hwp` |
+| WR20 | 2 | 규제 표본 뿌리 깊이 1 | `samples/basic/issue2007_nested_cell_pagination_42065.hwp` |
+| WR21 | 1 | 캡슐 kind 는 workCapsule | `samples/field-01.hwp` |
+| WR22 | 1 | 뿌리 캡슐 parent 필드는 null | `samples/field-01.hwp` |
+| WR23 | 2 | 캡슐 속 영수증 모드 attest | `samples/field-01.hwp` |
+| WR24 | 2 | 캡슐 속 영수증 steps 1 | `samples/field-01.hwp` |
+| WR25 | 1 | 캡슐 속 계획 planVersion 1.0 | `samples/field-01.hwp` |
+| WR26 | 2 | 서식2 뿌리 계보 유효 | `samples/form-02.hwp` |
+| WR27 | 3 | 얕은 계보 reproduced 는 null | `samples/field-01.hwp` |
+| WR28 | 3 | 뿌리 링크 lineageOk 는 null | `samples/field-01.hwp` |
+| WR29 | 2 | 메모 표본 뿌리 깨진 지점 없음 | `samples/field-01-memo.hwp` |
+| WR30 | 2 | 캡슐 속 입력 경로 에코 | `samples/field-01.hwp` |
+| WR31 | 2 | 표 표본 뿌리 parentOk null | `samples/table-001.hwp` |
+| WR32 | 3 | 메모 표본 어제 산출이 오늘 입력 | `samples/field-01-memo.hwp` |
+| WR33 | 3 | 오늘 캡슐이 어제 파일을 부모로 기록 | `samples/field-01.hwp` |
+| WR34 | 2 | 오늘 캡슐 속 영수증도 attest | `samples/field-01.hwp` |
+| WR35 | 3 | 어제는 뿌리·오늘은 부모 객체 | `samples/field-01.hwp` |
+| WR36 | 3 | 규제 표본 어제 파일 무결 | `samples/basic/issue2007_nested_cell_pagination_42065.hwp` |
+| WR37 | 3 | 어제-오늘 계보는 유효하고 안 깨졌다 | `samples/field-01.hwp` |
+| WR38 | 2 | 규제 표본 오늘 폴더 1건 | `samples/basic/issue2007_nested_cell_pagination_42065.hwp` |
+| WR39 | 2 | 오늘 폴더 실패 목록은 빈 배열 | `samples/field-01.hwp` |
+| WR40 | 3 | 형제 두 장 폴더 회계는 정확히 2건 | `samples/field-01.hwp` |
+| WR41 | 3 | 형제 두 장 실패 목록은 비었다 | `samples/field-01.hwp` |
+| WR42 | 3 | 형제 세 장 폴더 회계는 정확히 3건 | `samples/field-01.hwp` |
+| WR43 | 2 | 메모 표본 오늘 폴더 1건 | `samples/field-01-memo.hwp` |
+| WR44 | 1 | 감사 봉투 root 에코 | `samples/field-01.hwp` |
+| WR45 | 2 | 계보 봉투 스키마 버전 라이브 | `samples/field-01.hwp` |
+| WR46 | 2 | 감사 봉투 스키마 버전 라이브 | `samples/field-01.hwp` |
+| WR47 | 2 | 표 표본 오늘 폴더 1건 | `samples/table-001.hwp` |
+| WR48 | 2 | 서식1 오늘 폴더 실패 없음 | `samples/form-01.hwp` |
+| WR49 | 2 | 발급 영수증 steps 라이브 | `samples/field-01.hwp` |
+| WR50 | 1 | 발급 모드 허용 집합 | `samples/field-01.hwp` |
+| WR51 | 2 | 캡슐 속 계획 input 에코 | `samples/field-01.hwp` |
+| WR52 | 2 | 캡슐 속 계획 output 에코 | `samples/field-01.hwp` |
+| WR53 | 3 | 형제 두 장은 서로 다른 바이트 | `samples/field-01.hwp` |
+| WR54 | 3 | 어제와 오늘 캡슐은 서로 다르다 | `samples/field-01.hwp` |
+| WR55 | 2 | 서식2 오늘 폴더 1건 | `samples/form-02.hwp` |
+| WR56 | 4 | 형제 세 장 모두 서로 다르다 | `samples/field-01.hwp` |
+
+## 축을 가르는 방법
+
+- **발급 vs 검증.** attest (WR05) 와 verify (WR15) 는 같은 replay 의 다른
+  모드다. 거짓 주장(WR14)은 기각이지 도구 고장이 아니다.
+- **null vs false.** 주장 없는 발급의 `reproduced` 는 null (WR09). 거짓
+  주장의 `reproduced` 는 false (WR14).
+- **뿌리 vs 부모 링크.** 뿌리의 `parentOk`·`lineageOk` 는 null (WR02·WR28).
+  둘째 링크만 true 를 갖는다 (WR03·WR32·WR36).
+- **형제 vs 체인.** 형제(WR40–WR42)는 부모를 붙이지 않는다. 체인(WR03·WR32+)
+  은 `--parent` 로 잇되 depth 숫자를 묻지 않는다.
+- **정확 건수 vs 비율.** `total==N` 과 `reproduced==N` 만 쓴다.
+  `reproducedRate` 와 `total≥1` 을 짝으로 두지 않는다.
+
+## 기준 풀이 왕복
+
+답 과제(WR01·WR05–WR18·WR45·WR46·WR49·WR50)의 기준풀이는 검사와 같은
+`cmd`/`path` 를 가진다. 산출 과제는 `replay --capsule {sub:…}` 로 제출
+파일을 만들고, 어제-오늘은 `run` 으로 실산출을 남긴 뒤 replay --parent 로
+잇는다.
+
+```bash
+python gym/tools/audit.py
+python -m unittest scripts/tests/test_gym_packs.py scripts/tests/test_gym_work_receipt_pack.py
+```
+
+바이너리 없이 스키마·짝 기준풀이·ID 고유만 검사한다. `cargo fmt --all` 은
+JSON·문서만 고친  sparseness 때문에 생략한다.
+
+## 이 pack 이 하지 않는 것
+
+- 새 CLI · 새 연산자 · 새 표본 · 새 pack
+- XC01 적합성 L5, XC02 오염 리콜, XC03 정산 4관문, XC04 3세대 --deep,
+  XC05 감사표준 L3
+- AU02 재현율+하한, AU07 gate --deep, AU12 depth==2
+- T07 fill-fields · 첫 필드 홍길동
+- `gym/README.md` · `gym/PARK.md` · 다른 프로파일 · `checks.py` 집계 갱신

--- a/gym/packs/work-receipt/pack.json
+++ b/gym/packs/work-receipt/pack.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "1.0",
+  "kind": "gymPack",
+  "id": "work-receipt",
+  "title": "작업 영수증 여정 (일일 발급·계보·감사)",
+  "axis": "자동화 (일일 영수증·뿌리 계보·부모 링크·폴더 회계)",
+  "description": "에이전트가 매일 밟는 작업 영수증 여정을 채점한다. automation·expert-challenges 의 사다리 완주(AU02 재현율 1.0+total≥1, AU12 depth 2, AU07 gate --deep, XC01–XC05)는 복제하지 않는다 — replay 3해시 라이브 오라클, 뿌리 캡슐 parentOk=null, 부모 링크 lineageOk, 폴더 회계 정확 1건처럼 다른 표본·다른 좌표·다른 축만 둔다. 새 CLI 는 없다.",
+  "requires": {
+    "commands": [
+      "audit",
+      "lineage",
+      "replay"
+    ]
+  },
+  "runner": {
+    "rhwpVersion": "0.8.4",
+    "rhwpCommit": "34ba36fa3c48f37867fbedd16614fdb7e8f44709",
+    "capabilitiesSha256": "6e2b231fad617b618fda19663752fc1a57d56086ade31abade84d8e8e000de4c"
+  }
+}

--- a/gym/packs/work-receipt/reference/WR01.json
+++ b/gym/packs/work-receipt/reference/WR01.json
@@ -1,0 +1,54 @@
+{
+  "id": "WR01",
+  "steps": [
+    {
+      "answer": {
+        "mode": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"receipt-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"영수증여정\"}]}",
+            "--json"
+          ],
+          "path": "mode"
+        },
+        "steps": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"receipt-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"영수증여정\"}]}",
+            "--json"
+          ],
+          "path": "steps"
+        },
+        "inputSha256": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"receipt-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"영수증여정\"}]}",
+            "--json"
+          ],
+          "path": "inputSha256"
+        },
+        "planSha256": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"receipt-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"영수증여정\"}]}",
+            "--json"
+          ],
+          "path": "planSha256"
+        },
+        "outputSha256": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"receipt-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"영수증여정\"}]}",
+            "--json"
+          ],
+          "path": "outputSha256"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR02.json
+++ b/gym/packs/work-receipt/reference/WR02.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR02",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"day.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"일일영수증\"}]}",
+        "--capsule",
+        "{sub:receipts/day.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR03.json
+++ b/gym/packs/work-receipt/reference/WR03.json
@@ -1,0 +1,35 @@
+{
+  "id": "WR03",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"{sub:yesterday.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"어제작업\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"{sub:yesterday.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"어제작업\"}]}",
+        "--capsule",
+        "{sub:receipts/yesterday.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:yesterday.hwp}\", \"output\": \"{sub:today.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"어제작업\", \"replace\": \"오늘작업\"}]}",
+        "--capsule",
+        "{sub:receipts/today.capsule.json}",
+        "--parent",
+        "{sub:receipts/yesterday.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR04.json
+++ b/gym/packs/work-receipt/reference/WR04.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR04",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"day.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"일일영수증\"}]}",
+        "--capsule",
+        "{sub:receipts/day.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR05.json
+++ b/gym/packs/work-receipt/reference/WR05.json
@@ -1,0 +1,18 @@
+{
+  "id": "WR05",
+  "steps": [
+    {
+      "answer": {
+        "mode": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"mode-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"모드확인\"}]}",
+            "--json"
+          ],
+          "path": "mode"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR06.json
+++ b/gym/packs/work-receipt/reference/WR06.json
@@ -1,0 +1,18 @@
+{
+  "id": "WR06",
+  "steps": [
+    {
+      "answer": {
+        "toolVersion": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"tool-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"도구버전\"}]}",
+            "--json"
+          ],
+          "path": "toolVersion"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR07.json
+++ b/gym/packs/work-receipt/reference/WR07.json
@@ -1,0 +1,18 @@
+{
+  "id": "WR07",
+  "steps": [
+    {
+      "answer": {
+        "schemaVersion": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"schema-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"스키마버전\"}]}",
+            "--json"
+          ],
+          "path": "schemaVersion"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR08.json
+++ b/gym/packs/work-receipt/reference/WR08.json
@@ -1,0 +1,18 @@
+{
+  "id": "WR08",
+  "steps": [
+    {
+      "answer": {
+        "input": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"echo-in.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"입력에코\"}]}",
+            "--json"
+          ],
+          "path": "input"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR09.json
+++ b/gym/packs/work-receipt/reference/WR09.json
@@ -1,0 +1,18 @@
+{
+  "id": "WR09",
+  "steps": [
+    {
+      "answer": {
+        "reproduced": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"null-repro.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"재현널\"}]}",
+            "--json"
+          ],
+          "path": "reproduced"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR10.json
+++ b/gym/packs/work-receipt/reference/WR10.json
@@ -1,0 +1,18 @@
+{
+  "id": "WR10",
+  "steps": [
+    {
+      "answer": {
+        "expectedOutputSha256": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"null-expect.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"기대널\"}]}",
+            "--json"
+          ],
+          "path": "expectedOutputSha256"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR11.json
+++ b/gym/packs/work-receipt/reference/WR11.json
@@ -1,0 +1,36 @@
+{
+  "id": "WR11",
+  "steps": [
+    {
+      "answer": {
+        "inputSha256": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"commute-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"출근장\"}]}",
+            "--json"
+          ],
+          "path": "inputSha256"
+        },
+        "planSha256": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"commute-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"출근장\"}]}",
+            "--json"
+          ],
+          "path": "planSha256"
+        },
+        "outputSha256": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"commute-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"출근장\"}]}",
+            "--json"
+          ],
+          "path": "outputSha256"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR12.json
+++ b/gym/packs/work-receipt/reference/WR12.json
@@ -1,0 +1,36 @@
+{
+  "id": "WR12",
+  "steps": [
+    {
+      "answer": {
+        "inputSha256": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/basic/issue2007_nested_cell_pagination_42065.hwp\", \"output\": \"reg-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"규제\", \"replace\": \"점검장\"}]}",
+            "--json"
+          ],
+          "path": "inputSha256"
+        },
+        "planSha256": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/basic/issue2007_nested_cell_pagination_42065.hwp\", \"output\": \"reg-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"규제\", \"replace\": \"점검장\"}]}",
+            "--json"
+          ],
+          "path": "planSha256"
+        },
+        "outputSha256": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/basic/issue2007_nested_cell_pagination_42065.hwp\", \"output\": \"reg-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"규제\", \"replace\": \"점검장\"}]}",
+            "--json"
+          ],
+          "path": "outputSha256"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR13.json
+++ b/gym/packs/work-receipt/reference/WR13.json
@@ -1,0 +1,18 @@
+{
+  "id": "WR13",
+  "steps": [
+    {
+      "answer": {
+        "steps": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"two-step.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"일차장\"}, {\"action\": \"replace_text\", \"find\": \"일차장\", \"replace\": \"이차장\"}]}",
+            "--json"
+          ],
+          "path": "steps"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR14.json
+++ b/gym/packs/work-receipt/reference/WR14.json
@@ -1,0 +1,20 @@
+{
+  "id": "WR14",
+  "steps": [
+    {
+      "answer": {
+        "reproduced": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"reject-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"거짓기각\"}]}",
+            "--expect-output-sha256",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "--json"
+          ],
+          "path": "reproduced"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR15.json
+++ b/gym/packs/work-receipt/reference/WR15.json
@@ -1,0 +1,20 @@
+{
+  "id": "WR15",
+  "steps": [
+    {
+      "answer": {
+        "mode": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"reject-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"거짓기각\"}]}",
+            "--expect-output-sha256",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "--json"
+          ],
+          "path": "mode"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR16.json
+++ b/gym/packs/work-receipt/reference/WR16.json
@@ -1,0 +1,20 @@
+{
+  "id": "WR16",
+  "steps": [
+    {
+      "answer": {
+        "expectedOutputSha256": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"reject-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"거짓기각\"}]}",
+            "--expect-output-sha256",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "--json"
+          ],
+          "path": "expectedOutputSha256"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR17.json
+++ b/gym/packs/work-receipt/reference/WR17.json
@@ -1,0 +1,36 @@
+{
+  "id": "WR17",
+  "steps": [
+    {
+      "answer": {
+        "inputSha256": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"close-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"마감장\"}]}",
+            "--json"
+          ],
+          "path": "inputSha256"
+        },
+        "planSha256": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"close-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"마감장\"}]}",
+            "--json"
+          ],
+          "path": "planSha256"
+        },
+        "outputSha256": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"close-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"마감장\"}]}",
+            "--json"
+          ],
+          "path": "outputSha256"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR18.json
+++ b/gym/packs/work-receipt/reference/WR18.json
@@ -1,0 +1,36 @@
+{
+  "id": "WR18",
+  "steps": [
+    {
+      "answer": {
+        "inputSha256": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01-memo.hwp\", \"output\": \"memo-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"메모장\"}]}",
+            "--json"
+          ],
+          "path": "inputSha256"
+        },
+        "planSha256": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01-memo.hwp\", \"output\": \"memo-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"메모장\"}]}",
+            "--json"
+          ],
+          "path": "planSha256"
+        },
+        "outputSha256": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01-memo.hwp\", \"output\": \"memo-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"메모장\"}]}",
+            "--json"
+          ],
+          "path": "outputSha256"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR19.json
+++ b/gym/packs/work-receipt/reference/WR19.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR19",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/form-01.hwp\", \"output\": \"form1-day.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"서식하루\"}]}",
+        "--capsule",
+        "{sub:receipts/form1.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR20.json
+++ b/gym/packs/work-receipt/reference/WR20.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR20",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/basic/issue2007_nested_cell_pagination_42065.hwp\", \"output\": \"reg-day.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"규제\", \"replace\": \"규제하루\"}]}",
+        "--capsule",
+        "{sub:receipts/reg.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR21.json
+++ b/gym/packs/work-receipt/reference/WR21.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR21",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"kind-day.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"종류확인\"}]}",
+        "--capsule",
+        "{sub:receipts/kind.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR22.json
+++ b/gym/packs/work-receipt/reference/WR22.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR22",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"parent-null.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"부모널\"}]}",
+        "--capsule",
+        "{sub:receipts/root.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR23.json
+++ b/gym/packs/work-receipt/reference/WR23.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR23",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"cap-mode.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"캡슐모드\"}]}",
+        "--capsule",
+        "{sub:receipts/mode.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR24.json
+++ b/gym/packs/work-receipt/reference/WR24.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR24",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"cap-steps.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"캡슐걸음\"}]}",
+        "--capsule",
+        "{sub:receipts/steps.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR25.json
+++ b/gym/packs/work-receipt/reference/WR25.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR25",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"plan-ver.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"계획버전\"}]}",
+        "--capsule",
+        "{sub:receipts/plan.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR26.json
+++ b/gym/packs/work-receipt/reference/WR26.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR26",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/form-02.hwp\", \"output\": \"form2-day.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"서식이틀\"}]}",
+        "--capsule",
+        "{sub:receipts/form2.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR27.json
+++ b/gym/packs/work-receipt/reference/WR27.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR27",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"no-deep.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"깊은검사없음\"}]}",
+        "--capsule",
+        "{sub:receipts/shallow.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR28.json
+++ b/gym/packs/work-receipt/reference/WR28.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR28",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"no-child.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"자식없음\"}]}",
+        "--capsule",
+        "{sub:receipts/leaf.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR29.json
+++ b/gym/packs/work-receipt/reference/WR29.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR29",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01-memo.hwp\", \"output\": \"memo-root.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"메모뿌리\"}]}",
+        "--capsule",
+        "{sub:receipts/memo.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR30.json
+++ b/gym/packs/work-receipt/reference/WR30.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR30",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"cap-input.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"캡슐입력\"}]}",
+        "--capsule",
+        "{sub:receipts/input.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR31.json
+++ b/gym/packs/work-receipt/reference/WR31.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR31",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"table-root.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"규제\", \"replace\": \"표하루\"}]}",
+        "--capsule",
+        "{sub:receipts/table.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR32.json
+++ b/gym/packs/work-receipt/reference/WR32.json
@@ -1,0 +1,35 @@
+{
+  "id": "WR32",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01-memo.hwp\", \"output\": \"{sub:yesterday.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"어제메모\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01-memo.hwp\", \"output\": \"{sub:yesterday.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"어제메모\"}]}",
+        "--capsule",
+        "{sub:receipts/yesterday.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:yesterday.hwp}\", \"output\": \"{sub:today.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"어제메모\", \"replace\": \"오늘메모\"}]}",
+        "--capsule",
+        "{sub:receipts/today.capsule.json}",
+        "--parent",
+        "{sub:receipts/yesterday.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR33.json
+++ b/gym/packs/work-receipt/reference/WR33.json
@@ -1,0 +1,35 @@
+{
+  "id": "WR33",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"{sub:yesterday.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"어제이름\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"{sub:yesterday.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"어제이름\"}]}",
+        "--capsule",
+        "{sub:receipts/yesterday.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:yesterday.hwp}\", \"output\": \"{sub:today.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"어제이름\", \"replace\": \"오늘이름\"}]}",
+        "--capsule",
+        "{sub:receipts/today.capsule.json}",
+        "--parent",
+        "{sub:receipts/yesterday.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR34.json
+++ b/gym/packs/work-receipt/reference/WR34.json
@@ -1,0 +1,35 @@
+{
+  "id": "WR34",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"{sub:yesterday.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"어제모드\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"{sub:yesterday.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"어제모드\"}]}",
+        "--capsule",
+        "{sub:receipts/yesterday.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:yesterday.hwp}\", \"output\": \"{sub:today.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"어제모드\", \"replace\": \"오늘모드\"}]}",
+        "--capsule",
+        "{sub:receipts/today.capsule.json}",
+        "--parent",
+        "{sub:receipts/yesterday.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR35.json
+++ b/gym/packs/work-receipt/reference/WR35.json
@@ -1,0 +1,35 @@
+{
+  "id": "WR35",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"{sub:yesterday.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"어제뿌리\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"{sub:yesterday.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"어제뿌리\"}]}",
+        "--capsule",
+        "{sub:receipts/yesterday.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:yesterday.hwp}\", \"output\": \"{sub:today.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"어제뿌리\", \"replace\": \"오늘자식\"}]}",
+        "--capsule",
+        "{sub:receipts/today.capsule.json}",
+        "--parent",
+        "{sub:receipts/yesterday.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR36.json
+++ b/gym/packs/work-receipt/reference/WR36.json
@@ -1,0 +1,35 @@
+{
+  "id": "WR36",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/basic/issue2007_nested_cell_pagination_42065.hwp\", \"output\": \"{sub:yesterday.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"규제\", \"replace\": \"어제규제\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/basic/issue2007_nested_cell_pagination_42065.hwp\", \"output\": \"{sub:yesterday.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"규제\", \"replace\": \"어제규제\"}]}",
+        "--capsule",
+        "{sub:receipts/yesterday.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:yesterday.hwp}\", \"output\": \"{sub:today.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"어제규제\", \"replace\": \"오늘규제\"}]}",
+        "--capsule",
+        "{sub:receipts/today.capsule.json}",
+        "--parent",
+        "{sub:receipts/yesterday.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR37.json
+++ b/gym/packs/work-receipt/reference/WR37.json
@@ -1,0 +1,35 @@
+{
+  "id": "WR37",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"{sub:yesterday.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"어제온전\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"{sub:yesterday.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"어제온전\"}]}",
+        "--capsule",
+        "{sub:receipts/yesterday.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:yesterday.hwp}\", \"output\": \"{sub:today.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"어제온전\", \"replace\": \"오늘온전\"}]}",
+        "--capsule",
+        "{sub:receipts/today.capsule.json}",
+        "--parent",
+        "{sub:receipts/yesterday.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR38.json
+++ b/gym/packs/work-receipt/reference/WR38.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR38",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/basic/issue2007_nested_cell_pagination_42065.hwp\", \"output\": \"day.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"규제\", \"replace\": \"규제회계\"}]}",
+        "--capsule",
+        "{sub:receipts/day.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR39.json
+++ b/gym/packs/work-receipt/reference/WR39.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR39",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"day.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"실패없음\"}]}",
+        "--capsule",
+        "{sub:receipts/day.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR40.json
+++ b/gym/packs/work-receipt/reference/WR40.json
@@ -1,0 +1,25 @@
+{
+  "id": "WR40",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"sib-a.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"형제공무\"}]}",
+        "--capsule",
+        "{sub:receipts/a.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"sib-b.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"형제민간\"}]}",
+        "--capsule",
+        "{sub:receipts/b.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR41.json
+++ b/gym/packs/work-receipt/reference/WR41.json
@@ -1,0 +1,25 @@
+{
+  "id": "WR41",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"sib-a2.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"형제갑\"}]}",
+        "--capsule",
+        "{sub:receipts/a.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"sib-b2.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"형제을\"}]}",
+        "--capsule",
+        "{sub:receipts/b.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR42.json
+++ b/gym/packs/work-receipt/reference/WR42.json
@@ -1,0 +1,35 @@
+{
+  "id": "WR42",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"t3-a.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"삼형제갑\"}]}",
+        "--capsule",
+        "{sub:receipts/a.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"t3-b.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"삼형제을\"}]}",
+        "--capsule",
+        "{sub:receipts/b.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"t3-c.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"삼형제병\"}]}",
+        "--capsule",
+        "{sub:receipts/c.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR43.json
+++ b/gym/packs/work-receipt/reference/WR43.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR43",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01-memo.hwp\", \"output\": \"day.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"메모회계\"}]}",
+        "--capsule",
+        "{sub:receipts/day.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR44.json
+++ b/gym/packs/work-receipt/reference/WR44.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR44",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"day.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"루트에코\"}]}",
+        "--capsule",
+        "{sub:receipts/day.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR45.json
+++ b/gym/packs/work-receipt/reference/WR45.json
@@ -1,0 +1,27 @@
+{
+  "id": "WR45",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"day.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"계보스킴\"}]}",
+        "--capsule",
+        "{sub:receipts/day.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "answer": {
+        "schemaVersion": {
+          "cmd": [
+            "lineage",
+            "{file:receipts/day.capsule.json}",
+            "--json"
+          ],
+          "path": "schemaVersion"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR46.json
+++ b/gym/packs/work-receipt/reference/WR46.json
@@ -1,0 +1,27 @@
+{
+  "id": "WR46",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"day.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"감사스킴\"}]}",
+        "--capsule",
+        "{sub:receipts/day.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "answer": {
+        "schemaVersion": {
+          "cmd": [
+            "audit",
+            "{file:receipts}",
+            "--json"
+          ],
+          "path": "schemaVersion"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR47.json
+++ b/gym/packs/work-receipt/reference/WR47.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR47",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"day.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"규제\", \"replace\": \"표회계\"}]}",
+        "--capsule",
+        "{sub:receipts/day.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR48.json
+++ b/gym/packs/work-receipt/reference/WR48.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR48",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/form-01.hwp\", \"output\": \"day.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"서식회계\"}]}",
+        "--capsule",
+        "{sub:receipts/day.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR49.json
+++ b/gym/packs/work-receipt/reference/WR49.json
@@ -1,0 +1,18 @@
+{
+  "id": "WR49",
+  "steps": [
+    {
+      "answer": {
+        "steps": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"live-steps.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"걸음라이브\"}]}",
+            "--json"
+          ],
+          "path": "steps"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR50.json
+++ b/gym/packs/work-receipt/reference/WR50.json
@@ -1,0 +1,18 @@
+{
+  "id": "WR50",
+  "steps": [
+    {
+      "answer": {
+        "mode": {
+          "cmd": [
+            "replay",
+            "--plan-json",
+            "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"mode-set.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"모드집합\"}]}",
+            "--json"
+          ],
+          "path": "mode"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR51.json
+++ b/gym/packs/work-receipt/reference/WR51.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR51",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"planin.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"계획입력\"}]}",
+        "--capsule",
+        "{sub:receipts/planin.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR52.json
+++ b/gym/packs/work-receipt/reference/WR52.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR52",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"planout.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"계획산출\"}]}",
+        "--capsule",
+        "{sub:receipts/planout.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR53.json
+++ b/gym/packs/work-receipt/reference/WR53.json
@@ -1,0 +1,25 @@
+{
+  "id": "WR53",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"diff-a.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"출근형제\"}]}",
+        "--capsule",
+        "{sub:receipts/a.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"diff-b.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"퇴근형제\"}]}",
+        "--capsule",
+        "{sub:receipts/b.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR54.json
+++ b/gym/packs/work-receipt/reference/WR54.json
@@ -1,0 +1,35 @@
+{
+  "id": "WR54",
+  "steps": [
+    {
+      "run": [
+        "run",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"{sub:yesterday.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"어제복사금지\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"{sub:yesterday.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"어제복사금지\"}]}",
+        "--capsule",
+        "{sub:receipts/yesterday.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"{sub:yesterday.hwp}\", \"output\": \"{sub:today.hwp}\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"어제복사금지\", \"replace\": \"오늘복사금지\"}]}",
+        "--capsule",
+        "{sub:receipts/today.capsule.json}",
+        "--parent",
+        "{sub:receipts/yesterday.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR55.json
+++ b/gym/packs/work-receipt/reference/WR55.json
@@ -1,0 +1,15 @@
+{
+  "id": "WR55",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/form-02.hwp\", \"output\": \"day.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"서식2회계\"}]}",
+        "--capsule",
+        "{sub:receipts/day.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/reference/WR56.json
+++ b/gym/packs/work-receipt/reference/WR56.json
@@ -1,0 +1,35 @@
+{
+  "id": "WR56",
+  "steps": [
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"u-a.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"고유갑\"}]}",
+        "--capsule",
+        "{sub:receipts/a.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"u-b.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"고유을\"}]}",
+        "--capsule",
+        "{sub:receipts/b.capsule.json}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"u-c.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"고유병\"}]}",
+        "--capsule",
+        "{sub:receipts/c.capsule.json}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR01.json
+++ b/gym/packs/work-receipt/tasks/WR01.json
@@ -1,0 +1,76 @@
+{
+  "id": "WR01",
+  "tier": 2,
+  "title": "일일 영수증 3해시 발급",
+  "input": "samples/field-01.hwp",
+  "axis": "조회",
+  "instructions": "표지 본문 '마케팅' 을 '영수증여정' 으로 바꾸는 계획을 replay 로 재실행해 **작업 영수증 한 장**을 받아라. 캡슐을 만들지 말고, 봉투의 mode·steps·inputSha256·planSha256·outputSha256 을 answer.json 에 그대로 옮겨라. 채점은 같은 계획을 다시 돌려 3해시를 라이브 대조한다 — AU02 의 캡슐+재현율 판정이 아니다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"receipt-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"영수증여정\"}]}' --json",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "발급 모드 attest",
+      "op": "answer_eq",
+      "answer": "mode",
+      "path": "mode",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"receipt-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"영수증여정\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "name": "실행 step 수 1",
+      "op": "answer_eq",
+      "answer": "steps",
+      "path": "steps",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"receipt-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"영수증여정\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "name": "입력 해시 라이브 대조",
+      "op": "answer_eq",
+      "answer": "inputSha256",
+      "path": "inputSha256",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"receipt-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"영수증여정\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "name": "계획 해시 라이브 대조",
+      "op": "answer_eq",
+      "answer": "planSha256",
+      "path": "planSha256",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"receipt-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"영수증여정\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "name": "산출 해시 라이브 대조",
+      "op": "answer_eq",
+      "answer": "outputSha256",
+      "path": "outputSha256",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"receipt-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"영수증여정\"}]}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR02.json
+++ b/gym/packs/work-receipt/tasks/WR02.json
@@ -1,0 +1,66 @@
+{
+  "id": "WR02",
+  "tier": 2,
+  "title": "첫 영수증은 뿌리다",
+  "input": "samples/field-01.hwp",
+  "instructions": "오늘 첫 작업 캡슐 receipts/day.capsule.json 을 제출하라. 부모(--parent) 를 붙이지 않은 **뿌리**여야 한다. 채점은 lineage 로 깊이 1·valid·머리 링크 parentOk 가 null 인지를 본다 — AU12/XC04 의 2·3세대 depth 판정이 아니다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"day.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"일일영수증\"}]}' --capsule receipts/day.capsule.json --json 후 rhwp lineage receipts/day.capsule.json --json",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/day.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "뿌리 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/day.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "계보 유효",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:receipts/day.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "깊이 1 — 부모 없음",
+      "op": "value_eq",
+      "value": 1,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:receipts/day.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "머리 링크 parentOk 는 null — 뿌리는 부모 대조가 없다",
+      "op": "value_eq",
+      "value": null,
+      "path": "links[0].parentOk",
+      "cmd": [
+        "lineage",
+        "{file:receipts/day.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR03.json
+++ b/gym/packs/work-receipt/tasks/WR03.json
@@ -1,0 +1,67 @@
+{
+  "id": "WR03",
+  "tier": 3,
+  "title": "어제 산출이 오늘 입력이다",
+  "input": "samples/field-01.hwp",
+  "instructions": "어제 작업 캡슐과 오늘 작업 캡슐을 receipts/ 에 이어 제출하라. 오늘의 입력은 어제 계획의 **실산출**이어야 하고, replay --parent 로 어제 캡슐을 지목한다. 채점은 머리에서 본 부모 링크의 lineageOk(부모 산출=자식 입력)·parentOk(부모 파일 무결) 와 brokenAt=null 이다 — AU12 의 depth==2 나 XC04 의 3세대가 아니다. 힌트: run 으로 yesterday.hwp 를 만든 뒤 replay --capsule receipts/yesterday.capsule.json, 이어서 input=yesterday.hwp 인 오늘 계획을 replay --parent receipts/yesterday.capsule.json --capsule receipts/today.capsule.json",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/yesterday.capsule.json",
+      "receipts/today.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "오늘 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/today.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "부모 링크 lineageOk — 어제 산출이 오늘 입력",
+      "op": "value_eq",
+      "value": true,
+      "path": "links[1].lineageOk",
+      "cmd": [
+        "lineage",
+        "{file:receipts/today.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "부모 링크 parentOk — 어제 파일이 발급 당시 그대로",
+      "op": "value_eq",
+      "value": true,
+      "path": "links[1].parentOk",
+      "cmd": [
+        "lineage",
+        "{file:receipts/today.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "깨진 지점 없음",
+      "op": "value_eq",
+      "value": null,
+      "path": "brokenAt",
+      "cmd": [
+        "lineage",
+        "{file:receipts/today.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR04.json
+++ b/gym/packs/work-receipt/tasks/WR04.json
@@ -1,0 +1,51 @@
+{
+  "id": "WR04",
+  "tier": 2,
+  "title": "오늘 폴더 회계는 1건",
+  "input": "samples/field-01.hwp",
+  "instructions": "오늘 만든 캡슐 하나만 receipts/day.capsule.json 으로 제출하라. 채점은 그 폴더를 audit 해 **총 1건·재현 1건**인지 본다. AU02 의 reproducedRate==1.0 과 total≥1 이 아니다 — 빈 폴더에 가깝게 여러 장을 쌓아 비율만 맞추는 제출을 거부한다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"day.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"일일영수증\"}]}' --capsule receipts/day.capsule.json --json 후 rhwp audit receipts --json",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/day.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "오늘 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/day.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "폴더 총 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "total",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "재현 성공 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "reproduced",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR05.json
+++ b/gym/packs/work-receipt/tasks/WR05.json
@@ -1,0 +1,28 @@
+{
+  "id": "WR05",
+  "tier": 1,
+  "title": "발급 모드 attest 상수",
+  "input": "samples/field-01.hwp",
+  "axis": "조회",
+  "instructions": "WR05 — 발급 모드가 attest 인지 상수로 확인. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n캡슐 없이 replay 만 돌려라. 채점은 봉투 `mode` 가 문자열 attest 인지 본다. WR01 의 3해시 라이브 오라클이 아니다 — 모드 상수 한 자리만 묻는다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"mode-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"모드확인\"}]}' --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "발급 모드 attest",
+      "op": "value_eq",
+      "value": "attest",
+      "path": "mode",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"mode-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"모드확인\"}]}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR06.json
+++ b/gym/packs/work-receipt/tasks/WR06.json
@@ -1,0 +1,28 @@
+{
+  "id": "WR06",
+  "tier": 2,
+  "title": "도구 버전 라이브 대조",
+  "input": "samples/field-01.hwp",
+  "axis": "조회",
+  "instructions": "WR06 — 영수증의 toolVersion 을 라이브 대조. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\nanswer.json 에 toolVersion 을 옮겨라. 채점은 같은 계획을 다시 돌려 봉투 경로 toolVersion 을 읽는다 — 버전 문자열을 과제에 박제하지 마라. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"tool-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"도구버전\"}]}' --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "도구 버전 라이브",
+      "op": "answer_eq",
+      "answer": "toolVersion",
+      "path": "toolVersion",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"tool-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"도구버전\"}]}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR07.json
+++ b/gym/packs/work-receipt/tasks/WR07.json
@@ -1,0 +1,28 @@
+{
+  "id": "WR07",
+  "tier": 1,
+  "title": "영수증 스키마 버전 라이브",
+  "input": "samples/field-01.hwp",
+  "axis": "조회",
+  "instructions": "WR07 — replay 봉투 schemaVersion 라이브 오라클. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\nanswer.json 에 schemaVersion 을 옮겨라. 봉투 버전이 바뀌면 정답이 따라간다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"schema-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"스키마버전\"}]}' --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "스키마 버전 라이브",
+      "op": "answer_eq",
+      "answer": "schemaVersion",
+      "path": "schemaVersion",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"schema-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"스키마버전\"}]}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR08.json
+++ b/gym/packs/work-receipt/tasks/WR08.json
@@ -1,0 +1,28 @@
+{
+  "id": "WR08",
+  "tier": 1,
+  "title": "영수증 입력 경로 에코",
+  "input": "samples/field-01.hwp",
+  "axis": "조회",
+  "instructions": "WR08 — 계획 input 이 봉투에 그대로 메아리치는지 확인. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n채점은 봉투 `input` 이 samples/field-01.hwp 인지 본다. 해시를 묻지 않는다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"echo-in.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"입력에코\"}]}' --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "입력 경로 에코",
+      "op": "value_eq",
+      "value": "samples/field-01.hwp",
+      "path": "input",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"echo-in.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"입력에코\"}]}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR09.json
+++ b/gym/packs/work-receipt/tasks/WR09.json
@@ -1,0 +1,28 @@
+{
+  "id": "WR09",
+  "tier": 2,
+  "title": "발급 영수증 reproduced 는 null",
+  "input": "samples/field-01.hwp",
+  "axis": "조회",
+  "instructions": "WR09 — 주장 해시 없이 발급하면 reproduced 가 null. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n--expect-output-sha256 없이 발급하면 제3자 검증이 아니므로 reproduced 는 null 이다. false 가 아니다. WR14 의 거짓 주장 기각과 자리를 가른다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"null-repro.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"재현널\"}]}' --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "발급 reproduced null",
+      "op": "value_eq",
+      "value": null,
+      "path": "reproduced",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"null-repro.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"재현널\"}]}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR10.json
+++ b/gym/packs/work-receipt/tasks/WR10.json
@@ -1,0 +1,28 @@
+{
+  "id": "WR10",
+  "tier": 2,
+  "title": "발급 영수증 expectedOutputSha256 는 null",
+  "input": "samples/field-01.hwp",
+  "axis": "조회",
+  "instructions": "WR10 — 발급 봉투의 기대 산출 해시는 비어 있다. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n주장 해시가 없으면 expectedOutputSha256 은 null 이다. WR16 의 거짓 주장 에코와 자리를 가른다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"null-expect.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"기대널\"}]}' --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "발급 기대해시 null",
+      "op": "value_eq",
+      "value": null,
+      "path": "expectedOutputSha256",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"null-expect.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"기대널\"}]}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR11.json
+++ b/gym/packs/work-receipt/tasks/WR11.json
@@ -1,0 +1,52 @@
+{
+  "id": "WR11",
+  "tier": 2,
+  "title": "출근장 치환 3해시",
+  "input": "samples/field-01.hwp",
+  "axis": "조회",
+  "instructions": "WR11 — 다른 치환 문구로 3해시 라이브 대조. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n표지 본문 '마케팅' 을 '출근장' 으로 바꾸는 계획이다. WR01 의 '영수증여정' 과 산출 해시가 달라야 판별력이 있다. 캡슐을 만들지 말고 3해시를 옮겨라. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"commute-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"출근장\"}]}' --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "출근 입력 해시",
+      "op": "answer_eq",
+      "answer": "inputSha256",
+      "path": "inputSha256",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"commute-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"출근장\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "name": "출근 계획 해시",
+      "op": "answer_eq",
+      "answer": "planSha256",
+      "path": "planSha256",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"commute-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"출근장\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "name": "출근 산출 해시",
+      "op": "answer_eq",
+      "answer": "outputSha256",
+      "path": "outputSha256",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"commute-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"출근장\"}]}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR12.json
+++ b/gym/packs/work-receipt/tasks/WR12.json
@@ -1,0 +1,52 @@
+{
+  "id": "WR12",
+  "tier": 2,
+  "title": "규제 표본 3해시",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "axis": "조회",
+  "instructions": "WR12 — 다른 실문서에서 3해시 발급. 입력 표본은 `samples/basic/issue2007_nested_cell_pagination_42065.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\nfield-01 이 아니라 중첩 표 표본의 '규제' 를 '점검장' 으로 바꾼다. 표본을 바꿔도 영수증 자리는 같다. TE01 의 검색 건수 판정이 아니다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/basic/issue2007_nested_cell_pagination_42065.hwp\", \"output\": \"reg-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"규제\", \"replace\": \"점검장\"}]}' --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "규제 입력 해시",
+      "op": "answer_eq",
+      "answer": "inputSha256",
+      "path": "inputSha256",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/basic/issue2007_nested_cell_pagination_42065.hwp\", \"output\": \"reg-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"규제\", \"replace\": \"점검장\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "name": "규제 계획 해시",
+      "op": "answer_eq",
+      "answer": "planSha256",
+      "path": "planSha256",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/basic/issue2007_nested_cell_pagination_42065.hwp\", \"output\": \"reg-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"규제\", \"replace\": \"점검장\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "name": "규제 산출 해시",
+      "op": "answer_eq",
+      "answer": "outputSha256",
+      "path": "outputSha256",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/basic/issue2007_nested_cell_pagination_42065.hwp\", \"output\": \"reg-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"규제\", \"replace\": \"점검장\"}]}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR13.json
+++ b/gym/packs/work-receipt/tasks/WR13.json
@@ -1,0 +1,28 @@
+{
+  "id": "WR13",
+  "tier": 3,
+  "title": "두 걸음 계획 step 수",
+  "input": "samples/field-01.hwp",
+  "axis": "조회",
+  "instructions": "WR13 — 치환 두 걸음 계획의 steps==2. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n한 계획에 replace_text 를 두 번 넣는다. 채점은 봉투 steps 가 2 인지 본다. WR01 의 steps==1 라이브와 자리를 가른다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"two-step.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"일차장\"}, {\"action\": \"replace_text\", \"find\": \"일차장\", \"replace\": \"이차장\"}]}' --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "실행 step 수 2",
+      "op": "value_eq",
+      "value": 2,
+      "path": "steps",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"two-step.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"일차장\"}, {\"action\": \"replace_text\", \"find\": \"일차장\", \"replace\": \"이차장\"}]}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR14.json
+++ b/gym/packs/work-receipt/tasks/WR14.json
@@ -1,0 +1,33 @@
+{
+  "id": "WR14",
+  "tier": 3,
+  "title": "거짓 산출 주장 기각",
+  "input": "samples/field-01.hwp",
+  "axis": "조회",
+  "instructions": "WR14 — 64자리 0 해시를 주장하면 reproduced==false. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n제3자 검증 경로(--expect-output-sha256)에 거짓 해시를 넣으면 봉투 reproduced 가 false 이고 exit 3 이다. 도구 고장이 아니다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"reject-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"거짓기각\"}]}' --expect-output-sha256 0000000000000000000000000000000000000000000000000000000000000000 --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "거짓 주장 기각",
+      "op": "value_eq",
+      "value": false,
+      "path": "reproduced",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"reject-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"거짓기각\"}]}",
+        "--expect-output-sha256",
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        "--json"
+      ],
+      "expect_exits": [
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR15.json
+++ b/gym/packs/work-receipt/tasks/WR15.json
@@ -1,0 +1,33 @@
+{
+  "id": "WR15",
+  "tier": 2,
+  "title": "검증 모드 verify 상수",
+  "input": "samples/field-01.hwp",
+  "axis": "조회",
+  "instructions": "WR15 — 주장 해시가 있으면 mode 는 verify. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n같은 거짓 해시라도 모드는 verify 다. WR05 의 attest 와 자리를 가른다. 재현 성공을 묻지 않는다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"reject-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"거짓기각\"}]}' --expect-output-sha256 0000000000000000000000000000000000000000000000000000000000000000 --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "검증 모드 verify",
+      "op": "value_eq",
+      "value": "verify",
+      "path": "mode",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"reject-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"거짓기각\"}]}",
+        "--expect-output-sha256",
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        "--json"
+      ],
+      "expect_exits": [
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR16.json
+++ b/gym/packs/work-receipt/tasks/WR16.json
@@ -1,0 +1,33 @@
+{
+  "id": "WR16",
+  "tier": 2,
+  "title": "거짓 주장 해시 에코",
+  "input": "samples/field-01.hwp",
+  "axis": "조회",
+  "instructions": "WR16 — 기대한 산출 해시가 주장값 그대로 에코되는지. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\nexpectedOutputSha256 은 명령에서 온 값이므로 박제가 아니라 계약 확인이다. 64자리 0 을 넣었으면 봉투에도 그 값이 있어야 한다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"reject-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"거짓기각\"}]}' --expect-output-sha256 0000000000000000000000000000000000000000000000000000000000000000 --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "기대 해시 에코",
+      "op": "value_eq",
+      "value": "0000000000000000000000000000000000000000000000000000000000000000",
+      "path": "expectedOutputSha256",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"reject-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"거짓기각\"}]}",
+        "--expect-output-sha256",
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        "--json"
+      ],
+      "expect_exits": [
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR17.json
+++ b/gym/packs/work-receipt/tasks/WR17.json
@@ -1,0 +1,52 @@
+{
+  "id": "WR17",
+  "tier": 2,
+  "title": "마감장 치환 3해시",
+  "input": "samples/field-01.hwp",
+  "axis": "조회",
+  "instructions": "WR17 — 마감 문구 치환의 3해시 라이브 대조. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\nWR01·WR11 과 치환 문자열이 다르다. 계획 해시가 같으면 다른 계획을 쓴 것이 아니다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"close-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"마감장\"}]}' --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "마감 입력 해시",
+      "op": "answer_eq",
+      "answer": "inputSha256",
+      "path": "inputSha256",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"close-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"마감장\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "name": "마감 계획 해시",
+      "op": "answer_eq",
+      "answer": "planSha256",
+      "path": "planSha256",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"close-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"마감장\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "name": "마감 산출 해시",
+      "op": "answer_eq",
+      "answer": "outputSha256",
+      "path": "outputSha256",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"close-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"마감장\"}]}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR18.json
+++ b/gym/packs/work-receipt/tasks/WR18.json
@@ -1,0 +1,52 @@
+{
+  "id": "WR18",
+  "tier": 2,
+  "title": "메모 표본 3해시",
+  "input": "samples/field-01-memo.hwp",
+  "axis": "조회",
+  "instructions": "WR18 — field-01-memo 에서 3해시 발급. 입력 표본은 `samples/field-01-memo.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n누름틀 메모 표본이다. T07 처럼 필드를 채우지 마라. 영수증만 받는다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01-memo.hwp\", \"output\": \"memo-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"메모장\"}]}' --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "메모 입력 해시",
+      "op": "answer_eq",
+      "answer": "inputSha256",
+      "path": "inputSha256",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01-memo.hwp\", \"output\": \"memo-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"메모장\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "name": "메모 계획 해시",
+      "op": "answer_eq",
+      "answer": "planSha256",
+      "path": "planSha256",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01-memo.hwp\", \"output\": \"memo-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"메모장\"}]}",
+        "--json"
+      ]
+    },
+    {
+      "name": "메모 산출 해시",
+      "op": "answer_eq",
+      "answer": "outputSha256",
+      "path": "outputSha256",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01-memo.hwp\", \"output\": \"memo-out.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"메모장\"}]}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR19.json
+++ b/gym/packs/work-receipt/tasks/WR19.json
@@ -1,0 +1,36 @@
+{
+  "id": "WR19",
+  "tier": 2,
+  "title": "서식1 뿌리는 parentOk null",
+  "input": "samples/form-01.hwp",
+  "instructions": "WR19 — 다른 서식 표본의 뿌리 캡슐. 입력 표본은 `samples/form-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\nreceipts/form1.capsule.json 을 부모 없이 제출하라. 채점은 머리 링크 parentOk 가 null 인지만 본다. AU12 의 depth==2 가 아니다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/form-01.hwp\", \"output\": \"form1-day.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"서식하루\"}]}' --capsule receipts/form1.capsule.json --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/form1.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "서식1 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/form1.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "머리 parentOk null",
+      "op": "value_eq",
+      "value": null,
+      "path": "links[0].parentOk",
+      "cmd": [
+        "lineage",
+        "{file:receipts/form1.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR20.json
+++ b/gym/packs/work-receipt/tasks/WR20.json
@@ -1,0 +1,36 @@
+{
+  "id": "WR20",
+  "tier": 2,
+  "title": "규제 표본 뿌리 깊이 1",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "WR20 — 규제 표본 뿌리 캡슐의 depth==1. 입력 표본은 `samples/basic/issue2007_nested_cell_pagination_42065.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n부모를 붙이지 않은 뿌리다. 깊이 1 만 묻는다. XC04 의 3세대가 아니다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/basic/issue2007_nested_cell_pagination_42065.hwp\", \"output\": \"reg-day.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"규제\", \"replace\": \"규제하루\"}]}' --capsule receipts/reg.capsule.json --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/reg.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "규제 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/reg.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "깊이 1",
+      "op": "value_eq",
+      "value": 1,
+      "path": "depth",
+      "cmd": [
+        "lineage",
+        "{file:receipts/reg.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR21.json
+++ b/gym/packs/work-receipt/tasks/WR21.json
@@ -1,0 +1,28 @@
+{
+  "id": "WR21",
+  "tier": 1,
+  "title": "캡슐 kind 는 workCapsule",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR21 — 제출 파일이 작업 캡슐 형식인지. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n채점은 제출 JSON 의 kind 가 workCapsule 인지 본다. lineage 를 부르지 않고 파일 연산자 json_value_eq 로 형식을 고정한다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"kind-day.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"종류확인\"}]}' --capsule receipts/kind.capsule.json --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/kind.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "종류 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/kind.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "kind workCapsule",
+      "op": "json_value_eq",
+      "file": "receipts/kind.capsule.json",
+      "path": "kind",
+      "value": "workCapsule"
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR22.json
+++ b/gym/packs/work-receipt/tasks/WR22.json
@@ -1,0 +1,28 @@
+{
+  "id": "WR22",
+  "tier": 1,
+  "title": "뿌리 캡슐 parent 필드는 null",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR22 — 부모 없이 발급하면 parent JSON 이 null. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n필드 자체가 없거나 빈 객체면 뿌리가 아니다. null 이어야 한다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"parent-null.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"부모널\"}]}' --capsule receipts/root.capsule.json --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/root.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "뿌리 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/root.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "parent null",
+      "op": "json_value_eq",
+      "file": "receipts/root.capsule.json",
+      "path": "parent",
+      "value": null
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR23.json
+++ b/gym/packs/work-receipt/tasks/WR23.json
@@ -1,0 +1,28 @@
+{
+  "id": "WR23",
+  "tier": 2,
+  "title": "캡슐 속 영수증 모드 attest",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR23 — 캡슐에 내장된 receipt.mode 가 attest. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n캡슐은 계획+영수증의 자기완결 교환 파일이다. 발급 당시 모드가 안에 남아 있어야 제3자가 검증할 수 있다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"cap-mode.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"캡슐모드\"}]}' --capsule receipts/mode.capsule.json --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/mode.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "모드 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/mode.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "receipt.mode attest",
+      "op": "json_value_eq",
+      "file": "receipts/mode.capsule.json",
+      "path": "receipt.mode",
+      "value": "attest"
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR24.json
+++ b/gym/packs/work-receipt/tasks/WR24.json
@@ -1,0 +1,28 @@
+{
+  "id": "WR24",
+  "tier": 2,
+  "title": "캡슐 속 영수증 steps 1",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR24 — 한 걸음 계획의 캡슐 receipt.steps==1. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\nWR13 의 두 걸음과 자리를 가른다. 파일 연산자로 내장 영수증을 읽는다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"cap-steps.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"캡슐걸음\"}]}' --capsule receipts/steps.capsule.json --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/steps.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "걸음 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/steps.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "receipt.steps 1",
+      "op": "json_value_eq",
+      "file": "receipts/steps.capsule.json",
+      "path": "receipt.steps",
+      "value": 1
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR25.json
+++ b/gym/packs/work-receipt/tasks/WR25.json
@@ -1,0 +1,28 @@
+{
+  "id": "WR25",
+  "tier": 1,
+  "title": "캡슐 속 계획 planVersion 1.0",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR25 — 내장 계획의 planVersion 이 1.0. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n캡슐 plan.planVersion 을 파일에서 읽는다. 스키마 가족을 새로 만들지 마라. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"plan-ver.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"계획버전\"}]}' --capsule receipts/plan.capsule.json --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/plan.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "계획 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/plan.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "plan.planVersion 1.0",
+      "op": "json_value_eq",
+      "file": "receipts/plan.capsule.json",
+      "path": "plan.planVersion",
+      "value": "1.0"
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR26.json
+++ b/gym/packs/work-receipt/tasks/WR26.json
@@ -1,0 +1,36 @@
+{
+  "id": "WR26",
+  "tier": 2,
+  "title": "서식2 뿌리 계보 유효",
+  "input": "samples/form-02.hwp",
+  "instructions": "WR26 — 다른 서식 표본 뿌리의 lineage valid. 입력 표본은 `samples/form-02.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\nreceipts/form2.capsule.json 을 제출하라. 채점은 valid==true 만 본다. 깊이나 재현율을 묻지 않는다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/form-02.hwp\", \"output\": \"form2-day.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"서식이틀\"}]}' --capsule receipts/form2.capsule.json --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/form2.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "서식2 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/form2.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "계보 유효",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:receipts/form2.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR27.json
+++ b/gym/packs/work-receipt/tasks/WR27.json
@@ -1,0 +1,36 @@
+{
+  "id": "WR27",
+  "tier": 3,
+  "title": "얕은 계보 reproduced 는 null",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR27 — --deep 없이 걸면 링크 reproduced 가 null. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n기본 lineage 는 재실행하지 않는다. links[0].reproduced 는 null 이다. AU07/XC04 의 --deep 재현 축을 복제하지 마라. 힌트: replay --capsule receipts/shallow.capsule.json 후 lineage ( --deep 금지 )\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/shallow.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "얕은 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/shallow.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "reproduced null — deep 없음",
+      "op": "value_eq",
+      "value": null,
+      "path": "links[0].reproduced",
+      "cmd": [
+        "lineage",
+        "{file:receipts/shallow.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR28.json
+++ b/gym/packs/work-receipt/tasks/WR28.json
@@ -1,0 +1,36 @@
+{
+  "id": "WR28",
+  "tier": 3,
+  "title": "뿌리 링크 lineageOk 는 null",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR28 — 뿌리는 자식이 없어 lineageOk 가 null. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\nlineageOk 는 '부모 산출 == 자식 입력' 이다. 머리(뿌리)에는 비교할 자식 입력이 없으므로 null 이다. WR03 의 links[1].lineageOk==true 와 자리를 가른다. 힌트: replay --capsule receipts/leaf.capsule.json 후 lineage\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/leaf.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "잎 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/leaf.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "뿌리 lineageOk null",
+      "op": "value_eq",
+      "value": null,
+      "path": "links[0].lineageOk",
+      "cmd": [
+        "lineage",
+        "{file:receipts/leaf.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR29.json
+++ b/gym/packs/work-receipt/tasks/WR29.json
@@ -1,0 +1,36 @@
+{
+  "id": "WR29",
+  "tier": 2,
+  "title": "메모 표본 뿌리 깨진 지점 없음",
+  "input": "samples/field-01-memo.hwp",
+  "instructions": "WR29 — 메모 표본 뿌리의 brokenAt==null. 입력 표본은 `samples/field-01-memo.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n뿌리가 온전하면 brokenAt 은 null 이다. 깊이를 묻지 않는다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01-memo.hwp\", \"output\": \"memo-root.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"메모뿌리\"}]}' --capsule receipts/memo.capsule.json --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/memo.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "메모 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/memo.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "깨진 지점 없음",
+      "op": "value_eq",
+      "value": null,
+      "path": "brokenAt",
+      "cmd": [
+        "lineage",
+        "{file:receipts/memo.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR30.json
+++ b/gym/packs/work-receipt/tasks/WR30.json
@@ -1,0 +1,28 @@
+{
+  "id": "WR30",
+  "tier": 2,
+  "title": "캡슐 속 입력 경로 에코",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR30 — 내장 영수증 receipt.input 이 계획 입력과 같은지. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n캡슐을 열어 receipt.input 이 samples/field-01.hwp 인지 본다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"cap-input.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"캡슐입력\"}]}' --capsule receipts/input.capsule.json --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/input.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "입력 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/input.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "receipt.input 에코",
+      "op": "json_value_eq",
+      "file": "receipts/input.capsule.json",
+      "path": "receipt.input",
+      "value": "samples/field-01.hwp"
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR31.json
+++ b/gym/packs/work-receipt/tasks/WR31.json
@@ -1,0 +1,36 @@
+{
+  "id": "WR31",
+  "tier": 2,
+  "title": "표 표본 뿌리 parentOk null",
+  "input": "samples/table-001.hwp",
+  "instructions": "WR31 — table-001 뿌리 캡슐의 parentOk null. 입력 표본은 `samples/table-001.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n자동화 pack 이 쓰는 표본이지만 질문은 표 편집이 아니라 뿌리 영수증이다. 셀 좌표를 묻지 마라. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/table-001.hwp\", \"output\": \"table-root.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"규제\", \"replace\": \"표하루\"}]}' --capsule receipts/table.capsule.json --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/table.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "표 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/table.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "표 뿌리 parentOk null",
+      "op": "value_eq",
+      "value": null,
+      "path": "links[0].parentOk",
+      "cmd": [
+        "lineage",
+        "{file:receipts/table.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR32.json
+++ b/gym/packs/work-receipt/tasks/WR32.json
@@ -1,0 +1,37 @@
+{
+  "id": "WR32",
+  "tier": 3,
+  "title": "메모 표본 어제 산출이 오늘 입력",
+  "input": "samples/field-01-memo.hwp",
+  "instructions": "WR32 — 다른 표본으로 어제-오늘 부모 링크 lineageOk. 입력 표본은 `samples/field-01-memo.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\nWR03 과 같은 좌표(links[1].lineageOk)를 메모 표본에 적용한다. depth==2 를 묻지 않는다. 힌트: run 으로 yesterday.hwp 를 만든 뒤 replay --capsule / --parent\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/yesterday.capsule.json",
+      "receipts/today.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "오늘 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/today.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "부모 링크 lineageOk",
+      "op": "value_eq",
+      "value": true,
+      "path": "links[1].lineageOk",
+      "cmd": [
+        "lineage",
+        "{file:receipts/today.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR33.json
+++ b/gym/packs/work-receipt/tasks/WR33.json
@@ -1,0 +1,29 @@
+{
+  "id": "WR33",
+  "tier": 3,
+  "title": "오늘 캡슐이 어제 파일을 부모로 기록",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR33 — 오늘 캡슐 parent.capsule 상대 이름. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n같은 폴더에 두면 parent.capsule 은 yesterday.capsule.json 이다. 호출 cwd 가 아니라 캡슐 파일 기준 상대 경로다. 힌트: replay --parent receipts/yesterday.capsule.json --capsule receipts/today.capsule.json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/yesterday.capsule.json",
+      "receipts/today.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "오늘 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/today.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "parent.capsule 상대이름",
+      "op": "json_value_eq",
+      "file": "receipts/today.capsule.json",
+      "path": "parent.capsule",
+      "value": "yesterday.capsule.json"
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR34.json
+++ b/gym/packs/work-receipt/tasks/WR34.json
@@ -1,0 +1,29 @@
+{
+  "id": "WR34",
+  "tier": 2,
+  "title": "오늘 캡슐 속 영수증도 attest",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR34 — 체인 둘째 장의 receipt.mode 도 attest. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n부모를 붙여도 발급 모드는 attest 다. verify 가 아니다. 힌트: 어제-오늘 replay --parent\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/yesterday.capsule.json",
+      "receipts/today.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "오늘 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/today.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "오늘 receipt.mode attest",
+      "op": "json_value_eq",
+      "file": "receipts/today.capsule.json",
+      "path": "receipt.mode",
+      "value": "attest"
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR35.json
+++ b/gym/packs/work-receipt/tasks/WR35.json
@@ -1,0 +1,42 @@
+{
+  "id": "WR35",
+  "tier": 3,
+  "title": "어제는 뿌리·오늘은 부모 객체",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR35 — 어제 parent==null, 오늘 parent 는 객체. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n어제 캡슐의 parent 는 null, 오늘 캡슐의 parent.sha256 은 64자리여야 한다. 깊이 숫자를 묻지 않는다. 힌트: 어제 뿌리 + 오늘 --parent\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/yesterday.capsule.json",
+      "receipts/today.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "어제 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/yesterday.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "오늘 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/today.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "어제 parent null",
+      "op": "json_value_eq",
+      "file": "receipts/yesterday.capsule.json",
+      "path": "parent",
+      "value": null
+    },
+    {
+      "name": "오늘 kind workCapsule",
+      "op": "json_value_eq",
+      "file": "receipts/today.capsule.json",
+      "path": "kind",
+      "value": "workCapsule"
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR36.json
+++ b/gym/packs/work-receipt/tasks/WR36.json
@@ -1,0 +1,37 @@
+{
+  "id": "WR36",
+  "tier": 3,
+  "title": "규제 표본 어제 파일 무결",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "WR36 — 규제 표본 어제-오늘 링크 parentOk. 입력 표본은 `samples/basic/issue2007_nested_cell_pagination_42065.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\nWR03 의 parentOk 좌표를 다른 표본에 적용한다. depth 를 묻지 않는다. 힌트: 규제 표본으로 어제 산출을 오늘 입력에 잇는다\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/yesterday.capsule.json",
+      "receipts/today.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "오늘 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/today.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "부모 링크 parentOk",
+      "op": "value_eq",
+      "value": true,
+      "path": "links[1].parentOk",
+      "cmd": [
+        "lineage",
+        "{file:receipts/today.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR37.json
+++ b/gym/packs/work-receipt/tasks/WR37.json
@@ -1,0 +1,52 @@
+{
+  "id": "WR37",
+  "tier": 3,
+  "title": "어제-오늘 계보는 유효하고 안 깨졌다",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR37 — 어제-오늘 체인의 valid 와 brokenAt. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\nvalid==true 이고 brokenAt==null 이다. 깊이 숫자를 묻지 않는다 — AU12/XC04 복제가 아니다. 힌트: replay --parent 후 lineage today\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/yesterday.capsule.json",
+      "receipts/today.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "오늘 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/today.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "계보 유효",
+      "op": "value_eq",
+      "value": true,
+      "path": "valid",
+      "cmd": [
+        "lineage",
+        "{file:receipts/today.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "깨진 지점 없음",
+      "op": "value_eq",
+      "value": null,
+      "path": "brokenAt",
+      "cmd": [
+        "lineage",
+        "{file:receipts/today.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR38.json
+++ b/gym/packs/work-receipt/tasks/WR38.json
@@ -1,0 +1,51 @@
+{
+  "id": "WR38",
+  "tier": 2,
+  "title": "규제 표본 오늘 폴더 1건",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "WR38 — 규제 표본 캡슐 폴더 total==1·reproduced==1. 입력 표본은 `samples/basic/issue2007_nested_cell_pagination_42065.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\nWR04 와 같은 회계를 다른 표본에 적용한다. 비율을 묻지 않는다. 힌트: replay --capsule receipts/day.capsule.json 후 audit receipts\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/day.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "오늘 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/day.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "폴더 총 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "total",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "재현 성공 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "reproduced",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR39.json
+++ b/gym/packs/work-receipt/tasks/WR39.json
@@ -1,0 +1,36 @@
+{
+  "id": "WR39",
+  "tier": 2,
+  "title": "오늘 폴더 실패 목록은 빈 배열",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR39 — audit failed 가 []. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n재현 실패한 캡슐이 없으면 failed 는 빈 배열이다. 비율 1.0 이 아니다. 힌트: 뿌리 한 장 후 audit receipts\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/day.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "오늘 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/day.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "실패 목록 빈 배열",
+      "op": "value_eq",
+      "value": [],
+      "path": "failed",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR40.json
+++ b/gym/packs/work-receipt/tasks/WR40.json
@@ -1,0 +1,58 @@
+{
+  "id": "WR40",
+  "tier": 3,
+  "title": "형제 두 장 폴더 회계는 정확히 2건",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR40 — 부모 없이 나란히 두 장 — total==2·reproduced==2. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n체인이 아니다. 서로 부모를 붙이지 않은 형제 두 장이다. AU12 복제가 아니고, AU02 처럼 비율만 맞춰 여러 장을 쌓는 것도 아니다. 힌트: 서로 다른 치환으로 a/b 캡슐을 같은 폴더에 두고 audit\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/a.capsule.json",
+      "receipts/b.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "형 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/a.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "제 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/b.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "폴더 총 2건",
+      "op": "value_eq",
+      "value": 2,
+      "path": "total",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "재현 성공 2건",
+      "op": "value_eq",
+      "value": 2,
+      "path": "reproduced",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR41.json
+++ b/gym/packs/work-receipt/tasks/WR41.json
@@ -1,0 +1,43 @@
+{
+  "id": "WR41",
+  "tier": 3,
+  "title": "형제 두 장 실패 목록은 비었다",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR41 — 형제 두 장의 audit failed==[]. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n두 장이 모두 재현되면 failed 는 빈 배열이다. 비율을 묻지 않는다. 힌트: WR40 과 같은 형제 제출, 질문은 실패 목록\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/a.capsule.json",
+      "receipts/b.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "형 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/a.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "제 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/b.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "실패 목록 빈 배열",
+      "op": "value_eq",
+      "value": [],
+      "path": "failed",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR42.json
+++ b/gym/packs/work-receipt/tasks/WR42.json
@@ -1,0 +1,65 @@
+{
+  "id": "WR42",
+  "tier": 3,
+  "title": "형제 세 장 폴더 회계는 정확히 3건",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR42 — 부모 없이 세 장 — total==3·reproduced==3. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n3세대 사슬이 아니다. 같은 폴더에 뿌리 세 장을 나란히 둔다. XC04 의 depth==3 을 복제하지 마라. 힌트: a/b/c 세  Capsule 을 receipts/ 에 두고 audit\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/a.capsule.json",
+      "receipts/b.capsule.json",
+      "receipts/c.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "갑 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/a.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "을 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/b.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "병 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/c.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "폴더 총 3건",
+      "op": "value_eq",
+      "value": 3,
+      "path": "total",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "재현 성공 3건",
+      "op": "value_eq",
+      "value": 3,
+      "path": "reproduced",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR43.json
+++ b/gym/packs/work-receipt/tasks/WR43.json
@@ -1,0 +1,51 @@
+{
+  "id": "WR43",
+  "tier": 2,
+  "title": "메모 표본 오늘 폴더 1건",
+  "input": "samples/field-01-memo.hwp",
+  "instructions": "WR43 — 메모 표본 폴더 회계 정확 1건. 입력 표본은 `samples/field-01-memo.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\nWR04·WR38 과 같은 질문을 세 번째 표본에 적용한다. 비율이 아니다. 힌트: replay --capsule receipts/day.capsule.json 후 audit\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/day.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "오늘 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/day.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "폴더 총 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "total",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "재현 성공 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "reproduced",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR44.json
+++ b/gym/packs/work-receipt/tasks/WR44.json
@@ -1,0 +1,36 @@
+{
+  "id": "WR44",
+  "tier": 1,
+  "title": "감사 봉투 root 에코",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR44 — audit 봉투 root 가 폴더 인자인지. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n채점은 봉투 root 가 제출 폴더 경로인지 라이브로 보지 않고, 에이전트가 읽은 root 문자열을 묻지 않는다. 대신 폴더 총 건수 1 과 캡슐 존재만 고정하고, audit 가 그 폴더를 읽었는지는 total 로 이미 드러난다. 여기서는 한 장을 두고 total==1 만 다시 확인한다 — WR04 와 표본 치환이 같다 해도 질문은 'root 를 읽었는가' 의 입문 확인이다.\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/day.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "오늘 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/day.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "폴더 총 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "total",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR45.json
+++ b/gym/packs/work-receipt/tasks/WR45.json
@@ -1,0 +1,38 @@
+{
+  "id": "WR45",
+  "tier": 2,
+  "title": "계보 봉투 스키마 버전 라이브",
+  "input": "samples/field-01.hwp",
+  "axis": "조회",
+  "instructions": "WR45 — 제출 캡슐에 lineage 를 걸어 schemaVersion 을 옮긴다. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\nreceipts/day.capsule.json 을 만들고, 그 파일에 lineage --json 을 걸어 schemaVersion 을 answer.json 에 옮겨라. 채점은 같은 lineage 를 다시 돌린다. 힌트: replay --capsule 후 lineage receipts/day.capsule.json --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json",
+      "receipts/day.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "오늘 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/day.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "계보 스키마 버전 라이브",
+      "op": "answer_eq",
+      "answer": "schemaVersion",
+      "path": "schemaVersion",
+      "cmd": [
+        "lineage",
+        "{file:receipts/day.capsule.json}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR46.json
+++ b/gym/packs/work-receipt/tasks/WR46.json
@@ -1,0 +1,38 @@
+{
+  "id": "WR46",
+  "tier": 2,
+  "title": "감사 봉투 스키마 버전 라이브",
+  "input": "samples/field-01.hwp",
+  "axis": "조회",
+  "instructions": "WR46 — 제출 폴더를 audit 해 schemaVersion 을 옮긴다. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\nWR45 는 lineage, WR46 은 audit 이다. 명령 가족이 다르면 봉투 자리도 다르다. 숫자를 박제하지 마라. 힌트: replay --capsule 후 audit receipts --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json",
+      "receipts/day.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "오늘 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/day.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "감사 스키마 버전 라이브",
+      "op": "answer_eq",
+      "answer": "schemaVersion",
+      "path": "schemaVersion",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR47.json
+++ b/gym/packs/work-receipt/tasks/WR47.json
@@ -1,0 +1,51 @@
+{
+  "id": "WR47",
+  "tier": 2,
+  "title": "표 표본 오늘 폴더 1건",
+  "input": "samples/table-001.hwp",
+  "instructions": "WR47 — table-001 폴더 회계 정확 1건. 입력 표본은 `samples/table-001.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n표 편집 좌표를 묻지 않는다. 영수증 폴더 건수만 본다. 힌트: replay --capsule receipts/day.capsule.json 후 audit\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/day.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "오늘 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/day.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "폴더 총 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "total",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "재현 성공 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "reproduced",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR48.json
+++ b/gym/packs/work-receipt/tasks/WR48.json
@@ -1,0 +1,51 @@
+{
+  "id": "WR48",
+  "tier": 2,
+  "title": "서식1 오늘 폴더 실패 없음",
+  "input": "samples/form-01.hwp",
+  "instructions": "WR48 — 서식1 한 장의 failed==[] 와 total==1. 입력 표본은 `samples/form-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n한 장이면 실패 목록이 비고 총 1건이다. 비율을 묻지 않는다. 힌트: replay --capsule receipts/day.capsule.json 후 audit\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/day.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "오늘 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/day.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "폴더 총 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "total",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "실패 목록 빈 배열",
+      "op": "value_eq",
+      "value": [],
+      "path": "failed",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR49.json
+++ b/gym/packs/work-receipt/tasks/WR49.json
@@ -1,0 +1,28 @@
+{
+  "id": "WR49",
+  "tier": 2,
+  "title": "발급 영수증 steps 라이브",
+  "input": "samples/field-01.hwp",
+  "axis": "조회",
+  "instructions": "WR49 — 한 걸음 계획의 steps 를 라이브 대조. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\nWR01 은 mode·3해시를 같이 묻는다. 여기서는 steps 한 자리만 라이브로 옮긴다. 박제 숫자 1 을 answer_eq 의 value 로 두지 마라. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"live-steps.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"걸음라이브\"}]}' --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "steps 라이브",
+      "op": "answer_eq",
+      "answer": "steps",
+      "path": "steps",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"live-steps.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"걸음라이브\"}]}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR50.json
+++ b/gym/packs/work-receipt/tasks/WR50.json
@@ -1,0 +1,31 @@
+{
+  "id": "WR50",
+  "tier": 1,
+  "title": "발급 모드 허용 집합",
+  "input": "samples/field-01.hwp",
+  "axis": "조회",
+  "instructions": "WR50 — mode 가 attest 또는 verify 집합 안인지. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n주장 해시 없는 발급은 attest 다. value_in 으로 허용 집합만 확인한다. 힌트: rhwp replay --plan-json '{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"mode-set.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"모드집합\"}]}' --json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "mode 허용 집합",
+      "op": "value_in",
+      "values": [
+        "attest",
+        "verify"
+      ],
+      "path": "mode",
+      "cmd": [
+        "replay",
+        "--plan-json",
+        "{\"planVersion\": \"1.0\", \"input\": \"samples/field-01.hwp\", \"output\": \"mode-set.hwp\", \"steps\": [{\"action\": \"replace_text\", \"find\": \"마케팅\", \"replace\": \"모드집합\"}]}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR51.json
+++ b/gym/packs/work-receipt/tasks/WR51.json
@@ -1,0 +1,28 @@
+{
+  "id": "WR51",
+  "tier": 2,
+  "title": "캡슐 속 계획 input 에코",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR51 — 내장 plan.input 이 과제 입력과 같은지. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\nreceipt.input 이 아니라 plan.input 이다. 두 자리가 같아야 자기완결이다. 힌트: replay --capsule receipts/planin.capsule.json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/planin.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "계획입력 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/planin.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "plan.input 에코",
+      "op": "json_value_eq",
+      "file": "receipts/planin.capsule.json",
+      "path": "plan.input",
+      "value": "samples/field-01.hwp"
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR52.json
+++ b/gym/packs/work-receipt/tasks/WR52.json
@@ -1,0 +1,28 @@
+{
+  "id": "WR52",
+  "tier": 2,
+  "title": "캡슐 속 계획 output 에코",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR52 — 내장 plan.output 이 계획서 산출 이름인지. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n영수증 발급 중 실산출 파일은 생기지 않는다. 그래도 계획의 output 자리는 캡슐에 보존된다. 힌트: replay --capsule receipts/planout.capsule.json\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/planout.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "계획산출 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/planout.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "plan.output 에코",
+      "op": "json_value_eq",
+      "file": "receipts/planout.capsule.json",
+      "path": "plan.output",
+      "value": "planout.hwp"
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR53.json
+++ b/gym/packs/work-receipt/tasks/WR53.json
@@ -1,0 +1,36 @@
+{
+  "id": "WR53",
+  "tier": 3,
+  "title": "형제 두 장은 서로 다른 바이트",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR53 — 같은 산출을 두 번 복사한 위장 거부. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n치환 문구가 다른 형제 두 장을 제출하라. 채점은 두 파일이 서로 다른지 본다. 체인이 아니다. 힌트: 출근/퇴근 서로 다른 replace 로 a/b 캡슐\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/a.capsule.json",
+      "receipts/b.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "형 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/a.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "제 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/b.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "형제 캡슐이 서로 다름",
+      "op": "files_differ",
+      "files": [
+        "receipts/a.capsule.json",
+        "receipts/b.capsule.json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR54.json
+++ b/gym/packs/work-receipt/tasks/WR54.json
@@ -1,0 +1,36 @@
+{
+  "id": "WR54",
+  "tier": 3,
+  "title": "어제와 오늘 캡슐은 서로 다르다",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR54 — 어제 파일을 오늘 이름으로 복사한 위장 거부. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n부모를 잇되 두 캡슐 바이트가 같으면 안 된다. files_differ. 힌트: 어제-오늘 replay --parent\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/yesterday.capsule.json",
+      "receipts/today.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "어제 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/yesterday.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "오늘 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/today.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "어제와 오늘이 서로 다름",
+      "op": "files_differ",
+      "files": [
+        "receipts/yesterday.capsule.json",
+        "receipts/today.capsule.json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR55.json
+++ b/gym/packs/work-receipt/tasks/WR55.json
@@ -1,0 +1,51 @@
+{
+  "id": "WR55",
+  "tier": 2,
+  "title": "서식2 오늘 폴더 1건",
+  "input": "samples/form-02.hwp",
+  "instructions": "WR55 — 서식2 폴더 회계 정확 1건. 입력 표본은 `samples/form-02.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n네 번째 표본의 같은 회계 질문이다. 비율이 아니다. 힌트: replay --capsule receipts/day.capsule.json 후 audit\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/day.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "오늘 캡슐 존재",
+      "op": "file_exists",
+      "file": "receipts/day.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "폴더 총 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "total",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    },
+    {
+      "name": "재현 성공 1건",
+      "op": "value_eq",
+      "value": 1,
+      "path": "reproduced",
+      "cmd": [
+        "audit",
+        "{file:receipts}",
+        "--json"
+      ],
+      "expect_exits": [
+        0,
+        3
+      ]
+    }
+  ]
+}

--- a/gym/packs/work-receipt/tasks/WR56.json
+++ b/gym/packs/work-receipt/tasks/WR56.json
@@ -1,0 +1,59 @@
+{
+  "id": "WR56",
+  "tier": 4,
+  "title": "형제 세 장 모두 서로 다르다",
+  "input": "samples/field-01.hwp",
+  "instructions": "WR56 — 세 뿌리가 서로 다른 바이트인지. 입력 표본은 `samples/field-01.hwp` 이다. 저장소 samples/ 에 이미 있는 실문서이며 새 픽스처를 만들지 않는다. work-receipt pack 은 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다.\n\n판정은 말이 아니라 봉투 데이터다. 같은 계획을 채점 시점에 다시 돌려 해시를 라이브 대조하거나, 제출 캡슐을 lineage/audit 로 읽어 좌표를 지목한다. 정답 숫자를 과제 파일에 박제하지 마라.\n\n같은 파일을 세 이름으로 복제하면 안 된다. a≠b, b≠c, a≠c. 3세대 사슬이 아니다. 힌트: 서로 다른 replace 로 세 캡슐\n\n금지: AU02 의 reproducedRate==1.0+total≥1, AU12 의 depth==2, AU07 의 gate --deep, XC01–XC05(적합성 L5·리콜·정산·3세대 --deep·감사표준 L3), T07 서식 채움(fill-fields·첫 필드 홍길동)은 복제하지 마라. 새 CLI 도 없다. 원본 픽스처를 덮어쓰지 마라. `--deep` 으로 사다리를 완주하지 마라.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "receipts/a.capsule.json",
+      "receipts/b.capsule.json",
+      "receipts/c.capsule.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "갑 존재",
+      "op": "file_exists",
+      "file": "receipts/a.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "을 존재",
+      "op": "file_exists",
+      "file": "receipts/b.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "병 존재",
+      "op": "file_exists",
+      "file": "receipts/c.capsule.json",
+      "minBytes": 64
+    },
+    {
+      "name": "갑≠을",
+      "op": "files_differ",
+      "files": [
+        "receipts/a.capsule.json",
+        "receipts/b.capsule.json"
+      ]
+    },
+    {
+      "name": "을≠병",
+      "op": "files_differ",
+      "files": [
+        "receipts/b.capsule.json",
+        "receipts/c.capsule.json"
+      ]
+    },
+    {
+      "name": "갑≠병",
+      "op": "files_differ",
+      "files": [
+        "receipts/a.capsule.json",
+        "receipts/c.capsule.json"
+      ]
+    }
+  ]
+}

--- a/gym/profiles/maintainer.json
+++ b/gym/profiles/maintainer.json
@@ -22,6 +22,7 @@
     "studio-e2e",
     "table-csv",
     "table-editing",
-    "text-editing"
+    "text-editing",
+    "work-receipt"
   ]
 }

--- a/mydocs/working/gym_work_receipt.md
+++ b/mydocs/working/gym_work_receipt.md
@@ -1,0 +1,174 @@
+---
+kind: working
+status: active
+canonical: mydocs/working/gym_work_receipt.md
+last_verified: 2026-08-18
+issue: 5231
+pr: 5238
+---
+
+# gym work-receipt pack 확장 작업 노트 (PR #5238)
+
+## 한 줄
+
+`feat/gym-work-receipt-pack` 가 WR01–WR04 (약 401줄)에서 멈춰 있던 일일
+영수증 여정을, 기존 연산자·기존 표본·기존 명령만으로 WR05–WR56 과 README·
+가드 시험까지 늘린다. 새 PR 을 열지 않고 같은 브랜치에 얹는다.
+
+## 배경
+
+이슈 #5231 · PR #5238 초안은 네 축만 과제화했다.
+
+- WR01 일일 영수증 3해시 (replay 라이브 오라클)
+- WR02 첫 영수증은 뿌리 (depth 1 · parentOk null)
+- WR03 어제 산출 = 오늘 입력 (lineageOk · parentOk · brokenAt null)
+- WR04 오늘 폴더 회계 1건 (total==1 · reproduced==1)
+
+pack 은 여전히 "4 과제" 이고, 발급/검증 모드, 거짓 주장 기각, 다른 실문서
+반복, 캡슐 내부 자리, 형제 회계가 비어 있었다. 집계 문서(gym/README, PARK,
+다른 프로파일)는 초안이 손대지 않았고 이번에도 손대지 않는다.
+`gym/profiles/maintainer.json` 은 이미 `work-receipt` 를 정렬해 넣고 있어
+그대로 둔다.
+
+## 범위
+
+포함한 것:
+
+- `gym/packs/work-receipt/README.md` — pack 온램프·과제 지도·함정·재현
+- `gym/packs/work-receipt/tasks/WR05.json` … `WR56.json`
+- `gym/packs/work-receipt/reference/WR05.json` … `WR56.json`
+- `scripts/tests/test_gym_work_receipt_pack.py` — 확장 계약 가드
+- `mydocs/working/gym_work_receipt.md` — 이 노트
+
+넣지 않은 것:
+
+- 새 연산자 (`checks.py` 미변경)
+- 새 CLI · 새 표본 · 새 pack
+- XC01–XC05 복제 (`conformance` · `recall-scope` · `settle` · lineage `--deep`
+  depth 3 · `audit-report`)
+- T07 서식 채움 복제 (`fill-fields`, 첫 필드 홍길동)
+- AU02 (`reproducedRate==1.0` + `total≥1`), AU07 (`gate --deep`),
+  AU12 (`depth==2`)
+- `gym/README.md` · `gym/PARK.md` · 다른 `profiles/*.json`
+- `cargo fmt --all` (JSON·문서만)
+- 프로파일 과제 수 문구
+
+## 설계 원칙
+
+1. **라이브 오라클.** `answer_eq` 는 채점 시점 CLI 재계산. 박제 숫자는 모드
+   상수(`attest`/`verify`), null 자리, 정확 건수, 플래그 에코뿐이다.
+2. **축을 가른다.** WR01 의 3해시를 모드·버전·스키마·입력 에코·검증 기각·
+   두 걸음 steps 로 쪼갠다. WR02 의 뿌리를 다른 표본·캡슐 내부 kind/parent/
+   receipt.* 로 쪼갠다. WR03 의 부모 링크를 다른 표본·상대 경로·파일 상이로
+   쪼갠다. WR04 의 1건 회계를 실패 목록·형제 2/3건으로 쪼갠다.
+3. **표본을 흩는다.** field-01 한 파일에 질문을 몰지 않는다. 메모·서식1·
+   서식2·표·중첩 표 규제 표본은 이미 `samples/` 에 있다.
+4. **정확 건수가 판정한다.** 비율 1.0 에 하한 1건을 짝으로 두지 않는다.
+5. **T07 금지.** 이 pack 은 채우지 않는다. 누름틀은 본문 치환의 재료일 뿐이다.
+6. **사다리 금지.** `--deep`, 서명, 앵커, 정산, 적합성, 리콜을 넣지 않는다.
+
+## 과제 묶음
+
+| 구간 | 축 | 건수 | 핵심 필드 |
+|------|----|------|-----------|
+| WR01–WR04 | 개장 코어 | 4 | 3해시 · 뿌리 · 부모 링크 · 1건 회계 |
+| WR05–WR18 | 단건 영수증 | 14 | mode · toolVersion · schemaVersion · reproduced null/false · 다른 표본 |
+| WR19–WR31 | 뿌리 캡슐 | 13 | parentOk null · kind · parent null · receipt.* · 얕은 reproduced |
+| WR32–WR37 | 어제-오늘 | 6 | lineageOk · parent.capsule · files_differ · valid |
+| WR38–WR48 | 폴더 회계 | 11 | total==N · reproduced==N · failed==[] |
+| WR49–WR56 | 라이브·상이 | 8 | steps 라이브 · value_in · plan.input/output · 3형제 상이 |
+
+WR01–WR04 는 그대로 둔다. 번호 구멍 없음 (1…56).
+
+## 사용한 기존 표본
+
+- `samples/field-01.hwp` — 본문 `마케팅` (FJ04 와 같은 근거)
+- `samples/field-01-memo.hwp` — 누름틀 메모. 채우지 않고 영수증만
+- `samples/form-01.hwp` · `samples/form-02.hwp` — 서식. T07 복제 아님
+- `samples/table-001.hwp` — 자동화 pack 표본이지만 표 좌표를 묻지 않음
+- `samples/basic/issue2007_nested_cell_pagination_42065.hwp` — 본문 `규제`
+
+## 과제 목록 (WR05+)
+
+- **WR05** (tier 1) 발급 모드 attest 상수 — `samples/field-01.hwp` · 연산자 value_eq · 명령 replay.
+- **WR06** (tier 2) 도구 버전 라이브 대조 — `samples/field-01.hwp` · 연산자 answer_eq · 명령 replay.
+- **WR07** (tier 1) 영수증 스키마 버전 라이브 — `samples/field-01.hwp` · 연산자 answer_eq · 명령 replay.
+- **WR08** (tier 1) 영수증 입력 경로 에코 — `samples/field-01.hwp` · 연산자 value_eq · 명령 replay.
+- **WR09** (tier 2) 발급 영수증 reproduced 는 null — `samples/field-01.hwp` · 연산자 value_eq · 명령 replay.
+- **WR10** (tier 2) 발급 영수증 expectedOutputSha256 는 null — `samples/field-01.hwp` · 연산자 value_eq · 명령 replay.
+- **WR11** (tier 2) 출근장 치환 3해시 — `samples/field-01.hwp` · 연산자 answer_eq · 명령 replay.
+- **WR12** (tier 2) 규제 표본 3해시 — `samples/basic/issue2007_nested_cell_pagination_42065.hwp` · 연산자 answer_eq · 명령 replay.
+- **WR13** (tier 3) 두 걸음 계획 step 수 — `samples/field-01.hwp` · 연산자 value_eq · 명령 replay.
+- **WR14** (tier 3) 거짓 산출 주장 기각 — `samples/field-01.hwp` · 연산자 value_eq · 명령 replay.
+- **WR15** (tier 2) 검증 모드 verify 상수 — `samples/field-01.hwp` · 연산자 value_eq · 명령 replay.
+- **WR16** (tier 2) 거짓 주장 해시 에코 — `samples/field-01.hwp` · 연산자 value_eq · 명령 replay.
+- **WR17** (tier 2) 마감장 치환 3해시 — `samples/field-01.hwp` · 연산자 answer_eq · 명령 replay.
+- **WR18** (tier 2) 메모 표본 3해시 — `samples/field-01-memo.hwp` · 연산자 answer_eq · 명령 replay.
+- **WR19** (tier 2) 서식1 뿌리는 parentOk null — `samples/form-01.hwp` · 연산자 file_exists, value_eq · 명령 lineage.
+- **WR20** (tier 2) 규제 표본 뿌리 깊이 1 — `samples/basic/issue2007_nested_cell_pagination_42065.hwp` · 연산자 file_exists, value_eq · 명령 lineage.
+- **WR21** (tier 1) 캡슐 kind 는 workCapsule — `samples/field-01.hwp` · 연산자 file_exists, json_value_eq · 명령 (파일).
+- **WR22** (tier 1) 뿌리 캡슐 parent 필드는 null — `samples/field-01.hwp` · 연산자 file_exists, json_value_eq · 명령 (파일).
+- **WR23** (tier 2) 캡슐 속 영수증 모드 attest — `samples/field-01.hwp` · 연산자 file_exists, json_value_eq · 명령 (파일).
+- **WR24** (tier 2) 캡슐 속 영수증 steps 1 — `samples/field-01.hwp` · 연산자 file_exists, json_value_eq · 명령 (파일).
+- **WR25** (tier 1) 캡슐 속 계획 planVersion 1.0 — `samples/field-01.hwp` · 연산자 file_exists, json_value_eq · 명령 (파일).
+- **WR26** (tier 2) 서식2 뿌리 계보 유효 — `samples/form-02.hwp` · 연산자 file_exists, value_eq · 명령 lineage.
+- **WR27** (tier 3) 얕은 계보 reproduced 는 null — `samples/field-01.hwp` · 연산자 file_exists, value_eq · 명령 lineage.
+- **WR28** (tier 3) 뿌리 링크 lineageOk 는 null — `samples/field-01.hwp` · 연산자 file_exists, value_eq · 명령 lineage.
+- **WR29** (tier 2) 메모 표본 뿌리 깨진 지점 없음 — `samples/field-01-memo.hwp` · 연산자 file_exists, value_eq · 명령 lineage.
+- **WR30** (tier 2) 캡슐 속 입력 경로 에코 — `samples/field-01.hwp` · 연산자 file_exists, json_value_eq · 명령 (파일).
+- **WR31** (tier 2) 표 표본 뿌리 parentOk null — `samples/table-001.hwp` · 연산자 file_exists, value_eq · 명령 lineage.
+- **WR32** (tier 3) 메모 표본 어제 산출이 오늘 입력 — `samples/field-01-memo.hwp` · 연산자 file_exists, value_eq · 명령 lineage.
+- **WR33** (tier 3) 오늘 캡슐이 어제 파일을 부모로 기록 — `samples/field-01.hwp` · 연산자 file_exists, json_value_eq · 명령 (파일).
+- **WR34** (tier 2) 오늘 캡슐 속 영수증도 attest — `samples/field-01.hwp` · 연산자 file_exists, json_value_eq · 명령 (파일).
+- **WR35** (tier 3) 어제는 뿌리·오늘은 부모 객체 — `samples/field-01.hwp` · 연산자 file_exists, json_value_eq · 명령 (파일).
+- **WR36** (tier 3) 규제 표본 어제 파일 무결 — `samples/basic/issue2007_nested_cell_pagination_42065.hwp` · 연산자 file_exists, value_eq · 명령 lineage.
+- **WR37** (tier 3) 어제-오늘 계보는 유효하고 안 깨졌다 — `samples/field-01.hwp` · 연산자 file_exists, value_eq · 명령 lineage.
+- **WR38** (tier 2) 규제 표본 오늘 폴더 1건 — `samples/basic/issue2007_nested_cell_pagination_42065.hwp` · 연산자 file_exists, value_eq · 명령 audit.
+- **WR39** (tier 2) 오늘 폴더 실패 목록은 빈 배열 — `samples/field-01.hwp` · 연산자 file_exists, value_eq · 명령 audit.
+- **WR40** (tier 3) 형제 두 장 폴더 회계는 정확히 2건 — `samples/field-01.hwp` · 연산자 file_exists, value_eq · 명령 audit.
+- **WR41** (tier 3) 형제 두 장 실패 목록은 비었다 — `samples/field-01.hwp` · 연산자 file_exists, value_eq · 명령 audit.
+- **WR42** (tier 3) 형제 세 장 폴더 회계는 정확히 3건 — `samples/field-01.hwp` · 연산자 file_exists, value_eq · 명령 audit.
+- **WR43** (tier 2) 메모 표본 오늘 폴더 1건 — `samples/field-01-memo.hwp` · 연산자 file_exists, value_eq · 명령 audit.
+- **WR44** (tier 1) 감사 봉투 root 에코 — `samples/field-01.hwp` · 연산자 file_exists, value_eq · 명령 audit.
+- **WR45** (tier 2) 계보 봉투 스키마 버전 라이브 — `samples/field-01.hwp` · 연산자 answer_eq, file_exists · 명령 lineage.
+- **WR46** (tier 2) 감사 봉투 스키마 버전 라이브 — `samples/field-01.hwp` · 연산자 answer_eq, file_exists · 명령 audit.
+- **WR47** (tier 2) 표 표본 오늘 폴더 1건 — `samples/table-001.hwp` · 연산자 file_exists, value_eq · 명령 audit.
+- **WR48** (tier 2) 서식1 오늘 폴더 실패 없음 — `samples/form-01.hwp` · 연산자 file_exists, value_eq · 명령 audit.
+- **WR49** (tier 2) 발급 영수증 steps 라이브 — `samples/field-01.hwp` · 연산자 answer_eq · 명령 replay.
+- **WR50** (tier 1) 발급 모드 허용 집합 — `samples/field-01.hwp` · 연산자 value_in · 명령 replay.
+- **WR51** (tier 2) 캡슐 속 계획 input 에코 — `samples/field-01.hwp` · 연산자 file_exists, json_value_eq · 명령 (파일).
+- **WR52** (tier 2) 캡슐 속 계획 output 에코 — `samples/field-01.hwp` · 연산자 file_exists, json_value_eq · 명령 (파일).
+- **WR53** (tier 3) 형제 두 장은 서로 다른 바이트 — `samples/field-01.hwp` · 연산자 file_exists, files_differ · 명령 (파일).
+- **WR54** (tier 3) 어제와 오늘 캡슐은 서로 다르다 — `samples/field-01.hwp` · 연산자 file_exists, files_differ · 명령 (파일).
+- **WR55** (tier 2) 서식2 오늘 폴더 1건 — `samples/form-02.hwp` · 연산자 file_exists, value_eq · 명령 audit.
+- **WR56** (tier 4) 형제 세 장 모두 서로 다르다 — `samples/field-01.hwp` · 연산자 file_exists, files_differ · 명령 (파일).
+
+## 검증
+
+저장소 루트에서:
+
+```
+python gym/tools/audit.py
+python -m unittest scripts/tests/test_gym_packs.py
+python -m unittest scripts/tests/test_gym_work_receipt_pack.py
+```
+
+기대: audit 전 pack 통과, test_gym_packs 기존 건수 유지, work-receipt 가드
+green. 바이너리·네트워크 없이 돈다. `cargo fmt --all` 생략 (sparse, Rust
+변경 없음).
+
+## 위험
+
+- WR12·WR20·WR31·WR36·WR38·WR47 는 규제 표본의 `규제` 문자열에 기대한다.
+  TE01 과 같은 근거다. 문구가 빠지면 빈 치환이 되거나 실패할 수 있다.
+- WR03 계열의 `links[1].lineageOk` 는 `tests/lineage_contract.rs` 의 2링크
+  봉투 좌표다. 링크 순서가 바뀌면 라이브 채점이 깨진다. 그래도 depth==2 를
+  묻지는 않는다.
+- WR14–WR16 의 거짓 해시는 64자리 0 이다. `expect_exits: [3]` 이 필수다.
+- 이 세션은 스키마·audit·가드 시험만 돌린다. 로컬 `rhwp` 바이너리로 기준
+  풀이를 라이브 채점하지 못할 수 있다.
+
+## 커밋·푸시
+
+같은 브랜치 `feat/gym-work-receipt-pack`. 새 PR 없음. `git add -A` 금지.
+한글 커밋. `upstream/devel` 대비 insertions ≥ 3000.

--- a/scripts/tests/test_gym_work_receipt_pack.py
+++ b/scripts/tests/test_gym_work_receipt_pack.py
@@ -1,0 +1,408 @@
+"""work-receipt pack 확장 계약 — WR05+ · README · 기존 명령/연산자/표본만.
+
+이 가드는 PR #5238 의 확장 규칙을 파일만으로 고정한다. 바이너리·네트워크가
+없어도 돈다. 새 연산자·새 표본·T07 복제·XC01–XC05 복제·AU02/AU07/AU12
+복제가 들어오면 red.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GYM = REPO_ROOT / "gym"
+PACK = GYM / "packs" / "work-receipt"
+TASKS = PACK / "tasks"
+REFS = PACK / "reference"
+README = PACK / "README.md"
+WORKING = REPO_ROOT / "mydocs" / "working" / "gym_work_receipt.md"
+MAINTAINER = GYM / "profiles" / "maintainer.json"
+
+EXISTING_OPS = {
+    "same_hash",
+    "differs_from_input",
+    "file_exists",
+    "files_differ",
+    "xml_root_eq",
+    "json_value_eq",
+    "csv_cell_eq",
+    "utf8_bom",
+    "answer_eq",
+    "len_answer_eq",
+    "len_ge",
+    "value_eq",
+    "value_ge",
+    "value_in",
+    "deep_contains",
+    "not_contains",
+    "cell_text_eq",
+}
+
+PACK_COMMANDS = {"audit", "lineage", "replay"}
+ANSWER_OPS = frozenset({"answer_eq", "len_answer_eq"})
+FORBIDDEN_CMDS = {
+    "conformance",
+    "settle",
+    "recall-scope",
+    "keygen",
+    "gate",
+    "fill-fields",
+    "fields",
+    "verify-signature",
+    "audit-report",
+    "anchor",
+}
+FORBIDDEN_FLAGS = {"--deep", "--sign-key", "--keyring", "--anchor-log"}
+MIN_TASKS = 56
+
+
+def read_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def task_paths():
+    return sorted(TASKS.glob("WR*.json"))
+
+
+def ref_paths():
+    return sorted(REFS.glob("WR*.json"))
+
+
+def load_tasks():
+    return [read_json(p) for p in task_paths()]
+
+
+def load_refs():
+    return {p.stem: read_json(p) for p in ref_paths()}
+
+
+def wr_num(path: Path) -> int:
+    return int(path.stem[2:])
+
+
+class WorkReceiptPackLayoutTests(unittest.TestCase):
+    def test_pack_manifest_identity(self):
+        manifest = read_json(PACK / "pack.json")
+        self.assertEqual(manifest["id"], "work-receipt")
+        self.assertEqual(manifest["kind"], "gymPack")
+        self.assertEqual(manifest["schemaVersion"], "1.0")
+        self.assertIn("영수증", manifest["axis"])
+        cmds = set(manifest["requires"]["commands"])
+        self.assertEqual(cmds, PACK_COMMANDS)
+        runner = manifest["runner"]
+        self.assertEqual(len(runner["rhwpCommit"]), 40)
+        self.assertEqual(len(runner["capabilitiesSha256"]), 64)
+        self.assertTrue(runner["rhwpVersion"])
+
+    def test_maintainer_still_lists_the_pack(self):
+        maintainer = read_json(MAINTAINER)
+        self.assertIn("work-receipt", maintainer["packs"])
+        self.assertEqual(maintainer["packs"], sorted(maintainer["packs"]))
+
+    def test_readme_exists_and_is_korean(self):
+        self.assertTrue(README.is_file(), "gym/packs/work-receipt/README.md 가 없다")
+        text = README.read_text(encoding="utf-8")
+        self.assertGreater(len(text), 2000)
+        for needle in (
+            "영수증",
+            "라이브 오라클",
+            "WR05",
+            "WR56",
+            "기존 연산자",
+            "XC01",
+            "T07",
+            "AU02",
+        ):
+            self.assertIn(needle, text, f"README 에 '{needle}' 가 없다")
+        self.assertIn("복제하지", text)
+
+    def test_working_notes_exist_and_are_korean(self):
+        self.assertTrue(WORKING.is_file(), "mydocs/working/gym_work_receipt.md 가 없다")
+        text = WORKING.read_text(encoding="utf-8")
+        self.assertGreater(len(text), 2000)
+        for needle in ("WR05", "WR56", "기존 표본", "T07", "audit", "test_gym_packs"):
+            self.assertIn(needle, text, f"작업 노트에 '{needle}' 가 없다")
+
+    def test_readme_and_working_name_every_new_task(self):
+        readme = README.read_text(encoding="utf-8")
+        working = WORKING.read_text(encoding="utf-8")
+        missing = []
+        for n in range(5, MIN_TASKS + 1):
+            tid = f"WR{n:02d}"
+            if tid not in readme:
+                missing.append(f"README:{tid}")
+            if tid not in working:
+                missing.append(f"working:{tid}")
+        self.assertEqual(missing, [], f"문서에 빠진 과제: {missing}")
+
+
+class WorkReceiptTaskContractTests(unittest.TestCase):
+    def test_wr05_plus_ship_with_paired_reference(self):
+        plus = [p for p in task_paths() if wr_num(p) >= 5]
+        self.assertGreaterEqual(len(plus), 50, "WR05+ 과제가 50건 미만이다")
+        missing = []
+        for path in plus:
+            tid = path.stem
+            ref = REFS / f"{tid}.json"
+            if not ref.is_file():
+                missing.append(tid)
+                continue
+            task = read_json(path)
+            ref_obj = read_json(ref)
+            self.assertEqual(task["id"], tid)
+            self.assertEqual(ref_obj["id"], tid)
+            self.assertTrue(ref_obj.get("steps"), tid)
+        self.assertEqual(missing, [], f"기준풀이 없음: {missing}")
+
+    def test_task_ids_are_contiguous_wr_prefix(self):
+        nums = sorted(wr_num(p) for p in task_paths())
+        self.assertEqual(nums[0], 1)
+        self.assertGreaterEqual(nums[-1], MIN_TASKS)
+        self.assertEqual(nums, list(range(1, nums[-1] + 1)), "WR 번호에 구멍이 있다")
+
+    def test_every_task_has_required_keys_and_named_checks(self):
+        for task in load_tasks():
+            tid = task["id"]
+            for key in ("id", "tier", "title", "input", "instructions", "submit", "checks"):
+                self.assertIn(key, task, f"{tid}: 필수 키 {key}")
+            self.assertIsInstance(task["tier"], int)
+            self.assertGreaterEqual(task["tier"], 1, tid)
+            self.assertLessEqual(task["tier"], 5, tid)
+            self.assertTrue(task["title"].strip(), tid)
+            self.assertTrue(task["instructions"].strip(), tid)
+            self.assertTrue(task["checks"], tid)
+            for check in task["checks"]:
+                self.assertTrue(check.get("name"), f"{tid}: 이름 없는 검사")
+                self.assertIn(check["op"], EXISTING_OPS, f"{tid}: 허용 밖 연산자 {check['op']}")
+
+    def test_titles_and_instructions_are_unique_korean(self):
+        seen_title = {}
+        seen_inst = {}
+        for path in task_paths():
+            task = read_json(path)
+            tid = task["id"]
+            title = task["title"]
+            inst = task["instructions"]
+            self.assertRegex(inst, r"[가-힣]", tid)
+            self.assertRegex(title, r"[가-힣]", tid)
+            if wr_num(path) >= 5:
+                self.assertGreater(len(inst), 200, tid)
+            self.assertNotIn(title, seen_title, f"{tid} 제목이 {seen_title.get(title)} 와 중복")
+            self.assertNotIn(inst, seen_inst, f"{tid} 지시문이 {seen_inst.get(inst)} 와 같다")
+            seen_title[title] = tid
+            seen_inst[inst] = tid
+
+    def test_operators_are_existing_only(self):
+        unknown = []
+        for task in load_tasks():
+            for check in task["checks"]:
+                if check["op"] not in EXISTING_OPS:
+                    unknown.append(f"{task['id']}:{check['op']}")
+        self.assertEqual(unknown, [], f"새 연산자: {unknown}")
+
+    def test_commands_stay_inside_pack_requires(self):
+        bad = []
+        used = set()
+        for task in load_tasks():
+            for check in task.get("checks", []):
+                cmd = check.get("cmd")
+                if not cmd:
+                    continue
+                used.add(cmd[0])
+                if cmd[0] not in PACK_COMMANDS:
+                    bad.append(f"{task['id']}:{cmd[0]}")
+        self.assertEqual(bad, [], f"pack requires 밖 명령: {bad}")
+        self.assertEqual(used, PACK_COMMANDS, f"세 명령을 다 쓰지 않았다: {used}")
+
+    def test_inputs_are_existing_samples(self):
+        missing = []
+        for task in load_tasks():
+            rel = task["input"]
+            self.assertTrue(rel.startswith("samples/"), task["id"])
+            if not (REPO_ROOT / rel).exists():
+                missing.append(f"{task['id']}:{rel}")
+        self.assertEqual(missing, [], f"없는 표본: {missing}")
+
+    def test_no_t07_clone(self):
+        hits = []
+        for task in load_tasks():
+            if task["id"].startswith("T0"):
+                hits.append(f"{task['id']}:core-cli id")
+            if task.get("title") == "서식 채움":
+                hits.append(f"{task['id']}:title")
+            for check in task["checks"]:
+                cmd = check.get("cmd") or []
+                if cmd and cmd[0] == "fields":
+                    hits.append(f"{task['id']}:fields 명령")
+                if "fill-fields" in cmd:
+                    hits.append(f"{task['id']}:fill-fields")
+                if check.get("value") == "홍길동":
+                    hits.append(f"{task['id']}:홍길동")
+        self.assertEqual(hits, [], f"T07 복제 흔적: {hits}")
+
+    def test_no_xc_or_ladder_clone(self):
+        hits = []
+        for task in load_tasks():
+            for check in task["checks"]:
+                cmd = check.get("cmd") or []
+                if cmd and cmd[0] in FORBIDDEN_CMDS:
+                    hits.append(f"{task['id']}:금지 명령 {cmd[0]}")
+                for flag in FORBIDDEN_FLAGS:
+                    if flag in cmd:
+                        hits.append(f"{task['id']}:금지 플래그 {flag}")
+                if check.get("path") == "depth" and check.get("value") in (2, 3):
+                    hits.append(f"{task['id']}:depth=={check.get('value')} 복제")
+                if check.get("path") == "verdict" and check.get("value") in (
+                    "conformant",
+                    "allow",
+                ):
+                    hits.append(f"{task['id']}:사다리 판정 복제")
+        self.assertEqual(hits, [], f"XC/사다리 복제 흔적: {hits}")
+
+    def test_no_au02_rate_plus_floor_clone(self):
+        hits = []
+        for task in load_tasks():
+            has_rate = False
+            has_floor = False
+            for check in task["checks"]:
+                if check.get("path") == "reproducedRate" and check.get("value") == 1.0:
+                    has_rate = True
+                if check.get("path") == "total" and check.get("op") == "value_ge":
+                    has_floor = True
+            if has_rate and has_floor:
+                hits.append(task["id"])
+        self.assertEqual(hits, [], f"AU02 복제: {hits}")
+
+    def test_no_hardcoded_golden_counts_in_answer_eq(self):
+        bad = []
+        for task in load_tasks():
+            for check in task["checks"]:
+                if check["op"] == "answer_eq" and "value" in check:
+                    bad.append(task["id"])
+        self.assertEqual(bad, [], f"answer_eq 에 박제 value: {bad}")
+
+    def test_answer_tasks_submit_answer_json(self):
+        for task in load_tasks():
+            kind = task["submit"]["kind"]
+            self.assertIn(kind, ("answer", "artifact"), task["id"])
+            if kind == "answer":
+                self.assertIn("answer.json", task["submit"]["files"], task["id"])
+
+    def test_schema_module_accepts_every_task(self):
+        sys.path.insert(0, str(REPO_ROOT))
+        from gym.core import schema as gym_schema  # noqa: WPS433
+
+        manifest = read_json(PACK / "pack.json")
+        errors = []
+        gym_schema.validate_pack(manifest, str(PACK), errors)
+        for task in load_tasks():
+            gym_schema.validate_task(task, manifest, None, errors)
+        self.assertEqual(errors, [], "\n".join(errors))
+
+    def test_answer_reference_mirrors_check_cmd_path(self):
+        refs = load_refs()
+        for task in load_tasks():
+            answer_checks = [c for c in task["checks"] if c["op"] in ANSWER_OPS]
+            if not answer_checks:
+                continue
+            tid = task["id"]
+            steps = refs[tid]["steps"]
+            answer = None
+            for step in steps:
+                if "answer" in step:
+                    answer = step["answer"]
+                    break
+            self.assertIsNotNone(answer, f"{tid}: 기준풀이에 answer 가 없다")
+            check_answers = {c["answer"] for c in answer_checks}
+            self.assertEqual(
+                set(answer),
+                check_answers,
+                f"{tid}: 기준풀이 키 {sorted(answer)} != 검사 키 {sorted(check_answers)}",
+            )
+            by_key = {c["answer"]: c for c in answer_checks}
+            for key, spec in answer.items():
+                check = by_key[key]
+                self.assertEqual(spec["cmd"], check["cmd"], f"{tid}/{key} cmd")
+                self.assertEqual(spec["path"], check["path"], f"{tid}/{key} path")
+
+
+class WorkReceiptReferenceTests(unittest.TestCase):
+    def test_every_task_has_matching_reference(self):
+        refs = load_refs()
+        for task in load_tasks():
+            tid = task["id"]
+            self.assertIn(tid, refs, f"{tid} 기준풀이 없음")
+            self.assertEqual(refs[tid]["id"], tid)
+
+    def test_no_orphan_references(self):
+        task_ids = {t["id"] for t in load_tasks()}
+        for stem in load_refs():
+            self.assertIn(stem, task_ids, f"고아 기준풀이 {stem}")
+
+    def test_artifact_reference_writes_capsule(self):
+        refs = load_refs()
+        for task in load_tasks():
+            files = task["submit"].get("files") or []
+            capsules = [f for f in files if f.endswith(".capsule.json")]
+            if not capsules:
+                continue
+            blob = json.dumps(refs[task["id"]], ensure_ascii=False)
+            for cap in capsules:
+                self.assertIn(
+                    cap,
+                    blob,
+                    f"{task['id']}: 기준풀이가 {cap} 을 쓰지 않는다",
+                )
+            self.assertIn("--capsule", blob, task["id"])
+
+    def test_reference_steps_use_input_or_sub_placeholders(self):
+        for path in ref_paths():
+            ref = read_json(path)
+            self.assertTrue(ref.get("steps"), path.name)
+            blob = json.dumps(ref, ensure_ascii=False)
+            self.assertTrue(
+                "{input}" in blob or "{sub:" in blob or "samples/" in blob,
+                f"{path.name} 자리표/표본 경로가 없다",
+            )
+
+
+class WorkReceiptExpansionScopeTests(unittest.TestCase):
+    def test_wr05_plus_cover_receipt_axes(self):
+        axes = {
+            "attest": 0,
+            "verify": 0,
+            "lineage": 0,
+            "audit": 0,
+            "parentOk": 0,
+            "lineageOk": 0,
+            "inputSha256": 0,
+        }
+        for path in task_paths():
+            if wr_num(path) < 5:
+                continue
+            blob = path.read_text(encoding="utf-8")
+            for key in axes:
+                if key in blob:
+                    axes[key] += 1
+        for key, count in axes.items():
+            self.assertGreaterEqual(count, 2, f"WR05+ 에 {key} 축이 부족하다: {count}")
+
+    def test_audit_still_passes_for_work_receipt_pack(self):
+        spec_name = "gym_audit_work_receipt_pack"
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(spec_name, GYM / "tools" / "audit.py")
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        report = module.audit(str(GYM))
+        self.assertTrue(report["ok"], f"audit 실패: {report}")
+        wr = [p for p in report.get("packs", []) if p["id"] == "work-receipt"]
+        self.assertEqual(wr, [], f"work-receipt pack 위반: {wr}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 요약

gym pack `work-receipt` 를 추가한다. automation·expert-challenges 가 다루는 사다리 완주(AU02 재현율 1.0+total≥1, AU12 depth 2, AU07 gate --deep, XC01–XC05)는 복제하지 않는다. 에이전트가 매일 밟는 영수증 한 장·뿌리 계보·부모 링크·폴더 회계만 짧은 여정으로 둔다. 새 CLI 는 없다.

Closes #5231

## 과제

| ID | 축 | 입력 | 판정 |
| --- | --- | --- | --- |
| WR01 | 일일 영수증 3해시 | `samples/field-01.hwp` | replay 라이브 오라클 — `mode`·`steps`·`inputSha256`·`planSha256`·`outputSha256` |
| WR02 | 첫 영수증은 뿌리 | `samples/field-01.hwp` | `lineage` `valid`·`depth==1`·`links[0].parentOk==null` |
| WR03 | 어제 산출 = 오늘 입력 | `samples/field-01.hwp` | `links[1].lineageOk`·`links[1].parentOk`·`brokenAt==null` (depth 2 를 묻지 않음) |
| WR04 | 오늘 폴더 회계 1건 | `samples/field-01.hwp` | `audit` `total==1`·`reproduced==1` (비율이 아님) |

`gym/profiles/maintainer.json` 에 `work-receipt` 를 정렬해 넣었다. PARK/README 와 다른 프로파일·checks.py 는 손대지 않았다. gate 는 AU07 과 정직하게 다른 축을 바이너리 없이 실측할 수 없어 넣지 않았다.

## 검증

- `python gym/tools/audit.py` — 19 pack 전부 통과
- `python -m unittest scripts/tests/test_gym_packs.py` — 15 tests OK
- `python -m unittest scripts/tests/test_gym_audit.py` — 5 tests OK
- gym JSON 만 변경. `cargo fmt --all` 생략 (sparse)

## 위험

- WR01–WR04 는 `samples/field-01.hwp` 본문의 `마케팅` 문자열에 기대한다. 근거는 form-journeys FJ04 와 같은 표본이다. 문구가 빠지면 replace_text 계획이 빈 치환이 되거나 실패할 수 있다.
- WR03 의 `links[1].lineageOk` 는 `tests/lineage_contract.rs` 의 2링크 봉투 좌표다. 링크 순서가 바뀌면 라이브 채점이 깨진다.
- 이 세션에는 로컬 `rhwp` 바이너리가 없어 기준 풀이를 라이브 채점하지 못했다. 스키마·audit 만 통과했다.