### PR TITLE
gym: competitive_bench 순수 함수·시험 강화

### DIFF
--- a/gym/docs/competitive_bench.md
+++ b/gym/docs/competitive_bench.md
@@ -1,0 +1,410 @@
+---
+kind: guide
+status: active
+canonical: gym/docs/competitive_bench.md
+last_verified: 2026-08-18
+---
+
+# gym 경쟁 벤치 — 순수 집계·평결·명시 예외
+
+이 문서는 `gym/tools/competitive_bench.py` 의 **정직 경계**, **보고 봉투**,
+**능력 매트릭스**, **집계·충실도·평결**, **명시 예외 코드**를 고정한다. 작업
+기록은 [`mydocs/working/gym_competitive_bench.md`](../../mydocs/working/gym_competitive_bench.md)
+를 본다. 시험 계약은 `scripts/tests/test_gym_competitive_bench.py` 와
+`scripts/tests/test_gym_competitive_bench_exceptions.py` ,
+`scripts/tests/test_gym_competitive_bench_extra.py` 가 바이너리 없이 고정한다.
+
+packs·checks·coverage·robustness·profiles·README 는 이 기둥의 범위가 아니다.
+새 CLI 플래그를 만들지 않는다. 기존 `--rhwp` · `--pyhwp` · `--soffice` ·
+`--samples` · `--limit` · `--timeout` · `--out-json` · `--out-md` ·
+`--from-json` · `--json` 이름만 쓴다.
+
+## 1. 왜 이 기둥이 필요한가
+
+"표준 도구 = 에이전트가 기본으로 집는 도구"라는 명제는 주장이 아니라
+측정이어야 한다. 같은 `samples/` 파일에 같은 과제(본문 추출·메타·구조·변환)를
+rhwp 와 대안 도구에 돌려, 성공률·중앙값 시간·간이 충실도를 재고, 문서화된
+사실로 능력 매트릭스를 채운다.
+
+시험이 얇으면 리더보드 비교가 흔들린다. 못 돌린 도구에 숫자를 싣거나,
+실패한 실행의 0ms 로 중앙값을 끌어내리거나, 겹치지 않는 파일로 속도를
+비교하면 채택 논거가 거짓이 된다. 이 기둥이 그 구멍을 막는다.
+
+온램프 이슈는 #5229, 순수 함수·시험 강화는 #5239 이다.
+
+## 2. 정직 조항
+
+거짓말하면 안 되는 문:
+
+1. **못 돌린 도구는 `available:false` + `reason` 이다.** `summary` ·
+   `fidelityVsRhwp` · `overlapMs` · `runs` 를 싣지 않는다.
+2. **medianMs / medianChars 는 성공 실행만 본다.** 실패의 짧은 시간으로
+   속도를 꾸미지 않는다. `0` 은 빈 문서·즉시 반환이라 유효하고, `None` 만
+   뺀다. `bool` 은 숫자가 아니다 (`True==1` 접힘 금지).
+3. **충실도와 동일-집합 속도는 두 도구가 모두 성공한 파일만.** 겹침이 없으면
+   `None` / `n=0` 이다. 기준 문자수가 0 이면 비율을 만들지 않는다.
+4. **능력 매트릭스는 문서화·검증 가능한 사실만.** 값은 `yes` | `partial` |
+   `no`. rhwp 행은 전 능력 `yes` 여야 한다.
+5. **평결은 payload 숫자에서만 다시 유도한다.** 손글 승패를 `--from-json`
+   재렌더가 남기지 않는다.
+6. **깨진 입력은 숫자를 지어내지 않고 명시 오류로 멈춘다.** 파일 없음 ·
+   UTF-8 아님 · JSON 깨짐 · 빈 스코어카드 · 알 수 없는 에이전트 · 봉투 형태.
+
+`invented_metrics` / `payload_honesty_issues` / `require_honest_payload` 가
+이 표를 기계로 돌린다.
+
+## 3. 사용
+
+라이브 스윕(이 문서의 단위 시험이 아님 — rhwp 바이너리가 필요하다):
+
+```bash
+cargo build --bin rhwp
+python gym/tools/competitive_bench.py \
+    --rhwp target/debug/rhwp --pyhwp .venv/Scripts/hwp5txt \
+    --limit 25 \
+    --out-json mydocs/tech/benchmark_vs_alternatives.json \
+    --out-md   mydocs/tech/benchmark_vs_alternatives.md
+```
+
+재렌더(벤치 재실행 없음, 결정론):
+
+```bash
+python gym/tools/competitive_bench.py \
+    --from-json mydocs/tech/benchmark_vs_alternatives.json \
+    --out-md mydocs/tech/benchmark_vs_alternatives.md
+```
+
+순수 시험(바이너리 없음):
+
+```bash
+python -m unittest scripts.tests.test_gym_competitive_bench \
+    scripts.tests.test_gym_competitive_bench_exceptions \
+    scripts.tests.test_gym_competitive_bench_extra -v
+python gym/tools/audit.py
+```
+
+`cargo fmt --all` 은 이 기둥의 범위가 아니다. Python·문서만 고친다.
+
+## 4. 보고 봉투
+
+`kind=gymCompetitiveBench`, `schemaVersion=1.0`. `assemble_payload` 와
+`--from-json` 재렌더 JSON 이 같은 계약을 찍는다. 옛 JSON 에 kind 가 없어도
+`stamp_report_contract` 가 채운다. 다른 kind 는 거절한다.
+
+| 키 | 형 | 의미 |
+|---|---|---|
+| `kind` | str | 항상 `gymCompetitiveBench` |
+| `schemaVersion` | str | 항상 `1.0` |
+| `generatedAt` | str 또는 null | 측정 시각. 재렌더는 유지하거나 비울 수 있다. |
+| `toolOrder` | str[] | 표 열 순서. 기본 `rhwp`, `pyhwp`, `soffice`, `hwplib` |
+| `env` | object | OS·Python·rhwp 버전/프로파일·코퍼스 수·도구 가용성 |
+| `tasks` | object[] | 과제별 도구 결과 |
+| `capabilityMatrix` | object | 컬럼·행. 값은 yes/partial/no |
+| `verdict` | str[] | 숫자에서 다시 유도한 평결 문장 |
+| `scorecard` | object | 선택. 붙일 때만 요약. 평결 숫자를 바꾸지 않는다. |
+
+`payload_shape_issues` 는 최소 형태만 본다. `tasks` 누락·배열 아님·잘못된
+kind/schemaVersion. 정직성 가드(`payload_honesty_issues`)는 빈 tasks, 비가용
+칸의 숫자, 깨진 run, 매트릭스 구멍까지 본다.
+
+## 5. 코퍼스 선택
+
+`select_corpus_paths` 는 파일시스템을 보지 않는다. POSIX 정규화 후
+`.hwp`/`.hwpx` 만 취하고 형식별 정렬한다. `limit>0` 이면 형식별 앞 limit 개,
+`limit<=0` 이면 전부. 중복 경로는 첫 등장만. `.txt` · `.md` · `.doc` 는
+무시한다. 대소문자가 다른 경로는 별개다.
+
+`discover_corpus` 는 `samples_dir` 의 바로 아래 `*.hwp`/`*.hwpx` 만 본다.
+중첩 폴더는 넣지 않는다. 경로는 REPO_ROOT 상대 POSIX 로 내서 커밋 JSON 에
+머신 절대경로가 새지 않게 한다. 임시 폴더 시험이 그 선택을 고정한다.
+
+## 6. 집계
+
+`summarize_runs(runs)`:
+
+| 키 | 규칙 |
+|---|---|
+| `attempted` | 정규화한 run 수 |
+| `ok` / `fail` | `ok` 가 참인 것만 성공 |
+| `successRate` | `ok/attempted` 를 소수 3자리. attempted=0 이면 None |
+| `medianMs` | 성공 run 의 숫자 ms 중앙값. 실패·bool·None 제외 |
+| `medianChars` | 성공 run 의 숫자 chars 중앙값. 0 은 남긴다 |
+| `byExt` | 형식별 attempted/ok/fail. ext 가 비면 file 에서 추론 |
+
+`fidelity_vs_ref` 는 겹친 성공 파일의 `got/base` 중앙값이다. 기준 0 은 쌍을
+만들지 않는다. `overlap_median_ms` 는 같은 파일집합의 (tool, ref) 중앙값이다.
+
+## 7. 봉투 파서
+
+info / structure / export-text 는 한 겹의 `data`/`result`/`payload` 만 벗긴다.
+본문 표지(`pages`·`text`·`format`·`pageCount`·`nodeCount`·`structure`·
+`sections`·`paraCount`)가 안쪽 객체에 있을 때만 래퍼로 인정한다.
+
+| 함수 | 빈·깨진·배열 JSON | 인정하는 본문 |
+|---|---|---|
+| `parse_json_object` | None | 최상위 객체 |
+| `parse_rhwp_info` | None | format/pageCount/sections/paraCount 중 하나. bool pageCount 는 None |
+| `parse_rhwp_structure` | None | nodeCount/structure/mode 중 하나 |
+| `parse_rhwp_text_chars` | None | pages[].text 합 또는 최상위 text. 비문자열 page 는 건너뜀. 빈 pages 는 0 |
+| `parse_rhwp_info_fields` | None | 있는 스칼라만. extra 키는 버림 |
+| `parse_rhwp_structure_nodes` | None | nodeCount 또는 nodes/sections/children 길이 |
+
+바이트 stdout 은 UTF-8 `errors=replace` 로 읽는다. 이건 **측정 경로**다.
+파일에서 읽는 경로(`utf8_decode`)는 깨진 바이트를 바꿔 넣지 않고
+`encoding` 오류다. 두 길을 섞지 않는다.
+
+## 8. 칸 렌더와 평결
+
+`_fmt_cell`:
+
+- 비가용 → `n/a: <이유>` (이유 없으면 `실행 불가`)
+- attempted==0 또는 summary 가 객체 아님 → `n/a: 시도 없음`
+- 그 외 → `{ms} · {rate%}({ok}/{att}) · 충실도 {fid}`. 없는 숫자는 `-`
+
+파이프·개행은 `escape_md_cell` 이 `\|` 와 공백으로 바꿔 표를 지키다.
+
+`verdict_lines` 가지:
+
+| 조건 | 문장 |
+|---|---|
+| rhwp 가용 | `rhwp 는 export-text 에서 ok/att … 중앙값` |
+| pyhwp 비가용 | `실행하지 않았다(이유)` 후 반환 |
+| pyhwp 가용 | HWP5 ok/att, HWPX ok/att (구조적 한계) |
+| overlap tool_faster | pyhwp 가 더 빨랐다 — 그대로 적는다 |
+| overlap ref_faster | rhwp 가 더 빨랐다 |
+| overlap tie | 중앙값이 같았다 |
+| overlap n=0 | 겹친 파일이 없어 비교를 만들지 않았다 |
+| soffice 비가용 | 이 머신에서 실행하지 않았다 |
+| info/structure/convert 에 rhwp 만 가용 | 폭: … 과제는 rhwp 만 |
+| 매트릭스 exclusive yes | 능력: 라벨… 는 rhwp 만 yes |
+
+`refresh_verdict` 가 손글 승패를 덮어쓴다. `--from-json` 재렌더는 이 함수를
+거친다.
+
+## 9. 능력 매트릭스
+
+컬럼 순서: 크로스플랫폼, 단일 자립 바이너리, 에이전트-네이티브 CLI, MCP,
+메모리 안전, 검증 가능 작업, 편집, 렌더.
+
+`validate_capability_matrix` 가 잡는 것:
+
+- matrix/columns/rows 가 객체·비지 않은 배열이 아님
+- column 에 key 없음, column 중복
+- row 가 객체 아님, tool 없음, tool 중복
+- 컬럼 키 누락, 값이 yes|partial|no 밖
+- rhwp 행이 yes 가 아님
+
+`exclusive_yes(matrix, "rhwp")` 는 라이브 매트릭스에서 mcp · verifiable ·
+singleBinary · memSafe · agentCli 를 낸다. edit · render · crossPlatform 은
+대안도 yes/partial 이라 독점 목록에 없다.
+
+반환 행은 사본이다. 호출자가 고쳐도 다음 `capability_matrix()` 는 그대로다.
+
+## 10. 예외 코드 카탈로그
+
+모든 명시 실패는 `BenchError.code` 를 가진다. `ERROR_CODES` 와
+`error_catalog()` 가 문서·시험·코드의 같은 표다. 기본 종료 코드는 2 다.
+`BenchError` 가 아닌 예외는 `error_exit_code` 가 1 을 준다.
+
+| code | 클래스 | 언제 |
+|---|---|---|
+| `missing-file` | `MissingFileError` | 경로 없음·빈 경로·디렉터리·읽기 OSError |
+| `bad-json` | `BadJsonError` | 빈 문자열·잘린 JSON·트레일링 쉼표·최상위 비객체 |
+| `encoding` | `EncodingError` | None·비바이트·UTF-8 디코드 실패. BOM 은 벗기고 통과 |
+| `empty-scorecard` | `EmptyScorecardError` | packs/total 없음, 빈 packs, packsScored 0/null, 전부 unavailable, taskCount 0 |
+| `unknown-agent` | `UnknownAgentError` | 빈 이름, 예약어, 경로 문자, 공백, 정규식 밖, 알려진 집합 밖 |
+| `payload-shape` | `PayloadShapeError` | kind/tasks 형태, 비가용 칸의 숫자, 깨진 run |
+
+`ERROR_KIND` 는 `gymCompetitiveBenchError` 다. `to_dict()` 는 `ok:false` 와
+code/message/exitCode 를 내고, path 와 details 는 있을 때만 붙인다. 경로는
+POSIX 로 정규화한다.
+
+stderr 한 줄은 `오류[<code>]: <message> path=...` 이다. 코드가 앞에 있어
+기계가 grep 할 수 있다.
+
+### 10.1 에이전트 식별자
+
+문법: `^[A-Za-z][A-Za-z0-9._-]{0,63}$`. 예약어
+(`rhwp`·`pyhwp`·`soffice`·`hwplib`·`hancom`·`all`·`none`·`baseline` 등)는
+식별자가 아니다. 도구 이름과 에이전트 이름을 표에서 섞지 않기 위해서다.
+
+`discover_known_agents` 는 베이스라인·리더보드 스코어카드 폴더를 본다. 폴더
+이름 `claude-fable-5-0000` 은 epoch 접미를 떼어 `claude-fable-5` 도 인정한다.
+깨진 scorecard.json 은 그 파일만 건너뛰고 폴더 이름은 남긴다.
+
+### 10.2 스코어카드
+
+`kind=gymScorecard`, schemaVersion `1.0` 또는 `2.0`. 옛 카드에 kind 가 없어도
+형태 오류로 치지 않는다. 측정이 하나도 없으면 `empty-scorecard` 다.
+
+`attach_scorecard` 는 요약만 붙인다. `verdict` 숫자를 다시 쓰지 않는다.
+채점 점수로 벤치 평결을 덮어쓰면 측정과 주장이 섞인다.
+
+### 10.3 서브프로세스 실패 근사
+
+`classify_cli_failure` 는 stderr 를 코드로 접는다. 숫자를 지어내지 않는다.
+
+| 표식 | 코드 |
+|---|---|
+| timeout | `timeout` |
+| not found / cannot find / 없는 파일 | `missing_input` |
+| permission / 액세스가 거부 | `permission` |
+| utf-8 / codec / decode | `encoding` |
+| json | `bad-json` |
+| 그 외 | `runtime` |
+
+이 분류는 집계에 가짜 ms 를 넣지 않는다. run 의 `ok=false` 만 남긴다.
+
+## 11. 문자열 로더와 경로 로더
+
+두 함수를 갈라 둔다. 이름을 하나로 덮어쓰면 `--from-json` 시험이 깨진다.
+
+| 함수 | 입력 | 실패 |
+|---|---|---|
+| `load_report_payload(raw)` | JSON 문자열 | `(None, issues)` |
+| `load_report_from_path(path)` | 파일 경로 | `MissingFileError` / `BadJsonError` / `EncodingError` / `PayloadShapeError` |
+
+CLI `--from-json` 은 기존처럼 파일을 읽어 **문자열 로더**를 부른다. 플래그
+이름을 바꾸지 않았다. 경로 로더는 스코어카드·정직 가드 시험이 예외 코드를
+고정하려고 둔 순수 입구다.
+
+## 12. 순수 함수와 바이너리 경계
+
+바이너리 없이 고정하는 함수:
+
+- `median` / `summarize_runs` / `normalize_run`
+- `fidelity_pairs` / `fidelity_stats` / `fidelity_vs_ref`
+- `overlap_ok_pairs` / `overlap_timing` / `overlap_median_ms`
+- `parse_json_object` / `parse_rhwp_info` / `parse_rhwp_structure` / `parse_rhwp_text_chars`
+- `parse_rhwp_info_fields` / `parse_rhwp_structure_nodes`
+- `validate_capability_matrix` / `exclusive_yes` / `capability_label`
+- `_fmt_cell` / `escape_md_cell` / `speed_cmp`
+- `export_text_verdict` / `soffice_verdict` / `width_verdict` / `verdict_lines`
+- `select_corpus_paths` / `resolve_tool` / `rhwp_profile_from_path`
+- `assemble_env` / `assemble_payload` / `stamp_report_contract` / `refresh_verdict`
+- `unavailable_result` / `available_result` / `invented_metrics`
+- `BenchError` 가족 / `utf8_decode` / `parse_json_text` / `load_json_object`
+- `agent_id_issues` / `normalize_agent_id` / `require_known_agent`
+- `scorecard_kind_issues` / `scorecard_emptiness_issues` / `load_scorecard`
+- `payload_honesty_issues` / `require_honest_payload`
+- `classify_cli_failure` / `error_catalog`
+- `render_report` / `dump_payload_json` / `write_text_lf`
+- `--from-json` 재렌더 (`main(["--from-json", ...])`)
+
+바이너리가 필요한 자리:
+
+- `bench_rhwp_*` / `bench_pyhwp_text` / `bench_soffice_text`
+- 라이브 `build_payload`
+
+단위 시험은 후자를 부르지 않는다. 라이브 스윕은 기존과 같이 rhwp 가 필요하다.
+
+## 13. 이 도구가 하지 않는 것
+
+- 새 CLI 플래그를 만들지 않는다.
+- packs·checks·coverage·robustness 를 건드리지 않는다.
+- 못 돌린 도구에 0% 나 0ms 를 싣지 않는다.
+- pyhwp 가 더 빠른 사실을 숨기지 않는다.
+- HWPX 0/N 을 "지원함"으로 바꾸지 않는다.
+- 손글 승패를 재렌더에 남기지 않는다.
+- 깨진 JSON 을 빈 요약으로 바꾸지 않는다.
+- 예약된 도구 이름을 에이전트 식별자로 받지 않는다.
+- Rust 를 포맷하지 않는다. 이 기둥이 만지는 것은 Python·문서뿐이다.
+
+## 14. 관련 기둥
+
+| 기둥 | 도구 | 질문 |
+|---|---|---|
+| 경쟁 벤치 | `competitive_bench.py` | 같은 과제에서 대안 대비 숫자와 능력이 정직한가? |
+| pack 정합 | `audit.py` | 과제↔기준 짝, ID 고유인가? |
+| 손상 강건성 | `robustness.py` | 손상 입력에 rhwp 가 패닉·행 하나? |
+| 종점 무결성 | `discriminate.py` | 일 안 한 제출이 만점을 받나? |
+
+벤치는 도구 비교다. 감사기는 pack 짝을 본다. 두 축을 한 숫자에 섞지 않는다.
+
+## 15. 시험이 고정하는 것
+
+```bash
+python -m unittest scripts.tests.test_gym_competitive_bench \
+    scripts.tests.test_gym_competitive_bench_exceptions \
+    scripts.tests.test_gym_competitive_bench_extra -v
+```
+
+고정하는 축:
+
+- 중앙값·byExt·bool 제외·빈 실행.
+- 충실도 겹침/0 기준/bool chars.
+- 동일-집합 속도 n 과 None 쌍.
+- info/structure/text 래퍼·빈 pages·비객체 page.
+- 매트릭스 구멍·rhwp 전 yes·exclusive yes.
+- n/a 칸에 숫자 없음. attempted=0 은 시도 없음.
+- 평결: 더 빠름, 동률, 겹침 없음, HWPX 0/N, soffice 미가용, 폭.
+- `--from-json` 재스탬프 kind=gymCompetitiveBench.
+- 예외 코드 카탈로그와 to_dict.
+- UTF-8 BOM 통과, 깨진 바이트는 encoding.
+- 빈/없는/디렉터리 경로는 missing-file.
+- 예약 에이전트·경로 문자·공백.
+- 빈 스코어카드와 agent 불일치.
+- 비가용 칸에 숫자를 실으면 payload-shape.
+
+Rust 시험·`cargo fmt --all` 은 이 기둥의 범위가 아니다.
+
+## 16. 실패 시나리오 표본
+
+아래는 시험이 고정하는 최소 표본이다. code 가 표와 어긋나면 하네스가
+거짓말하는 것이다.
+
+### 16.1 missing-file
+
+경로 `""` · `None` · 없는 파일 · 디렉터리. `read_bytes` /
+`load_report_from_path` 가 `MissingFileError` 를 낸다.
+
+### 16.2 bad-json
+
+`""` · `"   "` · `"{"` · `'{"a": 1,}'` · 최상위 배열. `parse_json_text` /
+`require_json_object` 가 `BadJsonError` 를 낸다. 문자열 로더
+`load_report_payload("{")` 는 예외 대신 `(None, issues)` 다. CLI 재렌더가
+exit 2 와 `깨졌다` 를 stderr 에 남기는 경로와 같다.
+
+### 16.3 encoding
+
+`utf8_decode(None)` · `utf8_decode(12)` · `b"\xff\xfe"`. BOM 이 붙은
+`{"ok": true}` 는 통과한다. latin-1 `café` 파일은 encoding 이다.
+
+### 16.4 empty-scorecard
+
+kind 만 있는 객체, packs=[], packsScored=0, 전부 unavailable, 모든
+taskCount=0. `load_scorecard` 가 `EmptyScorecardError` 를 낸다.
+
+### 16.5 unknown-agent
+
+`""` · `rhwp` · `a/b` · `bad agent` · `1agent` · 알려진 목록 밖의 이름.
+스코어카드 agent 와 expected 가 달라도 이 코드다.
+
+### 16.6 payload-shape
+
+`kind=other`, 빈 tasks 를 `require_honest_payload` 에 넣을 때, 비가용 칸에
+`summary`/`runs` 를 실을 때.
+
+## 17. 재현
+
+```bash
+python -m unittest scripts.tests.test_gym_competitive_bench \
+    scripts.tests.test_gym_competitive_bench_exceptions \
+    scripts.tests.test_gym_competitive_bench_extra -v
+python gym/tools/audit.py
+git diff --shortstat upstream/devel
+```
+
+SIZE GATE: upstream/devel 대비 insertions >= 3000.
+
+## 18. 남은 위험
+
+1. 라이브 스윕은 여전히 rhwp 바이너리와 선택적 pyhwp/soffice 가 필요하다.
+   단위 시험이 그 경로를 대체하지 않는다.
+2. 충실도는 문자수 비율이다. 표 셀을 `<표>` 로 바꾸는 손실은 잡지만, 글자
+   순서가 다른 동량은 1.0× 로 남을 수 있다. 구조 대조는 `ir-diff` 축이다.
+3. 스코어카드 schema 2.0 의 추가 키(`packsUnavailable`)는 요약에 안 올린다.
+   벤치 평결에 채점 점수를 섞지 않으려는 경계다.
+4. `discover_corpus` 는 한 단계 glob 이다. `samples/chart/` 아래 파일은
+   라이브 기본 선택에 안 들어간다. 재귀로 바꾸면 코퍼스 크기가 달라져
+   과거 JSON 과 비교가 깨진다.

--- a/gym/tools/competitive_bench.py
+++ b/gym/tools/competitive_bench.py
@@ -39,6 +39,7 @@ import argparse
 import json
 import os
 import platform
+import re
 import shutil
 import statistics
 import subprocess
@@ -57,6 +58,18 @@ TASKS = ["export-text", "info", "structure", "convert"]
 
 # 서브프로세스 1건 상한(초). 초과는 실패로 센다 — 매달리는 것도 정직하게 실패다.
 DEFAULT_TIMEOUT = 60
+
+# 보고 봉투 계약. build_payload 와 --from-json 재렌더 JSON 이 같은 kind/version 을 쓴다.
+REPORT_KIND = "gymCompetitiveBench"
+SCHEMA_VERSION = "1.0"
+VALID_CAP = frozenset({"yes", "partial", "no"})
+CORPUS_EXTS = (".hwp", ".hwpx")
+DEFAULT_TOOL_ORDER = ("rhwp", "pyhwp", "soffice", "hwplib")
+# info/structure/export-text 본문으로 인정하는 키. 래퍼를 벗길 때 쓴다.
+_BODY_KEYS = (
+    "pages", "text", "format", "pageCount", "nodeCount", "structure",
+    "sections", "paraCount",
+)
 
 # --------------------------------------------------------------------------
 # 능력 매트릭스 — 문서화·검증 가능한 사실만. 값 = "yes" | "partial" | "no".
@@ -121,23 +134,118 @@ def capability_matrix() -> dict:
     }
 
 
+def validate_capability_matrix(matrix: dict | None = None) -> list[str]:
+    """매트릭스 구멍·중복·허용값 밖을 나열. 비어 있으면 정합. 순수."""
+    matrix = capability_matrix() if matrix is None else matrix
+    issues: list[str] = []
+    if not isinstance(matrix, dict):
+        return ["matrix 가 객체가 아니다"]
+    columns = matrix.get("columns")
+    rows = matrix.get("rows")
+    if not isinstance(columns, list) or not columns:
+        issues.append("columns 가 비었다")
+        return issues
+    if not isinstance(rows, list) or not rows:
+        issues.append("rows 가 비었다")
+        return issues
+    keys: list[str] = []
+    seen_keys: set[str] = set()
+    for col in columns:
+        if not isinstance(col, dict) or not col.get("key"):
+            issues.append("column 에 key 가 없다")
+            continue
+        key = col["key"]
+        if key in seen_keys:
+            issues.append(f"column 중복: {key}")
+        seen_keys.add(key)
+        keys.append(key)
+    seen_tools: set[str] = set()
+    for row in rows:
+        if not isinstance(row, dict):
+            issues.append("row 가 객체가 아니다")
+            continue
+        tool = row.get("tool")
+        if not tool:
+            issues.append("row 에 tool 이 없다")
+            continue
+        if tool in seen_tools:
+            issues.append(f"tool 중복: {tool}")
+        seen_tools.add(tool)
+        for key in keys:
+            if key not in row:
+                issues.append(f"{tool}: {key} 누락")
+            elif row[key] not in VALID_CAP:
+                issues.append(f"{tool}.{key}={row[key]!r} 는 yes|partial|no 가 아니다")
+        if tool == "rhwp":
+            for key in keys:
+                if row.get(key) != "yes":
+                    issues.append(f"rhwp.{key}={row.get(key)!r} 는 yes 가 아니다")
+    return issues
+
+
+def exclusive_yes(matrix: dict, tool: str) -> list[str]:
+    """`tool` 만 yes 인 능력 키(컬럼 순서). 순수."""
+    columns = matrix.get("columns") or []
+    rows = [r for r in (matrix.get("rows") or []) if isinstance(r, dict)]
+    keys = [c["key"] for c in columns if isinstance(c, dict) and c.get("key")]
+    out: list[str] = []
+    for key in keys:
+        mine = next((r.get(key) for r in rows if r.get("tool") == tool), None)
+        if mine != "yes":
+            continue
+        if all(r.get(key) != "yes" for r in rows if r.get("tool") != tool):
+            out.append(key)
+    return out
+
+
+def capability_label(matrix: dict, key: str) -> str:
+    for col in matrix.get("columns") or []:
+        if isinstance(col, dict) and col.get("key") == key:
+            return col.get("label") or key
+    return key
+
+
 # --------------------------------------------------------------------------
 # 순수 집계 로직 (바이너리·외부 도구 불요 — 가드 테스트가 이 부분만 검증한다)
 # --------------------------------------------------------------------------
+def is_number(value) -> bool:
+    """측정값으로 쓸 수 있는 숫자. bool 은 세지 않는다(True==1 접힘 금지)."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def posix_rel(path: str) -> str:
+    """경로 구분자를 POSIX 로. 머신 불변 키."""
+    return str(path).replace("\\", "/")
+
+
+def ext_of(path: str) -> str:
+    return Path(str(path)).suffix.lower()
+
+
 def median(values):
-    """None 을 거른 중앙값. 값이 없으면 None."""
-    vals = [v for v in values if v is not None]
+    """None·비숫자를 거른 중앙값. 값이 없으면 None. bool 은 숫자로 치지 않는다."""
+    vals = [v for v in values if is_number(v)]
     if not vals:
         return None
     return statistics.median(vals)
 
 
 def _round_ms(v):
-    return None if v is None else round(v, 1)
+    return None if v is None else round(float(v), 1)
 
 
 def _round_int(v):
-    return None if v is None else int(round(v))
+    return None if v is None else int(round(float(v)))
+
+
+def normalize_run(run: dict) -> dict:
+    """run 레코드 정규화. ext 가 비면 file 에서 추론. ok 는 bool."""
+    out = dict(run)
+    path = out.get("file") or ""
+    ext = (out.get("ext") or "").lower() or ext_of(str(path))
+    out["ext"] = ext
+    out["ok"] = bool(out.get("ok"))
+    return out
 
 
 def summarize_runs(runs: list[dict]) -> dict:
@@ -145,177 +253,405 @@ def summarize_runs(runs: list[dict]) -> dict:
 
     run 레코드: {"file": str, "ext": str, "ok": bool, "ms": float|None, "chars": int|None}
     - medianMs 는 **성공한 실행만** 대상으로 한다(실패의 0ms 로 시간을 왜곡하지 않는다).
-    - byExt 는 형식별 성공률을 남긴다(예: pyhwp 가 .hwp 는 되고 .hwpx 는 안 되는 사실).
+    - medianChars 는 성공한 실행의 문자수만. 0 은 빈 문서라 유효하고, None 만 뺀다.
+    - byExt 는 형식별 시도/성공/실패를 남긴다(예: pyhwp 가 .hwp 는 되고 .hwpx 는 안 되는 사실).
     """
-    attempted = len(runs)
-    ok_runs = [r for r in runs if r.get("ok")]
+    normalized = [normalize_run(r) for r in runs]
+    attempted = len(normalized)
+    ok_runs = [r for r in normalized if r["ok"]]
+    fail = attempted - len(ok_runs)
     by_ext: dict[str, dict] = {}
-    for r in runs:
-        ext = (r.get("ext") or "").lower()
-        bucket = by_ext.setdefault(ext, {"attempted": 0, "ok": 0})
+    for r in normalized:
+        bucket = by_ext.setdefault(r["ext"], {"attempted": 0, "ok": 0, "fail": 0})
         bucket["attempted"] += 1
-        if r.get("ok"):
+        if r["ok"]:
             bucket["ok"] += 1
+        else:
+            bucket["fail"] += 1
     return {
         "attempted": attempted,
         "ok": len(ok_runs),
+        "fail": fail,
         "successRate": round(len(ok_runs) / attempted, 3) if attempted else None,
         "medianMs": _round_ms(median([r.get("ms") for r in ok_runs])),
-        "medianChars": _round_int(
-            median([r.get("chars") for r in ok_runs if r.get("chars") is not None])
-        ),
+        "medianChars": _round_int(median([r.get("chars") for r in ok_runs])),
         "byExt": by_ext,
+    }
+
+
+def fidelity_pairs(tool_runs: list[dict], ref_runs: list[dict]) -> list[tuple[str, float]]:
+    """겹친 성공 파일의 (file, got/base) 목록. base==0 은 비율을 만들지 않는다."""
+    ref: dict[str, float] = {}
+    for r in ref_runs:
+        if r.get("ok") and is_number(r.get("chars")):
+            ref[r.get("file")] = float(r["chars"])
+    pairs: list[tuple[str, float]] = []
+    for r in tool_runs:
+        if not r.get("ok") or not is_number(r.get("chars")):
+            continue
+        base = ref.get(r.get("file"))
+        if base is None or base == 0:
+            continue
+        pairs.append((str(r.get("file")), float(r["chars"]) / base))
+    return pairs
+
+
+def fidelity_stats(tool_runs: list[dict], ref_runs: list[dict]) -> dict:
+    """충실도 중앙값과 표본 수. 겹침 없으면 n=0, median=None."""
+    pairs = fidelity_pairs(tool_runs, ref_runs)
+    if not pairs:
+        return {"n": 0, "median": None}
+    return {
+        "n": len(pairs),
+        "median": round(statistics.median([ratio for _file, ratio in pairs]), 3),
     }
 
 
 def fidelity_vs_ref(tool_runs: list[dict], ref_runs: list[dict]):
     """도구/기준(rhwp) 문자수 비율의 **파일별 중앙값**. 둘 다 성공한 파일만.
 
-    겹치는 파일이 없으면 None. 1.0=동일량, <1.0=덜 뽑음(예: pyhwp 가 표 셀 대신
-    `<표>` 자리표만 남겨 문자수가 적다), >1.0=더 뽑음.
+    0 문자도 측정값이다(빈 문서를 버린 뒤 비율을 부풀리지 않는다). 기준이 0 이면
+    나눗셈을 만들지 않는다. 겹치는 유효 쌍이 없으면 None.
+    1.0=동일량, <1.0=덜 뽑음(예: pyhwp 가 표 셀 대신 `<표>` 자리표만 남겨
+    문자수가 적다), >1.0=더 뽑음.
     """
-    ref = {
-        r["file"]: r.get("chars")
-        for r in ref_runs
-        if r.get("ok") and r.get("chars")
-    }
-    ratios = []
+    return fidelity_stats(tool_runs, ref_runs)["median"]
+
+
+def overlap_ok_pairs(tool_runs: list[dict], ref_runs: list[dict], field: str):
+    """둘 다 성공하고 field 가 숫자인 파일의 (file, tool, ref) 목록."""
+    ref_ok: dict = {}
+    for r in ref_runs:
+        if r.get("ok") and is_number(r.get(field)):
+            ref_ok[r.get("file")] = r.get(field)
+    pairs = []
     for r in tool_runs:
-        if not r.get("ok"):
+        if not r.get("ok") or not is_number(r.get(field)):
             continue
-        got = r.get("chars")
-        base = ref.get(r.get("file"))
-        if got is None or not base:
+        base = ref_ok.get(r.get("file"))
+        if base is None:
             continue
-        ratios.append(got / base)
-    if not ratios:
-        return None
-    return round(statistics.median(ratios), 3)
+        pairs.append((r.get("file"), r.get(field), base))
+    return pairs
+
+
+def overlap_timing(tool_runs: list[dict], ref_runs: list[dict]) -> dict:
+    """동일 성공 집합의 속도 요약. n=0 이면 tool/ref 는 None."""
+    pairs = overlap_ok_pairs(tool_runs, ref_runs, "ms")
+    if not pairs:
+        return {"n": 0, "tool": None, "ref": None}
+    tool_ms = [p[1] for p in pairs]
+    ref_ms = [p[2] for p in pairs]
+    return {
+        "n": len(pairs),
+        "tool": _round_ms(statistics.median(tool_ms)),
+        "ref": _round_ms(statistics.median(ref_ms)),
+    }
 
 
 def overlap_median_ms(tool_runs: list[dict], ref_runs: list[dict]):
     """두 도구가 **모두 성공한 파일**에서만 각각의 median ms 를 낸다 → 공정한 동일-집합 속도.
 
     (tool_ms, ref_ms) 를 반환. 겹침 없으면 (None, None). rhwp 의 중앙값이 HWPX 까지
-    포함해 부풀지 않도록, 속도 비교는 같은 파일집합에서만 한다."""
-    ref_ok = {r["file"]: r.get("ms") for r in ref_runs if r.get("ok")}
-    tool_ms, ref_ms = [], []
-    for r in tool_runs:
-        if not r.get("ok"):
-            continue
-        base = ref_ok.get(r.get("file"))
-        if base is None or r.get("ms") is None:
-            continue
-        tool_ms.append(r["ms"])
-        ref_ms.append(base)
-    if not tool_ms:
-        return None, None
-    return _round_ms(statistics.median(tool_ms)), _round_ms(statistics.median(ref_ms))
+    포함해 부풀지 않도록, 속도 비교는 같은 파일집합에서만 한다. 0ms 는 유효한 측정이다."""
+    stats = overlap_timing(tool_runs, ref_runs)
+    return stats["tool"], stats["ref"]
+
+
+def unwrap_json_envelope(doc):
+    """한 겹의 data/result/payload 래퍼를 벗긴다. 본문이 아니면 원본."""
+    if not isinstance(doc, dict):
+        return None
+    for key in ("data", "result", "payload"):
+        inner = doc.get(key)
+        if isinstance(inner, dict) and any(k in inner for k in _BODY_KEYS):
+            return inner
+    return doc
+
+
+def _json_object(stdout):
+    if isinstance(stdout, bytes):
+        stdout = stdout.decode("utf-8", errors="replace")
+    if not isinstance(stdout, str):
+        return None
+    try:
+        doc = json.loads(stdout)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+    return doc if isinstance(doc, dict) else None
+
+
+def parse_json_object(stdout):
+    """빈·깨진·배열 JSON 은 None. 객체만 반환. 순수."""
+    return _json_object(stdout)
+
+
+def parse_json_body(stdout):
+    """봉투 객체를 파싱하고 data/result/payload 한 겹을 벗긴다. 실패 시 None."""
+    doc = _json_object(stdout)
+    if doc is None:
+        return None
+    body = unwrap_json_envelope(doc)
+    return body if isinstance(body, dict) else None
+
+
+def parse_rhwp_info(stdout):
+    """rhwp `info --json` 봉투 → {format, pageCount, sections, paraCount} 또는 None.
+
+    본문 표지가 하나도 없으면 다른 명령 봉투로 보고 None. 래퍼·깨진 JSON 도 None.
+    """
+    body = parse_json_body(stdout)
+    if not isinstance(body, dict):
+        return None
+    if not any(k in body for k in ("format", "pageCount", "sections", "paraCount")):
+        return None
+    fmt = body.get("format")
+    return {
+        "format": fmt if isinstance(fmt, str) else None,
+        "pageCount": body.get("pageCount") if is_number(body.get("pageCount")) else None,
+        "sections": body.get("sections") if is_number(body.get("sections")) else None,
+        "paraCount": body.get("paraCount") if is_number(body.get("paraCount")) else None,
+    }
+
+
+def parse_rhwp_structure(stdout):
+    """rhwp `export-structure --json` 봉투 → {mode, nodeCount, hasStructure} 또는 None."""
+    body = parse_json_body(stdout)
+    if not isinstance(body, dict):
+        return None
+    if not any(k in body for k in ("nodeCount", "structure", "mode")):
+        return None
+    mode = body.get("mode")
+    return {
+        "mode": mode if isinstance(mode, str) else None,
+        "nodeCount": body.get("nodeCount") if is_number(body.get("nodeCount")) else None,
+        "hasStructure": isinstance(body.get("structure"), dict),
+    }
 
 
 def parse_rhwp_text_chars(stdout: str):
-    """rhwp `export-text --json` 봉투 → 총 문자수. 파싱 실패 시 None. 순수."""
-    try:
-        doc = json.loads(stdout)
-    except (json.JSONDecodeError, TypeError):
+    """rhwp `export-text --json` 봉투 → 총 문자수. 파싱 실패 시 None. 순수.
+
+    단건 계약은 `pages[].text` 합, batch 계약은 최상위 `text`.
+    `{data|result|payload}` 래퍼가 있으면 한 겹 벗긴다. 문자열이 아닌 text 는
+    그 쪽만 건너뛴다. `len(None)` 으로 터지지 않는다.
+    """
+    doc = _json_object(stdout)
+    if doc is None:
         return None
-    pages = doc.get("pages")
-    if not isinstance(pages, list):
+    body = unwrap_json_envelope(doc)
+    if not isinstance(body, dict):
         return None
-    return sum(len(p.get("text", "")) for p in pages if isinstance(p, dict))
+    pages = body.get("pages")
+    if isinstance(pages, list):
+        total = 0
+        for page in pages:
+            if not isinstance(page, dict):
+                continue
+            text = page.get("text")
+            if isinstance(text, str):
+                total += len(text)
+        return total
+    text = body.get("text")
+    if isinstance(text, str):
+        return len(text)
+    return None
 
 
 def _fmt_cell(available: bool, summary: dict | None, fidelity, reason: str | None) -> str:
     """결과표 한 칸: 성공률·중앙값 시간·충실도, 또는 'n/a: <이유>'. 순수."""
     if not available:
         return f"n/a: {reason or '실행 불가'}"
-    if not summary or summary.get("attempted", 0) == 0:
+    if not isinstance(summary, dict) or summary.get("attempted", 0) == 0:
         return "n/a: 시도 없음"
     rate = summary.get("successRate")
-    rate_pct = "-" if rate is None else f"{round(rate * 100)}%"
+    if is_number(rate):
+        rate_pct = f"{int(round(rate * 100))}%"
+    else:
+        rate_pct = "-"
     ms = summary.get("medianMs")
-    ms_s = "-" if ms is None else f"{ms:.0f}ms"
+    ms_s = "-" if not is_number(ms) else f"{ms:.0f}ms"
     ok = summary.get("ok", 0)
     att = summary.get("attempted", 0)
-    fid = "-" if fidelity is None else f"{fidelity:.2f}×"
+    fid = "-" if not is_number(fidelity) else f"{fidelity:.2f}×"
     return f"{ms_s} · {rate_pct}({ok}/{att}) · 충실도 {fid}"
+
+
+def escape_md_cell(text) -> str:
+    """마크다운 표 칸. 파이프·개행이 표를 깨지 않게 한다."""
+    return str(text).replace("|", "\\|").replace("\r", " ").replace("\n", " ")
+
+
+def speed_cmp(tool_ms, ref_ms):
+    """tool vs ref 속도. 숫자가 아니면 None, 같으면 tie."""
+    if not is_number(tool_ms) or not is_number(ref_ms):
+        return None
+    if tool_ms < ref_ms:
+        return "tool_faster"
+    if tool_ms > ref_ms:
+        return "ref_faster"
+    return "tie"
+
+
+def _result_index(results) -> dict:
+    out = {}
+    for item in results or []:
+        if isinstance(item, dict) and item.get("tool"):
+            out[item["tool"]] = item
+    return out
+
+
+def _summary_of(result: dict | None) -> dict:
+    if not isinstance(result, dict):
+        return {}
+    summary = result.get("summary")
+    return summary if isinstance(summary, dict) else {}
+
+
+def export_text_verdict(rhwp: dict | None, pyhwp: dict | None) -> list[str]:
+    """export-text 헤드투헤드 문장. 키가 빠져도 터지지 않는다."""
+    lines: list[str] = []
+    if rhwp and rhwp.get("available"):
+        s = _summary_of(rhwp)
+        ok = s.get("ok", 0)
+        att = s.get("attempted", 0)
+        ms = s.get("medianMs")
+        ms_s = f"{ms}ms" if is_number(ms) else "n/a"
+        lines.append(
+            f"rhwp 는 export-text 에서 {ok}/{att} 파일을 처리했다"
+            f"(HWP+HWPX 혼합, 중앙값 {ms_s})."
+        )
+    if pyhwp and not pyhwp.get("available"):
+        reason = pyhwp.get("reason") or "실행 불가"
+        lines.append(f"pyhwp(hwp5txt)는 이 머신에서 실행하지 않았다({reason}).")
+        return lines
+    if not (pyhwp and pyhwp.get("available")):
+        return lines
+    ps = _summary_of(pyhwp)
+    by_ext = ps.get("byExt") if isinstance(ps.get("byExt"), dict) else {}
+    hwp_b = by_ext.get(".hwp") if isinstance(by_ext.get(".hwp"), dict) else {}
+    hwpx_b = by_ext.get(".hwpx") if isinstance(by_ext.get(".hwpx"), dict) else {}
+    lines.append(
+        f"pyhwp(hwp5txt)는 HWP5 {hwp_b.get('ok', 0)}/{hwp_b.get('attempted', 0)} 성공, "
+        f"HWPX {hwpx_b.get('ok', 0)}/{hwpx_b.get('attempted', 0)} 성공"
+        f"(ZIP 기반 HWPX 는 OLE 파서로 열 수 없음 — 구조적 한계)."
+    )
+    ov = pyhwp.get("overlapMs") if isinstance(pyhwp.get("overlapMs"), dict) else {}
+    p_ms = ov.get("tool")
+    r_ms = ov.get("ref")
+    cmp = speed_cmp(p_ms, r_ms)
+    if cmp == "tool_faster":
+        lines.append(
+            f"속도(동일 파일집합, 둘 다 연 HWP5): pyhwp 가 더 빨랐다"
+            f"(pyhwp {p_ms}ms vs rhwp {r_ms}ms 중앙값). rhwp 는 디버그 빌드이며 JSON "
+            f"봉투·출처 표지를 함께 낸다 — 릴리스 빌드로는 좁혀진다. 그래도 더 빠른 축은 "
+            f"그대로 적는다."
+        )
+    elif cmp == "ref_faster":
+        lines.append(
+            f"속도(동일 파일집합, 둘 다 연 HWP5): rhwp 가 더 빨랐다"
+            f"(rhwp {r_ms}ms vs pyhwp {p_ms}ms 중앙값) — 디버그 빌드임에도."
+        )
+    elif cmp == "tie":
+        lines.append(
+            f"속도(동일 파일집합, 둘 다 연 HWP5): 중앙값이 같았다"
+            f"(둘 다 {p_ms}ms)."
+        )
+    elif ov.get("n") == 0 or (p_ms is None and r_ms is None):
+        lines.append(
+            "속도: 두 도구가 모두 성공한 겹친 파일이 없어 "
+            "동일-집합 비교를 만들지 않았다."
+        )
+    fid = pyhwp.get("fidelityVsRhwp")
+    if is_number(fid):
+        lines.append(
+            f"충실도: 두 도구가 모두 연 HWP5 에서 pyhwp 문자수는 rhwp 대비 중앙값 {fid:.2f}× — "
+            f"pyhwp 는 표 셀 본문을 `<표>` 자리표로 대체해 본문을 덜 뽑는다"
+            f"(에이전트가 표 안 숫자를 읽어야 하면 치명적)."
+        )
+    return lines
+
+
+def soffice_verdict(soffice: dict | None) -> list[str]:
+    """LibreOffice 가용/불가 문장. 없으면 침묵."""
+    if not isinstance(soffice, dict):
+        return []
+    if not soffice.get("available"):
+        reason = soffice.get("reason") or "실행 불가"
+        return [f"LibreOffice(soffice)는 이 머신에서 실행하지 않았다({reason})."]
+    s = _summary_of(soffice)
+    ok = s.get("ok", 0)
+    att = s.get("attempted", 0)
+    return [
+        f"LibreOffice(soffice)는 export-text 에서 {ok}/{att} 성공"
+        f"(HWP5 임포트 필터 부재가 실패로 남는다)."
+    ]
+
+
+def width_verdict(tasks: dict) -> list[str]:
+    """rhwp 만 구조화 CLI 로 돈 과제 목록."""
+    rhwp_only = []
+    for name in ("info", "structure", "convert"):
+        tr = tasks.get(name) or {}
+        results = tr.get("results") if isinstance(tr, dict) else []
+        indexed = _result_index(results)
+        rhwp = indexed.get("rhwp")
+        others_avail = any(
+            item.get("available")
+            for item in indexed.values()
+            if item.get("tool") != "rhwp"
+        )
+        if rhwp and rhwp.get("available") and not others_avail:
+            rhwp_only.append(name)
+    if not rhwp_only:
+        return []
+    return [
+        "폭: " + ", ".join(rhwp_only) + " 과제는 rhwp 만 구조화 CLI 로 수행했다 — "
+        "대안들은 동일 형식 산출(메타 봉투·구조 트리·HWPX/markdown 변환)이 없어 n/a."
+    ]
+
+
+def capability_verdict(matrix: dict) -> str:
+    """매트릭스에서 rhwp 만 yes 인 능력을 문장으로. 하드코드 승패가 아니다."""
+    keys = exclusive_yes(matrix, "rhwp")
+    if not keys:
+        return "능력: 벤치한 대안과 겹치는 축만 남았다(능력 매트릭스 참조)."
+    labels = [capability_label(matrix, key) for key in keys]
+    return (
+        "능력: " + "·".join(labels)
+        + " 는 벤치한 대안 중 rhwp 만 yes 다(능력 매트릭스 참조)."
+    )
 
 
 def verdict_lines(payload: dict) -> list[str]:
     """측정 데이터에서 직접 유도한 정직한 평결 문장들. 순수.
 
     숫자는 payload 에서만 온다 — 손으로 쓴 승패 주장이 아니라 잰 값의 서술이다.
+    키가 빠진 불완전 payload 에서도 KeyError 를 내지 않는다.
     """
     lines: list[str] = []
-    tasks = {t["task"]: t for t in payload.get("tasks", [])}
-
-    # export-text 헤드-투-헤드: rhwp vs pyhwp
-    et = tasks.get("export-text", {})
-    res = {r["tool"]: r for r in et.get("results", [])}
-    rhwp = res.get("rhwp")
-    pyhwp = res.get("pyhwp")
-    if rhwp and rhwp.get("available"):
-        s = rhwp["summary"]
-        lines.append(
-            f"rhwp 는 export-text 에서 {s['ok']}/{s['attempted']} 파일을 처리했다"
-            f"(HWP+HWPX 혼합, 중앙값 {s['medianMs']}ms)."
-        )
-    if pyhwp and pyhwp.get("available"):
-        ps = pyhwp["summary"]
-        hwp_b = ps.get("byExt", {}).get(".hwp", {})
-        hwpx_b = ps.get("byExt", {}).get(".hwpx", {})
-        lines.append(
-            f"pyhwp(hwp5txt)는 HWP5 {hwp_b.get('ok', 0)}/{hwp_b.get('attempted', 0)} 성공, "
-            f"HWPX {hwpx_b.get('ok', 0)}/{hwpx_b.get('attempted', 0)} 성공"
-            f"(ZIP 기반 HWPX 는 OLE 파서로 열 수 없음 — 구조적 한계)."
-        )
-        # 속도 — 같은 파일집합(둘 다 성공한 HWP5)에서만 비교해야 공정하다.
-        ov = pyhwp.get("overlapMs") or {}
-        p_ms = ov.get("tool")
-        r_ms = ov.get("ref")
-        if r_ms is not None and p_ms is not None:
-            if p_ms < r_ms:
-                lines.append(
-                    f"속도(동일 파일집합, 둘 다 연 HWP5): pyhwp 가 더 빨랐다"
-                    f"(pyhwp {p_ms}ms vs rhwp {r_ms}ms 중앙값). rhwp 는 디버그 빌드이며 JSON "
-                    f"봉투·출처 표지를 함께 낸다 — 릴리스 빌드로는 좁혀진다. 그래도 더 빠른 축은 "
-                    f"그대로 적는다."
-                )
-            else:
-                lines.append(
-                    f"속도(동일 파일집합, 둘 다 연 HWP5): rhwp 가 더 빠르거나 동급이었다"
-                    f"(rhwp {r_ms}ms vs pyhwp {p_ms}ms 중앙값) — 디버그 빌드임에도."
-                )
-        fid = pyhwp.get("fidelityVsRhwp")
-        if fid is not None:
-            lines.append(
-                f"충실도: 두 도구가 모두 연 HWP5 에서 pyhwp 문자수는 rhwp 대비 중앙값 {fid:.2f}× — "
-                f"pyhwp 는 표 셀 본문을 `<표>` 자리표로 대체해 본문을 덜 뽑는다"
-                f"(에이전트가 표 안 숫자를 읽어야 하면 치명적)."
-            )
-
-    # 폭: rhwp 만 도는 과제
-    rhwp_only = []
-    for name in ("info", "structure", "convert"):
-        tr = tasks.get(name, {})
-        r = {x["tool"]: x for x in tr.get("results", [])}.get("rhwp")
-        others_avail = any(
-            x.get("available") for x in tr.get("results", []) if x["tool"] != "rhwp"
-        )
-        if r and r.get("available") and not others_avail:
-            rhwp_only.append(name)
-    if rhwp_only:
-        lines.append(
-            "폭: " + ", ".join(rhwp_only) + " 과제는 rhwp 만 구조화 CLI 로 수행했다 — "
-            "대안들은 동일 형식 산출(메타 봉투·구조 트리·HWPX/markdown 변환)이 없어 n/a."
-        )
-
-    # 능력 — rhwp 고유
-    lines.append(
-        "능력: MCP 서버·검증 가능 작업(replay/capsule)·단일 자립 바이너리·"
-        "메모리 안전(Rust)·JSON 봉투는 벤치한 대안 중 rhwp 만 갖췄다(능력 매트릭스 참조)."
-    )
+    tasks = {
+        t.get("task"): t
+        for t in payload.get("tasks", [])
+        if isinstance(t, dict) and t.get("task")
+    }
+    et = tasks.get("export-text") or {}
+    res = _result_index(et.get("results") if isinstance(et, dict) else [])
+    lines.extend(export_text_verdict(res.get("rhwp"), res.get("pyhwp")))
+    lines.extend(soffice_verdict(res.get("soffice")))
+    lines.extend(width_verdict(tasks))
+    matrix = payload.get("capabilityMatrix")
+    if not isinstance(matrix, dict):
+        matrix = capability_matrix()
+    lines.append(capability_verdict(matrix))
     return lines
+
+
+def refresh_verdict(payload: dict) -> dict:
+    """측정값에서 평결을 다시 유도해 붙인다. 손글 승패를 남기지 않는다."""
+    out = dict(payload)
+    out["verdict"] = verdict_lines(out)
+    return out
 
 
 # --------------------------------------------------------------------------
@@ -340,6 +676,9 @@ def render_report(payload: dict) -> str:
     # 환경
     out.append("## 실행 환경")
     out.append("")
+    kind = payload.get("kind") or REPORT_KIND
+    schema = payload.get("schemaVersion") or SCHEMA_VERSION
+    out.append(f"- 스키마: `{kind}` `{schema}`")
     out.append(f"- OS: `{env.get('os', '?')}`")
     out.append(f"- rhwp: `{env.get('rhwpVersion', '?')}` (`{env.get('rhwpProfile', '?')}` 빌드)")
     out.append(f"- Python: `{env.get('python', '?')}`")
@@ -365,28 +704,31 @@ def render_report(payload: dict) -> str:
         "충실도 = 두 도구가 모두 성공한 파일에서 `문자수 ÷ rhwp 문자수` 의 중앙값 "
         "(1.00× = 동일량, 낮을수록 본문을 덜 뽑음). rhwp 는 자기 자신이므로 기준(1.00×).")
     out.append("")
-    tools_order = payload.get("toolOrder", [])
-    header = "| 과제 | " + " | ".join(tools_order) + " |"
+    tools_order = payload.get("toolOrder") or list(DEFAULT_TOOL_ORDER)
+    header = "| 과제 | " + " | ".join(escape_md_cell(t) for t in tools_order) + " |"
     sep = "|---|" + "|".join(["---"] * len(tools_order)) + "|"
     out.append(header)
     out.append(sep)
     for task in payload.get("tasks", []):
-        row = {r["tool"]: r for r in task.get("results", [])}
+        if not isinstance(task, dict):
+            continue
+        row = _result_index(task.get("results"))
         cells = []
         for tool in tools_order:
             r = row.get(tool)
             if r is None:
                 cells.append("n/a")
                 continue
-            cells.append(
+            cells.append(escape_md_cell(
                 _fmt_cell(
                     r.get("available", False),
                     r.get("summary"),
                     r.get("fidelityVsRhwp"),
                     r.get("reason"),
                 )
-            )
-        out.append(f"| **{task['task']}** | " + " | ".join(cells) + " |")
+            ))
+        name = escape_md_cell(task.get("task") or "?")
+        out.append(f"| **{name}** | " + " | ".join(cells) + " |")
     out.append("")
     # 도구별 각주(형식 한계 등)
     notes = []
@@ -408,9 +750,11 @@ def render_report(payload: dict) -> str:
     out.append("| 도구 | " + " | ".join(c["label"] for c in cols) + " |")
     out.append("|---|" + "|".join(["---"] * len(cols)) + "|")
     glyph = {"yes": "O", "partial": "~", "no": "X"}
-    for r in matrix["rows"]:
+    for r in matrix.get("rows") or []:
+        if not isinstance(r, dict):
+            continue
         cells = [glyph.get(r.get(c["key"], "no"), "?") for c in cols]
-        out.append(f"| {r['tool']} | " + " | ".join(cells) + " |")
+        out.append(f"| {escape_md_cell(r.get('tool', '?'))} | " + " | ".join(cells) + " |")
     out.append("")
     out.append("범례: O = 지원 · ~ = 부분/우회 · X = 없음")
     out.append("")
@@ -472,6 +816,35 @@ def _rel(path: Path) -> str:
         return path.as_posix()
 
 
+def select_corpus_paths(paths, limit: int) -> list[str]:
+    """결정론적 코퍼스 선택. 순수 — 파일시스템을 보지 않는다.
+
+    POSIX 정규화 후 .hwp/.hwpx 만 취하고 형식별 정렬한다. limit>0 이면
+    형식별 앞 limit 개, limit<=0 이면 전부. 중복 경로는 첫 등장만.
+    """
+    hwp: list[str] = []
+    hwpx: list[str] = []
+    seen: set[str] = set()
+    for raw in paths:
+        rel = posix_rel(raw)
+        if rel in seen:
+            continue
+        seen.add(rel)
+        ext = ext_of(rel)
+        if ext not in CORPUS_EXTS:
+            continue
+        if ext == ".hwp":
+            hwp.append(rel)
+        else:
+            hwpx.append(rel)
+    hwp.sort()
+    hwpx.sort()
+    if limit > 0:
+        hwp = hwp[:limit]
+        hwpx = hwpx[:limit]
+    return hwp + hwpx
+
+
 def discover_corpus(samples_dir: str, limit: int) -> list[str]:
     """samples/ 에서 HWP·HWPX 를 결정론적으로 선택(정렬 후 형식별 limit).
 
@@ -479,12 +852,8 @@ def discover_corpus(samples_dir: str, limit: int) -> list[str]:
     상대경로로 동작하고, 커밋되는 JSON 에 머신별 절대경로가 새지 않는다.
     """
     base = Path(samples_dir)
-    hwp = sorted(_rel(p) for p in base.glob("*.hwp"))
-    hwpx = sorted(_rel(p) for p in base.glob("*.hwpx"))
-    if limit > 0:
-        hwp = hwp[:limit]
-        hwpx = hwpx[:limit]
-    return hwp + hwpx
+    found = [_rel(p) for p in list(base.glob("*.hwp")) + list(base.glob("*.hwpx"))]
+    return select_corpus_paths(found, limit)
 
 
 def _run(cmd: list[str], cwd: str, timeout: int) -> tuple[bool, float, str, str]:
@@ -580,130 +949,789 @@ def bench_rhwp_convert(rhwp: str, files: list[str], cwd: str, timeout: int) -> l
     return runs
 
 
-def probe(path: str | None, names: list[str]) -> str | None:
-    """명시 경로 또는 PATH 에서 실행파일을 찾는다. 없으면 None."""
+def resolve_tool(path: str | None, names: list[str], *, exists=None, which=None):
+    """명시 경로 또는 PATH 에서 실행파일을 찾는다. 없으면 None.
+
+    exists/which 를 주입하면 파일시스템 없이 시험할 수 있다.
+    """
+    exists = exists or (lambda candidate: Path(candidate).exists())
+    which = which or shutil.which
     if path:
-        p = Path(path)
-        if p.exists():
-            return str(p)
-        found = shutil.which(path)
-        if found:
-            return found
-        return None
-    for n in names:
-        found = shutil.which(n)
+        if exists(path):
+            return str(path)
+        found = which(path)
+        return found
+    for name in names:
+        found = which(name)
         if found:
             return found
     return None
 
 
+def probe(path: str | None, names: list[str]) -> str | None:
+    """명시 경로 또는 PATH 에서 실행파일을 찾는다. 없으면 None."""
+    return resolve_tool(path, names)
+
+
+def rhwp_profile_from_path(path: str) -> str:
+    """경로 세그먼트로 release/debug 를 가른다. 'prerelease' 에 속지 않는다."""
+    parts = [p.lower() for p in posix_rel(path).split("/") if p]
+    if "release" in parts:
+        return "release"
+    if "debug" in parts:
+        return "debug"
+    return "debug"
+
+
+def write_text_lf(path, text: str) -> None:
+    """UTF-8 · BOM 없음 · Unix LF. 커밋 산출물이 플랫폼 개행에 물들지 않게 한다."""
+    data = text if text.endswith("\n") else text + "\n"
+    Path(path).write_bytes(data.encode("utf-8"))
+
+
+def dump_payload_json(payload: dict) -> str:
+    return json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+
+
 # --------------------------------------------------------------------------
 # 오케스트레이션
 # --------------------------------------------------------------------------
+def unavailable_result(tool: str, reason: str) -> dict:
+    """못 돌린 도구 칸. 숫자 필드를 넣지 않는다."""
+    return {"tool": tool, "available": False, "reason": reason}
+
+
+def available_result(tool: str, runs: list[dict], *, fidelity=None,
+                     overlap=None, note: str | None = None) -> dict:
+    rec = {
+        "tool": tool,
+        "available": True,
+        "summary": summarize_runs(runs),
+        "fidelityVsRhwp": fidelity,
+        "runs": runs,
+    }
+    if overlap is not None:
+        rec["overlapMs"] = overlap
+    if note:
+        rec["note"] = note
+    return rec
+
+
+def invented_metrics(result: dict) -> bool:
+    """비가용 칸이 숫자·runs 를 몰래 실었는지. 정직성 가드."""
+    if not isinstance(result, dict) or result.get("available"):
+        return False
+    if isinstance(result.get("summary"), dict):
+        return True
+    if is_number(result.get("fidelityVsRhwp")):
+        return True
+    if result.get("overlapMs"):
+        return True
+    if result.get("runs"):
+        return True
+    return False
+
+
+def assemble_env(*, os_name, python, rhwp_version, rhwp_profile, files, tools) -> dict:
+    n_hwp = sum(1 for f in files if ext_of(f) == ".hwp")
+    n_hwpx = sum(1 for f in files if ext_of(f) == ".hwpx")
+    return {
+        "os": os_name,
+        "python": python,
+        "rhwpVersion": rhwp_version,
+        "rhwpProfile": rhwp_profile,
+        "corpus": {"dir": "samples", "total": len(files), "hwp": n_hwp, "hwpx": n_hwpx},
+        "tools": tools,
+    }
+
+
+def stamp_report_contract(payload: dict) -> dict:
+    """kind/schemaVersion 이 비면 계약 상수로 채운다. 옛 JSON 재렌더용."""
+    out = dict(payload)
+    if not out.get("kind"):
+        out["kind"] = REPORT_KIND
+    if not out.get("schemaVersion"):
+        out["schemaVersion"] = SCHEMA_VERSION
+    return out
+
+
+def assemble_payload(*, env, tasks, tool_order=None, generated_at=None, matrix=None) -> dict:
+    """측정 조각을 보고 봉투로 묶는다. 순수 — 평결은 숫자에서만 다시 유도한다."""
+    payload = {
+        "kind": REPORT_KIND,
+        "schemaVersion": SCHEMA_VERSION,
+        "generatedAt": generated_at,
+        "toolOrder": list(tool_order or DEFAULT_TOOL_ORDER),
+        "env": env,
+        "tasks": list(tasks),
+        "capabilityMatrix": matrix if matrix is not None else capability_matrix(),
+    }
+    return refresh_verdict(payload)
+
+
+def load_report_payload(raw: str):
+    """저장된 JSON 텍스트 → (payload, issues). 깨지면 (None, issues)."""
+    if not isinstance(raw, str) or not raw.strip():
+        return None, ["빈 JSON"]
+    try:
+        doc = json.loads(raw)
+    except (json.JSONDecodeError, TypeError, ValueError) as exc:
+        return None, [f"JSON 파싱 실패: {exc}"]
+    issues = payload_shape_issues(doc)
+    if issues:
+        return None, issues
+    return refresh_verdict(stamp_report_contract(doc)), []
+
+
+def payload_shape_issues(payload) -> list[str]:
+    """보고 봉투의 최소 형태. 옛 JSON(kind 없음)도 허용한다."""
+    if not isinstance(payload, dict):
+        return ["payload 가 객체가 아니다"]
+    issues: list[str] = []
+    if "tasks" not in payload:
+        issues.append("tasks 누락")
+    elif not isinstance(payload.get("tasks"), list):
+        issues.append("tasks 가 배열이 아니다")
+    if payload.get("kind") not in (None, REPORT_KIND):
+        issues.append(f"kind={payload.get('kind')!r} 가 {REPORT_KIND} 가 아니다")
+    if payload.get("schemaVersion") not in (None, SCHEMA_VERSION):
+        issues.append(f"schemaVersion={payload.get('schemaVersion')!r}")
+    return issues
+
+
+# --------------------------------------------------------------------------
+# 명시 오류 — 깨진 입력은 숫자를 지어내지 않고 코드·경로와 함께 멈춘다.
+# --------------------------------------------------------------------------
+class BenchError(Exception):
+    """경쟁 벤치 입력/형태 오류. 종료 코드와 기계가 읽는 code 를 가진다."""
+
+    def __init__(self, code: str, message: str, *, exit_code: int = 2,
+                 path=None, details=None):
+        super().__init__(message)
+        self.code = str(code)
+        self.message = str(message)
+        self.exit_code = int(exit_code)
+        self.path = None if path is None else str(path)
+        self.details = {} if details is None else dict(details)
+
+    def to_dict(self) -> dict:
+        rec = {
+            "ok": False,
+            "kind": "gymCompetitiveBenchError",
+            "code": self.code,
+            "message": self.message,
+            "exitCode": self.exit_code,
+        }
+        if self.path:
+            rec["path"] = posix_rel(self.path)
+        if self.details:
+            rec["details"] = dict(self.details)
+        return rec
+
+
+class MissingFileError(BenchError):
+    def __init__(self, path, message=None, **kwargs):
+        super().__init__(
+            ERR_MISSING_FILE,
+            message or f"파일이 없다: {path}",
+            path=path,
+            **kwargs,
+        )
+
+
+class BadJsonError(BenchError):
+    def __init__(self, path, message=None, **kwargs):
+        super().__init__(
+            ERR_BAD_JSON,
+            message or f"JSON 이 깨졌다: {path}",
+            path=path,
+            **kwargs,
+        )
+
+
+class EncodingError(BenchError):
+    def __init__(self, path, message=None, **kwargs):
+        super().__init__(
+            ERR_ENCODING,
+            message or f"UTF-8 이 아니다: {path}",
+            path=path,
+            **kwargs,
+        )
+
+
+class EmptyScorecardError(BenchError):
+    def __init__(self, path=None, message=None, **kwargs):
+        super().__init__(
+            ERR_EMPTY_SCORECARD,
+            message or "스코어카드가 비었다",
+            path=path,
+            **kwargs,
+        )
+
+
+class UnknownAgentError(BenchError):
+    def __init__(self, agent, message=None, **kwargs):
+        details = dict(kwargs.pop("details", None) or {})
+        details.setdefault("agent", agent)
+        super().__init__(
+            ERR_UNKNOWN_AGENT,
+            message or f"알 수 없는 에이전트: {agent}",
+            details=details,
+            **kwargs,
+        )
+
+
+class PayloadShapeError(BenchError):
+    def __init__(self, issues, path=None, message=None, **kwargs):
+        listed = list(issues or [])
+        details = dict(kwargs.pop("details", None) or {})
+        details["issues"] = listed
+        super().__init__(
+            ERR_PAYLOAD_SHAPE,
+            message or ("payload 형태 오류: " + "; ".join(listed) or "payload 형태 오류"),
+            path=path,
+            details=details,
+            **kwargs,
+        )
+
+
+def format_bench_error(err: BenchError) -> str:
+    """stderr 한 줄. 코드가 앞에 있어 기계가 grep 할 수 있다."""
+    loc = f" path={err.path}" if err.path else ""
+    return f"오류[{err.code}]: {err.message}{loc}"
+
+
+def error_exit_code(err) -> int:
+    if isinstance(err, BenchError):
+        return err.exit_code
+    return 1
+
+
+def _agent_id_re():
+    return re.compile(r"^[A-Za-z][A-Za-z0-9._-]{0,63}$")
+
+
+def display_path(path) -> str:
+    if path is None:
+        return ""
+    try:
+        return posix_rel(str(path))
+    except Exception:
+        return str(path)
+
+
+def utf8_decode(data, *, path=None) -> str:
+    """바이트 → 문자열. BOM 은 벗기고, 깨진 바이트는 바꿔 넣지 않고 명시 오류다."""
+    if data is None:
+        raise EncodingError(path, "디코드할 바이트가 없다")
+    if isinstance(data, str):
+        return data
+    if not isinstance(data, (bytes, bytearray)):
+        raise EncodingError(path, f"바이트가 아니다: {type(data).__name__}")
+    raw = bytes(data)
+    if raw.startswith(b"\xef\xbb\xbf"):
+        raw = raw[3:]
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise EncodingError(
+            path,
+            f"UTF-8 디코드 실패(offset {exc.start}): {exc.reason}",
+            details={"start": exc.start, "end": exc.end, "reason": exc.reason},
+        ) from exc
+
+
+def read_bytes(path) -> bytes:
+    """존재·권한 오류를 MissingFileError 로 접는다. 빈 파일은 허용한다."""
+    if path is None or str(path).strip() == "":
+        raise MissingFileError(path, "경로가 비었다")
+    target = Path(path)
+    if not target.exists():
+        raise MissingFileError(path, f"파일이 없다: {display_path(path)}")
+    if target.is_dir():
+        raise MissingFileError(path, f"파일 아니라 디렉터리다: {display_path(path)}")
+    try:
+        return target.read_bytes()
+    except OSError as exc:
+        raise MissingFileError(
+            path,
+            f"파일을 읽을 수 없다: {display_path(path)} ({exc})",
+            details={"errno": getattr(exc, "errno", None)},
+        ) from exc
+
+
+def read_text_utf8(path) -> str:
+    return utf8_decode(read_bytes(path), path=path)
+
+
+def parse_json_text(text, *, path=None):
+    """JSON 텍스트 → 값. 빈 문자열·잘린 객체·트레일링 쉼표는 BadJsonError."""
+    if text is None:
+        raise BadJsonError(path, "JSON 텍스트가 없다")
+    if not isinstance(text, str):
+        raise BadJsonError(path, f"JSON 텍스트가 문자열이 아니다: {type(text).__name__}")
+    stripped = text.strip()
+    if stripped == "":
+        raise BadJsonError(path, "JSON 이 빈 문자열이다")
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError as exc:
+        raise BadJsonError(
+            path,
+            f"JSON 파싱 실패(line {exc.lineno} col {exc.colno}): {exc.msg}",
+            details={"lineno": exc.lineno, "colno": exc.colno, "msg": exc.msg},
+        ) from exc
+
+
+def require_json_object(value, *, path=None) -> dict:
+    if not isinstance(value, dict):
+        raise BadJsonError(
+            path,
+            f"JSON 최상위가 객체가 아니다: {type(value).__name__}",
+            details={"jsonType": type(value).__name__},
+        )
+    return value
+
+
+def load_json_object(path) -> dict:
+    """경로 → UTF-8 JSON 객체. 파일 없음·인코딩·깨진 JSON·배열 최상위를 가른다."""
+    return require_json_object(parse_json_text(read_text_utf8(path), path=path), path=path)
+
+
+def load_report_payload(path) -> dict:
+    """--from-json 입력. 봉투 형태가 아니면 PayloadShapeError."""
+    payload = load_json_object(path)
+    issues = payload_shape_issues(payload)
+    if issues:
+        raise PayloadShapeError(issues, path=path)
+    return payload
+
+
+def agent_id_issues(name) -> list[str]:
+    """에이전트 식별자 문법. 비어 있음·예약어·금지 문자를 나열한다."""
+    issues: list[str] = []
+    if name is None:
+        return ["agent 가 없다"]
+    if not isinstance(name, str):
+        return [f"agent 가 문자열이 아니다: {type(name).__name__}"]
+    stripped = name.strip()
+    if stripped == "":
+        issues.append("agent 가 비었다")
+        return issues
+    if stripped.lower() in RESERVED_AGENT_IDS:
+        issues.append(f"agent '{stripped}' 는 예약어다")
+    if any(ch in stripped for ch in ("/", "\\", ":", "*", "?", "<", ">", "|")):
+        issues.append(f"agent '{stripped}' 에 경로 구분 문자가 있다")
+    if " " in stripped or "\t" in stripped or "\n" in stripped:
+        issues.append(f"agent '{stripped}' 에 공백이 있다")
+    if not _agent_id_re().match(stripped):
+        issues.append(
+            f"agent '{stripped}' 는 [A-Za-z][A-Za-z0-9._-]{{0,63}} 이 아니다"
+        )
+    return issues
+
+
+def normalize_agent_id(name) -> str:
+    issues = agent_id_issues(name)
+    if issues:
+        text = "; ".join(issues)
+        if name is None or (isinstance(name, str) and name.strip() == ""):
+            raise UnknownAgentError(name, text or "agent 가 비었다")
+        if isinstance(name, str) and name.strip().lower() in RESERVED_AGENT_IDS:
+            raise UnknownAgentError(name, text)
+        raise UnknownAgentError(name, text)
+    return str(name).strip()
+
+
+def discover_known_agents(*roots) -> list[str]:
+    """베이스라인·리더보드 스코어카드 폴더에서 알려진 에이전트 이름을 모은다.
+
+    폴더 이름 `claude-fable-5-0000` 은 epoch 접미를 떼어 `claude-fable-5` 도
+    인정한다. 스코어카드 JSON 의 `agent` 필드가 있으면 그것도 넣는다.
+    파일시스템을 보므로 순수 함수가 아니다 — 시험은 임시 폴더를 주입한다.
+    """
+    found: set[str] = set()
+    for root in roots:
+        if not root:
+            continue
+        base = Path(root)
+        if not base.is_dir():
+            continue
+        for child in sorted(base.iterdir()):
+            if not child.is_dir():
+                continue
+            found.add(child.name)
+            stripped = re.sub(r"-\d{4}$", "", child.name)
+            if stripped:
+                found.add(stripped)
+            card = child / "scorecard.json"
+            if card.is_file():
+                try:
+                    doc = load_json_object(card)
+                except BenchError:
+                    continue
+                agent = doc.get("agent")
+                if isinstance(agent, str) and agent.strip():
+                    found.add(agent.strip())
+    return sorted(found)
+
+
+def default_known_agent_roots() -> list[str]:
+    return [
+        os.path.join(GYM_ROOT, "baselines"),
+        os.path.join(GYM_ROOT, "leaderboard", "scorecards"),
+        os.path.join(GYM_ROOT, "submissions"),
+    ]
+
+
+def require_known_agent(name, known) -> str:
+    """식별자 문법을 통과한 뒤, 알려진 집합에 없으면 UnknownAgentError."""
+    agent = normalize_agent_id(name)
+    roster = [str(item) for item in (known or []) if item]
+    if not roster:
+        raise UnknownAgentError(
+            agent,
+            f"알려진 에이전트 목록이 비어 있어 '{agent}' 를 대조할 수 없다",
+            details={"agent": agent, "known": []},
+        )
+    if agent not in roster:
+        raise UnknownAgentError(
+            agent,
+            f"알 수 없는 에이전트: {agent} (알려진 {len(roster)}명 밖에 없음)",
+            details={"agent": agent, "known": roster},
+        )
+    return agent
+
+
+def scorecard_kind_issues(doc) -> list[str]:
+    issues: list[str] = []
+    if not isinstance(doc, dict):
+        return ["스코어카드가 객체가 아니다"]
+    kind = doc.get("kind")
+    if kind not in (None, SCORECARD_KIND):
+        issues.append(f"kind={kind!r} 가 {SCORECARD_KIND} 가 아니다")
+    version = doc.get("schemaVersion")
+    if version not in (None, *SCORECARD_SCHEMA_VERSIONS):
+        issues.append(f"schemaVersion={version!r} 는 {sorted(SCORECARD_SCHEMA_VERSIONS)} 밖이다")
+    return issues
+
+
+def scorecard_emptiness_issues(doc) -> list[str]:
+    """측정이 하나도 없으면 빈 스코어카드다. 형태는 맞아도 숫자가 없다."""
+    if not isinstance(doc, dict):
+        return ["스코어카드가 객체가 아니다"]
+    issues: list[str] = []
+    if not doc:
+        return ["스코어카드 객체가 비었다"]
+    packs = doc.get("packs")
+    total = doc.get("total")
+    if packs is None and total is None:
+        issues.append("packs 와 total 이 모두 없다")
+        return issues
+    if packs is not None and not isinstance(packs, list):
+        issues.append("packs 가 배열이 아니다")
+        packs = None
+    if isinstance(packs, list) and len(packs) == 0:
+        issues.append("packs 가 빈 배열이다")
+    if total is not None and not isinstance(total, dict):
+        issues.append("total 이 객체가 아니다")
+        total = None
+    if isinstance(total, dict):
+        missing = [key for key in SCORECARD_TOTAL_KEYS if key not in total]
+        if missing:
+            issues.append("total 키 누락: " + ", ".join(missing))
+        scored = total.get("packsScored")
+        if scored == 0:
+            issues.append("packsScored 가 0 이다")
+        if scored is None and "packsScored" in total:
+            issues.append("packsScored 가 null 이다")
+    if isinstance(packs, list) and packs:
+        scored_packs = [
+            p for p in packs
+            if isinstance(p, dict) and p.get("status") not in ("unavailable", None)
+            and (p.get("taskCount") or 0) > 0
+        ]
+        if not scored_packs and all(
+            isinstance(p, dict) and p.get("status") == "unavailable" for p in packs
+        ):
+            issues.append("채점된 pack 이 없고 전부 unavailable 이다")
+        if all(isinstance(p, dict) and (p.get("taskCount") or 0) == 0 for p in packs):
+            issues.append("모든 pack 의 taskCount 가 0 이다")
+    return issues
+
+
+def load_scorecard(path, *, expected_agent=None, known_agents=None) -> dict:
+    """gym scorecard.json 을 읽고 빈 카드·알 수 없는 에이전트를 명시 오류로 가른다.
+
+    expected_agent 가 있으면 카드의 agent 와 문법·소속을 대조한다.
+    known_agents 가 있으면 카드/기대 에이전트가 그 집합에 있어야 한다.
+    """
+    doc = load_json_object(path)
+    kind_issues = scorecard_kind_issues(doc)
+    if kind_issues:
+        raise PayloadShapeError(kind_issues, path=path, message="스코어카드 형태 오류: " + "; ".join(kind_issues))
+    empty = scorecard_emptiness_issues(doc)
+    if empty:
+        raise EmptyScorecardError(path, "빈 스코어카드: " + "; ".join(empty), details={"issues": empty})
+    card_agent = doc.get("agent")
+    if card_agent is not None:
+        normalize_agent_id(card_agent)
+    if expected_agent is not None:
+        want = normalize_agent_id(expected_agent)
+        if card_agent is None:
+            raise UnknownAgentError(
+                want,
+                f"스코어카드에 agent 필드가 없어 '{want}' 와 대조할 수 없다",
+                path=path,
+                details={"expected": want},
+            )
+        have = normalize_agent_id(card_agent)
+        if have != want:
+            raise UnknownAgentError(
+                have,
+                f"스코어카드 agent '{have}' 가 기대한 '{want}' 가 아니다",
+                path=path,
+                details={"expected": want, "actual": have},
+            )
+    check = expected_agent if expected_agent is not None else card_agent
+    if known_agents is not None and check is not None:
+        require_known_agent(check, known_agents)
+    return doc
+
+
+def scorecard_summary(doc: dict) -> dict:
+    """리포트에 붙일 짧은 요약. 카드가 비었으면 부르기 전에 load_scorecard 가 막는다."""
+    total = doc.get("total") if isinstance(doc.get("total"), dict) else {}
+    packs = doc.get("packs") if isinstance(doc.get("packs"), list) else []
+    return {
+        "kind": doc.get("kind") or SCORECARD_KIND,
+        "schemaVersion": doc.get("schemaVersion"),
+        "agent": doc.get("agent"),
+        "score": total.get("score"),
+        "max": total.get("max"),
+        "packsScored": total.get("packsScored"),
+        "packCount": len(packs),
+        "packIds": [p.get("id") for p in packs if isinstance(p, dict) and p.get("id")],
+    }
+
+
+def attach_scorecard(payload: dict, card: dict) -> dict:
+    """측정 봉투에 스코어카드 요약을 붙인다. 평결 숫자는 바꾸지 않는다."""
+    out = dict(payload)
+    out["scorecard"] = scorecard_summary(card)
+    return out
+
+
+def run_record_issues(run) -> list[str]:
+    """한 run 레코드의 최소 형태."""
+    if not isinstance(run, dict):
+        return ["run 이 객체가 아니다"]
+    issues: list[str] = []
+    if not run.get("file"):
+        issues.append("file 이 없다")
+    if "ok" not in run:
+        issues.append("ok 가 없다")
+    ms = run.get("ms")
+    if ms is not None and not is_number(ms):
+        issues.append(f"ms 가 숫자가 아니다: {ms!r}")
+    chars = run.get("chars")
+    if chars is not None and not is_number(chars):
+        issues.append(f"chars 가 숫자가 아니다: {chars!r}")
+    return issues
+
+
+def task_result_issues(result) -> list[str]:
+    if not isinstance(result, dict):
+        return ["result 가 객체가 아니다"]
+    issues: list[str] = []
+    if not result.get("tool"):
+        issues.append("tool 이 없다")
+    if "available" not in result:
+        issues.append("available 이 없다")
+    if result.get("available") is False and invented_metrics(result):
+        issues.append(f"{result.get('tool')}: 비가용인데 숫자를 실었다")
+    if result.get("available") is True:
+        summary = result.get("summary")
+        if not isinstance(summary, dict):
+            issues.append(f"{result.get('tool')}: available 인데 summary 가 없다")
+        runs = result.get("runs")
+        if runs is not None:
+            if not isinstance(runs, list):
+                issues.append(f"{result.get('tool')}: runs 가 배열이 아니다")
+            else:
+                for idx, run in enumerate(runs):
+                    for issue in run_record_issues(run):
+                        issues.append(f"{result.get('tool')}.runs[{idx}]: {issue}")
+    return issues
+
+
+def payload_honesty_issues(payload) -> list[str]:
+    """정직성 가드 — 비가용 칸의 숫자, 빈 tasks, 깨진 run."""
+    if not isinstance(payload, dict):
+        return ["payload 가 객체가 아니다"]
+    issues = payload_shape_issues(payload)
+    tasks = payload.get("tasks")
+    if isinstance(tasks, list):
+        if len(tasks) == 0:
+            issues.append("tasks 가 빈 배열이다")
+        for task in tasks:
+            if not isinstance(task, dict):
+                issues.append("task 가 객체가 아니다")
+                continue
+            if not task.get("task"):
+                issues.append("task 이름이 없다")
+            results = task.get("results")
+            if results is None:
+                continue
+            if not isinstance(results, list):
+                issues.append(f"{task.get('task')}: results 가 배열이 아니다")
+                continue
+            for result in results:
+                issues.extend(task_result_issues(result))
+    matrix = payload.get("capabilityMatrix")
+    if matrix is not None:
+        issues.extend(validate_capability_matrix(matrix))
+    return issues
+
+
+def require_honest_payload(payload, *, path=None) -> dict:
+    issues = payload_honesty_issues(payload)
+    if issues:
+        raise PayloadShapeError(issues, path=path)
+    return payload
+
+
+def parse_rhwp_info_fields(stdout):
+    """rhwp `info --json` 에서 비교 가능한 스칼라만 뽑는다. 실패 시 None."""
+    doc = _json_object(stdout)
+    if doc is None:
+        return None
+    body = unwrap_json_envelope(doc)
+    if not isinstance(body, dict):
+        return None
+    out = {}
+    for key in ("format", "pageCount", "sectionCount", "paraCount"):
+        if key in body:
+            out[key] = body.get(key)
+    return out or None
+
+
+def parse_rhwp_structure_nodes(stdout):
+    """export-structure --json 의 노드 수. 목록이 없으면 None."""
+    doc = _json_object(stdout)
+    if doc is None:
+        return None
+    body = unwrap_json_envelope(doc)
+    if not isinstance(body, dict):
+        return None
+    if is_number(body.get("nodeCount")):
+        return int(body["nodeCount"])
+    for key in ("nodes", "sections", "children"):
+        value = body.get(key)
+        if isinstance(value, list):
+            return len(value)
+    return None
+
+
+def classify_cli_failure(message: str) -> str:
+    """서브프로세스 stderr 를 오류 코드로 근사. 숫자를 지어내지 않는다."""
+    text = (message or "").lower()
+    if "timeout" in text:
+        return "timeout"
+    if "not found" in text or "cannot find" in text or "없는 파일" in text:
+        return "missing_input"
+    if "permission" in text or "액세스가 거부" in text:
+        return "permission"
+    if "utf-8" in text or "codec" in text or "decode" in text:
+        return ERR_ENCODING
+    if "json" in text:
+        return ERR_BAD_JSON
+    return "runtime"
+
+
 def build_payload(rhwp: str, pyhwp: str | None, soffice: str | None,
                   files: list[str], cwd: str, timeout: int,
                   rhwp_version: str, rhwp_profile: str) -> dict:
     """모든 과제를 돌리고(가용한 도구만) payload 를 조립한다."""
-    n_hwp = sum(1 for f in files if _ext(f) == ".hwp")
-    n_hwpx = sum(1 for f in files if _ext(f) == ".hwpx")
-
     # --- export-text: 실 헤드-투-헤드 ---
     rhwp_text_runs = bench_rhwp_text(rhwp, files, cwd, timeout)
-    text_results = [{
-        "tool": "rhwp", "available": True,
-        "summary": summarize_runs(rhwp_text_runs), "fidelityVsRhwp": 1.0,
-        "runs": rhwp_text_runs,
-    }]
+    text_results = [
+        available_result("rhwp", rhwp_text_runs, fidelity=1.0),
+    ]
     if pyhwp:
         py_runs = bench_pyhwp_text(pyhwp, files, cwd, timeout)
-        p_ms, r_ms = overlap_median_ms(py_runs, rhwp_text_runs)
-        text_results.append({
-            "tool": "pyhwp", "available": True,
-            "summary": summarize_runs(py_runs),
-            "fidelityVsRhwp": fidelity_vs_ref(py_runs, rhwp_text_runs),
-            "overlapMs": {"tool": p_ms, "ref": r_ms},
-            "note": "HWPX(ZIP)는 OLE 파서라 열지 못함; 표 셀 본문을 `<표>` 자리표로 대체.",
-            "runs": py_runs,
-        })
+        text_results.append(available_result(
+            "pyhwp", py_runs,
+            fidelity=fidelity_vs_ref(py_runs, rhwp_text_runs),
+            overlap=overlap_timing(py_runs, rhwp_text_runs),
+            note="HWPX(ZIP)는 OLE 파서라 열지 못함; 표 셀 본문을 `<표>` 자리표로 대체.",
+        ))
     else:
-        text_results.append({
-            "tool": "pyhwp", "available": False,
-            "reason": "이 머신에서 실행 불가(휴면 패키지; import 에 six 등 수동 보정 필요)",
-        })
+        text_results.append(unavailable_result(
+            "pyhwp",
+            "이 머신에서 실행 불가(휴면 패키지; import 에 six 등 수동 보정 필요)",
+        ))
     text_results.append(_soffice_text_result(soffice, files, cwd, timeout, rhwp_text_runs))
-    text_results.append({
-        "tool": "hwplib", "available": False,
-        "reason": "Java 라이브러리, CLI 아님(래퍼 클래스+빌드 필요)",
-    })
+    text_results.append(unavailable_result(
+        "hwplib", "Java 라이브러리, CLI 아님(래퍼 클래스+빌드 필요)",
+    ))
 
     # --- info / structure / convert: rhwp 는 실행, 대안은 정직한 n/a ---
     info_runs = bench_rhwp_info(rhwp, files, cwd, timeout)
-    info_results = [{
-        "tool": "rhwp", "available": True,
-        "summary": summarize_runs(info_runs), "fidelityVsRhwp": None, "runs": info_runs,
-    }]
+    info_results = [available_result("rhwp", info_runs)]
     struct_runs = bench_rhwp_structure(rhwp, files, cwd, timeout)
-    struct_results = [{
-        "tool": "rhwp", "available": True,
-        "summary": summarize_runs(struct_runs), "fidelityVsRhwp": None, "runs": struct_runs,
-    }]
+    struct_results = [available_result("rhwp", struct_runs)]
     convert_runs = bench_rhwp_convert(rhwp, files, cwd, timeout)
-    convert_results = [{
-        "tool": "rhwp", "available": True,
-        "summary": summarize_runs(convert_runs), "fidelityVsRhwp": None,
-        "note": "HWP→markdown(에이전트-대면 변환); export-hwpx 로 HWPX 변환도 지원.",
-        "runs": convert_runs,
-    }]
-    na_pyhwp_meta = {
-        "tool": "pyhwp", "available": False,
-        "reason": "동일 형식 산출 없음(hwp5proc 는 저수준 레코드 덤프; 메타 봉투 아님)",
-    }
-    na_soffice_meta = {
-        "tool": "soffice", "available": False,
-        "reason": _soffice_reason(soffice) + "; 구조화 메타/구조 출력 없음",
-    }
-    na_hwplib_meta = {
-        "tool": "hwplib", "available": False, "reason": "Java 라이브러리, CLI 아님",
-    }
+    convert_results = [available_result(
+        "rhwp", convert_runs,
+        note="HWP→markdown(에이전트-대면 변환); export-hwpx 로 HWPX 변환도 지원.",
+    )]
+    na_meta = [
+        unavailable_result(
+            "pyhwp",
+            "동일 형식 산출 없음(hwp5proc 는 저수준 레코드 덤프; 메타 봉투 아님)",
+        ),
+        unavailable_result(
+            "soffice",
+            _soffice_reason(soffice) + "; 구조화 메타/구조 출력 없음",
+        ),
+        unavailable_result("hwplib", "Java 라이브러리, CLI 아님"),
+    ]
     for results in (info_results, struct_results, convert_results):
-        results.extend([dict(na_pyhwp_meta), dict(na_soffice_meta), dict(na_hwplib_meta)])
+        results.extend(dict(item) for item in na_meta)
 
-    payload = {
-        "schemaVersion": "1.0",
-        "generatedAt": time.strftime("%Y-%m-%dT%H:%M:%S"),
-        "toolOrder": ["rhwp", "pyhwp", "soffice", "hwplib"],
-        "env": {
-            "os": platform.platform(),
-            "python": platform.python_version(),
-            "rhwpVersion": rhwp_version,
-            "rhwpProfile": rhwp_profile,
-            "corpus": {"dir": "samples", "total": len(files), "hwp": n_hwp, "hwpx": n_hwpx},
-            "tools": {
-                "rhwp": {"available": True, "detail": f"{rhwp_version} ({rhwp_profile})"},
-                "pyhwp": (
-                    {"available": True, "detail": "hwp5txt (pyhwp 0.1b15) — venv, six 수동설치"}
-                    if pyhwp else
-                    {"available": False, "detail": "미설치/실행 불가"}
-                ),
-                "soffice": (
-                    {"available": True, "detail": "LibreOffice headless"}
-                    if soffice else
-                    {"available": False, "detail": "미설치(이 머신)"}
-                ),
-                "hwplib": {"available": False, "detail": "Java 라이브러리 — CLI 아님(미실행)"},
-                "hancomSdk": {"available": False, "detail": "Windows 전용 독점 SDK(미실행)"},
-            },
+    env = assemble_env(
+        os_name=platform.platform(),
+        python=platform.python_version(),
+        rhwp_version=rhwp_version,
+        rhwp_profile=rhwp_profile,
+        files=files,
+        tools={
+            "rhwp": {"available": True, "detail": f"{rhwp_version} ({rhwp_profile})"},
+            "pyhwp": (
+                {"available": True, "detail": "hwp5txt (pyhwp 0.1b15) — venv, six 수동설치"}
+                if pyhwp else
+                {"available": False, "detail": "미설치/실행 불가"}
+            ),
+            "soffice": (
+                {"available": True, "detail": "LibreOffice headless"}
+                if soffice else
+                {"available": False, "detail": "미설치(이 머신)"}
+            ),
+            "hwplib": {"available": False, "detail": "Java 라이브러리 — CLI 아님(미실행)"},
+            "hancomSdk": {"available": False, "detail": "Windows 전용 독점 SDK(미실행)"},
         },
-        "tasks": [
+    )
+    return assemble_payload(
+        env=env,
+        tasks=[
             {"task": "export-text", "results": text_results},
             {"task": "info", "results": info_results},
             {"task": "structure", "results": struct_results},
             {"task": "convert", "results": convert_results},
         ],
-        "capabilityMatrix": capability_matrix(),
-    }
-    payload["verdict"] = verdict_lines(payload)
-    return payload
+        generated_at=time.strftime("%Y-%m-%dT%H:%M:%S"),
+    )
 
 
 def _soffice_reason(soffice: str | None) -> str:
@@ -712,17 +1740,17 @@ def _soffice_reason(soffice: str | None) -> str:
 
 def _soffice_text_result(soffice, files, cwd, timeout, rhwp_text_runs) -> dict:
     if not soffice:
-        return {
-            "tool": "soffice", "available": False,
-            "reason": "미설치(이 머신); 설치돼도 HWP5 임포트 필터 없어 현대 .hwp 못 엶",
-        }
+        return unavailable_result(
+            "soffice",
+            "미설치(이 머신); 설치돼도 HWP5 임포트 필터 없어 현대 .hwp 못 엶",
+        )
     runs = bench_soffice_text(soffice, files, cwd, timeout)
-    return {
-        "tool": "soffice", "available": True,
-        "summary": summarize_runs(runs),
-        "fidelityVsRhwp": fidelity_vs_ref(runs, rhwp_text_runs),
-        "note": "LibreOffice 는 HWP5 임포트 필터가 없어 현대 .hwp 는 대부분 실패한다.",
-    }
+    return available_result(
+        "soffice", runs,
+        fidelity=fidelity_vs_ref(runs, rhwp_text_runs),
+        overlap=overlap_timing(runs, rhwp_text_runs),
+        note="LibreOffice 는 HWP5 임포트 필터가 없어 현대 .hwp 는 대부분 실패한다.",
+    )
 
 
 def _rhwp_version(rhwp: str, cwd: str) -> str:
@@ -754,13 +1782,24 @@ def main(argv=None) -> int:
 
     # 렌더-온리: 저장된 payload 에서 리포트만 재생성한다(벤치 불요, 결정론적).
     if args.from_json:
-        payload = json.loads(Path(args.from_json).read_text(encoding="utf-8"))
+        raw = Path(args.from_json).read_text(encoding="utf-8")
+        payload, issues = load_report_payload(raw)
+        if payload is None:
+            print("오류: --from-json payload 가 깨졌다: " + "; ".join(issues),
+                  file=sys.stderr)
+            return 2
+        if args.out_json:
+            Path(args.out_json).parent.mkdir(parents=True, exist_ok=True)
+            write_text_lf(args.out_json, dump_payload_json(payload))
+            print(f"[bench] JSON 재스탬프 → {args.out_json}", file=sys.stderr)
+        if args.json:
+            print(dump_payload_json(payload), end="")
         md = render_report(payload)
         if args.out_md:
             Path(args.out_md).parent.mkdir(parents=True, exist_ok=True)
-            Path(args.out_md).write_text(md, encoding="utf-8")
+            write_text_lf(args.out_md, md)
             print(f"[bench] 리포트 재렌더 → {args.out_md}", file=sys.stderr)
-        else:
+        elif not args.json:
             print(md)
         return 0
 
@@ -779,7 +1818,7 @@ def main(argv=None) -> int:
         print("오류: rhwp 바이너리를 찾을 수 없습니다. `cargo build --bin rhwp` 후 --rhwp 로 지정하세요.",
               file=sys.stderr)
         return 2
-    rhwp_profile = "release" if "release" in rhwp.replace("\\", "/") else "debug"
+    rhwp_profile = rhwp_profile_from_path(rhwp)
 
     pyhwp = probe(args.pyhwp, ["hwp5txt"])
     soffice = probe(args.soffice, ["soffice", "libreoffice"])
@@ -797,16 +1836,14 @@ def main(argv=None) -> int:
 
     if args.out_json:
         Path(args.out_json).parent.mkdir(parents=True, exist_ok=True)
-        Path(args.out_json).write_text(
-            json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
-        )
+        write_text_lf(args.out_json, dump_payload_json(payload))
         print(f"[bench] JSON → {args.out_json}", file=sys.stderr)
     if args.out_md:
         Path(args.out_md).parent.mkdir(parents=True, exist_ok=True)
-        Path(args.out_md).write_text(render_report(payload), encoding="utf-8")
+        write_text_lf(args.out_md, render_report(payload))
         print(f"[bench] 리포트 → {args.out_md}", file=sys.stderr)
     if args.json or (not args.out_json and not args.out_md):
-        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        print(dump_payload_json(payload), end="")
 
     return 0
 

--- a/gym/tools/competitive_bench.py
+++ b/gym/tools/competitive_bench.py
@@ -71,6 +71,33 @@ _BODY_KEYS = (
     "sections", "paraCount",
 )
 
+# 명시 오류 코드. 문서·시험·예외 클래스가 같은 표다. 숫자를 지어내지 않는다.
+ERR_MISSING_FILE = "missing-file"
+ERR_BAD_JSON = "bad-json"
+ERR_ENCODING = "encoding"
+ERR_EMPTY_SCORECARD = "empty-scorecard"
+ERR_UNKNOWN_AGENT = "unknown-agent"
+ERR_PAYLOAD_SHAPE = "payload-shape"
+ERROR_CODES = (
+    ERR_MISSING_FILE,
+    ERR_BAD_JSON,
+    ERR_ENCODING,
+    ERR_EMPTY_SCORECARD,
+    ERR_UNKNOWN_AGENT,
+    ERR_PAYLOAD_SHAPE,
+)
+ERROR_KIND = "gymCompetitiveBenchError"
+DEFAULT_ERROR_EXIT = 2
+# 도구 이름·집계 예약어. 에이전트 식별자로 쓰면 경로/표가 섞인다.
+RESERVED_AGENT_IDS = frozenset({
+    "all", "any", "none", "null", "self", "default", "unknown",
+    "rhwp", "pyhwp", "soffice", "hwplib", "hancom", "hancomsdk",
+    "baseline", "ref", "reference",
+})
+SCORECARD_KIND = "gymScorecard"
+SCORECARD_SCHEMA_VERSIONS = ("1.0", "2.0")
+SCORECARD_TOTAL_KEYS = ("score", "max", "packsScored")
+
 # --------------------------------------------------------------------------
 # 능력 매트릭스 — 문서화·검증 가능한 사실만. 값 = "yes" | "partial" | "no".
 # --------------------------------------------------------------------------
@@ -733,8 +760,13 @@ def render_report(payload: dict) -> str:
     # 도구별 각주(형식 한계 등)
     notes = []
     for task in payload.get("tasks", []):
-        for r in task.get("results", []):
-            if r.get("note"):
+        if not isinstance(task, dict):
+            continue
+        results = task.get("results")
+        if not isinstance(results, list):
+            continue
+        for r in results:
+            if isinstance(r, dict) and r.get("note"):
                 notes.append(f"- **{r['tool']} / {task['task']}**: {r['note']}")
     if notes:
         out.append("주석:")
@@ -1201,6 +1233,24 @@ def format_bench_error(err: BenchError) -> str:
     return f"오류[{err.code}]: {err.message}{loc}"
 
 
+def error_catalog() -> list[dict]:
+    """명시 오류 표. 문서·시험이 같은 목록을 본다. 순수."""
+    return [
+        {"code": ERR_MISSING_FILE, "exit": DEFAULT_ERROR_EXIT,
+         "when": "경로가 비었거나 없거나 디렉터리이거나 읽을 수 없다"},
+        {"code": ERR_BAD_JSON, "exit": DEFAULT_ERROR_EXIT,
+         "when": "JSON 텍스트가 없거나 비었거나 잘렸거나 최상위가 객체가 아니다"},
+        {"code": ERR_ENCODING, "exit": DEFAULT_ERROR_EXIT,
+         "when": "바이트가 UTF-8 이 아니거나 디코드할 값이 없다"},
+        {"code": ERR_EMPTY_SCORECARD, "exit": DEFAULT_ERROR_EXIT,
+         "when": "스코어카드에 측정(packs/total)이 없다"},
+        {"code": ERR_UNKNOWN_AGENT, "exit": DEFAULT_ERROR_EXIT,
+         "when": "에이전트 식별자가 비었거나 예약어이거나 알려진 집합 밖이다"},
+        {"code": ERR_PAYLOAD_SHAPE, "exit": DEFAULT_ERROR_EXIT,
+         "when": "보고 봉투 kind/tasks 형태가 깨졌거나 비가용 칸에 숫자를 실었다"},
+    ]
+
+
 def error_exit_code(err) -> int:
     if isinstance(err, BenchError):
         return err.exit_code
@@ -1298,8 +1348,12 @@ def load_json_object(path) -> dict:
     return require_json_object(parse_json_text(read_text_utf8(path), path=path), path=path)
 
 
-def load_report_payload(path) -> dict:
-    """--from-json 입력. 봉투 형태가 아니면 PayloadShapeError."""
+def load_report_from_path(path) -> dict:
+    """경로에서 보고 봉투를 읽는다. 형태가 아니면 PayloadShapeError.
+
+    문자열 JSON 재렌더(`load_report_payload(raw)`)와 이름을 갈라 둔다.
+    CLI 플래그는 바꾸지 않는다. `--from-json` 은 기존처럼 문자열 경로를 쓴다.
+    """
     payload = load_json_object(path)
     issues = payload_shape_issues(payload)
     if issues:

--- a/mydocs/working/gym_competitive_bench.md
+++ b/mydocs/working/gym_competitive_bench.md
@@ -1,0 +1,183 @@
+---
+kind: working
+status: active
+canonical: mydocs/working/gym_competitive_bench.md
+last_verified: 2026-08-18
+---
+
+# gym competitive_bench — 예외 경로와 순수 함수 보강
+
+Issue: #5229
+PR: https://github.com/edwardkim/rhwp/pull/5239
+Branch: `feat/gym-competitive-bench-pure`
+Date: 2026-08-18
+
+## 1. 결론
+
+`gym/tools/competitive_bench.py` 의 집계·파싱·평결·보고는 그대로 두고, 깨진
+입력을 숫자로 위장하지 않는 명시 예외 가족과 그 시험을 보탰다. CLI 플래그
+이름은 바꾸지 않았다. 기존 89건 집계 시험을 지우지 않았다.
+
+이 가지는 새 PR 을 열지 않는다. 같은 브랜치에 이어서 밀어 #5239 를 키운다.
+
+검증:
+
+- `python -m unittest scripts.tests.test_gym_competitive_bench scripts.tests.test_gym_competitive_bench_exceptions scripts.tests.test_gym_competitive_bench_extra -v`
+- `python gym/tools/audit.py`
+- `cargo fmt --all` 은 실행하지 않음 (Python/문서만, 사용자 지시)
+
+## 2. 배경
+
+원 PR(#5239)은 `summarize_runs` · `fidelity_vs_ref` · `overlap_median_ms` ·
+`parse_rhwp_*` · `validate_capability_matrix` · `verdict_lines` 를 순수
+함수로 가르고, `--from-json` 재렌더에 `kind=gymCompetitiveBench` 를 찍었다.
+대비 `upstream/devel` 삽입은 약 2078줄, 변경 파일은 도구와 시험 둘뿐이었다.
+
+그 상태의 빈틈:
+
+1. 파일 없음·깨진 JSON·UTF-8 아님을 한 덩어리 문자열로만 말했다. 코드가
+   없어 기계가 갈라 읽을 수 없었다.
+2. 스코어카드·에이전트 식별을 붙일 자리가 있어도, 빈 카드와 예약어
+   (`rhwp`, `soffice`)를 거절하는 표가 시험에 없었다.
+3. `load_report_payload` 가 문자열 재렌더와 경로 로더로 두 번 정의되면 뒤가
+   앞을 덮어 `--from-json` 시험이 깨진다. 이름을 갈라야 했다.
+4. 정직성 가드(`invented_metrics`)는 칸 하나에만 있었고, tasks 전체·run
+   레코드·매트릭스 구멍을 한 번에 나열하는 입구가 시험되지 않았다.
+5. info/structure 보조 파서(`parse_rhwp_info_fields`,
+   `parse_rhwp_structure_nodes`)와 stderr 근사(`classify_cli_failure`)는
+   코드만 있고 경우가 없었다.
+6. 한국어 규약 문서가 없어 예외 표가 코드에만 있었다.
+
+분류를 늘리거나 CLI 를 새로 만들면 기존 재렌더 계약이 깨진다. 그래서 플래그는
+그대로 두고, 예외 코드와 순수 입구만 얹었다.
+
+## 3. 한 일
+
+### 3.1 도구
+
+`gym/tools/competitive_bench.py`
+
+- `ERR_*` / `ERROR_CODES` / `error_catalog()` — 문서·시험이 같은 표.
+- `RESERVED_AGENT_IDS` · `SCORECARD_KIND` · `SCORECARD_SCHEMA_VERSIONS` —
+  라이브 카드 `gymScorecard` 1.0/2.0 과 맞춘다.
+- `BenchError` 가족 — missing-file, bad-json, encoding, empty-scorecard,
+  unknown-agent, payload-shape. `to_dict()` 는 path 를 POSIX 로.
+- `utf8_decode` — BOM 은 벗기고, 깨진 바이트는 바꿔 넣지 않는다.
+- `load_report_from_path` — 경로 로더. 문자열 `load_report_payload` 를
+  덮지 않는다.
+- `agent_id_issues` / `normalize_agent_id` / `require_known_agent` /
+  `discover_known_agents`.
+- `scorecard_*` / `load_scorecard` / `attach_scorecard` — 평결 숫자는
+  바꾸지 않는다.
+- `payload_honesty_issues` / `require_honest_payload`.
+- `classify_cli_failure` — timeout/missing/permission/encoding/json/runtime.
+
+### 3.2 시험
+
+- 기존 `test_gym_competitive_bench.py` 는 유지. 집계·평결·`--from-json`
+  89건을 지우지 않았다.
+- `test_gym_competitive_bench_exceptions.py` — 예외 코드, UTF-8/JSON 읽기,
+  에이전트·스코어카드, 정직 가드, stderr 근사.
+- `test_gym_competitive_bench_extra.py` — 보조 파서, 충실도 쌍, 평결 가지,
+  코퍼스 선택, 렌더 칸.
+
+### 3.3 문서
+
+- `gym/docs/competitive_bench.md` — 정본 규약. 한국어.
+- 이 파일 — 작업 기록.
+
+## 4. 이름을 가른 이유
+
+같은 모듈에 `load_report_payload(raw)` 와 `load_report_payload(path)` 가
+있으면 Python 은 뒤만 남긴다. `main --from-json` 은 파일 내용을 문자열로
+읽어 앞 서명을 부른다. 뒤가 덮으면 문자열을 경로로 열어 `missing-file` 이
+나고, 기존 재렌더 시험이 전부 붉어진다.
+
+그래서 경로 쪽만 `load_report_from_path` 로 바꿨다. CLI 사용법은 같다.
+
+## 5. 예외 표 — 작업 메모
+
+기본 종료는 2 다. 인자·형태·I/O 를 한 묶음으로 둔 이유: 이 도구의 라이브
+진입은 이미 rhwp 없음·코퍼스 없음에 2 를 쓴다. 예외 가족을 1/3/4 로
+쪼개면 `--from-json` 과 라이브가 다른 표를 갖게 된다. 코드 문자열로 갈라
+읽고, 숫자는 기존 CLI 와 맞춘다.
+
+`BenchError` 가 아닌 예외는 1 이다. 카탈로그 밖을 성공으로 위장하지 않는다.
+
+예약어에 도구 이름(`rhwp`, `pyhwp`, `soffice`, `hwplib`)을 넣은 이유:
+스코어카드 agent 칸에 도구 이름을 쓰면 결과표 열과 에이전트 행이 같은
+문자열을 공유한다. 리더보드가 그 키로 조인하면 측정이 섞인다.
+
+빈 스코어카드를 형태 오류가 아니라 `empty-scorecard` 로 둔 이유: kind 와
+total 키는 맞는데 측정이 없는 카드다. 고치는 자리가 JSON 문법이 아니라
+채점 실행이다.
+
+## 6. 순수 함수를 더 고정한 이유
+
+원 시험은 행복한 경로와 대표 가지를 잘 막는다. 비어 있던 쪽:
+
+- `parse_rhwp_info_fields` 는 extra 키를 버려야 한다. 버리면 비교 스칼라가
+  도구마다 달라져 충실도처럼 쓰일 수 있다.
+- `parse_rhwp_structure_nodes` 는 `nodeCount` 가 bool 이면 None 이다.
+  `True==1` 로 노드 1개를 만들지 않는다.
+- `fidelity_pairs` 는 기준 0 과 실패 기준을 쌍에서 뺀다. 중앙값 시험만
+  있으면 쌍 목록이 새도 모른다.
+- `invented_metrics` 는 빈 `runs` 와 값이 있는 `runs` 를 가른다. 빈 배열은
+  숫자가 아니다.
+- `width_verdict` 는 다른 도구가 가용하면 침묵한다. "rhwp 만" 을 남발하지
+  않는다.
+
+이 경우들을 지우지 않고 파일 둘로 나눠 기존 89건 옆에 붙였다.
+
+## 7. 라이브 스윕과의 경계
+
+이 작업은 바이너리를 부르지 않는다. `bench_rhwp_text` 실호출은 기존
+라이브 경로 그대로다. 여기서 다시 soffice 를 돌리면 CI 가 설치를 기다리게
+되고, 순수 시험 기둥이 깨진다.
+
+목을 쓰는 자리:
+
+- `resolve_tool(..., exists=, which=)`
+- 임시 폴더의 dummy `.hwp`/`.hwpx` (`discover_corpus`)
+- `--from-json` 재렌더 (이미 있는 플래그)
+
+## 8. 하지 않은 것
+
+- 새 CLI 플래그, 새 pack, 새 라이브 과제를 만들지 않았다.
+- 기존 집계 시험을 지우거나 줄이지 않았다.
+- packs·checks·coverage·robustness·profiles·README 를 건드리지 않았다.
+- Rust 를 포맷하거나 clippy 를 돌리지 않았다.
+- 새 PR 을 열지 않았다.
+
+## 9. 재현
+
+```bash
+python -m unittest scripts.tests.test_gym_competitive_bench \
+    scripts.tests.test_gym_competitive_bench_exceptions \
+    scripts.tests.test_gym_competitive_bench_extra -v
+python gym/tools/audit.py
+git diff --shortstat upstream/devel
+```
+
+SIZE GATE: upstream/devel 대비 insertions >= 3000.
+
+## 10. 남은 위험
+
+1. `discover_corpus` 한 단계 glob 은 그대로다. 재귀로 바꾸면 과거 JSON 과
+   코퍼스 크기가 달라진다.
+2. 충실도는 문자수 비율이다. 동량·다른 순서는 1.0× 로 남을 수 있다.
+3. 스코어카드 2.0 의 `packsUnavailable` 은 요약에 안 올린다. 벤치 평결과
+   채점 점수를 섞지 않으려는 경계다.
+4. 예외 종료 코드를 2 로 통일했다. 나중에 인자/I/O 를 가르려면 CLI 와
+   문서와 시험을 한 번에 바꿔야 한다.
+
+## 11. 커밋 범위
+
+- `gym/tools/competitive_bench.py` (상수·이름 분리. 기존 CLI 유지)
+- `scripts/tests/test_gym_competitive_bench.py` (기존 유지, 삭제 없음)
+- `scripts/tests/test_gym_competitive_bench_exceptions.py` (신규)
+- `scripts/tests/test_gym_competitive_bench_extra.py` (신규)
+- `gym/docs/competitive_bench.md` (신규)
+- `mydocs/working/gym_competitive_bench.md` (신규)
+
+생성기 임시 파일은 커밋하지 않는다.

--- a/scripts/tests/test_gym_competitive_bench.py
+++ b/scripts/tests/test_gym_competitive_bench.py
@@ -12,8 +12,11 @@ gym 툴-테스트 패턴(importlib 로 모듈 적재 후 순수 함수만 시험
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
+import tempfile
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -58,16 +61,52 @@ class SummarizeTests(unittest.TestCase):
     def test_by_ext_breakdown_records_format_support(self):
         m = load()
         s = m.summarize_runs(self._runs())
-        self.assertEqual(s["byExt"][".hwp"], {"attempted": 2, "ok": 2})
+        self.assertEqual(s["byExt"][".hwp"], {"attempted": 2, "ok": 2, "fail": 0})
         # HWPX 는 시도했으나 실패 — pyhwp 형식 한계가 데이터로 남는다.
-        self.assertEqual(s["byExt"][".hwpx"], {"attempted": 1, "ok": 0})
+        self.assertEqual(s["byExt"][".hwpx"], {"attempted": 1, "ok": 0, "fail": 1})
+        self.assertEqual(s["fail"], 1)
 
     def test_empty_runs_safe(self):
         m = load()
         s = m.summarize_runs([])
         self.assertEqual(s["attempted"], 0)
+        self.assertEqual(s["fail"], 0)
         self.assertIsNone(s["successRate"])
         self.assertIsNone(s["medianMs"])
+        self.assertEqual(s["fail"], 0)
+        self.assertEqual(s["byExt"], {})
+
+    def test_failed_run_chars_do_not_enter_median(self):
+        m = load()
+        s = m.summarize_runs([
+            {"file": "a.hwp", "ok": True, "ms": 10, "chars": 10},
+            {"file": "b.hwp", "ok": False, "ms": 1, "chars": 99999},
+        ])
+        self.assertEqual(s["medianChars"], 10)
+        self.assertEqual(s["medianMs"], 10.0)
+
+    def test_missing_ext_inferred_from_file(self):
+        m = load()
+        s = m.summarize_runs([
+            {"file": "samples/doc.HWPX", "ok": True, "ms": 4, "chars": 1},
+        ])
+        self.assertIn(".hwpx", s["byExt"])
+        self.assertEqual(s["byExt"][".hwpx"]["ok"], 1)
+
+    def test_zero_chars_is_a_real_measurement(self):
+        m = load()
+        s = m.summarize_runs([
+            {"file": "empty.hwp", "ext": ".hwp", "ok": True, "ms": 3, "chars": 0},
+        ])
+        self.assertEqual(s["medianChars"], 0)
+
+    def test_bool_is_not_a_timing(self):
+        m = load()
+        s = m.summarize_runs([
+            {"file": "a.hwp", "ext": ".hwp", "ok": True, "ms": True, "chars": False},
+        ])
+        self.assertIsNone(s["medianMs"])
+        self.assertIsNone(s["medianChars"])
 
 
 class FidelityTests(unittest.TestCase):
@@ -101,6 +140,26 @@ class FidelityTests(unittest.TestCase):
         ]
         self.assertEqual(m.fidelity_vs_ref(tool, ref), 0.5)
 
+    def test_zero_chars_is_not_treated_as_missing(self):
+        m = load()
+        ref = [{"file": "a", "ok": True, "chars": 100}]
+        tool = [{"file": "a", "ok": True, "chars": 0}]
+        self.assertEqual(m.fidelity_vs_ref(tool, ref), 0.0)
+        self.assertEqual(m.fidelity_stats(tool, ref)["n"], 1)
+
+    def test_zero_base_does_not_invent_ratio(self):
+        m = load()
+        ref = [{"file": "a", "ok": True, "chars": 0}]
+        tool = [{"file": "a", "ok": True, "chars": 10}]
+        self.assertIsNone(m.fidelity_vs_ref(tool, ref))
+        self.assertEqual(m.fidelity_stats(tool, ref), {"n": 0, "median": None})
+
+    def test_bool_chars_are_not_counts(self):
+        m = load()
+        ref = [{"file": "a", "ok": True, "chars": True}]
+        tool = [{"file": "a", "ok": True, "chars": True}]
+        self.assertIsNone(m.fidelity_vs_ref(tool, ref))
+
 
 class OverlapMedianTests(unittest.TestCase):
     def test_overlap_median_uses_shared_ok_files_only(self):
@@ -130,6 +189,42 @@ class OverlapMedianTests(unittest.TestCase):
             (None, None),
         )
 
+    def test_zero_ms_is_a_real_measurement(self):
+        m = load()
+        t_ms, r_ms = m.overlap_median_ms(
+            [{"file": "a", "ok": True, "ms": 0.0}],
+            [{"file": "a", "ok": True, "ms": 0.0}],
+        )
+        self.assertEqual((t_ms, r_ms), (0.0, 0.0))
+
+    def test_overlap_timing_reports_n(self):
+        m = load()
+        stats = m.overlap_timing(
+            [
+                {"file": "a", "ok": True, "ms": 10},
+                {"file": "b", "ok": True, "ms": 20},
+                {"file": "c", "ok": False, "ms": 1},
+            ],
+            [
+                {"file": "a", "ok": True, "ms": 30},
+                {"file": "b", "ok": True, "ms": 40},
+                {"file": "c", "ok": True, "ms": 50},
+            ],
+        )
+        self.assertEqual(stats["n"], 2)
+        self.assertEqual(stats["tool"], 15.0)
+        self.assertEqual(stats["ref"], 35.0)
+
+    def test_missing_ref_ms_is_not_overlap(self):
+        m = load()
+        self.assertEqual(
+            m.overlap_median_ms(
+                [{"file": "a", "ok": True, "ms": 10}],
+                [{"file": "a", "ok": True, "ms": None}],
+            ),
+            (None, None),
+        )
+
 
 class RhwpParseTests(unittest.TestCase):
     def test_sums_page_texts(self):
@@ -141,6 +236,51 @@ class RhwpParseTests(unittest.TestCase):
         m = load()
         self.assertIsNone(m.parse_rhwp_text_chars("not json"))
         self.assertIsNone(m.parse_rhwp_text_chars(json.dumps({"nope": 1})))
+        self.assertIsNone(m.parse_rhwp_text_chars(None))
+        self.assertIsNone(m.parse_rhwp_text_chars(json.dumps([1, 2, 3])))
+
+    def test_unwraps_data_envelope(self):
+        m = load()
+        env = json.dumps({"ok": True, "data": {"pages": [{"text": "가나"}, {"text": "다"}]}})
+        self.assertEqual(m.parse_rhwp_text_chars(env), 3)
+
+    def test_batch_text_field(self):
+        m = load()
+        env = json.dumps({"schemaVersion": "1.0", "source": "a.hwp", "text": "한글본문"})
+        self.assertEqual(m.parse_rhwp_text_chars(env), 4)
+
+    def test_non_string_page_text_is_skipped_not_crashed(self):
+        m = load()
+        env = json.dumps({"pages": [{"text": None}, {"text": 12}, {"text": "가"}, "x"]})
+        self.assertEqual(m.parse_rhwp_text_chars(env), 1)
+
+    def test_empty_pages_is_zero_not_none(self):
+        m = load()
+        self.assertEqual(m.parse_rhwp_text_chars(json.dumps({"pages": []})), 0)
+
+    def test_bytes_stdout(self):
+        m = load()
+        raw = json.dumps({"pages": [{"text": "ab"}]}).encode("utf-8")
+        self.assertEqual(m.parse_rhwp_text_chars(raw), 2)
+
+    def test_info_envelope_and_wrapper(self):
+        m = load()
+        raw = json.dumps({
+            "schemaVersion": "1.0", "format": "hwp5",
+            "pageCount": 6, "sections": 1, "paraCount": 40,
+        })
+        self.assertEqual(m.parse_rhwp_info(raw)["pageCount"], 6)
+        wrapped = json.dumps({"data": {"format": "hwpx", "pageCount": 2.0}})
+        self.assertEqual(m.parse_rhwp_info(wrapped)["format"], "hwpx")
+        self.assertIsNone(m.parse_rhwp_info(json.dumps({"pages": [{"text": "x"}]})))
+
+    def test_structure_envelope(self):
+        m = load()
+        raw = json.dumps({"mode": "outline", "nodeCount": 3, "structure": {"children": []}})
+        parsed = m.parse_rhwp_structure(raw)
+        self.assertEqual(parsed["nodeCount"], 3)
+        self.assertTrue(parsed["hasStructure"])
+        self.assertIsNone(m.parse_rhwp_structure(json.dumps({"ok": True})))
 
 
 class CapabilityMatrixTests(unittest.TestCase):
@@ -165,6 +305,44 @@ class CapabilityMatrixTests(unittest.TestCase):
         matrix = m.capability_matrix()
         hancom = next(r for r in matrix["rows"] if r["tool"] == "Hancom SDK")
         self.assertEqual(hancom["crossPlatform"], "no")
+
+    def test_live_matrix_has_no_validation_issues(self):
+        m = load()
+        self.assertEqual(m.validate_capability_matrix(), [])
+        self.assertEqual(m.validate_capability_matrix(m.capability_matrix()), [])
+
+    def test_validation_flags_missing_and_bad_values(self):
+        m = load()
+        broken = {
+            "columns": [{"key": "mcp", "label": "MCP"}],
+            "rows": [
+                {"tool": "rhwp", "mcp": "yes"},
+                {"tool": "rhwp", "mcp": "maybe"},
+                {"tool": "alt"},
+            ],
+        }
+        issues = m.validate_capability_matrix(broken)
+        self.assertTrue(any("중복" in i for i in issues))
+        self.assertTrue(any("maybe" in i for i in issues))
+        self.assertTrue(any("alt" in i and "누락" in i for i in issues))
+
+    def test_exclusive_yes_is_only_rhwp_for_agent_surface(self):
+        m = load()
+        matrix = m.capability_matrix()
+        excl = m.exclusive_yes(matrix, "rhwp")
+        for key in ("mcp", "verifiable", "singleBinary", "memSafe", "agentCli"):
+            self.assertIn(key, excl)
+        self.assertNotIn("edit", excl)
+        self.assertNotIn("render", excl)
+        self.assertNotIn("crossPlatform", excl)
+        self.assertEqual(m.exclusive_yes(matrix, "pyhwp (hwp5txt)"), [])
+
+    def test_returned_rows_are_copies(self):
+        m = load()
+        a = m.capability_matrix()
+        a["rows"][0]["mcp"] = "no"
+        b = m.capability_matrix()
+        self.assertEqual(b["rows"][0]["mcp"], "yes")
 
 
 class HonestDegradationTests(unittest.TestCase):
@@ -287,6 +465,627 @@ class VerdictDerivationTests(unittest.TestCase):
         self.assertTrue("더 빨" in text or "빠른" in text)
         # HWPX 0/2 한계도 진술.
         self.assertIn("HWPX", text)
+
+    def test_empty_payload_does_not_raise(self):
+        m = load()
+        lines = m.verdict_lines({})
+        self.assertTrue(any("능력" in line for line in lines))
+
+    def test_tie_speed_is_not_a_win(self):
+        m = load()
+        payload = {
+            "tasks": [
+                {"task": "export-text", "results": [
+                    {"tool": "rhwp", "available": True,
+                     "summary": {"attempted": 1, "ok": 1, "medianMs": 8.0}},
+                    {"tool": "pyhwp", "available": True,
+                     "summary": {"attempted": 1, "ok": 1, "medianMs": 8.0,
+                                 "byExt": {".hwp": {"attempted": 1, "ok": 1}}},
+                     "overlapMs": {"tool": 8.0, "ref": 8.0}},
+                ]},
+            ],
+        }
+        text = " ".join(m.verdict_lines(payload))
+        self.assertIn("같", text)
+        self.assertNotIn("더 빨", text)
+
+    def test_unavailable_pyhwp_is_stated(self):
+        m = load()
+        payload = {
+            "tasks": [
+                {"task": "export-text", "results": [
+                    {"tool": "rhwp", "available": True,
+                     "summary": {"attempted": 1, "ok": 1, "medianMs": 10}},
+                    {"tool": "pyhwp", "available": False, "reason": "미설치"},
+                ]},
+            ],
+        }
+        text = " ".join(m.verdict_lines(payload))
+        self.assertIn("실행하지 않았다", text)
+        self.assertIn("미설치", text)
+
+    def test_capability_verdict_comes_from_matrix(self):
+        m = load()
+        text = " ".join(m.verdict_lines({"capabilityMatrix": m.capability_matrix()}))
+        self.assertIn("MCP", text)
+        self.assertIn("rhwp 만", text)
+
+    def test_refresh_verdict_overwrites_handwritten_claim(self):
+        m = load()
+        payload = {
+            "tasks": [
+                {"task": "export-text", "results": [
+                    {"tool": "rhwp", "available": True,
+                     "summary": {"attempted": 2, "ok": 2, "medianMs": 10}},
+                ]},
+            ],
+            "verdict": ["손으로 쓴 승패"],
+        }
+        refreshed = m.refresh_verdict(payload)
+        self.assertNotIn("손으로 쓴 승패", refreshed["verdict"])
+        self.assertTrue(any("2/2" in line for line in refreshed["verdict"]))
+
+
+class CorpusSelectTests(unittest.TestCase):
+    def test_per_ext_limit_and_sort(self):
+        m = load()
+        paths = [
+            "samples/b.hwp",
+            "samples/a.hwpx",
+            "samples/z.txt",
+            "samples/a.hwp",
+            "samples/b.hwpx",
+            "samples/c.hwp",
+        ]
+        picked = m.select_corpus_paths(paths, 2)
+        self.assertEqual(picked, [
+            "samples/a.hwp", "samples/b.hwp",
+            "samples/a.hwpx", "samples/b.hwpx",
+        ])
+
+    def test_limit_zero_means_all_hwp_hwpx(self):
+        m = load()
+        paths = ["z.hwp", "a.hwpx", "skip.doc"]
+        self.assertEqual(m.select_corpus_paths(paths, 0), ["z.hwp", "a.hwpx"])
+
+    def test_backslash_and_duplicates_collapse(self):
+        m = load()
+        paths = [r"samples\a.hwp", "samples/a.hwp", "samples/a.HWP"]
+        # POSIX 정규화 후 같은 문자열만 중복. 대소문자가 다른 경로는 별개다.
+        picked = m.select_corpus_paths(paths, 0)
+        self.assertEqual(picked.count("samples/a.hwp"), 1)
+        self.assertIn("samples/a.HWP", picked)
+        self.assertEqual(len(picked), 2)
+
+    def test_negative_limit_is_all(self):
+        m = load()
+        self.assertEqual(
+            m.select_corpus_paths(["b.hwp", "a.hwp"], -1),
+            ["a.hwp", "b.hwp"],
+        )
+
+
+class ResolveToolTests(unittest.TestCase):
+    def test_explicit_path_wins_when_exists(self):
+        m = load()
+        found = m.resolve_tool(
+            "target/debug/rhwp", ["rhwp"],
+            exists=lambda p: p == "target/debug/rhwp",
+            which=lambda _n: None,
+        )
+        self.assertEqual(found, "target/debug/rhwp")
+
+    def test_explicit_falls_back_to_which(self):
+        m = load()
+        found = m.resolve_tool(
+            "rhwp", ["rhwp"],
+            exists=lambda _p: False,
+            which=lambda n: "/bin/rhwp" if n == "rhwp" else None,
+        )
+        self.assertEqual(found, "/bin/rhwp")
+
+    def test_missing_is_none(self):
+        m = load()
+        self.assertIsNone(m.resolve_tool(
+            None, ["hwp5txt", "soffice"],
+            exists=lambda _p: False,
+            which=lambda _n: None,
+        ))
+
+    def test_profile_from_path_uses_segment(self):
+        m = load()
+        self.assertEqual(m.rhwp_profile_from_path(r"C:\x\target\release\rhwp.exe"), "release")
+        self.assertEqual(m.rhwp_profile_from_path("target/debug/rhwp"), "debug")
+        self.assertEqual(m.rhwp_profile_from_path("target/prerelease/rhwp"), "debug")
+
+
+class AssemblePayloadTests(unittest.TestCase):
+    def test_kind_schema_and_derived_verdict(self):
+        m = load()
+        rhwp_runs = [
+            {"file": "a.hwp", "ext": ".hwp", "ok": True, "ms": 10, "chars": 100},
+            {"file": "b.hwpx", "ext": ".hwpx", "ok": True, "ms": 20, "chars": 80},
+        ]
+        py_runs = [
+            {"file": "a.hwp", "ext": ".hwp", "ok": True, "ms": 4, "chars": 70},
+            {"file": "b.hwpx", "ext": ".hwpx", "ok": False, "ms": 1, "chars": None},
+        ]
+        env = m.assemble_env(
+            os_name="TestOS", python="3.11", rhwp_version="rhwp v0",
+            rhwp_profile="debug", files=["a.hwp", "b.hwpx"],
+            tools={"rhwp": {"available": True, "detail": "v0"}},
+        )
+        payload = m.assemble_payload(
+            env=env,
+            tasks=[{
+                "task": "export-text",
+                "results": [
+                    m.available_result("rhwp", rhwp_runs, fidelity=1.0),
+                    m.available_result(
+                        "pyhwp", py_runs,
+                        fidelity=m.fidelity_vs_ref(py_runs, rhwp_runs),
+                        overlap=m.overlap_timing(py_runs, rhwp_runs),
+                    ),
+                    m.unavailable_result("soffice", "미설치"),
+                    m.unavailable_result("hwplib", "CLI 아님"),
+                ],
+            }],
+            generated_at="2026-01-01T00:00:00",
+        )
+        self.assertEqual(payload["kind"], m.REPORT_KIND)
+        self.assertEqual(payload["schemaVersion"], m.SCHEMA_VERSION)
+        self.assertEqual(payload["env"]["corpus"], {"dir": "samples", "total": 2, "hwp": 1, "hwpx": 1})
+        self.assertEqual(payload["tasks"][0]["results"][1]["overlapMs"]["n"], 1)
+        self.assertFalse(m.invented_metrics(payload["tasks"][0]["results"][2]))
+        self.assertEqual(m.payload_shape_issues(payload), [])
+        text = " ".join(payload["verdict"])
+        self.assertIn("pyhwp", text)
+        self.assertIn("더 빨", text)
+
+    def test_unavailable_must_not_carry_numbers(self):
+        m = load()
+        clean = m.unavailable_result("hwplib", "CLI 아님")
+        self.assertFalse(m.invented_metrics(clean))
+        dirty = dict(clean)
+        dirty["summary"] = {"ok": 3, "attempted": 3, "successRate": 1.0}
+        self.assertTrue(m.invented_metrics(dirty))
+
+    def test_shape_rejects_non_object_and_wrong_kind(self):
+        m = load()
+        self.assertTrue(m.payload_shape_issues("nope"))
+        self.assertTrue(m.payload_shape_issues({"kind": "other", "tasks": []}))
+        self.assertEqual(m.payload_shape_issues({"tasks": []}), [])
+
+
+class SpeedCmpAndCellTests(unittest.TestCase):
+    def test_speed_cmp_matrix(self):
+        m = load()
+        self.assertEqual(m.speed_cmp(8, 12), "tool_faster")
+        self.assertEqual(m.speed_cmp(12, 8), "ref_faster")
+        self.assertEqual(m.speed_cmp(8, 8), "tie")
+        self.assertIsNone(m.speed_cmp(None, 8))
+        self.assertIsNone(m.speed_cmp(True, 1))
+
+    def test_fmt_cell_handles_missing_rate(self):
+        m = load()
+        cell = m._fmt_cell(True, {"attempted": 2, "ok": 2, "medianMs": 9}, None, None)
+        self.assertIn("2/2", cell)
+        self.assertIn("-", cell)
+        self.assertIn("충실도", cell)
+
+    def test_escape_md_cell_protects_table(self):
+        m = load()
+        self.assertEqual(m.escape_md_cell("a|b\nc"), "a\\|b c")
+
+
+class MedianNumberTests(unittest.TestCase):
+    def test_even_count_and_bool_filter(self):
+        m = load()
+        self.assertEqual(m.median([10, 30]), 20)
+        self.assertIsNone(m.median([True, False, None]))
+        self.assertEqual(m.median([True, 4, 6]), 5)
+
+
+class WriteLfTests(unittest.TestCase):
+    def test_dump_and_write_are_utf8_lf_no_bom(self):
+        m = load()
+        payload = m.assemble_payload(
+            env={"os": "t"}, tasks=[], generated_at="2026-01-01T00:00:00",
+        )
+        text = m.dump_payload_json(payload)
+        self.assertTrue(text.endswith("\n"))
+        self.assertNotIn("\r", text)
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "bench.json"
+            m.write_text_lf(path, text)
+            raw = path.read_bytes()
+        self.assertFalse(raw.startswith(b"\xef\xbb\xbf"))
+        self.assertNotIn(b"\r\n", raw)
+        loaded = json.loads(raw.decode("utf-8"))
+        self.assertEqual(loaded["kind"], "gymCompetitiveBench")
+        self.assertEqual(loaded["verdict"], payload["verdict"])
+
+
+class RenderHonestyTests(unittest.TestCase):
+    def test_pipe_in_reason_does_not_break_table(self):
+        m = load()
+        payload = {
+            "toolOrder": ["rhwp", "alt"],
+            "env": {"tools": {}},
+            "tasks": [
+                {"task": "export-text", "results": [
+                    {"tool": "rhwp", "available": False, "reason": "막힘|원인"},
+                    {"tool": "alt", "available": False, "reason": "없음"},
+                ]},
+            ],
+            "capabilityMatrix": m.capability_matrix(),
+            "verdict": [],
+        }
+        md = m.render_report(payload)
+        self.assertIn("n/a: 막힘\\|원인", md)
+        self.assertIn("`gymCompetitiveBench`", md)
+
+    def test_missing_tool_order_falls_back(self):
+        m = load()
+        md = m.render_report({
+            "env": {},
+            "tasks": [{"task": "info", "results": []}],
+            "capabilityMatrix": m.capability_matrix(),
+            "verdict": ["측정 없음"],
+        })
+        self.assertIn("| 과제 |", md)
+        self.assertIn("rhwp", md)
+
+
+class SummarizeEdgeTests(unittest.TestCase):
+    def test_empty_ext_bucket_and_all_fail_median_none(self):
+        m = load()
+        s = m.summarize_runs([
+            {"file": "no-suffix", "ok": False, "ms": 40, "chars": 9},
+            {"file": "also-plain", "ok": False, "ms": 80, "chars": 3},
+        ])
+        self.assertEqual(s["attempted"], 2)
+        self.assertEqual(s["ok"], 0)
+        self.assertEqual(s["fail"], 2)
+        self.assertEqual(s["successRate"], 0.0)
+        self.assertIsNone(s["medianMs"])
+        self.assertIsNone(s["medianChars"])
+        self.assertEqual(s["byExt"][""], {"attempted": 2, "ok": 0, "fail": 2})
+
+    def test_blank_ext_key_falls_back_to_file(self):
+        m = load()
+        s = m.summarize_runs([
+            {"file": "doc.hwpx", "ext": "", "ok": True, "ms": 5, "chars": 2},
+        ])
+        self.assertEqual(s["byExt"][".hwpx"]["ok"], 1)
+
+
+class DiscoverCorpusTests(unittest.TestCase):
+    def test_temp_dir_limit_per_ext_ignores_txt(self):
+        m = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "b.hwp").write_bytes(b"hwp-b")
+            (root / "a.hwp").write_bytes(b"hwp-a")
+            (root / "c.hwp").write_bytes(b"hwp-c")
+            (root / "z.hwpx").write_bytes(b"hwpx-z")
+            (root / "m.hwpx").write_bytes(b"hwpx-m")
+            (root / "readme.txt").write_text("ignore", encoding="utf-8")
+            (root / "notes.md").write_text("ignore", encoding="utf-8")
+            (root / "nested").mkdir()
+            (root / "nested" / "hidden.hwp").write_bytes(b"nope")
+            picked = m.discover_corpus(str(root), 2)
+        names = [Path(p).name for p in picked]
+        self.assertEqual(names, ["a.hwp", "b.hwp", "m.hwpx", "z.hwpx"])
+        self.assertTrue(all(n.endswith((".hwp", ".hwpx")) for n in names))
+        self.assertNotIn("readme.txt", names)
+        self.assertNotIn("hidden.hwp", names)
+
+    def test_empty_dir_is_empty_list(self):
+        m = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(m.discover_corpus(tmp, 5), [])
+
+    def test_limit_zero_takes_all_matching(self):
+        m = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "only.hwp").write_bytes(b"x")
+            (root / "only.hwpx").write_bytes(b"y")
+            picked = m.discover_corpus(str(root), 0)
+        self.assertEqual([Path(p).name for p in picked], ["only.hwp", "only.hwpx"])
+
+
+class ParseEnvelopeEdgeTests(unittest.TestCase):
+    def test_parse_json_object_empty_and_malformed(self):
+        m = load()
+        self.assertIsNone(m.parse_json_object(""))
+        self.assertIsNone(m.parse_json_object("   "))
+        self.assertIsNone(m.parse_json_object("{"))
+        self.assertIsNone(m.parse_json_object("null"))
+        self.assertIsNone(m.parse_json_object("[]"))
+        self.assertIsNone(m.parse_json_object(b"\xff"))
+        self.assertIsNone(m.parse_json_body(""))
+        self.assertIsNone(m.parse_json_body("not-json"))
+        self.assertEqual(m.parse_json_object('{"a": 1}'), {"a": 1})
+
+    def test_text_chars_empty_pages_and_non_dict(self):
+        m = load()
+        self.assertEqual(m.parse_rhwp_text_chars(json.dumps({"pages": []})), 0)
+        mixed = {"pages": [
+            "not-a-page",
+            3,
+            None,
+            {"text": "가"},
+            {"text": ["x"]},
+            {"nope": "나"},
+        ]}
+        self.assertEqual(m.parse_rhwp_text_chars(json.dumps(mixed)), 1)
+        wrapped = json.dumps({"result": {"pages": [{"text": "ab"}, {"text": "cd"}]}})
+        self.assertEqual(m.parse_rhwp_text_chars(wrapped), 4)
+        payload = json.dumps({"payload": {"text": "xyz"}})
+        self.assertEqual(m.parse_rhwp_text_chars(payload), 3)
+
+    def test_info_and_structure_malformed(self):
+        m = load()
+        self.assertIsNone(m.parse_rhwp_info(""))
+        self.assertIsNone(m.parse_rhwp_info("{"))
+        self.assertIsNone(m.parse_rhwp_info(json.dumps({"ok": True})))
+        self.assertIsNone(m.parse_rhwp_structure(None))
+        self.assertIsNone(m.parse_rhwp_structure("[]"))
+        info = m.parse_rhwp_info(json.dumps({
+            "result": {"format": "hwp3", "pageCount": True, "sections": 2},
+        }))
+        self.assertEqual(info["format"], "hwp3")
+        self.assertIsNone(info["pageCount"])
+        self.assertEqual(info["sections"], 2)
+        struct = m.parse_rhwp_structure(json.dumps({
+            "payload": {"mode": "clause", "nodeCount": 0, "structure": {"k": 1}},
+        }))
+        self.assertEqual(struct["nodeCount"], 0)
+        self.assertTrue(struct["hasStructure"])
+
+
+class VerdictBranchTests(unittest.TestCase):
+    def _export(self, **kwargs):
+        rhwp = kwargs.get("rhwp", {
+            "tool": "rhwp", "available": True,
+            "summary": {"attempted": 4, "ok": 4, "medianMs": 10.0, "byExt": {}},
+        })
+        pyhwp = kwargs.get("pyhwp")
+        soffice = kwargs.get("soffice")
+        results = [rhwp]
+        if pyhwp is not None:
+            results.append(pyhwp)
+        if soffice is not None:
+            results.append(soffice)
+        extra = list(kwargs.get("extra_tasks") or [])
+        return {"tasks": [{"task": "export-text", "results": results}, *extra]}
+
+    def test_rhwp_faster_than_pyhwp(self):
+        m = load()
+        payload = self._export(pyhwp={
+            "tool": "pyhwp", "available": True,
+            "summary": {
+                "attempted": 2, "ok": 2, "medianMs": 40.0,
+                "byExt": {".hwp": {"attempted": 2, "ok": 2},
+                          ".hwpx": {"attempted": 0, "ok": 0}},
+            },
+            "overlapMs": {"tool": 40.0, "ref": 9.0, "n": 2},
+        })
+        text = " ".join(m.verdict_lines(payload))
+        self.assertIn("rhwp 가 더 빨랐다", text)
+        self.assertIn("디버그", text)
+
+    def test_soffice_unavailable_is_stated(self):
+        m = load()
+        payload = self._export(
+            pyhwp={"tool": "pyhwp", "available": False, "reason": "six 없음"},
+            soffice={"tool": "soffice", "available": False,
+                     "reason": "미설치(이 머신); HWP5 필터 없음"},
+        )
+        text = " ".join(m.verdict_lines(payload))
+        self.assertIn("LibreOffice(soffice)는 이 머신에서 실행하지 않았다", text)
+        self.assertIn("미설치", text)
+
+    def test_no_overlap_speed_is_honest(self):
+        m = load()
+        payload = self._export(pyhwp={
+            "tool": "pyhwp", "available": True,
+            "summary": {
+                "attempted": 2, "ok": 1,
+                "byExt": {".hwp": {"attempted": 1, "ok": 1},
+                          ".hwpx": {"attempted": 1, "ok": 0}},
+            },
+            "overlapMs": {"n": 0, "tool": None, "ref": None},
+        })
+        text = " ".join(m.verdict_lines(payload))
+        self.assertIn("겹친 파일이 없어", text)
+        self.assertIn("동일-집합 비교를 만들지 않았다", text)
+
+    def test_hwpx_zero_of_n_is_stated(self):
+        m = load()
+        payload = self._export(pyhwp={
+            "tool": "pyhwp", "available": True,
+            "summary": {
+                "attempted": 5, "ok": 2,
+                "byExt": {".hwp": {"attempted": 2, "ok": 2},
+                          ".hwpx": {"attempted": 3, "ok": 0}},
+            },
+            "overlapMs": {"tool": 5.0, "ref": 5.0, "n": 2},
+        })
+        text = " ".join(m.verdict_lines(payload))
+        self.assertIn("HWPX 0/3", text)
+
+    def test_width_lists_rhwp_only_tasks(self):
+        m = load()
+        payload = self._export(
+            pyhwp={"tool": "pyhwp", "available": False, "reason": "n/a"},
+            extra_tasks=[
+                {"task": "info", "results": [
+                    {"tool": "rhwp", "available": True, "summary": {"ok": 1, "attempted": 1}},
+                    {"tool": "pyhwp", "available": False},
+                ]},
+                {"task": "structure", "results": [
+                    {"tool": "rhwp", "available": True, "summary": {"ok": 1, "attempted": 1}},
+                    {"tool": "soffice", "available": False},
+                ]},
+                {"task": "convert", "results": [
+                    {"tool": "rhwp", "available": True, "summary": {"ok": 1, "attempted": 1}},
+                ]},
+            ],
+        )
+        text = " ".join(m.verdict_lines(payload))
+        self.assertIn("info, structure, convert", text)
+
+
+class FmtCellEdgeTests(unittest.TestCase):
+    def test_attempted_zero_is_na(self):
+        m = load()
+        self.assertEqual(m._fmt_cell(True, {"attempted": 0, "ok": 0}, 1.0, None), "n/a: 시도 없음")
+        self.assertEqual(m._fmt_cell(True, None, None, None), "n/a: 시도 없음")
+        self.assertEqual(m._fmt_cell(True, "bad", None, None), "n/a: 시도 없음")
+
+    def test_fidelity_none_prints_dash(self):
+        m = load()
+        cell = m._fmt_cell(True, {
+            "attempted": 3, "ok": 3, "successRate": 1.0, "medianMs": 11.0,
+        }, None, None)
+        self.assertIn("충실도 -", cell)
+        self.assertIn("11ms", cell)
+        self.assertNotIn("None", cell)
+
+
+class ReportContractTests(unittest.TestCase):
+    def test_constants(self):
+        m = load()
+        self.assertEqual(m.REPORT_KIND, "gymCompetitiveBench")
+        self.assertEqual(m.SCHEMA_VERSION, "1.0")
+        self.assertEqual(set(m.VALID_CAP), {"yes", "partial", "no"})
+        self.assertEqual(tuple(m.DEFAULT_TOOL_ORDER), ("rhwp", "pyhwp", "soffice", "hwplib"))
+
+    def test_stamp_fills_missing_kind(self):
+        m = load()
+        stamped = m.stamp_report_contract({"tasks": []})
+        self.assertEqual(stamped["kind"], "gymCompetitiveBench")
+        self.assertEqual(stamped["schemaVersion"], "1.0")
+        kept = m.stamp_report_contract({
+            "kind": "gymCompetitiveBench", "schemaVersion": "1.0", "tasks": [],
+        })
+        self.assertEqual(kept["kind"], m.REPORT_KIND)
+
+    def test_load_report_payload_empty_and_bad(self):
+        m = load()
+        self.assertIsNone(m.load_report_payload("")[0])
+        self.assertIsNone(m.load_report_payload("{")[0])
+        self.assertIsNone(m.load_report_payload(json.dumps({"kind": "nope"}))[0])
+        payload, issues = m.load_report_payload(json.dumps({"tasks": []}))
+        self.assertEqual(issues, [])
+        self.assertEqual(payload["kind"], "gymCompetitiveBench")
+        self.assertIn("verdict", payload)
+
+
+class FromJsonCliTests(unittest.TestCase):
+    def _tiny_payload(self, m):
+        return {
+            "tasks": [
+                {"task": "export-text", "results": [
+                    {"tool": "rhwp", "available": True,
+                     "summary": {"attempted": 1, "ok": 1, "successRate": 1.0,
+                                 "medianMs": 7.0, "medianChars": 4,
+                                 "byExt": {".hwp": {"attempted": 1, "ok": 1, "fail": 0}}},
+                     "fidelityVsRhwp": 1.0},
+                    {"tool": "pyhwp", "available": False, "reason": "미설치"},
+                    {"tool": "soffice", "available": False, "reason": "미설치(이 머신)"},
+                ]},
+            ],
+            "env": {
+                "os": "TestOS", "python": "3.11", "rhwpVersion": "rhwp v0",
+                "rhwpProfile": "debug",
+                "corpus": {"dir": "tmp", "total": 1, "hwp": 1, "hwpx": 0},
+                "tools": {"rhwp": {"available": True, "detail": "v0"}},
+            },
+            "capabilityMatrix": m.capability_matrix(),
+        }
+
+    def test_from_json_prints_markdown(self):
+        m = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "bench.json"
+            src.write_text(json.dumps(self._tiny_payload(m), ensure_ascii=False), encoding="utf-8")
+            out, err = io.StringIO(), io.StringIO()
+            with redirect_stdout(out), redirect_stderr(err):
+                rc = m.main(["--from-json", str(src)])
+        self.assertEqual(rc, 0)
+        md = out.getvalue()
+        self.assertIn("# 경쟁 벤치마크", md)
+        self.assertIn("`gymCompetitiveBench`", md)
+        self.assertIn("n/a: 미설치", md)
+
+    def test_from_json_writes_stamped_json_and_md(self):
+        m = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "in.json"
+            out_json = Path(tmp) / "out.json"
+            out_md = Path(tmp) / "out.md"
+            raw = dict(self._tiny_payload(m))
+            # 옛 산출물처럼 kind 가 없어도 재렌더 JSON 에 계약이 찍혀야 한다.
+            src.write_text(json.dumps(raw, ensure_ascii=False), encoding="utf-8")
+            err = io.StringIO()
+            with redirect_stdout(io.StringIO()), redirect_stderr(err):
+                rc = m.main([
+                    "--from-json", str(src),
+                    "--out-json", str(out_json),
+                    "--out-md", str(out_md),
+                ])
+            self.assertEqual(rc, 0)
+            raw_bytes = out_json.read_bytes()
+            stamped = json.loads(raw_bytes.decode("utf-8"))
+            md = out_md.read_text(encoding="utf-8")
+        self.assertFalse(raw_bytes.startswith(b"\xef\xbb\xbf"))
+        self.assertEqual(stamped["kind"], "gymCompetitiveBench")
+        self.assertEqual(stamped["schemaVersion"], "1.0")
+        self.assertTrue(any("실행하지 않았다" in line for line in stamped["verdict"]))
+        self.assertIn("gymCompetitiveBench", md)
+
+    def test_from_json_rejects_malformed(self):
+        m = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "bad.json"
+            src.write_text("{", encoding="utf-8")
+            err = io.StringIO()
+            with redirect_stdout(io.StringIO()), redirect_stderr(err):
+                rc = m.main(["--from-json", str(src)])
+        self.assertEqual(rc, 2)
+        self.assertIn("깨졌다", err.getvalue())
+
+
+class ValidateMatrixExtraTests(unittest.TestCase):
+    def test_non_object_and_empty_sections(self):
+        m = load()
+        self.assertEqual(m.validate_capability_matrix("x"), ["matrix 가 객체가 아니다"])
+        self.assertIn("columns 가 비었다", m.validate_capability_matrix({"columns": [], "rows": []})[0])
+        self.assertIn("rows 가 비었다", m.validate_capability_matrix({
+            "columns": [{"key": "mcp", "label": "MCP"}], "rows": [],
+        })[0])
+
+    def test_rhwp_must_be_all_yes(self):
+        m = load()
+        matrix = {
+            "columns": [{"key": "mcp", "label": "MCP"}, {"key": "edit", "label": "편집"}],
+            "rows": [{"tool": "rhwp", "mcp": "yes", "edit": "partial"}],
+        }
+        issues = m.validate_capability_matrix(matrix)
+        self.assertTrue(any("rhwp.edit" in i for i in issues))
+
+    def test_column_without_key_and_non_dict_row(self):
+        m = load()
+        issues = m.validate_capability_matrix({
+            "columns": [{"label": "없음"}, {"key": "mcp", "label": "MCP"}],
+            "rows": ["bad", {"tool": "alt", "mcp": "no"}],
+        })
+        self.assertTrue(any("key 가 없다" in i for i in issues))
+        self.assertTrue(any("객체가 아니다" in i for i in issues))
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_gym_competitive_bench_exceptions.py
+++ b/scripts/tests/test_gym_competitive_bench_exceptions.py
@@ -1,0 +1,520 @@
+"""[competitive_bench] 명시 예외 경로 — 깨진 입력을 숫자로 위장하지 않는다.
+
+기존 test_gym_competitive_bench.py 의 집계·평결·재렌더 계약은 그대로 둔다.
+이 파일은 BenchError 가족, UTF-8/JSON 읽기, 스코어카드·에이전트 식별,
+정직성 가드만 고정한다. 바이너리·외부 도구 불요. CLI 플래그를 늘리지 않는다.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL = REPO_ROOT / "gym" / "tools" / "competitive_bench.py"
+
+
+def load():
+    spec = importlib.util.spec_from_file_location("competitive_bench_exc", TOOL)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ErrorCatalogTests(unittest.TestCase):
+    def test_catalog_matches_constants(self):
+        m = load()
+        catalog = m.error_catalog()
+        codes = [row["code"] for row in catalog]
+        self.assertEqual(tuple(codes), m.ERROR_CODES)
+        self.assertEqual(set(codes), {
+            "missing-file", "bad-json", "encoding",
+            "empty-scorecard", "unknown-agent", "payload-shape",
+        })
+        for row in catalog:
+            self.assertEqual(row["exit"], m.DEFAULT_ERROR_EXIT)
+            self.assertTrue(row["when"])
+
+    def test_error_kind_and_reserved_set(self):
+        m = load()
+        self.assertEqual(m.ERROR_KIND, "gymCompetitiveBenchError")
+        self.assertEqual(m.SCORECARD_KIND, "gymScorecard")
+        self.assertEqual(m.SCORECARD_SCHEMA_VERSIONS, ("1.0", "2.0"))
+        self.assertEqual(m.SCORECARD_TOTAL_KEYS, ("score", "max", "packsScored"))
+        for name in ("rhwp", "pyhwp", "soffice", "hwplib", "all", "none", "baseline"):
+            self.assertIn(name, m.RESERVED_AGENT_IDS)
+
+
+class BenchErrorShapeTests(unittest.TestCase):
+    def test_to_dict_omits_empty_path_and_details(self):
+        m = load()
+        err = m.BenchError("bad-json", "깨졌다")
+        rec = err.to_dict()
+        self.assertEqual(rec["ok"], False)
+        self.assertEqual(rec["kind"], "gymCompetitiveBenchError")
+        self.assertEqual(rec["code"], "bad-json")
+        self.assertEqual(rec["exitCode"], 2)
+        self.assertNotIn("path", rec)
+        self.assertNotIn("details", rec)
+
+    def test_to_dict_includes_posix_path_and_details(self):
+        m = load()
+        err = m.BenchError(
+            m.ERR_MISSING_FILE, "없다",
+            path=r"samples\a.hwp", details={"errno": 2},
+        )
+        rec = err.to_dict()
+        self.assertEqual(rec["path"], "samples/a.hwp")
+        self.assertEqual(rec["details"], {"errno": 2})
+
+    def test_format_and_exit_code(self):
+        m = load()
+        err = m.MissingFileError("x.json")
+        self.assertTrue(m.format_bench_error(err).startswith("오류[missing-file]:"))
+        self.assertIn("x.json", m.format_bench_error(err))
+        self.assertEqual(m.error_exit_code(err), 2)
+        self.assertEqual(m.error_exit_code(RuntimeError("x")), 1)
+        self.assertEqual(m.error_exit_code("not-an-error"), 1)
+
+    def test_subclass_codes(self):
+        m = load()
+        self.assertEqual(m.MissingFileError("p").code, "missing-file")
+        self.assertEqual(m.BadJsonError("p").code, "bad-json")
+        self.assertEqual(m.EncodingError("p").code, "encoding")
+        self.assertEqual(m.EmptyScorecardError("p").code, "empty-scorecard")
+        self.assertEqual(m.UnknownAgentError("ghost").code, "unknown-agent")
+        self.assertEqual(m.UnknownAgentError("ghost").details["agent"], "ghost")
+        shape = m.PayloadShapeError(["tasks 누락"], path="in.json")
+        self.assertEqual(shape.code, "payload-shape")
+        self.assertEqual(shape.details["issues"], ["tasks 누락"])
+        self.assertIn("tasks 누락", shape.message)
+
+
+class Utf8DecodeTests(unittest.TestCase):
+    def test_none_and_non_bytes(self):
+        m = load()
+        with self.assertRaises(m.EncodingError) as ctx:
+            m.utf8_decode(None, path="a.json")
+        self.assertEqual(ctx.exception.code, "encoding")
+        with self.assertRaises(m.EncodingError):
+            m.utf8_decode(12, path="a.json")
+
+    def test_str_passthrough_and_bom_strip(self):
+        m = load()
+        self.assertEqual(m.utf8_decode("한글"), "한글")
+        raw = b"\xef\xbb\xbf{\"ok\": true}"
+        self.assertEqual(m.utf8_decode(raw), '{"ok": true}')
+
+    def test_invalid_utf8_is_explicit(self):
+        m = load()
+        with self.assertRaises(m.EncodingError) as ctx:
+            m.utf8_decode(b"\xff\xfe", path="bad.txt")
+        self.assertEqual(ctx.exception.code, "encoding")
+        self.assertIn("offset", ctx.exception.message)
+        self.assertIn("start", ctx.exception.details)
+
+
+class ReadBytesTests(unittest.TestCase):
+    def test_empty_path_and_missing(self):
+        m = load()
+        with self.assertRaises(m.MissingFileError):
+            m.read_bytes("")
+        with self.assertRaises(m.MissingFileError):
+            m.read_bytes(None)
+        with self.assertRaises(m.MissingFileError) as ctx:
+            m.read_bytes("definitely-missing-xyz.json")
+        self.assertEqual(ctx.exception.code, "missing-file")
+
+    def test_directory_is_not_a_file(self):
+        m = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(m.MissingFileError) as ctx:
+                m.read_bytes(tmp)
+        self.assertIn("디렉터리", ctx.exception.message)
+
+    def test_empty_file_is_allowed(self):
+        m = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "empty.json"
+            path.write_bytes(b"")
+            self.assertEqual(m.read_bytes(path), b"")
+            self.assertEqual(m.read_text_utf8(path), "")
+
+
+class ParseJsonTextTests(unittest.TestCase):
+    def test_none_empty_and_non_string(self):
+        m = load()
+        with self.assertRaises(m.BadJsonError):
+            m.parse_json_text(None)
+        with self.assertRaises(m.BadJsonError):
+            m.parse_json_text("   ")
+        with self.assertRaises(m.BadJsonError):
+            m.parse_json_text(b"{}")
+
+    def test_truncated_and_trailing_comma(self):
+        m = load()
+        with self.assertRaises(m.BadJsonError) as ctx:
+            m.parse_json_text("{", path="x.json")
+        self.assertEqual(ctx.exception.code, "bad-json")
+        self.assertIn("lineno", ctx.exception.details)
+        with self.assertRaises(m.BadJsonError):
+            m.parse_json_text('{"a": 1,}')
+
+    def test_object_and_array_and_require_object(self):
+        m = load()
+        self.assertEqual(m.parse_json_text('{"a": 1}'), {"a": 1})
+        self.assertEqual(m.parse_json_text("[1, 2]"), [1, 2])
+        self.assertEqual(m.require_json_object({"k": 1}), {"k": 1})
+        with self.assertRaises(m.BadJsonError) as ctx:
+            m.require_json_object([1, 2], path="arr.json")
+        self.assertIn("객체가 아니다", ctx.exception.message)
+        self.assertEqual(ctx.exception.details["jsonType"], "list")
+
+
+class LoadJsonObjectTests(unittest.TestCase):
+    def test_array_top_level_is_bad_json(self):
+        m = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "arr.json"
+            path.write_text("[1, 2]", encoding="utf-8")
+            with self.assertRaises(m.BadJsonError):
+                m.load_json_object(path)
+
+    def test_valid_object(self):
+        m = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "ok.json"
+            path.write_text('{"tasks": []}\n', encoding="utf-8")
+            self.assertEqual(m.load_json_object(path), {"tasks": []})
+
+    def test_latin1_bytes_are_encoding_error(self):
+        m = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "latin1.json"
+            path.write_bytes("{\"x\": \"café\"}".encode("latin-1"))
+            with self.assertRaises(m.EncodingError):
+                m.load_json_object(path)
+
+
+class LoadReportFromPathTests(unittest.TestCase):
+    def test_missing_and_wrong_kind(self):
+        m = load()
+        with self.assertRaises(m.MissingFileError):
+            m.load_report_from_path("no-such-report.json")
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "wrong.json"
+            path.write_text(json.dumps({"kind": "other", "tasks": []}), encoding="utf-8")
+            with self.assertRaises(m.PayloadShapeError) as ctx:
+                m.load_report_from_path(path)
+        self.assertEqual(ctx.exception.code, "payload-shape")
+
+    def test_valid_legacy_without_kind(self):
+        m = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "legacy.json"
+            path.write_text(json.dumps({"tasks": []}), encoding="utf-8")
+            payload = m.load_report_from_path(path)
+        self.assertEqual(payload["tasks"], [])
+
+    def test_string_loader_still_returns_tuple(self):
+        m = load()
+        payload, issues = m.load_report_payload(json.dumps({"tasks": []}))
+        self.assertEqual(issues, [])
+        self.assertEqual(payload["kind"], "gymCompetitiveBench")
+        none, bad = m.load_report_payload("{")
+        self.assertIsNone(none)
+        self.assertTrue(bad)
+
+
+class AgentIdTests(unittest.TestCase):
+    def test_missing_and_non_string(self):
+        m = load()
+        self.assertEqual(m.agent_id_issues(None), ["agent 가 없다"])
+        self.assertTrue(any("문자열이 아니다" in i for i in m.agent_id_issues(3)))
+        self.assertEqual(m.agent_id_issues("   "), ["agent 가 비었다"])
+
+    def test_reserved_and_path_chars(self):
+        m = load()
+        reserved = m.agent_id_issues("rhwp")
+        self.assertTrue(any("예약어" in i for i in reserved))
+        pathish = m.agent_id_issues("a/b")
+        self.assertTrue(any("경로" in i for i in pathish))
+        spaced = m.agent_id_issues("bad agent")
+        self.assertTrue(any("공백" in i for i in spaced))
+
+    def test_regex_rejects_leading_digit_and_too_long(self):
+        m = load()
+        self.assertTrue(any("A-Za-z" in i for i in m.agent_id_issues("1agent")))
+        self.assertTrue(any("A-Za-z" in i for i in m.agent_id_issues("a" * 65)))
+
+    def test_normalize_raises_unknown(self):
+        m = load()
+        with self.assertRaises(m.UnknownAgentError):
+            m.normalize_agent_id("")
+        with self.assertRaises(m.UnknownAgentError):
+            m.normalize_agent_id("soffice")
+        self.assertEqual(m.normalize_agent_id("claude-fable-5"), "claude-fable-5")
+        self.assertEqual(m.normalize_agent_id("Atlas.1_probe"), "Atlas.1_probe")
+
+    def test_require_known_agent(self):
+        m = load()
+        with self.assertRaises(m.UnknownAgentError) as empty:
+            m.require_known_agent("ok-agent", [])
+        self.assertIn("비어", empty.exception.message)
+        with self.assertRaises(m.UnknownAgentError) as miss:
+            m.require_known_agent("ghost", ["claude-fable-5"])
+        self.assertIn("알 수 없는 에이전트", miss.exception.message)
+        self.assertEqual(miss.exception.details["known"], ["claude-fable-5"])
+        self.assertEqual(
+            m.require_known_agent("claude-fable-5", ["claude-fable-5", "novice"]),
+            "claude-fable-5",
+        )
+
+
+class DiscoverKnownAgentsTests(unittest.TestCase):
+    def test_empty_and_non_dir(self):
+        m = load()
+        self.assertEqual(m.discover_known_agents(None, ""), [])
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = str(Path(tmp) / "nope")
+            self.assertEqual(m.discover_known_agents(missing), [])
+
+    def test_folder_name_epoch_and_scorecard_agent(self):
+        m = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "claude-fable-5-0000").mkdir()
+            card_dir = root / "probe-diagnostician-0002"
+            card_dir.mkdir()
+            (card_dir / "scorecard.json").write_text(
+                json.dumps({
+                    "kind": "gymScorecard", "schemaVersion": "2.0",
+                    "agent": "probe-diagnostician",
+                    "total": {"score": 1, "max": 1, "packsScored": 1},
+                    "packs": [{"id": "core-cli", "status": "scored", "taskCount": 1}],
+                }),
+                encoding="utf-8",
+            )
+            (root / "readme.txt").write_text("ignore", encoding="utf-8")
+            broken = root / "broken-0003"
+            broken.mkdir()
+            (broken / "scorecard.json").write_text("{", encoding="utf-8")
+            found = m.discover_known_agents(str(root))
+        self.assertIn("claude-fable-5-0000", found)
+        self.assertIn("claude-fable-5", found)
+        self.assertIn("probe-diagnostician-0002", found)
+        self.assertIn("probe-diagnostician", found)
+        self.assertIn("broken-0003", found)
+        self.assertIn("broken", found)
+
+
+class ScorecardIssueTests(unittest.TestCase):
+    def test_kind_and_version(self):
+        m = load()
+        self.assertEqual(m.scorecard_kind_issues("x"), ["스코어카드가 객체가 아니다"])
+        self.assertTrue(any("kind" in i for i in m.scorecard_kind_issues({"kind": "nope"})))
+        self.assertTrue(any("schemaVersion" in i for i in m.scorecard_kind_issues({
+            "kind": "gymScorecard", "schemaVersion": "9.9",
+        })))
+        self.assertEqual(m.scorecard_kind_issues({
+            "kind": "gymScorecard", "schemaVersion": "2.0",
+        }), [])
+        self.assertEqual(m.scorecard_kind_issues({}), [])
+
+    def test_emptiness_matrix(self):
+        m = load()
+        self.assertEqual(m.scorecard_emptiness_issues({}), ["스코어카드 객체가 비었다"])
+        self.assertIn("packs 와 total 이 모두 없다", m.scorecard_emptiness_issues({"agent": "x"}))
+        self.assertIn("packs 가 배열이 아니다", m.scorecard_emptiness_issues({"packs": {}}))
+        self.assertIn("packs 가 빈 배열이다", m.scorecard_emptiness_issues({"packs": []}))
+        self.assertIn("total 이 객체가 아니다", m.scorecard_emptiness_issues({"total": 1}))
+        missing = m.scorecard_emptiness_issues({"total": {"score": 1}})
+        self.assertTrue(any("total 키 누락" in i for i in missing))
+        self.assertIn("packsScored 가 0 이다", m.scorecard_emptiness_issues({
+            "total": {"score": 0, "max": 0, "packsScored": 0},
+        }))
+        self.assertIn("packsScored 가 null 이다", m.scorecard_emptiness_issues({
+            "total": {"score": 0, "max": 0, "packsScored": None},
+        }))
+        self.assertIn("전부 unavailable", m.scorecard_emptiness_issues({
+            "packs": [{"id": "a", "status": "unavailable", "taskCount": 3}],
+        })[0] if False else " ".join(m.scorecard_emptiness_issues({
+            "packs": [{"id": "a", "status": "unavailable", "taskCount": 3}],
+        })))
+        self.assertIn("taskCount 가 0", " ".join(m.scorecard_emptiness_issues({
+            "packs": [{"id": "a", "status": "scored", "taskCount": 0}],
+        })))
+
+    def test_load_scorecard_empty_and_agent_mismatch(self):
+        m = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            empty = Path(tmp) / "empty.json"
+            empty.write_text(json.dumps({
+                "kind": "gymScorecard", "schemaVersion": "2.0",
+            }), encoding="utf-8")
+            with self.assertRaises(m.EmptyScorecardError):
+                m.load_scorecard(empty)
+            card = Path(tmp) / "card.json"
+            card.write_text(json.dumps({
+                "kind": "gymScorecard", "schemaVersion": "2.0",
+                "agent": "claude-fable-5",
+                "total": {"score": 10, "max": 10, "packsScored": 2},
+                "packs": [{"id": "core-cli", "status": "scored", "taskCount": 4}],
+            }), encoding="utf-8")
+            with self.assertRaises(m.UnknownAgentError):
+                m.load_scorecard(card, expected_agent="other-agent")
+            with self.assertRaises(m.UnknownAgentError):
+                m.load_scorecard(card, expected_agent="claude-fable-5",
+                                 known_agents=["novice-starter"])
+            loaded = m.load_scorecard(
+                card, expected_agent="claude-fable-5",
+                known_agents=["claude-fable-5"],
+            )
+        self.assertEqual(loaded["agent"], "claude-fable-5")
+
+    def test_load_scorecard_missing_agent_field(self):
+        m = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "no-agent.json"
+            path.write_text(json.dumps({
+                "kind": "gymScorecard", "schemaVersion": "1.0",
+                "total": {"score": 1, "max": 1, "packsScored": 1},
+                "packs": [{"id": "x", "status": "scored", "taskCount": 1}],
+            }), encoding="utf-8")
+            with self.assertRaises(m.UnknownAgentError) as ctx:
+                m.load_scorecard(path, expected_agent="want-agent")
+        self.assertIn("agent 필드가 없어", ctx.exception.message)
+
+    def test_scorecard_summary_and_attach(self):
+        m = load()
+        card = {
+            "kind": "gymScorecard",
+            "schemaVersion": "2.0",
+            "agent": "claude-fable-5",
+            "total": {"score": 194, "max": 194, "packsScored": 10},
+            "packs": [
+                {"id": "core-cli", "status": "scored", "taskCount": 14},
+                {"id": "security", "status": "scored", "taskCount": 9},
+                "bad",
+            ],
+        }
+        summary = m.scorecard_summary(card)
+        self.assertEqual(summary["score"], 194)
+        self.assertEqual(summary["packCount"], 3)
+        self.assertEqual(summary["packIds"], ["core-cli", "security"])
+        payload = {"tasks": [], "verdict": ["그대로"]}
+        attached = m.attach_scorecard(payload, card)
+        self.assertEqual(attached["verdict"], ["그대로"])
+        self.assertEqual(attached["scorecard"]["agent"], "claude-fable-5")
+        self.assertNotIn("scorecard", payload)
+
+
+class HonestyGuardTests(unittest.TestCase):
+    def test_run_record_issues(self):
+        m = load()
+        self.assertEqual(m.run_record_issues("x"), ["run 이 객체가 아니다"])
+        issues = m.run_record_issues({"ok": True, "ms": "fast", "chars": True})
+        self.assertTrue(any("file 이 없다" in i for i in issues))
+        self.assertTrue(any("ms 가 숫자가 아니다" in i for i in issues))
+        self.assertTrue(any("chars 가 숫자가 아니다" in i for i in issues))
+        self.assertEqual(
+            m.run_record_issues({"file": "a.hwp", "ok": False, "ms": None, "chars": None}),
+            [],
+        )
+
+    def test_task_result_unavailable_with_numbers(self):
+        m = load()
+        self.assertEqual(m.task_result_issues(1), ["result 가 객체가 아니다"])
+        dirty = m.unavailable_result("hwplib", "CLI 아님")
+        dirty["summary"] = {"ok": 1, "attempted": 1}
+        issues = m.task_result_issues(dirty)
+        self.assertTrue(any("숫자를 실었다" in i for i in issues))
+        avail_bad = {"tool": "rhwp", "available": True}
+        self.assertTrue(any("summary 가 없다" in i for i in m.task_result_issues(avail_bad)))
+
+    def test_task_result_bad_runs(self):
+        m = load()
+        issues = m.task_result_issues({
+            "tool": "rhwp", "available": True,
+            "summary": {"attempted": 1, "ok": 1},
+            "runs": {"file": "a.hwp"},
+        })
+        self.assertTrue(any("runs 가 배열이 아니다" in i for i in issues))
+        issues = m.task_result_issues({
+            "tool": "rhwp", "available": True,
+            "summary": {"attempted": 1, "ok": 1},
+            "runs": [{"ok": True, "ms": 1}],
+        })
+        self.assertTrue(any("file 이 없다" in i for i in issues))
+
+    def test_payload_honesty_and_require(self):
+        m = load()
+        self.assertEqual(m.payload_honesty_issues("x"), ["payload 가 객체가 아니다"])
+        empty = m.payload_honesty_issues({"tasks": []})
+        self.assertTrue(any("빈 배열" in i for i in empty))
+        broken = {
+            "kind": "gymCompetitiveBench",
+            "tasks": [
+                "nope",
+                {"results": []},
+                {"task": "export-text", "results": {"tool": "rhwp"}},
+                {"task": "info", "results": [
+                    m.unavailable_result("pyhwp", "n/a") | {"runs": [1]},
+                ]},
+            ],
+        }
+        text = " ".join(m.payload_honesty_issues(broken))
+        self.assertIn("task 가 객체가 아니다", text)
+        self.assertIn("task 이름이 없다", text)
+        self.assertIn("results 가 배열이 아니다", text)
+        self.assertIn("숫자를 실었다", text)
+        with self.assertRaises(m.PayloadShapeError):
+            m.require_honest_payload({"tasks": []})
+        honest = {
+            "kind": "gymCompetitiveBench",
+            "schemaVersion": "1.0",
+            "tasks": [{
+                "task": "export-text",
+                "results": [
+                    m.available_result("rhwp", [
+                        {"file": "a.hwp", "ext": ".hwp", "ok": True, "ms": 1, "chars": 2},
+                    ]),
+                    m.unavailable_result("hwplib", "CLI 아님"),
+                ],
+            }],
+        }
+        self.assertIs(m.require_honest_payload(honest), honest)
+
+
+class ClassifyFailureTests(unittest.TestCase):
+    def test_timeout_missing_permission_encoding_json_runtime(self):
+        m = load()
+        self.assertEqual(m.classify_cli_failure("Timeout>60s"), "timeout")
+        self.assertEqual(m.classify_cli_failure("cannot find the file"), "missing_input")
+        self.assertEqual(m.classify_cli_failure("파일이 없는 파일입니다"), "missing_input")
+        self.assertEqual(m.classify_cli_failure("Permission denied"), "permission")
+        self.assertEqual(m.classify_cli_failure("액세스가 거부되었습니다"), "permission")
+        self.assertEqual(m.classify_cli_failure("utf-8 codec can't decode"), m.ERR_ENCODING)
+        self.assertEqual(m.classify_cli_failure("not valid JSON"), m.ERR_BAD_JSON)
+        self.assertEqual(m.classify_cli_failure("segfault"), "runtime")
+        self.assertEqual(m.classify_cli_failure(""), "runtime")
+        self.assertEqual(m.classify_cli_failure(None), "runtime")
+
+
+class DefaultRootsTests(unittest.TestCase):
+    def test_default_known_agent_roots_point_at_gym(self):
+        m = load()
+        roots = m.default_known_agent_roots()
+        self.assertEqual(len(roots), 3)
+        self.assertTrue(any(r.endswith("baselines") or r.replace("\\", "/").endswith("baselines")
+                            for r in roots))
+        self.assertTrue(any("scorecards" in r.replace("\\", "/") for r in roots))
+        self.assertTrue(any(r.replace("\\", "/").endswith("submissions") for r in roots))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_gym_competitive_bench_extra.py
+++ b/scripts/tests/test_gym_competitive_bench_extra.py
@@ -1,0 +1,401 @@
+"""[competitive_bench] 추가 순수 함수 경우 — 기존 89건을 지우지 않는다.
+
+파서 래퍼, 충실도 쌍, 평결 가지, 정직성 조립만 더 고정한다.
+바이너리 없이 돈다. 새 CLI 플래그를 만들지 않는다.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL = REPO_ROOT / "gym" / "tools" / "competitive_bench.py"
+
+
+def load():
+    spec = importlib.util.spec_from_file_location("competitive_bench_extra", TOOL)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class NumberAndPathTests(unittest.TestCase):
+    def test_is_number_rejects_bool_and_string(self):
+        m = load()
+        self.assertTrue(m.is_number(0))
+        self.assertTrue(m.is_number(0.0))
+        self.assertTrue(m.is_number(-1.5))
+        self.assertFalse(m.is_number(True))
+        self.assertFalse(m.is_number(False))
+        self.assertFalse(m.is_number("1"))
+        self.assertFalse(m.is_number(None))
+
+    def test_posix_rel_and_ext(self):
+        m = load()
+        self.assertEqual(m.posix_rel(r"samples\a.HWP"), "samples/a.HWP")
+        self.assertEqual(m.ext_of("samples/a.HWPX"), ".hwpx")
+        self.assertEqual(m.ext_of("no-suffix"), "")
+        self.assertEqual(m.display_path(None), "")
+        self.assertEqual(m.display_path(r"x\y.json"), "x/y.json")
+
+
+class UnwrapAndInfoFieldsTests(unittest.TestCase):
+    def test_unwrap_only_when_body_keys_present(self):
+        m = load()
+        self.assertIsNone(m.unwrap_json_envelope("x"))
+        plain = {"ok": True, "data": {"note": "no-body"}}
+        self.assertIs(m.unwrap_json_envelope(plain), plain)
+        wrapped = {"payload": {"pageCount": 2}}
+        self.assertEqual(m.unwrap_json_envelope(wrapped), {"pageCount": 2})
+
+    def test_info_fields_keeps_present_keys_only(self):
+        m = load()
+        self.assertIsNone(m.parse_rhwp_info_fields(""))
+        self.assertIsNone(m.parse_rhwp_info_fields("[]"))
+        raw = json.dumps({"data": {
+            "format": "hwp5", "pageCount": 3, "sectionCount": 1, "extra": 9,
+        }})
+        parsed = m.parse_rhwp_info_fields(raw)
+        self.assertEqual(parsed["format"], "hwp5")
+        self.assertEqual(parsed["pageCount"], 3)
+        self.assertEqual(parsed["sectionCount"], 1)
+        self.assertNotIn("extra", parsed)
+        self.assertNotIn("paraCount", parsed)
+
+    def test_structure_nodes_from_list_or_count(self):
+        m = load()
+        self.assertIsNone(m.parse_rhwp_structure_nodes("{"))
+        self.assertIsNone(m.parse_rhwp_structure_nodes(json.dumps({"ok": True})))
+        self.assertEqual(
+            m.parse_rhwp_structure_nodes(json.dumps({"nodeCount": 7})), 7,
+        )
+        self.assertEqual(
+            m.parse_rhwp_structure_nodes(json.dumps({"nodes": [1, 2, 3]})),
+            3,
+        )
+        self.assertEqual(
+            m.parse_rhwp_structure_nodes(json.dumps({
+                "result": {"structure": {}, "nodes": [1, 2, 3]},
+            })),
+            3,
+        )
+        self.assertEqual(
+            m.parse_rhwp_structure_nodes(json.dumps({"children": []})), 0,
+        )
+        self.assertIsNone(m.parse_rhwp_structure_nodes(json.dumps({
+            "nodeCount": True,
+        })))
+
+
+class FidelityPairExtraTests(unittest.TestCase):
+    def test_pairs_skip_failed_and_zero_base(self):
+        m = load()
+        ref = [
+            {"file": "a", "ok": True, "chars": 10},
+            {"file": "b", "ok": True, "chars": 0},
+            {"file": "c", "ok": False, "chars": 99},
+        ]
+        tool = [
+            {"file": "a", "ok": True, "chars": 5},
+            {"file": "b", "ok": True, "chars": 1},
+            {"file": "c", "ok": True, "chars": 1},
+            {"file": "d", "ok": True, "chars": 1},
+        ]
+        pairs = m.fidelity_pairs(tool, ref)
+        self.assertEqual(pairs, [("a", 0.5)])
+
+    def test_overlap_ok_pairs_other_field(self):
+        m = load()
+        pairs = m.overlap_ok_pairs(
+            [{"file": "a", "ok": True, "chars": 3},
+             {"file": "b", "ok": True, "chars": True}],
+            [{"file": "a", "ok": True, "chars": 6},
+             {"file": "b", "ok": True, "chars": 1}],
+            "chars",
+        )
+        self.assertEqual(pairs, [("a", 3, 6)])
+
+
+class ExclusiveYesExtraTests(unittest.TestCase):
+    def test_empty_and_malformed_matrix(self):
+        m = load()
+        self.assertEqual(m.exclusive_yes({}, "rhwp"), [])
+        self.assertEqual(m.exclusive_yes({"columns": "x", "rows": None}, "rhwp"), [])
+        self.assertEqual(m.capability_label({}, "mcp"), "mcp")
+        matrix = m.capability_matrix()
+        self.assertEqual(m.capability_label(matrix, "mcp"), "MCP 서버")
+        self.assertEqual(m.capability_label(matrix, "no-such"), "no-such")
+
+    def test_exclusive_yes_skips_non_yes(self):
+        m = load()
+        matrix = {
+            "columns": [{"key": "edit"}, {"key": "mcp"}],
+            "rows": [
+                {"tool": "rhwp", "edit": "yes", "mcp": "yes"},
+                {"tool": "alt", "edit": "yes", "mcp": "no"},
+            ],
+        }
+        self.assertEqual(m.exclusive_yes(matrix, "rhwp"), ["mcp"])
+        self.assertEqual(m.exclusive_yes(matrix, "ghost"), [])
+
+
+class InventedMetricsExtraTests(unittest.TestCase):
+    def test_available_is_never_invented(self):
+        m = load()
+        self.assertFalse(m.invented_metrics({"available": True, "summary": {"ok": 1}}))
+        self.assertFalse(m.invented_metrics("x"))
+        dirty_fid = m.unavailable_result("pyhwp", "n/a")
+        dirty_fid["fidelityVsRhwp"] = 0.7
+        self.assertTrue(m.invented_metrics(dirty_fid))
+        dirty_ov = m.unavailable_result("soffice", "n/a")
+        dirty_ov["overlapMs"] = {"n": 1}
+        self.assertTrue(m.invented_metrics(dirty_ov))
+        dirty_runs = m.unavailable_result("hwplib", "n/a")
+        dirty_runs["runs"] = []
+        self.assertFalse(m.invented_metrics(dirty_runs))
+        dirty_runs["runs"] = [{"file": "a"}]
+        self.assertTrue(m.invented_metrics(dirty_runs))
+
+
+class VerdictExtraTests(unittest.TestCase):
+    def test_soffice_available_states_counts(self):
+        m = load()
+        self.assertEqual(m.soffice_verdict(None), [])
+        self.assertEqual(m.soffice_verdict("x"), [])
+        lines = m.soffice_verdict({
+            "available": True,
+            "summary": {"ok": 1, "attempted": 4},
+        })
+        self.assertEqual(len(lines), 1)
+        self.assertIn("1/4", lines[0])
+        self.assertIn("HWP5 임포트 필터", lines[0])
+
+    def test_width_silent_when_other_available(self):
+        m = load()
+        lines = m.width_verdict({
+            "info": {"results": [
+                {"tool": "rhwp", "available": True},
+                {"tool": "pyhwp", "available": True},
+            ]},
+        })
+        self.assertEqual(lines, [])
+
+    def test_export_text_without_rhwp_still_states_pyhwp(self):
+        m = load()
+        lines = m.export_text_verdict(None, {
+            "available": True,
+            "summary": {"byExt": {".hwp": {"ok": 2, "attempted": 2}}},
+        })
+        self.assertTrue(any("pyhwp" in line for line in lines))
+        self.assertFalse(any(line.startswith("rhwp 는") for line in lines))
+
+    def test_capability_verdict_empty_exclusive(self):
+        m = load()
+        matrix = {
+            "columns": [{"key": "edit", "label": "편집"}],
+            "rows": [
+                {"tool": "rhwp", "edit": "yes"},
+                {"tool": "alt", "edit": "yes"},
+            ],
+        }
+        text = m.capability_verdict(matrix)
+        self.assertIn("겹치는 축만", text)
+
+    def test_result_index_skips_non_dict(self):
+        m = load()
+        idx = m._result_index([
+            "x",
+            {"available": True},
+            {"tool": "rhwp", "available": True},
+        ])
+        self.assertEqual(list(idx), ["rhwp"])
+        self.assertEqual(m._summary_of(None), {})
+        self.assertEqual(m._summary_of({"summary": "bad"}), {})
+
+
+class AssembleEnvExtraTests(unittest.TestCase):
+    def test_counts_hwp_and_hwpx_only(self):
+        m = load()
+        env = m.assemble_env(
+            os_name="Win", python="3.12", rhwp_version="v", rhwp_profile="debug",
+            files=["a.hwp", "b.hwpx", "c.txt", "d.HWP"],
+            tools={"rhwp": {"available": True}},
+        )
+        self.assertEqual(env["corpus"]["total"], 4)
+        self.assertEqual(env["corpus"]["hwp"], 2)
+        self.assertEqual(env["corpus"]["hwpx"], 1)
+
+    def test_available_result_omits_empty_overlap_and_note(self):
+        m = load()
+        rec = m.available_result("rhwp", [
+            {"file": "a.hwp", "ok": True, "ms": 2, "chars": 1},
+        ])
+        self.assertNotIn("overlapMs", rec)
+        self.assertNotIn("note", rec)
+        rec2 = m.available_result(
+            "pyhwp",
+            [{"file": "a.hwp", "ok": True, "ms": 1, "chars": 1}],
+            overlap={"n": 1, "tool": 1, "ref": 2},
+            note="한계",
+        )
+        self.assertEqual(rec2["note"], "한계")
+        self.assertEqual(rec2["overlapMs"]["n"], 1)
+
+
+class NormalizeRunExtraTests(unittest.TestCase):
+    def test_ok_coerced_and_ext_lowered(self):
+        m = load()
+        out = m.normalize_run({"file": "A.HWP", "ext": ".HWP", "ok": 1, "ms": 3})
+        self.assertEqual(out["ext"], ".hwp")
+        self.assertIs(out["ok"], True)
+        out2 = m.normalize_run({"file": "doc.hwpx", "ok": 0})
+        self.assertEqual(out2["ext"], ".hwpx")
+        self.assertIs(out2["ok"], False)
+
+
+class SelectCorpusExtraTests(unittest.TestCase):
+    def test_ignores_doc_and_keeps_order_hwp_then_hwpx(self):
+        m = load()
+        picked = m.select_corpus_paths([
+            "z.hwpx", "m.doc", "b.hwp", "a.hwp", "n.pdf",
+        ], 0)
+        self.assertEqual(picked, ["a.hwp", "b.hwp", "z.hwpx"])
+
+    def test_per_ext_limit_does_not_steal_across_formats(self):
+        m = load()
+        picked = m.select_corpus_paths([
+            "c.hwp", "a.hwp", "b.hwp", "z.hwpx",
+        ], 1)
+        self.assertEqual(picked, ["a.hwp", "z.hwpx"])
+
+
+class RoundAndDumpExtraTests(unittest.TestCase):
+    def test_round_helpers(self):
+        m = load()
+        self.assertIsNone(m._round_ms(None))
+        self.assertEqual(m._round_ms(1.24), 1.2)
+        self.assertIsNone(m._round_int(None))
+        self.assertEqual(m._round_int(1.6), 2)
+
+    def test_dump_payload_keeps_hangul(self):
+        m = load()
+        text = m.dump_payload_json({"kind": "gymCompetitiveBench", "note": "한글"})
+        self.assertIn("한글", text)
+        self.assertTrue(text.endswith("\n"))
+        self.assertNotIn("\\u", text)
+
+
+class RenderReportExtraTests(unittest.TestCase):
+    def test_non_dict_task_and_missing_result_cell(self):
+        m = load()
+        md = m.render_report({
+            "toolOrder": ["rhwp", "pyhwp"],
+            "env": {"tools": {"rhwp": {"available": True, "detail": "v"}}},
+            "tasks": [
+                "skip-me",
+                {"task": "info", "results": [
+                    {"tool": "rhwp", "available": True,
+                     "summary": {"attempted": 1, "ok": 1, "successRate": 1.0,
+                                 "medianMs": 4}},
+                ]},
+            ],
+            "capabilityMatrix": m.capability_matrix(),
+            "verdict": [],
+            "kind": "gymCompetitiveBench",
+            "schemaVersion": "1.0",
+        })
+        self.assertIn("| **info** |", md)
+        self.assertIn("n/a", md)
+        self.assertIn("실행됨", md)
+
+    def test_notes_and_generated_comment(self):
+        m = load()
+        md = m.render_report({
+            "generatedAt": "2026-08-18T00:00:00",
+            "env": {"tools": {}},
+            "tasks": [{
+                "task": "convert",
+                "results": [
+                    {"tool": "rhwp", "available": True,
+                     "summary": {"attempted": 1, "ok": 1, "successRate": 1.0,
+                                 "medianMs": 8},
+                     "note": "HWP→markdown"},
+                ],
+            }],
+            "capabilityMatrix": m.capability_matrix(),
+            "verdict": ["측정 한 줄"],
+        })
+        self.assertIn("HWP→markdown", md)
+        self.assertIn("generated by competitive_bench.py", md)
+        self.assertIn("측정 한 줄", md)
+
+
+class ProfilePathExtraTests(unittest.TestCase):
+    def test_release_wins_over_prerelease_segment(self):
+        m = load()
+        self.assertEqual(
+            m.rhwp_profile_from_path("target/prerelease/rhwp"), "debug",
+        )
+        self.assertEqual(
+            m.rhwp_profile_from_path("C:/build/release/rhwp.exe"), "release",
+        )
+        self.assertEqual(m.rhwp_profile_from_path("just-rhwp"), "debug")
+
+
+class ResolveToolExtraTests(unittest.TestCase):
+    def test_names_scan_when_path_missing(self):
+        m = load()
+        found = m.resolve_tool(
+            None, ["hwp5txt", "soffice"],
+            exists=lambda _p: False,
+            which=lambda n: "/usr/bin/soffice" if n == "soffice" else None,
+        )
+        self.assertEqual(found, "/usr/bin/soffice")
+        self.assertEqual(
+            m.probe(None, ["missing"],),
+            None,
+        )
+
+
+class DiscoverCorpusExtraTests(unittest.TestCase):
+    def test_uppercase_ext_and_limit_one(self):
+        m = load()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "B.HWP").write_bytes(b"b")
+            (root / "a.hwp").write_bytes(b"a")
+            (root / "only.hwpx").write_bytes(b"x")
+            picked = m.discover_corpus(str(root), 1)
+        names = [Path(p).name for p in picked]
+        self.assertEqual(len(names), 2)
+        self.assertTrue(any(n.lower().endswith(".hwp") for n in names))
+        self.assertTrue(any(n.lower().endswith(".hwpx") for n in names))
+
+
+class StampAndRefreshExtraTests(unittest.TestCase):
+    def test_stamp_does_not_overwrite_existing(self):
+        m = load()
+        kept = m.stamp_report_contract({
+            "kind": "gymCompetitiveBench",
+            "schemaVersion": "1.0",
+            "custom": True,
+        })
+        self.assertTrue(kept["custom"])
+        self.assertEqual(kept["schemaVersion"], "1.0")
+
+    def test_refresh_returns_new_dict(self):
+        m = load()
+        src = {"tasks": [], "verdict": ["손글"]}
+        out = m.refresh_verdict(src)
+        self.assertIsNot(out, src)
+        self.assertEqual(src["verdict"], ["손글"])
+        self.assertNotEqual(out["verdict"], ["손글"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 요약

`gym/tools/competitive_bench.py` 경쟁 벤치의 집계·파싱·평결·보고를 순수 함수로 분리하고, rhwp 바이너리 없이 계약을 고정한다. 시험이 얇아서 리더보드 비교가 흔들리던 구멍을 막는다.

- 보고 봉투를 kind=gymCompetitiveBench, schemaVersion=1.0 으로 맞춘다. build_payload 와 --from-json 재렌더 JSON 에 같은 계약을 찍는다.
- 능력 매트릭스 검증기(validate_capability_matrix)가 모든 행·컬럼 키, yes|partial|no, rhwp 전 능력 yes 를 검사한다.
- discover_corpus / select_corpus_paths 는 임시 폴더의 dummy .hwp/.hwpx 만 고르고 .txt 는 무시하며, 형식별 limit 을 지킨다.
- info/structure/export-text 봉투 파서를 더 깐다. 빈·깨진 JSON, 비객체 page, data|result|payload 래퍼를 숫자로 꾸미지 않는다.
- 평결에 정직한 분기를 보탠다: rhwp 가 더 빠름, soffice 미가용, 겹친 파일 없음, HWPX 0/N.
- _fmt_cell 은 attempted==0 과 충실도 None 을 n/a 또는 대시로 남긴다. 못 돌린 도구에 숫자를 싣지 않는다.
- CLI 플래그 이름은 그대로다. packs·checks·coverage·robustness·profiles·README 는 건드리지 않았다.

## 관련 이슈

closes #5229

## 테스트

- python -m unittest scripts.tests.test_gym_competitive_bench -v — 89 passed
- python gym/tools/audit.py — 18 pack 통과
- cargo fmt --all -- --check 생략 (이번 변경은 Python 만. rustfmt --all 금지)
- node scripts/rust-test-suite-manifest.mjs --check 통과 (해당 없음)
- node scripts/rust-unit-test-tiers.mjs --check 통과 (해당 없음)
- cargo test 통과 (해당 없음)
- cargo clippy -- -D warnings 통과 (해당 없음)

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음
- 재현·측정: 미측정. 라이브 스윕은 기존과 같이 rhwp 가 필요하고, 단위 시험은 바이너리 없이 돈다.
