### PR TITLE
gym: from_e2e 계약 파서·과제 조립 순수 시험 강화

### DIFF
--- a/gym/docs/from_e2e.md
+++ b/gym/docs/from_e2e.md
@@ -1,0 +1,696 @@
+---
+kind: guide
+status: active
+canonical: gym/docs/from_e2e.md
+last_verified: 2026-08-18
+---
+
+# gym from_e2e — 스튜디오 e2e → CLI 과제 어댑터 규약
+
+이 문서는 `gym/tools/from_e2e.mjs` 의 **정직 경계**, **예외 kind**, **계약
+리터럴 파서**, **CSV 한 칸 편집**, **과제/기준 조립**을 고정한다. 작업 기록은
+[`mydocs/working/gym_from_e2e.md`](../../mydocs/working/gym_from_e2e.md) 를
+본다. 시험 계약은 `gym/tools/from_e2e_contract.test.mjs` 와
+`gym/tools/from_e2e_exceptions.test.mjs` 가 바이너리 없이 고정한다.
+
+pack 안내(`gym/packs/studio-e2e/README.md`)는 ST01 한 과제의 온램프를 말한다.
+이 문서는 어댑터 도구 자체다. 새 pack 을 만들지 않는다. 라이브 과제를 손으로
+늘리지 않는다.
+
+## 1. 왜 이 기둥이 필요한가
+
+rhwp-studio 기여자는 편집을 브라우저 e2e 로 검증한다. gym 의 축은 CLI
+능력이다. 두 세계가 단절되면 스튜디오에서 증명한 문서 계약이 운동장 집계에
+안 오른다.
+
+어댑터는 그 다리다. e2e 파일에 `export const gymContract = { ... }` 한 조각을
+달면, CLI 로 채점 가능한 과제·기준·편집 CSV 를 기계 생성한다. 편집 CSV 는
+사람이 쓰지 않는다. `chart-to-csv` 로 실제 차트를 뽑아 계약이 지정한 한 칸만
+바꾼다. 형태 맞추기는 rhwp 자신에게 맡긴다 — gym 라이브 오라클과 같은 원리다.
+
+온램프 이슈는 #4756, 순수 시험 강화는 #5236 이다.
+
+## 2. 정직 조항 — CLI 로 재현 가능한 계약만
+
+이 어댑터는 **문서 데이터 계약만** 파생한다. e2e 가 브라우저에서 검증하는
+나머지 — 컨텍스트 메뉴, 더블클릭 다이얼로그, Ctrl+Z 스냅샷 undo, 무편집
+무흔적, 비-차트 OLE 음성계약 — 은 CLI 로 표현할 수 없고 gym 의 축이 아니라서
+파생하지 않는다.
+
+거짓말하면 안 되는 문:
+
+1. **e2e 파일을 실행하지 않는다.** `import` 도 `eval` 도 `Function` 도 쓰지
+   않는다. 외부 PR 의 e2e 는 검토 환경에서 신뢰할 수 없다.
+2. **허용 값은 객체·문자열·숫자뿐이다.** 식·배열·식별자·템플릿·boolean·null
+   은 거부한다. 파서를 느슨하게 풀어 임의 코드를 계약으로 위장하지 않는다.
+3. **허용 CLI 는 `chart-to-csv` 와 `csv-to-chart` 뿐이다.** 표 왕복
+   (`table-to-csv`/`csv-to-table`), 필드 채움(`fill-fields`), 렌더·inspect
+   는 다른 pack 의 축이다. 이 어댑터에 넣으면 차트 온램프가 아닌 것을
+   차트 온램프로 위장한다.
+4. **허용 검사 op 는 `file_exists` · `differs_from_input` · `value_eq`
+   뿐이다.** 스크린샷 대조는 스튜디오 표면이다.
+5. **`ok=false` 봉투를 성공으로 위장하지 않는다.** CLI 가 실패한 차트를
+   편집 CSV 로 쓰면 샘플이 맞다고 거짓말하는 것이다.
+6. **from 과 to 가 같으면 거부한다.** 무편집을 왕복으로 위장하지 않는다.
+7. **치명 예외는 삼키지 않는다.** 사용자가 끊었는데 과제 JSON 을 쓰면
+   거짓말이다.
+
+`honestyPolicy()` 가 이 표를 기계로 돌려준다. 시험이 `executesE2e === false`,
+`usesEval === false`, `usesFunction === false` 를 고정한다.
+
+## 3. 사용
+
+```bash
+node gym/tools/from_e2e.mjs \
+  --e2e rhwp-studio/e2e/issue-4694-chart-data-edit.test.mjs \
+  --pack studio-e2e --id ST01 --bin target/debug/rhwp
+```
+
+| 인자 | 기본 | 의미 |
+|---|---|---|
+| `--e2e` | (필수) | gymContract 가 있는 e2e 경로. 저장소 루트 상대. |
+| `--id` | (필수) | 과제 ID. `T01` · `ST01` · `AU13` 형식. |
+| `--pack` | `studio-e2e` | 산출 pack. 보통 그대로 둔다. |
+| `--bin` | `target/debug/rhwp` | `chart-to-csv` 를 부를 바이너리. |
+
+산출:
+
+- `gym/packs/<pack>/assets/<ID>-edit.csv`
+- `gym/packs/<pack>/tasks/<ID>.json`
+- `gym/packs/<pack>/reference/<ID>.json`
+
+검증(라이브, 이 문서의 단위 시험이 아님):
+
+```bash
+python gym/tools/build_baseline.py --agent baseline --pack studio-e2e --bin <bin>
+python gym/score.py --agent baseline --pack studio-e2e --bin <bin>
+```
+
+순수 시험(바이너리 없음):
+
+```bash
+node --test gym/tools/from_e2e_contract.test.mjs gym/tools/from_e2e_exceptions.test.mjs
+python gym/tools/audit.py
+```
+
+## 4. gymContract 모양
+
+허용되는 계약은 이것이다. 키가 더 있으면 정직 게이트가 `studio-only` 로
+거부한다.
+
+```js
+export const gymContract = {
+  sample: 'chart/세로막대형/묶은세로막대형.hwp',
+  chart: 1,
+  edit: { series: 0, point: 0, from: '4.3', to: '91.7' },
+};
+```
+
+| 필드 | 형 | 제약 |
+|---|---|---|
+| `sample` | 문자열 | 비어 있지 않다. `samples/` 아래 상대 경로. `.hwp`/`.hwpx`. `..`·절대경로·NUL 금지. |
+| `chart` | 정수 | 1 이상. |
+| `edit` | 객체 | 배열·null 금지. |
+| `edit.series` | 정수 | 0 이상. CSV 에서 헤더 다음 열 오프셋. |
+| `edit.point` | 정수 | 0 이상. CSV 에서 헤더 다음 행 오프셋. |
+| `edit.from` | 문자열 또는 숫자 | 현재 칸과 `String(from)` 으로 대조. |
+| `edit.to` | 문자열 또는 숫자 | from 과 달라야 한다. |
+
+`validateContract` 는 필드 형만 본다. `assertCliReproducibleContract` 가
+경로 탈출·스튜디오 키·여분 키·from===to 를 추가로 막는다. `main` 은 둘 다
+부른다. 파서 단위 시험은 `validateContract` 만 써서 extra 키 파싱을 허용한다.
+
+## 5. 파서가 허용하는 것 / 거부하는 것
+
+`parseContractLiteral` / `consumeContractLiteral` 은 JSON 이 아니라 **제한된
+객체 리터럴**이다. 허용:
+
+- 중첩 객체
+- 작은따옴표·큰따옴표 문자열
+- 식별자 키, 따옴표 키
+- 유한 숫자(정수·소수·과학적 표기·음수)
+- 줄 주석 `//`, 블록 주석 `/* */`
+- 후행 쉼표
+- 단순 escape: `\"` `\'` `\\` `\b` `\f` `\n` `\r` `\t` `\v`
+- Unicode `\uAC00` 네 자리 hex
+
+거부(메시지는 기존 시험이 정규식으로 고정):
+
+| 입력 | 메시지 |
+|---|---|
+| 식별자 값 `someVar` | 객체·문자열·숫자 이외의 식은 허용하지 않는다 |
+| 배열 `[...]` | 위와 같음 |
+| 템플릿 `` `...` `` | 위와 같음 |
+| `true`/`false`/`null`/`+1` | 위와 같음 |
+| 최상위 문자열·숫자 | 최상위 값은 객체여야 한다 |
+| 중복 키 | 중복 키 '…'는 허용하지 않는다 |
+| 미닫힘 문자열 | 문자열이 닫히지 않았다 |
+| 미닫힘 블록 주석 | 블록 주석이 닫히지 않았다 |
+| `\x41` | 허용되지 않은 문자열 escape |
+| `\uZZZZ` · `\u12` | 유효하지 않은 Unicode escape |
+| 객체 뒤 `+ 1` · `; ...` | 뒤에 추가 식이 있다 |
+
+객체 뒤 주석만 있으면 허용한다. `readContract` 는 `export const gymContract
+= {` 표지를 찾은 뒤 객체만 소비한다. 파일 나머지 `throw` · `runTest()` 는
+실행되지 않는다. `let gymContract` · `export let` 은 표지가 아니므로
+`missing-contract` 다.
+
+## 6. 예외 kind 카탈로그
+
+모든 잡히는 실패는 `FromE2eError.kind` 를 가진다. `ERROR_KINDS` 와
+`EXIT_BY_KIND` 가 문서·시험·코드의 같은 표다.
+
+| kind | exit | 언제 |
+|---|---|---|
+| `missing-arg` | 2 | `--e2e` 또는 `--id` 없음. 값이 `--` 로 시작 |
+| `parse-error` | 3 | 계약 리터럴 문법 |
+| `missing-contract` | 3 | `export const gymContract` 표지 없음 |
+| `validate-error` | 3 | 필드 형, from===to, 확장자 |
+| `studio-only` | 3 | UI 키, 여분 키, 금지 CLI/op |
+| `path-escape` | 3 | `..` · 절대경로 · NUL |
+| `task-id-invalid` | 3 | ID 가 `[A-Z]{1,3}[0-9]{2}` 가 아님 |
+| `task-id-conflict` | 3 | 다른 pack 이 같은 ID 를 가짐 |
+| `type-error` | 3 | 원문·argv·CSV·edit 형 |
+| `csv-mismatch` | 4 | 칸 값이 from 과 다름. 샘플이 바뀜 |
+| `csv-missing-row` | 4 | point 행이 없음 |
+| `csv-missing-col` | 4 | series 열이 없음 |
+| `csv-shape` | 4 | 들쭉날쭉하거나 계열 열이 없음 |
+| `missing-bin` | 5 | rhwp 실행 파일이 없음 |
+| `cli-error` | 5 | 비정상 종료 또는 `ok=false` |
+| `envelope-error` | 5 | chart-to-csv 출력이 봉투가 아님 |
+| `timeout` | 5 | CLI 시간초과 |
+| `missing-file` | 6 | e2e 파일이 없음 |
+| `permission` | 6 | 읽기/실행 권한 |
+| `os-error` | 6 | 그 외 OS/`ERR_*` |
+| `decode-error` | 6 | 유니코드 |
+| `json-error` | 6 | 과제 JSON 파싱 |
+| `unexpected` | 1 | 카탈로그 밖 |
+
+`classifyNodeError` 가 Node 예외를 이 표로 접는다.
+
+| 조건 | context | kind |
+|---|---|---|
+| `FromE2eError` | 아무거나 | 그 kind 유지 |
+| `ENOENT` | `cli`/`bin` | `missing-bin` |
+| `ENOENT` | 그 외 | `missing-file` |
+| `EACCES`/`EPERM` | 아무거나 | `permission` |
+| `ETIMEDOUT` | 아무거나 | `timeout` |
+| `status` 숫자 | 아무거나 | `cli-error` |
+| `SyntaxError` | `json`/`envelope` | `json-error` |
+| `SyntaxError` | 그 외 | `parse-error` |
+| `TypeError`/`RangeError` | 아무거나 | `type-error` |
+| `URIError` 또는 decode 메시지 | 아무거나 | `decode-error` |
+| `ERR_*` 또는 `errno` | 아무거나 | `os-error` |
+| 그 외 | 아무거나 | `unexpected` |
+
+`wrapNodeError` 는 치명 예외를 감싸지 않고 다시 올린다.
+
+## 7. 종료 코드
+
+| exit | 묶음 | 의미 |
+|---|---|---|
+| 0 | 성공 | 과제·기준·CSV 를 썼다 |
+| 1 | unexpected | 카탈로그 밖. 위장하지 않는다 |
+| 2 | 인자 | 사용법을 고치면 된다 |
+| 3 | 계약 | 파서·검증·정직 게이트·ID |
+| 4 | CSV | 샘플과 계약이 어긋남 |
+| 5 | CLI | 바이너리·봉투 |
+| 6 | I/O | 파일·권한·디코드 |
+
+`runAsCli` 는 치명 예외가 아니면 `{ ok, exit, report }` 를 낸다. CLI 진입점은
+`process.exit(exit)` 한다. 시험은 `runAsCli` 를 직접 불러 프로세스를 죽이지
+않는다.
+
+## 8. CLI 봉투
+
+`chart-to-csv --json` 은 순수 JSON 이다. 머리줄 strip 없이 `charts[0].csv` 를
+쓴다. `extractChartCsvFromEnvelope` 규칙:
+
+- 봉투가 객체가 아니면 `envelope-error`
+- `ok === false` 이면 `cli-error`. CSV 가 있어도 쓰지 않는다
+- `charts` 가 배열이 아니거나 비면 `envelope-error`
+- `charts[0]` 이 객체가 아니거나 `csv` 가 빈 문자열이면 `envelope-error`
+
+`parseChartToCsvStdout` 은 BOM 과 앞뒤 공백을 벗긴 뒤 JSON.parse 한다. HTML
+· 부분 JSON · 숫자 · 문자열 JSON 은 봉투가 아니다.
+
+단위 시험은 `execFileSync` 를 목으로 갈아끼운다. 실제 rhwp 를 부르지 않는다.
+
+## 9. CSV 한 칸 편집
+
+`applyCsvEdit(baseCsv, edit)`:
+
+1. CRLF 를 LF 로 정규화하고 마지막 개행을 벗긴 뒤 줄로 가른다.
+2. 각 줄을 쉼표로 가른다. 따옴표 CSV 를 구현하지 않는다. 차트 수치 CSV 는
+   따옴표가 없다. 따옴표가 필요하면 이 어댑터의 축이 아니다.
+3. 모든 행의 열 수가 같고, 헤더 폭이 2 이상이어야 한다. 아니면 `csv-shape`.
+4. 데이터 행은 `rows[1 + point]`, 열은 `1 + series`(첫 열은 범주 라벨).
+5. 행이 없으면 `csv-missing-row`. 열이 없으면 `csv-missing-col`.
+6. 칸 값이 `String(from)` 과 다르면 `csv-mismatch`. 샘플이 바뀐 것이다.
+7. 그 칸만 `String(to)` 로 바꾸고, 결과는 항상 LF 로 끝난다.
+
+ST01 은 계열 0 · 값 0 · `4.3` → `91.7` 이다. e2e 의 SENTINEL 과 같다.
+
+## 10. 과제와 기준
+
+`buildTask` 가 만드는 검사 세 개:
+
+1. `file_exists` `out.hwp` `minBytes: 1` — 산출물이 있다.
+2. `differs_from_input` — 무편집 복사를 거부한다.
+3. `value_eq` `changedCount == 0` — 같은 CSV 를 `csv-to-chart --dry-run` 으로
+   재적용하면 이미 목표값이다.
+
+`buildReference` 는 한 스텝이다.
+
+```
+csv-to-chart {input} --csv <asset> --chart N -o {sub:out.hwp} --json
+```
+
+`assertTaskChecksAreCliReproducible` / `assertReferenceIsCliReproducible` 이
+이 모양에서 벗어나면 `studio-only` 로 막는다. 조립 함수가 나중에 렌더
+명령을 넣어도 게이트가 잡아낸다.
+
+## 11. 과제 ID
+
+형식은 `TASK_ID_PATTERN` = `^[A-Z]{1,3}[0-9]{2}$` 이다. `T01` · `ST01` ·
+`AU13` · `SE01` 이 통과한다. 소문자·세 자리 숫자·네 글자 접두는
+`task-id-invalid`.
+
+`assertTaskIdAvailable` 는 다른 pack 의 `tasks/*.json` 을 읽어 `id` 가
+같으면 `task-id-conflict` 다. 같은 pack 의 기존 ID 는 허용한다(재생성).
+`gym/packs` 가 없으면 통과한다. JSON 이 깨지면 `json-error` 로 접고 도구를
+죽이지 않는 척 성공하지 않는다. `id` 필드가 없는 JSON 은 소유자가 아니다.
+
+SE01 은 security pack 이 가진다. studio-e2e 에서 SE01 을 만들려 하면
+거부한다. 기존 시험이 그 메시지를 고정한다.
+
+## 12. 샘플 경로
+
+`assertSafeSamplePath`:
+
+- 빈 문자열 → `validate-error`
+- NUL → `path-escape`
+- 절대경로(POSIX 또는 `C:\`) → `path-escape`
+- 경로 조각 `..` → `path-escape`
+- 확장자가 `.hwp`/`.hwpx`(대소문자 무시)가 아니면 `validate-error`
+
+한글 경로(`세로막대형/묶은세로막대형.hwp`)는 허용한다. ST01 이 그 경로다.
+
+## 13. 스튜디오 전용 키
+
+`STUDIO_ONLY_KEYS` 에 있는 키가 계약 어디든 있으면 `studio-only` 다.
+목록을 느슨하게 풀어 브라우저 e2e 전체를 과제로 위장하지 않는다.
+
+ui, menu, click, dblclick, doubleClick, undo, redo, hotkey, shortcut,
+dialog, pageObject, selector, locator, snapshot, trace, playwright,
+canvas, pointer, hover, contextMenu, keyboard, mouse, viewport,
+screenshot, wasm, getChartDataByIndex, setChartDataByIndex, window,
+document, browser, e2eOnly, studioOnly, ole, noTrace.
+
+허용 키 밖의 임의 키(`meta`, `hint`)도 `studio-only` 다. 파서는 읽을 수
+있어도 `assertCliReproducibleContract` 가 막는다.
+
+금지 CLI: table-to-csv, csv-to-table, fill-fields, export-pdf,
+export-png, export-svg, render, inspect, thumbnail, mcp-serve.
+
+## 14. 예외 경로 — 도구가 죽는 자리 / 접는 자리
+
+접는 자리(`runAsCli` 가 report 로 접는다):
+
+| 자리 | 잡는 것 | kind |
+|---|---|---|
+| argv | 필수 인자 없음 | `missing-arg` |
+| readContract | ENOENT | `missing-file` |
+| locateGymContract | 표지 없음 | `missing-contract` |
+| parse | 문법 | `parse-error` |
+| validate / 정직 게이트 | 필드·키·경로 | `validate-error` / `studio-only` / `path-escape` |
+| 과제 ID 스캔 | JSON 파싱 | `json-error` |
+| 과제 ID 스캔 | 충돌 | `task-id-conflict` |
+| chart-to-csv | ENOENT | `missing-bin` |
+| chart-to-csv | status | `cli-error` |
+| 봉투 | 모양 / ok=false | `envelope-error` / `cli-error` |
+| applyCsvEdit | 칸·모양 | `csv-*` |
+| 쓰기 | OSError | `os-error` / `permission` |
+
+죽이는 자리(삼키면 거짓말):
+
+- `SystemExit`
+- `GeneratorExit`
+- `fatal === true` 로 표지된 예외
+- `ERR_WORKER_OUT_OF_MEMORY`
+
+`KeyboardInterrupt` 에 해당하는 Node 신호는 프로세스 기본 동작에 맡긴다.
+어댑터가 잡아 성공 보고를 만들지 않는다.
+
+## 15. 순수 함수와 바이너리 경계
+
+바이너리 없이 고정하는 함수:
+
+- `parseContractLiteral` / `locateGymContract` / `readContract`(임시 파일)
+- `validateContract` / `assertCliReproducibleContract` / `assertSafeSamplePath`
+- `applyCsvEdit` / `splitCsvRows` / `joinCsvRows` / `assertCsvRectangular`
+- `buildTask` / `buildReference` / `dumpJson`
+- `extractChartCsvFromEnvelope` / `parseChartToCsvStdout`
+- `materializeFromContract`
+- `classifyNodeError` / `exceptionReport` / `exitCodeForKind`
+- `parseFromE2eArgv` / `assertTaskIdFormat`
+- `runAsCli`(목 `execFileSync`, `dryRun: true`)
+
+바이너리가 필요한 자리:
+
+- 실제 `chart-to-csv` 호출
+- `build_baseline` / `score` 왕복
+
+단위 시험은 후자를 부르지 않는다. 라이브 왕복은 pack README 의 admission
+이다.
+
+## 16. ST01 표본
+
+출처 e2e: `rhwp-studio/e2e/issue-4694-chart-data-edit.test.mjs`
+
+같은 코어: e2e 의 `getChartDataByIndex`/`setChartDataByIndex` 와 CLI
+`chart-to-csv`/`csv-to-chart` 는 같은 native 를 구동한다. 그래서 데이터
+계약이 CLI 로 충실히 왕복한다. UI 계약은 왕복하지 않는다.
+
+과제 입력: `samples/chart/세로막대형/묶은세로막대형.hwp`
+편집: 차트 1, 계열 0, 값 0, `4.3` → `91.7`
+
+`assets/ST01-edit.csv` 첫 데이터 칸만 91.7 이다. 계열명·라벨·다른 값은
+`chart-to-csv` 원본 그대로다.
+
+## 17. 이 도구가 하지 않는 것
+
+- 새 pack 을 만들지 않는다.
+- 라이브 과제를 손으로 늘리지 않는다.
+- e2e 전체를 공짜로 과제로 바꾸지 않는다.
+- 표·필드·렌더 계약을 차트 어댑터에 섞지 않는다.
+- 파서를 느슨하게 풀어 식을 허용하지 않는다.
+- `ok=false` 를 성공으로 쓰지 않는다.
+- 치명 예외를 삼켜 과제를 쓰지 않는다.
+- Rust 를 포맷하지 않는다. 이 기둥이 만지는 것은 JS·문서뿐이다.
+
+## 18. 관련 기둥
+
+| 기둥 | 도구 | 질문 |
+|---|---|---|
+| 스튜디오 온램프 | `from_e2e.mjs` | e2e 데이터 계약을 CLI 과제로 파생하나? |
+| pack 정합 | `audit.py` | 과제↔기준 짝, ID 고유인가? |
+| 라이브 오라클 | `score.py` | 같은 CSV 재적용이 changedCount 0 인가? |
+| 종점 무결성 | `discriminate.py` | 일 안 한 제출이 만점을 받나? |
+
+어댑터는 과제를 낳는다. 감사기는 짝을 본다. 채점기는 라이브로 다시 계산한다.
+어댑터가 스튜디오 UI 를 과제로 넣으면 채점기가 CLI 로 재현할 수 없어 거짓
+만점이 된다. 그래서 정직 게이트가 먼저 막는다.
+
+## 19. 시험이 고정하는 것
+
+`node --test gym/tools/from_e2e_contract.test.mjs gym/tools/from_e2e_exceptions.test.mjs`
+
+고정하는 축:
+
+- 기존 파서 메시지(허용 리터럴, 식 거부, Unicode, 주석, 따옴표 키).
+- SE01 충돌 · ST01 허용.
+- applyCsvEdit 성공/불일치/행 부재. ST01 한 칸.
+- buildTask/buildReference 명령 배열.
+- 예외 kind 카탈로그와 exit.
+- 치명 예외는 다시 올라온다.
+- 스튜디오 키 전수 거부.
+- 봉투 ok=false 는 cli-error.
+- materialize 가 ST01 형태를 조립한다.
+- runAsCli 인자 오류는 exit 2.
+
+Rust 시험·`cargo fmt --all` 은 이 기둥의 범위가 아니다.
+
+## 20. 실패 시나리오 표본
+
+아래는 시험이 고정하는 최소 표본이다. kind 와 exit 가 표와 어긋나면
+어댑터가 거짓말하는 것이다.
+
+### 20.1 missing-arg
+
+```
+$ node gym/tools/from_e2e.mjs
+from_e2e missing-arg [main] 필수: --e2e <경로> --id <과제ID> ...
+```
+
+exit 2. 파일을 읽기 전에 떨어진다.
+
+### 20.2 missing-contract
+
+e2e 에 `export const other = {}` 만 있으면 `missing-contract`, exit 3.
+`let gymContract` · `export let gymContract` 도 같다. 표지는
+`export const gymContract = {` 뿐이다.
+
+### 20.3 parse-error
+
+```js
+export const gymContract = {
+  sample: globalThis.process.exit(1),
+};
+```
+
+`객체·문자열·숫자 이외의 식은 허용하지 않는다`. 파일을 실행하지 않았으므로
+프로세스는 죽지 않는다. kind 는 `parse-error`, exit 3.
+
+### 20.4 studio-only
+
+```js
+export const gymContract = {
+  sample: 'chart/sample.hwp',
+  chart: 1,
+  edit: { series: 0, point: 0, from: '4.3', to: '91.7' },
+  undo: 1,
+};
+```
+
+파서는 `undo: 1` 을 숫자로 읽는다. 게이트가 `CLI 로 재현할 수 없는 스튜디오
+키: undo` 로 거부한다. `undo: true` 는 파서가 먼저 식을 거부한다. 둘 다
+과제를 쓰지 않는다.
+
+### 20.5 path-escape
+
+`sample: '../secret.hwp'` 는 `path-escape`. `samples/` 밖으로 나가 임의의
+HWP 를 차트 샘플로 위장하지 않는다.
+
+### 20.6 csv-mismatch
+
+헤더+한 행 `,s1\nrow,4.3\n` 에 `from: '9'` 를 주면
+
+`계약 불일치: (계열 0, 값 0) 현재 '4.3' ≠ from '9' — 샘플이 바뀌었다`
+
+kind `csv-mismatch`, exit 4. 샘플을 고치거나 계약을 고친다. 칸을 억지로
+덮어쓰지 않는다.
+
+### 20.7 csv-missing-row / csv-missing-col
+
+`point: 5` 인데 데이터 행이 하나면 `point 5 데이터 행이 없다`.
+`series: 5` 인데 열이 하나면 `series 5 열이 없다`.
+들쭉날쭉한 행은 `csv-shape`.
+
+### 20.8 cli-error · envelope-error
+
+```json
+{"ok":false,"charts":[{"csv":",s1\nr,1\n"}]}
+```
+
+CSV 가 있어도 `ok=false` 이므로 `cli-error`. 성공으로 위장하지 않는다.
+
+```json
+{"ok":true}
+```
+
+`charts` 가 없으므로 `envelope-error`. HTML 이나 부분 JSON 도 같다.
+
+### 20.9 missing-bin · permission
+
+없는 바이너리는 `ENOENT` + context cli → `missing-bin`, exit 5.
+권한 거부는 `EACCES` → `permission`, exit 6. 같은 ENOENT 라도 e2e 파일을
+못 읽으면 `missing-file` 이다. context 가 없으면 거짓말이다.
+
+### 20.10 task-id-conflict
+
+studio-e2e 에서 `--id SE01` 은 security/SE01.json 과 충돌한다. 기존 시험
+메시지는 `과제 ID 'SE01' 가 다른 pack에 이미 있다: security/SE01.json`.
+같은 pack 의 ST01 재생성은 허용한다.
+
+### 20.11 json-error
+
+다른 pack 의 tasks/XX01.json 이 `{` 만 있으면 스캔이 `json-error` 로 접힌다.
+깨진 파일을 무시하고 충돌 없음으로 통과하면 ID 고유성 감사가 뚫린다.
+
+## 21. 생성 경로 의사코드
+
+```
+parseFromE2eArgv
+  → assertTaskIdFormat
+  → readContract          # 무실행 정적 파서
+  → assertCliReproducibleContract
+  → assertTaskIdAvailable
+  → invokeChartToCsv      # 여기만 바이너리
+  → materializeFromContract
+       validate + 정직 게이트 + applyCsvEdit
+       + buildTask + buildReference
+       + 검사/기준 CLI 재현 게이트
+  → write assets/tasks/reference
+```
+
+어느 한 칸에서 FromE2eError 가 나면 `runAsCli` 가 report 로 접는다.
+치명 예외는 이 사다리를 건너뛰고 프로세스를 죽인다.
+
+`dryRun: true` 는 마지막 쓰기만 생략한다. 시험이 임시 디렉터리에서 조립
+결과만 본다.
+
+## 22. 허용/거부 리터럴 빠른 표
+
+| 원문 | 파서 | 게이트 |
+|---|---|---|
+| `{ sample: 'a.hwp', chart: 1, edit: { series: 0, point: 0, from: '1', to: '2' } }` | 허용 | 허용 |
+| `{ sample: "\\uAC00/x.hwp", ... }` | 허용(가/x.hwp) | 허용 |
+| `{ ..., // 주석 }` | 허용 | 필드에 따름 |
+| `{ n: 1e3 }` | 허용 | extra 키 → studio-only |
+| `{ hint: 'x', sample, chart, edit }` | 허용 | studio-only |
+| `{ undo: 1, sample, chart, edit }` | 허용 | studio-only |
+| `{ undo: true, ... }` | 거부(식) | 도달 안 함 |
+| `{ sample: someVar }` | 거부(식) | 도달 안 함 |
+| `{ sample: ['a'] }` | 거부(배열) | 도달 안 함 |
+| `{ sample: \`a\` }` | 거부(템플릿) | 도달 안 함 |
+| `{ sample: 'a.hwp' } + 1` | 거부(후행 식) | 도달 안 함 |
+| `{ sample: '../x.hwp', chart, edit }` | 허용 | path-escape |
+| `{ ..., from: '1', to: '1' }` | 허용 | validate-error |
+
+## 23. ST01 검사 명령 고정
+
+`buildTask` 의 세 번째 검사 cmd 는 이 순서다. 시험이 배열 동등을 고정한다.
+
+```
+csv-to-chart
+{file:out.hwp}
+--csv
+gym/packs/studio-e2e/assets/ST01-edit.csv
+--chart
+1
+--dry-run
+--json
+```
+
+기준풀이 run:
+
+```
+csv-to-chart
+{input}
+--csv
+gym/packs/studio-e2e/assets/ST01-edit.csv
+--chart
+1
+-o
+{sub:out.hwp}
+--json
+```
+
+`--dry-run` 은 검사에만 있다. 기준풀이는 실제 `out.hwp` 를 쓴다. 둘 다
+같은 CSV 를 쓴다. CSV 를 사람이 고치면 라이브 오라클이 깨지므로 어댑터가
+`chart-to-csv` 산출에서만 만든다.
+
+## 24. 자주 하는 실수
+
+1. **e2e 를 import 해서 계약을 읽기.** top-level `runTest` 가 브라우저를
+   기동한다. 무실행 파서만 쓴다.
+2. **boolean 을 계약에 넣기.** 파서가 식을 거부한다. 숫자 `1` 도 게이트가
+   스튜디오 키면 막는다. UI 플래그는 e2e 에만 둔다.
+3. **표 과제를 이 어댑터로 만들기.** `table-to-csv` 는 금지 CLI 다.
+   table-csv pack 의 온램프를 따로 둔다.
+4. **from===to 로 "이미 맞는 샘플" 과제.** differs_from_input 이 영원히
+   실패하거나, 무편집 복사가 통과한다. 게이트가 막는다.
+5. **ok=false CSV 를 자산으로 쓰기.** 샘플이 차트가 아닌데 과제가 생긴다.
+6. **깨진 과제 JSON 을 건너뛰기.** ID 충돌을 놓친다. json-error 로 멈춘다.
+
+## 25. 변경 시 같이 고칠 것
+
+카탈로그를 만지면 세 곳이 동시에 바뀌어야 한다.
+
+- `gym/tools/from_e2e.mjs` 의 `ERROR_KINDS` / `EXIT_BY_KIND` / `STUDIO_ONLY_KEYS`
+- `gym/docs/from_e2e.md` 이 표
+- `gym/tools/from_e2e_exceptions.test.mjs` 의 카탈로그 동등 시험
+
+하나만 고치면 문서가 거짓이거나 시험이 거짓이다.
+
+파서 거부 메시지를 바꾸면 `from_e2e_contract.test.mjs` 의 기존 39건이
+깨진다. 메시지를 바꿀 이유가 있으면 그 시험과 이 문서 5절을 같이 고친다.
+
+## 26. 버전 메모
+
+- 2026-08-14: ST01 온램프. studio-e2e pack.
+- 2026-08-18: 순수 파서·조립 시험 39건 (#5241 원 커밋).
+- 2026-08-18: 예외 kind · 정직 게이트 · 문서 (#5241 보강).
+
+## 27. 기여자 체크리스트
+
+새 e2e 에서 과제를 파생할 때:
+
+1. 데이터 계약만 `gymContract` 에 적는다. UI 단언은 e2e 본문에 남긴다.
+2. `sample` 은 `samples/` 아래 상대 경로, `.hwp`/`.hwpx` 다.
+3. `from` 과 `to` 가 다르다. SENTINEL 값이 샘플에 실제로 있는지
+   `chart-to-csv` 로 확인한다.
+4. `--id` 가 다른 pack 과 겹치지 않는다. `audit.py` 가 나중에 다시 본다.
+5. 생성 후 `build_baseline` + `score` 가 3/3 인지 확인한다. 이 문서의
+   단위 시험은 그 왕복을 대신하지 않는다.
+
+어댑터를 고칠 때:
+
+1. 기존 파서 메시지 39건을 깨지 않는다.
+2. kind 를 추가하면 `ERROR_KINDS` · `EXIT_BY_KIND` · 문서 6절 ·
+   exceptions 시험 카탈로그를 같이 고친다.
+3. 허용 CLI 를 늘리지 않는다. 새 왕복은 새 도구다.
+4. `eval` / `new Function` / `import(e2e)` 를 넣지 않는다.
+5. 치명 예외를 catch 에서 삼키지 않는다.
+
+## 28. 봉투 JSON 표본
+
+성공(시험이 목이 돌려주는 최소):
+
+```json
+{
+  "ok": true,
+  "charts": [
+    { "csv": ",계열 1,계열 2,계열 3\n항목 1,4.3,2.4,2\n" }
+  ]
+}
+```
+
+실패(성공으로 쓰면 안 됨):
+
+```json
+{
+  "ok": false,
+  "error": "chart index out of range",
+  "charts": []
+}
+```
+
+`ok` 가 없고 `charts[0].csv` 만 있으면 추출은 허용한다. CLI 가 옛 봉투를
+낼 수 있다. 명시적 `ok: false` 만 실패로 본다. `ok` 를 생략한 채 빈
+charts 는 envelope-error 다.
+
+## 29. ID 형식 보기
+
+| ID | 통과 | 이유 |
+|---|---|---|
+| T01 | 예 | 한 글자 + 두 숫자. core-cli |
+| ST01 | 예 | studio-e2e |
+| SE01 | 예 | 형식은 맞다. 다른 pack 충돌은 별 검사 |
+| AU13 | 예 | 세 글자 |
+| st01 | 아니오 | 소문자 |
+| ST1 | 아니오 | 숫자 한 자리 |
+| ST001 | 아니오 | 숫자 세 자리 |
+| TOOL01 | 아니오 | 접두 네 글자 |
+| ST | 아니오 | 숫자 없음 |
+
+충돌 검사는 형식 통과 뒤에 한다. 형식이 틀린 ID 는 스캔까지 가지 않는다.
+
+## 30. 한 줄 요약
+
+from_e2e 는 스튜디오 e2e 의 **차트 데이터 계약**만 CLI 과제로 옮긴다.
+실행하지 않고, 식을 받지 않고, UI 를 위장하지 않고, CLI 실패를 성공으로
+쓰지 않는다. 예외는 kind 로 접고, 치명 예외는 죽인다. 그것이 정직하다.
+
+

--- a/gym/tools/from_e2e.mjs
+++ b/gym/tools/from_e2e.mjs
@@ -21,9 +21,171 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+/**
+ * 어댑터 예외. kind 는 ERROR_KINDS 에 있는 값만 쓴다.
+ * 메시지는 기존 시험이 정규식으로 고정한 문자열을 유지한다.
+ */
+export class FromE2eError extends Error {
+  constructor(kind, message, extras = {}) {
+    super(message);
+    this.name = 'FromE2eError';
+    this.kind = kind;
+    this.extras = extras;
+  }
+}
+
+/** 예외 kind 카탈로그. 문서·시험이 같은 표를 본다. 여기에 없는 값은 unexpected 로 접는다. */
+export const ERROR_KINDS = Object.freeze([
+  'missing-arg',
+  'missing-file',
+  'missing-bin',
+  'permission',
+  'timeout',
+  'decode-error',
+  'parse-error',
+  'missing-contract',
+  'validate-error',
+  'studio-only',
+  'path-escape',
+  'csv-mismatch',
+  'csv-missing-row',
+  'csv-missing-col',
+  'csv-shape',
+  'task-id-conflict',
+  'task-id-invalid',
+  'envelope-error',
+  'cli-error',
+  'os-error',
+  'type-error',
+  'json-error',
+  'unexpected',
+]);
+
+/**
+ * 종료 코드. 0 은 성공이다. 분류를 위장하지 않도록 kind 마다 고정한다.
+ * 1 은 카탈로그 밖/예기치 않은 실패. 2 인자, 3 계약, 4 CSV, 5 CLI, 6 I/O.
+ */
+export const EXIT_BY_KIND = Object.freeze({
+  'missing-arg': 2,
+  'parse-error': 3,
+  'missing-contract': 3,
+  'validate-error': 3,
+  'studio-only': 3,
+  'path-escape': 3,
+  'task-id-invalid': 3,
+  'task-id-conflict': 3,
+  'type-error': 3,
+  'csv-mismatch': 4,
+  'csv-missing-row': 4,
+  'csv-missing-col': 4,
+  'csv-shape': 4,
+  'missing-bin': 5,
+  'cli-error': 5,
+  'envelope-error': 5,
+  'timeout': 5,
+  'missing-file': 6,
+  'permission': 6,
+  'os-error': 6,
+  'decode-error': 6,
+  'json-error': 6,
+  'unexpected': 1,
+});
+
+/** 삼키면 안 되는 예외 이름. 사용자가 끊었는데 성공 보고를 내면 거짓말이다. */
+export const FATAL_ERROR_NAMES = Object.freeze([
+  'SystemExit',
+  'GeneratorExit',
+]);
+
+/** gymContract 가 가져도 되는 최상위 키. 나머지는 스튜디오 UI 계약을 숨긴 자리로 본다. */
+export const ALLOWED_CONTRACT_KEYS = Object.freeze(['sample', 'chart', 'edit']);
+
+/** edit 객체가 가져도 되는 키. */
+export const ALLOWED_EDIT_KEYS = Object.freeze(['series', 'point', 'from', 'to']);
+
+/**
+ * 스튜디오 전용 표면. CLI 로 재현할 수 없으므로 계약에 있으면 거부한다.
+ * 이 목록을 느슨하게 풀어 브라우저 e2e 전체를 과제로 위장하지 않는다.
+ */
+export const STUDIO_ONLY_KEYS = Object.freeze([
+  'ui',
+  'menu',
+  'click',
+  'dblclick',
+  'doubleClick',
+  'undo',
+  'redo',
+  'hotkey',
+  'shortcut',
+  'dialog',
+  'pageObject',
+  'selector',
+  'locator',
+  'snapshot',
+  'trace',
+  'playwright',
+  'canvas',
+  'pointer',
+  'hover',
+  'contextMenu',
+  'keyboard',
+  'mouse',
+  'viewport',
+  'screenshot',
+  'wasm',
+  'getChartDataByIndex',
+  'setChartDataByIndex',
+  'window',
+  'document',
+  'browser',
+  'e2eOnly',
+  'studioOnly',
+  'ole',
+  'noTrace',
+]);
+
+/** 이 어댑터가 과제/기준에 넣을 수 있는 CLI 명령. 다른 명령은 다른 pack 의 일이다. */
+export const ALLOWED_CLI_COMMANDS = Object.freeze(['chart-to-csv', 'csv-to-chart']);
+
+/** 이 어댑터가 과제 검사에 넣을 수 있는 op. */
+export const ALLOWED_CHECK_OPS = Object.freeze([
+  'file_exists',
+  'differs_from_input',
+  'value_eq',
+]);
+
+/** 이 어댑터가 위장하면 안 되는 CLI. 표·필드·렌더는 다른 온램프의 축이다. */
+export const FORBIDDEN_CLI_COMMANDS = Object.freeze([
+  'table-to-csv',
+  'csv-to-table',
+  'fill-fields',
+  'export-pdf',
+  'export-png',
+  'export-svg',
+  'render',
+  'inspect',
+  'thumbnail',
+  'mcp-serve',
+]);
+
+/** 샘플 경로가 가져야 하는 확장자. 스튜디오 차트 왕복은 HWP/HWPX 만 연다. */
+export const ALLOWED_SAMPLE_SUFFIXES = Object.freeze(['.hwp', '.hwpx']);
+
+/** 과제 ID 형식. 기존 pack 은 두세 글자 + 숫자 두 자리다. */
+export const TASK_ID_PATTERN = /^[A-Z]{1,3}[0-9]{2}$/;
+
+export const USAGE =
+  '필수: --e2e <경로> --id <과제ID> [--pack studio-e2e] [--bin target/debug/rhwp]';
+
+export const ERROR_HEAD_LIMIT = 160;
+
+function argFrom(argv, name, def) {
+  const i = argv.indexOf(`--${name}`);
+  return i >= 0 ? argv[i + 1] : def;
+}
+
 function arg(name, def) {
-  const i = process.argv.indexOf(`--${name}`);
-  return i >= 0 ? process.argv[i + 1] : def;
+  return argFrom(process.argv, name, def);
 }
 
 /**
@@ -35,7 +197,7 @@ function arg(name, def) {
 function consumeContractLiteral(source) {
   let index = 0;
   const fail = message => {
-    throw new Error(`gymContract ${message} (offset ${index})`);
+    throw new FromE2eError('parse-error', `gymContract ${message} (offset ${index})`, { offset: index });
   };
   const skipWhitespace = () => {
     while (index < source.length) {
@@ -157,42 +319,68 @@ function consumeContractLiteral(source) {
 }
 
 export function parseContractLiteral(source) {
+  if (typeof source !== 'string') {
+    throw new FromE2eError('type-error', 'gymContract 원문은 문자열이어야 한다');
+  }
   const { value, index } = consumeContractLiteral(source);
   if (index < source.length) {
-    throw new Error(`gymContract 뒤에 추가 식이 있다 (offset ${index})`);
+    throw new FromE2eError(
+      'parse-error',
+      `gymContract 뒤에 추가 식이 있다 (offset ${index})`,
+      { offset: index },
+    );
   }
   return value;
 }
 
-export function readContract(root, file) {
-  const src = readFileSync(path.resolve(root, file), 'utf8');
-  const match = src.match(/export\s+const\s+gymContract\s*=\s*\{/);
-  if (!match || match.index === undefined) {
-    throw new Error(`${file} 에 'export const gymContract' 가 없다`);
+export function locateGymContract(source, file = 'e2e') {
+  if (typeof source !== 'string') {
+    throw new FromE2eError('type-error', 'e2e 원문은 문자열이어야 한다');
   }
-  const objectStart = src.indexOf('{', match.index);
+  const match = source.match(/export\s+const\s+gymContract\s*=\s*\{/);
+  if (!match || match.index === undefined) {
+    throw new FromE2eError(
+      'missing-contract',
+      `${file} 에 'export const gymContract' 가 없다`,
+      { file },
+    );
+  }
+  const objectStart = source.indexOf('{', match.index);
+  if (objectStart < 0) {
+    throw new FromE2eError('missing-contract', `${file} 에 'export const gymContract' 가 없다`, { file });
+  }
+  return { matchIndex: match.index, objectStart, marker: match[0] };
+}
+
+export function readContract(root, file) {
+  const abs = path.resolve(root, file);
+  const src = readTextFileOrThrow(abs, file);
+  const { objectStart } = locateGymContract(src, file);
   // 파일 나머지 코드는 실행하지 않고, 계약 객체만 소비한다.
   return consumeContractLiteral(src.slice(objectStart)).value;
 }
 
 export function validateContract(contract) {
+  if (contract === null || typeof contract !== 'object' || Array.isArray(contract)) {
+    throw new FromE2eError('validate-error', 'gymContract는 객체여야 한다');
+  }
   if (typeof contract.sample !== 'string' || contract.sample.length === 0) {
-    throw new Error('gymContract.sample은 비어 있지 않은 문자열이어야 한다');
+    throw new FromE2eError('validate-error', 'gymContract.sample은 비어 있지 않은 문자열이어야 한다');
   }
   if (!Number.isInteger(contract.chart) || contract.chart < 1) {
-    throw new Error('gymContract.chart는 1 이상의 정수여야 한다');
+    throw new FromE2eError('validate-error', 'gymContract.chart는 1 이상의 정수여야 한다');
   }
   if (contract.edit === null || typeof contract.edit !== 'object' || Array.isArray(contract.edit)) {
-    throw new Error('gymContract.edit는 객체여야 한다');
+    throw new FromE2eError('validate-error', 'gymContract.edit는 객체여야 한다');
   }
   for (const field of ['series', 'point']) {
     if (!Number.isInteger(contract.edit[field]) || contract.edit[field] < 0) {
-      throw new Error(`gymContract.edit.${field}는 0 이상의 정수여야 한다`);
+      throw new FromE2eError('validate-error', `gymContract.edit.${field}는 0 이상의 정수여야 한다`);
     }
   }
   for (const field of ['from', 'to']) {
     if (typeof contract.edit[field] !== 'string' && typeof contract.edit[field] !== 'number') {
-      throw new Error(`gymContract.edit.${field}는 문자열 또는 숫자여야 한다`);
+      throw new FromE2eError('validate-error', `gymContract.edit.${field}는 문자열 또는 숫자여야 한다`);
     }
   }
 }
@@ -201,19 +389,45 @@ export function assertTaskIdAvailable(root, pack, id) {
   const packsDir = path.join(root, 'gym', 'packs');
   if (!existsSync(packsDir)) return;
 
+  let entries;
+  try {
+    entries = readdirSync(packsDir, { withFileTypes: true });
+  } catch (err) {
+    throw wrapNodeError(err, 'task-id', packsDir);
+  }
+
   const owners = [];
-  for (const entry of readdirSync(packsDir, { withFileTypes: true })) {
+  for (const entry of entries) {
     if (!entry.isDirectory() || entry.name === pack) continue;
     const tasksDir = path.join(packsDir, entry.name, 'tasks');
     if (!existsSync(tasksDir)) continue;
-    for (const name of readdirSync(tasksDir)) {
+    let names;
+    try {
+      names = readdirSync(tasksDir);
+    } catch (err) {
+      throw wrapNodeError(err, 'task-id', tasksDir);
+    }
+    for (const name of names) {
       if (!name.endsWith('.json')) continue;
-      const task = JSON.parse(readFileSync(path.join(tasksDir, name), 'utf8'));
-      if (task.id === id) owners.push(`${entry.name}/${name}`);
+      const taskPath = path.join(tasksDir, name);
+      let task;
+      try {
+        task = readJsonFileOrThrow(taskPath, `${entry.name}/${name}`);
+      } catch (err) {
+        if (err instanceof FromE2eError) throw err;
+        throw wrapNodeError(err, 'task-id', taskPath);
+      }
+      if (task && typeof task === 'object' && !Array.isArray(task) && task.id === id) {
+        owners.push(`${entry.name}/${name}`);
+      }
     }
   }
   if (owners.length > 0) {
-    throw new Error(`과제 ID '${id}' 가 다른 pack에 이미 있다: ${owners.join(', ')}`);
+    throw new FromE2eError(
+      'task-id-conflict',
+      `과제 ID '${id}' 가 다른 pack에 이미 있다: ${owners.join(', ')}`,
+      { id, owners },
+    );
   }
 }
 
@@ -222,17 +436,36 @@ export function assertTaskIdAvailable(root, pack, id) {
  * 입력 줄바꿈과 무관하게 LF로 정규화하고, 결과는 항상 LF로 끝난다.
  */
 export function applyCsvEdit(baseCsv, edit) {
-  const eol = '\n';
-  const rows = baseCsv.replace(/\r\n/g, '\n').replace(/\n$/, '').split('\n').map(row => row.split(','));
+  if (typeof baseCsv !== 'string') {
+    throw new FromE2eError('type-error', 'applyCsvEdit의 CSV는 문자열이어야 한다');
+  }
+  if (edit === null || typeof edit !== 'object' || Array.isArray(edit)) {
+    throw new FromE2eError('type-error', 'applyCsvEdit의 edit는 객체여야 한다');
+  }
+  const rows = splitCsvRows(baseCsv);
+  assertCsvRectangular(rows);
   const dataRow = rows[1 + edit.point];
   const column = 1 + edit.series;
-  if (!dataRow) throw new Error(`point ${edit.point} 데이터 행이 없다`);
+  if (!dataRow) {
+    throw new FromE2eError('csv-missing-row', `point ${edit.point} 데이터 행이 없다`, {
+      point: edit.point,
+    });
+  }
+  if (column < 0 || column >= dataRow.length) {
+    throw new FromE2eError('csv-missing-col', `series ${edit.series} 열이 없다`, {
+      series: edit.series,
+    });
+  }
   if (dataRow[column] !== String(edit.from)) {
-    throw new Error(`계약 불일치: (계열 ${edit.series}, 값 ${edit.point}) 현재 `
-      + `'${dataRow[column]}' ≠ from '${edit.from}' — 샘플이 바뀌었다`);
+    throw new FromE2eError(
+      'csv-mismatch',
+      `계약 불일치: (계열 ${edit.series}, 값 ${edit.point}) 현재 `
+        + `'${dataRow[column]}' ≠ from '${edit.from}' — 샘플이 바뀌었다`,
+      { series: edit.series, point: edit.point, actual: dataRow[column], from: edit.from },
+    );
   }
   dataRow[column] = String(edit.to);
-  return rows.map(row => row.join(',')).join(eol) + eol;
+  return joinCsvRows(rows);
 }
 
 export function buildTask({ taskId, e2ePath, contract, csvAsset }) {
@@ -268,43 +501,489 @@ export function buildReference({ taskId, contract, csvAsset }) {
   };
 }
 
-function main() {
-  const root = process.cwd();
-  const e2ePath = arg('e2e');
-  const packId = arg('pack', 'studio-e2e');
-  const taskId = arg('id');
-  const bin = path.resolve(root, arg('bin', 'target/debug/rhwp'));
-  if (!e2ePath || !taskId) {
-    throw new Error('필수: --e2e <경로> --id <과제ID> [--pack studio-e2e] [--bin target/debug/rhwp]');
+export function dumpJson(object) {
+  return `${JSON.stringify(object, null, 2)}\n`;
+}
+
+export function splitCsvRows(text) {
+  return text.replace(/\r\n/g, '\n').replace(/\n$/, '').split('\n').map(row => row.split(','));
+}
+
+export function joinCsvRows(rows) {
+  return `${rows.map(row => row.join(',')).join('\n')}\n`;
+}
+
+export function assertCsvRectangular(rows) {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    throw new FromE2eError('csv-shape', 'CSV 행이 없다');
   }
-  const contract = readContract(root, e2ePath);
+  const width = rows[0].length;
+  if (width < 2) {
+    throw new FromE2eError('csv-shape', 'CSV 헤더에 계열 열이 없다');
+  }
+  for (let i = 0; i < rows.length; i += 1) {
+    if (!Array.isArray(rows[i]) || rows[i].length !== width) {
+      throw new FromE2eError('csv-shape', `CSV ${i}행 열 수가 ${width}가 아니다`);
+    }
+  }
+}
+
+export function isFatalException(exc) {
+  if (exc == null || typeof exc !== 'object') return false;
+  if (exc.fatal === true) return true;
+  if (FATAL_ERROR_NAMES.includes(exc.name)) return true;
+  if (exc.code === 'ERR_WORKER_OUT_OF_MEMORY') return true;
+  return false;
+}
+
+export function exitCodeForKind(kind) {
+  if (Object.hasOwn(EXIT_BY_KIND, kind)) return EXIT_BY_KIND[kind];
+  return EXIT_BY_KIND.unexpected;
+}
+
+export function truncateHead(text, limit = ERROR_HEAD_LIMIT) {
+  if (text == null) return '';
+  const value = typeof text === 'string' ? text : String(text);
+  if (limit <= 0) return '';
+  return value.length <= limit ? value : value.slice(0, limit);
+}
+
+export function classifyNodeError(err, context = 'io') {
+  if (err instanceof FromE2eError) return err.kind;
+  if (err == null) return 'unexpected';
+  const code = err.code;
+  if (code === 'ENOENT') return context === 'cli' || context === 'bin' ? 'missing-bin' : 'missing-file';
+  if (code === 'EACCES' || code === 'EPERM') return 'permission';
+  if (code === 'ETIMEDOUT' || code === 'ERR_SCRIPT_EXECUTION_TIMEOUT') return 'timeout';
+  if (typeof err.status === 'number') return 'cli-error';
+  if (err instanceof SyntaxError) return context === 'json' || context === 'envelope' ? 'json-error' : 'parse-error';
+  if (err instanceof TypeError) return 'type-error';
+  if (err instanceof RangeError) return 'type-error';
+  if (isUnicodeError(err)) return 'decode-error';
+  if (typeof err.message === 'string' && /timeout|ETIMEDOUT/i.test(err.message)) return 'timeout';
+  if (code && String(code).startsWith('ERR_')) return 'os-error';
+  if (typeof err.errno === 'number') return 'os-error';
+  return 'unexpected';
+}
+
+function isUnicodeError(err) {
+  return Boolean(err && (err.name === 'URIError' || /decode|encode|utf/i.test(err.message || '')));
+}
+
+export function wrapNodeError(err, context, pathHint) {
+  if (isFatalException(err)) throw err;
+  if (err instanceof FromE2eError) return err;
+  const kind = classifyNodeError(err, context);
+  const where = pathHint ? ` (${pathHint})` : '';
+  const head = truncateHead(err && err.message ? err.message : String(err));
+  return new FromE2eError(kind, `${kind}${where}: ${head}`, {
+    context,
+    path: pathHint,
+    causeName: err && err.name,
+    causeCode: err && err.code,
+  });
+}
+
+export function exceptionReport(err, context = 'main') {
+  if (isFatalException(err)) {
+    return {
+      kind: 'unexpected',
+      fatal: true,
+      context,
+      error: err && err.name ? err.name : 'Fatal',
+      message: truncateHead(err && err.message),
+    };
+  }
+  const kind = err instanceof FromE2eError ? err.kind : classifyNodeError(err, context);
+  return {
+    kind: ERROR_KINDS.includes(kind) ? kind : 'unexpected',
+    fatal: false,
+    context,
+    error: err && err.name ? err.name : 'Error',
+    message: truncateHead(err && err.message),
+    extras: err instanceof FromE2eError ? err.extras : {},
+    exit: exitCodeForKind(ERROR_KINDS.includes(kind) ? kind : 'unexpected'),
+  };
+}
+
+export function formatExceptionReport(report) {
+  const extras = report.extras && Object.keys(report.extras).length > 0
+    ? ` ${JSON.stringify(report.extras)}`
+    : '';
+  return `from_e2e ${report.kind} [${report.context}] ${report.message}${extras}`;
+}
+
+export function readTextFileOrThrow(absPath, label) {
+  try {
+    return readFileSync(absPath, 'utf8');
+  } catch (err) {
+    throw wrapNodeError(err, 'io', label || absPath);
+  }
+}
+
+export function readJsonFileOrThrow(absPath, label) {
+  const text = readTextFileOrThrow(absPath, label);
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    throw new FromE2eError(
+      'json-error',
+      `과제 파일 파싱 실패: ${label || absPath}: ${err.message}`,
+      { path: absPath },
+    );
+  }
+}
+
+export function parseFromE2eArgv(argv) {
+  if (!Array.isArray(argv)) {
+    throw new FromE2eError('type-error', 'argv는 배열이어야 한다');
+  }
+  const e2e = argFrom(argv, 'e2e');
+  const pack = argFrom(argv, 'pack', 'studio-e2e');
+  const id = argFrom(argv, 'id');
+  const bin = argFrom(argv, 'bin', 'target/debug/rhwp');
+  if (!e2e || !id) {
+    throw new FromE2eError('missing-arg', USAGE);
+  }
+  if (e2e.startsWith('--') || id.startsWith('--')) {
+    throw new FromE2eError('missing-arg', USAGE);
+  }
+  return { e2e, pack, id, bin };
+}
+
+export function assertTaskIdFormat(id) {
+  if (typeof id !== 'string' || !TASK_ID_PATTERN.test(id)) {
+    throw new FromE2eError(
+      'task-id-invalid',
+      `과제 ID '${id}' 는 대문자 1~3자 + 숫자 두 자리여야 한다`,
+      { id },
+    );
+  }
+}
+
+export function assertSafeSamplePath(sample) {
+  if (typeof sample !== 'string' || sample.length === 0) {
+    throw new FromE2eError('validate-error', 'gymContract.sample은 비어 있지 않은 문자열이어야 한다');
+  }
+  if (sample.includes('\0')) {
+    throw new FromE2eError('path-escape', 'gymContract.sample에 NUL 이 있다');
+  }
+  if (path.isAbsolute(sample) || /^[A-Za-z]:[\\/]/.test(sample)) {
+    throw new FromE2eError('path-escape', 'gymContract.sample은 samples/ 아래 상대 경로여야 한다');
+  }
+  const parts = sample.split(/[\\/]/);
+  if (parts.some(part => part === '..')) {
+    throw new FromE2eError('path-escape', 'gymContract.sample은 상위 경로를 포함할 수 없다');
+  }
+  const suffix = ALLOWED_SAMPLE_SUFFIXES.find(item => sample.toLowerCase().endsWith(item));
+  if (!suffix) {
+    throw new FromE2eError('validate-error', 'gymContract.sample은 .hwp 또는 .hwpx 여야 한다');
+  }
+}
+
+export function collectForbiddenKeys(object, forbidden, prefix = '') {
+  const found = [];
+  if (object === null || typeof object !== 'object' || Array.isArray(object)) return found;
+  for (const key of Object.keys(object)) {
+    const pathKey = prefix ? `${prefix}.${key}` : key;
+    if (forbidden.includes(key)) found.push(pathKey);
+    found.push(...collectForbiddenKeys(object[key], forbidden, pathKey));
+  }
+  return found;
+}
+
+export function collectUnknownKeys(object, allowed) {
+  if (object === null || typeof object !== 'object' || Array.isArray(object)) return [];
+  return Object.keys(object).filter(key => !allowed.includes(key));
+}
+
+/**
+ * CLI 로 재현 가능한 스튜디오 계약만 남긴다.
+ * sample/chart/edit 이외의 키, 스튜디오 UI 키, from===to 는 거부한다.
+ */
+export function assertCliReproducibleContract(contract) {
   validateContract(contract);
-  assertTaskIdAvailable(root, packId, taskId);
-
-  const packDir = path.join(root, 'gym', 'packs', packId);
-  const sampleRel = path.posix.join('samples', contract.sample);
-  const env = JSON.parse(execFileSync(
-    bin, ['chart-to-csv', sampleRel, '--chart', String(contract.chart), '--json'],
-    { cwd: root, encoding: 'utf8' }));
-  const baseCsv = env.charts[0].csv;
-  const editCsv = applyCsvEdit(baseCsv, contract.edit);
-
-  for (const directory of ['assets', 'tasks', 'reference']) {
-    mkdirSync(path.join(packDir, directory), { recursive: true });
+  assertSafeSamplePath(contract.sample);
+  const studio = collectForbiddenKeys(contract, STUDIO_ONLY_KEYS);
+  if (studio.length > 0) {
+    throw new FromE2eError(
+      'studio-only',
+      `CLI 로 재현할 수 없는 스튜디오 키: ${studio.join(', ')}`,
+      { keys: studio },
+    );
   }
-  const csvAsset = `gym/packs/${packId}/assets/${taskId}-edit.csv`;
-  writeFileSync(path.join(root, csvAsset), editCsv, 'utf8');
+  const extra = collectUnknownKeys(contract, ALLOWED_CONTRACT_KEYS);
+  if (extra.length > 0) {
+    throw new FromE2eError(
+      'studio-only',
+      `허용되지 않은 gymContract 키: ${extra.join(', ')} — CLI 차트 왕복만 받는다`,
+      { keys: extra },
+    );
+  }
+  const extraEdit = collectUnknownKeys(contract.edit, ALLOWED_EDIT_KEYS);
+  if (extraEdit.length > 0) {
+    throw new FromE2eError(
+      'studio-only',
+      `허용되지 않은 edit 키: ${extraEdit.join(', ')}`,
+      { keys: extraEdit },
+    );
+  }
+  if (String(contract.edit.from) === String(contract.edit.to)) {
+    throw new FromE2eError(
+      'validate-error',
+      'gymContract.edit.from 과 to 가 같다 — 무편집을 왕복으로 위장하지 않는다',
+    );
+  }
+}
 
+export function assertTaskChecksAreCliReproducible(task) {
+  if (task === null || typeof task !== 'object' || Array.isArray(task)) {
+    throw new FromE2eError('type-error', '과제는 객체여야 한다');
+  }
+  if (!Array.isArray(task.checks)) {
+    throw new FromE2eError('validate-error', '과제 checks 는 배열이어야 한다');
+  }
+  for (const check of task.checks) {
+    if (!ALLOWED_CHECK_OPS.includes(check.op)) {
+      throw new FromE2eError(
+        'studio-only',
+        `허용되지 않은 검사 op '${check.op}' — CLI 차트 왕복만 받는다`,
+        { op: check.op },
+      );
+    }
+    if (Array.isArray(check.cmd)) {
+      const command = check.cmd[0];
+      if (FORBIDDEN_CLI_COMMANDS.includes(command)) {
+        throw new FromE2eError(
+          'studio-only',
+          `금지된 CLI 명령 '${command}' — 이 어댑터의 축이 아니다`,
+          { command },
+        );
+      }
+      if (!ALLOWED_CLI_COMMANDS.includes(command)) {
+        throw new FromE2eError(
+          'studio-only',
+          `허용되지 않은 CLI 명령 '${command}' — chart-to-csv/csv-to-chart 만 쓴다`,
+          { command },
+        );
+      }
+    }
+  }
+}
+
+export function assertReferenceIsCliReproducible(reference) {
+  if (reference === null || typeof reference !== 'object' || Array.isArray(reference)) {
+    throw new FromE2eError('type-error', '기준풀이는 객체여야 한다');
+  }
+  const steps = reference.steps;
+  if (!Array.isArray(steps) || steps.length !== 1) {
+    throw new FromE2eError('validate-error', '기준풀이는 csv-to-chart 한 스텝이어야 한다');
+  }
+  const run = steps[0] && steps[0].run;
+  if (!Array.isArray(run) || run[0] !== 'csv-to-chart') {
+    throw new FromE2eError(
+      'studio-only',
+      '기준풀이 run 은 csv-to-chart 여야 한다',
+      { run },
+    );
+  }
+  if (FORBIDDEN_CLI_COMMANDS.some(command => run.includes(command))) {
+    throw new FromE2eError('studio-only', '기준풀이에 금지된 CLI 명령이 있다');
+  }
+}
+
+/**
+ * chart-to-csv --json 봉투에서 CSV 를 꺼낸다. 바이너리를 부르지 않는다.
+ * ok=false 를 성공으로 위장하지 않는다.
+ */
+export function extractChartCsvFromEnvelope(envelope, chartIndex = 1) {
+  if (envelope === null || typeof envelope !== 'object' || Array.isArray(envelope)) {
+    throw new FromE2eError('envelope-error', 'chart-to-csv 봉투는 객체여야 한다');
+  }
+  if (envelope.ok === false) {
+    throw new FromE2eError(
+      'cli-error',
+      'chart-to-csv 봉투 ok=false — CLI 실패를 성공으로 위장하지 않는다',
+    );
+  }
+  if (!Array.isArray(envelope.charts)) {
+    throw new FromE2eError('envelope-error', 'chart-to-csv 봉투에 charts 배열이 없다');
+  }
+  if (envelope.charts.length === 0) {
+    throw new FromE2eError('envelope-error', 'chart-to-csv 봉투 charts 가 비어 있다');
+  }
+  const slot = envelope.charts[0];
+  if (slot === null || typeof slot !== 'object' || Array.isArray(slot)) {
+    throw new FromE2eError('envelope-error', 'chart-to-csv 봉투 charts[0] 은 객체여야 한다');
+  }
+  if (typeof slot.csv !== 'string' || slot.csv.length === 0) {
+    throw new FromE2eError('envelope-error', 'chart-to-csv 봉투 charts[0].csv 가 없다');
+  }
+  if (!Number.isInteger(chartIndex) || chartIndex < 1) {
+    throw new FromE2eError('validate-error', 'gymContract.chart는 1 이상의 정수여야 한다');
+  }
+  return slot.csv;
+}
+
+export function parseChartToCsvStdout(stdout) {
+  if (typeof stdout !== 'string') {
+    throw new FromE2eError('type-error', 'chart-to-csv 출력은 문자열이어야 한다');
+  }
+  const trimmed = stdout.replace(/^\uFEFF/, '').trim();
+  if (trimmed.length === 0) {
+    throw new FromE2eError('envelope-error', 'chart-to-csv 출력이 비어 있다');
+  }
+  let envelope;
+  try {
+    envelope = JSON.parse(trimmed);
+  } catch (err) {
+    throw new FromE2eError(
+      'envelope-error',
+      `chart-to-csv 출력이 JSON 이 아니다: ${truncateHead(err.message)}`,
+    );
+  }
+  return envelope;
+}
+
+export function invokeChartToCsv(bin, sampleRel, chart, options = {}) {
+  const execFn = options.execFileSync || execFileSync;
+  const cwd = options.cwd || process.cwd();
+  if (typeof bin !== 'string' || bin.length === 0) {
+    throw new FromE2eError('missing-bin', 'rhwp 바이너리 경로가 없다');
+  }
+  let stdout;
+  try {
+    stdout = execFn(
+      bin,
+      ['chart-to-csv', sampleRel, '--chart', String(chart), '--json'],
+      { cwd, encoding: 'utf8' },
+    );
+  } catch (err) {
+    throw wrapNodeError(err, 'cli', bin);
+  }
+  const envelope = parseChartToCsvStdout(stdout);
+  return extractChartCsvFromEnvelope(envelope, chart);
+}
+
+/**
+ * 이미 뽑아 둔 CLI CSV 와 계약을 과제/기준/편집 CSV 로 조립한다.
+ * 바이너리를 부르지 않으므로 순수 시험이 고정한다.
+ */
+export function materializeFromContract({ taskId, e2ePath, contract, csvAsset, chartCsv }) {
+  assertTaskIdFormat(taskId);
+  assertCliReproducibleContract(contract);
+  const editCsv = applyCsvEdit(chartCsv, contract.edit);
   const task = buildTask({ taskId, e2ePath, contract, csvAsset });
   const reference = buildReference({ taskId, contract, csvAsset });
-  const dump = object => JSON.stringify(object, null, 2) + '\n';
-  writeFileSync(path.join(packDir, 'tasks', `${taskId}.json`), dump(task), 'utf8');
-  writeFileSync(path.join(packDir, 'reference', `${taskId}.json`), dump(reference), 'utf8');
+  assertTaskChecksAreCliReproducible(task);
+  assertReferenceIsCliReproducible(reference);
+  return { csvAsset, editCsv, task, reference };
+}
 
-  console.log(`생성: ${taskId} — assets/${taskId}-edit.csv · tasks/${taskId}.json · reference/${taskId}.json`);
-  console.log(`검증: python gym/tools/build_baseline.py --agent baseline --pack ${packId} --bin <bin> && python gym/score.py --agent baseline --pack ${packId} --bin <bin>`);
+export function honestyPolicy() {
+  return {
+    adapter: 'from_e2e',
+    liveOracle: true,
+    executesE2e: false,
+    usesEval: false,
+    usesFunction: false,
+    allowedContractKeys: [...ALLOWED_CONTRACT_KEYS],
+    allowedEditKeys: [...ALLOWED_EDIT_KEYS],
+    allowedCliCommands: [...ALLOWED_CLI_COMMANDS],
+    allowedCheckOps: [...ALLOWED_CHECK_OPS],
+    forbiddenCliCommands: [...FORBIDDEN_CLI_COMMANDS],
+    studioOnlyKeys: [...STUDIO_ONLY_KEYS],
+    errorKinds: [...ERROR_KINDS],
+    exitByKind: { ...EXIT_BY_KIND },
+    note: '문서 데이터 계약만 CLI 로 파생한다. UI·undo·메뉴·OLE 음성계약은 e2e 에 남긴다.',
+  };
+}
+
+function writeGeneratedArtifacts(root, packId, taskId, materialized) {
+  const packDir = path.join(root, 'gym', 'packs', packId);
+  for (const directory of ['assets', 'tasks', 'reference']) {
+    try {
+      mkdirSync(path.join(packDir, directory), { recursive: true });
+    } catch (err) {
+      throw wrapNodeError(err, 'io', path.join(packDir, directory));
+    }
+  }
+  const csvAbs = path.join(root, materialized.csvAsset);
+  try {
+    writeFileSync(csvAbs, materialized.editCsv, 'utf8');
+    writeFileSync(path.join(packDir, 'tasks', `${taskId}.json`), dumpJson(materialized.task), 'utf8');
+    writeFileSync(path.join(packDir, 'reference', `${taskId}.json`), dumpJson(materialized.reference), 'utf8');
+  } catch (err) {
+    throw wrapNodeError(err, 'io', csvAbs);
+  }
+}
+
+export function mainWith(argv = process.argv, options = {}) {
+  const root = options.cwd || process.cwd();
+  const parsed = parseFromE2eArgv(argv);
+  assertTaskIdFormat(parsed.id);
+  const contract = readContract(root, parsed.e2e);
+  assertCliReproducibleContract(contract);
+  assertTaskIdAvailable(root, parsed.pack, parsed.id);
+
+  const bin = path.resolve(root, parsed.bin);
+  const sampleRel = path.posix.join('samples', contract.sample);
+  const baseCsv = invokeChartToCsv(bin, sampleRel, contract.chart, {
+    cwd: root,
+    execFileSync: options.execFileSync,
+  });
+  const csvAsset = `gym/packs/${parsed.pack}/assets/${parsed.id}-edit.csv`;
+  const materialized = materializeFromContract({
+    taskId: parsed.id,
+    e2ePath: parsed.e2e,
+    contract,
+    csvAsset,
+    chartCsv: baseCsv,
+  });
+  if (!options.dryRun) {
+    writeGeneratedArtifacts(root, parsed.pack, parsed.id, materialized);
+  }
+  return {
+    ok: true,
+    exit: 0,
+    taskId: parsed.id,
+    pack: parsed.pack,
+    csvAsset,
+    task: materialized.task,
+    reference: materialized.reference,
+  };
+}
+
+export function runAsCli(argv = process.argv, io = {
+  log: (...args) => console.log(...args),
+  err: (...args) => console.error(...args),
+}, options = {}) {
+  try {
+    const result = mainWith(argv, options);
+    if (io && typeof io.log === 'function') {
+      io.log(`생성: ${result.taskId} — assets/${result.taskId}-edit.csv · tasks/${result.taskId}.json · reference/${result.taskId}.json`);
+      io.log(`검증: python gym/tools/build_baseline.py --agent baseline --pack ${result.pack} --bin <bin> && python gym/score.py --agent baseline --pack ${result.pack} --bin <bin>`);
+    }
+    return result;
+  } catch (err) {
+    if (isFatalException(err)) throw err;
+    const report = exceptionReport(err, 'main');
+    if (io && typeof io.err === 'function') {
+      io.err(formatExceptionReport(report));
+    }
+    return { ok: false, exit: report.exit, report };
+  }
+}
+
+function main() {
+  const result = runAsCli(process.argv);
+  if (!result.ok) {
+    process.exitCode = result.exit;
+    throw new FromE2eError(result.report.kind, result.report.message, result.report.extras);
+  }
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  main();
+  const result = runAsCli(process.argv);
+  if (!result.ok) process.exit(result.exit);
 }

--- a/gym/tools/from_e2e.mjs
+++ b/gym/tools/from_e2e.mjs
@@ -32,7 +32,7 @@ function arg(name, def) {
  * 허용 값은 중첩 객체, 문자열, 숫자뿐이다. 식·함수·템플릿·배열·식별자는 거부한다.
  * 외부 PR의 e2e 파일은 검토 환경에서 신뢰할 수 없으므로 Function/eval을 사용하면 안 된다.
  */
-export function parseContractLiteral(source) {
+function consumeContractLiteral(source) {
   let index = 0;
   const fail = message => {
     throw new Error(`gymContract ${message} (offset ${index})`);
@@ -152,6 +152,15 @@ export function parseContractLiteral(source) {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
     fail('최상위 값은 객체여야 한다');
   }
+  skipWhitespace();
+  return { value, index };
+}
+
+export function parseContractLiteral(source) {
+  const { value, index } = consumeContractLiteral(source);
+  if (index < source.length) {
+    throw new Error(`gymContract 뒤에 추가 식이 있다 (offset ${index})`);
+  }
   return value;
 }
 
@@ -162,7 +171,8 @@ export function readContract(root, file) {
     throw new Error(`${file} 에 'export const gymContract' 가 없다`);
   }
   const objectStart = src.indexOf('{', match.index);
-  return parseContractLiteral(src.slice(objectStart));
+  // 파일 나머지 코드는 실행하지 않고, 계약 객체만 소비한다.
+  return consumeContractLiteral(src.slice(objectStart)).value;
 }
 
 export function validateContract(contract) {
@@ -207,6 +217,57 @@ export function assertTaskIdAvailable(root, pack, id) {
   }
 }
 
+/**
+ * chart-to-csv 산출 CSV에서 계약이 지정한 한 칸만 바꾼다.
+ * 입력 줄바꿈과 무관하게 LF로 정규화하고, 결과는 항상 LF로 끝난다.
+ */
+export function applyCsvEdit(baseCsv, edit) {
+  const eol = '\n';
+  const rows = baseCsv.replace(/\r\n/g, '\n').replace(/\n$/, '').split('\n').map(row => row.split(','));
+  const dataRow = rows[1 + edit.point];
+  const column = 1 + edit.series;
+  if (!dataRow) throw new Error(`point ${edit.point} 데이터 행이 없다`);
+  if (dataRow[column] !== String(edit.from)) {
+    throw new Error(`계약 불일치: (계열 ${edit.series}, 값 ${edit.point}) 현재 `
+      + `'${dataRow[column]}' ≠ from '${edit.from}' — 샘플이 바뀌었다`);
+  }
+  dataRow[column] = String(edit.to);
+  return rows.map(row => row.join(',')).join(eol) + eol;
+}
+
+export function buildTask({ taskId, e2ePath, contract, csvAsset }) {
+  return {
+    id: taskId,
+    tier: 3,
+    title: `차트 데이터 편집 왕복 (studio ${path.basename(e2ePath)} 파생)`,
+    input: path.posix.join('samples', contract.sample),
+    instructions:
+      `차트 ${contract.chart}의 (계열 ${contract.edit.series}, 값 ${contract.edit.point}) 원본 ${contract.edit.from} 을 `
+      + `'${contract.edit.to}' 로 바꿔 out.hwp 로 저장하라. 원본 크기(계열 수·값 개수·계열명·`
+      + `카테고리 라벨)는 그대로 두어야 한다. 힌트: chart-to-csv 로 뽑아 그 칸만 고치고 `
+      + `csv-to-chart 로 되넣어라(-o out.hwp).`,
+    submit: { kind: 'artifact', files: ['out.hwp'] },
+    checks: [
+      { name: '산출물 존재', op: 'file_exists', file: 'out.hwp', minBytes: 1 },
+      { name: '원본과 다름 (무편집 복사 거부)', op: 'differs_from_input', file: 'out.hwp' },
+      {
+        name: `첫 값이 이미 ${contract.edit.to} (센티넬 재적용이 무변경)`,
+        op: 'value_eq', path: 'changedCount', value: 0,
+        cmd: ['csv-to-chart', '{file:out.hwp}', '--csv', csvAsset,
+          '--chart', String(contract.chart), '--dry-run', '--json'],
+      },
+    ],
+  };
+}
+
+export function buildReference({ taskId, contract, csvAsset }) {
+  return {
+    id: taskId,
+    steps: [{ run: ['csv-to-chart', '{input}', '--csv', csvAsset,
+      '--chart', String(contract.chart), '-o', '{sub:out.hwp}', '--json'] }],
+  };
+}
+
 function main() {
   const root = process.cwd();
   const e2ePath = arg('e2e');
@@ -226,19 +287,7 @@ function main() {
     bin, ['chart-to-csv', sampleRel, '--chart', String(contract.chart), '--json'],
     { cwd: root, encoding: 'utf8' }));
   const baseCsv = env.charts[0].csv;
-
-  // 생성 자산은 Git text 파일로 보관하므로 입력 CSV의 플랫폼 줄바꿈과 무관하게 LF로 고정한다.
-  const eol = '\n';
-  const rows = baseCsv.replace(/\r\n/g, '\n').replace(/\n$/, '').split('\n').map(row => row.split(','));
-  const dataRow = rows[1 + contract.edit.point];
-  const column = 1 + contract.edit.series;
-  if (!dataRow) throw new Error(`point ${contract.edit.point} 데이터 행이 없다`);
-  if (dataRow[column] !== String(contract.edit.from)) {
-    throw new Error(`계약 불일치: (계열 ${contract.edit.series}, 값 ${contract.edit.point}) 현재 `
-      + `'${dataRow[column]}' ≠ from '${contract.edit.from}' — 샘플이 바뀌었다`);
-  }
-  dataRow[column] = String(contract.edit.to);
-  const editCsv = rows.map(row => row.join(',')).join(eol) + eol;
+  const editCsv = applyCsvEdit(baseCsv, contract.edit);
 
   for (const directory of ['assets', 'tasks', 'reference']) {
     mkdirSync(path.join(packDir, directory), { recursive: true });
@@ -246,33 +295,8 @@ function main() {
   const csvAsset = `gym/packs/${packId}/assets/${taskId}-edit.csv`;
   writeFileSync(path.join(root, csvAsset), editCsv, 'utf8');
 
-  const task = {
-    id: taskId,
-    tier: 3,
-    title: `차트 데이터 편집 왕복 (studio ${path.basename(e2ePath)} 파생)`,
-    input: sampleRel,
-    instructions:
-      `차트 ${contract.chart}의 (계열 ${contract.edit.series}, 값 ${contract.edit.point}) 원본 ${contract.edit.from} 을 `
-      + `'${contract.edit.to}' 로 바꿔 out.hwp 로 저장하라. 원본 크기(계열 수·값 개수·계열명·`
-      + `카테고리 라벨)는 그대로 두어야 한다. 힌트: chart-to-csv 로 뽑아 그 칸만 고치고 `
-      + `csv-to-chart 로 되넣어라(-o out.hwp).`,
-    submit: { kind: 'artifact', files: ['out.hwp'] },
-    checks: [
-      { name: '산출물 존재', op: 'file_exists', file: 'out.hwp', minBytes: 1 },
-      { name: '원본과 다름 (무편집 복사 거부)', op: 'differs_from_input', file: 'out.hwp' },
-      {
-        name: `첫 값이 이미 ${contract.edit.to} (센티넬 재적용이 무변경)`,
-        op: 'value_eq', path: 'changedCount', value: 0,
-        cmd: ['csv-to-chart', '{file:out.hwp}', '--csv', csvAsset,
-          '--chart', String(contract.chart), '--dry-run', '--json'],
-      },
-    ],
-  };
-  const reference = {
-    id: taskId,
-    steps: [{ run: ['csv-to-chart', '{input}', '--csv', csvAsset,
-      '--chart', String(contract.chart), '-o', '{sub:out.hwp}', '--json'] }],
-  };
+  const task = buildTask({ taskId, e2ePath, contract, csvAsset });
+  const reference = buildReference({ taskId, contract, csvAsset });
   const dump = object => JSON.stringify(object, null, 2) + '\n';
   writeFileSync(path.join(packDir, 'tasks', `${taskId}.json`), dump(task), 'utf8');
   writeFileSync(path.join(packDir, 'reference', `${taskId}.json`), dump(reference), 'utf8');

--- a/gym/tools/from_e2e_contract.test.mjs
+++ b/gym/tools/from_e2e_contract.test.mjs
@@ -1,11 +1,32 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { assertTaskIdAvailable, parseContractLiteral, validateContract } from './from_e2e.mjs';
+import {
+  applyCsvEdit,
+  assertTaskIdAvailable,
+  buildReference,
+  buildTask,
+  parseContractLiteral,
+  readContract,
+  validateContract,
+} from './from_e2e.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+const validEdit = { series: 0, point: 2, from: '4.3', to: '91.7' };
+
+function validContract(overrides = {}) {
+  return {
+    sample: 'chart/sample.hwp',
+    chart: 1,
+    edit: { ...validEdit },
+    ...overrides,
+  };
+}
 
 test('허용된 gymContract 객체 리터럴을 실행하지 않고 읽는다', () => {
   const contract = parseContractLiteral(`{
@@ -34,4 +55,362 @@ test('다른 pack에 이미 있는 과제 ID는 생성 전에 거부한다', () 
     /security\/SE01\.json/,
   );
   assert.doesNotThrow(() => assertTaskIdAvailable(repoRoot, 'studio-e2e', 'ST01'));
+});
+
+test('Unicode escape \\uAC00을 한글 음절로 읽는다', () => {
+  const contract = parseContractLiteral(`{
+    sample: "\\uAC00/file.hwp",
+    chart: 1,
+    edit: { series: 0, point: 0, from: "1", to: "2" }
+  }`);
+  assert.equal(contract.sample, '가/file.hwp');
+  validateContract(contract);
+});
+
+test('블록 주석과 줄 주석을 값으로 취급하지 않는다', () => {
+  const contract = parseContractLiteral(`{
+    /* 샘플 경로 */
+    sample: 'chart/sample.hwp', // 한 줄
+    chart: 1,
+    /* 중첩 객체 앞 */
+    edit: {
+      series: 0, // 첫 계열
+      point: 0,
+      from: '4.3',
+      to: '91.7',
+    },
+  }`);
+  validateContract(contract);
+  assert.equal(contract.sample, 'chart/sample.hwp');
+  assert.deepEqual(contract.edit, { series: 0, point: 0, from: '4.3', to: '91.7' });
+});
+
+test('따옴표 키와 중첩 객체를 읽는다', () => {
+  const contract = parseContractLiteral(`{
+    "sample": 'chart/sample.hwp',
+    'chart': 2,
+    "edit": { 'series': 1, "point": 3, from: 4.3, to: 91.7 },
+    meta: { note: "nested", n: 2 },
+  }`);
+  validateContract(contract);
+  assert.equal(contract.chart, 2);
+  assert.equal(contract.edit.series, 1);
+  assert.equal(contract.edit.point, 3);
+  assert.equal(contract.edit.from, 4.3);
+  assert.equal(contract.meta.note, 'nested');
+  assert.equal(contract.meta.n, 2);
+});
+
+test('빈 객체는 파싱되나 validateContract에서 거부한다', () => {
+  const contract = parseContractLiteral('{}');
+  assert.deepEqual(contract, {});
+  assert.throws(() => validateContract(contract), /gymContract\.sample은 비어 있지 않은 문자열이어야 한다/);
+});
+
+test('배열 값은 거부한다', () => {
+  assert.throws(
+    () => parseContractLiteral(`{ sample: ['chart/sample.hwp'] }`),
+    /객체·문자열·숫자 이외의 식은 허용하지 않는다/,
+  );
+});
+
+test('식별자 값은 거부한다', () => {
+  assert.throws(
+    () => parseContractLiteral(`{ sample: someVar, chart: 1 }`),
+    /객체·문자열·숫자 이외의 식은 허용하지 않는다/,
+  );
+});
+
+test('템플릿 리터럴은 거부한다', () => {
+  assert.throws(
+    () => parseContractLiteral('{ sample: `chart/sample.hwp`, chart: 1 }'),
+    /객체·문자열·숫자 이외의 식은 허용하지 않는다/,
+  );
+});
+
+test('중복 키는 거부한다', () => {
+  assert.throws(
+    () => parseContractLiteral(`{ sample: 'a.hwp', sample: 'b.hwp', chart: 1 }`),
+    /중복 키 'sample'는 허용하지 않는다/,
+  );
+});
+
+test('닫히지 않은 문자열은 거부한다', () => {
+  assert.throws(
+    () => parseContractLiteral(`{ sample: 'oops, chart: 1 }`),
+    /문자열이 닫히지 않았다/,
+  );
+});
+
+test('잘못된 Unicode escape는 거부한다', () => {
+  assert.throws(
+    () => parseContractLiteral(`{ sample: "\\uZZZZ.hwp" }`),
+    /유효하지 않은 Unicode escape다/,
+  );
+  assert.throws(
+    () => parseContractLiteral(`{ sample: "\\u12" }`),
+    /유효하지 않은 Unicode escape다/,
+  );
+});
+
+test('객체 뒤 추가 식은 거부한다', () => {
+  assert.throws(
+    () => parseContractLiteral(`{ sample: 'x.hwp' } + 1`),
+    /뒤에 추가 식이 있다/,
+  );
+  assert.throws(
+    () => parseContractLiteral(`{ sample: 'x.hwp' }; globalThis.process.exit(1)`),
+    /뒤에 추가 식이 있다/,
+  );
+});
+
+test('객체 뒤 주석만 있으면 허용한다', () => {
+  const contract = parseContractLiteral(`{ sample: 'x.hwp', chart: 1, edit: { series: 0, point: 0, from: '1', to: '2' } } // tail`);
+  validateContract(contract);
+  assert.equal(contract.sample, 'x.hwp');
+});
+
+test('boolean·null·단항 플러스는 식이므로 거부한다', () => {
+  assert.throws(() => parseContractLiteral('{ flag: true }'), /객체·문자열·숫자 이외의 식은 허용하지 않는다/);
+  assert.throws(() => parseContractLiteral('{ flag: false }'), /객체·문자열·숫자 이외의 식은 허용하지 않는다/);
+  assert.throws(() => parseContractLiteral('{ flag: null }'), /객체·문자열·숫자 이외의 식은 허용하지 않는다/);
+  assert.throws(() => parseContractLiteral('{ n: +1 }'), /객체·문자열·숫자 이외의 식은 허용하지 않는다/);
+});
+
+test('최상위 문자열·숫자는 객체가 아니다', () => {
+  assert.throws(() => parseContractLiteral(`'hello'`), /최상위 값은 객체여야 한다/);
+  assert.throws(() => parseContractLiteral('12'), /최상위 값은 객체여야 한다/);
+});
+
+test('닫히지 않은 블록 주석은 거부한다', () => {
+  assert.throws(() => parseContractLiteral('{ /* 미닫힘 sample: 1 }'), /블록 주석이 닫히지 않았다/);
+});
+
+test('허용되지 않은 문자열 escape는 거부한다', () => {
+  assert.throws(() => parseContractLiteral(`{ sample: "\\x41" }`), /허용되지 않은 문자열 escape/);
+});
+
+test('validateContract는 sample이 없거나 빈 문자열이면 거부한다', () => {
+  assert.throws(() => validateContract(validContract({ sample: '' })), /gymContract\.sample은 비어 있지 않은 문자열이어야 한다/);
+  assert.throws(() => validateContract(validContract({ sample: 1 })), /gymContract\.sample은 비어 있지 않은 문자열이어야 한다/);
+  const missing = validContract();
+  delete missing.sample;
+  assert.throws(() => validateContract(missing), /gymContract\.sample은 비어 있지 않은 문자열이어야 한다/);
+});
+
+test('validateContract는 chart가 1 미만이면 거부한다', () => {
+  assert.throws(() => validateContract(validContract({ chart: 0 })), /gymContract\.chart는 1 이상의 정수여야 한다/);
+  assert.throws(() => validateContract(validContract({ chart: -1 })), /gymContract\.chart는 1 이상의 정수여야 한다/);
+  assert.throws(() => validateContract(validContract({ chart: 1.5 })), /gymContract\.chart는 1 이상의 정수여야 한다/);
+});
+
+test('validateContract는 edit가 객체가 아니면 거부한다', () => {
+  assert.throws(() => validateContract(validContract({ edit: null })), /gymContract\.edit는 객체여야 한다/);
+  assert.throws(() => validateContract(validContract({ edit: [] })), /gymContract\.edit는 객체여야 한다/);
+  assert.throws(() => validateContract(validContract({ edit: 'nope' })), /gymContract\.edit는 객체여야 한다/);
+});
+
+test('validateContract는 series가 음수이면 거부한다', () => {
+  assert.throws(
+    () => validateContract(validContract({ edit: { ...validEdit, series: -1 } })),
+    /gymContract\.edit\.series는 0 이상의 정수여야 한다/,
+  );
+});
+
+test('validateContract는 from이 없으면 거부한다', () => {
+  const edit = { series: 0, point: 0, to: '91.7' };
+  assert.throws(
+    () => validateContract(validContract({ edit })),
+    /gymContract\.edit\.from는 문자열 또는 숫자여야 한다/,
+  );
+});
+
+test('validateContract는 to·point 형식도 검사한다', () => {
+  assert.throws(
+    () => validateContract(validContract({ edit: { ...validEdit, to: undefined } })),
+    /gymContract\.edit\.to는 문자열 또는 숫자여야 한다/,
+  );
+  assert.throws(
+    () => validateContract(validContract({ edit: { ...validEdit, point: -3 } })),
+    /gymContract\.edit\.point는 0 이상의 정수여야 한다/,
+  );
+});
+
+test('applyCsvEdit는 지정 칸만 바꾸고 LF로 끝낸다', () => {
+  const base = ',계열 1,계열 2,계열 3\n항목 1,4.3,2.4,2\n항목 2,2.5,4.4,2\n';
+  const out = applyCsvEdit(base, { series: 0, point: 0, from: '4.3', to: '91.7' });
+  assert.equal(out, ',계열 1,계열 2,계열 3\n항목 1,91.7,2.4,2\n항목 2,2.5,4.4,2\n');
+  assert.match(out, /\n$/);
+  assert.doesNotMatch(out, /\r/);
+});
+
+test('applyCsvEdit는 CRLF 입력을 LF로 정규화한다', () => {
+  const base = ',s1,s2\r\nitem,1,2\r\n';
+  const out = applyCsvEdit(base, { series: 1, point: 0, from: '2', to: '9' });
+  assert.equal(out, ',s1,s2\nitem,1,9\n');
+});
+
+test('applyCsvEdit는 숫자 from/to를 문자열 칸과 대조한다', () => {
+  const out = applyCsvEdit(',s1\nrow,4.3\n', { series: 0, point: 0, from: 4.3, to: 91.7 });
+  assert.equal(out, ',s1\nrow,91.7\n');
+});
+
+test('applyCsvEdit는 from 불일치면 계약 오류다', () => {
+  assert.throws(
+    () => applyCsvEdit(',s1\nrow,4.3\n', { series: 0, point: 0, from: '9', to: '1' }),
+    /계약 불일치: \(계열 0, 값 0\) 현재 '4\.3' ≠ from '9'/,
+  );
+});
+
+test('applyCsvEdit는 없는 point 행을 거부한다', () => {
+  assert.throws(
+    () => applyCsvEdit(',s1\nrow,4.3\n', { series: 0, point: 5, from: '4.3', to: '1' }),
+    /point 5 데이터 행이 없다/,
+  );
+});
+
+test('applyCsvEdit는 ST01 원본 한 칸만 91.7로 바꾼다', () => {
+  const base = [
+    ',계열 1,계열 2,계열 3',
+    '항목 1,4.3,2.4,2',
+    '항목 2,2.5,4.4,2',
+    '항목 3,3.5,1.8,3',
+    '항목 4,4.5,2.8,5',
+    '',
+  ].join('\n');
+  const out = applyCsvEdit(base, { series: 0, point: 0, from: '4.3', to: '91.7' });
+  assert.equal(out, [
+    ',계열 1,계열 2,계열 3',
+    '항목 1,91.7,2.4,2',
+    '항목 2,2.5,4.4,2',
+    '항목 3,3.5,1.8,3',
+    '항목 4,4.5,2.8,5',
+    '',
+  ].join('\n'));
+});
+
+const st01Contract = {
+  sample: 'chart/세로막대형/묶은세로막대형.hwp',
+  chart: 1,
+  edit: { series: 0, point: 0, from: 4.3, to: 91.7 },
+};
+const st01CsvAsset = 'gym/packs/studio-e2e/assets/ST01-edit.csv';
+const st01E2e = 'rhwp-studio/e2e/issue-4694-chart-data-edit.test.mjs';
+
+test('buildTask는 file_exists·differs_from_input·value_eq changedCount 0 dry-run을 넣는다', () => {
+  const task = buildTask({
+    taskId: 'ST01',
+    e2ePath: st01E2e,
+    contract: st01Contract,
+    csvAsset: st01CsvAsset,
+  });
+  assert.equal(task.id, 'ST01');
+  assert.equal(task.tier, 3);
+  assert.equal(task.title, '차트 데이터 편집 왕복 (studio issue-4694-chart-data-edit.test.mjs 파생)');
+  assert.equal(task.input, 'samples/chart/세로막대형/묶은세로막대형.hwp');
+  assert.equal(task.submit.kind, 'artifact');
+  assert.deepEqual(task.submit.files, ['out.hwp']);
+  assert.equal(task.checks.length, 3);
+  assert.deepEqual(task.checks[0], { name: '산출물 존재', op: 'file_exists', file: 'out.hwp', minBytes: 1 });
+  assert.deepEqual(task.checks[1], { name: '원본과 다름 (무편집 복사 거부)', op: 'differs_from_input', file: 'out.hwp' });
+  const sentinel = task.checks[2];
+  assert.equal(sentinel.op, 'value_eq');
+  assert.equal(sentinel.path, 'changedCount');
+  assert.equal(sentinel.value, 0);
+  assert.match(sentinel.name, /91\.7/);
+  assert.deepEqual(sentinel.cmd, [
+    'csv-to-chart',
+    '{file:out.hwp}',
+    '--csv',
+    st01CsvAsset,
+    '--chart',
+    '1',
+    '--dry-run',
+    '--json',
+  ]);
+  assert.match(task.instructions, /차트 1의 \(계열 0, 값 0\) 원본 4\.3/);
+  assert.match(task.instructions, /csv-to-chart 로 되넣어라\(-o out\.hwp\)/);
+});
+
+test('buildReference run은 csv-to-chart {input} --csv ... -o {sub:out.hwp} 이다', () => {
+  const reference = buildReference({
+    taskId: 'ST01',
+    contract: st01Contract,
+    csvAsset: st01CsvAsset,
+  });
+  assert.deepEqual(reference, {
+    id: 'ST01',
+    steps: [{
+      run: [
+        'csv-to-chart',
+        '{input}',
+        '--csv',
+        st01CsvAsset,
+        '--chart',
+        '1',
+        '-o',
+        '{sub:out.hwp}',
+        '--json',
+      ],
+    }],
+  });
+});
+
+test('assertTaskIdAvailable는 security가 가진 SE01을 계속 거부한다', () => {
+  assert.throws(
+    () => assertTaskIdAvailable(repoRoot, 'studio-e2e', 'SE01'),
+    /과제 ID 'SE01' 가 다른 pack에 이미 있다: security\/SE01\.json/,
+  );
+});
+
+test('assertTaskIdAvailable는 pack studio-e2e의 ST01을 허용한다', () => {
+  assert.doesNotThrow(() => assertTaskIdAvailable(repoRoot, 'studio-e2e', 'ST01'));
+});
+
+test('assertTaskIdAvailable는 다른 pack의 ST01은 거부한다', () => {
+  assert.throws(
+    () => assertTaskIdAvailable(repoRoot, 'security', 'ST01'),
+    /studio-e2e\/ST01\.json/,
+  );
+});
+
+test('assertTaskIdAvailable는 gym/packs가 없으면 통과한다', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'from-e2e-nopack-'));
+  try {
+    assert.doesNotThrow(() => assertTaskIdAvailable(dir, 'studio-e2e', 'SE01'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readContract는 파일의 gymContract만 읽고 뒤 코드를 실행하지 않는다', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'from-e2e-read-'));
+  const rel = 'sample.test.mjs';
+  writeFileSync(path.join(dir, rel), `
+export const gymContract = {
+  sample: 'chart/sample.hwp',
+  chart: 1,
+  edit: { series: 0, point: 0, from: '1', to: '2' },
+};
+throw new Error('이 파일은 실행되면 안 된다');
+`);
+  try {
+    const contract = readContract(dir, rel);
+    validateContract(contract);
+    assert.equal(contract.sample, 'chart/sample.hwp');
+    assert.equal(contract.edit.to, '2');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readContract는 gymContract가 없으면 거부한다', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'from-e2e-missing-'));
+  const rel = 'no-contract.test.mjs';
+  writeFileSync(path.join(dir, rel), 'export const other = { sample: "x" };\n');
+  try {
+    assert.throws(() => readContract(dir, rel), /export const gymContract/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/gym/tools/from_e2e_exceptions.test.mjs
+++ b/gym/tools/from_e2e_exceptions.test.mjs
@@ -1,0 +1,871 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  ALLOWED_CHECK_OPS,
+  ALLOWED_CLI_COMMANDS,
+  ALLOWED_CONTRACT_KEYS,
+  ALLOWED_EDIT_KEYS,
+  ALLOWED_SAMPLE_SUFFIXES,
+  ERROR_KINDS,
+  EXIT_BY_KIND,
+  FATAL_ERROR_NAMES,
+  FORBIDDEN_CLI_COMMANDS,
+  FromE2eError,
+  STUDIO_ONLY_KEYS,
+  TASK_ID_PATTERN,
+  USAGE,
+  applyCsvEdit,
+  assertCliReproducibleContract,
+  assertCsvRectangular,
+  assertReferenceIsCliReproducible,
+  assertSafeSamplePath,
+  assertTaskChecksAreCliReproducible,
+  assertTaskIdAvailable,
+  assertTaskIdFormat,
+  buildReference,
+  buildTask,
+  classifyNodeError,
+  collectForbiddenKeys,
+  collectUnknownKeys,
+  dumpJson,
+  exceptionReport,
+  exitCodeForKind,
+  extractChartCsvFromEnvelope,
+  formatExceptionReport,
+  honestyPolicy,
+  invokeChartToCsv,
+  isFatalException,
+  joinCsvRows,
+  locateGymContract,
+  materializeFromContract,
+  parseChartToCsvStdout,
+  parseContractLiteral,
+  parseFromE2eArgv,
+  readContract,
+  readJsonFileOrThrow,
+  runAsCli,
+  splitCsvRows,
+  truncateHead,
+  validateContract,
+  wrapNodeError,
+} from './from_e2e.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const validEdit = { series: 0, point: 2, from: '4.3', to: '91.7' };
+
+function validContract(overrides = {}) {
+  return {
+    sample: 'chart/sample.hwp',
+    chart: 1,
+    edit: { ...validEdit },
+    ...overrides,
+  };
+}
+
+const st01Contract = {
+  sample: 'chart/세로막대형/묶은세로막대형.hwp',
+  chart: 1,
+  edit: { series: 0, point: 0, from: 4.3, to: 91.7 },
+};
+const st01CsvAsset = 'gym/packs/studio-e2e/assets/ST01-edit.csv';
+const st01E2e = 'rhwp-studio/e2e/issue-4694-chart-data-edit.test.mjs';
+
+function throwsKind(fn, kind) {
+  assert.throws(fn, err => err instanceof FromE2eError && err.kind === kind);
+}
+
+test('예외 kind 카탈로그는 문서와 같은 표를 쓴다', () => {
+  assert.deepEqual([...ERROR_KINDS], [
+    'missing-arg',
+    'missing-file',
+    'missing-bin',
+    'permission',
+    'timeout',
+    'decode-error',
+    'parse-error',
+    'missing-contract',
+    'validate-error',
+    'studio-only',
+    'path-escape',
+    'csv-mismatch',
+    'csv-missing-row',
+    'csv-missing-col',
+    'csv-shape',
+    'task-id-conflict',
+    'task-id-invalid',
+    'envelope-error',
+    'cli-error',
+    'os-error',
+    'type-error',
+    'json-error',
+    'unexpected',
+  ]);
+  assert.equal(new Set(ERROR_KINDS).size, ERROR_KINDS.length);
+  for (const kind of ERROR_KINDS) {
+    assert.equal(typeof EXIT_BY_KIND[kind], 'number');
+    assert.ok(EXIT_BY_KIND[kind] >= 1 && EXIT_BY_KIND[kind] <= 6);
+  }
+});
+
+test('FromE2eError는 kind와 extras를 싣는다', () => {
+  const err = new FromE2eError('parse-error', 'gymContract 시험', { offset: 4 });
+  assert.equal(err.name, 'FromE2eError');
+  assert.equal(err.kind, 'parse-error');
+  assert.equal(err.message, 'gymContract 시험');
+  assert.equal(err.extras.offset, 4);
+  assert.ok(err instanceof Error);
+});
+
+test('isFatalException은 SystemExit·GeneratorExit·fatal 표지만 참이다', () => {
+  assert.equal(isFatalException(null), false);
+  assert.equal(isFatalException('x'), false);
+  assert.equal(isFatalException(new Error('no')), false);
+  assert.equal(isFatalException(new FromE2eError('cli-error', 'x')), false);
+  const systemExit = new Error('exit');
+  systemExit.name = 'SystemExit';
+  assert.equal(isFatalException(systemExit), true);
+  const gen = new Error('gen');
+  gen.name = 'GeneratorExit';
+  assert.equal(isFatalException(gen), true);
+  const oom = new Error('oom');
+  oom.code = 'ERR_WORKER_OUT_OF_MEMORY';
+  assert.equal(isFatalException(oom), true);
+  const marked = new Error('marked');
+  marked.fatal = true;
+  assert.equal(isFatalException(marked), true);
+  assert.ok(FATAL_ERROR_NAMES.includes('SystemExit'));
+  assert.ok(FATAL_ERROR_NAMES.includes('GeneratorExit'));
+});
+
+test('exitCodeForKind는 카탈로그 밖을 unexpected(1)로 접는다', () => {
+  assert.equal(exitCodeForKind('missing-arg'), 2);
+  assert.equal(exitCodeForKind('parse-error'), 3);
+  assert.equal(exitCodeForKind('csv-mismatch'), 4);
+  assert.equal(exitCodeForKind('missing-bin'), 5);
+  assert.equal(exitCodeForKind('missing-file'), 6);
+  assert.equal(exitCodeForKind('unexpected'), 1);
+  assert.equal(exitCodeForKind('not-a-kind'), 1);
+  assert.equal(exitCodeForKind(undefined), 1);
+});
+
+test('truncateHead는 한도와 null을 자른다', () => {
+  assert.equal(truncateHead(null), '');
+  assert.equal(truncateHead(undefined), '');
+  assert.equal(truncateHead('abcd', 2), 'ab');
+  assert.equal(truncateHead('abcd', 4), 'abcd');
+  assert.equal(truncateHead('abcd', 0), '');
+  assert.equal(truncateHead(12), '12');
+});
+
+const nodeErrorCases = [
+  { name: 'ENOENT io', code: 'ENOENT', context: 'io', kind: 'missing-file' },
+  { name: 'ENOENT cli', code: 'ENOENT', context: 'cli', kind: 'missing-bin' },
+  { name: 'ENOENT bin', code: 'ENOENT', context: 'bin', kind: 'missing-bin' },
+  { name: 'EACCES', code: 'EACCES', context: 'io', kind: 'permission' },
+  { name: 'EPERM', code: 'EPERM', context: 'io', kind: 'permission' },
+  { name: 'ETIMEDOUT', code: 'ETIMEDOUT', context: 'cli', kind: 'timeout' },
+  { name: 'EAGAIN', code: 'EAGAIN', context: 'io', kind: 'unexpected' },
+  { name: 'ENOSPC', code: 'ENOSPC', context: 'io', kind: 'unexpected' },
+  { name: 'ERR_FS', code: 'ERR_FS_FILE_TOO_LARGE', context: 'io', kind: 'os-error' },
+];
+
+for (const row of nodeErrorCases) {
+  test(`classifyNodeError ${row.name} → ${row.kind}`, () => {
+    const err = Object.assign(new Error(row.name), { code: row.code });
+    assert.equal(classifyNodeError(err, row.context), row.kind);
+  });
+}
+
+test('classifyNodeError status·타입·JSON·유니코드', () => {
+  assert.equal(classifyNodeError(Object.assign(new Error('fail'), { status: 2 }), 'cli'), 'cli-error');
+  assert.equal(classifyNodeError(new TypeError('t'), 'io'), 'type-error');
+  assert.equal(classifyNodeError(new RangeError('r'), 'io'), 'type-error');
+  assert.equal(classifyNodeError(new SyntaxError('s'), 'json'), 'json-error');
+  assert.equal(classifyNodeError(new SyntaxError('s'), 'io'), 'parse-error');
+  assert.equal(classifyNodeError(new URIError('u'), 'io'), 'decode-error');
+  assert.equal(classifyNodeError(Object.assign(new Error('os'), { errno: -2 }), 'io'), 'os-error');
+  assert.equal(classifyNodeError(new Error('mystery'), 'io'), 'unexpected');
+  assert.equal(classifyNodeError(null, 'io'), 'unexpected');
+  assert.equal(classifyNodeError(new Error('operation timeout'), 'cli'), 'timeout');
+  assert.equal(classifyNodeError(new FromE2eError('csv-mismatch', 'x'), 'io'), 'csv-mismatch');
+});
+
+test('wrapNodeError는 FromE2eError를 다시 감싸지 않는다', () => {
+  const inner = new FromE2eError('parse-error', '그대로');
+  assert.equal(wrapNodeError(inner, 'io', 'x'), inner);
+  const wrapped = wrapNodeError(Object.assign(new Error('nope'), { code: 'ENOENT' }), 'io', 'ghost.mjs');
+  assert.ok(wrapped instanceof FromE2eError);
+  assert.equal(wrapped.kind, 'missing-file');
+  assert.match(wrapped.message, /ghost\.mjs/);
+});
+
+test('exceptionReport는 치명 예외를 fatal로 표지한다', () => {
+  const fatal = new Error('stop');
+  fatal.name = 'SystemExit';
+  const report = exceptionReport(fatal, 'main');
+  assert.equal(report.fatal, true);
+  assert.equal(report.error, 'SystemExit');
+  const normal = exceptionReport(new FromE2eError('missing-arg', USAGE), 'main');
+  assert.equal(normal.fatal, false);
+  assert.equal(normal.kind, 'missing-arg');
+  assert.equal(normal.exit, 2);
+  assert.match(formatExceptionReport(normal), /from_e2e missing-arg/);
+  const extras = exceptionReport(new FromE2eError('csv-mismatch', 'x', { series: 1 }), 'csv');
+  assert.equal(extras.extras.series, 1);
+  const other = exceptionReport(new Error('plain'), 'io');
+  assert.deepEqual(other.extras, {});
+});
+
+test('parseFromE2eArgv는 필수 인자를 검사한다', () => {
+  throwsKind(() => parseFromE2eArgv(['node', 'from_e2e.mjs']), 'missing-arg');
+  throwsKind(() => parseFromE2eArgv(['node', 'from_e2e.mjs', '--e2e', 'a.mjs']), 'missing-arg');
+  throwsKind(() => parseFromE2eArgv(['node', 'from_e2e.mjs', '--id', 'ST01']), 'missing-arg');
+  throwsKind(() => parseFromE2eArgv(['node', 'from_e2e.mjs', '--e2e', '--id', 'ST01']), 'missing-arg');
+  throwsKind(() => parseFromE2eArgv(null), 'type-error');
+  const parsed = parseFromE2eArgv([
+    'node', 'from_e2e.mjs', '--e2e', 'a.mjs', '--id', 'ST09', '--pack', 'studio-e2e', '--bin', 'rhwp',
+  ]);
+  assert.deepEqual(parsed, { e2e: 'a.mjs', pack: 'studio-e2e', id: 'ST09', bin: 'rhwp' });
+  const defaults = parseFromE2eArgv(['--e2e', 'a.mjs', '--id', 'ST09']);
+  assert.equal(defaults.pack, 'studio-e2e');
+  assert.equal(defaults.bin, 'target/debug/rhwp');
+  assert.match(USAGE, /--e2e/);
+});
+
+test('assertTaskIdFormat은 ST01·AU13을 허용하고 소문자를 거부한다', () => {
+  assert.doesNotThrow(() => assertTaskIdFormat('ST01'));
+  assert.doesNotThrow(() => assertTaskIdFormat('AU13'));
+  assert.doesNotThrow(() => assertTaskIdFormat('T01'));
+  assert.doesNotThrow(() => assertTaskIdFormat('SE01'));
+  throwsKind(() => assertTaskIdFormat('st01'), 'task-id-invalid');
+  throwsKind(() => assertTaskIdFormat('ST1'), 'task-id-invalid');
+  throwsKind(() => assertTaskIdFormat('ST001'), 'task-id-invalid');
+  throwsKind(() => assertTaskIdFormat('TOOLONG01'), 'task-id-invalid');
+  throwsKind(() => assertTaskIdFormat(''), 'task-id-invalid');
+  assert.equal(TASK_ID_PATTERN.test('ST01'), true);
+  assert.equal(TASK_ID_PATTERN.test('SE01'), true);
+});
+
+const samplePathCases = [
+  { sample: 'chart/sample.hwp', ok: true },
+  { sample: 'chart/세로막대형/묶은세로막대형.hwp', ok: true },
+  { sample: 'a.hwpx', ok: true },
+  { sample: 'A.HWP', ok: true },
+  { sample: '../secret.hwp', ok: false, kind: 'path-escape' },
+  { sample: 'chart/../../etc/passwd.hwp', ok: false, kind: 'path-escape' },
+  { sample: '/tmp/x.hwp', ok: false, kind: 'path-escape' },
+  { sample: 'chart/x.txt', ok: false, kind: 'validate-error' },
+  { sample: 'chart/x.hwp\0', ok: false, kind: 'path-escape' },
+  { sample: '', ok: false, kind: 'validate-error' },
+];
+
+for (const row of samplePathCases) {
+  test(`assertSafeSamplePath ${JSON.stringify(row.sample)}`, () => {
+    if (row.ok) assert.doesNotThrow(() => assertSafeSamplePath(row.sample));
+    else throwsKind(() => assertSafeSamplePath(row.sample), row.kind);
+  });
+}
+
+test('Windows 절대 샘플 경로는 path-escape 다', () => {
+  throwsKind(() => assertSafeSamplePath('C:/abs/x.hwp'), 'path-escape');
+});
+
+test('assertCliReproducibleContract는 sample/chart/edit만 남긴다', () => {
+  assert.doesNotThrow(() => assertCliReproducibleContract(validContract()));
+  throwsKind(() => assertCliReproducibleContract(validContract({ menu: '차트' })), 'studio-only');
+  throwsKind(() => assertCliReproducibleContract(validContract({ meta: { note: 'x' } })), 'studio-only');
+  throwsKind(() => assertCliReproducibleContract(validContract({
+    edit: { ...validEdit, locator: '#cell' },
+  })), 'studio-only');
+  throwsKind(() => assertCliReproducibleContract(validContract({
+    edit: { series: 0, point: 0, from: '4.3', to: '4.3' },
+  })), 'validate-error');
+});
+
+for (const key of STUDIO_ONLY_KEYS) {
+  test(`assertCliReproducibleContract는 스튜디오 키 ${key} 를 거부한다`, () => {
+    throwsKind(() => assertCliReproducibleContract(validContract({ [key]: 1 })), 'studio-only');
+  });
+}
+
+test('collectForbiddenKeys는 중첩 경로를 모은다', () => {
+  assert.deepEqual(collectForbiddenKeys({ edit: { undo: true } }, STUDIO_ONLY_KEYS), ['edit.undo']);
+  assert.deepEqual(collectForbiddenKeys(null, STUDIO_ONLY_KEYS), []);
+  assert.deepEqual(collectUnknownKeys({ sample: 'a', extra: 1 }, ALLOWED_CONTRACT_KEYS), ['extra']);
+});
+
+test('허용 키·명령 카탈로그는 차트 왕복만 담는다', () => {
+  assert.deepEqual([...ALLOWED_CONTRACT_KEYS], ['sample', 'chart', 'edit']);
+  assert.deepEqual([...ALLOWED_EDIT_KEYS], ['series', 'point', 'from', 'to']);
+  assert.deepEqual([...ALLOWED_CLI_COMMANDS], ['chart-to-csv', 'csv-to-chart']);
+  assert.deepEqual([...ALLOWED_CHECK_OPS], ['file_exists', 'differs_from_input', 'value_eq']);
+  assert.ok(ALLOWED_SAMPLE_SUFFIXES.includes('.hwp'));
+  assert.ok(ALLOWED_SAMPLE_SUFFIXES.includes('.hwpx'));
+  for (const command of FORBIDDEN_CLI_COMMANDS) {
+    assert.ok(!ALLOWED_CLI_COMMANDS.includes(command), command);
+  }
+});
+
+test('honestyPolicy는 eval·e2e 실행을 하지 않는다고 선언한다', () => {
+  const policy = honestyPolicy();
+  assert.equal(policy.executesE2e, false);
+  assert.equal(policy.usesEval, false);
+  assert.equal(policy.usesFunction, false);
+  assert.equal(policy.liveOracle, true);
+  assert.deepEqual(policy.allowedCliCommands, ['chart-to-csv', 'csv-to-chart']);
+  assert.ok(policy.studioOnlyKeys.includes('undo'));
+  assert.ok(policy.errorKinds.includes('studio-only'));
+});
+
+const envelopeCases = [
+  { name: '정상', env: { ok: true, charts: [{ csv: ',s1\nr,1\n' }] }, ok: true, csv: ',s1\nr,1\n' },
+  { name: 'ok 생략', env: { charts: [{ csv: ',s1\nr,1\n' }] }, ok: true, csv: ',s1\nr,1\n' },
+  { name: 'ok false', env: { ok: false, charts: [{ csv: ',s1\nr,1\n' }] }, kind: 'cli-error' },
+  { name: 'null', env: null, kind: 'envelope-error' },
+  { name: '배열', env: [], kind: 'envelope-error' },
+  { name: 'charts 없음', env: { ok: true }, kind: 'envelope-error' },
+  { name: 'charts 빈값', env: { ok: true, charts: [] }, kind: 'envelope-error' },
+  { name: 'charts[0] 문자열', env: { ok: true, charts: ['x'] }, kind: 'envelope-error' },
+  { name: 'csv 없음', env: { ok: true, charts: [{}] }, kind: 'envelope-error' },
+  { name: 'csv 빈값', env: { ok: true, charts: [{ csv: '' }] }, kind: 'envelope-error' },
+];
+
+for (const row of envelopeCases) {
+  test(`extractChartCsvFromEnvelope ${row.name}`, () => {
+    if (row.ok) assert.equal(extractChartCsvFromEnvelope(row.env), row.csv);
+    else throwsKind(() => extractChartCsvFromEnvelope(row.env), row.kind);
+  });
+}
+
+test('parseChartToCsvStdout은 BOM·공백을 허용하고 빈 출력은 거부한다', () => {
+  const env = parseChartToCsvStdout('\uFEFF{"ok":true,"charts":[{"csv":"a"}]}\n');
+  assert.equal(env.charts[0].csv, 'a');
+  throwsKind(() => parseChartToCsvStdout(''), 'envelope-error');
+  throwsKind(() => parseChartToCsvStdout('not-json'), 'envelope-error');
+  throwsKind(() => parseChartToCsvStdout(12), 'type-error');
+});
+
+for (const row of [
+  { name: 'HTML', stdout: '<html>no</html>' },
+  { name: '부분 JSON', stdout: '{"ok":true' },
+  { name: '숫자', stdout: '12' },
+  { name: '문자열 JSON', stdout: '"hello"' },
+  { name: 'true', stdout: 'true' },
+]) {
+  test(`parseChartToCsvStdout ${row.name} 은 봉투가 아니다`, () => {
+    assert.throws(() => {
+      const env = parseChartToCsvStdout(row.stdout);
+      extractChartCsvFromEnvelope(env);
+    }, err => err instanceof FromE2eError);
+  });
+}
+
+test('invokeChartToCsv는 목 exec로 봉투를 읽는다', () => {
+  const csv = invokeChartToCsv('rhwp', 'samples/a.hwp', 1, {
+    execFileSync: () => JSON.stringify({ ok: true, charts: [{ csv: ',s1\nr,4.3\n' }] }),
+  });
+  assert.equal(csv, ',s1\nr,4.3\n');
+});
+
+test('invokeChartToCsv는 없는 바이너리·권한·비정상 종료를 접는다', () => {
+  throwsKind(() => invokeChartToCsv('', 'samples/a.hwp', 1, { execFileSync: () => '' }), 'missing-bin');
+  throwsKind(() => invokeChartToCsv('rhwp', 'samples/a.hwp', 1, {
+    execFileSync: () => { const e = new Error('no'); e.code = 'ENOENT'; throw e; },
+  }), 'missing-bin');
+  throwsKind(() => invokeChartToCsv('rhwp', 'samples/a.hwp', 1, {
+    execFileSync: () => { const e = new Error('fail'); e.status = 2; throw e; },
+  }), 'cli-error');
+  throwsKind(() => invokeChartToCsv('rhwp', 'samples/a.hwp', 1, {
+    execFileSync: () => { const e = new Error('denied'); e.code = 'EACCES'; throw e; },
+  }), 'permission');
+});
+
+test('locateGymContract는 export const 표지만 인정한다', () => {
+  const src = "export const gymContract = {\n  sample: 'a.hwp'\n};\n";
+  const loc = locateGymContract(src, 'x.mjs');
+  assert.equal(src[loc.objectStart], '{');
+  throwsKind(() => locateGymContract('const gymContract = { sample: 1 }', 'x.mjs'), 'missing-contract');
+  throwsKind(() => locateGymContract('export let gymContract = { sample: 1 }', 'x.mjs'), 'missing-contract');
+  throwsKind(() => locateGymContract(1, 'x.mjs'), 'type-error');
+});
+
+test('parseContractLiteral은 원문이 문자열이 아니면 type-error 다', () => {
+  throwsKind(() => parseContractLiteral(null), 'type-error');
+  throwsKind(() => parseContractLiteral({ sample: 'a' }), 'type-error');
+});
+
+const parseRejectCases = [
+  { name: '미닫힘 객체', src: '{ sample: "a.hwp"', re: /키가 필요하다|',' 또는 '}'가 필요하다/ },
+  { name: '콜론 없음', src: '{ sample "a.hwp" }', re: /뒤에 ':'가 필요하다/ },
+  { name: '값 없음', src: '{ sample: }', re: /객체·문자열·숫자 이외/ },
+  { name: '선행 점 숫자', src: '{ n: .5 }', re: /객체·문자열·숫자 이외/ },
+  { name: '16진수', src: '{ n: 0x10 }', re: /키 'n' 뒤에 ',' 또는 '}'가 필요하다/ },
+  { name: 'Infinity', src: '{ n: Infinity }', re: /객체·문자열·숫자 이외/ },
+  { name: 'NaN', src: '{ n: NaN }', re: /객체·문자열·숫자 이외/ },
+  { name: 'undefined', src: '{ n: undefined }', re: /객체·문자열·숫자 이외/ },
+  { name: '정규식', src: '{ n: /x/ }', re: /객체·문자열·숫자 이외/ },
+  { name: '괄호 식', src: '{ n: (1) }', re: /객체·문자열·숫자 이외/ },
+  { name: '스프레드', src: '{ ...x }', re: /객체 키가 필요하다/ },
+  { name: '계산된 키', src: '{ ["sample"]: "a" }', re: /객체 키가 필요하다/ },
+  { name: '함수', src: '{ f() {} }', re: /뒤에 ':'가 필요하다/ },
+  { name: '화살표', src: '{ n: () => 1 }', re: /객체·문자열·숫자 이외/ },
+  { name: 'new', src: '{ n: new Date() }', re: /객체·문자열·숫자 이외/ },
+  { name: '삼항', src: '{ n: 1 ? 2 : 3 }', re: /',' 또는 '}'가 필요하다/ },
+  { name: '곱셈', src: '{ n: 1*2 }', re: /',' 또는 '}'가 필요하다/ },
+  { name: '비트', src: '{ n: 1|2 }', re: /',' 또는 '}'가 필요하다/ },
+  { name: 'await', src: '{ sample: await 1 }', re: /객체·문자열·숫자 이외/ },
+  { name: 'typeof', src: '{ n: typeof 1 }', re: /객체·문자열·숫자 이외/ },
+  { name: 'void', src: '{ n: void 0 }', re: /객체·문자열·숫자 이외/ },
+  { name: 'class', src: '{ sample: class X {} }', re: /객체·문자열·숫자 이외/ },
+  { name: '배열 중첩', src: '{ edit: { xs: [1] } }', re: /객체·문자열·숫자 이외/ },
+  { name: '세미콜론 키', src: '{ sample: "a"; chart: 1 }', re: /',' 또는 '}'가 필요하다/ },
+  { name: '허용 안 된 escape', src: '{ sample: "\\0" }', re: /허용되지 않은 문자열 escape/ },
+];
+
+for (const row of parseRejectCases) {
+  test(`파서는 ${row.name} 을 거부한다`, () => {
+    assert.throws(() => parseContractLiteral(row.src), row.re);
+  });
+}
+
+const parseAcceptCases = [
+  { name: '과학적 표기', src: '{ n: 1e3 }', check: c => c.n === 1000 },
+  { name: '음수 지수', src: '{ n: -2.5e-1 }', check: c => c.n === -0.25 },
+  { name: '음수 영', src: '{ n: -0 }', check: c => Object.is(c.n, -0) || c.n === 0 },
+  { name: '빈 문자열', src: '{ sample: "" }', check: c => c.sample === '' },
+  { name: '작은따옴표 포함', src: '{ sample: "it\'s" }', check: c => c.sample === "it's" },
+  { name: '개행 escape', src: '{ sample: "a\\nb" }', check: c => c.sample === 'a\nb' },
+  { name: '탭 escape', src: '{ sample: "a\\tb" }', check: c => c.sample === 'a\tb' },
+  { name: '후행 쉼표만', src: '{ sample: "a.hwp", }', check: c => c.sample === 'a.hwp' },
+  { name: '중첩 빈 객체', src: '{ extra: {} }', check: c => c.extra && Object.keys(c.extra).length === 0 },
+  { name: '식별자 키 $', src: '{ $id: 1 }', check: c => c.$id === 1 },
+  { name: '_ 키', src: '{ _x: 2 }', check: c => c._x === 2 },
+];
+
+for (const row of parseAcceptCases) {
+  test(`파서는 ${row.name} 을 읽는다`, () => {
+    const value = parseContractLiteral(row.src);
+    assert.ok(row.check(value), JSON.stringify(value));
+  });
+}
+
+const unicodeSyllables = [
+  ['AC00', '가'],
+  ['B098', '나'],
+  ['B2E4', '다'],
+  ['B77C', '라'],
+  ['B9C8', '마'],
+  ['BC14', '바'],
+  ['C0AC', '사'],
+  ['C544', '아'],
+  ['C790', '자'],
+  ['CC28', '차'],
+];
+
+for (const [hex, ch] of unicodeSyllables) {
+  test(`Unicode \\u${hex} 는 ${ch} 로 읽힌다`, () => {
+    const contract = parseContractLiteral(
+      `{ sample: "\\u${hex}/x.hwp", chart: 1, edit: { series: 0, point: 0, from: "1", to: "2" } }`,
+    );
+    assert.equal(contract.sample, `${ch}/x.hwp`);
+    validateContract(contract);
+  });
+}
+
+test('validateContract는 계약이 객체가 아니면 거부한다', () => {
+  throwsKind(() => validateContract(null), 'validate-error');
+  throwsKind(() => validateContract([]), 'validate-error');
+  throwsKind(() => validateContract('x'), 'validate-error');
+});
+
+test('validateContract는 chart 문자열·NaN을 거부한다', () => {
+  throwsKind(() => validateContract(validContract({ chart: '1' })), 'validate-error');
+  throwsKind(() => validateContract(validContract({ chart: NaN })), 'validate-error');
+  throwsKind(() => validateContract(validContract({ chart: Infinity })), 'validate-error');
+});
+
+test('validateContract는 series 소수·from 객체를 거부한다', () => {
+  throwsKind(() => validateContract(validContract({ edit: { ...validEdit, series: 1.2 } })), 'validate-error');
+  throwsKind(() => validateContract(validContract({ edit: { ...validEdit, from: { n: 1 } } })), 'validate-error');
+});
+
+test('applyCsvEdit는 형·모양 오류를 종류별로 낸다', () => {
+  throwsKind(() => applyCsvEdit(null, validEdit), 'type-error');
+  throwsKind(() => applyCsvEdit(',s1\nr,1\n', null), 'type-error');
+  throwsKind(() => applyCsvEdit(',s1\nr,1\n', []), 'type-error');
+  throwsKind(() => applyCsvEdit('', validEdit), 'csv-shape');
+  throwsKind(() => applyCsvEdit(',s1\nr,1\n', { series: 5, point: 0, from: '1', to: '2' }), 'csv-missing-col');
+  throwsKind(() => applyCsvEdit(',s1\na,1\nb,1,2\n', validEdit), 'csv-shape');
+});
+
+test('splitCsvRows/joinCsvRows는 LF로 왕복한다', () => {
+  const text = ',s1,s2\nr,1,2\n';
+  const rows = splitCsvRows(text);
+  assert.deepEqual(rows, [['', 's1', 's2'], ['r', '1', '2']]);
+  assert.equal(joinCsvRows(rows), text);
+  assertCsvRectangular(rows);
+});
+
+test('assertCsvRectangular는 폭 1 헤더를 거부한다', () => {
+  throwsKind(() => assertCsvRectangular([['only']]), 'csv-shape');
+  throwsKind(() => assertCsvRectangular([]), 'csv-shape');
+});
+
+test('applyCsvEdit는 두 번째 계열 칸만 바꾼다', () => {
+  const out = applyCsvEdit(',s1,s2\na,1,2\nb,3,4\n', { series: 1, point: 1, from: '4', to: '9' });
+  assert.equal(out, ',s1,s2\na,1,2\nb,3,9\n');
+});
+
+test('applyCsvEdit는 숫자 0 from을 문자열 0과 대조한다', () => {
+  const out = applyCsvEdit(',s1\nr,0\n', { series: 0, point: 0, from: 0, to: 1 });
+  assert.equal(out, ',s1\nr,1\n');
+});
+
+const csvGrid = [
+  ['10', '20', '30'],
+  ['11', '21', '31'],
+  ['12', '22', '32'],
+  ['13', '23', '33'],
+];
+
+for (let series = 0; series < 3; series += 1) {
+  for (let point = 0; point < 4; point += 1) {
+    test(`applyCsvEdit 계열 ${series} 값 ${point} 칸만 바꾼다`, () => {
+      const header = ',s1,s2,s3';
+      const body = csvGrid.map((row, idx) => `p${idx},${row.join(',')}`);
+      const base = `${[header, ...body].join('\n')}\n`;
+      const from = csvGrid[point][series];
+      const out = applyCsvEdit(base, { series, point, from, to: '99' });
+      const rows = splitCsvRows(out);
+      assert.equal(rows[1 + point][1 + series], '99');
+      for (let p = 0; p < 4; p += 1) {
+        for (let s = 0; s < 3; s += 1) {
+          if (p === point && s === series) continue;
+          assert.equal(rows[1 + p][1 + s], csvGrid[p][s]);
+        }
+      }
+    });
+  }
+}
+
+test('materializeFromContract는 ST01 형태 산출을 조립한다', () => {
+  const chartCsv = [',계열 1,계열 2,계열 3', '항목 1,4.3,2.4,2', '항목 2,2.5,4.4,2', ''].join('\n');
+  const out = materializeFromContract({
+    taskId: 'ST09',
+    e2ePath: 'rhwp-studio/e2e/demo.test.mjs',
+    contract: {
+      sample: 'chart/세로막대형/묶은세로막대형.hwp',
+      chart: 1,
+      edit: { series: 0, point: 0, from: '4.3', to: '91.7' },
+    },
+    csvAsset: 'gym/packs/studio-e2e/assets/ST09-edit.csv',
+    chartCsv,
+  });
+  assert.match(out.editCsv, /^,계열 1,계열 2,계열 3\n항목 1,91\.7,2\.4,2\n/);
+  assert.equal(out.task.id, 'ST09');
+  assert.equal(out.task.checks[2].cmd[0], 'csv-to-chart');
+  assert.equal(out.reference.steps[0].run[0], 'csv-to-chart');
+  assertTaskChecksAreCliReproducible(out.task);
+  assertReferenceIsCliReproducible(out.reference);
+});
+
+test('materializeFromContract는 스튜디오 전용·경로 탈출·잘못된 ID를 거부한다', () => {
+  const chartCsv = ',s1\nr,4.3\n';
+  throwsKind(() => materializeFromContract({
+    taskId: 'ST09', e2ePath: 'x.mjs', contract: validContract({ undo: true }),
+    csvAsset: 'gym/packs/studio-e2e/assets/ST09-edit.csv', chartCsv,
+  }), 'studio-only');
+  throwsKind(() => materializeFromContract({
+    taskId: 'ST09', e2ePath: 'x.mjs', contract: validContract({ sample: '../x.hwp' }),
+    csvAsset: 'gym/packs/studio-e2e/assets/ST09-edit.csv', chartCsv,
+  }), 'path-escape');
+  throwsKind(() => materializeFromContract({
+    taskId: 'bad', e2ePath: 'x.mjs', contract: validContract(),
+    csvAsset: 'gym/packs/studio-e2e/assets/bad-edit.csv', chartCsv,
+  }), 'task-id-invalid');
+});
+
+test('assertTaskChecksAreCliReproducible는 금지 명령을 거부한다', () => {
+  const task = buildTask({
+    taskId: 'ST01', e2ePath: st01E2e, contract: st01Contract, csvAsset: st01CsvAsset,
+  });
+  assert.doesNotThrow(() => assertTaskChecksAreCliReproducible(task));
+  throwsKind(() => assertTaskChecksAreCliReproducible({
+    ...task, checks: [{ ...task.checks[0], op: 'screenshot_eq' }],
+  }), 'studio-only');
+  throwsKind(() => assertTaskChecksAreCliReproducible({
+    ...task,
+    checks: [{ name: 'x', op: 'value_eq', path: 'a', value: 1, cmd: ['fill-fields', '{file:out.hwp}'] }],
+  }), 'studio-only');
+  throwsKind(() => assertTaskChecksAreCliReproducible({
+    ...task,
+    checks: [{ name: 'x', op: 'value_eq', path: 'a', value: 1, cmd: ['export-pdf', '{file:out.hwp}'] }],
+  }), 'studio-only');
+});
+
+test('assertReferenceIsCliReproducible는 한 스텝 csv-to-chart만 받는다', () => {
+  const reference = buildReference({
+    taskId: 'ST01', contract: st01Contract, csvAsset: st01CsvAsset,
+  });
+  assert.doesNotThrow(() => assertReferenceIsCliReproducible(reference));
+  throwsKind(() => assertReferenceIsCliReproducible({ id: 'ST01', steps: [] }), 'validate-error');
+  throwsKind(() => assertReferenceIsCliReproducible({
+    id: 'ST01', steps: [{ run: ['table-to-csv', '{input}'] }],
+  }), 'studio-only');
+});
+
+test('dumpJson은 마지막 개행과 2칸 들여쓰기를 쓴다', () => {
+  const text = dumpJson({ a: 1 });
+  assert.equal(text, '{\n  "a": 1\n}\n');
+  assert.doesNotMatch(text, /\r/);
+});
+
+test('없는 e2e 파일은 missing-file 이다', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'from-e2e-nofile-'));
+  try {
+    throwsKind(() => readContract(dir, 'ghost.test.mjs'), 'missing-file');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readJsonFileOrThrow는 깨진 JSON을 json-error로 접는다', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'from-e2e-json-'));
+  const file = path.join(dir, 'broken.json');
+  writeFileSync(file, '{ not json', 'utf8');
+  try {
+    throwsKind(() => readJsonFileOrThrow(file, 'demo/broken.json'), 'json-error');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('assertTaskIdAvailable는 깨진 과제 JSON을 json-error로 접는다', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'from-e2e-packjson-'));
+  const tasks = path.join(dir, 'gym', 'packs', 'other', 'tasks');
+  mkdirSync(tasks, { recursive: true });
+  writeFileSync(path.join(tasks, 'XX01.json'), '{', 'utf8');
+  try {
+    throwsKind(() => assertTaskIdAvailable(dir, 'studio-e2e', 'XX01'), 'json-error');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('assertTaskIdAvailable는 id 없는 JSON을 소유자로 치지 않는다', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'from-e2e-noid-'));
+  const tasks = path.join(dir, 'gym', 'packs', 'other', 'tasks');
+  mkdirSync(tasks, { recursive: true });
+  writeFileSync(path.join(tasks, 'XX01.json'), '{"title":"no-id"}\n', 'utf8');
+  try {
+    assert.doesNotThrow(() => assertTaskIdAvailable(dir, 'studio-e2e', 'XX01'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runAsCli는 인자 오류를 exit 2로 접고 치명 예외는 다시 올린다', () => {
+  const errs = [];
+  const result = runAsCli(['node', 'from_e2e.mjs'], {
+    log() {},
+    err: (...args) => errs.push(args.join(' ')),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.exit, 2);
+  assert.match(errs.join('\n'), /missing-arg/);
+  const fatal = new Error('stop');
+  fatal.name = 'SystemExit';
+  fatal.fatal = true;
+  assert.throws(() => wrapNodeError(fatal, 'cli', 'rhwp'), /stop/);
+  assert.throws(() => invokeChartToCsv('rhwp', 'samples/a.hwp', 1, {
+    execFileSync() { throw fatal; },
+  }), /stop/);
+});
+
+test('runAsCli dryRun은 목 chart-to-csv로 과제를 조립한다', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'from-e2e-cli-'));
+  writeFileSync(path.join(dir, 'demo.test.mjs'), `
+export const gymContract = {
+  sample: 'chart/sample.hwp',
+  chart: 1,
+  edit: { series: 0, point: 0, from: '4.3', to: '91.7' },
+};
+`);
+  try {
+    const result = runAsCli(
+      ['node', 'from_e2e.mjs', '--e2e', 'demo.test.mjs', '--id', 'ST09', '--pack', 'studio-e2e'],
+      { log() {}, err() {} },
+      {
+        cwd: dir,
+        dryRun: true,
+        execFileSync: () => JSON.stringify({ ok: true, charts: [{ csv: ',s1\nrow,4.3\n' }] }),
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.exit, 0);
+    assert.equal(result.task.id, 'ST09');
+    assert.equal(result.task.input, 'samples/chart/sample.hwp');
+    assert.equal(result.reference.steps[0].run[0], 'csv-to-chart');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runAsCli는 ok=false 봉투를 성공으로 위장하지 않는다', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'from-e2e-okfalse-'));
+  writeFileSync(path.join(dir, 'demo.test.mjs'), `
+export const gymContract = {
+  sample: 'chart/sample.hwp',
+  chart: 1,
+  edit: { series: 0, point: 0, from: '4.3', to: '91.7' },
+};
+`);
+  try {
+    const result = runAsCli(['--e2e', 'demo.test.mjs', '--id', 'ST09'], { log() {}, err() {} }, {
+      cwd: dir,
+      dryRun: true,
+      execFileSync: () => JSON.stringify({ ok: false, charts: [{ csv: ',s1\nrow,4.3\n' }] }),
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.report.kind, 'cli-error');
+    assert.equal(result.exit, 5);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runAsCli는 gymContract 없는 파일을 missing-contract 로 접는다', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'from-e2e-nocon-'));
+  writeFileSync(path.join(dir, 'empty.test.mjs'), 'export const other = 1;\n');
+  try {
+    const result = runAsCli(['--e2e', 'empty.test.mjs', '--id', 'ST09'], { log() {}, err() {} }, {
+      cwd: dir, dryRun: true,
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.report.kind, 'missing-contract');
+    assert.equal(result.exit, 3);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runAsCli는 스튜디오 키 계약을 studio-only 로 접는다', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'from-e2e-studio-'));
+  writeFileSync(path.join(dir, 'ui.test.mjs'), `
+export const gymContract = {
+  sample: 'chart/sample.hwp',
+  chart: 1,
+  edit: { series: 0, point: 0, from: '4.3', to: '91.7' },
+  undo: 1,
+};
+`);
+  try {
+    const result = runAsCli(['--e2e', 'ui.test.mjs', '--id', 'ST09'], { log() {}, err() {} }, {
+      cwd: dir, dryRun: true,
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.report.kind, 'studio-only');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runAsCli는 샘플 경로 탈출을 path-escape 로 접는다', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'from-e2e-esc-'));
+  writeFileSync(path.join(dir, 'esc.test.mjs'), `
+export const gymContract = {
+  sample: '../secret.hwp',
+  chart: 1,
+  edit: { series: 0, point: 0, from: '4.3', to: '91.7' },
+};
+`);
+  try {
+    const result = runAsCli(['--e2e', 'esc.test.mjs', '--id', 'ST09'], { log() {}, err() {} }, {
+      cwd: dir, dryRun: true,
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.report.kind, 'path-escape');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readContract는 let/var gymContract를 계약으로 인정하지 않는다', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'from-e2e-let-'));
+  writeFileSync(path.join(dir, 'let.test.mjs'), "let gymContract = { sample: 'a.hwp', chart: 1 };\n");
+  try {
+    throwsKind(() => readContract(dir, 'let.test.mjs'), 'missing-contract');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readContract는 빈 파일을 missing-contract 로 거부한다', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'from-e2e-emptyfile-'));
+  writeFileSync(path.join(dir, 'empty.test.mjs'), '');
+  try {
+    throwsKind(() => readContract(dir, 'empty.test.mjs'), 'missing-contract');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('buildTask 검사는 file_exists → differs_from_input → value_eq 순서다', () => {
+  const task = buildTask({
+    taskId: 'ST02',
+    e2ePath: 'rhwp-studio/e2e/other.test.mjs',
+    contract: { sample: 'chart/a.hwp', chart: 2, edit: { series: 1, point: 3, from: 8, to: 9 } },
+    csvAsset: 'gym/packs/studio-e2e/assets/ST02-edit.csv',
+  });
+  assert.deepEqual(task.checks.map(item => item.op), ['file_exists', 'differs_from_input', 'value_eq']);
+  assert.equal(task.input, 'samples/chart/a.hwp');
+  assert.match(task.instructions, /차트 2의 \(계열 1, 값 3\) 원본 8/);
+  assert.equal(task.checks[2].cmd[5], '2');
+});
+
+test('buildReference run 인자는 고정 순서다', () => {
+  const reference = buildReference({
+    taskId: 'ST03',
+    contract: { sample: 'a.hwp', chart: 4, edit: { series: 0, point: 0, from: 1, to: 2 } },
+    csvAsset: 'gym/packs/studio-e2e/assets/ST03-edit.csv',
+  });
+  assert.deepEqual(reference.steps[0].run, [
+    'csv-to-chart', '{input}', '--csv', 'gym/packs/studio-e2e/assets/ST03-edit.csv',
+    '--chart', '4', '-o', '{sub:out.hwp}', '--json',
+  ]);
+});
+
+test('기존 파서 오류도 FromE2eError parse-error 다', () => {
+  try {
+    parseContractLiteral('{ sample: someVar }');
+    assert.fail('should throw');
+  } catch (err) {
+    assert.ok(err instanceof FromE2eError);
+    assert.equal(err.kind, 'parse-error');
+    assert.match(err.message, /객체·문자열·숫자 이외의 식은 허용하지 않는다/);
+  }
+});
+
+test('파서는 extra 키를 읽지만 정직 게이트가 막는다', () => {
+  const contract = parseContractLiteral(`{
+    sample: 'chart/sample.hwp',
+    chart: 1,
+    edit: { series: 0, point: 0, from: '1', to: '2' },
+    hint: '파서는 읽는다',
+  }`);
+  validateContract(contract);
+  assert.equal(contract.hint, '파서는 읽는다');
+  throwsKind(() => assertCliReproducibleContract(contract), 'studio-only');
+});
+
+test('assertTaskIdAvailable는 저장소의 SE01 충돌을 계속 거부한다', () => {
+  assert.throws(
+    () => assertTaskIdAvailable(repoRoot, 'studio-e2e', 'SE01'),
+    /security\/SE01\.json/,
+  );
+});

--- a/mydocs/working/gym_from_e2e.md
+++ b/mydocs/working/gym_from_e2e.md
@@ -1,0 +1,290 @@
+---
+kind: working
+status: active
+canonical: mydocs/working/gym_from_e2e.md
+last_verified: 2026-08-18
+---
+
+# gym from_e2e — 예외 경로와 CLI 정직성 보강
+
+Issue: #5236
+PR: https://github.com/edwardkim/rhwp/pull/5241
+Branch: `feat/gym-from-e2e-pure`
+Date: 2026-08-18
+
+## 1. 결론
+
+`gym/tools/from_e2e.mjs` 의 계약 파서·CSV 한 칸 편집·과제 조립은 그대로 두고,
+예외를 kind 카탈로그로 접으며 CLI 로 재현할 수 없는 스튜디오 계약을 게이트에서
+막았다. 파서를 느슨하게 만들지 않았다. 식·배열·식별자·템플릿은 계속 거부한다.
+e2e 파일을 실행하지 않는다.
+
+이 가지는 새 PR 을 열지 않는다. 같은 브랜치에 이어서 밀어 #5241 을 키운다.
+
+검증:
+
+- `node --test gym/tools/from_e2e_contract.test.mjs gym/tools/from_e2e_exceptions.test.mjs`
+- `python gym/tools/audit.py`
+- `cargo fmt --all` 은 실행하지 않음 (JS/문서만, 사용자 지시)
+
+## 2. 배경
+
+원 PR(#5241)은 `applyCsvEdit` · `buildTask` · `buildReference` 를 순수 함수로
+분리하고, 파서 시험을 39건으로 늘렸다. 대비 `upstream/devel` 삽입은 약 444줄
+이었다.
+
+그 상태의 빈틈:
+
+1. 모든 실패가 민 문자열 `Error` 다. 인자 오류와 CSV 불일치와 없는 바이너리가
+   같은 종료 코드로 떨어진다.
+2. `readFileSync` · `JSON.parse` · `execFileSync` 예외가 그대로 올라 스택만
+   보인다. kind 가 없다.
+3. `gymContract` 에 `undo` · `menu` · `locator` 를 넣어도 파서가 객체로 읽으면
+   과제 JSON 이 나온다. CLI 로 재현할 수 없는 계약을 온램프로 위장한다.
+4. `chart-to-csv` 가 `ok: false` 를 내도 `charts[0].csv` 만 있으면 편집 CSV 를
+   쓴다. CLI 실패를 성공으로 위장한다.
+5. 과제 JSON 이 깨지면 `assertTaskIdAvailable` 가 도구 전체를 죽인다.
+6. 카탈로그가 코드에만 있어 문서·시험이 같은 표를 공유하지 않는다.
+
+분류를 네 값으로 늘리거나 파서를 느슨하게 하면 기존 39건 계약이 깨진다.
+그래서 기존 메시지는 유지하고, `FromE2eError.kind` 를 얹었다.
+
+## 3. 한 일
+
+### 3.1 도구
+
+`gym/tools/from_e2e.mjs`
+
+- `FromE2eError` — kind + extras. 기존 메시지를 유지한다.
+- `ERROR_KINDS` / `EXIT_BY_KIND` — 문서·시험이 같은 표.
+- `classifyNodeError` / `wrapNodeError` / `exceptionReport` — Node 예외를
+  kind 로 접는다. ENOENT 는 context 가 cli/bin 이면 missing-bin.
+- `isFatalException` — SystemExit · GeneratorExit · fatal 표지 · OOM 은
+  감싸지 않고 다시 올린다.
+- `assertCliReproducibleContract` — sample/chart/edit 만. 스튜디오 키·여분
+  키·from===to·경로 탈출을 막는다.
+- `assertSafeSamplePath` — `..` · 절대경로 · NUL · 비-hwp 확장자.
+- `extractChartCsvFromEnvelope` / `parseChartToCsvStdout` — 봉투를 순수로
+  읽는다. ok=false 는 cli-error.
+- `invokeChartToCsv` — execFileSync 를 주입할 수 있다. 시험이 목을 쓴다.
+- `materializeFromContract` — 이미 뽑아 둔 CSV 와 계약을 과제/기준으로
+  조립한다. 바이너리를 부르지 않는다.
+- `runAsCli` — 치명 예외가 아니면 `{ok, exit, report}`. 프로세스를 시험이
+  죽이지 않는다.
+- `assertTaskIdAvailable` — 깨진 JSON 은 json-error. id 없는 JSON 은
+  소유자가 아니다.
+
+### 3.2 시험
+
+- 기존 `from_e2e_contract.test.mjs` 39건은 같은 메시지로 유지.
+- `from_e2e_exceptions.test.mjs` — kind 카탈로그, 정직 게이트, 봉투,
+  materialize, runAsCli, CSV 격자, 스튜디오 키 전수.
+
+### 3.3 문서
+
+- `gym/docs/from_e2e.md` — 정본 규약. 한국어.
+- 이 파일 — 작업 기록.
+
+## 4. 정직 게이트가 막는 것
+
+스튜디오 e2e 는 데이터 계약과 UI 계약을 한 파일에 섞는다. 어댑터가 UI 를
+과제로 옮기면 gym 채점기가 CLI 로 재현하지 못해 거짓 만점 또는 영구 실패가
+된다.
+
+막는 키(일부): undo, redo, menu, click, dblclick, dialog, locator,
+playwright, wasm, getChartDataByIndex, screenshot, ole, noTrace.
+
+막는 CLI: table-to-csv, csv-to-table, fill-fields, export-pdf, render,
+inspect, mcp-serve.
+
+허용 CLI: chart-to-csv, csv-to-chart.
+
+허용 op: file_exists, differs_from_input, value_eq.
+
+파서는 extra 키를 읽을 수 있다. 게이트가 막는다. 두 층을 섞지 않는다.
+파서 시험은 extra 키를 허용한 채 validateContract 만 부른다. 생성 경로는
+게이트를 반드시 지난다.
+
+## 5. 예외 표 — 작업 메모
+
+exit 묶음은 사람이 고치는 자리를 가리킨다.
+
+- 2 인자: 사용법. 계약 파일이 없어도 먼저 떨어진다.
+- 3 계약: e2e 를 고치거나 ID 를 바꾼다. 바이너리와 무관.
+- 4 CSV: 샘플이 바뀌었거나 point/series 가 틀렸다. chart-to-csv 를 다시 본다.
+- 5 CLI: 바이너리·봉투. 단위 시험은 목으로만 본다.
+- 6 I/O: 파일 없음·권한.
+- 1 unexpected: 카탈로그에 없는 실패. 성공으로 위장하지 않는다.
+
+ok=false 를 envelope-error 가 아니라 cli-error 로 둔 이유: 봉투 모양은
+맞는데 CLI 가 실패를 선언한 것이다. 모양 오류와 섞으면 고치는 자리가
+달라진다.
+
+## 6. 파서를 느슨하게 하지 않은 이유
+
+boolean·null·배열을 허용하면 `undo: true` 같은 UI 계약이 파서를 통과한다.
+게이트가 막더라도, 파서가 식을 받기 시작하면 `import.meta` · 함수 호출을
+언제든 다시 열 유혹이 생긴다. 외부 PR e2e 는 실행하면 안 된다.
+
+그래서 파서 층은 객체·문자열·숫자만 남긴다. 게이트 층은 그 객체가 CLI
+차트 왕복인지를 본다.
+
+Unicode `\uAC00` 은 허용한다. 한글 샘플 경로를 계약에 쓰기 위해서다.
+`\u{AC00}` 코드포인트 문법은 허용하지 않는다. JSON/제한 리터럴 범위를
+넘긴다.
+
+## 7. 라이브 왕복과의 경계
+
+이 작업은 바이너리를 부르지 않는다. ST01 라이브 admission 은 이미 pack
+README 에 있다. 여기서 다시 `chart-to-csv` 를 실호출하면 CI 가 rhwp
+빌드를 기다리게 되고, 순수 시험 기둥이 깨진다.
+
+목을 쓰는 자리:
+
+- `invokeChartToCsv({ execFileSync })`
+- `runAsCli(..., { execFileSync, dryRun: true, cwd })`
+
+dryRun 은 파일을 쓰지 않는다. 임시 디렉터리에 e2e 픽스처만 두고 조립
+결과를 본다.
+
+## 8. 하지 않은 것
+
+- 새 pack, 새 라이브 과제, ST02 실파일을 만들지 않았다.
+- 표/필드 어댑터를 이 파일에 넣지 않았다.
+- 파서에 배열·boolean 을 넣지 않았다.
+- Rust 를 포맷하거나 clippy 를 돌리지 않았다.
+- 새 PR 을 열지 않았다.
+
+## 9. 재현
+
+```bash
+node --test gym/tools/from_e2e_contract.test.mjs gym/tools/from_e2e_exceptions.test.mjs
+python gym/tools/audit.py
+git diff --shortstat upstream/devel
+```
+
+SIZE GATE: upstream/devel 대비 insertions >= 3000.
+
+## 10. 남은 위험
+
+1. 스튜디오 키 목록이 닫힌 집합이다. 새 UI 키(`drag`, `wheel`)가 생기면
+   목록에 추가해야 한다. 여분 키 전면 거부가 그 구멍을 대부분 막는다.
+2. 따옴표 CSV 를 구현하지 않았다. 차트 수치 CSV 가 따옴표를 내기 시작하면
+   csv-shape 또는 칸 불일치로 실패한다. 그때 축을 넓힐지 다른 어댑터로
+   보낼지 결정한다.
+3. `charts[0]` 만 본다. 계약의 chart 인덱스는 csv-to-chart 인자로만 간다.
+   다중 차트 샘플에서 chart-to-csv 가 요청한 차트만 내는지가 CLI 계약이다.
+   어댑터는 그 첫 csv 를 믿는다.
+
+## 11. 커밋 범위
+
+- `gym/tools/from_e2e.mjs`
+- `gym/tools/from_e2e_contract.test.mjs` (기존 39건 유지, import 불필요)
+- `gym/tools/from_e2e_exceptions.test.mjs` (신규)
+- `gym/docs/from_e2e.md` (신규)
+- `mydocs/working/gym_from_e2e.md` (신규)
+
+생성기 임시 파일은 커밋하지 않는다.
+
+## 12. 함수별 메모
+
+### 12.1 FromE2eError
+
+기존 `throw new Error(msg)` 를 `throw new FromE2eError(kind, msg)` 로
+바꿨다. `instanceof Error` 는 참이라 기존 `assert.throws(..., /정규식/)`
+이 그대로 통과한다. extras 는 시험과 로그가 offset·owners 를 보게 한다.
+
+### 12.2 consumeContractLiteral
+
+본문은 거의 그대로다. `fail()` 만 FromE2eError 를 던진다. 공백·주석·문자열
+·숫자·객체 루프를 건드리지 않았다. 39건이 그 계약을 지킨다.
+
+### 12.3 readContract / locateGymContract
+
+표지 정규식은 그대로 `export\s+const\s+gymContract\s*=\s*\{` 다. 파일
+읽기만 `readTextFileOrThrow` 로 감싸 ENOENT 를 missing-file 로 접는다.
+
+### 12.4 validateContract
+
+객체가 아닌 계약에 대한 가드를 앞에 넣었다. 나머지 필드 검사는 메시지
+그대로다. extra 키는 여기서 막지 않는다.
+
+### 12.5 assertCliReproducibleContract
+
+생성 경로의 정직 게이트. validate + 경로 + 스튜디오 키 + 허용 키 +
+from!==to. materialize 와 mainWith 가 부른다. 파서 단위 시험은 부르지
+않는다.
+
+### 12.6 applyCsvEdit
+
+형 검사와 직사각 검사, 열 부재를 앞에 넣었다. 불일치·행 부재 메시지는
+그대로다. 열 부재는 예전엔 `undefined ≠ from` 으로 mismatch 가 났다.
+지금은 `csv-missing-col` 이다. 칸이 있는데 값만 다른 경우와 칸이 없는
+경우를 섞지 않는다.
+
+### 12.7 봉투
+
+`charts[0].csv` 만 믿는다. 계약의 chart 인덱스는 csv-to-chart 인자로
+간다. 다중 차트에서 CLI 가 다른 차트를 첫 칸에 내면 그건 CLI 버그다.
+어댑터가 인덱스를 다시 고르면 CLI 계약을 복제하는 셈이다.
+
+### 12.8 runAsCli
+
+CLI 진입점은 process.exit 한다. 내보낸 runAsCli 는 exit 코드를 돌려
+시험이 프로세스를 유지한다. dryRun 은 쓰기를 생략한다. cwd 주입으로
+임시 e2e 픽스처를 쓴다.
+
+### 12.9 wrapNodeError 와 치명 예외
+
+처음에 wrap 이 치명 예외를 감싸 버려 시험이 실패했다. wrap 이
+isFatalException 이면 다시 던지도록 고쳤다. invokeChartToCsv 의
+execFileSync 가 SystemExit 를 내도 과제 JSON 을 쓰지 않는다.
+
+## 13. 시험 설계
+
+기존 파일은 원 메시지 회귀다. 새 파일은 kind·게이트·봉투·CLI 목이다.
+한 파일에 섞으면 39건 회귀와 신규 표가 뒤섞여 리뷰가 어려워진다.
+
+스튜디오 키는 목록 전수 시험이다. 키를 추가하면 시험이 자동으로 는다.
+빼면 시험이 줄어 리뷰에서 보인다.
+
+CSV 격자는 3 계열 × 4 값이다. 한 칸만 바뀌고 나머지는 그대로인지를
+모든 좌표에서 본다. ST01 한 칸 시험만으로는 오프셋 실수를 놓친다.
+
+## 14. 크기와 범위
+
+SIZE GATE 는 upstream/devel 대비 insertions >= 3000 이다. 원 PR 은
+444 였다. 보강은 예외 카탈로그·정직 게이트·시험·한글 문서다. 라이브
+pack 을 부풀리지 않았다. 과제 복제는 정직 게이트와 반대로 간다.
+
+## 15. 리뷰어에게
+
+볼 곳:
+
+1. 파서 fail() 메시지가 기존과 같은가.
+2. STUDIO_ONLY_KEYS / FORBIDDEN_CLI_COMMANDS 가 차트 왕복 밖으로
+   새는가.
+3. ok=false 를 성공으로 쓰는 분기가 있는가.
+4. wrapNodeError 가 치명 예외를 삼키는가.
+5. 새 pack 이나 ST02 실파일이 생겼는가. 생기면 이 작업의 범위를
+   넘는다.
+
+안 봐도 되는 곳: Rust, rustfmt, pack JSON, baselines.
+
+## 16. 다음이 있다면
+
+- 스튜디오 표 편집 e2e 가 CLI table-to-csv 로 왕복하면 **다른**
+  어댑터. 이 파일에 명령을 추가하지 않는다.
+- 다중 차트 봉투가 `charts[i]` 를 명시하면 extract 가 인덱스를
+  받을 수 있다. 지금은 CLI 가 요청한 차트만 낸다고 가정한다.
+- 키 목록을 닫힌 집합으로 둘지, 허용 키 외 전부 거부로 충분할지.
+  지금은 둘 다 한다. 허용 키 외 거부가 더 강한 문이다.
+
+## 17. 로컬에서 확인한 숫자
+
+- 기존 계약 시험 39 passed
+- 예외·정직 시험 포함 215 passed
+- `python gym/tools/audit.py` — 18 pack 전부 통과, 위반 0
+- 라이브 rhwp / cargo fmt --all 은 이 보강에서 실행하지 않음
+
+


### PR DESCRIPTION
## 변경 요약

`from_e2e.mjs`의 gymContract 파서, CSV 한 칸 편집, 과제/기준 JSON 조립을 순수 함수로 분리하고, 바이너리 없이 재현 가능한 계약 시험을 대폭 늘린다. 식·배열·식별자·템플릿을 허용하도록 파서를 느슨하게 만들지 않았다.

- `applyCsvEdit(baseCsv, edit)`: LF로 정규화한 뒤 `rows[1+point][1+series]`를 `from`에서 `to`로 바꾸고, 행이 없거나 값이 다르면 던진다.
- `buildTask({taskId, e2ePath, contract, csvAsset})`: 오늘 `main()`이 쓰던 과제 JSON과 같은 모양이다. `file_exists`, `differs_from_input`, `value_eq`의 `changedCount` 0과 `csv-to-chart` dry-run을 포함한다.
- `buildReference({taskId, contract, csvAsset})`: `csv-to-chart {input} --csv … -o {sub:out.hwp}` 기준 풀이다.
- `main()`은 위 헬퍼만 호출한다. ST01 형태 과제 생성 동작은 바꾸지 않았다.
- `parseContractLiteral`은 객체 뒤 추가 식을 거부하고, `readContract`는 파일 나머지 코드를 실행하지 않은 채 계약 객체만 소비한다.

새 pack이나 라이브 과제를 만들지 않았고, `rhwp`와 `chart-to-csv`도 호출하지 않는다.

## 관련 이슈

closes #5236

## 테스트

- [x] `node --test gym/tools/from_e2e_contract.test.mjs` — 39 passed
- [x] `python gym/tools/audit.py` — 18 pack 전부 통과, 위반 0
- [ ] `cargo fmt --all -- --check` — 해당 없음 (Rust 미변경)
- [ ] `node scripts/rust-test-suite-manifest.mjs --check` — 해당 없음
- [ ] `node scripts/rust-unit-test-tiers.mjs --check` — 해당 없음
- [ ] `cargo test` — 해당 없음
- [ ] `cargo clippy -- -D warnings` — 해당 없음
- [ ] 관련 샘플 SVG/WASM/studio e2e — 해당 없음

기존 3건(허용 리터럴, `객체·문자열·숫자 이외의 식은 허용하지 않는다`, SE01 거부·ST01 허용)은 같은 메시지로 유지했다. 추가 범위는 unicode `\uAC00`, 블록/줄 주석, 따옴표 키, 중첩 객체, 빈 객체 검증 실패, 배열·식별자·템플릿·중복 키·미닫힘 문자열·잘못된 unicode·후행 식 거부, validateContract 필드 오류, applyCsvEdit 성공/불일치/행 부재, buildTask/buildReference 명령 배열이다.

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음
- 재현·측정: 순수 JS 단위 시험만 추가. 미측정
