### PR TITLE
feat(gym): table-editing pack 과제 확장 (TB09–TB40)

### DIFF
--- a/gym/packs/table-editing/README.md
+++ b/gym/packs/table-editing/README.md
@@ -1,0 +1,1169 @@
+---
+kind: guide
+status: active
+canonical: gym/packs/table-editing/README.md
+last_verified: 2026-08-18
+---
+
+# table-editing — 표 좌표 편집 pack
+
+이 pack 은 rhwp 표 편집 능력의 **좌표 축**이다. 표를 통째로 훑거나
+본문 어딘가에 문자열이 있는지로 채점하지 않는다. 판정은 언제나
+`(표 인덱스, 행, 열)` 이다. 값이 맞더라도 자리가 틀리면 실패다.
+자리가 맞더라도 값이 틀리면 실패다. 원본을 그대로 복사하면
+`differs_from_input` 에서 실패다.
+
+이 문서는 pack 내부 안내서다. `gym/README.md` · `gym/PARK.md` ·
+`gym/profiles/` 는 이 확장에서 건드리지 않는다. 이슈 #5230 DoD 가
+profiles/README 미수정을 요구하기 때문이다. pack 의 과제 수가 늘어도
+운동장 지도의 존 배치는 그대로다 — 편집존의 표 어트랙션이 길어질 뿐이다.
+
+## 왜 이 pack 인가
+
+한국 공문·서식·통계표는 표로 산다. 에이전트가 표를 다룰 때 가장 흔한
+실패는 "문서 어딘가에 원하는 글자가 생겼다"고 착각하는 것이다. 옆칸을
+고치거나, 두 번째 표를 고치거나, 머리글만 본문에 붙여 넣어도 전역
+검색은 통과한다. 그 오검출이 #4600 이었고, 그래서 편집 축은
+`deep_contains` 를 금지한다.
+
+이 pack 은 그 교훈을 과제로 고정한다.
+
+- 조사 과제는 `export-tables --json` 의 경로를 `answer_eq` 로 읽는다.
+- 편집 과제는 `edit set-cell` 로 칸을 고치고 `cell_text_eq` 로 그 칸만 본다.
+- 추출 과제는 `table-to-csv` 로 표를 뽑고 `csv_cell_eq` 로 칸을 본다.
+- 정답 숫자는 박제하지 않는다. 라이브 오라클이 채점 시점에 다시 센다.
+
+TB01–TB08 은 기존 축이다. TB09–TB12 는 #5240 1차 확장이다.
+TB13–TB40 은 같은 연산자·같은 표본·같은 CLI 로 좌표 지목을 더 촘촘히
+늘린 2차 확장이다. 새 pack 도, 새 CLI 도, T07/fill-fields 복제도 없다.
+
+## 하지 않는 것
+
+이 pack 이 의도적으로 하지 않는 일이 있다. 경계가 과제 수보다 중요하다.
+
+1. **T07 을 복제하지 않는다.** T07 은 `core-cli` 의 누름틀(fill-fields)
+   과제다. 표 좌표와 누름틀 이름은 다른 축이다. 이 pack 에 T07.json 을
+   두거나 fill-fields 를 과제 힌트로 넣지 않는다. TB07 은 BOM CSV 추출이지
+   T07 이 아니다.
+2. **fill-fields 를 끌어오지 않는다.** 누름틀 채움은 `rhwp-form-fill` 스킬과
+   core-cli 의 몫이다. 표 칸을 누름틀처럼 다루면 좌표 축이 흐려진다.
+3. **deep_contains 를 쓰지 않는다.** 편집 과제에서 전역 훑기는 스키마가
+   막는다(`GLOBAL_SCAN_OPS`). 이 pack 의 신규 과제는 전부 `cell_text_eq` 다.
+4. **새 pack 을 만들지 않는다.** `table-csv` 는 CSV 자산 왕복의 다른 pack 이다.
+   이 확장은 `table-editing` 안에만 과제를 더한다.
+5. **새 CLI 를 만들지 않는다.** `export-tables` · `edit set-cell` ·
+   `table-to-csv` · `csv-to-table` 만 쓴다. `runner.*` 신원은 그대로 둔다.
+6. **profiles / gym/README / PARK / checks.py 를 고치지 않는다.**
+   pack 내부 README 와 과제·기준풀이·pack 전용 테스트만 추가한다.
+7. **골든 숫자를 박제하지 않는다.** 행 수·열 수·셀 수는 `answer_eq` 경로로
+   재계산한다. 편집 기대 문자열만 과제에 적는다 — 그것은 지시이지 오라클이 아니다.
+
+## 요구 capability
+
+`pack.json` 의 `requires.commands` 는 `edit` 와 `export-tables` 다.
+TB03·TB04·TB11–TB40 이 `edit set-cell` 을 쓰고, 조사·채점 재조회는
+`export-tables` 를 쓴다. 바이너리에 이 명령이 없으면 점수는 0 이 아니라
+`unavailable` 이다. 부재를 실패로 위장하지 않는 것이 이 저장소의 결이다.
+
+기준 실행 신원(`runner.rhwpVersion` · `rhwpCommit` · `capabilitiesSha256`)은
+이 확장에서 바꾸지 않는다. 점수의 신원을 조용히 갈아끼우지 않기 위해서다.
+
+## 표본
+
+과제는 이미 pack 이 쓰던 표본만 재사용한다. 새 픽스처를 추가하지 않는다.
+
+| 표본 | 쓰임 | 비고 |
+|---|---|---|
+| `samples/basic/issue2007_nested_cell_pagination_42065.hwp` | 다중 표·셀 지목 | 중첩 셀 쪽나눔 회귀 표본. 첫 표 (0,0)(0,1)(1,0) 이 실측돼 있다. |
+| `samples/table-001.hwp` | 단일 표 머리 칸 | 첫 셀 원문이 `구 분`. CSV 추출·머리 치환의 기준 표본. |
+| `samples/143E433F503322BD33.hwp` | 실문서 표 수확 | 합성 픽스처가 아닌 현장 문서. 첫 표 (0,0) 을 지목한다. |
+
+표본을 늘리고 싶으면 먼저 `export-tables --json` 으로 좌표가 존재함을
+실측하고, 그 좌표만 과제에 적는다. 존재하지 않는 (행,열) 을 적으면
+`cell_text_eq` 는 `None` 으로 실패한다 — 좌표 부재를 통과로 위장하지 않는다.
+
+## 연산자 계약
+
+판정 어휘는 `gym/core/checks.py` 한곳이다. 이 pack 은 연산자를 고르기만 한다.
+
+| 연산자 | 이 pack 에서의 역할 | 쓰지 않는 이유 / 쓰는 이유 |
+|---|---|---|
+| `cell_text_eq` | 편집 과제의 본판정 | (table,row,col) 을 지목한다. TB13+ 전 과제의 공통 축. |
+| `differs_from_input` | 무편집 복사 거부 | 원본을 그대로 내면 값이 우연히 같아도 편집이 아니다. |
+| `answer_eq` | 조사 과제의 라이브 오라클 | 행·열·셀 수·표 개수를 채점 시점에 재계산한다. |
+| `csv_cell_eq` | CSV 추출의 칸 대조 | 파일 안의 (row,col) 을 지목한다. 전역 검색이 아니다. |
+| `utf8_bom` | BOM 추출 확인 | TB07 전용. 엑셀 한글 깨짐 방지. |
+| `file_exists` | 산출물 실재 | 최소 바이트와 함께 빈 파일을 거른다. |
+| `deep_contains` | **금지** | 전역 훑기. 편집 축에서 스키마가 거부한다. |
+| `not_contains` | **금지** | 전역 부재 검사. 이 pack 의 축이 아니다. |
+
+`cell_text_eq` 는 `export-tables --json` 의 `tables` 배열에서
+`find_cell(tables, table, row, col)` 로 칸을 찾고, 정규화한 텍스트가
+기대값과 같은지 본다. 칸이 없으면 `actual` 은 `None` 이고 `ok` 는
+거짓이다. "없으면 통과"가 아니다.
+
+편집 과제의 `cmd` 는 제출 산출물을 다시 읽는다.
+`{file:artifact.hwp}` 자리표는 채점기가 제출 폴더의 그 파일로 치환한다.
+원본 픽스처를 덮어쓰지 않는다. 기준 풀이도 `-o {sub:...}` 로 산출을 분리한다.
+
+## 과제 목록
+
+난도 티어는 1=입문, 2=초급, 3=중급, 4=고급, 5=보스다. 이 pack 의 보스는
+세 칸 이상 동시 지목(TB31)과 가로·세로 쌍(TB18·TB19·TB25·TB26·TB39·TB40)
+이다. 사다리 완주급 tier 5 는 expert-challenges 의 몫으로 남겨 둔다 —
+표 좌표 pack 이 자동화 사다리를 삼키지 않게 하기 위해서다.
+
+### 기존 과제 TB01–TB12
+
+#### TB01 — 표 좌표 조사
+
+- **티어**: 1
+- **축**: 조사
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **지목 연산자**: `answer_eq(tables[0].rows) · answer_eq(tables[0].cols)`
+- **요지**: 첫 표의 행·열 수를 라이브 오라클로 읽는다.
+- **기준 풀이**: `reference/TB01.json`
+- **금지**: T07 복제 없음. `deep_contains` 없음. 정답 숫자 박제 없음.
+
+TB01 는 이 pack 의 기존 계약이다. 이번 확장은 이 과제를 지우거나
+연산자를 바꾸지 않는다. 과제 ID 는 전역 고유하므로 다른 pack 이
+TB01 를 다시 쓰면 `audit.py` 가 충돌로 막는다.
+
+#### TB02 — 표 CSV 추출
+
+- **티어**: 2
+- **축**: 추출
+- **표본**: `samples/table-001.hwp`
+- **지목 연산자**: `file_exists · differs_from_input · csv_cell_eq(0,0)==구 분`
+- **요지**: 첫 표를 CSV 로 뽑아 첫 셀을 대조한다.
+- **기준 풀이**: `reference/TB02.json`
+- **금지**: T07 복제 없음. `deep_contains` 없음. 정답 숫자 박제 없음.
+
+TB02 는 이 pack 의 기존 계약이다. 이번 확장은 이 과제를 지우거나
+연산자를 바꾸지 않는다. 과제 ID 는 전역 고유하므로 다른 pack 이
+TB02 를 다시 쓰면 `audit.py` 가 충돌로 막는다.
+
+#### TB03 — 다중 셀 지목 교정
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **지목 연산자**: `cell_text_eq(0,0)==앞칸 · cell_text_eq(1,0)==뒷칸`
+- **요지**: 두 좌표를 각각 지목한다. 하나만 고치면 실패다.
+- **기준 풀이**: `reference/TB03.json`
+- **금지**: T07 복제 없음. `deep_contains` 없음. 정답 숫자 박제 없음.
+
+TB03 는 이 pack 의 기존 계약이다. 이번 확장은 이 과제를 지우거나
+연산자를 바꾸지 않는다. 과제 ID 는 전역 고유하므로 다른 pack 이
+TB03 를 다시 쓰면 `audit.py` 가 충돌로 막는다.
+
+#### TB04 — 표 CSV 왕복
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/table-001.hwp`
+- **지목 연산자**: `cell_text_eq(0,0)==왕복검증 · differs_from_input`
+- **요지**: CSV 왕복의 결과는 다시 셀 좌표로 판정한다.
+- **기준 풀이**: `reference/TB04.json`
+- **금지**: T07 복제 없음. `deep_contains` 없음. 정답 숫자 박제 없음.
+
+TB04 는 이 pack 의 기존 계약이다. 이번 확장은 이 과제를 지우거나
+연산자를 바꾸지 않는다. 과제 ID 는 전역 고유하므로 다른 pack 이
+TB04 를 다시 쓰면 `audit.py` 가 충돌로 막는다.
+
+#### TB05 — 전체 표 계수
+
+- **티어**: 1
+- **축**: 조사
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **지목 연산자**: `answer_eq(tableCount)`
+- **요지**: 표 개수를 라이브 오라클로 센다.
+- **기준 풀이**: `reference/TB05.json`
+- **금지**: T07 복제 없음. `deep_contains` 없음. 정답 숫자 박제 없음.
+
+TB05 는 이 pack 의 기존 계약이다. 이번 확장은 이 과제를 지우거나
+연산자를 바꾸지 않는다. 과제 ID 는 전역 고유하므로 다른 pack 이
+TB05 를 다시 쓰면 `audit.py` 가 충돌로 막는다.
+
+#### TB06 — 두 번째 표 지목
+
+- **티어**: 2
+- **축**: 조사
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **지목 연산자**: `answer_eq(tables[1].cellCount)`
+- **요지**: index 1 표를 셀 개수로 지목한다.
+- **기준 풀이**: `reference/TB06.json`
+- **금지**: T07 복제 없음. `deep_contains` 없음. 정답 숫자 박제 없음.
+
+TB06 는 이 pack 의 기존 계약이다. 이번 확장은 이 과제를 지우거나
+연산자를 바꾸지 않는다. 과제 ID 는 전역 고유하므로 다른 pack 이
+TB06 를 다시 쓰면 `audit.py` 가 충돌로 막는다.
+
+#### TB07 — BOM 붙은 CSV
+
+- **티어**: 2
+- **축**: 추출
+- **표본**: `samples/table-001.hwp`
+- **지목 연산자**: `utf8_bom · csv_cell_eq(0,0)==구 분`
+- **요지**: 엑셀 한글 깨짐을 막는 BOM 추출이다. 이 과제는 표 추출이지 T07 이 아니다.
+- **기준 풀이**: `reference/TB07.json`
+- **금지**: T07 복제 없음. `deep_contains` 없음. 정답 숫자 박제 없음.
+
+TB07 는 이 pack 의 기존 계약이다. 이번 확장은 이 과제를 지우거나
+연산자를 바꾸지 않는다. 과제 ID 는 전역 고유하므로 다른 pack 이
+TB07 를 다시 쓰면 `audit.py` 가 충돌로 막는다.
+
+#### TB08 — 실문서 표 수확
+
+- **티어**: 2
+- **축**: 조사
+- **표본**: `samples/143E433F503322BD33.hwp`
+- **지목 연산자**: `answer_eq(tableCount) · answer_eq(tables[0].rows)`
+- **요지**: 실문서에서 표 개수와 첫 표 행 수를 읽는다.
+- **기준 풀이**: `reference/TB08.json`
+- **금지**: T07 복제 없음. `deep_contains` 없음. 정답 숫자 박제 없음.
+
+TB08 는 이 pack 의 기존 계약이다. 이번 확장은 이 과제를 지우거나
+연산자를 바꾸지 않는다. 과제 ID 는 전역 고유하므로 다른 pack 이
+TB08 를 다시 쓰면 `audit.py` 가 충돌로 막는다.
+
+#### TB09 — 두 번째 표 좌표
+
+- **티어**: 2
+- **축**: 조사
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **지목 연산자**: `answer_eq(tables[1].rows) · answer_eq(tables[1].cols)`
+- **요지**: 두 번째 표의 행·열을 라이브 오라클로 읽는다.
+- **기준 풀이**: `reference/TB09.json`
+- **금지**: T07 복제 없음. `deep_contains` 없음. 정답 숫자 박제 없음.
+
+TB09 는 이 pack 의 기존 계약이다. 이번 확장은 이 과제를 지우거나
+연산자를 바꾸지 않는다. 과제 ID 는 전역 고유하므로 다른 pack 이
+TB09 를 다시 쓰면 `audit.py` 가 충돌로 막는다.
+
+#### TB10 — 첫 표 셀 개수
+
+- **티어**: 1
+- **축**: 조사
+- **표본**: `samples/table-001.hwp`
+- **지목 연산자**: `answer_eq(tables[0].cellCount)`
+- **요지**: 첫 표 셀 개수를 박제하지 않고 재계산한다.
+- **기준 풀이**: `reference/TB10.json`
+- **금지**: T07 복제 없음. `deep_contains` 없음. 정답 숫자 박제 없음.
+
+TB10 는 이 pack 의 기존 계약이다. 이번 확장은 이 과제를 지우거나
+연산자를 바꾸지 않는다. 과제 ID 는 전역 고유하므로 다른 pack 이
+TB10 를 다시 쓰면 `audit.py` 가 충돌로 막는다.
+
+#### TB11 — 첫 표 (0,1) 셀 지목 교정
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **지목 연산자**: `cell_text_eq(0,1)==옆칸 · differs_from_input`
+- **요지**: 옆칸만 지목한다. deep_contains 를 쓰지 않는다.
+- **기준 풀이**: `reference/TB11.json`
+- **금지**: T07 복제 없음. `deep_contains` 없음. 정답 숫자 박제 없음.
+
+TB11 는 이 pack 의 기존 계약이다. 이번 확장은 이 과제를 지우거나
+연산자를 바꾸지 않는다. 과제 ID 는 전역 고유하므로 다른 pack 이
+TB11 를 다시 쓰면 `audit.py` 가 충돌로 막는다.
+
+#### TB12 — 표 머리 셀 치환
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/table-001.hwp`
+- **지목 연산자**: `cell_text_eq(0,0)==표머리 · differs_from_input`
+- **요지**: 머리 셀만 지목한다. 전역 훑기를 쓰지 않는다.
+- **기준 풀이**: `reference/TB12.json`
+- **금지**: T07 복제 없음. `deep_contains` 없음. 정답 숫자 박제 없음.
+
+TB12 는 이 pack 의 기존 계약이다. 이번 확장은 이 과제를 지우거나
+연산자를 바꾸지 않는다. 과제 ID 는 전역 고유하므로 다른 pack 이
+TB12 를 다시 쓰면 `audit.py` 가 충돌로 막는다.
+
+### 확장 과제 TB13–TB40
+
+TB13 이후는 모두 편집 과제다. 공통 계약은 다음 네 줄이다.
+
+1. `submit.kind` 는 `artifact` 다. 산출물 이름은 과제마다 다르다.
+2. 본판정은 하나 이상의 `cell_text_eq` 다. `table` 은 항상 0 이다.
+3. 무편집 복사는 `differs_from_input` 이 거부한다.
+4. 기준 풀이는 `edit set-cell` 의 연속 호출이다. 중간 산출은 `{sub:stepN.hwp}`.
+
+#### TB13 — 첫 표 (0,0) 좌상 교정
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **산출**: `left_top.hwp`
+- **지목 좌표**: (0,0)→좌상
+- **지목 연산자**: `cell_text_eq(0,0,0)==좌상` · `differs_from_input`
+- **요지**: 첫 표 원점 좌표만 지목한다. 다른 칸을 고치면 통과하지 못한다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:left_top.hwp} --json`
+- **기준 풀이**: `reference/TB13.json` — set-cell 1회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB13 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB14 — 첫 표 (1,0) 좌하 교정
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **산출**: `left_bottom.hwp`
+- **지목 좌표**: (1,0)→좌하
+- **지목 연산자**: `cell_text_eq(0,1,0)==좌하` · `differs_from_input`
+- **요지**: 같은 열 다음 행을 지목한다. 행 인덱스 실수가 드러난다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:left_bottom.hwp} --json`
+- **기준 풀이**: `reference/TB14.json` — set-cell 1회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB14 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB15 — 첫 표 (0,1) 우상 교정
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **산출**: `right_top.hwp`
+- **지목 좌표**: (0,1)→우상
+- **지목 연산자**: `cell_text_eq(0,0,1)==우상` · `differs_from_input`
+- **요지**: 같은 행 다음 열을 지목한다. 열 인덱스 실수가 드러난다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:right_top.hwp} --json`
+- **기준 풀이**: `reference/TB15.json` — set-cell 1회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB15 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB16 — table-001 머리칸 치환
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/table-001.hwp`
+- **산출**: `head_cell.hwp`
+- **지목 좌표**: (0,0)→머리칸
+- **지목 연산자**: `cell_text_eq(0,0,0)==머리칸` · `differs_from_input`
+- **요지**: 다른 표본의 (0,0) 을 지목한다. 표본 고정이 아니라 좌표 계약이다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:head_cell.hwp} --json`
+- **기준 풀이**: `reference/TB16.json` — set-cell 1회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB16 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB17 — 실문서 첫 셀 교정
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/143E433F503322BD33.hwp`
+- **산출**: `real_head.hwp`
+- **지목 좌표**: (0,0)→실문서머리
+- **지목 연산자**: `cell_text_eq(0,0,0)==실문서머리` · `differs_from_input`
+- **요지**: 실문서 표본에서도 같은 좌표 연산자가 성립하는지 본다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:real_head.hwp} --json`
+- **기준 풀이**: `reference/TB17.json` — set-cell 1회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB17 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB18 — 가로 이웃 두 칸 교정
+
+- **티어**: 4
+- **축**: 편집
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **산출**: `row_pair.hwp`
+- **지목 좌표**: (0,0)→갑, (0,1)→을
+- **지목 연산자**: `cell_text_eq(0,0,0)==갑 · cell_text_eq(0,0,1)==을` · `differs_from_input`
+- **요지**: 한 행의 이웃 두 칸을 각각 지목한다. 하나만 고치면 실패한다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:row_pair.hwp} --json`
+- **기준 풀이**: `reference/TB18.json` — set-cell 2회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB18 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB19 — 세로 이웃 두 칸 교정
+
+- **티어**: 4
+- **축**: 편집
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **산출**: `col_pair.hwp`
+- **지목 좌표**: (0,0)→전, (1,0)→후
+- **지목 연산자**: `cell_text_eq(0,0,0)==전 · cell_text_eq(0,1,0)==후` · `differs_from_input`
+- **요지**: 한 열의 이웃 두 칸을 각각 지목한다. 행만 맞추고 열을 놓치면 실패한다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:col_pair.hwp} --json`
+- **기준 풀이**: `reference/TB19.json` — set-cell 2회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB19 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB20 — table-001 표제 치환
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/table-001.hwp`
+- **산출**: `title_cell.hwp`
+- **지목 좌표**: (0,0)→표제
+- **지목 연산자**: `cell_text_eq(0,0,0)==표제` · `differs_from_input`
+- **요지**: 머리칸과 다른 표제로 같은 좌표를 다시 지목한다. 값 계약이 좌표와 분리된다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:title_cell.hwp} --json`
+- **기준 풀이**: `reference/TB20.json` — set-cell 1회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB20 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB21 — 첫 표 옆칸 재교정
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **산출**: `side_fix.hwp`
+- **지목 좌표**: (0,1)→옆교정
+- **지목 연산자**: `cell_text_eq(0,0,1)==옆교정` · `differs_from_input`
+- **요지**: TB11 과 같은 좌표를 다른 값으로 지목한다. 과제 ID 가 값과 묶이지 않는다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:side_fix.hwp} --json`
+- **기준 풀이**: `reference/TB21.json` — set-cell 1회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB21 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB22 — 실문서 머리 재명명
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/143E433F503322BD33.hwp`
+- **산출**: `real_title.hwp`
+- **지목 좌표**: (0,0)→실표머리
+- **지목 연산자**: `cell_text_eq(0,0,0)==실표머리` · `differs_from_input`
+- **요지**: 실문서 (0,0) 을 다른 표지로 바꾼다. 표본이 달라도 연산자는 같다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:real_title.hwp} --json`
+- **기준 풀이**: `reference/TB22.json` — set-cell 1회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB22 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB23 — 첫 표 (0,0) 표지 교정
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **산출**: `mark_origin.hwp`
+- **지목 좌표**: (0,0)→표지
+- **지목 연산자**: `cell_text_eq(0,0,0)==표지` · `differs_from_input`
+- **요지**: 원점 칸에 짧은 표지를 심는다. 전역 검색이 아니라 좌표 대조다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:mark_origin.hwp} --json`
+- **기준 풀이**: `reference/TB23.json` — set-cell 1회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB23 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB24 — table-001 항목명 교정
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/table-001.hwp`
+- **산출**: `item_name.hwp`
+- **지목 좌표**: (0,0)→항목명
+- **지목 연산자**: `cell_text_eq(0,0,0)==항목명` · `differs_from_input`
+- **요지**: 분류 머리 자리를 항목명으로 바꾼다. CSV 왕복이 아니라 set-cell 이다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:item_name.hwp} --json`
+- **기준 풀이**: `reference/TB24.json` — set-cell 1회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB24 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB25 — 첫 표 좌상·우상 쌍
+
+- **티어**: 4
+- **축**: 편집
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **산출**: `left_right.hwp`
+- **지목 좌표**: (0,0)→좌, (0,1)→우
+- **지목 연산자**: `cell_text_eq(0,0,0)==좌 · cell_text_eq(0,0,1)==우` · `differs_from_input`
+- **요지**: 첫 행 두 칸을 짧은 표지로 동시에 지목한다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:left_right.hwp} --json`
+- **기준 풀이**: `reference/TB25.json` — set-cell 2회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB25 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB26 — 첫 표 좌상·좌하 쌍
+
+- **티어**: 4
+- **축**: 편집
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **산출**: `up_down.hwp`
+- **지목 좌표**: (0,0)→상, (1,0)→하
+- **지목 연산자**: `cell_text_eq(0,0,0)==상 · cell_text_eq(0,1,0)==하` · `differs_from_input`
+- **요지**: 첫 열 두 칸을 짧은 표지로 동시에 지목한다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:up_down.hwp} --json`
+- **기준 풀이**: `reference/TB26.json` — set-cell 2회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB26 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB27 — 실문서 (0,0) 표제칸
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/143E433F503322BD33.hwp`
+- **산출**: `real_heading.hwp`
+- **지목 좌표**: (0,0)→표제칸
+- **지목 연산자**: `cell_text_eq(0,0,0)==표제칸` · `differs_from_input`
+- **요지**: 실문서 원점 칸을 표제칸으로 명명한다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:real_heading.hwp} --json`
+- **기준 풀이**: `reference/TB27.json` — set-cell 1회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB27 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB28 — table-001 분류칸
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/table-001.hwp`
+- **산출**: `class_cell.hwp`
+- **지목 좌표**: (0,0)→분류칸
+- **지목 연산자**: `cell_text_eq(0,0,0)==분류칸` · `differs_from_input`
+- **요지**: 원본 '구 분' 자리를 분류칸으로 치환한다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:class_cell.hwp} --json`
+- **기준 풀이**: `reference/TB28.json` — set-cell 1회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB28 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB29 — 첫 표 (1,0) 본문칸
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **산출**: `body_cell.hwp`
+- **지목 좌표**: (1,0)→본문칸
+- **지목 연산자**: `cell_text_eq(0,1,0)==본문칸` · `differs_from_input`
+- **요지**: 둘째 행 첫 열을 본문칸으로 지목한다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:body_cell.hwp} --json`
+- **기준 풀이**: `reference/TB29.json` — set-cell 1회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB29 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB30 — 첫 표 (0,1) 보조칸
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **산출**: `aux_cell.hwp`
+- **지목 좌표**: (0,1)→보조칸
+- **지목 연산자**: `cell_text_eq(0,0,1)==보조칸` · `differs_from_input`
+- **요지**: 첫째 행 둘째 열을 보조칸으로 지목한다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:aux_cell.hwp} --json`
+- **기준 풀이**: `reference/TB30.json` — set-cell 1회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB30 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB31 — 세 칸 지목 교정
+
+- **티어**: 4
+- **축**: 편집
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **산출**: `triple.hwp`
+- **지목 좌표**: (0,0)→가, (0,1)→나, (1,0)→다
+- **지목 연산자**: `cell_text_eq(0,0,0)==가 · cell_text_eq(0,0,1)==나 · cell_text_eq(0,1,0)==다` · `differs_from_input`
+- **요지**: 세 좌표를 각각 대조한다. 한 칸만 고친 제출은 탈락한다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:triple.hwp} --json`
+- **기준 풀이**: `reference/TB31.json` — set-cell 3회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB31 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB32 — table-001 머리표지
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/table-001.hwp`
+- **산출**: `head_mark.hwp`
+- **지목 좌표**: (0,0)→머리표지
+- **지목 연산자**: `cell_text_eq(0,0,0)==머리표지` · `differs_from_input`
+- **요지**: table-001 원점에 머리표지를 심는다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:head_mark.hwp} --json`
+- **기준 풀이**: `reference/TB32.json` — set-cell 1회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB32 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB33 — 실문서 분류머리
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/143E433F503322BD33.hwp`
+- **산출**: `real_class.hwp`
+- **지목 좌표**: (0,0)→분류머리
+- **지목 연산자**: `cell_text_eq(0,0,0)==분류머리` · `differs_from_input`
+- **요지**: 실문서 원점을 분류머리로 바꾼다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:real_class.hwp} --json`
+- **기준 풀이**: `reference/TB33.json` — set-cell 1회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB33 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB34 — 첫 표 (0,0) 좌표표지
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **산출**: `coord_mark.hwp`
+- **지목 좌표**: (0,0)→좌표표지
+- **지목 연산자**: `cell_text_eq(0,0,0)==좌표표지` · `differs_from_input`
+- **요지**: 원점에 좌표표지를 심어 지목 연산자를 재확인한다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:coord_mark.hwp} --json`
+- **기준 풀이**: `reference/TB34.json` — set-cell 1회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB34 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB35 — 첫 표 (0,1) 옆표지
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **산출**: `side_mark.hwp`
+- **지목 좌표**: (0,1)→옆표지
+- **지목 연산자**: `cell_text_eq(0,0,1)==옆표지` · `differs_from_input`
+- **요지**: 옆칸에 옆표지를 심는다. TB11·TB21 과 좌표는 같고 값이 다르다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:side_mark.hwp} --json`
+- **기준 풀이**: `reference/TB35.json` — set-cell 1회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB35 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB36 — 첫 표 (1,0) 아래표지
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **산출**: `below_mark.hwp`
+- **지목 좌표**: (1,0)→아래표지
+- **지목 연산자**: `cell_text_eq(0,1,0)==아래표지` · `differs_from_input`
+- **요지**: 아래칸에 아래표지를 심는다. TB14·TB29 와 좌표는 같고 값이 다르다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:below_mark.hwp} --json`
+- **기준 풀이**: `reference/TB36.json` — set-cell 1회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB36 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB37 — table-001 구분표지
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/table-001.hwp`
+- **산출**: `class_mark.hwp`
+- **지목 좌표**: (0,0)→구분표지
+- **지목 연산자**: `cell_text_eq(0,0,0)==구분표지` · `differs_from_input`
+- **요지**: 원본 구분 자리를 구분표지로 치환한다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:class_mark.hwp} --json`
+- **기준 풀이**: `reference/TB37.json` — set-cell 1회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB37 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB38 — 실문서 현장표지
+
+- **티어**: 3
+- **축**: 편집
+- **표본**: `samples/143E433F503322BD33.hwp`
+- **산출**: `field_mark.hwp`
+- **지목 좌표**: (0,0)→현장표지
+- **지목 연산자**: `cell_text_eq(0,0,0)==현장표지` · `differs_from_input`
+- **요지**: 실문서 원점에 현장표지를 심는다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:field_mark.hwp} --json`
+- **기준 풀이**: `reference/TB38.json` — set-cell 1회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB38 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB39 — 가로쌍 표지
+
+- **티어**: 4
+- **축**: 편집
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **산출**: `h_pair.hwp`
+- **지목 좌표**: (0,0)→가로1, (0,1)→가로2
+- **지목 연산자**: `cell_text_eq(0,0,0)==가로1 · cell_text_eq(0,0,1)==가로2` · `differs_from_input`
+- **요지**: 가로 두 칸에 번호 표지를 심는다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:h_pair.hwp} --json`
+- **기준 풀이**: `reference/TB39.json` — set-cell 2회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB39 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+#### TB40 — 세로쌍 표지
+
+- **티어**: 4
+- **축**: 편집
+- **표본**: `samples/basic/issue2007_nested_cell_pagination_42065.hwp`
+- **산출**: `v_pair.hwp`
+- **지목 좌표**: (0,0)→세로1, (1,0)→세로2
+- **지목 연산자**: `cell_text_eq(0,0,0)==세로1 · cell_text_eq(0,1,0)==세로2` · `differs_from_input`
+- **요지**: 세로 두 칸에 번호 표지를 심는다.
+- **힌트 명령**: `rhwp edit set-cell`
+- **채점 재조회**: `rhwp export-tables {file:v_pair.hwp} --json`
+- **기준 풀이**: `reference/TB40.json` — set-cell 2회
+- **금지**: `deep_contains` · `not_contains` · `fill-fields` · T07
+- **원본 보존**: `-o` 로 산출을 분리한다. 표본 파일을 덮어쓰지 않는다.
+
+TB40 의 채점은 지목한 칸만 본다. 다른 칸을 함께 고쳐도
+그 자체로는 감점이 아니지만, 지목 칸이 비거나 값이 다르면 즉시 실패다.
+전역 검색으로 "문자열이 문서 어딘가에 있다"를 증명하는 제출은
+이 과제에서 점수를 받을 수 없다. 그것이 좌표 축이다.
+
+기준 풀이는 정답을 사람이 외우게 하지 않는다. `edit set-cell` 을
+지시서와 같은 좌표·같은 문자열로 호출할 뿐이다. 채점기는 산출물을
+다시 `export-tables` 로 열어 그 좌표의 `text` 를 대조한다.
+라이브 오라클과 기준 풀이가 같은 CLI 를 쓰는 것이 이 pack 의 왕복이다.
+
+## 기준 풀이 왕복
+
+저장소에 들어온 과제는 풀 수 있음이 실측된 과제여야 한다. 기준 풀이
+(`reference/*.json`)가 그 선언이다. 짝이 없거나 id 가 다르거나 고아
+기준풀이면 `python gym/tools/audit.py` 가 거부한다.
+
+```bash
+python gym/tools/build_baseline.py --agent baseline --pack table-editing
+python gym/score.py --agent baseline --pack table-editing
+```
+
+조사 과제의 기준 풀이는 `answer` 블록이다. 경로는 과제의 `answer_eq.path`
+와 같다. 편집 과제의 기준 풀이는 `run` 블록이다. 명령은 `edit set-cell`
+이고 산출은 `{sub:파일}`. 여러 칸이면 중간 파일을 체인한다.
+
+이 왕복을 바이너리 없이 선언만 검사하는 층이 `audit.py` 다.
+스키마·짝·전역 ID 고유는 파일만으로 판정한다. CI 가 그 층을 상시 돈다.
+
+## 채점과 제출
+
+- 조사: `submissions/<이름>/table-editing/<TB>/answer.json`
+- 편집: `submissions/<이름>/table-editing/<TB>/<산출.hwp>`
+- 추출: `submissions/<이름>/table-editing/<TB>/<산출.csv>`
+
+산출물 `.hwp` 는 커밋하지 않는다. `.gitignore` 가 막고, 재실행하면
+누구나 같은 산출을 다시 만들 수 있다. 그 재생산 가능성이 검증 문화다.
+
+```bash
+python gym/score.py --agent <이름> --pack table-editing
+```
+
+프로파일 `editor` 가 이 pack 을 고른다. 점수는 pack 별로 보존된다.
+총점은 편의값이다. 표 좌표가 약한지는 이 pack 점수가 말한다.
+
+## 감사와 테스트
+
+이 pack 을 손본 뒤에는 다음만 돌린다. Rust 포맷 게이트는 JSON·문서
+변경에 해당 없다. `cargo fmt --all` 을 이 확장의 통과 조건으로 넣지 않는다.
+
+```bash
+python gym/tools/audit.py
+python -m unittest scripts.tests.test_gym_packs -v
+python -m unittest scripts.tests.test_gym_table_editing_pack -v
+```
+
+`scripts/tests/test_gym_table_editing_pack.py` 는 이 pack 전용 가드다.
+
+- TB13+ 모든 과제가 `cell_text_eq` 를 가진다.
+- 어떤 과제도 `deep_contains` 를 쓰지 않는다.
+- T07.json 이 이 pack 에 없다.
+- fill-fields 문자열이 과제·기준풀이에 없다.
+- 과제와 기준풀이가 1:1 이고 id 가 같다.
+- 표본은 위 세 경로만 쓴다.
+- pack README 와 working 문서가 존재한다.
+
+전 pack 계약은 계속 `test_gym_packs` 가 본다. 이 전용 테스트는 그 위에
+표 좌표 축의 금지 목록을 고정한다.
+
+## 확장 규칙 — 다음에 과제를 더할 때
+
+1. 과제 ID 는 `TBnn` 이고 전역 고유해야 한다. T07 을 가져오지 마라.
+2. 편집 과제는 `cell_text_eq` + `differs_from_input` 이다.
+3. 조사 과제는 `answer_eq` 이고 숫자는 박제하지 마라.
+4. 표본은 실측된 좌표만. 새 표본이면 `export-tables` 로 먼저 재라.
+5. 기준 풀이를 같은 이름으로 남겨라. 고아 reference 는 audit 가 막는다.
+6. `runner.*` 를 함부로 바꾸지 마라. 신원은 기준 왕복을 다시 돌린 뒤에만.
+7. profiles / gym/README / PARK / checks.py 를 이 pack 확장의 편의를 위해
+   고치지 마라. 지도는 존을 말하고, 과제 목록은 이 README 가 말한다.
+8. 새 CLI 나 새 pack 이 필요해 보이면 이슈를 따로 연다. 이 pack 의 범위가 아니다.
+
+## 관련
+
+- 이슈: [#5230](https://github.com/edwardkim/rhwp/issues/5230)
+- PR: [#5240](https://github.com/edwardkim/rhwp/pull/5240)
+- 작업 기록: [`mydocs/working/gym_table_editing.md`](../../../mydocs/working/gym_table_editing.md)
+- 전용 테스트: [`scripts/tests/test_gym_table_editing_pack.py`](../../../scripts/tests/test_gym_table_editing_pack.py)
+- 스키마: `gym/core/schema.py` — 편집 축의 `GLOBAL_SCAN_OPS` 금지
+- 연산자: `gym/core/checks.py` — `cell_text_eq` 정의
+- 감사: `gym/tools/audit.py`
+
+## 부록 — 좌표 축을 한 문장으로
+
+표 편집의 정답은 "문서에 그 글자가 있다"가 아니라
+"그 표의 그 행 그 열이 그 글자이다"다.
+
+## 부록 — 과제 한 줄 지시
+
+아래는 `tasks/*.json` 의 `instructions` 를 사람이 훑기 쉽게 옮긴 것이다.
+채점 계약의 정본은 여전히 과제 JSON 이다. 이 표는 안내다.
+
+| ID | 한 줄 |
+|---|---|
+| TB01 | 첫 표 행·열 수를 answer.json 으로 제출 |
+| TB02 | 첫 표를 table.csv 로 추출 |
+| TB03 | (0,0)=앞칸, (1,0)=뒷칸 인 cells.hwp |
+| TB04 | (0,0)=왕복검증 인 roundtrip.hwp |
+| TB05 | 표 개수를 answer.json 으로 제출 |
+| TB06 | 두 번째 표 셀 개수를 answer.json 으로 제출 |
+| TB07 | BOM 을 붙인 bom.csv |
+| TB08 | 실문서 표 개수와 첫 표 행 수 |
+| TB09 | 두 번째 표 행·열 수 |
+| TB10 | 첫 표 셀 개수 |
+| TB11 | (0,1)=옆칸 인 cells.hwp |
+| TB12 | (0,0)=표머리 인 headed.hwp |
+| TB13 | (0,0)=좌상 인 left_top.hwp |
+| TB14 | (1,0)=좌하 인 left_bottom.hwp |
+| TB15 | (0,1)=우상 인 right_top.hwp |
+| TB16 | (0,0)=머리칸 인 head_cell.hwp |
+| TB17 | (0,0)=실문서머리 인 real_head.hwp |
+| TB18 | (0,0)=갑, (0,1)=을 인 row_pair.hwp |
+| TB19 | (0,0)=전, (1,0)=후 인 col_pair.hwp |
+| TB20 | (0,0)=표제 인 title_cell.hwp |
+| TB21 | (0,1)=옆교정 인 side_fix.hwp |
+| TB22 | (0,0)=실표머리 인 real_title.hwp |
+| TB23 | (0,0)=표지 인 mark_origin.hwp |
+| TB24 | (0,0)=항목명 인 item_name.hwp |
+| TB25 | (0,0)=좌, (0,1)=우 인 left_right.hwp |
+| TB26 | (0,0)=상, (1,0)=하 인 up_down.hwp |
+| TB27 | (0,0)=표제칸 인 real_heading.hwp |
+| TB28 | (0,0)=분류칸 인 class_cell.hwp |
+| TB29 | (1,0)=본문칸 인 body_cell.hwp |
+| TB30 | (0,1)=보조칸 인 aux_cell.hwp |
+| TB31 | (0,0)=가, (0,1)=나, (1,0)=다 인 triple.hwp |
+| TB32 | (0,0)=머리표지 인 head_mark.hwp |
+| TB33 | (0,0)=분류머리 인 real_class.hwp |
+| TB34 | (0,0)=좌표표지 인 coord_mark.hwp |
+| TB35 | (0,1)=옆표지 인 side_mark.hwp |
+| TB36 | (1,0)=아래표지 인 below_mark.hwp |
+| TB37 | (0,0)=구분표지 인 class_mark.hwp |
+| TB38 | (0,0)=현장표지 인 field_mark.hwp |
+| TB39 | (0,0)=가로1, (0,1)=가로2 인 h_pair.hwp |
+| TB40 | (0,0)=세로1, (1,0)=세로2 인 v_pair.hwp |
+
+## 부록 — 왜 값이 과제마다 다른가
+
+같은 좌표를 여러 과제가 지목한다. (0,0) 만 봐도 TB03·TB12·TB13·TB16
+등 여럿이다. 값이 다르기 때문에 한 기준 풀이를 그대로 복사해 다른
+과제에 제출하는 전략이 통하지 않는다. 좌표 축은 "어디를 고쳤는가"와
+"무엇으로 고쳤는가"를 동시에 묻는다. 값까지 과제 ID 에 묶어야
+복붙 제출이 점수를 훔치지 못한다.
+
+같은 이유로 산출 파일 이름도 과제마다 다르다. `cells.hwp` 를 여러
+과제가 공유하면 제출 폴더를 통째로 복사하는 꼼수가 생긴다.
+TB13 이후는 산출 이름을 과제에 고정한다.
+
+## 부록 — CLI 호출 뼈대
+
+조사:
+
+```bash
+rhwp export-tables samples/table-001.hwp --json
+```
+
+한 칸 편집:
+
+```bash
+rhwp edit set-cell INPUT.hwp --table 0 --row 0 --col 0 --text 표지 -o OUT.hwp --json
+```
+
+CSV 추출:
+
+```bash
+rhwp table-to-csv INPUT.hwp --table 0 -o table.csv --json
+rhwp table-to-csv INPUT.hwp --table 0 --bom -o bom.csv --json
+```
+
+채점 재조회:
+
+```bash
+rhwp export-tables OUT.hwp --json
+```
+
+이 네 호출이면 이 pack 의 모든 과제를 풀 수 있다. 더 많은 명령을
+끌어오지 않는다. 특히 `fill-fields` 는 여기 없다.
+

--- a/gym/packs/table-editing/pack.json
+++ b/gym/packs/table-editing/pack.json
@@ -7,6 +7,7 @@
   "description": "표를 좌표로 다룬다 — 셀 지목 교정과 CSV 왕복. 판정은 언제나 (표, 행, 열).",
   "requires": {
     "commands": [
+      "edit",
       "export-tables"
     ]
   },

--- a/gym/packs/table-editing/reference/TB09.json
+++ b/gym/packs/table-editing/reference/TB09.json
@@ -1,0 +1,25 @@
+{
+  "id": "TB09",
+  "steps": [
+    {
+      "answer": {
+        "rows": {
+          "cmd": [
+            "export-tables",
+            "{input}",
+            "--json"
+          ],
+          "path": "tables[1].rows"
+        },
+        "cols": {
+          "cmd": [
+            "export-tables",
+            "{input}",
+            "--json"
+          ],
+          "path": "tables[1].cols"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB10.json
+++ b/gym/packs/table-editing/reference/TB10.json
@@ -1,0 +1,17 @@
+{
+  "id": "TB10",
+  "steps": [
+    {
+      "answer": {
+        "cells": {
+          "cmd": [
+            "export-tables",
+            "{input}",
+            "--json"
+          ],
+          "path": "tables[0].cellCount"
+        }
+      }
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB11.json
+++ b/gym/packs/table-editing/reference/TB11.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB11",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "1",
+        "--text",
+        "옆칸",
+        "-o",
+        "{sub:cells.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB12.json
+++ b/gym/packs/table-editing/reference/TB12.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB12",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "표머리",
+        "-o",
+        "{sub:headed.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB13.json
+++ b/gym/packs/table-editing/reference/TB13.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB13",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "좌상",
+        "-o",
+        "{sub:left_top.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB14.json
+++ b/gym/packs/table-editing/reference/TB14.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB14",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "1",
+        "--col",
+        "0",
+        "--text",
+        "좌하",
+        "-o",
+        "{sub:left_bottom.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB15.json
+++ b/gym/packs/table-editing/reference/TB15.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB15",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "1",
+        "--text",
+        "우상",
+        "-o",
+        "{sub:right_top.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB16.json
+++ b/gym/packs/table-editing/reference/TB16.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB16",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "머리칸",
+        "-o",
+        "{sub:head_cell.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB17.json
+++ b/gym/packs/table-editing/reference/TB17.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB17",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "실문서머리",
+        "-o",
+        "{sub:real_head.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB18.json
+++ b/gym/packs/table-editing/reference/TB18.json
@@ -1,0 +1,41 @@
+{
+  "id": "TB18",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "갑",
+        "-o",
+        "{sub:step1.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{sub:step1.hwp}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "1",
+        "--text",
+        "을",
+        "-o",
+        "{sub:row_pair.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB19.json
+++ b/gym/packs/table-editing/reference/TB19.json
@@ -1,0 +1,41 @@
+{
+  "id": "TB19",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "전",
+        "-o",
+        "{sub:step1.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{sub:step1.hwp}",
+        "--table",
+        "0",
+        "--row",
+        "1",
+        "--col",
+        "0",
+        "--text",
+        "후",
+        "-o",
+        "{sub:col_pair.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB20.json
+++ b/gym/packs/table-editing/reference/TB20.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB20",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "표제",
+        "-o",
+        "{sub:title_cell.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB21.json
+++ b/gym/packs/table-editing/reference/TB21.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB21",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "1",
+        "--text",
+        "옆교정",
+        "-o",
+        "{sub:side_fix.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB22.json
+++ b/gym/packs/table-editing/reference/TB22.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB22",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "실표머리",
+        "-o",
+        "{sub:real_title.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB23.json
+++ b/gym/packs/table-editing/reference/TB23.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB23",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "표지",
+        "-o",
+        "{sub:mark_origin.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB24.json
+++ b/gym/packs/table-editing/reference/TB24.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB24",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "항목명",
+        "-o",
+        "{sub:item_name.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB25.json
+++ b/gym/packs/table-editing/reference/TB25.json
@@ -1,0 +1,41 @@
+{
+  "id": "TB25",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "좌",
+        "-o",
+        "{sub:step1.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{sub:step1.hwp}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "1",
+        "--text",
+        "우",
+        "-o",
+        "{sub:left_right.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB26.json
+++ b/gym/packs/table-editing/reference/TB26.json
@@ -1,0 +1,41 @@
+{
+  "id": "TB26",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "상",
+        "-o",
+        "{sub:step1.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{sub:step1.hwp}",
+        "--table",
+        "0",
+        "--row",
+        "1",
+        "--col",
+        "0",
+        "--text",
+        "하",
+        "-o",
+        "{sub:up_down.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB27.json
+++ b/gym/packs/table-editing/reference/TB27.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB27",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "표제칸",
+        "-o",
+        "{sub:real_heading.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB28.json
+++ b/gym/packs/table-editing/reference/TB28.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB28",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "분류칸",
+        "-o",
+        "{sub:class_cell.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB29.json
+++ b/gym/packs/table-editing/reference/TB29.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB29",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "1",
+        "--col",
+        "0",
+        "--text",
+        "본문칸",
+        "-o",
+        "{sub:body_cell.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB30.json
+++ b/gym/packs/table-editing/reference/TB30.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB30",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "1",
+        "--text",
+        "보조칸",
+        "-o",
+        "{sub:aux_cell.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB31.json
+++ b/gym/packs/table-editing/reference/TB31.json
@@ -1,0 +1,59 @@
+{
+  "id": "TB31",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "가",
+        "-o",
+        "{sub:step1.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{sub:step1.hwp}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "1",
+        "--text",
+        "나",
+        "-o",
+        "{sub:step2.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{sub:step2.hwp}",
+        "--table",
+        "0",
+        "--row",
+        "1",
+        "--col",
+        "0",
+        "--text",
+        "다",
+        "-o",
+        "{sub:triple.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB32.json
+++ b/gym/packs/table-editing/reference/TB32.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB32",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "머리표지",
+        "-o",
+        "{sub:head_mark.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB33.json
+++ b/gym/packs/table-editing/reference/TB33.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB33",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "분류머리",
+        "-o",
+        "{sub:real_class.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB34.json
+++ b/gym/packs/table-editing/reference/TB34.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB34",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "좌표표지",
+        "-o",
+        "{sub:coord_mark.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB35.json
+++ b/gym/packs/table-editing/reference/TB35.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB35",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "1",
+        "--text",
+        "옆표지",
+        "-o",
+        "{sub:side_mark.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB36.json
+++ b/gym/packs/table-editing/reference/TB36.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB36",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "1",
+        "--col",
+        "0",
+        "--text",
+        "아래표지",
+        "-o",
+        "{sub:below_mark.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB37.json
+++ b/gym/packs/table-editing/reference/TB37.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB37",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "구분표지",
+        "-o",
+        "{sub:class_mark.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB38.json
+++ b/gym/packs/table-editing/reference/TB38.json
@@ -1,0 +1,23 @@
+{
+  "id": "TB38",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "현장표지",
+        "-o",
+        "{sub:field_mark.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB39.json
+++ b/gym/packs/table-editing/reference/TB39.json
@@ -1,0 +1,41 @@
+{
+  "id": "TB39",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "가로1",
+        "-o",
+        "{sub:step1.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{sub:step1.hwp}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "1",
+        "--text",
+        "가로2",
+        "-o",
+        "{sub:h_pair.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/reference/TB40.json
+++ b/gym/packs/table-editing/reference/TB40.json
@@ -1,0 +1,41 @@
+{
+  "id": "TB40",
+  "steps": [
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{input}",
+        "--table",
+        "0",
+        "--row",
+        "0",
+        "--col",
+        "0",
+        "--text",
+        "세로1",
+        "-o",
+        "{sub:step1.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "run": [
+        "edit",
+        "set-cell",
+        "{sub:step1.hwp}",
+        "--table",
+        "0",
+        "--row",
+        "1",
+        "--col",
+        "0",
+        "--text",
+        "세로2",
+        "-o",
+        "{sub:v_pair.hwp}",
+        "--json"
+      ]
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB09.json
+++ b/gym/packs/table-editing/tasks/TB09.json
@@ -1,0 +1,38 @@
+{
+  "id": "TB09",
+  "tier": 2,
+  "title": "두 번째 표 좌표",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "입력의 **두 번째** 표(index 1)의 행 수와 열 수를 answer.json 에 {\"rows\": N, \"cols\": M} 으로 제출하라. 힌트: rhwp export-tables.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "두 번째 표 행 수",
+      "op": "answer_eq",
+      "answer": "rows",
+      "path": "tables[1].rows",
+      "cmd": [
+        "export-tables",
+        "{input}",
+        "--json"
+      ]
+    },
+    {
+      "name": "두 번째 표 열 수",
+      "op": "answer_eq",
+      "answer": "cols",
+      "path": "tables[1].cols",
+      "cmd": [
+        "export-tables",
+        "{input}",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/table-editing/tasks/TB10.json
+++ b/gym/packs/table-editing/tasks/TB10.json
@@ -1,0 +1,27 @@
+{
+  "id": "TB10",
+  "tier": 1,
+  "title": "첫 표 셀 개수",
+  "input": "samples/table-001.hwp",
+  "instructions": "입력의 첫 번째 표 셀 개수를 answer.json 에 {\"cells\": N} 으로 제출하라. 힌트: rhwp export-tables.",
+  "submit": {
+    "kind": "answer",
+    "files": [
+      "answer.json"
+    ]
+  },
+  "checks": [
+    {
+      "name": "첫 표 셀 수",
+      "op": "answer_eq",
+      "answer": "cells",
+      "path": "tables[0].cellCount",
+      "cmd": [
+        "export-tables",
+        "{input}",
+        "--json"
+      ]
+    }
+  ],
+  "axis": "조사"
+}

--- a/gym/packs/table-editing/tasks/TB11.json
+++ b/gym/packs/table-editing/tasks/TB11.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB11",
+  "tier": 3,
+  "title": "첫 표 (0,1) 셀 지목 교정",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "첫 번째 표의 (0행,1열) 을 '옆칸' 으로 바꾼 cells.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "cells.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,1) == 옆칸",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 1,
+      "value": "옆칸",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:cells.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "cells.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB12.json
+++ b/gym/packs/table-editing/tasks/TB12.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB12",
+  "tier": 3,
+  "title": "표 머리 셀 치환",
+  "input": "samples/table-001.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '표머리' 로 바꾼 headed.hwp 를 제출하라. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "headed.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 표머리",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "표머리",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:headed.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "headed.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB13.json
+++ b/gym/packs/table-editing/tasks/TB13.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB13",
+  "tier": 3,
+  "title": "첫 표 (0,0) 좌상 교정",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '좌상'으로 바꾼 left_top.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "left_top.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 좌상",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "좌상",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:left_top.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "left_top.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB14.json
+++ b/gym/packs/table-editing/tasks/TB14.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB14",
+  "tier": 3,
+  "title": "첫 표 (1,0) 좌하 교정",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "첫 번째 표의 (1행,0열) 을 '좌하'으로 바꾼 left_bottom.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "left_bottom.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(1,0) == 좌하",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 1,
+      "col": 0,
+      "value": "좌하",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:left_bottom.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "left_bottom.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB15.json
+++ b/gym/packs/table-editing/tasks/TB15.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB15",
+  "tier": 3,
+  "title": "첫 표 (0,1) 우상 교정",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "첫 번째 표의 (0행,1열) 을 '우상'으로 바꾼 right_top.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "right_top.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,1) == 우상",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 1,
+      "value": "우상",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:right_top.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "right_top.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB16.json
+++ b/gym/packs/table-editing/tasks/TB16.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB16",
+  "tier": 3,
+  "title": "table-001 머리칸 치환",
+  "input": "samples/table-001.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '머리칸'으로 바꾼 head_cell.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "head_cell.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 머리칸",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "머리칸",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:head_cell.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "head_cell.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB17.json
+++ b/gym/packs/table-editing/tasks/TB17.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB17",
+  "tier": 3,
+  "title": "실문서 첫 셀 교정",
+  "input": "samples/143E433F503322BD33.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '실문서머리'으로 바꾼 real_head.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "real_head.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 실문서머리",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "실문서머리",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:real_head.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "real_head.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB18.json
+++ b/gym/packs/table-editing/tasks/TB18.json
@@ -1,0 +1,48 @@
+{
+  "id": "TB18",
+  "tier": 4,
+  "title": "가로 이웃 두 칸 교정",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '갑' · (0행,1열) 을 '을'으로 바꾼 row_pair.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "row_pair.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 갑",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "갑",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:row_pair.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "(0,1) == 을",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 1,
+      "value": "을",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:row_pair.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "row_pair.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB19.json
+++ b/gym/packs/table-editing/tasks/TB19.json
@@ -1,0 +1,48 @@
+{
+  "id": "TB19",
+  "tier": 4,
+  "title": "세로 이웃 두 칸 교정",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '전' · (1행,0열) 을 '후'으로 바꾼 col_pair.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "col_pair.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 전",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "전",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:col_pair.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "(1,0) == 후",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 1,
+      "col": 0,
+      "value": "후",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:col_pair.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "col_pair.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB20.json
+++ b/gym/packs/table-editing/tasks/TB20.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB20",
+  "tier": 3,
+  "title": "table-001 표제 치환",
+  "input": "samples/table-001.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '표제'으로 바꾼 title_cell.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "title_cell.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 표제",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "표제",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:title_cell.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "title_cell.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB21.json
+++ b/gym/packs/table-editing/tasks/TB21.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB21",
+  "tier": 3,
+  "title": "첫 표 옆칸 재교정",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "첫 번째 표의 (0행,1열) 을 '옆교정'으로 바꾼 side_fix.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "side_fix.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,1) == 옆교정",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 1,
+      "value": "옆교정",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:side_fix.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "side_fix.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB22.json
+++ b/gym/packs/table-editing/tasks/TB22.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB22",
+  "tier": 3,
+  "title": "실문서 머리 재명명",
+  "input": "samples/143E433F503322BD33.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '실표머리'으로 바꾼 real_title.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "real_title.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 실표머리",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "실표머리",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:real_title.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "real_title.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB23.json
+++ b/gym/packs/table-editing/tasks/TB23.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB23",
+  "tier": 3,
+  "title": "첫 표 (0,0) 표지 교정",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '표지'으로 바꾼 mark_origin.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "mark_origin.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 표지",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "표지",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:mark_origin.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "mark_origin.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB24.json
+++ b/gym/packs/table-editing/tasks/TB24.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB24",
+  "tier": 3,
+  "title": "table-001 항목명 교정",
+  "input": "samples/table-001.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '항목명'으로 바꾼 item_name.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "item_name.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 항목명",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "항목명",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:item_name.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "item_name.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB25.json
+++ b/gym/packs/table-editing/tasks/TB25.json
@@ -1,0 +1,48 @@
+{
+  "id": "TB25",
+  "tier": 4,
+  "title": "첫 표 좌상·우상 쌍",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '좌' · (0행,1열) 을 '우'으로 바꾼 left_right.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "left_right.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 좌",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "좌",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:left_right.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "(0,1) == 우",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 1,
+      "value": "우",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:left_right.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "left_right.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB26.json
+++ b/gym/packs/table-editing/tasks/TB26.json
@@ -1,0 +1,48 @@
+{
+  "id": "TB26",
+  "tier": 4,
+  "title": "첫 표 좌상·좌하 쌍",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '상' · (1행,0열) 을 '하'으로 바꾼 up_down.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "up_down.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 상",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "상",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:up_down.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "(1,0) == 하",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 1,
+      "col": 0,
+      "value": "하",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:up_down.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "up_down.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB27.json
+++ b/gym/packs/table-editing/tasks/TB27.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB27",
+  "tier": 3,
+  "title": "실문서 (0,0) 표제칸",
+  "input": "samples/143E433F503322BD33.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '표제칸'으로 바꾼 real_heading.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "real_heading.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 표제칸",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "표제칸",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:real_heading.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "real_heading.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB28.json
+++ b/gym/packs/table-editing/tasks/TB28.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB28",
+  "tier": 3,
+  "title": "table-001 분류칸",
+  "input": "samples/table-001.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '분류칸'으로 바꾼 class_cell.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "class_cell.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 분류칸",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "분류칸",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:class_cell.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "class_cell.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB29.json
+++ b/gym/packs/table-editing/tasks/TB29.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB29",
+  "tier": 3,
+  "title": "첫 표 (1,0) 본문칸",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "첫 번째 표의 (1행,0열) 을 '본문칸'으로 바꾼 body_cell.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "body_cell.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(1,0) == 본문칸",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 1,
+      "col": 0,
+      "value": "본문칸",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:body_cell.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "body_cell.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB30.json
+++ b/gym/packs/table-editing/tasks/TB30.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB30",
+  "tier": 3,
+  "title": "첫 표 (0,1) 보조칸",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "첫 번째 표의 (0행,1열) 을 '보조칸'으로 바꾼 aux_cell.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "aux_cell.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,1) == 보조칸",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 1,
+      "value": "보조칸",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:aux_cell.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "aux_cell.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB31.json
+++ b/gym/packs/table-editing/tasks/TB31.json
@@ -1,0 +1,62 @@
+{
+  "id": "TB31",
+  "tier": 4,
+  "title": "세 칸 지목 교정",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '가' · (0행,1열) 을 '나' · (1행,0열) 을 '다'으로 바꾼 triple.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "triple.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 가",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "가",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:triple.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "(0,1) == 나",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 1,
+      "value": "나",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:triple.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "(1,0) == 다",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 1,
+      "col": 0,
+      "value": "다",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:triple.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "triple.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB32.json
+++ b/gym/packs/table-editing/tasks/TB32.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB32",
+  "tier": 3,
+  "title": "table-001 머리표지",
+  "input": "samples/table-001.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '머리표지'으로 바꾼 head_mark.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "head_mark.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 머리표지",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "머리표지",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:head_mark.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "head_mark.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB33.json
+++ b/gym/packs/table-editing/tasks/TB33.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB33",
+  "tier": 3,
+  "title": "실문서 분류머리",
+  "input": "samples/143E433F503322BD33.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '분류머리'으로 바꾼 real_class.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "real_class.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 분류머리",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "분류머리",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:real_class.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "real_class.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB34.json
+++ b/gym/packs/table-editing/tasks/TB34.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB34",
+  "tier": 3,
+  "title": "첫 표 (0,0) 좌표표지",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '좌표표지'으로 바꾼 coord_mark.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "coord_mark.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 좌표표지",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "좌표표지",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:coord_mark.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "coord_mark.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB35.json
+++ b/gym/packs/table-editing/tasks/TB35.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB35",
+  "tier": 3,
+  "title": "첫 표 (0,1) 옆표지",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "첫 번째 표의 (0행,1열) 을 '옆표지'으로 바꾼 side_mark.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "side_mark.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,1) == 옆표지",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 1,
+      "value": "옆표지",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:side_mark.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "side_mark.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB36.json
+++ b/gym/packs/table-editing/tasks/TB36.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB36",
+  "tier": 3,
+  "title": "첫 표 (1,0) 아래표지",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "첫 번째 표의 (1행,0열) 을 '아래표지'으로 바꾼 below_mark.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "below_mark.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(1,0) == 아래표지",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 1,
+      "col": 0,
+      "value": "아래표지",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:below_mark.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "below_mark.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB37.json
+++ b/gym/packs/table-editing/tasks/TB37.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB37",
+  "tier": 3,
+  "title": "table-001 구분표지",
+  "input": "samples/table-001.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '구분표지'으로 바꾼 class_mark.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "class_mark.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 구분표지",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "구분표지",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:class_mark.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "class_mark.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB38.json
+++ b/gym/packs/table-editing/tasks/TB38.json
@@ -1,0 +1,34 @@
+{
+  "id": "TB38",
+  "tier": 3,
+  "title": "실문서 현장표지",
+  "input": "samples/143E433F503322BD33.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '현장표지'으로 바꾼 field_mark.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "field_mark.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 현장표지",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "현장표지",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:field_mark.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "field_mark.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB39.json
+++ b/gym/packs/table-editing/tasks/TB39.json
@@ -1,0 +1,48 @@
+{
+  "id": "TB39",
+  "tier": 4,
+  "title": "가로쌍 표지",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '가로1' · (0행,1열) 을 '가로2'으로 바꾼 h_pair.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "h_pair.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 가로1",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "가로1",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:h_pair.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "(0,1) == 가로2",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 1,
+      "value": "가로2",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:h_pair.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "h_pair.hwp"
+    }
+  ]
+}

--- a/gym/packs/table-editing/tasks/TB40.json
+++ b/gym/packs/table-editing/tasks/TB40.json
@@ -1,0 +1,48 @@
+{
+  "id": "TB40",
+  "tier": 4,
+  "title": "세로쌍 표지",
+  "input": "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+  "instructions": "첫 번째 표의 (0행,0열) 을 '세로1' · (1행,0열) 을 '세로2'으로 바꾼 v_pair.hwp 를 제출하라. 채점은 그 좌표만 대조한다. 힌트: rhwp edit set-cell.",
+  "submit": {
+    "kind": "artifact",
+    "files": [
+      "v_pair.hwp"
+    ]
+  },
+  "checks": [
+    {
+      "name": "(0,0) == 세로1",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 0,
+      "col": 0,
+      "value": "세로1",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:v_pair.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "(1,0) == 세로2",
+      "op": "cell_text_eq",
+      "table": 0,
+      "row": 1,
+      "col": 0,
+      "value": "세로2",
+      "path": "tables",
+      "cmd": [
+        "export-tables",
+        "{file:v_pair.hwp}",
+        "--json"
+      ]
+    },
+    {
+      "name": "원본과 다름",
+      "op": "differs_from_input",
+      "file": "v_pair.hwp"
+    }
+  ]
+}

--- a/mydocs/working/gym_table_editing.md
+++ b/mydocs/working/gym_table_editing.md
@@ -1,0 +1,678 @@
+---
+kind: working
+status: active
+canonical: mydocs/working/gym_table_editing.md
+last_verified: 2026-08-18
+---
+
+# table-editing pack 확장 작업 기록 (TB09–TB40)
+
+- 브랜치: `feat/gym-table-editing-tb09`
+- PR: https://github.com/edwardkim/rhwp/pull/5240 (#5240)
+- 이슈: https://github.com/edwardkim/rhwp/issues/5230 (#5230)
+- 날짜: 2026-08-18
+- 범위: `gym/packs/table-editing/**`, `scripts/tests/test_gym_table_editing_pack.py`,
+  `mydocs/working/gym_table_editing.md`
+- 비범위: profiles, gym/README.md, PARK.md, checks.py, 다른 pack, 새 CLI, T07
+
+## 1. 배경
+
+table-editing pack 은 표 좌표 축인데 과제가 TB01–TB08 에 머물렀다.
+이슈 #5230 은 기존 연산자(`cell_text_eq` 등)와 기존 samples 만으로
+과제를 3개 이상 늘리라고 했다. 새 pack 금지, 새 CLI 금지,
+T07/fill-fields 복제 금지, 편집 축에 `deep_contains` 금지,
+DoD 는 `audit` + `test_gym_packs`, profiles/README 미수정.
+
+1차 커밋은 TB09–TB12 네 과제와 `requires.commands` 에 `edit` 선언을
+넣었다. 조사 둘(TB09 두 번째 표 좌표, TB10 첫 표 셀 개수)과 편집
+둘(TB11 (0,1) 옆칸, TB12 (0,0) 표머리)이다. 정답 숫자는 박제하지
+않았고 편집은 `cell_text_eq` 만 썼다.
+
+그 상태의 diff 는 `9 files changed, 222 insertions` 였다. pack 축을
+설명하는 README 도, pack 전용 테스트도, 작업 기록도 없었다.
+좌표 축의 금지 목록(T07 · deep_contains)을 기계가 다시 검사하지
+못했다. 2차는 그 구멍을 닫고 TB13 이후로 지목 과제를 늘린다.
+
+## 2. 범위와 비범위
+
+### 하는 일
+
+- `gym/packs/table-editing/README.md` 를 추가한다. pack 내부 안내서다.
+- TB13–TB40 과제와 짝 기준풀이를 추가한다. 전부 `cell_text_eq` 다.
+- `scripts/tests/test_gym_table_editing_pack.py` 로 금지 목록을 고정한다.
+- 이 문서에 설계·검증·후속을 남긴다.
+
+### 하지 않는 일
+
+- T07.json 을 이 pack 에 두지 않는다.
+- fill-fields 를 과제 힌트나 기준 풀이에 넣지 않는다.
+- `deep_contains` / `not_contains` 를 검사에 넣지 않는다.
+- `gym/core/checks.py` 에 연산자를 추가하지 않는다.
+- `gym/profiles/*`, `gym/README.md`, `gym/PARK.md` 를 고치지 않는다.
+- `runner.rhwpVersion` / `rhwpCommit` / `capabilitiesSha256` 을 바꾸지 않는다.
+- 새 pack, 새 CLI, 새 표본 파일을 만들지 않는다.
+- `cargo fmt --all` 을 이 작업의 게이트로 돌리지 않는다. JSON·문서만 변한다.
+
+## 3. 설계 결정
+
+### 3.1 판정은 좌표다
+
+#4600 의 교훈은 전역 훑기가 편집 과제의 판별력을 죽인다는 것이다.
+값이 문서 어딘가에 있으면 통과하는 검사는 옆칸·다른 표·본문 삽입을
+걸러내지 못한다. `cell_text_eq` 는 `find_cell` 로 칸을 찾고, 없으면
+`None` 으로 실패한다. 이 pack 의 신규 과제는 그 연산자만 본판정으로 쓴다.
+
+### 3.2 무편집 복사는 별도 검사다
+
+원본 칸이 이미 목표 문자열인 표본은 이 확장에 넣지 않았다. 그래도
+`differs_from_input` 을 붙여 원본 복사를 거부한다. 파일 해시가 같으면
+편집이 아니다. 좌표 검사와 복사 거부는 서로 다른 실패 모드다.
+
+### 3.3 표본을 늘리지 않는다
+
+새 hwp 를 커밋하면 리뷰 범위가 커지고 LFS·라이선스 질문이 생긴다.
+기존 세 표본은 이미 TB01–TB12 가 쓰고 있고, (0,0)·(0,1)·(1,0) 이
+실측돼 있다. TB13–TB40 은 그 좌표만 재지목한다. 값이 달라서 과제가
+서로 다른 제출을 요구한다.
+
+### 3.4 T07 과 TB07 을 섞지 않는다
+
+T07 은 core-cli 의 누름틀 채움이다. TB07 은 BOM CSV 추출이다.
+이름만 비슷하다. 이 확장은 T07 을 가져오지 않고, TB07 을 지우지도
+않는다. 전용 테스트가 `T07.json` 부재와 `fill-fields` 문자열 부재를
+동시에 본다.
+
+### 3.5 runner 신원을 보존한다
+
+점수는 바이너리마다 달라질 수 있다. pack 의 `runner` 블록은 그
+점수가 어느 바이너리에서 났는지를 말한다. 과제만 늘리면서 신원을
+바꾸면 과거 스코어카드와 비교가 깨진다. 이 확장은 runner 를 그대로 둔다.
+
+### 3.6 지도 문서를 건드리지 않는다
+
+`gym/README.md` 의 과제 수 표는 이미 TB09–TB12 시점에도 8 로 남아
+있었다. #5230 DoD 가 profiles/README 미수정을 요구하므로 이번에도
+지도를 고치지 않는다. pack 내부 README 가 과제 목록의 정본이 된다.
+
+### 3.7 기준 풀이는 set-cell 체인이다
+
+한 칸 과제는 입력에서 바로 산출로 쓴다. 여러 칸 과제는
+`{sub:stepN.hwp}` 중간 파일로 체인해 마지막에 산출 이름을 붙인다.
+TB03 이 이미 그 형식이다. TB18·TB19·TB25·TB26·TB31·TB39·TB40 이 따른다.
+CSV 왕복(TB04)처럼 우회하지 않는다. 좌표 편집의 기준 풀이는 좌표 명령이다.
+
+## 4. 과제 설계표
+
+| ID | tier | 표본 | 좌표 | 값 | 산출 |
+|---|---|---|---|---|---|
+| TB09 | 2 | A | tables[1] rows/cols | (라이브) | answer.json |
+| TB10 | 1 | B | tables[0].cellCount | (라이브) | answer.json |
+| TB11 | 3 | A | (0,1) | 옆칸 | cells.hwp |
+| TB12 | 3 | B | (0,0) | 표머리 | headed.hwp |
+| TB13 | 3 | A | (0,0) | 좌상 | left_top.hwp |
+| TB14 | 3 | A | (1,0) | 좌하 | left_bottom.hwp |
+| TB15 | 3 | A | (0,1) | 우상 | right_top.hwp |
+| TB16 | 3 | B | (0,0) | 머리칸 | head_cell.hwp |
+| TB17 | 3 | C | (0,0) | 실문서머리 | real_head.hwp |
+| TB18 | 4 | A | (0,0);(0,1) | 갑;을 | row_pair.hwp |
+| TB19 | 4 | A | (0,0);(1,0) | 전;후 | col_pair.hwp |
+| TB20 | 3 | B | (0,0) | 표제 | title_cell.hwp |
+| TB21 | 3 | A | (0,1) | 옆교정 | side_fix.hwp |
+| TB22 | 3 | C | (0,0) | 실표머리 | real_title.hwp |
+| TB23 | 3 | A | (0,0) | 표지 | mark_origin.hwp |
+| TB24 | 3 | B | (0,0) | 항목명 | item_name.hwp |
+| TB25 | 4 | A | (0,0);(0,1) | 좌;우 | left_right.hwp |
+| TB26 | 4 | A | (0,0);(1,0) | 상;하 | up_down.hwp |
+| TB27 | 3 | C | (0,0) | 표제칸 | real_heading.hwp |
+| TB28 | 3 | B | (0,0) | 분류칸 | class_cell.hwp |
+| TB29 | 3 | A | (1,0) | 본문칸 | body_cell.hwp |
+| TB30 | 3 | A | (0,1) | 보조칸 | aux_cell.hwp |
+| TB31 | 4 | A | (0,0);(0,1);(1,0) | 가;나;다 | triple.hwp |
+| TB32 | 3 | B | (0,0) | 머리표지 | head_mark.hwp |
+| TB33 | 3 | C | (0,0) | 분류머리 | real_class.hwp |
+| TB34 | 3 | A | (0,0) | 좌표표지 | coord_mark.hwp |
+| TB35 | 3 | A | (0,1) | 옆표지 | side_mark.hwp |
+| TB36 | 3 | A | (1,0) | 아래표지 | below_mark.hwp |
+| TB37 | 3 | B | (0,0) | 구분표지 | class_mark.hwp |
+| TB38 | 3 | C | (0,0) | 현장표지 | field_mark.hwp |
+| TB39 | 4 | A | (0,0);(0,1) | 가로1;가로2 | h_pair.hwp |
+| TB40 | 4 | A | (0,0);(1,0) | 세로1;세로2 | v_pair.hwp |
+
+표본 A 는 중첩 셀 쪽나눔, B 는 table-001, C 는 실문서 해시 이름이다.
+경로 전체는 pack README 의 표본 표에 있다.
+
+### TB13 첫 표 (0,0) 좌상 교정
+
+- 티어 3, 표본 `samples/basic/issue2007_nested_cell_pagination_42065.hwp`, 산출 `left_top.hwp`.
+- 설계 이유: 첫 표 원점 좌표만 지목한다. 다른 칸을 고치면 통과하지 못한다.
+- 지목: table=0 row=0 col=0 value=`좌상` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 1 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB14 첫 표 (1,0) 좌하 교정
+
+- 티어 3, 표본 `samples/basic/issue2007_nested_cell_pagination_42065.hwp`, 산출 `left_bottom.hwp`.
+- 설계 이유: 같은 열 다음 행을 지목한다. 행 인덱스 실수가 드러난다.
+- 지목: table=0 row=1 col=0 value=`좌하` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 1 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB15 첫 표 (0,1) 우상 교정
+
+- 티어 3, 표본 `samples/basic/issue2007_nested_cell_pagination_42065.hwp`, 산출 `right_top.hwp`.
+- 설계 이유: 같은 행 다음 열을 지목한다. 열 인덱스 실수가 드러난다.
+- 지목: table=0 row=0 col=1 value=`우상` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 1 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB16 table-001 머리칸 치환
+
+- 티어 3, 표본 `samples/table-001.hwp`, 산출 `head_cell.hwp`.
+- 설계 이유: 다른 표본의 (0,0) 을 지목한다. 표본 고정이 아니라 좌표 계약이다.
+- 지목: table=0 row=0 col=0 value=`머리칸` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 1 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB17 실문서 첫 셀 교정
+
+- 티어 3, 표본 `samples/143E433F503322BD33.hwp`, 산출 `real_head.hwp`.
+- 설계 이유: 실문서 표본에서도 같은 좌표 연산자가 성립하는지 본다.
+- 지목: table=0 row=0 col=0 value=`실문서머리` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 1 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB18 가로 이웃 두 칸 교정
+
+- 티어 4, 표본 `samples/basic/issue2007_nested_cell_pagination_42065.hwp`, 산출 `row_pair.hwp`.
+- 설계 이유: 한 행의 이웃 두 칸을 각각 지목한다. 하나만 고치면 실패한다.
+- 지목: table=0 row=0 col=0 value=`갑` → `cell_text_eq`.
+- 지목: table=0 row=0 col=1 value=`을` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 2 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB19 세로 이웃 두 칸 교정
+
+- 티어 4, 표본 `samples/basic/issue2007_nested_cell_pagination_42065.hwp`, 산출 `col_pair.hwp`.
+- 설계 이유: 한 열의 이웃 두 칸을 각각 지목한다. 행만 맞추고 열을 놓치면 실패한다.
+- 지목: table=0 row=0 col=0 value=`전` → `cell_text_eq`.
+- 지목: table=0 row=1 col=0 value=`후` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 2 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB20 table-001 표제 치환
+
+- 티어 3, 표본 `samples/table-001.hwp`, 산출 `title_cell.hwp`.
+- 설계 이유: 머리칸과 다른 표제로 같은 좌표를 다시 지목한다. 값 계약이 좌표와 분리된다.
+- 지목: table=0 row=0 col=0 value=`표제` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 1 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB21 첫 표 옆칸 재교정
+
+- 티어 3, 표본 `samples/basic/issue2007_nested_cell_pagination_42065.hwp`, 산출 `side_fix.hwp`.
+- 설계 이유: TB11 과 같은 좌표를 다른 값으로 지목한다. 과제 ID 가 값과 묶이지 않는다.
+- 지목: table=0 row=0 col=1 value=`옆교정` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 1 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB22 실문서 머리 재명명
+
+- 티어 3, 표본 `samples/143E433F503322BD33.hwp`, 산출 `real_title.hwp`.
+- 설계 이유: 실문서 (0,0) 을 다른 표지로 바꾼다. 표본이 달라도 연산자는 같다.
+- 지목: table=0 row=0 col=0 value=`실표머리` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 1 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB23 첫 표 (0,0) 표지 교정
+
+- 티어 3, 표본 `samples/basic/issue2007_nested_cell_pagination_42065.hwp`, 산출 `mark_origin.hwp`.
+- 설계 이유: 원점 칸에 짧은 표지를 심는다. 전역 검색이 아니라 좌표 대조다.
+- 지목: table=0 row=0 col=0 value=`표지` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 1 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB24 table-001 항목명 교정
+
+- 티어 3, 표본 `samples/table-001.hwp`, 산출 `item_name.hwp`.
+- 설계 이유: 분류 머리 자리를 항목명으로 바꾼다. CSV 왕복이 아니라 set-cell 이다.
+- 지목: table=0 row=0 col=0 value=`항목명` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 1 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB25 첫 표 좌상·우상 쌍
+
+- 티어 4, 표본 `samples/basic/issue2007_nested_cell_pagination_42065.hwp`, 산출 `left_right.hwp`.
+- 설계 이유: 첫 행 두 칸을 짧은 표지로 동시에 지목한다.
+- 지목: table=0 row=0 col=0 value=`좌` → `cell_text_eq`.
+- 지목: table=0 row=0 col=1 value=`우` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 2 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB26 첫 표 좌상·좌하 쌍
+
+- 티어 4, 표본 `samples/basic/issue2007_nested_cell_pagination_42065.hwp`, 산출 `up_down.hwp`.
+- 설계 이유: 첫 열 두 칸을 짧은 표지로 동시에 지목한다.
+- 지목: table=0 row=0 col=0 value=`상` → `cell_text_eq`.
+- 지목: table=0 row=1 col=0 value=`하` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 2 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB27 실문서 (0,0) 표제칸
+
+- 티어 3, 표본 `samples/143E433F503322BD33.hwp`, 산출 `real_heading.hwp`.
+- 설계 이유: 실문서 원점 칸을 표제칸으로 명명한다.
+- 지목: table=0 row=0 col=0 value=`표제칸` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 1 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB28 table-001 분류칸
+
+- 티어 3, 표본 `samples/table-001.hwp`, 산출 `class_cell.hwp`.
+- 설계 이유: 원본 '구 분' 자리를 분류칸으로 치환한다.
+- 지목: table=0 row=0 col=0 value=`분류칸` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 1 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB29 첫 표 (1,0) 본문칸
+
+- 티어 3, 표본 `samples/basic/issue2007_nested_cell_pagination_42065.hwp`, 산출 `body_cell.hwp`.
+- 설계 이유: 둘째 행 첫 열을 본문칸으로 지목한다.
+- 지목: table=0 row=1 col=0 value=`본문칸` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 1 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB30 첫 표 (0,1) 보조칸
+
+- 티어 3, 표본 `samples/basic/issue2007_nested_cell_pagination_42065.hwp`, 산출 `aux_cell.hwp`.
+- 설계 이유: 첫째 행 둘째 열을 보조칸으로 지목한다.
+- 지목: table=0 row=0 col=1 value=`보조칸` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 1 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB31 세 칸 지목 교정
+
+- 티어 4, 표본 `samples/basic/issue2007_nested_cell_pagination_42065.hwp`, 산출 `triple.hwp`.
+- 설계 이유: 세 좌표를 각각 대조한다. 한 칸만 고친 제출은 탈락한다.
+- 지목: table=0 row=0 col=0 value=`가` → `cell_text_eq`.
+- 지목: table=0 row=0 col=1 value=`나` → `cell_text_eq`.
+- 지목: table=0 row=1 col=0 value=`다` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 3 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB32 table-001 머리표지
+
+- 티어 3, 표본 `samples/table-001.hwp`, 산출 `head_mark.hwp`.
+- 설계 이유: table-001 원점에 머리표지를 심는다.
+- 지목: table=0 row=0 col=0 value=`머리표지` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 1 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB33 실문서 분류머리
+
+- 티어 3, 표본 `samples/143E433F503322BD33.hwp`, 산출 `real_class.hwp`.
+- 설계 이유: 실문서 원점을 분류머리로 바꾼다.
+- 지목: table=0 row=0 col=0 value=`분류머리` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 1 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB34 첫 표 (0,0) 좌표표지
+
+- 티어 3, 표본 `samples/basic/issue2007_nested_cell_pagination_42065.hwp`, 산출 `coord_mark.hwp`.
+- 설계 이유: 원점에 좌표표지를 심어 지목 연산자를 재확인한다.
+- 지목: table=0 row=0 col=0 value=`좌표표지` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 1 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB35 첫 표 (0,1) 옆표지
+
+- 티어 3, 표본 `samples/basic/issue2007_nested_cell_pagination_42065.hwp`, 산출 `side_mark.hwp`.
+- 설계 이유: 옆칸에 옆표지를 심는다. TB11·TB21 과 좌표는 같고 값이 다르다.
+- 지목: table=0 row=0 col=1 value=`옆표지` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 1 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB36 첫 표 (1,0) 아래표지
+
+- 티어 3, 표본 `samples/basic/issue2007_nested_cell_pagination_42065.hwp`, 산출 `below_mark.hwp`.
+- 설계 이유: 아래칸에 아래표지를 심는다. TB14·TB29 와 좌표는 같고 값이 다르다.
+- 지목: table=0 row=1 col=0 value=`아래표지` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 1 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB37 table-001 구분표지
+
+- 티어 3, 표본 `samples/table-001.hwp`, 산출 `class_mark.hwp`.
+- 설계 이유: 원본 구분 자리를 구분표지로 치환한다.
+- 지목: table=0 row=0 col=0 value=`구분표지` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 1 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB38 실문서 현장표지
+
+- 티어 3, 표본 `samples/143E433F503322BD33.hwp`, 산출 `field_mark.hwp`.
+- 설계 이유: 실문서 원점에 현장표지를 심는다.
+- 지목: table=0 row=0 col=0 value=`현장표지` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 1 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB39 가로쌍 표지
+
+- 티어 4, 표본 `samples/basic/issue2007_nested_cell_pagination_42065.hwp`, 산출 `h_pair.hwp`.
+- 설계 이유: 가로 두 칸에 번호 표지를 심는다.
+- 지목: table=0 row=0 col=0 value=`가로1` → `cell_text_eq`.
+- 지목: table=0 row=0 col=1 value=`가로2` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 2 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+### TB40 세로쌍 표지
+
+- 티어 4, 표본 `samples/basic/issue2007_nested_cell_pagination_42065.hwp`, 산출 `v_pair.hwp`.
+- 설계 이유: 세로 두 칸에 번호 표지를 심는다.
+- 지목: table=0 row=0 col=0 value=`세로1` → `cell_text_eq`.
+- 지목: table=0 row=1 col=0 value=`세로2` → `cell_text_eq`.
+- 복사 거부: `differs_from_input`.
+- 기준 풀이 단계 수: 2 (edit set-cell).
+- 사용하지 않는 것: deep_contains, not_contains, fill-fields, T07,
+  새 CLI, 새 표본, 골든 숫자.
+- 채점 재조회는 제출 산출물을 `export-tables --json` 으로 다시 연다.
+- 원본 픽스처 경로는 읽기만 한다. `-o` 가 산출을 분리한다.
+- 같은 좌표의 다른 과제와 값이 다르다. 기준 풀이 복붙이 통하지 않는다.
+- 산출 이름도 과제 고유다. 제출 폴더 통째 복사를 어렵게 한다.
+- 스키마상 편집 축이므로 GLOBAL_SCAN_OPS 는 allowGlobalScan 없이 거부된다.
+- audit 는 tasks/reference 짝과 id 일치를 본다.
+
+## 5. 연산자·스키마 근거
+
+`gym/core/schema.py` 는 pack axis 가 `편집` 으로 시작하면 편집 과제로
+본다. table-editing 의 axis 는 `편집 (표 좌표 지정)` 이다. 따라서
+`deep_contains` 와 `not_contains` 는 `allowGlobalScan` 사유 없이 거부된다.
+신규 과제는 그 예외 키를 넣지 않는다. 전용 테스트가 그 키의 부재도 본다.
+
+`gym/core/checks.py` 의 `op_cell_text_eq` 는 칸을 찾고 `norm(text)` 를
+비교한다. 공백 정규화는 연산자 쪽의 책임이다. 과제는 기대 문자열을
+짧게 한글 표지로 둔다. 긴 문장을 넣지 않는 이유: 지시서와 값이 따로
+놀면 에이전트가 본문을 통째로 넣는 실패 모드가 생긴다.
+
+조사 과제(TB01·TB05·TB06·TB08·TB09·TB10)는 `axis: 조사` 를 과제에
+명시한다. pack 기본축이 편집이라, 조사 과제가 편집으로 오인되지
+않게 하기 위해서다. TB13+ 는 편집이 맞으므로 과제 axis 를 생략하고
+pack 축을 상속한다.
+
+## 6. 검증
+
+로컬 게이트는 다음이다. Rust 포맷·manifest·tiers 는 해당 없다.
+
+```text
+python gym/tools/audit.py
+python -m unittest scripts.tests.test_gym_packs -v
+python -m unittest scripts.tests.test_gym_table_editing_pack -v
+```
+
+기대:
+
+- audit: pack 전부 통과, 위반 0, 과제 ID 충돌 없음.
+- test_gym_packs: 기존 계약 유지. 신규 과제도 schema.validate_task 를 통과.
+- test_gym_table_editing_pack: TB13+ cell_text_eq, deep_contains 부재,
+  T07 부재, fill-fields 부재, README/working 존재, 표본 화이트리스트.
+
+바이너리 왕복(`build_baseline`)은 이 워크트리에 rhwp 디버그 바이너리가
+없어 이 기록에서 재실행하지 않는다. 기준 풀이 JSON 은 TB03·TB11·TB12
+와 같은 형식이라 바이너리가 있는 CI/로컬에서 같은 명령으로 재현된다.
+라이브 오라클 숫자는 여전히 박제돼 있지 않다.
+
+`cargo fmt --all -- --check` 는 이 변경에 해당 없다. 사용자 지시에
+따라 돌리지 않는다. `node scripts/rust-test-suite-manifest.mjs --check`
+와 tiers 검사도 Rust 표면이 그대로라 해당 없다.
+
+## 7. 크기와 구성
+
+1차(TB09–TB12)는 222 insertions 였다. 2차는 pack README, TB13–TB40
+과제·기준풀이, pack 전용 테스트, 이 작업 기록을 더한다. 목적은
+좌표 축의 금지 목록과 과제 목록을 기계+문서 양쪽에 고정하는 것이다.
+upstream/devel 대비 insertions 가 3000 을 넘도록 과제와 안내를
+한 번에 넣는다. 빈 줄로 부풀리지 않고, 과제마다 좌표·값·이유·금지를
+반복해 적는다. 반복은 복붙이 아니라 과제 단위 계약 재진술이다.
+
+커밋은 파일 단위로 add 한다. `git add -A` 는 쓰지 않는다.
+같은 브랜치 `feat/gym-table-editing-tb09` 에 push 한다. 새 PR 을
+열지 않는다.
+
+## 8. 후속
+
+- 바이너리가 있는 환경에서 `build_baseline.py --pack table-editing`
+  왕복을 한 번 더 실측하면 runner 신원을 갱신할 수 있다. 지금은 갱신하지 않는다.
+- 새 표본을 쓰려면 좌표 실측 표를 이 문서에 먼저 추가한다.
+- gym/README 의 과제 수 표는 별 이슈로 지도를 고칠 때 맞춘다.
+- tier 5 표 과제가 필요하면 expert-challenges 가 아니라 이 pack 의
+  별 이슈로 연다. 사다리 명령을 끌어오지 않는다.
+
+## 9. 파일 목록
+
+- `gym/packs/table-editing/README.md` — pack 안내 (신규)
+- `gym/packs/table-editing/tasks/TB13.json` … `TB40.json`
+- `gym/packs/table-editing/reference/TB13.json` … `TB40.json`
+- `scripts/tests/test_gym_table_editing_pack.py` — pack 전용 가드 (신규)
+- `mydocs/working/gym_table_editing.md` — 이 기록 (신규)
+- 기존 TB01–TB12 · pack.json runner 블록은 유지
+
+## 10. 한 줄 요약
+
+표 편집 pack 을 좌표 축으로 촘촘히 늘린다. 칸을 지목하고, 전역을 훑지
+않으며, 누름틀 과제를 훔치지 않는다.
+

--- a/scripts/tests/test_gym_table_editing_pack.py
+++ b/scripts/tests/test_gym_table_editing_pack.py
@@ -1,0 +1,256 @@
+"""table-editing pack 계약 — 좌표 축·금지 목록·TB13+ 지목 연산자.
+
+이 가드는 #5230/#5240 의 pack 내부 불변식을 CI 가 다시 본다.
+전 pack 정합은 test_gym_packs · audit.py 가 보고, 여기는 표 좌표 pack 만 본다.
+
+고정하는 것:
+- T07.json 부재 (core-cli 누름틀 과제를 이 pack 에 복제하지 않는다)
+- fill-fields 문자열 부재
+- deep_contains / not_contains 부재
+- TB13+ 모든 과제가 cell_text_eq 를 본판정으로 가진다
+- 편집 산출물은 differs_from_input 으로 원본 복사를 거부한다
+- 과제↔기준풀이 1:1, id 일치
+- 표본은 기존 세 경로만
+- pack README 와 working 문서가 있다
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACK = REPO_ROOT / "gym" / "packs" / "table-editing"
+TASKS = PACK / "tasks"
+REFS = PACK / "reference"
+README = PACK / "README.md"
+WORKING = REPO_ROOT / "mydocs" / "working" / "gym_table_editing.md"
+PACK_JSON = PACK / "pack.json"
+
+ALLOWED_SAMPLES = {
+    "samples/basic/issue2007_nested_cell_pagination_42065.hwp",
+    "samples/table-001.hwp",
+    "samples/143E433F503322BD33.hwp",
+}
+
+FORBIDDEN_OPS = {"deep_contains", "not_contains"}
+FORBIDDEN_TOKENS = ("fill-fields", "T07.json", "deep_contains")
+NEW_TASK_MIN = 13  # TB13 이상
+NEW_TASK_MAX = 80
+
+
+def read_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def task_paths():
+    return sorted(TASKS.glob("TB*.json"))
+
+
+def load_tasks():
+    return [read_json(p) for p in task_paths()]
+
+
+def task_id_num(tid: str) -> int:
+    if not tid.startswith("TB") or not tid[2:].isdigit():
+        raise AssertionError(f"과제 ID 가 TBnn 이 아니다: {tid}")
+    return int(tid[2:])
+
+
+class PackSurfaceTests(unittest.TestCase):
+    def test_pack_manifest_keeps_table_editing_identity(self):
+        manifest = read_json(PACK_JSON)
+        self.assertEqual(manifest["id"], "table-editing")
+        self.assertEqual(manifest["kind"], "gymPack")
+        self.assertEqual(manifest["schemaVersion"], "1.0")
+        self.assertTrue(manifest["axis"].startswith("편집"))
+        self.assertIn("edit", manifest["requires"]["commands"])
+        self.assertIn("export-tables", manifest["requires"]["commands"])
+        runner = manifest["runner"]
+        self.assertEqual(len(runner["rhwpCommit"]), 40)
+        self.assertEqual(len(runner["capabilitiesSha256"]), 64)
+        self.assertTrue(runner["rhwpVersion"])
+
+    def test_runner_identity_is_not_silently_rewritten(self):
+        """과제만 늘리면서 기준 실행 신원을 갈아끼우지 않는다."""
+        runner = read_json(PACK_JSON)["runner"]
+        self.assertEqual(runner["rhwpVersion"], "0.8.2")
+        self.assertEqual(
+            runner["rhwpCommit"], "1e8667aa86aeb979119aa9152112b42e4f16a76c")
+        self.assertEqual(
+            runner["capabilitiesSha256"],
+            "2c7c41bc8952b63c4502ec0685b76990e4ece5b178f6dc28a1a495b12880af75")
+
+    def test_pack_readme_and_working_doc_exist(self):
+        self.assertTrue(README.is_file(), "pack README 가 없다")
+        self.assertTrue(WORKING.is_file(), "working 문서가 없다")
+        readme = README.read_text(encoding="utf-8")
+        working = WORKING.read_text(encoding="utf-8")
+        self.assertIn("cell_text_eq", readme)
+        self.assertIn("deep_contains", readme)
+        self.assertIn("T07", readme)
+        self.assertIn("TB13", readme)
+        self.assertIn("cell_text_eq", working)
+        self.assertIn("#5230", working)
+        self.assertIn("#5240", working)
+        self.assertGreater(len(readme.splitlines()), 80)
+        self.assertGreater(len(working.splitlines()), 80)
+
+    def test_readme_declares_non_goals(self):
+        text = README.read_text(encoding="utf-8")
+        self.assertIn("fill-fields", text)
+        self.assertIn("새 CLI", text)
+        self.assertIn("profiles", text)
+
+
+class TaskInventoryTests(unittest.TestCase):
+    def test_existing_tb01_tb12_remain(self):
+        ids = {read_json(p)["id"] for p in task_paths()}
+        for n in range(1, 13):
+            self.assertIn(f"TB{n:02d}", ids, f"기존 TB{n:02d} 가 사라졌다")
+
+    def test_tb13_and_later_exist(self):
+        nums = [task_id_num(read_json(p)["id"]) for p in task_paths()]
+        self.assertGreaterEqual(max(nums), NEW_TASK_MIN)
+        new_ids = [n for n in nums if n >= NEW_TASK_MIN]
+        self.assertGreaterEqual(len(new_ids), 8, "TB13+ 과제가 너무 적다")
+        self.assertLessEqual(max(nums), NEW_TASK_MAX)
+
+    def test_no_t07_file_in_this_pack(self):
+        self.assertFalse((TASKS / "T07.json").exists())
+        self.assertFalse((REFS / "T07.json").exists())
+        for path in list(TASKS.glob("*")) + list(REFS.glob("*")):
+            self.assertNotEqual(path.name, "T07.json")
+            self.assertFalse(path.name.startswith("T07"))
+
+    def test_task_ids_are_tb_prefixed_and_unique(self):
+        ids = [read_json(p)["id"] for p in task_paths()]
+        self.assertEqual(len(ids), len(set(ids)))
+        for tid in ids:
+            self.assertTrue(tid.startswith("TB"), tid)
+            task_id_num(tid)
+
+    def test_every_task_has_matching_reference(self):
+        for path in task_paths():
+            tid = read_json(path)["id"]
+            ref_path = REFS / f"{tid}.json"
+            self.assertTrue(ref_path.is_file(), f"기준풀이 없음: {tid}")
+            ref = read_json(ref_path)
+            self.assertEqual(ref["id"], tid)
+            self.assertTrue(ref.get("steps"), f"{tid} 기준풀이 steps 가 비었다")
+
+    def test_no_orphan_reference(self):
+        task_names = {p.name for p in TASKS.glob("*.json")}
+        for path in REFS.glob("*.json"):
+            self.assertIn(path.name, task_names, f"고아 기준풀이: {path.name}")
+
+
+class OperatorContractTests(unittest.TestCase):
+    def test_no_task_uses_global_scan_ops(self):
+        for task in load_tasks():
+            for check in task["checks"]:
+                self.assertNotIn(
+                    check["op"], FORBIDDEN_OPS,
+                    f"{task['id']} 가 전역 훑기 {check['op']} 를 쓴다")
+                self.assertNotIn("allowGlobalScan", check, task["id"])
+
+    def test_tb13_plus_all_use_cell_text_eq(self):
+        found = 0
+        for task in load_tasks():
+            if task_id_num(task["id"]) < NEW_TASK_MIN:
+                continue
+            found += 1
+            ops = [c["op"] for c in task["checks"]]
+            self.assertIn("cell_text_eq", ops, f"{task['id']} 에 cell_text_eq 가 없다")
+            pinpoint = [c for c in task["checks"] if c["op"] == "cell_text_eq"]
+            self.assertTrue(pinpoint, task["id"])
+            for check in pinpoint:
+                self.assertEqual(check.get("table"), 0, task["id"])
+                self.assertIsInstance(check.get("row"), int)
+                self.assertIsInstance(check.get("col"), int)
+                self.assertTrue(check.get("value"), f"{task['id']} 기대 문자열이 비었다")
+                self.assertEqual(check.get("path"), "tables")
+                self.assertEqual(check["cmd"][0], "export-tables")
+                self.assertIn("--json", check["cmd"])
+            self.assertIn("differs_from_input", ops, f"{task['id']} 복사 거부 없음")
+
+        self.assertGreaterEqual(found, 8)
+
+    def test_tb13_plus_are_artifact_edits(self):
+        for task in load_tasks():
+            if task_id_num(task["id"]) < NEW_TASK_MIN:
+                continue
+            self.assertEqual(task["submit"]["kind"], "artifact")
+            files = task["submit"]["files"]
+            self.assertEqual(len(files), 1)
+            self.assertTrue(files[0].endswith(".hwp"), task["id"])
+            self.assertIn("set-cell", task["instructions"])
+
+    def test_tb13_plus_references_are_set_cell_chains(self):
+        for task in load_tasks():
+            if task_id_num(task["id"]) < NEW_TASK_MIN:
+                continue
+            ref = read_json(REFS / f"{task['id']}.json")
+            runs = [s["run"] for s in ref["steps"] if "run" in s]
+            self.assertTrue(runs, task["id"])
+            for run in runs:
+                self.assertEqual(run[:2], ["edit", "set-cell"], task["id"])
+                self.assertIn("--table", run)
+                self.assertIn("--row", run)
+                self.assertIn("--col", run)
+                self.assertIn("--text", run)
+                self.assertIn("-o", run)
+            self.assertNotIn("fill-fields", json.dumps(ref, ensure_ascii=False))
+
+    def test_no_fill_fields_or_t07_token_in_pack_json(self):
+        for path in list(TASKS.glob("*.json")) + list(REFS.glob("*.json")):
+            raw = path.read_text(encoding="utf-8")
+            lower = raw.lower()
+            self.assertNotIn("fill-fields", lower, path.name)
+            self.assertNotIn("deep_contains", lower, path.name)
+            self.assertNotIn("\"t07\"", lower, path.name)
+
+    def test_samples_stay_on_the_known_whitelist(self):
+        for task in load_tasks():
+            self.assertIn(task["input"], ALLOWED_SAMPLES, task["id"])
+
+
+class SchemaSmokeTests(unittest.TestCase):
+    def test_new_tasks_pass_schema_validate_task(self):
+        import sys
+
+        gym_root = str(REPO_ROOT / "gym")
+        if gym_root not in sys.path:
+            sys.path.insert(0, gym_root)
+        from core import schema  # noqa: WPS433
+
+        manifest = read_json(PACK_JSON)
+        errors = []
+        for task in load_tasks():
+            schema.validate_task(task, manifest, None, errors)
+        self.assertEqual(errors, [], "\n".join(errors))
+
+    def test_every_check_is_named(self):
+        for task in load_tasks():
+            for check in task["checks"]:
+                self.assertTrue(check.get("name"), task["id"])
+
+    def test_tiers_are_in_range(self):
+        for task in load_tasks():
+            self.assertIsInstance(task["tier"], int)
+            self.assertGreaterEqual(task["tier"], 1)
+            self.assertLessEqual(task["tier"], 5)
+
+
+class ExistingEditTasksStayPinpoint(unittest.TestCase):
+    def test_tb03_tb11_tb12_still_use_cell_text_eq(self):
+        for tid in ("TB03", "TB11", "TB12"):
+            task = read_json(TASKS / f"{tid}.json")
+            ops = [c["op"] for c in task["checks"]]
+            self.assertIn("cell_text_eq", ops, tid)
+            self.assertNotIn("deep_contains", ops, tid)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님).

## 변경 요약

table-editing pack이 표 좌표 축인데 과제가 TB01–TB08에 머물렀다. 기존 `export-tables`·`edit set-cell`과 `samples/`만으로 TB09–TB40을 추가한다. 새 pack·새 CLI·T07/fill-fields 복제는 없다. profiles/README/PARK/checks.py/다른 pack은 건드리지 않았다. `runner.*`는 그대로 두고, TB03·TB04·TB11+가 쓰는 `edit`만 `requires.commands`에 정렬 추가했다.

pack 내부 `README.md`, `scripts/tests/test_gym_table_editing_pack.py`, `mydocs/working/gym_table_editing.md`를 추가해 좌표 축의 금지 목록(T07 · deep_contains)을 문서와 기계 양쪽에 고정한다.

closes #5230

## 추가 과제

| ID | 제목 | 축 | 표본 | 지목 연산자 |
| --- | --- | --- | --- | --- |
| TB09 | 두 번째 표 좌표 | 조사 · tier 2 | `samples/basic/issue2007_nested_cell_pagination_42065.hwp` | `answer_eq(tables[1].rows)` · `answer_eq(tables[1].cols)` |
| TB10 | 첫 표 셀 개수 | 조사 · tier 1 | `samples/table-001.hwp` | `answer_eq(tables[0].cellCount)` |
| TB11 | 첫 표 (0,1) 셀 지목 교정 | 편집 · tier 3 | `samples/basic/issue2007_nested_cell_pagination_42065.hwp` | `cell_text_eq(0,1)==옆칸` · `differs_from_input` |
| TB12 | 표 머리 셀 치환 | 편집 · tier 3 | `samples/table-001.hwp` | `cell_text_eq(0,0)==표머리` · `differs_from_input` |
| TB13–TB40 | 좌표 지목 교정 (28건) | 편집 · tier 3–4 | 기존 세 표본만 | 전부 `cell_text_eq` · `differs_from_input` |

기존 TB01–TB08은 유지한다. 과제 ID는 전역 고유하다. 정답 숫자는 박제하지 않고 라이브 오라클(`answer_eq`)로 재계산한다. 편집 과제는 `deep_contains`를 쓰지 않는다.

## 테스트

- `python gym/tools/audit.py` — 18 pack 전부 통과, 위반 0
- `python -m unittest scripts.tests.test_gym_packs scripts.tests.test_gym_table_editing_pack -v` — 35 tests OK
- **`cargo fmt --all -- --check`** — 해당 없음 (JSON·문서만 변경)
- `node scripts/rust-test-suite-manifest.mjs --check` — 해당 없음
- `node scripts/rust-unit-test-tiers.mjs --check` — 해당 없음
- `cargo test` — 해당 없음

## 성능 영향 및 측정 결과

- 예상 영향: 영향 없음
- 재현·측정: gym JSON 과제·기준풀이·pack 안내·전용 테스트만 추가. 런타임 경로 없음.